### PR TITLE
feat(claude_code): forward user/plugin MCP servers via --mcp-config

### DIFF
--- a/docs/adr/072-web-search-capability-tiers.md
+++ b/docs/adr/072-web-search-capability-tiers.md
@@ -81,12 +81,14 @@ Load-bearing decisions:
 
 - Standing up a SearXNG container (JSON format enabled) is all it takes
   to give claw agents sovereign search under the default `auto` mode.
-- **Firecrawl/MCP web tools are claw-only.** iterion does not forward
-  user-declared MCP servers to the claude_code/codex CLIs (only the
-  internal `ask_user` + board servers), so on claude_code the search path
-  is its native `WebSearch`/`WebFetch`. Forwarding user MCP servers to
-  the claude CLI via `--mcp-config` is a deferred follow-on that would
-  close this gap and make the ladder backend-symmetric.
+- **Firecrawl/MCP web tools reach both backends.** claw resolves them
+  in-process; claude_code forwards the node's active user/plugin MCP
+  servers to the agent CLI via `--mcp-config` (`wireUserMCP`), purely
+  additively — no `--tools` is passed, so claude_code keeps its native
+  `WebSearch`/`WebFetch` on by default and gains Firecrawl on top. codex
+  is unchanged. Caveat: a stdio server whose `command:` is a host path
+  won't resolve inside a sandbox container (same as the internal
+  ask_user/board stdio servers) — use an http/sse server there.
 - A SearXNG instance must have the `json` output format enabled; absence
   surfaces as an explicit HTTP-403 error, not a silent empty result
   (per the erreurs-explicites principle).

--- a/docs/web-search.md
+++ b/docs/web-search.md
@@ -113,13 +113,19 @@ Firecrawl's `search` (tier 3).
 - **claude_code** has its own native `WebSearch` / `WebFetch` (Claude Code
   CLI). A `claude_code` node that leaves `tools:` unset inherits them for
   free. If it restricts `tools:`, list `WebSearch` / `WebFetch` explicitly.
-- **External MCP servers (Firecrawl, custom SearXNG MCP) are resolved into
-  tools only for the `claw` backend.** iterion does not forward
-  user-declared `mcp_server` / plugin MCP configs to the claude_code or codex
-  CLIs (only the internal `ask_user` + board servers are wired there). On
-  claude_code, rely on its native web tools; the Firecrawl tier is claw-only.
-  Forwarding user MCP servers to the claude CLI via `--mcp-config` is a
-  possible future enhancement.
+- **External MCP servers (Firecrawl, custom SearXNG MCP) are forwarded to
+  BOTH backends.** The `claw` backend resolves them into tools in-process;
+  the `claude_code` backend forwards the node's active `mcp_server` / plugin
+  MCP configs to the agent CLI via `--mcp-config`
+  ([wireUserMCP](../pkg/backend/delegate/claude_code_hooks.go)). This is
+  purely additive — iterion never passes `--tools`, so claude_code keeps its
+  full native toolset (**WebSearch/WebFetch stay on by default**) and simply
+  gains the Firecrawl tools on top. codex is unchanged (no MCP wiring).
+- One caveat for claude_code stdio MCP servers: a `command:` that is a host
+  path won't resolve inside a sandboxed container (same limitation as the
+  internal ask_user/board stdio servers). Prefer an `http`/`sse` server for
+  sandboxed runs; a self-hosted Firecrawl MCP over HTTP is reachable from
+  inside the container.
 
 `web_fetch` (claw) and the tier resolution above are unrelated to Anthropic's
 server-side `web_search_*` / `web_fetch_*` tool types — claw does not pass

--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -360,6 +360,7 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, task Task) (result Resu
 	opts = installMaterializeSecretsHook(task, opts)
 	opts = installRewriteHook(task, opts)
 	opts = b.wireBoardMCP(task, opts, &extraAllowedTools)
+	opts = b.wireUserMCP(task, opts, &extraAllowedTools)
 
 	// Watch capabilities (watch.subscribe / watch.unsubscribe) are wired for
 	// the claw backend only so far — the claude_code stdio (__mcp-watch) and

--- a/pkg/backend/delegate/claude_code_hooks.go
+++ b/pkg/backend/delegate/claude_code_hooks.go
@@ -321,6 +321,53 @@ func (b *ClaudeCodeBackend) wireBoardMCP(task Task, opts []claudesdk.Option, ext
 	return opts
 }
 
+// wireUserMCP forwards the node's active user/plugin-declared MCP servers
+// (Task.MCPServers) to the claude_code CLI via --mcp-config, so their tools
+// are available to the agent — the claude_code half of the parity claw
+// already had. It is purely ADDITIVE: it registers servers only, never
+// passes --tools, so the native toolset (WebSearch/WebFetch, …) stays on by
+// default. AlwaysLoad is set so an http/sse server's tools surface past
+// claude-code's tool-search deferral (and a stdio server's tools are always
+// eager). When the node restricts its toolset (non-empty AllowedTools), each
+// server's tools are allow-listed by wildcard FQN (mcp__<server>__*) so the
+// declared MCP tools are not filtered out.
+//
+// Sandboxed stdio servers whose Command is a host path are left to the CLI:
+// the same host-path caveat as ask_user/board applies, but unlike those we
+// have no HTTP fallback for arbitrary user servers — an http/sse server is
+// reachable from inside the container, a stdio one only if its Command
+// resolves in-container.
+func (b *ClaudeCodeBackend) wireUserMCP(task Task, opts []claudesdk.Option, extras *[]string) []claudesdk.Option {
+	for _, s := range task.MCPServers {
+		var srv claudesdk.MCPServerConfig
+		switch strings.ToLower(strings.TrimSpace(s.Transport)) {
+		case "http":
+			if s.URL == "" {
+				b.Logger.Warn("[%s#%d/claude-code] MCP server %q: http transport with empty url; skipped", task.NodeID, task.Iteration, s.Name)
+				continue
+			}
+			srv = &claudesdk.MCPHTTPServer{URL: s.URL, Headers: s.Headers, AlwaysLoad: true}
+		case "sse":
+			if s.URL == "" {
+				b.Logger.Warn("[%s#%d/claude-code] MCP server %q: sse transport with empty url; skipped", task.NodeID, task.Iteration, s.Name)
+				continue
+			}
+			srv = &claudesdk.MCPSSEServer{URL: s.URL, Headers: s.Headers}
+		default: // stdio
+			if s.Command == "" {
+				b.Logger.Warn("[%s#%d/claude-code] MCP server %q: stdio transport with empty command; skipped", task.NodeID, task.Iteration, s.Name)
+				continue
+			}
+			srv = &claudesdk.MCPStdioServer{Command: s.Command, Args: s.Args, Env: s.Env}
+		}
+		opts = append(opts, claudesdk.WithMCPServer(s.Name, srv))
+		if len(task.AllowedTools) > 0 {
+			*extras = append(*extras, "mcp__"+s.Name+"__*")
+		}
+	}
+	return opts
+}
+
 // installInboxDrainHooks delivers operator-chatbox messages mid-session
 // (parity with the claw backend's per-iteration drain). PostToolUse fires
 // after every tool call and Stop fires when the LLM tries to end the turn;

--- a/pkg/backend/delegate/claude_code_usermcp_test.go
+++ b/pkg/backend/delegate/claude_code_usermcp_test.go
@@ -1,0 +1,63 @@
+package delegate
+
+import (
+	"bytes"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+func TestWireUserMCP_AddsValidServersSkipsInvalid(t *testing.T) {
+	b := &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{})}
+	task := Task{
+		AllowedTools: []string{"web_fetch"}, // restricted → extras get FQNs
+		MCPServers: []TaskMCPServer{
+			{Name: "firecrawl", Transport: "stdio", Command: "npx", Args: []string{"-y", "firecrawl-mcp"}},
+			{Name: "remote", Transport: "http", URL: "http://firecrawl.internal/mcp"},
+			{Name: "streamy", Transport: "sse", URL: "http://x/sse"},
+			{Name: "nocmd", Transport: "stdio"}, // empty command → skipped
+			{Name: "nourl", Transport: "http"},  // empty url → skipped
+		},
+	}
+	var extras []string
+	opts := b.wireUserMCP(task, nil, &extras)
+
+	if len(opts) != 3 {
+		t.Fatalf("expected 3 servers wired (stdio+http+sse), got %d", len(opts))
+	}
+	want := map[string]bool{"mcp__firecrawl__*": false, "mcp__remote__*": false, "mcp__streamy__*": false}
+	for _, e := range extras {
+		if _, ok := want[e]; ok {
+			want[e] = true
+		}
+	}
+	for fqn, seen := range want {
+		if !seen {
+			t.Errorf("expected allow-list FQN %q for a restricted node, missing (extras=%v)", fqn, extras)
+		}
+	}
+	for _, e := range extras {
+		if e == "mcp__nocmd__*" || e == "mcp__nourl__*" {
+			t.Errorf("skipped server leaked into extras: %q", e)
+		}
+	}
+}
+
+func TestWireUserMCP_NoExtrasWhenToolsetUnrestricted(t *testing.T) {
+	b := &ClaudeCodeBackend{Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{})}
+	task := Task{
+		// empty AllowedTools = "no restriction" → native toolset stays, and
+		// we must NOT allow-list (which would imply a restriction).
+		MCPServers: []TaskMCPServer{
+			{Name: "firecrawl", Transport: "stdio", Command: "npx"},
+		},
+	}
+	var extras []string
+	opts := b.wireUserMCP(task, nil, &extras)
+	if len(opts) != 1 {
+		t.Fatalf("expected 1 server wired, got %d", len(opts))
+	}
+	if len(extras) != 0 {
+		t.Errorf("expected no allow-list additions on an unrestricted node, got %v", extras)
+	}
+}

--- a/pkg/backend/delegate/delegate.go
+++ b/pkg/backend/delegate/delegate.go
@@ -246,6 +246,20 @@ type ToolDef struct {
 	Execute     func(ctx context.Context, input json.RawMessage) (string, error)
 }
 
+// TaskMCPServer is a resolved, user/plugin-declared MCP server carried on
+// Task.MCPServers for CLI backends to forward to the agent CLI. It mirrors
+// the runtime mcp.ServerConfig / claudesdk MCP server shape (stdio uses
+// Command/Args/Env; http/sse use URL/Headers).
+type TaskMCPServer struct {
+	Name      string
+	Transport string // "stdio" | "http" | "sse" (empty → stdio)
+	Command   string
+	Args      []string
+	URL       string
+	Headers   map[string]string
+	Env       map[string]string
+}
+
 // MemorySpec opts the node into the iterion workspace memory
 // tree (under ~/.iterion/projects/<encoded>/memory/<Scope>/).
 // Honored by backends that maintain their own session history (claw).
@@ -367,6 +381,17 @@ type Task struct {
 	// ToolDefs provides full tool definitions for backends that manage tool
 	// loops internally (e.g. claw). CLI-based backends ignore this field.
 	ToolDefs []ToolDef
+
+	// MCPServers are the user/plugin-declared MCP servers active for this
+	// node (from the workflow `mcp_server` decls, project .mcp.json, and
+	// enabled plugins' mcp_servers contributions). CLI backends
+	// (claude_code) forward them to the agent CLI via --mcp-config so
+	// their tools are available ALONGSIDE — never replacing — the native
+	// toolset (WebSearch/WebFetch stay on by default). The claw backend
+	// does NOT read this: it resolves the same servers into ToolDefs
+	// in-process via the MCP manager. Internal servers (ask_user, board)
+	// are wired separately by each backend and are absent here.
+	MCPServers []TaskMCPServer
 
 	// OutputSchema is the JSON Schema for the expected structured output.
 	// Nil means free-form text output.

--- a/pkg/backend/model/executor_build_task.go
+++ b/pkg/backend/model/executor_build_task.go
@@ -618,6 +618,14 @@ func (e *ClawExecutor) buildTask(ctx context.Context, node ir.Node, f backendFie
 		task.HasTools = true // claw needs the tool loop active for ask_user
 	}
 
+	// CLI backends (claude_code) can't resolve MCP tools in-process, so the
+	// node's active user/plugin MCP servers are forwarded to the agent CLI
+	// verbatim (delegate.wireUserMCP → --mcp-config). Additive only: it never
+	// passes --tools, so native WebSearch/WebFetch stay on by default.
+	if backendName == delegate.BackendClaudeCode && len(f.activeMCPServers) > 0 && e.mcpManager != nil {
+		task.MCPServers = e.resolveTaskMCPServers(f.activeMCPServers)
+	}
+
 	e.applySessionContinuity(&task, f, input)
 	applyResumeContinuity(&task, input)
 

--- a/pkg/backend/model/executor_toolresolve.go
+++ b/pkg/backend/model/executor_toolresolve.go
@@ -49,6 +49,38 @@ func (e *ClawExecutor) resolveToolsForNode(ctx context.Context, node ir.Node, na
 	return tools, nil
 }
 
+// resolveTaskMCPServers projects the node's active MCP server names into
+// the transport-agnostic delegate.TaskMCPServer shape that CLI backends
+// (claude_code) forward to the agent CLI. Unknown names (not in the MCP
+// manager's resolved catalog) are skipped — the manager holds only
+// user/plugin servers, so internal ones (ask_user, board) are naturally
+// absent. Auth-bearing http/sse servers are forwarded by URL+Headers; the
+// OAuth broker path (claw-only in-process resolution) is not replicated
+// here, so a server needing dynamic bearer refresh should carry a static
+// header instead.
+func (e *ClawExecutor) resolveTaskMCPServers(names []string) []delegate.TaskMCPServer {
+	if e.mcpManager == nil {
+		return nil
+	}
+	var out []delegate.TaskMCPServer
+	for _, name := range names {
+		cfg, ok := e.mcpManager.ServerConfig(name)
+		if !ok || cfg == nil {
+			continue
+		}
+		out = append(out, delegate.TaskMCPServer{
+			Name:      cfg.Name,
+			Transport: string(cfg.Transport),
+			Command:   cfg.Command,
+			Args:      append([]string(nil), cfg.Args...),
+			URL:       cfg.URL,
+			Headers:   cfg.Headers,
+			Env:       cfg.Env,
+		})
+	}
+	return out
+}
+
 // expandWildcards replaces wildcard entries ("mcp.<server>.*") with the
 // concrete tool names discovered from that MCP server.
 func (e *ClawExecutor) expandWildcards(ctx context.Context, node ir.Node, names []string) ([]string, error) {


### PR DESCRIPTION
## Context

Follow-up to #135. External MCP servers (Firecrawl, custom SearXNG MCP, any user `mcp_server`) were resolved into tools **only for the claw backend** — iterion never forwarded user/plugin MCP configs to the claude_code CLI (only internal ask_user + board). This closes that gap so the web-search Firecrawl tier (and any external MCP) works on claude_code too.

## Change

- `Task.MCPServers` + `TaskMCPServer` carry the node's **active** user/plugin MCP servers (from the resolved MCP catalog), populated for claude_code in `executor_build_task`.
- `wireUserMCP` forwards each to the agent CLI via `--mcp-config` (stdio → `MCPStdioServer`, http/sse → `MCP{HTTP,SSE}Server`, `AlwaysLoad` on http so tools surface past tool-search deferral).
- **Purely additive**: iterion never passes `--tools`, so claude_code keeps its full native toolset — **WebSearch/WebFetch stay on by default** — and simply gains the forwarded tools on top. codex unchanged.
- Restricted nodes (`tools:` set) allow-list each server by wildcard FQN `mcp__<name>__*`.

## Caveat (documented)

A stdio server whose `command:` is a host path won't resolve inside a sandbox container (same as internal ask_user/board stdio servers) — use an http/sse server there (a self-hosted Firecrawl MCP over HTTP is reachable in-container).

## Verification

- `wireUserMCP` unit tests: valid stdio/http/sse wired, invalid (empty command/url) skipped, FQN allow-listing only when toolset restricted (2 tests green)
- lint + `go vet` clean, `pkg/backend/delegate` + `pkg/backend/model` tests green
- docs/web-search.md + ADR-072 updated to reflect backend symmetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)