### PR TITLE
feat(docs-refresh): dismissals ledger — false-positive adjudications persist across passes

### DIFF
--- a/bots/docs-refresh/main.bot
+++ b/bots/docs-refresh/main.bot
@@ -226,6 +226,16 @@ vars:
   ## OUT of the target worktree is the repo-agnostic rule.
   scratch_dir: string = "${PROJECT_SCRATCH_DIR}/docs-refresh"
 
+  ## DISMISSALS LEDGER. JSON array of candidates the campaign
+  ## adjudicated as false positives ({doc, kind, value, reason});
+  ## build_manifest excludes ledger entries from every later pass so
+  ## the chunk window ADVANCES instead of re-surfacing the same
+  ## candidates — a zero-commit adjudication pass otherwise leaves the
+  ## manifest byte-identical and the run livelocks re-judging the same
+  ## chunk until max_passes (observed live, cloud run 019f86ce).
+  ## Out-of-tree like scratch_dir; empty disables the exclusion.
+  dismissed_path: string = "${PROJECT_SCRATCH_DIR}/docs-refresh/dismissed.json"
+
   ## BASELINE (G5). Known pre-existing build/test failures the campaign
   ## must SKIP rather than burn budget proving they aren't its own —
   ## docs-refresh rarely trips this (docs-only edits), but when
@@ -325,7 +335,10 @@ prompt campaign_system:
      doc with a semantic message (`docs(<area>): <what was aligned>`),
      body ending with the trailer line `Bot: docs-refresh`. Use
      `fix(<area>):` ONLY when you fixed a demonstrably misleading code
-     COMMENT (go_comment_globs opt-in).
+     COMMENT (go_comment_globs opt-in). A candidate you adjudicate as
+     a FALSE POSITIVE (no edit warranted) goes in the DISMISSALS
+     LEDGER (below) — dismissing without recording is what livelocks
+     the run.
 
   3. COMMIT EACH DOC AS YOU ALIGN IT — never batch. Stage everything
      including new files (`git add -A`) and commit before moving on.
@@ -371,8 +384,21 @@ prompt campaign_system:
   "severity:<low|medium|high>"]. Zero findings is a fine outcome. If
   the board tools are unavailable, list the findings in `summary`.
 
+  DISMISSALS LEDGER — the persistence half of adjudication. For EVERY
+  candidate you judge a false positive, append one entry to the JSON
+  array at `{{vars.dismissed_path}}` (create the file — `[]` — and its
+  parent directory on first use; read-modify-write, keep it valid
+  JSON):
+    {"doc": "<candidate doc>", "kind": "<candidate kind>",
+     "value": "<candidate value>", "reason": "<one line>"}
+  build_manifest excludes ledger entries from every later pass, so the
+  chunk window advances to the deferred docs. A dismissal that is not
+  recorded WILL come back to you next pass — recording it is part of
+  adjudicating it, exactly like committing is part of fixing.
+
   KEEP GOING, one doc at a time, until this pass has adjudicated every
-  candidate in its working set. Then STOP and report.
+  candidate in its working set (fixed+committed or dismissed+recorded).
+  Then STOP and report.
 
   TERMINATION CONTRACT (required structured output — this is how the
   engine detects completion; an under-specified end just gets
@@ -873,6 +899,9 @@ schema build_manifest_output:
   ## v2: the mechanically VERIFIED doc::anchor pairs — feeds the
   ## inter-run audit cache (update_audit_cache) so pre-verification no
   ## longer depends on retired reviewer claims.
+  ## Candidates dropped because the campaign's dismissals ledger
+  ## (vars.dismissed_path) already adjudicated them as false positives.
+  dismissed_excluded: int
   verified_pairs: string[]
 
 ## ─── Nodes ──────────────────────────────────────────────────────
@@ -1118,7 +1147,7 @@ print(json.dumps({
 ## All inputs flow via env vars (JSON-encoded for arrays); the
 ## tool's argv is empty.
 tool build_manifest:
-  command: `WS={{input.workspace_dir}} CODE_GLOBS={{input.code_scope_globs}} MAX_CANDIDATES={{input.max_drift_candidates}} MAX_CHUNK_DOCS={{input.max_review_chunk_docs}} python3 -c "
+  command: `WS={{input.workspace_dir}} CODE_GLOBS={{input.code_scope_globs}} MAX_CANDIDATES={{input.max_drift_candidates}} MAX_CHUNK_DOCS={{input.max_review_chunk_docs}} DISMISSED_PATH={{vars.dismissed_path}} python3 -c "
 import os, json, re, glob, subprocess, sys
 ws = os.environ['WS']
 os.chdir(ws)
@@ -1429,6 +1458,27 @@ priority = {
 ## we never scanned that surface, so there is nothing for the campaign to
 ## adjudicate — they would only be noise that tempts a false blocker.
 candidates = drifted + [a for a in unverifiable if a['kind'] == 'symbol_ref']
+
+## DISMISSALS LEDGER exclusion: candidates the campaign already
+## adjudicated as false positives (recorded at DISMISSED_PATH) are
+## dropped BEFORE the sort/chunk, so the chunk window advances to the
+## deferred docs instead of re-surfacing the same candidates forever.
+dismissed_path = os.environ.get('DISMISSED_PATH', '').strip()
+dismissed = set()
+if dismissed_path and os.path.exists(dismissed_path):
+    try:
+        with open(dismissed_path, encoding='utf-8') as df:
+            for e in json.load(df):
+                if isinstance(e, dict):
+                    dismissed.add((e.get('doc', ''), e.get('kind', ''), str(e.get('value', ''))))
+    except (OSError, json.JSONDecodeError, TypeError):
+        pass
+dismissed_excluded = 0
+if dismissed:
+    kept = [a for a in candidates if (a['doc'], a['kind'], str(a['value'])) not in dismissed]
+    dismissed_excluded = len(candidates) - len(kept)
+    candidates = kept
+
 candidates.sort(key=lambda a: (priority.get((a['status'], a['kind']), 9), a['doc'], a['line']))
 
 ## v0.16.0: doc-count chunking. After the severity sort, walk the
@@ -1495,6 +1545,7 @@ print(json.dumps({
     'chunked': chunked,
     'chunk_doc_count': chunk_doc_count,
     'max_review_chunk_docs': max_chunk_docs,
+    'dismissed_excluded': dismissed_excluded,
     'verified_pairs': sorted({a['doc'] + '::' + str(a.get('value','')) for a in verified}),
 }))
 " --docs {{input.doc_files}} --cli {{input.cli_commands}} --flags {{input.cli_flags}} --diag {{input.diagnostic_codes}}`

--- a/bots/docs-refresh/main.bot
+++ b/bots/docs-refresh/main.bot
@@ -797,16 +797,15 @@ schema author_output:
 schema mark_issue_output:
   text: string
 
-## update_audit_cache I/O (v0.5.0). The `audited_pairs: string[]`
-## field is shell-tokenised by iterion's template substitution
-## (`'pair1' 'pair2' 'pair3'`) so each element lands as a separate
-## argv entry to python3 — env var passing breaks on internal
-## whitespace, JSON encoding is unreachable via the {{!...}} raw
-## form because raw values still go through env-var assignment.
+## update_audit_cache I/O (v2.3.1). The verified pairs ride a FILE
+## (written by build_manifest under scratch), not inline argv: a large
+## repo produces thousands of pairs and an inline substitution blows
+## the kernel's per-argument limit — `fork/exec bash: argument list
+## too long`, observed live on cloud run 019f86ce (~4200 pairs).
 schema update_audit_cache_input:
   workspace_dir: string
   cache_path: string
-  audited_pairs: string[]
+  pairs_file: string
 
 schema update_audit_cache_output:
   cache_path: string
@@ -902,7 +901,11 @@ schema build_manifest_output:
   ## Candidates dropped because the campaign's dismissals ledger
   ## (vars.dismissed_path) already adjudicated them as false positives.
   dismissed_excluded: int
-  verified_pairs: string[]
+  ## Path (under scratch) of the JSON array of mechanically verified
+  ## doc::anchor pairs — consumed by update_audit_cache. A file, never
+  ## inline: thousands of pairs inline hit the kernel argv limit.
+  verified_pairs_file: string
+  verified_pairs_count: int
 
 ## ─── Nodes ──────────────────────────────────────────────────────
 
@@ -1147,7 +1150,7 @@ print(json.dumps({
 ## All inputs flow via env vars (JSON-encoded for arrays); the
 ## tool's argv is empty.
 tool build_manifest:
-  command: `WS={{input.workspace_dir}} CODE_GLOBS={{input.code_scope_globs}} MAX_CANDIDATES={{input.max_drift_candidates}} MAX_CHUNK_DOCS={{input.max_review_chunk_docs}} DISMISSED_PATH={{vars.dismissed_path}} python3 -c "
+  command: `WS={{input.workspace_dir}} CODE_GLOBS={{input.code_scope_globs}} MAX_CANDIDATES={{input.max_drift_candidates}} MAX_CHUNK_DOCS={{input.max_review_chunk_docs}} DISMISSED_PATH={{vars.dismissed_path}} PAIRS_OUT={{vars.scratch_dir}}/verified_pairs.json python3 -c "
 import os, json, re, glob, subprocess, sys
 ws = os.environ['WS']
 os.chdir(ws)
@@ -1508,6 +1511,21 @@ if max_candidates > 0:
     candidates = candidates[:max_candidates]
 chunk_doc_count = len({a['doc'] for a in candidates})
 
+## Verified pairs ride a FILE, never inline shell substitution: a large
+## repo yields thousands of pairs and an inline argv handoff blows the
+## kernel per-argument limit (E2BIG — seen live at ~4200 pairs).
+pairs_sorted = sorted({a['doc'] + '::' + str(a.get('value','')) for a in verified})
+pairs_out = os.environ.get('PAIRS_OUT', '').strip()
+pairs_out_written = ''
+if pairs_out:
+    try:
+        os.makedirs(os.path.dirname(pairs_out) or '.', exist_ok=True)
+        with open(pairs_out, 'w', encoding='utf-8') as pf:
+            json.dump(pairs_sorted, pf)
+        pairs_out_written = pairs_out
+    except OSError:
+        pass
+
 total_anchors = len(anchors)
 verified_anchors = len(verified)
 drifted_anchors = len(drifted)
@@ -1546,7 +1564,8 @@ print(json.dumps({
     'chunk_doc_count': chunk_doc_count,
     'max_review_chunk_docs': max_chunk_docs,
     'dismissed_excluded': dismissed_excluded,
-    'verified_pairs': sorted({a['doc'] + '::' + str(a.get('value','')) for a in verified}),
+    'verified_pairs_file': pairs_out_written,
+    'verified_pairs_count': len(pairs_sorted),
 }))
 " --docs {{input.doc_files}} --cli {{input.cli_commands}} --flags {{input.cli_flags}} --diag {{input.diagnostic_codes}}`
   input: build_manifest_input
@@ -1623,10 +1642,19 @@ tool update_audit_cache:
 import os, json, hashlib, re, sys, pathlib, subprocess
 ws = sys.argv[1]
 cache_path = sys.argv[2]
-pairs = sys.argv[3:]
+pairs_file = sys.argv[3] if len(sys.argv) > 3 else ''
 if not cache_path:
     print(json.dumps({'cache_path': '', 'entries_written': 0, 'git_head': '', 'skipped': 'no cache_path'}))
     sys.exit(0)
+pairs = []
+if pairs_file and os.path.exists(pairs_file):
+    try:
+        with open(pairs_file, encoding='utf-8') as pf:
+            loaded = json.load(pf)
+        if isinstance(loaded, list):
+            pairs = [p for p in loaded if isinstance(p, str)]
+    except (OSError, json.JSONDecodeError):
+        pass
 os.chdir(ws)
 def git_head():
     try:
@@ -1666,7 +1694,7 @@ head = git_head()
 with open(out_path, 'w') as out:
     json.dump({'v': 1, 'git_head': head, 'doc': doc_entries}, out, indent=2, sort_keys=True)
 print(json.dumps({'cache_path': str(out_path), 'entries_written': len(doc_entries), 'git_head': head, 'skipped': ''}))
-" {{input.workspace_dir}} {{input.cache_path}} {{input.audited_pairs}}`
+" {{input.workspace_dir}} {{input.cache_path}} {{input.pairs_file}}`
   input: update_audit_cache_input
   output: update_audit_cache_output
 
@@ -2007,7 +2035,7 @@ workflow docs_refresh:
   mark_issue_for_review -> update_audit_cache with {
     workspace_dir: "{{vars.workspace_dir}}",
     cache_path: "{{vars.audit_cache_path}}",
-    audited_pairs: "{{outputs.build_manifest.verified_pairs}}"
+    pairs_file: "{{outputs.build_manifest.verified_pairs_file}}"
   }
   ## ── PR tail (opt-in, feature-dev verbatim) ──────────────────────
   ## Reached on BOTH finishes (converged and max_passes-exhausted): the

--- a/bots/docs-refresh/manifest.yaml
+++ b/bots/docs-refresh/manifest.yaml
@@ -1,7 +1,15 @@
 name: docs-refresh
 display_name: Doki
 icon: 📚
-version: 2.3.0
+version: 2.3.1
+## 2.3.1 — verified pairs ride a FILE. update_audit_cache took the
+## manifest's verified_pairs inline as argv; a large repo yields
+## thousands of pairs and the substituted command blew the kernel
+## per-argument limit — `fork/exec bash: argument list too long`,
+## crash-looping the terminal node (observed live: cloud run 019f86ce,
+## ~4200 pairs). build_manifest now writes them to
+## <scratch>/verified_pairs.json (new verified_pairs_file /
+## verified_pairs_count outputs) and update_audit_cache reads the path.
 ## 2.3.0 — DISMISSALS LEDGER (v2 revival of the v1 dismissed-pairs
 ## accumulator). A zero-commit adjudication pass left the manifest
 ## byte-identical, so the severity-sorted chunker re-surfaced the SAME

--- a/bots/docs-refresh/manifest.yaml
+++ b/bots/docs-refresh/manifest.yaml
@@ -1,7 +1,17 @@
 name: docs-refresh
 display_name: Doki
 icon: 📚
-version: 2.2.1
+version: 2.3.0
+## 2.3.0 — DISMISSALS LEDGER (v2 revival of the v1 dismissed-pairs
+## accumulator). A zero-commit adjudication pass left the manifest
+## byte-identical, so the severity-sorted chunker re-surfaced the SAME
+## candidates and the run livelocked re-judging them until max_passes
+## (observed live: cloud run 019f86ce, 4 passes over the same 41
+## cli_flag false positives). The campaign now records every dismissed
+## candidate in vars.dismissed_path ({doc, kind, value, reason});
+## build_manifest excludes ledger entries before sort/chunk (new
+## dismissed_excluded output field), so the chunk window advances and
+## convergence means "all chunks fixed-or-dismissed".
 ## 2.2.1 — fix build_manifest list inputs: pass doc_files/cli_commands/
 ## cli_flags/diagnostic_codes as argv section markers instead of env
 ## assignments. The engine substitutes an all-string list as

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -509,7 +509,7 @@ forge-mr-create.
   code↔doc drift — or when a repo has NO docs yet and needs an initial
   set authored from the code. Fixes the DOCS only (never code logic)
   and commits.
-- **Vars**: `audit_cache_path` (string), `baseline` (string), `bundle_self_path` (string), `cli_surface_globs` (string), `code_scope_globs` (string), `coverage_target_pct` (int), `diagnostic_surface_globs` (string), `diff_since` (string), `doc_globs` (string), `docs_dir` (string), `excluded_dirs` (string), `go_comment_globs` (string), `issue_id` (string), `max_drift_candidates` (int), `max_passes` (int), `max_review_chunk_docs` (int), `mr_base` (string), `mr_branch` (string), `open_mr` (bool), `scope_notes` (string), `scratch_dir` (string), `source_issue_ref` (string), `workspace_dir` (string)
+- **Vars**: `audit_cache_path` (string), `baseline` (string), `bundle_self_path` (string), `cli_surface_globs` (string), `code_scope_globs` (string), `coverage_target_pct` (int), `diagnostic_surface_globs` (string), `diff_since` (string), `dismissed_path` (string), `doc_globs` (string), `docs_dir` (string), `excluded_dirs` (string), `go_comment_globs` (string), `issue_id` (string), `max_drift_candidates` (int), `max_passes` (int), `max_review_chunk_docs` (int), `mr_base` (string), `mr_branch` (string), `open_mr` (bool), `scope_notes` (string), `scratch_dir` (string), `source_issue_ref` (string), `workspace_dir` (string)
 - **Path**: `bots/docs-refresh/main.bot`
 
 ### `evolve` — Evoly


### PR DESCRIPTION
A zero-commit adjudication pass left the manifest byte-identical, so
the severity-sorted chunker re-surfaced the SAME candidates and the run
livelocked re-judging them until max_passes exhaustion (observed live:
cloud run 019f86ce — 4 passes over the same 41 cli_flag false
positives, ~1$ each). v2 had lost the v1 dismissed-pairs accumulator
with the review-loop retirement.

The campaign now records every dismissed candidate in
vars.dismissed_path ({doc, kind, value, reason}, out-of-tree scratch);
build_manifest excludes ledger entries before the sort/chunk (new
dismissed_excluded output field), so the chunk window advances and
convergence means every chunk fixed-or-dismissed. Bot 2.3.0.

Verified by two-pass emulation: pass B excludes all 40 ledgered
candidates and pulls the next deferred doc into the chunk.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
