### PR TITLE
feat(studio): surface PR/deploy links as headline result-links

### DIFF
--- a/bots/app-dev/main.bot
+++ b/bots/app-dev/main.bot
@@ -1243,6 +1243,37 @@ agent finalize_mr:
   capabilities: [board.read, board.comment]
   tool_max_steps: 20
 
+## surface_pr_link / surface_deploy_link — DETERMINISTIC result-link emitters
+## for the studio run summary. The studio surfaces a run's headline links (the
+## opened PR, the live deploy) from `[iterion] preview_url=… kind=…` directives
+## a tool node prints on stdout — never from an LLM agent's prose. Each is
+## reached only on the success it names (finalize_mr opened a PR ⇒ url set;
+## deploy_verify passed ⇒ deployed_url set); the python guard drops an empty url
+## so the scanner never sees a malformed directive. read-only, idempotent.
+schema surface_pr_link_input:
+  url: string
+
+schema surface_deploy_link_input:
+  url: string
+
+tool surface_pr_link:
+  input: surface_pr_link_input
+  command: `URL={{input.url}} python3 -c "
+import os
+u = (os.environ.get('URL') or '').strip()
+if u:
+    print('[iterion] preview_url=' + u + ' kind=pr scope=external')
+"`
+
+tool surface_deploy_link:
+  input: surface_deploy_link_input
+  command: `URL={{input.url}} python3 -c "
+import os
+u = (os.environ.get('URL') or '').strip()
+if u:
+    print('[iterion] preview_url=' + u + ' kind=deploy scope=external')
+"`
+
 ## ─── Deploy phase nodes (opt-in, platform-agnostic) ─────────────────
 
 ## deploy_gate — deterministic "should we deploy?" projection of
@@ -1518,7 +1549,13 @@ workflow app_dev:
   deploy_verify -> deploy when not pass as deploy_retry("{{vars.max_deploy_retries}}") with {
     fail_log: "DEPLOY NOT HEALTHY (fix exactly this, then redeploy):\n{{outputs.deploy_verify.reason}}"
   }
+  ## Healthy deploy → surface the live URL as a headline result-link (kind=deploy)
+  ## in the run summary, alongside the detailed deployment report, then the PR
+  ## tail. Retry-exhausted (not pass) → straight to the PR tail; the deploy is
+  ## best-effort and the committed app is real work regardless.
+  deploy_verify -> surface_deploy_link when pass with { url: "{{outputs.deploy.deployed_url}}" }
   deploy_verify -> mr_gate
+  surface_deploy_link -> mr_gate
 
   ## ── PR tail (opt-in, feature-dev verbatim) ──────────────────────
   mr_gate -> forge_auth_probe when open_mr
@@ -1532,4 +1569,9 @@ workflow app_dev:
     scope_notes:      "{{vars.app_prompt}}"
   }
   forge_auth_probe -> done when not available
-  finalize_mr -> done
+  ## PR opened → surface its URL as a headline result-link in the run summary
+  ## (deterministic stdout directive → preview_url_available kind=pr), then
+  ## finish. Nothing opened (empty diff / refused PR) → straight to done.
+  finalize_mr -> surface_pr_link when opened with { url: "{{outputs.finalize_mr.url}}" }
+  finalize_mr -> done when not opened
+  surface_pr_link -> done

--- a/bots/branch-improve-loop/main.bot
+++ b/bots/branch-improve-loop/main.bot
@@ -965,6 +965,25 @@ agent finalize_mr:
   ## makes impossible (the node is only entered when a push credential exists).
   tool_max_steps: 20
 
+## surface_pr_link — DETERMINISTIC result-link emitter for the studio run
+## summary. finalize_mr is an LLM agent, but the studio surfaces a run's
+## headline PR link from the deterministic `[iterion] preview_url=… kind=pr`
+## directive a tool node prints on stdout — never from agent prose. Reached
+## only when finalize_mr actually opened a PR (opened=true ⇒ url set); the
+## python guard drops an empty url so the scanner never sees a malformed
+## directive. read-only, idempotent.
+schema surface_pr_link_input:
+  url: string
+
+tool surface_pr_link:
+  input: surface_pr_link_input
+  command: `URL={{input.url}} python3 -c "
+import os
+u = (os.environ.get('URL') or '').strip()
+if u:
+    print('[iterion] preview_url=' + u + ' kind=pr scope=external')
+"`
+
 ## post_pr_feedback — Billy leaves his review verdict as a COMMENT on the PR he
 ## just hardened, so the author sees the conclusion in the forge. claude_code
 ## for gh + the mounted forge_token; low effort (it only distils a summary +
@@ -1088,4 +1107,9 @@ workflow branch_improve_loop:
     scope_notes:      "{{vars.scope_notes}}"
   }
   forge_auth_probe -> done when not available
-  finalize_mr -> done
+  ## PR opened → surface its URL as a headline result-link in the run summary
+  ## (deterministic stdout directive → preview_url_available kind=pr), then
+  ## finish. Nothing opened (empty diff / refused PR) → straight to done.
+  finalize_mr -> surface_pr_link when opened with { url: "{{outputs.finalize_mr.url}}" }
+  finalize_mr -> done when not opened
+  surface_pr_link -> done

--- a/bots/docs-refresh/main.bot
+++ b/bots/docs-refresh/main.bot
@@ -1492,6 +1492,25 @@ agent finalize_mr:
   capabilities: [board.read, board.comment]
   tool_max_steps: 20
 
+## surface_pr_link — DETERMINISTIC result-link emitter for the studio run
+## summary. finalize_mr is an LLM agent, but the studio surfaces a run's
+## headline PR link from the deterministic `[iterion] preview_url=… kind=pr`
+## directive a tool node prints on stdout — never from agent prose. Reached
+## only when finalize_mr actually opened a PR (opened=true ⇒ url set); the
+## python guard drops an empty url so the scanner never sees a malformed
+## directive. read-only, idempotent.
+schema surface_pr_link_input:
+  url: string
+
+tool surface_pr_link:
+  input: surface_pr_link_input
+  command: `URL={{input.url}} python3 -c "
+import os
+u = (os.environ.get('URL') or '').strip()
+if u:
+    print('[iterion] preview_url=' + u + ' kind=pr scope=external')
+"`
+
 ## ─── Workflow ───────────────────────────────────────────────────
 
 workflow docs_refresh:
@@ -1599,4 +1618,9 @@ workflow docs_refresh:
     drift_remaining:  "{{outputs.campaign.drift_remaining}}"
   }
   forge_auth_probe -> done when not available
-  finalize_mr -> done
+  ## PR opened → surface its URL as a headline result-link in the run summary
+  ## (deterministic stdout directive → preview_url_available kind=pr), then
+  ## finish. Nothing opened (empty diff / refused PR) → straight to done.
+  finalize_mr -> surface_pr_link when opened with { url: "{{outputs.finalize_mr.url}}" }
+  finalize_mr -> done when not opened
+  surface_pr_link -> done

--- a/bots/feature-dev/main.bot
+++ b/bots/feature-dev/main.bot
@@ -795,6 +795,25 @@ agent finalize_mr:
   ## makes impossible (the node is only entered when a push credential exists).
   tool_max_steps: 20
 
+## surface_pr_link — DETERMINISTIC result-link emitter for the studio run
+## summary. finalize_mr is an LLM agent, but the studio surfaces a run's
+## headline PR link from the deterministic `[iterion] preview_url=… kind=pr`
+## directive a tool node prints on stdout — never from agent prose. Reached
+## only when finalize_mr actually opened a PR (opened=true ⇒ url set); the
+## python guard drops an empty url so the scanner never sees a malformed
+## directive. read-only, idempotent.
+schema surface_pr_link_input:
+  url: string
+
+tool surface_pr_link:
+  input: surface_pr_link_input
+  command: `URL={{input.url}} python3 -c "
+import os
+u = (os.environ.get('URL') or '').strip()
+if u:
+    print('[iterion] preview_url=' + u + ' kind=pr scope=external')
+"`
+
 ## ─── Workflow ───────────────────────────────────────────────────
 
 workflow feature_dev:
@@ -883,4 +902,9 @@ workflow feature_dev:
     scope_notes:      "{{vars.feature_prompt}}"
   }
   forge_auth_probe -> done when not available
-  finalize_mr -> done
+  ## PR opened → surface its URL as a headline result-link in the run summary
+  ## (deterministic stdout directive → preview_url_available kind=pr), then
+  ## finish. Nothing opened (empty diff / refused PR) → straight to done.
+  finalize_mr -> surface_pr_link when opened with { url: "{{outputs.finalize_mr.url}}" }
+  finalize_mr -> done when not opened
+  surface_pr_link -> done

--- a/bots/whole-improve-loop/main.bot
+++ b/bots/whole-improve-loop/main.bot
@@ -661,6 +661,25 @@ agent finalize_mr:
   ## makes impossible (the node is only entered when a push credential exists).
   tool_max_steps: 20
 
+## surface_pr_link — DETERMINISTIC result-link emitter for the studio run
+## summary. finalize_mr is an LLM agent, but the studio surfaces a run's
+## headline PR link from the deterministic `[iterion] preview_url=… kind=pr`
+## directive a tool node prints on stdout — never from agent prose. Reached
+## only when finalize_mr actually opened a PR (opened=true ⇒ url set); the
+## python guard drops an empty url so the scanner never sees a malformed
+## directive. read-only, idempotent.
+schema surface_pr_link_input:
+  url: string
+
+tool surface_pr_link:
+  input: surface_pr_link_input
+  command: `URL={{input.url}} python3 -c "
+import os
+u = (os.environ.get('URL') or '').strip()
+if u:
+    print('[iterion] preview_url=' + u + ' kind=pr scope=external')
+"`
+
 ## ─── Workflow ───────────────────────────────────────────────────
 
 workflow whole_improve_loop:
@@ -733,4 +752,9 @@ workflow whole_improve_loop:
     scope_notes:      "{{vars.scope_notes}}"
   }
   forge_auth_probe -> done when not available
-  finalize_mr -> done
+  ## PR opened → surface its URL as a headline result-link in the run summary
+  ## (deterministic stdout directive → preview_url_available kind=pr), then
+  ## finish. Nothing opened (empty diff / refused PR) → straight to done.
+  finalize_mr -> surface_pr_link when opened with { url: "{{outputs.finalize_mr.url}}" }
+  finalize_mr -> done when not opened
+  surface_pr_link -> done

--- a/docs/browser-pane.md
+++ b/docs/browser-pane.md
@@ -38,6 +38,22 @@ echo "[iterion] preview_url=https://my-preview.example.com"
   refuses RFC1918, link-local, cloud-metadata, and `*.svc.cluster.local`
   addresses to mitigate SSRF.
 
+### Headline result-links (`kind=pr` / `deploy` / `app`)
+
+When `kind` is a **result kind** — `pr`, `deploy`, or `app` — the URL is
+additionally surfaced as a prominent, always-visible **result-link** in
+the run summary (the run header's result-links bar), like a CI run's
+"View deployment" button. The links are deduped by URL and kept in
+discovery order, so one run can advertise both a PR and a deploy. They
+are event-derived, so a reloaded terminal run rebuilds them from its
+event log. A `kind=pr` link is **link-only** (GitHub/GitLab block
+iframing, so it never loads in the Browser pane); `deploy`/`app` live
+sites keep the Browser pane too. The catalog PR-tail bots
+(`docs-refresh`, `feature-dev`, `app-dev`, `branch-improve-loop`,
+`whole-improve-loop`) emit `kind=pr` from a deterministic tool node once
+`finalize_mr` opens a PR; `app-dev` also emits `kind=deploy` for a
+healthy deploy.
+
 ## Capturing screenshots
 
 A tool node can also publish a screenshot it took (puppeteer,

--- a/studio/src/components/Runs/RunHeader.tsx
+++ b/studio/src/components/Runs/RunHeader.tsx
@@ -33,6 +33,7 @@ import FinalizationRow from "./runHeader/FinalizationRow";
 import ForkedFromRow from "./runHeader/ForkedFromRow";
 import RunChildrenPanel from "./runHeader/RunChildrenPanel";
 import NotesRow from "./runHeader/NotesRow";
+import ResultLinksRow from "./runHeader/ResultLinksRow";
 import RunNameEditor from "./runHeader/RunNameEditor";
 import RunTagsRow from "./runHeader/RunTagsRow";
 import SourceTicketRow from "./runHeader/SourceTicketRow";
@@ -54,6 +55,9 @@ interface Props {
 export default function RunHeader({ run, active, wsState, onResetLayout, bare = false }: Props) {
   const requestWsReconnect = useRunStore((s) => s.requestWsReconnect);
   const applySnapshot = useRunStore((s) => s.applySnapshot);
+  // Headline result-links (opened PR, live deploy) derived from the run's
+  // preview_url events — rebuilt on reload from the replayed event log.
+  const resultLinks = useRunStore((s) => s.resultLinks);
   const { busy, error, run: runAction, setError } = useAsyncAction();
   const [resumeOpen, setResumeOpen] = useState(false);
   const [forkOpen, setForkOpen] = useState(false);
@@ -422,6 +426,10 @@ export default function RunHeader({ run, active, wsState, onResetLayout, bare = 
       {liveStreamExpected && (
         <WSDisconnectBanner state={wsState} onReconnect={requestWsReconnect} />
       )}
+      {/* Headline result-links (opened PR, live deploy) — the run's
+          "what did it produce" at a glance, the topmost outcome bar above
+          the detailed deployment/finalization rows. */}
+      <ResultLinksRow links={resultLinks} />
       {/* What the run shipped, above where its commits landed: the live
           URL is the operator's destination at the end of a deploy run. */}
       {run.deployment && <DeploymentRow deployment={run.deployment} />}

--- a/studio/src/components/Runs/runHeader/ResultLinksRow.tsx
+++ b/studio/src/components/Runs/runHeader/ResultLinksRow.tsx
@@ -1,0 +1,76 @@
+// Extracted from RunHeader.tsx to keep that file focused.
+// Result-links banner: a run's headline deliverables (opened PR, live
+// deploy, published app) surfaced as prominent clickable links at the top
+// of the run summary — like a CI run's "View deployment" button. Fed by
+// the store's event-derived `resultLinks` (see store/run.ts ResultLink),
+// so it rebuilds on a reloaded terminal run from the replayed event log.
+//
+// This is a link-only surface: a PR page blocks iframing, so it is never
+// embedded in the Browser pane. Embeddable kinds (deploy/app live sites)
+// still drive the Browser pane in parallel — this row just gives their URL
+// a prominent, always-visible home in the summary.
+
+import {
+  ArrowRightIcon,
+  ExternalLinkIcon,
+  GlobeIcon,
+  Link2Icon,
+  RocketIcon,
+} from "@radix-ui/react-icons";
+import type { ComponentType } from "react";
+
+import type { ResultLink } from "@/store/run";
+
+interface KindMeta {
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+}
+
+// Per-kind presentation. Unknown result kinds fall back to a neutral
+// "Result" link rather than being dropped — the store already gates which
+// kinds reach this list, so anything here is meant to be shown.
+const KIND_META: Record<string, KindMeta> = {
+  pr: { label: "Pull request", icon: Link2Icon },
+  deploy: { label: "Deployment", icon: RocketIcon },
+  app: { label: "App", icon: GlobeIcon },
+};
+const FALLBACK_META: KindMeta = { label: "Result", icon: ExternalLinkIcon };
+
+// displayUrl strips the scheme for a compact label; the href keeps the
+// full URL so the link still resolves.
+function displayUrl(url: string): string {
+  return url.replace(/^https?:\/\//, "");
+}
+
+export default function ResultLinksRow({ links }: { links: ResultLink[] }) {
+  if (links.length === 0) return null;
+
+  return (
+    <div
+      className="shrink-0 px-4 py-2 bg-accent-soft/50 border-b border-border-default flex flex-col gap-1.5 text-body"
+      aria-label="Run result links"
+    >
+      {links.map((link) => {
+        const meta = KIND_META[link.kind] ?? FALLBACK_META;
+        const Icon = meta.icon;
+        return (
+          <div key={link.url} className="flex items-center gap-2 min-w-0">
+            <Icon className="w-4 h-4 shrink-0 text-accent-text" />
+            <span className="font-medium text-fg-default shrink-0">{meta.label}</span>
+            <ArrowRightIcon className="w-3 h-3 shrink-0 text-fg-subtle" />
+            <a
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 min-w-0 font-medium text-accent-text hover:underline focus-visible:ring-1 focus-visible:ring-accent rounded"
+              title={`Open ${link.url}`}
+            >
+              <span className="truncate">{displayUrl(link.url)}</span>
+              <ExternalLinkIcon className="w-3 h-3 shrink-0" />
+            </a>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/studio/src/store/run.test.ts
+++ b/studio/src/store/run.test.ts
@@ -79,6 +79,7 @@ beforeEach(() => {
       screenshots: [],
       liveSession: null,
     },
+    resultLinks: [],
   } as never);
 });
 
@@ -833,5 +834,116 @@ describe("applyLogChunk — byte-keyed overlap/dedup", () => {
     const log = runStore.getState().log;
     expect(log.text).toBe("🔧abcd"); // no dup of "bc", "d" appended
     expect(log.nextByte).toBe(8);
+  });
+});
+
+// previewEvent builds a preview_url_available event as the runtime emits
+// one from a tool node's `[iterion] preview_url=…` stdout directive.
+function previewEvent(
+  seq: number,
+  url: string,
+  kind?: string,
+  scope: "internal" | "external" = "external",
+): RunEvent {
+  return {
+    seq,
+    timestamp: ts(seq),
+    type: "preview_url_available",
+    run_id: "run_test",
+    branch_id: "main",
+    node_id: "surface_pr_link",
+    data: { url, kind, scope, source: "tool-stdout" },
+  };
+}
+
+describe("applyEventsBatch — result-links (headline PR/deploy surfacing)", () => {
+  it("captures a kind=pr preview_url as a visible result-link", () => {
+    runStore.getState().applyEventsBatch([
+      previewEvent(1, "https://github.com/o/r/pull/7", "pr"),
+    ]);
+    const { resultLinks } = runStore.getState();
+    expect(resultLinks).toHaveLength(1);
+    expect(resultLinks[0]).toMatchObject({
+      url: "https://github.com/o/r/pull/7",
+      kind: "pr",
+      scope: "external",
+    });
+  });
+
+  it("does NOT embed a PR link in the Browser pane (GitHub blocks iframing)", () => {
+    runStore.getState().applyEventsBatch([
+      previewEvent(1, "https://github.com/o/r/pull/7", "pr"),
+    ]);
+    const { browser } = runStore.getState();
+    // The PR surfaces as a result-link, never as the pane's currentUrl…
+    expect(browser.currentUrl).toBeNull();
+    // …but the seen-seq still advances so the pane's auto-reveal logic
+    // stays consistent.
+    expect(browser.lastEventSeqSeen).toBe(1);
+  });
+
+  it("keeps an embeddable deploy URL in the Browser pane AND as a result-link", () => {
+    runStore.getState().applyEventsBatch([
+      previewEvent(1, "https://app.example.com", "deploy"),
+    ]);
+    const st = runStore.getState();
+    expect(st.browser.currentUrl).toBe("https://app.example.com");
+    expect(st.browser.kind).toBe("deploy");
+    expect(st.resultLinks).toHaveLength(1);
+    expect(st.resultLinks[0]).toMatchObject({ kind: "deploy" });
+  });
+
+  it("does NOT capture a non-result kind (dev-server) as a result-link", () => {
+    runStore.getState().applyEventsBatch([
+      previewEvent(1, "http://localhost:5173", "dev-server"),
+    ]);
+    const st = runStore.getState();
+    expect(st.resultLinks).toHaveLength(0);
+    // …but it still drives the Browser pane.
+    expect(st.browser.currentUrl).toBe("http://localhost:5173");
+  });
+
+  it("holds both a deploy and a PR link, deduped by url, in discovery order", () => {
+    // app-dev shape: deploy surfaces first, the PR after the MR tail.
+    runStore.getState().applyEventsBatch([
+      previewEvent(1, "https://app.example.com", "deploy"),
+      previewEvent(2, "https://github.com/o/r/pull/7", "pr"),
+      // A duplicate PR directive (idempotent re-run) must not double it.
+      previewEvent(3, "https://github.com/o/r/pull/7", "pr"),
+    ]);
+    const { resultLinks } = runStore.getState();
+    expect(resultLinks.map((l) => l.kind)).toEqual(["deploy", "pr"]);
+    expect(resultLinks.map((l) => l.url)).toEqual([
+      "https://app.example.com",
+      "https://github.com/o/r/pull/7",
+    ]);
+  });
+
+  it("reconstructs result-links on a reloaded terminal run (event-log replay)", () => {
+    // A finished run: cold-loaded snapshot at the final seq, then the full
+    // event log hydrated via loadEventHistoryIfMissing (applyEventsBatch).
+    const finished = {
+      ...baseRun,
+      status: "finished",
+    } as unknown as RunHeader;
+    runStore.getState().applySnapshot({ run: finished, executions: [], last_seq: 3 });
+    // Snapshots carry no result-links; the replayed history rebuilds them.
+    expect(runStore.getState().resultLinks).toHaveLength(0);
+    runStore.getState().applyEventsBatch([
+      nodeStarted("finalize_mr", 1),
+      nodeFinished("finalize_mr", 2),
+      previewEvent(3, "https://github.com/o/r/pull/7", "pr"),
+    ]);
+    const { resultLinks } = runStore.getState();
+    expect(resultLinks).toHaveLength(1);
+    expect(resultLinks[0]).toMatchObject({
+      url: "https://github.com/o/r/pull/7",
+      kind: "pr",
+    });
+  });
+
+  it("ignores an empty-url preview event", () => {
+    runStore.getState().applyEventsBatch([previewEvent(1, "", "pr")]);
+    expect(runStore.getState().resultLinks).toHaveLength(0);
   });
 });

--- a/studio/src/store/run.ts
+++ b/studio/src/store/run.ts
@@ -134,6 +134,25 @@ const initialBrowserState: BrowserPaneState = {
   liveSession: null,
 };
 
+// ResultLink is a run's headline deliverable — an opened pull request, a
+// live deployment, a published app — surfaced as a prominent clickable
+// link in the run summary (RunHeader's ResultLinksRow), like a CI run's
+// "View deployment" button. Distinct from the embeddable Browser pane: a
+// PR page blocks iframing, so it lives here as a link only. Derived purely
+// from `preview_url_available` events whose `kind` is a result kind
+// (RESULT_LINK_KINDS), so a reloaded terminal run reconstructs the list by
+// replaying its event log — level-triggered, never live-only.
+export interface ResultLink {
+  url: string;
+  // "pr" | "deploy" | "app" today, kept a plain string so a new
+  // deterministic emitter can add a kind with no store change.
+  kind: string;
+  scope: PreviewScope;
+  // Event seq that produced/last-classified this url. Stable identity +
+  // sort key (ascending = discovery order).
+  seq: number;
+}
+
 // InFlightTool tracks a tool call the engine has reported as started but
 // not yet completed. Populated on `tool_started`, cleared on
 // `tool_called` / `tool_error` (matched by toolUseID when present,
@@ -282,6 +301,10 @@ export interface RunStoreState {
   followTail: boolean;
   log: RunLogState;
   browser: BrowserPaneState;
+  // Headline result-links (opened PR, live deploy, …), deduped by url,
+  // in discovery order. Event-derived (see ResultLink); rebuilt on reload
+  // from the replayed event log alongside `browser`.
+  resultLinks: ResultLink[];
   // Increments to request a fresh WS dial. The broker drops a run's
   // subscribers on terminal status (pkg/runview/service.go: CloseRun),
   // so after Resume the still-open WS conn no longer receives events
@@ -397,6 +420,7 @@ function freshInitial() {
     followTail: true,
     log: initialLogState,
     browser: initialBrowserState,
+    resultLinks: [] as ResultLink[],
     wsReconnectToken: 0,
     uiOpenEventLogToken: 0,
   };
@@ -492,6 +516,7 @@ export function createRunStore() {
           snapshot: snap,
           pendingHumanInput: rehydrated,
           browser: state.browser,
+          resultLinks: state.resultLinks,
           queuedMessages: state.queuedMessages,
         },
         newerEvents,

--- a/studio/src/store/run/reducer.ts
+++ b/studio/src/store/run/reducer.ts
@@ -15,6 +15,7 @@ import type {
   PreviewScope,
   QueuedMessageStatus,
   QueuedUserMessage,
+  ResultLink,
   RunStoreState,
   TodoListSnapshot,
 } from "../run";
@@ -159,7 +160,32 @@ type ReduceInput = Pick<
   | "pendingHumanInput"
   | "queuedMessages"
   | "browser"
+  | "resultLinks"
 >;
+
+// RESULT_LINK_KINDS are the preview_url `kind` values that a run
+// advertises as a headline deliverable in its summary (RunHeader's
+// ResultLinksRow) rather than (or in addition to) the embeddable Browser
+// pane. A "pr" is a link only — GitHub/GitLab block iframing — while
+// "deploy"/"app" are live sites that keep the Browser pane too.
+const RESULT_LINK_KINDS: ReadonlySet<string> = new Set(["pr", "deploy", "app"]);
+
+// upsertResultLink folds one link into the deduped-by-url list. A new url
+// appends (preserving discovery order); a known url updates its kind/scope
+// only when they actually changed (a later, more specific classification
+// wins). Returns the SAME array reference when nothing changed so the
+// reducer's identity check skips a needless re-render.
+function upsertResultLink(list: ResultLink[], link: ResultLink): ResultLink[] {
+  const idx = list.findIndex((l) => l.url === link.url);
+  if (idx === -1) return list.concat(link);
+  const existing = list[idx];
+  if (existing && existing.kind === link.kind && existing.scope === link.scope) {
+    return list;
+  }
+  const next = list.slice();
+  next[idx] = { ...link };
+  return next;
+}
 
 // execKey composes the (branch, node) lookup key used by
 // lastExecIDByNode. The `\t` separator is forbidden in both branch
@@ -214,6 +240,7 @@ export function reduceEvents(
     }
   };
   let browser = state.browser;
+  let resultLinks = state.resultLinks;
   // Clone the executions map only when the first mutation happens; if
   // the whole batch only contains pass-through event types we keep the
   // identity stable so React skips re-renders downstream.
@@ -695,6 +722,28 @@ export function reduceEvents(
         const rawScope = evt.data?.scope;
         const scope: PreviewScope = rawScope === "internal" ? "internal" : "external";
         const rawSource = evt.data?.source;
+        const kind = evt.data?.kind;
+
+        // Result-link kinds (pr / deploy / app) are the run's headline
+        // deliverables — captured into a deduped list surfaced as
+        // prominent links in the run summary, so one run can advertise
+        // both a PR and a deploy. Level-triggered from the event log, so
+        // a reloaded terminal run rebuilds them.
+        if (kind && RESULT_LINK_KINDS.has(kind)) {
+          resultLinks = upsertResultLink(resultLinks, { url, kind, scope, seq: evt.seq });
+        }
+
+        // A PR link is never embeddable (GitHub/GitLab block iframing),
+        // so it must not hijack the Browser pane — it lives only as a
+        // result link. lastEventSeqSeen still advances so the pane's
+        // auto-reveal logic stays consistent. Embeddable kinds
+        // (dev-server, artifact-html, deploy/app live sites) fall through
+        // and drive the pane as before.
+        if (kind === "pr") {
+          browser = { ...browser, lastEventSeqSeen: evt.seq };
+          break;
+        }
+
         // Manual URLs from setManualPreviewUrl take precedence: don't
         // overwrite an active manual selection with a workflow event.
         if (browser.source === "manual" && browser.currentUrl) {
@@ -706,7 +755,7 @@ export function reduceEvents(
           currentUrl: url,
           scope,
           source: rawSource === "tool-stdout" ? "tool-stdout" : "runtime",
-          kind: evt.data?.kind,
+          kind,
           lastEventSeqSeen: evt.seq,
         };
         break;
@@ -801,6 +850,9 @@ export function reduceEvents(
   }
   if (browser !== state.browser) {
     next.browser = browser;
+  }
+  if (resultLinks !== state.resultLinks) {
+    next.resultLinks = resultLinks;
   }
   if (inFlightMutated) {
     next.inFlightToolsByExec = inFlightToolsByExec;


### PR DESCRIPTION
## What

When a run **opens a PR** (`finalize_mr`) or **deploys an app** (Appy), surface that link **prominently at the top of the run summary** — like a CI run's "View deployment" button — instead of leaving it buried in a node's structured output.

## How

**Bots — deterministic emission (no engine change).** Each PR-tail bot (`docs-refresh`, `feature-dev`, `app-dev`, `branch-improve-loop`, `whole-improve-loop`) gains a `surface_pr_link` **tool** node that prints `[iterion] preview_url=<url> kind=pr scope=external` on stdout once `finalize_mr` actually opened a PR. This reuses the existing `scanPreviewURLs` → `preview_url_available` seam ([pkg/backend/model/preview_url.go](../blob/main/pkg/backend/model/preview_url.go), [hooks.go](../blob/main/pkg/backend/model/hooks.go)). It's a **deterministic** node (not the agent), gated by `when opened` + a python empty-url guard so the scanner never sees a malformed directive. `app-dev` additionally emits `kind=deploy` for a healthy deploy. Edges re-ordered so `done` stays terminal.

```
finalize_mr -> surface_pr_link when opened with { url: "{{outputs.finalize_mr.url}}" }
finalize_mr -> done when not opened
surface_pr_link -> done
```

**Studio — prominent render.** The run store keeps an **event-derived, deduped-by-url `resultLinks`** list (kind ∈ `{pr, deploy, app}`); a new `ResultLinksRow` renders them as prominent clickable links at the top of the `RunHeader` (above the deployment/finalization bars). Rebuilt on reload from the replayed event log (level-triggered, like `browser`). A `kind=pr` link is **link-only** — never embedded in the Browser pane (GitHub/GitLab block iframing); `deploy`/`app` live sites still drive the pane.

## Tests

- **7 new** store-reducer tests: pr capture, no-embed for pr, deploy embed+link, non-result kind ignored, dedup+discovery-order, **reload reconstruction**, empty-url ignore.
- Green: `go test ./e2e/ ./bots/ ./pkg/botreplay/` (MR-path e2e + catalog parse/compile/typing/universality + goldens all unchanged), `iterion validate` on all 5 bots, studio `vitest` (1016 tests) + `tsc -b --force` + eslint (0 errors).
- End-to-end proof: ran a minimal bot through the real engine → confirmed a `preview_url_available` event with `{kind: pr, scope: external, source: tool-stdout}` lands in `events.jsonl`.

## Docs

`docs/browser-pane.md` gains a "Headline result-links" subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)