### PR TITLE
fix(dsl): expose subbot output schemas

### DIFF
--- a/pkg/dsl/ir/ir.go
+++ b/pkg/dsl/ir/ir.go
@@ -564,6 +564,8 @@ func NodeOutputSchema(n Node) string {
 		return n.OutputSchema
 	case *ComputeNode:
 		return n.OutputSchema
+	case *SubbotNode:
+		return n.OutputSchema
 	case *WaitNode:
 		return n.OutputSchema
 	}

--- a/pkg/dsl/ir/subbot_test.go
+++ b/pkg/dsl/ir/subbot_test.go
@@ -37,6 +37,9 @@ func TestCompileSubbot(t *testing.T) {
 	if n.Source != "child.bot" || n.OutputSchema != "verdict" {
 		t.Fatalf("source/output = %q/%q", n.Source, n.OutputSchema)
 	}
+	if got := NodeOutputSchema(n); got != "verdict" {
+		t.Fatalf("NodeOutputSchema = %q, want verdict", got)
+	}
 	if len(n.With) != 1 || n.With[0].Key != "issue" {
 		t.Fatalf("with mappings = %v", n.With)
 	}

--- a/pkg/runtime/subbot_test.go
+++ b/pkg/runtime/subbot_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
@@ -86,6 +87,60 @@ func TestSubbotRunsChildAndMapsOutput(t *testing.T) {
 	}
 	if !routedToOK {
 		t.Error("expected the subbot's validated=true to route to the `ok` done node")
+	}
+}
+
+// TestSubbotOutputSchemaValidation ensures a parent validates the terminal
+// output returned by a nested run against the schema declared on the subbot.
+func TestSubbotOutputSchemaValidation(t *testing.T) {
+	wf := &ir.Workflow{
+		Name:  "subbot_output_validation",
+		Entry: "run_child",
+		Nodes: map[string]ir.Node{
+			"run_child": &ir.SubbotNode{
+				BaseNode:     ir.BaseNode{ID: "run_child"},
+				Source:       "child.bot",
+				OutputSchema: "verdict",
+			},
+			"done": &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{{From: "run_child", To: "done"}},
+		Schemas: map[string]*ir.Schema{
+			"verdict": {
+				Name: "verdict",
+				Fields: []*ir.SchemaField{
+					{Name: "validated", Type: ir.FieldTypeBool},
+				},
+			},
+		},
+		Prompts: map[string]*ir.Prompt{},
+		Vars:    map[string]*ir.Var{},
+		Loops:   map[string]*ir.Loop{},
+	}
+
+	runner := func(_ context.Context, _ SubbotRequest) (map[string]any, error) {
+		return map[string]any{"validated": "not-a-bool"}, nil
+	}
+	eng := New(
+		wf,
+		tmpStore(t),
+		newStubExecutor(),
+		WithSubbotRunner(runner),
+		WithOutputValidation(true),
+	)
+	err := eng.Run(context.Background(), "run-subbot-invalid-output", nil)
+	if err == nil {
+		t.Fatal("expected schema validation error, got nil")
+	}
+	var rtErr *RuntimeError
+	if !errors.As(err, &rtErr) {
+		t.Fatalf("expected RuntimeError, got %T: %v", err, err)
+	}
+	if rtErr.Code != ErrCodeSchemaValidation {
+		t.Fatalf("error code = %s, want %s", rtErr.Code, ErrCodeSchemaValidation)
+	}
+	if rtErr.NodeID != "run_child" {
+		t.Fatalf("node ID = %q, want run_child", rtErr.NodeID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- expose `SubbotNode.OutputSchema` through the shared `NodeOutputSchema` accessor
- restore static references/type checks and runtime output validation for native subbots
- cover compile-time lookup and invalid child output at runtime

## Tests

- `go test ./pkg/dsl/ir ./pkg/runtime ./pkg/botreplay`
- `git diff --check`