### PR TITLE
feat: cloud kanban board + one-way forge sync, push-to-forge, linked PRs & CI

### DIFF
--- a/pkg/cli/studio.go
+++ b/pkg/cli/studio.go
@@ -1,15 +1,15 @@
 package cli
 
 import (
-	"net"
-	"strings"
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/alert"
@@ -134,6 +134,7 @@ func desktopAlertsEnabled() bool {
 //     is delivered via opts.OnReady. Used by the desktop host so multiple
 //     instances/projects never fight for 4891.
 //   - opts.Port > 0   : use that exact port.
+//
 // isLoopbackBindHost reports whether bind addresses only the loopback
 // interface, so the no-auth local studio is reachable only from this host. An
 // unparseable hostname is treated as non-loopback (fail safe).

--- a/pkg/cli/studio_bind_test.go
+++ b/pkg/cli/studio_bind_test.go
@@ -10,17 +10,17 @@ func TestIsLoopbackBindHost(t *testing.T) {
 		bind string
 		want bool
 	}{
-		{"", true},               // defaults to 127.0.0.1 upstream
+		{"", true}, // defaults to 127.0.0.1 upstream
 		{"127.0.0.1", true},
-		{"127.0.0.5", true},      // whole 127/8 loopback
+		{"127.0.0.5", true}, // whole 127/8 loopback
 		{"::1", true},
 		{"localhost", true},
-		{"LocalHost", true},      // case-insensitive
-		{"0.0.0.0", false},       // all interfaces → network-exposed
+		{"LocalHost", true}, // case-insensitive
+		{"0.0.0.0", false},  // all interfaces → network-exposed
 		{"::", false},
-		{"192.168.1.10", false},  // LAN
+		{"192.168.1.10", false}, // LAN
 		{"10.0.0.3", false},
-		{"example.com", false},   // unparseable host → fail safe (non-loopback)
+		{"example.com", false}, // unparseable host → fail safe (non-loopback)
 	}
 	for _, c := range cases {
 		if got := isLoopbackBindHost(c.bind); got != c.want {

--- a/pkg/dispatcher/boardmongo/store.go
+++ b/pkg/dispatcher/boardmongo/store.go
@@ -631,6 +631,11 @@ func applyPatch(iss *native.Issue, p native.Patch, board *native.Board) patchRes
 		iss.BotArgs = next
 		changed = append(changed, "bot_args")
 	}
+	if p.External != nil {
+		ext := *p.External
+		iss.External = &ext
+		changed = append(changed, "external")
+	}
 	return patchResult{fields: changed}
 }
 

--- a/pkg/dispatcher/native/boardstore.go
+++ b/pkg/dispatcher/native/boardstore.go
@@ -39,3 +39,9 @@ type BoardStore interface {
 
 // Compile-time assertion that the filesystem store satisfies the contract.
 var _ BoardStore = (*Store)(nil)
+
+// Compile-time guarantees: the filesystem store is a full board backend.
+var (
+	_ BoardStore = (*Store)(nil)
+	_ BoardAdmin = (*Store)(nil)
+)

--- a/pkg/dispatcher/native/http.go
+++ b/pkg/dispatcher/native/http.go
@@ -9,50 +9,129 @@ import (
 	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
 )
 
+// BoardAPI serves the kanban REST surface against a BoardStore resolved
+// PER REQUEST. Local/self-hosted mode resolves a single constant store
+// (the filesystem *Store); cloud mode resolves the caller's tenant board
+// (boardmongo.Store keyed by team) so one server serves every team's board
+// from the same routes. The handlers only touch the BoardStore interface
+// (+ the optional BoardAdmin / commentDispatcherSource capabilities), so the
+// same code drives both backends.
+type BoardAPI struct {
+	// Resolve returns the board store for this request, or an error. A nil
+	// store (no error) is treated as "board not available" (404). In cloud
+	// mode it extracts the team from the path/identity and returns
+	// CloudBoardFor(team); the membership gate lives in the mount wrapper.
+	Resolve func(r *http.Request) (BoardStore, error)
+}
+
+// BoardAdmin is the optional board-CONFIG-mutation capability: editing
+// columns, custom fields, saved views and the label vocabulary, including
+// the cascades to issues (a column rename follows its cards). The
+// filesystem *Store implements it; the cloud Mongo store does not yet, so
+// cloud board-config editing returns 501 (the board itself can still be
+// replaced wholesale via PUT /board, which is a plain BoardStore.SetBoard).
+type BoardAdmin interface {
+	AddState(st State) error
+	RenameState(from, to string) (int, error)
+	DeleteState(name, migrateTo string) (int, error)
+	UpdateState(name string, p StatePatch) error
+	ReorderStates(order []string) error
+	AddField(f Field) error
+	UpdateField(name string, p FieldPatch) error
+	RenameField(from, to string) (int, error)
+	DeleteField(name string) (int, error)
+	ReorderFields(order []string) error
+	SaveView(v View) error
+	DeleteView(name string) error
+	RenameLabel(from, to string) (int, error)
+	MergeLabels(from, to string) (int, error)
+	DeleteLabel(label string) (int, error)
+}
+
+// commentDispatcherSource is implemented by *Store: it exposes the installed
+// slash-command resolver so handleAddComment can auto-dispatch a leading
+// "/command". A store that doesn't implement it (boardmongo) simply records
+// the comment — cloud command-dispatch flows through invocation_dispatch.go.
+type commentDispatcherSource interface {
+	getCommentDispatcher() CommentDispatcher
+}
+
+var errBoardAdminUnavailable = errors.New("board configuration editing is not available on this server yet")
+
 // RegisterRoutes mounts the native tracker's REST surface on mux under
-// prefix. Pass "" to mount at the mux root.
-//
-// We register one pattern per (method, path) so Go 1.22's ServeMux
-// doesn't flag ambiguities against other catch-all method routes
-// (e.g. the server's `OPTIONS /api/` CORS preflight).
+// prefix against a single constant store. Pass "" to mount at the mux root.
 func (s *Store) RegisterRoutes(mux *http.ServeMux, prefix string) {
 	s.RegisterRoutesWithMiddleware(mux, prefix, nil)
 }
 
-// RegisterRoutesWithMiddleware mounts the routes through a caller-
-// supplied wrapper (typically the studio server's requireAuth). nil
-// wraps each handler in the identity — same behaviour as RegisterRoutes.
-// Used so the studio server can gate every native-tracker call behind
-// JWT auth without introducing a single bare-path catch-all that
-// would conflict with the server's existing method-specific patterns.
+// RegisterRoutesWithMiddleware mounts the routes for this constant store
+// through a caller-supplied wrapper (typically the studio server's
+// requireAuth). It delegates to a BoardAPI whose resolver always returns s,
+// so the self-hosted single-board behaviour is unchanged.
 func (s *Store) RegisterRoutesWithMiddleware(mux *http.ServeMux, prefix string, wrap func(http.Handler) http.Handler) {
+	(&BoardAPI{Resolve: func(*http.Request) (BoardStore, error) { return s, nil }}).
+		RegisterRoutesWithMiddleware(mux, prefix, wrap)
+}
+
+// RegisterRoutesWithMiddleware mounts the kanban REST routes under prefix,
+// each wrapped by wrap (nil = identity). One pattern per (method, path) so
+// Go 1.22's ServeMux doesn't flag ambiguities against other catch-all
+// method routes. The prefix may itself contain path wildcards (e.g.
+// "/api/teams/{tid}/board") that the resolver reads back via PathValue.
+func (h *BoardAPI) RegisterRoutesWithMiddleware(mux *http.ServeMux, prefix string, wrap func(http.Handler) http.Handler) {
 	p := strings.TrimSuffix(prefix, "/")
 	if wrap == nil {
-		wrap = func(h http.Handler) http.Handler { return h }
+		wrap = func(hh http.Handler) http.Handler { return hh }
 	}
-	mux.Handle("GET "+p+"/issues", wrap(http.HandlerFunc(s.handleListIssues)))
-	mux.Handle("POST "+p+"/issues", wrap(http.HandlerFunc(s.handleCreateIssue)))
-	mux.Handle("GET "+p+"/issues/{id}", wrap(http.HandlerFunc(s.handleGetIssue)))
-	mux.Handle("PATCH "+p+"/issues/{id}", wrap(http.HandlerFunc(s.handlePatchIssue)))
-	mux.Handle("DELETE "+p+"/issues/{id}", wrap(http.HandlerFunc(s.handleDeleteIssue)))
-	mux.Handle("POST "+p+"/issues/{id}/transition", wrap(http.HandlerFunc(s.handleTransitionIssue)))
-	mux.Handle("POST "+p+"/issues/{id}/comments", wrap(http.HandlerFunc(s.handleAddComment)))
-	mux.Handle("GET "+p+"/labels", wrap(http.HandlerFunc(s.handleListLabels)))
-	mux.Handle("POST "+p+"/labels/rename", wrap(http.HandlerFunc(s.handleRenameLabel)))
-	mux.Handle("POST "+p+"/labels/merge", wrap(http.HandlerFunc(s.handleMergeLabels)))
-	mux.Handle("DELETE "+p+"/labels/{label}", wrap(http.HandlerFunc(s.handleDeleteLabel)))
-	mux.Handle("GET "+p+"/board", wrap(http.HandlerFunc(s.handleGetBoard)))
-	mux.Handle("PUT "+p+"/board", wrap(http.HandlerFunc(s.handlePutBoard)))
-	mux.Handle("POST "+p+"/board/states", wrap(http.HandlerFunc(s.handleAddState)))
-	mux.Handle("POST "+p+"/board/states/reorder", wrap(http.HandlerFunc(s.handleReorderStates)))
-	mux.Handle("PATCH "+p+"/board/states/{name}", wrap(http.HandlerFunc(s.handleUpdateState)))
-	mux.Handle("DELETE "+p+"/board/states/{name}", wrap(http.HandlerFunc(s.handleDeleteState)))
-	mux.Handle("POST "+p+"/board/fields", wrap(http.HandlerFunc(s.handleAddField)))
-	mux.Handle("POST "+p+"/board/fields/reorder", wrap(http.HandlerFunc(s.handleReorderFields)))
-	mux.Handle("PATCH "+p+"/board/fields/{name}", wrap(http.HandlerFunc(s.handleUpdateField)))
-	mux.Handle("DELETE "+p+"/board/fields/{name}", wrap(http.HandlerFunc(s.handleDeleteField)))
-	mux.Handle("POST "+p+"/board/views", wrap(http.HandlerFunc(s.handleSaveView)))
-	mux.Handle("DELETE "+p+"/board/views/{name}", wrap(http.HandlerFunc(s.handleDeleteView)))
+	mux.Handle("GET "+p+"/issues", wrap(http.HandlerFunc(h.handleListIssues)))
+	mux.Handle("POST "+p+"/issues", wrap(http.HandlerFunc(h.handleCreateIssue)))
+	mux.Handle("GET "+p+"/issues/{id}", wrap(http.HandlerFunc(h.handleGetIssue)))
+	mux.Handle("PATCH "+p+"/issues/{id}", wrap(http.HandlerFunc(h.handlePatchIssue)))
+	mux.Handle("DELETE "+p+"/issues/{id}", wrap(http.HandlerFunc(h.handleDeleteIssue)))
+	mux.Handle("POST "+p+"/issues/{id}/transition", wrap(http.HandlerFunc(h.handleTransitionIssue)))
+	mux.Handle("POST "+p+"/issues/{id}/comments", wrap(http.HandlerFunc(h.handleAddComment)))
+	mux.Handle("GET "+p+"/labels", wrap(http.HandlerFunc(h.handleListLabels)))
+	mux.Handle("POST "+p+"/labels/rename", wrap(http.HandlerFunc(h.handleRenameLabel)))
+	mux.Handle("POST "+p+"/labels/merge", wrap(http.HandlerFunc(h.handleMergeLabels)))
+	mux.Handle("DELETE "+p+"/labels/{label}", wrap(http.HandlerFunc(h.handleDeleteLabel)))
+	mux.Handle("GET "+p+"/board", wrap(http.HandlerFunc(h.handleGetBoard)))
+	mux.Handle("PUT "+p+"/board", wrap(http.HandlerFunc(h.handlePutBoard)))
+	mux.Handle("POST "+p+"/board/states", wrap(http.HandlerFunc(h.handleAddState)))
+	mux.Handle("POST "+p+"/board/states/reorder", wrap(http.HandlerFunc(h.handleReorderStates)))
+	mux.Handle("PATCH "+p+"/board/states/{name}", wrap(http.HandlerFunc(h.handleUpdateState)))
+	mux.Handle("DELETE "+p+"/board/states/{name}", wrap(http.HandlerFunc(h.handleDeleteState)))
+	mux.Handle("POST "+p+"/board/fields", wrap(http.HandlerFunc(h.handleAddField)))
+	mux.Handle("POST "+p+"/board/fields/reorder", wrap(http.HandlerFunc(h.handleReorderFields)))
+	mux.Handle("PATCH "+p+"/board/fields/{name}", wrap(http.HandlerFunc(h.handleUpdateField)))
+	mux.Handle("DELETE "+p+"/board/fields/{name}", wrap(http.HandlerFunc(h.handleDeleteField)))
+	mux.Handle("POST "+p+"/board/views", wrap(http.HandlerFunc(h.handleSaveView)))
+	mux.Handle("DELETE "+p+"/board/views/{name}", wrap(http.HandlerFunc(h.handleDeleteView)))
+}
+
+// store resolves the per-request board store, writing the appropriate error
+// and returning ok=false when unavailable.
+func (h *BoardAPI) store(w http.ResponseWriter, r *http.Request) (BoardStore, bool) {
+	s, err := h.Resolve(r)
+	if err != nil {
+		writeErr(w, statusForErr(err), err)
+		return nil, false
+	}
+	if s == nil {
+		writeErr(w, http.StatusNotFound, errors.New("board not available"))
+		return nil, false
+	}
+	return s, true
+}
+
+// admin type-asserts the BoardAdmin capability, writing 501 when the
+// resolved store can't edit board config (cloud boardmongo today).
+func (h *BoardAPI) admin(w http.ResponseWriter, s BoardStore) (BoardAdmin, bool) {
+	a, ok := s.(BoardAdmin)
+	if !ok {
+		writeErr(w, http.StatusNotImplemented, errBoardAdminUnavailable)
+		return nil, false
+	}
+	return a, true
 }
 
 // ---------------------------------------------------------------------------
@@ -72,70 +151,11 @@ type issueCreateReq struct {
 	BotArgs  map[string]string `json:"bot_args,omitempty"`
 }
 
-// handleListLabels returns every label currently in use on the board
-// with usage count + last-used timestamp. Sorted by count desc.
-// Read-only; no auth check beyond the wrap-middleware applied at mount.
-func (s *Store) handleListLabels(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, s.AggregateLabels())
-}
-
-type labelRenameReq struct {
-	From string `json:"from"`
-	To   string `json:"to"`
-}
-
-type labelOpResp struct {
-	Touched int `json:"touched"`
-}
-
-// handleRenameLabel POST /labels/rename {from, to}: rewrites every
-// occurrence of `from` to `to` across the board. Returns the number
-// of issues whose label set actually changed.
-func (s *Store) handleRenameLabel(w http.ResponseWriter, r *http.Request) {
-	var in labelRenameReq
-	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+func (h *BoardAPI) handleListIssues(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
 		return
 	}
-	n, err := s.RenameLabel(in.From, in.To)
-	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
-		return
-	}
-	writeJSON(w, http.StatusOK, labelOpResp{Touched: n})
-}
-
-// handleMergeLabels POST /labels/merge {from, to}: every issue
-// carrying `from` ends up carrying `to` (de-duped) and no longer
-// `from`. Audit-trail twin of rename.
-func (s *Store) handleMergeLabels(w http.ResponseWriter, r *http.Request) {
-	var in labelRenameReq
-	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
-		writeErr(w, http.StatusBadRequest, err)
-		return
-	}
-	n, err := s.MergeLabels(in.From, in.To)
-	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
-		return
-	}
-	writeJSON(w, http.StatusOK, labelOpResp{Touched: n})
-}
-
-// handleDeleteLabel DELETE /labels/{label}: strips the label from every
-// issue. The label name is URL-path-encoded by the client; the
-// router unescapes it via PathValue.
-func (s *Store) handleDeleteLabel(w http.ResponseWriter, r *http.Request) {
-	label := r.PathValue("label")
-	n, err := s.DeleteLabel(label)
-	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
-		return
-	}
-	writeJSON(w, http.StatusOK, labelOpResp{Touched: n})
-}
-
-func (s *Store) handleListIssues(w http.ResponseWriter, r *http.Request) {
 	filter := ListFilter{
 		States: r.URL.Query()["state"],
 		Labels: r.URL.Query()["label"],
@@ -151,13 +171,17 @@ func (s *Store) handleListIssues(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, issues)
 }
 
-func (s *Store) handleCreateIssue(w http.ResponseWriter, r *http.Request) {
+func (h *BoardAPI) handleCreateIssue(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
 	var in issueCreateReq
 	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	iss := Issue{
+	out, err := s.Create(Issue{
 		Title:    in.Title,
 		Body:     in.Body,
 		State:    in.State,
@@ -168,8 +192,7 @@ func (s *Store) handleCreateIssue(w http.ResponseWriter, r *http.Request) {
 		Fields:   in.Fields,
 		Bot:      in.Bot,
 		BotArgs:  in.BotArgs,
-	}
-	out, err := s.Create(iss)
+	})
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
@@ -197,10 +220,10 @@ type transitionReq struct {
 	To string `json:"to"`
 }
 
-// resolvePathID extracts the {id} segment, runs prefix resolution, and
-// returns the full ID. On miss/ambiguity writes the appropriate HTTP
-// error and returns "" + false.
-func (s *Store) resolvePathID(w http.ResponseWriter, r *http.Request) (string, bool) {
+// resolvePathID extracts the {id} segment, runs prefix resolution against
+// the resolved store, and returns the full ID. On miss/ambiguity writes the
+// appropriate HTTP error and returns "" + false.
+func resolvePathID(s BoardStore, w http.ResponseWriter, r *http.Request) (string, bool) {
 	raw := r.PathValue("id")
 	if raw == "" {
 		http.NotFound(w, r)
@@ -218,8 +241,12 @@ func (s *Store) resolvePathID(w http.ResponseWriter, r *http.Request) (string, b
 	return id, true
 }
 
-func (s *Store) handleGetIssue(w http.ResponseWriter, r *http.Request) {
-	id, ok := s.resolvePathID(w, r)
+func (h *BoardAPI) handleGetIssue(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	id, ok := resolvePathID(s, w, r)
 	if !ok {
 		return
 	}
@@ -231,8 +258,12 @@ func (s *Store) handleGetIssue(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, iss)
 }
 
-func (s *Store) handlePatchIssue(w http.ResponseWriter, r *http.Request) {
-	id, ok := s.resolvePathID(w, r)
+func (h *BoardAPI) handlePatchIssue(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	id, ok := resolvePathID(s, w, r)
 	if !ok {
 		return
 	}
@@ -259,8 +290,12 @@ func (s *Store) handlePatchIssue(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
-func (s *Store) handleDeleteIssue(w http.ResponseWriter, r *http.Request) {
-	id, ok := s.resolvePathID(w, r)
+func (h *BoardAPI) handleDeleteIssue(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	id, ok := resolvePathID(s, w, r)
 	if !ok {
 		return
 	}
@@ -271,8 +306,12 @@ func (s *Store) handleDeleteIssue(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (s *Store) handleTransitionIssue(w http.ResponseWriter, r *http.Request) {
-	id, ok := s.resolvePathID(w, r)
+func (h *BoardAPI) handleTransitionIssue(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	id, ok := resolvePathID(s, w, r)
 	if !ok {
 		return
 	}
@@ -293,14 +332,11 @@ func (s *Store) handleTransitionIssue(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, iss)
 }
 
-// commentReq is the body of POST /issues/{id}/comments. Body is the
-// comment text. The optional Bot / BotArgs / TransitionTo fields let a
-// caller (the studio comment box, which knows the bot catalogue and has
-// already parsed a `/command`) both record the comment AND dispatch a
-// run in one request: stamp the bot + per-run args and move the issue to
-// a dispatch-eligible state, which the polling dispatcher then runs. The
-// native store stays decoupled from the bot registry — command→bot
-// resolution happens in the caller, not here.
+// commentReq is the body of POST /issues/{id}/comments. Body is the comment
+// text. The optional Bot / BotArgs / TransitionTo fields let a caller record
+// the comment AND dispatch a run in one request. The native store stays
+// decoupled from the bot registry — command→bot resolution happens in the
+// caller (or the installed CommentDispatcher), not here.
 type commentReq struct {
 	Author       string            `json:"author,omitempty"`
 	Body         string            `json:"body"`
@@ -309,8 +345,12 @@ type commentReq struct {
 	TransitionTo string            `json:"transition_to,omitempty"`
 }
 
-func (s *Store) handleAddComment(w http.ResponseWriter, r *http.Request) {
-	id, ok := s.resolvePathID(w, r)
+func (h *BoardAPI) handleAddComment(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	id, ok := resolvePathID(s, w, r)
 	if !ok {
 		return
 	}
@@ -331,17 +371,19 @@ func (s *Store) handleAddComment(w http.ResponseWriter, r *http.Request) {
 	bot := in.Bot
 	botArgs := in.BotArgs
 	transitionTo := in.TransitionTo
-	// Auto-resolve a leading "/command" when the caller didn't pre-resolve a bot
-	// (the API/curl twin of the studio comment box, which resolves it client-side
-	// and posts explicit bot/bot_args). The server installs the resolver; a bare
-	// store leaves it nil and just records the comment, as before.
+	// Auto-resolve a leading "/command" when the caller didn't pre-resolve a
+	// bot AND the store exposes a comment dispatcher (the filesystem *Store
+	// does; boardmongo doesn't, so cloud just records the comment and lets
+	// invocation_dispatch.go handle commands).
 	if bot == nil && botArgs == nil && updated != nil {
-		if d := s.getCommentDispatcher(); d != nil {
-			if rbot, rargs, rto, rok := d(*updated, in.Body); rok {
-				bot = &rbot
-				botArgs = rargs
-				if transitionTo == "" {
-					transitionTo = rto
+		if src, sok := s.(commentDispatcherSource); sok {
+			if d := src.getCommentDispatcher(); d != nil {
+				if rbot, rargs, rto, rok := d(*updated, in.Body); rok {
+					bot = &rbot
+					botArgs = rargs
+					if transitionTo == "" {
+						transitionTo = rto
+					}
 				}
 			}
 		}
@@ -376,14 +418,106 @@ func (s *Store) handleAddComment(w http.ResponseWriter, r *http.Request) {
 }
 
 // ---------------------------------------------------------------------------
+// /labels
+// ---------------------------------------------------------------------------
+
+// handleListLabels returns every label currently in use on the board with
+// usage count + last-used timestamp. Read-only; auth is the mount wrapper.
+func (h *BoardAPI) handleListLabels(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, s.AggregateLabels())
+}
+
+type labelRenameReq struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+type labelOpResp struct {
+	Touched int `json:"touched"`
+}
+
+func (h *BoardAPI) handleRenameLabel(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	a, ok := h.admin(w, s)
+	if !ok {
+		return
+	}
+	var in labelRenameReq
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	n, err := a.RenameLabel(in.From, in.To)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, labelOpResp{Touched: n})
+}
+
+func (h *BoardAPI) handleMergeLabels(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	a, ok := h.admin(w, s)
+	if !ok {
+		return
+	}
+	var in labelRenameReq
+	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	n, err := a.MergeLabels(in.From, in.To)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, labelOpResp{Touched: n})
+}
+
+func (h *BoardAPI) handleDeleteLabel(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	a, ok := h.admin(w, s)
+	if !ok {
+		return
+	}
+	n, err := a.DeleteLabel(r.PathValue("label"))
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, labelOpResp{Touched: n})
+}
+
+// ---------------------------------------------------------------------------
 // /board
 // ---------------------------------------------------------------------------
 
-func (s *Store) handleGetBoard(w http.ResponseWriter, _ *http.Request) {
+func (h *BoardAPI) handleGetBoard(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
 	writeJSON(w, http.StatusOK, s.Board())
 }
 
-func (s *Store) handlePutBoard(w http.ResponseWriter, r *http.Request) {
+func (h *BoardAPI) handlePutBoard(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
 	var b Board
 	if err := json.NewDecoder(r.Body).Decode(&b); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
@@ -396,9 +530,9 @@ func (s *Store) handlePutBoard(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, s.Board())
 }
 
-// stateUpdateReq is the PATCH /board/states/{name} body. A non-nil Name
-// that differs from the path segment triggers a cascading rename (issues
-// in the column follow); the remaining fields are applied afterward.
+// stateUpdateReq is the PATCH /board/states/{name} body. A non-nil Name that
+// differs from the path segment triggers a cascading rename (issues in the
+// column follow); the remaining fields are applied afterward.
 type stateUpdateReq struct {
 	Name     *string `json:"name,omitempty"`
 	Display  *string `json:"display,omitempty"`
@@ -407,37 +541,48 @@ type stateUpdateReq struct {
 	Terminal *bool   `json:"terminal,omitempty"`
 }
 
-type reorderStatesReq struct {
+type reorderReq struct {
 	Order []string `json:"order"`
 }
 
-// stateDeleteConflictResp is the 409 body returned when a non-empty
-// column is deleted without a migration target. `count` lets the UI
-// prompt "move N issues to…".
+// stateDeleteConflictResp is the 409 body returned when a non-empty column is
+// deleted without a migration target. `count` lets the UI prompt "move N
+// issues to…".
 type stateDeleteConflictResp struct {
 	Error string `json:"error"`
 	Count int    `json:"count"`
 }
 
-// handleAddState POST /board/states: appends a new column. Body is a
-// State. Returns the refreshed board.
-func (s *Store) handleAddState(w http.ResponseWriter, r *http.Request) {
+func (h *BoardAPI) handleAddState(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	a, ok := h.admin(w, s)
+	if !ok {
+		return
+	}
 	var st State
 	if err := json.NewDecoder(r.Body).Decode(&st); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	if err := s.AddState(st); err != nil {
+	if err := a.AddState(st); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, s.Board())
 }
 
-// handleUpdateState PATCH /board/states/{name}: edits a column's
-// display/color/flags and, when the body carries a different `name`,
-// renames it first (cascading to issues). Returns the refreshed board.
-func (s *Store) handleUpdateState(w http.ResponseWriter, r *http.Request) {
+func (h *BoardAPI) handleUpdateState(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	a, ok := h.admin(w, s)
+	if !ok {
+		return
+	}
 	name := r.PathValue("name")
 	var in stateUpdateReq
 	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
@@ -446,14 +591,14 @@ func (s *Store) handleUpdateState(w http.ResponseWriter, r *http.Request) {
 	}
 	target := name
 	if in.Name != nil && *in.Name != name {
-		if _, err := s.RenameState(name, *in.Name); err != nil {
+		if _, err := a.RenameState(name, *in.Name); err != nil {
 			writeErr(w, http.StatusBadRequest, err)
 			return
 		}
 		target = *in.Name
 	}
 	if in.Display != nil || in.Color != nil || in.Eligible != nil || in.Terminal != nil {
-		if err := s.UpdateState(target, StatePatch{
+		if err := a.UpdateState(target, StatePatch{
 			Display:  in.Display,
 			Color:    in.Color,
 			Eligible: in.Eligible,
@@ -466,14 +611,17 @@ func (s *Store) handleUpdateState(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, s.Board())
 }
 
-// handleDeleteState DELETE /board/states/{name}?migrate_to=X: removes a
-// column. A non-empty column without a migration target returns 409 with
-// the issue count so the UI can prompt for a destination.
-func (s *Store) handleDeleteState(w http.ResponseWriter, r *http.Request) {
+func (h *BoardAPI) handleDeleteState(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	a, ok := h.admin(w, s)
+	if !ok {
+		return
+	}
 	name := r.PathValue("name")
-	migrateTo := r.URL.Query().Get("migrate_to")
-	_, err := s.DeleteState(name, migrateTo)
-	if err != nil {
+	if _, err := a.DeleteState(name, r.URL.Query().Get("migrate_to")); err != nil {
 		if errors.Is(err, ErrStateNotEmpty) {
 			count := 0
 			for _, iss := range mustList(s) {
@@ -490,24 +638,30 @@ func (s *Store) handleDeleteState(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, s.Board())
 }
 
-// handleReorderStates POST /board/states/reorder {order:[...]}: rewrites
-// the column order. Returns the refreshed board.
-func (s *Store) handleReorderStates(w http.ResponseWriter, r *http.Request) {
-	var in reorderStatesReq
+func (h *BoardAPI) handleReorderStates(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	a, ok := h.admin(w, s)
+	if !ok {
+		return
+	}
+	var in reorderReq
 	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	if err := s.ReorderStates(in.Order); err != nil {
+	if err := a.ReorderStates(in.Order); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, s.Board())
 }
 
-// mustList returns the current issues for the 409 count; on error it
-// returns nil (count falls back to 0, still a valid conflict response).
-func mustList(s *Store) []*Issue {
+// mustList returns the current issues for the 409 count; on error it returns
+// nil (count falls back to 0, still a valid conflict response).
+func mustList(s BoardStore) []*Issue {
 	issues, err := s.List(ListFilter{})
 	if err != nil {
 		return nil
@@ -515,9 +669,9 @@ func mustList(s *Store) []*Issue {
 	return issues
 }
 
-// fieldUpdateReq is the PATCH /board/fields/{name} body. A non-nil Name
-// that differs from the path triggers a cascading rename across issues;
-// remaining attributes are applied afterward.
+// fieldUpdateReq is the PATCH /board/fields/{name} body. A non-nil Name that
+// differs from the path triggers a cascading rename across issues; remaining
+// attributes are applied afterward.
 type fieldUpdateReq struct {
 	Name       *string    `json:"name,omitempty"`
 	Display    *string    `json:"display,omitempty"`
@@ -526,24 +680,36 @@ type fieldUpdateReq struct {
 	EnumValues *[]string  `json:"enum_values,omitempty"`
 }
 
-// handleAddField POST /board/fields: appends a custom-field definition.
-func (s *Store) handleAddField(w http.ResponseWriter, r *http.Request) {
+func (h *BoardAPI) handleAddField(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	a, ok := h.admin(w, s)
+	if !ok {
+		return
+	}
 	var f Field
 	if err := json.NewDecoder(r.Body).Decode(&f); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	if err := s.AddField(f); err != nil {
+	if err := a.AddField(f); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, s.Board())
 }
 
-// handleUpdateField PATCH /board/fields/{name}: edits a field definition
-// and, when the body carries a different `name`, renames it first
-// (cascading across issue.Fields maps).
-func (s *Store) handleUpdateField(w http.ResponseWriter, r *http.Request) {
+func (h *BoardAPI) handleUpdateField(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	a, ok := h.admin(w, s)
+	if !ok {
+		return
+	}
 	name := r.PathValue("name")
 	var in fieldUpdateReq
 	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
@@ -552,14 +718,14 @@ func (s *Store) handleUpdateField(w http.ResponseWriter, r *http.Request) {
 	}
 	target := name
 	if in.Name != nil && *in.Name != name {
-		if _, err := s.RenameField(name, *in.Name); err != nil {
+		if _, err := a.RenameField(name, *in.Name); err != nil {
 			writeErr(w, http.StatusBadRequest, err)
 			return
 		}
 		target = *in.Name
 	}
 	if in.Display != nil || in.Type != nil || in.Required != nil || in.EnumValues != nil {
-		if err := s.UpdateField(target, FieldPatch{
+		if err := a.UpdateField(target, FieldPatch{
 			Display:    in.Display,
 			Type:       in.Type,
 			Required:   in.Required,
@@ -572,48 +738,74 @@ func (s *Store) handleUpdateField(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, s.Board())
 }
 
-// handleDeleteField DELETE /board/fields/{name}: removes a field
-// definition and strips its key from every issue.
-func (s *Store) handleDeleteField(w http.ResponseWriter, r *http.Request) {
-	if _, err := s.DeleteField(r.PathValue("name")); err != nil {
+func (h *BoardAPI) handleDeleteField(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	a, ok := h.admin(w, s)
+	if !ok {
+		return
+	}
+	if _, err := a.DeleteField(r.PathValue("name")); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, s.Board())
 }
 
-// handleReorderFields POST /board/fields/reorder {order:[...]}.
-func (s *Store) handleReorderFields(w http.ResponseWriter, r *http.Request) {
-	var in reorderStatesReq
+func (h *BoardAPI) handleReorderFields(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	a, ok := h.admin(w, s)
+	if !ok {
+		return
+	}
+	var in reorderReq
 	if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	if err := s.ReorderFields(in.Order); err != nil {
+	if err := a.ReorderFields(in.Order); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, s.Board())
 }
 
-// handleSaveView POST /board/views: upserts a named filter/sort/group
-// preset (body = View). Returns the refreshed board.
-func (s *Store) handleSaveView(w http.ResponseWriter, r *http.Request) {
+func (h *BoardAPI) handleSaveView(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	a, ok := h.admin(w, s)
+	if !ok {
+		return
+	}
 	var v View
 	if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	if err := s.SaveView(v); err != nil {
+	if err := a.SaveView(v); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, s.Board())
 }
 
-// handleDeleteView DELETE /board/views/{name}: removes a saved view.
-func (s *Store) handleDeleteView(w http.ResponseWriter, r *http.Request) {
-	if err := s.DeleteView(r.PathValue("name")); err != nil {
+func (h *BoardAPI) handleDeleteView(w http.ResponseWriter, r *http.Request) {
+	s, ok := h.store(w, r)
+	if !ok {
+		return
+	}
+	a, ok := h.admin(w, s)
+	if !ok {
+		return
+	}
+	if err := a.DeleteView(r.PathValue("name")); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}

--- a/pkg/dispatcher/native/issue.go
+++ b/pkg/dispatcher/native/issue.go
@@ -39,11 +39,28 @@ type Issue struct {
 	LastWorkdir string    `json:"last_workdir,omitempty"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
+	// External links this card to an issue on an external forge — set when
+	// the card is mirrored FROM a forge (one-way forge→board sync) or pushed
+	// TO one (push-to-forge). It is metadata: the card's column stays
+	// operator-owned. Repo doubles as the board swimlane key (repo-per-lane).
+	External *ExternalRef `json:"external,omitempty"`
 	// Comments is the append-only discussion thread on the issue. Used
 	// by hooks / the dispatcher to leave a dispatch trail, by the studio
 	// IssueModal, and — once the comment-trigger wiring lands — to carry
 	// operator `/command` requests and the resulting MR/PR back-links.
 	Comments []Comment `json:"comments,omitempty"`
+}
+
+// ExternalRef links a board card to an issue on an external forge. Set by
+// the forge→board sync worker and the push-to-forge action; read by the card
+// PR/CI panel and push handler. Provider is "github"|"gitlab"|"forgejo".
+type ExternalRef struct {
+	Provider     string `json:"provider"`
+	ConnectionID string `json:"connection_id"`
+	Repo         string `json:"repo"`
+	Number       int    `json:"number"`
+	URL          string `json:"url,omitempty"`
+	State        string `json:"state,omitempty"`
 }
 
 // Comment is a single append-only note on a native issue. Author is a

--- a/pkg/dispatcher/native/store.go
+++ b/pkg/dispatcher/native/store.go
@@ -897,6 +897,10 @@ func (s *Store) List(filter ListFilter) ([]*Issue, error) {
 // own mutable instance and cannot mutate the in-memory cache.
 func cloneIssue(in *Issue) *Issue {
 	c := *in
+	if in.External != nil {
+		ext := *in.External
+		c.External = &ext
+	}
 	if in.Labels != nil {
 		c.Labels = append([]string(nil), in.Labels...)
 	}
@@ -962,6 +966,10 @@ type Patch struct {
 	// collection swaps. Per-key partial updates aren't useful because
 	// the studio always sends the full form state.
 	BotArgs *map[string]string
+	// External, when non-nil, sets the card's forge linkage (the
+	// forge→board sync worker refreshes url/state; push-to-forge stamps a
+	// previously-unlinked card). A nil pointer leaves the existing link.
+	External *ExternalRef
 }
 
 // Update applies the patch and emits an issue_updated event with the
@@ -1017,6 +1025,10 @@ func (s *Store) Update(id string, p Patch) (updated *Issue, err error) {
 		}
 		iss.Fields = merged
 		changed = append(changed, "fields")
+	}
+	if p.External != nil {
+		ext := *p.External
+		iss.External = &ext
 	}
 	if p.Bot != nil && *p.Bot != iss.Bot {
 		iss.Bot = *p.Bot

--- a/pkg/forge/forgejo/ci.go
+++ b/pkg/forge/forgejo/ci.go
@@ -1,0 +1,246 @@
+package forgejo
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// PullClient: Forgejo/Gitea pull-request + CI capability surfacing linked PRs
+// and commit-status CI state (current + history) on board cards.
+//
+// CI on Forgejo/Gitea is exposed as commit statuses (and, on newer Forgejo,
+// Actions). We use the commit-status surface — combined status for the
+// aggregate (GetCIStatus) and per-context statuses for history
+// (ListCIHistory) — which is portable across Gitea and every Forgejo version.
+var _ forge.PullClient = (*AdminClient)(nil)
+
+// issueRefPattern extracts "#<n>" issue references from a PR title/body for
+// best-effort LinkedIssues parsing.
+var issueRefPattern = regexp.MustCompile(`#(\d+)`)
+
+type forgejoBranchInfo struct {
+	Ref string `json:"ref"`
+	Sha string `json:"sha"`
+}
+
+// forgejoPull mirrors the Gitea API PullRequest shape (subset we normalize).
+type forgejoPull struct {
+	Number  int64              `json:"number"`
+	Title   string             `json:"title"`
+	Body    string             `json:"body"`
+	State   string             `json:"state"` // "open" | "closed"
+	HTMLURL string             `json:"html_url"`
+	Draft   bool               `json:"draft"`
+	Merged  bool               `json:"merged"`
+	Poster  *forgejoUser       `json:"user"`
+	Head    *forgejoBranchInfo `json:"head"`
+	Base    *forgejoBranchInfo `json:"base"`
+	Created *time.Time         `json:"created_at"`
+	Updated *time.Time         `json:"updated_at"`
+}
+
+func (p forgejoPull) toRef() forge.PullRef {
+	state := p.State
+	if p.Merged {
+		state = "merged"
+	}
+	ref := forge.PullRef{
+		Number: int(p.Number),
+		Title:  p.Title,
+		State:  state,
+		URL:    p.HTMLURL,
+		Draft:  p.Draft,
+	}
+	if p.Poster != nil {
+		ref.Author = p.Poster.Login
+	}
+	if p.Head != nil {
+		ref.SourceBranch = p.Head.Ref
+		ref.HeadSHA = p.Head.Sha
+	}
+	if p.Base != nil {
+		ref.TargetBranch = p.Base.Ref
+	}
+	if p.Created != nil {
+		ref.CreatedAt = *p.Created
+	}
+	if p.Updated != nil {
+		ref.UpdatedAt = *p.Updated
+	}
+	ref.LinkedIssues = parseLinkedIssues(p.Title, p.Body)
+	return ref
+}
+
+// parseLinkedIssues extracts unique "#<n>" references from a PR's title+body.
+func parseLinkedIssues(title, body string) []int {
+	seen := map[int]bool{}
+	var out []int
+	for _, text := range []string{title, body} {
+		for _, m := range issueRefPattern.FindAllStringSubmatch(text, -1) {
+			n, err := strconv.Atoi(m[1])
+			if err != nil || n <= 0 || seen[n] {
+				continue
+			}
+			seen[n] = true
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// ListPullRequests lists PRs for a repo. state defaults to "open".
+func (c *AdminClient) ListPullRequests(ctx context.Context, repo string, opts forge.PullListOptions) ([]forge.PullRef, error) {
+	vals := url.Values{}
+	state := opts.State
+	if state == "" {
+		state = "open"
+	}
+	vals.Set("state", state)
+	page := opts.Page
+	if page <= 0 {
+		page = 1
+	}
+	vals.Set("page", strconv.Itoa(page))
+	perPage := opts.PerPage
+	if perPage <= 0 {
+		perPage = 50
+	}
+	vals.Set("limit", strconv.Itoa(perPage))
+
+	var pulls []forgejoPull
+	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/pulls?"+vals.Encode(), nil, &pulls)
+	if err != nil {
+		return nil, err
+	}
+	if code != http.StatusOK {
+		return nil, statusErr("GET pulls", code)
+	}
+	out := make([]forge.PullRef, 0, len(pulls))
+	for _, p := range pulls {
+		out = append(out, p.toRef())
+	}
+	return out, nil
+}
+
+// GetPullRequest fetches one PR by index.
+func (c *AdminClient) GetPullRequest(ctx context.Context, repo string, number int) (forge.PullRef, error) {
+	var p forgejoPull
+	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/pulls/"+strconv.Itoa(number), nil, &p)
+	if err != nil {
+		return forge.PullRef{}, err
+	}
+	if code != http.StatusOK {
+		return forge.PullRef{}, statusErr("GET pull", code)
+	}
+	return p.toRef(), nil
+}
+
+// forgejoCommitStatus is one per-context commit status. Note the JSON quirk:
+// in the COMBINED status payload the per-context state is `status`, while the
+// aggregate top-level state is `state`.
+type forgejoCommitStatus struct {
+	State       string    `json:"status"`
+	Context     string    `json:"context"`
+	Description string    `json:"description"`
+	TargetURL   string    `json:"target_url"`
+	URL         string    `json:"url"`
+	Created     time.Time `json:"created_at"`
+	Updated     time.Time `json:"updated_at"`
+}
+
+// forgejoCombinedStatus is GET /commits/{ref}/status.
+type forgejoCombinedStatus struct {
+	State    string                `json:"state"`
+	SHA      string                `json:"sha"`
+	Statuses []forgejoCommitStatus `json:"statuses"`
+}
+
+// mapCIState normalizes a Gitea commit-status state to a forge.CI* constant.
+// failure/error → failed; warning → pending (advisory, non-terminal).
+func mapCIState(s string) string {
+	switch s {
+	case "success":
+		return forge.CISuccess
+	case "pending":
+		return forge.CIPending
+	case "failure", "error":
+		return forge.CIFailed
+	case "warning":
+		return forge.CIPending
+	case "skipped":
+		return forge.CISkipped
+	default:
+		return forge.CIUnknown
+	}
+}
+
+func (s forgejoCommitStatus) toRun(sha string) forge.CIRun {
+	return forge.CIRun{
+		Name:       s.Context,
+		Status:     mapCIState(s.State),
+		Conclusion: s.State,
+		URL:        s.TargetURL,
+		SHA:        sha,
+		StartedAt:  s.Created,
+		FinishedAt: s.Updated,
+	}
+}
+
+// GetCIStatus returns the current aggregate CI state + runs for a ref (commit
+// SHA or branch HEAD) via the combined commit-status endpoint.
+func (c *AdminClient) GetCIStatus(ctx context.Context, repo, ref string) (forge.CIStatus, error) {
+	var cs forgejoCombinedStatus
+	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/commits/"+url.PathEscape(ref)+"/status", nil, &cs)
+	if err != nil {
+		return forge.CIStatus{}, err
+	}
+	if code != http.StatusOK {
+		return forge.CIStatus{}, statusErr("GET commit status", code)
+	}
+	sha := cs.SHA
+	if sha == "" {
+		sha = ref
+	}
+	out := forge.CIStatus{
+		SHA:   sha,
+		State: mapCIState(cs.State),
+	}
+	for _, s := range cs.Statuses {
+		out.Runs = append(out.Runs, s.toRun(sha))
+	}
+	return out, nil
+}
+
+// ListCIHistory returns recent CI runs for a ref/branch HEAD via the
+// per-context statuses endpoint, newest first, up to limit (0 → 50).
+//
+// Best-effort: this is the commit-status surface, not Forgejo Actions tasks;
+// statuses-based history is the portable contract across Gitea/Forgejo.
+func (c *AdminClient) ListCIHistory(ctx context.Context, repo, ref string, limit int) ([]forge.CIRun, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	vals := url.Values{}
+	vals.Set("limit", strconv.Itoa(limit))
+	vals.Set("sort", "recentupdate")
+
+	var statuses []forgejoCommitStatus
+	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/commits/"+url.PathEscape(ref)+"/statuses?"+vals.Encode(), nil, &statuses)
+	if err != nil {
+		return nil, err
+	}
+	if code != http.StatusOK {
+		return nil, statusErr("GET commit statuses", code)
+	}
+	out := make([]forge.CIRun, 0, len(statuses))
+	for _, s := range statuses {
+		out = append(out, s.toRun(ref))
+	}
+	return out, nil
+}

--- a/pkg/forge/forgejo/issues.go
+++ b/pkg/forge/forgejo/issues.go
@@ -1,0 +1,185 @@
+package forgejo
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// IssueClient: Forgejo/Gitea issue read/write powering forge→board sync
+// (ListIssues) and board→forge push (Create/UpdateIssue).
+//
+// API base is "<BaseURL>/api/v1"; auth is the Gitea `token` scheme wired by
+// AdminClient.http(). Like GitHub, the issues endpoint conflates issues and
+// pull requests — an item with a non-null `pull_request` field is a PR, so
+// IssueRef.IsPullRequest is set accordingly (callers filter on it).
+var _ forge.IssueClient = (*AdminClient)(nil)
+
+// forgejoUser is the shared {login} shape for poster/assignee.
+type forgejoUser struct {
+	Login string `json:"login"`
+}
+
+type forgejoLabel struct {
+	Name string `json:"name"`
+}
+
+// forgejoPRMeta is the `pull_request` field on an issue (non-null ⇒ the item
+// is a PR, not a plain issue).
+type forgejoPRMeta struct {
+	Merged  bool   `json:"merged"`
+	HTMLURL string `json:"html_url"`
+}
+
+// forgejoIssue mirrors the Gitea API Issue shape (subset we normalize).
+type forgejoIssue struct {
+	Number      int64          `json:"number"`
+	Title       string         `json:"title"`
+	Body        string         `json:"body"`
+	State       string         `json:"state"` // "open" | "closed"
+	HTMLURL     string         `json:"html_url"`
+	Poster      *forgejoUser   `json:"user"`
+	Labels      []forgejoLabel `json:"labels"`
+	Assignees   []forgejoUser  `json:"assignees"`
+	PullRequest *forgejoPRMeta `json:"pull_request"`
+	Created     time.Time      `json:"created_at"`
+	Updated     time.Time      `json:"updated_at"`
+}
+
+func (i forgejoIssue) toRef() forge.IssueRef {
+	ref := forge.IssueRef{
+		Number:        int(i.Number),
+		Title:         i.Title,
+		Body:          i.Body,
+		State:         i.State,
+		URL:           i.HTMLURL,
+		IsPullRequest: i.PullRequest != nil,
+		CreatedAt:     i.Created,
+		UpdatedAt:     i.Updated,
+	}
+	if i.Poster != nil {
+		ref.Author = i.Poster.Login
+	}
+	for _, l := range i.Labels {
+		ref.Labels = append(ref.Labels, l.Name)
+	}
+	for _, a := range i.Assignees {
+		ref.Assignees = append(ref.Assignees, a.Login)
+	}
+	return ref
+}
+
+// ListIssues lists issues (and, conflated by Gitea, pull requests) for a repo.
+// state defaults to "open"; Since enables incremental sync.
+func (c *AdminClient) ListIssues(ctx context.Context, repo string, opts forge.IssueListOptions) ([]forge.IssueRef, error) {
+	vals := url.Values{}
+	state := opts.State
+	if state == "" {
+		state = "open"
+	}
+	vals.Set("state", state)
+	if len(opts.Labels) > 0 {
+		vals.Set("labels", strings.Join(opts.Labels, ","))
+	}
+	page := opts.Page
+	if page <= 0 {
+		page = 1
+	}
+	vals.Set("page", strconv.Itoa(page))
+	perPage := opts.PerPage
+	if perPage <= 0 {
+		perPage = 50
+	}
+	vals.Set("limit", strconv.Itoa(perPage))
+	if !opts.Since.IsZero() {
+		vals.Set("since", opts.Since.UTC().Format(time.RFC3339))
+	}
+
+	var issues []forgejoIssue
+	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/issues?"+vals.Encode(), nil, &issues)
+	if err != nil {
+		return nil, err
+	}
+	if code != http.StatusOK {
+		return nil, statusErr("GET issues", code)
+	}
+	out := make([]forge.IssueRef, 0, len(issues))
+	for _, i := range issues {
+		out = append(out, i.toRef())
+	}
+	return out, nil
+}
+
+// GetIssue fetches one issue (or PR) by its index.
+func (c *AdminClient) GetIssue(ctx context.Context, repo string, number int) (forge.IssueRef, error) {
+	var i forgejoIssue
+	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/issues/"+strconv.Itoa(number), nil, &i)
+	if err != nil {
+		return forge.IssueRef{}, err
+	}
+	if code != http.StatusOK {
+		return forge.IssueRef{}, statusErr("GET issue", code)
+	}
+	return i.toRef(), nil
+}
+
+// CreateIssue opens a new issue (board→forge push).
+//
+// QUIRK: Gitea's CreateIssueOption takes Labels as []int64 (label IDs), NOT
+// names — so we cannot attach labels by name here without an extra
+// name→ID resolution round-trip. Labels-by-name are therefore intentionally
+// skipped on create; set them with a follow-up label call if needed. Assignees
+// ARE accepted by login. The created issue's full shape is returned.
+func (c *AdminClient) CreateIssue(ctx context.Context, repo string, in forge.NewIssue) (forge.IssueRef, error) {
+	body := map[string]any{
+		"title": in.Title,
+		"body":  in.Body,
+	}
+	if len(in.Assignees) > 0 {
+		body["assignees"] = in.Assignees
+	}
+	var i forgejoIssue
+	code, err := c.do(ctx, http.MethodPost, "/repos/"+repo+"/issues", body, &i)
+	if err != nil {
+		return forge.IssueRef{}, err
+	}
+	if code/100 != 2 {
+		return forge.IssueRef{}, statusErr("create issue", code)
+	}
+	return i.toRef(), nil
+}
+
+// UpdateIssue applies a partial patch (title/body/state/assignees). Nil patch
+// fields are left untouched.
+//
+// Labels are not patched here for the same []int64 label-ID quirk as
+// CreateIssue (PATCH /issues/{index} takes label IDs, not names).
+func (c *AdminClient) UpdateIssue(ctx context.Context, repo string, number int, patch forge.IssuePatch) (forge.IssueRef, error) {
+	body := map[string]any{}
+	if patch.Title != nil {
+		body["title"] = *patch.Title
+	}
+	if patch.Body != nil {
+		body["body"] = *patch.Body
+	}
+	if patch.State != nil {
+		body["state"] = *patch.State
+	}
+	if patch.Assignees != nil {
+		body["assignees"] = *patch.Assignees
+	}
+	var i forgejoIssue
+	code, err := c.do(ctx, http.MethodPatch, "/repos/"+repo+"/issues/"+strconv.Itoa(number), body, &i)
+	if err != nil {
+		return forge.IssueRef{}, err
+	}
+	if code/100 != 2 {
+		return forge.IssueRef{}, statusErr("update issue", code)
+	}
+	return i.toRef(), nil
+}

--- a/pkg/forge/forgejo/issues_ci_test.go
+++ b/pkg/forge/forgejo/issues_ci_test.go
@@ -1,0 +1,311 @@
+package forgejo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// Capability interfaces are implemented (compile-time assertions also live in
+// issues.go / ci.go; restated here so a test reader sees the contract).
+var (
+	_ forge.IssueClient = (*AdminClient)(nil)
+	_ forge.PullClient  = (*AdminClient)(nil)
+)
+
+func TestForgejoListIssues_FiltersPRsAndAuth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "token tok" {
+			t.Errorf("auth scheme = %q, want token tok", r.Header.Get("Authorization"))
+		}
+		if !strings.HasSuffix(r.URL.Path, "/api/v1/repos/org/api/issues") {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("state"); got != "open" {
+			t.Errorf("state = %q, want open", got)
+		}
+		if got := r.URL.Query().Get("labels"); got != "bug,urgent" {
+			t.Errorf("labels = %q", got)
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"number":   7,
+				"title":    "a real issue",
+				"state":    "open",
+				"html_url": "https://fj/org/api/issues/7",
+				"user":     map[string]any{"login": "alice"},
+				"labels":   []map[string]any{{"name": "bug"}},
+				"assignees": []map[string]any{
+					{"login": "bob"},
+				},
+			},
+			{
+				"number":       8,
+				"title":        "a pull request",
+				"state":        "open",
+				"html_url":     "https://fj/org/api/pulls/8",
+				"pull_request": map[string]any{"merged": false, "html_url": "https://fj/org/api/pulls/8"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := New(srv.Client(), srv.URL, "tok")
+	issues, err := c.ListIssues(context.Background(), "org/api", forge.IssueListOptions{
+		Labels: []string{"bug", "urgent"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("len = %d, want 2", len(issues))
+	}
+	if issues[0].IsPullRequest {
+		t.Errorf("issue #7 flagged as PR")
+	}
+	if issues[0].Author != "alice" || len(issues[0].Labels) != 1 || issues[0].Labels[0] != "bug" {
+		t.Errorf("issue #7 = %+v", issues[0])
+	}
+	if len(issues[0].Assignees) != 1 || issues[0].Assignees[0] != "bob" {
+		t.Errorf("issue #7 assignees = %v", issues[0].Assignees)
+	}
+	if !issues[1].IsPullRequest {
+		t.Errorf("issue #8 (PR) not flagged as PR")
+	}
+}
+
+func TestForgejoGetIssue(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/repos/o/r/issues/12") {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"number": 12, "title": "t", "state": "closed", "html_url": "u",
+		})
+	}))
+	defer srv.Close()
+	ref, err := New(srv.Client(), srv.URL, "x").GetIssue(context.Background(), "o/r", 12)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.Number != 12 || ref.State != "closed" {
+		t.Errorf("ref = %+v", ref)
+	}
+}
+
+func TestForgejoCreateIssue_BodyAndAssignees(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"number": 99, "title": "new", "state": "open", "html_url": "https://fj/o/r/issues/99",
+		})
+	}))
+	defer srv.Close()
+
+	ref, err := New(srv.Client(), srv.URL, "x").CreateIssue(context.Background(), "o/r", forge.NewIssue{
+		Title:     "new",
+		Body:      "details",
+		Labels:    []string{"bug"}, // intentionally NOT sent (Gitea labels = []int64 IDs)
+		Assignees: []string{"carol"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.Number != 99 {
+		t.Errorf("ref = %+v", ref)
+	}
+	if got["title"] != "new" || got["body"] != "details" {
+		t.Errorf("body = %+v", got)
+	}
+	if _, present := got["labels"]; present {
+		t.Errorf("labels must be omitted on create (need int64 IDs), got %+v", got["labels"])
+	}
+	asg, _ := got["assignees"].([]any)
+	if len(asg) != 1 || asg[0] != "carol" {
+		t.Errorf("assignees = %v", got["assignees"])
+	}
+}
+
+func TestForgejoUpdateIssue_PartialPatch(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch || !strings.HasSuffix(r.URL.Path, "/issues/5") {
+			t.Errorf("method/path = %s %q", r.Method, r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"number": 5, "title": "t", "state": "closed", "html_url": "u",
+		})
+	}))
+	defer srv.Close()
+
+	state := "closed"
+	ref, err := New(srv.Client(), srv.URL, "x").UpdateIssue(context.Background(), "o/r", 5, forge.IssuePatch{
+		State: &state,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.State != "closed" {
+		t.Errorf("ref = %+v", ref)
+	}
+	if got["state"] != "closed" {
+		t.Errorf("patch body = %+v", got)
+	}
+	if _, present := got["title"]; present {
+		t.Errorf("nil patch fields must be omitted, got title=%v", got["title"])
+	}
+}
+
+func TestForgejoListPullRequests_MergedAndLinkedIssues(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/repos/o/r/pulls") {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"number":   3,
+				"title":    "fix thing (closes #12)",
+				"body":     "also relates to #7 and #7",
+				"state":    "closed",
+				"merged":   true,
+				"draft":    false,
+				"html_url": "https://fj/o/r/pulls/3",
+				"user":     map[string]any{"login": "dev"},
+				"head":     map[string]any{"ref": "feat/x", "sha": "abc123"},
+				"base":     map[string]any{"ref": "main", "sha": "def456"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	pulls, err := New(srv.Client(), srv.URL, "x").ListPullRequests(context.Background(), "o/r", forge.PullListOptions{State: "all"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pulls) != 1 {
+		t.Fatalf("len = %d", len(pulls))
+	}
+	p := pulls[0]
+	if p.State != "merged" {
+		t.Errorf("state = %q, want merged", p.State)
+	}
+	if p.SourceBranch != "feat/x" || p.TargetBranch != "main" || p.HeadSHA != "abc123" {
+		t.Errorf("branches = %+v", p)
+	}
+	if len(p.LinkedIssues) != 2 || p.LinkedIssues[0] != 12 || p.LinkedIssues[1] != 7 {
+		t.Errorf("linked issues = %v, want [12 7] (deduped)", p.LinkedIssues)
+	}
+}
+
+func TestForgejoGetPullRequest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/pulls/4") {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"number": 4, "title": "t", "state": "open", "html_url": "u",
+			"head": map[string]any{"ref": "b", "sha": "s"},
+		})
+	}))
+	defer srv.Close()
+	p, err := New(srv.Client(), srv.URL, "x").GetPullRequest(context.Background(), "o/r", 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Number != 4 || p.State != "open" || p.HeadSHA != "s" {
+		t.Errorf("pull = %+v", p)
+	}
+}
+
+func TestForgejoGetCIStatus_CombinedAggregation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/repos/o/r/commits/main/status") {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"state": "failure",
+			"sha":   "deadbeef",
+			"statuses": []map[string]any{
+				{"status": "success", "context": "build", "target_url": "https://ci/1"},
+				{"status": "failure", "context": "test", "target_url": "https://ci/2"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	st, err := New(srv.Client(), srv.URL, "x").GetCIStatus(context.Background(), "o/r", "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.SHA != "deadbeef" {
+		t.Errorf("sha = %q", st.SHA)
+	}
+	if st.State != forge.CIFailed {
+		t.Errorf("aggregate state = %q, want %q (failure→failed)", st.State, forge.CIFailed)
+	}
+	if len(st.Runs) != 2 {
+		t.Fatalf("runs = %d", len(st.Runs))
+	}
+	if st.Runs[0].Name != "build" || st.Runs[0].Status != forge.CISuccess {
+		t.Errorf("run[0] = %+v", st.Runs[0])
+	}
+	if st.Runs[1].Status != forge.CIFailed || st.Runs[1].SHA != "deadbeef" {
+		t.Errorf("run[1] = %+v", st.Runs[1])
+	}
+}
+
+func TestForgejoListCIHistory(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/repos/o/r/commits/main/statuses") {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("limit"); got != "5" {
+			t.Errorf("limit = %q", got)
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"status": "success", "context": "build"},
+			{"status": "pending", "context": "deploy"},
+		})
+	}))
+	defer srv.Close()
+
+	runs, err := New(srv.Client(), srv.URL, "x").ListCIHistory(context.Background(), "o/r", "main", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 2 || runs[0].Status != forge.CISuccess || runs[1].Status != forge.CIRunning && runs[1].Status != forge.CIPending {
+		t.Errorf("runs = %+v", runs)
+	}
+}
+
+func TestForgejoIssueErrorMapping(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	_, err := New(srv.Client(), srv.URL, "x").GetIssue(context.Background(), "o/r", 1)
+	if !errors.Is(err, forge.ErrUnauthorized) {
+		t.Errorf("401 → %v, want ErrUnauthorized", err)
+	}
+
+	srv404 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv404.Close()
+	_, err = New(srv404.Client(), srv404.URL, "x").GetPullRequest(context.Background(), "o/r", 1)
+	if !errors.Is(err, forge.ErrHookNotFound) {
+		t.Errorf("404 → %v, want ErrHookNotFound", err)
+	}
+}

--- a/pkg/forge/github/ci.go
+++ b/pkg/forge/github/ci.go
@@ -1,0 +1,342 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// PullClient capability — linked PRs + CI status (current + history) for board
+// cards. PRs come from /pulls; CI is the union of check-runs (GitHub Actions /
+// Apps) and the legacy combined commit-status, normalized onto forge.CI*.
+var _ forge.PullClient = (*AdminClient)(nil)
+
+// githubPull is the slice of the GitHub pull-request object we map to PullRef.
+type githubPull struct {
+	Number  int    `json:"number"`
+	Title   string `json:"title"`
+	Body    string `json:"body"`
+	State   string `json:"state"` // "open" | "closed"
+	HTMLURL string `json:"html_url"`
+	Draft   bool   `json:"draft"`
+	Head    struct {
+		Ref string `json:"ref"`
+		SHA string `json:"sha"`
+	} `json:"head"`
+	Base struct {
+		Ref string `json:"ref"`
+	} `json:"base"`
+	User struct {
+		Login string `json:"login"`
+	} `json:"user"`
+	MergedAt  *time.Time `json:"merged_at"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
+}
+
+// issueRefRe matches "#123" style references (incl. "fixes #123", "closes #7")
+// in a PR title/body, for best-effort LinkedIssues extraction.
+var issueRefRe = regexp.MustCompile(`#(\d+)`)
+
+// linkedIssues parses "#<n>" references out of a PR's title+body, deduped.
+func linkedIssues(title, body string) []int {
+	seen := map[int]bool{}
+	var out []int
+	for _, m := range issueRefRe.FindAllStringSubmatch(title+"\n"+body, -1) {
+		n, err := strconv.Atoi(m[1])
+		if err != nil || seen[n] {
+			continue
+		}
+		seen[n] = true
+		out = append(out, n)
+	}
+	return out
+}
+
+func (gp githubPull) toRef() forge.PullRef {
+	state := gp.State
+	if gp.MergedAt != nil {
+		state = "merged"
+	}
+	return forge.PullRef{
+		Number:       gp.Number,
+		Title:        gp.Title,
+		State:        state,
+		URL:          gp.HTMLURL,
+		SourceBranch: gp.Head.Ref,
+		TargetBranch: gp.Base.Ref,
+		HeadSHA:      gp.Head.SHA,
+		Author:       gp.User.Login,
+		Draft:        gp.Draft,
+		CreatedAt:    gp.CreatedAt,
+		UpdatedAt:    gp.UpdatedAt,
+		LinkedIssues: linkedIssues(gp.Title, gp.Body),
+	}
+}
+
+// ListPullRequests lists PRs for repo ("owner/repo"). GitHub's /pulls endpoint
+// has no `since` filter, so opts.Since is ignored here.
+func (c *AdminClient) ListPullRequests(ctx context.Context, repo string, opts forge.PullListOptions) ([]forge.PullRef, error) {
+	vals := url.Values{}
+	state := opts.State
+	if state == "" {
+		state = "open"
+	}
+	vals.Set("state", state)
+	perPage := opts.PerPage
+	if perPage <= 0 || perPage > 100 {
+		perPage = 50
+	}
+	vals.Set("per_page", strconv.Itoa(perPage))
+	page := opts.Page
+	if page <= 0 {
+		page = 1
+	}
+	vals.Set("page", strconv.Itoa(page))
+
+	var raw []githubPull
+	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/pulls?"+vals.Encode(), nil, &raw)
+	if err != nil {
+		return nil, err
+	}
+	if code != http.StatusOK {
+		return nil, statusErr("GET pulls", code)
+	}
+	out := make([]forge.PullRef, 0, len(raw))
+	for _, gp := range raw {
+		out = append(out, gp.toRef())
+	}
+	return out, nil
+}
+
+// GetPullRequest fetches one PR by number.
+func (c *AdminClient) GetPullRequest(ctx context.Context, repo string, number int) (forge.PullRef, error) {
+	var gp githubPull
+	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/pulls/"+strconv.Itoa(number), nil, &gp)
+	if err != nil {
+		return forge.PullRef{}, err
+	}
+	if code != http.StatusOK {
+		return forge.PullRef{}, statusErr("GET pull", code)
+	}
+	return gp.toRef(), nil
+}
+
+// githubCheckRuns is the check-runs list response (GitHub Actions / Apps).
+type githubCheckRuns struct {
+	CheckRuns []struct {
+		Name        string     `json:"name"`
+		Status      string     `json:"status"`     // queued | in_progress | completed
+		Conclusion  string     `json:"conclusion"` // success | failure | cancelled | skipped | timed_out | neutral | action_required
+		HTMLURL     string     `json:"html_url"`
+		StartedAt   *time.Time `json:"started_at"`
+		CompletedAt *time.Time `json:"completed_at"`
+	} `json:"check_runs"`
+}
+
+// githubCombinedStatus is the legacy combined commit-status response.
+type githubCombinedStatus struct {
+	State    string `json:"state"` // success | failure | pending
+	SHA      string `json:"sha"`
+	Statuses []struct {
+		Context   string    `json:"context"`
+		State     string    `json:"state"` // success | failure | pending | error
+		TargetURL string    `json:"target_url"`
+		CreatedAt time.Time `json:"created_at"`
+		UpdatedAt time.Time `json:"updated_at"`
+	} `json:"statuses"`
+}
+
+// checkRunStatus normalizes a check-run (status, conclusion) onto a forge.CI*
+// value. A completed run reports its conclusion; an in-flight one is running.
+func checkRunStatus(status, conclusion string) string {
+	switch status {
+	case "queued", "in_progress":
+		return forge.CIRunning
+	case "completed":
+		switch conclusion {
+		case "success":
+			return forge.CISuccess
+		case "failure", "timed_out", "action_required":
+			return forge.CIFailed
+		case "cancelled":
+			return forge.CICancelled
+		case "skipped", "neutral":
+			return forge.CISkipped
+		default:
+			return forge.CIUnknown
+		}
+	default:
+		return forge.CIUnknown
+	}
+}
+
+// commitStatusState normalizes a combined/individual commit-status state onto
+// a forge.CI* value.
+func commitStatusState(state string) string {
+	switch state {
+	case "success":
+		return forge.CISuccess
+	case "failure", "error":
+		return forge.CIFailed
+	case "pending":
+		return forge.CIRunning
+	default:
+		return forge.CIUnknown
+	}
+}
+
+func tm(p *time.Time) time.Time {
+	if p == nil {
+		return time.Time{}
+	}
+	return *p
+}
+
+// fetchCheckRuns returns the normalized check-runs for a ref (empty on 404,
+// which a repo without GitHub Actions returns).
+func (c *AdminClient) fetchCheckRuns(ctx context.Context, repo, ref string) ([]forge.CIRun, error) {
+	var cr githubCheckRuns
+	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/commits/"+url.PathEscape(ref)+"/check-runs", nil, &cr)
+	if err != nil {
+		return nil, err
+	}
+	if code == http.StatusNotFound {
+		return nil, nil
+	}
+	if code != http.StatusOK {
+		return nil, statusErr("GET check-runs", code)
+	}
+	runs := make([]forge.CIRun, 0, len(cr.CheckRuns))
+	for _, r := range cr.CheckRuns {
+		runs = append(runs, forge.CIRun{
+			Name:       r.Name,
+			Status:     checkRunStatus(r.Status, r.Conclusion),
+			Conclusion: r.Conclusion,
+			URL:        r.HTMLURL,
+			SHA:        ref,
+			StartedAt:  tm(r.StartedAt),
+			FinishedAt: tm(r.CompletedAt),
+		})
+	}
+	return runs, nil
+}
+
+// fetchCommitStatuses returns the normalized legacy commit-statuses for a ref.
+func (c *AdminClient) fetchCommitStatuses(ctx context.Context, repo, ref string) (sha string, _ []forge.CIRun, _ error) {
+	var cs githubCombinedStatus
+	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/commits/"+url.PathEscape(ref)+"/status", nil, &cs)
+	if err != nil {
+		return "", nil, err
+	}
+	if code == http.StatusNotFound {
+		return "", nil, nil
+	}
+	if code != http.StatusOK {
+		return "", nil, statusErr("GET commit status", code)
+	}
+	runs := make([]forge.CIRun, 0, len(cs.Statuses))
+	for _, s := range cs.Statuses {
+		runs = append(runs, forge.CIRun{
+			Name:       s.Context,
+			Status:     commitStatusState(s.State),
+			URL:        s.TargetURL,
+			SHA:        cs.SHA,
+			StartedAt:  s.CreatedAt,
+			FinishedAt: s.UpdatedAt,
+		})
+	}
+	return cs.SHA, runs, nil
+}
+
+// aggregateState rolls a set of normalized runs into a single CIStatus.State:
+// any failure → failed; any running/queued → running; all success → success;
+// none → unknown; otherwise pending.
+func aggregateState(runs []forge.CIRun) string {
+	if len(runs) == 0 {
+		return forge.CIUnknown
+	}
+	anyRunning, anySuccess, anyUnknown := false, false, false
+	for _, r := range runs {
+		switch r.Status {
+		case forge.CIFailed:
+			// Any hard failure dominates the aggregate.
+			return forge.CIFailed
+		case forge.CIRunning, forge.CIPending:
+			anyRunning = true
+		case forge.CISuccess:
+			anySuccess = true
+		case forge.CISkipped, forge.CICancelled:
+			// Non-blocking neutral states (GitHub treats skipped/cancelled
+			// as not failing the ref); they neither succeed nor block.
+		default:
+			anyUnknown = true
+		}
+	}
+	switch {
+	case anyRunning:
+		return forge.CIRunning
+	case anySuccess && !anyUnknown:
+		// At least one success and no unresolved state → green.
+		return forge.CISuccess
+	case anyUnknown:
+		return forge.CIUnknown
+	default:
+		// All runs were neutral (skipped/cancelled) — nothing to report green.
+		return forge.CIPending
+	}
+}
+
+// GetCIStatus returns the CURRENT aggregate CI state + runs for a ref,
+// combining GitHub Actions/App check-runs with the legacy commit-status API.
+func (c *AdminClient) GetCIStatus(ctx context.Context, repo, ref string) (forge.CIStatus, error) {
+	checkRuns, err := c.fetchCheckRuns(ctx, repo, ref)
+	if err != nil {
+		return forge.CIStatus{}, err
+	}
+	sha, statusRuns, err := c.fetchCommitStatuses(ctx, repo, ref)
+	if err != nil {
+		return forge.CIStatus{}, err
+	}
+	runs := append(checkRuns, statusRuns...)
+	if sha == "" {
+		sha = ref
+	}
+	return forge.CIStatus{
+		SHA:   sha,
+		State: aggregateState(runs),
+		Runs:  runs,
+	}, nil
+}
+
+// ListCIHistory lists recent check-runs for a ref/branch, newest first (by
+// start time), capped at limit (0 → 30).
+func (c *AdminClient) ListCIHistory(ctx context.Context, repo, ref string, limit int) ([]forge.CIRun, error) {
+	if limit <= 0 {
+		limit = 30
+	}
+	runs, err := c.fetchCheckRuns(ctx, repo, ref)
+	if err != nil {
+		return nil, err
+	}
+	// Newest first by start time (check-runs come latest-filtered but unsorted).
+	sortRunsNewestFirst(runs)
+	if len(runs) > limit {
+		runs = runs[:limit]
+	}
+	return runs, nil
+}
+
+// sortRunsNewestFirst orders runs by StartedAt descending (zero times last).
+func sortRunsNewestFirst(runs []forge.CIRun) {
+	for i := 1; i < len(runs); i++ {
+		for j := i; j > 0 && runs[j].StartedAt.After(runs[j-1].StartedAt); j-- {
+			runs[j], runs[j-1] = runs[j-1], runs[j]
+		}
+	}
+}

--- a/pkg/forge/github/ci_test.go
+++ b/pkg/forge/github/ci_test.go
@@ -1,0 +1,185 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+var _ forge.PullClient = (*AdminClient)(nil)
+
+func TestGitHubGetPullRequest_Mapping(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"number": 5, "title": "feat: x (fixes #12, closes #7)", "state": "closed",
+			"body":      "also references #12 again",
+			"html_url":  "https://github.com/o/r/pull/5",
+			"draft":     false,
+			"merged_at": "2026-01-02T03:04:05Z",
+			"head":      map[string]any{"ref": "feature", "sha": "deadbeef"},
+			"base":      map[string]any{"ref": "main"},
+			"user":      map[string]any{"login": "dave"},
+		})
+	}))
+	defer srv.Close()
+
+	c := &AdminClient{HTTP: srv.Client(), APIBase: srv.URL, Token: "t"}
+	pr, err := c.GetPullRequest(context.Background(), "o/r", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pr.State != "merged" {
+		t.Errorf("merged_at present → state should be merged, got %q", pr.State)
+	}
+	if pr.SourceBranch != "feature" || pr.TargetBranch != "main" || pr.HeadSHA != "deadbeef" {
+		t.Errorf("branch/sha mapping wrong: %+v", pr)
+	}
+	// LinkedIssues parsed from title+body, deduped.
+	if len(pr.LinkedIssues) != 2 {
+		t.Fatalf("linked issues = %v want [12 7]", pr.LinkedIssues)
+	}
+	if pr.LinkedIssues[0] != 12 || pr.LinkedIssues[1] != 7 {
+		t.Errorf("linked issues order/dedup wrong: %v", pr.LinkedIssues)
+	}
+}
+
+func TestGitHubGetCIStatus_Aggregation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/commits/abc123/check-runs"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"total_count": 2,
+				"check_runs": []map[string]any{
+					{"name": "build", "status": "completed", "conclusion": "success",
+						"html_url": "https://github.com/o/r/runs/1", "started_at": "2026-01-01T00:00:00Z"},
+					{"name": "deploy", "status": "in_progress", "conclusion": nil,
+						"html_url": "https://github.com/o/r/runs/2", "started_at": "2026-01-01T00:01:00Z"},
+				},
+			})
+		case strings.HasSuffix(r.URL.Path, "/commits/abc123/status"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"state": "pending", "sha": "abc123",
+				"statuses": []map[string]any{
+					{"context": "legacy-lint", "state": "success", "target_url": "https://ci/lint"},
+				},
+			})
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := &AdminClient{HTTP: srv.Client(), APIBase: srv.URL, Token: "t"}
+	st, err := c.GetCIStatus(context.Background(), "o/r", "abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.SHA != "abc123" {
+		t.Errorf("sha = %q", st.SHA)
+	}
+	// A run is in_progress → aggregate is running.
+	if st.State != forge.CIRunning {
+		t.Errorf("aggregate state = %q want %q", st.State, forge.CIRunning)
+	}
+	// 2 check-runs + 1 commit-status = 3 runs.
+	if len(st.Runs) != 3 {
+		t.Fatalf("runs = %d want 3", len(st.Runs))
+	}
+}
+
+func TestGitHubGetCIStatus_FailedWins(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/check-runs"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"check_runs": []map[string]any{
+					{"name": "build", "status": "completed", "conclusion": "success"},
+					{"name": "test", "status": "completed", "conclusion": "failure"},
+				},
+			})
+		case strings.HasSuffix(r.URL.Path, "/status"):
+			// No legacy statuses configured → 404 is the common case.
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := &AdminClient{HTTP: srv.Client(), APIBase: srv.URL, Token: "t"}
+	st, err := c.GetCIStatus(context.Background(), "o/r", "sha")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.State != forge.CIFailed {
+		t.Errorf("any failure → failed, got %q", st.State)
+	}
+	if len(st.Runs) != 2 {
+		t.Errorf("404 on /status must be empty, not error: runs=%d", len(st.Runs))
+	}
+}
+
+func TestGitHubGetCIStatus_AllSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/check-runs") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"check_runs": []map[string]any{
+					{"name": "build", "status": "completed", "conclusion": "success"},
+					{"name": "skipped-opt", "status": "completed", "conclusion": "skipped"},
+				},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"state": "success", "sha": "z", "statuses": []any{}})
+	}))
+	defer srv.Close()
+
+	c := &AdminClient{HTTP: srv.Client(), APIBase: srv.URL, Token: "t"}
+	st, err := c.GetCIStatus(context.Background(), "o/r", "z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.State != forge.CISuccess {
+		t.Errorf("success+skipped → success, got %q", st.State)
+	}
+}
+
+func TestGitHubListCIHistory_NewestFirstCapped(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"check_runs": []map[string]any{
+				{"name": "old", "status": "completed", "conclusion": "success", "started_at": "2026-01-01T00:00:00Z"},
+				{"name": "new", "status": "completed", "conclusion": "success", "started_at": "2026-03-01T00:00:00Z"},
+				{"name": "mid", "status": "completed", "conclusion": "success", "started_at": "2026-02-01T00:00:00Z"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := &AdminClient{HTTP: srv.Client(), APIBase: srv.URL, Token: "t"}
+	runs, err := c.ListCIHistory(context.Background(), "o/r", "main", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("limit not applied: %d", len(runs))
+	}
+	if runs[0].Name != "new" || runs[1].Name != "mid" {
+		t.Errorf("not newest-first: %s, %s", runs[0].Name, runs[1].Name)
+	}
+}
+
+func TestGitHubListPullRequests_ErrorMapping(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	c := &AdminClient{HTTP: srv.Client(), APIBase: srv.URL, Token: "t"}
+	if _, err := c.ListPullRequests(context.Background(), "o/r", forge.PullListOptions{}); err != forge.ErrUnauthorized {
+		t.Errorf("401 → %v want ErrUnauthorized", err)
+	}
+}

--- a/pkg/forge/github/issues.go
+++ b/pkg/forge/github/issues.go
@@ -1,0 +1,176 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// IssueClient capability — forge→board sync (ListIssues) + board→forge push
+// (Create/UpdateIssue). The GitHub issues endpoint conflates issues and pull
+// requests (a PR is an issue with a non-null `pull_request` field), so the
+// wire shape carries that field and IsPullRequest is set from it; the board
+// sync filters PRs out.
+var _ forge.IssueClient = (*AdminClient)(nil)
+
+// githubIssue is the slice of the GitHub issue object we map to IssueRef.
+// `pull_request` is present (non-null) only when the item is actually a PR.
+type githubIssue struct {
+	Number  int    `json:"number"`
+	Title   string `json:"title"`
+	Body    string `json:"body"`
+	State   string `json:"state"`
+	HTMLURL string `json:"html_url"`
+	Labels  []struct {
+		Name string `json:"name"`
+	} `json:"labels"`
+	Assignees []struct {
+		Login string `json:"login"`
+	} `json:"assignees"`
+	User struct {
+		Login string `json:"login"`
+	} `json:"user"`
+	CreatedAt   time.Time        `json:"created_at"`
+	UpdatedAt   time.Time        `json:"updated_at"`
+	PullRequest *json.RawMessage `json:"pull_request"`
+}
+
+func (gi githubIssue) toRef() forge.IssueRef {
+	labels := make([]string, 0, len(gi.Labels))
+	for _, l := range gi.Labels {
+		if l.Name != "" {
+			labels = append(labels, l.Name)
+		}
+	}
+	assignees := make([]string, 0, len(gi.Assignees))
+	for _, a := range gi.Assignees {
+		if a.Login != "" {
+			assignees = append(assignees, a.Login)
+		}
+	}
+	return forge.IssueRef{
+		Number:        gi.Number,
+		Title:         gi.Title,
+		Body:          gi.Body,
+		State:         gi.State,
+		URL:           gi.HTMLURL,
+		Labels:        labels,
+		Assignees:     assignees,
+		Author:        gi.User.Login,
+		CreatedAt:     gi.CreatedAt,
+		UpdatedAt:     gi.UpdatedAt,
+		IsPullRequest: gi.PullRequest != nil,
+	}
+}
+
+// ListIssues lists issues for repo ("owner/repo"). PRs are returned by the
+// same endpoint but flagged via IsPullRequest so callers can drop them.
+func (c *AdminClient) ListIssues(ctx context.Context, repo string, opts forge.IssueListOptions) ([]forge.IssueRef, error) {
+	vals := url.Values{}
+	state := opts.State
+	if state == "" {
+		state = "open"
+	}
+	vals.Set("state", state)
+	if len(opts.Labels) > 0 {
+		vals.Set("labels", strings.Join(opts.Labels, ","))
+	}
+	if !opts.Since.IsZero() {
+		vals.Set("since", opts.Since.UTC().Format(time.RFC3339))
+	}
+	perPage := opts.PerPage
+	if perPage <= 0 || perPage > 100 {
+		perPage = 50
+	}
+	vals.Set("per_page", strconv.Itoa(perPage))
+	page := opts.Page
+	if page <= 0 {
+		page = 1
+	}
+	vals.Set("page", strconv.Itoa(page))
+
+	var raw []githubIssue
+	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/issues?"+vals.Encode(), nil, &raw)
+	if err != nil {
+		return nil, err
+	}
+	if code != http.StatusOK {
+		return nil, statusErr("GET issues", code)
+	}
+	out := make([]forge.IssueRef, 0, len(raw))
+	for _, gi := range raw {
+		out = append(out, gi.toRef())
+	}
+	return out, nil
+}
+
+// GetIssue fetches one issue (or PR) by number.
+func (c *AdminClient) GetIssue(ctx context.Context, repo string, number int) (forge.IssueRef, error) {
+	var gi githubIssue
+	code, err := c.do(ctx, http.MethodGet, "/repos/"+repo+"/issues/"+strconv.Itoa(number), nil, &gi)
+	if err != nil {
+		return forge.IssueRef{}, err
+	}
+	if code != http.StatusOK {
+		return forge.IssueRef{}, statusErr("GET issue", code)
+	}
+	return gi.toRef(), nil
+}
+
+// CreateIssue opens a new issue (board→forge push).
+func (c *AdminClient) CreateIssue(ctx context.Context, repo string, in forge.NewIssue) (forge.IssueRef, error) {
+	body := map[string]any{"title": in.Title}
+	if in.Body != "" {
+		body["body"] = in.Body
+	}
+	if len(in.Labels) > 0 {
+		body["labels"] = in.Labels
+	}
+	if len(in.Assignees) > 0 {
+		body["assignees"] = in.Assignees
+	}
+	var gi githubIssue
+	code, err := c.do(ctx, http.MethodPost, "/repos/"+repo+"/issues", body, &gi)
+	if err != nil {
+		return forge.IssueRef{}, err
+	}
+	if code/100 != 2 {
+		return forge.IssueRef{}, statusErr("create issue", code)
+	}
+	return gi.toRef(), nil
+}
+
+// UpdateIssue applies a partial update; nil patch fields are left untouched.
+func (c *AdminClient) UpdateIssue(ctx context.Context, repo string, number int, patch forge.IssuePatch) (forge.IssueRef, error) {
+	body := map[string]any{}
+	if patch.Title != nil {
+		body["title"] = *patch.Title
+	}
+	if patch.Body != nil {
+		body["body"] = *patch.Body
+	}
+	if patch.State != nil {
+		body["state"] = *patch.State
+	}
+	if patch.Labels != nil {
+		body["labels"] = *patch.Labels
+	}
+	if patch.Assignees != nil {
+		body["assignees"] = *patch.Assignees
+	}
+	var gi githubIssue
+	code, err := c.do(ctx, http.MethodPatch, "/repos/"+repo+"/issues/"+strconv.Itoa(number), body, &gi)
+	if err != nil {
+		return forge.IssueRef{}, err
+	}
+	if code/100 != 2 {
+		return forge.IssueRef{}, statusErr("update issue", code)
+	}
+	return gi.toRef(), nil
+}

--- a/pkg/forge/github/issues_test.go
+++ b/pkg/forge/github/issues_test.go
@@ -1,0 +1,164 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+var _ forge.IssueClient = (*AdminClient)(nil)
+
+func TestGitHubListIssues_FiltersOutPRs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("state"); got != "all" {
+			t.Errorf("state = %q want all", got)
+		}
+		if got := r.URL.Query().Get("labels"); got != "bug,p1" {
+			t.Errorf("labels = %q", got)
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"number": 1, "title": "a real issue", "state": "open",
+				"html_url":  "https://github.com/o/r/issues/1",
+				"labels":    []map[string]any{{"name": "bug"}},
+				"assignees": []map[string]any{{"login": "alice"}},
+				"user":      map[string]any{"login": "bob"},
+			},
+			{
+				"number": 2, "title": "actually a PR", "state": "open",
+				"html_url":     "https://github.com/o/r/pull/2",
+				"pull_request": map[string]any{"url": "https://api.github.com/o/r/pulls/2"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := &AdminClient{HTTP: srv.Client(), APIBase: srv.URL, Token: "t"}
+	issues, err := c.ListIssues(context.Background(), "o/r", forge.IssueListOptions{
+		State: "all", Labels: []string{"bug", "p1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("want 2 items (PR flagged, not dropped), got %d", len(issues))
+	}
+	// Caller filters by IsPullRequest; verify the flag is set correctly.
+	prCount := 0
+	for _, i := range issues {
+		if i.IsPullRequest {
+			prCount++
+		}
+	}
+	if prCount != 1 {
+		t.Fatalf("want exactly 1 IsPullRequest, got %d", prCount)
+	}
+	if issues[0].IsPullRequest {
+		t.Error("issue #1 should not be a PR")
+	}
+	if !issues[1].IsPullRequest {
+		t.Error("issue #2 should be flagged as a PR")
+	}
+	if issues[0].Author != "bob" || len(issues[0].Labels) != 1 || issues[0].Labels[0] != "bug" {
+		t.Errorf("issue #1 mapping wrong: %+v", issues[0])
+	}
+	if len(issues[0].Assignees) != 1 || issues[0].Assignees[0] != "alice" {
+		t.Errorf("assignees wrong: %+v", issues[0].Assignees)
+	}
+}
+
+func TestGitHubCreateIssue_RoundTrip(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/repos/o/r/issues") {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"number": 42, "title": body["title"], "state": "open",
+			"html_url": "https://github.com/o/r/issues/42",
+		})
+	}))
+	defer srv.Close()
+
+	c := &AdminClient{HTTP: srv.Client(), APIBase: srv.URL, Token: "t"}
+	got, err := c.CreateIssue(context.Background(), "o/r", forge.NewIssue{
+		Title: "ship it", Body: "details", Labels: []string{"feat"}, Assignees: []string{"carol"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body["title"] != "ship it" || body["body"] != "details" {
+		t.Errorf("request body = %v", body)
+	}
+	if labels, _ := body["labels"].([]any); len(labels) != 1 || labels[0] != "feat" {
+		t.Errorf("labels = %v", body["labels"])
+	}
+	if got.Number != 42 || got.State != "open" {
+		t.Errorf("created = %+v", got)
+	}
+}
+
+func TestGitHubUpdateIssue_RoundTrip(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("method = %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/repos/o/r/issues/7") {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"number": 7, "title": "old", "state": body["state"],
+			"html_url": "https://github.com/o/r/issues/7",
+		})
+	}))
+	defer srv.Close()
+
+	c := &AdminClient{HTTP: srv.Client(), APIBase: srv.URL, Token: "t"}
+	closed := "closed"
+	got, err := c.UpdateIssue(context.Background(), "o/r", 7, forge.IssuePatch{State: &closed})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body["state"] != "closed" {
+		t.Errorf("request state = %v", body["state"])
+	}
+	// Title was nil in the patch → must be absent from the request body.
+	if _, present := body["title"]; present {
+		t.Errorf("nil patch field leaked into body: %v", body)
+	}
+	if got.Number != 7 || got.State != "closed" {
+		t.Errorf("updated = %+v", got)
+	}
+}
+
+func TestGitHubGetIssue_ErrorMapping(t *testing.T) {
+	cases := map[int]error{
+		http.StatusNotFound:     forge.ErrHookNotFound,
+		http.StatusUnauthorized: forge.ErrUnauthorized,
+		http.StatusForbidden:    forge.ErrForbidden,
+	}
+	for code, want := range cases {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(code)
+		}))
+		c := &AdminClient{HTTP: srv.Client(), APIBase: srv.URL, Token: "t"}
+		_, err := c.GetIssue(context.Background(), "o/r", 1)
+		if !errors.Is(err, want) {
+			t.Errorf("status %d → err %v, want %v", code, err, want)
+		}
+		srv.Close()
+	}
+}

--- a/pkg/forge/gitlab/capabilities_test.go
+++ b/pkg/forge/gitlab/capabilities_test.go
@@ -1,0 +1,320 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// TestListIssues_StateNormalizationAndEncoding pins the project-path
+// URL-encoding ("group/sub/api" → %2F), the state-query mapping
+// (open→opened), and the GitLab→forge state normalization (opened→open).
+func TestListIssues_StateNormalizationAndEncoding(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.EscapedPath(); !strings.HasSuffix(got, "/projects/group%2Fsub%2Fapi/issues") {
+			t.Errorf("escaped path = %q, want namespaced project id", got)
+		}
+		if r.URL.Query().Get("state") != "opened" {
+			t.Errorf("state = %q, want opened", r.URL.Query().Get("state"))
+		}
+		if r.URL.Query().Get("labels") != "bug,urgent" {
+			t.Errorf("labels = %q, want bug,urgent", r.URL.Query().Get("labels"))
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"iid": 6, "title": "boom", "description": "body text", "state": "opened",
+				"web_url": "https://gl/group/sub/api/-/issues/6", "labels": []string{"bug"},
+				"author":    map[string]any{"username": "alice"},
+				"assignees": []map[string]any{{"username": "bob"}},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	issues, err := New(srv.Client(), srv.URL, "tok").ListIssues(context.Background(), "group/sub/api", forge.IssueListOptions{
+		State:  "open",
+		Labels: []string{"bug", "urgent"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues = %d", len(issues))
+	}
+	i := issues[0]
+	if i.Number != 6 {
+		t.Errorf("number = %d, want 6 (iid)", i.Number)
+	}
+	if i.State != "open" {
+		t.Errorf("state = %q, want open (normalized from opened)", i.State)
+	}
+	if i.Body != "body text" {
+		t.Errorf("body = %q, want body text (from description)", i.Body)
+	}
+	if i.Author != "alice" {
+		t.Errorf("author = %q", i.Author)
+	}
+	if len(i.Assignees) != 1 || i.Assignees[0] != "bob" {
+		t.Errorf("assignees = %v", i.Assignees)
+	}
+}
+
+// TestCreateIssue_RoundTrip pins the write shape: title/description and the
+// comma-joined labels CSV, and that the iid+opened response round-trips back.
+func TestCreateIssue_RoundTrip(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatal(err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"iid": 11, "title": gotBody["title"], "description": gotBody["description"],
+			"state": "opened", "web_url": "https://gl/g/p/-/issues/11",
+		})
+	}))
+	defer srv.Close()
+
+	got, err := New(srv.Client(), srv.URL, "tok").CreateIssue(context.Background(), "g/p", forge.NewIssue{
+		Title:  "new bug",
+		Body:   "describe it",
+		Labels: []string{"bug", "p1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotBody["title"] != "new bug" {
+		t.Errorf("title body = %v", gotBody["title"])
+	}
+	if gotBody["description"] != "describe it" {
+		t.Errorf("description body = %v", gotBody["description"])
+	}
+	if gotBody["labels"] != "bug,p1" {
+		t.Errorf("labels body = %v, want comma-joined CSV", gotBody["labels"])
+	}
+	if got.Number != 11 || got.State != "open" {
+		t.Errorf("round-trip ref = %+v", got)
+	}
+}
+
+// TestUpdateIssue_StateEvent pins the state→state_event mapping (closed→close)
+// and that other patch fields ride along.
+func TestUpdateIssue_StateEvent(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s", r.Method)
+		}
+		if got := r.URL.EscapedPath(); !strings.HasSuffix(got, "/projects/g%2Fp/issues/6") {
+			t.Errorf("escaped path = %q", got)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"iid": 6, "title": gotBody["title"], "state": "closed", "web_url": "u",
+		})
+	}))
+	defer srv.Close()
+
+	title := "renamed"
+	state := "closed"
+	got, err := New(srv.Client(), srv.URL, "tok").UpdateIssue(context.Background(), "g/p", 6, forge.IssuePatch{
+		Title: &title,
+		State: &state,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotBody["state_event"] != "close" {
+		t.Errorf("state_event = %v, want close", gotBody["state_event"])
+	}
+	if gotBody["title"] != "renamed" {
+		t.Errorf("title = %v", gotBody["title"])
+	}
+	if got.State != "closed" {
+		t.Errorf("returned state = %q", got.State)
+	}
+}
+
+// TestUpdateIssue_Reopen pins the open→reopen mapping.
+func TestUpdateIssue_Reopen(t *testing.T) {
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{"iid": 6, "state": "opened", "web_url": "u"})
+	}))
+	defer srv.Close()
+	state := "open"
+	_, err := New(srv.Client(), srv.URL, "tok").UpdateIssue(context.Background(), "g/p", 6, forge.IssuePatch{State: &state})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotBody["state_event"] != "reopen" {
+		t.Errorf("state_event = %v, want reopen", gotBody["state_event"])
+	}
+}
+
+func TestGetIssue_404IsNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	_, err := New(srv.Client(), srv.URL, "tok").GetIssue(context.Background(), "g/p", 99)
+	if !errors.Is(err, forge.ErrHookNotFound) {
+		t.Errorf("get 404 = %v, want ErrHookNotFound", err)
+	}
+}
+
+// TestListPullRequests_Mapping pins MR state normalization (opened→open),
+// draft (work_in_progress→Draft), head SHA, branches, and LinkedIssues parse.
+func TestListPullRequests_Mapping(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.EscapedPath(); !strings.HasSuffix(got, "/projects/g%2Fp/merge_requests") {
+			t.Errorf("escaped path = %q", got)
+		}
+		if r.URL.Query().Get("state") != "opened" {
+			t.Errorf("state = %q, want opened", r.URL.Query().Get("state"))
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"iid": 42, "title": "fix the thing closes #12 and #7", "state": "opened",
+				"web_url": "https://gl/g/p/-/merge_requests/42", "source_branch": "feat", "target_branch": "main",
+				"sha": "abc123", "work_in_progress": true, "draft": false,
+				"author": map[string]any{"username": "carol"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	prs, err := New(srv.Client(), srv.URL, "tok").ListPullRequests(context.Background(), "g/p", forge.PullListOptions{State: "open"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("prs = %d", len(prs))
+	}
+	p := prs[0]
+	if p.Number != 42 || p.State != "open" {
+		t.Errorf("number/state = %d/%q", p.Number, p.State)
+	}
+	if p.HeadSHA != "abc123" || p.SourceBranch != "feat" || p.TargetBranch != "main" {
+		t.Errorf("branches/sha = %+v", p)
+	}
+	if !p.Draft {
+		t.Errorf("draft = false, want true (work_in_progress)")
+	}
+	if len(p.LinkedIssues) != 2 || p.LinkedIssues[0] != 12 || p.LinkedIssues[1] != 7 {
+		t.Errorf("linked issues = %v, want [12 7]", p.LinkedIssues)
+	}
+}
+
+// TestGetCIStatus_Aggregation pins per-job status normalization (canceled→
+// cancelled) and the worst-wins aggregate (a failed job → failed state).
+func TestGetCIStatus_Aggregation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.EscapedPath(); !strings.HasSuffix(got, "/repository/commits/abc123/statuses") {
+			t.Errorf("escaped path = %q", got)
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"name": "build", "status": "success", "sha": "abc123", "target_url": "https://gl/build"},
+			{"name": "test", "status": "failed", "sha": "abc123", "target_url": "https://gl/test"},
+			{"name": "lint", "status": "canceled", "sha": "abc123"},
+		})
+	}))
+	defer srv.Close()
+
+	st, err := New(srv.Client(), srv.URL, "tok").GetCIStatus(context.Background(), "g/p", "abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.SHA != "abc123" {
+		t.Errorf("sha = %q", st.SHA)
+	}
+	if st.State != forge.CIFailed {
+		t.Errorf("aggregate state = %q, want failed", st.State)
+	}
+	if len(st.Runs) != 3 {
+		t.Fatalf("runs = %d", len(st.Runs))
+	}
+	if st.Runs[2].Status != forge.CICancelled {
+		t.Errorf("lint status = %q, want cancelled (from canceled)", st.Runs[2].Status)
+	}
+}
+
+// TestGetCIStatus_AllSuccess pins the all-success aggregate.
+func TestGetCIStatus_AllSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"name": "build", "status": "success", "sha": "ddd"},
+			{"name": "test", "status": "success", "sha": "ddd"},
+		})
+	}))
+	defer srv.Close()
+	st, err := New(srv.Client(), srv.URL, "tok").GetCIStatus(context.Background(), "g/p", "ddd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.State != forge.CISuccess {
+		t.Errorf("state = %q, want success", st.State)
+	}
+}
+
+// TestListCIHistory_Pipelines pins one CIRun per pipeline, newest-first query
+// params, and the per-pipeline naming.
+func TestListCIHistory_Pipelines(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("ref") != "main" {
+			t.Errorf("ref = %q", r.URL.Query().Get("ref"))
+		}
+		if r.URL.Query().Get("per_page") != "5" {
+			t.Errorf("per_page = %q, want 5", r.URL.Query().Get("per_page"))
+		}
+		if r.URL.Query().Get("sort") != "desc" {
+			t.Errorf("sort = %q, want desc", r.URL.Query().Get("sort"))
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": 48, "status": "running", "ref": "main", "sha": "eee", "web_url": "https://gl/p/48"},
+			{"id": 47, "status": "success", "ref": "main", "sha": "ddd", "web_url": "https://gl/p/47"},
+		})
+	}))
+	defer srv.Close()
+
+	runs, err := New(srv.Client(), srv.URL, "tok").ListCIHistory(context.Background(), "g/p", "main", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("runs = %d", len(runs))
+	}
+	if runs[0].Name != "pipeline #48" || runs[0].Status != forge.CIRunning {
+		t.Errorf("run[0] = %+v", runs[0])
+	}
+	if runs[1].Name != "pipeline #47" || runs[1].Status != forge.CISuccess {
+		t.Errorf("run[1] = %+v", runs[1])
+	}
+}
+
+func TestListIssues_401IsUnauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	_, err := New(srv.Client(), srv.URL, "tok").ListIssues(context.Background(), "g/p", forge.IssueListOptions{})
+	if !errors.Is(err, forge.ErrUnauthorized) {
+		t.Errorf("list 401 = %v, want ErrUnauthorized", err)
+	}
+}
+
+// Compile-time assertions that AdminClient satisfies the optional capability
+// interfaces (also declared next to each impl, asserted here for visibility).
+var (
+	_ forge.IssueClient = (*AdminClient)(nil)
+	_ forge.PullClient  = (*AdminClient)(nil)
+)

--- a/pkg/forge/gitlab/ci.go
+++ b/pkg/forge/gitlab/ci.go
@@ -1,0 +1,295 @@
+package gitlab
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// gitlabMR is the GitLab merge-request shape (read). Like issues, an MR is
+// addressed by its per-project `iid`; `state` is "opened"/"merged"/"closed",
+// `sha` is the head commit, `work_in_progress`/`draft` flag a draft.
+type gitlabMR struct {
+	IID            int        `json:"iid"`
+	Title          string     `json:"title"`
+	Description    string     `json:"description"`
+	State          string     `json:"state"`
+	WebURL         string     `json:"web_url"`
+	SourceBranch   string     `json:"source_branch"`
+	TargetBranch   string     `json:"target_branch"`
+	SHA            string     `json:"sha"`
+	Draft          bool       `json:"draft"`
+	WorkInProgress bool       `json:"work_in_progress"`
+	Author         gitlabUser `json:"author"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+}
+
+// issueRefRe matches "#<n>" issue references in an MR title/description so
+// LinkedIssues can be parsed best-effort (GitLab has no first-class field for
+// arbitrary linkage in the MR payload).
+var issueRefRe = regexp.MustCompile(`#(\d+)`)
+
+// toRef normalizes a GitLab MR onto forge.PullRef. state "opened"→"open",
+// "merged"/"closed" pass through; draft is the OR of the two GitLab flags.
+func (mr gitlabMR) toRef() forge.PullRef {
+	return forge.PullRef{
+		Number:       mr.IID,
+		Title:        mr.Title,
+		State:        normMRState(mr.State),
+		URL:          mr.WebURL,
+		SourceBranch: mr.SourceBranch,
+		TargetBranch: mr.TargetBranch,
+		HeadSHA:      mr.SHA,
+		Author:       mr.Author.Username,
+		Draft:        mr.Draft || mr.WorkInProgress,
+		CreatedAt:    mr.CreatedAt,
+		UpdatedAt:    mr.UpdatedAt,
+		LinkedIssues: parseLinkedIssues(mr.Title + " " + mr.Description),
+	}
+}
+
+// normMRState maps GitLab's MR state onto the forge vocabulary:
+// "opened"→"open"; "merged"/"closed" are already canonical.
+func normMRState(s string) string {
+	if s == "opened" {
+		return "open"
+	}
+	return s
+}
+
+// mrStateQuery maps a forge PullListOptions.State onto GitLab's MR `state`
+// query value; "all"/empty → no filter.
+func mrStateQuery(state string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "open", "opened":
+		return "opened"
+	case "merged":
+		return "merged"
+	case "closed":
+		return "closed"
+	default:
+		return ""
+	}
+}
+
+// parseLinkedIssues extracts distinct "#<n>" issue numbers from free text,
+// preserving first-seen order.
+func parseLinkedIssues(text string) []int {
+	matches := issueRefRe.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := map[int]bool{}
+	var out []int
+	for _, m := range matches {
+		n, err := strconv.Atoi(m[1])
+		if err != nil || seen[n] {
+			continue
+		}
+		seen[n] = true
+		out = append(out, n)
+	}
+	return out
+}
+
+// ListPullRequests lists a project's merge requests, normalized to forge.PullRef.
+func (c *AdminClient) ListPullRequests(ctx context.Context, repo string, opts forge.PullListOptions) ([]forge.PullRef, error) {
+	vals := url.Values{}
+	if st := mrStateQuery(opts.State); st != "" {
+		vals.Set("state", st)
+	}
+	if !opts.Since.IsZero() {
+		vals.Set("updated_after", opts.Since.UTC().Format(time.RFC3339))
+	}
+	page := opts.Page
+	if page <= 0 {
+		page = 1
+	}
+	vals.Set("page", strconv.Itoa(page))
+	if opts.PerPage > 0 {
+		vals.Set("per_page", strconv.Itoa(opts.PerPage))
+	}
+
+	var mrs []gitlabMR
+	code, err := c.do(ctx, http.MethodGet, "/projects/"+projectID(repo)+"/merge_requests?"+vals.Encode(), nil, &mrs)
+	if err != nil {
+		return nil, err
+	}
+	if code != http.StatusOK {
+		return nil, statusErr("list merge requests", code)
+	}
+	out := make([]forge.PullRef, 0, len(mrs))
+	for _, mr := range mrs {
+		out = append(out, mr.toRef())
+	}
+	return out, nil
+}
+
+// GetPullRequest fetches one merge request by its per-project iid.
+func (c *AdminClient) GetPullRequest(ctx context.Context, repo string, number int) (forge.PullRef, error) {
+	var mr gitlabMR
+	code, err := c.do(ctx, http.MethodGet, "/projects/"+projectID(repo)+"/merge_requests/"+strconv.Itoa(number), nil, &mr)
+	if err != nil {
+		return forge.PullRef{}, err
+	}
+	if code != http.StatusOK {
+		return forge.PullRef{}, statusErr("get merge request", code)
+	}
+	return mr.toRef(), nil
+}
+
+// gitlabCommitStatus is one per-job commit status (the GitLab
+// /repository/commits/:sha/statuses entry).
+type gitlabCommitStatus struct {
+	Name       string    `json:"name"`
+	Status     string    `json:"status"`
+	SHA        string    `json:"sha"`
+	TargetURL  string    `json:"target_url"`
+	StartedAt  time.Time `json:"started_at"`
+	FinishedAt time.Time `json:"finished_at"`
+}
+
+// normCIStatus maps a GitLab job/pipeline status onto the forge CI* vocabulary.
+// GitLab's "canceled" (one L) and the queue states (created/preparing/…) are
+// folded onto the canonical set; unknown values → CIUnknown.
+func normCIStatus(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "success":
+		return forge.CISuccess
+	case "failed":
+		return forge.CIFailed
+	case "running":
+		return forge.CIRunning
+	case "canceled", "cancelled", "canceling":
+		return forge.CICancelled
+	case "skipped", "manual":
+		return forge.CISkipped
+	case "pending", "created", "preparing", "scheduled", "waiting_for_resource":
+		return forge.CIPending
+	default:
+		return forge.CIUnknown
+	}
+}
+
+// aggregateCIState folds a set of normalized run states into a single
+// aggregate: any failure → failed; any in-flight (running/pending) → that
+// state; all success → success; otherwise unknown. Mirrors the
+// "worst-wins, then in-flight, then success" convention.
+func aggregateCIState(runs []forge.CIRun) string {
+	if len(runs) == 0 {
+		return forge.CIUnknown
+	}
+	var anyRunning, anyPending, anySuccess bool
+	for _, r := range runs {
+		switch r.Status {
+		case forge.CIFailed:
+			return forge.CIFailed
+		case forge.CIRunning:
+			anyRunning = true
+		case forge.CIPending:
+			anyPending = true
+		case forge.CISuccess:
+			anySuccess = true
+		}
+	}
+	switch {
+	case anyRunning:
+		return forge.CIRunning
+	case anyPending:
+		return forge.CIPending
+	case anySuccess:
+		return forge.CISuccess
+	default:
+		// Only cancelled/skipped runs — no meaningful aggregate signal.
+		return forge.CIUnknown
+	}
+}
+
+// GetCIStatus returns the current aggregate CI state + per-job runs for a ref
+// (a commit SHA or branch name). It reads GitLab's commit-statuses endpoint,
+// which exposes one entry per CI job.
+func (c *AdminClient) GetCIStatus(ctx context.Context, repo, ref string) (forge.CIStatus, error) {
+	var statuses []gitlabCommitStatus
+	code, err := c.do(ctx, http.MethodGet,
+		"/projects/"+projectID(repo)+"/repository/commits/"+url.PathEscape(ref)+"/statuses", nil, &statuses)
+	if err != nil {
+		return forge.CIStatus{}, err
+	}
+	if code != http.StatusOK {
+		return forge.CIStatus{}, statusErr("get ci status", code)
+	}
+	runs := make([]forge.CIRun, 0, len(statuses))
+	sha := ref
+	for _, s := range statuses {
+		if s.SHA != "" {
+			sha = s.SHA
+		}
+		runs = append(runs, forge.CIRun{
+			Name:       s.Name,
+			Status:     normCIStatus(s.Status),
+			URL:        s.TargetURL,
+			SHA:        s.SHA,
+			StartedAt:  s.StartedAt,
+			FinishedAt: s.FinishedAt,
+		})
+	}
+	return forge.CIStatus{
+		SHA:   sha,
+		State: aggregateCIState(runs),
+		Runs:  runs,
+	}, nil
+}
+
+// gitlabPipeline is one pipeline entry (the GitLab /pipelines list shape).
+type gitlabPipeline struct {
+	ID        int       `json:"id"`
+	Status    string    `json:"status"`
+	Ref       string    `json:"ref"`
+	SHA       string    `json:"sha"`
+	WebURL    string    `json:"web_url"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// ListCIHistory returns recent pipelines for a ref/branch, newest first, one
+// CIRun per pipeline (Name="pipeline #<id>"). limit ≤ 0 → GitLab default page.
+func (c *AdminClient) ListCIHistory(ctx context.Context, repo, ref string, limit int) ([]forge.CIRun, error) {
+	vals := url.Values{}
+	if ref != "" {
+		vals.Set("ref", ref)
+	}
+	vals.Set("order_by", "id")
+	vals.Set("sort", "desc")
+	if limit > 0 {
+		vals.Set("per_page", strconv.Itoa(limit))
+	}
+	var pipelines []gitlabPipeline
+	code, err := c.do(ctx, http.MethodGet, "/projects/"+projectID(repo)+"/pipelines?"+vals.Encode(), nil, &pipelines)
+	if err != nil {
+		return nil, err
+	}
+	if code != http.StatusOK {
+		return nil, statusErr("list ci history", code)
+	}
+	out := make([]forge.CIRun, 0, len(pipelines))
+	for _, p := range pipelines {
+		out = append(out, forge.CIRun{
+			Name:       "pipeline #" + strconv.Itoa(p.ID),
+			Status:     normCIStatus(p.Status),
+			URL:        p.WebURL,
+			SHA:        p.SHA,
+			StartedAt:  p.CreatedAt,
+			FinishedAt: p.UpdatedAt,
+		})
+	}
+	return out, nil
+}
+
+var _ forge.PullClient = (*AdminClient)(nil)

--- a/pkg/forge/gitlab/issues.go
+++ b/pkg/forge/gitlab/issues.go
@@ -1,0 +1,186 @@
+package gitlab
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// gitlabUser is the lowest-common-denominator user shape GitLab embeds in
+// issues/merge-requests (author, assignees). Only the username is consumed.
+type gitlabUser struct {
+	Username string `json:"username"`
+	Name     string `json:"name"`
+}
+
+// gitlabIssue is the GitLab issue shape (read). GitLab addresses an issue by
+// its per-project `iid` (not the global `id`); `state` is "opened"/"closed",
+// `description` is the body, `web_url` is the URL.
+type gitlabIssue struct {
+	IID         int          `json:"iid"`
+	Title       string       `json:"title"`
+	Description string       `json:"description"`
+	State       string       `json:"state"`
+	WebURL      string       `json:"web_url"`
+	Labels      []string     `json:"labels"`
+	Author      gitlabUser   `json:"author"`
+	Assignees   []gitlabUser `json:"assignees"`
+	CreatedAt   time.Time    `json:"created_at"`
+	UpdatedAt   time.Time    `json:"updated_at"`
+}
+
+// toRef normalizes a GitLab issue onto forge.IssueRef. The per-project iid is
+// the number the rest of pkg/forge addresses; state "opened"→"open".
+func (gi gitlabIssue) toRef() forge.IssueRef {
+	assignees := make([]string, 0, len(gi.Assignees))
+	for _, a := range gi.Assignees {
+		if a.Username != "" {
+			assignees = append(assignees, a.Username)
+		}
+	}
+	return forge.IssueRef{
+		Number:    gi.IID,
+		Title:     gi.Title,
+		Body:      gi.Description,
+		State:     normIssueState(gi.State),
+		URL:       gi.WebURL,
+		Labels:    gi.Labels,
+		Assignees: assignees,
+		Author:    gi.Author.Username,
+		CreatedAt: gi.CreatedAt,
+		UpdatedAt: gi.UpdatedAt,
+	}
+}
+
+// normIssueState maps GitLab's "opened"/"closed" onto the forge "open"/"closed"
+// vocabulary. Any other value passes through unchanged.
+func normIssueState(s string) string {
+	if s == "opened" {
+		return "open"
+	}
+	return s
+}
+
+// issueStateQuery maps a forge IssueListOptions.State onto GitLab's `state`
+// query value ("opened"/"closed"); "all" / empty → no filter (GitLab lists all).
+func issueStateQuery(state string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "open", "opened":
+		return "opened"
+	case "closed":
+		return "closed"
+	default:
+		return ""
+	}
+}
+
+// ListIssues lists a project's issues, normalized to forge.IssueRef. Powers
+// forge→board one-way sync (incremental via opts.Since → updated_after).
+func (c *AdminClient) ListIssues(ctx context.Context, repo string, opts forge.IssueListOptions) ([]forge.IssueRef, error) {
+	vals := url.Values{}
+	if st := issueStateQuery(opts.State); st != "" {
+		vals.Set("state", st)
+	}
+	if len(opts.Labels) > 0 {
+		vals.Set("labels", strings.Join(opts.Labels, ","))
+	}
+	if !opts.Since.IsZero() {
+		vals.Set("updated_after", opts.Since.UTC().Format(time.RFC3339))
+	}
+	page := opts.Page
+	if page <= 0 {
+		page = 1
+	}
+	vals.Set("page", strconv.Itoa(page))
+	if opts.PerPage > 0 {
+		vals.Set("per_page", strconv.Itoa(opts.PerPage))
+	}
+
+	var issues []gitlabIssue
+	code, err := c.do(ctx, http.MethodGet, "/projects/"+projectID(repo)+"/issues?"+vals.Encode(), nil, &issues)
+	if err != nil {
+		return nil, err
+	}
+	if code != http.StatusOK {
+		return nil, statusErr("list issues", code)
+	}
+	out := make([]forge.IssueRef, 0, len(issues))
+	for _, gi := range issues {
+		out = append(out, gi.toRef())
+	}
+	return out, nil
+}
+
+// GetIssue fetches one issue by its per-project iid.
+func (c *AdminClient) GetIssue(ctx context.Context, repo string, number int) (forge.IssueRef, error) {
+	var gi gitlabIssue
+	code, err := c.do(ctx, http.MethodGet, "/projects/"+projectID(repo)+"/issues/"+strconv.Itoa(number), nil, &gi)
+	if err != nil {
+		return forge.IssueRef{}, err
+	}
+	if code != http.StatusOK {
+		return forge.IssueRef{}, statusErr("get issue", code)
+	}
+	return gi.toRef(), nil
+}
+
+// CreateIssue creates an issue (board→forge push). Labels are sent as a
+// comma-joined string (GitLab's write shape); assignees would need numeric
+// ids, which the board doesn't carry, so they're left to a later mapping.
+func (c *AdminClient) CreateIssue(ctx context.Context, repo string, in forge.NewIssue) (forge.IssueRef, error) {
+	body := map[string]any{"title": in.Title}
+	if in.Body != "" {
+		body["description"] = in.Body
+	}
+	if len(in.Labels) > 0 {
+		body["labels"] = strings.Join(in.Labels, ",")
+	}
+	var gi gitlabIssue
+	code, err := c.do(ctx, http.MethodPost, "/projects/"+projectID(repo)+"/issues", body, &gi)
+	if err != nil {
+		return forge.IssueRef{}, err
+	}
+	if code/100 != 2 {
+		return forge.IssueRef{}, statusErr("create issue", code)
+	}
+	return gi.toRef(), nil
+}
+
+// UpdateIssue applies a partial patch to an issue. State transitions map onto
+// GitLab's `state_event` (close|reopen); nil patch fields are left untouched.
+func (c *AdminClient) UpdateIssue(ctx context.Context, repo string, number int, patch forge.IssuePatch) (forge.IssueRef, error) {
+	body := map[string]any{}
+	if patch.Title != nil {
+		body["title"] = *patch.Title
+	}
+	if patch.Body != nil {
+		body["description"] = *patch.Body
+	}
+	if patch.Labels != nil {
+		body["labels"] = strings.Join(*patch.Labels, ",")
+	}
+	if patch.State != nil {
+		switch strings.ToLower(strings.TrimSpace(*patch.State)) {
+		case "closed":
+			body["state_event"] = "close"
+		case "open", "opened":
+			body["state_event"] = "reopen"
+		}
+	}
+	var gi gitlabIssue
+	code, err := c.do(ctx, http.MethodPut, "/projects/"+projectID(repo)+"/issues/"+strconv.Itoa(number), body, &gi)
+	if err != nil {
+		return forge.IssueRef{}, err
+	}
+	if code/100 != 2 {
+		return forge.IssueRef{}, statusErr("update issue", code)
+	}
+	return gi.toRef(), nil
+}
+
+var _ forge.IssueClient = (*AdminClient)(nil)

--- a/pkg/forge/issues.go
+++ b/pkg/forge/issues.go
@@ -105,7 +105,7 @@ type PullListOptions struct {
 // Forgejo Actions run / commit-status) normalized to a common shape.
 type CIRun struct {
 	Name       string    `json:"name"`
-	Status     string    `json:"status"`     // "queued" | "running" | "success" | "failed" | "cancelled" | "skipped"
+	Status     string    `json:"status"` // "queued" | "running" | "success" | "failed" | "cancelled" | "skipped"
 	Conclusion string    `json:"conclusion,omitempty"`
 	URL        string    `json:"url,omitempty"`
 	SHA        string    `json:"sha,omitempty"`

--- a/pkg/forge/issues.go
+++ b/pkg/forge/issues.go
@@ -1,0 +1,148 @@
+package forge
+
+import (
+	"context"
+	"time"
+)
+
+// This file defines the OPTIONAL issue / pull-request / CI capabilities a
+// provider's admin client may expose, on top of the mandatory Admin interface
+// (webhooks + repos). They are separate, type-asserted interfaces — exactly
+// like OAuthAppProvisioner — so a provider that doesn't implement one yet
+// degrades gracefully (the server checks `if ic, ok := admin.(IssueClient)`)
+// instead of forcing every client to stub them.
+//
+// Powering:
+//   - IssueClient → forge→board one-way sync (ListIssues) + board→forge
+//     push-to-forge (CreateIssue / UpdateIssue).
+//   - PullClient  → linked PRs + CI status (current + history) on board cards.
+//
+// `repo` is always the provider-native full name the rest of pkg/forge uses
+// (github/forgejo: "owner/repo"; gitlab: "group/project" path, the client
+// URL-encodes it). Numbers are the forge's own issue/MR iid.
+
+// IssueRef is a normalized forge issue (or, on GitHub/Forgejo where the issues
+// endpoint conflates them, possibly a pull request — see IsPullRequest).
+type IssueRef struct {
+	Number        int       `json:"number"`
+	Title         string    `json:"title"`
+	Body          string    `json:"body,omitempty"`
+	State         string    `json:"state"` // "open" | "closed"
+	URL           string    `json:"url"`
+	Labels        []string  `json:"labels,omitempty"`
+	Assignees     []string  `json:"assignees,omitempty"`
+	Author        string    `json:"author,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+	IsPullRequest bool      `json:"is_pull_request,omitempty"`
+}
+
+// IssueListOptions filters a ListIssues call. Zero value lists open issues,
+// first page. Since enables incremental sync (only issues updated since the
+// last sweep).
+type IssueListOptions struct {
+	State   string // "open" | "closed" | "all" (default "open")
+	Labels  []string
+	Page    int       // 1-based; 0 → 1
+	PerPage int       // 0 → provider default (≈50)
+	Since   time.Time // zero = no lower bound
+}
+
+// NewIssue is the payload for CreateIssue (board→forge push).
+type NewIssue struct {
+	Title     string
+	Body      string
+	Labels    []string
+	Assignees []string
+}
+
+// IssuePatch is a partial update for UpdateIssue. Nil fields are left
+// untouched; State is "open"|"closed".
+type IssuePatch struct {
+	Title     *string
+	Body      *string
+	State     *string
+	Labels    *[]string
+	Assignees *[]string
+}
+
+// IssueClient is the optional issue read/write capability. ListIssues powers
+// forge→board sync; Create/UpdateIssue power per-card push-to-forge.
+type IssueClient interface {
+	ListIssues(ctx context.Context, repo string, opts IssueListOptions) ([]IssueRef, error)
+	GetIssue(ctx context.Context, repo string, number int) (IssueRef, error)
+	CreateIssue(ctx context.Context, repo string, in NewIssue) (IssueRef, error)
+	UpdateIssue(ctx context.Context, repo string, number int, patch IssuePatch) (IssueRef, error)
+}
+
+// PullRef is a normalized pull/merge request.
+type PullRef struct {
+	Number       int       `json:"number"`
+	Title        string    `json:"title"`
+	State        string    `json:"state"` // "open" | "closed" | "merged"
+	URL          string    `json:"url"`
+	SourceBranch string    `json:"source_branch,omitempty"`
+	TargetBranch string    `json:"target_branch,omitempty"`
+	HeadSHA      string    `json:"head_sha,omitempty"`
+	Author       string    `json:"author,omitempty"`
+	Draft        bool      `json:"draft,omitempty"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	// LinkedIssues are issue numbers this PR references / closes, best-effort
+	// parsed from the title/body ("fixes #12", "Closes #7", "!?").
+	LinkedIssues []int `json:"linked_issues,omitempty"`
+}
+
+// PullListOptions filters ListPullRequests.
+type PullListOptions struct {
+	State   string // "open" | "closed" | "all" (default "open")
+	Page    int
+	PerPage int
+	Since   time.Time
+}
+
+// CIRun is one CI execution (a GitHub check-run / GitLab pipeline-or-job /
+// Forgejo Actions run / commit-status) normalized to a common shape.
+type CIRun struct {
+	Name       string    `json:"name"`
+	Status     string    `json:"status"`     // "queued" | "running" | "success" | "failed" | "cancelled" | "skipped"
+	Conclusion string    `json:"conclusion,omitempty"`
+	URL        string    `json:"url,omitempty"`
+	SHA        string    `json:"sha,omitempty"`
+	StartedAt  time.Time `json:"started_at,omitempty"`
+	FinishedAt time.Time `json:"finished_at,omitempty"`
+}
+
+// CIStatus is the aggregate CI state for a commit/ref plus its current runs.
+type CIStatus struct {
+	SHA   string  `json:"sha"`
+	State string  `json:"state"` // aggregate: "success" | "failed" | "running" | "pending" | "unknown"
+	Runs  []CIRun `json:"runs,omitempty"`
+}
+
+// PullClient is the optional PR + CI capability for surfacing linked PRs and
+// CI state (current + history) on board cards.
+type PullClient interface {
+	// ListPullRequests lists PRs/MRs for a repo (for linking to issues + the
+	// card PR panel).
+	ListPullRequests(ctx context.Context, repo string, opts PullListOptions) ([]PullRef, error)
+	// GetPullRequest fetches one PR/MR by number.
+	GetPullRequest(ctx context.Context, repo string, number int) (PullRef, error)
+	// GetCIStatus returns the CURRENT aggregate CI state + runs for a ref
+	// (commit SHA or branch).
+	GetCIStatus(ctx context.Context, repo, ref string) (CIStatus, error)
+	// ListCIHistory returns recent CI runs for a ref/branch, newest first,
+	// up to limit (0 → provider default).
+	ListCIHistory(ctx context.Context, repo, ref string, limit int) ([]CIRun, error)
+}
+
+// Normalized CI/issue state vocabularies, so providers map onto a stable set.
+const (
+	CIPending   = "pending"
+	CIRunning   = "running"
+	CISuccess   = "success"
+	CIFailed    = "failed"
+	CICancelled = "cancelled"
+	CISkipped   = "skipped"
+	CIUnknown   = "unknown"
+)

--- a/pkg/forge/repo_integration_store.go
+++ b/pkg/forge/repo_integration_store.go
@@ -35,6 +35,15 @@ type RepoIntegration struct {
 	HookURL         string `bson:"hook_url,omitempty" json:"hook_url,omitempty"` // the inbound URL we registered
 	ManagedSecretID string `bson:"managed_secret_id,omitempty" json:"managed_secret_id,omitempty"`
 
+	// SyncIssuesEnabled, when true, makes the forge→board sync worker mirror
+	// this repo's forge issues into the team's kanban board (one-way: forge is
+	// the source; a card's column is operator-owned once created). Toggled per
+	// repo from the studio Integrations tab. Off by default.
+	SyncIssuesEnabled bool `bson:"sync_issues_enabled,omitempty" json:"sync_issues_enabled,omitempty"`
+	// LastSyncedAt is the high-water mark of the last successful issue sync,
+	// passed as the `since` filter on the next sweep for incremental sync.
+	LastSyncedAt time.Time `bson:"last_synced_at,omitempty" json:"last_synced_at,omitempty"`
+
 	CreatedBy string    `bson:"created_by" json:"created_by"`
 	CreatedAt time.Time `bson:"created_at" json:"created_at"`
 	UpdatedAt time.Time `bson:"updated_at" json:"updated_at"`
@@ -52,6 +61,9 @@ type RepoIntegrationStore interface {
 	ListByTenant(ctx context.Context, tenantID string) ([]RepoIntegration, error)
 	ListByConnection(ctx context.Context, tenantID, connID string) ([]RepoIntegration, error)
 	ListByWebhook(ctx context.Context, tenantID, webhookID string) ([]RepoIntegration, error)
+	// ListSyncEnabled returns every integration (across all tenants) with
+	// SyncIssuesEnabled set, for the periodic forge→board sync worker.
+	ListSyncEnabled(ctx context.Context) ([]RepoIntegration, error)
 }
 
 // ---- in-memory store (tests / local) ----
@@ -126,6 +138,10 @@ func (m *MemoryRepoIntegrationStore) ListByConnection(_ context.Context, tenantI
 	return m.filter(func(ri RepoIntegration) bool {
 		return ri.TenantID == tenantID && ri.ConnectionID == connID
 	}), nil
+}
+
+func (m *MemoryRepoIntegrationStore) ListSyncEnabled(_ context.Context) ([]RepoIntegration, error) {
+	return m.filter(func(ri RepoIntegration) bool { return ri.SyncIssuesEnabled }), nil
 }
 
 func (m *MemoryRepoIntegrationStore) ListByWebhook(_ context.Context, tenantID, webhookID string) ([]RepoIntegration, error) {
@@ -233,6 +249,10 @@ func (s *MongoRepoIntegrationStore) ListByConnection(ctx context.Context, tenant
 
 func (s *MongoRepoIntegrationStore) ListByWebhook(ctx context.Context, tenantID, webhookID string) ([]RepoIntegration, error) {
 	return s.find(ctx, bson.M{"tenant_id": tenantID, "webhook_id": webhookID})
+}
+
+func (s *MongoRepoIntegrationStore) ListSyncEnabled(ctx context.Context) ([]RepoIntegration, error) {
+	return s.find(ctx, bson.M{"sync_issues_enabled": true})
 }
 
 func (s *MongoRepoIntegrationStore) find(ctx context.Context, filter bson.M) ([]RepoIntegration, error) {

--- a/pkg/server/board_cloud_routes.go
+++ b/pkg/server/board_cloud_routes.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+)
+
+// registerCloudBoardRoutes mounts the kanban board REST surface in CLOUD
+// mode, where there is no single filesystem board — each team has its own
+// Mongo-backed board (boardmongo, via cfg.CloudBoardFor). It reuses the very
+// same prefix the self-hosted mount uses (/api/v1/native) and the same
+// BoardAPI handlers, but resolves the store PER REQUEST from the caller's
+// ACTIVE TEAM (the team stamped on the JWT). So the studio board view works
+// unchanged in cloud — it just sees the active team's board — and switching
+// the active team switches the board. Board membership is implicit: a user
+// only ever resolves their own active team's board.
+//
+// Self-hosted mode (NativeTrackerStore != nil) keeps the single-store mount;
+// the two are mutually exclusive, so there is no route conflict.
+func (s *Server) registerCloudBoardRoutes() {
+	api := &native.BoardAPI{Resolve: s.cloudBoardResolve}
+	api.RegisterRoutesWithMiddleware(s.mux, "/api/v1/native", s.requireAuth)
+}
+
+// cloudBoardResolve returns the active team's board store for this request.
+// A request with no active team (a brand-new account not yet in a team)
+// resolves to a nil store, which BoardAPI renders as 404 "board not
+// available" rather than erroring.
+func (s *Server) cloudBoardResolve(r *http.Request) (native.BoardStore, error) {
+	id, _ := auth.FromContext(r.Context())
+	if id.TeamID == "" {
+		return nil, nil
+	}
+	return s.cfg.CloudBoardFor(id.TeamID), nil
+}

--- a/pkg/server/board_forge.go
+++ b/pkg/server/board_forge.go
@@ -1,0 +1,569 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// forgeSyncNamespace is the fixed UUIDv5 namespace that turns a forge issue
+// key ("<provider>:<repo>#<number>") into a deterministic, valid
+// "native:<uuid>" card ID, so re-syncing the same issue UPSERTS its card
+// instead of duplicating it.
+var forgeSyncNamespace = uuid.MustParse("a3f4c1d2-7b9e-5a6f-8c2d-1e0f9b8a7c6d")
+
+func forgeCardID(provider forge.Provider, repo string, number int) string {
+	key := fmt.Sprintf("%s:%s#%d", provider, repo, number)
+	return "native:" + uuid.NewSHA1(forgeSyncNamespace, []byte(key)).String()
+}
+
+// registerBoardForgeRoutes mounts the cloud-only forge↔board endpoints: the
+// per-repo sync toggle + manual sync (team-scoped), and the per-card
+// push-to-forge + linked-PR + CI views (active-team board scoped). All are
+// no-ops in self-hosted mode (no CloudBoardFor / forge stores).
+func (s *Server) registerBoardForgeRoutes() {
+	if s.cfg.CloudBoardFor == nil || s.forgeIntegrations == nil {
+		return
+	}
+	s.mux.Handle("PATCH /api/teams/{id}/forge/integrations/{iid}", s.requireAuth(http.HandlerFunc(s.handlePatchForgeIntegration)))
+	s.mux.Handle("POST /api/teams/{id}/forge/integrations/{iid}/sync", s.requireAuth(http.HandlerFunc(s.handleSyncForgeIntegration)))
+	s.mux.Handle("POST /api/v1/native/issues/{id}/push", s.requireAuth(http.HandlerFunc(s.handlePushIssueToForge)))
+	s.mux.Handle("GET /api/v1/native/issues/{id}/pulls", s.requireAuth(http.HandlerFunc(s.handleListIssuePulls)))
+	s.mux.Handle("GET /api/v1/native/issues/{id}/pulls/{number}/ci", s.requireAuth(http.HandlerFunc(s.handleIssuePullCI)))
+}
+
+// ---------------------------------------------------------------------------
+// per-repo sync toggle + manual sync (team-scoped)
+// ---------------------------------------------------------------------------
+
+type patchIntegrationReq struct {
+	SyncIssuesEnabled *bool `json:"sync_issues_enabled,omitempty"`
+}
+
+func (s *Server) handlePatchForgeIntegration(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	teamID := r.PathValue("id")
+	if !s.canManageTeam(r.Context(), id, teamID) {
+		httpError(w, http.StatusForbidden, "admin or owner required")
+		return
+	}
+	ri, ok := s.forgeIntegrationForTenant(w, r, teamID, r.PathValue("iid"))
+	if !ok {
+		return
+	}
+	var req patchIntegrationReq
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	if req.SyncIssuesEnabled != nil {
+		ri.SyncIssuesEnabled = *req.SyncIssuesEnabled
+	}
+	ri.UpdatedAt = time.Now().UTC()
+	if err := s.forgeIntegrations.Update(r.Context(), ri); err != nil {
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	writeJSON(w, ri)
+}
+
+type syncResult struct {
+	Synced  int `json:"synced"`
+	Created int `json:"created"`
+	Updated int `json:"updated"`
+}
+
+func (s *Server) handleSyncForgeIntegration(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	teamID := r.PathValue("id")
+	if !s.canManageTeam(r.Context(), id, teamID) {
+		httpError(w, http.StatusForbidden, "admin or owner required")
+		return
+	}
+	ri, ok := s.forgeIntegrationForTenant(w, r, teamID, r.PathValue("iid"))
+	if !ok {
+		return
+	}
+	created, updated, err := s.syncOneIntegration(r.Context(), teamID, ri)
+	if err != nil {
+		httpError(w, http.StatusBadGateway, "sync failed: %v", err)
+		return
+	}
+	writeJSON(w, syncResult{Synced: created + updated, Created: created, Updated: updated})
+}
+
+// forgeIntegrationForTenant loads an integration and asserts it belongs to the
+// team, writing 404 otherwise.
+func (s *Server) forgeIntegrationForTenant(w http.ResponseWriter, r *http.Request, teamID, iid string) (forge.RepoIntegration, bool) {
+	ri, err := s.forgeIntegrations.Get(r.Context(), iid)
+	if err != nil || ri.TenantID != teamID {
+		httpError(w, http.StatusNotFound, "integration not found")
+		return forge.RepoIntegration{}, false
+	}
+	return ri, true
+}
+
+// ---------------------------------------------------------------------------
+// forge → board sync (one-way; the source is the forge)
+// ---------------------------------------------------------------------------
+
+// syncOneIntegration mirrors one repo's forge issues into the team board and
+// stamps the integration's LastSyncedAt high-water mark. It is the unit both
+// the manual "Sync now" endpoint and the periodic worker call.
+func (s *Server) syncOneIntegration(ctx context.Context, teamID string, ri forge.RepoIntegration) (created, updated int, err error) {
+	conn, err := s.forgeConnections.Get(ctx, ri.ConnectionID)
+	if err != nil {
+		return 0, 0, fmt.Errorf("connection: %w", err)
+	}
+	admin, err := s.forgeAdminFor(ctx, conn)
+	if err != nil {
+		return 0, 0, fmt.Errorf("admin client: %w", err)
+	}
+	ic, ok := admin.(forge.IssueClient)
+	if !ok {
+		return 0, 0, fmt.Errorf("provider %s has no issue client", conn.Provider)
+	}
+	board := s.cfg.CloudBoardFor(teamID)
+	if board == nil {
+		return 0, 0, errors.New("no board for team")
+	}
+	issues, err := ic.ListIssues(ctx, ri.RepoFullName, forge.IssueListOptions{
+		State: "all", Since: ri.LastSyncedAt, PerPage: 100,
+	})
+	if err != nil {
+		return 0, 0, fmt.Errorf("list issues: %w", err)
+	}
+	b := board.Board()
+	openCol := defaultOpenColumn(b)
+	doneCol := terminalColumn(b)
+	for _, is := range issues {
+		if is.IsPullRequest {
+			continue // the board syncs ISSUES; PRs surface via the card PR panel
+		}
+		c, u, e := upsertForgeCard(board, b, openCol, doneCol, conn.Provider, ri.ConnectionID, ri.RepoFullName, is)
+		if e != nil {
+			if err == nil {
+				err = e
+			}
+			continue
+		}
+		created += c
+		updated += u
+	}
+	ri.LastSyncedAt = time.Now().UTC()
+	if uerr := s.forgeIntegrations.Update(ctx, ri); uerr != nil && err == nil {
+		err = uerr
+	}
+	return created, updated, err
+}
+
+// upsertForgeCard creates or updates the board card mirroring one forge issue.
+// On create the card lands in openCol (or doneCol when already closed); on
+// update the card's content/labels refresh but its COLUMN is left to the
+// operator — except a forge-close pulls a still-open card to the terminal
+// column. Returns (created, updated) as 0/1 flags.
+func upsertForgeCard(board native.BoardStore, b *native.Board, openCol, doneCol string, provider forge.Provider, connID, repo string, is forge.IssueRef) (int, int, error) {
+	cardID := forgeCardID(provider, repo, is.Number)
+	ext := &native.ExternalRef{
+		Provider:     string(provider),
+		ConnectionID: connID,
+		Repo:         repo,
+		Number:       is.Number,
+		URL:          is.URL,
+		State:        is.State,
+	}
+	existing, gerr := board.Get(cardID)
+	if gerr != nil {
+		col := openCol
+		if is.State == "closed" && doneCol != "" {
+			col = doneCol
+		}
+		if _, err := board.Create(native.Issue{
+			ID:       cardID,
+			Title:    is.Title,
+			Body:     is.Body,
+			State:    col,
+			Labels:   is.Labels,
+			Assignee: firstString(is.Assignees),
+			External: ext,
+		}); err != nil {
+			return 0, 0, err
+		}
+		return 1, 0, nil
+	}
+	labels := is.Labels
+	if _, err := board.Update(cardID, native.Patch{
+		Title:    &is.Title,
+		Body:     &is.Body,
+		Labels:   &labels,
+		External: ext,
+	}); err != nil {
+		return 0, 0, err
+	}
+	if is.State == "closed" && doneCol != "" && !isTerminalState(b, existing.State) {
+		_, _ = board.SetState(cardID, doneCol)
+	}
+	return 0, 1, nil
+}
+
+// defaultOpenColumn is the landing column for a newly-synced open issue: the
+// first non-terminal state on the board (the inbox in the default layout).
+func defaultOpenColumn(b *native.Board) string {
+	for _, st := range b.States {
+		if !st.Terminal {
+			return st.Name
+		}
+	}
+	if len(b.States) > 0 {
+		return b.States[0].Name
+	}
+	return ""
+}
+
+// terminalColumn is where a closed issue lands: the first terminal state.
+func terminalColumn(b *native.Board) string {
+	for _, st := range b.States {
+		if st.Terminal {
+			return st.Name
+		}
+	}
+	return ""
+}
+
+func isTerminalState(b *native.Board, name string) bool {
+	for _, st := range b.States {
+		if st.Name == name {
+			return st.Terminal
+		}
+	}
+	return false
+}
+
+func firstString(ss []string) string {
+	if len(ss) > 0 {
+		return ss[0]
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// board → forge: push a card to the forge as an issue (discreet card action)
+// ---------------------------------------------------------------------------
+
+type pushIssueReq struct {
+	ConnectionID string `json:"connection_id,omitempty"`
+	Repo         string `json:"repo,omitempty"`
+}
+
+type pushIssueResp struct {
+	URL      string `json:"url"`
+	Number   int    `json:"number"`
+	Provider string `json:"provider"`
+}
+
+func (s *Server) handlePushIssueToForge(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	board, ok := s.activeTeamBoard(w, id)
+	if !ok {
+		return
+	}
+	cardID, err := board.Resolve(r.PathValue("id"))
+	if err != nil {
+		httpError(w, http.StatusNotFound, "card not found")
+		return
+	}
+	card, err := board.Get(cardID)
+	if err != nil {
+		httpError(w, http.StatusNotFound, "card not found")
+		return
+	}
+	var req pushIssueReq
+	_ = decodeJSONOptional(r, &req)
+
+	_, connID, repo, number := forgeLinkOf(card)
+	// Already linked → update the existing forge issue from the card.
+	if connID != "" && repo != "" && number > 0 {
+		ic, conn, ok := s.issueClientForConn(w, r.Context(), id.TeamID, connID)
+		if !ok {
+			return
+		}
+		state := "open"
+		body := card.Body
+		title := card.Title
+		labels := card.Labels
+		ref, err := ic.UpdateIssue(r.Context(), repo, number, forge.IssuePatch{
+			Title: &title, Body: &body, State: &state, Labels: &labels,
+		})
+		if err != nil {
+			httpError(w, http.StatusBadGateway, "update forge issue: %v", err)
+			return
+		}
+		writeJSON(w, pushIssueResp{URL: ref.URL, Number: ref.Number, Provider: string(conn.Provider)})
+		return
+	}
+	// Unlinked → create a new forge issue; body+repo required.
+	if strings.TrimSpace(req.ConnectionID) == "" || strings.TrimSpace(req.Repo) == "" {
+		httpError(w, http.StatusBadRequest, "connection_id and repo are required to push an unlinked card")
+		return
+	}
+	ic, conn, ok := s.issueClientForConn(w, r.Context(), id.TeamID, req.ConnectionID)
+	if !ok {
+		return
+	}
+	ref, err := ic.CreateIssue(r.Context(), req.Repo, forge.NewIssue{
+		Title: card.Title, Body: card.Body, Labels: card.Labels,
+	})
+	if err != nil {
+		httpError(w, http.StatusBadGateway, "create forge issue: %v", err)
+		return
+	}
+	// Stamp the card with its new forge linkage so future pushes update it.
+	_, _ = board.Update(cardID, native.Patch{External: &native.ExternalRef{
+		Provider:     string(conn.Provider),
+		ConnectionID: req.ConnectionID,
+		Repo:         req.Repo,
+		Number:       ref.Number,
+		URL:          ref.URL,
+		State:        ref.State,
+	}})
+	writeJSON(w, pushIssueResp{URL: ref.URL, Number: ref.Number, Provider: string(conn.Provider)})
+}
+
+// ---------------------------------------------------------------------------
+// linked PRs + CI (read-only card panel)
+// ---------------------------------------------------------------------------
+
+func (s *Server) handleListIssuePulls(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	board, ok := s.activeTeamBoard(w, id)
+	if !ok {
+		return
+	}
+	card, ok := s.cardFromPath(w, r, board)
+	if !ok {
+		return
+	}
+	_, connID, repo, number := forgeLinkOf(card)
+	if repo == "" || connID == "" {
+		writeJSON(w, struct {
+			Pulls []forge.PullRef `json:"pulls"`
+		}{Pulls: []forge.PullRef{}})
+		return
+	}
+	pc, _, ok := s.pullClientForConn(w, r.Context(), id.TeamID, connID)
+	if !ok {
+		return
+	}
+	all, err := pc.ListPullRequests(r.Context(), repo, forge.PullListOptions{State: "all", PerPage: 100})
+	if err != nil {
+		httpError(w, http.StatusBadGateway, "list pull requests: %v", err)
+		return
+	}
+	// Keep only PRs that reference this card's forge issue number.
+	out := make([]forge.PullRef, 0, len(all))
+	for _, pr := range all {
+		if number > 0 && containsInt(pr.LinkedIssues, number) {
+			out = append(out, pr)
+		}
+	}
+	writeJSON(w, struct {
+		Pulls []forge.PullRef `json:"pulls"`
+	}{Pulls: out})
+}
+
+func (s *Server) handleIssuePullCI(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	board, ok := s.activeTeamBoard(w, id)
+	if !ok {
+		return
+	}
+	card, ok := s.cardFromPath(w, r, board)
+	if !ok {
+		return
+	}
+	_, connID, repo, _ := forgeLinkOf(card)
+	if repo == "" || connID == "" {
+		httpError(w, http.StatusBadRequest, "card is not linked to a forge")
+		return
+	}
+	number, err := strconv.Atoi(r.PathValue("number"))
+	if err != nil {
+		httpError(w, http.StatusBadRequest, "invalid pull number")
+		return
+	}
+	pc, _, ok := s.pullClientForConn(w, r.Context(), id.TeamID, connID)
+	if !ok {
+		return
+	}
+	pr, err := pc.GetPullRequest(r.Context(), repo, number)
+	if err != nil {
+		httpError(w, http.StatusBadGateway, "get pull request: %v", err)
+		return
+	}
+	ref := pr.HeadSHA
+	if ref == "" {
+		ref = pr.SourceBranch
+	}
+	status, err := pc.GetCIStatus(r.Context(), repo, ref)
+	if err != nil {
+		httpError(w, http.StatusBadGateway, "get ci status: %v", err)
+		return
+	}
+	history, _ := pc.ListCIHistory(r.Context(), repo, ref, 20)
+	writeJSON(w, struct {
+		Status  forge.CIStatus `json:"status"`
+		History []forge.CIRun  `json:"history"`
+	}{Status: status, History: history})
+}
+
+// ---------------------------------------------------------------------------
+// shared resolution helpers
+// ---------------------------------------------------------------------------
+
+// activeTeamBoard returns the caller's active-team board, 404 if none.
+func (s *Server) activeTeamBoard(w http.ResponseWriter, id auth.Identity) (native.BoardStore, bool) {
+	if s.cfg.CloudBoardFor == nil || id.TeamID == "" {
+		httpError(w, http.StatusNotFound, "board not available")
+		return nil, false
+	}
+	b := s.cfg.CloudBoardFor(id.TeamID)
+	if b == nil {
+		httpError(w, http.StatusNotFound, "board not available")
+		return nil, false
+	}
+	return b, true
+}
+
+func (s *Server) cardFromPath(w http.ResponseWriter, r *http.Request, board native.BoardStore) (*native.Issue, bool) {
+	cardID, err := board.Resolve(r.PathValue("id"))
+	if err != nil {
+		httpError(w, http.StatusNotFound, "card not found")
+		return nil, false
+	}
+	card, err := board.Get(cardID)
+	if err != nil {
+		httpError(w, http.StatusNotFound, "card not found")
+		return nil, false
+	}
+	return card, true
+}
+
+// issueClientForConn resolves a team connection to a forge.IssueClient.
+func (s *Server) issueClientForConn(w http.ResponseWriter, ctx context.Context, teamID, connID string) (forge.IssueClient, forge.Connection, bool) {
+	conn, err := s.forgeConnections.Get(ctx, connID)
+	if err != nil || conn.TenantID != teamID {
+		httpError(w, http.StatusNotFound, "connection not found")
+		return nil, forge.Connection{}, false
+	}
+	admin, err := s.forgeAdminFor(ctx, conn)
+	if err != nil {
+		httpError(w, http.StatusBadGateway, "admin client: %v", err)
+		return nil, forge.Connection{}, false
+	}
+	ic, ok := admin.(forge.IssueClient)
+	if !ok {
+		httpError(w, http.StatusNotImplemented, "provider %s has no issue client", conn.Provider)
+		return nil, forge.Connection{}, false
+	}
+	return ic, conn, true
+}
+
+func (s *Server) pullClientForConn(w http.ResponseWriter, ctx context.Context, teamID, connID string) (forge.PullClient, forge.Connection, bool) {
+	conn, err := s.forgeConnections.Get(ctx, connID)
+	if err != nil || conn.TenantID != teamID {
+		httpError(w, http.StatusNotFound, "connection not found")
+		return nil, forge.Connection{}, false
+	}
+	admin, err := s.forgeAdminFor(ctx, conn)
+	if err != nil {
+		httpError(w, http.StatusBadGateway, "admin client: %v", err)
+		return nil, forge.Connection{}, false
+	}
+	pc, ok := admin.(forge.PullClient)
+	if !ok {
+		httpError(w, http.StatusNotImplemented, "provider %s has no pull/CI client", conn.Provider)
+		return nil, forge.Connection{}, false
+	}
+	return pc, conn, true
+}
+
+// forgeLinkOf extracts a card's forge linkage from its typed External ref.
+func forgeLinkOf(card *native.Issue) (provider forge.Provider, connID, repo string, number int) {
+	if card == nil || card.External == nil {
+		return "", "", "", 0
+	}
+	e := card.External
+	return forge.Provider(e.Provider), e.ConnectionID, e.Repo, e.Number
+}
+
+func containsInt(xs []int, x int) bool {
+	for _, v := range xs {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}
+
+// decodeJSONOptional decodes an OPTIONAL request body into v, tolerating an
+// empty/absent body (returns nil) — used by push, where a forge-linked card
+// sends no body.
+func decodeJSONOptional(r *http.Request, v any) error {
+	if r.Body == nil {
+		return nil
+	}
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// periodic forge → board sync worker
+// ---------------------------------------------------------------------------
+
+// runBoardSyncWorker periodically sweeps every sync-enabled integration and
+// mirrors its forge issues onto the team board. Cloud-only; started from
+// server start alongside the forge/OAuth refresh workers. Best-effort: one
+// integration's failure is logged and the sweep continues.
+func (s *Server) runBoardSyncWorker(ctx context.Context, interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.syncAllEnabledIntegrations(ctx)
+		}
+	}
+}
+
+func (s *Server) syncAllEnabledIntegrations(ctx context.Context) {
+	ris, err := s.forgeIntegrations.ListSyncEnabled(ctx)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("board sync: list sync-enabled integrations: %v", err)
+		}
+		return
+	}
+	for _, ri := range ris {
+		c, u, err := s.syncOneIntegration(ctx, ri.TenantID, ri)
+		if err != nil && s.logger != nil {
+			s.logger.Warn("board sync: %s/%s: %v", ri.TenantID, ri.RepoFullName, err)
+		} else if (c > 0 || u > 0) && s.logger != nil {
+			s.logger.Info("board sync: %s %s → %d created, %d updated", ri.TenantID, ri.RepoFullName, c, u)
+		}
+	}
+}

--- a/pkg/server/board_forge_test.go
+++ b/pkg/server/board_forge_test.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// newTestBoard returns a fresh filesystem board store with the default layout
+// (inbox … done[terminal]).
+func newTestBoard(t *testing.T) *native.Store {
+	t.Helper()
+	st, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("native.NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func TestForgeCardID_Deterministic(t *testing.T) {
+	a := forgeCardID(forge.ProviderGitHub, "org/api", 12)
+	b := forgeCardID(forge.ProviderGitHub, "org/api", 12)
+	if a != b {
+		t.Fatalf("card id not deterministic: %q != %q", a, b)
+	}
+	if forgeCardID(forge.ProviderGitHub, "org/api", 13) == a {
+		t.Fatal("different issue numbers must yield different ids")
+	}
+	// Must be a valid native id (native:<uuid>) the store accepts on Create.
+	board := newTestBoard(t)
+	if _, err := board.Create(native.Issue{ID: a, Title: "x", State: "inbox"}); err != nil {
+		t.Fatalf("store rejected deterministic card id %q: %v", a, err)
+	}
+}
+
+func TestUpsertForgeCard_CreateUpdateIdempotent(t *testing.T) {
+	board := newTestBoard(t)
+	b := board.Board()
+	openCol := defaultOpenColumn(b) // "inbox"
+	doneCol := terminalColumn(b)    // "done"
+	if openCol == "" || doneCol == "" {
+		t.Fatalf("default board lacks open/terminal column: open=%q done=%q", openCol, doneCol)
+	}
+
+	is := forge.IssueRef{Number: 7, Title: "fix login", Body: "boom", State: "open", URL: "http://f/7", Labels: []string{"bug"}}
+	c, u, err := upsertForgeCard(board, b, openCol, doneCol, forge.ProviderGitHub, "conn1", "org/api", is)
+	if err != nil || c != 1 || u != 0 {
+		t.Fatalf("create: c=%d u=%d err=%v", c, u, err)
+	}
+	id := forgeCardID(forge.ProviderGitHub, "org/api", 7)
+	card, err := board.Get(id)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if card.State != openCol {
+		t.Errorf("open issue should land in %q, got %q", openCol, card.State)
+	}
+	if card.External == nil || card.External.Repo != "org/api" {
+		t.Fatalf("forge external ref not stamped: %+v", card.External)
+	}
+	if card.External.Number != 7 || card.External.ConnectionID != "conn1" {
+		t.Errorf("external ref wrong: %+v", card.External)
+	}
+
+	// Operator moves the card forward; a content re-sync must NOT yank it back.
+	if _, err := board.SetState(id, "in_progress"); err != nil {
+		t.Fatalf("setstate: %v", err)
+	}
+	is.Title = "fix login (v2)"
+	c, u, err = upsertForgeCard(board, b, openCol, doneCol, forge.ProviderGitHub, "conn1", "org/api", is)
+	if err != nil || c != 0 || u != 1 {
+		t.Fatalf("update: c=%d u=%d err=%v", c, u, err)
+	}
+	card, _ = board.Get(id)
+	if card.Title != "fix login (v2)" {
+		t.Errorf("title not updated: %q", card.Title)
+	}
+	if card.State != "in_progress" {
+		t.Errorf("re-sync clobbered operator column: %q", card.State)
+	}
+
+	// Forge closes the issue → still-open card moves to the terminal column.
+	is.State = "closed"
+	if _, _, err := upsertForgeCard(board, b, openCol, doneCol, forge.ProviderGitHub, "conn1", "org/api", is); err != nil {
+		t.Fatalf("close-sync: %v", err)
+	}
+	card, _ = board.Get(id)
+	if card.State != doneCol {
+		t.Errorf("closed forge issue should move card to %q, got %q", doneCol, card.State)
+	}
+
+	// Whole sweep must not have duplicated the card.
+	all, _ := board.List(native.ListFilter{})
+	if len(all) != 1 {
+		t.Errorf("expected exactly 1 card after idempotent upserts, got %d", len(all))
+	}
+}
+
+func TestUpsertForgeCard_ClosedCreatesInTerminal(t *testing.T) {
+	board := newTestBoard(t)
+	b := board.Board()
+	is := forge.IssueRef{Number: 9, Title: "old", State: "closed"}
+	if _, _, err := upsertForgeCard(board, b, defaultOpenColumn(b), terminalColumn(b), forge.ProviderForgejo, "c", "o/r", is); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	card, _ := board.Get(forgeCardID(forge.ProviderForgejo, "o/r", 9))
+	if card.State != terminalColumn(b) {
+		t.Errorf("closed issue should be created in terminal column, got %q", card.State)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1201,6 +1201,11 @@ func (s *Server) routes() {
 	// RegisterRoutesWithMiddleware variants preserve method-specific
 	// patterns so they don't conflict with the server's OPTIONS /api/
 	// catch-all.
+	if s.cfg.NativeTrackerStore == nil && s.cfg.CloudBoardFor != nil {
+		// Cloud mode: per-active-team board at the same /api/v1/native prefix
+		// the studio board client already uses (see board_cloud_routes.go).
+		s.registerCloudBoardRoutes()
+	}
 	if s.cfg.NativeTrackerStore != nil {
 		s.cfg.NativeTrackerStore.RegisterRoutesWithMiddleware(s.mux, "/api/v1/native", s.requireAuth)
 		// The Board MCP HTTP endpoint authenticates via its own

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -899,6 +899,20 @@ func (s *Server) ListenAndServe() error {
 			}
 		}()
 	}
+	// Forge → board issue sync (cloud only): periodically mirror every
+	// sync-enabled repo's forge issues onto its team board. Off unless a
+	// cloud board + the integration store are wired. See board_forge.go.
+	if s.cfg.CloudBoardFor != nil && s.forgeIntegrations != nil {
+		go func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go func() {
+				<-s.shutdown
+				cancel()
+			}()
+			s.runBoardSyncWorker(ctx, 5*time.Minute)
+		}()
+	}
 	// Orphan-run sweeper (cloud only): flips queued/running rows whose
 	// runner died without a terminal write to failed_resumable. Needs
 	// both the Mongo store (stale scan capability) and the queue (KV
@@ -1153,6 +1167,10 @@ func (s *Server) routes() {
 		if s.forgeOAuthApps != nil {
 			s.registerForgeOAuthAppRoutes()
 		}
+		// Cloud board ↔ forge: per-repo issue sync toggle + manual sync, and
+		// per-card push-to-forge + linked-PR/CI views (no-op without a cloud
+		// board). See board_forge.go.
+		s.registerBoardForgeRoutes()
 	}
 
 	// Per-tenant SSO providers (a tenant's own Keycloak + GitHub team-gating).

--- a/pkg/server/server_info.go
+++ b/pkg/server/server_info.go
@@ -99,7 +99,10 @@ func (s *Server) handleServerInfo(w http.ResponseWriter, r *http.Request) {
 				AllowedMIME:    s.cfg.AllowedUploadMIMEs,
 			},
 		},
-		NativeTrackerEnabled:     s.cfg.NativeTrackerStore != nil,
+		// True for the self-hosted filesystem board AND the cloud per-team
+		// Mongo board — both expose the same /api/v1/native surface, so the
+		// studio Board view is gated identically.
+		NativeTrackerEnabled:     s.cfg.NativeTrackerStore != nil || s.cfg.CloudBoardFor != nil,
 		DispatcherEnabled:        s.cfg.Dispatcher != nil,
 		EmailEnabled:             s.authSvc != nil && s.authSvc.EmailEnabled(),
 		MarketplaceEnabled:       s.marketplace != nil,

--- a/studio/src/api/forgeConnections.ts
+++ b/studio/src/api/forgeConnections.ts
@@ -45,7 +45,18 @@ export interface ForgeIntegration {
   hook_id: string;
   hook_url?: string;
   managed_secret_id?: string;
+  /** When true, the forge's issues are mirrored onto the team's native
+   *  board (one-way forge→board sync). Toggled per-integration from the
+   *  Integrations tab; absent on servers that predate the feature. */
+  sync_issues_enabled?: boolean;
   created_at: string;
+}
+
+/** Counts returned by a manual issue-sync run (POST …/sync). */
+export interface ForgeSyncResult {
+  synced: number;
+  created: number;
+  updated: number;
 }
 
 export interface ForgeEnablePreview {
@@ -196,6 +207,31 @@ export async function disableForgeIntegration(
   integrationID: string,
 ): Promise<void> {
   await request<void>(`/teams/${teamID}/forge/repo-bots/${integrationID}`, { method: "DELETE" });
+}
+
+// updateForgeIntegration patches a connected repo's integration — today
+// just the issue-sync toggle. Returns the refreshed ForgeIntegration so the
+// caller reflects the new `sync_issues_enabled` without a re-list.
+export async function updateForgeIntegration(
+  teamID: string,
+  integrationID: string,
+  patch: { sync_issues_enabled?: boolean },
+): Promise<ForgeIntegration> {
+  return request(`/teams/${teamID}/forge/integrations/${integrationID}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+}
+
+// syncForgeIntegration triggers a one-shot forge→board issue sync and
+// returns the counts (synced / created / updated) for the operator's toast.
+export async function syncForgeIntegration(
+  teamID: string,
+  integrationID: string,
+): Promise<ForgeSyncResult> {
+  return request(`/teams/${teamID}/forge/integrations/${integrationID}/sync`, {
+    method: "POST",
+  });
 }
 
 export async function listForgeOAuthApps(teamID: string): Promise<ForgeOAuthApp[]> {

--- a/studio/src/api/native.ts
+++ b/studio/src/api/native.ts
@@ -39,8 +39,24 @@ export interface NativeIssue {
    *  per-issue dispatcher workspace. Surfaced in the IssueModal as a
    *  copy/vscode link so operators can inspect the diff manually. */
   last_workdir?: string;
+  /** Typed forge linkage (mirrors Go's `external`). Present once a card is
+   *  pushed to / synced from a forge. This is the canonical source of truth
+   *  for the card's PR/CI panel + push semantics (replaces the legacy
+   *  fields["forge:*"] shape). */
+  external?: ExternalLink;
   created_at: string;
   updated_at: string;
+}
+
+// ExternalLink is a card's typed link to a forge issue/PR. `url` and `state`
+// are populated by the server once the linked issue exists.
+export interface ExternalLink {
+  provider: string;
+  connection_id: string;
+  repo: string;
+  number: number;
+  url?: string;
+  state?: string;
 }
 
 export interface NativeBoard {
@@ -106,6 +122,58 @@ export interface NativeIssuePatch {
 }
 
 // ---------------------------------------------------------------------------
+// Forge linkage — push a card to a forge, and read the forge's linked PRs +
+// CI status back. Cloud-mode only; mirror pkg/server's native forge routes.
+// ---------------------------------------------------------------------------
+
+// PushIssueBody is omitted for a card already linked to a forge (its
+// fields["forge:url"] is set — the server updates the linked issue). For an
+// UNLINKED card both connection_id and repo ("owner/repo") are required.
+export interface PushIssueBody {
+  connection_id?: string;
+  repo?: string;
+}
+
+export interface PushIssueResult {
+  url: string;
+  number: number;
+  provider: string;
+}
+
+// PullRef mirrors a forge pull/merge request linked to the issue.
+export interface PullRef {
+  number: number;
+  title: string;
+  state: string;
+  url: string;
+  source_branch: string;
+  target_branch: string;
+  head_sha: string;
+  draft: boolean;
+  author: string;
+  linked_issues: string[];
+}
+
+// CIRun is a single check/pipeline run on a PR's head commit.
+export interface CIRun {
+  name: string;
+  status: string;
+  conclusion: string;
+  url: string;
+  sha: string;
+  started_at: string;
+  finished_at: string;
+}
+
+// CIStatus is the aggregate CI state for a PR's head commit plus the current
+// runs; `history` (returned alongside it) carries recent prior runs.
+export interface CIStatus {
+  sha: string;
+  state: string;
+  runs: CIRun[];
+}
+
+// ---------------------------------------------------------------------------
 // REST surface
 // ---------------------------------------------------------------------------
 
@@ -148,6 +216,32 @@ export function transitionIssue(id: string, to: string): Promise<NativeIssue> {
     method: "POST",
     body: JSON.stringify({ to }),
   });
+}
+
+// pushIssueToForge mirrors a card to its forge. Omit `body` for a card
+// already linked to a forge (server updates the linked issue); pass
+// {connection_id, repo} to create-and-link an unlinked card.
+export function pushIssueToForge(id: string, body?: PushIssueBody): Promise<PushIssueResult> {
+  return request(`/issues/${encodeURIComponent(id)}/push`, {
+    method: "POST",
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+// listIssuePulls returns the forge pull/merge requests linked to a card.
+export function listIssuePulls(id: string): Promise<PullRef[]> {
+  return request<{ pulls: PullRef[] }>(`/issues/${encodeURIComponent(id)}/pulls`).then(
+    (r) => r.pulls ?? [],
+  );
+}
+
+// getIssuePullCI returns the aggregate CI status + recent run history for a
+// linked PR's head commit.
+export function getIssuePullCI(
+  id: string,
+  number: number,
+): Promise<{ status: CIStatus; history: CIRun[] }> {
+  return request(`/issues/${encodeURIComponent(id)}/pulls/${number}/ci`);
 }
 
 export function getBoard(): Promise<NativeBoard> {

--- a/studio/src/views/Board/BoardFilters.tsx
+++ b/studio/src/views/Board/BoardFilters.tsx
@@ -6,6 +6,7 @@ import { Select } from "@/components/ui/Select";
 
 import {
   BASE_GROUP_OPTIONS,
+  GROUP_MODE_REPO,
   groupModeForField,
   SORT_OPTIONS,
   type GroupMode,
@@ -29,6 +30,7 @@ export function BoardFilters({
   groupMode,
   onGroupChange,
   fieldNames,
+  hasRepoLinks,
   onReset,
 }: {
   searchQuery: string;
@@ -47,6 +49,9 @@ export function BoardFilters({
   groupMode: GroupMode;
   onGroupChange: (m: GroupMode) => void;
   fieldNames: string[];
+  // hasRepoLinks: true when at least one card is forge-linked, so the
+  // "Repository" swimlane grouping is worth offering.
+  hasRepoLinks: boolean;
   onReset: () => void;
 }) {
   const filtersActive =
@@ -114,6 +119,9 @@ export function BoardFilters({
               {o.label}
             </option>
           ))}
+          {hasRepoLinks && (
+            <option value={GROUP_MODE_REPO}>Repository</option>
+          )}
           {fieldNames.map((n) => (
             <option key={groupModeForField(n)} value={groupModeForField(n)}>
               Field: {n}

--- a/studio/src/views/Board/Column.tsx
+++ b/studio/src/views/Board/Column.tsx
@@ -1,14 +1,27 @@
-import { useState } from "react";
-import { GripVertical, MoreVertical } from "lucide-react";
+import { useEffect, useState } from "react";
+import { ArrowUpFromLine, GitBranch, GripVertical, MoreVertical } from "lucide-react";
 
+import { Button } from "@/components/ui/Button";
 import { Checkbox } from "@/components/ui/Checkbox";
+import { Dialog } from "@/components/ui/Dialog";
 import { IconButton } from "@/components/ui/IconButton";
+import { InlineBanner } from "@/components/ui/InlineBanner";
+import { Input } from "@/components/ui/Input";
 import { Popover, PopoverClose } from "@/components/ui/Popover";
+import { Select } from "@/components/ui/Select";
 import { formatRelative } from "@/lib/format";
 import { clickableRowProps } from "@/lib/a11y";
 import { softColor } from "@/lib/constants";
+import { useAuth } from "@/auth/AuthContext";
+import { useAsyncAction } from "@/hooks/useAsyncAction";
+import { useServerInfoStore } from "@/store/serverInfo";
+import { useUIStore } from "@/store/ui";
+import {
+  listForgeConnections,
+  type ForgeConnection,
+} from "@/api/forgeConnections";
 import type { DispatchSkipView, RetryView, RunningView } from "@/api/dispatcher";
-import type { NativeIssue } from "@/api/native";
+import { pushIssueToForge, type NativeIssue } from "@/api/native";
 
 import { DRAG_MIME_ISSUE_IDS, DRAG_MIME_STATE } from "./boardShared";
 
@@ -483,11 +496,23 @@ function IssueCard({
             </button>
           );
         })()}
+        {iss.external?.repo && (
+          <span
+            className="inline-flex items-center gap-0.5 rounded bg-surface-2 px-1 py-0.5 text-fg-subtle max-w-40 truncate"
+            title={`${iss.external.provider} · ${iss.external.repo}${
+              iss.external.number ? ` #${iss.external.number}` : ""
+            }`}
+          >
+            <GitBranch className="h-3 w-3 shrink-0 opacity-70" aria-hidden="true" />
+            <span className="truncate">{iss.external.repo}</span>
+          </span>
+        )}
         {iss.updated_at && (
           <span className="text-fg-subtle" title={iss.updated_at}>
             · updated {formatRelative(iss.updated_at)}
           </span>
         )}
+        <PushToForgeButton iss={iss} />
       </div>
       {running && (
         <div className="mt-1 flex items-center justify-between gap-2 rounded bg-success-soft px-1.5 py-1 text-caption text-success-fg">
@@ -563,6 +588,175 @@ function IssueCard({
         </button>
       )}
     </div>
+  );
+}
+
+// PushToForgeButton renders a discreet "push this card to a forge" affordance
+// in the card footer. Cloud-mode only (self-hosted boards have no forge
+// connection concept, so the button would only clutter). A card already
+// linked to a forge (external.url set) pushes directly (the server updates the
+// linked issue); an unlinked card opens a small dialog to pick a forge
+// connection + type an "owner/repo" target before creating-and-linking.
+function PushToForgeButton({ iss }: { iss: NativeIssue }) {
+  const mode = useServerInfoStore((s) => s.info?.mode);
+  const { activeTeamID } = useAuth();
+  const addToast = useUIStore((s) => s.addToast);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const pushAction = useAsyncAction();
+
+  if (mode !== "cloud") return null;
+
+  const linkedURL = iss.external?.url ?? "";
+
+  const onSuccess = (url: string) => {
+    addToast("Pushed to forge", "success", {
+      action: { label: "Open", onClick: () => window.open(url, "_blank", "noopener") },
+    });
+  };
+
+  const onDirectPush = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (linkedURL) {
+      const res = await pushAction.run(() => pushIssueToForge(iss.id));
+      if (res) onSuccess(res.url);
+      else if (pushAction.error) addToast(pushAction.error, "error");
+    } else {
+      setDialogOpen(true);
+    }
+  };
+
+  return (
+    <>
+      <IconButton
+        size="sm"
+        variant="ghost"
+        label="Push to forge"
+        tooltip="Push to forge"
+        className="ml-auto h-5 w-5"
+        disabled={pushAction.busy}
+        onClick={(e) => void onDirectPush(e)}
+      >
+        <ArrowUpFromLine className="h-3.5 w-3.5" aria-hidden="true" />
+      </IconButton>
+      {dialogOpen && (
+        <PushToForgeDialog
+          teamID={activeTeamID}
+          onClose={() => setDialogOpen(false)}
+          onPush={async (connectionId, repo) => {
+            const res = await pushAction.run(() =>
+              pushIssueToForge(iss.id, { connection_id: connectionId, repo }),
+            );
+            if (res) {
+              setDialogOpen(false);
+              onSuccess(res.url);
+            } else if (pushAction.error) {
+              throw new Error(pushAction.error);
+            }
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+// PushToForgeDialog collects the forge connection + "owner/repo" target for an
+// UNLINKED card, then delegates the push to the parent.
+function PushToForgeDialog({
+  teamID,
+  onClose,
+  onPush,
+}: {
+  teamID: string;
+  onClose: () => void;
+  onPush: (connectionId: string, repo: string) => Promise<void>;
+}) {
+  const [connections, setConnections] = useState<ForgeConnection[] | null>(null);
+  const [connectionId, setConnectionId] = useState("");
+  const [repo, setRepo] = useState("");
+  const loadAction = useAsyncAction();
+  const submitAction = useAsyncAction();
+
+  useEffect(() => {
+    void loadAction.run(async () => {
+      const conns = await listForgeConnections(teamID);
+      setConnections(conns);
+      const first = conns[0];
+      if (first) setConnectionId((cur) => cur || first.id);
+    });
+    // teamID is stable for the dialog's lifetime; load once on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const submit = async () => {
+    await submitAction.run(() => onPush(connectionId, repo.trim()));
+  };
+
+  const canSubmit = !!connectionId && repo.trim().length > 0 && !submitAction.busy;
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(o) => {
+        if (!o) onClose();
+      }}
+      title="Push to forge"
+      description="This card isn't linked to a forge yet. Pick a connection and a repository to create and link the issue."
+      footer={
+        <>
+          <Button variant="secondary" size="sm" onClick={onClose} disabled={submitAction.busy}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={() => void submit()}
+            loading={submitAction.busy}
+            disabled={!canSubmit}
+          >
+            Push
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-3" onClick={(e) => e.stopPropagation()}>
+        {(loadAction.error || submitAction.error) && (
+          <InlineBanner tone="danger" layout="inline">
+            {submitAction.error ?? loadAction.error}
+          </InlineBanner>
+        )}
+        <label className="block">
+          <span className="text-xs text-fg-muted mb-1 block">Forge connection</span>
+          {loadAction.busy ? (
+            <p className="text-xs text-fg-subtle italic">Loading connections…</p>
+          ) : connections && connections.length === 0 ? (
+            <p className="text-xs text-fg-subtle">
+              No forge connections. Connect one from the team Integrations tab first.
+            </p>
+          ) : (
+            <Select
+              value={connectionId}
+              onChange={(e) => setConnectionId(e.target.value)}
+              size="md"
+            >
+              {(connections ?? []).map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.provider} · @{c.account_login ?? c.id}
+                </option>
+              ))}
+            </Select>
+          )}
+        </label>
+        <label className="block">
+          <span className="text-xs text-fg-muted mb-1 block">Repository (owner/repo)</span>
+          <Input
+            value={repo}
+            onChange={(e) => setRepo(e.target.value)}
+            placeholder="owner/repo"
+            size="md"
+          />
+        </label>
+      </div>
+    </Dialog>
   );
 }
 

--- a/studio/src/views/Board/IssueModal.tsx
+++ b/studio/src/views/Board/IssueModal.tsx
@@ -2,8 +2,16 @@ import { useEffect, useMemo, useState } from "react";
 import { Link } from "wouter";
 
 import { type BotEntryWithSchema } from "@/api/bots";
-import type { NativeBoard, NativeIssue } from "@/api/native";
+import {
+  getIssuePullCI,
+  listIssuePulls,
+  type CIRun,
+  type NativeBoard,
+  type NativeIssue,
+  type PullRef,
+} from "@/api/native";
 import BranchDiffModal from "@/components/Runs/BranchDiffModal";
+import { Badge, type BadgeVariant } from "@/components/ui/Badge";
 import { Button } from "@/components/ui/Button";
 import { Checkbox } from "@/components/ui/Checkbox";
 import { Combobox } from "@/components/ui/Combobox";
@@ -19,6 +27,7 @@ import VarFieldInput, { defaultStringFor } from "@/components/shared/VarFieldInp
 import { useAsyncAction } from "@/hooks/useAsyncAction";
 import { isVarMissing, RequiredPill } from "@/lib/varValidation";
 import { useBotsStore } from "@/store/bots";
+import { useServerInfoStore } from "@/store/serverInfo";
 
 import { BotArgsForm } from "./BotArgsForm";
 import { BotPicker } from "./BotPicker";
@@ -371,6 +380,8 @@ function TicketTab({
         />
       )}
 
+      {initial && <PullRequestsSection issue={initial} />}
+
       {(board.fields ?? []).map((f) => (
         <Field key={f.name} label={(f.display ?? f.name) + ` (${f.type})`}>
           {f.type === "enum" ? (
@@ -575,6 +586,202 @@ function LastRunSection({
       )}
     </div>
   );
+}
+
+// PullRequestsSection lists the forge pull/merge requests linked to a card,
+// each with a compact CI status indicator and an expandable run list. Read-
+// only. Cloud-mode only, and rendered only when the card is forge-linked
+// (external.repo present) — so a plain native card shows nothing.
+function PullRequestsSection({ issue }: { issue: NativeIssue }) {
+  const mode = useServerInfoStore((s) => s.info?.mode);
+  const [pulls, setPulls] = useState<PullRef[] | null>(null);
+  const loadAction = useAsyncAction();
+
+  const forgeLinked = !!issue.external?.repo;
+  const eligible = mode === "cloud" && forgeLinked;
+
+  useEffect(() => {
+    if (!eligible) {
+      setPulls(null);
+      return;
+    }
+    void loadAction.run(async () => {
+      setPulls(await listIssuePulls(issue.id));
+    });
+    // Re-fetch only when the target issue changes; loadAction is stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [issue.id, eligible]);
+
+  // Hide entirely for cards that are neither forge-linked nor have PRs.
+  if (!eligible) return null;
+  if (!loadAction.busy && (pulls?.length ?? 0) === 0 && !loadAction.error) return null;
+
+  return (
+    <div className="rounded border border-border-default bg-surface-1 p-2 space-y-2">
+      <div className="text-micro uppercase tracking-wide text-fg-subtle">Pull requests</div>
+      {loadAction.busy && (
+        <p className="text-xs text-fg-subtle italic">Loading pull requests…</p>
+      )}
+      {loadAction.error && (
+        <InlineBanner tone="danger" layout="inline">
+          {loadAction.error}
+        </InlineBanner>
+      )}
+      {(pulls ?? []).map((pr) => (
+        <PullRow key={pr.number} issueID={issue.id} pr={pr} />
+      ))}
+    </div>
+  );
+}
+
+// PullRow renders one PR with its CI dot and an expandable run list (current
+// runs + recent history, lazily fetched on first expand).
+function PullRow({ issueID, pr }: { issueID: string; pr: PullRef }) {
+  const [expanded, setExpanded] = useState(false);
+  const [runs, setRuns] = useState<CIRun[] | null>(null);
+  const [ciState, setCIState] = useState<string>("");
+  const ciAction = useAsyncAction();
+
+  const loadCI = async () => {
+    await ciAction.run(async () => {
+      const { status, history } = await getIssuePullCI(issueID, pr.number);
+      setCIState(status.state);
+      // Current runs first, then recent history; de-dupe is the server's job.
+      setRuns([...(status.runs ?? []), ...(history ?? [])]);
+    });
+  };
+
+  const toggle = () => {
+    const next = !expanded;
+    setExpanded(next);
+    if (next && runs === null && !ciAction.busy) void loadCI();
+  };
+
+  return (
+    <div className="border-t border-border-subtle pt-1.5 first:border-t-0 first:pt-0">
+      <div className="flex items-center gap-2 text-xs">
+        <CIDot state={ciState} />
+        <a
+          href={pr.url}
+          target="_blank"
+          rel="noreferrer"
+          className="font-medium text-accent-text hover:underline truncate"
+          title={pr.title}
+        >
+          #{pr.number} {pr.title}
+        </a>
+        <Badge variant={prStateVariant(pr.state)} size="sm">
+          {pr.draft ? "draft" : pr.state}
+        </Badge>
+      </div>
+      <div className="mt-0.5 flex items-center gap-2 text-micro text-fg-subtle">
+        <span className="font-mono truncate">
+          {pr.source_branch} → {pr.target_branch}
+        </span>
+        <button
+          type="button"
+          onClick={toggle}
+          className="ml-auto text-accent-text hover:underline"
+        >
+          {expanded ? "Hide CI" : "CI"}
+        </button>
+      </div>
+      {expanded && (
+        <div className="mt-1 space-y-1">
+          {ciAction.busy && (
+            <p className="text-micro text-fg-subtle italic">Loading CI runs…</p>
+          )}
+          {ciAction.error && (
+            <InlineBanner tone="danger" layout="inline">
+              {ciAction.error}
+            </InlineBanner>
+          )}
+          {runs && runs.length === 0 && !ciAction.busy && (
+            <p className="text-micro text-fg-subtle">No CI runs reported.</p>
+          )}
+          {(runs ?? []).map((run, i) => (
+            <div key={`${run.name}-${run.sha}-${i}`} className="flex items-center gap-2 text-micro">
+              <Badge variant={ciRunVariant(run)} size="sm">
+                {run.conclusion || run.status}
+              </Badge>
+              {run.url ? (
+                <a
+                  href={run.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-accent-text hover:underline truncate"
+                >
+                  {run.name}
+                </a>
+              ) : (
+                <span className="text-fg-default truncate">{run.name}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// CIDot renders the aggregate CI state as a coloured dot:
+// success=green, failed=red, running/pending=amber, unknown=grey.
+function CIDot({ state }: { state: string }) {
+  const tone = ciTone(state);
+  const cls: Record<typeof tone, string> = {
+    success: "bg-success",
+    danger: "bg-danger",
+    warning: "bg-warning",
+    neutral: "bg-fg-subtle",
+  };
+  return (
+    <span
+      className={`inline-block h-2 w-2 rounded-full shrink-0 ${cls[tone]}`}
+      title={state ? `CI: ${state}` : "CI status unknown"}
+      aria-label={state ? `CI ${state}` : "CI status unknown"}
+    />
+  );
+}
+
+type CITone = "success" | "danger" | "warning" | "neutral";
+
+// ciTone maps a forge CI aggregate state to a semantic tone. Covers the
+// common GitHub/GitLab/Forgejo vocabularies (success/passed, failure/error,
+// running/pending/in_progress).
+function ciTone(state: string): CITone {
+  const s = state.toLowerCase();
+  if (["success", "passed", "completed", "ok"].includes(s)) return "success";
+  if (["failure", "failed", "error", "cancelled", "canceled"].includes(s)) return "danger";
+  if (["running", "pending", "in_progress", "queued", "waiting"].includes(s)) return "warning";
+  return "neutral";
+}
+
+function ciToneToBadge(tone: CITone): BadgeVariant {
+  switch (tone) {
+    case "success":
+      return "success";
+    case "danger":
+      return "danger";
+    case "warning":
+      return "warning";
+    default:
+      return "neutral";
+  }
+}
+
+// ciRunVariant prefers the run's conclusion (terminal) over its status
+// (lifecycle) when colouring the per-run badge.
+function ciRunVariant(run: CIRun): BadgeVariant {
+  return ciToneToBadge(ciTone(run.conclusion || run.status));
+}
+
+// prStateVariant maps a PR state to a badge variant (open=success,
+// merged=accent, closed=neutral).
+function prStateVariant(state: string): BadgeVariant {
+  const s = state.toLowerCase();
+  if (s === "merged") return "accent";
+  if (s === "open" || s === "opened") return "success";
+  return "neutral";
 }
 
 // coerceFields converts the modal's string-keyed state map into the

--- a/studio/src/views/Board/board/useSwimlanes.ts
+++ b/studio/src/views/Board/board/useSwimlanes.ts
@@ -4,6 +4,7 @@ import type { NativeBoard, NativeIssue } from "@/api/native";
 
 import {
   fieldNameFromGroupMode,
+  GROUP_MODE_REPO,
   LANE_NONE,
   type GroupMode,
   type SortMode,
@@ -35,6 +36,9 @@ function laneKeysFor(iss: NativeIssue, groupMode: GroupMode): string[] {
     const labels = iss.labels ?? [];
     return labels.length > 0 ? labels : [LANE_NONE];
   }
+  if (groupMode === GROUP_MODE_REPO) {
+    return [iss.external?.repo || LANE_NONE];
+  }
   const fieldName = fieldNameFromGroupMode(groupMode);
   if (fieldName) {
     const v = iss.fields?.[fieldName];
@@ -49,6 +53,7 @@ function laneLabel(key: string, groupMode: GroupMode): string {
   if (key === LANE_NONE) {
     if (groupMode === "assignee") return "Unassigned";
     if (groupMode === "label") return "No label";
+    if (groupMode === GROUP_MODE_REPO) return "No repository";
     return "—";
   }
   if (groupMode === "assignee") return `@${key}`;

--- a/studio/src/views/Board/boardShared.ts
+++ b/studio/src/views/Board/boardShared.ts
@@ -50,6 +50,11 @@ export const BASE_GROUP_OPTIONS: { value: GroupMode; label: string }[] = [
 // (no assignee, no labels, empty field). Always sorted last.
 export const LANE_NONE = "__none__";
 
+// GROUP_MODE_REPO groups the board into one swimlane per forge repository
+// (issue.external.repo). Offered only when at least one card is forge-linked;
+// unlinked cards fall into the LANE_NONE ("—") lane.
+export const GROUP_MODE_REPO = "repo";
+
 // A GroupMode of `field:<name>` groups by a custom field. The prefix
 // encoding lives here so the producer (BoardFilters' option list) and the
 // consumer (useSwimlanes' decode) share one source of truth.

--- a/studio/src/views/Board/index.tsx
+++ b/studio/src/views/Board/index.tsx
@@ -324,6 +324,12 @@ export default function BoardView() {
     () => issues.filter((i) => selectedIds.has(i.id)),
     [issues, selectedIds],
   );
+  // Offer the "Repository" swimlane grouping only when some card is
+  // forge-linked (carries external.repo).
+  const hasRepoLinks = useMemo(
+    () => issues.some((i) => !!i.external?.repo),
+    [issues],
+  );
   const allSelectedDispatchable =
     selectedIssues.length > 0 && selectedIssues.every((i) => isDispatchable(i.state));
 
@@ -575,6 +581,7 @@ export default function BoardView() {
         groupMode={groupMode}
         onGroupChange={setGroupMode}
         fieldNames={(board.fields ?? []).map((f) => f.name)}
+        hasRepoLinks={hasRepoLinks}
         onReset={() => {
           setSearchQuery("");
           clearLabelFilter();

--- a/studio/src/views/CloudLanding.tsx
+++ b/studio/src/views/CloudLanding.tsx
@@ -142,7 +142,7 @@ function BotShowcase() {
             <div className="flex items-baseline gap-2">
               <span className="truncate font-semibold text-fg-default">{b.name}</span>
               {typeof b.installs === "number" && b.installs > 0 && (
-                <span className="shrink-0 font-mono text-[10px] text-fg-subtle">
+                <span className="shrink-0 font-mono text-micro text-fg-subtle">
                   {b.installs}↓
                 </span>
               )}

--- a/studio/src/views/Marketplace/MarketplaceSubmit.tsx
+++ b/studio/src/views/Marketplace/MarketplaceSubmit.tsx
@@ -4,6 +4,7 @@ import { uploadBotBundle } from "@/api/bots";
 import type { MarketplaceScope } from "@/api/marketplace";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
 import { useUIStore } from "@/store/ui";
 import { toastError } from "@/lib/errorHints";
 
@@ -194,18 +195,17 @@ export function MarketplaceSubmit({
               >
                 Visibility
               </label>
-              <select
+              <Select
                 id={scopeId}
                 value={scope ?? ""}
                 onChange={(e) => setScope(e.target.value as MarketplaceScope)}
-                className="rounded border border-border-default bg-surface-1 px-2 py-1.5 text-xs text-fg-default focus:outline-none focus-visible:ring-1 focus-visible:ring-accent"
               >
                 {scopes?.map((sc) => (
                   <option key={sc} value={sc}>
                     {SCOPE_LABELS[sc] ?? sc}
                   </option>
                 ))}
-              </select>
+              </Select>
             </div>
           )}
           <div className="flex items-center justify-between gap-3">

--- a/studio/src/views/teams/tabs/integrations/ConnectionCard.tsx
+++ b/studio/src/views/teams/tabs/integrations/ConnectionCard.tsx
@@ -5,11 +5,16 @@ import type { BotEntryWithSchema } from "@/api/bots";
 import {
   type ForgeConnection,
   type ForgeIntegration,
+  type ForgeSyncResult,
   deleteForgeConnection,
   disableForgeIntegration,
+  syncForgeIntegration,
+  updateForgeIntegration,
 } from "@/api/forgeConnections";
 import { Button } from "@/components/ui/Button";
+import { Checkbox } from "@/components/ui/Checkbox";
 import { InlineBanner } from "@/components/ui/InlineBanner";
+import { useAsyncAction } from "@/hooks/useAsyncAction";
 
 import { type ConfirmFn, statusTone } from "./forgeShared";
 import { EnableRepoPanel } from "./EnableRepoPanel";
@@ -103,24 +108,15 @@ export function ConnectionCard({
         ) : (
           <ul className="space-y-1">
             {integrations.map((i) => (
-              <li
+              <RepoRow
                 key={i.id}
-                className="flex items-center justify-between gap-2 text-sm border-t border-border-subtle pt-1"
-              >
-                <span>
-                  <span className="font-mono">{i.repo_full_name}</span>{" "}
-                  <span className="text-fg-muted">· {i.bot_ids.join(", ")}</span>
-                </span>
-                {canManage && (
-                  <Button
-                    variant="danger"
-                    size="sm"
-                    onClick={() => disable(i)}
-                  >
-                    Disable
-                  </Button>
-                )}
-              </li>
+                teamID={teamID}
+                integration={i}
+                canManage={canManage}
+                onChanged={onChanged}
+                onDisable={() => disable(i)}
+                onError={onError}
+              />
             ))}
           </ul>
         )}
@@ -150,5 +146,97 @@ export function ConnectionCard({
           </Button>
         ))}
     </section>
+  );
+}
+
+// RepoRow renders one enabled repo with its issue-sync toggle ("Sync issues
+// to board", forge→board mirroring) and a "Sync now" ghost button that fires
+// a one-shot sync and surfaces the returned counts inline. Local optimistic
+// state on the toggle keeps the checkbox responsive across the PATCH.
+function RepoRow({
+  teamID,
+  integration,
+  canManage,
+  onChanged,
+  onDisable,
+  onError,
+}: {
+  teamID: string;
+  integration: ForgeIntegration;
+  canManage: boolean;
+  onChanged: () => void;
+  onDisable: () => void;
+  onError: (m: string) => void;
+}) {
+  const [syncEnabled, setSyncEnabled] = useState(!!integration.sync_issues_enabled);
+  const [lastSync, setLastSync] = useState<ForgeSyncResult | null>(null);
+  const toggleAction = useAsyncAction();
+  const syncAction = useAsyncAction();
+
+  const onToggle = async (next: boolean) => {
+    // Optimistic: flip immediately, revert on error so the checkbox never
+    // strands in a state the server didn't accept.
+    setSyncEnabled(next);
+    const updated = await toggleAction.run(() =>
+      updateForgeIntegration(teamID, integration.id, { sync_issues_enabled: next }),
+    );
+    if (updated) {
+      setSyncEnabled(!!updated.sync_issues_enabled);
+      onChanged();
+    } else {
+      setSyncEnabled(!next);
+      onError(toggleAction.error ?? "Failed to update sync setting");
+    }
+  };
+
+  const onSyncNow = async () => {
+    const res = await syncAction.run(() => syncForgeIntegration(teamID, integration.id));
+    if (res) {
+      setLastSync(res);
+    } else if (syncAction.error) {
+      onError(syncAction.error);
+    }
+  };
+
+  return (
+    <li className="border-t border-border-subtle pt-1 space-y-1">
+      <div className="flex items-center justify-between gap-2 text-sm">
+        <span>
+          <span className="font-mono">{integration.repo_full_name}</span>{" "}
+          <span className="text-fg-muted">· {integration.bot_ids.join(", ")}</span>
+        </span>
+        {canManage && (
+          <Button variant="danger" size="sm" onClick={onDisable}>
+            Disable
+          </Button>
+        )}
+      </div>
+      {canManage && (
+        <div className="flex items-center justify-between gap-2">
+          <Checkbox
+            label="Sync issues to board"
+            checked={syncEnabled}
+            disabled={toggleAction.busy}
+            onChange={(e) => void onToggle(e.target.checked)}
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => void onSyncNow()}
+            loading={syncAction.busy}
+            disabled={syncAction.busy}
+            title="Pull the forge's issues onto the board now"
+          >
+            Sync now
+          </Button>
+        </div>
+      )}
+      {lastSync && (
+        <InlineBanner tone="success" layout="inline">
+          Synced {lastSync.synced} issue{lastSync.synced === 1 ? "" : "s"} ·{" "}
+          {lastSync.created} created · {lastSync.updated} updated
+        </InlineBanner>
+      )}
+    </li>
   );
 }


### PR DESCRIPTION
Big-lot epic: bring the kanban **board to cloud mode**, **sync forge issues onto it** (one-way), let each card **push back to the forge**, and surface **linked PRs + CI status** — across GitHub, GitLab and Forgejo. Design locked with the operator: **one board per team, repos as swimlanes**.

## What's in here (4 commits, reviewable in order)

1. **`feat(forge)` — issue/PR/CI client capabilities (3 providers).** New optional, type-asserted interfaces (`forge.IssueClient`, `forge.PullClient`) mirroring the `OAuthAppProvisioner` pattern, implemented on each provider's `*AdminClient` over the existing `DoJSON`/`StatusErr` transport, with httptest unit tests. Handles GitHub PR-in-issues filtering + check-runs∪commit-status, GitLab `iid`/`opened↔open`/project-path encoding + pipelines, Forgejo `token ` auth + combined commit statuses.

2. **`feat(board)` — serve the board in cloud mode.** Refactors the native board HTTP handlers onto a per-request `BoardAPI{Resolve}` so the **same** handlers serve the self-hosted single store (constant resolver — behaviour unchanged, existing tests pass) and the cloud **per-active-team** Mongo board (`id.TeamID → CloudBoardFor`), at the same `/api/v1/native` prefix the studio already calls. `native_tracker_enabled` now true in cloud. Board-config editing splits into an optional `BoardAdmin` capability → cloud returns a clean **501** for column/field editing (viewing + card CRUD + move + comment all work) until boardmongo gains the mutations.

3. **`feat(board)` — forge↔board sync + push + PR/CI.**
   - **forge→board sync (one-way):** per-repo `Sync issues to board` toggle (`RepoIntegration.SyncIssuesEnabled`) + a 5-min sweep worker + manual `POST …/forge/integrations/{iid}/sync`. Idempotent (deterministic UUIDv5 card IDs), **operator's column is preserved** on re-sync, a forge-close pulls the card to the terminal column, PRs are skipped. Repo = swimlane key.
   - **push-to-forge:** `POST /api/v1/native/issues/{id}/push` creates/updates a forge issue from a card.
   - **linked PRs + CI:** `GET …/issues/{id}/pulls` and `…/pulls/{number}/ci` (current `CIStatus` + history).
   - Forge linkage is a typed `native.ExternalRef` on the card (threaded through `Patch` + both stores' `Update` + `cloneIssue`), **not** Fields (which are validated against board defs). Unit-tested mapping.

4. **`feat(studio)` — the board forge UI.** Sync toggle + "Sync now"; a discreet push-to-forge card button + dialog; a linked-PR + CI-status panel on the card modal; a "Repository" group-by mode (repo swimlanes) + a repo chip. Reads the typed `external` ref. Also greens two pre-existing source-discipline gate failures.

## Tests
- Go: full `pkg/server` suite + boardmongo conformance + the 3 forge providers + the new `board_forge` mapping tests — **all green**, `go vet` clean.
- Studio: `tsc` + `lint` (0 errors) + `build` + the **493**-test vitest suite (incl. source-discipline) — **all green**.

## Not in scope (follow-ups)
- Cloud board **config editing** (columns/fields) → implement `BoardAdmin` on boardmongo (currently 501).
- Live e2e against a real GitHub org / 2 GitLab / Forgejo — to run on preprod after merge.
- The `vv0.23.x` double-`v` version cosmetic in `server_info`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)