### PR TITLE
feat(cloud): native recurring schedules can run stateful repo-bound bots

### DIFF
--- a/bots/feed-watch/main.bot
+++ b/bots/feed-watch/main.bot
@@ -56,6 +56,17 @@ secrets:
     as: file
     optional: true
 
+  ## Forge API token, mounted read-only as a FILE (path/env only, never
+  ## read into a prompt). Used by state_commit=true runs so the cloud
+  ## runner injects it into the clone URL and the bot's `git push` of
+  ## the state dir authenticates. optional: true so a local/host run —
+  ## which authenticates git via the user's host credentials — still
+  ## works with no binding. An org binds its forge credential to this
+  ## name via a bot-secret binding, mirroring dep-update-guard.
+  forge_token:
+    as: file
+    optional: true
+
 vars:
   workspace_dir: string = "${PROJECT_DIR}"
 

--- a/cmd/iterion/remote_schedules.go
+++ b/cmd/iterion/remote_schedules.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"github.com/SocialGouv/iterion/pkg/cli"
+	"github.com/spf13/cobra"
+)
+
+// remote schedules — team-scoped CRUD over cloud recurring bot schedules.
+// Cloud-only (list/create/delete 404 when the target instance has no cloud
+// scheduler wired). Reuses teamBase + the shared JSON printers.
+
+var remoteSchedulesCmd = &cobra.Command{
+	Use:   "schedules",
+	Short: "Cron recurring bot schedules (team scope, cloud only)",
+}
+
+var remoteSchedulesListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List schedules for the active team",
+	Args:  cobra.NoArgs,
+	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
+		base, err := teamBase(cmd, c, "/schedules")
+		if err != nil {
+			return err
+		}
+		return cli.RemoteGetPrint(cmd.Context(), c, p, base)
+	}),
+}
+
+var remoteSchedulesCreateData string
+
+var remoteSchedulesCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a schedule (--data JSON: {bot_id, cron, vars?, repo_url?, repo_ref?, disabled?})",
+	Args:  cobra.NoArgs,
+	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
+		base, err := teamBase(cmd, c, "/schedules")
+		if err != nil {
+			return err
+		}
+		return cli.RemoteSendData(cmd.Context(), c, p, "POST", base, remoteSchedulesCreateData, "schedule JSON")
+	}),
+}
+
+var remoteSchedulesDeleteCmd = &cobra.Command{
+	Use:   "delete <schedule-id>",
+	Short: "Delete a schedule",
+	Args:  cobra.ExactArgs(1),
+	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
+		base, err := teamBase(cmd, c, "/schedules")
+		if err != nil {
+			return err
+		}
+		return cli.RemoteSendPrint(cmd.Context(), c, p, "DELETE", base+"/"+args[0], nil)
+	}),
+}
+
+func init() {
+	remoteSchedulesCreateCmd.Flags().StringVar(&remoteSchedulesCreateData, "data", "", "Schedule JSON (literal, @file, or @- for stdin)")
+	for _, c := range []*cobra.Command{remoteSchedulesListCmd, remoteSchedulesCreateCmd, remoteSchedulesDeleteCmd} {
+		c.Flags().StringVar(&remoteTeamFlag, "team", "", "Team id (default: switched/active team)")
+	}
+	remoteSchedulesCmd.AddCommand(remoteSchedulesListCmd, remoteSchedulesCreateCmd, remoteSchedulesDeleteCmd)
+	remoteCmd.AddCommand(remoteSchedulesCmd)
+}

--- a/pkg/cloudsched/cloudsched_test.go
+++ b/pkg/cloudsched/cloudsched_test.go
@@ -96,6 +96,96 @@ func TestTicker_DisabledNotFired(t *testing.T) {
 	}
 }
 
+// TestMemoryStore_CRUDRoundTrip exercises the CRUD surface added by the
+// team-scoped schedules REST API: create → list-by-team → get → update cron
+// (recomputes NextFireAt) → delete. Kept in-memory so it runs on `go test`
+// with no external dependency.
+func TestMemoryStore_CRUDRoundTrip(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+	now := time.Date(2026, 6, 22, 10, 0, 0, 0, time.UTC)
+	nextInit, err := NextFire("*/5 * * * *", now)
+	if err != nil {
+		t.Fatalf("NextFire seed: %v", err)
+	}
+	sb := ScheduledBot{
+		ID:         "sb-crud",
+		TenantID:   "team-A",
+		BotID:      "feed-watch",
+		Cron:       "*/5 * * * *",
+		Vars:       map[string]string{"mode": "digest"},
+		RepoURL:    "https://example.com/repo.git",
+		RepoRef:    "main",
+		NextFireAt: nextInit,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := store.Create(ctx, sb); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// List-by-team surfaces the new row (and only it).
+	rows, err := store.ListByTenant(ctx, "team-A")
+	if err != nil || len(rows) != 1 || rows[0].ID != "sb-crud" {
+		t.Fatalf("ListByTenant team-A: %+v err=%v", rows, err)
+	}
+	if rows[0].RepoURL != "https://example.com/repo.git" || rows[0].RepoRef != "main" {
+		t.Errorf("repo fields not persisted: %+v", rows[0])
+	}
+	otherRows, err := store.ListByTenant(ctx, "team-B")
+	if err != nil || len(otherRows) != 0 {
+		t.Errorf("ListByTenant team-B: %+v err=%v", otherRows, err)
+	}
+
+	// Get returns the same shape.
+	got, err := store.Get(ctx, "sb-crud")
+	if err != nil || got.BotID != "feed-watch" {
+		t.Fatalf("Get: %+v err=%v", got, err)
+	}
+
+	// Update: switch cron → NextFireAt must jump to the hourly slot.
+	newCron := "0 * * * *"
+	nextUpdated, err := NextFire(newCron, now)
+	if err != nil {
+		t.Fatalf("NextFire update: %v", err)
+	}
+	disabled := true
+	updated, err := store.Update(ctx, "sb-crud", SchedulePatch{
+		Cron:       &newCron,
+		NextFireAt: &nextUpdated,
+		Disabled:   &disabled,
+		UpdatedAt:  now.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Cron != newCron || !updated.NextFireAt.Equal(nextUpdated) {
+		t.Errorf("post-update state: %+v (want cron=%q next=%s)", updated, newCron, nextUpdated)
+	}
+	if !updated.Disabled {
+		t.Errorf("disabled flag not applied: %+v", updated)
+	}
+	if !updated.UpdatedAt.Equal(now.Add(time.Hour)) {
+		t.Errorf("UpdatedAt not stamped: %s", updated.UpdatedAt)
+	}
+
+	// Update unknown id → ErrNotFound (round-tripped by the REST handler as 404).
+	if _, err := store.Update(ctx, "does-not-exist", SchedulePatch{Disabled: &disabled}); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Update ghost: want ErrNotFound, got %v", err)
+	}
+
+	// Delete removes it.
+	if err := store.Delete(ctx, "sb-crud"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := store.Get(ctx, "sb-crud"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get after delete: want ErrNotFound, got %v", err)
+	}
+	if err := store.Delete(ctx, "sb-crud"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Delete after delete: want ErrNotFound, got %v", err)
+	}
+}
+
 func TestMongoStore_CAS(t *testing.T) {
 	uri := os.Getenv("ITERION_TEST_MONGO_URI")
 	if uri == "" {

--- a/pkg/cloudsched/memory.go
+++ b/pkg/cloudsched/memory.go
@@ -52,6 +52,19 @@ func (s *MemoryStore) ListByIntegration(_ context.Context, tenantID, integration
 	return out, nil
 }
 
+func (s *MemoryStore) ListByTenant(_ context.Context, tenantID string) ([]ScheduledBot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []ScheduledBot
+	for _, sb := range s.m {
+		if sb.TenantID == tenantID {
+			out = append(out, sb)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt.Before(out[j].CreatedAt) })
+	return out, nil
+}
+
 func (s *MemoryStore) ListDue(_ context.Context, now time.Time, limit int) ([]ScheduledBot, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -81,6 +94,18 @@ func (s *MemoryStore) ClaimTick(_ context.Context, id string, expectedNext, newN
 	sb.UpdatedAt = firedAt
 	s.m[id] = sb
 	return true, nil
+}
+
+func (s *MemoryStore) Update(_ context.Context, id string, patch SchedulePatch) (ScheduledBot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sb, ok := s.m[id]
+	if !ok {
+		return ScheduledBot{}, ErrNotFound
+	}
+	applySchedulePatch(&sb, patch)
+	s.m[id] = sb
+	return sb, nil
 }
 
 func (s *MemoryStore) Delete(_ context.Context, id string) error {

--- a/pkg/cloudsched/mongo.go
+++ b/pkg/cloudsched/mongo.go
@@ -66,6 +66,19 @@ func (s *MongoStore) ListByIntegration(ctx context.Context, tenantID, integratio
 	return out, nil
 }
 
+func (s *MongoStore) ListByTenant(ctx context.Context, tenantID string) ([]ScheduledBot, error) {
+	opt := options.Find().SetSort(bson.D{{Key: "created_at", Value: 1}})
+	cur, err := s.coll.Find(ctx, bson.M{"tenant_id": tenantID}, opt)
+	if err != nil {
+		return nil, fmt.Errorf("cloudsched: list by tenant: %w", err)
+	}
+	var out []ScheduledBot
+	if err := cur.All(ctx, &out); err != nil {
+		return nil, fmt.Errorf("cloudsched: decode: %w", err)
+	}
+	return out, nil
+}
+
 func (s *MongoStore) ListDue(ctx context.Context, now time.Time, limit int) ([]ScheduledBot, error) {
 	opt := options.Find().SetSort(bson.D{{Key: "next_fire_at", Value: 1}})
 	if limit > 0 {
@@ -97,6 +110,23 @@ func (s *MongoStore) ClaimTick(ctx context.Context, id string, expectedNext, new
 		return false, fmt.Errorf("cloudsched: claim tick: %w", err)
 	}
 	return res.MatchedCount > 0, nil
+}
+
+// Update applies a partial mutation. Reads the current row, mutates it via
+// applySchedulePatch, and writes back via ReplaceOne — the atomicity that
+// matters here is exactly-once fire (ClaimTick's CAS), not multi-writer
+// serialisation on the mutable payload (Cron/Vars/…), so a full replace is
+// safe and matches the semantics operators expect from a REST PATCH.
+func (s *MongoStore) Update(ctx context.Context, id string, patch SchedulePatch) (ScheduledBot, error) {
+	sb, err := s.Get(ctx, id)
+	if err != nil {
+		return ScheduledBot{}, err
+	}
+	applySchedulePatch(&sb, patch)
+	if _, err := s.coll.ReplaceOne(ctx, bson.M{"_id": id}, sb); err != nil {
+		return ScheduledBot{}, fmt.Errorf("cloudsched: update: %w", err)
+	}
+	return sb, nil
 }
 
 func (s *MongoStore) Delete(ctx context.Context, id string) error {

--- a/pkg/cloudsched/schedule.go
+++ b/pkg/cloudsched/schedule.go
@@ -13,7 +13,11 @@ import (
 	"github.com/robfig/cron/v3"
 )
 
-// ScheduledBot is one cron-scheduled bot run bound to a repo integration.
+// ScheduledBot is one cron-scheduled bot run. When RepoURL is set the cloud
+// runner clones that repo before the bot starts (RepoRef pins the ref);
+// stateful bots that persist to git (e.g. feed-watch state_commit=true) need
+// this to have a workspace to push to. When RepoURL is empty the run executes
+// against the runner pod's base WorkDir, matching the pre-repo behaviour.
 type ScheduledBot struct {
 	ID                string            `bson:"_id" json:"id"`
 	TenantID          string            `bson:"tenant_id" json:"tenant_id"`
@@ -21,6 +25,8 @@ type ScheduledBot struct {
 	BotID             string            `bson:"bot_id" json:"bot_id"`
 	Cron              string            `bson:"cron" json:"cron"` // 5-field standard cron
 	Vars              map[string]string `bson:"vars,omitempty" json:"vars,omitempty"`
+	RepoURL           string            `bson:"repo_url,omitempty" json:"repo_url,omitempty"`
+	RepoRef           string            `bson:"repo_ref,omitempty" json:"repo_ref,omitempty"`
 	Disabled          bool              `bson:"disabled,omitempty" json:"disabled,omitempty"`
 
 	// NextFireAt is the next UTC instant this schedule is due. The ticker
@@ -41,6 +47,10 @@ type Store interface {
 	Create(ctx context.Context, sb ScheduledBot) error
 	Get(ctx context.Context, id string) (ScheduledBot, error)
 	ListByIntegration(ctx context.Context, tenantID, integrationID string) ([]ScheduledBot, error)
+	// ListByTenant returns every schedule owned by tenantID (including rows
+	// with an empty RepoIntegrationID — the manual CRUD path). Ordered by
+	// CreatedAt ascending for stable rendering.
+	ListByTenant(ctx context.Context, tenantID string) ([]ScheduledBot, error)
 	// ListDue returns enabled schedules whose next_fire_at <= now (capped by
 	// limit, 0 = no cap), oldest-due first.
 	ListDue(ctx context.Context, now time.Time, limit int) ([]ScheduledBot, error)
@@ -49,8 +59,26 @@ type Store interface {
 	// THIS caller won the CAS. A losing replica gets (false, nil). This is the
 	// exactly-once primitive — no leader election.
 	ClaimTick(ctx context.Context, id string, expectedNext, newNext, firedAt time.Time) (bool, error)
+	// Update applies a partial mutation to an existing schedule. Only the
+	// non-nil fields of patch are written; NextFireAt is recomputed from the
+	// new Cron when Cron is set.
+	Update(ctx context.Context, id string, patch SchedulePatch) (ScheduledBot, error)
 	Delete(ctx context.Context, id string) error
 	DeleteByIntegration(ctx context.Context, tenantID, integrationID string) error
+}
+
+// SchedulePatch describes the mutable slice of ScheduledBot the manual CRUD
+// endpoint exposes. Nil field = leave untouched. Cron carries the new
+// expression when set (already validated by ValidateCron); the store
+// recomputes NextFireAt through NextFire(cron, now).
+type SchedulePatch struct {
+	Cron       *string
+	NextFireAt *time.Time
+	Vars       *map[string]string
+	RepoURL    *string
+	RepoRef    *string
+	Disabled   *bool
+	UpdatedAt  time.Time
 }
 
 // ErrNotFound is returned by Get/Delete for an unknown id.
@@ -71,4 +99,32 @@ func NextFire(expr string, after time.Time) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("cloudsched: invalid cron %q: %w", expr, err)
 	}
 	return sched.Next(after), nil
+}
+
+// applySchedulePatch mutates sb in place with the non-nil fields of patch.
+// UpdatedAt is stamped from patch.UpdatedAt (caller-provided so tests are
+// deterministic). NextFireAt takes patch.NextFireAt when set — callers with a
+// new Cron pre-compute this via NextFire so the store never calls time.Now.
+func applySchedulePatch(sb *ScheduledBot, patch SchedulePatch) {
+	if patch.Cron != nil {
+		sb.Cron = *patch.Cron
+	}
+	if patch.NextFireAt != nil {
+		sb.NextFireAt = *patch.NextFireAt
+	}
+	if patch.Vars != nil {
+		sb.Vars = *patch.Vars
+	}
+	if patch.RepoURL != nil {
+		sb.RepoURL = *patch.RepoURL
+	}
+	if patch.RepoRef != nil {
+		sb.RepoRef = *patch.RepoRef
+	}
+	if patch.Disabled != nil {
+		sb.Disabled = *patch.Disabled
+	}
+	if !patch.UpdatedAt.IsZero() {
+		sb.UpdatedAt = patch.UpdatedAt
+	}
 }

--- a/pkg/server/schedules_routes.go
+++ b/pkg/server/schedules_routes.go
@@ -1,0 +1,221 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/cloudsched"
+)
+
+// registerScheduleRoutes wires the team-scoped CRUD REST API for cloud
+// recurring bot schedules. Cloud-only: registered by server_routes when the
+// cloudsched store is present (local mode has no ticker to fire them).
+// Mirrors the sibling generic-secrets / bot-bindings routes for
+// requireAuth + team-authorization semantics.
+func (s *Server) registerScheduleRoutes() {
+	s.mux.Handle("GET /api/teams/{id}/schedules", s.requireAuth(http.HandlerFunc(s.handleListSchedules)))
+	s.mux.Handle("POST /api/teams/{id}/schedules", s.requireAuth(http.HandlerFunc(s.handleCreateSchedule)))
+	s.mux.Handle("PATCH /api/teams/{id}/schedules/{sid}", s.requireAuth(http.HandlerFunc(s.handleUpdateSchedule)))
+	s.mux.Handle("DELETE /api/teams/{id}/schedules/{sid}", s.requireAuth(http.HandlerFunc(s.handleDeleteSchedule)))
+}
+
+type createScheduleReq struct {
+	BotID    string            `json:"bot_id"`
+	Cron     string            `json:"cron"`
+	Vars     map[string]string `json:"vars,omitempty"`
+	RepoURL  string            `json:"repo_url,omitempty"`
+	RepoRef  string            `json:"repo_ref,omitempty"`
+	Disabled bool              `json:"disabled,omitempty"`
+}
+
+type updateScheduleReq struct {
+	Cron     *string            `json:"cron,omitempty"`
+	Vars     *map[string]string `json:"vars,omitempty"`
+	RepoURL  *string            `json:"repo_url,omitempty"`
+	RepoRef  *string            `json:"repo_ref,omitempty"`
+	Disabled *bool              `json:"disabled,omitempty"`
+}
+
+// scheduleNow returns the UTC instant used for CreatedAt / UpdatedAt and to
+// seed NextFire. Tests override via s.scheduleClock (a package-level test
+// hook) so NextFireAt is deterministic. Default is time.Now().UTC() —
+// matching the forge Orchestrator's clock default.
+func (s *Server) scheduleNow() time.Time {
+	if s.scheduleClock != nil {
+		return s.scheduleClock().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (s *Server) handleListSchedules(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	teamID := r.PathValue("id")
+	if !s.canViewTeam(r.Context(), id, teamID) {
+		httpError(w, http.StatusForbidden, "not a member")
+		return
+	}
+	rows, err := s.cfg.ScheduledBots.ListByTenant(r.Context(), teamID)
+	if err != nil {
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	if rows == nil {
+		rows = []cloudsched.ScheduledBot{}
+	}
+	writeJSON(w, struct {
+		Schedules []cloudsched.ScheduledBot `json:"schedules"`
+	}{Schedules: rows})
+}
+
+func (s *Server) handleCreateSchedule(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	teamID := r.PathValue("id")
+	if !s.canManageTeam(r.Context(), id, teamID) {
+		httpError(w, http.StatusForbidden, "admin or owner required")
+		return
+	}
+	var req createScheduleReq
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	botID := strings.TrimSpace(req.BotID)
+	cronExpr := strings.TrimSpace(req.Cron)
+	if botID == "" || cronExpr == "" {
+		httpError(w, http.StatusBadRequest, "bot_id and cron required")
+		return
+	}
+	if err := cloudsched.ValidateCron(cronExpr); err != nil {
+		httpError(w, http.StatusBadRequest, "%s", err.Error())
+		return
+	}
+	now := s.scheduleNow()
+	next, err := cloudsched.NextFire(cronExpr, now)
+	if err != nil {
+		httpError(w, http.StatusBadRequest, "%s", err.Error())
+		return
+	}
+	sb := cloudsched.ScheduledBot{
+		ID:         uuid.NewString(),
+		TenantID:   teamID,
+		BotID:      botID,
+		Cron:       cronExpr,
+		Vars:       req.Vars,
+		RepoURL:    strings.TrimSpace(req.RepoURL),
+		RepoRef:    strings.TrimSpace(req.RepoRef),
+		Disabled:   req.Disabled,
+		NextFireAt: next,
+		CreatedBy:  id.UserID,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := s.cfg.ScheduledBots.Create(r.Context(), sb); err != nil {
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	s.auditTenant(r, teamID, "schedule.created", "schedule", sb.ID, map[string]any{
+		"bot_id": botID, "cron": cronExpr, "repo_url": sb.RepoURL != "", "disabled": sb.Disabled,
+	})
+	w.WriteHeader(http.StatusCreated)
+	writeJSON(w, sb)
+}
+
+// scheduleForTeam looks the row up and enforces tenant ownership. A row that
+// belongs to another team surfaces as 404, not 403, so a caller can't probe
+// for schedule ids across teams — same discipline as bindingForTenantBot.
+func (s *Server) scheduleForTeam(w http.ResponseWriter, r *http.Request, teamID, id string) (cloudsched.ScheduledBot, bool) {
+	sb, err := s.cfg.ScheduledBots.Get(r.Context(), id)
+	if err != nil || sb.TenantID != teamID {
+		httpError(w, http.StatusNotFound, "schedule not found")
+		return cloudsched.ScheduledBot{}, false
+	}
+	return sb, true
+}
+
+func (s *Server) handleUpdateSchedule(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	teamID := r.PathValue("id")
+	if !s.canManageTeam(r.Context(), id, teamID) {
+		httpError(w, http.StatusForbidden, "admin or owner required")
+		return
+	}
+	scheduleID := r.PathValue("sid")
+	if _, ok := s.scheduleForTeam(w, r, teamID, scheduleID); !ok {
+		return
+	}
+	var req updateScheduleReq
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	now := s.scheduleNow()
+	patch := cloudsched.SchedulePatch{UpdatedAt: now}
+	if req.Cron != nil {
+		cronExpr := strings.TrimSpace(*req.Cron)
+		if err := cloudsched.ValidateCron(cronExpr); err != nil {
+			httpError(w, http.StatusBadRequest, "%s", err.Error())
+			return
+		}
+		next, err := cloudsched.NextFire(cronExpr, now)
+		if err != nil {
+			httpError(w, http.StatusBadRequest, "%s", err.Error())
+			return
+		}
+		patch.Cron = &cronExpr
+		patch.NextFireAt = &next
+	}
+	if req.Vars != nil {
+		patch.Vars = req.Vars
+	}
+	if req.RepoURL != nil {
+		trimmed := strings.TrimSpace(*req.RepoURL)
+		patch.RepoURL = &trimmed
+	}
+	if req.RepoRef != nil {
+		trimmed := strings.TrimSpace(*req.RepoRef)
+		patch.RepoRef = &trimmed
+	}
+	if req.Disabled != nil {
+		patch.Disabled = req.Disabled
+	}
+	updated, err := s.cfg.ScheduledBots.Update(r.Context(), scheduleID, patch)
+	if err != nil {
+		if errors.Is(err, cloudsched.ErrNotFound) {
+			httpError(w, http.StatusNotFound, "schedule not found")
+			return
+		}
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	s.auditTenant(r, teamID, "schedule.updated", "schedule", updated.ID, map[string]any{
+		"bot_id": updated.BotID, "cron_changed": req.Cron != nil, "disabled_changed": req.Disabled != nil,
+	})
+	writeJSON(w, updated)
+}
+
+func (s *Server) handleDeleteSchedule(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	teamID := r.PathValue("id")
+	if !s.canManageTeam(r.Context(), id, teamID) {
+		httpError(w, http.StatusForbidden, "admin or owner required")
+		return
+	}
+	scheduleID := r.PathValue("sid")
+	sb, ok := s.scheduleForTeam(w, r, teamID, scheduleID)
+	if !ok {
+		return
+	}
+	if err := s.cfg.ScheduledBots.Delete(r.Context(), scheduleID); err != nil {
+		if errors.Is(err, cloudsched.ErrNotFound) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	s.auditTenant(r, teamID, "schedule.deleted", "schedule", sb.ID, map[string]any{"bot_id": sb.BotID})
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/pkg/server/schedules_routes_test.go
+++ b/pkg/server/schedules_routes_test.go
@@ -1,0 +1,232 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/cloudsched"
+)
+
+// newScheduleTestServer wires an in-memory ScheduledBots store into a stock
+// org test server and pins scheduleClock so NextFireAt is deterministic.
+func newScheduleTestServer(t *testing.T) *Server {
+	t.Helper()
+	s := newOrgTestServer(t)
+	s.cfg.ScheduledBots = cloudsched.NewMemoryStore()
+	s.scheduleClock = func() time.Time { return time.Date(2026, 6, 22, 10, 0, 0, 0, time.UTC) }
+	return s
+}
+
+func scheduleReq(ctx context.Context, method, path, body, teamID, sid string) *http.Request {
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, path, nil)
+	} else {
+		r = httptest.NewRequest(method, path, strings.NewReader(body))
+	}
+	r = r.WithContext(ctx)
+	if teamID != "" {
+		r.SetPathValue("id", teamID)
+	}
+	if sid != "" {
+		r.SetPathValue("sid", sid)
+	}
+	return r
+}
+
+func TestSchedule_CreateHappy(t *testing.T) {
+	s := newScheduleTestServer(t)
+	ctx := superAdminCtx()
+	body := `{
+		"bot_id":"feed-watch",
+		"cron":"*/5 * * * *",
+		"vars":{"mode":"digest","category":"go"},
+		"repo_url":"https://example.com/repo.git",
+		"repo_ref":"main"
+	}`
+	w := httptest.NewRecorder()
+	s.handleCreateSchedule(w, scheduleReq(ctx, "POST", "/api/teams/t1/schedules", body, "t1", ""))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: code=%d body=%s", w.Code, w.Body.String())
+	}
+	var created cloudsched.ScheduledBot
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	if created.BotID != "feed-watch" || created.TenantID != "t1" {
+		t.Fatalf("bad payload: %+v", created)
+	}
+	if created.RepoURL != "https://example.com/repo.git" || created.RepoRef != "main" {
+		t.Errorf("repo fields dropped: %+v", created)
+	}
+	// NextFireAt must be > now and land on the next 5-minute slot for our
+	// pinned scheduleClock (10:00:00 → 10:05:00).
+	want := time.Date(2026, 6, 22, 10, 5, 0, 0, time.UTC)
+	if !created.NextFireAt.Equal(want) {
+		t.Errorf("NextFireAt: got %s want %s", created.NextFireAt, want)
+	}
+	if created.ID == "" || created.CreatedAt.IsZero() {
+		t.Errorf("id/created_at not stamped: %+v", created)
+	}
+}
+
+func TestSchedule_CreateBadCron(t *testing.T) {
+	s := newScheduleTestServer(t)
+	w := httptest.NewRecorder()
+	s.handleCreateSchedule(w, scheduleReq(superAdminCtx(), "POST", "/api/teams/t1/schedules",
+		`{"bot_id":"feed-watch","cron":"not a cron"}`, "t1", ""))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("bad cron: code=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestSchedule_CreateMissingFields(t *testing.T) {
+	s := newScheduleTestServer(t)
+	w := httptest.NewRecorder()
+	// no bot_id
+	s.handleCreateSchedule(w, scheduleReq(superAdminCtx(), "POST", "/api/teams/t1/schedules",
+		`{"cron":"*/5 * * * *"}`, "t1", ""))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("missing bot_id: code=%d", w.Code)
+	}
+}
+
+func TestSchedule_ListAndCrossTeamGate(t *testing.T) {
+	s := newScheduleTestServer(t)
+	ctx := superAdminCtx()
+
+	// Seed one row on t1 + one on t2, then list t1: only the t1 row must return.
+	w := httptest.NewRecorder()
+	s.handleCreateSchedule(w, scheduleReq(ctx, "POST", "/api/teams/t1/schedules",
+		`{"bot_id":"a","cron":"0 * * * *"}`, "t1", ""))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("seed t1: %d %s", w.Code, w.Body.String())
+	}
+	w = httptest.NewRecorder()
+	s.handleCreateSchedule(w, scheduleReq(ctx, "POST", "/api/teams/t2/schedules",
+		`{"bot_id":"b","cron":"0 * * * *"}`, "t2", ""))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("seed t2: %d %s", w.Code, w.Body.String())
+	}
+
+	w = httptest.NewRecorder()
+	s.handleListSchedules(w, scheduleReq(ctx, "GET", "/api/teams/t1/schedules", "", "t1", ""))
+	var lr struct {
+		Schedules []cloudsched.ScheduledBot `json:"schedules"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &lr); err != nil {
+		t.Fatal(err)
+	}
+	if len(lr.Schedules) != 1 || lr.Schedules[0].BotID != "a" {
+		t.Fatalf("list t1: %+v", lr.Schedules)
+	}
+}
+
+func TestSchedule_UpdateCrossTeamIs404(t *testing.T) {
+	s := newScheduleTestServer(t)
+	ctx := superAdminCtx()
+
+	// Seed a schedule on t1 …
+	w := httptest.NewRecorder()
+	s.handleCreateSchedule(w, scheduleReq(ctx, "POST", "/api/teams/t1/schedules",
+		`{"bot_id":"a","cron":"0 * * * *","vars":{"mode":"digest"}}`, "t1", ""))
+	var created cloudsched.ScheduledBot
+	json.Unmarshal(w.Body.Bytes(), &created)
+
+	// … then try to update it under team t2 → 404, not 200 or 403.
+	w = httptest.NewRecorder()
+	s.handleUpdateSchedule(w, scheduleReq(ctx, "PATCH",
+		"/api/teams/t2/schedules/"+created.ID,
+		`{"disabled":true}`, "t2", created.ID))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("cross-team update should 404: code=%d body=%s", w.Code, w.Body.String())
+	}
+
+	// Legitimate update from t1 → 200 and the disabled flag flips.
+	w = httptest.NewRecorder()
+	s.handleUpdateSchedule(w, scheduleReq(ctx, "PATCH",
+		"/api/teams/t1/schedules/"+created.ID,
+		`{"disabled":true,"cron":"*/10 * * * *"}`, "t1", created.ID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("legit update: code=%d body=%s", w.Code, w.Body.String())
+	}
+	var updated cloudsched.ScheduledBot
+	json.Unmarshal(w.Body.Bytes(), &updated)
+	if !updated.Disabled || updated.Cron != "*/10 * * * *" {
+		t.Errorf("update payload: %+v", updated)
+	}
+	wantNext := time.Date(2026, 6, 22, 10, 10, 0, 0, time.UTC)
+	if !updated.NextFireAt.Equal(wantNext) {
+		t.Errorf("NextFireAt should follow new cron: got %s want %s", updated.NextFireAt, wantNext)
+	}
+	// Vars survive an update that didn't specify them (nil pointer = untouched).
+	if updated.Vars["mode"] != "digest" {
+		t.Errorf("vars dropped on partial update: %+v", updated.Vars)
+	}
+}
+
+func TestSchedule_Delete(t *testing.T) {
+	s := newScheduleTestServer(t)
+	ctx := superAdminCtx()
+
+	w := httptest.NewRecorder()
+	s.handleCreateSchedule(w, scheduleReq(ctx, "POST", "/api/teams/t1/schedules",
+		`{"bot_id":"a","cron":"0 * * * *"}`, "t1", ""))
+	var created cloudsched.ScheduledBot
+	json.Unmarshal(w.Body.Bytes(), &created)
+
+	// Cross-team delete → 404.
+	w = httptest.NewRecorder()
+	s.handleDeleteSchedule(w, scheduleReq(ctx, "DELETE",
+		"/api/teams/t2/schedules/"+created.ID, "", "t2", created.ID))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("cross-team delete: code=%d", w.Code)
+	}
+
+	// Legit delete → 204.
+	w = httptest.NewRecorder()
+	s.handleDeleteSchedule(w, scheduleReq(ctx, "DELETE",
+		"/api/teams/t1/schedules/"+created.ID, "", "t1", created.ID))
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("delete: code=%d body=%s", w.Code, w.Body.String())
+	}
+	// Gone.
+	w = httptest.NewRecorder()
+	s.handleListSchedules(w, scheduleReq(ctx, "GET", "/api/teams/t1/schedules", "", "t1", ""))
+	var lr struct {
+		Schedules []cloudsched.ScheduledBot `json:"schedules"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &lr)
+	if len(lr.Schedules) != 0 {
+		t.Fatalf("after delete: %d", len(lr.Schedules))
+	}
+}
+
+// TestBuildScheduledLaunchSpec verifies the pure-data half of
+// launchScheduledBot threads repo binding + vars + bot id onto the LaunchSpec
+// so the cloud runner clones the pinned repo (mandatory for a stateful bot
+// that persists state to git). The full launchScheduledBot path needs a live
+// runs service; this focused unit protects the shape without that plumbing.
+func TestBuildScheduledLaunchSpec(t *testing.T) {
+	sb := cloudsched.ScheduledBot{
+		ID: "sb-1", TenantID: "team-A", BotID: "feed-watch",
+		Vars:    map[string]string{"mode": "digest"},
+		RepoURL: "https://example.com/repo.git",
+		RepoRef: "feat/x",
+	}
+	spec := buildScheduledLaunchSpec(sb, "/tmp/feed-watch/main.bot", "workflow: {}")
+	if spec.FilePath != "/tmp/feed-watch/main.bot" || spec.Source != "workflow: {}" {
+		t.Errorf("source pass-through: %+v", spec)
+	}
+	if spec.BotID != "feed-watch" || spec.Vars["mode"] != "digest" {
+		t.Errorf("identity/vars: %+v", spec)
+	}
+	if spec.RepoURL != "https://example.com/repo.git" || spec.RepoRef != "feat/x" {
+		t.Errorf("repo fields not threaded: %+v", spec)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -105,6 +105,11 @@ type Server struct {
 	// webhookLaunchBot overrides the inbound-webhook launch path (test
 	// seam). nil → realWebhookLaunchBot (resolve bot source + s.runs.Launch).
 	webhookLaunchBot func(ctx context.Context, botID string, vars map[string]string, repoURL, repoRef, projectPath string, keyOverrides, secretOverrides map[string]string) (string, error)
+	// scheduleClock overrides the wall clock the schedules CRUD stamps on
+	// CreatedAt / UpdatedAt / NextFireAt (test seam — tests need a
+	// deterministic instant to assert NextFire jumps to the expected slot).
+	// nil → time.Now().UTC().
+	scheduleClock func() time.Time
 	// webhookNoteGate overrides the conversational replier gate (forge
 	// token + loop-guard + reply-in-thread detection + allowlist/role authz
 	// — test seam, the real gate calls the GitLab API). nil →

--- a/pkg/server/server_routes.go
+++ b/pkg/server/server_routes.go
@@ -178,6 +178,12 @@ func (s *Server) routes() {
 		s.registerBotBindingRoutes()
 	}
 
+	// Recurring cloud schedules — team-scoped CRUD. Cloud-only (the ticker
+	// that fires them lives on the same Server.cfg.ScheduledBots handle).
+	if s.cfg.ScheduledBots != nil && s.authSvc != nil {
+		s.registerScheduleRoutes()
+	}
+
 	// Outbound forge integrations (connect a repo + auto-provision). Gated
 	// on the orchestrator being built (full dependency set) + the auth stack.
 	if s.forgeOrchestrator != nil && s.authSvc != nil {

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -742,7 +742,13 @@ func (s *Server) resolveBotSource(botID string) (path, source string, err error)
 // launchScheduledBot is the cloudsched.LaunchFunc: it launches a recurring bot
 // run for its tenant through the run service (cloud → publisher). The tenant
 // identity is stamped on the ctx so the publisher seals credentials + scopes
-// the run to the org.
+// the run to the org. When the schedule pins a RepoURL, it is threaded onto
+// the LaunchSpec so the runner clones the repo before the bot starts —
+// mandatory for stateful bots that persist state to git (feed-watch
+// state_commit=true), which need a workspace with push credentials wired.
+// Generic secrets declared by the bot (e.g. `webhooks`) resolve via the
+// publisher's bot-secret bindings, so SecretOverrides plumbing is not needed
+// here.
 func (s *Server) launchScheduledBot(ctx context.Context, sb cloudsched.ScheduledBot) error {
 	if s.runs == nil {
 		return errors.New("run service unavailable")
@@ -752,13 +758,24 @@ func (s *Server) launchScheduledBot(ctx context.Context, sb cloudsched.Scheduled
 	if err != nil {
 		return err
 	}
-	_, err = s.runs.Launch(ctx, runview.LaunchSpec{
+	_, err = s.runs.Launch(ctx, buildScheduledLaunchSpec(sb, path, source))
+	return err
+}
+
+// buildScheduledLaunchSpec is the pure-data half of launchScheduledBot,
+// exposed for unit testing without wiring a full runview.Service. It carries
+// the schedule's Vars + repo binding onto the LaunchSpec so the runner clones
+// the pinned repo (mandatory for stateful bots persisting state to git) and
+// stamps the BotID for the publisher's credential-resolution path.
+func buildScheduledLaunchSpec(sb cloudsched.ScheduledBot, path, source string) runview.LaunchSpec {
+	return runview.LaunchSpec{
 		FilePath: path,
 		Source:   source,
 		BotID:    sb.BotID,
 		Vars:     sb.Vars,
-	})
-	return err
+		RepoURL:  sb.RepoURL,
+		RepoRef:  sb.RepoRef,
+	}
 }
 
 // realWebhookLaunchBot is the production launch path for an inbound


### PR DESCRIPTION
Makes iterion's native cloud scheduler (`cloudsched`) able to run a **stateful, repo-bound** bot on a recurring schedule — the missing piece for running a feed-watch (Vigie) veille on cloud.

**Problem**: the `cloudsched` ticker fired `ScheduledBot` rows against no repo, so a stateful bot (feed-watch with `state_commit=true`) had no git workspace to persist to on ephemeral runners. Only the webhook launch path wired a repo.

**Changes**:
- `ScheduledBot` gains `RepoURL`/`RepoRef`; `launchScheduledBot` threads them onto the `LaunchSpec` (`buildScheduledLaunchSpec`) so the runner clones the repo + injects the forge token — the bot's `git push` then authenticates (same mechanics as the proven webhook path).
- New team-scoped CRUD API `/api/teams/{id}/schedules` (cloud-only, `requireAuth` + `canManage`/`canView`, cross-team 404, audit-logged) — forge provisioning was the only prior creation path and is too coarse for per-category schedules.
- Generic secrets (`webhooks`, `forge_token`) resolve via the publisher's bot-secret bindings — no `SecretOverrides` plumbing needed.
- feed-watch declares `forge_token` (optional) for the cloud clone/push.
- `iterion remote schedules list|create|delete` wired.

Tests: cloudsched CRUD round-trip, handler tests (create/bad-cron/cross-team-404/list/delete), a launch-spec wiring unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)