### PR TITLE
feat(dsl): parallel fan-out of isolated subbots (+ nested & resume SubbotRunner fixes)

### DIFF
--- a/docs/groups-iteration-subbots.md
+++ b/docs/groups-iteration-subbots.md
@@ -94,6 +94,7 @@ subbot run_ticket:
   with { issue: "{{outputs.plan.id}}" }   # → the child's vars
   output: ticket_verdict              # schema of the child's terminal output
   needs: worktree_slot                # optional resource lease for the child run
+  isolated: true                      # child confines writes to its own run/worktree
 
 plan -> run_ticket
 run_ticket -> merge when validated
@@ -104,10 +105,71 @@ run_ticket -> merge when validated
 - `needs:` leases a resource for the duration of the child run; the leased
   instance id (from a named pool) is passed to the child as `_lease_<resource>`
   so it can pick e.g. a worktree index.
+- `isolated:` (default `false`) is the mirror of an agent/judge node's
+  `readonly:`. See [Fanning subbots out in parallel](#fanning-subbots-out-in-parallel)
+  below — it is what makes the parallel pattern legal.
 - A depth guard bounds nested subbot recursion. Diagnostic **C119** (no `source`).
 - The runtime invokes a host-supplied `SubbotRunner`; the `iterion run` CLI
   wires one that compiles + runs the child sharing the parent store. (Studio /
   cloud wiring + parent↔child run linkage in the UI are follow-ons.)
+
+### Fanning subbots out in parallel
+
+A subbot runs a **whole child `.bot`** that may do anything, so the
+workspace-safety guard conservatively treats it as **mutating**: it refuses to
+fan the *same* subbot template out concurrently (`max_parallel_branches > 1`)
+over a `fan_out_each`, because two children could race the shared git
+worktree/index. By default the only legal subbot fan-out is therefore
+**serialized** (`max_parallel_branches: 1`).
+
+`isolated: true` **opts out of that guard**. It is an author assertion that the
+child **does not mutate the parent's shared workspace** — it confines every
+write to its own run store (`runs/<child_run_id>/`) and/or its own worktree —
+so N replays are safe to run at once. It is the exact analogue of `readonly:`
+on an agent/judge node: the runtime cannot *prove* the child is
+workspace-independent, so you certify it, and the guard then admits the
+parallel fan-out (both `fan_out_each` and static `fan_out_all`).
+
+```
+router dispatch:
+  mode: fan_out_each
+  over: "{{outputs.plan.tickets}}"
+  as: ticket
+
+subbot run_ticket:
+  source: "episode.bot"
+  with { id: "{{outputs.dispatch.ticket.id}}" }
+  isolated: true        # each child writes only to its own run store
+
+dispatch -> run_ticket
+run_ticket -> collect
+```
+
+> **Contract — use `isolated:` ONLY when true.** If the child *does* write the
+> shared worktree (e.g. it commits code to the same checkout), leaving it
+> serialized (`max_parallel_branches: 1`) or giving each child a real worktree
+> (`needs: <worktree_pool>` + a child that keys its worktree off `_lease_*`) is
+> the safe path. A false `isolated:` assertion re-opens exactly the parallel
+> shared-workspace race the guard exists to prevent.
+
+Parallel child runs are **data-race safe**: they share the parent's `RunStore`,
+whose per-run artifacts/events/checkpoints are isolated by `run_id` and guarded
+by a store-wide lock, and each child gets its own engine + (if `worktree: auto`)
+its own distinct git worktree. Concurrency is bounded only by the parent's
+`max_parallel_branches` (and any `needs:` lease pool). Two accounting/hygiene
+boundaries are worth knowing before a heavy fan-out:
+
+- **Budget does not compose across the boundary.** A child run is budgeted
+  purely from its own `.bot`; the parent's `max_cost_usd` / `max_tokens` /
+  `max_duration` do **not** bound the children, so N parallel children can
+  collectively spend well past the parent's cap. Bound them with a per-child
+  budget block, the run-level `--timeout`, and an explicit
+  `max_parallel_branches`.
+- **Same-target board writes are not cross-child atomic.** If several parallel
+  subbots hold `board.*` capabilities and mutate the **same** issue or board
+  config, the last writer wins (writes never corrupt the file, but an update
+  can be lost). Give each child a distinct target, or serialize board-mutating
+  subbots.
 
 ---
 
@@ -134,9 +196,18 @@ subbot run_ticket:
   with { issue: "{{outputs.dispatch.ticket.id}}" }
   output: ticket_verdict
   needs: worktree_slot
+  isolated: true                       # each child mutates only its leased worktree
 
 run_ticket -> collect when validated   # collect: await: best_effort
 ```
+
+`isolated: true` is what makes this parallel — the `worktree_slot` lease gives
+each child a distinct worktree, and `isolated:` certifies that the child
+confines its writes there rather than to the parent's shared checkout, so the
+safety guard admits the concurrent replays. Without it the fan-out would be
+rejected (see [Fanning subbots out in parallel](#fanning-subbots-out-in-parallel));
+drop `isolated:` and add `max_parallel_branches: 1` if the children genuinely
+share one workspace.
 
 See [examples/composition/](../examples/composition/) for a runnable tool-only
 demonstration.

--- a/examples/composition/parallel_subbots.bot
+++ b/examples/composition/parallel_subbots.bot
@@ -1,0 +1,49 @@
+## Demonstrates PARALLEL fan-out of an `isolated:` subbot (tool-only, no API keys).
+##
+##   make_items -> dispatch(fan_out_each) -> run_child(subbot, isolated) -> collect(wait_all) -> done
+##
+## `isolated: true` asserts each child run confines its writes to its own run
+## store, so the workspace-safety guard admits the concurrent replays. Drop the
+## flag (or the budget cap) and the run is rejected with WORKSPACE_SAFETY — see
+## docs/groups-iteration-subbots.md#fanning-subbots-out-in-parallel.
+schema items_out:
+  items: json
+
+schema vout:
+  validated: bool
+  echoed: string
+
+schema cout:
+  done: bool
+
+tool make_items:
+  command: `printf '{"items":[{"id":"ep1"},{"id":"ep2"},{"id":"ep3"}]}'`
+  output: items_out
+
+router dispatch:
+  mode: fan_out_each
+  over: "{{outputs.make_items.items}}"
+  as: ep
+
+## Runs child.bot once per element, concurrently. `isolated:` is what makes the
+## parallel fan-out legal; each child only echoes its own ticket id.
+subbot run_child:
+  source: "child.bot"
+  with { ticket: "{{outputs.dispatch.ep.id}}" }
+  output: vout
+  isolated: true
+
+compute collect:
+  await: wait_all
+  output: cout
+  expr:
+    done: "true"
+
+workflow parallel_subbots:
+  entry: make_items
+  budget:
+    max_parallel_branches: 3
+  make_items -> dispatch
+  dispatch    -> run_child
+  run_child   -> collect
+  collect     -> done

--- a/pkg/backend/model/executor.go
+++ b/pkg/backend/model/executor.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -137,6 +138,14 @@ type ClawExecutor struct {
 	// for node_finished output redaction, (b) materialise ${secret.X}
 	// placeholders at tool/shell exec (Layer 1). Nil disables it.
 	secretGuard *secretguard.Guard
+
+	// extraClosers are auxiliary resources opened during executor
+	// construction (e.g. the native board store, whose fsnotify watcher runs
+	// a goroutine + holds an inotify instance) that must be released on
+	// Close(). Without this each BuildExecutor call leaks one watcher — acute
+	// under parallel subbot fan-out, which builds one executor per child and
+	// can march toward fs.inotify.max_user_instances.
+	extraClosers []io.Closer
 }
 
 // SetSandbox installs the live sandbox handle on the executor. The
@@ -182,6 +191,20 @@ func WithToolRegistry(tr *tool.Registry) ClawExecutorOption {
 // WithMCPManager sets the generic MCP manager used to lazily discover MCP tools.
 func WithMCPManager(m *mcp.Manager) ClawExecutorOption {
 	return func(e *ClawExecutor) { e.mcpManager = m }
+}
+
+// WithExtraClosers registers auxiliary resources (nil entries ignored) to be
+// released when the executor is closed — e.g. the native board store opened for
+// board.* MCP tools, whose fsnotify watcher would otherwise leak a goroutine +
+// inotify fd per BuildExecutor call. Close() aggregates their errors.
+func WithExtraClosers(closers ...io.Closer) ClawExecutorOption {
+	return func(e *ClawExecutor) {
+		for _, c := range closers {
+			if c != nil {
+				e.extraClosers = append(e.extraClosers, c)
+			}
+		}
+	}
 }
 
 // WithToolPolicy sets the tool execution policy on the executor.
@@ -499,10 +522,14 @@ func (e *ClawExecutor) MCPHealthCheck(ctx context.Context, servers []string) err
 // Close releases resources held by the executor, including MCP server
 // connections. It should be called when the executor is no longer needed.
 func (e *ClawExecutor) Close() error {
+	var errs []error
 	if e.mcpManager != nil {
-		return e.mcpManager.Close()
+		errs = append(errs, e.mcpManager.Close())
 	}
-	return nil
+	for _, c := range e.extraClosers {
+		errs = append(errs, c.Close())
+	}
+	return errors.Join(errs...)
 }
 
 // SetVars merges run-level workflow variables into the executor's

--- a/pkg/backend/model/executor_closer_test.go
+++ b/pkg/backend/model/executor_closer_test.go
@@ -1,0 +1,58 @@
+package model
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+)
+
+// countingCloser records how many times Close was called and returns a fixed
+// error, so a test can assert both that Close ran and that its error surfaced.
+type countingCloser struct {
+	closed int
+	err    error
+}
+
+func (c *countingCloser) Close() error {
+	c.closed++
+	return c.err
+}
+
+// TestClawExecutorCloseReleasesExtraClosers guards the fsnotify-watcher leak
+// fix: WithExtraClosers-registered resources (e.g. the native board store) must
+// be released by ClawExecutor.Close(), nil entries ignored, and their errors
+// aggregated. Without this each per-subbot BuildExecutor call leaks a watcher.
+func TestClawExecutorCloseReleasesExtraClosers(t *testing.T) {
+	a := &countingCloser{}
+	sentinel := errors.New("board store close failed")
+	b := &countingCloser{err: sentinel}
+
+	// Interleave a nil to prove nil entries are dropped, not stored.
+	exec := NewClawExecutor(NewRegistry(), &ir.Workflow{}, WithExtraClosers(a, nil, b))
+
+	if got := len(exec.extraClosers); got != 2 {
+		t.Fatalf("extraClosers = %d, want 2 (nil entry must be ignored)", got)
+	}
+
+	err := exec.Close()
+	if a.closed != 1 {
+		t.Errorf("closer a closed %d times, want 1", a.closed)
+	}
+	if b.closed != 1 {
+		t.Errorf("closer b closed %d times, want 1", b.closed)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("Close() error = %v, want it to wrap the closer's error", err)
+	}
+}
+
+// TestClawExecutorCloseNoClosersNoError confirms the common path (no MCP
+// manager, no extra closers) still returns nil — a regression guard for the
+// errors.Join refactor.
+func TestClawExecutorCloseNoClosersNoError(t *testing.T) {
+	exec := NewClawExecutor(NewRegistry(), &ir.Workflow{})
+	if err := exec.Close(); err != nil {
+		t.Fatalf("Close() with no closers = %v, want nil", err)
+	}
+}

--- a/pkg/cli/resume.go
+++ b/pkg/cli/resume.go
@@ -205,6 +205,25 @@ func RunResumeWithFile(ctx context.Context, iterFile string, opts ResumeOptions,
 		runtime.WithForceResume(opts.Force),
 		runtime.WithBundle(bundleHandle),
 		runtime.WithPreset(r.Preset),
+		// Wire the subbot runner, mirroring the run path (run.go). Without
+		// it, ANY resumed run whose remaining graph contains a subbot node
+		// died with "no SubbotRunner is wired" — runs with subbots were
+		// unresumable as a class. The RunOptions below carries the resume
+		// flags that flow into child executors (permission gate, model/
+		// backend overrides, stub executor for tests).
+		runtime.WithSubbotRunner(subbotRunnerForCLI(iterFile, storeDir, s, logger, RunOptions{
+			StoreDir:        storeDir,
+			LogLevel:        opts.LogLevel,
+			NoInteractive:   opts.Background,
+			Background:      opts.Background,
+			Executor:        opts.Executor,
+			Permission:      opts.Permission,
+			PermissionAllow: opts.PermissionAllow,
+			PermissionAsk:   opts.PermissionAsk,
+			PermissionDeny:  opts.PermissionDeny,
+			ModelFor:        opts.ModelFor,
+			BackendFor:      opts.BackendFor,
+		})),
 	)
 
 	// Acquire exclusive run lock to prevent concurrent processes.

--- a/pkg/cli/resume_subbot_test.go
+++ b/pkg/cli/resume_subbot_test.go
@@ -1,0 +1,105 @@
+package cli_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	cli "github.com/SocialGouv/iterion/pkg/cli"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// TestResume_RunWithSubbot is the regression for the resume path missing the
+// SubbotRunner wiring: `iterion resume` built its engine WITHOUT
+// WithSubbotRunner, so ANY resumed run whose remaining graph contained a
+// subbot node died with "no SubbotRunner is wired" — runs with subbots were
+// unresumable as a class (contradicting the documented "all failure scenarios
+// are resumable" contract).
+//
+// Flow: parent = prep(tool) -> run_child(subbot) -> done. The child fails
+// while a marker file exists (prep has checkpointed, so the parent persists
+// failed_resumable), then the marker is removed and resume must re-run the
+// subbot to completion.
+func TestResume_RunWithSubbot(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "BOOM")
+	outFile := filepath.Join(dir, "child-out.txt")
+	if err := os.WriteFile(marker, nil, 0o644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	child := fmt.Sprintf(`schema out:
+  ok: bool
+tool work:
+  command: `+"`if [ -f %s ]; then echo boom >&2; exit 1; fi; printf done > %s; printf '{\"ok\":true}'`"+`
+  output: out
+workflow child:
+  worktree: none
+  entry: work
+  work -> done
+`, marker, outFile)
+	parent := `schema pout:
+  ready: bool
+schema out:
+  ok: bool
+tool prep:
+  command: ` + "`printf '{\"ready\":true}'`" + `
+  output: pout
+subbot run_child:
+  source: "child.bot"
+  output: out
+workflow parent:
+  worktree: none
+  entry: prep
+  prep -> run_child
+  run_child -> done
+`
+	writeFixture(t, dir, "child.bot", child)
+	parentPath := writeFixture(t, dir, "parent.bot", parent)
+	storeDir := filepath.Join(dir, "store")
+
+	// 1. Initial run: the subbot child fails -> parent failed_resumable
+	//    (prep checkpointed first, so the failure is past the first node).
+	p1, _ := newTestPrinter(cli.OutputHuman)
+	err := cli.RunRun(context.Background(), cli.RunOptions{
+		File:     parentPath,
+		StoreDir: storeDir,
+		RunID:    "subbot-resume-1",
+	}, p1)
+	if err == nil {
+		t.Fatal("initial run should fail (child hits the marker)")
+	}
+	s, _ := store.New(storeDir)
+	r, err := s.LoadRun(context.Background(), "subbot-resume-1")
+	if err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	if r.Status != store.RunStatusFailedResumable {
+		t.Fatalf("status = %s, want failed_resumable", r.Status)
+	}
+
+	// 2. Clear the failure trigger and resume: the subbot must run.
+	if err := os.Remove(marker); err != nil {
+		t.Fatalf("remove marker: %v", err)
+	}
+	p2, _ := newTestPrinter(cli.OutputHuman)
+	if err := cli.RunResumeWithFile(context.Background(), parentPath, cli.ResumeOptions{
+		RunID:    "subbot-resume-1",
+		StoreDir: storeDir,
+	}, p2); err != nil {
+		t.Fatalf("resume failed (SubbotRunner not wired on the resume path?): %v", err)
+	}
+
+	r, err = s.LoadRun(context.Background(), "subbot-resume-1")
+	if err != nil {
+		t.Fatalf("reload run: %v", err)
+	}
+	if r.Status != store.RunStatusFinished {
+		t.Errorf("status after resume = %s, want finished", r.Status)
+	}
+	if _, err := os.Stat(outFile); err != nil {
+		t.Errorf("child tool never ran on resume (output missing): %v", err)
+	}
+}

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -519,6 +519,12 @@ func subbotRunnerForCLI(parentPath, storeDir string, s store.RunStore, logger *i
 			runtime.WithLogger(logger),
 			runtime.WithWorkflowHash(hash),
 			runtime.WithFilePath(childPath),
+			// Wire the child engine with its own recursive runner so a child
+			// .bot that itself declares subbot nodes can run them (sources
+			// resolve relative to the CHILD's dir). Without this, nested
+			// subbots died with "no SubbotRunner is wired" even though the
+			// depth guard below exists precisely to bound that recursion.
+			runtime.WithSubbotRunner(subbotRunnerForCLI(childPath, storeDir, s, logger, opts)),
 			runtime.WithOnNodeFinished(func(_, _ string, out map[string]any) {
 				if out != nil {
 					last = out

--- a/pkg/cli/subbot_nested_test.go
+++ b/pkg/cli/subbot_nested_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// TestSubbotRunnerForCLI_NestedSubbot is the regression for nested subbots on
+// the CLI path: subbotRunnerForCLI built the child engine WITHOUT its own
+// SubbotRunner, so a child .bot that itself declared a subbot node died with
+// "no SubbotRunner is wired" — even though maxSubbotDepth exists precisely to
+// bound that recursion. The runner must be wired recursively, with the
+// grandchild's source resolving relative to the CHILD's directory.
+func TestSubbotRunnerForCLI_NestedSubbot(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "grandchild-ran.txt")
+
+	grandchild := `vars:
+  id: string = "none"
+schema out:
+  ok: bool
+tool deep:
+  command: ` + "`printf x > " + marker + `; printf '{"ok":true}'` + "`" + `
+  output: out
+workflow grandchild:
+  worktree: none
+  entry: deep
+  deep -> done
+`
+	child := `vars:
+  id: string = "none"
+schema out:
+  ok: bool
+subbot go_deeper:
+  source: "grandchild.bot"
+  with { id: "{{vars.id}}" }
+  output: out
+workflow child:
+  worktree: none
+  entry: go_deeper
+  go_deeper -> done
+`
+	for name, src := range map[string]string{"grandchild.bot": grandchild, "child.bot": child} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(src), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	storeDir := filepath.Join(dir, "store")
+	s, err := store.New(storeDir)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	logger := iterlog.New(iterlog.LevelError, os.Stderr)
+
+	runner := subbotRunnerForCLI(filepath.Join(dir, "parent.bot"), storeDir, s, logger, RunOptions{NoInteractive: true})
+	out, err := runner(context.Background(), runtime.SubbotRequest{
+		Source:      "child.bot",
+		Vars:        map[string]any{"id": "n1"},
+		ParentRunID: "parent-run",
+		NodeID:      "run_child",
+	})
+	if err != nil {
+		t.Fatalf("nested subbot run failed: %v", err)
+	}
+	// The child's terminal output IS its subbot node's output, i.e. the
+	// grandchild's terminal output.
+	if ok, _ := out["ok"].(bool); !ok {
+		t.Errorf("child terminal output = %v, want grandchild's {ok:true}", out)
+	}
+	if _, err := os.Stat(marker); err != nil {
+		t.Errorf("grandchild tool never ran (marker missing): %v", err)
+	}
+}
+
+// TestSubbotRunnerForCLI_RecursionDepthGuard proves the recursive wiring keeps
+// the maxSubbotDepth backstop intact: a self-recursive child errors out with
+// the depth-guard message instead of recursing forever.
+func TestSubbotRunnerForCLI_RecursionDepthGuard(t *testing.T) {
+	dir := t.TempDir()
+	selfRef := `schema out:
+  ok: bool
+subbot again:
+  source: "self.bot"
+  output: out
+workflow selfref:
+  worktree: none
+  entry: again
+  again -> done
+`
+	if err := os.WriteFile(filepath.Join(dir, "self.bot"), []byte(selfRef), 0o644); err != nil {
+		t.Fatalf("write self.bot: %v", err)
+	}
+
+	storeDir := filepath.Join(dir, "store")
+	s, err := store.New(storeDir)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	logger := iterlog.New(iterlog.LevelError, os.Stderr)
+
+	runner := subbotRunnerForCLI(filepath.Join(dir, "parent.bot"), storeDir, s, logger, RunOptions{NoInteractive: true})
+	_, err = runner(context.Background(), runtime.SubbotRequest{
+		Source:      "self.bot",
+		ParentRunID: "parent-run",
+		NodeID:      "again",
+	})
+	if err == nil {
+		t.Fatal("self-recursive subbot must fail on the depth guard, got nil error")
+	}
+	if !strings.Contains(err.Error(), "recursion too deep") {
+		t.Fatalf("expected depth-guard error, got: %v", err)
+	}
+}

--- a/pkg/dsl/ast/ast.go
+++ b/pkg/dsl/ast/ast.go
@@ -68,6 +68,7 @@ type UseDecl struct {
 //	  with: { issue: "{{input.id}}" }
 //	  output: ticket_verdict
 //	  needs: worktree_slot
+//	  isolated: true
 //
 // The child executes as a real run (it may contain loops); its terminal
 // output is mapped back to `outputs.<subbot>.<field>`.
@@ -77,7 +78,12 @@ type SubbotDecl struct {
 	With   []*WithEntry // vars passed to the child run (key = var name)
 	Output string       // schema reference describing the child's terminal output
 	Needs  []string     // named resource leases held while the child runs
-	Span   Span
+	// Isolated asserts the child run does NOT mutate the parent's shared
+	// workspace (it confines writes to its own run store / worktree), so the
+	// workspace-safety guard may fan it out in parallel. Mirror of an
+	// agent/judge node's `readonly:`. Default false = conservatively mutating.
+	Isolated bool
+	Span     Span
 }
 
 // EmitDecl is an `emit` node: it publishes a named event with an optional

--- a/pkg/dsl/ir/compile.go
+++ b/pkg/dsl/ir/compile.go
@@ -1259,6 +1259,7 @@ func (c *compiler) compileSubbots() {
 			With:         c.compileWithMappings(sd.Name, sd.With),
 			OutputSchema: sd.Output,
 			Needs:        sd.Needs,
+			Isolated:     sd.Isolated,
 		}
 	}
 }

--- a/pkg/dsl/ir/ir.go
+++ b/pkg/dsl/ir/ir.go
@@ -363,6 +363,10 @@ type SubbotNode struct {
 	With         []*DataMapping // vars passed to the child run (key = child var name)
 	OutputSchema string         // schema reference describing the child's terminal output
 	Needs        []string       // resource names acquired before running the child
+	// Isolated asserts the child does NOT mutate the parent's shared workspace,
+	// letting the workspace-safety guard fan this subbot out in parallel. Mirror
+	// of AgentNode/JudgeNode Readonly. Default false = conservatively mutating.
+	Isolated bool
 }
 
 // NodeKind implements Node.

--- a/pkg/dsl/parser/parser_nodes.go
+++ b/pkg/dsl/parser/parser_nodes.go
@@ -796,6 +796,7 @@ func (p *parser) parseUseDecl() *ast.UseDecl {
 //	  with: { var: "value", ... }
 //	  output: <schema>
 //	  needs: <resource>
+//	  isolated: true
 func (p *parser) parseSubbotDecl() *ast.SubbotDecl {
 	start, name, ok := p.parseDeclHeader("subbot")
 	if !ok {
@@ -823,6 +824,12 @@ func (p *parser) parseSubbotDecl() *ast.SubbotDecl {
 			p.next()
 			p.expect(TokenColon)
 			sd.Source = p.expectString()
+		case t.Type == TokenIdent && t.Value == "isolated":
+			p.next()
+			p.expect(TokenColon)
+			if v := p.parseBool(); v != nil {
+				sd.Isolated = *v
+			}
 		case t.Type == TokenNeeds:
 			p.next()
 			p.expect(TokenColon)

--- a/pkg/dsl/parser/parser_resources_lease_test.go
+++ b/pkg/dsl/parser/parser_resources_lease_test.go
@@ -127,3 +127,61 @@ workflow w:
 		t.Errorf("round-trip pair.Needs = %q, want pool,slot", got)
 	}
 }
+
+// TestParseSubbotIsolated covers the `isolated:` opt-in on a subbot node
+// (workspace-independence assertion that lets the fan-out safety guard admit the
+// subbot in parallel): text → AST (Isolated bool), the default (absent = false),
+// and the round-trip through unparse.
+func TestParseSubbotIsolated(t *testing.T) {
+	src := `schema r:
+  ok: bool
+
+tool start:
+  command: ` + "`printf '{\"ok\":true}'`" + `
+  output: r
+
+subbot iso:
+  source: "./c.bot"
+  isolated: true
+  output: r
+
+subbot plain:
+  source: "./d.bot"
+  output: r
+
+workflow w:
+  entry: start
+  start -> iso
+  iso -> plain
+  plain -> done
+`
+	res := parser.Parse("test.bot", src)
+	for _, d := range res.Diagnostics {
+		t.Fatalf("unexpected diagnostic: %s", d.Error())
+	}
+	if res.File == nil || len(res.File.Subbots) != 2 {
+		t.Fatalf("expected 2 subbots, got file=%v", res.File)
+	}
+	if !res.File.Subbots[0].Isolated {
+		t.Errorf("iso.Isolated = false, want true")
+	}
+	if res.File.Subbots[1].Isolated {
+		t.Errorf("plain.Isolated = true, want false (default)")
+	}
+
+	// Round-trip: unparse must re-emit `isolated:` and re-parsing must preserve it.
+	out := unparse.Unparse(res.File)
+	if !strings.Contains(out, "isolated: true") {
+		t.Errorf("unparse did not emit `isolated: true`:\n%s", out)
+	}
+	res2 := parser.Parse("rt.bot", out)
+	for _, d := range res2.Diagnostics {
+		t.Fatalf("round-trip diagnostic: %s", d.Error())
+	}
+	if !res2.File.Subbots[0].Isolated {
+		t.Errorf("round-trip iso.Isolated = false, want true")
+	}
+	if res2.File.Subbots[1].Isolated {
+		t.Errorf("round-trip plain.Isolated = true, want false")
+	}
+}

--- a/pkg/dsl/unparse/unparse.go
+++ b/pkg/dsl/unparse/unparse.go
@@ -456,6 +456,9 @@ func (w *fileWriter) writeSubbots(subbots []*ast.SubbotDecl) {
 		if len(s.Needs) > 0 {
 			fmt.Fprintf(&w.b, "  needs: [%s]\n", strings.Join(s.Needs, ", "))
 		}
+		if s.Isolated {
+			writeProp(&w.b, "isolated", "true")
+		}
 	}
 }
 

--- a/pkg/runtime/fan_out_internal_test.go
+++ b/pkg/runtime/fan_out_internal_test.go
@@ -16,6 +16,23 @@ func TestIsMutatingNode_ToolNodeAlwaysMutating(t *testing.T) {
 	}
 }
 
+func TestIsMutatingNode_SubbotDefaultMutating(t *testing.T) {
+	// A subbot with no isolation assertion may run a child that touches the
+	// shared workspace, so it is conservatively mutating.
+	if !isMutatingNode(&ir.SubbotNode{BaseNode: ir.BaseNode{ID: "sb"}}) {
+		t.Error("subbot node must be classified mutating by default")
+	}
+}
+
+func TestIsMutatingNode_SubbotIsolatedOptOut(t *testing.T) {
+	// `isolated:` asserts the child confines writes to its own run store /
+	// worktree — the mirror of an agent's Readonly — so it is not mutating.
+	n := &ir.SubbotNode{BaseNode: ir.BaseNode{ID: "sb"}, Isolated: true}
+	if isMutatingNode(n) {
+		t.Error("isolated subbot must not be classified mutating")
+	}
+}
+
 func TestIsMutatingNode_AgentReadonlyOverride(t *testing.T) {
 	// Even if the agent declares tools, Readonly=true wins.
 	n := &ir.AgentNode{

--- a/pkg/runtime/fan_out_subbot_test.go
+++ b/pkg/runtime/fan_out_subbot_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -9,6 +10,144 @@ import (
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
+
+// subbotFanOutWorkflow builds:
+//
+//	entry -> dispatch(fan_out_each over entry.items) -> run_child(subbot) -> collect(wait_all) -> done
+//
+// isolated toggles SubbotNode.Isolated; maxParallel sets the budget cap (0 =
+// uncapped, i.e. len(items)). Shared by the parallel-subbot workspace-safety
+// tests below.
+func subbotFanOutWorkflow(isolated bool, maxParallel int) *ir.Workflow {
+	router := &ir.RouterNode{
+		BaseNode:    ir.BaseNode{ID: "dispatch"},
+		RouterMode:  ir.RouterFanOutEach,
+		Over:        "{{outputs.entry.items}}",
+		OverRefs:    []*ir.Ref{{Kind: ir.RefOutputs, Path: []string{"entry", "items"}, Raw: "{{outputs.entry.items}}"}},
+		ItemBinding: "item",
+	}
+	wf := &ir.Workflow{
+		Name:  "fan_out_each_subbot_parallel",
+		Entry: "entry",
+		Nodes: map[string]ir.Node{
+			"entry":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "entry"}},
+			"dispatch": router,
+			"run_child": &ir.SubbotNode{
+				BaseNode: ir.BaseNode{ID: "run_child"},
+				Source:   "child.bot",
+				Isolated: isolated,
+				With: []*ir.DataMapping{
+					{Key: "ticket", Refs: []*ir.Ref{{Kind: ir.RefOutputs, Path: []string{"dispatch", "item", "id"}, Raw: "{{outputs.dispatch.item.id}}"}}, Raw: "{{outputs.dispatch.item.id}}"},
+				},
+			},
+			"collect": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "collect"}, AwaitMode: ir.AwaitWaitAll},
+			"done":    &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+			"fail":    &ir.FailNode{BaseNode: ir.BaseNode{ID: "fail"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "entry", To: "dispatch"},
+			{From: "dispatch", To: "run_child"},
+			{From: "run_child", To: "collect"},
+			{From: "collect", To: "done"},
+		},
+		Schemas: map[string]*ir.Schema{},
+		Prompts: map[string]*ir.Prompt{},
+		Vars:    map[string]*ir.Var{},
+		Loops:   map[string]*ir.Loop{},
+	}
+	if maxParallel > 0 {
+		wf.Budget = &ir.Budget{MaxParallelBranches: maxParallel}
+	}
+	return wf
+}
+
+// TestFanOutEach_SubbotParallel_AllowedWhenIsolated proves an `isolated:` subbot
+// template is admitted by the workspace-safety guard at max_parallel_branches>1
+// AND actually runs its children concurrently. Concurrency is measured with the
+// same deterministic barrier the semaphore tests use (no sleep): the runner
+// blocks each child until all N are inside, so a serialized implementation would
+// deadlock rather than pass — the peak is exact.
+func TestFanOutEach_SubbotParallel_AllowedWhenIsolated(t *testing.T) {
+	const n = 3
+	wf := subbotFanOutWorkflow(true, n)
+
+	var active, peak int32
+	barrier := make(chan struct{})
+	var once sync.Once
+	var calls int64
+	runner := func(_ context.Context, req SubbotRequest) (map[string]any, error) {
+		atomic.AddInt64(&calls, 1)
+		cur := atomic.AddInt32(&active, 1)
+		for { // lock-free max
+			p := atomic.LoadInt32(&peak)
+			if cur <= p || atomic.CompareAndSwapInt32(&peak, p, cur) {
+				break
+			}
+		}
+		if cur >= int32(n) {
+			once.Do(func() { close(barrier) })
+		}
+		<-barrier // block until all N children are concurrently inside
+		atomic.AddInt32(&active, -1)
+		return map[string]any{"committed": true}, nil
+	}
+
+	exec := newStubExecutor()
+	exec.on("entry", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"items": []any{item("A"), item("B"), item("C")}}, nil
+	})
+	exec.on("collect", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"done": true}, nil
+	})
+
+	s := tmpStore(t)
+	eng := New(wf, s, exec, WithSubbotRunner(runner))
+	if err := eng.Run(context.Background(), "run-fe-subbot-parallel", nil); err != nil {
+		t.Fatalf("isolated subbot fan_out_each at max_parallel=%d should be allowed, got %v", n, err)
+	}
+	r, _ := s.LoadRun(context.Background(), "run-fe-subbot-parallel")
+	if r.Status != store.RunStatusFinished {
+		t.Fatalf("expected finished, got %s", r.Status)
+	}
+	if got := atomic.LoadInt64(&calls); got != n {
+		t.Fatalf("subbot runner invoked %d times, want %d (one per element)", got, n)
+	}
+	if got := atomic.LoadInt32(&peak); got != int32(n) {
+		t.Fatalf("peak subbot concurrency = %d, want %d (isolated template did not run in parallel)", got, n)
+	}
+}
+
+// TestFanOutEach_SubbotParallel_RejectedWhenNotIsolated is the safe-default
+// non-regression: without `isolated:`, a subbot template fanned out with
+// max_parallel_branches>1 is still rejected by WORKSPACE_SAFETY before any child
+// runs.
+func TestFanOutEach_SubbotParallel_RejectedWhenNotIsolated(t *testing.T) {
+	wf := subbotFanOutWorkflow(false, 3)
+
+	var calls int64
+	runner := func(_ context.Context, _ SubbotRequest) (map[string]any, error) {
+		atomic.AddInt64(&calls, 1)
+		return map[string]any{"committed": true}, nil
+	}
+	exec := newStubExecutor()
+	exec.on("entry", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"items": []any{item("A"), item("B"), item("C")}}, nil
+	})
+
+	s := tmpStore(t)
+	eng := New(wf, s, exec, WithSubbotRunner(runner))
+	err := eng.Run(context.Background(), "run-fe-subbot-reject", nil)
+	if err == nil {
+		t.Fatal("expected workspace safety error for non-isolated parallel subbot")
+	}
+	var rtErr *RuntimeError
+	if !errors.As(err, &rtErr) || rtErr.Code != ErrCodeWorkspaceSafety {
+		t.Fatalf("expected RuntimeError ErrCodeWorkspaceSafety, got %T: %v", err, err)
+	}
+	if got := atomic.LoadInt64(&calls); got != 0 {
+		t.Fatalf("subbot runner invoked %d time(s), want 0 after safety rejection", got)
+	}
+}
 
 // TestFanOutEach_SubbotPerElement is the regression for #61: a `subbot` node
 // inside a `fan_out_each` branch used to fail with `unsupported node kind

--- a/pkg/runtime/workspace_safety.go
+++ b/pkg/runtime/workspace_safety.go
@@ -32,7 +32,9 @@ var readOnlyTools = map[string]bool{
 // Subbot nodes run a child .bot that may do anything (including mutate the
 // shared worktree), so they are conservatively treated as mutating — this
 // keeps validateWorkspaceSafety from admitting two subbot branches that would
-// race the same workspace. Nodes with Readonly=true are never considered
+// race the same workspace. A subbot may opt out with `isolated:` (it asserts
+// the child confines writes to its own run store / worktree), just as an
+// agent/judge node opts out with Readonly=true; neither is then considered
 // mutating.
 func isMutatingNode(node ir.Node) bool {
 	return isMutatingNodeWithBackend(node, "", nil)
@@ -50,7 +52,12 @@ func isMutatingNodeWithBackend(node ir.Node, defaultBackend string, resolver eff
 	case *ir.ToolNode:
 		return true
 	case *ir.SubbotNode:
-		return true
+		// A subbot marked `isolated:` asserts the child confines its writes to
+		// its own run store / worktree and never touches the parent's shared
+		// workspace, so it is safe to fan out in parallel (mirror of an
+		// agent/judge node's `readonly:`). Absent the flag, the child may do
+		// anything — conservatively mutating.
+		return !n.Isolated
 	case *ir.AgentNode:
 		if n.Readonly {
 			return false

--- a/pkg/runview/executor.go
+++ b/pkg/runview/executor.go
@@ -352,6 +352,11 @@ func BuildExecutor(spec ExecutorSpec) (*model.ClawExecutor, error) {
 		if err != nil {
 			spec.Logger.Warn("runview: open native board store at %s: %v — board MCP tools disabled", dispatcherStoreDir, err)
 		} else {
+			// The store owns an fsnotify watcher goroutine + inotify fd; hand
+			// it to the executor so Close() releases it. Otherwise every
+			// BuildExecutor call leaks one — acute under parallel subbot
+			// fan-out (one executor per child).
+			opts = append(opts, model.WithExtraClosers(ns))
 			boardCfg := &tool.BoardConfig{
 				Store: ns,
 				Capabilities: []string{


### PR DESCRIPTION
## Summary

Lifts the `WORKSPACE_SAFETY` restriction that made parallel subbot fan-out impossible, via an opt-in **`isolated:`** flag on the `subbot` node — plus two pre-existing SubbotRunner wiring bugs found (and fixed) while validating, and an fsnotify-watcher leak fix.

### 1. `feat(dsl)`: `isolated:` — parallel fan-out of subbots (53ec8aa6)

A `subbot` runs a whole child `.bot`, so the workspace-safety guard conservatively classified it as **unconditionally mutating**: the only legal subbot fan-out was serialized (`max_parallel_branches: 1`). For children that never touch the parent's shared workspace (e.g. one episode-render run per branch, each writing only to its own run store), that rejection is a false positive.

```
subbot run_episode:
  source: "episode.bot"
  with { id: "{{outputs.dispatch.ep.id}}" }
  isolated: true        # author asserts: child confines writes to its own run/worktree
```

`isolated:` is the exact mirror of `readonly:` on agent/judge nodes: `isMutatingNodeWithBackend` returns `!Isolated`, so both fan-out guards (`fan_out_each` **and** static `fan_out_all`) admit the parallel replays. Default `false` preserves today's safe serialized-only behaviour. Threaded through the full DSL stack (ast → parser → ir → compile → unparse, round-trips).

**Was the ban ever motivated by a real incident?** No — git archaeology shows it was a conservative static-analysis default added the evening the subbot feature shipped (89ace7f7, *"a child run **may** mutate"*), while the docs' headline **parallel** worktree-slot pattern had been published 7.5h earlier (b587f129) and was rejected at runtime ever since. No subbot race was ever observed (none could be — parallel subbots never executed). This PR reconciles code with the documented pattern.

**Concurrency safety** (audited: store, executor build, budget, cancellation, git worktrees): N child runs with distinct run_ids sharing the parent RunStore are data-race free; each child gets its own engine and (with `worktree: auto`) its own worktree. Two accounting boundaries are documented rather than code-enforced: parent budget does **not** bound children, and same-target board writes are last-writer-wins.

### 2. `fix(cli)`: nested subbots never worked (2af1bf38)

`subbotRunnerForCLI` built the child engine **without its own SubbotRunner**, so a child `.bot` declaring a subbot died with `no SubbotRunner is wired` — even though `maxSubbotDepth = 8` exists precisely to bound that recursion. Now wired recursively (grandchild sources resolve relative to the child's dir; ctx-carried depth keeps the guard effective).

### 3. `fix(cli)`: subbot runs were unresumable (bf22ead0)

`iterion resume` built its engine without `WithSubbotRunner`, so **any** resumed run whose remaining graph contained a subbot failed — runs with subbots were unresumable as a class, contradicting the "all failure scenarios are resumable" contract. Now mirrors the run path's wiring.

### 4. `fix(runview)`: fsnotify-watcher leak on every executor build (15a005da)

`BuildExecutor` opened `native.NewStore` (board MCP tools) on every call but never closed it — leaking a watcher goroutine + inotify fd per build, acute under parallel subbot fan-out (one executor per child, marching toward `fs.inotify.max_user_instances`). `ClawExecutor.Close()` now releases it via a new `WithExtraClosers` option.

## Validation

- **Unit/regression tests** (all green, `-race` included): guard classification both ways; real-concurrency `fan_out_each` test (deterministic barrier, peak=3); safe-default rejection; parser/unparse round-trip; nested + depth-guard tests; resume-with-subbot test; extra-closers test.
- **Real `.bot` battery** (10 scenarios against the built binary, all pass): timing-proof parallelism (2.1s vs 6s serialized, measured peak=3), failure→cancel-siblings→resume, `needs:` lease pool distribution, nested subbots, static `fan_out_all` ±isolated, DAG `depends_on` ordering, **3 parallel `worktree: auto` children on a real git repo** (exact branches, `git fsck` clean, no leftover worktrees), 12-item stress.
- Runnable tool-only example: `examples/composition/parallel_subbots.bot`.
- Docs: `docs/groups-iteration-subbots.md` — new "Fanning subbots out in parallel" section + headline pattern reconciled + budget/board caveats.
- Full `go test ./...` green except the two pre-existing `pkg/backend/tool` headless-screenshot tests, which fail on any machine with a DISPLAY and are untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)