### PR TITLE
fix(server,boardmongo): cloud parity for the awaiting-input lifecycle (#125)

### DIFF
--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -137,6 +137,31 @@ per-state** (`agent.max_concurrent_by_state`). A workflow state in
 the per-state map cannot exceed its individual cap even when the
 global cap has room.
 
+### Paused runs — the `awaiting_input` column + parked sweep
+
+A run that suspends for input (a `human` node → `paused_waiting_human`,
+or an operator soft-pause → `paused_operator`) is **not** a failure and
+is never retried. The dispatcher **parks** the card instead:
+
+- the card moves into the dedicated **`awaiting_input`** column (part of
+  the default board; older `board.json` / Mongo board configs are
+  schema-upgraded automatically — the state is inserted right after
+  `in_progress`; fully-custom boards without `in_progress` are left
+  untouched and the card simply stays in place),
+- the claim is retained (so no tick re-dispatches it), the slot is
+  freed, and the denormalized ⏸ badge (`awaiting_input` on the issue) is
+  set — the studio board shows "this pipeline needs me" at the column
+  level and the card's answer form keys off `last_run_id`.
+
+Answering happens **outside** the dispatcher (answer-from-board, the run
+console, or `iterion resume`), so a per-tick **parked sweep**
+(`reconcileParked`) watches the parked cards' runs and finishes the
+lifecycle: run `finished` → `agent.completed_state`, hard `failed` →
+`agent.failed_state` (claim released, badge cleared). Resumable statuses
+(`paused_*`, `failed_resumable`, `cancelled`) keep the card parked — it
+genuinely still awaits the operator. The cloud board coordinator runs
+the same sweep for cloud-launched cards.
+
 ### In-progress transition (`agent.running_state`)
 
 After `tracker.Claim` succeeds, the dispatcher transitions the issue

--- a/docs/native-tracker.md
+++ b/docs/native-tracker.md
@@ -57,15 +57,18 @@ fields the operator can attach to issues. Defaults:
 ```jsonc
 {
   "states": [
-    { "name": "inbox",       "display": "Inbox" },
-    { "name": "backlog",     "display": "Backlog" },
-    { "name": "ready",       "display": "Ready",       "eligible": true },
-    { "name": "in_progress", "display": "In progress", "eligible": true },
-    { "name": "review",      "display": "Review" },
-    { "name": "done",        "display": "Done",        "terminal": true },
-    { "name": "blocked",     "display": "Blocked",     "terminal": true }
+    { "name": "inbox",          "display": "Inbox" },
+    { "name": "backlog",        "display": "Backlog" },
+    { "name": "ready",          "display": "Ready",       "eligible": true },
+    { "name": "in_progress",    "display": "In progress", "eligible": true },
+    { "name": "awaiting_input", "display": "Awaiting input" },
+    { "name": "review",         "display": "Review" },
+    { "name": "done",           "display": "Done",        "terminal": true },
+    { "name": "blocked",        "display": "Blocked",     "terminal": true }
   ],
-  "fields": []
+  "fields": [
+    { "name": "bot_args", "display": "Bot args", "type": "text" }
+  ]
 }
 ```
 
@@ -73,6 +76,16 @@ fields the operator can attach to issues. Defaults:
 post their out-of-scope observations there (labeled `findings`) so
 operators can triage on /board without a separate inbox surface —
 drag inbox → backlog to promote, delete the card to dismiss.
+
+`awaiting_input` holds a dispatched card whose run paused for input
+(a `human` node, or an operator soft-pause): the dispatcher parks the
+card there — non-eligible, claim retained — and a per-tick sweep moves
+it on once the run reaches a terminal status (see the "Paused runs"
+section in [docs/dispatcher.md](dispatcher.md)). Boards persisted by an
+older iterion are **schema-upgraded automatically** on store open
+(filesystem) or on read (Mongo): missing `inbox` is prepended, missing
+`awaiting_input` is inserted right after `in_progress`. Fully-custom
+boards without an `in_progress` state are left untouched.
 
 | Property            | Meaning                                                            |
 |---------------------|--------------------------------------------------------------------|
@@ -151,24 +164,27 @@ machine-readable output:
 iterion issue list --state ready --json | jq '.[].id'
 ```
 
-### Open CLI gap: per-ticket `bot` / `bot_args`
+### Per-ticket `bot` / `bot_args`
 
-The underlying `native.Issue` record carries dedicated typed
-fields `Bot` (string) and `BotArgs` (`map[string]string`) — see
-the REST surface below — but `iterion issue create` and
-`iterion issue update` do **not** yet expose `--bot` or
-`--bot-arg` flags. `--field key=value` lands in the freeform
-`Fields` map, NOT in `BotArgs`.
+The `native.Issue` record carries dedicated typed routing fields:
+`Bot` (string) and `BotArgs` (`map[string]string`). At **create**
+time the CLI exposes them directly:
 
-Until the CLI ships those flags, set the two routing fields via
-one of:
+```bash
+iterion issue create --title "Ship X" --state ready \
+  --bot feature-dev --bot-arg feature_prompt="Ship X exactly as specced"
+```
 
-- the REST API (`POST` / `PATCH` `/api/v1/native/issues` with
+(`--field key=value` is different: it lands in the freeform `Fields`
+map, NOT in `BotArgs`.) `iterion issue update` does not expose the
+two flags yet — to change routing on an EXISTING card use one of:
+
+- the REST API (`PATCH /api/v1/native/issues/{id}` with
   `{ "bot": "feature_dev", "bot_args": { "feature_prompt": "…" } }`),
 - the board MCP / claw tools (`create_issue` and `set_bot` both accept
   `bot` / `bot_args`, so a bot with the `board.create` / `board.assign`
   capability can pin routing at create time),
-- a direct `native.Store.Create` / `Update` call from Go,
+- the studio issue modal,
 - or rely on the dispatcher-side `assignee_workflows:` /
   `assignee_dispatch:` mappings keyed on `--assignee` (see
   [docs/dispatcher.md](dispatcher.md)).

--- a/pkg/cli/dispatch.go
+++ b/pkg/cli/dispatch.go
@@ -98,8 +98,11 @@ func RunDispatch(p *Printer, opts DispatchOptions) error {
 	// live instance. That IS the desired end state — SaveConfig above
 	// already live-reloaded it with this invocation's config — so treat
 	// ErrAlreadyRunning as success instead of exiting the daemon.
-	if err := mgr.Start(); err != nil && !errors.Is(err, dispatcher.ErrAlreadyRunning) {
-		return err
+	if err := mgr.Start(); err != nil {
+		if !errors.Is(err, dispatcher.ErrAlreadyRunning) {
+			return err
+		}
+		logger.Info("dispatcher already auto-started from the persisted config — this invocation's config was live-reloaded onto it")
 	}
 	// Shutdown preserves the operator's last-known intent in
 	// runtime.json across SIGTERM / Ctrl-C. Stop is reserved for

--- a/pkg/dispatcher/boardmongo/store.go
+++ b/pkg/dispatcher/boardmongo/store.go
@@ -107,7 +107,12 @@ func EnsureSchema(ctx context.Context, db *mongo.Database) error {
 // --- board config ---
 
 // Board returns the tenant's board config, defaulting to native.DefaultBoard
-// when none is stored yet.
+// when none is stored yet. A persisted board from an older iterion is
+// schema-upgraded on READ (inbox / awaiting_input states) — the same upgrade
+// the filesystem store persists in loadOrInitBoard. Normalizing here (not
+// writing back) keeps reads race-free; the next SetBoard from the column
+// editor persists the upgraded shape naturally, and SetState validation
+// (which reads through this method) accepts the upgraded states either way.
 func (s *Store) Board() *native.Board {
 	ctx, cancel := ctxWithTimeout()
 	defer cancel()
@@ -117,6 +122,7 @@ func (s *Store) Board() *native.Board {
 		return native.DefaultBoard()
 	}
 	b := doc.Board
+	native.UpgradeBoardSchema(&b)
 	return &b
 }
 

--- a/pkg/dispatcher/native/board.go
+++ b/pkg/dispatcher/native/board.go
@@ -122,6 +122,41 @@ func (b *Board) StateByName(name string) *State {
 	return nil
 }
 
+// UpgradeBoardSchema applies the in-place upgrades a board persisted by an
+// older iterion needs to work with the current dispatcher, returning true
+// when it modified the board. Shared by the filesystem store
+// (loadOrInitBoard, which persists the result) and the Mongo store (Board(),
+// which normalizes on read). Idempotent; operator-customised boards keep
+// their ordering.
+//
+//   - `inbox` (bot-emitted findings land there) is prepended when missing.
+//   - `awaiting_input` (the dispatcher parks a paused card there) is
+//     inserted right after `in_progress` when missing. Boards without an
+//     `in_progress` state are fully custom — left untouched; the
+//     dispatcher's "stays in place" fallback covers them.
+func UpgradeBoardSchema(b *Board) bool {
+	changed := false
+	if b.StateByName(StateInbox) == nil {
+		b.States = append([]State{{Name: StateInbox, Display: "Inbox"}}, b.States...)
+		changed = true
+	}
+	if b.StateByName(StateAwaitingInput) == nil {
+		for i, st := range b.States {
+			if st.Name != StateInProgress {
+				continue
+			}
+			states := make([]State, 0, len(b.States)+1)
+			states = append(states, b.States[:i+1]...)
+			states = append(states, State{Name: StateAwaitingInput, Display: "Awaiting input"})
+			states = append(states, b.States[i+1:]...)
+			b.States = states
+			changed = true
+			break
+		}
+	}
+	return changed
+}
+
 // stateIndex returns the position of the state matching name, or -1.
 // Reorder/delete need the slice index; StateByName only yields a pointer.
 func (b *Board) stateIndex(name string) int {

--- a/pkg/dispatcher/native/store.go
+++ b/pkg/dispatcher/native/store.go
@@ -1318,35 +1318,13 @@ func (s *Store) loadOrInitBoard() error {
 		return fmt.Errorf("native store: invalid board: %w", err)
 	}
 	s.board = &b
-	// Pre-upgrade stores predate the `inbox` state. Prepend it once so
-	// bots emitting findings (which target inbox) work after upgrade
-	// without manual board.json edits. Idempotent: skipped when inbox
-	// is already present (operator-customised boards keep their order).
-	if s.board.StateByName(StateInbox) == nil {
-		s.board.States = append([]State{{Name: StateInbox, Display: "Inbox"}}, s.board.States...)
+	// Boards persisted by an older iterion may predate the `inbox` /
+	// `awaiting_input` states — apply the shared schema upgrade once and
+	// persist, so bots emitting findings and the dispatcher's paused-run
+	// parking work without manual board.json edits.
+	if UpgradeBoardSchema(s.board) {
 		if err := s.writeBoardLocked(); err != nil {
-			return fmt.Errorf("native store: persist inbox upgrade: %w", err)
-		}
-	}
-	// Pre-upgrade stores also predate the `awaiting_input` state. Insert it
-	// right after `in_progress` so the dispatcher's paused-run parking
-	// (moveToAwaitingInput) works after upgrade without manual board.json
-	// edits. Boards without an `in_progress` state are fully custom — leave
-	// them untouched; the dispatcher's "stays in place" fallback still applies.
-	if s.board.StateByName(StateAwaitingInput) == nil {
-		for i, st := range s.board.States {
-			if st.Name != StateInProgress {
-				continue
-			}
-			states := make([]State, 0, len(s.board.States)+1)
-			states = append(states, s.board.States[:i+1]...)
-			states = append(states, State{Name: StateAwaitingInput, Display: "Awaiting input"})
-			states = append(states, s.board.States[i+1:]...)
-			s.board.States = states
-			if err := s.writeBoardLocked(); err != nil {
-				return fmt.Errorf("native store: persist awaiting-input upgrade: %w", err)
-			}
-			break
+			return fmt.Errorf("native store: persist board schema upgrade: %w", err)
 		}
 	}
 	return nil

--- a/pkg/dispatcher/native/store_test.go
+++ b/pkg/dispatcher/native/store_test.go
@@ -134,6 +134,39 @@ func TestNewStoreInsertsAwaitingInputAfterInProgress(t *testing.T) {
 	}
 }
 
+func TestUpgradeBoardSchema(t *testing.T) {
+	// Pure-helper contract — the Mongo store applies this on READ (no
+	// persistence), so the filesystem-store tests above don't cover it.
+	legacy := &Board{States: []State{
+		{Name: StateBacklog, Display: "Backlog"},
+		{Name: StateReady, Display: "Ready", Eligible: true},
+		{Name: StateInProgress, Display: "In progress", Eligible: true},
+		{Name: StateDone, Display: "Done", Terminal: true},
+	}}
+	if !UpgradeBoardSchema(legacy) {
+		t.Fatal("legacy board must report changed")
+	}
+	names := make([]string, 0, len(legacy.States))
+	for _, s := range legacy.States {
+		names = append(names, s.Name)
+	}
+	want := []string{StateInbox, StateBacklog, StateReady, StateInProgress, StateAwaitingInput, StateDone}
+	if len(names) != len(want) {
+		t.Fatalf("states = %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Fatalf("states = %v, want %v", names, want)
+		}
+	}
+	if UpgradeBoardSchema(legacy) {
+		t.Fatal("second upgrade must be a no-op")
+	}
+	if UpgradeBoardSchema(DefaultBoard()) {
+		t.Fatal("DefaultBoard must not need upgrading")
+	}
+}
+
 func TestNewStoreLeavesCustomBoardWithoutInProgressUntouched(t *testing.T) {
 	// A fully custom board with no `in_progress` state gets NO
 	// awaiting_input insert — the dispatcher's "stays in place"

--- a/pkg/server/boarddispatch.go
+++ b/pkg/server/boarddispatch.go
@@ -46,6 +46,13 @@ type boardDispatcher struct {
 	blockedState    string
 	awaitingState   string
 
+	// statusFor + clearBadge power the parked-card sweep (sweepParked).
+	// statusFor reads a run's persisted status for a tenant; clearBadge
+	// clears the card's denormalized awaiting-input hint. Both optional —
+	// a nil statusFor disables the sweep.
+	statusFor  func(ctx context.Context, tenant, runID string) (store.RunStatus, error)
+	clearBadge func(tenant, id string)
+
 	interval time.Duration
 	sem      chan struct{}
 	logger   *iterlog.Logger
@@ -125,6 +132,55 @@ func (d *boardDispatcher) processCard(ctx context.Context, c boardmongo.Candidat
 	}
 }
 
+// sweepParked reconciles cards parked in the awaiting-input column whose
+// runs have since reached a terminal status. A cloud card parks UNCLAIMED
+// (processCard moved it to awaitingState and released), and every resume
+// surface — answer-from-board, run console, CLI — completes the run outside
+// this dispatcher's poll loop (which returned at the pause), so without the
+// sweep the card strands in awaiting_input forever. Mirrors the local
+// dispatcher's reconcileParked (pkg/dispatcher/parked.go): finished →
+// doneState, hard-failed → blockedState; resumable statuses (paused_*,
+// failed_resumable, cancelled) and in-flight ones stay parked. Multi-replica
+// safe without claims: a concurrent double-move lands on the same final
+// state, and awaiting_input is not in `eligible` so no replica re-dispatches.
+func (d *boardDispatcher) sweepParked(ctx context.Context) {
+	if d.statusFor == nil {
+		return
+	}
+	cands, err := d.coord.ListEligible(ctx, []string{d.awaitingState}, 200)
+	if err != nil {
+		d.warn("parked sweep list: %v", err)
+		return
+	}
+	for _, c := range cands {
+		runID := c.Issue.LastRunID
+		if runID == "" {
+			continue
+		}
+		st, err := d.statusFor(ctx, c.Tenant, runID)
+		if err != nil {
+			continue // best-effort: unreadable run → leave the card alone
+		}
+		var target string
+		switch st {
+		case store.RunStatusFinished:
+			target = d.doneState
+			d.log("card %s/%s resumed out-of-band and finished (run=%s) — moving to %s", c.Tenant, c.Issue.ID, runID, target)
+		case store.RunStatusFailed:
+			target = d.blockedState
+			d.warn("card %s/%s resumed out-of-band and failed hard (run=%s) — moving to %s", c.Tenant, c.Issue.ID, runID, target)
+		default:
+			continue // still paused / resumable / in flight — genuinely awaiting the operator
+		}
+		if d.clearBadge != nil {
+			d.clearBadge(c.Tenant, c.Issue.ID)
+		}
+		if err := d.coord.SetState(ctx, c.Tenant, c.Issue.ID, target); err != nil {
+			d.warn("parked sweep move %s/%s → %s: %v", c.Tenant, c.Issue.ID, target, err)
+		}
+	}
+}
+
 // run loops tick every interval until ctx is cancelled, then drains in-flight
 // cards. Start one per replica.
 func (d *boardDispatcher) run(ctx context.Context) {
@@ -132,6 +188,7 @@ func (d *boardDispatcher) run(ctx context.Context) {
 	defer t.Stop()
 	for {
 		d.tick(ctx)
+		d.sweepParked(ctx)
 		select {
 		case <-ctx.Done():
 			d.wg.Wait() // let in-flight cards finish their state transition
@@ -144,6 +201,12 @@ func (d *boardDispatcher) run(ctx context.Context) {
 func (d *boardDispatcher) warn(format string, args ...any) {
 	if d.logger != nil {
 		d.logger.Warn("board dispatcher: "+format, args...)
+	}
+}
+
+func (d *boardDispatcher) log(format string, args ...any) {
+	if d.logger != nil {
+		d.logger.Info("board dispatcher: "+format, args...)
 	}
 }
 
@@ -235,6 +298,20 @@ func (s *Server) setCardAwaitingInput(tenant, cardID string, v bool) {
 	if err := store.SetAwaitingInput(cardID, v); err != nil && s.logger != nil {
 		s.logger.Warn("board dispatcher: set awaiting-input=%v on card %s/%s: %v", v, tenant, cardID, err)
 	}
+}
+
+// boardRunStatus reads a run's persisted status for the parked-card sweep,
+// tenant-scoped exactly like processBoardCard's launch context.
+func (s *Server) boardRunStatus(ctx context.Context, tenant, runID string) (store.RunStatus, error) {
+	if s.runs == nil {
+		return "", errors.New("run service unavailable")
+	}
+	ctx = store.WithIdentity(ctx, tenant, "board-dispatcher")
+	run, err := s.runs.LoadRunCtx(ctx, runID)
+	if err != nil {
+		return "", err
+	}
+	return run.Status, nil
 }
 
 func (s *Server) processBoardCard(ctx context.Context, tenant string, iss native.Issue) error {

--- a/pkg/server/boarddispatch_test.go
+++ b/pkg/server/boarddispatch_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/boardmongo"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/store"
 )
 
 type fakeBoardCoord struct {
@@ -180,6 +181,68 @@ func TestBoardDispatcher_PausedRunMovesToAwaitingInput(t *testing.T) {
 	if len(f.claimed) != 0 {
 		t.Errorf("card should be released after a pause: %v", f.claimed)
 	}
+}
+
+// TestBoardDispatcher_SweepMovesParkedCards: a cloud card parks UNCLAIMED in
+// awaiting_input and every resume surface completes the run outside the
+// dispatcher's poll loop, so only sweepParked can move it on. finished →
+// done, hard-failed → blocked, resumable/in-flight statuses stay parked; the
+// denormalized ⏸ badge is cleared on every terminal move.
+func TestBoardDispatcher_SweepMovesParkedCards(t *testing.T) {
+	awaiting := func(id, runID string) boardmongo.Candidate {
+		return boardmongo.Candidate{Tenant: "t1", Issue: native.Issue{ID: id, State: native.StateAwaitingInput, LastRunID: runID}}
+	}
+	f := newFakeBoardCoord(
+		awaiting("native:done", "run-finished"),
+		awaiting("native:dead", "run-failed"),
+		awaiting("native:wait", "run-paused"),
+		awaiting("native:redo", "run-resumable"),
+		awaiting("native:none", ""), // never dispatched — must be left alone
+	)
+	statuses := map[string]store.RunStatus{
+		"run-finished":  store.RunStatusFinished,
+		"run-failed":    store.RunStatusFailed,
+		"run-paused":    store.RunStatusPausedWaitingHuman,
+		"run-resumable": store.RunStatusFailedResumable,
+	}
+	var bmu sync.Mutex
+	badgeCleared := map[string]bool{}
+	d := newBoardDispatcher(f, func(context.Context, string, native.Issue) error {
+		t.Fatal("sweep must never dispatch a parked card")
+		return nil
+	}, "replica-A", 4, nil)
+	d.statusFor = func(_ context.Context, _, runID string) (store.RunStatus, error) {
+		return statuses[runID], nil
+	}
+	d.clearBadge = func(_, id string) {
+		bmu.Lock()
+		badgeCleared[id] = true
+		bmu.Unlock()
+	}
+
+	d.sweepParked(context.Background())
+
+	if got := f.states["native:done"]; got != native.StateDone {
+		t.Errorf("finished card state = %q, want %q", got, native.StateDone)
+	}
+	if got := f.states["native:dead"]; got != native.StateBlocked {
+		t.Errorf("hard-failed card state = %q, want %q", got, native.StateBlocked)
+	}
+	for _, id := range []string{"native:wait", "native:redo", "native:none"} {
+		if got, moved := f.states[id]; moved {
+			t.Errorf("card %s must stay parked, was moved to %q", id, got)
+		}
+	}
+	if !badgeCleared["native:done"] || !badgeCleared["native:dead"] {
+		t.Errorf("badge must be cleared on terminal moves: %v", badgeCleared)
+	}
+	if badgeCleared["native:wait"] || badgeCleared["native:redo"] {
+		t.Errorf("badge must survive on parked cards: %v", badgeCleared)
+	}
+
+	// nil statusFor (unwired) must be a hard no-op.
+	d2 := newBoardDispatcher(f, func(context.Context, string, native.Issue) error { return nil }, "replica-A", 4, nil)
+	d2.sweepParked(context.Background())
 }
 
 func TestBoardDispatcher_ClaimConflictSkips(t *testing.T) {

--- a/pkg/server/server_lifecycle.go
+++ b/pkg/server/server_lifecycle.go
@@ -232,7 +232,12 @@ func (s *Server) ListenAndServe() error {
 				<-s.shutdown
 				cancel()
 			}()
-			newBoardDispatcher(s.cfg.CloudBoardCoordinator, s.processBoardCard, marker, 4, s.logger).run(ctx)
+			d := newBoardDispatcher(s.cfg.CloudBoardCoordinator, s.processBoardCard, marker, 4, s.logger)
+			// Parked-card sweep wiring: read a run's status tenant-scoped,
+			// and clear the denormalized ⏸ badge when the sweep moves a card.
+			d.statusFor = s.boardRunStatus
+			d.clearBadge = func(tenant, id string) { s.setCardAwaitingInput(tenant, id, false) }
+			d.run(ctx)
 		}()
 	}
 	// Truthful URL in the log: if the operator chose a non-loopback bind we

--- a/studio/src/views/Board/boardShared.ts
+++ b/studio/src/views/Board/boardShared.ts
@@ -21,6 +21,7 @@ export const BOARD_PALETTE: { label: string; value: string }[] = [
   { label: "Backlog", value: "var(--color-board-backlog)" },
   { label: "Ready", value: "var(--color-board-ready)" },
   { label: "In progress", value: "var(--color-board-in-progress)" },
+  { label: "Awaiting input", value: "var(--color-warning)" },
   { label: "Review", value: "var(--color-board-review)" },
   { label: "Done", value: "var(--color-board-done)" },
   { label: "Blocked", value: "var(--color-board-blocked)" },


### PR DESCRIPTION
Follow-up to #179 — the cloud board coordinator (the launch path prod uses for issue-labeled deliveries) had the same two awaiting-input gaps fixed locally there:

- **Board-schema parity**: a tenant's *persisted* Mongo board predating #173 lacks `awaiting_input` → the cloud park silently degraded. The filesystem store's upgrade is extracted into `native.UpgradeBoardSchema` (inbox prepend + awaiting_input after in_progress; custom boards without in_progress untouched) and applied **read-side** in `boardmongo.Board()` — `SetState` validation reads through it; the next `SetBoard` persists the upgraded shape naturally.
- **Parked-card sweep (`sweepParked`)**: a cloud card parks UNCLAIMED in `awaiting_input`, and every resume surface (answer-from-board, run console, CLI) completes the run outside the coordinator's poll loop — the card stranded forever. The sweep runs each interval alongside `tick`, mirroring the local `reconcileParked`: `finished` → done, hard `failed` → blocked, resumable statuses stay parked; ⏸ badge cleared on terminal moves. Multi-replica safe without claims (idempotent double-move; `awaiting_input` never in `eligible`).

Plus polish: docs (dispatcher.md "Paused runs" section, native-tracker.md default schema + auto-upgrade + corrected stale "no `--bot` flag" note), the Awaiting-input warning swatch in the column color picker, and an info log when `iterion dispatch` rides an auto-started manager.

Tests: `TestUpgradeBoardSchema` (pure helper — covers the mongo read-side), `TestBoardDispatcher_SweepMovesParkedCards` (5 statuses + badge + nil-wiring no-op), existing migration/sweep/dispatcher suites green, `task check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)