### PR TITLE
feat(board): render image-path inputs as a carousel on the /pipelines card sidebar

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -6794,6 +6794,30 @@
         ]
       }
     },
+    "/api/v1/pipeline-board/workspace-images/{path}": {
+      "get": {
+        "operationId": "getV1PipelineBoardWorkspaceImagesByPath",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "GET /api/v1/pipeline-board/workspace-images/{path...}",
+        "tags": [
+          "pipeline-board"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "/api/v1/plugins": {
       "get": {
         "operationId": "getV1Plugins",

--- a/pkg/server/pipeline_boards.go
+++ b/pkg/server/pipeline_boards.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -178,6 +179,60 @@ func (s *Server) registerPipelineBoardRoutes() {
 	s.mux.Handle("POST /api/v1/pipeline-board/tasks", s.requireAuth(http.HandlerFunc(s.handlePipelineBoardTaskCreate)))
 	s.mux.Handle("POST /api/v1/pipeline-board/tasks/{id}/ready", s.requireAuth(http.HandlerFunc(s.handlePipelineBoardTaskReady)))
 	s.mux.Handle("PATCH /api/v1/pipeline-board/tasks/{id}", s.requireAuth(http.HandlerFunc(s.handlePipelineBoardTaskUpdate)))
+	// Input thumbnails: a ticket's bot_args may reference images living in the
+	// studio workdir (e.g. a character-reference list) — this endpoint lets the
+	// card sidebar actually SHOW them instead of printing bare paths.
+	s.mux.Handle("GET /api/v1/pipeline-board/workspace-images/{path...}", s.requireAuth(http.HandlerFunc(s.handlePipelineBoardWorkspaceImage)))
+}
+
+// workspaceImageExts is the strict allowlist of the input-thumbnail endpoint:
+// it exists solely to preview images referenced by ticket inputs, so anything
+// that is not an image stays out of scope on purpose (no generic file reads).
+var workspaceImageExts = map[string]string{
+	".png":  "image/png",
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".webp": "image/webp",
+	".gif":  "image/gif",
+}
+
+// handlePipelineBoardWorkspaceImage serves one image file from the studio
+// workdir for the card sidebar's input thumbnails. Containment relies on
+// safePath — the same audited symlink-aware traversal boundary as the file
+// editor — and the extension allowlist keeps the endpoint image-only.
+func (s *Server) handlePipelineBoardWorkspaceImage(w http.ResponseWriter, r *http.Request) {
+	relPath := strings.TrimSpace(r.PathValue("path"))
+	if relPath == "" {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "workspace image: missing path")
+		return
+	}
+	contentType, ok := workspaceImageExts[strings.ToLower(filepath.Ext(relPath))]
+	if !ok {
+		s.httpErrorFor(w, r, http.StatusNotFound, "workspace image: unsupported extension: %s", filepath.Ext(relPath))
+		return
+	}
+	absPath, err := s.safePath(relPath)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "workspace image: invalid path: %v", err)
+		return
+	}
+	info, err := os.Stat(absPath)
+	if err != nil || !info.Mode().IsRegular() {
+		s.httpErrorFor(w, r, http.StatusNotFound, "workspace image: not found: %s", relPath)
+		return
+	}
+	file, err := os.Open(absPath)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusNotFound, "workspace image: not found: %s", relPath)
+		return
+	}
+	defer file.Close()
+	w.Header().Set("Content-Type", contentType)
+	// Reference images are regenerated IN PLACE under the same filename
+	// (portrait refresh): revalidate on each load so the sidebar never shows
+	// a stale face after a refresh, while still allowing conditional requests.
+	w.Header().Set("Cache-Control", "no-cache")
+	http.ServeContent(w, r, filepath.Base(absPath), info.ModTime(), file)
 }
 
 func (s *Server) resolvePipelineBoardStore(r *http.Request) (native.BoardStore, error) {

--- a/pkg/server/pipeline_boards_test.go
+++ b/pkg/server/pipeline_boards_test.go
@@ -766,3 +766,76 @@ func hasPipelineCard(cards []PipelineBoardCard, id string) bool {
 	}
 	return false
 }
+
+func TestPipelineBoardWorkspaceImageServesGuardsAndRefuses(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	refDir := filepath.Join(env.workDir, "assets", "characters", "histoire", "boudicca", "refs")
+	if err := os.MkdirAll(refDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte("\x89PNG fake-bytes")
+	if err := os.WriteFile(filepath.Join(refDir, "master.png"), payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(env.workDir, "secret.txt"), []byte("nope"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Nominal: a workdir-relative image is served with its content type.
+	resp, err := http.Get(env.http.URL + "/api/v1/pipeline-board/workspace-images/assets/characters/histoire/boudicca/refs/master.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := new(bytes.Buffer)
+	if _, err := body.ReadFrom(resp.Body); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (%s)", resp.StatusCode, body.String())
+	}
+	if got := resp.Header.Get("Content-Type"); got != "image/png" {
+		t.Fatalf("content-type = %q, want image/png", got)
+	}
+	if !bytes.Equal(body.Bytes(), payload) {
+		t.Fatalf("body = %q, want the file bytes", body.Bytes())
+	}
+
+	// Image-only allowlist: a non-image workdir file is refused even though
+	// it exists — this endpoint must not become a generic file reader.
+	resp, err = http.Get(env.http.URL + "/api/v1/pipeline-board/workspace-images/secret.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("non-image status = %d, want 404", resp.StatusCode)
+	}
+
+	// Traversal out of the workdir is rejected by safePath. The raw path
+	// must bypass Go's client-side dot-segment cleaning to reach the server.
+	req, err := http.NewRequest(http.MethodGet, env.http.URL+"/api/v1/pipeline-board/workspace-images/escape.png", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.URL.Path = "/api/v1/pipeline-board/workspace-images/../../../etc/passwd.png"
+	req.URL.RawPath = "/api/v1/pipeline-board/workspace-images/..%2F..%2F..%2Fetc%2Fpasswd.png"
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("traversal returned 200, want an error status")
+	}
+
+	// Missing file: clean 404.
+	resp, err = http.Get(env.http.URL + "/api/v1/pipeline-board/workspace-images/assets/absent.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing file status = %d, want 404", resp.StatusCode)
+	}
+}

--- a/studio/src/api/pipelineBoards.ts
+++ b/studio/src/api/pipelineBoards.ts
@@ -335,3 +335,12 @@ export async function updatePipelineTask(
     body: JSON.stringify(patch),
   });
 }
+
+// pipelineBoardImageURL builds the URL serving one workdir-relative image for
+// the card sidebar's input thumbnails (e.g. a ticket's character-reference
+// list). Segment-encode so subdirectories survive — encodeURIComponent on the
+// whole path would clobber the "/" separators.
+export function pipelineBoardImageURL(relPath: string): string {
+  const segments = relPath.split("/").map(encodeURIComponent).join("/");
+  return `${BASE}/workspace-images/${segments}`;
+}

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -3443,6 +3443,25 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/pipeline-board/workspace-images/{path}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                path: string;
+            };
+            cookie?: never;
+        };
+        /** GET /api/v1/pipeline-board/workspace-images/{path...} */
+        get: operations["getV1PipelineBoardWorkspaceImagesByPath"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/plugins": {
         parameters: {
             query?: never;
@@ -8973,6 +8992,26 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["Issue"];
                 };
+            };
+        };
+    };
+    getV1PipelineBoardWorkspaceImagesByPath: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                path: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/studio/src/views/PipelineBoard/PipelineCardDetails.test.tsx
+++ b/studio/src/views/PipelineBoard/PipelineCardDetails.test.tsx
@@ -192,3 +192,60 @@ describe("PipelineCardDetailsBody", () => {
     expect(html).toContain("no longer on the board");
   });
 });
+
+describe("InputsList image carousel", () => {
+  it("renders a JSON list of image paths as a carousel of workspace-image URLs", () => {
+    const html = render(
+      makeCard({
+        column_id: "backlog",
+        entry_input: {
+          character: "Boudicca",
+          character_refs:
+            '["assets/characters/histoire/boudicca/refs/master.png", "assets/characters/histoire/boudicca/refs/full_body.png"]',
+        },
+      }),
+    );
+    expect(html).toContain(
+      "/api/v1/pipeline-board/workspace-images/assets/characters/histoire/boudicca/refs/master.png",
+    );
+    // One image at a time, with a position counter and cycling controls.
+    expect(html).toContain("1/2");
+    expect(html).toContain("Next image");
+    expect(html).toContain("Previous image");
+    // Sibling non-image values keep the plain monospace rendering.
+    expect(html).toContain("Boudicca");
+  });
+
+  it("renders a single bare image path as an image without cycling controls", () => {
+    const html = render(
+      makeCard({
+        column_id: "backlog",
+        entry_input: { cover: "assets/cover art/../covers/final.png" },
+      }),
+    );
+    expect(html).not.toContain("workspace-images");
+    // Path with whitespace stays plain text; a clean single path renders.
+    const clean = render(
+      makeCard({
+        column_id: "backlog",
+        entry_input: { cover: "assets/covers/final.png" },
+      }),
+    );
+    expect(clean).toContain("/api/v1/pipeline-board/workspace-images/assets/covers/final.png");
+    expect(clean).not.toContain("Next image");
+  });
+
+  it("keeps sentences and mixed arrays as plain text", () => {
+    const html = render(
+      makeCard({
+        column_id: "backlog",
+        entry_input: {
+          notes: "voir le rendu final dans exports/preview.png",
+          mixed: '["assets/refs/master.png", "pas une image"]',
+        },
+      }),
+    );
+    expect(html).not.toContain("workspace-images");
+    expect(html).toContain("voir le rendu final");
+  });
+});

--- a/studio/src/views/PipelineBoard/PipelineCardDetails.tsx
+++ b/studio/src/views/PipelineBoard/PipelineCardDetails.tsx
@@ -1,9 +1,15 @@
-import { Cross2Icon } from "@radix-ui/react-icons";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  Cross2Icon,
+  DownloadIcon,
+} from "@radix-ui/react-icons";
+import { useState } from "react";
 import { Link } from "wouter";
 
-import type { PipelineBoardCard } from "@/api/pipelineBoards";
+import { pipelineBoardImageURL, type PipelineBoardCard } from "@/api/pipelineBoards";
 import type { UnifiedStatus } from "@/components/Runs/runStatusClasses";
-import { Badge, IconButton, InlineBanner, StatusBadge } from "@/components/ui";
+import { Badge, Dialog, IconButton, InlineBanner, StatusBadge } from "@/components/ui";
 
 import { ProducedElements } from "./ProducedElements";
 import { SequentialReviews } from "./SequentialReviews";
@@ -41,9 +47,148 @@ function stringifyValue(value: unknown): string {
   }
 }
 
+const IMAGE_PATH_RE = /\.(png|jpe?g|webp|gif)$/i;
+
+// imagePathsFrom extracts workdir-relative image paths from one input value:
+// either a JSON array of image paths (how bots ship reference-image lists in
+// bot_args) or a single bare path. Mixed arrays and anything else yield []
+// so the value falls back to the plain monospace rendering — a thumbnail
+// must never hide non-image content.
+function imagePathsFrom(value: unknown): string[] {
+  const asPathList = (items: unknown[]): string[] => {
+    const paths = items.filter(
+      (item): item is string => typeof item === "string" && IMAGE_PATH_RE.test(item.trim()),
+    );
+    return paths.length > 0 && paths.length === items.length
+      ? paths.map((p) => p.trim())
+      : [];
+  };
+  if (Array.isArray(value)) return asPathList(value);
+  if (typeof value !== "string") return [];
+  const text = value.trim();
+  if (!text || text.length > 4096) return [];
+  if (text.startsWith("[")) {
+    try {
+      const parsed: unknown = JSON.parse(text);
+      return Array.isArray(parsed) ? asPathList(parsed) : [];
+    } catch {
+      return [];
+    }
+  }
+  // Bare-path case: a single token only — a SENTENCE that happens to end in
+  // ".png" must stay plain text.
+  return IMAGE_PATH_RE.test(text) && !/\s/.test(text) ? [text] : [];
+}
+
+// InputImageCarousel renders an image-path input value as one image at a
+// time with prev/next cycling — reference lists carry several views of the
+// same character, so a carousel keeps the sidebar compact while every image
+// stays reachable. Clicking the image opens the SAME preview dialog as the
+// produced-elements viewer (large image + Download), with the carousel
+// arrows still available inside it. A failed load (deleted file, foreign
+// workdir) collapses back to the plain monospace text so no information is
+// ever lost.
+function InputImageCarousel({ paths, rawText }: { paths: string[]; rawText: string }) {
+  const [index, setIndex] = useState(0);
+  const [broken, setBroken] = useState(false);
+  const [viewerOpen, setViewerOpen] = useState(false);
+  const current = ((index % paths.length) + paths.length) % paths.length;
+  const path = paths[current];
+  if (broken || path === undefined) {
+    return (
+      <dd className="whitespace-pre-wrap break-words rounded-md border border-border-subtle bg-surface-2/40 px-2 py-1 font-mono text-xs text-fg-default">
+        {rawText}
+      </dd>
+    );
+  }
+  const url = pipelineBoardImageURL(path);
+  const fileName = path.split("/").pop() ?? path;
+  const cycler = (dir: -1 | 1, size: "sm" | "md" = "sm") =>
+    paths.length > 1 ? (
+      <IconButton
+        label={dir < 0 ? "Previous image" : "Next image"}
+        size={size}
+        variant="ghost"
+        onClick={() => setIndex((i) => i + dir)}
+      >
+        {dir < 0 ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+      </IconButton>
+    ) : (
+      <span />
+    );
+  return (
+    <dd className="space-y-1 rounded-md border border-border-subtle bg-surface-2/40 p-2">
+      <button
+        type="button"
+        onClick={() => setViewerOpen(true)}
+        title={`${path} — open preview`}
+        className="block w-full"
+      >
+        <img
+          src={url}
+          alt={path}
+          loading="lazy"
+          className="max-h-44 w-full rounded object-contain"
+          onError={() => setBroken(true)}
+        />
+      </button>
+      <div className="flex items-center justify-between gap-1">
+        {cycler(-1)}
+        <span
+          className="min-w-0 truncate font-mono text-micro text-fg-muted"
+          title={path}
+        >
+          {fileName}
+          {paths.length > 1 ? ` · ${current + 1}/${paths.length}` : ""}
+        </span>
+        {cycler(1)}
+      </div>
+      {viewerOpen && (
+        <Dialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setViewerOpen(false);
+          }}
+          widthClass="max-w-3xl"
+          title={<span className="font-mono text-xs">{path}</span>}
+          description={
+            paths.length > 1 ? <span>Image {current + 1}/{paths.length}</span> : undefined
+          }
+          footer={
+            <a
+              href={url}
+              download
+              className="inline-flex items-center gap-1 rounded-md border border-border-default px-2.5 py-1 text-xs font-medium text-fg-default hover:bg-surface-2"
+            >
+              <DownloadIcon /> Download
+            </a>
+          }
+        >
+          <div className="space-y-2">
+            <div className="flex max-h-[70vh] items-center justify-center overflow-auto rounded bg-surface-0 p-3">
+              <img src={url} alt={path} className="max-w-full" />
+            </div>
+            {paths.length > 1 && (
+              <div className="flex items-center justify-center gap-3">
+                {cycler(-1, "md")}
+                <span className="font-mono text-xs text-fg-muted">
+                  {current + 1}/{paths.length}
+                </span>
+                {cycler(1, "md")}
+              </div>
+            )}
+          </div>
+        </Dialog>
+      )}
+    </dd>
+  );
+}
+
 // InputsList renders the pipeline's full entry input (launch vars / task
 // bot-args) as an untruncated key → value list. The sidebar has the room the
-// compact card body does not, so values wrap instead of clipping.
+// compact card body does not, so values wrap instead of clipping. Values that
+// are image paths (reference-image lists…) render as an inline carousel
+// instead of bare paths.
 function InputsList({ input }: { input?: Record<string, unknown> }) {
   const entries = input ? Object.entries(input) : [];
   if (entries.length === 0) {
@@ -51,16 +196,23 @@ function InputsList({ input }: { input?: Record<string, unknown> }) {
   }
   return (
     <dl className="space-y-2">
-      {entries.map(([key, value]) => (
-        <div key={key} className="space-y-0.5">
-          <dt className="text-micro font-medium uppercase tracking-wide text-fg-muted">
-            {key}
-          </dt>
-          <dd className="whitespace-pre-wrap break-words rounded-md border border-border-subtle bg-surface-2/40 px-2 py-1 font-mono text-xs text-fg-default">
-            {stringifyValue(value)}
-          </dd>
-        </div>
-      ))}
+      {entries.map(([key, value]) => {
+        const imagePaths = imagePathsFrom(value);
+        return (
+          <div key={key} className="space-y-0.5">
+            <dt className="text-micro font-medium uppercase tracking-wide text-fg-muted">
+              {key}
+            </dt>
+            {imagePaths.length > 0 ? (
+              <InputImageCarousel paths={imagePaths} rawText={stringifyValue(value)} />
+            ) : (
+              <dd className="whitespace-pre-wrap break-words rounded-md border border-border-subtle bg-surface-2/40 px-2 py-1 font-mono text-xs text-fg-default">
+                {stringifyValue(value)}
+              </dd>
+            )}
+          </div>
+        );
+      })}
     </dl>
   );
 }


### PR DESCRIPTION
## What

Ticket `bot_args` may reference images living in the studio workdir — e.g. a pipeline that pins a character's reference PNGs on each episode ticket. The `/pipelines` card sidebar printed those values as bare paths; this PR renders them.

## Server

New endpoint `GET /api/v1/pipeline-board/workspace-images/{path...}` serving one workdir image for input thumbnails:

- **image-extension allowlist** (png/jpg/jpeg/webp/gif) — deliberately never a generic file reader;
- containment via `safePath`, the audited symlink-aware traversal boundary already shared by the file editor;
- `Cache-Control: no-cache` — reference images are regenerated in place under the same filename, so the sidebar must never show a stale face.

## Studio

`InputsList` values that are image paths (a JSON array of paths, or a single bare path) render as an `InputImageCarousel`:

- one image at a time, cycling arrows + `i/n` counter (reference lists carry several views of the same subject);
- clicking opens the **same preview `Dialog` as produced elements** (large view + Download), with the carousel arrows available inside the dialog;
- guardrails: mixed arrays, sentences that merely end in `.png`, and failed loads (deleted file, foreign workdir) all fall back to the plain monospace text — a thumbnail never hides non-image content.

## Tests

- Go: nominal serve (content type + bytes), non-image refusal, dot-segment traversal rejection, missing-file 404.
- Vitest: carousel rendering from a JSON list (URLs, counter, controls), single-path rendering without controls, plain-text fallbacks for sentences and mixed arrays.
- `tsc -b` clean; `go test ./pkg/server` green on this base.