### PR TITLE
fix(detect): recognize macOS Keychain for Claude Code OAuth (claude_code falsely unavailable on Mac)

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -16,7 +16,8 @@ to override the auto-selection.
 
 If you have **at least one** of:
 
-- a `~/.claude/.credentials.json` (Claude Code OAuth — "forfait")
+- Claude Code signed in (OAuth in the macOS Keychain on Mac, or
+  `~/.claude/.credentials.json` on Linux/WSL — "forfait")
 - `ANTHROPIC_API_KEY` set in your environment
 - `OPENAI_API_KEY` set in your environment
 - `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT`
@@ -218,11 +219,14 @@ actually make calls.
 
 | Credential | Source |
 |---|---|
-| OAuth (forfait) | `$CLAUDE_CONFIG_DIR/.credentials.json` (default `~/.claude/.credentials.json`; non-hidden `credentials.json` also accepted) |
+| OAuth (forfait) | **macOS:** the `Claude Code-credentials` item in the Keychain (where Claude Code 2.x stores it by default — no file is written). **Linux/WSL:** `$CLAUDE_CONFIG_DIR/.credentials.json` (default `~/.claude/.credentials.json`; non-hidden `credentials.json` also accepted) |
 | Binary | `claude` in `$PATH`, or `~/.claude/local/claude` |
 
-For auto-resolution, **OAuth is required**. If you only have
-`ANTHROPIC_API_KEY` and the binary, `claw` is preferred (same auth,
+On macOS the Keychain is probed for *existence only* (via
+`/usr/bin/security find-generic-password` — the token is never read), so a
+machine logged into Claude Code is detected even though it has no
+`.credentials.json` file. For auto-resolution, **OAuth is required**. If you
+only have `ANTHROPIC_API_KEY` and the binary, `claw` is preferred (same auth,
 no subprocess fork). To use `claude_code` with API-key auth, set
 `backend: claude_code` explicitly on the node.
 

--- a/pkg/backend/detect/detect.go
+++ b/pkg/backend/detect/detect.go
@@ -5,8 +5,11 @@ package detect
 
 import (
 	"context"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -118,6 +121,9 @@ func detectBackends(prov []ProviderStatus) []BackendStatus {
 			// (hidden); older docs/macOS keychain export use the
 			// non-hidden form. Probe both.
 			[]string{".credentials.json", "credentials.json"},
+			// Modern Claude Code (2.x) on macOS stores OAuth in the
+			// Keychain instead of a file — see claudeKeychainOAuthSource.
+			claudeKeychainOAuthSource,
 			"claude CLI",
 			"~/.claude/.credentials.json (Claude Code OAuth)",
 		),
@@ -125,6 +131,7 @@ func detectBackends(prov []ProviderStatus) []BackendStatus {
 		detectOAuthCLI(
 			BackendCodex, findCodexBinary, codexHomeDir,
 			[]string{"auth.json"},
+			nil, // codex OAuth lives only in auth.json (no OS-credential-store path)
 			"codex CLI",
 			"$CODEX_HOME/auth.json (Codex OAuth)",
 		),
@@ -132,15 +139,19 @@ func detectBackends(prov []ProviderStatus) []BackendStatus {
 }
 
 // detectOAuthCLI reports Available=true only when both a binary and an
-// OAuth credentials file are present. The API-key-only path (e.g.
-// ANTHROPIC_API_KEY + claude binary, no OAuth) is intentionally NOT
-// auto-eligible: claw uses the same key in-process and is faster, so
-// users wanting the CLI in that case must set `backend:` explicitly.
+// OAuth credential are present. The credential may live in a file under
+// configDir (Linux/WSL `.credentials.json`, exported keychain) or — for
+// backends whose CLI stores OAuth in the OS credential store — be surfaced
+// via extraOAuth (macOS Keychain for Claude Code). The API-key-only path
+// (e.g. ANTHROPIC_API_KEY + claude binary, no OAuth) is intentionally NOT
+// auto-eligible: claw uses the same key in-process and is faster, so users
+// wanting the CLI in that case must set `backend:` explicitly.
 func detectOAuthCLI(
 	name string,
 	findBin func() (string, bool),
 	configDir func() string,
 	credFiles []string,
+	extraOAuth func() string,
 	binDesc, oauthDesc string,
 ) BackendStatus {
 	st := BackendStatus{Name: name, Auth: AuthNone}
@@ -158,6 +169,17 @@ func detectOAuthCLI(
 				st.Sources = []string{credPath, "PATH:" + binPath}
 				return st
 			}
+		}
+	}
+	// OS credential store (macOS Keychain for Claude Code — the default
+	// store on darwin, where no .credentials.json file is written). Same
+	// OAuth semantics as the file form.
+	if extraOAuth != nil {
+		if label := extraOAuth(); label != "" {
+			st.Available = true
+			st.Auth = AuthOAuth
+			st.Sources = []string{label, "PATH:" + binPath}
+			return st
 		}
 	}
 	st.Hints = []string{
@@ -358,6 +380,46 @@ var findClaudeBinary = func() (string, bool) {
 		Name:      "claude",
 		Fallbacks: clilocate.ClaudeLocalFallback(),
 	})
+}
+
+// claudeCodeKeychainService is the macOS Keychain service name Claude Code
+// stores its OAuth token under (verified against Claude Code 2.x).
+const claudeCodeKeychainService = "Claude Code-credentials"
+
+// claudeKeychainOAuthSource returns a human-readable source label when
+// Claude Code OAuth credentials are present in the macOS Keychain — the
+// default credential store for Claude Code on darwin, where no
+// `.credentials.json` file is written. Returns "" on other platforms or
+// when the entry is absent, so the file-based probe stays authoritative
+// there. Declared as a var so tests can stub it deterministically (the real
+// implementation shells out to /usr/bin/security and must not run during
+// unit tests).
+//
+// Existence check only: `security find-generic-password` without `-w`/`-g`
+// never reads the token. Claude Code's own keychain ACL lets the owning
+// user's processes find the item with no authorization prompt (the CLI
+// reads it on every invocation), so this is non-intrusive even on the
+// studio's 30s detection poll.
+var claudeKeychainOAuthSource = func() string {
+	if runtime.GOOS != "darwin" {
+		return ""
+	}
+	if keychainHasItem(claudeCodeKeychainService) {
+		return "macOS Keychain: " + claudeCodeKeychainService
+	}
+	return ""
+}
+
+// keychainHasItem reports whether a generic-password item with the given
+// service exists in the user's keychain. Existence only — it never reads or
+// prints the secret.
+func keychainHasItem(service string) bool {
+	// Absolute path: a GUI-launched iterion may have a minimal PATH that
+	// omits /usr/bin, but /usr/bin/security is always present on macOS.
+	cmd := exec.Command("/usr/bin/security", "find-generic-password", "-s", service)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd.Run() == nil
 }
 
 // findCodexBinary probes the host for the codex CLI. PATH lookup wins;

--- a/pkg/backend/detect/detect_test.go
+++ b/pkg/backend/detect/detect_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -17,9 +18,15 @@ func isolateEnv(t *testing.T) {
 	t.Helper()
 	for _, k := range []string{
 		"ITERION_BACKEND_PREFERENCE",
-		"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN",
-		"OPENAI_API_KEY",
-		"AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT",
+		"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL",
+		"OPENAI_API_KEY", "OPENAI_BASE_URL",
+		// z.ai routes Anthropic through ANTHROPIC_BASE_URL + a ZAI_API_KEY /
+		// ANTHROPIC_AUTH_TOKEN; without scrubbing these, a z.ai-configured
+		// dev machine (a first-class supported provider) flips the anthropic
+		// provider off and turns detection tests red.
+		"ZAI_API_KEY",
+		// OpenAI ChatGPT-forfait preference overrides are detection inputs.
+		"ITERION_OPENAI_USE_OAUTH",
 		"AWS_REGION", "AWS_DEFAULT_REGION",
 		"GOOGLE_CLOUD_PROJECT",
 		"CLAUDE_CONFIG_DIR", "CODEX_HOME",
@@ -32,6 +39,11 @@ func isolateEnv(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	stubBinary(t, &findClaudeBinary, "")
 	stubBinary(t, &findCodexBinary, "")
+	// The macOS Keychain probe shells out to /usr/bin/security and would
+	// read the dev machine's real Claude Code login on darwin — stub it to
+	// "absent" so detection is deterministic on every host. Tests that
+	// exercise the keychain path re-stub it with a source label.
+	stubSource(t, &claudeKeychainOAuthSource, "")
 }
 
 // stubBinary swaps a binary-probe var for the duration of the test.
@@ -45,6 +57,15 @@ func stubBinary(t *testing.T, target *func() (string, bool), path string) {
 		}
 		return path, true
 	}
+	t.Cleanup(func() { *target = prev })
+}
+
+// stubSource swaps an OAuth-source-probe var (label == "" means "absent")
+// for the duration of the test. Restored on test cleanup.
+func stubSource(t *testing.T, target *func() string, label string) {
+	t.Helper()
+	prev := *target
+	*target = func() string { return label }
 	t.Cleanup(func() { *target = prev })
 }
 
@@ -152,6 +173,60 @@ func TestDetect_ClaudeCodeOAuth(t *testing.T) {
 	}
 	if r.ResolvedDefault != BackendClaudeCode {
 		t.Fatalf("ResolvedDefault = %q, want claude_code", r.ResolvedDefault)
+	}
+}
+
+// Modern Claude Code (2.x) on macOS stores OAuth in the Keychain, not in a
+// ~/.claude/.credentials.json file — so the file probe finds nothing even on
+// a fully logged-in machine. The Keychain probe must flip claude_code to
+// available so the resolver picks it and the studio enables Run.
+func TestDetect_ClaudeCodeKeychainOAuth(t *testing.T) {
+	isolateEnv(t)
+	stubBinary(t, &findClaudeBinary, "/fake/claude")
+	// No credentials.json on disk; OAuth lives in the macOS Keychain.
+	stubSource(t, &claudeKeychainOAuthSource, "macOS Keychain: Claude Code-credentials")
+
+	r := Detect(context.Background())
+
+	st := findBackend(t, r, BackendClaudeCode)
+	if !st.Available {
+		t.Fatalf("claude_code should be available via macOS Keychain OAuth")
+	}
+	if st.Auth != AuthOAuth {
+		t.Fatalf("claude_code auth = %q, want oauth", st.Auth)
+	}
+	// The source must surface the Keychain origin (not a phantom file path).
+	foundKeychain := false
+	for _, s := range st.Sources {
+		if strings.Contains(s, "Keychain") {
+			foundKeychain = true
+			break
+		}
+	}
+	if !foundKeychain {
+		t.Fatalf("claude_code sources = %v, want a Keychain source", st.Sources)
+	}
+	if r.ResolvedDefault != BackendClaudeCode {
+		t.Fatalf("ResolvedDefault = %q, want claude_code (preferred over claw)", r.ResolvedDefault)
+	}
+}
+
+// Regression guard for Linux/Windows: when neither a credentials file nor an
+// OS-credential-store token is present, claude_code must stay unavailable and
+// the resolver must not pick it. (isolateEnv stubs the Keychain probe to "".)
+func TestDetect_ClaudeCodeNoOAuthAnywhere(t *testing.T) {
+	isolateEnv(t)
+	stubBinary(t, &findClaudeBinary, "/fake/claude")
+	// No credentials file, no Keychain token.
+
+	r := Detect(context.Background())
+
+	st := findBackend(t, r, BackendClaudeCode)
+	if st.Available {
+		t.Fatalf("claude_code should be unavailable with no OAuth source")
+	}
+	if r.ResolvedDefault != "" {
+		t.Fatalf("ResolvedDefault = %q, want empty", r.ResolvedDefault)
 	}
 }
 

--- a/pkg/sandbox/kubernetes/manifest_pullpolicy_test.go
+++ b/pkg/sandbox/kubernetes/manifest_pullpolicy_test.go
@@ -7,7 +7,7 @@ func TestPullPolicyForImage(t *testing.T) {
 		// mutable tags must re-pull so a fresh CI bake isn't shadowed by a cache
 		"ghcr.io/socialgouv/iterion-sandbox-full:edge":   "Always",
 		"ghcr.io/socialgouv/iterion-sandbox-full:v1.2.3": "Always",
-		"alpine":                                         "Always",
+		"alpine": "Always",
 		// a pinned digest is immutable → no needless re-pull
 		"ghcr.io/x/y@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef": "IfNotPresent",
 	}


### PR DESCRIPTION
## Problem

On macOS with Claude Code installed and logged in, iterion reported `claude_code` as **unavailable** and printed:

```
claude CLI found at /opt/homebrew/bin/claude
no ~/.claude/.credentials.json (Claude Code OAuth) — set `backend: claude_code` explicitly to use API-key auth
```

This disabled **Run** in the studio and made the auto-resolver skip the forfait path — even though the `claude` CLI was fully authenticated.

## Root cause

Claude Code **2.x stores its OAuth token in the macOS Keychain** (service `Claude Code-credentials`), and no longer writes `~/.claude/.credentials.json`. iterion's `detectOAuthCLI` only checked the file on disk, so it produced a false negative on every modern macOS install:

```
$ ls ~/.claude/.credentials.json   # absent
$ security find-generic-password -s "Claude Code-credentials"   # FOUND ← the real token lives here
```

Verified on the reporting machine: `~/.claude/.credentials.json` absent, `~/.claude.json` present (UI state, not creds), Claude Code `2.1.187`, and the `Claude Code-credentials` Keychain item present.

## Fix

`pkg/backend/detect/detect.go` — add the macOS Keychain as a **second OAuth source** in `detectOAuthCLI`, probed only on `darwin` (`runtime.GOOS`):

- New `claudeKeychainOAuthSource` (stubbable var) → shells out to `/usr/bin/security find-generic-password -s "Claude Code-credentials"`.
- **Existence check only** — no `-w`/`-g`, so the OAuth token is **never read or printed**. Claude Code's own keychain ACL lets the owning user's process find the item without an authorization prompt (the CLI reads it on every invocation), so this is non-intrusive even on the studio's 30s detection poll.
- Non-darwin hosts return `""` → the file probe stays authoritative (no behaviour change on Linux/Windows). `codex` passes `nil` (auth.json only).

When found, `claude_code` flips to `Available=true, Auth=oauth` with source `macOS Keychain: Claude Code-credentials` — same semantics as the file form. `Report`/`BackendStatus` shape is unchanged, so the studio TS mirror needs no edit.

### Verification on the real host (before → after)

| | before | after |
|---|---|---|
| `claude_code` | `available=false` + the confusing hint | `available=true`, `auth=oauth`, source `macOS Keychain: Claude Code-credentials` |
| `ResolvedDefault` | `""` (Run disabled) | `"claude_code"` |

## Tests (`pkg/backend/detect`)

- `TestDetect_ClaudeCodeKeychainOAuth` — binary present, no creds file, keychain probe present → `claude_code` available via a Keychain source; resolver picks it. (Written first, confirmed red against the old code.)
- `TestDetect_ClaudeCodeNoOAuthAnywhere` — regression guard for Linux/Windows: no file **and** no keychain → stays unavailable.
- `isolateEnv` now also stubs the keychain probe (so tests are deterministic on a Mac dev machine) **and** scrubs `ANTHROPIC_BASE_URL` / `ZAI_API_KEY` / `OPENAI_BASE_URL` / `ITERION_OPENAI_USE_OAUTH`. The latter was a pre-existing harness gap: a z.ai-configured machine (a first-class supported provider) was turning `TestDetect_AnthropicAPIKey` / `OverridePreferenceFavorsClaw` / `CachedDetector_HonorsTTL` red.

Full `pkg/backend/detect` + `pkg/backend/model` suites green.

## Out of scope (not touched)

- Sandboxed runs on macOS still can't use the host Keychain from inside a Linux container (pre-existing; orthogonal — users inject API key / forfait creds there).
- `pkg/server`'s `TestBackendsDetectReflectsAnthropic` has the same z.ai-env gap in *its own* harness; pre-existing, fails identically on `main`, left for a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)