### PR TITLE
fix(runtime): execute subbot nodes inside fan_out_each branches

### DIFF
--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -1646,27 +1646,18 @@ func (e *Engine) snapshotAtNodeBoundary(rs *runState, nodeID string) {
 // stores the result as the node's output. It mirrors the standard execution
 // envelope (node_started → output → node_finished → checkpoint → edge select)
 // without invoking the executor backend.
-// execSubbot runs a SubbotNode: it resolves the `with:` mappings into the
-// child's input vars, acquires any `needs:` resource leases (passing the
-// leased instance id to the child as `_lease_<resource>`), invokes the
-// host-supplied SubbotRunner, and maps the child's terminal output to
-// outputs.<subbot>.<field>. The child is a full nested run, so it may contain
-// loops (unlike a fan-out branch).
-func (e *Engine) execSubbot(ctx context.Context, rs *runState, nodeID string, sn *ir.SubbotNode) (string, error) {
-	startedPayload := map[string]interface{}{
-		"kind":      "subbot",
-		"iteration": e.currentLoopIteration(nodeID, rs.loopCounters),
-		"source":    sn.Source,
-	}
-	if p := e.currentLoopIterationPath(nodeID, rs.loopCounters); p != "" {
-		startedPayload["iteration_path"] = p
-	}
-	if err := e.emit(rs.ctx, rs.runID, store.EventNodeStarted, nodeID, startedPayload); err != nil {
-		return "", err
-	}
-
+// runSubbotChild resolves the subbot's `with:` mappings against the given scope,
+// acquires any `needs:` resource leases (surfacing each leased instance id to the
+// child as `_lease_<resource>`), and invokes the host-supplied SubbotRunner,
+// returning the child run's terminal output. It is the executor-agnostic core
+// shared by the main-graph path (execSubbot, scope = rs.scope()) and the fan-out
+// branch path (executeNodeForBranch, scope = the branch's merged-output scope) —
+// only the scope used to resolve `with:` differs, so a per-element subbot reads
+// {{outputs.<router>.<as>.<field>}}. It does NOT emit events, record outputs, or
+// advance edges; each caller does that in its own idiom.
+func (e *Engine) runSubbotChild(ctx context.Context, rs *runState, nodeID string, sn *ir.SubbotNode, sc resolveScope) (map[string]interface{}, error) {
 	if e.subbotRunner == nil {
-		return "", &RuntimeError{
+		return nil, &RuntimeError{
 			Code:    ErrCodeExecutionFailed,
 			Message: fmt.Sprintf("subbot %q: no SubbotRunner is wired", nodeID),
 			NodeID:  nodeID,
@@ -1675,7 +1666,6 @@ func (e *Engine) execSubbot(ctx context.Context, rs *runState, nodeID string, sn
 	}
 
 	// Resolve the child's input vars from the `with:` mappings.
-	sc := rs.scope()
 	vars := make(map[string]interface{}, len(sn.With))
 	for _, dm := range sn.With {
 		vars[dm.Key] = e.resolveMapping(dm, sc)
@@ -1685,7 +1675,7 @@ func (e *Engine) execSubbot(ctx context.Context, rs *runState, nodeID string, sn
 	// leased instance id so the child can pick e.g. its worktree index.
 	release, leases, lerr := e.acquireResources(ctx, rs, sn.Needs)
 	if lerr != nil {
-		return "", lerr
+		return nil, lerr
 	}
 	defer release()
 	for res, id := range leases {
@@ -1699,7 +1689,7 @@ func (e *Engine) execSubbot(ctx context.Context, rs *runState, nodeID string, sn
 		NodeID:      nodeID,
 	})
 	if err != nil {
-		return "", &RuntimeError{
+		return nil, &RuntimeError{
 			Code:    ErrCodeExecutionFailed,
 			Message: fmt.Sprintf("subbot %q (source %q): %v", nodeID, sn.Source, err),
 			NodeID:  nodeID,
@@ -1708,6 +1698,30 @@ func (e *Engine) execSubbot(ctx context.Context, rs *runState, nodeID string, sn
 	}
 	if output == nil {
 		output = map[string]interface{}{}
+	}
+	return output, nil
+}
+
+// execSubbot runs a SubbotNode on the main graph: it emits the node-started
+// event, runs the child via runSubbotChild (with the run scope), maps the child's
+// terminal output to outputs.<subbot>.<field>, and advances the edge. The child is
+// a full nested run, so it may contain loops (unlike a fan-out branch).
+func (e *Engine) execSubbot(ctx context.Context, rs *runState, nodeID string, sn *ir.SubbotNode) (string, error) {
+	startedPayload := map[string]interface{}{
+		"kind":      "subbot",
+		"iteration": e.currentLoopIteration(nodeID, rs.loopCounters),
+		"source":    sn.Source,
+	}
+	if p := e.currentLoopIterationPath(nodeID, rs.loopCounters); p != "" {
+		startedPayload["iteration_path"] = p
+	}
+	if err := e.emit(rs.ctx, rs.runID, store.EventNodeStarted, nodeID, startedPayload); err != nil {
+		return "", err
+	}
+
+	output, err := e.runSubbotChild(ctx, rs, nodeID, sn, rs.scope())
+	if err != nil {
+		return "", err
 	}
 
 	rs.outputs[nodeID] = output

--- a/pkg/runtime/fan_out.go
+++ b/pkg/runtime/fan_out.go
@@ -548,6 +548,28 @@ func (e *Engine) executeNodeForBranch(ctx context.Context, rs *runState, runID, 
 			return nil, true
 		}
 		return output, false
+	case *ir.SubbotNode:
+		// A subbot is engine-special (a real nested run), like emit/wait — the
+		// model executor can't run it. Resolve `with:` against the branch's
+		// merged-output scope so {{outputs.<router>.<as>.<field>}} is available per
+		// element, then run the child via the shared subbot core.
+		output, serr := e.runSubbotChild(ctx, rs, currentNodeID, n, resolveScope{
+			vars:      rs.vars,
+			outputs:   merged,
+			runInputs: rs.runInputs,
+			artifacts: mergedArt,
+			rs:        rs,
+		})
+		if serr != nil {
+			result.err = fmt.Errorf("node %q in branch %s: %w", currentNodeID, branchID, serr)
+			return nil, true
+		}
+		result.outputs[currentNodeID] = output
+		if err := e.validateNodeOutput(currentNodeID, n, output); err != nil {
+			result.err = fmt.Errorf("node %q in branch %s: %w", currentNodeID, branchID, err)
+			return nil, true
+		}
+		return output, false
 	}
 
 	nodeInput := e.buildNodeInputRS(currentNodeID, resolveScope{

--- a/pkg/runtime/fan_out_subbot_test.go
+++ b/pkg/runtime/fan_out_subbot_test.go
@@ -1,0 +1,98 @@
+package runtime
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// TestFanOutEach_SubbotPerElement is the regression for #61: a `subbot` node
+// inside a `fan_out_each` branch used to fail with `unsupported node kind
+// "subbot"` because branch nodes were dispatched to the model executor (which
+// has no subbot case), while the main graph dispatched subbot via execSubbot.
+//
+// It asserts the documented "map a sub-bot over the items" pattern: the child
+// runs once per element, and its `with:` mappings resolve against the BRANCH
+// scope so {{outputs.dispatch.item.id}} is the element's id.
+func TestFanOutEach_SubbotPerElement(t *testing.T) {
+	router := &ir.RouterNode{
+		BaseNode:    ir.BaseNode{ID: "dispatch"},
+		RouterMode:  ir.RouterFanOutEach,
+		Over:        "{{outputs.entry.items}}",
+		OverRefs:    []*ir.Ref{{Kind: ir.RefOutputs, Path: []string{"entry", "items"}, Raw: "{{outputs.entry.items}}"}},
+		ItemBinding: "item",
+	}
+	wf := &ir.Workflow{
+		Name:  "fan_out_each_subbot",
+		Entry: "entry",
+		Nodes: map[string]ir.Node{
+			"entry":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "entry"}},
+			"dispatch": router,
+			"run_child": &ir.SubbotNode{
+				BaseNode: ir.BaseNode{ID: "run_child"},
+				Source:   "child.bot",
+				With: []*ir.DataMapping{
+					{Key: "ticket", Refs: []*ir.Ref{{Kind: ir.RefOutputs, Path: []string{"dispatch", "item", "id"}, Raw: "{{outputs.dispatch.item.id}}"}}, Raw: "{{outputs.dispatch.item.id}}"},
+				},
+			},
+			"collect": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "collect"}, AwaitMode: ir.AwaitWaitAll},
+			"done":    &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+			"fail":    &ir.FailNode{BaseNode: ir.BaseNode{ID: "fail"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "entry", To: "dispatch"},
+			{From: "dispatch", To: "run_child"},
+			{From: "run_child", To: "collect"},
+			{From: "collect", To: "done"},
+		},
+		Schemas: map[string]*ir.Schema{},
+		Prompts: map[string]*ir.Prompt{},
+		Vars:    map[string]*ir.Var{},
+		Loops:   map[string]*ir.Loop{},
+	}
+
+	var mu sync.Mutex
+	gotTickets := map[string]bool{}
+	var calls int64
+	runner := func(_ context.Context, req SubbotRequest) (map[string]interface{}, error) {
+		atomic.AddInt64(&calls, 1)
+		mu.Lock()
+		if tk, ok := req.Vars["ticket"].(string); ok {
+			gotTickets[tk] = true
+		}
+		mu.Unlock()
+		return map[string]interface{}{"committed": true}, nil
+	}
+
+	exec := newStubExecutor()
+	exec.on("entry", func(_ map[string]interface{}) (map[string]interface{}, error) {
+		return map[string]interface{}{"items": []interface{}{item("A"), item("B"), item("C")}}, nil
+	})
+	exec.on("collect", func(_ map[string]interface{}) (map[string]interface{}, error) {
+		return map[string]interface{}{"done": true}, nil
+	})
+
+	s := tmpStore(t)
+	eng := New(wf, s, exec, WithSubbotRunner(runner))
+	if err := eng.Run(context.Background(), "run-fe-subbot", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	r, _ := s.LoadRun(context.Background(), "run-fe-subbot")
+	if r.Status != store.RunStatusFinished {
+		t.Fatalf("expected finished, got %s", r.Status)
+	}
+	if got := atomic.LoadInt64(&calls); got != 3 {
+		t.Fatalf("subbot runner invoked %d times, want 3 (one per element)", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	for _, id := range []string{"A", "B", "C"} {
+		if !gotTickets[id] {
+			t.Errorf("subbot never ran for element %s (branch-scope with: resolution broken)", id)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #61.

## Problem

A `subbot` node inside a `fan_out_each` branch failed at runtime with
`model: unsupported node kind "subbot" for execution`, while the **same node in
the main graph runs fine**. Branch nodes execute through the model executor
(`executeNodeForBranch` → `e.executor.Execute`, `fan_out.go`), whose switch only
handles agent/judge/human/router/tool — `*ir.SubbotNode` falls through to the
`unsupported node kind` default. The main-graph dispatch, by contrast, special-
cases subbot via `execSubbot`. The branch path already special-cases the other
engine-special kinds (`EmitNode`/`WaitNode`, ADR-051) above the executor call;
`subbot` was just missing.

Net effect: the documented headline pattern in
`docs/groups-iteration-subbots.md` ("map a sub-bot over a dependency DAG of work
items, each in its own worktree slot") never executed — every per-element subbot
was a no-op.

## Fix

- Extract the executor-agnostic core of `execSubbot` into
  `runSubbotChild(ctx, rs, nodeID, sn, sc resolveScope)` — it resolves `with:`
  against the given scope, acquires `needs:` leases, and invokes the
  `SubbotRunner`. `execSubbot` keeps the main-graph idiom (events, output
  recording, edge selection) and calls it with `rs.scope()`.
- Add a `case *ir.SubbotNode` to `executeNodeForBranch`, mirroring the `WaitNode`
  case, that calls `runSubbotChild` with the branch's **merged-output** scope so
  `{{outputs.<router>.<as>.<field>}}` resolves to the per-element value.

No behaviour change on the main graph (pure refactor there); branches gain
subbot support.

## Test

`TestFanOutEach_SubbotPerElement` (regression for #61): a `fan_out_each` over
`[A, B, C]` with a `subbot` branch body + injected `SubbotRunner` asserts the
child runs once per element and each receives its own element id via the
branch-scoped `with:` mapping.

```
=== RUN   TestFanOutEach_SubbotPerElement
--- PASS: TestFanOutEach_SubbotPerElement (0.00s)
```

`go test ./pkg/runtime/... ./pkg/dsl/...` green; `pkg/runtime` `-race` green;
`gofmt` clean.

## End-to-end

A tool-only child subbot fanned over a 3-item DAG (`B depends_on A`) now: spawns
**3 distinct per-subbot worktrees**, runs `A ∥ C` in parallel, starts `B` only
after `A` finishes, and commits in each worktree — confirming worktree isolation
+ DAG ordering + per-element binding together.
