### PR TITLE
fix(studio)+feat(configshare): dialog overflow scroll + durable (never-expires) shares

### DIFF
--- a/pkg/server/config_share_derive_test.go
+++ b/pkg/server/config_share_derive_test.go
@@ -150,6 +150,38 @@ func TestConfigShare_MintRejectsUndeclaredEditableField(t *testing.T) {
 	}
 }
 
+// TestConfigShare_MintNeverExpires proves the opt-out from the default TTL: a
+// never_expires mint stores a zero ExpiresAt (Share.Active never times out) and
+// the view omits expires_at so the UI renders "never".
+func TestConfigShare_MintNeverExpires(t *testing.T) {
+	s := newOrgTestServer(t)
+	s.auditStore = audit.NewMemoryStore()
+	s.cfg.Bots.Paths = []string{botsDirAbs(t)}
+	seedTeam(t, s, "t1", "acme")
+	ctx := context.Background()
+	if _, err := s.authStore().CreateUser(ctx, identity.User{ID: "op", Email: "op@x", Status: identity.UserStatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.authStore().UpsertMembership(ctx, identity.Membership{UserID: "op", TeamID: "t1", Role: identity.RoleAdmin}); err != nil {
+		t.Fatal(err)
+	}
+	adminCtx := auth.WithIdentity(ctx, auth.Identity{UserID: "op", TeamID: "t1", Role: identity.RoleAdmin})
+
+	body := `{"bot_id":"feed-watch","label":"durable","repo_url":"https://github.com/o/r","repo_ref":"main","category":"a11y","never_expires":true}`
+	cw := httptest.NewRecorder()
+	s.handleCreateConfigShare(cw, mintShareReq(t, adminCtx, body))
+	if cw.Code != http.StatusCreated {
+		t.Fatalf("create = %d: %s", cw.Code, cw.Body.String())
+	}
+	var created map[string]any
+	if err := json.Unmarshal(cw.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := created["expires_at"]; ok {
+		t.Errorf("never-expiring share must omit expires_at, got %v", v)
+	}
+}
+
 // TestConfigShare_MintRejectsMissingCategoryForCategorySurface proves the
 // derived surface enforces its own contract: feed-watch's paths carry
 // {category}, so minting without one fails closed (400) rather than pinning a

--- a/pkg/server/config_shares_routes.go
+++ b/pkg/server/config_shares_routes.go
@@ -44,18 +44,28 @@ type createConfigShareReq struct {
 	EditableFields []string `json:"editable_fields"`
 	ReadOnly       bool     `json:"read_only"`
 	ExpiresDays    int      `json:"expires_days"`
+	// NeverExpires opts a share out of the default TTL entirely (durable access
+	// for standing, semi-trusted editors). Revocation is then only via rotate /
+	// delete — there is no time-bounded safety net, so it is opt-in.
+	NeverExpires bool `json:"never_expires"`
 }
 
 // shareView is the operator-facing projection — never the token hash.
 func (s *Server) shareView(sh *configshare.Share) map[string]any {
-	return map[string]any{
+	v := map[string]any{
 		"id": sh.ID, "bot_id": sh.BotID, "label": sh.Label, "repo_url": sh.RepoURL,
 		"repo_ref": sh.RepoRef, "config_path": sh.ConfigPath, "category": sh.Category,
 		"schema_ref": sh.SchemaRef, "allowed_paths": sh.AllowedPaths, "visible_paths": sh.VisiblePaths,
 		"read_only": sh.ReadOnly, "enabled": sh.Enabled, "token_last4": sh.TokenLast4,
-		"fingerprint": sh.Fingerprint, "created_at": sh.CreatedAt, "expires_at": sh.ExpiresAt,
+		"fingerprint": sh.Fingerprint, "created_at": sh.CreatedAt,
 		"revoked_at": sh.RevokedAt, "last_used_at": sh.LastUsedAt,
 	}
+	// Omit expires_at for a never-expiring share (zero time) so the UI renders
+	// "never" instead of the Go zero year.
+	if !sh.ExpiresAt.IsZero() {
+		v["expires_at"] = sh.ExpiresAt
+	}
+	return v
 }
 
 func (s *Server) shareURL(id, token string) string {
@@ -148,18 +158,24 @@ func (s *Server) handleCreateConfigShare(w http.ResponseWriter, r *http.Request)
 		httpError(w, http.StatusInternalServerError, "mint failed")
 		return
 	}
-	ttl := req.ExpiresDays
-	if ttl <= 0 {
-		ttl = defaultShareTTLDays
-	}
 	now := time.Now().UTC()
+	// A zero ExpiresAt never expires (Share.Active). never_expires opts into
+	// that; otherwise 0/omitted days falls back to the default TTL.
+	var expiresAt time.Time
+	if !req.NeverExpires {
+		ttl := req.ExpiresDays
+		if ttl <= 0 {
+			ttl = defaultShareTTLDays
+		}
+		expiresAt = now.AddDate(0, 0, ttl)
+	}
 	sh := &configshare.Share{
 		ID: uuid.NewString(), TenantID: teamID, BotID: req.BotID, Label: req.Label,
 		RepoURL: req.RepoURL, RepoRef: req.RepoRef, ConfigPath: configPath,
 		Category: req.Category, SchemaRef: req.SchemaRef,
 		AllowedPaths: allowed, VisiblePaths: visible, ReadOnly: req.ReadOnly,
 		TokenHash: hash, TokenLast4: last4, Fingerprint: fp,
-		Enabled: true, CreatedBy: id.UserID, CreatedAt: now, ExpiresAt: now.AddDate(0, 0, ttl),
+		Enabled: true, CreatedBy: id.UserID, CreatedAt: now, ExpiresAt: expiresAt,
 	}
 	if err := s.configShares.Create(r.Context(), sh); err != nil {
 		httpError(w, http.StatusInternalServerError, "create failed")

--- a/studio/src/api/configShareAdmin.ts
+++ b/studio/src/api/configShareAdmin.ts
@@ -57,6 +57,9 @@ export interface CreateShareInput {
   editable_fields?: string[];
   read_only?: boolean;
   expires_days?: number;
+  /** Opt out of the default TTL entirely — durable access (revoke via
+   *  rotate/delete). Wins over expires_days. */
+  never_expires?: boolean;
 }
 
 // Delivery mirrors configshare.Delivery — the forensic record of every

--- a/studio/src/components/ui/Dialog.tsx
+++ b/studio/src/components/ui/Dialog.tsx
@@ -41,7 +41,7 @@ export function Dialog({
       <RD.Portal>
         <RD.Overlay className={`fixed inset-0 ${overlayZ} bg-scrim-modal animate-fade-in`} />
         <RD.Content
-          className={`fixed left-1/2 top-1/2 ${contentZ} w-[calc(100vw-2rem)] ${widthClass} -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border-default bg-surface-1 text-fg-default shadow-[var(--shadow-lg)] animate-fade-in`}
+          className={`fixed left-1/2 top-1/2 ${contentZ} flex max-h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] ${widthClass} -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-border-default bg-surface-1 text-fg-default shadow-[var(--shadow-lg)] animate-fade-in`}
           onOpenAutoFocus={onOpenAutoFocus}
           // Radix warns unless every Content has a Description or an
           // explicit aria-describedby={undefined}. Dialogs without a
@@ -50,7 +50,7 @@ export function Dialog({
           {...(description ? {} : { "aria-describedby": undefined })}
         >
           {(title || !hideClose) && (
-            <div className="flex items-start justify-between border-b border-border-default px-4 py-3">
+            <div className="flex shrink-0 items-start justify-between border-b border-border-default px-4 py-3">
               <div className="min-w-0">
                 {title && (
                   <RD.Title className="text-sm font-semibold text-fg-default">
@@ -73,9 +73,9 @@ export function Dialog({
               )}
             </div>
           )}
-          <div className="px-4 py-3">{children}</div>
+          <div className="flex-1 overflow-y-auto px-4 py-3">{children}</div>
           {footer && (
-            <div className="flex items-center justify-end gap-2 border-t border-border-default px-4 py-3">
+            <div className="flex shrink-0 items-center justify-end gap-2 border-t border-border-default px-4 py-3">
               {footer}
             </div>
           )}

--- a/studio/src/views/Bots/BotHome/ConfigSharesCard.tsx
+++ b/studio/src/views/Bots/BotHome/ConfigSharesCard.tsx
@@ -256,6 +256,7 @@ function ShareRow({
           {share.expires_at && !expired && (
             <> · expires {formatRelative(share.expires_at)}</>
           )}
+          {!share.expires_at && !revoked && <> · never expires</>}
           {share.last_used_at && <> · last used {formatRelative(share.last_used_at)}</>}
         </span>
         <span className="ml-auto flex items-center gap-1.5">
@@ -294,6 +295,7 @@ function CreateShareDialog({
   const [category, setCategory] = useState("");
   const [readOnly, setReadOnly] = useState(false);
   const [expiresDays, setExpiresDays] = useState<number | "">(14);
+  const [neverExpires, setNeverExpires] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -344,9 +346,11 @@ function CreateShareDialog({
         // server derives + pins the paths. config_path + paths never sent.
         editable_fields: selectedFields,
         read_only: readOnly,
-        ...(typeof expiresDays === "number" && expiresDays > 0
-          ? { expires_days: expiresDays }
-          : {}),
+        ...(neverExpires
+          ? { never_expires: true }
+          : typeof expiresDays === "number" && expiresDays > 0
+            ? { expires_days: expiresDays }
+            : {}),
       };
       const minted = await createConfigShare(teamID, input);
       onCreated(minted);
@@ -504,14 +508,22 @@ function CreateShareDialog({
             onChange={(e) => setReadOnly(e.target.checked)}
             label="Read-only share"
           />
-          <div className="flex items-center gap-2 text-xs">
+          <Checkbox
+            checked={neverExpires}
+            onChange={(e) => setNeverExpires(e.target.checked)}
+            label="Never expires"
+          />
+          <div
+            className={`flex items-center gap-2 text-xs ${neverExpires ? "opacity-50" : ""}`}
+          >
             <label htmlFor="cs-exp">Expires in</label>
             <Input
               id="cs-exp"
               type="number"
               min={1}
               size="sm"
-              value={expiresDays}
+              disabled={neverExpires}
+              value={neverExpires ? "" : expiresDays}
               onChange={(e) => {
                 const n = e.target.value === "" ? "" : Number(e.target.value);
                 setExpiresDays(Number.isFinite(n) ? (n as number) : "");


### PR DESCRIPTION
Two config-share UX fixes reported while setting up the veille editor on prod.

## 1. Dialog scrolls when taller than the viewport (bug)
The modal was centered with no height cap, so a tall dialog (e.g. the config-share create form with its field checkboxes + surface preview) pushed its footer — and its primary action button — off-screen with no way to reach it. The shared `Dialog` now caps at `calc(100vh-2rem)`, lays out as a flex column, pins header + footer (`shrink-0`), and scrolls the body (`flex-1 overflow-y-auto`). **Applies to every dialog.**

## 2. "Never expires" option for durable share access (feat)
A share token had a mandatory TTL (default 14d) — too short for delegating standing config edits to a semi-trusted colleague, who'd need re-minting every fortnight. Opt-in `never_expires`: the mint stores a zero `ExpiresAt` (`Share.Active` already treats that as non-expiring), the view omits `expires_at`, and the create form gains a "Never expires" checkbox (disables the days input; the row shows "never expires"). Default stays 14d — the opt-out is deliberate, revocation is then rotate/delete.

Tests: mint with `never_expires` omits `expires_at`. Full `pkg/server` suite, gofmt/vet, studio tsc + eslint — green. No OpenAPI drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)