### PR TITLE
feat(studio): produced elements list the files written by the pipeline's nodes, not a raw git status

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4364,6 +4364,30 @@
         }
       ]
     },
+    "/api/runs/{id}/files/touched": {
+      "get": {
+        "operationId": "getRunsByIdFilesTouched",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "GET /api/runs/{id}/files/touched",
+        "tags": [
+          "runs"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "/api/runs/{id}/fork": {
       "parameters": [
         {

--- a/pkg/server/runs.go
+++ b/pkg/server/runs.go
@@ -66,6 +66,7 @@ func (s *Server) registerRunRoutes() {
 	s.mux.HandleFunc("GET /api/runs/{id}/artifact-files", s.handleListArtifactFiles)
 	s.mux.HandleFunc("GET /api/runs/{id}/artifact-files/{path...}", s.handleGetArtifactFile)
 	s.mux.HandleFunc("GET /api/runs/{id}/files", s.handleListRunFiles)
+	s.mux.HandleFunc("GET /api/runs/{id}/files/touched", s.handleListRunTouchedFiles)
 	s.mux.HandleFunc("GET /api/runs/{id}/files/diff", s.handleGetRunFileDiff)
 	s.mux.HandleFunc("GET /api/runs/{id}/files/content", s.handleGetRunFileContent)
 	s.mux.HandleFunc("PUT /api/runs/{id}/files/content", s.handleSaveRunFileContent)

--- a/pkg/server/runs_files.go
+++ b/pkg/server/runs_files.go
@@ -32,16 +32,24 @@ const maxRunFileEditBytes = 4 << 20
 //     each tagged with a `lifecycle` ("committed" | "uncommitted") so the
 //     studio can render a subtle committed-vs-in-flight distinction. This
 //     is the studio's default while a run is in progress.
+//   - modeProduced: "the best available full picture", lifecycle-agnostic.
+//     Resolves to combined while the worktree is live, then falls back to
+//     the persisted git-metadata snapshot and finally the historical
+//     BaseCommit..FinalCommit diff — instead of dead-ending on
+//     worktree_gone the way a strict combined request does. Used by the
+//     pipeline board's Produced-elements panel, which must keep showing a
+//     finished run's files after the engine gc'd its worktree.
 //
-// Once the worktree is gc'd, only modeBranch is meaningful: the
-// uncommitted and combined views return available=false with
-// reason="worktree_gone".
+// Once the worktree is gc'd, only modeBranch and modeProduced are
+// meaningful: the uncommitted and combined views return available=false
+// with reason="worktree_gone".
 type fileMode string
 
 const (
 	modeUncommitted fileMode = "uncommitted"
 	modeBranch      fileMode = "branch"
 	modeCombined    fileMode = "combined"
+	modeProduced    fileMode = "produced"
 )
 
 // Lifecycle tags annotate combined-mode entries (see combinedFiles). They
@@ -61,6 +69,8 @@ func parseFileMode(raw string) fileMode {
 		return modeBranch
 	case modeCombined:
 		return modeCombined
+	case modeProduced:
+		return modeProduced
 	default:
 		return ""
 	}
@@ -144,6 +154,11 @@ func (s *Server) handleListRunFiles(w http.ResponseWriter, r *http.Request) {
 		if effective == "" {
 			effective = modeUncommitted
 		}
+		// While the working directory exists, `produced` IS the combined
+		// view; the gone-worktree fallbacks below are what set it apart.
+		if effective == modeProduced {
+			effective = modeCombined
+		}
 		// `branch` mode without a baseline is unrenderable — the worktree
 		// exists but we have no anchor for the range. Surface that as
 		// no_baseline so the UI can prompt for a different mode, instead
@@ -217,6 +232,14 @@ func (s *Server) handleListRunFiles(w http.ResponseWriter, r *http.Request) {
 	// Finalized-run path: derive the file list from BaseCommit..FinalCommit
 	// inside the main repo. Requires both refs and a repo root.
 	if files, ok := s.historicalFiles(run); ok {
+		// A `produced` request tags the historical rows committed so the
+		// studio's per-row diff targets the branch range (the worktree —
+		// and with it any uncommitted view — is gone).
+		if requested == modeProduced {
+			for i := range files {
+				files[i].Lifecycle = lifecycleCommitted
+			}
+		}
 		s.writeJSONFor(w, r, runFilesResponse{
 			WorkDir:   run.WorkDir,
 			Worktree:  run.Worktree,
@@ -262,9 +285,10 @@ func unavailableReason(run *store.Run, terminalReason string) string {
 // handled the response. This is the cloud fallback for a run whose worktree
 // is gone: the runner recorded the branch-range diff (files vs base) into
 // the store. The snapshot represents the committed branch view, so for a
-// `combined` request the entries are tagged lifecycle=committed (there is
-// no uncommitted set to merge). A snapshot with zero files is a valid
-// "no changes" answer (Available=true), not an empty-state error.
+// `combined` (or `produced`) request the entries are tagged
+// lifecycle=committed (there is no uncommitted set to merge). A snapshot
+// with zero files is a valid "no changes" answer (Available=true), not an
+// empty-state error.
 func (s *Server) servePersistedFiles(w http.ResponseWriter, r *http.Request, run *store.Run, requested fileMode) bool {
 	gs := store.AsRunGitMetaStore(s.runs.RunStore())
 	if gs == nil {
@@ -283,7 +307,7 @@ func (s *Server) servePersistedFiles(w http.ResponseWriter, r *http.Request, run
 		files = []gitlib.FileStatus{}
 	}
 	effective := modeBranch
-	if requested == modeCombined {
+	if requested == modeCombined || requested == modeProduced {
 		effective = modeCombined
 		tagged := make([]gitlib.FileStatus, len(files))
 		for i, f := range files {

--- a/pkg/server/runs_files_test.go
+++ b/pkg/server/runs_files_test.go
@@ -678,3 +678,131 @@ func TestArtifactFileContentType_MediaTypes(t *testing.T) {
 		}
 	}
 }
+
+// TestRunFiles_ModeProduced_LiveWorktree verifies that produced resolves to
+// the combined view while the working directory exists: committed +
+// uncommitted union, lifecycle-tagged, live=true.
+func TestRunFiles_ModeProduced_LiveWorktree(t *testing.T) {
+	srv, hs := newTestServer(t)
+	dir := initRepo(t)
+	baseSHA := revParse(t, dir, "HEAD")
+
+	commitInRunWorktree(t, dir, "b.txt", "new\n", "add b")
+	if err := os.WriteFile(filepath.Join(dir, "c.txt"), []byte("scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	seedRunWithBaseline(t, srv, "produced-live", dir, baseSHA)
+
+	resp, err := http.Get(hs.URL + "/api/runs/produced-live/files?mode=produced")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out runFilesResponse
+	decodeJSONResp(t, resp, &out)
+	if !out.Available || !out.Live {
+		t.Fatalf("Available=%v Live=%v reason=%q", out.Available, out.Live, out.Reason)
+	}
+	if out.Mode != modeCombined {
+		t.Errorf("Mode: want combined (produced resolves to it live), got %q", out.Mode)
+	}
+	got := map[string]gitlib.FileStatus{}
+	for _, f := range out.Files {
+		got[f.Path] = f
+	}
+	if got["b.txt"].Lifecycle != lifecycleCommitted {
+		t.Errorf("b.txt lifecycle: want %q, got %+v", lifecycleCommitted, out.Files)
+	}
+	if got["c.txt"].Lifecycle != lifecycleUncommitted {
+		t.Errorf("c.txt lifecycle: want %q, got %+v", lifecycleUncommitted, out.Files)
+	}
+}
+
+// TestRunFiles_ModeProduced_WorktreeGone verifies the produced view does NOT
+// dead-end on worktree_gone the way combined does: it falls through to the
+// historical BaseCommit..FinalCommit diff, tagging every row committed so
+// per-row diffs target the branch range.
+func TestRunFiles_ModeProduced_WorktreeGone(t *testing.T) {
+	srv, hs := newTestServer(t)
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	for _, args := range [][]string{
+		{"init", "-q", "-b", "main"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "test"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = srv.cfg.WorkDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(srv.cfg.WorkDir, "a.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"add", "a.txt"}, {"commit", "-q", "-m", "base"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = srv.cfg.WorkDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	baseSHA := revParse(t, srv.cfg.WorkDir, "HEAD")
+	if err := os.WriteFile(filepath.Join(srv.cfg.WorkDir, "b.txt"), []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"add", "b.txt"}, {"commit", "-q", "-m", "add b"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = srv.cfg.WorkDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	finalSHA := revParse(t, srv.cfg.WorkDir, "HEAD")
+
+	st, err := store.New(srv.cfg.StoreDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := st.CreateRun(context.Background(), "produced-gone", "wf", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.WorkDir = "/nonexistent/host/path/.iterion/worktrees/produced-gone"
+	r.RepoRoot = srv.cfg.WorkDir
+	r.Worktree = true
+	r.Status = store.RunStatusFinished
+	r.BaseCommit = baseSHA
+	r.FinalCommit = finalSHA
+	if err := st.SaveRun(context.Background(), r); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Get(hs.URL + "/api/runs/produced-gone/files?mode=produced")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out runFilesResponse
+	decodeJSONResp(t, resp, &out)
+	if !out.Available {
+		t.Fatalf("Available=false reason=%q, want historical fallback", out.Reason)
+	}
+	if out.Live {
+		t.Errorf("Live=true, want false")
+	}
+	found := false
+	for _, f := range out.Files {
+		if f.Path == "b.txt" {
+			found = true
+			if f.Status != "A" {
+				t.Errorf("b.txt status = %q, want A", f.Status)
+			}
+			if f.Lifecycle != lifecycleCommitted {
+				t.Errorf("b.txt lifecycle = %q, want %q", f.Lifecycle, lifecycleCommitted)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("b.txt missing from produced historical view: %+v", out.Files)
+	}
+}

--- a/pkg/server/runs_files_touched.go
+++ b/pkg/server/runs_files_touched.go
@@ -1,0 +1,266 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// This file implements GET /api/runs/{id}/files/touched — the list of
+// workspace files the run's LLM nodes wrote or edited, derived from the
+// persisted tool_started events rather than from git.
+//
+// The git-based /files views answer "what changed in this working
+// directory", which is only equal to "what did the run produce" when the
+// run executed in an isolated worktree. For an in-place run (worktree:
+// none, or a non-git workspace) `git status` also reports the operator's
+// own pre-existing dirty files, and files the run already committed drop
+// out of it entirely. This endpoint answers the narrower, attribution-
+// aware question: which paths did the nodes actually write, and which
+// node wrote each one. The studio's pipeline-board "Produced elements"
+// panel intersects/annotates the git view with it.
+//
+// Known under-report, by design: files created by Bash commands, by
+// direct tool nodes (shell, no per-file tracking), or by CLI-agent
+// backends that stream no tool events (kimi) are invisible here — for
+// worktree runs the git channel still catches them; for in-place runs
+// missing those beats listing the operator's whole git status.
+
+// writeToolPathKeys maps each write-capable tool name to the ordered
+// input keys that carry the target path (first non-empty string wins).
+// Two namespaces coexist: CamelCase for the Claude Code SDK, snake_case
+// for claw-code-go's built-ins — kept in sync with the canonical
+// dispatch maps in pkg/backend/tooldisplay (CamelCaseKeys/SnakeCaseKeys),
+// restricted to the tools that mutate files. Read-only tools (Read,
+// read_file, Glob, …) and Bash are deliberately absent.
+var writeToolPathKeys = map[string][]string{
+	// Claude Code SDK tool names.
+	"Write":        {"file_path"},
+	"Edit":         {"file_path"},
+	"MultiEdit":    {"file_path"},
+	"NotebookEdit": {"notebook_path", "file_path"},
+	// claw-code-go built-ins.
+	"write_file":    {"path", "file_path"},
+	"file_edit":     {"path", "file_path"},
+	"notebook_edit": {"path", "file_path", "notebook_path"},
+}
+
+// touchedBlobReadCap bounds how much of a sidecar input blob we read when
+// the inline 4 KB preview didn't carry the path key. Both SDKs emit the
+// path as the first property, so this fallback is nearly never taken; the
+// cap keeps a pathological multi-MB input from being slurped whole.
+const touchedBlobReadCap = 1 << 20
+
+// touchedFile is one file written/edited by the run's LLM nodes.
+type touchedFile struct {
+	// Path is workdir-relative when the tool wrote inside run.WorkDir
+	// (matching the git /files listing), absolute otherwise.
+	Path string `json:"path"`
+	// NodeIDs lists the workflow nodes that wrote this path, in
+	// first-write order.
+	NodeIDs []string `json:"node_ids"`
+	// Writes counts the write/edit tool calls that targeted this path.
+	Writes int `json:"writes"`
+	// LastSeq is the event seq of the most recent write — lets pollers
+	// spot "new output since I last looked" cheaply.
+	LastSeq int64 `json:"last_seq"`
+}
+
+// runTouchedFilesResponse is the wire shape of
+// GET /api/runs/{id}/files/touched.
+type runTouchedFilesResponse struct {
+	WorkDir  string        `json:"work_dir,omitempty"`
+	Worktree bool          `json:"worktree,omitempty"`
+	Files    []touchedFile `json:"files"`
+}
+
+// handleListRunTouchedFiles scans the run's events for write-capable
+// tool calls and aggregates the targeted paths per file with node
+// attribution. A run with no events (or none matching) returns an empty
+// list — that is a valid "the nodes wrote nothing" answer, not an error.
+func (s *Server) handleListRunTouchedFiles(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "missing run id")
+		return
+	}
+	run, err := s.runs.LoadRunCtx(r.Context(), id)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusNotFound, "run not found: %v", err)
+		return
+	}
+	rs := s.runs.RunStore()
+	blobs := store.AsToolBlobStore(rs)
+
+	agg := make(map[string]*touchedFile)
+	scanErr := rs.ScanEvents(r.Context(), id, func(e *store.Event) bool {
+		if e.Type != store.EventToolStarted || e.Data == nil {
+			return true
+		}
+		tool, _ := e.Data["tool"].(string)
+		keys, ok := writeToolPathKeys[tool]
+		if !ok {
+			return true
+		}
+		p := normalizeTouchedPath(run.WorkDir, pathFromToolInput(r, blobs, id, e, keys))
+		// Re-check AFTER normalization: a whitespace-only tool path
+		// normalizes to "", and a path equal to the workdir itself to "." —
+		// neither is a file row (a degenerate Write's tool_started fires
+		// before the tool errors, so such inputs do land in events).
+		if p == "" || p == "." {
+			return true
+		}
+		tf := agg[p]
+		if tf == nil {
+			tf = &touchedFile{Path: p}
+			agg[p] = tf
+		}
+		tf.Writes++
+		if e.Seq > tf.LastSeq {
+			tf.LastSeq = e.Seq
+		}
+		if e.NodeID != "" && !slices.Contains(tf.NodeIDs, e.NodeID) {
+			tf.NodeIDs = append(tf.NodeIDs, e.NodeID)
+		}
+		return true
+	})
+	if scanErr != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "scan events: %v", scanErr)
+		return
+	}
+
+	files := make([]touchedFile, 0, len(agg))
+	for _, tf := range agg {
+		files = append(files, *tf)
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	s.writeJSONFor(w, r, runTouchedFilesResponse{
+		WorkDir:  run.WorkDir,
+		Worktree: run.Worktree,
+		Files:    files,
+	})
+}
+
+// pathFromToolInput extracts the target path from a tool_started event's
+// persisted input. Three storage shapes exist (see model.persistToolPayload):
+// full inline (`data.input`), sidecar preview (`data.input_preview`, first
+// 4 KB + `input_ref`), and capped inline fallback (`data.input` truncated,
+// `input_size` present). The truncated shapes are handled by the lenient
+// parser; when the preview didn't carry the key, the sidecar blob's head
+// is read as a last resort.
+func pathFromToolInput(r *http.Request, blobs store.ToolBlobStore, runID string, e *store.Event, keys []string) string {
+	if raw, ok := e.Data["input"].(string); ok && raw != "" {
+		if p := pathFromJSONObject(raw, keys); p != "" {
+			return p
+		}
+	}
+	if raw, ok := e.Data["input_preview"].(string); ok && raw != "" {
+		if p := pathFromJSONObject(raw, keys); p != "" {
+			return p
+		}
+	}
+	if ref, ok := e.Data["input_ref"].(string); ok && ref != "" && blobs != nil {
+		data, _, _, err := blobs.ReadToolBlob(r.Context(), runID, ref, "input", 0, touchedBlobReadCap)
+		if err == nil {
+			if p := pathFromJSONObject(string(data), keys); p != "" {
+				return p
+			}
+		}
+	}
+	return ""
+}
+
+// pathFromJSONObject returns the first candidate key's top-level string
+// value from raw. Complete JSON goes through json.Unmarshal; anything
+// else (a preview cut mid-stream, a capped inline fallback) falls back to
+// a token walk that keeps every top-level string seen before the cut —
+// tool inputs put the target path in the leading bytes, so a truncated
+// prefix nearly always still carries it.
+func pathFromJSONObject(raw string, keys []string) string {
+	var m map[string]any
+	if err := json.Unmarshal([]byte(raw), &m); err == nil {
+		for _, k := range keys {
+			if s, ok := m[k].(string); ok && s != "" {
+				return s
+			}
+		}
+		return ""
+	}
+
+	found := make(map[string]string)
+	dec := json.NewDecoder(strings.NewReader(raw))
+	if tok, err := dec.Token(); err != nil {
+		return ""
+	} else if d, ok := tok.(json.Delim); !ok || d != '{' {
+		return ""
+	}
+scan:
+	for {
+		keyTok, err := dec.Token()
+		if err != nil {
+			break
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			break // object close (or malformed) — done with top level
+		}
+		valTok, err := dec.Token()
+		if err != nil {
+			break
+		}
+		switch v := valTok.(type) {
+		case string:
+			found[key] = v
+		case json.Delim:
+			// Nested object/array value — drain its tokens so the walk
+			// stays at the top level. A truncation inside the nested
+			// value surfaces as a token error: stop, keep what we have.
+			depth := 1
+			for depth > 0 {
+				t, err := dec.Token()
+				if err != nil {
+					break scan
+				}
+				if d, ok := t.(json.Delim); ok {
+					switch d {
+					case '{', '[':
+						depth++
+					case '}', ']':
+						depth--
+					}
+				}
+			}
+		}
+	}
+	for _, k := range keys {
+		if s := found[k]; s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+// normalizeTouchedPath maps a tool-input path onto the same namespace the
+// git /files listing uses: workdir-relative for anything inside
+// run.WorkDir, untouched (cleaned) otherwise. Tools receive absolute
+// paths from claude_code and usually workdir-relative ones from claw, so
+// both spellings of the same file must collapse to one key.
+func normalizeTouchedPath(workDir, p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	p = filepath.Clean(p)
+	if workDir != "" && filepath.IsAbs(p) {
+		if rel, err := filepath.Rel(workDir, p); err == nil &&
+			rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return rel
+		}
+	}
+	return p
+}

--- a/pkg/server/runs_files_touched_test.go
+++ b/pkg/server/runs_files_touched_test.go
@@ -1,0 +1,216 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// seedTouchedEvents appends the given events to an existing run through a
+// fresh store handle (same pattern as seedRun).
+func seedTouchedEvents(t *testing.T, srv *Server, runID string, events []store.Event) {
+	t.Helper()
+	st, err := store.New(srv.cfg.StoreDir)
+	if err != nil {
+		t.Fatalf("open seed store: %v", err)
+	}
+	for i, evt := range events {
+		if _, err := st.AppendEvent(context.Background(), runID, evt); err != nil {
+			t.Fatalf("seed event %d: %v", i, err)
+		}
+	}
+}
+
+func getTouched(t *testing.T, hs string, runID string) runTouchedFilesResponse {
+	t.Helper()
+	resp, err := http.Get(hs + "/api/runs/" + runID + "/files/touched")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var out runTouchedFilesResponse
+	decodeJSONResp(t, resp, &out)
+	return out
+}
+
+// TestRunTouchedFiles_Aggregation covers the core extraction: both tool
+// namespaces, path normalization (absolute-under-workdir → relative),
+// dedup with node attribution + write counts, and the exclusion of
+// read-only / shell tools.
+func TestRunTouchedFiles_Aggregation(t *testing.T) {
+	srv, hs := newTestServer(t)
+	workDir := t.TempDir()
+	seedRunWithWorkDir(t, srv, "touched", workDir, false)
+	seedTouchedEvents(t, srv, "touched", []store.Event{
+		// claude_code Write, absolute path under workdir → relative.
+		{Type: store.EventToolStarted, RunID: "touched", NodeID: "implement",
+			Data: map[string]any{"tool": "Write", "input": `{"file_path": "` + workDir + `/pkg/a.go", "content": "x"}`}},
+		// Same file edited again by another node → one row, two nodes, 2 writes.
+		{Type: store.EventToolStarted, RunID: "touched", NodeID: "fix",
+			Data: map[string]any{"tool": "Edit", "input": `{"file_path": "` + workDir + `/pkg/a.go", "old_string": "x", "new_string": "y"}`}},
+		// claw write_file with a workdir-relative path.
+		{Type: store.EventToolStarted, RunID: "touched", NodeID: "implement",
+			Data: map[string]any{"tool": "write_file", "input": `{"path": "docs/readme.md", "content": "hi"}`}},
+		// Path outside the workdir stays absolute.
+		{Type: store.EventToolStarted, RunID: "touched", NodeID: "report",
+			Data: map[string]any{"tool": "Write", "input": `{"file_path": "/tmp/elsewhere/report.md", "content": "r"}`}},
+		// Read-only + shell tools are ignored even with a path/command.
+		{Type: store.EventToolStarted, RunID: "touched", NodeID: "implement",
+			Data: map[string]any{"tool": "Read", "input": `{"file_path": "` + workDir + `/pkg/a.go"}`}},
+		{Type: store.EventToolStarted, RunID: "touched", NodeID: "implement",
+			Data: map[string]any{"tool": "Bash", "input": `{"command": "touch ` + workDir + `/pkg/b.go"}`}},
+		// tool_called (post-execution) events never carry input — ignored.
+		{Type: store.EventToolCalled, RunID: "touched", NodeID: "implement",
+			Data: map[string]any{"tool": "Write", "input_size": 12}},
+		// Degenerate paths (a tool_started fires before the tool errors):
+		// whitespace-only normalizes to "", the workdir itself to "." —
+		// neither may become a row.
+		{Type: store.EventToolStarted, RunID: "touched", NodeID: "implement",
+			Data: map[string]any{"tool": "Write", "input": `{"file_path": "   ", "content": "x"}`}},
+		{Type: store.EventToolStarted, RunID: "touched", NodeID: "implement",
+			Data: map[string]any{"tool": "Write", "input": `{"file_path": "` + workDir + `", "content": "x"}`}},
+	})
+
+	out := getTouched(t, hs.URL, "touched")
+	if out.WorkDir != workDir {
+		t.Errorf("WorkDir = %q, want %q", out.WorkDir, workDir)
+	}
+	if len(out.Files) != 3 {
+		t.Fatalf("files = %+v, want 3 entries", out.Files)
+	}
+	// Sorted by path: /tmp/... < docs/... < pkg/...
+	if out.Files[0].Path != "/tmp/elsewhere/report.md" {
+		t.Errorf("files[0].Path = %q", out.Files[0].Path)
+	}
+	if out.Files[1].Path != "docs/readme.md" {
+		t.Errorf("files[1].Path = %q", out.Files[1].Path)
+	}
+	f := out.Files[2]
+	if f.Path != "pkg/a.go" {
+		t.Errorf("files[2].Path = %q, want pkg/a.go", f.Path)
+	}
+	if f.Writes != 2 {
+		t.Errorf("pkg/a.go writes = %d, want 2", f.Writes)
+	}
+	if len(f.NodeIDs) != 2 || f.NodeIDs[0] != "implement" || f.NodeIDs[1] != "fix" {
+		t.Errorf("pkg/a.go node_ids = %v, want [implement fix]", f.NodeIDs)
+	}
+	if f.LastSeq <= 0 {
+		t.Errorf("pkg/a.go last_seq = %d, want > 0", f.LastSeq)
+	}
+}
+
+// TestRunTouchedFiles_TruncatedPreviewAndBlob covers the sidecar shapes: a
+// 4 KB preview cut mid-content still yields the path (lenient token walk),
+// and a preview that lost the key falls back to the sidecar blob head.
+func TestRunTouchedFiles_TruncatedPreviewAndBlob(t *testing.T) {
+	srv, hs := newTestServer(t)
+	workDir := t.TempDir()
+	seedRunWithWorkDir(t, srv, "trunc", workDir, false)
+
+	// Preview: valid prefix of a Write input, cut inside the content value.
+	preview := `{"file_path": "big/file.txt", "content": "` + strings.Repeat("a", 100)
+	// Blob-backed input whose preview carried no key at all; the full blob does.
+	blobInput := `{"content": "` + strings.Repeat("b", 200) + `", "file_path": "from/blob.txt"}`
+	st, err := store.New(srv.cfg.StoreDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.WriteToolBlob(context.Background(), "trunc", "tu-blob", "input", []byte(blobInput)); err != nil {
+		t.Fatalf("WriteToolBlob: %v", err)
+	}
+
+	seedTouchedEvents(t, srv, "trunc", []store.Event{
+		{Type: store.EventToolStarted, RunID: "trunc", NodeID: "n1",
+			Data: map[string]any{"tool": "Write", "input_preview": preview, "input_ref": "tu-x", "input_size": 9000}},
+		{Type: store.EventToolStarted, RunID: "trunc", NodeID: "n2",
+			Data: map[string]any{"tool": "Write", "input_preview": `{"content": "` + strings.Repeat("b", 40), "input_ref": "tu-blob", "input_size": len(blobInput)}},
+	})
+
+	out := getTouched(t, hs.URL, "trunc")
+	if len(out.Files) != 2 {
+		t.Fatalf("files = %+v, want 2 entries", out.Files)
+	}
+	if out.Files[0].Path != "big/file.txt" || out.Files[0].NodeIDs[0] != "n1" {
+		t.Errorf("files[0] = %+v, want big/file.txt from n1", out.Files[0])
+	}
+	if out.Files[1].Path != "from/blob.txt" || out.Files[1].NodeIDs[0] != "n2" {
+		t.Errorf("files[1] = %+v, want from/blob.txt from n2", out.Files[1])
+	}
+}
+
+// TestRunTouchedFiles_EmptyAndMissing: a run with no write events returns
+// an empty list; an unknown run 404s.
+func TestRunTouchedFiles_EmptyAndMissing(t *testing.T) {
+	srv, hs := newTestServer(t)
+	seedRun(t, srv, "quiet", "wf", store.RunStatusFinished)
+
+	out := getTouched(t, hs.URL, "quiet")
+	if len(out.Files) != 0 {
+		t.Errorf("files = %+v, want empty", out.Files)
+	}
+
+	resp, err := http.Get(hs.URL + "/api/runs/nope/files/touched")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// TestPathFromJSONObject exercises the lenient parser directly on the
+// shapes persistToolPayload produces.
+func TestPathFromJSONObject(t *testing.T) {
+	keys := []string{"path", "file_path"}
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"complete", `{"path": "a/b.txt", "content": "x"}`, "a/b.txt"},
+		{"complete second key", `{"file_path": "c.txt"}`, "c.txt"},
+		{"key priority", `{"file_path": "second.txt", "path": "first.txt"}`, "first.txt"},
+		{"truncated inside string", `{"path": "a/b.txt", "content": "aaaa`, "a/b.txt"},
+		{"truncated inside nested", `{"path": "a/b.txt", "edits": [{"old": "x", "new`, "a/b.txt"},
+		{"truncated before key", `{"content": "aaaa`, ""},
+		{"key after nested value", `{"meta": {"k": 1}, "path": "late.txt"}`, "late.txt"},
+		{"not an object", `["path"]`, ""},
+		{"empty", ``, ""},
+		{"non-string value", `{"path": 42, "file_path": "real.txt"}`, "real.txt"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pathFromJSONObject(tc.raw, keys); got != tc.want {
+				t.Errorf("pathFromJSONObject(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeTouchedPath covers the workdir-relativization rules.
+func TestNormalizeTouchedPath(t *testing.T) {
+	cases := []struct {
+		workDir, in, want string
+	}{
+		{"/w", "/w/a/b.txt", "a/b.txt"},
+		{"/w", "a/b.txt", "a/b.txt"},
+		{"/w", "./a/b.txt", "a/b.txt"},
+		{"/w", "/elsewhere/x.txt", "/elsewhere/x.txt"},
+		{"/w", "/w", "."},
+		{"", "/abs/x.txt", "/abs/x.txt"},
+		{"/w", "  /w/spaced.txt ", "spaced.txt"},
+		{"/w", "", ""},
+	}
+	for _, tc := range cases {
+		if got := normalizeTouchedPath(tc.workDir, tc.in); got != tc.want {
+			t.Errorf("normalizeTouchedPath(%q, %q) = %q, want %q", tc.workDir, tc.in, got, tc.want)
+		}
+	}
+}

--- a/studio/src/api/runs/files.ts
+++ b/studio/src/api/runs/files.ts
@@ -9,6 +9,7 @@ import type {
   RunFiles,
   RunFilesMode,
   RunHeader,
+  RunTouchedFiles,
 } from "./types";
 
 export async function listRunFiles(
@@ -21,6 +22,14 @@ export async function listRunFiles(
   return request(
     `/runs/${encodeURIComponent(runId)}/files${suffix ? `?${suffix}` : ""}`,
   );
+}
+
+// listTouchedFiles returns the files the run's LLM nodes wrote/edited,
+// with per-node attribution — derived from run events, not git. The
+// pipeline board uses it to scope (in-place runs) and annotate (all runs)
+// the produced-elements list.
+export async function listTouchedFiles(runId: string): Promise<RunTouchedFiles> {
+  return request(`/runs/${encodeURIComponent(runId)}/files/touched`);
 }
 
 export async function getRunFileDiff(

--- a/studio/src/api/runs/types.ts
+++ b/studio/src/api/runs/types.ts
@@ -737,9 +737,13 @@ export interface RunFile {
 //   - "branch": BaseCommit..HEAD range (commits introduced by the run).
 //   - "combined": union of branch + uncommitted, each file tagged with a
 //     `lifecycle`. The studio's default while a run is in progress.
+//   - "produced": "best available full picture" — combined while the
+//     working directory exists, then persisted/historical branch-range
+//     fallback instead of worktree_gone. Used by the pipeline board's
+//     Produced-elements panel.
 // Empty string means "let the backend pick the default" (the live
 // uncommitted view when a worktree exists, branch otherwise).
-export type RunFilesMode = "uncommitted" | "branch" | "combined" | "";
+export type RunFilesMode = "uncommitted" | "branch" | "combined" | "produced" | "";
 
 // Mirror of server.runFilesResponse. `available` is the gate: when
 // false, `reason` is one of "no_workdir" | "not_git_repo" |
@@ -770,6 +774,31 @@ export interface RunFiles {
     | "worktree_gone"
     | "building"
     | string;
+}
+
+// TouchedFile is one file the run's LLM nodes wrote/edited, derived from
+// the persisted tool_started events (mirror of server.touchedFile). Paths
+// are workdir-relative when the write landed inside run.WorkDir (same
+// namespace as RunFile.path), absolute otherwise.
+export interface TouchedFile {
+  path: string;
+  // Workflow nodes that wrote this path, in first-write order.
+  node_ids: string[];
+  // Number of write/edit tool calls that targeted this path.
+  writes: number;
+  // Event seq of the most recent write.
+  last_seq: number;
+}
+
+// Mirror of server.runTouchedFilesResponse
+// (GET /api/runs/{id}/files/touched). Unlike the git-based RunFiles view,
+// this is derived purely from run events: it only ever lists what the
+// nodes actually wrote — never ambient workspace state — and knows
+// nothing about files created by Bash commands or direct tool nodes.
+export interface RunTouchedFiles {
+  work_dir?: string;
+  worktree?: boolean;
+  files: TouchedFile[];
 }
 
 // Mirror of pkg/git.DiffPayload. before/after are nil for added/deleted

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -2007,6 +2007,25 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/runs/{id}/files/touched": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** GET /api/runs/{id}/files/touched */
+        get: operations["getRunsByIdFilesTouched"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/runs/{id}/fork": {
         parameters: {
             query?: never;
@@ -6858,6 +6877,26 @@ export interface operations {
         };
     };
     getRunsByIdFilesDiff: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getRunsByIdFilesTouched: {
         parameters: {
             query?: never;
             header?: never;

--- a/studio/src/views/PipelineBoard/ProducedElements.tsx
+++ b/studio/src/views/PipelineBoard/ProducedElements.tsx
@@ -9,6 +9,7 @@ import {
   ExternalLinkIcon,
   FileIcon,
   FileTextIcon,
+  GearIcon,
   ImageIcon,
   ReloadIcon,
   SpeakerLoudIcon,
@@ -20,6 +21,7 @@ import {
   artifactFileURL,
   listArtifactFiles,
   listRunFiles,
+  listTouchedFiles,
   type RunFile,
   type RunFilesMode,
 } from "@/api/runs";
@@ -28,7 +30,11 @@ import { usePreview, type PreviewState } from "@/components/Runs/usePreview";
 import { formatBytes, formatRelative } from "@/lib/format";
 
 import { producedKindLabel, type ProducedFileKind } from "./fileKind";
-import { aggregateProducedItems, type ProducedItem } from "./producedItems";
+import {
+  aggregateProducedItems,
+  type ProducedItem,
+  type RunProducedSource,
+} from "./producedItems";
 
 // Monaco diff, loaded on click only — keeps the pipelines route chunk slim.
 const FileDiffDialog = lazy(() => import("@/components/Runs/FileDiffDialog"));
@@ -75,9 +81,12 @@ interface Props {
 
 // ProducedElements lists everything a pipeline (root + sub-bots) has produced
 // so far — the files written into each run's artifact area (previewable/
-// downloadable) plus the source files it added/modified in its worktree
-// (linked to that run's console). It polls while the pipeline is live so new
-// outputs appear as they land.
+// downloadable) plus the files its NODES added/modified (linked to that
+// run's console). Three feeds per run: the artifact manifest, the git view
+// (mode=produced — combined live, branch-range after finalization), and the
+// event-derived touched list that scopes in-place runs to what the nodes
+// actually wrote and attributes every row to its writing node(s). It polls
+// while the pipeline is live so new outputs appear as they land.
 export function ProducedElements({ runIds, status }: Props) {
   const polling = !status || !TERMINAL.has(status);
   const effectiveRunIds = runIds.slice(0, MAX_TREE_RUNS);
@@ -87,7 +96,7 @@ export function ProducedElements({ runIds, status }: Props) {
   const fileQueries = useQueries({
     queries: effectiveRunIds.map((id) => ({
       queryKey: ["pipeline-produced-files", id],
-      queryFn: () => listRunFiles(id, { mode: "combined" as const }),
+      queryFn: () => listRunFiles(id, { mode: "produced" as const }),
       refetchInterval: polling ? POLL_INTERVAL_MS : (false as const),
       refetchIntervalInBackground: false,
       retry: false,
@@ -102,12 +111,26 @@ export function ProducedElements({ runIds, status }: Props) {
       retry: false,
     })),
   });
+  const touchedQueries = useQueries({
+    queries: effectiveRunIds.map((id) => ({
+      queryKey: ["pipeline-produced-touched", id],
+      queryFn: () => listTouchedFiles(id),
+      refetchInterval: polling ? POLL_INTERVAL_MS : (false as const),
+      refetchIntervalInBackground: false,
+      retry: false,
+    })),
+  });
 
-  const items = aggregateProducedItems(
-    effectiveRunIds,
-    fileQueries.map((q) => q.data?.files),
-    artifactQueries.map((q) => q.data),
-  );
+  const sources: RunProducedSource[] = effectiveRunIds.map((id, i) => ({
+    runId: id,
+    files: fileQueries[i]?.data?.files,
+    filesAvailable: fileQueries[i]?.data?.available,
+    workDir: fileQueries[i]?.data?.work_dir,
+    worktree: fileQueries[i]?.data?.worktree,
+    touched: touchedQueries[i]?.data?.files,
+    artifacts: artifactQueries[i]?.data,
+  }));
+  const items = aggregateProducedItems(sources);
 
   const { preview, openPreview, closePreview } = usePreview(effectiveRunIds[0] ?? null);
   // The run + media kind of the open preview — the download link must target
@@ -124,13 +147,23 @@ export function ProducedElements({ runIds, status }: Props) {
   const [diffTarget, setDiffTarget] = useState<DiffTarget | null>(null);
 
   const loading =
-    fileQueries.some((q) => q.isLoading) || artifactQueries.some((q) => q.isLoading);
+    fileQueries.some((q) => q.isLoading) ||
+    artifactQueries.some((q) => q.isLoading) ||
+    touchedQueries.some((q) => q.isLoading);
   const fetching =
-    fileQueries.some((q) => q.isFetching) || artifactQueries.some((q) => q.isFetching);
+    fileQueries.some((q) => q.isFetching) ||
+    artifactQueries.some((q) => q.isFetching) ||
+    touchedQueries.some((q) => q.isFetching);
   const building = fileQueries.some((q) => q.data?.reason === "building");
+  // A failed feed silently shrinks the list (retry is off), so surface it.
+  const partialData =
+    fileQueries.some((q) => q.isError) ||
+    artifactQueries.some((q) => q.isError) ||
+    touchedQueries.some((q) => q.isError);
   const refresh = () => {
     fileQueries.forEach((q) => void q.refetch());
     artifactQueries.forEach((q) => void q.refetch());
+    touchedQueries.forEach((q) => void q.refetch());
   };
 
   return (
@@ -160,6 +193,12 @@ export function ProducedElements({ runIds, status }: Props) {
         <p className="text-micro text-warning-fg">
           Showing outputs for the first {MAX_TREE_RUNS} of {runIds.length} runs in
           this pipeline; {truncatedRuns} more are not shown.
+        </p>
+      )}
+
+      {partialData && (
+        <p className="text-micro text-warning-fg">
+          Some run data failed to load — this list may be incomplete.
         </p>
       )}
 
@@ -275,6 +314,11 @@ function ProducedRow({
     ? item.path.slice(0, item.path.lastIndexOf("/"))
     : "";
   const consoleHref = `/runs/${encodeURIComponent(item.runId)}`;
+  // A touched-only row (no git counterpart: status undefined) has nothing
+  // the diff endpoint can render — an in-place already-committed file
+  // diffs to two identical panes, and an out-of-workdir absolute path is
+  // rejected outright (400 "path must be relative"). No Diff affordance.
+  const diffable = item.source === "change" && item.status !== undefined;
 
   return (
     <li className="flex items-center gap-2 rounded-md border border-border-subtle bg-surface-2/40 px-2 py-1.5">
@@ -289,7 +333,7 @@ function ProducedRow({
           >
             {item.name}
           </button>
-        ) : (
+        ) : diffable ? (
           <button
             type="button"
             onClick={onDiff}
@@ -298,6 +342,13 @@ function ProducedRow({
           >
             {item.name}
           </button>
+        ) : (
+          <span
+            title={label}
+            className="block max-w-full truncate text-left text-xs font-medium text-fg-default"
+          >
+            {item.name}
+          </span>
         )}
         <div className="flex items-center gap-1.5 text-micro text-fg-subtle">
           {item.source === "artifact" ? (
@@ -316,7 +367,10 @@ function ProducedRow({
                   {dir}
                 </span>
               )}
-              {!item.binary && (
+              {/* +/- counts come from the git channel; a touched-only row
+                  (status undefined — e.g. an in-place run's already
+                  committed edit) has none to show. */}
+              {!item.binary && item.status !== undefined && (
                 <span className="tabular-nums">
                   <span className="text-success-fg">+{item.added ?? 0}</span>
                   <span className="text-fg-subtle"> </span>
@@ -324,6 +378,18 @@ function ProducedRow({
                 </span>
               )}
               {item.binary && <span>(binary)</span>}
+              {item.nodes && item.nodes.length > 0 && (
+                <span
+                  className="inline-flex min-w-0 items-center gap-0.5"
+                  title={`Written by node${item.nodes.length > 1 ? "s" : ""}: ${item.nodes.join(", ")}`}
+                >
+                  <GearIcon className="h-3 w-3 shrink-0" aria-hidden />
+                  <span className="truncate font-mono">
+                    {item.nodes.slice(0, 2).join(", ")}
+                    {item.nodes.length > 2 ? ` +${item.nodes.length - 2}` : ""}
+                  </span>
+                </span>
+              )}
             </>
           )}
           {multiRun && (
@@ -353,9 +419,11 @@ function ProducedRow({
         </div>
       ) : (
         <div className="flex shrink-0 items-center gap-1">
-          <Button variant="ghost" size="sm" onClick={onDiff}>
-            Diff
-          </Button>
+          {diffable && (
+            <Button variant="ghost" size="sm" onClick={onDiff}>
+              Diff
+            </Button>
+          )}
           <Link
             href={consoleHref}
             aria-label={`Open ${item.name} in the run console`}

--- a/studio/src/views/PipelineBoard/producedItems.test.ts
+++ b/studio/src/views/PipelineBoard/producedItems.test.ts
@@ -1,57 +1,87 @@
 import { describe, expect, it } from "vitest";
 
-import type { RunFile } from "@/api/runs";
+import type { RunFile, TouchedFile } from "@/api/runs";
 
-import { aggregateProducedItems, mergeProducedItems } from "./producedItems";
+import { aggregateProducedItems, type RunProducedSource } from "./producedItems";
 
 function file(partial: Partial<RunFile> & { path: string }): RunFile {
   return { status: "A", added: 0, deleted: 0, ...partial };
 }
 
-describe("mergeProducedItems", () => {
-  it("lists artifacts NEWEST first, then worktree changes by path", () => {
-    const items = mergeProducedItems(
-      [file({ path: "src/b.ts" }), file({ path: "src/a.ts" })],
-      [
-        { path: "renders/old.png", size: 5, modified_at: "2026-07-15T00:00:00Z" },
-        { path: "renders/new.mp4", size: 10, modified_at: "2026-07-15T09:30:00Z" },
-      ],
-      "run-1",
-    );
-    // The freshest output leads — it's the one a pending review is about.
-    expect(items.map((i) => i.path)).toEqual([
-      "renders/new.mp4",
-      "renders/old.png",
-      "src/a.ts",
-      "src/b.ts",
+function touched(path: string, ...nodeIds: string[]): TouchedFile {
+  return { path, node_ids: nodeIds, writes: 1, last_seq: 1 };
+}
+
+// A worktree-isolated run whose git channel answered: git is authoritative.
+function worktreeRun(partial: Partial<RunProducedSource> & { runId: string }): RunProducedSource {
+  return {
+    workDir: `/wt/${partial.runId}`,
+    worktree: true,
+    filesAvailable: true,
+    ...partial,
+  };
+}
+
+// An in-place run (no isolated worktree): git rows are gated on touched.
+function inPlaceRun(partial: Partial<RunProducedSource> & { runId: string }): RunProducedSource {
+  return {
+    workDir: "/workspace",
+    worktree: false,
+    filesAvailable: true,
+    ...partial,
+  };
+}
+
+describe("aggregateProducedItems — ordering & channels", () => {
+  it("lists artifacts NEWEST first across runs, then change rows by path", () => {
+    const items = aggregateProducedItems([
+      worktreeRun({
+        runId: "run-root",
+        files: [file({ path: "src/b.ts" }), file({ path: "src/a.ts" })],
+        artifacts: [
+          { path: "renders/old.png", size: 5, modified_at: "2026-07-15T00:00:00Z" },
+        ],
+      }),
+      worktreeRun({
+        runId: "run-child",
+        files: [file({ path: "child.py" })],
+        artifacts: [
+          { path: "renders/new.mp4", size: 10, modified_at: "2026-07-15T09:30:00Z" },
+        ],
+      }),
     ]);
-    expect(items.map((i) => i.source)).toEqual([
-      "artifact",
-      "artifact",
-      "change",
-      "change",
+    expect(items.map((i) => `${i.source}:${i.path}`)).toEqual([
+      "artifact:renders/new.mp4",
+      "artifact:renders/old.png",
+      "change:child.py",
+      "change:src/a.ts",
+      "change:src/b.ts",
     ]);
-    expect(items.every((i) => i.runId === "run-1")).toBe(true);
   });
 
-  it("ties on equal timestamps fall back to path order", () => {
-    const items = mergeProducedItems(
-      [],
-      [
-        { path: "b.png", size: 1, modified_at: "2026-07-15T00:00:00Z" },
-        { path: "a.png", size: 1, modified_at: "2026-07-15T00:00:00Z" },
-      ],
-      "run-1",
-    );
+  it("artifact ties on equal timestamps fall back to path order", () => {
+    const items = aggregateProducedItems([
+      worktreeRun({
+        runId: "run-1",
+        artifacts: [
+          { path: "b.png", size: 1, modified_at: "2026-07-15T00:00:00Z" },
+          { path: "a.png", size: 1, modified_at: "2026-07-15T00:00:00Z" },
+        ],
+      }),
+    ]);
     expect(items.map((i) => i.path)).toEqual(["a.png", "b.png"]);
   });
 
   it("classifies each item and carries its channel metadata", () => {
-    const [artifact, change] = mergeProducedItems(
-      [file({ path: "main.go", status: "M", added: 12, deleted: 3, lifecycle: "committed" })],
-      [{ path: "song.wav", size: 2048, modified_at: "2026-07-15T00:00:00Z" }],
-      "run-1",
-    );
+    const [artifact, change] = aggregateProducedItems([
+      worktreeRun({
+        runId: "run-1",
+        files: [
+          file({ path: "main.go", status: "M", added: 12, deleted: 3, lifecycle: "committed" }),
+        ],
+        artifacts: [{ path: "song.wav", size: 2048, modified_at: "2026-07-15T00:00:00Z" }],
+      }),
+    ]);
     expect(artifact).toMatchObject({
       source: "artifact",
       kind: "audio",
@@ -72,55 +102,192 @@ describe("mergeProducedItems", () => {
   });
 
   it("drops pure deletions — a removed file is not produced", () => {
-    const items = mergeProducedItems(
-      [file({ path: "gone.ts", status: "D" }), file({ path: "kept.ts", status: "A" })],
-      [],
-      "run-1",
-    );
+    const items = aggregateProducedItems([
+      worktreeRun({
+        runId: "run-1",
+        files: [file({ path: "gone.ts", status: "D" }), file({ path: "kept.ts" })],
+      }),
+    ]);
     expect(items.map((i) => i.path)).toEqual(["kept.ts"]);
   });
 
-  it("handles missing channels", () => {
-    expect(mergeProducedItems(undefined, undefined, "run-1")).toEqual([]);
-    expect(mergeProducedItems([], [], "run-1")).toEqual([]);
-  });
-
-  it("scopes keys by run so the same path across runs stays distinct", () => {
-    const keys = [
-      ...mergeProducedItems([file({ path: "shared.txt" })], [], "run-a"),
-      ...mergeProducedItems([file({ path: "shared.txt" })], [], "run-b"),
-    ].map((i) => i.key);
-    expect(new Set(keys).size).toBe(keys.length);
-    expect(keys).toEqual(["change:run-a:shared.txt", "change:run-b:shared.txt"]);
+  it("tolerates still-loading / errored run slots (undefined channels)", () => {
+    const items = aggregateProducedItems([
+      worktreeRun({ runId: "run-root", files: [file({ path: "root.go" })] }),
+      { runId: "run-child" },
+    ]);
+    expect(items.map((i) => i.path)).toEqual(["root.go"]);
+    expect(aggregateProducedItems([])).toEqual([]);
   });
 });
 
-describe("aggregateProducedItems", () => {
-  it("merges every run in the tree, freshest artifact first across runs", () => {
-    const items = aggregateProducedItems(
-      ["run-root", "run-child"],
-      [[file({ path: "root.go" })], [file({ path: "child.py" })]],
-      [
-        // The root's artifact is NEWER than the child's — it must lead even
-        // though the root comes first in the tree and "r" sorts after "c".
-        [{ path: "root.png", size: 1, modified_at: "2026-07-15T10:00:00Z" }],
-        [{ path: "child.mp3", size: 2, modified_at: "2026-07-15T08:00:00Z" }],
-      ],
-    );
-    expect(items.map((i) => `${i.source}:${i.runId}:${i.path}`)).toEqual([
-      "artifact:run-root:root.png",
-      "artifact:run-child:child.mp3",
-      "change:run-child:child.py",
-      "change:run-root:root.go",
+describe("aggregateProducedItems — in-place trust gate", () => {
+  it("drops git rows no node wrote (ambient operator state) for in-place runs", () => {
+    const items = aggregateProducedItems([
+      inPlaceRun({
+        runId: "run-1",
+        files: [
+          // The operator's own pre-existing dirty file — must NOT show.
+          file({ path: "operator-wip.ts", status: "M", added: 9, deleted: 9 }),
+          // Written by a node — kept, with real git counts.
+          file({ path: "src/feature.ts", status: "M", added: 4, deleted: 1, lifecycle: "uncommitted" }),
+        ],
+        touched: [touched("src/feature.ts", "implement")],
+      }),
     ]);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      path: "src/feature.ts",
+      status: "M",
+      added: 4,
+      deleted: 1,
+      nodes: ["implement"],
+    });
   });
 
-  it("tolerates still-loading / errored run slots (undefined data)", () => {
-    const items = aggregateProducedItems(
-      ["run-root", "run-child"],
-      [[file({ path: "root.go" })], undefined],
-      [undefined, [{ path: "child.mp3", size: 2, modified_at: "2026-07-15T00:00:00Z" }]],
-    );
-    expect(items.map((i) => i.path)).toEqual(["child.mp3", "root.go"]);
+  it("keeps touched-only rows (e.g. already committed in place) without git counts", () => {
+    const items = aggregateProducedItems([
+      inPlaceRun({
+        runId: "run-1",
+        files: [], // committed → no longer in git status
+        touched: [touched("docs/spec.md", "write_docs")],
+      }),
+    ]);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      path: "docs/spec.md",
+      runId: "run-1",
+      source: "change",
+      nodes: ["write_docs"],
+    });
+    expect(items[0]?.status).toBeUndefined();
+    expect(items[0]?.added).toBeUndefined();
+  });
+
+  it("shows nothing for an in-place run with no touched data (never the raw git status)", () => {
+    const items = aggregateProducedItems([
+      inPlaceRun({
+        runId: "run-1",
+        files: [file({ path: "operator-wip.ts", status: "M" })],
+      }),
+    ]);
+    expect(items).toEqual([]);
+  });
+
+  it("keeps all git rows for worktree runs, annotated with nodes where known", () => {
+    const items = aggregateProducedItems([
+      worktreeRun({
+        runId: "run-1",
+        files: [
+          file({ path: "by-node.ts", lifecycle: "uncommitted" }),
+          file({ path: "by-bash.sh", lifecycle: "uncommitted" }), // written via Bash — no touched entry
+        ],
+        touched: [touched("by-node.ts", "implement", "fix")],
+      }),
+    ]);
+    expect(items.map((i) => i.path)).toEqual(["by-bash.sh", "by-node.ts"]);
+    expect(items[0]?.nodes).toBeUndefined();
+    expect(items[1]?.nodes).toEqual(["implement", "fix"]);
+  });
+
+  it("falls back to touched rows when a worktree run's git channel is unavailable", () => {
+    // Cloud run mid-flight: worktree=true but the server pod has neither
+    // the worktree nor a gitmeta snapshot (available=false, "building").
+    const items = aggregateProducedItems([
+      worktreeRun({
+        runId: "run-1",
+        files: undefined,
+        filesAvailable: false,
+        touched: [touched("src/feature.ts", "implement")],
+      }),
+    ]);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      path: "src/feature.ts",
+      nodes: ["implement"],
+    });
+    expect(items[0]?.status).toBeUndefined();
+  });
+
+  it("suppresses touched rows for paths git reports deleted", () => {
+    const items = aggregateProducedItems([
+      inPlaceRun({
+        runId: "run-1",
+        files: [file({ path: "scratch-notes.md", status: "D" })],
+        touched: [touched("scratch-notes.md", "write_notes"), touched("kept.md", "write_notes")],
+      }),
+    ]);
+    expect(items.map((i) => i.path)).toEqual(["kept.md"]);
+  });
+});
+
+describe("aggregateProducedItems — shared-workdir dedupe", () => {
+  it("dedupes a path across runs sharing one working directory", () => {
+    const shared = { workDir: "/wt/pipeline", worktree: true, filesAvailable: true };
+    const items = aggregateProducedItems([
+      { runId: "run-parent", ...shared, files: [file({ path: "shared.txt", lifecycle: "uncommitted" })] },
+      {
+        runId: "run-child",
+        ...shared,
+        files: [file({ path: "shared.txt", lifecycle: "uncommitted" })],
+        touched: [touched("shared.txt", "child_node")],
+      },
+    ]);
+    expect(items).toHaveLength(1);
+    expect(items[0]?.nodes).toEqual(["child_node"]);
+  });
+
+  it("a committed row keeps the run whose branch range recorded it", () => {
+    const shared = { workDir: "/wt/pipeline", worktree: true, filesAvailable: true };
+    const items = aggregateProducedItems([
+      { runId: "run-parent", ...shared, files: [] },
+      {
+        runId: "run-child",
+        ...shared,
+        files: [file({ path: "committed.go", status: "M", lifecycle: "committed" })],
+      },
+    ]);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ runId: "run-child", lifecycle: "committed" });
+  });
+
+  it("prefers the uncommitted entry on a lifecycle collision across runs", () => {
+    const shared = { workDir: "/wt/pipeline", worktree: true, filesAvailable: true };
+    const items = aggregateProducedItems([
+      {
+        runId: "run-parent",
+        ...shared,
+        files: [file({ path: "hot.ts", status: "M", added: 1, deleted: 0, lifecycle: "committed" })],
+      },
+      {
+        runId: "run-child",
+        ...shared,
+        files: [file({ path: "hot.ts", status: "M", added: 7, deleted: 2, lifecycle: "uncommitted" })],
+      },
+    ]);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      runId: "run-child",
+      lifecycle: "uncommitted",
+      added: 7,
+      deleted: 2,
+    });
+  });
+
+  it("keeps distinct working directories separate (distinct keys, both rows)", () => {
+    const items = aggregateProducedItems([
+      worktreeRun({ runId: "run-a", files: [file({ path: "same.txt" })] }),
+      worktreeRun({ runId: "run-b", files: [file({ path: "same.txt" })] }),
+    ]);
+    expect(items).toHaveLength(2);
+    expect(new Set(items.map((i) => i.key)).size).toBe(2);
+  });
+
+  it("groups by run id while workDir is unknown (files query still loading)", () => {
+    const items = aggregateProducedItems([
+      { runId: "run-a", worktree: true, filesAvailable: true, files: [file({ path: "x.txt" })] },
+      { runId: "run-b", worktree: true, filesAvailable: true, files: [file({ path: "x.txt" })] },
+    ]);
+    expect(items).toHaveLength(2);
   });
 });

--- a/studio/src/views/PipelineBoard/producedItems.ts
+++ b/studio/src/views/PipelineBoard/producedItems.ts
@@ -1,18 +1,32 @@
-// Pure merge of a run's two output channels into one "produced elements"
-// list for the pipeline board sidebar:
+// Pure merge of a pipeline tree's output channels into one "produced
+// elements" list for the pipeline board sidebar:
 //
 //   - artifact files — arbitrary binaries/text a tool wrote into
 //     $ITERION_ARTIFACT_FILES_DIR (renders, SBOMs, generated media). These
 //     are the designed "outputs" area and are previewable/downloadable.
-//   - worktree changes — files the run added/modified in its git worktree
-//     (source code, committed assets), from the combined git-status+branch
-//     diff. Pure deletions are NOT produced elements and are dropped.
+//   - worktree changes — files added/modified in the run's working
+//     directory, from /files?mode=produced (combined git view while the
+//     worktree lives, branch-range fallback after finalization). Pure
+//     deletions are NOT produced elements and are dropped.
+//   - touched files — files the run's LLM nodes wrote/edited, derived from
+//     tool_started events (/files/touched). This channel carries the
+//     per-node attribution and is the trust anchor for runs that executed
+//     in place.
 //
-// The two channels live in disjoint path namespaces (artifact-area-relative
-// vs worktree-relative), so no cross-channel de-duplication is needed. The
-// component layer owns fetching + rendering; this module owns only the shape.
+// The git channel is only equal to "what the pipeline produced" when the
+// run executed in an isolated worktree. For an in-place run (worktree:
+// none, non-git workspace) `git status` also reports the operator's own
+// pre-existing dirty files — so for those runs the git rows are gated on
+// the touched set (a git row nobody's node wrote is ambient workspace
+// state, not a produced element), and touched-only rows (e.g. files the
+// run already committed) are added bare.
+//
+// Runs sharing one working directory (a parent and its sub-bots in the
+// same worktree) are deduped to one row per path, attributed to every
+// node that wrote it; the artifact channel stays per-run (artifact areas
+// are run-scoped by construction).
 
-import type { ArtifactFile, RunFile } from "@/api/runs";
+import type { ArtifactFile, RunFile, TouchedFile } from "@/api/runs";
 
 import { classifyProducedFile, type ProducedFileKind } from "./fileKind";
 
@@ -20,7 +34,8 @@ export interface ProducedItem {
   // Stable React key, unique across both channels and every run in the tree.
   key: string;
   // The run in the pipeline tree that produced this element (the root or a
-  // sub-bot). Drives preview / download / console-link targeting.
+  // sub-bot). Drives preview / download / console-link targeting; for a
+  // committed change row it is the run whose branch range contains it.
   runId: string;
   // Slash-separated display path within its channel.
   path: string;
@@ -33,12 +48,38 @@ export interface ProducedItem {
   size?: number;
   modifiedAt?: string;
 
-  // change-only
+  // change-only. `status` is undefined for a touched-only row (no git
+  // counterpart — e.g. an in-place run's already-committed edit); the UI
+  // hides the +/- counters for those.
   status?: string;
   added?: number;
   deleted?: number;
   binary?: boolean;
   lifecycle?: "committed" | "uncommitted";
+  // Workflow nodes that wrote this file (from the touched channel), in
+  // first-write order. Undefined when no attribution is known.
+  nodes?: string[];
+}
+
+// RunProducedSource is one run's fetched output channels, positionally
+// assembled by the component layer. Any field may be undefined while its
+// query is loading/errored — a missing channel contributes nothing.
+export interface RunProducedSource {
+  runId: string;
+  // /files?mode=produced
+  files?: RunFile[];
+  // The /files response's `available` flag: true when the git channel
+  // actually answered with a file list. A worktree run whose git view is
+  // unavailable (cloud run mid-flight → reason "building", errored query)
+  // must fall back to the touched channel rather than trusting an empty
+  // git set and showing nothing.
+  filesAvailable?: boolean;
+  workDir?: string;
+  worktree?: boolean;
+  // /files/touched
+  touched?: TouchedFile[];
+  // /artifact-files
+  artifacts?: ArtifactFile[];
 }
 
 function basename(path: string): string {
@@ -57,75 +98,137 @@ function artifactRecency(a: ProducedItem, b: ProducedItem): number {
   return a.path.localeCompare(b.path) || a.runId.localeCompare(b.runId);
 }
 
-// mergeProducedItems folds one run's artifact-file manifest and worktree
-// change list into an ordered list: artifacts first (the explicit outputs,
-// NEWEST first), then worktree additions/modifications sorted by path (git
-// reports no per-file mtime). A worktree entry whose status is a pure
-// deletion ("D") is excluded — a removed file is not something the pipeline
-// produced. `runId` is the owning run so keys stay unique when several runs
-// in a tree are merged together.
-export function mergeProducedItems(
-  files: RunFile[] | undefined,
-  artifacts: ArtifactFile[] | undefined,
-  runId: string,
-): ProducedItem[] {
-  const out: ProducedItem[] = [];
+function artifactItems(s: RunProducedSource): ProducedItem[] {
+  return (s.artifacts ?? []).map((a) => ({
+    key: `artifact:${s.runId}:${a.path}`,
+    runId: s.runId,
+    path: a.path,
+    name: basename(a.path),
+    kind: classifyProducedFile(a.path),
+    source: "artifact" as const,
+    size: a.size,
+    modifiedAt: a.modified_at,
+  }));
+}
 
-  const arts = [...(artifacts ?? [])].sort(
-    (a, b) =>
-      (b.modified_at ?? "").localeCompare(a.modified_at ?? "") ||
-      a.path.localeCompare(b.path),
-  );
-  for (const a of arts) {
-    out.push({
-      key: `artifact:${runId}:${a.path}`,
-      runId,
-      path: a.path,
-      name: basename(a.path),
-      kind: classifyProducedFile(a.path),
-      source: "artifact",
-      size: a.size,
-      modifiedAt: a.modified_at,
-    });
-  }
+interface GitEntry {
+  runId: string;
+  file: RunFile;
+}
 
-  const changes = (files ?? [])
-    .filter((f) => f.status !== "D")
-    .sort((a, b) => a.path.localeCompare(b.path));
-  for (const f of changes) {
-    out.push({
-      key: `change:${runId}:${f.path}`,
-      runId,
-      path: f.path,
-      name: basename(f.path),
-      kind: classifyProducedFile(f.path),
-      source: "change",
-      status: f.status,
-      added: f.added,
-      deleted: f.deleted,
-      binary: f.binary,
-      lifecycle: f.lifecycle,
-    });
-  }
+interface TouchAcc {
+  nodes: string[];
+  // First run (tree order) whose nodes wrote the path — the console/diff
+  // target for a touched-only row.
+  runId: string;
+}
 
-  return out;
+interface WorkdirGroup {
+  // True when at least one run in the group executed in an isolated
+  // worktree: every git row is then the pipeline's own work. False =
+  // in-place execution, where git status includes ambient operator state
+  // and rows must be gated on the touched set.
+  trusted: boolean;
+  // True when at least one run's git channel answered (available=true).
+  // A trusted group without a delivered git view falls back to touched
+  // rows instead of rendering an empty list.
+  gitDelivered: boolean;
+  git: Map<string, GitEntry[]>;
+  touched: Map<string, TouchAcc>;
+  // Paths git reported as pure deletions ("D"): dropped from the git
+  // rows AND used to suppress touched rows for files that no longer
+  // exist — a removed file is not produced.
+  deleted: Set<string>;
 }
 
 // aggregateProducedItems merges every run in a pipeline tree into one list,
-// then orders it globally: artifacts first, NEWEST first (across runs — the
+// ordered globally: artifacts first, NEWEST first (across runs — the
 // freshest output is the one a pending review is usually about), then
-// worktree changes by path (git reports no per-file mtime). Per-run results
-// arrive positionally aligned with `runIds` (index i = runIds[i]); a missing
-// slot (still loading / errored) contributes nothing.
-export function aggregateProducedItems(
-  runIds: string[],
-  files: Array<RunFile[] | undefined>,
-  artifacts: Array<ArtifactFile[] | undefined>,
-): ProducedItem[] {
+// change rows by path (git reports no per-file mtime).
+export function aggregateProducedItems(sources: RunProducedSource[]): ProducedItem[] {
   const all: ProducedItem[] = [];
-  runIds.forEach((runId, i) => {
-    all.push(...mergeProducedItems(files[i], artifacts[i], runId));
-  });
+  for (const s of sources) all.push(...artifactItems(s));
+
+  // Group the change channels by working directory so a parent and its
+  // sub-bots sharing one worktree yield one row per path instead of one
+  // per run. Runs whose workDir is still unknown (files query loading)
+  // group by run id — a transient, self-correcting split.
+  const groups = new Map<string, WorkdirGroup>();
+  for (const s of sources) {
+    const key = s.workDir ? `dir:${s.workDir}` : `run:${s.runId}`;
+    let g = groups.get(key);
+    if (!g) {
+      g = {
+        trusted: false,
+        gitDelivered: false,
+        git: new Map(),
+        touched: new Map(),
+        deleted: new Set(),
+      };
+      groups.set(key, g);
+    }
+    if (s.worktree === true) g.trusted = true;
+    if (s.filesAvailable === true) g.gitDelivered = true;
+    for (const f of s.files ?? []) {
+      if (f.status === "D") {
+        g.deleted.add(f.path); // a removed file is not produced
+        continue;
+      }
+      const entries = g.git.get(f.path);
+      if (entries) entries.push({ runId: s.runId, file: f });
+      else g.git.set(f.path, [{ runId: s.runId, file: f }]);
+    }
+    for (const t of s.touched ?? []) {
+      let acc = g.touched.get(t.path);
+      if (!acc) {
+        acc = { nodes: [], runId: s.runId };
+        g.touched.set(t.path, acc);
+      }
+      for (const n of t.node_ids ?? []) {
+        if (!acc.nodes.includes(n)) acc.nodes.push(n);
+      }
+    }
+  }
+
+  for (const [key, g] of groups) {
+    // Trusted (worktree) groups with a delivered git view: git is
+    // authoritative — touched only annotates. Everything else (in-place
+    // execution, or a worktree whose git channel is unavailable — e.g. a
+    // cloud run mid-flight) falls back to the touched set: only paths
+    // some node actually wrote qualify, minus paths git reports deleted;
+    // git enriches survivors with real +/- counts when present.
+    const paths =
+      g.trusted && g.gitDelivered
+        ? [...g.git.keys()]
+        : [...g.touched.keys()].filter((p) => !g.deleted.has(p));
+    for (const path of paths) {
+      const entries = g.git.get(path) ?? [];
+      // The uncommitted entry wins on collision (mirrors the server's
+      // combined-mode rule): it reflects the in-flight state, and its
+      // owning run's uncommitted diff is valid from any run sharing the
+      // directory. A committed row must keep the run whose branch range
+      // recorded it, or the diff link would miss.
+      const chosen =
+        entries.find((e) => e.file.lifecycle !== "committed") ?? entries[0];
+      const touch = g.touched.get(path);
+      const f = chosen?.file;
+      all.push({
+        key: `change:${key}:${path}`,
+        runId: chosen?.runId ?? touch?.runId ?? "",
+        path,
+        name: basename(path),
+        kind: classifyProducedFile(path),
+        source: "change",
+        status: f?.status,
+        added: f?.added,
+        deleted: f?.deleted,
+        binary: f?.binary,
+        lifecycle: f?.lifecycle,
+        nodes: touch && touch.nodes.length > 0 ? touch.nodes : undefined,
+      });
+    }
+  }
+
   all.sort((a, b) => {
     if (a.source !== b.source) return a.source === "artifact" ? -1 : 1;
     if (a.source === "artifact") return artifactRecency(a, b);


### PR DESCRIPTION
## Problem

The pipeline board's **Produced elements** panel sourced its change list from `GET /api/runs/{id}/files?mode=combined`. For a run **without an isolated worktree** (`worktree: none`, non-git workspace) that degrades to a plain `git status` of the operator's live workspace:

- the operator's own pre-existing dirty files showed up as pipeline outputs;
- nothing was attributed to the nodes that actually did the work;
- in-place runs that *committed* lost those files from the list entirely (no `BaseCommit` → no branch range);
- finished worktree runs lost their whole list once the engine gc'd the worktree (`worktree_gone`);
- runs sharing one worktree (parent + sub-bots) repeated every file once per run.

## Change

**Server**
- New `GET /api/runs/{id}/files/touched` ([pkg/server/runs_files_touched.go](../blob/feat/pipeline-produced-elements/pkg/server/runs_files_touched.go)): the files the run's LLM nodes wrote/edited, derived from persisted `tool_started` events — per-node attribution, write counts, workdir-relative normalization. Covers both tool namespaces (`Write`/`Edit`/`MultiEdit`/`NotebookEdit`, `write_file`/`file_edit`/`notebook_edit`, kept in sync with `tooldisplay`'s canonical maps) and all three input-persistence shapes: full inline, truncated 4 KB preview (lenient token-walk parser), and sidecar blob head — the blob fallback was validated against a real historical run where `file_path` lands *after* a >4 KB `content` field.
- New files mode `?mode=produced`: combined view while the working directory exists, then persisted-gitmeta → historical `BaseCommit..FinalCommit` fallback (lifecycle-tagged `committed`) instead of dead-ending on `worktree_gone`.

**Studio**
- `producedItems.ts` aggregation reworked: **trust gate** — worktree runs keep the authoritative git view (annotated with node chips); in-place runs only show files some node actually wrote, never ambient workspace state; availability-aware fallback (a cloud worktree run mid-flight falls back to touched rows instead of rendering empty); dedupe by shared working directory across the run tree; deleted-path suppression; committed rows keep the run whose branch range recorded them (diff targeting).
- `ProducedElements.tsx`: third polled feed (`/files/touched`), `mode=produced`, per-node ⚙ chips, no Diff affordance on rows without a git counterpart (the diff would be a 400 on absolute paths or a misleading empty diff), partial-data warning when a feed errors.

## Known limits (documented in code)

Files created by Bash commands, direct tool nodes, or CLI-agent backends that stream no tool events (kimi) are invisible to `/files/touched` — worktree runs still catch them via the git channel; for in-place runs, missing those beats listing the operator's whole `git status`. The designed channel for arbitrary media outputs remains the artifact area (`$ITERION_ARTIFACT_FILES_DIR`).

## Verification

- `go test ./pkg/server/` full package green; `go vet ./pkg/...`, `gofmt` clean; `go build ./...`.
- Studio: `tsc -b`, eslint, full vitest suite green (92 files / 750 tests, +2 new cases).
- `openapi.json` + `studio/src/api/schema.ts` regenerated; drift check re-verified on the isolated PR tree (`iterion openapi` output byte-identical).
- The PR tree was built and tested in a detached worktree, isolated from unrelated local WIP.
- End-to-end probe against a real historical run store: `/files/touched` returns the 4 node-written files, correctly attributed to their nodes, including the blob-offloaded input case.
- A 3-dimension multi-agent review (Go correctness / studio semantics / cross-layer) with adversarial verification produced 7 confirmed minor findings — all fixed in this diff (degenerate path guard, availability-aware trust gate, deleted-path suppression, non-diffable touched-only rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)