### PR TITLE
chore(openapi): regen spec — main drifted via direct pushes

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -481,6 +481,9 @@
       },
       "ExternalRef": {
         "properties": {
+          "author": {
+            "type": "string"
+          },
           "connection_id": {
             "type": "string"
           },

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -4529,6 +4529,7 @@ export interface components {
             status: string;
         };
         ExternalRef: {
+            author?: string;
             connection_id: string;
             number: number;
             provider: string;


### PR DESCRIPTION
Direct-to-main commits landed route changes without running
task openapi:gen; the CI drift gate then failed EVERY merge-queue
rebuild (main + PR), silently dropping queued PRs in a loop.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
