### PR TITLE
fix(pipelines): keep human reviews in FIFO order

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -942,12 +942,17 @@
           "run_id": {
             "type": "string"
           },
+          "updated_at": {
+            "format": "date-time",
+            "type": "string"
+          },
           "workflow_name": {
             "type": "string"
           }
         },
         "required": [
           "run_id",
+          "updated_at",
           "depth"
         ],
         "type": "object"

--- a/pkg/server/pipeline_boards_projection.go
+++ b/pkg/server/pipeline_boards_projection.go
@@ -560,6 +560,7 @@ func (b *pipelineProjectionBuilder) aggregateTree(root *store.Run) (treeExec, tr
 				NodeID:        run.Checkpoint.NodeID,
 				InteractionID: run.Checkpoint.InteractionID,
 				Questions:     cloneAnyMap(run.Checkpoint.InteractionQuestions),
+				UpdatedAt:     b.pendingReviewUpdatedAt(run),
 				Depth:         depth,
 			})
 		}
@@ -568,5 +569,41 @@ func (b *pipelineProjectionBuilder) aggregateTree(root *store.Run) (treeExec, tr
 		}
 	}
 	walk(root, 0)
+	// FIFO by the time each pending turn was requested. In particular, a
+	// review gate that resumes and re-pauses is a new turn and belongs at the
+	// back of the queue, even though its run keeps the same place in the tree.
+	sort.SliceStable(reviews, func(i, j int) bool {
+		a, c := reviews[i], reviews[j]
+		if !a.UpdatedAt.Equal(c.UpdatedAt) {
+			return a.UpdatedAt.Before(c.UpdatedAt)
+		}
+		if a.RunID != c.RunID {
+			return a.RunID < c.RunID
+		}
+		if a.NodeID != c.NodeID {
+			return a.NodeID < c.NodeID
+		}
+		return a.InteractionID < c.InteractionID
+	})
 	return
+}
+
+// pendingReviewUpdatedAt returns the enqueue time of the current pending
+// interaction. Interaction.RequestedAt is precise for guided review gates:
+// every new companion turn rewrites the stable interaction ID with a fresh
+// request timestamp. Legacy/missing interactions fall back to the run stamp.
+func (b *pipelineProjectionBuilder) pendingReviewUpdatedAt(run *store.Run) time.Time {
+	if run == nil {
+		return time.Time{}
+	}
+	if b.rs != nil && run.Checkpoint != nil && run.Checkpoint.InteractionID != "" {
+		interaction, err := b.rs.LoadInteraction(b.ctx, run.ID, run.Checkpoint.InteractionID)
+		if err == nil && interaction != nil && !interaction.RequestedAt.IsZero() {
+			return interaction.RequestedAt
+		}
+	}
+	if !run.UpdatedAt.IsZero() {
+		return run.UpdatedAt
+	}
+	return run.CreatedAt
 }

--- a/pkg/server/pipeline_boards_test.go
+++ b/pkg/server/pipeline_boards_test.go
@@ -253,6 +253,82 @@ func TestPipelineBoardFoldsDescendantsAndCollectsReviews(t *testing.T) {
 	}
 }
 
+func TestPipelineBoardPendingReviewsOldestUpdateFirstAndRepauseMovesToBack(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	base := time.Date(2026, time.July, 22, 10, 0, 0, 0, time.UTC)
+	env.seedRun(t, "review-root", "review", store.RunStatusRunning, func(run *store.Run) {
+		run.CreatedAt = base.Add(-time.Hour)
+		run.UpdatedAt = run.CreatedAt
+	})
+
+	seedReview := func(id string, createdAt, requestedAt time.Time) {
+		t.Helper()
+		interactionID := id + "_gate"
+		env.seedRun(t, id, "review", store.RunStatusPausedWaitingHuman, func(run *store.Run) {
+			run.ParentRunID = "review-root"
+			run.CreatedAt = createdAt
+			run.UpdatedAt = requestedAt
+			run.Checkpoint = &store.Checkpoint{
+				NodeID:               "gate",
+				InteractionID:        interactionID,
+				InteractionQuestions: map[string]any{"reply": id + "?"},
+			}
+		})
+		if err := env.runStore(t).WriteInteraction(context.Background(), &store.Interaction{
+			ID:          interactionID,
+			RunID:       id,
+			NodeID:      "gate",
+			RequestedAt: requestedAt,
+			Questions:   map[string]any{"reply": id + "?"},
+		}); err != nil {
+			t.Fatalf("WriteInteraction(%s): %v", id, err)
+		}
+	}
+
+	// Tree order is A, B, C by creation time. The review queue initially has
+	// the same order for a different reason: the pending-turn update stamps.
+	seedReview("ai-a", base.Add(-3*time.Minute), base)
+	seedReview("ai-b", base.Add(-2*time.Minute), base.Add(time.Minute))
+	seedReview("ai-c", base.Add(-time.Minute), base.Add(2*time.Minute))
+
+	assertQueue := func(wantIDs []string, wantTimes []time.Time) {
+		t.Helper()
+		card := findPipelineCard(t, env.projection(t).Cards, "run:review-root")
+		if len(card.PendingReviews) != len(wantIDs) {
+			t.Fatalf("pending_reviews = %+v, want %v", card.PendingReviews, wantIDs)
+		}
+		for i, wantID := range wantIDs {
+			got := card.PendingReviews[i]
+			if got.RunID != wantID || !got.UpdatedAt.Equal(wantTimes[i]) {
+				t.Errorf("pending_reviews[%d] = (%s, %s), want (%s, %s)",
+					i, got.RunID, got.UpdatedAt, wantID, wantTimes[i])
+			}
+		}
+	}
+
+	assertQueue(
+		[]string{"ai-a", "ai-b", "ai-c"},
+		[]time.Time{base, base.Add(time.Minute), base.Add(2 * time.Minute)},
+	)
+
+	// Guided reviews reuse the same run/node/interaction ID. Rewriting A's
+	// interaction with a fresh request stamp models its next AI turn: it must
+	// join the back instead of reclaiming A's structural position in the tree.
+	if err := env.runStore(t).WriteInteraction(context.Background(), &store.Interaction{
+		ID:          "ai-a_gate",
+		RunID:       "ai-a",
+		NodeID:      "gate",
+		RequestedAt: base.Add(3 * time.Minute),
+		Questions:   map[string]any{"reply": "ai-a next turn?"},
+	}); err != nil {
+		t.Fatalf("rewrite ai-a interaction: %v", err)
+	}
+	assertQueue(
+		[]string{"ai-b", "ai-c", "ai-a"},
+		[]time.Time{base.Add(time.Minute), base.Add(2 * time.Minute), base.Add(3 * time.Minute)},
+	)
+}
+
 // Root status maps to the five lanes; queued is TODO (waiting for a slot).
 func TestPipelineBoardColumnBucketing(t *testing.T) {
 	env := newPipelineBoardTestEnv(t)

--- a/pkg/server/pipeline_boards_types.go
+++ b/pkg/server/pipeline_boards_types.go
@@ -42,6 +42,10 @@ type PipelineBoardPendingReview struct {
 	NodeID        string         `json:"node_id,omitempty"`
 	InteractionID string         `json:"interaction_id,omitempty"`
 	Questions     map[string]any `json:"questions,omitempty"`
+	// UpdatedAt is when this exact pending turn joined the operator queue.
+	// Review gates reuse their interaction ID across dialogue turns, so the
+	// timestamp also versions the form on the Studio side.
+	UpdatedAt time.Time `json:"updated_at"`
 	// Depth is 0 for the root's own pause, >0 for a descendant's.
 	Depth int `json:"depth"`
 }

--- a/studio/src/api/pipelineBoards.test.ts
+++ b/studio/src/api/pipelineBoards.test.ts
@@ -46,6 +46,7 @@ describe("normalizePipelineBoard", () => {
               run_id: "run-child",
               node_id: "approval",
               depth: 1,
+              updated_at: "2026-07-14T09:30:00Z",
               questions: { approved: "Ship it?" },
             },
           ],
@@ -112,6 +113,7 @@ describe("normalizePipelineBoard", () => {
       run_id: "run-child",
       node_id: "approval",
       depth: 1,
+      updated_at: "2026-07-14T09:30:00Z",
       questions: { approved: "Ship it?" },
     });
     expect(board.cards[1]).toMatchObject({

--- a/studio/src/api/pipelineBoards.ts
+++ b/studio/src/api/pipelineBoards.ts
@@ -26,6 +26,8 @@ export interface PipelineBoardPendingReview {
   node_id?: string;
   interaction_id?: string;
   questions?: Record<string, unknown>;
+  /** When this exact pending turn joined the FIFO review queue. */
+  updated_at: string;
   depth: number;
 }
 
@@ -340,6 +342,7 @@ function normalizePendingReviews(
         ? { interaction_id: text(source.interaction_id) }
         : {}),
       ...(questions ? { questions } : {}),
+      updated_at: text(source.updated_at) ?? "",
       depth: Math.max(0, intValue(source.depth, 0)),
     };
   });

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -4666,6 +4666,8 @@ export interface components {
                 [key: string]: unknown;
             };
             run_id: string;
+            /** Format: date-time */
+            updated_at: string;
             workflow_name?: string;
         };
         PipelineBoardResponse: {

--- a/studio/src/views/PipelineBoard/PipelineCardDetails.test.tsx
+++ b/studio/src/views/PipelineBoard/PipelineCardDetails.test.tsx
@@ -113,7 +113,13 @@ describe("PipelineCardDetailsBody", () => {
         status: "running",
         entry_input: { topic: "jazz" },
         pending_reviews: [
-          { run_id: "run-child", node_id: "approval", depth: 1, questions: { approved: "Ship it?" } },
+          {
+            run_id: "run-child",
+            node_id: "approval",
+            depth: 1,
+            updated_at: "2026-07-15T09:30:00Z",
+            questions: { approved: "Ship it?" },
+          },
         ],
       }),
     );
@@ -132,7 +138,14 @@ describe("PipelineCardDetailsBody", () => {
         run_id: "run-orphan",
         status: "failed_resumable",
         failed: true,
-        pending_reviews: [{ run_id: "c1", node_id: "review", depth: 1 }],
+        pending_reviews: [
+          {
+            run_id: "c1",
+            node_id: "review",
+            depth: 1,
+            updated_at: "2026-07-15T09:30:00Z",
+          },
+        ],
       }),
     );
     expect(html).toContain("Response required");
@@ -146,7 +159,14 @@ describe("PipelineCardDetailsBody", () => {
         column_id: "in_progress",
         run_id: "run-ok",
         status: "running",
-        pending_reviews: [{ run_id: "c1", node_id: "review", depth: 1 }],
+        pending_reviews: [
+          {
+            run_id: "c1",
+            node_id: "review",
+            depth: 1,
+            updated_at: "2026-07-15T09:30:00Z",
+          },
+        ],
       }),
     );
     expect(html).toContain("Response required");

--- a/studio/src/views/PipelineBoard/PipelineColumns.test.tsx
+++ b/studio/src/views/PipelineBoard/PipelineColumns.test.tsx
@@ -314,6 +314,7 @@ describe("PipelineColumns", () => {
               run_id: "run-child",
               node_id: "approval",
               depth: 1,
+              updated_at: "2026-07-15T09:30:00Z",
               questions: { approved: "Ship it?" },
             },
           ],
@@ -349,7 +350,14 @@ describe("PipelineColumns", () => {
           failed: true,
           tree_executed_nodes: 3,
           tree_total_nodes: 10,
-          pending_reviews: [{ run_id: "c1", node_id: "review", depth: 1 }],
+          pending_reviews: [
+            {
+              run_id: "c1",
+              node_id: "review",
+              depth: 1,
+              updated_at: "2026-07-15T09:30:00Z",
+            },
+          ],
         }),
       ]),
     );
@@ -369,9 +377,24 @@ describe("PipelineColumns", () => {
           tree_executed_nodes: 2,
           tree_total_nodes: 8,
           pending_reviews: [
-            { run_id: "c1", node_id: "review", depth: 1 },
-            { run_id: "c2", node_id: "review", depth: 1 },
-            { run_id: "c3", node_id: "review", depth: 1 },
+            {
+              run_id: "c1",
+              node_id: "review",
+              depth: 1,
+              updated_at: "2026-07-15T09:30:00Z",
+            },
+            {
+              run_id: "c2",
+              node_id: "review",
+              depth: 1,
+              updated_at: "2026-07-15T09:31:00Z",
+            },
+            {
+              run_id: "c3",
+              node_id: "review",
+              depth: 1,
+              updated_at: "2026-07-15T09:32:00Z",
+            },
           ],
         }),
       ]),

--- a/studio/src/views/PipelineBoard/SequentialReviews.test.tsx
+++ b/studio/src/views/PipelineBoard/SequentialReviews.test.tsx
@@ -1,7 +1,15 @@
-import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+// @vitest-environment jsdom
 
-import type { PipelineBoardCard } from "@/api/pipelineBoards";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  PipelineBoardCard,
+  PipelineBoardPendingReview,
+} from "@/api/pipelineBoards";
+
+afterEach(cleanup);
 
 vi.mock("wouter", () => ({
   Link: ({
@@ -15,35 +23,45 @@ vi.mock("wouter", () => ({
   ),
 }));
 
-// The real HumanPromptForm owns the answer POST + resume. The mock forwards
-// the identity props and, crucially, invokes `onResumed` during render so the
-// static-render assertions can observe SequentialReviews wiring it to
-// `onResolved` (the board refetch) without a DOM click.
+// The real HumanPromptForm owns the draft + answer POST. This small stateful
+// DOM stand-in lets the queue test prove that React keeps the exact active
+// form mounted (and therefore preserves its in-progress draft) across polls.
 vi.mock("@/components/Runs/conversation/HumanPromptForm", () => ({
   default: (props: {
     runId: string;
     nodeId: string;
+    questions: Record<string, unknown>;
     sourceOverride?: string | null;
     onResumed?: () => void;
-  }) => {
-    props.onResumed?.();
-    return (
-      <div
-        data-testid="human-prompt"
-        data-run-id={props.runId}
-        data-node-id={props.nodeId}
-        data-source-null={props.sourceOverride === null ? "yes" : "no"}
-      />
-    );
-  },
+  }) => (
+    <div
+      data-testid="human-prompt"
+      data-run-id={props.runId}
+      data-node-id={props.nodeId}
+      data-question={String(props.questions.q ?? "")}
+      data-source-null={props.sourceOverride === null ? "yes" : "no"}
+    >
+      <input aria-label="Review draft" defaultValue="" />
+      <button type="button" onClick={props.onResumed}>
+        Resolve
+      </button>
+    </div>
+  ),
 }));
 
-import { SequentialReviews, clampReviewIndex } from "./SequentialReviews";
+import {
+  clampReviewIndex,
+  pendingReviewVersionKey,
+  sortPendingReviewsChronologically,
+} from "./reviewQueue";
+import { SequentialReviews } from "./SequentialReviews";
 
 function cardWithReviews(count: number): PipelineBoardCard {
   const pending = Array.from({ length: count }, (_, i) => ({
     run_id: `run-${i}`,
     node_id: `review_${i}`,
+    interaction_id: `interaction-${i}`,
+    updated_at: `2026-07-14T10:0${i}:00Z`,
     depth: i,
     questions: { q: `Q${i}?` },
   }));
@@ -73,6 +91,24 @@ describe("clampReviewIndex", () => {
   });
 });
 
+describe("review queue helpers", () => {
+  it("orders pending turns oldest first and versions a reused interaction by update", () => {
+    const a = cardWithReviews(1).pending_reviews?.[0] as PipelineBoardPendingReview;
+    const a2 = { ...a, updated_at: "2026-07-14T10:03:00Z" };
+    const b = {
+      ...a,
+      run_id: "run-b",
+      interaction_id: "interaction-b",
+      updated_at: "2026-07-14T10:01:00Z",
+    };
+    expect(sortPendingReviewsChronologically([a2, b]).map((r) => r.run_id)).toEqual([
+      "run-b",
+      "run-0",
+    ]);
+    expect(pendingReviewVersionKey(a2)).not.toBe(pendingReviewVersionKey(a));
+  });
+});
+
 describe("SequentialReviews", () => {
   it("mounts the first review one at a time, resuming with no source override", () => {
     const html = renderToStaticMarkup(
@@ -93,12 +129,65 @@ describe("SequentialReviews", () => {
 
   it("wires a successful answer to onResolved (the board refetch)", () => {
     const onResolved = vi.fn();
-    renderToStaticMarkup(
+    render(
       <SequentialReviews card={cardWithReviews(2)} onResolved={onResolved} />,
     );
-    // The mock invokes onResumed for the single mounted review; the component
-    // must route it to onResolved.
+    fireEvent.click(screen.getByRole("button", { name: "Resolve" }));
     expect(onResolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the active form and draft mounted while a newer AI turn joins the back", () => {
+    const pending = cardWithReviews(3).pending_reviews;
+    const a = pending?.[0];
+    const b = pending?.[1];
+    const c = pending?.[2];
+    if (!a || !b || !c) throw new Error("test requires three pending reviews");
+    const a2: PipelineBoardPendingReview = {
+      ...a,
+      updated_at: "2026-07-14T10:03:00Z",
+      questions: { q: "A2?" },
+    };
+    const view = render(
+      <SequentialReviews
+        card={{ ...cardWithReviews(3), pending_reviews: [c, a, b] }}
+        onResolved={() => {}}
+      />,
+    );
+
+    // FIFO sorting starts on A; resolving it immediately pins the next turn B
+    // even before the board refetch has returned.
+    expect(screen.getByTestId("human-prompt").getAttribute("data-run-id")).toBe(a.run_id);
+    fireEvent.click(screen.getByRole("button", { name: "Resolve" }));
+    expect(screen.getByTestId("human-prompt").getAttribute("data-run-id")).toBe(b.run_id);
+    fireEvent.change(screen.getByRole("textbox", { name: "Review draft" }), {
+      target: { value: "draft for B" },
+    });
+
+    // A's next turn has the same run/node/interaction identity but a newer
+    // update. It joins the back; polling must not replace B with C or A2.
+    view.rerender(
+      <SequentialReviews
+        card={{ ...cardWithReviews(3), pending_reviews: [b, c, a2] }}
+        onResolved={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("human-prompt").getAttribute("data-run-id")).toBe(b.run_id);
+    expect(
+      (screen.getByRole("textbox", { name: "Review draft" }) as HTMLInputElement).value,
+    ).toBe("draft for B");
+    expect(screen.getByTestId("human-prompt").getAttribute("data-question")).not.toBe("A2?");
+
+    // Once B is resolved/removed, the next oldest turn C gets the screen.
+    // A2 appears only when the operator explicitly advances to its turn.
+    view.rerender(
+      <SequentialReviews
+        card={{ ...cardWithReviews(3), pending_reviews: [c, a2] }}
+        onResolved={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("human-prompt").getAttribute("data-run-id")).toBe(c.run_id);
+    fireEvent.click(screen.getByRole("button", { name: "Next review" }));
+    expect(screen.getByTestId("human-prompt").getAttribute("data-question")).toBe("A2?");
   });
 
   it("renders nothing when there are no pending reviews", () => {

--- a/studio/src/views/PipelineBoard/SequentialReviews.tsx
+++ b/studio/src/views/PipelineBoard/SequentialReviews.tsx
@@ -1,24 +1,22 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "wouter";
 
 import type { PipelineBoardCard } from "@/api/pipelineBoards";
 import HumanPromptForm from "@/components/Runs/conversation/HumanPromptForm";
 import { Badge, Button, InlineBanner } from "@/components/ui";
 
+import {
+  clampReviewIndex,
+  pendingReviewVersionKey,
+  sortPendingReviewsChronologically,
+} from "./reviewQueue";
+
 interface Props {
   card: PipelineBoardCard;
-  // Refetches the board. Called after every successful answer BEFORE the
-  // operator advances, because resuming a review can retire it or spawn new
-  // child reviews — the fresh projection is authoritative.
+  // Refetches the board after every successful answer. The component pins the
+  // next existing turn first; the fresh projection may then retire the old
+  // review or append a new turn without replacing the active form.
   onResolved: () => void;
-}
-
-// clampReviewIndex keeps the active review index inside [0, total). The board
-// refetch after each answer can shrink the pending set out from under the
-// current index, so every read clamps.
-export function clampReviewIndex(index: number, total: number): number {
-  if (total <= 0) return 0;
-  return Math.min(Math.max(index, 0), total - 1);
 }
 
 // SequentialReviews steps through a card's pending human interactions one at a
@@ -26,15 +24,42 @@ export function clampReviewIndex(index: number, total: number): number {
 // POSTed to the exact run_id/node_id the review names (via HumanPromptForm's
 // existing resume path — not reimplemented here).
 export function SequentialReviews({ card, onResolved }: Props) {
-  const reviews = card.pending_reviews ?? [];
-  const [index, setIndex] = useState(0);
+  const reviews = useMemo(
+    () => sortPendingReviewsChronologically(card.pending_reviews ?? []),
+    [card.pending_reviews],
+  );
+  const reviewKeys = useMemo(
+    () => reviews.map(pendingReviewVersionKey),
+    [reviews],
+  );
+  const [activeReviewKey, setActiveReviewKey] = useState<string | null>(null);
+
+  // Polling may remove an answered turn and append a newer turn from the same
+  // AI. Keep the exact active version mounted while it still exists, so a
+  // draft in another form cannot be replaced underneath the operator. Once
+  // it disappears, continue from the (oldest) head of the refreshed queue.
+  let current = activeReviewKey === null ? -1 : reviewKeys.indexOf(activeReviewKey);
+  if (current < 0) current = 0;
 
   if (reviews.length === 0) return null;
 
   const total = reviews.length;
-  const current = clampReviewIndex(index, total);
   const review = reviews[current];
-  if (!review) return null;
+  const reviewKey = reviewKeys[current];
+  if (!review || !reviewKey) return null;
+
+  const selectReview = (index: number) => {
+    const key = reviewKeys[clampReviewIndex(index, total)];
+    if (key) setActiveReviewKey(key);
+  };
+
+  const handleResolved = () => {
+    // Advance immediately to the oldest other pending turn and pin it before
+    // the refetch returns. A new turn from the just-answered AI can then only
+    // append behind this active form; it cannot steal the screen.
+    setActiveReviewKey(reviewKeys.find((key) => key !== reviewKey) ?? null);
+    onResolved();
+  };
 
   return (
     <div className="space-y-2 rounded-md border border-warning/40 bg-warning-soft p-2">
@@ -54,7 +79,7 @@ export function SequentialReviews({ card, onResolved }: Props) {
               variant="secondary"
               size="sm"
               disabled={current <= 0}
-              onClick={() => setIndex(clampReviewIndex(current - 1, total))}
+              onClick={() => selectReview(current - 1)}
               aria-label="Previous review"
             >
               Prev
@@ -63,7 +88,7 @@ export function SequentialReviews({ card, onResolved }: Props) {
               variant="secondary"
               size="sm"
               disabled={current >= total - 1}
-              onClick={() => setIndex(clampReviewIndex(current + 1, total))}
+              onClick={() => selectReview(current + 1)}
               aria-label="Next review"
             >
               Next
@@ -94,12 +119,12 @@ export function SequentialReviews({ card, onResolved }: Props) {
 
       {review.run_id && review.node_id ? (
         <HumanPromptForm
-          key={`${review.run_id}:${review.node_id}`}
+          key={reviewKey}
           runId={review.run_id}
           nodeId={review.node_id}
           questions={review.questions ?? {}}
           sourceOverride={null}
-          onResumed={onResolved}
+          onResumed={handleResolved}
         />
       ) : (
         <InlineBanner tone="warning" layout="inline">

--- a/studio/src/views/PipelineBoard/reviewQueue.ts
+++ b/studio/src/views/PipelineBoard/reviewQueue.ts
@@ -1,0 +1,39 @@
+import type { PipelineBoardPendingReview } from "@/api/pipelineBoards";
+
+// Keeps navigation inside [0, total). Polling can shrink the queue between a
+// click and the render that consumes it.
+export function clampReviewIndex(index: number, total: number): number {
+  if (total <= 0) return 0;
+  return Math.min(Math.max(index, 0), total - 1);
+}
+
+// Review gates reuse their interaction ID (and often the same run/node) when
+// the AI answers and asks another question. The enqueue timestamp therefore
+// belongs in the identity: A@10 and the later A@13 are distinct queue turns.
+export function pendingReviewVersionKey(review: PipelineBoardPendingReview): string {
+  return JSON.stringify([
+    review.run_id,
+    review.node_id ?? "",
+    review.interaction_id ?? "",
+    review.updated_at,
+  ]);
+}
+
+function reviewTimestamp(review: PipelineBoardPendingReview): number {
+  const stamp = Date.parse(review.updated_at);
+  return Number.isNaN(stamp) ? 0 : stamp;
+}
+
+// Oldest pending turn first. The server emits this order too; sorting at the
+// component boundary keeps the queue correct for a stale/mixed-version API.
+export function sortPendingReviewsChronologically(
+  reviews: readonly PipelineBoardPendingReview[],
+): PipelineBoardPendingReview[] {
+  return [...reviews].sort((a, b) => {
+    const timeDelta = reviewTimestamp(a) - reviewTimestamp(b);
+    if (timeDelta !== 0) return timeDelta;
+    const ka = pendingReviewVersionKey(a);
+    const kb = pendingReviewVersionKey(b);
+    return ka < kb ? -1 : ka > kb ? 1 : 0;
+  });
+}


### PR DESCRIPTION
## Root cause

Pending human reviews were projected in run-tree traversal order, while the Studio kept the active form as a numeric index. When an AI resumed and re-paused, its next turn reused the same structural position and could replace another AI's form while the operator was typing.

## Fix

- timestamp each pending turn from `Interaction.RequestedAt` (with a run timestamp fallback)
- order pending reviews FIFO, oldest update first, with deterministic tie-breaking
- version and pin the active Studio form by run/node/interaction/update timestamp
- advance to the oldest existing turn before refetching so a new turn from the answered AI joins the back
- update the API/OpenAPI contracts and regression fixtures

## Test evidence

- `go test ./pkg/server -count=1`
- Studio TypeScript build/typecheck
- targeted Studio ESLint
- full Studio suite under Node 24: 114 files, 1005 tests passed
- regenerated OpenAPI spec and TypeScript schema with no drift
