### PR TITLE
feat: projected improvements from the AIDD framework (skill lint, fit/rot lens, memory supersede, dependency gating, reviewed-SHA guard, hold-labels)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ The full documentation lives under [`docs/`](docs/) — start with the [document
 
 **References**
 - [docs/references/dsl-grammar.md](docs/references/dsl-grammar.md) — readable grammar
-- [docs/references/diagnostics.md](docs/references/diagnostics.md) — authoritative sparse catalogue: DSL C001–C199 and bundle checks C200–C230
+- [docs/references/diagnostics.md](docs/references/diagnostics.md) — authoritative sparse catalogue: DSL C001–C199 and bundle checks C200–C234
 - [docs/references/patterns.md](docs/references/patterns.md) — 10 reusable workflow patterns
 - [docs/grammar/iterion_v1.ebnf](docs/grammar/iterion_v1.ebnf) — formal EBNF grammar
 

--- a/bots/app-dev/skills/forge-mr-create.md
+++ b/bots/app-dev/skills/forge-mr-create.md
@@ -1,3 +1,8 @@
+---
+name: forge-mr-create
+description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
+---
+
 <!-- DUPLICATE — one of five byte-identical copies (iterion has no
      skill-sharing primitive; see CLAUDE.md "If a skill ends up duplicated
      across multiple bundles"). Edit one, edit all five:
@@ -6,10 +11,6 @@
        bots/docs-refresh/skills/forge-mr-create.md
        bots/feature-dev/skills/forge-mr-create.md
        bots/whole-improve-loop/skills/forge-mr-create.md -->
----
-name: forge-mr-create
-description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
----
 
 # Opening a pull request from a finished run
 

--- a/bots/branch-improve-loop/skills/code-review-invariants.md
+++ b/bots/branch-improve-loop/skills/code-review-invariants.md
@@ -91,10 +91,37 @@ error) indistinguishable from "no data" — the panel renders empty, the
 outage is invisible. Log (or propagate) the error before returning the
 empty/degraded state. No silent recovery that hides a root cause.
 
-## How to use this in a self-review pass
+## 7. Fit and rot — did we build the RIGHT thing, and only that
+
+Sections 1–6 catch code that is *wrong*. This one catches code that is
+*correct but hollow* — it compiles, passes, reviews clean, and still isn't
+what the task needed. Two failure modes, opposite directions:
+
+- **Fit (under-serving):** does the change serve the actual *need*,
+  end-to-end, not just the literal acceptance criteria? A change can satisfy
+  every stated check and still miss the point — it addresses a symptom, sits
+  at the wrong layer, or handles the happy path the ticket named while the
+  real workflow the user described stays broken. Re-read the original intent,
+  then trace the delivered path against it. Name any gap between what was
+  asked for and what the code actually does — a passing test over the wrong
+  behavior is a façade, not a fix.
+- **Rot (over-serving):** did the change make the codebase *worse to work
+  in*? Three tells: **duplication** (a third helper doing what two existing
+  ones already do — reuse the sibling instead), **over-engineering** (an
+  abstraction, config knob, or generality with exactly one caller and no
+  second on the horizon — inline it), and **incoherence** (now there are two
+  ways to do the same thing, and the next author won't know which). Leave the
+  tree more coherent than you found it, not more tangled.
+
+Conformance to the repo's declared conventions is already covered for
+cross-cutting concerns by §1; here, just confirm the change reads like the
+code around it. This section is judgment, not a checklist — apply it once,
+honestly, and fix what you find in the same pass. It is **advisory**: the
+deterministic build+test gate stays the only thing that blocks shipping — this
+lens sharpens the diff, it never gates it.## How to use this in a self-review pass
 
 1. `git diff <base>` and `git diff --stat` — see the *whole* change.
-2. For each new/changed unit, walk sections 1–6. Most changes only touch a
+2. For each new/changed unit, walk sections 1–7. Most changes only touch a
    few; be honest about which apply.
 3. For anything you find, **fix it now** and note it. Do not defer.
 4. Only when a section genuinely doesn't apply (no new state, no new

--- a/bots/branch-improve-loop/skills/code-review-invariants.md
+++ b/bots/branch-improve-loop/skills/code-review-invariants.md
@@ -118,7 +118,9 @@ cross-cutting concerns by §1; here, just confirm the change reads like the
 code around it. This section is judgment, not a checklist — apply it once,
 honestly, and fix what you find in the same pass. It is **advisory**: the
 deterministic build+test gate stays the only thing that blocks shipping — this
-lens sharpens the diff, it never gates it.## How to use this in a self-review pass
+lens sharpens the diff, it never gates it.
+
+## How to use this in a self-review pass
 
 1. `git diff <base>` and `git diff --stat` — see the *whole* change.
 2. For each new/changed unit, walk sections 1–7. Most changes only touch a

--- a/bots/branch-improve-loop/skills/forge-mr-create.md
+++ b/bots/branch-improve-loop/skills/forge-mr-create.md
@@ -1,3 +1,8 @@
+---
+name: forge-mr-create
+description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
+---
+
 <!-- DUPLICATE — one of five byte-identical copies (iterion has no
      skill-sharing primitive; see CLAUDE.md "If a skill ends up duplicated
      across multiple bundles"). Edit one, edit all five:
@@ -6,10 +11,6 @@
        bots/docs-refresh/skills/forge-mr-create.md
        bots/feature-dev/skills/forge-mr-create.md
        bots/whole-improve-loop/skills/forge-mr-create.md -->
----
-name: forge-mr-create
-description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
----
 
 # Opening a pull request from a finished run
 

--- a/bots/docs-refresh/skills/forge-mr-create.md
+++ b/bots/docs-refresh/skills/forge-mr-create.md
@@ -1,3 +1,8 @@
+---
+name: forge-mr-create
+description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
+---
+
 <!-- DUPLICATE — one of five byte-identical copies (iterion has no
      skill-sharing primitive; see CLAUDE.md "If a skill ends up duplicated
      across multiple bundles"). Edit one, edit all five:
@@ -6,10 +11,6 @@
        bots/docs-refresh/skills/forge-mr-create.md
        bots/feature-dev/skills/forge-mr-create.md
        bots/whole-improve-loop/skills/forge-mr-create.md -->
----
-name: forge-mr-create
-description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
----
 
 # Opening a pull request from a finished run
 

--- a/bots/evolve/skills/session-continuity.md
+++ b/bots/evolve/skills/session-continuity.md
@@ -116,7 +116,9 @@ aged out. A superseded fact carries history; a wrong fact is noise. When in
 doubt, supersede (reversible) rather than delete (destructive).
 
 This keeps the tree from accreting silent contradictions — the failure mode
-that makes a long-lived memory untrustworthy.## The findings/ scope (cross-bot inbox)
+that makes a long-lived memory untrustworthy.
+
+## The findings/ scope (cross-bot inbox)
 
 `findings/` is a **distinct memory scope** — a sibling of this
 bot's own scope under `…/memory/`, not a subfolder of it. It is a

--- a/bots/evolve/skills/session-continuity.md
+++ b/bots/evolve/skills/session-continuity.md
@@ -90,7 +90,33 @@ Beyond CONTEXT_BRIEF.md, create dated/topic-tagged files when:
 The auto-index will surface all of these on the next iteration —
 no manual bookkeeping needed.
 
-## The findings/ scope (cross-bot inbox)
+## Updating, superseding, deleting
+
+Memory is long-lived: across many iterations the same fact gets revisited.
+Before you write a fact, **reconcile it against what's already there** — read
+the related file(s) first (the index makes them cheap to find), then classify:
+
+- **New** — nothing covers it. Write a fresh file.
+- **Covered** — an existing file already says this, correctly. Do nothing;
+  don't write a near-duplicate.
+- **Refines** — an existing file is right but incomplete. Edit it in place
+  (`memory_write` the same path with the fuller content). One fact, one home.
+- **Supersedes** — a new fact *contradicts* an old one (a decision reversed, a
+  value changed). Do NOT delete the old file. Instead:
+  - mark the old file `status:superseded` in its tags and add a
+    `superseded_by: <new-path>` line to its frontmatter;
+  - give the new file a `supersedes: <old-path>` line.
+  The trail stays legible (why the change happened), and a future iteration
+  reading the old file sees at a glance that it is stale and where to look.
+  (`status:superseded` shows in the index; the two link lines are ignored by
+  the indexer and read by humans/agents.)
+
+**Delete only a memory that was outright *wrong*** — never one that merely
+aged out. A superseded fact carries history; a wrong fact is noise. When in
+doubt, supersede (reversible) rather than delete (destructive).
+
+This keeps the tree from accreting silent contradictions — the failure mode
+that makes a long-lived memory untrustworthy.## The findings/ scope (cross-bot inbox)
 
 `findings/` is a **distinct memory scope** — a sibling of this
 bot's own scope under `…/memory/`, not a subfolder of it. It is a

--- a/bots/feature-dev/skills/code-review-invariants.md
+++ b/bots/feature-dev/skills/code-review-invariants.md
@@ -90,10 +90,37 @@ error) indistinguishable from "no data" — the panel renders empty, the
 outage is invisible. Log (or propagate) the error before returning the
 empty/degraded state. No silent recovery that hides a root cause.
 
-## How to use this in a self-review pass
+## 7. Fit and rot — did we build the RIGHT thing, and only that
+
+Sections 1–6 catch code that is *wrong*. This one catches code that is
+*correct but hollow* — it compiles, passes, reviews clean, and still isn't
+what the task needed. Two failure modes, opposite directions:
+
+- **Fit (under-serving):** does the change serve the actual *need*,
+  end-to-end, not just the literal acceptance criteria? A change can satisfy
+  every stated check and still miss the point — it addresses a symptom, sits
+  at the wrong layer, or handles the happy path the ticket named while the
+  real workflow the user described stays broken. Re-read the original intent,
+  then trace the delivered path against it. Name any gap between what was
+  asked for and what the code actually does — a passing test over the wrong
+  behavior is a façade, not a fix.
+- **Rot (over-serving):** did the change make the codebase *worse to work
+  in*? Three tells: **duplication** (a third helper doing what two existing
+  ones already do — reuse the sibling instead), **over-engineering** (an
+  abstraction, config knob, or generality with exactly one caller and no
+  second on the horizon — inline it), and **incoherence** (now there are two
+  ways to do the same thing, and the next author won't know which). Leave the
+  tree more coherent than you found it, not more tangled.
+
+Conformance to the repo's declared conventions is already covered for
+cross-cutting concerns by §1; here, just confirm the change reads like the
+code around it. This section is judgment, not a checklist — apply it once,
+honestly, and fix what you find in the same pass. It is **advisory**: the
+deterministic build+test gate stays the only thing that blocks shipping — this
+lens sharpens the diff, it never gates it.## How to use this in a self-review pass
 
 1. `git diff <base>` and `git diff --stat` — see the *whole* change.
-2. For each new/changed unit, walk sections 1–6. Most changes only touch a
+2. For each new/changed unit, walk sections 1–7. Most changes only touch a
    few; be honest about which apply.
 3. For anything you find, **fix it now** and note it. Do not defer.
 4. Only when a section genuinely doesn't apply (no new state, no new

--- a/bots/feature-dev/skills/code-review-invariants.md
+++ b/bots/feature-dev/skills/code-review-invariants.md
@@ -117,7 +117,9 @@ cross-cutting concerns by §1; here, just confirm the change reads like the
 code around it. This section is judgment, not a checklist — apply it once,
 honestly, and fix what you find in the same pass. It is **advisory**: the
 deterministic build+test gate stays the only thing that blocks shipping — this
-lens sharpens the diff, it never gates it.## How to use this in a self-review pass
+lens sharpens the diff, it never gates it.
+
+## How to use this in a self-review pass
 
 1. `git diff <base>` and `git diff --stat` — see the *whole* change.
 2. For each new/changed unit, walk sections 1–7. Most changes only touch a

--- a/bots/feature-dev/skills/forge-mr-create.md
+++ b/bots/feature-dev/skills/forge-mr-create.md
@@ -1,3 +1,8 @@
+---
+name: forge-mr-create
+description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
+---
+
 <!-- DUPLICATE — one of five byte-identical copies (iterion has no
      skill-sharing primitive; see CLAUDE.md "If a skill ends up duplicated
      across multiple bundles"). Edit one, edit all five:
@@ -6,10 +11,6 @@
        bots/docs-refresh/skills/forge-mr-create.md
        bots/feature-dev/skills/forge-mr-create.md
        bots/whole-improve-loop/skills/forge-mr-create.md -->
----
-name: forge-mr-create
-description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
----
 
 # Opening a pull request from a finished run
 

--- a/bots/review-pr/README.md
+++ b/bots/review-pr/README.md
@@ -99,6 +99,18 @@ iterion run bots/review-pr/main.bot \
   a loud banner if findings existed but zero inline comments landed — the
   board + report still succeed, so fix the forge connection and re-run
   with the same `pr_url`.
+- **Stale-review guard.** The inline findings anchor to `file:line`
+  positions computed against the tree the reviewers judged — the worktree
+  HEAD `diff_precheck` captured as `reviewed_sha`. `publish_review`
+  re-reads HEAD before posting and, if it has moved, **refuses to
+  publish** rather than landing comments on lines that have since shifted;
+  it emits a `skipped` reason telling you to re-run with the same `pr_url`
+  for a fresh review. Within a single run Revi is read-only, so HEAD never
+  drifts between the two nodes — the guard bites on a **resume** after the
+  branch advanced (and any future mid-run mutation). Fail-open: it fires
+  only when both SHAs read cleanly and differ, so a normal publish is
+  never blocked, and the board + report already ran, so no findings are
+  lost.
 
 ## Read-only by construction
 

--- a/bots/review-pr/main.bot
+++ b/bots/review-pr/main.bot
@@ -523,6 +523,11 @@ schema emit_output:
 schema diff_precheck_output:
   is_empty: bool
   changed_files: int
+  ## reviewed_sha: the worktree HEAD the reviewers judge against. Carried to
+  ## publish_review so it can refuse to post a review whose line anchors were
+  ## computed against a tree that has since changed (a resume after the branch
+  ## advanced) — a stale-review guard, not a new gate.
+  reviewed_sha: string
 
 ## ─── Forge PR review (v0.3.0) schemas ───────────────────────────
 
@@ -612,12 +617,13 @@ tool diff_precheck:
 import os, subprocess, json
 os.chdir(os.environ['WS'])
 base = os.environ.get('BASE', 'main')
+head = subprocess.run(['git', 'rev-parse', 'HEAD'], capture_output=True, text=True).stdout.strip()
 mb = subprocess.run(['git', 'merge-base', base, 'HEAD'], capture_output=True, text=True).stdout.strip()
 if not mb:
-    print(json.dumps({'is_empty': False, 'changed_files': -1})); raise SystemExit(0)
+    print(json.dumps({'is_empty': False, 'changed_files': -1, 'reviewed_sha': head})); raise SystemExit(0)
 out = subprocess.run(['git', 'diff', '--name-only', mb], capture_output=True, text=True).stdout.strip()
 files = [f for f in out.splitlines() if f.strip()]
-print(json.dumps({'is_empty': len(files) == 0, 'changed_files': len(files)}))
+print(json.dumps({'is_empty': len(files) == 0, 'changed_files': len(files), 'reviewed_sha': head}))
 "`
   output: diff_precheck_output
 
@@ -702,8 +708,8 @@ compute pr_gate:
 ## published is true ONLY on a 2xx from the endpoint, whose counts are
 ## forge-re-fetched (anti-façade), never self-estimated.
 tool publish_review:
-  command: `PUB_URL={{vars.forge_publish_url}} PUB_TOKEN={{vars.forge_publish_token}} MODE={{vars.pr_review_mode}} PR_URL={{input.pr_url}} FINDINGS={{input.findings}} QUESTIONS={{input.questions}} CLAUDE_FINDINGS={{input.claude_findings}} GPT_FINDINGS={{input.gpt_findings}} GATE_ENABLED={{vars.gate_enabled}} GATE_SEVERITY={{vars.gate_severity}} GATE_CONTEXT={{vars.gate_context}} python3 -c "
-import os, json, urllib.request, urllib.error
+  command: `WS={{vars.workspace_dir}} REVIEWED_SHA={{outputs.diff_precheck.reviewed_sha}} PUB_URL={{vars.forge_publish_url}} PUB_TOKEN={{vars.forge_publish_token}} MODE={{vars.pr_review_mode}} PR_URL={{input.pr_url}} FINDINGS={{input.findings}} QUESTIONS={{input.questions}} CLAUDE_FINDINGS={{input.claude_findings}} GPT_FINDINGS={{input.gpt_findings}} GATE_ENABLED={{vars.gate_enabled}} GATE_SEVERITY={{vars.gate_severity}} GATE_CONTEXT={{vars.gate_context}} python3 -c "
+import os, json, subprocess, urllib.request, urllib.error
 
 def emit(published, forge='unknown', review_url='', posted=0, sugg=0, skipped='', summary=''):
     print(json.dumps({'published': published, 'forge': forge, 'review_url': review_url,
@@ -716,6 +722,24 @@ tok = os.environ.get('PUB_TOKEN', '').strip()
 pr = os.environ.get('PR_URL', '').strip()
 mode = os.environ.get('MODE', '').strip() or 'inline'
 findings_parse_failed = False
+
+# Stale-review guard (#1): the findings' file:line anchors were computed
+# against the tree at REVIEWED_SHA. If the worktree HEAD has since moved (a
+# resume after the branch advanced), those anchors no longer match — refuse to
+# post a misaligned review rather than land comments on the wrong lines. Only
+# fires when we can positively read both SHAs and they differ (fail-open).
+reviewed = os.environ.get('REVIEWED_SHA', '').strip()
+ws = os.environ.get('WS', '').strip()
+if reviewed and ws:
+    try:
+        cur = subprocess.run(['git', '-C', ws, 'rev-parse', 'HEAD'],
+                             capture_output=True, text=True).stdout.strip()
+    except Exception:
+        cur = ''
+    if cur and cur != reviewed:
+        emit(False, skipped='tree changed since review (' + reviewed[:12] + ' -> ' + cur[:12] + '); the findings anchor to the reviewed tree, not HEAD. Re-run with the same pr_url for a fresh review.',
+             summary='publish skipped: the worktree HEAD moved after the reviewers judged it, so the inline anchors are stale. No comments posted.')
+
 try:
     findings = json.loads(os.environ.get('FINDINGS') or '[]')
 except ValueError:

--- a/bots/sec-audit-source/skills/HARNESS-ATTRIBUTION.md
+++ b/bots/sec-audit-source/skills/HARNESS-ATTRIBUTION.md
@@ -1,3 +1,9 @@
+---
+name: harness-attribution
+description: Provenance notice for Seki's threat-model, vuln-scan, triage, and patch skills — records that they are adapted from Anthropic's defending-code-reference-harness. Reference documentation, not a runtime skill.
+disable-model-invocation: true
+---
+
 # Harness attribution
 
 Seki's `threat-model`, `vuln-scan`, `triage`, and `patch` skills are

--- a/bots/whats-next/skills/session-continuity.md
+++ b/bots/whats-next/skills/session-continuity.md
@@ -126,7 +126,9 @@ aged out. A superseded fact carries history; a wrong fact is noise. When in
 doubt, supersede (reversible) rather than delete (destructive).
 
 This keeps the tree from accreting silent contradictions — the failure mode
-that makes a long-lived memory untrustworthy.## The findings/ scope (cross-bot inbox)
+that makes a long-lived memory untrustworthy.
+
+## The findings/ scope (cross-bot inbox)
 
 `findings/` is a **distinct memory scope** — a sibling of this
 bot's own scope under `…/memory/`, not a subfolder of it. It is a

--- a/bots/whats-next/skills/session-continuity.md
+++ b/bots/whats-next/skills/session-continuity.md
@@ -100,7 +100,33 @@ Beyond CONTEXT_BRIEF.md, create dated/topic-tagged files when:
 The auto-index will surface all of these on the next iteration —
 no manual bookkeeping needed.
 
-## The findings/ scope (cross-bot inbox)
+## Updating, superseding, deleting
+
+Memory is long-lived: across many iterations the same fact gets revisited.
+Before you write a fact, **reconcile it against what's already there** — read
+the related file(s) first (the index makes them cheap to find), then classify:
+
+- **New** — nothing covers it. Write a fresh file.
+- **Covered** — an existing file already says this, correctly. Do nothing;
+  don't write a near-duplicate.
+- **Refines** — an existing file is right but incomplete. Edit it in place
+  (`memory_write` the same path with the fuller content). One fact, one home.
+- **Supersedes** — a new fact *contradicts* an old one (a decision reversed, a
+  value changed). Do NOT delete the old file. Instead:
+  - mark the old file `status:superseded` in its tags and add a
+    `superseded_by: <new-path>` line to its frontmatter;
+  - give the new file a `supersedes: <old-path>` line.
+  The trail stays legible (why the change happened), and a future iteration
+  reading the old file sees at a glance that it is stale and where to look.
+  (`status:superseded` shows in the index; the two link lines are ignored by
+  the indexer and read by humans/agents.)
+
+**Delete only a memory that was outright *wrong*** — never one that merely
+aged out. A superseded fact carries history; a wrong fact is noise. When in
+doubt, supersede (reversible) rather than delete (destructive).
+
+This keeps the tree from accreting silent contradictions — the failure mode
+that makes a long-lived memory untrustworthy.## The findings/ scope (cross-bot inbox)
 
 `findings/` is a **distinct memory scope** — a sibling of this
 bot's own scope under `…/memory/`, not a subfolder of it. It is a

--- a/bots/whole-improve-loop/main.bot
+++ b/bots/whole-improve-loop/main.bot
@@ -205,6 +205,18 @@ prompt campaign_system:
   KEEP GOING, one site at a time, until this pass has applied the axis
   everywhere you can within your budget. Then STOP and report.
 
+  BEFORE YOU REPORT, sharpen the diff with two questions (advisory — the
+  build/test gate still decides; this only improves what you ship, it never
+  blocks it):
+    - Fit: does each change serve the real intent of the axis end-to-end, or
+      did you satisfy its letter while the underlying problem persists? A
+      change that passes the gate but doesn't move the actual need is a
+      façade — redo it, don't report it done.
+    - Rot: did you leave duplication (a third helper doing what two siblings
+      already do), a one-caller abstraction, or two ways to do the same thing?
+      Reuse the sibling and collapse it now — leave the tree more coherent than
+      you found it, not more tangled.
+
   TERMINATION CONTRACT (required structured output — this is how the engine
   detects completion; an under-specified end just gets re-poked):
     - axis_complete: true ONLY when a fresh re-scan finds NO remaining site

--- a/bots/whole-improve-loop/skills/forge-mr-create.md
+++ b/bots/whole-improve-loop/skills/forge-mr-create.md
@@ -1,3 +1,8 @@
+---
+name: forge-mr-create
+description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
+---
+
 <!-- DUPLICATE — one of five byte-identical copies (iterion has no
      skill-sharing primitive; see CLAUDE.md "If a skill ends up duplicated
      across multiple bundles"). Edit one, edit all five:
@@ -6,10 +11,6 @@
        bots/docs-refresh/skills/forge-mr-create.md
        bots/feature-dev/skills/forge-mr-create.md
        bots/whole-improve-loop/skills/forge-mr-create.md -->
----
-name: forge-mr-create
-description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
----
 
 # Opening a pull request from a finished run
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ For the architectural trade-off against prompt-only orchestration, read [why-not
 | [references/dsl-grammar.md](references/dsl-grammar.md) | Readable grammar derived from the parser surface. |
 | [grammar/iterion_v1.ebnf](grammar/iterion_v1.ebnf) | Formal EBNF counterpart. |
 | [grammar/V1_SCOPE.md](grammar/V1_SCOPE.md) | Living boundary of the additively evolved V1 grammar and AST. |
-| [references/diagnostics.md](references/diagnostics.md) | Authoritative sparse catalogue: DSL C001–C199 and bundle checks C200–C230. |
+| [references/diagnostics.md](references/diagnostics.md) | Authoritative sparse catalogue: DSL C001–C199 and bundle checks C200–C234. |
 | [routers.md](routers.md) | Five routing modes, per-item fan-out, and convergence. |
 | [groups-iteration-subbots.md](groups-iteration-subbots.md) | `group`/`use`, edge `foreach`, `fan_out_each`, resources, and nested bots. |
 | [human-in-the-loop.md](human-in-the-loop.md) | Human nodes and all six interaction values, including the node-specific `none` and `async` behavior. |

--- a/docs/adr/081-async-human-interaction.md
+++ b/docs/adr/081-async-human-interaction.md
@@ -87,7 +87,7 @@ claude_code's Stop hook).
 
 **Diagnostics.** C240 (error: `interaction: async` on a human node),
 C241 (error: `await_answers` without `timeout:`), C242 (warning: `from:`
-references a missing/non-async node). C240-band because C200–C230 are
+references a missing/non-async node). C240-band because C200–C234 are
 claimed by pkg/bundlelint.
 
 ## Rejected alternatives

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,7 +95,7 @@ and claimed by a runner.
    loop fuel, routing, convergence, capabilities, templates, sandbox settings,
    and backend constraints before execution. DSL diagnostics occupy C001–C199
    plus the async-interaction band C240–C242; bundle consistency checks occupy
-   C200–C230.
+   C200–C234.
 
 The compiler returns diagnostics rather than hiding repairs. The authoritative
 catalogue is [references/diagnostics.md](references/diagnostics.md); the language

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -52,7 +52,7 @@ iterion validate workflow.bot
 iterion validate bundle.botz --json
 ```
 
-Accepted inputs are `.bot`, `.botz`, and bundle directories. Validation reports sparse DSL diagnostics in C001–C199 and bundle checks in C200–C230; the [diagnostic catalogue](references/diagnostics.md) is authoritative.
+Accepted inputs are `.bot`, `.botz`, and bundle directories. Validation reports sparse DSL diagnostics in C001–C199 and bundle checks in C200–C234; the [diagnostic catalogue](references/diagnostics.md) is authoritative.
 
 ### `iterion diagram`
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -81,7 +81,7 @@ iterion/
 │   ├── dsl/                 # lexer/parser, AST, expressions, IR/compiler, unparser
 │   ├── runtime/             # graph engine, routing, loops, budgets, recovery, worktrees
 │   ├── backend/             # model/delegated executors, MCP, tools, cost, secret guard
-│   ├── bundle/              # .botz loading; bundlelint holds C200–C230 checks
+│   ├── bundle/              # .botz loading; bundlelint holds C200–C234 checks
 │   ├── sandbox/             # Docker/Podman/Kubernetes isolation and egress controls
 │   ├── store/               # local and cloud persistence abstractions
 │   ├── server/ + runview/   # studio/run/cloud HTTP and streaming surfaces
@@ -107,7 +107,7 @@ The labels `schedule-related`, `cloud-related`, and `extensions/state` above are
 
 ## Key contracts
 
-- DSL syntax lives in `pkg/dsl/parser`; compilation/semantic validation lives in the split files under `pkg/dsl/ir`. Diagnostics use sparse DSL range C001–C199; bundle checks use C200–C230.
+- DSL syntax lives in `pkg/dsl/parser`; compilation/semantic validation lives in the split files under `pkg/dsl/ir`. Diagnostics use sparse DSL range C001–C199; bundle checks use C200–C234.
 - `pkg/server` registers the HTTP route table that generates `openapi.json`; `task openapi:check` guards the committed spec and studio types.
 - `bots/` is the editable full catalogue. `pkg/cli/templates/dispatch_bots/` is generated for the embedded zero-config subset; do not hand-maintain the copies.
 - Studio's production build is copied into `pkg/server/static` and embedded into the Go binary.

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -223,10 +223,14 @@ Each tick (`polling.interval_ms`, default 30s):
    dependencies**: an issue whose body opens a line with
    `Depends on #N` / `Blocked by #N` is held out of the candidate set
    while `#N` is still open (the native tracker has its own richer
-   blocker model). Resolution is **fail-open** — a reference that
-   cannot be confirmed open (a typo, a closed issue, a cross-repo ref)
-   never holds the issue, so a mis-parse can only under-block, never
-   silently wedge a ticket. Each hold is logged at info level.
+   blocker model). Resolution is **best-effort and fail-open** — a
+   blocker holds the issue only when `#N` is positively seen open among
+   the issues this poll fetched. Because that fetch is scoped by the
+   configured `include_labels`, a blocker sitting in a *different* label
+   or state is not seen and fails open (the issue dispatches); likewise a
+   typo, a closed issue, or a cross-repo ref never holds. So a mis-parse
+   can only under-block, never silently wedge a ticket. Each hold is
+   logged at info level.
 4. **Sort.** `priority desc, created_at asc, identifier asc`.
 5. **Dispatch.** Walk candidates, skip those already claimed locally
    or queued for retry, and dispatch as long as both global and

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -218,7 +218,15 @@ Each tick (`polling.interval_ms`, default 30s):
    tracker as the source of truth.
 3. **Fetch candidates.** `tracker.ListCandidates(ctx)`. The native
    adapter filters by `Eligible` board states; the GitHub adapter
-   passes labels through `gh issue list --search`.
+   passes labels through `gh issue list --search`. Every external
+   adapter (github/forgejo/gitlab) also **honors body-declared
+   dependencies**: an issue whose body opens a line with
+   `Depends on #N` / `Blocked by #N` is held out of the candidate set
+   while `#N` is still open (the native tracker has its own richer
+   blocker model). Resolution is **fail-open** — a reference that
+   cannot be confirmed open (a typo, a closed issue, a cross-repo ref)
+   never holds the issue, so a mis-parse can only under-block, never
+   silently wedge a ticket. Each hold is logged at info level.
 4. **Sort.** `priority desc, created_at asc, identifier asc`.
 5. **Dispatch.** Walk candidates, skip those already claimed locally
    or queued for retry, and dispatch as long as both global and

--- a/docs/dsl-totality-and-tc.md
+++ b/docs/dsl-totality-and-tc.md
@@ -81,7 +81,7 @@ body has no exit edge, so only fuel/liveness can ever stop it).
 ## The static-predictability surface
 
 Compilation is a two-phase pipeline that emits ~110 diagnostics
-(C001–C199 plus the async band C240–C242 + bundlelint C200–C230, all sparse ranges). The full catalogue, with severity and fix,
+(C001–C199 plus the async band C240–C242 + bundlelint C200–C234, all sparse ranges). The full catalogue, with severity and fix,
 is in [references/diagnostics.md](references/diagnostics.md); a drift guard
 (`TestDiagCodesAreDocumented`) and a uniqueness guard (`TestDiagCodesAreUnique`)
 in [pkg/dsl/ir/diag_codes_test.go](../pkg/dsl/ir/diag_codes_test.go) keep that

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -502,7 +502,7 @@ Terminal targets `done` and `fail` are reserved and are never declared.
 
 ## Validation and references
 
-Run `iterion validate workflow.bot` before execution. Diagnostics occupy sparse ranges: DSL/compiler/runtime consistency checks use C001–C199 plus the async-interaction band C240–C242; bundle checks use C200–C230. The authoritative list is [references/diagnostics.md](references/diagnostics.md).
+Run `iterion validate workflow.bot` before execution. Diagnostics occupy sparse ranges: DSL/compiler/runtime consistency checks use C001–C199 plus the async-interaction band C240–C242; bundle checks use C200–C234. The authoritative list is [references/diagnostics.md](references/diagnostics.md).
 
 - [Readable grammar](references/dsl-grammar.md)
 - [Formal EBNF](grammar/iterion_v1.ebnf)

--- a/docs/references/diagnostics.md
+++ b/docs/references/diagnostics.md
@@ -170,6 +170,14 @@ except **C230**; warnings are surfaced but do not fail validation.
 | **C220** | warning | manifest capability granted by no node | A `manifest.capabilities` entry is granted by no workflow-level or node-level `capabilities:` list | Add it to a node's `capabilities:`, or drop it from the manifest (it is documentation-only otherwise) |
 | **C221** | warning | frontmatter capabilities override manifest | The `main.bot` `## ---` frontmatter declares `capabilities:` that differ from and silently override the manifest's | Keep one source of truth — drop the frontmatter list or align the two |
 | **C230** | error | per-bot memory name mismatch | A node uses `memory: visibility: bot`, but the manifest name, workflow name, and bundle dir name are not all identical — so the bot's memory tree splits across CLI (workflow name) and dispatcher (bundle name) launches | Make all three identical |
+| **C231** | warning | skill has no `name:` | A `skills/*.md` file has no `name:` frontmatter, so it is undiscoverable by name once mirrored into `.claude/skills/` | Add `name: <kebab-case-id>` to the skill frontmatter |
+| **C232** | warning | skill has no `description:` | A `skills/*.md` file has no `description:` frontmatter, so the router (Nexie) has no signal for when to select it | Add a `description:` saying what the skill is for and when it applies |
+| **C233** | warning | skill `description:` too terse | A skill `description:` is present but too short to route on (e.g. "Security stuff") | Describe what the skill does and the situation it applies to. Routability only — no phrasing template is imposed |
+| **C234** | warning | duplicate skill name | Two `skills/*.md` files declare the same `name:`, so one silently clobbers the other when mirrored | Give each skill a unique `name:` |
+
+The skill-authoring checks (**C231–C234**) guard *routability* — that a skill
+can be discovered and chosen by the router — not prose style. They impose no
+phrasing template and are all warnings, so a skill gap never fails validation.
 
 ## Quick Troubleshooting
 

--- a/docs/references/dsl-grammar.md
+++ b/docs/references/dsl-grammar.md
@@ -391,4 +391,4 @@ Namespace-specific shapes and constraints are detailed in the [DSL guide](../dsl
 
 Syntax-valid files can still fail compilation for duplicate ids, unknown schemas/prompts/nodes, invalid templates, unreachable nodes, non-exhaustive routing, undeclared cycles, router-mode property misuse, unsafe fan-out, bad resource references, capability mismatches, and invalid sandbox/secret/cursor configuration.
 
-Use `iterion validate file.bot`. The authoritative sparse code ranges are DSL C001–C199 (plus the async-interaction band C240–C242) and bundle checks C200–C230; see [diagnostics](diagnostics.md).
+Use `iterion validate file.bot`. The authoritative sparse code ranges are DSL C001–C199 (plus the async-interaction band C240–C242) and bundle checks C200–C234; see [diagnostics](diagnostics.md).

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -16,7 +16,7 @@ npx skills add https://github.com/SocialGouv/iterion --skill iterion-dsl
 | [`SKILL-run-and-refine.md`](../SKILL-run-and-refine.md) | Practice guide for running, debugging and iteratively refining `.bot` workflows against real data |
 | [`references/dsl-grammar.md`](references/dsl-grammar.md) | Formal grammar specification (EBNF) |
 | [`references/patterns.md`](references/patterns.md) | 10 reusable workflow patterns with annotated snippets |
-| [`references/diagnostics.md`](references/diagnostics.md) | Authoritative sparse catalogue of DSL diagnostics (C001–C199) and bundle checks (C200–C230), with causes and fixes |
+| [`references/diagnostics.md`](references/diagnostics.md) | Authoritative sparse catalogue of DSL diagnostics (C001–C199) and bundle checks (C200–C234), with causes and fixes |
 
 ## Usage
 

--- a/docs/visual-editor.md
+++ b/docs/visual-editor.md
@@ -26,7 +26,7 @@ See [cli-reference.md `#iterion-studio`](cli-reference.md#iterion-studio) for th
 - **Node library** — Drag pre-built node types (agent, judge, router, human, tool, compute) onto the canvas
 - **Property editor** — Edit node properties, schemas, prompts, and edge conditions in a side panel
 - **Source view** — Split-pane view showing the raw workflow source (`.bot`) alongside the visual graph
-- **Live diagnostics** — Real-time validation errors and warnings as you edit (sparse DSL range C001–C199; bundle checks C200–C230)
+- **Live diagnostics** — Real-time validation errors and warnings as you edit (sparse DSL range C001–C199; bundle checks C200–C234)
 - **File watching** — Detects external file changes via WebSocket and syncs automatically
 - **Undo/redo** — Full edit history
 - **Launch modal** — Fills `vars` and attachments at launch time, with bot/argument discovery driven by `--bots-path` (the modal's bot picker and argument form consume the same catalogue `iterion bots list` emits)

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -281,10 +281,12 @@ Every webhook carries four filters
   suppress the launch — *whatever* bot would have run — and record a
   filtered delivery. It is the operator's escape hatch to pause
   automation on one PR/issue without disabling the webhook; a human can
-  still trigger a bot manually via a `/command`. Case-insensitive; empty
-  = off. Fail-open: providers/payloads that don't carry the full label
-  set (GitLab, minimal payloads) simply aren't suppressed. Unlike
-  `label_allowlist` (which *selects* a bot), `hold_labels` *vetoes* them.
+  still trigger a bot manually via a `/command`. Applies to all four
+  auto-launch lanes (GitHub/Forgejo PR review + auto-heal, GitHub issue,
+  GitLab MR review, GitLab issue). Case-insensitive; empty = off; a `*`
+  entry holds everything. Fail-open: a minimal payload that doesn't carry
+  the label set simply isn't suppressed. Unlike `label_allowlist` (which
+  *selects* a bot), `hold_labels` *vetoes* them.
 - **`project_allowlist`** — `owner/repo` patterns. Empty = every project
   the forge fires for. Supports `*` (any), `owner/*`, or exact paths.
 - **`author_allowlist`** — PR/MR author logins allowed to trigger a

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -264,7 +264,7 @@ a key the org-admin has pinned (`handleGenericWebhook` in
 
 ## Matching: project + event + author allowlists, bot scope
 
-Every webhook carries four filters
+Every webhook carries four selection filters plus a bot-agnostic hold gate
 ([pkg/webhooks/types.go:Config](../pkg/webhooks/types.go)):
 
 - **`event_allowlist`** — provider-event names allowed; empty defaults

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -275,6 +275,16 @@ Every webhook carries four filters
   freshly-applied label fires (e.g. `["implement"]`). Empty = any label;
   case-insensitive; a bare `*` matches everything. No effect on the
   `pull_request` / `issue_comment` paths.
+- **`hold_labels`** — a **bot-agnostic suppression** set. When the
+  triggering PR or issue carries any of these labels, the auto-launch
+  lanes (PR-open review, merge-queue auto-heal, auto-implement-on-open)
+  suppress the launch — *whatever* bot would have run — and record a
+  filtered delivery. It is the operator's escape hatch to pause
+  automation on one PR/issue without disabling the webhook; a human can
+  still trigger a bot manually via a `/command`. Case-insensitive; empty
+  = off. Fail-open: providers/payloads that don't carry the full label
+  set (GitLab, minimal payloads) simply aren't suppressed. Unlike
+  `label_allowlist` (which *selects* a bot), `hold_labels` *vetoes* them.
 - **`project_allowlist`** — `owner/repo` patterns. Empty = every project
   the forge fires for. Supports `*` (any), `owner/*`, or exact paths.
 - **`author_allowlist`** — PR/MR author logins allowed to trigger a

--- a/docs/why-not-prompt-orchestration.md
+++ b/docs/why-not-prompt-orchestration.md
@@ -29,7 +29,7 @@ The moment you want any of the properties below, prompt-orchestration starts hit
 
 ### 1. Deterministic DAG
 
-The same `.bot` file produces the same graph of nodes and edges every time. The compiler and validators under [`pkg/dsl/ir/`](../pkg/dsl/ir/) turn the AST into an IR and emit sparse DSL diagnostic codes in C001–C199 (plus the async-interaction band C240–C242) for structural problems *before* you spend a token; bundle checks use C200–C230.
+The same `.bot` file produces the same graph of nodes and edges every time. The compiler and validators under [`pkg/dsl/ir/`](../pkg/dsl/ir/) turn the AST into an IR and emit sparse DSL diagnostic codes in C001–C199 (plus the async-interaction band C240–C242) for structural problems *before* you spend a token; bundle checks use C200–C234.
 
 With a prompt orchestrator, the topology is re-decided on every run. That's a feature for exploration and a bug for reproducibility — you can't diff "what changed between run 7 and run 8" if both runs invented their own plan.
 

--- a/pkg/bundlelint/lint.go
+++ b/pkg/bundlelint/lint.go
@@ -18,6 +18,7 @@ package bundlelint
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/SocialGouv/iterion/pkg/bundle"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
@@ -61,7 +62,33 @@ const (
 	// (visibility: bot) but the manifest name, workflow name, and bundle dir
 	// name disagree, so the bot's memory tree splits across launch paths.
 	DiagBundleNameTripleMismatch Code = "C230"
+
+	// Skill-authoring routability (C231–C234). A bundle's skills/*.md are
+	// mirrored into .claude/skills/ and selected by the router bot (Nexie)
+	// purely from their frontmatter. These checks guard *routability* — that
+	// a skill can be discovered and chosen — NOT prose style; they are all
+	// warnings (never block authoring) and deliberately impose no phrasing
+	// template (no mandated "Use when…/Not for…"), only presence + substance.
+
+	// DiagSkillNameMissing: a skill file has no `name:` frontmatter, so it is
+	// undiscoverable by name in the mirrored .claude/skills/ tree.
+	DiagSkillNameMissing Code = "C231"
+	// DiagSkillDescriptionMissing: a skill file has no `description:`, so the
+	// router has no signal for when to select it.
+	DiagSkillDescriptionMissing Code = "C232"
+	// DiagSkillDescriptionTerse: a skill `description:` is present but too
+	// short to route on (e.g. "Security stuff").
+	DiagSkillDescriptionTerse Code = "C233"
+	// DiagSkillNameDuplicate: two skill files in the bundle declare the same
+	// `name:`, so one silently clobbers the other when mirrored.
+	DiagSkillNameDuplicate Code = "C234"
 )
+
+// minRoutableDescription is the shortest `description:` the skill lint treats
+// as carrying enough signal for a router to select on. Deliberately low — the
+// check flags only the trivially-empty ("Security stuff"), not terse-but-real
+// descriptions; routability, not verbosity, is the bar.
+const minRoutableDescription = 24
 
 // Severity mirrors ir.Severity semantics: an error makes `iterion validate`
 // exit non-zero; a warning is surfaced but non-fatal.
@@ -110,6 +137,20 @@ type Input struct {
 	Workflow    *ir.Workflow
 	Frontmatter *bundle.Frontmatter
 	DirName     string
+	// Skills carries the bundle's parsed skills/*.md frontmatter for the
+	// routability checks (C231–C234). Empty skips them. bundlelint stays
+	// I/O-free: the caller scans the files (via skilllib.ScanFrontmatter) and
+	// passes the results in, mirroring how Frontmatter is supplied.
+	Skills []SkillDoc
+}
+
+// SkillDoc is one bundle skill file's routability-relevant frontmatter. Path
+// is the bundle-relative path used for diagnostic attribution (e.g.
+// "skills/repo-survey.md").
+type SkillDoc struct {
+	Path        string
+	Name        string
+	Description string
 }
 
 // CheckConsistency cross-checks a bot's manifest against its compiled
@@ -127,6 +168,7 @@ func CheckConsistency(in Input) []Diag {
 	checkForgeSecret(&diags, m, in.Workflow)
 	checkCapabilities(&diags, m, in.Workflow, in.Frontmatter)
 	checkBundleNameStability(&diags, m, in.Workflow, in.DirName)
+	checkSkills(&diags, in.Skills)
 
 	sort.SliceStable(diags, func(i, j int) bool {
 		if diags[i].Code != diags[j].Code {
@@ -303,6 +345,65 @@ func checkBundleNameStability(diags *[]Diag, m *bundle.Manifest, w *ir.Workflow,
 		),
 		Hint: "make all three identical (rename the bundle dir, the `workflow NAME:`, or the manifest name:)",
 	})
+}
+
+// checkSkills flags routability problems in a bundle's skills/*.md: a skill
+// the router can't discover (no name) or can't decide to select (no/terse
+// description), and a name collision that clobbers on mirror. All warnings —
+// a skill authoring gap should never fail `iterion validate`. Deliberately no
+// prose-style rules: presence + minimal substance + uniqueness only.
+func checkSkills(diags *[]Diag, skills []SkillDoc) {
+	if len(skills) == 0 {
+		return
+	}
+	// Iterate in Path order for deterministic output ahead of the final sort.
+	ordered := append([]SkillDoc(nil), skills...)
+	sort.SliceStable(ordered, func(i, j int) bool { return ordered[i].Path < ordered[j].Path })
+
+	firstByName := map[string]string{} // name → first Path that declared it
+	for _, s := range ordered {
+		name := strings.TrimSpace(s.Name)
+		desc := strings.TrimSpace(s.Description)
+
+		if name == "" {
+			*diags = append(*diags, Diag{
+				Code:     DiagSkillNameMissing,
+				Severity: SeverityWarning,
+				Field:    s.Path,
+				Message:  "skill has no `name:` frontmatter; it is undiscoverable by name once mirrored into .claude/skills/",
+				Hint:     "add `name: <kebab-case-id>` to the skill's frontmatter",
+			})
+		} else if prev, dup := firstByName[name]; dup {
+			*diags = append(*diags, Diag{
+				Code:     DiagSkillNameDuplicate,
+				Severity: SeverityWarning,
+				Field:    s.Path,
+				Message:  fmt.Sprintf("skill name %q is already declared by %s; one silently clobbers the other when mirrored into .claude/skills/", name, prev),
+				Hint:     "give each skill a unique name:",
+			})
+		} else {
+			firstByName[name] = s.Path
+		}
+
+		switch {
+		case desc == "":
+			*diags = append(*diags, Diag{
+				Code:     DiagSkillDescriptionMissing,
+				Severity: SeverityWarning,
+				Field:    s.Path,
+				Message:  "skill has no `description:` frontmatter; the router has no signal for when to select it",
+				Hint:     "add a `description:` saying what the skill is for and when it applies",
+			})
+		case len(desc) < minRoutableDescription:
+			*diags = append(*diags, Diag{
+				Code:     DiagSkillDescriptionTerse,
+				Severity: SeverityWarning,
+				Field:    s.Path,
+				Message:  fmt.Sprintf("skill `description:` (%q) is too short to route on", desc),
+				Hint:     "describe what the skill does and the situation it applies to, so the router can choose it",
+			})
+		}
+	}
 }
 
 // usesPerBotMemory reports whether any node opts into per-bot memory.

--- a/pkg/bundlelint/lint_test.go
+++ b/pkg/bundlelint/lint_test.go
@@ -309,3 +309,59 @@ func TestDeterministicOrder(t *testing.T) {
 		}
 	}
 }
+
+// TestCheckSkills covers the routability lint (C231–C234): missing name,
+// missing/terse description, and duplicate names — all warnings, no prose-style
+// rules. A well-formed skill set produces nothing.
+func TestCheckSkills(t *testing.T) {
+	cases := []struct {
+		name   string
+		skills []bundlelint.SkillDoc
+		want   []string
+	}{
+		{
+			name: "clean set — no diagnostics",
+			skills: []bundlelint.SkillDoc{
+				{Path: "skills/repo-survey.md", Name: "repo-survey", Description: "Survey a repository to map its layout, stack, and conventions."},
+				{Path: "skills/roadmap.md", Name: "roadmap", Description: "Synthesize a prioritized roadmap from the collected findings."},
+			},
+			want: nil,
+		},
+		{
+			name:   "missing name",
+			skills: []bundlelint.SkillDoc{{Path: "skills/x.md", Description: "A description long enough to route on cleanly."}},
+			want:   []string{"C231"},
+		},
+		{
+			name:   "missing description",
+			skills: []bundlelint.SkillDoc{{Path: "skills/x.md", Name: "x"}},
+			want:   []string{"C232"},
+		},
+		{
+			name:   "terse description",
+			skills: []bundlelint.SkillDoc{{Path: "skills/x.md", Name: "x", Description: "Security stuff"}},
+			want:   []string{"C233"},
+		},
+		{
+			name: "duplicate name",
+			skills: []bundlelint.SkillDoc{
+				{Path: "skills/a.md", Name: "dup", Description: "First skill with a routable description."},
+				{Path: "skills/b.md", Name: "dup", Description: "Second skill with a routable description."},
+			},
+			want: []string{"C234"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Manifest is required (CheckConsistency returns nil without it);
+			// the skill checks are independent of the workflow.
+			got := codesOf(bundlelint.CheckConsistency(bundlelint.Input{
+				Manifest: &bundle.Manifest{Name: "b"},
+				Skills:   tc.skills,
+			}))
+			if !eqCodes(got, tc.want) {
+				t.Errorf("codes = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/dsl/parser"
 	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/skilllib"
 )
 
 // ValidateResult holds the outcome of a validate command.
@@ -136,6 +137,7 @@ func RunValidate(path string, p *Printer) error {
 			Workflow:    cr.Workflow,
 			Frontmatter: bundle.ParseFrontmatter(src), // reuse the bytes already read
 			DirName:     bundleDir,
+			Skills:      scanBundleSkills(bundleHandle.SkillsDir),
 		})
 		for _, d := range diags {
 			result.BundleDiagnostics = append(result.BundleDiagnostics, d.Error())
@@ -178,4 +180,38 @@ func RunValidate(path string, p *Printer) error {
 		return fmt.Errorf("validation failed")
 	}
 	return nil
+}
+
+// scanBundleSkills reads a bundle's skills/*.md frontmatter (name +
+// description) for the routability lint (C231–C234), using the shared
+// skilllib parser so it never drifts from run-time discovery. An empty or
+// missing dir yields no docs (the checks then no-op). Non-.md entries and
+// unreadable files are skipped silently — the lint judges routability of the
+// skills that exist, not filesystem health.
+func scanBundleSkills(skillsDir string) []bundlelint.SkillDoc {
+	if skillsDir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return nil
+	}
+	var docs []bundlelint.SkillDoc
+	for _, e := range entries {
+		if e.IsDir() || !strings.EqualFold(filepath.Ext(e.Name()), ".md") {
+			continue
+		}
+		f, err := os.Open(filepath.Join(skillsDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		name, desc := skilllib.ScanFrontmatter(f)
+		_ = f.Close()
+		docs = append(docs, bundlelint.SkillDoc{
+			Path:        filepath.Join(bundle.DirSkills, e.Name()),
+			Name:        name,
+			Description: desc,
+		})
+	}
+	return docs
 }

--- a/pkg/dispatcher/tracker/blockers.go
+++ b/pkg/dispatcher/tracker/blockers.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
 )
 
 // Issue-dependency gating for the external forge adapters (github / forgejo /
@@ -44,9 +46,13 @@ func ParseBlockerRefs(body string) []int {
 	if body == "" {
 		return nil
 	}
+	lines := blockerLineRe.FindAllStringSubmatch(body, -1)
+	if len(lines) == 0 {
+		return nil // common case: no dependency line — allocate nothing
+	}
 	seen := map[int]bool{}
 	var out []int
-	for _, line := range blockerLineRe.FindAllStringSubmatch(body, -1) {
+	for _, line := range lines {
 		for _, ref := range issueRefRe.FindAllStringSubmatch(line[1], -1) {
 			n, err := strconv.Atoi(ref[1])
 			if err != nil || n <= 0 || seen[n] {
@@ -78,6 +84,26 @@ func HeldByOpenBlockers(body string, openNums map[int]bool) []int {
 	}
 	sort.Ints(held)
 	return held
+}
+
+// filterHeldByBlockers returns the subset of issues free to dispatch, dropping
+// (and logging, fail-open) any whose body declares a still-open blocker in
+// openNums. Shared by all three external adapters so the hold semantics + log
+// wording live in one place; adapter names the source ("github"/"forgejo"/
+// "gitlab") for the log line. A nil logger is tolerated.
+func filterHeldByBlockers(issues []Issue, openNums map[int]bool, logger *iterlog.Logger, adapter string) []Issue {
+	out := make([]Issue, 0, len(issues))
+	for _, iss := range issues {
+		if held := HeldByOpenBlockers(iss.Body, openNums); len(held) > 0 {
+			if logger != nil {
+				logger.Info("%s tracker: holding %s — declared open blocker(s) %s not yet closed",
+					adapter, iss.Identifier, formatIssueRefs(held))
+			}
+			continue
+		}
+		out = append(out, iss)
+	}
+	return out
 }
 
 // formatIssueRefs renders issue numbers as "#a, #b" for a log line.

--- a/pkg/dispatcher/tracker/blockers.go
+++ b/pkg/dispatcher/tracker/blockers.go
@@ -22,18 +22,24 @@ import (
 //
 //   - FAIL-OPEN. A blocker is "unsatisfied" only when we can positively see it
 //     is still open (its number is in the open-issue set the adapter just
-//     fetched). A reference we cannot resolve — a typo'd number, a cross-repo
-//     ref, an issue outside the fetched set — is treated as satisfied and does
-//     NOT hold the issue. A regex mis-parse can therefore never cause an
-//     invisible stall; the worst case is under-blocking, which the operator
-//     prefers over a ticket wedged for a reason no one can see.
+//     fetched — which, when the tracker filters candidates by label, is the
+//     label-matched set: a blocker in another state/label is not seen and
+//     fails open). A reference we cannot resolve — a typo'd number, a
+//     cross-repo ref, an issue outside the fetched set — is treated as
+//     satisfied and does NOT hold the issue. The worst case is under-blocking,
+//     which the operator prefers over a ticket wedged for a reason no one can
+//     see. This is best-effort honoring of a declared dependency, not a
+//     guarantee.
 //   - SAME-REPO `#N` ONLY. Every forge writes an in-repo dependency as `#N`;
 //     cross-repo / URL forms vary and are intentionally ignored (fail-open).
 
-// blockerLineRe matches a line that opens with a dependency keyword, tolerating
-// leading markdown quote/list markers ("> Blocked by …", "- Depends on …").
-// The captured tail is then scanned for `#N` references.
-var blockerLineRe = regexp.MustCompile(`(?im)^[\s>*+-]*(?:depends on|blocked by)\b(.*)$`)
+// blockerLineRe matches a line that OPENS with a dependency keyword and is
+// IMMEDIATELY followed by a run of `#N` refs (tolerating leading markdown
+// quote/list markers and an optional ":"). Group 1 is that refs run. Requiring
+// the refs to lead keeps the "under-block only" property: a line like
+// "Blocked by a design call, see #42" does NOT match (prose, not a ref, follows
+// the keyword), so a stray `#N` elsewhere never over-blocks.
+var blockerLineRe = regexp.MustCompile(`(?im)^[\s>*+-]*(?:depends on|blocked by)[:\s]+(#\d+(?:[\s,]+(?:and[\s,]+)?#\d+)*)`)
 
 // issueRefRe matches a same-repo issue reference `#N`.
 var issueRefRe = regexp.MustCompile(`#(\d+)`)

--- a/pkg/dispatcher/tracker/blockers.go
+++ b/pkg/dispatcher/tracker/blockers.go
@@ -1,0 +1,90 @@
+package tracker
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Issue-dependency gating for the external forge adapters (github / forgejo /
+// gitlab). The native tracker already models hard blockers richly
+// (pkg/dispatcher/native/blockers.go); the external adapters leave
+// Issue.Blockers empty, so a forge issue that declares "Blocked by #41" in its
+// body is dispatched anyway. These helpers let each adapter honor that
+// user-declared dependency by parsing the body and holding an issue whose
+// blocker is still open.
+//
+// Two deliberate design choices, both to avoid the failure mode the operator
+// cares about most — an issue that silently never dispatches:
+//
+//   - FAIL-OPEN. A blocker is "unsatisfied" only when we can positively see it
+//     is still open (its number is in the open-issue set the adapter just
+//     fetched). A reference we cannot resolve — a typo'd number, a cross-repo
+//     ref, an issue outside the fetched set — is treated as satisfied and does
+//     NOT hold the issue. A regex mis-parse can therefore never cause an
+//     invisible stall; the worst case is under-blocking, which the operator
+//     prefers over a ticket wedged for a reason no one can see.
+//   - SAME-REPO `#N` ONLY. Every forge writes an in-repo dependency as `#N`;
+//     cross-repo / URL forms vary and are intentionally ignored (fail-open).
+
+// blockerLineRe matches a line that opens with a dependency keyword, tolerating
+// leading markdown quote/list markers ("> Blocked by …", "- Depends on …").
+// The captured tail is then scanned for `#N` references.
+var blockerLineRe = regexp.MustCompile(`(?im)^[\s>*+-]*(?:depends on|blocked by)\b(.*)$`)
+
+// issueRefRe matches a same-repo issue reference `#N`.
+var issueRefRe = regexp.MustCompile(`#(\d+)`)
+
+// ParseBlockerRefs extracts the same-repo issue numbers a body declares as hard
+// dependencies via "Depends on #N" / "Blocked by #N" lines (case-insensitive,
+// one or more refs per line). Order-preserving and de-duplicated. Returns nil
+// when the body declares none.
+func ParseBlockerRefs(body string) []int {
+	if body == "" {
+		return nil
+	}
+	seen := map[int]bool{}
+	var out []int
+	for _, line := range blockerLineRe.FindAllStringSubmatch(body, -1) {
+		for _, ref := range issueRefRe.FindAllStringSubmatch(line[1], -1) {
+			n, err := strconv.Atoi(ref[1])
+			if err != nil || n <= 0 || seen[n] {
+				continue
+			}
+			seen[n] = true
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// HeldByOpenBlockers returns the sorted subset of a body's declared blocker
+// refs that are still open (present in openNums) — the reasons the issue must
+// be held this scan. An empty result means the issue is free to dispatch
+// (either it declares no blockers, or every declared blocker is satisfied /
+// unresolvable — fail-open). openNums is the set of issue numbers the adapter
+// observed open in the same repo this poll.
+func HeldByOpenBlockers(body string, openNums map[int]bool) []int {
+	refs := ParseBlockerRefs(body)
+	if len(refs) == 0 {
+		return nil
+	}
+	var held []int
+	for _, n := range refs {
+		if openNums[n] {
+			held = append(held, n)
+		}
+	}
+	sort.Ints(held)
+	return held
+}
+
+// formatIssueRefs renders issue numbers as "#a, #b" for a log line.
+func formatIssueRefs(nums []int) string {
+	parts := make([]string, len(nums))
+	for i, n := range nums {
+		parts[i] = "#" + strconv.Itoa(n)
+	}
+	return strings.Join(parts, ", ")
+}

--- a/pkg/dispatcher/tracker/blockers_test.go
+++ b/pkg/dispatcher/tracker/blockers_test.go
@@ -1,0 +1,55 @@
+package tracker
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseBlockerRefs(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want []int
+	}{
+		{"none", "Just a normal issue body with no deps.", nil},
+		{"blocked by single", "Blocked by #41\n", []int{41}},
+		{"depends on single", "Depends on #7", []int{7}},
+		{"case-insensitive", "BLOCKED BY #9", []int{9}},
+		{"multiple refs one line", "Blocked by #1, #2 and #3", []int{1, 2, 3}},
+		{"multiple lines dedup", "Blocked by #5\nDepends on #5\nDepends on #6", []int{5, 6}},
+		{"markdown markers", "> Blocked by #12\n- Depends on #13", []int{12, 13}},
+		{"mid-sentence is ignored", "This is not blocked by anything really", nil},
+		{"keyword without ref", "Blocked by a design decision", nil},
+		{"ref elsewhere ignored", "See #99 for context.\nCloses #100", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ParseBlockerRefs(tc.body); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ParseBlockerRefs(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHeldByOpenBlockers(t *testing.T) {
+	open := map[int]bool{41: true, 42: true} // #41,#42 still open; #40 closed/absent
+
+	cases := []struct {
+		name string
+		body string
+		want []int
+	}{
+		{"no blockers", "nothing here", nil},
+		{"open blocker holds", "Blocked by #41", []int{41}},
+		{"closed blocker frees (fail-open)", "Blocked by #40", nil},
+		{"unresolvable ref frees (fail-open)", "Blocked by #9999", nil},
+		{"mix — only open ones held, sorted", "Blocked by #42\nDepends on #40, #41", []int{41, 42}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HeldByOpenBlockers(tc.body, open); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("HeldByOpenBlockers(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/dispatcher/tracker/blockers_test.go
+++ b/pkg/dispatcher/tracker/blockers_test.go
@@ -20,7 +20,10 @@ func TestParseBlockerRefs(t *testing.T) {
 		{"markdown markers", "> Blocked by #12\n- Depends on #13", []int{12, 13}},
 		{"mid-sentence is ignored", "This is not blocked by anything really", nil},
 		{"keyword without ref", "Blocked by a design decision", nil},
+		{"keyword then prose then ref does not over-block", "Blocked by a design call, see #42", nil},
+		{"ref must lead — trailing prose ref ignored", "Blocked by #7 because of the schema #999", []int{7}},
 		{"ref elsewhere ignored", "See #99 for context.\nCloses #100", nil},
+		{"colon separator", "Blocked by: #8", []int{8}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/dispatcher/tracker/forgejo.go
+++ b/pkg/dispatcher/tracker/forgejo.go
@@ -79,7 +79,8 @@ func (a *ForgejoAdapter) Name() string { return "forgejo" }
 // negative-label search in the same syntax as GitHub).
 func (a *ForgejoAdapter) ListCandidates(ctx context.Context) ([]Issue, error) {
 	const pageSize = 50
-	out := make([]Issue, 0)
+	var pending []Issue
+	openNums := map[int]bool{} // all open issues seen — fail-open blocker set
 	err := paginateUntilShort(pageSize, 100, a.opts.Logger,
 		fmt.Sprintf("forgejo tracker: ListCandidates hit the 100-page cap on repo %s — beyond this point issues are silently dropped from dispatch; consider tightening label filters", a.opts.Repo),
 		func(page int) (int, error) {
@@ -98,6 +99,7 @@ func (a *ForgejoAdapter) ListCandidates(ctx context.Context) ([]Issue, error) {
 				return 0, err
 			}
 			for _, r := range raw {
+				openNums[r.Number] = true
 				labels := labelNames(r.Labels)
 				if anyOfString(labels, a.opts.ExcludeLabels) {
 					continue
@@ -109,12 +111,25 @@ func (a *ForgejoAdapter) ListCandidates(ctx context.Context) ([]Issue, error) {
 				if iss.WorkflowState == "" {
 					continue
 				}
-				out = append(out, iss)
+				pending = append(pending, iss)
 			}
 			return len(raw), nil
 		})
 	if err != nil {
 		return nil, err
+	}
+	// Second pass (after every page is in openNums): hold any issue whose
+	// body declares a still-open blocker. Fail-open — see blockers.go.
+	out := make([]Issue, 0, len(pending))
+	for _, iss := range pending {
+		if held := HeldByOpenBlockers(iss.Body, openNums); len(held) > 0 {
+			if a.opts.Logger != nil {
+				a.opts.Logger.Info("forgejo tracker: holding %s — declared open blocker(s) %s not yet closed",
+					iss.Identifier, formatIssueRefs(held))
+			}
+			continue
+		}
+		out = append(out, iss)
 	}
 	return out, nil
 }

--- a/pkg/dispatcher/tracker/forgejo.go
+++ b/pkg/dispatcher/tracker/forgejo.go
@@ -120,18 +120,7 @@ func (a *ForgejoAdapter) ListCandidates(ctx context.Context) ([]Issue, error) {
 	}
 	// Second pass (after every page is in openNums): hold any issue whose
 	// body declares a still-open blocker. Fail-open — see blockers.go.
-	out := make([]Issue, 0, len(pending))
-	for _, iss := range pending {
-		if held := HeldByOpenBlockers(iss.Body, openNums); len(held) > 0 {
-			if a.opts.Logger != nil {
-				a.opts.Logger.Info("forgejo tracker: holding %s — declared open blocker(s) %s not yet closed",
-					iss.Identifier, formatIssueRefs(held))
-			}
-			continue
-		}
-		out = append(out, iss)
-	}
-	return out, nil
+	return filterHeldByBlockers(pending, openNums, a.opts.Logger, "forgejo"), nil
 }
 
 // RefreshStates fetches each issue and re-derives its state from

--- a/pkg/dispatcher/tracker/github.go
+++ b/pkg/dispatcher/tracker/github.go
@@ -122,6 +122,12 @@ func (a *GitHubAdapter) ListCandidates(ctx context.Context) ([]Issue, error) {
 		a.opts.Logger.Warn("github tracker: ListCandidates hit the %d-issue cap on repo %s — beyond this point issues are silently dropped from dispatch; consider tightening label filters",
 			ghCandidateListLimit, a.opts.Repo)
 	}
+	// Open-issue set for fail-open blocker resolution (all open issues this
+	// list returned, before eligibility filtering).
+	openNums := make(map[int]bool, len(raw))
+	for _, r := range raw {
+		openNums[r.Number] = true
+	}
 	out2 := make([]Issue, 0, len(raw))
 	for _, r := range raw {
 		if !a.authorAllowed(r.Author.Login) {
@@ -130,6 +136,13 @@ func (a *GitHubAdapter) ListCandidates(ctx context.Context) ([]Issue, error) {
 		iss := a.toIssue(r)
 		if iss.WorkflowState == "" {
 			continue // doesn't match any configured state
+		}
+		if held := HeldByOpenBlockers(r.Body, openNums); len(held) > 0 {
+			if a.opts.Logger != nil {
+				a.opts.Logger.Info("github tracker: holding %s — declared open blocker(s) %s not yet closed",
+					iss.Identifier, formatIssueRefs(held))
+			}
+			continue // honor the issue's own "Blocked by/Depends on #N"
 		}
 		out2 = append(out2, iss)
 	}

--- a/pkg/dispatcher/tracker/github.go
+++ b/pkg/dispatcher/tracker/github.go
@@ -128,7 +128,7 @@ func (a *GitHubAdapter) ListCandidates(ctx context.Context) ([]Issue, error) {
 	for _, r := range raw {
 		openNums[r.Number] = true
 	}
-	out2 := make([]Issue, 0, len(raw))
+	pending := make([]Issue, 0, len(raw))
 	for _, r := range raw {
 		if !a.authorAllowed(r.Author.Login) {
 			continue // author not in the trusted-author allowlist
@@ -137,16 +137,10 @@ func (a *GitHubAdapter) ListCandidates(ctx context.Context) ([]Issue, error) {
 		if iss.WorkflowState == "" {
 			continue // doesn't match any configured state
 		}
-		if held := HeldByOpenBlockers(r.Body, openNums); len(held) > 0 {
-			if a.opts.Logger != nil {
-				a.opts.Logger.Info("github tracker: holding %s — declared open blocker(s) %s not yet closed",
-					iss.Identifier, formatIssueRefs(held))
-			}
-			continue // honor the issue's own "Blocked by/Depends on #N"
-		}
-		out2 = append(out2, iss)
+		pending = append(pending, iss)
 	}
-	return out2, nil
+	// Hold any issue whose body declares a still-open blocker (fail-open).
+	return filterHeldByBlockers(pending, openNums, a.opts.Logger, "github"), nil
 }
 
 // authorAllowed reports whether an issue author passes AuthorAllowlist

--- a/pkg/dispatcher/tracker/github.go
+++ b/pkg/dispatcher/tracker/github.go
@@ -130,6 +130,9 @@ func (a *GitHubAdapter) ListCandidates(ctx context.Context) ([]Issue, error) {
 	}
 	pending := make([]Issue, 0, len(raw))
 	for _, r := range raw {
+		if ghHasLabel(r.Labels, a.opts.ClaimedLabel) {
+			continue // already claimed by a dispatcher — not a candidate
+		}
 		if !a.authorAllowed(r.Author.Login) {
 			continue // author not in the trusted-author allowlist
 		}
@@ -390,6 +393,19 @@ type ghLabel struct {
 	Name string `json:"name"`
 }
 
+// ghHasLabel reports whether the issue carries the named label.
+func ghHasLabel(labels []ghLabel, want string) bool {
+	if want == "" {
+		return false
+	}
+	for _, l := range labels {
+		if l.Name == want {
+			return true
+		}
+	}
+	return false
+}
+
 type ghUser struct {
 	Login string `json:"login"`
 }
@@ -445,7 +461,11 @@ func buildSearch(opts GitHubOptions) string {
 	for _, l := range opts.ExcludeLabels {
 		parts = append(parts, "-label:"+quoteLabel(l))
 	}
-	parts = append(parts, "-label:"+quoteLabel(opts.ClaimedLabel))
+	// The claimed label is filtered CLIENT-side (ListCandidates), not here.
+	// Excluding it server-side would also drop claimed issues from the
+	// open-issue set the dependency gate resolves blockers against — so an
+	// issue "Blocked by #7" would dispatch the moment #7 was claimed, i.e.
+	// exactly while it is being implemented. Matches gitlab.go / forgejo.go.
 	return strings.Join(parts, " ")
 }
 

--- a/pkg/dispatcher/tracker/github_test.go
+++ b/pkg/dispatcher/tracker/github_test.go
@@ -254,7 +254,7 @@ func TestGitHubListCandidatesBlockers(t *testing.T) {
 	t.Run("held while blocker open", func(t *testing.T) {
 		blocker := map[string]any{
 			"number": 7, "title": "create schema", "state": "open",
-			"labels": []map[string]string{{"name": "wip"}},
+			"labels":    []map[string]string{{"name": "wip"}},
 			"createdAt": "2026-05-01T00:00:00Z", "updatedAt": "2026-05-01T00:00:00Z",
 			"url": "https://github.com/owner/repo/issues/7",
 		}

--- a/pkg/dispatcher/tracker/github_test.go
+++ b/pkg/dispatcher/tracker/github_test.go
@@ -238,3 +238,45 @@ func contains(args []string, want string) bool {
 	}
 	return false
 }
+
+// TestGitHubListCandidatesBlockers proves the body-declared dependency gate:
+// a "Blocked by #N" issue is held while #N is open, and dispatched once #N is
+// gone (fail-open — an unresolvable ref never stalls the issue).
+func TestGitHubListCandidatesBlockers(t *testing.T) {
+	mapping := map[string]tracker.LabelSelector{"ready": {LabelsInclude: []string{"ready"}}}
+	dependent := map[string]any{
+		"number": 42, "title": "needs the schema", "body": "Blocked by #7",
+		"state": "open", "labels": []map[string]string{{"name": "ready"}},
+		"createdAt": "2026-05-01T00:00:00Z", "updatedAt": "2026-05-01T00:00:00Z",
+		"url": "https://github.com/owner/repo/issues/42",
+	}
+
+	t.Run("held while blocker open", func(t *testing.T) {
+		blocker := map[string]any{
+			"number": 7, "title": "create schema", "state": "open",
+			"labels": []map[string]string{{"name": "wip"}},
+			"createdAt": "2026-05-01T00:00:00Z", "updatedAt": "2026-05-01T00:00:00Z",
+			"url": "https://github.com/owner/repo/issues/7",
+		}
+		fake := &fakeGH{listOut: mustJSON([]map[string]any{dependent, blocker})}
+		got, err := newGHAdapter(t, fake, mapping).ListCandidates(context.Background())
+		if err != nil {
+			t.Fatalf("ListCandidates: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("want 0 (issue #42 held by open #7), got %d: %+v", len(got), got)
+		}
+	})
+
+	t.Run("dispatched when blocker gone (fail-open)", func(t *testing.T) {
+		// #7 is not in the open set → treated as closed/satisfied.
+		fake := &fakeGH{listOut: mustJSON([]map[string]any{dependent})}
+		got, err := newGHAdapter(t, fake, mapping).ListCandidates(context.Background())
+		if err != nil {
+			t.Fatalf("ListCandidates: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != "github:owner/repo#42" {
+			t.Fatalf("want #42 dispatched, got %+v", got)
+		}
+	})
+}

--- a/pkg/dispatcher/tracker/github_test.go
+++ b/pkg/dispatcher/tracker/github_test.go
@@ -116,8 +116,48 @@ func TestGitHubListCandidates(t *testing.T) {
 	if got[0].Metadata["url"] != "https://github.com/owner/repo/issues/42" {
 		t.Fatalf("url metadata: %s", got[0].Metadata["url"])
 	}
-	if !strings.Contains(strings.Join(fake.calls[0], " "), "-label:iterion-claimed") {
-		t.Fatalf("expected default claim filter in search: %v", fake.calls[0])
+	// The claim filter is deliberately NOT server-side: excluding it from the
+	// search would also hide claimed issues from the open-issue set the
+	// dependency gate resolves blockers against. Filtered client-side instead.
+	if strings.Contains(strings.Join(fake.calls[0], " "), "-label:iterion-claimed") {
+		t.Fatalf("claim filter must not be server-side (it would hide in-flight blockers): %v", fake.calls[0])
+	}
+}
+
+// A claimed issue is being implemented RIGHT NOW, which is the single case a
+// dependency gate exists for. Excluding claimed issues server-side dropped
+// them from openNums, so HeldByOpenBlockers treated the blocker as satisfied
+// and released the dependent issue exactly then.
+func TestGitHubClaimedIssueStillHoldsItsDependents(t *testing.T) {
+	fake := &fakeGH{
+		listOut: mustJSON([]map[string]any{
+			{
+				"number": 7, "title": "the blocker", "state": "OPEN",
+				"labels":    []map[string]string{{"name": "ready"}, {"name": "iterion-claimed"}},
+				"createdAt": "2026-05-01T00:00:00Z", "updatedAt": "2026-05-01T00:00:00Z",
+			},
+			{
+				"number": 42, "title": "the dependent", "body": "Blocked by #7", "state": "OPEN",
+				"labels":    []map[string]string{{"name": "ready"}},
+				"createdAt": "2026-05-01T00:00:00Z", "updatedAt": "2026-05-01T00:00:00Z",
+			},
+		}),
+	}
+	a := newGHAdapter(t, fake, map[string]tracker.LabelSelector{
+		"ready": {LabelsInclude: []string{"ready"}},
+	})
+	got, err := a.ListCandidates(context.Background())
+	if err != nil {
+		t.Fatalf("ListCandidates: %v", err)
+	}
+	// The claimed blocker is not a candidate itself, and it holds #42.
+	for _, iss := range got {
+		if strings.HasSuffix(iss.ID, "#7") {
+			t.Errorf("a claimed issue must not be a candidate: %s", iss.ID)
+		}
+		if strings.HasSuffix(iss.ID, "#42") {
+			t.Errorf("dependent dispatched while its blocker #7 is in flight: %s", iss.ID)
+		}
 	}
 }
 

--- a/pkg/dispatcher/tracker/gitlab.go
+++ b/pkg/dispatcher/tracker/gitlab.go
@@ -124,18 +124,7 @@ func (a *GitLabAdapter) ListCandidates(ctx context.Context) ([]Issue, error) {
 	}
 	// Second pass (after every page is in openNums): hold any issue whose
 	// body declares a still-open blocker (`#IID`). Fail-open — see blockers.go.
-	out := make([]Issue, 0, len(pending))
-	for _, iss := range pending {
-		if held := HeldByOpenBlockers(iss.Body, openNums); len(held) > 0 {
-			if a.opts.Logger != nil {
-				a.opts.Logger.Info("gitlab tracker: holding %s — declared open blocker(s) %s not yet closed",
-					iss.Identifier, formatIssueRefs(held))
-			}
-			continue
-		}
-		out = append(out, iss)
-	}
-	return out, nil
+	return filterHeldByBlockers(pending, openNums, a.opts.Logger, "gitlab"), nil
 }
 
 // RefreshStates fetches each issue and re-derives its state from current

--- a/pkg/dispatcher/tracker/gitlab.go
+++ b/pkg/dispatcher/tracker/gitlab.go
@@ -85,7 +85,8 @@ func (a *GitLabAdapter) Name() string { return "gitlab" }
 // claimed-skip run locally.
 func (a *GitLabAdapter) ListCandidates(ctx context.Context) ([]Issue, error) {
 	const pageSize = 50
-	out := make([]Issue, 0)
+	var pending []Issue
+	openNums := map[int]bool{} // all open issues seen (by IID) — fail-open set
 	err := paginateUntilShort(pageSize, 100, a.opts.Logger,
 		fmt.Sprintf("gitlab tracker: ListCandidates hit the 100-page cap on repo %s — beyond this point issues are silently dropped from dispatch; consider tightening label filters", a.opts.Repo),
 		func(page int) (int, error) {
@@ -103,6 +104,7 @@ func (a *GitLabAdapter) ListCandidates(ctx context.Context) ([]Issue, error) {
 				return 0, err
 			}
 			for _, r := range raw {
+				openNums[r.IID] = true
 				if anyOfString(r.Labels, a.opts.ExcludeLabels) {
 					continue
 				}
@@ -113,12 +115,25 @@ func (a *GitLabAdapter) ListCandidates(ctx context.Context) ([]Issue, error) {
 				if iss.WorkflowState == "" {
 					continue
 				}
-				out = append(out, iss)
+				pending = append(pending, iss)
 			}
 			return len(raw), nil
 		})
 	if err != nil {
 		return nil, err
+	}
+	// Second pass (after every page is in openNums): hold any issue whose
+	// body declares a still-open blocker (`#IID`). Fail-open — see blockers.go.
+	out := make([]Issue, 0, len(pending))
+	for _, iss := range pending {
+		if held := HeldByOpenBlockers(iss.Body, openNums); len(held) > 0 {
+			if a.opts.Logger != nil {
+				a.opts.Logger.Info("gitlab tracker: holding %s — declared open blocker(s) %s not yet closed",
+					iss.Identifier, formatIssueRefs(held))
+			}
+			continue
+		}
+		out = append(out, iss)
 	}
 	return out, nil
 }

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -118,6 +118,25 @@ func applyWebhookVarLayers(vars map[string]string, cfg webhooks.Config) map[stri
 	return vars
 }
 
+// suppressedByHoldLabel applies the bot-agnostic hold-label veto shared by
+// every AUTO-launch lane (GitHub/Forgejo/GitLab, PR/MR + issue): if the
+// triggering entity carries a configured hold label, it records a filtered
+// delivery, writes a 200, and returns true so the caller returns without
+// launching — whatever bot would have run. Opt-in (empty HoldLabels = off) and
+// fail-open (a payload without the label set is never suppressed). The human
+// `/command` lanes deliberately do NOT call this — the label pauses automation,
+// not a deliberate manual trigger.
+func (s *Server) suppressedByHoldLabel(ctx context.Context, w http.ResponseWriter, cfg webhooks.Config, meta webhookEventMeta, labels []string, payloadHash, srcIP string) bool {
+	held := webhooks.HeldByLabel(cfg.HoldLabels, labels)
+	if held == "" {
+		return false
+	}
+	s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP,
+		`held: carries hold label "`+held+`" — automation suppressed (remove the label, or trigger a bot manually via a command)`)
+	writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+	return true
+}
+
 // mergeVarsInto copies every key from src into dst (overwriting on
 // collision) and returns dst. A nil src is a no-op. Used by the
 // webhook launch-vars builders to layer overlays (context vars,

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -101,6 +101,19 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 		return
 	}
 
+	// Hold-label gate (bot-agnostic, opt-in): if the PR carries a configured
+	// hold label, suppress EVERY auto-launch this handler can do (auto-heal and
+	// review alike) — the operator's escape hatch to pause automation on one PR
+	// without disabling the webhook. Placed before any launch decision so it
+	// vetoes all of them; fail-open (no HoldLabels / no labels in payload = no
+	// effect). A human can still trigger a bot manually via a `/command`.
+	if held := webhooks.HeldByLabel(cfg.HoldLabels, p.Labels); held != "" {
+		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP,
+			`held: PR carries hold label "`+held+`" — automation suppressed (remove the label, or trigger a bot manually via a command)`)
+		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+		return
+	}
+
 	// Merge-queue auto-heal: a PR ejected from the queue for a conflict or a
 	// combined-build failure (`dequeued` with a healable reason) is
 	// dispatched to the branch-improvement bot (Billy) to rebase on the base,
@@ -210,6 +223,17 @@ func (s *Server) handleGitHubIssues(w http.ResponseWriter, r *http.Request, cfg 
 		!webhooks.MatchEvent(cfg.EventAllowlist, "issues", "issues") ||
 		!webhooks.MatchProject(cfg.ProjectAllowlist, p.ProjectPath) {
 		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, "")
+		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+		return
+	}
+
+	// Hold-label gate (bot-agnostic, opt-in): a configured hold label on the
+	// issue suppresses the auto-launch (labeled + zero-touch alike), whatever
+	// bot would run. Fail-open; a human can still apply the trigger label after
+	// removing the hold. See the PR handler for the rationale.
+	if held := webhooks.HeldByLabel(cfg.HoldLabels, p.IssueLabels); held != "" {
+		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP,
+			`held: issue carries hold label "`+held+`" — automation suppressed (remove the label to re-enable)`)
 		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
 		return
 	}

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -101,16 +101,12 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 		return
 	}
 
-	// Hold-label gate (bot-agnostic, opt-in): if the PR carries a configured
-	// hold label, suppress EVERY auto-launch this handler can do (auto-heal and
-	// review alike) — the operator's escape hatch to pause automation on one PR
-	// without disabling the webhook. Placed before any launch decision so it
-	// vetoes all of them; fail-open (no HoldLabels / no labels in payload = no
-	// effect). A human can still trigger a bot manually via a `/command`.
-	if held := webhooks.HeldByLabel(cfg.HoldLabels, p.Labels); held != "" {
-		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP,
-			`held: PR carries hold label "`+held+`" — automation suppressed (remove the label, or trigger a bot manually via a command)`)
-		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+	// Hold-label gate (bot-agnostic, opt-in): a configured hold label on the PR
+	// vetoes EVERY auto-launch this handler can do (auto-heal and review alike)
+	// — the operator's escape hatch to pause automation on one PR. Placed before
+	// any launch decision so it covers all of them. A human can still trigger a
+	// bot manually via a `/command`.
+	if s.suppressedByHoldLabel(ctx, w, cfg, meta, p.Labels, payloadHash, srcIP) {
 		return
 	}
 
@@ -228,13 +224,9 @@ func (s *Server) handleGitHubIssues(w http.ResponseWriter, r *http.Request, cfg 
 	}
 
 	// Hold-label gate (bot-agnostic, opt-in): a configured hold label on the
-	// issue suppresses the auto-launch (labeled + zero-touch alike), whatever
-	// bot would run. Fail-open; a human can still apply the trigger label after
-	// removing the hold. See the PR handler for the rationale.
-	if held := webhooks.HeldByLabel(cfg.HoldLabels, p.IssueLabels); held != "" {
-		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP,
-			`held: issue carries hold label "`+held+`" — automation suppressed (remove the label to re-enable)`)
-		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+	// issue vetoes the auto-launch (labeled + zero-touch alike). See the PR
+	// handler for the rationale.
+	if s.suppressedByHoldLabel(ctx, w, cfg, meta, p.IssueLabels, payloadHash, srcIP) {
 		return
 	}
 

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -98,6 +98,12 @@ func (s *Server) handleGitLabMergeRequestEvent(ctx context.Context, w http.Respo
 		return
 	}
 
+	// Hold-label gate (bot-agnostic, opt-in): a configured hold label on the MR
+	// vetoes the auto-review. Same escape hatch as the GitHub PR path.
+	if s.suppressedByHoldLabel(ctx, w, cfg, meta, p.Labels, payloadHash, srcIP) {
+		return
+	}
+
 	// Iterion-bot guard: an MR opened by iterion's own forge bot already
 	// converged in its own loop — skip the auto-review (a human can still run
 	// `/revi`). Mirror of the GitHub PR-open path.
@@ -157,6 +163,12 @@ func (s *Server) handleGitLabIssueEvent(ctx context.Context, w http.ResponseWrit
 		!webhooks.MatchProject(cfg.ProjectAllowlist, p.ProjectPath) {
 		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, "")
 		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+		return
+	}
+
+	// Hold-label gate (bot-agnostic, opt-in): a configured hold label on the
+	// issue vetoes the labeled auto-launch. Same escape hatch as GitHub.
+	if s.suppressedByHoldLabel(ctx, w, cfg, meta, p.Labels, payloadHash, srcIP) {
 		return
 	}
 

--- a/pkg/server/webhooks_routes.go
+++ b/pkg/server/webhooks_routes.go
@@ -50,6 +50,7 @@ type webhookConfigReq struct {
 	EventAllowlist      []string          `json:"event_allowlist,omitempty"`
 	AuthorAllowlist     []string          `json:"author_allowlist,omitempty"`
 	LabelAllowlist      []string          `json:"label_allowlist,omitempty"`
+	HoldLabels          []string          `json:"hold_labels,omitempty"`
 	BlockForkPRs        *bool             `json:"block_fork_prs,omitempty"`
 	ReviewOnSync        *bool             `json:"review_on_sync,omitempty"`
 	Overlap             *string           `json:"overlap,omitempty"`
@@ -259,6 +260,7 @@ func (s *Server) handleCreateWebhook(w http.ResponseWriter, r *http.Request) {
 		EventAllowlist:      req.EventAllowlist,
 		AuthorAllowlist:     req.AuthorAllowlist,
 		LabelAllowlist:      req.LabelAllowlist,
+		HoldLabels:          req.HoldLabels,
 		BlockForkPRs:        req.BlockForkPRs != nil && *req.BlockForkPRs,
 		ReviewOnSync:        req.ReviewOnSync != nil && *req.ReviewOnSync,
 		Overlap:             overlapOrEmpty(req.Overlap),
@@ -425,6 +427,11 @@ func (s *Server) handleUpdateWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.LabelAllowlist != nil {
 		cfg.LabelAllowlist = req.LabelAllowlist
+	}
+	// A non-nil empty slice is how the operator turns the hold off again —
+	// distinct from the field being absent, which leaves it untouched.
+	if req.HoldLabels != nil {
+		cfg.HoldLabels = req.HoldLabels
 	}
 	if req.ReviewOnSync != nil {
 		cfg.ReviewOnSync = *req.ReviewOnSync

--- a/pkg/server/webhooks_routes_test.go
+++ b/pkg/server/webhooks_routes_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -407,5 +408,79 @@ func TestWebhookAuth_DisabledAndRateLimitAndQuota(t *testing.T) {
 	}
 	if code, _, _, _ := runWebhookAuth(s, "mq", pt3); code != http.StatusTooManyRequests {
 		t.Fatalf("mq second should be 429 (monthly quota): code=%d", code)
+	}
+}
+
+// TestWebhookHoldLabelsRoundTrip pins the config INGRESS for hold_labels.
+//
+// The suppression matcher, the four wired lanes and the docs were all correct,
+// but the field was declared on webhooks.Config and read by
+// suppressedByHoldLabel while nothing ever WROTE it: not the create builder,
+// not the PATCH applier, not the forge provisioning path. HeldByLabel
+// short-circuits on an empty set, so the operator's documented escape hatch to
+// pause automation on one PR was permanently a no-op, reachable only by a
+// direct Mongo write.
+func TestWebhookHoldLabelsRoundTrip(t *testing.T) {
+	s := newWebhookTestServer(t)
+	ctx := superAdminCtx()
+
+	w := httptest.NewRecorder()
+	body := `{"name":"gl","bot_ids":["review-pr"],"hold_labels":["iterion:hold","do-not-automate"]}`
+	s.handleCreateWebhook(w, whReq(ctx, "POST", "/api/teams/t1/webhooks", body, "t1", ""))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: code=%d body=%s", w.Code, w.Body.String())
+	}
+	var created struct {
+		Config webhooks.Config `json:"config"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if !slices.Equal(created.Config.HoldLabels, []string{"iterion:hold", "do-not-automate"}) {
+		t.Fatalf("hold_labels dropped on create: %v", created.Config.HoldLabels)
+	}
+
+	// PATCH replaces the set...
+	w = httptest.NewRecorder()
+	s.handleUpdateWebhook(w, whReq(ctx, "PATCH", "/api/teams/t1/webhooks/"+created.Config.ID,
+		`{"hold_labels":["paused"]}`, "t1", created.Config.ID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("patch: code=%d body=%s", w.Code, w.Body.String())
+	}
+	stored, err := s.webhookConfigs.Get(context.Background(), created.Config.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !slices.Equal(stored.HoldLabels, []string{"paused"}) {
+		t.Fatalf("hold_labels not applied on patch: %v", stored.HoldLabels)
+	}
+
+	// ...an omitted field leaves it untouched (a PATCH of something else must
+	// not silently unpause every held PR)...
+	w = httptest.NewRecorder()
+	s.handleUpdateWebhook(w, whReq(ctx, "PATCH", "/api/teams/t1/webhooks/"+created.Config.ID,
+		`{"name":"renamed"}`, "t1", created.Config.ID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("patch name: code=%d body=%s", w.Code, w.Body.String())
+	}
+	if stored, err = s.webhookConfigs.Get(context.Background(), created.Config.ID); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !slices.Equal(stored.HoldLabels, []string{"paused"}) {
+		t.Fatalf("an unrelated patch cleared hold_labels: %v", stored.HoldLabels)
+	}
+
+	// ...and an explicit empty list is how the hold is turned off.
+	w = httptest.NewRecorder()
+	s.handleUpdateWebhook(w, whReq(ctx, "PATCH", "/api/teams/t1/webhooks/"+created.Config.ID,
+		`{"hold_labels":[]}`, "t1", created.Config.ID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("patch clear: code=%d body=%s", w.Code, w.Body.String())
+	}
+	if stored, err = s.webhookConfigs.Get(context.Background(), created.Config.ID); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(stored.HoldLabels) != 0 {
+		t.Fatalf("hold_labels not clearable: %v", stored.HoldLabels)
 	}
 }

--- a/pkg/skilllib/frontmatter.go
+++ b/pkg/skilllib/frontmatter.go
@@ -85,11 +85,14 @@ func ScanFrontmatter(r io.Reader) (name, description string) {
 				block = append(block, "")
 				continue
 			}
-			if indent > baseIndent && trimmed != "---" {
+			// A more-indented line is block content — including one that reads
+			// "---" or "key:", which are literal text inside the scalar, not
+			// structure. Only a dedent to the key's indent (or less) ends it.
+			if indent > baseIndent {
 				block = append(block, trimmed)
 				continue
 			}
-			flushBlock() // dedent (or ---) ends the block; reprocess this line
+			flushBlock() // dedent ends the block; reprocess this line below
 		}
 		if trimmed == "---" {
 			break
@@ -103,10 +106,11 @@ func ScanFrontmatter(r io.Reader) (name, description string) {
 			continue
 		}
 		val := strings.TrimSpace(v)
-		if strings.HasPrefix(val, "|") || strings.HasPrefix(val, ">") {
-			// A block-scalar indicator opens a multi-line value (chomping/indent
-			// indicators after |/> are ignored — we only need the text). A bare
-			// empty value falls through and assigns "" like any scalar.
+		if isBlockScalarHeader(val) {
+			// A pure block-scalar header (`>`/`|` + optional chomping/indent
+			// indicator, nothing else) opens a multi-line value. `key: > text`
+			// with content on the same line is NOT a block — it falls through
+			// and is assigned as an inline scalar.
 			blockKey = key
 			fold = val[0] == '>'
 			baseIndent = len(k) - len(strings.TrimLeft(k, " \t"))
@@ -119,4 +123,20 @@ func ScanFrontmatter(r io.Reader) (name, description string) {
 	}
 	flushBlock() // frontmatter that ends at EOF mid-block
 	return name, description
+}
+
+// isBlockScalarHeader reports whether a value is a YAML block-scalar header:
+// `>` or `|`, optionally followed by a chomping indicator (`+`/`-`) and/or a
+// numeric indentation indicator, and nothing else. `> some text` (content on
+// the same line) is not a header — it is an inline value.
+func isBlockScalarHeader(val string) bool {
+	if val == "" || (val[0] != '>' && val[0] != '|') {
+		return false
+	}
+	for _, r := range val[1:] {
+		if r != '+' && r != '-' && (r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/skilllib/frontmatter.go
+++ b/pkg/skilllib/frontmatter.go
@@ -22,6 +22,12 @@ import (
 // errors on content — only the caller's file open can fail. This is the single
 // shared parser used by both the skill library and runview's bundle-skill
 // catalog (runview.readSkillFile), so the two never drift.
+//
+// Block scalars are supported: `description: >` (folded — continuation lines
+// joined into one whitespace-normalized string) and `description: |` (literal
+// — continuation lines joined with newlines). This matters because a skill's
+// routable text often lives in a multi-line block; without it the router would
+// see just the ">"/"|" indicator as the whole description.
 func ScanFrontmatter(r io.Reader) (name, description string) {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 64*1024), 1<<20)
@@ -29,6 +35,37 @@ func ScanFrontmatter(r io.Reader) (name, description string) {
 	// closing "---". Tolerant of leading whitespace and a file with no
 	// frontmatter block at all (the first content line ends the scan).
 	opened := false
+
+	// Block-scalar collection state. blockKey is non-empty while gathering a
+	// `>`/`|` value; fold selects folded (space-join) vs literal (newline-join);
+	// baseIndent is the key line's indent — a continuation line must be more
+	// indented (blank lines are part of the block).
+	var blockKey string
+	var fold bool
+	var baseIndent int
+	var block []string
+	assign := func(key, val string) {
+		switch key {
+		case "name":
+			name = val
+		case "description":
+			description = val
+		}
+	}
+	flushBlock := func() {
+		if blockKey == "" {
+			return
+		}
+		var joined string
+		if fold {
+			joined = strings.Join(strings.Fields(strings.Join(block, " ")), " ")
+		} else {
+			joined = strings.TrimRight(strings.Join(block, "\n"), "\n")
+		}
+		assign(blockKey, joined)
+		blockKey, block = "", nil
+	}
+
 	for scanner.Scan() {
 		line := strings.TrimRight(scanner.Text(), "\r")
 		trimmed := strings.TrimSpace(line)
@@ -42,6 +79,18 @@ func ScanFrontmatter(r io.Reader) (name, description string) {
 			}
 			break // first non-frontmatter content line → no frontmatter
 		}
+		if blockKey != "" {
+			indent := len(line) - len(strings.TrimLeft(line, " \t"))
+			if trimmed == "" {
+				block = append(block, "")
+				continue
+			}
+			if indent > baseIndent && trimmed != "---" {
+				block = append(block, trimmed)
+				continue
+			}
+			flushBlock() // dedent (or ---) ends the block; reprocess this line
+		}
 		if trimmed == "---" {
 			break
 		}
@@ -50,15 +99,26 @@ func ScanFrontmatter(r io.Reader) (name, description string) {
 			continue
 		}
 		key := strings.ToLower(strings.TrimSpace(k))
+		if key != "name" && key != "description" {
+			continue
+		}
 		val := strings.TrimSpace(v)
+		if val == "" || strings.HasPrefix(val, "|") || strings.HasPrefix(val, ">") {
+			// A bare/indicator value opens a block scalar (chomping/indent
+			// indicators after |/> are ignored — we only need the text).
+			if strings.HasPrefix(val, "|") || strings.HasPrefix(val, ">") {
+				blockKey = key
+				fold = val[0] == '>'
+				baseIndent = len(k) - len(strings.TrimLeft(k, " \t"))
+				block = nil
+				continue
+			}
+			// Empty value: leave the field empty (nothing to assign).
+		}
 		val = strings.TrimPrefix(val, "\"")
 		val = strings.TrimSuffix(val, "\"")
-		switch key {
-		case "name":
-			name = val
-		case "description":
-			description = val
-		}
+		assign(key, val)
 	}
+	flushBlock() // frontmatter that ends at EOF mid-block
 	return name, description
 }

--- a/pkg/skilllib/frontmatter.go
+++ b/pkg/skilllib/frontmatter.go
@@ -103,17 +103,15 @@ func ScanFrontmatter(r io.Reader) (name, description string) {
 			continue
 		}
 		val := strings.TrimSpace(v)
-		if val == "" || strings.HasPrefix(val, "|") || strings.HasPrefix(val, ">") {
-			// A bare/indicator value opens a block scalar (chomping/indent
-			// indicators after |/> are ignored — we only need the text).
-			if strings.HasPrefix(val, "|") || strings.HasPrefix(val, ">") {
-				blockKey = key
-				fold = val[0] == '>'
-				baseIndent = len(k) - len(strings.TrimLeft(k, " \t"))
-				block = nil
-				continue
-			}
-			// Empty value: leave the field empty (nothing to assign).
+		if strings.HasPrefix(val, "|") || strings.HasPrefix(val, ">") {
+			// A block-scalar indicator opens a multi-line value (chomping/indent
+			// indicators after |/> are ignored — we only need the text). A bare
+			// empty value falls through and assigns "" like any scalar.
+			blockKey = key
+			fold = val[0] == '>'
+			baseIndent = len(k) - len(strings.TrimLeft(k, " \t"))
+			block = nil
+			continue
 		}
 		val = strings.TrimPrefix(val, "\"")
 		val = strings.TrimSuffix(val, "\"")

--- a/pkg/skilllib/frontmatter_test.go
+++ b/pkg/skilllib/frontmatter_test.go
@@ -108,6 +108,38 @@ func TestScanFrontmatter(t *testing.T) {
 			wantName: "kept",
 			wantDesc: "",
 		},
+		{
+			// Folded block scalar (`>`): continuation lines join into one
+			// whitespace-normalized string. Without block-scalar support the
+			// router would see just ">" as the whole description.
+			name:     "folded block-scalar description",
+			in:       "---\nname: n\ndescription: >\n  first line\n  second line\n---\n# body\n",
+			wantName: "n",
+			wantDesc: "first line second line",
+		},
+		{
+			// Literal block scalar (`|`): newlines preserved.
+			name:     "literal block-scalar description",
+			in:       "---\nname: n\ndescription: |\n  line one\n  line two\n---\n",
+			wantName: "n",
+			wantDesc: "line one\nline two",
+		},
+		{
+			// A block scalar is terminated by a dedent to another key, which
+			// is then parsed normally.
+			name:     "block scalar ends at next key",
+			in:       "---\ndescription: >\n  folded text\nname: after\n---\n",
+			wantName: "after",
+			wantDesc: "folded text",
+		},
+		{
+			// Chomping/indent indicators after |/> are ignored (we only need
+			// the text), and the block may end at EOF/`---` mid-collection.
+			name:     "block scalar with chomping indicator",
+			in:       "---\nname: n\ndescription: |-\n  kept text\n---\n",
+			wantName: "n",
+			wantDesc: "kept text",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/skilllib/frontmatter_test.go
+++ b/pkg/skilllib/frontmatter_test.go
@@ -140,6 +140,22 @@ func TestScanFrontmatter(t *testing.T) {
 			wantName: "n",
 			wantDesc: "kept text",
 		},
+		{
+			// Regression: an indented "---" INSIDE a folded block is content,
+			// not a frontmatter terminator — later keys must survive.
+			name:     "indented --- inside block is content",
+			in:       "---\ndescription: >\n  before\n  ---\n  after\nname: kept\n---\n",
+			wantName: "kept",
+			wantDesc: "before --- after",
+		},
+		{
+			// Regression: a value with text after >/| on the same line is an
+			// inline scalar, NOT a block header — assign it verbatim.
+			name:     "inline > value is not a block scalar",
+			in:       "---\nname: n\ndescription: > inline text\n---\n",
+			wantName: "n",
+			wantDesc: "> inline text",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/webhooks/gitlab/issue.go
+++ b/pkg/webhooks/gitlab/issue.go
@@ -49,17 +49,21 @@ type LabelsChange struct {
 // the repo to clone, the issue to implement + back-link, and the labels that
 // were freshly added on this event.
 type ParsedIssue struct {
-	ProjectID      int64
-	ProjectPath    string
-	CloneURL       string
-	DefaultBranch  string // base ref a command's MR is opened against
-	IssueIID       int64
-	Action         string // "open" | "update" | "close" | "reopen"
-	Title          string
-	Description    string
-	URL            string // the issue's own web URL — the back-link target
-	State          string // "opened" | "closed"
-	AddedLabels    []string
+	ProjectID     int64
+	ProjectPath   string
+	CloneURL      string
+	DefaultBranch string // base ref a command's MR is opened against
+	IssueIID      int64
+	Action        string // "open" | "update" | "close" | "reopen"
+	Title         string
+	Description   string
+	URL           string // the issue's own web URL — the back-link target
+	State         string // "opened" | "closed"
+	AddedLabels   []string
+	// Labels is the issue's full current label set (titles) after the change —
+	// what the bot-agnostic hold-label gate reads (distinct from AddedLabels,
+	// which is only the freshly-added trigger).
+	Labels         []string
 	AuthorID       int64
 	AuthorUsername string
 }
@@ -87,9 +91,24 @@ func ParseIssue(body []byte) (ParsedIssue, error) {
 		URL:            oa.URL,
 		State:          oa.State,
 		AddedLabels:    addedLabels(e.Changes.Labels),
+		Labels:         labelTitles(e.Labels),
 		AuthorID:       e.User.ID,
 		AuthorUsername: e.User.Username,
 	}, nil
+}
+
+// labelTitles extracts the non-empty label titles from a GitLab label list.
+func labelTitles(labels []Label) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(labels))
+	for _, l := range labels {
+		if l.Title != "" {
+			out = append(out, l.Title)
+		}
+	}
+	return out
 }
 
 // addedLabels returns the label titles present in current but not previous.

--- a/pkg/webhooks/gitlab/issue_test.go
+++ b/pkg/webhooks/gitlab/issue_test.go
@@ -87,3 +87,17 @@ func TestAddedLabels(t *testing.T) {
 		}
 	}
 }
+
+func TestParseIssue_CurrentLabels(t *testing.T) {
+	body := `{"object_kind":"issue","project":{"path_with_namespace":"g/p"},"object_attributes":{"iid":3,"action":"update","state":"opened"},"labels":[{"title":"bug"},{"title":"iterion:hold"}],"changes":{"labels":{"previous":[{"title":"bug"}],"current":[{"title":"bug"},{"title":"iterion:hold"}]}}}`
+	p, err := ParseIssue([]byte(body))
+	if err != nil {
+		t.Fatalf("ParseIssue: %v", err)
+	}
+	if len(p.Labels) != 2 || p.Labels[0] != "bug" || p.Labels[1] != "iterion:hold" {
+		t.Fatalf("current Labels = %v, want [bug iterion:hold]", p.Labels)
+	}
+	if len(p.AddedLabels) != 1 || p.AddedLabels[0] != "iterion:hold" {
+		t.Fatalf("AddedLabels = %v, want [iterion:hold]", p.AddedLabels)
+	}
+}

--- a/pkg/webhooks/match.go
+++ b/pkg/webhooks/match.go
@@ -122,23 +122,13 @@ func matchCaseInsensitiveAllowlist(allowlist []string, value string) bool {
 // HeldByLabel returns the first label in `present` that appears in the
 // bot-agnostic `holdLabels` suppression set (case-insensitive), or "" when
 // none does. An empty holdLabels set (the default) always returns "" — the
-// hold gate is opt-in and fail-open (no labels present → nothing held).
+// hold gate is opt-in, so unlike an allowlist an empty set matches NOTHING;
+// past that guard it reuses the canonical matcher (so a `*` entry holds all).
 func HeldByLabel(holdLabels, present []string) string {
 	if len(holdLabels) == 0 {
 		return ""
 	}
-	for _, p := range present {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-		for _, h := range holdLabels {
-			if strings.EqualFold(strings.TrimSpace(h), p) {
-				return p
-			}
-		}
-	}
-	return ""
+	return FirstMatchingLabel(holdLabels, present)
 }
 
 // FirstMatchingLabel returns the first freshly-applied label that passes the

--- a/pkg/webhooks/match.go
+++ b/pkg/webhooks/match.go
@@ -119,6 +119,28 @@ func matchCaseInsensitiveAllowlist(allowlist []string, value string) bool {
 	return false
 }
 
+// HeldByLabel returns the first label in `present` that appears in the
+// bot-agnostic `holdLabels` suppression set (case-insensitive), or "" when
+// none does. An empty holdLabels set (the default) always returns "" — the
+// hold gate is opt-in and fail-open (no labels present → nothing held).
+func HeldByLabel(holdLabels, present []string) string {
+	if len(holdLabels) == 0 {
+		return ""
+	}
+	for _, p := range present {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		for _, h := range holdLabels {
+			if strings.EqualFold(strings.TrimSpace(h), p) {
+				return p
+			}
+		}
+	}
+	return ""
+}
+
 // FirstMatchingLabel returns the first freshly-applied label that passes the
 // allowlist — the trigger — or "" when none qualifies. With an empty allowlist
 // any added label qualifies (the first is returned). Used by the GitLab issues

--- a/pkg/webhooks/match_test.go
+++ b/pkg/webhooks/match_test.go
@@ -144,3 +144,19 @@ func TestMatchAuthorRule(t *testing.T) {
 		})
 	}
 }
+
+func TestHeldByLabel(t *testing.T) {
+	hold := []string{"iterion:hold", "do-not-automate"}
+	if got := HeldByLabel(nil, []string{"anything"}); got != "" {
+		t.Fatalf("empty holdLabels must never hold, got %q", got)
+	}
+	if got := HeldByLabel(hold, []string{"ready", "bug"}); got != "" {
+		t.Fatalf("no hold label present → not held, got %q", got)
+	}
+	if got := HeldByLabel(hold, []string{"ready", "Iterion:Hold"}); got != "Iterion:Hold" {
+		t.Fatalf("case-insensitive match expected, got %q", got)
+	}
+	if got := HeldByLabel(hold, []string{"do-not-automate"}); got != "do-not-automate" {
+		t.Fatalf("second hold label should match, got %q", got)
+	}
+}

--- a/pkg/webhooks/prforge/events.go
+++ b/pkg/webhooks/prforge/events.go
@@ -50,8 +50,12 @@ type PullRequest struct {
 	// every action but `opened`: on a push to an existing PR the sender is
 	// whoever pushed, which is not who the PR belongs to.
 	User Sender `json:"user"`
-	Head Ref    `json:"head"`
-	Base Ref    `json:"base"`
+	// Labels is the PR's current label set. GitHub/Gitea include it on the
+	// pull_request object; GitLab and minimal payloads omit it (empty → the
+	// hold-label suppression fail-opens). Read by the generic hold-label gate.
+	Labels []Label `json:"labels"`
+	Head   Ref     `json:"head"`
+	Base   Ref     `json:"base"`
 }
 
 type Ref struct {

--- a/pkg/webhooks/prforge/issues.go
+++ b/pkg/webhooks/prforge/issues.go
@@ -32,6 +32,9 @@ type IssuesEvent struct {
 		// the repo (OWNER|MEMBER|COLLABORATOR|CONTRIBUTOR|NONE|…); Forgejo
 		// omits it (empty).
 		AuthorAssociation string `json:"author_association"`
+		// Labels is the issue's current label set. GitHub/Gitea include it;
+		// empty when omitted (the hold-label gate fail-opens).
+		Labels []Label `json:"labels"`
 	} `json:"issue"`
 	Label  Label  `json:"label"`
 	Sender Sender `json:"sender"`
@@ -64,6 +67,9 @@ type ParsedIssue struct {
 	// AuthorAssociation is GitHub's author↔repo relationship for the issue
 	// author (empty on Forgejo) — the no-API-call trust fast path.
 	AuthorAssociation string
+	// IssueLabels is the issue's current label set (names). Empty when the
+	// payload omits it — the hold-label gate fail-opens.
+	IssueLabels []string
 }
 
 // ParseIssues decodes an issues webhook body from GitHub or Forgejo/Gitea
@@ -88,6 +94,7 @@ func ParseIssues(body []byte) (ParsedIssue, error) {
 		SenderLogin:       e.Sender.Login,
 		IssueAuthorLogin:  e.Issue.User.Login,
 		AuthorAssociation: e.Issue.AuthorAssociation,
+		IssueLabels:       labelNames(e.Issue.Labels),
 	}, nil
 }
 

--- a/pkg/webhooks/prforge/issues_test.go
+++ b/pkg/webhooks/prforge/issues_test.go
@@ -71,3 +71,14 @@ func TestIssuesIsLabeled(t *testing.T) {
 		}
 	}
 }
+
+func TestParseIssues_Labels(t *testing.T) {
+	body := `{"action":"opened","repository":{"full_name":"o/r"},"issue":{"number":9,"labels":[{"name":"bug"},{"name":"blocked"}]}}`
+	p, err := ParseIssues([]byte(body))
+	if err != nil {
+		t.Fatalf("ParseIssues: %v", err)
+	}
+	if len(p.IssueLabels) != 2 || p.IssueLabels[0] != "bug" || p.IssueLabels[1] != "blocked" {
+		t.Fatalf("issue labels = %v, want [bug blocked]", p.IssueLabels)
+	}
+}

--- a/pkg/webhooks/prforge/parser.go
+++ b/pkg/webhooks/prforge/parser.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // Parsed is the normalized PR view the inbound handler consumes. It
@@ -43,6 +44,9 @@ type Parsed struct {
 	// never auto-triggers a bot (IsReviewable is false); the trigger is the
 	// `ready_for_review` action that clears it.
 	Draft bool
+	// Labels is the PR's current label set (names). Empty when the payload
+	// omits it (GitLab, minimal payloads) — the hold-label gate fail-opens.
+	Labels []string
 }
 
 // healableDequeueReasons are the merge-queue eject reasons that a
@@ -97,6 +101,7 @@ func ParsePullRequest(body []byte) (Parsed, error) {
 		HeadRepoFullName: pr.Head.Repo.FullName,
 		DequeueReason:    e.Reason,
 		Draft:            pr.Draft,
+		Labels:           labelNames(pr.Labels),
 	}, nil
 }
 
@@ -108,6 +113,20 @@ func (p Parsed) Author() string {
 		return p.AuthorLogin
 	}
 	return p.SenderLogin
+}
+
+// labelNames extracts the trimmed, non-empty label names from a raw label list.
+func labelNames(labels []Label) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(labels))
+	for _, l := range labels {
+		if n := strings.TrimSpace(l.Name); n != "" {
+			out = append(out, n)
+		}
+	}
+	return out
 }
 
 // IsCrossRepo reports whether the PR's head branch lives in a DIFFERENT repo

--- a/pkg/webhooks/prforge/prforge_test.go
+++ b/pkg/webhooks/prforge/prforge_test.go
@@ -211,3 +211,14 @@ func TestIsSynchronize(t *testing.T) {
 // Allowlist matching tests live in pkg/webhooks/match_test.go (the
 // canonical webhooks.MatchEvent + MatchProject are exercised there with
 // every provider's default kinds).
+
+func TestParsePullRequest_Labels(t *testing.T) {
+	body := `{"action":"opened","number":5,"repository":{"full_name":"o/r"},"pull_request":{"number":5,"labels":[{"name":"ready"},{"name":"iterion:hold"},{"name":""}],"head":{"ref":"f","sha":"s"},"base":{"ref":"main"}}}`
+	p, err := ParsePullRequest([]byte(body))
+	if err != nil {
+		t.Fatalf("ParsePullRequest: %v", err)
+	}
+	if len(p.Labels) != 2 || p.Labels[0] != "ready" || p.Labels[1] != "iterion:hold" {
+		t.Fatalf("labels = %v, want [ready iterion:hold] (empty dropped)", p.Labels)
+	}
+}

--- a/pkg/webhooks/types.go
+++ b/pkg/webhooks/types.go
@@ -123,6 +123,13 @@ type Config struct {
 	// label triggers. Case-insensitive; see MatchLabel. Has no effect on the
 	// pull_request / issue_comment paths.
 	LabelAllowlist []string `bson:"label_allowlist,omitempty" json:"label_allowlist,omitempty"`
+	// HoldLabels is a bot-agnostic suppression set: when the triggering PR or
+	// issue carries any of these labels, the auto-launch lanes (PR-open review,
+	// auto-implement-on-open) suppress the launch — whatever bot would have
+	// run. It is the operator's escape hatch to pause automation on one
+	// PR/issue without disabling the webhook. Case-insensitive; empty = off.
+	// Distinct from LabelAllowlist (which selects a bot); this vetoes ALL bots.
+	HoldLabels []string `bson:"hold_labels,omitempty" json:"hold_labels,omitempty"`
 
 	// BranchImproveAsPR changes how the branch-improvement bot (Billy) lands
 	// its hardening on a PR it reviews. Default (false): it commits + pushes


### PR DESCRIPTION
## What

Seven improvements mined from the [ai-driven-dev/framework](https://github.com/ai-driven-dev/framework) (AIDD) marketplace and projected onto iterion — after filtering out everything that would impose an **artificial limitation on unproven postulates** (rejected: an LLM-reviewer certifier that would revive the relay ADR-058 removed; a `done_when`-must-be-pre-declared entry gate; a pre-declared file-blast-radius gate; a linear SDLC stage-pin; a self-reported confidence-% gate). Each kept item gates on an **objective fact** or **adds judgment / a human escape hatch** — never on how the work must proceed.

## The slice

| # | Change | Kind |
|---|--------|------|
| **#18** | `bundlelint` C231–C234 skill-authoring **routability lint** (warn-only, no phrasing dogma). Caught & fixed **6 real routing bugs** in the shipped catalog: block-scalar descriptions the shared parser returned as `">"`/`"|"`, and 5 skills whose frontmatter sat behind a leading HTML comment (invisible to frontmatter-first discovery). | engine + parser fix |
| **#5** | `fit / rot` **anti-façade lens** added to the code self-review skill + whole-improve-loop prompt. **Advisory only** — the deterministic build/test gate stays the sole ship-blocker (keeps ADR-058 convergence intact). | bot content |
| **#9** | Workspace-memory **reconcile-before-write + non-destructive supersede** (tombstone + `superseded_by`/`supersedes` links, never delete). Skill-level, no engine gate that could block a write or hide a doc. | bot content |
| **#11** | Dispatcher **honors body-declared issue dependencies** (`Depends on #N` / `Blocked by #N`) on external trackers (github/forgejo/gitlab). **Fail-open** — can only under-block, never silently wedge a ticket. | engine |
| **#1** | review-pr binds the published review to the **reviewed SHA** — refuses to post findings whose line anchors were computed against a since-changed tree (guards resume-after-branch-advanced). | bot DSL |
| **#12** | Bot-agnostic **`hold_labels`** webhook suppression: a label pauses automation on one PR/issue across all four auto-launch lanes, referencing **zero bot ids** (reduces the hardcoded-bot-id debt rather than extending it). | engine |

**#13** (comment idempotency) was investigated and **verified moot** — iterion has no auto-comment-on-outcome path to make idempotent, and webhook delivery is already idempotent; building one would be speculative.

## Quality passes (also in this branch)

- **`/simplify`** (4-angle): extracted `filterHeldByBlockers` (3 copies → 1), `HeldByLabel` now delegates to the canonical matcher, extracted `suppressedByHoldLabel` and **wired the two GitLab lanes the first cut missed** (making #12 actually generic).
- **Adversarial review** (opus, high effort): the SHA guard and hold-label gate held up; 5 findings fixed — glued `##` headings, an over-blocking regex (tightened, invariant restored), two frontmatter edge cases (indented `---` inside a block; inline `>` value), and honest docs for the label-scoped fail-open.

## Testing

`go build ./...`, `go vet`, `golangci-lint` (0 issues), and unit tests across `skilllib`, `bundlelint`, `dispatcher/tracker`, `webhooks`, `server`, `bots` (incl. golden replay) all green. New tests cover the block-scalar parser, blocker parsing/gating, hold-label matching + per-provider label parsing, and the skill lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
