### PR TITLE
ci(image): build via buildkit-operator (amd64) + native arm64 + Dockerfile cache mounts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,39 +1,72 @@
-# Build artefacts
+# .dockerignore for the ROOT build context (main Dockerfile only — sandbox/*
+# images use their own context dir, unaffected by this file). Keep the context
+# tiny: only what the Dockerfile COPYs needs to be sent to the daemon.
+# The Dockerfile COPYs: package.json, pnpm-lock.yaml, pnpm-workspace.yaml,
+# studio/, go.mod, go.sum, vendor/, cmd/, pkg/, bots/, docker/llm-clis/. Keep
+# those; ignore everything else below.
+
+# --- Dependencies / build output (rebuilt fresh in-image; huge if shipped) ---
+**/node_modules/
+studio/dist/
+studio/.vite/
+editor/dist/
+editor/node_modules/
+pkg/server/static/
+dist/
+
+# --- Build artefacts ---
 iterion
 iterion-desktop
 build/
 cmd/iterion-desktop/build/
+*.exe
 
-# IDE / editors
-.vscode/
-.idea/
+# --- Source dirs NOT needed by the main image (not COPYed / not imported) ---
+e2e/
+examples/
+charts/
+scripts/
+tooling/
+docs/
+.devcontainer/
+sandbox/
 
-# Local state — never bake into the image
-.iterion/
-.devbox/
-.works/
-.plans/
-
-# Editor build output (we rebuild fresh in the image)
-editor/dist/
-editor/node_modules/
-pkg/server/static/
-
-# Test caches
+# --- Test files + caches (the binary never compiles them) ---
+**/*_test.go
+**/testdata/
 *.coverprofile
 *.test
-testdata/
+cover.out
+coverage/
 
-# Git
-.git/
-.gitignore
-.github/
+# --- Local dev state — never bake into the image ---
+.iterion/
+.devbox/
+.direnv/
+.envrc
+.works/
+.plans/
+.claude/
+.repos/
 
-# OS
+# --- Tooling configs not used at build time ---
+Taskfile.yml
+devbox.json
+devbox.lock
+.golangci*
+renovate.json
+
+# --- IDE / editors / OS ---
+.vscode/
+.idea/
 .DS_Store
 *.swp
 
-# Docs that don't change image behaviour
-docs/
-README.md
-CHANGELOG.md
+# --- Git / CI / docs metadata ---
+.git/
+.gitignore
+.dockerignore
+.github/
+*.md
+LICENSE
+*.log

--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -118,7 +118,7 @@ jobs:
         uses: socialgouv/buildkit-operator@20ed87560a925cc4aa3ef453e59aa10dce58975c
         with:
           buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
-          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST || 'bkod.fabrique.social.gouv.fr' }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST || 'bko.fabrique.social.gouv.fr' }}
           ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
           cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
           key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}

--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -41,6 +41,11 @@ on:
         description: "True on pull_request events (validate-only: local amd64 build, no operator, no push)."
         required: true
         type: boolean
+      multiarch:
+        description: "Build arm64 + sign + SBOM (true on main/tags). False on feature-branch pushes = amd64-only fast path."
+        required: false
+        type: boolean
+        default: false
 
 env:
   REGISTRY: ghcr.io
@@ -146,7 +151,8 @@ jobs:
   # staging tag. gha layer cache keyed per image+arch.
   # --------------------------------------------------------------------------
   arm64:
-    if: ${{ !inputs.is-pr }}
+    # Only on main/tags (multiarch). Feature-branch pushes stay amd64-only (fast).
+    if: ${{ !inputs.is-pr && inputs.multiarch }}
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
@@ -185,15 +191,25 @@ jobs:
           build-args: ${{ inputs.build-args }}
           provenance: mode=max
           sbom: true
-          cache-from: type=gha,scope=${{ inputs.image-name }}-arm64
-          cache-to: type=gha,mode=max,scope=${{ inputs.image-name }}-arm64
+          # Registry cache persists layers across runs more durably than gha (no
+          # 10 GB eviction); gha kept as a fast secondary. The arm64 leg has no
+          # warm operator daemon, so cross-run layer cache is its main lever.
+          cache-from: |
+            type=registry,ref=${{ env.IMAGE_REF }}:buildcache-arm64
+            type=gha,scope=${{ inputs.image-name }}-arm64
+          cache-to: |
+            type=registry,ref=${{ env.IMAGE_REF }}:buildcache-arm64,mode=max
+            type=gha,mode=max,scope=${{ inputs.image-name }}-arm64
 
   # --------------------------------------------------------------------------
   # merge — stitch the two per-arch staging manifests into the published
   # multi-arch index (final tags), then cosign-sign + SBOM-attest the index.
   # --------------------------------------------------------------------------
   merge:
-    if: ${{ !inputs.is-pr }}
+    # Runs once amd64 succeeded, whether arm64 ran (multiarch) or was skipped
+    # (feature branch). always() prevents auto-skip on the skipped arm64 need; the
+    # explicit guards then require amd64 success and a non-failing arm64.
+    if: ${{ always() && !inputs.is-pr && needs.amd64.result == 'success' && needs.arm64.result != 'failure' }}
     needs: [amd64, arm64]
     runs-on: ubuntu-latest
     permissions:
@@ -231,24 +247,30 @@ jobs:
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
           SHA: ${{ github.sha }}
+          MULTIARCH: ${{ inputs.multiarch }}
         run: |
           set -eux
           tflags=""
           for t in $TAGS; do tflags="$tflags -t $t"; done
+          # amd64 always; arm64 only when this is a multiarch (main/tag) build.
+          sources="${IMAGE_REF}:${SHA}-amd64"
+          [ "$MULTIARCH" = "true" ] && sources="$sources ${IMAGE_REF}:${SHA}-arm64"
           # shellcheck disable=SC2086
-          docker buildx imagetools create $tflags \
-            "${IMAGE_REF}:${SHA}-amd64" \
-            "${IMAGE_REF}:${SHA}-arm64"
+          docker buildx imagetools create $tflags $sources
           # The index digest is the authoritative address we sign + attest (the
           # per-arch staging tags stay — the index references their manifests).
           first_tag="$(printf '%s\n' $TAGS | head -n1)"
           digest="$(docker buildx imagetools inspect "$first_tag" --format '{{.Manifest.Digest}}')"
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
+      # Sign + SBOM only for published multi-arch (main/tags) images. Feature-branch
+      # builds skip them for speed — they're ephemeral branch tags, not releases.
       - name: Install cosign
+        if: ${{ inputs.multiarch }}
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
       - name: Generate SBOM (syft) for the index
+        if: ${{ inputs.multiarch }}
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.IMAGE_REF }}@${{ steps.index.outputs.digest }}
@@ -258,6 +280,7 @@ jobs:
           upload-release-assets: false
 
       - name: Sign index + attest SBOM (cosign keyless OIDC)
+        if: ${{ inputs.multiarch }}
         env:
           DIGEST: ${{ steps.index.outputs.digest }}
         run: |

--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -121,7 +121,7 @@ jobs:
         # Pin moved forward on each operator release. This SHA must be pushed to
         # github.com/SocialGouv/buildkit-operator (branch feat/build-args-passthrough)
         # for `uses:` to resolve it — it carries the --build-arg passthrough.
-        uses: socialgouv/buildkit-operator@20ed87560a925cc4aa3ef453e59aa10dce58975c
+        uses: socialgouv/buildkit-operator@8707e7f9d2a3baeeb5154bfbd0ae114bccfa4e58
         with:
           buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
           gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST || 'bkod.fabrique.social.gouv.fr' }}

--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -92,6 +92,12 @@ jobs:
       contents: read
       packages: write
       id-token: write # GitHub OIDC identity for buildd /route auth
+    env:
+      # Wait for the daemon to be Ready (poll /prewarm) before pointing buildx at
+      # it — a freshly-provisioned (cold-start) daemon otherwise refuses the gRPC
+      # connection and buildx fails with "context deadline exceeded". Job-level so
+      # the operator's composite build.sh inherits it.
+      BUILDKIT_OPERATOR_WAIT_WARM: "1"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -1,0 +1,261 @@
+# Reusable image build — buildkit-operator composite (amd64 on the in-house
+# buildkit-operator daemon, arm64 on a native GitHub arm runner, merged into one
+# multi-arch index and cosign-signed). Called once per image by image.yml.
+#
+# Why composite: the in-house buildkit-operator (Ministères Sociaux, gateway
+# bkod.fabrique.social.gouv.fr) currently has a single amd64 node, so arm64 can't
+# route to it. amd64 builds on the warm daemon (persistent cache mounts + S3 cold
+# cache — the dogfood path); arm64 builds natively on ubuntu-24.04-arm (no QEMU
+# emulation). The two per-arch manifests are stitched into the published index.
+#
+# PR builds DON'T touch the operator: fork PRs get no secrets (mTLS material is
+# withheld), so a PR validates with a plain local buildx --load (amd64 only),
+# exactly like the pre-migration workflow.
+name: build-image (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        description: "Image repo name without registry/owner (e.g. iterion, iterion-sandbox-slim)."
+        required: true
+        type: string
+      routing-name:
+        description: "buildkit-operator `name` routing component — gives this image its own warm daemon + cache."
+        required: true
+        type: string
+      context:
+        description: "Build context path."
+        required: true
+        type: string
+      file:
+        description: "Dockerfile path."
+        required: true
+        type: string
+      build-args:
+        description: "Build args, one KEY=VALUE per line."
+        required: false
+        type: string
+        default: ""
+      is-pr:
+        description: "True on pull_request events (validate-only: local amd64 build, no operator, no push)."
+        required: true
+        type: boolean
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  # --------------------------------------------------------------------------
+  # PR validation — plain local buildx, amd64 only, --load (no push, no secrets).
+  # Mirrors the pre-migration PR behaviour; works for fork PRs that get no mTLS.
+  # --------------------------------------------------------------------------
+  pr-validate:
+    if: ${{ inputs.is-pr }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build (amd64, load, no push)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.file }}
+          platforms: linux/amd64
+          push: false
+          load: true
+          build-args: ${{ inputs.build-args }}
+          cache-from: type=gha,scope=${{ inputs.image-name }}-pr
+          cache-to: type=gha,mode=max,scope=${{ inputs.image-name }}-pr
+
+  # --------------------------------------------------------------------------
+  # amd64 — built on the in-house buildkit-operator warm daemon, pushed to a
+  # per-arch staging tag the merge job stitches into the published index.
+  # --------------------------------------------------------------------------
+  amd64:
+    if: ${{ !inputs.is-pr }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # GitHub OIDC identity for buildd /route auth
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Compute lowercase image ref
+        run: echo "IMAGE_REF=$(echo '${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ inputs.image-name }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Compute OCI labels
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ env.IMAGE_REF }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build amd64 on buildkit-operator
+        # Pin moved forward on each operator release. This SHA must be pushed to
+        # github.com/SocialGouv/buildkit-operator (branch feat/build-args-passthrough)
+        # for `uses:` to resolve it — it carries the --build-arg passthrough.
+        uses: socialgouv/buildkit-operator@20ed87560a925cc4aa3ef453e59aa10dce58975c
+        with:
+          buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST || 'bkod.fabrique.social.gouv.fr' }}
+          ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
+          cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
+          key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}
+          token: ${{ secrets.BUILDKIT_OPERATOR_TOKEN }}
+          name: ${{ inputs.routing-name }}
+          arch: amd64
+          context: ${{ inputs.context }}
+          file: ${{ inputs.file }}
+          build-args: ${{ inputs.build-args }}
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.IMAGE_REF }}:${{ github.sha }}-amd64
+          push: true
+          provenance: mode=max
+          sbom: true
+          sign: false # the published index is signed once in the merge job
+
+  # --------------------------------------------------------------------------
+  # arm64 — native build on a GitHub arm runner (no QEMU), pushed to a per-arch
+  # staging tag. gha layer cache keyed per image+arch.
+  # --------------------------------------------------------------------------
+  arm64:
+    if: ${{ !inputs.is-pr }}
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Compute lowercase image ref
+        run: echo "IMAGE_REF=$(echo '${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ inputs.image-name }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Compute OCI labels
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ env.IMAGE_REF }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build arm64 (native)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.file }}
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.IMAGE_REF }}:${{ github.sha }}-arm64
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ inputs.build-args }}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha,scope=${{ inputs.image-name }}-arm64
+          cache-to: type=gha,mode=max,scope=${{ inputs.image-name }}-arm64
+
+  # --------------------------------------------------------------------------
+  # merge — stitch the two per-arch staging manifests into the published
+  # multi-arch index (final tags), then cosign-sign + SBOM-attest the index.
+  # --------------------------------------------------------------------------
+  merge:
+    if: ${{ !inputs.is-pr }}
+    needs: [amd64, arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # cosign keyless
+    steps:
+      - name: Compute lowercase image ref
+        run: echo "IMAGE_REF=$(echo '${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ inputs.image-name }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+      - name: Compute tags
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ env.IMAGE_REF }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=edge,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Login to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch index from per-arch staging manifests
+        id: index
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -eux
+          tflags=""
+          for t in $TAGS; do tflags="$tflags -t $t"; done
+          # shellcheck disable=SC2086
+          docker buildx imagetools create $tflags \
+            "${IMAGE_REF}:${SHA}-amd64" \
+            "${IMAGE_REF}:${SHA}-arm64"
+          # The index digest is the authoritative address we sign + attest (the
+          # per-arch staging tags stay — the index references their manifests).
+          first_tag="$(printf '%s\n' $TAGS | head -n1)"
+          digest="$(docker buildx imagetools inspect "$first_tag" --format '{{.Manifest.Digest}}')"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
+
+      - name: Generate SBOM (syft) for the index
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ env.IMAGE_REF }}@${{ steps.index.outputs.digest }}
+          format: spdx-json
+          output-file: image.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Sign index + attest SBOM (cosign keyless OIDC)
+        env:
+          DIGEST: ${{ steps.index.outputs.digest }}
+        run: |
+          # Fulcio + Rekor intermittently rate-limit/time out; retry with backoff.
+          sign() { for a in 1 2 3 4 5; do "$@" && return 0; echo "::warning::cosign attempt $a failed (Sigstore transient?); retry in $((a*10))s"; sleep $((a*10)); done; return 1; }
+          sign cosign sign --yes "${IMAGE_REF}@${DIGEST}" || { echo "::error::cosign sign failed"; exit 1; }
+          sign cosign attest --yes --predicate image.spdx.json --type spdx "${IMAGE_REF}@${DIGEST}" || { echo "::error::cosign attest failed"; exit 1; }

--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -124,7 +124,7 @@ jobs:
         uses: socialgouv/buildkit-operator@20ed87560a925cc4aa3ef453e59aa10dce58975c
         with:
           buildd-url: ${{ vars.BUILDKIT_OPERATOR_BUILDD_URL }}
-          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST || 'bko.fabrique.social.gouv.fr' }}
+          gateway-host: ${{ vars.BUILDKIT_OPERATOR_GATEWAY_HOST || 'bkod.fabrique.social.gouv.fr' }}
           ca: ${{ secrets.BUILDKIT_OPERATOR_CA }}
           cert: ${{ secrets.BUILDKIT_OPERATOR_CERT }}
           key: ${{ secrets.BUILDKIT_OPERATOR_KEY }}

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,5 +1,10 @@
 name: 🐳 Container Image
 
+# Each image is built by the reusable _build-image.yml: amd64 on the in-house
+# buildkit-operator warm daemon, arm64 natively on a GitHub arm runner, merged
+# into one multi-arch index and cosign-signed. PR events validate locally
+# (amd64 --load, no operator/secrets). See _build-image.yml for the rationale.
+
 on:
   push:
     branches:
@@ -12,6 +17,7 @@ on:
       - "docker/**"
       - "sandbox/**"
       - ".github/workflows/image.yml"
+      - ".github/workflows/_build-image.yml"
       - "go.mod"
       - "go.sum"
   workflow_dispatch:
@@ -25,391 +31,81 @@ concurrency:
 permissions:
   contents: read
   packages: write
-  # cosign keyless OIDC signing + SBOM attestations need an OIDC token
-  # at workflow level. The signing step itself runs in jobs that
-  # explicitly mount this permission.
+  # cosign keyless OIDC signing + the operator's GitHub OIDC /route auth need an
+  # OIDC token at workflow level; reusable-workflow jobs request it per-job.
   id-token: write
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/iterion
-
 jobs:
+  # Shared values: lowercase owner (OCI refs must be lowercase) + the base image
+  # tag the sandbox chain bakes in — the release tag on a tag push, else the
+  # rolling `edge` (also `edge` on PRs, which reference the published base).
+  prep:
+    runs-on: ubuntu-latest
+    outputs:
+      owner_lc: ${{ steps.vars.outputs.owner_lc }}
+      base_tag: ${{ steps.vars.outputs.base_tag }}
+    steps:
+      - id: vars
+        run: |
+          echo "owner_lc=$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            echo "base_tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "base_tag=edge" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Main iterion image.
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    needs: prep
+    uses: ./.github/workflows/_build-image.yml
+    secrets: inherit
+    with:
+      image-name: iterion
+      routing-name: iterion
+      context: .
+      file: Dockerfile
+      build-args: |
+        VERSION=${{ github.ref_name }}
+        COMMIT=${{ github.sha }}
+      is-pr: ${{ github.event_name == 'pull_request' }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute lowercase image ref
-        # OCI references must be lowercase. github.repository_owner
-        # preserves case (e.g. SocialGouv) — feeding the raw value to
-        # `cosign sign` / `cosign attest` produces "could not parse
-        # reference". Lowercase once into REGISTRY_IMAGE and reuse.
-        run: |
-          echo "REGISTRY_IMAGE=$(echo '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
-
-      - name: Compute tags
-        id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=raw,value=edge,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-
-      - name: Build (and push when not a PR)
-        id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: .
-          file: Dockerfile
-          # PRs build linux/amd64 only — cross-arch QEMU emulation
-          # roughly doubles the wall-clock and the result is thrown
-          # away anyway. Branch and tag pushes still build both archs.
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
-          push: ${{ github.event_name != 'pull_request' }}
-          load: ${{ github.event_name == 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ github.ref_name }}
-            COMMIT=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      # ── Supply-chain attestation (Sprint-8 hardening) ─────────────
-      # Only sign + attest when we actually pushed an image (skipped on
-      # PR builds that only `load` into the local daemon). The digest is
-      # the unique address — signing the tag would let a later push
-      # under the same tag claim the signature.
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
-
-      - name: Generate SBOM (syft)
-        if: github.event_name != 'pull_request'
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
-        with:
-          image: ${{ env.REGISTRY_IMAGE }}@${{ steps.build.outputs.digest }}
-          format: spdx-json
-          output-file: iterion-image.spdx.json
-          upload-artifact: false
-          upload-release-assets: false
-
-      - name: Sign image (cosign keyless OIDC)
-        if: github.event_name != 'pull_request'
-        run: |
-          # cosign keyless hits Fulcio + Rekor (public Sigstore services) which
-          # intermittently rate-limit/time out. Retry with backoff so a transient
-          # Sigstore hiccup doesn't fail the whole image run.
-          for a in 1 2 3 4 5; do
-            cosign sign --yes "${REGISTRY_IMAGE}@${DIGEST}" && exit 0
-            echo "::warning::cosign sign attempt $a failed (Sigstore transient?); retry in $((a*10))s"; sleep $((a*10))
-          done
-          echo "::error::cosign sign failed after 5 attempts"; exit 1
-        env:
-          DIGEST: ${{ steps.build.outputs.digest }}
-
-      - name: Attest SBOM
-        if: github.event_name != 'pull_request'
-        run: |
-          for a in 1 2 3 4 5; do
-            cosign attest --yes \
-              --predicate iterion-image.spdx.json \
-              --type spdx \
-              "${REGISTRY_IMAGE}@${DIGEST}" && exit 0
-            echo "::warning::cosign attest attempt $a failed (Sigstore transient?); retry in $((a*10))s"; sleep $((a*10))
-          done
-          echo "::error::cosign attest failed after 5 attempts"; exit 1
-        env:
-          DIGEST: ${{ steps.build.outputs.digest }}
-
-  # ----------------------------------------------------------------------
-  # iterion-sandbox-slim — default image used by `sandbox: auto` when no
-  # .devcontainer/devcontainer.json is found. Pinned to the iterion
-  # release tag, with a rolling `edge` tag tracking main.
-  # ----------------------------------------------------------------------
+  # iterion-sandbox-slim — bakes in the iterion binary via COPY --from, so it
+  # needs the iterion image (and its :edge / :vX.Y.Z tag) published first.
   build-sandbox-slim:
-    runs-on: ubuntu-latest
-    # needs: build so the iterion image (and its :edge / :vX.Y.Z tag) is pushed
-    # before this Dockerfile bakes it in via COPY --from (the sandboxed claw
-    # runner needs `iterion` on PATH inside the pod — k8s can't bind-mount it).
-    needs: build
-    env:
-      SANDBOX_IMAGE_NAME: ${{ github.repository_owner }}/iterion-sandbox-slim
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    needs: [prep, build]
+    uses: ./.github/workflows/_build-image.yml
+    secrets: inherit
+    with:
+      image-name: iterion-sandbox-slim
+      routing-name: iterion-sandbox-slim
+      context: sandbox/slim
+      file: sandbox/slim/Dockerfile
+      build-args: ITERION_IMAGE=ghcr.io/${{ needs.prep.outputs.owner_lc }}/iterion:${{ needs.prep.outputs.base_tag }}
+      is-pr: ${{ github.event_name == 'pull_request' }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute lowercase image ref
-        run: |
-          echo "SANDBOX_IMAGE_REF=$(echo '${{ env.REGISTRY }}/${{ env.SANDBOX_IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
-          # iterion image ref to bake in — matches this build's tag: the release
-          # version on a tag push, else the rolling :edge tracking main.
-          IT=$(echo '${{ env.REGISTRY }}/${{ github.repository_owner }}/iterion' | tr '[:upper:]' '[:lower:]')
-          # Use the canonical env vars, not GitHub-expression interpolation: a
-          # crafted tag name (github.ref_name) inlined into this shell would be a
-          # GHA script-injection on tag push. $GITHUB_REF_NAME is the same value,
-          # injection-safe. (Do NOT write the expression delimiters in a run:
-          # comment — GitHub evaluates them even here, and an invalid one fails
-          # the whole workflow to compile.)
-          if [ "$GITHUB_REF_TYPE" = 'tag' ]; then BAKE_REF="$GITHUB_REF_NAME"; else BAKE_REF='edge'; fi
-          echo "ITERION_BAKE_IMAGE=${IT}:${BAKE_REF}" >> "$GITHUB_ENV"
-
-      - name: Compute tags
-        id: meta-slim
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
-        with:
-          images: ${{ env.SANDBOX_IMAGE_REF }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=raw,value=edge,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-
-      - name: Build (and push when not a PR)
-        id: build-slim
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: sandbox/slim
-          file: sandbox/slim/Dockerfile
-          build-args: |
-            ITERION_IMAGE=${{ env.ITERION_BAKE_IMAGE }}
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
-          push: ${{ github.event_name != 'pull_request' }}
-          load: ${{ github.event_name == 'pull_request' }}
-          tags: ${{ steps.meta-slim.outputs.tags }}
-          labels: ${{ steps.meta-slim.outputs.labels }}
-          cache-from: type=gha,scope=sandbox-slim
-          cache-to: type=gha,mode=max,scope=sandbox-slim
-
-      - name: Install cosign (slim)
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
-
-      - name: Sign sandbox-slim image
-        if: github.event_name != 'pull_request'
-        run: |
-          for a in 1 2 3 4 5; do
-            cosign sign --yes "${SANDBOX_IMAGE_REF}@${DIGEST}" && exit 0
-            echo "::warning::cosign sign attempt $a failed (Sigstore transient?); retry in $((a*10))s"; sleep $((a*10))
-          done
-          echo "::error::cosign sign failed after 5 attempts"; exit 1
-        env:
-          DIGEST: ${{ steps.build-slim.outputs.digest }}
-
-  # ----------------------------------------------------------------------
-  # iterion-sandbox-full — opt-in richer variant FROM the slim image.
-  # Chained on build-sandbox-slim so it picks up the freshly-built base
-  # for the same ref. Users select it via --sandbox-default-image or the
-  # ITERION_SANDBOX_DEFAULT_IMAGE env var.
-  # ----------------------------------------------------------------------
+  # iterion-sandbox-full — FROM the freshly-built slim image.
   build-sandbox-full:
-    runs-on: ubuntu-latest
-    needs: build-sandbox-slim
-    env:
-      SANDBOX_IMAGE_NAME: ${{ github.repository_owner }}/iterion-sandbox-full
-      SANDBOX_SLIM_NAME: ${{ github.repository_owner }}/iterion-sandbox-slim
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    needs: [prep, build-sandbox-slim]
+    uses: ./.github/workflows/_build-image.yml
+    secrets: inherit
+    with:
+      image-name: iterion-sandbox-full
+      routing-name: iterion-sandbox-full
+      context: sandbox/full
+      file: sandbox/full/Dockerfile
+      build-args: BASE=ghcr.io/${{ needs.prep.outputs.owner_lc }}/iterion-sandbox-slim:${{ needs.prep.outputs.base_tag }}
+      is-pr: ${{ github.event_name == 'pull_request' }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute lowercase image refs
-        run: |
-          echo "SANDBOX_IMAGE_REF=$(echo '${{ env.REGISTRY }}/${{ env.SANDBOX_IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
-          echo "SANDBOX_SLIM_REF=$(echo '${{ env.REGISTRY }}/${{ env.SANDBOX_SLIM_NAME }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
-
-      - name: Compute tags
-        id: meta-full
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
-        with:
-          images: ${{ env.SANDBOX_IMAGE_REF }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=raw,value=edge,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-
-      - name: Resolve slim base ref
-        shell: bash
-        run: |
-          # Pick the slim tag that matches the current build context: a
-          # release tag or the rolling `edge` tag on main; PRs build a
-          # short-lived ephemeral image and reference it by short tag.
-          # $GITHUB_REF (canonical env var), not the github.ref expression
-          # inlined — a crafted tag name would otherwise script-inject this
-          # shell (and a run: comment is still evaluated by GitHub).
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            BASE_TAG="${GITHUB_REF_NAME}"
-          else
-            BASE_TAG="edge"
-          fi
-          echo "SANDBOX_FULL_BASE=${SANDBOX_SLIM_REF}:${BASE_TAG}" >> "$GITHUB_ENV"
-
-      - name: Build (and push when not a PR)
-        id: build-full
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: sandbox/full
-          file: sandbox/full/Dockerfile
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
-          push: ${{ github.event_name != 'pull_request' }}
-          load: ${{ github.event_name == 'pull_request' }}
-          tags: ${{ steps.meta-full.outputs.tags }}
-          labels: ${{ steps.meta-full.outputs.labels }}
-          build-args: |
-            BASE=${{ env.SANDBOX_FULL_BASE }}
-          cache-from: type=gha,scope=sandbox-full
-          cache-to: type=gha,mode=max,scope=sandbox-full
-
-      - name: Install cosign (full)
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
-
-      - name: Sign sandbox-full image
-        if: github.event_name != 'pull_request'
-        run: |
-          for a in 1 2 3 4 5; do
-            cosign sign --yes "${SANDBOX_IMAGE_REF}@${DIGEST}" && exit 0
-            echo "::warning::cosign sign attempt $a failed (Sigstore transient?); retry in $((a*10))s"; sleep $((a*10))
-          done
-          echo "::error::cosign sign failed after 5 attempts"; exit 1
-        env:
-          DIGEST: ${{ steps.build-full.outputs.digest }}
-
-  # ----------------------------------------------------------------------
-  # iterion-sandbox-sec — security-scanner variant FROM the full image
-  # (semgrep/gosec/govulncheck/bandit/pip-audit/trivy/gitleaks). Required
-  # by sec-audit-source / sec-audit-deps, which pin this ref via
-  # sandbox.image — without it the audits silently produce a zero-finding
-  # façade. Chained on build-sandbox-full so it picks up the freshly-built
-  # base for the same ref.
-  # ----------------------------------------------------------------------
+  # iterion-sandbox-sec — FROM the freshly-built full image. Required by
+  # sec-audit-source / sec-audit-deps (pinned via sandbox.image).
   build-sandbox-sec:
-    runs-on: ubuntu-latest
-    needs: build-sandbox-full
-    env:
-      SANDBOX_IMAGE_NAME: ${{ github.repository_owner }}/iterion-sandbox-sec
-      SANDBOX_FULL_NAME: ${{ github.repository_owner }}/iterion-sandbox-full
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-
-      - name: Set up Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute lowercase image refs
-        run: |
-          echo "SANDBOX_IMAGE_REF=$(echo '${{ env.REGISTRY }}/${{ env.SANDBOX_IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
-          echo "SANDBOX_FULL_REF=$(echo '${{ env.REGISTRY }}/${{ env.SANDBOX_FULL_NAME }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
-
-      - name: Compute tags
-        id: meta-sec
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
-        with:
-          images: ${{ env.SANDBOX_IMAGE_REF }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-            type=raw,value=edge,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
-            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-
-      - name: Resolve full base ref
-        shell: bash
-        run: |
-          # Mirror build-sandbox-full's base resolution: a release tag or
-          # the rolling `edge` tag on main; PRs build against the published
-          # full:edge (the PR's own full image isn't pushed to the registry).
-          # $GITHUB_REF (canonical env var), not the github.ref expression
-          # inlined — a crafted tag name would otherwise script-inject this
-          # shell (and a run: comment is still evaluated by GitHub).
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            BASE_TAG="${GITHUB_REF_NAME}"
-          else
-            BASE_TAG="edge"
-          fi
-          echo "SANDBOX_SEC_BASE=${SANDBOX_FULL_REF}:${BASE_TAG}" >> "$GITHUB_ENV"
-
-      - name: Build (and push when not a PR)
-        id: build-sec
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: sandbox/sec
-          file: sandbox/sec/Dockerfile
-          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
-          push: ${{ github.event_name != 'pull_request' }}
-          load: ${{ github.event_name == 'pull_request' }}
-          tags: ${{ steps.meta-sec.outputs.tags }}
-          labels: ${{ steps.meta-sec.outputs.labels }}
-          build-args: |
-            BASE=${{ env.SANDBOX_SEC_BASE }}
-          cache-from: type=gha,scope=sandbox-sec
-          cache-to: type=gha,mode=max,scope=sandbox-sec
-
-      - name: Install cosign (sec)
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
-
-      - name: Sign sandbox-sec image
-        if: github.event_name != 'pull_request'
-        run: |
-          for a in 1 2 3 4 5; do
-            cosign sign --yes "${SANDBOX_IMAGE_REF}@${DIGEST}" && exit 0
-            echo "::warning::cosign sign attempt $a failed (Sigstore transient?); retry in $((a*10))s"; sleep $((a*10))
-          done
-          echo "::error::cosign sign failed after 5 attempts"; exit 1
-        env:
-          DIGEST: ${{ steps.build-sec.outputs.digest }}
-
+    needs: [prep, build-sandbox-full]
+    uses: ./.github/workflows/_build-image.yml
+    secrets: inherit
+    with:
+      image-name: iterion-sandbox-sec
+      routing-name: iterion-sandbox-sec
+      context: sandbox/sec
+      file: sandbox/sec/Dockerfile
+      build-args: BASE=ghcr.io/${{ needs.prep.outputs.owner_lc }}/iterion-sandbox-full:${{ needs.prep.outputs.base_tag }}
+      is-pr: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -68,6 +68,9 @@ jobs:
         VERSION=${{ github.ref_name }}
         COMMIT=${{ github.sha }}
       is-pr: ${{ github.event_name == 'pull_request' }}
+      # Full multi-arch (+ sign + SBOM) only on main and release tags; feature
+      # branches build amd64-only on the operator for a fast iteration loop.
+      multiarch: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
 
   # iterion-sandbox-slim — bakes in the iterion binary via COPY --from, so it
   # needs the iterion image (and its :edge / :vX.Y.Z tag) published first.
@@ -82,6 +85,9 @@ jobs:
       file: sandbox/slim/Dockerfile
       build-args: ITERION_IMAGE=ghcr.io/${{ needs.prep.outputs.owner_lc }}/iterion:${{ needs.prep.outputs.base_tag }}
       is-pr: ${{ github.event_name == 'pull_request' }}
+      # Full multi-arch (+ sign + SBOM) only on main and release tags; feature
+      # branches build amd64-only on the operator for a fast iteration loop.
+      multiarch: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
 
   # iterion-sandbox-full — FROM the freshly-built slim image.
   build-sandbox-full:
@@ -95,6 +101,9 @@ jobs:
       file: sandbox/full/Dockerfile
       build-args: BASE=ghcr.io/${{ needs.prep.outputs.owner_lc }}/iterion-sandbox-slim:${{ needs.prep.outputs.base_tag }}
       is-pr: ${{ github.event_name == 'pull_request' }}
+      # Full multi-arch (+ sign + SBOM) only on main and release tags; feature
+      # branches build amd64-only on the operator for a fast iteration loop.
+      multiarch: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
 
   # iterion-sandbox-sec — FROM the freshly-built full image. Required by
   # sec-audit-source / sec-audit-deps (pinned via sandbox.image).
@@ -109,3 +118,6 @@ jobs:
       file: sandbox/sec/Dockerfile
       build-args: BASE=ghcr.io/${{ needs.prep.outputs.owner_lc }}/iterion-sandbox-full:${{ needs.prep.outputs.base_tag }}
       is-pr: ${{ github.event_name == 'pull_request' }}
+      # Full multi-arch (+ sign + SBOM) only on main and release tags; feature
+      # branches build amd64-only on the operator for a fast iteration loop.
+      multiarch: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,14 @@ WORKDIR /app
 # resolve from the locked deps tree, then layer the studio sources.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY studio/package.json studio/.npmrc* ./studio/
-RUN corepack enable && \
+# Cache mount for the pnpm content-addressable store: on buildkit-operator's
+# warm daemon it persists across builds, so a source-only change (which
+# invalidates this layer) still resolves every dep from the warm store instead
+# of re-fetching from the registry. --store-dir pins it onto the mount.
+RUN --mount=type=cache,target=/pnpm-store \
+    corepack enable && \
     corepack pnpm install --frozen-lockfile --prefer-offline \
+        --store-dir=/pnpm-store \
         --filter ./studio...
 COPY studio ./studio
 RUN corepack pnpm --filter ./studio exec vite build
@@ -50,7 +56,12 @@ COPY bots ./bots
 # Embed the freshly-built studio assets the Go binary serves at GET /.
 COPY --from=studio-builder /app/studio/dist ./pkg/server/static
 ENV CGO_ENABLED=0 GOFLAGS="-mod=vendor -trimpath"
-RUN go build \
+# Cache mount for the Go build cache (compiled package objects). Deps are
+# vendored (no module download), so this only caches compilation — kept warm
+# on the operator daemon it turns a full recompile into an incremental one
+# when a source change invalidates this layer.
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    go build \
     -ldflags="-X github.com/SocialGouv/iterion/pkg/internal/appinfo.Version=v${VERSION} \
               -X github.com/SocialGouv/iterion/pkg/internal/appinfo.Commit=${COMMIT}" \
     -o /out/iterion ./cmd/iterion
@@ -63,7 +74,10 @@ WORKDIR /llm
 COPY docker/llm-clis/package.json ./package.json
 # npm install (no lock yet) honours the exact pinned versions in
 # package.json. `task docker:pin-llm-clis` (T-39) regenerates these.
-RUN npm install --omit=dev --no-audit --no-fund
+# Cache mount for npm's package cache (~/.npm): warm on the operator daemon,
+# the pinned tarballs are reused instead of re-downloaded on every build.
+RUN --mount=type=cache,target=/root/.npm \
+    npm install --omit=dev --no-audit --no-fund
 
 # ---------------------------------------------------------------------
 # Stage 4 — Runtime
@@ -95,7 +109,14 @@ ENV ITERION_VERSION=${VERSION} \
 #               build JSON note payloads with `jq -nc --arg`; without it
 #               every cloud converse/review run burned an LLM round-trip
 #               on exit-127 before falling back to python3.
-RUN apt-get update \
+# apt cache mounts keep the downloaded .deb archives + package lists warm on
+# the operator daemon (dropping docker-clean so apt doesn't purge them). Both
+# dirs are cache mounts, so they never land in the final image layer — no need
+# for the old `rm -rf /var/lib/apt/lists` cleanup.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+ && apt-get update \
  && apt-get install -y --no-install-recommends \
         git \
         ca-certificates \
@@ -104,8 +125,7 @@ RUN apt-get update \
         curl \
         passwd \
         python3 \
-        jq \
- && rm -rf /var/lib/apt/lists/*
+        jq
 
 # glab (GitLab CLI) — review-pr (Revi) runs WITHOUT a sandbox, so in
 # cloud it executes inside the runner pod and posts code reviews onto

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1
 # Iterion container image. Multi-stage:
 #   1. studio-builder — vite build of the React studio → dist/
 #   2. go-builder     — go build (vendor mode, CGO disabled, ldflags
@@ -14,7 +14,9 @@
 # ---------------------------------------------------------------------
 # Stage 1 — Studio frontend
 # ---------------------------------------------------------------------
-FROM node:22-bookworm-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4 AS studio-builder
+# --platform=$BUILDPLATFORM: the studio bundle is JS (arch-independent), so build
+# it once on the builder's native arch — never under emulation for an arm64 target.
+FROM --platform=$BUILDPLATFORM node:22-bookworm-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4 AS studio-builder
 WORKDIR /app
 # pnpm-workspace.yaml + pnpm-lock.yaml live at the repo root; the
 # studio/ directory is a workspace member that doesn't carry its own
@@ -32,26 +34,33 @@ RUN --mount=type=cache,target=/pnpm-store \
         --store-dir=/pnpm-store \
         --filter ./studio...
 COPY studio ./studio
-RUN corepack pnpm --filter ./studio exec vite build
+# vite cache mount: incremental studio rebuilds reuse the transform/dep cache.
+RUN --mount=type=cache,target=/app/studio/node_modules/.vite \
+    corepack pnpm --filter ./studio exec vite build
 
 # ---------------------------------------------------------------------
 # Stage 2 — Go binary
 # ---------------------------------------------------------------------
-FROM golang:1.26-bookworm@sha256:b305420a68d0f229d91eb3b3ed9e519fcf2cf5461da4bef997bf927e8c0bfd2b AS go-builder
+# --platform=$BUILDPLATFORM: run the Go toolchain on the builder's native arch and
+# CROSS-compile to the target (CGO is off, so this is free) — never emulate the Go
+# compile for an arm64 target. TARGETOS/TARGETARCH are injected by buildx.
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm@sha256:b305420a68d0f229d91eb3b3ed9e519fcf2cf5461da4bef997bf927e8c0bfd2b AS go-builder
 WORKDIR /src
 ARG VERSION=0.0.0
 ARG COMMIT=unknown
+ARG TARGETOS
+ARG TARGETARCH
 COPY go.mod go.sum ./
 COPY vendor ./vendor
-COPY cmd ./cmd
-COPY pkg ./pkg
-COPY e2e ./e2e
-COPY examples ./examples
-# bots/ holds the 9 productised bot bundles (relocated from examples/ in
-# 969d55b4). pkg/cli/embedded_recipes.go embeds them via the
-# github.com/SocialGouv/iterion/bots package, so the source tree must be
-# present for `go build` under -mod=vendor — without this COPY the build
-# fails: "cannot find module providing package .../bots".
+# --exclude test files: a *_test.go edit no longer changes the copied content, so
+# the go build layer stays CACHED (the binary never compiles test files anyway).
+COPY --exclude=**/*_test.go cmd ./cmd
+COPY --exclude=**/*_test.go pkg ./pkg
+# bots/ holds the productised bot bundles. pkg/cli embeds them via the
+# github.com/SocialGouv/iterion/bots package, so the source tree must be present
+# for `go build` under -mod=vendor. (e2e/ and examples/ are NOT imported or
+# embedded by ./cmd/iterion, so they are deliberately not copied — keeps the build
+# layer from invalidating on test/example edits.)
 COPY bots ./bots
 # Embed the freshly-built studio assets the Go binary serves at GET /.
 COPY --from=studio-builder /app/studio/dist ./pkg/server/static
@@ -59,10 +68,12 @@ ENV CGO_ENABLED=0 GOFLAGS="-mod=vendor -trimpath"
 # Cache mount for the Go build cache (compiled package objects). Deps are
 # vendored (no module download), so this only caches compilation — kept warm
 # on the operator daemon it turns a full recompile into an incremental one
-# when a source change invalidates this layer.
+# when a source change invalidates this layer. -s -w strips the binary (smaller
+# final image, faster link). GOOS/GOARCH come from buildx for cross-compilation.
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    go build \
-    -ldflags="-X github.com/SocialGouv/iterion/pkg/internal/appinfo.Version=v${VERSION} \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
+    -ldflags="-s -w \
+              -X github.com/SocialGouv/iterion/pkg/internal/appinfo.Version=v${VERSION} \
               -X github.com/SocialGouv/iterion/pkg/internal/appinfo.Commit=${COMMIT}" \
     -o /out/iterion ./cmd/iterion
 

--- a/docs/ci-performance-buildkit-operator.md
+++ b/docs/ci-performance-buildkit-operator.md
@@ -1,126 +1,125 @@
-# CI performance — buildkit-operator migration (factual comparison)
+# CI performance — buildkit-operator migration (measured)
 
-This is the evidence file for the `image.yml` migration to
-[buildkit-operator](https://github.com/SocialGouv/buildkit-operator). The goal is
-to **prove or disprove**, with real numbers, the speed gain of building the
-iterion container images on the in-house buildkit-operator (amd64) + a native
-arm64 GitHub runner, vs the previous `docker buildx` + QEMU multi-arch path.
-
-Be factual. If a state shows no gain, it is recorded as-is.
+Evidence file for the `image.yml` migration to
+[buildkit-operator](https://github.com/SocialGouv/buildkit-operator): amd64 builds
+on the in-house buildkit-operator warm daemon, arm64 on a native GitHub arm runner,
+merged into one multi-arch index. Goal: prove or disprove, with real numbers, the
+speed gain vs the previous `docker buildx` + QEMU multi-arch path. All numbers below
+are measured from real GitHub Actions runs on `SocialGouv/iterion`.
 
 ## What changed
 
 | | OLD (pre-migration) | NEW (this migration) |
 |---|---|---|
-| amd64 | `docker buildx` on the GH runner | buildkit-operator warm daemon (persistent cache mounts + S3 cold cache) |
+| amd64 | `docker buildx` on the GH runner | buildkit-operator warm daemon (persistent cache mounts + S3 cold cache, GitHub-OIDC mTLS) |
 | arm64 | **QEMU emulation** on the amd64 GH runner | **native** `ubuntu-24.04-arm` runner |
-| cache | GitHub Actions cache (`type=gha`), layers only | daemon-local PVC (layers **+** `RUN --mount=type=cache` mounts) + S3 cold cache |
+| cache | GitHub Actions cache (`type=gha`), layers only | daemon PVC: layers **+** `RUN --mount=type=cache` mounts + S3 cold cache |
 | supply chain | cosign + syft per image | provenance/SBOM per-arch (operator), cosign-signed index once at merge |
 
 The Dockerfiles also gained `RUN --mount=type=cache` mounts (pnpm store, go-build,
-npm, apt, pip, go module cache) — warm on the operator daemon, they cut
-compile/install cost even when a source-only change invalidates the layer.
+npm, apt, pip, go module cache) — warm on the operator daemon.
 
-## Cache states measured
+## Headline — full image.yml chain wall-clock
 
-| state | how it's forced | what it represents |
+Source: `gh run view`. Reproduce: `scripts/bench/ci-build-bench.sh ci-durations --old-run <id> --new-run <id>`.
+
+| run | path | chain wall-clock | speedup |
+|---|---|---|---|
+| `28290258656` | OLD — QEMU multi-arch | **62.3 min** | 1.00× |
+| `28293580991` | NEW — operator amd64 + native arm64, **cold** daemons (first build, S3 seed) | **37.9 min** | **1.64×** |
+| `28294577915` | NEW — operator amd64 + native arm64, **warm** daemons (steady state) | **26.7 min** | **2.33×** |
+
+Steady-state CI (warm daemons) is the number that matters day-to-day: **62.3 → 26.7 min (2.33×)**.
+The cold run is the honest first-build cost (daemon provision + S3 cache seed).
+
+## Per-image, per-leg (minutes)
+
+OLD is a single multi-arch job (amd64+arm64 under QEMU in one number). NEW runs
+amd64 (operator) and arm64 (native) in parallel, then a merge job.
+
+| image | OLD (QEMU multi-arch) | NEW amd64 cold | NEW amd64 warm | NEW arm64 native | NEW merge |
+|---|---|---|---|---|---|
+| iterion (`build`) | **33.3** | 8.6 | **0.8** | 2.8–6.7 | 1.0 |
+| sandbox-slim | 2.6 | 5.5 | 3.1 | 1.9–2.3 | 1.4 |
+| sandbox-full | 4.4 | 5.9 | 3.6 | 2.1–2.4 | 1.7 |
+| sandbox-sec | **21.9** | 9.1 | 6.3 | 3.8–3.9 | 2.3 |
+
+Per-image NEW wall-clock = max(amd64, arm64) + merge (legs run in parallel).
+
+## Dockerfile cache mounts — measured effect
+
+The `RUN --mount=type=cache` mounts (Part A) pay off on the warm operator daemon.
+Evidence from the `build / amd64` operator log:
+
+- The mounts run as authored:
+  `#27 [studio-builder] RUN --mount=type=cache,target=/pnpm-store … pnpm install --store-dir=/pnpm-store …`
+  and `#26 [llm-clis] RUN --mount=type=cache,target=/root/.npm npm install …`.
+- The daemon **persists** them: its cache config exports `type==exec.cachemount`
+  (`"Cache export": true … "type==exec.cachemount"`).
+- S3 cold cache is active: `#14 importing cache manifest from s3:…`.
+
+Result on the iterion image (amd64 operator leg):
+
+| | cold daemon (first build + S3 seed) | warm daemon |
 |---|---|---|
-| `baseline-cold` | `docker buildx --no-cache` | worst case, no operator |
-| `baseline-warm` | `docker buildx` reusing local layer cache | best case without the operator |
-| `operator-cold` | operator `untrusted=true` (ephemeral daemon, `cache:null`) | true cold on the operator — no mounts, no S3 |
-| `operator-warm` | operator, 2nd build on the same routing key | warm PVC: cache mounts + layers |
-| `s3-cold-rehydrate` | fresh daemon after a seed (k8s-side, see below) | cross-daemon / scale-to-zero recovery |
-| `daemon-cold-start` | first `/route` to a scaled-to-zero project | PVC attach (~19.5s p50, masked by prewarm) |
+| amd64 build | **8.6 min** | **0.8 min** (~10×) |
 
-`s3-cold-rehydrate` and `daemon-cold-start` are **not** forceable from a pure CI
-client (they need k8s-side BuildProject deletion); they are read from the
-operator's Prometheus metrics and its `TestS3ColdCache` e2e, and cited below.
+The lockfile-first layer ordering already gated dep re-download on lockfile changes
+(`COPY package.json pnpm-lock.yaml` → `pnpm install --frozen-lockfile` → `COPY studio`,
+Go `-mod=vendor`); the cache mounts add warm-store reuse of the compile/install cost on top.
 
-## Headline: full image.yml chain wall-clock
+## Upstream-referenced figures (operator docs, for context)
 
-Source of truth: `gh run view <id>` (job `startedAt`/`completedAt`).
-Reproduce: `scripts/bench/ci-build-bench.sh ci-durations --old-run <id> --new-run <id>`.
+From the operator's `docs/performance.md` / `docs/storage-and-cold-cache.md` — not our
+measurement, cited for orientation:
 
-### OLD — run `28290258656` (main @ `722d8f80`, QEMU multi-arch) — MEASURED
+- S3 cold rehydrate: ~41.8 s → ~4.5 s (~9×) on a fresh daemon (layers only).
+- Daemon cold-start: ~19.5 s p50 PVC attach; ~90 s full provision — masked in steady
+  state by scale-to-zero + PVC retention + `/prewarm` (we set `BUILDKIT_OPERATOR_WAIT_WARM=1`).
 
-| job | wall-clock | note |
-|---|---|---|
-| build (iterion) | **33.3 min** | Go compile + studio + tools, **arm64 under QEMU** |
-| build-sandbox-slim | 2.6 min | |
-| build-sandbox-full | 4.4 min | Go tarball + tool installs, arm64 under QEMU |
-| build-sandbox-sec | **21.9 min** | semgrep/gosec/trivy installs **under QEMU** |
-| **chain total** | **62.3 min** | sequential `needs:` chain |
+## Conclusion (honest, per axis)
 
-The two QEMU-bound steps (main image 33 min, sec 22 min) are **88% of the chain**.
-
-### NEW — run `<TBD>` (operator amd64 + native arm64) — TO FILL
-
-> Fill after the first migrated run (workflow_dispatch on the branch, or first
-> push to main). Command:
-> `scripts/bench/ci-build-bench.sh ci-durations --old-run 28290258656 --new-run <new-id>`
-
-| job | amd64 (operator) | arm64 (native) | merge+sign | note |
-|---|---|---|---|---|
-| build (iterion) | _TBD_ | _TBD_ | _TBD_ | |
-| build-sandbox-slim | _TBD_ | _TBD_ | _TBD_ | |
-| build-sandbox-full | _TBD_ | _TBD_ | _TBD_ | |
-| build-sandbox-sec | _TBD_ | _TBD_ | _TBD_ | |
-| **chain total** | | | **_TBD_** | warm-daemon run |
-
-| | OLD | NEW (cold daemon) | NEW (warm daemon) | speedup |
-|---|---|---|---|---|
-| chain total (min) | 62.3 | _TBD_ | _TBD_ | _TBD_× |
-
-> Record **two** NEW numbers: the first migrated run (cold daemon, one-time PVC
-> attach + cache seed) and a re-run (warm daemon). The warm number is the
-> steady-state CI experience; the cold number is the honest first-run cost.
-
-## Per-build micro-benchmark (cache states)
-
-Source of truth: `scripts/bench/ci-build-bench.sh build --image <bench|main|slim|full|sec> --runs 3`.
-Run it where the operator is reachable (mTLS certs + `BUILDKIT_OPERATOR_BUILDD_URL`).
-
-### image `bench` (representative, cheap) — TO FILL
-
-| cache state | min (s) | median (s) | max (s) | CACHED steps |
-|---|---|---|---|---|
-| baseline-cold | _TBD_ | | | |
-| baseline-warm | _TBD_ | | | |
-| operator-cold | _TBD_ | | | |
-| operator-warm | _TBD_ | | | |
-
-(Repeat per real image with `--image main|slim|full|sec` for production fidelity.)
-
-## Upstream-referenced figures (not our measurement)
-
-From the operator's `docs/performance.md` / `docs/storage-and-cold-cache.md`,
-cited for context — to be corroborated by our own runs above where possible:
-
-- S3 cold rehydrate: **~41.8 s → ~4.5 s (~9×)** on a fresh daemon (layers only;
-  cache mounts are per-daemon, not exported).
-- Daemon cold-start: **~19.5 s p50** PVC attach; **~90 s** full provision —
-  masked in steady state by scale-to-zero + PVC retention + `/prewarm`.
-- Warm dedicated daemon vs shared pool: **~9.6 s vs ~18.3 s**.
-
-## Conclusion — TO WRITE after NEW numbers land
-
-State plainly, per axis:
-- Did the chain total drop, and by how much (cold and warm)?
-- Did native arm64 remove the QEMU penalty on `build` + `sec` specifically?
-- Did the cache mounts help the warm re-run (CACHED-step count, compile time)?
-- Any axis with **no** gain or a regression (e.g. cold-daemon first run slower
-  than QEMU baseline) — record it; that is the honest pilot result of running our
-  own buildkit-operator service.
+- **The QEMU-bound heavy images are crushed.** The two offenders that were 88% of the
+  OLD chain — iterion (33.3 min) and sandbox-sec (21.9 min) — drop to ~7.7 and ~8.6 min
+  warm wall-clock. Eliminating QEMU arm64 (native arm runner) is the single biggest win.
+- **Warm operator amd64 is excellent.** iterion amd64 8.6 → 0.8 min once the daemon is
+  warm (cache mounts + S3) — a ~10× drop, exactly the Dockerfile-cache-mount payoff.
+- **Cold-start has a real one-time cost.** First build on a fresh daemon (provision +
+  S3 seed) makes the cold chain 37.9 min vs 26.7 warm — still well under OLD's 62.3.
+- **Light images gain the least, proportionally.** sandbox-slim/full were already cheap
+  under QEMU (2.6 / 4.4 min); the operator + per-image merge overhead (~1.4–1.8 min)
+  means they're roughly flat-to-slightly-worse cold and modestly better warm. The net
+  chain win comes from the heavy images, not these.
+- **arm64-native is fast but gha-cache-variable.** Native arm64 ranges 1.9–6.7 min
+  depending on the gha layer-cache state of the run (cache mounts don't persist on the
+  gha leg). It is never the QEMU 20–33 min anymore, but it is now often the per-image
+  critical path — a future lever (registry cache / a second operator arch) if needed.
+- **Net, factual:** steady-state CI **62.3 → 26.7 min, 2.33×**; first-cold **1.64×**.
+  The migration is a clear win, dominated by killing QEMU and warming the heavy-image
+  amd64 builds on our own buildkit-operator (a successful dogfood of the in-house service).
 
 ## Reproduce
 
 ```sh
 # Full chain comparison (needs gh):
-scripts/bench/ci-build-bench.sh ci-durations            # lists recent main runs
-scripts/bench/ci-build-bench.sh ci-durations --old-run 28290258656 --new-run <new-id>
+scripts/bench/ci-build-bench.sh ci-durations --old-run 28290258656 --new-run 28294577915
 
 # Per-state micro-bench (needs docker; operator states need mTLS + BUILDD_URL):
-export BUILDKIT_OPERATOR_BUILDD_URL=...   # + BUILDKIT_OPERATOR_GATEWAY_HOST, mTLS certs on the buildx remote
+export BUILDKIT_OPERATOR_BUILDD_URL=https://buildd.bko.fabrique.social.gouv.fr
+export BUILDKIT_OPERATOR_GATEWAY_HOST=bkod.fabrique.social.gouv.fr   # + mTLS certs on the buildx remote
 scripts/bench/ci-build-bench.sh build --image bench --runs 3
 scripts/bench/ci-build-bench.sh build --image sec  --runs 3   # the worst QEMU offender
 ```
+
+## Operational notes (provisioning that made it work)
+
+- buildd `/route` API: `https://buildd.bko.fabrique.social.gouv.fr` (publicly reachable).
+- Daemon gateway (off-cluster, from GitHub-hosted runners):
+  `gateway-host: bkod.fabrique.social.gouv.fr` — the public wildcard LB
+  (`*.bkod.fabrique.social.gouv.fr` → 79.137.120.122:443). The internal `bko.*` host is
+  filtered off-cluster; using it yields `context deadline exceeded`.
+- Auth: GitHub OIDC (audience `buildkit-operator`) — no static token needed.
+- `BUILDKIT_OPERATOR_WAIT_WARM=1` on the amd64 job: wait for the daemon to be Ready
+  before pointing buildx at it (a cold-start daemon otherwise refuses the gRPC connection).
+- Org vars/secrets (visibility ALL): `BUILDKIT_OPERATOR_BUILDD_URL`,
+  `BUILDKIT_OPERATOR_GATEWAY_HOST`, `BUILDKIT_OPERATOR_{CA,CERT,KEY}`.

--- a/docs/ci-performance-buildkit-operator.md
+++ b/docs/ci-performance-buildkit-operator.md
@@ -1,0 +1,126 @@
+# CI performance — buildkit-operator migration (factual comparison)
+
+This is the evidence file for the `image.yml` migration to
+[buildkit-operator](https://github.com/SocialGouv/buildkit-operator). The goal is
+to **prove or disprove**, with real numbers, the speed gain of building the
+iterion container images on the in-house buildkit-operator (amd64) + a native
+arm64 GitHub runner, vs the previous `docker buildx` + QEMU multi-arch path.
+
+Be factual. If a state shows no gain, it is recorded as-is.
+
+## What changed
+
+| | OLD (pre-migration) | NEW (this migration) |
+|---|---|---|
+| amd64 | `docker buildx` on the GH runner | buildkit-operator warm daemon (persistent cache mounts + S3 cold cache) |
+| arm64 | **QEMU emulation** on the amd64 GH runner | **native** `ubuntu-24.04-arm` runner |
+| cache | GitHub Actions cache (`type=gha`), layers only | daemon-local PVC (layers **+** `RUN --mount=type=cache` mounts) + S3 cold cache |
+| supply chain | cosign + syft per image | provenance/SBOM per-arch (operator), cosign-signed index once at merge |
+
+The Dockerfiles also gained `RUN --mount=type=cache` mounts (pnpm store, go-build,
+npm, apt, pip, go module cache) — warm on the operator daemon, they cut
+compile/install cost even when a source-only change invalidates the layer.
+
+## Cache states measured
+
+| state | how it's forced | what it represents |
+|---|---|---|
+| `baseline-cold` | `docker buildx --no-cache` | worst case, no operator |
+| `baseline-warm` | `docker buildx` reusing local layer cache | best case without the operator |
+| `operator-cold` | operator `untrusted=true` (ephemeral daemon, `cache:null`) | true cold on the operator — no mounts, no S3 |
+| `operator-warm` | operator, 2nd build on the same routing key | warm PVC: cache mounts + layers |
+| `s3-cold-rehydrate` | fresh daemon after a seed (k8s-side, see below) | cross-daemon / scale-to-zero recovery |
+| `daemon-cold-start` | first `/route` to a scaled-to-zero project | PVC attach (~19.5s p50, masked by prewarm) |
+
+`s3-cold-rehydrate` and `daemon-cold-start` are **not** forceable from a pure CI
+client (they need k8s-side BuildProject deletion); they are read from the
+operator's Prometheus metrics and its `TestS3ColdCache` e2e, and cited below.
+
+## Headline: full image.yml chain wall-clock
+
+Source of truth: `gh run view <id>` (job `startedAt`/`completedAt`).
+Reproduce: `scripts/bench/ci-build-bench.sh ci-durations --old-run <id> --new-run <id>`.
+
+### OLD — run `28290258656` (main @ `722d8f80`, QEMU multi-arch) — MEASURED
+
+| job | wall-clock | note |
+|---|---|---|
+| build (iterion) | **33.3 min** | Go compile + studio + tools, **arm64 under QEMU** |
+| build-sandbox-slim | 2.6 min | |
+| build-sandbox-full | 4.4 min | Go tarball + tool installs, arm64 under QEMU |
+| build-sandbox-sec | **21.9 min** | semgrep/gosec/trivy installs **under QEMU** |
+| **chain total** | **62.3 min** | sequential `needs:` chain |
+
+The two QEMU-bound steps (main image 33 min, sec 22 min) are **88% of the chain**.
+
+### NEW — run `<TBD>` (operator amd64 + native arm64) — TO FILL
+
+> Fill after the first migrated run (workflow_dispatch on the branch, or first
+> push to main). Command:
+> `scripts/bench/ci-build-bench.sh ci-durations --old-run 28290258656 --new-run <new-id>`
+
+| job | amd64 (operator) | arm64 (native) | merge+sign | note |
+|---|---|---|---|---|
+| build (iterion) | _TBD_ | _TBD_ | _TBD_ | |
+| build-sandbox-slim | _TBD_ | _TBD_ | _TBD_ | |
+| build-sandbox-full | _TBD_ | _TBD_ | _TBD_ | |
+| build-sandbox-sec | _TBD_ | _TBD_ | _TBD_ | |
+| **chain total** | | | **_TBD_** | warm-daemon run |
+
+| | OLD | NEW (cold daemon) | NEW (warm daemon) | speedup |
+|---|---|---|---|---|
+| chain total (min) | 62.3 | _TBD_ | _TBD_ | _TBD_× |
+
+> Record **two** NEW numbers: the first migrated run (cold daemon, one-time PVC
+> attach + cache seed) and a re-run (warm daemon). The warm number is the
+> steady-state CI experience; the cold number is the honest first-run cost.
+
+## Per-build micro-benchmark (cache states)
+
+Source of truth: `scripts/bench/ci-build-bench.sh build --image <bench|main|slim|full|sec> --runs 3`.
+Run it where the operator is reachable (mTLS certs + `BUILDKIT_OPERATOR_BUILDD_URL`).
+
+### image `bench` (representative, cheap) — TO FILL
+
+| cache state | min (s) | median (s) | max (s) | CACHED steps |
+|---|---|---|---|---|
+| baseline-cold | _TBD_ | | | |
+| baseline-warm | _TBD_ | | | |
+| operator-cold | _TBD_ | | | |
+| operator-warm | _TBD_ | | | |
+
+(Repeat per real image with `--image main|slim|full|sec` for production fidelity.)
+
+## Upstream-referenced figures (not our measurement)
+
+From the operator's `docs/performance.md` / `docs/storage-and-cold-cache.md`,
+cited for context — to be corroborated by our own runs above where possible:
+
+- S3 cold rehydrate: **~41.8 s → ~4.5 s (~9×)** on a fresh daemon (layers only;
+  cache mounts are per-daemon, not exported).
+- Daemon cold-start: **~19.5 s p50** PVC attach; **~90 s** full provision —
+  masked in steady state by scale-to-zero + PVC retention + `/prewarm`.
+- Warm dedicated daemon vs shared pool: **~9.6 s vs ~18.3 s**.
+
+## Conclusion — TO WRITE after NEW numbers land
+
+State plainly, per axis:
+- Did the chain total drop, and by how much (cold and warm)?
+- Did native arm64 remove the QEMU penalty on `build` + `sec` specifically?
+- Did the cache mounts help the warm re-run (CACHED-step count, compile time)?
+- Any axis with **no** gain or a regression (e.g. cold-daemon first run slower
+  than QEMU baseline) — record it; that is the honest pilot result of running our
+  own buildkit-operator service.
+
+## Reproduce
+
+```sh
+# Full chain comparison (needs gh):
+scripts/bench/ci-build-bench.sh ci-durations            # lists recent main runs
+scripts/bench/ci-build-bench.sh ci-durations --old-run 28290258656 --new-run <new-id>
+
+# Per-state micro-bench (needs docker; operator states need mTLS + BUILDD_URL):
+export BUILDKIT_OPERATOR_BUILDD_URL=...   # + BUILDKIT_OPERATOR_GATEWAY_HOST, mTLS certs on the buildx remote
+scripts/bench/ci-build-bench.sh build --image bench --runs 3
+scripts/bench/ci-build-bench.sh build --image sec  --runs 3   # the worst QEMU offender
+```

--- a/sandbox/full/Dockerfile
+++ b/sandbox/full/Dockerfile
@@ -41,7 +41,10 @@ USER root
 #   curl             — already present via slim, but reaffirmed for
 #                      the apt-repo setups below.
 # ---------------------------------------------------------------------
-RUN apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+ && apt-get update \
  && apt-get install -y --no-install-recommends \
         python3 \
         python3-pip \
@@ -51,8 +54,7 @@ RUN apt-get update \
         ca-certificates \
         curl \
         gnupg \
- && corepack enable pnpm \
- && rm -rf /var/lib/apt/lists/*
+ && corepack enable pnpm
 
 # ---------------------------------------------------------------------
 # Layer 1b — Go toolchain, pinned to match devbox.json's go@1.26 (the
@@ -76,14 +78,15 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # Layer 2 — gh (GitHub CLI) via official deb repo. Pinned to the apt
 # stable line so updates roll with the rest of the image rebuild.
 # ---------------------------------------------------------------------
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
         | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
  && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
         > /etc/apt/sources.list.d/github-cli.list \
  && apt-get update \
- && apt-get install -y --no-install-recommends gh \
- && rm -rf /var/lib/apt/lists/*
+ && apt-get install -y --no-install-recommends gh
 
 # ---------------------------------------------------------------------
 # Layer 2b — glab (GitLab CLI), sibling to gh. Revi publishes code

--- a/sandbox/sec/Dockerfile
+++ b/sandbox/sec/Dockerfile
@@ -31,7 +31,12 @@ USER root
 # system install needs --break-system-packages; the console scripts land
 # on /usr/local/bin which is already on PATH. semgrep is the heavy one.
 # ---------------------------------------------------------------------
-RUN pip3 install --no-cache-dir --break-system-packages \
+# pip cache mount (~/.cache/pip): warm on the operator daemon, the wheels for
+# semgrep (the heavy one) + bandit + pip-audit are reused instead of refetched.
+# The mount isn't part of the image layer, so dropping --no-cache-dir keeps the
+# final image just as small while making rebuilds fast.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 install --break-system-packages \
         semgrep \
         bandit \
         pip-audit
@@ -43,11 +48,16 @@ RUN pip3 install --no-cache-dir --break-system-packages \
 # ---------------------------------------------------------------------
 ARG GOSEC_VERSION=latest
 ARG GOVULNCHECK_VERSION=latest
-RUN GOBIN=/usr/local/bin GOFLAGS=-mod=mod \
+# Cache mounts for the Go module cache (/root/go/pkg/mod) + build cache: the
+# gosec/govulncheck source + compiled objects stay warm on the operator daemon,
+# so re-installs skip the module download + recompile. Both are mounts (not
+# image layers), so they replace the old `rm -rf` cleanup for free.
+RUN --mount=type=cache,target=/root/go \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOBIN=/usr/local/bin GOFLAGS=-mod=mod \
         go install "github.com/securego/gosec/v2/cmd/gosec@${GOSEC_VERSION}" \
  && GOBIN=/usr/local/bin GOFLAGS=-mod=mod \
-        go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}" \
- && rm -rf /root/go/pkg /root/.cache/go-build
+        go install "golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}"
 
 # ---------------------------------------------------------------------
 # Layer 3 — single-binary scanners. Arch-derived like the full image so
@@ -87,9 +97,12 @@ RUN case "$(uname -m)" in \
 # whether deepsec is actually callable.
 # ---------------------------------------------------------------------
 ARG DEEPSEC_VERSION=latest
-RUN { curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/root/.npm \
+    { rm -f /etc/apt/apt.conf.d/docker-clean \
+        && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
         && apt-get install -y --no-install-recommends nodejs \
-        && rm -rf /var/lib/apt/lists/* \
         && npm install -g "deepsec@${DEEPSEC_VERSION}" ; } \
     || echo "deepsec Layer 4 setup did not complete — run_deepsec_scanner will degrade gracefully (enable_deepsec=true users should rebuild with a Node 22+ base or pre-install deepsec)."
 

--- a/scripts/bench/ci-build-bench.sh
+++ b/scripts/bench/ci-build-bench.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env sh
+# ci-build-bench.sh — factual speed comparison of buildkit-operator vs plain
+# `docker buildx` for the iterion container images, across cache states.
+#
+# It exists because the upstream operator (SocialGouv/buildkit-operator) ships a
+# perf *methodology* (docs/performance.md) but no repeatable bench script — this
+# is that script, parameterised for the iterion image set and reusable upstream.
+#
+# Modes:
+#   ci-build-bench.sh build [--image NAME] [--runs N] [--out DIR]
+#     Times a build across cache states → CSV + Markdown (min/median/max wall-clock
+#     + CACHED-step count). States:
+#       baseline-cold  plain `docker buildx --no-cache` (fresh)            — worst case, no operator
+#       baseline-warm  plain `docker buildx` reusing the local layer cache — best case, no operator
+#       operator-cold  buildkit-operator, untrusted=true                   — ephemeral daemon, NO cache (true cold)
+#       operator-warm  buildkit-operator, 2nd build same routing key       — warm PVC (cache mounts + layers)
+#     operator-* are skipped unless BUILDKIT_OPERATOR_BUILDD_URL + mTLS certs are set.
+#
+#   ci-build-bench.sh ci-durations [--old-run ID] [--new-run ID]
+#     OLD (QEMU multi-arch) vs NEW (operator amd64 + native arm64) full image.yml
+#     chain wall-clock, via `gh run view`. No IDs → lists recent main runs to pick from.
+#
+# Not forced from a pure CI client (need k8s-side BuildProject deletion): S3 cold
+# rehydrate (~9x) + daemon cold-start (~19.5s attach). Read them from the operator's
+# Prometheus metrics / e2e (TestS3ColdCache). See docs/ci-performance-buildkit-operator.md.
+set -eu
+
+IMAGE="bench"; RUNS=3; OUT="${TMPDIR:-/tmp}/iterion-ci-bench"
+BKO_REF="${BKO_REF:-20ed87560a925cc4aa3ef453e59aa10dce58975c}"
+GATEWAY_HOST="${BUILDKIT_OPERATOR_GATEWAY_HOST:-bkod.fabrique.social.gouv.fr}"
+OLD_RUN=""; NEW_RUN=""
+
+mode="${1:-build}"; [ $# -gt 0 ] && shift || true
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --image) IMAGE="$2"; shift 2 ;;
+    --runs)  RUNS="$2";  shift 2 ;;
+    --out)   OUT="$2";   shift 2 ;;
+    --old-run) OLD_RUN="$2"; shift 2 ;;
+    --new-run) NEW_RUN="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+mkdir -p "$OUT"
+
+median() { sort -n | awk '{a[NR]=$1} END{if(NR==0){print "NA";exit} m=int((NR+1)/2); if(NR%2)print a[m]; else printf "%.2f",(a[m]+a[m+1])/2}'; }
+minv()   { sort -n | head -n1; }
+maxv()   { sort -n | tail -n1; }
+now()    { date +%s.%N; }
+elapsed(){ awk "BEGIN{printf \"%.2f\", $2-$1}"; }
+cached_count() { grep -c 'CACHED' "$1" 2>/dev/null || echo 0; }
+
+# Representative throwaway context (cheap iterations); --image main|slim|full|sec
+# points at the real Dockerfiles for production-fidelity numbers.
+bench_context() {
+  d="$OUT/ctx"; mkdir -p "$d"
+  cat > "$d/Dockerfile" <<'DF'
+# syntax=docker/dockerfile:1.7
+FROM golang:1.26-bookworm
+WORKDIR /src
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    bash -c 'echo "BENCH_RAN=$(date +%s)"; for i in $(seq 1 8); do printf "package p%d\nfunc F%d() int { return %d }\n" "$i" "$i" "$i" > /tmp/p$i.go; go build -o /dev/null /tmp/p$i.go 2>/dev/null || true; done'
+DF
+  printf '%s' "$d"
+}
+resolve_target() {
+  case "$IMAGE" in
+    bench) CTX="$(bench_context)"; FILE="$CTX/Dockerfile"; BUILD_ARGS="" ;;
+    main)  CTX="."; FILE="Dockerfile"; BUILD_ARGS="VERSION=bench
+COMMIT=bench" ;;
+    slim)  CTX="sandbox/slim"; FILE="sandbox/slim/Dockerfile"; BUILD_ARGS="ITERION_IMAGE=ghcr.io/socialgouv/iterion:edge" ;;
+    full)  CTX="sandbox/full"; FILE="sandbox/full/Dockerfile"; BUILD_ARGS="BASE=ghcr.io/socialgouv/iterion-sandbox-slim:edge" ;;
+    sec)   CTX="sandbox/sec";  FILE="sandbox/sec/Dockerfile";  BUILD_ARGS="BASE=ghcr.io/socialgouv/iterion-sandbox-full:edge" ;;
+    *) echo "unknown --image $IMAGE" >&2; exit 2 ;;
+  esac
+}
+
+baseline() { # $1=label $2=extra flags ; one build, echoes seconds
+  log="$OUT/$1.log"; argflags=""
+  for a in $BUILD_ARGS; do argflags="$argflags --build-arg $a"; done
+  t0="$(now)"
+  # shellcheck disable=SC2086
+  docker buildx build --builder default $2 $argflags --progress=plain \
+    -f "$FILE" --output=type=cacheonly "$CTX" >"$log" 2>&1 || { echo "FAIL"; return 1; }
+  t1="$(now)"; elapsed "$t0" "$t1"
+}
+operator() { # $1=label $2=untrusted $3=routing-name ; one build, echoes seconds
+  log="$OUT/$1.log"; bs="$OUT/build.sh"
+  t0="$(now)"
+  BUILD_ARGS="$BUILD_ARGS" REPO="${GITHUB_REPOSITORY:-socialgouv/iterion}" NAME="$3" ARCH=amd64 \
+  BUILD_CONTEXT="$CTX" DOCKERFILE="$FILE" TAGS="iterion-bench:$1" PUSH=false UNTRUSTED="$2" \
+  BUILDKIT_OPERATOR_GATEWAY_HOST="$GATEWAY_HOST" \
+    sh "$bs" >"$log" 2>&1 || { echo "FAIL"; return 1; }
+  t1="$(now)"; elapsed "$t0" "$t1"
+}
+fetch_build_sh() {
+  bs="$OUT/build.sh"
+  if [ -n "${BKO_BUILD_SH:-}" ] && [ -f "$BKO_BUILD_SH" ]; then cp "$BKO_BUILD_SH" "$bs";
+  else curl -fsSL "https://raw.githubusercontent.com/SocialGouv/buildkit-operator/${BKO_REF}/scripts/build.sh" -o "$bs"; fi
+}
+
+run_state() { # $1=label $2=fn $3=arg1 $4=arg2 ; appends a CSV row
+  times=""; last=""; i=0
+  while [ "$i" -lt "$RUNS" ]; do
+    i=$((i+1)); printf '  %-14s run %d/%d... ' "$1" "$i" "$RUNS" >&2
+    t="$("$2" "$1" "$3" "$4" 2>>"$OUT/err.log" || true)"
+    case "$t" in
+      ''|FAIL|*[!0-9.]*) printf 'skip\n' >&2 ;;
+      *) times="$times$t
+"; last="$OUT/$1.log"; printf '%ss\n' "$t" >&2 ;;
+    esac
+  done
+  if [ -z "$times" ]; then echo "$1,NA,NA,NA,NA,$RUNS" >> "$CSV"; return; fi
+  mn="$(printf '%s' "$times" | grep . | minv)"
+  md="$(printf '%s' "$times" | grep . | median)"
+  mx="$(printf '%s' "$times" | grep . | maxv)"
+  echo "$1,$mn,$md,$mx,$(cached_count "$last"),$RUNS" >> "$CSV"
+}
+
+do_build() {
+  resolve_target
+  CSV="$OUT/results-$IMAGE.csv"; MD="$OUT/results-$IMAGE.md"
+  echo "state,min_s,median_s,max_s,cached_steps,runs" > "$CSV"
+  echo "Benchmarking image=$IMAGE runs=$RUNS → $OUT" >&2
+
+  run_state "baseline-cold" baseline "--no-cache" ""
+  run_state "baseline-warm" baseline "" ""
+
+  if [ -n "${BUILDKIT_OPERATOR_BUILDD_URL:-}" ]; then
+    fetch_build_sh
+    UNIQ="bench-$(od -An -N3 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n' || echo "$$")"
+    run_state "operator-cold" operator "true"  "$UNIQ-cold"
+    run_state "operator-warm" operator "false" "$UNIQ-warm" # 1st seeds, runs ≥2 are warm
+  else
+    echo "NOTE: BUILDKIT_OPERATOR_BUILDD_URL unset → operator states skipped (baseline only)." >&2
+  fi
+
+  {
+    echo "### Build-time benchmark — image \`$IMAGE\` (runs=$RUNS)"; echo
+    echo "| cache state | min (s) | median (s) | max (s) | CACHED steps |"
+    echo "|---|---|---|---|---|"
+    tail -n +2 "$CSV" | while IFS=, read -r st mn md mx cc _; do echo "| $st | $mn | $md | $mx | $cc |"; done
+  } > "$MD"
+  echo "----"; cat "$MD"; echo; echo "CSV: $CSV"
+}
+
+run_minutes() { gh run view "$1" --json createdAt,updatedAt --jq '((.updatedAt|fromdateiso8601)-(.createdAt|fromdateiso8601))/60|(.*10|round)/10'; }
+do_ci_durations() {
+  command -v gh >/dev/null || { echo "gh not installed" >&2; exit 1; }
+  if [ -z "$OLD_RUN" ] || [ -z "$NEW_RUN" ]; then
+    echo "Recent successful image.yml runs on main:" >&2
+    gh run list --workflow image.yml --branch main --status success -L 6 \
+      --json databaseId,headSha,createdAt --jq '.[]|"  run \(.databaseId)  \(.headSha[0:8])  \(.createdAt)"' >&2
+    echo "Re-run with --old-run <pre-migration ID> --new-run <post-migration ID>." >&2
+    exit 0
+  fi
+  old="$(run_minutes "$OLD_RUN")"; new="$(run_minutes "$NEW_RUN")"
+  sp="$(awk "BEGIN{ if($new>0) printf \"%.2f\", $old/$new; else print \"NA\" }")"
+  printf '| image.yml chain | wall-clock (min) |\n|---|---|\n'
+  printf '| OLD QEMU multi-arch (run %s) | %s |\n' "$OLD_RUN" "$old"
+  printf '| NEW operator amd64 + native arm64 (run %s) | %s |\n' "$NEW_RUN" "$new"
+  printf '| speedup | %s× |\n' "$sp"
+}
+
+case "$mode" in
+  build) do_build ;;
+  ci-durations) do_ci_durations ;;
+  *) echo "usage: $0 build|ci-durations [flags]" >&2; exit 2 ;;
+esac

--- a/scripts/bench/ci-build-bench.sh
+++ b/scripts/bench/ci-build-bench.sh
@@ -26,7 +26,7 @@
 set -eu
 
 IMAGE="bench"; RUNS=3; OUT="${TMPDIR:-/tmp}/iterion-ci-bench"
-BKO_REF="${BKO_REF:-20ed87560a925cc4aa3ef453e59aa10dce58975c}"
+BKO_REF="${BKO_REF:-8707e7f9d2a3baeeb5154bfbd0ae114bccfa4e58}"
 GATEWAY_HOST="${BUILDKIT_OPERATOR_GATEWAY_HOST:-bkod.fabrique.social.gouv.fr}"
 OLD_RUN=""; NEW_RUN=""
 


### PR DESCRIPTION
## Why

CI image builds are the iteration bottleneck. Measured on the latest `main` run
(`28290258656`): the `image.yml` chain takes **62.3 min** — the iterion image
(**33 min**) and `sandbox-sec` (**22 min**) dominate, both because arm64 is built
under **QEMU emulation**.

## What

**Migrate `image.yml` to a reusable `_build-image.yml` composite:**
- **amd64** → in-house **buildkit-operator** warm daemon (persistent cache mounts
  + S3 cold cache, GitHub-OIDC mTLS) — no QEMU; also dogfoods our own service.
- **arm64** → **native** `ubuntu-24.04-arm` runner (no emulation).
- **merge** → one multi-arch index from the per-arch staging manifests,
  cosign-signed + SBOM-attested once on the index digest.
- **PR events** validate locally (amd64 `--load`, no operator/secrets) so fork PRs
  keep working without the mTLS material.
- The 4 images keep their `needs:` chain (iterion → slim → full → sec) and
  base-tag resolution (edge on main/PR, `vX.Y.Z` on tags).

**Dockerfile `RUN --mount=type=cache` mounts** (warm on the operator daemon): pnpm
store + go-build (root), npm (llm-clis), apt (runtime); apt + pip + go module/build
caches (sandbox full/sec). Layer ordering already gated dep re-download on lockfile
changes; the mounts cut the compile/install cost too.

**Benchmark + report:** `scripts/bench/ci-build-bench.sh` (repeatable, all cache
states) + `docs/ci-performance-buildkit-operator.md` (measured OLD baseline; NEW
slots filled from the first migrated run).

## Dependencies / follow-ups

- Requires the buildkit-operator action SHA `20ed8756` (build-args passthrough,
  SocialGouv/buildkit-operator#1) — already pushed so `uses:` resolves.
- Repo `vars`/`secrets`: `BUILDKIT_OPERATOR_BUILDD_URL` (+ optional
  `BUILDKIT_OPERATOR_GATEWAY_HOST`) and `BUILDKIT_OPERATOR_{CA,CERT,KEY,TOKEN}`.
- This PR's `image.yml` run is **validate-only** (PR path); the operator path is
  exercised by a `workflow_dispatch` / first push to main, then the report's NEW
  numbers get filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)