### PR TITLE
fix(skills/verify-build): put the codegen-drift gate in the copyable example (#167)

### DIFF
--- a/bots/adr-cartograph/skills/verify-build.md
+++ b/bots/adr-cartograph/skills/verify-build.md
@@ -57,6 +57,39 @@ Prefer the **fast** path: compile the whole module (a compile error is the
 common breakage) + run the unit tests. Skip slow integration / e2e / live
 suites unless they are the only tests the repo has.
 
+## 1b. Include the repo's codegen-freshness / drift checks
+
+Build + test green does NOT mean CI is green. Many repos commit **generated
+artifacts** — an OpenAPI/Swagger spec + generated client types, protobuf/gRPC
+stubs, generated mocks, a Helm chart version pinned to a package file — and
+enforce in CI that the committed copy matches a fresh regeneration
+(`regenerate && git diff --exit-code`). A change that adds an API route, a
+proto message, or a schema field but forgets to regenerate ships **green
+build + red CI** — exactly the drift the downstream reviewer/CI catches that
+you should catch here instead.
+
+So your `verify.sh` **must** mirror CI's gates, not just build+test — a build+test-only
+`verify.sh` is the single most common way an autonomous change ships green-locally /
+red-in-CI. This is not optional whenever the repo commits generated artifacts:
+
+- **Read the CI config** (`.github/workflows/*.yml`, `.gitlab-ci.yml`,
+  `.circleci/`) and include every gate it enforces — especially steps named
+  *drift*, *generate*, *codegen*, *check*, *fmt*, *lint*, *tidy/verify*.
+- **Grep the task runner** for freshness targets: `Taskfile.yml`/`Makefile`
+  entries like `*:gen` / `*:generate` / `*:check` / `openapi:check` /
+  `proto:check`. When a `check`/`verify` umbrella target exists that bundles
+  lint + test + drift, prefer it — it is the repo's own definition of "CI
+  green".
+- The pattern to add for each committed-generated artifact:
+  `<the repo's regen command> && git diff --exit-code -- <the generated
+  paths>` — a non-empty diff means stale, which is a real red.
+
+If you changed code that feeds a generator (a new HTTP route, a new exported
+type in a schema-bearing package), regenerating and committing the output is
+part of the work — the gate is here to force it. (iterion specifically:
+`task openapi:check` + the helm chart drift check are CI gates; a new
+`/api/...` route needs `task openapi:gen` committed.)
+
 ## 2. Write the verify script to the scratch dir
 
 Write an executable POSIX-sh script at the exact `verify.sh` path your task
@@ -71,10 +104,19 @@ non-zero on any failure**. Example
 set -e
 devbox run -- task build
 devbox run -- task test
+# Codegen-freshness gate (§1b) — regenerate the repo's committed derived
+# artifacts, then fail if the tree drifted. Adapt the regen command(s) to the
+# repo (grep the task runner for *:gen / *:generate); omit this block only when
+# the repo commits NO generated artifacts. `git diff --exit-code` (no paths)
+# catches drift in whatever the regen wrote.
+devbox run -- task openapi:gen      # ← the repo's own regen target(s)
+git diff --exit-code || { echo "codegen drift — regenerate + commit the output" >&2; exit 1; }
 ```
 
 The deterministic gate re-runs **this** script and gates the commit on its real
-exit code — so it must genuinely pass, not merely look plausible.
+exit code — so it must genuinely pass, not merely look plausible. A `verify.sh`
+that omits the §1b regen step when the repo has generated artifacts is the
+canonical way a change lands green-locally / red-in-CI.
 
 ## 3. Run it, and fix what the just-applied changes broke
 

--- a/bots/branch-improve-loop/skills/verify-build.md
+++ b/bots/branch-improve-loop/skills/verify-build.md
@@ -68,7 +68,9 @@ proto message, or a schema field but forgets to regenerate ships **green
 build + red CI** — exactly the drift the downstream reviewer/CI catches that
 you should catch here instead.
 
-So your `verify.sh` must mirror CI's gates, not just build+test:
+So your `verify.sh` **must** mirror CI's gates, not just build+test — a build+test-only
+`verify.sh` is the single most common way an autonomous change ships green-locally /
+red-in-CI. This is not optional whenever the repo commits generated artifacts:
 
 - **Read the CI config** (`.github/workflows/*.yml`, `.gitlab-ci.yml`,
   `.circleci/`) and include every gate it enforces — especially steps named
@@ -102,10 +104,19 @@ non-zero on any failure**. Example
 set -e
 devbox run -- task build
 devbox run -- task test
+# Codegen-freshness gate (§1b) — regenerate the repo's committed derived
+# artifacts, then fail if the tree drifted. Adapt the regen command(s) to the
+# repo (grep the task runner for *:gen / *:generate); omit this block only when
+# the repo commits NO generated artifacts. `git diff --exit-code` (no paths)
+# catches drift in whatever the regen wrote.
+devbox run -- task openapi:gen      # ← the repo's own regen target(s)
+git diff --exit-code || { echo "codegen drift — regenerate + commit the output" >&2; exit 1; }
 ```
 
 The deterministic gate re-runs **this** script and gates the commit on its real
-exit code — so it must genuinely pass, not merely look plausible.
+exit code — so it must genuinely pass, not merely look plausible. A `verify.sh`
+that omits the §1b regen step when the repo has generated artifacts is the
+canonical way a change lands green-locally / red-in-CI.
 
 ## 3. Run it, and fix what the just-applied changes broke
 

--- a/bots/dep-update-guard/skills/verify-build.md
+++ b/bots/dep-update-guard/skills/verify-build.md
@@ -57,6 +57,39 @@ Prefer the **fast** path: compile the whole module (a compile error is the
 common breakage) + run the unit tests. Skip slow integration / e2e / live
 suites unless they are the only tests the repo has.
 
+## 1b. Include the repo's codegen-freshness / drift checks
+
+Build + test green does NOT mean CI is green. Many repos commit **generated
+artifacts** — an OpenAPI/Swagger spec + generated client types, protobuf/gRPC
+stubs, generated mocks, a Helm chart version pinned to a package file — and
+enforce in CI that the committed copy matches a fresh regeneration
+(`regenerate && git diff --exit-code`). A change that adds an API route, a
+proto message, or a schema field but forgets to regenerate ships **green
+build + red CI** — exactly the drift the downstream reviewer/CI catches that
+you should catch here instead.
+
+So your `verify.sh` **must** mirror CI's gates, not just build+test — a build+test-only
+`verify.sh` is the single most common way an autonomous change ships green-locally /
+red-in-CI. This is not optional whenever the repo commits generated artifacts:
+
+- **Read the CI config** (`.github/workflows/*.yml`, `.gitlab-ci.yml`,
+  `.circleci/`) and include every gate it enforces — especially steps named
+  *drift*, *generate*, *codegen*, *check*, *fmt*, *lint*, *tidy/verify*.
+- **Grep the task runner** for freshness targets: `Taskfile.yml`/`Makefile`
+  entries like `*:gen` / `*:generate` / `*:check` / `openapi:check` /
+  `proto:check`. When a `check`/`verify` umbrella target exists that bundles
+  lint + test + drift, prefer it — it is the repo's own definition of "CI
+  green".
+- The pattern to add for each committed-generated artifact:
+  `<the repo's regen command> && git diff --exit-code -- <the generated
+  paths>` — a non-empty diff means stale, which is a real red.
+
+If you changed code that feeds a generator (a new HTTP route, a new exported
+type in a schema-bearing package), regenerating and committing the output is
+part of the work — the gate is here to force it. (iterion specifically:
+`task openapi:check` + the helm chart drift check are CI gates; a new
+`/api/...` route needs `task openapi:gen` committed.)
+
 ## 2. Write the verify script to the scratch dir
 
 Write an executable POSIX-sh script at the exact `verify.sh` path your task
@@ -71,10 +104,19 @@ non-zero on any failure**. Example
 set -e
 devbox run -- task build
 devbox run -- task test
+# Codegen-freshness gate (§1b) — regenerate the repo's committed derived
+# artifacts, then fail if the tree drifted. Adapt the regen command(s) to the
+# repo (grep the task runner for *:gen / *:generate); omit this block only when
+# the repo commits NO generated artifacts. `git diff --exit-code` (no paths)
+# catches drift in whatever the regen wrote.
+devbox run -- task openapi:gen      # ← the repo's own regen target(s)
+git diff --exit-code || { echo "codegen drift — regenerate + commit the output" >&2; exit 1; }
 ```
 
 The deterministic gate re-runs **this** script and gates the commit on its real
-exit code — so it must genuinely pass, not merely look plausible.
+exit code — so it must genuinely pass, not merely look plausible. A `verify.sh`
+that omits the §1b regen step when the repo has generated artifacts is the
+canonical way a change lands green-locally / red-in-CI.
 
 ## 3. Run it, and fix what the just-applied changes broke
 

--- a/bots/docs-refresh/skills/verify-build.md
+++ b/bots/docs-refresh/skills/verify-build.md
@@ -57,6 +57,39 @@ Prefer the **fast** path: compile the whole module (a compile error is the
 common breakage) + run the unit tests. Skip slow integration / e2e / live
 suites unless they are the only tests the repo has.
 
+## 1b. Include the repo's codegen-freshness / drift checks
+
+Build + test green does NOT mean CI is green. Many repos commit **generated
+artifacts** — an OpenAPI/Swagger spec + generated client types, protobuf/gRPC
+stubs, generated mocks, a Helm chart version pinned to a package file — and
+enforce in CI that the committed copy matches a fresh regeneration
+(`regenerate && git diff --exit-code`). A change that adds an API route, a
+proto message, or a schema field but forgets to regenerate ships **green
+build + red CI** — exactly the drift the downstream reviewer/CI catches that
+you should catch here instead.
+
+So your `verify.sh` **must** mirror CI's gates, not just build+test — a build+test-only
+`verify.sh` is the single most common way an autonomous change ships green-locally /
+red-in-CI. This is not optional whenever the repo commits generated artifacts:
+
+- **Read the CI config** (`.github/workflows/*.yml`, `.gitlab-ci.yml`,
+  `.circleci/`) and include every gate it enforces — especially steps named
+  *drift*, *generate*, *codegen*, *check*, *fmt*, *lint*, *tidy/verify*.
+- **Grep the task runner** for freshness targets: `Taskfile.yml`/`Makefile`
+  entries like `*:gen` / `*:generate` / `*:check` / `openapi:check` /
+  `proto:check`. When a `check`/`verify` umbrella target exists that bundles
+  lint + test + drift, prefer it — it is the repo's own definition of "CI
+  green".
+- The pattern to add for each committed-generated artifact:
+  `<the repo's regen command> && git diff --exit-code -- <the generated
+  paths>` — a non-empty diff means stale, which is a real red.
+
+If you changed code that feeds a generator (a new HTTP route, a new exported
+type in a schema-bearing package), regenerating and committing the output is
+part of the work — the gate is here to force it. (iterion specifically:
+`task openapi:check` + the helm chart drift check are CI gates; a new
+`/api/...` route needs `task openapi:gen` committed.)
+
 ## 2. Write the verify script to the scratch dir
 
 Write an executable POSIX-sh script at the exact `verify.sh` path your task
@@ -71,10 +104,19 @@ non-zero on any failure**. Example
 set -e
 devbox run -- task build
 devbox run -- task test
+# Codegen-freshness gate (§1b) — regenerate the repo's committed derived
+# artifacts, then fail if the tree drifted. Adapt the regen command(s) to the
+# repo (grep the task runner for *:gen / *:generate); omit this block only when
+# the repo commits NO generated artifacts. `git diff --exit-code` (no paths)
+# catches drift in whatever the regen wrote.
+devbox run -- task openapi:gen      # ← the repo's own regen target(s)
+git diff --exit-code || { echo "codegen drift — regenerate + commit the output" >&2; exit 1; }
 ```
 
 The deterministic gate re-runs **this** script and gates the commit on its real
-exit code — so it must genuinely pass, not merely look plausible.
+exit code — so it must genuinely pass, not merely look plausible. A `verify.sh`
+that omits the §1b regen step when the repo has generated artifacts is the
+canonical way a change lands green-locally / red-in-CI.
 
 ## 3. Run it, and fix what the just-applied changes broke
 

--- a/bots/feature-dev/skills/verify-build.md
+++ b/bots/feature-dev/skills/verify-build.md
@@ -68,7 +68,9 @@ proto message, or a schema field but forgets to regenerate ships **green
 build + red CI** — exactly the drift the downstream reviewer/CI catches that
 you should catch here instead.
 
-So your `verify.sh` must mirror CI's gates, not just build+test:
+So your `verify.sh` **must** mirror CI's gates, not just build+test — a build+test-only
+`verify.sh` is the single most common way an autonomous change ships green-locally /
+red-in-CI. This is not optional whenever the repo commits generated artifacts:
 
 - **Read the CI config** (`.github/workflows/*.yml`, `.gitlab-ci.yml`,
   `.circleci/`) and include every gate it enforces — especially steps named
@@ -102,10 +104,19 @@ non-zero on any failure**. Example
 set -e
 devbox run -- task build
 devbox run -- task test
+# Codegen-freshness gate (§1b) — regenerate the repo's committed derived
+# artifacts, then fail if the tree drifted. Adapt the regen command(s) to the
+# repo (grep the task runner for *:gen / *:generate); omit this block only when
+# the repo commits NO generated artifacts. `git diff --exit-code` (no paths)
+# catches drift in whatever the regen wrote.
+devbox run -- task openapi:gen      # ← the repo's own regen target(s)
+git diff --exit-code || { echo "codegen drift — regenerate + commit the output" >&2; exit 1; }
 ```
 
 The deterministic gate re-runs **this** script and gates the commit on its real
-exit code — so it must genuinely pass, not merely look plausible.
+exit code — so it must genuinely pass, not merely look plausible. A `verify.sh`
+that omits the §1b regen step when the repo has generated artifacts is the
+canonical way a change lands green-locally / red-in-CI.
 
 ## 3. Run it, and fix what the just-applied changes broke
 

--- a/bots/feature-gap-fill/skills/verify-build.md
+++ b/bots/feature-gap-fill/skills/verify-build.md
@@ -57,6 +57,39 @@ Prefer the **fast** path: compile the whole module (a compile error is the
 common breakage) + run the unit tests. Skip slow integration / e2e / live
 suites unless they are the only tests the repo has.
 
+## 1b. Include the repo's codegen-freshness / drift checks
+
+Build + test green does NOT mean CI is green. Many repos commit **generated
+artifacts** — an OpenAPI/Swagger spec + generated client types, protobuf/gRPC
+stubs, generated mocks, a Helm chart version pinned to a package file — and
+enforce in CI that the committed copy matches a fresh regeneration
+(`regenerate && git diff --exit-code`). A change that adds an API route, a
+proto message, or a schema field but forgets to regenerate ships **green
+build + red CI** — exactly the drift the downstream reviewer/CI catches that
+you should catch here instead.
+
+So your `verify.sh` **must** mirror CI's gates, not just build+test — a build+test-only
+`verify.sh` is the single most common way an autonomous change ships green-locally /
+red-in-CI. This is not optional whenever the repo commits generated artifacts:
+
+- **Read the CI config** (`.github/workflows/*.yml`, `.gitlab-ci.yml`,
+  `.circleci/`) and include every gate it enforces — especially steps named
+  *drift*, *generate*, *codegen*, *check*, *fmt*, *lint*, *tidy/verify*.
+- **Grep the task runner** for freshness targets: `Taskfile.yml`/`Makefile`
+  entries like `*:gen` / `*:generate` / `*:check` / `openapi:check` /
+  `proto:check`. When a `check`/`verify` umbrella target exists that bundles
+  lint + test + drift, prefer it — it is the repo's own definition of "CI
+  green".
+- The pattern to add for each committed-generated artifact:
+  `<the repo's regen command> && git diff --exit-code -- <the generated
+  paths>` — a non-empty diff means stale, which is a real red.
+
+If you changed code that feeds a generator (a new HTTP route, a new exported
+type in a schema-bearing package), regenerating and committing the output is
+part of the work — the gate is here to force it. (iterion specifically:
+`task openapi:check` + the helm chart drift check are CI gates; a new
+`/api/...` route needs `task openapi:gen` committed.)
+
 ## 2. Write the verify script to the scratch dir
 
 Write an executable POSIX-sh script at the exact `verify.sh` path your task
@@ -71,10 +104,19 @@ non-zero on any failure**. Example
 set -e
 devbox run -- task build
 devbox run -- task test
+# Codegen-freshness gate (§1b) — regenerate the repo's committed derived
+# artifacts, then fail if the tree drifted. Adapt the regen command(s) to the
+# repo (grep the task runner for *:gen / *:generate); omit this block only when
+# the repo commits NO generated artifacts. `git diff --exit-code` (no paths)
+# catches drift in whatever the regen wrote.
+devbox run -- task openapi:gen      # ← the repo's own regen target(s)
+git diff --exit-code || { echo "codegen drift — regenerate + commit the output" >&2; exit 1; }
 ```
 
 The deterministic gate re-runs **this** script and gates the commit on its real
-exit code — so it must genuinely pass, not merely look plausible.
+exit code — so it must genuinely pass, not merely look plausible. A `verify.sh`
+that omits the §1b regen step when the repo has generated artifacts is the
+canonical way a change lands green-locally / red-in-CI.
 
 ## 3. Run it, and fix what the just-applied changes broke
 

--- a/bots/secured-renovacy/skills/verify-build.md
+++ b/bots/secured-renovacy/skills/verify-build.md
@@ -57,6 +57,39 @@ Prefer the **fast** path: compile the whole module (a compile error is the
 common breakage) + run the unit tests. Skip slow integration / e2e / live
 suites unless they are the only tests the repo has.
 
+## 1b. Include the repo's codegen-freshness / drift checks
+
+Build + test green does NOT mean CI is green. Many repos commit **generated
+artifacts** — an OpenAPI/Swagger spec + generated client types, protobuf/gRPC
+stubs, generated mocks, a Helm chart version pinned to a package file — and
+enforce in CI that the committed copy matches a fresh regeneration
+(`regenerate && git diff --exit-code`). A change that adds an API route, a
+proto message, or a schema field but forgets to regenerate ships **green
+build + red CI** — exactly the drift the downstream reviewer/CI catches that
+you should catch here instead.
+
+So your `verify.sh` **must** mirror CI's gates, not just build+test — a build+test-only
+`verify.sh` is the single most common way an autonomous change ships green-locally /
+red-in-CI. This is not optional whenever the repo commits generated artifacts:
+
+- **Read the CI config** (`.github/workflows/*.yml`, `.gitlab-ci.yml`,
+  `.circleci/`) and include every gate it enforces — especially steps named
+  *drift*, *generate*, *codegen*, *check*, *fmt*, *lint*, *tidy/verify*.
+- **Grep the task runner** for freshness targets: `Taskfile.yml`/`Makefile`
+  entries like `*:gen` / `*:generate` / `*:check` / `openapi:check` /
+  `proto:check`. When a `check`/`verify` umbrella target exists that bundles
+  lint + test + drift, prefer it — it is the repo's own definition of "CI
+  green".
+- The pattern to add for each committed-generated artifact:
+  `<the repo's regen command> && git diff --exit-code -- <the generated
+  paths>` — a non-empty diff means stale, which is a real red.
+
+If you changed code that feeds a generator (a new HTTP route, a new exported
+type in a schema-bearing package), regenerating and committing the output is
+part of the work — the gate is here to force it. (iterion specifically:
+`task openapi:check` + the helm chart drift check are CI gates; a new
+`/api/...` route needs `task openapi:gen` committed.)
+
 ## 2. Write the verify script to the scratch dir
 
 Write an executable POSIX-sh script at the exact `verify.sh` path your task
@@ -71,10 +104,19 @@ non-zero on any failure**. Example
 set -e
 devbox run -- task build
 devbox run -- task test
+# Codegen-freshness gate (§1b) — regenerate the repo's committed derived
+# artifacts, then fail if the tree drifted. Adapt the regen command(s) to the
+# repo (grep the task runner for *:gen / *:generate); omit this block only when
+# the repo commits NO generated artifacts. `git diff --exit-code` (no paths)
+# catches drift in whatever the regen wrote.
+devbox run -- task openapi:gen      # ← the repo's own regen target(s)
+git diff --exit-code || { echo "codegen drift — regenerate + commit the output" >&2; exit 1; }
 ```
 
 The deterministic gate re-runs **this** script and gates the commit on its real
-exit code — so it must genuinely pass, not merely look plausible.
+exit code — so it must genuinely pass, not merely look plausible. A `verify.sh`
+that omits the §1b regen step when the repo has generated artifacts is the
+canonical way a change lands green-locally / red-in-CI.
 
 ## 3. Run it, and fix what the just-applied changes broke
 

--- a/bots/test-coverage/skills/verify-build.md
+++ b/bots/test-coverage/skills/verify-build.md
@@ -57,6 +57,39 @@ Prefer the **fast** path: compile the whole module (a compile error is the
 common breakage) + run the unit tests. Skip slow integration / e2e / live
 suites unless they are the only tests the repo has.
 
+## 1b. Include the repo's codegen-freshness / drift checks
+
+Build + test green does NOT mean CI is green. Many repos commit **generated
+artifacts** — an OpenAPI/Swagger spec + generated client types, protobuf/gRPC
+stubs, generated mocks, a Helm chart version pinned to a package file — and
+enforce in CI that the committed copy matches a fresh regeneration
+(`regenerate && git diff --exit-code`). A change that adds an API route, a
+proto message, or a schema field but forgets to regenerate ships **green
+build + red CI** — exactly the drift the downstream reviewer/CI catches that
+you should catch here instead.
+
+So your `verify.sh` **must** mirror CI's gates, not just build+test — a build+test-only
+`verify.sh` is the single most common way an autonomous change ships green-locally /
+red-in-CI. This is not optional whenever the repo commits generated artifacts:
+
+- **Read the CI config** (`.github/workflows/*.yml`, `.gitlab-ci.yml`,
+  `.circleci/`) and include every gate it enforces — especially steps named
+  *drift*, *generate*, *codegen*, *check*, *fmt*, *lint*, *tidy/verify*.
+- **Grep the task runner** for freshness targets: `Taskfile.yml`/`Makefile`
+  entries like `*:gen` / `*:generate` / `*:check` / `openapi:check` /
+  `proto:check`. When a `check`/`verify` umbrella target exists that bundles
+  lint + test + drift, prefer it — it is the repo's own definition of "CI
+  green".
+- The pattern to add for each committed-generated artifact:
+  `<the repo's regen command> && git diff --exit-code -- <the generated
+  paths>` — a non-empty diff means stale, which is a real red.
+
+If you changed code that feeds a generator (a new HTTP route, a new exported
+type in a schema-bearing package), regenerating and committing the output is
+part of the work — the gate is here to force it. (iterion specifically:
+`task openapi:check` + the helm chart drift check are CI gates; a new
+`/api/...` route needs `task openapi:gen` committed.)
+
 ## 2. Write the verify script to the scratch dir
 
 Write an executable POSIX-sh script at the exact `verify.sh` path your task
@@ -71,10 +104,19 @@ non-zero on any failure**. Example
 set -e
 devbox run -- task build
 devbox run -- task test
+# Codegen-freshness gate (§1b) — regenerate the repo's committed derived
+# artifacts, then fail if the tree drifted. Adapt the regen command(s) to the
+# repo (grep the task runner for *:gen / *:generate); omit this block only when
+# the repo commits NO generated artifacts. `git diff --exit-code` (no paths)
+# catches drift in whatever the regen wrote.
+devbox run -- task openapi:gen      # ← the repo's own regen target(s)
+git diff --exit-code || { echo "codegen drift — regenerate + commit the output" >&2; exit 1; }
 ```
 
 The deterministic gate re-runs **this** script and gates the commit on its real
-exit code — so it must genuinely pass, not merely look plausible.
+exit code — so it must genuinely pass, not merely look plausible. A `verify.sh`
+that omits the §1b regen step when the repo has generated artifacts is the
+canonical way a change lands green-locally / red-in-CI.
 
 ## 3. Run it, and fix what the just-applied changes broke
 

--- a/bots/whole-improve-loop/skills/verify-build.md
+++ b/bots/whole-improve-loop/skills/verify-build.md
@@ -68,7 +68,9 @@ proto message, or a schema field but forgets to regenerate ships **green
 build + red CI** — exactly the drift the downstream reviewer/CI catches that
 you should catch here instead.
 
-So your `verify.sh` must mirror CI's gates, not just build+test:
+So your `verify.sh` **must** mirror CI's gates, not just build+test — a build+test-only
+`verify.sh` is the single most common way an autonomous change ships green-locally /
+red-in-CI. This is not optional whenever the repo commits generated artifacts:
 
 - **Read the CI config** (`.github/workflows/*.yml`, `.gitlab-ci.yml`,
   `.circleci/`) and include every gate it enforces — especially steps named
@@ -102,10 +104,19 @@ non-zero on any failure**. Example
 set -e
 devbox run -- task build
 devbox run -- task test
+# Codegen-freshness gate (§1b) — regenerate the repo's committed derived
+# artifacts, then fail if the tree drifted. Adapt the regen command(s) to the
+# repo (grep the task runner for *:gen / *:generate); omit this block only when
+# the repo commits NO generated artifacts. `git diff --exit-code` (no paths)
+# catches drift in whatever the regen wrote.
+devbox run -- task openapi:gen      # ← the repo's own regen target(s)
+git diff --exit-code || { echo "codegen drift — regenerate + commit the output" >&2; exit 1; }
 ```
 
 The deterministic gate re-runs **this** script and gates the commit on its real
-exit code — so it must genuinely pass, not merely look plausible.
+exit code — so it must genuinely pass, not merely look plausible. A `verify.sh`
+that omits the §1b regen step when the repo has generated artifacts is the
+canonical way a change lands green-locally / red-in-CI.
 
 ## 3. Run it, and fix what the just-applied changes broke
 


### PR DESCRIPTION
Closes #167.

## The real gap

#167 asked to make verify-build run the repo's codegen/drift gates. On
inspection the skill **already** carried §1b ("Include the repo's
codegen-freshness / drift checks", naming `task openapi:check` + the helm
chart gate) — yet Featurly's #159/#162 dogfood runs still shipped OpenAPI
drift that CI's `openapi:check` caught.

Root cause: the skill's **example `verify.sh` showed only build+test**, and
agents copy the example verbatim. The imperative guidance was in prose §1b
below the example, so it got skipped.

## Fix

- **Put the drift gate in the example itself** (`<regen> && git diff
  --exit-code`), marked "adapt the regen target to the repo" — now what gets
  copied includes the gate.
- **Make §1b imperative** ("must", "not optional whenever the repo commits
  generated artifacts").
- **Unify the two variants**: 3 bots had §1b, 6 didn't (2 distinct md5s).
  All 9 catalog bots now share one canonical copy.

## Follow-up (not in scope)

The skill is still *advisory* — the truly deterministic fix is a `verify_run`
gate that discovers and runs the repo's `*:check` targets independently of the
agent-authored verify.sh. Noted for a future engine change; this PR closes the
copy-the-example behavior that caused the observed drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)