### PR TITLE
fix(cli): runs prune survives unreadable run dirs

### DIFF
--- a/pkg/cli/runs_prune.go
+++ b/pkg/cli/runs_prune.go
@@ -59,6 +59,10 @@ type PruneResult struct {
 	Pruned       []PrunedRun `json:"pruned"`
 	PrunedCount  int         `json:"pruned_count"`
 	SkippedCount int         `json:"skipped_count"`
+	// Unreadable lists run dirs whose run.json could not be loaded
+	// (partial delete, crash before the first write). They are never
+	// deleted — the operator inspects or removes them by hand.
+	Unreadable []string `json:"unreadable,omitempty"`
 }
 
 // pruneAgeField is the constant advertised on --json output and in the
@@ -116,11 +120,17 @@ func RunPrune(opts PruneOptions, p *Printer) error {
 		ts  time.Time
 	}
 	scanned := 0
+	var unreadable []string
 	candidates := make([]candidate, 0, len(ids))
 	for _, id := range ids {
 		r, err := s.LoadRun(ctx, id)
 		if err != nil {
-			return fmt.Errorf("load run %s: %w", id, err)
+			// A run dir without a loadable run.json (partial delete,
+			// crash before the first write) must not sink the whole
+			// retention sweep. Surface it loudly and move on — and
+			// never delete what could not be read.
+			unreadable = append(unreadable, id)
+			continue
 		}
 		scanned++
 		if _, ok := statuses[r.Status]; !ok {
@@ -183,6 +193,7 @@ func RunPrune(opts PruneOptions, p *Printer) error {
 		Pruned:       pruned,
 		PrunedCount:  len(pruned),
 		SkippedCount: scanned - len(pruned),
+		Unreadable:   unreadable,
 	}
 	return renderPruneResult(p, result)
 }
@@ -308,6 +319,16 @@ func renderPruneResult(p *Printer, r PruneResult) error {
 	verb := "would prune"
 	if !r.DryRun {
 		verb = "pruned"
+	}
+
+	if len(r.Unreadable) > 0 {
+		sample := r.Unreadable
+		if len(sample) > 5 {
+			sample = sample[:5]
+		}
+		p.Line("WARNING: %d unreadable run dir(s) (no loadable run.json) left untouched — inspect or remove by hand: %s%s",
+			len(r.Unreadable), strings.Join(sample, ", "),
+			map[bool]string{true: ", …", false: ""}[len(r.Unreadable) > 5])
 	}
 
 	if r.PrunedCount == 0 {

--- a/pkg/cli/runs_prune_test.go
+++ b/pkg/cli/runs_prune_test.go
@@ -377,3 +377,39 @@ func TestRunPrune_JSONOutput(t *testing.T) {
 		t.Fatalf("dry-run must not delete; got remaining=%v", remaining)
 	}
 }
+
+// -----------------------------------------------------------------------
+// Unreadable run dirs (no loadable run.json) are surfaced, not fatal
+// -----------------------------------------------------------------------
+
+func TestRunPrune_UnreadableRunDirSurfacedNotFatal(t *testing.T) {
+	f := newPruneFixture(t)
+	f.seedRun(t, "old", store.RunStatusFinished, 40*24*time.Hour)
+	orphan := filepath.Join(f.dir, "runs", "orphan-no-runjson")
+	if err := os.MkdirAll(orphan, 0o755); err != nil {
+		t.Fatalf("mkdir orphan: %v", err)
+	}
+
+	buf := &bytes.Buffer{}
+	p := &Printer{W: buf, Format: OutputHuman}
+	if err := RunPrune(PruneOptions{
+		StoreDir:  f.dir,
+		OlderThan: 30 * 24 * time.Hour,
+		Now:       func() time.Time { return f.now },
+	}, p); err != nil {
+		t.Fatalf("an unreadable run dir must not fail the sweep: %v", err)
+	}
+
+	if _, err := os.Stat(orphan); err != nil {
+		t.Fatalf("orphan dir must be left untouched: %v", err)
+	}
+	remaining := listRunIDs(t, f.store)
+	for _, id := range remaining {
+		if id == "old" {
+			t.Fatalf("readable matching run must still be pruned; remaining=%v", remaining)
+		}
+	}
+	if !strings.Contains(buf.String(), "unreadable run dir") {
+		t.Fatalf("unreadable dirs must be surfaced in the output, got %q", buf.String())
+	}
+}


### PR DESCRIPTION
Found by smoke-testing #213's `runs prune` on a real operator store: a run dir without a loadable `run.json` (partial delete / crash before first write) sank the whole retention sweep via `LoadRun`. The sweep now surfaces those dirs (human WARNING + `unreadable` in `--json`), never deletes them, and prunes the rest. Regression test included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)