### PR TITLE
fix(delegate): let text-output backends satisfy single-string-field schemas

### DIFF
--- a/pkg/backend/delegate/parse.go
+++ b/pkg/backend/delegate/parse.go
@@ -55,13 +55,46 @@ func parseSDKOutput(resultText *string, structuredOutput any, outputSchema json.
 			}
 		}
 
-		// Fallback: wrap raw text.
+		// Fallback: wrap raw text. If the output schema expects exactly one
+		// required field of type "string" (e.g. shell_result {result}), a
+		// text-only backend — kimi, or any CLI agent that cannot emit a
+		// JSON-schema-shaped result like claude_code/codex do — satisfies it
+		// by placing its final text in that field. Treat this as a VALID
+		// result (fallback=false), not a validation failure. Multi-field or
+		// non-string schemas still require real JSON and keep the {"text":…}
+		// fallback so the retry path can ask the model for structured output.
+		if field := singleRequiredStringField(outputSchema); field != "" {
+			return map[string]any{field: text}, rawLen, false
+		}
 		output = map[string]any{"text": text}
 		fb := len(outputSchema) > 0
 		return output, rawLen, fb
 	}
 
 	return map[string]any{}, 0, false
+}
+
+// singleRequiredStringField returns the name of the schema's sole required
+// field when that field is of type "string", or "" otherwise. Lets a
+// text-output backend satisfy a single-string-field schema (e.g. shell_result)
+// by wrapping its final text under that field.
+func singleRequiredStringField(outputSchema json.RawMessage) string {
+	if len(outputSchema) == 0 {
+		return ""
+	}
+	var s struct {
+		Required   []string `json:"required"`
+		Properties map[string]struct {
+			Type string `json:"type"`
+		} `json:"properties"`
+	}
+	if json.Unmarshal(outputSchema, &s) != nil || len(s.Required) != 1 {
+		return ""
+	}
+	if prop, ok := s.Properties[s.Required[0]]; ok && prop.Type == "string" {
+		return s.Required[0]
+	}
+	return ""
 }
 
 // validateWorkDir checks that workDir resolves to a path within baseDir.

--- a/pkg/backend/delegate/parse_test.go
+++ b/pkg/backend/delegate/parse_test.go
@@ -14,6 +14,7 @@ func strptr(s string) *string { return &s }
 // called StructuredOutput) must fall through to the result-text path.
 func TestParseSDKOutput(t *testing.T) {
 	schema := json.RawMessage(`{"type":"object","properties":{"echoed":{"type":"string"}},"required":["echoed"]}`)
+	multiSchema := json.RawMessage(`{"type":"object","properties":{"a":{"type":"string"},"b":{"type":"string"}},"required":["a","b"]}`)
 
 	tests := []struct {
 		name         string
@@ -53,10 +54,17 @@ func TestParseSDKOutput(t *testing.T) {
 			wantKey:    "echoed", wantVal: "FENCED", wantFallback: false,
 		},
 		{
-			name:       "plain text with schema wraps as fallback",
+			name:       "plain text with single-string schema wraps under that field (valid)",
 			resultText: strptr("just some prose, no json"),
 			structured: nil,
 			schema:     schema,
+			wantKey:    "echoed", wantVal: "just some prose, no json", wantFallback: false,
+		},
+		{
+			name:       "plain text with multi-field schema wraps as fallback",
+			resultText: strptr("just some prose, no json"),
+			structured: nil,
+			schema:     multiSchema,
 			wantKey:    "text", wantVal: "just some prose, no json", wantFallback: true,
 		},
 		{


### PR DESCRIPTION
## Problem

A CLI-agent backend that only returns free-form text — e.g. **`kimi`**, which has no JSON-schema / structured-output mode like claude_code's `StructuredOutput` tool or codex's `WithOutputSchema` — always lands in `parseSDKOutput`'s text fallback, which wraps the final text as `{"text": …}`.

For a node whose output schema is a **single required string field** (e.g. `shell_result { result: string }`, used by every file-writing agent node), this failed validation with `missing required field "result"` and aborted the run — even though the agent had done its work (wrote its files) and its final text was exactly the intended `result`.

Observed at runtime:
```
Delegation finished [plan_series]: kimi
⚠️ structured output parsing fell back to text wrapper
❌ Run failed: node "plan_series": structured output invalid: missing required field "result"
```

## Fix

In the fallback branch of `parseSDKOutput` (the single choke point shared by all backends), when the output schema declares **exactly one required field of type `"string"`**, place the final text under that field name and treat it as a **valid** result (`fallback=false`) instead of the generic `{"text": …}` failure.

Multi-field or non-string schemas keep the existing `{"text": …}` fallback + retry, since those genuinely require the model to emit structured JSON.

This fixes `kimi` (and any future text-only CLI backend) for single-string-field schemas **without affecting** `claude_code` / `codex`, which already produce schema-conforming JSON and only reach this fallback in degraded cases (where the wrapping is desirable anyway).

## Tests

`TestParseSDKOutput` updated: the single-string-schema plain-text case now expects the field-wrapped valid result, and a new multi-field-schema case preserves coverage of the genuine `{"text": …}` fallback path. `go test ./pkg/backend/delegate/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)