### PR TITLE
feat(dsl): per-node command: override for a claude-code-compatible CLI on claude_code

### DIFF
--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -77,6 +77,7 @@ agent reviewer:
 |----------|-------------|
 | `model` | LLM model identifier (supports `${ENV_VAR}`) |
 | `backend` | Execution backend: `claw` (default, in-process LLM), `claude_code` (recommended for tool use), `codex` (discouraged, see [Delegation](delegation.md)) |
+| `command` | Per-node CLI binary override, honored by the `claude_code` backend: replaces the default `claude` CLI with another claude-code-compatible binary (e.g. `kimi`) so a single run can mix an Opus node and a Kimi node, both via the CLI. Supports `${ENV_VAR}`. Ignored (with a `C174` warning) on `claw`/`codex`. |
 | `input` / `output` | Schema references for structured I/O |
 | `publish` | Persist output as a named artifact |
 | `system` / `user` | Prompt references |

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -77,7 +77,7 @@ agent reviewer:
 |----------|-------------|
 | `model` | LLM model identifier (supports `${ENV_VAR}`) |
 | `backend` | Execution backend: `claw` (default, in-process LLM), `claude_code` (recommended for tool use), `codex` (discouraged, see [Delegation](delegation.md)) |
-| `command` | Per-node CLI binary override, honored by the `claude_code` backend: replaces the default `claude` CLI with another claude-code-compatible binary (e.g. `kimi`) so a single run can mix an Opus node and a Kimi node, both via the CLI. Supports `${ENV_VAR}`. Ignored (with a `C174` warning) on `claw`/`codex`. |
+| `command` | Per-node CLI binary override, honored by the `claude_code` backend: run this node with an alternate **claude-code-compatible** CLI instead of the default `claude` (e.g. a pinned build or a compatible wrapper). The target must speak the claude-code CLI protocol (Session mode: `--print`, `--input-format`/`--output-format stream-json` with the prompt on stdin, `--permission-mode`, `--append-system-prompt`) — a CLI with a different interface is **not** supported. Swaps the **binary only**, not credentials/endpoint. Supports `${ENV_VAR}`. Ignored (with a `C174` warning) on `claw`/`codex`. |
 | `input` / `output` | Schema references for structured I/O |
 | `publish` | Persist output as a named artifact |
 | `system` / `user` | Prompt references |

--- a/docs/references/diagnostics.md
+++ b/docs/references/diagnostics.md
@@ -111,6 +111,7 @@ All diagnostic codes emitted during compilation (`ir.Compile`) and validation (`
 | **C170** | error | Invalid memory visibility | `memory: visibility:` has an unknown value | Use a known visibility (`bot`/`project`/`cross_project`/`user`/`org`/`global`) |
 | **C171** | error | Memory visibility conflict | `memory: visibility:` is combined with the legacy `project_root:` | Use `visibility:` alone — drop the legacy `project_root:` |
 | **C172** | warning | Malformed provider step | A `provider:` chain element of the `provider:model` form has an empty provider or model part | Provide both parts, e.g. `anthropic:claude-sonnet-4-6` |
+| **C174** | warning | Command ignored | A per-node `command:` CLI-binary override is set on a backend that ignores it (`claw`/`codex`) — only `claude_code` honors it | Switch to `backend: "claude_code"`, or drop the `command:` |
 | **C190** | warning | Supervisor watches non-agent | A `supervisor` `watches:` a node id that isn't an agent node | Watch an agent node, or fix the node id |
 | **C191** | warning | Malformed supervisor | A `supervisor` declaration is malformed (e.g. a bad cooldown duration) | Use a valid Go duration for cooldown |
 | **C192** | error | Duplicate supervisor | The same `supervisor <name>:` is declared twice | Rename or merge |

--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -120,8 +120,9 @@ func (b *ClaudeCodeBackend) buildTransportOptions(task Task) []claudesdk.Option 
 	}
 	opts = append(opts, claudesdk.WithModel(model))
 
-	// CLI binary path: the per-node task override (DSL `command:`, e.g.
-	// "kimi") wins over the backend-level default; the shared backend is
+	// CLI binary path: the per-node task override (DSL `command:`, an
+	// alternate claude-code-compatible CLI) wins over the backend-level
+	// default; the shared backend is
 	// left unmutated so it can serve other nodes with their own override.
 	cliPath := b.Command
 	if task.Command != "" {
@@ -709,8 +710,9 @@ func (b *ClaudeCodeBackend) formatOutput(ctx context.Context, task Task, session
 		model = defaultClaudeCodeModel
 	}
 	opts = append(opts, claudesdk.WithModel(model))
-	// CLI binary path: the per-node task override (DSL `command:`, e.g.
-	// "kimi") wins over the backend-level default; the shared backend is
+	// CLI binary path: the per-node task override (DSL `command:`, an
+	// alternate claude-code-compatible CLI) wins over the backend-level
+	// default; the shared backend is
 	// left unmutated so it can serve other nodes with their own override.
 	cliPath := b.Command
 	if task.Command != "" {

--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -120,8 +120,15 @@ func (b *ClaudeCodeBackend) buildTransportOptions(task Task) []claudesdk.Option 
 	}
 	opts = append(opts, claudesdk.WithModel(model))
 
-	if b.Command != "" {
-		opts = append(opts, claudesdk.WithCLIPath(b.Command))
+	// CLI binary path: the per-node task override (DSL `command:`, e.g.
+	// "kimi") wins over the backend-level default; the shared backend is
+	// left unmutated so it can serve other nodes with their own override.
+	cliPath := b.Command
+	if task.Command != "" {
+		cliPath = task.Command
+	}
+	if cliPath != "" {
+		opts = append(opts, claudesdk.WithCLIPath(cliPath))
 	}
 
 	// When the run is sandboxed, route the claude CLI subprocess
@@ -702,8 +709,15 @@ func (b *ClaudeCodeBackend) formatOutput(ctx context.Context, task Task, session
 		model = defaultClaudeCodeModel
 	}
 	opts = append(opts, claudesdk.WithModel(model))
-	if b.Command != "" {
-		opts = append(opts, claudesdk.WithCLIPath(b.Command))
+	// CLI binary path: the per-node task override (DSL `command:`, e.g.
+	// "kimi") wins over the backend-level default; the shared backend is
+	// left unmutated so it can serve other nodes with their own override.
+	cliPath := b.Command
+	if task.Command != "" {
+		cliPath = task.Command
+	}
+	if cliPath != "" {
+		opts = append(opts, claudesdk.WithCLIPath(cliPath))
 	}
 
 	// Capture every spawned subprocess so promptWithTimeout can SIGKILL

--- a/pkg/backend/delegate/delegate.go
+++ b/pkg/backend/delegate/delegate.go
@@ -317,6 +317,13 @@ type Task struct {
 	// Required for API-based backends; ignored by CLI-based backends.
 	Model string
 
+	// Command is the per-node CLI binary override (env-expanded). Honored
+	// only by claude_code, where it replaces the default `claude` binary
+	// with another claude-code-compatible CLI (e.g. `kimi`). It takes
+	// precedence over the backend-level Command default. Empty means "use
+	// the backend default"; ignored by all other backends.
+	Command string
+
 	// HasTools indicates whether the node has tools, enabling backends to
 	// choose between structured-output and text-with-tools generation strategies.
 	HasTools bool

--- a/pkg/backend/delegate/delegate.go
+++ b/pkg/backend/delegate/delegate.go
@@ -319,7 +319,7 @@ type Task struct {
 
 	// Command is the per-node CLI binary override (env-expanded). Honored
 	// only by claude_code, where it replaces the default `claude` binary
-	// with another claude-code-compatible CLI (e.g. `kimi`). It takes
+	// with an alternate claude-code-compatible CLI (a pinned build or wrapper). It takes
 	// precedence over the backend-level Command default. Empty means "use
 	// the backend default"; ignored by all other backends.
 	Command string

--- a/pkg/backend/model/executor_build_task.go
+++ b/pkg/backend/model/executor_build_task.go
@@ -21,6 +21,7 @@ type backendFields struct {
 	model            string
 	backend          string
 	provider         string
+	command          string // node-level `command:` CLI binary override (honored by claude_code)
 	systemPrompt     string
 	userPrompt       string
 	reasoningEffort  string
@@ -50,6 +51,7 @@ func extractBackendFields(node ir.Node) (backendFields, error) {
 	case *ir.AgentNode:
 		return backendFields{
 			id: n.ID, model: n.Model, backend: n.Backend, provider: n.Provider,
+			command:      n.Command,
 			systemPrompt: n.SystemPrompt, userPrompt: n.UserPrompt,
 			reasoningEffort: n.ReasoningEffort, outputSchema: n.OutputSchema,
 			tools: n.Tools, toolMaxSteps: n.ToolMaxSteps,
@@ -67,6 +69,7 @@ func extractBackendFields(node ir.Node) (backendFields, error) {
 	case *ir.JudgeNode:
 		return backendFields{
 			id: n.ID, model: n.Model, backend: n.Backend, provider: n.Provider,
+			command:      n.Command,
 			systemPrompt: n.SystemPrompt, userPrompt: n.UserPrompt,
 			reasoningEffort: n.ReasoningEffort, outputSchema: n.OutputSchema,
 			tools: n.Tools, toolMaxSteps: n.ToolMaxSteps,
@@ -452,6 +455,9 @@ func (e *ClawExecutor) buildTask(ctx context.Context, node ir.Node, f backendFie
 		Hooks:      e.delegateHooksFor(f.id, backendName, LoopIterationFromContext(ctx)),
 		InboxDrain: e.bindInboxDrain(ctx),
 	}
+	// Per-node CLI binary override (env-expanded). Only claude_code consumes
+	// it; other backends ignore Task.Command. Empty = backend default.
+	task.Command = ir.ExpandEnvWithDefault(f.command)
 	// Command-output compression mode (precedence: run override > node DSL >
 	// workflow DSL > ITERION_COMPRESS env). Stored as a string so the delegate
 	// layer + IPC wire form stay decoupled from the rewrite enum; "" (off) is

--- a/pkg/dsl/ast/ast.go
+++ b/pkg/dsl/ast/ast.go
@@ -442,6 +442,7 @@ type LLMDecl struct {
 	Model             string // string literal, may contain ${...} env refs
 	Backend           string // execution backend name (e.g. "claude_code"); when set, bypasses direct LLM API
 	Provider          string // credential routing hint(s): single ("anthropic"/"zai"/"openai"/""=auto) or an ordered fallback chain ("anthropic,zai,openai"); may contain ${...} env refs
+	Command           string // per-node CLI binary override, honored by claude_code (default "claude"); may contain ${...} env refs
 	MCP               *MCPConfigDecl
 	Input             string           // schema reference name
 	Output            string           // schema reference name

--- a/pkg/dsl/ast/jsonenc.go
+++ b/pkg/dsl/ast/jsonenc.go
@@ -282,6 +282,7 @@ type jsonAgentDecl struct {
 	Model             string               `json:"model,omitempty"`
 	Backend           string               `json:"backend,omitempty"`
 	Provider          string               `json:"provider,omitempty"`
+	Command           string               `json:"command,omitempty"`
 	MCP               *jsonMCPConfigDecl   `json:"mcp,omitempty"`
 	Input             string               `json:"input,omitempty"`
 	Output            string               `json:"output,omitempty"`
@@ -315,6 +316,7 @@ type jsonJudgeDecl struct {
 	Model             string               `json:"model,omitempty"`
 	Backend           string               `json:"backend,omitempty"`
 	Provider          string               `json:"provider,omitempty"`
+	Command           string               `json:"command,omitempty"`
 	MCP               *jsonMCPConfigDecl   `json:"mcp,omitempty"`
 	Input             string               `json:"input,omitempty"`
 	Output            string               `json:"output,omitempty"`
@@ -1008,6 +1010,7 @@ func agentToJSON(a *AgentDecl) *jsonAgentDecl {
 		Model:             a.Model,
 		Backend:           a.Backend,
 		Provider:          a.Provider,
+		Command:           a.Command,
 		MCP:               mcpConfigToJSON(a.MCP),
 		Input:             a.Input,
 		Output:            a.Output,
@@ -1043,6 +1046,7 @@ func judgeToJSON(j *JudgeDecl) *jsonJudgeDecl {
 		Model:             j.Model,
 		Backend:           j.Backend,
 		Provider:          j.Provider,
+		Command:           j.Command,
 		MCP:               mcpConfigToJSON(j.MCP),
 		Input:             j.Input,
 		Output:            j.Output,
@@ -1505,6 +1509,7 @@ func agentFromJSON(ja *jsonAgentDecl) (*AgentDecl, error) {
 			Model:             ja.Model,
 			Backend:           ja.Backend,
 			Provider:          ja.Provider,
+			Command:           ja.Command,
 			MCP:               mcpConfigFromJSON(ja.MCP),
 			Input:             ja.Input,
 			Output:            ja.Output,
@@ -1554,6 +1559,7 @@ func judgeFromJSON(jj *jsonJudgeDecl) (*JudgeDecl, error) {
 			Model:             jj.Model,
 			Backend:           jj.Backend,
 			Provider:          jj.Provider,
+			Command:           jj.Command,
 			MCP:               mcpConfigFromJSON(jj.MCP),
 			Input:             jj.Input,
 			Output:            jj.Output,

--- a/pkg/dsl/ir/compile.go
+++ b/pkg/dsl/ir/compile.go
@@ -775,6 +775,7 @@ func (c *compiler) buildLLMNodeShared(kind, name string, d *ast.LLMDecl) (LLMFie
 			Model:           model,
 			Backend:         d.Backend,
 			Provider:        d.Provider,
+			Command:         d.Command,
 			SystemPrompt:    d.System,
 			UserPrompt:      d.User,
 			MaxTokens:       d.MaxTokens,

--- a/pkg/dsl/ir/ir.go
+++ b/pkg/dsl/ir/ir.go
@@ -157,6 +157,7 @@ type LLMFields struct {
 	Model           string // model identifier (env refs already noted)
 	Backend         string // execution backend name (empty = direct LLM call); may contain ${VAR} env refs
 	Provider        string // credential routing hint(s): single ("anthropic"/"zai"/"openai"/""=auto) or an ordered fallback chain ("anthropic,zai,openai"); may contain ${VAR} env refs
+	Command         string // per-node CLI binary override, honored by claude_code; may contain ${VAR}
 	SystemPrompt    string // prompt reference name
 	UserPrompt      string // prompt reference name
 	MaxTokens       int    // per-node cap on output tokens (0 = backend default)

--- a/pkg/dsl/ir/validate.go
+++ b/pkg/dsl/ir/validate.go
@@ -37,6 +37,7 @@ func (c *compiler) validate(w *Workflow) {
 	c.validatePlaywrightMCP(w)
 	c.validateCapabilities(w)
 	c.validateProviders(w)
+	c.validateCommand(w)
 	c.validateCursorInvocations(w)
 	c.validateReviewGates(w)
 	c.validateCompress(w)

--- a/pkg/dsl/ir/validate_command.go
+++ b/pkg/dsl/ir/validate_command.go
@@ -21,14 +21,20 @@ var commandIgnoringBackends = map[string]bool{
 // when the per-node `command:` CLI-binary override is set on a backend
 // that cannot consume it:
 //
-//   - C174 (warning) when `command:` is non-empty AND the backend is
-//     explicitly `claw` or `codex`. Only claude_code honors the override.
+//   - C174 (warning) when `command:` is non-empty AND the effective
+//     backend resolves to `claw` or `codex`. Only claude_code honors the
+//     override.
 //
-// It is deliberately conservative: an empty/`auto` backend (deferred to
-// runtime auto-resolution) and any env-ref backend (${VAR}, resolved only
-// at run time) are skipped — the literal text isn't the resolved backend,
-// so warning there would misfire. The check is a warning, never an error:
-// the run still proceeds and the override is simply ignored downstream.
+// The effective backend mirrors the runtime precedence knowable at compile
+// time: the node's own `backend:`, falling back to the workflow-level
+// `default_backend:` when the node leaves it empty/`auto` (see
+// ClawExecutor.resolveBackendName). It is deliberately conservative about
+// what it CANNOT know: an env-ref backend (${VAR}) and a backend that stays
+// empty after the default_backend fallback (deferred to
+// ITERION_DEFAULT_BACKEND / host credential auto-detection) are skipped —
+// the literal text isn't the resolved backend, so warning there would
+// misfire. The check is a warning, never an error: the run still proceeds
+// and the override is simply ignored downstream.
 func (c *compiler) validateCommand(w *Workflow) {
 	for _, n := range w.Nodes {
 		nn, ok := n.(LLMNode)
@@ -39,7 +45,15 @@ func (c *compiler) validateCommand(w *Workflow) {
 		if f.Command == "" {
 			continue
 		}
+		// Resolve the effective backend: the node's own `backend:` wins; an
+		// empty/`auto` node backend falls back to the workflow default,
+		// exactly as resolveBackendName does at run time. An env-ref node
+		// backend is kept as-is (the node made an explicit, unresolvable
+		// choice — don't override it with the workflow default).
 		backend := f.Backend
+		if backend == "" || backend == "auto" {
+			backend = w.DefaultBackend
+		}
 		// Empty/auto backend and env-ref forms resolve at run time; the
 		// literal text isn't the resolved backend, so defer to runtime.
 		if backend == "" || backend == "auto" || strings.Contains(backend, "${") {

--- a/pkg/dsl/ir/validate_command.go
+++ b/pkg/dsl/ir/validate_command.go
@@ -1,0 +1,54 @@
+package ir
+
+import "strings"
+
+// Per-node CLI-command diagnostics.
+const (
+	DiagCommandIgnored DiagCode = "C174" // `command:` set on a backend that does not consume it (warning)
+)
+
+// commandIgnoringBackends are the explicitly-named backends that do NOT
+// honor the per-node `command:` CLI-binary override. Only claude_code
+// swaps its CLI binary (default `claude`) for the given command (e.g.
+// `kimi`); claw makes a direct API call (no CLI) and codex resolves its
+// own binary, so a `command:` there is inert.
+var commandIgnoringBackends = map[string]bool{
+	"claw":  true,
+	"codex": true,
+}
+
+// validateCommand walks every LLM-capable node (agent, judge) and warns
+// when the per-node `command:` CLI-binary override is set on a backend
+// that cannot consume it:
+//
+//   - C174 (warning) when `command:` is non-empty AND the backend is
+//     explicitly `claw` or `codex`. Only claude_code honors the override.
+//
+// It is deliberately conservative: an empty/`auto` backend (deferred to
+// runtime auto-resolution) and any env-ref backend (${VAR}, resolved only
+// at run time) are skipped — the literal text isn't the resolved backend,
+// so warning there would misfire. The check is a warning, never an error:
+// the run still proceeds and the override is simply ignored downstream.
+func (c *compiler) validateCommand(w *Workflow) {
+	for _, n := range w.Nodes {
+		nn, ok := n.(LLMNode)
+		if !ok {
+			continue
+		}
+		f := nn.GetLLMFields()
+		if f.Command == "" {
+			continue
+		}
+		backend := f.Backend
+		// Empty/auto backend and env-ref forms resolve at run time; the
+		// literal text isn't the resolved backend, so defer to runtime.
+		if backend == "" || backend == "auto" || strings.Contains(backend, "${") {
+			continue
+		}
+		if commandIgnoringBackends[backend] {
+			c.warnfAt(DiagCommandIgnored, nn.NodeID(), "",
+				"%s %q: command %q has no effect on backend=%q (only claude_code honors the per-node CLI-binary override); it will be ignored",
+				nn.NodeKind().String(), nn.NodeID(), f.Command, backend)
+		}
+	}
+}

--- a/pkg/dsl/ir/validate_command.go
+++ b/pkg/dsl/ir/validate_command.go
@@ -9,8 +9,8 @@ const (
 
 // commandIgnoringBackends are the explicitly-named backends that do NOT
 // honor the per-node `command:` CLI-binary override. Only claude_code
-// swaps its CLI binary (default `claude`) for the given command (e.g.
-// `kimi`); claw makes a direct API call (no CLI) and codex resolves its
+// swaps its CLI binary (default `claude`) for the given command (an
+// alternate claude-code-compatible CLI); claw makes a direct API call (no CLI) and codex resolves its
 // own binary, so a `command:` there is inert.
 var commandIgnoringBackends = map[string]bool{
 	"claw":  true,

--- a/pkg/dsl/ir/validate_command_test.go
+++ b/pkg/dsl/ir/validate_command_test.go
@@ -29,26 +29,26 @@ workflow w:
 
 // claw makes a direct API call (no CLI), so a `command:` there is inert.
 func TestCommand_IgnoredOnClawWarns(t *testing.T) {
-	r := compileFile(t, commandSrc("claw", "kimi"))
+	r := compileFile(t, commandSrc("claw", "claude-canary"))
 	expectDiag(t, r, DiagCommandIgnored)
 }
 
 // codex resolves its own binary, so a `command:` there is inert too.
 func TestCommand_IgnoredOnCodexWarns(t *testing.T) {
-	r := compileFile(t, commandSrc("codex", "kimi"))
+	r := compileFile(t, commandSrc("codex", "claude-canary"))
 	expectDiag(t, r, DiagCommandIgnored)
 }
 
 // claude_code honors the override, so no C174.
 func TestCommand_OnClaudeCodeNoWarning(t *testing.T) {
-	r := compileFile(t, commandSrc("claude_code", "kimi"))
+	r := compileFile(t, commandSrc("claude_code", "claude-canary"))
 	expectNoDiag(t, r, DiagCommandIgnored)
 }
 
 // An env-ref backend resolves only at run time; the literal text isn't the
 // resolved backend, so the validator must defer and not warn.
 func TestCommand_EnvRefBackendSkips(t *testing.T) {
-	r := compileFile(t, commandSrc("${BACKEND:-claw}", "kimi"))
+	r := compileFile(t, commandSrc("${BACKEND:-claw}", "claude-canary"))
 	expectNoDiag(t, r, DiagCommandIgnored)
 }
 
@@ -65,7 +65,7 @@ prompt sys:
 judge reviewer:
   model: "gpt-4"
   backend: "claw"
-  command: "kimi"
+  command: "claude-canary"
   system: sys
   output: empty
 

--- a/pkg/dsl/ir/validate_command_test.go
+++ b/pkg/dsl/ir/validate_command_test.go
@@ -52,6 +52,47 @@ func TestCommand_EnvRefBackendSkips(t *testing.T) {
 	expectNoDiag(t, r, DiagCommandIgnored)
 }
 
+// commandSrcDefaultBackend builds a one-agent workflow whose node leaves
+// `backend:` unset, so the effective backend is the workflow-level
+// `default_backend:` — the compile-time-knowable fallback the validator
+// must honor.
+func commandSrcDefaultBackend(defaultBackend, command string) string {
+	return `
+schema empty:
+  ok: bool
+
+prompt sys:
+  body
+  hello
+
+agent writer:
+  model: "gpt-4"
+  command: "` + command + `"
+  system: sys
+  output: empty
+
+workflow w:
+  default_backend: "` + defaultBackend + `"
+  entry: writer
+  writer -> done
+`
+}
+
+// A node with no explicit backend inherits the workflow `default_backend:`;
+// when that resolves to claw the command is inert, so C174 must fire even
+// though the node itself names no backend.
+func TestCommand_InheritsDefaultBackendClawWarns(t *testing.T) {
+	r := compileFile(t, commandSrcDefaultBackend("claw", "claude-canary"))
+	expectDiag(t, r, DiagCommandIgnored)
+}
+
+// Same inheritance, but default_backend is claude_code, which honors the
+// override — no warning.
+func TestCommand_InheritsDefaultBackendClaudeCodeNoWarning(t *testing.T) {
+	r := compileFile(t, commandSrcDefaultBackend("claude_code", "claude-canary"))
+	expectNoDiag(t, r, DiagCommandIgnored)
+}
+
 // `command:` also works on judge nodes and warns on a hint-ignoring backend.
 func TestCommand_JudgeIgnoredOnClawWarns(t *testing.T) {
 	src := `

--- a/pkg/dsl/ir/validate_command_test.go
+++ b/pkg/dsl/ir/validate_command_test.go
@@ -1,0 +1,78 @@
+package ir
+
+import "testing"
+
+// commandSrc builds a minimal one-agent workflow with the given backend
+// and command field so the command validator can be exercised in
+// isolation.
+func commandSrc(backend, command string) string {
+	return `
+schema empty:
+  ok: bool
+
+prompt sys:
+  body
+  hello
+
+agent writer:
+  model: "gpt-4"
+  backend: "` + backend + `"
+  command: "` + command + `"
+  system: sys
+  output: empty
+
+workflow w:
+  entry: writer
+  writer -> done
+`
+}
+
+// claw makes a direct API call (no CLI), so a `command:` there is inert.
+func TestCommand_IgnoredOnClawWarns(t *testing.T) {
+	r := compileFile(t, commandSrc("claw", "kimi"))
+	expectDiag(t, r, DiagCommandIgnored)
+}
+
+// codex resolves its own binary, so a `command:` there is inert too.
+func TestCommand_IgnoredOnCodexWarns(t *testing.T) {
+	r := compileFile(t, commandSrc("codex", "kimi"))
+	expectDiag(t, r, DiagCommandIgnored)
+}
+
+// claude_code honors the override, so no C174.
+func TestCommand_OnClaudeCodeNoWarning(t *testing.T) {
+	r := compileFile(t, commandSrc("claude_code", "kimi"))
+	expectNoDiag(t, r, DiagCommandIgnored)
+}
+
+// An env-ref backend resolves only at run time; the literal text isn't the
+// resolved backend, so the validator must defer and not warn.
+func TestCommand_EnvRefBackendSkips(t *testing.T) {
+	r := compileFile(t, commandSrc("${BACKEND:-claw}", "kimi"))
+	expectNoDiag(t, r, DiagCommandIgnored)
+}
+
+// `command:` also works on judge nodes and warns on a hint-ignoring backend.
+func TestCommand_JudgeIgnoredOnClawWarns(t *testing.T) {
+	src := `
+schema empty:
+  ok: bool
+
+prompt sys:
+  body
+  hello
+
+judge reviewer:
+  model: "gpt-4"
+  backend: "claw"
+  command: "kimi"
+  system: sys
+  output: empty
+
+workflow w:
+  entry: reviewer
+  reviewer -> done
+`
+	r := compileFile(t, src)
+	expectDiag(t, r, DiagCommandIgnored)
+}

--- a/pkg/dsl/parser/parser_nodes.go
+++ b/pkg/dsl/parser/parser_nodes.go
@@ -102,6 +102,9 @@ func (p *parser) parseLLMProp(d *ast.LLMDecl, propTok Token, kind string) {
 	case TokenProvider:
 		p.expect(TokenColon)
 		d.Provider = p.expectString()
+	case TokenCommand:
+		p.expect(TokenColon)
+		d.Command = p.expectString()
 	case TokenInteraction:
 		p.expect(TokenColon)
 		d.Interaction = p.parseInteractionMode()

--- a/pkg/dsl/parser/parser_test.go
+++ b/pkg/dsl/parser/parser_test.go
@@ -608,10 +608,10 @@ func TestAgentSessionFork(t *testing.T) {
 }
 
 func TestAgentCommand(t *testing.T) {
-	src := `agent kimi_worker:
-  model: "kimi-k2"
+	src := `agent alt_worker:
+  model: "claude-opus-4-8"
   backend: "claude_code"
-  command: "kimi"
+  command: "claude-canary"
   system: sys
   user: usr
 `
@@ -619,14 +619,14 @@ func TestAgentCommand(t *testing.T) {
 	assertNoDiags(t, res)
 
 	a := res.File.Agents[0]
-	assertEq(t, "Command", a.Command, "kimi")
+	assertEq(t, "Command", a.Command, "claude-canary")
 }
 
 func TestJudgeCommand(t *testing.T) {
-	src := `judge kimi_reviewer:
-  model: "kimi-k2"
+	src := `judge alt_reviewer:
+  model: "claude-opus-4-8"
   backend: "claude_code"
-  command: "kimi"
+  command: "claude-canary"
   system: sys
   user: usr
 `
@@ -634,7 +634,7 @@ func TestJudgeCommand(t *testing.T) {
 	assertNoDiags(t, res)
 
 	j := res.File.Judges[0]
-	assertEq(t, "Command", j.Command, "kimi")
+	assertEq(t, "Command", j.Command, "claude-canary")
 }
 
 func TestAgentReasoningEffort(t *testing.T) {

--- a/pkg/dsl/parser/parser_test.go
+++ b/pkg/dsl/parser/parser_test.go
@@ -607,6 +607,36 @@ func TestAgentSessionFork(t *testing.T) {
 	assertEq(t, "Backend", a.Backend, "claude_code")
 }
 
+func TestAgentCommand(t *testing.T) {
+	src := `agent kimi_worker:
+  model: "kimi-k2"
+  backend: "claude_code"
+  command: "kimi"
+  system: sys
+  user: usr
+`
+	res := parser.Parse("test.bot", src)
+	assertNoDiags(t, res)
+
+	a := res.File.Agents[0]
+	assertEq(t, "Command", a.Command, "kimi")
+}
+
+func TestJudgeCommand(t *testing.T) {
+	src := `judge kimi_reviewer:
+  model: "kimi-k2"
+  backend: "claude_code"
+  command: "kimi"
+  system: sys
+  user: usr
+`
+	res := parser.Parse("test.bot", src)
+	assertNoDiags(t, res)
+
+	j := res.File.Judges[0]
+	assertEq(t, "Command", j.Command, "kimi")
+}
+
 func TestAgentReasoningEffort(t *testing.T) {
 	src := `agent planner:
   model: "claude-4"

--- a/pkg/dsl/unparse/unparse.go
+++ b/pkg/dsl/unparse/unparse.go
@@ -202,7 +202,7 @@ func (w *fileWriter) writeAgents(agents []*ast.AgentDecl) {
 			writeMCPConfigBlock(&w.b, a.MCP, "  ")
 		}
 		writeAgentFields(&w.b, llmFields{
-			Model: a.Model, Backend: a.Backend, Provider: a.Provider,
+			Model: a.Model, Backend: a.Backend, Provider: a.Provider, Command: a.Command,
 			Input: a.Input, Output: a.Output, Publish: a.Publish,
 			System: a.System, User: a.User, Session: a.Session,
 			Tools: a.Tools, ToolPolicy: a.ToolPolicy, Capabilities: a.Capabilities,
@@ -232,7 +232,7 @@ func (w *fileWriter) writeJudges(judges []*ast.JudgeDecl) {
 			writeMCPConfigBlock(&w.b, j.MCP, "  ")
 		}
 		writeAgentFields(&w.b, llmFields{
-			Model: j.Model, Backend: j.Backend, Provider: j.Provider,
+			Model: j.Model, Backend: j.Backend, Provider: j.Provider, Command: j.Command,
 			Input: j.Input, Output: j.Output, Publish: j.Publish,
 			System: j.System, User: j.User, Session: j.Session,
 			Tools: j.Tools, ToolPolicy: j.ToolPolicy, Capabilities: j.Capabilities,
@@ -825,7 +825,7 @@ func quoteList(vals []string) string {
 // silently corrupt the emitted source. Field names mirror ast.AgentDecl
 // / ast.JudgeDecl so the call-site literals read as a direct projection.
 type llmFields struct {
-	Model, Backend, Provider            string
+	Model, Backend, Provider, Command   string
 	Input, Output, Publish              string
 	System, User                        string
 	Session                             ast.SessionMode
@@ -851,6 +851,9 @@ func writeAgentFields(b *strings.Builder, f llmFields) {
 	}
 	if f.Provider != "" {
 		writeQuotedProp(b, "provider", f.Provider)
+	}
+	if f.Command != "" {
+		writeQuotedProp(b, "command", f.Command)
 	}
 	if f.Input != "" {
 		writeIdentProp(b, "input", f.Input)


### PR DESCRIPTION
## Summary

Exposes a per-node `command:` field on `agent`/`judge`, honoured by the `claude_code` backend, to run a node with an **alternate claude-code-compatible CLI** instead of the default `claude` (a pinned build, or a compatible wrapper/proxy). Wires the existing `ClaudeCodeBackend.Command` / `WithCLIPath`, which was never exposed to the DSL.

```iter
agent reviewer:
  backend: "claude_code"
  command: "claude-canary"     # alternate claude-code-compatible CLI on PATH
```

## How

- **DSL/IR**: `command:` on `LLMDecl` (`ast.go`) / `LLMFields` (`ir.go`); `TokenCommand` (already used by tool nodes) handled in `parseLLMProp`; lowered in `compile.go`.
- **Thread**: `backendFields` → `buildTask` env-expands and sets `Task.Command` → `ClaudeCodeBackend.Execute` prefers the task-level command over the backend default (`cliPath := b.Command; if task.Command != "" { cliPath = task.Command }`), applied via `WithCLIPath` at both invocation sites; the shared backend struct is never mutated.
- **Guardrail**: honoured by `claude_code` only; compile-time **warning C174** on `claw`/`codex`.
- **Round-trip** (unparse) + docs.

## The override itself is verified complete

An adversarial trace plus an empirical run (a fake CLI wired as `command:`) confirm the override reaches **every** spawn path — streaming, one-shot, structured-output two-pass, resume, and the sandbox docker-exec path — so the specified binary is launched, never `claude`, and there is no `claude --version`/health preflight that bypasses it.

## Limitations (scoped intentionally)

1. **Binary only, not credentials/endpoint.** `command:` swaps the CLI binary but not per-node credentials: the subprocess inherits the same `ANTHROPIC_*`/cred env as a default `claude` node. This field runs an alternate *claude-code-compatible* CLI, not a different provider/endpoint per node.
2. **Target must speak the claude-code CLI protocol.** The backend drives the CLI in Session mode (`--print`, `--input-format`/`--output-format stream-json` with the prompt on stdin, `--permission-mode`, `--append-system-prompt`, `--model` — defaulting to `claude-opus-4-8` when unset). A CLI with a different argument surface is not supported (e.g. Moonshot's `kimi-code`, which uses `-p <prompt>` and rejects `--print`).
3. **Pre-existing host env asymmetry (tracked in #77).** On the host, the structured-output formatting pass (`formatOutput`) rebuilds the subprocess env without seeding `os.Environ()`, unlike Pass 1 — so a `command:` node with an `output:` schema may not see the inherited ambient env on that pass. Orthogonal to this change; surfaced while reviewing it and filed separately as #77.

## Related

- #70 — a dedicated backend for a third-party agent CLI with a *non*-claude-code argument protocol (e.g. Moonshot `kimi-code`), which this `command:` override deliberately does not cover.
- #77 — the host `formatOutput` env asymmetry noted above.

## Tests

Parser (`command:` populates the field on agent + judge), validation (C174 fires on `claw`/`codex`, not on `claude_code`; a `${VAR}` backend is skipped).

## Verification

```
go build ./... && go vet ./pkg/dsl/... ./pkg/backend/...
go test ./pkg/dsl/... ./pkg/backend/... -count=1
```
All green; `gofmt` clean.

> Draft: verified locally (build, vet, gofmt, unit tests on touched packages); opening as draft pending full CI review.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)
