### PR TITLE
fix(claude_code): sandboxed spawns lose the runner's ambient forfait — forward Anthropic env explicitly

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -695,7 +695,13 @@ Architecture:
   delegate points sandboxed CLI spawns at it via `CLAUDE_CONFIG_DIR`
   (the per-spawn `CLAUDE_CODE_OAUTH_TOKEN` env stays as the
   first-precedence path). The runner's forfait refresher rewrites both
-  the Secret and the seeded copy mid-run.
+  the Secret and the seeded copy mid-run. When the run carries NO sealed
+  claude credentials, the delegate forwards the runner's ambient
+  Anthropic env (`CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` /
+  `ANTHROPIC_AUTH_TOKEN`+`BASE_URL`) into sandboxed spawns verbatim —
+  host spawns inherit `os.Environ()`, a `kubectl exec` does not, and the
+  prod runner-pod-level forfait otherwise never reaches the in-pod CLI
+  (`Not logged in` on every exec, observed on run 019f8a6c).
 - Cleanup deletes the pod (and its emptyDir) on run exit.
 
 #### Orphan garbage collection (ADR-070)

--- a/pkg/backend/delegate/claude_code_creds.go
+++ b/pkg/backend/delegate/claude_code_creds.go
@@ -97,6 +97,42 @@ func taskSandboxed(task Task) bool {
 	return task.Sandbox != nil && task.Sandbox.Driver() != "noop"
 }
 
+// ambientAnthropicEnvForSandbox returns the Anthropic-flavoured
+// credential vars present in THIS process' environment, for explicit
+// forwarding into a sandboxed CLI spawn.
+//
+// On the host path the claude subprocess inherits os.Environ()
+// (hostSpawnEnv / the SDK's default spawn), so an ambient
+// CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY — the prod runner's
+// forfait delivery channel (the `iterion-forfait` secret sets
+// CLAUDE_CODE_OAUTH_TOKEN on the runner pod) — authenticates every run
+// with NO ctx credentials. A sandboxed spawn inherits the CONTAINER env
+// instead (kubectl/docker exec + the SDK env map only), so that ambient
+// credential silently vanished: observed live on the first sandboxed
+// cloud run (019f8a6c) — every claude exec, main pass and formatting
+// pass alike, ran with env_keys=1 and died `Not logged in · Please run
+// /login` (4s, 0 tokens), surfacing as the opaque "structured output
+// invalid: missing required field …". Values are forwarded VERBATIM —
+// the CLI applies its own precedence among them, exactly as it does for
+// inherited host env.
+func ambientAnthropicEnvForSandbox() map[string]string {
+	env := map[string]string{}
+	for _, k := range []string{
+		"ANTHROPIC_API_KEY",
+		"ANTHROPIC_AUTH_TOKEN",
+		"ANTHROPIC_BASE_URL",
+		"CLAUDE_CODE_OAUTH_TOKEN",
+	} {
+		if v := os.Getenv(k); v != "" {
+			env[k] = v
+		}
+	}
+	if len(env) == 0 {
+		return nil
+	}
+	return env
+}
+
 // credEnvToOpts converts a credential env map into claudesdk.Option
 // values with a stable key order. Extracted so the cross-provider
 // fingerprint path can compute the env map once, derive a fingerprint,
@@ -278,11 +314,22 @@ func anthropicCredEnvForCLI(ctx context.Context, providerHint string, sandboxed 
 		}
 		// Process-env path: rely on ANTHROPIC_API_KEY inherited by the
 		// CLI. Actively clear ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN
-		// so a stale z.ai value from the parent env doesn't leak in.
-		return map[string]string{
+		// so a stale z.ai value from the parent env doesn't leak in. A
+		// sandboxed spawn inherits the CONTAINER env, not this process'
+		// — forward the ambient Anthropic-direct credentials explicitly
+		// (keeping the z.ai suppression: the hint forces direct).
+		env := map[string]string{
 			"ANTHROPIC_BASE_URL":   "",
 			"ANTHROPIC_AUTH_TOKEN": "",
 		}
+		if sandboxed {
+			for _, k := range []string{"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"} {
+				if v := os.Getenv(k); v != "" {
+					env[k] = v
+				}
+			}
+		}
+		return env
 	}
 
 	// providerHint=="zai": force the z.ai facade. Prefer in-context
@@ -344,6 +391,15 @@ func anthropicCredEnvForCLI(ctx context.Context, providerHint string, sandboxed 
 				"ANTHROPIC_AUTH_TOKEN": zai,
 			}
 		}
+	}
+	// Host path: nil = let the spawned CLI inherit whatever ambient
+	// Anthropic env this process carries (os.Environ passthrough). A
+	// sandboxed spawn has no such inheritance — forward the ambient
+	// credentials explicitly so a runner-pod-level forfait
+	// (CLAUDE_CODE_OAUTH_TOKEN) or API key reaches the in-container CLI
+	// exactly as it would a host spawn.
+	if sandboxed {
+		return ambientAnthropicEnvForSandbox()
 	}
 	return nil
 }

--- a/pkg/backend/delegate/claude_code_sandbox_env_test.go
+++ b/pkg/backend/delegate/claude_code_sandbox_env_test.go
@@ -1,0 +1,169 @@
+package delegate
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+// captureSandboxCmdRun fakes a real (kubernetes-shaped) sandbox Run and
+// records every exec's argv / WorkDir / env so tests can assert exactly
+// what a sandboxed CLI spawn receives.
+type captureSandboxCmdRun struct {
+	sandbox.Run
+	argvs [][]string
+	cwds  []string
+	envs  []map[string]string
+}
+
+func (c *captureSandboxCmdRun) Driver() string { return "kubernetes" }
+
+func (c *captureSandboxCmdRun) Command(ctx context.Context, cmd []string, opts sandbox.ExecOpts) *exec.Cmd {
+	c.argvs = append(c.argvs, append([]string(nil), cmd...))
+	c.cwds = append(c.cwds, opts.WorkDir)
+	env := map[string]string{}
+	for k, v := range opts.Env {
+		env[k] = v
+	}
+	c.envs = append(c.envs, env)
+	// A no-output command: claudesdk.Prompt reads EOF and returns a
+	// ProcessError — the capture has happened by then.
+	return exec.CommandContext(ctx, "true")
+}
+
+// TestAnthropicCredEnv_SandboxForwardsAmbientCreds pins the fix for the
+// first sandboxed cloud run (019f8a6c): prod delivers the Claude forfait
+// as CLAUDE_CODE_OAUTH_TOKEN in the RUNNER pod env (no sealed claude
+// OAuth in the bundle). A host spawn inherits os.Environ() so that
+// always authenticated; a sandboxed spawn gets only the SDK env map, so
+// every claude exec ran env_keys=1 and died "Not logged in". Under
+// sandbox the ambient Anthropic env must be forwarded verbatim; on the
+// host the nil return (inheritance) stays.
+func TestAnthropicCredEnv_SandboxForwardsAmbientCreds(t *testing.T) {
+	t.Run("ambient forfait token", func(t *testing.T) {
+		resetClaudeCredEnv(t)
+		t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-RUNNERPOD")
+
+		got := anthropicCredEnvForCLI(context.Background(), "", true)
+		if got["CLAUDE_CODE_OAUTH_TOKEN"] != "sk-ant-oat-RUNNERPOD" {
+			t.Fatalf("sandboxed spawn must carry the ambient forfait token, got %v", got)
+		}
+		if host := anthropicCredEnvForCLI(context.Background(), "", false); host != nil {
+			t.Fatalf("host spawn keeps env inheritance (nil), got %v", host)
+		}
+	})
+
+	t.Run("ambient API key", func(t *testing.T) {
+		resetClaudeCredEnv(t)
+		t.Setenv("ANTHROPIC_API_KEY", "sk-ant-api-AMBIENT")
+
+		got := anthropicCredEnvForCLI(context.Background(), "", true)
+		if got["ANTHROPIC_API_KEY"] != "sk-ant-api-AMBIENT" {
+			t.Fatalf("sandboxed spawn must carry the ambient API key, got %v", got)
+		}
+	})
+
+	t.Run("hint anthropic still forwards ambient under sandbox", func(t *testing.T) {
+		resetClaudeCredEnv(t)
+		t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-RUNNERPOD")
+		t.Setenv("ANTHROPIC_BASE_URL", "https://api.z.ai/api/anthropic") // stale z.ai — must stay suppressed
+
+		got := anthropicCredEnvForCLI(context.Background(), "anthropic", true)
+		if got["CLAUDE_CODE_OAUTH_TOKEN"] != "sk-ant-oat-RUNNERPOD" {
+			t.Fatalf("hint=anthropic sandboxed must forward the ambient token, got %v", got)
+		}
+		if v, present := got["ANTHROPIC_BASE_URL"]; !present || v != "" {
+			t.Fatalf("z.ai suppression must survive the forwarding: %v", got)
+		}
+	})
+
+	t.Run("nothing ambient stays nil", func(t *testing.T) {
+		resetClaudeCredEnv(t)
+		if got := anthropicCredEnvForCLI(context.Background(), "", true); got != nil {
+			t.Fatalf("no ambient creds → nil (loud downstream no-credential error), got %v", got)
+		}
+	})
+}
+
+// TestFormatOutput_SandboxExecParity pins Pass-2 parity with the main
+// pass: the formatting exec must route through the sandbox Run and carry
+// the SAME credential env the main pass computes (setupCredsAndSession
+// and formatOutput share anthropicCredEnvForCLI), with cwd left empty so
+// the driver applies the container workingDir — the workspace — exactly
+// like the main pass (the claude session key derives from it, so the
+// resumed session is found).
+func TestFormatOutput_SandboxExecParity(t *testing.T) {
+	assertParity := func(t *testing.T, ctx context.Context, wantEnvKeys []string) {
+		t.Helper()
+		fake := &captureSandboxCmdRun{}
+		task := Task{
+			NodeID:       "campaign",
+			WorkDir:      "/host/worktree",
+			Sandbox:      fake,
+			OutputSchema: []byte(`{"type":"object","properties":{"docs_aligned":{"type":"boolean"}}}`),
+		}
+		b := &ClaudeCodeBackend{Logger: iterlog.Nop()}
+		_, _ = b.formatOutput(ctx, task, "sess-643e6598")
+
+		if len(fake.argvs) != 1 {
+			t.Fatalf("expected exactly one sandbox exec, got %d", len(fake.argvs))
+		}
+		argv := strings.Join(fake.argvs[0], " ")
+		if !strings.Contains(argv, "--resume sess-643e6598") {
+			t.Errorf("fmt exec must resume the Pass-1 session, argv: %s", argv)
+		}
+		if fake.cwds[0] != "" {
+			t.Errorf("fmt exec cwd = %q — must stay empty so the driver applies the container workingDir (same session key as the main pass)", fake.cwds[0])
+		}
+		// The exec env must match what the MAIN pass computes from the same
+		// inputs, plus the effort dial.
+		mainCredEnv := anthropicCredEnvForCLI(ctx, task.ProviderHint, taskSandboxed(task))
+		for k, v := range mainCredEnv {
+			if fake.envs[0][k] != v {
+				t.Errorf("fmt env[%s] = %q, want the main pass value %q", k, fake.envs[0][k], v)
+			}
+		}
+		if _, ok := fake.envs[0]["CLAUDE_CODE_EFFORT_LEVEL"]; !ok {
+			t.Error("fmt env missing CLAUDE_CODE_EFFORT_LEVEL")
+		}
+		for _, k := range wantEnvKeys {
+			if fake.envs[0][k] == "" {
+				t.Errorf("fmt env missing %s (keys: %v)", k, envKeys(fake.envs[0]))
+			}
+		}
+	}
+
+	t.Run("ambient runner-pod forfait (the live prod shape)", func(t *testing.T) {
+		resetClaudeCredEnv(t)
+		t.Setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-RUNNERPOD")
+		assertParity(t, context.Background(), []string{"CLAUDE_CODE_OAUTH_TOKEN"})
+	})
+
+	t.Run("materialised ctx forfait (sealed-bundle shape)", func(t *testing.T) {
+		resetClaudeCredEnv(t)
+		dir := t.TempDir()
+		blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat-BUNDLE","refreshToken":"r","expiresAt":1}}`
+		if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(blob), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+			OAuthCredentialFiles: map[string]string{string(secrets.OAuthKindClaudeCode): dir},
+		})
+		assertParity(t, ctx, []string{"CLAUDE_CODE_OAUTH_TOKEN", "CLAUDE_CONFIG_DIR"})
+	})
+}
+
+func envKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## Diagnosis diverges from the hypothesis — grounded in the full prod run log

Fetched the complete log of run `019f8a6c` via `iterion remote api`. Key facts:

- **ALL 25 claude execs — main pass AND formatting pass — ran with `env_keys=1`, `cwd=`** (`grep env_keys` histogram: `25 × cwd= env_keys=1`). The main pass was not fine: every "campaign" delegation lasted ~4s, **0 tokens**, and its result text was **`Not logged in · Please run /login`** (16 occurrences). The "content" in the campaign prompt came from earlier claw/tool nodes, not from a successful claude pass.
- The end-of-run claw recovery hit a REAL `openai: API error 429 (quota)` → the sealed bundle **did** carry an OpenAI key but **no claude_code OAuth**.
- Prod delivers the Claude forfait as **`CLAUDE_CODE_OAUTH_TOKEN` in the runner pod env** (secret `iterion-forfait`) — not as a sealed bundle credential. Pre-cutover, host spawns inherited `os.Environ()` (`hostSpawnEnv` / the SDK default), so that ambient token authenticated every run. A **sandboxed** spawn receives only the SDK env map through `kubectl exec` — the ambient token silently never reached the pod. That is the entire failure.

**Hypotheses (a)/(b) checked and disproved by test**: Pass-2 `formatOutput` already routes through the sandbox Run and computes its credential env from the **same** `anthropicCredEnvForCLI` inputs as the main pass — a capture probe on unmodified code shows the fmt exec receiving the full 6-key env (`CLAUDE_CONFIG_DIR=/tmp/iterion-claude-config`, `CLAUDE_CODE_OAUTH_TOKEN`, suppressions, effort) when ctx creds exist. And `cwd=""` is *correct* under sandbox: the driver applies the container workingDir (the workspace) for both passes, so they share one session key — resume works (pinned by the new parity test). With zero auth, the CLI's `Not logged in` text parsed as "fallback text" → retries → `missing required field …` — the exact observed cascade.

## Fix

`anthropicCredEnvForCLI`: when the ctx-credential branches resolve nothing and the spawn is **sandboxed** (real driver, not the noop passthrough), forward the ambient Anthropic env verbatim — `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`+`ANTHROPIC_BASE_URL` — restoring exact host-inheritance parity (the CLI applies its own precedence among them, as it would for inherited env). The `hint=anthropic` path forwards the direct-auth pair while keeping its z.ai suppression. Host spawns keep the `nil` return (inheritance). No ambient creds → still `nil`, so the no-credential failure stays loud. One function fixes main pass, formatting pass, and the recovery formatter alike — they share the seam.

## Test evidence

- `TestFormatOutput_SandboxExecParity` (the requested test): fake sandbox Run captures the Pass-2 exec — asserts it routes through the sandbox channel, resumes the Pass-1 session, keeps `cwd=""` (container workingDir = same session key as the main pass), and carries **exactly the main pass's credential env** (compared against `anthropicCredEnvForCLI` with identical inputs) + the effort dial. Two shapes: ambient runner-pod forfait (the live prod config) and materialised ctx forfait (sealed-bundle config).
- `TestAnthropicCredEnv_SandboxForwardsAmbientCreds`: ambient token / ambient API key forwarded under sandbox; host stays nil (inheritance); `hint=anthropic` forwards while keeping z.ai suppression; nothing ambient → nil (loud failure preserved).
- `go build ./...` ✓ · vet ✓ · gofmt clean · `go test ./pkg/backend/delegate/ ./pkg/backend/model/` ✓.

## Known follow-ups (out of scope)
- Per-exec env rides the `kubectl exec` argv (`env K=V` prefix) — true for the ctx-forfait token already; moving exec env delivery off argv is a separate hardening.
- Long-term, prod could seal the forfait into run bundles (per-tenant) instead of a runner-pod-level env var; this fix preserves today's deliberate platform-forfait model.
- The claw recovery's OpenAI 429 in this run is a real quota issue, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
