### PR TITLE
fix(claude_code): export CLAUDE_CODE_OAUTH_TOKEN for the forfait (headless auth)

### DIFF
--- a/pkg/backend/delegate/claude_code_cred_test.go
+++ b/pkg/backend/delegate/claude_code_cred_test.go
@@ -2,6 +2,8 @@ package delegate
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/secrets"
@@ -137,6 +139,29 @@ func assertForfaitEnv(t *testing.T, got map[string]string, wantDir string) {
 		if !present || v != "" {
 			t.Errorf("%s must be present and empty (suppression): present=%v val=%q", k, present, v)
 		}
+	}
+}
+
+// When the materialised dir holds a real credentials.json, the resolver also
+// exports CLAUDE_CODE_OAUTH_TOKEN — the first-precedence headless auth path
+// that bypasses a cloud runner's env shadowing the credentials FILE. A dir
+// without a readable file degrades to the file path (no token key).
+func TestClaudeForfaitEnv_ExportsOAuthTokenFromFile(t *testing.T) {
+	dir := t.TempDir()
+	blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat-TESTTOKEN","refreshToken":"r","expiresAt":1,"scopes":["user:inference"]}}`
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(blob), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := claudeForfaitEnv(dir)
+	assertForfaitEnv(t, got, dir)
+	if got["CLAUDE_CODE_OAUTH_TOKEN"] != "sk-ant-oat-TESTTOKEN" {
+		t.Errorf("CLAUDE_CODE_OAUTH_TOKEN: got %q, want the file's accessToken", got["CLAUDE_CODE_OAUTH_TOKEN"])
+	}
+
+	// No file → no token key, file path preserved.
+	bare := claudeForfaitEnv(t.TempDir())
+	if _, present := bare["CLAUDE_CODE_OAUTH_TOKEN"]; present {
+		t.Errorf("CLAUDE_CODE_OAUTH_TOKEN must be absent when no credentials file is present: %v", bare)
 	}
 }
 

--- a/pkg/backend/delegate/claude_code_creds.go
+++ b/pkg/backend/delegate/claude_code_creds.go
@@ -2,8 +2,10 @@ package delegate
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -197,12 +199,46 @@ func providerFingerprint(env map[string]string) string {
 // CLI falls through to the OAuth token. Mirrors how the z.ai/anthropic hints
 // clear the base-URL/token to stop a stale value leaking in.
 func claudeForfaitEnv(dir string) map[string]string {
-	return map[string]string{
+	env := map[string]string{
 		"CLAUDE_CONFIG_DIR":    dir,
 		"ANTHROPIC_API_KEY":    "",
 		"ANTHROPIC_AUTH_TOKEN": "",
 		"ANTHROPIC_BASE_URL":   "",
 	}
+	// Also pass the OAuth access token via CLAUDE_CODE_OAUTH_TOKEN — the
+	// headless auth path the Claude Code CLI checks BEFORE the credentials file
+	// (and before any apiKeyHelper), the same one its own UI hints at
+	// ("export CLAUDE_CODE_OAUTH_TOKEN=<token>"). The file path
+	// ($CLAUDE_CONFIG_DIR/.credentials.json) works standalone — verified with
+	// the runner's exact CLI build — but a cloud runner's full inherited pod
+	// env can shadow it, so the CLI reports "Not logged in" despite a valid
+	// materialised forfait. Reading it here from the materialised file (kept
+	// fresh by the runner's refresh worker; re-read per spawn) makes the env
+	// token deterministically win. Best-effort: on any read/parse failure we
+	// fall back to the file path alone (prior behaviour).
+	if tok := readForfaitAccessToken(dir); tok != "" {
+		env["CLAUDE_CODE_OAUTH_TOKEN"] = tok
+	}
+	return env
+}
+
+// readForfaitAccessToken extracts claudeAiOauth.accessToken from the
+// materialised Claude Code credentials.json in dir. Returns "" (never an error)
+// when the file is absent or malformed — the caller degrades to the file path.
+func readForfaitAccessToken(dir string) string {
+	data, err := os.ReadFile(filepath.Join(dir, ".credentials.json"))
+	if err != nil {
+		return ""
+	}
+	var v struct {
+		ClaudeAIOauth struct {
+			AccessToken string `json:"accessToken"`
+		} `json:"claudeAiOauth"`
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return ""
+	}
+	return v.ClaudeAIOauth.AccessToken
 }
 
 func anthropicCredEnvForCLI(ctx context.Context, providerHint string) map[string]string {


### PR DESCRIPTION
Follow-up to #184. Getting `claude_code` + Claude subscription forfait working on the cloud runner.

## The wall #184 revealed

#184 stopped the CLI from picking the inherited (dead) shared `ANTHROPIC_API_KEY`. The forfait then resolved to `Not logged in · Please run /login` on the runner — even though the per-run forfait **was** materialised (`oauth-forfait active kind=claude_code file=…/.credentials.json`) and the token is valid.

## Root cause (isolated locally against the runner's EXACT CLI build)

Downloaded `@anthropic-ai/claude-code@2.1.175` (the runner's pin) and tested both auth paths with a minimal `credentials.json`:
- file in `$CLAUDE_CONFIG_DIR/.credentials.json` → **works** (`OK-175-FILE`)
- `CLAUDE_CODE_OAUTH_TOKEN` env → **works** (`OK-175-ENV`)

So it's **neither the CLI version nor the credential shape**. What differs is the cloud runner's **full inherited pod env**, which shadows the CLI's FILE auth path (the file is only consulted *after* the env / apiKeyHelper checks in the CLI's resolver).

## Fix

Also export **`CLAUDE_CODE_OAUTH_TOKEN`** — the CLI checks it **before** the file and before any apiKeyHelper (it's the exact mechanism the CLI's own UI hints at: `export CLAUDE_CODE_OAUTH_TOKEN=<token>`), so it deterministically wins and bypasses whatever pod-env state breaks the file path. Read from the materialised `credentials.json` (kept fresh by the runner's refresh worker, re-read per spawn); any read/parse failure degrades to the file path alone (prior behaviour).

## Tests

`TestClaudeForfaitEnv_ExportsOAuthTokenFromFile` — token exported from a real file, key omitted when absent. All existing `TestAnthropicCredEnv_*` / `TestMergeCmdEnv` still green.

Part of the sovereign-web-search / firecrawl-in-cloud line (#178, #180, #184). `claude_code` already forwards firecrawl correctly (`mcp=1`); this is the last piece — Anthropic auth for the headless CLI on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)