### PR TITLE
chore: gofmt manifest_pullpolicy_test.go (main is red on gofmt CI)

### DIFF
--- a/pkg/sandbox/kubernetes/manifest_pullpolicy_test.go
+++ b/pkg/sandbox/kubernetes/manifest_pullpolicy_test.go
@@ -7,7 +7,7 @@ func TestPullPolicyForImage(t *testing.T) {
 		// mutable tags must re-pull so a fresh CI bake isn't shadowed by a cache
 		"ghcr.io/socialgouv/iterion-sandbox-full:edge":   "Always",
 		"ghcr.io/socialgouv/iterion-sandbox-full:v1.2.3": "Always",
-		"alpine":                                         "Always",
+		"alpine": "Always",
 		// a pinned digest is immutable → no needless re-pull
 		"ghcr.io/x/y@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef": "IfNotPresent",
 	}


### PR DESCRIPTION
## What

`pkg/sandbox/kubernetes/manifest_pullpolicy_test.go` is unformatted and the repo-wide `gofmt` CI gate is **red on `main`** — and therefore on every open PR (#43, #45, …).

Introduced by `25b04eb7` ("fix(sandbox): drop docker-only host bind mounts on k8s + pull mutable sandbox images fresh"), which shipped the test with a line `gofmt` rejects:

```diff
-		"alpine":                                         "Always",
+		"alpine": "Always",
```

gofmt drops the struct-field alignment table once the long `@sha256:…` entry breaks the column, so the hand-aligned `"alpine"` line is flagged.

## Verification

```
$ gofmt -l pkg/sandbox/kubernetes/manifest_pullpolicy_test.go   # (now empty)
$ go test ./pkg/sandbox/kubernetes/...
```

This is the root-cause fix; #43 and #45 carry the same one-liner so their CI goes green in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)