### PR TITLE
fix(studio): "Open child bot" 404 — resolve child path against the right parent

### DIFF
--- a/studio/src/components/EditorView.tsx
+++ b/studio/src/components/EditorView.tsx
@@ -12,15 +12,12 @@ import SubNodePalette from "@/components/Canvas/SubNodePalette";
 import SourceView from "@/components/SourceView/SourceView";
 import { DesktopOnlyNotice, IconButton } from "@/components/ui";
 import { useUIStore } from "@/store/ui";
-import { useDocumentStoreInstance } from "@/store/document";
+import { useDocumentStore, useDocumentStoreInstance } from "@/store/document";
 import { useSelectionStore } from "@/store/selection";
 import { useAutoValidation } from "@/hooks/useAutoValidation";
 import { useAutoOpenDiagnosticsOnError } from "@/hooks/useAutoOpenDiagnosticsOnError";
 import { useFileWatcher } from "@/hooks/useFileWatcher";
-import { useConfirm } from "@/hooks/useConfirm";
-import { DISCARD_CHANGES_PROMPT } from "@/lib/copy";
-import { toastError } from "@/lib/errorHints";
-import * as api from "@/api/client";
+import { editorDeepLinkTargetsDocument } from "@/lib/editorDeepLink";
 
 interface EditorViewProps {
   // Whether this editor tab is currently the visible one. EditorTabsView
@@ -47,7 +44,7 @@ export default function EditorView({ active = true }: EditorViewProps) {
   const inspectorCollapsed = useUIStore((s) => s.inspectorCollapsed);
   const toggleInspectorCollapsed = useUIStore((s) => s.toggleInspectorCollapsed);
   const setPendingFitNodeId = useUIStore((s) => s.setPendingFitNodeId);
-  const addToast = useUIStore((s) => s.addToast);
+  const currentFilePath = useDocumentStore((s) => s.currentFilePath);
   const setSelectedNode = useSelectionStore((s) => s.setSelectedNode);
 
   const search = useSearch();
@@ -63,11 +60,11 @@ export default function EditorView({ active = true }: EditorViewProps) {
   useAutoOpenDiagnosticsOnError();
   useFileWatcher();
 
-  const { confirm, dialog: confirmDialog } = useConfirm();
-
-  // Honor deep links from the run console: /?file=<workspace-relative>&node=<ir_node_id>&from=<runId>.
-  // Mounted once, runs whenever the search string changes — the early
-  // return avoids re-loading the same file on unrelated navigation.
+  // Honor node-focus deep links from the run console:
+  // /editor?file=<workspace-relative>&node=<ir_node_id>&from=<runId>.
+  // EditorTabsView + EditorTabHost exclusively own file/tab hydration.
+  // Keeping that responsibility out of every mounted EditorView prevents a
+  // hidden or untitled tab from consuming another tab's global ?file= URL.
   useEffect(() => {
     if (handledSearch.current === search) return;
     const params = new URLSearchParams(search);
@@ -78,46 +75,24 @@ export default function EditorView({ active = true }: EditorViewProps) {
       handledSearch.current = search;
       return;
     }
+
+    // The matching EditorTabHost may still be loading. Do not mark this
+    // search as handled until the active document is the requested file.
+    if (!editorDeepLinkTargetsDocument(active, currentFilePath, file)) return;
     handledSearch.current = search;
 
-    const docStore = docStoreInst.getState();
-    const alreadyOpen = file && docStore.currentFilePath === file;
-
-    const applyNodeFocus = () => {
-      if (!node) return;
+    if (node) {
       setSelectedNode(node);
       setPendingFitNodeId(node);
-    };
-
-    const proceedOpen = async () => {
-      if (docStore.isDirty()) {
-        const ok = await confirm(DISCARD_CHANGES_PROMPT);
-        if (!ok) return;
-      }
-      try {
-        const result = await api.openFile(file!);
-        const ds = docStoreInst.getState();
-        ds.setDocument(result.document);
-        ds.setCurrentFilePath(result.path);
-        ds.setCurrentSource(result.source);
-        ds.markSaved();
-        // Selection waits a tick so the new document's nodes have
-        // been registered with React Flow before we attempt to
-        // center on one of them.
-        setTimeout(applyNodeFocus, 0);
-      } catch (err) {
-        toastError(addToast, err, "Open from run failed");
-      }
-    };
-
-    if (file && !alreadyOpen) {
-      void proceedOpen();
-    } else {
-      applyNodeFocus();
     }
-
     if (from) setBannerRunId(from);
-  }, [search, addToast, setPendingFitNodeId, setSelectedNode, confirm]);
+  }, [
+    active,
+    search,
+    currentFilePath,
+    setPendingFitNodeId,
+    setSelectedNode,
+  ]);
 
   const dismissBanner = () => {
     setBannerRunId(null);
@@ -292,7 +267,6 @@ export default function EditorView({ active = true }: EditorViewProps) {
         )}
       </div>
       </DesktopOnlyNotice>
-      {confirmDialog}
       </div>
     </ReactFlowProvider>
   );

--- a/studio/src/components/Inspector/InspectorNode.tsx
+++ b/studio/src/components/Inspector/InspectorNode.tsx
@@ -5,7 +5,10 @@ import { useSelectionStore } from "@/store/selection";
 import { useTabsStore } from "@/store/tabs";
 import { NODE_COLORS, NODE_ICONS, softColor } from "@/lib/constants";
 import { getAllNodeNames } from "@/lib/defaults";
-import { parseSubbotChildId, resolveSubbotSource } from "@/lib/subbotGraph";
+import {
+  parseSubbotChildId,
+  resolveChildBotOpenPath,
+} from "@/lib/subbotGraph";
 import type {
   AgentDecl,
   ComputeDecl,
@@ -251,10 +254,23 @@ function NodeForm({ match }: { match: NodeMatch }) {
  *  RecentFilesPanel: openTab + URL so deep-link state stays in sync). */
 function useOpenChildBot() {
   const currentFilePath = useDocumentStore((s) => s.currentFilePath);
+  const activeEditorFile = useTabsStore((s) => {
+    const active = s.tabs.find((tab) => tab.id === s.activeEditorTabId);
+    return active?.kind === "editor" ? (active.params.file ?? null) : null;
+  });
   const [, setLocation] = useLocation();
   return (source: string | undefined) => {
     if (!source) return;
-    const path = resolveSubbotSource(currentFilePath, source);
+    // currentFilePath is normally authoritative. The tab binding is a safe
+    // fallback during route hydration: Pipelines may activate the editor tab
+    // one render before EditorTabHost has copied its file into the document
+    // store. Never send a parent-relative source to the workspace-root API.
+    const path = resolveChildBotOpenPath(
+      currentFilePath,
+      activeEditorFile,
+      source,
+    );
+    if (!path) return;
     useTabsStore.getState().openTab("editor", { file: path });
     setLocation(`/editor?file=${encodeURIComponent(path)}`);
   };
@@ -360,4 +376,3 @@ function SubbotChildNotice({ subbotId, childId }: { subbotId: string; childId: s
     </div>
   );
 }
-

--- a/studio/src/lib/editorDeepLink.test.ts
+++ b/studio/src/lib/editorDeepLink.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { editorDeepLinkTargetsDocument } from "./editorDeepLink";
+
+describe("editorDeepLinkTargetsDocument", () => {
+  it("accepts the visible tab already bound to the requested file", () => {
+    expect(
+      editorDeepLinkTargetsDocument(
+        true,
+        "bots/town-dev/main.bot",
+        "bots/town-dev/main.bot",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects an active untitled tab while the destination tab hydrates", () => {
+    expect(
+      editorDeepLinkTargetsDocument(
+        true,
+        null,
+        "bots/town-dev/main.bot",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects hidden hydrated tabs that share the browser URL", () => {
+    expect(
+      editorDeepLinkTargetsDocument(
+        false,
+        "bots/another-bot/main.bot",
+        "bots/town-dev/main.bot",
+      ),
+    ).toBe(false);
+  });
+});

--- a/studio/src/lib/editorDeepLink.ts
+++ b/studio/src/lib/editorDeepLink.ts
@@ -1,0 +1,14 @@
+/**
+ * A file-scoped editor deep-link belongs only to the visible tab whose
+ * document is already bound to that file. EditorTabsView/EditorTabHost own
+ * creating and hydrating the matching tab; sibling EditorViews stay mounted
+ * for fast tab switching and must ignore the shared browser URL.
+ */
+export function editorDeepLinkTargetsDocument(
+  active: boolean,
+  currentFilePath: string | null,
+  requestedFile: string | null,
+): boolean {
+  if (!active) return false;
+  return requestedFile === null || requestedFile === currentFilePath;
+}

--- a/studio/src/lib/subbotGraph.test.ts
+++ b/studio/src/lib/subbotGraph.test.ts
@@ -10,6 +10,7 @@ import {
   isSubbotChildId,
   makeSubbotChildId,
   parseSubbotChildId,
+  resolveChildBotOpenPath,
   resolveSubbotSource,
   subbotLocalName,
   type SubbotDocEntry,
@@ -142,6 +143,43 @@ describe("resolveSubbotSource", () => {
 
   it("never escapes above the workspace root", () => {
     expect(resolveSubbotSource("main.bot", "../../child.bot")).toBe("child.bot");
+  });
+});
+
+describe("resolveChildBotOpenPath", () => {
+  const parent =
+    "iterion/bots/town-vertical-pipeline/town-dev/main.bot";
+  const child =
+    "iterion/bots/town-vertical-pipeline/town-dev/subbots/epic-foundation.bot";
+
+  it("uses the active editor tab while the document path hydrates", () => {
+    expect(
+      resolveChildBotOpenPath(
+        null,
+        parent,
+        "subbots/epic-foundation.bot",
+      ),
+    ).toBe(child);
+  });
+
+  it("prefers the document path once it is available", () => {
+    expect(
+      resolveChildBotOpenPath(
+        parent,
+        "bots/stale/main.bot",
+        "subbots/epic-foundation.bot",
+      ),
+    ).toBe(child);
+  });
+
+  it("never sends a parent-relative source to the workspace-root API", () => {
+    expect(
+      resolveChildBotOpenPath(
+        null,
+        null,
+        "subbots/epic-foundation.bot",
+      ),
+    ).toBeNull();
   });
 });
 

--- a/studio/src/lib/subbotGraph.ts
+++ b/studio/src/lib/subbotGraph.ts
@@ -94,6 +94,24 @@ export function resolveSubbotSource(parentFilePath: string | null, source: strin
   return parts.join("/");
 }
 
+/**
+ * Resolve the file opened by the Inspector's "Open child bot" action.
+ * The document store path is authoritative; the active tab binding covers
+ * the short hydration window before EditorTabHost copies that path into the
+ * store. With neither parent, returning null is safer than treating a
+ * parent-relative source as workspace-relative.
+ */
+export function resolveChildBotOpenPath(
+  documentFilePath: string | null,
+  activeEditorFile: string | null,
+  source: string,
+): string | null {
+  const parentFilePath = documentFilePath ?? activeEditorFile;
+  return parentFilePath
+    ? resolveSubbotSource(parentFilePath, source)
+    : null;
+}
+
 /** Topology fingerprint of the expansion state: which subbots have a loaded
  *  (or failed) child document, and each loaded child's own topology —
  *  RECURSIVELY, so a nested child doc arriving re-fires the editor's ELK


### PR DESCRIPTION
## What was wrong

Clicking **"Open child bot"** from the editor inspector (a subbot node → `SubbotForm` / `SubbotChildNotice`) could return a **404**.

The child `.bot` path is resolved from the parent file: `resolveSubbotSource(parentFilePath, source)`, where `source` is parent-relative (`subbots/multiview-judge.bot`). But `parentFilePath` (the document store's `currentFilePath`) can be **null during the short route-hydration window** — arriving from the Pipelines board activates the editor tab one render *before* `EditorTabHost` copies the file into the document store. With a null parent, the parent-relative `source` was resolved against the **workspace root**, producing a wrong path the editor API 404s on.

## The fix

- **`resolveChildBotOpenPath(documentFilePath, activeEditorFile, source)`** (`subbotGraph.ts`): the document path is authoritative; the **active editor tab's bound file** is a safe fallback during hydration; with neither, return `null` (never send a parent-relative source to the workspace-root API). `useOpenChildBot` bails on `null` instead of navigating to a 404.
- **`editorDeepLinkTargetsDocument(active, currentFilePath, requestedFile)`** (`editorDeepLink.ts`, new): a mounted `EditorView` consumes the shared `?file=&node=&from=` deep-link only when it's the active tab already bound to that file (or the link carries no file) — sibling/untitled tabs stay mounted for fast tab-switching and must ignore the global URL. File/tab hydration stays the sole responsibility of `EditorTabsView`/`EditorTabHost`.

## Tests
- `resolveChildBotOpenPath`: fallback-during-hydration / prefers-document-path / null-guard (never workspace-root).
- `editorDeepLinkTargetsDocument`: active-and-bound / rejects untitled-while-hydrating / rejects hidden-hydrated.
- 36 tests pass, tsc clean on touched files.

## Verified live
Reproduced on a running studio in a clean (cache-less) headless browser: selecting a subbot node → inspector "Open child bot" → opens the child in a new tab, child renders, **0 API errors ≥ 400** (no 404). The `SubbotFrameNode` frame "Open" icon works identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)