### PR TITLE
fix(webhooks): never auto-launch on fork PRs; keep dep-bot PRs off the improve loop

### DIFF
--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -203,6 +204,13 @@ func selectForgePRBot(cfg webhooks.Config, p prforge.Parsed) string {
 	if p.IsCrossRepo() {
 		return ""
 	}
+	// Dependency-update PRs (Dependabot/Renovate) never route to the
+	// branch-improvement loop: an improve loop over a bumped manifest/lockfile
+	// is off-target and churns the bot's own PR. The dependency guard (Vetty)
+	// owns that lane — via its own invocation / a `/command`.
+	if isDependencyBotAuthor(p.SenderLogin) {
+		return ""
+	}
 	if len(forge.ParseIssueRefs(true, p.Title, p.Description)) == 0 {
 		return ""
 	}
@@ -210,6 +218,18 @@ func selectForgePRBot(cfg webhooks.Config, p prforge.Parsed) string {
 		return ""
 	}
 	return branchImproveBotID
+}
+
+// isDependencyBotAuthor reports whether login is an automated dependency-update
+// bot (Dependabot / Renovate, including the "renovate[bot]" GitHub-App form and
+// common self-hosted names). Case-insensitive.
+func isDependencyBotAuthor(login string) bool {
+	l := strings.ToLower(strings.TrimSpace(login))
+	switch l {
+	case "dependabot[bot]", "dependabot", "renovate[bot]", "renovate", "renovate-bot":
+		return true
+	}
+	return strings.HasPrefix(l, "renovate[") || strings.HasPrefix(l, "dependabot[")
 }
 
 // resolveReviewBot picks the bot id for a forge-specific review-PR

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -85,12 +85,17 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 	}
 	meta := prforgePRMeta(p)
 
-	// Fork guard (opt-in): a fork PR (head repo != base repo) is untrusted, so
-	// when the webhook enables block_fork_prs it never auto-launches ANY bot —
-	// the operator validates it first (anti budget-exhaustion). Filtered as a
-	// clean 200 so the forge keeps the hook enabled.
-	if cfg.BlockForkPRs && p.IsCrossRepo() {
-		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, "fork PR blocked by block_fork_prs (operator validation required)")
+	// Fork guard (UNCONDITIONAL on the auto path): a fork PR (head repo != base
+	// repo) is untrusted — an adversary can open one to run code in our runner
+	// with the forge token and to exhaust the tenant's budget. So an inbound PR
+	// event NEVER auto-launches a bot on a fork, regardless of block_fork_prs.
+	// A repo-authorized collaborator can still run one DELIBERATELY by issuing a
+	// `/command` on the PR: that path (handlePRForgeComment) gates on the
+	// commenter's CollaboratorPermission, so only a trusted user, manually,
+	// triggers a run against fork code. Filtered as a clean 200 so the forge
+	// keeps the hook enabled.
+	if p.IsCrossRepo() {
+		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, "fork PR — auto-launch blocked (untrusted; a repo collaborator can trigger a bot manually via a command)")
 		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
 		return
 	}

--- a/pkg/server/webhooks_github_test.go
+++ b/pkg/server/webhooks_github_test.go
@@ -233,23 +233,33 @@ func TestGitHubWebhook_TicketPRRoutesToBilly(t *testing.T) {
 
 // TestGitHubWebhook_ForkTicketPRStaysOnReviewer: the fork guard — a fork PR that
 // closes an issue must NOT route to the mutating bot; it stays on the reviewer.
-func TestGitHubWebhook_ForkTicketPRStaysOnReviewer(t *testing.T) {
+// A fork PR NEVER auto-launches a bot — not even the reviewer — regardless of
+// block_fork_prs. The auto path is untrusted (adversary-controlled code + budget
+// exhaustion); a repo collaborator triggers a bot manually via a command
+// instead (gated on CollaboratorPermission in handlePRForgeComment).
+func TestGitHubWebhook_ForkPRBlockedFromAutoLaunch(t *testing.T) {
 	s := newWebhookTestServer(t)
-	var gotBot string
-	s.webhookLaunchBot = func(_ context.Context, botID string, _ map[string]string, _, _, _ string, _, _ map[string]string) (string, error) {
-		gotBot = botID
+	launched := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		launched++
 		return "run-x", nil
 	}
 	cfg, pt := ghConfig(t, s)
 	cfg.BotIDs = []string{"review-pr", "branch-improve-loop"}
+	// block_fork_prs deliberately NOT set — the guard is unconditional now.
 
 	w := httptest.NewRecorder()
 	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghForkTicketPR, prforge.EventHeaderPullRequest, pt))
-	if w.Code != http.StatusAccepted {
+	if w.Code != http.StatusOK {
 		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
 	}
-	if gotBot != "review-pr" {
-		t.Fatalf("fork PR must stay on the reviewer (fork guard), got %q", gotBot)
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != webhooks.StatusFiltered {
+		t.Fatalf("fork PR must be filtered on the auto path, got %q", resp["status"])
+	}
+	if launched != 0 {
+		t.Fatalf("fork PR must NOT auto-launch any bot, launched=%d", launched)
 	}
 }
 

--- a/pkg/server/webhooks_prbot_test.go
+++ b/pkg/server/webhooks_prbot_test.go
@@ -66,6 +66,16 @@ func TestSelectForgePRBot(t *testing.T) {
 		ProjectPath: "acme/widgets", HeadRepoFullName: "acme/widgets",
 		Title: "Chore: tidy", Description: "no linked issue here",
 	}
+	// A dependency-bot PR that even references a ticket must still be excluded
+	// from the improve loop — the dependency guard owns that lane.
+	depBotPR := prforge.Parsed{
+		ProjectPath: "acme/widgets", HeadRepoFullName: "acme/widgets",
+		Title: "chore(deps): bump lib", Description: "Fixes #12", SenderLogin: "dependabot[bot]",
+	}
+	renovatePR := prforge.Parsed{
+		ProjectPath: "acme/widgets", HeadRepoFullName: "acme/widgets",
+		Title: "chore(deps): bump lib", Description: "Fixes #12", SenderLogin: "renovate[bot]",
+	}
 
 	cases := []struct {
 		name string
@@ -78,6 +88,8 @@ func TestSelectForgePRBot(t *testing.T) {
 		{"fork ticket PR → fall through (fork guard)", billyEnabled, forkTicketPR, ""},
 		{"standalone PR (no ticket) → fall through", billyEnabled, standalonePR, ""},
 		{"ticket PR but billy not enabled → fall through", billyDisabled, ticketPR, ""},
+		{"dependabot ticket PR → excluded from improve loop", billyEnabled, depBotPR, ""},
+		{"renovate ticket PR → excluded from improve loop", billyEnabled, renovatePR, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -129,5 +141,26 @@ func TestBranchImproveVars_AsPR(t *testing.T) {
 	}
 	if _, direct := v["push_branch"]; direct {
 		t.Errorf("push_branch must NOT be set in as-PR mode (no in-place push): %v", v)
+	}
+}
+
+func TestIsDependencyBotAuthor(t *testing.T) {
+	for _, tc := range []struct {
+		login string
+		want  bool
+	}{
+		{"dependabot[bot]", true},
+		{"Dependabot[bot]", true},
+		{"renovate[bot]", true},
+		{"renovate", true},
+		{"renovate-bot", true},
+		{"renovate[my-org]", true},
+		{"", false},
+		{"devthejo", false},
+		{"someone-renovating", false},
+	} {
+		if got := isDependencyBotAuthor(tc.login); got != tc.want {
+			t.Errorf("isDependencyBotAuthor(%q) = %v, want %v", tc.login, got, tc.want)
+		}
 	}
 }


### PR DESCRIPTION
Two safety boundaries on the inbound GitHub PR path, hardened after dogfooding the dependency guard (Vetty).

## 1. Fork PRs — unconditional auto-block (security)

A fork PR (head repo != base repo) is attacker-controlled: auto-launching a bot runs untrusted code in our runner with the forge token, and lets an adversary exhaust the tenant's budget by opening PRs. The guard was **opt-in** (`block_fork_prs`, off by default — so a fork PR still auto-reviewed via Revi).

Now **unconditional** on the auto path: an inbound PR event never auto-launches any bot on a fork. A repo **collaborator** can still run one deliberately via a `/command` — that path (`handlePRForgeComment`) already gates on the commenter's `CollaboratorPermission`, so only a trusted user, manually, triggers a run against fork code. (This is exactly the operator model: fork bots yes, but manual + by an authorized team user, never automatic.)

## 2. Dependency PRs stay off the improve loop

Dependabot/Renovate PRs never route to the branch-improvement loop — an improve loop over a bumped manifest/lockfile is off-target and churns the bot's own PR. The dependency guard (Vetty) owns that lane. `selectForgePRBot` returns `""` for a dep-bot author (new `isDependencyBotAuthor`: dependabot[bot] / renovate[bot] incl. self-hosted forms).

## Tests
Fork PR is filtered with **zero** launches (was "stays on reviewer"); `selectForgePRBot` excludes dependabot/renovate ticket PRs; `isDependencyBotAuthor` matcher table. Full `pkg/server` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)