### PR TITLE
feat: config-editor role — SSO-team-scoped access to config-share (ADR-078)

### DIFF
--- a/docs/adr/078-config-editor-role-sso-team-scoped-access.md
+++ b/docs/adr/078-config-editor-role-sso-team-scoped-access.md
@@ -1,0 +1,111 @@
+# ADR-078 — Config-editor role: SSO-team-scoped access to config-share
+
+Status: accepted · 2026-07-18
+
+Extends [ADR-076](076-scoped-config-share-editor.md) (scoped config-share
+editor) and [ADR-077](077-declarative-per-bot-config-share-surface.md). ADR-076
+shipped the editor as a **bearer capability URL** (`iws_` token, synthetic
+`KindShare` principal). This ADR adds a second, complementary access path: a
+**real user, authenticated via org SSO, holding a least-privilege `config_editor`
+capability on a team**, who reaches only the config-share editor views for that
+team's bots — nothing else in the studio.
+
+## Context
+
+The capability-URL model (ADR-076) is right for a **truly external** editor
+(no account, no SSO): you hand them a link, zero onboarding. But for the actual
+first user — internal design/a11y colleagues who curate the veille config — it
+has real weaknesses the operator felt in practice:
+
+- it is a **bearer secret** (leaks if the URL is pasted/forwarded/synced);
+- **no identity or attribution** — the delivery audit records IP/UA, not *who*;
+- **no revoke-by-person** — you rotate the token (breaking everyone's link) or
+  delete the share;
+- keeping a standing link alive needed the **"never expires"** opt-out
+  (ADR-077 follow-up) — a permanent credential, the classic smell.
+
+For colleagues who are (or can be) in the org's SSO, the better model is: access
+is a property of **team membership + a scoped role**. In the team with the
+config-editor capability → you can edit that team's bots' config; removed from
+the team → access is gone. No token, no expiry, real identity.
+
+The two models are **complementary, not competing**: capability-URL for the
+account-less external case, SSO-team-scoped for the internal case.
+
+## Decision
+
+Add a `config_editor` capability and an SSO-authenticated editor surface, built
+so it does **not** weaken the ADR-076 token path.
+
+1. **`config_editor` is an ORTHOGONAL capability, not a rank on the role
+   ladder.** The team role ladder is strictly linear (`viewer < member < admin
+   < owner`, compared by `AtLeast`), and — critically — `canViewTeam` admits any
+   `Role.Valid()` principal, *not* `AtLeast(RoleViewer)`. So a naive "below
+   viewer" linear role would silently gain broad team read. Instead,
+   `config_editor` is a distinct role value that the **standard gates
+   (`canViewTeam`/`canManageTeam`/`canViewOrg`) explicitly reject**, and that
+   only a **new `canEditConfigShares(team)` gate** accepts. It grants exactly one
+   thing: edit this team's config-shares. Nothing else.
+
+2. **A SEPARATE authenticated endpoint — the token path stays cookie-less.**
+   The public editor routes (`/api/config-share/{id}/…`) keep their Bearer-only,
+   `credentials:"omit"`, structurally-CSRF-immune contract (ADR-076). The
+   real-user path is a new group under the normal session auth:
+   `GET /api/teams/{id}/config-shares` (already exists, now also readable by a
+   config-editor), `GET|PATCH /api/teams/{id}/config-shares/{sid}/config` behind
+   `requireAuth + canEditConfigShares`, reusing the SAME
+   `configShareSvc.ProjectedRead`/`ApplyEdit` the public handlers call. The
+   real user is `KindUser` (not synthetic), so it passes the `IsSynthetic()`
+   guard cleanly — ADR-076's synthetic rejection is untouched and is *not* a
+   blocker here.
+
+3. **A role-keyed limited studio shell.** `RestrictedShell` today triggers on
+   "member of zero teams" and shows the marketplace. A config-editor *is* a team
+   member, so a **new branch in `AuthGate`** — keyed on the active role being
+   `config_editor` — renders a sibling limited shell that mounts ONLY the
+   config-share editors for the team's bots, reached through the **normal cookie
+   session client** (`@/api/client`), not the `iws_`-hardwired `configShare.ts` /
+   `ConfigShareView`.
+
+4. **No org over-grant.** A team membership normally mirrors up to an
+   `OrgRoleMember`, which passes `canViewOrg` (org roster/usage/settings read).
+   A `config_editor` must **not** mirror to org membership — it stays purely
+   team-and-config-scoped.
+
+5. **Attribution.** The `configshare.Delivery` audit row gains an `actor` field,
+   so a real-user edit is attributable to the user (the token path keeps its
+   `share:<id>` actor).
+
+6. **SSO assignment.** `config_editor` is assignable through the existing SSO
+   role plumbing — a GitHub "config editors" team → `GitHubTeamGrant{Role:
+   config_editor}`, or an OIDC provider `DefaultRole: config_editor` — once the
+   role value is `Valid()`. The operator UI adds `config_editor` to the team
+   members role picker (invite + change-role), which validates only
+   `role.Valid()`, so no member-management handler changes.
+
+## Scope (MVP) + follow-ups
+
+- **MVP: team-scoped.** A `config_editor` can edit **all** of their team's
+  config-shares. There is no member→bot binding today; per-bot / per-share
+  narrowing (a config-editor limited to `feed-watch/a11y` only) is a follow-up
+  (natural home: a scoped field on `Membership` or a join consulted by
+  `canEditConfigShares`).
+- Follow-ups: per-bot/per-share member binding; an org-level "config editor only"
+  concept if org context is ever needed; email-invite copy tailored to the
+  config-editor role.
+
+## Consequences
+
+- The operator gets a **no-token, revoke-by-membership** way to delegate config
+  editing to colleagues, with real identity + attribution — the durable-access
+  need that previously forced a never-expiring token.
+- The capability-URL path is **unchanged and still the right tool** for
+  account-less external editors. `never_expires` remains, but is no longer the
+  *only* way to grant standing access.
+- One new low-privilege capability enters the auth model. It is deliberately
+  **out of the linear ladder** so it can never be mistaken for "viewer+" by a
+  gate that checks `Valid()` — the single biggest correctness hazard, closed by
+  a golden test asserting `config_editor` is rejected by every standard gate and
+  admitted by `canEditConfigShares` alone.
+
+Reference: [docs/config-share.md](../config-share.md).

--- a/openapi.json
+++ b/openapi.json
@@ -5561,6 +5561,74 @@
         ]
       }
     },
+    "/api/teams/{id}/config-editor/shares": {
+      "get": {
+        "operationId": "getTeamsByIdConfigEditorShares",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "GET /api/teams/{id}/config-editor/shares",
+        "tags": [
+          "teams"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/api/teams/{id}/config-editor/shares/{sid}/config": {
+      "get": {
+        "operationId": "getTeamsByIdConfigEditorSharesBySidConfig",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "GET /api/teams/{id}/config-editor/shares/{sid}/config",
+        "tags": [
+          "teams"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "in": "path",
+          "name": "sid",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "patch": {
+        "operationId": "patchTeamsByIdConfigEditorSharesBySidConfig",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "PATCH /api/teams/{id}/config-editor/shares/{sid}/config",
+        "tags": [
+          "teams"
+        ]
+      }
+    },
     "/api/teams/{id}/config-shares": {
       "get": {
         "operationId": "getTeamsByIdConfigShares",

--- a/pkg/auth/orgsso/orgsso_test.go
+++ b/pkg/auth/orgsso/orgsso_test.go
@@ -103,6 +103,17 @@ func TestMemoryStore_GitHub_OnePerTenant(t *testing.T) {
 	}
 }
 
+// TestGitHubGrant_ConfigEditorNotCapped proves the config_editor capability is
+// assignable via SSO (ADR-078): unlike an admin grant (capped to member),
+// config_editor is Valid and below-admin, so RoleForGroups passes it through
+// unchanged — a "veille editors" GitHub team can grant it directly.
+func TestGitHubGrant_ConfigEditorNotCapped(t *testing.T) {
+	row := githubRow("g", "t", GitHubTeamGrant{GitHubOrg: "acme", TeamSlug: "veille-editors", Role: identity.RoleConfigEditor})
+	if r, ok := row.RoleForGroups([]string{"acme/veille-editors"}); !ok || r != identity.RoleConfigEditor {
+		t.Errorf("config_editor grant → %q,%v want config_editor (not capped like admin)", r, ok)
+	}
+}
+
 func TestMemoryStore_ListByTenantKind(t *testing.T) {
 	ctx := context.Background()
 	st := NewMemoryStore()

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -821,6 +821,13 @@ func (s *Service) grantOrgMembershipForTeam(ctx context.Context, userID, teamID 
 		return "", nil
 	}
 	want := identity.OrgRoleForTeamRole(teamRole)
+	if want == "" {
+		// A team capability outside the ladder (config_editor) confers no org
+		// membership — never mirror it up (an org-member row would pass
+		// canViewOrg → org roster/usage read). Login still resolves the org
+		// context with an empty OrgRole, which the org gates reject. ADR-078.
+		return t.OrgID, nil
+	}
 	// Never downgrade an existing higher org-role.
 	if existing, gerr := s.store.GetOrgMembership(ctx, userID, t.OrgID); gerr == nil && existing.Role.AtLeast(want) {
 		return t.OrgID, nil

--- a/pkg/configshare/types.go
+++ b/pkg/configshare/types.go
@@ -67,18 +67,22 @@ func (s *Share) Active(now time.Time) bool {
 // through a share — the forensic trail after a token leak: who (source IP +
 // UA), when, what changed (before/after blob SHA + the changed leaf paths).
 type Delivery struct {
-	ID           string    `json:"id" bson:"_id"`
-	ShareID      string    `json:"share_id" bson:"share_id"`
-	TenantID     string    `json:"tenant_id" bson:"tenant_id"`
-	At           time.Time `json:"at" bson:"at"`
-	SourceIP     string    `json:"source_ip" bson:"source_ip"`
-	UserAgent    string    `json:"user_agent" bson:"user_agent"`
-	Method       string    `json:"method" bson:"method"`
-	Status       int       `json:"status" bson:"status"`
-	BeforeSHA    string    `json:"before_sha,omitempty" bson:"before_sha,omitempty"`
-	AfterSHA     string    `json:"after_sha,omitempty" bson:"after_sha,omitempty"`
-	ChangedPaths []string  `json:"changed_paths,omitempty" bson:"changed_paths,omitempty"`
-	Error        string    `json:"error,omitempty" bson:"error,omitempty"`
+	ID        string    `json:"id" bson:"_id"`
+	ShareID   string    `json:"share_id" bson:"share_id"`
+	TenantID  string    `json:"tenant_id" bson:"tenant_id"`
+	At        time.Time `json:"at" bson:"at"`
+	SourceIP  string    `json:"source_ip" bson:"source_ip"`
+	UserAgent string    `json:"user_agent" bson:"user_agent"`
+	Method    string    `json:"method" bson:"method"`
+	// Actor attributes the edit: "share:<id>" for a token (capability-URL)
+	// edit, "user:<id>" for an authenticated config-editor session (ADR-078).
+	// Empty on legacy rows.
+	Actor        string   `json:"actor,omitempty" bson:"actor,omitempty"`
+	Status       int      `json:"status" bson:"status"`
+	BeforeSHA    string   `json:"before_sha,omitempty" bson:"before_sha,omitempty"`
+	AfterSHA     string   `json:"after_sha,omitempty" bson:"after_sha,omitempty"`
+	ChangedPaths []string `json:"changed_paths,omitempty" bson:"changed_paths,omitempty"`
+	Error        string   `json:"error,omitempty" bson:"error,omitempty"`
 }
 
 // Store persists shares + their delivery audit, tenant-scoped. GetByID takes

--- a/pkg/identity/config_editor_test.go
+++ b/pkg/identity/config_editor_test.go
@@ -29,3 +29,23 @@ func TestRoleConfigEditor_OrthogonalToLadder(t *testing.T) {
 		t.Error("config_editor must NOT be AtLeast(viewer) — that is the over-grant hazard ADR-078 closes")
 	}
 }
+
+// TestOrgRoleForTeamRole_ConfigEditorConfersNoOrgRole locks ADR-078 decision 4:
+// a config_editor team membership must NOT mirror to an org role (an org-member
+// row would pass canViewOrg → org roster/usage read). The ladder roles are
+// unchanged.
+func TestOrgRoleForTeamRole_ConfigEditorConfersNoOrgRole(t *testing.T) {
+	if got := OrgRoleForTeamRole(RoleConfigEditor); got != "" {
+		t.Errorf("config_editor org role = %q, want \"\" (no org mirror)", got)
+	}
+	for role, want := range map[Role]OrgRole{
+		RoleViewer: OrgRoleMember,
+		RoleMember: OrgRoleMember,
+		RoleAdmin:  OrgRoleAdmin,
+		RoleOwner:  OrgRoleAdmin,
+	} {
+		if got := OrgRoleForTeamRole(role); got != want {
+			t.Errorf("OrgRoleForTeamRole(%s) = %q, want %q", role, got, want)
+		}
+	}
+}

--- a/pkg/identity/config_editor_test.go
+++ b/pkg/identity/config_editor_test.go
@@ -1,0 +1,31 @@
+package identity
+
+import "testing"
+
+// TestRoleConfigEditor_OrthogonalToLadder locks ADR-078's core invariant: the
+// config_editor capability is a real, assignable role (Valid → round-trips
+// through the JWT claim + member API) yet sits OUTSIDE the viewer<member<admin<
+// owner ladder — it is neither ≥ any ladder role nor is any ladder role ≥ it —
+// so a gate that admits AtLeast(RoleViewer) can never mistake it for viewer+.
+func TestRoleConfigEditor_OrthogonalToLadder(t *testing.T) {
+	if !RoleConfigEditor.Valid() {
+		t.Fatal("config_editor must be Valid() so it round-trips through JWT + member API")
+	}
+	ladder := []Role{RoleViewer, RoleMember, RoleAdmin, RoleOwner}
+	for _, r := range ladder {
+		if RoleConfigEditor.AtLeast(r) {
+			t.Errorf("config_editor must NOT be AtLeast(%s)", r)
+		}
+		if r.AtLeast(RoleConfigEditor) {
+			t.Errorf("%s must NOT be AtLeast(config_editor)", r)
+		}
+		// The gate's new check (AtLeast(RoleViewer)) still admits every ladder
+		// role — equivalent to the old Valid() for these four.
+		if !r.AtLeast(RoleViewer) {
+			t.Errorf("%s must be AtLeast(viewer) — the standard team-view gate", r)
+		}
+	}
+	if RoleConfigEditor.AtLeast(RoleViewer) {
+		t.Error("config_editor must NOT be AtLeast(viewer) — that is the over-grant hazard ADR-078 closes")
+	}
+}

--- a/pkg/identity/types.go
+++ b/pkg/identity/types.go
@@ -30,6 +30,15 @@ const (
 	RoleMember Role = "member"
 	RoleAdmin  Role = "admin"
 	RoleOwner  Role = "owner"
+	// RoleConfigEditor is an ORTHOGONAL least-privilege capability, NOT a rung
+	// on the viewer<member<admin<owner ladder (ADR-078): it grants exactly one
+	// thing — edit this team's config-shares — and nothing else. It ranks 0, so
+	// AtLeast never places it in the ladder (it is neither ≥ viewer nor is any
+	// ladder role ≥ it), yet Valid() accepts it so it round-trips through the
+	// JWT claim and the member-management API. Standard team gates admit
+	// AtLeast(RoleViewer) (equivalent to the old Valid() for the four ladder
+	// roles), which excludes this; only canEditConfigShares admits it.
+	RoleConfigEditor Role = "config_editor"
 )
 
 // rank gives a totally-ordered weight so callers can express
@@ -58,8 +67,10 @@ func (r Role) AtLeast(want Role) bool {
 	return haveRank >= wantRank
 }
 
-// Valid reports whether r is one of the four known roles.
-func (r Role) Valid() bool { return r.rank() > 0 }
+// Valid reports whether r is an assignable role — the four ladder roles plus
+// the orthogonal config_editor capability (rank 0, so ladder comparisons
+// exclude it, but it is still a real, storable, JWT-round-trippable role).
+func (r Role) Valid() bool { return r.rank() > 0 || r == RoleConfigEditor }
 
 // OrgRole is the org-level RBAC level — coarser than the per-team
 // Role: an org member is granted access to 0..N teams within the org,

--- a/pkg/identity/types.go
+++ b/pkg/identity/types.go
@@ -114,10 +114,17 @@ func (r OrgRole) Valid() bool { return r.rank() > 0 }
 // and the teams→orgs backfill): team owners/admins become org admins,
 // everyone else an org member.
 func OrgRoleForTeamRole(r Role) OrgRole {
-	if r.AtLeast(RoleAdmin) {
+	switch {
+	case r.AtLeast(RoleAdmin):
 		return OrgRoleAdmin
+	case r.AtLeast(RoleViewer):
+		return OrgRoleMember
 	}
-	return OrgRoleMember
+	// A capability OUTSIDE the ladder (config_editor, rank 0) confers no org
+	// role — it must not mirror up to an org membership (ADR-078), else it
+	// would pass canViewOrg. Login still resolves the org context with an empty
+	// OrgRole, which the org gates reject.
+	return ""
 }
 
 // UserStatus tracks whether the user can log in. Disabled users

--- a/pkg/server/auth_routes.go
+++ b/pkg/server/auth_routes.go
@@ -1562,14 +1562,41 @@ func (s *Server) canViewTeam(ctx context.Context, id auth.Identity, teamID strin
 	if id.IsSuperAdmin {
 		return true
 	}
-	if id.TeamID == teamID && id.Role.Valid() {
+	// AtLeast(RoleViewer) is equivalent to the old Valid() for the four ladder
+	// roles, but excludes the orthogonal config_editor capability (rank 0) — a
+	// config editor is not a team viewer (ADR-078); it reaches only its own
+	// endpoints via canEditConfigShares.
+	if id.TeamID == teamID && id.Role.AtLeast(identity.RoleViewer) {
 		return true
 	}
-	if mb, err := s.authStore().GetMembership(ctx, id.UserID, teamID); err == nil && mb.Role.Valid() {
+	if mb, err := s.authStore().GetMembership(ctx, id.UserID, teamID); err == nil && mb.Role.AtLeast(identity.RoleViewer) {
 		return true
 	}
 	// An org admin/owner can view every team in their org.
 	return s.orgAdminOfTeam(ctx, id, teamID)
+}
+
+// canEditConfigShares reports whether the principal may read/write this team's
+// config-shares through the AUTHENTICATED (session) editor endpoints: the
+// orthogonal config_editor capability on this team, plus anyone who already
+// manages it (admin/owner, org admin, super-admin). Deliberately NOT
+// canViewTeam — a plain viewer/member was never delegated config editing. The
+// public iws_ token path has its own middleware; synthetic principals are
+// rejected here. See ADR-078.
+func (s *Server) canEditConfigShares(ctx context.Context, id auth.Identity, teamID string) bool {
+	if id.IsSynthetic() {
+		return false
+	}
+	if id.IsSuperAdmin {
+		return true
+	}
+	if id.TeamID == teamID && id.Role == identity.RoleConfigEditor {
+		return true
+	}
+	if mb, err := s.authStore().GetMembership(ctx, id.UserID, teamID); err == nil && mb.Role == identity.RoleConfigEditor {
+		return true
+	}
+	return s.canManageTeam(ctx, id, teamID)
 }
 
 func (s *Server) canManageTeam(ctx context.Context, id auth.Identity, teamID string) bool {

--- a/pkg/server/config_editor_routes.go
+++ b/pkg/server/config_editor_routes.go
@@ -1,0 +1,119 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/configshare"
+)
+
+// registerConfigEditorRoutes wires the AUTHENTICATED (session) config-editor
+// surface (ADR-078): a real user holding the config_editor capability on a team
+// — or a team admin — edits the team's config-shares WITHOUT an iws_ token,
+// through the normal cookie session. Distinct from the public capability-URL
+// routes (registerConfigSharePublicRoutes), which keep their Bearer-only,
+// cookie-less, CSRF-immune contract untouched. Same ProjectedRead/ApplyEdit
+// service, so the projection + fail-closed allow-list are identical.
+func (s *Server) registerConfigEditorRoutes() {
+	s.mux.Handle("GET /api/teams/{id}/config-editor/shares", s.requireAuth(http.HandlerFunc(s.handleConfigEditorList)))
+	s.mux.Handle("GET /api/teams/{id}/config-editor/shares/{sid}/config", s.requireAuth(http.HandlerFunc(s.handleConfigEditorGet)))
+	s.mux.Handle("PATCH /api/teams/{id}/config-editor/shares/{sid}/config", s.requireAuth(http.HandlerFunc(s.handleConfigEditorPatch)))
+}
+
+// editorShareView is the REDUCED projection a config-editor sees — enough to
+// render the editor menu, never the token metadata / audit surface the operator
+// shareView carries (token_last4, fingerprint, deliveries).
+func editorShareView(sh *configshare.Share) map[string]any {
+	return map[string]any{
+		"id": sh.ID, "bot_id": sh.BotID, "label": sh.Label,
+		"category": sh.Category, "config_path": sh.ConfigPath, "read_only": sh.ReadOnly,
+	}
+}
+
+// loadEditableShare gates on canEditConfigShares and loads the share, verifying
+// it belongs to the path team.
+func (s *Server) loadEditableShare(w http.ResponseWriter, r *http.Request) (*configshare.Share, bool) {
+	id, _ := auth.FromContext(r.Context())
+	teamID := r.PathValue("id")
+	if !s.canEditConfigShares(r.Context(), id, teamID) {
+		httpError(w, http.StatusForbidden, "forbidden")
+		return nil, false
+	}
+	sh, err := s.configShares.GetByID(r.Context(), r.PathValue("sid"))
+	if err != nil || sh == nil || sh.TenantID != teamID || !sh.Enabled {
+		httpError(w, http.StatusNotFound, "not found")
+		return nil, false
+	}
+	return sh, true
+}
+
+func (s *Server) handleConfigEditorList(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	teamID := r.PathValue("id")
+	if !s.canEditConfigShares(r.Context(), id, teamID) {
+		httpError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+	rows, err := s.configShares.ListByTenant(r.Context(), teamID)
+	if err != nil {
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	views := make([]map[string]any, 0, len(rows))
+	for _, sh := range rows {
+		if !sh.Enabled {
+			continue
+		}
+		views = append(views, editorShareView(sh))
+	}
+	writeJSON(w, map[string]any{"shares": views})
+}
+
+func (s *Server) handleConfigEditorGet(w http.ResponseWriter, r *http.Request) {
+	sh, ok := s.loadEditableShare(w, r)
+	if !ok {
+		return
+	}
+	fc, err := s.resolveShareFC(r.Context(), sh)
+	if err != nil {
+		httpError(w, http.StatusBadGateway, "config source unavailable")
+		return
+	}
+	proj, sha, err := s.configShareSvc.ProjectedRead(r.Context(), fc, sh)
+	if err != nil {
+		httpError(w, http.StatusBadGateway, "read failed")
+		return
+	}
+	writeJSON(w, map[string]any{
+		"config": proj, "sha": sha,
+		"bot_id": sh.BotID, "label": sh.Label, "category": sh.Category,
+		"config_path": sh.ConfigPath, "read_only": sh.ReadOnly,
+	})
+}
+
+func (s *Server) handleConfigEditorPatch(w http.ResponseWriter, r *http.Request) {
+	sh, ok := s.loadEditableShare(w, r)
+	if !ok {
+		return
+	}
+	if sh.ReadOnly {
+		httpError(w, http.StatusForbidden, "read_only")
+		return
+	}
+	var req configSharePatchReq
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 128<<10)).Decode(&req); err != nil {
+		httpError(w, http.StatusBadRequest, "invalid body")
+		return
+	}
+	if len(req.Patch) == 0 {
+		httpError(w, http.StatusBadRequest, "patch has no editable field")
+		return
+	}
+	if req.SHA == "" {
+		httpError(w, http.StatusBadRequest, "sha required")
+		return
+	}
+	msg := "chore(config-share): edit " + sh.ConfigPath + " via config-editor"
+	s.applyShareEditAndRespond(w, r, sh, req, msg)
+}

--- a/pkg/server/config_editor_routes_test.go
+++ b/pkg/server/config_editor_routes_test.go
@@ -1,0 +1,179 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/audit"
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/configshare"
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/identity"
+)
+
+// seedTeamMember creates a user + team membership and returns the matching
+// authenticated identity.
+func seedTeamMember(t *testing.T, s *Server, ctx context.Context, uid string, role identity.Role) auth.Identity {
+	t.Helper()
+	if _, err := s.authStore().CreateUser(ctx, identity.User{ID: uid, Email: uid + "@x", Status: identity.UserStatusActive}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.authStore().UpsertMembership(ctx, identity.Membership{UserID: uid, TeamID: "t1", Role: role}); err != nil {
+		t.Fatal(err)
+	}
+	return auth.Identity{UserID: uid, TeamID: "t1", Role: role}
+}
+
+// TestConfigEditorGates_OrthogonalCapability is the golden RBAC test for
+// ADR-078: config_editor is rejected by every standard team gate and admitted
+// only by canEditConfigShares; a plain viewer is the inverse (sees the team,
+// can't edit config); an admin passes both.
+func TestConfigEditorGates_OrthogonalCapability(t *testing.T) {
+	s := newOrgTestServer(t)
+	seedTeam(t, s, "t1", "acme")
+	ctx := context.Background()
+	editor := seedTeamMember(t, s, ctx, "ed", identity.RoleConfigEditor)
+	viewer := seedTeamMember(t, s, ctx, "vi", identity.RoleViewer)
+	admin := seedTeamMember(t, s, ctx, "ad", identity.RoleAdmin)
+
+	// config_editor: out of the ladder — no team view/manage, yes config edit.
+	if s.canViewTeam(ctx, editor, "t1") {
+		t.Error("config_editor must NOT pass canViewTeam")
+	}
+	if s.canManageTeam(ctx, editor, "t1") {
+		t.Error("config_editor must NOT pass canManageTeam")
+	}
+	if !s.canEditConfigShares(ctx, editor, "t1") {
+		t.Error("config_editor must pass canEditConfigShares")
+	}
+
+	// viewer: the inverse — sees the team, not a config editor.
+	if !s.canViewTeam(ctx, viewer, "t1") {
+		t.Error("viewer must pass canViewTeam")
+	}
+	if s.canEditConfigShares(ctx, viewer, "t1") {
+		t.Error("viewer must NOT pass canEditConfigShares")
+	}
+
+	// admin: manages the team, so also edits config.
+	if !s.canManageTeam(ctx, admin, "t1") {
+		t.Error("admin must pass canManageTeam")
+	}
+	if !s.canEditConfigShares(ctx, admin, "t1") {
+		t.Error("admin must pass canEditConfigShares")
+	}
+}
+
+// TestConfigEditor_EndToEnd proves the authenticated editor surface: a
+// config_editor session lists the team's shares, reads a projected config, and
+// patches it (recording a "user:" delivery); a viewer is 403 on every editor
+// endpoint.
+func TestConfigEditor_EndToEnd(t *testing.T) {
+	s := newOrgTestServer(t)
+	s.auditStore = audit.NewMemoryStore()
+	seedTeam(t, s, "t1", "acme")
+	ctx := context.Background()
+	editor := seedTeamMember(t, s, ctx, "ed", identity.RoleConfigEditor)
+	viewer := seedTeamMember(t, s, ctx, "vi", identity.RoleViewer)
+
+	fc := &fakeShareFC{content: []byte(shareTestConfig), sha: "sha-1"}
+	s.configShareFC = func(context.Context, *configshare.Share) (forge.FileClient, error) { return fc, nil }
+
+	sh := &configshare.Share{
+		ID: "sh1", TenantID: "t1", BotID: "feed-watch", Label: "a11y", Category: "a11y",
+		RepoURL: "https://github.com/o/r", RepoRef: "main", ConfigPath: "feed-watch.json",
+		AllowedPaths: []string{"categories.a11y.feeds", "categories.a11y.editorial"},
+		VisiblePaths: []string{"categories.a11y.feeds", "categories.a11y.editorial", "categories.a11y.digest_title"},
+		Enabled:      true,
+	}
+	if err := s.configShares.Create(ctx, sh); err != nil {
+		t.Fatal(err)
+	}
+
+	edCtx := auth.WithIdentity(ctx, editor)
+	req := func(method, path string, body string) *http.Request {
+		var r *http.Request
+		if body == "" {
+			r = httptest.NewRequest(method, path, nil)
+		} else {
+			r = httptest.NewRequest(method, path, strings.NewReader(body))
+		}
+		r = r.WithContext(edCtx)
+		r.SetPathValue("id", "t1")
+		r.SetPathValue("sid", "sh1")
+		return r
+	}
+
+	// ---- list: config_editor sees the share (reduced view, no token metadata) ----
+	lw := httptest.NewRecorder()
+	s.handleConfigEditorList(lw, req("GET", "/api/teams/t1/config-editor/shares", ""))
+	if lw.Code != http.StatusOK {
+		t.Fatalf("list = %d: %s", lw.Code, lw.Body.String())
+	}
+	if strings.Contains(lw.Body.String(), "token_last4") || strings.Contains(lw.Body.String(), "fingerprint") {
+		t.Errorf("config-editor list must NOT leak token metadata: %s", lw.Body.String())
+	}
+	if !strings.Contains(lw.Body.String(), `"sh1"`) {
+		t.Errorf("config-editor list missing the share: %s", lw.Body.String())
+	}
+
+	// ---- get: projected config scoped to a11y ----
+	gw := httptest.NewRecorder()
+	s.handleConfigEditorGet(gw, req("GET", "/api/teams/t1/config-editor/shares/sh1/config", ""))
+	if gw.Code != http.StatusOK {
+		t.Fatalf("get = %d: %s", gw.Code, gw.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(gw.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["sha"] != "sha-1" {
+		t.Errorf("get sha = %v", got["sha"])
+	}
+	// No leak of the other category / sinks in the projection.
+	if strings.Contains(gw.Body.String(), "cyber") || strings.Contains(gw.Body.String(), "sinks") {
+		t.Errorf("projection leaked out-of-scope data: %s", gw.Body.String())
+	}
+
+	// ---- patch: applies + records a user: delivery ----
+	pw := httptest.NewRecorder()
+	s.handleConfigEditorPatch(pw, req("PATCH", "/api/teams/t1/config-editor/shares/sh1/config",
+		`{"sha":"sha-1","patch":{"categories":{"a11y":{"editorial":"new prompt"}}}}`))
+	if pw.Code != http.StatusOK {
+		t.Fatalf("patch = %d: %s", pw.Code, pw.Body.String())
+	}
+	if fc.puts != 1 {
+		t.Errorf("expected 1 PutFile, got %d", fc.puts)
+	}
+	dels, err := s.configShares.ListDeliveries(ctx, "sh1", 10)
+	if err != nil || len(dels) == 0 {
+		t.Fatalf("expected a delivery row: %v", err)
+	}
+	if dels[0].Actor != "user:ed" {
+		t.Errorf("delivery actor = %q, want user:ed", dels[0].Actor)
+	}
+
+	// ---- a viewer is 403 on every editor endpoint ----
+	viCtx := auth.WithIdentity(ctx, viewer)
+	for _, ep := range []struct{ method, path string }{
+		{"GET", "/api/teams/t1/config-editor/shares"},
+		{"GET", "/api/teams/t1/config-editor/shares/sh1/config"},
+	} {
+		vr := httptest.NewRequest(ep.method, ep.path, nil).WithContext(viCtx)
+		vr.SetPathValue("id", "t1")
+		vr.SetPathValue("sid", "sh1")
+		vw := httptest.NewRecorder()
+		if ep.method == "GET" && strings.HasSuffix(ep.path, "/config") {
+			s.handleConfigEditorGet(vw, vr)
+		} else {
+			s.handleConfigEditorList(vw, vr)
+		}
+		if vw.Code != http.StatusForbidden {
+			t.Errorf("viewer on %s %s = %d, want 403", ep.method, ep.path, vw.Code)
+		}
+	}
+}

--- a/pkg/server/config_share_routes.go
+++ b/pkg/server/config_share_routes.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/configshare"
 	"github.com/SocialGouv/iterion/pkg/forge"
 	forgegithub "github.com/SocialGouv/iterion/pkg/forge/github"
@@ -99,12 +100,20 @@ func (s *Server) handleConfigSharePatch(w http.ResponseWriter, r *http.Request) 
 		httpError(w, http.StatusBadRequest, "sha required")
 		return
 	}
+	msg := "chore(config-share): edit " + sh.ConfigPath + " via share " + sh.TokenLast4
+	s.applyShareEditAndRespond(w, r, sh, req, msg)
+}
+
+// applyShareEditAndRespond runs ApplyEdit for BOTH the public token path and
+// the authenticated config-editor path (ADR-078), recording the delivery and
+// writing the response identically so the two surfaces can never drift. The
+// caller validates read_only / patch / sha and supplies the commit message.
+func (s *Server) applyShareEditAndRespond(w http.ResponseWriter, r *http.Request, sh *configshare.Share, req configSharePatchReq, msg string) {
 	fc, err := s.resolveShareFC(r.Context(), sh)
 	if err != nil {
 		httpError(w, http.StatusBadGateway, "config source unavailable")
 		return
 	}
-	msg := "chore(config-share): edit " + sh.ConfigPath + " via share " + sh.TokenLast4
 	newSHA, changed, err := s.configShareSvc.ApplyEdit(r.Context(), fc, sh, req.Patch, req.SHA, msg, shareCommitAuthorName, shareCommitAuthorEmail)
 	switch {
 	case errors.Is(err, forge.ErrFileConflict):
@@ -133,9 +142,20 @@ func (s *Server) handleConfigSharePatch(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) recordShareDelivery(r *http.Request, sh *configshare.Share, status int, beforeSHA, afterSHA string, changed []string, errMsg string) {
+	// Attribute the edit from the request principal: the token middleware
+	// stamps a "share:<id>" UserID (KindShare); an authenticated config-editor
+	// is a real user (ADR-078).
+	actor := ""
+	if id, ok := auth.FromContext(r.Context()); ok {
+		if id.Kind == auth.KindShare {
+			actor = id.UserID
+		} else if id.UserID != "" {
+			actor = "user:" + id.UserID
+		}
+	}
 	d := &configshare.Delivery{
 		ID: uuid.NewString(), ShareID: sh.ID, TenantID: sh.TenantID, At: time.Now().UTC(),
-		SourceIP: s.clientIP(r), UserAgent: r.UserAgent(), Method: r.Method,
+		SourceIP: s.clientIP(r), UserAgent: r.UserAgent(), Method: r.Method, Actor: actor,
 		Status: status, BeforeSHA: beforeSHA, AfterSHA: afterSHA, ChangedPaths: changed, Error: errMsg,
 	}
 	// Synchronous + detached ctx: the audit trail is the forensic record after

--- a/pkg/server/server_routes.go
+++ b/pkg/server/server_routes.go
@@ -194,6 +194,9 @@ func (s *Server) routes() {
 	if s.configShares != nil && s.genericSecrets != nil && s.sealer != nil && s.authSvc != nil {
 		s.registerConfigSharePublicRoutes()
 		s.registerConfigShareAdminRoutes()
+		// Authenticated config-editor surface (ADR-078): SSO-team-scoped session
+		// editing, distinct from the public token path.
+		s.registerConfigEditorRoutes()
 	}
 
 	// Outbound forge integrations (connect a repo + auto-provision). Gated

--- a/studio/src/App.tsx
+++ b/studio/src/App.tsx
@@ -57,6 +57,7 @@ import ToastContainer from "@/components/shared/Toast";
 import MissingCLIBanner from "@/components/MissingCLIBanner";
 import CloudLanding, { PublicTopBar } from "@/views/CloudLanding";
 const RestrictedShell = lazy(() => import("@/views/RestrictedShell"));
+const ConfigEditorShell = lazy(() => import("@/views/ConfigEditorShell"));
 const CliAuthPage = lazy(() => import("@/views/CliAuthPage"));
 const ConfigShareView = lazy(() => import("@/views/ConfigShare"));
 import { useDesktop } from "@/hooks/useDesktop";
@@ -117,7 +118,7 @@ function ScopedPaneReauth() {
 // session so the AuthGate consults the URL when it sees the
 // "anonymous" state and dispatches to the matching public view.
 function AuthGate() {
-  const { status, signOut, isRestricted, retryConnection } = useAuth();
+  const { status, signOut, isRestricted, activeRole, retryConnection } = useAuth();
   const [location] = useLocation();
   const serverInfo = useServerInfoStore((s) => s.info);
 
@@ -212,6 +213,18 @@ function AuthGate() {
     return (
       <Suspense fallback={<BootLoading />}>
         <ConfigShareView />
+      </Suspense>
+    );
+  }
+  // The least-privilege `config_editor` role gets a limited shell that can
+  // ONLY edit the team's config-shares — no Sidebar, no runs/board/launch.
+  // It's a real team member (isRestricted is false for them), so this branch
+  // must sit ABOVE the isRestricted check. The auth side-doors above
+  // (/invitations/accept, /cli-auth, /config/:id) stay reachable for them.
+  if (activeRole === "config_editor") {
+    return (
+      <Suspense fallback={<BootLoading />}>
+        <ConfigEditorShell />
       </Suspense>
     );
   }

--- a/studio/src/api/auth.ts
+++ b/studio/src/api/auth.ts
@@ -9,7 +9,11 @@ import { apiBase } from "@/lib/scope";
 
 const BASE = apiBase().replace(/\/$/, "");
 
-export type Role = "owner" | "admin" | "member" | "viewer";
+// `config_editor` is a least-privilege team role: it can ONLY edit the team's
+// config-shares (via the ConfigEditorShell), nothing else in the studio. It
+// sits below `viewer` in the access ladder (a viewer reads the whole studio;
+// a config_editor reaches only the config editor).
+export type Role = "owner" | "admin" | "member" | "viewer" | "config_editor";
 export type UserStatus = "active" | "disabled" | "pending_password_change";
 
 export interface UserView {

--- a/studio/src/api/configEditor.ts
+++ b/studio/src/api/configEditor.ts
@@ -1,0 +1,119 @@
+// Config-editor client — operator-facing, COOKIE-session-authed (uses the
+// shared apiRequest so the normal session cookie, silent refresh, and global
+// 401 handling all apply). Talks to the config-editor routes under
+// /api/teams/{id}/config-editor/*.
+//
+// This is the network layer for the least-privilege `config_editor` role's
+// studio shell (@/views/ConfigEditorShell). A config_editor is a real team
+// member whose session lives in the same HttpOnly cookie as any operator, so
+// these calls MUST ride the shared client (credentials: "include").
+//
+// It is deliberately DISTINCT from @/api/configShare — that module is the
+// isolated, iws_-token / credentials:"omit" client for the anonymous,
+// shell-less /config/:id editor, and is eslint-forbidden outside
+// src/views/ConfigShare/**. Do not confuse the two: this file is the
+// signed-in path, that one is the tokened public path.
+
+import { apiRequest, guard404, ApiError, FeatureUnavailableError } from "./client";
+
+export { FeatureUnavailableError };
+
+// EditorShare is one config-share the signed-in config_editor may edit,
+// as listed by GET /api/teams/{id}/config-editor/shares.
+export interface EditorShare {
+  id: string;
+  bot_id: string;
+  label: string;
+  category: string;
+  config_path: string;
+  read_only: boolean;
+}
+
+// EditorConfigResponse mirrors GET .../shares/{sid}/config. `config` is the
+// file projected to the editable-field set only; `sha` is the
+// optimistic-concurrency token that must be echoed back on PATCH.
+export interface EditorConfigResponse {
+  config: Record<string, unknown>;
+  sha: string;
+  bot_id: string;
+  label: string;
+  category: string;
+  config_path: string;
+  read_only: boolean;
+}
+
+// EditorPatchInput is the PATCH body: the base sha the edit was made against
+// plus a sparse nested-object patch carrying ONLY the changed leaves.
+export interface EditorPatchInput {
+  sha: string;
+  patch: Record<string, unknown>;
+}
+
+// EditorPatchResult is the discriminated outcome of a PATCH. Modeled on the
+// proven ConfigShare result shape:
+//   - "ok"          — 200; carries the new sha + list of changed dotted paths.
+//   - "conflict"    — 409; the file changed under us. Carries the FRESH server
+//                     projection + sha so the caller can render "yours vs
+//                     theirs" and require an explicit overwrite. NEVER auto-retry.
+//   - "not_editable"— 400; a field in the patch is off the editable list.
+export type EditorPatchResult =
+  | { kind: "ok"; sha: string; changed: string[] }
+  | { kind: "conflict"; config: Record<string, unknown>; sha: string }
+  | { kind: "not_editable"; message: string };
+
+function teamBase(teamID: string): string {
+  return `/api/teams/${encodeURIComponent(teamID)}/config-editor`;
+}
+
+// listEditorShares returns the config-shares the active team exposes to its
+// config_editor members. 404 (feature disabled on this server) surfaces as a
+// typed FeatureUnavailableError.
+export function listEditorShares(teamID: string): Promise<EditorShare[]> {
+  return guard404("config-editor", async () => {
+    const r = await apiRequest<{ shares: EditorShare[] }>(`${teamBase(teamID)}/shares`);
+    return r.shares ?? [];
+  });
+}
+
+// getEditorConfig loads the editable projection of one share plus its sha.
+export function getEditorConfig(
+  teamID: string,
+  shareID: string,
+): Promise<EditorConfigResponse> {
+  return guard404("config-editor", () =>
+    apiRequest<EditorConfigResponse>(
+      `${teamBase(teamID)}/shares/${encodeURIComponent(shareID)}/config`,
+    ),
+  );
+}
+
+// patchEditorConfig submits {sha, patch} and normalises the three server
+// outcomes into EditorPatchResult. On a 409 the shared apiRequest collapses
+// the error body to its message, so we re-read the fresh projection via
+// getEditorConfig to recover the current {config, sha} for the conflict view —
+// one extra round-trip only on the rare conflict path, and it stays entirely
+// on the shared (cookie + silent-refresh) client rather than a raw fetch.
+export async function patchEditorConfig(
+  teamID: string,
+  shareID: string,
+  input: EditorPatchInput,
+): Promise<EditorPatchResult> {
+  try {
+    const r = await apiRequest<{ sha: string; changed?: string[] }>(
+      `${teamBase(teamID)}/shares/${encodeURIComponent(shareID)}/config`,
+      { method: "PATCH", body: JSON.stringify(input) },
+    );
+    return { kind: "ok", sha: r.sha, changed: r.changed ?? [] };
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 409) {
+      const fresh = await getEditorConfig(teamID, shareID);
+      return { kind: "conflict", config: fresh.config, sha: fresh.sha };
+    }
+    if (err instanceof ApiError && err.status === 400) {
+      return { kind: "not_editable", message: err.message };
+    }
+    // 401 (session expiry) is handled inside apiRequest (silent refresh, else
+    // global sign-out); anything else is a genuine failure — propagate it.
+    throw err;
+  }
+}

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -2723,6 +2723,46 @@ export interface paths {
         patch: operations["patchTeamsByIdBotsByBotIdBindingsByBindingId"];
         trace?: never;
     };
+    "/api/teams/{id}/config-editor/shares": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** GET /api/teams/{id}/config-editor/shares */
+        get: operations["getTeamsByIdConfigEditorShares"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/teams/{id}/config-editor/shares/{sid}/config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                sid: string;
+            };
+            cookie?: never;
+        };
+        /** GET /api/teams/{id}/config-editor/shares/{sid}/config */
+        get: operations["getTeamsByIdConfigEditorSharesBySidConfig"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** PATCH /api/teams/{id}/config-editor/shares/{sid}/config */
+        patch: operations["patchTeamsByIdConfigEditorSharesBySidConfig"];
+        trace?: never;
+    };
     "/api/teams/{id}/config-shares": {
         parameters: {
             query?: never;
@@ -8162,6 +8202,68 @@ export interface operations {
                 id: string;
                 bot_id: string;
                 binding_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getTeamsByIdConfigEditorShares: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getTeamsByIdConfigEditorSharesBySidConfig: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                sid: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    patchTeamsByIdConfigEditorSharesBySidConfig: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                sid: string;
             };
             cookie?: never;
         };

--- a/studio/src/auth/AuthContext.tsx
+++ b/studio/src/auth/AuthContext.tsx
@@ -280,7 +280,15 @@ export function isLocalIdentity(user: UserView | null | undefined): boolean {
 // 403 message).
 export function hasRole(role: Role | null, want: Role | "super-admin"): boolean {
   if (!role) return false;
-  const order: Record<Role, number> = { viewer: 1, member: 2, admin: 3, owner: 4 };
+  // config_editor is least-privilege (0): it satisfies no viewer/member/admin/
+  // owner requirement — it can only reach the config editor, never the studio.
+  const order: Record<Role, number> = {
+    config_editor: 0,
+    viewer: 1,
+    member: 2,
+    admin: 3,
+    owner: 4,
+  };
   if (want === "super-admin") return false; // checked separately via user.is_super_admin
   return order[role] >= order[want];
 }

--- a/studio/src/views/ConfigEditorShell.tsx
+++ b/studio/src/views/ConfigEditorShell.tsx
@@ -1,0 +1,858 @@
+/**
+ * ConfigEditorShell — the limited studio surface for the least-privilege
+ * `config_editor` team role.
+ *
+ * A config_editor is a real, cookie-authenticated team member who may do
+ * exactly ONE thing: edit their team's config-shares. They get no Sidebar, no
+ * runs/board/launch — just this shell (modeled on RestrictedShell): the brand
+ * header + a config-editor workspace.
+ *
+ * The network layer is @/api/configEditor, which rides the SHARED cookie
+ * client (credentials: "include"). This is deliberately NOT the isolated
+ * @/api/configShare (iws_-token, credentials:"omit") used by the anonymous
+ * /config/:id editor — that boundary is eslint-enforced under
+ * src/views/ConfigShare/**; this signed-in shell lives outside it.
+ *
+ * The field-editing UX mirrors the proven ConfigShare editor: a plain
+ * <textarea> for string fields (no markdown preview), a text-input list for
+ * array fields (feeds), Save that sends {sha, patch}, and a 409 conflict flow
+ * that shows "yours vs theirs" and NEVER auto-clobbers. Unlike ConfigShare
+ * (hard-wired to feeds+editorial), this shell renders whatever editable string
+ * / string-array leaves the server's projected config contains.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useAuth } from "@/auth/AuthContext";
+import { errorMessage } from "@/lib/errorHints";
+import {
+  getEditorConfig,
+  listEditorShares,
+  patchEditorConfig,
+  type EditorConfigResponse,
+  type EditorShare,
+} from "@/api/configEditor";
+import { BrandMark } from "@/components/ui/BrandMark";
+import { ThemeToggle } from "@/components/ui/ThemeToggle";
+import {
+  BrandWordmark,
+  Button,
+  Card,
+  Dialog,
+  EmptyState,
+  FieldLabel,
+  InlineBanner,
+  Input,
+  Spinner,
+  Textarea,
+} from "@/components/ui";
+
+// ---------------------------------------------------------------------------
+// Editable-field model — walk the server's projected config into a flat list
+// of editable string / string-array leaves.
+// ---------------------------------------------------------------------------
+
+type FieldKind = "string" | "array";
+type FieldValue = string | string[];
+
+interface EditableField {
+  /** Dotted path from the config root, e.g. "categories.a11y.feeds". */
+  path: string;
+  /** Last path segment, used as the field label ("feeds", "editorial"). */
+  leaf: string;
+  /** Dotted parent path ("categories › a11y"), "" for a top-level leaf. */
+  parentLabel: string;
+  kind: FieldKind;
+}
+
+const httpUrlPattern = /^https?:\/\/\S+$/i;
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((x) => typeof x === "string");
+}
+
+// walkEditableFields does a stable depth-first walk of the projection,
+// collecting every string leaf and every (all-string) array leaf. Nested
+// objects are recursed; numbers/booleans/null and arrays-of-objects are
+// skipped (nothing to render an input for). The server has already projected
+// `config` down to the editable surface, so in practice every leaf here is
+// something the PATCH accepts.
+function walkEditableFields(
+  config: Record<string, unknown>,
+  prefix: string[] = [],
+): EditableField[] {
+  const out: EditableField[] = [];
+  for (const key of Object.keys(config)) {
+    const value = config[key];
+    const path = [...prefix, key];
+    if (typeof value === "string") {
+      out.push(fieldAt(path, "string"));
+    } else if (isStringArray(value)) {
+      out.push(fieldAt(path, "array"));
+    } else if (value && typeof value === "object" && !Array.isArray(value)) {
+      out.push(...walkEditableFields(value as Record<string, unknown>, path));
+    }
+    // else: not an editable leaf — skip.
+  }
+  return out;
+}
+
+function fieldAt(path: string[], kind: FieldKind): EditableField {
+  const leaf = path[path.length - 1] ?? "";
+  const parent = path.slice(0, -1);
+  return {
+    path: path.join("."),
+    leaf,
+    parentLabel: parent.join(" › "),
+    kind,
+  };
+}
+
+function getPath(obj: Record<string, unknown>, path: string): unknown {
+  let cur: unknown = obj;
+  for (const p of path.split(".")) {
+    if (cur === null || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[p];
+  }
+  return cur;
+}
+
+function setPath(target: Record<string, unknown>, path: string, value: unknown): void {
+  const parts = path.split(".");
+  const last = parts.length - 1;
+  let cur: Record<string, unknown> = target;
+  for (let i = 0; i < last; i++) {
+    const p = parts[i];
+    if (p === undefined) continue;
+    const next = cur[p];
+    if (next === null || typeof next !== "object" || Array.isArray(next)) {
+      cur[p] = {};
+    }
+    cur = cur[p] as Record<string, unknown>;
+  }
+  const leaf = parts[last];
+  if (leaf !== undefined) cur[leaf] = value;
+}
+
+function readStringAt(config: Record<string, unknown>, path: string): string {
+  const v = getPath(config, path);
+  return typeof v === "string" ? v : "";
+}
+
+function readArrayAt(config: Record<string, unknown>, path: string): string[] {
+  const v = getPath(config, path);
+  return isStringArray(v) ? v.slice() : [];
+}
+
+type Draft = Record<string, FieldValue>;
+
+// initDraft projects the config into the form's editable values. Empty arrays
+// default to a single blank row so a first-time editor sees a field to type in.
+function initDraft(fields: EditableField[], config: Record<string, unknown>): Draft {
+  const draft: Draft = {};
+  for (const f of fields) {
+    if (f.kind === "string") {
+      draft[f.path] = readStringAt(config, f.path);
+    } else {
+      const arr = readArrayAt(config, f.path);
+      draft[f.path] = arr.length > 0 ? arr : [""];
+    }
+  }
+  return draft;
+}
+
+function normArray(a: string[]): string[] {
+  return a.map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+function fieldChanged(field: EditableField, draft: Draft, baseline: Draft): boolean {
+  const d = draft[field.path];
+  const b = baseline[field.path];
+  if (field.kind === "string") return (d as string) !== (b as string);
+  return !arraysEqual(normArray(d as string[]), normArray(b as string[]));
+}
+
+// buildPatch turns the changed leaves into a sparse nested-object PATCH body.
+// Strings are sent as-is (whitespace can be meaningful); arrays are trimmed
+// with empty rows dropped.
+function buildPatch(
+  fields: EditableField[],
+  draft: Draft,
+  baseline: Draft,
+): Record<string, unknown> {
+  const patch: Record<string, unknown> = {};
+  for (const f of fields) {
+    if (!fieldChanged(f, draft, baseline)) continue;
+    const value =
+      f.kind === "string" ? (draft[f.path] as string) : normArray(draft[f.path] as string[]);
+    setPath(patch, f.path, value);
+  }
+  return patch;
+}
+
+// ---------------------------------------------------------------------------
+// Shell chrome — brand header + Sign out, matching RestrictedShell.
+// ---------------------------------------------------------------------------
+
+export default function ConfigEditorShell() {
+  const { user, signOut, activeTeamID, activeTeam } = useAuth();
+  return (
+    <div className="flex h-screen min-h-0 flex-col bg-surface-0 text-fg-default">
+      <header className="flex items-center justify-between border-b border-border-subtle px-4 py-3 sm:px-6">
+        <div className="flex items-center gap-2.5">
+          <BrandMark className="h-7 w-7" />
+          <BrandWordmark />
+          <span aria-hidden className="text-fg-subtle">
+            /
+          </span>
+          <span className="text-sm font-medium text-fg-default">Config editor</span>
+        </div>
+        <div className="flex items-center gap-2 sm:gap-3">
+          <ThemeToggle />
+          <span className="hidden text-xs text-fg-muted sm:inline">{user?.email}</span>
+          <Button variant="secondary" size="sm" onClick={() => void signOut()}>
+            Sign out
+          </Button>
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        <main className="mx-auto w-full max-w-5xl px-4 py-6 sm:px-6">
+          {activeTeamID ? (
+            <Workspace teamID={activeTeamID} teamName={activeTeam?.team_name} />
+          ) : (
+            <InlineBanner tone="warning" layout="inline" title="No active team">
+              Your account has no active team, so there are no config-shares to edit.
+              Ask an administrator to add you to a team.
+            </InlineBanner>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Workspace — share list (master) + editor (detail).
+// ---------------------------------------------------------------------------
+
+function Workspace({ teamID, teamName }: { teamID: string; teamName?: string }) {
+  const [shares, setShares] = useState<EditorShare[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const list = await listEditorShares(teamID);
+      setShares(list);
+      // Auto-select the first share so the editor isn't an empty right pane.
+      setSelectedId((cur) => cur ?? list[0]?.id ?? null);
+    } catch (err) {
+      setShares([]);
+      setError(errorMessage(err));
+    }
+  }, [teamID]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (shares === null && !error) {
+    return (
+      <div className="flex items-center gap-2 p-6 text-sm text-fg-muted">
+        <Spinner /> Loading config-shares…
+      </div>
+    );
+  }
+
+  const selected = shares?.find((s) => s.id === selectedId) ?? null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h1 className="text-lg font-semibold text-fg-default">Config editor</h1>
+        <p className="text-sm text-fg-muted">
+          Edit the config-shares
+          {teamName ? (
+            <>
+              {" "}for <span className="font-medium text-fg-default">{teamName}</span>
+            </>
+          ) : null}
+          . Only the fields listed for each share are editable.
+        </p>
+      </div>
+
+      {error && (
+        <InlineBanner tone="danger" layout="inline" title="Couldn't load config-shares">
+          {error}
+          <div className="mt-2">
+            <Button variant="secondary" size="sm" onClick={() => void load()}>
+              Try again
+            </Button>
+          </div>
+        </InlineBanner>
+      )}
+
+      {shares && shares.length === 0 && !error ? (
+        <Card>
+          <EmptyState
+            title="No config-shares"
+            message="This team has no config-shares assigned to you yet. Ask an administrator to create one."
+          />
+        </Card>
+      ) : shares && shares.length > 0 ? (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-[minmax(220px,300px)_1fr]">
+          <ShareList
+            shares={shares}
+            selectedId={selectedId}
+            onSelect={(id) => setSelectedId(id)}
+          />
+          <div className="min-w-0">
+            {selected ? (
+              <ShareEditor key={selected.id} teamID={teamID} share={selected} />
+            ) : (
+              <Card>
+                <EmptyState message="Select a config-share on the left to edit it." />
+              </Card>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ShareList({
+  shares,
+  selectedId,
+  onSelect,
+}: {
+  shares: EditorShare[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <ul className="flex flex-col gap-2" aria-label="Config-shares">
+      {shares.map((s) => {
+        const active = s.id === selectedId;
+        return (
+          <li key={s.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(s.id)}
+              aria-current={active ? "true" : undefined}
+              className={`w-full rounded-[var(--radius-lg)] border px-3 py-2 text-left transition-colors ${
+                active
+                  ? "border-accent bg-accent-soft/50"
+                  : "border-border-default bg-surface-1 hover:border-border-strong"
+              }`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="truncate text-sm font-medium text-fg-default">
+                  {s.label || s.bot_id || s.id}
+                </span>
+                {s.read_only && (
+                  <span className="shrink-0 text-caption text-fg-subtle">read-only</span>
+                )}
+              </div>
+              <div className="mt-0.5 flex flex-wrap items-center gap-x-2 text-caption text-fg-subtle">
+                {s.bot_id && <span className="truncate">{s.bot_id}</span>}
+                {s.category && (
+                  <>
+                    <span aria-hidden>·</span>
+                    <span className="truncate">{s.category}</span>
+                  </>
+                )}
+              </div>
+              {s.config_path && (
+                <div className="mt-0.5 truncate font-mono text-caption text-fg-subtle">
+                  {s.config_path}
+                </div>
+              )}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ShareEditor — load one share's projected config, edit its fields, save.
+// Remounted (key={share.id}) on selection so all state resets cleanly.
+// ---------------------------------------------------------------------------
+
+type SaveStatus =
+  | { kind: "idle" }
+  | { kind: "saved"; changed: number }
+  | { kind: "error"; message: string };
+
+function ShareEditor({ teamID, share }: { teamID: string; share: EditorShare }) {
+  const [meta, setMeta] = useState<EditorConfigResponse | null>(null);
+  const [fields, setFields] = useState<EditableField[]>([]);
+  const [baseline, setBaseline] = useState<Draft>({});
+  const [draft, setDraft] = useState<Draft>({});
+  const [sha, setSha] = useState("");
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState<SaveStatus>({ kind: "idle" });
+  const [conflict, setConflict] = useState<{ serverDraft: Draft; serverSha: string } | null>(
+    null,
+  );
+  const bootRef = useRef(false);
+
+  const bootstrap = useCallback(async () => {
+    setLoadError(null);
+    try {
+      const cfg = await getEditorConfig(teamID, share.id);
+      const fs = walkEditableFields(cfg.config);
+      const d = initDraft(fs, cfg.config);
+      setMeta(cfg);
+      setFields(fs);
+      setBaseline(d);
+      setDraft(d);
+      setSha(cfg.sha);
+    } catch (err) {
+      setLoadError(errorMessage(err));
+    }
+  }, [teamID, share.id]);
+
+  useEffect(() => {
+    if (bootRef.current) return;
+    bootRef.current = true;
+    void bootstrap();
+  }, [bootstrap]);
+
+  const readOnly = meta?.read_only ?? share.read_only;
+  const dirty = useMemo(
+    () => fields.some((f) => fieldChanged(f, draft, baseline)),
+    [fields, draft, baseline],
+  );
+
+  const setField = useCallback((path: string, value: FieldValue) => {
+    setDraft((prev) => ({ ...prev, [path]: value }));
+    setStatus({ kind: "idle" });
+  }, []);
+
+  const onSave = useCallback(
+    async (forcedSha?: string) => {
+      if (readOnly) return;
+      const patch = buildPatch(fields, draft, baseline);
+      if (Object.keys(patch).length === 0) return;
+      setSaving(true);
+      setStatus({ kind: "idle" });
+      try {
+        const result = await patchEditorConfig(teamID, share.id, {
+          sha: forcedSha ?? sha,
+          patch,
+        });
+        if (result.kind === "conflict") {
+          setConflict({
+            serverDraft: initDraft(fields, result.config),
+            serverSha: result.sha,
+          });
+          setStatus({
+            kind: "error",
+            message: "Someone else edited this file — review the differences before saving.",
+          });
+          return;
+        }
+        if (result.kind === "not_editable") {
+          setStatus({ kind: "error", message: result.message });
+          return;
+        }
+        setBaseline({ ...draft });
+        setSha(result.sha);
+        setStatus({ kind: "saved", changed: result.changed.length });
+        setConflict(null);
+      } catch (err) {
+        setStatus({ kind: "error", message: errorMessage(err) });
+      } finally {
+        setSaving(false);
+      }
+    },
+    [readOnly, fields, draft, baseline, teamID, share.id, sha],
+  );
+
+  if (loadError) {
+    return (
+      <InlineBanner tone="danger" layout="inline" title="Couldn't load this config-share">
+        {loadError}
+        <div className="mt-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => {
+              bootRef.current = false;
+              void bootstrap();
+            }}
+          >
+            Try again
+          </Button>
+        </div>
+      </InlineBanner>
+    );
+  }
+
+  if (!meta) {
+    return (
+      <div className="flex items-center gap-2 p-6 text-sm text-fg-muted">
+        <Spinner /> Loading configuration…
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <InlineBanner
+        tone="info"
+        layout="inline"
+        title={`Scoped editor — ${share.label || share.bot_id || share.id}`}
+      >
+        Editing {share.category ? <strong>{share.category}</strong> : "the config"} of{" "}
+        <code className="font-mono">{meta.config_path || share.config_path}</code>. Only the
+        fields below are editable — everything else in the file is out of scope.
+      </InlineBanner>
+
+      {readOnly && (
+        <InlineBanner tone="info" layout="inline" title="Read-only">
+          You have read-only access to this share. You can review the values below but Save
+          is disabled.
+        </InlineBanner>
+      )}
+
+      {fields.length === 0 ? (
+        <Card>
+          <EmptyState message="This config-share exposes no editable fields." />
+        </Card>
+      ) : (
+        fields.map((f) =>
+          f.kind === "string" ? (
+            <StringField
+              key={f.path}
+              field={f}
+              value={draft[f.path] as string}
+              disabled={readOnly}
+              onChange={(v) => setField(f.path, v)}
+            />
+          ) : (
+            <ArrayField
+              key={f.path}
+              field={f}
+              value={draft[f.path] as string[]}
+              disabled={readOnly}
+              onChange={(v) => setField(f.path, v)}
+            />
+          ),
+        )
+      )}
+
+      {fields.length > 0 && (
+        <div className="sticky bottom-0 -mx-4 border-t border-border-subtle bg-surface-0/95 px-4 py-3 backdrop-blur sm:-mx-6 sm:px-6">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <StatusLine status={status} readOnly={readOnly} dirty={dirty} />
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={saving || !dirty || readOnly}
+                onClick={() => {
+                  setDraft(baseline);
+                  setStatus({ kind: "idle" });
+                }}
+              >
+                Reset
+              </Button>
+              <Button
+                variant="primary"
+                size="md"
+                loading={saving}
+                disabled={saving || !dirty || readOnly}
+                onClick={() => void onSave()}
+              >
+                Save changes
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {conflict && (
+        <ConflictDialog
+          fields={fields}
+          yours={draft}
+          server={conflict.serverDraft}
+          onCancel={() => setConflict(null)}
+          onOverwrite={() => void onSave(conflict.serverSha)}
+          onAdoptServer={() => {
+            setDraft(conflict.serverDraft);
+            setBaseline(conflict.serverDraft);
+            setSha(conflict.serverSha);
+            setConflict(null);
+            setStatus({ kind: "idle" });
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Field widgets — a plain textarea for strings, an add/remove list for arrays.
+// ---------------------------------------------------------------------------
+
+function StringField({
+  field,
+  value,
+  disabled,
+  onChange,
+}: {
+  field: EditableField;
+  value: string;
+  disabled: boolean;
+  onChange: (v: string) => void;
+}) {
+  const multiline = value.includes("\n") || value.length > 80;
+  return (
+    <Card>
+      <FieldLabel help={field.parentLabel || undefined}>{field.leaf}</FieldLabel>
+      <Textarea
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+        rows={multiline ? 8 : 3}
+        className="font-mono"
+      />
+    </Card>
+  );
+}
+
+function ArrayField({
+  field,
+  value,
+  disabled,
+  onChange,
+}: {
+  field: EditableField;
+  value: string[];
+  disabled: boolean;
+  onChange: (v: string[]) => void;
+}) {
+  // Feed lists are the common case and get url-typed inputs + validation;
+  // any other array leaf falls back to plain text rows.
+  const isFeeds = field.leaf === "feeds";
+  const rows = value.length > 0 ? value : [""];
+  const setAt = (i: number, v: string) => {
+    const next = rows.slice();
+    next[i] = v;
+    onChange(next);
+  };
+  const removeAt = (i: number) => {
+    const next = rows.slice();
+    next.splice(i, 1);
+    if (next.length === 0) next.push("");
+    onChange(next);
+  };
+  const count = rows.filter((r) => r.trim().length > 0).length;
+  return (
+    <Card>
+      <div className="mb-2 flex items-baseline justify-between">
+        <FieldLabel help={field.parentLabel || undefined}>{field.leaf}</FieldLabel>
+        <span className="text-caption text-fg-subtle">
+          {count} item{count === 1 ? "" : "s"}
+        </span>
+      </div>
+      <ul className="flex flex-col gap-2">
+        {rows.map((item, i) => {
+          const trimmed = item.trim();
+          const err = isFeeds && trimmed.length > 0 && !httpUrlPattern.test(trimmed);
+          return (
+            <li key={i} className="flex items-center gap-2">
+              <Input
+                type={isFeeds ? "url" : "text"}
+                inputMode={isFeeds ? "url" : undefined}
+                autoComplete="off"
+                spellCheck={false}
+                size="md"
+                value={item}
+                error={err}
+                disabled={disabled}
+                placeholder={isFeeds ? "https://example.org/feed.xml" : ""}
+                aria-label={`${field.leaf} ${i + 1}`}
+                onChange={(e) => setAt(i, e.target.value)}
+                className="font-mono"
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={disabled}
+                onClick={() => removeAt(i)}
+                aria-label={`Remove ${field.leaf} ${i + 1}`}
+              >
+                Remove
+              </Button>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="mt-2">
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={disabled}
+          onClick={() => onChange([...rows, ""])}
+        >
+          + Add
+        </Button>
+      </div>
+    </Card>
+  );
+}
+
+function StatusLine({
+  status,
+  readOnly,
+  dirty,
+}: {
+  status: SaveStatus;
+  readOnly: boolean;
+  dirty: boolean;
+}) {
+  if (readOnly) return <span className="text-xs text-fg-subtle">Read-only share</span>;
+  if (status.kind === "saved") {
+    return (
+      <span className="text-xs text-success-fg">
+        Saved · {status.changed} field{status.changed === 1 ? "" : "s"} updated
+      </span>
+    );
+  }
+  if (status.kind === "error") {
+    return <span className="text-xs text-danger-fg">{status.message}</span>;
+  }
+  return (
+    <span className="text-xs text-fg-subtle">{dirty ? "Unsaved changes" : "No changes"}</span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Conflict resolution — explicit user action, never a silent retry.
+// ---------------------------------------------------------------------------
+
+function ConflictDialog({
+  fields,
+  yours,
+  server,
+  onCancel,
+  onOverwrite,
+  onAdoptServer,
+}: {
+  fields: EditableField[];
+  yours: Draft;
+  server: Draft;
+  onCancel: () => void;
+  onOverwrite: () => void;
+  onAdoptServer: () => void;
+}) {
+  // Only surface the leaves that actually differ between the two versions.
+  const diffed = useMemo(
+    () => fields.filter((f) => fieldChanged(f, yours, server)),
+    [fields, yours, server],
+  );
+  return (
+    <Dialog
+      open
+      onOpenChange={(v) => {
+        if (!v) onCancel();
+      }}
+      title="This config changed on the server"
+      description="Someone else edited the file after you opened it. Review the differences below and choose how to proceed — no automatic retry."
+      widthClass="max-w-3xl"
+      stack="confirm"
+      footer={
+        <>
+          <Button variant="ghost" size="sm" onClick={onCancel}>
+            Keep editing
+          </Button>
+          <Button variant="secondary" size="sm" onClick={onAdoptServer}>
+            Use the server version
+          </Button>
+          <Button variant="danger" size="sm" onClick={onOverwrite}>
+            Overwrite with mine
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        {diffed.map((f) => (
+          <div key={f.path}>
+            <div className="mb-1 text-caption font-semibold uppercase tracking-wider text-fg-subtle">
+              {f.parentLabel ? `${f.parentLabel} › ${f.leaf}` : f.leaf}
+            </div>
+            <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+              <ConflictPane title="Your draft" field={f} value={yours[f.path]} />
+              <ConflictPane
+                title="Server version (current)"
+                field={f}
+                value={server[f.path]}
+                highlight
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </Dialog>
+  );
+}
+
+function ConflictPane({
+  title,
+  field,
+  value,
+  highlight = false,
+}: {
+  title: string;
+  field: EditableField;
+  value?: FieldValue;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={`rounded-md border p-3 text-xs ${
+        highlight ? "border-accent bg-accent-soft/50" : "border-border-default bg-surface-2"
+      }`}
+    >
+      <h3 className="mb-1 text-caption font-semibold uppercase tracking-wider text-fg-subtle">
+        {title}
+      </h3>
+      {field.kind === "array" ? (
+        (() => {
+          const items = normArray(Array.isArray(value) ? value : []);
+          return items.length === 0 ? (
+            <p className="italic text-fg-subtle">empty</p>
+          ) : (
+            <ul className="space-y-0.5 font-mono">
+              {items.map((it, i) => (
+                <li key={i} className="truncate">
+                  {it}
+                </li>
+              ))}
+            </ul>
+          );
+        })()
+      ) : (
+        <pre className="whitespace-pre-wrap wrap-break-word font-mono text-fg-default">
+          {(typeof value === "string" ? value : "") || (
+            <span className="italic text-fg-subtle">empty</span>
+          )}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/studio/src/views/teams/TeamPage.tsx
+++ b/studio/src/views/teams/TeamPage.tsx
@@ -28,7 +28,17 @@ import InviteLinkPanel from "@/components/shared/InviteLinkPanel";
 import AuditTab from "./tabs/AuditTab";
 import MemoryTab from "./tabs/MemoryTab";
 
-const ROLES = ["viewer", "member", "admin", "owner"] as const;
+// config_editor is prepended (index 0) so it reads as the least-privileged
+// role: the demotion-confirm heuristic below (ROLES.indexOf comparison)
+// correctly flags any downgrade *to* config_editor as a demotion, and it
+// mirrors the access ladder in @/api/auth.
+const ROLES = ["config_editor", "viewer", "member", "admin", "owner"] as const;
+
+// roleLabel gives the technical `config_editor` string a friendly display
+// name; every other role renders as-is (matching the existing lowercase UI).
+function roleLabel(role: string): string {
+  return role === "config_editor" ? "Config editor" : role;
+}
 
 // SSO, Usage, members-roster and billing are ORG-level — they live on the Org
 // settings page (/orgs/:id). The team page keeps the team's own administrative
@@ -88,7 +98,9 @@ export default function TeamPage() {
       <span className="text-sm font-semibold">Team not found</span>
     ),
     right: team ? (
-      <span className="text-xs text-fg-muted">Your role: {activeRole ?? "—"}</span>
+      <span className="text-xs text-fg-muted">
+        Your role: {activeRole ? roleLabel(activeRole) : "—"}
+      </span>
     ) : null,
   });
 
@@ -266,7 +278,7 @@ function Members({ teamID, canManage }: { teamID: string; canManage: boolean }) 
               >
                 {ROLES.map((r) => (
                   <option key={r} value={r}>
-                    {r}
+                    {roleLabel(r)}
                   </option>
                 ))}
               </Select>
@@ -315,12 +327,12 @@ function Members({ teamID, canManage }: { teamID: string; canManage: boolean }) 
                     >
                       {ROLES.map((r) => (
                         <option key={r} value={r}>
-                          {r}
+                          {roleLabel(r)}
                         </option>
                       ))}
                     </Select>
                   ) : (
-                    m.role
+                    roleLabel(m.role)
                   )}
                 </Td>
                 <Td align="right">
@@ -356,7 +368,7 @@ function Members({ teamID, canManage }: { teamID: string; canManage: boolean }) 
               {invs.map((i) => (
                 <Tr key={i.id}>
                   <Td>{i.email}</Td>
-                  <Td>{i.role}</Td>
+                  <Td>{roleLabel(i.role)}</Td>
                   <Td className="text-fg-muted">
                     {new Date(i.expires_at).toLocaleString()}
                   </Td>


### PR DESCRIPTION
A second, complementary way to reach the scoped config-share editor ([ADR-076](docs/adr/076-scoped-config-share-editor.md)): a **real user, authenticated via the normal session (ultimately org SSO), holding a least-privilege `config_editor` capability on a team**, edits that team's config-shares WITHOUT an `iws_` token, through a locked-down studio shell. The public capability-URL/token path is **untouched** — the two are complementary (external account-less token vs internal identity). See [ADR-078](docs/adr/078-config-editor-role-sso-team-scoped-access.md).

Motivation: for the actual first users — internal design/a11y colleagues curating the veille config — a bearer token in a URL has no identity/attribution, no revoke-by-person, and needed the "never expires" opt-out (a permanent secret). SSO-team-scoped access fixes all three: real identity, revoke-by-team-membership, no token/expiry.

## Backend (security core)
- `config_editor` is an **orthogonal capability, not a ladder rung** (rank 0, so `AtLeast` never places it in viewer<member<admin<owner) yet `Valid()` so it round-trips through the JWT + member API. **Golden test** locks the orthogonality.
- `canViewTeam` switches `Valid()`→`AtLeast(RoleViewer)` — **identical for the four ladder roles, excludes config_editor** (closes the over-grant hazard where a `Valid()` check would admit any new role). New `canEditConfigShares` gate admits the capability + team/org admins only.
- New authenticated surface `/api/teams/{id}/config-editor/shares[/{sid}/config]` (GET list reduced view, GET projected config, PATCH) reusing the **same** `ProjectedRead`/`ApplyEdit` as the token path via a shared `applyShareEditAndRespond` — the projection + fail-closed allow-list can never drift. `Delivery.actor` (`share:` vs `user:`) for attribution.
- SSO: config_editor is assignable via a GitHub team grant (un-capped, unlike admin) or an OIDC default_role. It does **NOT** mirror to an org membership (`OrgRoleForTeamRole`→"" + `grantOrgMembershipForTeam` skip), so it never passes `canViewOrg`; login still resolves fine (empty OrgRole).

## Frontend
- `AuthGate` renders a locked-down `ConfigEditorShell` when the active role is `config_editor` — above `isRestricted`, below the `/invitations/accept` + `/cli-auth` + `/config/:id` side-doors. **No Sidebar, no router** — every route resolves to it.
- The shell is a master/detail config editor (share list → per-field textarea/array widgets → Save with sha optimistic-concurrency + 409 "yours vs theirs", never auto-clobber), on a **cookie-session client** (`api/configEditor.ts`), distinct from the `iws_`-token `configShare.ts`.
- Operators assign the role from the team members picker (`config_editor` in `ROLES`, "Config editor" label). `hasRole(config_editor,…)=0` — satisfies no operator UI gate.

## Tests
Golden RBAC (config_editor rejected by every standard gate, admitted by canEditConfigShares; viewer inverse; admin both); role orthogonality; no-org-mirror; SSO grant un-capped; end-to-end editor flow (reduced list no token leak, scoped projection, patch + `user:` delivery, viewer 403). Full `pkg/server` (40s) + `identity` + `auth` + `configshare` green; gofmt + vet; studio tsc + eslint; OpenAPI regenerated.

MVP scope: team-scoped (a config_editor edits all the team's config-shares). Per-bot/per-share member binding is a documented follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)