### PR TITLE
fix(sandbox/k8s): default sandbox.user to the published images' uid

### DIFF
--- a/pkg/sandbox/kubernetes/driver.go
+++ b/pkg/sandbox/kubernetes/driver.go
@@ -202,6 +202,17 @@ func (d *Driver) Prepare(_ context.Context, spec sandbox.Spec) (sandbox.Prepared
 	// validated lazily — translateMounts at manifest-render time produces
 	// a clear error pointing at the offending entry, so authors see the
 	// offending mount string verbatim rather than a generic rejection here.
+	// Default the numeric user before validation: under sandbox-by-default
+	// most specs are the platform's synthetic default-image spec (published
+	// iterion-sandbox-* images, which all run as devbox uid 1000) and carry
+	// no user: field — hard-requiring one made every ambient cloud sandbox
+	// fail at boot (observed live, run 019f8a37). An explicit user: still
+	// wins; for a foreign image whose filesystem expects another uid, the
+	// kubelet's runAsNonRoot/permission failure stays the visible guard.
+	if spec.User == "" {
+		spec.User = defaultPodUser
+		d.logger.Info("kubernetes: sandbox.user not set — defaulting to %s (published iterion sandbox images run as devbox uid 1000); declare user: to override", defaultPodUser)
+	}
 	if err := ValidateSpec(spec); err != nil {
 		return nil, err
 	}
@@ -211,6 +222,11 @@ func (d *Driver) Prepare(_ context.Context, spec sandbox.Spec) (sandbox.Prepared
 	}
 	return &Prepared{spec: spec, workspace: workspace}, nil
 }
+
+// defaultPodUser is the uid:gid a spec without user: runs as on the
+// kubernetes driver — the devbox user every published iterion-sandbox-*
+// image is built with.
+const defaultPodUser = "1000:1000"
 
 // Start applies the pod manifest, waits for Ready, optionally runs
 // post-create, and returns a live [Run] handle.

--- a/pkg/sandbox/kubernetes/driver_defaultuser_test.go
+++ b/pkg/sandbox/kubernetes/driver_defaultuser_test.go
@@ -1,0 +1,48 @@
+package kubernetes
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+)
+
+// A spec without user: (the platform's synthetic default-image spec under
+// sandbox-by-default) defaults to the published images' devbox uid instead
+// of hard-failing at boot.
+func TestPrepareDefaultsUser(t *testing.T) {
+	d := &Driver{kubectl: "kubectl", namespace: "test", logger: iterlog.New(iterlog.LevelInfo, io.Discard)}
+	prepared, err := d.Prepare(context.Background(), sandbox.Spec{
+		Mode:      sandbox.ModeAuto,
+		Image:     "ghcr.io/socialgouv/iterion-sandbox-full:edge",
+		HostState: sandbox.HostStateNone,
+	})
+	if err != nil {
+		t.Fatalf("Prepare must default the user, got: %v", err)
+	}
+	if got := prepared.(*Prepared).spec.User; got != defaultPodUser {
+		t.Fatalf("User = %q, want %q", got, defaultPodUser)
+	}
+	// An explicit user still wins.
+	prepared, err = d.Prepare(context.Background(), sandbox.Spec{
+		Mode:      sandbox.ModeAuto,
+		Image:     "ghcr.io/socialgouv/iterion-sandbox-full:edge",
+		HostState: sandbox.HostStateNone,
+		User:      "1234",
+	})
+	if err != nil {
+		t.Fatalf("explicit user: %v", err)
+	}
+	if got := prepared.(*Prepared).spec.User; got != "1234" {
+		t.Fatalf("User = %q, want 1234", got)
+	}
+	// Non-numeric user still rejected by ValidateSpec.
+	if _, err = d.Prepare(context.Background(), sandbox.Spec{
+		Mode: sandbox.ModeAuto, Image: "x", HostState: sandbox.HostStateNone, User: "devbox",
+	}); err == nil || !strings.Contains(err.Error(), "must be numeric") {
+		t.Fatalf("non-numeric user must be rejected, got: %v", err)
+	}
+}


### PR DESCRIPTION
Hard-requiring user: made every ambient-default cloud sandbox fail at
boot (observed live, run 019f8a37): the platform's synthetic
default-image spec carries no user:, and all published iterion-sandbox-*
images run as devbox uid 1000. Prepare now defaults an empty user to
1000:1000 (logged); an explicit user: wins, non-numeric stays rejected,
and a foreign image expecting another uid still fails visibly at the
kubelet's runAsNonRoot/permission guard.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
