### PR TITLE
feat(studio): per-schedule variables (feed-watch per-category digests)

### DIFF
--- a/studio/src/views/Triggers/ScheduleDialogs.tsx
+++ b/studio/src/views/Triggers/ScheduleDialogs.tsx
@@ -74,6 +74,7 @@ export function NewScheduleDialog({
   const [botId, setBotId] = useState("");
   const [cron, setCron] = useState("0 2 * * *");
   const [policy, setPolicy] = useState<SchedulePolicyValue>(policyValueFromSchedule());
+  const [vars, setVars] = useState<{ key: string; value: string }[]>([]);
   const action = useAsyncAction();
   const [, navigate] = useLocation();
 
@@ -90,6 +91,7 @@ export function NewScheduleDialog({
       setBotId("");
       setCron("0 2 * * *");
       setPolicy(policyValueFromSchedule());
+      setVars([]);
       action.clearError();
     }
   }
@@ -107,7 +109,16 @@ export function NewScheduleDialog({
       return;
     }
     const res = await action.run(() =>
-      createTeamSchedule(teamID, buildCreatePayload({ botId, cron, repo, policy })),
+      createTeamSchedule(
+        teamID,
+        buildCreatePayload({
+          botId,
+          cron,
+          repo,
+          policy,
+          vars: Object.fromEntries(vars.map((r) => [r.key, r.value])),
+        }),
+      ),
     );
     if (res) onCreated();
   }
@@ -164,6 +175,69 @@ export function NewScheduleDialog({
         </div>
 
         <CronField value={cron} onChange={setCron} />
+
+        <div>
+          <FieldLabel>Variables (optional)</FieldLabel>
+          <p className="mb-1 text-caption text-fg-subtle">
+            Passed to the bot on each fire — e.g. a feed-watch per-category
+            digest needs <span className="font-mono">mode=digest</span> and{" "}
+            <span className="font-mono">category=a11y</span>.
+          </p>
+          <div className="flex flex-col gap-1.5">
+            {vars.map((row, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <Input
+                  size="sm"
+                  placeholder="name"
+                  value={row.key}
+                  onChange={(e) =>
+                    setVars((rows) =>
+                      rows.map((r, j) =>
+                        j === i ? { ...r, key: e.target.value } : r,
+                      ),
+                    )
+                  }
+                  className="w-32 font-mono"
+                />
+                <span className="text-fg-subtle">=</span>
+                <Input
+                  size="sm"
+                  placeholder="value"
+                  value={row.value}
+                  onChange={(e) =>
+                    setVars((rows) =>
+                      rows.map((r, j) =>
+                        j === i ? { ...r, value: e.target.value } : r,
+                      ),
+                    )
+                  }
+                  className="flex-1 font-mono"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() =>
+                    setVars((rows) => rows.filter((_, j) => j !== i))
+                  }
+                  aria-label="Remove variable"
+                >
+                  ✕
+                </Button>
+              </div>
+            ))}
+            <div>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() =>
+                  setVars((rows) => [...rows, { key: "", value: "" }])
+                }
+              >
+                + Add variable
+              </Button>
+            </div>
+          </div>
+        </div>
 
         <div>
           <FieldLabel>Tick policy</FieldLabel>

--- a/studio/src/views/Triggers/scheduleModel.test.ts
+++ b/studio/src/views/Triggers/scheduleModel.test.ts
@@ -149,6 +149,25 @@ describe("buildCreatePayload", () => {
     ).toEqual({ bot_id: "feature-dev", cron: "0 2 * * *" });
   });
 
+  it("threads non-empty vars and drops blank keys", () => {
+    expect(
+      buildCreatePayload({
+        botId: "feed-watch",
+        cron: "0 8 * * 1",
+        repo: null,
+        policy,
+        vars: { mode: "digest", category: "a11y", "": "ignored", "  ": "x" },
+      }).vars,
+    ).toEqual({ mode: "digest", category: "a11y" });
+  });
+
+  it("omits vars when every key is blank", () => {
+    expect(
+      buildCreatePayload({ botId: "b", cron: "0 * * * *", repo: null, policy, vars: { "": "x" } })
+        .vars,
+    ).toBeUndefined();
+  });
+
   it("binds the repo via clone_url, falling back to web_url", () => {
     const withClone = repo({ clone_url: "https://github.com/acme/app.git" });
     expect(

--- a/studio/src/views/Triggers/scheduleModel.ts
+++ b/studio/src/views/Triggers/scheduleModel.ts
@@ -150,6 +150,9 @@ export interface ScheduleDraft {
   /** The connected repo to bind to, or null for "no repository". */
   repo: ForgeTeamRepo | null;
   policy: SchedulePolicyValue;
+  /** Per-run vars passed to the bot on each fire (e.g. a feed-watch digest's
+   *  `mode=digest` + `category=a11y`). Empty when the bot needs none. */
+  vars?: Record<string, string>;
 }
 
 /**
@@ -166,6 +169,13 @@ export function buildCreatePayload(d: ScheduleDraft): ScheduleCreateInput {
   };
   if (d.repo) {
     input.repo_url = d.repo.clone_url || d.repo.web_url || d.repo.repo_full_name;
+  }
+  if (d.vars) {
+    const vars: Record<string, string> = {};
+    for (const [k, v] of Object.entries(d.vars)) {
+      if (k.trim()) vars[k.trim()] = v;
+    }
+    if (Object.keys(vars).length > 0) input.vars = vars;
   }
   const p = policyFieldsFromValue(d.policy);
   if (p.overlap === "allow") {


### PR DESCRIPTION
The team **Schedules** form (Automations view) set only bot + cron + policy. A feed-watch **per-category digest** needs `mode=digest` + `category=<key>` passed as vars — the API (`ScheduleCreateInput.vars`) and `cloudsched.ScheduledBot.Vars` already carry them, but the form had no way to enter them. So you couldn't schedule per-category digests on distinct cadences from the UI.

Adds an optional key/value **Variables** editor to the New Schedule dialog (add/remove rows). `buildCreatePayload` threads non-empty pairs into `vars`, dropping blank keys. Universal — works for any bot's runtime vars, not just feed-watch.

Tests: `buildCreatePayload` threads vars, drops blank keys, omits `vars` when all blank (scheduleModel.test.ts, 13 pass). tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)