### PR TITLE
fix(dispatcher,bots): close the two #125 réserves — awaiting-input lifecycle + deterministic drift gate

### DIFF
--- a/bots/adr-cartograph/main.bot
+++ b/bots/adr-cartograph/main.bot
@@ -969,6 +969,15 @@ script = os.path.join(scratch, 'verify.sh')
 if not os.path.exists(script):
     print(json.dumps({'passed': True, 'skipped': True, 'exit_code': 0, 'log_tail': 'verify_build produced no verify.sh in the scratch dir; build gate SKIPPED (counted as pass, but surfaced) -- verify_build should write the script'}))
     raise SystemExit(0)
+def tree_state():
+    try:
+        p = subprocess.run(['git', '-C', ws, 'status', '--porcelain'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=60)
+        if p.returncode != 0:
+            return None
+        return set(l for l in p.stdout.splitlines() if l.strip())
+    except Exception:
+        return None
+pre = tree_state()
 rc = 0
 out = ''
 try:
@@ -981,6 +990,43 @@ except subprocess.TimeoutExpired as e:
 except Exception as e:
     out = 'verify_run could not execute the script: ' + str(e)
     rc = 1
+# Deterministic codegen-drift tail (stack-agnostic; the gate stays
+# deterministic per ADR-044). Only on a GREEN verify: (1) if the repo's own
+# CI enforces a drift gate, verify.sh must mirror it; (2) a green verify
+# must not leave new changes in the tree (regen output belongs in a commit).
+if rc == 0:
+    import glob
+    def has_drift_gate(text):
+        for l in text.splitlines():
+            if ('diff' in l and ('--exit-code' in l or '--quiet' in l)) or 'status --porcelain' in l:
+                return True
+        return False
+    ci_hit = ''
+    for pat in ('.github/workflows/*.yml', '.github/workflows/*.yaml', '.gitlab-ci.yml', '.circleci/config.yml'):
+        for f in sorted(glob.glob(os.path.join(ws, pat))):
+            try:
+                if has_drift_gate(open(f, encoding='utf-8', errors='replace').read()):
+                    ci_hit = os.path.relpath(f, ws)
+                    break
+            except OSError:
+                pass
+        if ci_hit:
+            break
+    if ci_hit:
+        try:
+            vs = open(script, encoding='utf-8', errors='replace').read()
+        except OSError:
+            vs = ''
+        if not has_drift_gate(vs):
+            rc = 3
+            out = out + chr(10) + 'DRIFT GATE MISSING: CI (' + ci_hit + ') enforces a codegen-drift gate but ' + script + ' has none -- edit the script per the verify-build skill section 1b (run the repo regen command, then: git diff --exit-code).'
+    if rc == 0 and pre is not None:
+        post = tree_state()
+        if post is not None:
+            fresh = sorted(post - pre)
+            if fresh:
+                rc = 4
+                out = out + chr(10) + 'UNCOMMITTED REGEN OUTPUT: a green verify left new changes in the tree; commit (or gitignore) them:' + chr(10) + chr(10).join(fresh[:50])
 try:
     with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
         lf.write(out)

--- a/bots/adr-cartograph/skills/verify-build.md
+++ b/bots/adr-cartograph/skills/verify-build.md
@@ -90,6 +90,13 @@ part of the work — the gate is here to force it. (iterion specifically:
 `task openapi:check` + the helm chart drift check are CI gates; a new
 `/api/...` route needs `task openapi:gen` committed.)
 
+This section is **deterministically enforced** by the verify gate: when the
+repo's CI config contains a drift gate and your `verify.sh` has no
+`git diff --exit-code`/`--quiet` line, the gate fails with a DRIFT GATE
+MISSING error; and a green verify that leaves new changes in the tree fails
+with UNCOMMITTED REGEN OUTPUT. Writing the gate here is cheaper than being
+bounced by the enforcement.
+
 ## 2. Write the verify script to the scratch dir
 
 Write an executable POSIX-sh script at the exact `verify.sh` path your task

--- a/bots/branch-improve-loop/main.bot
+++ b/bots/branch-improve-loop/main.bot
@@ -674,6 +674,15 @@ script = os.path.join(scratch, 'verify.sh')
 if not os.path.exists(script):
     print(json.dumps({'passed': True, 'skipped': True, 'exit_code': 0, 'log_tail': 'verify_build produced no verify.sh in the scratch dir; build/test gate SKIPPED (counted as pass, but surfaced) -- verify_build should write the script'}))
     raise SystemExit(0)
+def tree_state():
+    try:
+        p = subprocess.run(['git', '-C', ws, 'status', '--porcelain'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=60)
+        if p.returncode != 0:
+            return None
+        return set(l for l in p.stdout.splitlines() if l.strip())
+    except Exception:
+        return None
+pre = tree_state()
 rc = 0
 out = ''
 try:
@@ -686,6 +695,43 @@ except subprocess.TimeoutExpired as e:
 except Exception as e:
     out = 'verify_run could not execute the script: ' + str(e)
     rc = 1
+# Deterministic codegen-drift tail (stack-agnostic; the gate stays
+# deterministic per ADR-044). Only on a GREEN verify: (1) if the repo's own
+# CI enforces a drift gate, verify.sh must mirror it; (2) a green verify
+# must not leave new changes in the tree (regen output belongs in a commit).
+if rc == 0:
+    import glob
+    def has_drift_gate(text):
+        for l in text.splitlines():
+            if ('diff' in l and ('--exit-code' in l or '--quiet' in l)) or 'status --porcelain' in l:
+                return True
+        return False
+    ci_hit = ''
+    for pat in ('.github/workflows/*.yml', '.github/workflows/*.yaml', '.gitlab-ci.yml', '.circleci/config.yml'):
+        for f in sorted(glob.glob(os.path.join(ws, pat))):
+            try:
+                if has_drift_gate(open(f, encoding='utf-8', errors='replace').read()):
+                    ci_hit = os.path.relpath(f, ws)
+                    break
+            except OSError:
+                pass
+        if ci_hit:
+            break
+    if ci_hit:
+        try:
+            vs = open(script, encoding='utf-8', errors='replace').read()
+        except OSError:
+            vs = ''
+        if not has_drift_gate(vs):
+            rc = 3
+            out = out + chr(10) + 'DRIFT GATE MISSING: CI (' + ci_hit + ') enforces a codegen-drift gate but ' + script + ' has none -- edit the script per the verify-build skill section 1b (run the repo regen command, then: git diff --exit-code).'
+    if rc == 0 and pre is not None:
+        post = tree_state()
+        if post is not None:
+            fresh = sorted(post - pre)
+            if fresh:
+                rc = 4
+                out = out + chr(10) + 'UNCOMMITTED REGEN OUTPUT: a green verify left new changes in the tree; commit (or gitignore) them:' + chr(10) + chr(10).join(fresh[:50])
 try:
     with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
         lf.write(out)

--- a/bots/branch-improve-loop/skills/verify-build.md
+++ b/bots/branch-improve-loop/skills/verify-build.md
@@ -90,6 +90,13 @@ part of the work — the gate is here to force it. (iterion specifically:
 `task openapi:check` + the helm chart drift check are CI gates; a new
 `/api/...` route needs `task openapi:gen` committed.)
 
+This section is **deterministically enforced** by the verify gate: when the
+repo's CI config contains a drift gate and your `verify.sh` has no
+`git diff --exit-code`/`--quiet` line, the gate fails with a DRIFT GATE
+MISSING error; and a green verify that leaves new changes in the tree fails
+with UNCOMMITTED REGEN OUTPUT. Writing the gate here is cheaper than being
+bounced by the enforcement.
+
 ## 2. Write the verify script to the scratch dir
 
 Write an executable POSIX-sh script at the exact `verify.sh` path your task

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -608,6 +608,15 @@ script = os.path.join(scratch, 'verify.sh')
 if not os.path.exists(script):
     print(json.dumps({'passed': False, 'skipped': True, 'exit_code': 1, 'log_tail': 'verify_build produced no verify.sh -- refusing to commit an unverified alignment (fail-closed: this gate is the only path to commit).'}))
     raise SystemExit(0)
+def tree_state():
+    try:
+        p = subprocess.run(['git', '-C', ws, 'status', '--porcelain'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=60)
+        if p.returncode != 0:
+            return None
+        return set(l for l in p.stdout.splitlines() if l.strip())
+    except Exception:
+        return None
+pre = tree_state()
 rc = 0
 out = ''
 try:
@@ -620,6 +629,43 @@ except subprocess.TimeoutExpired as e:
 except Exception as e:
     out = 'verify_run could not execute the script: ' + str(e)
     rc = 1
+# Deterministic codegen-drift tail (stack-agnostic; the gate stays
+# deterministic per ADR-044). Only on a GREEN verify: (1) if the repo's own
+# CI enforces a drift gate, verify.sh must mirror it; (2) a green verify
+# must not leave new changes in the tree (regen output belongs in a commit).
+if rc == 0:
+    import glob
+    def has_drift_gate(text):
+        for l in text.splitlines():
+            if ('diff' in l and ('--exit-code' in l or '--quiet' in l)) or 'status --porcelain' in l:
+                return True
+        return False
+    ci_hit = ''
+    for pat in ('.github/workflows/*.yml', '.github/workflows/*.yaml', '.gitlab-ci.yml', '.circleci/config.yml'):
+        for f in sorted(glob.glob(os.path.join(ws, pat))):
+            try:
+                if has_drift_gate(open(f, encoding='utf-8', errors='replace').read()):
+                    ci_hit = os.path.relpath(f, ws)
+                    break
+            except OSError:
+                pass
+        if ci_hit:
+            break
+    if ci_hit:
+        try:
+            vs = open(script, encoding='utf-8', errors='replace').read()
+        except OSError:
+            vs = ''
+        if not has_drift_gate(vs):
+            rc = 3
+            out = out + chr(10) + 'DRIFT GATE MISSING: CI (' + ci_hit + ') enforces a codegen-drift gate but ' + script + ' has none -- edit the script per the verify-build skill section 1b (run the repo regen command, then: git diff --exit-code).'
+    if rc == 0 and pre is not None:
+        post = tree_state()
+        if post is not None:
+            fresh = sorted(post - pre)
+            if fresh:
+                rc = 4
+                out = out + chr(10) + 'UNCOMMITTED REGEN OUTPUT: a green verify left new changes in the tree; commit (or gitignore) them:' + chr(10) + chr(10).join(fresh[:50])
 try:
     with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
         lf.write(out)

--- a/bots/dep-update-guard/skills/verify-build.md
+++ b/bots/dep-update-guard/skills/verify-build.md
@@ -90,6 +90,13 @@ part of the work — the gate is here to force it. (iterion specifically:
 `task openapi:check` + the helm chart drift check are CI gates; a new
 `/api/...` route needs `task openapi:gen` committed.)
 
+This section is **deterministically enforced** by the verify gate: when the
+repo's CI config contains a drift gate and your `verify.sh` has no
+`git diff --exit-code`/`--quiet` line, the gate fails with a DRIFT GATE
+MISSING error; and a green verify that leaves new changes in the tree fails
+with UNCOMMITTED REGEN OUTPUT. Writing the gate here is cheaper than being
+bounced by the enforcement.
+
 ## 2. Write the verify script to the scratch dir
 
 Write an executable POSIX-sh script at the exact `verify.sh` path your task

--- a/bots/docs-refresh/main.bot
+++ b/bots/docs-refresh/main.bot
@@ -1481,6 +1481,15 @@ script = os.path.join(scratch, 'verify.sh')
 if not os.path.exists(script):
     print(json.dumps({'passed': True, 'skipped': True, 'exit_code': 0, 'log_tail': 'verify_build produced no verify.sh in the scratch dir; build gate SKIPPED (counted as pass, but surfaced) -- verify_build should write the script'}))
     raise SystemExit(0)
+def tree_state():
+    try:
+        p = subprocess.run(['git', '-C', ws, 'status', '--porcelain'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=60)
+        if p.returncode != 0:
+            return None
+        return set(l for l in p.stdout.splitlines() if l.strip())
+    except Exception:
+        return None
+pre = tree_state()
 rc = 0
 out = ''
 try:
@@ -1493,6 +1502,43 @@ except subprocess.TimeoutExpired as e:
 except Exception as e:
     out = 'verify_run could not execute the script: ' + str(e)
     rc = 1
+# Deterministic codegen-drift tail (stack-agnostic; the gate stays
+# deterministic per ADR-044). Only on a GREEN verify: (1) if the repo's own
+# CI enforces a drift gate, verify.sh must mirror it; (2) a green verify
+# must not leave new changes in the tree (regen output belongs in a commit).
+if rc == 0:
+    import glob
+    def has_drift_gate(text):
+        for l in text.splitlines():
+            if ('diff' in l and ('--exit-code' in l or '--quiet' in l)) or 'status --porcelain' in l:
+                return True
+        return False
+    ci_hit = ''
+    for pat in ('.github/workflows/*.yml', '.github/workflows/*.yaml', '.gitlab-ci.yml', '.circleci/config.yml'):
+        for f in sorted(glob.glob(os.path.join(ws, pat))):
+            try:
+                if has_drift_gate(open(f, encoding='utf-8', errors='replace').read()):
+                    ci_hit = os.path.relpath(f, ws)
+                    break
+            except OSError:
+                pass
+        if ci_hit:
+            break
+    if ci_hit:
+        try:
+            vs = open(script, encoding='utf-8', errors='replace').read()
+        except OSError:
+            vs = ''
+        if not has_drift_gate(vs):
+            rc = 3
+            out = out + chr(10) + 'DRIFT GATE MISSING: CI (' + ci_hit + ') enforces a codegen-drift gate but ' + script + ' has none -- edit the script per the verify-build skill section 1b (run the repo regen command, then: git diff --exit-code).'
+    if rc == 0 and pre is not None:
+        post = tree_state()
+        if post is not None:
+            fresh = sorted(post - pre)
+            if fresh:
+                rc = 4
+                out = out + chr(10) + 'UNCOMMITTED REGEN OUTPUT: a green verify left new changes in the tree; commit (or gitignore) them:' + chr(10) + chr(10).join(fresh[:50])
 try:
     with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
         lf.write(out)

--- a/bots/docs-refresh/skills/verify-build.md
+++ b/bots/docs-refresh/skills/verify-build.md
@@ -90,6 +90,13 @@ part of the work — the gate is here to force it. (iterion specifically:
 `task openapi:check` + the helm chart drift check are CI gates; a new
 `/api/...` route needs `task openapi:gen` committed.)
 
+This section is **deterministically enforced** by the verify gate: when the
+repo's CI config contains a drift gate and your `verify.sh` has no
+`git diff --exit-code`/`--quiet` line, the gate fails with a DRIFT GATE
+MISSING error; and a green verify that leaves new changes in the tree fails
+with UNCOMMITTED REGEN OUTPUT. Writing the gate here is cheaper than being
+bounced by the enforcement.
+
 ## 2. Write the verify script to the scratch dir
 
 Write an executable POSIX-sh script at the exact `verify.sh` path your task

--- a/bots/feature-dev/main.bot
+++ b/bots/feature-dev/main.bot
@@ -623,6 +623,15 @@ script = os.path.join(scratch, 'verify.sh')
 if not os.path.exists(script):
     print(json.dumps({'passed': True, 'skipped': True, 'exit_code': 0, 'log_tail': 'verify_build produced no verify.sh in the scratch dir; build/test gate SKIPPED (counted as pass, but surfaced) -- verify_build should write the script'}))
     raise SystemExit(0)
+def tree_state():
+    try:
+        p = subprocess.run(['git', '-C', ws, 'status', '--porcelain'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=60)
+        if p.returncode != 0:
+            return None
+        return set(l for l in p.stdout.splitlines() if l.strip())
+    except Exception:
+        return None
+pre = tree_state()
 rc = 0
 out = ''
 try:
@@ -635,6 +644,43 @@ except subprocess.TimeoutExpired as e:
 except Exception as e:
     out = 'verify_run could not execute the script: ' + str(e)
     rc = 1
+# Deterministic codegen-drift tail (stack-agnostic; the gate stays
+# deterministic per ADR-044). Only on a GREEN verify: (1) if the repo's own
+# CI enforces a drift gate, verify.sh must mirror it; (2) a green verify
+# must not leave new changes in the tree (regen output belongs in a commit).
+if rc == 0:
+    import glob
+    def has_drift_gate(text):
+        for l in text.splitlines():
+            if ('diff' in l and ('--exit-code' in l or '--quiet' in l)) or 'status --porcelain' in l:
+                return True
+        return False
+    ci_hit = ''
+    for pat in ('.github/workflows/*.yml', '.github/workflows/*.yaml', '.gitlab-ci.yml', '.circleci/config.yml'):
+        for f in sorted(glob.glob(os.path.join(ws, pat))):
+            try:
+                if has_drift_gate(open(f, encoding='utf-8', errors='replace').read()):
+                    ci_hit = os.path.relpath(f, ws)
+                    break
+            except OSError:
+                pass
+        if ci_hit:
+            break
+    if ci_hit:
+        try:
+            vs = open(script, encoding='utf-8', errors='replace').read()
+        except OSError:
+            vs = ''
+        if not has_drift_gate(vs):
+            rc = 3
+            out = out + chr(10) + 'DRIFT GATE MISSING: CI (' + ci_hit + ') enforces a codegen-drift gate but ' + script + ' has none -- edit the script per the verify-build skill section 1b (run the repo regen command, then: git diff --exit-code).'
+    if rc == 0 and pre is not None:
+        post = tree_state()
+        if post is not None:
+            fresh = sorted(post - pre)
+            if fresh:
+                rc = 4
+                out = out + chr(10) + 'UNCOMMITTED REGEN OUTPUT: a green verify left new changes in the tree; commit (or gitignore) them:' + chr(10) + chr(10).join(fresh[:50])
 try:
     with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
         lf.write(out)

--- a/bots/feature-dev/skills/verify-build.md
+++ b/bots/feature-dev/skills/verify-build.md
@@ -90,6 +90,13 @@ part of the work — the gate is here to force it. (iterion specifically:
 `task openapi:check` + the helm chart drift check are CI gates; a new
 `/api/...` route needs `task openapi:gen` committed.)
 
+This section is **deterministically enforced** by the verify gate: when the
+repo's CI config contains a drift gate and your `verify.sh` has no
+`git diff --exit-code`/`--quiet` line, the gate fails with a DRIFT GATE
+MISSING error; and a green verify that leaves new changes in the tree fails
+with UNCOMMITTED REGEN OUTPUT. Writing the gate here is cheaper than being
+bounced by the enforcement.
+
 ## 2. Write the verify script to the scratch dir
 
 Write an executable POSIX-sh script at the exact `verify.sh` path your task

--- a/bots/feature-gap-fill/main.bot
+++ b/bots/feature-gap-fill/main.bot
@@ -417,6 +417,15 @@ script = os.path.join(scratch, 'verify.sh')
 if not os.path.exists(script):
     print(json.dumps({'passed': True, 'skipped': True, 'exit_code': 0, 'log_tail': 'verify_build produced no verify.sh in the scratch dir; build/test gate SKIPPED (counted as pass, but surfaced) -- verify_build should write the script'}))
     raise SystemExit(0)
+def tree_state():
+    try:
+        p = subprocess.run(['git', '-C', ws, 'status', '--porcelain'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=60)
+        if p.returncode != 0:
+            return None
+        return set(l for l in p.stdout.splitlines() if l.strip())
+    except Exception:
+        return None
+pre = tree_state()
 rc = 0
 out = ''
 try:
@@ -429,6 +438,43 @@ except subprocess.TimeoutExpired as e:
 except Exception as e:
     out = 'verify_run could not execute the script: ' + str(e)
     rc = 1
+# Deterministic codegen-drift tail (stack-agnostic; the gate stays
+# deterministic per ADR-044). Only on a GREEN verify: (1) if the repo's own
+# CI enforces a drift gate, verify.sh must mirror it; (2) a green verify
+# must not leave new changes in the tree (regen output belongs in a commit).
+if rc == 0:
+    import glob
+    def has_drift_gate(text):
+        for l in text.splitlines():
+            if ('diff' in l and ('--exit-code' in l or '--quiet' in l)) or 'status --porcelain' in l:
+                return True
+        return False
+    ci_hit = ''
+    for pat in ('.github/workflows/*.yml', '.github/workflows/*.yaml', '.gitlab-ci.yml', '.circleci/config.yml'):
+        for f in sorted(glob.glob(os.path.join(ws, pat))):
+            try:
+                if has_drift_gate(open(f, encoding='utf-8', errors='replace').read()):
+                    ci_hit = os.path.relpath(f, ws)
+                    break
+            except OSError:
+                pass
+        if ci_hit:
+            break
+    if ci_hit:
+        try:
+            vs = open(script, encoding='utf-8', errors='replace').read()
+        except OSError:
+            vs = ''
+        if not has_drift_gate(vs):
+            rc = 3
+            out = out + chr(10) + 'DRIFT GATE MISSING: CI (' + ci_hit + ') enforces a codegen-drift gate but ' + script + ' has none -- edit the script per the verify-build skill section 1b (run the repo regen command, then: git diff --exit-code).'
+    if rc == 0 and pre is not None:
+        post = tree_state()
+        if post is not None:
+            fresh = sorted(post - pre)
+            if fresh:
+                rc = 4
+                out = out + chr(10) + 'UNCOMMITTED REGEN OUTPUT: a green verify left new changes in the tree; commit (or gitignore) them:' + chr(10) + chr(10).join(fresh[:50])
 try:
     with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
         lf.write(out)

--- a/bots/feature-gap-fill/skills/verify-build.md
+++ b/bots/feature-gap-fill/skills/verify-build.md
@@ -90,6 +90,13 @@ part of the work — the gate is here to force it. (iterion specifically:
 `task openapi:check` + the helm chart drift check are CI gates; a new
 `/api/...` route needs `task openapi:gen` committed.)
 
+This section is **deterministically enforced** by the verify gate: when the
+repo's CI config contains a drift gate and your `verify.sh` has no
+`git diff --exit-code`/`--quiet` line, the gate fails with a DRIFT GATE
+MISSING error; and a green verify that leaves new changes in the tree fails
+with UNCOMMITTED REGEN OUTPUT. Writing the gate here is cheaper than being
+bounced by the enforcement.
+
 ## 2. Write the verify script to the scratch dir
 
 Write an executable POSIX-sh script at the exact `verify.sh` path your task

--- a/bots/secured-renovacy/main.bot
+++ b/bots/secured-renovacy/main.bot
@@ -2987,6 +2987,15 @@ script = os.path.join(scratch, 'verify.sh')
 if not os.path.exists(script):
     print(json.dumps({'passed': True, 'skipped': True, 'exit_code': 0, 'log_tail': 'p2_verify_build produced no verify.sh; build gate SKIPPED (counted as pass, but surfaced)'}))
     raise SystemExit(0)
+def tree_state():
+    try:
+        p = subprocess.run(['git', '-C', ws, 'status', '--porcelain'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=60)
+        if p.returncode != 0:
+            return None
+        return set(l for l in p.stdout.splitlines() if l.strip())
+    except Exception:
+        return None
+pre = tree_state()
 rc = 0
 out = ''
 try:
@@ -2999,6 +3008,43 @@ except subprocess.TimeoutExpired as e:
 except Exception as e:
     out = 'p2_verify_run could not execute the script: ' + str(e)
     rc = 1
+# Deterministic codegen-drift tail (stack-agnostic; the gate stays
+# deterministic per ADR-044). Only on a GREEN verify: (1) if the repo's own
+# CI enforces a drift gate, verify.sh must mirror it; (2) a green verify
+# must not leave new changes in the tree (regen output belongs in a commit).
+if rc == 0:
+    import glob
+    def has_drift_gate(text):
+        for l in text.splitlines():
+            if ('diff' in l and ('--exit-code' in l or '--quiet' in l)) or 'status --porcelain' in l:
+                return True
+        return False
+    ci_hit = ''
+    for pat in ('.github/workflows/*.yml', '.github/workflows/*.yaml', '.gitlab-ci.yml', '.circleci/config.yml'):
+        for f in sorted(glob.glob(os.path.join(ws, pat))):
+            try:
+                if has_drift_gate(open(f, encoding='utf-8', errors='replace').read()):
+                    ci_hit = os.path.relpath(f, ws)
+                    break
+            except OSError:
+                pass
+        if ci_hit:
+            break
+    if ci_hit:
+        try:
+            vs = open(script, encoding='utf-8', errors='replace').read()
+        except OSError:
+            vs = ''
+        if not has_drift_gate(vs):
+            rc = 3
+            out = out + chr(10) + 'DRIFT GATE MISSING: CI (' + ci_hit + ') enforces a codegen-drift gate but ' + script + ' has none -- edit the script per the verify-build skill section 1b (run the repo regen command, then: git diff --exit-code).'
+    if rc == 0 and pre is not None:
+        post = tree_state()
+        if post is not None:
+            fresh = sorted(post - pre)
+            if fresh:
+                rc = 4
+                out = out + chr(10) + 'UNCOMMITTED REGEN OUTPUT: a green verify left new changes in the tree; commit (or gitignore) them:' + chr(10) + chr(10).join(fresh[:50])
 try:
     with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
         lf.write(out)

--- a/bots/secured-renovacy/skills/verify-build.md
+++ b/bots/secured-renovacy/skills/verify-build.md
@@ -90,6 +90,13 @@ part of the work — the gate is here to force it. (iterion specifically:
 `task openapi:check` + the helm chart drift check are CI gates; a new
 `/api/...` route needs `task openapi:gen` committed.)
 
+This section is **deterministically enforced** by the verify gate: when the
+repo's CI config contains a drift gate and your `verify.sh` has no
+`git diff --exit-code`/`--quiet` line, the gate fails with a DRIFT GATE
+MISSING error; and a green verify that leaves new changes in the tree fails
+with UNCOMMITTED REGEN OUTPUT. Writing the gate here is cheaper than being
+bounced by the enforcement.
+
 ## 2. Write the verify script to the scratch dir
 
 Write an executable POSIX-sh script at the exact `verify.sh` path your task

--- a/bots/test-coverage/main.bot
+++ b/bots/test-coverage/main.bot
@@ -439,6 +439,15 @@ if not os.path.exists(script):
     rc = 0
     out = 'verify_build produced no verify.sh in the scratch dir; build/test gate SKIPPED (counted as pass, but surfaced) -- verify_build should write the script'
 else:
+    def tree_state():
+        try:
+            p = subprocess.run(['git', '-C', ws, 'status', '--porcelain'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=60)
+            if p.returncode != 0:
+                return None
+            return set(l for l in p.stdout.splitlines() if l.strip())
+        except Exception:
+            return None
+    pre = tree_state()
     rc = 0
     out = ''
     try:
@@ -451,6 +460,43 @@ else:
     except Exception as e:
         out = 'verify_run could not execute the script: ' + str(e)
         rc = 1
+    # Deterministic codegen-drift tail (stack-agnostic; the gate stays
+    # deterministic per ADR-044). Only on a GREEN verify: (1) if the repo's own
+    # CI enforces a drift gate, verify.sh must mirror it; (2) a green verify
+    # must not leave new changes in the tree (regen output belongs in a commit).
+    if rc == 0:
+        import glob
+        def has_drift_gate(text):
+            for l in text.splitlines():
+                if ('diff' in l and ('--exit-code' in l or '--quiet' in l)) or 'status --porcelain' in l:
+                    return True
+            return False
+        ci_hit = ''
+        for pat in ('.github/workflows/*.yml', '.github/workflows/*.yaml', '.gitlab-ci.yml', '.circleci/config.yml'):
+            for f in sorted(glob.glob(os.path.join(ws, pat))):
+                try:
+                    if has_drift_gate(open(f, encoding='utf-8', errors='replace').read()):
+                        ci_hit = os.path.relpath(f, ws)
+                        break
+                except OSError:
+                    pass
+            if ci_hit:
+                break
+        if ci_hit:
+            try:
+                vs = open(script, encoding='utf-8', errors='replace').read()
+            except OSError:
+                vs = ''
+            if not has_drift_gate(vs):
+                rc = 3
+                out = out + chr(10) + 'DRIFT GATE MISSING: CI (' + ci_hit + ') enforces a codegen-drift gate but ' + script + ' has none -- edit the script per the verify-build skill section 1b (run the repo regen command, then: git diff --exit-code).'
+        if rc == 0 and pre is not None:
+            post = tree_state()
+            if post is not None:
+                fresh = sorted(post - pre)
+                if fresh:
+                    rc = 4
+                    out = out + chr(10) + 'UNCOMMITTED REGEN OUTPUT: a green verify left new changes in the tree; commit (or gitignore) them:' + chr(10) + chr(10).join(fresh[:50])
     passed = rc == 0
     try:
         with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:

--- a/bots/test-coverage/skills/verify-build.md
+++ b/bots/test-coverage/skills/verify-build.md
@@ -90,6 +90,13 @@ part of the work — the gate is here to force it. (iterion specifically:
 `task openapi:check` + the helm chart drift check are CI gates; a new
 `/api/...` route needs `task openapi:gen` committed.)
 
+This section is **deterministically enforced** by the verify gate: when the
+repo's CI config contains a drift gate and your `verify.sh` has no
+`git diff --exit-code`/`--quiet` line, the gate fails with a DRIFT GATE
+MISSING error; and a green verify that leaves new changes in the tree fails
+with UNCOMMITTED REGEN OUTPUT. Writing the gate here is cheaper than being
+bounced by the enforcement.
+
 ## 2. Write the verify script to the scratch dir
 
 Write an executable POSIX-sh script at the exact `verify.sh` path your task

--- a/bots/verify_run_drift_test.go
+++ b/bots/verify_run_drift_test.go
@@ -1,0 +1,219 @@
+package bots
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+)
+
+// TestVerifyRunDriftTail guards the deterministic codegen-drift tail shared
+// by the catalog bots' verify_run gate. The verify-build SKILL teaches the
+// agent to mirror CI's drift gates in verify.sh, but prose alone was gamed
+// twice (OpenAPI drift shipped green-locally / red-in-CI): the agent copies
+// the example and omits the gate. The tail makes the gate deterministic:
+//
+//  1. CI-mirror assertion — if the repo's own CI config enforces a drift
+//     gate (git diff --exit-code / --quiet / status --porcelain), verify.sh
+//     must contain one too, else the gate fails with an instructive log.
+//  2. Post-verify tree-drift — a GREEN verify must not leave new changes in
+//     the tree (regen output belongs in a commit), else the gate fails and
+//     names the paths.
+//
+// The test extracts the verify_run command from feature-dev's compiled IR
+// (byte-shared with whole/branch-improve-loop + feature-gap-fill, guarded by
+// the bundle-consistency test) and executes it for real against fixtures.
+func TestVerifyRunDriftTail(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	command := verifyRunCommand(t, "feature-dev/main.bot")
+
+	type verifyResult struct {
+		Passed   bool   `json:"passed"`
+		Skipped  bool   `json:"skipped"`
+		ExitCode int    `json:"exit_code"`
+		LogTail  string `json:"log_tail"`
+	}
+
+	run := func(t *testing.T, ws, scratch string) verifyResult {
+		t.Helper()
+		cmd := strings.ReplaceAll(command, "{{vars.workspace_dir}}", ws)
+		cmd = strings.ReplaceAll(cmd, "{{vars.scratch_dir}}", scratch)
+		out, err := exec.Command("sh", "-c", cmd).Output()
+		if err != nil {
+			t.Fatalf("verify_run command failed to execute: %v (out %q)", err, out)
+		}
+		var res verifyResult
+		if uerr := json.Unmarshal(out, &res); uerr != nil {
+			t.Fatalf("verify_run output is not the verify_result JSON: %v (out %q)", uerr, out)
+		}
+		return res
+	}
+
+	gitWorkspace := func(t *testing.T) string {
+		t.Helper()
+		ws := t.TempDir()
+		if out, err := exec.Command("git", "-C", ws, "init", "-q").CombinedOutput(); err != nil {
+			t.Fatalf("git init: %v (%s)", err, out)
+		}
+		return ws
+	}
+
+	writeVerifySh := func(t *testing.T, scratch, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ciWithDriftGate := func(t *testing.T, ws string) {
+		t.Helper()
+		dir := filepath.Join(ws, ".github", "workflows")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		yml := "jobs:\n  test:\n    steps:\n      - run: |\n          task openapi:gen\n          git diff --exit-code openapi.json\n"
+		if err := os.WriteFile(filepath.Join(dir, "ci.yml"), []byte(yml), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("ci_gate_missing_from_verify_sh_fails", func(t *testing.T) {
+		ws, scratch := gitWorkspace(t), t.TempDir()
+		ciWithDriftGate(t, ws)
+		writeVerifySh(t, scratch, "#!/bin/sh\nexit 0\n") // gateless
+		res := run(t, ws, scratch)
+		if res.Passed {
+			t.Fatalf("gateless verify.sh must fail when CI enforces a drift gate: %+v", res)
+		}
+		if !strings.Contains(res.LogTail, "DRIFT GATE MISSING") || !strings.Contains(res.LogTail, "section 1b") {
+			t.Fatalf("log_tail must carry the instructive drift message, got %q", res.LogTail)
+		}
+	})
+
+	t.Run("green_verify_leaving_new_tree_changes_fails", func(t *testing.T) {
+		ws, scratch := gitWorkspace(t), t.TempDir() // no CI config → assertion 1 skipped
+		writeVerifySh(t, scratch, "#!/bin/sh\necho generated > gen-out.txt\nexit 0\n")
+		res := run(t, ws, scratch)
+		if res.Passed {
+			t.Fatalf("a green verify that dirties the tree must fail: %+v", res)
+		}
+		if !strings.Contains(res.LogTail, "UNCOMMITTED REGEN OUTPUT") || !strings.Contains(res.LogTail, "gen-out.txt") {
+			t.Fatalf("log_tail must name the leftover paths, got %q", res.LogTail)
+		}
+	})
+
+	t.Run("clean_green_verify_passes", func(t *testing.T) {
+		ws, scratch := gitWorkspace(t), t.TempDir()
+		writeVerifySh(t, scratch, "#!/bin/sh\nexit 0\n")
+		res := run(t, ws, scratch)
+		if !res.Passed || res.ExitCode != 0 {
+			t.Fatalf("clean green verify must pass: %+v", res)
+		}
+	})
+
+	t.Run("ci_gate_mirrored_in_verify_sh_passes", func(t *testing.T) {
+		ws, scratch := gitWorkspace(t), t.TempDir()
+		ciWithDriftGate(t, ws)
+		writeVerifySh(t, scratch, "#!/bin/sh\ngit diff --exit-code\n")
+		res := run(t, ws, scratch)
+		if !res.Passed {
+			t.Fatalf("verify.sh mirroring the CI drift gate must pass: %+v", res)
+		}
+	})
+
+	t.Run("red_verify_reports_real_exit_code_unchanged", func(t *testing.T) {
+		ws, scratch := gitWorkspace(t), t.TempDir()
+		writeVerifySh(t, scratch, "#!/bin/sh\nexit 7\n")
+		res := run(t, ws, scratch)
+		if res.Passed || res.ExitCode != 7 {
+			t.Fatalf("red verify must keep its real exit code: %+v", res)
+		}
+	})
+
+	t.Run("missing_verify_sh_still_skips", func(t *testing.T) {
+		ws, scratch := gitWorkspace(t), t.TempDir()
+		res := run(t, ws, scratch)
+		if !res.Passed || !res.Skipped {
+			t.Fatalf("missing verify.sh must keep the surfaced-skip contract: %+v", res)
+		}
+	})
+
+	t.Run("non_git_workspace_degrades_gracefully", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir() // no .git → tree_state None → drift check 2 skipped
+		writeVerifySh(t, scratch, "#!/bin/sh\necho artifact > out.txt\nexit 0\n")
+		res := run(t, ws, scratch)
+		if !res.Passed {
+			t.Fatalf("non-git workspace must not fail on the drift tail: %+v", res)
+		}
+	})
+}
+
+// TestVerifyRunDriftTailPresentInAllBots asserts every catalog bot carrying a
+// verify_run-style gate ships the deterministic drift tail (the body is
+// copy-pasted per bot — no DSL include — so a new bot or an edit can silently
+// drop it).
+func TestVerifyRunDriftTailPresentInAllBots(t *testing.T) {
+	bots := map[string]string{
+		"feature-dev/main.bot":         "verify_run",
+		"whole-improve-loop/main.bot":  "verify_run",
+		"branch-improve-loop/main.bot": "verify_run",
+		"feature-gap-fill/main.bot":    "verify_run",
+		"test-coverage/main.bot":       "verify_run",
+		"dep-update-guard/main.bot":    "verify_run",
+		"adr-cartograph/main.bot":      "verify_run",
+		"docs-refresh/main.bot":        "verify_run",
+		"secured-renovacy/main.bot":    "p2_verify_run",
+	}
+	for rel, node := range bots {
+		t.Run(rel, func(t *testing.T) {
+			cmd := toolCommand(t, rel, node)
+			for _, marker := range []string{"tree_state", "DRIFT GATE MISSING", "UNCOMMITTED REGEN OUTPUT"} {
+				if !strings.Contains(cmd, marker) {
+					t.Errorf("%s %s lacks the deterministic drift tail (missing %q)", rel, node, marker)
+				}
+			}
+		})
+	}
+}
+
+// verifyRunCommand compiles a bot and returns its verify_run tool command.
+func verifyRunCommand(t *testing.T, rel string) string {
+	t.Helper()
+	return toolCommand(t, rel, "verify_run")
+}
+
+func toolCommand(t *testing.T, rel, node string) string {
+	t.Helper()
+	src, err := os.ReadFile(rel)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	pr := parser.Parse(rel, string(src))
+	if pr.File == nil {
+		t.Fatalf("parse produced no File")
+	}
+	cr := ir.Compile(pr.File)
+	if cr.Workflow == nil {
+		t.Fatalf("compile produced no Workflow")
+	}
+	raw, ok := cr.Workflow.Nodes[node]
+	if !ok {
+		t.Fatalf("no %s node", node)
+	}
+	tn, ok := raw.(*ir.ToolNode)
+	if !ok {
+		t.Fatalf("%s is %T, want *ir.ToolNode", node, raw)
+	}
+	return tn.Command
+}

--- a/bots/whole-improve-loop/main.bot
+++ b/bots/whole-improve-loop/main.bot
@@ -511,6 +511,15 @@ script = os.path.join(scratch, 'verify.sh')
 if not os.path.exists(script):
     print(json.dumps({'passed': True, 'skipped': True, 'exit_code': 0, 'log_tail': 'verify_build produced no verify.sh in the scratch dir; build/test gate SKIPPED (counted as pass, but surfaced) -- verify_build should write the script'}))
     raise SystemExit(0)
+def tree_state():
+    try:
+        p = subprocess.run(['git', '-C', ws, 'status', '--porcelain'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=60)
+        if p.returncode != 0:
+            return None
+        return set(l for l in p.stdout.splitlines() if l.strip())
+    except Exception:
+        return None
+pre = tree_state()
 rc = 0
 out = ''
 try:
@@ -523,6 +532,43 @@ except subprocess.TimeoutExpired as e:
 except Exception as e:
     out = 'verify_run could not execute the script: ' + str(e)
     rc = 1
+# Deterministic codegen-drift tail (stack-agnostic; the gate stays
+# deterministic per ADR-044). Only on a GREEN verify: (1) if the repo's own
+# CI enforces a drift gate, verify.sh must mirror it; (2) a green verify
+# must not leave new changes in the tree (regen output belongs in a commit).
+if rc == 0:
+    import glob
+    def has_drift_gate(text):
+        for l in text.splitlines():
+            if ('diff' in l and ('--exit-code' in l or '--quiet' in l)) or 'status --porcelain' in l:
+                return True
+        return False
+    ci_hit = ''
+    for pat in ('.github/workflows/*.yml', '.github/workflows/*.yaml', '.gitlab-ci.yml', '.circleci/config.yml'):
+        for f in sorted(glob.glob(os.path.join(ws, pat))):
+            try:
+                if has_drift_gate(open(f, encoding='utf-8', errors='replace').read()):
+                    ci_hit = os.path.relpath(f, ws)
+                    break
+            except OSError:
+                pass
+        if ci_hit:
+            break
+    if ci_hit:
+        try:
+            vs = open(script, encoding='utf-8', errors='replace').read()
+        except OSError:
+            vs = ''
+        if not has_drift_gate(vs):
+            rc = 3
+            out = out + chr(10) + 'DRIFT GATE MISSING: CI (' + ci_hit + ') enforces a codegen-drift gate but ' + script + ' has none -- edit the script per the verify-build skill section 1b (run the repo regen command, then: git diff --exit-code).'
+    if rc == 0 and pre is not None:
+        post = tree_state()
+        if post is not None:
+            fresh = sorted(post - pre)
+            if fresh:
+                rc = 4
+                out = out + chr(10) + 'UNCOMMITTED REGEN OUTPUT: a green verify left new changes in the tree; commit (or gitignore) them:' + chr(10) + chr(10).join(fresh[:50])
 try:
     with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
         lf.write(out)

--- a/bots/whole-improve-loop/skills/verify-build.md
+++ b/bots/whole-improve-loop/skills/verify-build.md
@@ -90,6 +90,13 @@ part of the work — the gate is here to force it. (iterion specifically:
 `task openapi:check` + the helm chart drift check are CI gates; a new
 `/api/...` route needs `task openapi:gen` committed.)
 
+This section is **deterministically enforced** by the verify gate: when the
+repo's CI config contains a drift gate and your `verify.sh` has no
+`git diff --exit-code`/`--quiet` line, the gate fails with a DRIFT GATE
+MISSING error; and a green verify that leaves new changes in the tree fails
+with UNCOMMITTED REGEN OUTPUT. Writing the gate here is cheaper than being
+bounced by the enforcement.
+
 ## 2. Write the verify script to the scratch dir
 
 Write an executable POSIX-sh script at the exact `verify.sh` path your task

--- a/docs/bot-runs/feature-dev.md
+++ b/docs/bot-runs/feature-dev.md
@@ -48,6 +48,13 @@
   in prose; (b) contain forfait spend — a long multi-wave campaign can deplete org credit
   mid-flight (finish stragglers from a credited local session); (c) `--merge-into none` +
   `post_to_board=false` on every dogfood launch kept the operator's tree clean.
+- Réserves closed (2026-07-14 follow-up): **awaiting-input validated live** on a local
+  `iterion dispatch` (legacy board auto-migrated, pause → card into the column, CLI resume →
+  new `reconcileParked` sweep moves it to review) — the validation surfaced 3 engine gaps
+  (no board migration for existing stores, parked cards stranded after out-of-band resume,
+  `iterion dispatch` re-run exiting on "already running"), all fixed; and the **verify-build
+  drift gate is now deterministic** (CI-mirror assertion + post-verify tree-drift check in
+  every verify_run body, all 9 bots), not just skill prose.
 
 ## 2026-07-09 — first CLOUD runs: label an issue → implement → open a PR (runs 019f4590 / 019f45dd / 019f45f6)
 

--- a/pkg/cli/dispatch.go
+++ b/pkg/cli/dispatch.go
@@ -92,7 +92,13 @@ func RunDispatch(p *Printer, opts DispatchOptions) error {
 	if err := mgr.SaveConfig(cfg); err != nil {
 		return err
 	}
-	if err := mgr.Start(); err != nil {
+	// NewManager auto-starts when the store carries a persisted config
+	// (first-boot intent defaults to Running), so on any re-run of
+	// `iterion dispatch` over the same store the explicit Start finds a
+	// live instance. That IS the desired end state — SaveConfig above
+	// already live-reloaded it with this invocation's config — so treat
+	// ErrAlreadyRunning as success instead of exiting the daemon.
+	if err := mgr.Start(); err != nil && !errors.Is(err, dispatcher.ErrAlreadyRunning) {
 		return err
 	}
 	// Shutdown preserves the operator's last-known intent in

--- a/pkg/dispatcher/loop.go
+++ b/pkg/dispatcher/loop.go
@@ -28,6 +28,7 @@ func (c *Dispatcher) tick(ctx context.Context) {
 
 	c.reconcileStalled(ctx, cfg)
 	c.refreshRunningStates(ctx)
+	c.reconcileParked(ctx)
 
 	if c.paused.Load() {
 		c.fireSnapshot()

--- a/pkg/dispatcher/manager.go
+++ b/pkg/dispatcher/manager.go
@@ -239,6 +239,14 @@ func (m *Manager) SaveConfig(cfg *Config) error {
 	return nil
 }
 
+// ErrAlreadyRunning is returned by Start when a Dispatcher is already
+// live — which NewManager's auto-start makes the NORMAL case for any
+// caller starting explicitly on a store with a persisted config (e.g.
+// `iterion dispatch` re-run on the same store dir). Callers that just
+// need "a dispatcher is running with my config" should treat it as
+// success: SaveConfig live-reloads the running instance.
+var ErrAlreadyRunning = errors.New("manager: already running")
+
 // Start spins up a fresh Dispatcher from the persisted config. Returns
 // an error and stays in StateError when the start sequence fails (bad
 // workflow, missing tracker creds, port conflict, …).
@@ -246,7 +254,7 @@ func (m *Manager) Start() error {
 	m.mu.Lock()
 	if m.cur != nil {
 		m.mu.Unlock()
-		return errors.New("manager: already running")
+		return ErrAlreadyRunning
 	}
 	cfg := m.cfg
 	m.mu.Unlock()

--- a/pkg/dispatcher/native/adapter.go
+++ b/pkg/dispatcher/native/adapter.go
@@ -127,6 +127,28 @@ func (a *Adapter) Release(ctx context.Context, id, marker string) error {
 	return a.store.Release(id, marker)
 }
 
+// ListAwaitingInput returns the cards parked in the awaiting-input
+// column that this dispatcher may reconcile: unclaimed (post-restart,
+// after the stale-claim sweep) or claimed by the given marker. Cards
+// claimed by ANOTHER live daemon sharing the store are excluded — their
+// owner reconciles them. Consumed by the dispatcher's parked sweep
+// (reconcileParked in pkg/dispatcher) via optional-interface assertion,
+// same seam as SetLastRun/SetAwaitingInput.
+func (a *Adapter) ListAwaitingInput(marker string) ([]tracker.Issue, error) {
+	issues, err := a.store.List(ListFilter{States: []string{StateAwaitingInput}})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]tracker.Issue, 0, len(issues))
+	for _, iss := range issues {
+		if iss.Claim != "" && iss.Claim != marker {
+			continue
+		}
+		out = append(out, toTrackerIssue(iss))
+	}
+	return out, nil
+}
+
 // SetLastRun stamps the (runID, workdir) pair on the issue so the
 // dispatcher can pivot from a kanban card back to the run that
 // processed it (studio's IssueModal, the resume fallback in

--- a/pkg/dispatcher/native/store.go
+++ b/pkg/dispatcher/native/store.go
@@ -1328,6 +1328,27 @@ func (s *Store) loadOrInitBoard() error {
 			return fmt.Errorf("native store: persist inbox upgrade: %w", err)
 		}
 	}
+	// Pre-upgrade stores also predate the `awaiting_input` state. Insert it
+	// right after `in_progress` so the dispatcher's paused-run parking
+	// (moveToAwaitingInput) works after upgrade without manual board.json
+	// edits. Boards without an `in_progress` state are fully custom — leave
+	// them untouched; the dispatcher's "stays in place" fallback still applies.
+	if s.board.StateByName(StateAwaitingInput) == nil {
+		for i, st := range s.board.States {
+			if st.Name != StateInProgress {
+				continue
+			}
+			states := make([]State, 0, len(s.board.States)+1)
+			states = append(states, s.board.States[:i+1]...)
+			states = append(states, State{Name: StateAwaitingInput, Display: "Awaiting input"})
+			states = append(states, s.board.States[i+1:]...)
+			s.board.States = states
+			if err := s.writeBoardLocked(); err != nil {
+				return fmt.Errorf("native store: persist awaiting-input upgrade: %w", err)
+			}
+			break
+		}
+	}
 	return nil
 }
 

--- a/pkg/dispatcher/native/store_test.go
+++ b/pkg/dispatcher/native/store_test.go
@@ -85,6 +85,88 @@ func TestNewStorePrependsInboxToLegacyBoard(t *testing.T) {
 	}
 }
 
+func TestNewStoreInsertsAwaitingInputAfterInProgress(t *testing.T) {
+	// Simulate an existing operator's board.json that predates the
+	// `awaiting_input` state — the upgrade path must insert it right
+	// after `in_progress` so the dispatcher's paused-run parking
+	// (moveToAwaitingInput) works without manual board.json edits.
+	dir := t.TempDir()
+	legacy := Board{
+		States: []State{
+			{Name: StateInbox, Display: "Inbox"},
+			{Name: StateReady, Display: "Ready", Eligible: true},
+			{Name: StateInProgress, Display: "In progress", Eligible: true},
+			{Name: StateDone, Display: "Done", Terminal: true},
+		},
+		UpdatedAt: time.Now().UTC(),
+	}
+	data, err := json.MarshalIndent(&legacy, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal legacy board: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "board.json"), data, 0o644); err != nil {
+		t.Fatalf("write legacy board: %v", err)
+	}
+
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	got := s.Board().States
+	if len(got) != 5 {
+		t.Fatalf("want 5 states after awaiting-input insert, got %d: %+v", len(got), got)
+	}
+	if got[2].Name != StateInProgress || got[3].Name != StateAwaitingInput {
+		t.Fatalf("want awaiting_input right after in_progress, got %+v", got)
+	}
+	if got[3].Eligible || got[3].Terminal {
+		t.Fatalf("awaiting_input must be non-eligible, non-terminal: %+v", got[3])
+	}
+
+	// Re-load to confirm the upgrade was persisted and is idempotent.
+	s2, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore (second pass): %v", err)
+	}
+	if len(s2.Board().States) != 5 {
+		t.Fatalf("awaiting_input inserted twice: %+v", s2.Board().States)
+	}
+}
+
+func TestNewStoreLeavesCustomBoardWithoutInProgressUntouched(t *testing.T) {
+	// A fully custom board with no `in_progress` state gets NO
+	// awaiting_input insert — the dispatcher's "stays in place"
+	// fallback covers it.
+	dir := t.TempDir()
+	custom := Board{
+		States: []State{
+			{Name: StateInbox, Display: "Inbox"},
+			{Name: "triage", Display: "Triage", Eligible: true},
+			{Name: "shipped", Display: "Shipped", Terminal: true},
+		},
+		UpdatedAt: time.Now().UTC(),
+	}
+	data, err := json.MarshalIndent(&custom, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal custom board: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "board.json"), data, 0o644); err != nil {
+		t.Fatalf("write custom board: %v", err)
+	}
+
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if got := s.Board().States; len(got) != 3 {
+		t.Fatalf("custom board must be untouched, got %+v", got)
+	}
+	if s.Board().StateByName(StateAwaitingInput) != nil {
+		t.Fatal("awaiting_input must not be inserted into a board without in_progress")
+	}
+}
+
 func TestCreateAndGet(t *testing.T) {
 	s := newTestStore(t)
 	iss, err := s.Create(Issue{Title: "first", State: "ready"})

--- a/pkg/dispatcher/parked.go
+++ b/pkg/dispatcher/parked.go
@@ -1,0 +1,106 @@
+package dispatcher
+
+import (
+	"context"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// reconcileParked sweeps cards parked in the awaiting-input column whose
+// runs have since reached a terminal status. Every resume surface — CLI
+// `iterion resume`, the studio run console, answer-from-board — completes
+// the run OUTSIDE the dispatcher (the pause arm's worker returned when the
+// run parked), so without this sweep the card strands in awaiting_input
+// with its claim retained forever.
+//
+// finished → CompletedState; hard-failed (non-resumable) → FailedState.
+// Resumable statuses (paused_*, failed_resumable, cancelled) and in-flight
+// ones (running, queued) stay parked — the card genuinely still awaits the
+// operator. Native-tracker only (optional-interface seam, same as
+// stampLastRun/setAwaitingInput); every call is local disk I/O, safe on
+// the actor per the ADR-028 Step 3 boundary.
+func (c *Dispatcher) reconcileParked(ctx context.Context) {
+	lister, ok := c.tracker.(interface {
+		ListAwaitingInput(marker string) ([]tracker.Issue, error)
+	})
+	if !ok {
+		return
+	}
+	look, ok := c.tracker.(interface {
+		LastRunForIssue(id string) (string, error)
+	})
+	if !ok {
+		return
+	}
+	parked, err := lister.ListAwaitingInput(c.hostMarker)
+	if err != nil {
+		c.logger.Warn("dispatcher: parked sweep list: %v", err)
+		return
+	}
+	if len(parked) == 0 {
+		return
+	}
+	cfg := c.cfg.Load()
+	moved := false
+	for _, iss := range parked {
+		if _, running := c.state.running[iss.ID]; running {
+			continue // a live worker owns it (e.g. mid re-dispatch)
+		}
+		runID, err := look.LastRunForIssue(iss.ID)
+		if err != nil || runID == "" {
+			continue
+		}
+		var target string
+		switch c.runStatusOnDisk(runID) {
+		case store.RunStatusFinished:
+			target = cfg.Agent.CompletedState
+			c.logger.Info("dispatcher: %s resumed out-of-band and finished (run=%s) — moving awaiting-input card to %q", iss.Identifier, runID, target)
+		case store.RunStatusFailed:
+			target = cfg.Agent.FailedState
+			c.logger.Warn("dispatcher: %s resumed out-of-band and failed hard (run=%s) — moving awaiting-input card to %q", iss.Identifier, runID, target)
+		default:
+			continue // still paused / resumable / in flight — genuinely awaiting the operator
+		}
+		if target == "" || target == native.StateAwaitingInput {
+			continue
+		}
+		c.setAwaitingInput(iss.ID, false)
+		if err := c.tracker.UpdateState(ctx, iss.ID, target); err != nil {
+			c.logger.Warn("dispatcher: parked sweep move %s → %q: %v", iss.Identifier, target, err)
+			continue
+		}
+		// Transition FIRST, Release LAST (same ordering as the finish
+		// worker): the claim keeps ListCandidates away until the card is
+		// in its final, mostly-non-eligible state.
+		if err := c.tracker.Release(ctx, iss.ID, c.hostMarker); err != nil {
+			c.logger.Warn("dispatcher: parked sweep release %s: %v", iss.Identifier, err)
+		}
+		c.claims.Remove(iss.ID)
+		moved = true
+	}
+	if moved {
+		c.fireSnapshot()
+	}
+}
+
+// runStatusOnDisk reads a run's persisted status straight from the store.
+// Best-effort — any read error returns the empty status, which the parked
+// sweep treats as "leave the card alone" (mirrors resumableRunID).
+func (c *Dispatcher) runStatusOnDisk(runID string) store.RunStatus {
+	if runID == "" || c.storeDir == "" {
+		return ""
+	}
+	s, err := store.New(c.storeDir, store.WithLogger(c.logger))
+	if err != nil {
+		c.logger.Debug("dispatcher: open store for parked sweep: %v", err)
+		return ""
+	}
+	r, err := s.LoadRun(context.Background(), runID)
+	if err != nil {
+		c.logger.Debug("dispatcher: cannot read run %s for parked sweep: %v", runID, err)
+		return ""
+	}
+	return r.Status
+}

--- a/pkg/dispatcher/parked_test.go
+++ b/pkg/dispatcher/parked_test.go
@@ -1,0 +1,194 @@
+package dispatcher
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// TestReconcileParked guards the parked-card sweep: every resume surface
+// (CLI `iterion resume`, studio run console, answer-from-board) completes
+// a parked run OUTSIDE the dispatcher, so only the sweep can move the
+// awaiting-input card to its final state. Without it the card strands in
+// awaiting_input with its claim retained forever.
+func TestReconcileParked(t *testing.T) {
+	cases := []struct {
+		name      string
+		runStatus store.RunStatus
+		wantState string // "" = card must stay parked
+		wantClaim bool
+	}{
+		{"finished run moves card to completed", store.RunStatusFinished, "review", false},
+		{"hard-failed run moves card to failed", store.RunStatusFailed, "blocked", false},
+		{"still-paused run stays parked", store.RunStatusPausedWaitingHuman, "", true},
+		{"failed-resumable run stays parked (operator can resume)", store.RunStatusFailedResumable, "", true},
+		{"cancelled run stays parked (checkpoint resumable)", store.RunStatusCancelled, "", true},
+		{"running resume-in-flight stays parked", store.RunStatusRunning, "", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Real run store with a run in the scenario's status.
+			runStore, err := store.New(dir)
+			if err != nil {
+				t.Fatalf("store.New: %v", err)
+			}
+			run, err := runStore.CreateRun(context.Background(), "run-parked-1", "wf", nil)
+			if err != nil {
+				t.Fatalf("CreateRun: %v", err)
+			}
+			run.Status = tc.runStatus
+			if err := runStore.SaveRun(context.Background(), run); err != nil {
+				t.Fatalf("SaveRun: %v", err)
+			}
+
+			// Real native tracker with a card parked in awaiting_input,
+			// claimed by this dispatcher, last_run pointing at the run.
+			ns, err := native.NewStore(filepath.Join(dir, "dispatcher"))
+			if err != nil {
+				t.Fatalf("native.NewStore: %v", err)
+			}
+			iss, err := ns.Create(native.Issue{Title: "parked", State: native.StateAwaitingInput})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			if err := ns.Claim(iss.ID, "test-host-1"); err != nil {
+				t.Fatalf("Claim: %v", err)
+			}
+			if err := ns.SetLastRun(iss.ID, "run-parked-1", ""); err != nil {
+				t.Fatalf("SetLastRun: %v", err)
+			}
+			if err := ns.SetAwaitingInput(iss.ID, true); err != nil {
+				t.Fatalf("SetAwaitingInput: %v", err)
+			}
+
+			cfg := &Config{
+				Name:     "test",
+				Workflow: filepath.Join(t.TempDir(), "fake.bot"),
+				Tracker:  TrackerConfig{Kind: "native"},
+				Polling:  PollingConfig{IntervalMS: 50},
+				Agent: AgentConfig{
+					MaxConcurrent:  4,
+					RunningState:   "in_progress",
+					CompletedState: "review",
+					FailedState:    "blocked",
+				},
+				Workspace: WorkspaceConfig{Root: filepath.Join(dir, "ws")},
+			}
+			cfg.applyDefaults()
+			ws, err := NewWorkspaces(cfg.Workspace.Root)
+			if err != nil {
+				t.Fatalf("NewWorkspaces: %v", err)
+			}
+			c, err := New(Options{
+				Config:     cfg,
+				Tracker:    native.NewAdapter(ns),
+				Runner:     &StubRunner{},
+				Workspaces: ws,
+				Logger:     iterlog.New(iterlog.LevelError, &bytes.Buffer{}),
+				HostMarker: "test-host-1",
+				StoreDir:   dir,
+			})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+
+			c.reconcileParked(context.Background())
+
+			got, err := ns.Get(iss.ID)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			wantState := tc.wantState
+			if wantState == "" {
+				wantState = native.StateAwaitingInput
+			}
+			if got.State != wantState {
+				t.Errorf("card state = %q, want %q", got.State, wantState)
+			}
+			if claimed := got.Claim != ""; claimed != tc.wantClaim {
+				t.Errorf("card claimed = %v, want %v", claimed, tc.wantClaim)
+			}
+			if tc.wantState != "" && got.AwaitingInput {
+				t.Errorf("awaiting-input badge must be cleared on the terminal transition")
+			}
+			if tc.wantState == "" && !got.AwaitingInput {
+				t.Errorf("awaiting-input badge must survive while the card stays parked")
+			}
+		})
+	}
+}
+
+// TestReconcileParked_SkipsOtherDaemonsClaims: a card parked by ANOTHER
+// live daemon sharing the store must be left for its owner.
+func TestReconcileParked_SkipsOtherDaemonsClaims(t *testing.T) {
+	dir := t.TempDir()
+	runStore, err := store.New(dir)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	run, err := runStore.CreateRun(context.Background(), "run-other-1", "wf", nil)
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	run.Status = store.RunStatusFinished
+	if err := runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+	ns, err := native.NewStore(filepath.Join(dir, "dispatcher"))
+	if err != nil {
+		t.Fatalf("native.NewStore: %v", err)
+	}
+	iss, err := ns.Create(native.Issue{Title: "theirs", State: native.StateAwaitingInput})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := ns.Claim(iss.ID, "other-host-9"); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if err := ns.SetLastRun(iss.ID, "run-other-1", ""); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+
+	cfg := &Config{
+		Name:     "test",
+		Workflow: filepath.Join(t.TempDir(), "fake.bot"),
+		Tracker:  TrackerConfig{Kind: "native"},
+		Polling:  PollingConfig{IntervalMS: 50},
+		Agent: AgentConfig{
+			MaxConcurrent: 4, RunningState: "in_progress",
+			CompletedState: "review", FailedState: "blocked",
+		},
+		Workspace: WorkspaceConfig{Root: filepath.Join(dir, "ws")},
+	}
+	cfg.applyDefaults()
+	ws, err := NewWorkspaces(cfg.Workspace.Root)
+	if err != nil {
+		t.Fatalf("NewWorkspaces: %v", err)
+	}
+	c, err := New(Options{
+		Config: cfg, Tracker: native.NewAdapter(ns), Runner: &StubRunner{},
+		Workspaces: ws, Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{}),
+		HostMarker: "test-host-1", StoreDir: dir,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	c.reconcileParked(context.Background())
+
+	got, err := ns.Get(iss.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != native.StateAwaitingInput || got.Claim != "other-host-9" {
+		t.Errorf("another daemon's parked card must be untouched, got state=%q claim=%q", got.State, got.Claim)
+	}
+}


### PR DESCRIPTION
Closes the two réserves from the #125 close-out (refs #125, #167, follow-up to #173/#174).

## 1. Awaiting-input card lifecycle (validated live)

Validating #173 on a local `iterion dispatch` surfaced three engine gaps, all fixed:

- **Board migration** — `loadOrInitBoard` only wrote `DefaultBoard()` when `board.json` was absent, so **every pre-#173 board lacked `awaiting_input`** and `moveToAwaitingInput` silently degraded ("stays in place") for all existing operators. Now mirrors the `inbox` upgrade: insert `awaiting_input` right after `in_progress` when absent; fully-custom boards (no `in_progress`) stay untouched.
- **Parked-card sweep (`reconcileParked`)** — every resume surface (CLI `iterion resume`, run console, answer-from-board) completes a parked run *outside* the dispatcher, so the card stranded in `awaiting_input` with its claim retained forever. New per-tick sweep (native tracker, optional-interface seam): `finished` → CompletedState, hard-`failed` → FailedState; resumable statuses (`paused_*`, `failed_resumable`, `cancelled`) stay parked. Cards claimed by another live daemon are left to their owner.
- **`iterion dispatch` re-run exited(1)** — `NewManager` auto-starts on a persisted config, so the CLI's explicit `Start()` hit "already running" and the daemon died on every re-run over the same store. Typed `ErrAlreadyRunning`, treated as success (SaveConfig already live-reloads the running instance).

**Live validation** (scratch store, `examples/human-in-the-loop.bot`): legacy board auto-migrated on store open → dispatch → pause → card moved into the "Awaiting input" column (`moved to awaiting-input, kept claimed, NOT retried`) → out-of-band CLI resume → run finished → sweep: `resumed out-of-band and finished — moving awaiting-input card to "review"`, claim released, badge cleared. Re-run of `iterion dispatch` on the same store now stays up.

## 2. Deterministic codegen-drift gate (#167 follow-up)

#174 fixed the skill prose (agents copy the example verify.sh), but the gate stayed advisory. This adds a deterministic tail to every `verify_run` body (all 9 catalog bots; the canonical four stay byte-identical), run only on a GREEN verify:

1. **CI-mirror assertion** — if the repo's own CI enforces a drift gate (`git diff --exit-code`/`--quiet`, `status --porcelain`) and verify.sh contains none → fail with an instructive `DRIFT GATE MISSING` log (fed back to the campaign via the existing `gate → campaign` edge).
2. **Post-verify tree-drift** — a green verify must not leave new changes in the tree (regen output belongs in a commit) → fail naming the paths.

Wrapper-agnostic by design: the tail never invokes the repo's toolchain (a bare `task` outside devbox would false-fail); the CI config is the source of truth. ADR-044 intact — the gate stays deterministic, no recovery rungs.

## Tests

- `TestNewStoreInsertsAwaitingInputAfterInProgress` + custom-board-untouched (native store migration)
- `TestReconcileParked` (6 statuses) + `TestReconcileParked_SkipsOtherDaemonsClaims` (real native store + run store)
- `TestVerifyRunDriftTail` (7 fixtures, executes the real command body) + `TestVerifyRunDriftTailPresentInAllBots` (9 bots)
- `task check` green (lint + unit + e2e + goldens + studio 597)

🤖 Generated with [Claude Code](https://claude.com/claude-code)