### PR TITLE
chore(vendor): bump claw — omit null `required` in /responses tool schemas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,7 @@ require (
 )
 
 require (
-	github.com/SocialGouv/claw-code-go v0.1.1-0.20260713082314-0faf395d7c34
+	github.com/SocialGouv/claw-code-go v0.1.1-0.20260714085100-c9eed790765b
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/aws/aws-sdk-go-v2 v1.42.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.28

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQ
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260713082314-0faf395d7c34 h1:AzODmrI8C5gZgxcW4SLtAcV7vqTeCh9KJTPmnN3l7Oo=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260713082314-0faf395d7c34/go.mod h1:c0yGvkNqLl+A4KNRBBEg1iP3dhnnM9z0XX6jCFlA15k=
+github.com/SocialGouv/claw-code-go v0.1.1-0.20260714085100-c9eed790765b h1:5JhXvBCunV0OyBqjug+KJ4Ife5MFrMBCFecD3A9/yHI=
+github.com/SocialGouv/claw-code-go v0.1.1-0.20260714085100-c9eed790765b/go.mod h1:c0yGvkNqLl+A4KNRBBEg1iP3dhnnM9z0XX6jCFlA15k=
 github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
 github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/aws/aws-sdk-go-v2 v1.42.1 h1:9eOTgu1z/dVtYpNZ3/8/XbbaX0x/BqE3HUzAzs6K0ek=

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/api/providers/openai/responses.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/api/providers/openai/responses.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/SocialGouv/claw-code-go/internal/api"
 	"github.com/SocialGouv/claw-code-go/internal/api/httputil"
+	"github.com/SocialGouv/claw-code-go/internal/api/providers/openaiwire"
 	"github.com/SocialGouv/claw-code-go/internal/api/sseutil"
 )
 
@@ -385,11 +386,13 @@ func convertMessagesToResponsesInput(messages []api.Message) []oaiResponsesMessa
 func convertToolsToResponses(tools []api.Tool) ([]oaiResponsesTool, error) {
 	out := make([]oaiResponsesTool, 0, len(tools))
 	for _, t := range tools {
-		params, err := json.Marshal(map[string]interface{}{
-			"type":       t.InputSchema.Type,
-			"properties": t.InputSchema.Properties,
-			"required":   t.InputSchema.Required,
-		})
+		// Same normalisation as the chat path (openaiwire.ConvertTools): a nil
+		// `required` must be OMITTED, not marshalled as `null` — the responses
+		// API validator rejects null with "None is not of type 'array'", which
+		// silently killed every MCP tool that has only optional parameters
+		// (e.g. firecrawl_interact / firecrawl_monitor_create). Routing both
+		// transports through the shared helper keeps them from drifting.
+		params, err := openaiwire.NormalizedParameters(t.InputSchema)
 		if err != nil {
 			return nil, fmt.Errorf("openai: marshal input schema for tool %q: %w", t.Name, err)
 		}

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/api/providers/openaiwire/convert.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/api/providers/openaiwire/convert.go
@@ -116,22 +116,7 @@ func ConvertMessages(system string, messages []api.Message) []Message {
 func ConvertTools(provider string, tools []api.Tool) ([]Tool, error) {
 	result := make([]Tool, 0, len(tools))
 	for _, t := range tools {
-		schemaType := t.InputSchema.Type
-		if schemaType == "" {
-			schemaType = "object"
-		}
-		properties := t.InputSchema.Properties
-		if properties == nil {
-			properties = map[string]api.Property{}
-		}
-		schema := map[string]interface{}{
-			"type":       schemaType,
-			"properties": properties,
-		}
-		if len(t.InputSchema.Required) > 0 {
-			schema["required"] = t.InputSchema.Required
-		}
-		params, err := json.Marshal(schema)
+		params, err := NormalizedParameters(t.InputSchema)
 		if err != nil {
 			return nil, fmt.Errorf("%s: marshal input schema for tool %q: %w", provider, t.Name, err)
 		}
@@ -145,4 +130,41 @@ func ConvertTools(provider string, tools []api.Tool) ([]Tool, error) {
 		})
 	}
 	return result, nil
+}
+
+// NormalizedParameters marshals an InputSchema into an OpenAI-function
+// `parameters` object, normalising the three shapes OpenAI's validator (both
+// /chat/completions and /responses) rejects as `null`:
+//   - `required` is OMITTED when nil/empty — a nil []string marshals to JSON
+//     null and OpenAI errors "None is not of type 'array'". This is the shape
+//     an MCP tool with only optional parameters produces (e.g. firecrawl's
+//     firecrawl_interact / firecrawl_monitor_create).
+//   - `properties` defaults to `{}` rather than null for a tool that declares
+//     no parameters.
+//   - `type` defaults to "object" when empty so the schema is a valid
+//     JSON-Schema object descriptor.
+//
+// Both the chat and responses tool converters route through this so the
+// normalisation can never drift between the two OpenAI transports.
+func NormalizedParameters(schema api.InputSchema) (json.RawMessage, error) {
+	schemaType := schema.Type
+	if schemaType == "" {
+		schemaType = "object"
+	}
+	properties := schema.Properties
+	if properties == nil {
+		properties = map[string]api.Property{}
+	}
+	out := map[string]interface{}{
+		"type":       schemaType,
+		"properties": properties,
+	}
+	if len(schema.Required) > 0 {
+		out["required"] = schema.Required
+	}
+	params, err := json.Marshal(out)
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(params), nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -66,7 +66,7 @@ github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/shared
 github.com/AzureAD/microsoft-authentication-library-for-go/apps/internal/version
 github.com/AzureAD/microsoft-authentication-library-for-go/apps/managedidentity
 github.com/AzureAD/microsoft-authentication-library-for-go/apps/public
-# github.com/SocialGouv/claw-code-go v0.1.1-0.20260713082314-0faf395d7c34
+# github.com/SocialGouv/claw-code-go v0.1.1-0.20260714085100-c9eed790765b
 ## explicit; go 1.25.0
 github.com/SocialGouv/claw-code-go/hooks
 github.com/SocialGouv/claw-code-go/internal/api


### PR DESCRIPTION
Bumps the vendored `claw-code-go` pin to [`c9eed79`](https://github.com/SocialGouv/claw-code-go/commit/c9eed79).

## Why

The self-hosted **firecrawl** MCP server (now resolvable in cloud runs after #178) exposes tools whose input schema has **only optional parameters** — `firecrawl_interact`, `firecrawl_monitor_create`. claw's `/responses` tool converter marshalled `"required": Required` unconditionally, so those became `"required": null`, which OpenAI's `/responses` validator rejects: `Invalid schema for function '<name>': None is not of type 'array'`. A single bad function fails the **whole** tools list, so firecrawl was unusable via the `mcp.firecrawl.*` wildcard under the ChatGPT-OAuth forfait (which always routes to `/responses`) — even though tool discovery now succeeds.

Tools **with** required fields (`firecrawl_scrape` / `firecrawl_search`) were unaffected, which is why a **narrowed** tool list already works end-to-end (validated live: `firecrawl_scrape` scraped example.com via the self-host and returned its real title/h1).

## Fix (upstream claw)

The chat converter already omitted empty `required`; the `/responses` converter had drifted. The upstream commit extracts a shared `openaiwire.NormalizedParameters` (omit empty `required`, default `type`→`object`, default `properties`→`{}`) and routes **both** OpenAI transports through it so they can't diverge again. Regression tests: `TestConvertToolsToResponses_OmitsNullRequired`, `TestNormalizedParameters`.

Pin bumped via `scripts/bump-claw.sh` (never hand-written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)