### PR TITLE
fix(runner): bake pinned firecrawl-mcp into runner image (+ renovate auto-bump)

### DIFF
--- a/Dockerfile.runner-devbox
+++ b/Dockerfile.runner-devbox
@@ -38,6 +38,18 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends nodejs \
  && rm -rf /var/lib/apt/lists/*
 
+# Pre-install the firecrawl MCP server (shipped `firecrawl` builtin plugin) so
+# the runtime `npx -y firecrawl-mcp@<ver>` starts INSTANTLY from the warm global
+# install instead of downloading on a cold pod. A cold `npx` download races the
+# MCP tools/list discovery → the server answers with [] before its tools
+# register → the plugin's `mcp.firecrawl.*` wildcard resolves to nothing.
+# Baking it in makes discovery deterministic. The version is PINNED (supply-
+# chain: never resolve a moving `latest` at build OR run time) and MUST match
+# pkg/plugin/builtin/firecrawl/plugin.yaml's `npx` arg so runtime reuses this
+# exact global install instead of fetching another version.
+ARG FIRECRAWL_MCP_VERSION=3.22.3
+RUN npm install -g "firecrawl-mcp@${FIRECRAWL_MCP_VERSION}" && npm cache clean --force
+
 # gh + glab (Revi posts reviews from the runner pod) + kubectl (parity with the
 # base runner image; also used by the k8s sandbox driver if ever enabled).
 ARG GLAB_VERSION=1.102.0

--- a/Dockerfile.runner-devbox
+++ b/Dockerfile.runner-devbox
@@ -47,6 +47,7 @@ RUN apt-get update \
 # chain: never resolve a moving `latest` at build OR run time) and MUST match
 # pkg/plugin/builtin/firecrawl/plugin.yaml's `npx` arg so runtime reuses this
 # exact global install instead of fetching another version.
+# renovate: datasource=npm depName=firecrawl-mcp versioning=npm
 ARG FIRECRAWL_MCP_VERSION=3.22.3
 RUN npm install -g "firecrawl-mcp@${FIRECRAWL_MCP_VERSION}" && npm cache clean --force
 

--- a/pkg/plugin/builtin/firecrawl/plugin.yaml
+++ b/pkg/plugin/builtin/firecrawl/plugin.yaml
@@ -30,6 +30,7 @@ contributes:
       # runner reuses its warm pre-installed global instead of downloading.
       args:
         - -y
+        # renovate: datasource=npm depName=firecrawl-mcp versioning=npm
         - firecrawl-mcp@3.22.3
       env:
         FIRECRAWL_API_URL: "{{config.api_url}}"

--- a/pkg/plugin/builtin/firecrawl/plugin.yaml
+++ b/pkg/plugin/builtin/firecrawl/plugin.yaml
@@ -25,9 +25,12 @@ contributes:
     - name: firecrawl
       transport: stdio
       command: npx
+      # Version PINNED (supply-chain: never resolve a moving `latest`). Must
+      # match Dockerfile.runner-devbox's FIRECRAWL_MCP_VERSION so the cloud
+      # runner reuses its warm pre-installed global instead of downloading.
       args:
         - -y
-        - firecrawl-mcp
+        - firecrawl-mcp@3.22.3
       env:
         FIRECRAWL_API_URL: "{{config.api_url}}"
         FIRECRAWL_API_KEY: "{{config.api_key}}"

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,17 @@
       "depNameTemplate": "go",
       "datasourceTemplate": "golang-version",
       "versioningTemplate": "go"
+    },
+    {
+      "customType": "regex",
+      "description": "Inline `# renovate: datasource=… depName=… versioning=…` pins. Captures the version on the line right after the comment, in ANY file (e.g. the pinned firecrawl-mcp in Dockerfile.runner-devbox's ARG and pkg/plugin/builtin/firecrawl/plugin.yaml's npx arg — both MUST stay in lockstep, so a bump PR touches both). To pin another tool anywhere, drop the same comment above its version line.",
+      "managerFilePatterns": [
+        "/(^|/)Dockerfile\\.runner-devbox$/",
+        "/(^|/)pkg/plugin/builtin/firecrawl/plugin\\.yaml$/"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+[^\\n]*?(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ]
     }
   ],
   "packageRules": [
@@ -75,7 +86,15 @@
     {
       "description": "Group devbox (Nix) version-pinned package updates from the custom manager.",
       "matchManagers": ["custom.regex"],
+      "matchDepNames": ["go"],
       "groupName": "devbox"
+    },
+    {
+      "description": "firecrawl-mcp is pinned in BOTH the runner Dockerfile ARG and the firecrawl plugin manifest; group them so one PR bumps both in lockstep. Labelled security — it's a supply-chain-sensitive runtime download baked into the runner image.",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["firecrawl-mcp"],
+      "groupName": "firecrawl-mcp",
+      "labels": ["dependencies", "security"]
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Context

The `firecrawl` builtin plugin's stdio MCP server runs `npx -y firecrawl-mcp`. On a **cold** runner pod that DOWNLOADS the package, racing the MCP `tools/list` discovery — the server answers `[]` before its tools register, so `mcp.firecrawl.*` resolves to nothing and the agent never gets firecrawl tools. Observed live across several prod runs; a direct MCP handshake to the very same server on the runner listed the full toolset. (#172 stopped that empty result from *poisoning* the disk cache; this closes the cold first-discovery itself.)

## Change

Bake `firecrawl-mcp` into the `iterion-runner-devbox` image so the runtime `npx` reuses a warm global install → the server starts instantly and discovery is deterministic.

**Supply-chain hardening** (per review): the version is **pinned**, never a moving `latest` — both in the Dockerfile (`ARG FIRECRAWL_MCP_VERSION=3.22.3`) and the plugin manifest (`firecrawl-mcp@3.22.3`), so build-time and run-time resolve the SAME version.

**Renovate** keeps the pin fresh: an inline `# renovate: datasource=npm depName=firecrawl-mcp versioning=npm` comment above each version + a `customManager` reading it. Both lines share `depName firecrawl-mcp` → Renovate groups them into ONE lockstep bump PR (labelled `security`). Also scoped the pre-existing `custom.regex → devbox` group rule to `depName: go` so it no longer swallows this one.

## Verification

- `renovate-config-validator`: config validated successfully.
- Plugin still loads (`iterion plugin info firecrawl`), manifest valid, `pkg/plugin` tests green.
- After the runner `:edge` rebuilds with this, `mcp.firecrawl.*` resolves in cloud claw runs (validation to follow on deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)