### PR TITLE
docs: alignment harvest (benchmark-verified fixes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ Other top-level directories: `studio/` (React/Vite frontend), `examples/` (.bot 
 |------|-------------|
 | **Agent** | LLM node with tools, structured I/O, optional delegation (claude_code, codex) |
 | **Judge** | LLM node producing verdicts (typically no tools) |
-| **Router** | Routing node with 4 modes: `fan_out_all`, `condition`, `round_robin`, `llm` (see `docs/routers.md`) |
+| **Router** | Routing node with 5 modes: `fan_out_all`, `fan_out_each`, `condition`, `round_robin`, `llm` (see `docs/routers.md`) |
 | **Human** | Pause/resume via `interaction: human` (default for human nodes); optional `interaction: llm` or `llm_or_human` can auto-answer or escalate. Agent/judge nodes can instead declare **`interaction: async`** (**ADR-081**): the agent posts questions via `ask_user_async` and KEEPS WORKING — answers arrive in its message queue (node-scoped inbox) whenever the operator replies; the `await_answers` tool is the LLM-discretion sync point (pauses only if something is still pending). See [docs/async-interaction.md](docs/async-interaction.md). |
 | **Tool** | Direct shell command execution (no LLM). ACTION tool nodes may opt into the **Verified Action** quad (`goal`+`postcondition`+`policy`+`recovery`) so a brittle recipe self-heals (idempotent-skip → recipe → self-repair → agent → policy) instead of hard-blocking; the postcondition is the deterministic truth oracle at every rung. **Gates stay deterministic** — never attach recovery to a `recipe == postcondition` gate (enforced by C103–C106). See [docs/adr/044-adaptive-recovery-for-deterministic-action-nodes.md](docs/adr/044-adaptive-recovery-for-deterministic-action-nodes.md). |
 | **Compute** | Deterministic expression node for derived structured output (no LLM, no shell) |
@@ -673,11 +673,11 @@ refresh for upgrade cases) is documented in
 
 Current bundles and their skills:
 - [bots/whats-next/skills/](bots/whats-next/skills/) —
-  10 skills: `whats-next` (operating playbook), `iterion-bot-catalog`,
+  11 skills: `whats-next` (operating playbook), `iterion-bot-catalog`,
   `iterion-dsl-quickref`, `iterion-board` (board capabilities
   reference for the claude_code / claw `board.*` tools),
   `iterion-label-vocabulary`, `repo-survey`, `roadmap-synthesis`,
-  `priority-elicitation`, `session-continuity` (iterion workspace
+  `operator-arbitrage`, `factory-ops`, `session-continuity` (iterion workspace
   memory — `memory_read` / `memory_write` / `memory_list` for the
   cross-run knowledge tree under
   `~/.iterion/projects/<key>/memory/<scope>/`), and `dogfood-cycle`
@@ -835,7 +835,7 @@ the following are violations when they appear as **defaults**:
 **Not violations** (these are the *runtime*, not the target repo):
 references to iterion the engine running the bot — `mcp__iterion_board__*`
 capability tools, "iterion's expr / template substitution", `iterion
-report` for surfacing output, `.bot`/`.bot` DSL syntax. The bot is
+report` for surfacing output, `.bot`/`.botz` DSL syntax. The bot is
 *written for* iterion; it must not be *scoped to* iterion.
 
 **Enforcement:** `bots/catalog_universality_test.go` greps every
@@ -1057,7 +1057,7 @@ iterion studio [--port] [--dir] [--bind] [--bots-path] [--no-browser-pane] [--ma
 iterion report --run-id <id> [--store-dir] [--output]  # Generate chronological run report
 iterion dispatch <config.yaml> [--port]  # Long-running dispatcher (tracker → workflow per issue)
 iterion schedule add|list|remove|run|install|uninstall|audit  # Cron recurring bots via the host crontab — no daemon; overlap policy + guard + tick audit (see docs/scheduling.md)
-iterion issue create|list|show|move|update|close|board  # Native kanban tracker
+iterion issue create|list|show|move|update|close|board|import  # Native kanban tracker
 iterion bots create <slug> [--template <id>] [--workdir <dir>] [--dest <dir>]  # Scaffold a bot bundle (CLI half of the studio builder /bots/new)
 iterion bots templates                  # List the templates `bots create` can start from
 iterion bots list [--paths <dir>] [--format json|markdown|skill]  # Discover .bot/.botz bundles (used by whats-next + dispatcher zero-config)

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ The full documentation lives under [`docs/`](docs/) — start with the [document
 
 **References**
 - [docs/references/dsl-grammar.md](docs/references/dsl-grammar.md) — readable grammar
-- [docs/references/diagnostics.md](docs/references/diagnostics.md) — authoritative sparse catalogue: DSL C001–C199 and bundle checks C200–C230
+- [docs/references/diagnostics.md](docs/references/diagnostics.md) — authoritative sparse catalogue: DSL C001–C199 (plus async-interaction C240–C242) and bundle checks C200–C230
 - [docs/references/patterns.md](docs/references/patterns.md) — 10 reusable workflow patterns
 - [docs/grammar/iterion_v1.ebnf](docs/grammar/iterion_v1.ebnf) — formal EBNF grammar
 

--- a/bots/whats-next/README.md
+++ b/bots/whats-next/README.md
@@ -76,5 +76,5 @@ All under [`skills/`](skills/), mirrored to `<workspace>/.claude/skills/`
 at run start: `whats-next` (playbook), `iterion-board`,
 `iterion-bot-catalog` (generated — edit bot manifests, not the file),
 `iterion-label-vocabulary`, `repo-survey`, `roadmap-synthesis`,
-`priority-elicitation`, `session-continuity`, `iterion-dsl-quickref`,
-`dogfood-cycle`.
+`operator-arbitrage`, `factory-ops`, `session-continuity`,
+`iterion-dsl-quickref`, `dogfood-cycle`.

--- a/bots/whole-improve-loop/README.md
+++ b/bots/whole-improve-loop/README.md
@@ -60,6 +60,13 @@ campaign ──▶ verify_build ──▶ verify_run ──▶ gate
                                               mr_gate ──▶ (finalize_mr) ──▶ done
 ```
 
+Two deterministic probe nodes front the LLM steps (omitted above for
+clarity): `verify_probe` sits between `campaign` and the verify pair —
+when a valid `verify.sh` already exists it routes straight to
+`verify_run`, skipping the `verify_build` LLM step; and `forge_auth_probe`
+sits between `mr_gate` and `finalize_mr`, checking a push credential
+exists before the MR-opening agent runs (no credential → `done`).
+
 - **`campaign`** (adaptive, claude_code, whole-repo, full tools) is the whole
   engine: it reads `git log`, builds a living todo list from a brief
   exploration, and applies the axis one site at a time — locate → smallest

--- a/docs/adr/082-sandbox-by-default.md
+++ b/docs/adr/082-sandbox-by-default.md
@@ -1,6 +1,6 @@
 # ADR-082 — Sandbox by default
 
-- Status: accepted (Phases 1–2 shipped; Phase 3 planned)
+- Status: accepted (Phases 1–3 shipped; Phase 3 opt-in per-environment via `runner.sandbox.enabled`)
 - Date: 2026-07-22
 - Deciders: devthejo
 
@@ -83,12 +83,20 @@ toolchain caches); everything else (claude install gates, `~/.claude`
 mounts, `CLAUDE_CONFIG_DIR`, `user:`, `network: open`) is gone —
 platform defaults cover them.
 
-### Phase 3 — cloud cutover (planned)
+### Phase 3 — cloud cutover (shipped)
 
-Lift the chart's `ITERION_SANDBOX_OVERRIDE=none` so cloud runs execute
-in per-run sandbox pods (kubernetes driver + ADR-070 per-run credential
-Secret). Known blockers to resolve first, all confirmed by code
-inspection:
+Cloud runs execute in per-run sandbox pods (kubernetes driver + ADR-070
+per-run credential Secret) when a deployment sets
+`runner.sandbox.enabled: true` (base chart default `false` → the chart
+pins `ITERION_SANDBOX_OVERRIDE=none`; prod opts in via
+`values-prod.yaml`). The runner entry point itself resolves the sandbox
+default to `auto` (`resolveRunnerSandboxDefault` in
+[cmd/iterion/runner.go](../../cmd/iterion/runner.go)), so the override is
+the only thing standing between a runner pod and a per-run sandbox. The
+four blockers below were resolved before the cutover, all confirmed by
+code inspection; the prod-validated dogfood is recorded in
+[docs/bot-runs/docs-refresh.md](../bot-runs/docs-refresh.md) (2026-07-22,
+run 019f8a8f — converged sandboxed, PR #270 opened in-pod):
 
 1. **Worktree git + push** — RESOLVED (feat/sandbox-cloud-git). No
    init-container/PVC needed: the driver already tar-copies the *clone
@@ -124,9 +132,10 @@ inspection:
    token delivered as a file secret — or a per-bot policy grant to
    stay unsandboxed.
 
-Validation for the cutover: re-run the Doki repo-targeted cloud dogfood
-sandboxed and compare against the 2026-07-21/22 unsandboxed baseline
-(`docs/bot-runs/docs-refresh.md`).
+Validation for the cutover was performed: the Doki repo-targeted cloud
+dogfood was re-run sandboxed and compared against the 2026-07-21/22
+unsandboxed baseline (`docs/bot-runs/docs-refresh.md`) — the sandboxed
+run converged and opened its PR from inside the pod.
 
 ## Alternatives considered
 
@@ -152,5 +161,7 @@ sandboxed and compare against the 2026-07-21/22 unsandboxed baseline
 - The per-launch sandbox confirmation disappears for the common case;
   security review focuses on explicit `sandbox: none` declarations,
   which C128 makes greppable and reviewable.
-- Until Phase 3 lands, cloud behaviour is unchanged — the dogfood
-  baseline stays comparable.
+- Cloud behaviour is unchanged for deployments that leave
+  `runner.sandbox.enabled: false` (the base-chart default); enabling it
+  puts each cloud run in its own per-run sandbox pod. Prod runs
+  sandboxed.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,8 +95,9 @@ and claimed by a runner.
    executable graph.
 4. **Validate** — structural and semantic passes check reachability, cycles and
    loop fuel, routing, convergence, capabilities, templates, sandbox settings,
-   and backend constraints before execution. DSL diagnostics occupy C001–C199;
-   bundle consistency checks occupy C200–C230.
+   and backend constraints before execution. DSL diagnostics occupy C001–C199
+   plus the async-interaction band C240–C242; bundle consistency checks occupy
+   C200–C230.
 
 The compiler returns diagnostics rather than hiding repairs. The authoritative
 catalogue is [references/diagnostics.md](references/diagnostics.md); the language

--- a/docs/bot-invocations.md
+++ b/docs/bot-invocations.md
@@ -18,7 +18,7 @@ neither (Nexie, Evoly) stay out of the picker.
 
 ```yaml
 invocations:
-  - kind: forge | command | schedule | board   # required, closed set
+  - kind: forge | command | schedule | board | keepalive   # required, closed set
     mode: direct | board                        # optional, default direct
     args_var: <workflow var>                    # optional: where the trigger payload lands
     context_vars: { k: v }                       # optional: vars stamped on every run from this path
@@ -27,6 +27,7 @@ invocations:
     command:  { name: featurly, aliases: [feature-dev], scope: pr|issue|any,
                 min_replier_role: maintainer, disambiguator: when_args_empty|when_args_present }
     schedule: { suggested_cron: "0 2 * * 1", default_vars: { k: v } }
+    keepalive: { interval: "30s" }               # relaunch cadence (>= 5s; sub-minute needs the resident scheduler)
 ```
 
 Validation runs at manifest parse time (`bundle.validateInvocations`): unknown
@@ -41,10 +42,17 @@ a var the bot's workflow does not declare.
 - **`command`** — a `/slash-command` in a PR/MR/issue comment. The universal
   manual trigger, on all three forges (GitLab notes, GitHub/Forgejo
   `issue_comment`). Resolved through the per-webhook command map.
-- **`schedule`** — a suggested cron the Integrations UI proposes. *(Cloud
-  scheduler not yet wired — the suggestion shows but does not fire; see P3.)*
+- **`schedule`** — a suggested cron. Enabling a bot with a schedule
+  invocation provisions a firing cloud `ScheduledBot` (the orchestrator's
+  `syncSchedules`), with the cadence overridable in the enable dialog; the
+  in-process `trigger.Scheduler` fires schedule-kind subscriptions on their
+  cron. Self-hosted CLI uses `iterion schedule` instead.
 - **`board`** — a dispatcher target: an issue whose `Bot` is this bot is picked
   up and run.
+- **`keepalive`** — always-on: a fresh, individually budgeted run is relaunched
+  every `interval` with at-most-one-live semantics (a stale run is reaped, not
+  stacked). Sub-minute cadence needs the resident in-process scheduler; the host
+  crontab floors at one minute.
 
 ## Execution mode
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -188,6 +188,15 @@ iterion runs prune --older-than 168h --keep-last 100
 
 Default retention deletes `finished`, `failed`, and `cancelled` runs older than 720 hours. `failed_resumable` requires explicit inclusion via `--status`. Only `<store-dir>/runs/` is touched; worktrees are not removed.
 
+### `iterion runs questions` / `iterion runs answer`
+
+```bash
+iterion runs questions <run-id>                   # list a run's pending async questions
+iterion runs answer <run-id> <interaction-id> "<answer>"
+```
+
+The async-question subcommands drive the `ask_user_async` / `await_answers` interaction (ADR-081): `questions` lists the questions an agent has posted and is still awaiting, and `answer` replies to one without pausing the run. See [async-interaction.md](async-interaction.md).
+
 ## Bot creation, discovery, and extension distribution
 
 ### `iterion bots`
@@ -380,7 +389,7 @@ The watcher evaluates on turn boundaries/monitor matches and injects node-scoped
 
 ## Remote, benchmarks, and utility commands
 
-`iterion remote` exposes typed cloud domains for runs, bots, marketplace, issues/boards, dispatcher, triggers, orgs/teams/users, tokens, secrets/keys/bindings, webhooks/forge, audit/usage/limits, memory, plugins, SSO/admin, routes/OpenAPI, and raw API access. CI can use `ITERION_REMOTE_URL`, `ITERION_REMOTE_TOKEN`, and optional team/org selectors without a config file. The complete reference is [cloud CLI](cloud-cli.md).
+`iterion remote` exposes typed cloud domains for runs, bots, marketplace, issues/boards, dispatcher, triggers, schedules, orgs/teams/users, tokens, secrets/keys/bindings, webhooks/forge, audit/usage/limits, memory, plugins, SSO/admin, routes/OpenAPI, and raw API access. CI can use `ITERION_REMOTE_URL`, `ITERION_REMOTE_TOKEN`, and optional team/org selectors without a config file. The complete reference is [cloud CLI](cloud-cli.md).
 
 `iterion bench asymptote` accepts primary `--runs`, optional `--variant-runs`, a required `--judge-node`, judge field/threshold, loop selector, labels, title, per-run detail, and output path. See [asymptote bench](asymptote-bench.md).
 

--- a/docs/cloud-cli.md
+++ b/docs/cloud-cli.md
@@ -97,6 +97,7 @@ the staging step alone and prints the upload id.
 | `labels` / `board` | `list · rename · merge · delete` / `get · set` |
 | `dispatcher` | `status · state · start · stop · pause · resume · refresh · reload · config · issue · cancel` |
 | `triggers` | `list · get · create · update · delete · emit` |
+| `schedules` | `list · create · delete` (team-scoped cloud recurring-bot schedules) |
 | `teams` | `list · create · switch · members · invitations` |
 | `orgs` | `list · switch · members · invitations · usage · teams` |
 | `me` | `password · sessions-revoke-all · sso-links` |

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -28,7 +28,7 @@ linked references.
 | Reuse and extension | Bundles, recipes/presets, project/global skills, plugins, MCP servers, marketplace entries, command-output rewriters, and bot/repository `devbox.json` toolchains. |
 | Automation | Host schedules, tracker dispatcher, native-board events, run-completion chains, forge/generic webhooks, and the event-driven trigger spine. |
 | Cloud control plane | Organization → team tenancy, SSO/password auth, PATs, BYOK and bound secrets, audit and quotas, repo-first forge integrations, NATS-queued runners, MongoDB/S3 persistence, and the typed `iterion remote` CLI. |
-| Maintained bots | 24 bundles live under `bots/`; nine general-purpose bots are embedded for zero-config dispatcher use. See the [catalogue](examples.md). |
+| Maintained bots | 25 bundles live under `bots/`; nine general-purpose bots are embedded for zero-config dispatcher use. See the [catalogue](examples.md). |
 
 ## End-to-end execution
 

--- a/docs/delegation.md
+++ b/docs/delegation.md
@@ -19,6 +19,7 @@ agent implementer:
 | `claw` (default) | recommended for read-only / judges | In-process multi-provider LLM client (Anthropic, OpenAI, …) — use with `model: "openai/gpt-5.4-mini"` etc. |
 | `codex` | **discouraged** | Runs the `codex` CLI as a subprocess. Cannot configure its tool set, tends to fill its own context window, and has weaker iterion integration. The compiler emits a `C030` warning per node. Kept for compatibility — prefer `claude_code` or `claw`+OpenAI in new workflows. |
 | `kimi` | opt-in | Runs Moonshot's `kimi-code` CLI, whose argv is disjoint from claude-code's (`kimi -p <prompt> --output-format stream-json [-m <alias>]`). A concrete instance of iterion's generic CLI-agent backend. See [Backends → Third-party agent CLIs](backends.md#third-party-agent-clis-kimi-grok-and-the-cli-agent-seam) and [ADR-065](adr/065-dedicated-cli-agent-backend.md). |
+| `grok` | opt-in | Runs xAI's Grok Build CLI (`grok -p <prompt> --output-format json …`), argv disjoint from claude-code's; another concrete instance of the generic CLI-agent backend, registered alongside `kimi`. Distinct from `claw` + `model: "xai/…"` (the metered xAI HTTP API). See [Backends → Third-party agent CLIs](backends.md#third-party-agent-clis-kimi-grok-and-the-cli-agent-seam) and [ADR-065](adr/065-dedicated-cli-agent-backend.md). |
 
 > 💡 `claude_code` works with your Claude subscription (Pro/Max/Team/Enterprise) — no separate API key required. `claw` calls provider APIs directly and needs the corresponding API key (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, …).
 

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -104,7 +104,7 @@ the in-flight runs, and the retry queue, with pause/stop controls:
 
 ```mermaid
 flowchart LR
-  TRK["Tracker<br/>(native / GH /<br/>Forgejo)"]
+  TRK["Tracker<br/>(native / GH /<br/>GitLab / Forgejo)"]
   DSP["Dispatcher<br/>(1 actor goro)"]
   RUN["Runner<br/>(engine = LLM<br/>+ tools)"]
 
@@ -198,7 +198,7 @@ agent:
   running_state: none   # keep claimed issues in their source state
 ```
 
-External trackers (GitHub, Forgejo) map the abstract state to labels;
+External trackers (GitHub, GitLab, Forgejo) map the abstract state to labels;
 if the YAML's `state_mapping` doesn't declare `in_progress`,
 `UpdateState` returns `ErrTransitionRejected` and the dispatcher
 logs + continues without aborting the dispatch.
@@ -422,11 +422,12 @@ for the stock assignee workflow selection.
 **How to set `bot` / `bot_args` today**: REST API only —
 `POST /api/v1/native/issues` or `PATCH /api/v1/native/issues/{id}`
 with `{ "bot": "feature_dev", "bot_args": { "feature_prompt": "…" } }`.
-The `iterion issue create/update` CLI does **not** yet expose
-dedicated bot-selection or bot-argument flags; `--field key=value` lands in
-the freeform `Fields` map, not in `BotArgs`, and is not merged into dispatch
-vars. Operators driving routing purely through the CLI should rely on
-`assignee_workflows:` + `assignee_dispatch:` instead.
+`iterion issue create` exposes `--bot` and `--bot-arg key=value`
+(they land in the typed `Bot` / `BotArgs` fields the dispatcher routes
+on). `iterion issue update` does **not** yet — change routing on an
+existing card via the REST `PATCH` above, the board MCP tools, or the
+studio. Note that `--field key=value` on either command lands in the
+freeform `Fields` map, not in `BotArgs`.
 
 ### Per-assignee dispatch overrides
 
@@ -618,6 +619,30 @@ tracker:
 Same label-driven semantics as GitHub; label updates go through
 `PUT /api/v1/repos/<owner>/<repo>/issues/<n>/labels` so iterion does
 not need to resolve numeric label IDs.
+
+### `tracker.kind: gitlab`
+
+Direct client against the GitLab v4 REST API. Auth is the
+`PRIVATE-TOKEN: $GITLAB_TOKEN` header; the `repo` project path is
+URL-encoded (`owner/repo` → `owner%2Frepo`) internally.
+
+```yaml
+tracker:
+  kind: gitlab
+  gitlab:
+    host: https://gitlab.com
+    repo: owner/repo
+    token: $GITLAB_TOKEN
+    include_labels: [ready]
+    claimed_label: claimed        # optional; defaults to iterion-claimed
+    state_mapping:
+      ready:       { labels_include: [ready] }
+      in_progress: { labels_include: [claimed] }
+```
+
+Same label-driven claim semantics as GitHub/Forgejo — the claim label
+(default `iterion-claimed`) marks an issue as taken so a single
+dispatcher instance never double-claims it.
 
 ## HTTP / WS surface
 

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -15,7 +15,7 @@ A file may contain these top-level declarations:
 ```text
 vars, presets, attachments, secrets, mcp_server,
 prompt, schema, cursor, supervisor,
-agent, judge, router, human, tool, compute, emit, wait, subbot,
+agent, judge, router, human, tool, compute, emit, wait, await_answers, subbot,
 group, use, workflow
 ```
 
@@ -255,7 +255,9 @@ human approval:
   min_answers: 1
 ```
 
-`interaction` is one of `none`, `human`, `llm`, `llm_or_human`, or `review`. A review gate additionally accepts `review_url`, `posture`, `merge_strategy`, `merge_into`, and `max_turns`. Human nodes may also publish labeled artifacts and converge with `await`. See [human-in-the-loop](human-in-the-loop.md) and [review/merge gate](review-merge-gate.md).
+`interaction` is one of `none`, `human`, `llm`, `llm_or_human`, `review`, or `async`. A review gate additionally accepts `review_url`, `posture`, `merge_strategy`, `merge_into`, and `max_turns`. Human nodes may also publish labeled artifacts and converge with `await`. See [human-in-the-loop](human-in-the-loop.md) and [review/merge gate](review-merge-gate.md).
+
+`interaction: async` (ADR-081) lets an agent/judge node post **non-blocking** questions via the `ask_user_async` tool and keep working; answers land in a node-scoped inbox. The dedicated `await_answers` node is the deterministic sync point — it parks only its own branch until every pending question of the `from:` node (or the whole run) is answered (mandatory `timeout:`), outputting `{answers: [...]}`. Diagnostics C240–C242. See [async interaction](async-interaction.md).
 
 Resume a pause with `iterion resume --run-id <id> --file workflow.bot --answer key=value`.
 
@@ -275,7 +277,7 @@ tool run_tests:
   needs: [test_slot]
 ```
 
-`command` and `script` are mutually exclusive. A script adds `language: js|py|sh|bash` (default `sh`). Tools also accept `input`, `output`, `publish`, `artifact_labels`, `await`, `sandbox`, `compress`, `permission`, and `needs`.
+`command` and `script` are mutually exclusive. A script adds `language: js|node|py|python|python3|sh|bash` (default `sh`). Tools also accept `input`, `output`, `publish`, `artifact_labels`, `await`, `sandbox`, `compress`, `permission`, and `needs`.
 
 Verified Actions add a deterministic outcome check and bounded recovery:
 
@@ -492,7 +494,7 @@ Terminal targets `done` and `fail` are reserved and are never declared.
 
 ## Validation and references
 
-Run `iterion validate workflow.bot` before execution. Diagnostics occupy sparse ranges: DSL/compiler/runtime consistency checks use C001–C199; bundle checks use C200–C230. The authoritative list is [references/diagnostics.md](references/diagnostics.md).
+Run `iterion validate workflow.bot` before execution. Diagnostics occupy sparse ranges: DSL/compiler/runtime consistency checks use C001–C199 (with a later C240+ band for async-interaction checks, since C200–C230 is claimed by bundle checks); bundle checks use C200–C230. The authoritative list is [references/diagnostics.md](references/diagnostics.md).
 
 - [Readable grammar](references/dsl-grammar.md)
 - [Formal EBNF](grammar/iterion_v1.ebnf)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -42,6 +42,7 @@ These bots are shipped in the repository and are discoverable by the CLI and stu
 | 🧬 Evoly | [`evolve`](../bots/evolve/) | Long-horizon product and architecture partner backed by persistent per-bot memory. |
 | 🧩 Fini | [`feature-gap-fill`](../bots/feature-gap-fill/) | Finish a structured partial-implementation gap while preserving what already works. |
 | 🔭 Vigie | [`feed-watch`](../bots/feed-watch/) | Collect RSS/Atom feeds at zero LLM cost, then produce and deliver grounded digests. |
+| 🏷️ Triagy | [`issue-triage`](../bots/issue-triage/) | Single-shot card triage: read a fresh board card, classify it against the bot catalogue, stamp the handler bot + labels, and leave a routing comment. Fires on `triage:auto`; never dispatched work TO. |
 | 💬 Revi (converse) | [`revi-converse`](../bots/revi-converse/) | Answer a focused `/revi` follow-up in the same forge discussion; never edits code. |
 | ♿ Acci | [`rgaa-audit`](../bots/rgaa-audit/) | Read-only RGAA 4.1.2 source audit with a deterministic coverage gate. |
 | ⛓️ Shieldy | [`supply-shield`](../bots/supply-shield/) | Diff-scoped dependency-malware gate for forge events. |

--- a/docs/human-in-the-loop.md
+++ b/docs/human-in-the-loop.md
@@ -8,7 +8,7 @@ an approval before a deploy, a missing requirement only a human knows, a
 first-class, **resumable** part of the graph: a run can pause, wait for a
 human (for seconds or for days), and pick up exactly where it left off.
 
-This page covers the `human` node, the five accepted interaction values, the form
+This page covers the `human` node, the five interaction values a human node accepts, the form
 the studio renders, and every way to answer (studio, CLI, HTTP).
 
 ## The `human` node

--- a/docs/import.md
+++ b/docs/import.md
@@ -82,8 +82,8 @@ iterion import flow.js --dry-run --json                       # machine-readable
 2. Fill every `hole_N` var (or replace the ref with real DSL) and
    resolve every `## IMPORT TODO`.
 3. `iterion validate <draft>.bot`, then a dogfood run.
-4. Promote it to a bundle when it earns a manifest: `iterion bundle
-   init` and move the workflow in.
+4. Promote it to a bundle when it earns a manifest: scaffold one with
+   `iterion bots create <slug>` and move the imported workflow into it.
 
 ## In the studio
 

--- a/docs/native-tracker.md
+++ b/docs/native-tracker.md
@@ -7,8 +7,8 @@ through the `iterion issue` CLI or the studio's Board view.
 
 The native tracker is a deliberate design choice: iterion's autonomous
 loop should not require the operator to lock themselves into a
-proprietary issue tracker. External adapters (`github`, `forgejo`) are
-optional plug-ins, not the source of truth.
+proprietary issue tracker. External adapters (`github`, `gitlab`,
+`forgejo`) are optional plug-ins, not the source of truth.
 
 The studio's Board view (`/board`) is a drag-and-drop front end over
 this store — cards carry labels, priorities, and per-card bot assignees:
@@ -40,7 +40,9 @@ one record to `events.jsonl`. The event types are:
 
 `issue_created`, `issue_updated`, `issue_state_changed`,
 `issue_deleted`, `issue_claimed`, `issue_released`,
-`issue_last_run_updated`, `board_updated`.
+`issue_last_run_updated`, `issue_comment_added`,
+`issue_blockers_updated`, `issue_unblocked`, `label_rename`,
+`label_merge`, `label_delete`, `board_updated`.
 
 The dispatcher stamps every issue it processes with `last_run_id`
 (the run that handled it) + `last_workdir` (the worktree path on
@@ -134,6 +136,15 @@ issue write — unknown fields and bad types are rejected.
 
 Field values are rendered into workflow inputs via
 `{{issue.fields.<name>}}` in the dispatcher's `dispatch.vars` block.
+
+### Comments
+
+Each issue carries an append-only `comments` thread (`Issue.Comments`,
+persisted with the issue). A bot writes to it through the
+`board.comment` capability's `comment_issue` tool; every append emits
+an `issue_comment_added` event. The thread is a lightweight discussion
+record alongside the structured fields — the `events.jsonl` log remains
+the full audit trail.
 
 ## CLI — `iterion issue`
 
@@ -458,8 +469,6 @@ adapter := native.NewAdapter(s) // satisfies tracker.Tracker
 
 ## Limitations (v1)
 
-- **No comments.** Events.jsonl is the audit trail; user-facing
-  comments are a v2 ergonomic.
 - **No bi-directional sync with GitHub / Forgejo.** A single
   dispatcher instance picks one tracker. Mirroring is on the v2
   roadmap.

--- a/docs/oauth-forfait.md
+++ b/docs/oauth-forfait.md
@@ -70,7 +70,7 @@ values are overridable per deployment:
 | Env var | Purpose |
 | --- | --- |
 | `ITERION_OAUTH_FORFAIT_ANTHROPIC_CLIENT_ID` | Claude Code OAuth client id. **Defaults** to the public client; override only if Anthropic rotates it. |
-| `ITERION_OAUTH_FORFAIT_OPENAI_CLIENT_ID` | Codex OAuth client id (refresh). |
+| `ITERION_OAUTH_FORFAIT_CODEX_CLIENT_ID` | Codex OAuth client id (refresh). |
 | `ITERION_OAUTH_FORFAIT_ANTHROPIC_AUTHORIZE_URL` | Override the authorize endpoint (default `https://claude.ai/oauth/authorize`). |
 | `ITERION_OAUTH_FORFAIT_ANTHROPIC_REDIRECT_URI` | Override the headless redirect (default `https://platform.claude.com/oauth/code/callback`). |
 | `ITERION_OAUTH_FORFAIT_ANTHROPIC_SCOPES` | Override the requested scopes. |

--- a/docs/references/diagnostics.md
+++ b/docs/references/diagnostics.md
@@ -45,7 +45,7 @@ All diagnostic codes emitted during compilation (`ir.Compile`) and validation (`
 | **C022** | error | LLM router edge has condition | An edge from an `llm` router has a `when` clause | Remove the `when` clause — LLM routers select targets directly |
 | **C023** | error | LLM-only property on non-LLM router | Properties `model`, `backend`, `system`, `user`, `multi`, or `reasoning_effort` are set on a router that isn't `mode: llm` | Remove these properties or change the mode to `llm` |
 | **C026** | error | Invalid loop iterations | A loop's `max_iterations` is less than 1 | Set `max_iterations` to at least 1 |
-| **C027** | error | Invalid reasoning effort | `reasoning_effort` has a value other than `low`, `medium`, `high`, `xhigh`, `max` | Use one of the five valid values |
+| **C027** | error | Invalid reasoning effort | `reasoning_effort` has a value other than `low`, `medium`, `high`, `xhigh`, `max`, `ultracode` | Use one of the six valid values (`ultracode` is remapped to `xhigh` on the wire) |
 | **C028** | error | Duplicate with-mapping key | The same `with` key appears on multiple non-conditional edges to the same target | Use unique keys, or make edges conditional/convergent |
 | **C029** | error | Unknown outputs node reference | A `{{outputs.<node>...}}` template targets a node not declared anywhere in the file | Declare the node or fix the typo |
 | **C031** | error | outputs ref field not in output schema | `{{outputs.<node>.<field>}}` references a field absent from that node's `output:` schema | Reference an existing field, or add the field to the schema |

--- a/docs/references/dsl-grammar.md
+++ b/docs/references/dsl-grammar.md
@@ -15,7 +15,7 @@ file = { top_level_decl } ;
 top_level_decl = vars | presets | attachments | secrets | mcp_server
                | prompt | schema | cursor | supervisor
                | agent | judge | router | human | tool | compute
-               | emit | wait | subbot | group | use | workflow ;
+               | emit | wait | await_answers | subbot | group | use | workflow ;
 ```
 
 At most one top-level `vars`, `presets`, `attachments`, and `secrets` block is retained. Named declarations may repeat only when their names remain unique after compilation.
@@ -157,7 +157,7 @@ They share the exact property surface:
 | `timeout` | duration string |
 | `readonly`, `full_access` | boolean |
 | `images` | string list |
-| `interaction` | `none`, `human`, `llm`, `llm_or_human`, `review` |
+| `interaction` | `none`, `human`, `llm`, `llm_or_human`, `review`, `async` (`async` is agent/judge-only) |
 | `interaction_prompt` | prompt identifier |
 | `interaction_model` | string |
 | `await` | `wait_all`, `best_effort` |

--- a/docs/routers.md
+++ b/docs/routers.md
@@ -235,7 +235,7 @@ Routers are fan-out sources and do not declare `await:` themselves.
 
 The compiler catches common mistakes at compile time:
 
-- **Mode-specific properties** — `model`, `backend`, `provider`, `system`, `user`, `multi`, and `reasoning_effort` belong to `llm`; `over`, `as`, `key`, and `depends_on` belong to `fan_out_each`.
+- **Mode-specific properties** — `model`, `backend`, `system`, `user`, `multi`, and `reasoning_effort` belong to `llm`; `over`, `as`, `key`, and `depends_on` belong to `fan_out_each`.
 - **Missing model and backend on LLM routers** — if neither `model` nor `backend` is set, a warning is emitted (the built-in default model will be used at runtime).
 - **Conditional edges on LLM routers** — LLM routers must use unconditional edges because the LLM decides the route, not edge conditions.
 - **Malformed per-item fan-out** — `fan_out_each` requires `over:`, exactly one unconditional outgoing template edge, and `key:` whenever `depends_on:` is set.

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -13,10 +13,13 @@ filesystem. The ambient default degrades gracefully instead of
 failing: outside a git repository it is silently not applicable, and
 on a host with no container runtime the run proceeds unsandboxed with
 a visible `sandbox_skipped` event. An EXPLICIT sandbox request (CLI
-flag or workflow block) never degrades — it errors. (The cloud runner
-currently pins `ITERION_SANDBOX_OVERRIDE=none` — the runner pod is the
-isolation boundary there until the k8s sandbox path carries worktree
-git access and interactive channels end-to-end.)
+flag or workflow block) never degrades — it errors. (In cloud, per-run
+sandbox pods are gated by the chart's `runner.sandbox.enabled` toggle:
+off — the base-chart default — pins `ITERION_SANDBOX_OVERRIDE=none` and
+the runner pod is the isolation boundary; on — as prod runs — puts each
+cloud run in its own kubernetes-driver sandbox pod. The k8s path now
+carries worktree git/push and interactive channels end-to-end, see
+[ADR-082](adr/082-sandbox-by-default.md) Phase 3.)
 
 ## Quick start
 
@@ -420,9 +423,10 @@ The repo's installs in place so relative package references
 ### Runs without a sandbox (cloud runner pods, plain host runs)
 
 Provisioning is **not** tied to a sandbox container. When no sandbox is
-active — which is **every cloud run** (the chart pins
+active — every cloud run on a deployment that leaves
+`runner.sandbox.enabled: false` (the chart then pins
 `ITERION_SANDBOX_OVERRIDE=none`: the runner pod is the isolation
-boundary, so a bot's inline `sandbox:` block never starts a container)
+boundary, so a bot's inline `sandbox:` block never starts a container),
 and every local `iterion run` without a sandbox declaration — the same
 two sources are provisioned **on the executing host**: `devbox install`
 runs at run start (the bot's config staged into a per-run temp dir,

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -42,8 +42,9 @@ schedules:
       label_source: sec-audit-self
     description: Weekly SAST self-audit  # optional; emitted as a crontab comment
     disabled: false                      # keep in the manifest, leave out of the crontab
-    overlap: skip                        # optional: skip (default) | allow — see "Overlap policy"
+    overlap: skip                        # optional: skip (default) | allow | keepalive — see "Overlap policy"
     max_concurrent: 0                    # optional, with overlap: allow — cap on live runs (0 = unlimited)
+    stale_after: ""                       # optional, with overlap: keepalive — relaunch if the live run is stale — see "Always-on agents"
     guard: ""                            # optional pre-launch sh -lc gate — see "Guard command"
     guard_timeout: "30s"                 # optional guard subprocess timeout
     guard_var: guard_output              # optional var name receiving the guard stdout


### PR DESCRIPTION
Consolidates two benchmark-verified documentation-alignment passes (agents `native-ref` + `native-strong`) into one clean PR, rebased on current `origin/main`. Every change was re-verified against the actual Go/TS code before keeping it; no code is touched (23 `.md` files only).

## Zones aligned
- **Async interaction (ADR-081)** — `await_answers` top-level node + `interaction: async` across `dsl.md`, `dsl-grammar.md`, `architecture.md`, `human-in-the-loop.md`, `README.md`; new `iterion runs questions|answer` subcommands in `cli-reference.md` (positional args, matching the real CLI — corrected from the source branch's flag form); C240–C242 diagnostics band.
- **Sandbox (ADR-082 Phase 3)** — cloud sandbox cutover documented as shipped/gated by `runner.sandbox.enabled` (`resolveRunnerSandboxDefault`), validated by the 2026-07-22 sandboxed dogfood (run 019f8a8f, PR #270).
- **Dispatcher / native tracker** — `tracker.kind: gitlab`, issue comments thread (`comment_issue`), new issue events, `iterion issue create --bot/--bot-arg` flags.
- **Backends** — `grok` CLI-agent backend in the delegation table; `oauth-forfait` env var corrected to `ITERION_OAUTH_FORFAIT_CODEX_CLIENT_ID`; bundle promotion via `iterion bots create`.
- **Routers / diagnostics** — dropped invalid `provider` property from llm-router list; `ultracode` added to C027 reasoning-effort values.
- **Invocations / scheduling** — `keepalive` invocation kind + `overlap: keepalive` / `stale_after`.
- **Cloud CLI** — `remote schedules` command group.
- **Catalog** — Triagy (`issue-triage`) added; bundle count 24→25; whats-next skills refreshed (`operator-arbitrage` + `factory-ops` replace `priority-elicitation`); whole-improve-loop probe nodes.
- **CLAUDE.md** — router 5 modes (`fan_out_each`), 11 skills, `.botz` typo, `issue import` subcommand.

## Notes
- **Discarded / deduped:** overlaps between the two source branches were unioned (CLAUDE.md, cli-reference.md, cloud-cli.md, current-state.md, dsl.md, examples.md); `dsl.md` kept `native-ref`'s superset; the identical 24→25 bundle bump applied once; `cloud-cli.md` schedules-row description merged. One factual correction over the sources: the `runs answer` invocation uses positional args, not flags.
- **Nothing was already on main** — the two branches share merge-base `21816a00b` and `origin/main` had zero drift on every touched doc file, so no fix was pre-applied.
- This is the `docs/` layer. Heavier-drift surfaces (bot READMEs beyond the two touched here, deep cloud docs) are a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
