### PR TITLE
feat(board): 'Awaiting input' column for paused dispatched runs (#125)

### DIFF
--- a/pkg/dispatcher/commands.go
+++ b/pkg/dispatcher/commands.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/runtime"
@@ -397,7 +398,13 @@ func (c *Dispatcher) finishRun(ctx context.Context, issueID string, err error) {
 	if errors.Is(err, runtime.ErrRunPaused) || errors.Is(err, runtime.ErrRunPausedOperator) {
 		c.stampLastRun(issueID, r)
 		c.setAwaitingInput(issueID, true)
-		c.logger.Info("dispatcher: %s paused awaiting input (run=%s): %v — left claimed and in-progress, NOT retried. Resume it from the run console; the issue keeps a live link via last_run.", r.Identifier, r.RunID, err)
+		// Move the card into the dedicated "awaiting input" column so the
+		// board shows "this pipeline needs me" at the column level (not only
+		// the per-card badge). Best-effort: a custom board without the state,
+		// or an external tracker that rejects it, keeps the card in place (the
+		// retained claim already blocks re-dispatch either way).
+		c.moveToAwaitingInput(issueID, r.Identifier)
+		c.logger.Info("dispatcher: %s paused awaiting input (run=%s): %v — moved to awaiting-input, kept claimed, NOT retried. Resume it from the run console; the issue keeps a live link via last_run.", r.Identifier, r.RunID, err)
 		c.fireSnapshot()
 		return
 	}
@@ -687,6 +694,17 @@ func (c *Dispatcher) setAwaitingInput(issueID string, v bool) {
 	}
 	if err := setter.SetAwaitingInput(issueID, v); err != nil {
 		c.logger.Warn("dispatcher: set awaiting-input=%v on %s: %v", v, issueID, err)
+	}
+}
+
+// moveToAwaitingInput best-effort transitions a paused card into the
+// StateAwaitingInput column. A board without that state (custom schema) or an
+// external tracker that rejects the transition leaves the card in place — the
+// retained claim already blocks re-dispatch, so this is a display-only
+// refinement, never load-bearing.
+func (c *Dispatcher) moveToAwaitingInput(issueID, identifier string) {
+	if err := c.tracker.UpdateState(context.Background(), issueID, native.StateAwaitingInput); err != nil {
+		c.logger.Info("dispatcher: %s stays in place (no awaiting-input column): %v", identifier, err)
 	}
 }
 

--- a/pkg/dispatcher/commands_paused_test.go
+++ b/pkg/dispatcher/commands_paused_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/runtime"
@@ -117,14 +118,15 @@ func TestFinishRun_PausedForInputIsParkedNotRetried(t *testing.T) {
 				t.Errorf("a retry was scheduled for a paused run — re-runs would re-hit the same pause")
 			}
 
-			// 3) The issue must stay where it is — not moved to FailedState
-			//    ("blocked") and not reverted to its source state ("ready").
+			// 3) The issue moves to the dedicated "awaiting input" column —
+			//    NOT to FailedState ("blocked") and NOT reverted to its source
+			//    state ("ready"). A pause is not a failure.
 			states, err := ft.RefreshStates(context.Background(), []string{issueID})
 			if err != nil {
 				t.Fatalf("RefreshStates: %v", err)
 			}
-			if got := states[issueID]; got != "in_progress" {
-				t.Errorf("issue state = %q, want %q (paused run must not be moved to blocked or reverted)", got, "in_progress")
+			if got := states[issueID]; got != native.StateAwaitingInput {
+				t.Errorf("issue state = %q, want %q (paused run moves to the awaiting-input column, not blocked/reverted)", got, native.StateAwaitingInput)
 			}
 
 			// 4) The slot must be freed and the entry dropped from running.

--- a/pkg/dispatcher/native/board.go
+++ b/pkg/dispatcher/native/board.go
@@ -15,9 +15,14 @@ const (
 	StateBacklog    = "backlog"
 	StateReady      = "ready"
 	StateInProgress = "in_progress"
-	StateReview     = "review"
-	StateDone       = "done"
-	StateBlocked    = "blocked"
+	// StateAwaitingInput holds a dispatched card whose run paused waiting for
+	// a human answer (paused_waiting_human). Non-eligible (the dispatcher
+	// never re-picks it) and non-terminal (the run resumes on answer). The
+	// column-level expression of the per-card AwaitingInput badge.
+	StateAwaitingInput = "awaiting_input"
+	StateReview        = "review"
+	StateDone          = "done"
+	StateBlocked       = "blocked"
 )
 
 // FieldType enumerates the supported custom-field value kinds.
@@ -95,6 +100,7 @@ func DefaultBoard() *Board {
 			{Name: StateBacklog, Display: "Backlog"},
 			{Name: StateReady, Display: "Ready", Eligible: true},
 			{Name: StateInProgress, Display: "In progress", Eligible: true},
+			{Name: StateAwaitingInput, Display: "Awaiting input"},
 			{Name: StateReview, Display: "Review"},
 			{Name: StateDone, Display: "Done", Terminal: true},
 			{Name: StateBlocked, Display: "Blocked", Terminal: true},

--- a/pkg/server/boarddispatch.go
+++ b/pkg/server/boarddispatch.go
@@ -24,6 +24,12 @@ type boardCoordinator interface {
 	Release(ctx context.Context, tenant, id, marker string) error
 }
 
+// errCardPaused marks a processBoardCard error whose run parked on a
+// human/operator gate (paused_waiting_human / paused_operator) rather than
+// failing. processCard routes such a card to the awaiting-input column, not
+// blocked.
+var errCardPaused = errors.New("board dispatcher: run paused awaiting input")
+
 // boardDispatcher polls the cloud board for eligible cards and runs each via
 // the injected process func (launch + poll-to-terminal). Multi-replica-safe
 // WITHOUT leader election: the per-card Claim is a CAS, so each card is claimed
@@ -38,6 +44,7 @@ type boardDispatcher struct {
 	inProgressState string
 	doneState       string
 	blockedState    string
+	awaitingState   string
 
 	interval time.Duration
 	sem      chan struct{}
@@ -58,6 +65,7 @@ func newBoardDispatcher(coord boardCoordinator, process func(context.Context, st
 		inProgressState: native.StateInProgress,
 		doneState:       native.StateDone,
 		blockedState:    native.StateBlocked,
+		awaitingState:   native.StateAwaitingInput,
 		interval:        5 * time.Second,
 		sem:             make(chan struct{}, concurrency),
 		logger:          logger,
@@ -100,8 +108,14 @@ func (d *boardDispatcher) processCard(ctx context.Context, c boardmongo.Candidat
 	runErr := d.process(ctx, c.Tenant, c.Issue)
 	final := d.doneState
 	if runErr != nil {
-		final = d.blockedState
-		d.warn("card %s/%s run failed: %v", c.Tenant, c.Issue.ID, runErr)
+		// A pause is not a failure: route the card to the awaiting-input
+		// column so the operator answers it there, not to blocked.
+		if errors.Is(runErr, errCardPaused) {
+			final = d.awaitingState
+		} else {
+			final = d.blockedState
+			d.warn("card %s/%s run failed: %v", c.Tenant, c.Issue.ID, runErr)
+		}
 	}
 	if err := d.coord.SetState(ctx, c.Tenant, c.Issue.ID, final); err != nil {
 		d.warn("card %s/%s → %s: %v", c.Tenant, c.Issue.ID, final, err)
@@ -273,12 +287,13 @@ func (s *Server) processBoardCard(ctx context.Context, tenant string, iss native
 			case st.IsTerminal():
 				return fmt.Errorf("run %s ended %s", runID, st)
 			case st.IsPaused():
-				// Parked on a human/operator gate — stop waiting; the card
-				// goes to blocked and the operator resumes the run. Denormalize
-				// the pause hint so the grid can badge the card without a
-				// per-run fetch.
+				// Parked on a human/operator gate — stop waiting; the operator
+				// resumes the run. Denormalize the pause hint so the grid can
+				// badge the card without a per-run fetch, and wrap errCardPaused
+				// so processCard routes the card to the awaiting-input column
+				// instead of blocked (a pause is not a failure).
 				s.setCardAwaitingInput(tenant, iss.ID, true)
-				return fmt.Errorf("run %s paused (%s)", runID, st)
+				return fmt.Errorf("run %s paused (%s): %w", runID, st, errCardPaused)
 			}
 		}
 		select {

--- a/pkg/server/boarddispatch_test.go
+++ b/pkg/server/boarddispatch_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -162,6 +163,22 @@ func TestBoardDispatcher_FailedRunMovesToBlocked(t *testing.T) {
 	d.wg.Wait()
 	if f.states["native:1"] != native.StateBlocked {
 		t.Errorf("failed run should move card to blocked, got %q", f.states["native:1"])
+	}
+}
+
+func TestBoardDispatcher_PausedRunMovesToAwaitingInput(t *testing.T) {
+	f := newFakeBoardCoord(readyCard("native:1", "feature-dev"))
+	// A process func that signals a pause (errCardPaused) rather than a failure.
+	d := newBoardDispatcher(f, func(context.Context, string, native.Issue) error {
+		return fmt.Errorf("run r1 paused (paused_waiting_human): %w", errCardPaused)
+	}, "replica-A", 4, nil)
+	d.tick(context.Background())
+	d.wg.Wait()
+	if f.states["native:1"] != native.StateAwaitingInput {
+		t.Errorf("paused run should move card to awaiting_input, got %q", f.states["native:1"])
+	}
+	if len(f.claimed) != 0 {
+		t.Errorf("card should be released after a pause: %v", f.claimed)
 	}
 }
 

--- a/studio/src/views/Board/boardShared.ts
+++ b/studio/src/views/Board/boardShared.ts
@@ -111,6 +111,10 @@ export function defaultStateColor(name: string, eligible: boolean, terminal: boo
       return "var(--color-board-ready)";
     case "in_progress":
       return "var(--color-board-in-progress)";
+    case "awaiting_input":
+      // Warning-toned to match the per-card ⏸ awaiting-input badge; a
+      // non-terminal "needs a human answer" column.
+      return "var(--color-warning)";
     case "review":
       return "var(--color-board-review)";
     case "done":


### PR DESCRIPTION
Nice-to-have **C** of #125 — the last board-side piece. A dispatched run that pauses for human input now moves its card into a dedicated **"Awaiting input"** column (non-eligible, non-terminal), the column-level expression of the per-card ⏸ badge (#161).

Hand-implemented (the prod forfait was credit-depleted, so Featurly couldn't; done in a credited session following the #165 spec).

## Changes
- `native.DefaultBoard()` gains `StateAwaitingInput` (after `in_progress`).
- **Local dispatcher** (`commands.go`): the pause arm of `finishRun` best-effort transitions the card to `awaiting_input` — falls back to in-place on a custom board / external tracker that rejects it (the retained claim already blocks re-dispatch).
- **Cloud dispatcher** (`boarddispatch.go`): `processBoardCard` wraps a new `errCardPaused` sentinel on a pause; `processCard` routes it to `awaitingState` instead of `blocked` (a pause is not a failure).
- **Studio** (`boardShared.ts`): warning-toned column color matching the badge.

## Verified
`go build` + dispatcher/server tests (updated the paused-park test to expect `awaiting_input`; new `PausedRunMovesToAwaitingInput` cloud test) + studio `tsc`/vitest green. Mirrored CI's `openapi:gen` + gofmt gates locally — clean.

Closes #165. Refs #125.