### PR TITLE
feat(run): make the MCP startup health-check non-fatal via --skip-mcp-health

### DIFF
--- a/cmd/iterion/run.go
+++ b/cmd/iterion/run.go
@@ -16,6 +16,7 @@ var runOpts struct {
 	timeout             time.Duration
 	logLevel            string
 	noInteractive       bool
+	skipMCPHealth       bool
 	varFlags            []string
 	modelFor            []string
 	backendFor          []string
@@ -55,6 +56,7 @@ var runCmd = &cobra.Command{
 			Timeout:             runOpts.timeout,
 			LogLevel:            runOpts.logLevel,
 			NoInteractive:       runOpts.noInteractive,
+			SkipMCPHealth:       runOpts.skipMCPHealth,
 			Background:          runOpts.background,
 			MergeInto:           runOpts.mergeInto,
 			BranchName:          runOpts.branchName,
@@ -101,6 +103,7 @@ func init() {
 	f.DurationVar(&runOpts.timeout, "timeout", 0, "Maximum run duration (e.g. 30s, 5m, 1h)")
 	f.StringVar(&runOpts.logLevel, "log-level", "", "Log verbosity: error, warn, info, debug, trace")
 	f.BoolVar(&runOpts.noInteractive, "no-interactive", false, "Don't prompt on TTY; exit on human pause")
+	f.BoolVar(&runOpts.skipMCPHealth, "skip-mcp-health", false, "Don't abort the run when an MCP server fails its startup health-check — log the failure as a warning and continue. Also enabled by ITERION_SKIP_MCP_HEALTH=1. Use when a declared MCP server (e.g. an HTTP-OAuth one) is unreachable/unauthorized in this environment but the run does not depend on it.")
 	f.BoolVar(&runOpts.background, "background", false, "Internal: managed-runner mode for the studio server (writes .pid, suppresses interactive prompts)")
 	_ = f.MarkHidden("background")
 	f.StringVar(&runOpts.mergeInto, "merge-into", "", "For worktree:auto runs, branch to merge into after the run (\"\"/\"current\"=current branch, \"none\"=skip, or a branch name)")

--- a/go.sum
+++ b/go.sum
@@ -14,12 +14,6 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJ
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260630065455-1d45debd8c14 h1:wRDB4gjqccSVSCyrJqV6AVZfkc0gO/yo/CNlueB+RIM=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260630065455-1d45debd8c14/go.mod h1:hquBysL8+24vrlr2eVE0rXO4mFg+8TnjYxO4g9MrzCg=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260702084906-776a069ae96d h1:UHFjSxprS8pnoDuH7wPTuaEQ+6XCm++A/smBBdgsSVU=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260702084906-776a069ae96d/go.mod h1:hquBysL8+24vrlr2eVE0rXO4mFg+8TnjYxO4g9MrzCg=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260702092447-05398ca7f79e h1:OQwUDj6yR9dCWaBkL3rIJLu6JnJ8gVgOa6oxQiR+oNk=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260702092447-05398ca7f79e/go.mod h1:hquBysL8+24vrlr2eVE0rXO4mFg+8TnjYxO4g9MrzCg=
 github.com/SocialGouv/claw-code-go v0.1.1-0.20260702094037-dad0827ec028 h1:oI86t60oWoME0QaVDJ6edmSQoQeALzPtbuDYa8EzjlQ=
 github.com/SocialGouv/claw-code-go v0.1.1-0.20260702094037-dad0827ec028/go.mod h1:hquBysL8+24vrlr2eVE0rXO4mFg+8TnjYxO4g9MrzCg=
 github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=

--- a/openapi.json
+++ b/openapi.json
@@ -42,9 +42,6 @@
             "format": "date-time",
             "type": "string"
           },
-          "managed_secret_id": {
-            "type": "string"
-          },
           "namespace": {
             "type": "string"
           },

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -119,6 +119,21 @@ type RunOptions struct {
 	// (capped exponential backoff) and re-invokes resume in-process up to N
 	// times, re-using this run's exact overrides. See auto_resume.go.
 	AutoResume int
+	// SkipMCPHealth downgrades a failing MCP startup health-check from a
+	// fatal error to a warning: the check still runs (its diagnostics are
+	// logged) but a failure no longer aborts the run. Set by --skip-mcp-health
+	// or a truthy ITERION_SKIP_MCP_HEALTH env var. Useful when the project
+	// .mcp.json declares a server that is unreachable/unauthorized in this
+	// environment (e.g. an HTTP-OAuth MCP) but the run does not depend on it.
+	SkipMCPHealth bool
+}
+
+// skipMCPHealthFromEnv reports whether ITERION_SKIP_MCP_HEALTH is truthy, so
+// the toggle also applies without the CLI flag — e.g. to launcher scripts
+// that export it, and to any entry point that reuses RunRun.
+func skipMCPHealthFromEnv() bool {
+	v := os.Getenv("ITERION_SKIP_MCP_HEALTH")
+	return v == "1" || strings.EqualFold(v, "true")
 }
 
 // RunRun executes a workflow or recipe and reports the outcome.
@@ -244,7 +259,11 @@ func RunRun(ctx context.Context, opts RunOptions, p *Printer) error {
 		}()
 	}
 	if err := runview.MCPHealthCheck(ctx, executor, wf.ActiveMCPServers); err != nil {
-		return err
+		if opts.SkipMCPHealth || skipMCPHealthFromEnv() {
+			logger.Warn("MCP health-check failed but tolerated (--skip-mcp-health / ITERION_SKIP_MCP_HEALTH): %v", err)
+		} else {
+			return err
+		}
 	}
 
 	// Wire the subbot runner so `subbot` nodes can run a child .bot as a

--- a/pkg/cli/run_skipmcp_test.go
+++ b/pkg/cli/run_skipmcp_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import "testing"
+
+func TestSkipMCPHealthFromEnv(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"1", true},
+		{"true", true},
+		{"TRUE", true},
+		{"True", true},
+		{"", false},
+		{"0", false},
+		{"false", false},
+		{"yes", false}, // only "1" / "true" (any case) are truthy
+	}
+	for _, c := range cases {
+		t.Setenv("ITERION_SKIP_MCP_HEALTH", c.val)
+		if got := skipMCPHealthFromEnv(); got != c.want {
+			t.Errorf("skipMCPHealthFromEnv() with ITERION_SKIP_MCP_HEALTH=%q = %v, want %v", c.val, got, c.want)
+		}
+	}
+}

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -3490,7 +3490,6 @@ export interface components {
             kind: string;
             /** Format: date-time */
             last_refreshed_at?: string;
-            managed_secret_id?: string;
             namespace?: string;
             provider: string;
             scopes?: string[];


### PR DESCRIPTION
## Problem

`iterion run` aborts at startup if any active MCP server fails `MCPHealthCheck` (`pkg/cli/run.go`). This hard-blocks a run whenever the project's `.mcp.json` declares a server that is unreachable or unauthorized in the current environment — e.g. an HTTP-OAuth MCP needing interactive auth the run can't perform — even though the run doesn't actually depend on that server.

The only workaround has been to edit `.mcp.json` before the run, which is error-prone: it's easy to accidentally commit the neutralized file and wipe the project's MCP config for everyone.

## Change

Add a `--skip-mcp-health` flag on `iterion run`, plus a truthy `ITERION_SKIP_MCP_HEALTH` env var (so the toggle also applies to launcher scripts and any entry point reusing `RunRun`, not just the CLI). When set:

- the health-check **still runs** (its diagnostics are logged, so you still see *which* server is broken),
- but a failure is **downgraded from a fatal error to a warning** instead of aborting the run.

Default behaviour is unchanged (strict abort). `subbot` children run in-process and don't re-run the check, so this single gate covers the whole run tree.

## Test

- `go build ./...`, `go vet`, `gofmt` clean.
- Added `TestSkipMCPHealthFromEnv` (env parsing: `1`/`true` any case → true; else false).
- Existing `pkg/cli` tests pass.