### PR TITLE
fix(studio): human-gate answer surfaces schema-load failures instead of a dead fallback (#244)

### DIFF
--- a/studio/src/components/Runs/conversation/HumanPromptForm.test.tsx
+++ b/studio/src/components/Runs/conversation/HumanPromptForm.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import HumanPromptForm from "./HumanPromptForm";
+
+// useHumanNodeSchema fetches the run workflow via react-query, so every
+// render needs a client. retry:false makes the error path settle on the
+// first rejection instead of retrying.
+function renderWithClient(ui: ReactElement) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+const getRunWorkflow = vi.fn();
+const getRun = vi.fn().mockResolvedValue({});
+const resumeRun = vi.fn().mockResolvedValue({ run_id: "run-1", status: "running" });
+
+vi.mock("@/api/runs", () => ({
+  getRun: (...args: unknown[]) => getRun(...args),
+  getRunWorkflow: (...args: unknown[]) => getRunWorkflow(...args),
+  resumeRun: (...args: unknown[]) => resumeRun(...args),
+}));
+
+vi.mock("@/store/document", () => ({
+  useDocumentStore: (select: (state: { currentSource: string | null }) => unknown) =>
+    select({ currentSource: null }),
+}));
+
+vi.mock("@/store/run", () => ({
+  useRunStore: (select: (state: Record<string, unknown>) => unknown) =>
+    select({
+      setRunStatus: vi.fn(),
+      requestWsReconnect: vi.fn(),
+      applySnapshot: vi.fn(),
+      resyncEventsAfterResume: vi.fn(),
+    }),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("HumanPromptForm — schema fetch failure (iterion#244)", () => {
+  it("surfaces the load error + a Retry instead of silently dropping to a verdict-less fallback", async () => {
+    getRunWorkflow.mockRejectedValue(new Error("load workflow: cannot read file"));
+
+    renderWithClient(
+      <HumanPromptForm
+        runId="run-1"
+        nodeId="style_kit_review"
+        // The node's resolved INPUT lands here; the verdict lives in the
+        // OUTPUT schema, which failed to load. The old behaviour rendered
+        // these input fields (or an empty "Resume" form) — see the bug.
+        questions={{ boards: "candidate boards", detail: "the detail" }}
+        sourceOverride={null}
+      />,
+    );
+
+    // The error is surfaced, naming the cause…
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toMatch(
+        /Couldn't load the answer form/i,
+      ),
+    );
+    // …and a Retry affordance is offered.
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    // The misleading fallback is NOT shown: no empty-questions "Resume"
+    // form, and the raw input fields are not presented as the answer.
+    expect(
+      screen.queryByText(/paused without specific questions/i),
+    ).toBeNull();
+    // No answer ever left the client on this failed load.
+    expect(resumeRun).not.toHaveBeenCalled();
+
+    // Retry re-fetches the schema.
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(getRunWorkflow).toHaveBeenCalledTimes(2));
+  });
+
+  it("still answers the verdict when the schema loads (regression)", async () => {
+    getRunWorkflow.mockResolvedValue({
+      nodes: [
+        {
+          id: "style_kit_review",
+          output_schema: [
+            { name: "approved", type: "bool" },
+            { name: "notes", type: "string" },
+          ],
+        },
+      ],
+      stale_hash: false,
+    });
+
+    renderWithClient(
+      <HumanPromptForm
+        runId="run-1"
+        nodeId="style_kit_review"
+        questions={{}}
+        sourceOverride={null}
+      />,
+    );
+
+    const reject = await waitFor(() =>
+      screen.getByRole("button", { name: "Reject" }),
+    );
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "spacing is off" },
+    });
+    fireEvent.click(reject);
+
+    await waitFor(() =>
+      expect(resumeRun).toHaveBeenCalledWith(
+        "run-1",
+        expect.objectContaining({
+          answers: { approved: false, notes: "spacing is off" },
+        }),
+      ),
+    );
+  });
+});

--- a/studio/src/components/Runs/conversation/HumanPromptForm.tsx
+++ b/studio/src/components/Runs/conversation/HumanPromptForm.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/Button";
 import { WizardForm } from "@/components/ui/WizardForm";
 import { useHumanNodeSchema } from "@/hooks/useHumanNodeSchema";
 import { ASK_USER_RESPONSE_KEY } from "@/lib/askUserOptions";
-import type { FormAnswer } from "@/lib/whats-next/questionForm";
+import type { FormAnswer, FormSpec } from "@/lib/whats-next/questionForm";
 import {
   coerceFormAnswerToSchema,
   formSpecFromSchema,
@@ -67,11 +67,25 @@ export default function HumanPromptForm({
   const resolvedSource =
     (sourceOverride !== undefined ? sourceOverride : currentSource) ?? undefined;
 
-  const { fields, loading, staleHash } = useHumanNodeSchema(runId, nodeId);
+  const {
+    fields,
+    loading,
+    staleHash,
+    error: schemaError,
+    reload: reloadSchema,
+  } = useHumanNodeSchema(runId, nodeId);
 
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(false);
+  // Answers of the last rejected attempt when the server refused the
+  // resume because the workflow source changed since the run started.
+  // Non-null renders a one-click "force" retry that replays them with
+  // force: true — without it the operator's answer is silently lost
+  // with no recourse but the CLI.
+  const [forceRetry, setForceRetry] = useState<Record<string, unknown> | null>(
+    null,
+  );
   // The latest form draft is captured here so the quick-action
   // Approve/Reject and skip/idk buttons can submit alongside the
   // current text. WizardForm emits FormAnswer atomically; we also
@@ -84,7 +98,6 @@ export default function HumanPromptForm({
   const snapshotTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     setSubmitted(false);
-    setLatestAnswer({});
     setError(null);
   }, [nodeId]);
   useEffect(() => {
@@ -131,15 +144,25 @@ export default function HumanPromptForm({
     });
   }, [fields, questions]);
 
+  useEffect(() => {
+    if (!formSpec) {
+      setLatestAnswer({});
+      return;
+    }
+    setLatestAnswer(defaultAnswerForSpec(formSpec));
+  }, [nodeId, formSpec]);
+
   if (submitted) return null;
 
-  const submit = async (answers: Record<string, unknown>) => {
+  const submit = async (answers: Record<string, unknown>, force = false) => {
     setBusy(true);
     setError(null);
+    setForceRetry(null);
     try {
       await resumeRun(runId, {
         answers,
         source: resolvedSource,
+        ...(force ? { force: true } : {}),
       });
       setSubmitted(true);
       // A board caller isn't viewing this run's canvas — skip the
@@ -174,7 +197,9 @@ export default function HumanPromptForm({
           .catch(() => {});
       }, 600);
     } catch (e) {
-      setError(errorMessage(e));
+      const msg = errorMessage(e);
+      setError(msg);
+      if (/source has changed/i.test(msg)) setForceRetry(answers);
     } finally {
       setBusy(false);
     }
@@ -187,8 +212,16 @@ export default function HumanPromptForm({
   // rendering would show the wrong form. Route straight to the
   // questions-driven PauseForm.
   const isAskUserPause = ASK_USER_RESPONSE_KEY in (questions ?? {});
+  // The output-schema fetch FAILED (not merely "no schema"). We must NOT
+  // silently drop into the PauseForm fallback: that form renders the
+  // node's INPUT questions with no verdict/notes controls, so the
+  // operator can neither approve/reject nor record notes — they hit
+  // "Resume" (empty answers), the run re-pauses, and the typed feedback
+  // is gone. Surface the error + a Retry instead (iterion#244).
+  const schemaFailed = !isAskUserPause && !loading && !!schemaError;
   const useFallback =
-    isAskUserPause || (!loading && (fields === null || fields.length === 0));
+    isAskUserPause ||
+    (!loading && !schemaError && (fields === null || fields.length === 0));
   const approveField = fields?.find(
     (f) => f.type === "bool" && f.name === "approved",
   );
@@ -209,9 +242,13 @@ export default function HumanPromptForm({
 
   const submitWithVerdict = (value: boolean | string) => {
     if (!fields || !verdictField) return;
+    const answerWithDefaults = {
+      ...defaultAnswerForSpec(formSpec),
+      ...latestAnswer,
+    };
     const { answers, errors } = coerceFormAnswerToSchema(
       visibleFields,
-      latestAnswer,
+      answerWithDefaults,
     );
     if (Object.keys(errors).length > 0) {
       setError("Fix invalid fields: " + Object.keys(errors).join(", "));
@@ -261,11 +298,29 @@ export default function HumanPromptForm({
       {staleHash && (
         <div className="text-caption text-warning-fg" role="status">
           The workflow source changed since this run started. Submit will still
-          try — pass <code>--force</code> later if it rejects.
+          try — if the server rejects it, a force-retry button will appear.
         </div>
       )}
       {loading && !isAskUserPause ? (
         <p className="text-micro text-fg-subtle">Loading question form…</p>
+      ) : schemaFailed ? (
+        <div className="space-y-2">
+          <p className="text-danger-fg text-micro" role="alert">
+            Couldn't load the answer form for this gate: {schemaError}
+          </p>
+          <p className="text-micro text-fg-subtle">
+            The run is still paused — your answer wasn't lost. Retry, or open
+            the run console to answer it there.
+          </p>
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={loading}
+            onClick={() => reloadSchema()}
+          >
+            Retry
+          </Button>
+        </div>
       ) : useFallback ? (
         <PauseForm
           runId={runId}
@@ -282,6 +337,7 @@ export default function HumanPromptForm({
           {formSpec && (
             <WizardForm
               spec={formSpec}
+              mode={formSpec.mode}
               busy={busy}
               hideSubmit={!!verdictField}
               onAnswerChange={setLatestAnswer}
@@ -295,6 +351,21 @@ export default function HumanPromptForm({
             <p className="text-danger-fg text-micro" role="alert">
               {error}
             </p>
+          )}
+          {forceRetry && (
+            <div className="flex items-center gap-2">
+              <Button
+                variant="primary"
+                size="sm"
+                disabled={busy}
+                onClick={() => void submit(forceRetry, true)}
+              >
+                Resume with updated workflow (force)
+              </Button>
+              <span className="text-micro text-fg-subtle">
+                Replays your answer against the current workflow source.
+              </span>
+            </div>
           )}
           {approveField && (
             <div className="flex items-center gap-2 pt-2 border-t border-border-subtle">
@@ -351,6 +422,20 @@ export default function HumanPromptForm({
         </>
       )}
     </div>
+  );
+}
+
+function defaultAnswerForSpec(spec: FormSpec | null): FormAnswer {
+  if (!spec) return {};
+  return Object.fromEntries(
+    spec.questions.map((question) => [
+      question.id,
+      question.kind === "checkbox"
+        ? [...(question.defaultValues ?? [])]
+        : "defaultValue" in question
+          ? question.defaultValue ?? ""
+          : "",
+    ]),
   );
 }
 

--- a/studio/src/components/ui/WizardForm.tsx
+++ b/studio/src/components/ui/WizardForm.tsx
@@ -58,22 +58,27 @@ export function WizardForm({
     setVisited(new Set([0]));
   }, [initial]);
 
+  // Publish the current answers to the parent AFTER commit — never from
+  // inside a setState updater (that runs during render and triggers
+  // React's "Cannot update a component while rendering a different
+  // component" warning, which can drop the update). Verdict buttons live
+  // outside the wizard in schema-driven human gates and read this via
+  // onAnswerChange; firing on mount also publishes the defaults so
+  // clicking a verdict without first toggling a preselected field still
+  // submits the visible selection.
+  useEffect(() => {
+    onAnswerChange?.(answers);
+  }, [answers, onAnswerChange]);
+
   const total = spec.questions.length;
   const useWizard =
     mode === "wizard" || (mode === "auto" && total >= 2);
   const single = total === 1;
   const submitLabel = spec.submitLabel ?? "Send";
 
-  const setOne = useCallback(
-    (id: string, value: string | string[]) => {
-      setAnswers((prev) => {
-        const next = { ...prev, [id]: value };
-        if (onAnswerChange) onAnswerChange(next);
-        return next;
-      });
-    },
-    [onAnswerChange],
-  );
+  const setOne = useCallback((id: string, value: string | string[]) => {
+    setAnswers((prev) => ({ ...prev, [id]: value }));
+  }, []);
 
   const submit = () => {
     if (busy || !isFormValid(spec, answers)) return;

--- a/studio/src/hooks/useHumanNodeSchema.ts
+++ b/studio/src/hooks/useHumanNodeSchema.ts
@@ -10,17 +10,29 @@ interface State {
   error: string | null;
 }
 
+export interface HumanNodeSchema extends State {
+  // reload re-fetches the run workflow — the "Retry" affordance when the
+  // first fetch failed (see HumanPromptForm). Backed by react-query's
+  // refetch, so it re-runs the query and repopulates the shared cache.
+  reload: () => void;
+}
+
 const initial: State = { fields: null, loading: false, staleHash: false, error: null };
 
 // useHumanNodeSchema returns the output_schema fields for the paused
-// human node. Callers MUST distinguish loading=true (don't render the
-// form yet) from loading=false && fields===null (no schema, fall back
-// to free-text PauseForm). Conflating them ships the fallback during
-// the brief fetch window and turns typed answers into strings.
+// human node. Callers MUST distinguish three outcomes, never conflate
+// them:
+//   - loading=true                      → don't render the form yet
+//   - loading=false && error!=null      → the fetch FAILED; surface it
+//     and offer reload() — do NOT silently fall back (a fallback form
+//     that can't express the gate's verdict strands the operator and
+//     drops their notes; iterion#244)
+//   - loading=false && error==null && fields empty → the node genuinely
+//     has no output schema → free-text PauseForm fallback is correct
 export function useHumanNodeSchema(
   runId: string | null,
   nodeId: string | undefined,
-): State {
+): HumanNodeSchema {
   const enabled = !!runId && !!nodeId;
   const query = useQuery<WireWorkflow>({
     // Shares the run console's workflow cache (useNodeLabel,
@@ -33,14 +45,24 @@ export function useHumanNodeSchema(
     staleTime: Infinity,
   });
 
-  if (!enabled) return initial;
+  const reload = () => {
+    void query.refetch();
+  };
+
+  if (!enabled) return { ...initial, reload };
   // isPending (not isLoading): whenever we have neither data nor a
   // settled error, report loading — never the "no schema" fallback.
   if (query.isPending && !query.error) {
-    return { fields: null, loading: true, staleHash: false, error: null };
+    return { fields: null, loading: true, staleHash: false, error: null, reload };
   }
   if (query.error) {
-    return { fields: null, loading: false, staleHash: false, error: errorMessage(query.error) };
+    return {
+      fields: null,
+      loading: false,
+      staleHash: false,
+      error: errorMessage(query.error),
+      reload,
+    };
   }
   const wf = query.data;
   const node = wf?.nodes.find((n) => n.id === nodeId);
@@ -49,5 +71,6 @@ export function useHumanNodeSchema(
     loading: false,
     staleHash: !!wf?.stale_hash,
     error: null,
+    reload,
   };
 }


### PR DESCRIPTION
Fixes #244.

## What was wrong

Answering a paused `human` node from the studio (pipeline-board card *or* run console) could silently do nothing: no response recorded, the node stays `paused_waiting_human`, and the reviewer's typed notes are lost — with no error surfaced.

I reproduced the whole path end-to-end in a real browser (Playwright against the built SPA driving the pipeline board). The backend `/api/runs/{id}/resume` + the `pending_reviews` projection + the board→`HumanPromptForm`→`resumeRun` wiring are all correct; the failure is a **frontend robustness hole**.

## Root cause

1. **Silent, unrecoverable fallback when the output-schema fetch fails.** `HumanPromptForm` loads the human node's OUTPUT schema via `GET /api/runs/{id}/workflow` to render the verdict form (Approve/Reject + notes). It destructured the hook result but **ignored its `error`**. On any fetch failure (the run's worktree missing the source, a bundle path, a transient error) `fields` is `null`, so the form silently dropped into `PauseForm` — which renders the node's **INPUT** questions with *no* verdict/notes controls. The operator can only click "Resume" (empty answers) → the run re-pauses → the notes are gone, and nothing tells them why.

2. **React `setState`-in-render.** `WizardForm.setOne` called the parent's `onAnswerChange` from *inside* a `setState` updater (runs during render), tripping `Cannot update a component (HumanPromptForm) while rendering a different component (WizardForm)` — which can drop the published draft.

## The fix

- `useHumanNodeSchema` now exposes `error` + a stable `reload()`, and its contract names the three distinct outcomes: **loading** / **fetch-failed** / **genuinely-no-schema**.
- `HumanPromptForm` renders a clear error + **Retry** when the schema fetch *failed*, and only uses the free-text `PauseForm` fallback when the node *genuinely* has no output schema. The run stays paused and **no answer is sent on a failed load** — the operator isn't stranded and their intent isn't silently mis-submitted.
- `WizardForm` publishes answers from a post-commit `useEffect`, never from inside a `setState` updater.
- Carries the stale-source **force-retry** affordance (a resume rejected with `source has changed` now offers a one-click force replay) so a bot edited since launch can still be answered from the card.

## Tests

- New `HumanPromptForm.test.tsx`: the schema-failure branch (error + Retry shown, misleading fallback **not** shown, nothing sent) and a verdict regression (schema loads → Reject → `resumeRun` with `{approved:false, notes}`).
- Existing `PauseTab` / `SequentialReviews` / `LastRunSection` suites still green.

### Verified live (Playwright)
- Happy path: Reject → `POST /resume {"answers":{"notes":…,"approved":false}}` → 202; the React warning is gone.
- Failure path: `/workflow` 404 → "Couldn't load the answer form…" + Retry; no Reject button, no misleading "paused without specific questions" form, no request sent; Retry re-fetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)