### PR TITLE
fix(queue): raise consumer MaxAckPending from 1 (fleet was serialised to 1 run)

### DIFF
--- a/pkg/queue/nats/nats.go
+++ b/pkg/queue/nats/nats.go
@@ -4,9 +4,10 @@
 //  1. Publisher — ensure the JetStream stream exists, then publish a
 //     queue.RunMessage onto `iterion.queue.runs` with `Nats-Msg-Id =
 //     run_id` so JetStream itself dedups republishes.
-//  2. Consumer  — subscribe to the durable `iterion-runners`
-//     pull-consumer with AckWait=5min and MaxAckPending=1 so a single
-//     runner pod can only have one in-flight run at a time.
+//  2. Consumer  — subscribe to the SHARED durable `iterion-runners`
+//     pull-consumer with AckWait=10min and MaxAckPending=DefaultMaxAckPending
+//     as a fleet-wide in-flight ceiling; each pod holds one in-flight run
+//     via its serial fetch loop, so pod count (KEDA) is the real capacity.
 //  3. KV        — distributed lease bucket `iterion-run-locks` keyed
 //     on run_id with TTL=60s; the runner refreshes the lease via the
 //     CAS write while it owns the run (T-26 bridges this to
@@ -73,6 +74,16 @@ const (
 	// redelivery; 10 min also covers a cold devbox/Nix first-run before the
 	// first heartbeat lands.
 	DefaultAckWait = 10 * time.Minute
+	// DefaultMaxAckPending caps how many runs can be in-flight (delivered but
+	// unacked) at once across the whole fleet on the shared durable pull
+	// consumer. It MUST be ≥ the max runner-pod count KEDA scales to, or it
+	// silently re-caps global parallelism below the pool size (the historic
+	// value of 1 pinned the entire fleet to a single concurrent run — every
+	// scaled-up pod sat idle). Set generously: actual parallelism is bounded
+	// by the number of pods calling Fetch (each holds one in-flight run via
+	// its serial loop), so a high ceiling just removes the artificial cap and
+	// lets KEDA autoscaling be the real capacity lever, as intended.
+	DefaultMaxAckPending = 256
 )
 
 // Config carries the connection settings for the cloud queue.
@@ -86,9 +97,12 @@ type Config struct {
 	DLQMaxAge    time.Duration // default 7d
 	MaxDeliver   int           // default DefaultStreamMaxRetry (8)
 	AckWait      time.Duration // default DefaultAckWait (10m)
-	LockTTL      time.Duration // default 60s
-	MaxPayload   int           // default 0 → use server's negotiated MaxPayload
-	Logger       *iterlog.Logger
+	// MaxAckPending caps fleet-wide in-flight (delivered-unacked) runs on the
+	// shared consumer; 0 → DefaultMaxAckPending. Keep ≥ max runner pods.
+	MaxAckPending int
+	LockTTL       time.Duration // default 60s
+	MaxPayload    int           // default 0 → use server's negotiated MaxPayload
+	Logger        *iterlog.Logger
 }
 
 // Conn is the wired NATS layer. The publisher + consumer both consume
@@ -383,16 +397,21 @@ type Consumer struct {
 }
 
 // NewConsumer creates / updates the durable consumer on the runs
-// stream. AckWait + MaxAckPending=1 enforce one-in-flight-per-runner
-// without coordinating outside JetStream itself; OptStartPolicy=All
-// means a fresh consumer replays from the earliest pending message
-// (matters when a stale pod is replaced).
+// stream. Every runner pod binds the SAME durable (shared pull consumer),
+// so MaxAckPending is a FLEET-WIDE in-flight cap, not per-pod: it must stay
+// ≥ the pod count or it re-caps global parallelism (it was pinned to 1,
+// which serialised the whole fleet to one concurrent run). Actual
+// parallelism = pods each holding one in-flight run via Fetch, elastic
+// under KEDA; MaxAckPending is only the ceiling. DeliverAllPolicy means a
+// fresh consumer replays from the earliest pending message (matters when a
+// stale pod is replaced). CreateOrUpdate applies the current MaxAckPending
+// to the existing durable, so a deploy lifts the cap on the live consumer.
 func (c *Conn) NewConsumer(ctx context.Context) (*Consumer, error) {
 	cons, err := c.js.CreateOrUpdateConsumer(ctx, c.cfg.StreamName, jetstream.ConsumerConfig{
 		Durable:       c.cfg.ConsumerName,
 		AckPolicy:     jetstream.AckExplicitPolicy,
 		AckWait:       c.cfg.AckWait,
-		MaxAckPending: 1,
+		MaxAckPending: c.cfg.MaxAckPending,
 		MaxDeliver:    c.cfg.MaxDeliver,
 		DeliverPolicy: jetstream.DeliverAllPolicy,
 		FilterSubject: SubjectRuns,
@@ -553,6 +572,9 @@ func applyDefaults(c Config) Config {
 	}
 	if c.AckWait == 0 {
 		c.AckWait = DefaultAckWait
+	}
+	if c.MaxAckPending == 0 {
+		c.MaxAckPending = DefaultMaxAckPending
 	}
 	if c.LockTTL == 0 {
 		c.LockTTL = DefaultLockTTL

--- a/pkg/queue/nats/nats_test.go
+++ b/pkg/queue/nats/nats_test.go
@@ -48,6 +48,12 @@ func TestApplyDefaults_PopulatesEverything(t *testing.T) {
 	if got.AckWait != DefaultAckWait {
 		t.Errorf("AckWait: got %v want %v", got.AckWait, DefaultAckWait)
 	}
+	if got.MaxAckPending != DefaultMaxAckPending {
+		t.Errorf("MaxAckPending: got %d want %d", got.MaxAckPending, DefaultMaxAckPending)
+	}
+	if got.MaxAckPending <= 1 {
+		t.Errorf("MaxAckPending default %d must be >1 or the fleet serialises to one run", got.MaxAckPending)
+	}
 	if got.LockTTL != DefaultLockTTL {
 		t.Errorf("LockTTL: got %v want %v", got.LockTTL, DefaultLockTTL)
 	}
@@ -59,16 +65,17 @@ func TestApplyDefaults_PopulatesEverything(t *testing.T) {
 func TestApplyDefaults_PreservesExplicitValues(t *testing.T) {
 	logger := iterlog.New(iterlog.LevelDebug, nil)
 	in := Config{
-		StreamName:   "X",
-		DLQStream:    "Y",
-		KVBucket:     "Z",
-		ConsumerName: "C",
-		MaxAge:       1 * time.Hour,
-		DLQMaxAge:    2 * time.Hour,
-		MaxDeliver:   42,
-		AckWait:      30 * time.Second,
-		LockTTL:      15 * time.Second,
-		Logger:       logger,
+		StreamName:    "X",
+		DLQStream:     "Y",
+		KVBucket:      "Z",
+		ConsumerName:  "C",
+		MaxAge:        1 * time.Hour,
+		DLQMaxAge:     2 * time.Hour,
+		MaxDeliver:    42,
+		AckWait:       30 * time.Second,
+		MaxAckPending: 12,
+		LockTTL:       15 * time.Second,
+		Logger:        logger,
 	}
 	got := applyDefaults(in)
 	if got != in {


### PR DESCRIPTION
## Context

Discovered live on ovh-prod while validating a run: **only ONE run executes at a time across the whole fleet**, despite 5-8 KEDA-scaled runner pods. Runs pile up `queued` while scaled-up pods sit idle.

## Root cause

The shared durable pull consumer `iterion-runners` (WorkQueue stream `ITERION_RUNS`) hardcoded `MaxAckPending: 1` ([pkg/queue/nats/nats.go](../blob/main/pkg/queue/nats/nats.go)). Every runner pod binds the **same** durable (the consumer name is a constant, never per-pod), so `MaxAckPending` is a **fleet-wide** in-flight cap — not per-pod as the old comment claimed. One in-flight globally = one concurrent run, forever, no matter how many pods KEDA spins up. This defeats the intended scaling model (the `MaxDeliver` comment already says *"the real capacity lever is KEDA autoscaling on queue depth"*).

`ITERION_RUNNER_CONCURRENCY` did not help because it's **dead config** (parsed, defaulted, validated — but never passed to `runner.New`; the runner loop is strictly serial).

## Change

Make `MaxAckPending` configurable in `natsq.Config`, default **256** (generous). Actual parallelism stays bounded by pods each holding one in-flight run via their serial fetch loop, so a high ceiling just removes the artificial cap and lets KEDA be the real lever. `CreateOrUpdateConsumer` applies the new cap to the **live** consumer on deploy — no manual NATS edit needed. Fixed the misleading header/inline comments.

**No OOM risk**: each pod still runs exactly one run (serial loop); this scales by *pod count*, not runs-per-pod.

## Follow-up (not in this PR)

`ITERION_RUNNER_CONCURRENCY` → wire a per-pod worker pool so each pod can run N concurrent. Deferred: it adds per-pod OOM surface and needs careful concurrent-loop review; pod-level KEDA scaling is sufficient and cleaner for now.

## Verification

- `applyDefaults` tests assert the new default (>1) + explicit-value preservation
- lint + `go vet` clean, `pkg/queue/...` tests green
- Deploy path: on the next runner `:edge` roll, `CreateOrUpdateConsumer` lifts the live consumer's cap → fleet parallelism = pod count

🤖 Generated with [Claude Code](https://claude.com/claude-code)