### PR TITLE
fix(studio): bound pipeline card titles

### DIFF
--- a/pkg/server/pipeline_boards.go
+++ b/pkg/server/pipeline_boards.go
@@ -24,6 +24,9 @@ const (
 
 	pipelineTreeMaxDepth = 20
 	pipelineTreeMaxCards = 500
+	// Keep the card label compact even when a bot input or ticket title is a
+	// full brief. The complete value remains available in EntryInput / Body.
+	pipelineTitleMaxRunes = 80
 
 	// pipelineFinalAnswerField mirrors notify.DefaultAnswerField — the
 	// artifact-data key a finished run's "output" is read from. Duplicated

--- a/pkg/server/pipeline_boards_progress.go
+++ b/pkg/server/pipeline_boards_progress.go
@@ -222,6 +222,24 @@ func pipelineTruncate(s string, max int) string {
 	return s[:max] + "…"
 }
 
+// compactPipelineTitle turns any selected label into a bounded, single-line
+// card title. Inputs can legitimately contain entire Markdown briefs; those
+// belong in EntryInput, not in the board title or its JSON payload.
+func compactPipelineTitle(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			s = line
+			break
+		}
+	}
+	s = strings.Join(strings.Fields(s), " ")
+	runes := []rune(s)
+	if len(runes) <= pipelineTitleMaxRunes {
+		return s
+	}
+	return strings.TrimSpace(string(runes[:pipelineTitleMaxRunes-1])) + "…"
+}
+
 // pipelineDisplayTitle picks the label shown on a pipeline card.
 //
 // Priority:
@@ -241,22 +259,22 @@ func pipelineDisplayTitle(issue *native.Issue, root *store.Run) string {
 		inputs = stringMapToAny(issue.BotArgs)
 	}
 	if t := titleFromContentInputs(inputs); t != "" {
-		return t
+		return compactPipelineTitle(t)
 	}
 	if issue != nil {
 		if t := strings.TrimSpace(issue.Title); t != "" {
-			return t
+			return compactPipelineTitle(t)
 		}
 	}
 	if root != nil {
 		if t := strings.TrimSpace(root.BundleDisplayName); t != "" {
-			return t
+			return compactPipelineTitle(t)
 		}
 		if t := humanizePipelineName(root.WorkflowName); t != "" && t != "Pipeline" {
-			return t
+			return compactPipelineTitle(t)
 		}
 		if t := strings.TrimSpace(root.Name); t != "" {
-			return t
+			return compactPipelineTitle(t)
 		}
 	}
 	return "Pipeline"

--- a/pkg/server/pipeline_boards_tasks.go
+++ b/pkg/server/pipeline_boards_tasks.go
@@ -105,7 +105,7 @@ func (s *Server) handlePipelineBoardTaskCreate(w http.ResponseWriter, r *http.Re
 		s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board task: invalid request: %v", err)
 		return
 	}
-	req.Title = strings.TrimSpace(req.Title)
+	req.Title = compactPipelineTitle(req.Title)
 	req.Bot = strings.TrimSpace(req.Bot)
 	if req.Title == "" {
 		s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board task: title is required")
@@ -254,7 +254,7 @@ func uniquePipelineTitle(boardStore native.BoardStore, desired string) string {
 		return desired
 	}
 	for n := 2; n < 100000; n++ {
-		candidate := fmt.Sprintf("#%d - %s", n, desired)
+		candidate := compactPipelineTitle(fmt.Sprintf("#%d - %s", n, desired))
 		if _, clash := taken[candidate]; !clash {
 			return candidate
 		}
@@ -324,7 +324,7 @@ func (s *Server) handlePipelineBoardTaskUpdate(w http.ResponseWriter, r *http.Re
 		External: req.External,
 	}
 	if req.Title != nil {
-		title := strings.TrimSpace(*req.Title)
+		title := compactPipelineTitle(*req.Title)
 		if title == "" {
 			s.httpErrorFor(w, r, http.StatusBadRequest, "pipeline board update: title cannot be empty")
 			return

--- a/pkg/server/pipeline_boards_test.go
+++ b/pkg/server/pipeline_boards_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -439,6 +440,45 @@ func TestPipelineBoardTaskCreateEnsuresUniqueTitle(t *testing.T) {
 	// A distinct title is untouched.
 	if got := create("Other"); got != "Other" {
 		t.Errorf("distinct = %q, want %q", got, "Other")
+	}
+	longTitle := strings.Repeat("é", pipelineTitleMaxRunes+20)
+	if got := create(longTitle); len([]rune(got)) != pipelineTitleMaxRunes {
+		t.Errorf("long first title has %d runes, want %d", len([]rune(got)), pipelineTitleMaxRunes)
+	}
+	if got := create(longTitle); len([]rune(got)) != pipelineTitleMaxRunes || !strings.HasPrefix(got, "#2 - ") {
+		t.Errorf("long duplicate = %q, want bounded title with #2 prefix", got)
+	}
+}
+
+func TestPipelineBoardTaskCreateCompactsLongTitle(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	rawTitle := "A detailed product idea\n\n" + strings.Repeat("with extensive context ", 20)
+	payload, err := json.Marshal(map[string]string{
+		"bot":   "review",
+		"title": rawTitle,
+	})
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	resp, err := http.Post(
+		env.http.URL+"/api/v1/pipeline-board/tasks",
+		"application/json",
+		bytes.NewReader(payload),
+	)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		resp.Body.Close()
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusCreated)
+	}
+	var out native.Issue
+	decodeJSONResp(t, resp, &out)
+	if want := compactPipelineTitle(rawTitle); out.Title != want {
+		t.Fatalf("stored title = %q, want %q", out.Title, want)
+	}
+	if strings.Contains(out.Title, "\n") {
+		t.Fatalf("stored title still contains a newline: %q", out.Title)
 	}
 }
 
@@ -927,6 +967,36 @@ func TestPipelineDisplayTitle_TaskFromBotArgs(t *testing.T) {
 	want := "Boudicca · ÉP 2/5 — La Ville sans Murailles"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestPipelineDisplayTitle_IgnoresLongFormInput(t *testing.T) {
+	root := &store.Run{
+		BundleDisplayName: "Ida",
+		Inputs: map[string]any{
+			"idea": strings.Repeat("A full product brief with Markdown. ", 400),
+		},
+	}
+	if got := pipelineDisplayTitle(nil, root); got != "Ida" {
+		t.Fatalf("got %q, want bundle display name", got)
+	}
+}
+
+func TestPipelineDisplayTitle_CompactsAndTruncatesLongCandidate(t *testing.T) {
+	root := &store.Run{
+		Inputs: map[string]any{
+			"topic": "A detailed product idea " + strings.Repeat("with extensive context ", 10) + "\n\nIgnored details",
+		},
+	}
+	got := pipelineDisplayTitle(nil, root)
+	if strings.Contains(got, "\n") {
+		t.Fatalf("title still contains a newline: %q", got)
+	}
+	if len([]rune(got)) > pipelineTitleMaxRunes {
+		t.Fatalf("title has %d runes, want at most %d: %q", len([]rune(got)), pipelineTitleMaxRunes, got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("truncated title = %q, want ellipsis", got)
 	}
 }
 

--- a/studio/src/views/PipelineBoard/AddTaskDialog.tsx
+++ b/studio/src/views/PipelineBoard/AddTaskDialog.tsx
@@ -30,6 +30,12 @@ import { useBotsStore } from "@/store/bots";
 import { BotPicker } from "@/views/Board/BotPicker";
 import { RepositoryField } from "@/views/Board/issueModal/RepositoryField";
 
+import {
+  compactPipelineTaskTitle,
+  derivePipelineTaskTitle,
+  PIPELINE_TASK_TITLE_MAX_LENGTH,
+} from "./taskTitle";
+
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -126,7 +132,9 @@ function AddTaskDialogContent({
 }: Props) {
   const isEdit = !!editTask;
   const [botName, setBotName] = useState(editTask?.bot_id ?? "");
-  const [title, setTitle] = useState(editTask?.title ?? "");
+  const [title, setTitle] = useState(() =>
+    compactPipelineTaskTitle(editTask?.title ?? ""),
+  );
   const [body, setBody] = useState(editTask?.body ?? "");
   const [labels, setLabels] = useState<string[]>(editTask?.labels ?? []);
   const [priority, setPriority] = useState(editTask?.priority ?? 0);
@@ -256,14 +264,13 @@ function AddTaskDialogContent({
   // The title auto-derives from the primary inputs so the operator only has
   // to pick the input principal; they can still override it under Advanced.
   const derivedTitle = useMemo(() => {
-    const values = primaryFields
-      .map((f) => (botArgs[f.name] ?? "").trim())
-      .filter(Boolean);
-    if (values.length > 0) return values.join(" · ");
-    return selectedBot?.display_name?.trim() || botName.trim();
+    return derivePipelineTaskTitle(
+      primaryFields.map((f) => botArgs[f.name] ?? ""),
+      selectedBot?.display_name?.trim() || botName.trim(),
+    );
   }, [primaryFields, botArgs, selectedBot, botName]);
 
-  const effectiveTitle = title.trim() || derivedTitle;
+  const effectiveTitle = compactPipelineTaskTitle(title) || derivedTitle;
   const canSubmit =
     botName.trim().length > 0 &&
     effectiveTitle.length > 0 &&
@@ -455,6 +462,7 @@ function AddTaskDialogContent({
                   value={title}
                   onChange={(event) => setTitle(event.target.value)}
                   placeholder={derivedTitle || "What should this pipeline do?"}
+                  maxLength={PIPELINE_TASK_TITLE_MAX_LENGTH}
                   size="md"
                 />
                 <span className="mt-1 block text-micro text-fg-subtle">

--- a/studio/src/views/PipelineBoard/taskTitle.test.ts
+++ b/studio/src/views/PipelineBoard/taskTitle.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  compactPipelineTaskTitle,
+  derivePipelineTaskTitle,
+  PIPELINE_TASK_TITLE_MAX_LENGTH,
+} from "./taskTitle";
+
+describe("pipeline task titles", () => {
+  it("keeps short primary values readable", () => {
+    expect(derivePipelineTaskTitle(["Boudicca", "Episode 1"], "Fallback")).toBe(
+      "Boudicca · Episode 1",
+    );
+  });
+
+  it("uses the first meaningful line of a multiline brief", () => {
+    const title = derivePipelineTaskTitle(
+      [
+        "Je travaille sur une idée de produit.\n\n## Vision générale\n" +
+          "Une description très détaillée. ".repeat(20),
+      ],
+      "Ida",
+    );
+
+    expect(title).toBe("Je travaille sur une idée de produit.");
+  });
+
+  it("uses the bot label when primary values are blank", () => {
+    expect(derivePipelineTaskTitle(["  ", "\n"], "App concept")).toBe(
+      "App concept",
+    );
+  });
+
+  it("also bounds an explicit title", () => {
+    const title = compactPipelineTaskTitle("é".repeat(100));
+    expect(Array.from(title)).toHaveLength(PIPELINE_TASK_TITLE_MAX_LENGTH);
+    expect(title.endsWith("…")).toBe(true);
+  });
+});

--- a/studio/src/views/PipelineBoard/taskTitle.ts
+++ b/studio/src/views/PipelineBoard/taskTitle.ts
@@ -1,0 +1,35 @@
+export const PIPELINE_TASK_TITLE_MAX_LENGTH = 80;
+
+/**
+ * Keep task titles useful as labels. Primary inputs may be complete Markdown
+ * briefs; the brief remains in bot_args while the title becomes a compact,
+ * single-line preview.
+ */
+export function compactPipelineTaskTitle(value: string): string {
+  const normalized =
+    value
+      .split(/\r?\n/u)
+      .map((line) => line.trim())
+      .find(Boolean)
+      ?.replace(/\s+/gu, " ") ?? "";
+  const characters = Array.from(normalized);
+  if (characters.length <= PIPELINE_TASK_TITLE_MAX_LENGTH) return normalized;
+
+  return `${characters
+    .slice(0, PIPELINE_TASK_TITLE_MAX_LENGTH - 1)
+    .join("")
+    .trimEnd()}…`;
+}
+
+export function derivePipelineTaskTitle(
+  primaryValues: string[],
+  fallback: string,
+): string {
+  const values = primaryValues
+    .map(compactPipelineTaskTitle)
+    .filter(Boolean);
+
+  return compactPipelineTaskTitle(
+    values.length > 0 ? values.join(" · ") : fallback,
+  );
+}


### PR DESCRIPTION
## Summary

- derive automatic pipeline-card titles from the first meaningful input line
- cap generated, explicit, persisted, and projected titles at 80 Unicode characters
- keep the complete brief in bot arguments instead of copying it into the title
- preserve bounded duplicate-title prefixes and add frontend/backend regression coverage

## Validation

- go test ./pkg/server -count=1
- targeted Vitest suite for pipeline task titles
- TypeScript project build
- production Vite build
- ESLint on the touched Studio files