### PR TITLE
fix(runner): sandbox-by-default at the runner entry point

### DIFF
--- a/cmd/iterion/runner.go
+++ b/cmd/iterion/runner.go
@@ -244,9 +244,9 @@ func runRunner(cmd *cobra.Command, _ []string) error {
 		// ITERION_SANDBOX_OVERRIDE=none without this left cloud runs
 		// executing unsandboxed in the runner pod, because the runner
 		// wired the raw (empty) config value and the engine is neutral.
-		SandboxDefault:    resolveRunnerSandboxDefault(cfg.Sandbox.Default),
-		SandboxHostState:  cfg.Sandbox.HostState,
-		SandboxOverride:   cfg.Sandbox.Override,
+		SandboxDefault:   resolveRunnerSandboxDefault(cfg.Sandbox.Default),
+		SandboxHostState: cfg.Sandbox.HostState,
+		SandboxOverride:  cfg.Sandbox.Override,
 	})
 	if err != nil {
 		return fmt.Errorf("runner: build: %w", err)

--- a/cmd/iterion/runner.go
+++ b/cmd/iterion/runner.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -22,6 +23,18 @@ import (
 	mongostore "github.com/SocialGouv/iterion/pkg/store/mongo"
 	"github.com/spf13/cobra"
 )
+
+// resolveRunnerSandboxDefault applies sandbox-by-default to the runner
+// entry point: an explicit config value (ITERION_SANDBOX_DEFAULT or the
+// config file) wins; unset resolves to auto, mirroring
+// runtime.ResolveGlobalSandboxDefault for the other entry points. Set
+// ITERION_SANDBOX_DEFAULT=none to restore the historical behaviour.
+func resolveRunnerSandboxDefault(configured string) string {
+	if v := strings.ToLower(strings.TrimSpace(configured)); v != "" {
+		return v
+	}
+	return "auto"
+}
 
 // parseLevel resolves a string level from the loader, falling back to
 // info on parse failure. Shared by the cloud-mode subcommands
@@ -225,7 +238,13 @@ func runRunner(cmd *cobra.Command, _ []string) error {
 		MemoryStore:       memStore,
 		OrgUsage:          orgUsageCounter,
 		BotsPaths:         botsPaths,
-		SandboxDefault:    cfg.Sandbox.Default,
+		// Sandbox-by-default: the runner is a product entry point like
+		// `iterion run` — an unset ITERION_SANDBOX_DEFAULT resolves to
+		// auto. Discovered live (run 019f8a05): lifting the chart's
+		// ITERION_SANDBOX_OVERRIDE=none without this left cloud runs
+		// executing unsandboxed in the runner pod, because the runner
+		// wired the raw (empty) config value and the engine is neutral.
+		SandboxDefault:    resolveRunnerSandboxDefault(cfg.Sandbox.Default),
 		SandboxHostState:  cfg.Sandbox.HostState,
 		SandboxOverride:   cfg.Sandbox.Override,
 	})


### PR DESCRIPTION
The runner wired the raw ITERION_SANDBOX_DEFAULT config value into the
engine; with the chart's ITERION_SANDBOX_OVERRIDE=none lifted (ADR-082
Phase 3) and the env unset, the neutral engine ran cloud workflows
unsandboxed in the runner pod — observed live on run 019f8a05
(host-path devbox provisioning, no sibling sandbox pod). Unset now
resolves to auto, mirroring the other product entry points; an explicit
value (incl. none) still wins.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
