### PR TITLE
fix(secrets): materialize as:file secrets on host (non-sandbox) runs

### DIFF
--- a/pkg/backend/model/executor.go
+++ b/pkg/backend/model/executor.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/SocialGouv/claw-code-go/pkg/api/hooks"
@@ -153,6 +154,19 @@ type ClawExecutor struct {
 	// under parallel subbot fan-out, which builds one executor per child and
 	// can march toward fs.inotify.max_user_instances.
 	extraClosers []io.Closer
+
+	// hostSecretOnce fires ensureHostSecretFiles exactly once per executor:
+	// on the first Execute call of a HOST (non-sandbox) run it materialises
+	// every `as: file` workflow secret to a per-run tempdir so
+	// {{secrets.X.path}} resolves to a real host file. Sandbox runs are a
+	// no-op (the sandbox driver bind-mounts the same files via
+	// [sandbox.Spec.SecretFiles]). hostSecretCleanup deletes the dir on
+	// Close(); hostSecretErr sticks after a first-call failure so every
+	// subsequent Execute surfaces the same error rather than silently
+	// proceeding with unresolved secret paths.
+	hostSecretOnce    sync.Once
+	hostSecretCleanup func()
+	hostSecretErr     error
 }
 
 // SetSandbox installs the live sandbox handle on the executor. The
@@ -534,7 +548,8 @@ func (e *ClawExecutor) MCPHealthCheck(ctx context.Context, servers []string) err
 }
 
 // Close releases resources held by the executor, including MCP server
-// connections. It should be called when the executor is no longer needed.
+// connections and the per-run host secret-file tempdir (host runs only —
+// sandbox runs never populate it).
 func (e *ClawExecutor) Close() error {
 	var errs []error
 	if e.mcpManager != nil {
@@ -543,7 +558,54 @@ func (e *ClawExecutor) Close() error {
 	for _, c := range e.extraClosers {
 		errs = append(errs, c.Close())
 	}
+	if e.hostSecretCleanup != nil {
+		e.hostSecretCleanup()
+	}
 	return errors.Join(errs...)
+}
+
+// ensureHostSecretFiles materialises `as: file` workflow secrets to a
+// per-run host tempdir on the first Execute call of a HOST (non-sandbox)
+// run. Sandbox runs are a no-op — the sandbox driver already bind-mounts
+// each file at its declared mount_path via [sandbox.Spec.SecretFiles], so
+// this path stays strictly gated on `e.sandbox == nil` to keep sandbox
+// behaviour byte-for-byte unchanged.
+//
+// Idempotent via sync.Once; the resulting rewrite of the guard's
+// filePathByName / fileHints happens strictly before any concurrent
+// Execute reads them, so ResolveSecretRef sees the host path.
+func (e *ClawExecutor) ensureHostSecretFiles() error {
+	if e.sandbox != nil {
+		return nil
+	}
+	if e.secretGuard == nil || len(e.secretGuard.SecretFileHints()) == 0 {
+		return nil
+	}
+	e.hostSecretOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "iterion-secrets-*")
+		if err != nil {
+			e.hostSecretErr = fmt.Errorf("model: create host secrets dir: %w", err)
+			return
+		}
+		if err := os.Chmod(dir, 0o700); err != nil {
+			_ = os.RemoveAll(dir)
+			e.hostSecretErr = fmt.Errorf("model: chmod host secrets dir: %w", err)
+			return
+		}
+		fileCleanup, err := e.secretGuard.MaterializeHostFiles(dir)
+		if err != nil {
+			_ = os.RemoveAll(dir)
+			e.hostSecretErr = err
+			return
+		}
+		e.hostSecretCleanup = func() {
+			if fileCleanup != nil {
+				fileCleanup()
+			}
+			_ = os.RemoveAll(dir)
+		}
+	})
+	return e.hostSecretErr
 }
 
 // SetVars merges run-level workflow variables into the executor's
@@ -739,6 +801,15 @@ func (e *ClawExecutor) delegateHooksFor(nodeID string, backendName string, itera
 
 // Execute implements runtime.NodeExecutor.
 func (e *ClawExecutor) Execute(ctx context.Context, node ir.Node, input map[string]any) (map[string]any, error) {
+	// Host runs (no sandbox) materialise `as: file` workflow secrets to a
+	// tempdir on the first call so {{secrets.X.path}} resolves to a real
+	// host file for tool nodes AND for agent/judge prompts. Cheap
+	// sync.Once check after the first hit; a no-op when no file secrets
+	// are declared or when a sandbox owns the mounts.
+	if err := e.ensureHostSecretFiles(); err != nil {
+		return nil, err
+	}
+
 	// Promote the engine-supplied run ID into the richer
 	// runtimeContext that backends read for session-aware retries.
 	runID := RunIDFromContext(ctx)

--- a/pkg/backend/model/executor_host_secrets_test.go
+++ b/pkg/backend/model/executor_host_secrets_test.go
@@ -1,0 +1,165 @@
+package model
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/secretguard"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+)
+
+// TestExecutorHostFileSecret_MaterialisesAndReadsBack drives the fix
+// end-to-end: on a HOST (no-sandbox) run, `{{secrets.X.path}}` must
+// resolve to a real host file whose content is the plaintext value —
+// the exact scenario the veille bot hit before the fix
+// (path_ref='/run/iterion/secrets/webhooks' MISSING).
+func TestExecutorHostFileSecret_MaterialisesAndReadsBack(t *testing.T) {
+	const payload = "https://hook.example/w1"
+	guard := secretguard.New([]secretguard.Secret{{
+		Name:     "webhooks",
+		Value:    payload,
+		FilePath: "/run/iterion/secrets/webhooks",
+	}}, secretguard.DefaultConfig())
+
+	exec := newTestClawExecutor(NewRegistry(), &ir.Workflow{}, WithSecretGuard(guard))
+	t.Cleanup(func() { _ = exec.Close() })
+
+	// A tool node whose shell script reads the host path and echoes the
+	// content — proves the template resolves to a real file, and the file
+	// contains the expected plaintext.
+	node := &ir.ToolNode{
+		BaseNode: ir.BaseNode{ID: "read_webhooks"},
+		Command:  "cat {{secrets.webhooks.path}}",
+		CommandRefs: []*ir.Ref{{
+			Kind: ir.RefSecrets, Path: []string{"webhooks", "path"},
+			Raw: "{{secrets.webhooks.path}}",
+		}},
+	}
+	out, err := exec.Execute(context.Background(), node, map[string]any{})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if got, _ := out["result"].(string); !strings.Contains(got, payload) {
+		t.Fatalf("tool node did not read materialised host file (got %q, want to contain %q)", got, payload)
+	}
+
+	// The guard's file path should now be a host path (not the sandbox mount).
+	hostPath := guard.ResolveSecretRef("webhooks")
+	if hostPath == "/run/iterion/secrets/webhooks" {
+		t.Fatal("host materialisation did not rewrite the guard path")
+	}
+	if !filepath.IsAbs(hostPath) {
+		t.Fatalf("host path is not absolute: %q", hostPath)
+	}
+	info, err := os.Stat(hostPath)
+	if err != nil {
+		t.Fatalf("stat host secret file: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("host secret perms = %v, want 0600", info.Mode().Perm())
+	}
+
+	// Close removes the tempdir.
+	dir := filepath.Dir(hostPath)
+	if err := exec.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("Close did not remove host secret tempdir %q: %v", dir, err)
+	}
+}
+
+// TestExecutorHostFileSecret_OnceAcrossExecutions verifies the sync.Once
+// gate: two Execute calls reuse the same host tempfile, so the guard is
+// rewritten exactly once.
+func TestExecutorHostFileSecret_OnceAcrossExecutions(t *testing.T) {
+	guard := secretguard.New([]secretguard.Secret{{
+		Name:     "tok",
+		Value:    "v-abcdef",
+		FilePath: "/run/iterion/secrets/tok",
+	}}, secretguard.DefaultConfig())
+	exec := newTestClawExecutor(NewRegistry(), &ir.Workflow{}, WithSecretGuard(guard))
+	t.Cleanup(func() { _ = exec.Close() })
+
+	node := &ir.ToolNode{
+		BaseNode: ir.BaseNode{ID: "n"},
+		Command:  "echo {{secrets.tok.path}}",
+		CommandRefs: []*ir.Ref{{
+			Kind: ir.RefSecrets, Path: []string{"tok", "path"},
+			Raw: "{{secrets.tok.path}}",
+		}},
+	}
+	if _, err := exec.Execute(context.Background(), node, nil); err != nil {
+		t.Fatalf("Execute #1: %v", err)
+	}
+	first := guard.ResolveSecretRef("tok")
+	if _, err := exec.Execute(context.Background(), node, nil); err != nil {
+		t.Fatalf("Execute #2: %v", err)
+	}
+	if second := guard.ResolveSecretRef("tok"); second != first {
+		t.Fatalf("host path changed between calls (%q vs %q); sync.Once should hold", first, second)
+	}
+}
+
+// TestExecutorHostFileSecret_SandboxPathUnchanged is the byte-for-byte
+// safety net for the sandbox path: with a live sandbox handle,
+// ensureHostSecretFiles is a strict no-op — the guard's file path stays
+// at the sandbox mount, no tempdir is created, and Close has nothing to
+// clean up.
+func TestExecutorHostFileSecret_SandboxPathUnchanged(t *testing.T) {
+	guard := secretguard.New([]secretguard.Secret{{
+		Name:     "webhooks",
+		Value:    "sandbox-owned",
+		FilePath: "/run/iterion/secrets/webhooks",
+	}}, secretguard.DefaultConfig())
+	exec := newTestClawExecutor(NewRegistry(), &ir.Workflow{}, WithSecretGuard(guard))
+	exec.SetSandbox(fakeSandboxRun{})
+	t.Cleanup(func() { _ = exec.Close() })
+
+	if err := exec.ensureHostSecretFiles(); err != nil {
+		t.Fatalf("ensureHostSecretFiles (sandbox): %v", err)
+	}
+	if got := guard.ResolveSecretRef("webhooks"); got != "/run/iterion/secrets/webhooks" {
+		t.Errorf("sandbox path mutated (got %q); host materialisation must not touch sandbox runs", got)
+	}
+	hints := guard.SecretFileHints()
+	if len(hints) != 1 || hints[0].Path != "/run/iterion/secrets/webhooks" {
+		t.Errorf("sandbox hints mutated: %+v", hints)
+	}
+	if exec.hostSecretCleanup != nil {
+		t.Error("no host cleanup should be installed on the sandbox path")
+	}
+}
+
+// TestExecutorHostFileSecret_NoGuardNoOp checks the cheap fast-path: an
+// executor with no secret guard sees ensureHostSecretFiles as a no-op
+// (nil-safe) and installs no cleanup.
+func TestExecutorHostFileSecret_NoGuardNoOp(t *testing.T) {
+	exec := newTestClawExecutor(NewRegistry(), &ir.Workflow{})
+	t.Cleanup(func() { _ = exec.Close() })
+	if err := exec.ensureHostSecretFiles(); err != nil {
+		t.Fatalf("ensureHostSecretFiles: %v", err)
+	}
+	if exec.hostSecretCleanup != nil {
+		t.Error("no cleanup expected on the guardless path")
+	}
+}
+
+// fakeSandboxRun is the minimum satisfying sandbox.Run implementation
+// for the "sandbox path unchanged" test — it never has to actually run
+// anything because ensureHostSecretFiles bails out on `e.sandbox != nil`.
+type fakeSandboxRun struct{}
+
+func (fakeSandboxRun) Driver() string { return "fake" }
+func (fakeSandboxRun) Command(ctx context.Context, _ []string, _ sandbox.ExecOpts) *exec.Cmd {
+	return exec.CommandContext(ctx, "true")
+}
+func (fakeSandboxRun) Exec(context.Context, []string, sandbox.ExecOpts) (sandbox.ExecResult, error) {
+	return sandbox.ExecResult{}, nil
+}
+func (fakeSandboxRun) Cleanup(context.Context) error { return nil }

--- a/pkg/backend/secretguard/secretguard.go
+++ b/pkg/backend/secretguard/secretguard.go
@@ -28,11 +28,16 @@
 package secretguard
 
 import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/SocialGouv/iterion/pkg/backend/tool/privacy/detector"
+	"github.com/SocialGouv/iterion/pkg/secrets"
 )
 
 // Secret is one protected value. Value is the plaintext; Placeholder
@@ -110,6 +115,10 @@ func DefaultConfig() Config {
 func PlaceholderForName(name string) string { return defaultPlaceholder(name) }
 
 // Guard is an immutable, concurrency-safe scrubber built once per run.
+// The one documented mutation seam is MaterializeHostFiles, which rewrites
+// filePathByName / fileHints exactly once per run under a caller-provided
+// sync.Once so the rewrite happens strictly before any concurrent Execute
+// consults ResolveSecretRef.
 type Guard struct {
 	secrets            []Secret
 	literalPlaceholder map[string]string // every encoding → its placeholder
@@ -117,6 +126,7 @@ type Guard struct {
 	placeholderValue   map[string]string // placeholder → raw value (Materialize)
 	filePathByName     map[string]string // secret name → mounted file path
 	fileHints          []FileSecretHint
+	fileValueByName    map[string]string   // secret name → file plaintext (host materialisation)
 	encodingsByName    map[string][]string // secret name → its value encodings (egress DLP)
 	det                *detector.Detector
 	cfg                Config
@@ -170,6 +180,16 @@ func New(secrets []Secret, cfg Config) *Guard {
 		if s.FilePath != "" {
 			g.filePathByName[s.Name] = s.FilePath
 			g.fileHints = append(g.fileHints, FileSecretHint{Name: s.Name, Path: s.FilePath, Env: s.Env})
+			// Keep the plaintext for host materialisation, even for values
+			// below MinLen (which the redaction/DLP path drops as unsafe to
+			// taint). MaterializeHostFiles is the only reader; the exported
+			// SecretFileHints never carries it.
+			if s.Value != "" {
+				if g.fileValueByName == nil {
+					g.fileValueByName = make(map[string]string, 1)
+				}
+				g.fileValueByName[s.Name] = s.Value
+			}
 		}
 		if len([]rune(s.Value)) < cfg.MinLen {
 			continue
@@ -511,4 +531,51 @@ func (g *Guard) SecretFileHints() []FileSecretHint {
 	out := make([]FileSecretHint, len(g.fileHints))
 	copy(out, g.fileHints)
 	return out
+}
+
+// MaterializeHostFiles writes each file secret's plaintext to
+// dir/<sanitized-name> (files 0600) and rewrites the guard so
+// ResolveSecretRef + SecretFileHints return the HOST path instead of the
+// sandbox mount path. It is the non-sandbox counterpart to the sandbox
+// driver's SecretFiles bind-mounts: on a host (non-sandbox) run nothing
+// else writes the mount path, so a {{secrets.X.path}} reference would
+// otherwise resolve to /run/iterion/secrets/X and fail on read.
+//
+// File secrets with no resolved value (Optional + unbound) are skipped
+// verbatim — the guard keeps the sandbox mount path so the tool sees the
+// same "no such file" it would in a sandbox, mirroring
+// pkg/runtime/sandbox_secret_files.go's skip.
+//
+// Concurrency: the caller MUST serialise this method against any concurrent
+// ResolveSecretRef / SecretFileHints reader (the executor guards it with a
+// sync.Once fired before dispatching any node). The returned cleanup removes
+// each written file; callers typically wrap it to also remove `dir`. Nil-safe.
+func (g *Guard) MaterializeHostFiles(dir string) (func(), error) {
+	if g == nil || len(g.fileHints) == 0 {
+		return func() {}, nil
+	}
+	if strings.TrimSpace(dir) == "" {
+		return nil, errors.New("secretguard: host materialisation dir is empty")
+	}
+	var written []string
+	cleanup := func() {
+		for _, p := range written {
+			_ = os.Remove(p)
+		}
+	}
+	for i, h := range g.fileHints {
+		val, ok := g.fileValueByName[h.Name]
+		if !ok || val == "" {
+			continue
+		}
+		hostPath := filepath.Join(dir, secrets.SanitizeFileName(h.Name))
+		if err := os.WriteFile(hostPath, []byte(val), 0o600); err != nil {
+			cleanup()
+			return nil, fmt.Errorf("secretguard: write host secret file %q: %w", h.Name, err)
+		}
+		written = append(written, hostPath)
+		g.fileHints[i].Path = hostPath
+		g.filePathByName[h.Name] = hostPath
+	}
+	return cleanup, nil
 }

--- a/pkg/backend/secretguard/secretguard_test.go
+++ b/pkg/backend/secretguard/secretguard_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -279,6 +281,150 @@ func TestFileSecretReferenceRendersPathAndRegistersValue(t *testing.T) {
 	hints := g.SecretFileHints()
 	if len(hints) != 1 || hints[0].Path != "/run/iterion/secrets/kubeconfig" || hints[0].Env != "KUBECONFIG" {
 		t.Fatalf("file hints not preserved: %+v", hints)
+	}
+}
+
+// TestMaterializeHostFiles_RewritesPathAndWritesValue guards the host
+// materialisation seam: on a non-sandbox run, MaterializeHostFiles writes
+// each file secret's plaintext to dir/<sanitized-name> (0600) and
+// rewrites ResolveSecretRef + SecretFileHints to the HOST path so
+// {{secrets.X.path}} resolves to a real file.
+func TestMaterializeHostFiles_RewritesPathAndWritesValue(t *testing.T) {
+	const payload = "webhook-content-abcdef"
+	g := newTestGuard(t, Secret{
+		Name:     "webhooks.json",
+		Value:    payload,
+		FilePath: "/run/iterion/secrets/webhooks.json",
+		Env:      "WEBHOOKS_FILE",
+	})
+	dir := t.TempDir()
+	cleanup, err := g.MaterializeHostFiles(dir)
+	if err != nil {
+		t.Fatalf("MaterializeHostFiles: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("cleanup should not be nil")
+	}
+
+	wantPath := filepath.Join(dir, "webhooks.json")
+	if got := g.ResolveSecretRef("webhooks.json"); got != wantPath {
+		t.Errorf("ResolveSecretRef after materialise = %q, want %q", got, wantPath)
+	}
+	hints := g.SecretFileHints()
+	if len(hints) != 1 || hints[0].Path != wantPath {
+		t.Fatalf("hints not rewritten: %+v", hints)
+	}
+
+	info, err := os.Stat(wantPath)
+	if err != nil {
+		t.Fatalf("stat host secret file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("host secret file perms = %v, want 0600", perm)
+	}
+	b, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read host secret file: %v", err)
+	}
+	if string(b) != payload {
+		t.Errorf("host secret content = %q, want %q", string(b), payload)
+	}
+
+	cleanup()
+	if _, err := os.Stat(wantPath); !os.IsNotExist(err) {
+		t.Errorf("cleanup did not remove host secret file: %v", err)
+	}
+}
+
+// TestMaterializeHostFiles_SanitisesFilename verifies the host filename
+// follows the shared SanitizeFileName rule (non-safe chars → `_`), so a
+// secret named e.g. "cluster/kubeconfig" lands under a portable basename
+// regardless of the DSL name shape.
+func TestMaterializeHostFiles_SanitisesFilename(t *testing.T) {
+	g := newTestGuard(t, Secret{
+		Name:     "cluster/kubeconfig",
+		Value:    "content",
+		FilePath: "/run/iterion/secrets/cluster_kubeconfig",
+	})
+	dir := t.TempDir()
+	cleanup, err := g.MaterializeHostFiles(dir)
+	if err != nil {
+		t.Fatalf("MaterializeHostFiles: %v", err)
+	}
+	defer cleanup()
+	got := g.ResolveSecretRef("cluster/kubeconfig")
+	want := filepath.Join(dir, "cluster_kubeconfig")
+	if got != want {
+		t.Errorf("ResolveSecretRef = %q, want %q", got, want)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Errorf("host secret file missing at %q: %v", want, err)
+	}
+}
+
+// TestMaterializeHostFiles_SkipsEmptyValue mirrors the sandbox skip for
+// an Optional file secret with no resolved value: no host file is
+// written, and the mount path stays at the pre-materialise value so the
+// tool sees the same "no such file" it would in a sandbox.
+func TestMaterializeHostFiles_SkipsEmptyValue(t *testing.T) {
+	g := newTestGuard(t, Secret{
+		Name:     "opt",
+		Value:    "",
+		FilePath: "/run/iterion/secrets/opt",
+	})
+	dir := t.TempDir()
+	cleanup, err := g.MaterializeHostFiles(dir)
+	if err != nil {
+		t.Fatalf("MaterializeHostFiles: %v", err)
+	}
+	defer cleanup()
+	if got := g.ResolveSecretRef("opt"); got != "/run/iterion/secrets/opt" {
+		t.Errorf("empty-value secret path should be unchanged, got %q", got)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Errorf("no file should be written for empty value, got %v", entries)
+	}
+}
+
+// TestMaterializeHostFiles_NoFileHints is a no-op safety: a guard with
+// only value secrets returns a nil-safe cleanup and no error.
+func TestMaterializeHostFiles_NoFileHints(t *testing.T) {
+	g := newTestGuard(t, Secret{Name: "token", Value: fakeKey})
+	cleanup, err := g.MaterializeHostFiles(t.TempDir())
+	if err != nil {
+		t.Fatalf("MaterializeHostFiles: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("cleanup should not be nil even on no-op")
+	}
+	cleanup() // must not panic
+}
+
+// TestMaterializeHostFiles_NilGuard is the nil-guard no-op path.
+func TestMaterializeHostFiles_NilGuard(t *testing.T) {
+	var g *Guard
+	cleanup, err := g.MaterializeHostFiles("/tmp/does-not-matter")
+	if err != nil {
+		t.Fatalf("nil guard: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("nil guard should still return a callable cleanup")
+	}
+	cleanup()
+}
+
+// TestMaterializeHostFiles_EmptyDirError refuses an empty target dir so
+// a caller that forgets to build the tempdir sees a loud failure instead
+// of silently writing to CWD.
+func TestMaterializeHostFiles_EmptyDirError(t *testing.T) {
+	g := newTestGuard(t, Secret{
+		Name:     "tok",
+		Value:    "v",
+		FilePath: "/run/iterion/secrets/tok",
+	})
+	if _, err := g.MaterializeHostFiles(""); err == nil {
+		t.Fatal("expected error on empty dir")
 	}
 }
 

--- a/pkg/secrets/files.go
+++ b/pkg/secrets/files.go
@@ -10,16 +10,25 @@ const SecretFilesMountDir = "/run/iterion/secrets"
 
 var secretFileNameSanitizer = regexp.MustCompile(`[^A-Za-z0-9_.-]+`)
 
-// DefaultFileMountPath returns the stable in-sandbox file path for a
-// workflow secret mounted as a file. The path is deterministic so prompts
-// can reference it before the sandbox container is started.
-func DefaultFileMountPath(name string) string {
+// SanitizeFileName reduces a secret name to a safe basename for a secret
+// file (letters, digits, `_`, `.`, `-`). It is the shared rule behind
+// DefaultFileMountPath (sandbox mount) and the host-side materialisation
+// used by non-sandbox runs, so the same secret lands under the same
+// filename on either path.
+func SanitizeFileName(name string) string {
 	clean := secretFileNameSanitizer.ReplaceAllString(name, "_")
 	clean = strings.Trim(clean, "._-")
 	if clean == "" {
 		clean = "secret"
 	}
-	return SecretFilesMountDir + "/" + clean
+	return clean
+}
+
+// DefaultFileMountPath returns the stable in-sandbox file path for a
+// workflow secret mounted as a file. The path is deterministic so prompts
+// can reference it before the sandbox container is started.
+func DefaultFileMountPath(name string) string {
+	return SecretFilesMountDir + "/" + SanitizeFileName(name)
 }
 
 func ResolveFileMountPath(name, override string) string {


### PR DESCRIPTION
## Bug

An `as: file` workflow secret only materialized **inside a sandbox** — the sandbox driver bind-mounts it at `/run/iterion/secrets/<name>` via `SecretFiles`. On a **host (non-sandbox) run** — the exact path `iterion schedule`/cron uses — `{{secrets.X.path}}` still resolved to that in-container mount path, which nothing writes on the host. Tool nodes and agent prompts referencing the path read a dangling file.

Surfaced dogfooding a feed-watch (Vigie) veille bot: the deterministic `notify` tool node reads `{{secrets.webhooks.path}}` to POST a digest to a Mattermost webhook, and it 404'd on every host run.

## Fix

On the first `Execute` of a **non-sandbox** run, the executor materializes each `as: file` secret to a per-run host tempdir (dir `0700`, files `0600`) and rewrites the guard so `{{secrets.X.path}}` and the file secret's `env:` var resolve to the host path. Cleaned up on executor `Close()`.

- Strictly gated on `e.sandbox == nil` — **sandbox runs are byte-for-byte unchanged** (still the bind-mount path).
- `sync.Once`-guarded, fired before any node's template resolution, so the rewrite lands before any concurrent `ResolveSecretRef` reader.
- Errors surface (a write failure fails the node — no silent skip); unresolved optional secrets are skipped verbatim, mirroring the sandbox skip.
- `Guard.MaterializeHostFiles` owns the write; the newly-shared `secrets.SanitizeFileName` keeps the host basename identical to the sandbox mount basename.

## Tests

- `pkg/backend/secretguard`: rewrite + read-back + `0600` perms, sanitization, empty-value skip (sandbox parity), no-hints / nil-guard no-ops, empty-dir loud error.
- `pkg/backend/model`: a host tool node reading `{{secrets.X.path}}` sees the content; `sync.Once` idempotency; sandbox-path-unchanged; no-guard fast path.

Verified end-to-end: a host run of a bot with `secrets: webhooks: {as: file}` now resolves the path to a real `/tmp/iterion-secrets-*/webhooks` (0600, correct bytes) instead of the dangling `/run/iterion/secrets/webhooks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
