### PR TITLE
ci(version): add nightly auto-release schedule (24h, brew tap included)

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -10,6 +10,14 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  schedule:
+    # Nightly auto-release: when there are unreleased commits since the last
+    # tag, bump + tag, which cascades to release.yml (binaries + chart) and
+    # brew-update.yml (Homebrew tap). Days with no new commits are skipped by
+    # the guard step below to avoid empty releases.
+    # 22:27 UTC ≈ 00:27 CET — artefacts land before the European morning.
+    # Tune the time to taste; this is the only nightly trigger in the chain.
+    - cron: "27 22 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,6 +31,7 @@ jobs:
   version:
     if: >-
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
       (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     steps:
@@ -54,7 +63,25 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Skip nightly release when nothing changed
+        id: changes
+        if: github.event_name == 'schedule'
+        run: |
+          set -euo pipefail
+          LAST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          if [ -z "$LAST_TAG" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "no previous tag — releasing"
+          elif git log "${LAST_TAG}..HEAD" --oneline | grep -q .; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "commits since ${LAST_TAG} — releasing"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "no commits since ${LAST_TAG} — skipping nightly release"
+          fi
+
       - name: Run release-it
+        if: steps.changes.outputs.has_changes != 'false'
         env:
           # Use the token-bureau App token so the GitHub Release that
           # release-it creates carries an App identity. Releases created

--- a/pkg/sandbox/kubernetes/manifest_pullpolicy_test.go
+++ b/pkg/sandbox/kubernetes/manifest_pullpolicy_test.go
@@ -7,7 +7,7 @@ func TestPullPolicyForImage(t *testing.T) {
 		// mutable tags must re-pull so a fresh CI bake isn't shadowed by a cache
 		"ghcr.io/socialgouv/iterion-sandbox-full:edge":   "Always",
 		"ghcr.io/socialgouv/iterion-sandbox-full:v1.2.3": "Always",
-		"alpine":                                         "Always",
+		"alpine": "Always",
 		// a pinned digest is immutable → no needless re-pull
 		"ghcr.io/x/y@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef": "IfNotPresent",
 	}


### PR DESCRIPTION
## What

Adds a **nightly schedule** to `version.yml` so a release is cut once every 24h when there are unreleased commits — keeping the Homebrew tap, CLI binaries and Helm chart fresh while the project moves fast.

## Why

The project is highly experimental and ships frequent changes, but today releases only happen on manual `workflow_dispatch` or PR merge. A daily release keeps `brew upgrade iterion` (and the Docker image / chart) current without anyone having to trigger it by hand — the tap stays in sync day-to-day.

## How

`version.yml` is the only entry point without a time-based trigger, and the rest of the release cascade already exists and fires automatically:

```
version.yml  (release-it: bump + tag v*)
   └─ tag push ─►  release.yml        (6 binaries + cosign + SBOM + chart + GitHub Release)
                     └─ workflow_run ─►  brew-update.yml   (updates Formula/ + Cask/ on the tap)
```

So **no change is needed to `release.yml` or `brew-update.yml`** — the daily tag flows through them unchanged, including the Homebrew tap update.

### The change (minimal, backwards-compatible)

- New `schedule` trigger: `cron: "27 22 * * *"` (22:27 UTC ≈ 00:27 CET → artefacts ready by the European morning). One line to retune.
- `schedule` added to the job `if:` gate.
- A guard step (`Skip nightly release when nothing changed`) skips days with no commits since the last tag, to avoid empty releases / changelog noise.
- `workflow_dispatch` and `pull_request` triggers are untouched.

The guard uses `git describe --tags --abbrev=0` (checkout already runs with `fetch-depth: 0`), is gated on `event_name == 'schedule'`, so manual / PR-merge runs are unaffected.

## Notes

- Auth still goes through `token-bureau` (unchanged), so the GitHub Release carries the App identity and `brew-update.yml`'s `workflow_run` trigger fires as designed.
- The cron time is deliberately off the top of the hour to avoid the Actions peak.

Happy to adjust the time, or drop the no-op guard if you'd prefer an unconditional daily bump.
