### PR TITLE
fix(studio): replay no longer shows "No log captured." past the log window

### DIFF
--- a/pkg/server/runs_log.go
+++ b/pkg/server/runs_log.go
@@ -18,7 +18,10 @@ func (s *Server) registerRunLogRoutes() {
 // for runs live in this process, the store's RunLogStore otherwise
 // (runs/<id>/run.log on a filesystem store, the run_logs chunks on the
 // Mongo store — one persisted read path for both, ADR-053). ?from=N
-// skips bytes; default 0.
+// skips bytes (default 0); ?until=M bounds the read to [from, until)
+// so the studio's replay scrubber can fetch exactly the prefix its
+// in-memory window evicted instead of re-downloading the whole log.
+// until <= 0 (or absent) means "to the current end".
 func (s *Server) handleGetRunLog(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
@@ -37,25 +40,35 @@ func (s *Server) handleGetRunLog(w http.ResponseWriter, r *http.Request) {
 	if from < 0 {
 		from = 0
 	}
+	until, _ := strconv.ParseInt(r.URL.Query().Get("until"), 10, 64)
+	if until < 0 {
+		until = 0
+	}
 	ls := store.AsRunLogStore(s.runs.RunStore())
 
 	if buf := s.runs.GetLogBuffer(id); buf != nil {
-		offset, data, total := buf.Snapshot(from)
+		snapOffset, data, total := buf.Snapshot(from)
+		respOffset := snapOffset
 		// If the ring has evicted bytes older than `from`, fill the
-		// missing prefix [from, offset) from the persisted log
+		// missing prefix [from, snapOffset) from the persisted log
 		// (authoritative; the ring is just a 1 MiB live tail). Without
 		// this, the studio's "copy log" / "download log" buttons on a
 		// long-running active run miss everything before the ring's
 		// lower bound — same root cause as the WS subscribe path.
 		var prefix []byte
-		if offset > from && ls != nil {
-			if pre, err := ls.ReadRunLogRange(r.Context(), id, from, offset); err == nil && len(pre) > 0 {
+		if snapOffset > from && ls != nil {
+			prefixEnd := snapOffset
+			if until > 0 && until < prefixEnd {
+				prefixEnd = until
+			}
+			if pre, err := ls.ReadRunLogRange(r.Context(), id, from, prefixEnd); err == nil && len(pre) > 0 {
 				prefix = pre
-				offset = from
+				respOffset = from
 			}
 		}
+		data = trimLogWindow(snapOffset, data, until)
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		w.Header().Set("X-Iterion-Log-Offset", strconv.FormatInt(offset, 10))
+		w.Header().Set("X-Iterion-Log-Offset", strconv.FormatInt(respOffset, 10))
 		w.Header().Set("X-Iterion-Log-Total", strconv.FormatInt(total, 10))
 		if len(prefix) > 0 {
 			_, _ = w.Write(prefix)
@@ -77,7 +90,7 @@ func (s *Server) handleGetRunLog(w http.ResponseWriter, r *http.Request) {
 		s.httpErrorFor(w, r, http.StatusNotFound, "no log captured for run %q", id)
 		return
 	}
-	data, err := ls.ReadRunLogRange(r.Context(), id, from, 0)
+	data, err := ls.ReadRunLogRange(r.Context(), id, from, until)
 	if err != nil {
 		s.httpErrorFor(w, r, http.StatusInternalServerError, "read log: %v", err)
 		return
@@ -86,4 +99,20 @@ func (s *Server) handleGetRunLog(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Iterion-Log-Offset", strconv.FormatInt(from, 10))
 	w.Header().Set("X-Iterion-Log-Total", strconv.FormatInt(total, 10))
 	_, _ = w.Write(data)
+}
+
+// trimLogWindow bounds a live-buffer snapshot to [.., until): data
+// covers [snapOffset, snapOffset+len(data)) in the run's byte stream;
+// until <= 0 means unbounded.
+func trimLogWindow(snapOffset int64, data []byte, until int64) []byte {
+	if until <= 0 {
+		return data
+	}
+	if until <= snapOffset {
+		return nil
+	}
+	if until < snapOffset+int64(len(data)) {
+		return data[:until-snapOffset]
+	}
+	return data
 }

--- a/pkg/server/runs_log_test.go
+++ b/pkg/server/runs_log_test.go
@@ -1,0 +1,145 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// seedRunLog persists raw log bytes for a run through the store's
+// RunLogStore — the same interface the cloud runner's runLogWriter
+// appends through (Mongo run_logs chunks) and the replay endpoint
+// reads back. The filesystem backend stands in here; the Mongo
+// backend's identical semantics are pinned by the storetest
+// conformance suite (mongo-conformance CI job).
+func seedRunLog(t *testing.T, srv *Server, runID string, chunks ...string) {
+	t.Helper()
+	st, err := store.New(srv.cfg.StoreDir)
+	if err != nil {
+		t.Fatalf("open seed store: %v", err)
+	}
+	ls := store.AsRunLogStore(st)
+	if ls == nil {
+		t.Fatal("filesystem store must implement RunLogStore")
+	}
+	var off int64
+	for i, c := range chunks {
+		if err := ls.AppendRunLog(context.Background(), runID, off, []byte(c)); err != nil {
+			t.Fatalf("AppendRunLog #%d: %v", i, err)
+		}
+		off += int64(len(c))
+	}
+}
+
+// getLog hits the replay endpoint directly (no live buffer exists for
+// a seeded terminal run, so this exercises the persisted-store path —
+// the one every finished cloud run takes).
+func getLog(t *testing.T, srv *Server, runID, query string) (*httptest.ResponseRecorder, string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/runs/"+runID+"/log"+query, nil)
+	req.SetPathValue("id", runID)
+	rec := httptest.NewRecorder()
+	srv.handleGetRunLog(rec, req)
+	body, err := io.ReadAll(rec.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return rec, string(body)
+}
+
+// TestGetRunLogRange proves the replay endpoint serves the persisted
+// log for a terminal run — full read, from-offset read, and the
+// bounded [from, until) window the studio's replay scrubber uses to
+// fetch the head its in-memory buffer evicted.
+func TestGetRunLogRange(t *testing.T) {
+	srv, _ := newTestServer(t)
+	const runID = "run-log-range"
+	seedRun(t, srv, runID, "demo", store.RunStatusFinished)
+	seedRunLog(t, srv, runID, "hello ", "world")
+
+	t.Run("full", func(t *testing.T) {
+		rec, body := getLog(t, srv, runID, "")
+		if rec.Code != http.StatusOK || body != "hello world" {
+			t.Fatalf("got %d %q; want 200 %q", rec.Code, body, "hello world")
+		}
+		if got := rec.Header().Get("X-Iterion-Log-Total"); got != "11" {
+			t.Fatalf("X-Iterion-Log-Total = %q; want 11", got)
+		}
+		if got := rec.Header().Get("X-Iterion-Log-Offset"); got != "0" {
+			t.Fatalf("X-Iterion-Log-Offset = %q; want 0", got)
+		}
+	})
+
+	t.Run("from", func(t *testing.T) {
+		rec, body := getLog(t, srv, runID, "?from=6")
+		if rec.Code != http.StatusOK || body != "world" {
+			t.Fatalf("got %d %q; want 200 %q", rec.Code, body, "world")
+		}
+	})
+
+	t.Run("until window crossing a chunk boundary", func(t *testing.T) {
+		rec, body := getLog(t, srv, runID, "?from=4&until=9")
+		if rec.Code != http.StatusOK || body != "o wor" {
+			t.Fatalf("got %d %q; want 200 %q", rec.Code, body, "o wor")
+		}
+	})
+
+	t.Run("evicted-head prefix fetch (from=0&until=N)", func(t *testing.T) {
+		rec, body := getLog(t, srv, runID, "?from=0&until=6")
+		if rec.Code != http.StatusOK || body != "hello " {
+			t.Fatalf("got %d %q; want 200 %q", rec.Code, body, "hello ")
+		}
+	})
+
+	t.Run("negative until reads to end", func(t *testing.T) {
+		rec, body := getLog(t, srv, runID, "?until=-3")
+		if rec.Code != http.StatusOK || body != "hello world" {
+			t.Fatalf("got %d %q; want 200 %q", rec.Code, body, "hello world")
+		}
+	})
+}
+
+// TestGetRunLogEmpty pins the honest-degradation contract: a run with
+// no persisted log yields 404, never an empty 200 that would read as a
+// captured-but-empty log.
+func TestGetRunLogEmpty(t *testing.T) {
+	srv, _ := newTestServer(t)
+	const runID = "run-log-empty"
+	seedRun(t, srv, runID, "demo", store.RunStatusFinished)
+
+	rec, _ := getLog(t, srv, runID, "")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("empty log: got status %d; want 404", rec.Code)
+	}
+}
+
+// TestTrimLogWindow covers the live-buffer half of the ?until=
+// contract: the snapshot window [snapOffset, snapOffset+len) bounded
+// at until.
+func TestTrimLogWindow(t *testing.T) {
+	data := []byte("abcdef") // covers [10, 16)
+	cases := []struct {
+		name  string
+		until int64
+		want  []byte
+	}{
+		{"unbounded", 0, data},
+		{"negative means unbounded", -1, data},
+		{"entirely before window", 10, nil},
+		{"mid-window", 13, []byte("abc")},
+		{"exactly window end", 16, data},
+		{"past window end", 99, data},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := trimLogWindow(10, data, c.until); !bytes.Equal(got, c.want) {
+				t.Fatalf("trimLogWindow(10, %q, %d) = %q; want %q", data, c.until, got, c.want)
+			}
+		})
+	}
+}

--- a/studio/src/components/Runs/LogLinesView.tsx
+++ b/studio/src/components/Runs/LogLinesView.tsx
@@ -14,6 +14,7 @@ import { formatBytes } from "@/lib/format";
 import { downloadBlob } from "@/lib/download";
 import { readBooleanFlag, writeBooleanFlag } from "@/lib/localStorageFlag";
 import { selectInFlightTools, useRunStore } from "@/store/run";
+import { clampLogBody } from "@/store/run/logBuffer";
 import { useTabsStore } from "@/store/tabs";
 import { useUIStore } from "@/store/ui";
 
@@ -211,23 +212,68 @@ export default function LogLinesView({
     };
   }, [subscribeLogs, unsubscribeLogs]);
 
+  // Evicted-head fallback for the replay scrubber. The in-memory buffer
+  // is a bounded tail (MAX_LOG_BYTES): on a log larger than the cap the
+  // head [0, log.start) is trimmed away, and a scrub position below
+  // log.start used to render as an empty panel mislabelled "No log
+  // captured." Fetch that prefix once from the authoritative persisted
+  // log (run.log on a filesystem store, run_logs chunks on Mongo) and
+  // cache it in the run store; the cache is keyed on log.start so a
+  // further live trim triggers a refetch of the widened gap.
+  const prefix = log.prefix;
+  const setLogPrefix = useRunStore((s) => s.setLogPrefix);
+  const clamping = clampToBytes !== null && clampToBytes !== undefined;
+  const needPrefixFetch =
+    clamping && log.start > 0 && (!prefix || prefix.until !== log.start);
+  // The error is keyed by the `until` it failed for, so a later trim
+  // (a new fetch target) supersedes it without a synchronous state
+  // reset inside the effect.
+  const [prefixError, setPrefixError] = useState<{
+    until: number;
+    message: string;
+  } | null>(null);
+  useEffect(() => {
+    if (!needPrefixFetch) return;
+    const until = log.start;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(
+          apiURL(`/runs/${encodeURIComponent(runId)}/log?from=0&until=${until}`),
+          { credentials: "include" },
+        );
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const text = await res.text();
+        if (!cancelled) setLogPrefix({ until, text });
+      } catch (err) {
+        console.error("[LogLinesView] evicted-log prefix fetch failed:", err);
+        if (!cancelled) setPrefixError({ until, message: String(err) });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [needPrefixFetch, log.start, runId, setLogPrefix]);
+  const prefixState: PrefixState = !clamping || log.start === 0
+    ? "none"
+    : prefix && prefix.until === log.start
+      ? "ready"
+      : prefixError && prefixError.until === log.start
+        ? "error"
+        : "loading";
+
   // Annotate lines with their inferred level. Continuation lines (from
   // LogBlock) inherit the level of the most recent header so a level
   // filter doesn't strand a multi-line block's body.
   //
-  // When clampToBytes is set, slice the buffer to the absolute byte
-  // position the time-travel scrubber asks for (events[scrubSeq].log_
-  // offset on the parent side). Bytes BEFORE the ring's lower bound
-  // (log.start) have been evicted from the 1 MB window — those are
-  // silently absent until we wire a /api/runs/{id}/log fetch fallback.
+  // When clampToBytes is set, clampLogBody slices the buffer to the
+  // absolute byte position the time-travel scrubber asks for
+  // (events[scrubSeq].log_offset on the parent side), byte-accurately,
+  // stitching in the fetched evicted-head prefix when the position
+  // falls below the in-memory window.
   const annotated = useMemo<AnnotatedLine[]>(() => {
-    if (!log.text) return [];
-    let body = log.text;
-    if (clampToBytes !== null && clampToBytes !== undefined) {
-      const rel = clampToBytes - log.start;
-      if (rel <= 0) return [];
-      if (rel < body.length) body = body.slice(0, rel);
-    }
+    const body = clampLogBody(log.text, log.start, prefix, clampToBytes);
+    if (!body) return [];
     const raw = body.endsWith("\n") ? body.slice(0, -1) : body;
     const split = raw.split("\n");
     const out: AnnotatedLine[] = new Array(split.length);
@@ -243,7 +289,7 @@ export default function LogLinesView({
       }
     }
     return out;
-  }, [log.text, log.start, clampToBytes]);
+  }, [log.text, log.start, prefix, clampToBytes]);
 
   // Per-(node, iteration) pre-filter. Backends prefix every node-bound
   // line as [NodeID#iter/component]; we scan past the timestamp+emoji
@@ -385,7 +431,7 @@ export default function LogLinesView({
           {filtered.length} / {lineCount} lines
           {!isFiltered && <> · {formatBytes(totalBytes)}</>}
         </span>
-        {!isFiltered && droppedBytes > 0 && (
+        {!isFiltered && droppedBytes > 0 && prefixState !== "ready" && (
           <span
             className="text-warning-fg text-caption"
             title={`${formatBytes(droppedBytes)} of older output rolled out of the in-memory tail; download the full log to inspect.`}
@@ -568,7 +614,13 @@ export default function LogLinesView({
         <div className="flex-1 min-w-0 min-h-0 px-3 py-1">
           {filtered.length === 0 ? (
             <div className="text-fg-subtle py-2 text-micro">
-              {emptyMessage(lineCount, isFiltered, log.subscribed)}
+              {emptyMessage(
+                lineCount,
+                isFiltered,
+                log.subscribed,
+                log.total,
+                prefixState,
+              )}
             </div>
           ) : (
             <Virtuoso
@@ -763,13 +815,27 @@ function inferLevel(text: string): string | null {
   return null;
 }
 
+// PrefixState tracks the evicted-head fetch the replay scrubber relies
+// on: "none" when no fetch is needed (not clamping, or nothing was
+// evicted), then loading → ready | error.
+type PrefixState = "none" | "loading" | "ready" | "error";
+
 function emptyMessage(
   lineCount: number,
   isFiltered: boolean,
   subscribed: boolean,
+  totalBytes: number,
+  prefixState: PrefixState,
 ): string {
   if (lineCount > 0) return "No log lines match.";
   if (isFiltered) return "No log lines tagged with this node yet.";
+  // Replay-scrub states: the log exists but the scrub position falls in
+  // the evicted head being (re)fetched. Never claim "No log captured."
+  // while totalBytes proves otherwise.
+  if (prefixState === "loading") return "Loading earlier log…";
+  if (prefixState === "error")
+    return "Earlier log unavailable — fetching the evicted portion failed (see console).";
   if (subscribed) return "Waiting for log output…";
+  if (totalBytes > 0) return "No log output at this replay position.";
   return "No log captured.";
 }

--- a/studio/src/store/run.ts
+++ b/studio/src/store/run.ts
@@ -224,6 +224,12 @@ export interface RunLogState {
   // Set when the backend emits log_terminated — the live stream is
   // over, but the existing text remains for inspection.
   terminated: boolean;
+  // Evicted-head cache for the replay scrubber: the log bytes [0, until)
+  // that rolled out of the in-memory window (start > 0), fetched on
+  // demand from GET /runs/{id}/log?from=0&until=<start>. Only valid
+  // while until === start — a further trim widens the gap and the view
+  // refetches. Null until the scrubber first needs it.
+  prefix: { until: number; text: string } | null;
 }
 
 export interface RunStoreState {
@@ -334,6 +340,9 @@ export interface RunStoreState {
   setLogSubscribed: (subscribed: boolean) => void;
   applyLogChunk: (chunk: { offset: number; text: string; total?: number }) => void;
   markLogTerminated: () => void;
+  // Installs the evicted-head cache fetched by the replay scrubber (see
+  // RunLogState.prefix). Pass null to drop it.
+  setLogPrefix: (prefix: { until: number; text: string } | null) => void;
   clearLog: () => void;
 
   // Manual URL entry from the Browser pane URL bar. Cleared by `null`.
@@ -357,6 +366,7 @@ const initialLogState: RunLogState = {
   text: "",
   subscribed: false,
   terminated: false,
+  prefix: null,
 };
 
 // freshInitial returns a value-only snapshot of the initial reducer
@@ -700,6 +710,8 @@ export function createRunStore() {
 
   markLogTerminated: () =>
     set((s) => ({ log: { ...s.log, terminated: true, subscribed: false } })),
+
+  setLogPrefix: (prefix) => set((s) => ({ log: { ...s.log, prefix } })),
 
   clearLog: () => set({ log: initialLogState }),
 

--- a/studio/src/store/run/logBuffer.test.ts
+++ b/studio/src/store/run/logBuffer.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clampLogBody,
+  sliceFromByteOffset,
+  sliceToByteOffset,
+  utf8Len,
+} from "./logBuffer";
+
+// The replay scrubber cuts the log at Event.log_offset — a BYTE
+// position — so the head slice must count UTF-8 bytes, not UTF-16 code
+// units. The run console is dense with multi-byte glyphs (ℹ️, 🔧, ▸),
+// which is exactly where a code-unit slice drifts.
+describe("sliceToByteOffset", () => {
+  it("cuts ASCII at the byte position", () => {
+    expect(sliceToByteOffset("hello world", 5)).toBe("hello");
+  });
+
+  it("returns the whole string at or past its byte length", () => {
+    expect(sliceToByteOffset("abc", 3)).toBe("abc");
+    expect(sliceToByteOffset("abc", 99)).toBe("abc");
+  });
+
+  it("returns empty for byteLen <= 0", () => {
+    expect(sliceToByteOffset("abc", 0)).toBe("");
+    expect(sliceToByteOffset("abc", -1)).toBe("");
+  });
+
+  it("counts multi-byte glyphs by their UTF-8 width", () => {
+    // "ℹ" is 3 bytes; "🔧" is 4 bytes (surrogate pair).
+    expect(sliceToByteOffset("ℹab", 3)).toBe("ℹ");
+    expect(sliceToByteOffset("ℹab", 4)).toBe("ℹa");
+    expect(sliceToByteOffset("🔧ab", 4)).toBe("🔧");
+    expect(sliceToByteOffset("🔧ab", 5)).toBe("🔧a");
+  });
+
+  it("never ends with a partial code point", () => {
+    // Cutting inside the 4-byte 🔧 excludes it entirely.
+    expect(sliceToByteOffset("🔧ab", 3)).toBe("");
+    expect(sliceToByteOffset("aℹ", 2)).toBe("a");
+  });
+
+  it("complements sliceFromByteOffset at every boundary", () => {
+    const s = "aℹ️ b🔧c ▸ d";
+    const total = utf8Len(s);
+    for (let cut = 0; cut <= total; cut++) {
+      const head = sliceToByteOffset(s, cut);
+      const tail = sliceFromByteOffset(s, cut);
+      // On a code-point boundary the two halves reassemble exactly; on
+      // a mid-code-point cut the straddling glyph is dropped from both
+      // (head excludes it, tail skips it) — never duplicated.
+      expect(utf8Len(head) <= cut).toBe(true);
+      expect(head + tail === s || utf8Len(head) + utf8Len(tail) < total).toBe(
+        true,
+      );
+    }
+  });
+});
+
+// Regression for the "No log captured." replay bug: on a log larger
+// than MAX_LOG_BYTES the store trims the head, and a scrub position
+// below the window's start rendered as an empty panel. clampLogBody
+// must serve those bytes from the fetched prefix instead.
+describe("clampLogBody", () => {
+  const start = 100; // window covers [100, …)
+  const windowText = "window-bytes";
+  const prefix = { until: start, text: "p".repeat(100) };
+
+  it("returns the window untouched when not clamping", () => {
+    expect(clampLogBody(windowText, start, null, null)).toBe(windowText);
+    expect(clampLogBody(windowText, start, prefix, undefined)).toBe(windowText);
+  });
+
+  it("serves a clamp position inside the evicted head from the prefix", () => {
+    expect(clampLogBody(windowText, start, prefix, 40)).toBe("p".repeat(40));
+  });
+
+  it("is empty (never stale window bytes) while the prefix is missing", () => {
+    expect(clampLogBody(windowText, start, null, 40)).toBe("");
+  });
+
+  it("stitches prefix + window slice past the window start", () => {
+    expect(clampLogBody(windowText, start, prefix, start + 6)).toBe(
+      "p".repeat(100) + "window",
+    );
+  });
+
+  it("ignores a stale prefix that no longer reaches the window start", () => {
+    const stale = { until: 50, text: "p".repeat(50) };
+    // Below the window with a stale prefix: nothing trustworthy to show.
+    expect(clampLogBody(windowText, start, stale, 40)).toBe("");
+    // Above the window start: window slice only, no misaligned stitch.
+    expect(clampLogBody(windowText, start, stale, start + 6)).toBe("window");
+  });
+
+  it("clamps at exactly the stream end", () => {
+    expect(clampLogBody(windowText, start, prefix, start + windowText.length)).toBe(
+      prefix.text + windowText,
+    );
+  });
+});

--- a/studio/src/store/run/logBuffer.ts
+++ b/studio/src/store/run/logBuffer.ts
@@ -55,3 +55,54 @@ export function sliceFromByteOffset(s: string, byteSkip: number): string {
   }
   return s.slice(unit);
 }
+
+// sliceToByteOffset returns the leading `byteLen` UTF-8 bytes of `s` as a
+// string, cutting on a code-point boundary — the head-side twin of
+// sliceFromByteOffset. The replay scrubber clamps the log to an absolute
+// byte position (Event.log_offset), so the visible slice must be cut by
+// bytes, not UTF-16 code units. If byteLen lands inside a multi-byte code
+// point, the partial code point is excluded, so the result never ends with
+// a broken character. byteLen <= 0 returns ""; byteLen ≥ the string's byte
+// length returns `s`.
+export function sliceToByteOffset(s: string, byteLen: number): string {
+  if (byteLen <= 0) return "";
+  let bytes = 0;
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    let step: number;
+    let next = i + 1;
+    if (c < 0x80) step = 1;
+    else if (c < 0x800) step = 2;
+    else if (c >= 0xd800 && c <= 0xdbff) {
+      step = 4;
+      next = i + 2; // paired low surrogate
+    } else step = 3;
+    if (bytes + step > byteLen) return s.slice(0, i);
+    bytes += step;
+    i = next - 1;
+  }
+  return s;
+}
+
+// clampLogBody resolves what the log panel should render at a replay
+// clamp position. `text` covers bytes [start, …) of the run's log
+// stream; `prefix` (when loaded and still aligned: prefix.until ===
+// start) covers the evicted head [0, start). clampToBytes is the
+// absolute byte position to clamp at (null/undefined = live, no
+// clamp). All cuts are byte-accurate — Event.log_offset counts UTF-8
+// bytes while JS strings index UTF-16 code units.
+export function clampLogBody(
+  text: string,
+  start: number,
+  prefix: { until: number; text: string } | null,
+  clampToBytes: number | null | undefined,
+): string {
+  if (clampToBytes === null || clampToBytes === undefined) return text;
+  const pfx = prefix && prefix.until === start ? prefix.text : null;
+  if (clampToBytes <= start) {
+    // Scrub position falls inside the evicted head: only the fetched
+    // prefix can show it. Empty while the fetch is in flight/failed.
+    return pfx ? sliceToByteOffset(pfx, clampToBytes) : "";
+  }
+  return (pfx ?? "") + sliceToByteOffset(text, clampToBytes - start);
+}


### PR DESCRIPTION
## Symptom

On prod (cloud mode), opening the replay scrubber on finished runs — e.g. docs_refresh runs `019f86ce…` / `019f874d…` — showed an empty log panel labelled **"No log captured."**, although the full log downloads fine via the copy/download buttons.

## Root cause (client-side — capture & serving were never broken)

Traced end-to-end against prod before touching anything:

- **Capture** ✅ — the runner pod tees the engine logger into `store.RunLogStore` (`pkg/runner/loop.go` → `runLogWriter` → Mongo `run_logs` chunks).
- **Serving** ✅ — both `GET /api/runs/{id}/log` (full 1.03 MiB body) and the WS `subscribe_logs` path (`runstream.MongoSource` backfill: 705 chunks + `log_terminated`, verified with a raw WS client against prod) return the complete log.
- **Rendering** ❌ — the studio's run store caps its in-memory log buffer at **1 MiB** (`studio/src/store/run/logBuffer.ts` `MAX_LOG_BYTES`) and trims the head to 768 KiB. Any cloud campaign log exceeds that, so `log.start > 0` ("+259.9 KiB older evicted"). The replay clamp in `LogLinesView.tsx` then did `if (clampToBytes - log.start <= 0) return []` — every scrub position inside the evicted head rendered **0 lines**, and `emptyMessage()` mislabelled that state "No log captured." (the code even carried a comment admitting the gap: *"silently absent until we wire a /api/runs/{id}/log fetch fallback"*).

Reproduced live on prod run `019f874d` (log = 1,080,962 bytes > 1 MiB): logs tab shows `9338 / 9338 lines`, press ▶ replay → `0 / 0 lines` + "No log captured.".

## Fix (serves the log from its designed persisted source)

- `pkg/server/runs_log.go` — `GET /api/runs/{id}/log` grows an **`until`** query param bounding the read to `[from, until)` on both the live-buffer and persisted-store paths (`ReadRunLogRange` already supported it), so the client fetches exactly the evicted head, not the whole log again.
- `studio` — when the scrub position needs bytes below the window, `LogLinesView` lazily fetches the prefix `[0, log.start)` once, caches it in the run store (keyed on the window start; refetched if a live trim widens the gap), and `clampLogBody` stitches prefix + window at the clamp. Clamp cuts are now **byte-accurate** (`sliceToByteOffset`) — `Event.log_offset` counts UTF-8 bytes and the old UTF-16 `String.slice` drifted on the console's multi-byte glyphs.
- **No silent masking**: while the prefix is in flight the panel says "Loading earlier log…"; a failed fetch shows an explicit error message; "No log captured." is shown only when the persisted total is genuinely zero (the endpoint keeps 404ing in that case — pinned by test).

## Verification

- `devbox run -- go build ./...` clean; `go test ./pkg/runview/... ./pkg/server/ ./pkg/store/... ./pkg/runner/` all pass (incl. new `runs_log_test.go`: full/from/until windows, 404-on-empty, live-buffer trim). Cloud-store persistence semantics are pinned by the existing `storetest` conformance suite (`mongo-conformance` CI job) — append/read-range/size incl. `[from, until)` windows.
- `studio`: `tsc -b --force` clean, `vitest run` 991/991 pass (new `logBuffer.test.ts`: byte-slice + `clampLogBody` regression suite simulating the exact eviction scenario).
- End-to-end with the patched build: a local finished run with a 2.12 MiB log ("+1.4 MiB evicted" client-side), scrubbing to seq 3 (clamp ≈ 28 KB, deep inside the evicted head) now renders **412 lines** from the fetched prefix; mid-run scrub renders 11,360 stitched lines; "No log captured." no longer appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)