### PR TITLE
fix(kimi): support current stream-json protocol

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -444,7 +444,7 @@ iterion ships a dedicated **`kimi`** backend for it:
 ```yaml
 agent implement:
   backend: "kimi"
-  model: "moonshot/kimi-k2"    # the provider segment is stripped → `-m kimi-k2`
+  model: "kimi-code/kimi-for-coding" # complete kimi-code alias is preserved
   system: "…the task…"
 ```
 
@@ -452,8 +452,9 @@ Under the hood, `kimi` is a concrete instance of a generic **CLI-agent
 backend** (`delegate.CLIAgentBackend` + `CLIAgentProtocol`, see
 [ADR-065](adr/065-dedicated-cli-agent-backend.md)) that builds the target
 CLI's *own* command line, runs it with a wall-clock timeout (inside the run's
-sandbox container when one is active), parses its stdout (kimi emits a
-claude-code-style `stream-json` stream) into the structured result, and retries
+sandbox container when one is active), parses its role-based `stream-json`
+stdout (with backward compatibility for the former claude-code-style events)
+into the structured result, and retries
 on a no-output / network transient. Adding another such CLI is a new protocol
 *value*, not new plumbing.
 

--- a/pkg/backend/delegate/cliagent.go
+++ b/pkg/backend/delegate/cliagent.go
@@ -372,13 +372,11 @@ func envSliceToMap(resolve func(context.Context) map[string]string, ctx context.
 	return resolve(ctx)
 }
 
-// parseStreamJSONText walks a claude-code-style NDJSON stream (`type: assistant`
-// text blocks + a terminal `type: result`) and extracts the assistant's final
-// text, session id, and token usage. It is defensive: unrecognised lines are
-// skipped, and when no `result` event is present it accumulates assistant text
-// blocks; when nothing parses it falls back to the raw stream. Third-party
-// agent CLIs that emit `--output-format stream-json` overwhelmingly mirror this
-// event shape; a protocol whose stream differs supplies its own ParseOutput.
+// parseStreamJSONText walks both the legacy claude-code-style NDJSON stream
+// (`type: assistant` + terminal `type: result`) and kimi-code 0.23+'s native
+// role stream (`role: assistant`, followed by a `role: meta` resume hint).
+// It extracts the assistant's final text, session id, and token usage. Unknown
+// lines are skipped; when nothing parses it falls back to the raw stream.
 func parseStreamJSONText(stdout string) (text, sessionID string, tokens int) {
 	var assistantText strings.Builder
 	var resultText string
@@ -396,15 +394,29 @@ func parseStreamJSONText(stdout string) (text, sessionID string, tokens int) {
 		if sid, ok := ev["session_id"].(string); ok && sid != "" {
 			sessionID = sid
 		}
+		if u, ok := ev["usage"].(map[string]any); ok {
+			tokens += asInt(u["input_tokens"]) + asInt(u["output_tokens"])
+		}
+		if role, _ := ev["role"].(string); role == "assistant" {
+			switch content := ev["content"].(type) {
+			case string:
+				assistantText.WriteString(content)
+			case []any:
+				for _, item := range content {
+					if block, ok := item.(map[string]any); ok {
+						if value, ok := block["text"].(string); ok {
+							assistantText.WriteString(value)
+						}
+					}
+				}
+			}
+		}
 		typ, _ := ev["type"].(string)
 		switch typ {
 		case "result":
 			if r, ok := ev["result"].(string); ok {
 				resultText = r
 				haveResult = true
-			}
-			if u, ok := ev["usage"].(map[string]any); ok {
-				tokens += asInt(u["input_tokens"]) + asInt(u["output_tokens"])
 			}
 		case "assistant":
 			if msg, ok := ev["message"].(map[string]any); ok {

--- a/pkg/backend/delegate/cliagent.go
+++ b/pkg/backend/delegate/cliagent.go
@@ -378,7 +378,8 @@ func envSliceToMap(resolve func(context.Context) map[string]string, ctx context.
 // It extracts the assistant's final text, session id, and token usage. Unknown
 // lines are skipped; when nothing parses it falls back to the raw stream.
 func parseStreamJSONText(stdout string) (text, sessionID string, tokens int) {
-	var assistantText strings.Builder
+	var legacyAssistantText strings.Builder
+	var nativeAssistantText string
 	var resultText string
 	haveResult := false
 
@@ -398,17 +399,25 @@ func parseStreamJSONText(stdout string) (text, sessionID string, tokens int) {
 			tokens += asInt(u["input_tokens"]) + asInt(u["output_tokens"])
 		}
 		if role, _ := ev["role"].(string); role == "assistant" {
+			var message strings.Builder
 			switch content := ev["content"].(type) {
 			case string:
-				assistantText.WriteString(content)
+				message.WriteString(content)
 			case []any:
 				for _, item := range content {
 					if block, ok := item.(map[string]any); ok {
 						if value, ok := block["text"].(string); ok {
-							assistantText.WriteString(value)
+							message.WriteString(value)
 						}
 					}
 				}
+			}
+			// Native kimi role events are complete assistant messages, not
+			// token deltas. Tool-using sessions can contain an early status
+			// message followed by the actual final answer; keep the latest
+			// non-empty message instead of concatenating both into invalid JSON.
+			if message.Len() > 0 {
+				nativeAssistantText = message.String()
 			}
 		}
 		typ, _ := ev["type"].(string)
@@ -425,7 +434,7 @@ func parseStreamJSONText(stdout string) (text, sessionID string, tokens int) {
 						if blk, ok := c.(map[string]any); ok {
 							if t, _ := blk["type"].(string); t == "text" {
 								if txt, ok := blk["text"].(string); ok {
-									assistantText.WriteString(txt)
+									legacyAssistantText.WriteString(txt)
 								}
 							}
 						}
@@ -438,8 +447,10 @@ func parseStreamJSONText(stdout string) (text, sessionID string, tokens int) {
 	switch {
 	case haveResult && resultText != "":
 		return resultText, sessionID, tokens
-	case assistantText.Len() > 0:
-		return assistantText.String(), sessionID, tokens
+	case nativeAssistantText != "":
+		return nativeAssistantText, sessionID, tokens
+	case legacyAssistantText.Len() > 0:
+		return legacyAssistantText.String(), sessionID, tokens
 	default:
 		// Nothing recognisable — hand back the raw stream so the schema-aware
 		// fallback can still try to extract a JSON object from it.

--- a/pkg/backend/delegate/cliagent_test.go
+++ b/pkg/backend/delegate/cliagent_test.go
@@ -53,7 +53,7 @@ func TestCLIAgentBuildArgs(t *testing.T) {
 		}
 		promptArg := task.BuildSystemPrompt() + "\n\n" + task.UserPrompt
 		args, stdin := b.buildArgs(kimiProtocol, task, promptArg, task.BuildSystemPrompt())
-		want := []string{"-p", "be terse\n\nhello", "--output-format", "stream-json", "-m", "kimi-k2"}
+		want := []string{"-p", "be terse\n\nhello", "--output-format", "stream-json", "-m", "moonshot/kimi-k2"}
 		if !reflect.DeepEqual(args, want) {
 			t.Fatalf("args = %v, want %v", args, want)
 		}
@@ -98,10 +98,10 @@ func TestCLIAgentBuildArgs(t *testing.T) {
 
 func TestKimiMapModel(t *testing.T) {
 	cases := map[string]string{
-		"moonshot/kimi-k2": "kimi-k2",
-		"kimi/k2":          "k2",
+		"moonshot/kimi-k2": "moonshot/kimi-k2",
+		"kimi/k2":          "kimi/k2",
 		"kimi-k2":          "kimi-k2",
-		"  moonshot/x  ":   "x",
+		"  moonshot/x  ":   "moonshot/x",
 	}
 	for in, want := range cases {
 		if got := kimiMapModel(in); got != want {
@@ -111,6 +111,21 @@ func TestKimiMapModel(t *testing.T) {
 }
 
 func TestParseStreamJSONText(t *testing.T) {
+	t.Run("kimi 0.23 native role stream", func(t *testing.T) {
+		stream := `{"role":"assistant","content":"final answer"}
+{"role":"meta","type":"session.resume_hint","session_id":"sess-current","content":"resume"}`
+		text, sid, tokens := parseStreamJSONText(stream)
+		if text != "final answer" {
+			t.Errorf("text = %q, want final answer", text)
+		}
+		if sid != "sess-current" {
+			t.Errorf("sessionID = %q, want sess-current", sid)
+		}
+		if tokens != 0 {
+			t.Errorf("tokens = %d, want 0 when stream reports no usage", tokens)
+		}
+	})
+
 	t.Run("result event wins", func(t *testing.T) {
 		stream := `{"type":"assistant","message":{"content":[{"type":"text","text":"thinking"}]}}
 {"type":"result","result":"final answer","session_id":"sess-1","usage":{"input_tokens":10,"output_tokens":5}}`
@@ -152,10 +167,11 @@ func TestCLIAgentExecute(t *testing.T) {
 	}
 	dir := t.TempDir()
 	fake := filepath.Join(dir, "fakekimi")
-	// The script emits a stream-json result whose text is a JSON object, so
+	// The script emits kimi-code 0.23's role stream whose content is a JSON object, so
 	// the schema-aware fallback extracts it into Result.Output.
 	script := `#!/bin/sh
-printf '%s\n' '{"type":"result","result":"{\"answer\":\"42\"}","session_id":"s9","usage":{"input_tokens":3,"output_tokens":7}}'
+printf '%s\n' '{"role":"assistant","content":"{\"answer\":\"42\"}"}'
+printf '%s\n' '{"role":"meta","type":"session.resume_hint","session_id":"s9"}'
 `
 	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil { // #nosec G306 — test fixture must be executable
 		t.Fatal(err)
@@ -184,8 +200,8 @@ printf '%s\n' '{"type":"result","result":"{\"answer\":\"42\"}","session_id":"s9"
 	if got := res.Output["answer"]; got != "42" {
 		t.Errorf("Output[answer] = %v, want 42", got)
 	}
-	if res.Tokens != 10 {
-		t.Errorf("Tokens = %d, want 10", res.Tokens)
+	if res.Tokens != 0 {
+		t.Errorf("Tokens = %d, want 0 when kimi reports no usage", res.Tokens)
 	}
 }
 

--- a/pkg/backend/delegate/cliagent_test.go
+++ b/pkg/backend/delegate/cliagent_test.go
@@ -126,6 +126,21 @@ func TestParseStreamJSONText(t *testing.T) {
 		}
 	})
 
+	t.Run("kimi native role stream keeps final assistant message", func(t *testing.T) {
+		stream := `{"role":"assistant","content":"I will inspect the files first."}
+{"role":"assistant","tool_calls":[{"type":"function","id":"tool-1"}]}
+{"role":"tool","tool_call_id":"tool-1","content":"done"}
+{"role":"assistant","content":"{\"answer\":\"42\"}"}
+{"role":"meta","type":"session.resume_hint","session_id":"sess-tools"}`
+		text, sid, _ := parseStreamJSONText(stream)
+		if text != `{"answer":"42"}` {
+			t.Errorf("text = %q, want final JSON message", text)
+		}
+		if sid != "sess-tools" {
+			t.Errorf("sessionID = %q, want sess-tools", sid)
+		}
+	})
+
 	t.Run("result event wins", func(t *testing.T) {
 		stream := `{"type":"assistant","message":{"content":[{"type":"text","text":"thinking"}]}}
 {"type":"result","result":"final answer","session_id":"sess-1","usage":{"input_tokens":10,"output_tokens":5}}`

--- a/pkg/backend/delegate/kimi.go
+++ b/pkg/backend/delegate/kimi.go
@@ -47,14 +47,10 @@ func NewKimiBackend(logger *iterlog.Logger, command string) *CLIAgentBackend {
 	}
 }
 
-// kimiMapModel translates an iterion model spec into the alias kimi's `-m`
-// flag expects. iterion specs are `provider/model` (e.g. "moonshot/kimi-k2");
-// kimi wants the bare alias, so we strip a leading provider segment. A spec
-// with no "/" is passed through unchanged (already an alias, e.g. "kimi-k2").
+// kimiMapModel preserves the complete kimi-code model alias. Current aliases
+// commonly contain a slash themselves (for example
+// "kimi-code/kimi-for-coding"), so treating the prefix as an iterion provider
+// and stripping it produces an alias that kimi-code cannot resolve.
 func kimiMapModel(model string) string {
-	model = strings.TrimSpace(model)
-	if i := strings.Index(model, "/"); i >= 0 {
-		return model[i+1:]
-	}
-	return model
+	return strings.TrimSpace(model)
 }


### PR DESCRIPTION
## Summary
- parse kimi-code 0.23+ role-based stream-json while keeping legacy events
- preserve complete kimi-code model aliases such as kimi-code/kimi-for-coding
- update backend documentation and end-to-end fake CLI coverage

## Validation
- go test ./pkg/backend/delegate
- real local smoke with kimi-code 0.23.5 through Iterion: structured output parsed successfully