### PR TITLE
feat(configshare): declarative per-bot shareable surface + per-share field subsetting

### DIFF
--- a/bots/feed-watch/manifest.yaml
+++ b/bots/feed-watch/manifest.yaml
@@ -57,3 +57,17 @@ invocations:
     mode: direct
     context_vars: { mode: digest }
     schedule: { suggested_cron: "0 8 * * 1" }
+
+## Scoped config-share surface: what a non-operator may edit from a share URL
+## (pkg/configshare). The operator mints a share for one category; the mint
+## expands {category} and pins these exact paths — feeds + editorial are
+## editable, digest_title is read-only context, and everything else (other
+## categories, the `sinks` routing) stays off-limits. A share can never exceed
+## this. Adding this block is all a bot needs to gain the config-share editor.
+config_share:
+  config_path: feed-watch.json
+  editable_paths:
+    - "categories.{category}.feeds"
+    - "categories.{category}.editorial"
+  visible_paths:
+    - "categories.{category}.digest_title"

--- a/docs/adr/077-declarative-per-bot-config-share-surface.md
+++ b/docs/adr/077-declarative-per-bot-config-share-surface.md
@@ -1,0 +1,113 @@
+# ADR-077 — Declarative per-bot config-share surface
+
+Status: accepted · 2026-07-18
+
+Extends [ADR-076](076-scoped-config-share-editor.md) (the scoped config-share
+editor). ADR-076 shipped the isolation core; this ADR records how a bot
+**declares** what a share may touch, so the primitive generalizes beyond its
+first user (feed-watch/Vigie).
+
+## Context
+
+ADR-076 shipped config-share with the shareable surface — `config_path`,
+`allowed_paths`, `visible_paths` — **supplied by the operator at mint** (or by
+the studio create dialog, which hardcoded feed-watch's shape: a `veille.yaml`
+default and client-side `categories.{cat}.{field}` path templating).
+
+That violates iterion's universal-bots bar (a catalog bot must be adoptable
+with zero bespoke code): a second bot wanting config-share would need the SPA's
+mint form edited to know its config file and fields, and the operator would
+have to hand-type literal JSON paths — error-prone (a typo widens the grant)
+and untied to anything the bot committed to git. The knowledge of *what is
+shareable* belongs with the bot, versioned and PR-reviewed, not in the operator's
+head or the SPA.
+
+## Options considered
+
+1. **Status quo — operator-supplied paths.** No bot artifact. Fails the
+   universal bar (per-bot SPA edits), and the grant is only as correct as the
+   operator's typing. Rejected.
+2. **A separate `bots/<bot>/config-share.schema.json`** (JSON-Schema with
+   `x-share-editable` / `x-share-visible` annotations + per-field constraints).
+   Richest — carries JSON-Schema validation and an operator preview — but
+   introduces a new file + a new schema-annotation format to author and load,
+   and duplicates constraints the runtime already validates. Heavier than the
+   MVP needs. Deferred (kept as the growth path for richer per-field
+   constraints).
+3. **A `config_share:` block in the existing `manifest.yaml`** declaring
+   `config_path` + `editable_paths` / `visible_paths` **path templates**, with
+   a `{category}` placeholder for per-category configs; reuse the existing
+   deterministic validators (`ValidatePaths`, the `feeds`/`editorial` field
+   guards). Chosen.
+
+## Decision
+
+A bot declares its config-share surface with a `config_share:` block in its
+`manifest.yaml`:
+
+```yaml
+config_share:
+  config_path: feed-watch.json
+  editable_paths:
+    - "categories.{category}.feeds"
+    - "categories.{category}.editorial"
+  visible_paths:
+    - "categories.{category}.digest_title"
+```
+
+- **The mint derives, and pins, from the block.** Given `bot_id` (+ a
+  `category` when the templates carry `{category}`), the mint resolves the bot's
+  manifest, expands `{category}`, and pins `config_path` + `allowed_paths` +
+  `visible_paths` on the `Share`. The operator supplies only who/where + the
+  category — never a path. A share **can never exceed** the declared surface.
+- **The block is authoritative; explicit paths are the fallback.** When a bot
+  declares a block, client-supplied paths are ignored (the block is the
+  contract). A bot with no block — or a loose `.bot` not resolvable on the
+  server — falls back to today's explicit operator paths, so the change is
+  backward-compatible and cloud-safe.
+- **Per-share least privilege via field subsetting.** A mint may narrow a
+  derived grant to a SUBSET of the bot's declared editable fields
+  (`editable_fields: ["feeds"]`, by leaf name). A non-selected field is neither
+  writable nor visible — a feeds-only curator can't touch or even read the
+  editorial prompt (the LLM-injection surface). Selecting a field the bot never
+  declared editable is a 400, not a silent widen. Enforced in `DeriveGrant`; the
+  studio form renders a data-driven checkbox per declared field.
+- **Deterministic guards stay.** `configshare.DeriveGrant` validates the
+  category (`^[A-Za-z0-9_-]+$` — no dot, no traversal), fails closed on an
+  unresolved placeholder (never pins a literal `{…}` segment), and its output
+  still passes through `ValidatePaths` (literal / no-overlap / no-forbidden).
+  The read-side `pruneForbidden` and write-side allow-list walk from ADR-076 are
+  unchanged — this ADR only decides *where the surface comes from*, not how it
+  is enforced.
+- **The studio form is data-driven.** `config_share` is mirrored onto
+  `botregistry.Entry` (so it reaches the SPA via `/api/v1/bots`); the
+  "Config-share links" card reads it to render the editable/visible fields and
+  hides itself for bots that declare none — no hardcoded per-bot shape.
+
+## Consequences
+
+- **A second bot adopts the whole editor by adding the block alone** — no Go,
+  no SPA change. This is the universal-bots contract for config-share.
+- The shareable surface is **git-reviewed** and colocated with the bot, matching
+  ADR-076's "config stays versioned/PR-reviewable" premise. Changing what is
+  shareable is a manifest edit in a PR, not operator tribal knowledge.
+- Field validation is still keyed by leaf segment name (`feeds`, `editorial`):
+  a bot reusing those names inherits the SSRF/size guards; a bot with a **novel**
+  editable field passes structurally (the path allow-list still gates it, but no
+  value-shape check runs). Richer per-field constraints declared in the block
+  (option 2's JSON-Schema) are the growth path.
+- **Per-share field subsetting is supported** (least privilege): a share exposes
+  exactly the declared editable fields the operator selects for it, defaulting to
+  the full set. The `feeds` / `editorial` risk asymmetry (editorial is the
+  injection surface) is the motivating case.
+
+## Accepted follow-ups (not blockers)
+
+- Richer per-field constraints in the block (option 2's JSON-Schema), so a novel
+  field gets a value-shape check, not only a path gate.
+- Category existence check at mint (read the file and reject a category absent
+  from it) — today an unknown category yields an empty projection, harmless but
+  not caught early.
+
+Reference: [docs/config-share.md](../config-share.md),
+[pkg/configshare/schema.go](../../pkg/configshare/schema.go) (`DeriveGrant`).

--- a/docs/config-share.md
+++ b/docs/config-share.md
@@ -22,6 +22,37 @@ The operator gets back a URL `…/config/<id>#<token>` and the `iws_` token
 and Save commits the change straight to the repo through the forge's contents
 API — an atomic `if-match` write, no clone, no bot run.
 
+### The shareable surface is declared by the bot
+
+`config_path`, `allowed_paths` and `visible_paths` are not hand-typed by the
+operator — they are **derived from the bot's own manifest** at mint time. A bot
+declares what a share may touch with a `config_share:` block in its
+`manifest.yaml`:
+
+```yaml
+config_share:
+  config_path: feed-watch.json
+  editable_paths:
+    - "categories.{category}.feeds"
+    - "categories.{category}.editorial"
+  visible_paths:
+    - "categories.{category}.digest_title"
+```
+
+A `{category}` placeholder makes the surface per-category: the operator mints a
+share by naming a category (`a11y`), and the mint expands `{category}` →
+`a11y`, pins `config_path`, and computes `allowed_paths` / `visible_paths` from
+the templates. A share **can never exceed** what the bot committed to git, and a
+second bot adopts the whole editor by adding this block alone — no server or SPA
+change (the studio's "Config-share links" card reads the block to render a
+data-driven mint form, and hides itself for bots that declare none). The
+`{category}` value is validated (`[A-Za-z0-9_-]+` — no dots or traversal), and
+the derived paths still run through the same literal/no-overlap/no-forbidden
+`ValidatePaths` guard. A bot with no `config_share:` block (or a loose `.bot`
+not resolvable on the server) falls back to explicit operator-supplied paths.
+See [`pkg/configshare/schema.go`](../pkg/configshare/schema.go)
+(`DeriveGrant`).
+
 ## Security model
 
 The editor is the anti-injection boundary for a feature that hands a token to an
@@ -105,12 +136,16 @@ Mongo store (`configshare.NewMongoStore`, TTL'd audit).
 ## MVP scope + follow-ups
 
 Shipped: GitHub provider, Bearer-only token (no cookie exchange), 14-day default
-TTL, one share per category, the team `forge_token` PAT for writes, operator
-paths supplied explicitly (or derived by the studio's create dialog).
+TTL, one share per category, the team `forge_token` PAT for writes, and the
+per-bot `config_share:` manifest block that declares the shareable surface — the
+mint derives `config_path` + `allowed_paths` + `visible_paths` from it, and the
+studio card renders a data-driven form, so a **second bot adopts the whole editor
+by adding the block alone** (no Go or SPA change).
 
 Follow-ups (not blockers): a repo-narrowed github-app installation token (tighter
 blast radius than the team PAT); a one-shot code-per-handout exchange (so a
-pasted URL burns once); a per-bot `config_share:` manifest block + schema so the
-editor form auto-derives fields; GitLab/Forgejo `FileClient`; a preview/test-run
-button. The server primitive is already generic — a second bot needs no Go
-change, only its paths.
+pasted URL burns once); per-share field subsetting (a share exposing a subset of
+the bot's declared editable fields — today a share exposes the full declared
+surface for its category); richer per-field JSON-Schema constraints in the block
+(beyond the built-in `feeds`/`editorial` validators); GitLab/Forgejo
+`FileClient`; a preview/test-run button.

--- a/docs/config-share.md
+++ b/docs/config-share.md
@@ -136,16 +136,16 @@ Mongo store (`configshare.NewMongoStore`, TTL'd audit).
 ## MVP scope + follow-ups
 
 Shipped: GitHub provider, Bearer-only token (no cookie exchange), 14-day default
-TTL, one share per category, the team `forge_token` PAT for writes, and the
-per-bot `config_share:` manifest block that declares the shareable surface — the
-mint derives `config_path` + `allowed_paths` + `visible_paths` from it, and the
-studio card renders a data-driven form, so a **second bot adopts the whole editor
-by adding the block alone** (no Go or SPA change).
+TTL, one share per category, the team `forge_token` PAT for writes, the per-bot
+`config_share:` manifest block that declares the shareable surface (the mint
+derives `config_path` + `allowed_paths` + `visible_paths` from it and the studio
+card renders a data-driven form, so a **second bot adopts the whole editor by
+adding the block alone** — no Go or SPA change), and **per-share field
+subsetting** (an operator mints, say, a feeds-only share; a non-selected field is
+neither writable nor visible).
 
 Follow-ups (not blockers): a repo-narrowed github-app installation token (tighter
 blast radius than the team PAT); a one-shot code-per-handout exchange (so a
-pasted URL burns once); per-share field subsetting (a share exposing a subset of
-the bot's declared editable fields — today a share exposes the full declared
-surface for its category); richer per-field JSON-Schema constraints in the block
+pasted URL burns once); richer per-field JSON-Schema constraints in the block
 (beyond the built-in `feeds`/`editorial` validators); GitLab/Forgejo
 `FileClient`; a preview/test-run button.

--- a/pkg/botregistry/registry.go
+++ b/pkg/botregistry/registry.go
@@ -66,6 +66,13 @@ type Entry struct {
 	// allow_create adds "create a new repository" on a connected forge.
 	Repo *bundle.RepoRequirement `json:"repo,omitempty" yaml:"repo,omitempty"`
 
+	// ConfigShare mirrors the manifest config_share: block (the bot's
+	// scoped config-share surface). The studio's "Share config" card reads
+	// it to drive a data-driven mint form (the editable fields + config
+	// file come from the bot, not hardcoded per bot); nil = the bot exposes
+	// no config-share surface and the card is not offered.
+	ConfigShare *bundle.ConfigShareSpec `json:"config_share,omitempty" yaml:"config_share,omitempty"`
+
 	// Invocations is the typed routing contract from the manifest
 	// (manifest.yaml invocations:) — how this bot can be triggered (forge
 	// event, /slash-command, schedule, board) and the execution mode each
@@ -382,6 +389,7 @@ func parseBundle(dir string) (*Entry, error) {
 		DispatchVars:    m.DispatchVars,
 		Forge:           m.Forge,
 		Repo:            m.Repo,
+		ConfigShare:     m.ConfigShare,
 		Invocations:     bundle.EffectiveInvocations(m),
 		WhenToUse:       strings.TrimSpace(m.WhenToUse),
 		Author:          m.Author,

--- a/pkg/bundle/manifest.go
+++ b/pkg/bundle/manifest.go
@@ -149,6 +149,19 @@ type Manifest struct {
 	// me at a repo"), never a target-repo assumption: catalog bots stay
 	// repo-agnostic.
 	Repo *RepoRequirement `yaml:"repo,omitempty"`
+
+	// ConfigShare declares this bot's SCOPED CONFIG-SHARE surface: which
+	// fields of its workspace config file a non-operator may edit through a
+	// scoped share URL (pkg/configshare), so a share can be minted for THIS
+	// bot without the operator hand-typing the config file's JSON paths. The
+	// mint DERIVES the grant's editable/visible paths and config file from
+	// this block (expanding a {category} placeholder for a per-category
+	// config), pinning them at mint time — a share can never be minted
+	// outside the surface the bot committed to git. Advisory declaration like
+	// Repo/Forge (the runtime never reads it; the config-share mint does).
+	// A second bot adopts the whole config-share editor by adding this block
+	// alone — no server or SPA change.
+	ConfigShare *ConfigShareSpec `yaml:"config_share,omitempty"`
 }
 
 // Valid RepoRequirement.Mode values.
@@ -179,6 +192,29 @@ type RepoRequirement struct {
 	// Visibility seeds a created repo's visibility: "private" (the
 	// default) or "public".
 	Visibility string `yaml:"visibility,omitempty" json:"visibility,omitempty"`
+}
+
+// ConfigShareSpec is a bot's declared scoped config-share surface — the
+// contract that lets an operator mint a share for the bot (pkg/configshare)
+// without knowing its config file's JSON structure, and that a share can never
+// exceed. A second bot adopts the config-share editor by adding this block
+// alone: no server or SPA change.
+type ConfigShareSpec struct {
+	// ConfigPath is the config file inside the target repo a share edits
+	// (e.g. "feed-watch.json"). Repo-relative; normalized + guarded at mint
+	// (no traversal, no .git/.github, inside the workspace).
+	ConfigPath string `yaml:"config_path" json:"config_path"`
+	// EditablePaths are the dotted leaf paths a share may WRITE. A
+	// "{category}" placeholder is expanded to the concrete category at mint
+	// (e.g. "categories.{category}.feeds"), so ONE declaration covers every
+	// category; a config with no categories lists literal paths. No globs —
+	// every entry is a full leaf path.
+	EditablePaths []string `yaml:"editable_paths" json:"editable_paths"`
+	// VisiblePaths are extra READ-ONLY dotted paths a share may read back as
+	// context (e.g. "categories.{category}.digest_title"). The GET projection
+	// returns EditablePaths ∪ VisiblePaths and nothing else. Same {category}
+	// expansion. Optional.
+	VisiblePaths []string `yaml:"visible_paths,omitempty" json:"visible_paths,omitempty"`
 }
 
 // Normalized forge event vocabulary used in a manifest `forge.events`

--- a/pkg/bundle/manifest_configshare_test.go
+++ b/pkg/bundle/manifest_configshare_test.go
@@ -1,0 +1,42 @@
+package bundle
+
+import "testing"
+
+func TestLoadManifest_ParsesConfigShareBlock(t *testing.T) {
+	body := `name: feedy
+schema_version: 1
+config_share:
+  config_path: feed-watch.json
+  editable_paths:
+    - "categories.{category}.feeds"
+    - "categories.{category}.editorial"
+  visible_paths:
+    - "categories.{category}.digest_title"
+`
+	m, err := LoadManifest(writeManifestForTest(t, body))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.ConfigShare == nil {
+		t.Fatal("config_share block not parsed")
+	}
+	if m.ConfigShare.ConfigPath != "feed-watch.json" {
+		t.Errorf("config_path = %q", m.ConfigShare.ConfigPath)
+	}
+	if len(m.ConfigShare.EditablePaths) != 2 || m.ConfigShare.EditablePaths[0] != "categories.{category}.feeds" {
+		t.Errorf("editable_paths = %v", m.ConfigShare.EditablePaths)
+	}
+	if len(m.ConfigShare.VisiblePaths) != 1 || m.ConfigShare.VisiblePaths[0] != "categories.{category}.digest_title" {
+		t.Errorf("visible_paths = %v", m.ConfigShare.VisiblePaths)
+	}
+}
+
+func TestLoadManifest_NoConfigShareBlockIsNil(t *testing.T) {
+	m, err := LoadManifest(writeManifestForTest(t, "name: plain\nschema_version: 1\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.ConfigShare != nil {
+		t.Errorf("expected nil ConfigShare, got %+v", m.ConfigShare)
+	}
+}

--- a/pkg/configshare/schema.go
+++ b/pkg/configshare/schema.go
@@ -1,0 +1,95 @@
+package configshare
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// categoryPlaceholder is the token a bot's config_share path templates carry
+// when the surface is per-category; the mint substitutes the concrete category.
+const categoryPlaceholder = "{category}"
+
+// categoryRe is the safe shape for a category key expanded into a dotted path:
+// letters/digits/underscore/hyphen only — no dot (would forge an extra path
+// segment), no traversal, no whitespace. Matches the config-file category keys
+// (feed-watch: "cyber", "a11y", …).
+var categoryRe = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// HasCategoryPlaceholder reports whether any of the given template sets carries
+// the {category} placeholder — i.e. the bot's config-share surface is
+// per-category, so a mint MUST supply a category.
+func HasCategoryPlaceholder(sets ...[]string) bool {
+	for _, set := range sets {
+		for _, t := range set {
+			if strings.Contains(t, categoryPlaceholder) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// DeriveGrant expands a bot's declared config-share path templates (manifest
+// config_share.editable_paths / visible_paths) for ONE category into the
+// concrete (allowed, visible) dotted-path sets a Share pins at mint time. A
+// "{category}" placeholder requires a well-formed, non-empty category and is
+// substituted; templates without it pass through literally. The returned
+// visible set is the union of the expanded editable + visible templates
+// (VisiblePaths is a read superset of AllowedPaths), deduped, editable first.
+//
+// All failures wrap ErrValidation so the mint maps them to 400. The output is
+// still run through ValidatePaths by the mint — DeriveGrant resolves the
+// surface; ValidatePaths enforces the literal/no-overlap/no-forbidden rules.
+func DeriveGrant(editable, visible []string, category string) (allowed []string, visibleOut []string, err error) {
+	if HasCategoryPlaceholder(editable, visible) {
+		if category == "" {
+			return nil, nil, fmt.Errorf("%w: category required for this bot's config-share surface", ErrValidation)
+		}
+		if !categoryRe.MatchString(category) {
+			return nil, nil, fmt.Errorf("%w: invalid category %q (letters, digits, _ and - only)", ErrValidation, category)
+		}
+	}
+	expand := func(templates []string) ([]string, error) {
+		out := make([]string, 0, len(templates))
+		for _, t := range templates {
+			if strings.TrimSpace(t) == "" {
+				continue
+			}
+			p := strings.ReplaceAll(t, categoryPlaceholder, category)
+			// A leftover brace = an unknown placeholder; fail closed rather
+			// than pin a path carrying a literal "{…}" segment.
+			if strings.ContainsAny(p, "{}") {
+				return nil, fmt.Errorf("%w: unresolved placeholder in %q", ErrValidation, t)
+			}
+			out = append(out, p)
+		}
+		return out, nil
+	}
+	allowed, err = expand(editable)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(allowed) == 0 {
+		return nil, nil, fmt.Errorf("%w: config-share surface declares no editable paths", ErrValidation)
+	}
+	vis, err := expand(visible)
+	if err != nil {
+		return nil, nil, err
+	}
+	seen := make(map[string]bool, len(allowed)+len(vis))
+	visibleOut = make([]string, 0, len(allowed)+len(vis))
+	for _, p := range allowed {
+		if !seen[p] {
+			seen[p] = true
+			visibleOut = append(visibleOut, p)
+		}
+	}
+	for _, p := range vis {
+		if !seen[p] {
+			seen[p] = true
+			visibleOut = append(visibleOut, p)
+		}
+	}
+	return allowed, visibleOut, nil
+}

--- a/pkg/configshare/schema.go
+++ b/pkg/configshare/schema.go
@@ -30,6 +30,15 @@ func HasCategoryPlaceholder(sets ...[]string) bool {
 	return false
 }
 
+// leafOf returns a path template's last segment — the field name a share
+// selects on (e.g. "categories.{category}.feeds" → "feeds").
+func leafOf(t string) string {
+	if i := strings.LastIndex(t, "."); i >= 0 {
+		return t[i+1:]
+	}
+	return t
+}
+
 // DeriveGrant expands a bot's declared config-share path templates (manifest
 // config_share.editable_paths / visible_paths) for ONE category into the
 // concrete (allowed, visible) dotted-path sets a Share pins at mint time. A
@@ -38,16 +47,42 @@ func HasCategoryPlaceholder(sets ...[]string) bool {
 // visible set is the union of the expanded editable + visible templates
 // (VisiblePaths is a read superset of AllowedPaths), deduped, editable first.
 //
+// selectedFields narrows the grant to a SUBSET of the bot's declared editable
+// fields (by leaf name — least privilege per share): empty = the full declared
+// editable surface; otherwise only the named fields, and every name MUST match
+// a declared editable leaf (else ErrValidation). A non-selected editable field
+// is neither writable nor visible (it drops out of both sets), keeping a
+// feeds-only editor blind to the editorial prompt.
+//
 // All failures wrap ErrValidation so the mint maps them to 400. The output is
 // still run through ValidatePaths by the mint — DeriveGrant resolves the
 // surface; ValidatePaths enforces the literal/no-overlap/no-forbidden rules.
-func DeriveGrant(editable, visible []string, category string) (allowed []string, visibleOut []string, err error) {
+func DeriveGrant(editable, visible []string, category string, selectedFields ...string) (allowed []string, visibleOut []string, err error) {
 	if HasCategoryPlaceholder(editable, visible) {
 		if category == "" {
 			return nil, nil, fmt.Errorf("%w: category required for this bot's config-share surface", ErrValidation)
 		}
 		if !categoryRe.MatchString(category) {
 			return nil, nil, fmt.Errorf("%w: invalid category %q (letters, digits, _ and - only)", ErrValidation, category)
+		}
+	}
+	// Narrow the editable templates to the selected fields, if any.
+	editableUsed := editable
+	if len(selectedFields) > 0 {
+		byLeaf := make(map[string][]string, len(editable))
+		for _, t := range editable {
+			if strings.TrimSpace(t) == "" {
+				continue
+			}
+			byLeaf[leafOf(t)] = append(byLeaf[leafOf(t)], t)
+		}
+		editableUsed = nil
+		for _, f := range selectedFields {
+			ts, ok := byLeaf[f]
+			if !ok {
+				return nil, nil, fmt.Errorf("%w: field %q is not editable for this bot", ErrValidation, f)
+			}
+			editableUsed = append(editableUsed, ts...)
 		}
 	}
 	expand := func(templates []string) ([]string, error) {
@@ -66,7 +101,7 @@ func DeriveGrant(editable, visible []string, category string) (allowed []string,
 		}
 		return out, nil
 	}
-	allowed, err = expand(editable)
+	allowed, err = expand(editableUsed)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/configshare/schema_test.go
+++ b/pkg/configshare/schema_test.go
@@ -66,6 +66,37 @@ func TestDeriveGrant_UnresolvedPlaceholderFailsClosed(t *testing.T) {
 	}
 }
 
+func TestDeriveGrant_SubsetSelectsFields(t *testing.T) {
+	editable := []string{"categories.{category}.feeds", "categories.{category}.editorial"}
+	visible := []string{"categories.{category}.digest_title"}
+	// Feeds-only share: editorial is neither writable NOR visible.
+	allowed, vis, err := DeriveGrant(editable, visible, "a11y", "feeds")
+	if err != nil {
+		t.Fatalf("DeriveGrant subset: %v", err)
+	}
+	if !reflect.DeepEqual(allowed, []string{"categories.a11y.feeds"}) {
+		t.Errorf("allowed = %v, want [categories.a11y.feeds]", allowed)
+	}
+	wantVisible := []string{"categories.a11y.feeds", "categories.a11y.digest_title"}
+	if !reflect.DeepEqual(vis, wantVisible) {
+		t.Errorf("visible = %v, want %v (editorial must NOT be visible)", vis, wantVisible)
+	}
+	for _, p := range vis {
+		if p == "categories.a11y.editorial" {
+			t.Errorf("editorial leaked into visible for a feeds-only share: %v", vis)
+		}
+	}
+}
+
+func TestDeriveGrant_SubsetRejectsUndeclaredField(t *testing.T) {
+	editable := []string{"categories.{category}.feeds", "categories.{category}.editorial"}
+	// `sinks` is not a declared editable field (it's hard-forbidden) — a share
+	// can't select it.
+	if _, _, err := DeriveGrant(editable, nil, "a11y", "sinks"); !errors.Is(err, ErrValidation) {
+		t.Fatalf("want ErrValidation selecting an undeclared field, got %v", err)
+	}
+}
+
 func TestDeriveGrant_DerivedPathsPassValidatePaths(t *testing.T) {
 	// The whole point: the mint runs DeriveGrant output through ValidatePaths.
 	allowed, vis, err := DeriveGrant(

--- a/pkg/configshare/schema_test.go
+++ b/pkg/configshare/schema_test.go
@@ -1,0 +1,80 @@
+package configshare
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestDeriveGrant_CategoryExpansion(t *testing.T) {
+	editable := []string{"categories.{category}.feeds", "categories.{category}.editorial"}
+	visible := []string{"categories.{category}.digest_title"}
+	allowed, vis, err := DeriveGrant(editable, visible, "a11y")
+	if err != nil {
+		t.Fatalf("DeriveGrant: %v", err)
+	}
+	wantAllowed := []string{"categories.a11y.feeds", "categories.a11y.editorial"}
+	if !reflect.DeepEqual(allowed, wantAllowed) {
+		t.Errorf("allowed = %v, want %v", allowed, wantAllowed)
+	}
+	// visible = union(allowed, visible-templates), editable first, deduped.
+	wantVisible := []string{"categories.a11y.feeds", "categories.a11y.editorial", "categories.a11y.digest_title"}
+	if !reflect.DeepEqual(vis, wantVisible) {
+		t.Errorf("visible = %v, want %v", vis, wantVisible)
+	}
+}
+
+func TestDeriveGrant_MissingCategoryIsValidationError(t *testing.T) {
+	_, _, err := DeriveGrant([]string{"categories.{category}.feeds"}, nil, "")
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("want ErrValidation for missing category, got %v", err)
+	}
+}
+
+func TestDeriveGrant_RejectsUnsafeCategory(t *testing.T) {
+	for _, bad := range []string{"a.b", "../etc", "a b", "a/b", "__proto__.x"} {
+		if _, _, err := DeriveGrant([]string{"categories.{category}.feeds"}, nil, bad); !errors.Is(err, ErrValidation) {
+			t.Errorf("category %q must be rejected as ErrValidation, got %v", bad, err)
+		}
+	}
+}
+
+func TestDeriveGrant_LiteralPathsPassThrough(t *testing.T) {
+	// A bot with no {category} placeholder mints without a category.
+	allowed, vis, err := DeriveGrant([]string{"settings.feeds"}, []string{"settings.title"}, "")
+	if err != nil {
+		t.Fatalf("DeriveGrant literal: %v", err)
+	}
+	if !reflect.DeepEqual(allowed, []string{"settings.feeds"}) {
+		t.Errorf("allowed = %v", allowed)
+	}
+	if !reflect.DeepEqual(vis, []string{"settings.feeds", "settings.title"}) {
+		t.Errorf("visible = %v", vis)
+	}
+}
+
+func TestDeriveGrant_NoEditablePathsIsError(t *testing.T) {
+	if _, _, err := DeriveGrant(nil, []string{"categories.{category}.digest_title"}, "a11y"); !errors.Is(err, ErrValidation) {
+		t.Fatalf("want ErrValidation when no editable paths, got %v", err)
+	}
+}
+
+func TestDeriveGrant_UnresolvedPlaceholderFailsClosed(t *testing.T) {
+	// A typo'd placeholder must not pin a path with a literal "{…}" segment.
+	if _, _, err := DeriveGrant([]string{"categories.{cat}.feeds"}, nil, "a11y"); !errors.Is(err, ErrValidation) {
+		t.Fatalf("want ErrValidation for unresolved placeholder, got %v", err)
+	}
+}
+
+func TestDeriveGrant_DerivedPathsPassValidatePaths(t *testing.T) {
+	// The whole point: the mint runs DeriveGrant output through ValidatePaths.
+	allowed, vis, err := DeriveGrant(
+		[]string{"categories.{category}.feeds", "categories.{category}.editorial"},
+		[]string{"categories.{category}.digest_title"}, "cyber")
+	if err != nil {
+		t.Fatalf("DeriveGrant: %v", err)
+	}
+	if err := ValidatePaths(allowed, vis); err != nil {
+		t.Fatalf("derived paths must satisfy ValidatePaths: %v", err)
+	}
+}

--- a/pkg/server/config_share_derive_test.go
+++ b/pkg/server/config_share_derive_test.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/audit"
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/identity"
+)
+
+// mintShareReq builds an operator (admin) create-share request.
+func mintShareReq(t *testing.T, adminCtx context.Context, body string) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest("POST", "/api/teams/t1/config-shares", strings.NewReader(body)).WithContext(adminCtx)
+	r.SetPathValue("id", "t1")
+	return r
+}
+
+func jsonStrs(v any) []string {
+	arr, _ := v.([]any)
+	out := make([]string, 0, len(arr))
+	for _, x := range arr {
+		if s, ok := x.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// TestConfigShare_MintDerivesFromBotManifest proves the generalization: an
+// operator mints a share for feed-watch with ONLY bot_id + category — no
+// hand-typed JSON paths — and the mint DERIVES the editable/visible paths +
+// config file from the bot's manifest config_share: block (expanding
+// {category}). This is the "a bot declares its shareable surface, a share can
+// never exceed it" contract, exercised against the REAL feed-watch manifest.
+func TestConfigShare_MintDerivesFromBotManifest(t *testing.T) {
+	s := newOrgTestServer(t)
+	s.auditStore = audit.NewMemoryStore()
+	s.cfg.Bots.Paths = []string{botsDirAbs(t)} // real bots/, incl. feed-watch's config_share block
+	seedTeam(t, s, "t1", "acme")
+	ctx := context.Background()
+	if _, err := s.authStore().CreateUser(ctx, identity.User{ID: "op", Email: "op@x", Status: identity.UserStatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.authStore().UpsertMembership(ctx, identity.Membership{UserID: "op", TeamID: "t1", Role: identity.RoleAdmin}); err != nil {
+		t.Fatal(err)
+	}
+	adminCtx := auth.WithIdentity(ctx, auth.Identity{UserID: "op", TeamID: "t1", Role: identity.RoleAdmin})
+
+	// Only bot_id + category — the surface is derived, not supplied.
+	body := `{"bot_id":"feed-watch","label":"a11y","repo_url":"https://github.com/o/r","repo_ref":"main","category":"a11y"}`
+	cw := httptest.NewRecorder()
+	s.handleCreateConfigShare(cw, mintShareReq(t, adminCtx, body))
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create = %d: %s", cw.Code, cw.Body.String())
+	}
+	var created map[string]any
+	if err := json.Unmarshal(cw.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	if got := created["config_path"]; got != "feed-watch.json" {
+		t.Errorf("config_path = %v, want feed-watch.json (derived from manifest)", got)
+	}
+	allowed := jsonStrs(created["allowed_paths"])
+	wantAllowed := []string{"categories.a11y.feeds", "categories.a11y.editorial"}
+	if !reflect.DeepEqual(allowed, wantAllowed) {
+		t.Errorf("allowed_paths = %v, want %v ({category}→a11y)", allowed, wantAllowed)
+	}
+	visible := jsonStrs(created["visible_paths"])
+	for _, want := range []string{"categories.a11y.feeds", "categories.a11y.editorial", "categories.a11y.digest_title"} {
+		found := false
+		for _, v := range visible {
+			if v == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("visible_paths %v missing %q (feeds+editorial+digest_title expected)", visible, want)
+		}
+	}
+}
+
+// TestConfigShare_MintRejectsMissingCategoryForCategorySurface proves the
+// derived surface enforces its own contract: feed-watch's paths carry
+// {category}, so minting without one fails closed (400) rather than pinning a
+// path with a literal "{category}" segment.
+func TestConfigShare_MintRejectsMissingCategoryForCategorySurface(t *testing.T) {
+	s := newOrgTestServer(t)
+	s.auditStore = audit.NewMemoryStore()
+	s.cfg.Bots.Paths = []string{botsDirAbs(t)}
+	seedTeam(t, s, "t1", "acme")
+	ctx := context.Background()
+	if _, err := s.authStore().CreateUser(ctx, identity.User{ID: "op", Email: "op@x", Status: identity.UserStatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.authStore().UpsertMembership(ctx, identity.Membership{UserID: "op", TeamID: "t1", Role: identity.RoleAdmin}); err != nil {
+		t.Fatal(err)
+	}
+	adminCtx := auth.WithIdentity(ctx, auth.Identity{UserID: "op", TeamID: "t1", Role: identity.RoleAdmin})
+
+	body := `{"bot_id":"feed-watch","label":"x","repo_url":"https://github.com/o/r","repo_ref":"main"}`
+	cw := httptest.NewRecorder()
+	s.handleCreateConfigShare(cw, mintShareReq(t, adminCtx, body))
+	if cw.Code != http.StatusBadRequest {
+		t.Fatalf("mint without category = %d, want 400 (%s)", cw.Code, cw.Body.String())
+	}
+}

--- a/pkg/server/config_share_derive_test.go
+++ b/pkg/server/config_share_derive_test.go
@@ -87,6 +87,69 @@ func TestConfigShare_MintDerivesFromBotManifest(t *testing.T) {
 	}
 }
 
+// TestConfigShare_MintSubsetOfEditableFields proves per-share least privilege:
+// an operator mints a feeds-only share of feed-watch (editable_fields:["feeds"]),
+// and the derived grant excludes editorial from BOTH the writable and visible
+// sets — a feeds curator can't touch or even read the editorial prompt.
+func TestConfigShare_MintSubsetOfEditableFields(t *testing.T) {
+	s := newOrgTestServer(t)
+	s.auditStore = audit.NewMemoryStore()
+	s.cfg.Bots.Paths = []string{botsDirAbs(t)}
+	seedTeam(t, s, "t1", "acme")
+	ctx := context.Background()
+	if _, err := s.authStore().CreateUser(ctx, identity.User{ID: "op", Email: "op@x", Status: identity.UserStatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.authStore().UpsertMembership(ctx, identity.Membership{UserID: "op", TeamID: "t1", Role: identity.RoleAdmin}); err != nil {
+		t.Fatal(err)
+	}
+	adminCtx := auth.WithIdentity(ctx, auth.Identity{UserID: "op", TeamID: "t1", Role: identity.RoleAdmin})
+
+	body := `{"bot_id":"feed-watch","label":"feeds-only","repo_url":"https://github.com/o/r","repo_ref":"main","category":"a11y","editable_fields":["feeds"]}`
+	cw := httptest.NewRecorder()
+	s.handleCreateConfigShare(cw, mintShareReq(t, adminCtx, body))
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create = %d: %s", cw.Code, cw.Body.String())
+	}
+	var created map[string]any
+	if err := json.Unmarshal(cw.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	if allowed := jsonStrs(created["allowed_paths"]); !reflect.DeepEqual(allowed, []string{"categories.a11y.feeds"}) {
+		t.Errorf("allowed_paths = %v, want [categories.a11y.feeds] only", allowed)
+	}
+	for _, p := range jsonStrs(created["visible_paths"]) {
+		if p == "categories.a11y.editorial" {
+			t.Errorf("editorial leaked into a feeds-only share's visible_paths: %v", created["visible_paths"])
+		}
+	}
+}
+
+// TestConfigShare_MintRejectsUndeclaredEditableField proves the subset can't
+// escape the declared surface: selecting a field the bot never declared
+// editable (here `sinks`, the digest routing) is a 400, not a silent widen.
+func TestConfigShare_MintRejectsUndeclaredEditableField(t *testing.T) {
+	s := newOrgTestServer(t)
+	s.auditStore = audit.NewMemoryStore()
+	s.cfg.Bots.Paths = []string{botsDirAbs(t)}
+	seedTeam(t, s, "t1", "acme")
+	ctx := context.Background()
+	if _, err := s.authStore().CreateUser(ctx, identity.User{ID: "op", Email: "op@x", Status: identity.UserStatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.authStore().UpsertMembership(ctx, identity.Membership{UserID: "op", TeamID: "t1", Role: identity.RoleAdmin}); err != nil {
+		t.Fatal(err)
+	}
+	adminCtx := auth.WithIdentity(ctx, auth.Identity{UserID: "op", TeamID: "t1", Role: identity.RoleAdmin})
+
+	body := `{"bot_id":"feed-watch","label":"x","repo_url":"https://github.com/o/r","repo_ref":"main","category":"a11y","editable_fields":["sinks"]}`
+	cw := httptest.NewRecorder()
+	s.handleCreateConfigShare(cw, mintShareReq(t, adminCtx, body))
+	if cw.Code != http.StatusBadRequest {
+		t.Fatalf("select undeclared field = %d, want 400 (%s)", cw.Code, cw.Body.String())
+	}
+}
+
 // TestConfigShare_MintRejectsMissingCategoryForCategorySurface proves the
 // derived surface enforces its own contract: feed-watch's paths carry
 // {category}, so minting without one fails closed (400) rather than pinning a

--- a/pkg/server/config_shares_routes.go
+++ b/pkg/server/config_shares_routes.go
@@ -37,8 +37,13 @@ type createConfigShareReq struct {
 	SchemaRef    string   `json:"schema_ref"`
 	AllowedPaths []string `json:"allowed_paths"`
 	VisiblePaths []string `json:"visible_paths"`
-	ReadOnly     bool     `json:"read_only"`
-	ExpiresDays  int      `json:"expires_days"`
+	// EditableFields optionally narrows a derived (config_share-block) grant to
+	// a SUBSET of the bot's declared editable fields (by leaf name, e.g.
+	// ["feeds"]) — least privilege per share. Empty = the full declared
+	// surface. Ignored for a bot with no declared block.
+	EditableFields []string `json:"editable_fields"`
+	ReadOnly       bool     `json:"read_only"`
+	ExpiresDays    int      `json:"expires_days"`
 }
 
 // shareView is the operator-facing projection — never the token hash.
@@ -118,7 +123,7 @@ func (s *Server) handleCreateConfigShare(w http.ResponseWriter, r *http.Request)
 	allowed := req.AllowedPaths
 	visible := req.VisiblePaths
 	if spec := s.botConfigShareSpec(req.BotID); spec != nil {
-		a, v, err := configshare.DeriveGrant(spec.EditablePaths, spec.VisiblePaths, req.Category)
+		a, v, err := configshare.DeriveGrant(spec.EditablePaths, spec.VisiblePaths, req.Category, req.EditableFields...)
 		if err != nil {
 			httpError(w, http.StatusBadRequest, "%s", err.Error())
 			return

--- a/pkg/server/config_shares_routes.go
+++ b/pkg/server/config_shares_routes.go
@@ -3,11 +3,14 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+	"path/filepath"
 	"time"
 
 	"github.com/google/uuid"
 
 	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/botregistry"
+	"github.com/SocialGouv/iterion/pkg/bundle"
 	"github.com/SocialGouv/iterion/pkg/configshare"
 )
 
@@ -61,6 +64,25 @@ func (s *Server) shareURL(id, token string) string {
 	return base + "/config/" + id + "#" + token
 }
 
+// botConfigShareSpec resolves a bot_id to its declared config-share surface
+// (manifest config_share: block), or nil when the bot declares none or is not
+// resolvable on this server (a loose .bot, or a bot absent from the effective
+// paths). Best-effort by design: the operator is trusted (canManageTeam), so a
+// bot without a discoverable surface mints with explicit operator-supplied
+// paths — the block is a guard-rail + convenience for the common case, not the
+// trust boundary against the operator.
+func (s *Server) botConfigShareSpec(botID string) *bundle.ConfigShareSpec {
+	mainFile, err := botregistry.ResolveBotPath(botID, s.effectivePaths())
+	if err != nil {
+		return nil
+	}
+	m, err := bundle.LoadManifest(filepath.Join(filepath.Dir(mainFile), "manifest.yaml"))
+	if err != nil || m == nil {
+		return nil
+	}
+	return m.ConfigShare
+}
+
 func (s *Server) handleCreateConfigShare(w http.ResponseWriter, r *http.Request) {
 	id, _ := auth.FromContext(r.Context())
 	teamID := r.PathValue("id")
@@ -85,15 +107,34 @@ func (s *Server) handleCreateConfigShare(w http.ResponseWriter, r *http.Request)
 		httpError(w, http.StatusBadRequest, "%s", err.Error())
 		return
 	}
-	if err := configshare.ValidateConfigPath(req.ConfigPath); err != nil {
+	// When the bot DECLARES a config-share surface (manifest config_share:),
+	// it is authoritative: the mint DERIVES the config file + editable/visible
+	// paths from it (expanding {category}), so a share can never be minted
+	// outside what the bot committed to git. The operator supplies only
+	// bot_id + category. A bot with no declared surface (or one not resolvable
+	// on this server — e.g. a loose .bot) falls back to explicit
+	// operator-supplied paths, unchanged.
+	configPath := req.ConfigPath
+	allowed := req.AllowedPaths
+	visible := req.VisiblePaths
+	if spec := s.botConfigShareSpec(req.BotID); spec != nil {
+		a, v, err := configshare.DeriveGrant(spec.EditablePaths, spec.VisiblePaths, req.Category)
+		if err != nil {
+			httpError(w, http.StatusBadRequest, "%s", err.Error())
+			return
+		}
+		allowed, visible = a, v
+		if spec.ConfigPath != "" {
+			configPath = spec.ConfigPath
+		}
+	} else if len(visible) == 0 {
+		visible = allowed
+	}
+	if err := configshare.ValidateConfigPath(configPath); err != nil {
 		httpError(w, http.StatusBadRequest, "%s", err.Error())
 		return
 	}
-	visible := req.VisiblePaths
-	if len(visible) == 0 {
-		visible = req.AllowedPaths
-	}
-	if err := configshare.ValidatePaths(req.AllowedPaths, visible); err != nil {
+	if err := configshare.ValidatePaths(allowed, visible); err != nil {
 		httpError(w, http.StatusBadRequest, "%s", err.Error())
 		return
 	}
@@ -109,9 +150,9 @@ func (s *Server) handleCreateConfigShare(w http.ResponseWriter, r *http.Request)
 	now := time.Now().UTC()
 	sh := &configshare.Share{
 		ID: uuid.NewString(), TenantID: teamID, BotID: req.BotID, Label: req.Label,
-		RepoURL: req.RepoURL, RepoRef: req.RepoRef, ConfigPath: req.ConfigPath,
+		RepoURL: req.RepoURL, RepoRef: req.RepoRef, ConfigPath: configPath,
 		Category: req.Category, SchemaRef: req.SchemaRef,
-		AllowedPaths: req.AllowedPaths, VisiblePaths: visible, ReadOnly: req.ReadOnly,
+		AllowedPaths: allowed, VisiblePaths: visible, ReadOnly: req.ReadOnly,
 		TokenHash: hash, TokenLast4: last4, Fingerprint: fp,
 		Enabled: true, CreatedBy: id.UserID, CreatedAt: now, ExpiresAt: now.AddDate(0, 0, ttl),
 	}

--- a/studio/src/api/bots.ts
+++ b/studio/src/api/bots.ts
@@ -62,6 +62,11 @@ export interface BotEntry {
    *  optional-skip) driven off this. `mode: "none"` behaves like an
    *  absent block (kept so a bot can document the choice). */
   repo?: RepoRequirement;
+  /** Scoped config-share surface (manifest `config_share:` block) — which
+   *  fields of the bot's config file a non-operator may edit through a share
+   *  URL. Present only when the bot declares one; the "Share config" card
+   *  reads it to drive a data-driven mint form and is hidden otherwise. */
+  config_share?: ConfigShareSpec;
   /** Typed routing contract (manifest `invocations:`) — how this bot can be
    *  triggered (forge event, /slash-command, schedule, board) and the
    *  execution mode each path uses. Drives the Integrations picker grouping.
@@ -144,6 +149,22 @@ export interface RepoRequirement {
   default_branch?: string;
   /** Seeds a created repo's visibility (default "private"). */
   visibility?: "private" | "public";
+}
+
+/** ConfigShareSpec mirrors the manifest `config_share:` block — the bot's
+ *  scoped config-share surface. The mint DERIVES a share's editable/visible
+ *  paths + config file from this (expanding a `{category}` placeholder), so a
+ *  share can never exceed what the bot committed to git and a second bot
+ *  adopts the editor by adding this block alone. */
+export interface ConfigShareSpec {
+  /** Config file inside the target repo a share edits (e.g. "feed-watch.json"). */
+  config_path: string;
+  /** Dotted leaf paths a share may WRITE. A `{category}` placeholder is
+   *  expanded per share (e.g. "categories.{category}.feeds"). No globs. */
+  editable_paths: string[];
+  /** Extra read-only dotted paths a share may READ back as context (same
+   *  `{category}` expansion). The projection returns editable ∪ visible. */
+  visible_paths?: string[];
 }
 
 /** BotPatch is the editable subset of a bot's manifest. Omitted fields

--- a/studio/src/api/configShareAdmin.ts
+++ b/studio/src/api/configShareAdmin.ts
@@ -43,11 +43,14 @@ export interface CreateShareInput {
   label: string;
   repo_url: string;
   repo_ref: string;
-  config_path: string;
+  /** Config file + paths are DERIVED server-side from the bot's manifest
+   *  config_share: block when omitted (the normal path). Kept optional for a
+   *  bot with no declared surface, where the operator supplies them. */
+  config_path?: string;
   category: string;
   schema_ref?: string;
-  allowed_paths: string[];
-  visible_paths: string[];
+  allowed_paths?: string[];
+  visible_paths?: string[];
   read_only?: boolean;
   expires_days?: number;
 }

--- a/studio/src/api/configShareAdmin.ts
+++ b/studio/src/api/configShareAdmin.ts
@@ -51,6 +51,10 @@ export interface CreateShareInput {
   schema_ref?: string;
   allowed_paths?: string[];
   visible_paths?: string[];
+  /** Optional least-privilege subset of the bot's declared editable fields
+   *  (by leaf name, e.g. ["feeds"]) for a DERIVED grant. Omitted / full list =
+   *  the whole declared surface. */
+  editable_fields?: string[];
   read_only?: boolean;
   expires_days?: number;
 }

--- a/studio/src/views/Bots/BotHome/ConfigSharesCard.tsx
+++ b/studio/src/views/Bots/BotHome/ConfigSharesCard.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import type { BotEntryWithSchema } from "@/api/bots";
+import type { BotEntryWithSchema, ConfigShareSpec } from "@/api/bots";
 import {
   createConfigShare,
   deleteConfigShare,
@@ -75,6 +75,12 @@ export function ConfigSharesCard({ entry }: { entry: BotEntryWithSchema }) {
 
   if (!teamID) return null;
   if (unavailable) return null;
+  // Config-share is offered only for bots that DECLARE a shareable surface
+  // (manifest config_share: block). Everything the mint form needs — the
+  // config file + which fields are editable — comes from this spec, so a
+  // second bot gets the card by adding the block, with no code change here.
+  const spec = entry.config_share;
+  if (!spec) return null;
 
   const onRotate = async (share: ShareView) => {
     setBusyShareID(share.id);
@@ -147,6 +153,7 @@ export function ConfigSharesCard({ entry }: { entry: BotEntryWithSchema }) {
         <CreateShareDialog
           teamID={teamID}
           botID={entry.name}
+          spec={spec}
           onCancel={() => setCreating(false)}
           onCreated={(minted) => {
             setCreating(false);
@@ -268,59 +275,47 @@ function ShareRow({
 // Create dialog
 // ---------------------------------------------------------------------------
 
-const FEED_WATCH_DEFAULT_FIELDS: { key: string; label: string }[] = [
-  { key: "feeds", label: "Feeds (RSS source URLs)" },
-  { key: "editorial", label: "Editorial prompt" },
-];
-const FEED_WATCH_VISIBLE_EXTRA = ["digest_title"];
-
 function CreateShareDialog({
   teamID,
   botID,
+  spec,
   onCancel,
   onCreated,
 }: {
   teamID: string;
   botID: string;
+  spec: ConfigShareSpec;
   onCancel: () => void;
   onCreated: (minted: ShareWithToken) => void;
 }) {
   const [label, setLabel] = useState("");
   const [repoURL, setRepoURL] = useState("");
   const [repoRef, setRepoRef] = useState("main");
-  const [configPath, setConfigPath] = useState("veille.yaml");
   const [category, setCategory] = useState("");
-  const [selected, setSelected] = useState<Record<string, boolean>>({
-    feeds: true,
-    editorial: true,
-  });
   const [readOnly, setReadOnly] = useState(false);
   const [expiresDays, setExpiresDays] = useState<number | "">(14);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const allowedPaths = useMemo(() => {
-    if (!category.trim()) return [];
-    const cat = category.trim();
-    return FEED_WATCH_DEFAULT_FIELDS.filter((f) => selected[f.key]).map(
-      (f) => `categories.${cat}.${f.key}`,
-    );
-  }, [category, selected]);
-
-  const visiblePaths = useMemo(() => {
-    if (allowedPaths.length === 0) return [];
-    const cat = category.trim();
-    const extras = FEED_WATCH_VISIBLE_EXTRA.map((k) => `categories.${cat}.${k}`);
-    return [...allowedPaths, ...extras];
-  }, [allowedPaths, category]);
+  // The bot DECLARES its shareable surface (spec); the server derives + pins
+  // the exact editable/visible paths + config file at mint. This form only
+  // collects who/where + the category — never the paths, which is what keeps
+  // it generic (a second bot needs no change here).
+  const needsCategory = useMemo(
+    () =>
+      [...spec.editable_paths, ...(spec.visible_paths ?? [])].some((p) =>
+        p.includes("{category}"),
+      ),
+    [spec],
+  );
+  const expand = (p: string) =>
+    p.split("{category}").join(category.trim() || "<category>");
 
   const submitDisabled =
     !label.trim() ||
     !repoURL.trim() ||
     !repoRef.trim() ||
-    !configPath.trim() ||
-    !category.trim() ||
-    allowedPaths.length === 0 ||
+    (needsCategory && !category.trim()) ||
     busy;
 
   const submit = async () => {
@@ -332,11 +327,10 @@ function CreateShareDialog({
         label: label.trim(),
         repo_url: repoURL.trim(),
         repo_ref: repoRef.trim(),
-        config_path: configPath.trim(),
         category: category.trim(),
-        allowed_paths: allowedPaths,
-        visible_paths: visiblePaths,
         read_only: readOnly,
+        // config_path + paths are DERIVED server-side from the bot's
+        // config_share block — never sent from here.
         ...(typeof expiresDays === "number" && expiresDays > 0
           ? { expires_days: expiresDays }
           : {}),
@@ -416,18 +410,7 @@ function CreateShareDialog({
             />
           </div>
         </div>
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-          <div>
-            <FieldLabel htmlFor="cs-path">Config path</FieldLabel>
-            <Input
-              id="cs-path"
-              size="md"
-              value={configPath}
-              onChange={(e) => setConfigPath(e.target.value)}
-              placeholder="veille.yaml"
-              className="font-mono"
-            />
-          </div>
+        {needsCategory && (
           <div>
             <FieldLabel htmlFor="cs-cat">Category</FieldLabel>
             <Input
@@ -439,30 +422,44 @@ function CreateShareDialog({
               className="font-mono"
             />
           </div>
-        </div>
+        )}
         <div>
-          <FieldLabel>Editable fields</FieldLabel>
-          <div className="flex flex-col gap-1 rounded-md border border-border-default bg-surface-2 p-2">
-            {FEED_WATCH_DEFAULT_FIELDS.map((f) => (
-              <div key={f.key} className="flex items-center gap-2 text-xs">
-                <Checkbox
-                  checked={!!selected[f.key]}
-                  onChange={(e) =>
-                    setSelected((s) => ({ ...s, [f.key]: e.target.checked }))
-                  }
-                  label={f.label}
-                />
-                <span className="ml-auto font-mono text-caption text-fg-subtle">
-                  {category.trim()
-                    ? `categories.${category.trim()}.${f.key}`
-                    : `categories.<category>.${f.key}`}
-                </span>
-              </div>
-            ))}
+          <FieldLabel>What this share exposes</FieldLabel>
+          <div className="rounded-md border border-border-default bg-surface-2 p-2 text-xs">
+            <div className="mb-1 text-fg-subtle">
+              Config file:{" "}
+              <span className="font-mono text-fg-default">
+                {spec.config_path}
+              </span>
+            </div>
+            <div className="font-medium text-fg-default">Editable</div>
+            <ul className="mb-1 flex flex-col gap-0.5">
+              {spec.editable_paths.map((p) => (
+                <li key={p} className="font-mono text-caption text-fg-muted">
+                  {expand(p)}
+                </li>
+              ))}
+            </ul>
+            {(spec.visible_paths?.length ?? 0) > 0 && (
+              <>
+                <div className="font-medium text-fg-default">
+                  Read-only context
+                </div>
+                <ul className="flex flex-col gap-0.5">
+                  {(spec.visible_paths ?? []).map((p) => (
+                    <li
+                      key={p}
+                      className="font-mono text-caption text-fg-subtle"
+                    >
+                      {expand(p)}
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
           </div>
           <p className="mt-1 text-caption text-fg-subtle">
-            Read-only context (visible but not editable):{" "}
-            <span className="font-mono">digest_title</span>
+            These fields come from the bot's manifest and can't be widened here.
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-4">

--- a/studio/src/views/Bots/BotHome/ConfigSharesCard.tsx
+++ b/studio/src/views/Bots/BotHome/ConfigSharesCard.tsx
@@ -299,8 +299,9 @@ function CreateShareDialog({
 
   // The bot DECLARES its shareable surface (spec); the server derives + pins
   // the exact editable/visible paths + config file at mint. This form only
-  // collects who/where + the category — never the paths, which is what keeps
-  // it generic (a second bot needs no change here).
+  // collects who/where + the category + WHICH of the declared editable fields
+  // this share exposes — never raw paths, which keeps it generic (a second bot
+  // needs no change here).
   const needsCategory = useMemo(
     () =>
       [...spec.editable_paths, ...(spec.visible_paths ?? [])].some((p) =>
@@ -308,6 +309,16 @@ function CreateShareDialog({
       ),
     [spec],
   );
+  // Declared editable fields, by leaf name — the least-privilege subset unit.
+  // Start with all selected (the full declared surface).
+  const editableFields = useMemo(
+    () => spec.editable_paths.map((p) => p.split(".").pop() ?? p),
+    [spec],
+  );
+  const [selected, setSelected] = useState<Record<string, boolean>>(() =>
+    Object.fromEntries(editableFields.map((f) => [f, true])),
+  );
+  const selectedFields = editableFields.filter((f) => selected[f]);
   const expand = (p: string) =>
     p.split("{category}").join(category.trim() || "<category>");
 
@@ -316,6 +327,7 @@ function CreateShareDialog({
     !repoURL.trim() ||
     !repoRef.trim() ||
     (needsCategory && !category.trim()) ||
+    selectedFields.length === 0 ||
     busy;
 
   const submit = async () => {
@@ -328,9 +340,10 @@ function CreateShareDialog({
         repo_url: repoURL.trim(),
         repo_ref: repoRef.trim(),
         category: category.trim(),
+        // Least-privilege subset of the bot's declared editable fields; the
+        // server derives + pins the paths. config_path + paths never sent.
+        editable_fields: selectedFields,
         read_only: readOnly,
-        // config_path + paths are DERIVED server-side from the bot's
-        // config_share block — never sent from here.
         ...(typeof expiresDays === "number" && expiresDays > 0
           ? { expires_days: expiresDays }
           : {}),
@@ -423,6 +436,27 @@ function CreateShareDialog({
             />
           </div>
         )}
+        {editableFields.length > 1 && (
+          <div>
+            <FieldLabel>Fields this share may edit</FieldLabel>
+            <div className="flex flex-col gap-1 rounded-md border border-border-default bg-surface-2 p-2">
+              {editableFields.map((f) => (
+                <Checkbox
+                  key={f}
+                  checked={!!selected[f]}
+                  onChange={(e) =>
+                    setSelected((s) => ({ ...s, [f]: e.target.checked }))
+                  }
+                  label={f}
+                />
+              ))}
+            </div>
+            <p className="mt-1 text-caption text-fg-subtle">
+              Uncheck a field to withhold it — a share can't touch or even read
+              the fields you leave off.
+            </p>
+          </div>
+        )}
         <div>
           <FieldLabel>What this share exposes</FieldLabel>
           <div className="rounded-md border border-border-default bg-surface-2 p-2 text-xs">
@@ -434,11 +468,13 @@ function CreateShareDialog({
             </div>
             <div className="font-medium text-fg-default">Editable</div>
             <ul className="mb-1 flex flex-col gap-0.5">
-              {spec.editable_paths.map((p) => (
-                <li key={p} className="font-mono text-caption text-fg-muted">
-                  {expand(p)}
-                </li>
-              ))}
+              {spec.editable_paths
+                .filter((p) => selected[p.split(".").pop() ?? p])
+                .map((p) => (
+                  <li key={p} className="font-mono text-caption text-fg-muted">
+                    {expand(p)}
+                  </li>
+                ))}
             </ul>
             {(spec.visible_paths?.length ?? 0) > 0 && (
               <>


### PR DESCRIPTION
Generalizes the scoped config-share editor ([ADR-076](docs/adr/076-scoped-config-share-editor.md)) so it is no longer hardcoded to feed-watch: a bot **declares** what a share may touch, and the mint **derives** the grant from that declaration. Follow-up to #226 (config-share MVP), off the merged main.

## What changed

**A bot declares its shareable surface** in `manifest.yaml`:

```yaml
config_share:
  config_path: feed-watch.json
  editable_paths:
    - "categories.{category}.feeds"
    - "categories.{category}.editorial"
  visible_paths:
    - "categories.{category}.digest_title"
```

- The mint (`POST /api/teams/{id}/config-shares`) resolves the bot's block and **derives + pins** `config_path` + `allowed_paths` + `visible_paths`, expanding a `{category}` placeholder. A share **can never exceed** what the bot committed to git; a bot with no block (or a loose `.bot`) falls back to explicit operator paths (backward compatible).
- `configshare.DeriveGrant` validates the category (`[A-Za-z0-9_-]+`, no dot/traversal), fails closed on an unresolved placeholder, and its output still runs through `ValidatePaths`.
- `config_share` is mirrored onto `botregistry.Entry` → the studio card renders a **data-driven** mint form (drops the hardcoded feed-watch shape + `veille.yaml` default) and hides itself for bots with no declared surface. **A second bot adopts the whole editor by adding the block alone — no Go or SPA change.**

**Per-share field subsetting (least privilege).** A mint may narrow a grant to a subset of the declared editable fields (`editable_fields: ["feeds"]`). A non-selected field is neither writable nor visible — a feeds-only curator can't touch or even read the editorial prompt (the LLM-injection surface). Selecting an undeclared field is a 400. The studio renders a data-driven checkbox per field.

## Tests

- `DeriveGrant`: `{category}` expansion, category validation, fail-closed on unresolved placeholder, literal passthrough, subset (feeds-only excludes editorial from write **and** read), undeclared-field rejection.
- manifest parse of the `config_share:` block.
- mint derives from the **real feed-watch manifest**; rejects a missing category; mint subset-of-fields; mint rejects an undeclared field.
- Full `pkg/server` (race) + `bundle` + `botregistry` + `configshare` suites, gofmt + vet, studio `tsc` + eslint — all green.

Records the decision in [ADR-077](docs/adr/077-declarative-per-bot-config-share-surface.md) (extends ADR-076). Reference: [docs/config-share.md](docs/config-share.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)