### PR TITLE
fix(sandbox): unusable devcontainer falls back to the default image at the ambient tier

### DIFF
--- a/pkg/runtime/sandbox.go
+++ b/pkg/runtime/sandbox.go
@@ -820,6 +820,24 @@ func resolveSandboxSpec(
 				return nil, source, "", fmt.Errorf("runtime: sandbox: mode=auto but no .devcontainer/devcontainer.json found at %s — add one or switch to inline mode", repoRoot)
 			}
 			if byDefault {
+				// Ambient default: a devcontainer the sandbox cannot use
+				// (parse error, refused runArgs like --privileged, …) must
+				// not disable sandboxing when a default image exists — the
+				// repo's devcontainer serves human dev environments first,
+				// and rejecting it would leave every run on such a repo
+				// permanently unsandboxed (observed live: iterion's own
+				// devcontainer declares --privileged; run 019f8a0b degraded
+				// to unsandboxed instead of using the default image).
+				if defaultImage != "" {
+					var spec sandbox.Spec
+					if wf != nil && wf.Sandbox != nil {
+						spec = fromIRSpec(wf.Sandbox)
+					}
+					spec.Mode = sandbox.ModeAuto
+					spec.Image = defaultImage
+					expandSandboxSpec(&spec, repoRoot)
+					return &spec, source + fmt.Sprintf(" (devcontainer unusable — %v — default image: %s)", err, defaultImage), "", nil
+				}
 				return nil, source, fmt.Sprintf("devcontainer.json unreadable: %v", err), nil
 			}
 			return nil, source, "", fmt.Errorf("runtime: sandbox: read devcontainer.json: %w", err)

--- a/pkg/runtime/sandbox_internal_test.go
+++ b/pkg/runtime/sandbox_internal_test.go
@@ -510,15 +510,28 @@ func TestResolveSandboxSpecDefaultTierDegrades(t *testing.T) {
 	if wErr := os.WriteFile(filepath.Join(repo, ".devcontainer", "devcontainer.json"), []byte("{not json"), 0o644); wErr != nil {
 		t.Fatalf("write: %v", wErr)
 	}
+	// With a default image available, a broken devcontainer falls back to
+	// it (still sandboxed); only WITHOUT a default image does the run
+	// degrade to unsandboxed with a visible skipReason.
 	spec, _, skipReason, err = resolveSandboxSpec(&ir.Workflow{}, repo, "", "auto", "ghcr.io/test/sandbox:v1")
 	if err != nil {
-		t.Fatalf("default-tier auto with a broken devcontainer must degrade, got err: %v", err)
+		t.Fatalf("default-tier auto with a broken devcontainer must not error, got: %v", err)
+	}
+	if spec == nil || spec.Image != "ghcr.io/test/sandbox:v1" {
+		t.Fatalf("expected default-image fallback spec, got %+v", spec)
+	}
+	if skipReason != "" {
+		t.Errorf("default-image fallback must not carry a skipReason, got %q", skipReason)
+	}
+	spec, _, skipReason, err = resolveSandboxSpec(&ir.Workflow{}, repo, "", "auto", "")
+	if err != nil {
+		t.Fatalf("default-tier auto, broken devcontainer, no default image: must degrade, got err: %v", err)
 	}
 	if spec != nil {
 		t.Fatalf("expected nil spec, got %+v", spec)
 	}
 	if skipReason == "" {
-		t.Error("broken-devcontainer degrade must carry a skipReason (sandbox_skipped event)")
+		t.Error("no-default-image degrade must carry a skipReason (sandbox_skipped event)")
 	}
 	if _, _, _, err = resolveSandboxSpec(autoWf, repo, "", "", "ghcr.io/test/sandbox:v1"); err == nil {
 		t.Fatal("explicit auto with a broken devcontainer must error")
@@ -533,5 +546,38 @@ func TestResolveGlobalSandboxDefault(t *testing.T) {
 	t.Setenv("ITERION_SANDBOX_DEFAULT", "NONE")
 	if got := ResolveGlobalSandboxDefault(); got != "none" {
 		t.Errorf("env none: got %q, want none", got)
+	}
+}
+
+func TestResolveSandboxSpecDefaultTierUnusableDevcontainerFallsBack(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".devcontainer"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A devcontainer the sandbox refuses (privileged runArgs) — the
+	// ambient default must fall back to the default image, not to
+	// unsandboxed execution.
+	if err := os.WriteFile(filepath.Join(repo, ".devcontainer", "devcontainer.json"),
+		[]byte(`{"image":"x","runArgs":["--privileged"]}`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	spec, source, skipReason, err := resolveSandboxSpec(&ir.Workflow{}, repo, "", "auto", "ghcr.io/test/sandbox:v1")
+	if err != nil {
+		t.Fatalf("default-tier auto with unusable devcontainer must not error, got: %v", err)
+	}
+	if skipReason != "" {
+		t.Fatalf("must not degrade to unsandboxed (skipReason %q)", skipReason)
+	}
+	if spec == nil || spec.Image != "ghcr.io/test/sandbox:v1" {
+		t.Fatalf("expected default-image spec, got %+v", spec)
+	}
+	if !strings.Contains(source, "devcontainer unusable") {
+		t.Errorf("source = %q, want it to note the unusable devcontainer", source)
+	}
+
+	// Explicit workflow auto keeps the hard error.
+	autoWf := &ir.Workflow{Sandbox: &ir.SandboxSpec{Mode: string(sandbox.ModeAuto)}}
+	if _, _, _, err := resolveSandboxSpec(autoWf, repo, "", "", "ghcr.io/test/sandbox:v1"); err == nil {
+		t.Fatal("explicit auto with unusable devcontainer must error")
 	}
 }


### PR DESCRIPTION
Under sandbox-by-default, a repo whose devcontainer the sandbox refuses
(parse error, rejected runArgs like --privileged) degraded straight to
UNSANDBOXED execution — permanently, for every run on that repo
(observed live: iterion's own devcontainer declares --privileged; cloud
run 019f8a0b skipped its sandbox pod). The devcontainer serves human
dev environments first; when the ambient default selected auto and a
default image exists, fall back to that image (still sandboxed, source
notes the unusable devcontainer). No default image → the previous
visible skip; an EXPLICIT sandbox request keeps the hard error.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
