### PR TITLE
fix(model): consume tenant codex ChatGPT-forfait in cloud runs

### DIFF
--- a/cmd/iterion/runner.go
+++ b/cmd/iterion/runner.go
@@ -157,6 +157,18 @@ func runRunner(cmd *cobra.Command, _ []string) error {
 			return creds.APIKey(secrets.Provider(provider))
 		}, true
 	})
+	// Per-run OAuth-forfait dirs (codex / claude_code) the runner materialised
+	// at claim time. Lets the in-process claw model factory consume a tenant's
+	// resolved OpenAI ChatGPT-forfait in cloud mode (no ~/.codex on the pod).
+	model.SetOAuthDirLookup(func(ctx context.Context) (func(string) string, bool) {
+		creds, ok := secrets.CredentialsFromContext(ctx)
+		if !ok {
+			return nil, false
+		}
+		return func(kind string) string {
+			return creds.OAuthDir(kind)
+		}, true
+	})
 
 	// Shared knowledge memory persists in the tenant's document store
 	// (not the pod's ephemeral disk) so it survives across runs/pods.

--- a/pkg/backend/model/openai_forfait_ctx_test.go
+++ b/pkg/backend/model/openai_forfait_ctx_test.go
@@ -1,0 +1,94 @@
+package model
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeCodexAuth drops a chatgpt-mode auth.json into a fresh CODEX_HOME-shaped
+// dir and returns that dir (the shape Credentials.OAuthDir("codex") yields).
+func writeCodexAuth(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	blob := `{"auth_mode":"chatgpt","tokens":{"access_token":"tok-abc","account_id":"acct-xyz"}}`
+	if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte(blob), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestResolveWithContext_OpenAICodexForfaitFromCtx(t *testing.T) {
+	dir := writeCodexAuth(t)
+	// A tenant with NO BYOK openai key, but a resolved codex forfait dir.
+	SetCredentialsLookup(func(ctx context.Context) (func(string) string, bool) {
+		return func(string) string { return "" }, true
+	})
+	SetOAuthDirLookup(func(ctx context.Context) (func(string) string, bool) {
+		return func(kind string) string {
+			if kind == "codex" {
+				return dir
+			}
+			return ""
+		}, true
+	})
+	t.Cleanup(func() {
+		SetCredentialsLookup(func(context.Context) (func(string) string, bool) { return nil, false })
+		SetOAuthDirLookup(func(context.Context) (func(string) string, bool) { return nil, false })
+	})
+	// Neutralise the disk/env knobs so the ctx forfait is the only signal.
+	t.Setenv("OPENAI_BASE_URL", "")
+	t.Setenv("ITERION_OPENAI_USE_OAUTH", "")
+
+	reg := NewRegistry()
+	client, err := reg.ResolveWithContext(context.Background(), "openai/gpt-5.4-mini")
+	if err != nil {
+		t.Fatalf("ResolveWithContext: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected a ChatGPT-forfait client from the ctx-resolved codex dir, got nil")
+	}
+}
+
+func TestOpenAIFromCtxForfait_DisabledAndAbsent(t *testing.T) {
+	reg := NewRegistry()
+
+	t.Run("no oauth dir → not ok", func(t *testing.T) {
+		SetOAuthDirLookup(func(context.Context) (func(string) string, bool) {
+			return func(string) string { return "" }, true
+		})
+		t.Cleanup(func() { SetOAuthDirLookup(func(context.Context) (func(string) string, bool) { return nil, false }) })
+		t.Setenv("OPENAI_BASE_URL", "")
+		t.Setenv("ITERION_OPENAI_USE_OAUTH", "")
+		if _, ok, _ := reg.openAIFromCtxForfait(context.Background(), "gpt-5.4-mini"); ok {
+			t.Error("expected ok=false with no codex dir")
+		}
+	})
+
+	t.Run("USE_OAUTH=0 disables → not ok", func(t *testing.T) {
+		dir := writeCodexAuth(t)
+		SetOAuthDirLookup(func(context.Context) (func(string) string, bool) {
+			return func(string) string { return dir }, true
+		})
+		t.Cleanup(func() { SetOAuthDirLookup(func(context.Context) (func(string) string, bool) { return nil, false }) })
+		t.Setenv("OPENAI_BASE_URL", "")
+		t.Setenv("ITERION_OPENAI_USE_OAUTH", "0")
+		if _, ok, _ := reg.openAIFromCtxForfait(context.Background(), "gpt-5.4-mini"); ok {
+			t.Error("expected ok=false when ITERION_OPENAI_USE_OAUTH=0")
+		}
+	})
+
+	t.Run("OPENAI_BASE_URL set disables → not ok", func(t *testing.T) {
+		dir := writeCodexAuth(t)
+		SetOAuthDirLookup(func(context.Context) (func(string) string, bool) {
+			return func(string) string { return dir }, true
+		})
+		t.Cleanup(func() { SetOAuthDirLookup(func(context.Context) (func(string) string, bool) { return nil, false }) })
+		t.Setenv("ITERION_OPENAI_USE_OAUTH", "")
+		t.Setenv("OPENAI_BASE_URL", "http://localhost:1234")
+		if _, ok, _ := reg.openAIFromCtxForfait(context.Background(), "gpt-5.4-mini"); ok {
+			t.Error("expected ok=false when OPENAI_BASE_URL is set")
+		}
+	})
+}

--- a/pkg/backend/model/registry.go
+++ b/pkg/backend/model/registry.go
@@ -173,10 +173,11 @@ func (r *Registry) registerDefaults() {
 		//     keep using the access_token captured at first resolve.
 		//     Codex CLI rotates tokens ~hourly; restart the daemon to
 		//     refresh, or set a tight max_duration on dispatcher jobs.
-		//   - Cloud mode: bypasses runner-materialised per-tenant
-		//     OAuth state in secrets.CredentialsFromContext. Cloud
-		//     deployments must use the API-key BYOK path until the
-		//     factory learns to consume creds.OAuthDir("codex").
+		//   - This disk factory is the process-env / desktop path. Cloud
+		//     mode instead resolves the tenant's per-run codex forfait via
+		//     ResolveWithContext → openAIFromCtxForfait (reads
+		//     Credentials.OAuthDir("codex")), so a runner with no ~/.codex
+		//     still uses the connected ChatGPT-forfait.
 		apiKey := os.Getenv("OPENAI_API_KEY")
 		oauthPref := os.Getenv("ITERION_OPENAI_USE_OAUTH")
 		oauthDisabled := oauthPref == "0" || cfg.BaseURL != ""
@@ -184,9 +185,7 @@ func (r *Registry) registerDefaults() {
 		shouldTryOAuth := !oauthDisabled && (apiKey == "" || oauthForced)
 		if shouldTryOAuth {
 			if view, err := secrets.LoadCodexCredentialsFromDisk(); err == nil && view.IsChatGPTMode() {
-				cfg.OAuthToken = view.Tokens.AccessToken
-				cfg.OpenAIChatGPTAccountID = view.Tokens.AccountID
-				cfg.OpenAIClientVersion = codexCLIVersion()
+				applyCodexOAuth(&cfg, view)
 				return p.NewClient(withClientIdentity(cfg))
 			}
 		}
@@ -396,7 +395,17 @@ func (r *Registry) ResolveWithContext(ctx context.Context, spec string) (api.API
 	}
 	overrideKey := creds(providerName)
 	if overrideKey == "" {
-		// No tenant-scoped key for this provider — fall back to the
+		// No tenant-scoped BYOK key. For openai, try the tenant's RESOLVED
+		// codex ChatGPT-forfait before falling back: in cloud mode the disk
+		// factory (r.Resolve) reads the pod's ~/.codex, which is empty — the
+		// per-run forfait lives in Credentials.OAuthDir("codex"). Closes the
+		// documented "factory learns to consume creds.OAuthDir(codex)" gap.
+		if providerName == "openai" {
+			if client, ok, err := r.openAIFromCtxForfait(ctx, modelID); ok {
+				return client, err
+			}
+		}
+		// No tenant-scoped credential for this provider — fall back to the
 		// shared resolver (env vars + cache).
 		return r.Resolve(spec)
 	}
@@ -436,4 +445,66 @@ func SetCredentialsLookup(fn func(ctx context.Context) (func(provider string) st
 
 func credentialsLookup(ctx context.Context) (credentialsResolver, bool) {
 	return credentialsLookupFn(ctx)
+}
+
+// applyCodexOAuth stamps a Codex ChatGPT-forfait view onto a provider config
+// (Bearer OAuth token + account id + client version header). Shared by the
+// disk-based factory and the ctx-resolved (cloud) path so both build an
+// identical ChatGPT-mode client.
+func applyCodexOAuth(cfg *api.ProviderConfig, view secrets.CodexCredentialsView) {
+	cfg.OAuthToken = view.Tokens.AccessToken
+	cfg.OpenAIChatGPTAccountID = view.Tokens.AccountID
+	cfg.OpenAIClientVersion = codexCLIVersion()
+}
+
+// openAIFromCtxForfait builds an OpenAI ChatGPT-forfait client from the
+// tenant's per-run-materialised codex credentials (Credentials.OAuthDir),
+// honouring the same disable knobs as the disk factory. Returns ok=false when
+// OAuth is disabled, no codex dir is resolved, or the dir has no ChatGPT-mode
+// auth.json — the caller then falls back to the shared resolver.
+func (r *Registry) openAIFromCtxForfait(ctx context.Context, modelID string) (api.APIClient, bool, error) {
+	if os.Getenv("ITERION_OPENAI_USE_OAUTH") == "0" || os.Getenv("OPENAI_BASE_URL") != "" {
+		return nil, false, nil
+	}
+	dir := oauthDirLookup(ctx, "codex")
+	if dir == "" {
+		return nil, false, nil
+	}
+	view, err := secrets.LoadCodexCredentialsFrom(dir)
+	if err != nil || !view.IsChatGPTMode() {
+		return nil, false, nil
+	}
+	cfg := api.ProviderConfig{Model: modelID, BaseURL: os.Getenv("OPENAI_BASE_URL")}
+	applyCodexOAuth(&cfg, view)
+	client, cerr := openaiprovider.New().NewClient(withClientIdentity(cfg))
+	return client, true, cerr
+}
+
+// oauthDirResolver maps an OAuth kind ("codex" / "claude_code") to its
+// per-run materialised credentials dir, or "" when absent.
+type oauthDirResolver func(kind string) string
+
+// oauthDirLookupFn is the indirection that lets pkg/runner inject a reader of
+// Credentials.OAuthDir from ctx, keeping this package's coupling to the runner
+// injection-based (mirrors credentialsLookupFn). Default: no-op.
+var oauthDirLookupFn = func(ctx context.Context) (oauthDirResolver, bool) {
+	return nil, false
+}
+
+// SetOAuthDirLookup wires a per-ctx OAuth-dir reader. The runner calls this at
+// boot with a closure over secrets.CredentialsFromContext(ctx).OAuthDir.
+// Idempotent; latest call wins.
+func SetOAuthDirLookup(fn func(ctx context.Context) (func(kind string) string, bool)) {
+	oauthDirLookupFn = func(ctx context.Context) (oauthDirResolver, bool) {
+		f, ok := fn(ctx)
+		return oauthDirResolver(f), ok
+	}
+}
+
+func oauthDirLookup(ctx context.Context, kind string) string {
+	f, ok := oauthDirLookupFn(ctx)
+	if !ok || f == nil {
+		return ""
+	}
+	return f(kind)
 }

--- a/pkg/secrets/codex_loadfrom_test.go
+++ b/pkg/secrets/codex_loadfrom_test.go
@@ -1,0 +1,32 @@
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadCodexCredentialsFrom(t *testing.T) {
+	dir := t.TempDir()
+	blob := `{"auth_mode":"chatgpt","tokens":{"access_token":"tok-1","account_id":"acct-1"}}`
+	if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte(blob), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	v, err := LoadCodexCredentialsFrom(dir)
+	if err != nil {
+		t.Fatalf("LoadCodexCredentialsFrom: %v", err)
+	}
+	if !v.IsChatGPTMode() {
+		t.Fatalf("expected chatgpt mode, got %+v", v)
+	}
+	if v.Tokens.AccessToken != "tok-1" || v.Tokens.AccountID != "acct-1" {
+		t.Errorf("wrong tokens: %+v", v.Tokens)
+	}
+
+	if _, err := LoadCodexCredentialsFrom(""); err == nil {
+		t.Error("expected error on empty dir")
+	}
+	if _, err := LoadCodexCredentialsFrom(t.TempDir()); err == nil {
+		t.Error("expected error when auth.json is absent")
+	}
+}

--- a/pkg/secrets/oauth.go
+++ b/pkg/secrets/oauth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -183,6 +184,24 @@ func CodexAuthJSONPath() string {
 		return ""
 	}
 	return filepath.Join(home, ".codex", "auth.json")
+}
+
+// LoadCodexCredentialsFrom reads and parses Codex CLI's auth.json from an
+// EXPLICIT CODEX_HOME-shaped directory (`<dir>/auth.json`), rather than the
+// process's default location. This is the cloud path: the runner materialises
+// a tenant's resolved codex OAuth-forfait into a per-run temp dir
+// (Credentials.OAuthDir("codex")), and the in-process claw model factory reads
+// it from there instead of the pod's (empty) ~/.codex. Empty dir → error.
+func LoadCodexCredentialsFrom(dir string) (CodexCredentialsView, error) {
+	if strings.TrimSpace(dir) == "" {
+		return CodexCredentialsView{}, fmt.Errorf("secrets: empty codex credentials dir")
+	}
+	path := filepath.Join(dir, "auth.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return CodexCredentialsView{}, fmt.Errorf("secrets: read %s: %w", path, err)
+	}
+	return ParseCodexView(data)
 }
 
 // LoadCodexCredentialsFromDisk reads and parses Codex CLI's auth.json from


### PR DESCRIPTION
## Context

Trying to run a `claw` + `openai/*` bot on prod with a connected OpenAI ChatGPT-forfait (Codex OAuth) kept failing `429 exceeded your current quota`: the run used the platform's (quota-dead) `OPENAI_API_KEY` instead of the forfait.

Root cause was a **documented** gap (the old comment in `registry.go`): the OpenAI provider factory read the ChatGPT-forfait only from the process's `~/.codex/auth.json` (`LoadCodexCredentialsFromDisk`). A cloud runner pod has **no `~/.codex`** — the tenant's forfait is materialised per-run into `Credentials.OAuthDir("codex")`, which the factory never consulted.

## Fix

Wire the per-run resolved forfait through ctx:
- `ResolveWithContext`, for `openai` with no BYOK key, now builds the ChatGPT client from `Credentials.OAuthDir("codex")` (`openAIFromCtxForfait`), honouring the same `ITERION_OPENAI_USE_OAUTH` / `OPENAI_BASE_URL` disable knobs as the disk factory.
- `secrets.LoadCodexCredentialsFrom(dir)` — load `auth.json` from an explicit CODEX_HOME-shaped dir.
- `model.SetOAuthDirLookup` — runner-injected reader of `creds.OAuthDir` (mirrors `SetCredentialsLookup`), keeping the model package's runner coupling indirection-based.
- `applyCodexOAuth` helper shared by both paths.

This is an **iterion** fix — claw already accepts the OAuth token + account id; iterion just wasn't feeding them in cloud mode. `claude_code` + Anthropic OAuth-forfait was unaffected (it's a spawned CLI wired via `OAuthCredentialFiles`); this closes the in-process `claw` + OpenAI path.

## Verification

- `pkg/secrets`: `LoadCodexCredentialsFrom` (present/empty/absent).
- `pkg/backend/model`: `ResolveWithContext` builds a ChatGPT client from a ctx-resolved codex dir; the disable/absent guards return not-ok.
- lint + `go vet` clean; `pkg/secrets` + `pkg/backend/model` + `cmd/...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)