### PR TITLE
fix(ci): green main — pin async-questions backend + kill webpush Deliver data race

### DIFF
--- a/examples/async-questions/main.bot
+++ b/examples/async-questions/main.bot
@@ -57,7 +57,13 @@ prompt finalize_user:
   Operator answers:
   {{outputs.gate.answers}}
 
+## ask_user_async / await_answers are claw-native tools, so the async
+## drafting agent runs on claw. Pinning backend+model also keeps the bot
+## in the CI compile floor (TestCatalogBotsParseAndCompileClean), which
+## compiles with no credentials to auto-detect.
 agent draft:
+  backend: "claw"
+  model: "anthropic/claude-sonnet-4-6"
   interaction: async
   system: draft_sys
   user: draft_user
@@ -71,6 +77,8 @@ await_answers gate:
   timeout: "30m"
 
 agent finalize:
+  backend: "claw"
+  model: "anthropic/claude-sonnet-4-6"
   system: finalize_sys
   user: finalize_user
   output: final_out

--- a/pkg/usernotify/webpush/sink.go
+++ b/pkg/usernotify/webpush/sink.go
@@ -115,7 +115,15 @@ func (s *Sink) Deliver(ctx context.Context, n usernotify.Notification) error {
 }
 
 func (s *Sink) push(ctx context.Context, body []byte, sub *Subscription) error {
-	resp, err := wp.SendNotificationWithContext(ctx, body, &wp.Subscription{
+	// webpush-go wraps the message with bytes.NewBuffer (no copy) and then
+	// appends a padding delimiter into it, mutating the slice's backing
+	// array in place. Deliver fans the SAME body slice out to every
+	// concurrent push goroutine, so without a per-call copy those in-place
+	// writes race on the shared array (caught by -race in
+	// TestSinkDeliverAndPrune). Give each send its own copy.
+	msg := make([]byte, len(body))
+	copy(msg, body)
+	resp, err := wp.SendNotificationWithContext(ctx, msg, &wp.Subscription{
 		Endpoint: sub.Endpoint,
 		Keys:     wp.Keys{P256dh: sub.P256dh, Auth: sub.Auth},
 	}, &wp.Options{


### PR DESCRIPTION
`main` is currently **red** on the required `test` and `race` checks (verified on tip `e90b0e96`), which blocks every open PR through the merge queue. Two independent, pre-existing defects — both reproduced locally and fixed here.

## 1. `TestCatalogBotsParseAndCompileClean` — `test` + `race`

The ADR-081 merge added `examples/async-questions/main.bot`, whose `draft`/`finalize` agents declare no `model`/`backend`. The catalog compile-floor test runs a pure `ir.Compile` with **no credentials to auto-detect**, so `C018` fires ("agent must set 'model' or 'backend'").

`ask_user_async` / `await_answers` are **claw-native** tools (`pkg/backend/tool/claw_async_ask.go`), so the async agent belongs on claw. Pinned `backend: "claw"` + a model on both agents — matching the convention in `clarify` / `deploy-e2e` / `review-merge-gate`.

## 2. `TestSinkDeliverAndPrune` — `race` (DATA RACE)

`Sink.Deliver` fans the **same** `body []byte` out to every concurrent `push` goroutine. webpush-go's `SendNotificationWithContext` does `bytes.NewBuffer(body)` (no copy) then appends a padding delimiter into it — an **in-place write to the shared backing array** — so concurrent sends race on it (the race detector flags two goroutines writing the same address).

Fix: copy the body per `push` call so each send owns its buffer.

## Verification (Go 1.26, `-mod=vendor`)
- `go test ./bots/ -run TestCatalogBotsParseAndCompileClean` → ok
- `go test ./pkg/usernotify/webpush/ -race -count=10` → ok
- `gofmt -l` clean, `go vet` clean

Unblocks #245 (and every other open PR) once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)