### PR TITLE
feat(plugin): env-based enablement + config for cloud/headless

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -56,6 +56,28 @@ A single plugin may contribute several kinds (repo-falcon ships `mcp_servers` +
   default for a plugin with no recorded preference is its manifest
   `default_enabled`. (`$ITERION_HOME` overrides the home dir.)
 
+### Env-based enablement & config (cloud / headless)
+
+`~/.iterion/plugins.yaml` is per-machine and ephemeral in a cloud runner pod,
+so enablement can also be driven by **immutable env** — set once on the
+runtime (e.g. a Helm chart's `config.extraEnv`), no persistent file needed.
+Env wins over both stored state and `default_enabled`:
+
+| Env var | Effect |
+|---------|--------|
+| `ITERION_PLUGINS_ENABLE=a,b` | force-enable these plugins (comma/space list) |
+| `ITERION_PLUGINS_DISABLE=c`  | force-disable (wins over enable for the same name) |
+| `ITERION_PLUGIN_<NAME>_<KEY>=v` | set config value `<key>` for `<name>` (highest precedence over defaults + stored values) |
+
+`<NAME>`/`<KEY>` are upper-cased with `-` → `_`. Example — enable the
+`firecrawl` MCP plugin and point it at a self-hosted instance, entirely from
+env:
+
+```sh
+ITERION_PLUGINS_ENABLE=firecrawl
+ITERION_PLUGIN_FIRECRAWL_API_URL=http://iterion-firecrawl:3002
+```
+
 ## Manifest reference (`plugin.yaml`)
 
 ```yaml

--- a/pkg/plugin/config.go
+++ b/pkg/plugin/config.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -16,12 +17,42 @@ func (r *Registry) EffectiveConfig(name string) map[string]string {
 			if f.Default != "" {
 				out[f.Key] = f.Default
 			}
+			// Highest precedence: an env override ITERION_PLUGIN_<NAME>_<KEY>.
+			// This is the cloud/headless path — the operator (or the Helm
+			// chart) sets plugin config via immutable env instead of the
+			// per-pod-ephemeral plugins.yaml. Only declared keys are read.
+			if v, ok := pluginConfigEnv(name, f.Key); ok {
+				out[f.Key] = v
+			}
 		}
 	}
 	for k, v := range r.config[name] {
+		// Operator-stored values overlay defaults, but a declared env
+		// override still wins (set above and re-asserted here so a stored
+		// value can't shadow the immutable env).
+		if envV, ok := pluginConfigEnv(name, k); ok {
+			out[k] = envV
+			continue
+		}
 		out[k] = v
 	}
 	return out
+}
+
+// pluginConfigEnv reads the env override for one plugin config key:
+// ITERION_PLUGIN_<NAME>_<KEY>, upper-cased with '-' → '_'. Returns the raw
+// value and whether the env var is set (empty-but-set is honoured, e.g. to
+// blank a defaulted URL). E.g. plugin "firecrawl" key "api_url" →
+// ITERION_PLUGIN_FIRECRAWL_API_URL.
+func pluginConfigEnv(name, key string) (string, bool) {
+	env := "ITERION_PLUGIN_" + envToken(name) + "_" + envToken(key)
+	return os.LookupEnv(env)
+}
+
+// envToken upper-cases and replaces '-' with '_' so kebab plugin/config names
+// map to a legal env-var segment.
+func envToken(s string) string {
+	return strings.ToUpper(strings.ReplaceAll(s, "-", "_"))
 }
 
 // StoredConfig returns a copy of the operator-set values for a plugin (no

--- a/pkg/plugin/env_override_test.go
+++ b/pkg/plugin/env_override_test.go
@@ -1,0 +1,99 @@
+package plugin
+
+import "testing"
+
+// newTestRegistry builds an in-memory registry over the given plugins with
+// empty operator state/config (the env-override tests set env, not state).
+func newTestRegistry(t *testing.T, plugins ...*Plugin) *Registry {
+	return &Registry{
+		home:    t.TempDir(),
+		plugins: plugins,
+		state:   map[string]bool{},
+		config:  map[string]map[string]string{},
+	}
+}
+
+func TestResolveEnabled_EnvOverrides(t *testing.T) {
+	mk := func(name string, def bool) *Plugin {
+		return &Plugin{Manifest: Manifest{Name: name, DefaultEnabled: def}}
+	}
+
+	t.Run("enable a default-disabled plugin", func(t *testing.T) {
+		r := newTestRegistry(t, mk("firecrawl", false))
+		t.Setenv("ITERION_PLUGINS_ENABLE", "firecrawl")
+		t.Setenv("ITERION_PLUGINS_DISABLE", "")
+		r.resolveEnabled()
+		if !r.IsEnabled("firecrawl") {
+			t.Fatal("ITERION_PLUGINS_ENABLE did not enable firecrawl")
+		}
+	})
+
+	t.Run("disable a default-enabled plugin", func(t *testing.T) {
+		r := newTestRegistry(t, mk("rtk", true))
+		t.Setenv("ITERION_PLUGINS_ENABLE", "")
+		t.Setenv("ITERION_PLUGINS_DISABLE", "rtk")
+		r.resolveEnabled()
+		if r.IsEnabled("rtk") {
+			t.Fatal("ITERION_PLUGINS_DISABLE did not disable rtk")
+		}
+	})
+
+	t.Run("disable wins over enable", func(t *testing.T) {
+		r := newTestRegistry(t, mk("x", false))
+		t.Setenv("ITERION_PLUGINS_ENABLE", "x")
+		t.Setenv("ITERION_PLUGINS_DISABLE", "x")
+		r.resolveEnabled()
+		if r.IsEnabled("x") {
+			t.Fatal("disable should win over enable")
+		}
+	})
+
+	t.Run("comma and space separated", func(t *testing.T) {
+		r := newTestRegistry(t, mk("a", false), mk("b", false), mk("c", false))
+		t.Setenv("ITERION_PLUGINS_ENABLE", "a, b c")
+		t.Setenv("ITERION_PLUGINS_DISABLE", "")
+		r.resolveEnabled()
+		for _, n := range []string{"a", "b", "c"} {
+			if !r.IsEnabled(n) {
+				t.Errorf("%s not enabled from list", n)
+			}
+		}
+	})
+}
+
+func TestEffectiveConfig_EnvOverride(t *testing.T) {
+	p := &Plugin{Manifest: Manifest{
+		Name: "firecrawl",
+		Config: []ConfigField{
+			{Key: "api_url", Default: ""},
+			{Key: "api_key", Type: "secret", Default: "self-hosted"},
+		},
+	}}
+
+	t.Run("env overrides default", func(t *testing.T) {
+		r := newTestRegistry(t, p)
+		t.Setenv("ITERION_PLUGIN_FIRECRAWL_API_URL", "http://iterion-firecrawl:3002")
+		eff := r.EffectiveConfig("firecrawl")
+		if eff["api_url"] != "http://iterion-firecrawl:3002" {
+			t.Fatalf("env override not applied: %v", eff)
+		}
+	})
+
+	t.Run("env overrides stored operator value", func(t *testing.T) {
+		r := newTestRegistry(t, p)
+		r.config["firecrawl"] = map[string]string{"api_key": "stored-key"}
+		t.Setenv("ITERION_PLUGIN_FIRECRAWL_API_KEY", "env-key")
+		eff := r.EffectiveConfig("firecrawl")
+		if eff["api_key"] != "env-key" {
+			t.Fatalf("env should win over stored value: %v", eff)
+		}
+	})
+
+	t.Run("no env → default/stored intact", func(t *testing.T) {
+		r := newTestRegistry(t, p)
+		eff := r.EffectiveConfig("firecrawl")
+		if eff["api_key"] != "self-hosted" {
+			t.Fatalf("default lost without env: %v", eff)
+		}
+	})
+}

--- a/pkg/plugin/registry.go
+++ b/pkg/plugin/registry.go
@@ -212,16 +212,40 @@ func (r *Registry) loadInstalled() {
 }
 
 func (r *Registry) resolveEnabled() {
+	enableEnv := envNameSet("ITERION_PLUGINS_ENABLE")
+	disableEnv := envNameSet("ITERION_PLUGINS_DISABLE")
 	for _, p := range r.plugins {
 		if v, ok := r.state[p.Name()]; ok {
 			p.Enabled = v
 		} else {
 			p.Enabled = p.Manifest.DefaultEnabled
 		}
+		// Env overrides win over both stored state and default_enabled — the
+		// cloud/headless path where the operator (or Helm chart) toggles a
+		// builtin via immutable env instead of the per-pod-ephemeral
+		// plugins.yaml. Disable wins over enable when a name is in both.
+		if enableEnv[p.Name()] {
+			p.Enabled = true
+		}
+		if disableEnv[p.Name()] {
+			p.Enabled = false
+		}
 	}
 	sort.SliceStable(r.plugins, func(i, j int) bool {
 		return r.plugins[i].Name() < r.plugins[j].Name()
 	})
+}
+
+// envNameSet parses a comma/space-separated env var into a set of plugin
+// names (trimmed, empties dropped). Used by ITERION_PLUGINS_ENABLE/DISABLE.
+func envNameSet(env string) map[string]bool {
+	out := map[string]bool{}
+	for _, tok := range strings.FieldsFunc(os.Getenv(env), func(r rune) bool { return r == ',' || r == ' ' }) {
+		if t := strings.TrimSpace(tok); t != "" {
+			out[t] = true
+		}
+	}
+	return out
 }
 
 // Get returns the plugin with the given name.


### PR DESCRIPTION
## Context

Unblocks the Firecrawl (tier 3) prod deployment. A builtin plugin's enable-state lives in `~/.iterion/plugins.yaml`, which is per-pod-ephemeral in a cloud runner — so there was **no way to enable + configure** the `firecrawl` MCP plugin on cloud runners. This adds immutable-env overrides so a Helm chart's `config.extraEnv` can drive it.

## Change

Highest-precedence env overrides (over stored state + `default_enabled` / config defaults):

| Env | Effect |
|-----|--------|
| `ITERION_PLUGINS_ENABLE=a,b` | force-enable (comma/space list) |
| `ITERION_PLUGINS_DISABLE=c` | force-disable (wins over enable) |
| `ITERION_PLUGIN_<NAME>_<KEY>=v` | set config `<key>` for `<name>` (upper-case, `-`→`_`) |

Example (cloud): `ITERION_PLUGINS_ENABLE=firecrawl` + `ITERION_PLUGIN_FIRECRAWL_API_URL=http://iterion-firecrawl:3002`.

`resolveEnabled` (registry.go) + `EffectiveConfig` (config.go). Docs in plugins.md.

## Verification

- 7 unit subtests (enable/disable/precedence/list parsing; config env over default + stored)
- lint + `go vet` clean, `pkg/plugin` tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)