### PR TITLE
feat(budget): warn_tokens — advisory token threshold that warns without blocking

### DIFF
--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -437,6 +437,7 @@ workflow review:
     max_duration: "30m"
     max_cost_usd: 10
     max_tokens: 400000
+    warn_tokens: 300000
     max_iterations: 100
 
   resources:
@@ -486,7 +487,7 @@ Terminal targets `done` and `fail` are reserved and are never declared.
 - `sandbox: auto` resolves a devcontainer/default image. Block form supports image/build, user/workspace, host-state, environment, mounts, post-create, and network policy; see [sandbox](sandbox.md).
 - `permission: off|ask|deny` plus allow/ask/deny rules creates an execution-time tool gate. CLI overrides are available; see [permissions](permissions.md).
 - `compress: off|on|ultra` controls output compression where supported; see [ultracode](ultracode.md).
-- Workflow budgets are shared across branches in that run. Hitting cost, token, duration, parallelism, or iteration limits emits budget events and stops/parks according to the failure path. Nested subbot runs retain their own budgets.
+- Workflow budgets are shared across branches in that run. Hitting cost, token, duration, parallelism, or iteration limits emits budget events and stops/parks according to the failure path. Nested subbot runs retain their own budgets. `warn_tokens` is the advisory exception: crossing it emits a single `budget_warning` event (`advisory: true`) suggesting an audit of what consumed the tokens, and execution continues — use it instead of `max_tokens` when heavy consumption is legitimate (judge/rewrite loops going to their bounds) but worth an operator's look.
 - `resources` are named semaphores. Integer values declare capacities; string arrays declare leaseable named members exposed to nodes that list the resource in `needs:`.
 
 ## Validation and references

--- a/openapi.json
+++ b/openapi.json
@@ -1049,6 +1049,9 @@
           },
           "max_tokens": {
             "type": "integer"
+          },
+          "warn_tokens": {
+            "type": "integer"
           }
         },
         "type": "object"

--- a/pkg/alert/alert.go
+++ b/pkg/alert/alert.go
@@ -31,7 +31,8 @@ const (
 	// persisted timeline shows both edges.
 	KindStallRecovered Kind = "stall_recovered"
 	// KindBudgetWarning fires the first time a budget axis crosses the
-	// runtime warning threshold (80%).
+	// runtime warning threshold (80%) or an advisory warn threshold
+	// (e.g. warn_tokens), which reports without ever blocking.
 	KindBudgetWarning Kind = "budget_warning"
 	// KindBudgetExceeded fires when a budget axis hits its hard cap.
 	KindBudgetExceeded Kind = "budget_exceeded"

--- a/pkg/alert/manager.go
+++ b/pkg/alert/manager.go
@@ -319,9 +319,14 @@ func (m *Manager) budgetAlertLocked(kind Kind, rs *runState, evt store.Event, ax
 		pct = used / limit * 100
 	}
 	var reason string
-	if kind == KindBudgetExceeded {
+	switch {
+	case kind == KindBudgetExceeded:
 		reason = fmt.Sprintf("%s budget exhausted (%.0f/%.0f)", axis, used, limit)
-	} else {
+	case boolData(evt.Data, "advisory"):
+		// warn_tokens-style advisory: consumption is unusual, nothing was
+		// blocked — suggest a look rather than announce a ceiling.
+		reason = fmt.Sprintf("%s crossed the advisory threshold (%.0f/%.0f) — worth auditing what consumed so much", axis, used, limit)
+	default:
 		reason = fmt.Sprintf("%s budget at %.0f%% (%.0f/%.0f)", axis, pct, used, limit)
 	}
 	return m.alertLocked(kind, rs, evt.NodeID, reason, axis, pct, ts)
@@ -406,6 +411,14 @@ func (m *Manager) dispatch(sinks []Sink, alerts []Alert) {
 			}()
 		}
 	}
+}
+
+func boolData(d map[string]any, key string) bool {
+	if d == nil {
+		return false
+	}
+	v, _ := d[key].(bool)
+	return v
 }
 
 func strData(d map[string]any, key string) string {

--- a/pkg/dsl/ast/ast.go
+++ b/pkg/dsl/ast/ast.go
@@ -752,6 +752,7 @@ type BudgetBlock struct {
 	MaxDuration         string  // e.g. "60m", empty = not set
 	MaxCostUSD          float64 // 0 = not set
 	MaxTokens           int     // 0 = not set
+	WarnTokens          int     // advisory-only token threshold (0 = not set): warns, never blocks
 	MaxIterations       int     // 0 = not set
 	Span                Span
 }

--- a/pkg/dsl/ast/jsonenc.go
+++ b/pkg/dsl/ast/jsonenc.go
@@ -642,6 +642,7 @@ type jsonBudgetBlock struct {
 	MaxDuration         string  `json:"max_duration,omitempty"`
 	MaxCostUSD          float64 `json:"max_cost_usd,omitempty"`
 	MaxTokens           int     `json:"max_tokens,omitempty"`
+	WarnTokens          int     `json:"warn_tokens,omitempty"`
 	MaxIterations       int     `json:"max_iterations,omitempty"`
 }
 
@@ -1213,6 +1214,7 @@ func workflowToJSON(w *WorkflowDecl) *jsonWorkflowDecl {
 			MaxDuration:         w.Budget.MaxDuration,
 			MaxCostUSD:          w.Budget.MaxCostUSD,
 			MaxTokens:           w.Budget.MaxTokens,
+			WarnTokens:          w.Budget.WarnTokens,
 			MaxIterations:       w.Budget.MaxIterations,
 		}
 	}
@@ -1799,6 +1801,7 @@ func workflowFromJSON(jw *jsonWorkflowDecl) (*WorkflowDecl, error) {
 			MaxDuration:         jw.Budget.MaxDuration,
 			MaxCostUSD:          jw.Budget.MaxCostUSD,
 			MaxTokens:           jw.Budget.MaxTokens,
+			WarnTokens:          jw.Budget.WarnTokens,
 			MaxIterations:       jw.Budget.MaxIterations,
 		}
 	}

--- a/pkg/dsl/ir/compile.go
+++ b/pkg/dsl/ir/compile.go
@@ -1807,6 +1807,7 @@ func (c *compiler) compileBudget(b *ast.BudgetBlock) *Budget {
 		MaxDuration:         b.MaxDuration,
 		MaxCostUSD:          cost,
 		MaxTokens:           b.MaxTokens,
+		WarnTokens:          b.WarnTokens,
 		MaxIterations:       b.MaxIterations,
 	}
 }

--- a/pkg/dsl/ir/ir.go
+++ b/pkg/dsl/ir/ir.go
@@ -1261,7 +1261,10 @@ type Budget struct {
 	MaxDuration         string // e.g. "60m"
 	MaxCostUSD          float64
 	MaxTokens           int
-	MaxIterations       int
+	// WarnTokens is advisory-only: crossing it emits a budget_warning
+	// (advisory) but never blocks execution. 0 = disabled.
+	WarnTokens    int
+	MaxIterations int
 }
 
 // ClampToCeiling lowers each numeric limit so it never EXCEEDS the

--- a/pkg/dsl/parser/parser_helpers.go
+++ b/pkg/dsl/parser/parser_helpers.go
@@ -253,7 +253,7 @@ func isKeywordToken(tt TokenType) bool {
 		TokenTypeString, TokenTypeBool, TokenTypeInt, TokenTypeFloat,
 		TokenTypeJSON, TokenTypeStringArray,
 		TokenMaxParallelBranches, TokenMaxDuration, TokenMaxCostUSD,
-		TokenMaxTokens, TokenMaxIterations,
+		TokenMaxTokens, TokenMaxIterations, TokenWarnTokens,
 		TokenCompaction, TokenThreshold, TokenPreserveRecent,
 		TokenMemory, TokenEnabled, TokenScope, TokenAutoload, TokenRead, TokenWrite, TokenPreCompactInject,
 		TokenWorktree,

--- a/pkg/dsl/parser/parser_test.go
+++ b/pkg/dsl/parser/parser_test.go
@@ -852,6 +852,7 @@ func TestBudgetBlock(t *testing.T) {
     max_duration: "60m"
     max_cost_usd: 30.5
     max_tokens: 400000
+    warn_tokens: 250000
     max_iterations: 10
   a -> done
 `
@@ -866,6 +867,7 @@ func TestBudgetBlock(t *testing.T) {
 	assertEq(t, "MaxDuration", b.MaxDuration, "60m")
 	assertEq(t, "MaxCostUSD", b.MaxCostUSD, 30.5)
 	assertEq(t, "MaxTokens", b.MaxTokens, 400000)
+	assertEq(t, "WarnTokens", b.WarnTokens, 250000)
 	assertEq(t, "MaxIterations", b.MaxIterations, 10)
 }
 

--- a/pkg/dsl/parser/parser_workflow.go
+++ b/pkg/dsl/parser/parser_workflow.go
@@ -183,6 +183,9 @@ func (p *parser) parseBudgetProp(bb *ast.BudgetBlock, propTok Token) {
 	case TokenMaxTokens:
 		p.expect(TokenColon)
 		bb.MaxTokens = p.expectInt()
+	case TokenWarnTokens:
+		p.expect(TokenColon)
+		bb.WarnTokens = p.expectInt()
 	case TokenMaxIterations:
 		p.expect(TokenColon)
 		bb.MaxIterations = p.expectInt()

--- a/pkg/dsl/parser/token.go
+++ b/pkg/dsl/parser/token.go
@@ -144,6 +144,7 @@ const (
 	TokenMaxCostUSD
 	TokenMaxTokens
 	TokenMaxIterations
+	TokenWarnTokens
 	// Compaction block + properties
 	TokenCompaction
 	TokenThreshold
@@ -311,6 +312,7 @@ var tokenNames = map[TokenType]string{
 	TokenMaxCostUSD:          "max_cost_usd",
 	TokenMaxTokens:           "max_tokens",
 	TokenMaxIterations:       "max_iterations",
+	TokenWarnTokens:          "warn_tokens",
 
 	TokenCompaction:       "compaction",
 	TokenThreshold:        "threshold",
@@ -451,6 +453,7 @@ var keywords = map[string]TokenType{
 	"max_cost_usd":          TokenMaxCostUSD,
 	"max_tokens":            TokenMaxTokens,
 	"max_iterations":        TokenMaxIterations,
+	"warn_tokens":           TokenWarnTokens,
 	"compaction":            TokenCompaction,
 	"threshold":             TokenThreshold,
 	"preserve_recent":       TokenPreserveRecent,

--- a/pkg/dsl/unparse/unparse.go
+++ b/pkg/dsl/unparse/unparse.go
@@ -1246,6 +1246,9 @@ func writeBudget(b *strings.Builder, budget *ast.BudgetBlock) {
 	if budget.MaxTokens > 0 {
 		fmt.Fprintf(b, "    max_tokens: %d\n", budget.MaxTokens)
 	}
+	if budget.WarnTokens > 0 {
+		fmt.Fprintf(b, "    warn_tokens: %d\n", budget.WarnTokens)
+	}
 	if budget.MaxIterations > 0 {
 		fmt.Fprintf(b, "    max_iterations: %d\n", budget.MaxIterations)
 	}

--- a/pkg/dsl/unparse/unparse_test.go
+++ b/pkg/dsl/unparse/unparse_test.go
@@ -140,6 +140,7 @@ func TestUnparseBasic(t *testing.T) {
 					MaxDuration:         "30m",
 					MaxCostUSD:          15,
 					MaxTokens:           400000,
+					WarnTokens:          250000,
 					MaxIterations:       10,
 				},
 				Edges: []*ast.Edge{
@@ -201,7 +202,7 @@ func TestUnparseBasic(t *testing.T) {
 		"workflow my_workflow:",
 		"  vars:\n    branch: string\n    ci_command: string = \"make test\"",
 		"  entry: my_agent",
-		"  budget:\n    max_parallel_branches: 1\n    max_duration: \"30m\"\n    max_cost_usd: 15\n    max_tokens: 400000\n    max_iterations: 10",
+		"  budget:\n    max_parallel_branches: 1\n    max_duration: \"30m\"\n    max_cost_usd: 15\n    max_tokens: 400000\n    warn_tokens: 250000\n    max_iterations: 10",
 		"my_agent -> plan_fix with {",
 		"diagnosis: \"{{outputs.diagnose}}\"",
 		"plan_fix -> act_fix",

--- a/pkg/runtime/branch.go
+++ b/pkg/runtime/branch.go
@@ -315,6 +315,7 @@ func (e *Engine) recordBranchUsage(ctx context.Context, rs *runState, runID, bra
 	for _, w := range findWarnings(checks) {
 		if err := e.emitBranch(ctx, runID, branchID, store.EventBudgetWarning, currentNodeID, map[string]any{
 			"dimension": w.dimension,
+			"advisory":  w.advisory,
 			"used":      w.used,
 			"limit":     w.limit,
 		}); err != nil {

--- a/pkg/runtime/budget.go
+++ b/pkg/runtime/budget.go
@@ -30,6 +30,9 @@ type SharedBudget struct {
 	maxCostUSD    float64
 	maxIterations int
 	maxDuration   time.Duration
+	// warnTokens is advisory-only: crossing it emits a single
+	// budget_warning (advisory=true) but never hard-limits the run.
+	warnTokens int
 
 	// Consumed.
 	tokensUsed     int
@@ -70,14 +73,17 @@ func newSharedBudget(b *ir.Budget, logger *iterlog.Logger) *SharedBudget {
 		}
 	}
 
-	// If no limits are set beyond MaxParallelBranches (handled elsewhere), skip.
-	if b.MaxTokens == 0 && b.MaxCostUSD == 0 && b.MaxIterations == 0 && maxDur == 0 {
+	// If no limits are set beyond MaxParallelBranches (handled elsewhere),
+	// skip. A warn-only threshold still needs the tracker: it never blocks,
+	// but consumption must be counted for the advisory to fire.
+	if b.MaxTokens == 0 && b.MaxCostUSD == 0 && b.MaxIterations == 0 && maxDur == 0 && b.WarnTokens == 0 {
 		return nil
 	}
 
 	return &SharedBudget{
 		logger:          logger,
 		maxTokens:       b.MaxTokens,
+		warnTokens:      b.WarnTokens,
 		maxCostUSD:      b.MaxCostUSD,
 		maxIterations:   b.MaxIterations,
 		maxDuration:     maxDur,
@@ -193,6 +199,7 @@ type budgetCheckResult struct {
 	exceeded    bool
 	hardLimited bool // true when 90% <= ratio < 100%
 	warning     bool
+	advisory    bool   // warning came from a warn-only threshold (warn_tokens)
 	dimension   string // "tokens", "cost_usd", "iterations", "duration"
 	used        float64
 	limit       float64
@@ -304,6 +311,18 @@ func (b *SharedBudget) checkLocked() []budgetCheckResult {
 	check("cost_usd", b.costUsed, b.maxCostUSD)
 	check("duration", float64(time.Since(b.startedAt)), float64(b.maxDuration))
 
+	// The advisory token threshold reports once on the tokens axis and
+	// never blocks: the operator asked to be told (audit hint), not
+	// stopped. It shares the axis dedupe with the ratio warning above so
+	// a run surfaces at most one tokens warning.
+	if b.warnTokens > 0 && b.tokensUsed >= b.warnTokens && !b.warningsEmitted["tokens"] {
+		b.warningsEmitted["tokens"] = true
+		results = append(results, budgetCheckResult{
+			warning: true, advisory: true, dimension: "tokens",
+			used: float64(b.tokensUsed), limit: float64(b.warnTokens),
+		})
+	}
+
 	return results
 }
 
@@ -412,6 +431,7 @@ func (e *Engine) recordAndCheckBudget(rs *runState, nodeID string, output map[st
 	for _, w := range findWarnings(checks) {
 		_ = e.emit(rs.ctx, rs.runID, store.EventBudgetWarning, nodeID, map[string]any{
 			"dimension": w.dimension,
+			"advisory":  w.advisory,
 			"used":      w.used,
 			"limit":     w.limit,
 		})

--- a/pkg/runtime/budget_persist.go
+++ b/pkg/runtime/budget_persist.go
@@ -26,6 +26,7 @@ func snapshotBudgetForPersist(b *ir.Budget) *store.RunBudget {
 	return &store.RunBudget{
 		MaxCostUSD:          b.MaxCostUSD,
 		MaxTokens:           b.MaxTokens,
+		WarnTokens:          b.WarnTokens,
 		MaxIterations:       b.MaxIterations,
 		MaxDuration:         ir.ExpandEnvWithDefault(b.MaxDuration),
 		MaxParallelBranches: b.MaxParallelBranches,

--- a/pkg/runtime/budget_test.go
+++ b/pkg/runtime/budget_test.go
@@ -245,6 +245,71 @@ func TestBudgetTokensExceeded(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Test: warn_tokens advisory — warns once, never blocks
+// ---------------------------------------------------------------------------
+
+func TestWarnTokensAdvisoryNeverBlocks(t *testing.T) {
+	wf := &ir.Workflow{
+		Name:  "warn_tokens_test",
+		Entry: "a",
+		Nodes: map[string]ir.Node{
+			"a":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}},
+			"b":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "b"}},
+			"c":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "c"}},
+			"done": &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+			"fail": &ir.FailNode{BaseNode: ir.BaseNode{ID: "fail"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "a", To: "b"},
+			{From: "b", To: "c"},
+			{From: "c", To: "done"},
+		},
+		Schemas: map[string]*ir.Schema{},
+		Prompts: map[string]*ir.Prompt{},
+		Vars:    map[string]*ir.Var{},
+		Loops:   map[string]*ir.Loop{},
+		// Advisory-only budget: no hard cap. 3 nodes × 60 tokens cross the
+		// 100-token warn threshold on the second node.
+		Budget: &ir.Budget{WarnTokens: 100},
+	}
+
+	exec := newStubExecutor()
+	for _, id := range []string{"a", "b", "c"} {
+		exec.on(id, func(_ map[string]any) (map[string]any, error) {
+			return map[string]any{"ok": true, "_tokens": 60}, nil
+		})
+	}
+
+	s := tmpStore(t)
+	eng := New(wf, s, exec)
+
+	// The whole point: crossing the advisory threshold must not fail the run.
+	if err := eng.Run(context.Background(), "run-warn-tokens", nil); err != nil {
+		t.Fatalf("advisory threshold must never block, got: %v", err)
+	}
+
+	events, err := s.LoadEvents(context.Background(), "run-warn-tokens")
+	if err != nil {
+		t.Fatalf("load events: %v", err)
+	}
+	warnings := 0
+	for _, evt := range events {
+		if evt.Type == store.EventBudgetExceeded {
+			t.Errorf("unexpected budget_exceeded event: %v", evt.Data)
+		}
+		if evt.Type == store.EventBudgetWarning && evt.Data["dimension"] == "tokens" {
+			warnings++
+			if adv, _ := evt.Data["advisory"].(bool); !adv {
+				t.Errorf("expected advisory=true on warn_tokens warning, got %v", evt.Data)
+			}
+		}
+	}
+	if warnings != 1 {
+		t.Errorf("expected exactly 1 advisory warning (deduped), got %d", warnings)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Test: cost-based budget exceeded
 // ---------------------------------------------------------------------------
 

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -120,6 +120,7 @@ type RunModelOverride struct {
 type RunBudget struct {
 	MaxCostUSD          float64 `json:"max_cost_usd,omitempty" bson:"max_cost_usd,omitempty"`
 	MaxTokens           int     `json:"max_tokens,omitempty" bson:"max_tokens,omitempty"`
+	WarnTokens          int     `json:"warn_tokens,omitempty" bson:"warn_tokens,omitempty"`
 	MaxIterations       int     `json:"max_iterations,omitempty" bson:"max_iterations,omitempty"`
 	MaxDuration         string  `json:"max_duration,omitempty" bson:"max_duration,omitempty"`
 	MaxParallelBranches int     `json:"max_parallel_branches,omitempty" bson:"max_parallel_branches,omitempty"`

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -4695,6 +4695,7 @@ export interface components {
             max_iterations?: number;
             max_parallel_branches?: number;
             max_tokens?: number;
+            warn_tokens?: number;
         };
         RunHeader: {
             active_duration_ms: number;


### PR DESCRIPTION
## Motivation

Hard token caps kill runs whose consumption is legitimate. A judge that refuses a script three times triggers three full rewrites (~160k tokens each) and rides the review loop to its by-design bound (`max_script_rewrites`) — the run then dies at 90% of `max_tokens` mid-pipeline and needs a raise-the-cap + force-resume surgery to finish. Two shorts episodes died exactly this way today at 926k/933k of a 1M cap that was sized on the nominal single-pass profile (~450k for a full episode).

The operator wants to be **told** that a run consumed unusually much (so the loop behavior can be audited), not **stopped** mid-flight.

## What this adds

A new budget key, `warn_tokens`, advisory-only:

```yaml
budget:
  warn_tokens: 1000000   # advisory: warn once, never block
```

- Crossing the threshold emits a single `budget_warning` event with `advisory: true`; execution continues. It shares the tokens-axis dedupe with the existing 80%-ratio warning, so a run surfaces at most one tokens warning.
- The alert reason says what the operator should do: `tokens crossed the advisory threshold (X/Y) — worth auditing what consumed so much` (vs. the ceiling-style `budget at N%`).
- A budget block with **only** `warn_tokens` still builds the runtime tracker (consumption must be counted for the advisory to fire) but can no longer stop the run.
- `max_tokens` semantics are unchanged; both keys can coexist.

## Changes

- **DSL**: `warn_tokens` through parser, AST, IR, unparse, JSON enc/dec
- **runtime**: `SharedBudget` advisory check; `advisory` flag propagated on `budget_warning` events from both the main loop and parallel branches
- **store/persist**: `WarnTokens` on `RunBudget` snapshots
- **alert**: advisory-specific reason text; `boolData` helper
- **docs**: budget reference updated (`docs/dsl.md`)

## Tests

- New engine-level `TestWarnTokensAdvisoryNeverBlocks`: crossing the threshold never fails the run, exactly one deduped advisory warning, no `budget_exceeded`
- Parser + unparse round-trips extended with `warn_tokens`
- `go test ./pkg/...` green, except the two pre-existing `pkg/backend/tool` computer-use failures that assume a headless environment (identical on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)