### PR TITLE
feat(cli): add --commit flag to version command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1123,7 +1123,7 @@ iterion bundle pack                     # Pack a .botz bundle (create it with `b
 iterion sandbox doctor [file] [--strict] [--target auto|cloud|local]  # Diagnose host sandbox prerequisites; --strict validates a run's full config pre-flight (see docs/sandbox.md)
 iterion migrate to-cloud [flags]        # Migrate a local store into a cloud (Mongo + S3) backend
 iterion server [--port] [--store-dir]   # HTTP server (run console + studio), without the studio launcher
-iterion version [--commit]              # Print version; --commit prints only the git SHA (errors when the build carries none)
+iterion version [--commit]              # Print version; --commit prints only the 12-char git SHA (errors when the build carries none)
 
 # Operational runner and hidden subprocess entry points:
 # `iterion runner`, `iterion __claw-runner`, `iterion __mcp-ask-user`, `iterion __mcp-board`, `iterion __mcp-control`, `iterion __scan-shards`, `iterion __claude-hook-drain`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1123,7 +1123,7 @@ iterion bundle pack                     # Pack a .botz bundle (create it with `b
 iterion sandbox doctor [file] [--strict] [--target auto|cloud|local]  # Diagnose host sandbox prerequisites; --strict validates a run's full config pre-flight (see docs/sandbox.md)
 iterion migrate to-cloud [flags]        # Migrate a local store into a cloud (Mongo + S3) backend
 iterion server [--port] [--store-dir]   # HTTP server (run console + studio), without the studio launcher
-iterion version                         # Print version
+iterion version [--commit]              # Print version; --commit prints only the git SHA (errors when the build carries none)
 
 # Operational runner and hidden subprocess entry points:
 # `iterion runner`, `iterion __claw-runner`, `iterion __mcp-ask-user`, `iterion __mcp-board`, `iterion __mcp-control`, `iterion __scan-shards`, `iterion __claude-hook-drain`

--- a/cmd/iterion/version.go
+++ b/cmd/iterion/version.go
@@ -7,15 +7,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var versionCommitOnly bool
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show version information",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(cli.Version())
+		out := cli.Version()
+		if versionCommitOnly {
+			out = cli.RawCommit()
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), out)
 	},
 }
 
 func init() {
+	versionCmd.Flags().BoolVar(&versionCommitOnly, "commit", false, "Print only the git commit SHA")
 	rootCmd.AddCommand(versionCmd)
 }

--- a/cmd/iterion/version.go
+++ b/cmd/iterion/version.go
@@ -10,19 +10,35 @@ import (
 
 var versionCommitOnly bool
 
+// commitDisplayLen mirrors the truncation appinfo.FullVersion applies to the
+// `+<sha>` suffix, so `--commit` always equals the SHA `iterion version`
+// prints. The raw value's width is build-dependent — a plain `go build` infers
+// the full 40-char vcs.revision, release builds inject `git rev-parse --short`,
+// and the container images pass a 40-char `github.sha` — which would otherwise
+// make the flag's output vary with the binary's provenance.
+const commitDisplayLen = 12
+
+// versionInfo is the seam tests stub. A `go test` binary carries no VCS
+// stamping and no ldflags, so cli.RawCommit() is always empty under test and
+// the populated-SHA path would be unreachable end to end.
+var versionInfo = func() (full, commit string) { return cli.Version(), cli.RawCommit() }
+
 // versionOutput resolves what `iterion version` prints for the given build
-// metadata. It takes both values as arguments rather than reading them from
-// cli: a test binary carries no injected SHA, so the populated-commit branch
-// is unreachable from a test that drives the command end to end.
+// metadata.
 func versionOutput(full, commit string, commitOnly bool) (string, error) {
 	if !commitOnly {
 		return full, nil
 	}
-	// A build with neither an -X ldflag nor VCS build info carries no SHA.
-	// Printing an empty line would hand a script the empty string as if it
-	// were the commit — fail visibly instead.
-	if commit = strings.TrimSpace(commit); commit == "" {
+	// A build with neither an -X ldflag nor VCS build info carries no SHA, and
+	// the Dockerfile defaults `ARG COMMIT=unknown` so a bare `docker build .`
+	// injects that sentinel. Printing either would hand a script a bogus value
+	// as if it were the commit — fail visibly instead.
+	commit = strings.TrimSpace(commit)
+	if commit == "" || commit == "unknown" {
 		return "", fmt.Errorf("this binary carries no commit SHA (built without -ldflags -X ...appinfo.Commit and without VCS build info)")
+	}
+	if len(commit) > commitDisplayLen {
+		commit = commit[:commitDisplayLen]
 	}
 	return commit, nil
 }
@@ -32,7 +48,8 @@ var versionCmd = &cobra.Command{
 	Short: "Show version information",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		out, err := versionOutput(cli.Version(), cli.RawCommit(), versionCommitOnly)
+		full, commit := versionInfo()
+		out, err := versionOutput(full, commit, versionCommitOnly)
 		if err != nil {
 			return err
 		}
@@ -42,6 +59,6 @@ var versionCmd = &cobra.Command{
 }
 
 func init() {
-	versionCmd.Flags().BoolVar(&versionCommitOnly, "commit", false, "Print only the git commit SHA")
+	versionCmd.Flags().BoolVar(&versionCommitOnly, "commit", false, "Print only the git commit SHA (as embedded in `iterion version`)")
 	rootCmd.AddCommand(versionCmd)
 }

--- a/cmd/iterion/version.go
+++ b/cmd/iterion/version.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/SocialGouv/iterion/pkg/cli"
 	"github.com/spf13/cobra"
@@ -9,16 +10,34 @@ import (
 
 var versionCommitOnly bool
 
+// versionOutput resolves what `iterion version` prints for the given build
+// metadata. It takes both values as arguments rather than reading them from
+// cli: a test binary carries no injected SHA, so the populated-commit branch
+// is unreachable from a test that drives the command end to end.
+func versionOutput(full, commit string, commitOnly bool) (string, error) {
+	if !commitOnly {
+		return full, nil
+	}
+	// A build with neither an -X ldflag nor VCS build info carries no SHA.
+	// Printing an empty line would hand a script the empty string as if it
+	// were the commit — fail visibly instead.
+	if commit = strings.TrimSpace(commit); commit == "" {
+		return "", fmt.Errorf("this binary carries no commit SHA (built without -ldflags -X ...appinfo.Commit and without VCS build info)")
+	}
+	return commit, nil
+}
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show version information",
 	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		out := cli.Version()
-		if versionCommitOnly {
-			out = cli.RawCommit()
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out, err := versionOutput(cli.Version(), cli.RawCommit(), versionCommitOnly)
+		if err != nil {
+			return err
 		}
 		fmt.Fprintln(cmd.OutOrStdout(), out)
+		return nil
 	},
 }
 

--- a/cmd/iterion/version_test.go
+++ b/cmd/iterion/version_test.go
@@ -8,6 +8,16 @@ import (
 	"github.com/SocialGouv/iterion/pkg/cli"
 )
 
+// stubVersionInfo pins the build metadata the command reads, so the
+// populated-SHA path runs through the real cobra wiring. Without it that path
+// is unreachable: a `go test` binary carries no VCS stamping and no ldflags.
+func stubVersionInfo(t *testing.T, full, commit string) {
+	t.Helper()
+	prev := versionInfo
+	versionInfo = func() (string, string) { return full, commit }
+	t.Cleanup(func() { versionInfo = prev })
+}
+
 // runVersion drives the real rootCmd (the only correct way — versionCmd has a
 // parent, so cobra's Execute delegates to root and ignores args set directly on
 // the subcommand) and returns its combined stdout/stderr plus the exec error.
@@ -44,6 +54,17 @@ func TestVersionOutput(t *testing.T) {
 		{name: "commit flag trims surrounding space", full: "v1.2.3", commit: "  abc1234\n", commitOnly: true, want: "abc1234"},
 		{name: "commit flag errors when no SHA was injected", full: "dev", commit: "", commitOnly: true, wantErr: true},
 		{name: "default is unaffected by a missing SHA", full: "dev", commit: "", want: "dev"},
+		// A plain `go build` infers the full 40-char vcs.revision, and the
+		// container images inject a 40-char github.sha — both must agree with
+		// the 12-char suffix `iterion version` prints.
+		{
+			name: "commit flag truncates a full SHA to the width version prints",
+			full: "dev+e8adfa3f8823", commit: "e8adfa3f8823b262fbce5d2ed7ff9918d64b8591",
+			commitOnly: true, want: "e8adfa3f8823",
+		},
+		// The Dockerfile defaults ARG COMMIT=unknown, so a bare `docker build .`
+		// injects that sentinel rather than nothing.
+		{name: "commit flag rejects the Dockerfile unknown sentinel", full: "dev+unknown", commit: "unknown", commitOnly: true, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -67,35 +88,42 @@ func TestVersionOutput(t *testing.T) {
 	}
 }
 
-// TestVersionCommand_CommitFlag verifies the cobra wiring: `--commit` reaches
-// versionOutput with the flag set, and the result is printed on a single line
-// with no version prefix. A test binary usually has no SHA, in which case the
-// command must fail rather than print an empty line.
+// TestVersionCommand_CommitFlag verifies the cobra wiring end to end on a
+// build that DOES carry a SHA: `--commit` reaches versionOutput with the flag
+// set, and the result is a single bare line with no version prefix.
 func TestVersionCommand_CommitFlag(t *testing.T) {
-	got, err := runVersion(t, "version", "--commit")
+	const sha = "e8adfa3f8823b262fbce5d2ed7ff9918d64b8591"
+	stubVersionInfo(t, "v3.10.3+e8adfa3f8823", sha)
 
-	if strings.TrimSpace(cli.RawCommit()) == "" {
-		if err == nil {
-			t.Fatalf("expected an error with no commit SHA injected, got output %q", got)
-		}
-		return
-	}
+	got, err := runVersion(t, "version", "--commit")
 	if err != nil {
 		t.Fatalf("[version --commit] failed: %v", err)
 	}
-	if got != cli.RawCommit() {
-		t.Errorf("commit output = %q, want %q", got, cli.RawCommit())
+	if want := sha[:commitDisplayLen]; got != want {
+		t.Errorf("commit output = %q, want %q", got, want)
 	}
 	if strings.Contains(got, "\n") {
 		t.Errorf("expected single line, got multi-line output: %q", got)
 	}
-	if cli.RawCommit() != cli.Version() && strings.Contains(got, cli.Version()) {
-		t.Errorf("commit output leaked full version string: %q", got)
+	if strings.Contains(got, "v3.10.3") {
+		t.Errorf("commit output leaked the version string: %q", got)
+	}
+}
+
+// TestVersionCommand_CommitFlagNoSHA covers the other build shape through the
+// same wiring: no injected SHA must fail rather than print an empty line.
+func TestVersionCommand_CommitFlagNoSHA(t *testing.T) {
+	stubVersionInfo(t, "dev", "")
+
+	got, err := runVersion(t, "version", "--commit")
+	if err == nil {
+		t.Fatalf("expected an error with no commit SHA injected, got output %q", got)
 	}
 }
 
 // TestVersionCommand_DefaultUnchanged guards the additive promise: with no
-// flag, the command still prints the full human-readable version string.
+// flag, the command still prints the full human-readable version string of the
+// real build.
 func TestVersionCommand_DefaultUnchanged(t *testing.T) {
 	got, err := runVersion(t, "version")
 	if err != nil {

--- a/cmd/iterion/version_test.go
+++ b/cmd/iterion/version_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/cli"
+)
+
+// runVersion drives the real rootCmd (the only correct way — versionCmd has a
+// parent, so cobra's Execute delegates to root and ignores args set directly on
+// the subcommand) and returns its combined stdout/stderr.
+func runVersion(t *testing.T, args ...string) string {
+	t.Helper()
+	t.Cleanup(func() {
+		versionCommitOnly = false
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs(args)
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("%v failed: %v", args, err)
+	}
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+// TestVersionCommand_CommitFlag verifies that `iterion version --commit`
+// prints ONLY the bare commit SHA on a single line — no version prefix,
+// no extra text — so scripts can capture the SHA directly.
+func TestVersionCommand_CommitFlag(t *testing.T) {
+	got := runVersion(t, "version", "--commit")
+
+	if got != cli.RawCommit() {
+		t.Errorf("commit output = %q, want %q", got, cli.RawCommit())
+	}
+	if strings.Contains(got, "\n") {
+		t.Errorf("expected single line, got multi-line output: %q", got)
+	}
+	if cli.RawCommit() != cli.Version() && strings.Contains(got, cli.Version()) {
+		t.Errorf("commit output leaked full version string: %q", got)
+	}
+}
+
+// TestVersionCommand_DefaultUnchanged guards the additive promise: with no
+// flag, the command still prints the full human-readable version string.
+func TestVersionCommand_DefaultUnchanged(t *testing.T) {
+	got := runVersion(t, "version")
+
+	if got != cli.Version() {
+		t.Errorf("default output = %q, want %q", got, cli.Version())
+	}
+}

--- a/cmd/iterion/version_test.go
+++ b/cmd/iterion/version_test.go
@@ -10,8 +10,8 @@ import (
 
 // runVersion drives the real rootCmd (the only correct way — versionCmd has a
 // parent, so cobra's Execute delegates to root and ignores args set directly on
-// the subcommand) and returns its combined stdout/stderr.
-func runVersion(t *testing.T, args ...string) string {
+// the subcommand) and returns its combined stdout/stderr plus the exec error.
+func runVersion(t *testing.T, args ...string) (string, error) {
 	t.Helper()
 	t.Cleanup(func() {
 		versionCommitOnly = false
@@ -23,18 +23,66 @@ func runVersion(t *testing.T, args ...string) string {
 	rootCmd.SetOut(&buf)
 	rootCmd.SetErr(&buf)
 	rootCmd.SetArgs(args)
-	if err := rootCmd.Execute(); err != nil {
-		t.Fatalf("%v failed: %v", args, err)
-	}
-	return strings.TrimRight(buf.String(), "\n")
+	err := rootCmd.Execute()
+	return strings.TrimRight(buf.String(), "\n"), err
 }
 
-// TestVersionCommand_CommitFlag verifies that `iterion version --commit`
-// prints ONLY the bare commit SHA on a single line — no version prefix,
-// no extra text — so scripts can capture the SHA directly.
-func TestVersionCommand_CommitFlag(t *testing.T) {
-	got := runVersion(t, "version", "--commit")
+// TestVersionOutput covers both build shapes directly. A test binary carries
+// no injected SHA, so driving the command end to end can only ever exercise
+// the empty-commit branch — hence the pure function.
+func TestVersionOutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		full       string
+		commit     string
+		commitOnly bool
+		want       string
+		wantErr    bool
+	}{
+		{name: "default prints the full version", full: "v1.2.3+abc1234", commit: "abc1234", want: "v1.2.3+abc1234"},
+		{name: "commit flag prints only the SHA", full: "v1.2.3+abc1234", commit: "abc1234", commitOnly: true, want: "abc1234"},
+		{name: "commit flag trims surrounding space", full: "v1.2.3", commit: "  abc1234\n", commitOnly: true, want: "abc1234"},
+		{name: "commit flag errors when no SHA was injected", full: "dev", commit: "", commitOnly: true, wantErr: true},
+		{name: "default is unaffected by a missing SHA", full: "dev", commit: "", want: "dev"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := versionOutput(tt.full, tt.commit, tt.commitOnly)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got output %q", got)
+				}
+				if got != "" {
+					t.Errorf("expected no output alongside the error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("output = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
 
+// TestVersionCommand_CommitFlag verifies the cobra wiring: `--commit` reaches
+// versionOutput with the flag set, and the result is printed on a single line
+// with no version prefix. A test binary usually has no SHA, in which case the
+// command must fail rather than print an empty line.
+func TestVersionCommand_CommitFlag(t *testing.T) {
+	got, err := runVersion(t, "version", "--commit")
+
+	if strings.TrimSpace(cli.RawCommit()) == "" {
+		if err == nil {
+			t.Fatalf("expected an error with no commit SHA injected, got output %q", got)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("[version --commit] failed: %v", err)
+	}
 	if got != cli.RawCommit() {
 		t.Errorf("commit output = %q, want %q", got, cli.RawCommit())
 	}
@@ -49,8 +97,10 @@ func TestVersionCommand_CommitFlag(t *testing.T) {
 // TestVersionCommand_DefaultUnchanged guards the additive promise: with no
 // flag, the command still prints the full human-readable version string.
 func TestVersionCommand_DefaultUnchanged(t *testing.T) {
-	got := runVersion(t, "version")
-
+	got, err := runVersion(t, "version")
+	if err != nil {
+		t.Fatalf("[version] failed: %v", err)
+	}
 	if got != cli.Version() {
 		t.Errorf("default output = %q, want %q", got, cli.Version())
 	}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -399,4 +399,4 @@ The watcher evaluates on turn boundaries/monitor matches and injects node-scoped
 
 `iterion bench asymptote` accepts primary `--runs`, optional `--variant-runs`, a required `--judge-node`, judge field/threshold, loop selector, labels, title, per-run detail, and output path. See [asymptote bench](asymptote-bench.md).
 
-`iterion completion <bash|zsh|fish|powershell>` emits shell completion. `iterion version` prints build version and commit.
+`iterion completion <bash|zsh|fish|powershell>` emits shell completion. `iterion version` prints build version and commit; `--commit` prints only the SHA, truncated to the same 12 characters the default output embeds, and exits non-zero when the build carries none (no `-ldflags` injection, no VCS build info, or the Dockerfile's `unknown` default) rather than handing a script an empty or bogus value.


### PR DESCRIPTION
Adds a `--commit` boolean flag to `iterion version`. When set, the command prints **only** the bare short git commit SHA (injected via ldflags, exposed through `cli.RawCommit()`) on a single line — letting scripts capture the SHA directly without parsing the full human-readable version string.

- Default `iterion version` output is **unchanged** (purely additive).
- Output now flows through `cmd.OutOrStdout()` so the command is testable.
- New `cmd/iterion/version_test.go` covers the flag (single-line bare SHA, no version-string leak) and guards the additive promise.

Scope: `cmd/iterion/version.go` (+ test).

Closes the feature requested in #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)