### PR TITLE
fix(runtime/skills): mirror a flat <name>.md alias next to the SKILL.md dir

### DIFF
--- a/pkg/runtime/bundle.go
+++ b/pkg/runtime/bundle.go
@@ -141,15 +141,9 @@ func MirrorSingleSkill(workDir string, b *bundle.Bundle, name string, logger *it
 		}
 		return copyDir(srcPath, destPath)
 	}
-	// File skill → directory form <dest>/<stem>/SKILL.md (see skillDestDirForm).
-	skillDir, skillDest, markerPath, derr := skillDestDirForm(dest, markerDir, name)
-	if derr != nil {
-		return derr
-	}
-	if err := os.MkdirAll(skillDir, 0o755); err != nil {
-		return fmt.Errorf("runtime/bundle: mkdir %s: %w", skillDir, err)
-	}
-	_, err = reconcileSkillFile(srcPath, skillDest, markerPath, logger)
+	// File skill → directory form (native discovery) + flat alias (prompt
+	// Reads). Shared with mirrorBundleSkills via mirrorFileSkill.
+	_, err = mirrorFileSkill(dest, markerDir, srcPath, name, logger)
 	return err
 }
 
@@ -171,6 +165,41 @@ func skillDestDirForm(dest, markerDir, srcName string) (skillDir, destPath, mark
 	destPath = filepath.Join(skillDir, "SKILL.md")
 	markerPath = filepath.Join(markerDir, stem+".SKILL.md.sha256")
 	return skillDir, destPath, markerPath, nil
+}
+
+// mirrorFileSkill mirrors one flat "<stem>.md" source skill into BOTH forms
+// under <dest>:
+//   - directory form <stem>/SKILL.md — what the claude_code (and claw) Skill
+//     TOOLS discover natively (Agent Skills spec);
+//   - flat alias <stem>.md — what a bot prompt that Reads the skill by PATH
+//     ("READ .claude/skills/<stem>.md FIRST", the pattern most catalog bots
+//     use for upfront context) resolves.
+//
+// The mirror historically wrote only the flat file, then moved to the
+// directory form for native discovery — which silently broke every prompt
+// still Reading the flat path (the agent then wastes turns re-finding the file,
+// observed dogfooding Vetty on a dependency PR). Writing both keeps native
+// discovery AND explicit Reads working. Each form goes through
+// reconcileSkillFile so the workspace-wins collision policy holds independently;
+// the returned outcome is the directory-form result (the one callers tally).
+func mirrorFileSkill(dest, markerDir, srcPath, name string, logger *iterlog.Logger) (skillReconcileOutcome, error) {
+	skillDir, skillDest, markerPath, err := skillDestDirForm(dest, markerDir, name)
+	if err != nil {
+		return skillOutcomeShadowed, err
+	}
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		return skillOutcomeShadowed, fmt.Errorf("runtime/bundle: mkdir %s: %w", skillDir, err)
+	}
+	outcome, err := reconcileSkillFile(srcPath, skillDest, markerPath, logger)
+	if err != nil {
+		return outcome, err
+	}
+	flatDest := filepath.Join(dest, name)
+	flatMarker := filepath.Join(markerDir, name+".sha256")
+	if _, ferr := reconcileSkillFile(srcPath, flatDest, flatMarker, logger); ferr != nil {
+		return outcome, ferr
+	}
+	return outcome, nil
 }
 
 // mirrorBundleSkills copies every top-level entry from bundle.SkillsDir
@@ -233,17 +262,10 @@ func mirrorBundleSkills(workDir string, b *bundle.Bundle, logger *iterlog.Logger
 			mirrored++
 			continue
 		}
-		// File skill → mirror as <dest>/<stem>/SKILL.md (directory form) so
-		// the claude_code Skill tool discovers it; a flat <name>.md is
-		// invisible to it. Shared reconciliation with MirrorSingleSkill.
-		skillDir, skillDest, markerPath, derr := skillDestDirForm(dest, markerDir, name)
-		if derr != nil {
-			return derr
-		}
-		if err := os.MkdirAll(skillDir, 0o755); err != nil {
-			return fmt.Errorf("runtime/bundle: mkdir %s: %w", skillDir, err)
-		}
-		outcome, err := reconcileSkillFile(srcPath, skillDest, markerPath, logger)
+		// File skill → both the directory form (native Skill-tool discovery)
+		// and the flat <name>.md alias (prompt Reads). Shared with
+		// MirrorSingleSkill via mirrorFileSkill.
+		outcome, err := mirrorFileSkill(dest, markerDir, srcPath, name, logger)
 		if err != nil {
 			return err
 		}

--- a/pkg/runtime/bundle_test.go
+++ b/pkg/runtime/bundle_test.go
@@ -31,9 +31,17 @@ func TestMirrorBundleSkills_CopiesIntoClaudeSkills(t *testing.T) {
 
 	dest := filepath.Join(workDir, ".claude", "skills")
 	// Flat "probe.md" source mirrors to the directory form "probe/SKILL.md"
-	// (the only form claude_code's Skill tool discovers).
+	// (the form claude_code's Skill tool discovers natively).
 	if _, err := os.Stat(filepath.Join(dest, "probe", "SKILL.md")); err != nil {
 		t.Errorf("probe/SKILL.md missing: %v", err)
+	}
+	// AND to the flat alias "probe.md" so a bot prompt that Reads the skill by
+	// its flat path (`.claude/skills/probe.md`, the pattern most catalog bots
+	// use) resolves it instead of failing + re-finding the file.
+	if got, err := os.ReadFile(filepath.Join(dest, "probe.md")); err != nil {
+		t.Errorf("flat alias probe.md missing: %v", err)
+	} else if string(got) != "# probe\n" {
+		t.Errorf("flat alias probe.md content = %q, want the source content", got)
 	}
 	// A source that is already a directory is copied through unchanged.
 	if _, err := os.Stat(filepath.Join(dest, "nested", "step.md")); err != nil {


### PR DESCRIPTION
Found dogfooding **Vetty** (dep-update-guard) on a real Renovate PR (#182).

## Problem

The skill mirror writes the CC-2.x **directory form** `.claude/skills/<name>/SKILL.md` (what the claude_code / claw Skill **tools** discover natively). But ~8 shipped catalog bots have prompts that **Read the skill by its flat path** — e.g. `READ THE SKILL FIRST: `.claude/skills/dependency-pr-guard.md``. That flat file no longer exists, so the Read fails and the agent burns turns re-finding it.

Observed live on Vetty's audit node:
```
🔧 Read .claude/skills/dependency-pr-guard.md
❌ File does not exist. Did you mean dependency-pr-guard?   ← the DIR exists, the flat .md doesn't
🔧 Read .claude/skills/package-managers.md      ❌ File does not exist
🔧 Bash find / -name "dependency-pr-guard*" ...  → /opt/iterion/bots/dep-update-guard/skills/...
```
The agent recovered from the runner image's baked `/opt/iterion/bots/...` copy — but that fallback **doesn't exist on a non-iterion target repo**, so Vetty (and evolve, bmady, adr-rechallenge, secured-renovacy, revi-converse, review-pr, sec-audit-source) would run with a degraded/no skill there.

## Fix

Mirror **both** forms: the directory form (native discovery) **and** a flat `<name>.md` alias (explicit prompt Reads). Both go through the same `reconcileSkillFile` workspace-wins collision policy, so a repo's own committed skill of the same name still shadows the bundle's. Shared helper `mirrorFileSkill` keeps `mirrorBundleSkills` and `MirrorSingleSkill` in lockstep.

Test: `TestMirrorBundleSkills_CopiesIntoClaudeSkills` now asserts both `probe/SKILL.md` and the flat `probe.md` alias (+ content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)