### PR TITLE
feat(claw): per-node base_url/api_key_env endpoint override

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -229,6 +229,58 @@ field first, so the `:-` in `${VAR:-x}` is never mistaken for a
 Like the hint chain itself, per-element models only take effect on
 `claude_code` (the only backend that walks the chain today).
 
+## Per-node endpoint override (`base_url` / `api_key_env`)
+
+`provider:` routes among the credentials the **process env** already
+carries. It cannot, by itself, point two nodes of the same run at two
+different endpoints: the `claw` backend reads `OPENAI_BASE_URL` /
+`ANTHROPIC_BASE_URL` from the process env, so setting one globally would
+redirect **every** claw node. The per-node **`base_url`** + **`api_key_env`**
+fields close that gap — they let a single run mix a real Opus node and a
+third-party OpenAI-compatible node (e.g. Kimi/Moonshot) without any global
+env var:
+
+```yaml
+agent opus_writer:
+  backend: "claw"
+  model: "anthropic/claude-opus-4-8"   # real Anthropic, from ANTHROPIC_API_KEY
+
+agent kimi_reviewer:
+  backend: "claw"
+  model: "openai/kimi-k2"              # OpenAI-compatible wire
+  base_url: "https://api.moonshot.ai/v1"
+  api_key_env: "MOONSHOT_API_KEY"      # key read from $MOONSHOT_API_KEY
+```
+
+Semantics:
+
+- **`base_url`** — when non-empty, the claw backend builds *this node's*
+  API client against this endpoint instead of the process-env default. The
+  `model:` prefix still selects the provider factory (`openai/…` →
+  OpenAI-compatible client, `anthropic/…` → Anthropic-compatible client), so
+  any OpenAI- or Anthropic-shaped facade works.
+- **`api_key_env`** — the **name** of the env var holding the API key for
+  that endpoint. The key is read via `os.Getenv` **at client construction**;
+  its value never rides the node/task, the sandbox IPC wire form, or any log
+  line — only the env-var name does. Empty means the endpoint needs no key
+  (or reuses the provider's own env default).
+- Both fields support `${VAR}` / `${VAR:-default}` expansion.
+- The override client is **never cached** (endpoint + key are node-scoped),
+  and an explicit `base_url` on an `openai/…` node deliberately bypasses the
+  ChatGPT-OAuth path so no Codex headers ever masquerade to a third party.
+
+Only **`claw`** honours these fields — it is the sole backend that builds its
+API client in-process. Setting them on `claude_code`/`codex` (which resolve
+credentials from the process env / their own auth files) warns **C173** at
+compile time and the fields are ignored. Supported providers for the override
+are `openai` and `anthropic`; any other `model:` prefix errors at run time.
+
+> **Sandbox note.** For a sandboxed claw node (`sandbox:`), the in-container
+> runner reads `os.Getenv(api_key_env)` too, but the sandbox only forwards a
+> fixed allow-list of provider env vars — a custom `api_key_env` name is not
+> yet forwarded into the container, so the override currently applies to the
+> in-process (unsandboxed) path.
+
 ## Transient-error & network resilience
 
 A brief internet/API outage should not abort a whole run. Every backend

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -77,6 +77,8 @@ agent reviewer:
 |----------|-------------|
 | `model` | LLM model identifier (supports `${ENV_VAR}`) |
 | `backend` | Execution backend: `claw` (default, in-process LLM), `claude_code` (recommended for tool use), `codex` (discouraged, see [Delegation](delegation.md)) |
+| `base_url` | Per-node endpoint override for `backend: claw` — point this node at an OpenAI/Anthropic-compatible facade (e.g. Kimi/Moonshot) without a global `OPENAI_BASE_URL`. Supports `${ENV_VAR}`. Ignored (with warning **C173**) on non-`claw` backends. See [Backends](backends.md#per-node-endpoint-override-base_url--api_key_env). |
+| `api_key_env` | Name of the env var holding the API key for `base_url`; the value is read at client construction and never inlined or logged. Supports `${ENV_VAR}`. |
 | `input` / `output` | Schema references for structured I/O |
 | `publish` | Persist output as a named artifact |
 | `system` / `user` | Prompt references |

--- a/docs/references/diagnostics.md
+++ b/docs/references/diagnostics.md
@@ -111,6 +111,7 @@ All diagnostic codes emitted during compilation (`ir.Compile`) and validation (`
 | **C170** | error | Invalid memory visibility | `memory: visibility:` has an unknown value | Use a known visibility (`bot`/`project`/`cross_project`/`user`/`org`/`global`) |
 | **C171** | error | Memory visibility conflict | `memory: visibility:` is combined with the legacy `project_root:` | Use `visibility:` alone — drop the legacy `project_root:` |
 | **C172** | warning | Malformed provider step | A `provider:` chain element of the `provider:model` form has an empty provider or model part | Provide both parts, e.g. `anthropic:claude-sonnet-4-6` |
+| **C173** | warning | Endpoint override ignored | `base_url`/`api_key_env` is set on a backend other than `claw` (only claw builds its client in-process and honours a per-node endpoint) | Drop the fields, or set `backend: claw` on the node |
 | **C190** | warning | Supervisor watches non-agent | A `supervisor` `watches:` a node id that isn't an agent node | Watch an agent node, or fix the node id |
 | **C191** | warning | Malformed supervisor | A `supervisor` declaration is malformed (e.g. a bad cooldown duration) | Use a valid Go duration for cooldown |
 | **C192** | error | Duplicate supervisor | The same `supervisor <name>:` is declared twice | Rename or merge |

--- a/pkg/backend/delegate/delegate.go
+++ b/pkg/backend/delegate/delegate.go
@@ -512,6 +512,23 @@ type Task struct {
 	// backend itself stays chain-unaware.
 	ProviderHint string
 
+	// BaseURL is the resolved per-node claw endpoint override from the DSL
+	// `base_url:` field (post env-expansion). When non-empty, the claw
+	// backend builds this node's API client against this endpoint instead
+	// of the process-env default (OPENAI_BASE_URL / ANTHROPIC_BASE_URL),
+	// so a single run can mix a real Opus node and a third-party
+	// OpenAI-compatible node (e.g. Kimi/Moonshot) without a global env var.
+	// Honoured ONLY by the claw backend; CLI backends ignore it (compile
+	// time C173 warns). Empty means "use the process-env default".
+	BaseURL string
+
+	// APIKeyEnv is the NAME of the env var carrying the API key for BaseURL
+	// (DSL `api_key_env:`, post env-expansion). The claw backend reads
+	// os.Getenv(APIKeyEnv) at client construction; the key VALUE is never
+	// stored on the Task, serialized onto the wire, or logged. Empty means
+	// the endpoint needs no key (or reuses the provider's env default).
+	APIKeyEnv string
+
 	// Hooks lets the backend surface mid-execution events back to the
 	// engine without returning. Currently used by the claude_code
 	// delegate to emit `tool_started` and `tool_called` events as the

--- a/pkg/backend/delegate/io.go
+++ b/pkg/backend/delegate/io.go
@@ -74,6 +74,8 @@ type IOTask struct {
 	ForkSession            bool                  `json:"fork_session,omitempty"`
 	SessionFingerprint     string                `json:"session_fingerprint,omitempty"`
 	ProviderHint           string                `json:"provider_hint,omitempty"`
+	BaseURL                string                `json:"base_url,omitempty"`
+	APIKeyEnv              string                `json:"api_key_env,omitempty"`
 	InteractionEnabled     bool                  `json:"interaction_enabled,omitempty"`
 	ResumeConversation     json.RawMessage       `json:"resume_conversation,omitempty"`
 	ResumePendingToolUseID string                `json:"resume_pending_tool_use_id,omitempty"`
@@ -163,6 +165,8 @@ func ToIOTask(t Task) IOTask {
 		ForkSession:            t.ForkSession,
 		SessionFingerprint:     t.SessionFingerprint,
 		ProviderHint:           t.ProviderHint,
+		BaseURL:                t.BaseURL,
+		APIKeyEnv:              t.APIKeyEnv,
 		InteractionEnabled:     t.InteractionEnabled,
 		ResumeConversation:     t.ResumeConversation,
 		ResumePendingToolUseID: t.ResumePendingToolUseID,
@@ -211,6 +215,8 @@ func FromIOTask(t IOTask) Task {
 		ForkSession:            t.ForkSession,
 		SessionFingerprint:     t.SessionFingerprint,
 		ProviderHint:           t.ProviderHint,
+		BaseURL:                t.BaseURL,
+		APIKeyEnv:              t.APIKeyEnv,
 		InteractionEnabled:     t.InteractionEnabled,
 		ResumeConversation:     t.ResumeConversation,
 		ResumePendingToolUseID: t.ResumePendingToolUseID,

--- a/pkg/backend/model/claw_backend.go
+++ b/pkg/backend/model/claw_backend.go
@@ -211,11 +211,32 @@ func (b *ClawBackend) Execute(ctx context.Context, task delegate.Task) (delegate
 		}
 	}
 
-	// Resolve API client. Phase C: in cloud mode the runner stamps
-	// per-tenant BYOK credentials into ctx, ResolveWithContext then
-	// builds a fresh APIClient with the override key (no cache hit
-	// across tenants). Local mode keeps the env-fallback path.
-	client, err := b.registry.ResolveWithContext(ctx, task.Model)
+	// Resolve API client.
+	//
+	// Per-node endpoint override (DSL base_url/api_key_env) takes
+	// precedence: when the node pins its own endpoint, build a fresh
+	// client against it with the key read from os.Getenv(APIKeyEnv) HERE,
+	// at construction time — the key value never rides the Task, the wire
+	// form, or a log line. This is what lets one run mix a real Opus node
+	// and a third-party OpenAI-compatible node (Kimi/Moonshot) without a
+	// global OPENAI_BASE_URL/ANTHROPIC_BASE_URL. Otherwise fall back to the
+	// standard resolver: Phase C, in cloud mode the runner stamps
+	// per-tenant BYOK credentials into ctx and ResolveWithContext builds a
+	// fresh APIClient with the override key (no cache hit across tenants);
+	// local mode keeps the env-fallback + per-process cache path.
+	var (
+		client api.APIClient
+		err    error
+	)
+	if task.BaseURL != "" || task.APIKeyEnv != "" {
+		apiKey := ""
+		if task.APIKeyEnv != "" {
+			apiKey = os.Getenv(task.APIKeyEnv)
+		}
+		client, err = b.registry.ResolveWithEndpoint(task.Model, task.BaseURL, apiKey)
+	} else {
+		client, err = b.registry.ResolveWithContext(ctx, task.Model)
+	}
 	if err != nil {
 		return delegate.Result{}, fmt.Errorf("claw backend: %w", err)
 	}

--- a/pkg/backend/model/claw_backend_test.go
+++ b/pkg/backend/model/claw_backend_test.go
@@ -121,6 +121,56 @@ func TestClawBackend_TextGeneration(t *testing.T) {
 	}
 }
 
+// TestClawBackend_PerNodeEndpointOverride verifies that a Task carrying a
+// per-node endpoint override (BaseURL + APIKeyEnv) is resolved through the
+// registry's endpoint factory — NOT the shared env-based resolver — and that
+// the API key is read from os.Getenv(APIKeyEnv) at construction time (so it
+// never has to ride the Task). This is the mix-Opus-and-Kimi path.
+func TestClawBackend_PerNodeEndpointOverride(t *testing.T) {
+	reg := NewRegistry()
+	endpointMock := &execMockClient{
+		streams: []<-chan api.StreamEvent{mockStreamEvents("kimi says hi", "end_turn")},
+	}
+
+	// The plain (env-based) factory must NOT be consulted when the node
+	// pins its own endpoint — fail loudly if it is.
+	reg.Register("test", func(modelID string) (api.APIClient, error) {
+		t.Errorf("plain provider factory was called; expected the endpoint factory to be used for a node with BaseURL set")
+		return endpointMock, nil
+	})
+
+	var gotBaseURL, gotKey string
+	reg.providersWithEndpoint["test"] = func(modelID, baseURL, apiKey string) (api.APIClient, error) {
+		gotBaseURL, gotKey = baseURL, apiKey
+		return endpointMock, nil
+	}
+
+	t.Setenv("MY_KIMI_KEY", "sk-kimi-secret")
+
+	backend := NewClawBackend(reg, EventHooks{}, RetryPolicy{})
+
+	result, err := backend.Execute(context.Background(), delegate.Task{
+		NodeID:     "kimi_node",
+		Model:      "test/kimi-k2",
+		UserPrompt: "Say hi",
+		BaseURL:    "https://api.moonshot.ai/v1",
+		APIKeyEnv:  "MY_KIMI_KEY",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotBaseURL != "https://api.moonshot.ai/v1" {
+		t.Errorf("endpoint factory baseURL = %q, want %q", gotBaseURL, "https://api.moonshot.ai/v1")
+	}
+	if gotKey != "sk-kimi-secret" {
+		t.Errorf("endpoint factory apiKey = %q, want the value of $MY_KIMI_KEY", gotKey)
+	}
+	if result.Output["text"] != "kimi says hi" {
+		t.Errorf("text = %q, want %q", result.Output["text"], "kimi says hi")
+	}
+}
+
 // TestClawBackend_TextWithToolsAndSchema verifies the text+tools+schema strategy.
 func TestClawBackend_TextWithToolsAndSchema(t *testing.T) {
 	reg := NewRegistry()

--- a/pkg/backend/model/claw_registry_test.go
+++ b/pkg/backend/model/claw_registry_test.go
@@ -282,6 +282,76 @@ func TestClawRegistry_ResolveAfterUnknownProviderRegister(t *testing.T) {
 	}
 }
 
+// TestClawRegistry_ResolveWithEndpoint verifies the per-node endpoint
+// override path: ResolveWithEndpoint routes to the provider's endpoint
+// factory with the explicit base URL + key, never touches the shared cache
+// (each call rebuilds), and errors for a provider with no endpoint factory.
+func TestClawRegistry_ResolveWithEndpoint(t *testing.T) {
+	r := NewRegistry()
+	mock := &execMockClient{streams: []<-chan api.StreamEvent{mockStreamEvents("hi", "end_turn")}}
+
+	var calls int32
+	var gotModel, gotBaseURL, gotKey string
+	// Endpoint factories are keyed in providersWithEndpoint; the test lives
+	// in package model so it can inject a capturing one directly.
+	r.providersWithEndpoint["custom"] = func(modelID, baseURL, apiKey string) (api.APIClient, error) {
+		atomic.AddInt32(&calls, 1)
+		gotModel, gotBaseURL, gotKey = modelID, baseURL, apiKey
+		return mock, nil
+	}
+
+	c, err := r.ResolveWithEndpoint("custom/my-model", "https://facade.example/v1", "sk-secret")
+	if err != nil {
+		t.Fatalf("ResolveWithEndpoint: unexpected error: %v", err)
+	}
+	if c != mock {
+		t.Errorf("returned client = %v, want the endpoint factory's mock", c)
+	}
+	if gotModel != "my-model" {
+		t.Errorf("modelID = %q, want %q (provider prefix must be stripped)", gotModel, "my-model")
+	}
+	if gotBaseURL != "https://facade.example/v1" {
+		t.Errorf("baseURL = %q, want %q", gotBaseURL, "https://facade.example/v1")
+	}
+	if gotKey != "sk-secret" {
+		t.Errorf("apiKey = %q, want %q", gotKey, "sk-secret")
+	}
+
+	// Not cached: a second resolve must invoke the factory again (the
+	// endpoint + key are node-scoped, never shared across nodes).
+	if _, err := r.ResolveWithEndpoint("custom/my-model", "https://facade.example/v1", "sk-secret"); err != nil {
+		t.Fatalf("second ResolveWithEndpoint: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("endpoint factory called %d times, want 2 (uncached)", got)
+	}
+
+	// A provider with no endpoint factory is a loud error, not a silent
+	// fall-through to the env-based resolver.
+	if _, err := r.ResolveWithEndpoint("bedrock/some-model", "https://x/v1", "k"); err == nil {
+		t.Error("expected error for provider without an endpoint factory")
+	}
+}
+
+// TestClawRegistry_ResolveWithEndpoint_BuiltinProviders verifies the two
+// built-in endpoint factories (openai, anthropic) are wired and build a
+// client without error, and that an invalid spec is rejected.
+func TestClawRegistry_ResolveWithEndpoint_BuiltinProviders(t *testing.T) {
+	r := NewRegistry()
+	for _, spec := range []string{"openai/kimi-k2", "anthropic/claude-opus-4-8"} {
+		c, err := r.ResolveWithEndpoint(spec, "https://facade.example/v1", "sk-test")
+		if err != nil {
+			t.Errorf("ResolveWithEndpoint(%q): unexpected error: %v", spec, err)
+		}
+		if c == nil {
+			t.Errorf("ResolveWithEndpoint(%q): nil client", spec)
+		}
+	}
+	if _, err := r.ResolveWithEndpoint("no-slash", "https://x/v1", "k"); err == nil {
+		t.Error("expected error for malformed spec")
+	}
+}
+
 // providerNameForIdx returns a deterministic provider name for the given
 // index. Used by TestClawRegistry_ResolveConcurrentDifferentKeys.
 func providerNameForIdx(i int) string {

--- a/pkg/backend/model/executor_build_task.go
+++ b/pkg/backend/model/executor_build_task.go
@@ -21,6 +21,8 @@ type backendFields struct {
 	model            string
 	backend          string
 	provider         string
+	baseURL          string // per-node claw endpoint override (base_url:); "" = default
+	apiKeyEnv        string // env-var name holding the key for baseURL (api_key_env:); "" = unset
 	systemPrompt     string
 	userPrompt       string
 	reasoningEffort  string
@@ -50,6 +52,7 @@ func extractBackendFields(node ir.Node) (backendFields, error) {
 	case *ir.AgentNode:
 		return backendFields{
 			id: n.ID, model: n.Model, backend: n.Backend, provider: n.Provider,
+			baseURL: n.BaseURL, apiKeyEnv: n.APIKeyEnv,
 			systemPrompt: n.SystemPrompt, userPrompt: n.UserPrompt,
 			reasoningEffort: n.ReasoningEffort, outputSchema: n.OutputSchema,
 			tools: n.Tools, toolMaxSteps: n.ToolMaxSteps,
@@ -67,6 +70,7 @@ func extractBackendFields(node ir.Node) (backendFields, error) {
 	case *ir.JudgeNode:
 		return backendFields{
 			id: n.ID, model: n.Model, backend: n.Backend, provider: n.Provider,
+			baseURL: n.BaseURL, apiKeyEnv: n.APIKeyEnv,
 			systemPrompt: n.SystemPrompt, userPrompt: n.UserPrompt,
 			reasoningEffort: n.ReasoningEffort, outputSchema: n.OutputSchema,
 			tools: n.Tools, toolMaxSteps: n.ToolMaxSteps,
@@ -449,6 +453,16 @@ func (e *ClawExecutor) buildTask(ctx context.Context, node ir.Node, f backendFie
 		Sandbox:               e.sandbox,
 		// ProviderHint is set per-attempt by dispatchWithProviderFallback
 		// as it walks the node's provider chain.
+		//
+		// Per-node claw endpoint override (base_url:/api_key_env:). Env-expanded
+		// here so a recipe can defer the endpoint + key-var name to the process
+		// env (`base_url: "${KIMI_BASE_URL}"`). The key VALUE itself is never
+		// carried on the Task — only the env-var name is; the claw backend reads
+		// os.Getenv(APIKeyEnv) at client construction so the secret never enters
+		// the Task, the wire form, or any log line. Honoured only by backend=claw
+		// (compile-time C173 warns when set on another backend).
+		BaseURL:    ir.ExpandEnvWithDefault(f.baseURL),
+		APIKeyEnv:  ir.ExpandEnvWithDefault(f.apiKeyEnv),
 		Hooks:      e.delegateHooksFor(f.id, backendName, LoopIterationFromContext(ctx)),
 		InboxDrain: e.bindInboxDrain(ctx),
 	}

--- a/pkg/backend/model/registry.go
+++ b/pkg/backend/model/registry.go
@@ -30,6 +30,18 @@ type ProviderFactory func(modelID string) (api.APIClient, error)
 // available — the result is NOT cached (multi-tenant safety).
 type KeyedProviderFactory func(modelID, apiKey string) (api.APIClient, error)
 
+// EndpointProviderFactory builds an APIClient given BOTH an explicit base
+// URL and an explicit API key. Used by ResolveWithEndpoint for per-node
+// endpoint overrides (DSL base_url/api_key_env): unlike KeyedProviderFactory
+// (which honours only a key but still reads the base URL from the process
+// env), here the endpoint AND the key both come from the node, so one run
+// can pin a claw node at a third-party OpenAI-compatible facade (Kimi /
+// Moonshot) while another node hits the real Anthropic API — no global
+// OPENAI_BASE_URL/ANTHROPIC_BASE_URL needed. The result is NOT cached (the
+// key + endpoint are node-scoped). baseURL "" falls back to the provider's
+// default endpoint; apiKey "" is passed through (keyless / env-default).
+type EndpointProviderFactory func(modelID, baseURL, apiKey string) (api.APIClient, error)
+
 // cacheEntry holds a per-key sync.Once so concurrent resolves for the same
 // spec only invoke the factory once, without holding the registry lock for
 // the duration of slow factory I/O (e.g. AWS IMDS, Google ADC).
@@ -47,18 +59,20 @@ type cacheEntry struct {
 var claudeForfaitWarnOnce sync.Once
 
 type Registry struct {
-	mu               sync.Mutex
-	providers        map[string]ProviderFactory
-	providersWithKey map[string]KeyedProviderFactory
-	cache            map[string]*cacheEntry
+	mu                    sync.Mutex
+	providers             map[string]ProviderFactory
+	providersWithKey      map[string]KeyedProviderFactory
+	providersWithEndpoint map[string]EndpointProviderFactory
+	cache                 map[string]*cacheEntry
 }
 
 // NewRegistry creates a model registry pre-loaded with built-in providers.
 func NewRegistry() *Registry {
 	r := &Registry{
-		providers:        make(map[string]ProviderFactory),
-		providersWithKey: make(map[string]KeyedProviderFactory),
-		cache:            make(map[string]*cacheEntry),
+		providers:             make(map[string]ProviderFactory),
+		providersWithKey:      make(map[string]KeyedProviderFactory),
+		providersWithEndpoint: make(map[string]EndpointProviderFactory),
+		cache:                 make(map[string]*cacheEntry),
 	}
 	r.registerDefaults()
 	return r
@@ -199,6 +213,28 @@ func (r *Registry) registerDefaults() {
 			APIKey:  apiKey,
 			Model:   modelID,
 			BaseURL: os.Getenv("OPENAI_BASE_URL"),
+		}))
+	}
+	// Per-node endpoint override (DSL base_url/api_key_env). Both the base
+	// URL and the key come from the node, so this is the path that mixes a
+	// third-party OpenAI-compatible facade (Kimi/Moonshot) with a real
+	// Anthropic node in one run. An explicit base URL deliberately bypasses
+	// the ChatGPT-OAuth path (same as an explicit OPENAI_BASE_URL) so no
+	// codex_cli headers ever masquerade to a third party.
+	r.providersWithEndpoint["openai"] = func(modelID, baseURL, apiKey string) (api.APIClient, error) {
+		p := openaiprovider.New()
+		return p.NewClient(withClientIdentity(api.ProviderConfig{
+			APIKey:  apiKey,
+			Model:   modelID,
+			BaseURL: baseURL,
+		}))
+	}
+	r.providersWithEndpoint["anthropic"] = func(modelID, baseURL, apiKey string) (api.APIClient, error) {
+		p := anthropicprovider.New()
+		return p.NewClient(withClientIdentity(api.ProviderConfig{
+			APIKey:  apiKey,
+			Model:   modelID,
+			BaseURL: baseURL,
 		}))
 	}
 	// AWS Bedrock — auth via aws-sdk-go-v2 standard credential chain
@@ -408,6 +444,37 @@ func (r *Registry) ResolveWithContext(ctx context.Context, spec string) (api.API
 		return r.Resolve(spec)
 	}
 	return factory(modelID, overrideKey)
+}
+
+// ResolveWithEndpoint builds a fresh (never cached) APIClient for spec
+// using an explicit base URL and API key, bypassing the process-env
+// endpoint resolution. It backs the per-node claw endpoint override (DSL
+// base_url/api_key_env), letting one run mix a real Opus node with a
+// third-party OpenAI-compatible node (Kimi/Moonshot) without a global
+// OPENAI_BASE_URL/ANTHROPIC_BASE_URL.
+//
+// The result is intentionally NOT cached: the endpoint + key are
+// node-scoped, and caching them against a bare modelID would leak one
+// node's facade onto another node that shares the model id. Only providers
+// that expose an EndpointProviderFactory (openai, anthropic) are
+// supported; any other provider returns an error so a misconfigured node
+// fails loudly instead of silently ignoring the override.
+func (r *Registry) ResolveWithEndpoint(spec, baseURL, apiKey string) (api.APIClient, error) {
+	providerName, modelID, err := ParseModelSpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	r.mu.Lock()
+	factory, ok := r.providersWithEndpoint[providerName]
+	r.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("model: provider %q does not support a per-node endpoint override (base_url/api_key_env); supported: anthropic, openai", providerName)
+	}
+	client, err := factory(modelID, baseURL, apiKey)
+	if err != nil {
+		return nil, fmt.Errorf("model: provider %q failed to create model %q with endpoint override: %w", providerName, modelID, err)
+	}
+	return client, nil
 }
 
 // credentialsLookup returns a closure that maps a provider name to

--- a/pkg/dsl/ast/ast.go
+++ b/pkg/dsl/ast/ast.go
@@ -442,6 +442,8 @@ type LLMDecl struct {
 	Model             string // string literal, may contain ${...} env refs
 	Backend           string // execution backend name (e.g. "claude_code"); when set, bypasses direct LLM API
 	Provider          string // credential routing hint(s): single ("anthropic"/"zai"/"openai"/""=auto) or an ordered fallback chain ("anthropic,zai,openai"); may contain ${...} env refs
+	BaseURL           string // per-node claw endpoint override (OpenAI/Anthropic-compatible facade); may contain ${...} env refs
+	APIKeyEnv         string // name of the env var holding the API key for BaseURL; the value is read at client construction, never inlined; may contain ${...} env refs
 	MCP               *MCPConfigDecl
 	Input             string           // schema reference name
 	Output            string           // schema reference name

--- a/pkg/dsl/ir/compile.go
+++ b/pkg/dsl/ir/compile.go
@@ -775,6 +775,8 @@ func (c *compiler) buildLLMNodeShared(kind, name string, d *ast.LLMDecl) (LLMFie
 			Model:           model,
 			Backend:         d.Backend,
 			Provider:        d.Provider,
+			BaseURL:         d.BaseURL,
+			APIKeyEnv:       d.APIKeyEnv,
 			SystemPrompt:    d.System,
 			UserPrompt:      d.User,
 			MaxTokens:       d.MaxTokens,

--- a/pkg/dsl/ir/endpoint_override_test.go
+++ b/pkg/dsl/ir/endpoint_override_test.go
@@ -1,0 +1,119 @@
+package ir
+
+import "testing"
+
+// endpointSrc builds a minimal one-agent workflow with the given backend
+// and per-node endpoint override fields so the endpoint-override compile +
+// validation path can be exercised in isolation. Empty base_url/api_key_env
+// values are omitted so the "unset" case can be tested too.
+func endpointSrc(backend, baseURL, apiKeyEnv string) string {
+	src := `
+schema empty:
+  ok: bool
+
+prompt sys:
+  body
+  hello
+
+agent writer:
+  model: "openai/kimi-k2"
+  backend: "` + backend + `"
+`
+	if baseURL != "" {
+		src += `  base_url: "` + baseURL + `"` + "\n"
+	}
+	if apiKeyEnv != "" {
+		src += `  api_key_env: "` + apiKeyEnv + `"` + "\n"
+	}
+	src += `  system: sys
+  output: empty
+
+workflow w:
+  entry: writer
+  writer -> done
+`
+	return src
+}
+
+// TestEndpointOverride_PopulatesLLMFields verifies base_url/api_key_env flow
+// from the DSL through the parser and compiler onto the node's LLMFields.
+func TestEndpointOverride_PopulatesLLMFields(t *testing.T) {
+	w := mustCompile(t, endpointSrc("claw", "https://api.moonshot.ai/v1", "MOONSHOT_API_KEY"))
+	n, ok := w.Nodes["writer"].(*AgentNode)
+	if !ok {
+		t.Fatalf("writer node = %T, want *AgentNode", w.Nodes["writer"])
+	}
+	if n.BaseURL != "https://api.moonshot.ai/v1" {
+		t.Errorf("BaseURL = %q, want %q", n.BaseURL, "https://api.moonshot.ai/v1")
+	}
+	if n.APIKeyEnv != "MOONSHOT_API_KEY" {
+		t.Errorf("APIKeyEnv = %q, want %q", n.APIKeyEnv, "MOONSHOT_API_KEY")
+	}
+}
+
+// TestEndpointOverride_NoFieldsLeavesEmpty verifies the fields default to
+// empty when the DSL omits them (so the claw backend takes the normal
+// env-fallback resolve path).
+func TestEndpointOverride_NoFieldsLeavesEmpty(t *testing.T) {
+	w := mustCompile(t, endpointSrc("claw", "", ""))
+	n := w.Nodes["writer"].(*AgentNode)
+	if n.BaseURL != "" || n.APIKeyEnv != "" {
+		t.Errorf("expected empty override fields, got BaseURL=%q APIKeyEnv=%q", n.BaseURL, n.APIKeyEnv)
+	}
+}
+
+// TestEndpointOverride_OnClawNoWarning verifies claw honours the override, so
+// no C173 is emitted.
+func TestEndpointOverride_OnClawNoWarning(t *testing.T) {
+	r := compileFile(t, endpointSrc("claw", "https://api.moonshot.ai/v1", "MOONSHOT_API_KEY"))
+	expectNoDiag(t, r, DiagEndpointOverrideIgnored)
+}
+
+// TestEndpointOverride_UnsetBackendNoWarning verifies an unset backend
+// (defaults to claw at runtime) does not warn.
+func TestEndpointOverride_UnsetBackendNoWarning(t *testing.T) {
+	// An unset backend can't be expressed via endpointSrc (it always emits
+	// backend:), so build the source inline without a backend line.
+	src := `
+schema empty:
+  ok: bool
+
+prompt sys:
+  body
+  hello
+
+agent writer:
+  model: "openai/kimi-k2"
+  base_url: "https://api.moonshot.ai/v1"
+  api_key_env: "MOONSHOT_API_KEY"
+  system: sys
+  output: empty
+
+workflow w:
+  entry: writer
+  writer -> done
+`
+	r := compileFile(t, src)
+	expectNoDiag(t, r, DiagEndpointOverrideIgnored)
+}
+
+// TestEndpointOverride_OnClaudeCodeWarns verifies C173 fires when the fields
+// are set on a backend (claude_code) that ignores them.
+func TestEndpointOverride_OnClaudeCodeWarns(t *testing.T) {
+	r := compileFile(t, endpointSrc("claude_code", "https://api.moonshot.ai/v1", "MOONSHOT_API_KEY"))
+	expectDiag(t, r, DiagEndpointOverrideIgnored)
+}
+
+// TestEndpointOverride_ApiKeyEnvAloneWarnsOnCodex verifies the warning fires
+// even when only api_key_env (no base_url) is set on an ignoring backend.
+func TestEndpointOverride_ApiKeyEnvAloneWarnsOnCodex(t *testing.T) {
+	r := compileFile(t, endpointSrc("codex", "", "MOONSHOT_API_KEY"))
+	expectDiag(t, r, DiagEndpointOverrideIgnored)
+}
+
+// TestEndpointOverride_EnvRefBackendSkipsValidation verifies a backend given
+// as a ${VAR} env ref is not judged at compile time (no false C173).
+func TestEndpointOverride_EnvRefBackendSkipsValidation(t *testing.T) {
+	r := compileFile(t, endpointSrc("${BACKEND:-claw}", "https://api.moonshot.ai/v1", "MOONSHOT_API_KEY"))
+	expectNoDiag(t, r, DiagEndpointOverrideIgnored)
+}

--- a/pkg/dsl/ir/ir.go
+++ b/pkg/dsl/ir/ir.go
@@ -157,6 +157,8 @@ type LLMFields struct {
 	Model           string // model identifier (env refs already noted)
 	Backend         string // execution backend name (empty = direct LLM call); may contain ${VAR} env refs
 	Provider        string // credential routing hint(s): single ("anthropic"/"zai"/"openai"/""=auto) or an ordered fallback chain ("anthropic,zai,openai"); may contain ${VAR} env refs
+	BaseURL         string // per-node claw endpoint override (OpenAI/Anthropic-compatible facade); honoured only by backend=claw; may contain ${VAR} env refs
+	APIKeyEnv       string // name of the env var holding the API key for BaseURL; the value is read at claw client construction, never inlined/logged; may contain ${VAR} env refs
 	SystemPrompt    string // prompt reference name
 	UserPrompt      string // prompt reference name
 	MaxTokens       int    // per-node cap on output tokens (0 = backend default)

--- a/pkg/dsl/ir/validate.go
+++ b/pkg/dsl/ir/validate.go
@@ -37,6 +37,7 @@ func (c *compiler) validate(w *Workflow) {
 	c.validatePlaywrightMCP(w)
 	c.validateCapabilities(w)
 	c.validateProviders(w)
+	c.validateEndpointOverride(w)
 	c.validateCursorInvocations(w)
 	c.validateReviewGates(w)
 	c.validateCompress(w)

--- a/pkg/dsl/ir/validate_provider.go
+++ b/pkg/dsl/ir/validate_provider.go
@@ -4,10 +4,23 @@ import "strings"
 
 // Provider-routing diagnostics.
 const (
-	DiagUnknownProvider       DiagCode = "C087" // provider chain token outside the known set (warning)
-	DiagProviderChainIgnored  DiagCode = "C088" // multi-provider chain on a backend that ignores the hint (warning)
-	DiagMalformedProviderStep DiagCode = "C172" // provider chain element of the `provider:model` form with an empty provider or model part (warning)
+	DiagUnknownProvider         DiagCode = "C087" // provider chain token outside the known set (warning)
+	DiagProviderChainIgnored    DiagCode = "C088" // multi-provider chain on a backend that ignores the hint (warning)
+	DiagMalformedProviderStep   DiagCode = "C172" // provider chain element of the `provider:model` form with an empty provider or model part (warning)
+	DiagEndpointOverrideIgnored DiagCode = "C173" // base_url/api_key_env on a backend other than claw, which ignores them (warning)
 )
+
+// endpointHonoringBackends is the set of backends that consume the per-node
+// endpoint override (base_url/api_key_env). Only claw builds its API client
+// in-process, so only claw can honour a node-scoped endpoint + key; the
+// CLI-based backends (claude_code/codex) resolve their credentials from the
+// process env / their own auth files and ignore these fields. An unset
+// backend defaults to claw at runtime, so it is treated as honoring too.
+var endpointHonoringBackends = map[string]bool{
+	"":     true, // unset → defaults to claw
+	"claw": true,
+	"auto": true, // resolves to a detected backend; claw when claw creds present
+}
 
 // KnownProviders is the set of credential-routing hints the runtime
 // understands for the per-node `provider:` field (and its comma-separated
@@ -95,6 +108,42 @@ func (c *compiler) validateProviders(w *Workflow) {
 		case *RouterNode:
 			if nn.RouterMode == RouterLLM {
 				check("router", nn.ID, nn.Backend, nn.Provider)
+			}
+		}
+	}
+}
+
+// validateEndpointOverride walks every LLM-capable node and warns (C173)
+// when a per-node endpoint override (base_url / api_key_env) is set on a
+// backend that does not build its own API client in-process. Only claw
+// consumes these fields; claude_code/codex resolve credentials from the
+// process env / their own auth files and silently ignore them. Emitting a
+// warning (never an error) keeps the run going — the fields are simply
+// inert on those backends. A backend carrying a ${VAR} env ref is skipped:
+// its resolved value isn't known at compile time.
+func (c *compiler) validateEndpointOverride(w *Workflow) {
+	check := func(kind, id, backend, baseURL, apiKeyEnv string) {
+		if baseURL == "" && apiKeyEnv == "" {
+			return
+		}
+		if strings.Contains(backend, "${") {
+			return // resolves at run time; can't judge the literal
+		}
+		if endpointHonoringBackends[strings.TrimSpace(backend)] {
+			return
+		}
+		c.warnfAt(DiagEndpointOverrideIgnored, id, "",
+			"%s %q: base_url/api_key_env have no effect on backend=%q (only claw builds its API client in-process and honours a per-node endpoint); the fields are ignored",
+			kind, id, backend)
+	}
+	for _, n := range w.Nodes {
+		switch nn := n.(type) {
+		case LLMNode:
+			f := nn.GetLLMFields()
+			check(nn.NodeKind().String(), nn.NodeID(), f.Backend, f.BaseURL, f.APIKeyEnv)
+		case *RouterNode:
+			if nn.RouterMode == RouterLLM {
+				check("router", nn.ID, nn.Backend, nn.BaseURL, nn.APIKeyEnv)
 			}
 		}
 	}

--- a/pkg/dsl/parser/parser_helpers.go
+++ b/pkg/dsl/parser/parser_helpers.go
@@ -233,7 +233,7 @@ func isKeywordToken(tt TokenType) bool {
 		TokenAuth, TokenReadonly,
 		TokenDefaultBackend,
 		TokenInteraction, TokenInteractionPrompt, TokenInteractionModel,
-		TokenBackend, TokenProvider, TokenAwait, TokenWhen, TokenNot, TokenAs,
+		TokenBackend, TokenProvider, TokenBaseURL, TokenAPIKeyEnv, TokenAwait, TokenWhen, TokenNot, TokenAs,
 		TokenWith, TokenEnum, TokenFresh, TokenInherit, TokenArtifactsOnly,
 		TokenFork,
 		TokenFanOutAll, TokenCondition, TokenRoundRobin, TokenLLM, TokenMulti,

--- a/pkg/dsl/parser/parser_nodes.go
+++ b/pkg/dsl/parser/parser_nodes.go
@@ -102,6 +102,12 @@ func (p *parser) parseLLMProp(d *ast.LLMDecl, propTok Token, kind string) {
 	case TokenProvider:
 		p.expect(TokenColon)
 		d.Provider = p.expectString()
+	case TokenBaseURL:
+		p.expect(TokenColon)
+		d.BaseURL = p.expectString()
+	case TokenAPIKeyEnv:
+		p.expect(TokenColon)
+		d.APIKeyEnv = p.expectString()
 	case TokenInteraction:
 		p.expect(TokenColon)
 		d.Interaction = p.parseInteractionMode()

--- a/pkg/dsl/parser/parser_test.go
+++ b/pkg/dsl/parser/parser_test.go
@@ -523,6 +523,24 @@ func TestRouterDeclLLMWithBackend(t *testing.T) {
 	assertEq(t, "System", r.System, "my_prompt")
 }
 
+func TestAgentEndpointOverride(t *testing.T) {
+	src := `agent kimi:
+  model: "openai/kimi-k2"
+  backend: "claw"
+  base_url: "https://api.moonshot.ai/v1"
+  api_key_env: "MOONSHOT_API_KEY"
+`
+	res := parser.Parse("test.bot", src)
+	assertNoDiags(t, res)
+
+	if len(res.File.Agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(res.File.Agents))
+	}
+	a := res.File.Agents[0]
+	assertEq(t, "BaseURL", a.BaseURL, "https://api.moonshot.ai/v1")
+	assertEq(t, "APIKeyEnv", a.APIKeyEnv, "MOONSHOT_API_KEY")
+}
+
 func TestHumanDecl(t *testing.T) {
 	src := `human review:
   input: review_in

--- a/pkg/dsl/parser/token.go
+++ b/pkg/dsl/parser/token.go
@@ -91,6 +91,8 @@ const (
 	TokenNeeds
 	TokenDefaultBackend
 	TokenProvider
+	TokenBaseURL
+	TokenAPIKeyEnv
 	TokenInteraction
 	TokenInteractionPrompt
 	TokenInteractionModel
@@ -262,6 +264,8 @@ var tokenNames = map[TokenType]string{
 	TokenNeeds:              "needs",
 	TokenDefaultBackend:     "default_backend",
 	TokenProvider:           "provider",
+	TokenBaseURL:            "base_url",
+	TokenAPIKeyEnv:          "api_key_env",
 	TokenInteraction:        "interaction",
 	TokenInteractionPrompt:  "interaction_prompt",
 	TokenInteractionModel:   "interaction_model",
@@ -399,6 +403,8 @@ var keywords = map[string]TokenType{
 	"needs":                 TokenNeeds,
 	"default_backend":       TokenDefaultBackend,
 	"provider":              TokenProvider,
+	"base_url":              TokenBaseURL,
+	"api_key_env":           TokenAPIKeyEnv,
 	"interaction":           TokenInteraction,
 	"interaction_prompt":    TokenInteractionPrompt,
 	"interaction_model":     TokenInteractionModel,

--- a/pkg/dsl/unparse/unparse.go
+++ b/pkg/dsl/unparse/unparse.go
@@ -203,6 +203,7 @@ func (w *fileWriter) writeAgents(agents []*ast.AgentDecl) {
 		}
 		writeAgentFields(&w.b, llmFields{
 			Model: a.Model, Backend: a.Backend, Provider: a.Provider,
+			BaseURL: a.BaseURL, APIKeyEnv: a.APIKeyEnv,
 			Input: a.Input, Output: a.Output, Publish: a.Publish,
 			System: a.System, User: a.User, Session: a.Session,
 			Tools: a.Tools, ToolPolicy: a.ToolPolicy, Capabilities: a.Capabilities,
@@ -233,6 +234,7 @@ func (w *fileWriter) writeJudges(judges []*ast.JudgeDecl) {
 		}
 		writeAgentFields(&w.b, llmFields{
 			Model: j.Model, Backend: j.Backend, Provider: j.Provider,
+			BaseURL: j.BaseURL, APIKeyEnv: j.APIKeyEnv,
 			Input: j.Input, Output: j.Output, Publish: j.Publish,
 			System: j.System, User: j.User, Session: j.Session,
 			Tools: j.Tools, ToolPolicy: j.ToolPolicy, Capabilities: j.Capabilities,
@@ -826,6 +828,7 @@ func quoteList(vals []string) string {
 // / ast.JudgeDecl so the call-site literals read as a direct projection.
 type llmFields struct {
 	Model, Backend, Provider            string
+	BaseURL, APIKeyEnv                  string
 	Input, Output, Publish              string
 	System, User                        string
 	Session                             ast.SessionMode
@@ -851,6 +854,12 @@ func writeAgentFields(b *strings.Builder, f llmFields) {
 	}
 	if f.Provider != "" {
 		writeQuotedProp(b, "provider", f.Provider)
+	}
+	if f.BaseURL != "" {
+		writeQuotedProp(b, "base_url", f.BaseURL)
+	}
+	if f.APIKeyEnv != "" {
+		writeQuotedProp(b, "api_key_env", f.APIKeyEnv)
 	}
 	if f.Input != "" {
 		writeIdentProp(b, "input", f.Input)


### PR DESCRIPTION
## Summary

Adds two per-node DSL fields on `agent`/`judge` (`backend: claw`) so a single run can mix a **real Opus** node and a **third-party OpenAI-compatible** node (e.g. Kimi/Moonshot) without a global `OPENAI_BASE_URL`/`ANTHROPIC_BASE_URL`:

- `base_url:` — per-node claw endpoint override (OpenAI/Anthropic-compatible facade), `${VAR}`-expandable.
- `api_key_env:` — the **name** of the env var holding the key for that endpoint; the value is read via `os.Getenv` **at client construction** and never rides the task, the sandbox IPC wire form, or any log line.

```iter
agent kimi_reviewer:
  backend: "claw"
  model: "openai/kimi-k2"
  base_url: "https://api.moonshot.ai/v1"
  api_key_env: "MOONSHOT_API_KEY"
```

## How

- **DSL/IR**: new tokens `base_url`/`api_key_env` (`token.go`), fields on `LLMDecl` (`ast.go`) and `LLMFields` (`ir.go`), parsed in `parser_nodes.go`, compiled in `compile.go`.
- **Thread**: `backendFields` → `buildTask` env-expands and sets `Task.BaseURL`/`Task.APIKeyEnv` → carried on `delegate.Task` (+ `IOTask` for the sandbox path).
- **Client construction**: new `Registry.ResolveWithEndpoint` builds a **fresh, uncached** client (endpoint + key are node-scoped) via a per-provider `EndpointProviderFactory` registered for `openai` and `anthropic`. `ClawBackend.Execute` takes this path when `BaseURL`/`APIKeyEnv` is set, otherwise the unchanged `ResolveWithContext` path. An explicit `base_url` on an `openai/…` node deliberately bypasses the ChatGPT-OAuth path.
- **Guardrail**: only `claw` consumes these fields; setting them on `claude_code`/`codex` warns **C173** at compile time (`validateEndpointOverride`), documented in `docs/references/diagnostics.md`.
- **Round-trip**: the unparser emits both fields for parse→unparse parity.

## Tests

- Parser: `base_url`/`api_key_env` populate the AST/`LLMFields`.
- Compile/validation: C173 fires on `claude_code`/`codex`, not on `claw` or an unset backend; a `${VAR}` backend is skipped.
- Registry: `ResolveWithEndpoint` dispatches to the endpoint factory with the right base URL + key, is uncached, and errors for unsupported providers.
- Backend: `ClawBackend.Execute` with `BaseURL`+`APIKeyEnv` routes through the endpoint factory (not the env resolver) and reads the key from `os.Getenv`.

## Verification

```
go build ./...
go vet ./pkg/dsl/... ./pkg/backend/...
go test ./pkg/dsl/... ./pkg/backend/... -count=1
```
All green; `gofmt` clean.

## Known limitation

For a **sandboxed** claw node the fields are threaded through `IOTask` and the in-container runner reads `os.Getenv(api_key_env)`, but the sandbox only forwards a fixed allow-list of provider env vars — a custom `api_key_env` name is not yet forwarded into the container. Noted in `docs/backends.md`; the override applies to the in-process (default) path today.

> Draft: verified locally (build, vet, gofmt, unit tests on touched packages); opening as draft pending full CI review.

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)
