### PR TITLE
fix(claude_code): forfait OAuth must suppress an inherited ANTHROPIC_API_KEY

### DIFF
--- a/pkg/backend/delegate/claude_code_cred_test.go
+++ b/pkg/backend/delegate/claude_code_cred_test.go
@@ -107,8 +107,36 @@ func TestAnthropicCredEnv_HintAnthropicFallsToOAuthDir(t *testing.T) {
 		string(secrets.OAuthKindClaudeCode): "/tmp/iterion-oauth-claude",
 	})
 	got := anthropicCredEnvForCLI(ctx, "anthropic")
-	if got["CLAUDE_CONFIG_DIR"] != "/tmp/iterion-oauth-claude" {
-		t.Errorf("CLAUDE_CONFIG_DIR: got %q, want /tmp/iterion-oauth-claude", got["CLAUDE_CONFIG_DIR"])
+	assertForfaitEnv(t, got, "/tmp/iterion-oauth-claude")
+}
+
+func TestAnthropicCredEnv_AutoForfaitSuppressesInheritedKey(t *testing.T) {
+	resetClaudeCredEnv(t)
+	// A shared, possibly-dead ANTHROPIC_API_KEY in the runner's pod env must
+	// NOT shadow a resolved per-run forfait: the returned map suppresses it
+	// (""), and mergeCmdEnv (claudesdk) turns that into an absent var so the
+	// CLI uses the CLAUDE_CONFIG_DIR OAuth token.
+	t.Setenv("ANTHROPIC_API_KEY", "sk-dead-shared")
+	ctx := ctxWithCreds(t, nil, map[string]string{
+		string(secrets.OAuthKindClaudeCode): "/tmp/iterion-oauth-claude",
+	})
+	got := anthropicCredEnvForCLI(ctx, "")
+	assertForfaitEnv(t, got, "/tmp/iterion-oauth-claude")
+}
+
+// assertForfaitEnv pins the forfait env contract: the OAuth config dir is
+// wired and every Anthropic-flavoured credential that could shadow it is
+// explicitly emptied (suppression signal consumed by mergeCmdEnv).
+func assertForfaitEnv(t *testing.T, got map[string]string, wantDir string) {
+	t.Helper()
+	if got["CLAUDE_CONFIG_DIR"] != wantDir {
+		t.Errorf("CLAUDE_CONFIG_DIR: got %q, want %q", got["CLAUDE_CONFIG_DIR"], wantDir)
+	}
+	for _, k := range []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL"} {
+		v, present := got[k]
+		if !present || v != "" {
+			t.Errorf("%s must be present and empty (suppression): present=%v val=%q", k, present, v)
+		}
 	}
 }
 

--- a/pkg/backend/delegate/claude_code_creds.go
+++ b/pkg/backend/delegate/claude_code_creds.go
@@ -185,6 +185,26 @@ func providerFingerprint(env map[string]string) string {
 // inherited env var" (e.g. {"ANTHROPIC_BASE_URL": ""} actively
 // suppresses a stale z.ai value in the parent env when the hint asks
 // for Anthropic-direct).
+// claudeForfaitEnv wires the CLI to a per-run OAuth-forfait credentials.json
+// (desktop `claude login` shape) via CLAUDE_CONFIG_DIR — and actively
+// SUPPRESSES any Anthropic-flavoured credential inherited from the process
+// env. The claude CLI prefers ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN over the
+// OAuth token in CLAUDE_CONFIG_DIR, so a cloud runner that carries a shared
+// ANTHROPIC_API_KEY in its pod env (e.g. an operator-configured key, possibly
+// dead) would otherwise override the forfait — the run then fails with the
+// inherited key's error ("Credit balance is too low") even though a valid
+// forfait was resolved. Setting the vars to "" overrides the inheritance so the
+// CLI falls through to the OAuth token. Mirrors how the z.ai/anthropic hints
+// clear the base-URL/token to stop a stale value leaking in.
+func claudeForfaitEnv(dir string) map[string]string {
+	return map[string]string{
+		"CLAUDE_CONFIG_DIR":    dir,
+		"ANTHROPIC_API_KEY":    "",
+		"ANTHROPIC_AUTH_TOKEN": "",
+		"ANTHROPIC_BASE_URL":   "",
+	}
+}
+
 func anthropicCredEnvForCLI(ctx context.Context, providerHint string) map[string]string {
 	creds, hasCreds := secrets.CredentialsFromContext(ctx)
 
@@ -196,7 +216,7 @@ func anthropicCredEnvForCLI(ctx context.Context, providerHint string) map[string
 				return map[string]string{"ANTHROPIC_API_KEY": k}
 			}
 			if d := creds.OAuthDir(string(secrets.OAuthKindClaudeCode)); d != "" {
-				return map[string]string{"CLAUDE_CONFIG_DIR": d}
+				return claudeForfaitEnv(d)
 			}
 		}
 		// Process-env path: rely on ANTHROPIC_API_KEY inherited by the
@@ -249,7 +269,7 @@ func anthropicCredEnvForCLI(ctx context.Context, providerHint string) map[string
 		case creds.APIKey(secrets.ProviderAnthropic) != "":
 			return map[string]string{"ANTHROPIC_API_KEY": creds.APIKey(secrets.ProviderAnthropic)}
 		case creds.OAuthDir(string(secrets.OAuthKindClaudeCode)) != "":
-			return map[string]string{"CLAUDE_CONFIG_DIR": creds.OAuthDir(string(secrets.OAuthKindClaudeCode))}
+			return claudeForfaitEnv(creds.OAuthDir(string(secrets.OAuthKindClaudeCode)))
 		}
 	}
 	// Env-fallback: ZAI_API_KEY is the convenience knob for desktop

--- a/pkg/backend/delegate/claudesdk/process.go
+++ b/pkg/backend/delegate/claudesdk/process.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -259,10 +260,7 @@ func spawnProcess(ctx context.Context, cliPath string, args []string, opts spawn
 		if opts.Cwd != "" {
 			cmd.Dir = opts.Cwd
 		}
-		cmd.Env = os.Environ()
-		for k, v := range opts.Env {
-			cmd.Env = append(cmd.Env, k+"="+v)
-		}
+		cmd.Env = mergeCmdEnv(os.Environ(), opts.Env)
 	}
 
 	// Pipes are file descriptors in the parent process; if a later step
@@ -494,4 +492,46 @@ func (p *cliProcess) drainStderr() {
 			p.stderrCallback(line)
 		}
 	}
+}
+
+// mergeCmdEnv layers override onto base (typically os.Environ()) with
+// key-level REPLACEMENT rather than blind appending. A key present in override
+// removes every inherited occurrence, then:
+//   - non-empty value → the override value is set (single occurrence);
+//   - empty value → the key is SUPPRESSED (left absent).
+//
+// This matters because a plain `append(os.Environ(), "K=v")` leaves duplicate
+// keys, and the child's resolution of a duplicate is not guaranteed to be the
+// appended (last) one — glibc getenv and Node build process.env differently.
+// The claude CLI prefers ANTHROPIC_API_KEY over the CLAUDE_CONFIG_DIR OAuth
+// token, so a runner carrying a shared ANTHROPIC_API_KEY in its pod env would
+// otherwise shadow a per-run forfait even when the resolver set the key to ""
+// to suppress it. Deterministic (override keys applied in sorted order).
+func mergeCmdEnv(base []string, override map[string]string) []string {
+	if len(override) == 0 {
+		return base
+	}
+	out := make([]string, 0, len(base)+len(override))
+	for _, kv := range base {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			out = append(out, kv)
+			continue
+		}
+		if _, ok := override[kv[:eq]]; ok {
+			continue // inherited value replaced/suppressed below
+		}
+		out = append(out, kv)
+	}
+	keys := make([]string, 0, len(override))
+	for k := range override {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if v := override[k]; v != "" {
+			out = append(out, k+"="+v)
+		}
+	}
+	return out
 }

--- a/pkg/backend/delegate/claudesdk/process_env_test.go
+++ b/pkg/backend/delegate/claudesdk/process_env_test.go
@@ -1,0 +1,81 @@
+package claudesdk
+
+import (
+	"strings"
+	"testing"
+)
+
+// mergeCmdEnv must REPLACE inherited keys (no duplicates) and treat an empty
+// override value as suppression. The claude CLI prefers ANTHROPIC_API_KEY over
+// the CLAUDE_CONFIG_DIR OAuth token, so a per-run forfait that sets
+// ANTHROPIC_API_KEY="" to shadow a runner's inherited key relies on this: a
+// plain append would leave a duplicate whose resolution is not guaranteed.
+func TestMergeCmdEnv(t *testing.T) {
+	base := []string{
+		"PATH=/usr/bin",
+		"ANTHROPIC_API_KEY=sk-dead-inherited",
+		"ANTHROPIC_BASE_URL=https://stale.zai",
+		"HOME=/root",
+	}
+	override := map[string]string{
+		"CLAUDE_CONFIG_DIR":    "/tmp/iter-oauth-xyz",
+		"ANTHROPIC_API_KEY":    "", // suppress the inherited dead key
+		"ANTHROPIC_BASE_URL":   "", // suppress stale z.ai base
+		"ANTHROPIC_AUTH_TOKEN": "",
+	}
+	got := mergeCmdEnv(base, override)
+
+	// No inherited ANTHROPIC_API_KEY may survive, in any form.
+	for _, kv := range got {
+		if strings.HasPrefix(kv, "ANTHROPIC_API_KEY=") {
+			t.Errorf("ANTHROPIC_API_KEY must be suppressed entirely, found %q", kv)
+		}
+		if strings.HasPrefix(kv, "ANTHROPIC_BASE_URL=") {
+			t.Errorf("ANTHROPIC_BASE_URL must be suppressed entirely, found %q", kv)
+		}
+	}
+	// The forfait dir and untouched inherited vars survive exactly once.
+	if n := countKey(got, "CLAUDE_CONFIG_DIR"); n != 1 || !contains(got, "CLAUDE_CONFIG_DIR=/tmp/iter-oauth-xyz") {
+		t.Errorf("CLAUDE_CONFIG_DIR not set once: n=%d env=%v", n, got)
+	}
+	if !contains(got, "PATH=/usr/bin") || !contains(got, "HOME=/root") {
+		t.Errorf("inherited unrelated vars dropped: %v", got)
+	}
+}
+
+// A non-empty override replaces (not duplicates) an inherited key.
+func TestMergeCmdEnv_ReplaceNonEmpty(t *testing.T) {
+	got := mergeCmdEnv([]string{"K=old", "OTHER=x"}, map[string]string{"K": "new"})
+	if countKey(got, "K") != 1 || !contains(got, "K=new") {
+		t.Errorf("K should be replaced once with new: %v", got)
+	}
+	if contains(got, "K=old") {
+		t.Errorf("stale K=old survived: %v", got)
+	}
+}
+
+func TestMergeCmdEnv_EmptyOverrideReturnsBase(t *testing.T) {
+	base := []string{"A=1"}
+	if got := mergeCmdEnv(base, nil); len(got) != 1 || got[0] != "A=1" {
+		t.Errorf("empty override should return base unchanged: %v", got)
+	}
+}
+
+func countKey(env []string, key string) int {
+	n := 0
+	for _, kv := range env {
+		if strings.HasPrefix(kv, key+"=") {
+			n++
+		}
+	}
+	return n
+}
+
+func contains(env []string, want string) bool {
+	for _, kv := range env {
+		if kv == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Problem

A cloud runner carries the operator-configured `ANTHROPIC_API_KEY` in its pod env (the `iterion-llm` secret). When a run resolves a **per-run OAuth-forfait** (Claude subscription), the resolver returned `{"CLAUDE_CONFIG_DIR": dir}` but left that inherited key in place. The claude CLI **prefers `ANTHROPIC_API_KEY`** over the `CLAUDE_CONFIG_DIR` OAuth token, so the forfait was shadowed and the run failed with the *inherited* key's error.

Observed live (firecrawl end-to-end validation): firecrawl was forwarded correctly (`mcp=1, tools=30`), but every `claude_code` turn returned a 25-char `"Credit balance is too low"` (the shared key's dead-balance error) instead of using the freshly-provisioned forfait. The runner logs confirmed the forfait *was* materialised (`oauth-forfait active kind=claude_code file=/tmp/iter-oauth-…/.credentials.json`) — it was just being shadowed.

## Fix

1. **`claudeForfaitEnv`** returns the OAuth dir **and** empties `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL`, mirroring how the existing z.ai/anthropic hints clear stale routing.
2. **`claudesdk` subprocess env by REPLACEMENT, not blind append** (`mergeCmdEnv`): an override key removes every inherited occurrence; an empty value **suppresses** the key entirely. `append(os.Environ(), "K=v")` left duplicate keys whose child-side resolution isn't guaranteed to be the appended one (glibc `getenv` vs Node `process.env` differ) — so the `""` suppression the resolver *already* used for z.ai was itself unreliable. Now deterministic.

## Tests

- `TestMergeCmdEnv` (replace / suppress-when-empty / no-dup / no-op),
- `TestAnthropicCredEnv_AutoForfaitSuppressesInheritedKey` + the extended `…FallsToOAuthDir` assert the three vars are emptied under both the default and `anthropic` hints.

Part of the sovereign-web-search / firecrawl-in-cloud line (follows #178 + #180). Unblocks the `claude_code` + forfait path so it uses the Claude subscription instead of a shared/dead API key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)