### PR TITLE
fix(codex): make delegated writes reliable

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -293,17 +293,26 @@ auto-resolution. `OPENAI_API_KEY` alone routes to `claw`.
 
 #### Sandbox and `full_access`
 
-A codex node runs under codex's own sandbox. By default the mode is the
-least-privilege one implied by the node's tools: `read-only`, or
-`workspace-write` when a mutating tool (`Bash`/`Edit`/`Write`/`NotebookEdit`)
-is declared. Neither allows **network egress** — so a codex agent cannot reach
-an external API (e.g. codex's built-in `imagegen`, or any HTTP call) by default.
+A codex node runs under codex's own sandbox. `readonly: true` always selects
+`read-only` (and takes precedence over a conflicting `full_access: true`).
+Otherwise, an omitted/empty `tools:` list keeps Iterion's normal
+"native tools unrestricted" contract and selects `workspace-write`; a non-empty
+list uses `read-only` only when all declared tools are known readers, and
+`workspace-write` when it contains a writer/shell tool (both Iterion snake_case
+names and Claude-style names are recognised). Unknown/custom names conservatively
+select `workspace-write`; use `readonly: true` for an explicit lock-down.
+
+With Codex's default configuration neither `read-only` nor `workspace-write`
+allows **network egress** — so a codex agent cannot reach an external API (e.g.
+codex's built-in `imagegen`, or any HTTP call). A user-level Codex config can
+override workspace-write network policy; Iterion does not currently rewrite that
+file, so operators who require a hard network boundary should use an Iterion
+Docker/Kubernetes sandbox with a backend that supports it.
 
 To grant network access, the pipeline author sets `full_access: true` on the
 node. It lifts the sandbox to `danger-full-access` (unrestricted network +
 out-of-workspace writes) — the same posture as `codex exec -s
-danger-full-access`. It is **off by default and opt-in per node**, so network is
-always a deliberate choice, never granted implicitly:
+danger-full-access`. It is **off by default and opt-in per node** in the workflow:
 
 ```
 agent make_cover:
@@ -313,6 +322,12 @@ agent make_cover:
 ```
 
 Other backends ignore `full_access` (they do not impose the codex sandbox).
+
+> **Outer-sandbox limitation:** the pinned Codex Agent SDK cannot yet route its
+> subprocess through Iterion's Docker/Kubernetes command builder. Iterion fails
+> such a node explicitly instead of silently launching the CLI on the host. Set
+> `sandbox: none` to rely on Codex's own sandbox, or use `claude_code`/`claw`
+> when the outer container boundary is required.
 
 #### Image inputs (`images:`)
 

--- a/pkg/backend/delegate/codex.go
+++ b/pkg/backend/delegate/codex.go
@@ -9,7 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
+	"unicode/utf8"
 
 	codexsdk "github.com/ethpandaops/codex-agent-sdk-go"
 
@@ -32,6 +34,13 @@ type CodexBackend struct {
 
 // Execute runs the codex CLI with the given task using the Codex Agent SDK.
 func (b *CodexBackend) Execute(ctx context.Context, task Task) (Result, error) {
+	if task.Sandbox != nil && task.Sandbox.Driver() != "noop" {
+		return Result{ExitCode: -1, BackendName: BackendCodex}, fmt.Errorf(
+			"delegate: codex cannot run inside Iterion %s sandbox with the pinned SDK; "+
+				"set sandbox: none or use claude_code/claw",
+			task.Sandbox.Driver(),
+		)
+	}
 	if task.WorkDir != "" {
 		if err := validateWorkDir(task.WorkDir, task.BaseDir); err != nil {
 			return Result{}, err
@@ -48,6 +57,12 @@ func (b *CodexBackend) Execute(ctx context.Context, task Task) (Result, error) {
 	if task.WorkDir != "" {
 		opts = append(opts, codexsdk.WithCwd(task.WorkDir))
 	}
+	if model := strings.TrimPrefix(task.Model, "openai/"); model != "" {
+		opts = append(opts, codexsdk.WithModel(model))
+	}
+	if task.ToolMaxSteps > 0 {
+		opts = append(opts, codexsdk.WithMaxTurns(task.ToolMaxSteps))
+	}
 	// Codex executes its built-in shell without routing tool_use through any
 	// SDK callback, so per-name allow/deny at the SDK level has no effect on
 	// the shell. Our only real lever is codex's sandbox mode. Translate the
@@ -55,7 +70,8 @@ func (b *CodexBackend) Execute(ctx context.Context, task Task) (Result, error) {
 	// node do its job. bypassPermissions skips user-escalation prompts so
 	// non-interactive runs don't hang; the explicit Sandbox wins over the
 	// permission-mode default via session.go:187.
-	opts = append(opts, codexsdk.WithSandbox(codexSandboxForTask(task)))
+	sandboxMode := codexSandboxForTask(task)
+	opts = append(opts, codexsdk.WithSandbox(sandboxMode))
 	opts = append(opts, codexsdk.WithPermissionMode("bypassPermissions"))
 
 	// Forward node-declared input images to the codex CLI as `-i`, enabling
@@ -69,11 +85,12 @@ func (b *CodexBackend) Execute(ctx context.Context, task Task) (Result, error) {
 		opts = append(opts, codexsdk.WithCliPath(b.Command))
 	}
 
-	// Structured output: when tools are present we skip WithOutputSchema on the
-	// work pass and rely on a dedicated formatting pass (formatOutput) to
-	// guarantee schema-conforming JSON via session resume. Without tools the
-	// single-pass WithOutputSchema is enough.
-	needsTwoPass := len(task.OutputSchema) > 0 && len(task.AllowedTools) > 0
+	// Structured output always uses a dedicated formatting pass via session
+	// resume. Codex's native tools cannot currently be disabled by Iterion: even
+	// a readonly task with no declared tools may read/grep/shell. Applying the
+	// schema to the work pass would therefore combine tools + strict output in
+	// exactly the mode this split is designed to avoid.
+	needsTwoPass := codexNeedsTwoPass(task)
 	if len(task.OutputSchema) > 0 && !needsTwoPass {
 		opts = append(opts, codexsdk.WithOutputSchema(string(task.OutputSchema)))
 	}
@@ -90,28 +107,15 @@ func (b *CodexBackend) Execute(ctx context.Context, task Task) (Result, error) {
 	}
 
 	// Stream stderr for live observability and capture for diagnostics.
-	var stderrBuf strings.Builder
-	// Phase C+D: per-run credential injection. Order of preference:
-	//   1. Tenant-scoped OPENAI_API_KEY (BYOK) — direct API billing.
-	//   2. User OAuth-forfait — auth.json materialised in tmp by the
-	//      runner; we point CODEX_HOME at it.
-	// At most one is set so the CLI's auth source is unambiguous.
-	if creds, ok := secrets.CredentialsFromContext(ctx); ok {
-		envOverride := map[string]string{}
-		switch {
-		case creds.APIKey(secrets.ProviderOpenAI) != "":
-			envOverride["OPENAI_API_KEY"] = creds.APIKey(secrets.ProviderOpenAI)
-		case creds.OAuthDir(string(secrets.OAuthKindCodex)) != "":
-			envOverride["CODEX_HOME"] = creds.OAuthDir(string(secrets.OAuthKindCodex))
-		}
-		if len(envOverride) > 0 {
-			opts = append(opts, codexsdk.WithEnv(envOverride))
-		}
+	var stderrCapture codexStderrCapture
+	// Keep credential setup in one helper: structured-output formatting starts a
+	// second CLI process and must use the exact same per-run auth source.
+	if envOverride := codexCredEnvForCLI(ctx); len(envOverride) > 0 {
+		opts = append(opts, codexsdk.WithEnv(envOverride))
 	}
 
 	opts = append(opts, codexsdk.WithStderr(func(line string) {
-		stderrBuf.WriteString(line)
-		stderrBuf.WriteString("\n")
+		stderrCapture.AppendLine(line)
 		if line != "" {
 			b.Logger.Info("[%s#%d/codex:err] %s", task.NodeID, task.Iteration, line)
 		}
@@ -122,13 +126,13 @@ func (b *CodexBackend) Execute(ctx context.Context, task Task) (Result, error) {
 		return Result{
 			Duration:    totalDuration,
 			ExitCode:    -1,
-			Stderr:      stderrBuf.String(),
+			Stderr:      stderrCapture.String(),
 			BackendName: BackendCodex,
 		}, err
 	}
 
 	if resultMsg == nil {
-		diag := inspectCodexRollout(lastThreadID)
+		diag := inspectCodexRollout(ctx, lastThreadID)
 		errMsg := fmt.Sprintf("delegate: codex: no result message received after %d attempts", maxCodexRetries)
 		if diag != "" {
 			errMsg += " (" + diag + ")"
@@ -136,7 +140,7 @@ func (b *CodexBackend) Execute(ctx context.Context, task Task) (Result, error) {
 		return Result{
 			Duration:    totalDuration,
 			ExitCode:    -1,
-			Stderr:      stderrBuf.String(),
+			Stderr:      stderrCapture.String(),
 			BackendName: BackendCodex,
 		}, fmt.Errorf("%s", errMsg)
 	}
@@ -144,7 +148,7 @@ func (b *CodexBackend) Execute(ctx context.Context, task Task) (Result, error) {
 	result := Result{
 		Duration:    totalDuration,
 		ExitCode:    0,
-		Stderr:      stderrBuf.String(),
+		Stderr:      stderrCapture.String(),
 		BackendName: BackendCodex,
 		SessionID:   resultMsg.SessionID,
 	}
@@ -159,12 +163,17 @@ func (b *CodexBackend) Execute(ctx context.Context, task Task) (Result, error) {
 	if resultMsg.IsError && resultMsg.Subtype != "success" {
 		return result, fmt.Errorf("delegate: codex error: subtype=%s", resultMsg.Subtype)
 	}
+	if terminalErr := codexTerminalFailure(resultMsg, result.Stderr); terminalErr != nil {
+		return result, terminalErr
+	}
 
-	// Two-pass execution: when tools + schema are both present, Pass 1 output
-	// is free-form text. Run Pass 2 with WithOutputSchema + read-only sandbox
-	// (no writes during formatting) to guarantee structured output via session
-	// resume.
-	if needsTwoPass && resultMsg.SessionID != "" {
+	// Pass 1 output is free-form text. Pass 2 uses WithOutputSchema + read-only
+	// sandbox (no writes during formatting) to guarantee structured output via
+	// session resume.
+	if needsTwoPass {
+		if resultMsg.SessionID == "" {
+			return result, fmt.Errorf("delegate: codex structured output requires a resumable session, but the work pass returned no session ID")
+		}
 		const maxFmtAttempts = 2
 		for attempt := 1; attempt <= maxFmtAttempts; attempt++ {
 			b.Logger.Debug("codex [formatting pass %d/%d] starting structured output extraction (session=%s)", attempt, maxFmtAttempts, resultMsg.SessionID)
@@ -185,9 +194,15 @@ func (b *CodexBackend) Execute(ctx context.Context, task Task) (Result, error) {
 			result.FormattingPassUsed = true
 
 			output, rawLen, fallback := parseSDKOutput(fmtRM.Result, fmtRM.StructuredOutput, task.OutputSchema)
-			if fallback && attempt < maxFmtAttempts {
-				b.Logger.Warn("codex [formatting pass %d/%d] produced fallback text, retrying", attempt, maxFmtAttempts)
+			if (len(output) == 0 || fallback) && attempt < maxFmtAttempts {
+				b.Logger.Warn("codex [formatting pass %d/%d] produced empty/fallback output, retrying", attempt, maxFmtAttempts)
 				continue
+			}
+			if len(output) == 0 {
+				return result, fmt.Errorf("delegate: codex formatting pass returned empty structured output")
+			}
+			if fallback {
+				return result, fmt.Errorf("delegate: codex formatting pass did not return schema-conforming JSON")
 			}
 			result.Output = output
 			result.RawOutputLen = rawLen
@@ -195,6 +210,7 @@ func (b *CodexBackend) Execute(ctx context.Context, task Task) (Result, error) {
 			cost.Annotate(result.Output, task.Model, totalIn, totalOut)
 			return result, nil
 		}
+		return result, fmt.Errorf("delegate: codex formatting pass exhausted without a result")
 	}
 
 	output, rawLen, fallback := parseSDKOutput(resultMsg.Result, resultMsg.StructuredOutput, task.OutputSchema)
@@ -202,30 +218,8 @@ func (b *CodexBackend) Execute(ctx context.Context, task Task) (Result, error) {
 	result.RawOutputLen = rawLen
 	result.ParseFallback = fallback
 
-	// Recovery pass: if schema is set but we got empty/fallback output, retry
-	// via session resume with WithOutputSchema. Mirrors claude_code.go:219-238.
-	if (len(output) == 0 || fallback) && len(task.OutputSchema) > 0 && resultMsg.SessionID != "" {
-		b.Logger.Debug("codex: empty output with schema — attempting recovery formatting pass (session=%s)", resultMsg.SessionID)
-		fmtRM, fmtDuration, fmtErr := b.formatOutput(ctx, task, resultMsg.SessionID)
-		result.Duration += fmtDuration
-		if fmtErr == nil {
-			if fmtRM.Usage != nil {
-				totalIn += fmtRM.Usage.InputTokens
-				totalOut += fmtRM.Usage.OutputTokens
-				result.Tokens = totalIn + totalOut
-			}
-			result.FormattingPassUsed = true
-			fmtOutput, fmtRawLen, fmtFallback := parseSDKOutput(fmtRM.Result, fmtRM.StructuredOutput, task.OutputSchema)
-			if len(fmtOutput) > 0 {
-				result.Output = fmtOutput
-				result.RawOutputLen = fmtRawLen
-				result.ParseFallback = fmtFallback
-			} else {
-				b.Logger.Warn("codex: recovery formatting pass also produced empty output")
-			}
-		} else {
-			b.Logger.Warn("codex: recovery formatting pass failed: %v", fmtErr)
-		}
+	if len(result.Output) == 0 {
+		return result, fmt.Errorf("delegate: codex returned empty output")
 	}
 
 	cost.Annotate(result.Output, task.Model, totalIn, totalOut)
@@ -281,7 +275,7 @@ func (b *CodexBackend) runQueryWithRetry(ctx context.Context, task Task, prompt 
 		// No ResultMessage: inspect the rollout log to classify the failure.
 		// Overflow is not retryable — same prompt will overflow again and
 		// burn tokens. Break with a clear error so the caller fails fast.
-		diag := inspectCodexRollout(lastThreadID)
+		diag := inspectCodexRollout(ctx, lastThreadID)
 		if strings.Contains(diag, "context window") {
 			return nil, totalDuration, lastThreadID, fmt.Errorf("delegate: codex: %s", diag)
 		}
@@ -318,12 +312,14 @@ func (b *CodexBackend) runQueryWithRetry(ctx context.Context, task Task, prompt 
 // WithOutputSchema and a tight formatting prompt. Sandbox is forced to
 // read-only so the pass cannot mutate state while rendering the final JSON.
 func (b *CodexBackend) formatOutput(ctx context.Context, task Task, sessionID string) (*codexsdk.ResultMessage, time.Duration, error) {
+	var stderrCapture codexStderrCapture
 	opts := []codexsdk.Option{
 		codexsdk.WithResume(sessionID),
 		codexsdk.WithOutputSchema(string(task.OutputSchema)),
 		codexsdk.WithSandbox("read-only"),
 		codexsdk.WithPermissionMode("bypassPermissions"),
 		codexsdk.WithStderr(func(line string) {
+			stderrCapture.AppendLine(line)
 			if line != "" {
 				b.Logger.Info("[%s#%d/fmt] %s", task.NodeID, task.Iteration, line)
 			}
@@ -332,11 +328,17 @@ func (b *CodexBackend) formatOutput(ctx context.Context, task Task, sessionID st
 	if task.WorkDir != "" {
 		opts = append(opts, codexsdk.WithCwd(task.WorkDir))
 	}
+	if model := strings.TrimPrefix(task.Model, "openai/"); model != "" {
+		opts = append(opts, codexsdk.WithModel(model))
+	}
 	if b.Command != "" {
 		opts = append(opts, codexsdk.WithCliPath(b.Command))
 	}
 	if task.ReasoningEffort != "" {
 		opts = append(opts, codexsdk.WithEffort(mapReasoningEffort(task.ReasoningEffort)))
+	}
+	if envOverride := codexCredEnvForCLI(ctx); len(envOverride) > 0 {
+		opts = append(opts, codexsdk.WithEnv(envOverride))
 	}
 
 	prompt := "Format your complete findings as JSON matching the required output schema. Do not call any tools; just return the JSON."
@@ -350,6 +352,9 @@ func (b *CodexBackend) formatOutput(ctx context.Context, task Task, sessionID st
 	}
 	if rm.IsError && rm.Subtype != "success" {
 		return rm, duration, fmt.Errorf("codex formatting pass error: subtype=%s", rm.Subtype)
+	}
+	if terminalErr := codexTerminalFailure(rm, stderrCapture.String()); terminalErr != nil {
+		return rm, duration, terminalErr
 	}
 	return rm, duration, nil
 }
@@ -423,16 +428,26 @@ func (b *CodexBackend) logAssistantActivity(nodeID string, iteration int, msg *c
 // of ~/.codex/sessions/.../rollout-*-<threadID>.jsonl. Used when codex exits
 // without sending turn.completed/turn.failed (e.g. context-window overflow).
 // Returns "" when nothing useful can be extracted.
-func inspectCodexRollout(threadID string) string {
+func inspectCodexRollout(ctx context.Context, threadID string) string {
 	if threadID == "" {
 		return ""
 	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
+	codexHome := ""
+	if env := codexCredEnvForCLI(ctx); env != nil {
+		codexHome = env["CODEX_HOME"]
+	}
+	if codexHome == "" {
+		codexHome = os.Getenv("CODEX_HOME")
+	}
+	if codexHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		codexHome = filepath.Join(home, ".codex")
 	}
 	// Codex writes rollouts to ~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<thread_id>.jsonl.
-	pattern := filepath.Join(home, ".codex", "sessions", "*", "*", "*", "rollout-*-"+threadID+".jsonl")
+	pattern := filepath.Join(codexHome, "sessions", "*", "*", "*", "rollout-*-"+threadID+".jsonl")
 	matches, err := filepath.Glob(pattern)
 	if err != nil || len(matches) == 0 {
 		return ""
@@ -507,37 +522,236 @@ func contentBlocksText(blocks []codexsdk.ContentBlock) string {
 	return truncate(sb.String(), 500)
 }
 
+// codexStderrCapture is safe for SDK callbacks, which may run on their own
+// stderr-draining goroutine while the query loop reads the accumulated text.
+type codexStderrCapture struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (c *codexStderrCapture) AppendLine(line string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.buf.WriteString(line)
+	c.buf.WriteString("\n")
+}
+
+func (c *codexStderrCapture) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.String()
+}
+
+// codexCredEnvForCLI resolves the per-run Codex credential environment. Keep
+// this shared by the work and formatting passes: the latter resumes the first
+// pass in a new CLI process and otherwise loses tenant-scoped auth.
+func codexCredEnvForCLI(ctx context.Context) map[string]string {
+	creds, ok := secrets.CredentialsFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	if key := creds.APIKey(secrets.ProviderOpenAI); key != "" {
+		return map[string]string{
+			"OPENAI_API_KEY": key,
+			"CODEX_API_KEY":  "",
+		}
+	}
+	if dir := creds.OAuthDir(string(secrets.OAuthKindCodex)); dir != "" {
+		// A shared runner key must not shadow the per-run ChatGPT OAuth bundle.
+		return map[string]string{
+			"CODEX_HOME":     dir,
+			"OPENAI_API_KEY": "",
+			"CODEX_API_KEY":  "",
+		}
+	}
+	return nil
+}
+
+// codexTerminalFailure recognises the SDK failure mode where Codex emits a
+// nominal ResultMessage whose text is actually a terminal CLI/API error.
+// Without this guard a single-string schema can wrap that text as a valid
+// result, or an empty result can look like a successful side-effect-only task.
+func codexTerminalFailure(rm *codexsdk.ResultMessage, stderr string) error {
+	if rm == nil {
+		return nil
+	}
+	// A schema-validated payload is authoritative. Stale stderr or a human-facing
+	// textual summary must never turn a valid structured result into a failure.
+	if hasNonEmptyStructuredOutput(rm.StructuredOutput) {
+		return nil
+	}
+	resultText := ""
+	if rm.Result != nil {
+		resultText = strings.TrimSpace(*rm.Result)
+	}
+	if isCodexBareLimitNotice(resultText) {
+		return &ErrRateLimited{Provider: BackendCodex, Detail: resultText}
+	}
+	if resultText != "" && hasCodexTerminalErrorEnvelope(resultText) {
+		lower := strings.ToLower(resultText)
+		if isCodexRateLimitError(lower) {
+			return &ErrRateLimited{Provider: BackendCodex, Detail: resultText}
+		}
+		if isCodexTerminalNetworkError(lower) {
+			return &ErrTransient{Provider: BackendCodex, Reason: "network", Detail: resultText}
+		}
+		if isCodexAuthOrAPIStatusError(lower) {
+			return fmt.Errorf("delegate: codex terminal error: %s", truncate(resultText, 500))
+		}
+	}
+	if resultText == "" && MatchesNetworkSignature(stderr) {
+		return &ErrTransient{
+			Provider: BackendCodex,
+			Reason:   "network",
+			Detail:   truncate(strings.TrimSpace(stderr), 500),
+		}
+	}
+	return nil
+}
+
+// isCodexBareLimitNotice covers short provider notices that the CLI can expose
+// as a nominal ResultMessage without an "Error:" envelope. Prefix matching plus
+// a tight length cap avoids classifying normal agent discussion of quotas or
+// capacity as a terminal failure.
+func isCodexBareLimitNotice(text string) bool {
+	if len(text) == 0 || len(text) > 300 {
+		return false
+	}
+	lower := strings.ToLower(strings.TrimSpace(text))
+	for _, prefix := range []string{
+		"you've hit your usage limit",
+		"you’ve hit your usage limit",
+		"you have hit your usage limit",
+		"you've hit your limit",
+		"you’ve hit your limit",
+		"usage limit reached",
+		"rate limit exceeded",
+		"quota exceeded",
+		"selected model is at capacity",
+		"we're currently experiencing high demand",
+		"we’re currently experiencing high demand",
+		"we are currently experiencing high demand",
+	} {
+		if strings.HasPrefix(lower, prefix) {
+			rest := strings.TrimSpace(strings.TrimPrefix(lower, prefix))
+			first, _ := utf8.DecodeRuneInString(rest)
+			if rest == "" || strings.ContainsRune(".!:;·—-…", first) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isCodexRateLimitError(lower string) bool {
+	return strings.Contains(lower, "unexpected status 429") ||
+		strings.Contains(lower, "rate limit exceeded") ||
+		strings.Contains(lower, "you've hit your usage limit") ||
+		strings.Contains(lower, "usage limit reached") ||
+		strings.Contains(lower, "quota exceeded") ||
+		strings.Contains(lower, "insufficient_quota")
+}
+
+func isCodexTerminalNetworkError(lower string) bool {
+	for _, signature := range []string{
+		"stream disconnected", "error sending request", "unable to connect to api",
+		"connection refused", "connection reset", "connection closed before",
+		"unexpected eof", "tls handshake timeout", "temporary failure in name resolution",
+		"unexpected status 500", "unexpected status 502", "unexpected status 503",
+		"unexpected status 504",
+	} {
+		if strings.Contains(lower, signature) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasCodexTerminalErrorEnvelope limits classification to the shapes emitted by
+// the CLI itself. Ordinary task output such as "Failed tests: ..." or
+// "Error handling strategy: ..." must remain valid content.
+func hasCodexTerminalErrorEnvelope(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	for _, prefix := range []string{
+		"error:", "fatal:", "api error:", "stream disconnected",
+		"connection closed", "connection reset", "connection refused",
+	} {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func isCodexAuthOrAPIStatusError(lower string) bool {
+	return strings.Contains(lower, "unexpected status 401") ||
+		strings.Contains(lower, "unexpected status 403") ||
+		strings.Contains(lower, "401 unauthorized") ||
+		strings.Contains(lower, "403 forbidden") ||
+		strings.Contains(lower, "authentication failed") ||
+		strings.Contains(lower, "missing bearer or basic authentication") ||
+		strings.Contains(lower, "unexpected status 4") ||
+		strings.Contains(lower, "unexpected status 5")
+}
+
+func hasNonEmptyStructuredOutput(value any) bool {
+	if value == nil {
+		return false
+	}
+	if obj, ok := value.(map[string]any); ok {
+		return len(obj) > 0
+	}
+	b, err := json.Marshal(value)
+	return err == nil && string(b) != "null" && string(b) != "{}" && string(b) != "[]"
+}
+
 // codexSandboxForAllowedTools picks the least-privilege codex sandbox mode
-// compatible with the intent expressed by AllowedTools:
-//   - empty allowlist or read-only tools only → "read-only"
-//   - any mutating tool (Bash/Edit/Write/NotebookEdit) → "workspace-write"
+// compatible with the intent expressed by a non-empty AllowedTools list.
+// Iterion accepts both Claude-style TitleCase names and its native snake_case
+// aliases, so normalise before deciding whether filesystem mutation is needed.
 //
 // "danger-full-access" is intentionally never chosen here — workflows that
 // truly need unrestricted network or out-of-workspace writes must request it
-// via an explicit codex config override, not by listing a mutating tool.
+// with the node-level `full_access: true`, not by listing a mutating tool.
 func codexSandboxForAllowedTools(allowed []string) string {
 	for _, t := range allowed {
-		switch t {
-		case "Bash", "Edit", "Write", "NotebookEdit":
+		switch strings.ToLower(strings.TrimSpace(t)) {
+		case "read", "read_file", "readfile", "cat", "glob", "grep", "ls":
+			continue
+		case "bash", "shell", "sh",
+			"edit", "edit_file", "file_edit", "multiedit", "str_replace",
+			"write", "write_file", "writefile",
+			"notebookedit", "notebook_edit", "patch", "apply_patch", "run_command":
+			return "workspace-write"
+		default:
+			// Unknown/custom tool names cannot prove the task is read-only. Prefer
+			// preserving writer semantics; explicit `readonly:` remains the lock.
 			return "workspace-write"
 		}
 	}
 	return "read-only"
 }
 
-// codexSandboxForTask picks the codex sandbox mode for a task. A node that
-// explicitly opts into full_access gets "danger-full-access" — unrestricted
-// network egress + out-of-workspace writes. This is the ONLY way to give a
-// codex node network access (e.g. a CLI that reaches an external API, such as
-// codex's built-in imagegen). Without the opt-in we fall back to the
-// least-privilege mode derived from the declared tools, so the default stays
-// locked and network egress is always a deliberate, per-node choice made by
-// the pipeline author in the .bot.
+// codexSandboxForTask maps the DSL's access intent to Codex. readonly is the
+// explicit lock-down and wins over a conflicting full_access opt-in.
+// With neither flag, an empty tools list means "native toolset unrestricted"
+// throughout Iterion, so Codex must receive workspace-write rather than silently
+// changing that contract to read-only. A restricted list is classified by name.
 func codexSandboxForTask(task Task) string {
+	if task.Readonly {
+		return "read-only"
+	}
 	if task.FullAccess {
 		return "danger-full-access"
 	}
+	if len(task.AllowedTools) == 0 {
+		return "workspace-write"
+	}
 	return codexSandboxForAllowedTools(task.AllowedTools)
+}
+
+func codexNeedsTwoPass(task Task) bool {
+	return len(task.OutputSchema) > 0
 }
 
 // mapReasoningEffort converts iterion reasoning effort strings to Codex SDK Effort constants.

--- a/pkg/backend/delegate/codex_cred_test.go
+++ b/pkg/backend/delegate/codex_cred_test.go
@@ -1,0 +1,80 @@
+package delegate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+func TestCodexCredEnvForCLI_APIKeyWinsOverOAuth(t *testing.T) {
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		APIKeys: map[secrets.Provider]string{
+			secrets.ProviderOpenAI: "sk-run",
+		},
+		OAuthCredentialFiles: map[string]string{
+			string(secrets.OAuthKindCodex): "/tmp/codex-oauth",
+		},
+	})
+
+	got := codexCredEnvForCLI(ctx)
+	if got["OPENAI_API_KEY"] != "sk-run" {
+		t.Fatalf("OPENAI_API_KEY = %q, want per-run key", got["OPENAI_API_KEY"])
+	}
+	if _, ok := got["CODEX_HOME"]; ok {
+		t.Fatal("CODEX_HOME must not be set when the per-run API key wins")
+	}
+	if value, ok := got["CODEX_API_KEY"]; !ok || value != "" {
+		t.Fatalf("CODEX_API_KEY must be explicitly cleared, present=%v value=%q", ok, value)
+	}
+}
+
+func TestCodexCredEnvForCLI_OAuthSuppressesInheritedKeys(t *testing.T) {
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		OAuthCredentialFiles: map[string]string{
+			string(secrets.OAuthKindCodex): "/tmp/codex-oauth",
+		},
+	})
+
+	got := codexCredEnvForCLI(ctx)
+	if got["CODEX_HOME"] != "/tmp/codex-oauth" {
+		t.Fatalf("CODEX_HOME = %q, want /tmp/codex-oauth", got["CODEX_HOME"])
+	}
+	for _, key := range []string{"OPENAI_API_KEY", "CODEX_API_KEY"} {
+		if value, ok := got[key]; !ok || value != "" {
+			t.Errorf("%s must be explicitly cleared, present=%v value=%q", key, ok, value)
+		}
+	}
+}
+
+func TestCodexCredEnvForCLI_NoPerRunScope(t *testing.T) {
+	if got := codexCredEnvForCLI(context.Background()); got != nil {
+		t.Fatalf("got %v, want nil without per-run credentials", got)
+	}
+}
+
+func TestInspectCodexRolloutUsesPerRunCodexHome(t *testing.T) {
+	codexHome := t.TempDir()
+	threadID := "thread-test"
+	dir := filepath.Join(codexHome, "sessions", "2026", "07", "14")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	rollout := filepath.Join(dir, "rollout-test-"+threadID+".jsonl")
+	line := `{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"total_tokens":42},"model_context_window":1000}}}` + "\n"
+	if err := os.WriteFile(rollout, []byte(line), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		OAuthCredentialFiles: map[string]string{
+			string(secrets.OAuthKindCodex): codexHome,
+		},
+	})
+
+	got := inspectCodexRollout(ctx, threadID)
+	if got == "" {
+		t.Fatal("rollout diagnostic was not found under per-run CODEX_HOME")
+	}
+}

--- a/pkg/backend/delegate/delegate.go
+++ b/pkg/backend/delegate/delegate.go
@@ -316,12 +316,17 @@ type Task struct {
 	// FullAccess, when true, lifts the codex backend's sandbox to
 	// "danger-full-access" (unrestricted network egress + out-of-workspace
 	// writes) instead of the least-privilege mode derived from AllowedTools.
-	// It is the only way to grant a codex node network access — e.g. a CLI
-	// that reaches an external API such as codex's built-in imagegen. Off by
-	// default; other backends ignore it. Set from the node-level
+	// It is Iterion's explicit way to grant a codex node network access — e.g.
+	// a CLI that reaches an external API such as codex's built-in imagegen. Off
+	// by default; other backends ignore it. Set from the node-level
 	// `full_access:` DSL field, so network is a deliberate, per-node choice
 	// by the pipeline author.
 	FullAccess bool
+
+	// Readonly, when true, forces delegated agents into a read-only sandbox.
+	// The executor copies this from the node-level `readonly:` DSL field so
+	// backend enforcement matches workspace-safety scheduling.
+	Readonly bool
 
 	// Images are node-level input image paths (from the `images:` DSL field,
 	// templated + resolved per run). The codex backend forwards them to the
@@ -588,10 +593,11 @@ type Task struct {
 	ResumeAnswer string
 
 	// Sandbox is the live sandbox handle for the run, or nil when the
-	// workflow runs without isolation. Backends route their CLI
-	// subprocess calls through it (via the SDK's CommandBuilder hook
-	// for claude_code, or directly via Run.Command for shell-out
-	// backends) so the agent's tools execute inside the container.
+	// workflow runs without isolation. Supported backends route their CLI
+	// subprocess calls through it (via the SDK's CommandBuilder hook for
+	// claude_code, or directly via Run.Command for shell-out backends) so the
+	// agent's tools execute inside the container. A backend whose SDK cannot
+	// route the process must reject the task rather than escape to the host.
 	//
 	// In-process backends (claw) refuse to start when this is set —
 	// see runtime.containsClawNode for the compile-time guard.

--- a/pkg/backend/delegate/delegate_test.go
+++ b/pkg/backend/delegate/delegate_test.go
@@ -3,6 +3,7 @@ package delegate
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -213,12 +214,16 @@ func TestCodexSandboxForAllowedTools(t *testing.T) {
 	}{
 		{"empty allowlist defaults to read-only (fail-safe)", nil, "read-only"},
 		{"bash unlocks workspace-write, not full-access", []string{"Read", "Bash"}, "workspace-write"},
+		{"native lowercase bash unlocks workspace-write", []string{"read_file", "bash"}, "workspace-write"},
 		{"edit is mutating -> workspace-write", []string{"Read", "Edit"}, "workspace-write"},
+		{"native file_edit is mutating", []string{"read_file", "file_edit"}, "workspace-write"},
 		{"write is mutating -> workspace-write", []string{"Write"}, "workspace-write"},
+		{"native write_file is mutating", []string{"write_file"}, "workspace-write"},
 		{"notebookedit is mutating -> workspace-write", []string{"NotebookEdit"}, "workspace-write"},
+		{"native notebook_edit is mutating", []string{"notebook_edit"}, "workspace-write"},
 		{"read-only reviewer stays read-only", []string{"Read", "Glob", "Grep"}, "read-only"},
 		{"single read tool stays read-only", []string{"Grep"}, "read-only"},
-		{"unknown name falls through to read-only", []string{"SomeFutureTool"}, "read-only"},
+		{"unknown name preserves possible writer semantics", []string{"SomeFutureTool"}, "workspace-write"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -236,20 +241,134 @@ func TestCodexSandboxForTask(t *testing.T) {
 			t.Errorf("FullAccess=true = %q, want danger-full-access", got)
 		}
 	})
-	t.Run("full_access wins over the tool-derived mode", func(t *testing.T) {
-		got := codexSandboxForTask(Task{FullAccess: true, AllowedTools: []string{"Read"}})
-		if got != "danger-full-access" {
-			t.Errorf("= %q, want danger-full-access", got)
+	t.Run("readonly wins over conflicting full_access", func(t *testing.T) {
+		got := codexSandboxForTask(Task{FullAccess: true, Readonly: true, AllowedTools: []string{"Read"}})
+		if got != "read-only" {
+			t.Errorf("= %q, want read-only", got)
 		}
 	})
-	t.Run("without opt-in, stays least-privilege", func(t *testing.T) {
-		if got := codexSandboxForTask(Task{AllowedTools: []string{"Bash"}}); got != "workspace-write" {
+	t.Run("readonly forces read-only even with mutating tools", func(t *testing.T) {
+		if got := codexSandboxForTask(Task{Readonly: true, AllowedTools: []string{"bash", "write_file"}}); got != "read-only" {
+			t.Errorf("readonly task = %q, want read-only", got)
+		}
+	})
+	t.Run("default task preserves unrestricted native tool semantics", func(t *testing.T) {
+		if got := codexSandboxForTask(Task{}); got != "workspace-write" {
+			t.Errorf("empty task = %q, want workspace-write", got)
+		}
+	})
+	t.Run("restricted tools stay least-privilege", func(t *testing.T) {
+		if got := codexSandboxForTask(Task{AllowedTools: []string{"bash"}}); got != "workspace-write" {
 			t.Errorf("Bash without full_access = %q, want workspace-write", got)
 		}
-		if got := codexSandboxForTask(Task{}); got != "read-only" {
-			t.Errorf("empty task = %q, want read-only", got)
+		if got := codexSandboxForTask(Task{AllowedTools: []string{"read_file", "grep"}}); got != "read-only" {
+			t.Errorf("read-only allowlist = %q, want read-only", got)
 		}
 	})
+}
+
+func TestCodexNeedsTwoPassForEveryStructuredTask(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object"}`)
+	tests := []struct {
+		name string
+		task Task
+		want bool
+	}{
+		{"no schema needs no formatter", Task{}, false},
+		{"default empty tools", Task{OutputSchema: schema}, true},
+		{"writer list", Task{OutputSchema: schema, AllowedTools: []string{"write_file"}}, true},
+		{"readonly reader list", Task{OutputSchema: schema, Readonly: true, AllowedTools: []string{"read_file"}}, true},
+		{"readonly empty tools can still read or shell", Task{OutputSchema: schema, Readonly: true}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := codexNeedsTwoPass(tt.task); got != tt.want {
+				t.Fatalf("codexNeedsTwoPass(%+v) = %v, want %v", tt.task, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCodexRejectsOuterSandboxInsteadOfEscapingToHost(t *testing.T) {
+	b := &CodexBackend{Logger: testLogger()}
+	result, err := b.Execute(context.Background(), Task{Sandbox: &recordingRun{}})
+	if err == nil || !strings.Contains(err.Error(), "cannot run inside Iterion recording sandbox") {
+		t.Fatalf("error = %v, want explicit outer-sandbox rejection", err)
+	}
+	if result.BackendName != BackendCodex || result.ExitCode != -1 {
+		t.Fatalf("result = %+v, want codex failure metadata", result)
+	}
+}
+
+func TestCodexTerminalFailure(t *testing.T) {
+	empty := ""
+	errText := "Error: stream disconnected before completion"
+	authText := "Error: unexpected status 401 Unauthorized"
+	rateText := "Error: unexpected status 429 rate limit exceeded"
+	bareUsageText := "You've hit your usage limit. Try again later."
+	bareQuotaText := "Quota exceeded. Check your plan and billing details."
+	bareCapacityText := "Selected model is at capacity. Please retry later."
+	bareDemandText := "We're currently experiencing high demand. Please retry shortly."
+	valid := "done"
+	discussion := "I fixed the network error and completed the task."
+	failedTests := "Failed tests: TestWidget and TestParser"
+	errorDiscussion := "Error: network error handling is documented in recovery.go"
+	quotaDiscussion := "Quota exceeded handling is documented in the operator guide."
+	tests := []struct {
+		name          string
+		rm            *codexsdk.ResultMessage
+		stderr        string
+		wantError     bool
+		wantTransient bool
+		wantRateLimit bool
+	}{
+		{"empty result with disconnected stderr", &codexsdk.ResultMessage{Result: &empty}, "stream disconnected", true, true, false},
+		{"network error text cannot satisfy string schema", &codexsdk.ResultMessage{Result: &errText}, "", true, true, false},
+		{"auth error fails without formatting", &codexsdk.ResultMessage{Result: &authText}, "", true, false, false},
+		{"rate limit is typed", &codexsdk.ResultMessage{Result: &rateText}, "", true, false, true},
+		{"bare usage limit is typed", &codexsdk.ResultMessage{Result: &bareUsageText}, "", true, false, true},
+		{"bare quota notice is typed", &codexsdk.ResultMessage{Result: &bareQuotaText}, "", true, false, true},
+		{"bare capacity notice is typed", &codexsdk.ResultMessage{Result: &bareCapacityText}, "", true, false, true},
+		{"bare high-demand notice is typed", &codexsdk.ResultMessage{Result: &bareDemandText}, "", true, false, true},
+		{"valid result ignores unrelated stderr", &codexsdk.ResultMessage{Result: &valid}, "diagnostic", false, false, false},
+		{"discussion of recovered network error is valid", &codexsdk.ResultMessage{Result: &discussion}, "", false, false, false},
+		{"ordinary failed-tests summary is valid", &codexsdk.ResultMessage{Result: &failedTests}, "", false, false, false},
+		{"ordinary error-prefixed discussion is valid", &codexsdk.ResultMessage{Result: &errorDiscussion}, "", false, false, false},
+		{"ordinary quota discussion is valid", &codexsdk.ResultMessage{Result: &quotaDiscussion}, "", false, false, false},
+		{"structured result survives stale stderr", &codexsdk.ResultMessage{Result: &empty, StructuredOutput: map[string]any{"ok": true}}, "stream disconnected", false, false, false},
+		{"structured result wins over error-like text", &codexsdk.ResultMessage{Result: &errText, StructuredOutput: map[string]any{"summary": "Error: stream disconnected"}}, "", false, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := codexTerminalFailure(tt.rm, tt.stderr)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("error = %v, wantError %v", err, tt.wantError)
+			}
+			_, transient := err.(*ErrTransient)
+			if transient != tt.wantTransient {
+				t.Errorf("transient = %v, want %v (err=%v)", transient, tt.wantTransient, err)
+			}
+			_, rateLimited := err.(*ErrRateLimited)
+			if rateLimited != tt.wantRateLimit {
+				t.Errorf("rateLimited = %v, want %v (err=%v)", rateLimited, tt.wantRateLimit, err)
+			}
+		})
+	}
+}
+
+func TestCodexFormattingStderrCapturePreservesTransientClassification(t *testing.T) {
+	var capture codexStderrCapture
+	capture.AppendLine("stream disconnected before completion")
+	empty := ""
+
+	err := codexTerminalFailure(&codexsdk.ResultMessage{Result: &empty}, capture.String())
+	var transient *ErrTransient
+	if !errors.As(err, &transient) {
+		t.Fatalf("codexTerminalFailure() error = %T %v, want *ErrTransient", err, err)
+	}
+	if transient.Reason != "network" {
+		t.Fatalf("transient reason = %q, want network", transient.Reason)
+	}
 }
 
 func TestTruncate(t *testing.T) {

--- a/pkg/backend/delegate/io.go
+++ b/pkg/backend/delegate/io.go
@@ -49,6 +49,7 @@ type IOTask struct {
 	UserPrompt             string                `json:"user_prompt,omitempty"`
 	UserContent            []ContentBlock        `json:"user_content,omitempty"`
 	AllowedTools           []string              `json:"allowed_tools,omitempty"`
+	Readonly               bool                  `json:"readonly,omitempty"`
 	Capabilities           []string              `json:"capabilities,omitempty"`
 	StoreDir               string                `json:"store_dir,omitempty"`
 	BoardHTTPEndpoint      string                `json:"board_http_endpoint,omitempty"`
@@ -139,6 +140,7 @@ func ToIOTask(t Task) IOTask {
 		UserPrompt:             t.UserPrompt,
 		UserContent:            t.UserContent,
 		AllowedTools:           t.AllowedTools,
+		Readonly:               t.Readonly,
 		Capabilities:           t.Capabilities,
 		StoreDir:               t.StoreDir,
 		BoardHTTPEndpoint:      t.BoardHTTPEndpoint,
@@ -189,6 +191,7 @@ func FromIOTask(t IOTask) Task {
 		UserPrompt:             t.UserPrompt,
 		UserContent:            t.UserContent,
 		AllowedTools:           t.AllowedTools,
+		Readonly:               t.Readonly,
 		Capabilities:           t.Capabilities,
 		StoreDir:               t.StoreDir,
 		BoardHTTPEndpoint:      t.BoardHTTPEndpoint,

--- a/pkg/backend/delegate/io_test.go
+++ b/pkg/backend/delegate/io_test.go
@@ -19,6 +19,7 @@ func TestIOTaskRoundTrip(t *testing.T) {
 			{Type: "image", MediaType: "image/png", Data: "aW1hZ2U=", Path: "assets/image.png", Name: "diagram"},
 		},
 		AllowedTools:          []string{"Bash", "Read"},
+		Readonly:              true,
 		OutputSchema:          json.RawMessage(`{"type":"object"}`),
 		Model:                 "anthropic/claude-sonnet-4-6",
 		HasTools:              true,
@@ -99,6 +100,9 @@ func TestIOTaskRoundTrip(t *testing.T) {
 	}
 	if got.HasTools != original.HasTools {
 		t.Errorf("HasTools = %v", got.HasTools)
+	}
+	if got.Readonly != original.Readonly {
+		t.Errorf("Readonly = %v, want %v", got.Readonly, original.Readonly)
 	}
 	if got.SessionID != original.SessionID {
 		t.Errorf("SessionID = %q", got.SessionID)

--- a/pkg/backend/delegate/network_errors.go
+++ b/pkg/backend/delegate/network_errors.go
@@ -60,6 +60,7 @@ var networkErrorSignatures = []string{
 	"unable to connect to api", "failedtoopensocket", "http: eof",
 	"http2: timeout", "http2: server sent goaway",
 	"server closed idle connection",
+	"stream disconnected",
 }
 
 // MatchesNetworkSignature reports whether s (an error message or a captured

--- a/pkg/backend/model/executor_build_task.go
+++ b/pkg/backend/model/executor_build_task.go
@@ -41,6 +41,7 @@ type backendFields struct {
 	compress         string   // node-level `compress:` value ("" = unset)
 	permission       string   // node-level `permission:` mode override ("" = inherit)
 	timeout          string   // node-level `timeout:` Go duration ("" = no per-node bound); may contain ${VAR} env refs
+	readonly         bool     // node-level `readonly:` — force delegated agents into a read-only sandbox
 	fullAccess       bool     // node-level `full_access:` — lift the codex sandbox to danger-full-access (network egress)
 	images           []string // node-level `images:` — templated input image paths forwarded to codex as `-i` (i2i)
 }
@@ -72,6 +73,7 @@ func extractBackendFields(node ir.Node) (backendFields, error) {
 			compress:         n.Compress,
 			permission:       n.Permission,
 			timeout:          n.Timeout,
+			readonly:         n.Readonly,
 			fullAccess:       n.FullAccess,
 			images:           n.Images,
 		}, nil
@@ -94,6 +96,7 @@ func extractBackendFields(node ir.Node) (backendFields, error) {
 			compress:         n.Compress,
 			permission:       n.Permission,
 			timeout:          n.Timeout,
+			readonly:         n.Readonly,
 			fullAccess:       n.FullAccess,
 			images:           n.Images,
 		}, nil
@@ -517,6 +520,7 @@ func (e *ClawExecutor) buildTask(ctx context.Context, node ir.Node, f backendFie
 		UserPrompt:            userText,
 		UserContent:           userContent,
 		AllowedTools:          f.tools,
+		Readonly:              f.readonly,
 		FullAccess:            f.fullAccess,
 		Images:                resolvedImages,
 		Capabilities:          effectiveCaps,

--- a/pkg/backend/model/executor_readonly_test.go
+++ b/pkg/backend/model/executor_readonly_test.go
@@ -1,0 +1,35 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+)
+
+func TestExtractBackendFieldsCarriesReadonly(t *testing.T) {
+	tests := []struct {
+		name string
+		node ir.Node
+	}{
+		{
+			name: "agent",
+			node: &ir.AgentNode{LLMFields: ir.LLMFields{Readonly: true}},
+		},
+		{
+			name: "judge",
+			node: &ir.JudgeNode{LLMFields: ir.LLMFields{Readonly: true}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields, err := extractBackendFields(tt.node)
+			if err != nil {
+				t.Fatalf("extractBackendFields: %v", err)
+			}
+			if !fields.readonly {
+				t.Fatal("readonly flag was lost before Task construction")
+			}
+		})
+	}
+}

--- a/pkg/backend/model/executor_resolve.go
+++ b/pkg/backend/model/executor_resolve.go
@@ -56,6 +56,13 @@ func (e *ClawExecutor) resolveBackendName(node ir.Node) string {
 	return delegate.BackendClaw
 }
 
+// EffectiveBackendName exposes the exact runtime resolution to safety checks.
+// In particular, callers must not reimplement this chain and accidentally miss
+// launch overrides, environment defaults, or credential-based auto-detection.
+func (e *ClawExecutor) EffectiveBackendName(node ir.Node) string {
+	return e.resolveBackendName(node)
+}
+
 // providerStep is one element of a resolved provider fallback chain: a
 // credential-routing hint paired with an optional per-element model
 // override. An empty Model means "inherit the node's `model:`" — the

--- a/pkg/runtime/fan_out_internal_test.go
+++ b/pkg/runtime/fan_out_internal_test.go
@@ -49,10 +49,47 @@ func TestIsMutatingNode_AgentWithOneMutatingTool(t *testing.T) {
 }
 
 func TestIsMutatingNode_AgentWithNoTools(t *testing.T) {
-	// An agent without any tools cannot mutate via the executor.
+	// With no backend signal (unit-test stub), preserve the model-only default.
 	n := &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}}
 	if isMutatingNode(n) {
-		t.Error("agent with no tools should not be mutating")
+		t.Error("agent with no tools and no CLI backend should not be mutating")
+	}
+}
+
+func TestIsMutatingNode_CLIBackendWithNoTools(t *testing.T) {
+	for _, backend := range []string{"codex", "claude_code", "kimi", "custom_cli"} {
+		n := &ir.AgentNode{
+			BaseNode:  ir.BaseNode{ID: "a"},
+			LLMFields: ir.LLMFields{Backend: backend},
+		}
+		if !isMutatingNode(n) {
+			t.Errorf("unrestricted %s agent must be classified mutating", backend)
+		}
+	}
+}
+
+type fixedBackendResolver string
+
+func (r fixedBackendResolver) EffectiveBackendName(ir.Node) string { return string(r) }
+
+func TestIsMutatingNode_EffectiveBackendAndFullAccess(t *testing.T) {
+	n := &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}}
+	if !isMutatingNodeWithBackend(n, "", fixedBackendResolver("codex")) {
+		t.Error("agent resolved to unrestricted codex must be mutating")
+	}
+	if isMutatingNodeWithBackend(n, "codex", fixedBackendResolver("claw")) {
+		t.Error("effective claw launch override must win over the workflow default")
+	}
+	full := &ir.AgentNode{BaseNode: ir.BaseNode{ID: "full"}, LLMFields: ir.LLMFields{FullAccess: true}}
+	if !isMutatingNode(full) {
+		t.Error("full_access agent must be mutating")
+	}
+	locked := &ir.AgentNode{
+		BaseNode:  ir.BaseNode{ID: "locked"},
+		LLMFields: ir.LLMFields{Readonly: true, FullAccess: true, Backend: "codex"},
+	}
+	if isMutatingNode(locked) {
+		t.Error("readonly must win over conflicting full_access")
 	}
 }
 
@@ -277,6 +314,34 @@ func TestValidateWorkspaceSafety_RejectsTwoMutatingBranches(t *testing.T) {
 	ok := errorAs(err, &rtErr)
 	if !ok || rtErr.Code != ErrCodeWorkspaceSafety {
 		t.Errorf("expected RuntimeError ErrCodeWorkspaceSafety, got %v", err)
+	}
+}
+
+func TestValidateWorkspaceSafety_RejectsParallelUnrestrictedCodexAgents(t *testing.T) {
+	wf := &ir.Workflow{
+		Name:           "t",
+		DefaultBackend: "codex",
+		Nodes: map[string]ir.Node{
+			"router":  &ir.RouterNode{BaseNode: ir.BaseNode{ID: "router"}, RouterMode: ir.RouterFanOutAll},
+			"agent_a": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "agent_a"}},
+			"agent_b": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "agent_b"}},
+			"join":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "join"}, AwaitMode: ir.AwaitWaitAll},
+			"done":    &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "router", To: "agent_a"},
+			{From: "router", To: "agent_b"},
+			{From: "agent_a", To: "join"},
+			{From: "agent_b", To: "join"},
+			{From: "join", To: "done"},
+		},
+	}
+	e := &Engine{workflow: wf}
+	if err := e.validateWorkspaceSafety("router", []*ir.Edge{
+		{From: "router", To: "agent_a"},
+		{From: "router", To: "agent_b"},
+	}); err == nil {
+		t.Fatal("parallel unrestricted codex agents must be rejected as mutating")
 	}
 }
 

--- a/pkg/runtime/workspace_safety.go
+++ b/pkg/runtime/workspace_safety.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 )
@@ -22,14 +23,29 @@ var readOnlyTools = map[string]bool{
 }
 
 // isMutatingNode returns true if the node may modify the workspace.
-// Tool nodes are always mutating. Agent/judge nodes are mutating only
-// if they have at least one tool that is not in the read-only set.
+// Tool nodes are always mutating. Agent/judge nodes are mutating when
+// full_access is set, when they have at least one tool that is not in the
+// read-only set, or when the effective backend is a CLI delegate and its tool
+// list is omitted (CLI delegates treat an empty list as unrestricted native
+// tools). The engine asks the production executor for the effective backend so
+// launch overrides, environment defaults, and auto-detection are included.
 // Subbot nodes run a child .bot that may do anything (including mutate the
 // shared worktree), so they are conservatively treated as mutating — this
 // keeps validateWorkspaceSafety from admitting two subbot branches that would
 // race the same workspace. Nodes with Readonly=true are never considered
 // mutating.
 func isMutatingNode(node ir.Node) bool {
+	return isMutatingNodeWithBackend(node, "", nil)
+}
+
+// effectiveBackendResolver is implemented by the production model executor.
+// Keeping the interface here avoids duplicating its evolving resolution chain
+// (launch override -> DSL -> workflow default -> env -> auto-detection).
+type effectiveBackendResolver interface {
+	EffectiveBackendName(ir.Node) string
+}
+
+func isMutatingNodeWithBackend(node ir.Node, defaultBackend string, resolver effectiveBackendResolver) bool {
 	switch n := node.(type) {
 	case *ir.ToolNode:
 		return true
@@ -38,6 +54,9 @@ func isMutatingNode(node ir.Node) bool {
 	case *ir.AgentNode:
 		if n.Readonly {
 			return false
+		}
+		if n.FullAccess || unrestrictedCLIBackendCanWrite(node, n.LLMFields, n.Tools, defaultBackend, resolver) {
+			return true
 		}
 		for _, t := range n.Tools {
 			if !readOnlyTools[t] {
@@ -48,6 +67,9 @@ func isMutatingNode(node ir.Node) bool {
 		if n.Readonly {
 			return false
 		}
+		if n.FullAccess || unrestrictedCLIBackendCanWrite(node, n.LLMFields, n.Tools, defaultBackend, resolver) {
+			return true
+		}
 		for _, t := range n.Tools {
 			if !readOnlyTools[t] {
 				return true
@@ -55,6 +77,31 @@ func isMutatingNode(node ir.Node) bool {
 		}
 	}
 	return false
+}
+
+func unrestrictedCLIBackendCanWrite(
+	node ir.Node,
+	fields ir.LLMFields,
+	tools []string,
+	defaultBackend string,
+	resolver effectiveBackendResolver,
+) bool {
+	if len(tools) > 0 {
+		return false
+	}
+	backend := strings.TrimSpace(ir.ExpandEnvWithDefault(fields.Backend))
+	if backend == "" {
+		backend = strings.TrimSpace(ir.ExpandEnvWithDefault(defaultBackend))
+	}
+	if resolver != nil {
+		if effective := strings.TrimSpace(resolver.EffectiveBackendName(node)); effective != "" {
+			backend = effective
+		}
+	}
+	if backend == "" || backend == "auto" {
+		return false
+	}
+	return backend != "claw"
 }
 
 // branchContainsMutation walks from startNodeID to globalConvergence (or to a
@@ -101,7 +148,8 @@ func (e *Engine) branchContainsMutation(startNodeID, globalConvergence string) b
 		if isTerminalNode(node) {
 			continue
 		}
-		if isMutatingNode(node) {
+		resolver, _ := e.executor.(effectiveBackendResolver)
+		if isMutatingNodeWithBackend(node, e.workflow.DefaultBackend, resolver) {
 			return true
 		}
 		for _, edge := range e.workflow.Edges {


### PR DESCRIPTION
## Summary

- preserve Iterion's delegated-tool contract for Codex: omitted tools allow workspace writes, explicit `readonly` wins, and native/Claude-style writer aliases select `workspace-write`
- propagate `readonly` to backend tasks and make workspace-safety checks use the effective runtime backend (including launch overrides and auto-detection)
- make schema output reliable with a dedicated resume/format pass, consistent model and per-run credentials, strict fallback handling, and typed terminal/rate/network errors
- capture stderr safely in both Codex passes so transient formatting failures remain retryable
- honor model and tool-step settings, and inspect rollouts under the per-run `CODEX_HOME`
- fail explicitly for unsupported Iterion Docker/Kubernetes outer sandboxes instead of silently running Codex on the host

## Validation

- `go test -mod=vendor ./pkg/backend/delegate ./pkg/runtime ./pkg/backend/model`
- `go test -race -mod=vendor ./pkg/backend/delegate`
- `go vet -mod=vendor ./pkg/backend/delegate ./pkg/runtime ./pkg/backend/model`
- live Codex regression: both an explicit lowercase `write_file` task and an omitted-tools task wrote the expected marker under `workspace-write`, then returned schema-conforming output through the formatting pass
- full repository suite was also exercised; the only two failures reproduce unchanged on `main` and require a headful computer-use environment:
  - `TestRegisterClawComputerUse_ScreenshotPropagatesUnavailable`
  - `TestRegisterClawComputerUse_ComputerUsePropagatesUnavailable`

## Follow-up

Supporting Codex inside Iterion's Docker/Kubernetes sandbox needs a process/SDK routing integration. This PR makes the current limitation explicit and safe; that larger boundary change should be handled separately with dedicated Docker/Kubernetes integration tests.
