### PR TITLE
fix(mcp): retry tool discovery on an empty result (startup race)

### DIFF
--- a/pkg/backend/mcp/manager.go
+++ b/pkg/backend/mcp/manager.go
@@ -228,6 +228,16 @@ func (m *Manager) HealthCheck(ctx context.Context, servers []string) error {
 // exit; the per-call timeout caps the leak window.
 const mcpHealthPingTimeout = 5 * time.Second
 
+// mcpDiscoveryEmptyRetries / mcpDiscoveryEmptyBackoff bound the retry-on-empty
+// in ensureServer: an MCP server can answer tools/list before it finishes
+// registering its tools right after initialize. Up to 6 extra re-lists spaced
+// 500ms apart (~3s) covers that startup race without stalling a genuinely
+// tool-less server for long.
+const (
+	mcpDiscoveryEmptyRetries = 6
+	mcpDiscoveryEmptyBackoff = 500 * time.Millisecond
+)
+
 // ServerNames returns the names of every server known to the catalog
 // (whether or not it has been connected yet). The order is stable but
 // unspecified.
@@ -347,17 +357,30 @@ func (m *Manager) ensureServer(ctx context.Context, registry *tool.Registry, ser
 	if toolsList == nil {
 		didListTools = true
 		var listErr error
-		toolsList, listErr = client.ListTools(ctx)
-		if listErr != nil {
-			return false, fmt.Errorf("mcp: discover tools for %q: %w", server, listErr)
+		// Retry-on-empty. A server (notably fastmcp-based ones like
+		// firecrawl-mcp) can answer tools/list right after `initialize` but
+		// BEFORE it finishes registering its tools, returning [] on the first
+		// call. Re-list a few times with a short backoff on the SAME session so
+		// a startup race doesn't leave the server tool-less for the whole run.
+		// A genuinely tool-less server just costs a few cheap re-lists.
+		for attempt := 0; ; attempt++ {
+			toolsList, listErr = client.ListTools(ctx)
+			if listErr != nil {
+				return false, fmt.Errorf("mcp: discover tools for %q: %w", server, listErr)
+			}
+			if len(toolsList) > 0 || attempt >= mcpDiscoveryEmptyRetries {
+				break
+			}
+			select {
+			case <-ctx.Done():
+				return false, ctx.Err()
+			case <-time.After(mcpDiscoveryEmptyBackoff):
+			}
 		}
-		// NEVER cache an empty tool list. An `npx -y <pkg>` stdio server can
-		// answer tools/list before it finishes registering its tools on a cold
-		// pod (the package is still downloading/initialising), returning [].
-		// Persisting that to the disk cache poisons EVERY later run on the pod
-		// (fast cache hit → 0 tools forever). Skipping the write lets the next
-		// run — with a warm npx cache — rediscover the real tools. A server
-		// that genuinely exposes no tools simply re-lists (cheap) each time.
+		// NEVER cache an empty tool list — a startup race (above) shouldn't
+		// poison the persistent disk cache and starve EVERY later run on the pod
+		// (fast empty cache hit → 0 tools forever). Only a non-empty discovery
+		// is durable enough to cache.
 		if m.cache != nil && len(toolsList) > 0 {
 			_ = m.cache.Set(server, state.cfg, toolsList) // best-effort
 		}


### PR DESCRIPTION
## Context

Last mile of the firecrawl-in-a-cloud-run thread. Even after baking a **warm** `firecrawl-mcp` into the runner image (#176), `mcp.firecrawl.*` still resolved to zero tools in claw runs — the discovery came back empty *instantly*, not slowly. So it was never the npx cold download.

Root cause: a fastmcp-based stdio server answers `tools/list` right after `initialize` but **before** it finishes registering its tools, so the go-sdk client's immediate list gets `[]`. (A manual handshake with natural delays listed the full toolset — the race only bites the fast automated path.) #172 stopped that empty from *poisoning* the cache, but the live discovery still returned empty.

## Fix

Retry-on-empty in `ensureServer`: re-list up to 6× with a 500ms backoff on the **same session** before giving up (~3s max). Recovers the startup race for any MCP server. A genuinely tool-less server just costs a few cheap re-lists — and is still never cached (#172).

## Verification

- `pkg/backend/mcp` green; `TestManager_EmptyToolListNotCached` now also exercises the retry-exhaustion path (0-tool server → 6 retries → still empty → not cached).
- Live validation on deploy: re-run the claw firecrawl bot → `mcp.firecrawl.*` resolves + `firecrawl_scrape` is invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)