### PR TITLE
feat(webhooks): auto-heal PRs ejected from the merge queue via Billy

### DIFF
--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -95,6 +95,36 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 		return
 	}
 
+	// Merge-queue auto-heal: a PR ejected from the queue for a conflict or a
+	// combined-build failure (`dequeued` with a healable reason) is
+	// dispatched to the branch-improvement bot (Billy) to rebase on the base,
+	// resolve the conflict / fix the combined break, and push so it re-enters
+	// the queue — closing the loop the queue opens (it DETECTS the break; the
+	// bot REPAIRS it, no human). Same-repo + allowlist + bot-permitted only;
+	// the per-(PR,head-sha) idempotency bounds a heal to one attempt per head
+	// (Billy's push advances the head, so a re-eject re-heals the NEW state,
+	// and Billy's own convergence + the author allowlist bound the loop).
+	if p.NeedsAutoHeal() {
+		if !webhooks.MatchProject(cfg.ProjectAllowlist, p.ProjectPath) ||
+			!webhooks.MatchAuthor(cfg.AuthorAllowlist, p.SenderLogin) ||
+			!cfg.AllowsBot(branchImproveBotID) {
+			s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, "auto-heal not permitted (project/author/bot)")
+			writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+			return
+		}
+		healIdem := knowledge.ChecksumHex([]byte(fmt.Sprintf("heal|%s|%s|%s|%d|%s", cfg.TenantID, cfg.ID, p.ProjectPath, p.PRNumber, p.HeadSHA)))
+		mission := fmt.Sprintf(
+			"This PR was ejected from the merge queue (reason: %s). Rebase the branch on `%s`, "+
+				"resolve any conflicts, and fix whatever breaks the build when the branch is combined "+
+				"with the current `%s` (a compile break, a stale generated file, a test broken by an "+
+				"interleaved merge). Keep the PR's own change intact; only reconcile it with the new base. "+
+				"Push so the PR can re-enter the merge queue.\n\n%s",
+			p.DequeueReason, p.TargetBranch, p.TargetBranch, strings.TrimSpace(p.Title+"\n\n"+p.Description))
+		healVars := branchImproveVars(p.TargetBranch, p.SourceBranch, p.PRURL, mission, false, cfg.LaunchVars)
+		s.insertAndLaunchWebhook(ctx, w, r, cfg, meta, healIdem, branchImproveBotID, healVars, p.CloneURL, p.SourceBranch, payloadHash, srcIP)
+		return
+	}
+
 	if !p.IsReviewable() ||
 		!webhooks.MatchEvent(cfg.EventAllowlist, "pull_request", "pull_request") ||
 		!webhooks.MatchProject(cfg.ProjectAllowlist, p.ProjectPath) ||

--- a/pkg/server/webhooks_github_test.go
+++ b/pkg/server/webhooks_github_test.go
@@ -119,6 +119,69 @@ const ghTicketPR = `{
   "sender": {"login": "alice"}
 }`
 
+// ghDequeuedPR: a PR ejected from the merge queue for a conflict → the
+// auto-heal path dispatches Billy to rebase+resolve+repush.
+const ghDequeuedPR = `{
+  "action": "dequeued", "number": 9, "reason": "MERGE_CONFLICT",
+  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+  "pull_request": {"number": 9, "title": "Add subtract", "body": "Implements subtraction.",
+    "html_url": "https://github.com/acme/widgets/pull/9", "state": "open",
+    "head": {"ref": "feat/subtract", "sha": "aaa111", "repo": {"full_name": "acme/widgets"}},
+    "base": {"ref": "main", "repo": {"full_name": "acme/widgets"}}},
+  "sender": {"login": "alice"}
+}`
+
+// TestGitHubWebhook_DequeuedPRAutoHeals: a merge-queue ejection for a conflict
+// dispatches Billy to reconcile the branch with the base + re-enter the queue.
+func TestGitHubWebhook_DequeuedPRAutoHeals(t *testing.T) {
+	s := newWebhookTestServer(t)
+	var gotBot, gotRef string
+	var gotVars map[string]string
+	s.webhookLaunchBot = func(_ context.Context, botID string, vars map[string]string, _, repoRef, _ string, _, _ map[string]string) (string, error) {
+		gotBot, gotVars, gotRef = botID, vars, repoRef
+		return "run-heal", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"review-pr", "branch-improve-loop"}
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghDequeuedPR, prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	if gotBot != "branch-improve-loop" {
+		t.Fatalf("dequeued PR must auto-heal via Billy, got %q", gotBot)
+	}
+	if gotVars["open_mr"] != "false" || gotVars["push_branch"] != "feat/subtract" || gotVars["base_ref"] != "main" {
+		t.Fatalf("heal vars wrong: %v", gotVars)
+	}
+	if gotRef != "feat/subtract" {
+		t.Fatalf("heal must check out the PR head branch, got %q", gotRef)
+	}
+	if !strings.Contains(gotVars["scope_notes"], "ejected from the merge queue") || !strings.Contains(gotVars["scope_notes"], "MERGE_CONFLICT") {
+		t.Fatalf("heal mission must state the queue-eject reason: %q", gotVars["scope_notes"])
+	}
+}
+
+// TestGitHubWebhook_DequeuedNonHealableReasonIgnored: a dequeue for a
+// non-fixable reason (manual dequeue / queue reset) launches nothing.
+func TestGitHubWebhook_DequeuedNonHealableReasonIgnored(t *testing.T) {
+	s := newWebhookTestServer(t)
+	launched := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		launched++
+		return "x", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"review-pr", "branch-improve-loop"}
+	body := `{"action":"dequeued","number":9,"reason":"DEQUEUED_MANUALLY","repository":{"id":42,"full_name":"acme/widgets","clone_url":"https://github.com/acme/widgets.git"},"pull_request":{"number":9,"title":"x","state":"open","html_url":"u","head":{"ref":"b","sha":"s","repo":{"full_name":"acme/widgets"}},"base":{"ref":"main","repo":{"full_name":"acme/widgets"}}},"sender":{"login":"alice"}}`
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), body, prforge.EventHeaderPullRequest, pt))
+	if launched != 0 {
+		t.Fatalf("a non-healable dequeue must launch nothing, launched=%d", launched)
+	}
+}
+
 // ghForkTicketPR: same ticket link but head.repo is a FORK → the guard keeps it
 // on the reviewer path.
 const ghForkTicketPR = `{

--- a/pkg/webhooks/prforge/events.go
+++ b/pkg/webhooks/prforge/events.go
@@ -18,8 +18,12 @@ const EventHeaderPullRequest = "pull_request"
 // decode. Field names follow the wire's camelCase pattern; the shape is
 // identical between GitHub and Forgejo/Gitea for the fields we read.
 type PullRequestEvent struct {
-	Action      string      `json:"action"`
-	Number      int64       `json:"number"`
+	Action string `json:"action"`
+	Number int64  `json:"number"`
+	// Reason is set on a `dequeued` action — why the PR left the merge
+	// queue (e.g. "MERGE_CONFLICT", "CI_FAILURE", "INVALID_MERGE_COMMIT").
+	// Empty for every other action.
+	Reason      string      `json:"reason"`
 	Repository  Repository  `json:"repository"`
 	PullRequest PullRequest `json:"pull_request"`
 	Sender      Sender      `json:"sender"`

--- a/pkg/webhooks/prforge/parser.go
+++ b/pkg/webhooks/prforge/parser.go
@@ -29,6 +29,29 @@ type Parsed struct {
 	// differs from ProjectPath (the base repo) for a fork PR; empty when the
 	// payload omits head.repo. Read by IsCrossRepo for the fork guard.
 	HeadRepoFullName string
+	// DequeueReason is the merge-queue eject reason on a `dequeued`
+	// action (e.g. "MERGE_CONFLICT", "CI_FAILURE"). Empty otherwise.
+	DequeueReason string
+}
+
+// healableDequeueReasons are the merge-queue eject reasons that a
+// branch-improvement auto-heal can actually fix: a textual conflict with
+// the queue head, or a combined-build/CI failure. Reasons like a manual
+// dequeue or a queue reset are NOT healable (nothing to fix on the branch)
+// — re-dispatching a bot on those would be waste or a loop.
+var healableDequeueReasons = map[string]bool{
+	"MERGE_CONFLICT":       true,
+	"CI_FAILURE":           true,
+	"INVALID_MERGE_COMMIT": true,
+	"MERGE_CONFLICT_ERROR": true,
+}
+
+// NeedsAutoHeal reports whether this delivery is a merge-queue ejection an
+// auto-heal bot should try to fix — the PR left the queue because its diff
+// conflicts with, or breaks the combined build against, the current queue
+// head. The webhook handler still applies the fork/allowlist/bot guards.
+func (p Parsed) NeedsAutoHeal() bool {
+	return p.Action == "dequeued" && healableDequeueReasons[p.DequeueReason]
 }
 
 // ParsePullRequest decodes a pull_request webhook body from GitHub or
@@ -60,6 +83,7 @@ func ParsePullRequest(body []byte) (Parsed, error) {
 		State:            pr.State,
 		SenderLogin:      e.Sender.Login,
 		HeadRepoFullName: pr.Head.Repo.FullName,
+		DequeueReason:    e.Reason,
 	}, nil
 }
 

--- a/pkg/webhooks/prforge/parser_autoheal_test.go
+++ b/pkg/webhooks/prforge/parser_autoheal_test.go
@@ -1,0 +1,24 @@
+package prforge
+
+import "testing"
+
+func TestNeedsAutoHeal(t *testing.T) {
+	cases := []struct {
+		action, reason string
+		want           bool
+	}{
+		{"dequeued", "MERGE_CONFLICT", true},
+		{"dequeued", "CI_FAILURE", true},
+		{"dequeued", "INVALID_MERGE_COMMIT", true},
+		{"dequeued", "DEQUEUED_MANUALLY", false},
+		{"dequeued", "", false},
+		{"opened", "MERGE_CONFLICT", false},
+		{"synchronize", "", false},
+	}
+	for _, c := range cases {
+		p := Parsed{Action: c.action, DequeueReason: c.reason}
+		if got := p.NeedsAutoHeal(); got != c.want {
+			t.Errorf("NeedsAutoHeal(action=%q reason=%q) = %v, want %v", c.action, c.reason, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes the loop the merge queue opens: queue DETECTS a broken combination (dequeued MERGE_CONFLICT/CI_FAILURE), Billy REPAIRS it (rebase+resolve+fix+repush → re-enter queue), no human. Same-repo + allowlist + bot-permitted; per-(PR,head-sha) idempotent. Tests: parser NeedsAutoHeal + handler heal-dispatch + non-healable-ignored. Dogfooding the merge queue itself.