### PR TITLE
fix(detect): fallback to `claude auth status` for claude.ai web-auth (Max/Pro)

### DIFF
--- a/pkg/backend/detect/detect.go
+++ b/pkg/backend/detect/detect.go
@@ -5,6 +5,7 @@ package detect
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"os/exec"
@@ -81,11 +82,14 @@ type ProviderStatus struct {
 // codex is intentionally absent — explicit opt-in only.
 var DefaultPreferenceOrder = []string{BackendClaudeCode, BackendClaw}
 
-// Detect runs the probes synchronously. ctx is honored for timed probes
-// (currently none — all probes are local stat / env reads).
+// Detect runs the probes synchronously. ctx is honored for timed probes:
+// most are local stat / env reads, but the claude_code fallback may shell
+// out to `claude auth status --json` (3 s timeout) when no credentials file
+// is present. Results are cached by CachedDetector, so the subprocess runs
+// at most once per TTL window.
 func Detect(ctx context.Context) Report {
 	prov := detectProviders()
-	backends := detectBackends(prov)
+	backends := detectBackends(ctx, prov)
 	pref := PreferenceFromEnv()
 	return Report{
 		PreferenceOrder: pref,
@@ -113,20 +117,9 @@ func PreferenceFromEnv() []string {
 	return out
 }
 
-func detectBackends(prov []ProviderStatus) []BackendStatus {
+func detectBackends(ctx context.Context, prov []ProviderStatus) []BackendStatus {
 	return []BackendStatus{
-		detectOAuthCLI(
-			BackendClaudeCode, findClaudeBinary, claudeConfigDir,
-			// Linux/WSL ships Claude Code OAuth as `.credentials.json`
-			// (hidden); older docs/macOS keychain export use the
-			// non-hidden form. Probe both.
-			[]string{".credentials.json", "credentials.json"},
-			// Modern Claude Code (2.x) on macOS stores OAuth in the
-			// Keychain instead of a file — see claudeKeychainOAuthSource.
-			claudeKeychainOAuthSource,
-			"claude CLI",
-			"~/.claude/.credentials.json (Claude Code OAuth)",
-		),
+		detectClaudeCode(ctx),
 		detectClaw(prov),
 		detectOAuthCLI(
 			BackendCodex, findCodexBinary, codexHomeDir,
@@ -136,6 +129,88 @@ func detectBackends(prov []ProviderStatus) []BackendStatus {
 			"$CODEX_HOME/auth.json (Codex OAuth)",
 		),
 	}
+}
+
+// detectClaudeCode probes for the claude_code backend in three escalating
+// steps, each cheaper than the next is general:
+//  1. credentials file (.credentials.json / credentials.json in ~/.claude) —
+//     the Linux/WSL hidden form and legacy macOS export;
+//  2. macOS Keychain (darwin only, ~10ms existence check) — where Claude
+//     Code 2.x stores OAuth with no file written (see claudeKeychainOAuthSource);
+//  3. `claude auth status --json` — the cross-platform fallback that asks the
+//     CLI itself, covering any other store / future platform where the first
+//     two find nothing but the user is in fact logged in (loggedIn=true).
+func detectClaudeCode(ctx context.Context) BackendStatus {
+	// Steps 1-2: credentials file, then the macOS Keychain fast-path. Both
+	// are handled inside detectOAuthCLI via the keychain extraOAuth probe.
+	st := detectOAuthCLI(
+		BackendClaudeCode, findClaudeBinary, claudeConfigDir,
+		[]string{".credentials.json", "credentials.json"},
+		// Modern Claude Code (2.x) on macOS stores OAuth in the Keychain
+		// instead of a file — darwin-only, never reads the token.
+		claudeKeychainOAuthSource,
+		"claude CLI",
+		"~/.claude/.credentials.json (Claude Code OAuth)",
+	)
+	if st.Available {
+		return st
+	}
+
+	// Binary not found — nothing more to try.
+	binPath, hasBin := findClaudeBinary()
+	if !hasBin {
+		return st
+	}
+
+	// Step 3: `claude auth status --json`. Cross-platform truth from the CLI;
+	// covers claude.ai web-auth on hosts where no file/keychain entry surfaced.
+	if claudeAuthStatusFn(ctx, binPath) {
+		return BackendStatus{
+			Name:      BackendClaudeCode,
+			Available: true,
+			Auth:      AuthOAuth,
+			Sources:   []string{"claude auth status (claude.ai OAuth)", "PATH:" + binPath},
+		}
+	}
+	return st
+}
+
+// claudeAuthStatusFn invokes `claude auth status --json` and reports whether
+// the user is logged in via claude.ai OAuth (the "forfait" web-auth).
+//
+// It deliberately requires authMethod == "claude.ai" and does NOT accept
+// authMethod == "api_key": an ANTHROPIC_API_KEY makes `claude auth status`
+// report loggedIn=true, but the API-key path is intentionally not
+// OAuth-eligible for auto-resolution — claw uses the same key in-process and
+// is preferred (see detectOAuthCLI). Without this guard, any host with
+// ANTHROPIC_API_KEY set would wrongly resolve to claude_code.
+//
+// Declared as a var so tests can stub it without requiring a real claude
+// binary.
+var claudeAuthStatusFn = func(ctx context.Context, binPath string) bool {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, binPath, "auth", "status", "--json").Output()
+	if err != nil {
+		return false
+	}
+	return claudeAuthStatusIsForfait(out)
+}
+
+// claudeAuthStatusIsForfait parses `claude auth status --json` output and
+// reports whether it represents a claude.ai OAuth ("forfait") login. Split out
+// as a pure function so the api_key-exclusion logic is unit-testable without a
+// real claude binary (claudeAuthStatusFn itself is stubbed in tests).
+func claudeAuthStatusIsForfait(out []byte) bool {
+	var result struct {
+		LoggedIn   bool   `json:"loggedIn"`
+		AuthMethod string `json:"authMethod"`
+	}
+	if json.Unmarshal(out, &result) != nil {
+		return false
+	}
+	// Forfait OAuth only — exclude api_key / none.
+	return result.LoggedIn && result.AuthMethod == "claude.ai"
 }
 
 // detectOAuthCLI reports Available=true only when both a binary and an

--- a/pkg/backend/detect/detect_test.go
+++ b/pkg/backend/detect/detect_test.go
@@ -44,6 +44,9 @@ func isolateEnv(t *testing.T) {
 	// "absent" so detection is deterministic on every host. Tests that
 	// exercise the keychain path re-stub it with a source label.
 	stubSource(t, &claudeKeychainOAuthSource, "")
+	// Likewise prevent real `claude auth status` subprocess calls; tests that
+	// need web-auth detection stub this explicitly.
+	stubClaudeAuthStatus(t, false)
 }
 
 // stubBinary swaps a binary-probe var for the duration of the test.
@@ -67,6 +70,14 @@ func stubSource(t *testing.T, target *func() string, label string) {
 	prev := *target
 	*target = func() string { return label }
 	t.Cleanup(func() { *target = prev })
+}
+
+// stubClaudeAuthStatus swaps claudeAuthStatusFn for the duration of the test.
+func stubClaudeAuthStatus(t *testing.T, loggedIn bool) {
+	t.Helper()
+	prev := claudeAuthStatusFn
+	claudeAuthStatusFn = func(_ context.Context, _ string) bool { return loggedIn }
+	t.Cleanup(func() { claudeAuthStatusFn = prev })
 }
 
 func writeFile(t *testing.T, path, body string) {
@@ -344,6 +355,71 @@ func TestCachedDetector_HonorsTTL(t *testing.T) {
 	r3 := cache.Get(context.Background())
 	if r3.ResolvedDefault != BackendClaw {
 		t.Fatalf("after invalidate, ResolvedDefault = %q, want claw", r3.ResolvedDefault)
+	}
+}
+
+func TestDetect_ClaudeCodeWebAuth(t *testing.T) {
+	// Binary present, no credentials file, but `claude auth status` reports
+	// loggedIn=true. Covers the newer claude.ai OAuth (Max/Pro) that stores
+	// tokens in the OS keychain rather than ~/.claude/.credentials.json.
+	isolateEnv(t)
+	stubBinary(t, &findClaudeBinary, "/fake/claude")
+	stubClaudeAuthStatus(t, true)
+
+	r := Detect(context.Background())
+
+	st := findBackend(t, r, BackendClaudeCode)
+	if !st.Available {
+		t.Fatalf("claude_code should be available via auth status fallback")
+	}
+	if st.Auth != AuthOAuth {
+		t.Fatalf("claude_code auth = %q, want %q", st.Auth, AuthOAuth)
+	}
+	if r.ResolvedDefault != BackendClaudeCode {
+		t.Fatalf("ResolvedDefault = %q, want claude_code", r.ResolvedDefault)
+	}
+}
+
+func TestDetect_ClaudeCodeWebAuth_NotLoggedIn(t *testing.T) {
+	// Binary present, no credentials file, auth status says not logged in.
+	// claude_code must remain unavailable.
+	isolateEnv(t)
+	stubBinary(t, &findClaudeBinary, "/fake/claude")
+	stubClaudeAuthStatus(t, false)
+
+	r := Detect(context.Background())
+
+	st := findBackend(t, r, BackendClaudeCode)
+	if st.Available {
+		t.Fatalf("claude_code should NOT be available when not logged in")
+	}
+	if len(st.Hints) == 0 {
+		t.Fatalf("expected hints when claude_code unavailable, got none")
+	}
+}
+
+// `claude auth status` reports loggedIn=true even when the only credential is
+// an ANTHROPIC_API_KEY (authMethod=api_key). That path must NOT count as OAuth
+// forfait, or any API-key host would wrongly auto-resolve to claude_code over
+// claw. Only authMethod=claude.ai qualifies.
+func TestClaudeAuthStatusIsForfait(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want bool
+	}{
+		{"forfait claude.ai", `{"loggedIn":true,"authMethod":"claude.ai","subscriptionType":"max"}`, true},
+		{"api key not forfait", `{"loggedIn":true,"authMethod":"api_key","apiKeySource":"ANTHROPIC_API_KEY"}`, false},
+		{"logged out", `{"loggedIn":false,"authMethod":"none"}`, false},
+		{"empty authMethod", `{"loggedIn":true}`, false},
+		{"garbage", `not json`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := claudeAuthStatusIsForfait([]byte(tc.out)); got != tc.want {
+				t.Fatalf("claudeAuthStatusIsForfait(%s) = %v, want %v", tc.out, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/pkg/backend/model/resolve_backend_test.go
+++ b/pkg/backend/model/resolve_backend_test.go
@@ -27,6 +27,27 @@ func resetEnvForResolve(t *testing.T) {
 		t.Setenv(k, "")
 	}
 	t.Setenv("HOME", t.TempDir())
+	// Point PATH at an empty dir so the detector can't discover the host's
+	// real `claude`/`codex` binaries. Without this, the claude_code probe's
+	// `claude auth status` fallback would spawn the real CLI during these
+	// unit tests — non-deterministic across hosts and, worse, the CLI writes
+	// `.claude.json.backup` files into the test cwd. Tests that need a binary
+	// present install a fake one on PATH explicitly (see fakeExecOnPath).
+	t.Setenv("PATH", t.TempDir())
+}
+
+// fakeExecOnPath drops a no-op executable named `name` into a fresh dir and
+// prepends that dir to PATH, so the detector's binary probe (exec.LookPath)
+// finds it without invoking the host's real CLI. PATH is restored on cleanup
+// via t.Setenv.
+func fakeExecOnPath(t *testing.T, name string) {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, name)
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 // newExecutorForResolveTest returns a minimal executor wired to a fresh
@@ -102,21 +123,10 @@ func TestResolveBackend_DetectClaudeOAuth(t *testing.T) {
 	if err := os.WriteFile(credPath, []byte("{}"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	// Also need a `claude` binary discoverable. We can't easily mock PATH
-	// here without breaking other tests, so verify the detect report
-	// agrees that claude_code is unavailable on this machine if the
-	// binary is absent — and skip if so. CI / dev boxes usually have
-	// `claude` installed; if not, we just confirm the fallback.
-	report := detect.Detect(t.Context())
-	var claudeAvail bool
-	for _, b := range report.Backends {
-		if b.Name == detect.BackendClaudeCode {
-			claudeAvail = b.Available
-		}
-	}
-	if !claudeAvail {
-		t.Skip("claude binary not discoverable on this host; skipping OAuth-resolution check")
-	}
+	// claude_code requires a discoverable `claude` binary AND an OAuth
+	// credential. The creds file above supplies the credential; install a
+	// fake binary so the file probe wins without spawning the real CLI.
+	fakeExecOnPath(t, "claude")
 	e := newExecutorForResolveTest("")
 	got := e.resolveBackendName(&ir.AgentNode{})
 	if got != detect.BackendClaudeCode {


### PR DESCRIPTION
## Problem

Claude Max/Pro users who sign in via the browser (`claude auth login`) use the newer **claude.ai web-auth** flow, which stores tokens in the OS keychain rather than writing `~/.claude/.credentials.json`. The file-based probe in `detectOAuthCLI` reported `claude_code` as `Available=false`, causing the studio BackendStatusPill to show a confusing hint:

```
claude CLI found at /Users/…/claude
no ~/.claude/.credentials.json (Claude Code OAuth) — set `backend: claude_code` explicitly to use API-key auth
```

…even though `claude auth status --json` returns `loggedIn: true`.

## Fix

- Extracts `detectClaudeCode()` from `detectBackends()` to add a second probe stage.
- **Fast path:** existing credentials-file check (unchanged, covers Linux/WSL + legacy macOS exports).
- **Fallback:** when no file is found but the binary is present, runs `claude auth status --json` with a 3 s timeout and accepts `loggedIn: true` — this is the path Max/Pro users hit.
- `claudeAuthStatusFn` is a package-level `var` so tests can stub it without a real binary.
- Threads the existing `ctx` from `Detect()` down to `detectBackends()` / `detectClaudeCode()` so the subprocess respects cancellation.

## Tests

- `TestDetect_ClaudeCodeWebAuth` — binary present, no file, auth status `true` → `Available=true`, `Auth="oauth"`, resolves as default.
- `TestDetect_ClaudeCodeWebAuth_NotLoggedIn` — binary present, no file, auth status `false` → `Available=false`, hints present.
- `isolateEnv` now stubs `claudeAuthStatusFn=false` so existing tests never spawn a real subprocess.
- All existing tests remain green (file-based path is unchanged; new fallback is unreachable when binary is stubbed to `""`).