### PR TITLE
fix(webhooks): never auto-launch bots on draft PRs/MRs (GitHub, GitLab, Forgejo)

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -85,10 +85,15 @@ stay intact for the provider handler's signature recomputation
 Single URL, two event kinds dispatched on `X-Gitlab-Event`
 ([pkg/server/webhooks_gitlab.go](../pkg/server/webhooks_gitlab.go)):
 
-- **`Merge Request Hook`** — auto-review on `open`/`reopen`. Pushes that
-  produce action `update` deliberately do **not** re-trigger (auto-review
-  on every push was found too noisy; cf.
-  [pkg/webhooks/gitlab/parser.go:IsReviewable](../pkg/webhooks/gitlab/parser.go)).
+- **`Merge Request Hook`** — auto-review on `open`/`reopen`, and on the
+  **draft→ready transition**. A **draft MR never auto-launches** (the author
+  is still iterating — auto-running a bot wastes budget and churns an
+  unfinished branch). GitLab has no dedicated ready action, so the trigger is
+  the `update` whose `changes.draft` (or the deprecated `work_in_progress`)
+  went `true→false`. Ordinary pushes (action `update` with an unchanged draft
+  flag) deliberately do **not** re-trigger — auto-review on every push was
+  found too noisy; cf.
+  [pkg/webhooks/gitlab/parser.go:IsReviewable](../pkg/webhooks/gitlab/parser.go).
 - **`Note Hook`** — on-demand re-review. Only acts when the note hangs
   off an open MR **and** its first non-whitespace token is exactly
   `/revi`. Quoting "please run /revi" mid-text does not trigger
@@ -117,7 +122,14 @@ event paths trigger; ping / push / everything else is silently filtered
 (returns 200 — a 4xx makes GitHub disable the webhook after repeated
 failures; [pkg/server/webhooks_github.go](../pkg/server/webhooks_github.go)):
 
-- **`pull_request`** with action `opened` or `reopened` → PR auto-review.
+- **`pull_request`** with action `opened`, `reopened`, or `ready_for_review`
+  → PR auto-review. A **draft PR never auto-launches** (the `draft` flag is
+  honoured on every action — the trigger is `ready_for_review`, which clears
+  it). A **fork PR** (head branch in a different repo) is likewise never
+  auto-launched: it is untrusted, so a repo collaborator must trigger a bot
+  manually via the `/command` path — the anti budget-exhaustion boundary
+  ([pkg/webhooks/prforge/parser.go:IsReviewable](../pkg/webhooks/prforge/parser.go) +
+  `IsCrossRepo`).
 - **`issue_comment`** → the universal `/command` slash path (e.g.
   `/featurly <prompt>`), routed through the command registry.
 - **`issues`** with action `labeled` → launches the webhook's bot with
@@ -146,6 +158,14 @@ deployments); same for `X-Forgejo-Event` / `X-Gitea-Event`. The
 signature header is treated as a hex digest with or without the
 `sha256=` prefix
 ([pkg/server/webhooks_forgejo.go:forgejoSignatureHeader](../pkg/server/webhooks_forgejo.go)).
+
+The same draft/fork guards as GitHub apply (shared `prforge` parser):
+a draft PR (`pull_request.draft == true`) never auto-launches, and a fork
+PR never auto-launches. **Caveat:** Forgejo/Gitea has no `ready_for_review`
+webhook action (marking a WIP PR ready arrives as `edited`, which does not
+auto-trigger), so on Forgejo the draft→ready re-trigger is on-demand — a
+collaborator reopens the PR or uses the `/command` path. The no-draft and
+no-fork guarantees hold regardless.
 
 ### Generic (`POST /api/webhooks/generic/{id}`)
 

--- a/pkg/server/webhooks_github_test.go
+++ b/pkg/server/webhooks_github_test.go
@@ -119,6 +119,30 @@ const ghTicketPR = `{
   "sender": {"login": "alice"}
 }`
 
+// ghDraftTicketPR: a same-repo ticket PR opened as a DRAFT — must NOT
+// auto-launch a bot (the author is still iterating).
+const ghDraftTicketPR = `{
+  "action": "opened", "number": 9,
+  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+  "pull_request": {"number": 9, "title": "Add subtract", "body": "Implements subtraction.\n\nFixes #12", "draft": true,
+    "html_url": "https://github.com/acme/widgets/pull/9", "state": "open",
+    "head": {"ref": "feat/subtract", "sha": "aaa111", "repo": {"full_name": "acme/widgets"}},
+    "base": {"ref": "main", "repo": {"full_name": "acme/widgets"}}},
+  "sender": {"login": "alice"}
+}`
+
+// ghReadyForReviewPR: the draft above marked ready-for-review — THE
+// auto-trigger (draft flag now false).
+const ghReadyForReviewPR = `{
+  "action": "ready_for_review", "number": 9,
+  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+  "pull_request": {"number": 9, "title": "Add subtract", "body": "Implements subtraction.\n\nFixes #12", "draft": false,
+    "html_url": "https://github.com/acme/widgets/pull/9", "state": "open",
+    "head": {"ref": "feat/subtract", "sha": "aaa111", "repo": {"full_name": "acme/widgets"}},
+    "base": {"ref": "main", "repo": {"full_name": "acme/widgets"}}},
+  "sender": {"login": "alice"}
+}`
+
 // ghDequeuedPR: a PR ejected from the merge queue for a conflict → the
 // auto-heal path dispatches Billy to rebase+resolve+repush.
 const ghDequeuedPR = `{
@@ -130,6 +154,54 @@ const ghDequeuedPR = `{
     "base": {"ref": "main", "repo": {"full_name": "acme/widgets"}}},
   "sender": {"login": "alice"}
 }`
+
+// A DRAFT PR never auto-launches a bot — the author is still iterating.
+func TestGitHubWebhook_DraftPRNotAutoLaunched(t *testing.T) {
+	s := newWebhookTestServer(t)
+	launched := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		launched++
+		return "run-x", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"review-pr", "branch-improve-loop"}
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghDraftTicketPR, prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusOK {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != webhooks.StatusFiltered {
+		t.Fatalf("draft PR must be filtered, got %q", resp["status"])
+	}
+	if launched != 0 {
+		t.Fatalf("draft PR must NOT auto-launch any bot, launched=%d", launched)
+	}
+}
+
+// Marking a draft PR ready-for-review IS the auto-trigger: this ticket PR
+// then routes to the branch-improvement bot exactly like a fresh open.
+func TestGitHubWebhook_ReadyForReviewLaunches(t *testing.T) {
+	s := newWebhookTestServer(t)
+	var gotBot string
+	s.webhookLaunchBot = func(_ context.Context, botID string, _ map[string]string, _, _, _ string, _, _ map[string]string) (string, error) {
+		gotBot = botID
+		return "run-x", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"review-pr", "branch-improve-loop"}
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReadyForReviewPR, prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	if gotBot != branchImproveBotID {
+		t.Fatalf("ready_for_review ticket PR should route to %q, got %q", branchImproveBotID, gotBot)
+	}
+}
 
 // TestGitHubWebhook_DequeuedPRAutoHeals: a merge-queue ejection for a conflict
 // dispatches Billy to reconcile the branch with the base + re-enter the queue.

--- a/pkg/server/webhooks_gitlab_test.go
+++ b/pkg/server/webhooks_gitlab_test.go
@@ -96,6 +96,68 @@ func TestGitLabWebhook_HappyPath(t *testing.T) {
 	}
 }
 
+// glDraftMR is a draft MR opened — must be filtered (never auto-launched)
+// even though the action is "open".
+const glDraftMR = `{
+  "object_kind": "merge_request",
+  "project": {"id": 42, "path_with_namespace": "acme/widgets", "git_http_url": "https://gitlab.com/acme/widgets.git"},
+  "object_attributes": {"iid": 9, "action": "open", "source_branch": "wip/x", "target_branch": "main",
+    "title": "Draft: Add X", "description": "wip", "url": "https://gitlab.com/acme/widgets/-/merge_requests/9",
+    "draft": true, "work_in_progress": true, "last_commit": {"id": "sha9"}}
+}`
+
+// glReadyMR is the draft→ready transition (update clearing changes.draft):
+// GitLab's stand-in for a ready-for-review action — this MUST launch.
+const glReadyMR = `{
+  "object_kind": "merge_request",
+  "project": {"id": 42, "path_with_namespace": "acme/widgets", "git_http_url": "https://gitlab.com/acme/widgets.git"},
+  "object_attributes": {"iid": 9, "action": "update", "source_branch": "wip/x", "target_branch": "main",
+    "title": "Add X", "description": "ready", "url": "https://gitlab.com/acme/widgets/-/merge_requests/9",
+    "draft": false, "work_in_progress": false, "last_commit": {"id": "sha9"}},
+  "changes": {"draft": {"previous": true, "current": false}}
+}`
+
+func TestGitLabWebhook_DraftMRNotAutoLaunched(t *testing.T) {
+	s := newWebhookTestServer(t)
+	var calls int
+	s.webhookLaunchBot = func(_ context.Context, _ string, _ map[string]string, _, _, _ string, _, _ map[string]string) (string, error) {
+		calls++
+		return "run-x", nil
+	}
+	w := httptest.NewRecorder()
+	s.handleGitLabWebhook(w, glReq(gitlabCtx(glConfig()), glDraftMR, gitlab.EventHeaderMergeRequest))
+	if w.Code != http.StatusOK {
+		t.Fatalf("draft MR should be a filtered 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != webhooks.StatusFiltered {
+		t.Fatalf("draft MR status=%q want filtered", resp["status"])
+	}
+	if calls != 0 {
+		t.Fatalf("draft MR must NOT launch a bot (calls=%d)", calls)
+	}
+}
+
+func TestGitLabWebhook_ReadyForReviewLaunches(t *testing.T) {
+	s := newWebhookTestServer(t)
+	var calls int
+	var gotBot string
+	s.webhookLaunchBot = func(_ context.Context, botID string, _ map[string]string, _, _, _ string, _, _ map[string]string) (string, error) {
+		calls++
+		gotBot = botID
+		return "run-ready", nil
+	}
+	w := httptest.NewRecorder()
+	s.handleGitLabWebhook(w, glReq(gitlabCtx(glConfig()), glReadyMR, gitlab.EventHeaderMergeRequest))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("ready MR should launch (202), got %d body=%s", w.Code, w.Body.String())
+	}
+	if calls != 1 || gotBot != "review-pr" {
+		t.Fatalf("ready MR must launch review bot once: calls=%d bot=%q", calls, gotBot)
+	}
+}
+
 func TestGitLabWebhook_Idempotent(t *testing.T) {
 	s := newWebhookTestServer(t)
 	var calls int

--- a/pkg/webhooks/gitlab/events.go
+++ b/pkg/webhooks/gitlab/events.go
@@ -17,6 +17,26 @@ type MergeRequestEvent struct {
 	Project          Project          `json:"project"`
 	ObjectAttributes ObjectAttributes `json:"object_attributes"`
 	Labels           []Label          `json:"labels"`
+	// Changes records the before/after of attributes touched by this event.
+	// GitLab has no dedicated "ready_for_review" action — a draft MR marked
+	// ready arrives as an `update` whose Changes.Draft went true→false, so
+	// the handler must inspect this to distinguish it from a plain push.
+	Changes Changes `json:"changes"`
+}
+
+// Changes is the top-level `changes` object GitLab sends on `update`
+// events. We decode only the draft-transition fields. Pointers so a
+// missing key is distinguishable from a present {false,false}.
+type Changes struct {
+	Draft          *BoolChange `json:"draft"`
+	WorkInProgress *BoolChange `json:"work_in_progress"` // deprecated alias GitLab still emits
+}
+
+// BoolChange is the {previous,current} pair GitLab uses for a boolean
+// attribute inside `changes`.
+type BoolChange struct {
+	Previous bool `json:"previous"`
+	Current  bool `json:"current"`
 }
 
 type Project struct {
@@ -37,6 +57,11 @@ type ObjectAttributes struct {
 	URL          string `json:"url"`
 	OldRev       string `json:"oldrev"`
 	LastCommit   Commit `json:"last_commit"`
+	// Draft is GitLab's work-in-progress flag (14.0+); WorkInProgress is the
+	// deprecated alias older GitLab still sends. Either set ⇒ the MR must not
+	// auto-launch a bot; the trigger is the update that clears it.
+	Draft          bool `json:"draft"`
+	WorkInProgress bool `json:"work_in_progress"`
 }
 
 type Commit struct {

--- a/pkg/webhooks/gitlab/gitlab_test.go
+++ b/pkg/webhooks/gitlab/gitlab_test.go
@@ -57,22 +57,83 @@ func TestParseMergeRequest_RejectsNonMR(t *testing.T) {
 
 func TestIsReviewable(t *testing.T) {
 	cases := []struct {
-		action, oldrev, head string
-		want                 bool
+		action             string
+		draft, becameReady bool
+		want               bool
 	}{
-		{"open", "", "h", true},
-		{"reopen", "", "h", true},
-		{"update", "old", "h", false}, // push no longer auto-triggers (re-review is on-demand via /revi)
-		{"update", "h", "h", false},   // metadata edit
-		{"update", "", "h", false},    // label-only
-		{"close", "", "h", false},
-		{"approved", "", "h", false},
+		{"open", false, false, true},
+		{"reopen", false, false, true},
+		{"update", false, false, false}, // push no longer auto-triggers (re-review is on-demand via /revi)
+		{"close", false, false, false},
+		{"approved", false, false, false},
+		// A currently-draft MR never auto-triggers, whatever the action.
+		{"open", true, false, false},
+		{"reopen", true, false, false},
+		// The draft→ready transition (update clearing draft) IS the trigger —
+		// GitLab has no dedicated ready action, so it rides `update`.
+		{"update", false, true, true},
+		// Draft cleared but still marked draft (defensive) must not trigger.
+		{"update", true, true, false},
 	}
 	for _, c := range cases {
-		p := Parsed{Action: c.action, OldRev: c.oldrev, HeadSHA: c.head}
+		p := Parsed{Action: c.action, Draft: c.draft, BecameReady: c.becameReady}
 		if p.IsReviewable() != c.want {
-			t.Errorf("action=%q oldrev=%q head=%q => %v want %v", c.action, c.oldrev, c.head, p.IsReviewable(), c.want)
+			t.Errorf("action=%q draft=%v becameReady=%v => %v want %v", c.action, c.draft, c.becameReady, p.IsReviewable(), c.want)
 		}
+	}
+}
+
+// mrDraftOpenPayload is a draft MR opened — must be filtered (never
+// auto-launched) even though the action is "open".
+const mrDraftOpenPayload = `{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "project": {"id": 42, "path_with_namespace": "acme/widgets", "git_http_url": "https://gitlab.com/acme/widgets.git"},
+  "object_attributes": {
+    "iid": 8, "action": "open", "source_branch": "wip/x", "target_branch": "main",
+    "title": "Draft: Add X", "url": "https://gitlab.com/acme/widgets/-/merge_requests/8",
+    "draft": true, "work_in_progress": true, "last_commit": {"id": "abc123"}
+  }
+}`
+
+// mrReadyPayload is the draft→ready transition: an `update` whose
+// changes.draft went true→false. This IS the auto-trigger.
+const mrReadyPayload = `{
+  "object_kind": "merge_request",
+  "event_type": "merge_request",
+  "project": {"id": 42, "path_with_namespace": "acme/widgets", "git_http_url": "https://gitlab.com/acme/widgets.git"},
+  "object_attributes": {
+    "iid": 8, "action": "update", "source_branch": "wip/x", "target_branch": "main",
+    "title": "Add X", "url": "https://gitlab.com/acme/widgets/-/merge_requests/8",
+    "draft": false, "work_in_progress": false, "last_commit": {"id": "abc123"}
+  },
+  "changes": {"draft": {"previous": true, "current": false}}
+}`
+
+func TestParseMergeRequest_Draft(t *testing.T) {
+	draft, err := ParseMergeRequest([]byte(mrDraftOpenPayload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !draft.Draft {
+		t.Error("draft MR must parse Draft=true")
+	}
+	if draft.IsReviewable() {
+		t.Error("draft MR (action=open) must NOT be auto-reviewable")
+	}
+
+	ready, err := ParseMergeRequest([]byte(mrReadyPayload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ready.Draft {
+		t.Error("ready MR must parse Draft=false")
+	}
+	if !ready.BecameReady {
+		t.Error("draft→ready update must set BecameReady")
+	}
+	if !ready.IsReviewable() {
+		t.Error("draft→ready transition MUST be auto-reviewable")
 	}
 }
 

--- a/pkg/webhooks/gitlab/parser.go
+++ b/pkg/webhooks/gitlab/parser.go
@@ -23,6 +23,14 @@ type Parsed struct {
 	OldRev         string
 	Labels         []string
 	SenderUsername string // the actor that opened/reopened the MR (e.g. "renovate")
+	// Draft reports whether the MR is currently a work-in-progress draft. A
+	// draft MR never auto-triggers a bot (IsReviewable is false).
+	Draft bool
+	// BecameReady is true when THIS event is the draft→ready transition
+	// (GitLab's `changes.draft` went true→false on an `update`). It is the
+	// GitLab equivalent of GitHub's `ready_for_review` action — the moment a
+	// draft becomes reviewable — since GitLab has no dedicated action for it.
+	BecameReady bool
 }
 
 // ParseMergeRequest decodes a GitLab merge_request webhook body.
@@ -41,6 +49,15 @@ func ParseMergeRequest(body []byte) (Parsed, error) {
 			labels = append(labels, l.Title)
 		}
 	}
+	// A draft→ready transition is an `update` whose changes show draft (or the
+	// deprecated work_in_progress alias) going true→false.
+	becameReady := false
+	if c := e.Changes.Draft; c != nil && c.Previous && !c.Current {
+		becameReady = true
+	}
+	if c := e.Changes.WorkInProgress; c != nil && c.Previous && !c.Current {
+		becameReady = true
+	}
 	return Parsed{
 		ProjectID:      e.Project.ID,
 		ProjectPath:    e.Project.PathWithNamespace,
@@ -57,18 +74,28 @@ func ParseMergeRequest(body []byte) (Parsed, error) {
 		OldRev:         oa.OldRev,
 		Labels:         labels,
 		SenderUsername: e.User.Username,
+		Draft:          oa.Draft || oa.WorkInProgress,
+		BecameReady:    becameReady,
 	}, nil
 }
 
 // IsReviewable reports whether the MR action should AUTO-trigger a review.
-// Only open/reopen do: a review fires once when the MR is created (or
-// reopened). Pushes to the MR ("update" with a new head) deliberately do
-// NOT re-trigger — auto-review-on-every-push was found too heavy. Re-review
-// after a push is on-demand via the `/revi` note command instead.
+// A DRAFT MR is never auto-reviewable — the author is still iterating, so
+// auto-running a bot wastes budget and churns an unfinished branch. Otherwise
+// a review fires when the MR is created (open), reopened, or marked ready
+// (the `update` that clears draft — GitLab's stand-in for a ready action).
+// Plain pushes to the MR ("update" with a new head, draft unchanged)
+// deliberately do NOT re-trigger — auto-review-on-every-push was found too
+// heavy; re-review after a push is on-demand via the `/revi` note command.
 func (p Parsed) IsReviewable() bool {
+	if p.Draft {
+		return false
+	}
 	switch p.Action {
 	case "open", "reopen":
 		return true
+	case "update":
+		return p.BecameReady
 	default:
 		return false
 	}

--- a/pkg/webhooks/prforge/events.go
+++ b/pkg/webhooks/prforge/events.go
@@ -42,8 +42,12 @@ type PullRequest struct {
 	Body    string `json:"body"`
 	HTMLURL string `json:"html_url"`
 	State   string `json:"state"`
-	Head    Ref    `json:"head"`
-	Base    Ref    `json:"base"`
+	// Draft is GitHub's / Gitea's work-in-progress flag. A draft PR must not
+	// auto-launch a bot — the author is still iterating; the trigger is the
+	// `ready_for_review` action (or open/reopen while not draft).
+	Draft bool `json:"draft"`
+	Head  Ref  `json:"head"`
+	Base  Ref  `json:"base"`
 }
 
 type Ref struct {

--- a/pkg/webhooks/prforge/parser.go
+++ b/pkg/webhooks/prforge/parser.go
@@ -32,6 +32,10 @@ type Parsed struct {
 	// DequeueReason is the merge-queue eject reason on a `dequeued`
 	// action (e.g. "MERGE_CONFLICT", "CI_FAILURE"). Empty otherwise.
 	DequeueReason string
+	// Draft reports whether the PR is a work-in-progress draft. A draft PR
+	// never auto-triggers a bot (IsReviewable is false); the trigger is the
+	// `ready_for_review` action that clears it.
+	Draft bool
 }
 
 // healableDequeueReasons are the merge-queue eject reasons that a
@@ -84,6 +88,7 @@ func ParsePullRequest(body []byte) (Parsed, error) {
 		SenderLogin:      e.Sender.Login,
 		HeadRepoFullName: pr.Head.Repo.FullName,
 		DequeueReason:    e.Reason,
+		Draft:            pr.Draft,
 	}, nil
 }
 
@@ -99,13 +104,19 @@ func (p Parsed) IsCrossRepo() bool {
 }
 
 // IsReviewable reports whether the PR action should AUTO-trigger a
-// review. Same contract as gitlab.Parsed.IsReviewable — only opened /
-// reopened. Subsequent push actions ("synchronize" on GitHub-shaped
-// payloads, "synchronized" on Gitea-shaped payloads) deliberately do
-// NOT re-trigger; re-review is on-demand.
+// review. A DRAFT PR is never auto-reviewable — the author is still
+// iterating, and auto-running a bot on it wastes budget and churns an
+// unfinished branch; the trigger is instead `ready_for_review` (which
+// clears the draft flag). Otherwise: only opened / reopened. Subsequent
+// push actions ("synchronize" on GitHub-shaped payloads, "synchronized"
+// on Gitea-shaped payloads) deliberately do NOT re-trigger; re-review is
+// on-demand.
 func (p Parsed) IsReviewable() bool {
+	if p.Draft {
+		return false
+	}
 	switch p.Action {
-	case "opened", "reopened":
+	case "opened", "reopened", "ready_for_review":
 		return true
 	default:
 		return false

--- a/pkg/webhooks/prforge/prforge_test.go
+++ b/pkg/webhooks/prforge/prforge_test.go
@@ -159,23 +159,30 @@ func TestParsePullRequest_MalformedFails(t *testing.T) {
 func TestIsReviewable(t *testing.T) {
 	cases := []struct {
 		action string
+		draft  bool
 		want   bool
 	}{
-		{"opened", true},
-		{"reopened", true},
+		{"opened", false, true},
+		{"reopened", false, true},
+		// A draft PR being marked ready-for-review is THE auto-trigger.
+		{"ready_for_review", false, true},
+		// A DRAFT PR never auto-triggers, whatever the action — the author
+		// is still iterating; the trigger is ready_for_review (draft=false).
+		{"opened", true, false},
+		{"reopened", true, false},
 		// GitHub spells the push action "synchronize"; Gitea spells it
 		// "synchronized". Both must filter, since re-review is on-demand.
-		{"synchronize", false},
-		{"synchronized", false},
-		{"edited", false},
-		{"labeled", false},
-		{"closed", false},
-		{"review_requested", false},
+		{"synchronize", false, false},
+		{"synchronized", false, false},
+		{"edited", false, false},
+		{"labeled", false, false},
+		{"closed", false, false},
+		{"review_requested", false, false},
 	}
 	for _, c := range cases {
-		p := Parsed{Action: c.action}
+		p := Parsed{Action: c.action, Draft: c.draft}
 		if got := p.IsReviewable(); got != c.want {
-			t.Errorf("action=%q => %v want %v", c.action, got, c.want)
+			t.Errorf("action=%q draft=%v => %v want %v", c.action, c.draft, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
## Why

Bots (Billy/Revi/improve-loops) must **not** auto-launch on a PR/MR while it is a **draft** — the author is still iterating, so an auto-run wastes budget and churns an unfinished branch. Auto-review should fire only once the PR/MR is **ready for review**.

Requested: *« on ne devrait pas lancer de bot automatique sur les PR tant qu'elles sont en draft, seulement dès qu'elles sont ready to review »* — and it must work on **GitHub, GitLab et Forgejo**.

## What

The guard sits on the **auto-launch** path only (`IsReviewable`). The manual `/command` (GitHub/Forgejo) and `/revi` (GitLab) paths are untouched — an explicit human request may still review a draft.

**GitHub + Forgejo/Gitea** (shared `prforge` parser)
- Parse `pull_request.draft`; `IsReviewable` returns false while draft.
- Trigger set is now `opened` / `reopened` / `ready_for_review` (the action that clears the draft flag).

**GitLab** (separate `gitlab` parser)
- Parse `object_attributes.draft` (+ the deprecated `work_in_progress` alias); a draft MR is filtered.
- GitLab has **no dedicated ready action** — the draft→ready transition is the `update` whose `changes.draft` (or `changes.work_in_progress`) went `true→false` (`BecameReady`). A plain push (`update`, draft unchanged) still does **not** re-trigger.

**Forgejo/Gitea caveat** (documented): no `ready_for_review` webhook action exists — marking a WIP PR ready arrives as `edited`, which we don't auto-trigger. So on Forgejo the draft→ready re-trigger is **on-demand** (reopen or `/command`). The **no-draft** and **no-fork** guarantees hold regardless.

## Verification
- Parser tests for all three forges (`prforge`, `gitlab`): draft filtered, ready-transition reviewable.
- Handler-level tests: `TestGitHubWebhook_DraftPRNotAutoLaunched` / `_ReadyForReviewLaunches`, `TestGitLabWebhook_DraftMRNotAutoLaunched` / `_ReadyForReviewLaunches`.
- `go test ./pkg/webhooks/... ./pkg/server/` green; `gofmt`/`go vet` clean.
- Wire shapes confirmed against Gitea source (`HookIssueAction` has no `ready_for_review`; `PullRequest.Draft` exists) and GitLab webhook docs (`changes.draft {previous,current}`, ready = `update`).

Docs: [docs/webhooks.md](docs/webhooks.md) per-provider trigger sections updated (incl. the fork guard already shipped in #189).

🤖 Generated with [Claude Code](https://claude.com/claude-code)