### PR TITLE
fix(claude_code): seed os.Environ() in formatOutput host spawn (structured-output env strip)

### DIFF
--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -660,6 +661,22 @@ func (b *ClaudeCodeBackend) runRecoveryFormatterPass(ctx context.Context, task T
 	}
 }
 
+// hostSpawnEnv returns the process environment with the per-task env entries
+// appended (last-wins), matching the SDK's default host spawn
+// (claudesdk/process.go: cmd.Env = os.Environ() then append) and Pass 1. The
+// host-side CommandBuilder installed by formatOutput to capture the spawned
+// cmd would otherwise set cmd.Env to ONLY the per-task entries, stripping
+// PATH/HOME and any ambient credential env from the structured-output format
+// pass. Appending the per-task entries last preserves their precedence over
+// inherited values (os/exec keeps the last occurrence of a duplicate key).
+func hostSpawnEnv(extra map[string]string) []string {
+	base := os.Environ()
+	for k, v := range extra {
+		base = append(base, k+"="+v)
+	}
+	return base
+}
+
 // formatOutput performs the second pass of two-pass execution: resumes the
 // Pass 1 session with WithOutputFormat (no tools) to guarantee structured JSON
 // output conforming to the schema. The model already has full context from the
@@ -758,12 +775,14 @@ func (b *ClaudeCodeBackend) formatOutput(ctx context.Context, task Task, session
 		opts = append(opts, claudesdk.WithCommandBuilder(func(ctx context.Context, path string, args []string, cwd string, env map[string]string, openStdin bool) *exec.Cmd {
 			cmd := exec.CommandContext(ctx, path, args...)
 			cmd.Dir = cwd
-			if len(env) > 0 {
-				cmd.Env = make([]string, 0, len(env))
-				for k, v := range env {
-					cmd.Env = append(cmd.Env, k+"="+v)
-				}
-			}
+			// Seed os.Environ() before the per-task entries — matching the
+			// SDK's default host spawn (claudesdk/process.go) and Pass 1 — so
+			// the format pass inherits PATH/HOME and any ambient credential
+			// env instead of running with a stripped environment. The prior
+			// code set cmd.Env to ONLY the per-task entries, dropping the
+			// inherited env (CLAUDE_CODE_EFFORT_LEVEL is always present, so the
+			// strip always fired). Per-task entries stay last so they still win.
+			cmd.Env = hostSpawnEnv(env)
 			captureCmd(cmd)
 			return cmd
 		}))

--- a/pkg/backend/delegate/claude_code_hostenv_test.go
+++ b/pkg/backend/delegate/claude_code_hostenv_test.go
@@ -1,0 +1,52 @@
+package delegate
+
+import "testing"
+
+// TestHostSpawnEnv_SeedsOsEnviron guards the fix for the formatOutput
+// host-side env strip: the structured-output format pass must inherit the
+// ambient environment (PATH/HOME/credential vars), not run with only the
+// per-task entries.
+func TestHostSpawnEnv_SeedsOsEnviron(t *testing.T) {
+	t.Setenv("ITERION_HOSTENV_PROBE", "ambient")
+	got := hostSpawnEnv(map[string]string{"EXTRA_KEY": "extra"})
+
+	hasAmbient, hasExtra := false, false
+	for _, e := range got {
+		switch e {
+		case "ITERION_HOSTENV_PROBE=ambient":
+			hasAmbient = true
+		case "EXTRA_KEY=extra":
+			hasExtra = true
+		}
+	}
+	if !hasAmbient {
+		t.Fatal("hostSpawnEnv dropped the inherited env (ITERION_HOSTENV_PROBE missing) — the format pass would run with a stripped environment")
+	}
+	if !hasExtra {
+		t.Fatal("hostSpawnEnv did not include the per-task entry EXTRA_KEY")
+	}
+}
+
+// TestHostSpawnEnv_PerTaskWinsOverInherited verifies per-task entries keep
+// precedence over inherited values (os/exec keeps the last duplicate key, so
+// the per-task entry must appear after the inherited one).
+func TestHostSpawnEnv_PerTaskWinsOverInherited(t *testing.T) {
+	t.Setenv("ITERION_HOSTENV_DUP", "inherited")
+	got := hostSpawnEnv(map[string]string{"ITERION_HOSTENV_DUP": "override"})
+
+	lastInherited, lastOverride := -1, -1
+	for i, e := range got {
+		switch e {
+		case "ITERION_HOSTENV_DUP=inherited":
+			lastInherited = i
+		case "ITERION_HOSTENV_DUP=override":
+			lastOverride = i
+		}
+	}
+	if lastOverride < 0 {
+		t.Fatal("per-task override missing from hostSpawnEnv output")
+	}
+	if lastInherited >= 0 && lastOverride < lastInherited {
+		t.Fatalf("per-task override (idx %d) must come after inherited value (idx %d) so os/exec last-wins picks it", lastOverride, lastInherited)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #77. On the **host** (non-sandbox) path, `formatOutput` (the structured-output two-pass formatting step) installed a `WithCommandBuilder` — "solely to capture the cmd reference" for a SIGKILL-on-timeout hedge — that also rebuilt `cmd.Env` from **only** the per-task env entries, dropping `os.Environ()`. Because `CLAUDE_CODE_EFFORT_LEVEL` is always appended, `len(env) > 0` was effectively always true, so the strip always fired.

Result: Pass 1 (`Execute`) preserved the ambient environment, but Pass 2 (`formatOutput`) ran with a stripped env — losing `PATH`, `HOME`, and any ambient credential env (e.g. an `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN` facade, or forfait creds under `~/.claude` which needs `HOME`). This bites structured-output nodes that also have tools (schema + tools → two-pass) on the host.

## Fix

Seed `os.Environ()` before appending the per-task entries, matching the SDK's default host spawn (`claudesdk/process.go`) and Pass 1. Extracted a small `hostSpawnEnv` helper so the behaviour is unit-tested. Per-task entries are appended **last**, so they keep precedence over inherited values (os/exec keeps the last duplicate key) — same semantics as `process.go`.

Only `formatOutput`'s host builder had this strip; Pass 1 (`buildTransportOptions`) uses the SDK default host spawn (no host capture builder), so it was already correct and is unchanged.

## Tests

- `TestHostSpawnEnv_SeedsOsEnviron` — an ambient var survives and the per-task entry is present.
- `TestHostSpawnEnv_PerTaskWinsOverInherited` — a per-task override appears after the inherited value, so os/exec last-wins picks it.

## Verification

```
go build ./... && go vet ./pkg/backend/delegate/...
go test ./... -count=1
```
All green; `gofmt` clean.

> Draft: verified locally (build, vet, gofmt, full unit suite on the touched packages + `go test ./...`); opening as draft pending full CI review.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)
