### PR TITLE
fix: unblock red main — gofmt manifest_pullpolicy_test.go + publish dispatcher freed-slot snapshot before Release worker

### DIFF
--- a/pkg/dispatcher/commands.go
+++ b/pkg/dispatcher/commands.go
@@ -510,8 +510,19 @@ func (c *Dispatcher) finishRun(ctx context.Context, issueID string, err error) {
 		}
 	}
 
-	c.launchFinish(plan)
+	// Publish the freed-slot snapshot BEFORE handing the Release HTTP to the
+	// off-actor worker. launchFinish spawns the worker, which enters
+	// tracker.Release as soon as the runtime schedules it; if fireSnapshot ran
+	// after launchFinish that scheduling could let the worker enter Release
+	// (and, in tests, fire releaseEntered) while the published snapshot still
+	// showed the slot in use (GlobalUsed=1). That window is a flake under CI's
+	// scheduling and — per ADR-028 Step 3 — a real violation of "slot
+	// accounting is observable before the release HTTP completes": the studio
+	// could read the slot as used while Release is in flight. The paused
+	// branch above already publishes before returning; the worker reads only
+	// the immutable plan, so publishing first is safe.
 	c.fireSnapshot()
+	c.launchFinish(plan)
 }
 
 // exhausted reports whether a failing issue has reached the configured

--- a/pkg/sandbox/kubernetes/manifest_pullpolicy_test.go
+++ b/pkg/sandbox/kubernetes/manifest_pullpolicy_test.go
@@ -7,7 +7,7 @@ func TestPullPolicyForImage(t *testing.T) {
 		// mutable tags must re-pull so a fresh CI bake isn't shadowed by a cache
 		"ghcr.io/socialgouv/iterion-sandbox-full:edge":   "Always",
 		"ghcr.io/socialgouv/iterion-sandbox-full:v1.2.3": "Always",
-		"alpine":                                         "Always",
+		"alpine": "Always",
 		// a pinned digest is immutable → no needless re-pull
 		"ghcr.io/x/y@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef": "IfNotPresent",
 	}


### PR DESCRIPTION
> Supersedes #46 (its gofmt fix is folded in here — see below).

`main` is **red** in two independent ways, and because the `gofmt` and `race` gates run repo-wide, no single-purpose fix-PR can pass CI alone. This PR carries **both** fixes so `main` (and the PRs depending on it: #43, #45) can go green.

## 1. `gofmt` — `pkg/sandbox/kubernetes/manifest_pullpolicy_test.go`

Commit `25b04eb7` shipped this test with a line `gofmt` rejects (excess alignment padding on the `"alpine"` case — gofmt drops the table once the long `@sha256:…` entry breaks the column):

```diff
-		"alpine":                                         "Always",
+		"alpine": "Always",
```

One-line alignment fix.

## 2. `race` — dispatcher snapshot ordering (the real bug)

`finishRun` dispatched the off-actor finish worker (`launchFinish`) and only **then** called `fireSnapshot`:

```go
c.launchFinish(plan)   // spawns worker → enters tracker.Release → fires releaseEntered
c.fireSnapshot()       // publishes GlobalUsed=0 … *after* the worker may have fired releaseEntered
```

The worker enters `tracker.Release` as soon as the runtime schedules it, so under CI's scheduling `releaseEntered` can land while the published snapshot still reads `GlobalUsed=1`. Two consequences:

- `TestSlotFreedBeforeReleaseHTTP` / `TestActorResponsiveWhileFinishHTTPInFlight` flake red on the `race` job (they wait on `releaseEntered` then read `Snapshot()`). They pass locally (fast host schedules `fireSnapshot` first) but fail ~half the time on CI — **main has been red on `race`**.
- It's also a genuine **ADR-028 Step 3** invariant violation: *"slot accounting is observable before the release HTTP completes."* The studio could read a slot as in-use while `Release` is in flight.

**Fix:** publish first, then hand off —
```go
c.fireSnapshot()
c.launchFinish(plan)
```
The worker reads only the immutable `plan` (never `c.state`/`c.cfg`), so publishing first is safe; the paused branch already followed this order. The window is gone, the two tests become deterministic.

## Verification

```
$ go test -race -count=10 -run 'TestSlotFreedBeforeReleaseHTTP|TestActorResponsiveWhileFinishHTTPInFlight' ./pkg/dispatcher/
ok  	github.com/SocialGouv/iterion/pkg/dispatcher   1.219s
$ gofmt -l pkg/sandbox/kubernetes/manifest_pullpolicy_test.go   # (empty)
```
The local host can't reproduce the race flake, so the proof is **this PR's `race` + `test` CI jobs going green where `main`'s are red**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)