### PR TITLE
fix(mcp): never cache an empty tool-discovery result (cold-start poisoning)

### DIFF
--- a/pkg/backend/mcp/empty_nocache_test.go
+++ b/pkg/backend/mcp/empty_nocache_test.go
@@ -1,0 +1,43 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/tool"
+	gomcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestManager_EmptyToolListNotCached guards the cold-start poisoning fix: a
+// server that lists zero tools (e.g. `npx -y <pkg>` answered tools/list before
+// registering its tools) must NOT be written to the disk cache, or every later
+// run on the pod gets a fast empty cache hit and the server's tools never
+// appear. EnsureServers still succeeds (empty is not an error); the next run
+// simply re-lists.
+func TestManager_EmptyToolListNotCached(t *testing.T) {
+	// A server with NO tools registered.
+	mcpServer := gomcp.NewServer(&gomcp.Implementation{Name: "empty", Version: "v0"}, nil)
+	handler := gomcp.NewStreamableHTTPHandler(
+		func(r *http.Request) *gomcp.Server { return mcpServer },
+		&gomcp.StreamableHTTPOptions{Stateless: true, JSONResponse: true},
+	)
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	cfg := map[string]*ServerConfig{
+		"empty": {Name: "empty", Transport: TransportHTTP, URL: server.URL},
+	}
+	cache := NewToolCache(t.TempDir(), time.Hour)
+	m := NewManager(cfg, WithToolCache(cache))
+	defer m.Close()
+
+	if err := m.EnsureServers(context.Background(), tool.NewRegistry(), []string{"empty"}); err != nil {
+		t.Fatalf("EnsureServers on a zero-tool server should not error: %v", err)
+	}
+	if _, ok := cache.Get("empty", cfg["empty"]); ok {
+		t.Fatal("an empty tool list must NOT be cached (would poison every later run on the pod)")
+	}
+}

--- a/pkg/backend/mcp/manager.go
+++ b/pkg/backend/mcp/manager.go
@@ -351,7 +351,14 @@ func (m *Manager) ensureServer(ctx context.Context, registry *tool.Registry, ser
 		if listErr != nil {
 			return false, fmt.Errorf("mcp: discover tools for %q: %w", server, listErr)
 		}
-		if m.cache != nil {
+		// NEVER cache an empty tool list. An `npx -y <pkg>` stdio server can
+		// answer tools/list before it finishes registering its tools on a cold
+		// pod (the package is still downloading/initialising), returning [].
+		// Persisting that to the disk cache poisons EVERY later run on the pod
+		// (fast cache hit → 0 tools forever). Skipping the write lets the next
+		// run — with a warm npx cache — rediscover the real tools. A server
+		// that genuinely exposes no tools simply re-lists (cheap) each time.
+		if m.cache != nil && len(toolsList) > 0 {
 			_ = m.cache.Set(server, state.cfg, toolsList) // best-effort
 		}
 	}


### PR DESCRIPTION
## Context

On a prod run, `wildcard "mcp.firecrawl.*" matched no tools (server firecrawl may not be started or has no tools)` — yet a direct MCP handshake to the very same `npx -y firecrawl-mcp` server on the runner listed its full toolset (scrape, `firecrawl_search`, …). So the server works; iterion just saw zero tools.

## Root cause

`ensureServer` persists `client.ListTools` results to the **disk** `ToolCache` (per-pod, TTL'd). An `npx -y <pkg>` stdio server can answer `tools/list` with `[]` on a **cold** pod (the package is still downloading / the fastmcp server hasn't finished registering its tools when discovery runs). That empty list got cached → every later run on the pod took a fast empty cache hit → the tools never appeared. Poisoned cache.

## Fix

Skip `cache.Set` when the tool list is empty. `EnsureServers` still succeeds (empty is not an error), and the next run — with a warm npx cache — rediscovers and caches the real tools. A server that genuinely exposes no tools just re-lists (cheap) each time. General: helps any npx-based MCP plugin, not only firecrawl.

## Verification

- `TestManager_EmptyToolListNotCached`: a zero-tool server is NOT written to the cache.
- `TestManagerWithCache` (existing): a non-empty discovery is still cached (no regression).
- lint + `go vet` clean; `pkg/backend/mcp` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)