### PR TITLE
feat(dsl): parallel_safe — parallel fan_out_each of a mutating tool

### DIFF
--- a/docs/groups-iteration-subbots.md
+++ b/docs/groups-iteration-subbots.md
@@ -172,6 +172,49 @@ run_ticket -> collect
 > the safe path. A false `isolated:` assertion re-opens exactly the parallel
 > shared-workspace race the guard exists to prevent.
 
+### `parallel_safe:` — the same opt-out for a `tool` node
+
+A `tool` node is conservatively **mutating** too (it runs a command that may
+write anything), so the *same* guard refuses to fan a tool template out
+concurrently. When each replay writes only to a **disjoint, item-keyed target**
+— e.g. one keyframe per `scene_id` under `runs/<run>/keyframes/candidates/<scene_id>/`
+— the replays never race, and `parallel_safe: true` opts the tool out of the
+guard on a `fan_out_each`:
+
+```
+router keyframes_dispatch:
+  mode: fan_out_each
+  over: "{{outputs.prepare.keyframes}}"
+  as: keyframe
+  key: scene_id
+
+tool generate_keyframe_scene:
+  command: "render --scene {{outputs.keyframes_dispatch.keyframe.scene_id}}"
+  parallel_safe: true   # each replay writes only to its own scene-keyed path
+
+keyframes_dispatch -> generate_keyframe_scene
+generate_keyframe_scene -> verify   # wait_all
+```
+
+Unlike `isolated:` (own run store/worktree) the tool still writes to the shared
+workspace — it just **partitions** those writes by the fan-out item. Unlike
+`readonly:` it is not read-only.
+
+`parallel_safe:` is **scoped to `fan_out_each`** — the one place a single
+template node is replayed over distinct items, so the item-keyed disjointness
+holds by construction. It has no effect on a static `fan_out_all` or an
+`llm-router` multi-select, where the parallel branches are *different* nodes with
+no shared item key: there a tool stays conservatively mutating (use
+`max_parallel_branches: 1`, or give each branch its own output path and keep them
+under the one-mutating-branch limit). A `parallel_safe` tool followed by any
+*other* mutating node in the same template branch is still guarded.
+
+> **Contract — use `parallel_safe:` ONLY when replays write disjointly.** If two
+> replays can touch the same path (a shared aggregate file, a fixed output name),
+> leave it serialized (`max_parallel_branches: 1`). A false `parallel_safe:`
+> assertion re-opens a last-writer-wins race — the same failure mode the guard
+> exists to prevent.
+
 Parallel child runs are **data-race safe**: they share the parent's `RunStore`,
 whose per-run artifacts/events/checkpoints are isolated by `run_id` and guarded
 by a store-wide lock, and each child gets its own engine + (if `worktree: auto`)

--- a/pkg/dsl/ast/ast.go
+++ b/pkg/dsl/ast/ast.go
@@ -630,7 +630,15 @@ type ToolNodeDecl struct {
 	Postcondition string         // cheap deterministic check (shell, exit 0 = met); single source of truth for success
 	Policy        string         // required | recover | best_effort ("" defaults to required when Postcondition is set)
 	Recovery      *RecoveryBlock // bounded recovery rung config (nil = no recovery rungs)
-	Span          Span
+
+	// ParallelSafe (`parallel_safe: true`) asserts that concurrent fan-out
+	// replays of this tool write only to disjoint, item-keyed targets and never
+	// race one another on the shared workspace, letting the workspace-safety
+	// guard fan the tool out in parallel. Mirror of a subbot's `isolated:` /
+	// an agent-judge `readonly:`, for a tool that still writes but partitions
+	// its writes. Default false = conservatively mutating (serialized fan-out).
+	ParallelSafe bool
+	Span         Span
 }
 
 // RecoveryBlock configures the bounded recovery rungs of a Verified Action

--- a/pkg/dsl/ast/jsonenc.go
+++ b/pkg/dsl/ast/jsonenc.go
@@ -410,6 +410,7 @@ type jsonToolNodeDecl struct {
 	Policy         string             `json:"policy,omitempty"`
 	Recovery       *jsonRecoveryBlock `json:"recovery,omitempty"`
 	Needs          []string           `json:"needs,omitempty"`
+	ParallelSafe   bool               `json:"parallel_safe,omitempty"`
 }
 
 // jsonRecoveryBlock is the JSON form of an ast.RecoveryBlock (ADR-044).
@@ -741,6 +742,7 @@ func toJSON(f *File) *jsonFile {
 			Policy:         t.Policy,
 			Recovery:       recoveryBlockToJSON(t.Recovery),
 			Needs:          t.Needs,
+			ParallelSafe:   t.ParallelSafe,
 		})
 	}
 	for _, c := range f.Computes {
@@ -1355,6 +1357,7 @@ func fromJSON(jf *jsonFile) (*File, error) {
 			Policy:         jt.Policy,
 			Recovery:       recoveryBlockFromJSON(jt.Recovery),
 			Needs:          jt.Needs,
+			ParallelSafe:   jt.ParallelSafe,
 		})
 	}
 

--- a/pkg/dsl/ast/jsonenc_test.go
+++ b/pkg/dsl/ast/jsonenc_test.go
@@ -212,6 +212,34 @@ func TestAttachmentsRoundtrip(t *testing.T) {
 	}
 }
 
+func TestToolParallelSafeRoundtrip(t *testing.T) {
+	original := &ast.File{
+		Tools: []*ast.ToolNodeDecl{
+			{Name: "render_scene", Command: "render --scene x", ParallelSafe: true},
+			{Name: "plain", Command: "echo ok"},
+		},
+	}
+	data, err := ast.MarshalFile(original)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if !strings.Contains(string(data), `"parallel_safe": true`) {
+		t.Errorf("expected parallel_safe in JSON: %s", data)
+	}
+	restored, err := ast.UnmarshalFile(data)
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	if !reflect.DeepEqual(original, restored) {
+		t.Errorf("roundtrip mismatch:\noriginal=%#v\nrestored=%#v", original, restored)
+	}
+	// omitempty: the plain tool must not emit the key.
+	plainData, _ := ast.MarshalFile(&ast.File{Tools: []*ast.ToolNodeDecl{{Name: "plain", Command: "echo ok"}}})
+	if strings.Contains(string(plainData), "parallel_safe") {
+		t.Errorf("parallel_safe should be omitted when false: %s", plainData)
+	}
+}
+
 func TestLoopClauseRoundtrip(t *testing.T) {
 	// The loop bound has three wire forms (literal / expression / unbounded
 	// with optional fuel); each must survive marshal → unmarshal untouched,

--- a/pkg/dsl/ir/compile.go
+++ b/pkg/dsl/ir/compile.go
@@ -1187,6 +1187,7 @@ func (c *compiler) compileTools() {
 			PostcondRefs:  postcondRefs,
 			Policy:        policy,
 			Recovery:      recovery,
+			ParallelSafe:  t.ParallelSafe,
 		}
 	}
 }

--- a/pkg/dsl/ir/ir.go
+++ b/pkg/dsl/ir/ir.go
@@ -334,6 +334,17 @@ type ToolNode struct {
 	Recovery      *RecoverySpec // bounded recovery rung config (nil = no rungs)
 
 	Needs []string // resource names this node acquires before running (counting semaphores)
+
+	// ParallelSafe asserts that concurrent fan-out replays of this tool write
+	// only to disjoint, item-keyed targets and never race one another on the
+	// shared workspace, letting the workspace-safety guard fan the tool out in
+	// parallel (max_parallel_branches > 1). It is scoped to a fan_out_each
+	// template — the one place a single node is replayed over items; it has no
+	// effect on a static fan_out_all / llm-router (distinct branches, no item
+	// key). Unlike a subbot's Isolated, the tool still writes to the shared
+	// workspace — it just partitions those writes; unlike an agent/judge
+	// Readonly, it is not read-only. Default false = conservatively mutating.
+	ParallelSafe bool
 }
 
 // Verified Action policy values (ADR-044).

--- a/pkg/dsl/parser/parser_nodes.go
+++ b/pkg/dsl/parser/parser_nodes.go
@@ -502,6 +502,11 @@ func (p *parser) parseToolNodeProp(td *ast.ToolNodeDecl, propTok Token) {
 			td.Policy = p.expectIdent()
 		case "recovery":
 			td.Recovery = p.parseRecoveryBlock(propTok)
+		case "parallel_safe":
+			p.expect(TokenColon)
+			if v := p.parseBool(); v != nil {
+				td.ParallelSafe = *v
+			}
 		default:
 			p.addError(DiagUnknownProperty, propTok, "unknown tool property '"+propTok.Value+"'")
 			p.skipToNewline()

--- a/pkg/dsl/parser/parser_verified_action_test.go
+++ b/pkg/dsl/parser/parser_verified_action_test.go
@@ -41,6 +41,30 @@ func TestParseVerifiedActionQuad(t *testing.T) {
 	}
 }
 
+// parallel_safe is an opt-in bool on tool nodes that lets a mutating tool fan
+// out in parallel (its concurrent replays write to disjoint targets).
+func TestParseToolParallelSafe(t *testing.T) {
+	src := `tool render_scene:
+  command: "render --scene {{outputs.dispatch.item.id}}"
+  parallel_safe: true
+`
+	res := parser.Parse("test.bot", src)
+	assertNoDiags(t, res)
+	if len(res.File.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(res.File.Tools))
+	}
+	if !res.File.Tools[0].ParallelSafe {
+		t.Fatal("expected ParallelSafe = true")
+	}
+
+	// Absent the property, it defaults to false (safe, serialized-only fan-out).
+	res2 := parser.Parse("test.bot", "tool plain:\n  command: \"echo ok\"\n")
+	assertNoDiags(t, res2)
+	if res2.File.Tools[0].ParallelSafe {
+		t.Fatal("plain tool must default ParallelSafe = false")
+	}
+}
+
 // A tool node with no quad fields still parses (backward compatible).
 func TestParseToolNodeNoQuad(t *testing.T) {
 	src := `tool plain:

--- a/pkg/dsl/unparse/unparse.go
+++ b/pkg/dsl/unparse/unparse.go
@@ -408,6 +408,9 @@ func (w *fileWriter) writeTools(tools []*ast.ToolNodeDecl) {
 		if t.Policy != "" {
 			writeProp(&w.b, "policy", t.Policy)
 		}
+		if t.ParallelSafe {
+			writeProp(&w.b, "parallel_safe", "true")
+		}
 		if t.Recovery != nil {
 			writeRecoveryBlock(&w.b, t.Recovery, "  ")
 		}

--- a/pkg/dsl/unparse/verified_action_test.go
+++ b/pkg/dsl/unparse/verified_action_test.go
@@ -60,3 +60,33 @@ workflow w:
 		t.Fatalf("recovery not preserved: %+v", tn.Recovery)
 	}
 }
+
+// parallel_safe must survive an IR→.bot round-trip so `iterion resume`
+// change-detection hashing stays correct.
+func TestUnparseParallelSafe_RoundTrip(t *testing.T) {
+	src := `tool render_scene:
+  command: "render --scene {{outputs.dispatch.item.id}}"
+  parallel_safe: true
+
+workflow w:
+  entry: render_scene
+  render_scene -> done
+`
+	res := parser.Parse("test.bot", src)
+	if len(res.Diagnostics) != 0 {
+		t.Fatalf("unexpected diagnostics: %+v", res.Diagnostics)
+	}
+
+	out := unparse.Unparse(res.File)
+	if !strings.Contains(out, "parallel_safe: true") {
+		t.Fatalf("unparse output missing parallel_safe:\n%s", out)
+	}
+
+	res2 := parser.Parse("test.bot", out)
+	if len(res2.Diagnostics) != 0 {
+		t.Fatalf("reparse diagnostics: %+v\nsource:\n%s", res2.Diagnostics, out)
+	}
+	if !res2.File.Tools[0].ParallelSafe {
+		t.Fatal("parallel_safe not preserved across round-trip")
+	}
+}

--- a/pkg/runtime/fan_out_internal_test.go
+++ b/pkg/runtime/fan_out_internal_test.go
@@ -10,9 +10,28 @@ import (
 // isMutatingNode — workspace mutation classifier
 // ---------------------------------------------------------------------------
 
-func TestIsMutatingNode_ToolNodeAlwaysMutating(t *testing.T) {
+func TestIsMutatingNode_ToolNodeMutatingByDefault(t *testing.T) {
 	if !isMutatingNode(&ir.ToolNode{BaseNode: ir.BaseNode{ID: "tool"}}) {
-		t.Error("tool node must be classified mutating")
+		t.Error("tool node must be classified mutating by default")
+	}
+}
+
+func TestIsMutatingNode_ToolParallelSafeScopedToFanOutEach(t *testing.T) {
+	// `parallel_safe:` relaxes a tool to non-mutating ONLY on a fan_out_each
+	// template (item-keyed disjoint replays). The general classifier — used by
+	// the static fan_out_all / llm-router guard, where branches are distinct
+	// nodes with no item-key guarantee — keeps it conservatively mutating.
+	n := &ir.ToolNode{BaseNode: ir.BaseNode{ID: "tool"}, ParallelSafe: true}
+	if !isMutatingNode(n) {
+		t.Error("parallel_safe tool must stay mutating in the general (non-fan_out_each) classifier")
+	}
+	if isMutatingNodeCtx(n, "", nil, true) {
+		t.Error("parallel_safe tool must be exempt on a fan_out_each template")
+	}
+	// Without the flag, a tool is mutating in both contexts.
+	plain := &ir.ToolNode{BaseNode: ir.BaseNode{ID: "plain"}}
+	if !isMutatingNodeCtx(plain, "", nil, true) {
+		t.Error("plain tool must stay mutating even on a fan_out_each template")
 	}
 }
 
@@ -271,11 +290,11 @@ func TestBranchContainsMutation_DetectsMutationBetweenIntermediateJoinAndGlobalC
 	}
 	e := &Engine{workflow: wf}
 	// Branch A reaches mut_a (mutating) before global_join.
-	if !e.branchContainsMutation("a", "global_join") {
+	if !e.branchContainsMutation("a", "global_join", false) {
 		t.Error("BFS must catch mutation after an intermediate join, before the global convergence")
 	}
 	// Branch B has no mutation up to global_join.
-	if e.branchContainsMutation("b", "global_join") {
+	if e.branchContainsMutation("b", "global_join", false) {
 		t.Error("branch B has no mutation; got mutation=true")
 	}
 }
@@ -292,7 +311,7 @@ func TestBranchContainsMutation_StopsAtTerminalNode(t *testing.T) {
 		Edges: []*ir.Edge{{From: "a", To: "done"}},
 	}
 	e := &Engine{workflow: wf}
-	if e.branchContainsMutation("a", "") {
+	if e.branchContainsMutation("a", "", false) {
 		t.Error("branch ending in done before global convergence should not report mutation")
 	}
 }

--- a/pkg/runtime/fan_out_tool_test.go
+++ b/pkg/runtime/fan_out_tool_test.go
@@ -1,0 +1,229 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// toolFanOutWorkflow builds:
+//
+//	entry -> dispatch(fan_out_each over entry.items) -> run_scene(tool) -> collect(wait_all) -> done
+//
+// parallelSafe toggles ToolNode.ParallelSafe; maxParallel sets the budget cap
+// (0 = uncapped, i.e. len(items)). Mirror of subbotFanOutWorkflow for the tool
+// opt-out.
+func toolFanOutWorkflow(parallelSafe bool, maxParallel int) *ir.Workflow {
+	router := &ir.RouterNode{
+		BaseNode:    ir.BaseNode{ID: "dispatch"},
+		RouterMode:  ir.RouterFanOutEach,
+		Over:        "{{outputs.entry.items}}",
+		OverRefs:    []*ir.Ref{{Kind: ir.RefOutputs, Path: []string{"entry", "items"}, Raw: "{{outputs.entry.items}}"}},
+		ItemBinding: "item",
+	}
+	wf := &ir.Workflow{
+		Name:  "fan_out_each_tool_parallel",
+		Entry: "entry",
+		Nodes: map[string]ir.Node{
+			"entry":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "entry"}},
+			"dispatch": router,
+			"run_scene": &ir.ToolNode{
+				BaseNode:     ir.BaseNode{ID: "run_scene"},
+				Command:      "write --scene {{outputs.dispatch.item.id}}",
+				ParallelSafe: parallelSafe,
+			},
+			"collect": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "collect"}, AwaitMode: ir.AwaitWaitAll},
+			"done":    &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+			"fail":    &ir.FailNode{BaseNode: ir.BaseNode{ID: "fail"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "entry", To: "dispatch"},
+			{From: "dispatch", To: "run_scene"},
+			{From: "run_scene", To: "collect"},
+			{From: "collect", To: "done"},
+		},
+		Schemas: map[string]*ir.Schema{},
+		Prompts: map[string]*ir.Prompt{},
+		Vars:    map[string]*ir.Var{},
+		Loops:   map[string]*ir.Loop{},
+	}
+	if maxParallel > 0 {
+		wf.Budget = &ir.Budget{MaxParallelBranches: maxParallel}
+	}
+	return wf
+}
+
+// TestFanOutEach_ToolParallel_AllowedWhenParallelSafe proves a `parallel_safe:`
+// tool template is admitted by the workspace-safety guard at
+// max_parallel_branches>1 AND actually runs concurrently. Concurrency is
+// measured with the same deterministic barrier the subbot test uses (no sleep):
+// each replay blocks until all N are inside, so a serialized implementation
+// would deadlock rather than pass — the peak is exact.
+func TestFanOutEach_ToolParallel_AllowedWhenParallelSafe(t *testing.T) {
+	const n = 3
+	wf := toolFanOutWorkflow(true, n)
+
+	var active, peak int32
+	barrier := make(chan struct{})
+	var once sync.Once
+	var calls int64
+
+	exec := newStubExecutor()
+	exec.on("entry", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"items": []any{item("A"), item("B"), item("C")}}, nil
+	})
+	exec.on("run_scene", func(_ map[string]any) (map[string]any, error) {
+		atomic.AddInt64(&calls, 1)
+		cur := atomic.AddInt32(&active, 1)
+		for { // lock-free max
+			p := atomic.LoadInt32(&peak)
+			if cur <= p || atomic.CompareAndSwapInt32(&peak, p, cur) {
+				break
+			}
+		}
+		if cur >= int32(n) {
+			once.Do(func() { close(barrier) })
+		}
+		<-barrier // block until all N replays are concurrently inside
+		atomic.AddInt32(&active, -1)
+		return map[string]any{"committed": true}, nil
+	})
+	exec.on("collect", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"done": true}, nil
+	})
+
+	s := tmpStore(t)
+	eng := New(wf, s, exec)
+	if err := eng.Run(context.Background(), "run-fe-tool-parallel", nil); err != nil {
+		t.Fatalf("parallel_safe tool fan_out_each at max_parallel=%d should be allowed, got %v", n, err)
+	}
+	r, _ := s.LoadRun(context.Background(), "run-fe-tool-parallel")
+	if r.Status != store.RunStatusFinished {
+		t.Fatalf("expected finished, got %s", r.Status)
+	}
+	if got := atomic.LoadInt64(&calls); got != n {
+		t.Fatalf("tool executed %d times, want %d (one per element)", got, n)
+	}
+	if got := atomic.LoadInt32(&peak); got != int32(n) {
+		t.Fatalf("peak tool concurrency = %d, want %d (parallel_safe template did not run in parallel)", got, n)
+	}
+}
+
+// TestFanOutEach_ToolParallel_RejectedWhenTemplateHasOtherMutatingNode proves the
+// exemption is scoped to the parallel_safe node itself: a template that chains a
+// parallel_safe tool INTO a second, non-safe tool still contains a mutating node,
+// so the guard rejects the parallel fan-out before any replay runs.
+func TestFanOutEach_ToolParallel_RejectedWhenTemplateHasOtherMutatingNode(t *testing.T) {
+	wf := toolFanOutWorkflow(true, 3)
+	// Insert a plain (non-parallel_safe) tool between run_scene and collect.
+	wf.Nodes["post_process"] = &ir.ToolNode{BaseNode: ir.BaseNode{ID: "post_process"}, Command: "aggregate > out/report.json"}
+	// Rewire: run_scene -> post_process -> collect.
+	for _, e := range wf.Edges {
+		if e.From == "run_scene" && e.To == "collect" {
+			e.To = "post_process"
+		}
+	}
+	wf.Edges = append(wf.Edges, &ir.Edge{From: "post_process", To: "collect"})
+
+	var sceneCalls, postCalls int64
+	exec := newStubExecutor()
+	exec.on("entry", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"items": []any{item("A"), item("B"), item("C")}}, nil
+	})
+	exec.on("run_scene", func(_ map[string]any) (map[string]any, error) {
+		atomic.AddInt64(&sceneCalls, 1)
+		return map[string]any{"committed": true}, nil
+	})
+	exec.on("post_process", func(_ map[string]any) (map[string]any, error) {
+		atomic.AddInt64(&postCalls, 1)
+		return map[string]any{"done": true}, nil
+	})
+
+	s := tmpStore(t)
+	eng := New(wf, s, exec)
+	err := eng.Run(context.Background(), "run-fe-tool-mixed", nil)
+	if err == nil {
+		t.Fatal("expected workspace safety error: template chains a non-parallel_safe tool")
+	}
+	var rtErr *RuntimeError
+	if !errors.As(err, &rtErr) || rtErr.Code != ErrCodeWorkspaceSafety {
+		t.Fatalf("expected RuntimeError ErrCodeWorkspaceSafety, got %T: %v", err, err)
+	}
+	if sceneCalls != 0 || postCalls != 0 {
+		t.Fatalf("no branch node should run after safety rejection; scene=%d post=%d", sceneCalls, postCalls)
+	}
+}
+
+// TestValidateWorkspaceSafety_ParallelSafeToolsStillRejectedInFanOutAll pins the
+// scope of the opt-out: `parallel_safe:` relaxes only the fan_out_each guard.
+// In a STATIC fan_out_all the branches are distinct nodes with no item-key
+// disjointness guarantee, so two parallel_safe tools writing in parallel remain
+// a violation.
+func TestValidateWorkspaceSafety_ParallelSafeToolsStillRejectedInFanOutAll(t *testing.T) {
+	wf := &ir.Workflow{
+		Name: "t",
+		Nodes: map[string]ir.Node{
+			"router": &ir.RouterNode{BaseNode: ir.BaseNode{ID: "router"}, RouterMode: ir.RouterFanOutAll},
+			"tool_a": &ir.ToolNode{BaseNode: ir.BaseNode{ID: "tool_a"}, Command: "build A > out/report.json", ParallelSafe: true},
+			"tool_b": &ir.ToolNode{BaseNode: ir.BaseNode{ID: "tool_b"}, Command: "build B > out/report.json", ParallelSafe: true},
+			"join":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "join"}, AwaitMode: ir.AwaitWaitAll},
+			"done":   &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "router", To: "tool_a"},
+			{From: "router", To: "tool_b"},
+			{From: "tool_a", To: "join"},
+			{From: "tool_b", To: "join"},
+			{From: "join", To: "done"},
+		},
+	}
+	e := &Engine{workflow: wf}
+	err := e.validateWorkspaceSafety("router", []*ir.Edge{
+		{From: "router", To: "tool_a"},
+		{From: "router", To: "tool_b"},
+	})
+	if err == nil {
+		t.Fatal("parallel_safe must not relax the static fan_out_all guard")
+	}
+	var rtErr *RuntimeError
+	if !errors.As(err, &rtErr) || rtErr.Code != ErrCodeWorkspaceSafety {
+		t.Fatalf("expected RuntimeError ErrCodeWorkspaceSafety, got %T: %v", err, err)
+	}
+}
+
+// TestFanOutEach_ToolParallel_RejectedWhenNotParallelSafe is the safe-default
+// non-regression: without `parallel_safe:`, a tool template fanned out with
+// max_parallel_branches>1 is still rejected by WORKSPACE_SAFETY before any
+// replay runs.
+func TestFanOutEach_ToolParallel_RejectedWhenNotParallelSafe(t *testing.T) {
+	wf := toolFanOutWorkflow(false, 3)
+
+	var calls int64
+	exec := newStubExecutor()
+	exec.on("entry", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"items": []any{item("A"), item("B"), item("C")}}, nil
+	})
+	exec.on("run_scene", func(_ map[string]any) (map[string]any, error) {
+		atomic.AddInt64(&calls, 1)
+		return map[string]any{"committed": true}, nil
+	})
+
+	s := tmpStore(t)
+	eng := New(wf, s, exec)
+	err := eng.Run(context.Background(), "run-fe-tool-reject", nil)
+	if err == nil {
+		t.Fatal("expected workspace safety error for non-parallel_safe parallel tool")
+	}
+	var rtErr *RuntimeError
+	if !errors.As(err, &rtErr) || rtErr.Code != ErrCodeWorkspaceSafety {
+		t.Fatalf("expected RuntimeError ErrCodeWorkspaceSafety, got %T: %v", err, err)
+	}
+	if got := atomic.LoadInt64(&calls); got != 0 {
+		t.Fatalf("tool executed %d time(s), want 0 after safety rejection", got)
+	}
+}

--- a/pkg/runtime/workspace_safety.go
+++ b/pkg/runtime/workspace_safety.go
@@ -23,19 +23,23 @@ var readOnlyTools = map[string]bool{
 }
 
 // isMutatingNode returns true if the node may modify the workspace.
-// Tool nodes are always mutating. Agent/judge nodes are mutating when
-// full_access is set, when they have at least one tool that is not in the
-// read-only set, or when the effective backend is a CLI delegate and its tool
-// list is omitted (CLI delegates treat an empty list as unrestricted native
-// tools). The engine asks the production executor for the effective backend so
-// launch overrides, environment defaults, and auto-detection are included.
-// Subbot nodes run a child .bot that may do anything (including mutate the
-// shared worktree), so they are conservatively treated as mutating — this
+// Tool nodes are always mutating in this general classifier. Agent/judge nodes
+// are mutating when full_access is set, when they have at least one tool that is
+// not in the read-only set, or when the effective backend is a CLI delegate and
+// its tool list is omitted (CLI delegates treat an empty list as unrestricted
+// native tools). The engine asks the production executor for the effective
+// backend so launch overrides, environment defaults, and auto-detection are
+// included. Subbot nodes run a child .bot that may do anything (including mutate
+// the shared worktree), so they are conservatively treated as mutating — this
 // keeps validateWorkspaceSafety from admitting two subbot branches that would
 // race the same workspace. A subbot may opt out with `isolated:` (it asserts
-// the child confines writes to its own run store / worktree), just as an
-// agent/judge node opts out with Readonly=true; neither is then considered
-// mutating.
+// the child confines writes to its own run store / worktree) and an agent/judge
+// node with Readonly=true; both are context-independent, so they are honoured
+// everywhere. A tool's `parallel_safe:` opt-out is NOT honoured here: it only
+// applies to a fan_out_each template (see isMutatingNodeCtx), because only there
+// is a single node replayed over distinct items with disjoint, item-keyed
+// writes — in a static fan_out_all / llm-router the branches are different nodes
+// with no such guarantee.
 func isMutatingNode(node ir.Node) bool {
 	return isMutatingNodeWithBackend(node, "", nil)
 }
@@ -48,9 +52,23 @@ type effectiveBackendResolver interface {
 }
 
 func isMutatingNodeWithBackend(node ir.Node, defaultBackend string, resolver effectiveBackendResolver) bool {
+	return isMutatingNodeCtx(node, defaultBackend, resolver, false)
+}
+
+// isMutatingNodeCtx classifies a node for workspace-safety. fanOutEachTemplate is
+// true only when walking a fan_out_each template branch; there a tool marked
+// `parallel_safe:` is treated as non-mutating (the author asserts its concurrent
+// replays write only to disjoint, item-keyed targets — mirror of a subbot's
+// `isolated:` / an agent-judge `readonly:`, but scoped to the fan_out_each
+// replay, the only place a single template node is fanned out over items). In
+// every other context (fanOutEachTemplate=false) a tool is conservatively
+// mutating even with the flag: static fan_out_all / llm-router branches are
+// DISTINCT nodes with no item-key disjointness guarantee. Subbot Isolated and
+// agent/judge Readonly are context-independent and honoured in both.
+func isMutatingNodeCtx(node ir.Node, defaultBackend string, resolver effectiveBackendResolver, fanOutEachTemplate bool) bool {
 	switch n := node.(type) {
 	case *ir.ToolNode:
-		return true
+		return !(fanOutEachTemplate && n.ParallelSafe)
 	case *ir.SubbotNode:
 		// A subbot marked `isolated:` asserts the child confines its writes to
 		// its own run store / worktree and never touches the parent's shared
@@ -130,7 +148,13 @@ func unrestrictedCLIBackendCanWrite(
 // fan-out (the node where all branches reconverge), not the first
 // intermediate join. We pass that in explicitly. Terminal nodes (done/fail)
 // also stop the walk because the branch ends there.
-func (e *Engine) branchContainsMutation(startNodeID, globalConvergence string) bool {
+//
+// fanOutEachTemplate is true only when the branch is a fan_out_each template
+// (one node replayed over items); it relaxes a `parallel_safe:` tool to
+// non-mutating along the walk. A branch that also contains any OTHER mutating
+// node (a non-parallel_safe tool, a full_access agent, a non-isolated subbot)
+// is still reported as mutating.
+func (e *Engine) branchContainsMutation(startNodeID, globalConvergence string, fanOutEachTemplate bool) bool {
 	visited := map[string]bool{}
 	queue := []string{startNodeID}
 	for len(queue) > 0 {
@@ -156,7 +180,7 @@ func (e *Engine) branchContainsMutation(startNodeID, globalConvergence string) b
 			continue
 		}
 		resolver, _ := e.executor.(effectiveBackendResolver)
-		if isMutatingNodeWithBackend(node, e.workflow.DefaultBackend, resolver) {
+		if isMutatingNodeCtx(node, e.workflow.DefaultBackend, resolver, fanOutEachTemplate) {
 			return true
 		}
 		for _, edge := range e.workflow.Edges {
@@ -179,7 +203,10 @@ func (e *Engine) validateWorkspaceSafety(routerNodeID string, fanEdges []*ir.Edg
 	mutatingCount := 0
 	var mutatingBranches []string
 	for _, edge := range fanEdges {
-		if e.branchContainsMutation(edge.To, globalConvergence) {
+		// Static fan_out_all / llm-router: branches are DISTINCT nodes, so a
+		// tool's `parallel_safe:` (item-keyed disjoint replays) does not apply —
+		// pass fanOutEachTemplate=false.
+		if e.branchContainsMutation(edge.To, globalConvergence, false) {
 			mutatingCount++
 			mutatingBranches = append(mutatingBranches, edge.To)
 		}
@@ -203,7 +230,10 @@ func (e *Engine) validateFanOutEachWorkspaceSafety(routerNodeID string, tmplEdge
 	if itemCount <= 1 || maxParallel <= 1 || tmplEdge == nil {
 		return nil
 	}
-	if !e.branchContainsMutation(tmplEdge.To, convergence) {
+	// Fan_out_each template: a single node replayed over items, so a
+	// `parallel_safe:` tool along the template is exempt (item-keyed disjoint
+	// writes). Any other mutating node still trips the guard.
+	if !e.branchContainsMutation(tmplEdge.To, convergence, true) {
 		return nil
 	}
 	return &RuntimeError{


### PR DESCRIPTION
## Summary

Adds an opt-in **`parallel_safe:`** flag on `tool` nodes so a mutating tool can be fanned out in parallel over a `fan_out_each` (`max_parallel_branches > 1`). It is the tool-node counterpart of #197's `isolated:` (subbot) and of `readonly:` (agent/judge).

### Motivation

The workspace-safety guard treats a `tool` node as **unconditionally mutating**, so it refuses to replay the same tool template concurrently over a `fan_out_each` — the only legal tool fan-out was serialized (`max_parallel_branches: 1`). When each replay writes to a **disjoint, item-keyed target** (e.g. one keyframe per `scene_id` under `runs/<run>/keyframes/candidates/<scene_id>/`) the replays never race, and that rejection is a false positive — exactly the shape #197 fixed for subbots.

```
router keyframes_dispatch:
  mode: fan_out_each
  over: "{{outputs.prepare.keyframes}}"
  as: keyframe
  key: scene_id

tool generate_keyframe_scene:
  command: "render --scene {{outputs.keyframes_dispatch.keyframe.scene_id}}"
  parallel_safe: true   # each replay writes only to its own scene-keyed path

keyframes_dispatch -> generate_keyframe_scene
generate_keyframe_scene -> verify   # wait_all
```

### Scope — `fan_out_each` only

`parallel_safe` relaxes **only** the `fan_out_each` guard. `isMutatingNodeCtx` exempts a `parallel_safe` tool solely on a fan_out_each template (the one place a single node is replayed over distinct items, so item-keyed disjointness holds by construction). In a static `fan_out_all` / `llm-router` multi-select the branches are **different** nodes with no shared item key, so a tool stays conservatively mutating there. A `parallel_safe` tool chained into any **other** mutating node in the same template still trips the guard. Default `false` preserves today's safe, serialized-only behaviour.

Unlike `isolated:` (own run store/worktree) the tool still writes to the shared workspace — it just **partitions** its writes by the fan-out item; unlike `readonly:` it is not read-only.

### Threading

Through the full DSL text stack: `ast.ToolNodeDecl` → parser `parseToolNodeProp` (`parallel_safe: <bool>`, a plain identifier prop like the ADR-044 quad) → `ir.ToolNode` → `compileTools` → unparse `writeTools` (round-trips) → `jsonenc` marshal/unmarshal. A single classifier (`isMutatingNodeCtx`) feeds both guards, so the one-line semantics change covers wait-all and fan_out_each together.

### Tests

- `isMutatingNode` scoping: general classifier keeps a `parallel_safe` tool mutating; fan_out_each ctx exempts it.
- Real-concurrency `fan_out_each` tool test — deterministic barrier, peak = 3, passes under `-race` (a serialized impl would deadlock).
- Safe-default rejection (no flag → still rejected, 0 executions).
- Mixed-template rejection: `parallel_safe` tool → plain tool still trips the guard, 0 executions.
- Static `fan_out_all` non-relaxation: two `parallel_safe` tools still rejected.
- Parser + unparse + jsonenc round-trips.
- Docs reconciled in `docs/groups-iteration-subbots.md` next to `isolated:`.

`go test ./pkg/dsl/... ./pkg/runtime/` green; `go vet` clean.

### Follow-ups (not in this PR)

Studio `ToolForm` control + run-console `WireNode` chip, for parity with `isolated:`/`readonly:` (cosmetic — the `.bot` text path and open→save round-trip already carry the flag as an opaque key; the studio tool mirror already omits `postcondition`/`policy`/`recovery` too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)