### PR TITLE
feat(web-search): sovereign web search tiers (SearXNG → Firecrawl)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,8 @@ discovered by claude_code via `--setting-sources project`), `hooks` (JSON
 fragments idempotently merged into `.claude/settings.json`), and
 `lifecycle` (index/refresh). Builtins are embedded
 ([pkg/plugin/builtin/](pkg/plugin/builtin/)); `rtk` ships **enabled**,
-`graphify` + `repo-falcon` ship **disabled**. Installed plugins live under
+`graphify` + `repo-falcon` + `firecrawl` (web search/scrape MCP —
+[docs/web-search.md](docs/web-search.md)) ship **disabled**. Installed plugins live under
 `~/.iterion/plugins/<name>/`, enable state in `~/.iterion/plugins.yaml`. Manage
 with `iterion plugin list|info|enable|disable|run|install|uninstall`. The plugin
 system never injects Go code (static `CGO_ENABLED=0` binaries rule out Go

--- a/docs/adr/072-web-search-capability-tiers.md
+++ b/docs/adr/072-web-search-capability-tiers.md
@@ -1,0 +1,94 @@
+# ADR-072 — Web search as a sovereign capability ladder (SearXNG → Firecrawl)
+
+Status: **accepted** (2026-07-13). Ships with the implementation
+(claw SearXNG backend + `ITERION_WEB_SEARCH` resolver + `firecrawl`
+builtin plugin + [docs/web-search.md](../web-search.md)).
+
+## Context
+
+Before this change, web search in iterion was incomplete and, for the
+default backend, effectively dormant:
+
+- **claw** (`claw-code-go`) shipped two client-side tools: `web_fetch`
+  (HTTP GET + strip HTML, registered by default) and `web_search`
+  (`BRAVE_API_KEY` → Brave, else a DuckDuckGo Lite scrape).
+- **iterion** registered `web_search` only behind `ClawDefaults.IncludeWebSearch`,
+  and **no production code ever set that flag** — so claw agents could
+  `web_fetch` a known URL but never *discover* one.
+- **claude_code** got web search for free (native `WebSearch`/`WebFetch`)
+  when a node left `tools:` unset.
+- The **MCP** layer (`mcp_server` DSL, plugin `mcp_servers`) already
+  existed and was first-class, but resolved into tools **only for the
+  claw backend**.
+
+Two forces shaped the decision. First, **sovereignty**: the primary
+operator is a French public-sector org, so a default that leaks every
+search query to Brave/Google (or scrapes DuckDuckGo) is undesirable; a
+self-hosted search path must be a first-class, preferred option.
+Second, **not multiplying the agent's surface**: search should stay one
+tool the agent already knows (`web_search`), not a new per-provider tool
+per deployment.
+
+## Options considered
+
+1. **Provider-per-tool** — add `brave_search`, `searxng_search`,
+   `firecrawl_search` as distinct tools. Rejected: forces the agent (and
+   every bot author) to know which tool a given deployment wired, and
+   couples bots to infra.
+2. **Anthropic server-side web tools** — pass through
+   `web_search_20250305`. Rejected: claw's `api.Tool` has no `type`
+   field, it is Anthropic-only, and it defeats sovereignty (search runs
+   on Anthropic's servers).
+3. **Firecrawl-only** — require the full Firecrawl stack for any search.
+   Rejected: too heavy for the common case (a single SearXNG container,
+   or just a Brave key, is enough for search without JS rendering).
+4. **A resolved capability ladder** (chosen) — search stays one tool
+   whose backend is resolved from the environment; scraping is the
+   built-in `web_fetch` until the top tier, where Firecrawl (over the
+   existing MCP seam) adds JS render / crawl / extract.
+
+## Decision
+
+Adopt a four-tier ladder, each tier reusing an existing seam:
+
+| Tier | Infra | Search | Scrape/crawl |
+|------|-------|--------|--------------|
+| 0 | none | DuckDuckGo Lite | `web_fetch` |
+| 1 | Brave key | Brave API | `web_fetch` |
+| 2 | one SearXNG container | **SearXNG** | `web_fetch` |
+| 3 | Firecrawl + SearXNG | Firecrawl `search` | Firecrawl (JS, crawl, extract) |
+
+Load-bearing decisions:
+
+- **SearXNG lives in claw's `web_search`**, alongside Brave/DDG, with
+  precedence `SEARXNG_URL`/`SEARXNG_ENDPOINT` → `BRAVE_API_KEY` → DDG. A
+  configured sovereign instance wins over any external service. It stays
+  one tool; the agent learns nothing new. (Upstream, so every claw
+  consumer benefits; iterion vendors it.)
+- **`web_search` enablement is resolved, not hardcoded**:
+  `ITERION_WEB_SEARCH=on|off|auto` (default `auto`) via
+  `tool.ResolveWebSearchEnabled`. `auto` registers the tool only when a
+  search backend is configured (SearXNG/Brave), keeping the brittle,
+  query-leaking DDG scrape **opt-in** (reachable only via `on`). Wired at
+  the single `ClawDefaults` construction site, shared by the local and
+  cloud runner paths.
+- **Firecrawl is a builtin plugin** (`mcp_servers` contribution,
+  disabled by default), reusing the plugin/MCP machinery — zero engine
+  code. SearXNG pairs with it via Firecrawl's own `SEARXNG_ENDPOINT`, so
+  one SearXNG instance serves both tier 2 and tier 3.
+
+## Consequences
+
+- Standing up a SearXNG container (JSON format enabled) is all it takes
+  to give claw agents sovereign search under the default `auto` mode.
+- **Firecrawl/MCP web tools are claw-only.** iterion does not forward
+  user-declared MCP servers to the claude_code/codex CLIs (only the
+  internal `ask_user` + board servers), so on claude_code the search path
+  is its native `WebSearch`/`WebFetch`. Forwarding user MCP servers to
+  the claude CLI via `--mcp-config` is a deferred follow-on that would
+  close this gap and make the ladder backend-symmetric.
+- A SearXNG instance must have the `json` output format enabled; absence
+  surfaces as an explicit HTTP-403 error, not a silent empty result
+  (per the erreurs-explicites principle).
+- No dependency on Anthropic server-side web tools; all web work stays
+  client-side (claw) or in the operator's own Firecrawl (tier 3).

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -353,6 +353,10 @@ sensible default for the first available provider — currently
 `anthropic/claude-opus-4-8` for Anthropic and
 `openai/gpt-5.4-mini` for OpenAI.
 
+For web search & fetch on claw (the `web_search`/`web_fetch` tools, the
+SearXNG → Brave → DuckDuckGo backend ladder, `ITERION_WEB_SEARCH`, and the
+Firecrawl MCP tier), see [web-search.md](web-search.md).
+
 ### OpenAI via ChatGPT forfait (Codex CLI OAuth)
 
 When Codex CLI is signed in via *Sign in with ChatGPT* (rather than the

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -8,7 +8,9 @@ out-of-process** packages. A plugin never injects Go code (iterion ships static
 
 Plugins are installable-by-default, uninstallable, replaceable, and composable —
 `rtk` (the command-output compressor) ships as a plugin enabled by default; the
-knowledge-graph explorers `graphify` and `repo-falcon` ship disabled.
+knowledge-graph explorers `graphify` and `repo-falcon` and the web toolkit
+`firecrawl` (Firecrawl search/scrape/crawl MCP — see
+[web-search.md](web-search.md)) ship disabled.
 
 ## Contribution kinds (v1)
 
@@ -47,7 +49,7 @@ A single plugin may contribute several kinds (repo-falcon ships `mcp_servers` +
 ## Where plugins live
 
 - **Builtins** are embedded in the binary under `pkg/plugin/builtin/<name>/`
-  (`rtk`, `graphify`, `repo-falcon`).
+  (`rtk`, `graphify`, `repo-falcon`, `firecrawl`).
 - **Installed** plugins live under `~/.iterion/plugins/<name>/` (a directory
   with a `plugin.yaml`). `iterion plugin install <path|git-url>` puts them there.
 - **Enable/disable state** is persisted in `~/.iterion/plugins.yaml`; the

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -1,0 +1,126 @@
+# Web search & fetch
+
+How agents discover and read the web in iterion, as a **capability ladder**
+you climb only as far as your needs (and your sovereignty constraints)
+require. Search stays **one tool** (`web_search`) whose backend is resolved
+from the environment; scraping is either the built-in `web_fetch` or, at the
+top tier, Firecrawl over MCP.
+
+| Tier | Infra to run | Search backend | Scrape / crawl |
+|------|--------------|----------------|----------------|
+| 0 | nothing | DuckDuckGo Lite (scrape) | `web_fetch` (HTTP GET + strip HTML) |
+| 1 | a Brave API key | Brave Search API | `web_fetch` |
+| 2 | **one SearXNG container** | **SearXNG** (sovereign) | `web_fetch` |
+| 3 | Firecrawl + SearXNG | Firecrawl `search` | Firecrawl (JS render, readability, crawl, extract) |
+
+## The two built-in tools (claw backend)
+
+The `claw` backend ships two client-side web tools from `claw-code-go`:
+
+- **`web_fetch`** — fetch a known URL, strip HTML to text (15s, 50 KB cap).
+  Registered **by default**. No search/discovery: you must already have the URL.
+- **`web_search`** — query the web, return `title / url / snippet` rows. Its
+  backend is resolved at execute time by env precedence:
+
+  ```
+  SEARXNG_URL (or SEARXNG_ENDPOINT)  →  a self-hosted SearXNG instance
+  else BRAVE_API_KEY                 →  the Brave Search API
+  else                               →  DuckDuckGo Lite (HTML scrape)
+  ```
+
+  A configured **sovereign** instance wins over any external service, so
+  queries never leak to Brave/Google once `SEARXNG_URL` is set.
+
+### Enabling `web_search`
+
+`web_search` is gated (its zero-config DDG fallback is brittle and leaks
+queries). The gate is `ITERION_WEB_SEARCH`, resolved by
+[`tool.ResolveWebSearchEnabled`](../pkg/backend/tool/web_search_enable.go):
+
+| `ITERION_WEB_SEARCH` | Effect |
+|----------------------|--------|
+| `on` / `true` / `1`  | always register (DuckDuckGo scrape included) |
+| `off` / `false` / `0`| never register |
+| unset / `auto` (default) | register **only** when a search backend is configured (`SEARXNG_URL`, `SEARXNG_ENDPOINT`, or `BRAVE_API_KEY`) |
+
+So in the default `auto` mode, standing up a SearXNG container (or setting a
+Brave key) is all it takes to give claw agents real web search; the
+low-quality DDG scrape is reachable only by explicitly forcing `on`.
+
+A node still has to allow the tool — list `web_search` in the node's `tools:`
+(or leave `tools:` unset on claw to inherit the full set).
+
+### SearXNG setup (tier 2)
+
+Run one SearXNG container and **enable its JSON output format** (required —
+`web_search` requests `format=json`, and an instance without it returns
+HTTP 403, surfaced as an explicit error):
+
+```yaml
+# searxng settings.yml
+search:
+  formats:
+    - html
+    - json
+```
+
+Then point iterion at it:
+
+```sh
+export SEARXNG_URL=http://localhost:8080   # activates SearXNG + auto-enables web_search
+```
+
+## Tier 3 — Firecrawl over MCP (`firecrawl` builtin plugin)
+
+For JS-rendered pages, readability extraction, crawling, and structured
+extract, use **Firecrawl**, which iterion wires as an MCP server through the
+built-in `firecrawl` plugin (disabled by default):
+
+```sh
+iterion plugin enable firecrawl
+# self-hosted Firecrawl? set its URL (leave empty for Firecrawl cloud):
+iterion plugin config firecrawl api_url=http://localhost:3002
+```
+
+The plugin contributes an `mcp.firecrawl.*` server to the workflow MCP
+catalog. A claw node uses it like any MCP tool:
+
+```iter
+agent researcher:
+  backend: claw
+  tools: [mcp.firecrawl.search, mcp.firecrawl.scrape, web_fetch]
+  mcp:
+    servers: [firecrawl]
+```
+
+### Pairing Firecrawl with SearXNG (sovereign tier 3)
+
+Firecrawl's own `search` endpoint delegates to a configured search provider.
+To keep the whole stack sovereign, point **Firecrawl** (not the MCP client)
+at your SearXNG instance via its deployment env:
+
+```sh
+# in Firecrawl's docker-compose / env, NOT in iterion:
+SEARXNG_ENDPOINT=http://searxng:8080
+```
+
+iterion just connects to Firecrawl; Firecrawl uses SearXNG internally. So a
+single SearXNG instance can serve both claw's `web_search` (tier 2) and
+Firecrawl's `search` (tier 3).
+
+## Backend note: claude_code vs claw
+
+- **claude_code** has its own native `WebSearch` / `WebFetch` (Claude Code
+  CLI). A `claude_code` node that leaves `tools:` unset inherits them for
+  free. If it restricts `tools:`, list `WebSearch` / `WebFetch` explicitly.
+- **External MCP servers (Firecrawl, custom SearXNG MCP) are resolved into
+  tools only for the `claw` backend.** iterion does not forward
+  user-declared `mcp_server` / plugin MCP configs to the claude_code or codex
+  CLIs (only the internal `ask_user` + board servers are wired there). On
+  claude_code, rely on its native web tools; the Firecrawl tier is claw-only.
+  Forwarding user MCP servers to the claude CLI via `--mcp-config` is a
+  possible future enhancement.
+
+`web_fetch` (claw) and the tier resolution above are unrelated to Anthropic's
+server-side `web_search_*` / `web_fetch_*` tool types — claw does not pass
+those through; all web work is client-side.

--- a/examples/web-search/research.bot
+++ b/examples/web-search/research.bot
@@ -1,0 +1,44 @@
+## Tier-2 web search with claw's web_search tool.
+##
+## web_search resolves its backend from the environment at run time:
+##   SEARXNG_URL (or SEARXNG_ENDPOINT) -> a self-hosted SearXNG instance
+##   else BRAVE_API_KEY                -> the Brave Search API
+##   else                              -> DuckDuckGo Lite (scrape)
+##
+## The tool is registered when ITERION_WEB_SEARCH=on, or (default `auto`)
+## when any of those backends is configured. See docs/web-search.md.
+
+vars:
+  topic: string = "the SearXNG metasearch engine"
+
+prompt researcher_system:
+  You are a web researcher. Use web_search to find relevant sources for
+  the topic, then web_fetch the most promising URLs to read their
+  content. Summarize the findings and cite every source URL you used.
+
+prompt researcher_user:
+  Research this topic and produce a sourced summary: {{vars.topic}}
+
+schema researcher_output:
+  summary: string
+  sources: string[]
+
+agent researcher:
+  backend: "claw"
+  model: "anthropic/claude-sonnet-4-6"
+  system: researcher_system
+  user: researcher_user
+  output: researcher_output
+  tools: [web_search, web_fetch]
+  tool_max_steps: 8
+  session: fresh
+
+workflow main:
+  entry: researcher
+
+  budget:
+    max_duration: "5m"
+    max_cost_usd: 2
+    max_tokens: 100000
+
+  researcher -> done

--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,7 @@ require (
 )
 
 require (
-	github.com/SocialGouv/claw-code-go v0.1.1-0.20260711111517-6cda56bc05a9
+	github.com/SocialGouv/claw-code-go v0.1.1-0.20260713082314-0faf395d7c34
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/aws/aws-sdk-go-v2 v1.42.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.28

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQ
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260711111517-6cda56bc05a9 h1:Ae6/XbKYhtcO0S7RmBOpgDLFYKF5aimyo/Vl7E+iV3Q=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260711111517-6cda56bc05a9/go.mod h1:c0yGvkNqLl+A4KNRBBEg1iP3dhnnM9z0XX6jCFlA15k=
+github.com/SocialGouv/claw-code-go v0.1.1-0.20260713082314-0faf395d7c34 h1:AzODmrI8C5gZgxcW4SLtAcV7vqTeCh9KJTPmnN3l7Oo=
+github.com/SocialGouv/claw-code-go v0.1.1-0.20260713082314-0faf395d7c34/go.mod h1:c0yGvkNqLl+A4KNRBBEg1iP3dhnnM9z0XX6jCFlA15k=
 github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
 github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/aws/aws-sdk-go-v2 v1.42.1 h1:9eOTgu1z/dVtYpNZ3/8/XbbaX0x/BqE3HUzAzs6K0ek=

--- a/pkg/backend/tool/claw_builtins.go
+++ b/pkg/backend/tool/claw_builtins.go
@@ -499,9 +499,10 @@ type ClawDefaults struct {
 	PlanMode *clawtools.PlanModeState
 
 	// IncludeWebSearch toggles registration of the `web_search` tool.
-	// Off by default because it falls back to scraping DuckDuckGo Lite
-	// when BRAVE_API_KEY is unset, which is brittle; tests typically
-	// override the URL via env to point at a fixture.
+	// Production callers resolve it via ResolveWebSearchEnabled (env
+	// ITERION_WEB_SEARCH + configured search backends); tests set it
+	// directly. The tool self-degrades SearXNG → Brave → DuckDuckGo
+	// Lite at execute time based on env.
 	IncludeWebSearch bool
 
 	// IncludeComputerUse toggles screenshot + computer_use registration.

--- a/pkg/backend/tool/web_search_enable.go
+++ b/pkg/backend/tool/web_search_enable.go
@@ -1,0 +1,48 @@
+package tool
+
+import (
+	"os"
+	"strings"
+)
+
+// searchBackendEnvs are the env vars that indicate a real, configured
+// web-search backend. SEARXNG_URL/SEARXNG_ENDPOINT point at a
+// self-hosted SearXNG instance (the sovereign default); BRAVE_API_KEY
+// keys the Brave Search API. Their presence is what flips the "auto"
+// mode on. The DuckDuckGo Lite scrape is intentionally NOT represented
+// here: it needs no config, is brittle, and leaks queries to a third
+// party, so it is never a silent default — reach it only by forcing
+// ITERION_WEB_SEARCH=on.
+var searchBackendEnvs = []string{"SEARXNG_URL", "SEARXNG_ENDPOINT", "BRAVE_API_KEY"}
+
+// ResolveWebSearchEnabled decides whether the claw `web_search` tool is
+// registered for a run. Precedence mirrors backend auto-detection:
+//
+//   - ITERION_WEB_SEARCH=on|true|1   → always register (DDG scrape included)
+//   - ITERION_WEB_SEARCH=off|false|0 → never register
+//   - unset / auto (the default)     → register only when a search backend
+//     is configured (SEARXNG_URL / SEARXNG_ENDPOINT / BRAVE_API_KEY)
+//
+// The zero-config DuckDuckGo fallback is thus opt-in via `on`, keeping
+// the sovereign SearXNG / keyed-Brave path the only automatic surface.
+func ResolveWebSearchEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("ITERION_WEB_SEARCH"))) {
+	case "on", "true", "1":
+		return true
+	case "off", "false", "0":
+		return false
+	default: // "", "auto", or anything unrecognized → auto
+		return searchBackendConfigured()
+	}
+}
+
+// searchBackendConfigured reports whether any configured search backend
+// env is set to a non-empty value.
+func searchBackendConfigured() bool {
+	for _, k := range searchBackendEnvs {
+		if strings.TrimSpace(os.Getenv(k)) != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/backend/tool/web_search_enable_test.go
+++ b/pkg/backend/tool/web_search_enable_test.go
@@ -1,0 +1,35 @@
+package tool
+
+import "testing"
+
+func TestResolveWebSearchEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{"default off, no backend", map[string]string{}, false},
+		{"auto on with searxng", map[string]string{"SEARXNG_URL": "http://searx:8080"}, true},
+		{"auto on with searxng endpoint alias", map[string]string{"SEARXNG_ENDPOINT": "http://searx:8080"}, true},
+		{"auto on with brave key", map[string]string{"BRAVE_API_KEY": "k"}, true},
+		{"explicit on with no backend (ddg allowed)", map[string]string{"ITERION_WEB_SEARCH": "on"}, true},
+		{"explicit off masks configured backend", map[string]string{"ITERION_WEB_SEARCH": "off", "SEARXNG_URL": "http://searx:8080"}, false},
+		{"auto keyword with backend", map[string]string{"ITERION_WEB_SEARCH": "auto", "BRAVE_API_KEY": "k"}, true},
+		{"auto keyword without backend", map[string]string{"ITERION_WEB_SEARCH": "auto"}, false},
+		{"empty env value ignored", map[string]string{"SEARXNG_URL": "  "}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear all relevant envs, then set the case's.
+			for _, k := range []string{"ITERION_WEB_SEARCH", "SEARXNG_URL", "SEARXNG_ENDPOINT", "BRAVE_API_KEY"} {
+				t.Setenv(k, "")
+			}
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			if got := ResolveWebSearchEnabled(); got != tt.want {
+				t.Errorf("ResolveWebSearchEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/plugin/builtin/firecrawl/plugin.yaml
+++ b/pkg/plugin/builtin/firecrawl/plugin.yaml
@@ -1,0 +1,33 @@
+name: firecrawl
+version: 1.0.0
+description: Firecrawl MCP — web search + JS-rendered scrape/crawl/extract (self-hostable, pairs with a SearXNG search backend)
+author: Firecrawl (https://github.com/firecrawl/firecrawl)
+schema_version: 1
+default_enabled: false
+config:
+  - key: api_url
+    label: Firecrawl API URL
+    type: string
+    description: >-
+      Base URL of your self-hosted Firecrawl (e.g. http://localhost:3002).
+      Leave empty to use the Firecrawl cloud API. Point Firecrawl itself at
+      a SearXNG instance via its own SEARXNG_ENDPOINT env (deployment-side).
+    default: ""
+  - key: api_key
+    label: Firecrawl API key
+    type: secret
+    description: >-
+      API key. Required for Firecrawl cloud; for a self-hosted instance set
+      any non-empty value the instance accepts.
+    default: "self-hosted"
+contributes:
+  mcp_servers:
+    - name: firecrawl
+      transport: stdio
+      command: npx
+      args:
+        - -y
+        - firecrawl-mcp
+      env:
+        FIRECRAWL_API_URL: "{{config.api_url}}"
+        FIRECRAWL_API_KEY: "{{config.api_key}}"

--- a/pkg/runview/executor.go
+++ b/pkg/runview/executor.go
@@ -313,7 +313,10 @@ func BuildExecutor(spec ExecutorSpec) (*model.ClawExecutor, error) {
 		opts = append(opts, model.WithMCPManager(mcpManager))
 	}
 
-	clawDefaults := tool.ClawDefaults{Workspace: workspace}
+	clawDefaults := tool.ClawDefaults{
+		Workspace:        workspace,
+		IncludeWebSearch: tool.ResolveWebSearchEnabled(),
+	}
 	if planDir != "" {
 		clawDefaults.PlanMode = &clawtools.PlanModeState{Active: &planActive, Dir: planDir}
 	}

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/tools/web_search.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/tools/web_search.go
@@ -31,6 +31,19 @@ func braveSearchEndpoint() string {
 	return defaultBraveSearchURL
 }
 
+// searxngBaseURL returns the configured SearXNG instance base URL, or
+// "" when none is set. Unlike Brave/DDG this has no default: SearXNG is
+// self-hosted, so the base URL is the activation signal. SEARXNG_URL is
+// the primary env; SEARXNG_ENDPOINT is accepted as an alias because it
+// is the name Firecrawl already uses for the same setting. The base is
+// also the test-injection point (point it at an httptest server).
+func searxngBaseURL() string {
+	if v := os.Getenv("SEARXNG_URL"); v != "" {
+		return v
+	}
+	return os.Getenv("SEARXNG_ENDPOINT")
+}
+
 func ddgSearchEndpoint() string {
 	if v := os.Getenv("CLAW_WEB_SEARCH_DDG_URL"); v != "" {
 		return v
@@ -42,7 +55,7 @@ func ddgSearchEndpoint() string {
 func WebSearchTool() api.Tool {
 	return api.Tool{
 		Name:        "web_search",
-		Description: "Search the web and return a list of results with title, URL, and snippet. Uses Brave Search API if BRAVE_API_KEY is set, otherwise DuckDuckGo.",
+		Description: "Search the web and return a list of results with title, URL, and snippet. Uses a self-hosted SearXNG instance if SEARXNG_URL is set, else the Brave Search API if BRAVE_API_KEY is set, otherwise DuckDuckGo.",
 		InputSchema: api.InputSchema{
 			Type: "object",
 			Properties: map[string]api.Property{
@@ -83,10 +96,76 @@ func ExecuteWebSearch(input map[string]any) (string, error) {
 		numResults = 20
 	}
 
+	if base := searxngBaseURL(); base != "" {
+		return searxngSearch(query, numResults, base)
+	}
 	if apiKey := os.Getenv("BRAVE_API_KEY"); apiKey != "" {
 		return braveSearch(query, numResults, apiKey)
 	}
 	return ddgSearch(query, numResults)
+}
+
+// searxngSearch queries a self-hosted SearXNG instance via its JSON API.
+// The instance must have the `json` output format enabled in its
+// settings (`search.formats` must include `json`); otherwise it returns
+// HTTP 403 and the caller sees an explicit error rather than a silent
+// empty result.
+func searxngSearch(query string, numResults int, base string) (string, error) {
+	params := url.Values{}
+	params.Set("q", query)
+	params.Set("format", "json")
+	params.Set("categories", "general")
+	params.Set("safesearch", "0")
+
+	endpoint := strings.TrimRight(base, "/") + "/search?" + params.Encode()
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("web_search: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "claw-code/0.1 (searxng)")
+
+	client := &http.Client{Timeout: searchTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("web_search (searxng): %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("web_search (searxng): HTTP %d (is the JSON format enabled in the instance settings?)", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("web_search (searxng): read body: %w", err)
+	}
+
+	var result struct {
+		Results []struct {
+			Title   string `json:"title"`
+			URL     string `json:"url"`
+			Content string `json:"content"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("web_search (searxng): parse response: %w", err)
+	}
+
+	if len(result.Results) == 0 {
+		return "No results found.", nil
+	}
+
+	if len(result.Results) > numResults {
+		result.Results = result.Results[:numResults]
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Search results for: %s\n\n", query)
+	for i, r := range result.Results {
+		fmt.Fprintf(&sb, "%d. %s\n   %s\n   %s\n\n", i+1, r.Title, r.URL, r.Content)
+	}
+	return strings.TrimSpace(sb.String()), nil
 }
 
 // braveSearch queries the Brave Search API.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -66,7 +66,7 @@ github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/shared
 github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/version
 github.com/AzureAD/microsoft-authentication-library-for-go/apps/managedidentity
 github.com/AzureAD/microsoft-authentication-library-for-go/apps/public
-# github.com/SocialGouv/claw-code-go v0.1.1-0.20260711111517-6cda56bc05a9
+# github.com/SocialGouv/claw-code-go v0.1.1-0.20260713082314-0faf395d7c34
 ## explicit; go 1.25.0
 github.com/SocialGouv/claw-code-go/hooks
 github.com/SocialGouv/claw-code-go/internal/api


### PR DESCRIPTION
## Context

Web search in iterion was incomplete and, for the default backend, dormant: claw's `web_search` was gated behind `ClawDefaults.IncludeWebSearch`, which **no production code ever set** — claw agents could `web_fetch` a known URL but never discover one. This turns web search into a **sovereign capability ladder**, one tool (`web_search`) whose backend resolves from the env, plus Firecrawl at the top tier over the existing MCP seam.

| Tier | Infra | Search | Scrape/crawl |
|------|-------|--------|--------------|
| 0 | none | DuckDuckGo Lite | `web_fetch` |
| 1 | Brave key | Brave API | `web_fetch` |
| 2 | one SearXNG container | **SearXNG** (sovereign) | `web_fetch` |
| 3 | Firecrawl + SearXNG | Firecrawl `search` | Firecrawl (JS, crawl, extract) |

## Changes

- **claw (vendored)**: SearXNG backend in `web_search`, precedence `SEARXNG_URL`/`SEARXNG_ENDPOINT` → Brave → DDG (claw-code-go@0faf395, bumped via `scripts/bump-claw.sh`).
- **Enable resolver**: `ITERION_WEB_SEARCH=on|off|auto` (default `auto`) via `tool.ResolveWebSearchEnabled` — auto-registers `web_search` only when a search backend is configured, keeping the brittle DDG scrape opt-in. Wired at the single `ClawDefaults` site (local + cloud runner).
- **Firecrawl builtin plugin** (disabled by default): `mcp_servers` contribution for JS-rendered scrape/crawl/extract, config `api_url`/`api_key`. Zero engine code.
- **Docs**: `docs/web-search.md`, ADR-072, pointers, example bot.

## Limitation (documented)

External MCP (Firecrawl) is **claw-only** — iterion doesn't forward user MCP servers to the claude_code CLI. On claude_code, search stays its native `WebSearch`/`WebFetch`. Forwarding via `--mcp-config` is a deferred follow-on.

## Verification

- claw unit tests (SearXNG backend + precedence), resolver tests (9 cases)
- lint + `go vet` clean, **full unit suite green** (vendor bump breaks nothing)
- `iterion plugin info firecrawl` (disabled, mcp), example bot validates OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)