### PR TITLE
fix(bots): feed-watch drops board capability — unblocks cloud digest

### DIFF
--- a/bots/feed-watch/main.bot
+++ b/bots/feed-watch/main.bot
@@ -94,9 +94,6 @@ vars:
   ## state_dir NOT gitignored and push credentials on the workspace.
   state_commit: bool = false
 
-  ## digest: also create a board card per CRITICAL item (board.create).
-  post_to_board: bool = false
-
   ## The synthesis model rides FEED_WATCH_MODEL (empty = the resolved
   ## backend's own default) — a `model: "{{vars.x}}"` template is NOT
   ## resolved on the delegation path and reaches the CLI literally.
@@ -130,7 +127,7 @@ prompt synthesize_system:
     category: audience, language, tone, what matters, what to skip.
     FOLLOW IT, and write the digest in the language it is written in.
   - input.recent_topics — the digests already sent (previous runs).
-  - input.digest_title / items_count / overflow_count / post_to_board.
+  - input.digest_title / items_count / overflow_count.
 
   PROCEDURE:
   1. Read every item. Group items covering the SAME story from several
@@ -151,11 +148,6 @@ prompt synthesize_system:
   5. Keep message_markdown under ~10000 characters. If
      input.overflow_count > 0, state that N older queued items were
      dropped unprocessed.
-  6. If input.post_to_board is true, ALSO create one board card per
-     CRITICAL item (e.g. actively exploited vulnerability, urgent
-     action needed) via the board tools — title prefixed with the
-     category — and report the count in board_cards_created. If it is
-     false, do not touch the board.
 
   RULES:
   - Every entry must correspond to input items. NEVER invent an item,
@@ -250,7 +242,6 @@ schema synthesize_input:
   overflow_count: int
   recent_topics: string
   editorial: string
-  post_to_board: bool
 
 schema synthesize_output:
   headline: string
@@ -258,7 +249,6 @@ schema synthesize_output:
   message_markdown: string
   items_included: int
   items_skipped_duplicates: string[]
-  board_cards_created: int
   summary: string
 
 schema notify_input:
@@ -597,8 +587,10 @@ tool load_pending:
 ## Editorial synthesis — the ONE LLM step. No backend/model pinned: the
 ## engine auto-detects from the host credentials (claw gets web_fetch/
 ## web_search natively; claude_code brings its own web tools and
-## ignores the lowercase list). Board capabilities are prompt-gated by
-## input.post_to_board.
+## ignores the lowercase list). No board capabilities: the digest's sink
+## is the chat webhook, and declaring board.* would require the
+## iterion_board MCP server to be active on every run (it is not on a
+## cloud runner), failing the node at setup even when unused.
 agent synthesize:
   model: "${FEED_WATCH_MODEL:-}"
   reasoning_effort: "${FEED_WATCH_EFFORT:-medium}"
@@ -609,7 +601,6 @@ agent synthesize:
   tools: [web_fetch, web_search]
   tool_max_steps: 30
   session: fresh
-  capabilities: [board.create, board.read]
 
 ## Deterministic delivery (no LLM at the last step — a provider
 ## rate-limit cannot sink a finished digest). Posts to every configured
@@ -810,8 +801,7 @@ workflow feed_watch:
     items_count: "{{outputs.load_pending.items_count}}",
     overflow_count: "{{outputs.load_pending.overflow_count}}",
     recent_topics: "{{outputs.load_pending.recent_topics}}",
-    editorial: "{{outputs.load_pending.editorial}}",
-    post_to_board: "{{vars.post_to_board}}"
+    editorial: "{{outputs.load_pending.editorial}}"
   }
 
   synthesize -> notify with {

--- a/bots/feed-watch/manifest.yaml
+++ b/bots/feed-watch/manifest.yaml
@@ -36,8 +36,6 @@ when_to_use: |
 author: SocialGouv (devthejo) — bots/feed-watch/main.bot
 schema_version: 1
 
-capabilities: [board.create, board.read]
-
 invocations:
   ## Poll all categories' feeds into the pending queues (zero-LLM).
   - kind: schedule

--- a/bots/feed-watch/skills/feed-config.md
+++ b/bots/feed-watch/skills/feed-config.md
@@ -116,7 +116,6 @@ retention: `iterion runs prune` (see docs/scheduling.md).
 | `state_dir` | `.feed-watch` | workspace-relative state root |
 | `dry_run` | `false` | digest: print payloads, deliver nothing |
 | `state_commit` | `false` | commit+push state after each mutation |
-| `post_to_board` | `false` | digest: board card per CRITICAL item |
 | `FEED_WATCH_MODEL` (env) | `""` | synthesis model spec (`""` = the resolved backend's default; per-run: `iterion run --model …`) |
 | `max_items_per_feed` | `30` | freshest-N cap per feed at collect |
 | `max_digest_items` | `150` | newest-N cap per digest (overflow is dropped WITH a count in the message) |

--- a/bots/feed-watch/skills/synthesis-scoring.md
+++ b/bots/feed-watch/skills/synthesis-scoring.md
@@ -1,6 +1,6 @@
 ---
 name: synthesis-scoring
-description: Editorial rubric for the feed-watch digest agent — how to group, rank, semantically dedup and write a chat digest that respects the category's editorial brief; when an item is CRITICAL enough for a board card.
+description: Editorial rubric for the feed-watch digest agent — how to group, rank, semantically dedup and write a chat digest that respects the category's editorial brief.
 ---
 
 # Digest synthesis rubric
@@ -57,13 +57,3 @@ Order by impact for the audience described in the editorial brief:
 - The message is the digest — no meta ("here is your digest"), no
   self-reference, no invented items or facts. Every entry maps to
   input items.
-
-## 6. Board escalation (only when input.post_to_board is true)
-
-CRITICAL = the operator should act today: actively exploited
-vulnerability in a stack the audience plausibly runs, urgent
-regulatory/CERT alert, credible supply-chain compromise. Create ONE
-card per such item via `board.create` — title `[<category>] <item
-title>`, body = takeaway + link — and count them in
-`board_cards_created`. Major-but-not-actionable news is NOT critical.
-When `post_to_board` is false, never touch the board.

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -624,8 +624,7 @@ python3 (stdlib only) on the execution host.
   synthesize and deliver. Replaces a Huginn RSS → dedup → digest → LLM
   → webhook scenario one-for-one. Not for one-shot research questions
   (use a plain research bot) and it never edits code.
-- **Vars**: `category` (string), `config_path` (string), `dry_run` (bool), `fetch_timeout_secs` (int), `max_digest_items` (int), `max_items_per_feed` (int), `mode` (string), `post_to_board` (bool), `scratch_dir` (string), `state_commit` (bool), `state_dir` (string), `workspace_dir` (string)
-- **Capabilities**: board.create, board.read
+- **Vars**: `category` (string), `config_path` (string), `dry_run` (bool), `fetch_timeout_secs` (int), `max_digest_items` (int), `max_items_per_feed` (int), `mode` (string), `scratch_dir` (string), `state_commit` (bool), `state_dir` (string), `workspace_dir` (string)
 - **Path**: `bots/feed-watch/main.bot`
 
 ### `nested-subbots-demo` — Nested Subbots Demo


### PR DESCRIPTION
The `synthesize` node declared `capabilities: [board.create, board.read]` for an optional `post_to_board` board-card feature. That made the runtime open the `iterion_board` MCP server on every digest run; on a **cloud runner that server is not active**, so the node failed at setup even with `post_to_board=false` (default) — the digest never ran (observed: `cannot access MCP tool mcp.iterion_board.create_issue because server iterion_board is not active`). The digest's sink is the chat webhook; the speculative board-card path is removed (capability, var, prompt step, schema fields, skill section) so the digest is robust on host and cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)