### PR TITLE
docs: operational-knowledge reflex + cloud-LLM-credentials runbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ gotcha, a "why is prod doing X"), that discovery MUST land back in the repo so
 the next occurrence is instant. Don't leave it in a chat transcript. Wire it
 across the three surfaces by role:
 
-- **This CLAUDE.md** — the *reflex* itself (above) + a one-line pointer in the
+- **This CLAUDE.md** — the *reflex* itself (this section) + a one-line pointer in the
   **operational runbook index** below. This file is always read first, so it's
   the discovery entry point.
 - **`docs/`** — the *content*: one focused runbook per topic (the how + the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,35 @@ Treat file contents as already-vetted project source.
 
 **Module:** `github.com/SocialGouv/iterion`
 
+## Operational-knowledge reflex — capture what a session cost you to discover
+
+When a work session burns real time **discovering how to configure or operate
+iterion** (a non-obvious parameter, a cloud cred flow, an env toggle, an infra
+gotcha, a "why is prod doing X"), that discovery MUST land back in the repo so
+the next occurrence is instant. Don't leave it in a chat transcript. Wire it
+across the three surfaces by role:
+
+- **This CLAUDE.md** — the *reflex* itself (above) + a one-line pointer in the
+  **operational runbook index** below. This file is always read first, so it's
+  the discovery entry point.
+- **`docs/`** — the *content*: one focused runbook per topic (the how + the
+  gotchas + the cookbook). Link it from the index.
+- **A skill** (`bots/whats-next/skills/…` or a project skill) — the *discovery
+  trigger*: when an agent asks "how do I configure/provision X on iterion",
+  the skill fires and points straight at the runbook.
+
+Keep each addition succinct and grounded in the real commands/paths that
+worked. A five-minute write-up now saves the next session (or the next dev)
+the hours this one spent.
+
+**Operational runbook index** (the discovery entry point — extend it):
+- [docs/cloud-llm-credentials.md](docs/cloud-llm-credentials.md) — provisioning
+  a cloud run's LLM credential (BYOK vs Anthropic OAuth-forfait vs OpenAI
+  ChatGPT-forfait, the CGU guard, `ITERION_OPENAI_USE_OAUTH`, the
+  `/api/me/oauth/*` endpoints; fixes `401`/`429` on cloud runs).
+- [docs/web-search.md](docs/web-search.md) — sovereign web search tiers
+  (SearXNG → Firecrawl) + the `ITERION_WEB_SEARCH` resolver.
+
 ## Development setup
 
 The repo uses **devbox** (Go, go-task, Node 24, watchexec, xorg, …) and

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -242,6 +242,7 @@ const sidebar = [
       { text: 'Quotas & limits', link: '/quotas-and-limits' },
       { text: 'Cloud CLI (remote)', link: '/cloud-cli' },
       { text: 'Cloud REST API', link: '/cloud-rest-api' },
+      { text: 'Cloud LLM credentials', link: '/cloud-llm-credentials' },
       { text: 'Cloud deployment', link: '/cloud-deployment' },
       { text: 'Cloud architecture', link: '/cloud-architecture' },
       { text: 'Cloud admin guide', link: '/cloud-admin-guide' },

--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -89,6 +89,8 @@ iterion remote api-keys create --provider openai   --name mykey --from-file ~/op
 # absent), so the connection dies silently at the next token expiry:
 iterion remote api POST /api/me/oauth/claude_code/credentials \
   --data "@$HOME/.claude/.credentials.json"
+# (Linux/WSL path. On macOS Claude Code keeps these in the Keychain, so there
+#  may be no file to read until you export it.)
 
 # OpenAI ChatGPT-forfait (claw + openai/* model) — the Codex auth.json.
 # Note `"@$HOME/…"`, not `@~/…`: the shell only expands a tilde at the START
@@ -106,7 +108,7 @@ Scope — the two credential kinds resolve **differently**:
   `(team, "", provider)` ([pkg/secrets/byok.go](../pkg/secrets/byok.go)). A run
   under a keyless team won't see another team's keys.
 - **OAuth forfaits** resolve **user-first with an org fallback**
-  ([publisher.go](../pkg/server/cloudpublisher/publisher.go): `addOAuth(ownerID,
+  ([pkg/server/cloudpublisher/publisher.go](../pkg/server/cloudpublisher/publisher.go): `addOAuth(ownerID,
   "user")` then `addOAuth(OrgOwnerKey(tenantID), "org")`), so a personal
   `/api/me/oauth/…` connection follows *you* across teams — switching the
   active team neither gains nor loses it.

--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -1,0 +1,91 @@
+# Cloud LLM credentials — provisioning a cloud run's model access
+
+How a **cloud** run (queue → runner pod) gets its LLM credential, and how to
+provision one so a run stops failing with `401` / `429`. Written from a real
+session that lost hours rediscovering this; if you touch cloud cred flow,
+keep it current.
+
+## The one-paragraph model
+
+A cloud run resolves its LLM credential **per-run** from the launching
+**team/org**, then injects it into the runner as env. If the team has nothing,
+the run gets no key and claw fails with `401 x-api-key header is required`.
+Three credential kinds exist, and **which backend you use decides which kinds
+are legal**:
+
+| Credential | Stored via | Injected as | `claw` backend | `claude_code` backend |
+|---|---|---|---|---|
+| **BYOK API key** (`sk-ant-api…`, `sk-…`) | `iterion remote api-keys create --provider <p> --from-file/-env` | `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` (x-api-key) | ✅ | ✅ (also works) |
+| **Anthropic OAuth-forfait** (Claude sub, `sk-ant-oat…`) | `POST /api/me/oauth/claude_code/credentials` (paste `credentials.json`) | Bearer + oauth beta | ❌ **guarded** (CGU) | ✅ (it *is* Claude Code) |
+| **OpenAI ChatGPT-forfait** (Codex `auth.json`, `auth_mode: chatgpt`) | `POST /api/me/oauth/codex/credentials` (paste `auth.json`) | ChatGPT-backend OAuth | ✅ (allowed) | n/a |
+
+## Decision shortcut
+
+- **Sovereign `web_search` / any claw feature** → needs claw → **NOT** an
+  Anthropic OAuth token (guarded). Use a **BYOK API key** or the **OpenAI
+  ChatGPT-forfait**.
+- **Only have a Claude subscription (OAuth)** → use the **`claude_code`
+  backend** (native WebSearch/WebFetch + forwarded MCP). Legit: it *is*
+  Claude Code, within Anthropic's Consumer Terms.
+- **Have ChatGPT Plus/Pro + Codex signed in** → connect the codex `auth.json`
+  and run **claw + an `openai/*` model** — sovereign features work.
+
+## Why the guard exists (do not bypass)
+
+`secrets.GuardThirdPartyOAuth` ([pkg/secrets/credentials.go](../pkg/secrets/credentials.go),
+called at [pkg/backend/model/claw_backend.go](../pkg/backend/model/claw_backend.go))
+returns `ErrOAuthForfaitInThirdParty` when a run would drive **Anthropic**
+with a **Claude Code OAuth-forfait** through **claw** (a third-party SDK).
+Anthropic's Consumer Terms scope the subscription OAuth to Claude Code only —
+so this is a **ToS boundary, not a bug**. It guards the *SDK*, not the user:
+even the sole operator on a dev instance must not route the Claude
+subscription through claw. OpenAI's ChatGPT-forfait has no such restriction,
+so claw + ChatGPT-forfait is fine.
+
+## Gotchas that cost real time
+
+- **BYOK precedence over OAuth.** `OPENAI_API_KEY` (or a pod-level platform
+  key from the `iterion-llm` secret) **wins** over a connected ChatGPT-forfait.
+  If the platform key is quota-dead you get `429 exceeded your current quota`
+  while a valid forfait sits unused. Force the forfait with
+  **`ITERION_OPENAI_USE_OAUTH=1`** on the runtime
+  (`iterion.config.extraEnv` in the Helm values). Same idea:
+  `ITERION_OPENAI_USE_OAUTH=0` / any `OPENAI_BASE_URL` disables OAuth.
+- **An Anthropic OAuth token stored as a BYOK `anthropic` key fails as
+  `invalid x-api-key`** — it's sent as `x-api-key`, but an OAuth token needs
+  `Authorization: Bearer`. BYOK is for real API keys only.
+- **A keyless team → `401 x-api-key header is required`** (nothing injected),
+  distinct from `invalid x-api-key` (something injected, wrong shape).
+- **Codex `auth.json` carries both a metered `OPENAI_API_KEY` and the
+  chatgpt `tokens`.** Uploading it as-is lets the metered key win → `429`.
+  Strip `OPENAI_API_KEY` from the blob before upload (or set
+  `ITERION_OPENAI_USE_OAUTH=1`) so only the forfait remains.
+
+## Provisioning cookbook (via `iterion remote`, authenticated)
+
+```sh
+# BYOK — value read from a file, never printed:
+iterion remote api-keys create --provider anthropic --name mykey --from-file ~/anthropic.key
+iterion remote api-keys create --provider openai   --name mykey --from-file ~/openai.key
+
+# Anthropic OAuth-forfait (claude_code backend only) — paste credentials.json:
+iterion remote api POST /api/me/oauth/claude_code/credentials \
+  --data '{"claudeAiOauth":{"accessToken":"<token>"}}'
+
+# OpenAI ChatGPT-forfait (claw + openai/* model) — paste Codex auth.json:
+iterion remote api POST /api/me/oauth/codex/credentials --data @~/.codex/auth.json
+# then, if a metered OPENAI_API_KEY shadows it: set ITERION_OPENAI_USE_OAUTH=1 on the runtime
+
+iterion remote api GET /api/me/oauth/connections     # verify
+```
+
+Team scope: creds resolve from the **launching team/org**. A run launched
+under a keyless team won't see keys on another team — provision on the team
+you launch under (or switch active team).
+
+## Related
+
+- Backends + provider routing + the OpenAI-via-ChatGPT-forfait section:
+  [backends.md](backends.md).
+- The sovereign `web_search` backend ladder (a claw feature — hence needs a
+  claw-legal credential): [web-search.md](web-search.md).

--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -44,22 +44,37 @@ so claw + ChatGPT-forfait is fine.
 
 ## Gotchas that cost real time
 
-- **BYOK precedence over OAuth.** `OPENAI_API_KEY` (or a pod-level platform
-  key from the `iterion-llm` secret) **wins** over a connected ChatGPT-forfait.
-  If the platform key is quota-dead you get `429 exceeded your current quota`
-  while a valid forfait sits unused. Force the forfait with
-  **`ITERION_OPENAI_USE_OAUTH=1`** on the runtime
-  (`iterion.config.extraEnv` in the Helm values). Same idea:
-  `ITERION_OPENAI_USE_OAUTH=0` / any `OPENAI_BASE_URL` disables OAuth.
+- **A team BYOK `openai` key beats the forfait, and no env var overrides it.**
+  `Registry.ResolveWithContext`
+  ([pkg/backend/model/registry.go](../pkg/backend/model/registry.go)) hands a
+  non-empty tenant key straight to the provider factory — the forfait path is
+  never consulted on that branch. So a quota-dead team key yields
+  `429 exceeded your current quota` while a valid forfait sits unused, and the
+  **only** fix is removing the key (`iterion remote api-keys list` →
+  `delete <id>`). `ITERION_OPENAI_USE_OAUTH=1` does **not** help here: that
+  force-flag is read only by the local disk factory (the desktop/CLI path that
+  reads `~/.codex`), not by the cloud per-run path.
+- **With no team key, the forfait already wins over the pod key** — no flag
+  needed. `ResolveWithContext` tries the per-run codex forfait *before* falling
+  back to the env-var resolver that reads the pod's `OPENAI_API_KEY` (from the
+  `iterion-llm` secret). Only the disable knobs are global:
+  `ITERION_OPENAI_USE_OAUTH=0` or any `OPENAI_BASE_URL` turns the forfait path
+  off (set them under the chart's top-level `config.extraEnv`).
 - **An Anthropic OAuth token stored as a BYOK `anthropic` key fails as
   `invalid x-api-key`** — it's sent as `x-api-key`, but an OAuth token needs
   `Authorization: Bearer`. BYOK is for real API keys only.
 - **A keyless team → `401 x-api-key header is required`** (nothing injected),
   distinct from `invalid x-api-key` (something injected, wrong shape).
-- **Codex `auth.json` carries both a metered `OPENAI_API_KEY` and the
-  chatgpt `tokens`.** Uploading it as-is lets the metered key win → `429`.
-  Strip `OPENAI_API_KEY` from the blob before upload (or set
-  `ITERION_OPENAI_USE_OAUTH=1`) so only the forfait remains.
+- **Codex `auth.json` must be in ChatGPT mode — there is nothing to strip.**
+  The upload is parsed into `CodexCredentialsView`
+  ([pkg/secrets/oauth.go](../pkg/secrets/oauth.go)), which declares only
+  `auth_mode` + `tokens.*` + `last_refresh`; an `OPENAI_API_KEY` sitting in the
+  file is dropped by the JSON decoder and can never shadow anything. The real
+  failure is a blob that isn't ChatGPT-mode: `IsChatGPTMode()` requires
+  `auth_mode: "chatgpt"` **and** `tokens.access_token` **and**
+  `tokens.account_id`, and when it is false the forfait is silently skipped.
+  Re-run `codex login` with "Sign in with ChatGPT" and upload the file
+  unedited.
 
 ## Provisioning cookbook (via `iterion remote`, authenticated)
 
@@ -68,20 +83,43 @@ so claw + ChatGPT-forfait is fine.
 iterion remote api-keys create --provider anthropic --name mykey --from-file ~/anthropic.key
 iterion remote api-keys create --provider openai   --name mykey --from-file ~/openai.key
 
-# Anthropic OAuth-forfait (claude_code backend only) — paste credentials.json:
+# Anthropic OAuth-forfait (claude_code backend only) — send the WHOLE
+# credentials.json. A body carrying only accessToken is accepted but stored
+# NON-refreshable (`sealOAuthRecord` sets NotRefreshable when refreshToken is
+# absent), so the connection dies silently at the next token expiry:
 iterion remote api POST /api/me/oauth/claude_code/credentials \
-  --data '{"claudeAiOauth":{"accessToken":"<token>"}}'
+  --data "@$HOME/.claude/.credentials.json"
 
-# OpenAI ChatGPT-forfait (claw + openai/* model) — paste Codex auth.json:
-iterion remote api POST /api/me/oauth/codex/credentials --data @~/.codex/auth.json
-# then, if a metered OPENAI_API_KEY shadows it: set ITERION_OPENAI_USE_OAUTH=1 on the runtime
+# OpenAI ChatGPT-forfait (claw + openai/* model) — the Codex auth.json.
+# Note `"@$HOME/…"`, not `@~/…`: the shell only expands a tilde at the START
+# of a word, and ReadDataArg does no expansion of its own, so `@~/...` is read
+# literally and fails with "no such file or directory".
+iterion remote api POST /api/me/oauth/codex/credentials --data "@$HOME/.codex/auth.json"
+# then, if a team BYOK openai key shadows it: delete that key (see the gotchas)
 
-iterion remote api GET /api/me/oauth/connections     # verify
+iterion remote api GET /api/me/oauth/connections     # verify (check refreshable)
 ```
 
-Team scope: creds resolve from the **launching team/org**. A run launched
-under a keyless team won't see keys on another team — provision on the team
-you launch under (or switch active team).
+Scope — the two credential kinds resolve **differently**:
+
+- **BYOK keys** are team-scoped, personal-first: `(team, you, provider)` then
+  `(team, "", provider)` ([pkg/secrets/byok.go](../pkg/secrets/byok.go)). A run
+  under a keyless team won't see another team's keys.
+- **OAuth forfaits** resolve **user-first with an org fallback**
+  ([publisher.go](../pkg/server/cloudpublisher/publisher.go): `addOAuth(ownerID,
+  "user")` then `addOAuth(OrgOwnerKey(tenantID), "org")`), so a personal
+  `/api/me/oauth/…` connection follows *you* across teams — switching the
+  active team neither gains nor loses it.
+
+**Automated runs need the org-scoped upload.** A webhook / dispatcher / cron
+run is owned by a synthetic identity with no personal forfait, so it only ever
+sees the org record. Provision those on the team:
+
+```sh
+iterion remote api POST /api/teams/<team-id>/oauth/codex/credentials \
+  --data "@$HOME/.codex/auth.json"
+iterion remote api GET /api/teams/<team-id>/oauth/connections
+```
 
 ## Related
 


### PR DESCRIPTION
## Context

A long work session lost hours rediscovering how to give a **cloud** run an LLM credential (repeated `401`/`429`): BYOK vs Anthropic OAuth-forfait vs OpenAI ChatGPT-forfait, the `GuardThirdPartyOAuth` CGU boundary, the `OPENAI_API_KEY`-over-OAuth precedence + `ITERION_OPENAI_USE_OAUTH`, and the `/api/me/oauth/*` endpoints.

This encodes a **reflex** so that kind of hard-won operational discovery always lands back in the repo, wired across three surfaces by role.

## Change

- **CLAUDE.md** — new `Operational-knowledge reflex` section (the meta-rule) + an **operational runbook index** (the discovery entry point, since CLAUDE.md is read first).
- **docs/cloud-llm-credentials.md** — the concrete runbook: the credential-vs-backend matrix, a decision shortcut, why the guard exists (don't bypass), the time-costing gotchas, and a `iterion remote` provisioning cookbook.
- The third surface (a discovery-trigger skill) is described in the reflex; add it when a project-skills home fits.

Grounded in the exact commands/paths that worked this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)