### PR TITLE
feat(board): board-as-pipeline-projection slice + ADR-071 (refs #125)

### DIFF
--- a/docs/adr/071-board-as-pipeline-projection.md
+++ b/docs/adr/071-board-as-pipeline-projection.md
@@ -1,0 +1,122 @@
+# ADR-071 — Board as a projection of a pipeline (additive)
+
+Status: **proposed** (2026-07-12). Records the target direction from
+[issue #125](https://github.com/SocialGouv/iterion/issues/125) and the
+decisions taken on its load-bearing forks. Frames the shift **additively**:
+the pipeline view is a projection layered over the existing shared board, not
+a replacement of it. The first concrete increment (a short-term slice on
+existing seams) ships alongside this ADR; the deeper inversion (a ticket that
+*is* a pipeline instance with a child/shards tree) stays an open tension.
+
+## Context
+
+Today the native kanban board is a **generic shared backlog**: a queue of
+tickets the dispatcher consumes to launch runs. The proposal in #125 is to
+evolve it toward a **live projection of a pipeline** — one board = one
+pipeline (+ its children), columns = the human interactions the pipeline
+needs, and cards in a "human feedback" column answerable directly from the
+board.
+
+The current model, verified against the source (2026-07-12):
+
+- **`Board{States,Fields,Views,UpdatedAt}` has no identity** — no id/name/
+  pipeline/bot. Identity *is* the storage path; one board per store (local) /
+  per tenant (cloud) ([board.go](../../pkg/dispatcher/native/board.go)).
+- **The ticket carries the bot** (`Issue.Bot`/`BotArgs`/`Assignee`), not the
+  board. The dispatcher routes *many* bots from one board, per-ticket, never
+  per-column ([config.go](../../pkg/dispatcher/config.go)).
+- **Ticket→run is a single overwritten `LastRunID` pointer** — no history, no
+  parent/child (only `Blockers`). The parent/child/shards tree lives only in
+  `pkg/queue`, invisible to the board.
+- **`State` carries only `Eligible`/`Terminal`** — no "awaiting human"
+  semantic; it is only *implied* by a non-eligible non-terminal column.
+- **The human answers off the board.** A run that pauses goes
+  `paused_waiting_human` and is answered only via the run console /
+  `iterion resume`; a *dispatched* run that pauses is parked in-progress and
+  the operator is sent to the run console
+  ([commands.go](../../pkg/dispatcher/commands.go)). The board's only human
+  channel (comments / slash-commands) *launches a new run*.
+
+Two facts about the seams matter for the design:
+
+1. **`QueueMessage` cannot unblock a paused human node** — it only queues a
+   cooperative message drained into the system prompt at the next pause. Only
+   **`Resume`** records structured answers and re-enters the graph. So
+   answering-from-board must target `Resume`.
+2. **A pause was signal-less on the trigger bus** — the run-lifecycle kinds
+   were only `run.finished/failed/cancelled`, and `emitRunCompletion`
+   *mislabeled* a pause as `run.failed`. A board projection that marks a card
+   "awaiting input" needs a real pause signal.
+
+## Decision
+
+### D1 — Additive projection, not replacement
+Keep the shared backlog board as the dispatcher's substrate. Add the pipeline
+view as a **new projection** (a filtered lens over the same store), not a new
+per-pipeline board file. The two answer different questions — "what's queued,
+all bots" vs "where is THIS pipeline and what does it need from me" — and the
+dispatcher's per-state concurrency / eligibility / one-tracker-per-config
+model, which rests on a single shared board, stays untouched.
+
+### D2 — A single generic "awaiting input" column
+Human interactions are **dynamic** (0, 1, or N per run, schema-driven) and do
+not map cleanly onto a fixed set of columns. Rather than statically extracting
+per-interaction columns from the IR graph (fragile under loops / conditionals
+/ dynamic `ask_user`), a **single "awaiting input" column** holds every paused
+card, and each card carries its own pause state (node + questions) read from
+the run checkpoint.
+
+### D3 — Answer from the board via `Resume` + a real pause signal
+The answer affordance reuses the run-console interaction contract verbatim
+(`PauseForm` → `POST /api/runs/{id}/resume {answers}`), keyed on
+`Issue.LastRunID → GET /api/runs/{id}` and gated on `paused_waiting_human`.
+A new `run.paused` trigger kind (`KindRunPaused`) replaces the mislabeled
+`run.failed`, so a future live projection can subscribe to "this card now
+needs input" the same way `board_source` bridges board→run.
+
+## Tensions — decided or open
+
+| # | Tension | Resolution |
+|---|---------|-----------|
+| T1 | Shared board → board-per-pipeline breaks dispatcher concurrency/eligibility semantics | **Decided (D1):** unchanged. The shared board stays the substrate; the pipeline view is a filter, so the limits keep meaning. |
+| T2 | Where does a board's identity live + how does it bind to a pipeline? | **Decided (D1):** a projection is scoped by a *filter* over the shared store (labels / bot), not a new board identity. Inverting the `kind:board` bot→board subscription is not required for the projection. |
+| T3 | Dynamic per-run interactions → fixed columns | **Decided (D2):** one "awaiting input" column, per-card pause state. |
+| T5 | Which seam to answer from? | **Decided (D3):** `Resume` (not `QueueMessage`) + a `run.paused` signal. |
+| T4 | Project the parent/child/shards tree onto cards | **Open.** Needs a ticket↔runs **1:N** model; today it is a single `LastRunID` pointer and the tree lives only in `pkg/queue`. A follow-on. |
+| T6 | Is the board the source of truth for forge ingestion (self-hosted), or a mirror? | **Decided: mirror.** Generalize the cloud forge→board sync to self-hosted (`SyncForgeIssuesToBoard`); the forge stays authoritative. |
+
+## First increment (shipped with this ADR)
+
+A short-term slice on existing seams, independent of the open tensions:
+
+- **`run.paused` trigger signal** — `KindRunPaused` + fix the
+  `emitRunCompletion` mislabel so a pause emits `run.paused` (carrying
+  `node_id` + `interaction_id`), not `run.failed`
+  ([trigger_emit.go](../../pkg/runview/trigger_emit.go)).
+- **Answer-from-board affordance** — the paused-run answer form mounted on the
+  board card's Last-run panel, reusing `PauseForm` and resolving to `Resume`
+  with **no source** (the server falls back to the run's persisted FilePath;
+  passing the operator's editor buffer would resume an unrelated workflow)
+  ([LastRunSection.tsx](../../studio/src/views/Board/issueModal/LastRunSection.tsx)).
+- **`board.create` MCP parity** — the `create_issue` boardop now accepts
+  `bot`/`bot_args`, matching REST `POST /issues`
+  ([ops.go](../../pkg/dispatcher/native/boardops/ops.go)), so a board-fed
+  pipeline can be pinned at create time on all three transports.
+- **Unified "feed the first column"** — the canonical ingest contract
+  (`POST /issues` with no `state` → first column, PAT `iap_`) is documented,
+  and the forge→board sync core is extracted store-agnostic
+  (`SyncForgeIssuesToBoard`) so a self-hosted import can reuse it.
+
+## Consequences
+
+- No migration: the change is additive; existing boards, dispatchers, and
+  bots are unaffected.
+- The `run.paused` fix removes a latent bug (a pause polluting the run-failed
+  chain), independent of the board work.
+- **Deferred** (open tensions, follow-ons): the ticket↔runs 1:N history and
+  parent/child/shards tree projection (T4); the self-hosted forge-import entry
+  point (a forge client + repo→board mapping without a cloud integration
+  store) that wires `SyncForgeIssuesToBoard` (T6); a board-wide per-card
+  "awaiting input" badge (needs a denormalized `awaiting_input` signal on the
+  issue to avoid an N+1 run fetch on every board render); and moving a parked
+  dispatched run's card into the "awaiting input" column on pause.

--- a/docs/adr/071-board-as-pipeline-projection.md
+++ b/docs/adr/071-board-as-pipeline-projection.md
@@ -83,7 +83,7 @@ needs input" the same way `board_source` bridges board→run.
 | T3 | Dynamic per-run interactions → fixed columns | **Decided (D2):** one "awaiting input" column, per-card pause state. |
 | T5 | Which seam to answer from? | **Decided (D3):** `Resume` (not `QueueMessage`) + a `run.paused` signal. |
 | T4 | Project the parent/child/shards tree onto cards | **Open.** Needs a ticket↔runs **1:N** model; today it is a single `LastRunID` pointer and the tree lives only in `pkg/queue`. A follow-on. |
-| T6 | Is the board the source of truth for forge ingestion (self-hosted), or a mirror? | **Decided: mirror.** Generalize the cloud forge→board sync to self-hosted (`SyncForgeIssuesToBoard`); the forge stays authoritative. |
+| T6 | Is the board the source of truth for forge ingestion (self-hosted), or a mirror? | **Decided: mirror.** Generalize the cloud forge→board sync to self-hosted (`syncForgeIssuesToBoard`); the forge stays authoritative. |
 
 ## First increment (shipped with this ADR)
 
@@ -105,7 +105,7 @@ A short-term slice on existing seams, independent of the open tensions:
 - **Unified "feed the first column"** — the canonical ingest contract
   (`POST /issues` with no `state` → first column, PAT `iap_`) is documented,
   and the forge→board sync core is extracted store-agnostic
-  (`SyncForgeIssuesToBoard`) so a self-hosted import can reuse it.
+  (`syncForgeIssuesToBoard`) so a self-hosted import can reuse it.
 
 ## Consequences
 
@@ -116,7 +116,7 @@ A short-term slice on existing seams, independent of the open tensions:
 - **Deferred** (open tensions, follow-ons): the ticket↔runs 1:N history and
   parent/child/shards tree projection (T4); the self-hosted forge-import entry
   point (a forge client + repo→board mapping without a cloud integration
-  store) that wires `SyncForgeIssuesToBoard` (T6); a board-wide per-card
+  store) that wires `syncForgeIssuesToBoard` (T6); a board-wide per-card
   "awaiting input" badge (needs a denormalized `awaiting_input` signal on the
   issue to avoid an N+1 run fetch on every board render); and moving a parked
   dispatched run's card into the "awaiting input" column on pause.

--- a/docs/native-tracker.md
+++ b/docs/native-tracker.md
@@ -240,7 +240,7 @@ an operator clicking "add") uses the **same** contract:
 - **A pipeline feeding the board (6b).** A run-completion `run.finished`
   trigger event chains a downstream launch (`serviceLauncher` /
   `NativeBoardEffect`) that can create the next card.
-- **Forge import (6a, self-hosted).** `SyncForgeIssuesToBoard`
+- **Forge import (6a, self-hosted).** `syncForgeIssuesToBoard`
   ([board_forge.go](../pkg/server/board_forge.go)) is the store-agnostic core
   that mirrors a repo's forge issues into a native board — one-way, forge is
   the source of truth, cards land in the first column on create and refresh in

--- a/docs/native-tracker.md
+++ b/docs/native-tracker.md
@@ -165,6 +165,9 @@ one of:
 
 - the REST API (`POST` / `PATCH` `/api/v1/native/issues` with
   `{ "bot": "feature_dev", "bot_args": { "feature_prompt": "…" } }`),
+- the board MCP / claw tools (`create_issue` and `set_bot` both accept
+  `bot` / `bot_args`, so a bot with the `board.create` / `board.assign`
+  capability can pin routing at create time),
 - a direct `native.Store.Create` / `Update` call from Go,
 - or rely on the dispatcher-side `assignee_workflows:` /
   `assignee_dispatch:` mappings keyed on `--assignee` (see
@@ -218,6 +221,32 @@ as a local kanban for:
 - **Lightweight personal queue.** Replace a sticky-note `TODO.md`
   with something that survives reflows, accepts custom fields, and
   speaks JSON.
+
+## Feeding the first column (the canonical ingest contract)
+
+The board's leftmost column is the single, canonical entry point for new
+work — whatever puts a card there (CI, an API caller, another pipeline, or
+an operator clicking "add") uses the **same** contract:
+
+- **`POST /api/v1/native/issues` with no `state`.** `Store.Create` defaults
+  an empty `state` to the board's first column
+  ([store.go](../pkg/dispatcher/native/store.go) — `in.State = States[0].Name`),
+  so an ingester never needs to know the column's name. The body may carry
+  `bot` / `bot_args` to pin the pipeline that will run the card (parity across
+  REST, the MCP `create_issue` boardop, and claw's `mcp.iterion_board.create`).
+  Authenticate a machine caller with a `iap_` PAT (see *Programmatic access*).
+- **CI / external API (6a).** A CI job POSTs a finding straight onto the
+  first column — no dispatcher required.
+- **A pipeline feeding the board (6b).** A run-completion `run.finished`
+  trigger event chains a downstream launch (`serviceLauncher` /
+  `NativeBoardEffect`) that can create the next card.
+- **Forge import (6a, self-hosted).** `SyncForgeIssuesToBoard`
+  ([board_forge.go](../pkg/server/board_forge.go)) is the store-agnostic core
+  that mirrors a repo's forge issues into a native board — one-way, forge is
+  the source of truth, cards land in the first column on create and refresh in
+  place on update. It is wired for cloud today; the self-hosted entry point
+  (resolving a forge client + repo→board mapping without a cloud integration
+  store) is a follow-on (see ADR-071).
 
 ## Programmatic access
 

--- a/pkg/dispatcher/native/boardops/ops.go
+++ b/pkg/dispatcher/native/boardops/ops.go
@@ -271,11 +271,11 @@ func Call(store native.BoardStore, caps Capabilities, name string, rawArgs json.
 
 func doCreate(store native.BoardStore, raw json.RawMessage) (json.RawMessage, error) {
 	var args struct {
-		Title    string         `json:"title"`
-		Body     string         `json:"body"`
-		State    string         `json:"state"`
-		Labels   []string       `json:"labels"`
-		Priority int            `json:"priority"`
+		Title    string            `json:"title"`
+		Body     string            `json:"body"`
+		State    string            `json:"state"`
+		Labels   []string          `json:"labels"`
+		Priority int               `json:"priority"`
 		Assignee string            `json:"assignee"`
 		Blockers []string          `json:"blockers"`
 		Fields   map[string]any    `json:"fields"`

--- a/pkg/dispatcher/native/boardops/ops.go
+++ b/pkg/dispatcher/native/boardops/ops.go
@@ -124,7 +124,9 @@ var allTools = []Tool{
             "priority":{"type":"integer","description":"Higher = more important. Default 0."},
             "assignee":{"type":"string","description":"Bot or user handle this issue is assigned to."},
             "blockers":{"type":"array","items":{"type":"string"},"description":"IDs of issues that must be terminal before this one is eligible."},
-            "fields":{"type":"object","description":"Custom board fields (validated against board schema)."}
+            "fields":{"type":"object","description":"Custom board fields (validated against board schema)."},
+            "bot":{"type":"string","description":"CANONICAL bot that runs this issue when the dispatcher picks it up (e.g. feature-dev). The dispatcher routes by bot first, else assignee."},
+            "bot_args":{"type":"object","additionalProperties":{"type":"string"},"description":"Per-ticket workflow var overrides (--var key=value) applied at launch."}
           },
           "required":["title"]
         }`),
@@ -274,9 +276,11 @@ func doCreate(store native.BoardStore, raw json.RawMessage) (json.RawMessage, er
 		State    string         `json:"state"`
 		Labels   []string       `json:"labels"`
 		Priority int            `json:"priority"`
-		Assignee string         `json:"assignee"`
-		Blockers []string       `json:"blockers"`
-		Fields   map[string]any `json:"fields"`
+		Assignee string            `json:"assignee"`
+		Blockers []string          `json:"blockers"`
+		Fields   map[string]any    `json:"fields"`
+		Bot      string            `json:"bot"`
+		BotArgs  map[string]string `json:"bot_args"`
 	}
 	if err := unmarshalArgs(raw, &args); err != nil {
 		return nil, err
@@ -293,6 +297,8 @@ func doCreate(store native.BoardStore, raw json.RawMessage) (json.RawMessage, er
 		Assignee: args.Assignee,
 		Blockers: args.Blockers,
 		Fields:   args.Fields,
+		Bot:      args.Bot,
+		BotArgs:  args.BotArgs,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/dispatcher/native/boardops/ops_test.go
+++ b/pkg/dispatcher/native/boardops/ops_test.go
@@ -207,6 +207,33 @@ func TestSetBot_SetsBotFieldNotAssignee(t *testing.T) {
 	}
 }
 
+func TestCreateIssue_SetsBotAndBotArgs(t *testing.T) {
+	s := newStore(t)
+	caps := NewCapabilities("board.create")
+	// The MCP create_issue must reach parity with REST POST /issues, which
+	// already accepts bot/bot_args: a board-fed pipeline needs its bot pinned
+	// at create time, without a follow-up set_bot round trip.
+	res, err := Call(s, caps, "create_issue", json.RawMessage(
+		`{"title":"Ship feature","bot":"feature-dev","bot_args":{"feature_prompt":"add X"}}`))
+	if err != nil {
+		t.Fatalf("create_issue: %v", err)
+	}
+	var iss native.Issue
+	if err := json.Unmarshal(res, &iss); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Get(iss.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Bot != "feature-dev" {
+		t.Errorf("Bot = %q, want feature-dev", got.Bot)
+	}
+	if got.BotArgs["feature_prompt"] != "add X" {
+		t.Errorf("BotArgs = %+v, want feature_prompt=add X", got.BotArgs)
+	}
+}
+
 func TestSetBot_RequiresAssignCapability(t *testing.T) {
 	s := newStore(t)
 	// Only board.read granted → set_bot (needs board.assign) must be denied.

--- a/pkg/runview/service_launch.go
+++ b/pkg/runview/service_launch.go
@@ -488,10 +488,11 @@ func (s *Service) spawnRun(
 			nctx := store.WithoutTenantFilter(context.Background())
 			s.completionNotifier.FireForRun(nctx, s.store, runID)
 		}
-		// Emit the run-completion trigger event ("runned by iterion"): a
+		// Emit the run-outcome trigger event ("runned by iterion"): a
 		// finished/failed/cancelled run can fire downstream runs (pipelines,
-		// on-failure escalation). No-op unless an event publisher is wired.
-		s.emitRunCompletion(runID, bodyErr)
+		// on-failure escalation), and a paused run marks its board card
+		// "awaiting input". No-op unless an event publisher is wired.
+		s.emitRunOutcome(runID, bodyErr)
 		// On cancel, the engine flipped run.Status to cancelled but didn't
 		// run finalizeWorktree (that's the success path only). If the run
 		// produced commits, RecoverFinalize promotes the worktree HEAD to

--- a/pkg/runview/trigger_emit.go
+++ b/pkg/runview/trigger_emit.go
@@ -10,9 +10,11 @@ import (
 	"github.com/SocialGouv/iterion/pkg/trigger"
 )
 
-// emitRunCompletion publishes a run-completion trigger.Event when a run reaches
-// a terminal state — the "runned by iterion" source that lets a finished or
-// failed run fire downstream runs (pipelines, on-failure escalation). It is a
+// emitRunOutcome publishes a run-outcome trigger.Event when a run leaves the
+// engine — the "runned by iterion" source that lets a finished/failed run fire
+// downstream runs (pipelines, on-failure escalation) and a paused run mark its
+// board card "awaiting input". The kind spans terminal outcomes
+// (run.finished/failed/cancelled) AND the non-terminal run.paused. It is a
 // best-effort no-op unless an event publisher is wired, and never blocks the
 // run goroutine on a slow consumer (the bus fan-out is itself lossy).
 //
@@ -20,7 +22,7 @@ import (
 // status to the run record, re-read here to enrich the event with repo/bot for
 // matching and templating). A load failure still emits the bare event so a
 // downstream subscription keyed only on source/kind/bot still fires.
-func (s *Service) emitRunCompletion(runID string, bodyErr error) {
+func (s *Service) emitRunOutcome(runID string, bodyErr error) {
 	if s.eventPublisher == nil {
 		return
 	}
@@ -51,14 +53,14 @@ func (s *Service) emitRunCompletion(runID string, bodyErr error) {
 		}
 		// Trust the persisted status over the derived kind when it is
 		// unambiguous (the engine is the source of truth).
-		switch r.Status {
-		case store.RunStatusFinished:
+		switch {
+		case r.Status == store.RunStatusFinished:
 			kind = trigger.KindRunFinished
-		case store.RunStatusFailed, store.RunStatusFailedResumable:
+		case r.Status == store.RunStatusFailed, r.Status == store.RunStatusFailedResumable:
 			kind = trigger.KindRunFailed
-		case store.RunStatusCancelled:
+		case r.Status == store.RunStatusCancelled:
 			kind = trigger.KindRunCancelled
-		case store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator:
+		case r.Status.IsPaused():
 			kind = trigger.KindRunPaused
 		}
 		// A paused run carries the node + pending interaction on its

--- a/pkg/runview/trigger_emit.go
+++ b/pkg/runview/trigger_emit.go
@@ -24,16 +24,23 @@ func (s *Service) emitRunCompletion(runID string, bodyErr error) {
 	if s.eventPublisher == nil {
 		return
 	}
+	// A pause is NOT a terminal failure. Match it BEFORE the bodyErr!=nil arm
+	// so a run that suspends on a human node (ErrRunPaused) or an operator
+	// soft-pause (ErrRunPausedOperator) emits run.paused, not run.failed. This
+	// is load-failure-resilient: it holds even when the persisted-status enrich
+	// below can't read the run.
 	kind := trigger.KindRunFinished
 	switch {
 	case errors.Is(bodyErr, runtime.ErrRunCancelled):
 		kind = trigger.KindRunCancelled
+	case errors.Is(bodyErr, runtime.ErrRunPaused), errors.Is(bodyErr, runtime.ErrRunPausedOperator):
+		kind = trigger.KindRunPaused
 	case bodyErr != nil:
 		kind = trigger.KindRunFailed
 	}
 
 	fctx := store.WithoutTenantFilter(context.Background())
-	var repo, botID, status, name string
+	var repo, botID, status, name, nodeID, interactionID string
 	if r, err := s.store.LoadRun(fctx, runID); err == nil && r != nil {
 		repo = r.ProjectPath
 		botID = r.BotID
@@ -42,8 +49,8 @@ func (s *Service) emitRunCompletion(runID string, bodyErr error) {
 		if name == "" {
 			name = r.WorkflowName
 		}
-		// Trust the persisted terminal status over the derived kind when it
-		// is unambiguous (the engine is the source of truth).
+		// Trust the persisted status over the derived kind when it is
+		// unambiguous (the engine is the source of truth).
 		switch r.Status {
 		case store.RunStatusFinished:
 			kind = trigger.KindRunFinished
@@ -51,9 +58,25 @@ func (s *Service) emitRunCompletion(runID string, bodyErr error) {
 			kind = trigger.KindRunFailed
 		case store.RunStatusCancelled:
 			kind = trigger.KindRunCancelled
+		case store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator:
+			kind = trigger.KindRunPaused
+		}
+		// A paused run carries the node + pending interaction on its
+		// checkpoint; surface both so a board projection can pinpoint the
+		// paused node and render the answer affordance.
+		if r.Checkpoint != nil {
+			nodeID = r.Checkpoint.NodeID
+			interactionID = r.Checkpoint.InteractionID
 		}
 	}
 
+	payload := map[string]any{"bot_id": botID, "status": status, "run_id": runID}
+	if nodeID != "" {
+		payload["node_id"] = nodeID
+	}
+	if interactionID != "" {
+		payload["interaction_id"] = interactionID
+	}
 	ev := trigger.Event{
 		ID:         "run:" + runID,
 		Source:     trigger.SourceRun,
@@ -61,7 +84,7 @@ func (s *Service) emitRunCompletion(runID string, bodyErr error) {
 		Repo:       repo,
 		Subject:    trigger.Subject{Type: "run", ID: runID, Title: name, State: status},
 		Actor:      botID,
-		Payload:    map[string]any{"bot_id": botID, "status": status, "run_id": runID},
+		Payload:    payload,
 		OccurredAt: time.Now().UTC(),
 	}
 	_ = s.eventPublisher.Publish(fctx, ev)

--- a/pkg/runview/trigger_emit_test.go
+++ b/pkg/runview/trigger_emit_test.go
@@ -17,14 +17,14 @@ func (c *capturePublisher) Publish(_ context.Context, ev trigger.Event) error {
 	return nil
 }
 
-func TestEmitRunCompletionKinds(t *testing.T) {
+func TestEmitRunOutcomeKinds(t *testing.T) {
 	svc, err := NewService(t.TempDir(), WithLogger(iterlog.Nop()))
 	if err != nil {
 		t.Fatalf("NewService: %v", err)
 	}
 
 	// No publisher → no-op (must not panic).
-	svc.emitRunCompletion("run-x", nil)
+	svc.emitRunOutcome("run-x", nil)
 
 	cap := &capturePublisher{}
 	svc.SetEventPublisher(cap)
@@ -47,7 +47,7 @@ func TestEmitRunCompletionKinds(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			before := len(cap.events)
-			svc.emitRunCompletion(tc.runID, tc.bodyErr)
+			svc.emitRunOutcome(tc.runID, tc.bodyErr)
 			if len(cap.events) != before+1 {
 				t.Fatalf("expected one event emitted, got %d", len(cap.events)-before)
 			}

--- a/pkg/runview/trigger_emit_test.go
+++ b/pkg/runview/trigger_emit_test.go
@@ -38,6 +38,11 @@ func TestEmitRunCompletionKinds(t *testing.T) {
 		{"finished", "run-1", nil, trigger.KindRunFinished},
 		{"failed", "run-2", errors.New("boom"), trigger.KindRunFailed},
 		{"cancelled", "run-3", runtime.ErrRunCancelled, trigger.KindRunCancelled},
+		// A pause must NOT be mislabeled run.failed. With no persisted run the
+		// enrich switch can't run, so this asserts the load-resilient
+		// bodyErr-branch fix specifically.
+		{"paused_human", "run-4", runtime.ErrRunPaused, trigger.KindRunPaused},
+		{"paused_operator", "run-5", runtime.ErrRunPausedOperator, trigger.KindRunPaused},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/server/board_forge.go
+++ b/pkg/server/board_forge.go
@@ -122,10 +122,10 @@ func (s *Server) forgeIntegrationForTenant(w http.ResponseWriter, r *http.Reques
 // forge → board sync (one-way; the source is the forge)
 // ---------------------------------------------------------------------------
 
-// SyncForgeIssuesToBoard mirrors one repo's forge issues into a native board.
+// syncForgeIssuesToBoard mirrors one repo's forge issues into a native board.
 // It is store- and cloud-agnostic — it takes an already-resolved issue client
 // + board — so the cloud per-team sync and a (future) self-hosted single-store
-// import share ONE implementation. Forge is the source of truth (one-way);
+// import can share ONE implementation. Forge is the source of truth (one-way);
 // pull requests are skipped (they surface via the card PR panel). Cards land in
 // the first non-terminal column on create and refresh in place on update; see
 // upsertForgeCard for the column policy. Returns per-issue create/update counts.
@@ -133,7 +133,7 @@ func (s *Server) forgeIntegrationForTenant(w http.ResponseWriter, r *http.Reques
 // The high-water mark (LastSyncedAt) is the caller's concern — it is the only
 // piece that differs between the cloud integration store and a self-hosted
 // entry point, so it stays out of this pure core.
-func SyncForgeIssuesToBoard(ctx context.Context, ic forge.IssueClient, provider forge.Provider, connID, repo string, board native.BoardStore, since time.Time) (created, updated int, err error) {
+func syncForgeIssuesToBoard(ctx context.Context, ic forge.IssueClient, provider forge.Provider, connID, repo string, board native.BoardStore, since time.Time) (created, updated int, err error) {
 	issues, err := ic.ListIssues(ctx, repo, forge.IssueListOptions{
 		State: "all", Since: since, PerPage: 100,
 	})
@@ -162,7 +162,7 @@ func SyncForgeIssuesToBoard(ctx context.Context, ic forge.IssueClient, provider 
 
 // syncOneIntegration mirrors one repo's forge issues into the team board and
 // stamps the integration's LastSyncedAt high-water mark. It is the cloud
-// wrapper around SyncForgeIssuesToBoard: it resolves the connection → issue
+// wrapper around syncForgeIssuesToBoard: it resolves the connection → issue
 // client → team board, then persists the high-water mark. It is the unit both
 // the manual "Sync now" endpoint and the periodic worker call.
 func (s *Server) syncOneIntegration(ctx context.Context, teamID string, ri forge.RepoIntegration) (created, updated int, err error) {
@@ -182,10 +182,9 @@ func (s *Server) syncOneIntegration(ctx context.Context, teamID string, ri forge
 	if board == nil {
 		return 0, 0, errors.New("no board for team")
 	}
-	created, updated, err = SyncForgeIssuesToBoard(ctx, ic, conn.Provider, ri.ConnectionID, ri.RepoFullName, board, ri.LastSyncedAt)
-	// Advance the high-water mark unconditionally (mirrors the prior
-	// behaviour): a partial-failure sync still records progress on the
-	// issues it did upsert.
+	created, updated, err = syncForgeIssuesToBoard(ctx, ic, conn.Provider, ri.ConnectionID, ri.RepoFullName, board, ri.LastSyncedAt)
+	// Advance the high-water mark unconditionally: a partial-failure sync
+	// still records progress on the issues it did upsert.
 	ri.LastSyncedAt = time.Now().UTC()
 	if uerr := s.forgeIntegrations.Update(ctx, ri); uerr != nil && err == nil {
 		err = uerr

--- a/pkg/server/board_forge.go
+++ b/pkg/server/board_forge.go
@@ -122,8 +122,48 @@ func (s *Server) forgeIntegrationForTenant(w http.ResponseWriter, r *http.Reques
 // forge → board sync (one-way; the source is the forge)
 // ---------------------------------------------------------------------------
 
+// SyncForgeIssuesToBoard mirrors one repo's forge issues into a native board.
+// It is store- and cloud-agnostic — it takes an already-resolved issue client
+// + board — so the cloud per-team sync and a (future) self-hosted single-store
+// import share ONE implementation. Forge is the source of truth (one-way);
+// pull requests are skipped (they surface via the card PR panel). Cards land in
+// the first non-terminal column on create and refresh in place on update; see
+// upsertForgeCard for the column policy. Returns per-issue create/update counts.
+//
+// The high-water mark (LastSyncedAt) is the caller's concern — it is the only
+// piece that differs between the cloud integration store and a self-hosted
+// entry point, so it stays out of this pure core.
+func SyncForgeIssuesToBoard(ctx context.Context, ic forge.IssueClient, provider forge.Provider, connID, repo string, board native.BoardStore, since time.Time) (created, updated int, err error) {
+	issues, err := ic.ListIssues(ctx, repo, forge.IssueListOptions{
+		State: "all", Since: since, PerPage: 100,
+	})
+	if err != nil {
+		return 0, 0, fmt.Errorf("list issues: %w", err)
+	}
+	b := board.Board()
+	openCol := defaultOpenColumn(b)
+	doneCol := terminalColumn(b)
+	for _, is := range issues {
+		if is.IsPullRequest {
+			continue // the board syncs ISSUES; PRs surface via the card PR panel
+		}
+		c, u, e := upsertForgeCard(board, b, openCol, doneCol, provider, connID, repo, is)
+		if e != nil {
+			if err == nil {
+				err = e
+			}
+			continue
+		}
+		created += c
+		updated += u
+	}
+	return created, updated, err
+}
+
 // syncOneIntegration mirrors one repo's forge issues into the team board and
-// stamps the integration's LastSyncedAt high-water mark. It is the unit both
+// stamps the integration's LastSyncedAt high-water mark. It is the cloud
+// wrapper around SyncForgeIssuesToBoard: it resolves the connection → issue
+// client → team board, then persists the high-water mark. It is the unit both
 // the manual "Sync now" endpoint and the periodic worker call.
 func (s *Server) syncOneIntegration(ctx context.Context, teamID string, ri forge.RepoIntegration) (created, updated int, err error) {
 	conn, err := s.forgeConnections.Get(ctx, ri.ConnectionID)
@@ -142,29 +182,10 @@ func (s *Server) syncOneIntegration(ctx context.Context, teamID string, ri forge
 	if board == nil {
 		return 0, 0, errors.New("no board for team")
 	}
-	issues, err := ic.ListIssues(ctx, ri.RepoFullName, forge.IssueListOptions{
-		State: "all", Since: ri.LastSyncedAt, PerPage: 100,
-	})
-	if err != nil {
-		return 0, 0, fmt.Errorf("list issues: %w", err)
-	}
-	b := board.Board()
-	openCol := defaultOpenColumn(b)
-	doneCol := terminalColumn(b)
-	for _, is := range issues {
-		if is.IsPullRequest {
-			continue // the board syncs ISSUES; PRs surface via the card PR panel
-		}
-		c, u, e := upsertForgeCard(board, b, openCol, doneCol, conn.Provider, ri.ConnectionID, ri.RepoFullName, is)
-		if e != nil {
-			if err == nil {
-				err = e
-			}
-			continue
-		}
-		created += c
-		updated += u
-	}
+	created, updated, err = SyncForgeIssuesToBoard(ctx, ic, conn.Provider, ri.ConnectionID, ri.RepoFullName, board, ri.LastSyncedAt)
+	// Advance the high-water mark unconditionally (mirrors the prior
+	// behaviour): a partial-failure sync still records progress on the
+	// issues it did upsert.
 	ri.LastSyncedAt = time.Now().UTC()
 	if uerr := s.forgeIntegrations.Update(ctx, ri); uerr != nil && err == nil {
 		err = uerr

--- a/pkg/server/board_forge_test.go
+++ b/pkg/server/board_forge_test.go
@@ -1,11 +1,37 @@
 package server
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/forge"
 )
+
+// fakeIssueClient is a minimal forge.IssueClient whose ListIssues returns a
+// canned set; the other methods are unused by SyncForgeIssuesToBoard.
+type fakeIssueClient struct {
+	issues []forge.IssueRef
+	calls  int
+}
+
+func (f *fakeIssueClient) ListIssues(context.Context, string, forge.IssueListOptions) ([]forge.IssueRef, error) {
+	f.calls++
+	return f.issues, nil
+}
+func (f *fakeIssueClient) GetIssue(context.Context, string, int) (forge.IssueRef, error) {
+	return forge.IssueRef{}, nil
+}
+func (f *fakeIssueClient) CreateIssue(context.Context, string, forge.NewIssue) (forge.IssueRef, error) {
+	return forge.IssueRef{}, nil
+}
+func (f *fakeIssueClient) UpdateIssue(context.Context, string, int, forge.IssuePatch) (forge.IssueRef, error) {
+	return forge.IssueRef{}, nil
+}
+func (f *fakeIssueClient) CommentIssue(context.Context, string, int, string) (forge.CommentRef, error) {
+	return forge.CommentRef{}, nil
+}
 
 // newTestBoard returns a fresh filesystem board store with the default layout
 // (inbox … done[terminal]).
@@ -95,6 +121,53 @@ func TestUpsertForgeCard_CreateUpdateIdempotent(t *testing.T) {
 	all, _ := board.List(native.ListFilter{})
 	if len(all) != 1 {
 		t.Errorf("expected exactly 1 card after idempotent upserts, got %d", len(all))
+	}
+}
+
+// TestSyncForgeIssuesToBoard_StoreAgnostic exercises the extracted pure core
+// against a fake issue client + a local native store — the shape a self-hosted
+// import (no cloud integration store) would use. Asserts open issues land in
+// the first column, PRs are skipped, and a re-sync upserts (no duplicates).
+func TestSyncForgeIssuesToBoard_StoreAgnostic(t *testing.T) {
+	board := newTestBoard(t)
+	openCol := defaultOpenColumn(board.Board())
+	ic := &fakeIssueClient{issues: []forge.IssueRef{
+		{Number: 1, Title: "add metrics", State: "open", Labels: []string{"feat"}},
+		{Number: 2, Title: "a PR, skipped", State: "open", IsPullRequest: true},
+		{Number: 3, Title: "old bug", State: "closed"},
+	}}
+
+	created, updated, err := SyncForgeIssuesToBoard(
+		context.Background(), ic, forge.ProviderGitHub, "conn1", "org/api", board, time.Time{})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if created != 2 || updated != 0 {
+		t.Fatalf("first sync created=%d updated=%d, want 2/0 (PR skipped)", created, updated)
+	}
+	all, _ := board.List(native.ListFilter{})
+	if len(all) != 2 {
+		t.Fatalf("expected 2 cards (PR excluded), got %d", len(all))
+	}
+	openCard, err := board.Get(forgeCardID(forge.ProviderGitHub, "org/api", 1))
+	if err != nil {
+		t.Fatalf("get open card: %v", err)
+	}
+	if openCard.State != openCol {
+		t.Errorf("open issue landed in %q, want first column %q", openCard.State, openCol)
+	}
+
+	// Re-sync = idempotent upsert, not duplication.
+	created, updated, err = SyncForgeIssuesToBoard(
+		context.Background(), ic, forge.ProviderGitHub, "conn1", "org/api", board, time.Time{})
+	if err != nil {
+		t.Fatalf("re-sync: %v", err)
+	}
+	if created != 0 || updated != 2 {
+		t.Fatalf("re-sync created=%d updated=%d, want 0/2", created, updated)
+	}
+	if all, _ := board.List(native.ListFilter{}); len(all) != 2 {
+		t.Fatalf("re-sync duplicated cards: got %d, want 2", len(all))
 	}
 }
 

--- a/pkg/server/board_forge_test.go
+++ b/pkg/server/board_forge_test.go
@@ -137,7 +137,7 @@ func TestSyncForgeIssuesToBoard_StoreAgnostic(t *testing.T) {
 		{Number: 3, Title: "old bug", State: "closed"},
 	}}
 
-	created, updated, err := SyncForgeIssuesToBoard(
+	created, updated, err := syncForgeIssuesToBoard(
 		context.Background(), ic, forge.ProviderGitHub, "conn1", "org/api", board, time.Time{})
 	if err != nil {
 		t.Fatalf("sync: %v", err)
@@ -158,7 +158,7 @@ func TestSyncForgeIssuesToBoard_StoreAgnostic(t *testing.T) {
 	}
 
 	// Re-sync = idempotent upsert, not duplication.
-	created, updated, err = SyncForgeIssuesToBoard(
+	created, updated, err = syncForgeIssuesToBoard(
 		context.Background(), ic, forge.ProviderGitHub, "conn1", "org/api", board, time.Time{})
 	if err != nil {
 		t.Fatalf("re-sync: %v", err)
@@ -168,6 +168,9 @@ func TestSyncForgeIssuesToBoard_StoreAgnostic(t *testing.T) {
 	}
 	if all, _ := board.List(native.ListFilter{}); len(all) != 2 {
 		t.Fatalf("re-sync duplicated cards: got %d, want 2", len(all))
+	}
+	if ic.calls != 2 {
+		t.Fatalf("ListIssues called %d times, want 2 (one per sync)", ic.calls)
 	}
 }
 

--- a/pkg/trigger/event.go
+++ b/pkg/trigger/event.go
@@ -54,6 +54,13 @@ const (
 	KindRunFinished  = "run.finished"
 	KindRunFailed    = "run.failed"
 	KindRunCancelled = "run.cancelled"
+	// KindRunPaused fires when a run suspends waiting for a human answer
+	// (paused_waiting_human) or an operator soft-pause (paused_operator). It
+	// is NOT a terminal kind: the run holds a valid checkpoint plus a pending
+	// interaction and re-enters the graph on resume. A board projection keys
+	// off this to mark a card "awaiting input"; Payload carries node_id +
+	// interaction_id so a consumer can pinpoint the paused node.
+	KindRunPaused = "run.paused"
 )
 
 // Reserved Payload keys.

--- a/studio/src/components/Runs/PauseForm.tsx
+++ b/studio/src/components/Runs/PauseForm.tsx
@@ -97,7 +97,7 @@ export default function PauseForm({
   // undefined so the resume carries no source and the server falls back to
   // the run's persisted FilePath.
   const resolvedSource =
-    sourceOverride !== undefined ? (sourceOverride ?? undefined) : (currentSource ?? undefined);
+    (sourceOverride !== undefined ? sourceOverride : currentSource) ?? undefined;
 
   const onChange = (name: string, next: string) => {
     setValues((prev) => ({ ...prev, [name]: next }));

--- a/studio/src/components/Runs/PauseForm.tsx
+++ b/studio/src/components/Runs/PauseForm.tsx
@@ -19,6 +19,13 @@ interface Props {
   // Optional one-line description that the agent surfaced on pause
   // (e.g. "Awaiting your approval to merge"). Comes from event data.
   message?: string;
+  // Overrides the workflow source sent with the resume. Run-console
+  // callers omit it and the editor buffer (currentSource) is used. The
+  // board caller passes `null` to send NO source — the operator isn't
+  // editing this run's workflow, so the server must fall back to the
+  // run's persisted FilePath instead of resuming against an unrelated
+  // editor buffer.
+  sourceOverride?: string | null;
   onSubmitted?: () => void;
 }
 
@@ -54,7 +61,13 @@ function briefInput(input?: Record<string, unknown>): string {
   }
 }
 
-export default function PauseForm({ runId, questions, message, onSubmitted }: Props) {
+export default function PauseForm({
+  runId,
+  questions,
+  message,
+  sourceOverride,
+  onSubmitted,
+}: Props) {
   const marker = useMemo(() => permissionMarker(questions ?? {}), [questions]);
   const options = useMemo(() => askUserOptions(questions ?? {}), [questions]);
   // Reserved (underscore) keys are runtime plumbing (options payload,
@@ -80,6 +93,11 @@ export default function PauseForm({ runId, questions, message, onSubmitted }: Pr
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const currentSource = useDocumentStore((s) => s.currentSource);
+  // An explicit prop (including null) wins over the editor buffer; null →
+  // undefined so the resume carries no source and the server falls back to
+  // the run's persisted FilePath.
+  const resolvedSource =
+    sourceOverride !== undefined ? (sourceOverride ?? undefined) : (currentSource ?? undefined);
 
   const onChange = (name: string, next: string) => {
     setValues((prev) => ({ ...prev, [name]: next }));
@@ -92,7 +110,7 @@ export default function PauseForm({ runId, questions, message, onSubmitted }: Pr
       // The runtime accepts a generic answers map; values are passed
       // through to the resumed node's inputs. Strings are the safest
       // common type for an ad-hoc pause UI.
-      await resumeRun(runId, { answers: values, source: currentSource ?? undefined });
+      await resumeRun(runId, { answers: values, source: resolvedSource });
       onSubmitted?.();
     } catch (e) {
       setError(errorMessage(e));
@@ -111,7 +129,7 @@ export default function PauseForm({ runId, questions, message, onSubmitted }: Pr
     try {
       await resumeRun(runId, {
         answers: { [ASK_USER_KEY]: decision },
-        source: currentSource ?? undefined,
+        source: resolvedSource,
       });
       onSubmitted?.();
     } catch (e) {

--- a/studio/src/views/Board/issueModal/LastRunSection.test.tsx
+++ b/studio/src/views/Board/issueModal/LastRunSection.test.tsx
@@ -67,7 +67,7 @@ describe("LastRunSection answer-from-board affordance", () => {
     fireEvent.click(submit);
 
     await waitFor(() => expect(resumeRun).toHaveBeenCalledTimes(1));
-    const [runId, body] = resumeRun.mock.calls[0];
+    const [runId, body] = resumeRun.mock.calls[0]!;
     expect(runId).toBe("r1");
     expect(body.answers).toEqual({ decision: "yes" });
     // Critical: the editor buffer must NOT leak in as the resume source.

--- a/studio/src/views/Board/issueModal/LastRunSection.test.tsx
+++ b/studio/src/views/Board/issueModal/LastRunSection.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { LastRunSection } from "./LastRunSection";
+
+// Mock the runs API: getRun feeds the paused-run detection, resumeRun is
+// what the answer affordance must call.
+const getRun = vi.fn();
+const resumeRun = vi.fn().mockResolvedValue({ run_id: "r1", status: "running" });
+vi.mock("@/api/runs", () => ({
+  getRun: (...a: unknown[]) => getRun(...a),
+  resumeRun: (...a: unknown[]) => resumeRun(...a),
+}));
+
+// The document store backs PauseForm's editor-buffer source; the board
+// caller overrides it, so its value must NOT reach resumeRun.
+vi.mock("@/store/document", () => ({
+  useDocumentStore: (sel: (s: { currentSource: string | null }) => unknown) =>
+    sel({ currentSource: "some-other-bot.bot" }),
+}));
+
+// BranchDiffModal pulls a heavy dependency chain we don't exercise here.
+vi.mock("@/components/Runs/BranchDiffModal", () => ({ default: () => null }));
+
+function renderSection(runID: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <LastRunSection runID={runID} />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("LastRunSection answer-from-board affordance", () => {
+  it("renders the pause affordance and resumes with NO source (falls back to persisted FilePath)", async () => {
+    getRun.mockResolvedValue({
+      run: {
+        id: "r1",
+        status: "paused_waiting_human",
+        checkpoint: {
+          node_id: "ask_reviewer",
+          interaction_id: "r1_ask_reviewer",
+          interaction_questions: { decision: "Ship it?" },
+        },
+      },
+      executions: [],
+      last_seq: 0,
+    });
+
+    renderSection("r1");
+
+    await waitFor(() => expect(screen.getByText(/Awaiting input/i)).toBeTruthy());
+    // The question field label from PauseForm is rendered.
+    await waitFor(() => expect(screen.getByText(/decision/i)).toBeTruthy());
+
+    const textarea = document.querySelector("textarea");
+    expect(textarea).toBeTruthy();
+    fireEvent.change(textarea as HTMLTextAreaElement, { target: { value: "yes" } });
+    const submit = screen.getByRole("button", { name: /submit|send|resume/i });
+    fireEvent.click(submit);
+
+    await waitFor(() => expect(resumeRun).toHaveBeenCalledTimes(1));
+    const [runId, body] = resumeRun.mock.calls[0];
+    expect(runId).toBe("r1");
+    expect(body.answers).toEqual({ decision: "yes" });
+    // Critical: the editor buffer must NOT leak in as the resume source.
+    expect(body.source).toBeUndefined();
+  });
+
+  it("shows only the plain last-run panel when the run is not paused", async () => {
+    getRun.mockResolvedValue({
+      run: { id: "r1", status: "finished", checkpoint: {} },
+      executions: [],
+      last_seq: 0,
+    });
+    renderSection("r1");
+    await waitFor(() => expect(screen.getByText(/Last run/i)).toBeTruthy());
+    expect(screen.queryByText(/Awaiting input/i)).toBeNull();
+  });
+});

--- a/studio/src/views/Board/issueModal/LastRunSection.tsx
+++ b/studio/src/views/Board/issueModal/LastRunSection.tsx
@@ -5,6 +5,7 @@ import { Link } from "wouter";
 import BranchDiffModal from "@/components/Runs/BranchDiffModal";
 import PauseForm from "@/components/Runs/PauseForm";
 import { getRun } from "@/api/runs";
+import { rehydratePendingHumanInput } from "@/store/run/reducer";
 import { Button } from "@/components/ui/Button";
 import { CopyButton } from "@/components/ui/CopyButton";
 
@@ -13,27 +14,27 @@ import { CopyButton } from "@/components/ui/CopyButton";
 // operator can respond to a paused pipeline directly from the board
 // instead of detouring through the run console (issue #125, point 4).
 //
-// It reuses PauseForm verbatim: the paused questions live on the run
-// checkpoint (store.Checkpoint.InteractionQuestions, surfaced through the
-// snapshot's opaque checkpoint index signature), the same data PauseForm
-// consumes in the run console. sourceOverride={null} is load-bearing: the
-// operator isn't editing this run's workflow here, so the resume must
-// carry NO source and let the server fall back to the run's persisted
-// FilePath (passing the editor buffer would resume an unrelated workflow).
+// It reuses PauseForm verbatim, decoding the paused node's questions with
+// the shared rehydratePendingHumanInput (which runtime-narrows the opaque
+// run checkpoint and gates on paused_waiting_human) — the same helper the
+// run console uses to rebuild the pause panel after a reload.
+// sourceOverride={null} is load-bearing: the operator isn't editing this
+// run's workflow here, so the resume must carry NO source and let the
+// server fall back to the run's persisted FilePath (passing the editor
+// buffer would resume an unrelated workflow).
 function AwaitingInput({ runID }: { runID: string }) {
   const { data, refetch } = useQuery({
     queryKey: ["board-last-run", runID],
     queryFn: ({ signal }) => getRun(runID, { signal }),
-    // Poll gently: a parked run flips to running on resume and back if it
-    // re-pauses; a light refetch keeps the affordance honest without a WS.
-    refetchInterval: 5000,
+    // Poll only while genuinely paused: one fetch to learn the status, then
+    // a light refetch that stops once the run resumes/terminates (a parked
+    // run flips to running on answer). `enabled` can't gate this — the first
+    // fetch is what reveals the status.
+    refetchInterval: (q) =>
+      q.state.data?.run?.status === "paused_waiting_human" ? 5000 : false,
   });
-  const run = data?.run;
-  const paused =
-    run?.status === "paused_waiting_human" || run?.status === "paused_operator";
-  if (!paused) return null;
-  const questions =
-    (run?.checkpoint?.interaction_questions as Record<string, unknown> | undefined) ?? {};
+  const pending = data ? rehydratePendingHumanInput(data) : null;
+  if (!pending) return null;
   return (
     <div className="rounded border border-warning/40 bg-warning-soft p-2 space-y-2">
       <div className="text-micro uppercase tracking-wide text-warning-fg">
@@ -41,7 +42,7 @@ function AwaitingInput({ runID }: { runID: string }) {
       </div>
       <PauseForm
         runId={runID}
-        questions={questions}
+        questions={pending.questions ?? {}}
         sourceOverride={null}
         onSubmitted={() => void refetch()}
       />

--- a/studio/src/views/Board/issueModal/LastRunSection.tsx
+++ b/studio/src/views/Board/issueModal/LastRunSection.tsx
@@ -1,13 +1,58 @@
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "wouter";
 
 import BranchDiffModal from "@/components/Runs/BranchDiffModal";
+import PauseForm from "@/components/Runs/PauseForm";
+import { getRun } from "@/api/runs";
 import { Button } from "@/components/ui/Button";
 import { CopyButton } from "@/components/ui/CopyButton";
+
+// AwaitingInput reads the stamped last run and, when it is paused on a
+// human node, renders the answer affordance inline on the card — so an
+// operator can respond to a paused pipeline directly from the board
+// instead of detouring through the run console (issue #125, point 4).
+//
+// It reuses PauseForm verbatim: the paused questions live on the run
+// checkpoint (store.Checkpoint.InteractionQuestions, surfaced through the
+// snapshot's opaque checkpoint index signature), the same data PauseForm
+// consumes in the run console. sourceOverride={null} is load-bearing: the
+// operator isn't editing this run's workflow here, so the resume must
+// carry NO source and let the server fall back to the run's persisted
+// FilePath (passing the editor buffer would resume an unrelated workflow).
+function AwaitingInput({ runID }: { runID: string }) {
+  const { data, refetch } = useQuery({
+    queryKey: ["board-last-run", runID],
+    queryFn: ({ signal }) => getRun(runID, { signal }),
+    // Poll gently: a parked run flips to running on resume and back if it
+    // re-pauses; a light refetch keeps the affordance honest without a WS.
+    refetchInterval: 5000,
+  });
+  const run = data?.run;
+  const paused =
+    run?.status === "paused_waiting_human" || run?.status === "paused_operator";
+  if (!paused) return null;
+  const questions =
+    (run?.checkpoint?.interaction_questions as Record<string, unknown> | undefined) ?? {};
+  return (
+    <div className="rounded border border-warning/40 bg-warning-soft p-2 space-y-2">
+      <div className="text-micro uppercase tracking-wide text-warning-fg">
+        ⏸ Awaiting input
+      </div>
+      <PauseForm
+        runId={runID}
+        questions={questions}
+        sourceOverride={null}
+        onSubmitted={() => void refetch()}
+      />
+    </div>
+  );
+}
 
 // LastRunSection renders a compact "Last run" panel inside the
 // Ticket tab when the dispatcher has stamped a run on the issue.
 // Surfaces:
+//   - An inline answer affordance when the run is paused on a human node.
 //   - A wouter Link to the run console at /runs/<id>.
 //   - The worktree path with copy-to-clipboard and vscode:// links
 //     so the operator can pivot from the kanban card into a diff
@@ -27,6 +72,7 @@ export function LastRunSection({
   const runLabel = runID ? runID.slice(0, 12) : "";
   return (
     <div className="rounded border border-border-default bg-surface-1 p-2 space-y-1.5">
+      {runID && <AwaitingInput runID={runID} />}
       <div className="text-micro uppercase tracking-wide text-fg-subtle">
         Last run
       </div>

--- a/studio/src/views/Board/issueModal/LastRunSection.tsx
+++ b/studio/src/views/Board/issueModal/LastRunSection.tsx
@@ -26,14 +26,22 @@ function AwaitingInput({ runID }: { runID: string }) {
   const { data, refetch } = useQuery({
     queryKey: ["board-last-run", runID],
     queryFn: ({ signal }) => getRun(runID, { signal }),
-    // Poll only while genuinely paused: one fetch to learn the status, then
-    // a light refetch that stops once the run resumes/terminates (a parked
-    // run flips to running on answer). `enabled` can't gate this — the first
-    // fetch is what reveals the status.
-    refetchInterval: (q) =>
-      q.state.data?.run?.status === "paused_waiting_human" ? 5000 : false,
+    // Poll while the run can still transition into (or back out of) a pause,
+    // stopping once it is terminal. A resume flips a paused card to running
+    // and a later human node re-pauses it — polling through 'running'/'queued'
+    // keeps the affordance live without reopening the modal. `enabled` can't
+    // gate this; the first fetch is what reveals the status.
+    refetchInterval: (q) => {
+      const s = q.state.data?.run?.status;
+      return s === "running" ||
+        s === "queued" ||
+        s === "paused_waiting_human" ||
+        s === "paused_operator"
+        ? 5000
+        : false;
+    },
   });
-  const pending = data ? rehydratePendingHumanInput(data) : null;
+  const pending = data?.run ? rehydratePendingHumanInput(data) : null;
   if (!pending) return null;
   return (
     <div className="rounded border border-warning/40 bg-warning-soft p-2 space-y-2">


### PR DESCRIPTION
First increment of the "board as a projection of a pipeline" direction from #125. Framed **additively** (per ADR-071): the shared backlog board is untouched; this ships the seams the pipeline view needs, plus the design record. The deeper inversion (ticket↔runs 1:N tree, self-hosted forge import) stays deferred as open tensions.

## What's in it

- **WS-A — `run.paused` trigger signal.** New `trigger.KindRunPaused`; `emitRunOutcome` (renamed from `emitRunCompletion`) now emits `run.paused` for a paused run instead of mislabeling it `run.failed`. Carries `node_id` + `interaction_id` so a board projection can pinpoint the paused node. Fixes a latent bug (a pause polluted the run-failed chain).
- **WS-B — answer a paused run from the board.** The run-console `PauseForm` is mounted on the board card's Last-run panel (issue modal); when the stamped last run is `paused_waiting_human`, the operator answers inline → `POST /resume`, no detour through the run console. Reuses the shared `rehydratePendingHumanInput` decoder; resumes with **no source** so the server falls back to the run's persisted FilePath (the editor buffer must not resume an unrelated workflow).
- **WS-C — `board.create` MCP parity.** The `create_issue` boardop now accepts `bot`/`bot_args`, matching REST `POST /issues` — a board-fed pipeline can be pinned at create time on all three transports.
- **WS-D — unify "feed the first column".** Extracted the store-/cloud-agnostic `syncForgeIssuesToBoard` core (cloud wrapper keeps the high-water mark); documented the canonical ingest contract (`POST /issues` with no `state` → first column, PAT `iap_`).
- **ADR-071** — the additive-projection design record; the 6 tensions marked decided (T1/T2/T3/T5/T6) or open (T4).

## Not in scope (deferred, see ADR-071)
Ticket↔runs 1:N history + parent/child/shards tree projection (T4); the self-hosted forge-import entry point (T6); a board-wide per-card "awaiting input" badge (needs a denormalized field to avoid an N+1 fetch); moving a parked dispatched run's card into an "awaiting input" column.

## Verification
`task build` · `go vet` · unit tests (trigger/runview/boardops/server) · **full e2e** · studio `tsc -b` + `LastRunSection` component test — all green. Went through `/simplify` and a high-effort `/code-review` (5 findings, all applied).

Refs #125 (first increment; the discussion stays open for the deferred tensions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)