### PR TITLE
fix(studio): board answer affordance renders the paused node's schema (follow-up to #132)

### DIFF
--- a/studio/src/components/Runs/conversation/HumanPromptForm.tsx
+++ b/studio/src/components/Runs/conversation/HumanPromptForm.tsx
@@ -24,6 +24,16 @@ interface Props {
   // typing a reply. Only meaningful on free-text-only turns. Default
   // = ["skip", "idk"]; pass empty to suppress.
   quickActions?: ReadonlyArray<"skip" | "idk" | "later">;
+  // Overrides the workflow source sent with the resume. Run-console
+  // callers omit it and the editor buffer (currentSource) is used; a
+  // board caller (answering a paused card, not editing this run's
+  // workflow) passes `null` to send NO source so the server falls back
+  // to the run's persisted FilePath.
+  sourceOverride?: string | null;
+  // Called after a successful resume INSTEAD of the run-console WS
+  // machinery (reconnect / snapshot resync). A board caller passes this
+  // to refetch its own view; when omitted the run-console behaviour runs.
+  onResumed?: () => void;
 }
 
 // HumanPromptForm renders the inline form for a pending human-pause
@@ -42,6 +52,8 @@ export default function HumanPromptForm({
   nodeId,
   questions,
   quickActions = ["skip", "idk"],
+  sourceOverride,
+  onResumed,
 }: Props) {
   const setRunStatus = useRunStore((s) => s.setRunStatus);
   const requestWsReconnect = useRunStore((s) => s.requestWsReconnect);
@@ -50,6 +62,10 @@ export default function HumanPromptForm({
     (s) => s.resyncEventsAfterResume,
   );
   const currentSource = useDocumentStore((s) => s.currentSource);
+  // Explicit prop (incl. null) wins over the editor buffer; null → no
+  // source on the resume (server uses the run's persisted FilePath).
+  const resolvedSource =
+    (sourceOverride !== undefined ? sourceOverride : currentSource) ?? undefined;
 
   const { fields, loading, staleHash } = useHumanNodeSchema(runId, nodeId);
 
@@ -116,9 +132,15 @@ export default function HumanPromptForm({
     try {
       await resumeRun(runId, {
         answers,
-        source: currentSource ?? undefined,
+        source: resolvedSource,
       });
       setSubmitted(true);
+      // A board caller isn't viewing this run's canvas — skip the
+      // run-console WS machinery entirely and let it refetch its view.
+      if (onResumed) {
+        onResumed();
+        return;
+      }
       setRunStatus("running");
       // The broker dropped this run's subscribers when the prior pass
       // hit paused_waiting_human; without a fresh dial the resumed
@@ -230,9 +252,11 @@ export default function HumanPromptForm({
         <PauseForm
           runId={runId}
           questions={questions}
+          sourceOverride={sourceOverride}
           onSubmitted={() => {
             setSubmitted(true);
-            setRunStatus("running");
+            if (onResumed) onResumed();
+            else setRunStatus("running");
           }}
         />
       ) : (

--- a/studio/src/views/Board/issueModal/LastRunSection.test.tsx
+++ b/studio/src/views/Board/issueModal/LastRunSection.test.tsx
@@ -1,27 +1,40 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { LastRunSection } from "./LastRunSection";
 
-// Mock the runs API: getRun feeds the paused-run detection, resumeRun is
-// what the answer affordance must call.
+// Mock the runs API: getRun feeds paused-run detection, getRunWorkflow feeds
+// the paused node's OUTPUT schema (what HumanPromptForm renders), resumeRun is
+// the answer call.
 const getRun = vi.fn();
+const getRunWorkflow = vi.fn();
 const resumeRun = vi.fn().mockResolvedValue({ run_id: "r1", status: "running" });
 vi.mock("@/api/runs", () => ({
   getRun: (...a: unknown[]) => getRun(...a),
+  getRunWorkflow: (...a: unknown[]) => getRunWorkflow(...a),
   resumeRun: (...a: unknown[]) => resumeRun(...a),
 }));
 
-// The document store backs PauseForm's editor-buffer source; the board
-// caller overrides it, so its value must NOT reach resumeRun.
+// PauseForm's editor-buffer source; the board caller overrides it.
 vi.mock("@/store/document", () => ({
   useDocumentStore: (sel: (s: { currentSource: string | null }) => unknown) =>
     sel({ currentSource: "some-other-bot.bot" }),
 }));
 
-// BranchDiffModal pulls a heavy dependency chain we don't exercise here.
+// HumanPromptForm reads run-store selectors; on the board (onResumed set) they
+// must not fire, but the hooks are still called — return no-ops.
+vi.mock("@/store/run", () => ({
+  useRunStore: (sel: (s: Record<string, unknown>) => unknown) =>
+    sel({
+      setRunStatus: vi.fn(),
+      requestWsReconnect: vi.fn(),
+      applySnapshot: vi.fn(),
+      resyncEventsAfterResume: vi.fn(),
+    }),
+}));
+
 vi.mock("@/components/Runs/BranchDiffModal", () => ({ default: () => null }));
 
 function renderSection(runID: string) {
@@ -39,39 +52,48 @@ afterEach(() => {
 });
 
 describe("LastRunSection answer-from-board affordance", () => {
-  it("renders the pause affordance and resumes with NO source (falls back to persisted FilePath)", async () => {
+  it("renders the paused human node's OUTPUT-schema fields, not the checkpoint context vars", async () => {
     getRun.mockResolvedValue({
       run: {
         id: "r1",
         status: "paused_waiting_human",
         checkpoint: {
-          node_id: "ask_reviewer",
-          interaction_id: "r1_ask_reviewer",
-          interaction_questions: { decision: "Ship it?" },
+          node_id: "approval",
+          interaction_id: "r1_approval",
+          // Context vars carried on the checkpoint — must NOT become the form.
+          interaction_questions: { change_summary: "bump sdk", service: "checkout-api" },
         },
       },
       executions: [],
       last_seq: 0,
     });
+    getRunWorkflow.mockResolvedValue({
+      nodes: [
+        {
+          id: "approval",
+          output_schema: [
+            { name: "environment", type: "string", enum_values: ["staging", "production"] },
+            { name: "approve", type: "bool" },
+            { name: "reviewer", type: "string" },
+            { name: "notes", type: "string" },
+          ],
+        },
+      ],
+      stale_hash: false,
+    });
 
     renderSection("r1");
 
     await waitFor(() => expect(screen.getByText(/Awaiting input/i)).toBeTruthy());
-    // The question field label from PauseForm is rendered.
-    await waitFor(() => expect(screen.getByText(/decision/i)).toBeTruthy());
-
-    const textarea = document.querySelector("textarea");
-    expect(textarea).toBeTruthy();
-    fireEvent.change(textarea as HTMLTextAreaElement, { target: { value: "yes" } });
-    const submit = screen.getByRole("button", { name: /submit|send|resume/i });
-    fireEvent.click(submit);
-
-    await waitFor(() => expect(resumeRun).toHaveBeenCalledTimes(1));
-    const [runId, body] = resumeRun.mock.calls[0]!;
-    expect(runId).toBe("r1");
-    expect(body.answers).toEqual({ decision: "yes" });
-    // Critical: the editor buffer must NOT leak in as the resume source.
-    expect(body.source).toBeUndefined();
+    // The schema-driven wizard renders the first output-schema field
+    // (environment, an enum) with its options — proof the form comes from
+    // the node's output schema, not the checkpoint's plain context-var map.
+    await waitFor(() => expect(screen.getByText(/environment/i)).toBeTruthy());
+    expect(screen.getByText(/staging/i)).toBeTruthy();
+    expect(screen.getByText(/production/i)).toBeTruthy();
+    // The checkpoint context vars must NOT be rendered as answer fields.
+    expect(screen.queryByText(/change_summary/i)).toBeNull();
+    expect(screen.queryByText(/checkout-api/i)).toBeNull();
   });
 
   it("shows only the plain last-run panel when the run is not paused", async () => {

--- a/studio/src/views/Board/issueModal/LastRunSection.tsx
+++ b/studio/src/views/Board/issueModal/LastRunSection.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Link } from "wouter";
 
 import BranchDiffModal from "@/components/Runs/BranchDiffModal";
-import PauseForm from "@/components/Runs/PauseForm";
+import HumanPromptForm from "@/components/Runs/conversation/HumanPromptForm";
 import { getRun } from "@/api/runs";
 import { rehydratePendingHumanInput } from "@/store/run/reducer";
 import { Button } from "@/components/ui/Button";
@@ -14,14 +14,15 @@ import { CopyButton } from "@/components/ui/CopyButton";
 // operator can respond to a paused pipeline directly from the board
 // instead of detouring through the run console (issue #125, point 4).
 //
-// It reuses PauseForm verbatim, decoding the paused node's questions with
-// the shared rehydratePendingHumanInput (which runtime-narrows the opaque
-// run checkpoint and gates on paused_waiting_human) — the same helper the
-// run console uses to rebuild the pause panel after a reload.
-// sourceOverride={null} is load-bearing: the operator isn't editing this
-// run's workflow here, so the resume must carry NO source and let the
-// server fall back to the run's persisted FilePath (passing the editor
-// buffer would resume an unrelated workflow).
+// It reuses HumanPromptForm — the SAME schema-driven form the run console
+// renders — so a paused human node's real answer fields (its output
+// schema: enums, checkboxes, text) show, not the checkpoint's context
+// vars. rehydratePendingHumanInput (shared, runtime-narrows the opaque
+// checkpoint, gates on paused_waiting_human) yields the paused node id +
+// questions map the form needs. sourceOverride={null} sends NO source so
+// the server resumes against the run's persisted FilePath (the operator
+// isn't editing this run's workflow); onResumed refetches the board view
+// instead of the run-console WS machinery.
 function AwaitingInput({ runID }: { runID: string }) {
   const { data, refetch } = useQuery({
     queryKey: ["board-last-run", runID],
@@ -42,17 +43,18 @@ function AwaitingInput({ runID }: { runID: string }) {
     },
   });
   const pending = data?.run ? rehydratePendingHumanInput(data) : null;
-  if (!pending) return null;
+  if (!pending || !pending.node_id) return null;
   return (
     <div className="rounded border border-warning/40 bg-warning-soft p-2 space-y-2">
       <div className="text-micro uppercase tracking-wide text-warning-fg">
         ⏸ Awaiting input
       </div>
-      <PauseForm
+      <HumanPromptForm
         runId={runID}
+        nodeId={pending.node_id}
         questions={pending.questions ?? {}}
         sourceOverride={null}
-        onSubmitted={() => void refetch()}
+        onResumed={() => void refetch()}
       />
     </div>
   );


### PR DESCRIPTION
Follow-up to #132, found by **dogfooding the answer-from-board flow live** (local studio + Playwright).

## The bug
The board affordance used `PauseForm`, which renders the checkpoint's `interaction_questions` map. For a **schema-driven human node** that map holds *context vars* (e.g. `change_summary`, `service`), not the answer fields. So the card showed the wrong inputs, and submitting sent the wrong keys — `approve` was missing → the run routed to **fail**.

| Before (bug) | After (fix) |
|---|---|
| text fields `change_summary` / `service` | 4-field wizard: `environment` (enum) / `approve` / `reviewer` / `notes` |

## The fix
Render the **same schema-driven form the run console uses** — `HumanPromptForm`, which fetches the node's `output_schema` (enum/bool/text widgets) and falls back to `PauseForm` only for ask_user/schemaless pauses. Made `HumanPromptForm` reusable off the run console via two optional props:
- `sourceOverride` — board passes `null` so the resume carries no source (server falls back to the run's persisted FilePath); same fix already applied to `PauseForm` in #132.
- `onResumed` — board refetches its own view instead of the run-console WS reconnect/snapshot machinery (which targets a run the board isn't viewing).

## Verified live (end-to-end)
Local studio + a real `paused_waiting_human` run on a board card, driven via Playwright:
- the card renders the correct wizard (`environment` staging/production, `approve`, `reviewer`, `notes`);
- answering from the board records `{approve:true, environment:"staging", reviewer:"…", notes:"…"}` and fires `human_answers_recorded → run_resumed → edge_selected(approve→done) → run_finished`.

Plus the updated `LastRunSection` component test (asserts schema fields render, not context vars) and the full studio suite (581 tests) green.

Refs #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)