### PR TITLE
feat(studio): pipeline board — 3 lanes, plan provenance, launch-now drag

### DIFF
--- a/cmd/iterion/mcp_board.go
+++ b/cmd/iterion/mcp_board.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native/boardops"
@@ -34,7 +35,10 @@ var mcpBoardCmd = &cobra.Command{
 			return err
 		}
 		caps := boardops.NewCapabilities(os.Getenv("ITERION_BOARD_CAPS"))
-		return runMCPBoardServer(os.Stdin, os.Stdout, store, caps)
+		// Planner provenance: the runtime stamps the source ticket so
+		// create_issue can auto-set parent_id when the agent omits it.
+		env := boardops.CallEnv{SpawnParentID: strings.TrimSpace(os.Getenv("ITERION_SOURCE_ISSUE_ID"))}
+		return runMCPBoardServer(os.Stdin, os.Stdout, store, caps, env)
 	},
 }
 
@@ -58,13 +62,13 @@ func openBoardStoreFromEnv() (*native.Store, error) {
 	return native.NewStore(root)
 }
 
-func runMCPBoardServer(in io.Reader, out io.Writer, store *native.Store, caps boardops.Capabilities) error {
+func runMCPBoardServer(in io.Reader, out io.Writer, store *native.Store, caps boardops.Capabilities, env boardops.CallEnv) error {
 	return runMCPLoop(in, out, 1024*1024, func(req mcpRequest) mcpResponse {
-		return dispatchMCPBoard(req, store, caps)
+		return dispatchMCPBoard(req, store, caps, env)
 	})
 }
 
-func dispatchMCPBoard(req mcpRequest, store *native.Store, caps boardops.Capabilities) mcpResponse {
+func dispatchMCPBoard(req mcpRequest, store *native.Store, caps boardops.Capabilities, env boardops.CallEnv) mcpResponse {
 	resp := mcpResponse{JSONRPC: "2.0", ID: req.ID}
 
 	switch req.Method {
@@ -90,7 +94,7 @@ func dispatchMCPBoard(req mcpRequest, store *native.Store, caps boardops.Capabil
 			resp.Error = mcpInvalidParamsError(err)
 			return resp
 		}
-		raw, err := boardops.Call(store, caps, params.Name, params.Arguments)
+		raw, err := boardops.CallWithEnv(store, caps, params.Name, params.Arguments, env)
 		if err != nil {
 			if errors.Is(err, boardops.ErrCapabilityDenied) {
 				resp.Error = &mcpError{Code: -32601, Message: err.Error()}

--- a/cmd/iterion/mcp_board_test.go
+++ b/cmd/iterion/mcp_board_test.go
@@ -17,7 +17,7 @@ func drive(t *testing.T, store *native.Store, caps boardops.Capabilities, lines 
 	t.Helper()
 	in := strings.NewReader(strings.Join(lines, "\n") + "\n")
 	out := &bytes.Buffer{}
-	if err := runMCPBoardServer(in, out, store, caps); err != nil && err != io.EOF {
+	if err := runMCPBoardServer(in, out, store, caps, boardops.CallEnv{}); err != nil && err != io.EOF {
 		t.Fatalf("runMCPBoardServer: %v", err)
 	}
 	dec := json.NewDecoder(out)

--- a/docs/adr/076-pipeline-hard-blockers-and-waiting-deps.md
+++ b/docs/adr/076-pipeline-hard-blockers-and-waiting-deps.md
@@ -1,0 +1,120 @@
+# ADR-076 — Pipeline hard blockers, waiting_deps, and unified launch admission
+
+Status: **accepted** (2026-07-18). Follow-up to [ADR-074](074-dedicated-pipeline-board-projection.md)
+and the multi-pipeline “design-first” product brief (Town production bus).
+
+## Context
+
+The native tracker already stored `Issue.Blockers []string` and the dispatcher
+adapter skipped candidates whose blockers were not all *terminal*. Two gaps
+blocked multi-pipeline production graphs (mesh → humanoid → feature):
+
+1. **Satisfaction was any-terminal.** `StateBlocked` is terminal (“won't do”),
+   so a cancelled/abandoned dep would *satisfy* dependents and make them
+   eligible — wrong for hard asset deps that must finish successfully.
+2. **The studio `/pipelines` launch loop ignored blockers entirely.** A ticket
+   in `StateReady` with open blockers could start from the admission loop while
+   `iterion dispatch` would skip it.
+3. **No non-terminal hold state for open deps.** Operators had only
+   `blocked` (terminal) or “stay Ready and hope”, neither of which models
+   “written ticket waiting on upstream tickets.”
+
+## Decision
+
+### D1 — Ready only when hard deps are satisfied; else `waiting_deps`
+
+`POST …/tasks/{id}/ready` with `ready:true`:
+
+- if every blocker is `StateDone` → `StateReady`;
+- else if the board has `waiting_deps` → park there;
+- else → `409` with `open_blockers` in the JSON body.
+
+Create-with-`start:true` uses the same rule. Unstage (`ready:false`) goes to
+`backlog` (fallback `inbox`).
+
+### D2 — Blocker satisfied ⇔ `state == done` only
+
+Shared helpers in [`pkg/dispatcher/native/blockers.go`](../../pkg/dispatcher/native/blockers.go):
+
+- `BlockerSatisfied(iss)` — only `StateDone`;
+- `BlockersSatisfied` / `ResolveBlockers` — missing IDs fail closed (open);
+- `CanLaunch` / `LaunchBlockedReason` — bot + `StateReady` + blockers all done.
+
+Used by:
+
+1. `Adapter.ListCandidates` (dispatcher);
+2. `admitReadyPipelines` (studio launch loop);
+3. projection `launch_blocked_reason` / `open_blocker_count`.
+
+### D3 — Auto-promote when unblocked
+
+When an issue transitions to `done`, dependents in `waiting_deps` whose blockers
+are now all satisfied move to:
+
+- **`backlog`** by default (human decides Ready);
+- **`ready`** when `bot_args.auto_ready` is a truthy string (`true`/`1`/`yes`).
+
+Emits `issue_unblocked` (+ `issue_state_changed` with `reason: unblocked`).
+
+### D4 — Reverse index on read (V1)
+
+`blocking: [{id, title}]` is computed over the full issue list at projection
+time. No stored reverse index.
+
+### D5 — Cycle rejection at write
+
+`Create` / `Update` reject blocker lists that would create a cycle
+(including self-ref). Missing blocker IDs remain allowed (fail closed at launch).
+
+### Default board + migration
+
+New state:
+
+| name           | display           | eligible | terminal |
+|----------------|-------------------|----------|----------|
+| `waiting_deps` | Waiting on deps   | false    | false    |
+
+`UpgradeBoardSchema` inserts it after `ready` (else after `backlog`) on
+existing boards, same additive pattern as `awaiting_input`.
+
+`StateBlocked` stays terminal “won't do” and does **not** satisfy hard deps.
+
+## Projection / API surface
+
+On each pipeline-board card (ticket-backed):
+
+```json
+{
+  "blockers": [{"id":"…","title":"…","state":"…","bot":"…","satisfied":true}],
+  "open_blocker_count": 0,
+  "launch_blocked_reason": "open_blockers|waiting_deps|…",
+  "blocking": [{"id":"…","title":"…"}]
+}
+```
+
+`create` / `PATCH` accept `blockers: string[]`. Events:
+`issue_blockers_updated`, `issue_unblocked`.
+
+## Consequences
+
+- Multi-pipeline DAGs (feature blocked on meshes) work on both dispatch and
+  `/pipelines` without GitHub Issues as the bus.
+- Custom boards without `waiting_deps` still gate launch via
+  `open_blocker_count` / `CanLaunch`; only Ready staging is stricter (409).
+- Soft deps, artefact acceptance, and upsert-by-`input_path` stay later waves
+  (V2/V3 of the product brief).
+
+## Follow-ups shipped in the same wave (V2–V3)
+
+- **Ticket contract** (`bot_args` vocabulary + drawer strip) —
+  `ticket_contract.go`.
+- **Upsert** by `(bot, bot_args.input_path)` on `POST …/tasks?upsert`.
+- **require_blocker_labels** optional gate on hard blockers (artefact
+  acceptance without a second state machine).
+- **Bulk ready** + **recompute-deps** endpoints; **dependency-graph** GET.
+- **UI filters**: pipeline_kind, family_id, waiting-on-deps only.
+
+## Non-goals (still deferred)
+
+- Soft-deps / scoring, path-based artefact file checks, board-per-bot, proxy
+  Godot fields (`placement_ref`), GitHub as pipeline source of truth.

--- a/docs/native-tracker.md
+++ b/docs/native-tracker.md
@@ -60,6 +60,7 @@ fields the operator can attach to issues. Defaults:
     { "name": "inbox",          "display": "Inbox" },
     { "name": "backlog",        "display": "Backlog" },
     { "name": "ready",          "display": "Ready",       "eligible": true },
+    { "name": "waiting_deps",   "display": "Waiting on deps" },
     { "name": "in_progress",    "display": "In progress", "eligible": true },
     { "name": "awaiting_input", "display": "Awaiting input" },
     { "name": "review",         "display": "Review" },
@@ -77,6 +78,14 @@ post their out-of-scope observations there (labeled `findings`) so
 operators can triage on /board without a separate inbox surface —
 drag inbox → backlog to promote, delete the card to dismiss.
 
+`waiting_deps` holds a ticket whose **hard blockers** are not yet
+`done` (see [ADR-076](adr/076-pipeline-hard-blockers-and-waiting-deps.md)).
+Non-eligible and non-terminal: neither the dispatcher nor the
+`/pipelines` launch loop will start it. Distinct from `blocked`, which
+is terminal “won't do” and must **not** be used as a temporary hold
+for open deps (a ticket in `blocked` does **not** satisfy anyone
+else's blockers).
+
 `awaiting_input` holds a dispatched card whose run paused for input
 (a `human` node, or an operator soft-pause): the dispatcher parks the
 card there — non-eligible, claim retained — and a per-tick sweep moves
@@ -84,14 +93,15 @@ it on once the run reaches a terminal status (see the "Paused runs"
 section in [docs/dispatcher.md](dispatcher.md)). Boards persisted by an
 older iterion are **schema-upgraded automatically** on store open
 (filesystem) or on read (Mongo): missing `inbox` is prepended, missing
-`awaiting_input` is inserted right after `in_progress`. Fully-custom
-boards without an `in_progress` state are left untouched.
+`waiting_deps` is inserted after `ready` (else after `backlog`),
+missing `awaiting_input` is inserted right after `in_progress`.
+Fully-custom boards without those anchors are left untouched for the
+optional inserts.
 
 | Property            | Meaning                                                            |
 |---------------------|--------------------------------------------------------------------|
-| `eligible: true`    | Dispatcher will dispatch issues sitting in this state.              |
-| `terminal: true`    | Dispatcher treats this state as a stop signal; blocker dependencies | 
-|                     | resolve.                                                           |
+| `eligible: true`    | Dispatcher will dispatch issues sitting in this state (subject to hard-blocker gate). |
+| `terminal: true`    | Dispatcher treats this state as a stop signal for *lifecycle*. Hard blocker satisfaction is **only** `done` (not every terminal state). |
 
 A state can be both `eligible` and `terminal` — for example a
 `completed` column that triggers a final wrap-up workflow before
@@ -232,10 +242,10 @@ different product surface — a **control center** for watching and unblocking
 many pipelines at once — not a saved filter and not a replacement for `/board`:
 
 - `/board` remains the editable, shared dispatcher backlog;
-- `/board` remains the editable, shared dispatcher backlog;
 - `/pipelines` is one global projection of every **root** pipeline, across all
   bots;
-- it has five fixed lanes — `Backlog`, `Todo`, `In progress`, `Done`, `Failed`;
+- it has three fixed lanes — `Opened`, `In progress`, `Closed` (IDs `opened`,
+  `in_progress`, `closed`; the IDs are the wire contract);
 - each card is one root pipeline; its descendant runs are **folded into the
   root card** (aggregate node progress + a list of pending human reviews), not
   shown as separate cards;
@@ -246,31 +256,106 @@ many pipelines at once — not a saved filter and not a replacement for `/board`
   time.
 
 Lane semantics — the board is **task-centric**:
-- `Backlog` = tickets being prepared;
-- `Todo` = tickets you staged with the card's **“→ Todo”** button, plus runs
-  waiting for a local slot (queued); “→ Backlog” unstages an unlaunched ticket.
-  The launch loop starts ready tickets **highest priority first** (the same
-  `P{n}` field /board sorts on; ties go oldest-first) — set it from the
-  ticket's Edit dialog, shown as a `P{n}` badge on the card;
-- `In progress` = running or awaiting a human review (progress bar +
-  Blocked tag);
-- `Done` = finished — the pipeline's output shows in the details sidebar;
-- `Failed` = the run failed / was cancelled, with the **error shown as the
-  reason**; ticket-backed cards offer **Retry** (back to Todo) and Edit.
+- `Opened` = every not-yet-running ticket (pairs with `Closed`). A per-card
+  **Ready** badge marks the ones cleared to leave Opened for In progress (a
+  staged task, or a run already queued for a slot); tickets with open hard
+  deps show **Blocked by N** / **Waiting on deps**; the rest show **Not
+  ready**. The card's **Mark ready** / **Unmark ready** buttons flip that
+  state; Mark ready with open blockers parks the ticket in `waiting_deps`
+  (or 409 on boards without that state). A not-ready ticket also offers
+  **Delete** (confirmed, and refused server-side while any run in the tree is
+  active). The launch loop starts ready tickets **highest priority first**
+  **and only when every hard blocker is `done`** — same `native.CanLaunch`
+  rule as the dispatcher. A header control filters the lane by **All /
+  Ready / Not ready**;
+- `In progress` = running or awaiting a human review (progress bar + Blocked
+  tag). A running card offers **Pause** (soft operator pause — the engine
+  checkpoints at the next safe boundary; **Resume** appears while paused); a
+  ticket-backed card offers **Reset** (cancels the run tree, then restages the
+  ticket to Ready for a fresh start); a ticket-less card offers **Stop** (plain
+  cancel → the run lands in Closed as failed);
+- `Closed` = every finished pipeline, success or failure. A per-card
+  **Success** / **Failed** badge distinguishes the outcome; a successful card's
+  output shows in the details sidebar, a failed one shows the **error as the
+  reason** and (ticket-backed) offers **Retry** (restages to Ready) + Edit. A
+  header control filters the lane by **All / Success / Failed**.
+
+**Hard dependencies (blockers).** Ticket-to-ticket DAG (roots only — not
+sub-bot runs). Satisfied only when the blocker issue is in state `done`
+(not merely terminal). Optional extra gate: set
+`bot_args.require_blocker_labels` (e.g. `accepted`) so a done blocker still
+blocks until it carries those labels (artefact acceptance without a second
+state machine). Projection fields on each card: `blockers` (enriched
+`{id,title,state,bot,satisfied,missing_labels?}`), `open_blocker_count`,
+`launch_blocked_reason`, `blocking` (reverse index, computed on read).
+When the last blocker reaches `done` (and labels if required), dependents
+in `waiting_deps` auto-promote to `backlog` (or `ready` if
+`bot_args.auto_ready` is truthy) and emit `issue_unblocked`. Full contract:
+[ADR-076](adr/076-pipeline-hard-blockers-and-waiting-deps.md).
+
+### Ticket contract (`bot_args`)
+
+Iterion stays game-agnostic. Cross-bot multi-pipeline tickets share a small
+**well-known key vocabulary** (constants in
+`pkg/dispatcher/native/ticket_contract.go`). Bots own the immutable request
+JSON on disk; the board only routes execution.
+
+| Key | Role |
+|-----|------|
+| `input_path` | Path to the immutable request file (primary). Upsert key with `bot`. |
+| `revision_id` / `request_hash` | Immutability / cache identity |
+| `asset_id` / `feature_id` / `family_id` | Correlation / bulk filters |
+| `pipeline_kind` | `mesh` \| `humanoid` \| `feature` \| custom — UI filter |
+| `produces` / `consumes` | Serialized artefact / dependency lists (JSON strings) |
+| `doc_refs` | Optional design refs |
+| `auto_ready` | Truthy → auto Ready when unblocked (else backlog) |
+| `require_blocker_labels` | Comma-separated labels required on every hard blocker |
+| `spawned_from` | Planner ticket id that published this card (synced with `Issue.ParentID`) |
+| `role` | Optional `planner` \| `producer` hint for UI grouping |
+
+**Planner provenance.** Distinct from hard `blockers` (scheduling): a planner
+ticket can spawn child tickets via `board.create` / `POST …/tasks`. When the
+creating run is sourced from a ticket, `parent_id` / `spawned_from` is
+auto-stamped. The `/pipelines` projection exposes `parent_issue_id`,
+`children[]`, and `children_summary` so Inventory can group children under a
+collapsible plan card.
+
+The `/pipelines` drawer surfaces these under **Ticket contract** before the
+generic inputs list.
+
+**Upsert.** Planners re-run without flooding the board: `POST …/tasks` with
+`upsert: true` and `bot_args.input_path` updates the existing card matching
+`(bot, input_path)` (title / blockers / bot_args). Does **not** reset state
+when the ticket is already `in_progress` / `done` / `awaiting_input`.
+
+**Multi-engine access.** Board mutations do not require Claude MCP tools.
+Canonical surfaces for every backend (Claude / Codex / Kimi / scripts):
+
+1. **REST** — `/api/v1/pipeline-board/*` and `/api/v1/native/issues/*` (this page);
+2. **CLI** — `iterion issue create|list|show|update|move … --blocker … --bot … --bot-arg key=value`;
+3. **HTTP MCP** — `/api/v1/mcp/board` (ephemeral run token) for sandboxed agents.
 
 Ticket movement is **button-driven** — there is no drag & drop. The studio's
 launch loop starts ready tickets when a concurrency slot frees (no
-`iterion dispatch` needed). Run cards (In progress / Done / Failed without a
-ticket) are positioned by run state and cannot be moved.
+`iterion dispatch` needed). Run cards (In progress / Closed without a
+ticket) are positioned by run state and cannot be moved. Per-lane filters are
+client-side and compose on top of the global search / bot / label /
+`pipeline_kind` / `family_id` / “Waiting on deps” bar.
 
 The aggregate read API is intentionally server-side, so the browser does not
 perform an N+1 traversal over issues, checkpoints and child runs:
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
-| `/api/v1/pipeline-board` | GET | Global projection: 5 fixed lanes + one folded card per root pipeline (progress, pending reviews, output, concurrency) |
-| `/api/v1/pipeline-board/tasks` | POST | Create a ticket; `bot` required **in the body**; `{start:true}` creates it ready (Todo), else Backlog |
-| `/api/v1/pipeline-board/tasks/{id}/ready` | POST | `{ready}` flips a ticket ready↔backlog — the backend of the “→ Todo” / “→ Backlog” / Retry buttons |
+| `/api/v1/pipeline-board` | GET | Global projection: 3 fixed lanes + one folded card per root pipeline (progress, pending reviews, deps, contract args, output, concurrency) |
+| `/api/v1/pipeline-board/tasks` | POST | Create a ticket; `bot` required; optional `blockers`, `upsert`; `{start:true}` → ready when deps OK else `waiting_deps` |
+| `/api/v1/pipeline-board/tasks/{id}/ready` | POST | `{ready}` stages Ready when hard deps are done, else parks in `waiting_deps` (or 409); unstage → backlog |
+| `/api/v1/pipeline-board/tasks/{id}` | PATCH | Edit a not-yet-run ticket (title, body, labels, priority, bot, bot_args, blockers) |
+| `/api/v1/pipeline-board/tasks/{id}` | DELETE | Delete a ticket (issue only, never a run); 409 while any run in its tree is active |
+| `/api/v1/pipeline-board/tasks/{id}/reset` | POST | Cancel every active run in the ticket's tree, then restage it to Ready |
+| `/api/v1/pipeline-board/tasks/{id}/dependency-graph` | GET | Limited-depth hard-dep graph (also `GET /api/v1/native/issues/{id}/dependency-graph`) |
+| `/api/v1/pipeline-board/bulk/ready` | POST | `{ids?\|family_id?\|pipeline_kind?}` stage many tickets Ready (skip open blockers by default) |
+| `/api/v1/pipeline-board/bulk/recompute-deps` | POST | Re-promote `waiting_deps` tickets whose blockers are now satisfied |
 
 **Local concurrency cap.** `iterion studio` caps concurrent **root** pipelines
 at `--max-concurrent-pipelines` (default 3; also

--- a/openapi.json
+++ b/openapi.json
@@ -19,6 +19,56 @@
         ],
         "type": "object"
       },
+      "BlockerInfo": {
+        "properties": {
+          "bot": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "labels": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "missing_labels": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "satisfied": {
+            "type": "boolean"
+          },
+          "state": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "satisfied"
+        ],
+        "type": "object"
+      },
+      "BlockingInfo": {
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
       "Checkpoint": {
         "properties": {
           "artifact_versions": {
@@ -230,6 +280,84 @@
           "created_by",
           "created_at",
           "updated_at"
+        ],
+        "type": "object"
+      },
+      "DependencyGraphEdge": {
+        "properties": {
+          "from": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "from",
+          "to"
+        ],
+        "type": "object"
+      },
+      "DependencyGraphNode": {
+        "properties": {
+          "blockers": {
+            "items": {
+              "$ref": "#/components/schemas/BlockerInfo"
+            },
+            "type": "array"
+          },
+          "blocking": {
+            "items": {
+              "$ref": "#/components/schemas/BlockingInfo"
+            },
+            "type": "array"
+          },
+          "bot": {
+            "type": "string"
+          },
+          "depth": {
+            "type": "integer"
+          },
+          "id": {
+            "type": "string"
+          },
+          "satisfied": {
+            "type": "boolean"
+          },
+          "state": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "depth"
+        ],
+        "type": "object"
+      },
+      "DependencyGraphResponse": {
+        "properties": {
+          "edges": {
+            "items": {
+              "$ref": "#/components/schemas/DependencyGraphEdge"
+            },
+            "type": "array"
+          },
+          "nodes": {
+            "items": {
+              "$ref": "#/components/schemas/DependencyGraphNode"
+            },
+            "type": "array"
+          },
+          "root": {
+            "$ref": "#/components/schemas/DependencyGraphNode"
+          }
+        },
+        "required": [
+          "root",
+          "nodes"
         ],
         "type": "object"
       },
@@ -447,6 +575,9 @@
           "last_workdir": {
             "type": "string"
           },
+          "parent_id": {
+            "type": "string"
+          },
           "priority": {
             "type": "integer"
           },
@@ -502,11 +633,32 @@
             },
             "type": "array"
           },
+          "blockers": {
+            "items": {
+              "$ref": "#/components/schemas/BlockerInfo"
+            },
+            "type": "array"
+          },
+          "blocking": {
+            "items": {
+              "$ref": "#/components/schemas/BlockingInfo"
+            },
+            "type": "array"
+          },
           "body": {
             "type": "string"
           },
           "bot_id": {
             "type": "string"
+          },
+          "children": {
+            "items": {
+              "$ref": "#/components/schemas/PipelineBoardChildRef"
+            },
+            "type": "array"
+          },
+          "children_summary": {
+            "$ref": "#/components/schemas/PipelineBoardChildrenSummary"
           },
           "column_id": {
             "type": "string"
@@ -552,7 +704,19 @@
             },
             "type": "array"
           },
+          "launch_blocked_reason": {
+            "type": "string"
+          },
+          "open_blocker_count": {
+            "type": "integer"
+          },
           "output": {
+            "type": "string"
+          },
+          "parent_issue_id": {
+            "type": "string"
+          },
+          "parent_title": {
             "type": "string"
           },
           "pending_reviews": {
@@ -569,6 +733,9 @@
           },
           "ready": {
             "type": "boolean"
+          },
+          "role": {
+            "type": "string"
           },
           "run_id": {
             "type": "string"
@@ -613,6 +780,60 @@
           "tree_total_nodes",
           "created_at",
           "updated_at"
+        ],
+        "type": "object"
+      },
+      "PipelineBoardChildRef": {
+        "properties": {
+          "bot_id": {
+            "type": "string"
+          },
+          "card_id": {
+            "type": "string"
+          },
+          "issue_id": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "issue_id"
+        ],
+        "type": "object"
+      },
+      "PipelineBoardChildrenSummary": {
+        "properties": {
+          "done": {
+            "type": "integer"
+          },
+          "failed": {
+            "type": "integer"
+          },
+          "in_progress": {
+            "type": "integer"
+          },
+          "open": {
+            "type": "integer"
+          },
+          "ready": {
+            "type": "integer"
+          },
+          "total": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "ready",
+          "in_progress",
+          "done",
+          "failed",
+          "open"
         ],
         "type": "object"
       },
@@ -1732,6 +1953,12 @@
       },
       "pipelineBoardTaskRequest": {
         "properties": {
+          "blockers": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "body": {
             "type": "string"
           },
@@ -1753,6 +1980,9 @@
             },
             "type": "array"
           },
+          "parent_id": {
+            "type": "string"
+          },
           "priority": {
             "type": "integer"
           },
@@ -1761,6 +1991,9 @@
           },
           "title": {
             "type": "string"
+          },
+          "upsert": {
+            "type": "boolean"
           }
         },
         "required": [
@@ -1771,6 +2004,12 @@
       },
       "pipelineBoardUpdateRequest": {
         "properties": {
+          "blockers": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "body": {
             "type": "string"
           },
@@ -1799,6 +2038,126 @@
             "type": "string"
           }
         },
+        "type": "object"
+      },
+      "pipelineBulkDeleteRequest": {
+        "properties": {
+          "ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "ids"
+        ],
+        "type": "object"
+      },
+      "pipelineBulkDeleteResponse": {
+        "properties": {
+          "deleted": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "skipped": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "skipped_why": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "deleted"
+        ],
+        "type": "object"
+      },
+      "pipelineBulkReadyRequest": {
+        "properties": {
+          "family_id": {
+            "type": "string"
+          },
+          "ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "only_satisfied": {
+            "type": "boolean"
+          },
+          "pipeline_kind": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "pipelineBulkReadyResponse": {
+        "properties": {
+          "ready": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "skipped": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "skipped_why": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "waiting_deps": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "ready"
+        ],
+        "type": "object"
+      },
+      "pipelineRecomputeDepsRequest": {
+        "properties": {
+          "closed_id": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "pipelineRecomputeDepsResponse": {
+        "properties": {
+          "promoted": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "targets": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "promoted"
+        ],
         "type": "object"
       },
       "setOrgStatusReq": {
@@ -7267,6 +7626,37 @@
         ]
       }
     },
+    "/api/v1/native/issues/{id}/dependency-graph": {
+      "get": {
+        "operationId": "getV1NativeIssuesByIdDependencyGraph",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DependencyGraphResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "GET /api/v1/native/issues/{id}/dependency-graph",
+        "tags": [
+          "native"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "/api/v1/pipeline-board": {
       "get": {
         "operationId": "getV1PipelineBoard",
@@ -7283,6 +7673,99 @@
           }
         },
         "summary": "GET /api/v1/pipeline-board",
+        "tags": [
+          "pipeline-board"
+        ]
+      }
+    },
+    "/api/v1/pipeline-board/bulk/delete": {
+      "post": {
+        "operationId": "postV1PipelineBoardBulkDelete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/pipelineBulkDeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/pipelineBulkDeleteResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "POST /api/v1/pipeline-board/bulk/delete",
+        "tags": [
+          "pipeline-board"
+        ]
+      }
+    },
+    "/api/v1/pipeline-board/bulk/ready": {
+      "post": {
+        "operationId": "postV1PipelineBoardBulkReady",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/pipelineBulkReadyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/pipelineBulkReadyResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "POST /api/v1/pipeline-board/bulk/ready",
+        "tags": [
+          "pipeline-board"
+        ]
+      }
+    },
+    "/api/v1/pipeline-board/bulk/recompute-deps": {
+      "post": {
+        "operationId": "postV1PipelineBoardBulkRecomputeDeps",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/pipelineRecomputeDepsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/pipelineRecomputeDepsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "POST /api/v1/pipeline-board/bulk/recompute-deps",
         "tags": [
           "pipeline-board"
         ]
@@ -7320,6 +7803,18 @@
       }
     },
     "/api/v1/pipeline-board/tasks/{id}": {
+      "delete": {
+        "operationId": "deleteV1PipelineBoardTasksById",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "DELETE /api/v1/pipeline-board/tasks/{id}",
+        "tags": [
+          "pipeline-board"
+        ]
+      },
       "parameters": [
         {
           "in": "path",
@@ -7355,6 +7850,61 @@
           }
         },
         "summary": "PATCH /api/v1/pipeline-board/tasks/{id}",
+        "tags": [
+          "pipeline-board"
+        ]
+      }
+    },
+    "/api/v1/pipeline-board/tasks/{id}/dependency-graph": {
+      "get": {
+        "operationId": "getV1PipelineBoardTasksByIdDependencyGraph",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DependencyGraphResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "GET /api/v1/pipeline-board/tasks/{id}/dependency-graph",
+        "tags": [
+          "pipeline-board"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/api/v1/pipeline-board/tasks/{id}/launch": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "postV1PipelineBoardTasksByIdLaunch",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "POST /api/v1/pipeline-board/tasks/{id}/launch",
         "tags": [
           "pipeline-board"
         ]
@@ -7396,6 +7946,30 @@
           }
         },
         "summary": "POST /api/v1/pipeline-board/tasks/{id}/ready",
+        "tags": [
+          "pipeline-board"
+        ]
+      }
+    },
+    "/api/v1/pipeline-board/tasks/{id}/reset": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "postV1PipelineBoardTasksByIdReset",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "POST /api/v1/pipeline-board/tasks/{id}/reset",
         "tags": [
           "pipeline-board"
         ]

--- a/pkg/backend/delegate/claude_code_hooks.go
+++ b/pkg/backend/delegate/claude_code_hooks.go
@@ -290,6 +290,9 @@ func (b *ClaudeCodeBackend) wireBoardMCP(task Task, opts []claudesdk.Option, ext
 		if task.StoreDir != "" {
 			env["ITERION_STORE_DIR"] = task.StoreDir
 		}
+		if task.SourceIssueID != "" {
+			env["ITERION_SOURCE_ISSUE_ID"] = task.SourceIssueID
+		}
 		opts = append(opts, claudesdk.WithMCPServer(boardMCPServerName, &claudesdk.MCPStdioServer{
 			Command: selfPath,
 			Args:    []string{boardMCPSubcommand},

--- a/pkg/backend/delegate/delegate.go
+++ b/pkg/backend/delegate/delegate.go
@@ -299,6 +299,11 @@ type Task struct {
 	// NodeID is the IR node identifier, used for observability hooks.
 	NodeID string
 
+	// SourceIssueID is the native ticket that owns this run (dispatcher
+	// or pipeline launch). Board MCP create_issue auto-stamps children
+	// with this parent when set. Empty for ad-hoc runs.
+	SourceIssueID string
+
 	// Iteration is the 0-based loop iteration counter for this
 	// execution. Aligned with the loop_iteration field exposed in
 	// events / ExecutionState. Zero for nodes outside any loop.

--- a/pkg/backend/model/executor.go
+++ b/pkg/backend/model/executor.go
@@ -119,14 +119,19 @@ type ClawExecutor struct {
 	sessions *nodeSessionStore
 
 	// boardRegister mints a per-node board MCP run token for the given
-	// capabilities (returns the token registered with the server's
-	// BoardMCPTokenRegistry). Set via WithBoardRegister on the server
-	// path; nil on CLI runs (sandboxed board-emit then stays disabled).
-	boardRegister func(caps []string) string
+	// capabilities and owning ticket (returns the token registered with
+	// the server's BoardMCPTokenRegistry). Set via WithBoardRegister on
+	// the server path; nil on CLI runs (sandboxed board-emit then stays
+	// disabled).
+	boardRegister func(caps []string, sourceIssueID string) string
 	// boardEndpoint is the per-run gateway-reachable board MCP URL pushed
 	// in by the engine after the sandbox starts (SetBoardEndpoint). Empty
 	// disables sandboxed board-emit wiring (C082).
 	boardEndpoint string
+	// sourceIssueID is the ticket that owns this run (if any). Plumbed
+	// into board MCP / claw board tools so create_issue can auto-stamp
+	// parent_id on spawned children.
+	sourceIssueID string
 
 	// detector lazily probes host credentials (claude_code OAuth,
 	// codex OAuth, ANTHROPIC_API_KEY, …) so resolveBackendName can
@@ -195,8 +200,16 @@ type ClawExecutorOption func(*ClawExecutor)
 // path). The closure registers a token for the node's board capabilities
 // with the server's BoardMCPTokenRegistry and returns it; the executor
 // pairs it with the board endpoint on each sandboxed board-cap node.
-func WithBoardRegister(fn func(caps []string) string) ClawExecutorOption {
+// sourceIssueID is the ticket owning the run, so the HTTP transport can
+// auto-stamp parent_id on board.create like the other two transports.
+func WithBoardRegister(fn func(caps []string, sourceIssueID string) string) ClawExecutorOption {
 	return func(e *ClawExecutor) { e.boardRegister = fn }
+}
+
+// WithSourceIssueID stamps the ticket that owns this run so board.create
+// can auto-link spawned children (parent_id / spawned_from).
+func WithSourceIssueID(issueID string) ClawExecutorOption {
+	return func(e *ClawExecutor) { e.sourceIssueID = strings.TrimSpace(issueID) }
 }
 
 // WithEventHooks sets observability callbacks on the executor.

--- a/pkg/backend/model/executor_build_task.go
+++ b/pkg/backend/model/executor_build_task.go
@@ -606,6 +606,7 @@ func (e *ClawExecutor) buildTask(ctx context.Context, node ir.Node, f backendFie
 
 	task := delegate.Task{
 		NodeID:                f.id,
+		SourceIssueID:         e.sourceIssueID,
 		Iteration:             LoopIterationFromContext(ctx),
 		SystemPrompt:          systemText,
 		SystemPromptMode:      delegate.SystemPromptModeForBackend(backendName),
@@ -939,7 +940,12 @@ func (e *ClawExecutor) applyBoardEndpoint(task *delegate.Task, effectiveCaps []s
 		return
 	}
 	task.BoardHTTPEndpoint = e.boardEndpoint
-	task.BoardRunToken = e.boardRegister(effectiveCaps)
+	// The source ticket rides the grant so board.create over the HTTP
+	// transport auto-stamps parent_id / spawned_from exactly like the
+	// stdio (__mcp-board) and in-process (claw) paths do — otherwise a
+	// sandboxed planner publishes orphan tickets and the parent card
+	// loses its children counter.
+	task.BoardRunToken = e.boardRegister(effectiveCaps, e.sourceIssueID)
 }
 
 // applySessionContinuity wires the inherit / inherit_if_available /

--- a/pkg/backend/tool/claw_board_tools.go
+++ b/pkg/backend/tool/claw_board_tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native/boardops"
@@ -16,6 +17,9 @@ import (
 type BoardConfig struct {
 	Store        *native.Store
 	Capabilities []string
+	// SourceIssueID is the ticket that owns the calling run (if any).
+	// Auto-stamped as parent_id on create_issue when the agent omits it.
+	SourceIssueID string
 }
 
 // RegisterClawBoardTools registers the seven board operations as
@@ -37,10 +41,11 @@ func RegisterClawBoardTools(reg *Registry, cfg *BoardConfig) error {
 	for _, c := range cfg.Capabilities {
 		caps[c] = true
 	}
+	env := boardops.CallEnv{SpawnParentID: strings.TrimSpace(cfg.SourceIssueID)}
 	for _, t := range boardops.ToolsFor(caps) {
 		t := t // capture for closure
 		exec := func(ctx context.Context, input json.RawMessage) (string, error) {
-			raw, err := boardops.Call(cfg.Store, caps, t.Name, input)
+			raw, err := boardops.CallWithEnv(cfg.Store, caps, t.Name, input, env)
 			if err != nil {
 				return "", err
 			}

--- a/pkg/dispatcher/boardmongo/store.go
+++ b/pkg/dispatcher/boardmongo/store.go
@@ -160,9 +160,13 @@ func (s *Store) Create(in native.Issue) (*native.Issue, error) {
 	if err := board.ValidateFieldValues(in.Fields); err != nil {
 		return nil, err
 	}
+	in.Blockers = native.NormalizeBlockers(in.Blockers)
 	if in.ID == "" {
 		in.ID = "native:" + uuid.NewString()
 	} else if err := validateIssueID(in.ID); err != nil {
+		return nil, err
+	}
+	if err := native.ValidateBlockers(s, in.ID, in.Blockers); err != nil {
 		return nil, err
 	}
 	now := time.Now().UTC()
@@ -178,6 +182,14 @@ func (s *Store) Create(in native.Issue) (*native.Issue, error) {
 	}
 	if err := s.emit(native.Event{Type: native.EvtIssueCreated, IssueID: in.ID, Payload: map[string]any{"state": in.State, "title": in.Title}}); err != nil {
 		return nil, err
+	}
+	if len(in.Blockers) > 0 {
+		if err := s.emit(native.Event{
+			Type: native.EvtIssueBlockersUpdated, IssueID: in.ID,
+			Payload: map[string]any{"blockers": append([]string(nil), in.Blockers...)},
+		}); err != nil {
+			return nil, err
+		}
 	}
 	clone := in
 	return &clone, nil
@@ -260,6 +272,14 @@ func (s *Store) Update(id string, p native.Patch) (*native.Issue, error) {
 	if err != nil {
 		return nil, err
 	}
+	if p.Blockers != nil {
+		next := native.NormalizeBlockers(*p.Blockers)
+		if err := native.ValidateBlockers(s, id, next); err != nil {
+			return nil, err
+		}
+		// Normalize before applyPatch so the stored list is clean.
+		p.Blockers = &next
+	}
 	changed := applyPatch(iss, p, s.Board())
 	if len(changed.fields) == 0 {
 		return iss, changed.err
@@ -273,6 +293,17 @@ func (s *Store) Update(id string, p native.Patch) (*native.Issue, error) {
 	}
 	if err := s.emit(native.Event{Type: native.EvtIssueUpdated, IssueID: iss.ID, Payload: map[string]any{"changed": changed.fields}}); err != nil {
 		return nil, err
+	}
+	for _, f := range changed.fields {
+		if f == "blockers" {
+			if err := s.emit(native.Event{
+				Type: native.EvtIssueBlockersUpdated, IssueID: iss.ID,
+				Payload: map[string]any{"blockers": append([]string(nil), iss.Blockers...)},
+			}); err != nil {
+				return nil, err
+			}
+			break
+		}
 	}
 	return iss, nil
 }
@@ -298,6 +329,10 @@ func (s *Store) SetState(id, newState string) (*native.Issue, error) {
 	}
 	if err := s.emit(native.Event{Type: native.EvtIssueState, IssueID: iss.ID, Payload: map[string]any{"from": old, "to": newState}}); err != nil {
 		return nil, err
+	}
+	if newState == native.StateDone {
+		// Best-effort: do not roll back a successful done transition.
+		_ = native.PromoteUnblockedDependents(s, id)
 	}
 	return iss, nil
 }

--- a/pkg/dispatcher/native/adapter.go
+++ b/pkg/dispatcher/native/adapter.go
@@ -24,21 +24,19 @@ func NewAdapter(store BoardStore) *Adapter { return &Adapter{store: store} }
 func (a *Adapter) Name() string { return "native" }
 
 // ListCandidates returns unclaimed issues whose state is marked
-// eligible on the board, excluding those whose blockers are not all
-// terminal. Missing blockers are treated as open.
+// eligible on the board, excluding those whose hard blockers are not
+// all StateDone (see BlockersSatisfied / CanLaunch). Missing blockers
+// are treated as open (fail closed). Terminal non-success states such
+// as StateBlocked do NOT satisfy a dependency.
 func (a *Adapter) ListCandidates(ctx context.Context) ([]tracker.Issue, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	b := a.store.Board()
 	eligible := make([]string, 0, len(b.States))
-	terminal := make(map[string]bool, len(b.States))
 	for _, s := range b.States {
 		if s.Eligible {
 			eligible = append(eligible, s.Name)
-		}
-		if s.Terminal {
-			terminal[s.Name] = true
 		}
 	}
 	if len(eligible) == 0 {
@@ -51,25 +49,15 @@ func (a *Adapter) ListCandidates(ctx context.Context) ([]tracker.Issue, error) {
 	}
 	out := make([]tracker.Issue, 0, len(issues))
 	for _, iss := range issues {
-		if a.hasOpenBlocker(iss.Blockers, terminal) {
+		// Same hard-dep rule as the pipeline launch loop (CanLaunch's
+		// blocker half, including optional require_blocker_labels).
+		ok, _ := BlockersSatisfiedForIssue(a.store, iss)
+		if !ok {
 			continue
 		}
 		out = append(out, toTrackerIssue(iss))
 	}
 	return out, nil
-}
-
-func (a *Adapter) hasOpenBlocker(blockers []string, terminal map[string]bool) bool {
-	for _, id := range blockers {
-		iss, err := a.store.Get(id)
-		if err != nil {
-			return true
-		}
-		if !terminal[iss.State] {
-			return true
-		}
-	}
-	return false
 }
 
 // RefreshStates returns the current state for each requested ID;

--- a/pkg/dispatcher/native/adapter_test.go
+++ b/pkg/dispatcher/native/adapter_test.go
@@ -68,6 +68,36 @@ func TestListCandidatesBlockerGating(t *testing.T) {
 	}
 }
 
+// Terminal non-success (StateBlocked) must NOT satisfy a hard dep — same rule
+// as CanLaunch / the pipeline launch loop.
+func TestListCandidatesBlockedDoesNotSatisfy(t *testing.T) {
+	a, s := newAdapter(t)
+
+	wont, _ := s.Create(native.Issue{Title: "won't do", State: native.StateBlocked})
+	gated, _ := s.Create(native.Issue{
+		Title: "needs real done", State: native.StateReady, Blockers: []string{wont.ID},
+	})
+	candidates, _ := a.ListCandidates(context.Background())
+	for _, c := range candidates {
+		if c.ID == gated.ID {
+			t.Fatal("blocker in terminal blocked must not make dependent eligible")
+		}
+	}
+}
+
+func TestListCandidatesMissingBlockerFailClosed(t *testing.T) {
+	a, s := newAdapter(t)
+	gated, _ := s.Create(native.Issue{
+		Title: "dangling", State: native.StateReady, Blockers: []string{"native:missing"},
+	})
+	candidates, _ := a.ListCandidates(context.Background())
+	for _, c := range candidates {
+		if c.ID == gated.ID {
+			t.Fatal("missing blocker must fail closed")
+		}
+	}
+}
+
 func TestRefreshStates(t *testing.T) {
 	a, s := newAdapter(t)
 	x, _ := s.Create(native.Issue{Title: "x", State: "ready"})

--- a/pkg/dispatcher/native/blockers.go
+++ b/pkg/dispatcher/native/blockers.go
@@ -1,0 +1,356 @@
+package native
+
+import (
+	"fmt"
+	"strings"
+)
+
+// IssueGetter is the minimal lookup surface hard-blocker evaluation needs.
+// *Store and every BoardStore implementation satisfy it via Get.
+type IssueGetter interface {
+	Get(id string) (*Issue, error)
+}
+
+// BlockerInfo is a resolved dependency for projection and API responses.
+type BlockerInfo struct {
+	ID        string   `json:"id"`
+	Title     string   `json:"title,omitempty"`
+	State     string   `json:"state,omitempty"`
+	Bot       string   `json:"bot,omitempty"`
+	Labels    []string `json:"labels,omitempty"`
+	Satisfied bool     `json:"satisfied"`
+	// MissingLabels lists required labels still absent when state is done
+	// but bot_args.require_blocker_labels is set on the dependent.
+	MissingLabels []string `json:"missing_labels,omitempty"`
+}
+
+// BlockerPolicy optional gates beyond state==done (V3.2 artefact acceptance).
+type BlockerPolicy struct {
+	// RequireLabels must all be present on each blocker once it is done.
+	RequireLabels []string
+}
+
+// BlockingInfo is one reverse-index entry: an issue that lists this one as
+// a blocker. Computed on read (V1 — not stored).
+type BlockingInfo struct {
+	ID    string `json:"id"`
+	Title string `json:"title,omitempty"`
+}
+
+// BlockerSatisfied reports whether one issue satisfies a hard dependency.
+// Product rule (multi-pipeline / Town): only StateDone counts. Terminal
+// non-success states (e.g. blocked = "won't do") must NOT unblock
+// dependents — that was the gap that made StateBlocked unusable as a
+// temporary hold.
+func BlockerSatisfied(iss *Issue) bool {
+	return iss != nil && iss.State == StateDone
+}
+
+// NormalizeBlockers trims, drops empties, and dedupes while preserving order.
+func NormalizeBlockers(ids []string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+// ResolveBlockers enriches blocker IDs with the default (state-only) policy.
+func ResolveBlockers(g IssueGetter, ids []string) []BlockerInfo {
+	return ResolveBlockersPolicy(g, ids, BlockerPolicy{})
+}
+
+// ResolveBlockersPolicy enriches blocker IDs. Missing IDs are unsatisfied
+// (fail closed). When policy.RequireLabels is set, a done blocker still
+// fails until it carries every required label.
+func ResolveBlockersPolicy(g IssueGetter, ids []string, policy BlockerPolicy) []BlockerInfo {
+	ids = NormalizeBlockers(ids)
+	if len(ids) == 0 {
+		return nil
+	}
+	out := make([]BlockerInfo, 0, len(ids))
+	for _, id := range ids {
+		info := BlockerInfo{ID: id}
+		iss, err := g.Get(id)
+		if err != nil || iss == nil {
+			out = append(out, info)
+			continue
+		}
+		info.Title = iss.Title
+		info.State = iss.State
+		info.Bot = iss.Bot
+		if len(iss.Labels) > 0 {
+			info.Labels = append([]string(nil), iss.Labels...)
+		}
+		info.Satisfied = BlockerSatisfied(iss)
+		if info.Satisfied && len(policy.RequireLabels) > 0 {
+			var missing []string
+			have := make(map[string]struct{}, len(iss.Labels))
+			for _, l := range iss.Labels {
+				have[l] = struct{}{}
+			}
+			for _, want := range policy.RequireLabels {
+				if _, ok := have[want]; !ok {
+					missing = append(missing, want)
+				}
+			}
+			if len(missing) > 0 {
+				info.Satisfied = false
+				info.MissingLabels = missing
+			}
+		}
+		out = append(out, info)
+	}
+	return out
+}
+
+// BlockersSatisfied returns ok when every blocker is StateDone (no label policy).
+func BlockersSatisfied(g IssueGetter, ids []string) (ok bool, open []BlockerInfo) {
+	return BlockersSatisfiedPolicy(g, ids, BlockerPolicy{})
+}
+
+// BlockersSatisfiedPolicy returns ok when every blocker passes state+labels.
+func BlockersSatisfiedPolicy(g IssueGetter, ids []string, policy BlockerPolicy) (ok bool, open []BlockerInfo) {
+	resolved := ResolveBlockersPolicy(g, ids, policy)
+	if len(resolved) == 0 {
+		return true, nil
+	}
+	for _, b := range resolved {
+		if !b.Satisfied {
+			open = append(open, b)
+		}
+	}
+	return len(open) == 0, open
+}
+
+// BlockersSatisfiedForIssue applies the dependent's bot_args policy
+// (require_blocker_labels) to its blockers list.
+func BlockersSatisfiedForIssue(g IssueGetter, iss *Issue) (ok bool, open []BlockerInfo) {
+	if iss == nil {
+		return true, nil
+	}
+	policy := BlockerPolicy{RequireLabels: RequireBlockerLabels(iss.BotArgs)}
+	return BlockersSatisfiedPolicy(g, iss.Blockers, policy)
+}
+
+// ResolveBlockersForIssue is the projection counterpart of BlockersSatisfiedForIssue.
+func ResolveBlockersForIssue(g IssueGetter, iss *Issue) []BlockerInfo {
+	if iss == nil {
+		return nil
+	}
+	policy := BlockerPolicy{RequireLabels: RequireBlockerLabels(iss.BotArgs)}
+	return ResolveBlockersPolicy(g, iss.Blockers, policy)
+}
+
+// OpenBlockerCount is the number of unsatisfied hard blockers (state-only).
+func OpenBlockerCount(g IssueGetter, ids []string) int {
+	_, open := BlockersSatisfied(g, ids)
+	return len(open)
+}
+
+// CanLaunch is the unified admission rule for a pipeline / dispatcher ticket:
+//
+//	has a non-empty bot
+//	AND state is StateReady (the only launch-eligible staging state for /pipelines)
+//	AND every hard blocker is StateDone
+//	AND optional require_blocker_labels on those blockers are present
+//
+// The studio launch loop and the dispatcher adapter share this helper so a
+// ticket cannot slip through one path while being gated by the other.
+// Run-store freshness (already-finished last run, etc.) is a separate check
+// owned by the admission loop — this is the board-side gate only.
+func CanLaunch(g IssueGetter, iss *Issue) bool {
+	return LaunchBlockedReason(g, iss) == ""
+}
+
+// LaunchBlockedReason returns a short machine reason when CanLaunch would
+// refuse, or "" when the board-side gate is clear.
+func LaunchBlockedReason(g IssueGetter, iss *Issue) string {
+	if iss == nil {
+		return "missing_issue"
+	}
+	if strings.TrimSpace(iss.Bot) == "" {
+		return "no_bot"
+	}
+	if iss.State == StateWaitingDeps {
+		return "waiting_deps"
+	}
+	if iss.State != StateReady {
+		return "not_ready"
+	}
+	ok, open := BlockersSatisfiedForIssue(g, iss)
+	if !ok {
+		for _, b := range open {
+			if len(b.MissingLabels) > 0 {
+				return "blocker_labels"
+			}
+		}
+		return "open_blockers"
+	}
+	return ""
+}
+
+// ReverseBlockers builds the reverse index for one issue id: every other
+// issue that lists it in Blockers. Computed on read (V1).
+func ReverseBlockers(all []*Issue, id string) []BlockingInfo {
+	if id == "" {
+		return nil
+	}
+	var out []BlockingInfo
+	for _, iss := range all {
+		if iss == nil {
+			continue
+		}
+		for _, b := range iss.Blockers {
+			if b == id {
+				out = append(out, BlockingInfo{ID: iss.ID, Title: iss.Title})
+				break
+			}
+		}
+	}
+	return out
+}
+
+// WouldCreateCycle reports whether setting issue id's blockers to the given
+// list would introduce a cycle (A→B→A). Missing blocker IDs cannot form a
+// path and are ignored; a self-reference is always a cycle.
+func WouldCreateCycle(g IssueGetter, id string, blockers []string) bool {
+	if id == "" {
+		return false
+	}
+	for _, b := range NormalizeBlockers(blockers) {
+		if b == id {
+			return true
+		}
+		if reaches(g, b, id, map[string]bool{}) {
+			return true
+		}
+	}
+	return false
+}
+
+func reaches(g IssueGetter, from, target string, visiting map[string]bool) bool {
+	if from == target {
+		return true
+	}
+	if visiting[from] {
+		return false
+	}
+	visiting[from] = true
+	iss, err := g.Get(from)
+	if err != nil || iss == nil {
+		return false
+	}
+	for _, b := range iss.Blockers {
+		if reaches(g, strings.TrimSpace(b), target, visiting) {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidateBlockers returns an error when the proposed blockers list would
+// create a cycle for issue id. Missing IDs are allowed (fail-closed at
+// launch); only cycles are rejected at write time.
+func ValidateBlockers(g IssueGetter, id string, blockers []string) error {
+	if WouldCreateCycle(g, id, blockers) {
+		return fmt.Errorf("blockers: cycle detected")
+	}
+	return nil
+}
+
+// AutoReadyFromArgs reports whether bot_args request auto-promotion to Ready
+// when the last hard blocker becomes done.
+func AutoReadyFromArgs(args map[string]string) bool {
+	if args == nil {
+		return false
+	}
+	v := strings.ToLower(strings.TrimSpace(args["auto_ready"]))
+	return v == "true" || v == "1" || v == "yes"
+}
+
+// UnblockTarget returns the state a waiting_deps ticket should move to when
+// its last hard blocker becomes done. Default: backlog (human decides Ready);
+// opt-in StateReady when bot_args.auto_ready is truthy. Empty when the board
+// lacks the preferred target (caller keeps the ticket put).
+func UnblockTarget(board *Board, iss *Issue) string {
+	if board == nil || iss == nil {
+		return ""
+	}
+	want := StateBacklog
+	if AutoReadyFromArgs(iss.BotArgs) {
+		want = StateReady
+	}
+	if board.StateByName(want) != nil {
+		return want
+	}
+	// Fallbacks: ready if backlog missing, else nothing.
+	if want != StateReady && board.StateByName(StateReady) != nil {
+		return StateReady
+	}
+	return ""
+}
+
+// PromoteUnblockedDependents is the BoardStore-facing auto-promote used after
+// a ticket reaches StateDone (Mongo store, or any backend without an
+// in-mutex index). Dependents in StateWaitingDeps whose hard blockers are
+// now all satisfied move to UnblockTarget. Best-effort: a failed promote
+// does not roll back the closed ticket. The filesystem *Store uses a
+// locked sibling inside SetState instead of this helper to avoid re-lock.
+func PromoteUnblockedDependents(store BoardStore, closedID string) error {
+	if store == nil || closedID == "" {
+		return nil
+	}
+	board := store.Board()
+	if board == nil || board.StateByName(StateWaitingDeps) == nil {
+		return nil
+	}
+	candidates, err := store.List(ListFilter{States: []string{StateWaitingDeps}})
+	if err != nil {
+		return err
+	}
+	for _, iss := range candidates {
+		if iss == nil {
+			continue
+		}
+		lists := false
+		for _, b := range iss.Blockers {
+			if b == closedID {
+				lists = true
+				break
+			}
+		}
+		if !lists {
+			continue
+		}
+		ok, _ := BlockersSatisfiedForIssue(store, iss)
+		if !ok {
+			continue
+		}
+		target := UnblockTarget(board, iss)
+		if target == "" || target == iss.State {
+			continue
+		}
+		// SetState may re-enter Promote on done only — target is backlog/ready.
+		if _, err := store.SetState(iss.ID, target); err != nil {
+			return err
+		}
+		// Note: issue_unblocked is emitted by the filesystem store's locked
+		// path; for BoardStore backends that only emit issue_state_changed,
+		// that event is still enough for audit tails. Mongo emit of
+		// EvtIssueUnblocked can be added when a second consumer needs it.
+	}
+	return nil
+}

--- a/pkg/dispatcher/native/blockers_test.go
+++ b/pkg/dispatcher/native/blockers_test.go
@@ -1,0 +1,210 @@
+package native_test
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+)
+
+func TestBlockerSatisfiedOnlyDone(t *testing.T) {
+	cases := []struct {
+		state string
+		want  bool
+	}{
+		{native.StateDone, true},
+		{native.StateBlocked, false}, // terminal but not success
+		{native.StateReady, false},
+		{native.StateInProgress, false},
+		{native.StateWaitingDeps, false},
+		{"", false},
+	}
+	for _, c := range cases {
+		got := native.BlockerSatisfied(&native.Issue{State: c.state})
+		if got != c.want {
+			t.Errorf("BlockerSatisfied(state=%q)=%v want %v", c.state, got, c.want)
+		}
+	}
+	if native.BlockerSatisfied(nil) {
+		t.Error("nil issue must not be satisfied")
+	}
+}
+
+func TestBlockersSatisfiedMissingIsOpen(t *testing.T) {
+	s, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	done, _ := s.Create(native.Issue{Title: "done", State: native.StateDone})
+	ok, open := native.BlockersSatisfied(s, []string{done.ID, "native:missing"})
+	if ok {
+		t.Fatal("missing blocker must fail closed")
+	}
+	if len(open) != 1 || open[0].ID != "native:missing" || open[0].Satisfied {
+		t.Fatalf("open = %+v", open)
+	}
+}
+
+func TestBlockersSatisfiedAllDone(t *testing.T) {
+	s, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, _ := s.Create(native.Issue{Title: "a", State: native.StateDone})
+	b, _ := s.Create(native.Issue{Title: "b", State: native.StateDone})
+	ok, open := native.BlockersSatisfied(s, []string{a.ID, b.ID})
+	if !ok || len(open) != 0 {
+		t.Fatalf("ok=%v open=%+v", ok, open)
+	}
+}
+
+func TestBlockersSatisfiedBlockedDoesNotCount(t *testing.T) {
+	s, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// StateBlocked is terminal but must NOT satisfy a hard dep.
+	blocked, _ := s.Create(native.Issue{Title: "abandoned", State: native.StateBlocked})
+	ok, open := native.BlockersSatisfied(s, []string{blocked.ID})
+	if ok {
+		t.Fatal("blocked (won't-do) must not satisfy a dep")
+	}
+	if len(open) != 1 || open[0].Satisfied {
+		t.Fatalf("open = %+v", open)
+	}
+}
+
+func TestCanLaunch(t *testing.T) {
+	s, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocker, _ := s.Create(native.Issue{Title: "mesh", State: native.StateInProgress, Bot: "mesh-bot"})
+	gated, _ := s.Create(native.Issue{
+		Title:    "feature",
+		State:    native.StateReady,
+		Bot:      "feature-bot",
+		Blockers: []string{blocker.ID},
+	})
+	if native.CanLaunch(s, gated) {
+		t.Fatal("ready + open blocker must not launch")
+	}
+	if got := native.LaunchBlockedReason(s, gated); got != "open_blockers" {
+		t.Fatalf("reason = %q, want open_blockers", got)
+	}
+
+	if _, err := s.SetState(blocker.ID, native.StateDone); err != nil {
+		t.Fatal(err)
+	}
+	// Reload gated — state unchanged.
+	gated, _ = s.Get(gated.ID)
+	if !native.CanLaunch(s, gated) {
+		t.Fatal("ready + all blockers done must launch")
+	}
+	if got := native.LaunchBlockedReason(s, gated); got != "" {
+		t.Fatalf("reason = %q, want empty", got)
+	}
+}
+
+func TestCanLaunchWaitingDepsNever(t *testing.T) {
+	s, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	iss, _ := s.Create(native.Issue{
+		Title: "waiting",
+		State: native.StateWaitingDeps,
+		Bot:   "feature-bot",
+	})
+	if native.CanLaunch(s, iss) {
+		t.Fatal("waiting_deps must never be launchable")
+	}
+	if got := native.LaunchBlockedReason(s, iss); got != "waiting_deps" {
+		t.Fatalf("reason = %q, want waiting_deps", got)
+	}
+}
+
+func TestCanLaunchNoBot(t *testing.T) {
+	s, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	iss, _ := s.Create(native.Issue{Title: "no bot", State: native.StateReady})
+	if native.CanLaunch(s, iss) {
+		t.Fatal("ticket without bot must not launch")
+	}
+	if got := native.LaunchBlockedReason(s, iss); got != "no_bot" {
+		t.Fatalf("reason = %q, want no_bot", got)
+	}
+}
+
+func TestValidateBlockersCycle(t *testing.T) {
+	s, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, _ := s.Create(native.Issue{Title: "a", State: native.StateBacklog})
+	b, _ := s.Create(native.Issue{Title: "b", State: native.StateBacklog, Blockers: []string{a.ID}})
+
+	// Setting a.blockers = [b] creates A→B→A.
+	if err := native.ValidateBlockers(s, a.ID, []string{b.ID}); err == nil {
+		t.Fatal("expected cycle error")
+	}
+	// Self-ref.
+	if err := native.ValidateBlockers(s, a.ID, []string{a.ID}); err == nil {
+		t.Fatal("expected self-cycle error")
+	}
+	// Acyclic is fine.
+	c, _ := s.Create(native.Issue{Title: "c", State: native.StateBacklog})
+	if err := native.ValidateBlockers(s, a.ID, []string{c.ID}); err != nil {
+		t.Fatalf("acyclic should pass: %v", err)
+	}
+}
+
+func TestNormalizeBlockers(t *testing.T) {
+	got := native.NormalizeBlockers([]string{"  a  ", "", "b", "a", " b "})
+	if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestReverseBlockers(t *testing.T) {
+	all := []*native.Issue{
+		{ID: "a", Title: "A", Blockers: []string{"x"}},
+		{ID: "b", Title: "B", Blockers: []string{"y", "x"}},
+		{ID: "c", Title: "C"},
+	}
+	got := native.ReverseBlockers(all, "x")
+	if len(got) != 2 {
+		t.Fatalf("got %+v", got)
+	}
+	if got[0].ID != "a" || got[1].ID != "b" {
+		t.Fatalf("order/ids = %+v", got)
+	}
+}
+
+func TestAutoReadyFromArgs(t *testing.T) {
+	if !native.AutoReadyFromArgs(map[string]string{"auto_ready": "true"}) {
+		t.Fatal("true")
+	}
+	if !native.AutoReadyFromArgs(map[string]string{"auto_ready": "1"}) {
+		t.Fatal("1")
+	}
+	if native.AutoReadyFromArgs(map[string]string{"auto_ready": "false"}) {
+		t.Fatal("false")
+	}
+	if native.AutoReadyFromArgs(nil) {
+		t.Fatal("nil")
+	}
+}
+
+func TestUnblockTarget(t *testing.T) {
+	board := native.DefaultBoard()
+	iss := &native.Issue{BotArgs: map[string]string{}}
+	if got := native.UnblockTarget(board, iss); got != native.StateBacklog {
+		t.Fatalf("default = %q, want backlog", got)
+	}
+	iss.BotArgs = map[string]string{"auto_ready": "true"}
+	if got := native.UnblockTarget(board, iss); got != native.StateReady {
+		t.Fatalf("auto_ready = %q, want ready", got)
+	}
+}

--- a/pkg/dispatcher/native/board.go
+++ b/pkg/dispatcher/native/board.go
@@ -11,10 +11,15 @@ import (
 // the shipped defaults should use the constants so renames stay
 // compile-checked.
 const (
-	StateInbox      = "inbox"
-	StateBacklog    = "backlog"
-	StateReady      = "ready"
-	StateInProgress = "in_progress"
+	StateInbox   = "inbox"
+	StateBacklog = "backlog"
+	StateReady   = "ready"
+	// StateWaitingDeps holds a ticket whose hard blockers are not yet
+	// StateDone. Non-eligible and non-terminal: the launch loop and the
+	// dispatcher skip it, and it does not satisfy anyone else's blockers
+	// (unlike StateBlocked, which is terminal "won't do").
+	StateWaitingDeps = "waiting_deps"
+	StateInProgress  = "in_progress"
 	// StateAwaitingInput holds a dispatched card whose run paused waiting for
 	// a human answer (paused_waiting_human). Non-eligible (the dispatcher
 	// never re-picks it) and non-terminal (the run resumes on answer). The
@@ -22,7 +27,10 @@ const (
 	StateAwaitingInput = "awaiting_input"
 	StateReview        = "review"
 	StateDone          = "done"
-	StateBlocked       = "blocked"
+	// StateBlocked is terminal "won't do" / abandoned — not a temporary
+	// hold for open deps (use StateWaitingDeps). A ticket in blocked does
+	// NOT satisfy hard blockers of dependents (see BlockerSatisfied).
+	StateBlocked = "blocked"
 )
 
 // FieldType enumerates the supported custom-field value kinds.
@@ -99,6 +107,7 @@ func DefaultBoard() *Board {
 			{Name: StateInbox, Display: "Inbox"},
 			{Name: StateBacklog, Display: "Backlog"},
 			{Name: StateReady, Display: "Ready", Eligible: true},
+			{Name: StateWaitingDeps, Display: "Waiting on deps"},
 			{Name: StateInProgress, Display: "In progress", Eligible: true},
 			{Name: StateAwaitingInput, Display: "Awaiting input"},
 			{Name: StateReview, Display: "Review"},
@@ -130,6 +139,10 @@ func (b *Board) StateByName(name string) *State {
 // their ordering.
 //
 //   - `inbox` (bot-emitted findings land there) is prepended when missing.
+//   - `waiting_deps` (tickets with open hard blockers) is inserted right
+//     after `ready` when missing; if there is no `ready`, after `backlog`.
+//     Boards with neither are left untouched — the launch gate still
+//     works via open_blocker_count alone.
 //   - `awaiting_input` (the dispatcher parks a paused card there) is
 //     inserted right after `in_progress` when missing. Boards without an
 //     `in_progress` state are fully custom — left untouched; the
@@ -139,6 +152,12 @@ func UpgradeBoardSchema(b *Board) bool {
 	if b.StateByName(StateInbox) == nil {
 		b.States = append([]State{{Name: StateInbox, Display: "Inbox"}}, b.States...)
 		changed = true
+	}
+	if b.StateByName(StateWaitingDeps) == nil {
+		if insertStateAfter(b, StateReady, State{Name: StateWaitingDeps, Display: "Waiting on deps"}) ||
+			insertStateAfter(b, StateBacklog, State{Name: StateWaitingDeps, Display: "Waiting on deps"}) {
+			changed = true
+		}
 	}
 	if b.StateByName(StateAwaitingInput) == nil {
 		for i, st := range b.States {
@@ -155,6 +174,26 @@ func UpgradeBoardSchema(b *Board) bool {
 		}
 	}
 	return changed
+}
+
+// insertStateAfter inserts st immediately after the state named after, if
+// that anchor exists. Returns true when it modified the board.
+func insertStateAfter(b *Board, after string, st State) bool {
+	if b == nil {
+		return false
+	}
+	for i, cur := range b.States {
+		if cur.Name != after {
+			continue
+		}
+		states := make([]State, 0, len(b.States)+1)
+		states = append(states, b.States[:i+1]...)
+		states = append(states, st)
+		states = append(states, b.States[i+1:]...)
+		b.States = states
+		return true
+	}
+	return false
 }
 
 // stateIndex returns the position of the state matching name, or -1.

--- a/pkg/dispatcher/native/boardops/ops.go
+++ b/pkg/dispatcher/native/boardops/ops.go
@@ -129,7 +129,7 @@ var allTools = []Tool{
 	{
 		Name:        "create_issue",
 		Capability:  CapBoardCreate,
-		Description: "Create a new issue on the native kanban board. Returns the created issue.",
+		Description: "Create a new issue on the native kanban board. Returns the created issue. When called from a planner run, parent_id/spawned_from is auto-stamped from the source ticket unless overridden.",
 		InputSchema: json.RawMessage(`{
           "type":"object",
           "properties":{
@@ -140,9 +140,10 @@ var allTools = []Tool{
             "priority":{"type":"integer","description":"Higher = more important. Default 0."},
             "assignee":{"type":"string","description":"Bot or user handle this issue is assigned to."},
             "blockers":{"type":"array","items":{"type":"string"},"description":"IDs of issues that must be terminal before this one is eligible."},
+            "parent_id":{"type":"string","description":"Planner ticket that spawned this one (provenance). Auto-filled from the creating run's source issue when omitted."},
             "fields":{"type":"object","description":"Custom board fields (validated against board schema)."},
             "bot":{"type":"string","description":"CANONICAL bot that runs this issue when the dispatcher picks it up (e.g. feature-dev). The dispatcher routes by bot first, else assignee."},
-            "bot_args":{"type":"object","additionalProperties":{"type":"string"},"description":"Per-ticket workflow var overrides (--var key=value) applied at launch."}
+            "bot_args":{"type":"object","additionalProperties":{"type":"string"},"description":"Per-ticket workflow var overrides (--var key=value) applied at launch. Use spawned_from for planner provenance (synced with parent_id)."}
           },
           "required":["title"]
         }`),
@@ -243,8 +244,8 @@ var toolByName = func() map[string]*Tool {
 // dispatchByName maps a tool name to its handler. Populated once at init
 // so Call can dispatch in O(1).
 var dispatchByName = map[string]func(native.BoardStore, json.RawMessage) (json.RawMessage, error){
-	"comment_issue":    doComment,
-	"create_issue":     doCreate,
+	"comment_issue": doComment,
+	// create_issue is dispatched via doCreate in CallWithEnv (needs CallEnv).
 	"transition_issue": doTransition,
 	"assign_issue":     doAssign,
 	"set_bot":          doSetBot,
@@ -267,16 +268,33 @@ func ToolsFor(caps Capabilities) []Tool {
 	return out
 }
 
+// CallEnv carries ambient context for a boardops invocation (e.g. the
+// source issue of the run that is calling create_issue).
+type CallEnv struct {
+	// SpawnParentID is the issue id of the ticket that owns the calling
+	// run. Used to auto-stamp parent_id / bot_args.spawned_from on create
+	// when the agent omits them. Empty = no auto parent.
+	SpawnParentID string
+}
+
 // Call dispatches a tool invocation. The result is a JSON-encoded value
 // suitable for direct embedding in an MCP `content[0].text` field or an
 // HTTP response body.
 func Call(store native.BoardStore, caps Capabilities, name string, rawArgs json.RawMessage) (json.RawMessage, error) {
+	return CallWithEnv(store, caps, name, rawArgs, CallEnv{})
+}
+
+// CallWithEnv is Call with ambient spawn context (planner → child stamp).
+func CallWithEnv(store native.BoardStore, caps Capabilities, name string, rawArgs json.RawMessage, env CallEnv) (json.RawMessage, error) {
 	t, ok := toolByName[name]
 	if !ok {
 		return nil, fmt.Errorf("unknown tool %q", name)
 	}
 	if !caps.Has(t.Capability) {
 		return nil, fmt.Errorf("%w: tool %q needs capability %q", ErrCapabilityDenied, name, t.Capability)
+	}
+	if name == "create_issue" {
+		return doCreate(store, rawArgs, env)
 	}
 	return dispatchByName[name](store, rawArgs)
 }
@@ -285,7 +303,7 @@ func Call(store native.BoardStore, caps Capabilities, name string, rawArgs json.
 // Operation implementations
 // ---------------------------------------------------------------------------
 
-func doCreate(store native.BoardStore, raw json.RawMessage) (json.RawMessage, error) {
+func doCreate(store native.BoardStore, raw json.RawMessage, env CallEnv) (json.RawMessage, error) {
 	var args struct {
 		Title    string            `json:"title"`
 		Body     string            `json:"body"`
@@ -294,6 +312,7 @@ func doCreate(store native.BoardStore, raw json.RawMessage) (json.RawMessage, er
 		Priority int               `json:"priority"`
 		Assignee string            `json:"assignee"`
 		Blockers []string          `json:"blockers"`
+		ParentID string            `json:"parent_id"`
 		Fields   map[string]any    `json:"fields"`
 		Bot      string            `json:"bot"`
 		BotArgs  map[string]string `json:"bot_args"`
@@ -304,6 +323,31 @@ func doCreate(store native.BoardStore, raw json.RawMessage) (json.RawMessage, er
 	if strings.TrimSpace(args.Title) == "" {
 		return nil, errors.New("title is required")
 	}
+	botArgs := args.BotArgs
+	if botArgs == nil {
+		botArgs = map[string]string{}
+	} else {
+		// Defensive copy so we don't mutate the caller's map.
+		cp := make(map[string]string, len(botArgs)+1)
+		for k, v := range botArgs {
+			cp[k] = v
+		}
+		botArgs = cp
+	}
+	parentID := strings.TrimSpace(args.ParentID)
+	if parentID == "" {
+		parentID = strings.TrimSpace(botArgs[native.BotArgSpawnedFrom])
+	}
+	if parentID == "" {
+		parentID = strings.TrimSpace(env.SpawnParentID)
+	}
+	if parentID != "" {
+		botArgs[native.BotArgSpawnedFrom] = parentID
+	}
+	// Empty map → nil for cleaner JSON.
+	if len(botArgs) == 0 {
+		botArgs = nil
+	}
 	iss, err := store.Create(native.Issue{
 		Title:    args.Title,
 		Body:     args.Body,
@@ -312,9 +356,10 @@ func doCreate(store native.BoardStore, raw json.RawMessage) (json.RawMessage, er
 		Priority: args.Priority,
 		Assignee: args.Assignee,
 		Blockers: args.Blockers,
+		ParentID: parentID,
 		Fields:   args.Fields,
 		Bot:      args.Bot,
-		BotArgs:  args.BotArgs,
+		BotArgs:  botArgs,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/dispatcher/native/boardops/ops_test.go
+++ b/pkg/dispatcher/native/boardops/ops_test.go
@@ -281,3 +281,42 @@ func TestClose_RejectsNonTerminalTarget(t *testing.T) {
 		t.Fatalf("expected not-terminal rejection, got %v", err)
 	}
 }
+
+func TestCreateIssue_ParentIDAndAutoSpawn(t *testing.T) {
+	dir := t.TempDir()
+	s, err := native.NewStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	caps := NewCapabilities("board.create,board.read")
+
+	// Explicit parent_id
+	raw, err := Call(s, caps, "create_issue", json.RawMessage(
+		`{"title":"child","parent_id":"native:planner-1","bot":"producer"}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var child native.Issue
+	if err := json.Unmarshal(raw, &child); err != nil {
+		t.Fatal(err)
+	}
+	if child.ParentID != "native:planner-1" {
+		t.Fatalf("ParentID = %q", child.ParentID)
+	}
+	if child.BotArgs[native.BotArgSpawnedFrom] != "native:planner-1" {
+		t.Fatalf("spawned_from = %v", child.BotArgs)
+	}
+
+	// Auto from CallEnv
+	raw2, err := CallWithEnv(s, caps, "create_issue", json.RawMessage(`{"title":"auto-child"}`), CallEnv{SpawnParentID: "native:auto-parent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var child2 native.Issue
+	_ = json.Unmarshal(raw2, &child2)
+	if child2.ParentID != "native:auto-parent" {
+		t.Fatalf("auto ParentID = %q", child2.ParentID)
+	}
+}

--- a/pkg/dispatcher/native/event.go
+++ b/pkg/dispatcher/native/event.go
@@ -14,7 +14,14 @@ const (
 	EvtIssueReleased EventType = "issue_released"
 	EvtIssueLastRun  EventType = "issue_last_run_updated"
 	EvtIssueComment  EventType = "issue_comment_added"
-	EvtBoardUpdated  EventType = "board_updated"
+	// EvtIssueBlockersUpdated is emitted when an issue's blockers list changes
+	// (create-with-blockers, Update patch). Payload: {blockers: []string}.
+	EvtIssueBlockersUpdated EventType = "issue_blockers_updated"
+	// EvtIssueUnblocked is emitted when a waiting_deps ticket is auto-
+	// promoted because its last hard blocker reached StateDone. Payload:
+	// {from, to, closed_blocker}.
+	EvtIssueUnblocked EventType = "issue_unblocked"
+	EvtBoardUpdated   EventType = "board_updated"
 	// Label-vocabulary management events, emitted once per touched
 	// issue. The payload carries `{from, to}` for rename/merge and
 	// `{label}` for delete.

--- a/pkg/dispatcher/native/issue.go
+++ b/pkg/dispatcher/native/issue.go
@@ -6,14 +6,21 @@ import "time"
 // dispatcher consumes a normalized view via tracker.Issue (see
 // pkg/dispatcher/tracker/native.go for the conversion).
 type Issue struct {
-	ID       string         `json:"id"`
-	Title    string         `json:"title"`
-	Body     string         `json:"body,omitempty"`
-	State    string         `json:"state"`
-	Labels   []string       `json:"labels,omitempty"`
-	Priority int            `json:"priority,omitempty"`
-	Assignee string         `json:"assignee,omitempty"`
-	Blockers []string       `json:"blockers,omitempty"`
+	ID       string   `json:"id"`
+	Title    string   `json:"title"`
+	Body     string   `json:"body,omitempty"`
+	State    string   `json:"state"`
+	Labels   []string `json:"labels,omitempty"`
+	Priority int      `json:"priority,omitempty"`
+	Assignee string   `json:"assignee,omitempty"`
+	Blockers []string `json:"blockers,omitempty"`
+	// ParentID is the planner (or prior planner) ticket that spawned this
+	// one. Distinct from Blockers (scheduling deps): ParentID is provenance
+	// / campaign ownership so the /pipelines UI can nest children under a
+	// plan. Empty for root tickets. Stamped automatically by board.create
+	// when the creating run is sourced from a ticket, or set explicitly via
+	// create_issue parent_id / bot_args.spawned_from.
+	ParentID string         `json:"parent_id,omitempty"`
 	Fields   map[string]any `json:"fields,omitempty"`
 	// Bot, when non-empty, overrides the dispatcher's per-assignee /
 	// global workflow selection for this ticket. The dispatcher

--- a/pkg/dispatcher/native/store_issues.go
+++ b/pkg/dispatcher/native/store_issues.go
@@ -37,6 +37,8 @@ func (s *Store) Create(in Issue) (created *Issue, err error) {
 	if err := s.board.ValidateFieldValues(in.Fields); err != nil {
 		return nil, err
 	}
+	in.Blockers = NormalizeBlockers(in.Blockers)
+	in.ParentID = strings.TrimSpace(in.ParentID)
 
 	if in.ID == "" {
 		in.ID = "native:" + uuid.NewString()
@@ -45,6 +47,13 @@ func (s *Store) Create(in Issue) (created *Issue, err error) {
 	}
 	if _, exists := s.index[in.ID]; exists {
 		return nil, fmt.Errorf("issue: id %q already exists", in.ID)
+	}
+	if in.ParentID == in.ID {
+		return nil, errors.New("issue: parent_id cannot be self")
+	}
+	// Cycle check once the final id is known (catches self-ref + A→B→A).
+	if err := s.validateBlockersLocked(in.ID, in.Blockers); err != nil {
+		return nil, err
 	}
 	now := time.Now().UTC()
 	in.CreatedAt = now
@@ -59,6 +68,15 @@ func (s *Store) Create(in Issue) (created *Issue, err error) {
 		Payload: map[string]any{"state": in.State, "title": in.Title},
 	}); err != nil {
 		return nil, err
+	}
+	if len(in.Blockers) > 0 {
+		if err := s.emitPostCommitEvent(Event{
+			Type:    EvtIssueBlockersUpdated,
+			IssueID: in.ID,
+			Payload: map[string]any{"blockers": append([]string(nil), in.Blockers...)},
+		}); err != nil {
+			return nil, err
+		}
 	}
 	clone := in
 	return &clone, nil
@@ -177,6 +195,9 @@ type Patch struct {
 	Priority *int
 	Assignee *string
 	Blockers *[]string
+	// ParentID, when non-nil, sets the planner provenance pointer (empty
+	// string clears it). Distinct from Blockers.
+	ParentID *string
 	// Fields is merged into the issue's Fields. A nil value deletes the key.
 	Fields map[string]any
 	// Bot, when non-nil, sets the per-ticket bot override (empty string
@@ -226,9 +247,23 @@ func (s *Store) Update(id string, p Patch) (updated *Issue, err error) {
 		iss.Assignee = *p.Assignee
 		changed = append(changed, "assignee")
 	}
+	if p.ParentID != nil && *p.ParentID != iss.ParentID {
+		pid := strings.TrimSpace(*p.ParentID)
+		if pid == id {
+			return nil, errors.New("issue: parent_id cannot be self")
+		}
+		iss.ParentID = pid
+		changed = append(changed, "parent_id")
+	}
+	blockersChanged := false
 	if p.Blockers != nil {
-		iss.Blockers = append([]string(nil), (*p.Blockers)...)
+		next := NormalizeBlockers(*p.Blockers)
+		if err := s.validateBlockersLocked(id, next); err != nil {
+			return nil, err
+		}
+		iss.Blockers = next
 		changed = append(changed, "blockers")
+		blockersChanged = true
 	}
 	if len(p.Fields) > 0 {
 		merged := map[string]any{}
@@ -283,11 +318,23 @@ func (s *Store) Update(id string, p Patch) (updated *Issue, err error) {
 	}); err != nil {
 		return nil, err
 	}
+	if blockersChanged {
+		if err := s.emitPostCommitEvent(Event{
+			Type:    EvtIssueBlockersUpdated,
+			IssueID: iss.ID,
+			Payload: map[string]any{"blockers": append([]string(nil), iss.Blockers...)},
+		}); err != nil {
+			return nil, err
+		}
+	}
 	return iss, nil
 }
 
 // SetState transitions an issue, validating against the board. Returns
-// tracker.ErrTransitionRejected if newState is unknown.
+// tracker.ErrTransitionRejected if newState is unknown. When the new
+// state is StateDone, dependents parked in StateWaitingDeps whose hard
+// blockers are now all satisfied are auto-promoted (default → backlog,
+// or → ready when bot_args.auto_ready is set) and emit issue_unblocked.
 func (s *Store) SetState(id, newState string) (updated *Issue, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -316,7 +363,100 @@ func (s *Store) SetState(id, newState string) (updated *Issue, err error) {
 	}); err != nil {
 		return nil, err
 	}
+	if newState == StateDone {
+		// Best-effort: a failed auto-promote must not roll back the
+		// successful transition that just committed.
+		_ = s.promoteUnblockedDependentsLocked(id)
+	}
 	return iss, nil
+}
+
+// validateBlockersLocked rejects cycles against the in-memory index. Caller
+// must hold s.mu. Uses a locked IssueGetter so Get is not re-entered.
+func (s *Store) validateBlockersLocked(id string, blockers []string) error {
+	return ValidateBlockers(lockedIssueGetter{s: s}, id, blockers)
+}
+
+// promoteUnblockedDependentsLocked walks every issue that lists closedID as
+// a blocker. Those currently in StateWaitingDeps with all blockers now
+// satisfied are moved to UnblockTarget and emit EvtIssueUnblocked. Caller
+// holds s.mu.
+func (s *Store) promoteUnblockedDependentsLocked(closedID string) error {
+	if closedID == "" || s.board.StateByName(StateWaitingDeps) == nil {
+		return nil
+	}
+	// Snapshot IDs first — promote mutates the index.
+	var candidates []string
+	for id, iss := range s.index {
+		if iss == nil || iss.State != StateWaitingDeps {
+			continue
+		}
+		for _, b := range iss.Blockers {
+			if b == closedID {
+				candidates = append(candidates, id)
+				break
+			}
+		}
+	}
+	g := lockedIssueGetter{s: s}
+	for _, id := range candidates {
+		iss := s.index[id]
+		if iss == nil || iss.State != StateWaitingDeps {
+			continue
+		}
+		ok, _ := BlockersSatisfiedForIssue(g, iss)
+		if !ok {
+			continue
+		}
+		target := UnblockTarget(s.board, iss)
+		if target == "" || target == iss.State {
+			continue
+		}
+		if s.board.StateByName(target) == nil {
+			continue
+		}
+		from := iss.State
+		// Mutate a clone then write — index holds shared pointers.
+		next := cloneIssue(iss)
+		next.State = target
+		next.UpdatedAt = time.Now().UTC()
+		if err := s.writeIssueLocked(next); err != nil {
+			return err
+		}
+		s.index[id] = cloneIssue(next)
+		if err := s.emitPostCommitEvent(Event{
+			Type:    EvtIssueUnblocked,
+			IssueID: id,
+			Payload: map[string]any{
+				"from":           from,
+				"to":             target,
+				"closed_blocker": closedID,
+			},
+		}); err != nil {
+			return err
+		}
+		// Also emit a state-changed for consumers that only watch that type.
+		if err := s.emitPostCommitEvent(Event{
+			Type:    EvtIssueState,
+			IssueID: id,
+			Payload: map[string]any{"from": from, "to": target, "reason": "unblocked"},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// lockedIssueGetter implements IssueGetter using the store's index without
+// taking the mutex — only safe while the caller already holds s.mu.
+type lockedIssueGetter struct{ s *Store }
+
+func (g lockedIssueGetter) Get(id string) (*Issue, error) {
+	iss, ok := g.s.index[id]
+	if !ok || iss == nil {
+		return nil, tracker.ErrNotFound
+	}
+	return cloneIssue(iss), nil
 }
 
 // Delete removes the issue file and emits an issue_deleted event.

--- a/pkg/dispatcher/native/store_test.go
+++ b/pkg/dispatcher/native/store_test.go
@@ -67,11 +67,15 @@ func TestNewStorePrependsInboxToLegacyBoard(t *testing.T) {
 	}
 
 	got := s.Board().States
-	if len(got) != 4 {
-		t.Fatalf("want 4 states after inbox prepend, got %d: %+v", len(got), got)
+	// Upgrade also inserts waiting_deps after ready → 5 states.
+	if len(got) != 5 {
+		t.Fatalf("want 5 states after schema upgrade, got %d: %+v", len(got), got)
 	}
 	if got[0].Name != StateInbox {
 		t.Fatalf("want inbox as first state, got %q", got[0].Name)
+	}
+	if got[2].Name != StateReady || got[3].Name != StateWaitingDeps {
+		t.Fatalf("want waiting_deps after ready, got %+v", got)
 	}
 
 	// Re-load to confirm the upgrade was persisted (idempotent: a
@@ -80,8 +84,8 @@ func TestNewStorePrependsInboxToLegacyBoard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStore (second pass): %v", err)
 	}
-	if len(s2.Board().States) != 4 {
-		t.Fatalf("inbox prepended twice: %+v", s2.Board().States)
+	if len(s2.Board().States) != 5 {
+		t.Fatalf("schema upgrade ran twice: %+v", s2.Board().States)
 	}
 }
 
@@ -114,14 +118,23 @@ func TestNewStoreInsertsAwaitingInputAfterInProgress(t *testing.T) {
 	}
 
 	got := s.Board().States
-	if len(got) != 5 {
-		t.Fatalf("want 5 states after awaiting-input insert, got %d: %+v", len(got), got)
+	// Upgrade inserts waiting_deps (after ready) + awaiting_input (after in_progress).
+	// Legacy had: inbox, ready, in_progress, done → +2 = 6.
+	if len(got) != 6 {
+		t.Fatalf("want 6 states after schema upgrade, got %d: %+v", len(got), got)
 	}
-	if got[2].Name != StateInProgress || got[3].Name != StateAwaitingInput {
+	// ready → waiting_deps → in_progress → awaiting_input
+	if got[1].Name != StateReady || got[2].Name != StateWaitingDeps {
+		t.Fatalf("want waiting_deps right after ready, got %+v", got)
+	}
+	if got[2].Eligible || got[2].Terminal {
+		t.Fatalf("waiting_deps must be non-eligible, non-terminal: %+v", got[2])
+	}
+	if got[3].Name != StateInProgress || got[4].Name != StateAwaitingInput {
 		t.Fatalf("want awaiting_input right after in_progress, got %+v", got)
 	}
-	if got[3].Eligible || got[3].Terminal {
-		t.Fatalf("awaiting_input must be non-eligible, non-terminal: %+v", got[3])
+	if got[4].Eligible || got[4].Terminal {
+		t.Fatalf("awaiting_input must be non-eligible, non-terminal: %+v", got[4])
 	}
 
 	// Re-load to confirm the upgrade was persisted and is idempotent.
@@ -129,8 +142,8 @@ func TestNewStoreInsertsAwaitingInputAfterInProgress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStore (second pass): %v", err)
 	}
-	if len(s2.Board().States) != 5 {
-		t.Fatalf("awaiting_input inserted twice: %+v", s2.Board().States)
+	if len(s2.Board().States) != 6 {
+		t.Fatalf("schema upgrade inserted twice: %+v", s2.Board().States)
 	}
 }
 
@@ -150,7 +163,7 @@ func TestUpgradeBoardSchema(t *testing.T) {
 	for _, s := range legacy.States {
 		names = append(names, s.Name)
 	}
-	want := []string{StateInbox, StateBacklog, StateReady, StateInProgress, StateAwaitingInput, StateDone}
+	want := []string{StateInbox, StateBacklog, StateReady, StateWaitingDeps, StateInProgress, StateAwaitingInput, StateDone}
 	if len(names) != len(want) {
 		t.Fatalf("states = %v, want %v", names, want)
 	}

--- a/pkg/dispatcher/native/ticket_contract.go
+++ b/pkg/dispatcher/native/ticket_contract.go
@@ -1,0 +1,149 @@
+package native
+
+import (
+	"strings"
+)
+
+// Well-known BotArgs keys for cross-bot multi-pipeline tickets. Iterion does
+// not interpret Town/game-specific semantics beyond what admission and the
+// /pipelines UI need; bots own the request JSON on disk pointed by InputPathKey.
+//
+// See docs/native-tracker.md § Ticket contract (bot_args) and ADR-076.
+const (
+	// BotArgInputPath is the primary immutable request file path (relative to
+	// the workspace). Upsert key with Bot: (bot, input_path).
+	BotArgInputPath = "input_path"
+	// BotArgRevisionID / BotArgRequestHash — immutability / cache identity.
+	BotArgRevisionID  = "revision_id"
+	BotArgRequestHash = "request_hash"
+	// Correlation ids.
+	BotArgAssetID   = "asset_id"
+	BotArgFeatureID = "feature_id"
+	BotArgFamilyID  = "family_id"
+	// BotArgPipelineKind — mesh | humanoid | feature | custom (filter surface).
+	BotArgPipelineKind = "pipeline_kind"
+	// Serialized artefact / dependency lists (JSON strings in bot_args).
+	BotArgProduces = "produces"
+	BotArgConsumes = "consumes"
+	BotArgDocRefs  = "doc_refs"
+	// BotArgAutoReady — when truthy, waiting_deps → ready on unblock (else backlog).
+	BotArgAutoReady = "auto_ready"
+	// BotArgRequireBlockerLabels — comma-separated labels every hard blocker
+	// must also carry once done (e.g. "accepted"). Empty = state-only gate.
+	BotArgRequireBlockerLabels = "require_blocker_labels"
+	// BotArgSpawnedFrom — planner ticket id that published this card. Kept in
+	// bot_args for contract visibility; Issue.ParentID is the store-canonical
+	// pointer (kept in sync on create). Distinct from blockers.
+	BotArgSpawnedFrom = "spawned_from"
+	// BotArgRole — optional planner|producer hint for UI grouping. Prefer
+	// stamping on planner-published tickets (role=producer) and planner roots
+	// (role=planner); empty = infer from parent/children.
+	BotArgRole = "role"
+)
+
+// ContractDisplayKeys are bot_args keys the /pipelines drawer surfaces in a
+// dedicated “Contract” strip (not buried in a generic key dump).
+var ContractDisplayKeys = []string{
+	BotArgInputPath,
+	BotArgAssetID,
+	BotArgFeatureID,
+	BotArgFamilyID,
+	BotArgPipelineKind,
+	BotArgProduces,
+	BotArgConsumes,
+	BotArgRevisionID,
+	BotArgRequestHash,
+	BotArgDocRefs,
+	BotArgAutoReady,
+	BotArgRequireBlockerLabels,
+	BotArgSpawnedFrom,
+	BotArgRole,
+}
+
+// UpsertKey returns the (bot, input_path) pair used for ticket reconcile, or
+// ("","") when upsert is not possible.
+func UpsertKey(bot string, args map[string]string) (botName, inputPath string, ok bool) {
+	botName = strings.TrimSpace(bot)
+	if botName == "" || args == nil {
+		return "", "", false
+	}
+	inputPath = strings.TrimSpace(args[BotArgInputPath])
+	if inputPath == "" {
+		return "", "", false
+	}
+	return botName, inputPath, true
+}
+
+// RequireBlockerLabels parses bot_args.require_blocker_labels into a clean list.
+func RequireBlockerLabels(args map[string]string) []string {
+	if args == nil {
+		return nil
+	}
+	raw := strings.TrimSpace(args[BotArgRequireBlockerLabels])
+	if raw == "" {
+		return nil
+	}
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ';' || r == ' '
+	})
+	out := make([]string, 0, len(parts))
+	seen := map[string]struct{}{}
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	return out
+}
+
+// IssueHasAllLabels reports whether iss carries every required label.
+func IssueHasAllLabels(iss *Issue, labels []string) bool {
+	if len(labels) == 0 {
+		return true
+	}
+	if iss == nil {
+		return false
+	}
+	have := make(map[string]struct{}, len(iss.Labels))
+	for _, l := range iss.Labels {
+		have[l] = struct{}{}
+	}
+	for _, want := range labels {
+		if _, ok := have[want]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// FindByBotInputPath returns the first issue matching bot + bot_args.input_path.
+// Used by pipeline-board upsert. Match is exact on both strings.
+func FindByBotInputPath(store BoardStore, bot, inputPath string) (*Issue, error) {
+	bot = strings.TrimSpace(bot)
+	inputPath = strings.TrimSpace(inputPath)
+	if bot == "" || inputPath == "" {
+		return nil, nil
+	}
+	all, err := store.List(ListFilter{})
+	if err != nil {
+		return nil, err
+	}
+	for _, iss := range all {
+		if iss == nil || iss.Bot != bot {
+			continue
+		}
+		if iss.BotArgs == nil {
+			continue
+		}
+		if strings.TrimSpace(iss.BotArgs[BotArgInputPath]) == inputPath {
+			return iss, nil
+		}
+	}
+	return nil, nil
+}

--- a/pkg/dispatcher/native/ticket_contract_test.go
+++ b/pkg/dispatcher/native/ticket_contract_test.go
@@ -1,0 +1,86 @@
+package native_test
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+)
+
+func TestFindByBotInputPath(t *testing.T) {
+	s, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, _ := s.Create(native.Issue{
+		Title: "mesh A", Bot: "mesh-bot", State: native.StateBacklog,
+		BotArgs: map[string]string{native.BotArgInputPath: "requests/a.json"},
+	})
+	_, _ = s.Create(native.Issue{
+		Title: "other", Bot: "mesh-bot", State: native.StateBacklog,
+		BotArgs: map[string]string{native.BotArgInputPath: "requests/b.json"},
+	})
+
+	got, err := native.FindByBotInputPath(s, "mesh-bot", "requests/a.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.ID != a.ID {
+		t.Fatalf("got %+v, want %s", got, a.ID)
+	}
+	miss, _ := native.FindByBotInputPath(s, "mesh-bot", "requests/nope.json")
+	if miss != nil {
+		t.Fatal("expected nil for missing path")
+	}
+}
+
+func TestRequireBlockerLabels(t *testing.T) {
+	got := native.RequireBlockerLabels(map[string]string{
+		native.BotArgRequireBlockerLabels: "accepted, qa",
+	})
+	if len(got) != 2 || got[0] != "accepted" || got[1] != "qa" {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestBlockersSatisfiedRequireLabels(t *testing.T) {
+	s, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Done but missing accepted label.
+	dep, _ := s.Create(native.Issue{
+		Title: "mesh", State: native.StateDone, Bot: "mesh",
+		Labels: []string{"source:planner"},
+	})
+	feature, _ := s.Create(native.Issue{
+		Title: "feat", State: native.StateReady, Bot: "feature",
+		Blockers: []string{dep.ID},
+		BotArgs:  map[string]string{native.BotArgRequireBlockerLabels: "accepted"},
+	})
+	if native.CanLaunch(s, feature) {
+		t.Fatal("must not launch without accepted label on blocker")
+	}
+	if got := native.LaunchBlockedReason(s, feature); got != "blocker_labels" {
+		t.Fatalf("reason = %q, want blocker_labels", got)
+	}
+	// Stamp accepted.
+	labels := []string{"source:planner", "accepted"}
+	if _, err := s.Update(dep.ID, native.Patch{Labels: &labels}); err != nil {
+		t.Fatal(err)
+	}
+	feature, _ = s.Get(feature.ID)
+	if !native.CanLaunch(s, feature) {
+		t.Fatal("must launch once blocker has accepted")
+	}
+}
+
+func TestUpsertKey(t *testing.T) {
+	_, _, ok := native.UpsertKey("bot", nil)
+	if ok {
+		t.Fatal("nil args")
+	}
+	b, p, ok := native.UpsertKey("bot", map[string]string{native.BotArgInputPath: "x.json"})
+	if !ok || b != "bot" || p != "x.json" {
+		t.Fatalf("got %q %q %v", b, p, ok)
+	}
+}

--- a/pkg/dispatcher/native/unblock_test.go
+++ b/pkg/dispatcher/native/unblock_test.go
@@ -1,0 +1,117 @@
+package native_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+)
+
+func TestPromoteUnblockedDependentsToBacklog(t *testing.T) {
+	s, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mesh, err := s.Create(native.Issue{Title: "mesh", State: native.StateInProgress, Bot: "mesh"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	feature, err := s.Create(native.Issue{
+		Title:    "feature",
+		State:    native.StateWaitingDeps,
+		Bot:      "feature",
+		Blockers: []string{mesh.ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.SetState(mesh.ID, native.StateDone); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Get(feature.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != native.StateBacklog {
+		t.Fatalf("feature state = %q, want backlog after unblock", got.State)
+	}
+
+	// Audit: issue_unblocked event present.
+	found := false
+	_ = s.ScanEvents(func(ev *native.Event) bool {
+		if ev.Type == native.EvtIssueUnblocked && ev.IssueID == feature.ID {
+			found = true
+			return false
+		}
+		return true
+	})
+	if !found {
+		t.Fatal("expected issue_unblocked event")
+	}
+}
+
+func TestPromoteUnblockedDependentsAutoReady(t *testing.T) {
+	s, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mesh, _ := s.Create(native.Issue{Title: "mesh", State: native.StateInProgress, Bot: "mesh"})
+	feature, _ := s.Create(native.Issue{
+		Title:    "feature",
+		State:    native.StateWaitingDeps,
+		Bot:      "feature",
+		Blockers: []string{mesh.ID},
+		BotArgs:  map[string]string{"auto_ready": "true"},
+	})
+	if _, err := s.SetState(mesh.ID, native.StateDone); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := s.Get(feature.ID)
+	if got.State != native.StateReady {
+		t.Fatalf("auto_ready feature state = %q, want ready", got.State)
+	}
+	if !native.CanLaunch(s, got) {
+		t.Fatal("auto_ready feature must be CanLaunch after unblock")
+	}
+}
+
+func TestCreateRejectsBlockerCycle(t *testing.T) {
+	s, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, _ := s.Create(native.Issue{Title: "a", State: native.StateBacklog})
+	b, err := s.Create(native.Issue{Title: "b", State: native.StateBacklog, Blockers: []string{a.ID}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Patch a to block on b → cycle.
+	blockers := []string{b.ID}
+	if _, err := s.Update(a.ID, native.Patch{Blockers: &blockers}); err == nil {
+		t.Fatal("expected cycle rejection on Update")
+	}
+}
+
+func TestWaitingDepsNotDispatched(t *testing.T) {
+	a, s := newAdapter(t)
+	_, _ = s.Create(native.Issue{
+		Title: "waiting",
+		State: native.StateWaitingDeps,
+		Bot:   "feature",
+	})
+	// Also put a ready free ticket so the board isn't empty of eligibles.
+	ready, _ := s.Create(native.Issue{Title: "go", State: native.StateReady, Bot: "mesh"})
+	cands, err := a.ListCandidates(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range cands {
+		if c.ID != ready.ID {
+			t.Fatalf("unexpected candidate %s", c.ID)
+		}
+	}
+	if len(cands) != 1 {
+		t.Fatalf("candidates = %d, want 1", len(cands))
+	}
+}

--- a/pkg/runview/executor.go
+++ b/pkg/runview/executor.go
@@ -62,6 +62,10 @@ type ExecutorSpec struct {
 	RunID    string
 	Logger   *iterlog.Logger
 	StoreDir string
+	// SourceIssueID is the ticket that owns this run (dispatcher / pipeline
+	// launch). Empty for ad-hoc runs. Used to auto-stamp parent_id when the
+	// bot creates child tickets via board.create.
+	SourceIssueID string
 	// ExtraHooks are merged into the store-backed event hooks. Pass
 	// the prometheus exporter's hooks here (cli does this); the HTTP
 	// service can pass nothing or a future broker-side hook chain.
@@ -104,7 +108,7 @@ type ExecutorSpec struct {
 	// path): it registers the node's board caps with the server's token
 	// registry and returns the token. nil (CLI) leaves sandboxed
 	// board-emit disabled.
-	BoardRegister func(caps []string) string
+	BoardRegister func(caps []string, sourceIssueID string) string
 	// Compress is the run-level command-output-compression override ("",
 	// "on", "ultra", "off"), forwarded to the executor as the highest-priority
 	// input to rewrite.Resolve (above node/workflow DSL and ITERION_COMPRESS).
@@ -288,6 +292,9 @@ func BuildExecutor(spec ExecutorSpec) (*model.ClawExecutor, error) {
 		model.WithPermissionOverride(spec.Permission),
 		model.WithPermissionRules(spec.PermissionAllow, spec.PermissionAsk, spec.PermissionDeny),
 	}
+	if sid := resolveSourceIssueID(spec); sid != "" {
+		opts = append(opts, model.WithSourceIssueID(sid))
+	}
 	if spec.BoardRegister != nil {
 		opts = append(opts, model.WithBoardRegister(spec.BoardRegister))
 	}
@@ -382,6 +389,9 @@ func BuildExecutor(spec ExecutorSpec) (*model.ClawExecutor, error) {
 			boardCfg := &tool.BoardConfig{
 				Store:        ns,
 				Capabilities: boardops.AllCapabilities(),
+				// The owning ticket travels with the tools so board.create
+				// auto-stamps parent_id / spawned_from on spawned children.
+				SourceIssueID: resolveSourceIssueID(spec),
 			}
 			if err := tool.RegisterClawBoardTools(toolReg, boardCfg); err != nil {
 				spec.Logger.Warn("runview: RegisterClawBoardTools: %v", err)
@@ -555,4 +565,32 @@ func newLLMClassifierFromEnv(reg *model.Registry, logger *iterlog.Logger) (permi
 		Cache:     permissions.NewClassifierCache(30 * time.Minute),
 		MaxTokens: 64,
 	}, nil
+}
+
+// resolveSourceIssueID returns the ticket that owns this run: explicit
+// ExecutorSpec.SourceIssueID first, else LoadRun(Source.IssueID) when the
+// store can load the record. Empty for ad-hoc launches.
+func resolveSourceIssueID(spec ExecutorSpec) string {
+	if id := strings.TrimSpace(spec.SourceIssueID); id != "" {
+		return id
+	}
+	if spec.RunID == "" {
+		return ""
+	}
+	type runLoader interface {
+		LoadRun(ctx context.Context, id string) (*store.Run, error)
+	}
+	loader, ok := spec.Store.(runLoader)
+	if !ok {
+		return ""
+	}
+	ctx := spec.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	r, err := loader.LoadRun(ctx, spec.RunID)
+	if err != nil || r == nil || r.Source == nil {
+		return ""
+	}
+	return strings.TrimSpace(r.Source.IssueID)
 }

--- a/pkg/runview/service.go
+++ b/pkg/runview/service.go
@@ -378,7 +378,7 @@ type Service struct {
 	// board tokens. Both nil unless the server wires them via
 	// WithBoardMCP — sandboxed board-emit then stays disabled.
 	boardMCPHandler http.Handler
-	boardRegister   func(caps []string) string
+	boardRegister   func(caps []string, sourceIssueID string) string
 	// workDir is the directory the engine should treat as ${PROJECT_DIR}
 	// and as the repo-lookup seed for worktree: auto. Empty means
 	// "default to os.Getwd() at Run() time" — the right thing for the
@@ -633,7 +633,7 @@ func WithStore(s store.RunStore) ServiceOption {
 // server mux. register mints a per-node run token against the server's
 // BoardMCPTokenRegistry. Both are threaded into the engine + executor so
 // sandboxed claude_code can write the operator's board.
-func WithBoardMCP(handler http.Handler, register func(caps []string) string) ServiceOption {
+func WithBoardMCP(handler http.Handler, register func(caps []string, sourceIssueID string) string) ServiceOption {
 	return func(svc *Service) {
 		svc.boardMCPHandler = handler
 		svc.boardRegister = register

--- a/pkg/server/bots_routes.go
+++ b/pkg/server/bots_routes.go
@@ -17,23 +17,41 @@ import (
 // share one type for "where to look for bots".
 type BotsConfig = botregistry.Config
 
+// currentWorkDir snapshots cfg.WorkDir under the state lock — it is
+// hot-swapped on a studio project switch (swapWorkDir).
+func (s *Server) currentWorkDir() string {
+	s.stateMu.RLock()
+	defer s.stateMu.RUnlock()
+	return s.cfg.WorkDir
+}
+
 // effectivePaths returns the configured bot paths, falling back to the
-// project-relative conventions when none are configured.
+// project-relative conventions when none are configured. Only an
+// explicit --bots-path pins the catalog; the default derives from the
+// LIVE WorkDir on every call so bot discovery follows a project switch.
 func (s *Server) effectivePaths() []string {
+	return s.effectivePathsFor(s.currentWorkDir())
+}
+
+func (s *Server) effectivePathsFor(workDir string) []string {
 	if len(s.cfg.Bots.Paths) > 0 {
 		return s.cfg.Bots.Paths
 	}
-	if s.cfg.WorkDir == "" {
+	if workDir == "" {
 		return nil
 	}
-	return botregistry.DefaultPaths(s.cfg.WorkDir)
+	return botregistry.DefaultPaths(workDir)
 }
 
 // botListOptions builds the discovery options for the bot endpoints,
 // passing WorkDir so each Entry.Enabled reflects the workspace overlay
 // (.iterion/bot-overrides.yaml) composed over the manifest default.
+// Paths and Workdir derive from ONE WorkDir snapshot: two reads could
+// straddle a concurrent project switch and compose one project's bots
+// with the other's enabled-overlay.
 func (s *Server) botListOptions() botregistry.ListOptions {
-	return botregistry.ListOptions{Paths: s.effectivePaths(), Workdir: s.cfg.WorkDir}
+	workDir := s.currentWorkDir()
+	return botregistry.ListOptions{Paths: s.effectivePathsFor(workDir), Workdir: workDir}
 }
 
 // handleBotsList returns the discovered bots' metadata + vars schema.

--- a/pkg/server/bots_routes_test.go
+++ b/pkg/server/bots_routes_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -352,5 +353,103 @@ func TestBotOverlayRoute_TogglesWithoutTouchingManifest(t *testing.T) {
 	json.Unmarshal(rec.Body.Bytes(), &b)
 	if !b.Enabled {
 		t.Error("clearing the overlay should restore Enabled=true")
+	}
+}
+
+// The studio wires cfg.Bots.Paths ONLY for an explicit --bots-path; the
+// default catalog must re-derive from the LIVE WorkDir so /api/v1/bots
+// (and pipeline-ticket bot resolution via findBot) follows a project
+// switch instead of staying pinned to the boot workspace.
+func TestBotsListFollowsProjectSwitch(t *testing.T) {
+	botregistry.ClearSchemaCache()
+	// Keep swapWorkDir's per-project store out of the real ~/.iterion.
+	t.Setenv("ITERION_HOME", t.TempDir())
+
+	dirA := t.TempDir()
+	writeBotFile(t, filepath.Join(dirA, "bots", "alpha.bot"),
+		strings.ReplaceAll(testBotSrc, "feature_dev", "alpha"))
+	dirB := t.TempDir()
+	writeBotFile(t, filepath.Join(dirB, "bots", "beta.bot"),
+		strings.ReplaceAll(testBotSrc, "feature_dev", "beta"))
+
+	srv := New(Config{
+		DisableAuth: true,
+		WorkDir:     dirA,
+		// No Bots.Paths: the catalog derives from the current WorkDir.
+	}, iterlog.New(iterlog.LevelError, nil))
+	srv.handler = srv.mux
+
+	listNames := func() []string {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/bots", nil)
+		rec := httptest.NewRecorder()
+		srv.handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d; body=%s", rec.Code, rec.Body.String())
+		}
+		var resp struct {
+			Bots []botregistry.EntryWithSchema `json:"bots"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
+		}
+		names := make([]string, 0, len(resp.Bots))
+		for _, b := range resp.Bots {
+			names = append(names, b.Name)
+		}
+		return names
+	}
+
+	if got := listNames(); len(got) != 1 || got[0] != "alpha" {
+		t.Fatalf("boot workspace: bots = %v, want [alpha]", got)
+	}
+
+	if err := srv.swapWorkDir(context.Background(), dirB); err != nil {
+		t.Fatalf("swapWorkDir: %v", err)
+	}
+
+	if got := listNames(); len(got) != 1 || got[0] != "beta" {
+		t.Fatalf("after project switch: bots = %v, want [beta]", got)
+	}
+}
+
+// An explicit --bots-path stays pinned across project switches — it is
+// a deliberate operator override, not a workspace convention.
+func TestBotsListExplicitPathsPinnedAcrossSwitch(t *testing.T) {
+	botregistry.ClearSchemaCache()
+	t.Setenv("ITERION_HOME", t.TempDir())
+
+	pinned := t.TempDir()
+	writeBotFile(t, filepath.Join(pinned, "alpha.bot"),
+		strings.ReplaceAll(testBotSrc, "feature_dev", "alpha"))
+	dirB := t.TempDir()
+	writeBotFile(t, filepath.Join(dirB, "bots", "beta.bot"),
+		strings.ReplaceAll(testBotSrc, "feature_dev", "beta"))
+
+	srv := New(Config{
+		DisableAuth: true,
+		WorkDir:     t.TempDir(),
+		Bots:        BotsConfig{Paths: []string{pinned}},
+	}, iterlog.New(iterlog.LevelError, nil))
+	srv.handler = srv.mux
+
+	if err := srv.swapWorkDir(context.Background(), dirB); err != nil {
+		t.Fatalf("swapWorkDir: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/bots", nil)
+	rec := httptest.NewRecorder()
+	srv.handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Bots []botregistry.EntryWithSchema `json:"bots"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
+	}
+	if len(resp.Bots) != 1 || resp.Bots[0].Name != "alpha" {
+		t.Fatalf("explicit --bots-path must stay pinned: got %+v", resp.Bots)
 	}
 }

--- a/pkg/server/mcp_board_handler.go
+++ b/pkg/server/mcp_board_handler.go
@@ -40,7 +40,12 @@ type BoardMCPTokenRegistry struct {
 
 type boardMCPGrant struct {
 	Capabilities boardops.Capabilities
-	ExpiresAt    time.Time
+	// SourceIssueID is the ticket that owns the granted run, carried so
+	// board.create over this transport auto-stamps parent_id /
+	// spawned_from the same way the stdio and in-process transports do.
+	// Empty for runs with no owning ticket (plain studio/CLI launches).
+	SourceIssueID string
+	ExpiresAt     time.Time
 }
 
 // BoardMCPTokenStore is the per-run board-MCP token registry. The in-memory
@@ -52,7 +57,7 @@ type boardMCPGrant struct {
 // a Register failure means the minted token would never authorize, so the
 // minter must not hand it out; lookup is called by the HTTP handler.
 type BoardMCPTokenStore interface {
-	Register(token string, caps []string) error
+	Register(token string, caps []string, sourceIssueID string) error
 	Revoke(token string)
 	lookup(token string) (boardMCPGrant, bool)
 }
@@ -80,10 +85,11 @@ func newBoardMCPToken() string {
 // Register stores a token with its grant. A subsequent call with the same
 // token replaces the grant. A full registry is an error: the token would
 // never authorize, so the caller must not hand it out.
-func (r *BoardMCPTokenRegistry) Register(token string, caps []string) error {
+func (r *BoardMCPTokenRegistry) Register(token string, caps []string, sourceIssueID string) error {
 	grant := boardMCPGrant{
-		Capabilities: boardops.Capabilities{},
-		ExpiresAt:    r.now().Add(boardMCPDefaultTTL),
+		Capabilities:  boardops.Capabilities{},
+		SourceIssueID: strings.TrimSpace(sourceIssueID),
+		ExpiresAt:     r.now().Add(boardMCPDefaultTTL),
 	}
 	for _, c := range caps {
 		grant.Capabilities[c] = true
@@ -230,11 +236,11 @@ func (h *boardMCPHandler) serve(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
-	resp := dispatchHTTP(req, h.store, grant.Capabilities)
+	resp := dispatchHTTP(req, h.store, grant.Capabilities, boardops.CallEnv{SpawnParentID: grant.SourceIssueID})
 	writeJSONStatus(w, http.StatusOK, resp)
 }
 
-func dispatchHTTP(req mcpReq, store *native.Store, caps boardops.Capabilities) mcpResp {
+func dispatchHTTP(req mcpReq, store *native.Store, caps boardops.Capabilities, env boardops.CallEnv) mcpResp {
 	resp := mcpResp{JSONRPC: "2.0", ID: req.ID}
 
 	switch req.Method {
@@ -270,7 +276,7 @@ func dispatchHTTP(req mcpReq, store *native.Store, caps boardops.Capabilities) m
 			resp.Error = &mcpRespError{Code: -32602, Message: "invalid params: " + err.Error()}
 			return resp
 		}
-		raw, err := boardops.Call(store, caps, params.Name, params.Arguments)
+		raw, err := boardops.CallWithEnv(store, caps, params.Name, params.Arguments, env)
 		if err != nil {
 			if errors.Is(err, boardops.ErrCapabilityDenied) {
 				resp.Error = &mcpRespError{Code: -32601, Message: err.Error()}

--- a/pkg/server/mcp_board_handler_test.go
+++ b/pkg/server/mcp_board_handler_test.go
@@ -67,7 +67,7 @@ func TestBoardMCP_HTTP_UnknownToken(t *testing.T) {
 // board MCP from ever registering. The field must always be present.
 func TestBoardMCP_HTTP_InitializeServerInfoVersion(t *testing.T) {
 	srv, reg, _ := newMCPBoardTestServer(t)
-	reg.Register("tok", []string{"board.read"})
+	reg.Register("tok", []string{"board.read"}, "")
 	defer reg.Revoke("tok")
 	resp := doMCP(t, srv, "tok", map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize"})
 	defer resp.Body.Close()
@@ -95,7 +95,7 @@ func TestBoardMCP_HTTP_InitializeServerInfoVersion(t *testing.T) {
 
 func TestBoardMCP_HTTP_ToolsListFiltersByCaps(t *testing.T) {
 	srv, reg, _ := newMCPBoardTestServer(t)
-	reg.Register("tok", []string{"board.read"})
+	reg.Register("tok", []string{"board.read"}, "")
 	defer reg.Revoke("tok")
 	resp := doMCP(t, srv, "tok", map[string]any{"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
 	defer resp.Body.Close()
@@ -127,7 +127,7 @@ func TestBoardMCP_HTTP_ToolsListFiltersByCaps(t *testing.T) {
 
 func TestBoardMCP_HTTP_CreateAndRead(t *testing.T) {
 	srv, reg, store := newMCPBoardTestServer(t)
-	reg.Register("tok", []string{"board.create", "board.read"})
+	reg.Register("tok", []string{"board.create", "board.read"}, "")
 	defer reg.Revoke("tok")
 
 	resp := doMCP(t, srv, "tok", map[string]any{
@@ -160,9 +160,87 @@ func TestBoardMCP_HTTP_CreateAndRead(t *testing.T) {
 	}
 }
 
+// A sandboxed planner reaches the board over THIS transport. Without the
+// owning ticket on the grant, board.create publishes orphan children —
+// parent_id stays empty, so the parent card can't show its "N / M closed"
+// children counter. The stdio and in-process transports already stamp it;
+// this locks in parity for the HTTP one.
+func TestBoardMCP_HTTP_CreateStampsParentFromGrant(t *testing.T) {
+	srv, reg, store := newMCPBoardTestServer(t)
+	parent, err := store.Create(native.Issue{Title: "Planner"})
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	reg.Register("tok", []string{"board.create", "board.read"}, parent.ID)
+	defer reg.Revoke("tok")
+
+	resp := doMCP(t, srv, "tok", map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{
+			"name":      "create_issue",
+			"arguments": map[string]any{"title": "Spawned child"},
+		},
+	})
+	defer resp.Body.Close()
+	var r struct {
+		Result struct {
+			Content []map[string]any `json:"content"`
+			IsError bool             `json:"isError"`
+		} `json:"result"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&r)
+	if r.Result.IsError {
+		t.Fatalf("expected success, got isError=true: %+v", r.Result.Content)
+	}
+	var iss native.Issue
+	_ = json.Unmarshal([]byte(r.Result.Content[0]["text"].(string)), &iss)
+	if iss.ParentID != parent.ID {
+		t.Fatalf("parent_id = %q, want %q (auto-stamped from the grant)", iss.ParentID, parent.ID)
+	}
+	got, _ := store.Get(iss.ID)
+	if got == nil || got.ParentID != parent.ID {
+		t.Fatalf("stored parent_id = %+v, want %q", got, parent.ID)
+	}
+	if got.BotArgs[native.BotArgSpawnedFrom] != parent.ID {
+		t.Fatalf("spawned_from = %q, want %q", got.BotArgs[native.BotArgSpawnedFrom], parent.ID)
+	}
+}
+
+// An explicit parent_id argument still wins over the grant's default.
+func TestBoardMCP_HTTP_ExplicitParentOverridesGrant(t *testing.T) {
+	srv, reg, store := newMCPBoardTestServer(t)
+	grantParent, _ := store.Create(native.Issue{Title: "Grant planner"})
+	otherParent, _ := store.Create(native.Issue{Title: "Explicit planner"})
+	reg.Register("tok", []string{"board.create", "board.read"}, grantParent.ID)
+	defer reg.Revoke("tok")
+
+	resp := doMCP(t, srv, "tok", map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{
+			"name": "create_issue",
+			"arguments": map[string]any{
+				"title":     "Child",
+				"parent_id": otherParent.ID,
+			},
+		},
+	})
+	defer resp.Body.Close()
+	var r struct {
+		Result struct {
+			Content []map[string]any `json:"content"`
+		} `json:"result"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&r)
+	var iss native.Issue
+	_ = json.Unmarshal([]byte(r.Result.Content[0]["text"].(string)), &iss)
+	if iss.ParentID != otherParent.ID {
+		t.Fatalf("parent_id = %q, want the explicit %q", iss.ParentID, otherParent.ID)
+	}
+}
+
 func TestBoardMCP_HTTP_CapabilityDenied(t *testing.T) {
 	srv, reg, _ := newMCPBoardTestServer(t)
-	reg.Register("tok", []string{"board.read"})
+	reg.Register("tok", []string{"board.read"}, "")
 	defer reg.Revoke("tok")
 
 	resp := doMCP(t, srv, "tok", map[string]any{
@@ -190,11 +268,11 @@ func TestBoardMCP_HTTP_CapabilityDenied(t *testing.T) {
 func TestBoardMCPTokenRegistry_RegisterFullReturnsError(t *testing.T) {
 	reg := NewBoardMCPTokenRegistry()
 	for i := 0; i < boardMCPMaxTokens; i++ {
-		if err := reg.Register(fmt.Sprintf("tok-%d", i), []string{"board.read"}); err != nil {
+		if err := reg.Register(fmt.Sprintf("tok-%d", i), []string{"board.read"}, ""); err != nil {
 			t.Fatalf("Register %d within cap: %v", i, err)
 		}
 	}
-	err := reg.Register("one-too-many", []string{"board.read"})
+	err := reg.Register("one-too-many", []string{"board.read"}, "")
 	if err == nil {
 		t.Fatal("Register beyond the cap should error")
 	}

--- a/pkg/server/openapi_schema.go
+++ b/pkg/server/openapi_schema.go
@@ -109,6 +109,20 @@ func routeSchemas() map[string]routeOp {
 			request:  pipelineBoardUpdateRequest{},
 			response: native.Issue{},
 		},
+		"GET /api/v1/pipeline-board/tasks/{id}/dependency-graph": {response: DependencyGraphResponse{}},
+		"GET /api/v1/native/issues/{id}/dependency-graph":        {response: DependencyGraphResponse{}},
+		"POST /api/v1/pipeline-board/bulk/ready": {
+			request:  pipelineBulkReadyRequest{},
+			response: pipelineBulkReadyResponse{},
+		},
+		"POST /api/v1/pipeline-board/bulk/delete": {
+			request:  pipelineBulkDeleteRequest{},
+			response: pipelineBulkDeleteResponse{},
+		},
+		"POST /api/v1/pipeline-board/bulk/recompute-deps": {
+			request:  pipelineRecomputeDepsRequest{},
+			response: pipelineRecomputeDepsResponse{},
+		},
 
 		"POST /api/teams/{id}/forge/oauth-apps": {request: forgeOAuthAppReq{}, response: forge.ForgeOAuthApp{}},
 		"POST /api/teams/{id}/forge/oauth-apps/github-manifest": {

--- a/pkg/server/pipeline_admission.go
+++ b/pkg/server/pipeline_admission.go
@@ -2,8 +2,8 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher"
@@ -39,7 +39,7 @@ func (s *Server) dispatcherActivelyLaunching() bool {
 
 // runPipelineAdmissionLoop is the studio's minimal, pipeline-cap-scoped
 // dispatcher: it launches tickets the operator marked ready (staged into
-// Todo) whenever a concurrency slot is free. Without it, "ready" tickets
+// Ready) whenever a concurrency slot is free. Without it, "ready" tickets
 // would sit forever unless the operator ran a full `iterion dispatch`.
 // Stops when the server shuts down.
 func (s *Server) runPipelineAdmissionLoop() {
@@ -56,11 +56,14 @@ func (s *Server) runPipelineAdmissionLoop() {
 	}
 }
 
-// admitReadyPipelines launches ready tickets (StateReady, a bot, no active
-// run) oldest-first while concurrency slots remain free. The concurrency
-// gate in runview.Service.Launch is the authority — this loop only decides
-// WHICH ready ticket to submit next and stops offering more once the cap is
-// reached.
+// admitReadyPipelines launches ready tickets (StateReady, a bot, hard
+// blockers all done, no active run) oldest-first while concurrency slots
+// remain free. The concurrency gate in runview.Service.Launch is the
+// authority — this loop only decides WHICH ready ticket to submit next and
+// stops offering more once the cap is reached. Hard-dep admission shares
+// native.CanLaunch with the dispatcher adapter so a ticket with open
+// blockers can never launch from /pipelines while being skipped by
+// iterion dispatch.
 func (s *Server) admitReadyPipelines() {
 	board := s.cfg.NativeTrackerStore
 	if board == nil {
@@ -84,10 +87,11 @@ func (s *Server) admitReadyPipelines() {
 	}
 	ready := make([]*native.Issue, 0)
 	for _, iss := range issues {
-		if iss == nil || strings.TrimSpace(iss.Bot) == "" {
+		if iss == nil {
 			continue
 		}
-		if iss.State != native.StateReady {
+		// Board-side gate: bot + StateReady + blockers all StateDone.
+		if !native.CanLaunch(board, iss) {
 			continue
 		}
 		if !pipelineTicketLaunchable(context.Background(), runs.RunStore(), iss) {
@@ -110,7 +114,7 @@ func (s *Server) admitReadyPipelines() {
 // highest Priority first (the operator's ranking dial, same field /board
 // sorts on), oldest CreatedAt as the tie-break so equal-priority tickets
 // launch first-come-first-served. This IS the "which ticket goes next from
-// Todo" policy — keep it aligned with the projection's card ordering.
+// Ready" policy — keep it aligned with the projection's card ordering.
 func sortReadyTickets(ready []*native.Issue) {
 	sort.SliceStable(ready, func(i, j int) bool {
 		if ready[i].Priority != ready[j].Priority {
@@ -122,7 +126,7 @@ func sortReadyTickets(ready []*native.Issue) {
 
 // pipelineTicketLaunchable reports whether a ready ticket has no run that is
 // active or already finished — i.e. it is fresh, or its last run failed and
-// the operator retried it to Todo.
+// the operator retried it to Ready.
 func pipelineTicketLaunchable(ctx context.Context, rs store.RunStore, iss *native.Issue) bool {
 	if rs == nil {
 		return true
@@ -147,26 +151,67 @@ func pipelineTicketLaunchable(ctx context.Context, rs store.RunStore, iss *nativ
 	}
 }
 
+// warnAdmissionSkipOnce logs a ready ticket whose bot the current catalog
+// can't launch (unknown or disabled), deduped per (ticket, bot) so the 2s
+// admission tick doesn't repeat it. A later tick with a DIFFERENT bot (the
+// ticket was re-stamped) or a resolvable one re-arms the warning.
+func (s *Server) warnAdmissionSkipOnce(ticketID, bot string, found bool) {
+	s.admissionSkipMu.Lock()
+	defer s.admissionSkipMu.Unlock()
+	if s.admissionSkipWarned == nil {
+		s.admissionSkipWarned = make(map[string]string)
+	}
+	if s.admissionSkipWarned[ticketID] == bot {
+		return
+	}
+	s.admissionSkipWarned[ticketID] = bot
+	reason := "is disabled"
+	if !found {
+		reason = "is not in the current workspace's catalog"
+	}
+	s.logger.Warn("pipeline admission: ticket %s stays in Ready — bot %q %s", ticketID, bot, reason)
+}
+
 // launchReadyTicket moves a ready ticket out of StateReady (so a slow launch
 // can't be double-picked by the next tick), launches its bot through the
 // concurrency gate, and stamps the resulting run onto the ticket so the
 // projection folds them into one card. A launch failure reverts the ticket
 // to Backlog.
 func (s *Server) launchReadyTicket(runs *runview.Service, board native.BoardStore, iss *native.Issue) {
+	if _, err := s.launchTicketNow(runs, board, iss); err != nil {
+		// launchTicketNow already logged the specifics; the loop is
+		// best-effort and simply retries on the next tick.
+		return
+	}
+}
+
+// launchTicketNow claims a ticket and launches its bot, returning the run
+// id. It is the shared body of the admission loop (which ignores the error
+// and retries next tick) and of the operator's explicit "launch now" drag,
+// which needs the failure reported back over HTTP. The bot-not-in-catalog
+// case is a *skip*, not a failure, for the loop — hence the dedicated
+// error the caller can distinguish.
+func (s *Server) launchTicketNow(runs *runview.Service, board native.BoardStore, iss *native.Issue) (string, error) {
 	entry, found, err := s.findBot(iss.Bot)
 	if err != nil {
 		s.logger.Warn("pipeline admission: resolve bot %q: %v", iss.Bot, err)
-		return
+		return "", fmt.Errorf("resolve bot %q: %w", iss.Bot, err)
 	}
 	if !found || !entry.Enabled {
-		return // unknown/disabled bot: leave the ticket in Todo, surfaced as-is
+		// Unknown/disabled bot: leave the ticket in Ready, surfaced as-is.
+		// Say so (once per ticket+bot, not every tick) — after a studio
+		// project switch the boot-scoped board can reference bots the
+		// current workspace's catalog no longer resolves, and a silent
+		// skip reads as a stuck pipeline.
+		s.warnAdmissionSkipOnce(iss.ID, iss.Bot, found)
+		return "", fmt.Errorf("bot %q is not in this workspace's catalog (or is disabled)", iss.Bot)
 	}
 	// Leave StateReady BEFORE launching so the next tick won't re-pick this
 	// ticket while Launch is in flight. StateInProgress is not StateReady, so
 	// admitReadyPipelines skips it; the run's status then drives the column.
 	if _, err := board.SetState(iss.ID, native.StateInProgress); err != nil {
 		s.logger.Warn("pipeline admission: claim ticket %s: %v", iss.ID, err)
-		return
+		return "", fmt.Errorf("claim ticket: %w", err)
 	}
 	res, err := runs.Launch(context.Background(), runview.LaunchSpec{
 		FilePath: entry.MainFile(),
@@ -179,10 +224,11 @@ func (s *Server) launchReadyTicket(runs *runview.Service, board native.BoardStor
 		if _, rErr := board.SetState(iss.ID, native.StateInbox); rErr != nil {
 			s.logger.Warn("pipeline admission: revert ticket %s: %v", iss.ID, rErr)
 		}
-		return
+		return "", fmt.Errorf("launch: %w", err)
 	}
 	if err := board.SetLastRun(iss.ID, res.RunID, ""); err != nil {
 		s.logger.Warn("pipeline admission: link run %s to ticket %s: %v", res.RunID, iss.ID, err)
 	}
 	s.logger.Info("pipeline admission: started ticket %s as run %s (bot %s)", iss.ID, res.RunID, entry.Name)
+	return res.RunID, nil
 }

--- a/pkg/server/pipeline_admission_blockers_test.go
+++ b/pkg/server/pipeline_admission_blockers_test.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+)
+
+// The launch loop and the dispatcher share native.CanLaunch. These tests pin
+// the board-side gate that admitReadyPipelines consults so a Ready ticket with
+// open blockers can never start from /pipelines.
+func TestCanLaunchSharedWithAdmissionGate(t *testing.T) {
+	s, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocker, _ := s.Create(native.Issue{Title: "mesh", State: native.StateInProgress, Bot: "mesh"})
+	feature, _ := s.Create(native.Issue{
+		Title: "feature", State: native.StateReady, Bot: "feature",
+		Blockers: []string{blocker.ID},
+	})
+
+	// Same predicate admitReadyPipelines uses.
+	if native.CanLaunch(s, feature) {
+		t.Fatal("Ready + open blocker must not be CanLaunch")
+	}
+
+	// Adapter agrees.
+	a := native.NewAdapter(s)
+	cands, _ := a.ListCandidates(context.Background())
+	for _, c := range cands {
+		if c.ID == feature.ID {
+			t.Fatal("dispatcher must also skip open-blocker Ready ticket")
+		}
+	}
+
+	if _, err := s.SetState(blocker.ID, native.StateDone); err != nil {
+		t.Fatal(err)
+	}
+	feature, _ = s.Get(feature.ID)
+	if !native.CanLaunch(s, feature) {
+		t.Fatal("after blocker done, Ready ticket must be CanLaunch")
+	}
+}
+
+func TestWaitingDepsNotLaunchable(t *testing.T) {
+	s, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	iss, _ := s.Create(native.Issue{
+		Title: "waiting", State: native.StateWaitingDeps, Bot: "feature",
+	})
+	if native.CanLaunch(s, iss) {
+		t.Fatal("waiting_deps must never CanLaunch")
+	}
+}

--- a/pkg/server/pipeline_board_actions.go
+++ b/pkg/server/pipeline_board_actions.go
@@ -1,0 +1,357 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// Ticket-level actions on the pipeline board that go beyond the ready-state
+// toggle: deleting a Backlog ticket and resetting an in-progress one. Both
+// are guarded so they can never break an in-flight run they don't own —
+// delete refuses while a run is active, and reset only restages the ticket
+// after every run in its tree has been cancelled through the same seams the
+// run console uses.
+
+// issueRunRoots returns the ROOT runs owned by a ticket: the dispatcher's
+// LastRunID pointer, the attempt history refs, and any run whose Source
+// names the issue (the in-flight edge the projection also honours).
+// Descendants are reached from these via issueTreeRuns.
+func issueRunRoots(issue *native.Issue, runs map[string]*store.Run) []*store.Run {
+	if issue == nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	roots := make([]*store.Run, 0, len(issue.Runs)+1)
+	appendRoot := func(run *store.Run) {
+		if run == nil {
+			return
+		}
+		if _, ok := seen[run.ID]; ok {
+			return
+		}
+		seen[run.ID] = struct{}{}
+		roots = append(roots, run)
+	}
+	appendRoot(runs[issue.LastRunID])
+	for _, ref := range issue.Runs {
+		appendRoot(runs[ref.RunID])
+	}
+	for _, run := range runs {
+		if run.Source != nil && run.Source.IssueID == issue.ID {
+			appendRoot(run)
+		}
+	}
+	return roots
+}
+
+// issueTreeRuns expands the ticket's root runs into the full run tree
+// (roots first, then descendants breadth-first), reusing the projection's
+// parent edge (ParentRunID with the ForkedFrom compatibility fallback) and
+// its depth guard so a pathological parent/child cycle cannot hang the
+// handler.
+func issueTreeRuns(issue *native.Issue, runs map[string]*store.Run) []*store.Run {
+	children := map[string][]*store.Run{}
+	for _, run := range runs {
+		if parentID := pipelineParentRunID(run); parentID != "" && parentID != run.ID {
+			children[parentID] = append(children[parentID], run)
+		}
+	}
+	visited := map[string]struct{}{}
+	tree := make([]*store.Run, 0)
+	var walk func(run *store.Run, depth int)
+	walk = func(run *store.Run, depth int) {
+		if run == nil || depth > pipelineTreeMaxDepth {
+			return
+		}
+		if _, seen := visited[run.ID]; seen {
+			return
+		}
+		visited[run.ID] = struct{}{}
+		tree = append(tree, run)
+		for _, child := range children[run.ID] {
+			walk(child, depth+1)
+		}
+	}
+	for _, root := range issueRunRoots(issue, runs) {
+		walk(root, 0)
+	}
+	return tree
+}
+
+// loadRunIndex snapshots the run store into the id→run map the tree
+// helpers consume. A nil service yields an empty index (delete/reset then
+// operate on the ticket alone).
+func loadRunIndex(ctx context.Context, runs *runview.Service) (map[string]*store.Run, error) {
+	index := map[string]*store.Run{}
+	if runs == nil {
+		return index, nil
+	}
+	records, err := runs.ListRunRecordsCtx(ctx, runview.ListFilter{})
+	if err != nil {
+		return nil, err
+	}
+	for _, run := range records {
+		index[run.ID] = run
+	}
+	return index, nil
+}
+
+// handlePipelineBoardTaskDelete removes a ticket the operator no longer
+// wants — the backend of the Backlog card's Delete button. It only deletes
+// the native ISSUE, never a run: past attempts stay in the run store (they
+// resurface as standalone Done/Failed cards, same as /board deletes). While
+// any run in the ticket's tree is still active (running / paused / queued)
+// the delete is refused with 409 — cancel or reset first — so a live
+// pipeline can never be silently detached from its ticket.
+func (s *Server) handlePipelineBoardTaskDelete(w http.ResponseWriter, r *http.Request) {
+	if !s.requireSafeOrigin(w, r) {
+		return
+	}
+	boardStore, err := s.resolvePipelineBoardStore(r)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board: resolve store: %v", err)
+		return
+	}
+	if boardStore == nil {
+		s.httpErrorFor(w, r, http.StatusNotFound, "pipeline board: native tracker is not available")
+		return
+	}
+	id := strings.TrimSpace(r.PathValue("id"))
+	if id == "" {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board delete: missing task id")
+		return
+	}
+	issue, err := boardStore.Get(id)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusNotFound, "pipeline board delete: %v", err)
+		return
+	}
+	s.stateMu.RLock()
+	runs := s.runs
+	s.stateMu.RUnlock()
+	runIndex, err := loadRunIndex(r.Context(), runs)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board delete: list runs: %v", err)
+		return
+	}
+	for _, run := range issueTreeRuns(issue, runIndex) {
+		if !run.Status.IsTerminal() {
+			s.httpErrorFor(w, r, http.StatusConflict,
+				"pipeline board delete: run %s is still %s — cancel or reset the ticket first", run.ID, run.Status)
+			return
+		}
+	}
+	if err := boardStore.Delete(id); err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board delete: %v", err)
+		return
+	}
+	s.reflectAllowedOrigin(w, r)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handlePipelineBoardTaskReset restarts an in-progress ticket from zero —
+// the backend of the In-progress card's Reset button. It cancels every
+// still-active run in the ticket's tree through the SAME cascade the run
+// console's Cancel uses (in-process cancel → dispatcher cancel → inactive
+// status flip), and only then restages the ticket to Ready so the admission
+// loop relaunches it fresh once the cancelled runs settle
+// (pipelineTicketLaunchable holds the launch until the old run is
+// terminal). If any run cannot be cancelled from this process the reset is
+// refused with 409 and the ticket is left untouched.
+func (s *Server) handlePipelineBoardTaskReset(w http.ResponseWriter, r *http.Request) {
+	if !s.requireSafeOrigin(w, r) {
+		return
+	}
+	boardStore, err := s.resolvePipelineBoardStore(r)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board: resolve store: %v", err)
+		return
+	}
+	if boardStore == nil {
+		s.httpErrorFor(w, r, http.StatusNotFound, "pipeline board: native tracker is not available")
+		return
+	}
+	id := strings.TrimSpace(r.PathValue("id"))
+	if id == "" {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board reset: missing task id")
+		return
+	}
+	issue, err := boardStore.Get(id)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusNotFound, "pipeline board reset: %v", err)
+		return
+	}
+	if strings.TrimSpace(issue.Bot) == "" {
+		s.httpErrorFor(w, r, http.StatusConflict, "pipeline board reset: ticket %s has no bot — not a pipeline ticket", id)
+		return
+	}
+	s.stateMu.RLock()
+	runs := s.runs
+	s.stateMu.RUnlock()
+	runIndex, err := loadRunIndex(r.Context(), runs)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board reset: list runs: %v", err)
+		return
+	}
+	// Roots before descendants (tree walk order): cancelling the root first
+	// lets the engine's own context propagation stop in-process children,
+	// and the sweep then flips any independently-parked child.
+	cancelled := make([]string, 0, 1)
+	for _, run := range issueTreeRuns(issue, runIndex) {
+		if run.Status.IsTerminal() {
+			continue
+		}
+		if !s.cancelPipelineRun(r.Context(), runs, run.ID) {
+			s.httpErrorFor(w, r, http.StatusConflict,
+				"pipeline board reset: run %s could not be cancelled from this process — cancel it from its run console first", run.ID)
+			return
+		}
+		cancelled = append(cancelled, run.ID)
+		if s.logger != nil {
+			s.logger.Info("pipeline board: reset ticket %s cancelled run %s (was %s)", id, run.ID, run.Status)
+		}
+	}
+	// A cancel may only have been SIGNALLED (the engine unwinds at its next
+	// safe boundary), and the admission loop's relaunch gate
+	// (pipelineTicketLaunchable) only inspects LastRunID. If the still-dying
+	// run is linked to the ticket some other way (e.g. a dispatcher attempt
+	// that never stamped LastRunID), pin it as the current attempt BEFORE
+	// restaging so the fresh launch waits for it to actually stop.
+	if runs != nil {
+		for _, runID := range cancelled {
+			run, loadErr := runs.LoadRunCtx(r.Context(), runID)
+			if loadErr != nil || run.Status.IsTerminal() {
+				continue
+			}
+			if issue.LastRunID != run.ID {
+				if slErr := boardStore.SetLastRun(id, run.ID, ""); slErr != nil && s.logger != nil {
+					s.logger.Warn("pipeline board: reset ticket %s: pin dying run %s: %v", id, run.ID, slErr)
+				}
+			}
+			break
+		}
+	}
+	updated, err := boardStore.SetState(id, native.StateReady)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board reset: restage: %v", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	s.reflectAllowedOrigin(w, r)
+	_ = json.NewEncoder(w).Encode(updated)
+}
+
+// cancelPipelineRun signals one run to stop, mirroring handleCancelRun's
+// cascade: in-process cancel first, then the dispatcher's cancel funcs,
+// then the inactive status flip for parked runs, accepting an
+// already-terminal run as success. Returns false only when the run stays
+// active and unreachable from this process (e.g. held by another one).
+func (s *Server) cancelPipelineRun(ctx context.Context, runs *runview.Service, runID string) bool {
+	if runs == nil {
+		return false
+	}
+	if err := runs.Cancel(runID); err == nil {
+		return true
+	} else if !errors.Is(err, runview.ErrRunNotActive) {
+		if s.logger != nil {
+			s.logger.Warn("pipeline board: cancel run %s: %v", runID, err)
+		}
+		return false
+	}
+	if s.cfg.Dispatcher != nil && s.cfg.Dispatcher.CancelRun(runID) {
+		return true
+	}
+	if cancelled, err := runs.CancelInactiveCtx(ctx, runID); err == nil && cancelled {
+		return true
+	} else if err != nil && s.logger != nil {
+		s.logger.Warn("pipeline board: cancel inactive run %s: %v", runID, err)
+	}
+	run, err := runs.LoadRunCtx(ctx, runID)
+	if err != nil {
+		// The run vanished from the store — nothing left to protect.
+		return true
+	}
+	return run.Status.IsTerminal()
+}
+
+// handlePipelineBoardTaskLaunch starts a ticket RIGHT NOW, bypassing the
+// admission loop's priority ordering (POST .../tasks/{id}/launch). It backs
+// the Opened → In progress drag: the operator overrides the queue, jumping
+// this ticket ahead of higher-priority ones.
+//
+// What it bypasses: the ready-state staging and the priority/oldest-first
+// ordering — i.e. exactly the ranking. What it does NOT bypass, because
+// those are correctness rather than ranking:
+//   - open hard dependencies (a ticket whose blockers aren't done would run
+//     against work that doesn't exist yet),
+//   - a run already active or finished on this ticket (that is what Reset
+//     and Retry are for),
+//   - the pipeline concurrency cap — over it, runview.Service.Launch parks
+//     the run as queued instead of running, which would silently contradict
+//     the drop the operator just made. We refuse with 409 and say why.
+func (s *Server) handlePipelineBoardTaskLaunch(w http.ResponseWriter, r *http.Request) {
+	if !s.requireSafeOrigin(w, r) {
+		return
+	}
+	boardStore, err := s.resolvePipelineBoardStore(r)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board: resolve store: %v", err)
+		return
+	}
+	if boardStore == nil {
+		s.httpErrorFor(w, r, http.StatusNotFound, "pipeline board: native tracker is not available")
+		return
+	}
+	id := strings.TrimSpace(r.PathValue("id"))
+	if id == "" {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board launch: missing task id")
+		return
+	}
+	issue, err := boardStore.Get(id)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusNotFound, "pipeline board launch: %v", err)
+		return
+	}
+	if strings.TrimSpace(issue.Bot) == "" {
+		s.httpErrorFor(w, r, http.StatusConflict, "pipeline board launch: ticket %s has no bot — not a pipeline ticket", id)
+		return
+	}
+	s.stateMu.RLock()
+	runs := s.runs
+	s.stateMu.RUnlock()
+	if runs == nil {
+		s.httpErrorFor(w, r, http.StatusConflict, "pipeline board launch: no run service on this server")
+		return
+	}
+	if !pipelineTicketLaunchable(r.Context(), runs.RunStore(), issue) {
+		s.httpErrorFor(w, r, http.StatusConflict,
+			"pipeline board launch: ticket %s already has an active or finished run — use Reset or Retry", id)
+		return
+	}
+	if ok, open := native.BlockersSatisfiedForIssue(boardStore, issue); !ok {
+		s.httpErrorFor(w, r, http.StatusConflict,
+			"pipeline board launch: ticket %s still waits on %d unfinished dependency — dependencies are correctness, not ranking", id, len(open))
+		return
+	}
+	if st := runs.PipelineConcurrency(); st.Enabled && st.Active >= st.Max {
+		s.httpErrorFor(w, r, http.StatusConflict,
+			"pipeline board launch: all %d pipeline slots are busy — stop or pause a run first (launching anyway would only park this one as queued)", st.Max)
+		return
+	}
+	runID, err := s.launchTicketNow(runs, boardStore, issue)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusConflict, "pipeline board launch: %v", err)
+		return
+	}
+	if s.logger != nil {
+		s.logger.Info("pipeline board: ticket %s launched on operator demand as run %s (queue bypassed)", id, runID)
+	}
+	writeJSONStatus(w, http.StatusAccepted, map[string]string{"task_id": id, "run_id": runID})
+}

--- a/pkg/server/pipeline_board_actions_test.go
+++ b/pkg/server/pipeline_board_actions_test.go
@@ -1,0 +1,310 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// The first lane is "opened" (pairs with "closed"); readiness is a per-card
+// badge, not a separate lane.
+func TestPipelineBoardOpenedLaneTitle(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	for _, column := range env.projection(t).Columns {
+		if column.ID == pipelineColumnOpened {
+			if column.Title != "Opened" {
+				t.Errorf("opened lane title = %q, want %q", column.Title, "Opened")
+			}
+			return
+		}
+	}
+	t.Fatalf("no %q column in projection", pipelineColumnOpened)
+}
+
+func deleteTask(t *testing.T, env *pipelineBoardTestEnv, id string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodDelete, env.http.URL+"/api/v1/pipeline-board/tasks/"+id, nil)
+	if err != nil {
+		t.Fatalf("build DELETE: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+	return resp
+}
+
+func resetTask(t *testing.T, env *pipelineBoardTestEnv, id string) *http.Response {
+	t.Helper()
+	resp, err := http.Post(env.http.URL+"/api/v1/pipeline-board/tasks/"+id+"/reset", "application/json", bytes.NewBufferString(`{}`))
+	if err != nil {
+		t.Fatalf("POST reset: %v", err)
+	}
+	return resp
+}
+
+// A Backlog ticket with no runs deletes cleanly and leaves the board.
+func TestPipelineBoardTaskDeleteRemovesBacklogTicket(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	issue, err := env.board.Create(native.Issue{Title: "Never launched", State: native.StateInbox, Bot: "review"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	resp := deleteTask(t, env, issue.ID)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete status = %d, want 204", resp.StatusCode)
+	}
+	if _, err := env.board.Get(issue.ID); err == nil {
+		t.Errorf("issue %s still exists after delete", issue.ID)
+	}
+	for _, card := range env.projection(t).Cards {
+		if card.IssueID == issue.ID {
+			t.Errorf("deleted ticket still projected: %+v", card)
+		}
+	}
+}
+
+// Deleting a ticket whose run tree still has an active run is refused —
+// a live pipeline can never be silently detached from its ticket. The
+// guard covers the root (LastRunID) and descendants reached through
+// ParentRunID.
+func TestPipelineBoardTaskDeleteRefusedWhileRunActive(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+
+	t.Run("running root", func(t *testing.T) {
+		issue, err := env.board.Create(native.Issue{Title: "Live root", State: native.StateInProgress, Bot: "review"})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		env.seedRun(t, "del-live-root", "review", store.RunStatusRunning, func(run *store.Run) {
+			run.FilePath = env.botPath
+		})
+		if err := env.board.SetLastRun(issue.ID, "del-live-root", ""); err != nil {
+			t.Fatalf("SetLastRun: %v", err)
+		}
+		resp := deleteTask(t, env, issue.ID)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("delete status = %d, want 409", resp.StatusCode)
+		}
+		if _, err := env.board.Get(issue.ID); err != nil {
+			t.Errorf("issue vanished despite refused delete: %v", err)
+		}
+	})
+
+	t.Run("paused descendant of a terminal root", func(t *testing.T) {
+		issue, err := env.board.Create(native.Issue{Title: "Live child", State: native.StateInProgress, Bot: "review"})
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		env.seedRun(t, "del-done-root", "review", store.RunStatusFailed, func(run *store.Run) {
+			run.FilePath = env.botPath
+		})
+		env.seedRun(t, "del-paused-child", "review", store.RunStatusPausedWaitingHuman, func(run *store.Run) {
+			run.FilePath = env.botPath
+			run.ParentRunID = "del-done-root"
+			run.Checkpoint = &store.Checkpoint{NodeID: "approval", InteractionID: "int-1"}
+		})
+		if err := env.board.SetLastRun(issue.ID, "del-done-root", ""); err != nil {
+			t.Fatalf("SetLastRun: %v", err)
+		}
+		resp := deleteTask(t, env, issue.ID)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("delete status = %d, want 409", resp.StatusCode)
+		}
+	})
+}
+
+// Once every attempt is terminal the ticket deletes; its runs stay in the
+// store untouched (delete removes the ISSUE only, never a run).
+func TestPipelineBoardTaskDeleteAllowedAfterTerminalRuns(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	issue, err := env.board.Create(native.Issue{Title: "Old attempt", State: native.StateInbox, Bot: "review"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	env.seedRun(t, "del-terminal", "review", store.RunStatusCancelled, func(run *store.Run) {
+		run.FilePath = env.botPath
+	})
+	if err := env.board.SetLastRun(issue.ID, "del-terminal", ""); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+	resp := deleteTask(t, env, issue.ID)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete status = %d, want 204", resp.StatusCode)
+	}
+	if _, err := env.runStore(t).LoadRun(context.Background(), "del-terminal"); err != nil {
+		t.Errorf("run deleted alongside the ticket: %v", err)
+	}
+}
+
+// Reset cancels every parked run in the ticket's tree (root + descendant)
+// and restages the ticket to Ready so the admission loop relaunches it
+// fresh.
+func TestPipelineBoardTaskResetCancelsParkedTreeAndRestages(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	issue, err := env.board.Create(native.Issue{Title: "Stuck pipeline", State: native.StateInProgress, Bot: "review"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	env.seedRun(t, "reset-root", "review", store.RunStatusPausedWaitingHuman, func(run *store.Run) {
+		run.FilePath = env.botPath
+		run.Checkpoint = &store.Checkpoint{NodeID: "approval", InteractionID: "int-root"}
+	})
+	env.seedRun(t, "reset-child", "review", store.RunStatusPausedWaitingHuman, func(run *store.Run) {
+		run.FilePath = env.botPath
+		run.ParentRunID = "reset-root"
+		run.Checkpoint = &store.Checkpoint{NodeID: "approval", InteractionID: "int-child"}
+	})
+	if err := env.board.SetLastRun(issue.ID, "reset-root", ""); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+
+	resp := resetTask(t, env, issue.ID)
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		t.Fatalf("reset status = %d, want 200", resp.StatusCode)
+	}
+	var updated native.Issue
+	decodeJSONResp(t, resp, &updated)
+	if updated.State != native.StateReady {
+		t.Errorf("reset state = %q, want %q", updated.State, native.StateReady)
+	}
+	rs := env.runStore(t)
+	for _, id := range []string{"reset-root", "reset-child"} {
+		run, err := rs.LoadRun(context.Background(), id)
+		if err != nil {
+			t.Fatalf("LoadRun(%s): %v", id, err)
+		}
+		if run.Status != store.RunStatusCancelled {
+			t.Errorf("run %s status = %q, want cancelled", id, run.Status)
+		}
+	}
+}
+
+// A run persisted as "running" but held by no process (another process, or
+// a stale crash record) cannot be cancelled from here: reset refuses and
+// leaves both the ticket and the run untouched.
+func TestPipelineBoardTaskResetRefusedWhenRunNotCancellable(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	issue, err := env.board.Create(native.Issue{Title: "Foreign run", State: native.StateInProgress, Bot: "review"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	env.seedRun(t, "reset-foreign", "review", store.RunStatusRunning, func(run *store.Run) {
+		run.FilePath = env.botPath
+	})
+	if err := env.board.SetLastRun(issue.ID, "reset-foreign", ""); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+
+	resp := resetTask(t, env, issue.ID)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("reset status = %d, want 409", resp.StatusCode)
+	}
+	after, err := env.board.Get(issue.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if after.State != native.StateInProgress {
+		t.Errorf("issue state = %q, want untouched %q", after.State, native.StateInProgress)
+	}
+	run, err := env.runStore(t).LoadRun(context.Background(), "reset-foreign")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if run.Status != store.RunStatusRunning {
+		t.Errorf("run status = %q, want untouched running", run.Status)
+	}
+}
+
+func launchTask(t *testing.T, env *pipelineBoardTestEnv, id string) *http.Response {
+	t.Helper()
+	resp, err := http.Post(env.http.URL+"/api/v1/pipeline-board/tasks/"+id+"/launch", "application/json", bytes.NewBufferString(`{}`))
+	if err != nil {
+		t.Fatalf("POST launch: %v", err)
+	}
+	return resp
+}
+
+// The Opened → In progress drag overrides the launch ORDER, never the
+// guards that keep the board honest. A ticket already carrying an active
+// run must be refused: the drop must not detach or duplicate that run.
+func TestPipelineBoardTaskLaunchRefusedWhenRunActive(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	issue, err := env.board.Create(native.Issue{Title: "Already live", State: native.StateInProgress, Bot: "review"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	env.seedRun(t, "run-live", "review", store.RunStatusRunning, nil)
+	if err := env.board.SetLastRun(issue.ID, "run-live", ""); err != nil {
+		t.Fatal(err)
+	}
+	resp := launchTask(t, env, issue.ID)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("launch status = %d, want 409 while a run is active", resp.StatusCode)
+	}
+}
+
+// Hard dependencies are correctness, not ranking — the drag bypasses
+// priority, never an unfinished blocker.
+func TestPipelineBoardTaskLaunchRefusedWithOpenBlocker(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	blocker, err := env.board.Create(native.Issue{Title: "Upstream", State: native.StateInbox, Bot: "review"})
+	if err != nil {
+		t.Fatalf("Create blocker: %v", err)
+	}
+	issue, err := env.board.Create(native.Issue{
+		Title:    "Blocked",
+		State:    native.StateInbox,
+		Bot:      "review",
+		Blockers: []string{blocker.ID},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	resp := launchTask(t, env, issue.ID)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("launch status = %d, want 409 with an open blocker", resp.StatusCode)
+	}
+	got, err := env.board.Get(issue.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.State != native.StateInbox {
+		t.Fatalf("refused launch mutated the ticket: state = %q", got.State)
+	}
+}
+
+// A ticket with no bot is not a pipeline ticket at all.
+func TestPipelineBoardTaskLaunchRefusedWithoutBot(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	issue, err := env.board.Create(native.Issue{Title: "Note to self", State: native.StateInbox})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	resp := launchTask(t, env, issue.ID)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("launch status = %d, want 409 for a bot-less ticket", resp.StatusCode)
+	}
+}
+
+func TestPipelineBoardTaskLaunchUnknownTicket(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	resp := launchTask(t, env, "does-not-exist")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("launch status = %d, want 404", resp.StatusCode)
+	}
+}

--- a/pkg/server/pipeline_board_deps.go
+++ b/pkg/server/pipeline_board_deps.go
@@ -1,0 +1,468 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+)
+
+// ---------------------------------------------------------------------------
+// Dependency graph + bulk ops (Vague 3)
+// ---------------------------------------------------------------------------
+
+// DependencyGraphNode is one ticket in a limited-depth dependency walk.
+type DependencyGraphNode struct {
+	ID        string                `json:"id"`
+	Title     string                `json:"title,omitempty"`
+	State     string                `json:"state,omitempty"`
+	Bot       string                `json:"bot,omitempty"`
+	Satisfied bool                  `json:"satisfied,omitempty"`
+	Blockers  []native.BlockerInfo  `json:"blockers,omitempty"`
+	Blocking  []native.BlockingInfo `json:"blocking,omitempty"`
+	Depth     int                   `json:"depth"`
+}
+
+// DependencyGraphResponse is the GET …/dependency-graph payload.
+type DependencyGraphResponse struct {
+	Root  DependencyGraphNode   `json:"root"`
+	Nodes []DependencyGraphNode `json:"nodes"`
+	// Edges is a flat list of from→to (dependent → blocker) for simple UIs.
+	Edges []DependencyGraphEdge `json:"edges,omitempty"`
+}
+
+// DependencyGraphEdge is one directed hard-dep edge.
+type DependencyGraphEdge struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+const dependencyGraphMaxDepth = 4
+const dependencyGraphMaxNodes = 64
+
+// handlePipelineBoardDependencyGraph walks hard blockers (and reverse
+// blocking one hop) for a ticket. Depth is capped so a large production
+// board cannot fan out unbounded.
+func (s *Server) handlePipelineBoardDependencyGraph(w http.ResponseWriter, r *http.Request) {
+	boardStore, err := s.resolvePipelineBoardStore(r)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "dependency graph: resolve store: %v", err)
+		return
+	}
+	if boardStore == nil {
+		s.httpErrorFor(w, r, http.StatusNotFound, "dependency graph: native tracker is not available")
+		return
+	}
+	id := strings.TrimSpace(r.PathValue("id"))
+	if id == "" {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "dependency graph: missing id")
+		return
+	}
+	// Accept short prefixes via Resolve when available.
+	if resolved, rerr := boardStore.Resolve(id); rerr == nil && resolved != "" {
+		id = resolved
+	}
+	rootIss, err := boardStore.Get(id)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusNotFound, "dependency graph: %v", err)
+		return
+	}
+	all, err := boardStore.List(native.ListFilter{})
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "dependency graph: list: %v", err)
+		return
+	}
+
+	seen := map[string]struct{}{rootIss.ID: {}}
+	var nodes []DependencyGraphNode
+	var edges []DependencyGraphEdge
+
+	rootNode := DependencyGraphNode{
+		ID:       rootIss.ID,
+		Title:    rootIss.Title,
+		State:    rootIss.State,
+		Bot:      rootIss.Bot,
+		Blockers: native.ResolveBlockersForIssue(boardStore, rootIss),
+		Blocking: native.ReverseBlockers(all, rootIss.ID),
+		Depth:    0,
+	}
+	// Walk blockers outward.
+	type item struct {
+		id    string
+		depth int
+	}
+	queue := []item{{id: rootIss.ID, depth: 0}}
+	for len(queue) > 0 && len(nodes)+1 < dependencyGraphMaxNodes {
+		cur := queue[0]
+		queue = queue[1:]
+		iss, gerr := boardStore.Get(cur.id)
+		if gerr != nil || iss == nil {
+			continue
+		}
+		if cur.depth > 0 {
+			nodes = append(nodes, DependencyGraphNode{
+				ID:       iss.ID,
+				Title:    iss.Title,
+				State:    iss.State,
+				Bot:      iss.Bot,
+				Blockers: native.ResolveBlockersForIssue(boardStore, iss),
+				Blocking: native.ReverseBlockers(all, iss.ID),
+				Depth:    cur.depth,
+			})
+		}
+		if cur.depth >= dependencyGraphMaxDepth {
+			continue
+		}
+		for _, bid := range native.NormalizeBlockers(iss.Blockers) {
+			edges = append(edges, DependencyGraphEdge{From: iss.ID, To: bid})
+			if _, ok := seen[bid]; ok {
+				continue
+			}
+			seen[bid] = struct{}{}
+			queue = append(queue, item{id: bid, depth: cur.depth + 1})
+		}
+	}
+	// One hop reverse: tickets this root blocks (already on root.Blocking).
+	for _, b := range rootNode.Blocking {
+		if _, ok := seen[b.ID]; ok {
+			continue
+		}
+		if len(nodes)+1 >= dependencyGraphMaxNodes {
+			break
+		}
+		seen[b.ID] = struct{}{}
+		if dep, gerr := boardStore.Get(b.ID); gerr == nil && dep != nil {
+			nodes = append(nodes, DependencyGraphNode{
+				ID:       dep.ID,
+				Title:    dep.Title,
+				State:    dep.State,
+				Bot:      dep.Bot,
+				Blockers: native.ResolveBlockersForIssue(boardStore, dep),
+				Depth:    -1, // reverse hop
+			})
+			edges = append(edges, DependencyGraphEdge{From: dep.ID, To: rootIss.ID})
+		}
+	}
+
+	resp := DependencyGraphResponse{Root: rootNode, Nodes: nodes, Edges: edges}
+	w.Header().Set("Content-Type", "application/json")
+	s.reflectAllowedOrigin(w, r)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+type pipelineBulkReadyRequest struct {
+	// IDs is an explicit list of ticket ids to stage. When empty, FamilyID
+	// and/or PipelineKind filter the board.
+	IDs          []string `json:"ids,omitempty"`
+	FamilyID     string   `json:"family_id,omitempty"`
+	PipelineKind string   `json:"pipeline_kind,omitempty"`
+	// OnlySatisfied skips tickets whose hard blockers are still open
+	// (default true — only mark Ready when CanLaunch-adjacent deps OK).
+	OnlySatisfied *bool `json:"only_satisfied,omitempty"`
+}
+
+type pipelineBulkReadyResponse struct {
+	Ready       []string          `json:"ready"`
+	WaitingDeps []string          `json:"waiting_deps,omitempty"`
+	Skipped     []string          `json:"skipped,omitempty"`
+	SkippedWhy  map[string]string `json:"skipped_why,omitempty"`
+}
+
+type pipelineBulkDeleteRequest struct {
+	IDs []string `json:"ids"`
+}
+
+type pipelineBulkDeleteResponse struct {
+	Deleted    []string          `json:"deleted"`
+	Skipped    []string          `json:"skipped,omitempty"`
+	SkippedWhy map[string]string `json:"skipped_why,omitempty"`
+}
+
+// handlePipelineBoardBulkDelete removes many Opened tickets in one call —
+// the multi-select "Delete selected" affordance. Same guards as single
+// DELETE: issue only (never runs); skip tickets with any non-terminal run
+// in their tree (active_run). Missing ids are skipped, not 404.
+func (s *Server) handlePipelineBoardBulkDelete(w http.ResponseWriter, r *http.Request) {
+	if !s.requireSafeOrigin(w, r) {
+		return
+	}
+	boardStore, err := s.resolvePipelineBoardStore(r)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "bulk delete: resolve store: %v", err)
+		return
+	}
+	if boardStore == nil {
+		s.httpErrorFor(w, r, http.StatusNotFound, "bulk delete: native tracker is not available")
+		return
+	}
+	var req pipelineBulkDeleteRequest
+	if err := readJSON(r, &req); err != nil {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "bulk delete: invalid request: %v", err)
+		return
+	}
+	if len(req.IDs) == 0 {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "bulk delete: ids required")
+		return
+	}
+	s.stateMu.RLock()
+	runs := s.runs
+	s.stateMu.RUnlock()
+	runIndex, err := loadRunIndex(r.Context(), runs)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "bulk delete: list runs: %v", err)
+		return
+	}
+	out := pipelineBulkDeleteResponse{SkippedWhy: map[string]string{}}
+	seen := map[string]struct{}{}
+	for _, id := range req.IDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		issue, gerr := boardStore.Get(id)
+		if gerr != nil || issue == nil {
+			out.Skipped = append(out.Skipped, id)
+			out.SkippedWhy[id] = "not_found"
+			continue
+		}
+		if strings.TrimSpace(issue.Bot) == "" {
+			out.Skipped = append(out.Skipped, id)
+			out.SkippedWhy[id] = "not_pipeline_ticket"
+			continue
+		}
+		// Refuse while any run in the tree is still live (same as single delete).
+		blocked := false
+		for _, run := range issueTreeRuns(issue, runIndex) {
+			if run != nil && !run.Status.IsTerminal() {
+				out.Skipped = append(out.Skipped, id)
+				out.SkippedWhy[id] = "active_run:" + string(run.Status)
+				blocked = true
+				break
+			}
+		}
+		if blocked {
+			continue
+		}
+		if derr := boardStore.Delete(id); derr != nil {
+			out.Skipped = append(out.Skipped, id)
+			out.SkippedWhy[id] = derr.Error()
+			continue
+		}
+		out.Deleted = append(out.Deleted, id)
+	}
+	if len(out.SkippedWhy) == 0 {
+		out.SkippedWhy = nil
+	}
+	w.Header().Set("Content-Type", "application/json")
+	s.reflectAllowedOrigin(w, r)
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// handlePipelineBoardBulkReady stages many tickets Ready (or waiting_deps)
+// in one call — "Ready all tickets of family X whose deps are satisfied".
+func (s *Server) handlePipelineBoardBulkReady(w http.ResponseWriter, r *http.Request) {
+	if !s.requireSafeOrigin(w, r) {
+		return
+	}
+	boardStore, err := s.resolvePipelineBoardStore(r)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "bulk ready: resolve store: %v", err)
+		return
+	}
+	if boardStore == nil {
+		s.httpErrorFor(w, r, http.StatusNotFound, "bulk ready: native tracker is not available")
+		return
+	}
+	var req pipelineBulkReadyRequest
+	if err := readJSON(r, &req); err != nil {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "bulk ready: invalid request: %v", err)
+		return
+	}
+	onlySatisfied := true
+	if req.OnlySatisfied != nil {
+		onlySatisfied = *req.OnlySatisfied
+	}
+	candidates, err := s.collectBulkTargets(boardStore, req)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "bulk ready: %v", err)
+		return
+	}
+	board := boardStore.Board()
+	out := pipelineBulkReadyResponse{SkippedWhy: map[string]string{}}
+	for _, iss := range candidates {
+		if iss == nil || strings.TrimSpace(iss.Bot) == "" {
+			continue
+		}
+		if isPipelineTerminalOrActive(iss.State) {
+			out.Skipped = append(out.Skipped, iss.ID)
+			out.SkippedWhy[iss.ID] = "active_or_terminal"
+			continue
+		}
+		ok, _ := native.BlockersSatisfiedForIssue(boardStore, iss)
+		target := native.StateReady
+		if !ok {
+			if onlySatisfied {
+				out.Skipped = append(out.Skipped, iss.ID)
+				out.SkippedWhy[iss.ID] = "open_blockers"
+				continue
+			}
+			if board != nil && board.StateByName(native.StateWaitingDeps) != nil {
+				target = native.StateWaitingDeps
+			} else {
+				out.Skipped = append(out.Skipped, iss.ID)
+				out.SkippedWhy[iss.ID] = "open_blockers"
+				continue
+			}
+		}
+		if _, err := boardStore.SetState(iss.ID, target); err != nil {
+			out.Skipped = append(out.Skipped, iss.ID)
+			out.SkippedWhy[iss.ID] = err.Error()
+			continue
+		}
+		if target == native.StateReady {
+			out.Ready = append(out.Ready, iss.ID)
+		} else {
+			out.WaitingDeps = append(out.WaitingDeps, iss.ID)
+		}
+	}
+	if len(out.SkippedWhy) == 0 {
+		out.SkippedWhy = nil
+	}
+	w.Header().Set("Content-Type", "application/json")
+	s.reflectAllowedOrigin(w, r)
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+func (s *Server) collectBulkTargets(boardStore native.BoardStore, req pipelineBulkReadyRequest) ([]*native.Issue, error) {
+	if len(req.IDs) > 0 {
+		out := make([]*native.Issue, 0, len(req.IDs))
+		for _, id := range req.IDs {
+			id = strings.TrimSpace(id)
+			if id == "" {
+				continue
+			}
+			if resolved, err := boardStore.Resolve(id); err == nil && resolved != "" {
+				id = resolved
+			}
+			iss, err := boardStore.Get(id)
+			if err != nil {
+				continue
+			}
+			out = append(out, iss)
+		}
+		return out, nil
+	}
+	family := strings.TrimSpace(req.FamilyID)
+	kind := strings.TrimSpace(req.PipelineKind)
+	if family == "" && kind == "" {
+		return nil, errBulkFilterRequired
+	}
+	all, err := boardStore.List(native.ListFilter{})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*native.Issue, 0)
+	for _, iss := range all {
+		if iss == nil || strings.TrimSpace(iss.Bot) == "" {
+			continue
+		}
+		if family != "" {
+			if iss.BotArgs == nil || strings.TrimSpace(iss.BotArgs[native.BotArgFamilyID]) != family {
+				continue
+			}
+		}
+		if kind != "" {
+			if iss.BotArgs == nil || strings.TrimSpace(iss.BotArgs[native.BotArgPipelineKind]) != kind {
+				continue
+			}
+		}
+		out = append(out, iss)
+	}
+	return out, nil
+}
+
+var errBulkFilterRequired = errString("bulk ready: provide ids, family_id, or pipeline_kind")
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+type pipelineRecomputeDepsRequest struct {
+	// ClosedID, when set, only re-evaluates dependents of that ticket.
+	// Empty = scan every waiting_deps ticket.
+	ClosedID string `json:"closed_id,omitempty"`
+}
+
+type pipelineRecomputeDepsResponse struct {
+	Promoted []string          `json:"promoted"`
+	Targets  map[string]string `json:"targets,omitempty"` // id → new state
+}
+
+// handlePipelineBoardRecomputeDeps re-runs the unblock promotion for
+// waiting_deps tickets (after bulk closes or external edits).
+func (s *Server) handlePipelineBoardRecomputeDeps(w http.ResponseWriter, r *http.Request) {
+	if !s.requireSafeOrigin(w, r) {
+		return
+	}
+	boardStore, err := s.resolvePipelineBoardStore(r)
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "recompute deps: resolve store: %v", err)
+		return
+	}
+	if boardStore == nil {
+		s.httpErrorFor(w, r, http.StatusNotFound, "recompute deps: native tracker is not available")
+		return
+	}
+	var req pipelineRecomputeDepsRequest
+	_ = readJSON(r, &req) // empty body OK
+
+	out := pipelineRecomputeDepsResponse{Targets: map[string]string{}}
+	if id := strings.TrimSpace(req.ClosedID); id != "" {
+		if resolved, rerr := boardStore.Resolve(id); rerr == nil && resolved != "" {
+			id = resolved
+		}
+		if err := native.PromoteUnblockedDependents(boardStore, id); err != nil {
+			s.httpErrorFor(w, r, http.StatusInternalServerError, "recompute deps: %v", err)
+			return
+		}
+		// PromoteUnblockedDependents does not return ids — re-list for response.
+		// Best-effort empty promoted list is fine for the closed-id path.
+	} else {
+		// Full scan: every waiting_deps ticket whose blockers are now OK.
+		waiting, err := boardStore.List(native.ListFilter{States: []string{native.StateWaitingDeps}})
+		if err != nil {
+			s.httpErrorFor(w, r, http.StatusInternalServerError, "recompute deps: list: %v", err)
+			return
+		}
+		board := boardStore.Board()
+		for _, iss := range waiting {
+			if iss == nil {
+				continue
+			}
+			ok, _ := native.BlockersSatisfiedForIssue(boardStore, iss)
+			if !ok {
+				continue
+			}
+			target := native.UnblockTarget(board, iss)
+			if target == "" || target == iss.State {
+				continue
+			}
+			if _, err := boardStore.SetState(iss.ID, target); err != nil {
+				continue
+			}
+			out.Promoted = append(out.Promoted, iss.ID)
+			out.Targets[iss.ID] = target
+		}
+	}
+	if len(out.Targets) == 0 {
+		out.Targets = nil
+	}
+	w.Header().Set("Content-Type", "application/json")
+	s.reflectAllowedOrigin(w, r)
+	_ = json.NewEncoder(w).Encode(out)
+}

--- a/pkg/server/pipeline_board_upsert_test.go
+++ b/pkg/server/pipeline_board_upsert_test.go
@@ -1,0 +1,228 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+func TestPipelineBoardTaskUpsertByInputPath(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	// First create.
+	body := `{
+		"bot":"review",
+		"title":"Asset fort",
+		"bot_args":{"input_path":"requests/fort.json","asset_id":"fort","pipeline_kind":"mesh"},
+		"upsert":true
+	}`
+	resp, err := http.Post(env.http.URL+"/api/v1/pipeline-board/tasks", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("create status = %d", resp.StatusCode)
+	}
+	var first native.Issue
+	if err := json.NewDecoder(resp.Body).Decode(&first); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second create with upsert + same key → update, not duplicate.
+	body2 := `{
+		"bot":"review",
+		"title":"Asset fort (rev2)",
+		"bot_args":{"input_path":"requests/fort.json","asset_id":"fort","pipeline_kind":"mesh","revision_id":"2"},
+		"blockers":[],
+		"upsert":true
+	}`
+	resp2, err := http.Post(env.http.URL+"/api/v1/pipeline-board/tasks", "application/json", bytes.NewBufferString(body2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("upsert status = %d (want 200)", resp2.StatusCode)
+	}
+	var second native.Issue
+	if err := json.NewDecoder(resp2.Body).Decode(&second); err != nil {
+		t.Fatal(err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("upsert created new id %s, want %s", second.ID, first.ID)
+	}
+	if second.Title != "Asset fort (rev2)" {
+		t.Fatalf("title = %q", second.Title)
+	}
+	if second.BotArgs["revision_id"] != "2" {
+		t.Fatalf("bot_args = %+v", second.BotArgs)
+	}
+
+	all, err := env.board.List(native.ListFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for _, iss := range all {
+		if iss != nil && iss.Bot == "review" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("want 1 review ticket after upsert, got %d", n)
+	}
+}
+
+func TestPipelineBoardBulkReady(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	mesh, err := env.board.Create(native.Issue{
+		Title: "mesh", Bot: "review", State: native.StateDone,
+		BotArgs: map[string]string{native.BotArgInputPath: "m.json", native.BotArgFamilyID: "f1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	feat, err := env.board.Create(native.Issue{
+		Title: "feature", Bot: "review", State: native.StateBacklog,
+		Blockers: []string{mesh.ID},
+		BotArgs: map[string]string{
+			native.BotArgInputPath:    "f.json",
+			native.BotArgFamilyID:     "f1",
+			native.BotArgPipelineKind: "feature",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Open-blocker ticket in same family — should be skipped when only_satisfied.
+	_, _ = env.board.Create(native.Issue{
+		Title: "blocked feat", Bot: "review", State: native.StateBacklog,
+		Blockers: []string{"native:missing"},
+		BotArgs: map[string]string{
+			native.BotArgInputPath: "g.json",
+			native.BotArgFamilyID:  "f1",
+		},
+	})
+
+	body := `{"family_id":"f1"}`
+	resp, err := http.Post(env.http.URL+"/api/v1/pipeline-board/bulk/ready", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	var out struct {
+		Ready   []string `json:"ready"`
+		Skipped []string `json:"skipped"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Ready) != 1 || out.Ready[0] != feat.ID {
+		t.Fatalf("ready = %v, want [%s]", out.Ready, feat.ID)
+	}
+	got, _ := env.board.Get(feat.ID)
+	if got.State != native.StateReady {
+		t.Fatalf("feature state = %q", got.State)
+	}
+}
+
+func TestPipelineBoardDependencyGraph(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	a, _ := env.board.Create(native.Issue{Title: "A", Bot: "review", State: native.StateDone})
+	b, _ := env.board.Create(native.Issue{
+		Title: "B", Bot: "review", State: native.StateWaitingDeps, Blockers: []string{a.ID},
+	})
+	resp, err := http.Get(env.http.URL + "/api/v1/pipeline-board/tasks/" + b.ID + "/dependency-graph")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	var g DependencyGraphResponse
+	if err := json.NewDecoder(resp.Body).Decode(&g); err != nil {
+		t.Fatal(err)
+	}
+	if g.Root.ID != b.ID {
+		t.Fatalf("root = %s", g.Root.ID)
+	}
+	if len(g.Root.Blockers) != 1 || !g.Root.Blockers[0].Satisfied {
+		t.Fatalf("blockers = %+v", g.Root.Blockers)
+	}
+	foundA := false
+	for _, n := range g.Nodes {
+		if n.ID == a.ID {
+			foundA = true
+		}
+	}
+	if !foundA {
+		t.Fatalf("nodes missing A: %+v", g.Nodes)
+	}
+}
+
+func TestPipelineBoardBulkDelete(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	a, err := env.board.Create(native.Issue{Title: "draft A", Bot: "review", State: native.StateInbox})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := env.board.Create(native.Issue{Title: "draft B", Bot: "review", State: native.StateReady})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Ticket with active run — must be skipped.
+	live, err := env.board.Create(native.Issue{Title: "live", Bot: "review", State: native.StateInProgress})
+	if err != nil {
+		t.Fatal(err)
+	}
+	env.seedRun(t, "run-live-bulk", "review", store.RunStatusRunning, nil)
+	if err := env.board.SetLastRun(live.ID, "run-live-bulk", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	body := `{"ids":["` + a.ID + `","` + b.ID + `","` + live.ID + `","native:missing"]}`
+	resp, err := http.Post(env.http.URL+"/api/v1/pipeline-board/bulk/delete", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+	var out struct {
+		Deleted    []string          `json:"deleted"`
+		Skipped    []string          `json:"skipped"`
+		SkippedWhy map[string]string `json:"skipped_why"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Deleted) != 2 {
+		t.Fatalf("deleted = %v, want 2", out.Deleted)
+	}
+	del := map[string]bool{}
+	for _, id := range out.Deleted {
+		del[id] = true
+	}
+	if !del[a.ID] || !del[b.ID] {
+		t.Fatalf("deleted = %v, want %s and %s", out.Deleted, a.ID, b.ID)
+	}
+	// live + missing skipped
+	if len(out.Skipped) < 2 {
+		t.Fatalf("skipped = %v", out.Skipped)
+	}
+	if _, err := env.board.Get(a.ID); err == nil {
+		t.Fatal("A should be gone")
+	}
+	if _, err := env.board.Get(live.ID); err != nil {
+		t.Fatal("live must remain")
+	}
+}

--- a/pkg/server/pipeline_boards.go
+++ b/pkg/server/pipeline_boards.go
@@ -14,11 +14,13 @@ import (
 // second mutable store — cards are positioned by persisted run state, so
 // there is no drag-and-drop. See docs/native-tracker.md + ADR-074.
 const (
-	pipelineColumnBacklog    = "backlog"
-	pipelineColumnTodo       = "todo"
+	// Three fixed lanes. "opened" folds backlog + ready staging (a per-card
+	// `ready` badge distinguishes prepared-but-not-ready from launch-eligible);
+	// "closed" folds done + failed (per-card success/failed). IDs are the wire
+	// contract (filters, tests).
+	pipelineColumnOpened     = "opened"
 	pipelineColumnInProgress = "in_progress"
-	pipelineColumnDone       = "done"
-	pipelineColumnFailed     = "failed"
+	pipelineColumnClosed     = "closed"
 
 	pipelineTreeMaxDepth = 20
 	pipelineTreeMaxCards = 500
@@ -40,6 +42,17 @@ func (s *Server) registerPipelineBoardRoutes() {
 	s.mux.Handle("POST /api/v1/pipeline-board/tasks", s.requireAuth(http.HandlerFunc(s.handlePipelineBoardTaskCreate)))
 	s.mux.Handle("POST /api/v1/pipeline-board/tasks/{id}/ready", s.requireAuth(http.HandlerFunc(s.handlePipelineBoardTaskReady)))
 	s.mux.Handle("PATCH /api/v1/pipeline-board/tasks/{id}", s.requireAuth(http.HandlerFunc(s.handlePipelineBoardTaskUpdate)))
+	// Ticket lifecycle beyond the ready toggle.
+	s.mux.Handle("DELETE /api/v1/pipeline-board/tasks/{id}", s.requireAuth(http.HandlerFunc(s.handlePipelineBoardTaskDelete)))
+	s.mux.Handle("POST /api/v1/pipeline-board/tasks/{id}/reset", s.requireAuth(http.HandlerFunc(s.handlePipelineBoardTaskReset)))
+	s.mux.Handle("POST /api/v1/pipeline-board/tasks/{id}/launch", s.requireAuth(http.HandlerFunc(s.handlePipelineBoardTaskLaunch)))
+	// Bulk + graph (multi-pipeline production ops).
+	s.mux.Handle("POST /api/v1/pipeline-board/bulk/ready", s.requireAuth(http.HandlerFunc(s.handlePipelineBoardBulkReady)))
+	s.mux.Handle("POST /api/v1/pipeline-board/bulk/delete", s.requireAuth(http.HandlerFunc(s.handlePipelineBoardBulkDelete)))
+	s.mux.Handle("POST /api/v1/pipeline-board/bulk/recompute-deps", s.requireAuth(http.HandlerFunc(s.handlePipelineBoardRecomputeDeps)))
+	s.mux.Handle("GET /api/v1/pipeline-board/tasks/{id}/dependency-graph", s.requireAuth(http.HandlerFunc(s.handlePipelineBoardDependencyGraph)))
+	// Also under /api/v1/native for CLI/MCP consumers that already use that prefix.
+	s.mux.Handle("GET /api/v1/native/issues/{id}/dependency-graph", s.requireAuth(http.HandlerFunc(s.handlePipelineBoardDependencyGraph)))
 	// Input thumbnails: a ticket's bot_args may reference images living in the
 	// studio workdir (e.g. a character-reference list) — this endpoint lets the
 	// card sidebar actually SHOW them instead of printing bare paths.

--- a/pkg/server/pipeline_boards_progress.go
+++ b/pkg/server/pipeline_boards_progress.go
@@ -2,9 +2,11 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strings"
 
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -144,27 +146,28 @@ func pipelineColumnForRoot(root *store.Run, reviews []PipelineBoardPendingReview
 	}
 	switch root.Status {
 	case store.RunStatusQueued:
-		// Waiting for a local concurrency slot — not yet executing.
-		return pipelineColumnTodo
+		// Waiting for a local concurrency slot — not yet executing, so it
+		// stays in Opened (the studio badges it Ready — it is cleared to run).
+		return pipelineColumnOpened
 	case store.RunStatusFinished:
-		return pipelineColumnDone
+		return pipelineColumnClosed
 	case store.RunStatusRunning, store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator:
 		// An operator soft-pause is a RESUMABLE mid-flight state (the run
 		// console offers Resume), not a failure — it stays In progress with
-		// its "paused" status chip rather than landing in Failed with a
+		// its "paused" status chip rather than landing in Closed with a
 		// Retry-from-zero affordance.
 		return pipelineColumnInProgress
 	case store.RunStatusFailed, store.RunStatusFailedResumable, store.RunStatusCancelled:
-		// A failed/cancelled run lands in the FAILED lane (with its error
-		// as the reason) until the operator retries it back to Todo.
-		return pipelineColumnFailed
+		// A failed/cancelled run lands in the CLOSED lane (with its error as
+		// the reason, flagged failed) until the operator retries it to Opened.
+		return pipelineColumnClosed
 	default:
 		return pipelineColumnInProgress
 	}
 }
 
 // pipelineRunFailed reports whether a run status marks a card failed (as
-// opposed to a not-yet-ready backlog ticket).
+// opposed to a successfully-finished one — both share the Closed lane).
 func pipelineRunFailed(status store.RunStatus) bool {
 	switch status {
 	case store.RunStatusFailed, store.RunStatusFailedResumable, store.RunStatusCancelled:
@@ -217,6 +220,196 @@ func pipelineTruncate(s string, max int) string {
 		return s
 	}
 	return s[:max] + "…"
+}
+
+// pipelineDisplayTitle picks the label shown on a pipeline card.
+//
+// Priority:
+//  1. Content-derived title from bot inputs / bot_args (explains WHAT the
+//     pipeline is producing — e.g. "Boudicca · ÉP 1/5 — Le Fouet et le Serment")
+//  2. Native ticket title (operator-authored)
+//  3. Bundle display name / humanized workflow name
+//  4. Run codename (GenerateRunName) — last resort; unique but opaque
+//
+// Run codenames are intentionally NOT preferred: they are branch/ID helpers,
+// not content labels. See titleFromContentInputs for the input key heuristics.
+func pipelineDisplayTitle(issue *native.Issue, root *store.Run) string {
+	var inputs map[string]any
+	if root != nil && len(root.Inputs) > 0 {
+		inputs = root.Inputs
+	} else if issue != nil && len(issue.BotArgs) > 0 {
+		inputs = stringMapToAny(issue.BotArgs)
+	}
+	if t := titleFromContentInputs(inputs); t != "" {
+		return t
+	}
+	if issue != nil {
+		if t := strings.TrimSpace(issue.Title); t != "" {
+			return t
+		}
+	}
+	if root != nil {
+		if t := strings.TrimSpace(root.BundleDisplayName); t != "" {
+			return t
+		}
+		if t := humanizePipelineName(root.WorkflowName); t != "" && t != "Pipeline" {
+			return t
+		}
+		if t := strings.TrimSpace(root.Name); t != "" {
+			return t
+		}
+	}
+	return "Pipeline"
+}
+
+// titleFromContentInputs builds a human content label from common bot input
+// keys. Prefer structured subject + episode framing (shorts / series bots)
+// over free-form prose. Returns "" when inputs have nothing usable so callers
+// can fall through to ticket title / run name.
+//
+// Recognised patterns (first match wins on each slot):
+//
+//	subject:  character | requested_character | subject | family | family_name |
+//	          asset_name | collection | series
+//	episode:  episode_no (+ episode_total) | ep / episode
+//	title:    episode_title | title | topic | feature | name (when not a path)
+//
+// Example: character=Boudicca, episode_no=1, episode_total=5,
+// episode_title="Le Fouet et le Serment"
+// → "Boudicca · ÉP 1/5 — Le Fouet et le Serment"
+func titleFromContentInputs(inputs map[string]any) string {
+	if len(inputs) == 0 {
+		return ""
+	}
+	get := func(keys ...string) string {
+		for _, k := range keys {
+			v, ok := inputs[k]
+			if !ok || v == nil {
+				continue
+			}
+			s := strings.TrimSpace(fmt.Sprint(v))
+			if s == "" || s == "<nil>" {
+				continue
+			}
+			return s
+		}
+		return ""
+	}
+
+	subject := get(
+		"character", "requested_character", "subject",
+		"family", "family_id", "family_name", "asset_name", "collection", "series",
+	)
+	// Planners often only carry a path — use the file stem as subject
+	// (e.g. assets/.../boudicca.json → boudicca).
+	if subject == "" {
+		if p := get("input_path", "catalog_path", "output_dir"); p != "" {
+			base := filepath.Base(strings.TrimRight(p, "/\\"))
+			base = strings.TrimSuffix(base, filepath.Ext(base))
+			base = strings.TrimSpace(base)
+			if base != "" && !looksLikeMachineToken(base) {
+				subject = humanizePipelineName(base)
+			}
+		}
+	}
+	epNo := get("episode_no", "ep", "episode")
+	// episode_index is often 0-based; only use it when episode_no is absent,
+	// and prefer the 1-based display the operator expects (index+1 when numeric).
+	if epNo == "" {
+		if idx := get("episode_index"); idx != "" {
+			epNo = episodeIndexAsOneBased(idx)
+		}
+	}
+	epTotal := get("episode_total", "episodes", "episode_count")
+	epTitle := get("episode_title", "title", "topic", "feature")
+	// "name" is common but often a machine id / path — only use when it looks
+	// human (no slash, not a bare uuid-ish token) and we still have nothing.
+	if epTitle == "" {
+		if n := get("name"); n != "" && !looksLikeMachineToken(n) {
+			epTitle = n
+		}
+	}
+
+	// Full shorts-style frame: Subject · ÉP n/N — Title
+	if epNo != "" {
+		epLabel := "ÉP " + epNo
+		if epTotal != "" {
+			epLabel = fmt.Sprintf("ÉP %s/%s", epNo, epTotal)
+		}
+		switch {
+		case subject != "" && epTitle != "":
+			return fmt.Sprintf("%s · %s — %s", subject, epLabel, epTitle)
+		case subject != "":
+			return fmt.Sprintf("%s · %s", subject, epLabel)
+		case epTitle != "":
+			return fmt.Sprintf("%s — %s", epLabel, epTitle)
+		default:
+			return epLabel
+		}
+	}
+
+	if subject != "" && epTitle != "" && subject != epTitle {
+		return fmt.Sprintf("%s — %s", subject, epTitle)
+	}
+	if epTitle != "" {
+		return epTitle
+	}
+	if subject != "" {
+		return subject
+	}
+
+	// Last-resort content: a short prose field, truncated so it can't blow the card.
+	for _, k := range []string{"hook", "angle", "summary", "place", "period"} {
+		if s := get(k); s != "" {
+			return pipelineTruncate(s, 80)
+		}
+	}
+	return ""
+}
+
+// episodeIndexAsOneBased turns a 0-based episode_index into a 1-based display
+// number when the value is a plain integer; non-numeric values pass through.
+func episodeIndexAsOneBased(idx string) string {
+	var n int
+	if _, err := fmt.Sscanf(idx, "%d", &n); err == nil {
+		// Heuristic: indices start at 0 in many bots; if the value is already
+		// ≥1 leave it (some bots store 1-based in episode_index).
+		if n == 0 {
+			return "1"
+		}
+		// For n>=1 we can't know base — keep as-is (callers prefer episode_no).
+		return fmt.Sprintf("%d", n)
+	}
+	return idx
+}
+
+// looksLikeMachineToken rejects values that are paths, UUIDs, or codenames
+// from being used as a human title fragment.
+func looksLikeMachineToken(s string) bool {
+	if strings.ContainsAny(s, "/\\") {
+		return true
+	}
+	if strings.Count(s, "-") >= 3 && !strings.Contains(s, " ") {
+		// e.g. run codenames orbital-plunge-borealroar-707f
+		return true
+	}
+	// Hex-ish uuid fragments
+	if len(s) >= 32 {
+		hexish := true
+		for _, r := range s {
+			if r == '-' {
+				continue
+			}
+			if (r < '0' || r > '9') && (r < 'a' || r > 'f') && (r < 'A' || r > 'F') {
+				hexish = false
+				break
+			}
+		}
+		if hexish {
+			return true
+		}
+	}
+	return false
 }
 
 func humanizePipelineName(value string) string {

--- a/pkg/server/pipeline_boards_projection.go
+++ b/pkg/server/pipeline_boards_projection.go
@@ -41,6 +41,8 @@ func (s *Server) handlePipelineBoard(w http.ResponseWriter, r *http.Request) {
 type pipelineProjectionBuilder struct {
 	ctx            context.Context
 	rs             store.RunStore
+	boardStore     native.BoardStore
+	allIssues      []*native.Issue
 	runs           map[string]*store.Run
 	children       map[string][]*store.Run
 	terminalStates map[string]struct{}
@@ -65,6 +67,7 @@ func (s *Server) buildPipelineBoard(ctx context.Context, boardStore native.Board
 	}
 	builder := &pipelineProjectionBuilder{
 		ctx:            ctx,
+		boardStore:     boardStore,
 		runs:           map[string]*store.Run{},
 		children:       map[string][]*store.Run{},
 		terminalStates: map[string]struct{}{},
@@ -88,6 +91,7 @@ func (s *Server) buildPipelineBoard(ctx context.Context, boardStore native.Board
 	if err != nil {
 		return PipelineBoardResponse{}, fmt.Errorf("list native tasks: %w", err)
 	}
+	builder.allIssues = allIssues
 	// Global board: keep every issue that names a bot (any bot). Issues
 	// with no bot belong to the shared backlog (/board), not to pipelines.
 	issues := make([]*native.Issue, 0, len(allIssues))
@@ -120,7 +124,18 @@ func (s *Server) buildPipelineBoard(ctx context.Context, boardStore native.Board
 	for _, issue := range issues {
 		root := builder.currentRunForIssue(issue)
 		if root == nil {
-			builder.addTaskCard(issue)
+			builder.addTaskCard(issue, nil)
+			continue
+		}
+		// Restaged for relaunch: ticket is back in Opened (ready / inbox /
+		// waiting_deps / …) while LastRunID still points at a terminal
+		// failed/cancelled attempt. Project the TICKET card — not the old
+		// Closed run — so Ready stays visible and the admission queue can
+		// be understood. Without this, Retry/reset leaves the card stuck
+		// behind its cancelled run in Closed (episode "invisible but not
+		// lost"). History remains on Attempts.
+		if pipelineIssueRestagedForRelaunch(issue, root) {
+			builder.addTaskCard(issue, root)
 			continue
 		}
 		builder.addRootCard(root, issue)
@@ -150,6 +165,14 @@ func (s *Server) buildPipelineBoard(ctx context.Context, boardStore native.Board
 	for _, run := range standalone {
 		builder.addRootCard(run, nil)
 	}
+
+	// Planner provenance only — a parent is an ordinary card and lands in
+	// Closed as soon as its own run finishes, regardless of its children.
+	// (There used to be a campaign hold pinning executed parents to Opened
+	// until every child closed; it made the parent's own lane lie about its
+	// run. The relation now shows purely as data: the children counter on
+	// the parent, the parent name on each child.)
+	builder.enrichParentChildLinks()
 
 	response.Cards = builder.cards
 	if response.Cards == nil {
@@ -354,11 +377,39 @@ func (b *pipelineProjectionBuilder) attemptsForIssue(issue *native.Issue, curren
 	return attempts
 }
 
+// pipelineIssueRestagedForRelaunch reports that the operator (or reset /
+// Retry) put the ticket back into a pre-launch staging state while the
+// current attempt is a terminal failure/cancel. The board must show an
+// Opened task card, not bury the ticket under the old Closed run card.
+// Finished-success is excluded — admission will not relaunch it.
+func pipelineIssueRestagedForRelaunch(issue *native.Issue, root *store.Run) bool {
+	if issue == nil || root == nil {
+		return false
+	}
+	if !pipelineRunFailed(root.Status) {
+		return false
+	}
+	switch issue.State {
+	case native.StateReady, native.StateInbox, native.StateWaitingDeps,
+		native.StateBacklog:
+		return true
+	default:
+		// in_progress / awaiting_input / done / blocked / review → keep the
+		// run card (live or closed outcome of that attempt).
+		return false
+	}
+}
+
 // addTaskCard emits a card for a native task pinned to a bot that has no
-// current run yet. A ticket in a launch-eligible (ready) state sits in
-// Todo — the launch loop starts it when a slot frees; otherwise it is a
-// Backlog ticket the operator prepares and stages to Todo when ready.
-func (b *pipelineProjectionBuilder) addTaskCard(issue *native.Issue) {
+// *active* run (never launched, or restaged after a failed/cancelled
+// attempt). Every not-yet-running ticket sits in Opened; its `ready` flag
+// (StateReady) drives the studio's Ready badge + filter — the launch loop
+// starts exactly the ready ones when a slot frees, the rest are still being
+// prepared. A terminal-state ticket with no run lands in Closed.
+//
+// prior is the terminal previous attempt when restaged; it enriches title /
+// entry_input / attempts without moving the card to Closed.
+func (b *pipelineProjectionBuilder) addTaskCard(issue *native.Issue, prior *store.Run) {
 	if issue == nil || len(b.cards) >= pipelineTreeMaxCards {
 		b.cardLimitReached = len(b.cards) >= pipelineTreeMaxCards
 		return
@@ -366,20 +417,22 @@ func (b *pipelineProjectionBuilder) addTaskCard(issue *native.Issue) {
 	_, terminal := b.terminalStates[issue.State]
 	// "Ready" is the specific StateReady the operator stages a ticket into;
 	// the launch loop starts exactly those. Other non-terminal states
-	// (inbox/…) are Backlog tickets being prepared.
+	// (inbox/waiting_deps/…) are tickets being prepared — same Opened lane,
+	// no Ready badge (waiting_deps surfaces via open_blocker_count + reason).
 	ready := issue.State == native.StateReady
-	column := pipelineColumnBacklog
-	switch {
-	case terminal:
-		column = pipelineColumnDone
-	case ready:
-		column = pipelineColumnTodo
+	column := pipelineColumnOpened
+	if terminal {
+		column = pipelineColumnClosed
 	}
-	b.cards = append(b.cards, PipelineBoardCard{
+	entry := stringMapToAny(issue.BotArgs)
+	if len(entry) == 0 && prior != nil {
+		entry = cloneAnyMap(prior.Inputs)
+	}
+	card := PipelineBoardCard{
 		ID:         "task:" + issue.ID,
 		Kind:       "task",
 		ColumnID:   column,
-		Title:      issue.Title,
+		Title:      pipelineDisplayTitle(issue, prior),
 		Body:       issue.Body,
 		IssueID:    issue.ID,
 		IssueState: issue.State,
@@ -388,11 +441,14 @@ func (b *pipelineProjectionBuilder) addTaskCard(issue *native.Issue) {
 		Priority:   issue.Priority,
 		External:   issue.External,
 		BotID:      issue.Bot,
-		EntryInput: stringMapToAny(issue.BotArgs),
+		Role:       pipelineIssueRole(issue),
+		EntryInput: entry,
 		CreatedAt:  issue.CreatedAt,
 		UpdatedAt:  issue.UpdatedAt,
-		Attempts:   b.attemptsForIssue(issue, nil),
-	})
+		Attempts:   b.attemptsForIssue(issue, prior),
+	}
+	b.attachDeps(&card, issue)
+	b.cards = append(b.cards, card)
 }
 
 // addRootCard emits ONE card for a root run, folding its whole descendant
@@ -414,19 +470,11 @@ func (b *pipelineProjectionBuilder) addRootCard(root *store.Run, issue *native.I
 	rootExec, rootTotal := b.runProgress(root)
 	treeExec, treeTotal, descCount, reviews, treeRunIDs := b.aggregateTree(root)
 
-	title := strings.TrimSpace(root.Name)
-	if title == "" {
-		title = humanizePipelineName(root.WorkflowName)
-	}
-	if issue != nil {
-		title = issue.Title
-	}
-
 	card := PipelineBoardCard{
 		ID:                "run:" + root.ID,
 		Kind:              "run",
 		ColumnID:          pipelineColumnForRoot(root, reviews),
-		Title:             title,
+		Title:             pipelineDisplayTitle(issue, root),
 		RunID:             root.ID,
 		WorkflowName:      root.WorkflowName,
 		BotID:             pipelineRunBotID(root),

--- a/pkg/server/pipeline_boards_provenance.go
+++ b/pkg/server/pipeline_boards_provenance.go
@@ -1,0 +1,271 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// Planner provenance + hard-dependency enrichment for the pipeline board
+// projection, and the ticket upsert path. Split out of pipeline_boards.go
+// so the projection file stays about lanes and progress.
+
+func isPipelineTerminalOrActive(state string) bool {
+	switch state {
+	case native.StateInProgress, native.StateAwaitingInput, native.StateReview,
+		native.StateDone, native.StateBlocked:
+		return true
+	default:
+		return false
+	}
+}
+
+// pipelineIssueRole returns bot_args.role when set.
+func pipelineIssueRole(iss *native.Issue) string {
+	if iss == nil || iss.BotArgs == nil {
+		return ""
+	}
+	return strings.TrimSpace(iss.BotArgs[native.BotArgRole])
+}
+
+// pipelineIssueParentID returns the planner provenance pointer for an issue.
+func pipelineIssueParentID(iss *native.Issue) string {
+	if iss == nil {
+		return ""
+	}
+	if id := strings.TrimSpace(iss.ParentID); id != "" {
+		return id
+	}
+	if iss.BotArgs != nil {
+		return strings.TrimSpace(iss.BotArgs[native.BotArgSpawnedFrom])
+	}
+	return ""
+}
+
+// formatBlockerIDs is a short human list for error messages.
+func formatBlockerIDs(open []native.BlockerInfo) string {
+	if len(open) == 0 {
+		return "[]"
+	}
+	parts := make([]string, 0, len(open))
+	for _, b := range open {
+		if b.Title != "" {
+			parts = append(parts, fmt.Sprintf("%s (%s)", b.ID, b.Title))
+		} else {
+			parts = append(parts, b.ID)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// enrichParentChildLinks fills ParentIssueID / Children / ChildrenSummary /
+// Role on every issue-backed card from the native issue graph.
+func (b *pipelineProjectionBuilder) enrichParentChildLinks() {
+	if len(b.allIssues) == 0 || len(b.cards) == 0 {
+		return
+	}
+	issueByID := make(map[string]*native.Issue, len(b.allIssues))
+	childrenByParent := map[string][]*native.Issue{}
+	for _, iss := range b.allIssues {
+		if iss == nil {
+			continue
+		}
+		issueByID[iss.ID] = iss
+		if pid := pipelineIssueParentID(iss); pid != "" {
+			childrenByParent[pid] = append(childrenByParent[pid], iss)
+		}
+	}
+	cardByIssue := make(map[string]int, len(b.cards))
+	for i := range b.cards {
+		if id := b.cards[i].IssueID; id != "" {
+			cardByIssue[id] = i
+		}
+	}
+	for i := range b.cards {
+		c := &b.cards[i]
+		if c.IssueID == "" {
+			continue
+		}
+		iss := issueByID[c.IssueID]
+		if iss == nil {
+			continue
+		}
+		pid := pipelineIssueParentID(iss)
+		c.ParentIssueID = pid
+		if pid != "" {
+			if p := issueByID[pid]; p != nil {
+				c.ParentTitle = p.Title
+			}
+		}
+		kids := childrenByParent[c.IssueID]
+		if len(kids) == 0 {
+			if c.Role == "" && pid != "" {
+				c.Role = "producer"
+			}
+			continue
+		}
+		if c.Role == "" {
+			c.Role = "planner"
+		}
+		// Stable order: priority desc, then created asc (same as board).
+		sort.SliceStable(kids, func(a, b int) bool {
+			if kids[a].Priority != kids[b].Priority {
+				return kids[a].Priority > kids[b].Priority
+			}
+			return kids[a].CreatedAt.Before(kids[b].CreatedAt)
+		})
+		summary := &PipelineBoardChildrenSummary{Total: len(kids)}
+		refs := make([]PipelineBoardChildRef, 0, len(kids))
+		for _, k := range kids {
+			ref := PipelineBoardChildRef{
+				IssueID: k.ID,
+				Title:   k.Title,
+				State:   k.State,
+				BotID:   k.Bot,
+			}
+			if j, ok := cardByIssue[k.ID]; ok {
+				child := b.cards[j]
+				ref.CardID = child.ID
+				switch {
+				case child.ColumnID == pipelineColumnInProgress:
+					summary.InProgress++
+				case child.ColumnID == pipelineColumnClosed && child.Failed:
+					summary.Failed++
+				case child.ColumnID == pipelineColumnClosed:
+					summary.Done++
+				case child.Ready:
+					summary.Ready++
+				default:
+					summary.Open++
+				}
+			} else {
+				// Child not on board (no bot) — count from issue state.
+				switch k.State {
+				case native.StateDone:
+					summary.Done++
+				case native.StateInProgress, native.StateAwaitingInput, native.StateReview:
+					summary.InProgress++
+				case native.StateBlocked:
+					summary.Failed++
+				case native.StateReady:
+					summary.Ready++
+				default:
+					summary.Open++
+				}
+			}
+			refs = append(refs, ref)
+		}
+		c.Children = refs
+		c.ChildrenSummary = summary
+	}
+}
+
+// attachDeps fills the hard-dependency projection fields on a card from
+// its native issue. No-op when the card has no issue provenance.
+func (b *pipelineProjectionBuilder) attachDeps(card *PipelineBoardCard, issue *native.Issue) {
+	if card == nil || issue == nil || b.boardStore == nil {
+		return
+	}
+	blockers := native.ResolveBlockersForIssue(b.boardStore, issue)
+	card.Blockers = blockers
+	open := 0
+	for _, bl := range blockers {
+		if !bl.Satisfied {
+			open++
+		}
+	}
+	card.OpenBlockerCount = open
+	card.Blocking = native.ReverseBlockers(b.allIssues, issue.ID)
+	// launch_blocked_reason is useful even for non-ready tickets (waiting_deps
+	// / open blockers) so the UI can show a badge without re-deriving the rule.
+	if reason := native.LaunchBlockedReason(b.boardStore, issue); reason != "" {
+		// For non-ready tickets that simply aren't staged yet, suppress the
+		// generic "not_ready" noise — only surface actionable gates.
+		if reason == "not_ready" && issue.State != native.StateReady {
+			if open > 0 {
+				// Prefer blocker_labels when any open entry is label-gated.
+				for _, bl := range blockers {
+					if len(bl.MissingLabels) > 0 {
+						card.LaunchBlockedReason = "blocker_labels"
+						return
+					}
+				}
+				card.LaunchBlockedReason = "open_blockers"
+			} else if issue.State == native.StateWaitingDeps {
+				card.LaunchBlockedReason = "waiting_deps"
+			}
+		} else {
+			card.LaunchBlockedReason = reason
+		}
+	}
+}
+
+// upsertPipelineTask patches title/body/labels/priority/bot_args/blockers on an
+// existing ticket. Does not move out of in_progress / done / awaiting_input;
+// optional Start only stages ready/waiting_deps when the ticket is still
+// pre-execution (backlog/inbox/waiting_deps/ready).
+func (s *Server) upsertPipelineTask(
+	boardStore native.BoardStore,
+	board *native.Board,
+	existing *native.Issue,
+	req pipelineBoardTaskRequest,
+	botName string,
+	botArgs map[string]string,
+	blockers []string,
+) (*native.Issue, error) {
+	if err := native.ValidateBlockers(boardStore, existing.ID, blockers); err != nil {
+		return nil, err
+	}
+	title := strings.TrimSpace(req.Title)
+	body := strings.TrimSpace(req.Body)
+	patch := native.Patch{
+		Title:    &title,
+		Body:     &body,
+		Priority: &req.Priority,
+		Bot:      &botName,
+		BotArgs:  &botArgs,
+		Blockers: &blockers,
+	}
+	if req.Labels != nil {
+		labels := append([]string(nil), req.Labels...)
+		patch.Labels = &labels
+	}
+	iss, err := boardStore.Update(existing.ID, patch)
+	if err != nil {
+		return nil, err
+	}
+	// State: only nudge pre-run tickets. Never yank a live/finished run.
+	if isPipelineTerminalOrActive(iss.State) {
+		return iss, nil
+	}
+	policy := native.BlockerPolicy{RequireLabels: native.RequireBlockerLabels(botArgs)}
+	ok, _ := native.BlockersSatisfiedPolicy(boardStore, blockers, policy)
+	var target string
+	if req.Start {
+		if ok {
+			target = native.StateReady
+		} else if board != nil && board.StateByName(native.StateWaitingDeps) != nil {
+			target = native.StateWaitingDeps
+		}
+	} else if !ok && board != nil && board.StateByName(native.StateWaitingDeps) != nil {
+		// Keep / move to waiting_deps when deps still open.
+		target = native.StateWaitingDeps
+	}
+	if target != "" && target != iss.State && board != nil && board.StateByName(target) != nil {
+		return boardStore.SetState(iss.ID, target)
+	}
+	return iss, nil
+}
+
+// writeJSONError emits a STRUCTURED error body (not the plain-text
+// httpErrorFor) so the studio can branch on a machine code — the
+// open-blockers refusal ships the blocker list with it.
+func (s *Server) writeJSONError(w http.ResponseWriter, r *http.Request, code int, body map[string]any) {
+	s.reflectAllowedOrigin(w, r)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/pkg/server/pipeline_boards_tasks.go
+++ b/pkg/server/pipeline_boards_tasks.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -20,10 +21,19 @@ type pipelineBoardTaskRequest struct {
 	Labels   []string          `json:"labels,omitempty"`
 	Priority int               `json:"priority,omitempty"`
 	BotArgs  map[string]string `json:"bot_args,omitempty"`
-	Start    bool              `json:"start,omitempty"`
+	// Blockers are hard deps: issue IDs that must reach StateDone before
+	// this ticket can launch. Cycles are rejected at create.
+	Blockers []string `json:"blockers,omitempty"`
+	// ParentID is the planner ticket that spawned this one (provenance).
+	// Also accepted via bot_args.spawned_from.
+	ParentID string `json:"parent_id,omitempty"`
+	Start    bool   `json:"start,omitempty"`
+	// Upsert, when true and bot_args.input_path is set, updates an existing
+	// ticket with the same (bot, input_path) instead of creating a duplicate.
+	// Does not reset state when the match is already in_progress / done /
+	// awaiting_input (or has an active run stamp).
+	Upsert bool `json:"upsert,omitempty"`
 	// External links the task to a forge repo (same shape as the native
-	// board's create) so pipeline tasks participate in the repo-first
-	// scope like every other card.
 	External *native.ExternalRef `json:"external,omitempty"`
 }
 
@@ -123,19 +133,88 @@ func (s *Server) handlePipelineBoardTaskCreate(w http.ResponseWriter, r *http.Re
 		s.httpErrorFor(w, r, http.StatusConflict, "pipeline board task: native board has no states")
 		return
 	}
+	blockers := native.NormalizeBlockers(req.Blockers)
+	botArgs := cloneStringMap(req.BotArgs)
+	blockerPolicy := native.BlockerPolicy{RequireLabels: native.RequireBlockerLabels(botArgs)}
+
+	// Upsert: planners re-run without duplicating tickets for the same request file.
+	if req.Upsert {
+		if bot, inputPath, ok := native.UpsertKey(entry.Name, botArgs); ok {
+			existing, ferr := native.FindByBotInputPath(boardStore, bot, inputPath)
+			if ferr != nil {
+				s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board task: upsert lookup: %v", ferr)
+				return
+			}
+			if existing != nil {
+				issue, uerr := s.upsertPipelineTask(boardStore, board, existing, req, entry.Name, botArgs, blockers)
+				if uerr != nil {
+					if strings.Contains(uerr.Error(), "cycle") {
+						s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board task: %v", uerr)
+						return
+					}
+					s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board task: upsert: %v", uerr)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				s.reflectAllowedOrigin(w, r)
+				// 200 = updated existing; create stays 201.
+				_ = json.NewEncoder(w).Encode(issue)
+				return
+			}
+		}
+	}
+
+	if err := native.ValidateBlockers(boardStore, "", blockers); err != nil {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board task: %v", err)
+		return
+	}
 	state := board.States[0].Name
 	if req.Start {
-		state = ""
-		for _, candidate := range board.States {
-			if candidate.Eligible && !candidate.Terminal {
-				state = candidate.Name
-				break
+		// Prefer StateReady when present; fall back to first eligible.
+		state = native.StateReady
+		if board.StateByName(state) == nil {
+			state = ""
+			for _, candidate := range board.States {
+				if candidate.Eligible && !candidate.Terminal {
+					state = candidate.Name
+					break
+				}
 			}
 		}
 		if state == "" {
 			s.httpErrorFor(w, r, http.StatusConflict, "pipeline board task: native board has no dispatch-eligible state")
 			return
 		}
+		// D1: Ready only when hard deps are satisfied; otherwise park in
+		// waiting_deps (or refuse if that state is absent on a custom board).
+		ok, open := native.BlockersSatisfiedPolicy(boardStore, blockers, blockerPolicy)
+		if !ok {
+			if board.StateByName(native.StateWaitingDeps) != nil {
+				state = native.StateWaitingDeps
+			} else {
+				s.httpErrorFor(w, r, http.StatusConflict,
+					"pipeline board task: cannot start with open blockers %s (board has no waiting_deps state)",
+					formatBlockerIDs(open))
+				return
+			}
+		}
+	} else if len(blockers) > 0 {
+		// Planner publish: if deps known open and waiting_deps exists, park there
+		// so the card is visible as waiting (not a silent draft).
+		ok, _ := native.BlockersSatisfiedPolicy(boardStore, blockers, blockerPolicy)
+		if !ok && board.StateByName(native.StateWaitingDeps) != nil {
+			state = native.StateWaitingDeps
+		}
+	}
+	parentID := strings.TrimSpace(req.ParentID)
+	if parentID == "" && botArgs != nil {
+		parentID = strings.TrimSpace(botArgs[native.BotArgSpawnedFrom])
+	}
+	if parentID != "" {
+		if botArgs == nil {
+			botArgs = map[string]string{}
+		}
+		botArgs[native.BotArgSpawnedFrom] = parentID
 	}
 	issue, err := boardStore.Create(native.Issue{
 		Title:    uniquePipelineTitle(boardStore, req.Title),
@@ -198,12 +277,15 @@ func cloneStringMap(in map[string]string) map[string]string {
 // (a Backlog ticket, or a failed one before retry). Only non-nil fields are
 // applied; the studio form sends the full state it wants to persist.
 type pipelineBoardUpdateRequest struct {
-	Title    *string             `json:"title,omitempty"`
-	Body     *string             `json:"body,omitempty"`
-	Labels   *[]string           `json:"labels,omitempty"`
-	Priority *int                `json:"priority,omitempty"`
-	Bot      *string             `json:"bot,omitempty"`
-	BotArgs  *map[string]string  `json:"bot_args,omitempty"`
+	Title    *string            `json:"title,omitempty"`
+	Body     *string            `json:"body,omitempty"`
+	Labels   *[]string          `json:"labels,omitempty"`
+	Priority *int               `json:"priority,omitempty"`
+	Bot      *string            `json:"bot,omitempty"`
+	BotArgs  *map[string]string `json:"bot_args,omitempty"`
+	// Blockers, when non-nil, replaces the hard-dep list wholesale (empty
+	// slice clears). Cycles are rejected.
+	Blockers *[]string           `json:"blockers,omitempty"`
 	External *native.ExternalRef `json:"external,omitempty"`
 }
 
@@ -268,8 +350,20 @@ func (s *Server) handlePipelineBoardTaskUpdate(w http.ResponseWriter, r *http.Re
 		}
 		patch.Bot = &bot
 	}
+	if req.Blockers != nil {
+		normalized := native.NormalizeBlockers(*req.Blockers)
+		if err := native.ValidateBlockers(boardStore, id, normalized); err != nil {
+			s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board update: %v", err)
+			return
+		}
+		patch.Blockers = &normalized
+	}
 	issue, err := boardStore.Update(id, patch)
 	if err != nil {
+		if strings.Contains(err.Error(), "cycle") {
+			s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board update: %v", err)
+			return
+		}
 		s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board update: %v", err)
 		return
 	}
@@ -277,14 +371,17 @@ func (s *Server) handlePipelineBoardTaskUpdate(w http.ResponseWriter, r *http.Re
 }
 
 type pipelineBoardReadyRequest struct {
-	// Ready true stages the ticket Backlog→Todo (StateReady, eligible for
-	// the launch loop); false unstages it Todo→Backlog (StateInbox).
+	// Ready true stages the ticket Backlog→Ready (StateReady, eligible for
+	// the launch loop); false unstages it Ready→Backlog (StateInbox).
 	Ready bool `json:"ready"`
 }
 
 // handlePipelineBoardTaskReady flags a native ticket ready (or back to
-// backlog) — the backend of the board's “→ Todo” / “→ Backlog” buttons. A ready ticket is
-// launched by the admission loop when a concurrency slot frees.
+// backlog) — the backend of the board's “→ Ready” / “→ Backlog” buttons. A
+// ready ticket is launched by the admission loop when a concurrency slot
+// frees. D1: Ready is only accepted when hard blockers are all StateDone;
+// otherwise the ticket is parked in waiting_deps (or 409 when that state
+// is absent on a custom board).
 func (s *Server) handlePipelineBoardTaskReady(w http.ResponseWriter, r *http.Request) {
 	if !s.requireSafeOrigin(w, r) {
 		return
@@ -308,9 +405,33 @@ func (s *Server) handlePipelineBoardTaskReady(w http.ResponseWriter, r *http.Req
 		s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board ready: invalid request: %v", err)
 		return
 	}
-	target := native.StateInbox
+	// Unstage → backlog (prefer StateBacklog; StateInbox is the historical
+	// unstage target for boards that still use it as the first column).
+	target := native.StateBacklog
+	if board := boardStore.Board(); board != nil && board.StateByName(target) == nil {
+		target = native.StateInbox
+	}
 	if req.Ready {
-		target = native.StateReady
+		iss, gerr := boardStore.Get(id)
+		if gerr != nil {
+			s.httpErrorFor(w, r, http.StatusNotFound, "pipeline board ready: %v", gerr)
+			return
+		}
+		ok, open := native.BlockersSatisfiedForIssue(boardStore, iss)
+		if !ok {
+			if board := boardStore.Board(); board != nil && board.StateByName(native.StateWaitingDeps) != nil {
+				target = native.StateWaitingDeps
+			} else {
+				s.writeJSONError(w, r, http.StatusConflict, map[string]any{
+					"error":         "open_blockers",
+					"message":       fmt.Sprintf("cannot mark ready: open blockers %s", formatBlockerIDs(open)),
+					"open_blockers": open,
+				})
+				return
+			}
+		} else {
+			target = native.StateReady
+		}
 	}
 	issue, err := boardStore.SetState(id, target)
 	if err != nil {

--- a/pkg/server/pipeline_boards_test.go
+++ b/pkg/server/pipeline_boards_test.go
@@ -155,16 +155,23 @@ func (e *pipelineBoardTestEnv) projection(t *testing.T) PipelineBoardResponse {
 }
 
 // The five fixed lanes, in order.
-func TestPipelineBoardHasFourFixedColumns(t *testing.T) {
+func TestPipelineBoardHasThreeFixedColumns(t *testing.T) {
 	env := newPipelineBoardTestEnv(t)
 	projection := env.projection(t)
-	want := []string{pipelineColumnBacklog, pipelineColumnTodo, pipelineColumnInProgress, pipelineColumnDone, pipelineColumnFailed}
+	want := []struct{ id, title string }{
+		{pipelineColumnOpened, "Opened"},
+		{pipelineColumnInProgress, "In progress"},
+		{pipelineColumnClosed, "Closed"},
+	}
 	if len(projection.Columns) != len(want) {
 		t.Fatalf("columns = %+v, want %v", projection.Columns, want)
 	}
-	for i, id := range want {
-		if projection.Columns[i].ID != id {
-			t.Errorf("column[%d] = %q, want %q", i, projection.Columns[i].ID, id)
+	for i, w := range want {
+		if projection.Columns[i].ID != w.id {
+			t.Errorf("column[%d] id = %q, want %q", i, projection.Columns[i].ID, w.id)
+		}
+		if projection.Columns[i].Title != w.title {
+			t.Errorf("column[%d] title = %q, want %q", i, projection.Columns[i].Title, w.title)
 		}
 	}
 }
@@ -250,19 +257,22 @@ func TestPipelineBoardFoldsDescendantsAndCollectsReviews(t *testing.T) {
 func TestPipelineBoardColumnBucketing(t *testing.T) {
 	env := newPipelineBoardTestEnv(t)
 	cases := []struct {
-		id     string
-		status store.RunStatus
-		column string
+		id         string
+		status     store.RunStatus
+		column     string
+		wantFailed bool
 	}{
-		{"r-running", store.RunStatusRunning, pipelineColumnInProgress},
-		{"r-paused", store.RunStatusPausedWaitingHuman, pipelineColumnInProgress},
-		{"r-finished", store.RunStatusFinished, pipelineColumnDone},
-		{"r-failed", store.RunStatusFailed, pipelineColumnFailed},
-		{"r-resumable", store.RunStatusFailedResumable, pipelineColumnFailed},
-		{"r-cancelled", store.RunStatusCancelled, pipelineColumnFailed},
+		{"r-running", store.RunStatusRunning, pipelineColumnInProgress, false},
+		{"r-paused", store.RunStatusPausedWaitingHuman, pipelineColumnInProgress, false},
+		// Finished (success) and failed/cancelled all fold into CLOSED; the
+		// Failed flag distinguishes the outcome for the lane's filter + badge.
+		{"r-finished", store.RunStatusFinished, pipelineColumnClosed, false},
+		{"r-failed", store.RunStatusFailed, pipelineColumnClosed, true},
+		{"r-resumable", store.RunStatusFailedResumable, pipelineColumnClosed, true},
+		{"r-cancelled", store.RunStatusCancelled, pipelineColumnClosed, true},
 		// An operator soft-pause is resumable mid-flight state, NOT a
 		// failure — it must never offer Retry-from-zero (L1, PR review).
-		{"r-operator", store.RunStatusPausedOperator, pipelineColumnInProgress},
+		{"r-operator", store.RunStatusPausedOperator, pipelineColumnInProgress, false},
 	}
 	for _, c := range cases {
 		env.seedRun(t, c.id, "review", c.status, func(run *store.Run) {
@@ -287,14 +297,15 @@ func TestPipelineBoardColumnBucketing(t *testing.T) {
 		if card.ColumnID != c.column {
 			t.Errorf("%s column = %q, want %q", c.id, card.ColumnID, c.column)
 		}
-		// Failed runs land in the FAILED lane and must carry the Failed flag
-		// so the UI offers Retry and shows the error as the reason.
-		if c.column == pipelineColumnFailed && !card.Failed {
-			t.Errorf("%s in Failed must have Failed=true", c.id)
+		// A failed/cancelled run in CLOSED must carry the Failed flag so the
+		// UI offers Retry, filters it as "failed", and shows the reason; a
+		// successful finish must not.
+		if card.Failed != c.wantFailed {
+			t.Errorf("%s Failed = %v, want %v", c.id, card.Failed, c.wantFailed)
 		}
 	}
 	queued := findPipelineCard(t, projection.Cards, "run:r-queued")
-	if queued.ColumnID != pipelineColumnTodo {
+	if queued.ColumnID != pipelineColumnOpened {
 		t.Errorf("queued column = %q, want todo", queued.ColumnID)
 	}
 	if queued.QueuePosition != 1 {
@@ -334,8 +345,11 @@ func TestPipelineBoardProgressAndOutput(t *testing.T) {
 	}
 
 	out := findPipelineCard(t, projection.Cards, "run:run-output")
-	if out.ColumnID != pipelineColumnDone {
-		t.Errorf("finished column = %q, want done", out.ColumnID)
+	if out.ColumnID != pipelineColumnClosed {
+		t.Errorf("finished column = %q, want closed", out.ColumnID)
+	}
+	if out.Failed {
+		t.Errorf("finished run must not be flagged Failed")
 	}
 	if out.ExecutedNodes != out.TotalNodes || out.TotalNodes != 3 {
 		t.Errorf("finished progress = %d/%d, want 3/3 (100%% clamp)", out.ExecutedNodes, out.TotalNodes)
@@ -518,8 +532,8 @@ func TestPipelineBoardAssociatesInflightSourceAndStandaloneRun(t *testing.T) {
 	if inflight.IssueID != issue.ID || inflight.Title != issue.Title {
 		t.Errorf("inflight source association = %+v", inflight)
 	}
-	if findPipelineCard(t, projection.Cards, "run:run-manual").ColumnID != pipelineColumnDone {
-		t.Error("manual finished run should be projected in Done")
+	if findPipelineCard(t, projection.Cards, "run:run-manual").ColumnID != pipelineColumnClosed {
+		t.Error("manual finished run should be projected in Closed")
 	}
 	for _, card := range projection.Cards {
 		if card.Kind == "task" {
@@ -550,13 +564,14 @@ func TestPipelineBoardFoldsChildOfAnotherBot(t *testing.T) {
 	}
 }
 
-// A not-yet-ready native task (non-eligible state) is a Draft card; an
-// eligible (ready) one is a Todo card the launch loop will start.
+// Both a not-yet-ready native task (non-eligible state) and an eligible
+// (ready) one live in the TODO lane now; the Ready flag distinguishes them
+// (drives the Ready/Draft badge + the Todo lane's readiness filter).
 func TestPipelineBoardProjectsTaskDraftVsTodo(t *testing.T) {
 	env := newPipelineBoardTestEnv(t)
 	draft, err := env.board.Create(native.Issue{
 		Title:   "Being prepared",
-		State:   native.StateInbox, // non-eligible → Draft
+		State:   native.StateInbox, // non-eligible → Todo, not ready (Draft badge)
 		Bot:     "review",
 		BotArgs: map[string]string{"scope": "api"},
 	})
@@ -565,7 +580,7 @@ func TestPipelineBoardProjectsTaskDraftVsTodo(t *testing.T) {
 	}
 	ready, err := env.board.Create(native.Issue{
 		Title: "Ready to run",
-		State: native.StateReady, // eligible → Todo
+		State: native.StateReady, // eligible → Todo, ready
 		Bot:   "review",
 	})
 	if err != nil {
@@ -574,14 +589,14 @@ func TestPipelineBoardProjectsTaskDraftVsTodo(t *testing.T) {
 
 	projection := env.projection(t)
 	d := findPipelineCard(t, projection.Cards, "task:"+draft.ID)
-	if d.Kind != "task" || d.ColumnID != pipelineColumnBacklog || d.Ready {
-		t.Errorf("draft card = %+v, want kind=task column=draft ready=false", d)
+	if d.Kind != "task" || d.ColumnID != pipelineColumnOpened || d.Ready {
+		t.Errorf("draft card = %+v, want kind=task column=todo ready=false", d)
 	}
 	if d.EntryInput["scope"] != "api" {
 		t.Errorf("draft entry_input = %+v, want bot_args", d.EntryInput)
 	}
 	r := findPipelineCard(t, projection.Cards, "task:"+ready.ID)
-	if r.ColumnID != pipelineColumnTodo || !r.Ready {
+	if r.ColumnID != pipelineColumnOpened || !r.Ready {
 		t.Errorf("ready card = %+v, want column=todo ready=true", r)
 	}
 }
@@ -614,14 +629,15 @@ func TestPipelineBoardTaskReadyTogglesState(t *testing.T) {
 		t.Errorf("ready=true state = %q, want %q", got.State, native.StateReady)
 	}
 	// On the board the readied ticket is now in Todo.
-	if card := findPipelineCard(t, env.projection(t).Cards, "task:"+issue.ID); card.ColumnID != pipelineColumnTodo || !card.Ready {
+	if card := findPipelineCard(t, env.projection(t).Cards, "task:"+issue.ID); card.ColumnID != pipelineColumnOpened || !card.Ready {
 		t.Errorf("after ready: card = %+v, want column=todo ready=true", card)
 	}
-	if got := post(false); got.State != native.StateInbox {
-		t.Errorf("ready=false state = %q, want %q", got.State, native.StateInbox)
+	if got := post(false); got.State != native.StateBacklog {
+		t.Errorf("ready=false state = %q, want %q", got.State, native.StateBacklog)
 	}
-	if card := findPipelineCard(t, env.projection(t).Cards, "task:"+issue.ID); card.ColumnID != pipelineColumnBacklog {
-		t.Errorf("after unready: card column = %q, want draft", card.ColumnID)
+	// Unstaged, the ticket stays in Todo but loses its Ready flag (Draft badge).
+	if card := findPipelineCard(t, env.projection(t).Cards, "task:"+issue.ID); card.ColumnID != pipelineColumnOpened || card.Ready {
+		t.Errorf("after unready: card = %+v, want column=todo ready=false", card)
 	}
 }
 
@@ -652,9 +668,9 @@ func TestPipelineBoardTaskUpdateEditsDraft(t *testing.T) {
 	if out.Title != "Polished" || out.Priority != 3 || out.BotArgs["scope"] != "new" || out.BotArgs["extra"] != "1" {
 		t.Errorf("updated issue = %+v", out)
 	}
-	// The edit shows on the board's Draft card.
+	// The edit shows on the board's Todo (draft) card.
 	card := findPipelineCard(t, env.projection(t).Cards, "task:"+issue.ID)
-	if card.Title != "Polished" || card.ColumnID != pipelineColumnBacklog || card.EntryInput["scope"] != "new" {
+	if card.Title != "Polished" || card.ColumnID != pipelineColumnOpened || card.EntryInput["scope"] != "new" {
 		t.Errorf("edited draft card = %+v", card)
 	}
 
@@ -837,5 +853,314 @@ func TestPipelineBoardWorkspaceImageServesGuardsAndRefuses(t *testing.T) {
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("missing file status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestTitleFromContentInputs_ShortsEpisode(t *testing.T) {
+	got := titleFromContentInputs(map[string]any{
+		"character":     "Boudicca",
+		"episode_no":    "1",
+		"episode_total": "5",
+		"episode_title": "Le Fouet et le Serment",
+		"hook":          "Rome croyait frapper une veuve…",
+	})
+	want := "Boudicca · ÉP 1/5 — Le Fouet et le Serment"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestTitleFromContentInputs_SubjectOnly(t *testing.T) {
+	got := titleFromContentInputs(map[string]any{"requested_character": "Boudicca"})
+	if got != "Boudicca" {
+		t.Fatalf("got %q, want Boudicca", got)
+	}
+}
+
+func TestTitleFromContentInputs_Empty(t *testing.T) {
+	if got := titleFromContentInputs(nil); got != "" {
+		t.Fatalf("nil → %q", got)
+	}
+	if got := titleFromContentInputs(map[string]any{"max_script_rewrites": "2"}); got != "" {
+		t.Fatalf("noise-only keys should not yield a title, got %q", got)
+	}
+}
+
+func TestPipelineDisplayTitle_PrefersContentOverRunCodename(t *testing.T) {
+	root := &store.Run{
+		Name:         "orbital-plunge-borealroar-707f",
+		WorkflowName: "shorts_historical_episode",
+		Inputs: map[string]any{
+			"character":     "Boudicca",
+			"episode_no":    "4",
+			"episode_total": "5",
+			"episode_title": "Londinium Sacrifiée",
+		},
+	}
+	got := pipelineDisplayTitle(nil, root)
+	want := "Boudicca · ÉP 4/5 — Londinium Sacrifiée"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestPipelineDisplayTitle_IssueTitleWhenNoContent(t *testing.T) {
+	issue := &native.Issue{Title: "Review the release"}
+	root := &store.Run{Name: "comet-bonk-novazap-d859", WorkflowName: "review"}
+	got := pipelineDisplayTitle(issue, root)
+	if got != "Review the release" {
+		t.Fatalf("got %q, want issue title", got)
+	}
+}
+
+func TestPipelineDisplayTitle_TaskFromBotArgs(t *testing.T) {
+	issue := &native.Issue{
+		Title: "draft ticket",
+		BotArgs: map[string]string{
+			"character":     "Boudicca",
+			"episode_no":    "2",
+			"episode_total": "5",
+			"episode_title": "La Ville sans Murailles",
+		},
+	}
+	got := pipelineDisplayTitle(issue, nil)
+	want := "Boudicca · ÉP 2/5 — La Ville sans Murailles"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// Content inputs on a live root must surface on the board projection even
+// when no native ticket is linked (the common studio launch path).
+func TestPipelineBoardCardTitleFromRunInputs(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	env.seedRun(t, "run-ep", "shorts_historical_episode", store.RunStatusRunning, func(run *store.Run) {
+		run.Name = "orbital-plunge-borealroar-707f"
+		run.BotID = "shorts-episode"
+		run.Inputs = map[string]any{
+			"character":     "Boudicca",
+			"episode_no":    "1",
+			"episode_total": "5",
+			"episode_title": "Le Fouet et le Serment",
+		}
+	})
+	projection := env.projection(t)
+	card := findPipelineCard(t, projection.Cards, "run:run-ep")
+	want := "Boudicca · ÉP 1/5 — Le Fouet et le Serment"
+	if card.Title != want {
+		t.Fatalf("card title = %q, want %q", card.Title, want)
+	}
+}
+
+// A ticket restaged to ready after its last run was cancelled must appear
+// as an Opened/Ready TASK card — not stuck in Closed behind the old run.
+// Regression for: "episode invisible but not lost: ready, waiting for a slot".
+func TestPipelineBoardRestagedReadyAfterCancelShowsOpenedTask(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	issue, err := env.board.Create(native.Issue{
+		Title: "Episode 5",
+		State: native.StateReady,
+		Bot:   "review",
+		BotArgs: map[string]string{
+			"character":     "Boudicca",
+			"episode_no":    "5",
+			"episode_total": "5",
+			"episode_title": "Le Dernier Fracas",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	env.seedRun(t, "run-cancelled-ep5", "shorts_historical_episode", store.RunStatusCancelled, func(run *store.Run) {
+		run.Name = "void-smash-synthsnarl-0db8"
+		run.BotID = "shorts-episode"
+		run.Inputs = map[string]any{
+			"character":     "Boudicca",
+			"episode_no":    "5",
+			"episode_total": "5",
+			"episode_title": "Le Dernier Fracas",
+		}
+	})
+	if err := env.board.SetLastRun(issue.ID, "run-cancelled-ep5", ""); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+
+	projection := env.projection(t)
+
+	// Must NOT project the cancelled run as the primary closed card.
+	if hasPipelineCard(projection.Cards, "run:run-cancelled-ep5") {
+		t.Fatalf("cancelled prior run must not be the board card when ticket is restaged ready: %+v", projection.Cards)
+	}
+	card := findPipelineCard(t, projection.Cards, "task:"+issue.ID)
+	if card.ColumnID != pipelineColumnOpened {
+		t.Errorf("column = %q, want opened", card.ColumnID)
+	}
+	if !card.Ready {
+		t.Errorf("ready = false, want true (ticket is StateReady)")
+	}
+	if card.Kind != "task" {
+		t.Errorf("kind = %q, want task", card.Kind)
+	}
+	wantTitle := "Boudicca · ÉP 5/5 — Le Dernier Fracas"
+	if card.Title != wantTitle {
+		t.Errorf("title = %q, want %q", card.Title, wantTitle)
+	}
+	// Prior attempt still listed for history / drawer.
+	foundAttempt := false
+	for _, a := range card.Attempts {
+		if a.RunID == "run-cancelled-ep5" {
+			foundAttempt = true
+			break
+		}
+	}
+	if !foundAttempt {
+		t.Errorf("attempts missing cancelled prior run: %+v", card.Attempts)
+	}
+}
+
+// A cancelled run whose ticket is STILL in_progress (not restaged) stays
+// Closed — restaging is what flips projection back to Opened.
+func TestPipelineBoardCancelledRunWithoutRestageStaysClosed(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	issue, err := env.board.Create(native.Issue{
+		Title: "Still closed",
+		State: native.StateInProgress,
+		Bot:   "review",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	env.seedRun(t, "run-still-closed", "review", store.RunStatusCancelled, nil)
+	if err := env.board.SetLastRun(issue.ID, "run-still-closed", ""); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+	projection := env.projection(t)
+	card := findPipelineCard(t, projection.Cards, "run:run-still-closed")
+	if card.ColumnID != pipelineColumnClosed {
+		t.Errorf("column = %q, want closed", card.ColumnID)
+	}
+	if !card.Failed {
+		t.Error("failed flag should be set for cancelled run")
+	}
+}
+
+func TestPipelineIssueRestagedForRelaunch(t *testing.T) {
+	ready := &native.Issue{State: native.StateReady}
+	inProg := &native.Issue{State: native.StateInProgress}
+	cancelled := &store.Run{Status: store.RunStatusCancelled}
+	finished := &store.Run{Status: store.RunStatusFinished}
+	running := &store.Run{Status: store.RunStatusRunning}
+	if !pipelineIssueRestagedForRelaunch(ready, cancelled) {
+		t.Error("ready+cancelled should restage")
+	}
+	if pipelineIssueRestagedForRelaunch(ready, finished) {
+		t.Error("ready+finished must not restage (success not relaunched)")
+	}
+	if pipelineIssueRestagedForRelaunch(ready, running) {
+		t.Error("ready+running must not restage")
+	}
+	if pipelineIssueRestagedForRelaunch(inProg, cancelled) {
+		t.Error("in_progress+cancelled is not restaged (still owns the attempt)")
+	}
+}
+
+func TestPipelineBoardParentChildProjection(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	parent, err := env.board.Create(native.Issue{
+		Title:   "Plan series",
+		State:   native.StateDone,
+		Bot:     "review",
+		BotArgs: map[string]string{native.BotArgRole: "planner"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := env.board.Create(native.Issue{
+		Title:    "Episode 1",
+		State:    native.StateReady,
+		Bot:      "review",
+		ParentID: parent.ID,
+		BotArgs: map[string]string{
+			native.BotArgSpawnedFrom: parent.ID,
+			native.BotArgRole:        "producer",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	proj := env.projection(t)
+	pCard := findPipelineCard(t, proj.Cards, "task:"+parent.ID)
+	if pCard.Role != "planner" {
+		t.Errorf("parent role = %q", pCard.Role)
+	}
+	if pCard.ChildrenSummary == nil || pCard.ChildrenSummary.Total != 1 {
+		t.Fatalf("children summary = %+v", pCard.ChildrenSummary)
+	}
+	if len(pCard.Children) != 1 || pCard.Children[0].IssueID != child.ID {
+		t.Fatalf("children = %+v", pCard.Children)
+	}
+	cCard := findPipelineCard(t, proj.Cards, "task:"+child.ID)
+	if cCard.ParentIssueID != parent.ID {
+		t.Errorf("child parent = %q", cCard.ParentIssueID)
+	}
+	if cCard.ParentTitle != "Plan series" {
+		t.Errorf("parent title = %q", cCard.ParentTitle)
+	}
+}
+
+// A planner parent is an ORDINARY card: once its own run finishes it lands
+// in Closed, even while spawned children are still open. (It used to be
+// pinned to Opened with launch_blocked_reason=awaiting_children until every
+// child closed — that made the parent's lane contradict its own run status.)
+// The relation survives as data: the children summary on the parent, and
+// parent_id / parent_title on each child.
+func TestPipelineBoardParentClosesIndependentlyOfChildren(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	parent, err := env.board.Create(native.Issue{
+		Title:   "Plan series",
+		State:   native.StateDone,
+		Bot:     "review",
+		BotArgs: map[string]string{native.BotArgRole: "planner"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	env.seedRun(t, "run-plan", "shorts_series_plan", store.RunStatusFinished, func(run *store.Run) {
+		run.BotID = "shorts-series-plan"
+	})
+	if err := env.board.SetLastRun(parent.ID, "run-plan", ""); err != nil {
+		t.Fatal(err)
+	}
+	child, err := env.board.Create(native.Issue{
+		Title:    "Episode 1",
+		State:    native.StateReady,
+		Bot:      "review",
+		ParentID: parent.ID,
+		BotArgs: map[string]string{
+			native.BotArgSpawnedFrom: parent.ID,
+			native.BotArgRole:        "producer",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proj := env.projection(t)
+	pCard := findPipelineCard(t, proj.Cards, "run:run-plan")
+	if pCard.ColumnID != pipelineColumnClosed {
+		t.Fatalf("parent column = %q, want closed (its own run finished)", pCard.ColumnID)
+	}
+	if pCard.LaunchBlockedReason == "awaiting_children" {
+		t.Fatal("awaiting_children must no longer be emitted")
+	}
+	if pCard.ChildrenSummary == nil || pCard.ChildrenSummary.Total != 1 {
+		t.Fatalf("parent lost its children counter: %+v", pCard.ChildrenSummary)
+	}
+	cCard := findPipelineCard(t, proj.Cards, "task:"+child.ID)
+	if cCard.ColumnID != pipelineColumnOpened {
+		t.Fatalf("child column = %q, want opened", cCard.ColumnID)
+	}
+	if cCard.ParentIssueID != parent.ID || cCard.ParentTitle != "Plan series" {
+		t.Fatalf("child lost its parent link: %q / %q", cCard.ParentIssueID, cCard.ParentTitle)
 	}
 }

--- a/pkg/server/pipeline_boards_types.go
+++ b/pkg/server/pipeline_boards_types.go
@@ -17,17 +17,18 @@ type PipelineBoardColumn struct {
 	Kind  string `json:"kind"`
 }
 
-// pipelineColumns is the fixed, client-order column set. Backlog holds
-// not-yet-ready tickets; Failed holds pipelines whose run ended in failure
-// (with the reason) until the operator retries them to Todo; the local
-// launch loop starts ready tickets when a concurrency slot frees.
+// pipelineColumns is the fixed, client-order column set. Opened holds every
+// not-yet-running ticket — a per-card `ready` flag marks the launch-eligible
+// ones (the studio badges + filters them), the rest are still being
+// prepared; the local launch loop starts ready tickets when a concurrency
+// slot frees. Closed holds every finished pipeline, success or failure —
+// a per-card success/failed outcome distinguishes them (surfaced as the
+// Closed lane's filter). In progress holds running / awaiting-review runs.
 func pipelineColumns() []PipelineBoardColumn {
 	return []PipelineBoardColumn{
-		{ID: pipelineColumnBacklog, Title: "Backlog", Kind: "backlog"},
-		{ID: pipelineColumnTodo, Title: "Todo", Kind: "todo"},
+		{ID: pipelineColumnOpened, Title: "Opened", Kind: "opened"},
 		{ID: pipelineColumnInProgress, Title: "In progress", Kind: "in_progress"},
-		{ID: pipelineColumnDone, Title: "Done", Kind: "done"},
-		{ID: pipelineColumnFailed, Title: "Failed", Kind: "failed"},
+		{ID: pipelineColumnClosed, Title: "Closed", Kind: "closed"},
 	}
 }
 
@@ -54,6 +55,28 @@ type PipelineBoardAttempt struct {
 	At     *time.Time      `json:"at,omitempty"`
 }
 
+// PipelineBoardChildRef is one spawned child ticket under a planner parent.
+type PipelineBoardChildRef struct {
+	IssueID string `json:"issue_id"`
+	Title   string `json:"title,omitempty"`
+	State   string `json:"state,omitempty"`
+	BotID   string `json:"bot_id,omitempty"`
+	// CardID is the pipeline card id (task:… or run:…) when the child is
+	// projected on the board; empty if the child has no bot card yet.
+	CardID string `json:"card_id,omitempty"`
+}
+
+// PipelineBoardChildrenSummary is the compact face for a plan group.
+type PipelineBoardChildrenSummary struct {
+	Total      int `json:"total"`
+	Ready      int `json:"ready"`
+	InProgress int `json:"in_progress"`
+	Done       int `json:"done"`
+	Failed     int `json:"failed"`
+	// Open is opened-but-not-ready (drafts / waiting_deps).
+	Open int `json:"open"`
+}
+
 // PipelineBoardCard is the read model the studio polls: one per root
 // pipeline (or per not-yet-launched native task). Descendants are NOT
 // separate cards — their progress and pending reviews are folded here.
@@ -70,8 +93,27 @@ type PipelineBoardCard struct {
 	Labels     []string `json:"labels,omitempty"`
 	Priority   int      `json:"priority,omitempty"`
 	// External is the backing issue's forge linkage — the card's repo
-	// identity, powering the repo-first scope on /pipelines.
+	// provenance when the ticket was imported from a forge.
 	External *native.ExternalRef `json:"external,omitempty"`
+
+	// Hard-dependency graph (ticket roots only — not sub-bot runs).
+	// Blockers are resolved server-side; OpenBlockerCount > 0 means the
+	// launch loop will refuse even if Ready is true.
+	Blockers            []native.BlockerInfo `json:"blockers,omitempty"`
+	OpenBlockerCount    int                  `json:"open_blocker_count,omitempty"`
+	LaunchBlockedReason string               `json:"launch_blocked_reason,omitempty"`
+	// Blocking is the reverse index: tickets that list this one as a blocker.
+	Blocking []native.BlockingInfo `json:"blocking,omitempty"`
+
+	// Planner provenance (distinct from hard blockers). ParentIssueID is the
+	// ticket that spawned this one; Children are reverse edges on the board.
+	ParentIssueID string                  `json:"parent_issue_id,omitempty"`
+	ParentTitle   string                  `json:"parent_title,omitempty"`
+	Children      []PipelineBoardChildRef `json:"children,omitempty"`
+	// ChildrenSummary aggregates child ticket statuses for the plan group face.
+	ChildrenSummary *PipelineBoardChildrenSummary `json:"children_summary,omitempty"`
+	// Role is planner|producer when known (bot_args.role or inferred).
+	Role string `json:"role,omitempty"`
 
 	// Run identity (empty for a not-yet-launched task card).
 	RunID        string          `json:"run_id,omitempty"`
@@ -81,14 +123,14 @@ type PipelineBoardCard struct {
 	Error        string          `json:"error,omitempty"`
 	// Failed is true when the card sits in the FAILED lane because its run
 	// failed / was cancelled. The UI shows the Error as the reason and
-	// offers a Retry (move back to Todo) on ticket-backed cards.
+	// offers a Retry (move back to Ready) on ticket-backed cards.
 	Failed bool `json:"failed,omitempty"`
 	// Ready reflects whether a task-backed card's ticket is in a
 	// launch-eligible (ready) state — used by the UI to place run-less
-	// tasks in Todo vs Backlog and to enable the move buttons.
+	// tasks in Ready vs Backlog and to enable the move buttons.
 	Ready bool `json:"ready,omitempty"`
 
-	// TODO — the pipeline's entry input (launch vars / task bot-args).
+	// Ready lane — the pipeline's entry input (launch vars / task bot-args).
 	EntryInput map[string]any `json:"entry_input,omitempty"`
 	// QueuePosition is the 1-based place in the local concurrency queue
 	// (queued roots only); 0 otherwise.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -69,6 +69,12 @@ type Server struct {
 	// header (see runs_loc.go). Non-nil after New.
 	locCache *runLOCCache
 
+	// admissionSkipWarned dedupes the pipeline-admission "unresolvable
+	// bot" warning per (ticket, bot) so a stranded Ready ticket logs
+	// once instead of every 2s tick. Guarded by admissionSkipMu.
+	admissionSkipMu     sync.Mutex
+	admissionSkipWarned map[string]string
+
 	authSvc        *auth.Service
 	authLimiter    authRateLimiterBackend
 	signer         *auth.JWTSigner
@@ -223,7 +229,7 @@ func (s *Server) boardMCPServiceOption(logger *iterlog.Logger) (runview.ServiceO
 	mux := http.NewServeMux()
 	RegisterBoardMCPRoutes(mux, "/api/v1/mcp/board", s.cfg.NativeTrackerStore, s.boardMCPTokens)
 	reg := s.boardMCPTokens
-	return runview.WithBoardMCP(mux, func(caps []string) string {
+	return runview.WithBoardMCP(mux, func(caps []string, sourceIssueID string) string {
 		token := newBoardMCPToken()
 		if token == "" {
 			if logger != nil {
@@ -231,7 +237,7 @@ func (s *Server) boardMCPServiceOption(logger *iterlog.Logger) (runview.ServiceO
 			}
 			return ""
 		}
-		if err := reg.Register(token, caps); err != nil {
+		if err := reg.Register(token, caps, sourceIssueID); err != nil {
 			if logger != nil {
 				logger.Error("board MCP: %v; sandboxed board-emit disabled for a node", err)
 			}

--- a/pkg/server/valkey_stores.go
+++ b/pkg/server/valkey_stores.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -84,8 +85,17 @@ func newValkeyBoardMCPTokenStore(rdb redis.UniversalClient, logger *iterlog.Logg
 	return &valkeyBoardMCPTokenStore{rdb: rdb, logger: logger}
 }
 
-func (s *valkeyBoardMCPTokenStore) Register(token string, caps []string) error {
-	b, err := json.Marshal(caps)
+// boardTokenPayload is the stored grant. It replaced a bare `[]string` of
+// capabilities when the owning ticket had to ride along (so board.create
+// over the HTTP transport can auto-stamp parent_id); lookup still accepts
+// the legacy array shape written by an older replica mid-rollout.
+type boardTokenPayload struct {
+	Caps          []string `json:"caps"`
+	SourceIssueID string   `json:"src,omitempty"`
+}
+
+func (s *valkeyBoardMCPTokenStore) Register(token string, caps []string, sourceIssueID string) error {
+	b, err := json.Marshal(boardTokenPayload{Caps: caps, SourceIssueID: strings.TrimSpace(sourceIssueID)})
 	if err != nil {
 		return fmt.Errorf("marshal board MCP caps: %w", err)
 	}
@@ -121,12 +131,20 @@ func (s *valkeyBoardMCPTokenStore) lookup(token string) (boardMCPGrant, bool) {
 	if err != nil {
 		return boardMCPGrant{}, false
 	}
-	var caps []string
-	if json.Unmarshal(b, &caps) != nil {
-		return boardMCPGrant{}, false
+	var payload boardTokenPayload
+	if json.Unmarshal(b, &payload) != nil {
+		// Legacy shape: a bare capability array (pre-parent_id rollout).
+		var caps []string
+		if json.Unmarshal(b, &caps) != nil {
+			return boardMCPGrant{}, false
+		}
+		payload.Caps = caps
 	}
-	grant := boardMCPGrant{Capabilities: boardops.Capabilities{}}
-	for _, c := range caps {
+	grant := boardMCPGrant{
+		Capabilities:  boardops.Capabilities{},
+		SourceIssueID: payload.SourceIssueID,
+	}
+	for _, c := range payload.Caps {
 		grant.Capabilities[c] = true
 	}
 	// ExpiresAt left zero: Redis already evicted the key if it lapsed, and the

--- a/pkg/server/valkey_stores_test.go
+++ b/pkg/server/valkey_stores_test.go
@@ -76,7 +76,7 @@ func TestValkeyBoardMCPTokenStore_RegisterLookupRevoke(t *testing.T) {
 	mr, rdb := newTestRedis(t)
 	s := newValkeyBoardMCPTokenStore(rdb, nil)
 
-	if err := s.Register("tok1", []string{"board.read", "board.move"}); err != nil {
+	if err := s.Register("tok1", []string{"board.read", "board.move"}, ""); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 	g, ok := s.lookup("tok1")
@@ -91,7 +91,7 @@ func TestValkeyBoardMCPTokenStore_RegisterLookupRevoke(t *testing.T) {
 		t.Errorf("revoked token should miss")
 	}
 	// TTL eviction.
-	if err := s.Register("tok2", []string{"board.read"}); err != nil {
+	if err := s.Register("tok2", []string{"board.read"}, ""); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
 	mr.FastForward(boardMCPDefaultTTL + time.Minute)
@@ -107,7 +107,7 @@ func TestValkeyBoardMCPTokenStore_RegisterSurfacesSetFailure(t *testing.T) {
 	s := newValkeyBoardMCPTokenStore(rdb, nil)
 
 	mr.SetError("valkey down")
-	err := s.Register("secret-token", []string{"board.read"})
+	err := s.Register("secret-token", []string{"board.read"}, "")
 	if err == nil {
 		t.Fatal("Register should surface the Set failure")
 	}

--- a/studio/src/api/pipelineBoards.test.ts
+++ b/studio/src/api/pipelineBoards.test.ts
@@ -20,13 +20,12 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 describe("normalizePipelineBoard", () => {
-  it("keeps the four fixed columns, folded root cards, draft/ready flags and concurrency", () => {
+  it("keeps the three fixed columns, folded root cards, ready flags and concurrency", () => {
     const board = normalizePipelineBoard({
       columns: [
-        { id: "draft", title: "Draft", kind: "draft" },
-        { id: "todo", title: "Todo", kind: "todo" },
+        { id: "opened", title: "Opened", kind: "opened" },
         { id: "in_progress", title: "In progress", kind: "in_progress" },
-        { id: "done", title: "Done", kind: "done" },
+        { id: "closed", title: "Closed", kind: "closed" },
       ],
       cards: [
         {
@@ -56,7 +55,7 @@ describe("normalizePipelineBoard", () => {
         {
           id: "task:iss-1",
           kind: "task",
-          column_id: "todo",
+          column_id: "opened",
           title: "Backlog item",
           issue_id: "iss-1",
           issue_state: "ready",
@@ -73,7 +72,7 @@ describe("normalizePipelineBoard", () => {
         {
           id: "task:iss-2",
           kind: "run",
-          column_id: "draft",
+          column_id: "closed",
           title: "Broke last time",
           issue_id: "iss-2",
           run_id: "run-old",
@@ -92,10 +91,9 @@ describe("normalizePipelineBoard", () => {
     });
 
     expect(board.columns.map((c) => c.id)).toEqual([
-      "draft",
-      "todo",
+      "opened",
       "in_progress",
-      "done",
+      "closed",
     ]);
     expect(board.concurrency).toEqual({
       enabled: true,
@@ -118,13 +116,13 @@ describe("normalizePipelineBoard", () => {
     });
     expect(board.cards[1]).toMatchObject({
       kind: "task",
-      column_id: "todo",
+      column_id: "opened",
       ready: true,
       entry_input: { area: "api", verbose: true },
       queue_position: 2,
     });
     expect(board.cards[2]).toMatchObject({
-      column_id: "draft",
+      column_id: "closed",
       failed: true,
       error: "boom",
     });
@@ -132,7 +130,7 @@ describe("normalizePipelineBoard", () => {
 
   it("defaults progress and concurrency when the server omits them", () => {
     const board = normalizePipelineBoard({
-      cards: [{ id: "task:x", column_id: "todo", title: "Loose" }],
+      cards: [{ id: "task:x", column_id: "opened", title: "Loose" }],
     });
     expect(board.columns).toEqual([]);
     expect(board.concurrency).toEqual({
@@ -150,13 +148,77 @@ describe("normalizePipelineBoard", () => {
     });
     expect(board.cards[0]?.pending_reviews).toBeUndefined();
   });
+
+  // Regression: this normalizer is a whitelist, and planner provenance was
+  // missing from it — so a parent card arrived in the views with no
+  // children_summary and rendered neither the Plan badge nor the
+  // "N / M closed" children counter, even though the server sent both.
+  it("keeps planner provenance (role, parent, children, summary)", () => {
+    const board = normalizePipelineBoard({
+      cards: [
+        {
+          id: "run:parent",
+          column_id: "opened",
+          title: "Boudicca",
+          run_id: "run-1",
+          role: "planner",
+          children: [
+            { issue_id: "kid-1", title: "ÉP 1", state: "done", card_id: "run:kid1" },
+            { issue_id: "", title: "dropped — no issue_id" },
+          ],
+          children_summary: {
+            total: 5,
+            ready: 0,
+            in_progress: 1,
+            done: 2,
+            failed: 2,
+            open: 0,
+          },
+        },
+        {
+          id: "run:child",
+          column_id: "in_progress",
+          title: "ÉP 4/5",
+          parent_issue_id: "native:parent",
+          parent_title: "Boudicca",
+          role: "producer",
+        },
+      ],
+    });
+    const parent = board.cards[0];
+    expect(parent?.role).toBe("planner");
+    expect(parent?.children_summary).toEqual({
+      total: 5,
+      ready: 0,
+      in_progress: 1,
+      done: 2,
+      failed: 2,
+      open: 0,
+    });
+    expect(parent?.children).toEqual([
+      { issue_id: "kid-1", title: "ÉP 1", state: "done", card_id: "run:kid1" },
+    ]);
+    const child = board.cards[1];
+    expect(child?.parent_issue_id).toBe("native:parent");
+    expect(child?.parent_title).toBe("Boudicca");
+    expect(child?.role).toBe("producer");
+  });
+
+  it("omits planner provenance when the server sends none", () => {
+    const board = normalizePipelineBoard({
+      cards: [{ id: "task:x", column_id: "opened", title: "Loose" }],
+    });
+    expect(board.cards[0]?.children_summary).toBeUndefined();
+    expect(board.cards[0]?.children).toBeUndefined();
+    expect(board.cards[0]?.role).toBeUndefined();
+  });
 });
 
 describe("getPipelineBoard", () => {
   it("GETs the single global board endpoint", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       jsonResponse({
-        columns: [{ id: "todo", title: "Todo", kind: "todo" }],
+        columns: [{ id: "opened", title: "Opened", kind: "opened" }],
         cards: [],
         concurrency: { enabled: false, max: 0, active: 0, waiting: 0 },
         generated_at: "2026-07-14T10:00:00Z",

--- a/studio/src/api/pipelineBoards.ts
+++ b/studio/src/api/pipelineBoards.ts
@@ -11,7 +11,7 @@ const BASE = "/api/v1/pipeline-board";
 
 // The five fixed lanes, in the order the server emits them.
 export interface PipelineBoardColumn {
-  id: string; // "backlog" | "todo" | "in_progress" | "done" | "failed"
+  id: string; // "opened" | "in_progress" | "closed"
   title: string;
   kind: string;
 }
@@ -36,6 +36,42 @@ export interface PipelineBoardAttempt {
   at?: string;
 }
 
+// Resolved hard dependency on another ticket (server-side enrichment).
+export interface PipelineBoardBlocker {
+  id: string;
+  title?: string;
+  state?: string;
+  bot?: string;
+  labels?: string[];
+  satisfied: boolean;
+  missing_labels?: string[];
+}
+
+// Reverse-index entry: a ticket that lists this card as a blocker.
+export interface PipelineBoardBlocking {
+  id: string;
+  title?: string;
+}
+
+/** Spawned child ticket under a planner parent. */
+export interface PipelineBoardChildRef {
+  issue_id: string;
+  title?: string;
+  state?: string;
+  bot_id?: string;
+  card_id?: string;
+}
+
+/** Aggregated child statuses for a plan group face. */
+export interface PipelineBoardChildrenSummary {
+  total: number;
+  ready: number;
+  in_progress: number;
+  done: number;
+  failed: number;
+  open: number;
+}
+
 // PipelineBoardCard is the read model the studio polls: one per root pipeline
 // (or per not-yet-launched native task). Descendants are folded into their
 // root — there are no per-child cards.
@@ -52,6 +88,21 @@ export interface PipelineBoardCard {
   labels?: string[];
   priority?: number;
 
+  // Hard-dependency graph (ticket roots). open_blocker_count > 0 means the
+  // launch loop will refuse even if ready is true.
+  blockers?: PipelineBoardBlocker[];
+  open_blocker_count?: number;
+  launch_blocked_reason?: string;
+  blocking?: PipelineBoardBlocking[];
+
+  // Planner provenance (distinct from hard blockers).
+  parent_issue_id?: string;
+  parent_title?: string;
+  children?: PipelineBoardChildRef[];
+  children_summary?: PipelineBoardChildrenSummary;
+  /** planner | producer when known. */
+  role?: string;
+
   // Run identity (empty for a not-yet-launched task card).
   run_id?: string;
   workflow_name?: string;
@@ -60,13 +111,13 @@ export interface PipelineBoardCard {
   error?: string;
 
   // Failed lane — the ticket's last run failed/cancelled (Retry stages it
-  // back to Todo), as opposed to a not-yet-ready Backlog ticket.
+  // back to Ready), as opposed to a not-yet-ready Backlog ticket.
   failed?: boolean;
-  // Todo lane — a task-backed ticket in the ready state (waiting for a
+  // Ready lane (wire ID "opened") — a task-backed ticket staged (waiting for a
   // concurrency slot; the studio auto-launches it when one frees).
   ready?: boolean;
 
-  // TODO lane — launch vars / task bot-args, and the concurrency-queue place.
+  // Ready lane — launch vars / task bot-args, and the concurrency-queue place.
   entry_input?: Record<string, unknown>;
   queue_position?: number;
 
@@ -96,7 +147,7 @@ export interface PipelineBoardCard {
 }
 
 // The local pipeline-concurrency gate. When `enabled` is false the other
-// fields are zero and the TODO lane only holds not-yet-launched native tasks.
+// fields are zero and the Ready lane only holds not-yet-launched native tasks.
 export interface PipelineConcurrency {
   enabled: boolean;
   max: number;
@@ -122,10 +173,14 @@ export interface CreatePipelineTaskInput {
   labels?: string[];
   priority?: number;
   bot_args?: Record<string, string>;
+  /** Hard deps: issue IDs that must reach done before this ticket can launch. */
+  blockers?: string[];
   start?: boolean;
   // Optional repo-first scoping: link the new task to a connected forge repo
   // at creation. Mirrors NativeIssueCreate.external.
   external?: ExternalLinkInput;
+  /** Reconcile by (bot, bot_args.input_path) instead of creating a duplicate. */
+  upsert?: boolean;
 }
 
 type UnknownRecord = Record<string, unknown>;
@@ -193,6 +248,80 @@ function normalizeExternal(value: unknown): ExternalLinkInput | undefined {
   return out;
 }
 
+function normalizeBlockers(value: unknown): PipelineBoardBlocker[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value
+    .map((entry) => {
+      const source = record(entry) ?? {};
+      const id = text(source.id);
+      if (!id) return null;
+      return {
+        id,
+        ...(text(source.title) ? { title: text(source.title) } : {}),
+        ...(text(source.state) ? { state: text(source.state) } : {}),
+        ...(text(source.bot) ? { bot: text(source.bot) } : {}),
+        ...(stringArray(source.labels) !== undefined
+          ? { labels: stringArray(source.labels) }
+          : {}),
+        satisfied: booleanValue(source.satisfied),
+        ...(stringArray(source.missing_labels) !== undefined
+          ? { missing_labels: stringArray(source.missing_labels) }
+          : {}),
+      };
+    })
+    .filter((b): b is PipelineBoardBlocker => b !== null);
+}
+
+function normalizeBlocking(value: unknown): PipelineBoardBlocking[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value
+    .map((entry) => {
+      const source = record(entry) ?? {};
+      const id = text(source.id);
+      if (!id) return null;
+      return {
+        id,
+        ...(text(source.title) ? { title: text(source.title) } : {}),
+      };
+    })
+    .filter((b): b is PipelineBoardBlocking => b !== null);
+}
+
+function normalizeChildRefs(
+  value: unknown,
+): PipelineBoardChildRef[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value
+    .map((entry) => {
+      const source = record(entry) ?? {};
+      const issueID = text(source.issue_id);
+      if (!issueID) return null;
+      return {
+        issue_id: issueID,
+        ...(text(source.title) ? { title: text(source.title) } : {}),
+        ...(text(source.state) ? { state: text(source.state) } : {}),
+        ...(text(source.bot_id) ? { bot_id: text(source.bot_id) } : {}),
+        ...(text(source.card_id) ? { card_id: text(source.card_id) } : {}),
+      };
+    })
+    .filter((c): c is PipelineBoardChildRef => c !== null);
+}
+
+function normalizeChildrenSummary(
+  value: unknown,
+): PipelineBoardChildrenSummary | undefined {
+  const source = record(value);
+  if (!source) return undefined;
+  return {
+    total: intValue(source.total, 0),
+    ready: intValue(source.ready, 0),
+    in_progress: intValue(source.in_progress, 0),
+    done: intValue(source.done, 0),
+    failed: intValue(source.failed, 0),
+    open: intValue(source.open, 0),
+  };
+}
+
 function normalizePendingReviews(
   value: unknown,
 ): PipelineBoardPendingReview[] | undefined {
@@ -244,7 +373,7 @@ export function normalizePipelineBoardCard(
   return {
     id,
     kind: text(source.kind) ?? (runID ? "run" : "task"),
-    column_id: text(source.column_id) ?? "todo",
+    column_id: text(source.column_id) ?? "opened",
     title: text(source.title) ?? id,
     ...(text(source.body) ? { body: text(source.body) } : {}),
     ...(issueID ? { issue_id: issueID } : {}),
@@ -255,6 +384,36 @@ export function normalizePipelineBoardCard(
     ...(numberValue(source.priority) !== undefined
       ? { priority: numberValue(source.priority) }
       : {}),
+    ...(normalizeBlockers(source.blockers) !== undefined
+      ? { blockers: normalizeBlockers(source.blockers) }
+      : {}),
+    ...(numberValue(source.open_blocker_count) !== undefined
+      ? { open_blocker_count: intValue(source.open_blocker_count, 0) }
+      : {}),
+    ...(text(source.launch_blocked_reason)
+      ? { launch_blocked_reason: text(source.launch_blocked_reason) }
+      : {}),
+    ...(normalizeBlocking(source.blocking) !== undefined
+      ? { blocking: normalizeBlocking(source.blocking) }
+      : {}),
+    // Planner provenance. This normalizer is a WHITELIST — a field absent
+    // here never reaches the views, however faithfully the server emits it
+    // (that is exactly how the parent card lost its "N / M closed" children
+    // counter and its Plan badge while /api/v1/pipeline-board was serving
+    // both). Keep it in sync with PipelineBoardCard.
+    ...(text(source.parent_issue_id)
+      ? { parent_issue_id: text(source.parent_issue_id) }
+      : {}),
+    ...(text(source.parent_title)
+      ? { parent_title: text(source.parent_title) }
+      : {}),
+    ...(normalizeChildRefs(source.children) !== undefined
+      ? { children: normalizeChildRefs(source.children) }
+      : {}),
+    ...(normalizeChildrenSummary(source.children_summary) !== undefined
+      ? { children_summary: normalizeChildrenSummary(source.children_summary) }
+      : {}),
+    ...(text(source.role) ? { role: text(source.role) } : {}),
     ...(runID ? { run_id: runID } : {}),
     ...(text(source.workflow_name)
       ? { workflow_name: text(source.workflow_name) }
@@ -330,10 +489,54 @@ export async function createPipelineTask(
   });
 }
 
-// markPipelineTaskReady flips a task-backed ticket between the ready (Todo)
-// and backlog states — the write behind the board's "→ Todo" / "→ Backlog"
-// move buttons. The studio auto-launches ready tickets when a concurrency slot
-// frees.
+export interface BulkReadyInput {
+  ids?: string[];
+  family_id?: string;
+  pipeline_kind?: string;
+  only_satisfied?: boolean;
+}
+
+export interface BulkReadyResult {
+  ready: string[];
+  waiting_deps?: string[];
+  skipped?: string[];
+  skipped_why?: Record<string, string>;
+}
+
+/** Stage many tickets Ready (or waiting_deps). Used by multi-select bulk. */
+export async function bulkReadyPipelineTasks(
+  input: BulkReadyInput,
+): Promise<BulkReadyResult> {
+  return apiRequest<BulkReadyResult>(`${BASE}/bulk/ready`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export interface BulkDeleteInput {
+  ids: string[];
+}
+
+export interface BulkDeleteResult {
+  deleted: string[];
+  skipped?: string[];
+  skipped_why?: Record<string, string>;
+}
+
+/** Delete many tickets (issue only). Skips tickets with active runs. */
+export async function bulkDeletePipelineTasks(
+  input: BulkDeleteInput,
+): Promise<BulkDeleteResult> {
+  return apiRequest<BulkDeleteResult>(`${BASE}/bulk/delete`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+// markPipelineTaskReady flips a task-backed ticket between the ready and
+// draft states (both stay in the Todo lane) — the write behind the board's
+// Mark ready / Unmark ready / Retry buttons. The studio auto-launches ready
+// tickets when a concurrency slot frees.
 export async function markPipelineTaskReady(
   taskId: string,
   ready: boolean,
@@ -344,6 +547,38 @@ export async function markPipelineTaskReady(
       method: "POST",
       body: JSON.stringify({ ready }),
     },
+  );
+}
+
+// deletePipelineTask removes a ticket — the Backlog card's Delete button.
+// Server-guarded: refused (409) while any run in the ticket's tree is still
+// active, so a live pipeline can never be detached from its ticket. Runs are
+// never deleted, only the native issue.
+export async function deletePipelineTask(taskId: string): Promise<void> {
+  await apiRequest<unknown>(`${BASE}/tasks/${encodeURIComponent(taskId)}`, {
+    method: "DELETE",
+  });
+}
+
+// resetPipelineTask restarts an in-progress ticket from zero: the server
+// cancels every still-active run in the ticket's tree, then restages the
+// ticket to Ready so the admission loop relaunches it fresh. Refused (409)
+// when a run is held by another process.
+export async function resetPipelineTask(taskId: string): Promise<void> {
+  await apiRequest<unknown>(
+    `${BASE}/tasks/${encodeURIComponent(taskId)}/reset`,
+    { method: "POST", body: JSON.stringify({}) },
+  );
+}
+
+// launchPipelineTask starts a ticket immediately, jumping the admission
+// loop's priority order (the Opened → In progress drag). The server still
+// refuses (409) on an active run, an unfinished hard dependency, or a full
+// concurrency cap — those are correctness, not ranking.
+export async function launchPipelineTask(taskId: string): Promise<void> {
+  await apiRequest<unknown>(
+    `${BASE}/tasks/${encodeURIComponent(taskId)}/launch`,
+    { method: "POST", body: JSON.stringify({}) },
   );
 }
 
@@ -359,6 +594,8 @@ export interface PipelineTaskPatch {
   // Re-links the task's forge repo (absent = unchanged). Mirrors
   // NativeIssuePatch.external.
   external?: ExternalLinkInput;
+  /** Replace hard-dep list wholesale; empty array clears. */
+  blockers?: string[];
 }
 
 // updatePipelineTask edits a Backlog (or ready-but-unlaunched) ticket before it

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -3706,6 +3706,25 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/native/issues/{id}/dependency-graph": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** GET /api/v1/native/issues/{id}/dependency-graph */
+        get: operations["getV1NativeIssuesByIdDependencyGraph"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/pipeline-board": {
         parameters: {
             query?: never;
@@ -3717,6 +3736,57 @@ export interface paths {
         get: operations["getV1PipelineBoard"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pipeline-board/bulk/delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** POST /api/v1/pipeline-board/bulk/delete */
+        post: operations["postV1PipelineBoardBulkDelete"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pipeline-board/bulk/ready": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** POST /api/v1/pipeline-board/bulk/ready */
+        post: operations["postV1PipelineBoardBulkReady"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pipeline-board/bulk/recompute-deps": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** POST /api/v1/pipeline-board/bulk/recompute-deps */
+        post: operations["postV1PipelineBoardBulkRecomputeDeps"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3752,11 +3822,50 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
-        delete?: never;
+        /** DELETE /api/v1/pipeline-board/tasks/{id} */
+        delete: operations["deleteV1PipelineBoardTasksById"];
         options?: never;
         head?: never;
         /** PATCH /api/v1/pipeline-board/tasks/{id} */
         patch: operations["patchV1PipelineBoardTasksById"];
+        trace?: never;
+    };
+    "/api/v1/pipeline-board/tasks/{id}/dependency-graph": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** GET /api/v1/pipeline-board/tasks/{id}/dependency-graph */
+        get: operations["getV1PipelineBoardTasksByIdDependencyGraph"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pipeline-board/tasks/{id}/launch": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** POST /api/v1/pipeline-board/tasks/{id}/launch */
+        post: operations["postV1PipelineBoardTasksByIdLaunch"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/api/v1/pipeline-board/tasks/{id}/ready": {
@@ -3772,6 +3881,25 @@ export interface paths {
         put?: never;
         /** POST /api/v1/pipeline-board/tasks/{id}/ready */
         post: operations["postV1PipelineBoardTasksByIdReady"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pipeline-board/tasks/{id}/reset": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** POST /api/v1/pipeline-board/tasks/{id}/reset */
+        post: operations["postV1PipelineBoardTasksByIdReset"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4209,6 +4337,19 @@ export interface components {
             model?: string;
             node_count: number;
         };
+        BlockerInfo: {
+            bot?: string;
+            id: string;
+            labels?: string[];
+            missing_labels?: string[];
+            satisfied: boolean;
+            state?: string;
+            title?: string;
+        };
+        BlockingInfo: {
+            id: string;
+            title?: string;
+        };
         Checkpoint: {
             artifact_versions: {
                 [key: string]: number;
@@ -4294,6 +4435,25 @@ export interface components {
             /** Format: date-time */
             updated_at: string;
         };
+        DependencyGraphEdge: {
+            from: string;
+            to: string;
+        };
+        DependencyGraphNode: {
+            blockers?: components["schemas"]["BlockerInfo"][];
+            blocking?: components["schemas"]["BlockingInfo"][];
+            bot?: string;
+            depth: number;
+            id: string;
+            satisfied?: boolean;
+            state?: string;
+            title?: string;
+        };
+        DependencyGraphResponse: {
+            edges?: components["schemas"]["DependencyGraphEdge"][];
+            nodes: components["schemas"]["DependencyGraphNode"][];
+            root: components["schemas"]["DependencyGraphNode"];
+        };
         ExecutionState: {
             branch_id: string;
             current_event_seq: number;
@@ -4360,6 +4520,7 @@ export interface components {
             labels?: string[];
             last_run_id?: string;
             last_workdir?: string;
+            parent_id?: string;
             priority?: number;
             runs?: components["schemas"]["RunRef"][];
             state: string;
@@ -4375,8 +4536,12 @@ export interface components {
         };
         PipelineBoardCard: {
             attempts?: components["schemas"]["PipelineBoardAttempt"][];
+            blockers?: components["schemas"]["BlockerInfo"][];
+            blocking?: components["schemas"]["BlockingInfo"][];
             body?: string;
             bot_id?: string;
+            children?: components["schemas"]["PipelineBoardChildRef"][];
+            children_summary?: components["schemas"]["PipelineBoardChildrenSummary"];
             column_id: string;
             /** Format: date-time */
             created_at: string;
@@ -4393,11 +4558,16 @@ export interface components {
             issue_state?: string;
             kind: string;
             labels?: string[];
+            launch_blocked_reason?: string;
+            open_blocker_count?: number;
             output?: string;
+            parent_issue_id?: string;
+            parent_title?: string;
             pending_reviews?: components["schemas"]["PipelineBoardPendingReview"][];
             priority?: number;
             queue_position?: number;
             ready?: boolean;
+            role?: string;
             run_id?: string;
             status?: string;
             title: string;
@@ -4408,6 +4578,21 @@ export interface components {
             /** Format: date-time */
             updated_at: string;
             workflow_name?: string;
+        };
+        PipelineBoardChildRef: {
+            bot_id?: string;
+            card_id?: string;
+            issue_id: string;
+            state?: string;
+            title?: string;
+        };
+        PipelineBoardChildrenSummary: {
+            done: number;
+            failed: number;
+            in_progress: number;
+            open: number;
+            ready: number;
+            total: number;
         };
         PipelineBoardColumn: {
             id: string;
@@ -4743,6 +4928,7 @@ export interface components {
             ready: boolean;
         };
         pipelineBoardTaskRequest: {
+            blockers?: string[];
             body?: string;
             bot: string;
             bot_args?: {
@@ -4750,11 +4936,14 @@ export interface components {
             };
             external?: components["schemas"]["ExternalRef"];
             labels?: string[];
+            parent_id?: string;
             priority?: number;
             start?: boolean;
             title: string;
+            upsert?: boolean;
         };
         pipelineBoardUpdateRequest: {
+            blockers?: string[];
             body?: string;
             bot?: string;
             bot_args?: {
@@ -4764,6 +4953,39 @@ export interface components {
             labels?: string[];
             priority?: number;
             title?: string;
+        };
+        pipelineBulkDeleteRequest: {
+            ids: string[];
+        };
+        pipelineBulkDeleteResponse: {
+            deleted: string[];
+            skipped?: string[];
+            skipped_why?: {
+                [key: string]: string;
+            };
+        };
+        pipelineBulkReadyRequest: {
+            family_id?: string;
+            ids?: string[];
+            only_satisfied?: boolean;
+            pipeline_kind?: string;
+        };
+        pipelineBulkReadyResponse: {
+            ready: string[];
+            skipped?: string[];
+            skipped_why?: {
+                [key: string]: string;
+            };
+            waiting_deps?: string[];
+        };
+        pipelineRecomputeDepsRequest: {
+            closed_id?: string;
+        };
+        pipelineRecomputeDepsResponse: {
+            promoted: string[];
+            targets?: {
+                [key: string]: string;
+            };
         };
         setOrgStatusReq: {
             reason?: string;
@@ -9783,6 +10005,28 @@ export interface operations {
             };
         };
     };
+    getV1NativeIssuesByIdDependencyGraph: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DependencyGraphResponse"];
+                };
+            };
+        };
+    };
     getV1PipelineBoard: {
         parameters: {
             query?: never;
@@ -9799,6 +10043,78 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PipelineBoardResponse"];
+                };
+            };
+        };
+    };
+    postV1PipelineBoardBulkDelete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["pipelineBulkDeleteRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["pipelineBulkDeleteResponse"];
+                };
+            };
+        };
+    };
+    postV1PipelineBoardBulkReady: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["pipelineBulkReadyRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["pipelineBulkReadyResponse"];
+                };
+            };
+        };
+    };
+    postV1PipelineBoardBulkRecomputeDeps: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["pipelineRecomputeDepsRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["pipelineRecomputeDepsResponse"];
                 };
             };
         };
@@ -9824,6 +10140,26 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["Issue"];
                 };
+            };
+        };
+    };
+    deleteV1PipelineBoardTasksById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -9853,6 +10189,48 @@ export interface operations {
             };
         };
     };
+    getV1PipelineBoardTasksByIdDependencyGraph: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DependencyGraphResponse"];
+                };
+            };
+        };
+    };
+    postV1PipelineBoardTasksByIdLaunch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     postV1PipelineBoardTasksByIdReady: {
         parameters: {
             query?: never;
@@ -9876,6 +10254,26 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["Issue"];
                 };
+            };
+        };
+    };
+    postV1PipelineBoardTasksByIdReset: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/studio/src/components/shared/BotFilterSelect.tsx
+++ b/studio/src/components/shared/BotFilterSelect.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useMemo } from "react";
+
+import type { BotEntry } from "@/api/bots";
+import { Select } from "@/components/ui/Select";
+import { botVisual, canon } from "@/lib/personas";
+import { useBotsStore } from "@/store/bots";
+
+/** botFilterLabel renders a filter-dropdown option for a raw bot identity
+ *  (a card's bot_id, or its workflow-name fallback): the catalog persona
+ *  (emoji + display_name) when the identity resolves to a discovered bot,
+ *  else the raw identity unchanged. Snake/kebab variants of one id resolve
+ *  the same catalog entry (canon), so a loose run's `pipeline_board_demo`
+ *  workflow name still finds the `pipeline-board-demo` bundle. */
+export function botFilterLabel(
+  identity: string,
+  catalog: BotEntry[] | null | undefined,
+): string {
+  const key = canon(identity);
+  const hit = (catalog ?? []).find((b) => canon(b.name) === key);
+  const persona = hit?.display_name?.trim();
+  if (!hit || !persona) return identity;
+  return `${botVisual(hit).emoji} ${persona}`;
+}
+
+export interface BotFilterOption {
+  value: string;
+  label: string;
+}
+
+/** botFilterOptions maps the board's raw bot identities to dropdown
+ *  options. The option VALUE stays the raw identity — filtering is an
+ *  exact match on card data, only the label is humanized. Two raw
+ *  identities can resolve the same persona (a bundle launch's bot_id
+ *  `pipeline-board-demo` next to a loose run's workflow-name fallback
+ *  `pipeline_board_demo`): each keeps its own option so neither
+ *  population becomes unreachable, and colliding labels get the raw
+ *  identity appended so the operator can tell them apart. */
+export function botFilterOptions(
+  allBots: string[],
+  catalog: BotEntry[] | null | undefined,
+): BotFilterOption[] {
+  const options = allBots.map((value) => ({
+    value,
+    label: botFilterLabel(value, catalog),
+  }));
+  const labelCounts = new Map<string, number>();
+  for (const o of options) {
+    labelCounts.set(o.label, (labelCounts.get(o.label) ?? 0) + 1);
+  }
+  for (const o of options) {
+    if ((labelCounts.get(o.label) ?? 0) > 1 && o.label !== o.value) {
+      o.label = `${o.label} (${o.value})`;
+    }
+  }
+  // Order by what the operator reads: the persona/identity text, not the
+  // leading emoji token (raw-identity labels have no emoji to strip).
+  return options.sort((a, b) =>
+    a.label.replace(/^\S+\s/, "").localeCompare(b.label.replace(/^\S+\s/, "")),
+  );
+}
+
+/** BotFilterSelect is the shared bot dropdown of the /board and /pipelines
+ *  filter bars. It reads the shared bots store (fetching it on first
+ *  mount) so raw slugs upgrade to persona names as soon as the catalog
+ *  loads; identities without a catalog match keep rendering raw. */
+export function BotFilterSelect({
+  value,
+  allBots,
+  onChange,
+  ariaLabel = "Filter by bot",
+}: {
+  value: string;
+  /** Raw identities present on the board's cards (already deduped). */
+  allBots: string[];
+  onChange: (v: string) => void;
+  ariaLabel?: string;
+}) {
+  const bots = useBotsStore((s) => s.bots);
+  const fetchBots = useBotsStore((s) => s.fetch);
+  useEffect(() => {
+    if (bots === null) void fetchBots();
+  }, [bots, fetchBots]);
+
+  const options = useMemo(() => botFilterOptions(allBots, bots), [allBots, bots]);
+
+  return (
+    <div className="w-auto">
+      <Select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label={ariaLabel}
+      >
+        <option value="">All bots</option>
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </Select>
+    </div>
+  );
+}

--- a/studio/src/components/shared/LabelFilterPopover.tsx
+++ b/studio/src/components/shared/LabelFilterPopover.tsx
@@ -13,11 +13,16 @@ export function LabelFilter({
   selected,
   onToggle,
   onClear,
+  label = "Labels",
+  searchPlaceholder = "Search labels…",
 }: {
   allLabels: string[];
   selected: Set<string>;
   onToggle: (l: string) => void;
   onClear: () => void;
+  /** Button caption (e.g. "Tags" on the pipeline board). */
+  label?: string;
+  searchPlaceholder?: string;
 }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -59,7 +64,7 @@ export function LabelFilter({
         aria-haspopup="listbox"
         aria-expanded={open}
       >
-        <span>Labels</span>
+        <span>{label}</span>
         {count > 0 && (
           <span className="px-1 rounded bg-accent text-fg-onAccent text-caption">{count}</span>
         )}
@@ -74,8 +79,8 @@ export function LabelFilter({
               type="text"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search labels…"
-              aria-label="Search labels"
+              placeholder={searchPlaceholder}
+              aria-label={searchPlaceholder}
             />
           </div>
           <ul className="py-1 overflow-auto">

--- a/studio/src/lib/personas.ts
+++ b/studio/src/lib/personas.ts
@@ -59,7 +59,7 @@ const FALLBACK_COLORS = [
 /** Canonicalise a technical bot id: lower-case, collapse runs of `_`/`-`
  *  into a single `-`. So `feature_dev`, `feature-dev` and `Feature_Dev`
  *  all map to the same key. */
-function canon(name: string): string {
+export function canon(name: string): string {
   return name.trim().toLowerCase().replace(/[_-]+/g, "-");
 }
 

--- a/studio/src/views/PipelineBoard/AddTaskDialog.tsx
+++ b/studio/src/views/PipelineBoard/AddTaskDialog.tsx
@@ -34,10 +34,11 @@ interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onCreated: () => void;
-  // When set, the dialog edits this existing (Backlog / ready-but-unlaunched)
-  // ticket instead of creating a new one: the form pre-fills from the card
-  // and Save PATCHes it. The ready-state stays under the “→ Todo” / “→ Backlog” buttons,
-  // so the "Ready to run" checkbox is hidden in edit mode.
+  // When set, the dialog edits this existing (not-yet-run Todo, or failed
+  // Closed) ticket instead of creating a new one: the form pre-fills from the
+  // card and Save PATCHes it. The ready-state stays under the card's Mark
+  // ready / Unmark buttons, so the "Ready to run" checkbox is hidden in edit
+  // mode.
   editTask?: PipelineBoardCard;
 }
 
@@ -131,6 +132,10 @@ function AddTaskDialogContent({
   const [priority, setPriority] = useState(editTask?.priority ?? 0);
   const [botArgs, setBotArgs] = useState<Record<string, string>>(() =>
     coerceEntryInput(editTask?.entry_input),
+  );
+  // Hard deps: native issue IDs that must reach done before this ticket launches.
+  const [blockersText, setBlockersText] = useState(() =>
+    (editTask?.blockers ?? []).map((b) => b.id).join("\n"),
   );
   const [start, setStart] = useState(false);
   // Open Advanced by default when editing so the title / description / labels /
@@ -276,6 +281,10 @@ function AddTaskDialogContent({
       return;
     }
     const external = resolveExternalForSubmit();
+    const blockers = blockersText
+      .split(/[\n,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
     if (isEdit && editTask?.issue_id) {
       const patch: PipelineTaskPatch = {
         bot: botName.trim(),
@@ -285,6 +294,7 @@ function AddTaskDialogContent({
         priority,
         bot_args: botArgs,
         ...(external ? { external } : {}),
+        blockers,
       };
       const result = await action.run(() =>
         updatePipelineTask(editTask.issue_id as string, patch),
@@ -301,6 +311,7 @@ function AddTaskDialogContent({
       ...(labels.length > 0 ? { labels } : {}),
       ...(priority !== 0 ? { priority } : {}),
       ...(Object.keys(botArgs).length > 0 ? { bot_args: botArgs } : {}),
+      ...(blockers.length > 0 ? { blockers } : {}),
       ...(start && botEnabled ? { start: true } : {}),
       ...(external ? { external } : {}),
     };
@@ -317,7 +328,7 @@ function AddTaskDialogContent({
       title={isEdit ? "Edit ticket" : "Add pipeline task"}
       description={
         isEdit
-          ? "Edit this backlog ticket before it runs. Technical parameters sit under Advanced."
+          ? "Edit this Opened ticket before it runs. Technical parameters sit under Advanced."
           : "Pick the pipeline to run and its input. Technical parameters sit under Advanced."
       }
       widthClass="max-w-2xl"
@@ -351,7 +362,7 @@ function AddTaskDialogContent({
             disabled={!canSubmit}
             onClick={() => void submit()}
           >
-            {isEdit ? "Save" : start && botEnabled ? "Add to Todo" : "Add to Backlog"}
+            {isEdit ? "Save" : start && botEnabled ? "Add ready to Opened" : "Add to Opened"}
           </Button>
         </>
       }
@@ -497,16 +508,52 @@ function AddTaskDialogContent({
                     setPriority(Number(event.target.value) || 0)
                   }
                   min={0}
-                  title="Higher numbers launch first from Todo; equal priorities go oldest-first. 0 = unprioritized."
+                  title="Higher numbers launch first once ready; equal priorities go oldest-first. 0 = unprioritized."
                 />
                 <span className="mt-1 block text-micro text-fg-subtle">
-                  Higher launches first from Todo.
+                  Higher launches first once ready.
+                </span>
+              </label>
+
+              <label className="block">
+                <span className="mb-1 block text-xs text-fg-muted">
+                  Blockers (hard deps)
+                </span>
+                <Textarea
+                  value={blockersText}
+                  onChange={(event) => setBlockersText(event.target.value)}
+                  placeholder={"native:…\nnative:…"}
+                  rows={3}
+                  title="Issue IDs that must reach Done before this ticket can launch. One per line or comma-separated."
+                />
+                <span className="mt-1 block text-micro text-fg-subtle">
+                  Ticket IDs that must finish (state <code>done</code>) before
+                  this one can launch. Cycles are rejected. Open blockers park
+                  the ticket in Waiting on deps instead of Ready.
                 </span>
               </label>
             </div>
           )}
         </div>
 
+
+        {!isEdit && (
+          <div className="border-t border-border-default pt-4">
+            <Checkbox
+              checked={start}
+              onChange={(event) => setStart(event.target.checked)}
+              disabled={!botName || !botEnabled}
+              label="Ready to run"
+              help={
+                !botName
+                  ? "Pick a pipeline first."
+                  : botEnabled
+                    ? "Marks the ticket ready — it starts automatically when a concurrency slot frees. Otherwise it stays in Opened as a draft until you Mark ready."
+                    : "This bot is disabled. The ticket stays in Opened as a draft; enable the bot, then Mark ready to run."
+              }
+            />
+          </div>
+        )}
       </div>
     </Dialog>
   );

--- a/studio/src/views/PipelineBoard/ImagePreview.tsx
+++ b/studio/src/views/PipelineBoard/ImagePreview.tsx
@@ -1,0 +1,205 @@
+import { DownloadIcon, MinusIcon, PlusIcon, ResetIcon } from "@radix-ui/react-icons";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+
+import { Dialog, IconButton } from "@/components/ui";
+
+const ZOOM_MIN = 0.5;
+const ZOOM_MAX = 5;
+const ZOOM_STEP = 0.25;
+
+// ImagePreviewDialog shows a full-viewport-safe image viewer with zoom
+// (+/−, wheel, double-click) and pan-by-drag when zoomed. Used by ticket
+// input thumbnails and produced-elements previews on /pipelines only.
+export function ImagePreviewDialog({
+  open,
+  onOpenChange,
+  src,
+  alt,
+  title,
+  description,
+  downloadHref,
+  footerExtra,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  src: string;
+  alt: string;
+  title?: ReactNode;
+  description?: ReactNode;
+  downloadHref?: string;
+  footerExtra?: ReactNode;
+}) {
+  const [zoom, setZoom] = useState(1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const dragRef = useRef<{
+    active: boolean;
+    startX: number;
+    startY: number;
+    originX: number;
+    originY: number;
+    pointerId: number;
+  } | null>(null);
+  const viewportRef = useRef<HTMLDivElement>(null);
+
+  // Reset zoom + pan each time a new image / open cycle starts.
+  useEffect(() => {
+    if (open) {
+      setZoom(1);
+      setPan({ x: 0, y: 0 });
+    }
+  }, [open, src]);
+
+  const bump = useCallback((delta: number) => {
+    setZoom((z) => {
+      const next = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, Math.round((z + delta) * 100) / 100));
+      if (next <= 1) setPan({ x: 0, y: 0 });
+      return next;
+    });
+  }, []);
+
+  const resetView = useCallback(() => {
+    setZoom(1);
+    setPan({ x: 0, y: 0 });
+  }, []);
+
+  const onWheel = useCallback(
+    (e: React.WheelEvent) => {
+      if (!(e.ctrlKey || e.metaKey)) return;
+      e.preventDefault();
+      bump(e.deltaY > 0 ? -ZOOM_STEP : ZOOM_STEP);
+    },
+    [bump],
+  );
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (zoom <= 1) return;
+      // Primary button / touch only.
+      if (e.button !== 0 && e.pointerType === "mouse") return;
+      e.preventDefault();
+      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      dragRef.current = {
+        active: true,
+        startX: e.clientX,
+        startY: e.clientY,
+        originX: pan.x,
+        originY: pan.y,
+        pointerId: e.pointerId,
+      };
+    },
+    [zoom, pan.x, pan.y],
+  );
+
+  const onPointerMove = useCallback((e: React.PointerEvent) => {
+    const drag = dragRef.current;
+    if (!drag?.active) return;
+    setPan({
+      x: drag.originX + (e.clientX - drag.startX),
+      y: drag.originY + (e.clientY - drag.startY),
+    });
+  }, []);
+
+  const endDrag = useCallback((e: React.PointerEvent) => {
+    const drag = dragRef.current;
+    if (!drag?.active) return;
+    if (drag.pointerId === e.pointerId) {
+      try {
+        (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+      } catch {
+        /* already released */
+      }
+      dragRef.current = null;
+    }
+  }, []);
+
+  const canPan = zoom > 1;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      widthClass="max-w-5xl"
+      title={title}
+      description={description}
+      footer={
+        <div className="flex w-full flex-wrap items-center justify-between gap-2">
+          <div className="flex items-center gap-1" role="group" aria-label="Zoom controls">
+            <IconButton
+              label="Zoom out"
+              size="sm"
+              variant="ghost"
+              onClick={() => bump(-ZOOM_STEP)}
+              disabled={zoom <= ZOOM_MIN}
+            >
+              <MinusIcon />
+            </IconButton>
+            <span className="min-w-[3.5rem] text-center font-mono text-xs text-fg-muted">
+              {Math.round(zoom * 100)}%
+            </span>
+            <IconButton
+              label="Zoom in"
+              size="sm"
+              variant="ghost"
+              onClick={() => bump(ZOOM_STEP)}
+              disabled={zoom >= ZOOM_MAX}
+            >
+              <PlusIcon />
+            </IconButton>
+            <IconButton
+              label="Reset zoom and pan"
+              size="sm"
+              variant="ghost"
+              onClick={resetView}
+              disabled={zoom === 1 && pan.x === 0 && pan.y === 0}
+            >
+              <ResetIcon />
+            </IconButton>
+            <span className="ml-1 text-micro text-fg-subtle">
+              Ctrl+scroll · drag to pan when zoomed · double-click reset
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            {footerExtra}
+            {downloadHref && (
+              <a
+                href={downloadHref}
+                download
+                className="inline-flex items-center gap-1 rounded-md border border-border-default px-2.5 py-1 text-xs font-medium text-fg-default hover:bg-surface-2"
+              >
+                <DownloadIcon /> Download
+              </a>
+            )}
+          </div>
+        </div>
+      }
+    >
+      <div
+        ref={viewportRef}
+        onWheel={onWheel}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
+        className={`flex min-h-[min(70vh,720px)] max-h-[min(70vh,720px)] items-center justify-center overflow-hidden rounded-md bg-surface-0 ${
+          canPan ? "cursor-grab active:cursor-grabbing touch-none" : "cursor-default"
+        }`}
+        title={canPan ? "Drag to pan · Ctrl+scroll to zoom" : "Ctrl+scroll to zoom"}
+      >
+        <img
+          src={src}
+          alt={alt}
+          draggable={false}
+          onDoubleClick={resetView}
+          className="max-w-none select-none object-contain"
+          style={{
+            maxHeight: "min(70vh, 720px)",
+            maxWidth: "100%",
+            transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+            transformOrigin: "center center",
+            transition: dragRef.current?.active ? "none" : "transform 100ms ease-out",
+          }}
+        />
+      </div>
+    </Dialog>
+  );
+}

--- a/studio/src/views/PipelineBoard/PipelineCardDetails.test.tsx
+++ b/studio/src/views/PipelineBoard/PipelineCardDetails.test.tsx
@@ -63,7 +63,7 @@ describe("PipelineCardDetailsBody", () => {
   it("Todo card shows inputs only — no produced elements, no response form", () => {
     const html = render(
       makeCard({
-        column_id: "todo",
+        column_id: "opened",
         kind: "task",
         issue_id: "iss-1",
         entry_input: { topic: "jazz", length: "3m" },
@@ -156,9 +156,10 @@ describe("PipelineCardDetailsBody", () => {
   it("Failed card shows the failure reason + inputs + produced elements", () => {
     const html = render(
       makeCard({
-        column_id: "failed",
+        column_id: "closed",
         run_id: "run-ko",
         status: "failed_resumable",
+        failed: true,
         error: "budget exceeded at node compose",
         entry_input: { topic: "jazz" },
       }),
@@ -170,10 +171,10 @@ describe("PipelineCardDetailsBody", () => {
     expect(html).toContain('data-run-ids="run-ko"');
   });
 
-  it("Done card shows inputs + result + produced elements", () => {
+  it("successful Closed card shows inputs + result + produced elements", () => {
     const html = render(
       makeCard({
-        column_id: "done",
+        column_id: "closed",
         run_id: "run-done",
         status: "finished",
         entry_input: { topic: "jazz" },
@@ -189,7 +190,7 @@ describe("PipelineCardDetailsBody", () => {
   it("renders object input values as pretty-printed JSON blocks, scalars inline", () => {
     const html = render(
       makeCard({
-        column_id: "todo",
+        column_id: "opened",
         kind: "task",
         entry_input: { topic: "jazz", options: { tempo: 120, mood: "calm" } },
       }),
@@ -203,8 +204,8 @@ describe("PipelineCardDetailsBody", () => {
   });
 
   it("renders a 'No inputs recorded' fallback and a stale banner", () => {
-    const html = render(makeCard({ column_id: "todo", kind: "task" }), true);
-    expect(html).toContain("No inputs recorded");
+    const html = render(makeCard({ column_id: "opened", kind: "task" }), true);
+    expect(html).toContain("No additional inputs");
     expect(html).toContain("no longer on the board");
   });
 });
@@ -213,7 +214,7 @@ describe("InputsList image carousel", () => {
   it("renders a JSON list of image paths as a carousel of workspace-image URLs", () => {
     const html = render(
       makeCard({
-        column_id: "backlog",
+        column_id: "opened",
         entry_input: {
           character: "Boudicca",
           character_refs:
@@ -235,7 +236,7 @@ describe("InputsList image carousel", () => {
   it("renders a single bare image path as an image without cycling controls", () => {
     const html = render(
       makeCard({
-        column_id: "backlog",
+        column_id: "opened",
         entry_input: { cover: "assets/cover art/../covers/final.png" },
       }),
     );
@@ -243,7 +244,7 @@ describe("InputsList image carousel", () => {
     // Path with whitespace stays plain text; a clean single path renders.
     const clean = render(
       makeCard({
-        column_id: "backlog",
+        column_id: "opened",
         entry_input: { cover: "assets/covers/final.png" },
       }),
     );
@@ -254,7 +255,7 @@ describe("InputsList image carousel", () => {
   it("keeps sentences and mixed arrays as plain text", () => {
     const html = render(
       makeCard({
-        column_id: "backlog",
+        column_id: "opened",
         entry_input: {
           notes: "voir le rendu final dans exports/preview.png",
           mixed: '["assets/refs/master.png", "pas une image"]',

--- a/studio/src/views/PipelineBoard/PipelineCardDetails.tsx
+++ b/studio/src/views/PipelineBoard/PipelineCardDetails.tsx
@@ -1,16 +1,20 @@
 import {
+  ArrowLeftIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   Cross2Icon,
-  DownloadIcon,
+  ExternalLinkIcon,
 } from "@radix-ui/react-icons";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { Link } from "wouter";
 
 import { pipelineBoardImageURL, type PipelineBoardCard } from "@/api/pipelineBoards";
 import type { UnifiedStatus } from "@/components/Runs/runStatusClasses";
-import { Badge, Dialog, IconButton, InlineBanner, StatusBadge } from "@/components/ui";
+import { Badge, Button, IconButton, InlineBanner, StatusBadge } from "@/components/ui";
 
+import { cardRoutePath } from "./cardRoute";
+import { ImagePreviewDialog } from "./ImagePreview";
 import { ProducedElements } from "./ProducedElements";
 import { SequentialReviews } from "./SequentialReviews";
 
@@ -143,56 +147,64 @@ function InputImageCarousel({ paths, rawText }: { paths: string[]; rawText: stri
         </span>
         {cycler(1)}
       </div>
-      {viewerOpen && (
-        <Dialog
-          open
-          onOpenChange={(open) => {
-            if (!open) setViewerOpen(false);
-          }}
-          widthClass="max-w-3xl"
-          title={<span className="font-mono text-xs">{path}</span>}
-          description={
-            paths.length > 1 ? <span>Image {current + 1}/{paths.length}</span> : undefined
-          }
-          footer={
-            <a
-              href={url}
-              download
-              className="inline-flex items-center gap-1 rounded-md border border-border-default px-2.5 py-1 text-xs font-medium text-fg-default hover:bg-surface-2"
-            >
-              <DownloadIcon /> Download
-            </a>
-          }
-        >
-          <div className="space-y-2">
-            <div className="flex max-h-[70vh] items-center justify-center overflow-auto rounded bg-surface-0 p-3">
-              <img src={url} alt={path} className="max-w-full" />
+      <ImagePreviewDialog
+        open={viewerOpen}
+        onOpenChange={setViewerOpen}
+        src={url}
+        alt={path}
+        title={<span className="font-mono text-xs">{path}</span>}
+        description={
+          paths.length > 1 ? (
+            <span>
+              Image {current + 1}/{paths.length}
+            </span>
+          ) : undefined
+        }
+        downloadHref={url}
+        footerExtra={
+          paths.length > 1 ? (
+            <div className="flex items-center gap-2">
+              {cycler(-1, "md")}
+              <span className="font-mono text-xs text-fg-muted">
+                {current + 1}/{paths.length}
+              </span>
+              {cycler(1, "md")}
             </div>
-            {paths.length > 1 && (
-              <div className="flex items-center justify-center gap-3">
-                {cycler(-1, "md")}
-                <span className="font-mono text-xs text-fg-muted">
-                  {current + 1}/{paths.length}
-                </span>
-                {cycler(1, "md")}
-              </div>
-            )}
-          </div>
-        </Dialog>
-      )}
+          ) : undefined
+        }
+      />
     </dd>
   );
 }
 
+// Contract keys the multi-pipeline bus surfaces first (matches native.ContractDisplayKeys).
+const CONTRACT_KEYS = [
+  "input_path",
+  "asset_id",
+  "feature_id",
+  "family_id",
+  "pipeline_kind",
+  "produces",
+  "consumes",
+  "revision_id",
+  "request_hash",
+  "doc_refs",
+  "auto_ready",
+  "require_blocker_labels",
+] as const;
+
+const CONTRACT_KEY_SET = new Set<string>(CONTRACT_KEYS);
 // InputsList renders the pipeline's full entry input (launch vars / task
 // bot-args) as an untruncated key → value list. The sidebar has the room the
 // compact card body does not, so values wrap instead of clipping. Values that
 // are image paths (reference-image lists…) render as an inline carousel
-// instead of bare paths.
+// instead of bare paths. Contract keys are shown separately above.
 function InputsList({ input }: { input?: Record<string, unknown> }) {
-  const entries = input ? Object.entries(input) : [];
+  const entries = input
+    ? Object.entries(input).filter(([k]) => !CONTRACT_KEY_SET.has(k))
+    : [];
   if (entries.length === 0) {
-    return <p className="text-xs italic text-fg-subtle">No inputs recorded.</p>;
+    return <p className="text-xs italic text-fg-subtle">No additional inputs.</p>;
   }
   return (
     <dl className="space-y-2">
@@ -232,7 +244,7 @@ function MetaRow({ card }: { card: PipelineBoardCard }) {
       {!!card.priority && card.priority > 0 && (
         <Badge
           variant="warning"
-          title={`Priority ${card.priority} — higher numbers launch first from Todo`}
+          title={`Priority ${card.priority} — higher numbers launch first once ready`}
         >
           P{card.priority}
         </Badge>
@@ -257,13 +269,200 @@ function SectionHeading({ children }: { children: React.ReactNode }) {
   return <h3 className="text-xs font-semibold text-fg-default">{children}</h3>;
 }
 
+// ContractSection shows stable bot_args (request file + correlation) above
+// the free-form Inputs dump so operators don't hunt opaque key blobs.
+function ContractSection({ card }: { card: PipelineBoardCard }) {
+  const input = card.entry_input ?? {};
+  const rows: { key: string; value: string }[] = [];
+  for (const key of CONTRACT_KEYS) {
+    const raw = input[key];
+    if (raw === undefined || raw === null || raw === "") continue;
+    const value = stringifyValue(raw).trim();
+    if (!value) continue;
+    rows.push({ key, value });
+  }
+  if (rows.length === 0) return null;
+  return (
+    <section aria-label="Ticket contract" className="space-y-2">
+      <SectionHeading>Ticket contract</SectionHeading>
+      <dl className="space-y-1.5">
+        {rows.map(({ key, value }) => (
+          <div key={key} className="space-y-0.5">
+            <dt className="text-micro font-medium uppercase tracking-wide text-fg-muted">
+              {key}
+            </dt>
+            <dd className="break-all rounded-md border border-border-subtle bg-surface-2/40 px-2 py-1 font-mono text-xs text-fg-default">
+              {value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+// SpawnTreeSection shows planner provenance: who created this ticket and
+// which children it published. Distinct from hard blockers (scheduling).
+function SpawnTreeSection({ card }: { card: PipelineBoardCard }) {
+  const children = card.children ?? [];
+  const hasParent = !!card.parent_issue_id;
+  if (!hasParent && children.length === 0) return null;
+  return (
+    <section aria-label="Plan tree" className="space-y-3">
+      {hasParent && (
+        <div className="space-y-1.5">
+          <SectionHeading>Spawned from</SectionHeading>
+          <div className="rounded-md border border-border-subtle bg-surface-2/40 px-2 py-1.5 text-xs">
+            <div className="font-medium text-fg-default">
+              {card.parent_title || card.parent_issue_id}
+            </div>
+            <div className="mt-0.5 font-mono text-micro text-fg-subtle">
+              {card.parent_issue_id}
+            </div>
+          </div>
+        </div>
+      )}
+      {children.length > 0 && (
+        <div className="space-y-1.5">
+          <SectionHeading>
+            Children
+            {card.children_summary
+              ? ` (${card.children_summary.total})`
+              : ` (${children.length})`}
+          </SectionHeading>
+          {card.children_summary && (
+            <p className="text-micro text-fg-muted">
+              <span className="font-medium tabular-nums text-fg-default">
+                {(card.children_summary.done ?? 0) +
+                  (card.children_summary.failed ?? 0)}
+                /{card.children_summary.total} closed
+              </span>
+              {" · "}
+              {card.children_summary.ready} ready ·{" "}
+              {card.children_summary.in_progress} live ·{" "}
+              {card.children_summary.open} open
+            </p>
+          )}
+          <ul className="space-y-1">
+            {children.map((ch) => (
+              <li
+                key={ch.issue_id}
+                className="flex flex-wrap items-center gap-1.5 rounded-md border border-border-subtle bg-surface-2/40 px-2 py-1 text-xs"
+              >
+                <span className="min-w-0 flex-1 truncate font-medium text-fg-default">
+                  {ch.title || ch.issue_id}
+                </span>
+                {ch.state && (
+                  <Badge variant="neutral" title={`State: ${ch.state}`}>
+                    {ch.state}
+                  </Badge>
+                )}
+                {ch.bot_id && (
+                  <span className="truncate text-micro text-fg-subtle">
+                    {ch.bot_id}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}
+
+// DependenciesSection surfaces hard deps (blockers) and reverse deps
+// (blocking). Distinct from human-review "Blocked" — these are ticket-to-
+// ticket gates the launch loop honours.
+function DependenciesSection({ card }: { card: PipelineBoardCard }) {
+  const blockers = card.blockers ?? [];
+  const blocking = card.blocking ?? [];
+  if (blockers.length === 0 && blocking.length === 0) return null;
+  return (
+    <section aria-label="Dependencies" className="space-y-3">
+      {blockers.length > 0 && (
+        <div className="space-y-1.5">
+          <SectionHeading>
+            Depends on
+            {(card.open_blocker_count ?? 0) > 0
+              ? ` (${card.open_blocker_count} open)`
+              : ""}
+          </SectionHeading>
+          <ul className="space-y-1">
+            {blockers.map((b) => (
+              <li
+                key={b.id}
+                className="flex flex-wrap items-center gap-1.5 rounded-md border border-border-subtle bg-surface-2/40 px-2 py-1 text-xs"
+              >
+                <span className="min-w-0 flex-1 truncate font-medium text-fg-default">
+                  {b.title || b.id}
+                </span>
+                {b.state && (
+                  <Badge
+                    variant={b.satisfied ? "success" : "warning"}
+                    title={b.satisfied ? "Hard dep satisfied (done)" : `State: ${b.state}`}
+                  >
+                    {b.state}
+                  </Badge>
+                )}
+                {!b.satisfied && !b.state && (
+                  <Badge variant="danger" title="Blocker issue not found">
+                    missing
+                  </Badge>
+                )}
+                {b.missing_labels && b.missing_labels.length > 0 && (
+                  <Badge
+                    variant="warning"
+                    title={`Needs labels: ${b.missing_labels.join(", ")}`}
+                  >
+                    needs {b.missing_labels.join(", ")}
+                  </Badge>
+                )}
+                <code className="text-micro text-fg-subtle" title={b.id}>
+                  {b.id.slice(0, 16)}
+                </code>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {blocking.length > 0 && (
+        <div className="space-y-1.5">
+          <SectionHeading>Blocks</SectionHeading>
+          <ul className="space-y-1">
+            {blocking.map((b) => (
+              <li
+                key={b.id}
+                className="flex flex-wrap items-center gap-1.5 rounded-md border border-border-subtle bg-surface-2/40 px-2 py-1 text-xs"
+              >
+                <span className="min-w-0 flex-1 truncate font-medium text-fg-default">
+                  {b.title || b.id}
+                </span>
+                <code className="text-micro text-fg-subtle" title={b.id}>
+                  {b.id.slice(0, 16)}
+                </code>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {card.launch_blocked_reason && (
+        <p className="text-caption text-fg-muted">
+          Launch gate:{" "}
+          <code className="text-fg-default">{card.launch_blocked_reason}</code>
+        </p>
+      )}
+    </section>
+  );
+}
+
 // PipelineCardDetailsBody composes the sidebar sections by lane:
-//   - Todo / Backlog (no run started)   → Inputs only.
+//   - Todo (no run started)              → Inputs only.
 //   - In progress                        → Inputs + Produced elements.
 //   - In progress, awaiting human input  → + the response form (first, so the
 //                                          operator's action is front and centre).
-//   - Done                               → Inputs + Result + Produced elements.
-//   - Failed                             → Failure reason + Inputs + Produced
+//   - Closed, success                    → Inputs + Result + Produced elements.
+//   - Closed, failed                     → Failure reason + Inputs + Produced
 //                                          elements (what it made before dying).
 // Exported (separately from the panel wrapper) so it can be unit-tested in
 // isolation from the docked-panel chrome.
@@ -281,9 +480,11 @@ export function PipelineCardDetailsBody({
   const reviews = card.pending_reviews ?? [];
   const showProduced =
     !!card.run_id &&
-    (card.column_id === "in_progress" ||
-      card.column_id === "done" ||
-      card.column_id === "failed");
+    (card.column_id === "in_progress" || card.column_id === "closed");
+  // A Closed card is a failure when the run failed/was cancelled; otherwise it
+  // finished successfully (drives the Failure vs Result sections below).
+  const closedFailed = card.column_id === "closed" && card.failed === true;
+  const closedSuccess = card.column_id === "closed" && card.failed !== true;
   // The whole pipeline tree — root + sub-bots — so a sub-bot's produced
   // elements surface here too. Falls back to the root run for older
   // projections that don't emit the tree.
@@ -305,8 +506,20 @@ export function PipelineCardDetailsBody({
 
       <MetaRow card={card} />
 
+      <ContractSection card={card} />
+
+      <div id="pipeline-card-deps">
+        <DependenciesSection card={card} />
+      </div>
+
+      <SpawnTreeSection card={card} />
+
       {reviews.length > 0 && (
-        <section aria-label="Response required" className="space-y-2">
+        <section
+          id="pipeline-card-review"
+          aria-label="Response required"
+          className="space-y-2"
+        >
           <SectionHeading>Response required</SectionHeading>
           {card.failed && (
             <InlineBanner tone="warning" layout="inline">
@@ -320,7 +533,7 @@ export function PipelineCardDetailsBody({
         </section>
       )}
 
-      {card.column_id === "failed" && card.error && (
+      {closedFailed && card.error && (
         <section aria-label="Failure" className="space-y-2">
           <SectionHeading>Failure</SectionHeading>
           <InlineBanner tone="danger" layout="inline">
@@ -334,7 +547,7 @@ export function PipelineCardDetailsBody({
         <InputsList input={card.entry_input} />
       </section>
 
-      {card.column_id === "done" && card.output && (
+      {closedSuccess && card.output && (
         <section aria-label="Result" className="space-y-2">
           <SectionHeading>Result</SectionHeading>
           <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border-default bg-surface-0 p-2 font-mono text-xs text-fg-muted">
@@ -355,25 +568,97 @@ interface Props {
   stale?: boolean;
   onClose: () => void;
   onRefetch: () => void;
+  /** "overlay" (default): fixed panel over the board. "page": full-page shell. */
+  presentation?: "overlay" | "page";
+  /** Scroll/highlight a section when the drawer opens. */
+  focusSection?: "default" | "deps" | "review";
 }
 
-// PipelineCardDetails is the right-hand details panel opened by clicking a
-// pipeline card. It docks beside the board (non-modal — the board stays fully
-// interactive, and clicking another card just swaps the panel's contents) and
-// projects the selected card's inputs, produced elements, and (when the
-// pipeline is blocked on a human gate) the response form.
+// PipelineCardDetails projects a card's contract, deps, inputs, produced
+// elements, and human reviews. Overlay mode floats above the board (board
+// stays full width); page mode is the GitHub-style dedicated route.
 export default function PipelineCardDetails({
   card,
   stale,
   onClose,
   onRefetch,
+  presentation = "overlay",
+  focusSection = "default",
 }: Props) {
-  return (
-    <aside
-      className="flex w-[26rem] max-w-[80vw] shrink-0 flex-col border-l border-border-default bg-surface-1"
-      aria-label={`Details for ${card.title}`}
-    >
-      <div className="flex items-start justify-between gap-2 border-b border-border-default px-4 py-3">
+  const fullPath = cardRoutePath(card);
+  // Scrim ignores the first tick so the same click that opened the drawer
+  // cannot immediately close it (portal mounts under the cursor).
+  const [scrimArmed, setScrimArmed] = useState(false);
+
+  useEffect(() => {
+    if (presentation !== "overlay") return;
+    setScrimArmed(false);
+    const t = window.setTimeout(() => setScrimArmed(true), 0);
+    return () => window.clearTimeout(t);
+  }, [presentation, card.id]);
+
+  useEffect(() => {
+    if (focusSection === "default") return;
+    const id =
+      focusSection === "deps"
+        ? "pipeline-card-deps"
+        : focusSection === "review"
+          ? "pipeline-card-review"
+          : null;
+    if (!id) return;
+    const t = window.setTimeout(() => {
+      document.getElementById(id)?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 50);
+    return () => window.clearTimeout(t);
+  }, [focusSection, card.id]);
+
+  // Escape closes the overlay (page mode uses browser back / explicit link).
+  useEffect(() => {
+    if (presentation !== "overlay") return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [presentation, onClose]);
+
+  // Lock body scroll while the overlay is up (board can still reflow underneath).
+  useEffect(() => {
+    if (presentation !== "overlay") return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [presentation]);
+
+  const header =
+    presentation === "page" ? (
+      // Full-page: breadcrumb-style back (not a popup close).
+      <div className="flex shrink-0 flex-wrap items-start justify-between gap-3 border-b border-border-default px-6 py-4">
+        <div className="min-w-0 flex-1 space-y-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            leadingIcon={<ArrowLeftIcon />}
+            className="-ml-2"
+          >
+            Back to pipelines
+          </Button>
+          <div className="min-w-0">
+            <h1 className="text-lg font-semibold text-fg-default" title={card.title}>
+              {card.title}
+            </h1>
+            <p className="mt-0.5 truncate text-xs text-fg-subtle">
+              {card.kind === "task" ? "Task" : "Run"}
+              {card.bot_id ? ` · ${card.bot_id}` : ""}
+            </p>
+          </div>
+        </div>
+      </div>
+    ) : (
+      <div className="flex shrink-0 items-start justify-between gap-2 border-b border-border-default px-4 py-3">
         <div className="min-w-0">
           <h2 className="truncate text-sm font-semibold text-fg-default" title={card.title}>
             {card.title}
@@ -383,13 +668,67 @@ export default function PipelineCardDetails({
             {card.bot_id ? ` · ${card.bot_id}` : ""}
           </p>
         </div>
-        <IconButton label="Close details" size="sm" variant="ghost" onClick={onClose}>
-          <Cross2Icon />
-        </IconButton>
+        <div className="flex shrink-0 items-center gap-0.5">
+          <Link
+            href={fullPath}
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-fg-subtle hover:bg-surface-2 hover:text-fg-default"
+            title="Open full page"
+            aria-label="Open full page"
+          >
+            <ExternalLinkIcon />
+          </Link>
+          <IconButton label="Close details" size="sm" variant="ghost" onClick={onClose}>
+            <Cross2Icon />
+          </IconButton>
+        </div>
       </div>
-      <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
-        <PipelineCardDetailsBody card={card} stale={stale} onRefetch={onRefetch} />
+    );
+
+  const body = (
+    <div
+      className={`min-h-0 flex-1 overflow-y-auto py-3 ${
+        presentation === "page" ? "px-6" : "px-4"
+      }`}
+    >
+      <PipelineCardDetailsBody card={card} stale={stale} onRefetch={onRefetch} />
+    </div>
+  );
+
+  if (presentation === "page") {
+    return (
+      <div
+        className="flex h-full min-h-0 w-full flex-col"
+        aria-label={`Details for ${card.title}`}
+      >
+        {header}
+        {body}
       </div>
-    </aside>
+    );
+  }
+
+  // Portal to body: the board tree is under main overflow:hidden (and card
+  // hover uses transform), which traps position:fixed descendants and made
+  // the drawer invisible / unusable. Same pattern as Dialog/Drawer.
+  return createPortal(
+    <>
+      <div
+        role="presentation"
+        className="fixed inset-0 bg-scrim-modal animate-fade-in-opacity"
+        style={{ zIndex: "var(--z-overlay)" }}
+        aria-hidden={!scrimArmed}
+        onClick={scrimArmed ? onClose : undefined}
+      />
+      <aside
+        className="fixed inset-y-0 right-0 flex w-[min(28rem,100vw)] flex-col border-l border-border-default bg-surface-1 shadow-[var(--shadow-lg)] animate-slide-in-right"
+        style={{ zIndex: "var(--z-modal)" }}
+        aria-label={`Details for ${card.title}`}
+        role="dialog"
+        aria-modal="true"
+      >
+        {header}
+        {body}
+      </aside>
+    </>,
+    document.body,
   );
 }

--- a/studio/src/views/PipelineBoard/PipelineCardPage.tsx
+++ b/studio/src/views/PipelineBoard/PipelineCardPage.tsx
@@ -1,0 +1,119 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link, useLocation, useParams } from "wouter";
+
+import { getPipelineBoard } from "@/api/pipelineBoards";
+import { useHeaderSlot } from "@/components/shared/useHeaderSlot";
+import { Button, EmptyState, InlineBanner, Spinner } from "@/components/ui";
+import { errorMessage } from "@/lib/errorHints";
+
+import { findCardByRouteKey, parseCardRoute } from "./cardRoute";
+import PipelineCardDetails from "./PipelineCardDetails";
+
+const POLL_INTERVAL_MS = 3000;
+
+// PipelineCardPage is the GitHub-style dedicated card page at
+// /pipelines/cards/:kind/:id — same content as the board drawer, full width.
+export default function PipelineCardPage() {
+  const params = useParams<{ kind?: string; id?: string }>();
+  const [, setLocation] = useLocation();
+  const routeKey = parseCardRoute(params.kind, params.id);
+
+  const query = useQuery({
+    queryKey: ["pipeline-board"],
+    queryFn: ({ signal }) => getPipelineBoard({ signal }),
+    refetchInterval: POLL_INTERVAL_MS,
+    refetchIntervalInBackground: false,
+    retry: false,
+  });
+
+  useHeaderSlot({
+    left: (
+      <div className="flex min-w-0 items-center gap-2 text-xs">
+        <Link href="/pipelines" className="text-accent-text hover:underline">
+          Pipelines
+        </Link>
+        <span className="text-fg-subtle">/</span>
+        <span className="truncate font-medium text-fg-default">
+          {query.data && routeKey
+            ? (findCardByRouteKey(query.data.cards, routeKey)?.title ?? "Card")
+            : "Card"}
+        </span>
+      </div>
+    ),
+    right: (
+      <Button
+        variant="secondary"
+        size="sm"
+        loading={query.isFetching}
+        onClick={() => void query.refetch()}
+      >
+        Refresh
+      </Button>
+    ),
+  });
+
+  if (!routeKey) {
+    return (
+      <div className="flex h-full flex-col p-4">
+        <InlineBanner tone="danger" title="Invalid card link">
+          <Link href="/pipelines" className="text-accent-text hover:underline">
+            Back to pipelines
+          </Link>
+        </InlineBanner>
+      </div>
+    );
+  }
+
+  if (query.isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center gap-2 text-sm text-fg-muted">
+        <Spinner /> Loading card…
+      </div>
+    );
+  }
+
+  if (!query.data) {
+    return (
+      <div className="flex h-full flex-col p-4">
+        <InlineBanner tone="danger" title="Couldn't load the pipeline board">
+          <div className="flex flex-wrap items-center gap-3">
+            <span>
+              {query.error ? errorMessage(query.error) : "Pipeline board unavailable."}
+            </span>
+            <Button variant="secondary" size="sm" onClick={() => void query.refetch()}>
+              Retry
+            </Button>
+          </div>
+        </InlineBanner>
+      </div>
+    );
+  }
+
+  const card = findCardByRouteKey(query.data.cards, routeKey);
+  if (!card) {
+    return (
+      <div className="flex h-full flex-col p-6">
+        <EmptyState
+          title="Card not found"
+          message="This pipeline ticket is no longer on the board (deleted, or the link is stale)."
+          action={
+            <Button variant="primary" size="sm" onClick={() => setLocation("/pipelines")}>
+              Back to pipelines
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full min-h-0 w-full overflow-hidden">
+      <PipelineCardDetails
+        card={card}
+        presentation="page"
+        onClose={() => setLocation("/pipelines")}
+        onRefetch={() => void query.refetch()}
+      />
+    </div>
+  );
+}

--- a/studio/src/views/PipelineBoard/PipelineColumns.test.tsx
+++ b/studio/src/views/PipelineBoard/PipelineColumns.test.tsx
@@ -3,11 +3,29 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PipelineBoard, PipelineBoardCard } from "@/api/pipelineBoards";
 
-// PipelineColumns imports markPipelineTaskReady for the button-driven
-// Backlog ↔ Todo moves.
-const { markReadyMock } = vi.hoisted(() => ({ markReadyMock: vi.fn() }));
+// PipelineColumns imports markPipelineTaskReady for the button-driven ready
+// toggles, plus the delete/reset ticket actions and the run controls
+// (pause / resume / stop).
+const { markReadyMock, deleteTaskMock, resetTaskMock, launchTaskMock, pauseRunMock, resumeRunMock, cancelRunMock } =
+  vi.hoisted(() => ({
+    markReadyMock: vi.fn(),
+    deleteTaskMock: vi.fn(),
+    resetTaskMock: vi.fn(),
+    launchTaskMock: vi.fn(),
+    pauseRunMock: vi.fn(),
+    resumeRunMock: vi.fn(),
+    cancelRunMock: vi.fn(),
+  }));
 vi.mock("@/api/pipelineBoards", () => ({
   markPipelineTaskReady: markReadyMock,
+  deletePipelineTask: deleteTaskMock,
+  resetPipelineTask: resetTaskMock,
+  launchPipelineTask: launchTaskMock,
+}));
+vi.mock("@/api/runs", () => ({
+  pauseRun: pauseRunMock,
+  resumeRun: resumeRunMock,
+  cancelRun: cancelRunMock,
 }));
 
 vi.mock("wouter", () => ({
@@ -20,29 +38,56 @@ vi.mock("wouter", () => ({
       {children}
     </a>
   ),
+  useLocation: () => ["/pipelines", vi.fn()],
 }));
 
+// The card resolves "Edit bot" against the catalog store.
+vi.mock("@/store/bots", () => ({
+  useBotsStore: (sel: (s: unknown) => unknown) =>
+    sel({
+      bots: [
+        { name: "shorts-episode", rel_path: "bots/shorts-episode", is_bundle: true },
+      ],
+      fetch: () => Promise.resolve(),
+    }),
+}));
+
+vi.mock("@/store/ui", () => ({
+  useUIStore: (sel: (s: { addToast: () => void }) => unknown) =>
+    sel({ addToast: vi.fn() }),
+}));
+
+import { cardReady, closedOutcome } from "./columnFilters";
+import { resolveMenuItems, resolvePrimaryAction } from "./primaryAction";
 import {
   PipelineColumns,
-  canMoveToBacklog,
-  canMoveToTodo,
+  LAUNCH_DRAG_TYPE,
+  botEditorPath,
+  canDeleteTicket,
+  canLaunchNow,
+  canMarkReady,
+  canPauseRun,
+  canResetTicket,
+  canResumeRun,
+  canStopRun,
+  canUnmarkReady,
   isTicketEditable,
   moveTicket,
 } from "./PipelineColumns";
 
+// Three fixed lanes: Opened (backlog + ready staging), In progress, Closed
+// (success + failure).
 const columns = [
-  { id: "backlog", title: "Backlog", kind: "backlog" },
-  { id: "todo", title: "Todo", kind: "todo" },
+  { id: "opened", title: "Opened", kind: "opened" },
   { id: "in_progress", title: "In progress", kind: "in_progress" },
-  { id: "done", title: "Done", kind: "done" },
-  { id: "failed", title: "Failed", kind: "failed" },
+  { id: "closed", title: "Closed", kind: "closed" },
 ];
 
 function makeCard(partial: Partial<PipelineBoardCard>): PipelineBoardCard {
   return {
     id: "card",
     kind: "run",
-    column_id: "backlog",
+    column_id: "opened",
     title: "Card",
     executed_nodes: 0,
     total_nodes: 0,
@@ -74,16 +119,21 @@ function count(html: string, needle: string): number {
 
 beforeEach(() => {
   markReadyMock.mockReset();
+  deleteTaskMock.mockReset();
+  resetTaskMock.mockReset();
+  pauseRunMock.mockReset();
+  resumeRunMock.mockReset();
+  cancelRunMock.mockReset();
 });
 
 describe("PipelineColumns", () => {
-  it("buckets cards client-side into the fixed lanes", () => {
+  it("buckets cards client-side into the three fixed lanes", () => {
     const html = render(
       makeBoard([
-        makeCard({ id: "d", column_id: "backlog", kind: "task", issue_id: "iss-1", title: "Backlog task" }),
+        makeCard({ id: "d", column_id: "opened", kind: "task", issue_id: "iss-1", title: "Draft task" }),
         makeCard({
           id: "t",
-          column_id: "todo",
+          column_id: "opened",
           title: "Queued run",
           run_id: "r1",
           status: "queued",
@@ -100,7 +150,7 @@ describe("PipelineColumns", () => {
         }),
         makeCard({
           id: "done",
-          column_id: "done",
+          column_id: "closed",
           title: "Done card",
           run_id: "r3",
           status: "finished",
@@ -109,32 +159,34 @@ describe("PipelineColumns", () => {
       ]),
     );
 
-    expect(html).toContain("Backlog task");
+    expect(html).toContain("Draft task");
     expect(html).toContain("Queued run");
     expect(html).toContain("#2"); // queue position badge (Todo)
     expect(html).toContain("12 / 40 nodes"); // progress (in_progress)
     expect(count(html, 'role="article"')).toBe(4);
-    // Drag & drop is gone entirely.
-    expect(html).not.toContain('draggable="true"');
+    // Card POSITION stays server-derived: the only drag on this board is the
+    // launch-now override, and only launchable Opened tickets carry it (here:
+    // the draft; not the queued run, the live run, or the finished one).
+    expect(count(html, 'draggable="true"')).toBe(1);
   });
 
-  it("cards are lean: no body text, labels, inputs, kind badge, or output", () => {
+  it("cards are lean: no body text, raw inputs, or output; tags are visible chips", () => {
     const html = render(
       makeBoard([
         makeCard({
           id: "d",
-          column_id: "backlog",
+          column_id: "opened",
           kind: "task",
           issue_id: "iss-1",
           title: "Lean task",
           body: "long ticket description",
           labels: ["labelled-x"],
-          entry_input: { topic: "jazz-input" },
+          entry_input: { topic: "jazz-input", character: "Boudicca" },
           priority: 3,
         }),
         makeCard({
           id: "done",
-          column_id: "done",
+          column_id: "closed",
           run_id: "r3",
           status: "finished",
           title: "Done card",
@@ -146,19 +198,51 @@ describe("PipelineColumns", () => {
     );
 
     expect(html).not.toContain("long ticket description");
-    expect(html).not.toContain("labelled-x");
-    expect(html).not.toContain("jazz-input");
+    expect(html).not.toContain("jazz-input"); // raw input keys stay off the face
     expect(html).not.toContain("Result text"); // output lives in the sidebar
     expect(html).not.toContain("bot-meta"); // meta chips removed
     expect(html).not.toContain("wf_name_meta");
+    // Tags (issue labels + content-derived) ARE on the card face.
+    expect(html).toContain("labelled-x");
+    expect(html).toContain("Boudicca");
   });
 
-  it("renders a failed pipeline in the Failed lane with its reason and Retry", () => {
+  it("Todo badges readiness: a staged task is Ready, a prepared one is Not ready", () => {
+    const html = render(
+      makeBoard([
+        makeCard({ id: "r", column_id: "opened", kind: "task", issue_id: "iss-1", ready: true, title: "Staged" }),
+        makeCard({ id: "d", column_id: "opened", kind: "task", issue_id: "iss-2", title: "Prep" }),
+      ]),
+    );
+    // Badge spans (not the header filter chips, which are buttons).
+    expect(html).toContain(">Ready</span>");
+    expect(html).toContain(">Not ready</span>");
+  });
+
+  it("a queued run is badged Ready (cleared to launch) with its slot position", () => {
+    const html = render(
+      makeBoard([
+        makeCard({
+          id: "q",
+          column_id: "opened",
+          kind: "run",
+          run_id: "r1",
+          status: "queued",
+          queue_position: 3,
+          title: "Queued",
+        }),
+      ]),
+    );
+    expect(html).toContain(">Ready</span>");
+    expect(html).toContain("#3");
+  });
+
+  it("renders a failed pipeline in the Closed lane with its reason and Retry", () => {
     const html = render(
       makeBoard([
         makeCard({
           id: "failed",
-          column_id: "failed",
+          column_id: "closed",
           kind: "run",
           title: "Broke last time",
           issue_id: "iss-2",
@@ -171,6 +255,7 @@ describe("PipelineColumns", () => {
     );
 
     expect(html).toContain("kaboom"); // the reason stays visible
+    expect(html).toContain(">Failed</span>"); // outcome badge (not the filter chip)
     expect(html).toContain("Retry"); // ticket-backed → retryable to Todo
   });
 
@@ -179,7 +264,7 @@ describe("PipelineColumns", () => {
       makeBoard([
         makeCard({
           id: "failed-standalone",
-          column_id: "failed",
+          column_id: "closed",
           kind: "run",
           title: "Manual run",
           run_id: "run-solo",
@@ -191,6 +276,25 @@ describe("PipelineColumns", () => {
     );
     expect(html).toContain("exploded");
     expect(html).not.toContain("Retry");
+  });
+
+  it("a successful Closed card shows a Success badge and no error/Retry", () => {
+    const html = render(
+      makeBoard([
+        makeCard({
+          id: "ok",
+          column_id: "closed",
+          kind: "run",
+          issue_id: "iss-9",
+          run_id: "run-ok",
+          status: "finished",
+          title: "Clean finish",
+        }),
+      ]),
+    );
+    expect(html).toContain(">Success</span>"); // outcome badge
+    expect(html).not.toContain(">Failed</span>"); // no failed badge (the Failed filter chip is a button)
+    expect(html).not.toContain("Retry"); // a success is not retryable
   });
 
   it("shows a Blocked tag naming the gate + progress; the form lives in the sidebar only", () => {
@@ -277,15 +381,117 @@ describe("PipelineColumns", () => {
   });
 });
 
-describe("priority", () => {
-  it("shows the P badge on Backlog / Todo / Failed cards (the launch-order dial)", () => {
+describe("per-column filters", () => {
+  it("renders In progress section then Inventory (Opened tab by default)", () => {
+    const html = render(makeBoard([]));
+    expect(html).toContain("In progress");
+    expect(html).toContain("Inventory");
+    expect(html).toContain("Nothing running right now.");
+  });
+});
+
+describe("parent / child cards are ordinary, ungrouped cards", () => {
+  const parent = makeCard({
+    id: "p",
+    column_id: "closed",
+    kind: "run",
+    issue_id: "iss-parent",
+    run_id: "r-parent",
+    status: "finished",
+    title: "Boudicca",
+    role: "planner",
+    children_summary: { total: 5, ready: 0, in_progress: 1, done: 2, failed: 2, open: 0 },
+  });
+  const kid = makeCard({
+    id: "k1",
+    column_id: "opened",
+    kind: "task",
+    issue_id: "k1",
+    title: "ÉP 1",
+    parent_issue_id: "iss-parent",
+    parent_title: "Boudicca",
+  });
+  const loose = makeCard({
+    id: "loose",
+    column_id: "opened",
+    kind: "task",
+    issue_id: "loose",
+    title: "Standalone",
+  });
+
+  // The parent has children still open, yet its own run finished — it must
+  // sit in Closed like any other finished card. No campaign hold, no
+  // expand/collapse, no stacked face.
+  it("shows every card in one flat grid, with no expand affordance", () => {
+    const html = render(makeBoard([parent, kid, loose]));
+    expect(html).toContain("Boudicca");
+    expect(html).toContain("ÉP 1");
+    expect(html).toContain("Standalone");
+    expect(html).not.toContain("data-plan-stack");
+    expect(html).not.toContain("child tickets of");
+    expect(html).not.toContain("Awaiting children");
+  });
+
+  // The only surviving link on the child face: the parent name above the
+  // title. Purely typographic — the card keeps the standard border, no
+  // accent rule singling it out.
+  it("names the parent above a child's title", () => {
+    const html = render(makeBoard([kid]));
+    expect(html).toContain("Spawned by Boudicca");
+    expect(html).not.toContain("border-l-accent");
+  });
+
+  it("leaves an unrelated card free of the parent tie", () => {
+    const html = render(makeBoard([loose]));
+    expect(html).not.toContain("Spawned by");
+  });
+});
+
+describe("children counter on a planner parent", () => {
+  // Mirrors the In-progress node bar, but counts CLOSED children (done +
+  // failed) over the total — the campaign-progress face of a plan group.
+  it("renders 'N / M closed' with a progressbar on the parent card", () => {
     const html = render(
       makeBoard([
-        makeCard({ id: "d", column_id: "backlog", kind: "task", issue_id: "iss-1", priority: 5 }),
-        makeCard({ id: "t", column_id: "todo", kind: "task", issue_id: "iss-2", priority: 3 }),
+        makeCard({
+          id: "p",
+          column_id: "opened",
+          kind: "task",
+          issue_id: "parent-1",
+          title: "Planner parent",
+          role: "planner",
+          children_summary: {
+            total: 5,
+            ready: 0,
+            in_progress: 3,
+            done: 1,
+            failed: 1,
+            open: 0,
+          },
+        }),
+      ]),
+    );
+    expect(html).toContain("2 / 5 closed");
+    expect(html).toContain('aria-label="2 of 5 children closed"');
+  });
+
+  it("omits the counter when the card has no children", () => {
+    const html = render(
+      makeBoard([makeCard({ id: "s", column_id: "opened", kind: "task", issue_id: "solo" })]),
+    );
+    expect(html).not.toContain("children closed");
+    expect(html).not.toContain(" closed</div>");
+  });
+});
+
+describe("priority", () => {
+  it("shows the P badge on Todo (draft) and Closed (failed) cards", () => {
+    const html = render(
+      makeBoard([
+        makeCard({ id: "d", column_id: "opened", kind: "task", issue_id: "iss-1", priority: 5 }),
         makeCard({
           id: "f",
-          column_id: "failed",
+          column_id: "closed",
           kind: "run",
           issue_id: "iss-3",
           run_id: "r1",
@@ -296,15 +502,14 @@ describe("priority", () => {
       ]),
     );
     expect(html).toContain("P5");
-    expect(html).toContain("P3");
     expect(html).toContain("P2");
-    expect(html).toContain("launch first from Todo");
+    expect(html).toContain("launch first once ready");
   });
 
   it("hides the badge for unprioritized (0) cards", () => {
     const html = render(
       makeBoard([
-        makeCard({ id: "d", column_id: "todo", kind: "task", issue_id: "iss-1", priority: 0 }),
+        makeCard({ id: "d", column_id: "opened", kind: "task", issue_id: "iss-1", priority: 0 }),
       ]),
     );
     expect(html).not.toContain(">P0<");
@@ -312,7 +517,7 @@ describe("priority", () => {
 });
 
 describe("card details affordance", () => {
-  it("renders a Details affordance and a pointer cursor when onOpenCard is given", () => {
+  it("is clickable with primary Open run when onOpenCard is given", () => {
     const html = renderToStaticMarkup(
       <PipelineColumns
         board={makeBoard([
@@ -322,77 +527,218 @@ describe("card details affordance", () => {
         onOpenCard={() => {}}
       />,
     );
-    expect(html).toContain("Details for Running");
+    expect(html).toContain("Open run");
     expect(html).toContain("cursor-pointer");
-    expect(html).not.toContain("cursor-grab");
+    expect(html).toContain("More actions for Running");
   });
 
-  it("omits the Details affordance when onOpenCard is absent", () => {
+  it("omits pointer cursor when onOpenCard is absent", () => {
     const html = render(
       makeBoard([
         makeCard({ id: "a", column_id: "in_progress", run_id: "r1", status: "running", title: "Running" }),
       ]),
     );
-    expect(html).not.toContain("aria-label=\"Details for");
     expect(html).not.toContain("cursor-pointer");
   });
 });
 
-describe("move buttons (no drag & drop)", () => {
-  it("a Backlog task shows → Todo; a Todo task shows → Backlog", () => {
+describe("ready toggle buttons (no drag & drop)", () => {
+  it("a draft Opened task shows Mark ready; a ready Opened task shows Unmark ready", () => {
     const html = render(
       makeBoard([
-        makeCard({ id: "d", column_id: "backlog", kind: "task", issue_id: "iss-1", title: "Prep me" }),
-        makeCard({ id: "t", column_id: "todo", kind: "task", issue_id: "iss-2", title: "Staged" }),
+        makeCard({ id: "d", column_id: "opened", kind: "task", issue_id: "iss-1", title: "Prep me" }),
+        makeCard({ id: "r", column_id: "opened", kind: "task", issue_id: "iss-2", ready: true, title: "Staged" }),
       ]),
     );
-    expect(html).toContain("→ Todo");
-    expect(html).toContain("→ Backlog");
+    expect(html).toContain("Mark ready");
+    expect(html).toContain("Unmark ready");
   });
 
-  it("run-backed cards get no move buttons", () => {
+  it("run-backed cards get no ready-toggle primary actions", () => {
     const html = render(
       makeBoard([
-        makeCard({ id: "q", column_id: "todo", kind: "run", run_id: "r1", status: "queued", issue_id: "iss-3" }),
+        makeCard({ id: "q", column_id: "opened", kind: "run", run_id: "r1", status: "queued", issue_id: "iss-3" }),
         makeCard({ id: "p", column_id: "in_progress", kind: "run", run_id: "r2", status: "running" }),
-        makeCard({ id: "done", column_id: "done", kind: "run", run_id: "r3", status: "finished" }),
+        makeCard({ id: "done", column_id: "closed", kind: "run", run_id: "r3", status: "finished" }),
       ]),
     );
-    expect(html).not.toContain("→ Todo");
-    expect(html).not.toContain("→ Backlog");
+    expect(html).not.toContain("Mark ready");
+    expect(html).not.toContain("Unmark ready");
   });
 });
 
-describe("move helpers", () => {
-  it("canMoveToTodo: backlog tasks stage; failed-lane tickets retry", () => {
-    expect(canMoveToTodo(makeCard({ column_id: "backlog", kind: "task", issue_id: "iss-1" }))).toBe(true);
-    expect(
-      canMoveToTodo(makeCard({ column_id: "failed", kind: "run", issue_id: "iss-1", failed: true })),
-    ).toBe(true);
-    // Legacy tolerance: a failed card still projected into backlog stays retryable.
-    expect(
-      canMoveToTodo(makeCard({ column_id: "backlog", kind: "run", issue_id: "iss-1", failed: true })),
-    ).toBe(true);
-    // Not backlog/failed lane, executing, or no ticket → immobile.
-    expect(canMoveToTodo(makeCard({ column_id: "todo", kind: "task", issue_id: "iss-1" }))).toBe(false);
-    expect(
-      canMoveToTodo(makeCard({ column_id: "backlog", kind: "run", issue_id: "iss-1", status: "running" })),
-    ).toBe(false);
-    expect(canMoveToTodo(makeCard({ column_id: "backlog", kind: "task" }))).toBe(false);
-    expect(canMoveToTodo(makeCard({ column_id: "failed", kind: "run", failed: true }))).toBe(false);
+describe("card actions (delete / pause / resume / reset / stop)", () => {
+  it("gates secondary actions via capabilities (menu-only in UI)", () => {
+    const draft = makeCard({ column_id: "opened", kind: "task", issue_id: "iss-1" });
+    const ready = makeCard({
+      column_id: "opened",
+      kind: "task",
+      issue_id: "iss-2",
+      ready: true,
+    });
+    const live = makeCard({
+      column_id: "in_progress",
+      kind: "run",
+      run_id: "r1",
+      issue_id: "iss-3",
+      status: "running",
+    });
+    const paused = makeCard({
+      column_id: "in_progress",
+      kind: "run",
+      run_id: "r1",
+      issue_id: "iss-1",
+      status: "paused_operator",
+    });
+    const lone = makeCard({
+      column_id: "in_progress",
+      kind: "run",
+      run_id: "r1",
+      status: "running",
+    });
+    expect(canDeleteTicket(draft)).toBe(true);
+    expect(canDeleteTicket(ready)).toBe(false);
+    expect(canPauseRun(live)).toBe(true);
+    expect(canResetTicket(live)).toBe(true);
+    expect(canStopRun(live)).toBe(false);
+    expect(canResumeRun(paused)).toBe(true);
+    expect(canPauseRun(paused)).toBe(false);
+    expect(canStopRun(lone)).toBe(true);
+    expect(canResetTicket(lone)).toBe(false);
   });
 
-  it("canMoveToBacklog: todo-only, unlaunched task-backed tickets", () => {
-    expect(canMoveToBacklog(makeCard({ column_id: "todo", kind: "task", issue_id: "iss-1" }))).toBe(true);
+  it("running card primary is Open run; paused primary is Resume", () => {
+    expect(
+      render(
+        makeBoard([
+          makeCard({
+            id: "p",
+            column_id: "in_progress",
+            kind: "run",
+            run_id: "r1",
+            issue_id: "iss-1",
+            status: "running",
+            title: "Live",
+          }),
+        ]),
+      ),
+    ).toContain("Open run");
+    expect(
+      render(
+        makeBoard([
+          makeCard({
+            id: "p",
+            column_id: "in_progress",
+            kind: "run",
+            run_id: "r1",
+            issue_id: "iss-1",
+            status: "paused_operator",
+            title: "Parked",
+          }),
+        ]),
+      ),
+    ).toContain("Resume");
+  });
+});
+
+describe("readiness helpers", () => {
+  it("cardReady: staged tasks and queued runs are ready; drafts are not", () => {
+    expect(cardReady(makeCard({ ready: true }))).toBe(true);
+    expect(cardReady(makeCard({ status: "queued" }))).toBe(true);
+    expect(cardReady(makeCard({ kind: "task", ready: false }))).toBe(false);
+    expect(cardReady(makeCard({ status: "running" }))).toBe(false);
+  });
+
+  it("closedOutcome: failed flag splits success from failure", () => {
+    expect(closedOutcome(makeCard({ failed: true }))).toBe("failed");
+    expect(closedOutcome(makeCard({ status: "finished" }))).toBe("success");
+  });
+});
+
+describe("action helpers", () => {
+  it("canMarkReady: draft Todo tasks stage; failed Closed tickets retry", () => {
+    expect(canMarkReady(makeCard({ column_id: "opened", kind: "task", issue_id: "iss-1" }))).toBe(true);
+    expect(
+      canMarkReady(makeCard({ column_id: "closed", kind: "run", issue_id: "iss-1", failed: true })),
+    ).toBe(true);
+    // Already-ready Todo tasks, successful Closed cards, ticket-less, or
+    // executing cards cannot be marked ready.
+    expect(
+      canMarkReady(makeCard({ column_id: "opened", kind: "task", issue_id: "iss-1", ready: true })),
+    ).toBe(false);
+    expect(canMarkReady(makeCard({ column_id: "closed", kind: "run", issue_id: "iss-1" }))).toBe(false);
+    expect(canMarkReady(makeCard({ column_id: "opened", kind: "task" }))).toBe(false);
+    expect(canMarkReady(makeCard({ column_id: "closed", kind: "run", failed: true }))).toBe(false);
+  });
+
+  it("canUnmarkReady: only staged (ready) Todo task cards", () => {
+    expect(
+      canUnmarkReady(makeCard({ column_id: "opened", kind: "task", issue_id: "iss-1", ready: true })),
+    ).toBe(true);
     // A queued RUN in Todo is fixed by run state.
     expect(
-      canMoveToBacklog(makeCard({ column_id: "todo", kind: "run", issue_id: "iss-1", status: "queued" })),
+      canUnmarkReady(makeCard({ column_id: "opened", kind: "run", issue_id: "iss-1", status: "queued" })),
     ).toBe(false);
-    expect(canMoveToBacklog(makeCard({ column_id: "backlog", kind: "task", issue_id: "iss-1" }))).toBe(false);
-    expect(canMoveToBacklog(makeCard({ column_id: "todo", kind: "task" }))).toBe(false);
+    expect(
+      canUnmarkReady(makeCard({ column_id: "opened", kind: "task", issue_id: "iss-1" })),
+    ).toBe(false); // draft, not ready
+    expect(canUnmarkReady(makeCard({ column_id: "opened", kind: "task", ready: true }))).toBe(false); // no ticket
   });
 
-  it("moveTicket(true) stages to Todo, then refetches", async () => {
+  it("canDeleteTicket: only draft (not-ready) Todo task cards", () => {
+    expect(canDeleteTicket(makeCard({ column_id: "opened", kind: "task", issue_id: "iss-1" }))).toBe(true);
+    expect(
+      canDeleteTicket(makeCard({ column_id: "opened", kind: "task", issue_id: "iss-1", ready: true })),
+    ).toBe(false); // ready → unmark first
+    expect(
+      canDeleteTicket(makeCard({ column_id: "opened", kind: "run", issue_id: "iss-1", status: "queued" })),
+    ).toBe(false);
+    expect(canDeleteTicket(makeCard({ column_id: "opened", kind: "task" }))).toBe(false);
+    expect(canDeleteTicket(makeCard({ column_id: "closed", kind: "run", issue_id: "iss-1", failed: true }))).toBe(
+      false,
+    );
+  });
+
+  it("canPauseRun / canResumeRun: gated on the exact live status", () => {
+    expect(
+      canPauseRun(makeCard({ column_id: "in_progress", run_id: "r1", status: "running" })),
+    ).toBe(true);
+    expect(
+      canPauseRun(makeCard({ column_id: "in_progress", run_id: "r1", status: "paused_waiting_human" })),
+    ).toBe(false);
+    expect(canPauseRun(makeCard({ column_id: "in_progress", status: "running" }))).toBe(false);
+    expect(
+      canResumeRun(makeCard({ column_id: "in_progress", run_id: "r1", status: "paused_operator" })),
+    ).toBe(true);
+    expect(
+      canResumeRun(makeCard({ column_id: "in_progress", run_id: "r1", status: "running" })),
+    ).toBe(false);
+  });
+
+  it("canResetTicket / canStopRun: ticket-backed resets, standalone stops", () => {
+    expect(
+      canResetTicket(
+        makeCard({ column_id: "in_progress", run_id: "r1", issue_id: "iss-1", status: "running" }),
+      ),
+    ).toBe(true);
+    expect(
+      canResetTicket(makeCard({ column_id: "in_progress", run_id: "r1", status: "running" })),
+    ).toBe(false);
+    expect(
+      canResetTicket(makeCard({ column_id: "opened", kind: "task", issue_id: "iss-1" })),
+    ).toBe(false);
+    expect(
+      canStopRun(makeCard({ column_id: "in_progress", run_id: "r1", status: "running" })),
+    ).toBe(true);
+    expect(
+      canStopRun(
+        makeCard({ column_id: "in_progress", run_id: "r1", issue_id: "iss-1", status: "running" }),
+      ),
+    ).toBe(false);
+    expect(canStopRun(makeCard({ column_id: "closed", run_id: "r1", status: "finished" }))).toBe(false);
+  });
+
+  it("moveTicket(true) stages ready, then refetches", async () => {
     markReadyMock.mockResolvedValue(undefined);
     const onDone = vi.fn();
     await moveTicket("iss-1", true, onDone);
@@ -400,7 +746,7 @@ describe("move helpers", () => {
     expect(onDone).toHaveBeenCalledTimes(1);
   });
 
-  it("moveTicket(false) unstages to Backlog", async () => {
+  it("moveTicket(false) unstages back to draft", async () => {
     markReadyMock.mockResolvedValue(undefined);
     const onDone = vi.fn();
     await moveTicket("iss-1", false, onDone);
@@ -410,21 +756,21 @@ describe("move helpers", () => {
 });
 
 describe("isTicketEditable", () => {
-  it("allows editing not-yet-run task-backed tickets (incl. failed-lane fixes)", () => {
+  it("allows editing not-yet-run Todo tickets and failed Closed ones", () => {
     expect(
-      isTicketEditable(makeCard({ column_id: "backlog", kind: "task", issue_id: "iss-1" })),
+      isTicketEditable(makeCard({ column_id: "opened", kind: "task", issue_id: "iss-1" })),
+    ).toBe(true);
+    expect(
+      isTicketEditable(makeCard({ column_id: "opened", kind: "task", issue_id: "iss-2", ready: true })),
     ).toBe(true);
     expect(
       isTicketEditable(
-        makeCard({ column_id: "failed", kind: "run", issue_id: "iss-2", failed: true }),
+        makeCard({ column_id: "closed", kind: "run", issue_id: "iss-3", failed: true }),
       ),
-    ).toBe(true);
-    expect(
-      isTicketEditable(makeCard({ column_id: "todo", kind: "task", issue_id: "iss-3" })),
     ).toBe(true);
   });
 
-  it("blocks editing executing / finished / queued cards", () => {
+  it("blocks editing executing / successful / queued cards", () => {
     expect(
       isTicketEditable(
         makeCard({ column_id: "in_progress", kind: "run", issue_id: "iss-4", status: "running" }),
@@ -432,38 +778,154 @@ describe("isTicketEditable", () => {
     ).toBe(false);
     expect(
       isTicketEditable(
-        makeCard({ column_id: "done", kind: "run", issue_id: "iss-5", status: "finished" }),
+        makeCard({ column_id: "closed", kind: "run", issue_id: "iss-5", status: "finished" }),
       ),
-    ).toBe(false);
+    ).toBe(false); // successful → history, not editable
     expect(
       isTicketEditable(
-        makeCard({ column_id: "todo", kind: "run", issue_id: "iss-6", status: "queued" }),
+        makeCard({ column_id: "opened", kind: "run", issue_id: "iss-6", status: "queued" }),
       ),
     ).toBe(false);
-    expect(isTicketEditable(makeCard({ column_id: "backlog", kind: "task" }))).toBe(false);
+    expect(isTicketEditable(makeCard({ column_id: "opened", kind: "task" }))).toBe(false);
   });
 
-  it("renders an Edit affordance only for editable cards when a handler is given", () => {
-    const editableHtml = renderToStaticMarkup(
-      <PipelineColumns
-        board={makeBoard([
-          makeCard({ id: "e", column_id: "backlog", kind: "task", issue_id: "iss-1", title: "Backlog task" }),
-        ])}
-        onRefetch={() => {}}
-        onEditTask={() => {}}
-      />,
-    );
-    expect(editableHtml).toContain("Edit ticket Backlog task");
+  it("marks opened tasks editable; running cards are not", () => {
+    expect(
+      isTicketEditable(
+        makeCard({ column_id: "opened", kind: "task", issue_id: "iss-1", title: "Draft task" }),
+      ),
+    ).toBe(true);
+    expect(
+      isTicketEditable(
+        makeCard({ column_id: "in_progress", kind: "run", run_id: "run-x", status: "running" }),
+      ),
+    ).toBe(false);
+  });
+});
 
-    const runningHtml = renderToStaticMarkup(
-      <PipelineColumns
-        board={makeBoard([
-          makeCard({ id: "r", column_id: "in_progress", kind: "run", run_id: "run-x", status: "running" }),
-        ])}
-        onRefetch={() => {}}
-        onEditTask={() => {}}
-      />,
+// Drag & drop exists for exactly ONE transition: Opened → In progress, the
+// operator's override of the priority queue. canLaunchNow mirrors the
+// server's guards so the UI never offers a drag the backend would refuse.
+describe("launch-now drag (Opened → In progress)", () => {
+  const draggable = makeCard({
+    id: "t",
+    column_id: "opened",
+    kind: "task",
+    issue_id: "iss-1",
+    title: "Draft",
+  });
+
+  it("marks an eligible Opened ticket as draggable", () => {
+    const html = render(makeBoard([draggable]));
+    expect(html).toContain('draggable="true"');
+    expect(html).toContain("Drag onto In progress to start now");
+    expect(html).toContain("data-launch-dropzone");
+  });
+
+  it("allows a plain Opened ticket", () => {
+    expect(canLaunchNow(draggable)).toBe(true);
+  });
+
+  it("refuses cards the server would 409 on", () => {
+    // Already launched — Reset/Retry own that transition, not the drag.
+    expect(
+      canLaunchNow(makeCard({ ...draggable, run_id: "r1", status: "queued" })),
+    ).toBe(false);
+    // Unfinished hard dependency: correctness, not ranking.
+    expect(canLaunchNow(makeCard({ ...draggable, open_blocker_count: 2 }))).toBe(
+      false,
     );
-    expect(runningHtml).not.toContain("aria-label=\"Edit ticket");
+    // Already closed, or a run card with no ticket to launch.
+    expect(canLaunchNow(makeCard({ ...draggable, column_id: "closed" }))).toBe(
+      false,
+    );
+    expect(canLaunchNow(makeCard({ ...draggable, kind: "run" }))).toBe(false);
+    expect(canLaunchNow(makeCard({ ...draggable, issue_id: undefined }))).toBe(
+      false,
+    );
+  });
+
+  it("does not make Closed cards draggable", () => {
+    const html = render(
+      makeBoard([
+        makeCard({
+          id: "c",
+          column_id: "closed",
+          kind: "run",
+          issue_id: "iss-2",
+          run_id: "r2",
+          status: "finished",
+          title: "Done",
+        }),
+      ]),
+    );
+    expect(html).not.toContain('draggable="true"');
+  });
+
+  it("uses a bespoke MIME type so stray drags are ignored", () => {
+    expect(LAUNCH_DRAG_TYPE).toBe("application/x-iterion-ticket");
+  });
+});
+
+// "Edit bot" opens the BOT's main.bot in the editor — distinct from "Edit",
+// which edits the ticket. The path comes from the catalog's rel_path, the
+// same derivation the Catalog dialog uses.
+describe("botEditorPath", () => {
+  const catalog = [
+    { name: "shorts-episode", rel_path: "bots/shorts-episode", is_bundle: true },
+    { name: "loose", path: "/abs/loose.bot", is_bundle: false },
+    { name: "no-rel", is_bundle: true },
+  ];
+
+  it("resolves a bundle to its main.bot", () => {
+    expect(botEditorPath("shorts-episode", catalog)).toBe(
+      "bots/shorts-episode/main.bot",
+    );
+  });
+
+  it("returns null when there is nothing stable to open", () => {
+    // A loose .bot is not an editable bundle; a bundle the server could not
+    // relativise has no workspace path; an unknown or absent bot_id has no
+    // entry at all. In every case the menu entry is withheld rather than
+    // pointing at a file the editor would fail to open.
+    expect(botEditorPath("loose", catalog)).toBeNull();
+    expect(botEditorPath("no-rel", catalog)).toBeNull();
+    expect(botEditorPath("ghost", catalog)).toBeNull();
+    expect(botEditorPath(undefined, catalog)).toBeNull();
+    expect(botEditorPath("  ", catalog)).toBeNull();
+    // Catalog not loaded yet.
+    expect(botEditorPath("shorts-episode", null)).toBeNull();
+  });
+});
+
+describe("Edit bot menu entry", () => {
+  const withBot = makeCard({
+    id: "d",
+    column_id: "opened",
+    kind: "task",
+    issue_id: "iss-1",
+    title: "Draft",
+    bot_id: "shorts-episode",
+  });
+  const kinds = (card: PipelineBoardCard) =>
+    resolveMenuItems(card, resolvePrimaryAction(card).kind).map((i) => i.kind);
+
+  // The ⋯ menu is a Radix dropdown: its items only exist in the DOM once
+  // opened, so the contract is asserted on the resolver, not the markup.
+  it("is offered on an Opened card that names a bot", () => {
+    expect(kinds(withBot)).toContain("edit_bot");
+  });
+
+  it("is distinct from Edit, which edits the ticket", () => {
+    const items = resolveMenuItems(withBot, resolvePrimaryAction(withBot).kind);
+    const editBot = items.find((i) => i.kind === "edit_bot");
+    expect(editBot?.label).toBe("Edit bot");
+    expect(items.find((i) => i.kind === "edit")?.label).toBe("Edit");
+  });
+
+  it("is withheld when the card names no bot", () => {
+    expect(kinds(makeCard({ ...withBot, bot_id: undefined }))).not.toContain(
+      "edit_bot",
+    );
   });
 });

--- a/studio/src/views/PipelineBoard/PipelineColumns.tsx
+++ b/studio/src/views/PipelineBoard/PipelineColumns.tsx
@@ -1,47 +1,116 @@
-import { useState } from "react";
-import { Link } from "wouter";
+import { useEffect, useState, type ReactNode } from "react";
+import { Link, useLocation } from "wouter";
 
 import type {
   PipelineBoard,
   PipelineBoardCard as PipelineBoardCardDTO,
-  PipelineBoardColumn,
 } from "@/api/pipelineBoards";
-import { markPipelineTaskReady } from "@/api/pipelineBoards";
+import { DotsHorizontalIcon } from "@radix-ui/react-icons";
+
+import {
+  bulkDeletePipelineTasks,
+  bulkReadyPipelineTasks,
+  deletePipelineTask,
+  launchPipelineTask,
+  markPipelineTaskReady,
+  resetPipelineTask,
+} from "@/api/pipelineBoards";
+import { cancelRun, pauseRun, resumeRun } from "@/api/runs";
 import type { UnifiedStatus } from "@/components/Runs/runStatusClasses";
-import { Badge, Card, InlineBanner, StatusBadge } from "@/components/ui";
+import {
+  Badge,
+  Button,
+  Card,
+  Checkbox,
+  DropdownMenu,
+  DropdownMenuItem,
+  IconButton,
+  InlineBanner,
+  StatusBadge,
+} from "@/components/ui";
+import { useConfirm } from "@/hooks/useConfirm";
 import { errorMessage } from "@/lib/errorHints";
 import { formatRelative } from "@/lib/format";
+import { useBotsStore } from "@/store/bots";
+import { useUIStore } from "@/store/ui";
+
+import { cardRoutePath } from "./cardRoute";
+import {
+  canDeleteTicket,
+  canLaunchNow,
+  canMarkReady,
+  canPauseRun,
+  canResetTicket,
+  canResumeRun,
+  canStopRun,
+  canUnmarkReady,
+  isTicketEditable,
+} from "./cardCapabilities";
+import { cardReady, closedOutcome } from "./columnFilters";
+import {
+  filterInventoryCards,
+  inventoryTabCounts,
+  partitionPipelineCards,
+  type PipelineFilterState,
+} from "./filters";
+import { PipelineFilters } from "./PipelineFilters";
+import {
+  isCardSelectable,
+  resolveMenuItems,
+  resolvePrimaryAction,
+  type MenuItemKind,
+  type PrimaryKind,
+} from "./primaryAction";
+import { QueueBanner } from "./QueueBanner";
+import { faceTags } from "./cardTags";
+import { formatChildrenSummary } from "./planGroups";
+import { hasOpenDeps } from "./queueSummary";
+
+// Re-export capabilities for existing tests.
+export {
+  canDeleteTicket,
+  canLaunchNow,
+  canMarkReady,
+  canPauseRun,
+  canResetTicket,
+  canResumeRun,
+  canStopRun,
+  canUnmarkReady,
+  isTicketEditable,
+};
 
 interface Props {
   board: PipelineBoard;
   onRefetch: () => void;
-  // Opens the edit dialog for a still-editable (Backlog / ready-unlaunched)
-  // ticket. Absent → no Edit affordance is shown.
   onEditTask?: (card: PipelineBoardCardDTO) => void;
-  // Opens the right-hand details sidebar for a card. Absent → cards are not
-  // clickable and no Details affordance is shown.
-  onOpenCard?: (card: PipelineBoardCardDTO) => void;
+  onOpenCard?: (card: PipelineBoardCardDTO, focus?: OpenCardFocus) => void;
+  /** Full board cards (unfiltered by inventory tab) — for queue banner. */
+  allCardsForQueue?: PipelineBoardCardDTO[];
+  filters?: PipelineFilterState;
+  onFiltersChange?: (next: PipelineFilterState) => void;
+  onFiltersReset?: () => void;
+  filterOptions?: {
+    allBots: string[];
+    allLabels: string[];
+    allKinds: string[];
+    allFamilies: string[];
+  };
+  /** Repo-first scoping (cloud): forwarded to the filter bar's
+   *  "Include unscoped" affordance. */
+  repoScope?: string | null;
+  includeUnscoped?: boolean;
+  onIncludeUnscopedChange?: (v: boolean) => void;
 }
 
-// isInteractiveClick reports whether a card click landed on (or inside) an
-// interactive descendant — a link, button, or form control — rather than the
-// card's inert chrome. Card-level clicks open the details sidebar; clicks on
-// the title link or the footer/move buttons must keep doing their own thing,
-// so those are ignored here. The walk stops at the card element itself (the
-// handler's currentTarget).
+// isInteractiveClick: card body always opens the drawer. Only the footer
+// (CTA / ⋯ / run link) and the multi-select checkbox may swallow the click.
+// Mark those regions with data-card-footer / data-no-card-open.
 function isInteractiveClick(e: React.MouseEvent): boolean {
   const boundary = e.currentTarget;
   let node = e.target as HTMLElement | null;
   while (node && node !== boundary) {
-    const tag = node.tagName;
     if (
-      tag === "A" ||
-      tag === "BUTTON" ||
-      tag === "INPUT" ||
-      tag === "TEXTAREA" ||
-      tag === "SELECT" ||
-      tag === "LABEL" ||
-      node.getAttribute("role") === "button" ||
+      node.hasAttribute("data-card-footer") ||
       node.hasAttribute("data-no-card-open")
     ) {
       return true;
@@ -73,55 +142,8 @@ function humanizeToken(value: string): string {
   return label ? label.charAt(0).toUpperCase() + label.slice(1) : value;
 }
 
-function columnAccent(id: string): string {
-  switch (id) {
-    case "backlog":
-      return "bg-fg-subtle";
-    case "todo":
-      return "bg-warning";
-    case "in_progress":
-      return "bg-info";
-    case "done":
-      return "bg-success";
-    case "failed":
-      return "bg-danger";
-    default:
-      return "bg-accent";
-  }
-}
-
-// Ticket movement is BUTTON-driven — there is no drag & drop on this board.
-// canMoveToTodo: a ticket-backed card that is not executing — a Backlog task
-// being staged, or a Failed pipeline being retried. Running / paused /
-// queued / finished runs are fixed by run state.
-export function canMoveToTodo(card: PipelineBoardCardDTO): boolean {
-  if (!card.issue_id) return false;
-  if (card.column_id === "backlog") return card.kind === "task" || card.failed === true;
-  if (card.column_id === "failed") return card.failed === true;
-  return false;
-}
-
-// canMoveToBacklog: a ready-but-unlaunched Todo task goes back to Backlog. A
-// queued RUN sitting in Todo is fixed by run state.
-export function canMoveToBacklog(card: PipelineBoardCardDTO): boolean {
-  return !!card.issue_id && card.column_id === "todo" && card.kind === "task";
-}
-
-// isTicketEditable reports whether a ticket can still be edited before it
-// runs: it must be task-backed (issue_id) and not executing — a Backlog card,
-// a Failed pipeline being fixed before retry, or a ready-but-unlaunched Todo
-// task card. In-progress / done cards and queued runs are fixed.
-export function isTicketEditable(card: PipelineBoardCardDTO): boolean {
-  if (!card.issue_id) return false;
-  return (
-    card.column_id === "backlog" ||
-    card.column_id === "failed" ||
-    (card.column_id === "todo" && card.kind === "task")
-  );
-}
-
-// moveTicket flips a ticket's ready state (true → Todo, staged for the launch
-// loop; false → back to Backlog), then refetches the board.
+// moveTicket flips a ticket's ready state (true → staged for the launch loop;
+// false → back to being-prepared), then refetches the board.
 export async function moveTicket(
   issueId: string,
   ready: boolean,
@@ -131,210 +153,743 @@ export async function moveTicket(
   onDone();
 }
 
-export function PipelineColumns({ board, onRefetch, onEditTask, onOpenCard }: Props) {
-  const { columns, cards } = board;
-  const [moveError, setMoveError] = useState<string | null>(null);
+export type OpenCardFocus = "default" | "deps" | "review";
+
+// Custom MIME type for the Opened → In progress drag. Using a bespoke type
+// (not text/plain) means the In-progress zone only lights up for a ticket
+// drag, and a stray text selection dropped on the board does nothing.
+export const LAUNCH_DRAG_TYPE = "application/x-iterion-ticket";
+
+// botEditorPath maps a card's bot_id to the workspace-relative main.bot the
+// editor opens (/editor?file=…), using the catalog's server-relativised
+// rel_path — the same derivation the Catalog dialog and Launch view use.
+// Null for a loose .bot (no bundle) or a bot the catalog can't resolve:
+// there is nothing stable to open, so the menu entry is simply not offered.
+export function botEditorPath(
+  botID: string | undefined,
+  bots: { name: string; rel_path?: string; is_bundle?: boolean }[] | null,
+): string | null {
+  const id = (botID ?? "").trim();
+  if (!id || !bots) return null;
+  const entry = bots.find((b) => b.name === id);
+  if (!entry || !entry.is_bundle || !entry.rel_path) return null;
+  return `${entry.rel_path}/main.bot`;
+}
+
+// PipelineCardActions bundles run controls + ticket lifecycle.
+export interface PipelineCardActions {
+  onPause: (card: PipelineBoardCardDTO) => void;
+  onResume: (card: PipelineBoardCardDTO) => void;
+  onStop: (card: PipelineBoardCardDTO) => void;
+  onReset: (card: PipelineBoardCardDTO) => void;
+  onDelete: (card: PipelineBoardCardDTO) => void;
+}
+
+export function PipelineColumns({
+  board,
+  onRefetch,
+  onEditTask,
+  onOpenCard,
+  allCardsForQueue,
+  filters,
+  onFiltersChange,
+  onFiltersReset,
+  filterOptions,
+  repoScope,
+  includeUnscoped,
+  onIncludeUnscopedChange,
+}: Props) {
+  const { cards } = board;
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
+  // Drag & drop is scoped to ONE transition: Opened → In progress, the
+  // operator's explicit "run this now" override of the priority queue.
+  // Every other card position stays server-derived (this board has no
+  // free-form drag).
+  const [dropActive, setDropActive] = useState(false);
+  // True while a ticket is in flight, so the In-progress zone can advertise
+  // itself as a target before the pointer even reaches it.
+  const [dragging, setDragging] = useState(false);
+  const addToast = useUIStore((s) => s.addToast);
+  const { confirm, dialog: confirmDialog } = useConfirm();
+  // Warm the catalog so a card's "Edit bot" entry can resolve its main.bot.
+  // The store dedupes: this is a no-op once any view has loaded the bots.
+  const fetchBots = useBotsStore((s) => s.fetch);
+  useEffect(() => {
+    void fetchBots();
+  }, [fetchBots]);
 
   const onMoveTicket = async (issueId: string, ready: boolean) => {
-    setMoveError(null);
+    setActionError(null);
     try {
       await moveTicket(issueId, ready, onRefetch);
     } catch (e) {
-      setMoveError(errorMessage(e));
+      setActionError(errorMessage(e));
     }
   };
 
+  const runAction = async (fn: () => Promise<unknown>) => {
+    setActionError(null);
+    try {
+      await fn();
+      onRefetch();
+    } catch (e) {
+      setActionError(errorMessage(e));
+    }
+  };
+
+  const actions: PipelineCardActions = {
+    // Pause / Resume are reversible — no confirm friction.
+    onPause: (card) => void runAction(() => pauseRun(card.run_id as string)),
+    onResume: (card) => void runAction(() => resumeRun(card.run_id as string, {})),
+    onStop: async (card) => {
+      if (
+        !(await confirm({
+          title: "Stop this pipeline?",
+          message:
+            "The run is cancelled at the next safe boundary and lands in Closed as failed, with its partial work preserved.",
+          confirmLabel: "Stop",
+          confirmVariant: "danger",
+        }))
+      )
+        return;
+      await runAction(() => cancelRun(card.run_id as string));
+    },
+    onReset: async (card) => {
+      if (
+        !(await confirm({
+          title: "Reset this ticket?",
+          message:
+            "The current run (and its sub-runs) are cancelled, then the ticket is restaged to Ready and starts over from zero.",
+          confirmLabel: "Reset",
+          confirmVariant: "danger",
+        }))
+      )
+        return;
+      await runAction(() => resetPipelineTask(card.issue_id as string));
+    },
+    onDelete: async (card) => {
+      if (
+        !(await confirm({
+          title: "Delete this ticket?",
+          message: "This removes it from the board and cannot be undone.",
+          confirmLabel: "Delete",
+          confirmVariant: "danger",
+        }))
+      )
+        return;
+      await runAction(() => deletePipelineTask(card.issue_id as string));
+    },
+  };
+
+  const onLaunchNow = async (issueId: string) => {
+    setDropActive(false);
+    await runAction(() => launchPipelineTask(issueId));
+  };
+
+  const { inProgress, inventory } = partitionPipelineCards(cards);
+  const tab = filters?.inventoryTab ?? "opened";
+  const tabCounts = inventoryTabCounts(inventory);
+  const inventoryVisible = filters
+    ? filterInventoryCards(inventory, filters)
+    : inventory;
+  const tabTotal = tab === "opened" ? tabCounts.opened : tabCounts.closed;
+
+  const selectableVisible = inventoryVisible.filter(isCardSelectable);
+  const selectedOnPage = selectableVisible.filter((c) =>
+    selectedIds.has(c.issue_id as string),
+  );
+
+  const toggleSelect = (issueId: string, on: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (on) next.add(issueId);
+      else next.delete(issueId);
+      return next;
+    });
+  };
+
+  const selectAllVisible = () => {
+    setSelectedIds(new Set(selectableVisible.map((c) => c.issue_id as string)));
+  };
+
+  const clearSelection = () => setSelectedIds(new Set());
+
+  const onBulkReady = async () => {
+    const ids = [...selectedIds];
+    if (ids.length === 0) return;
+    setBulkBusy(true);
+    setActionError(null);
+    try {
+      const res = await bulkReadyPipelineTasks({ ids, only_satisfied: true });
+      const nReady = res.ready?.length ?? 0;
+      const nWait = res.waiting_deps?.length ?? 0;
+      const nSkip = res.skipped?.length ?? 0;
+      addToast(
+        `Bulk ready: ${nReady} ready` +
+          (nWait ? `, ${nWait} waiting on deps` : "") +
+          (nSkip ? `, ${nSkip} skipped` : ""),
+        nReady > 0 ? "success" : "info",
+      );
+      clearSelection();
+      onRefetch();
+    } catch (e) {
+      setActionError(errorMessage(e));
+    } finally {
+      setBulkBusy(false);
+    }
+  };
+
+  const onBulkDelete = async () => {
+    const ids = [...selectedIds];
+    if (ids.length === 0) return;
+    if (
+      !(await confirm({
+        title: `Delete ${ids.length} ticket${ids.length === 1 ? "" : "s"}?`,
+        message:
+          "Removes the selected tickets from the board. Past runs stay in the run store. Tickets with an active run are skipped.",
+        confirmLabel: "Delete",
+        confirmVariant: "danger",
+      }))
+    ) {
+      return;
+    }
+    setBulkBusy(true);
+    setActionError(null);
+    try {
+      const res = await bulkDeletePipelineTasks({ ids });
+      const nDel = res.deleted?.length ?? 0;
+      const nSkip = res.skipped?.length ?? 0;
+      addToast(
+        `Bulk delete: ${nDel} removed` +
+          (nSkip ? `, ${nSkip} skipped` : ""),
+        nDel > 0 ? "success" : "info",
+      );
+      clearSelection();
+      onRefetch();
+    } catch (e) {
+      setActionError(errorMessage(e));
+    } finally {
+      setBulkBusy(false);
+    }
+  };
+
+  const queueCards = allCardsForQueue ?? cards;
+
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-      {moveError && (
+      {confirmDialog}
+      {actionError && (
         <div className="px-4 pt-2">
           <InlineBanner tone="danger" layout="inline">
-            {moveError}
+            {actionError}
           </InlineBanner>
         </div>
       )}
       <div
-        className="flex min-h-0 flex-1 items-start gap-3 overflow-x-auto px-4 pb-4"
+        className="min-h-0 flex-1 space-y-6 overflow-y-auto px-4 pb-6"
         role="region"
-        aria-label="Pipeline board columns"
+        aria-label="Pipeline cards"
       >
-        {columns.map((column) => (
-          <PipelineColumn
-            key={column.id}
-            column={column}
-            cards={cards.filter((card) => card.column_id === column.id)}
-            onMoveTicket={onMoveTicket}
-            onEditTask={onEditTask}
-            onOpenCard={onOpenCard}
-          />
-        ))}
+        <div
+          onDragOver={(e) => {
+            if (!e.dataTransfer.types.includes(LAUNCH_DRAG_TYPE)) return;
+            e.preventDefault();
+            e.dataTransfer.dropEffect = "move";
+            setDropActive(true);
+          }}
+          onDragLeave={(e) => {
+            // Only clear when the pointer truly left the zone, not when it
+            // crosses into a child element.
+            if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+            setDropActive(false);
+          }}
+          onDrop={(e) => {
+            const issueId = e.dataTransfer.getData(LAUNCH_DRAG_TYPE);
+            if (!issueId) return;
+            e.preventDefault();
+            void onLaunchNow(issueId);
+          }}
+          className={`rounded-lg transition-colors ${
+            dropActive
+              ? "ring-2 ring-accent/60 bg-accent-soft/20"
+              : dragging
+                ? "ring-1 ring-dashed ring-accent/40"
+                : ""
+          }`}
+          data-launch-dropzone
+        >
+          <CardSection
+            id="in-progress"
+            title="In progress"
+            subtitle={
+              dropActive || dragging
+                ? "Drop a ticket here to launch it now — jumps the priority queue"
+                : "Live pipelines — concurrency-capped"
+            }
+            accent="bg-info"
+            count={inProgress.length}
+            empty={
+              dropActive
+                ? "Drop here to start this ticket now."
+                : "Nothing running right now."
+            }
+          >
+            <CardGrid
+              cards={inProgress}
+              onMoveTicket={onMoveTicket}
+              actions={actions}
+              onEditTask={onEditTask}
+              onOpenCard={onOpenCard}
+            />
+          </CardSection>
+        </div>
+
+        <QueueBanner
+          cards={queueCards}
+          concurrency={board.concurrency}
+          onOpenCard={(c) => onOpenCard?.(c)}
+        />
+
+        <section aria-labelledby="pipeline-inventory-heading" className="space-y-3">
+          <div className="flex flex-wrap items-end justify-between gap-2">
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="h-0.5 w-6 rounded bg-fg-subtle" aria-hidden />
+                <h2
+                  id="pipeline-inventory-heading"
+                  className="text-xs font-semibold text-fg-default"
+                >
+                  Inventory
+                </h2>
+              </div>
+              <p className="mt-0.5 text-micro text-fg-muted">
+                Opened queue and closed history as tabs — newest first.
+              </p>
+            </div>
+          </div>
+
+          {filters && onFiltersChange && onFiltersReset && filterOptions && (
+            <PipelineFilters
+              filters={filters}
+              allBots={filterOptions.allBots}
+              allLabels={filterOptions.allLabels}
+              allKinds={filterOptions.allKinds}
+              allFamilies={filterOptions.allFamilies}
+              total={tabTotal}
+              filtered={inventoryVisible.length}
+              onChange={onFiltersChange}
+              onReset={onFiltersReset}
+              showInventoryChrome
+              tabCounts={tabCounts}
+              repoScope={repoScope}
+              includeUnscoped={includeUnscoped}
+              onIncludeUnscopedChange={onIncludeUnscopedChange}
+            />
+          )}
+
+          {tab === "opened" && selectableVisible.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={selectAllVisible}
+                disabled={bulkBusy}
+              >
+                Select all visible ({selectableVisible.length})
+              </Button>
+              {selectedIds.size > 0 && (
+                <>
+                  <Button
+                    variant="primary"
+                    size="sm"
+                    loading={bulkBusy}
+                    onClick={() => void onBulkReady()}
+                  >
+                    Ready selected ({selectedOnPage.length || selectedIds.size})
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    loading={bulkBusy}
+                    onClick={() => void onBulkDelete()}
+                  >
+                    Delete selected ({selectedOnPage.length || selectedIds.size})
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={clearSelection}>
+                    Clear selection
+                  </Button>
+                </>
+              )}
+            </div>
+          )}
+
+          {inventoryVisible.length === 0 ? (
+            <div className="flex min-h-24 items-center justify-center rounded-lg border border-dashed border-border-default px-3 text-center text-micro text-fg-subtle">
+              {tab === "opened"
+                ? "No opened tickets match these filters."
+                : "No closed pipelines match these filters."}
+            </div>
+          ) : (
+            <CardGrid
+              cards={inventoryVisible}
+              onMoveTicket={onMoveTicket}
+              actions={actions}
+              onEditTask={onEditTask}
+              onOpenCard={onOpenCard}
+              selectedIds={selectedIds}
+              onToggleSelect={tab === "opened" ? toggleSelect : undefined}
+              // Only Opened tickets can be launched now; a Closed card has
+              // already run.
+              draggableToLaunch={tab === "opened"}
+              onDragStateChange={setDragging}
+            />
+          )}
+        </section>
       </div>
     </div>
   );
 }
 
-function PipelineColumn({
-  column,
-  cards,
-  onMoveTicket,
-  onEditTask,
-  onOpenCard,
+function CardSection({
+  id,
+  title,
+  subtitle,
+  accent,
+  count,
+  empty,
+  children,
 }: {
-  column: PipelineBoardColumn;
-  cards: PipelineBoardCardDTO[];
-  onMoveTicket: (issueId: string, ready: boolean) => void;
-  onEditTask?: (card: PipelineBoardCardDTO) => void;
-  onOpenCard?: (card: PipelineBoardCardDTO) => void;
+  id: string;
+  title: string;
+  subtitle: string;
+  accent: string;
+  count: number;
+  empty: string;
+  children: ReactNode;
 }) {
   return (
-    <section
-      className="flex max-h-full w-[21rem] shrink-0 flex-col overflow-hidden rounded-[var(--radius-lg)] border border-border-default bg-surface-2/70"
-      aria-labelledby={`pipeline-column-${column.id}`}
-    >
-      <div className="relative shrink-0 border-b border-border-default bg-surface-1 px-3 py-2.5">
-        <span
-          className={`absolute inset-x-0 top-0 h-0.5 ${columnAccent(column.id)}`}
-          aria-hidden
-        />
-        <div className="flex items-center gap-2">
-          <h2
-            id={`pipeline-column-${column.id}`}
-            className="min-w-0 flex-1 truncate text-xs font-semibold text-fg-default"
-            title={column.title}
-          >
-            {column.title}
-          </h2>
-          <Badge variant="neutral">{cards.length}</Badge>
+    <section aria-labelledby={`pipeline-section-${id}`} className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2 border-b border-border-default pb-2">
+        <span className={`h-0.5 w-6 rounded ${accent}`} aria-hidden />
+        <h2
+          id={`pipeline-section-${id}`}
+          className="text-xs font-semibold text-fg-default"
+        >
+          {title}
+        </h2>
+        <Badge variant="neutral">{count}</Badge>
+        <span className="text-micro text-fg-muted">{subtitle}</span>
+      </div>
+      {count === 0 ? (
+        <div className="flex min-h-20 items-center justify-center rounded-lg border border-dashed border-border-default px-3 text-center text-micro text-fg-subtle">
+          {empty}
         </div>
-      </div>
-
-      <div className="min-h-24 flex-1 space-y-2 overflow-y-auto p-2">
-        {cards.length === 0 ? (
-          <div className="flex min-h-20 items-center justify-center rounded-md border border-dashed border-border-default px-3 text-center text-micro text-fg-subtle">
-            No cards here
-          </div>
-        ) : (
-          cards.map((card) => (
-            <PipelineCard
-              key={card.id}
-              card={card}
-              onMoveTicket={onMoveTicket}
-              onEditTask={onEditTask}
-              onOpenCard={onOpenCard}
-            />
-          ))
-        )}
-      </div>
+      ) : (
+        children
+      )}
     </section>
+  );
+}
+
+function CardGrid({
+  cards,
+  onMoveTicket,
+  actions,
+  onEditTask,
+  onOpenCard,
+  selectedIds,
+  onToggleSelect,
+  draggableToLaunch,
+  onDragStateChange,
+}: {
+  cards: PipelineBoardCardDTO[];
+  onMoveTicket: (issueId: string, ready: boolean) => void;
+  actions?: PipelineCardActions;
+  onEditTask?: (card: PipelineBoardCardDTO) => void;
+  onOpenCard?: (card: PipelineBoardCardDTO, focus?: OpenCardFocus) => void;
+  selectedIds?: Set<string>;
+  onToggleSelect?: (issueId: string, on: boolean) => void;
+  /** Enables the Opened → In progress launch drag on eligible cards. */
+  draggableToLaunch?: boolean;
+  onDragStateChange?: (dragging: boolean) => void;
+}) {
+  // auto-rows:1fr is not needed — grid items stretch to the tallest card
+  // in each row; PipelineCard uses h-full + flex so shorter siblings match.
+  return (
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(16rem,1fr))] items-stretch gap-3">
+      {cards.map((card) => (
+        <PipelineCard
+          key={card.id}
+          card={card}
+          onMoveTicket={onMoveTicket}
+          actions={actions}
+          onEditTask={onEditTask}
+          onOpenCard={onOpenCard}
+          selected={
+            !!card.issue_id && !!selectedIds?.has(card.issue_id)
+          }
+          onToggleSelect={
+            onToggleSelect && isCardSelectable(card)
+              ? (on) => onToggleSelect(card.issue_id as string, on)
+              : undefined
+          }
+          {...(draggableToLaunch && canLaunchNow(card)
+            ? { launchDrag: { onDragStateChange } }
+            : {})}
+        />
+      ))}
+    </div>
   );
 }
 
 interface CardProps {
   card: PipelineBoardCardDTO;
   onMoveTicket: (issueId: string, ready: boolean) => void;
+  actions?: PipelineCardActions;
   onEditTask?: (card: PipelineBoardCardDTO) => void;
-  onOpenCard?: (card: PipelineBoardCardDTO) => void;
+  onOpenCard?: (card: PipelineBoardCardDTO, focus?: OpenCardFocus) => void;
+  selected?: boolean;
+  onToggleSelect?: (on: boolean) => void;
+  /** Present when this card may be dragged into In progress to launch now. */
+  launchDrag?: { onDragStateChange?: (dragging: boolean) => void };
 }
 
-// PipelineCard is deliberately LEAN: title, status (progress / blocked / why),
-// and the footer (run access, Details, Edit, move buttons). Everything else —
-// inputs, produced elements, the review form, labels, description — lives in
-// the details sidebar the card click opens.
-export function PipelineCard({ card, onMoveTicket, onEditTask, onOpenCard }: CardProps) {
+// PipelineCard: lean status + primary CTA + ⋯ menu. Body click opens drawer.
+export function PipelineCard({
+  card,
+  onMoveTicket,
+  actions,
+  onEditTask,
+  onOpenCard,
+  selected,
+  onToggleSelect,
+  launchDrag,
+}: CardProps) {
   const timestamp = card.updated_at || card.created_at;
-  const editable = !!onEditTask && isTicketEditable(card);
   const openable = !!onOpenCard;
+  const primary = resolvePrimaryAction(card);
+  const [, setLocation] = useLocation();
+  const tags = faceTags(card);
+  const bots = useBotsStore((s) => s.bots);
+  const botFile = botEditorPath(card.bot_id, bots);
+  // The bot entry is only offered when the catalog can point at a real
+  // main.bot — a loose .bot file has nothing to open.
+  const menu = resolveMenuItems(card, primary.kind).filter(
+    (item) => item.kind !== "edit_bot" || botFile !== null,
+  );
+
+  const runAction = (kind: PrimaryKind | MenuItemKind) => {
+    switch (kind) {
+      case "mark_ready":
+      case "retry":
+        if (card.issue_id) void onMoveTicket(card.issue_id, true);
+        break;
+      case "unmark_ready":
+        if (card.issue_id) void onMoveTicket(card.issue_id, false);
+        break;
+      case "view_deps":
+        onOpenCard?.(card, "deps");
+        break;
+      case "answer_review":
+        onOpenCard?.(card, "review");
+        break;
+      case "details":
+        onOpenCard?.(card);
+        break;
+      case "edit":
+        onEditTask?.(card);
+        break;
+      case "delete":
+        actions?.onDelete(card);
+        break;
+      case "pause":
+        actions?.onPause(card);
+        break;
+      case "resume":
+        actions?.onResume(card);
+        break;
+      case "reset":
+        actions?.onReset(card);
+        break;
+      case "stop":
+        actions?.onStop(card);
+        break;
+      case "open_run":
+        if (card.run_id) setLocation(`/runs/${encodeURIComponent(card.run_id)}`);
+        break;
+      case "full_page":
+        setLocation(cardRoutePath(card));
+        break;
+      case "edit_bot":
+        if (botFile) setLocation(`/editor?file=${encodeURIComponent(botFile)}`);
+        break;
+      default:
+        break;
+    }
+  };
 
   return (
     <Card
-      className={`space-y-2 p-3 ${openable ? "cursor-pointer" : ""}`}
+      className={`flex h-full min-h-0 flex-col gap-2 p-3 ${openable ? "cursor-pointer" : ""} ${
+        selected ? "ring-2 ring-accent/50 border-accent" : ""
+      }`}
       interactive={openable}
       data-card-id={card.id}
+      {...(launchDrag && card.issue_id
+        ? {
+            draggable: true,
+            onDragStart: (e: React.DragEvent) => {
+              e.dataTransfer.setData(LAUNCH_DRAG_TYPE, card.issue_id as string);
+              e.dataTransfer.effectAllowed = "move";
+              launchDrag.onDragStateChange?.(true);
+            },
+            onDragEnd: () => launchDrag.onDragStateChange?.(false),
+            title: "Drag onto In progress to start now (skips the queue)",
+          }
+        : {})}
       role="article"
       aria-label={`${card.title}, ${humanizeToken(card.kind)}`}
       onClick={
         openable
           ? (e) => {
-              // Clicks on the title link or footer buttons act on their own;
-              // only inert-chrome clicks open the sidebar.
               if (isInteractiveClick(e)) return;
+              e.stopPropagation();
               onOpenCard?.(card);
             }
           : undefined
       }
     >
-      <CardTitle card={card} />
+      {/* Child tie: the campaign this ticket was spawned by, sitting above
+          the title. Cards are ungrouped and independently ordered now, so
+          this line is the ONLY thing carrying the parent relation on the
+          face — deliberately typographic, with no card-level chrome. */}
+      {card.parent_title && (
+        <div className="-mb-0.5 flex min-w-0 items-center gap-1 text-micro text-accent-text">
+          <span aria-hidden>↳</span>
+          <span
+            className="truncate"
+            title={`Spawned by ${card.parent_title}`}
+          >
+            {card.parent_title}
+          </span>
+        </div>
+      )}
 
-      {card.column_id === "backlog" && <BacklogStatus card={card} />}
-      {card.column_id === "todo" && <TodoStatus card={card} />}
-      {card.column_id === "in_progress" && <InProgressStatus card={card} />}
-      {card.column_id === "done" && <DoneStatus card={card} />}
-      {card.column_id === "failed" && <FailedStatus card={card} />}
+      <div className="flex min-w-0 items-start gap-2">
+        {onToggleSelect && (
+          <div data-no-card-open className="pt-0.5" onClick={(e) => e.stopPropagation()}>
+            <Checkbox
+              checked={!!selected}
+              onChange={(e) => onToggleSelect(e.target.checked)}
+              aria-label={`Select ${card.title}`}
+            />
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <CardTitle card={card} />
+        </div>
+      </div>
 
-      <div className="flex items-center gap-2 border-t border-border-default pt-2 text-micro">
+      {/* Body grows so cards in a grid row share one height; overflow stays clipped. */}
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-hidden">
+        {card.column_id === "opened" && <TodoStatus card={card} />}
+        {card.column_id === "in_progress" && <InProgressStatus card={card} />}
+        {card.column_id === "closed" && <ClosedStatus card={card} />}
+
+        {/* Parent side of the relation. The child side is the ↳ line above
+            the title — repeating it here as "Plan: <parent>" was redundant. */}
+        {(card.role === "planner" ||
+          (card.children_summary && card.children_summary.total > 0)) && (
+          <div className="flex min-w-0 flex-wrap items-center gap-1 text-micro text-fg-muted">
+            <Badge variant="info" title="Planner — spawns child tickets">
+              Plan
+            </Badge>
+          </div>
+        )}
+
+        {card.children_summary && card.children_summary.total > 0 && (
+          <ChildrenProgressBar
+            closed={
+              (card.children_summary.done ?? 0) +
+              (card.children_summary.failed ?? 0)
+            }
+            total={card.children_summary.total}
+            detail={formatChildrenSummary(card.children_summary)}
+          />
+        )}
+
+        {tags.shown.length > 0 && (
+          <CardTags shown={tags.shown} more={tags.more} />
+        )}
+
+        <DepsPreview card={card} />
+      </div>
+
+      <div
+        data-card-footer
+        className="mt-auto flex min-w-0 shrink-0 items-center gap-2 border-t border-border-default pt-2 text-micro"
+        onClick={(e) => e.stopPropagation()}
+      >
         {card.run_id ? (
           <Link
             href={`/runs/${encodeURIComponent(card.run_id)}`}
-            className="font-mono text-accent-text hover:underline"
+            className="shrink-0 font-mono text-accent-text hover:underline"
             title={`Open run ${card.run_id}`}
             aria-label={`Open run ${card.run_id} in the run console`}
           >
             {card.run_id.slice(0, 12)}
           </Link>
         ) : (
-          <span className="text-fg-subtle">Not started</span>
+          <span className="shrink-0 text-fg-subtle">Not started</span>
         )}
-        <span className="ml-auto flex items-center gap-2">
-          {canMoveToTodo(card) && card.issue_id && (
-            <button
-              type="button"
-              onClick={() => onMoveTicket(card.issue_id as string, true)}
-              className="text-accent-text hover:underline"
-              aria-label={`${card.failed ? "Retry" : "Move to Todo"}: ${card.title}`}
-              title={
-                card.failed
-                  ? "Retry — stage this ticket back to Todo"
-                  : "Stage this ticket: it starts when a slot frees"
-              }
-            >
-              {card.failed ? "Retry" : "→ Todo"}
-            </button>
-          )}
-          {canMoveToBacklog(card) && card.issue_id && (
-            <button
-              type="button"
-              onClick={() => onMoveTicket(card.issue_id as string, false)}
-              className="text-accent-text hover:underline"
-              aria-label={`Back to Backlog: ${card.title}`}
-              title="Unstage this ticket back to Backlog"
-            >
-              → Backlog
-            </button>
-          )}
-          {openable && (
-            <button
-              type="button"
-              onClick={() => onOpenCard?.(card)}
-              className="text-accent-text hover:underline"
-              aria-label={`Details for ${card.title}`}
-            >
-              Details
-            </button>
-          )}
-          {editable && (
-            <button
-              type="button"
-              onClick={() => onEditTask?.(card)}
-              className="text-accent-text hover:underline"
-              aria-label={`Edit ticket ${card.title}`}
-            >
-              Edit
-            </button>
-          )}
-          {timestamp && (
-            <span className="text-fg-subtle" title={timestamp}>
-              {formatRelative(timestamp)}
-            </span>
+        {timestamp && (
+          <span className="min-w-0 truncate text-fg-subtle" title={timestamp}>
+            {formatRelative(timestamp)}
+          </span>
+        )}
+        <span className="ml-auto flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              runAction(primary.kind);
+            }}
+            className={`rounded-md px-2 py-0.5 font-medium hover:underline ${
+              primary.danger
+                ? "text-danger-fg"
+                : "bg-accent-soft text-accent-text"
+            }`}
+            aria-label={`${primary.label}: ${card.title}`}
+          >
+            {primary.label}
+          </button>
+          {menu.length > 0 && (
+            <div onClick={(e) => e.stopPropagation()}>
+              <DropdownMenu
+                align="end"
+                trigger={
+                  <IconButton
+                    label={`More actions for ${card.title}`}
+                    size="sm"
+                    variant="ghost"
+                  >
+                    <DotsHorizontalIcon />
+                  </IconButton>
+                }
+              >
+                {menu.map((item) => (
+                  <DropdownMenuItem
+                    key={item.kind}
+                    className={item.danger ? "text-danger-fg" : undefined}
+                    onSelect={() => runAction(item.kind)}
+                  >
+                    {item.label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenu>
+            </div>
           )}
         </span>
       </div>
@@ -342,21 +897,72 @@ export function PipelineCard({ card, onMoveTicket, onEditTask, onOpenCard }: Car
   );
 }
 
-// CardTitle links to the run console when the card is backed by a run;
-// otherwise it is plain text (a not-yet-launched native task).
-function CardTitle({ card }: { card: PipelineBoardCardDTO }) {
-  if (card.run_id) {
+// DepsPreview is display-only — body click opens the drawer (Dependencies section).
+function DepsPreview({ card }: { card: PipelineBoardCardDTO }) {
+  if (!hasOpenDeps(card)) return null;
+  const open =
+    card.blockers?.filter((b) => !b.satisfied).slice(0, 2) ?? [];
+  const more = Math.max(0, (card.open_blocker_count ?? open.length) - open.length);
+  if (open.length === 0 && (card.open_blocker_count ?? 0) === 0) {
     return (
-      <Link
-        href={`/runs/${encodeURIComponent(card.run_id)}`}
-        className="text-sm font-medium leading-snug text-fg-default hover:underline"
-      >
-        {card.title}
-      </Link>
+      <div className="w-full truncate rounded-md border border-warning/30 bg-warning-soft/40 px-2 py-1 text-left text-micro text-warning-fg">
+        Waiting on deps — open card for graph
+      </div>
     );
   }
   return (
-    <div className="text-sm font-medium leading-snug text-fg-default">{card.title}</div>
+    <div className="w-full min-w-0 space-y-0.5 rounded-md border border-warning/30 bg-warning-soft/40 px-2 py-1.5 text-left">
+      <div className="text-micro font-medium text-warning-fg">
+        Blocked by {card.open_blocker_count ?? open.length}
+      </div>
+      <ul className="min-w-0 space-y-0.5 text-micro text-fg-muted">
+        {open.map((b) => (
+          <li key={b.id} className="truncate" title={b.title || b.id}>
+            · {b.title || b.id}
+            {b.state ? (
+              <span className="text-fg-subtle"> ({b.state})</span>
+            ) : (
+              <span className="text-danger-fg"> (missing)</span>
+            )}
+          </li>
+        ))}
+        {more > 0 && (
+          <li className="text-fg-subtle">+{more} more</li>
+        )}
+      </ul>
+    </div>
+  );
+}
+
+// CardTags: compact chips from issue labels + content-derived tags.
+// Display-only — filtering stays on the Inventory Tags dropdown.
+function CardTags({ shown, more }: { shown: string[]; more: number }) {
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-1">
+      {shown.map((tag) => (
+        <Badge key={tag} variant="neutral" className="max-w-full truncate" title={tag}>
+          {tag}
+        </Badge>
+      ))}
+      {more > 0 && (
+        <span className="text-micro text-fg-subtle" title={`${more} more tags`}>
+          +{more}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// CardTitle is plain text so a body click always opens the drawer (run console
+// remains available from the footer run-id link).
+function CardTitle({ card }: { card: PipelineBoardCardDTO }) {
+  return (
+    <div
+      className="line-clamp-2 break-words text-sm font-medium leading-snug text-fg-default"
+      title={card.title}
+    >
+      {card.title}
+    </div>
   );
 }
 
@@ -372,50 +978,65 @@ function StatusChip({ status }: { status?: string }) {
 // --- per-lane STATUS (the card's only body content) -------------------------
 
 // PriorityBadge mirrors /board's P{n} chip. On this board the number is not
-// just a sort key: the admission loop launches ready Todo tickets highest
+// just a sort key: the admission loop launches ready tickets highest
 // priority first (ties oldest-first), so P drives WHICH pipeline goes next.
 function PriorityBadge({ priority }: { priority?: number }) {
   if (!priority || priority <= 0) return null;
   return (
     <Badge
       variant="warning"
-      title={`Priority ${priority} — higher numbers launch first from Todo`}
+      title={`Priority ${priority} — higher numbers launch first once ready`}
     >
       P{priority}
     </Badge>
   );
 }
 
-// Backlog: why the ticket is here — failed (with the error) or being prepared.
-function BacklogStatus({ card }: { card: PipelineBoardCardDTO }) {
-  return (
-    <div className="space-y-2">
-      <div className="flex flex-wrap items-center gap-1">
-        <PriorityBadge priority={card.priority} />
-        {card.failed && <Badge variant="danger">Failed</Badge>}
-      </div>
-      {card.failed && card.error && (
-        <InlineBanner tone="danger" layout="inline">
-          {card.error}
-        </InlineBanner>
-      )}
-    </div>
-  );
-}
-
-// Todo: queue position (waiting for a concurrency slot) or ready — plus the
-// priority that decides its launch turn.
+// Todo: every not-yet-running ticket. Ready badge = cleared to leave Todo for
+// In progress (same predicate as the column "Ready" filter). Open hard deps
+// get a separate blocked chip so they never look launchable.
 function TodoStatus({ card }: { card: PipelineBoardCardDTO }) {
+  const ready = cardReady(card);
   const queuePosition = card.queue_position ?? 0;
+  const openBlockers = card.open_blocker_count ?? 0;
+  const waitingDeps =
+    card.issue_state === "waiting_deps" ||
+    card.launch_blocked_reason === "waiting_deps" ||
+    card.launch_blocked_reason === "open_blockers" ||
+    card.launch_blocked_reason === "blocker_labels";
   return (
     <div className="flex flex-wrap items-center gap-1">
       <PriorityBadge priority={card.priority} />
-      {queuePosition > 0 ? (
-        <Badge variant="warning">Waiting · #{queuePosition}</Badge>
+      {ready ? (
+        <Badge
+          variant="success"
+          title="Ready — will move to In progress when a concurrency slot frees"
+        >
+          Ready
+        </Badge>
+      ) : waitingDeps || openBlockers > 0 ? (
+        <Badge
+          variant="warning"
+          title={
+            openBlockers > 0
+              ? `Blocked by ${openBlockers} open hard dep${openBlockers === 1 ? "" : "s"} — will not leave Todo until they are done`
+              : "Waiting on dependencies — not ready for In progress yet"
+          }
+        >
+          {openBlockers > 0 ? `Blocked by ${openBlockers}` : "Waiting on deps"}
+        </Badge>
       ) : (
-        <span className="text-micro text-fg-subtle">
-          Ready — launches by priority when a slot frees
-        </span>
+        <Badge
+          variant="neutral"
+          title="Not ready — Mark ready when the ticket can enter In progress"
+        >
+          Not ready
+        </Badge>
+      )}
+      {queuePosition > 0 && (
+        <Badge variant="warning" title={`Queue position ${queuePosition}`}>
+          #{queuePosition}
+        </Badge>
       )}
     </div>
   );
@@ -435,13 +1056,14 @@ function InProgressStatus({ card }: { card: PipelineBoardCardDTO }) {
       ? `Blocked — human review${reviews[0]?.node_id ? ` · ${reviews[0].node_id}` : ""}`
       : `Blocked — ${reviews.length} human reviews`;
   return (
-    <div className="space-y-2">
+    <div className="min-w-0 space-y-2">
       <ProgressBar executed={card.tree_executed_nodes} total={card.tree_total_nodes} />
-      <div className="flex flex-wrap items-center gap-1">
+      <div className="flex min-w-0 flex-wrap items-center gap-1">
         {reviews.length > 0 ? (
           <Badge
             variant="warning"
-            title="Waiting on a human review — open the card to answer it"
+            className="max-w-full truncate"
+            title={`${blockedLabel} — open the card to answer it`}
           >
             {blockedLabel}
           </Badge>
@@ -476,29 +1098,75 @@ function ProgressBar({ executed, total }: { executed: number; total: number }) {
   );
 }
 
-// Done: just the terminal status — the output lives in the sidebar's Result.
-function DoneStatus({ card }: { card: PipelineBoardCardDTO }) {
+// ChildrenProgressBar mirrors In-progress node bars: full-width track +
+// "N / M closed" caption (campaign progress for planner parents).
+function ChildrenProgressBar({
+  closed,
+  total,
+  detail,
+}: {
+  closed: number;
+  total: number;
+  detail?: string;
+}) {
+  if (total <= 0) return null;
+  const pct = Math.min(100, Math.round((closed / total) * 100));
   return (
-    <div className="flex flex-wrap items-center gap-1">
-      <StatusChip status={card.status} />
+    <div className="flex min-w-0 flex-col gap-1" title={detail || undefined}>
+      <div
+        className="h-1.5 w-full overflow-hidden rounded-full bg-surface-3"
+        role="progressbar"
+        aria-valuenow={closed}
+        aria-valuemin={0}
+        aria-valuemax={total}
+        aria-label={`${closed} of ${total} children closed`}
+      >
+        <div
+          className="h-full rounded-full bg-success transition-all"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="text-micro tabular-nums text-fg-subtle">
+        {closed} / {total} closed
+      </div>
     </div>
   );
 }
 
-// Failed: the terminal status + the failure REASON. Retry (→ Todo) and Edit
-// live in the footer for ticket-backed cards; the priority shows because a
-// retried ticket re-enters the Todo launch order with it.
-function FailedStatus({ card }: { card: PipelineBoardCardDTO }) {
+// Closed: every finished pipeline, success or failure. A Success badge for a
+// clean finish (output in the sidebar's Result); for a failure, a Failed badge
+// + the exact status chip (cancelled vs failed vs resumable) + the REASON, and
+// the priority (a retried ticket re-enters the launch order with it). Retry /
+// Edit live in the footer for ticket-backed failed cards.
+//
+// Long error strings (stack traces, LLM dumps) are clamped to 2 lines — full
+// text is on title hover and in the details drawer.
+function ClosedStatus({ card }: { card: PipelineBoardCardDTO }) {
+  const failed = closedOutcome(card) === "failed";
+  if (!failed) {
+    return (
+      <div className="flex flex-wrap items-center gap-1">
+        <Badge variant="success" title="Finished successfully">
+          Success
+        </Badge>
+      </div>
+    );
+  }
   return (
-    <div className="space-y-2">
+    <div className="min-w-0 space-y-1.5">
       <div className="flex flex-wrap items-center gap-1">
         <PriorityBadge priority={card.priority} />
+        <Badge variant="danger">Failed</Badge>
         <StatusChip status={card.status} />
       </div>
       {card.error && (
-        <InlineBanner tone="danger" layout="inline">
-          {card.error}
-        </InlineBanner>
+        <div title={card.error} className="min-w-0">
+          <InlineBanner tone="danger" layout="inline" className="min-w-0 py-1.5">
+            <p className="line-clamp-2 break-words whitespace-pre-wrap">
+              {card.error}
+            </p>
+          </InlineBanner>
+        </div>
       )}
     </div>
   );

--- a/studio/src/views/PipelineBoard/PipelineFilters.tsx
+++ b/studio/src/views/PipelineBoard/PipelineFilters.tsx
@@ -1,21 +1,30 @@
+import { BotFilterSelect } from "@/components/shared/BotFilterSelect";
 import { LabelFilter } from "@/components/shared/LabelFilterPopover";
 import { Button } from "@/components/ui/Button";
 import { Checkbox } from "@/components/ui/Checkbox";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
 
-import { pipelineFiltersActive, type PipelineFilterState } from "./filters";
+import {
+  pipelineFiltersActive,
+  type ClosedSubfilter,
+  type InventoryTab,
+  type OpenedSubfilter,
+  type PipelineFilterState,
+} from "./filters";
 
-// PipelineFilters is the /pipelines counterpart of the /board filter bar:
-// text search, bot select, label multi-select, a filtered/total counter and
-// a reset — same look, same semantics (labels AND, exact bot). When
-// `repoScope` is set (cloud + a chosen active repo) a companion "Include
-// unscoped" checkbox mirrors /board's BoardFilters affordance, letting the
-// operator surface cards that carry no repo identity alongside the scoped set.
+// PipelineFilters sits above the inventory card grid (tabbed Opened | Closed):
+// text search, bot select, label multi-select, a filtered/total counter and a
+// reset (labels AND, exact bot). When `repoScope` is set (cloud + a chosen
+// active repo) a companion "Include unscoped" checkbox mirrors /board's
+// BoardFilters affordance, letting the operator surface cards that carry no
+// repo identity alongside the scoped set.
 export function PipelineFilters({
   filters,
   allBots,
   allLabels,
+  allKinds = [],
+  allFamilies = [],
   total,
   filtered,
   onChange,
@@ -23,10 +32,14 @@ export function PipelineFilters({
   repoScope,
   includeUnscoped,
   onIncludeUnscopedChange,
+  showInventoryChrome = false,
+  tabCounts,
 }: {
   filters: PipelineFilterState;
   allBots: string[];
   allLabels: string[];
+  allKinds?: string[];
+  allFamilies?: string[];
   total: number;
   filtered: number;
   onChange: (next: PipelineFilterState) => void;
@@ -34,8 +47,12 @@ export function PipelineFilters({
   repoScope?: string | null;
   includeUnscoped?: boolean;
   onIncludeUnscopedChange?: (v: boolean) => void;
+  /** Tabs Opened/Closed + subfilter chips. */
+  showInventoryChrome?: boolean;
+  tabCounts?: { opened: number; closed: number };
 }) {
   const active = pipelineFiltersActive(filters);
+  const tab: InventoryTab = filters.inventoryTab ?? "opened";
 
   const toggleLabel = (label: string) => {
     const labels = new Set(filters.labels);
@@ -44,61 +61,239 @@ export function PipelineFilters({
     onChange({ ...filters, labels });
   };
 
+  const setTab = (next: InventoryTab) => {
+    if (next === tab) return;
+    onChange({ ...filters, inventoryTab: next });
+  };
+
   return (
-    <div className="flex flex-wrap items-center gap-2 border-b border-border-default bg-surface-1 px-3 py-2 text-xs">
-      <div className="min-w-[200px] flex-shrink-0">
-        <Input
-          type="search"
-          value={filters.query}
-          onChange={(e) => onChange({ ...filters, query: e.target.value })}
-          placeholder="Search title / body / run id…"
-          aria-label="Search pipelines"
-        />
-      </div>
-      {allBots.length > 0 && (
-        <div className="w-auto">
-          <Select
-            value={filters.bot}
-            onChange={(e) => onChange({ ...filters, bot: e.target.value })}
-            aria-label="Filter by bot"
+    <div className="space-y-2 rounded-lg border border-border-default bg-surface-1 px-3 py-2 text-xs">
+      {showInventoryChrome && (
+        <div className="space-y-2">
+          <div
+            className="flex gap-0 border-b border-border-default"
+            role="tablist"
+            aria-label="Inventory section"
           >
-            <option value="">All bots</option>
-            {allBots.map((b) => (
-              <option key={b} value={b}>
-                {b}
+            {(
+              [
+                {
+                  id: "opened" as const,
+                  label: "Opened",
+                  count: tabCounts?.opened,
+                  title: "Queue and drafts — not finished yet",
+                },
+                {
+                  id: "closed" as const,
+                  label: "Closed",
+                  count: tabCounts?.closed,
+                  title: "Finished pipelines — success or failed",
+                },
+              ] as const
+            ).map((t) => {
+              const selected = tab === t.id;
+              return (
+                <button
+                  key={t.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={selected}
+                  title={t.title}
+                  onClick={() => setTab(t.id)}
+                  className={`-mb-px flex items-center gap-1.5 border-b-2 px-3 py-1.5 text-xs font-medium transition-colors ${
+                    selected
+                      ? "border-accent text-accent-text"
+                      : "border-transparent text-fg-muted hover:text-fg-default"
+                  }`}
+                >
+                  {t.label}
+                  {typeof t.count === "number" && (
+                    <span
+                      className={`rounded-full px-1.5 py-0 text-micro tabular-nums ${
+                        selected
+                          ? "bg-accent-soft text-accent-text"
+                          : "bg-surface-2 text-fg-subtle"
+                      }`}
+                    >
+                      {t.count}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          {tab === "opened" ? (
+            <SubfilterChips
+              ariaLabel="Filter opened tickets"
+              value={filters.openedSubfilter ?? "all"}
+              options={[
+                { value: "all", label: "All", title: "Every opened ticket" },
+                {
+                  value: "ready",
+                  label: "Ready",
+                  title: "Cleared to launch when a slot frees",
+                },
+                {
+                  value: "not_ready",
+                  label: "Not ready",
+                  title: "Drafts and tickets blocked by deps",
+                },
+              ]}
+              onChange={(openedSubfilter: OpenedSubfilter) =>
+                onChange({ ...filters, openedSubfilter })
+              }
+            />
+          ) : (
+            <SubfilterChips
+              ariaLabel="Filter closed tickets"
+              value={filters.closedSubfilter ?? "all"}
+              options={[
+                { value: "all", label: "All", title: "Every closed pipeline" },
+                {
+                  value: "success",
+                  label: "Success",
+                  title: "Finished successfully",
+                },
+                {
+                  value: "failed",
+                  label: "Failed",
+                  title: "Failed or cancelled",
+                },
+              ]}
+              onChange={(closedSubfilter: ClosedSubfilter) =>
+                onChange({ ...filters, closedSubfilter })
+              }
+            />
+          )}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="min-w-[200px] flex-shrink-0">
+          <Input
+            type="search"
+            value={filters.query}
+            onChange={(e) => onChange({ ...filters, query: e.target.value })}
+            placeholder="Search title / body / input_path / run id…"
+            aria-label="Search pipelines"
+          />
+        </div>
+        {allBots.length > 0 && (
+          <BotFilterSelect
+            value={filters.bot}
+            allBots={allBots}
+            onChange={(bot) => onChange({ ...filters, bot })}
+            ariaLabel="Filter by bot"
+          />
+        )}
+        {allLabels.length > 0 && (
+          <LabelFilter
+            allLabels={allLabels}
+            selected={filters.labels}
+            onToggle={toggleLabel}
+            onClear={() => onChange({ ...filters, labels: new Set() })}
+            label="Tags"
+            searchPlaceholder="Search tags…"
+          />
+        )}
+        {repoScope && onIncludeUnscopedChange && (
+          <Checkbox
+            checked={!!includeUnscoped}
+            onChange={(e) => onIncludeUnscopedChange(e.target.checked)}
+            label={
+              !includeUnscoped && total > filtered
+                ? `Include unscoped (${total - filtered} hidden)`
+                : "Include unscoped"
+            }
+            help={`When on, cards with no repository also show alongside cards linked to ${repoScope}.`}
+          />
+        )}
+        {allKinds.length > 0 && (
+          <Select
+            fit
+            value={filters.pipelineKind}
+            onChange={(e) => onChange({ ...filters, pipelineKind: e.target.value })}
+            aria-label="Filter by pipeline kind"
+            title="bot_args.pipeline_kind"
+          >
+            <option value="">All kinds</option>
+            {allKinds.map((k) => (
+              <option key={k} value={k}>
+                {k}
               </option>
             ))}
           </Select>
-        </div>
-      )}
-      {allLabels.length > 0 && (
-        <LabelFilter
-          allLabels={allLabels}
-          selected={filters.labels}
-          onToggle={toggleLabel}
-          onClear={() => onChange({ ...filters, labels: new Set() })}
-        />
-      )}
-      {repoScope && onIncludeUnscopedChange && (
+        )}
+        {allFamilies.length > 0 && (
+          <Select
+            fit
+            className="max-w-[10rem]"
+            value={filters.familyId}
+            onChange={(e) => onChange({ ...filters, familyId: e.target.value })}
+            aria-label="Filter by family id"
+            title="bot_args.family_id"
+          >
+            <option value="">All families</option>
+            {allFamilies.map((k) => (
+              <option key={k} value={k}>
+                {k}
+              </option>
+            ))}
+          </Select>
+        )}
         <Checkbox
-          checked={!!includeUnscoped}
-          onChange={(e) => onIncludeUnscopedChange(e.target.checked)}
-          label={
-            !includeUnscoped && total > filtered
-              ? `Include unscoped (${total - filtered} hidden)`
-              : "Include unscoped"
+          checked={filters.waitingDepsOnly}
+          onChange={(e) =>
+            onChange({ ...filters, waitingDepsOnly: e.target.checked })
           }
-          help={`When on, cards with no repository also show alongside cards linked to ${repoScope}.`}
+          label="Waiting on deps"
+          title="Show only tickets with open hard blockers or waiting_deps"
         />
-      )}
-      <span className="ml-auto text-fg-muted">
-        {active ? `${filtered} / ${total}` : `${total} card${total === 1 ? "" : "s"}`}
-      </span>
-      {active && (
-        <Button variant="ghost" size="sm" onClick={onReset}>
-          reset
-        </Button>
-      )}
+        <span className="ml-auto text-fg-muted">
+          {active || filtered !== total
+            ? `${filtered} / ${total}`
+            : `${total} card${total === 1 ? "" : "s"}`}
+        </span>
+        {active && (
+          <Button variant="ghost" size="sm" onClick={onReset}>
+            reset
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SubfilterChips<T extends string>({
+  ariaLabel,
+  value,
+  options,
+  onChange,
+}: {
+  ariaLabel: string;
+  value: T;
+  options: { value: T; label: string; title: string }[];
+  onChange: (next: T) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1" role="group" aria-label={ariaLabel}>
+      {options.map((o) => (
+        <button
+          key={o.value}
+          type="button"
+          aria-pressed={value === o.value}
+          title={o.title}
+          onClick={() => onChange(o.value)}
+          className={`rounded-full border px-2 py-0.5 text-micro font-medium transition-colors ${
+            value === o.value
+              ? "border-accent bg-accent-soft text-accent-text"
+              : "border-border-default bg-surface-2 text-fg-muted hover:text-fg-default"
+          }`}
+        >
+          {o.label}
+        </button>
+      ))}
     </div>
   );
 }

--- a/studio/src/views/PipelineBoard/ProducedElements.tsx
+++ b/studio/src/views/PipelineBoard/ProducedElements.tsx
@@ -30,6 +30,7 @@ import { usePreview, type PreviewState } from "@/components/Runs/usePreview";
 import { formatBytes, formatRelative } from "@/lib/format";
 
 import { producedKindLabel, type ProducedFileKind } from "./fileKind";
+import { ImagePreviewDialog } from "./ImagePreview";
 import {
   aggregateProducedItems,
   type ProducedItem,
@@ -240,7 +241,23 @@ export function ProducedElements({ runIds, status }: Props) {
         </Suspense>
       )}
 
-      {preview && (
+      {preview && isImagePreview(preview, previewKind) && preview.blobURL ? (
+        <ImagePreviewDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) closePreview();
+          }}
+          src={preview.blobURL}
+          alt={preview.path}
+          title={<span className="font-mono text-xs">{preview.path}</span>}
+          description={
+            <span>
+              {formatBytes(preview.size)} · {preview.contentType || "loading…"}
+            </span>
+          }
+          downloadHref={`${artifactFileURL(previewRunId, preview.path)}?download=1`}
+        />
+      ) : preview ? (
         <Dialog
           open
           onOpenChange={(open) => {
@@ -265,9 +282,15 @@ export function ProducedElements({ runIds, status }: Props) {
         >
           <PreviewBody preview={preview} kind={previewKind} />
         </Dialog>
-      )}
+      ) : null}
     </section>
   );
+}
+
+function isImagePreview(preview: PreviewState, kind: ProducedFileKind): boolean {
+  if (preview.loading || preview.error || !preview.blobURL) return false;
+  if (preview.textBody !== null) return false;
+  return preview.contentType.startsWith("image/") || kind === "image";
 }
 
 // KIND_ICON maps a produced kind to its row glyph. Media kinds (image/audio/

--- a/studio/src/views/PipelineBoard/QueueBanner.tsx
+++ b/studio/src/views/PipelineBoard/QueueBanner.tsx
@@ -1,0 +1,73 @@
+import type { PipelineBoardCard, PipelineConcurrency } from "@/api/pipelineBoards";
+
+import { computeQueueSummary } from "./queueSummary";
+
+export function QueueBanner({
+  cards,
+  concurrency,
+  onOpenCard,
+}: {
+  cards: PipelineBoardCard[];
+  concurrency?: PipelineConcurrency;
+  onOpenCard?: (card: PipelineBoardCard) => void;
+}) {
+  const s = computeQueueSummary(cards, concurrency);
+  if (s.readyCount === 0 && s.waitingDepsCount === 0 && s.draftCount === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border border-border-default bg-surface-1 px-3 py-2 text-xs"
+      role="status"
+      aria-label="Launch queue summary"
+    >
+      <span className="font-semibold text-fg-default">Queue</span>
+      <span className="text-fg-muted">
+        <strong className="font-medium text-success-fg">{s.readyCount}</strong> ready
+      </span>
+      <span className="text-fg-subtle">·</span>
+      <span className="text-fg-muted">
+        <strong className="font-medium text-warning-fg">{s.waitingDepsCount}</strong> waiting
+        on deps
+      </span>
+      {s.draftCount > 0 && (
+        <>
+          <span className="text-fg-subtle">·</span>
+          <span className="text-fg-muted">
+            <strong className="font-medium text-fg-default">{s.draftCount}</strong> draft
+          </span>
+        </>
+      )}
+      {s.slotsFree !== null && s.slotsMax !== null && (
+        <>
+          <span className="text-fg-subtle">·</span>
+          <span
+            className="text-fg-muted"
+            title={`${s.slotsActive ?? 0} active of ${s.slotsMax} max concurrent roots`}
+          >
+            slots{" "}
+            <strong className="font-medium text-fg-default">
+              {s.slotsFree}/{s.slotsMax}
+            </strong>{" "}
+            free
+          </span>
+        </>
+      )}
+      {s.nextUp && (
+        <>
+          <span className="text-fg-subtle">·</span>
+          <button
+            type="button"
+            onClick={() => onOpenCard?.(s.nextUp!)}
+            className="min-w-0 truncate text-left text-accent-text hover:underline"
+            title={`Next up: ${s.nextUp.title}`}
+          >
+            Next up: <span className="font-medium">{s.nextUp.title}</span>
+            {(s.nextUp.priority ?? 0) > 0 ? ` (P${s.nextUp.priority})` : ""}
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/studio/src/views/PipelineBoard/cardCapabilities.ts
+++ b/studio/src/views/PipelineBoard/cardCapabilities.ts
@@ -1,0 +1,74 @@
+import type { PipelineBoardCard } from "@/api/pipelineBoards";
+
+import { cardReady } from "./columnFilters";
+
+// Ticket movement is BUTTON-driven — there is no drag & drop on this board.
+// canMarkReady: stage a not-yet-ready Opened task into the launch queue, or
+// retry a Failed pipeline in Closed — both flip the ticket to StateReady.
+export function canMarkReady(card: PipelineBoardCard): boolean {
+  if (!card.issue_id) return false;
+  if (card.column_id === "closed") return card.failed === true;
+  if (card.column_id === "opened") return card.kind === "task" && !cardReady(card);
+  return false;
+}
+
+export function canUnmarkReady(card: PipelineBoardCard): boolean {
+  return (
+    !!card.issue_id &&
+    card.column_id === "opened" &&
+    card.kind === "task" &&
+    card.ready === true
+  );
+}
+
+export function canDeleteTicket(card: PipelineBoardCard): boolean {
+  return (
+    !!card.issue_id &&
+    card.kind === "task" &&
+    card.column_id === "opened" &&
+    !cardReady(card)
+  );
+}
+
+// canLaunchNow: the ticket may be dragged from Opened straight into In
+// progress, overriding the admission loop's priority order. Mirrors the
+// server's guards (POST .../tasks/{id}/launch) so the UI never offers a
+// drag the backend would 409 — except the concurrency cap, which is live
+// state the server owns and reports back.
+export function canLaunchNow(card: PipelineBoardCard): boolean {
+  return (
+    !!card.issue_id &&
+    card.kind === "task" &&
+    card.column_id === "opened" &&
+    !card.run_id &&
+    (card.open_blocker_count ?? 0) === 0
+  );
+}
+
+export function canPauseRun(card: PipelineBoardCard): boolean {
+  return card.column_id === "in_progress" && !!card.run_id && card.status === "running";
+}
+
+export function canResumeRun(card: PipelineBoardCard): boolean {
+  return (
+    card.column_id === "in_progress" &&
+    !!card.run_id &&
+    card.status === "paused_operator"
+  );
+}
+
+export function canResetTicket(card: PipelineBoardCard): boolean {
+  return card.column_id === "in_progress" && !!card.issue_id && !!card.run_id;
+}
+
+export function canStopRun(card: PipelineBoardCard): boolean {
+  return card.column_id === "in_progress" && !!card.run_id && !card.issue_id;
+}
+
+export function isTicketEditable(card: PipelineBoardCard): boolean {
+  if (!card.issue_id) return false;
+  return (
+    (card.column_id === "opened" && card.kind === "task") ||
+    (card.column_id === "closed" && card.failed === true)
+  );
+}

--- a/studio/src/views/PipelineBoard/cardRoute.test.ts
+++ b/studio/src/views/PipelineBoard/cardRoute.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import type { PipelineBoardCard } from "@/api/pipelineBoards";
+
+import {
+  cardRouteKey,
+  cardRoutePath,
+  findCardByRouteKey,
+  parseCardRoute,
+} from "./cardRoute";
+
+function card(partial: Partial<PipelineBoardCard>): PipelineBoardCard {
+  return {
+    id: "card",
+    kind: "task",
+    column_id: "opened",
+    title: "Card",
+    executed_nodes: 0,
+    total_nodes: 0,
+    tree_executed_nodes: 0,
+    tree_total_nodes: 0,
+    created_at: "",
+    updated_at: "",
+    ...partial,
+  };
+}
+
+describe("cardRouteKey / path", () => {
+  it("prefers issue_id for stable deep links", () => {
+    const c = card({ id: "task:x", issue_id: "native:abc", run_id: "r1" });
+    expect(cardRouteKey(c)).toEqual({ kind: "issue", id: "native:abc" });
+    expect(cardRoutePath(c)).toBe("/pipelines/cards/issue/native%3Aabc");
+  });
+
+  it("falls back to run then card id", () => {
+    expect(cardRouteKey(card({ id: "run:r9", run_id: "r9" }))).toEqual({
+      kind: "run",
+      id: "r9",
+    });
+    expect(cardRouteKey(card({ id: "task:only" }))).toEqual({
+      kind: "id",
+      id: "task:only",
+    });
+  });
+});
+
+describe("parseCardRoute + findCardByRouteKey", () => {
+  const cards = [
+    card({ id: "task:a", issue_id: "native:1", title: "A" }),
+    card({ id: "run:r2", run_id: "r2", title: "B" }),
+  ];
+
+  it("round-trips issue keys", () => {
+    const key = parseCardRoute("issue", encodeURIComponent("native:1"));
+    expect(key).toEqual({ kind: "issue", id: "native:1" });
+    expect(findCardByRouteKey(cards, key!)?.title).toBe("A");
+  });
+
+  it("finds runs by run_id", () => {
+    const key = parseCardRoute("run", "r2");
+    expect(findCardByRouteKey(cards, key!)?.title).toBe("B");
+  });
+
+  it("rejects unknown kinds", () => {
+    expect(parseCardRoute("nope", "x")).toBeNull();
+  });
+});

--- a/studio/src/views/PipelineBoard/cardRoute.ts
+++ b/studio/src/views/PipelineBoard/cardRoute.ts
@@ -1,0 +1,50 @@
+import type { PipelineBoardCard } from "@/api/pipelineBoards";
+
+// URL key for a pipeline card. Prefer issue_id (stable across task→run
+// transition), then run_id, then the projection card id.
+export type CardRouteKey =
+  | { kind: "issue"; id: string }
+  | { kind: "run"; id: string }
+  | { kind: "id"; id: string };
+
+export function cardRouteKey(card: PipelineBoardCard): CardRouteKey {
+  if (card.issue_id) return { kind: "issue", id: card.issue_id };
+  if (card.run_id) return { kind: "run", id: card.run_id };
+  return { kind: "id", id: card.id };
+}
+
+/** Path segment pair for wouter: /pipelines/cards/:kind/:id */
+export function cardRoutePath(card: PipelineBoardCard): string {
+  const key = cardRouteKey(card);
+  return `/pipelines/cards/${key.kind}/${encodeURIComponent(key.id)}`;
+}
+
+export function parseCardRoute(
+  kind: string | undefined,
+  id: string | undefined,
+): CardRouteKey | null {
+  if (!kind || !id) return null;
+  const decoded = decodeURIComponent(id);
+  if (kind === "issue" || kind === "run" || kind === "id") {
+    return { kind, id: decoded };
+  }
+  return null;
+}
+
+export function findCardByRouteKey(
+  cards: PipelineBoardCard[],
+  key: CardRouteKey,
+): PipelineBoardCard | null {
+  switch (key.kind) {
+    case "issue":
+      return cards.find((c) => c.issue_id === key.id) ?? null;
+    case "run":
+      return (
+        cards.find((c) => c.run_id === key.id) ??
+        cards.find((c) => c.id === `run:${key.id}`) ??
+        null
+      );
+    case "id":
+      return cards.find((c) => c.id === key.id) ?? null;
+  }
+}

--- a/studio/src/views/PipelineBoard/cardTags.test.ts
+++ b/studio/src/views/PipelineBoard/cardTags.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import type { PipelineBoardCard } from "@/api/pipelineBoards";
+
+import {
+  cardHasAllTags,
+  cardTags,
+  collectTagVocabulary,
+  faceTags,
+} from "./cardTags";
+
+function card(partial: Partial<PipelineBoardCard>): PipelineBoardCard {
+  return {
+    id: "c1",
+    kind: "run",
+    column_id: "opened",
+    title: "t",
+    executed_nodes: 0,
+    total_nodes: 0,
+    tree_executed_nodes: 0,
+    tree_total_nodes: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...partial,
+  };
+}
+
+describe("cardTags", () => {
+  it("unions issue labels with content-derived tags", () => {
+    const tags = cardTags(
+      card({
+        labels: ["urgent", "video"],
+        entry_input: {
+          character: "Boudicca",
+          episode_no: "1",
+          episode_total: "5",
+          episode_title: "Le Fouet",
+          pipeline_kind: "shorts",
+        },
+      }),
+    );
+    expect(tags).toContain("urgent");
+    expect(tags).toContain("video");
+    expect(tags).toContain("Boudicca");
+    expect(tags).toContain("ÉP 1/5");
+    expect(tags).toContain("shorts");
+    // episode_title is for the card title, not a tag (too long / unique).
+    expect(tags).not.toContain("Le Fouet");
+  });
+
+  it("dedupes case-insensitively and skips paths / long values", () => {
+    const tags = cardTags(
+      card({
+        labels: ["Boudicca", "path/to/x"],
+        entry_input: {
+          character: "boudicca",
+          family_id: "assets/humanoid/foo", // path-ish → dropped
+        },
+      }),
+    );
+    expect(tags.filter((t) => t.toLowerCase() === "boudicca")).toHaveLength(1);
+    expect(tags.some((t) => t.includes("/"))).toBe(false);
+  });
+
+  it("cardHasAllTags is AND over the full vocabulary", () => {
+    const c = card({
+      labels: ["a"],
+      entry_input: { character: "Boudicca", episode_no: "2", episode_total: "5" },
+    });
+    expect(cardHasAllTags(c, new Set(["a", "Boudicca"]))).toBe(true);
+    expect(cardHasAllTags(c, new Set(["a", "missing"]))).toBe(false);
+    expect(cardHasAllTags(c, new Set(["ÉP 2/5"]))).toBe(true);
+  });
+
+  it("faceTags caps chips and reports overflow", () => {
+    const c = card({
+      labels: ["a", "b", "c", "d", "e"],
+    });
+    const { shown, more } = faceTags(c, 3);
+    expect(shown).toEqual(["a", "b", "c"]);
+    expect(more).toBe(2);
+  });
+
+  it("collectTagVocabulary sorts the board-wide set", () => {
+    const vocab = collectTagVocabulary([
+      card({ id: "1", labels: ["zeta"], entry_input: { character: "Ada" } }),
+      card({ id: "2", labels: ["alpha"] }),
+    ]);
+    expect(vocab).toEqual(["Ada", "alpha", "zeta"]);
+  });
+});

--- a/studio/src/views/PipelineBoard/cardTags.ts
+++ b/studio/src/views/PipelineBoard/cardTags.ts
@@ -1,0 +1,105 @@
+// Card tags: the operator-visible chip vocabulary for a pipeline card.
+//
+// Sources (union, de-duplicated, stable order):
+//  1. Native issue labels (authored on the ticket / by bots)
+//  2. Content-derived tags from entry_input — so run-only cards (no issue)
+//     still carry filterable chips explaining WHAT they produce
+//
+// Used by: card face chips, filter vocabulary, label-filter matching.
+// Keep this list short and human — long prose (hook/angle/summary) is never
+// a tag; it belongs in the title or the drawer.
+
+import type { PipelineBoardCard } from "@/api/pipelineBoards";
+
+import { cardArg } from "./filters";
+
+/** Max chips rendered on the card face before "+N". */
+export const CARD_TAG_FACE_LIMIT = 4;
+
+// cardTags returns the full ordered tag list for a card.
+export function cardTags(card: PipelineBoardCard): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const push = (raw: string | undefined | null) => {
+    const t = (raw ?? "").trim();
+    if (!t) return;
+    // Guard against path-like / huge values sneaking in via free-form labels.
+    // Episode chips like "ÉP 1/5" are fine; "assets/foo/bar" is not.
+    if (t.length > 48) return;
+    if (looksLikePathTag(t)) return;
+    const key = t.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push(t);
+  };
+
+  for (const l of card.labels ?? []) push(l);
+
+  // Subject / series framing (shorts, humanoid, mesh).
+  push(cardArg(card, "character"));
+  push(cardArg(card, "requested_character"));
+  push(cardArg(card, "subject"));
+  push(cardArg(card, "family_id"));
+  push(cardArg(card, "family"));
+  push(cardArg(card, "family_name"));
+  push(cardArg(card, "series"));
+  push(cardArg(card, "collection"));
+  push(cardArg(card, "pipeline_kind"));
+  push(cardArg(card, "type_id"));
+
+  // Compact episode frame as one chip (filterable), not each field alone.
+  const epNo = cardArg(card, "episode_no") || cardArg(card, "episode");
+  const epTotal = cardArg(card, "episode_total");
+  if (epNo) {
+    push(epTotal ? `ÉP ${epNo}/${epTotal}` : `ÉP ${epNo}`);
+  }
+
+  return out;
+}
+
+// cardHasAllTags is the AND-match used by the board label/tag filter.
+export function cardHasAllTags(card: PipelineBoardCard, required: Set<string>): boolean {
+  if (!required || required.size === 0) return true;
+  const have = new Set(cardTags(card).map((t) => t.toLowerCase()));
+  for (const t of required) {
+    if (!have.has(t.toLowerCase())) return false;
+  }
+  return true;
+}
+
+// collectTagVocabulary is the union of every card's tags (sorted).
+export function collectTagVocabulary(cards: PipelineBoardCard[]): string[] {
+  const all = new Set<string>();
+  for (const card of cards) {
+    for (const t of cardTags(card)) all.add(t);
+  }
+  return Array.from(all).sort((a, b) => a.localeCompare(b));
+}
+
+// faceTags splits the full list into chips shown on the card + overflow count.
+export function faceTags(card: PipelineBoardCard, limit = CARD_TAG_FACE_LIMIT): {
+  shown: string[];
+  more: number;
+} {
+  const all = cardTags(card);
+  if (all.length <= limit) return { shown: all, more: 0 };
+  return { shown: all.slice(0, limit), more: all.length - limit };
+}
+
+// looksLikePathTag rejects filesystem/URL-ish values. Allows short fractions
+// like "ÉP 1/5" or "3/4" (at most one slash, no dots/backslashes).
+function looksLikePathTag(t: string): boolean {
+  if (t.includes("\\")) return true;
+  const slashes = (t.match(/\//g) ?? []).length;
+  if (slashes === 0) return false;
+  if (slashes >= 2) return true;
+  // Single slash: path if it has a dot segment or looks like dir/file.
+  if (t.includes(".")) return true;
+  // "ÉP 1/5" / "v2/final" ok; "assets/foo" has letters on both sides with
+  // no digit-only side — still a path-ish label. Prefer: allow only when
+  // at least one side is purely numeric (episode fractions).
+  const [left = "", right = ""] = t.split("/");
+  const leftNum = /^\d+$/.test(left.trim()) || /\b\d+$/.test(left.trim());
+  const rightNum = /^\d+$/.test(right.trim());
+  return !(leftNum || rightNum);
+}

--- a/studio/src/views/PipelineBoard/columnFilters.test.ts
+++ b/studio/src/views/PipelineBoard/columnFilters.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import type { PipelineBoardCard } from "@/api/pipelineBoards";
+
+import {
+  applyColumnFilter,
+  cardReady,
+  closedOutcome,
+  columnFilterActive,
+  emptyColumnFilters,
+} from "./columnFilters";
+
+function card(partial: Partial<PipelineBoardCard>): PipelineBoardCard {
+  return {
+    id: "card",
+    kind: "run",
+    column_id: "opened",
+    title: "Card",
+    executed_nodes: 0,
+    total_nodes: 0,
+    tree_executed_nodes: 0,
+    tree_total_nodes: 0,
+    created_at: "",
+    updated_at: "",
+    ...partial,
+  };
+}
+
+describe("cardReady", () => {
+  it("is true for staged tasks and queued runs when deps are clear", () => {
+    expect(cardReady(card({ ready: true }))).toBe(true);
+    expect(cardReady(card({ status: "queued" }))).toBe(true);
+    expect(cardReady(card({ kind: "task", ready: false }))).toBe(false);
+    expect(cardReady(card({ status: "running" }))).toBe(false);
+    expect(cardReady(card({}))).toBe(false);
+  });
+
+  it("is false when hard deps still block launch", () => {
+    expect(cardReady(card({ ready: true, open_blocker_count: 2 }))).toBe(false);
+    expect(cardReady(card({ ready: true, issue_state: "waiting_deps" }))).toBe(false);
+    expect(
+      cardReady(card({ ready: true, launch_blocked_reason: "open_blockers" })),
+    ).toBe(false);
+  });
+});
+
+describe("closedOutcome", () => {
+  it("splits failed from success on the failed flag", () => {
+    expect(closedOutcome(card({ failed: true }))).toBe("failed");
+    expect(closedOutcome(card({ status: "finished" }))).toBe("success");
+    expect(closedOutcome(card({ failed: false }))).toBe("success");
+  });
+});
+
+describe("emptyColumnFilters", () => {
+  it("defaults both lanes to 'all' and is a fresh object each call", () => {
+    const a = emptyColumnFilters();
+    const b = emptyColumnFilters();
+    expect(a).toEqual({ todoReadiness: "all", closedOutcome: "all" });
+    a.todoReadiness = "ready";
+    expect(b.todoReadiness).toBe("all"); // no aliasing
+  });
+});
+
+describe("columnFilterActive", () => {
+  it("reports a non-default per-column filter", () => {
+    const base = emptyColumnFilters();
+    expect(columnFilterActive("opened", base)).toBe(false);
+    expect(columnFilterActive("opened", { ...base, todoReadiness: "ready" })).toBe(true);
+    expect(columnFilterActive("closed", base)).toBe(false);
+    expect(columnFilterActive("closed", { ...base, closedOutcome: "failed" })).toBe(true);
+    // In progress (and any lane without a control) is never "active".
+    expect(columnFilterActive("in_progress", { ...base, todoReadiness: "ready" })).toBe(false);
+  });
+});
+
+describe("applyColumnFilter", () => {
+  const todoCards = [
+    card({ id: "ready", ready: true }),
+    card({ id: "queued", kind: "run", status: "queued" }),
+    card({ id: "draft", kind: "task" }),
+  ];
+  const closedCards = [
+    card({ id: "ok", column_id: "closed", status: "finished" }),
+    card({ id: "bad", column_id: "closed", failed: true }),
+  ];
+
+  it("Todo: 'ready' keeps cleared-to-launch cards, 'draft' keeps the rest", () => {
+    const base = emptyColumnFilters();
+    expect(
+      applyColumnFilter("opened", todoCards, { ...base, todoReadiness: "ready" }).map((c) => c.id),
+    ).toEqual(["ready", "queued"]);
+    expect(
+      applyColumnFilter("opened", todoCards, { ...base, todoReadiness: "draft" }).map((c) => c.id),
+    ).toEqual(["draft"]);
+    // 'all' returns the input unchanged (same reference — no needless copy).
+    expect(applyColumnFilter("opened", todoCards, base)).toBe(todoCards);
+  });
+
+  it("Closed: 'success' and 'failed' narrow by outcome", () => {
+    const base = emptyColumnFilters();
+    expect(
+      applyColumnFilter("closed", closedCards, { ...base, closedOutcome: "success" }).map((c) => c.id),
+    ).toEqual(["ok"]);
+    expect(
+      applyColumnFilter("closed", closedCards, { ...base, closedOutcome: "failed" }).map((c) => c.id),
+    ).toEqual(["bad"]);
+    expect(applyColumnFilter("closed", closedCards, base)).toBe(closedCards);
+  });
+
+  it("a column without a control is returned unchanged", () => {
+    const cards = [card({ column_id: "in_progress", status: "running" })];
+    expect(
+      applyColumnFilter("in_progress", cards, { todoReadiness: "ready", closedOutcome: "failed" }),
+    ).toBe(cards);
+  });
+});

--- a/studio/src/views/PipelineBoard/columnFilters.ts
+++ b/studio/src/views/PipelineBoard/columnFilters.ts
@@ -1,0 +1,77 @@
+// Per-column filtering for the /pipelines board. Distinct from filters.ts
+// (the GLOBAL search/bot/label bar that narrows the whole board): these
+// controls live in a single column's header and narrow only that column —
+// the Todo lane by readiness, the Closed lane by success/failure outcome.
+// They compose ON TOP of the global filter (global runs first, per-column
+// second). Pure functions here so they can be unit-tested and reused by the
+// card badges without a circular import back into PipelineColumns.
+
+import type { PipelineBoardCard } from "@/api/pipelineBoards";
+
+// cardReady reports whether a Todo card is cleared to advance to In progress:
+// staged (server `ready` = StateReady) or already queued for a concurrency
+// slot, AND hard deps are satisfied (no open blockers / waiting_deps).
+// Drives the Ready badge and the Todo column's "Ready only" filter.
+export function cardReady(card: PipelineBoardCard): boolean {
+  if ((card.open_blocker_count ?? 0) > 0) return false;
+  if (card.issue_state === "waiting_deps") return false;
+  if (
+    card.launch_blocked_reason === "open_blockers" ||
+    card.launch_blocked_reason === "waiting_deps" ||
+    card.launch_blocked_reason === "blocker_labels"
+  ) {
+    return false;
+  }
+  return card.ready === true || card.status === "queued";
+}
+
+// closedOutcome splits the Closed lane: a failed / cancelled / resumable run
+// is "failed"; everything else there finished successfully. Drives the Closed
+// column's outcome filter + the Success/Failed badge.
+export function closedOutcome(card: PipelineBoardCard): "success" | "failed" {
+  return card.failed === true ? "failed" : "success";
+}
+
+export type TodoReadinessFilter = "all" | "ready" | "draft";
+export type ClosedOutcomeFilter = "all" | "success" | "failed";
+
+export interface ColumnFilterState {
+  // Todo lane: show all, only ready (cleared to launch), or only drafts.
+  todoReadiness: TodoReadinessFilter;
+  // Closed lane: show all, only successes, or only failures.
+  closedOutcome: ClosedOutcomeFilter;
+}
+
+// Factory (not a shared constant) so a reset can never alias prior state.
+export function emptyColumnFilters(): ColumnFilterState {
+  return { todoReadiness: "all", closedOutcome: "all" };
+}
+
+// columnFilterActive reports whether the given column currently has a
+// non-default per-column filter applied (drives the "N of M" header hint).
+export function columnFilterActive(
+  columnId: string,
+  state: ColumnFilterState,
+): boolean {
+  if (columnId === "opened") return state.todoReadiness !== "all";
+  if (columnId === "closed") return state.closedOutcome !== "all";
+  return false;
+}
+
+// applyColumnFilter narrows a single column's already-globally-filtered cards
+// by its per-column control. Columns without a control (in_progress, and any
+// future lane) are returned unchanged.
+export function applyColumnFilter(
+  columnId: string,
+  cards: PipelineBoardCard[],
+  state: ColumnFilterState,
+): PipelineBoardCard[] {
+  if (columnId === "opened" && state.todoReadiness !== "all") {
+    const wantReady = state.todoReadiness === "ready";
+    return cards.filter((card) => cardReady(card) === wantReady);
+  }
+  if (columnId === "closed" && state.closedOutcome !== "all") {
+    return cards.filter((card) => closedOutcome(card) === state.closedOutcome);
+  }
+  return cards;
+}

--- a/studio/src/views/PipelineBoard/filters.test.ts
+++ b/studio/src/views/PipelineBoard/filters.test.ts
@@ -5,8 +5,11 @@ import type { PipelineBoardCard } from "@/api/pipelineBoards";
 import {
   collectFilterOptions,
   emptyPipelineFilters,
+  filterInventoryCards,
   filterPipelineCards,
+  partitionPipelineCards,
   pipelineFiltersActive,
+  sortNewestFirst,
 } from "./filters";
 
 function card(partial: Partial<PipelineBoardCard>): PipelineBoardCard {
@@ -73,6 +76,32 @@ describe("filterPipelineCards", () => {
     expect(filterPipelineCards(cards, f).map((c) => c.id)).toEqual(["a", "b"]);
   });
 
+  it("filters by pipeline_kind, family_id, and waiting deps", () => {
+    const kindCards = [
+      card({
+        id: "m",
+        entry_input: { pipeline_kind: "mesh", family_id: "fort", input_path: "a.json" },
+      }),
+      card({
+        id: "f",
+        entry_input: { pipeline_kind: "feature", family_id: "fort" },
+        open_blocker_count: 2,
+        issue_state: "waiting_deps",
+      }),
+      card({ id: "x", entry_input: { pipeline_kind: "mesh", family_id: "other" } }),
+    ];
+    const base = emptyPipelineFilters();
+    expect(
+      filterPipelineCards(kindCards, { ...base, pipelineKind: "mesh" }).map((c) => c.id),
+    ).toEqual(["m", "x"]);
+    expect(
+      filterPipelineCards(kindCards, { ...base, familyId: "fort" }).map((c) => c.id),
+    ).toEqual(["m", "f"]);
+    expect(
+      filterPipelineCards(kindCards, { ...base, waitingDepsOnly: true }).map((c) => c.id),
+    ).toEqual(["f"]);
+  });
+
   it("bot filter matches the workflow_name fallback for bot-less runs", () => {
     const looseCards = [
       card({ id: "x", workflow_name: "shorts_historical_series" }),
@@ -101,6 +130,7 @@ describe("filterPipelineCards", () => {
 
   it("composes filters (search + bot + labels)", () => {
     const f = {
+      ...emptyPipelineFilters(),
       query: "render",
       bot: "shorts",
       labels: new Set(["urgent"]),
@@ -112,6 +142,80 @@ describe("filterPipelineCards", () => {
   });
 });
 
+describe("partitionPipelineCards + inventory filters", () => {
+  it("splits in progress from inventory and sorts newest first", () => {
+    const mixed = [
+      card({
+        id: "old-open",
+        column_id: "opened",
+        updated_at: "2026-07-01T00:00:00Z",
+      }),
+      card({
+        id: "new-closed",
+        column_id: "closed",
+        updated_at: "2026-07-14T00:00:00Z",
+        failed: true,
+      }),
+      card({
+        id: "running",
+        column_id: "in_progress",
+        status: "running",
+        updated_at: "2026-07-10T00:00:00Z",
+      }),
+    ];
+    const { inProgress, inventory } = partitionPipelineCards(mixed);
+    expect(inProgress.map((c) => c.id)).toEqual(["running"]);
+    expect(inventory.map((c) => c.id)).toEqual(["new-closed", "old-open"]);
+  });
+
+  it("filterInventoryCards applies tab + subfilter", () => {
+    const inv = [
+      card({ id: "r", column_id: "opened", ready: true }),
+      card({ id: "d", column_id: "opened" }),
+      card({ id: "ok", column_id: "closed", failed: false }),
+      card({ id: "bad", column_id: "closed", failed: true }),
+    ];
+    const base = emptyPipelineFilters();
+    expect(
+      filterInventoryCards(inv, { ...base, inventoryTab: "opened", openedSubfilter: "ready" }).map(
+        (c) => c.id,
+      ),
+    ).toEqual(["r"]);
+    expect(
+      filterInventoryCards(inv, {
+        ...base,
+        inventoryTab: "opened",
+        openedSubfilter: "not_ready",
+      }).map((c) => c.id),
+    ).toEqual(["d"]);
+    expect(
+      filterInventoryCards(inv, {
+        ...base,
+        inventoryTab: "closed",
+        closedSubfilter: "success",
+      }).map((c) => c.id),
+    ).toEqual(["ok"]);
+    expect(
+      filterInventoryCards(inv, {
+        ...base,
+        inventoryTab: "closed",
+        closedSubfilter: "failed",
+      }).map((c) => c.id),
+    ).toEqual(["bad"]);
+    expect(
+      filterInventoryCards(inv, { ...base, inventoryTab: "opened" }).map((c) => c.id),
+    ).toEqual(["r", "d"]);
+  });
+
+  it("sortNewestFirst is stable on equal timestamps via id", () => {
+    const got = sortNewestFirst([
+      card({ id: "b", updated_at: "2026-07-01T00:00:00Z" }),
+      card({ id: "a", updated_at: "2026-07-01T00:00:00Z" }),
+    ]);
+    expect(got.map((c) => c.id)).toEqual(["a", "b"]);
+  });
+});
+
 describe("pipelineFiltersActive", () => {
   it("detects any active filter", () => {
     expect(pipelineFiltersActive(emptyPipelineFilters())).toBe(false);
@@ -119,6 +223,9 @@ describe("pipelineFiltersActive", () => {
     expect(pipelineFiltersActive({ ...emptyPipelineFilters(), bot: "b" })).toBe(true);
     expect(
       pipelineFiltersActive({ ...emptyPipelineFilters(), labels: new Set(["l"]) }),
+    ).toBe(true);
+    expect(
+      pipelineFiltersActive({ ...emptyPipelineFilters(), openedSubfilter: "ready" }),
     ).toBe(true);
   });
 

--- a/studio/src/views/PipelineBoard/filters.ts
+++ b/studio/src/views/PipelineBoard/filters.ts
@@ -6,20 +6,63 @@
 
 import type { PipelineBoardCard } from "@/api/pipelineBoards";
 
+import { cardHasAllTags, cardTags, collectTagVocabulary } from "./cardTags";
+import { cardReady, closedOutcome } from "./columnFilters";
+
+/** Which inventory tab is active (default: opened). */
+export type InventoryTab = "opened" | "closed";
+
+/** Sub-filters within the Opened tab. */
+export type OpenedSubfilter = "all" | "ready" | "not_ready";
+
+/** Sub-filters within the Closed tab. */
+export type ClosedSubfilter = "all" | "success" | "failed";
+
 export interface PipelineFilterState {
   query: string;
   bot: string;
   labels: Set<string>;
+  /** bot_args.pipeline_kind exact match (empty = any). */
+  pipelineKind: string;
+  /** bot_args.family_id exact match (empty = any). */
+  familyId: string;
+  /** Only cards with open hard blockers or issue_state waiting_deps. */
+  waitingDepsOnly: boolean;
+  /** Inventory tab: Opened (default) vs Closed. */
+  inventoryTab: InventoryTab;
+  /** Ready / not ready chips (Opened tab only). */
+  openedSubfilter: OpenedSubfilter;
+  /** Success / failed chips (Closed tab only). */
+  closedSubfilter: ClosedSubfilter;
 }
 
 // Factory (not a shared constant): each call returns a fresh Set so a reset
 // can never alias a previous selection.
 export function emptyPipelineFilters(): PipelineFilterState {
-  return { query: "", bot: "", labels: new Set() };
+  return {
+    query: "",
+    bot: "",
+    labels: new Set(),
+    pipelineKind: "",
+    familyId: "",
+    waitingDepsOnly: false,
+    inventoryTab: "opened",
+    openedSubfilter: "all",
+    closedSubfilter: "all",
+  };
 }
 
 export function pipelineFiltersActive(f: PipelineFilterState): boolean {
-  return f.query.trim() !== "" || f.bot !== "" || f.labels.size > 0;
+  return (
+    (f.query ?? "").trim() !== "" ||
+    (f.bot ?? "") !== "" ||
+    (f.labels?.size ?? 0) > 0 ||
+    (f.pipelineKind ?? "") !== "" ||
+    (f.familyId ?? "") !== "" ||
+    !!f.waitingDepsOnly ||
+    (f.openedSubfilter ?? "all") !== "all" ||
+    (f.closedSubfilter ?? "all") !== "all"
+  );
 }
 
 // cardBotIdentity is the value the bot dropdown filters on: the bot id when
@@ -31,22 +74,38 @@ export function cardBotIdentity(card: PipelineBoardCard): string {
   return card.bot_id || card.workflow_name || "";
 }
 
+// cardArg reads a bot_args / entry_input string key from the card projection.
+export function cardArg(card: PipelineBoardCard, key: string): string {
+  const v = card.entry_input?.[key];
+  return typeof v === "string" ? v.trim() : "";
+}
+
 // collectFilterOptions derives the dropdown vocabularies from the cards
-// actually on the board — including labels created on the fly by bots.
+// actually on the board — including labels created on the fly by bots and
+// content-derived tags (character, family_id, ÉP n/N, …).
 export function collectFilterOptions(cards: PipelineBoardCard[]): {
   allBots: string[];
   allLabels: string[];
+  allKinds: string[];
+  allFamilies: string[];
 } {
   const bots = new Set<string>();
-  const labels = new Set<string>();
+  const kinds = new Set<string>();
+  const families = new Set<string>();
   for (const card of cards) {
     const identity = cardBotIdentity(card);
     if (identity) bots.add(identity);
-    for (const l of card.labels ?? []) labels.add(l);
+    const kind = cardArg(card, "pipeline_kind");
+    if (kind) kinds.add(kind);
+    const family = cardArg(card, "family_id");
+    if (family) families.add(family);
   }
   return {
     allBots: Array.from(bots).sort(),
-    allLabels: Array.from(labels).sort(),
+    // "Labels" filter is the full tag vocabulary (issue labels ∪ derived).
+    allLabels: collectTagVocabulary(cards),
+    allKinds: Array.from(kinds).sort(),
+    allFamilies: Array.from(families).sort(),
   };
 }
 
@@ -69,15 +128,27 @@ export function cardMatchesRepo(
 // bot identity (bot_id, falling back to workflow_name — see cardBotIdentity).
 // When `repoScope` is set the card must match it via cardMatchesRepo, unless
 // `includeUnscoped` allows repo-less cards through as well.
+// Lifecycle chips for the inventory section are applied separately (see
+// filterInventoryCards) so in-progress is never hidden by "opened only".
 export function filterPipelineCards(
   cards: PipelineBoardCard[],
   f: PipelineFilterState,
   repoScope: string | null = null,
   includeUnscoped = false,
 ): PipelineBoardCard[] {
-  const q = f.query.trim().toLowerCase();
-  const bot = f.bot.trim();
-  if (!q && !bot && f.labels.size === 0 && !repoScope) return cards;
+  const q = (f.query ?? "").trim().toLowerCase();
+  const bot = (f.bot ?? "").trim();
+  const kind = (f.pipelineKind ?? "").trim();
+  const family = (f.familyId ?? "").trim();
+  const labels = f.labels ?? new Set<string>();
+  const hasTextFilters =
+    q !== "" ||
+    bot !== "" ||
+    labels.size > 0 ||
+    kind !== "" ||
+    family !== "" ||
+    !!f.waitingDepsOnly;
+  if (!hasTextFilters && !repoScope) return cards;
   return cards.filter((card) => {
     if (q) {
       const hay = [
@@ -86,17 +157,27 @@ export function filterPipelineCards(
         card.workflow_name ?? "",
         card.run_id ?? "",
         card.issue_id ?? "",
+        cardArg(card, "input_path"),
+        cardArg(card, "asset_id"),
+        cardArg(card, "feature_id"),
+        ...cardTags(card),
       ]
         .join("\t")
         .toLowerCase();
       if (!hay.includes(q)) return false;
     }
     if (bot && cardBotIdentity(card) !== bot) return false;
-    if (f.labels.size > 0) {
-      const have = new Set(card.labels ?? []);
-      for (const l of f.labels) {
-        if (!have.has(l)) return false;
-      }
+    if (labels.size > 0 && !cardHasAllTags(card, labels)) return false;
+    if (kind && cardArg(card, "pipeline_kind") !== kind) return false;
+    if (family && cardArg(card, "family_id") !== family) return false;
+    if (f.waitingDepsOnly) {
+      const open = card.open_blocker_count ?? 0;
+      const waiting =
+        card.issue_state === "waiting_deps" ||
+        card.launch_blocked_reason === "waiting_deps" ||
+        card.launch_blocked_reason === "open_blockers" ||
+        open > 0;
+      if (!waiting) return false;
     }
     if (repoScope) {
       const hasRepo = !!card.external?.repo;
@@ -108,4 +189,69 @@ export function filterPipelineCards(
     }
     return true;
   });
+}
+
+/** Newest first by updated_at (fallback created_at). */
+export function sortNewestFirst(cards: PipelineBoardCard[]): PipelineBoardCard[] {
+  return [...cards].sort((a, b) => {
+    const ta = Date.parse(a.updated_at || a.created_at || "") || 0;
+    const tb = Date.parse(b.updated_at || b.created_at || "") || 0;
+    if (tb !== ta) return tb - ta;
+    // Stable tie-break: ascending id.
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+}
+
+export function partitionPipelineCards(cards: PipelineBoardCard[]): {
+  inProgress: PipelineBoardCard[];
+  inventory: PipelineBoardCard[];
+} {
+  const inProgress: PipelineBoardCard[] = [];
+  const inventory: PipelineBoardCard[] = [];
+  for (const card of cards) {
+    if (card.column_id === "in_progress") inProgress.push(card);
+    else inventory.push(card);
+  }
+  return {
+    inProgress: sortNewestFirst(inProgress),
+    inventory: sortNewestFirst(inventory),
+  };
+}
+
+/** Apply inventory tab + subfilter to opened/closed cards (not in-progress). */
+export function filterInventoryCards(
+  cards: PipelineBoardCard[],
+  f: Pick<PipelineFilterState, "inventoryTab" | "openedSubfilter" | "closedSubfilter">,
+): PipelineBoardCard[] {
+  const tab = f.inventoryTab ?? "opened";
+  if (tab === "opened") {
+    const sub = f.openedSubfilter ?? "all";
+    return cards.filter((card) => {
+      if (card.column_id !== "opened") return false;
+      if (sub === "ready") return cardReady(card);
+      if (sub === "not_ready") return !cardReady(card);
+      return true;
+    });
+  }
+  const sub = f.closedSubfilter ?? "all";
+  return cards.filter((card) => {
+    if (card.column_id !== "closed") return false;
+    if (sub === "success") return closedOutcome(card) === "success";
+    if (sub === "failed") return closedOutcome(card) === "failed";
+    return true;
+  });
+}
+
+/** Counts for tab badges (pre-subfilter, post text filters). */
+export function inventoryTabCounts(cards: PipelineBoardCard[]): {
+  opened: number;
+  closed: number;
+} {
+  let opened = 0;
+  let closed = 0;
+  for (const card of cards) {
+    if (card.column_id === "opened") opened++;
+    else if (card.column_id === "closed") closed++;
+  }
+  return { opened, closed };
 }

--- a/studio/src/views/PipelineBoard/index.tsx
+++ b/studio/src/views/PipelineBoard/index.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
 import { Link } from "wouter";
+import { useQuery } from "@tanstack/react-query";
 
 import { getPipelineBoard, type PipelineBoardCard } from "@/api/pipelineBoards";
 import { useHeaderSlot } from "@/components/shared/useHeaderSlot";
@@ -8,11 +8,14 @@ import { Button, EmptyState, InlineBanner, Spinner } from "@/components/ui";
 import { useActiveRepo } from "@/hooks/useActiveRepo";
 import { errorMessage } from "@/lib/errorHints";
 import { formatRelative } from "@/lib/format";
+import { useUIStore } from "@/store/ui";
 
 import AddTaskDialog from "./AddTaskDialog";
 import PipelineCardDetails from "./PipelineCardDetails";
-import { PipelineColumns } from "./PipelineColumns";
-import { PipelineFilters } from "./PipelineFilters";
+import {
+  PipelineColumns,
+  type OpenCardFocus,
+} from "./PipelineColumns";
 import {
   collectFilterOptions,
   emptyPipelineFilters,
@@ -25,11 +28,8 @@ const POLL_INTERVAL_MS = 3000;
 export default function PipelineBoardView() {
   const [addTaskOpen, setAddTaskOpen] = useState(false);
   const [editTask, setEditTask] = useState<PipelineBoardCard | null>(null);
-  // The card whose details sidebar is open. Held as the click-time snapshot;
-  // its live version is re-derived from each poll so status / reviews /
-  // produced elements stay current while the drawer is open.
   const [selected, setSelected] = useState<PipelineBoardCard | null>(null);
-  // Client-side filters (search / bot / labels), mirroring /board's bar.
+  const [drawerFocus, setDrawerFocus] = useState<OpenCardFocus>("default");
   const [filters, setFilters] = useState(emptyPipelineFilters);
   // Repo-first scoping: default the visible cards to the sidebar's active
   // repo (cloud only, non-overview); the "Include unscoped" toggle lets
@@ -45,6 +45,10 @@ export default function PipelineBoardView() {
       ? activeRepo.repo_full_name
       : null;
   const [includeUnscoped, setIncludeUnscoped] = useState(false);
+  const addToast = useUIStore((s) => s.addToast);
+  // issue_id → run_id snapshot for launch-toast detection.
+  const prevIssueRuns = useRef<Map<string, string>>(new Map());
+  const launchToastPrimed = useRef(false);
 
   const query = useQuery({
     queryKey: ["pipeline-board"],
@@ -53,6 +57,46 @@ export default function PipelineBoardView() {
     refetchIntervalInBackground: false,
     retry: false,
   });
+
+  // Toast when a ticket-backed card gains a new run_id while in progress
+  // (admission loop or dispatcher just launched it).
+  useEffect(() => {
+    const cards = query.data?.cards;
+    if (!cards) return;
+    const next = new Map<string, string>();
+    for (const c of cards) {
+      if (c.issue_id && c.run_id) next.set(c.issue_id, c.run_id);
+    }
+    if (!launchToastPrimed.current) {
+      prevIssueRuns.current = next;
+      launchToastPrimed.current = true;
+      return;
+    }
+    for (const [issueId, runId] of next) {
+      const prev = prevIssueRuns.current.get(issueId);
+      if (prev === runId) continue;
+      if (prev && prev === runId) continue;
+      // New or changed run id for this issue.
+      if (!prev || prev !== runId) {
+        const card = cards.find((c) => c.issue_id === issueId);
+        if (card?.column_id === "in_progress") {
+          addToast(
+            `Started “${card.title}” · ${runId.slice(0, 12)}…`,
+            "success",
+            {
+              action: {
+                label: "Open run",
+                onClick: () => {
+                  window.location.href = `/runs/${encodeURIComponent(runId)}`;
+                },
+              },
+            },
+          );
+        }
+      }
+    }
+    prevIssueRuns.current = next;
+  }, [query.data?.cards, addToast]);
 
   useHeaderSlot({
     left: <span className="text-xs font-medium text-fg-default">Pipelines</span>,
@@ -101,21 +145,25 @@ export default function PipelineBoardView() {
   const board = query.data;
   const { concurrency } = board;
 
-  // Re-locate the open card in the latest projection (id can change as a task
-  // becomes a run); fall back to the snapshot and flag it stale when the card
-  // has left the board entirely. Selection tracks the FULL card set — a card
-  // hidden by a filter keeps its open sidebar.
   const liveSelected = selected ? findFollowCard(board.cards, selected) : null;
   const detailCard = liveSelected ?? selected;
   const detailStale = selected !== null && liveSelected === null;
 
   const filterOptions = collectFilterOptions(board.cards);
+  // ONE filtered set: the text/label/kind chips AND the repo scope. The
+  // lifecycle chips (Opened/Closed tabs) are applied further down, inside
+  // PipelineColumns, so In progress is never hidden by an inventory tab.
   const filteredCards = filterPipelineCards(
     board.cards,
     filters,
     repoScope,
     includeUnscoped,
   );
+
+  const openCard = (card: PipelineBoardCard, focus: OpenCardFocus = "default") => {
+    setDrawerFocus(focus);
+    setSelected(card);
+  };
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
@@ -125,14 +173,18 @@ export default function PipelineBoardView() {
             {/* The view's title lives in the header slot ("Pipelines");
                 the body opens with the explanatory intro line only. */}
             <p className="max-w-3xl text-xs text-fg-muted">
-              Every launched pipeline (and not-yet-started task) across all bots, bucketed
-              into five fixed lanes. Cards advance automatically as their runs progress —
-              there is no drag &amp; drop here, unlike the{" "}
+              Live runs up top. Inventory tabs{" "}
+              <strong className="font-medium text-fg-default">Opened</strong>{" "}
+              (default) and{" "}
+              <strong className="font-medium text-fg-default">Closed</strong>.
+              Queue banner shows ready / waiting / next up. One primary action
+              per card; more in ⋯. Cards advance automatically as their runs
+              progress — the only drag here is Opened → In progress, which
+              launches a ticket immediately, unlike the{" "}
               <Link href="/board" className="text-accent-text hover:underline">
                 Board
               </Link>
-              . Stage a Backlog ticket with its “→ Todo” button (or edit it first), retry a
-              Failed one, and click any card for details.
+              .
             </p>
           </div>
           <div className="flex items-center gap-2 text-caption text-fg-subtle">
@@ -165,27 +217,12 @@ export default function PipelineBoardView() {
         )}
       </div>
 
-      {board.cards.length > 0 && (
-        <PipelineFilters
-          filters={filters}
-          allBots={filterOptions.allBots}
-          allLabels={filterOptions.allLabels}
-          total={board.cards.length}
-          filtered={filteredCards.length}
-          onChange={setFilters}
-          onReset={() => setFilters(emptyPipelineFilters())}
-          repoScope={repoScope}
-          includeUnscoped={includeUnscoped}
-          onIncludeUnscopedChange={setIncludeUnscoped}
-        />
-      )}
-
-      <div className="flex min-h-0 flex-1 overflow-hidden">
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+      <div className="relative min-h-0 flex-1 overflow-hidden">
+        <div className="flex h-full min-w-0 flex-col overflow-hidden">
           {board.cards.length === 0 ? (
             <EmptyState
               title="No pipelines yet"
-              message="Add a task to feed Todo, or launch a bot. Running pipelines and their human reviews appear here automatically."
+              message="Add a task or launch a bot. Running pipelines and their human reviews appear here automatically."
               action={
                 <Button variant="primary" size="sm" onClick={() => setAddTaskOpen(true)}>
                   Add first task
@@ -196,9 +233,17 @@ export default function PipelineBoardView() {
           ) : (
             <PipelineColumns
               board={{ ...board, cards: filteredCards }}
+              allCardsForQueue={board.cards}
               onRefetch={() => void query.refetch()}
               onEditTask={setEditTask}
-              onOpenCard={setSelected}
+              onOpenCard={openCard}
+              filters={filters}
+              onFiltersChange={setFilters}
+              onFiltersReset={() => setFilters(emptyPipelineFilters())}
+              filterOptions={filterOptions}
+              repoScope={repoScope}
+              includeUnscoped={includeUnscoped}
+              onIncludeUnscopedChange={setIncludeUnscoped}
             />
           )}
         </div>
@@ -207,7 +252,12 @@ export default function PipelineBoardView() {
           <PipelineCardDetails
             card={detailCard}
             stale={detailStale}
-            onClose={() => setSelected(null)}
+            presentation="overlay"
+            focusSection={drawerFocus}
+            onClose={() => {
+              setSelected(null);
+              setDrawerFocus("default");
+            }}
             onRefetch={() => void query.refetch()}
           />
         )}

--- a/studio/src/views/PipelineBoard/planGroups.test.ts
+++ b/studio/src/views/PipelineBoard/planGroups.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  childrenClosedCount,
+  childrenProgressPct,
+  formatChildrenClosedRatio,
+  formatChildrenSummary,
+} from "./planGroups";
+
+const summary = {
+  total: 5,
+  ready: 2,
+  in_progress: 1,
+  done: 1,
+  failed: 1,
+  open: 1,
+};
+
+describe("children counters", () => {
+  // "Closed" on this board means finished OR failed — a failed child is
+  // done with, not still pending, so it counts toward the campaign total.
+  it("counts done + failed as closed", () => {
+    expect(childrenClosedCount(summary)).toBe(2);
+    expect(childrenProgressPct(summary)).toBe(40);
+  });
+
+  it("leads with closed/total", () => {
+    expect(formatChildrenClosedRatio(summary)).toBe("2/5 closed");
+    expect(formatChildrenSummary(summary)).toMatch(/^2\/5 closed/);
+    expect(formatChildrenSummary(summary)).toContain("1 live");
+  });
+
+  it("degrades safely with no summary", () => {
+    expect(childrenClosedCount(undefined)).toBe(0);
+    expect(childrenProgressPct(undefined)).toBe(0);
+    expect(formatChildrenClosedRatio(undefined)).toBe("");
+    expect(formatChildrenClosedRatio(undefined, 3)).toBe("0/3 closed");
+    expect(formatChildrenSummary(undefined, 3)).toBe("3 children");
+  });
+});

--- a/studio/src/views/PipelineBoard/planGroups.ts
+++ b/studio/src/views/PipelineBoard/planGroups.ts
@@ -1,0 +1,59 @@
+// Planner provenance formatting.
+//
+// The board does NOT group parents and children: every card — planner or
+// spawned — is an ordinary, independently-ordered cell, and a parent lands
+// in Closed as soon as its own run finishes. The relation survives purely
+// as data on the two faces: the closed-children counter on the parent
+// (these helpers), and the parent name above each child's title.
+//
+// (An earlier iteration folded children into an expand/collapse campaign
+// block. It was removed: a full-width block broke the grid, and holding an
+// executed parent in Opened made its lane lie about its run.)
+
+import type { PipelineBoardCard } from "@/api/pipelineBoards";
+
+/** Board-closed children = success (done) + failed/cancelled. */
+export function childrenClosedCount(
+  s: PipelineBoardCard["children_summary"] | undefined,
+): number {
+  if (!s) return 0;
+  return (s.done ?? 0) + (s.failed ?? 0);
+}
+
+/** e.g. "2/5 closed" — primary campaign progress label. */
+export function formatChildrenClosedRatio(
+  s: PipelineBoardCard["children_summary"] | undefined,
+  fallbackTotal?: number,
+): string {
+  if (s && s.total > 0) {
+    return `${childrenClosedCount(s)}/${s.total} closed`;
+  }
+  if (fallbackTotal && fallbackTotal > 0) {
+    return `0/${fallbackTotal} closed`;
+  }
+  return "";
+}
+
+export function formatChildrenSummary(
+  s: PipelineBoardCard["children_summary"] | undefined,
+  fallbackCount?: number,
+): string {
+  if (!s) {
+    return fallbackCount && fallbackCount > 0
+      ? `${fallbackCount} children`
+      : "";
+  }
+  const closed = childrenClosedCount(s);
+  const parts: string[] = [`${closed}/${s.total} closed`];
+  if (s.in_progress) parts.push(`${s.in_progress} live`);
+  if (s.ready) parts.push(`${s.ready} ready`);
+  if (s.open) parts.push(`${s.open} open`);
+  return parts.join(" · ");
+}
+
+export function childrenProgressPct(
+  s: PipelineBoardCard["children_summary"] | undefined,
+): number {
+  if (!s || s.total <= 0) return 0;
+  return Math.min(100, Math.round((childrenClosedCount(s) / s.total) * 100));
+}

--- a/studio/src/views/PipelineBoard/primaryAction.ts
+++ b/studio/src/views/PipelineBoard/primaryAction.ts
@@ -1,0 +1,139 @@
+import type { PipelineBoardCard } from "@/api/pipelineBoards";
+
+import {
+  canDeleteTicket,
+  canMarkReady,
+  canPauseRun,
+  canResetTicket,
+  canResumeRun,
+  canStopRun,
+  canUnmarkReady,
+  isTicketEditable,
+} from "./cardCapabilities";
+import { hasOpenDeps } from "./queueSummary";
+
+export type PrimaryKind =
+  | "mark_ready"
+  | "unmark_ready"
+  | "view_deps"
+  | "answer_review"
+  | "resume"
+  | "open_run"
+  | "details"
+  | "retry";
+
+export interface PrimaryAction {
+  kind: PrimaryKind;
+  label: string;
+  danger?: boolean;
+}
+
+export type MenuItemKind =
+  | PrimaryKind
+  | "edit"
+  | "delete"
+  | "pause"
+  | "stop"
+  | "reset"
+  | "full_page"
+  | "edit_bot"
+  | "details";
+
+export interface MenuItem {
+  kind: MenuItemKind;
+  label: string;
+  danger?: boolean;
+}
+
+export function resolvePrimaryAction(card: PipelineBoardCard): PrimaryAction {
+  if (card.column_id === "opened") {
+    if (hasOpenDeps(card)) {
+      return { kind: "view_deps", label: "View deps" };
+    }
+    if (canUnmarkReady(card)) {
+      return { kind: "unmark_ready", label: "Unmark ready" };
+    }
+    if (canMarkReady(card)) {
+      return { kind: "mark_ready", label: "Mark ready" };
+    }
+    return { kind: "details", label: "Details" };
+  }
+
+  if (card.column_id === "in_progress") {
+    if ((card.pending_reviews?.length ?? 0) > 0) {
+      return { kind: "answer_review", label: "Answer" };
+    }
+    if (canResumeRun(card)) {
+      return { kind: "resume", label: "Resume" };
+    }
+    if (card.run_id) {
+      return { kind: "open_run", label: "Open run" };
+    }
+    return { kind: "details", label: "Details" };
+  }
+
+  if (card.failed && canMarkReady(card)) {
+    return { kind: "retry", label: "Retry" };
+  }
+  return { kind: "details", label: "Details" };
+}
+
+/** Secondary actions for the ⋯ menu (excludes the primary kind). */
+export function resolveMenuItems(
+  card: PipelineBoardCard,
+  primary: PrimaryKind,
+): MenuItem[] {
+  const items: MenuItem[] = [];
+  const add = (item: MenuItem) => {
+    if (item.kind === primary) return;
+    if (items.some((i) => i.kind === item.kind)) return;
+    items.push(item);
+  };
+
+  if (card.column_id === "opened") {
+    if (canMarkReady(card) && hasOpenDeps(card)) {
+      add({ kind: "mark_ready", label: "Mark ready (park if deps open)" });
+    }
+    if (canUnmarkReady(card)) {
+      add({ kind: "unmark_ready", label: "Unmark ready" });
+    }
+    if (isTicketEditable(card)) {
+      add({ kind: "edit", label: "Edit" });
+    }
+    if (canDeleteTicket(card)) {
+      add({ kind: "delete", label: "Delete", danger: true });
+    }
+    // "Edit bot" opens the BOT's main.bot in the editor — distinct from
+    // "Edit", which edits this TICKET. Only offered when the card names a
+    // bot; whether that bot is an editable bundle is resolved at render
+    // time against the catalog (a loose .bot has no rel_path).
+    if (card.bot_id) {
+      add({ kind: "edit_bot", label: "Edit bot" });
+    }
+  }
+
+  if (card.column_id === "in_progress") {
+    if (canPauseRun(card)) add({ kind: "pause", label: "Pause" });
+    if (canResumeRun(card)) add({ kind: "resume", label: "Resume" });
+    if (canResetTicket(card)) add({ kind: "reset", label: "Reset", danger: true });
+    if (canStopRun(card)) add({ kind: "stop", label: "Stop", danger: true });
+    if (card.run_id) add({ kind: "open_run", label: "Open run console" });
+  }
+
+  if (card.column_id === "closed") {
+    if (card.failed && canMarkReady(card)) {
+      add({ kind: "retry", label: "Retry" });
+    }
+    if (isTicketEditable(card)) add({ kind: "edit", label: "Edit" });
+    if (card.run_id) add({ kind: "open_run", label: "Open run console" });
+  }
+
+  add({ kind: "details", label: "Details" });
+  add({ kind: "full_page", label: "Open full page" });
+
+  return items;
+}
+
+export function isCardSelectable(card: PipelineBoardCard): boolean {
+  return card.column_id === "opened" && !!card.issue_id && card.kind === "task";
+}

--- a/studio/src/views/PipelineBoard/queueSummary.test.ts
+++ b/studio/src/views/PipelineBoard/queueSummary.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import type { PipelineBoardCard } from "@/api/pipelineBoards";
+
+import { computeQueueSummary, sortLaunchOrder } from "./queueSummary";
+
+function card(partial: Partial<PipelineBoardCard>): PipelineBoardCard {
+  return {
+    id: "c",
+    kind: "task",
+    column_id: "opened",
+    title: "T",
+    executed_nodes: 0,
+    total_nodes: 0,
+    tree_executed_nodes: 0,
+    tree_total_nodes: 0,
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-01T00:00:00Z",
+    ...partial,
+  };
+}
+
+describe("computeQueueSummary", () => {
+  it("counts ready / waiting / draft and picks next by priority then age", () => {
+    const cards = [
+      card({
+        id: "a",
+        issue_id: "i1",
+        ready: true,
+        priority: 1,
+        created_at: "2026-07-01T00:00:00Z",
+        title: "low-old",
+      }),
+      card({
+        id: "b",
+        issue_id: "i2",
+        ready: true,
+        priority: 5,
+        created_at: "2026-07-02T00:00:00Z",
+        title: "high",
+      }),
+      card({
+        id: "c",
+        issue_id: "i3",
+        open_blocker_count: 2,
+        title: "blocked",
+      }),
+      card({ id: "d", issue_id: "i4", title: "draft" }),
+      card({
+        id: "e",
+        column_id: "in_progress",
+        run_id: "r",
+        status: "running",
+      }),
+    ];
+    const s = computeQueueSummary(cards, {
+      enabled: true,
+      max: 3,
+      active: 1,
+      waiting: 0,
+    });
+    expect(s.readyCount).toBe(2);
+    expect(s.waitingDepsCount).toBe(1);
+    expect(s.draftCount).toBe(1);
+    expect(s.slotsFree).toBe(2);
+    expect(s.nextUp?.title).toBe("high");
+  });
+});
+
+describe("sortLaunchOrder", () => {
+  it("priority desc then created_at asc", () => {
+    const got = sortLaunchOrder([
+      card({ id: "old-low", priority: 1, created_at: "2026-07-01T00:00:00Z" }),
+      card({ id: "new-high", priority: 5, created_at: "2026-07-10T00:00:00Z" }),
+      card({ id: "old-mid", priority: 3, created_at: "2026-07-02T00:00:00Z" }),
+      card({ id: "new-mid", priority: 3, created_at: "2026-07-05T00:00:00Z" }),
+    ]);
+    expect(got.map((c) => c.id)).toEqual([
+      "new-high",
+      "old-mid",
+      "new-mid",
+      "old-low",
+    ]);
+  });
+});

--- a/studio/src/views/PipelineBoard/queueSummary.ts
+++ b/studio/src/views/PipelineBoard/queueSummary.ts
@@ -1,0 +1,84 @@
+import type { PipelineBoardCard, PipelineConcurrency } from "@/api/pipelineBoards";
+
+import { cardReady } from "./columnFilters";
+
+export interface QueueSummary {
+  readyCount: number;
+  waitingDepsCount: number;
+  draftCount: number;
+  /** Free concurrency slots; null when cap disabled. */
+  slotsFree: number | null;
+  slotsMax: number | null;
+  slotsActive: number | null;
+  /** Next ticket the admission loop would pick (among ready opened cards). */
+  nextUp: PipelineBoardCard | null;
+}
+
+function hasOpenDeps(card: PipelineBoardCard): boolean {
+  if ((card.open_blocker_count ?? 0) > 0) return true;
+  if (card.issue_state === "waiting_deps") return true;
+  const reason = card.launch_blocked_reason;
+  return (
+    reason === "open_blockers" ||
+    reason === "waiting_deps" ||
+    reason === "blocker_labels"
+  );
+}
+
+/** Same order as server sortReadyTickets: priority desc, then created_at asc. */
+export function sortLaunchOrder(cards: PipelineBoardCard[]): PipelineBoardCard[] {
+  return [...cards].sort((a, b) => {
+    if (a.priority !== b.priority) return (b.priority ?? 0) - (a.priority ?? 0);
+    const ta = Date.parse(a.created_at || "") || 0;
+    const tb = Date.parse(b.created_at || "") || 0;
+    if (ta !== tb) return ta - tb;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+}
+
+export function computeQueueSummary(
+  cards: PipelineBoardCard[],
+  concurrency?: PipelineConcurrency,
+): QueueSummary {
+  let readyCount = 0;
+  let waitingDepsCount = 0;
+  let draftCount = 0;
+  const ready: PipelineBoardCard[] = [];
+
+  for (const card of cards) {
+    if (card.column_id !== "opened") continue;
+    if (cardReady(card)) {
+      readyCount++;
+      ready.push(card);
+      continue;
+    }
+    if (hasOpenDeps(card)) {
+      waitingDepsCount++;
+      continue;
+    }
+    draftCount++;
+  }
+
+  const nextUp = sortLaunchOrder(ready)[0] ?? null;
+
+  let slotsFree: number | null = null;
+  let slotsMax: number | null = null;
+  let slotsActive: number | null = null;
+  if (concurrency?.enabled && concurrency.max > 0) {
+    slotsMax = concurrency.max;
+    slotsActive = concurrency.active;
+    slotsFree = Math.max(0, concurrency.max - concurrency.active);
+  }
+
+  return {
+    readyCount,
+    waitingDepsCount,
+    draftCount,
+    slotsFree,
+    slotsMax,
+    slotsActive,
+    nextUp,
+  };
+}
+
+export { hasOpenDeps };


### PR DESCRIPTION
Follow-ups to the global pipeline board (#193), plus the board-MCP fix that makes planner provenance work at all.

## Board model

- **Three fixed lanes**: **Opened** (drafts + ready staging — readiness is a per-card badge, not a lane), **In progress**, **Closed** (success + failure together). Per-column filters: `All / Ready / Not ready` on Opened, `All / Success / Failed` on Closed.
- **Ticket actions** beyond the ready toggle: delete a not-yet-ready ticket (409 while any run in its tree is active) and reset an in-progress one (cancels the whole run tree through the same seams the run console uses, then restages to Ready).
- **Launch-now drag**, Opened → In progress — the *only* drag on this board. It overrides the launch **order** (ready staging + priority/oldest-first). It does **not** override correctness: an active/finished run, an unfinished hard dependency, or a full concurrency cap each refuse with an explicit 409. Every other card position stays server-derived.
  - The cap refusal is deliberate: launching anyway would have `runview.Service.Launch` park the run as `queued`, so the card would fall back into Opened and the drop would silently lie.
- **Edit bot** opens the card's bot `main.bot` in the editor, resolved from the catalog `rel_path`; withheld when there is no editable bundle to open. Distinct from **Edit**, which edits the ticket.

## Planner provenance

Three independent bugs, each of which alone hid the parent/child relation:

1. **`parent_id` was never stamped over the HTTP transport.** `/api/v1/mcp/board` — the transport **sandboxed** runs use — called `boardops.Call` with no `CallEnv`, unlike the stdio (`__mcp-board`) and in-process (claw) paths. A sandboxed planner therefore published orphan tickets. The owning ticket now rides the token grant. The Valkey store still reads the legacy bare-array payload, so a replica mid-rollout stays compatible.
2. **The client normalizer dropped the fields.** `normalizePipelineBoardCard` is a whitelist and omitted `role`, `children`, `children_summary`, `parent_issue_id`, `parent_title` — the server sent them, the views never saw them.
3. **The campaign hold lied about the parent's lane.** An executed planner was pinned to Opened with `launch_blocked_reason=awaiting_children` until every child closed, contradicting its own finished run. Removed: a parent is an ordinary card and closes with its own run. The relation now shows purely as data — the closed-children counter on the parent, the parent name above each child's title.

## Scope note

The working tree this came from mixes several chantiers. This branch is scoped to the **pipeline board and its unpushed base** (native blockers / ticket contract / board deps, which the board-MCP fix builds on — `boardops.CallEnv` does not exist on `main`). DSL, runtime and subbot work is deliberately excluded.

It also repairs `cmd/iterion/mcp_board_test.go`, which no longer compiled after the `CallEnv` signature change and would have failed `go vet ./...` in CI.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` — clean.
- `go test ./...` — green (the two `pkg/backend/tool` computer-use failures are environmental: those tests assert an error *in a headless env*, and the dev box has X11).
- `vite build` — clean.
- Board test suites: 133 passing across 13 files.

**Draft**: parts of the base come from earlier sessions and warrant a read before this goes ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)