### PR TITLE
feat(delegate): dedicated CLI-agent backend for non-claude-code argv (kimi-code)

### DIFF
--- a/docs/adr/065-dedicated-cli-agent-backend.md
+++ b/docs/adr/065-dedicated-cli-agent-backend.md
@@ -1,0 +1,91 @@
+# ADR-065: Dedicated CLI-agent backend for non-claude-code argument protocols
+
+- **Status**: Accepted
+- **Date**: 2026-07-09
+- **Code**: [pkg/backend/delegate/cliagent.go](../../pkg/backend/delegate/cliagent.go) (`CLIAgentBackend`, `CLIAgentProtocol`), [pkg/backend/delegate/kimi.go](../../pkg/backend/delegate/kimi.go) (`BackendKimi`, `kimiProtocol`)
+
+## Context
+
+iterion had no way to run a third-party agent CLI whose argument protocol
+differs from claude-code / codex. The `claude_code` backend drives its CLI in
+**Session mode**: `--print`, `--input-format`/`--output-format stream-json`
+with the prompt on **stdin**, `--permission-mode`, `--append-system-prompt`,
+`--model`, … A per-node `command:` override (#76) only swaps the *binary*
+while keeping that exact argv, so it can only drive a claude-code-**compatible**
+CLI (a pinned build, a compatible proxy/wrapper).
+
+Moonshot's **`kimi-code`** is not compatible. Its flag surface is disjoint:
+
+```
+kimi -p <prompt> --output-format {text,stream-json} [-m <alias>]
+```
+
+`kimi --print …` fails with `error: unknown option '--print' (Did you mean
+--prompt?)` — the prompt is a `-p <prompt>` *value*, not stdin under
+`--print`. #76 cannot run it. This is the separate, larger need #75/#76
+deferred: running an agent CLI with a **different argument protocol**.
+
+## Decision
+
+Add a **generic, protocol-driven CLI-agent backend** rather than a bespoke
+one-off per CLI. `CLIAgentProtocol` declares, as data, everything that varies
+between agent CLIs:
+
+- **argv shape** — prompt delivery (`-p <prompt>` arg vs. bare-switch + stdin),
+  the output-format flag/value, the model flag, an optional system-prompt flag,
+  static extra args;
+- **model mapping** — `MapModel` translates iterion's `provider/model` spec
+  into the CLI's native alias (kimi: strip the provider segment → `-m kimi-k2`);
+- **effort mapping** — `MapEffort` maps a reasoning-effort level onto extra
+  argv, or is `nil` when the CLI has no effort dial (kimi);
+- **output parsing** — `ParseOutput` turns raw stdout into the assistant's
+  final text (+ session id, tokens); the shared, schema-aware `parseSDKOutput`
+  fallback then handles `output:` schemas uniformly with the other backends;
+- **credential/endpoint resolution** — `ResolveEnv` layers overrides sourced
+  from the CLI's own config/env conventions, or is `nil` to let the CLI resolve
+  its own credentials from the inherited host environment (kimi reads e.g.
+  `$MOONSHOT_API_KEY` itself).
+
+`CLIAgentBackend` wraps a protocol and mirrors the **codex backend's shape**:
+build native argv → run with a wall-clock timeout (host or, when sandboxed,
+inside the run's container via `sandbox.Run.Command`) → parse stdout → retry on
+a no-output/network transient. **kimi** (`backend: "kimi"`) ships as the first
+concrete instance (`kimiProtocol`), registered in `DefaultRegistry`. When the
+CLI emits no system-prompt flag (kimi), the node's composed `system:` task is
+folded in as a preamble to the `-p` prompt so the task still reaches the agent;
+the CLI keeps its own native agentic posture (`SystemPromptStandalone`).
+
+## Trade-offs / Consequences
+
+- **Tools are not host-gated.** Like codex, kimi runs with its *own* built-in
+  toolset; iterion's node `tools:`/`AllowedTools` list is advisory only — the
+  protocol has no lever to restrict the target CLI's shell. Nodes needing a
+  hard permission boundary should use `claude_code` (the permission gate) or
+  `claw` (native tool restriction). Documented in docs/backends.md.
+- **Sessions/continuity are best-effort.** We capture a `session_id` from the
+  stream when present, but resume/fork is not wired for CLI-agent backends yet
+  (the CLI's resume protocol is per-vendor). Kimi runs fresh each node.
+- **Auto-detection excludes it.** kimi is explicit opt-in (`backend: "kimi"`);
+  the credential detector never auto-selects it, so no host with a Moonshot key
+  silently re-targets away from claude_code.
+
+## Alternatives considered
+
+### 1. A hardcoded, per-CLI backend (a `KimiBackend` from scratch)
+Straightforward but non-reusable: the next CLI (Gemini CLI, aider, …) repeats
+all the subprocess/timeout/retry/parse plumbing. **Rejected** — the varying
+parts are pure data; a declarative protocol captures them without new Go per
+CLI (the next backend is a new `CLIAgentProtocol` value, not a new type).
+
+### 2. Extend the `command:` override (#76) with argv templating
+Fold "different protocol" into the same field. **Rejected** — #76 is precisely
+scoped to *claude-code-compatible* binaries (pinned build / compatible proxy),
+where keeping the Session-mode argv is the point. Overloading it with a full
+argv-templating mini-language would blur a clean boundary and reimplement, in
+config, what a typed protocol expresses in code. #76 stays the binary swap;
+this ADR is the protocol switch.
+
+### 3. A per-node `claw` endpoint override (the original #75)
+Point claw's OpenAI-compatible client at Moonshot's API. **Rejected upstream**
+already: it drives the *model API*, not the *agent CLI* — it loses kimi-code's
+own tool loop / agent behaviour, which is the reason to run kimi-code at all.

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -378,6 +378,50 @@ gray-area but has no explicit prohibition today. We treat this as
 pragmatic — if OpenAI changes the terms or tightens enforcement, set
 `ITERION_OPENAI_USE_OAUTH=0` and fall back to `OPENAI_API_KEY`.
 
+## Third-party agent CLIs (`kimi`, and the CLI-agent seam)
+
+Some agent CLIs have an argument protocol **disjoint from claude-code's**
+Session mode (`--print`, prompt on stdin, `--append-system-prompt`, …), so
+neither `backend: claude_code` nor the per-node `command:` override (which
+only swaps the *binary* while keeping claude-code's argv) can drive them.
+Moonshot's **`kimi-code`** is the motivating case — it takes the prompt as
+`-p <prompt>` (`kimi --print …` errors with `unknown option '--print'`):
+
+```
+kimi -p <prompt> --output-format {text,stream-json} [-m <alias>]
+```
+
+iterion ships a dedicated **`kimi`** backend for it:
+
+```yaml
+agent implement:
+  backend: "kimi"
+  model: "moonshot/kimi-k2"    # the provider segment is stripped → `-m kimi-k2`
+  system: "…the task…"
+```
+
+Under the hood, `kimi` is a concrete instance of a generic **CLI-agent
+backend** (`delegate.CLIAgentBackend` + `CLIAgentProtocol`, see
+[ADR-065](adr/065-dedicated-cli-agent-backend.md)) that builds the target
+CLI's *own* command line, runs it with a wall-clock timeout (inside the run's
+sandbox container when one is active), parses its stdout (kimi emits a
+claude-code-style `stream-json` stream) into the structured result, and retries
+on a no-output / network transient. Adding another such CLI is a new protocol
+*value*, not new plumbing.
+
+Behavioural notes specific to CLI-agent backends:
+
+- **Explicit opt-in.** `kimi` is never auto-detected; you select it with
+  `backend: "kimi"`. No Moonshot credential silently re-targets a run.
+- **Credentials** are resolved by the CLI itself from its own env/config (e.g.
+  `$MOONSHOT_API_KEY`) — iterion inherits the host environment and does not
+  fight the CLI's native resolution.
+- **Tools are not host-gated.** Like `codex`, kimi runs with its *own* built-in
+  toolset; a node's `tools:` list is advisory. For a hard tool-permission
+  boundary use `claude_code` (permission gate) or `claw` (native restriction).
+- **Effort** has no effect (kimi has no reasoning-effort dial); **sessions**
+  are captured for observability but resume/fork is not yet wired.
+
 ## Editor UX
 
 The studio calls `GET /api/backends/detect` at mount time. The

--- a/docs/delegation.md
+++ b/docs/delegation.md
@@ -18,6 +18,7 @@ agent implementer:
 | `claude_code` | recommended | Runs the `claude` CLI as a subprocess with full tool access |
 | `claw` (default) | recommended for read-only / judges | In-process multi-provider LLM client (Anthropic, OpenAI, …) — use with `model: "openai/gpt-5.4-mini"` etc. |
 | `codex` | **discouraged** | Runs the `codex` CLI as a subprocess. Cannot configure its tool set, tends to fill its own context window, and has weaker iterion integration. The compiler emits a `C030` warning per node. Kept for compatibility — prefer `claude_code` or `claw`+OpenAI in new workflows. |
+| `kimi` | opt-in | Runs Moonshot's `kimi-code` CLI, whose argv is disjoint from claude-code's (`kimi -p <prompt> --output-format stream-json [-m <alias>]`). A concrete instance of iterion's generic CLI-agent backend. See [Backends → Third-party agent CLIs](backends.md#third-party-agent-clis-kimi-and-the-cli-agent-seam) and [ADR-065](adr/065-dedicated-cli-agent-backend.md). |
 
 > 💡 `claude_code` works with your Claude subscription (Pro/Max/Team/Enterprise) — no separate API key required. `claw` calls provider APIs directly and needs the corresponding API key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, …).
 

--- a/pkg/backend/delegate/cliagent.go
+++ b/pkg/backend/delegate/cliagent.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -303,11 +304,23 @@ func (b *CLIAgentBackend) runOnce(ctx context.Context, task Task, binary string,
 	var outBuf, errBuf bytes.Buffer
 	argv := append([]string{binary}, args...)
 
+	// A stdin-delivery protocol (PromptViaStdin) must route its prompt
+	// through the sandbox ExecOpts, NOT by setting cmd.Stdin after the
+	// driver builds the command: the docker/k8s drivers only allocate a
+	// forwarded stdin (`docker exec --interactive`) when opts.Stdin (or
+	// KeepStdinOpen) is set, so a post-hoc cmd.Stdin would be silently
+	// dropped inside the container.
+	var stdin io.Reader
+	if stdinPrompt != "" {
+		stdin = strings.NewReader(stdinPrompt)
+	}
+
 	var cmd *exec.Cmd
 	if task.Sandbox != nil {
 		cmd = task.Sandbox.Command(runCtx, argv, sandbox.ExecOpts{
 			Env:     envSliceToMap(b.Protocol.ResolveEnv, ctx),
 			WorkDir: task.WorkDir,
+			Stdin:   stdin,
 		})
 	} else {
 		cmd = exec.CommandContext(runCtx, binary, args...) // #nosec G204 — binary/args are backend-configured, not attacker-controlled.
@@ -315,12 +328,10 @@ func (b *CLIAgentBackend) runOnce(ctx context.Context, task Task, binary string,
 		if task.WorkDir != "" {
 			cmd.Dir = task.WorkDir
 		}
+		cmd.Stdin = stdin
 	}
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf
-	if stdinPrompt != "" {
-		cmd.Stdin = strings.NewReader(stdinPrompt)
-	}
 
 	runErr := cmd.Run()
 	stdout = outBuf.String()

--- a/pkg/backend/delegate/cliagent.go
+++ b/pkg/backend/delegate/cliagent.go
@@ -1,0 +1,415 @@
+package delegate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/cost"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+)
+
+// CLIAgentProtocol declares how to drive a third-party agent CLI whose
+// argument protocol is NOT claude-code-compatible (see ADR-065). Unlike the
+// per-node `command:` override (#76) — which only swaps the binary while
+// keeping claude-code's Session-mode argv (`--print`, `--input-format
+// stream-json`, prompt on stdin, …) — a protocol describes the CLI's *own*
+// invocation. It is the seam a real backend (e.g. Moonshot's `kimi-code`,
+// `kimi -p <prompt> --output-format stream-json -m <alias>`) plugs into.
+//
+// The zero value is not usable; construct one per target CLI (see kimi.go)
+// and register a CLIAgentBackend wrapping it.
+type CLIAgentProtocol struct {
+	// Name is the backend registration name and the label stamped on
+	// Result.BackendName / log lines (e.g. "kimi").
+	Name string
+
+	// DefaultBinary is the CLI executable to invoke when the backend's
+	// Command override is empty (e.g. "kimi").
+	DefaultBinary string
+
+	// PromptFlag delivers the user prompt on the command line. When
+	// PromptViaStdin is false, the prompt is passed as the flag's value:
+	// `<PromptFlag> <prompt>` (e.g. "-p <prompt>"). When PromptViaStdin is
+	// true and PromptFlag is set, PromptFlag is emitted as a bare switch and
+	// the prompt is written to the process stdin instead. Empty PromptFlag +
+	// PromptViaStdin means "prompt straight to stdin, no flag".
+	PromptFlag     string
+	PromptViaStdin bool
+
+	// SystemPromptFlag, when set, delivers the composed system prompt as
+	// `<SystemPromptFlag> <system>`. When empty (the common case for CLIs
+	// with no system-prompt flag, incl. kimi-code), the system prompt is
+	// folded in as a preamble to the user prompt so the node's `system:`
+	// task still reaches the agent.
+	SystemPromptFlag string
+
+	// ModelFlag maps Task.Model onto the CLI's own model selector, emitted as
+	// `<ModelFlag> <MapModel(model)>` when both ModelFlag and the mapped model
+	// are non-empty. MapModel translates iterion's `provider/model` spec into
+	// the CLI's native alias; nil passes Model through verbatim.
+	ModelFlag string
+	MapModel  func(model string) string
+
+	// OutputFormatFlag + OutputFormat request a machine-readable stream from
+	// the CLI (e.g. "--output-format" "stream-json"). Empty OutputFormatFlag
+	// leaves the CLI at its default (text) format.
+	OutputFormatFlag string
+	OutputFormat     string
+
+	// MapEffort maps an iterion reasoning-effort level ("low".."max") onto
+	// extra argv the CLI understands. Return an empty slice for an effort the
+	// CLI can't express; a nil MapEffort drops effort entirely (the CLI has no
+	// effort dial).
+	MapEffort func(effort string) []string
+
+	// ExtraArgs are appended verbatim after all generated flags (static CLI
+	// switches the protocol always wants, e.g. a non-interactive flag).
+	ExtraArgs []string
+
+	// ParseOutput extracts the assistant's final text (plus optional session
+	// id and token count) from the CLI's raw stdout. For a stream-json
+	// protocol it walks the NDJSON events; for a text protocol it returns
+	// stdout verbatim. The returned text is then fed through the shared
+	// schema-aware fallback (parseSDKOutput) so structured `output:` schemas
+	// work the same way they do for the other backends. nil defaults to
+	// treating stdout as plain text.
+	ParseOutput func(stdout string) (text, sessionID string, tokens int)
+
+	// ResolveEnv returns credential/endpoint environment overrides sourced
+	// from the target CLI's own config/env conventions (and any per-run
+	// injected credentials on the context). The returned map is layered on
+	// top of the inherited process environment. nil means "inherit the host
+	// environment unchanged" — the CLI resolves its own credentials, which is
+	// the correct default for a CLI that reads e.g. $MOONSHOT_API_KEY itself.
+	ResolveEnv func(ctx context.Context) map[string]string
+}
+
+// CLIAgentBackend is a delegate.Backend that drives a third-party agent CLI
+// described by a CLIAgentProtocol. It mirrors the codex backend's shape —
+// build native argv, run with a wall-clock timeout, parse stdout, retry on a
+// no-output transient — but the invocation is the target CLI's own, not
+// claude-code's. See ADR-065.
+type CLIAgentBackend struct {
+	// Protocol describes the target CLI's argument protocol.
+	Protocol CLIAgentProtocol
+	// Command overrides Protocol.DefaultBinary (the per-node `command:`
+	// override / an operator-pinned build path).
+	Command string
+	// Timeout caps a single CLI invocation's wall-clock time. Zero uses
+	// defaultCLIAgentTimeout. The context deadline (run budget) still applies
+	// and wins when tighter.
+	Timeout time.Duration
+	// Logger is the leveled logger for diagnostic output.
+	Logger *iterlog.Logger
+}
+
+const (
+	maxCLIAgentRetries     = 3
+	defaultCLIAgentTimeout = 20 * time.Minute
+)
+
+// Execute runs the target CLI for the given task and parses its output into a
+// delegate.Result.
+func (b *CLIAgentBackend) Execute(ctx context.Context, task Task) (Result, error) {
+	if task.WorkDir != "" {
+		if err := validateWorkDir(task.WorkDir, task.BaseDir); err != nil {
+			return Result{}, err
+		}
+	}
+	proto := b.Protocol
+	backendName := proto.Name
+	if backendName == "" {
+		backendName = "cli_agent"
+	}
+
+	binary := b.Command
+	if binary == "" {
+		binary = proto.DefaultBinary
+	}
+	if binary == "" {
+		return Result{BackendName: backendName, ExitCode: -1},
+			fmt.Errorf("delegate: %s: no CLI binary configured (set command: or protocol DefaultBinary)", backendName)
+	}
+
+	systemPrompt := task.BuildSystemPrompt()
+	userPrompt := task.UserPrompt
+
+	// When the CLI exposes no system-prompt flag, fold the composed system
+	// prompt in as a preamble so the node's task still reaches the agent.
+	promptArg := userPrompt
+	if proto.SystemPromptFlag == "" && systemPrompt != "" {
+		if promptArg != "" {
+			promptArg = systemPrompt + "\n\n" + promptArg
+		} else {
+			promptArg = systemPrompt
+		}
+	}
+
+	args, stdinPrompt := b.buildArgs(proto, task, promptArg, systemPrompt)
+
+	env := os.Environ()
+	if proto.ResolveEnv != nil {
+		for k, v := range proto.ResolveEnv(ctx) {
+			env = append(env, k+"="+v)
+		}
+	}
+
+	timeout := b.Timeout
+	if timeout <= 0 {
+		timeout = defaultCLIAgentTimeout
+	}
+
+	start := time.Now()
+	stdout, stderr, exitCode, err := b.runWithRetry(ctx, task, binary, args, stdinPrompt, env, timeout)
+	duration := time.Since(start)
+
+	result := Result{
+		Duration:    duration,
+		ExitCode:    exitCode,
+		Stderr:      truncate(stderr, 8192),
+		BackendName: backendName,
+	}
+	if err != nil {
+		return result, err
+	}
+
+	// Parse the CLI's stdout into the assistant's final text, then apply the
+	// shared schema-aware fallback so `output:` schemas behave uniformly.
+	parse := proto.ParseOutput
+	if parse == nil {
+		parse = func(s string) (string, string, int) { return s, "", 0 }
+	}
+	text, sessionID, tokens := parse(stdout)
+	result.SessionID = sessionID
+	result.Tokens = tokens
+
+	output, rawLen, fallback := parseSDKOutput(&text, nil, task.OutputSchema)
+	result.Output = output
+	result.RawOutputLen = rawLen
+	result.ParseFallback = fallback
+
+	cost.Annotate(result.Output, task.Model, 0, tokens)
+	return result, nil
+}
+
+// buildArgs assembles the target CLI's argv from the protocol + task. It
+// returns the argument slice (excluding the binary itself) and the prompt to
+// pipe on stdin (empty unless the protocol uses stdin delivery).
+func (b *CLIAgentBackend) buildArgs(proto CLIAgentProtocol, task Task, promptArg, systemPrompt string) (args []string, stdinPrompt string) {
+	if proto.PromptViaStdin {
+		if proto.PromptFlag != "" {
+			args = append(args, proto.PromptFlag)
+		}
+		stdinPrompt = promptArg
+	} else if proto.PromptFlag != "" {
+		args = append(args, proto.PromptFlag, promptArg)
+	}
+
+	if proto.OutputFormatFlag != "" && proto.OutputFormat != "" {
+		args = append(args, proto.OutputFormatFlag, proto.OutputFormat)
+	}
+
+	if proto.ModelFlag != "" && task.Model != "" {
+		model := task.Model
+		if proto.MapModel != nil {
+			model = proto.MapModel(model)
+		}
+		if model != "" {
+			args = append(args, proto.ModelFlag, model)
+		}
+	}
+
+	if proto.SystemPromptFlag != "" && systemPrompt != "" {
+		args = append(args, proto.SystemPromptFlag, systemPrompt)
+	}
+
+	if proto.MapEffort != nil && task.ReasoningEffort != "" {
+		args = append(args, proto.MapEffort(task.ReasoningEffort)...)
+	}
+
+	args = append(args, proto.ExtraArgs...)
+	return args, stdinPrompt
+}
+
+// runWithRetry runs the CLI to completion, retrying up to maxCLIAgentRetries
+// when the process exits successfully but produces no stdout (a known
+// transient failure mode for streaming agent CLIs) or fails with a
+// network-signature error. Overflow/quota/fatal exits are surfaced fast.
+func (b *CLIAgentBackend) runWithRetry(ctx context.Context, task Task, binary string, args []string, stdinPrompt string, env []string, timeout time.Duration) (stdout, stderr string, exitCode int, err error) {
+	for attempt := 1; attempt <= maxCLIAgentRetries; attempt++ {
+		stdout, stderr, exitCode, err = b.runOnce(ctx, task, binary, args, stdinPrompt, env, timeout)
+
+		if err == nil && strings.TrimSpace(stdout) != "" {
+			return stdout, stderr, exitCode, nil
+		}
+
+		// Context cancelled/deadline: not retryable, surface immediately.
+		if ctx.Err() != nil {
+			return stdout, stderr, exitCode, fmt.Errorf("delegate: %s: context ended: %w", b.Protocol.Name, ctx.Err())
+		}
+
+		transient := err != nil && (MatchesNetworkSignature(err.Error()) || MatchesNetworkSignature(stderr))
+		empty := err == nil && strings.TrimSpace(stdout) == ""
+		if !transient && !empty {
+			// A genuine non-transient failure (bad flag, auth error, …):
+			// don't burn retries on a deterministic failure.
+			return stdout, stderr, exitCode, err
+		}
+
+		if attempt < maxCLIAgentRetries {
+			backoff := time.Duration(1<<uint(attempt-1)) * time.Second
+			if backoff > 8*time.Second {
+				backoff = 8 * time.Second
+			}
+			reason := "no output"
+			if transient {
+				reason = "transient error"
+			}
+			if b.Logger != nil {
+				b.Logger.Warn("[%s#%d/%s] %s (attempt %d/%d), retrying after %s",
+					task.NodeID, task.Iteration, b.Protocol.Name, reason, attempt, maxCLIAgentRetries, backoff)
+			}
+			select {
+			case <-ctx.Done():
+				return stdout, stderr, exitCode, fmt.Errorf("delegate: %s: context ended during retry: %w", b.Protocol.Name, ctx.Err())
+			case <-time.After(backoff):
+			}
+		}
+	}
+
+	if err != nil {
+		return stdout, stderr, exitCode, &ErrTransient{
+			Provider: b.Protocol.Name,
+			Reason:   "cli agent failed",
+			Detail:   fmt.Sprintf("%v after %d attempts", err, maxCLIAgentRetries),
+		}
+	}
+	return stdout, stderr, exitCode, fmt.Errorf("delegate: %s: no output after %d attempts", b.Protocol.Name, maxCLIAgentRetries)
+}
+
+// runOnce executes a single CLI invocation, on the host or (when the task is
+// sandboxed) inside the run's container, honouring the wall-clock timeout.
+func (b *CLIAgentBackend) runOnce(ctx context.Context, task Task, binary string, args []string, stdinPrompt string, env []string, timeout time.Duration) (stdout, stderr string, exitCode int, err error) {
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var outBuf, errBuf bytes.Buffer
+	argv := append([]string{binary}, args...)
+
+	var cmd *exec.Cmd
+	if task.Sandbox != nil {
+		cmd = task.Sandbox.Command(runCtx, argv, sandbox.ExecOpts{
+			Env:     envSliceToMap(b.Protocol.ResolveEnv, ctx),
+			WorkDir: task.WorkDir,
+		})
+	} else {
+		cmd = exec.CommandContext(runCtx, binary, args...) // #nosec G204 — binary/args are backend-configured, not attacker-controlled.
+		cmd.Env = env
+		if task.WorkDir != "" {
+			cmd.Dir = task.WorkDir
+		}
+	}
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	if stdinPrompt != "" {
+		cmd.Stdin = strings.NewReader(stdinPrompt)
+	}
+
+	runErr := cmd.Run()
+	stdout = outBuf.String()
+	stderr = errBuf.String()
+	if stderr != "" && b.Logger != nil {
+		for _, line := range strings.Split(strings.TrimRight(stderr, "\n"), "\n") {
+			if line != "" {
+				b.Logger.Info("[%s#%d/%s:err] %s", task.NodeID, task.Iteration, b.Protocol.Name, line)
+			}
+		}
+	}
+	if cmd.ProcessState != nil {
+		exitCode = cmd.ProcessState.ExitCode()
+	}
+	if runErr != nil {
+		return stdout, stderr, exitCode, fmt.Errorf("delegate: %s: %s failed: %w", b.Protocol.Name, binary, runErr)
+	}
+	return stdout, stderr, exitCode, nil
+}
+
+// envSliceToMap re-derives the ResolveEnv override map for the sandbox ExecOpts
+// path (the container already inherits its own base env; we only layer the
+// protocol's credential/endpoint overrides on top).
+func envSliceToMap(resolve func(context.Context) map[string]string, ctx context.Context) map[string]string {
+	if resolve == nil {
+		return nil
+	}
+	return resolve(ctx)
+}
+
+// parseStreamJSONText walks a claude-code-style NDJSON stream (`type: assistant`
+// text blocks + a terminal `type: result`) and extracts the assistant's final
+// text, session id, and token usage. It is defensive: unrecognised lines are
+// skipped, and when no `result` event is present it accumulates assistant text
+// blocks; when nothing parses it falls back to the raw stream. Third-party
+// agent CLIs that emit `--output-format stream-json` overwhelmingly mirror this
+// event shape; a protocol whose stream differs supplies its own ParseOutput.
+func parseStreamJSONText(stdout string) (text, sessionID string, tokens int) {
+	var assistantText strings.Builder
+	var resultText string
+	haveResult := false
+
+	for _, line := range strings.Split(stdout, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || line[0] != '{' {
+			continue
+		}
+		var ev map[string]any
+		if json.Unmarshal([]byte(line), &ev); ev == nil {
+			continue
+		}
+		if sid, ok := ev["session_id"].(string); ok && sid != "" {
+			sessionID = sid
+		}
+		typ, _ := ev["type"].(string)
+		switch typ {
+		case "result":
+			if r, ok := ev["result"].(string); ok {
+				resultText = r
+				haveResult = true
+			}
+			if u, ok := ev["usage"].(map[string]any); ok {
+				tokens += asInt(u["input_tokens"]) + asInt(u["output_tokens"])
+			}
+		case "assistant":
+			if msg, ok := ev["message"].(map[string]any); ok {
+				if content, ok := msg["content"].([]any); ok {
+					for _, c := range content {
+						if blk, ok := c.(map[string]any); ok {
+							if t, _ := blk["type"].(string); t == "text" {
+								if txt, ok := blk["text"].(string); ok {
+									assistantText.WriteString(txt)
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	switch {
+	case haveResult && resultText != "":
+		return resultText, sessionID, tokens
+	case assistantText.Len() > 0:
+		return assistantText.String(), sessionID, tokens
+	default:
+		// Nothing recognisable — hand back the raw stream so the schema-aware
+		// fallback can still try to extract a JSON object from it.
+		return stdout, sessionID, tokens
+	}
+}

--- a/pkg/backend/delegate/cliagent_test.go
+++ b/pkg/backend/delegate/cliagent_test.go
@@ -5,13 +5,33 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"testing"
 
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
 )
+
+// recordingRun is a minimal sandbox.Run that records the ExecOpts handed to
+// Command and runs a canned host command in the container's stead, so a
+// backend's sandbox wiring can be asserted without a real container.
+type recordingRun struct {
+	gotOpts sandbox.ExecOpts
+	script  string // sh -c body the fake "container" runs
+}
+
+func (r *recordingRun) Driver() string { return "recording" }
+func (r *recordingRun) Command(ctx context.Context, _ []string, opts sandbox.ExecOpts) *exec.Cmd {
+	r.gotOpts = opts
+	return exec.CommandContext(ctx, "sh", "-c", r.script) // #nosec G204 — test fixture
+}
+func (r *recordingRun) Exec(context.Context, []string, sandbox.ExecOpts) (sandbox.ExecResult, error) {
+	return sandbox.ExecResult{}, nil
+}
+func (r *recordingRun) Cleanup(context.Context) error { return nil }
 
 func testLogger() *iterlog.Logger { return iterlog.New(iterlog.LevelError, io.Discard) }
 
@@ -160,6 +180,35 @@ printf '%s\n' '{"type":"result","result":"{\"answer\":\"42\"}","session_id":"s9"
 	}
 	if res.Tokens != 10 {
 		t.Errorf("Tokens = %d, want 10", res.Tokens)
+	}
+}
+
+// TestCLIAgentSandboxStdin guards that a PromptViaStdin protocol running under
+// a sandbox routes its prompt through sandbox.ExecOpts.Stdin (so the container
+// driver allocates a forwarded stdin), rather than a post-hoc cmd.Stdin the
+// driver silently drops.
+func TestCLIAgentSandboxStdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake CLI is POSIX-only")
+	}
+	proto := CLIAgentProtocol{
+		Name:           "stdinbot",
+		DefaultBinary:  "stdinbot",
+		PromptViaStdin: true,
+		ParseOutput:    parseStreamJSONText,
+	}
+	run := &recordingRun{script: `printf '%s\n' '{"type":"result","result":"ok"}'`}
+	b := &CLIAgentBackend{Protocol: proto, Logger: testLogger()}
+	_, err := b.Execute(context.Background(), Task{NodeID: "n1", UserPrompt: "the prompt", Sandbox: run})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if run.gotOpts.Stdin == nil {
+		t.Fatal("ExecOpts.Stdin is nil — prompt would be dropped inside the container")
+	}
+	got, _ := io.ReadAll(run.gotOpts.Stdin)
+	if string(got) != "the prompt" {
+		t.Errorf("stdin = %q, want %q", got, "the prompt")
 	}
 }
 

--- a/pkg/backend/delegate/cliagent_test.go
+++ b/pkg/backend/delegate/cliagent_test.go
@@ -1,0 +1,172 @@
+package delegate
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+func testLogger() *iterlog.Logger { return iterlog.New(iterlog.LevelError, io.Discard) }
+
+func TestCLIAgentBuildArgs(t *testing.T) {
+	b := &CLIAgentBackend{Protocol: kimiProtocol, Logger: testLogger()}
+
+	t.Run("kimi native argv, system folded into prompt", func(t *testing.T) {
+		task := Task{
+			SystemPrompt:     "be terse",
+			SystemPromptMode: SystemPromptStandalone,
+			UserPrompt:       "hello",
+			Model:            "moonshot/kimi-k2",
+		}
+		promptArg := task.BuildSystemPrompt() + "\n\n" + task.UserPrompt
+		args, stdin := b.buildArgs(kimiProtocol, task, promptArg, task.BuildSystemPrompt())
+		want := []string{"-p", "be terse\n\nhello", "--output-format", "stream-json", "-m", "kimi-k2"}
+		if !reflect.DeepEqual(args, want) {
+			t.Fatalf("args = %v, want %v", args, want)
+		}
+		if stdin != "" {
+			t.Fatalf("stdin = %q, want empty (kimi passes prompt as -p arg)", stdin)
+		}
+	})
+
+	t.Run("no model flag when model empty", func(t *testing.T) {
+		args, _ := b.buildArgs(kimiProtocol, Task{UserPrompt: "x"}, "x", "")
+		for _, a := range args {
+			if a == "-m" {
+				t.Fatalf("unexpected -m flag with empty model: %v", args)
+			}
+		}
+	})
+
+	t.Run("stdin delivery", func(t *testing.T) {
+		proto := CLIAgentProtocol{Name: "t", DefaultBinary: "t", PromptFlag: "-", PromptViaStdin: true}
+		args, stdin := (&CLIAgentBackend{Protocol: proto}).buildArgs(proto, Task{UserPrompt: "hi"}, "hi", "")
+		if len(args) != 1 || args[0] != "-" {
+			t.Fatalf("args = %v, want [-]", args)
+		}
+		if stdin != "hi" {
+			t.Fatalf("stdin = %q, want hi", stdin)
+		}
+	})
+
+	t.Run("effort + extra args", func(t *testing.T) {
+		proto := CLIAgentProtocol{
+			Name: "t", DefaultBinary: "t", PromptFlag: "-p",
+			MapEffort: func(e string) []string { return []string{"--effort", e} },
+			ExtraArgs: []string{"--yes"},
+		}
+		args, _ := (&CLIAgentBackend{Protocol: proto}).buildArgs(proto, Task{UserPrompt: "x", ReasoningEffort: "high"}, "x", "")
+		want := []string{"-p", "x", "--effort", "high", "--yes"}
+		if !reflect.DeepEqual(args, want) {
+			t.Fatalf("args = %v, want %v", args, want)
+		}
+	})
+}
+
+func TestKimiMapModel(t *testing.T) {
+	cases := map[string]string{
+		"moonshot/kimi-k2": "kimi-k2",
+		"kimi/k2":          "k2",
+		"kimi-k2":          "kimi-k2",
+		"  moonshot/x  ":   "x",
+	}
+	for in, want := range cases {
+		if got := kimiMapModel(in); got != want {
+			t.Errorf("kimiMapModel(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestParseStreamJSONText(t *testing.T) {
+	t.Run("result event wins", func(t *testing.T) {
+		stream := `{"type":"assistant","message":{"content":[{"type":"text","text":"thinking"}]}}
+{"type":"result","result":"final answer","session_id":"sess-1","usage":{"input_tokens":10,"output_tokens":5}}`
+		text, sid, tokens := parseStreamJSONText(stream)
+		if text != "final answer" {
+			t.Errorf("text = %q, want %q", text, "final answer")
+		}
+		if sid != "sess-1" {
+			t.Errorf("sessionID = %q, want sess-1", sid)
+		}
+		if tokens != 15 {
+			t.Errorf("tokens = %d, want 15", tokens)
+		}
+	})
+
+	t.Run("falls back to assistant text when no result", func(t *testing.T) {
+		stream := `{"type":"assistant","message":{"content":[{"type":"text","text":"part1 "}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"part2"}]}}`
+		text, _, _ := parseStreamJSONText(stream)
+		if text != "part1 part2" {
+			t.Errorf("text = %q, want %q", text, "part1 part2")
+		}
+	})
+
+	t.Run("non-json falls back to raw", func(t *testing.T) {
+		text, _, _ := parseStreamJSONText("plain text output")
+		if text != "plain text output" {
+			t.Errorf("text = %q, want raw passthrough", text)
+		}
+	})
+}
+
+// TestCLIAgentExecute drives the backend end-to-end against a fake CLI script
+// that echoes a stream-json result, verifying argv assembly, stdout parsing,
+// and structured-output extraction.
+func TestCLIAgentExecute(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script fake CLI is POSIX-only")
+	}
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "fakekimi")
+	// The script emits a stream-json result whose text is a JSON object, so
+	// the schema-aware fallback extracts it into Result.Output.
+	script := `#!/bin/sh
+printf '%s\n' '{"type":"result","result":"{\"answer\":\"42\"}","session_id":"s9","usage":{"input_tokens":3,"output_tokens":7}}'
+`
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil { // #nosec G306 — test fixture must be executable
+		t.Fatal(err)
+	}
+
+	b := &CLIAgentBackend{Protocol: kimiProtocol, Command: fake, Logger: testLogger()}
+	task := Task{
+		NodeID:       "n1",
+		UserPrompt:   "what is the answer",
+		Model:        "moonshot/kimi-k2",
+		OutputSchema: json.RawMessage(`{"type":"object","properties":{"answer":{"type":"string"}}}`),
+	}
+	res, err := b.Execute(context.Background(), task)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.BackendName != BackendKimi {
+		t.Errorf("BackendName = %q, want %q", res.BackendName, BackendKimi)
+	}
+	if res.SessionID != "s9" {
+		t.Errorf("SessionID = %q, want s9", res.SessionID)
+	}
+	if res.ParseFallback {
+		t.Errorf("ParseFallback = true, want false (result was valid JSON)")
+	}
+	if got := res.Output["answer"]; got != "42" {
+		t.Errorf("Output[answer] = %v, want 42", got)
+	}
+	if res.Tokens != 10 {
+		t.Errorf("Tokens = %d, want 10", res.Tokens)
+	}
+}
+
+func TestCLIAgentExecuteNoBinary(t *testing.T) {
+	b := &CLIAgentBackend{Protocol: CLIAgentProtocol{Name: "x"}, Logger: testLogger()}
+	_, err := b.Execute(context.Background(), Task{UserPrompt: "hi"})
+	if err == nil {
+		t.Fatal("expected error when no binary configured")
+	}
+}

--- a/pkg/backend/delegate/kimi.go
+++ b/pkg/backend/delegate/kimi.go
@@ -1,0 +1,60 @@
+package delegate
+
+import (
+	"strings"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+// BackendKimi is the registration name for the Moonshot kimi-code backend
+// (`backend: "kimi"` in the DSL). It drives Moonshot's `kimi` CLI, whose
+// argument protocol is disjoint from claude-code's (it takes the prompt as
+// `-p <prompt>`, not `--print` with the prompt on stdin), so neither
+// `backend: "claude_code"` nor a per-node `command:` override (#76) can run
+// it. See ADR-065.
+const BackendKimi = "kimi"
+
+// kimiProtocol describes Moonshot's kimi-code CLI:
+//
+//	kimi -p <prompt> --output-format stream-json [-m <alias>]
+//
+// The prompt (with the node's `system:` task folded in as a preamble, since
+// kimi exposes no system-prompt flag) is passed as the value of `-p`; the CLI
+// emits a claude-code-style stream-json event stream we parse for the final
+// assistant text. Credentials/endpoint are resolved by the CLI itself from its
+// own environment/config (e.g. $MOONSHOT_API_KEY), so ResolveEnv is nil.
+var kimiProtocol = CLIAgentProtocol{
+	Name:             BackendKimi,
+	DefaultBinary:    "kimi",
+	PromptFlag:       "-p",
+	OutputFormatFlag: "--output-format",
+	OutputFormat:     "stream-json",
+	ModelFlag:        "-m",
+	MapModel:         kimiMapModel,
+	ParseOutput:      parseStreamJSONText,
+	// MapEffort nil: kimi-code has no reasoning-effort dial.
+	// ResolveEnv nil: kimi reads its own credentials from the host env/config.
+}
+
+// NewKimiBackend constructs the Moonshot kimi-code backend. command overrides
+// the default `kimi` binary (a pinned build / wrapper path); empty uses the
+// binary on PATH.
+func NewKimiBackend(logger *iterlog.Logger, command string) *CLIAgentBackend {
+	return &CLIAgentBackend{
+		Protocol: kimiProtocol,
+		Command:  command,
+		Logger:   logger,
+	}
+}
+
+// kimiMapModel translates an iterion model spec into the alias kimi's `-m`
+// flag expects. iterion specs are `provider/model` (e.g. "moonshot/kimi-k2");
+// kimi wants the bare alias, so we strip a leading provider segment. A spec
+// with no "/" is passed through unchanged (already an alias, e.g. "kimi-k2").
+func kimiMapModel(model string) string {
+	model = strings.TrimSpace(model)
+	if i := strings.Index(model, "/"); i >= 0 {
+		return model[i+1:]
+	}
+	return model
+}

--- a/pkg/backend/delegate/registry.go
+++ b/pkg/backend/delegate/registry.go
@@ -31,10 +31,12 @@ func (r *Registry) Resolve(name string) (Backend, error) {
 }
 
 // DefaultRegistry returns a registry pre-loaded with the standard
-// claude_code and codex backends.
+// claude_code and codex backends, plus the dedicated third-party
+// CLI-agent backends (currently: kimi, Moonshot's kimi-code — see ADR-065).
 func DefaultRegistry(logger *iterlog.Logger) *Registry {
 	r := NewRegistry()
 	r.Register(BackendClaudeCode, &ClaudeCodeBackend{Logger: logger})
 	r.Register(BackendCodex, &CodexBackend{Logger: logger})
+	r.Register(BackendKimi, NewKimiBackend(logger, ""))
 	return r
 }

--- a/pkg/server/webhooks_github_test.go
+++ b/pkg/server/webhooks_github_test.go
@@ -132,7 +132,8 @@ const ghForkTicketPR = `{
 
 // TestGitHubWebhook_TicketPRRoutesToBilly: a same-repo PR that closes an issue,
 // on a webhook that enables Billy, launches branch-improve-loop with Billy's
-// vars (open_mr=false — the PR already exists; no pr_url — not the review path).
+// vars (open_mr=false — the PR already exists; push_branch set — Billy pushes
+// in-place onto the PR; pr_url carried so Billy can post its review comment).
 func TestGitHubWebhook_TicketPRRoutesToBilly(t *testing.T) {
 	s := newWebhookTestServer(t)
 	var gotBot string
@@ -158,8 +159,11 @@ func TestGitHubWebhook_TicketPRRoutesToBilly(t *testing.T) {
 	if !strings.Contains(gotVars["scope_notes"], "Add subtract") {
 		t.Fatalf("scope_notes must carry the PR title/body: %q", gotVars["scope_notes"])
 	}
-	if _, ok := gotVars["pr_url"]; ok {
-		t.Fatalf("billy path must not use reviewPRVars (pr_url present): %v", gotVars)
+	if gotVars["push_branch"] != "feat/subtract" {
+		t.Fatalf("billy path must set push_branch to the PR source branch (in-place push, not the review path): %v", gotVars)
+	}
+	if gotVars["pr_url"] == "" {
+		t.Fatalf("billy carries pr_url so it can post its review-comment feedback on the PR: %v", gotVars)
 	}
 }
 


### PR DESCRIPTION
Adds a dedicated **CLI-agent backend** for third-party agent CLIs whose argument protocol differs from claude-code/codex — the concrete driver being Moonshot's `kimi-code` (`kimi -p <prompt> --output-format stream-json [-m <model>]`), which is *not* claude-code-argument-compatible and therefore cannot be driven by `backend: claude_code` nor the per-node `command:` override (#76).

### Slices landed
- **feat(delegate):** dedicated CLI-agent backend for kimi-code — builds the target CLI's native argv (`kimi -p …`), runs it with a wall-clock timeout, parses stdout into `delegate.Result`, maps model/effort/tools/output-schema onto what the target CLI actually supports, and resolves credentials/endpoint from the target CLI's own config/env.
- **docs(adr):** ADR-065 — dedicated CLI-agent backend for non-claude-code argv.
- **docs(backends):** document the kimi backend + the CLI-agent seam.

### Relation to #76
#76 remains the generic per-node `command:` override for *claude-code-compatible* CLIs (pinned build, compatible wrapper/proxy). This series covers the separate, larger need: running an agent CLI with a **different** argument protocol.

Closes #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via an iterion improvement run.