### PR TITLE
test(dispatcher): deterministicize the two -race CI flakes

### DIFF
--- a/pkg/dispatcher/dispatcher_test.go
+++ b/pkg/dispatcher/dispatcher_test.go
@@ -571,10 +571,19 @@ func TestDispatcherGivesUpAfterMaxAttempts(t *testing.T) {
 		t.Fatalf("dispatch calls = %d, want 2 (initial + 1 retry, then give up)", got)
 	}
 	// No lingering bookkeeping: the retry entry was dropped on give-up.
-	snap := c.Snapshot()
-	if len(snap.Running) != 0 || len(snap.Retries) != 0 {
-		t.Fatalf("after give-up: running=%d retries=%d, want 0/0", len(snap.Running), len(snap.Retries))
+	// The tracker's "blocked" write happens on the give-up WORKER before
+	// the actor applies cmdDropRetry and republishes — so poll for the
+	// snapshot to converge instead of asserting a single read (the -race
+	// CI flake: retries=1 observed in the gap).
+	for time.Now().Before(deadline) {
+		snap := c.Snapshot()
+		if len(snap.Running) == 0 && len(snap.Retries) == 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
+	snap := c.Snapshot()
+	t.Fatalf("after give-up: running=%d retries=%d, want 0/0", len(snap.Running), len(snap.Retries))
 }
 
 func TestDispatcherRespectsClaimConflict(t *testing.T) {

--- a/pkg/dispatcher/reconcile_stalled_test.go
+++ b/pkg/dispatcher/reconcile_stalled_test.go
@@ -60,10 +60,27 @@ func TestReconcileStalled_ForceReapsCtxIgnoringWorker(t *testing.T) {
 		t.Fatal("dispatch never started")
 	}
 
+	// Wait for the dispatch to be VISIBLE in a published snapshot before
+	// polling for the reap: dispatchStarted fires from the WORKER
+	// goroutine, which is unordered with the actor's fireSnapshot for the
+	// dispatch — polling for Running==0 straight away can read the initial
+	// EMPTY snapshot and misread it as "already reaped" (the 0.06s CI
+	// flake), then find the entry in the follow-up check and report a
+	// phantom missing tombstone.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(c.Snapshot().Running) == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(c.Snapshot().Running) != 1 {
+		t.Fatalf("dispatched entry never appeared in a snapshot; snapshot=%+v", c.Snapshot())
+	}
+
 	// Expect: stall fires (>100ms after dispatch with no events),
 	// grace expires (>100ms after first cancel), force-reap runs.
 	// Total budget: ~500ms; allow 3s for CI slop.
-	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		snap := c.Snapshot()
 		if len(snap.Running) == 0 {


### PR DESCRIPTION
The two recurring \`race\`-job flakes (`TestReconcileStalled_ForceReapsCtxIgnoringWorker` — hit twice today on #174/#181 — and `TestDispatcherGivesUpAfterMaxAttempts`) share one root cause: **a single `Snapshot()` read asserted where only eventual consistency is guaranteed**. The actor goroutine is the sole snapshot publisher; worker goroutines are unordered with its `fireSnapshot`.

- **ReconcileStalled**: `dispatchStarted` fires from the worker, which can run *before* the actor publishes the snapshot carrying the running entry → the poll loop reads the initial empty snapshot, misreads it as "already reaped", then the follow-up check finds the entry → phantom "tombstone missing" (matches the observed 0.06s failure profile). Fix: wait for the entry to **appear** in a snapshot before polling for the reap.
- **GivesUpAfterMaxAttempts**: the give-up worker writes the tracker's `blocked` **before** the actor applies `cmdDropRetry` and republishes → a read-once assertion can observe `retries=1`. Fix: poll for convergence to 0/0 within the existing deadline.

Test-only; no engine change. Stressed **270 runs green**: `-race -count=50` + `-count=30 -cpu=1,2,4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)