### PR TITLE
fix(sandbox/k8s): git-safe pod workspace — dubious-ownership 128 broke sandbox start on the cutover

### DIFF
--- a/pkg/sandbox/kubernetes/driver_test.go
+++ b/pkg/sandbox/kubernetes/driver_test.go
@@ -79,19 +79,12 @@ func TestPrepareRejectsMissingImage(t *testing.T) {
 	}
 }
 
-func TestPrepareRequiresUser(t *testing.T) {
-	d := &Driver{namespace: "test"}
-	_, err := d.Prepare(context.Background(), sandbox.Spec{
-		Mode:  sandbox.ModeInline,
-		Image: "alpine:3.20",
-	})
-	if err == nil {
-		t.Fatal("expected rejection of spec with empty User (runAsNonRoot would fail at kubelet)")
-	}
-	if !strings.Contains(err.Error(), "sandbox.user") {
-		t.Errorf("error should mention sandbox.user, got: %v", err)
-	}
-}
+// NOTE: Prepare no longer rejects an empty user — sandbox-by-default
+// (#265) defaults it to the published images' devbox uid; that contract
+// (defaulting + explicit-user precedence) is pinned in
+// driver_defaultuser_test.go. ValidateSpec (the doctor-facing battery,
+// which sees the spec BEFORE Prepare's defaulting) still requires one —
+// see validate_test.go.
 
 func TestPrepareRejectsNonNumericUser(t *testing.T) {
 	d := &Driver{namespace: "test"}

--- a/pkg/sandbox/kubernetes/manifest.go
+++ b/pkg/sandbox/kubernetes/manifest.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/SocialGouv/iterion/pkg/sandbox"
@@ -220,6 +221,22 @@ func BuildPodManifest(in PodManifestInput) ([]byte, error) {
 		// them so the network posture matches the documented
 		// "allowlist via iterion proxy" promise.
 		envSlice = upsertEnv(envSlice, "NO_PROXY", "localhost,127.0.0.1")
+	}
+
+	// Git safe.directory for the workspace. The emptyDir mountpoint is
+	// created root-owned by kubelet (fsGroup only sets the group), while
+	// every `kubectl exec` — the post-populate git fixup, the agent's own
+	// git, tool nodes — runs as the non-root workload user, so git ≥2.35.2
+	// rejects the repo at the workspace root as dubiously owned; `git -C
+	// <ws> config …` then fails discovery with the notoriously opaque
+	// "fatal: not in a git directory" (exit 128 — observed live on run
+	// 019f8a50, breaking sandbox start at fixupWorkspaceGit). safe.directory
+	// is only honoured from protected configuration; the GIT_CONFIG_*
+	// environment ("command" scope, git ≥2.38) is the one protected channel
+	// a pod env can carry, and every exec inherits it.
+	envSlice, gitEnvErr := appendGitSafeDirectoryEnv(envSlice, workspace)
+	if gitEnvErr != nil {
+		return nil, fmt.Errorf("kubernetes: %w", gitEnvErr)
 	}
 
 	// Egress TLS-inspection CA (Layer 2): mount the per-run CA Secret and
@@ -572,6 +589,36 @@ func envMapToSlice(env map[string]string) []any {
 		out = append(out, map[string]any{"name": k, "value": env[k]})
 	}
 	return out
+}
+
+// appendGitSafeDirectoryEnv appends `safe.directory=<workspace>` to the
+// pod's GIT_CONFIG_{COUNT,KEY_n,VALUE_n} environment, preserving any
+// entries the spec already carries (their count is read and our entry
+// appended after them). A malformed pre-existing GIT_CONFIG_COUNT is a
+// hard error — silently renumbering (or skipping) would either clobber
+// the workflow's git config or reintroduce the dubious-ownership 128
+// this exists to fix.
+func appendGitSafeDirectoryEnv(envSlice []any, workspace string) ([]any, error) {
+	next := 0
+	for _, e := range envSlice {
+		m, ok := e.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, _ := m["name"].(string); name == "GIT_CONFIG_COUNT" {
+			raw, _ := m["value"].(string)
+			n, err := strconv.Atoi(strings.TrimSpace(raw))
+			if err != nil || n < 0 {
+				return nil, fmt.Errorf("spec env GIT_CONFIG_COUNT=%q is not a non-negative integer; fix it so the workspace safe.directory entry can be appended", raw)
+			}
+			next = n
+			break
+		}
+	}
+	envSlice = upsertEnv(envSlice, fmt.Sprintf("GIT_CONFIG_KEY_%d", next), "safe.directory")
+	envSlice = upsertEnv(envSlice, fmt.Sprintf("GIT_CONFIG_VALUE_%d", next), workspace)
+	envSlice = upsertEnv(envSlice, "GIT_CONFIG_COUNT", strconv.Itoa(next+1))
+	return envSlice, nil
 }
 
 // upsertEnv replaces (or appends) an env var on the slice. Used to

--- a/pkg/sandbox/kubernetes/manifest_gitenv_test.go
+++ b/pkg/sandbox/kubernetes/manifest_gitenv_test.go
@@ -1,0 +1,105 @@
+package kubernetes
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+)
+
+// manifestEnv extracts the workload container's env as a name→value map
+// from a rendered pod manifest.
+func manifestEnv(t *testing.T, manifest []byte) map[string]string {
+	t.Helper()
+	var pod struct {
+		Spec struct {
+			Containers []struct {
+				Env []struct {
+					Name  string `json:"name"`
+					Value string `json:"value"`
+				} `json:"env"`
+			} `json:"containers"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal(manifest, &pod); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if len(pod.Spec.Containers) != 1 {
+		t.Fatalf("containers = %d, want 1", len(pod.Spec.Containers))
+	}
+	env := map[string]string{}
+	for _, e := range pod.Spec.Containers[0].Env {
+		env[e.Name] = e.Value
+	}
+	return env
+}
+
+// TestBuildPodManifest_GitSafeDirectoryEnv pins the fix for the live
+// prod failure (run 019f8a50): the workspace emptyDir mountpoint is
+// root-owned (kubelet; fsGroup only sets the group) while every exec
+// runs as the non-root workload user, so git ≥2.35.2 flags the repo at
+// the workspace root as dubiously owned and `git -C <ws> config` dies
+// with "fatal: not in a git directory" (exit 128) — killing sandbox
+// start at fixupWorkspaceGit. The pod env must carry safe.directory for
+// the workspace via the protected GIT_CONFIG_* command scope, which
+// every kubectl exec (fixup, agent git, tool nodes) inherits.
+func TestBuildPodManifest_GitSafeDirectoryEnv(t *testing.T) {
+	t.Run("default workspace", func(t *testing.T) {
+		out, err := BuildPodManifest(PodManifestInput{
+			Namespace: "ns", Name: "iterion-run-x", Spec: sandbox.Spec{Image: "img"},
+		})
+		if err != nil {
+			t.Fatalf("BuildPodManifest: %v", err)
+		}
+		env := manifestEnv(t, out)
+		if env["GIT_CONFIG_COUNT"] != "1" || env["GIT_CONFIG_KEY_0"] != "safe.directory" || env["GIT_CONFIG_VALUE_0"] != "/workspace" {
+			t.Fatalf("safe.directory env not injected for the default workspace: %v", env)
+		}
+	})
+
+	t.Run("host-mirror workspace mount (the repo-targeted cloud shape)", func(t *testing.T) {
+		out, err := BuildPodManifest(PodManifestInput{
+			Namespace: "ns", Name: "iterion-run-x",
+			Spec:           sandbox.Spec{Image: "img"},
+			WorkspaceMount: "/tmp/iterion/repos/run-1",
+		})
+		if err != nil {
+			t.Fatalf("BuildPodManifest: %v", err)
+		}
+		env := manifestEnv(t, out)
+		if env["GIT_CONFIG_VALUE_0"] != "/tmp/iterion/repos/run-1" {
+			t.Fatalf("safe.directory must target the mounted workspace path: %v", env)
+		}
+	})
+
+	t.Run("pre-existing GIT_CONFIG entries are preserved, ours appended", func(t *testing.T) {
+		out, err := BuildPodManifest(PodManifestInput{
+			Namespace: "ns", Name: "iterion-run-x",
+			Spec: sandbox.Spec{Image: "img", Env: map[string]string{
+				"GIT_CONFIG_COUNT":   "1",
+				"GIT_CONFIG_KEY_0":   "commit.gpgsign",
+				"GIT_CONFIG_VALUE_0": "false",
+			}},
+		})
+		if err != nil {
+			t.Fatalf("BuildPodManifest: %v", err)
+		}
+		env := manifestEnv(t, out)
+		if env["GIT_CONFIG_KEY_0"] != "commit.gpgsign" || env["GIT_CONFIG_VALUE_0"] != "false" {
+			t.Fatalf("pre-existing git-config env clobbered: %v", env)
+		}
+		if env["GIT_CONFIG_COUNT"] != "2" || env["GIT_CONFIG_KEY_1"] != "safe.directory" || env["GIT_CONFIG_VALUE_1"] != "/workspace" {
+			t.Fatalf("safe.directory not appended after existing entries: %v", env)
+		}
+	})
+
+	t.Run("malformed GIT_CONFIG_COUNT is a hard error", func(t *testing.T) {
+		_, err := BuildPodManifest(PodManifestInput{
+			Namespace: "ns", Name: "iterion-run-x",
+			Spec: sandbox.Spec{Image: "img", Env: map[string]string{"GIT_CONFIG_COUNT": "banana"}},
+		})
+		if err == nil {
+			t.Fatal("expected a hard error on a malformed GIT_CONFIG_COUNT")
+		}
+	})
+}

--- a/pkg/sandbox/kubernetes/workspace_test.go
+++ b/pkg/sandbox/kubernetes/workspace_test.go
@@ -120,6 +120,78 @@ func TestFixupWorkspaceGitScript(t *testing.T) {
 	}
 }
 
+// TestFixupWorkspaceGitScript_DubiousOwnership replicates the REAL pod
+// condition that killed prod run 019f8a50: the workspace emptyDir
+// mountpoint is root-owned (kubelet creates it; fsGroup only sets the
+// group) while the exec user is the non-root workload uid, so git's
+// safe.directory check rejects the repo and `git -C <ws> config` dies
+// with the opaque "fatal: not in a git directory" (exit 128). Simulated
+// with git's own GIT_TEST_ASSUME_DIFFERENT_OWNER knob (the same one
+// git's test suite uses — no root needed). The pod-env fix
+// (BuildPodManifest's GIT_CONFIG_* safe.directory, inherited by every
+// kubectl exec) must make the exact same script pass.
+func TestFixupWorkspaceGitScript_DubiousOwnership(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "init", "-q", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	credPath := filepath.Join(dir, ".git", "iterion-credentials")
+	if err := os.WriteFile(credPath, []byte("https://oauth2:tok@example.com\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sanity: the knob must actually break repository discovery on this
+	// host's git (≥2.35.2). If it doesn't (ancient git), the regression
+	// can't be exercised here.
+	probe := exec.Command("git", "-C", dir, "rev-parse", "--git-dir")
+	probe.Env = append(os.Environ(), "GIT_TEST_ASSUME_DIFFERENT_OWNER=1")
+	if err := probe.Run(); err == nil {
+		t.Skip("this git does not honour GIT_TEST_ASSUME_DIFFERENT_OWNER; cannot simulate the root-owned pod workspace")
+	}
+
+	// WITHOUT the pod env: the exact live failure — exit 128.
+	cmd := exec.Command("sh", "-c", fixupWorkspaceGitScript, "sh", dir)
+	cmd.Env = append(os.Environ(), "GIT_TEST_ASSUME_DIFFERENT_OWNER=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected the fixup to fail under dubious ownership (the live 128), got success:\n%s", out)
+	}
+	if ee, ok := err.(*exec.ExitError); !ok || ee.ExitCode() != 128 {
+		t.Fatalf("expected exit 128, got %v\n%s", err, out)
+	}
+
+	// WITH the env BuildPodManifest now injects (safe.directory for the
+	// workspace, protected command scope): the same script succeeds and
+	// re-points the credential helper.
+	cmd = exec.Command("sh", "-c", fixupWorkspaceGitScript, "sh", dir)
+	cmd.Env = append(os.Environ(),
+		"GIT_TEST_ASSUME_DIFFERENT_OWNER=1",
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=safe.directory",
+		"GIT_CONFIG_VALUE_0="+dir,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("fixup with safe.directory env: %v\n%s", err, out)
+	}
+	read := exec.Command("git", "-C", dir, "config", "credential.helper")
+	read.Env = append(os.Environ(),
+		"GIT_TEST_ASSUME_DIFFERENT_OWNER=1",
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=safe.directory",
+		"GIT_CONFIG_VALUE_0="+dir,
+	)
+	got, err := read.Output()
+	if err != nil {
+		t.Fatalf("read credential.helper: %v", err)
+	}
+	if want := "store --file=" + credPath; strings.TrimSpace(string(got)) != want {
+		t.Errorf("credential.helper = %q, want %q", strings.TrimSpace(string(got)), want)
+	}
+}
+
 // TestExportWorkspace_WorkspaceLessRunIsNoop pins the export gate: a run
 // that never populated a workspace (RunInfo.WorkspacePath empty) has
 // nothing to write back and must not shell out at all.


### PR DESCRIPTION
## Root cause (prod run 019f8a50, first real k8s-cutover execution)

`sandbox start: … fixup workspace git: exited 128: fatal: not in a git directory`.

Not a path mismatch, not an ordering bug, not `git config --local` outside a repo — hypotheses (1)/(2)/(4) verified clean (populate and fixup both target the same `p.workspace`, populate's `tar` fully waits before the fixup runs, and the script guards on `[ -d "$ws/.git" ]`). It is hypothesis **(3): ownership**:

- The workspace emptyDir **mountpoint is created root-owned by kubelet** — `fsGroup: 1000` only sets the *group* (setgid), the owner stays `root`.
- Every `kubectl exec` runs as the workload user — **1000:1000** since `Prepare`'s user default (#265, the exact prod config).
- git ≥ 2.35.2's `safe.directory` protection flags a repo whose worktree root is owned by another user as *dubious*, which makes repository **discovery** fail — and `git -C <ws> config …` (a local-config write) then surfaces the notoriously opaque `fatal: not in a git directory`, exit 128.

Reproduced exactly (real git, using git's own `GIT_TEST_ASSUME_DIFFERENT_OWNER` simulation knob — the one its test suite uses): the shipped fixup script exits **128** with the same message; with `safe.directory` supplied through the `GIT_CONFIG_*` environment it succeeds. Had the fixup not tripped first, the agent's first in-pod `git status` would have hit the same wall.

## Fix

`BuildPodManifest` now injects `safe.directory=<workspace>` into the **pod env** via `GIT_CONFIG_{COUNT,KEY_n,VALUE_n}` — the one *protected-configuration* channel (`command` scope, git ≥ 2.38; the images ship ≥ 2.39) that a pod env can carry (`safe.directory` is deliberately ignored in repo-local config). Every `kubectl exec` inherits the container env, so one injection covers the post-populate fixup, the agent's own git, and tool nodes alike.

- Pre-existing `GIT_CONFIG_*` entries in the spec env are preserved — ours is appended after them and the count updated.
- A malformed pre-existing `GIT_CONFIG_COUNT` is a **hard error** (silent renumbering would clobber the workflow's git config or silently reintroduce the 128).
- Value is the exact workspace path (least privilege), matching both the default `/workspace` and the host-mirror mount used by repo-targeted cloud runs (`/tmp/iterion/repos/<run-id>`).

Also removed in passing: the stale `TestPrepareRequiresUser`, red on main since #265 (direct push) switched `Prepare` to *default* the empty user (its replacement, `TestPrepareDefaultsUser` in `driver_defaultuser_test.go`, already pins the new contract; `ValidateSpec` still requires a user — `validate_test.go`).

## Test evidence

- `TestFixupWorkspaceGitScript_DubiousOwnership` — replicates the REAL pod condition against the exact script bytes: **without** the env → exit **128** (the live failure, asserted); **with** the env `BuildPodManifest` now injects → the same script succeeds and re-points the credential helper. Self-skips on a git too old to honour the simulation knob.
- `TestBuildPodManifest_GitSafeDirectoryEnv` — default `/workspace`, host-mirror workspace mount, pre-existing `GIT_CONFIG_*` preservation + append, malformed-count hard error.
- `go build ./...` ✓ · `go vet` ✓ · `gofmt` clean · `go test ./pkg/sandbox/... ./pkg/runtime/ ./pkg/runner/` ✓ (incl. the previously-red kubernetes package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
