### PR TITLE
feat(config): expose the NATS work-queue tuning knobs via env + YAML

### DIFF
--- a/cmd/iterion/runner.go
+++ b/cmd/iterion/runner.go
@@ -93,12 +93,18 @@ func runRunner(cmd *cobra.Command, _ []string) error {
 
 	// 1. NATS layer — provides the queue + KV lock bucket.
 	natsConn, err := natsq.Connect(rootCtx, natsq.Config{
-		URL:        cfg.NATS.URL,
-		StreamName: cfg.NATS.Stream,
-		DLQStream:  cfg.NATS.DLQStream,
-		KVBucket:   cfg.NATS.KVBucket,
-		LockTTL:    cfg.Runner.LockTTL,
-		Logger:     logger,
+		URL:           cfg.NATS.URL,
+		StreamName:    cfg.NATS.Stream,
+		DLQStream:     cfg.NATS.DLQStream,
+		KVBucket:      cfg.NATS.KVBucket,
+		MaxAckPending: cfg.NATS.MaxAckPending,
+		AckWait:       cfg.NATS.AckWait,
+		MaxDeliver:    cfg.NATS.MaxDeliver,
+		MaxAge:        cfg.NATS.MaxAge,
+		DLQMaxAge:     cfg.NATS.DLQMaxAge,
+		MaxPayload:    cfg.NATS.MaxPayload,
+		LockTTL:       cfg.Runner.LockTTL,
+		Logger:        logger,
 	})
 	if err != nil {
 		return fmt.Errorf("runner: connect NATS: %w", err)

--- a/cmd/iterion/server.go
+++ b/cmd/iterion/server.go
@@ -199,11 +199,17 @@ func runServer(cmd *cobra.Command, _ []string) error {
 	}()
 
 	natsConn, err := natsq.Connect(rootCtx, natsq.Config{
-		URL:        cfg.NATS.URL,
-		StreamName: cfg.NATS.Stream,
-		DLQStream:  cfg.NATS.DLQStream,
-		KVBucket:   cfg.NATS.KVBucket,
-		Logger:     logger,
+		URL:           cfg.NATS.URL,
+		StreamName:    cfg.NATS.Stream,
+		DLQStream:     cfg.NATS.DLQStream,
+		KVBucket:      cfg.NATS.KVBucket,
+		MaxAckPending: cfg.NATS.MaxAckPending,
+		AckWait:       cfg.NATS.AckWait,
+		MaxDeliver:    cfg.NATS.MaxDeliver,
+		MaxAge:        cfg.NATS.MaxAge,
+		DLQMaxAge:     cfg.NATS.DLQMaxAge,
+		MaxPayload:    cfg.NATS.MaxPayload,
+		Logger:        logger,
 	})
 	if err != nil {
 		return fmt.Errorf("server: connect NATS: %w", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -258,12 +258,24 @@ type SandboxConfig struct {
 	Override string `yaml:"override"`
 }
 
-// NATSConfig holds the NATS JetStream connection + stream/bucket names.
+// NATSConfig holds the NATS JetStream connection + stream/bucket names,
+// plus the work-queue tuning knobs. The tuning fields default to zero =
+// inherit the natsq defaults (MaxAckPending 256, AckWait 10m, MaxDeliver 8,
+// MaxAge 24h, DLQMaxAge 7d, MaxPayload server-negotiated). Server and runner
+// deployments must be fed the same values — whichever connects last
+// re-pins the shared stream/consumer.
 type NATSConfig struct {
 	URL       string `yaml:"url"`
 	Stream    string `yaml:"stream"`
 	KVBucket  string `yaml:"kv_bucket"`
 	DLQStream string `yaml:"dlq_stream"`
+
+	MaxAckPending int           `yaml:"max_ack_pending"` // fleet-wide in-flight (delivered-unacked) cap on the shared consumer
+	AckWait       time.Duration `yaml:"ack_wait"`        // per-delivery ack window before redelivery
+	MaxDeliver    int           `yaml:"max_deliver"`     // delivery attempts before the message parks in the DLQ
+	MaxAge        time.Duration `yaml:"max_age"`         // run-stream retention
+	DLQMaxAge     time.Duration `yaml:"dlq_max_age"`     // DLQ retention
+	MaxPayload    int           `yaml:"max_payload"`     // publish-size guard override (bytes)
 }
 
 // MongoConfig holds the Mongo connection + DB + events TTL.
@@ -454,6 +466,24 @@ func (c *Config) Validate() error {
 		}
 		if c.NATS.DLQStream == "" {
 			return fmt.Errorf("ITERION_NATS_DLQ_STREAM must not be empty")
+		}
+		if c.NATS.MaxAckPending < 0 {
+			return fmt.Errorf("ITERION_NATS_MAX_ACK_PENDING %d invalid (want >= 0; 0 inherits the default)", c.NATS.MaxAckPending)
+		}
+		if c.NATS.MaxDeliver < 0 {
+			return fmt.Errorf("ITERION_NATS_MAX_DELIVER %d invalid (want >= 0; 0 inherits the default)", c.NATS.MaxDeliver)
+		}
+		if c.NATS.AckWait < 0 {
+			return fmt.Errorf("ITERION_NATS_ACK_WAIT %s invalid (want >= 0; 0 inherits the default)", c.NATS.AckWait)
+		}
+		if c.NATS.MaxAge < 0 {
+			return fmt.Errorf("ITERION_NATS_MAX_AGE %s invalid (want >= 0; 0 inherits the default)", c.NATS.MaxAge)
+		}
+		if c.NATS.DLQMaxAge < 0 {
+			return fmt.Errorf("ITERION_NATS_DLQ_MAX_AGE %s invalid (want >= 0; 0 inherits the default)", c.NATS.DLQMaxAge)
+		}
+		if c.NATS.MaxPayload < 0 {
+			return fmt.Errorf("ITERION_NATS_MAX_PAYLOAD %d invalid (want >= 0; 0 inherits the default)", c.NATS.MaxPayload)
 		}
 		if c.Mongo.URI == "" {
 			return fmt.Errorf("ITERION_MONGO_URI required when mode=cloud")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -480,3 +480,59 @@ func TestLoad_InvalidRunnerDurations(t *testing.T) {
 		})
 	}
 }
+
+func TestLoad_NATSQueueTuningEnvOverride(t *testing.T) {
+	clearITERION(t)
+	t.Setenv("ITERION_NATS_MAX_ACK_PENDING", "512")
+	t.Setenv("ITERION_NATS_ACK_WAIT", "15m")
+	t.Setenv("ITERION_NATS_MAX_DELIVER", "12")
+	t.Setenv("ITERION_NATS_MAX_AGE", "48h")
+	t.Setenv("ITERION_NATS_DLQ_MAX_AGE", "336h")
+	t.Setenv("ITERION_NATS_MAX_PAYLOAD", "4194304")
+	cfg, err := Load(LoadOptions{})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.NATS.MaxAckPending != 512 {
+		t.Errorf("MaxAckPending = %d, want 512", cfg.NATS.MaxAckPending)
+	}
+	if cfg.NATS.AckWait != 15*time.Minute {
+		t.Errorf("AckWait = %s, want 15m", cfg.NATS.AckWait)
+	}
+	if cfg.NATS.MaxDeliver != 12 {
+		t.Errorf("MaxDeliver = %d, want 12", cfg.NATS.MaxDeliver)
+	}
+	if cfg.NATS.MaxAge != 48*time.Hour {
+		t.Errorf("MaxAge = %s, want 48h", cfg.NATS.MaxAge)
+	}
+	if cfg.NATS.DLQMaxAge != 336*time.Hour {
+		t.Errorf("DLQMaxAge = %s, want 336h", cfg.NATS.DLQMaxAge)
+	}
+	if cfg.NATS.MaxPayload != 4194304 {
+		t.Errorf("MaxPayload = %d, want 4194304", cfg.NATS.MaxPayload)
+	}
+}
+
+func TestLoad_NATSQueueTuningYAML(t *testing.T) {
+	clearITERION(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "c.yaml")
+	body := "nats:\n  max_ack_pending: 64\n  ack_wait: 5m\n  max_deliver: 3\n  max_age: 12h\n  dlq_max_age: 72h\n  max_payload: 1048576\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(LoadOptions{YAMLPath: path})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.NATS.MaxAckPending != 64 || cfg.NATS.MaxDeliver != 3 || cfg.NATS.MaxPayload != 1048576 {
+		t.Errorf("ints = %d/%d/%d, want 64/3/1048576", cfg.NATS.MaxAckPending, cfg.NATS.MaxDeliver, cfg.NATS.MaxPayload)
+	}
+	if cfg.NATS.AckWait != 5*time.Minute || cfg.NATS.MaxAge != 12*time.Hour || cfg.NATS.DLQMaxAge != 72*time.Hour {
+		t.Errorf("durations = %s/%s/%s, want 5m/12h/72h", cfg.NATS.AckWait, cfg.NATS.MaxAge, cfg.NATS.DLQMaxAge)
+	}
+	// Zero-value default preserved: tuning left unset inherits natsq defaults.
+	if d := Defaults(); d.NATS.MaxAckPending != 0 || d.NATS.AckWait != 0 {
+		t.Errorf("Defaults() tuning fields must stay zero (inherit natsq): %+v", d.NATS)
+	}
+}

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -21,6 +21,24 @@ func loadEnv(cfg *Config) error {
 	lookupString("ITERION_NATS_STREAM", &cfg.NATS.Stream)
 	lookupString("ITERION_NATS_KV_BUCKET", &cfg.NATS.KVBucket)
 	lookupString("ITERION_NATS_DLQ_STREAM", &cfg.NATS.DLQStream)
+	if err := lookupInt("ITERION_NATS_MAX_ACK_PENDING", &cfg.NATS.MaxAckPending); err != nil {
+		return err
+	}
+	if err := lookupDuration("ITERION_NATS_ACK_WAIT", &cfg.NATS.AckWait); err != nil {
+		return err
+	}
+	if err := lookupInt("ITERION_NATS_MAX_DELIVER", &cfg.NATS.MaxDeliver); err != nil {
+		return err
+	}
+	if err := lookupDuration("ITERION_NATS_MAX_AGE", &cfg.NATS.MaxAge); err != nil {
+		return err
+	}
+	if err := lookupDuration("ITERION_NATS_DLQ_MAX_AGE", &cfg.NATS.DLQMaxAge); err != nil {
+		return err
+	}
+	if err := lookupInt("ITERION_NATS_MAX_PAYLOAD", &cfg.NATS.MaxPayload); err != nil {
+		return err
+	}
 
 	lookupString("ITERION_MONGO_URI", &cfg.Mongo.URI)
 	lookupString("ITERION_MONGO_DB", &cfg.Mongo.DB)

--- a/pkg/config/yaml.go
+++ b/pkg/config/yaml.go
@@ -103,6 +103,13 @@ type yamlNATSConfig struct {
 	Stream    *string `yaml:"stream"`
 	KVBucket  *string `yaml:"kv_bucket"`
 	DLQStream *string `yaml:"dlq_stream"`
+
+	MaxAckPending *int    `yaml:"max_ack_pending"`
+	AckWait       *string `yaml:"ack_wait"`
+	MaxDeliver    *int    `yaml:"max_deliver"`
+	MaxAge        *string `yaml:"max_age"`
+	DLQMaxAge     *string `yaml:"dlq_max_age"`
+	MaxPayload    *int    `yaml:"max_payload"`
 }
 
 type yamlMongoConfig struct {
@@ -149,6 +156,30 @@ func (y *yamlConfig) applyTo(cfg *Config) error {
 		applyString(y.NATS.Stream, &cfg.NATS.Stream)
 		applyString(y.NATS.KVBucket, &cfg.NATS.KVBucket)
 		applyString(y.NATS.DLQStream, &cfg.NATS.DLQStream)
+		applyInt(y.NATS.MaxAckPending, &cfg.NATS.MaxAckPending)
+		applyInt(y.NATS.MaxDeliver, &cfg.NATS.MaxDeliver)
+		applyInt(y.NATS.MaxPayload, &cfg.NATS.MaxPayload)
+		if y.NATS.AckWait != nil {
+			d, err := time.ParseDuration(*y.NATS.AckWait)
+			if err != nil {
+				return fmt.Errorf("nats.ack_wait: %w", err)
+			}
+			cfg.NATS.AckWait = d
+		}
+		if y.NATS.MaxAge != nil {
+			d, err := time.ParseDuration(*y.NATS.MaxAge)
+			if err != nil {
+				return fmt.Errorf("nats.max_age: %w", err)
+			}
+			cfg.NATS.MaxAge = d
+		}
+		if y.NATS.DLQMaxAge != nil {
+			d, err := time.ParseDuration(*y.NATS.DLQMaxAge)
+			if err != nil {
+				return fmt.Errorf("nats.dlq_max_age: %w", err)
+			}
+			cfg.NATS.DLQMaxAge = d
+		}
 	}
 	if y.Mongo != nil {
 		applyString(y.Mongo.URI, &cfg.Mongo.URI)


### PR DESCRIPTION
From the 2026-07-15 roadmap study (quick-wins batch).

`natsq.Config` already carries `MaxAckPending`/`AckWait`/`MaxDeliver`/`MaxAge`/`DLQMaxAge`/`MaxPayload` with sane defaults, but neither `cmd/iterion/server.go` nor `cmd/iterion/runner.go` passed them — so re-tuning the fleet-wide in-flight cap or the redelivery window (both needed live during the 2026-07 launch waves: `MaxDeliver 3→8`, `AckWait 5→10m`, `MaxAckPending 1→256` were all code changes) required a rebuild.

- `config.NATSConfig` gains the six knobs: env `ITERION_NATS_MAX_ACK_PENDING`, `ITERION_NATS_ACK_WAIT`, `ITERION_NATS_MAX_DELIVER`, `ITERION_NATS_MAX_AGE`, `ITERION_NATS_DLQ_MAX_AGE`, `ITERION_NATS_MAX_PAYLOAD` + matching `nats.*` YAML keys (durations as Go-duration strings, same as `runner.heartbeat`).
- Both `natsq.Connect` sites now thread them; **zero = inherit the natsq default**, so existing deployments are byte-identical.
- Negative values rejected at `Validate` (cloud mode).
- Struct comment documents the operational constraint: server and runner deployments must be fed the same values — whichever connects last re-pins the shared stream/consumer.
- Deliberately NOT wired: `ITERION_RUNNER_CONCURRENCY` (dead config today) — making it real means a per-pod worker pool in `pkg/runner/loop.go`, which is roadmap chantier C1, not a passthrough.

Tests: env-override + YAML-overlay + zero-default preservation (`pkg/config`); gofmt/vet/build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)