### PR TITLE
feat(webhooks): PR-open auto-reviews only (Revi); Billy on /billy with Revi's review

### DIFF
--- a/bots/branch-improve-loop/main.bot
+++ b/bots/branch-improve-loop/main.bot
@@ -169,6 +169,16 @@ vars:
   ## only in the iterion run. The PR-webhook trigger sets it. Empty = skip.
   pr_url: string = ""
 
+  ## Prior review to START FROM, not re-derive. When Billy is invoked with
+  ## `/billy` on a PR that Revi (review-pr) already reviewed, the iterion
+  ## webhook handler seeds this with Revi's most recent findings for that PR
+  ## (severity/category/file:line/detail per finding). Treat them as a
+  ## high-signal head start — verify each against the current diff, FIX the
+  ## real ones, and keep reviewing for anything Revi missed (Revi is
+  ## read-only; you fix + commit). Empty (default) = no prior review, review
+  ## the diff from scratch.
+  prior_review: string = ""
+
 secrets:
   ## Forge access for push + PR creation + the issue back-link. Mounted as a
   ## read-only file the gh/glab CLI authenticates from; never read into a
@@ -285,6 +295,12 @@ prompt campaign_user:
 
   Extra context / notes (empty = the diff speaks for itself):
   {{vars.scope_notes}}
+
+  PRIOR REVIEW to start from (empty = none; when present, another reviewer
+  (Revi) already reviewed this PR — treat each finding as a high-signal head
+  start: verify it against the CURRENT diff, FIX the real ones and commit,
+  then keep reviewing for anything it missed — do NOT just trust it):
+  {{vars.prior_review}}
 
   BASELINE — pre-existing failures / known-flaky tests to SKIP (empty =
   establish it once cheaply against {{vars.base_ref}}, then skip what predates

--- a/bots/branch-improve-loop/manifest.yaml
+++ b/bots/branch-improve-loop/manifest.yaml
@@ -78,7 +78,7 @@ invocations:
   - kind: command
     mode: board
     args_var: scope_notes
-    command: { name: billy, aliases: [branch-improve-loop, improve], scope: any, min_replier_role: developer }
+    command: { name: billy, aliases: [branch-improve-loop, improve], scope: any, min_replier_role: maintainer }
   - kind: board
 
 ## Studio launch-form hierarchy: `primary` inputs render top-level in

--- a/bots/branch-improve-loop/manifest.yaml
+++ b/bots/branch-improve-loop/manifest.yaml
@@ -70,15 +70,15 @@ forge:
   secret: forge_token
 
 invocations:
+  # Billy runs on a PR ONLY on this deliberate `/billy` (alias `/improve`)
+  # slash-command, gated on the commenter's repo rights (min_replier_role).
+  # There is NO PR-open auto-launch: opening a PR only ever auto-REVIEWS it
+  # (Revi). `/billy` picks up where Revi left off — the handler seeds
+  # `prior_review` from Revi's most recent review of the PR.
   - kind: command
     mode: board
     args_var: scope_notes
-    command: { name: billy, aliases: [branch-improve-loop], scope: any, min_replier_role: maintainer }
-  # A same-repo PR that implements a tracked issue auto-launches Billy to harden
-  # it (fork guard + ticket dedup live in the inbound handler: selectForgePRBot).
-  - kind: forge
-    mode: direct
-    forge: { event: pull_request, actions: [opened, reopened] }
+    command: { name: billy, aliases: [branch-improve-loop, improve], scope: any, min_replier_role: developer }
   - kind: board
 
 ## Studio launch-form hierarchy: `primary` inputs render top-level in

--- a/bots/issue-triage/skills/iterion-bot-catalog.md
+++ b/bots/issue-triage/skills/iterion-bot-catalog.md
@@ -247,7 +247,7 @@ docs/references/productive-session-patterns.md.
   improves what it finds, converging when a fresh re-review is clean and a
   deterministic build/test gate is green. For a whole-codebase (not
   branch-scoped) cross-cutting improvement, use whole-improve-loop instead.
-- **Vars**: `base_ref` (string), `baseline` (string), `max_passes` (int), `mr_base` (string), `mr_branch` (string), `open_mr` (bool), `pr_url` (string), `push_branch` (string), `scope_notes` (string), `scratch_dir` (string), `source_issue_ref` (string), `workspace_dir` (string)
+- **Vars**: `base_ref` (string), `baseline` (string), `max_passes` (int), `mr_base` (string), `mr_branch` (string), `open_mr` (bool), `pr_url` (string), `prior_review` (string), `push_branch` (string), `scope_notes` (string), `scratch_dir` (string), `source_issue_ref` (string), `workspace_dir` (string)
 - **Path**: `bots/branch-improve-loop/main.bot`
 
 ### `dep-update-guard` — Vetty

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -416,7 +416,7 @@ docs/references/productive-session-patterns.md.
   improves what it finds, converging when a fresh re-review is clean and a
   deterministic build/test gate is green. For a whole-codebase (not
   branch-scoped) cross-cutting improvement, use whole-improve-loop instead.
-- **Vars**: `base_ref` (string), `baseline` (string), `max_passes` (int), `mr_base` (string), `mr_branch` (string), `open_mr` (bool), `pr_url` (string), `push_branch` (string), `scope_notes` (string), `scratch_dir` (string), `source_issue_ref` (string), `workspace_dir` (string)
+- **Vars**: `base_ref` (string), `baseline` (string), `max_passes` (int), `mr_base` (string), `mr_branch` (string), `open_mr` (bool), `pr_url` (string), `prior_review` (string), `push_branch` (string), `scope_notes` (string), `scratch_dir` (string), `source_issue_ref` (string), `workspace_dir` (string)
 - **Path**: `bots/branch-improve-loop/main.bot`
 
 ### `dep-update-guard` — Vetty

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -123,15 +123,19 @@ event paths trigger; ping / push / everything else is silently filtered
 failures; [pkg/server/webhooks_github.go](../pkg/server/webhooks_github.go)):
 
 - **`pull_request`** with action `opened`, `reopened`, or `ready_for_review`
-  → PR auto-review. A **draft PR never auto-launches** (the `draft` flag is
-  honoured on every action — the trigger is `ready_for_review`, which clears
-  it). A **fork PR** (head branch in a different repo) is likewise never
-  auto-launched: it is untrusted, so a repo collaborator must trigger a bot
-  manually via the `/command` path — the anti budget-exhaustion boundary
+  → PR auto-**review** (Revi / `review-pr`). This lane is **review-only**: a
+  PR-open NEVER auto-launches the mutating branch-improve loop (Billy) — see
+  *PR auto-lane: review, not mutate* below. A **draft PR never auto-launches**
+  (the `draft` flag is honoured on every action — the trigger is
+  `ready_for_review`, which clears it). A **fork PR** (head branch in a
+  different repo) is likewise never auto-launched: it is untrusted, so a repo
+  collaborator must trigger a bot manually via the `/command` path — the anti
+  budget-exhaustion boundary
   ([pkg/webhooks/prforge/parser.go:IsReviewable](../pkg/webhooks/prforge/parser.go) +
-  `IsCrossRepo`).
+  `IsCrossRepo`). A PR opened by iterion's **own forge bot** (another iterion
+  bot's PR — see below) is also skipped.
 - **`issue_comment`** → the universal `/command` slash path (e.g.
-  `/featurly <prompt>`), routed through the command registry.
+  `/featurly <prompt>`, `/billy`), routed through the command registry.
 - **`issues`** with action `labeled` → launches the webhook's bot with
   the labeled issue turned into a feature task. The handler derives
   `feature_prompt` (issue title + body), `open_mr=true`, and
@@ -179,6 +183,45 @@ webhook action (marking a WIP PR ready arrives as `edited`, which does not
 auto-trigger), so on Forgejo the draft→ready re-trigger is on-demand — a
 collaborator reopens the PR or uses the `/command` path. The no-draft and
 no-fork guarantees hold regardless.
+
+### PR auto-lane: review, not mutate (Revi vs Billy)
+
+The PR/MR **open** lane (GitHub `pull_request`, GitLab `merge_request`,
+Forgejo PR) is **review-only**. Opening a PR auto-launches the read-only
+reviewer **Revi** (`review-pr`) and nothing else — it never runs the
+mutating branch-improve loop **Billy** (`branch-improve-loop`). Two
+carve-outs sit around that rule
+([pkg/server/webhooks_github.go:handlePRForgeReview](../pkg/server/webhooks_github.go),
+[pkg/server/webhooks_common.go:isIterionForgeBotAuthor](../pkg/server/webhooks_common.go)):
+
+- **Iterion-bot PRs are skipped.** A PR opened by iterion's OWN forge bot
+  (another iterion bot — Doki, Willy, Featurly… — pushing through the
+  tenant's forge integration) is **not** auto-reviewed: it already
+  converged inside its own loop, so re-reviewing it just wastes budget and
+  adds noise. The author is matched against the tenant's provisioned forge
+  connection — a GitHub/Forgejo App's `<app_slug>[bot]` login, or (GitLab)
+  the connected bot account — **not** a generic `[bot]` suffix, so
+  Dependabot / Renovate PRs stay reviewable. A human can still force a
+  review with a manual `/revi`. Filtered as a clean 200 (visible reason).
+- **Merge-queue auto-heal is preserved.** A PR *ejected from the GitHub
+  merge queue* for a healable reason (`dequeued`, `NeedsAutoHeal`) still
+  dispatches **Billy** to rebase, resolve the conflict / fix the combined
+  break, and re-enter the queue — a narrow, distinct trigger
+  (same-repo + project/author allowlist + bot-permitted, one attempt per
+  head SHA), unrelated to the review lane.
+
+**Billy on demand — `/billy` (alias `/improve`).** To run Billy on a PR,
+a repo collaborator issues a **`/billy`** slash-command in a PR/MR comment.
+The command reuses the SAME authorization gate as every other
+`/command` / `/revi` (loop-guard + `AuthorizedRepliers` allowlist OR a
+repo permission ≥ the route's `min_replier_role`), so a non-collaborator
+cannot invoke it. Billy then commits its hardening onto the PR's own
+branch (or opens a separate PR with `branch_improve_as_pr`). When Revi has
+already reviewed that PR, the handler seeds Billy's run with Revi's most
+recent findings under the **`prior_review`** var — so Billy starts from
+that review instead of re-deriving it (best-effort: with no prior review,
+Billy reviews the diff from scratch;
+[pkg/server/webhooks_prior_review.go](../pkg/server/webhooks_prior_review.go)).
 
 ### Generic (`POST /api/webhooks/generic/{id}`)
 

--- a/pkg/server/invocation_dispatch.go
+++ b/pkg/server/invocation_dispatch.go
@@ -205,7 +205,7 @@ func (s *Server) ensureBoardCard(ctx context.Context, cfg webhooks.Config, route
 	// webhook launch vars never reaches a board-mode run — the bot then works
 	// off its DSL defaults (e.g. mr_gate.push_back=false strands the campaign
 	// commits on the runner's storage branch instead of the PR).
-	for _, k := range []string{"pr_url", "base_ref", "target_branch", "source_branch", "pr_author", "push_branch", "open_mr", "mr_base"} {
+	for _, k := range []string{"pr_url", "base_ref", "target_branch", "source_branch", "pr_author", "push_branch", "open_mr", "mr_base", "prior_review"} {
 		if v, ok := vars[k]; ok && v != "" {
 			botArgs[k] = v
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -180,7 +180,16 @@ type Server struct {
 	// PR-surface command comment (the issue_comment payload carries no head
 	// branch — test seam). nil → realWebhookPRForgePRResolver.
 	webhookPRForgePRResolver func(ctx context.Context, cfg webhooks.Config, provider webhooks.Provider, p prforge.ParsedNote, route webhooks.CommandRoute) (forge.PullRef, error)
-	httpClient               *http.Client
+	// webhookIterionBotAuthor overrides the "is this PR/MR authored by iterion's
+	// own forge bot" check that keeps the PR-open auto-review lane from launching
+	// Revi on another iterion bot's PR (test seam — the real impl resolves the
+	// provisioned forge Connection). nil → realIterionBotAuthor.
+	webhookIterionBotAuthor func(ctx context.Context, cfg webhooks.Config, login string) bool
+	// webhookPriorReview overrides the lookup of the most recent review-pr (Revi)
+	// run for a PR, whose findings seed a `/billy` invocation (test seam). nil →
+	// realWebhookPriorReview. Returns "" when no prior review is found (best-effort).
+	webhookPriorReview func(ctx context.Context, cfg webhooks.Config, prURL, projectPath string, prNumber int) string
+	httpClient         *http.Client
 
 	// forgeHTTP is the SSRF-guarded client for outbound forge calls, built
 	// once (its strict flag is startup-fixed) so connection pooling is

--- a/pkg/server/webhooks_command_test.go
+++ b/pkg/server/webhooks_command_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
@@ -519,5 +520,78 @@ func TestGitLabIssueNote_NonOpensMRNoStamp(t *testing.T) {
 	}
 	if _, ok := cards[0].BotArgs["open_mr"]; ok {
 		t.Errorf("non-opens_mr command must not stamp open_mr: %+v", cards[0].BotArgs)
+	}
+}
+
+// TestGitHubIssueComment_BillyUnauthorizedRejected: `/billy` from a commenter
+// who fails the authorization gate (no repo write) is filtered (200) and NEVER
+// launches the mutating branch-improve loop (req 3 — the authz gate is
+// mandatory, reused verbatim from the /revi/command path).
+func TestGitHubIssueComment_BillyUnauthorizedRejected(t *testing.T) {
+	s := newWebhookTestServer(t)
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"branch-improve-loop"}
+	cfg.CommandMap = map[string][]webhooks.CommandRoute{
+		"billy": {{BotID: "branch-improve-loop", ArgsVar: "scope_notes", Scope: "any"}},
+	}
+	s.webhookPRForgeCommandGate = func(context.Context, webhooks.Config, webhooks.Provider, prforge.ParsedNote, webhooks.CommandRoute) (bool, string, error) {
+		return false, "replier not authorized: mallory", nil
+	}
+	launched := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		launched++
+		return "x", nil
+	}
+	body := `{"action":"created","repository":{"full_name":"acme/widgets","clone_url":"https://github.com/acme/widgets.git"},"issue":{"number":7,"title":"t","body":"","state":"open","pull_request":{"html_url":"https://github.com/acme/widgets/pull/7"}},"comment":{"id":561,"body":"/billy fix it"},"sender":{"login":"mallory"}}`
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), body, prforge.EventHeaderIssueComment, pt))
+	if w.Code != http.StatusOK {
+		t.Fatalf("unauthorized /billy must be filtered 200, got %d", w.Code)
+	}
+	if launched != 0 {
+		t.Fatalf("unauthorized /billy must NOT launch Billy, launched=%d", launched)
+	}
+}
+
+// TestGitHubIssueComment_BillySeedsPriorReview: an authorized `/billy` on a PR
+// Revi already reviewed carries that review into the run as `prior_review`
+// (req 4), so Billy starts from Revi's findings instead of re-deriving them.
+func TestGitHubIssueComment_BillySeedsPriorReview(t *testing.T) {
+	s := newWebhookTestServer(t)
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"branch-improve-loop"}
+	cfg.CommandMap = map[string][]webhooks.CommandRoute{
+		"billy": {{BotID: "branch-improve-loop", ArgsVar: "scope_notes", Scope: "any"}},
+	}
+	s.webhookPRForgeCommandGate = func(context.Context, webhooks.Config, webhooks.Provider, prforge.ParsedNote, webhooks.CommandRoute) (bool, string, error) {
+		return true, "authorized", nil
+	}
+	s.webhookPRForgePRResolver = func(context.Context, webhooks.Config, webhooks.Provider, prforge.ParsedNote, webhooks.CommandRoute) (forge.PullRef, error) {
+		return forge.PullRef{Number: 7, State: "open", SourceBranch: "feat/x", TargetBranch: "main"}, nil
+	}
+	var gotPRURL string
+	s.webhookPriorReview = func(_ context.Context, _ webhooks.Config, prURL, _ string, prNumber int) string {
+		gotPRURL = prURL
+		if prNumber != 7 {
+			t.Errorf("prior-review lookup pr number = %d, want 7", prNumber)
+		}
+		return "Prior review of this PR by Revi: 1 finding\n- [high/security] SQLi (db.go:42)"
+	}
+	var gotVars map[string]string
+	s.webhookLaunchBot = func(_ context.Context, _ string, vars map[string]string, _, _, _ string, _, _ map[string]string) (string, error) {
+		gotVars = vars
+		return "run-billy-seed", nil
+	}
+	body := `{"action":"created","repository":{"full_name":"acme/widgets","clone_url":"https://github.com/acme/widgets.git"},"issue":{"number":7,"title":"t","body":"","state":"open","pull_request":{"html_url":"https://github.com/acme/widgets/pull/7"}},"comment":{"id":562,"body":"/billy"},"sender":{"login":"alice"}}`
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), body, prforge.EventHeaderIssueComment, pt))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	if gotPRURL != "https://github.com/acme/widgets/pull/7" {
+		t.Fatalf("prior-review lookup used pr_url=%q", gotPRURL)
+	}
+	if !strings.Contains(gotVars["prior_review"], "SQLi") {
+		t.Fatalf("prior_review var must carry Revi's findings, got %q", gotVars["prior_review"])
 	}
 }

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -10,10 +10,9 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/SocialGouv/iterion/pkg/forge"
 	"github.com/SocialGouv/iterion/pkg/knowledge"
+	"github.com/SocialGouv/iterion/pkg/store"
 	"github.com/SocialGouv/iterion/pkg/webhooks"
-	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
 )
 
 // maxWebhookBodyBytes caps the inbound payload every provider handler
@@ -73,9 +72,12 @@ const defaultWebhookBotReviewPR = "review-pr"
 // path with the args ignored — matching today's behaviour.
 const defaultWebhookBotReviConverse = "revi-converse"
 
-// branchImproveBotID is the branch-improvement bot (Billy) the PR-open path
-// routes to — instead of the default reviewer — when a same-repo PR implements
-// a tracked issue. See selectForgePRBot.
+// branchImproveBotID is the branch-improvement bot (Billy). It is NEVER
+// auto-launched on a PR-open (that lane is Revi's — a PR-open only ever
+// auto-reviews); Billy runs on a PR only on the deliberate `/billy` slash-
+// command (handlePRForgeComment / handleGitLabCommandNote, gated on the
+// commenter's repo rights) or on the narrow merge-queue auto-heal path
+// (NeedsAutoHeal in handlePRForgeReview).
 const branchImproveBotID = "branch-improve-loop"
 
 // featureDevBotID is the implementer bot (Featurly) the issue-labeled path
@@ -191,38 +193,65 @@ func stampBranchImprovePushBack(vars map[string]string, botID, sourceBranch stri
 	}
 }
 
-// selectForgePRBot deterministically routes a PR-open delivery to the
-// branch-improvement bot (Billy) instead of the default reviewer (Revi) when
-// ALL of:
-//   - the PR is NOT from a fork (IsCrossRepo) — a fork PR pushing through a
-//     MUTATING bot is the budget-exhaustion vector, so it stays on the
-//     read-only review path pending operator validation (the fork guard);
-//   - the PR links a tracked issue ("Fixes #N" in the title/body) — the PR is
-//     finishing a ticket, so Billy hardens it. This is also the ticket↔PR
-//     dedup: the PR's Billy run IS the work, so the ticket lane should not also
-//     spin up a fresh feature run (Featurly); and
-//   - the webhook actually enables Billy (AllowsBot).
+// isIterionForgeBotAuthor reports whether the PR/MR author `login` is iterion's
+// OWN forge bot — i.e. this PR was opened by another iterion bot (Doki, Willy,
+// Featurly…) through the tenant's forge integration. Such PRs already converge
+// to near-perfection inside their own loop, so the PR-open auto-review lane must
+// NOT launch Revi on them (a manual `/revi` still can). The detection is
+// derived from the tenant's provisioned forge connection, NOT a generic `[bot]`
+// suffix — Dependabot/Renovate/etc. must stay reviewable:
+//   - GitHub / Forgejo App: the App's bot login is exactly `<app_slug>[bot]`
+//     (e.g. "iterion-forge-61934180[bot]"), and app_slug is pinned on the
+//     Connection the orchestrator provisioned this webhook from.
+//   - GitLab / other non-App: iterion authors MRs as the connected bot account,
+//     so a match on that connection's AccountLogin is the equivalent signal
+//     (gated to GitLab so a GitHub OAuth connection to a HUMAN account can't
+//     make that human's own PRs unreviewable).
 //
-// Returns "" to fall through to resolveReviewBot (the existing Revi/default
-// resolution) — the behaviour for standalone PRs and every fork PR.
-func selectForgePRBot(cfg webhooks.Config, p prforge.Parsed) string {
-	if p.IsCrossRepo() {
-		return ""
+// Fail-safe: any resolution miss (no provisioning marker, no connection store,
+// no app slug) returns false — the PR stays on the normal auto-review path.
+// Routed through the webhookIterionBotAuthor seam so handler tests need no live
+// connection store.
+func (s *Server) isIterionForgeBotAuthor(ctx context.Context, cfg webhooks.Config, login string) bool {
+	fn := s.webhookIterionBotAuthor
+	if fn == nil {
+		fn = s.realIterionBotAuthor
 	}
-	// Dependency-update PRs (Dependabot/Renovate) never route to the
-	// branch-improvement loop: an improve loop over a bumped manifest/lockfile
-	// is off-target and churns the bot's own PR. The dependency guard (Vetty)
-	// owns that lane — via its own invocation / a `/command`.
-	if isDependencyBotAuthor(p.SenderLogin) {
-		return ""
+	return fn(ctx, cfg, login)
+}
+
+// realIterionBotAuthor is the production isIterionForgeBotAuthor: it resolves the
+// forge Connection the webhook was provisioned from and compares `login` against
+// that connection's bot identity. See isIterionForgeBotAuthor for the contract.
+func (s *Server) realIterionBotAuthor(ctx context.Context, cfg webhooks.Config, login string) bool {
+	login = strings.TrimSpace(login)
+	if login == "" || s.forgeConnections == nil {
+		return false
 	}
-	if len(forge.ParseIssueRefs(true, p.Title, p.Description)) == 0 {
-		return ""
+	connID := strings.TrimPrefix(cfg.ProvisionedBy, "forge:")
+	if connID == "" || connID == cfg.ProvisionedBy {
+		// Not an orchestrator-provisioned webhook → no known iterion bot identity.
+		return false
 	}
-	if !cfg.AllowsBot(branchImproveBotID) {
-		return ""
+	conn, err := s.forgeConnections.Get(store.WithTenant(ctx, cfg.TenantID), connID)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Debug("webhooks: iterion-bot-author check: connection %s: %v", connID, err)
+		}
+		return false
 	}
-	return branchImproveBotID
+	// GitHub/Forgejo App: the bot login is the app slug suffixed with [bot].
+	if conn.AppSlug != "" && strings.EqualFold(login, conn.AppSlug+"[bot]") {
+		return true
+	}
+	// GitLab (and other non-App forges): iterion authors MRs as the connection's
+	// own account. Gated to GitLab so a GitHub OAuth link to a human account
+	// can't render that human's PRs unreviewable.
+	if cfg.Provider == webhooks.ProviderGitLab && conn.AccountLogin != "" &&
+		strings.EqualFold(login, conn.AccountLogin) {
+		return true
+	}
+	return false
 }
 
 // isDependencyBotAuthor reports whether login is an automated dependency-update
@@ -265,8 +294,7 @@ func (s *Server) resolveReviewBot(
 // the reviewer default is wrong here. Precedence: an operator-pinned
 // DefaultBotID wins (explicit intent); else the canonical implementer
 // (Featurly) when the webhook permits it; else fall back to SelectBot /
-// review-pr so a reviewer-only webhook keeps its prior behaviour. The
-// deterministic counterpart to selectForgePRBot on the issue path.
+// review-pr so a reviewer-only webhook keeps its prior behaviour.
 func (s *Server) selectIssueLabeledBot(
 	ctx context.Context,
 	w http.ResponseWriter,

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -139,29 +139,30 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 		return
 	}
 
-	// PR-open bot selection: a same-repo PR that implements a tracked issue
-	// routes to the branch-improvement bot (Billy) to harden it — and dedup the
-	// ticket lane; standalone PRs and every fork PR keep the default reviewer
-	// (Revi). selectForgePRBot has already validated AllowsBot for a non-empty
-	// return, so only the fall-through path needs resolveReviewBot's gate.
-	botID := selectForgePRBot(cfg, p)
-	if botID == "" {
-		var ok bool
-		if botID, ok = s.resolveReviewBot(ctx, w, cfg, meta, payloadHash, srcIP); !ok {
-			return
-		}
+	// Iterion-bot guard: a PR opened by iterion's OWN forge bot (Doki/Willy/
+	// Featurly… through the tenant's forge integration) already converged inside
+	// its own loop — auto-reviewing it wastes budget and adds noise. Filter it
+	// (a human can still run `/revi` on it manually).
+	if s.isIterionForgeBotAuthor(ctx, cfg, p.SenderLogin) {
+		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP,
+			"PR authored by iterion's forge bot — auto-review skipped (self-produced; run /revi to force a review)")
+		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+		return
+	}
+
+	// PR-open auto-lane = REVIEW ONLY (Revi). Billy is NEVER auto-launched on a
+	// PR-open — it runs on a deliberate `/billy` comment (or the narrow
+	// merge-queue auto-heal above). resolveReviewBot gates AllowsBot.
+	botID, ok := s.resolveReviewBot(ctx, w, cfg, meta, payloadHash, srcIP)
+	if !ok {
+		return
 	}
 
 	// Idempotency: one launch per (tenant, webhook, repo, PR#, head sha).
 	idemKey := knowledge.ChecksumHex([]byte(fmt.Sprintf("%s%s|%s|%s|%d|%s", idemPrefix, cfg.TenantID, cfg.ID, p.ProjectPath, p.PRNumber, p.HeadSHA)))
 
 	scopeNotes := strings.TrimSpace(p.Title + "\n\n" + p.Description)
-	var vars map[string]string
-	if botID == branchImproveBotID {
-		vars = branchImproveVars(p.TargetBranch, p.SourceBranch, p.PRURL, scopeNotes, cfg.BranchImproveAsPR, cfg.LaunchVars)
-	} else {
-		vars = reviewPRVars(p.PRURL, p.TargetBranch, scopeNotes, cfg.LaunchVars, map[string]string{"pr_author": p.SenderLogin})
-	}
+	vars := reviewPRVars(p.PRURL, p.TargetBranch, scopeNotes, cfg.LaunchVars, map[string]string{"pr_author": p.SenderLogin})
 
 	s.insertAndLaunchWebhook(ctx, w, r, cfg, meta, idemKey, botID, vars, p.CloneURL, p.SourceBranch, payloadHash, srcIP)
 }

--- a/pkg/server/webhooks_github_test.go
+++ b/pkg/server/webhooks_github_test.go
@@ -181,8 +181,10 @@ func TestGitHubWebhook_DraftPRNotAutoLaunched(t *testing.T) {
 	}
 }
 
-// Marking a draft PR ready-for-review IS the auto-trigger: this ticket PR
-// then routes to the branch-improvement bot exactly like a fresh open.
+// Marking a draft PR ready-for-review IS the auto-trigger — and the auto-lane
+// is REVIEW-ONLY (Revi). Even a ticket PR must NOT auto-launch Billy on open:
+// Billy runs on a PR only on a deliberate `/billy` command (or the auto-heal
+// path). This pins the decoupling (req 1+2).
 func TestGitHubWebhook_ReadyForReviewLaunches(t *testing.T) {
 	s := newWebhookTestServer(t)
 	var gotBot string
@@ -198,8 +200,8 @@ func TestGitHubWebhook_ReadyForReviewLaunches(t *testing.T) {
 	if w.Code != http.StatusAccepted {
 		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
 	}
-	if gotBot != branchImproveBotID {
-		t.Fatalf("ready_for_review ticket PR should route to %q, got %q", branchImproveBotID, gotBot)
+	if gotBot != "review-pr" {
+		t.Fatalf("ready_for_review PR must auto-REVIEW (Revi), never auto-launch Billy; got %q", gotBot)
 	}
 }
 
@@ -266,40 +268,79 @@ const ghForkTicketPR = `{
   "sender": {"login": "mallory"}
 }`
 
-// TestGitHubWebhook_TicketPRRoutesToBilly: a same-repo PR that closes an issue,
-// on a webhook that enables Billy, launches branch-improve-loop with Billy's
-// vars (open_mr=false — the PR already exists; push_branch set — Billy pushes
-// in-place onto the PR; pr_url carried so Billy can post its review comment).
-func TestGitHubWebhook_TicketPRRoutesToBilly(t *testing.T) {
+// TestGitHubWebhook_TicketPRAutoReviewsNeverBilly: a same-repo PR that closes an
+// issue must NOT auto-launch Billy on open (req 1+2). Even with Billy enabled on
+// the webhook, the PR-open auto-lane is REVIEW-ONLY — it routes to Revi with the
+// review vars, never the mutating branch-improve loop.
+func TestGitHubWebhook_TicketPRAutoReviewsNeverBilly(t *testing.T) {
 	s := newWebhookTestServer(t)
 	var gotBot string
 	var gotVars map[string]string
 	s.webhookLaunchBot = func(_ context.Context, botID string, vars map[string]string, _, _, _ string, _, _ map[string]string) (string, error) {
 		gotBot, gotVars = botID, vars
-		return "run-billy", nil
+		return "run-review", nil
 	}
 	cfg, pt := ghConfig(t, s)
-	cfg.BotIDs = []string{"review-pr", "branch-improve-loop"} // enable Billy on this repo
+	cfg.BotIDs = []string{"review-pr", "branch-improve-loop"} // Billy enabled — still must not auto-launch
 
 	w := httptest.NewRecorder()
 	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghTicketPR, prforge.EventHeaderPullRequest, pt))
 	if w.Code != http.StatusAccepted {
 		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
 	}
-	if gotBot != "branch-improve-loop" {
-		t.Fatalf("ticket PR must route to Billy, got %q", gotBot)
+	if gotBot != "review-pr" {
+		t.Fatalf("ticket PR must auto-REVIEW (Revi), never auto-launch Billy; got %q", gotBot)
 	}
-	if gotVars["open_mr"] != "false" || gotVars["base_ref"] != "main" {
-		t.Fatalf("billy vars: %v", gotVars)
+	// Review vars, not Billy's push-back vars.
+	if gotVars["post_to_board"] != "false" || gotVars["pr_review_mode"] != "inline" {
+		t.Fatalf("expected Revi review vars, got %v", gotVars)
 	}
-	if !strings.Contains(gotVars["scope_notes"], "Add subtract") {
-		t.Fatalf("scope_notes must carry the PR title/body: %q", gotVars["scope_notes"])
+	if _, ok := gotVars["push_branch"]; ok {
+		t.Fatalf("review lane must NOT carry Billy's push_branch: %v", gotVars)
 	}
-	if gotVars["push_branch"] != "feat/subtract" {
-		t.Fatalf("billy path must set push_branch to the PR source branch (in-place push, not the review path): %v", gotVars)
+	if gotVars["pr_author"] != "alice" {
+		t.Fatalf("review run must stamp pr_author, got %v", gotVars)
 	}
-	if gotVars["pr_url"] == "" {
-		t.Fatalf("billy carries pr_url so it can post its review-comment feedback on the PR: %v", gotVars)
+}
+
+// TestGitHubWebhook_IterionBotPRSkipsReview: a PR opened by iterion's OWN forge
+// bot (login = <app_slug>[bot], resolved from the provisioned connection) is
+// NOT auto-reviewed — it already converged in its own loop (req 5). A generic
+// [bot] (Dependabot) is unaffected (covered by the auto-review happy path).
+func TestGitHubWebhook_IterionBotPRSkipsReview(t *testing.T) {
+	s := newWebhookTestServer(t)
+	launched := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		launched++
+		return "run-x", nil
+	}
+	// Seam: the provisioned connection's bot is "iterion-forge-1234[bot]".
+	s.webhookIterionBotAuthor = func(_ context.Context, _ webhooks.Config, login string) bool {
+		return login == "iterion-forge-1234[bot]"
+	}
+	cfg, pt := ghConfig(t, s)
+
+	body := `{
+	  "action": "opened", "number": 21,
+	  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+	  "pull_request": {"number": 21, "title": "Docs: align", "body": "aligned by Doki",
+	    "html_url": "https://github.com/acme/widgets/pull/21", "state": "open",
+	    "head": {"ref": "iterion/run/docs", "sha": "ddd333", "repo": {"full_name": "acme/widgets"}},
+	    "base": {"ref": "main", "repo": {"full_name": "acme/widgets"}}},
+	  "sender": {"login": "iterion-forge-1234[bot]"}
+	}`
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), body, prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusOK {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["status"] != webhooks.StatusFiltered {
+		t.Fatalf("iterion-bot PR must be filtered, got %q", resp["status"])
+	}
+	if launched != 0 {
+		t.Fatalf("iterion-bot PR must NOT auto-launch any bot, launched=%d", launched)
 	}
 }
 

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -93,6 +93,16 @@ func (s *Server) handleGitLabMergeRequestEvent(ctx context.Context, w http.Respo
 		return
 	}
 
+	// Iterion-bot guard: an MR opened by iterion's own forge bot already
+	// converged in its own loop — skip the auto-review (a human can still run
+	// `/revi`). Mirror of the GitHub PR-open path.
+	if s.isIterionForgeBotAuthor(ctx, cfg, p.SenderUsername) {
+		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP,
+			"MR authored by iterion's forge bot — auto-review skipped (self-produced; run /revi to force a review)")
+		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+		return
+	}
+
 	botID, ok := s.resolveReviewBot(ctx, w, cfg, meta, payloadHash, srcIP)
 	if !ok {
 		return
@@ -385,6 +395,9 @@ func (s *Server) handleGitLabCommandNote(ctx context.Context, w http.ResponseWri
 		vars = buildGitLabIssueCommandVars(p, route, cmdArgs, cfg.LaunchVars)
 	} else {
 		stampBranchImprovePushBack(vars, route.BotID, p.SourceBranch, cfg.BranchImproveAsPR)
+		// `/billy` on an MR seeds the run with Revi's most recent review of it
+		// (best-effort — see stampPriorReview). Symmetric with the GitHub path.
+		s.stampPriorReview(ctx, cfg, route.BotID, vars, p.MRURL, p.ProjectPath, int(p.MRIID))
 	}
 	// "cmd|" prefix keeps the key space disjoint from the mr|/note| paths.
 	idemKey := knowledge.ChecksumHex([]byte(fmt.Sprintf("cmd|%s|%s|%d|%s", cfg.TenantID, cfg.ID, p.ProjectID, p.SubjectID())))

--- a/pkg/server/webhooks_prbot_test.go
+++ b/pkg/server/webhooks_prbot_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/webhooks"
-	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
 )
 
 // TestSelectIssueLabeledBot pins the issue-labeled routing: a freshly-labeled
@@ -39,62 +38,6 @@ func TestSelectIssueLabeledBot(t *testing.T) {
 			}
 			if got != c.want {
 				t.Errorf("selectIssueLabeledBot = %q, want %q", got, c.want)
-			}
-		})
-	}
-}
-
-// TestSelectForgePRBot pins the deterministic PR-open routing: a same-repo PR
-// that implements a tracked issue routes to the branch-improvement bot (Billy);
-// fork PRs, ticket-less PRs, and repos that don't enable Billy all fall through
-// (return "") to the default reviewer resolution. This is the fork guard + the
-// ticket↔PR dedup, both encoded in one pure function.
-func TestSelectForgePRBot(t *testing.T) {
-	billyEnabled := webhooks.Config{BotIDs: []string{"review-pr", branchImproveBotID}}
-	billyDisabled := webhooks.Config{BotIDs: []string{"review-pr"}}
-	wildcard := webhooks.Config{BotIDs: []string{"*"}}
-
-	ticketPR := prforge.Parsed{
-		ProjectPath: "acme/widgets", HeadRepoFullName: "acme/widgets",
-		Title: "Add subtract", Description: "Implements subtraction.\n\nFixes #12",
-	}
-	forkTicketPR := prforge.Parsed{
-		ProjectPath: "acme/widgets", HeadRepoFullName: "mallory/widgets",
-		Title: "Add subtract", Description: "Fixes #12",
-	}
-	standalonePR := prforge.Parsed{
-		ProjectPath: "acme/widgets", HeadRepoFullName: "acme/widgets",
-		Title: "Chore: tidy", Description: "no linked issue here",
-	}
-	// A dependency-bot PR that even references a ticket must still be excluded
-	// from the improve loop — the dependency guard owns that lane.
-	depBotPR := prforge.Parsed{
-		ProjectPath: "acme/widgets", HeadRepoFullName: "acme/widgets",
-		Title: "chore(deps): bump lib", Description: "Fixes #12", SenderLogin: "dependabot[bot]",
-	}
-	renovatePR := prforge.Parsed{
-		ProjectPath: "acme/widgets", HeadRepoFullName: "acme/widgets",
-		Title: "chore(deps): bump lib", Description: "Fixes #12", SenderLogin: "renovate[bot]",
-	}
-
-	cases := []struct {
-		name string
-		cfg  webhooks.Config
-		p    prforge.Parsed
-		want string
-	}{
-		{"same-repo ticket PR + billy enabled → billy", billyEnabled, ticketPR, branchImproveBotID},
-		{"same-repo ticket PR + wildcard webhook → billy", wildcard, ticketPR, branchImproveBotID},
-		{"fork ticket PR → fall through (fork guard)", billyEnabled, forkTicketPR, ""},
-		{"standalone PR (no ticket) → fall through", billyEnabled, standalonePR, ""},
-		{"ticket PR but billy not enabled → fall through", billyDisabled, ticketPR, ""},
-		{"dependabot ticket PR → excluded from improve loop", billyEnabled, depBotPR, ""},
-		{"renovate ticket PR → excluded from improve loop", billyEnabled, renovatePR, ""},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := selectForgePRBot(tc.cfg, tc.p); got != tc.want {
-				t.Errorf("selectForgePRBot = %q, want %q", got, tc.want)
 			}
 		})
 	}

--- a/pkg/server/webhooks_prforge.go
+++ b/pkg/server/webhooks_prforge.go
@@ -113,6 +113,10 @@ func (s *Server) handlePRForgeComment(ctx context.Context, w http.ResponseWriter
 	vars := buildPRForgeCommandVars(p, pr, route, cmdArgs, cfg.LaunchVars)
 	if pr != nil {
 		stampBranchImprovePushBack(vars, route.BotID, pr.SourceBranch, cfg.BranchImproveAsPR)
+		// `/billy` on a PR picks up where Revi left off: seed the run with the
+		// most recent review-pr findings for this PR (best-effort — Billy just
+		// re-reviews from scratch when none exist). Operator LaunchVars win.
+		s.stampPriorReview(ctx, cfg, route.BotID, vars, p.PRURL, p.ProjectPath, int(p.IssueNumber))
 	}
 	idemKey := knowledge.ChecksumHex([]byte(fmt.Sprintf("cmd|%s|%s|%s|%s", cfg.TenantID, cfg.ID, p.ProjectPath, p.SubjectID())))
 	s.dispatchInvocation(ctx, w, r, cfg, meta, idemKey, route, vars, p.CloneURL, repoRef, payloadHash, srcIP)

--- a/pkg/server/webhooks_prior_review.go
+++ b/pkg/server/webhooks_prior_review.go
@@ -1,0 +1,201 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+)
+
+// reviewBotID is the read-only cross-family reviewer (Revi) whose findings a
+// `/billy` invocation on the same PR picks up as its starting point.
+const reviewBotID = defaultWebhookBotReviewPR
+
+// priorReviewVar is the launch var Billy (branch-improve-loop) reads to start
+// from Revi's review instead of re-deriving it. Declared on the bot's main.bot.
+const priorReviewVar = "prior_review"
+
+// maxPriorReviewRunsScanned bounds the reverse scan for the most recent Revi run
+// on a PR. Run ids are UUIDv7 and ListRuns returns them created-at ascending on
+// both backends, so scanning from the newest end and stopping at the first match
+// finds the latest review after loading only a few runs in the common case; the
+// cap keeps a pathological store (a PR never reviewed) from a full-table scan on
+// this manual, best-effort path.
+const maxPriorReviewRunsScanned = 400
+
+// maxPriorReviewChars caps the rendered prior-review text injected into Billy's
+// prompt (~a few thousand tokens): enough for Revi's finding set, bounded so a
+// huge review can't blow the launch var / prompt budget.
+const maxPriorReviewChars = 12000
+
+// findPriorReview resolves the most recent Revi (review-pr) run for the PR and
+// renders its findings as the `prior_review` seed text for a `/billy` launch.
+// Best-effort: any miss (no run service, no matching run, unreadable artifact)
+// returns "" and Billy simply reviews the PR from scratch. Routed through the
+// webhookPriorReview seam so handler tests need no run store.
+func (s *Server) findPriorReview(ctx context.Context, cfg webhooks.Config, prURL, projectPath string, prNumber int) string {
+	fn := s.webhookPriorReview
+	if fn == nil {
+		fn = s.realWebhookPriorReview
+	}
+	return fn(ctx, cfg, prURL, projectPath, prNumber)
+}
+
+// stampPriorReview seeds a `/billy` (branch-improve-loop) launch with Revi's
+// most recent review of the PR under the `prior_review` var, so Billy starts
+// from that review instead of re-deriving it. No-op for any other bot, when the
+// var is already pinned (operator LaunchVars / ContextVars win), or when no
+// prior review exists. Best-effort: never blocks or fails the launch.
+func (s *Server) stampPriorReview(ctx context.Context, cfg webhooks.Config, botID string, vars map[string]string, prURL, projectPath string, prNumber int) {
+	if botID != branchImproveBotID || vars == nil {
+		return
+	}
+	if _, pinned := vars[priorReviewVar]; pinned {
+		return
+	}
+	if pr := s.findPriorReview(ctx, cfg, prURL, projectPath, prNumber); pr != "" {
+		vars[priorReviewVar] = pr
+	}
+}
+
+// realWebhookPriorReview is the production findPriorReview: scan the run store
+// (newest first) for the latest terminal review-pr run whose pr_url input
+// matches this PR, load its merged-findings artifact, and render it.
+func (s *Server) realWebhookPriorReview(ctx context.Context, cfg webhooks.Config, prURL, projectPath string, prNumber int) string {
+	if s.runs == nil || strings.TrimSpace(prURL) == "" {
+		return ""
+	}
+	rs := s.runs.RunStore()
+	if rs == nil {
+		return ""
+	}
+	ctx = store.WithTenant(ctx, cfg.TenantID)
+	ids, err := rs.ListRuns(ctx)
+	if err != nil || len(ids) == 0 {
+		return ""
+	}
+	// ListRuns is created-at ascending on both backends; walk from the newest
+	// end and stop at the first review-pr run for this PR (the latest review).
+	scanned := 0
+	for i := len(ids) - 1; i >= 0 && scanned < maxPriorReviewRunsScanned; i-- {
+		scanned++
+		run, lerr := rs.LoadRun(ctx, ids[i])
+		if lerr != nil {
+			continue
+		}
+		if run.BotID != reviewBotID {
+			continue
+		}
+		if !runTargetsPR(run, prURL) {
+			continue
+		}
+		return renderPriorReview(ctx, rs, run.ID, prURL)
+	}
+	return ""
+}
+
+// runTargetsPR reports whether the run's launch inputs pin the given PR url.
+func runTargetsPR(run *store.Run, prURL string) bool {
+	if run == nil {
+		return false
+	}
+	v, ok := run.Inputs["pr_url"]
+	if !ok {
+		return false
+	}
+	got, ok := v.(string)
+	return ok && strings.EqualFold(strings.TrimSpace(got), strings.TrimSpace(prURL))
+}
+
+// reviewConvergeNode is the review-pr node whose output artifact carries the
+// merged, de-duplicated finding set (schema emit_output: findings + counts).
+const reviewConvergeNode = "converge"
+
+// renderPriorReview loads the review run's merged-findings artifact and renders
+// a compact, bounded markdown digest suitable for injection into Billy's prompt.
+// Returns "" on any read failure.
+func renderPriorReview(ctx context.Context, rs store.RunStore, runID, prURL string) string {
+	art, err := rs.LoadLatestArtifact(ctx, runID, reviewConvergeNode)
+	if err != nil || art == nil {
+		return ""
+	}
+	findings := decodeFindings(art.Data["findings"])
+	var b strings.Builder
+	fmt.Fprintf(&b, "Prior review of this PR by Revi (review-pr, run %s):\n", runID)
+	if len(findings) == 0 {
+		b.WriteString("Revi reviewed the PR and reported no findings. Confirm the diff is clean and improve anything it missed.\n")
+		return truncate(b.String(), maxPriorReviewChars)
+	}
+	fmt.Fprintf(&b, "%d finding(s). Address each, then continue reviewing the diff for anything Revi missed:\n\n", len(findings))
+	for _, f := range findings {
+		writeFinding(&b, f)
+		if b.Len() >= maxPriorReviewChars {
+			break
+		}
+	}
+	return truncate(b.String(), maxPriorReviewChars)
+}
+
+// decodeFindings normalises the artifact's `findings` value — persisted either
+// as a decoded []any (filesystem JSON) or re-marshalled string (defensive) —
+// into a slice of finding maps.
+func decodeFindings(raw any) []map[string]any {
+	switch v := raw.(type) {
+	case []any:
+		out := make([]map[string]any, 0, len(v))
+		for _, e := range v {
+			if m, ok := e.(map[string]any); ok {
+				out = append(out, m)
+			}
+		}
+		return out
+	case string:
+		var arr []map[string]any
+		if json.Unmarshal([]byte(v), &arr) == nil {
+			return arr
+		}
+	}
+	return nil
+}
+
+// writeFinding renders one finding as a bounded markdown bullet.
+func writeFinding(b *strings.Builder, f map[string]any) {
+	sev := strings.TrimSpace(fmt.Sprint(firstNonEmpty(f["severity"], "")))
+	cat := strings.TrimSpace(fmt.Sprint(firstNonEmpty(f["category"], "")))
+	title := strings.TrimSpace(fmt.Sprint(firstNonEmpty(f["title"], "")))
+	file := strings.TrimSpace(fmt.Sprint(firstNonEmpty(f["file"], "")))
+	line := strings.TrimSpace(fmt.Sprint(firstNonEmpty(f["line"], "")))
+	detail := strings.TrimSpace(fmt.Sprint(firstNonEmpty(f["detail"], "")))
+
+	head := "-"
+	if sev != "" || cat != "" {
+		head += " [" + strings.TrimSpace(sev+"/"+cat) + "]"
+	}
+	if title != "" {
+		head += " " + title
+	}
+	if file != "" {
+		loc := file
+		if line != "" && line != "0" {
+			loc += ":" + line
+		}
+		head += " (" + loc + ")"
+	}
+	b.WriteString(head + "\n")
+	if detail != "" {
+		b.WriteString("  " + truncate(detail, 600) + "\n")
+	}
+}
+
+func firstNonEmpty(v any, fallback string) any {
+	if v == nil {
+		return fallback
+	}
+	if s, ok := v.(string); ok && strings.TrimSpace(s) == "" {
+		return fallback
+	}
+	return v
+}

--- a/pkg/server/webhooks_prior_review_test.go
+++ b/pkg/server/webhooks_prior_review_test.go
@@ -1,0 +1,132 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+)
+
+// TestRealIterionBotAuthor pins the iterion-forge-bot detection (req 5): it
+// matches ONLY the bot identity derived from the tenant's provisioned forge
+// connection — a GitHub App's `<app_slug>[bot]` or (GitLab only) the connected
+// account — never a generic `[bot]` that would catch Dependabot/Renovate.
+func TestRealIterionBotAuthor(t *testing.T) {
+	conns := forge.NewMemoryConnectionStore()
+	// GitHub App connection: bot login = iterion-forge-1234[bot].
+	if err := conns.Create(context.Background(), forge.Connection{
+		ID: "c-gh", TenantID: "t1", Provider: forge.ProviderGitHub, AppSlug: "iterion-forge-1234",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// GitLab PAT connection: iterion authors MRs as this bot account.
+	if err := conns.Create(context.Background(), forge.Connection{
+		ID: "c-gl", TenantID: "t1", Provider: forge.ProviderGitLab, AccountLogin: "iterion-bot",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{forgeConnections: conns}
+
+	ghCfg := webhooks.Config{TenantID: "t1", Provider: webhooks.ProviderGitHub, ProvisionedBy: "forge:c-gh"}
+	glCfg := webhooks.Config{TenantID: "t1", Provider: webhooks.ProviderGitLab, ProvisionedBy: "forge:c-gl"}
+	handCfg := webhooks.Config{TenantID: "t1", Provider: webhooks.ProviderGitHub} // operator-created, no provisioning
+
+	cases := []struct {
+		name  string
+		cfg   webhooks.Config
+		login string
+		want  bool
+	}{
+		{"github app bot matches", ghCfg, "iterion-forge-1234[bot]", true},
+		{"github app bot case-insensitive", ghCfg, "Iterion-Forge-1234[bot]", true},
+		{"github dependabot NOT matched", ghCfg, "dependabot[bot]", false},
+		{"github human NOT matched", ghCfg, "alice", false},
+		{"gitlab bot account matches", glCfg, "iterion-bot", true},
+		{"gitlab other account NOT matched", glCfg, "alice", false},
+		{"hand-created webhook never matches (no connection)", handCfg, "iterion-forge-1234[bot]", false},
+		{"empty login never matches", ghCfg, "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := s.realIterionBotAuthor(context.Background(), c.cfg, c.login); got != c.want {
+				t.Errorf("realIterionBotAuthor(%q) = %v, want %v", c.login, got, c.want)
+			}
+		})
+	}
+}
+
+// TestRenderPriorReview checks that Revi's merged findings render into a bounded
+// markdown digest Billy can consume (req 4), including the empty-findings case.
+func TestRenderPriorReview(t *testing.T) {
+	rs, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	// A review run with two findings.
+	run, err := rs.CreateRun(ctx, mustRunID(t), "review-pr", map[string]any{"pr_url": "https://github.com/acme/widgets/pull/7"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rs.WriteArtifact(ctx, &store.Artifact{
+		RunID:  run.ID,
+		NodeID: reviewConvergeNode,
+		Data: map[string]any{
+			"total_findings": 2,
+			"findings": []any{
+				map[string]any{"severity": "high", "category": "security", "title": "SQL injection", "file": "db.go", "line": float64(42), "detail": "user input concatenated into a query"},
+				map[string]any{"severity": "low", "category": "style", "title": "unused var"},
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := renderPriorReview(ctx, rs, run.ID, "https://github.com/acme/widgets/pull/7")
+	for _, want := range []string{"Prior review", "SQL injection", "db.go:42", "high/security", "unused var"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("rendered prior review missing %q:\n%s", want, got)
+		}
+	}
+
+	// Empty findings → a "no findings" seed, not an empty string.
+	empty, err := rs.CreateRun(ctx, mustRunID(t), "review-pr", map[string]any{"pr_url": "https://github.com/acme/widgets/pull/8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rs.WriteArtifact(ctx, &store.Artifact{
+		RunID: empty.ID, NodeID: reviewConvergeNode, Data: map[string]any{"findings": []any{}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if e := renderPriorReview(ctx, rs, empty.ID, "https://github.com/acme/widgets/pull/8"); !strings.Contains(e, "no findings") {
+		t.Errorf("empty-findings render should note no findings, got %q", e)
+	}
+}
+
+// TestRunTargetsPR pins the PR-match predicate used to select the review run.
+func TestRunTargetsPR(t *testing.T) {
+	run := &store.Run{Inputs: map[string]any{"pr_url": "https://github.com/acme/widgets/pull/7"}}
+	if !runTargetsPR(run, "https://github.com/acme/widgets/pull/7") {
+		t.Error("should match the exact pr_url")
+	}
+	if runTargetsPR(run, "https://github.com/acme/widgets/pull/9") {
+		t.Error("must not match a different PR")
+	}
+	if runTargetsPR(&store.Run{Inputs: map[string]any{}}, "x") {
+		t.Error("no pr_url input → no match")
+	}
+}
+
+func mustRunID(t *testing.T) string {
+	t.Helper()
+	id, err := store.GenerateRunID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}

--- a/pkg/webhooks/types.go
+++ b/pkg/webhooks/types.go
@@ -146,8 +146,9 @@ type Config struct {
 	// The anti budget-exhaustion boundary: a fork PR is untrusted (an adversary
 	// can open many to trigger costly bot runs), so an operator must validate it
 	// before a bot runs. Off by default (fork PRs still auto-review via Revi;
-	// the mutating branch-improve bot never runs on a fork regardless — see
-	// selectForgePRBot). Recommended ON for a public repo.
+	// the mutating branch-improve bot never runs on a PR-open regardless — the
+	// PR-open lane is review-only, see handlePRForgeReview). Recommended ON for
+	// a public repo.
 	BlockForkPRs bool `bson:"block_fork_prs,omitempty" json:"block_fork_prs,omitempty"`
 
 	// ForgeBaseURL, when set, pins the forge instance this webhook's bot


### PR DESCRIPTION
## What & why

Rework the forge PR-webhook auto-launch wiring so the **PR/MR open lane is review-only**. Opening a PR now only ever auto-launches **Revi** (`review-pr`); the mutating branch-improve loop **Billy** is never auto-launched on a PR-open. This fixes the case where Billy was wrongly launched on a doc-alignment PR (#282) because the PR referenced a ticket.

## The 5 changes

1+2. **Billy decoupled from PR-open auto-launch.** Removed `selectForgePRBot` (the ticket-PR → `branch-improve-loop` routing). `handlePRForgeReview` / `handleGitLabMergeRequestEvent` now always resolve the reviewer. The fork guard and dependency-bot behaviour are unchanged (they already filtered upstream).

3. **`/billy` on demand** (alias `/improve`), reserved to authorized users. This was already reachable through the generic slash-command path + Billy's manifest `command` invocation; this PR keeps it, adds the `/improve` alias, and aligns its `min_replier_role` with `/revi` (write ≡ `developer`). The **same** existing authorization gate (`AuthorizedRepliers` allowlist OR repo permission ≥ role, loop-guard, idempotence, delivery audit) is reused verbatim.

4. **Billy picks up Revi's work.** When `/billy` runs on a PR Revi already reviewed, the handler finds the most recent `review-pr` run for that PR (by `pr_url`), renders its merged findings, and seeds Billy under the new `prior_review` var (declared on `branch-improve-loop`, injected into `campaign_user`, carried through board-mode `BotArgs`). Best-effort: no prior review → Billy reviews from scratch.

5. **Revi skipped on iterion-bot PRs.** A PR opened by iterion's own forge bot (Doki/Willy/Featurly…) is filtered from the auto-review lane. Detection resolves the tenant's **provisioned forge connection** identity — GitHub/Forgejo App `<app_slug>[bot]`, or (GitLab) the connected bot account — **never a generic `[bot]`**, so Dependabot/Renovate stay reviewable. A manual `/revi` still forces a review.

**Preserved, distinct lane:** the **merge-queue auto-heal** (`NeedsAutoHeal`) still dispatches Billy to rebase/resolve/repush an ejected PR — a narrow, legitimate trigger, left untouched.

## How the two tricky bits were solved

- **Iterion-bot author detection (req 5):** derived from `cfg.ProvisionedBy = "forge:<conn_id>"` → `forge.Connection`. GitHub/Forgejo App bot login is exactly `AppSlug + "[bot]"`; for GitLab, iterion authors MRs as `AccountLogin` (gated to GitLab so a GitHub OAuth link to a human account can't make that human unreviewable). Fail-safe: any resolution miss → not-a-bot → normal review. Behind the `webhookIterionBotAuthor` test seam.
- **Recovering Revi's work (req 4):** reverse-scan `ListRuns` (created-at ascending on both fs + Mongo; UUIDv7 ids) for the latest `review-pr` run whose `pr_url` input matches, load its `converge` node artifact (merged findings), render a bounded markdown digest. Bounded scan + early stop; behind the `webhookPriorReview` seam.

## Security

No existing check relaxed — allowlists, idempotency, author-trust, HMAC, and the slash-command authz gate are all intact. Note: Billy's `/billy` role default moved from `maintainer` → `developer` (write) to match `/revi` per the requested "same gate"; the collaborator-permission gate itself is unchanged, only the threshold.

## Tests / verification

`go build ./... && go vet ./pkg/server/... && go test ./pkg/server/... ./pkg/webhooks/... -count=1` green; golangci-lint clean; gofmt clean; `bots/...` + `pkg/cli/...` + `pkg/forge/...` green; catalog regenerated. New/adapted tests: iterion-bot filter, `/billy` authorized + unauthorized, prior-review render, connection-derived bot detection, PR-open-routes-to-Revi-never-Billy, auto-heal intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)