### PR TITLE
fix(server): exempt per-run token surfaces from the operator-JWT gate

### DIFF
--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -210,6 +210,14 @@ func isPublicPath(path string) bool {
 	if strings.HasPrefix(path, "/api/config-share/") {
 		return true
 	}
+	// Per-run X-Iterion-Run token surfaces (board MCP HTTP transport,
+	// deterministic forge review publishing): the handler authenticates
+	// the run token itself and 401s on a missing/unknown one, so the
+	// operator-JWT gate must not front them — a sandboxed or
+	// runner-launched run carries no JWT.
+	if strings.HasPrefix(path, "/api/v1/mcp/") || path == "/api/v1/forge/publish-review" {
+		return true
+	}
 	if strings.HasPrefix(path, "/assets/") || strings.HasPrefix(path, "/static/") {
 		return true
 	}

--- a/pkg/server/middleware_test.go
+++ b/pkg/server/middleware_test.go
@@ -34,3 +34,34 @@ func TestExtractBearerAcceptsTokenOnWSPaths(t *testing.T) {
 		})
 	}
 }
+
+// TestIsPublicPathRunTokenSurfaces pins the JWT-gate bypass for the
+// per-run X-Iterion-Run token surfaces: the handlers authenticate the
+// run token themselves and 401 on a missing/unknown one, and a
+// sandboxed or runner-launched run carries no operator JWT. Regressing
+// this re-breaks board MCP writes and deterministic forge review
+// publishing on cloud instances (observed live: Revi run 019f8ad0
+// publish_review HTTP 401 "authentication required").
+func TestIsPublicPathRunTokenSurfaces(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/api/v1/forge/publish-review", true},
+		{"/api/v1/mcp/board", true},
+		{"/api/v1/mcp/board/tools", true},
+		{"/api/v1/forge/publish-reviewX", false}, // exact match only
+		{"/api/v1/native", false},                // stays JWT-gated
+		{"/api/runs", false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+			if got := isPublicPath(tc.path); got != tc.want {
+				t.Fatalf("isPublicPath(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The board MCP HTTP transport (`/api/v1/mcp/*`) and the deterministic forge review publish endpoint (`/api/v1/forge/publish-review`) are self-authenticated by their per-run `X-Iterion-Run` token — the route registrations already say *intentionally bypasses requireAuth* — but the umbrella `authMiddleware` still fronted them: on a cloud instance (auth on) every call from a run 401'd with "authentication required" before reaching the token check. Local mode (`DisableAuth`) never showed it.

Observed live: review-pr run `019f8ad0` `publish_review` HTTP 401 (first real exercise of deterministic publishing #261); the board-endpoint gap on runner-launched runs (native:1ec7b869) shares this root cause.

Handlers keep failing closed: a missing/unknown token is still a 401 — now from the handler that actually checks it. Regression test `TestIsPublicPathRunTokenSurfaces` pins the bypass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)