### PR TITLE
contrib(web-search): docker-compose for sovereign SearXNG + Firecrawl

### DIFF
--- a/contrib/web-search/.env.example
+++ b/contrib/web-search/.env.example
@@ -1,0 +1,12 @@
+# Copy to .env and adjust. `docker compose` auto-loads .env from this dir.
+
+# --- SearXNG (tier 2) ---
+SEARXNG_PORT=8080
+# Generate one: openssl rand -hex 32
+SEARXNG_SECRET=please-change-this-local-secret
+
+# --- Firecrawl (tier 3, --profile firecrawl) ---
+FIRECRAWL_PORT=3002
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=postgres

--- a/contrib/web-search/README.md
+++ b/contrib/web-search/README.md
@@ -1,0 +1,107 @@
+# Sovereign web-search stack for iterion
+
+A reference `docker compose` for the two self-hosted tiers of iterion's web
+search (see [../../docs/web-search.md](../../docs/web-search.md)):
+
+- **Tier 2 — SearXNG**: sovereign metasearch. Powers claw's `web_search`
+  (and, forwarded, claude_code). One light container. No query leaves your
+  network.
+- **Tier 3 — Firecrawl**: JS-rendered scrape / crawl / extract, with its own
+  `search` delegated to the same SearXNG. Heavier (redis + rabbitmq +
+  postgres + playwright).
+
+## Quick start (tier 2 — SearXNG only)
+
+```sh
+cd contrib/web-search
+cp .env.example .env
+sed -i "s/please-change-this-local-secret/$(openssl rand -hex 32)/" .env
+
+docker compose up -d searxng
+
+# Verify the JSON API (must be 200 with a results array):
+curl -s "http://localhost:8080/search?q=test&format=json" | head -c 200
+```
+
+Point iterion at it. Under the default `ITERION_WEB_SEARCH=auto`, setting
+`SEARXNG_URL` both selects the SearXNG backend AND auto-enables `web_search`:
+
+```sh
+export SEARXNG_URL=http://localhost:8080
+```
+
+Then run a claw node with `web_search` in its `tools:` — e.g. the example
+[../../examples/web-search/research.bot](../../examples/web-search/research.bot):
+
+```sh
+iterion run examples/web-search/research.bot --store-dir "$PWD/.iterion"
+```
+
+Precedence is `SEARXNG_URL` → `BRAVE_API_KEY` → DuckDuckGo, so a configured
+SearXNG always wins.
+
+## Tier 3 — Firecrawl (opt-in)
+
+Firecrawl's `search` delegates to the SearXNG above (`SEARXNG_ENDPOINT`), so
+one instance serves both tiers.
+
+```sh
+docker compose --profile firecrawl up -d      # pulls redis/rabbitmq/postgres/playwright/firecrawl
+
+# Verify (all five services + firecrawl reachable):
+curl -s http://localhost:3002/                          # → {"message":"Firecrawl API", ...}
+curl -s -X POST http://localhost:3002/v1/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"iterion","limit":3}'                    # routed through SearXNG
+curl -s -X POST http://localhost:3002/v1/scrape \
+  -H 'Content-Type: application/json' \
+  -d '{"url":"https://example.com","formats":["markdown"]}'
+
+# Enable the iterion plugin (disabled by default) and point it at the local API:
+iterion plugin enable firecrawl
+iterion plugin config firecrawl api_url=http://localhost:3002
+```
+
+A claw node then uses `mcp.firecrawl.search` / `mcp.firecrawl.scrape` with
+`mcp: { servers: [firecrawl] }`. On claude_code the same servers are
+forwarded via `--mcp-config` (native WebSearch/WebFetch stay on too).
+
+The images are pre-built (`ghcr.io/firecrawl/*`); no local build. To pin a
+version, replace `:latest` with a digest.
+
+## SearXNG settings
+
+[searxng/settings.yml](searxng/settings.yml) inherits SearXNG's defaults and
+overrides only what iterion needs. The **load-bearing** line is:
+
+```yaml
+search:
+  formats:
+    - html
+    - json      # REQUIRED — without it, /search?format=json → HTTP 403
+```
+
+`server.limiter: false` disables bot-detection for a private instance; keep
+it **behind your own network boundary** (don't expose an unlimited instance
+publicly).
+
+## From local to infra / prod
+
+The same two services move to your cluster unchanged; only the wiring differs:
+
+1. **Deploy** SearXNG (and optionally Firecrawl) on the infra — a Deployment
+   + Service each, mounting the same `settings.yml` (JSON format enabled),
+   `SEARXNG_SECRET` from a Secret. Keep them **cluster-internal** (no public
+   ingress) — they are unauthenticated by design.
+2. **Wire prod iterion**: set on the iterion runtime/runner environment
+   - `SEARXNG_URL=http://searxng.<namespace>.svc:8080` (tier 2, auto-enables
+     `web_search`), and
+   - for tier 3, `iterion plugin enable firecrawl` +
+     `firecrawl.api_url=http://firecrawl.<namespace>.svc:3002`, with
+     Firecrawl's own `SEARXNG_ENDPOINT` pointing at the in-cluster SearXNG.
+3. **Sandboxed runs**: prefer the http/sse transport for the Firecrawl MCP so
+   it's reachable from inside the container (a stdio server's host `command:`
+   is not) — see [../../docs/web-search.md](../../docs/web-search.md).
+
+Nothing here is iterion-specific: it's a plain SearXNG + Firecrawl stack that
+any consumer of `SEARXNG_URL` / the Firecrawl API can share.

--- a/contrib/web-search/docker-compose.yml
+++ b/contrib/web-search/docker-compose.yml
@@ -1,0 +1,120 @@
+# Sovereign web-search stack for iterion (tier 2 + tier 3).
+#
+#   Tier 2 — SearXNG only (light, ~1 container). Powers claw's web_search on
+#            both backends. Bring up just this:
+#              docker compose up -d searxng
+#            then point iterion at it:
+#              export SEARXNG_URL=http://localhost:8080
+#
+#   Tier 3 — Firecrawl (JS render / crawl / extract), pointed at the same
+#            SearXNG for its own search. Heavier (redis + rabbitmq + postgres
+#            + playwright). Enable with the firecrawl profile:
+#              docker compose --profile firecrawl up -d
+#            then enable the iterion plugin:
+#              iterion plugin enable firecrawl
+#              iterion plugin config firecrawl api_url=http://localhost:3002
+#
+# See README.md for the full walkthrough and the infra/prod notes.
+
+name: iterion-web-search
+
+services:
+  # ---- Tier 2: SearXNG (sovereign metasearch) --------------------------
+  searxng:
+    image: searxng/searxng:latest
+    restart: unless-stopped
+    ports:
+      - "${SEARXNG_PORT:-8080}:8080"
+    volumes:
+      - ./searxng/settings.yml:/etc/searxng/settings.yml:ro
+    environment:
+      SEARXNG_SECRET: ${SEARXNG_SECRET:-please-change-this-local-secret}
+      SEARXNG_BASE_URL: http://localhost:${SEARXNG_PORT:-8080}/
+    networks:
+      - websearch
+    logging:
+      driver: "json-file"
+      options: { max-size: "5m", max-file: "2" }
+
+  # ---- Tier 3: Firecrawl (opt-in via `--profile firecrawl`) ------------
+  # Image-based (no local build). Firecrawl's `search` delegates to the
+  # SearXNG above via SEARXNG_ENDPOINT — one instance serves both tiers.
+  redis:
+    image: redis:alpine
+    profiles: ["firecrawl"]
+    command: redis-server --bind 0.0.0.0
+    networks: [websearch]
+    logging:
+      driver: "json-file"
+      options: { max-size: "5m", max-file: "2" }
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    profiles: ["firecrawl"]
+    command: rabbitmq-server
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "check_running"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks: [websearch]
+    logging:
+      driver: "json-file"
+      options: { max-size: "5m", max-file: "2" }
+
+  nuq-postgres:
+    image: ghcr.io/firecrawl/nuq-postgres:latest
+    profiles: ["firecrawl"]
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+    networks: [websearch]
+    logging:
+      driver: "json-file"
+      options: { max-size: "5m", max-file: "2" }
+
+  playwright-service:
+    image: ghcr.io/firecrawl/playwright-service:latest
+    profiles: ["firecrawl"]
+    environment:
+      PORT: 3000
+    networks: [websearch]
+    logging:
+      driver: "json-file"
+      options: { max-size: "5m", max-file: "2" }
+
+  firecrawl:
+    image: ghcr.io/firecrawl/firecrawl:latest
+    profiles: ["firecrawl"]
+    depends_on:
+      redis: { condition: service_started }
+      playwright-service: { condition: service_started }
+      rabbitmq: { condition: service_healthy }
+    environment:
+      HOST: "0.0.0.0"
+      PORT: ${FIRECRAWL_PORT:-3002}
+      REDIS_URL: redis://redis:6379
+      REDIS_RATE_LIMIT_URL: redis://redis:6379
+      PLAYWRIGHT_MICROSERVICE_URL: http://playwright-service:3000/scrape
+      POSTGRES_HOST: nuq-postgres
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+      USE_DB_AUTHENTICATION: "false"
+      NUQ_RABBITMQ_URL: amqp://rabbitmq:5672
+      # The sovereign wiring: Firecrawl's own search goes through SearXNG.
+      SEARXNG_ENDPOINT: http://searxng:8080
+      ENV: local
+    ports:
+      - "${FIRECRAWL_PORT:-3002}:${FIRECRAWL_PORT:-3002}"
+    networks: [websearch]
+    logging:
+      driver: "json-file"
+      options: { max-size: "10m", max-file: "3" }
+
+networks:
+  websearch:
+    driver: bridge

--- a/contrib/web-search/searxng/settings.yml
+++ b/contrib/web-search/searxng/settings.yml
@@ -1,0 +1,25 @@
+# SearXNG settings for the iterion sovereign web-search tier.
+#
+# The one line that matters for iterion: search.formats includes `json`.
+# Without it, SearXNG answers /search?format=json with HTTP 403 and claw's
+# web_search surfaces an explicit error (see docs/web-search.md).
+#
+# `use_default_settings: true` inherits SearXNG's full engine catalogue; the
+# keys below only override what iterion needs for a local, programmatic,
+# unauthenticated instance.
+use_default_settings: true
+
+server:
+  # Overridden at runtime by the SEARXNG_SECRET env (see docker-compose).
+  secret_key: "change-me-in-.env"
+  # The limiter/bot-detection blocks programmatic clients; off for a
+  # private local/self-hosted instance behind your own network boundary.
+  limiter: false
+  public_instance: false
+  image_proxy: false
+
+search:
+  # REQUIRED for iterion: expose the JSON API.
+  formats:
+    - html
+    - json


### PR DESCRIPTION
## Context

Companion to #135 (web-search tiers) and #137 (claude_code MCP forwarding): a reference self-host stack so an operator can stand up the sovereign search tiers with one `docker compose`. See [docs/web-search.md](../blob/main/docs/web-search.md).

## Contents (`contrib/web-search/`)

- `docker-compose.yml` — **tier 2** `searxng` (JSON format enabled) + **tier 3** Firecrawl (`--profile firecrawl`, image-based: redis/rabbitmq/nuq-postgres/playwright/firecrawl) with `SEARXNG_ENDPOINT` pointed at the same SearXNG, so one instance serves both tiers.
- `searxng/settings.yml` — inherits SearXNG defaults, overrides only what iterion needs (the load-bearing `search.formats: [html, json]`, limiter off for a private instance).
- `.env.example`, `README.md` (local bring-up → iterion wiring → infra/prod path).

## Verification

- **Tier 2 validated live end-to-end**: `docker compose up -d searxng`, JSON API returns 38 real results; iterion's exact `web_search` path (`RegisterClawWebSearch` → SearXNG backend, no `BRAVE_API_KEY`) returns formatted results incl. the iterion repo — proving `SEARXNG_URL` precedence + auto-enable.
- Tier 3 uses the official `ghcr.io/firecrawl/*` images wired per Firecrawl's own compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)