### PR TITLE
feat(backend): add xAI Grok as a first-class claw provider

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -20,6 +20,7 @@ If you have **at least one** of:
   `~/.claude/.credentials.json` on Linux/WSL — "forfait")
 - `ANTHROPIC_API_KEY` set in your environment
 - `OPENAI_API_KEY` set in your environment
+- `XAI_API_KEY` set in your environment (xAI Grok)
 - `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT`
 - AWS credentials (Bedrock) or `GOOGLE_CLOUD_PROJECT` (Vertex)
 
@@ -359,14 +360,39 @@ claw-only).
 |---|---|
 | `anthropic` | `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` |
 | `openai` | `OPENAI_API_KEY`, **or** Codex CLI signed in via "Sign in with ChatGPT" (see `OpenAI via ChatGPT forfait` below) |
+| `xai` | `XAI_API_KEY` (xAI Grok — OpenAI-compatible chat completions at `api.x.ai`) |
 | `foundry` (Azure) | `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_ENDPOINT` |
 | `bedrock` | `AWS_REGION` or `AWS_DEFAULT_REGION` (full chain handled by AWS SDK) |
 | `vertex` | `GOOGLE_CLOUD_PROJECT` |
 
 When `model:` on the agent is also empty, the runtime substitutes a
 sensible default for the first available provider — currently
-`anthropic/claude-opus-4-8` for Anthropic and
-`openai/gpt-5.4-mini` for OpenAI.
+`anthropic/claude-opus-4-8` for Anthropic,
+`openai/gpt-5.4-mini` for OpenAI, and
+`xai/grok-3` for xAI.
+
+### xAI Grok (`model: "xai/…"`)
+
+xAI is a first-class claw provider. Set `XAI_API_KEY` (or store a BYOK
+key under provider `xai` in cloud mode) and point a node at a Grok
+model:
+
+```yaml
+agent planner:
+  backend: "claw"
+  model: "xai/grok-3"
+  # optional: model: "xai/grok-3-mini"  # reasoning variant
+```
+
+Optional `XAI_BASE_URL` overrides the host (default `https://api.x.ai`).
+A trailing `/v1` is stripped automatically so pasting the public
+OpenAI-SDK base URL (`https://api.x.ai/v1`) still works — claw's
+OpenAI-compatible client always appends `/v1/chat/completions`.
+
+In cloud mode the same key can be stored as a per-org BYOK record with
+`provider: xai` (see [byok.md](byok.md)). Sandboxed runs with
+`network: allowlist` already include `api.x.ai` in the `iterion-default`
+preset.
 
 For web search & fetch on claw (the `web_search`/`web_fetch` tools, the
 SearXNG → Brave → DuckDuckGo backend ladder, `ITERION_WEB_SEARCH`, and the

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -171,12 +171,12 @@ sandbox:
 
 The shipped **`iterion-default`** preset is the recommended
 starting point for allowlist mode: it covers the LLM endpoints
-(anthropic, openai, openrouter, bedrock, googleapis, azure,
-mistral) plus package registries (npm, PyPI, golang proxy) plus
-code hosts (github, gitlab, bitbucket) plus apt mirrors. It is
-**not** applied implicitly — operators name it explicitly so the
-default-open posture and the curated-allowlist posture are
-unambiguous from the YAML.
+(anthropic, openai, xAI/Grok, openrouter, bedrock, googleapis,
+azure, mistral, z.ai) plus package registries (npm, PyPI, golang
+proxy) plus code hosts (github, gitlab, bitbucket) plus apt
+mirrors. It is **not** applied implicitly — operators name it
+explicitly so the default-open posture and the curated-allowlist
+posture are unambiguous from the YAML.
 
 By default the proxy does NOT terminate TLS — only the CONNECT
 host:port is inspected, and the encrypted bytes pass through

--- a/pkg/backend/detect/detect.go
+++ b/pkg/backend/detect/detect.go
@@ -286,6 +286,7 @@ func detectClaw(prov []ProviderStatus) BackendStatus {
 	st.Hints = []string{
 		"no ANTHROPIC_API_KEY",
 		"no OPENAI_API_KEY",
+		"no XAI_API_KEY",
 		"no AZURE_OPENAI_API_KEY",
 		"no AWS region (Bedrock)",
 		"no GOOGLE_CLOUD_PROJECT (Vertex)",
@@ -324,6 +325,16 @@ func detectProviders() []ProviderStatus {
 			SuggestedModel: "anthropic/glm-5.2",
 		},
 		detectOpenAIProvider(),
+		{
+			// xAI Grok — claw drives it through the OpenAI-compatible
+			// client (registry providers["xai"]). Detection is a pure
+			// env probe: XAI_API_KEY. Suggested model matches claw's
+			// built-in registry alias (`grok` → grok-3).
+			Name:           "xai",
+			Available:      os.Getenv("XAI_API_KEY") != "",
+			Source:         envSource("XAI_API_KEY"),
+			SuggestedModel: "xai/grok-3",
+		},
 		{
 			Name:           "foundry",
 			Available:      os.Getenv("AZURE_OPENAI_API_KEY") != "" && os.Getenv("AZURE_OPENAI_ENDPOINT") != "",

--- a/pkg/backend/detect/detect_test.go
+++ b/pkg/backend/detect/detect_test.go
@@ -25,6 +25,9 @@ func isolateEnv(t *testing.T) {
 		// dev machine (a first-class supported provider) flips the anthropic
 		// provider off and turns detection tests red.
 		"ZAI_API_KEY",
+		// xAI Grok is a first-class claw provider (XAI_API_KEY); scrub so a
+		// host with a real key does not flip claw Available unexpectedly.
+		"XAI_API_KEY", "XAI_BASE_URL",
 		// OpenAI ChatGPT-forfait preference overrides are detection inputs.
 		"ITERION_OPENAI_USE_OAUTH",
 		"AWS_REGION", "AWS_DEFAULT_REGION",
@@ -342,6 +345,48 @@ func TestZAISuggestedModel(t *testing.T) {
 	}
 }
 
+func TestDetect_XAIProvider(t *testing.T) {
+	isolateEnv(t)
+
+	// Absent key → xai listed but unavailable.
+	r := Detect(context.Background())
+	xai := findProvider(t, r, "xai")
+	if xai.Available {
+		t.Fatalf("xai Available=true with no XAI_API_KEY")
+	}
+	if xai.SuggestedModel != "xai/grok-3" {
+		t.Fatalf("xai suggested = %q, want xai/grok-3", xai.SuggestedModel)
+	}
+
+	// Present key → available, source name only (no secret leak), and
+	// claw flips to available so auto-resolve can land on it.
+	t.Setenv("XAI_API_KEY", "xai-test-secret")
+	r = Detect(context.Background())
+	xai = findProvider(t, r, "xai")
+	if !xai.Available {
+		t.Fatal("xai Available=false with XAI_API_KEY set")
+	}
+	if xai.Source != "XAI_API_KEY" {
+		t.Fatalf("xai Source = %q, want XAI_API_KEY", xai.Source)
+	}
+	claw := findBackend(t, r, BackendClaw)
+	if !claw.Available {
+		t.Fatal("claw should be available when XAI_API_KEY is set")
+	}
+	if r.ResolvedDefault != BackendClaw {
+		t.Fatalf("ResolvedDefault = %q, want claw", r.ResolvedDefault)
+	}
+	// Never leak the key value into the report fields.
+	if strings.Contains(xai.Source, "xai-test-secret") {
+		t.Fatal("detect report leaks XAI_API_KEY value")
+	}
+	for _, src := range claw.Sources {
+		if strings.Contains(src, "xai-test-secret") {
+			t.Fatal("claw sources leak XAI_API_KEY value")
+		}
+	}
+}
+
 func TestCachedDetector_HonorsTTL(t *testing.T) {
 	isolateEnv(t)
 	cache := NewCachedDetector(0) // never expires
@@ -432,4 +477,15 @@ func findBackend(t *testing.T, r Report, name string) BackendStatus {
 	}
 	t.Fatalf("backend %q missing from report", name)
 	return BackendStatus{}
+}
+
+func findProvider(t *testing.T, r Report, name string) ProviderStatus {
+	t.Helper()
+	for _, p := range r.Providers {
+		if p.Name == name {
+			return p
+		}
+	}
+	t.Fatalf("provider %q missing from report", name)
+	return ProviderStatus{}
 }

--- a/pkg/backend/model/capabilities.go
+++ b/pkg/backend/model/capabilities.go
@@ -25,6 +25,8 @@ func curatedCapabilities(provider, modelID string) ModelCapabilities {
 		return anthropicCapabilities(modelID)
 	case "openai":
 		return openaiCapabilities(modelID)
+	case "xai":
+		return xaiCapabilities(modelID)
 	default:
 		// Conservative default: tool calling + temperature, no reasoning.
 		return ModelCapabilities{
@@ -94,5 +96,28 @@ func openaiCapabilities(modelID string) ModelCapabilities {
 		Reasoning:   isReasoning,
 		ToolCall:    true,
 		Temperature: !isReasoning,
+	}
+}
+
+// xaiCapabilities returns static capabilities for xAI Grok models.
+// Mirrors claw-code-go's openai provider isReasoningModel (grok-3-mini
+// always uses reasoning mode) and claw's built-in context window
+// (131_072 for the grok-2/3 family). Dynamic modelspecs overlay newer
+// numbers when the online aggregator has them.
+func xaiCapabilities(modelID string) ModelCapabilities {
+	lower := strings.ToLower(modelID)
+	// stripRoutingPrefix-equivalent: "xai/grok-3-mini" won't reach here
+	// (ParseModelSpec already strips the provider), but a nested prefix
+	// like "grok/grok-3-mini" is still possible if someone types it.
+	if idx := strings.LastIndex(lower, "/"); idx >= 0 {
+		lower = lower[idx+1:]
+	}
+	// claw: grok-3-mini always uses reasoning mode (rejects temperature).
+	isReasoning := lower == "grok-3-mini"
+	return ModelCapabilities{
+		Reasoning:     isReasoning,
+		ToolCall:      true,
+		Temperature:   !isReasoning,
+		ContextWindow: 131_072,
 	}
 }

--- a/pkg/backend/model/registry.go
+++ b/pkg/backend/model/registry.go
@@ -228,6 +228,46 @@ func (r *Registry) registerDefaults() {
 		p := foundryprovider.New()
 		return p.NewClient(withClientIdentity(api.ProviderConfig{APIKey: apiKey, Model: modelID}))
 	}
+	// xAI Grok — OpenAI-compatible chat completions at api.x.ai.
+	// Auth via XAI_API_KEY (or cloud BYOK under provider "xai"). Model
+	// specs look like `xai/grok-3`, `xai/grok-3-mini`, `xai/grok-4`.
+	// claw-code-go reuses the openai provider for xAI (SelectProvider
+	// maps "xai" → openaiprovider); we do the same so StreamResponse,
+	// tool calling, and reasoning-model detection stay shared.
+	r.providers["xai"] = func(modelID string) (api.APIClient, error) {
+		p := openaiprovider.New()
+		return p.NewClient(withClientIdentity(api.ProviderConfig{
+			APIKey:  os.Getenv("XAI_API_KEY"),
+			Model:   modelID,
+			BaseURL: xaiBaseURL(),
+		}))
+	}
+	r.providersWithKey["xai"] = func(modelID, apiKey string) (api.APIClient, error) {
+		p := openaiprovider.New()
+		return p.NewClient(withClientIdentity(api.ProviderConfig{
+			APIKey:  apiKey,
+			Model:   modelID,
+			BaseURL: xaiBaseURL(),
+		}))
+	}
+}
+
+// xaiBaseURL resolves the OpenAI-compatible host for xAI. Prefer an
+// explicit XAI_BASE_URL (operator / proxy override); otherwise the
+// published api.x.ai host. Trailing `/v1` is stripped so a user who
+// pastes the SDK-style base URL does not end up posting to
+// `…/v1/v1/chat/completions` (the openai client always appends
+// `/v1/chat/completions`).
+func xaiBaseURL() string {
+	base := strings.TrimSpace(os.Getenv("XAI_BASE_URL"))
+	if base == "" {
+		base = secrets.XAIDefaultBaseURL
+	}
+	base = strings.TrimRight(base, "/")
+	if strings.HasSuffix(strings.ToLower(base), "/v1") {
+		base = strings.TrimRight(base[:len(base)-3], "/")
+	}
+	return base
 }
 
 // withClientIdentity injects ITERION_LLM_USER_AGENT (the iterion-branded

--- a/pkg/backend/model/registry_xai_test.go
+++ b/pkg/backend/model/registry_xai_test.go
@@ -1,0 +1,116 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+func TestXAIBaseURL_Default(t *testing.T) {
+	t.Setenv("XAI_BASE_URL", "")
+	if got := xaiBaseURL(); got != secrets.XAIDefaultBaseURL {
+		t.Fatalf("xaiBaseURL() = %q, want %q", got, secrets.XAIDefaultBaseURL)
+	}
+}
+
+func TestXAIBaseURL_StripTrailingV1(t *testing.T) {
+	// Users copy the OpenAI-SDK style base URL from xAI docs
+	// (`https://api.x.ai/v1`); the openai client appends
+	// `/v1/chat/completions`, so we strip the trailing /v1.
+	t.Setenv("XAI_BASE_URL", "https://api.x.ai/v1/")
+	if got := xaiBaseURL(); got != "https://api.x.ai" {
+		t.Fatalf("xaiBaseURL() = %q, want https://api.x.ai", got)
+	}
+}
+
+func TestXAIBaseURL_ProxyOverride(t *testing.T) {
+	t.Setenv("XAI_BASE_URL", "https://proxy.example.com/xai")
+	if got := xaiBaseURL(); got != "https://proxy.example.com/xai" {
+		t.Fatalf("xaiBaseURL() = %q, want proxy host", got)
+	}
+}
+
+func TestRegistry_XAIProviderRegistered(t *testing.T) {
+	// Without a key the factory still builds a client — the openai
+	// provider only errors when APIKey is empty *and* no OAuth pair is
+	// present. We pass a dummy key via env so NewClient succeeds.
+	t.Setenv("XAI_API_KEY", "xai-test")
+	t.Setenv("XAI_BASE_URL", "")
+
+	r := NewRegistry()
+	client, err := r.Resolve("xai/grok-3")
+	if err != nil {
+		t.Fatalf("Resolve(xai/grok-3): %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
+
+	// Capabilities should resolve without error (xai is a known provider).
+	caps, err := r.Capabilities("xai/grok-3")
+	if err != nil {
+		t.Fatalf("Capabilities: %v", err)
+	}
+	if !caps.ToolCall {
+		t.Error("grok-3 should support tool calling")
+	}
+	if !caps.Temperature {
+		t.Error("grok-3 should accept temperature")
+	}
+	if caps.ContextWindow != 131_072 {
+		t.Errorf("ContextWindow = %d, want 131072", caps.ContextWindow)
+	}
+}
+
+func TestRegistry_XAIProviderWithKey(t *testing.T) {
+	// BYOK path: ResolveWithContext with a per-run key for "xai".
+	// Env empty so we prove the keyed factory is what built the client.
+	t.Setenv("XAI_API_KEY", "")
+	r := NewRegistry()
+
+	SetCredentialsLookup(func(ctx context.Context) (func(string) string, bool) {
+		return func(provider string) string {
+			if provider == "xai" {
+				return "byok-xai-key"
+			}
+			return ""
+		}, true
+	})
+	t.Cleanup(func() {
+		SetCredentialsLookup(func(context.Context) (func(string) string, bool) {
+			return nil, false
+		})
+	})
+
+	client, err := r.ResolveWithContext(context.Background(), "xai/grok-3-mini")
+	if err != nil {
+		t.Fatalf("ResolveWithContext: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected non-nil BYOK client")
+	}
+
+	// Env-only Resolve should fail (no XAI_API_KEY) — proves BYOK is
+	// the path that succeeded above rather than a silent env fallback.
+	if _, err := r.Resolve("xai/grok-3-mini"); err == nil {
+		t.Fatal("Resolve without env key should fail")
+	}
+}
+
+func TestXAICapabilities_ReasoningMini(t *testing.T) {
+	caps := curatedCapabilities("xai", "grok-3-mini")
+	if !caps.Reasoning {
+		t.Error("grok-3-mini should be Reasoning")
+	}
+	if caps.Temperature {
+		t.Error("grok-3-mini should not accept Temperature")
+	}
+	caps = curatedCapabilities("xai", "grok-3")
+	if caps.Reasoning {
+		t.Error("grok-3 should not be Reasoning by default")
+	}
+	if !caps.Temperature {
+		t.Error("grok-3 should accept Temperature")
+	}
+}

--- a/pkg/sandbox/netproxy/matcher_test.go
+++ b/pkg/sandbox/netproxy/matcher_test.go
@@ -213,6 +213,7 @@ func TestPresetIterionDefault(t *testing.T) {
 	allowed := []string{
 		"api.anthropic.com",
 		"api.openai.com",
+		"api.x.ai",
 		"registry.npmjs.org",
 		"github.com",
 		"raw.github.com",

--- a/pkg/sandbox/netproxy/preset.go
+++ b/pkg/sandbox/netproxy/preset.go
@@ -37,6 +37,11 @@ func iterionDefaultRules() []string {
 		"api.anthropic.com",
 		"api.openai.com",
 		"openrouter.ai",
+		// xAI Grok (OpenAI-compatible chat completions). Required for
+		// `model: "xai/grok-…"` under sandbox.network allowlist —
+		// without it the CONNECT proxy blocks the upstream and the
+		// claw call fails before any token is produced.
+		"api.x.ai",
 		"**.bedrock.amazonaws.com",
 		"**.googleapis.com",
 		"**.openai.azure.com",

--- a/pkg/secrets/byok.go
+++ b/pkg/secrets/byok.go
@@ -68,6 +68,13 @@ const (
 // registry agree without re-deriving the URL.
 const ZAIDefaultBaseURL = "https://api.z.ai/api/anthropic"
 
+// XAIDefaultBaseURL is the host claw's OpenAI-compatible client targets
+// for xAI Grok. The openai provider appends `/v1/chat/completions`, so
+// this value must NOT include a trailing `/v1` (unlike the public
+// OpenAI-SDK convention of `base_url=https://api.x.ai/v1`). Override
+// with `XAI_BASE_URL` when pointing at a proxy or regional endpoint.
+const XAIDefaultBaseURL = "https://api.x.ai"
+
 // Valid reports whether p is one of the known providers.
 func (p Provider) Valid() bool {
 	switch p {

--- a/pkg/server/backends_routes_test.go
+++ b/pkg/server/backends_routes_test.go
@@ -18,7 +18,7 @@ func TestBackendsDetectRouteShape(t *testing.T) {
 	for _, k := range []string{
 		"ITERION_BACKEND_PREFERENCE",
 		"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN",
-		"OPENAI_API_KEY",
+		"OPENAI_API_KEY", "XAI_API_KEY",
 		"AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT",
 		"AWS_REGION", "AWS_DEFAULT_REGION",
 		"GOOGLE_CLOUD_PROJECT",
@@ -54,6 +54,23 @@ func TestBackendsDetectRouteShape(t *testing.T) {
 	if got.ResolvedDefault != "" {
 		t.Fatalf("ResolvedDefault = %q, want empty (no creds)", got.ResolvedDefault)
 	}
+	// xai must appear in the providers list even when unavailable, so the
+	// studio can render it as a configure-me option.
+	foundXAI := false
+	for _, p := range got.Providers {
+		if p.Name == "xai" {
+			foundXAI = true
+			if p.Available {
+				t.Fatal("xai Available=true with no XAI_API_KEY")
+			}
+			if p.SuggestedModel != "xai/grok-3" {
+				t.Fatalf("xai SuggestedModel = %q", p.SuggestedModel)
+			}
+		}
+	}
+	if !foundXAI {
+		t.Fatal("xai provider missing from detect report")
+	}
 }
 
 // TestBackendsDetectReflectsAnthropic verifies that setting an env var is
@@ -61,7 +78,7 @@ func TestBackendsDetectRouteShape(t *testing.T) {
 func TestBackendsDetectReflectsAnthropic(t *testing.T) {
 	for _, k := range []string{
 		"ITERION_BACKEND_PREFERENCE",
-		"ANTHROPIC_AUTH_TOKEN", "OPENAI_API_KEY",
+		"ANTHROPIC_AUTH_TOKEN", "OPENAI_API_KEY", "XAI_API_KEY",
 		"AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT",
 		"AWS_REGION", "AWS_DEFAULT_REGION",
 		"GOOGLE_CLOUD_PROJECT",

--- a/studio/src/api/backends.ts
+++ b/studio/src/api/backends.ts
@@ -13,7 +13,7 @@ export interface BackendStatus {
 }
 
 export interface ProviderStatus {
-  name: "anthropic" | "openai" | "foundry" | "bedrock" | "vertex" | "zai";
+  name: "anthropic" | "openai" | "xai" | "foundry" | "bedrock" | "vertex" | "zai";
   available: boolean;
   source: string;
   suggested_model?: string;


### PR DESCRIPTION
## Summary

Adds **xAI Grok** as a first-class in-process (`claw`) provider so operators can use Grok models the same way as Anthropic/OpenAI.

- Register `xai` in the model registry (env `XAI_API_KEY` + cloud BYOK `provider: xai`)
- Detect `XAI_API_KEY` in `/api/backends/detect` (surfaces in studio Settings → Backends; makes `claw` available)
- Suggested default model: `xai/grok-3`
- Sandbox `iterion-default` allowlist includes `api.x.ai`
- Capabilities heuristics for Grok (tool call, 131k context; `grok-3-mini` as reasoning)
- Docs: `docs/backends.md`, `docs/sandbox.md`

### Usage

```bash
export XAI_API_KEY=...
```

```yaml
agent planner:
  backend: "claw"
  model: "xai/grok-3"
```

Optional `XAI_BASE_URL` (default `https://api.x.ai`); a trailing `/v1` is stripped so pasting the public OpenAI-SDK base URL still works.

## Test plan

- [x] `go test ./pkg/backend/detect/ ./pkg/backend/model/ ./pkg/server/ ./pkg/sandbox/netproxy/` with XAI-focused filters
- [ ] Set `XAI_API_KEY`, open studio → Settings → Backends: claw available, xai provider listed
- [ ] `iterion run` a minimal bot with `backend: claw` + `model: xai/grok-3`
- [ ] Cloud BYOK: store key under provider `xai`, launch a run with `model: xai/grok-3`
- [ ] Sandboxed run with `network: allowlist` + preset `iterion-default` reaches `api.x.ai`