### PR TITLE
fix(ci): regenerate drifted artifacts — stale go.sum entries + openapi spec/types

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -14,12 +14,6 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJ
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgvJqCH0sFfrBUTnUJSBrBf7++ypk+twtRs=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260630065455-1d45debd8c14 h1:wRDB4gjqccSVSCyrJqV6AVZfkc0gO/yo/CNlueB+RIM=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260630065455-1d45debd8c14/go.mod h1:hquBysL8+24vrlr2eVE0rXO4mFg+8TnjYxO4g9MrzCg=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260702084906-776a069ae96d h1:UHFjSxprS8pnoDuH7wPTuaEQ+6XCm++A/smBBdgsSVU=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260702084906-776a069ae96d/go.mod h1:hquBysL8+24vrlr2eVE0rXO4mFg+8TnjYxO4g9MrzCg=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260702092447-05398ca7f79e h1:OQwUDj6yR9dCWaBkL3rIJLu6JnJ8gVgOa6oxQiR+oNk=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260702092447-05398ca7f79e/go.mod h1:hquBysL8+24vrlr2eVE0rXO4mFg+8TnjYxO4g9MrzCg=
 github.com/SocialGouv/claw-code-go v0.1.1-0.20260702094037-dad0827ec028 h1:oI86t60oWoME0QaVDJ6edmSQoQeALzPtbuDYa8EzjlQ=
 github.com/SocialGouv/claw-code-go v0.1.1-0.20260702094037-dad0827ec028/go.mod h1:hquBysL8+24vrlr2eVE0rXO4mFg+8TnjYxO4g9MrzCg=
 github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=

--- a/openapi.json
+++ b/openapi.json
@@ -42,9 +42,6 @@
             "format": "date-time",
             "type": "string"
           },
-          "managed_secret_id": {
-            "type": "string"
-          },
           "namespace": {
             "type": "string"
           },

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -3490,7 +3490,6 @@ export interface components {
             kind: string;
             /** Format: date-time */
             last_refreshed_at?: string;
-            managed_secret_id?: string;
             namespace?: string;
             provider: string;
             scopes?: string[];


### PR DESCRIPTION
## Problem

`vendor-check` and the OpenAPI drift gate in the `test` job fail **on main** (latest main run: both jobs red) — so every open PR inherits a red CI regardless of its content.

Two independent drifts:
- **go.sum**: three stale `claw-code-go` pseudo-version pairs left behind by successive bumps made without `go mod tidy` — `vendor-check` runs tidy+vendor and diffs.
- **openapi.json + studio/src/api/schema.ts**: still carry the removed `managed_secret_id` field — `task openapi:check` regenerates and diffs.

## Change

Regenerate all three artifacts (`go mod tidy && go mod vendor`; `task openapi:gen`). No code change; regeneration is stable (idempotent on a second run).

Note: the occasionally-red `race` job is the flaky `TestDispatcherGivesUpAfterMaxAttempts` (passes on sibling runs) — unrelated, not addressed here.