### PR TITLE
feat(store,runner,cloudpublisher): T-42 IRRef fallback for oversized compiled IR at NATS enqueue

### DIFF
--- a/docs/adr/075-irref-fallback-for-oversized-cloud-queue-ir.md
+++ b/docs/adr/075-irref-fallback-for-oversized-cloud-queue-ir.md
@@ -1,0 +1,92 @@
+# ADR-075 — IRRef fallback: offload an oversized compiled IR out-of-band at cloud dispatch
+
+- Status: accepted
+- Date: 2026-07-16
+- Deciders: jo (direction), Claude (analysis + implementation)
+
+## Context
+
+Cloud-mode dispatch marshals a run's compiled IR (the AST `File`) inline
+onto the NATS `RunMessage.IRCompiled` field. NATS rejects any message
+larger than the server-negotiated `max_payload` (default 1 MiB), so a
+workflow whose compiled IR exceeds that budget **hard-failed at enqueue**:
+`pkg/queue/nats` pre-checked the marshaled body against `max_payload` and
+returned an error that literally read "IRRef fallback (T-42) not yet
+implemented"; the runner's `loadWorkflow` symmetrically errored when
+`IRCompiled` was empty.
+
+The wire contract already anticipated the fix: `queue.RunMessage` carried
+an unused `IRRef` field (`StorageKey` + `Backend ∈ {s3, mongo}`) and
+`Validate` enforced "exactly one of IRCompiled / IRRef". Only the two
+ends of the pipe — publisher offload and runner fetch — were stubs.
+
+Large IRs are rare (most bots are well under 1 MiB compiled) but not
+hypothetical: fan-out/subbot expansions, big `vars` defaults, and
+generated workflows push the ceiling. The failure mode was the worst
+kind — a clean local run that becomes undispatchable in cloud with an
+opaque size error.
+
+## Decision
+
+Implement the fallback as an **out-of-band object reference**, reusing the
+S3 blob backend that already holds artifacts and tool blobs (the
+ADR-073 cloud-twin pattern), rather than trying to make the IR fit on the
+wire.
+
+- **New store seam `store.IRBlobStore`** (`PutIRBlob`/`GetIRBlob`/
+  `IRBlobBackend`) + `AsIRBlobStore`, mirroring `ToolBlobStore`. The Mongo
+  store satisfies it, backed by `blob.Client` under `ir/<run_id>.json`
+  (one object per run — the fallback only ever stashes a single IR).
+  Filesystem/local stores deliberately do **not** implement it: the local
+  runtime never crosses the queue, so an oversized-IR offload cannot arise.
+- **Publisher offloads in `p.publish`** (covers both Launch and Resume).
+  It sizes the marshaled `RunMessage` against `Conn.MaxPayload()`; when the
+  inline IR would blow the limit it PUTs the IR to the blob store and swaps
+  `IRCompiled` for an `IRRef`. A cheap `len(IR)+64 KiB` envelope-reserve
+  gate keeps the small-IR hot path off the precise marshal.
+- **Runner fetches in `loadWorkflow`**: when `IRCompiled` is empty and an
+  `IRRef` is present, it hydrates the IR through `AsIRBlobStore`.
+- **Fail loudly, never silently.** An oversized IR with no `IRBlobStore`
+  seam is a hard error at publish (not a truncated message); a present ref
+  the store can't fetch is a hard error at load. The `nats` guard stays as
+  a final safety net for a message that reached publish un-offloaded.
+- **Wire-key re-validation.** `GetIRBlob` re-derives the canonical
+  `ir/<run_id>.json` key from the wire `StorageKey` and rejects any
+  mismatch, so a tampered queue reference can never widen the S3 key space
+  (same containment discipline as `RunFileKey`).
+
+The `Backend` enum keeps `mongo` as a documented option, but the shipped
+impl is `s3` — the blob backend is where run-scoped bytes already live.
+
+### Alternatives rejected
+
+- **Chunk the IR across multiple NATS messages.** Rejected: reassembly,
+  ordering, and partial-failure semantics on a work-queue stream that is
+  designed for one-message-one-unit-of-work; a large multiplier of
+  complexity for a rare case.
+- **Compress the IR inline (gzip on the wire).** Rejected: buys only a
+  constant factor — a large enough workflow still exceeds `max_payload` —
+  while adding a decode branch and an opaque binary blob on every message.
+  The out-of-band ref removes the ceiling entirely.
+- **Store the IR in Mongo (GridFS / a document).** Rejected: a compiled IR
+  can pass the 16 MiB BSON ceiling, and the S3 blob path already models
+  run-scoped byte blobs (artifacts, tool bodies, run files) — mirroring
+  ADR-073's tool-blob choice.
+
+## Consequences
+
+- Workflows whose compiled IR exceeds `max_payload` dispatch and run in
+  cloud instead of failing at enqueue. The common (small-IR) path is
+  unchanged — no extra marshal, no blob write.
+- The oversized path adds one S3 PUT at publish and one S3 GET on the
+  runner's cold path, and couples oversized-IR dispatch to blob-backend
+  availability (a blob outage surfaces as a loud publish/load error, which
+  is the intended behaviour).
+- New S3 key space `ir/<run_id>.json`, swept by the per-run `DeleteRun`
+  cleanup alongside artifacts/tool-blobs/run-files.
+- `Conn.MaxPayload()` is now exposed on the queue connection; the publisher
+  holds a `maxPayload func() int64` seam so the offload decision is unit
+  testable without a live NATS server.
+- `migrate to-cloud` does not copy the new `ir/` key space; consistent with
+  ADR-073's note that the blob spaces are not yet migrated (captured as a
+  board finding).

--- a/pkg/queue/nats/nats.go
+++ b/pkg/queue/nats/nats.go
@@ -216,6 +216,13 @@ func (c *Conn) JetStream() jetstream.JetStream { return c.js }
 // can layer a CAS lease on top of it without re-resolving the bucket.
 func (c *Conn) KV() jetstream.KeyValue { return c.kv }
 
+// MaxPayload returns the server-negotiated maximum message size (bytes)
+// this connection will accept, or 0 when unknown / not connected. The
+// cloud publisher reads it to decide when a RunMessage's compiled IR must
+// be offloaded out-of-band via the IRRef fallback (T-42) instead of being
+// inlined on the wire.
+func (c *Conn) MaxPayload() int64 { return c.nc.MaxPayload() }
+
 // EnsureSchema creates the JetStream streams + KV bucket idempotently.
 // Designed to run on every server / runner boot so the topology is
 // self-healing — if an operator deletes a stream by mistake the next
@@ -274,11 +281,13 @@ func (c *Conn) PublishRun(ctx context.Context, msg *queue.RunMessage) (*jetstrea
 	// NATS rejects messages larger than the server-negotiated
 	// max_payload (default 1 MiB). Catch the limit ourselves so the
 	// caller gets a clean, actionable error instead of an opaque
-	// runtime ErrMaxPayload after the IR has been built. The IRRef
-	// fallback for oversized workflows is tracked under T-42; until
-	// it lands, surface the gap explicitly.
+	// runtime ErrMaxPayload after the IR has been built. Oversized IR is
+	// meant to be offloaded out-of-band by the publisher (IRRef fallback,
+	// T-42) BEFORE reaching here; a message that still exceeds the limit
+	// at publish means the offload path was skipped (e.g. a store without
+	// the IRBlobStore seam), so surface it explicitly.
 	if maxPayload := c.nc.MaxPayload(); maxPayload > 0 && int64(len(body)) > maxPayload {
-		return nil, fmt.Errorf("queue/nats: RunMessage size %d exceeds NATS max_payload %d for run %s — IRRef fallback (T-42) not yet implemented", len(body), maxPayload, msg.RunID)
+		return nil, fmt.Errorf("queue/nats: RunMessage size %d exceeds NATS max_payload %d for run %s — compiled IR was not offloaded via the IRRef fallback (store lacks out-of-band IR blob support?)", len(body), maxPayload, msg.RunID)
 	}
 
 	headers := nats.Header{}

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -1014,7 +1014,7 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage) error {
 		defer cancel()
 	}
 
-	wf, err := loadWorkflow(msg)
+	wf, err := loadWorkflow(ctx, msg, store.AsIRBlobStore(r.cfg.Store))
 	if err != nil {
 		return err
 	}
@@ -2054,18 +2054,28 @@ func materializeOAuthCredentials(kind string, payload []byte) (dir string, fname
 	return dir, fname, nil
 }
 
-// loadWorkflow decodes the AST embedded in the message and compiles
-// it to IR. T-42 will add a fallback for IRRef when IRCompiled is
-// absent (oversized IR pulled from S3 or Mongo); the inline case
-// covers the vast majority of workflows.
-func loadWorkflow(msg *queue.RunMessage) (*ir.Workflow, error) {
-	if len(msg.IRCompiled) == 0 {
-		// IRRef fallback isn't wired yet — server should always
-		// inline the IR for now. Fail loudly so the operator can
-		// surface the "IR too large" mode they hit.
-		return nil, fmt.Errorf("runner: RunMessage.IRCompiled is empty (IRRef fallback not yet implemented)")
+// loadWorkflow decodes the AST for a run and compiles it to IR. The IR
+// travels inline on RunMessage.IRCompiled for the vast majority of
+// workflows; when it exceeds the NATS max_payload the publisher offloads
+// it out-of-band (T-42) and sends an IRRef instead, which the runner
+// fetches here via the store's IRBlobStore seam (blobs may be nil for a
+// store without the seam — then an IRRef is unrecoverable and fails loudly).
+func loadWorkflow(ctx context.Context, msg *queue.RunMessage, blobs store.IRBlobStore) (*ir.Workflow, error) {
+	raw := msg.IRCompiled
+	if len(raw) == 0 {
+		if msg.IRRef == nil || msg.IRRef.StorageKey == "" {
+			return nil, fmt.Errorf("runner: RunMessage for run %s carries neither IRCompiled nor IRRef", msg.RunID)
+		}
+		if blobs == nil {
+			return nil, fmt.Errorf("runner: run %s references out-of-band IR (%s:%s) but this store cannot fetch IR blobs", msg.RunID, msg.IRRef.Backend, msg.IRRef.StorageKey)
+		}
+		fetched, err := blobs.GetIRBlob(ctx, msg.IRRef.StorageKey)
+		if err != nil {
+			return nil, fmt.Errorf("runner: fetch out-of-band IR %s for run %s: %w", msg.IRRef.StorageKey, msg.RunID, err)
+		}
+		raw = fetched
 	}
-	file, err := ast.UnmarshalFile(msg.IRCompiled)
+	file, err := ast.UnmarshalFile(raw)
 	if err != nil {
 		return nil, fmt.Errorf("runner: decode IR: %w", err)
 	}

--- a/pkg/runner/loop_test.go
+++ b/pkg/runner/loop_test.go
@@ -146,20 +146,99 @@ func TestMaterializeOAuthCredentials_UnknownKindRejected(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLoadWorkflow_RejectsEmptyIR(t *testing.T) {
-	_, err := loadWorkflow(&queue.RunMessage{RunID: "r", WorkflowName: "wf"})
-	if err == nil || !strings.Contains(err.Error(), "IRCompiled is empty") {
-		t.Errorf("expected IRCompiled-empty err, got %v", err)
+	_, err := loadWorkflow(context.Background(), &queue.RunMessage{RunID: "r", WorkflowName: "wf"}, nil)
+	if err == nil || !strings.Contains(err.Error(), "neither IRCompiled nor IRRef") {
+		t.Errorf("expected neither-IRCompiled-nor-IRRef err, got %v", err)
 	}
 }
 
 func TestLoadWorkflow_RejectsMalformedIR(t *testing.T) {
-	_, err := loadWorkflow(&queue.RunMessage{
+	_, err := loadWorkflow(context.Background(), &queue.RunMessage{
 		RunID:        "r",
 		WorkflowName: "wf",
 		IRCompiled:   []byte(`{not valid json`),
-	})
+	}, nil)
 	if err == nil || !strings.Contains(err.Error(), "decode IR") {
 		t.Errorf("expected decode IR err, got %v", err)
+	}
+}
+
+// fakeIRBlobs is a store.IRBlobStore that serves preloaded IR bytes so the
+// runner's out-of-band fetch path (IRRef fallback, T-42) is exercisable
+// without S3/Mongo.
+type fakeIRBlobs struct {
+	blobs map[string][]byte
+	err   error
+}
+
+func (f *fakeIRBlobs) GetIRBlob(_ context.Context, key string) ([]byte, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	b, ok := f.blobs[key]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return b, nil
+}
+
+func (f *fakeIRBlobs) PutIRBlob(_ context.Context, runID string, body []byte) (string, error) {
+	key := "ir/" + runID + ".json"
+	if f.blobs == nil {
+		f.blobs = map[string][]byte{}
+	}
+	f.blobs[key] = body
+	return key, nil
+}
+
+func (f *fakeIRBlobs) IRBlobBackend() string { return "s3" }
+
+// TestLoadWorkflow_FetchesIRRef is the runner half of T-42: an oversized
+// workflow arrives with an empty IRCompiled and an IRRef, and the runner
+// hydrates it by fetching the blob back through the IRBlobStore seam.
+func TestLoadWorkflow_FetchesIRRef(t *testing.T) {
+	const src = "workflow main:\n  entry: a\n  a -> done\nagent a:\n  backend: \"claw\"\n  model: \"openai/gpt-5.4-mini\"\n  system: sys\nprompt sys:\n  hi\n"
+	pr := parser.Parse("main.bot", src)
+	body, err := ast.MarshalFile(pr.File)
+	if err != nil {
+		t.Fatalf("marshal AST: %v", err)
+	}
+	blobs := &fakeIRBlobs{blobs: map[string][]byte{"ir/run-big.json": body}}
+	msg := &queue.RunMessage{
+		RunID:        "run-big",
+		WorkflowName: "main",
+		IRRef:        &queue.IRRef{StorageKey: "ir/run-big.json", Backend: queue.IRBackendS3},
+	}
+	wf, err := loadWorkflow(context.Background(), msg, blobs)
+	if err != nil {
+		t.Fatalf("loadWorkflow: %v", err)
+	}
+	if wf == nil || wf.Name != "main" {
+		t.Fatalf("expected workflow main, got %+v", wf)
+	}
+}
+
+func TestLoadWorkflow_IRRefWithoutSeamFails(t *testing.T) {
+	msg := &queue.RunMessage{
+		RunID:        "run-big",
+		WorkflowName: "main",
+		IRRef:        &queue.IRRef{StorageKey: "ir/run-big.json", Backend: queue.IRBackendS3},
+	}
+	_, err := loadWorkflow(context.Background(), msg, nil)
+	if err == nil || !strings.Contains(err.Error(), "cannot fetch IR blobs") {
+		t.Fatalf("expected cannot-fetch err, got %v", err)
+	}
+}
+
+func TestLoadWorkflow_IRRefFetchErrorPropagates(t *testing.T) {
+	msg := &queue.RunMessage{
+		RunID:        "run-big",
+		WorkflowName: "main",
+		IRRef:        &queue.IRRef{StorageKey: "ir/missing.json", Backend: queue.IRBackendS3},
+	}
+	_, err := loadWorkflow(context.Background(), msg, &fakeIRBlobs{})
+	if err == nil || !strings.Contains(err.Error(), "fetch out-of-band IR") {
+		t.Fatalf("expected fetch err, got %v", err)
 	}
 }
 
@@ -211,11 +290,11 @@ workflow main:
 
 	// Faithful mirror of the runner: hydrate the pre-compiled AST, then
 	// resolve the MCP catalog against the workspace (executeRun's sequence).
-	wf, err := loadWorkflow(&queue.RunMessage{
+	wf, err := loadWorkflow(context.Background(), &queue.RunMessage{
 		RunID:        "r",
 		WorkflowName: "main",
 		IRCompiled:   body,
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("loadWorkflow: %v", err)
 	}

--- a/pkg/runview/runstream/mongo_test.go
+++ b/pkg/runview/runstream/mongo_test.go
@@ -386,5 +386,12 @@ func (nopBlob) GetRunFile(context.Context, string, string) (io.ReadCloser, blob.
 	return nil, blob.RunFileObject{}, blob.ErrArtifactNotFound
 }
 func (nopBlob) DeleteRunFiles(context.Context, string) error { return nil }
+func (nopBlob) PutIRBlob(context.Context, string, []byte) error {
+	return nil
+}
+func (nopBlob) GetIRBlob(context.Context, string) ([]byte, error) {
+	return nil, blob.ErrArtifactNotFound
+}
+func (nopBlob) DeleteRunIR(context.Context, string) error { return nil }
 
 var _ blob.Client = nopBlob{}

--- a/pkg/server/cloudpublisher/ir_offload_test.go
+++ b/pkg/server/cloudpublisher/ir_offload_test.go
@@ -1,0 +1,155 @@
+package cloudpublisher
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// fakeIRStore is a RunStore that also satisfies store.IRBlobStore, capturing
+// offloaded IR bytes in memory so the offload path is testable without S3.
+type fakeIRStore struct {
+	store.RunStore
+	blobs   map[string][]byte
+	backend string
+}
+
+func (f *fakeIRStore) PutIRBlob(_ context.Context, runID string, body []byte) (string, error) {
+	key := "ir/" + runID + ".json"
+	if f.blobs == nil {
+		f.blobs = map[string][]byte{}
+	}
+	f.blobs[key] = append([]byte{}, body...)
+	return key, nil
+}
+
+func (f *fakeIRStore) GetIRBlob(_ context.Context, storageKey string) ([]byte, error) {
+	b, ok := f.blobs[storageKey]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return append([]byte{}, b...), nil
+}
+
+func (f *fakeIRStore) IRBlobBackend() string {
+	if f.backend != "" {
+		return f.backend
+	}
+	return "s3"
+}
+
+func testPublisher(st store.RunStore, maxPayload int64) *Publisher {
+	return &Publisher{
+		store:      st,
+		logger:     iterlog.New(iterlog.LevelError, io.Discard),
+		maxPayload: func() int64 { return maxPayload },
+	}
+}
+
+func bigIR(n int) json.RawMessage {
+	return json.RawMessage(`{"pad":"` + strings.Repeat("x", n) + `"}`)
+}
+
+func TestOffloadOversizedIR_SmallStaysInline(t *testing.T) {
+	fake := &fakeIRStore{}
+	p := testPublisher(fake, 1<<20) // 1 MiB
+	ir := bigIR(1024)
+	msg := &queue.RunMessage{V: queue.SchemaVersion, RunID: "run-small", WorkflowName: "wf", IRCompiled: ir}
+	if err := p.offloadOversizedIR(context.Background(), msg); err != nil {
+		t.Fatalf("offload: %v", err)
+	}
+	if !bytes.Equal(msg.IRCompiled, ir) {
+		t.Fatal("small IR should stay inline")
+	}
+	if msg.IRRef != nil {
+		t.Fatalf("small IR should not offload, got ref %+v", msg.IRRef)
+	}
+	if len(fake.blobs) != 0 {
+		t.Fatalf("nothing should be stashed, got %d blobs", len(fake.blobs))
+	}
+}
+
+func TestOffloadOversizedIR_LargeOffloads(t *testing.T) {
+	fake := &fakeIRStore{}
+	const maxPayload = 64 * 1024
+	p := testPublisher(fake, maxPayload)
+	ir := bigIR(200 * 1024) // well over the limit
+	msg := &queue.RunMessage{V: queue.SchemaVersion, RunID: "run-big", WorkflowName: "wf", IRCompiled: ir}
+	if err := p.offloadOversizedIR(context.Background(), msg); err != nil {
+		t.Fatalf("offload: %v", err)
+	}
+	if msg.IRCompiled != nil {
+		t.Fatal("oversized IR should be cleared from the message")
+	}
+	if msg.IRRef == nil {
+		t.Fatal("oversized IR should produce an IRRef")
+	}
+	if msg.IRRef.Backend != queue.IRBackendS3 {
+		t.Fatalf("backend = %q, want s3", msg.IRRef.Backend)
+	}
+	if msg.IRRef.StorageKey != "ir/run-big.json" {
+		t.Fatalf("storage key = %q", msg.IRRef.StorageKey)
+	}
+	// The message must now validate and fit.
+	if err := msg.Validate(); err != nil {
+		t.Fatalf("offloaded message fails Validate: %v", err)
+	}
+	body, _ := json.Marshal(msg)
+	if int64(len(body)) > maxPayload {
+		t.Fatalf("offloaded message still %d bytes (> %d)", len(body), maxPayload)
+	}
+	// Round-trips: the runner can fetch the exact bytes back by key.
+	got, err := fake.GetIRBlob(context.Background(), msg.IRRef.StorageKey)
+	if err != nil {
+		t.Fatalf("GetIRBlob: %v", err)
+	}
+	if !bytes.Equal(got, ir) {
+		t.Fatal("stashed IR bytes differ from the original")
+	}
+}
+
+func TestOffloadOversizedIR_NoSeamFailsLoudly(t *testing.T) {
+	// A store without the IRBlobStore seam must error, not silently
+	// truncate the IR or publish an oversized message.
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	p := testPublisher(st, 64*1024)
+	msg := &queue.RunMessage{V: queue.SchemaVersion, RunID: "run-x", WorkflowName: "wf", IRCompiled: bigIR(200 * 1024)}
+	err = p.offloadOversizedIR(context.Background(), msg)
+	if err == nil || !strings.Contains(err.Error(), "cannot host an out-of-band IR blob") {
+		t.Fatalf("expected out-of-band failure, got %v", err)
+	}
+}
+
+func TestOffloadOversizedIR_UnknownBackendRejected(t *testing.T) {
+	fake := &fakeIRStore{backend: "filesystem"}
+	p := testPublisher(fake, 64*1024)
+	msg := &queue.RunMessage{V: queue.SchemaVersion, RunID: "run-y", WorkflowName: "wf", IRCompiled: bigIR(200 * 1024)}
+	err := p.offloadOversizedIR(context.Background(), msg)
+	if err == nil || !strings.Contains(err.Error(), "unsupported backend") {
+		t.Fatalf("expected unsupported-backend error, got %v", err)
+	}
+}
+
+func TestOffloadOversizedIR_NoMaxPayloadIsNoop(t *testing.T) {
+	fake := &fakeIRStore{}
+	p := &Publisher{store: fake, logger: iterlog.New(iterlog.LevelError, io.Discard)} // maxPayload nil
+	ir := bigIR(200 * 1024)
+	msg := &queue.RunMessage{V: queue.SchemaVersion, RunID: "run-z", WorkflowName: "wf", IRCompiled: ir}
+	if err := p.offloadOversizedIR(context.Background(), msg); err != nil {
+		t.Fatalf("offload: %v", err)
+	}
+	if msg.IRRef != nil || !bytes.Equal(msg.IRCompiled, ir) {
+		t.Fatal("with no max_payload the message must be untouched")
+	}
+}

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -97,13 +97,13 @@ type TeamResolver interface {
 
 // Publisher is a runview.LaunchPublisher backed by NATS + Mongo.
 type Publisher struct {
-	nats           *natsq.Conn
-	publishRun     func(context.Context, *queue.RunMessage) error
-	cancelRun      func(string) error
+	nats       *natsq.Conn
+	publishRun func(context.Context, *queue.RunMessage) error
+	cancelRun  func(string) error
 	// maxPayload reports the NATS server-negotiated max message size so
 	// the offload path can size a RunMessage against it. Nil (the default
 	// in unit tests) disables IR offload — the message is published as-is.
-	maxPayload func() int64
+	maxPayload     func() int64
 	store          store.RunStore
 	runs           *mongo.Collection
 	logger         *iterlog.Logger

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -100,6 +100,10 @@ type Publisher struct {
 	nats           *natsq.Conn
 	publishRun     func(context.Context, *queue.RunMessage) error
 	cancelRun      func(string) error
+	// maxPayload reports the NATS server-negotiated max message size so
+	// the offload path can size a RunMessage against it. Nil (the default
+	// in unit tests) disables IR offload — the message is published as-is.
+	maxPayload func() int64
 	store          store.RunStore
 	runs           *mongo.Collection
 	logger         *iterlog.Logger
@@ -188,6 +192,7 @@ func New(cfg Config) (*Publisher, error) {
 			return err
 		},
 		cancelRun:      cfg.NATS.CancelRun,
+		maxPayload:     cfg.NATS.MaxPayload,
 		store:          cfg.Store,
 		runs:           cfg.MongoColl,
 		logger:         cfg.Logger,
@@ -544,10 +549,10 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 		return 0, fmt.Errorf("cloudpublisher: save run: %w", err)
 	}
 
-	// 2. Build the RunMessage. We marshal the AST inline; T-42 will
-	//    add the IRRef fallback for oversized workflows. The
-	//    runner side re-parses + re-compiles, so the wire payload
-	//    is the AST File, not the compiled IR.
+	// 2. Build the RunMessage. We marshal the AST inline; p.publish then
+	//    offloads it out-of-band via an IRRef (T-42) if it would exceed
+	//    the NATS max_payload. The runner side re-parses + re-compiles, so
+	//    the wire payload is the AST File, not the compiled IR.
 	body, err := marshalIRFromSpec(spec.FilePath, spec.Source)
 	if err != nil {
 		return 0, err
@@ -762,6 +767,9 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 }
 
 func (p *Publisher) publish(ctx context.Context, msg *queue.RunMessage) error {
+	if err := p.offloadOversizedIR(ctx, msg); err != nil {
+		return err
+	}
 	if p.publishRun != nil {
 		return p.publishRun(ctx, msg)
 	}
@@ -770,6 +778,78 @@ func (p *Publisher) publish(ctx context.Context, msg *queue.RunMessage) error {
 	}
 	_, err := p.nats.PublishRun(ctx, msg)
 	return err
+}
+
+// irEnvelopeReserve is the byte headroom kept for the RunMessage's
+// non-IR fields (ids, vars, trace, backend, …) when deciding whether the
+// inline IR still fits under max_payload. IRCompiled is embedded verbatim
+// (json.RawMessage), so the marshaled envelope is ~len(IRCompiled) plus
+// these fields; the reserve lets the common (small-IR) path skip the
+// precise marshal below.
+const irEnvelopeReserve = 64 * 1024
+
+// offloadOversizedIR swaps the inline compiled IR for a lightweight IRRef
+// when the marshaled RunMessage would exceed the NATS max_payload. It
+// stashes the IR in the store's out-of-band blob backend (S3, via the
+// IRBlobStore seam) keyed by run id and points the message at it. This is
+// the T-42 fallback that keeps a workflow whose compiled IR is larger than
+// the payload budget (default 1 MiB) dispatchable instead of hard-failing
+// at enqueue.
+//
+// No-op when: NATS is not wired (unit tests stub publishRun), the message
+// already carries an IRRef, there is no inline IR, or the IR comfortably
+// fits. Fails loudly — rather than silently truncating — when the IR is
+// oversized but the store cannot host an IR blob.
+func (p *Publisher) offloadOversizedIR(ctx context.Context, msg *queue.RunMessage) error {
+	if p.maxPayload == nil || msg.IRRef != nil || len(msg.IRCompiled) == 0 {
+		return nil
+	}
+	maxPayload := p.maxPayload()
+	if maxPayload <= 0 {
+		return nil
+	}
+	// Cheap gate: if the IR plus the envelope reserve is under the limit,
+	// it fits — skip the precise (re-)marshal on the hot path.
+	if int64(len(msg.IRCompiled))+irEnvelopeReserve <= maxPayload {
+		return nil
+	}
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("cloudpublisher: marshal RunMessage for run %s: %w", msg.RunID, err)
+	}
+	if int64(len(body)) <= maxPayload {
+		return nil
+	}
+
+	blobs := store.AsIRBlobStore(p.store)
+	if blobs == nil {
+		return fmt.Errorf("cloudpublisher: RunMessage for run %s is %d bytes (exceeds NATS max_payload %d) but the store cannot host an out-of-band IR blob (IRRef fallback unavailable)", msg.RunID, len(body), maxPayload)
+	}
+	backend, err := irBackendForName(blobs.IRBlobBackend())
+	if err != nil {
+		return err
+	}
+	key, err := blobs.PutIRBlob(ctx, msg.RunID, msg.IRCompiled)
+	if err != nil {
+		return fmt.Errorf("cloudpublisher: stash oversized IR for run %s: %w", msg.RunID, err)
+	}
+	msg.IRCompiled = nil
+	msg.IRRef = &queue.IRRef{StorageKey: key, Backend: backend}
+	p.logger.Info("cloudpublisher: run %s compiled IR (%d bytes) exceeds NATS max_payload %d — offloaded to %s:%s", msg.RunID, len(body), maxPayload, backend, key)
+	return nil
+}
+
+// irBackendForName maps an IRBlobStore backend name to the wire enum the
+// runner validates, rejecting anything the queue contract doesn't accept.
+func irBackendForName(name string) (queue.IRBackend, error) {
+	switch queue.IRBackend(name) {
+	case queue.IRBackendS3:
+		return queue.IRBackendS3, nil
+	case queue.IRBackendMongo:
+		return queue.IRBackendMongo, nil
+	default:
+		return "", fmt.Errorf("cloudpublisher: IR blob store reported unsupported backend %q (want s3|mongo)", name)
+	}
 }
 
 func (p *Publisher) cancel(runID string) error {

--- a/pkg/store/blob/iface.go
+++ b/pkg/store/blob/iface.go
@@ -122,6 +122,30 @@ type Client interface {
 	// DeleteRunFiles removes every blob under `runfiles/<runID>/` in a
 	// single sweep. Best-effort, mirroring DeleteRunAttachments.
 	DeleteRunFiles(ctx context.Context, runID string) error
+
+	// PutIRBlob stashes an out-of-band compiled IR under `ir/<runID>.json`
+	// (the queue IRRef fallback for workflows whose IR exceeds the NATS
+	// max_payload). Idempotent: re-PUTting the same run replaces the bytes.
+	PutIRBlob(ctx context.Context, runID string, body []byte) error
+
+	// GetIRBlob returns the IR bytes previously PUT for a run, addressed by
+	// the storage key carried on queue.IRRef.StorageKey. Returns
+	// ErrArtifactNotFound when the key is absent. The key is validated
+	// against the canonical `ir/<run_id>.json` shape so a tampered
+	// reference can never widen the key space.
+	GetIRBlob(ctx context.Context, storageKey string) ([]byte, error)
+
+	// DeleteRunIR removes the `ir/<runID>.json` blob. Best-effort, part of
+	// the per-run cleanup sweep alongside DeleteRun / DeleteRunToolBlobs.
+	// Idempotent: deleting a non-existent key returns nil.
+	DeleteRunIR(ctx context.Context, runID string) error
+}
+
+// IRBlobKey returns the canonical layout key for an out-of-band compiled
+// IR: `ir/<run_id>.json`. This is the value stamped on
+// queue.IRRef.StorageKey.
+func IRBlobKey(runID string) (string, error) {
+	return irBlobKey(runID)
 }
 
 // RunFileObject is the metadata the blob backend reports for one

--- a/pkg/store/blob/irkey_test.go
+++ b/pkg/store/blob/irkey_test.go
@@ -1,0 +1,50 @@
+package blob
+
+import "testing"
+
+func TestIRBlobKey(t *testing.T) {
+	key, err := IRBlobKey("run_123")
+	if err != nil {
+		t.Fatalf("IRBlobKey: %v", err)
+	}
+	if key != "ir/run_123.json" {
+		t.Fatalf("key = %q, want ir/run_123.json", key)
+	}
+}
+
+func TestIRBlobKeyRejectsTraversal(t *testing.T) {
+	if _, err := IRBlobKey("../etc"); err == nil {
+		t.Fatal("expected error on traversal run id")
+	}
+}
+
+func TestValidateIRBlobKey(t *testing.T) {
+	// Round-trips its own canonical key.
+	key, err := IRBlobKey("run_abc")
+	if err != nil {
+		t.Fatalf("IRBlobKey: %v", err)
+	}
+	got, err := validateIRBlobKey(key)
+	if err != nil {
+		t.Fatalf("validateIRBlobKey(%q): %v", key, err)
+	}
+	if got != key {
+		t.Fatalf("got %q, want %q", got, key)
+	}
+}
+
+func TestValidateIRBlobKeyRejectsTampered(t *testing.T) {
+	cases := []string{
+		"ir/../secret.json",       // traversal in the run component
+		"tools/run/output",        // wrong prefix
+		"ir/run.txt",              // wrong suffix
+		"ir/run/nested.json",      // extra path segment
+		"run.json",                // no prefix
+		"ir/.json",                // empty run id
+	}
+	for _, c := range cases {
+		if _, err := validateIRBlobKey(c); err == nil {
+			t.Errorf("validateIRBlobKey(%q): expected error, got nil", c)
+		}
+	}
+}

--- a/pkg/store/blob/irkey_test.go
+++ b/pkg/store/blob/irkey_test.go
@@ -35,12 +35,12 @@ func TestValidateIRBlobKey(t *testing.T) {
 
 func TestValidateIRBlobKeyRejectsTampered(t *testing.T) {
 	cases := []string{
-		"ir/../secret.json",       // traversal in the run component
-		"tools/run/output",        // wrong prefix
-		"ir/run.txt",              // wrong suffix
-		"ir/run/nested.json",      // extra path segment
-		"run.json",                // no prefix
-		"ir/.json",                // empty run id
+		"ir/../secret.json",  // traversal in the run component
+		"tools/run/output",   // wrong prefix
+		"ir/run.txt",         // wrong suffix
+		"ir/run/nested.json", // extra path segment
+		"run.json",           // no prefix
+		"ir/.json",           // empty run id
 	}
 	for _, c := range cases {
 		if _, err := validateIRBlobKey(c); err == nil {

--- a/pkg/store/blob/key.go
+++ b/pkg/store/blob/key.go
@@ -81,6 +81,33 @@ func toolBlobKey(runID, toolUseID, kind string) (string, error) {
 	return fmt.Sprintf("tools/%s/%s/%s", runID, toolUseID, kind), nil
 }
 
+// irBlobKey builds the canonical S3 key for an out-of-band compiled IR:
+// ir/<run_id>.json. One object per run (the IRRef fallback only ever
+// stashes a single IR per run), so there is no sub-path to sanitise
+// beyond the run id.
+func irBlobKey(runID string) (string, error) {
+	if err := store.SanitizePathComponent("run_id", runID); err != nil {
+		return "", fmt.Errorf("blob: invalid run_id: %w", err)
+	}
+	return fmt.Sprintf("ir/%s.json", runID), nil
+}
+
+// validateIRBlobKey re-derives the canonical IR key from a storage key
+// carried on the wire (queue.IRRef.StorageKey) and confirms they match,
+// so a tampered or malformed reference can never escape the ir/ prefix.
+// Returns the (identical) canonical key on success.
+func validateIRBlobKey(storageKey string) (string, error) {
+	runID := strings.TrimSuffix(strings.TrimPrefix(storageKey, "ir/"), ".json")
+	canonical, err := irBlobKey(runID)
+	if err != nil {
+		return "", err
+	}
+	if canonical != storageKey {
+		return "", fmt.Errorf("blob: invalid IR storage key %q (want ir/<run_id>.json)", storageKey)
+	}
+	return canonical, nil
+}
+
 // toolBlobRunPrefix is the S3 key prefix containing every tool blob for
 // a run. Trailing slash guards against matching `tools/<runID>-other/`.
 func toolBlobRunPrefix(runID string) (string, error) {

--- a/pkg/store/blob/s3.go
+++ b/pkg/store/blob/s3.go
@@ -521,6 +521,67 @@ func (c *S3Client) GetToolBlobRange(ctx context.Context, runID, toolUseID, kind 
 	return data, total, eof, nil
 }
 
+// PutIRBlob uploads an out-of-band compiled IR under ir/<runID>.json.
+// Idempotent: re-PUTting the same run replaces the bytes.
+func (c *S3Client) PutIRBlob(ctx context.Context, runID string, body []byte) error {
+	key, err := irBlobKey(runID)
+	if err != nil {
+		return err
+	}
+	_, err = c.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(c.bucket),
+		Key:         aws.String(key),
+		Body:        bytes.NewReader(body),
+		ContentType: aws.String("application/json"),
+	})
+	if err != nil {
+		return fmt.Errorf("blob: put IR blob %s: %w", key, err)
+	}
+	return nil
+}
+
+// GetIRBlob fetches the IR bytes for the given storage key (as carried on
+// queue.IRRef.StorageKey). The key is re-validated against the canonical
+// ir/<run_id>.json shape before use so a tampered reference on the wire
+// can never widen the key space. Returns ErrArtifactNotFound when absent.
+func (c *S3Client) GetIRBlob(ctx context.Context, storageKey string) ([]byte, error) {
+	key, err := validateIRBlobKey(storageKey)
+	if err != nil {
+		return nil, err
+	}
+	out, err := c.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(c.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		if isS3NotFound(err) {
+			return nil, fmt.Errorf("%w: %s", ErrArtifactNotFound, key)
+		}
+		return nil, fmt.Errorf("blob: get IR blob %s: %w", key, err)
+	}
+	defer out.Body.Close()
+	body, err := io.ReadAll(out.Body)
+	if err != nil {
+		return nil, fmt.Errorf("blob: read IR blob %s: %w", key, err)
+	}
+	return body, nil
+}
+
+// DeleteRunIR removes the ir/<runID>.json blob. Idempotent, best-effort.
+func (c *S3Client) DeleteRunIR(ctx context.Context, runID string) error {
+	key, err := irBlobKey(runID)
+	if err != nil {
+		return err
+	}
+	if _, err := c.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(c.bucket),
+		Key:    aws.String(key),
+	}); err != nil {
+		return fmt.Errorf("blob: delete IR blob %s: %w", key, err)
+	}
+	return nil
+}
+
 // DeleteRunToolBlobs sweeps every blob under tools/<runID>/. Mirrors
 // DeleteRunAttachments' batched, best-effort semantics.
 func (c *S3Client) DeleteRunToolBlobs(ctx context.Context, runID string) error {

--- a/pkg/store/irblob.go
+++ b/pkg/store/irblob.go
@@ -1,0 +1,40 @@
+package store
+
+import "context"
+
+// IRBlobStore is an optional interface a store implements to stash an
+// oversized compiled IR out-of-band, keyed by run id. It is the storage
+// half of the queue's IRRef fallback: when a workflow's marshaled IR
+// exceeds the NATS max_payload (default 1 MiB), the cloud publisher parks
+// the IR here and sends a lightweight queue.IRRef on the RunMessage; the
+// runner fetches it back before compiling.
+//
+// The cloud (Mongo) store satisfies it, backed by the same S3 blob client
+// that holds artifacts + tool blobs (IR blobs can exceed the 16 MiB BSON
+// ceiling, so they live in S3, not Mongo). Filesystem / local stores do
+// NOT implement it — the local runtime never crosses the queue, so an
+// oversized-IR offload cannot arise there. Callers MUST nil-check via
+// AsIRBlobStore.
+type IRBlobStore interface {
+	// PutIRBlob stashes body under a deterministic key derived from
+	// runID and returns that key (which travels on queue.IRRef.StorageKey).
+	// Idempotent: re-writing the same run replaces the prior bytes.
+	PutIRBlob(ctx context.Context, runID string, body []byte) (storageKey string, err error)
+	// GetIRBlob returns the bytes previously stashed under storageKey.
+	// A missing blob returns an os.ErrNotExist-compatible error.
+	GetIRBlob(ctx context.Context, storageKey string) ([]byte, error)
+	// IRBlobBackend names the backend the blobs live in ("s3" | "mongo"),
+	// matching the queue.IRBackend enum the publisher stamps on the IRRef.
+	IRBlobBackend() string
+}
+
+// AsIRBlobStore returns s as IRBlobStore when the backend can host
+// out-of-band IR blobs, or nil otherwise. Callers MUST nil-check
+// (filesystem / local stores return nil).
+func AsIRBlobStore(s RunStore) IRBlobStore {
+	if s == nil {
+		return nil
+	}
+	b, _ := s.(IRBlobStore)
+	return b
+}

--- a/pkg/store/mongo/conformance_test.go
+++ b/pkg/store/mongo/conformance_test.go
@@ -298,3 +298,29 @@ func (b *inMemoryBlob) DeleteRunFiles(_ context.Context, runID string) error {
 	}
 	return nil
 }
+
+func (b *inMemoryBlob) PutIRBlob(_ context.Context, runID string, body []byte) error {
+	key, err := blob.IRBlobKey(runID)
+	if err != nil {
+		return err
+	}
+	b.data[key] = append([]byte{}, body...)
+	return nil
+}
+
+func (b *inMemoryBlob) GetIRBlob(_ context.Context, storageKey string) ([]byte, error) {
+	body, ok := b.data[storageKey]
+	if !ok {
+		return nil, blob.ErrArtifactNotFound
+	}
+	return append([]byte{}, body...), nil
+}
+
+func (b *inMemoryBlob) DeleteRunIR(_ context.Context, runID string) error {
+	key, err := blob.IRBlobKey(runID)
+	if err != nil {
+		return err
+	}
+	delete(b.data, key)
+	return nil
+}

--- a/pkg/store/mongo/irblobs.go
+++ b/pkg/store/mongo/irblobs.go
@@ -1,0 +1,49 @@
+package mongo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/store/blob"
+)
+
+// The cloud (Mongo) store satisfies the out-of-band IR blob seam, backed
+// by the same S3 blob client that holds artifacts + tool blobs. It is the
+// storage half of the queue's IRRef fallback: a workflow whose compiled IR
+// exceeds the NATS max_payload is parked here by the publisher and fetched
+// back by the runner. IR blobs can exceed the 16 MiB BSON ceiling, so they
+// live in S3, not Mongo — matching artifacts + tool blobs.
+var _ store.IRBlobStore = (*Store)(nil)
+
+// PutIRBlob implements store.IRBlobStore: PUT the marshaled IR to S3 under
+// ir/<runID>.json and return that key for queue.IRRef.StorageKey.
+func (s *Store) PutIRBlob(ctx context.Context, runID string, body []byte) (string, error) {
+	key, err := blob.IRBlobKey(runID)
+	if err != nil {
+		return "", err
+	}
+	if err := s.blob.PutIRBlob(ctx, runID, body); err != nil {
+		return "", fmt.Errorf("store/mongo: put IR blob %s: %w", runID, err)
+	}
+	return key, nil
+}
+
+// GetIRBlob implements store.IRBlobStore: fetch the IR bytes addressed by
+// the storage key carried on the queue message. A missing blob returns an
+// os.ErrNotExist-compatible error.
+func (s *Store) GetIRBlob(ctx context.Context, storageKey string) ([]byte, error) {
+	body, err := s.blob.GetIRBlob(ctx, storageKey)
+	if err != nil {
+		if errors.Is(err, blob.ErrArtifactNotFound) {
+			return nil, fmt.Errorf("store/mongo: IR blob %s not found: %w", storageKey, os.ErrNotExist)
+		}
+		return nil, fmt.Errorf("store/mongo: get IR blob %s: %w", storageKey, err)
+	}
+	return body, nil
+}
+
+// IRBlobBackend implements store.IRBlobStore: cloud IR blobs live in S3.
+func (s *Store) IRBlobBackend() string { return "s3" }

--- a/pkg/store/mongo/irblobs_test.go
+++ b/pkg/store/mongo/irblobs_test.go
@@ -1,0 +1,43 @@
+package mongo
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+)
+
+// The IRBlobStore methods only touch the S3 blob backend (not Mongo), so a
+// bare *Store with an in-memory blob exercises the real cloud impl without
+// a live database.
+
+func TestStoreIRBlob_RoundTrip(t *testing.T) {
+	s := &Store{blob: newInMemoryBlob()}
+	ctx := context.Background()
+	body := []byte(`{"nodes":[{"id":"a"}]}`)
+	key, err := s.PutIRBlob(ctx, "run-1", body)
+	if err != nil {
+		t.Fatalf("PutIRBlob: %v", err)
+	}
+	if key != "ir/run-1.json" {
+		t.Fatalf("key = %q, want ir/run-1.json", key)
+	}
+	got, err := s.GetIRBlob(ctx, key)
+	if err != nil {
+		t.Fatalf("GetIRBlob: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("round-trip mismatch: got %q want %q", got, body)
+	}
+	if s.IRBlobBackend() != "s3" {
+		t.Fatalf("backend = %q, want s3", s.IRBlobBackend())
+	}
+}
+
+func TestStoreIRBlob_NotFoundIsErrNotExist(t *testing.T) {
+	s := &Store{blob: newInMemoryBlob()}
+	_, err := s.GetIRBlob(context.Background(), "ir/absent.json")
+	if err == nil || !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected os.ErrNotExist, got %v", err)
+	}
+}

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -89,6 +89,9 @@ func (s *Store) DeleteRun(ctx context.Context, id string) error {
 	if err := s.blob.DeleteRunFiles(ctx, id); err != nil {
 		return fmt.Errorf("store/mongo: blob delete run files %s: %w", id, err)
 	}
+	if err := s.blob.DeleteRunIR(ctx, id); err != nil {
+		return fmt.Errorf("store/mongo: blob delete IR blob %s: %w", id, err)
+	}
 	// Also sweep the runner-local scratch dir if this store owns one (a
 	// runner-side store; server-side stores leave runFilesScratch empty
 	// so the join is harmless but the tree never exists).


### PR DESCRIPTION
Chantier **C1** de la roadmap 2026-H2 (ticket board `8bd8042a`, ADR-075). Débloque le hard-fail cloud sur les IR volumineuses.

Produit par un run feature-dev (Featurly) sur main frais, diff vérifié propre, build + `go test` verts (pkg/runner, pkg/store/{,,blob,mongo}, pkg/server/cloudpublisher).

## Problème

En cloud-mode, le dispatch marshale l'IR compilée dans le `RunMessage` NATS. Quand l'IR dépasse le `max_payload` négocié, l'enqueue **hard-fail** avec un `ErrMaxPayload` opaque — le run ne part jamais.

## Fix — offload out-of-band via IRRef

- **`IRBlobStore` seam** (`pkg/store/blob/` + `pkg/store/irblob.go`) — stockage hors-bande de l'IR compilée, backends S3 + Mongo (`pkg/store/mongo/irblobs.go`), avec conformance test.
- **cloudpublisher** — quand l'IR dépasse `MaxPayload`, l'**offload** vers le blob store et met un `IRRef` (clé) dans le `RunMessage` au lieu de l'IR inline.
- **runner** — quand `IRCompiled` est vide, **fetch l'IR via l'IRRef** avant d'exécuter (le fallback que le ticket nommait).
- `queue/nats` expose `MaxPayload` pour la décision d'offload.
- **ADR-075** documente le mécanisme. Tests : loop_test, ir_offload_test, irblobs/irkey/conformance.

+785 / 16 fichiers, 7 commits.

## Contexte

Re-dispatché sur main frais (le 1er passage de l'usine du 2026-07-15 était sur un base dépassé par #193). Suit NATSBus #201 et LaunchSpec #210 (chantiers cloud C1/C2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)