### PR TITLE
feat(board): editable columns + custom fields + swimlanes + saved views

### DIFF
--- a/pkg/dispatcher/native/board.go
+++ b/pkg/dispatcher/native/board.go
@@ -98,6 +98,17 @@ func (b *Board) StateByName(name string) *State {
 	return nil
 }
 
+// stateIndex returns the position of the state matching name, or -1.
+// Reorder/delete need the slice index; StateByName only yields a pointer.
+func (b *Board) stateIndex(name string) int {
+	for i := range b.States {
+		if b.States[i].Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
 // FieldByName returns the field matching name, or nil.
 func (b *Board) FieldByName(name string) *Field {
 	for i := range b.Fields {

--- a/pkg/dispatcher/native/board.go
+++ b/pkg/dispatcher/native/board.go
@@ -50,10 +50,24 @@ type Field struct {
 	Default    any       `json:"default,omitempty"`
 }
 
-// Board is the kanban configuration: ordered states + custom field schema.
+// View is a saved board filter/sort/group preset. Shared across operators
+// via board.json; the studio's view picker loads one to restore the
+// search query, label/assignee filters, card sort, and swimlane grouping.
+type View struct {
+	Name     string   `json:"name"`
+	Search   string   `json:"search,omitempty"`
+	Labels   []string `json:"labels,omitempty"`
+	Assignee string   `json:"assignee,omitempty"`
+	Sort     string   `json:"sort,omitempty"`
+	GroupBy  string   `json:"group_by,omitempty"`
+}
+
+// Board is the kanban configuration: ordered states + custom field schema
+// + saved views.
 type Board struct {
 	States    []State   `json:"states"`
 	Fields    []Field   `json:"fields,omitempty"`
+	Views     []View    `json:"views,omitempty"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
@@ -152,6 +166,16 @@ func (b *Board) Validate() error {
 			return fmt.Errorf("board: field %q has unknown type %q", f.Name, f.Type)
 		}
 		fseen[f.Name] = true
+	}
+	vseen := map[string]bool{}
+	for _, v := range b.Views {
+		if v.Name == "" {
+			return errors.New("board: view name must be non-empty")
+		}
+		if vseen[v.Name] {
+			return fmt.Errorf("board: duplicate view name %q", v.Name)
+		}
+		vseen[v.Name] = true
 	}
 	return nil
 }

--- a/pkg/dispatcher/native/board.go
+++ b/pkg/dispatcher/native/board.go
@@ -123,6 +123,17 @@ func (b *Board) stateIndex(name string) int {
 	return -1
 }
 
+// fieldIndex returns the position of the field matching name, or -1.
+// Symmetric to stateIndex; the field mutators need the slice index.
+func (b *Board) fieldIndex(name string) int {
+	for i := range b.Fields {
+		if b.Fields[i].Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
 // FieldByName returns the field matching name, or nil.
 func (b *Board) FieldByName(name string) *Field {
 	for i := range b.Fields {

--- a/pkg/dispatcher/native/field_management_test.go
+++ b/pkg/dispatcher/native/field_management_test.go
@@ -1,0 +1,124 @@
+package native
+
+import (
+	"testing"
+)
+
+// fieldBoard seeds a store with one state + a couple of custom fields.
+func fieldBoard(t *testing.T) *Store {
+	t.Helper()
+	s := newTestStore(t)
+	if err := s.SetBoard(&Board{
+		States: []State{{Name: "ready"}},
+		Fields: []Field{
+			{Name: "sev", Type: FieldEnum, EnumValues: []string{"low", "high"}},
+			{Name: "owner", Type: FieldText},
+		},
+	}); err != nil {
+		t.Fatalf("SetBoard: %v", err)
+	}
+	return s
+}
+
+func TestAddField(t *testing.T) {
+	s := fieldBoard(t)
+	if err := s.AddField(Field{Name: "eta", Type: FieldDate}); err != nil {
+		t.Fatalf("AddField: %v", err)
+	}
+	if s.Board().FieldByName("eta") == nil {
+		t.Fatal("eta not added")
+	}
+	if err := s.AddField(Field{Name: "eta", Type: FieldText}); err == nil {
+		t.Fatal("expected duplicate rejection")
+	}
+	// enum without values is rejected by board validation
+	if err := s.AddField(Field{Name: "bad", Type: FieldEnum}); err == nil {
+		t.Fatal("expected enum-needs-values rejection")
+	}
+}
+
+func TestRenameFieldCascades(t *testing.T) {
+	s := fieldBoard(t)
+	iss, _ := s.Create(Issue{Title: "x", State: "ready", Fields: map[string]any{"owner": "jo", "sev": "high"}})
+
+	touched, err := s.RenameField("owner", "assignee_name")
+	if err != nil {
+		t.Fatalf("RenameField: %v", err)
+	}
+	if touched != 1 {
+		t.Fatalf("touched = %d, want 1", touched)
+	}
+	if s.Board().FieldByName("owner") != nil || s.Board().FieldByName("assignee_name") == nil {
+		t.Fatal("schema rename not applied")
+	}
+	got, _ := s.Get(iss.ID)
+	if _, ok := got.Fields["owner"]; ok {
+		t.Fatal("old key still present on issue")
+	}
+	if got.Fields["assignee_name"] != "jo" {
+		t.Fatalf("value not carried: %+v", got.Fields)
+	}
+	// onto-existing refused
+	if _, err := s.RenameField("sev", "assignee_name"); err == nil {
+		t.Fatal("expected onto-existing rejection")
+	}
+}
+
+func TestUpdateField(t *testing.T) {
+	s := fieldBoard(t)
+	disp := "Severity"
+	req := true
+	if err := s.UpdateField("sev", FieldPatch{Display: &disp, Required: &req}); err != nil {
+		t.Fatalf("UpdateField: %v", err)
+	}
+	f := s.Board().FieldByName("sev")
+	if f.Display != disp || !f.Required {
+		t.Fatalf("update not applied: %+v", f)
+	}
+	if err := s.UpdateField("nope", FieldPatch{}); err == nil {
+		t.Fatal("expected unknown-field error")
+	}
+}
+
+func TestDeleteFieldStripsIssues(t *testing.T) {
+	s := fieldBoard(t)
+	iss, _ := s.Create(Issue{Title: "x", State: "ready", Fields: map[string]any{"owner": "jo", "sev": "high"}})
+
+	touched, err := s.DeleteField("owner")
+	if err != nil {
+		t.Fatalf("DeleteField: %v", err)
+	}
+	if touched != 1 {
+		t.Fatalf("touched = %d, want 1", touched)
+	}
+	if s.Board().FieldByName("owner") != nil {
+		t.Fatal("field not removed from schema")
+	}
+	got, _ := s.Get(iss.ID)
+	if _, ok := got.Fields["owner"]; ok {
+		t.Fatal("owner key not stripped from issue")
+	}
+	if got.Fields["sev"] != "high" {
+		t.Fatal("unrelated field lost")
+	}
+	// A subsequent update must still validate (no orphaned key).
+	if _, err := s.Update(iss.ID, Patch{Fields: map[string]any{"sev": "low"}}); err != nil {
+		t.Fatalf("post-delete update: %v", err)
+	}
+}
+
+func TestReorderFields(t *testing.T) {
+	s := fieldBoard(t)
+	if err := s.ReorderFields([]string{"owner", "sev"}); err != nil {
+		t.Fatalf("ReorderFields: %v", err)
+	}
+	if s.Board().Fields[0].Name != "owner" {
+		t.Fatal("reorder not applied")
+	}
+	if err := s.ReorderFields([]string{"owner"}); err == nil {
+		t.Fatal("expected wrong-length rejection")
+	}
+	if err := s.ReorderFields([]string{"owner", "nope"}); err == nil {
+		t.Fatal("expected unknown-field rejection")
+	}
+}

--- a/pkg/dispatcher/native/http.go
+++ b/pkg/dispatcher/native/http.go
@@ -47,6 +47,10 @@ func (s *Store) RegisterRoutesWithMiddleware(mux *http.ServeMux, prefix string, 
 	mux.Handle("POST "+p+"/board/states/reorder", wrap(http.HandlerFunc(s.handleReorderStates)))
 	mux.Handle("PATCH "+p+"/board/states/{name}", wrap(http.HandlerFunc(s.handleUpdateState)))
 	mux.Handle("DELETE "+p+"/board/states/{name}", wrap(http.HandlerFunc(s.handleDeleteState)))
+	mux.Handle("POST "+p+"/board/fields", wrap(http.HandlerFunc(s.handleAddField)))
+	mux.Handle("POST "+p+"/board/fields/reorder", wrap(http.HandlerFunc(s.handleReorderFields)))
+	mux.Handle("PATCH "+p+"/board/fields/{name}", wrap(http.HandlerFunc(s.handleUpdateField)))
+	mux.Handle("DELETE "+p+"/board/fields/{name}", wrap(http.HandlerFunc(s.handleDeleteField)))
 }
 
 // ---------------------------------------------------------------------------
@@ -507,6 +511,87 @@ func mustList(s *Store) []*Issue {
 		return nil
 	}
 	return issues
+}
+
+// fieldUpdateReq is the PATCH /board/fields/{name} body. A non-nil Name
+// that differs from the path triggers a cascading rename across issues;
+// remaining attributes are applied afterward.
+type fieldUpdateReq struct {
+	Name       *string    `json:"name,omitempty"`
+	Display    *string    `json:"display,omitempty"`
+	Type       *FieldType `json:"type,omitempty"`
+	Required   *bool      `json:"required,omitempty"`
+	EnumValues *[]string  `json:"enum_values,omitempty"`
+}
+
+// handleAddField POST /board/fields: appends a custom-field definition.
+func (s *Store) handleAddField(w http.ResponseWriter, r *http.Request) {
+	var f Field
+	if err := json.NewDecoder(r.Body).Decode(&f); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := s.AddField(f); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.Board())
+}
+
+// handleUpdateField PATCH /board/fields/{name}: edits a field definition
+// and, when the body carries a different `name`, renames it first
+// (cascading across issue.Fields maps).
+func (s *Store) handleUpdateField(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	var in fieldUpdateReq
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	target := name
+	if in.Name != nil && *in.Name != name {
+		if _, err := s.RenameField(name, *in.Name); err != nil {
+			writeErr(w, http.StatusBadRequest, err)
+			return
+		}
+		target = *in.Name
+	}
+	if in.Display != nil || in.Type != nil || in.Required != nil || in.EnumValues != nil {
+		if err := s.UpdateField(target, FieldPatch{
+			Display:    in.Display,
+			Type:       in.Type,
+			Required:   in.Required,
+			EnumValues: in.EnumValues,
+		}); err != nil {
+			writeErr(w, http.StatusBadRequest, err)
+			return
+		}
+	}
+	writeJSON(w, http.StatusOK, s.Board())
+}
+
+// handleDeleteField DELETE /board/fields/{name}: removes a field
+// definition and strips its key from every issue.
+func (s *Store) handleDeleteField(w http.ResponseWriter, r *http.Request) {
+	if _, err := s.DeleteField(r.PathValue("name")); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.Board())
+}
+
+// handleReorderFields POST /board/fields/reorder {order:[...]}.
+func (s *Store) handleReorderFields(w http.ResponseWriter, r *http.Request) {
+	var in reorderStatesReq
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := s.ReorderFields(in.Order); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.Board())
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/dispatcher/native/http.go
+++ b/pkg/dispatcher/native/http.go
@@ -51,6 +51,8 @@ func (s *Store) RegisterRoutesWithMiddleware(mux *http.ServeMux, prefix string, 
 	mux.Handle("POST "+p+"/board/fields/reorder", wrap(http.HandlerFunc(s.handleReorderFields)))
 	mux.Handle("PATCH "+p+"/board/fields/{name}", wrap(http.HandlerFunc(s.handleUpdateField)))
 	mux.Handle("DELETE "+p+"/board/fields/{name}", wrap(http.HandlerFunc(s.handleDeleteField)))
+	mux.Handle("POST "+p+"/board/views", wrap(http.HandlerFunc(s.handleSaveView)))
+	mux.Handle("DELETE "+p+"/board/views/{name}", wrap(http.HandlerFunc(s.handleDeleteView)))
 }
 
 // ---------------------------------------------------------------------------
@@ -588,6 +590,30 @@ func (s *Store) handleReorderFields(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := s.ReorderFields(in.Order); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.Board())
+}
+
+// handleSaveView POST /board/views: upserts a named filter/sort/group
+// preset (body = View). Returns the refreshed board.
+func (s *Store) handleSaveView(w http.ResponseWriter, r *http.Request) {
+	var v View
+	if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := s.SaveView(v); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.Board())
+}
+
+// handleDeleteView DELETE /board/views/{name}: removes a saved view.
+func (s *Store) handleDeleteView(w http.ResponseWriter, r *http.Request) {
+	if err := s.DeleteView(r.PathValue("name")); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}

--- a/pkg/dispatcher/native/http.go
+++ b/pkg/dispatcher/native/http.go
@@ -43,6 +43,10 @@ func (s *Store) RegisterRoutesWithMiddleware(mux *http.ServeMux, prefix string, 
 	mux.Handle("DELETE "+p+"/labels/{label}", wrap(http.HandlerFunc(s.handleDeleteLabel)))
 	mux.Handle("GET "+p+"/board", wrap(http.HandlerFunc(s.handleGetBoard)))
 	mux.Handle("PUT "+p+"/board", wrap(http.HandlerFunc(s.handlePutBoard)))
+	mux.Handle("POST "+p+"/board/states", wrap(http.HandlerFunc(s.handleAddState)))
+	mux.Handle("POST "+p+"/board/states/reorder", wrap(http.HandlerFunc(s.handleReorderStates)))
+	mux.Handle("PATCH "+p+"/board/states/{name}", wrap(http.HandlerFunc(s.handleUpdateState)))
+	mux.Handle("DELETE "+p+"/board/states/{name}", wrap(http.HandlerFunc(s.handleDeleteState)))
 }
 
 // ---------------------------------------------------------------------------
@@ -384,6 +388,125 @@ func (s *Store) handlePutBoard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, s.Board())
+}
+
+// stateUpdateReq is the PATCH /board/states/{name} body. A non-nil Name
+// that differs from the path segment triggers a cascading rename (issues
+// in the column follow); the remaining fields are applied afterward.
+type stateUpdateReq struct {
+	Name     *string `json:"name,omitempty"`
+	Display  *string `json:"display,omitempty"`
+	Color    *string `json:"color,omitempty"`
+	Eligible *bool   `json:"eligible,omitempty"`
+	Terminal *bool   `json:"terminal,omitempty"`
+}
+
+type reorderStatesReq struct {
+	Order []string `json:"order"`
+}
+
+// stateDeleteConflictResp is the 409 body returned when a non-empty
+// column is deleted without a migration target. `count` lets the UI
+// prompt "move N issues to…".
+type stateDeleteConflictResp struct {
+	Error string `json:"error"`
+	Count int    `json:"count"`
+}
+
+// handleAddState POST /board/states: appends a new column. Body is a
+// State. Returns the refreshed board.
+func (s *Store) handleAddState(w http.ResponseWriter, r *http.Request) {
+	var st State
+	if err := json.NewDecoder(r.Body).Decode(&st); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := s.AddState(st); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.Board())
+}
+
+// handleUpdateState PATCH /board/states/{name}: edits a column's
+// display/color/flags and, when the body carries a different `name`,
+// renames it first (cascading to issues). Returns the refreshed board.
+func (s *Store) handleUpdateState(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	var in stateUpdateReq
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	target := name
+	if in.Name != nil && *in.Name != name {
+		if _, err := s.RenameState(name, *in.Name); err != nil {
+			writeErr(w, http.StatusBadRequest, err)
+			return
+		}
+		target = *in.Name
+	}
+	if in.Display != nil || in.Color != nil || in.Eligible != nil || in.Terminal != nil {
+		if err := s.UpdateState(target, StatePatch{
+			Display:  in.Display,
+			Color:    in.Color,
+			Eligible: in.Eligible,
+			Terminal: in.Terminal,
+		}); err != nil {
+			writeErr(w, http.StatusBadRequest, err)
+			return
+		}
+	}
+	writeJSON(w, http.StatusOK, s.Board())
+}
+
+// handleDeleteState DELETE /board/states/{name}?migrate_to=X: removes a
+// column. A non-empty column without a migration target returns 409 with
+// the issue count so the UI can prompt for a destination.
+func (s *Store) handleDeleteState(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	migrateTo := r.URL.Query().Get("migrate_to")
+	_, err := s.DeleteState(name, migrateTo)
+	if err != nil {
+		if errors.Is(err, ErrStateNotEmpty) {
+			count := 0
+			for _, iss := range mustList(s) {
+				if iss.State == name {
+					count++
+				}
+			}
+			writeJSON(w, http.StatusConflict, stateDeleteConflictResp{Error: err.Error(), Count: count})
+			return
+		}
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.Board())
+}
+
+// handleReorderStates POST /board/states/reorder {order:[...]}: rewrites
+// the column order. Returns the refreshed board.
+func (s *Store) handleReorderStates(w http.ResponseWriter, r *http.Request) {
+	var in reorderStatesReq
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := s.ReorderStates(in.Order); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, s.Board())
+}
+
+// mustList returns the current issues for the 409 count; on error it
+// returns nil (count falls back to 0, still a valid conflict response).
+func mustList(s *Store) []*Issue {
+	issues, err := s.List(ListFilter{})
+	if err != nil {
+		return nil
+	}
+	return issues
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/dispatcher/native/http_test.go
+++ b/pkg/dispatcher/native/http_test.go
@@ -177,6 +177,104 @@ func TestHTTPBoardGetPut(t *testing.T) {
 	}
 }
 
+func TestHTTPStateManagement(t *testing.T) {
+	srv, s := newServerWithStore(t)
+	defer srv.Close()
+	do := func(method, path string, body string) *http.Response {
+		var rdr *bytes.Buffer
+		if body != "" {
+			rdr = bytes.NewBufferString(body)
+		} else {
+			rdr = bytes.NewBuffer(nil)
+		}
+		req, _ := http.NewRequest(method, srv.URL+path, rdr)
+		req.Header.Set("Content-Type", "application/json")
+		r, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s %s: %v", method, path, err)
+		}
+		return r
+	}
+
+	// Add a column.
+	if r := do(http.MethodPost, "/board/states", `{"name":"triage","display":"Triage"}`); r.StatusCode != 200 {
+		t.Fatalf("add state: %d", r.StatusCode)
+	} else {
+		r.Body.Close()
+	}
+	if s.Board().StateByName("triage") == nil {
+		t.Fatal("triage not added")
+	}
+
+	// Rename via PATCH (cascades) — put an issue in backlog first.
+	iss, _ := s.Create(native.Issue{Title: "x", State: "backlog"})
+	if r := do(http.MethodPatch, "/board/states/backlog", `{"name":"todo"}`); r.StatusCode != 200 {
+		t.Fatalf("rename state: %d", r.StatusCode)
+	} else {
+		r.Body.Close()
+	}
+	if got, _ := s.Get(iss.ID); got.State != "todo" {
+		t.Fatalf("issue not migrated on rename: %q", got.State)
+	}
+
+	// Edit color/flags via PATCH (no rename).
+	if r := do(http.MethodPatch, "/board/states/todo", `{"color":"var(--color-board-ready)","eligible":true}`); r.StatusCode != 200 {
+		t.Fatalf("update state: %d", r.StatusCode)
+	} else {
+		r.Body.Close()
+	}
+	if st := s.Board().StateByName("todo"); st == nil || !st.Eligible {
+		t.Fatalf("flags not updated: %+v", st)
+	}
+
+	// Delete non-empty without target → 409 + count.
+	r := do(http.MethodDelete, "/board/states/todo", "")
+	if r.StatusCode != http.StatusConflict {
+		t.Fatalf("delete non-empty: want 409, got %d", r.StatusCode)
+	}
+	var conflict struct {
+		Error string `json:"error"`
+		Count int    `json:"count"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&conflict)
+	r.Body.Close()
+	if conflict.Count != 1 {
+		t.Fatalf("conflict count = %d, want 1", conflict.Count)
+	}
+
+	// Delete with migration target.
+	if r := do(http.MethodDelete, "/board/states/todo?migrate_to=ready", ""); r.StatusCode != 200 {
+		t.Fatalf("delete with target: %d", r.StatusCode)
+	} else {
+		r.Body.Close()
+	}
+	if s.Board().StateByName("todo") != nil {
+		t.Fatal("todo not deleted")
+	}
+	if got, _ := s.Get(iss.ID); got.State != "ready" {
+		t.Fatalf("issue not migrated on delete: %q", got.State)
+	}
+
+	// Reorder.
+	names := make([]string, 0)
+	for _, st := range s.Board().States {
+		names = append(names, st.Name)
+	}
+	rev := make([]string, len(names))
+	for i := range names {
+		rev[i] = names[len(names)-1-i]
+	}
+	order, _ := json.Marshal(map[string][]string{"order": rev})
+	if r := do(http.MethodPost, "/board/states/reorder", string(order)); r.StatusCode != 200 {
+		t.Fatalf("reorder: %d", r.StatusCode)
+	} else {
+		r.Body.Close()
+	}
+	if s.Board().States[0].Name != rev[0] {
+		t.Fatal("reorder not applied")
+	}
+}
+
 func TestHTTPIDPrefix(t *testing.T) {
 	srv, s := newServerWithStore(t)
 	defer srv.Close()

--- a/pkg/dispatcher/native/state_management_test.go
+++ b/pkg/dispatcher/native/state_management_test.go
@@ -1,0 +1,246 @@
+package native
+
+import (
+	"errors"
+	"testing"
+)
+
+// countState returns how many indexed issues are currently in `state`.
+func countState(t *testing.T, s *Store, state string) int {
+	t.Helper()
+	issues, err := s.List(ListFilter{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	n := 0
+	for _, iss := range issues {
+		if iss.State == state {
+			n++
+		}
+	}
+	return n
+}
+
+func TestAddState(t *testing.T) {
+	s := newTestStore(t)
+	if err := s.AddState(State{Name: "triage", Display: "Triage"}); err != nil {
+		t.Fatalf("AddState: %v", err)
+	}
+	if s.Board().StateByName("triage") == nil {
+		t.Fatal("triage not added")
+	}
+	// Appended last.
+	states := s.Board().States
+	if states[len(states)-1].Name != "triage" {
+		t.Fatalf("triage not appended last: %v", states)
+	}
+	// Duplicate rejected.
+	if err := s.AddState(State{Name: "triage"}); err == nil {
+		t.Fatal("expected duplicate rejection")
+	}
+	// Empty name rejected.
+	if err := s.AddState(State{Name: ""}); err == nil {
+		t.Fatal("expected empty-name rejection")
+	}
+}
+
+func TestRenameStateCascades(t *testing.T) {
+	s := newTestStore(t)
+	a, _ := s.Create(Issue{Title: "a", State: "backlog"})
+	b, _ := s.Create(Issue{Title: "b", State: "backlog"})
+	_, _ = s.Create(Issue{Title: "c", State: "ready"})
+
+	touched, err := s.RenameState("backlog", "todo")
+	if err != nil {
+		t.Fatalf("RenameState: %v", err)
+	}
+	if touched != 2 {
+		t.Fatalf("touched = %d, want 2", touched)
+	}
+	if s.Board().StateByName("backlog") != nil {
+		t.Fatal("old state still present")
+	}
+	if s.Board().StateByName("todo") == nil {
+		t.Fatal("new state missing")
+	}
+	for _, id := range []string{a.ID, b.ID} {
+		got, _ := s.Get(id)
+		if got.State != "todo" {
+			t.Fatalf("issue %s state = %q, want todo", id, got.State)
+		}
+	}
+
+	// Per-issue rename events emitted with the right reason.
+	renamed := 0
+	_ = s.ScanEvents(func(e *Event) bool {
+		if e.Type == EvtIssueState && e.Payload["reason"] == "state_rename" {
+			renamed++
+		}
+		return true
+	})
+	if renamed != 2 {
+		t.Fatalf("state_rename events = %d, want 2", renamed)
+	}
+}
+
+func TestRenameStateEdgeCases(t *testing.T) {
+	s := newTestStore(t)
+	// rename to self → no-op
+	if n, err := s.RenameState("ready", "ready"); err != nil || n != 0 {
+		t.Fatalf("self-rename: n=%d err=%v", n, err)
+	}
+	// rename unknown → error
+	if _, err := s.RenameState("nope", "x"); err == nil {
+		t.Fatal("expected unknown-state error")
+	}
+	// rename onto existing → refused
+	if _, err := s.RenameState("ready", "done"); err == nil {
+		t.Fatal("expected onto-existing rejection")
+	}
+	// empty names → error
+	if _, err := s.RenameState("", "x"); err == nil {
+		t.Fatal("expected empty-name rejection")
+	}
+}
+
+func TestDeleteStateEmpty(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.DeleteState("review", ""); err != nil {
+		t.Fatalf("DeleteState empty: %v", err)
+	}
+	if s.Board().StateByName("review") != nil {
+		t.Fatal("review not removed")
+	}
+}
+
+func TestDeleteStateNonEmptyRequiresTarget(t *testing.T) {
+	s := newTestStore(t)
+	_, _ = s.Create(Issue{Title: "a", State: "backlog"})
+
+	if _, err := s.DeleteState("backlog", ""); !errors.Is(err, ErrStateNotEmpty) {
+		t.Fatalf("want ErrStateNotEmpty, got %v", err)
+	}
+	// still present after the refused delete
+	if s.Board().StateByName("backlog") == nil {
+		t.Fatal("backlog wrongly removed on refused delete")
+	}
+
+	touched, err := s.DeleteState("backlog", "ready")
+	if err != nil {
+		t.Fatalf("DeleteState with target: %v", err)
+	}
+	if touched != 1 {
+		t.Fatalf("touched = %d, want 1", touched)
+	}
+	if s.Board().StateByName("backlog") != nil {
+		t.Fatal("backlog not removed")
+	}
+	if countState(t, s, "ready") != 1 {
+		t.Fatal("issue not migrated to ready")
+	}
+}
+
+func TestDeleteStateGuards(t *testing.T) {
+	s := newTestStore(t)
+	// unknown state
+	if _, err := s.DeleteState("nope", ""); err == nil {
+		t.Fatal("expected unknown-state error")
+	}
+	_, _ = s.Create(Issue{Title: "a", State: "backlog"})
+	// bad migration target
+	if _, err := s.DeleteState("backlog", "nowhere"); err == nil {
+		t.Fatal("expected bad-target error")
+	}
+	// target == name
+	if _, err := s.DeleteState("backlog", "backlog"); err == nil {
+		t.Fatal("expected same-target error")
+	}
+
+	// deleting down to the last column is refused
+	single := newTestStore(t)
+	if err := single.SetBoard(&Board{States: []State{{Name: "only"}}}); err != nil {
+		t.Fatalf("SetBoard: %v", err)
+	}
+	if _, err := single.DeleteState("only", ""); err == nil {
+		t.Fatal("expected last-column rejection")
+	}
+}
+
+func TestUpdateState(t *testing.T) {
+	s := newTestStore(t)
+	disp := "Backlog!"
+	color := "var(--color-board-ready)"
+	elig := true
+	if err := s.UpdateState("backlog", StatePatch{Display: &disp, Color: &color, Eligible: &elig}); err != nil {
+		t.Fatalf("UpdateState: %v", err)
+	}
+	st := s.Board().StateByName("backlog")
+	if st.Display != disp || st.Color != color || !st.Eligible {
+		t.Fatalf("update not applied: %+v", st)
+	}
+	// unknown state
+	if err := s.UpdateState("nope", StatePatch{}); err == nil {
+		t.Fatal("expected unknown-state error")
+	}
+}
+
+func TestReorderStates(t *testing.T) {
+	s := newTestStore(t)
+	orig := s.Board().States
+	names := make([]string, len(orig))
+	for i, st := range orig {
+		names[i] = st.Name
+	}
+	// reverse
+	rev := make([]string, len(names))
+	for i := range names {
+		rev[i] = names[len(names)-1-i]
+	}
+	if err := s.ReorderStates(rev); err != nil {
+		t.Fatalf("ReorderStates: %v", err)
+	}
+	got := s.Board().States
+	for i := range rev {
+		if got[i].Name != rev[i] {
+			t.Fatalf("order[%d] = %q, want %q", i, got[i].Name, rev[i])
+		}
+	}
+	// wrong length
+	if err := s.ReorderStates(names[:len(names)-1]); err == nil {
+		t.Fatal("expected wrong-length rejection")
+	}
+	// duplicate / unknown set
+	bad := append([]string(nil), rev...)
+	bad[0] = bad[1]
+	if err := s.ReorderStates(bad); err == nil {
+		t.Fatal("expected duplicate rejection")
+	}
+}
+
+func TestStateManagementPersists(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := s.AddState(State{Name: "triage", Display: "Triage"}); err != nil {
+		t.Fatalf("AddState: %v", err)
+	}
+	if _, err := s.RenameState("backlog", "todo"); err != nil {
+		t.Fatalf("RenameState: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	s2, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if s2.Board().StateByName("triage") == nil {
+		t.Fatal("triage did not persist")
+	}
+	if s2.Board().StateByName("todo") == nil || s2.Board().StateByName("backlog") != nil {
+		t.Fatal("rename did not persist")
+	}
+}

--- a/pkg/dispatcher/native/store.go
+++ b/pkg/dispatcher/native/store.go
@@ -692,6 +692,67 @@ func (s *Store) ReorderFields(order []string) (err error) {
 	})
 }
 
+// ---------------------------------------------------------------------------
+// Saved views (board.Views): named filter/sort/group presets, persisted in
+// board.json so they're shared across operators. No issue migration.
+// ---------------------------------------------------------------------------
+
+// SaveView upserts a named view (replaces by name if it exists, else
+// appends). Rejects an empty name.
+func (s *Store) SaveView(v View) (err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer s.recoverMutator("SaveView", &err)
+	if v.Name == "" {
+		return errors.New("native store: view name cannot be empty")
+	}
+	next := cloneBoard(s.board)
+	replaced := false
+	for i := range next.Views {
+		if next.Views[i].Name == v.Name {
+			next.Views[i] = v
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		next.Views = append(next.Views, v)
+	}
+	if err := s.setBoardLocked(next); err != nil {
+		return err
+	}
+	return s.emitPostCommitEvent(Event{
+		Type:    EvtBoardUpdated,
+		Payload: map[string]any{"op": "view_save", "view": v.Name},
+	})
+}
+
+// DeleteView removes a named view. Unknown names error.
+func (s *Store) DeleteView(name string) (err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer s.recoverMutator("DeleteView", &err)
+	idx := -1
+	for i := range s.board.Views {
+		if s.board.Views[i].Name == name {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return fmt.Errorf("native store: unknown view %q", name)
+	}
+	next := cloneBoard(s.board)
+	next.Views = append(next.Views[:idx], next.Views[idx+1:]...)
+	if err := s.setBoardLocked(next); err != nil {
+		return err
+	}
+	return s.emitPostCommitEvent(Event{
+		Type:    EvtBoardUpdated,
+		Payload: map[string]any{"op": "view_delete", "view": name},
+	})
+}
+
 // ReorderStates rewrites the column order. `order` must be a permutation
 // of the current state names (same set, no missing/extra/duplicate
 // entries). Never migrates issues.
@@ -1657,5 +1718,6 @@ func cloneBoard(b *Board) *Board {
 	c := *b
 	c.States = append([]State(nil), b.States...)
 	c.Fields = append([]Field(nil), b.Fields...)
+	c.Views = append([]View(nil), b.Views...)
 	return &c
 }

--- a/pkg/dispatcher/native/store.go
+++ b/pkg/dispatcher/native/store.go
@@ -530,13 +530,7 @@ func (s *Store) UpdateField(name string, p FieldPatch) (err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	defer s.recoverMutator("UpdateField", &err)
-	idx := -1
-	for i := range s.board.Fields {
-		if s.board.Fields[i].Name == name {
-			idx = i
-			break
-		}
-	}
+	idx := s.board.fieldIndex(name)
 	if idx < 0 {
 		return fmt.Errorf("native store: unknown field %q", name)
 	}
@@ -575,13 +569,7 @@ func (s *Store) RenameField(from, to string) (touched int, err error) {
 	if from == to {
 		return 0, nil
 	}
-	idx := -1
-	for i := range s.board.Fields {
-		if s.board.Fields[i].Name == from {
-			idx = i
-			break
-		}
-	}
+	idx := s.board.fieldIndex(from)
 	if idx < 0 {
 		return 0, fmt.Errorf("native store: unknown field %q", from)
 	}
@@ -623,13 +611,7 @@ func (s *Store) DeleteField(name string) (touched int, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	defer s.recoverMutator("DeleteField", &err)
-	idx := -1
-	for i := range s.board.Fields {
-		if s.board.Fields[i].Name == name {
-			idx = i
-			break
-		}
-	}
+	idx := s.board.fieldIndex(name)
 	if idx < 0 {
 		return 0, fmt.Errorf("native store: unknown field %q", name)
 	}
@@ -659,27 +641,43 @@ func (s *Store) DeleteField(name string) (touched int, err error) {
 	})
 }
 
+// reorderByName validates that `order` is a permutation of the names of
+// `items` (per the name accessor) and returns a new slice in that order.
+// `kind` labels errors ("state"/"field"). Shared by ReorderStates and
+// ReorderFields, whose only difference is the element type.
+func reorderByName[T any](items []T, order []string, name func(T) string, kind string) ([]T, error) {
+	if len(order) != len(items) {
+		return nil, fmt.Errorf("native store: reorder expects %d %ss, got %d", len(items), kind, len(order))
+	}
+	pos := make(map[string]int, len(items))
+	for i, it := range items {
+		pos[name(it)] = i
+	}
+	seen := map[string]bool{}
+	out := make([]T, 0, len(order))
+	for _, n := range order {
+		if seen[n] {
+			return nil, fmt.Errorf("native store: duplicate %s %q in reorder", kind, n)
+		}
+		i, ok := pos[n]
+		if !ok {
+			return nil, fmt.Errorf("native store: unknown %s %q in reorder", kind, n)
+		}
+		seen[n] = true
+		out = append(out, items[i])
+	}
+	return out, nil
+}
+
 // ReorderFields rewrites the field order. `order` must be a permutation
 // of the current field names. Never touches issues.
 func (s *Store) ReorderFields(order []string) (err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	defer s.recoverMutator("ReorderFields", &err)
-	if len(order) != len(s.board.Fields) {
-		return fmt.Errorf("native store: reorder expects %d fields, got %d", len(s.board.Fields), len(order))
-	}
-	seen := map[string]bool{}
-	reordered := make([]Field, 0, len(order))
-	for _, name := range order {
-		if seen[name] {
-			return fmt.Errorf("native store: duplicate field %q in reorder", name)
-		}
-		f := s.board.FieldByName(name)
-		if f == nil {
-			return fmt.Errorf("native store: unknown field %q in reorder", name)
-		}
-		seen[name] = true
-		reordered = append(reordered, *f)
+	reordered, err := reorderByName(s.board.Fields, order, func(f Field) string { return f.Name }, "field")
+	if err != nil {
+		return err
 	}
 	next := cloneBoard(s.board)
 	next.Fields = reordered
@@ -760,21 +758,9 @@ func (s *Store) ReorderStates(order []string) (err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	defer s.recoverMutator("ReorderStates", &err)
-	if len(order) != len(s.board.States) {
-		return fmt.Errorf("native store: reorder expects %d states, got %d", len(s.board.States), len(order))
-	}
-	seen := map[string]bool{}
-	reordered := make([]State, 0, len(order))
-	for _, name := range order {
-		if seen[name] {
-			return fmt.Errorf("native store: duplicate state %q in reorder", name)
-		}
-		st := s.board.StateByName(name)
-		if st == nil {
-			return fmt.Errorf("native store: unknown state %q in reorder", name)
-		}
-		seen[name] = true
-		reordered = append(reordered, *st)
+	reordered, err := reorderByName(s.board.States, order, func(st State) string { return st.Name }, "state")
+	if err != nil {
+		return err
 	}
 	next := cloneBoard(s.board)
 	next.States = reordered

--- a/pkg/dispatcher/native/store.go
+++ b/pkg/dispatcher/native/store.go
@@ -447,6 +447,251 @@ func (s *Store) UpdateState(name string, p StatePatch) (err error) {
 	})
 }
 
+// ---------------------------------------------------------------------------
+// Custom field schema management (board.Fields). Mirrors the state
+// mutators: granular ops, atomic under s.mu, with a key cascade across
+// issue.Fields maps on rename/delete so no issue is left referencing a
+// field the schema no longer knows (which Update's ValidateFieldValues
+// would otherwise reject).
+// ---------------------------------------------------------------------------
+
+// applyFieldRewriteLocked rewrites each indexed issue's Fields map via
+// transform, persisting + reindexing + emitting EvtIssueUpdated per
+// changed issue. The caller already holds s.mu. Returns issues touched.
+// Mirrors applyLabelRewriteLocked's partial-progress contract.
+func (s *Store) applyFieldRewriteLocked(
+	transform func(fields map[string]any) (map[string]any, bool),
+	reason string,
+) (int, error) {
+	touched := 0
+	for id, iss := range s.index {
+		if len(iss.Fields) == 0 {
+			continue
+		}
+		nextFields, changed := transform(iss.Fields)
+		if !changed {
+			continue
+		}
+		next := cloneIssue(iss)
+		next.Fields = nextFields
+		next.UpdatedAt = time.Now().UTC()
+		if err := s.writeIssueLocked(next); err != nil {
+			return touched, fmt.Errorf("native store: write %s during %s: %w", id, reason, err)
+		}
+		s.index[id] = next
+		if err := s.emitPostCommitEvent(Event{
+			Type:    EvtIssueUpdated,
+			IssueID: id,
+			Payload: map[string]any{"changed": []string{"fields"}, "reason": reason},
+		}); err != nil {
+			return touched, err
+		}
+		touched++
+	}
+	return touched, nil
+}
+
+// AddField appends a new custom-field definition. Rejects empty/duplicate
+// names; the candidate board is validated (enum needs values, known type).
+func (s *Store) AddField(f Field) (err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer s.recoverMutator("AddField", &err)
+	if f.Name == "" {
+		return errors.New("native store: field name cannot be empty")
+	}
+	if s.board.FieldByName(f.Name) != nil {
+		return fmt.Errorf("native store: field %q already exists", f.Name)
+	}
+	next := cloneBoard(s.board)
+	next.Fields = append(next.Fields, f)
+	if err := s.setBoardLocked(next); err != nil {
+		return err
+	}
+	return s.emitPostCommitEvent(Event{
+		Type:    EvtBoardUpdated,
+		Payload: map[string]any{"op": "field_add", "field": f.Name},
+	})
+}
+
+// FieldPatch carries the editable definition fields for UpdateField. A
+// nil pointer leaves the corresponding attribute untouched. Renames go
+// through RenameField (they cascade), never here.
+type FieldPatch struct {
+	Display    *string    `json:"display,omitempty"`
+	Type       *FieldType `json:"type,omitempty"`
+	Required   *bool      `json:"required,omitempty"`
+	EnumValues *[]string  `json:"enum_values,omitempty"`
+}
+
+// UpdateField edits a field definition in place (no rename, no value
+// migration). The amended board is validated before commit.
+func (s *Store) UpdateField(name string, p FieldPatch) (err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer s.recoverMutator("UpdateField", &err)
+	idx := -1
+	for i := range s.board.Fields {
+		if s.board.Fields[i].Name == name {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return fmt.Errorf("native store: unknown field %q", name)
+	}
+	next := cloneBoard(s.board)
+	f := &next.Fields[idx]
+	if p.Display != nil {
+		f.Display = *p.Display
+	}
+	if p.Type != nil {
+		f.Type = *p.Type
+	}
+	if p.Required != nil {
+		f.Required = *p.Required
+	}
+	if p.EnumValues != nil {
+		f.EnumValues = *p.EnumValues
+	}
+	if err := s.setBoardLocked(next); err != nil {
+		return err
+	}
+	return s.emitPostCommitEvent(Event{
+		Type:    EvtBoardUpdated,
+		Payload: map[string]any{"op": "field_update", "field": name},
+	})
+}
+
+// RenameField renames a field definition and cascades the key across
+// every issue's Fields map. Refuses renaming onto an existing field.
+func (s *Store) RenameField(from, to string) (touched int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer s.recoverMutator("RenameField", &err)
+	if from == "" || to == "" {
+		return 0, errors.New("native store: field name cannot be empty")
+	}
+	if from == to {
+		return 0, nil
+	}
+	idx := -1
+	for i := range s.board.Fields {
+		if s.board.Fields[i].Name == from {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return 0, fmt.Errorf("native store: unknown field %q", from)
+	}
+	if s.board.FieldByName(to) != nil {
+		return 0, fmt.Errorf("native store: target field %q already exists", to)
+	}
+	next := cloneBoard(s.board)
+	next.Fields[idx].Name = to
+	if err := s.setBoardLocked(next); err != nil {
+		return 0, err
+	}
+	touched, err = s.applyFieldRewriteLocked(func(fields map[string]any) (map[string]any, bool) {
+		v, ok := fields[from]
+		if !ok {
+			return fields, false
+		}
+		out := make(map[string]any, len(fields))
+		for k, val := range fields {
+			if k == from {
+				continue
+			}
+			out[k] = val
+		}
+		out[to] = v
+		return out, true
+	}, "field_rename")
+	if err != nil {
+		return touched, err
+	}
+	return touched, s.emitPostCommitEvent(Event{
+		Type:    EvtBoardUpdated,
+		Payload: map[string]any{"op": "field_rename", "from": from, "to": to},
+	})
+}
+
+// DeleteField removes a field definition and strips its key from every
+// issue (so no issue keeps a value the schema no longer validates).
+func (s *Store) DeleteField(name string) (touched int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer s.recoverMutator("DeleteField", &err)
+	idx := -1
+	for i := range s.board.Fields {
+		if s.board.Fields[i].Name == name {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return 0, fmt.Errorf("native store: unknown field %q", name)
+	}
+	touched, err = s.applyFieldRewriteLocked(func(fields map[string]any) (map[string]any, bool) {
+		if _, ok := fields[name]; !ok {
+			return fields, false
+		}
+		out := make(map[string]any, len(fields))
+		for k, val := range fields {
+			if k != name {
+				out[k] = val
+			}
+		}
+		return out, true
+	}, "field_delete")
+	if err != nil {
+		return touched, err
+	}
+	next := cloneBoard(s.board)
+	next.Fields = append(next.Fields[:idx], next.Fields[idx+1:]...)
+	if err := s.setBoardLocked(next); err != nil {
+		return touched, err
+	}
+	return touched, s.emitPostCommitEvent(Event{
+		Type:    EvtBoardUpdated,
+		Payload: map[string]any{"op": "field_delete", "field": name},
+	})
+}
+
+// ReorderFields rewrites the field order. `order` must be a permutation
+// of the current field names. Never touches issues.
+func (s *Store) ReorderFields(order []string) (err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer s.recoverMutator("ReorderFields", &err)
+	if len(order) != len(s.board.Fields) {
+		return fmt.Errorf("native store: reorder expects %d fields, got %d", len(s.board.Fields), len(order))
+	}
+	seen := map[string]bool{}
+	reordered := make([]Field, 0, len(order))
+	for _, name := range order {
+		if seen[name] {
+			return fmt.Errorf("native store: duplicate field %q in reorder", name)
+		}
+		f := s.board.FieldByName(name)
+		if f == nil {
+			return fmt.Errorf("native store: unknown field %q in reorder", name)
+		}
+		seen[name] = true
+		reordered = append(reordered, *f)
+	}
+	next := cloneBoard(s.board)
+	next.Fields = reordered
+	if err := s.setBoardLocked(next); err != nil {
+		return err
+	}
+	return s.emitPostCommitEvent(Event{
+		Type:    EvtBoardUpdated,
+		Payload: map[string]any{"op": "field_reorder"},
+	})
+}
+
 // ReorderStates rewrites the column order. `order` must be a permutation
 // of the current state names (same set, no missing/extra/duplicate
 // entries). Never migrates issues.

--- a/pkg/dispatcher/native/store.go
+++ b/pkg/dispatcher/native/store.go
@@ -211,6 +211,12 @@ func (s *Store) Board() *Board {
 // both the live store and on-disk state consistent on the old board
 // — the previous order (swap → write) silently diverged in-memory
 // from disk on EIO / quota / permission errors (F-CD-9).
+//
+// SetBoard does NOT migrate issues: replacing the state list here leaves
+// issues pointing at states that may no longer exist (they fall into the
+// studio's "__unmapped__" bucket). Use it only for whole-board seeds and
+// no-migration edits. Column renames/deletes that must move issues go
+// through RenameState/DeleteState, which cascade across the issue files.
 func (s *Store) SetBoard(b *Board) (err error) {
 	if err := b.Validate(); err != nil {
 		return err
@@ -226,6 +232,253 @@ func (s *Store) SetBoard(b *Board) (err error) {
 		return err
 	}
 	return s.emitPostCommitEvent(Event{Type: EvtBoardUpdated})
+}
+
+// ErrStateNotEmpty is returned by DeleteState when the target column
+// still holds issues and no migration target was supplied. The HTTP
+// layer maps it to 409 so the UI can prompt for a destination column.
+var ErrStateNotEmpty = errors.New("native store: state has issues; migration target required")
+
+// setBoardLocked validates a candidate board, swaps it in, and persists
+// it, rolling back to the previous board on a write failure (mirrors
+// SetBoard's commit discipline). The caller already holds s.mu. It does
+// NOT emit an event — column mutators emit a precise EvtBoardUpdated with
+// an op discriminator after any per-issue cascade completes.
+func (s *Store) setBoardLocked(next *Board) error {
+	if err := next.Validate(); err != nil {
+		return err
+	}
+	prev := s.board
+	s.board = next
+	if err := s.writeBoardLocked(); err != nil {
+		s.board = prev
+		return err
+	}
+	return nil
+}
+
+// migrateStateLocked rewrites every indexed issue in state `from` to
+// state `to`, emitting one EvtIssueState per touched issue with the
+// given reason. The caller already holds s.mu and has validated both
+// states. Returns the number of issues moved. A mid-loop write failure
+// leaves earlier issues migrated and later ones untouched — acceptable
+// and self-consistent (those issues simply stay in `from` until retried,
+// or surface in the "__unmapped__" bucket if the column is already gone);
+// recoverMutator rebuilds the index from disk on panic. Mirrors the
+// partial-progress contract of applyLabelRewriteLocked.
+func (s *Store) migrateStateLocked(from, to, reason string) (int, error) {
+	touched := 0
+	for id, iss := range s.index {
+		if iss.State != from {
+			continue
+		}
+		// Clone before mutating: index entries are shared with reader
+		// goroutines holding earlier defensive copies.
+		next := cloneIssue(iss)
+		next.State = to
+		next.UpdatedAt = time.Now().UTC()
+		if err := s.writeIssueLocked(next); err != nil {
+			return touched, fmt.Errorf("native store: write %s during state migration: %w", id, err)
+		}
+		s.index[id] = next
+		if err := s.emitPostCommitEvent(Event{
+			Type:    EvtIssueState,
+			IssueID: id,
+			Payload: map[string]any{"from": from, "to": to, "reason": reason},
+		}); err != nil {
+			return touched, err
+		}
+		touched++
+	}
+	return touched, nil
+}
+
+// AddState appends a new column to the board. The column lands last; the
+// operator reorders afterward via ReorderStates. Rejects an empty or
+// duplicate name. No issue migration.
+func (s *Store) AddState(st State) (err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer s.recoverMutator("AddState", &err)
+	if st.Name == "" {
+		return errors.New("native store: state name cannot be empty")
+	}
+	if s.board.StateByName(st.Name) != nil {
+		return fmt.Errorf("native store: state %q already exists", st.Name)
+	}
+	next := cloneBoard(s.board)
+	next.States = append(next.States, st)
+	if err := s.setBoardLocked(next); err != nil {
+		return err
+	}
+	return s.emitPostCommitEvent(Event{
+		Type:    EvtBoardUpdated,
+		Payload: map[string]any{"op": "state_add", "state": st.Name},
+	})
+}
+
+// RenameState renames a column and cascades the change to every issue in
+// it. Renaming onto an existing column is refused (it would silently
+// merge two columns' semantics — delete-with-migrate is the explicit path
+// for that). Renaming to itself is a no-op. Returns the number of issues
+// touched. The board is renamed first, then issues are migrated, so a
+// mid-cascade failure leaves a renamed column with some issues still
+// carrying the old name (they land in "__unmapped__" until retried).
+func (s *Store) RenameState(from, to string) (touched int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer s.recoverMutator("RenameState", &err)
+	if from == "" || to == "" {
+		return 0, errors.New("native store: state name cannot be empty")
+	}
+	if from == to {
+		return 0, nil
+	}
+	idx := s.board.stateIndex(from)
+	if idx < 0 {
+		return 0, fmt.Errorf("native store: unknown state %q", from)
+	}
+	if s.board.StateByName(to) != nil {
+		return 0, fmt.Errorf("native store: target state %q already exists; delete-with-migrate to merge columns", to)
+	}
+	next := cloneBoard(s.board)
+	next.States[idx].Name = to
+	if err := s.setBoardLocked(next); err != nil {
+		return 0, err
+	}
+	touched, err = s.migrateStateLocked(from, to, "state_rename")
+	if err != nil {
+		return touched, err
+	}
+	return touched, s.emitPostCommitEvent(Event{
+		Type:    EvtBoardUpdated,
+		Payload: map[string]any{"op": "state_rename", "from": from, "to": to},
+	})
+}
+
+// DeleteState removes a column. If it still holds issues, migrateTo must
+// name another existing column to receive them (else ErrStateNotEmpty).
+// Refuses to delete the last remaining column. Issues are migrated first,
+// then the column is dropped, so no issue is ever left in a column that
+// no longer exists. Returns the number of issues migrated.
+func (s *Store) DeleteState(name, migrateTo string) (touched int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer s.recoverMutator("DeleteState", &err)
+	if s.board.stateIndex(name) < 0 {
+		return 0, fmt.Errorf("native store: unknown state %q", name)
+	}
+	if len(s.board.States) <= 1 {
+		return 0, errors.New("native store: cannot delete the last column")
+	}
+	count := 0
+	for _, iss := range s.index {
+		if iss.State == name {
+			count++
+		}
+	}
+	if count > 0 {
+		if migrateTo == "" {
+			return 0, ErrStateNotEmpty
+		}
+		if migrateTo == name {
+			return 0, errors.New("native store: migration target must differ from the deleted state")
+		}
+		if s.board.StateByName(migrateTo) == nil {
+			return 0, fmt.Errorf("native store: unknown migration target %q", migrateTo)
+		}
+		touched, err = s.migrateStateLocked(name, migrateTo, "state_delete")
+		if err != nil {
+			return touched, err
+		}
+	}
+	next := cloneBoard(s.board)
+	idx := next.stateIndex(name)
+	next.States = append(next.States[:idx], next.States[idx+1:]...)
+	if err := s.setBoardLocked(next); err != nil {
+		return touched, err
+	}
+	return touched, s.emitPostCommitEvent(Event{
+		Type:    EvtBoardUpdated,
+		Payload: map[string]any{"op": "state_delete", "state": name, "migrate_to": migrateTo},
+	})
+}
+
+// StatePatch carries the editable per-column fields for UpdateState.
+// Nil pointers leave the corresponding field untouched.
+type StatePatch struct {
+	Display  *string `json:"display,omitempty"`
+	Color    *string `json:"color,omitempty"`
+	Eligible *bool   `json:"eligible,omitempty"`
+	Terminal *bool   `json:"terminal,omitempty"`
+}
+
+// UpdateState edits a column's display name, color, and eligible/terminal
+// flags. It never renames (that cascades — use RenameState) and never
+// migrates issues.
+func (s *Store) UpdateState(name string, p StatePatch) (err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer s.recoverMutator("UpdateState", &err)
+	idx := s.board.stateIndex(name)
+	if idx < 0 {
+		return fmt.Errorf("native store: unknown state %q", name)
+	}
+	next := cloneBoard(s.board)
+	st := &next.States[idx]
+	if p.Display != nil {
+		st.Display = *p.Display
+	}
+	if p.Color != nil {
+		st.Color = *p.Color
+	}
+	if p.Eligible != nil {
+		st.Eligible = *p.Eligible
+	}
+	if p.Terminal != nil {
+		st.Terminal = *p.Terminal
+	}
+	if err := s.setBoardLocked(next); err != nil {
+		return err
+	}
+	return s.emitPostCommitEvent(Event{
+		Type:    EvtBoardUpdated,
+		Payload: map[string]any{"op": "state_update", "state": name},
+	})
+}
+
+// ReorderStates rewrites the column order. `order` must be a permutation
+// of the current state names (same set, no missing/extra/duplicate
+// entries). Never migrates issues.
+func (s *Store) ReorderStates(order []string) (err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer s.recoverMutator("ReorderStates", &err)
+	if len(order) != len(s.board.States) {
+		return fmt.Errorf("native store: reorder expects %d states, got %d", len(s.board.States), len(order))
+	}
+	seen := map[string]bool{}
+	reordered := make([]State, 0, len(order))
+	for _, name := range order {
+		if seen[name] {
+			return fmt.Errorf("native store: duplicate state %q in reorder", name)
+		}
+		st := s.board.StateByName(name)
+		if st == nil {
+			return fmt.Errorf("native store: unknown state %q in reorder", name)
+		}
+		seen[name] = true
+		reordered = append(reordered, *st)
+	}
+	next := cloneBoard(s.board)
+	next.States = reordered
+	if err := s.setBoardLocked(next); err != nil {
+		return err
+	}
+	return s.emitPostCommitEvent(Event{
+		Type:    EvtBoardUpdated,
+		Payload: map[string]any{"op": "state_reorder"},
+	})
 }
 
 // Create persists a new issue. The State must be one of the configured

--- a/pkg/dispatcher/native/view_management_test.go
+++ b/pkg/dispatcher/native/view_management_test.go
@@ -1,0 +1,61 @@
+package native
+
+import "testing"
+
+func TestSaveAndDeleteView(t *testing.T) {
+	s := newTestStore(t)
+
+	if err := s.SaveView(View{Name: "Mine", Assignee: "jo", Sort: "priority", GroupBy: "assignee"}); err != nil {
+		t.Fatalf("SaveView: %v", err)
+	}
+	if len(s.Board().Views) != 1 {
+		t.Fatalf("want 1 view, got %d", len(s.Board().Views))
+	}
+
+	// Upsert by name (replace, not append).
+	if err := s.SaveView(View{Name: "Mine", Assignee: "alice"}); err != nil {
+		t.Fatalf("SaveView upsert: %v", err)
+	}
+	views := s.Board().Views
+	if len(views) != 1 || views[0].Assignee != "alice" {
+		t.Fatalf("upsert did not replace: %+v", views)
+	}
+
+	// Empty name rejected.
+	if err := s.SaveView(View{Name: ""}); err == nil {
+		t.Fatal("expected empty-name rejection")
+	}
+
+	// Delete.
+	if err := s.DeleteView("Mine"); err != nil {
+		t.Fatalf("DeleteView: %v", err)
+	}
+	if len(s.Board().Views) != 0 {
+		t.Fatal("view not deleted")
+	}
+	if err := s.DeleteView("nope"); err == nil {
+		t.Fatal("expected unknown-view error")
+	}
+}
+
+func TestViewsPersist(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := s.SaveView(View{Name: "Triage", Labels: []string{"bug"}, GroupBy: "label"}); err != nil {
+		t.Fatalf("SaveView: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	s2, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	views := s2.Board().Views
+	if len(views) != 1 || views[0].Name != "Triage" || views[0].GroupBy != "label" {
+		t.Fatalf("view did not persist: %+v", views)
+	}
+}

--- a/studio/src/App.tsx
+++ b/studio/src/App.tsx
@@ -15,6 +15,7 @@ const LaunchView = lazy(() => import("@/components/Runs/LaunchView"));
 const RunsTabsView = lazy(() => import("@/components/Runs/RunsTabsView"));
 const BoardView = lazy(() => import("@/views/Board"));
 const LabelsView = lazy(() => import("@/views/Board/Labels"));
+const FieldsView = lazy(() => import("@/views/Board/Fields"));
 const RunsAnalyticsView = lazy(() => import("@/views/RunsAnalytics"));
 const DispatcherView = lazy(() => import("@/views/Dispatcher"));
 const MarketplaceView = lazy(() => import("@/views/Marketplace"));
@@ -258,6 +259,13 @@ function AuthedApp() {
             <Route path="/board/labels">
               <ErrorBoundary area="Board labels view">
                 <LabelsView />
+              </ErrorBoundary>
+            </Route>
+          )}
+          {serverInfo?.native_tracker_enabled && (
+            <Route path="/board/fields">
+              <ErrorBoundary area="Board fields view">
+                <FieldsView />
               </ErrorBoundary>
             </Route>
           )}

--- a/studio/src/api/native.ts
+++ b/studio/src/api/native.ts
@@ -147,6 +147,44 @@ export function putBoard(board: Partial<NativeBoard>): Promise<NativeBoard> {
 }
 
 // ---------------------------------------------------------------------------
+// Column (state) management. Mirrors the native /board/states REST surface.
+// Each call returns the refreshed board so callers refresh without a
+// second getBoard(). Rename/delete cascade across issues server-side.
+// ---------------------------------------------------------------------------
+
+// Editable per-column fields. `name` triggers a cascading rename when it
+// differs from the path segment.
+export type NativeStatePatch = Partial<
+  Pick<NativeState, "name" | "display" | "color" | "eligible" | "terminal">
+>;
+
+export function addState(state: NativeState): Promise<NativeBoard> {
+  return request("/board/states", { method: "POST", body: JSON.stringify(state) });
+}
+
+export function updateState(name: string, patch: NativeStatePatch): Promise<NativeBoard> {
+  return request(`/board/states/${encodeURIComponent(name)}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+}
+
+// deleteState removes a column. When the column is non-empty and no
+// migrateTo is given, the server returns 409 (ApiError) so the caller can
+// prompt for a destination column.
+export function deleteState(name: string, migrateTo?: string): Promise<NativeBoard> {
+  const q = migrateTo ? `?migrate_to=${encodeURIComponent(migrateTo)}` : "";
+  return request(`/board/states/${encodeURIComponent(name)}${q}`, { method: "DELETE" });
+}
+
+export function reorderStates(order: string[]): Promise<NativeBoard> {
+  return request("/board/states/reorder", {
+    method: "POST",
+    body: JSON.stringify({ order }),
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Label vocabulary management. Mirrors the native /labels REST surface.
 // ---------------------------------------------------------------------------
 

--- a/studio/src/api/native.ts
+++ b/studio/src/api/native.ts
@@ -185,6 +185,37 @@ export function reorderStates(order: string[]): Promise<NativeBoard> {
 }
 
 // ---------------------------------------------------------------------------
+// Custom field schema management. Mirrors the native /board/fields REST
+// surface. Rename cascades the key across issue.Fields; delete strips it.
+// ---------------------------------------------------------------------------
+
+export type NativeFieldPatch = Partial<
+  Pick<NativeField, "name" | "display" | "type" | "required" | "enum_values">
+>;
+
+export function addField(field: NativeField): Promise<NativeBoard> {
+  return request("/board/fields", { method: "POST", body: JSON.stringify(field) });
+}
+
+export function updateField(name: string, patch: NativeFieldPatch): Promise<NativeBoard> {
+  return request(`/board/fields/${encodeURIComponent(name)}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+}
+
+export function deleteField(name: string): Promise<NativeBoard> {
+  return request(`/board/fields/${encodeURIComponent(name)}`, { method: "DELETE" });
+}
+
+export function reorderFields(order: string[]): Promise<NativeBoard> {
+  return request("/board/fields/reorder", {
+    method: "POST",
+    body: JSON.stringify({ order }),
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Label vocabulary management. Mirrors the native /labels REST surface.
 // ---------------------------------------------------------------------------
 

--- a/studio/src/api/native.ts
+++ b/studio/src/api/native.ts
@@ -46,7 +46,19 @@ export interface NativeIssue {
 export interface NativeBoard {
   states: NativeState[];
   fields?: NativeField[];
+  views?: NativeView[];
   updated_at: string;
+}
+
+// NativeView mirrors pkg/dispatcher/native.View — a saved filter/sort/group
+// preset persisted in board.json and shared across operators.
+export interface NativeView {
+  name: string;
+  search?: string;
+  labels?: string[];
+  assignee?: string;
+  sort?: string;
+  group_by?: string;
 }
 
 export interface NativeState {
@@ -213,6 +225,19 @@ export function reorderFields(order: string[]): Promise<NativeBoard> {
     method: "POST",
     body: JSON.stringify({ order }),
   });
+}
+
+// ---------------------------------------------------------------------------
+// Saved views. Mirrors the native /board/views REST surface. saveView
+// upserts by name; both return the refreshed board.
+// ---------------------------------------------------------------------------
+
+export function saveView(view: NativeView): Promise<NativeBoard> {
+  return request("/board/views", { method: "POST", body: JSON.stringify(view) });
+}
+
+export function deleteView(name: string): Promise<NativeBoard> {
+  return request(`/board/views/${encodeURIComponent(name)}`, { method: "DELETE" });
 }
 
 // ---------------------------------------------------------------------------

--- a/studio/src/views/Board/BoardFilters.tsx
+++ b/studio/src/views/Board/BoardFilters.tsx
@@ -4,7 +4,12 @@ import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
 
-import { SORT_OPTIONS, type SortMode } from "./boardShared";
+import {
+  BASE_GROUP_OPTIONS,
+  SORT_OPTIONS,
+  type GroupMode,
+  type SortMode,
+} from "./boardShared";
 
 export function BoardFilters({
   searchQuery,
@@ -20,6 +25,9 @@ export function BoardFilters({
   onAssigneeChange,
   sortMode,
   onSortChange,
+  groupMode,
+  onGroupChange,
+  fieldNames,
   onReset,
 }: {
   searchQuery: string;
@@ -35,6 +43,9 @@ export function BoardFilters({
   onAssigneeChange: (v: string) => void;
   sortMode: SortMode;
   onSortChange: (m: SortMode) => void;
+  groupMode: GroupMode;
+  onGroupChange: (m: GroupMode) => void;
+  fieldNames: string[];
   onReset: () => void;
 }) {
   const filtersActive =
@@ -85,6 +96,26 @@ export function BoardFilters({
           {SORT_OPTIONS.map((o) => (
             <option key={o.value} value={o.value}>
               {o.label}
+            </option>
+          ))}
+        </Select>
+      </label>
+      <label htmlFor="board-group-select" className="flex items-center gap-1 text-fg-muted">
+        Group
+        <Select
+          id="board-group-select"
+          value={groupMode}
+          onChange={(e) => onGroupChange(e.target.value)}
+          title="Split the board into horizontal swimlanes"
+        >
+          {BASE_GROUP_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+          {fieldNames.map((n) => (
+            <option key={`field:${n}`} value={`field:${n}`}>
+              Field: {n}
             </option>
           ))}
         </Select>

--- a/studio/src/views/Board/BoardFilters.tsx
+++ b/studio/src/views/Board/BoardFilters.tsx
@@ -6,6 +6,7 @@ import { Select } from "@/components/ui/Select";
 
 import {
   BASE_GROUP_OPTIONS,
+  groupModeForField,
   SORT_OPTIONS,
   type GroupMode,
   type SortMode,
@@ -114,7 +115,7 @@ export function BoardFilters({
             </option>
           ))}
           {fieldNames.map((n) => (
-            <option key={`field:${n}`} value={`field:${n}`}>
+            <option key={groupModeForField(n)} value={groupModeForField(n)}>
               Field: {n}
             </option>
           ))}

--- a/studio/src/views/Board/Column.tsx
+++ b/studio/src/views/Board/Column.tsx
@@ -201,8 +201,8 @@ export function Column({
                 <IconButton
                   size="sm"
                   variant="ghost"
-                  aria-label={`Manage ${display} column`}
-                  title="Column options"
+                  label={`Manage ${display} column`}
+                  tooltip="Column options"
                   className="ml-1"
                   // Don't let the header's dragstart hijack a menu click.
                   draggable={false}

--- a/studio/src/views/Board/Column.tsx
+++ b/studio/src/views/Board/Column.tsx
@@ -1,13 +1,16 @@
 import { useState } from "react";
+import { GripVertical, MoreVertical } from "lucide-react";
 
 import { Checkbox } from "@/components/ui/Checkbox";
+import { IconButton } from "@/components/ui/IconButton";
+import { Popover, PopoverClose } from "@/components/ui/Popover";
 import { formatRelative } from "@/lib/format";
 import { clickableRowProps } from "@/lib/a11y";
 import { softColor } from "@/lib/constants";
 import type { DispatchSkipView, RetryView, RunningView } from "@/api/dispatcher";
 import type { NativeIssue } from "@/api/native";
 
-import { DRAG_MIME_ISSUE_IDS } from "./boardShared";
+import { DRAG_MIME_ISSUE_IDS, DRAG_MIME_STATE } from "./boardShared";
 
 // Max label chips shown on a card before collapsing the rest into "+N".
 const MAX_CARD_LABELS = 3;
@@ -60,6 +63,15 @@ interface ColumnProps {
   // are still draggable, but the user gets a clear "nothing will pick
   // these up" signal.
   dimmed?: boolean;
+  // Column-management callbacks (operator-only). Absent for the synthetic
+  // "__unmapped__" column, which renders no header menu / drag handle.
+  onEditColumn?: (name: string) => void;
+  onDeleteColumn?: (name: string) => void;
+  // onMoveColumn nudges a column one slot left/right (keyboard-free reorder).
+  onMoveColumn?: (name: string, dir: "left" | "right") => void;
+  // onReorderColumn fires when another column header is dropped onto this
+  // one: move `dragged` to this column's position.
+  onReorderColumn?: (dragged: string, target: string) => void;
 }
 
 export function Column({
@@ -83,8 +95,13 @@ export function Column({
   onCancelRun,
   onOpenRun,
   dimmed,
+  onEditColumn,
+  onDeleteColumn,
+  onMoveColumn,
+  onReorderColumn,
 }: ColumnProps) {
   const [dragOver, setDragOver] = useState(false);
+  const manageable = name !== "__unmapped__";
   const selCount = issues.reduce((n, i) => n + (selectedIds.has(i.id) ? 1 : 0), 0);
   const allSelected = issues.length > 0 && selCount === issues.length;
   // Dim only the eligible columns when the dispatcher is paused — the
@@ -108,6 +125,13 @@ export function Column({
         e.preventDefault();
         setDragOver(false);
         if (name === "__unmapped__") return;
+        // Column reorder takes precedence: a header drag carries the
+        // dragged state name, which must not be mistaken for a card drop.
+        const draggedState = e.dataTransfer.getData(DRAG_MIME_STATE);
+        if (draggedState) {
+          if (draggedState !== name) onReorderColumn?.(draggedState, name);
+          return;
+        }
         const json = e.dataTransfer.getData(DRAG_MIME_ISSUE_IDS);
         if (json) {
           try {
@@ -124,9 +148,25 @@ export function Column({
         if (single) onDrop([single], name);
       }}
     >
-      <div className="px-3 py-2 border-b border-border-default flex items-center justify-between text-xs">
+      <div
+        className="px-3 py-2 border-b border-border-default flex items-center justify-between text-xs"
+        // The header is the drag handle for column reorder. Made
+        // draggable only for manageable columns; the grip icon signals it.
+        draggable={manageable && !!onReorderColumn}
+        onDragStart={(e) => {
+          if (!manageable || !onReorderColumn) return;
+          e.dataTransfer.setData(DRAG_MIME_STATE, name);
+          e.dataTransfer.effectAllowed = "move";
+        }}
+      >
         <span className="flex items-center gap-2 min-w-0">
-          {name !== "__unmapped__" && issues.length > 0 && (
+          {manageable && onReorderColumn && (
+            <GripVertical
+              className="h-3.5 w-3.5 shrink-0 text-fg-subtle cursor-grab"
+              aria-hidden="true"
+            />
+          )}
+          {manageable && issues.length > 0 && (
             <Checkbox
               checked={allSelected}
               ref={(el) => {
@@ -154,6 +194,73 @@ export function Column({
           {issues.length}
           {eligible && <span className="ml-1 text-success">●</span>}
           {terminal && <span className="ml-1 text-fg-muted">✓</span>}
+          {manageable && (onEditColumn || onDeleteColumn || onMoveColumn) && (
+            <Popover
+              align="end"
+              trigger={
+                <IconButton
+                  size="sm"
+                  variant="ghost"
+                  aria-label={`Manage ${display} column`}
+                  title="Column options"
+                  className="ml-1"
+                  // Don't let the header's dragstart hijack a menu click.
+                  draggable={false}
+                  onDragStart={(e) => e.preventDefault()}
+                >
+                  <MoreVertical className="h-4 w-4" />
+                </IconButton>
+              }
+              contentClassName="p-1 min-w-40 text-xs"
+            >
+              <div className="flex flex-col">
+                {onEditColumn && (
+                  <PopoverClose asChild>
+                    <button
+                      type="button"
+                      className="text-left px-2 py-1.5 rounded hover:bg-surface-2 text-fg-default"
+                      onClick={() => onEditColumn(name)}
+                    >
+                      Edit column…
+                    </button>
+                  </PopoverClose>
+                )}
+                {onMoveColumn && (
+                  <>
+                    <PopoverClose asChild>
+                      <button
+                        type="button"
+                        className="text-left px-2 py-1.5 rounded hover:bg-surface-2 text-fg-default"
+                        onClick={() => onMoveColumn(name, "left")}
+                      >
+                        Move left
+                      </button>
+                    </PopoverClose>
+                    <PopoverClose asChild>
+                      <button
+                        type="button"
+                        className="text-left px-2 py-1.5 rounded hover:bg-surface-2 text-fg-default"
+                        onClick={() => onMoveColumn(name, "right")}
+                      >
+                        Move right
+                      </button>
+                    </PopoverClose>
+                  </>
+                )}
+                {onDeleteColumn && (
+                  <PopoverClose asChild>
+                    <button
+                      type="button"
+                      className="text-left px-2 py-1.5 rounded hover:bg-surface-2 text-danger-fg"
+                      onClick={() => onDeleteColumn(name)}
+                    >
+                      Delete column…
+                    </button>
+                  </PopoverClose>
+                )}
+              </div>
+            </Popover>
+          )}
         </span>
       </div>
       <div className="p-2 flex-1 flex flex-col gap-2 overflow-auto">

--- a/studio/src/views/Board/ColumnDialogs.tsx
+++ b/studio/src/views/Board/ColumnDialogs.tsx
@@ -17,46 +17,13 @@
 import { useState } from "react";
 
 import type { NativeState } from "@/api/native";
-import { Button } from "@/components/ui/Button";
 import { Checkbox } from "@/components/ui/Checkbox";
 import { Dialog } from "@/components/ui/Dialog";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
 
 import { BOARD_PALETTE, defaultStateColor } from "./boardShared";
-
-function ModalActions({
-  onCancel,
-  primaryLabel,
-  primaryVariant,
-  onPrimary,
-  busy,
-  disabled,
-}: {
-  onCancel: () => void;
-  primaryLabel: string;
-  primaryVariant: "primary" | "danger";
-  onPrimary: () => void;
-  busy: boolean;
-  disabled?: boolean;
-}) {
-  return (
-    <>
-      <Button variant="secondary" size="sm" onClick={onCancel} disabled={busy}>
-        Cancel
-      </Button>
-      <Button
-        variant={primaryVariant}
-        size="sm"
-        onClick={onPrimary}
-        loading={busy}
-        disabled={busy || disabled}
-      >
-        {busy ? "…" : primaryLabel}
-      </Button>
-    </>
-  );
-}
+import { ModalActions } from "./ModalActions";
 
 // Shared swatch grid + flags editor used by Add and Edit.
 function ColumnAppearance({

--- a/studio/src/views/Board/ColumnDialogs.tsx
+++ b/studio/src/views/Board/ColumnDialogs.tsx
@@ -1,0 +1,449 @@
+// Column-management dialogs for the native board — the operator surface
+// for the editable columns that bring the board to GitHub-Projects-style
+// parity. Three dialogs:
+//
+//   AddColumnDialog    — create a new column (machine name + display +
+//                        color + eligible/terminal flags).
+//   EditColumnDialog   — edit an existing column's display/color/flags,
+//                        and rename it inline (cascades to issues; a note
+//                        shows how many will move).
+//   DeleteColumnDialog — remove a column. A non-empty column requires a
+//                        migration target (issues move there first); the
+//                        last remaining column cannot be deleted.
+//
+// All three reuse the design-system Dialog/Input/Select/Checkbox/Button
+// primitives and follow Labels.tsx's busy/disabled footer pattern.
+
+import { useState } from "react";
+
+import type { NativeState } from "@/api/native";
+import { Button } from "@/components/ui/Button";
+import { Checkbox } from "@/components/ui/Checkbox";
+import { Dialog } from "@/components/ui/Dialog";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+
+import { BOARD_PALETTE, defaultStateColor } from "./boardShared";
+
+function ModalActions({
+  onCancel,
+  primaryLabel,
+  primaryVariant,
+  onPrimary,
+  busy,
+  disabled,
+}: {
+  onCancel: () => void;
+  primaryLabel: string;
+  primaryVariant: "primary" | "danger";
+  onPrimary: () => void;
+  busy: boolean;
+  disabled?: boolean;
+}) {
+  return (
+    <>
+      <Button variant="secondary" size="sm" onClick={onCancel} disabled={busy}>
+        Cancel
+      </Button>
+      <Button
+        variant={primaryVariant}
+        size="sm"
+        onClick={onPrimary}
+        loading={busy}
+        disabled={busy || disabled}
+      >
+        {busy ? "…" : primaryLabel}
+      </Button>
+    </>
+  );
+}
+
+// Shared swatch grid + flags editor used by Add and Edit.
+function ColumnAppearance({
+  display,
+  color,
+  eligible,
+  terminal,
+  fallbackName,
+  onChange,
+}: {
+  display: string;
+  color: string; // "" = auto (defaultStateColor fallback)
+  eligible: boolean;
+  terminal: boolean;
+  fallbackName: string;
+  onChange: (patch: {
+    display?: string;
+    color?: string;
+    eligible?: boolean;
+    terminal?: boolean;
+  }) => void;
+}) {
+  const effectiveAuto = defaultStateColor(fallbackName, eligible, terminal);
+  return (
+    <>
+      <label className="block space-y-1">
+        <span className="text-micro text-fg-muted">Display name</span>
+        <Input
+          type="text"
+          value={display}
+          placeholder={fallbackName}
+          onChange={(e) => onChange({ display: e.target.value })}
+        />
+      </label>
+
+      <div className="space-y-1">
+        <span className="text-micro text-fg-muted">Color</span>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => onChange({ color: "" })}
+            title="Auto (semantic default)"
+            className={`h-6 w-6 rounded-full border-2 ${
+              color === "" ? "border-accent ring-2 ring-accent/40" : "border-border-default"
+            }`}
+            style={{ backgroundColor: effectiveAuto, opacity: 0.5 }}
+            aria-label="Automatic color"
+          />
+          {BOARD_PALETTE.map((p) => (
+            <button
+              key={p.value}
+              type="button"
+              onClick={() => onChange({ color: p.value })}
+              title={p.label}
+              className={`h-6 w-6 rounded-full border-2 ${
+                color === p.value
+                  ? "border-accent ring-2 ring-accent/40"
+                  : "border-border-default"
+              }`}
+              style={{ backgroundColor: p.value }}
+              aria-label={`${p.label} color`}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-2 rounded border border-border-subtle p-2">
+        <label className="flex items-start gap-2">
+          <Checkbox
+            checked={eligible}
+            onChange={(e) => onChange({ eligible: e.target.checked })}
+            className="mt-0.5"
+          />
+          <span className="text-micro">
+            <span className="text-fg-default font-medium">Eligible</span> — the
+            dispatcher may pick up issues in this column (the “Let’s go” lane is
+            the first eligible, non-terminal column).
+          </span>
+        </label>
+        <label className="flex items-start gap-2">
+          <Checkbox
+            checked={terminal}
+            onChange={(e) => onChange({ terminal: e.target.checked })}
+            className="mt-0.5"
+          />
+          <span className="text-micro">
+            <span className="text-fg-default font-medium">Terminal</span> — an
+            end state (done/blocked). Issues here are treated as “no more work”.
+          </span>
+        </label>
+        {eligible && terminal && (
+          <p className="text-micro text-warning-fg">
+            A terminal column is never the dispatch lane even when eligible.
+          </p>
+        )}
+      </div>
+    </>
+  );
+}
+
+export function AddColumnDialog({
+  existingNames,
+  busy,
+  error,
+  onCancel,
+  onSubmit,
+}: {
+  existingNames: string[];
+  busy: boolean;
+  error: string | null;
+  onCancel: () => void;
+  onSubmit: (state: NativeState) => void;
+}) {
+  const [name, setName] = useState("");
+  const [display, setDisplay] = useState("");
+  const [color, setColor] = useState("");
+  const [eligible, setEligible] = useState(false);
+  const [terminal, setTerminal] = useState(false);
+
+  const trimmed = name.trim();
+  const duplicate = existingNames.includes(trimmed);
+  const invalid = trimmed === "" || duplicate;
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(o) => {
+        if (!o) onCancel();
+      }}
+      title="Add column"
+      description="Columns are board states. The new column is appended on the right — drag its handle or use Move to reorder."
+      widthClass="max-w-md"
+      footer={
+        <ModalActions
+          onCancel={onCancel}
+          primaryLabel="Add column"
+          primaryVariant="primary"
+          onPrimary={() =>
+            onSubmit({
+              name: trimmed,
+              display: display.trim() || undefined,
+              color: color || undefined,
+              eligible: eligible || undefined,
+              terminal: terminal || undefined,
+            })
+          }
+          busy={busy}
+          disabled={invalid}
+        />
+      }
+    >
+      <div className="space-y-3">
+        <label className="block space-y-1">
+          <span className="text-micro text-fg-muted">
+            Machine name (lowercase, used by bots &amp; the dispatcher)
+          </span>
+          <Input
+            type="text"
+            autoFocus
+            value={name}
+            placeholder="e.g. triage"
+            onChange={(e) => setName(e.target.value)}
+            className="font-mono"
+            error={duplicate}
+          />
+          {duplicate && (
+            <span className="text-micro text-danger-fg">
+              A column named “{trimmed}” already exists.
+            </span>
+          )}
+        </label>
+        <ColumnAppearance
+          display={display}
+          color={color}
+          eligible={eligible}
+          terminal={terminal}
+          fallbackName={trimmed || "new"}
+          onChange={(p) => {
+            if (p.display !== undefined) setDisplay(p.display);
+            if (p.color !== undefined) setColor(p.color);
+            if (p.eligible !== undefined) setEligible(p.eligible);
+            if (p.terminal !== undefined) setTerminal(p.terminal);
+          }}
+        />
+        {error && (
+          <p className="text-micro text-danger-fg" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+    </Dialog>
+  );
+}
+
+export function EditColumnDialog({
+  state,
+  issueCount,
+  existingNames,
+  busy,
+  error,
+  onCancel,
+  onSubmit,
+}: {
+  state: NativeState;
+  issueCount: number;
+  existingNames: string[]; // other columns' names (excludes this one)
+  busy: boolean;
+  error: string | null;
+  // patch.name set only when the machine name changed (triggers a rename).
+  onCancel: () => void;
+  onSubmit: (patch: {
+    name?: string;
+    display?: string;
+    color?: string;
+    eligible?: boolean;
+    terminal?: boolean;
+  }) => void;
+}) {
+  const [name, setName] = useState(state.name);
+  const [display, setDisplay] = useState(state.display ?? "");
+  const [color, setColor] = useState(state.color ?? "");
+  const [eligible, setEligible] = useState(!!state.eligible);
+  const [terminal, setTerminal] = useState(!!state.terminal);
+
+  const trimmed = name.trim();
+  const renamed = trimmed !== state.name;
+  const duplicate = renamed && existingNames.includes(trimmed);
+  const invalid = trimmed === "" || duplicate;
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(o) => {
+        if (!o) onCancel();
+      }}
+      title={`Edit “${state.display ?? state.name}”`}
+      widthClass="max-w-md"
+      footer={
+        <ModalActions
+          onCancel={onCancel}
+          primaryLabel="Save"
+          primaryVariant="primary"
+          onPrimary={() =>
+            onSubmit({
+              name: renamed ? trimmed : undefined,
+              display: display.trim(),
+              color,
+              eligible,
+              terminal,
+            })
+          }
+          busy={busy}
+          disabled={invalid}
+        />
+      }
+    >
+      <div className="space-y-3">
+        <label className="block space-y-1">
+          <span className="text-micro text-fg-muted">
+            Machine name (renaming moves every issue in this column)
+          </span>
+          <Input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="font-mono"
+            error={duplicate}
+          />
+          {duplicate && (
+            <span className="text-micro text-danger-fg">
+              A column named “{trimmed}” already exists — delete-with-migrate to
+              merge columns.
+            </span>
+          )}
+          {renamed && !duplicate && issueCount > 0 && (
+            <span className="text-micro text-warning-fg">
+              {issueCount} issue{issueCount === 1 ? "" : "s"} will move to “{trimmed}”.
+            </span>
+          )}
+        </label>
+        <ColumnAppearance
+          display={display}
+          color={color}
+          eligible={eligible}
+          terminal={terminal}
+          fallbackName={trimmed || state.name}
+          onChange={(p) => {
+            if (p.display !== undefined) setDisplay(p.display);
+            if (p.color !== undefined) setColor(p.color);
+            if (p.eligible !== undefined) setEligible(p.eligible);
+            if (p.terminal !== undefined) setTerminal(p.terminal);
+          }}
+        />
+        {error && (
+          <p className="text-micro text-danger-fg" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+    </Dialog>
+  );
+}
+
+export function DeleteColumnDialog({
+  state,
+  issueCount,
+  otherStates,
+  isLast,
+  busy,
+  error,
+  onCancel,
+  onSubmit,
+}: {
+  state: NativeState;
+  issueCount: number;
+  otherStates: NativeState[];
+  isLast: boolean;
+  busy: boolean;
+  error: string | null;
+  onSubmit: (migrateTo: string | undefined) => void;
+  onCancel: () => void;
+}) {
+  const [migrateTo, setMigrateTo] = useState("");
+  const needsTarget = issueCount > 0;
+  const disabled = isLast || (needsTarget && migrateTo === "");
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(o) => {
+        if (!o) onCancel();
+      }}
+      title={`Delete “${state.display ?? state.name}”?`}
+      widthClass="max-w-md"
+      footer={
+        <ModalActions
+          onCancel={onCancel}
+          primaryLabel="Delete column"
+          primaryVariant="danger"
+          onPrimary={() => onSubmit(needsTarget ? migrateTo : undefined)}
+          busy={busy}
+          disabled={disabled}
+        />
+      }
+    >
+      <div className="space-y-3 text-body">
+        {isLast ? (
+          <p className="text-warning-fg">
+            This is the only column — a board must keep at least one. Add another
+            column first.
+          </p>
+        ) : needsTarget ? (
+          <>
+            <p className="text-fg-default">
+              This column holds {issueCount} issue{issueCount === 1 ? "" : "s"}.
+              Choose where to move {issueCount === 1 ? "it" : "them"} before the
+              column is removed.
+            </p>
+            <label className="block space-y-1">
+              <span className="text-micro text-fg-muted">Move issues to</span>
+              <Select
+                value={migrateTo}
+                onChange={(e) => setMigrateTo(e.target.value)}
+                aria-label="Migration target column"
+              >
+                <option value="" disabled>
+                  Select a column…
+                </option>
+                {otherStates.map((s) => (
+                  <option key={s.name} value={s.name}>
+                    {s.display ?? s.name}
+                  </option>
+                ))}
+              </Select>
+            </label>
+          </>
+        ) : (
+          <p className="text-fg-default">
+            This column is empty and will be removed. This cannot be undone.
+          </p>
+        )}
+        {error && (
+          <p className="text-micro text-danger-fg" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+    </Dialog>
+  );
+}

--- a/studio/src/views/Board/Fields.tsx
+++ b/studio/src/views/Board/Fields.tsx
@@ -1,0 +1,378 @@
+// Fields view — operator surface for the board's custom-field schema.
+//
+// The native board carries a typed custom-field schema (board.Fields:
+// text / number / enum / date / bool) that issues fill in and bots read.
+// Until now the schema could only be seeded via `iterion issue board
+// init` or a raw PUT /board; there was no way to add a field, fix a
+// typo'd name, change a type, or drop a field from the studio. This view
+// exposes the granular field ops the store grew alongside the column
+// ones — add / edit / rename / delete / reorder — each cascading to
+// issues server-side (rename rewrites the key, delete strips it) so the
+// issues stay schema-valid.
+//
+// Mirrors Labels.tsx's structure (busy/error footer, confirm-on-delete).
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useLocation } from "wouter";
+
+import {
+  addField,
+  deleteField,
+  getBoard,
+  reorderFields,
+  updateField,
+  type NativeBoard,
+  type NativeField,
+  type NativeFieldType,
+} from "@/api/native";
+import { Button } from "@/components/ui/Button";
+import { Checkbox } from "@/components/ui/Checkbox";
+import { Dialog } from "@/components/ui/Dialog";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+import { TagInput } from "@/components/ui/TagInput";
+import { ErrorBoundary } from "@/components/shared/ErrorBoundary";
+import { useAsyncAction } from "@/hooks/useAsyncAction";
+import { useConfirm } from "@/hooks/useConfirm";
+import { errorMessage } from "@/lib/errorHints";
+
+const FIELD_TYPES: NativeFieldType[] = ["text", "number", "enum", "date", "bool"];
+
+type DialogState =
+  | { kind: "none" }
+  | { kind: "add" }
+  | { kind: "edit"; field: NativeField };
+
+export default function FieldsView() {
+  return (
+    <ErrorBoundary area="Fields view">
+      <FieldsViewInner />
+    </ErrorBoundary>
+  );
+}
+
+function FieldsViewInner() {
+  const [, setLocation] = useLocation();
+  const [board, setBoard] = useState<NativeBoard | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [dialog, setDialog] = useState<DialogState>({ kind: "none" });
+  const action = useAsyncAction();
+  const { confirm, dialog: confirmDialog } = useConfirm();
+
+  const refresh = useCallback(async () => {
+    try {
+      setBoard(await getBoard());
+      setLoadError(null);
+    } catch (e) {
+      setLoadError(errorMessage(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const fields = useMemo(() => board?.fields ?? [], [board]);
+
+  const onApply = useCallback(
+    async (op: () => Promise<unknown>) => {
+      const ok = await action.run(async () => {
+        await op();
+        await refresh();
+        return true;
+      });
+      if (ok) setDialog({ kind: "none" });
+    },
+    [action, refresh],
+  );
+
+  const onDelete = useCallback(
+    async (f: NativeField) => {
+      const ok = await confirm({
+        title: `Delete field “${f.display ?? f.name}”?`,
+        message: `Removes the field from the board schema and strips its value from every issue that carries it. This cannot be undone.`,
+        confirmLabel: "Delete",
+        confirmVariant: "danger",
+      });
+      if (!ok) return;
+      await action.run(async () => {
+        await deleteField(f.name);
+        await refresh();
+      });
+    },
+    [action, confirm, refresh],
+  );
+
+  const onMove = useCallback(
+    (name: string, dir: "up" | "down") => {
+      const names = fields.map((f) => f.name);
+      const i = names.indexOf(name);
+      const j = dir === "up" ? i - 1 : i + 1;
+      const a = names[i];
+      const b = names[j];
+      if (a === undefined || b === undefined) return;
+      names[i] = b;
+      names[j] = a;
+      void action.run(async () => {
+        await reorderFields(names);
+        await refresh();
+        return true;
+      });
+    },
+    [fields, action, refresh],
+  );
+
+  return (
+    <div className="h-full overflow-auto p-4 space-y-3 text-label">
+      <header className="flex items-baseline gap-3">
+        <h1 className="text-lg font-semibold text-fg-default">Board fields</h1>
+        <span className="text-fg-muted text-micro">
+          {fields.length} custom field{fields.length === 1 ? "" : "s"}
+        </span>
+        <div className="ml-auto flex items-center gap-2">
+          <Button variant="primary" size="sm" onClick={() => setDialog({ kind: "add" })}>
+            + Add field
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => setLocation("/board")}>
+            ← Back to board
+          </Button>
+        </div>
+      </header>
+
+      <p className="text-fg-muted text-micro max-w-3xl">
+        Custom fields extend each issue with typed metadata (severity, ETA,
+        owner…). Bots read and write them via the board tools. Renaming a field
+        rewrites the key on every issue; deleting it strips the value — issues
+        stay schema-valid either way.
+      </p>
+
+      {(action.error || loadError) && (
+        <div className="text-danger-fg text-micro" role="alert">
+          {action.error ?? loadError}
+        </div>
+      )}
+
+      {!board && <EmptyState message="Loading…" />}
+
+      {board && fields.length === 0 && (
+        <p className="text-fg-muted text-micro italic">
+          No custom fields yet. Add one to attach typed metadata to issues.
+        </p>
+      )}
+
+      {fields.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-body border border-border-subtle">
+            <thead>
+              <tr className="bg-surface-1 text-fg-muted text-left">
+                <th className="px-2 py-1 font-medium">Name</th>
+                <th className="px-2 py-1 font-medium w-24">Type</th>
+                <th className="px-2 py-1 font-medium w-20">Required</th>
+                <th className="px-2 py-1 font-medium">Values</th>
+                <th className="px-2 py-1 font-medium w-56">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fields.map((f, i) => (
+                <tr key={f.name} className="border-t border-border-subtle hover:bg-surface-1/40">
+                  <td className="px-2 py-1 font-mono text-fg-default">
+                    {f.name}
+                    {f.display && (
+                      <span className="ml-2 text-fg-muted font-sans">{f.display}</span>
+                    )}
+                  </td>
+                  <td className="px-2 py-1 text-fg-default">{f.type}</td>
+                  <td className="px-2 py-1 text-fg-muted">{f.required ? "yes" : "—"}</td>
+                  <td className="px-2 py-1 text-fg-muted truncate max-w-xs">
+                    {f.type === "enum" ? (f.enum_values ?? []).join(", ") : "—"}
+                  </td>
+                  <td className="px-2 py-1">
+                    <div className="flex gap-1.5 items-center">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={i === 0}
+                        onClick={() => onMove(f.name, "up")}
+                        title="Move up"
+                      >
+                        ↑
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled={i === fields.length - 1}
+                        onClick={() => onMove(f.name, "down")}
+                        title="Move down"
+                      >
+                        ↓
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setDialog({ kind: "edit", field: f })}
+                      >
+                        edit
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-danger-fg hover:text-danger"
+                        onClick={() => void onDelete(f)}
+                      >
+                        delete
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {dialog.kind === "add" && (
+        <FieldDialog
+          mode="add"
+          existingNames={fields.map((f) => f.name)}
+          busy={action.busy}
+          onCancel={() => setDialog({ kind: "none" })}
+          onSubmit={(field) => void onApply(() => addField(field))}
+        />
+      )}
+      {dialog.kind === "edit" && (
+        <FieldDialog
+          mode="edit"
+          field={dialog.field}
+          existingNames={fields.map((f) => f.name).filter((n) => n !== dialog.field.name)}
+          busy={action.busy}
+          onCancel={() => setDialog({ kind: "none" })}
+          onSubmit={(field) =>
+            void onApply(() =>
+              updateField(dialog.field.name, {
+                name: field.name !== dialog.field.name ? field.name : undefined,
+                display: field.display ?? "",
+                type: field.type,
+                required: field.required ?? false,
+                enum_values: field.type === "enum" ? field.enum_values ?? [] : [],
+              }),
+            )
+          }
+        />
+      )}
+      {confirmDialog}
+    </div>
+  );
+}
+
+function FieldDialog({
+  mode,
+  field,
+  existingNames,
+  busy,
+  onCancel,
+  onSubmit,
+}: {
+  mode: "add" | "edit";
+  field?: NativeField;
+  existingNames: string[];
+  busy: boolean;
+  onCancel: () => void;
+  onSubmit: (field: NativeField) => void;
+}) {
+  const [name, setName] = useState(field?.name ?? "");
+  const [display, setDisplay] = useState(field?.display ?? "");
+  const [type, setType] = useState<NativeFieldType>(field?.type ?? "text");
+  const [required, setRequired] = useState(!!field?.required);
+  const [enumValues, setEnumValues] = useState<string[]>(field?.enum_values ?? []);
+
+  const trimmed = name.trim();
+  const duplicate = existingNames.includes(trimmed);
+  const enumInvalid = type === "enum" && enumValues.length === 0;
+  const invalid = trimmed === "" || duplicate || enumInvalid;
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(o) => {
+        if (!o) onCancel();
+      }}
+      title={mode === "add" ? "Add field" : `Edit “${field?.display ?? field?.name}”`}
+      widthClass="max-w-md"
+      footer={
+        <>
+          <Button variant="secondary" size="sm" onClick={onCancel} disabled={busy}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            loading={busy}
+            disabled={busy || invalid}
+            onClick={() =>
+              onSubmit({
+                name: trimmed,
+                display: display.trim() || undefined,
+                type,
+                required: required || undefined,
+                enum_values: type === "enum" ? enumValues : undefined,
+              })
+            }
+          >
+            {busy ? "…" : mode === "add" ? "Add field" : "Save"}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-3">
+        <label className="block space-y-1">
+          <span className="text-micro text-fg-muted">
+            Machine name (renaming rewrites the key on every issue)
+          </span>
+          <Input
+            type="text"
+            autoFocus
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="font-mono"
+            error={duplicate}
+          />
+          {duplicate && (
+            <span className="text-micro text-danger-fg">
+              A field named “{trimmed}” already exists.
+            </span>
+          )}
+        </label>
+        <label className="block space-y-1">
+          <span className="text-micro text-fg-muted">Display name (optional)</span>
+          <Input type="text" value={display} onChange={(e) => setDisplay(e.target.value)} />
+        </label>
+        <label className="block space-y-1">
+          <span className="text-micro text-fg-muted">Type</span>
+          <Select value={type} onChange={(e) => setType(e.target.value as NativeFieldType)}>
+            {FIELD_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </Select>
+        </label>
+        {type === "enum" && (
+          <div className="space-y-1">
+            <span className="text-micro text-fg-muted">Enum values</span>
+            <TagInput value={enumValues} onChange={setEnumValues} placeholder="add a value…" />
+            {enumInvalid && (
+              <span className="text-micro text-danger-fg">
+                An enum field needs at least one value.
+              </span>
+            )}
+          </div>
+        )}
+        <label className="flex items-center gap-2">
+          <Checkbox checked={required} onChange={(e) => setRequired(e.target.checked)} />
+          <span className="text-micro text-fg-default">Required on every issue</span>
+        </label>
+      </div>
+    </Dialog>
+  );
+}

--- a/studio/src/views/Board/Fields.tsx
+++ b/studio/src/views/Board/Fields.tsx
@@ -37,6 +37,9 @@ import { useAsyncAction } from "@/hooks/useAsyncAction";
 import { useConfirm } from "@/hooks/useConfirm";
 import { errorMessage } from "@/lib/errorHints";
 
+import { moveInArray } from "./boardShared";
+import { ModalActions } from "./ModalActions";
+
 const FIELD_TYPES: NativeFieldType[] = ["text", "number", "enum", "date", "bool"];
 
 type DialogState =
@@ -106,16 +109,14 @@ function FieldsViewInner() {
 
   const onMove = useCallback(
     (name: string, dir: "up" | "down") => {
-      const names = fields.map((f) => f.name);
-      const i = names.indexOf(name);
-      const j = dir === "up" ? i - 1 : i + 1;
-      const a = names[i];
-      const b = names[j];
-      if (a === undefined || b === undefined) return;
-      names[i] = b;
-      names[j] = a;
+      const next = moveInArray(
+        fields.map((f) => f.name),
+        name,
+        dir === "up" ? -1 : 1,
+      );
+      if (!next) return;
       void action.run(async () => {
-        await reorderFields(names);
+        await reorderFields(next);
         await refresh();
         return true;
       });
@@ -300,28 +301,21 @@ function FieldDialog({
       title={mode === "add" ? "Add field" : `Edit “${field?.display ?? field?.name}”`}
       widthClass="max-w-md"
       footer={
-        <>
-          <Button variant="secondary" size="sm" onClick={onCancel} disabled={busy}>
-            Cancel
-          </Button>
-          <Button
-            variant="primary"
-            size="sm"
-            loading={busy}
-            disabled={busy || invalid}
-            onClick={() =>
-              onSubmit({
-                name: trimmed,
-                display: display.trim() || undefined,
-                type,
-                required: required || undefined,
-                enum_values: type === "enum" ? enumValues : undefined,
-              })
-            }
-          >
-            {busy ? "…" : mode === "add" ? "Add field" : "Save"}
-          </Button>
-        </>
+        <ModalActions
+          onCancel={onCancel}
+          primaryLabel={mode === "add" ? "Add field" : "Save"}
+          busy={busy}
+          disabled={invalid}
+          onPrimary={() =>
+            onSubmit({
+              name: trimmed,
+              display: display.trim() || undefined,
+              type,
+              required: required || undefined,
+              enum_values: type === "enum" ? enumValues : undefined,
+            })
+          }
+        />
       }
     >
       <div className="space-y-3">

--- a/studio/src/views/Board/ModalActions.tsx
+++ b/studio/src/views/Board/ModalActions.tsx
@@ -1,0 +1,38 @@
+// Shared Cancel + primary footer for the board's management dialogs
+// (column add/edit/delete, field add/edit, save-view). One place for the
+// busy/disabled wiring so the three dialog families stay consistent.
+
+import { Button } from "@/components/ui/Button";
+
+export function ModalActions({
+  onCancel,
+  primaryLabel,
+  primaryVariant = "primary",
+  onPrimary,
+  busy,
+  disabled,
+}: {
+  onCancel: () => void;
+  primaryLabel: string;
+  primaryVariant?: "primary" | "danger";
+  onPrimary: () => void;
+  busy: boolean;
+  disabled?: boolean;
+}) {
+  return (
+    <>
+      <Button variant="secondary" size="sm" onClick={onCancel} disabled={busy}>
+        Cancel
+      </Button>
+      <Button
+        variant={primaryVariant}
+        size="sm"
+        onClick={onPrimary}
+        loading={busy}
+        disabled={busy || disabled}
+      >
+        {busy ? "…" : primaryLabel}
+      </Button>
+    </>
+  );
+}

--- a/studio/src/views/Board/ViewBar.tsx
+++ b/studio/src/views/Board/ViewBar.tsx
@@ -1,0 +1,169 @@
+// ViewBar — saved-view picker for the board. Sits under the filter bar:
+// pick a saved view to restore its search/labels/assignee/sort/grouping,
+// save the current filter combo as a named view, or delete the active
+// one. Views are persisted in board.json (shared across operators).
+
+import { useState } from "react";
+
+import type { NativeView } from "@/api/native";
+import { Button } from "@/components/ui/Button";
+import { Dialog } from "@/components/ui/Dialog";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+
+export function ViewBar({
+  views,
+  activeView,
+  onApply,
+  onSave,
+  onDelete,
+  busy,
+  error,
+}: {
+  views: NativeView[];
+  activeView: string;
+  onApply: (v: NativeView | null) => void;
+  onSave: (name: string) => void;
+  onDelete: (name: string) => void;
+  busy: boolean;
+  error: string | null;
+}) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [name, setName] = useState("");
+
+  if (views.length === 0 && !dialogOpen) {
+    // Nothing saved yet — offer only the "Save current view" affordance.
+    return (
+      <div className="px-3 py-1.5 border-b border-border-default bg-surface-0 flex items-center gap-2 text-xs">
+        <span className="text-fg-muted">Views</span>
+        <Button variant="ghost" size="sm" onClick={() => setDialogOpen(true)}>
+          + Save current view
+        </Button>
+        {error && <span className="text-danger-fg">{error}</span>}
+        {dialogOpen && (
+          <SaveDialog
+            name={name}
+            existing={views.map((v) => v.name)}
+            busy={busy}
+            onChange={setName}
+            onCancel={() => setDialogOpen(false)}
+            onSubmit={() => {
+              onSave(name.trim());
+              setDialogOpen(false);
+              setName("");
+            }}
+          />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-3 py-1.5 border-b border-border-default bg-surface-0 flex items-center gap-2 text-xs">
+      <label htmlFor="board-view-select" className="text-fg-muted">
+        Views
+      </label>
+      <Select
+        id="board-view-select"
+        value={activeView}
+        onChange={(e) => {
+          const v = views.find((x) => x.name === e.target.value) ?? null;
+          onApply(v);
+        }}
+        aria-label="Saved views"
+      >
+        <option value="">Custom…</option>
+        {views.map((v) => (
+          <option key={v.name} value={v.name}>
+            {v.name}
+          </option>
+        ))}
+      </Select>
+      <Button variant="ghost" size="sm" onClick={() => setDialogOpen(true)}>
+        Save view…
+      </Button>
+      {activeView && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-danger-fg hover:text-danger"
+          onClick={() => onDelete(activeView)}
+        >
+          Delete view
+        </Button>
+      )}
+      {error && <span className="text-danger-fg ml-2">{error}</span>}
+
+      {dialogOpen && (
+        <SaveDialog
+          name={name || activeView}
+          existing={views.map((v) => v.name)}
+          busy={busy}
+          onChange={setName}
+          onCancel={() => setDialogOpen(false)}
+          onSubmit={() => {
+            onSave((name || activeView).trim());
+            setDialogOpen(false);
+            setName("");
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function SaveDialog({
+  name,
+  existing,
+  busy,
+  onChange,
+  onCancel,
+  onSubmit,
+}: {
+  name: string;
+  existing: string[];
+  busy: boolean;
+  onChange: (v: string) => void;
+  onCancel: () => void;
+  onSubmit: () => void;
+}) {
+  const trimmed = name.trim();
+  const overwrite = existing.includes(trimmed);
+  return (
+    <Dialog
+      open
+      onOpenChange={(o) => {
+        if (!o) onCancel();
+      }}
+      title="Save view"
+      description="Captures the current search, label/assignee filters, sort, and grouping under a name. Saving over an existing name updates it."
+      widthClass="max-w-md"
+      footer={
+        <>
+          <Button variant="secondary" size="sm" onClick={onCancel} disabled={busy}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            loading={busy}
+            disabled={busy || trimmed === ""}
+            onClick={onSubmit}
+          >
+            {overwrite ? "Update" : "Save"}
+          </Button>
+        </>
+      }
+    >
+      <label className="block space-y-1">
+        <span className="text-micro text-fg-muted">View name</span>
+        <Input type="text" autoFocus value={name} onChange={(e) => onChange(e.target.value)} />
+        {overwrite && (
+          <span className="text-micro text-warning-fg">
+            Updates the existing “{trimmed}” view.
+          </span>
+        )}
+      </label>
+    </Dialog>
+  );
+}

--- a/studio/src/views/Board/ViewBar.tsx
+++ b/studio/src/views/Board/ViewBar.tsx
@@ -11,6 +11,8 @@ import { Dialog } from "@/components/ui/Dialog";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
 
+import { ModalActions } from "./ModalActions";
+
 export function ViewBar({
   views,
   activeView,
@@ -139,20 +141,13 @@ function SaveDialog({
       description="Captures the current search, label/assignee filters, sort, and grouping under a name. Saving over an existing name updates it."
       widthClass="max-w-md"
       footer={
-        <>
-          <Button variant="secondary" size="sm" onClick={onCancel} disabled={busy}>
-            Cancel
-          </Button>
-          <Button
-            variant="primary"
-            size="sm"
-            loading={busy}
-            disabled={busy || trimmed === ""}
-            onClick={onSubmit}
-          >
-            {overwrite ? "Update" : "Save"}
-          </Button>
-        </>
+        <ModalActions
+          onCancel={onCancel}
+          primaryLabel={overwrite ? "Update" : "Save"}
+          busy={busy}
+          disabled={trimmed === ""}
+          onPrimary={onSubmit}
+        />
       }
     >
       <label className="block space-y-1">

--- a/studio/src/views/Board/board/useColumnManagement.ts
+++ b/studio/src/views/Board/board/useColumnManagement.ts
@@ -18,6 +18,8 @@ import {
 } from "@/api/native";
 import { useAsyncAction } from "@/hooks/useAsyncAction";
 
+import { moveInArray } from "../boardShared";
+
 type ColumnDialog =
   | { kind: "none" }
   | { kind: "add" }
@@ -121,14 +123,8 @@ export function useColumnManagement({
     (name: string, dir: "left" | "right") => {
       if (!board) return;
       const names = board.states.map((s) => s.name);
-      const i = names.indexOf(name);
-      const j = dir === "left" ? i - 1 : i + 1;
-      const a = names[i];
-      const b = names[j];
-      if (a === undefined || b === undefined) return;
-      names[i] = b;
-      names[j] = a;
-      void reorder(names);
+      const next = moveInArray(names, name, dir === "left" ? -1 : 1);
+      if (next) void reorder(next);
     },
     [board, reorder],
   );

--- a/studio/src/views/Board/board/useColumnManagement.ts
+++ b/studio/src/views/Board/board/useColumnManagement.ts
@@ -123,8 +123,11 @@ export function useColumnManagement({
       const names = board.states.map((s) => s.name);
       const i = names.indexOf(name);
       const j = dir === "left" ? i - 1 : i + 1;
-      if (i < 0 || j < 0 || j >= names.length) return;
-      [names[i], names[j]] = [names[j], names[i]];
+      const a = names[i];
+      const b = names[j];
+      if (a === undefined || b === undefined) return;
+      names[i] = b;
+      names[j] = a;
       void reorder(names);
     },
     [board, reorder],

--- a/studio/src/views/Board/board/useColumnManagement.ts
+++ b/studio/src/views/Board/board/useColumnManagement.ts
@@ -1,0 +1,187 @@
+// Column-management glue for BoardView: holds the dialog state, wires the
+// native /board/states REST calls, and exposes the per-column callbacks
+// the Column header menu + reorder drag need. Kept out of index.tsx so the
+// board view stays legible. Every mutation calls refresh() afterward — a
+// rename/delete also moves issues server-side, so a full board+issues
+// re-pull keeps the byState grouping correct.
+
+import { useCallback, useMemo, useState } from "react";
+
+import {
+  addState,
+  deleteState,
+  reorderStates,
+  updateState,
+  type NativeBoard,
+  type NativeIssue,
+  type NativeState,
+} from "@/api/native";
+import { useAsyncAction } from "@/hooks/useAsyncAction";
+
+type ColumnDialog =
+  | { kind: "none" }
+  | { kind: "add" }
+  | { kind: "edit"; state: NativeState }
+  | { kind: "delete"; state: NativeState };
+
+export interface UseColumnManagementResult {
+  dialog: ColumnDialog;
+  openAddColumn: () => void;
+  closeDialog: () => void;
+  busy: boolean;
+  error: string | null;
+  onEditColumn: (name: string) => void;
+  onDeleteColumn: (name: string) => void;
+  onMoveColumn: (name: string, dir: "left" | "right") => void;
+  onReorderColumn: (dragged: string, target: string) => void;
+  submitAdd: (state: NativeState) => void;
+  submitEdit: (patch: {
+    name?: string;
+    display?: string;
+    color?: string;
+    eligible?: boolean;
+    terminal?: boolean;
+  }) => void;
+  submitDelete: (migrateTo: string | undefined) => void;
+  // issueCount(name) → how many of the current issues sit in that column.
+  issueCount: (name: string) => number;
+}
+
+export function useColumnManagement({
+  board,
+  issues,
+  refresh,
+}: {
+  board: NativeBoard | null;
+  issues: NativeIssue[];
+  refresh: () => Promise<void> | void;
+}): UseColumnManagementResult {
+  const [dialog, setDialog] = useState<ColumnDialog>({ kind: "none" });
+  const action = useAsyncAction();
+
+  const counts = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const iss of issues) m.set(iss.state, (m.get(iss.state) ?? 0) + 1);
+    return m;
+  }, [issues]);
+  const issueCount = useCallback((name: string) => counts.get(name) ?? 0, [counts]);
+
+  const stateByName = useCallback(
+    (name: string) => board?.states.find((s) => s.name === name) ?? null,
+    [board],
+  );
+
+  const closeDialog = useCallback(() => setDialog({ kind: "none" }), []);
+  const openAddColumn = useCallback(() => setDialog({ kind: "add" }), []);
+
+  const onEditColumn = useCallback(
+    (name: string) => {
+      const st = stateByName(name);
+      if (st) setDialog({ kind: "edit", state: st });
+    },
+    [stateByName],
+  );
+
+  const onDeleteColumn = useCallback(
+    (name: string) => {
+      const st = stateByName(name);
+      if (st) setDialog({ kind: "delete", state: st });
+    },
+    [stateByName],
+  );
+
+  // run wraps a mutation: refresh on success, close the dialog. Errors
+  // surface via action.error (rendered by the dialog).
+  const run = useCallback(
+    async (op: () => Promise<unknown>, keepOpenOnError = true) => {
+      const ok = await action.run(async () => {
+        await op();
+        await refresh();
+        return true;
+      });
+      if (ok || !keepOpenOnError) closeDialog();
+    },
+    [action, refresh, closeDialog],
+  );
+
+  const reorder = useCallback(
+    async (order: string[]) => {
+      // Reorder fires from menu/drag without a dialog open — surface
+      // failures through action.error but don't toggle dialog state.
+      await action.run(async () => {
+        await reorderStates(order);
+        await refresh();
+        return true;
+      });
+    },
+    [action, refresh],
+  );
+
+  const onMoveColumn = useCallback(
+    (name: string, dir: "left" | "right") => {
+      if (!board) return;
+      const names = board.states.map((s) => s.name);
+      const i = names.indexOf(name);
+      const j = dir === "left" ? i - 1 : i + 1;
+      if (i < 0 || j < 0 || j >= names.length) return;
+      [names[i], names[j]] = [names[j], names[i]];
+      void reorder(names);
+    },
+    [board, reorder],
+  );
+
+  const onReorderColumn = useCallback(
+    (dragged: string, target: string) => {
+      if (!board || dragged === target) return;
+      const names = board.states.map((s) => s.name).filter((n) => n !== dragged);
+      const at = names.indexOf(target);
+      if (at < 0) return;
+      names.splice(at, 0, dragged);
+      void reorder(names);
+    },
+    [board, reorder],
+  );
+
+  const submitAdd = useCallback(
+    (state: NativeState) => void run(() => addState(state)),
+    [run],
+  );
+
+  const submitEdit = useCallback(
+    (patch: {
+      name?: string;
+      display?: string;
+      color?: string;
+      eligible?: boolean;
+      terminal?: boolean;
+    }) => {
+      if (dialog.kind !== "edit") return;
+      void run(() => updateState(dialog.state.name, patch));
+    },
+    [dialog, run],
+  );
+
+  const submitDelete = useCallback(
+    (migrateTo: string | undefined) => {
+      if (dialog.kind !== "delete") return;
+      void run(() => deleteState(dialog.state.name, migrateTo));
+    },
+    [dialog, run],
+  );
+
+  return {
+    dialog,
+    openAddColumn,
+    closeDialog,
+    busy: action.busy,
+    error: action.error,
+    onEditColumn,
+    onDeleteColumn,
+    onMoveColumn,
+    onReorderColumn,
+    submitAdd,
+    submitEdit,
+    submitDelete,
+    issueCount,
+  };
+}

--- a/studio/src/views/Board/board/useSwimlanes.ts
+++ b/studio/src/views/Board/board/useSwimlanes.ts
@@ -1,0 +1,118 @@
+import { useMemo } from "react";
+
+import type { NativeBoard, NativeIssue } from "@/api/native";
+
+import { LANE_NONE, type GroupMode, type SortMode } from "../boardShared";
+
+import { sortComparator } from "./boardSort";
+
+// A swimlane: one horizontal band of the board, keyed by the grouping
+// dimension's value. `byState` mirrors useBoardColumns' per-column buckets
+// (board states + the "__unmapped__" fallback) scoped to this lane.
+export interface Lane {
+  key: string;
+  label: string;
+  byState: Map<string, NativeIssue[]>;
+  count: number;
+}
+
+// laneKeysFor returns the lane(s) an issue belongs to under groupMode.
+// Most dimensions yield one lane; "label" yields one per label (an issue
+// with several labels appears in each), or LANE_NONE when it has none.
+function laneKeysFor(iss: NativeIssue, groupMode: GroupMode): string[] {
+  if (groupMode === "assignee") {
+    return [iss.assignee?.trim() || LANE_NONE];
+  }
+  if (groupMode === "priority") {
+    return [`P${iss.priority ?? 0}`];
+  }
+  if (groupMode === "label") {
+    const labels = iss.labels ?? [];
+    return labels.length > 0 ? labels : [LANE_NONE];
+  }
+  if (groupMode.startsWith("field:")) {
+    const name = groupMode.slice("field:".length);
+    const v = iss.fields?.[name];
+    if (v === undefined || v === null || v === "") return [LANE_NONE];
+    return [String(v)];
+  }
+  return [LANE_NONE];
+}
+
+// laneLabel renders a lane key for display.
+function laneLabel(key: string, groupMode: GroupMode): string {
+  if (key === LANE_NONE) {
+    if (groupMode === "assignee") return "Unassigned";
+    if (groupMode === "label") return "No label";
+    return "—";
+  }
+  if (groupMode === "assignee") return `@${key}`;
+  return key;
+}
+
+// laneSortValue orders lanes: priority descending numeric; everything else
+// alphabetical; the LANE_NONE bucket always sorts last.
+function compareLaneKeys(a: string, b: string, groupMode: GroupMode): number {
+  if (a === LANE_NONE) return 1;
+  if (b === LANE_NONE) return -1;
+  if (groupMode === "priority") {
+    const na = Number(a.replace(/^P/, "")) || 0;
+    const nb = Number(b.replace(/^P/, "")) || 0;
+    return nb - na;
+  }
+  return a.localeCompare(b);
+}
+
+// useSwimlanes groups filteredIssues into horizontal lanes for the board's
+// swimlane view. Returns null for groupMode "none" (the caller renders the
+// flat board). Card buckets within each lane are sorted by sortMode, the
+// same as useBoardColumns, so the two views stay visually consistent.
+export function useSwimlanes({
+  board,
+  filteredIssues,
+  groupMode,
+  sortMode,
+}: {
+  board: NativeBoard | null;
+  filteredIssues: NativeIssue[];
+  groupMode: GroupMode;
+  sortMode: SortMode;
+}): Lane[] | null {
+  return useMemo(() => {
+    if (!board || groupMode === "none") return null;
+    const stateNames = board.states.map((s) => s.name);
+    const lanes = new Map<string, Map<string, NativeIssue[]>>();
+
+    const ensureLane = (key: string) => {
+      let m = lanes.get(key);
+      if (!m) {
+        m = new Map<string, NativeIssue[]>();
+        for (const n of stateNames) m.set(n, []);
+        m.set("__unmapped__", []);
+        lanes.set(key, m);
+      }
+      return m;
+    };
+
+    for (const iss of filteredIssues) {
+      for (const key of laneKeysFor(iss, groupMode)) {
+        const m = ensureLane(key);
+        const bucket = m.has(iss.state) ? iss.state : "__unmapped__";
+        m.get(bucket)!.push(iss);
+      }
+    }
+
+    const cmp = sortComparator(sortMode);
+    const out: Lane[] = [];
+    for (const [key, byState] of lanes) {
+      let count = 0;
+      for (const list of byState.values()) {
+        list.sort(cmp);
+        count += list.length;
+      }
+      out.push({ key, label: laneLabel(key, groupMode), byState, count });
+    }
+    out.sort((a, b) => compareLaneKeys(a.key, b.key, groupMode));
+    return out;
+  }, [board, filteredIssues, groupMode, sortMode]);
+}

--- a/studio/src/views/Board/board/useSwimlanes.ts
+++ b/studio/src/views/Board/board/useSwimlanes.ts
@@ -2,7 +2,12 @@ import { useMemo } from "react";
 
 import type { NativeBoard, NativeIssue } from "@/api/native";
 
-import { LANE_NONE, type GroupMode, type SortMode } from "../boardShared";
+import {
+  fieldNameFromGroupMode,
+  LANE_NONE,
+  type GroupMode,
+  type SortMode,
+} from "../boardShared";
 
 import { sortComparator } from "./boardSort";
 
@@ -30,9 +35,9 @@ function laneKeysFor(iss: NativeIssue, groupMode: GroupMode): string[] {
     const labels = iss.labels ?? [];
     return labels.length > 0 ? labels : [LANE_NONE];
   }
-  if (groupMode.startsWith("field:")) {
-    const name = groupMode.slice("field:".length);
-    const v = iss.fields?.[name];
+  const fieldName = fieldNameFromGroupMode(groupMode);
+  if (fieldName) {
+    const v = iss.fields?.[fieldName];
     if (v === undefined || v === null || v === "") return [LANE_NONE];
     return [String(v)];
   }

--- a/studio/src/views/Board/boardShared.ts
+++ b/studio/src/views/Board/boardShared.ts
@@ -9,6 +9,23 @@
 // accidentally be interpreted as text/plain.
 export const DRAG_MIME_ISSUE_IDS = "application/iterion-issue-ids";
 
+// Custom MIME for column-reorder drag payloads carrying the dragged
+// state name. A column's onDrop checks this FIRST so a header drag
+// reorders columns instead of being mistaken for a card drop.
+export const DRAG_MIME_STATE = "application/iterion-state-name";
+
+// BOARD_PALETTE is the set of column colors offered by the column-edit
+// dialog's swatch picker. Values are CSS vars so they track the active
+// theme (light/dark) — the same vars defaultStateColor() returns.
+export const BOARD_PALETTE: { label: string; value: string }[] = [
+  { label: "Backlog", value: "var(--color-board-backlog)" },
+  { label: "Ready", value: "var(--color-board-ready)" },
+  { label: "In progress", value: "var(--color-board-in-progress)" },
+  { label: "Review", value: "var(--color-board-review)" },
+  { label: "Done", value: "var(--color-board-done)" },
+  { label: "Blocked", value: "var(--color-board-blocked)" },
+];
+
 // Priority presets offered by the bulk "Priority" picker (the magnitudes
 // the roadmap uses). Columns sort by priority descending by default.
 export const PRIORITY_PRESETS = [0, 1, 2, 3, 5, 10, 20, 30];

--- a/studio/src/views/Board/boardShared.ts
+++ b/studio/src/views/Board/boardShared.ts
@@ -33,6 +33,23 @@ export const PRIORITY_PRESETS = [0, 1, 2, 3, 5, 10, 20, 30];
 // Intra-column ordering modes offered by the board's Sort selector.
 export type SortMode = "priority" | "updated" | "created" | "title";
 
+// Swimlane grouping. "none" renders the flat board; the others split the
+// board into horizontal lanes (rows) keyed by the chosen dimension, with
+// the columns repeated inside each lane. A "field:<name>" value groups by
+// a custom field, so the type stays an open string.
+export type GroupMode = string;
+
+export const BASE_GROUP_OPTIONS: { value: GroupMode; label: string }[] = [
+  { value: "none", label: "No grouping" },
+  { value: "assignee", label: "Assignee" },
+  { value: "label", label: "Label" },
+  { value: "priority", label: "Priority" },
+];
+
+// Sentinel lane key for issues with no value for the grouping dimension
+// (no assignee, no labels, empty field). Always sorted last.
+export const LANE_NONE = "__none__";
+
 export const SORT_OPTIONS: { value: SortMode; label: string }[] = [
   { value: "priority", label: "Priority" },
   { value: "updated", label: "Recently updated" },

--- a/studio/src/views/Board/boardShared.ts
+++ b/studio/src/views/Board/boardShared.ts
@@ -50,6 +50,39 @@ export const BASE_GROUP_OPTIONS: { value: GroupMode; label: string }[] = [
 // (no assignee, no labels, empty field). Always sorted last.
 export const LANE_NONE = "__none__";
 
+// A GroupMode of `field:<name>` groups by a custom field. The prefix
+// encoding lives here so the producer (BoardFilters' option list) and the
+// consumer (useSwimlanes' decode) share one source of truth.
+const FIELD_GROUP_PREFIX = "field:";
+
+export function groupModeForField(name: string): GroupMode {
+  return `${FIELD_GROUP_PREFIX}${name}`;
+}
+
+// moveInArray returns a new copy of `items` with `name` shifted by `delta`
+// (-1 = earlier, +1 = later), or null when the move is out of bounds /
+// the item is absent. Shared by the column (left/right) and field (up/down)
+// one-step reorder controls.
+export function moveInArray(items: string[], name: string, delta: -1 | 1): string[] | null {
+  const i = items.indexOf(name);
+  const j = i + delta;
+  const a = items[i];
+  const b = items[j];
+  if (a === undefined || b === undefined) return null;
+  const out = items.slice();
+  out[i] = b;
+  out[j] = a;
+  return out;
+}
+
+// fieldNameFromGroupMode returns the custom-field name a GroupMode targets,
+// or null when it's a built-in dimension (none/assignee/label/priority).
+export function fieldNameFromGroupMode(mode: GroupMode): string | null {
+  return mode.startsWith(FIELD_GROUP_PREFIX)
+    ? mode.slice(FIELD_GROUP_PREFIX.length)
+    : null;
+}
+
 export const SORT_OPTIONS: { value: SortMode; label: string }[] = [
   { value: "priority", label: "Priority" },
   { value: "updated", label: "Recently updated" },

--- a/studio/src/views/Board/index.tsx
+++ b/studio/src/views/Board/index.tsx
@@ -315,6 +315,14 @@ export default function BoardView() {
         <Button
           variant="secondary"
           size="sm"
+          onClick={() => setLocation("/board/fields")}
+          title="Manage the board's custom-field schema"
+        >
+          Fields
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
           onClick={columns.openAddColumn}
           title="Add a new column (board state)"
         >

--- a/studio/src/views/Board/index.tsx
+++ b/studio/src/views/Board/index.tsx
@@ -11,13 +11,17 @@ import {
   createIssue,
   deleteIssue,
   patchIssue,
+  saveView,
+  deleteView,
   type NativeIssue,
   type NativeState,
+  type NativeView,
 } from "@/api/native";
 import IssueModal from "./IssueModal";
 import { BoardFilters } from "./BoardFilters";
 import { BoardKeyboardHelp } from "./BoardKeyboardHelp";
 import { Column } from "./Column";
+import { ViewBar } from "./ViewBar";
 import {
   AddColumnDialog,
   DeleteColumnDialog,
@@ -26,6 +30,7 @@ import {
 import { SelectionToolbar } from "./SelectionToolbar";
 import SettingsDrawer from "@/components/Dispatcher/SettingsDrawer";
 import TrackerErrorBanner from "@/components/shared/TrackerErrorBanner";
+import { useAsyncAction } from "@/hooks/useAsyncAction";
 import { useBoardKeyboard } from "@/hooks/useBoardKeyboard";
 import { useConfirm } from "@/hooks/useConfirm";
 import { useToggleSet } from "@/hooks/useToggleSet";
@@ -71,10 +76,15 @@ export default function BoardView() {
     set: labelFilter,
     toggle: onLabelToggle,
     clear: clearLabelFilter,
+    replace: replaceLabels,
   } = useToggleSet<string>();
   const [assigneeFilter, setAssigneeFilter] = useState("");
   const [sortMode, setSortMode] = useState<SortMode>("priority");
   const [groupMode, setGroupMode] = useState<GroupMode>("none");
+  // Saved views: activeView is the currently-applied preset's name ("" =
+  // custom/unsaved). viewAction tracks the save/delete REST call.
+  const [activeView, setActiveView] = useState("");
+  const viewAction = useAsyncAction();
   // `onLabelToggle` (from useToggleSet) is the single source of truth
   // for label filter toggling — used both by the top filter strip and
   // by clicking a chip on any card, so card-level chips toggle the
@@ -126,6 +136,52 @@ export default function BoardView() {
   // Column (state) management: header menu + reorder drag + add/edit/
   // delete dialogs. Mutations refresh the board+issues afterward.
   const columns = useColumnManagement({ board, issues, refresh });
+
+  // Saved-view handlers. applyView restores a preset's filter/sort/group;
+  // onSaveView snapshots the current combo; onDeleteView drops one.
+  const applyView = useCallback(
+    (v: NativeView | null) => {
+      if (!v) {
+        setActiveView("");
+        return;
+      }
+      setSearchQuery(v.search ?? "");
+      replaceLabels(v.labels ?? []);
+      setAssigneeFilter(v.assignee ?? "");
+      setSortMode((v.sort as SortMode) || "priority");
+      setGroupMode(v.group_by || "none");
+      setActiveView(v.name);
+    },
+    [replaceLabels],
+  );
+  const onSaveView = useCallback(
+    (name: string) => {
+      if (!name) return;
+      void viewAction.run(async () => {
+        await saveView({
+          name,
+          search: searchQuery || undefined,
+          labels: labelFilter.size > 0 ? [...labelFilter] : undefined,
+          assignee: assigneeFilter || undefined,
+          sort: sortMode,
+          group_by: groupMode,
+        });
+        await refresh();
+        setActiveView(name);
+      });
+    },
+    [viewAction, searchQuery, labelFilter, assigneeFilter, sortMode, groupMode, refresh],
+  );
+  const onDeleteView = useCallback(
+    (name: string) => {
+      void viewAction.run(async () => {
+        await deleteView(name);
+        await refresh();
+        setActiveView((cur) => (cur === name ? "" : cur));
+      });
+    },
+    [viewAction, refresh],
+  );
 
   // Multi-selection state + click/drag-start selection logic.
   const {
@@ -524,7 +580,18 @@ export default function BoardView() {
           clearLabelFilter();
           setAssigneeFilter("");
           setGroupMode("none");
+          setActiveView("");
         }}
+      />
+
+      <ViewBar
+        views={board.views ?? []}
+        activeView={activeView}
+        onApply={applyView}
+        onSave={onSaveView}
+        onDelete={onDeleteView}
+        busy={viewAction.busy}
+        error={viewAction.error}
       />
 
       {issues.length === 0 && (

--- a/studio/src/views/Board/index.tsx
+++ b/studio/src/views/Board/index.tsx
@@ -12,6 +12,7 @@ import {
   deleteIssue,
   patchIssue,
   type NativeIssue,
+  type NativeState,
 } from "@/api/native";
 import IssueModal from "./IssueModal";
 import { BoardFilters } from "./BoardFilters";
@@ -31,6 +32,7 @@ import { useToggleSet } from "@/hooks/useToggleSet";
 import { useUIStore } from "@/store/ui";
 import {
   defaultStateColor,
+  type GroupMode,
   type SortMode,
 } from "./boardShared";
 import { EmptyBoard } from "./board/EmptyBoard";
@@ -39,6 +41,7 @@ import { isDispatchable } from "./board/boardSort";
 import { useBoardData } from "./board/useBoardData";
 import { useDispatcherPoll } from "./board/useDispatcherPoll";
 import { useBoardColumns } from "./board/useBoardColumns";
+import { useSwimlanes } from "./board/useSwimlanes";
 import { useColumnManagement } from "./board/useColumnManagement";
 import { useBoardSelection } from "./board/useBoardSelection";
 import { useBoardDragDrop } from "./board/useBoardDragDrop";
@@ -71,6 +74,7 @@ export default function BoardView() {
   } = useToggleSet<string>();
   const [assigneeFilter, setAssigneeFilter] = useState("");
   const [sortMode, setSortMode] = useState<SortMode>("priority");
+  const [groupMode, setGroupMode] = useState<GroupMode>("none");
   // `onLabelToggle` (from useToggleSet) is the single source of truth
   // for label filter toggling — used both by the top filter strip and
   // by clicking a chip on any card, so card-level chips toggle the
@@ -113,6 +117,11 @@ export default function BoardView() {
       assigneeFilter,
       sortMode,
     });
+
+  // Swimlanes: null when grouping is off (flat board), else the per-lane
+  // grouping of the same filtered issues. Column management is offered only
+  // in the flat view, so swimlane columns render without header menus.
+  const swimlanes = useSwimlanes({ board, filteredIssues, groupMode, sortMode });
 
   // Column (state) management: header menu + reorder drag + add/edit/
   // delete dialogs. Mutations refresh the board+issues afterward.
@@ -404,6 +413,72 @@ export default function BoardView() {
     );
   }
 
+  // renderStateColumn builds a <Column> for a board state from a byState
+  // map. Used by both the flat board and each swimlane; column-management
+  // affordances (menu, reorder handle) are offered only in the flat view
+  // (manage=true), so swimlane columns stay clean.
+  const renderStateColumn = (
+    s: NativeState,
+    map: Map<string, NativeIssue[]>,
+    manage: boolean,
+    keyPrefix = "",
+  ) => (
+    <Column
+      key={keyPrefix + s.name}
+      name={s.name}
+      display={s.display ?? s.name}
+      terminal={!!s.terminal}
+      eligible={!!s.eligible}
+      color={s.color ?? defaultStateColor(s.name, !!s.eligible, !!s.terminal)}
+      issues={map.get(s.name) ?? []}
+      selectedIds={selectedIds}
+      runningByIssue={runningByIssue}
+      retryingByIssue={retryingByIssue}
+      skipByIssue={skipByIssue}
+      onDrop={onColumnDrop}
+      onClickCard={onCardClick}
+      onDragStartCard={onCardDragStart}
+      onOpenCard={(iss) => setEditing(iss)}
+      onSelectColumn={selectColumn}
+      onLabelClick={onLabelToggle}
+      activeLabels={labelFilter}
+      onCancelRun={onCancelRun}
+      onOpenRun={(runId) => setLocation(`/runs/${encodeURIComponent(runId)}`)}
+      dimmed={dispatcherPaused}
+      onEditColumn={manage ? columns.onEditColumn : undefined}
+      onDeleteColumn={manage ? columns.onDeleteColumn : undefined}
+      onMoveColumn={manage ? columns.onMoveColumn : undefined}
+      onReorderColumn={manage ? columns.onReorderColumn : undefined}
+    />
+  );
+
+  const renderUnmapped = (map: Map<string, NativeIssue[]>, keyPrefix = "") =>
+    (map.get("__unmapped__")?.length ?? 0) > 0 ? (
+      <Column
+        key={keyPrefix + "__unmapped__"}
+        name="__unmapped__"
+        display="Unmapped"
+        terminal={false}
+        eligible={false}
+        color="var(--color-board-backlog)"
+        issues={map.get("__unmapped__") ?? []}
+        selectedIds={selectedIds}
+        runningByIssue={runningByIssue}
+        retryingByIssue={retryingByIssue}
+        skipByIssue={skipByIssue}
+        onDrop={onColumnDrop}
+        onClickCard={onCardClick}
+        onDragStartCard={onCardDragStart}
+        onOpenCard={(iss) => setEditing(iss)}
+        onSelectColumn={selectColumn}
+        onLabelClick={onLabelToggle}
+        activeLabels={labelFilter}
+        onCancelRun={onCancelRun}
+        onOpenRun={(runId) => setLocation(`/runs/${encodeURIComponent(runId)}`)}
+        dimmed={dispatcherPaused}
+      />
+    ) : null;
+
   return (
     <div className="h-full flex flex-col overflow-hidden">
       <DispatcherControlBar onOpenSettings={() => setSettingsOpen(true)} />
@@ -441,10 +516,14 @@ export default function BoardView() {
         onAssigneeChange={setAssigneeFilter}
         sortMode={sortMode}
         onSortChange={setSortMode}
+        groupMode={groupMode}
+        onGroupChange={setGroupMode}
+        fieldNames={(board.fields ?? []).map((f) => f.name)}
         onReset={() => {
           setSearchQuery("");
           clearLabelFilter();
           setAssigneeFilter("");
+          setGroupMode("none");
         }}
       />
 
@@ -479,61 +558,34 @@ export default function BoardView() {
           if (selectedIds.size > 0) setSingleSelection(null);
         }}
       >
-        <div className="flex gap-3 min-w-fit">
-          {board.states.map((s) => (
-            <Column
-              key={s.name}
-              name={s.name}
-              display={s.display ?? s.name}
-              terminal={!!s.terminal}
-              eligible={!!s.eligible}
-              color={s.color ?? defaultStateColor(s.name, !!s.eligible, !!s.terminal)}
-              issues={byState.get(s.name) ?? []}
-              selectedIds={selectedIds}
-              runningByIssue={runningByIssue}
-              retryingByIssue={retryingByIssue}
-              skipByIssue={skipByIssue}
-              onDrop={onColumnDrop}
-              onClickCard={onCardClick}
-              onDragStartCard={onCardDragStart}
-              onOpenCard={(iss) => setEditing(iss)}
-              onSelectColumn={selectColumn}
-              onLabelClick={onLabelToggle}
-              activeLabels={labelFilter}
-              onCancelRun={onCancelRun}
-              onOpenRun={(runId) => setLocation(`/runs/${encodeURIComponent(runId)}`)}
-              dimmed={dispatcherPaused}
-              onEditColumn={columns.onEditColumn}
-              onDeleteColumn={columns.onDeleteColumn}
-              onMoveColumn={columns.onMoveColumn}
-              onReorderColumn={columns.onReorderColumn}
-            />
-          ))}
-          {(byState.get("__unmapped__")?.length ?? 0) > 0 && (
-            <Column
-              name="__unmapped__"
-              display="Unmapped"
-              terminal={false}
-              eligible={false}
-              color="var(--color-board-backlog)"
-              issues={byState.get("__unmapped__") ?? []}
-              selectedIds={selectedIds}
-              runningByIssue={runningByIssue}
-              retryingByIssue={retryingByIssue}
-              skipByIssue={skipByIssue}
-              onDrop={onColumnDrop}
-              onClickCard={onCardClick}
-              onDragStartCard={onCardDragStart}
-              onOpenCard={(iss) => setEditing(iss)}
-              onSelectColumn={selectColumn}
-              onLabelClick={onLabelToggle}
-              activeLabels={labelFilter}
-              onCancelRun={onCancelRun}
-              onOpenRun={(runId) => setLocation(`/runs/${encodeURIComponent(runId)}`)}
-              dimmed={dispatcherPaused}
-            />
-          )}
-        </div>
+        {swimlanes ? (
+          <div className="flex flex-col gap-4 min-w-fit">
+            {swimlanes.length === 0 && (
+              <div className="text-fg-muted text-xs p-4">
+                No issues to group by this dimension.
+              </div>
+            )}
+            {swimlanes.map((lane) => (
+              <section key={lane.key} className="space-y-2">
+                <h2 className="text-xs font-semibold text-fg-default flex items-center gap-2 sticky left-0">
+                  <span className="uppercase tracking-wide">{lane.label}</span>
+                  <span className="text-fg-muted font-normal">{lane.count}</span>
+                </h2>
+                <div className="flex gap-3 min-w-fit">
+                  {board.states.map((s) =>
+                    renderStateColumn(s, lane.byState, false, lane.key + "::"),
+                  )}
+                  {renderUnmapped(lane.byState, lane.key + "::")}
+                </div>
+              </section>
+            ))}
+          </div>
+        ) : (
+          <div className="flex gap-3 min-w-fit">
+            {board.states.map((s) => renderStateColumn(s, byState, true))}
+            {renderUnmapped(byState)}
+          </div>
+        )}
       </div>
 
       {creating && (

--- a/studio/src/views/Board/index.tsx
+++ b/studio/src/views/Board/index.tsx
@@ -17,6 +17,11 @@ import IssueModal from "./IssueModal";
 import { BoardFilters } from "./BoardFilters";
 import { BoardKeyboardHelp } from "./BoardKeyboardHelp";
 import { Column } from "./Column";
+import {
+  AddColumnDialog,
+  DeleteColumnDialog,
+  EditColumnDialog,
+} from "./ColumnDialogs";
 import { SelectionToolbar } from "./SelectionToolbar";
 import SettingsDrawer from "@/components/Dispatcher/SettingsDrawer";
 import TrackerErrorBanner from "@/components/shared/TrackerErrorBanner";
@@ -34,6 +39,7 @@ import { isDispatchable } from "./board/boardSort";
 import { useBoardData } from "./board/useBoardData";
 import { useDispatcherPoll } from "./board/useDispatcherPoll";
 import { useBoardColumns } from "./board/useBoardColumns";
+import { useColumnManagement } from "./board/useColumnManagement";
 import { useBoardSelection } from "./board/useBoardSelection";
 import { useBoardDragDrop } from "./board/useBoardDragDrop";
 import {
@@ -107,6 +113,10 @@ export default function BoardView() {
       assigneeFilter,
       sortMode,
     });
+
+  // Column (state) management: header menu + reorder drag + add/edit/
+  // delete dialogs. Mutations refresh the board+issues afterward.
+  const columns = useColumnManagement({ board, issues, refresh });
 
   // Multi-selection state + click/drag-start selection logic.
   const {
@@ -302,6 +312,14 @@ export default function BoardView() {
         >
           Labels
         </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={columns.openAddColumn}
+          title="Add a new column (board state)"
+        >
+          + Add column
+        </Button>
         <Button variant="secondary" size="sm" onClick={() => void refresh()}>
           Refresh
         </Button>
@@ -333,6 +351,49 @@ export default function BoardView() {
   }
   if (!board) {
     return <EmptyBoard kind="missing" />;
+  }
+
+  // Build the active column dialog at statement level so the discriminated
+  // union narrows cleanly (it wouldn't inside JSX .map/.filter callbacks).
+  const colDialog = columns.dialog;
+  let columnDialogNode: React.ReactNode = null;
+  if (colDialog.kind === "add") {
+    columnDialogNode = (
+      <AddColumnDialog
+        existingNames={board.states.map((s) => s.name)}
+        busy={columns.busy}
+        error={columns.error}
+        onCancel={columns.closeDialog}
+        onSubmit={columns.submitAdd}
+      />
+    );
+  } else if (colDialog.kind === "edit") {
+    const st = colDialog.state;
+    columnDialogNode = (
+      <EditColumnDialog
+        state={st}
+        issueCount={columns.issueCount(st.name)}
+        existingNames={board.states.map((s) => s.name).filter((n) => n !== st.name)}
+        busy={columns.busy}
+        error={columns.error}
+        onCancel={columns.closeDialog}
+        onSubmit={columns.submitEdit}
+      />
+    );
+  } else if (colDialog.kind === "delete") {
+    const st = colDialog.state;
+    columnDialogNode = (
+      <DeleteColumnDialog
+        state={st}
+        issueCount={columns.issueCount(st.name)}
+        otherStates={board.states.filter((s) => s.name !== st.name)}
+        isLast={board.states.length <= 1}
+        busy={columns.busy}
+        error={columns.error}
+        onCancel={columns.closeDialog}
+        onSubmit={columns.submitDelete}
+      />
+    );
   }
 
   return (
@@ -434,6 +495,10 @@ export default function BoardView() {
               onCancelRun={onCancelRun}
               onOpenRun={(runId) => setLocation(`/runs/${encodeURIComponent(runId)}`)}
               dimmed={dispatcherPaused}
+              onEditColumn={columns.onEditColumn}
+              onDeleteColumn={columns.onDeleteColumn}
+              onMoveColumn={columns.onMoveColumn}
+              onReorderColumn={columns.onReorderColumn}
             />
           ))}
           {(byState.get("__unmapped__")?.length ?? 0) > 0 && (
@@ -492,6 +557,7 @@ export default function BoardView() {
           }
         />
       )}
+      {columnDialogNode}
       {confirmDialog}
       {helpOpen && <BoardKeyboardHelp onClose={() => setHelpOpen(false)} />}
     </div>


### PR DESCRIPTION
## Why

The native kanban board (`/board`) rendered its columns from `board.states[]` but had **no UI to manage them** — no add/rename/delete/reorder, no color/flag editing. The only path was a whole-board `PUT` that **orphaned issues** on rename/delete (`SetBoard` validated internal consistency but never migrated issues). This brings the board to GitHub-Projects-style parity.

## What

Four phases, each backed by atomic, granular REST endpoints (no more orphaning):

1. **Editable columns** — add / rename (cascades to issues) / delete (**requires a migration target** for a non-empty column; can't delete the last) / reorder (header drag + Move ←/→) / edit display·color·`eligible`·`terminal`. Backend: `AddState`/`RenameState`/`DeleteState`/`UpdateState`/`ReorderStates` + `/board/states*`.
2. **Custom-field schema editor** — `/board/fields` page: add/edit/rename (cascades the key across `issue.Fields`)/delete (strips the key)/reorder; type picker + enum-values + required. Backend: `AddField`/…/`ReorderFields` + `/board/fields*`.
3. **Swimlane grouping** — "Group" selector → horizontal lanes by assignee / label / priority / custom field (frontend-only).
4. **Saved views** — named filter+sort+group presets persisted in `board.json`, shared across operators. Backend: `Board.Views` + `SaveView`/`DeleteView` + `/board/views*`.

Plus a quality pass (shared `Board.fieldIndex`, generic `reorderByName[T]`, `moveInArray`, centralised `field:` group-mode encoding, shared `ModalActions` dialog footer).

All operator-only (no new `boardops` bot capability). Mutators follow the existing `s.mu` + `recoverMutator` + `setBoardLocked` + `emitPostCommitEvent` discipline; the cascade helpers mirror `applyLabelRewriteLocked`.

## Tests

Go store + HTTP coverage for every op and guard (rename cascade, delete-with/without-target 409, last-column refusal, reorder validation, field key cascade/strip, view upsert + persistence). `go test ./pkg/dispatcher/...`, `go vet`, `tsc -b`, and the studio `vite build` all green. Every operation was exercised live in the studio via Playwright (add → rename-cascade → delete-with-migration → reorder; enum field; assignee swimlanes; save → reload → re-apply view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)