### PR TITLE
fix(e2e): un-flake TestAwaitAnswersReleasedByAnswer under -race

### DIFF
--- a/e2e/async_interaction_test.go
+++ b/e2e/async_interaction_test.go
@@ -91,8 +91,12 @@ func TestAwaitAnswersReleasedByAnswer(t *testing.T) {
 		if err != nil {
 			t.Fatalf("run: %v", err)
 		}
-	case <-time.After(4 * time.Second):
-		t.Fatal("run did not converge within 4s after the answer (doorbell not honoured?)")
+	// Ceiling ABOVE the await_answers 5s level-poll: if the doorbell rings
+	// before the gate branch parks (the 300ms sleep lost the race — seen
+	// under -race on CI), the level-triggered poll still releases the
+	// branch; only a miss of BOTH mechanisms is a real failure.
+	case <-time.After(15 * time.Second):
+		t.Fatal("run did not converge after the answer (neither doorbell nor level-poll released the gate)")
 	}
 
 	r, err := s.LoadRun(context.Background(), runID)


### PR DESCRIPTION
The 4s convergence ceiling sat UNDER the await_answers 5s level-poll:
when the answer + doorbell land before the gate branch parks (the fixed
300ms sleep loses that race under -race scheduling), release falls to
the level-poll and the test times out spuriously — observed on the
PR #252 queue run. Raise the ceiling above the poll interval; a miss of
both mechanisms is still a hard failure.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
