### PR TITLE
docs: align stale engine docs with shipped reality (kimi, C082 HTTP path, MaxAckPending, ADR hygiene)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ Other top-level directories: `studio/` (React/Vite frontend), `examples/` (.bot 
 ```
 .bot source → Lexer (indent-sensitive tokens) → Parser (recursive-descent) → AST
   → ir.Compile() → IR Workflow (nodes + edges + schemas + prompts + budget)
-  → Diagnostics from ir.Compile() / ir.Validate() (sparse codes C001–C086: compile errors, reachability, routing, cycles, attachments, presets, capability checks (C080–C082), cursor declarations (C083–C086), etc.)
+  → Diagnostics from ir.Compile() / ir.Validate() (sparse codes C001–C199: compile errors, reachability, routing, cycles, attachments, presets, capability checks (C080–C082), cursor declarations (C083–C086), etc.)
   → runtime.Engine.Run() → execution with events, budget, and persistence
 ```
 
@@ -196,10 +196,11 @@ src -> dst with {field: "{{ref}}"}      # data mapping
 
 ### Backend selection
 
-Three backends are wired:
+Four backends are wired:
 - `claw` (default, in-process) — recommended for read-only LLM nodes (judges, reviewers, planners). Use any provider model claw supports, e.g. `model: "openai/gpt-5.4-mini"` or `model: "anthropic/claude-sonnet-4-6"`.
 - `claude_code` — recommended for nodes that need real tool/shell access (implementers, fixers).
 - `codex` — **deprecated / frozen — do NOT do new implementation work on the codex delegate** (`pkg/backend/delegate/codex.go`). Kept only for backward compatibility and live-test coverage (`task test:live`); do not extend it (e.g. new error handling, network-resilience retyping, tool wiring) — apply such work to `claude_code`/`claw` only. The IR compiler emits `C030` for any node using it. Background: codex SDK cannot configure its tool set (`AllowedTools`/`CanUseTool` don't gate the built-in shell), it tends to fill its own context window, and its iterion integration is less ergonomic. New workflows must not adopt it.
+- `kimi` — Moonshot's kimi-code CLI driven through the generic CLI-agent seam (ADR-065, [pkg/backend/delegate/kimi.go](pkg/backend/delegate/kimi.go)): `backend: "kimi"`, prompt via `-p`, stream-json output, model alias passed through verbatim (e.g. `model: "kimi-code/kimi-for-coding"`); credentials are resolved by the CLI itself from its own env/config. Sessions are best-effort — resume/fork are not wired for CLI-agent backends, so each node runs fresh.
 
 **Auto-detection.** When neither the node (`backend:`) nor the workflow (`default_backend:`) names a backend, and `ITERION_DEFAULT_BACKEND` is unset, the resolver in [pkg/backend/model/executor.go:resolveBackendName](pkg/backend/model/executor.go) probes the host for credentials (Claude Code OAuth, ANTHROPIC_API_KEY, OPENAI_API_KEY, AWS, GCP) and picks the first match in `ITERION_BACKEND_PREFERENCE` (default `claude_code,claw` — codex is intentionally excluded). When `model:` is also empty and the resolved backend is `claw`, the runtime substitutes a sensible model spec for the first available provider. The studio surfaces the live detection via the toolbar BackendStatusPill and disables Run when no credential is found. See [docs/backends.md](docs/backends.md).
 
@@ -308,7 +309,7 @@ V2-6 wires `sandbox.build:` via `docker buildx build` on the local docker driver
 
 - **RuntimeError** (`pkg/runtime/errors.go`) — structured error with `Code` (type `ErrorCode`), `Message`, `NodeID`, `Hint`, `Cause`
   - Codes: `NODE_NOT_FOUND`, `NO_OUTGOING_EDGE`, `LOOP_EXHAUSTED`, `BUDGET_EXCEEDED`, `EXECUTION_FAILED`, `WORKSPACE_SAFETY`, `TIMEOUT`, `CANCELLED`, `JOIN_FAILED`, `RESUME_INVALID`
-- **Diagnostics** (`pkg/dsl/ir/compile.go`, `pkg/dsl/ir/validate.go`) — compile-time warnings/errors with sparse codes C001–C086 (unknown refs, routing issues, unreachable nodes, undeclared cycles, attachments, presets, capability checks (C080–C082), cursor declarations (C083–C086), etc.)
+- **Diagnostics** (`pkg/dsl/ir/compile.go`, `pkg/dsl/ir/validate.go`) — compile-time warnings/errors with sparse codes C001–C199 (unknown refs, routing issues, unreachable nodes, undeclared cycles, attachments, presets, capability checks (C080–C082), cursor declarations (C083–C086), etc.)
 - **Sentinel errors**: `ErrRunPaused` (resumable), `ErrRunCancelled` (resumable with checkpoint), `ErrBudgetExceeded`
 - **Resumable failures**: Most runtime failures produce `failed_resumable` status with a checkpoint. See `docs/resume.md` for the exhaustive matrix.
 
@@ -905,8 +906,10 @@ matching every pinned version in go.mod / package-lock.json / requirements.txt
 pip-audit heuristics still need an installed tree, and the code-pattern /
 typosquat-corpus malware signals remain pending (native:3a81df64), so a run
 still banners partial coverage — but it is no longer a 0-finding scaffold.
-(In a sandboxed run the board MCP is unavailable, so findings land in the
-markdown report, not the board, until C082's HTTP board path lands.)
+(In a sandboxed run the board tools ride the HTTP transport —
+`/api/v1/mcp/board` with an ephemeral run token; known gap: on Linux
+docker the in-container endpoint can be unreachable (native:e6cd506e),
+in which case findings land in the markdown report instead of the board.)
 
 Each cron line routes through `iterion schedule run <name>`, which
 re-reads `~/.iterion/schedules.yaml` so the manifest stays authoritative;

--- a/docs/adr/055-unit-convergent-adaptive-improve-loop.md
+++ b/docs/adr/055-unit-convergent-adaptive-improve-loop.md
@@ -6,6 +6,13 @@ terminal-commit + blind-chunk-review design of the loop-bot family
 `feature_dev`) for the *improvement* use case. Piloted on
 `whole_improve_loop`, then rolled to the family.
 
+> Amended by [ADR-057](057-axis-driven-work-list-sweep.md) (the unit of
+> work became the axis-driven work-list) and superseded for the improve
+> loops by [ADR-058](058-minimal-framing-lean-on-the-agent.md) (minimal
+> framing, one campaign agent). The per-unit verify gate / incremental
+> commit / bounded-loop machinery introduced here remains the substrate
+> of the v2 campaign shape.
+
 ## Context
 
 A production-readiness dogfood of `whole_improve_loop` (Willy) against this

--- a/docs/adr/057-axis-driven-work-list-sweep.md
+++ b/docs/adr/057-axis-driven-work-list-sweep.md
@@ -6,6 +6,13 @@ chunks) with an **axis-driven work-list sweep**. ADR-055's landing/convergence
 machinery (per-item verify gate, incremental commit, bounded loops) is kept;
 what changes is the **unit of work** and how it is discovered.
 
+> Superseded for the improve loops by
+> [ADR-058](058-minimal-framing-lean-on-the-agent.md): the encoded
+> reviewer/fixer sweep graph is gone — one campaign agent carries the
+> axis and the work-list inside its contract. This ADR remains the
+> reference for the sweep mechanics (axis definition, work-list
+> discovery, done-oracle re-enumeration).
+
 ## Context
 
 Two dogfood facts and one observed human workflow forced this.

--- a/docs/adr/071-board-as-pipeline-projection.md
+++ b/docs/adr/071-board-as-pipeline-projection.md
@@ -142,3 +142,25 @@ cloud integration store) has landed as **`iterion issue import`**
   `--token-env`, never a flag value.
 
 This closes T6's self-hosted arm; the deeper T4 tree projection remains open.
+
+## Addendum (2026-07-15) — the #125 campaign shipped the deferred follow-ons
+
+The "Deferred" list above is now history — the board-as-pipeline campaign
+(GitHub epic #125, delivered 2026-07-12→14 by the Featurly/Billy factory)
+landed all four:
+
+- **T4 ticket↔runs 1:N history** — native cards keep an append-only run
+  history (`RunRefs`, newest-last; see `TestSetLastRunAppendsRunHistory`),
+  rendered as the per-card run history (#154).
+- **T4b parent/child/shards tree** — the run store carries the lineage
+  (`ParentRunID` + `ShardIndex`/`ShardCount`/`ShardLabel` on `store.Run`,
+  reverse query `ListChildRuns` — [pkg/store/iface.go](../../pkg/store/iface.go)),
+  projected as the run tree in the console and on the card (#162, #169).
+- **Per-card "awaiting input" badge** — denormalized signal, no N+1 run
+  fetch (#161).
+- **"Awaiting input" column** — a paused dispatched run's card moves into
+  the generic `awaiting_input` state and back on resume (#173), with the
+  awaiting-input lifecycle hardened for cloud parity (#179, #181).
+
+The 2026-07-13 addendum above (T6 `iterion issue import`) plus this one
+close every deferred item; the ADR is fully implemented.

--- a/docs/adr/073-cloud-twins-for-fs-only-run-detail-seams.md
+++ b/docs/adr/073-cloud-twins-for-fs-only-run-detail-seams.md
@@ -1,4 +1,4 @@
-# ADR-068 — Cloud twins for the three filesystem-only run-detail store seams (turns, tool blobs, artifact files)
+# ADR-073 — Cloud twins for the three filesystem-only run-detail store seams (turns, tool blobs, artifact files)
 
 - Status: accepted
 - Date: 2026-07-12

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -3,8 +3,9 @@
 // distributed lease, hydrates the workflow IR, and executes runs
 // against the Mongo+S3 store.
 //
-// One runner pod handles one in-flight run at a time
-// (MaxAckPending=1 on the JetStream consumer); horizontal scale
+// One runner pod handles one in-flight run at a time (its fetch loop
+// is sequential; the shared consumer's MaxAckPending caps fleet-wide
+// in-flight deliveries); horizontal scale
 // comes from spawning more pods (KEDA scales on lag — see plan §F
 // T-36 runner-keda-scaledobject.yaml).
 //
@@ -975,8 +976,8 @@ func (r *Runner) heartbeat(ctx context.Context, runCancel context.CancelFunc, lo
 			// InProgress() the broker redelivers the message to a sibling
 			// and, after MaxDeliver attempts, drops it from the queue —
 			// destroying the crash-recovery safety net while the run is
-			// still healthy and head-of-line-blocking the consumer
-			// (MaxAckPending=1). Best-effort: a transient miss is retried
+			// still healthy and head-of-line-blocking one of the consumer's
+			// MaxAckPending slots. Best-effort: a transient miss is retried
 			// on the next tick, well inside AckWait.
 			if err := delivery.InProgress(); err != nil {
 				r.cfg.Logger.Warn("runner: heartbeat InProgress failed: %v", err)
@@ -1122,8 +1123,8 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage) error {
 	// under a prior run's identity). The per-run forge_token FILE is already
 	// isolated above; this isolates the CLI's own persisted auth. The delegate
 	// subprocess inherits these from os.Environ(); no-op for sandboxed runs
-	// (fresh container HOME). Safe because the runner is sequential
-	// (MaxAckPending=1).
+	// (fresh container HOME). Safe because each runner pod processes one
+	// run at a time (sequential fetch loop).
 	if cliDir, derr := os.MkdirTemp("", "iterion-cli-"); derr == nil {
 		prevGlab, hadGlab := os.LookupEnv("GLAB_CONFIG_DIR")
 		prevGH, hadGH := os.LookupEnv("GH_CONFIG_DIR")
@@ -1594,7 +1595,7 @@ func extractRepoHost(repoURL string) (string, error) {
 // gitOpTimeout bounds a single runner-side git subprocess. Without it a
 // clone/fetch against a wedged remote hangs on the run ctx alone — and a
 // run launched without --timeout has NO deadline, so the git subprocess
-// pins the MaxAckPending=1 runner pod indefinitely while the heartbeat
+// pins the runner pod (one in-flight run each) indefinitely while the heartbeat
 // keeps the lease alive (the heartbeat proves the pod lives, not that
 // the clone progresses). GIT_TERMINAL_PROMPT=0 covers the credential
 // prompt, not a stalled TCP transfer. Override with

--- a/pkg/runner/org_spend_test.go
+++ b/pkg/runner/org_spend_test.go
@@ -60,7 +60,7 @@ func TestRecordOrgSpendKey(t *testing.T) {
 // TestGitOpTimeoutBoundsSubprocess proves runGit is wall-clock bounded
 // even when the caller's ctx has no deadline — the exact shape of a run
 // launched without --timeout, where a wedged clone used to pin the
-// MaxAckPending=1 pod forever.
+// runner pod (one in-flight run each) forever.
 func TestGitOpTimeoutBoundsSubprocess(t *testing.T) {
 	old := gitOpTimeout
 	gitOpTimeout = 300 * time.Millisecond

--- a/pkg/runner/runlog_writer.go
+++ b/pkg/runner/runlog_writer.go
@@ -21,7 +21,7 @@ import (
 // Offsets are absolute stream positions seeded from RunLogSize at run
 // claim, so a resumed/redelivered run appends after the persisted tail
 // instead of overlapping it. The writer is the single producer per run
-// (queue MaxAckPending=1 + run lock); the store's unique
+// (per-pod sequential loop + run lock); the store's unique
 // (run_id, offset) index is the safety net.
 //
 // Failure policy: a flush retries a few times with a short backoff and
@@ -57,7 +57,7 @@ const (
 
 // registerLogWriter exposes the run's writer to the store's
 // LogPositionFn hook (logWriterTotal) so AppendEvent can stamp
-// Event.LogOffset. The runner is sequential (MaxAckPending=1) but the
+// Event.LogOffset. Each runner pod is sequential (one in-flight run) but the
 // map keeps the wiring correct regardless.
 func (r *Runner) registerLogWriter(runID string, w *runLogWriter) {
 	r.logWritersMu.Lock()

--- a/pkg/store/mongo/runlogs.go
+++ b/pkg/store/mongo/runlogs.go
@@ -14,8 +14,8 @@ import (
 )
 
 // runLogDoc is one append-only chunk of a run's raw log byte stream
-// (ADR-053). The runner pod is the single writer per run (queue
-// MaxAckPending=1 + run lock) and allocates offsets from a local
+// (ADR-053). The runner pod is the single writer per run (per-pod
+// sequential loop + run lock) and allocates offsets from a local
 // counter seeded from RunLogSize at claim time; the unique
 // (run_id, offset) index is the race/redelivery safety net. The server
 // pod's log stream source tails inserts via a change stream and the


### PR DESCRIPTION
Documentation/comment refresh from the 2026-07-15 roadmap study — every item below was verified against the code before editing.

## CLAUDE.md
- **kimi backend documented** (it was absent): Moonshot kimi-code via the CLI-agent seam (ADR-065), `backend: "kimi"`, verbatim model alias, credentials via the CLI's own env; sessions best-effort (no resume/fork).
- **Security section**: dropped the stale claim that sandboxed board access waits on C082 — the `/api/v1/mcp/board` HTTP path is shipped and wired for sandboxed claude_code (`RegisterBoardMCPRoutes` + `wireBoardMCP`); the remaining gap is the Linux-docker reachability bug (`native:e6cd506e`), now stated as such.
- Diagnostics range `C001–C086` → `C001–C199` (×2).

## Stale `MaxAckPending=1` comments (8 sites, pkg/runner + pkg/store/mongo)
Since the fleet-serialization fix the consumer default is 256; the real invariant is **one in-flight run per pod (sequential fetch loop) + per-run store lock**. Reworded the eight comments that still presented `MaxAckPending=1` as the design.

## ADR hygiene
- **Duplicate ADR-068 resolved**: `068-cloud-twins…` → **ADR-073** (zero inbound references; ADR-067's link targets the diff-content 068, which keeps the number).
- **ADR-055 / ADR-057**: supersession pointers toward ADR-058 (the improve-loop chain 055→057→058 was unannotated).
- **ADR-071 addendum**: the #125 board-as-pipeline campaign shipped every deferred follow-on — `RunRefs` per-card run history (#154), `ParentRunID`/shard-tuple + `ListChildRuns` run tree (#162/#169), awaiting-input badge (#161) + column (#173, hardened #179/#181). ADR now fully implemented.

Deliberately left alone: the `review_mode`/`mono_family` mentions in `bots/**` headers — they are accurate v1→v2 retirement notes (only `pr_review_mode`, a different var, is still declared), not stale claims.

No behavior change — comments/docs only (gofmt/vet/build green on touched packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)