### PR TITLE
fix(studio): guard undefined preset.values in BotHome PresetsCard

### DIFF
--- a/studio/src/views/Bots/BotHome/index.tsx
+++ b/studio/src/views/Bots/BotHome/index.tsx
@@ -662,7 +662,9 @@ function PresetsCard({ entry }: { entry: BotEntryWithSchema }) {
     <Card>
       <SectionTitle flush>Presets</SectionTitle>
       <ul className="mt-1 space-y-1.5">
-        {presets.map((p) => (
+        {presets.map((p) => {
+          const valueCount = p.values?.length ?? 0;
+          return (
           <li key={p.name} className="rounded-md border border-border-default bg-surface-2 px-2 py-1.5">
             <div className="flex items-baseline gap-1.5">
               <span className="text-xs font-medium text-fg-default">
@@ -672,12 +674,13 @@ function PresetsCard({ entry }: { entry: BotEntryWithSchema }) {
                 <span className="font-mono text-caption text-fg-subtle">{p.name}</span>
               )}
               <span className="ml-auto text-caption text-fg-subtle">
-                {p.values.length} value{p.values.length === 1 ? "" : "s"}
+                {valueCount} value{valueCount === 1 ? "" : "s"}
               </span>
             </div>
             {p.description && <p className="mt-0.5 text-caption text-fg-muted">{p.description}</p>}
           </li>
-        ))}
+          );
+        })}
       </ul>
     </Card>
   );


### PR DESCRIPTION
## Problem

Visiting a bot home view (`/bots/<id>`) crashed with:

> TypeError: can't access property "length", a.values is undefined

for bots whose presets carry no var overrides (e.g. bmady's persona presets).

## Root cause

`PresetValue` slices serialize as `json:"values,omitempty"` ([pkg/botregistry/schema.go](pkg/botregistry/schema.go)), so a preset with an empty `Values` omits the field entirely — the frontend then read `p.values.length` on `undefined` and the whole Bot home view render-errored.

## Fix

Default the value count to 0 when `values` is absent, mirroring the existing `c.values && c.values.length` guard in `CursorsFields`. Frontend-only; `omitempty` on an optional array is idiomatic and left as-is (the consumer must tolerate absence).

Typecheck (`tsc -b`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)