### PR TITLE
fix(studio): suppress the WS "stale" banner on paused/terminal runs

### DIFF
--- a/studio/src/components/Runs/RunHeader.tsx
+++ b/studio/src/components/Runs/RunHeader.tsx
@@ -84,6 +84,17 @@ export default function RunHeader({ run, active, wsState, onResetLayout, bare = 
   // doesn't ship cross-process pause; cancel falls back via NATS but
   // pause has no NATS subject yet).
   const canPause = run.status === "running" && active;
+  // The WS "disconnected — data may be stale" banner is only meaningful
+  // while MORE live events are expected (running / queued). A paused or
+  // terminal run legitimately ENDS its event stream — the broker closes
+  // the channel on pause/completion and the WS emits `terminated`, which
+  // the client turns into wsState="closed" — so the data is complete, not
+  // stale. Without this gate a paused run (waiting for the operator's
+  // answer) shows a false "disconnected" alarm whose Reconnect re-triggers
+  // the same `terminated` immediately. Resume redials the WS on its own
+  // (wsReconnectToken), so the live tail returns when the run continues.
+  const liveStreamExpected =
+    run.status === "running" || run.status === "queued";
   // Fork is offered for every run that has a checkpoint to anchor on
   // — paused, finished, failed, cancelled. We don't gate by status
   // because "fork from a finished run" is a perfectly valid use case
@@ -380,7 +391,9 @@ export default function RunHeader({ run, active, wsState, onResetLayout, bare = 
           {error}
         </InlineBanner>
       )}
-      <WSDisconnectBanner state={wsState} onReconnect={requestWsReconnect} />
+      {liveStreamExpected && (
+        <WSDisconnectBanner state={wsState} onReconnect={requestWsReconnect} />
+      )}
       {showFinalization && <FinalizationRow run={run} />}
       {run.forked_from && <ForkedFromRow run={run} />}
       {run.source?.issue_id && <SourceTicketRow source={run.source} />}

--- a/studio/src/views/Bots/BotHome/index.tsx
+++ b/studio/src/views/Bots/BotHome/index.tsx
@@ -662,7 +662,9 @@ function PresetsCard({ entry }: { entry: BotEntryWithSchema }) {
     <Card>
       <SectionTitle flush>Presets</SectionTitle>
       <ul className="mt-1 space-y-1.5">
-        {presets.map((p) => (
+        {presets.map((p) => {
+          const valueCount = p.values?.length ?? 0;
+          return (
           <li key={p.name} className="rounded-md border border-border-default bg-surface-2 px-2 py-1.5">
             <div className="flex items-baseline gap-1.5">
               <span className="text-xs font-medium text-fg-default">
@@ -672,12 +674,13 @@ function PresetsCard({ entry }: { entry: BotEntryWithSchema }) {
                 <span className="font-mono text-caption text-fg-subtle">{p.name}</span>
               )}
               <span className="ml-auto text-caption text-fg-subtle">
-                {p.values.length} value{p.values.length === 1 ? "" : "s"}
+                {valueCount} value{valueCount === 1 ? "" : "s"}
               </span>
             </div>
             {p.description && <p className="mt-0.5 text-caption text-fg-muted">{p.description}</p>}
           </li>
-        ))}
+          );
+        })}
       </ul>
     </Card>
   );


### PR DESCRIPTION
Found while testing the answer-from-board feature (#132/#134): opening a **paused** run shows a false **"Live updates disconnected — data may be stale."** banner, and clicking **Reconnect** re-triggers it immediately.

## Root cause
The broker closes a run's event stream when it **pauses** (same as on completion), and the WS handler turns any stream end into a `terminated` envelope ([runs_ws.go:468](https://github.com/SocialGouv/iterion/blob/main/pkg/server/runs_ws.go)). The client maps `terminated` → `wsState="closed"`, which renders the banner. A **genuine** network drop instead goes to `"reconnecting"` (auto-retry, no banner) — so `"closed"` only ever means the stream *legitimately* ended (pause or terminal), where the data is **complete, not stale**. Reconnecting re-subscribes to an already-closed broker channel and gets `terminated` again → the loop.

## Fix
Gate `WSDisconnectBanner` on `run.status ∈ {running, queued}` (states where more live events are actually expected). Paused/terminal runs suppress the false alarm; resume already redials the WS (`wsReconnectToken`) so the live tail returns when the run continues. This also fixes the same false banner on finished/failed/cancelled runs.

## Verified
Live (local studio + Playwright): a `paused_waiting_human` run no longer shows the banner or Reconnect button while the pause form renders. Full studio suite (581) + tsc + eslint green.