### PR TITLE
fix(docs-refresh): pass build_manifest list inputs as argv, not env

### DIFF
--- a/bots/docs-refresh/main.bot
+++ b/bots/docs-refresh/main.bot
@@ -1118,22 +1118,27 @@ print(json.dumps({
 ## All inputs flow via env vars (JSON-encoded for arrays); the
 ## tool's argv is empty.
 tool build_manifest:
-  command: `WS={{input.workspace_dir}} DOC_FILES={{input.doc_files}} CLI_COMMANDS={{input.cli_commands}} CLI_FLAGS={{input.cli_flags}} DIAG_CODES={{input.diagnostic_codes}} CODE_GLOBS={{input.code_scope_globs}} MAX_CANDIDATES={{input.max_drift_candidates}} MAX_CHUNK_DOCS={{input.max_review_chunk_docs}} python3 -c "
-import os, json, re, glob, subprocess
+  command: `WS={{input.workspace_dir}} CODE_GLOBS={{input.code_scope_globs}} MAX_CANDIDATES={{input.max_drift_candidates}} MAX_CHUNK_DOCS={{input.max_review_chunk_docs}} python3 -c "
+import os, json, re, glob, subprocess, sys
 ws = os.environ['WS']
 os.chdir(ws)
-def jload(name, default):
-    raw = os.environ.get(name, '')
-    if not raw:
-        return default
-    try:
-        return json.loads(raw)
-    except json.JSONDecodeError:
-        return default
-doc_files = jload('DOC_FILES', [])
-cli_commands = set(jload('CLI_COMMANDS', []))
-cli_flags = set(jload('CLI_FLAGS', []))
-diag_codes = set(jload('DIAG_CODES', []))
+## List inputs ride argv after section markers (--docs/--cli/--flags/
+## --diag): the engine substitutes an all-string list as space-joined
+## escaped words — argv semantics. In an env assignment the second
+## element would run as a command (exit 127). Same idiom as
+## update_audit_cache's sys.argv tail.
+buckets = {'--docs': [], '--cli': [], '--flags': [], '--diag': []}
+cur = None
+for a in sys.argv[1:]:
+    if a in buckets:
+        cur = a
+        continue
+    if cur is not None:
+        buckets[cur].append(a)
+doc_files = buckets['--docs']
+cli_commands = set(buckets['--cli'])
+cli_flags = set(buckets['--flags'])
+diag_codes = set(buckets['--diag'])
 code_globs = [g.strip() for g in os.environ.get('CODE_GLOBS', '').split(',') if g.strip()]
 try:
     max_candidates = int(os.environ.get('MAX_CANDIDATES', '150'))
@@ -1492,7 +1497,7 @@ print(json.dumps({
     'max_review_chunk_docs': max_chunk_docs,
     'verified_pairs': sorted({a['doc'] + '::' + str(a.get('value','')) for a in verified}),
 }))
-"`
+" --docs {{input.doc_files}} --cli {{input.cli_commands}} --flags {{input.cli_flags}} --diag {{input.diagnostic_codes}}`
   input: build_manifest_input
   output: build_manifest_output
 

--- a/bots/docs-refresh/manifest.yaml
+++ b/bots/docs-refresh/manifest.yaml
@@ -1,7 +1,15 @@
 name: docs-refresh
 display_name: Doki
 icon: 📚
-version: 2.2.0
+version: 2.2.1
+## 2.2.1 — fix build_manifest list inputs: pass doc_files/cli_commands/
+## cli_flags/diagnostic_codes as argv section markers instead of env
+## assignments. The engine substitutes an all-string list as
+## space-joined escaped words, so `DOC_FILES={{input.doc_files}}` made
+## the shell execute the second filename (exit 127) — a regression
+## introduced by the 55d7170e6 raw-interpolation removal, observed on
+## the first repo-targeted cloud dogfood (run 019f86ac). Same argv
+## idiom as update_audit_cache.
 ## 2.2.0 — PR finalization tail (opt-in, feature-dev verbatim). When
 ## open_mr=true, after the run finishes (converged or max_passes
 ## exhausted with banked commits) a deterministic forge_auth_probe


### PR DESCRIPTION
The engine substitutes an all-string list into a tool `command:` as space-joined escaped words, so `DOC_FILES={{input.doc_files}}` made the shell execute the second filename (`bash: line 1: README.md: command not found`, exit 127) — a docs-refresh regression from the 55d7170e6 raw-interpolation removal, caught by the first repo-targeted cloud dogfood (run 019f86ac, prod). Last full-pass dogfoods predate that commit; the 2026-07-20 noop dogfood short-circuited before build_manifest, so the regression stayed invisible.

Fix: move `doc_files`/`cli_commands`/`cli_flags`/`diagnostic_codes` to argv section markers (`--docs/--cli/--flags/--diag`) — space-join IS argv semantics — the same idiom update_audit_cache already uses. Scalars stay env. Bot 2.2.1.

Verified by faithful shell emulation of the engine substitution against this repo: 3 docs → 467 anchors, coverage 81%, 40 candidates, empty `--flags` bucket handled. `iterion validate` OK, `go test ./bots/` green.

The underlying engine behavior is the known deferred all-string-slice case documented in `shellEscapeValue` (pkg/backend/model/executor_tool.go) — this PR fixes the bot idiom, not the engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)