### PR TITLE
fix(runner): skip k8s sandbox reaper when runner is the isolation boundary

### DIFF
--- a/pkg/runner/reaper.go
+++ b/pkg/runner/reaper.go
@@ -69,7 +69,18 @@ type runLoader interface {
 // a ticker for as long as the runner loop lives. No-op when the runner
 // is not in-cluster (kubernetes.Detect fails) or has no NATS connection
 // (the lease is the liveness authority). Started by Run.
+//
+// Also a no-op when this runner is itself the isolation boundary
+// (ITERION_SANDBOX_OVERRIDE=none): that CLI-strength override forbids any
+// workflow from activating the k8s sandbox driver, so the runner never
+// spawns a sibling sandbox pod — there is nothing to reap, and firing the
+// reaper would only surface a permission error (the runner SA isn't granted
+// pods RBAC when the sandbox is disabled) on every tick.
 func (r *Runner) runSandboxReaper(ctx context.Context) {
+	if r.cfg.SandboxOverride == "none" {
+		r.cfg.Logger.Info("runner: k8s sandbox reaper disabled — runner is the isolation boundary (ITERION_SANDBOX_OVERRIDE=none), no sandbox pods to reap")
+		return
+	}
 	interval := sandboxReapInterval()
 	// Boot-time reap: catch a sibling that died before THIS runner booted.
 	r.reapOrphanSandboxResources(ctx)

--- a/pkg/runner/reaper_test.go
+++ b/pkg/runner/reaper_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"testing"
+	"time"
 
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -144,5 +147,33 @@ func TestSandboxReapInterval_EnvOverride(t *testing.T) {
 	t.Setenv("ITERION_SANDBOX_REAP_INTERVAL", "0")
 	if got := sandboxReapInterval(); got != 0 {
 		t.Fatalf("sandboxReapInterval() = %v, want 0 (disables ticker)", got)
+	}
+}
+
+// TestRunSandboxReaper_DisabledWhenIsolationBoundary pins that a runner
+// whose ITERION_SANDBOX_OVERRIDE=none (it is itself the isolation boundary,
+// so it never spawns sandbox pods) short-circuits the reaper immediately:
+// no boot scan, no ticker. Otherwise the reaper would poll a namespace it
+// has no pods RBAC for and log a Forbidden warn on every tick. The gate
+// returning promptly (rather than blocking on the ticker loop) is the
+// observable proof.
+func TestRunSandboxReaper_DisabledWhenIsolationBoundary(t *testing.T) {
+	// A non-zero interval so that, absent the gate, runSandboxReaper would
+	// enter its ticker loop and block until ctx is cancelled.
+	t.Setenv("ITERION_SANDBOX_REAP_INTERVAL", "60s")
+	r := &Runner{cfg: Config{
+		SandboxOverride: "none",
+		Logger:          iterlog.New(iterlog.LevelError, io.Discard),
+	}}
+	done := make(chan struct{})
+	go func() {
+		r.runSandboxReaper(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+		// Gate worked: returned without touching NATS/Detect or the ticker.
+	case <-time.After(2 * time.Second):
+		t.Fatal("runSandboxReaper did not return with SandboxOverride=none — the reaper must be disabled when the runner is the isolation boundary")
 	}
 }


### PR DESCRIPTION
## Problem

#145 wired the k8s sandbox reaper into the runner claim-loop, gated only on in-cluster (`kubernetes.Detect`) + NATS. A runner with `ITERION_SANDBOX_OVERRIDE=none` is itself the isolation boundary — that CLI-strength override forbids any workflow from activating the k8s sandbox driver, so it never spawns a sibling sandbox pod. Nothing to reap, but the reaper fired every tick, polling a namespace it has no pods RBAC for (`runner-rbac.yaml` grants pods list/delete only when `runner.sandbox.enabled`) and logging a Forbidden warn each time.

Caught by dogfooding on ovh-prod right after deploying #145:
```
runner: reap orphan k8s sandbox resources: kubernetes: list managed pods: exit status 1
```
(`pods is forbidden: serviceaccount:iterion:iterion cannot list pods`) every 60s, on a runner that runs unsandboxed (`ITERION_SANDBOX_OVERRIDE=none`).

## Fix

Gate `runSandboxReaper` on `SandboxOverride != "none"`. When the override is `none` the runner can never create sandbox pods, so the reaper short-circuits (info log, no boot scan, no ticker) — least privilege (no pods RBAC required) and no warn noise. When the override is empty a bot can still opt into the k8s sandbox, so the reaper stays armed.

New test `TestRunSandboxReaper_DisabledWhenIsolationBoundary` pins the gate (returns promptly instead of entering the ticker loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)