### PR TITLE
feat(review-pr): env-overridable second-reviewer backend — Claude-forfait-only instances

### DIFF
--- a/bots/review-pr/main.bot
+++ b/bots/review-pr/main.bot
@@ -530,7 +530,12 @@ judge reviewer_gpt:
   ## Explicit backend pin: "openai/gpt-5.5" only resolves via claw.
   ## Without it the auto-resolver routes through claude_code, which
   ## doesn't recognise openai/* models and the schema validator fails.
-  backend: "claw"
+  ## Both env-overridable so an instance without a usable OpenAI quota
+  ## can run the second reviewer on the Claude forfait instead
+  ## (ITERION_VIBE_BACKEND_GPT=claude_code +
+  ## ITERION_VIBE_MODEL_GPT=claude-sonnet-4-6 — cross-model diversity
+  ## when cross-vendor isn't available).
+  backend: "${ITERION_VIBE_BACKEND_GPT:-claw}"
   model: "${ITERION_VIBE_MODEL_GPT:-openai/gpt-5.5}"
   reasoning_effort: "${ITERION_VIBE_EFFORT_GPT:-high}"
   output: review_output

--- a/bots/review-pr/manifest.yaml
+++ b/bots/review-pr/manifest.yaml
@@ -1,7 +1,10 @@
 name: review-pr
 display_name: Revi
 icon: 🔎
-version: 0.3.0
+version: 0.3.1
+## 0.3.1 — reviewer_gpt backend env-overridable (ITERION_VIBE_BACKEND_GPT)
+## so a Claude-forfait-only instance runs the second reviewer on
+## claude_code (cross-model diversity) when OpenAI quota is unavailable.
 description: |
   Read-only cross-family code reviewer. Reviews the working-tree diff
   of the current branch against its base with two independent reviewers


### PR DESCRIPTION
OpenAI quota exhaustion on prod killed every reviewer_gpt branch
(insufficient_quota). The backend pin becomes
${ITERION_VIBE_BACKEND_GPT:-claw} so an instance without usable OpenAI
runs the second reviewer on claude_code (with
ITERION_VIBE_MODEL_GPT=claude-sonnet-4-6 — cross-model diversity when
cross-vendor isn't available). Defaults unchanged. Bot 0.3.1.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
