### PR TITLE
feat(model): inject schema-validation error into structured-output retry prompt

### DIFF
--- a/pkg/backend/model/executor_build_task.go
+++ b/pkg/backend/model/executor_build_task.go
@@ -306,8 +306,11 @@ func (e *ClawExecutor) executeBackend(ctx context.Context, node ir.Node, input m
 // failure that one retry can plausibly fix (parse-fallback OR missing-
 // required-field), one retry through retryDelegateLoop is attempted —
 // inheriting the standard transient-backoff budget — and the retry
-// result is re-validated. The OnDelegateRetry observer hook fires for
-// the schema-fallback retry (otherwise invisible to outer observers,
+// result is re-validated. The retry does not replay the identical prompt:
+// its UserPrompt (plus, for multimodal tasks, an extra text ContentBlock)
+// is augmented with a delimited feedback block naming the validation error
+// so the model can correct itself. The OnDelegateRetry observer hook fires
+// for the schema-fallback retry (otherwise invisible to outer observers,
 // which only see transient-error retries), token / duration are
 // accumulated across the first attempt + retry so per-node accounting
 // reflects the full cost paid, and stampDelegateOutputMeta is re-applied
@@ -359,12 +362,29 @@ func (e *ClawExecutor) validateAndRetry(
 		di.Attempt = 1
 		e.hooks.OnDelegateRetry(f.id, di)
 	}
+	// Build a retry copy of the task whose UserPrompt (and, for multimodal
+	// tasks, an extra text ContentBlock) carries a delimited feedback block
+	// naming the validation failure, so the model can correct its output
+	// instead of blindly re-running the identical prompt. The ORIGINAL task
+	// is preserved untouched — its token/duration accounting has already
+	// been accumulated above and must not be disturbed.
+	retryTask := *task
+	feedback := formatSchemaRetryFeedback(err)
+	retryTask.UserPrompt = appendSchemaRetryFeedback(retryTask.UserPrompt, feedback)
+	if len(retryTask.UserContent) > 0 {
+		// Copy the slice header so appending feedback to the retry task does
+		// not mutate the original task's backing array.
+		retryTask.UserContent = append(
+			append([]delegate.ContentBlock(nil), retryTask.UserContent...),
+			delegate.ContentBlock{Type: "text", Text: feedback},
+		)
+	}
 	// Route the schema-fallback retry through retryDelegateLoop so it
 	// inherits the same transient-error backoff every other delegate call
 	// gets — a direct backend.Execute here skipped the retry budget and
 	// gave up on the first transient SDK hiccup.
 	retryResult, retryErr := e.retryDelegateLoop(ctx, f.id, backendName, func() (delegate.Result, error) {
-		return backend.Execute(ctx, *task)
+		return backend.Execute(ctx, retryTask)
 	})
 	if retryErr != nil || retryResult.ParseFallback {
 		return result, fmt.Errorf("model: node %q: structured output invalid: %w", f.id, err)
@@ -380,6 +400,31 @@ func (e *ClawExecutor) validateAndRetry(
 		return retryResult, fmt.Errorf("model: node %q: structured output invalid after retry: %w", f.id, retryValErr)
 	}
 	return retryResult, nil
+}
+
+// schemaRetryFeedbackMarker delimits the schema-validation feedback block
+// injected into a retry prompt. Kept as a const so tests can assert on it
+// without duplicating the literal.
+const schemaRetryFeedbackMarker = "[OUTPUT SCHEMA VALIDATION FAILED]"
+
+// formatSchemaRetryFeedback renders the delimited feedback block appended to
+// a retry prompt when structured output fails validation. err is the concrete
+// validation failure (missing field, parse fallback) so the model knows what
+// to fix.
+func formatSchemaRetryFeedback(err error) string {
+	return fmt.Sprintf(
+		"%s\n%s\nReturn a corrected response that matches the required output schema exactly. Output only the JSON object.",
+		schemaRetryFeedbackMarker, err,
+	)
+}
+
+// appendSchemaRetryFeedback appends the feedback block to an existing user
+// prompt, separated by a blank line. An empty prompt yields the feedback alone.
+func appendSchemaRetryFeedback(prompt, feedback string) string {
+	if prompt == "" {
+		return feedback
+	}
+	return prompt + "\n\n" + feedback
 }
 
 // buildTask assembles the delegate.Task for an agent/judge LLM node from the

--- a/pkg/backend/model/executor_retry_feedback_test.go
+++ b/pkg/backend/model/executor_retry_feedback_test.go
@@ -1,0 +1,92 @@
+package model
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+)
+
+// capturingBackend records every Task it is asked to Execute so a test can
+// assert on the prompt content the executor sends per attempt.
+type capturingBackend struct {
+	mu      sync.Mutex
+	tasks   []delegate.Task
+	results []delegate.Result
+}
+
+func (b *capturingBackend) Execute(_ context.Context, task delegate.Task) (delegate.Result, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	idx := len(b.tasks)
+	b.tasks = append(b.tasks, task)
+	if idx < len(b.results) {
+		return b.results[idx], nil
+	}
+	return delegate.Result{}, nil
+}
+
+// TestValidateAndRetry_InjectsSchemaFeedback proves that when structured
+// output fails validation with a retry-eligible error (missing required
+// field), the executor's SECOND backend call receives a UserPrompt augmented
+// with the schema-validation feedback marker — the model is told what failed
+// instead of blindly re-running the identical prompt.
+func TestValidateAndRetry_InjectsSchemaFeedback(t *testing.T) {
+	backend := &capturingBackend{
+		results: []delegate.Result{
+			// 1st call: valid JSON but missing the required "answer" field.
+			{Output: map[string]interface{}{"other": "x"}, BackendName: "test_backend"},
+			// 2nd call: corrected, schema-valid output.
+			{Output: map[string]interface{}{"answer": "blue"}, BackendName: "test_backend"},
+		},
+	}
+
+	reg := delegate.NewRegistry()
+	reg.Register("test_backend", backend)
+	wf := &ir.Workflow{
+		Prompts: map[string]*ir.Prompt{},
+		Schemas: map[string]*ir.Schema{
+			"out_schema": {
+				Name:   "out_schema",
+				Fields: []*ir.SchemaField{{Name: "answer", Type: ir.FieldTypeString}},
+			},
+		},
+	}
+	exec := NewClawExecutor(NewRegistry(), wf,
+		WithBackendRegistry(reg),
+		WithRetryPolicy(RetryPolicy{MaxAttempts: 3, BackoffBase: time.Millisecond}),
+	)
+
+	node := &ir.AgentNode{
+		BaseNode:     ir.BaseNode{ID: "answerer"},
+		LLMFields:    ir.LLMFields{Backend: "test_backend"},
+		SchemaFields: ir.SchemaFields{OutputSchema: "out_schema"},
+	}
+
+	output, err := exec.executeBackend(context.Background(), node, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := output["answer"]; got != "blue" {
+		t.Fatalf("expected corrected answer=blue, got %v", output)
+	}
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if len(backend.tasks) != 2 {
+		t.Fatalf("expected exactly 2 backend calls (attempt + feedback retry), got %d", len(backend.tasks))
+	}
+	if strings.Contains(backend.tasks[0].UserPrompt, schemaRetryFeedbackMarker) {
+		t.Errorf("first attempt must NOT carry the retry feedback marker: %q", backend.tasks[0].UserPrompt)
+	}
+	if !strings.Contains(backend.tasks[1].UserPrompt, schemaRetryFeedbackMarker) {
+		t.Errorf("retry attempt UserPrompt missing feedback marker %q: %q", schemaRetryFeedbackMarker, backend.tasks[1].UserPrompt)
+	}
+	if !strings.Contains(backend.tasks[1].UserPrompt, "missing required field") {
+		t.Errorf("retry feedback should name the validation error, got: %q", backend.tasks[1].UserPrompt)
+	}
+}


### PR DESCRIPTION
## Summary

When a node's structured output fails schema validation for a retry-eligible reason (parse-fallback or missing-required-field), `validateAndRetry` re-ran the **identical** task — the model never learned what was wrong, so the retry often reproduced the same invalid shape.

The retry now sends a **copy** of the task whose `UserPrompt` is augmented with a delimited feedback block naming the validation error, so the model can correct itself:

```
[OUTPUT SCHEMA VALIDATION FAILED]
<err>
Return a corrected response that matches the required output schema exactly. Output only the JSON object.
```

## Changes

- `retryTask := *task` — the **original** task is left untouched, so its already-accumulated token/duration accounting for per-node budgeting is undisturbed.
- Two small helpers: `formatSchemaRetryFeedback(err)` and `appendSchemaRetryFeedback(prompt, feedback)`; marker exposed as `const schemaRetryFeedbackMarker` so tests assert on it without duplicating the literal.
- Multimodal tasks (`UserContent` non-empty) also get a `ContentBlock{Type:"text"}` with the same feedback, appended on a **copied** slice so the original backing array isn't mutated.
- Function doc comment updated.

Only `pkg/backend/model/executor_build_task.go` changes; no DSL surface added.

## Test

`TestValidateAndRetry_InjectsSchemaFeedback` — a capturing backend returns a missing-required-field JSON on the first call (retry-eligible) and a valid JSON on the second; asserts the second call's task carries the feedback marker and the underlying error, and the first does not.

## Verification

```
go build ./...
go vet ./pkg/backend/model/
go test ./pkg/backend/model/... -count=1
```
All green; `gofmt` clean.

> Draft: verified locally (build, vet, gofmt, unit tests on the touched package); opening as draft pending full CI review.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)
