### PR TITLE
fix(runner): close the clone SSRF TOCTOU with a pinned-dial clone-guard proxy

### DIFF
--- a/pkg/runner/gitproxy.go
+++ b/pkg/runner/gitproxy.go
@@ -1,0 +1,93 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/sandbox/netproxy"
+	"github.com/SocialGouv/iterion/pkg/secure/httpdial"
+)
+
+// cloneAllowPrivate reports whether the on-prem escape hatch for internal
+// forges is set. Shared by validateRepoTarget's pre-check and the clone-guard
+// proxy's connect-time dial so the two layers can never disagree.
+func cloneAllowPrivate() bool {
+	return os.Getenv("ITERION_RUNNER_CLONE_ALLOW_PRIVATE") == "1"
+}
+
+// startCloneGuardProxy starts a loopback CONNECT proxy that gives the runner's
+// git subprocesses connect-time SSRF enforcement — the layer validateRepoTarget's
+// pre-check structurally cannot provide, because git re-resolves the hostname in
+// its own subprocess. The proxy re-resolves the CONNECT target itself through
+// the shared SSRF guard and dials ONLY the validated IP (public-unicast in
+// strict mode), so a DNS-rebinding answer between the pre-check and git's
+// connect hits the same guard again at the moment that matters. Unlike the
+// /etc/hosts pin, this works on non-root pods (kubelet-owned hosts file) and
+// needs no cluster egress NetworkPolicy.
+//
+// The policy additionally allowlists the single repo host, so a redirect or
+// alternate-URL fetch to any other host is refused outright (defence in depth
+// on top of http.followRedirects=false).
+//
+// strict mirrors validateRepoTarget: on-prem deployments cloning internal
+// forges (ITERION_RUNNER_CLONE_ALLOW_PRIVATE=1) keep working — the dial then
+// pins the first resolved address without the public-unicast requirement.
+//
+// Covers http(s) transports only (git ignores HTTPS_PROXY for ssh remotes);
+// ssh clones keep the pre-check + pod egress policy as their guard.
+func startCloneGuardProxy(repoHost string, strict bool) (endpoint string, shutdown func(), err error) {
+	policy, err := netproxy.Compile(netproxy.ModeAllowlist, []string{repoHost})
+	if err != nil {
+		return "", nil, fmt.Errorf("clone-guard proxy: compile policy for %q: %w", repoHost, err)
+	}
+	token, err := netproxy.NewToken()
+	if err != nil {
+		return "", nil, fmt.Errorf("clone-guard proxy: mint token: %w", err)
+	}
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	proxy, err := netproxy.New(netproxy.Options{
+		Policy: policy,
+		Token:  token,
+		Dial: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, splitErr := net.SplitHostPort(addr)
+			if splitErr != nil {
+				return nil, splitErr
+			}
+			ip, resolveErr := httpdial.ResolvePublicHost(ctx, host, strict)
+			if resolveErr != nil {
+				return nil, resolveErr
+			}
+			return dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+		},
+	})
+	if err != nil {
+		return "", nil, fmt.Errorf("clone-guard proxy: %w", err)
+	}
+	if err := proxy.Start("127.0.0.1:0"); err != nil {
+		return "", nil, fmt.Errorf("clone-guard proxy: %w", err)
+	}
+	shutdown = func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = proxy.Shutdown(ctx)
+	}
+	return proxy.Endpoint("127.0.0.1"), shutdown, nil
+}
+
+// cloneGuardEnv renders the environment that routes a git subprocess through
+// the clone-guard proxy. Both spellings are set because git consults the
+// lowercase forms first and libcurl accepts either; NO_PROXY is cleared so an
+// inherited exclusion cannot bypass the guard for the repo host.
+func cloneGuardEnv(endpoint string) []string {
+	return []string{
+		"HTTPS_PROXY=" + endpoint,
+		"https_proxy=" + endpoint,
+		"HTTP_PROXY=" + endpoint,
+		"http_proxy=" + endpoint,
+		"NO_PROXY=",
+		"no_proxy=",
+	}
+}

--- a/pkg/runner/gitproxy_test.go
+++ b/pkg/runner/gitproxy_test.go
@@ -1,0 +1,180 @@
+package runner
+
+import (
+	"bufio"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// startEchoListener starts a loopback TCP listener standing in for an
+// internal service an SSRF probe would target. It echoes one line back on
+// the first accepted connection.
+func startEchoListener(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("echo listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		line, err := bufio.NewReader(conn).ReadString('\n')
+		if err != nil {
+			return
+		}
+		_, _ = conn.Write([]byte(line))
+	}()
+	return ln.Addr().String()
+}
+
+// dialProxy opens a raw client connection to the clone-guard proxy endpoint
+// and returns it with the parsed auth token.
+func dialProxy(t *testing.T, endpoint string) (net.Conn, string) {
+	t.Helper()
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		t.Fatalf("parse endpoint %q: %v", endpoint, err)
+	}
+	token, _ := u.User.Password()
+	conn, err := net.Dial("tcp", u.Host)
+	if err != nil {
+		t.Fatalf("dial proxy %s: %v", u.Host, err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn, token
+}
+
+// connectStatus issues a CONNECT for target through the proxy connection and
+// returns the HTTP status line. withAuth controls the Proxy-Authorization
+// header (Basic, as git/libcurl derives it from the proxy-URL userinfo).
+func connectStatus(t *testing.T, conn net.Conn, target, token string, withAuth bool) (string, *bufio.Reader) {
+	t.Helper()
+	req := fmt.Sprintf("CONNECT %s HTTP/1.1\r\nHost: %s\r\n", target, target)
+	if withAuth {
+		cred := base64.StdEncoding.EncodeToString([]byte("t:" + token))
+		req += "Proxy-Authorization: Basic " + cred + "\r\n"
+	}
+	req += "\r\n"
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatalf("write CONNECT: %v", err)
+	}
+	r := bufio.NewReader(conn)
+	status, err := r.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read CONNECT status: %v", err)
+	}
+	return strings.TrimSpace(status), r
+}
+
+// The rebinding scenario: the CONNECT host passes the hostname policy (it IS
+// the repo host) but resolves to a non-public address. Strict mode must refuse
+// at dial time — this is the connect-time layer the /etc/hosts pin cannot
+// provide on non-root pods.
+func TestCloneGuardProxyStrictRefusesNonPublicDial(t *testing.T) {
+	echoAddr := startEchoListener(t)
+	endpoint, shutdown, err := startCloneGuardProxy("127.0.0.1", true)
+	if err != nil {
+		t.Fatalf("startCloneGuardProxy: %v", err)
+	}
+	defer shutdown()
+
+	conn, token := dialProxy(t, endpoint)
+	status, _ := connectStatus(t, conn, echoAddr, token, true)
+	if !strings.Contains(status, "502") {
+		t.Fatalf("CONNECT %s status = %q; want 502 (dial refused: non-public IP)", echoAddr, status)
+	}
+}
+
+// Off-host CONNECTs are refused by the single-host allowlist regardless of
+// where they resolve — the redirect / alternate-URL vector.
+func TestCloneGuardProxyRefusesOffHostConnect(t *testing.T) {
+	endpoint, shutdown, err := startCloneGuardProxy("repo.example.com", true)
+	if err != nil {
+		t.Fatalf("startCloneGuardProxy: %v", err)
+	}
+	defer shutdown()
+
+	conn, token := dialProxy(t, endpoint)
+	status, _ := connectStatus(t, conn, "attacker.example.org:443", token, true)
+	if !strings.Contains(status, "403") {
+		t.Fatalf("off-host CONNECT status = %q; want 403 (policy)", status)
+	}
+}
+
+// With the on-prem escape hatch (allowPrivate → strict=false) an internal
+// forge stays reachable and bytes tunnel through.
+func TestCloneGuardProxyAllowPrivateTunnels(t *testing.T) {
+	echoAddr := startEchoListener(t)
+	endpoint, shutdown, err := startCloneGuardProxy("127.0.0.1", false)
+	if err != nil {
+		t.Fatalf("startCloneGuardProxy: %v", err)
+	}
+	defer shutdown()
+
+	conn, token := dialProxy(t, endpoint)
+	status, r := connectStatus(t, conn, echoAddr, token, true)
+	if !strings.Contains(status, "200") {
+		t.Fatalf("CONNECT %s status = %q; want 200", echoAddr, status)
+	}
+	// Drain the response headers (a lone CRLF after the status line).
+	if line, err := r.ReadString('\n'); err != nil || strings.TrimSpace(line) != "" {
+		t.Fatalf("expected empty line after 200, got %q err=%v", line, err)
+	}
+	if _, err := conn.Write([]byte("ping\n")); err != nil {
+		t.Fatalf("write through tunnel: %v", err)
+	}
+	echoed, err := r.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	if strings.TrimSpace(echoed) != "ping" {
+		t.Fatalf("tunnel echo = %q; want ping", echoed)
+	}
+}
+
+// The per-clone token gates the proxy: a client without it gets 407, so
+// another process on the pod cannot ride the guard's allowlist.
+func TestCloneGuardProxyRequiresAuth(t *testing.T) {
+	endpoint, shutdown, err := startCloneGuardProxy("repo.example.com", true)
+	if err != nil {
+		t.Fatalf("startCloneGuardProxy: %v", err)
+	}
+	defer shutdown()
+
+	conn, _ := dialProxy(t, endpoint)
+	status, _ := connectStatus(t, conn, "repo.example.com:443", "", false)
+	if !strings.Contains(status, "407") {
+		t.Fatalf("unauthenticated CONNECT status = %q; want 407", status)
+	}
+}
+
+func TestCloneGuardEnv(t *testing.T) {
+	env := cloneGuardEnv("http://t:tok@127.0.0.1:9")
+	want := map[string]bool{
+		"HTTPS_PROXY=http://t:tok@127.0.0.1:9": false,
+		"https_proxy=http://t:tok@127.0.0.1:9": false,
+		"HTTP_PROXY=http://t:tok@127.0.0.1:9":  false,
+		"http_proxy=http://t:tok@127.0.0.1:9":  false,
+		"NO_PROXY=":                            false,
+		"no_proxy=":                            false,
+	}
+	for _, e := range env {
+		if _, ok := want[e]; !ok {
+			t.Fatalf("unexpected env entry %q", e)
+		}
+		want[e] = true
+	}
+	for k, seen := range want {
+		if !seen {
+			t.Fatalf("missing env entry %q", k)
+		}
+	}
+}

--- a/pkg/runner/hostpin.go
+++ b/pkg/runner/hostpin.go
@@ -21,9 +21,10 @@ const ssrfPinMarker = "# iterion-runner ssrf-pin"
 //
 // It returns a restore func that removes ONLY the lines this call added (it
 // re-reads and filters, so a concurrent unrelated edit is preserved). The
-// caller treats any error as "could not pin" and proceeds — the pod egress
-// NetworkPolicy is the authoritative control. Pure on hostsPath, so it is
-// unit-testable with a temp file.
+// caller treats any error as "could not pin" and proceeds — the clone-guard
+// CONNECT proxy (startCloneGuardProxy) is the connect-time control for https
+// clones; the pin is belt-and-braces and the only rebinding cover for ssh
+// remotes. Pure on hostsPath, so it is unit-testable with a temp file.
 func pinHostInHostsFile(hostsPath, host string, ip net.IP) (func(), error) {
 	if host == "" || ip == nil {
 		return nil, fmt.Errorf("ssrf-pin: empty host or ip")

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -1385,31 +1385,45 @@ func (r *Runner) prepareRepoWorkspace(ctx context.Context, msg *queue.RunMessage
 	}
 	// SSRF connect-time hardening for the two TOCTOU vectors validateRepoTarget
 	// alone can't close (it resolves but git re-resolves at connect time):
-	//   (a) DNS rebinding — pin the validated public IP for the host in
-	//       /etc/hosts so git resolves to the SAME address we just checked.
-	//       Best-effort: needs a writable /etc/hosts. On a non-root runner it
-	//       is kubelet-owned and unwritable — expected, so we log once at info
-	//       and proceed (unexpected failures still warn per-clone).
+	//   (a) DNS rebinding — the clone-guard CONNECT proxy below is the
+	//       enforcing layer: git dials through a loopback proxy that
+	//       re-resolves the CONNECT host through the same SSRF guard and dials
+	//       ONLY the validated IP, so it holds on non-root pods too. The
+	//       /etc/hosts pin stays as belt-and-braces (it also covers ssh
+	//       remotes) but is best-effort: on a non-root runner the file is
+	//       kubelet-owned and unwritable — expected, logged once at info.
 	//   (b) HTTP 302 → internal — disabled per git invocation below
-	//       (http.followRedirects=false); the clone URL is already canonical https.
-	// The pod-level egress NetworkPolicy (block RFC1918/metadata) remains the
-	// authoritative control — VALIDATE THIS PATH IN CLOUD E2E (runner /etc/hosts
-	// writability + clone still succeeds). See loop.go validateRepoTarget note.
-	if host, herr := extractRepoHost(msg.RepoURL); herr == nil && pinnedIP != nil {
+	//       (http.followRedirects=false), and the proxy's single-host
+	//       allowlist refuses any off-host CONNECT regardless.
+	// The pod-level egress NetworkPolicy (block RFC1918/metadata) stays as
+	// infra defence-in-depth on top.
+	host, hostErr := extractRepoHost(msg.RepoURL)
+	if hostErr == nil && pinnedIP != nil {
 		if restore, perr := pinHostInHostsFile(runnerHostsFile, host, pinnedIP); perr == nil {
 			defer restore()
 		} else if pinUnavailable(perr) {
 			// Expected & permanent on a non-root runner: /etc/hosts is a
 			// kubelet-managed bind-mount owned by root, so the pin can never
-			// land here. Log ONCE at info — the pre-check + pod egress
-			// NetworkPolicy is the authoritative control.
+			// land here. Log ONCE at info — the clone-guard proxy is the
+			// connect-time control.
 			r.ssrfPinUnavailableOnce.Do(func() {
-				r.cfg.Logger.Info("runner: SSRF IP-pin unavailable on this runner: %s not writable (non-root); pre-check + pod egress policy is the control (%v)", runnerHostsFile, perr)
+				r.cfg.Logger.Info("runner: SSRF IP-pin unavailable on this runner: %s not writable (non-root); the clone-guard proxy is the connect-time control (%v)", runnerHostsFile, perr)
 			})
 		} else {
 			// Unexpected: writable file but the write still failed. Keep warning per-clone.
-			r.cfg.Logger.Warn("runner: SSRF IP-pin skipped for %s→%s (%v); relying on pre-check + pod egress policy", host, pinnedIP, perr)
+			r.cfg.Logger.Warn("runner: SSRF IP-pin skipped for %s→%s (%v); the clone-guard proxy is the connect-time control", host, pinnedIP, perr)
 		}
+	}
+	// git honours HTTPS_PROXY for http(s) transports only; ssh remotes keep
+	// the pre-check + hosts pin + pod egress policy as their guard.
+	var gitEnv []string
+	if hostErr == nil && strings.HasPrefix(strings.ToLower(strings.TrimSpace(msg.RepoURL)), "https://") {
+		endpoint, stopProxy, perr := startCloneGuardProxy(host, !cloneAllowPrivate())
+		if perr != nil {
+			return "", fmt.Errorf("runner: %w", perr)
+		}
+		defer stopProxy()
+		gitEnv = cloneGuardEnv(endpoint)
 	}
 	dir := filepath.Join(r.cfg.WorkDir, "repos", msg.RunID)
 	if err := os.RemoveAll(dir); err != nil {
@@ -1431,11 +1445,11 @@ func (r *Runner) prepareRepoWorkspace(ctx context.Context, msg *queue.RunMessage
 	// -c http.followRedirects=false closes SSRF vector (b): a 302 from the
 	// validated canonical https host to an internal address must not be
 	// auto-followed by git.
-	if err := r.runGit(ctx, "", tok, "-c", "http.followRedirects=false", "clone", "--no-tags", "--quiet", cloneURL, dir); err != nil {
+	if err := r.runGitEnv(ctx, "", tok, gitEnv, "-c", "http.followRedirects=false", "clone", "--no-tags", "--quiet", cloneURL, dir); err != nil {
 		return "", err
 	}
 	if ref := strings.TrimSpace(msg.RepoSHA); ref != "" {
-		if err := r.runGit(ctx, dir, tok, "-c", "http.followRedirects=false", "fetch", "--no-tags", "--quiet", "origin", ref); err != nil {
+		if err := r.runGitEnv(ctx, dir, tok, gitEnv, "-c", "http.followRedirects=false", "fetch", "--no-tags", "--quiet", "origin", ref); err != nil {
 			return "", err
 		}
 		if err := r.runGit(ctx, dir, tok, "checkout", "--quiet", "-B", ref, "FETCH_HEAD"); err != nil {
@@ -1539,17 +1553,15 @@ func validateRepoTarget(ctx context.Context, repoURL, repoSHA string) (net.IP, e
 	if err != nil {
 		return nil, fmt.Errorf("runner: reject repo url: %w", err)
 	}
-	allowPrivate := os.Getenv("ITERION_RUNNER_CLONE_ALLOW_PRIVATE") == "1"
-	// DEFENCE-IN-DEPTH, NOT COMPLETE: this resolves the host to confirm it is a
-	// public address, but the resolved IP is intentionally not bound to the
-	// subsequent `git clone/fetch` (runGit), which re-resolves the hostname at
-	// connect time. A DNS-rebinding answer (public IP here, internal IP for git)
-	// or a 302 redirect to an internal address therefore still slips past this
-	// check — a real TOCTOU. The complete fix is connect-time enforcement
-	// (route runner git through the netproxy / a pod egress policy) or IP
-	// pinning; tracked on the board (SSRF DNS-rebinding TOCTOU in
-	// validateRepoTarget, source:sec-audit-self). Keep this pre-check as the
-	// first line, but do not treat it as full SSRF protection.
+	allowPrivate := cloneAllowPrivate()
+	// First line of defence: refuse non-public hosts before any subprocess
+	// spawns, and feed the resolved IP to the /etc/hosts pin. On its own this
+	// would be TOCTOU-incomplete (git re-resolves the hostname at connect
+	// time); the enforcing layer is the clone-guard CONNECT proxy
+	// (startCloneGuardProxy) prepareRepoWorkspace routes https git through,
+	// which re-validates and pins the resolved IP at the moment of the dial.
+	// ssh remotes are not proxied — for them this pre-check, the hosts pin and
+	// the pod egress policy remain the guard.
 	ip, err := httpdial.ResolvePublicHost(ctx, host, !allowPrivate)
 	if err != nil {
 		return nil, fmt.Errorf("runner: repo host %q is not a public address (set ITERION_RUNNER_CLONE_ALLOW_PRIVATE=1 to allow internal forges): %w", host, err)
@@ -1614,6 +1626,13 @@ func defaultGitOpTimeout() time.Duration {
 // authed clone URL never leaks into logs. Each invocation is bounded by
 // gitOpTimeout on top of the caller's ctx.
 func (r *Runner) runGit(ctx context.Context, dir, tok string, args ...string) error {
+	return r.runGitEnv(ctx, dir, tok, nil, args...)
+}
+
+// runGitEnv is runGit with extra environment entries appended after the
+// baseline (later entries win) — network git ops use it to route through the
+// clone-guard proxy via HTTPS_PROXY.
+func (r *Runner) runGitEnv(ctx context.Context, dir, tok string, extraEnv []string, args ...string) error {
 	if gitOpTimeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, gitOpTimeout)
@@ -1632,6 +1651,7 @@ func (r *Runner) runGit(ctx context.Context, dir, tok string, args ...string) er
 	// Never prompt for credentials (fail fast instead of hanging), and ignore
 	// any host-level git config in the runner image.
 	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_CONFIG_NOSYSTEM=1")
+	cmd.Env = append(cmd.Env, extraEnv...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		detail, shown := strings.TrimSpace(string(out)), strings.Join(args, " ")


### PR DESCRIPTION
## Problem

`validateRepoTarget` resolves the webhook-sourced repo host through the SSRF guard but discards the binding: `git clone/fetch` re-resolves the hostname in its own subprocess. A DNS-rebinding answer (public IP for the pre-check, `127.0.0.1`/ClusterIP/metadata for git) — or a 302 — turns the runner pod into a blind SSRF probe. Board finding `native:b83df797` (source:sec-audit-self, severity:high).

The existing mitigations don't close it on the real prod topology:
- the `/etc/hosts` pin needs a writable hosts file — kubelet-owned + uid 10001 ⇒ structurally inert on non-root pods;
- the chart's egress NetworkPolicy is `enabled: false` by default (and allowlist-based when on);
- `http.followRedirects=false` only covers the redirect vector.

## Fix — connect-time enforcement, no root, no cluster policy needed

`startCloneGuardProxy` (new `pkg/runner/gitproxy.go`) starts an ephemeral loopback CONNECT proxy per clone, reusing `pkg/sandbox/netproxy` with an injected dialer:
- policy = single-host allowlist (the repo host) → any off-host CONNECT (redirect/alternate-URL) is 403;
- the dialer re-resolves the CONNECT target through `httpdial.ResolvePublicHost` and dials **only** the validated IP → a rebinding answer is refused at the moment of the dial (502);
- per-clone bearer token (Basic via proxy-URL userinfo, as git/libcurl sends it) gates the listener;
- `ITERION_RUNNER_CLONE_ALLOW_PRIVATE=1` keeps on-prem internal forges working (strict=false; the dial still pins the resolved IP);
- wired into `prepareRepoWorkspace` via `HTTPS_PROXY`/… env on the clone+fetch invocations only (`runGitEnv`). ssh remotes are not proxied — pre-check + hosts pin + egress policy remain their guard.

The hosts pin and `followRedirects=false` stay as belt-and-braces; comments updated so the pre-check is no longer described as the enforcing layer.

## Tests

`pkg/runner/gitproxy_test.go` (hermetic, no DNS):
- strict CONNECT to a host resolving non-public → **502** (the rebind scenario);
- off-host CONNECT → **403**; missing token → **407**;
- allow-private CONNECT tunnels bytes end-to-end (echo);
- `cloneGuardEnv` contents.

`go build ./...` + full `pkg/runner` suite green; gofmt/vet clean.

Follow-up (tracked on the board ticket before closing): cloud e2e pass to confirm a real forge clone through the proxy on the prod runner image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)