### PR TITLE
feat(webhooks): /revi approve — maintainer override for the merge gate

### DIFF
--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -108,12 +108,14 @@ Three ways, in order of preference:
    `review_on_sync`) and flips green when the finding is gone.
 2. **`/revi approve [reason]`** — a **maintainer** comments this on the PR to
    force-green the `revi/review` status on the current head, for a finding
-   they dispute. Trust-gated: the commenter must hold real repo rights
-   (`MinAuthorRole` / `AuthorAllowlist`, verified live via the forge
-   permission API) — an arbitrary contributor cannot wave a finding through.
-   The status carries "approved by @user: reason" and links to the comment as
-   the audit trail. It does **not** launch a re-review. *(GitHub + Forgejo
-   today; GitLab `/revi approve` on a note is a follow-on.)*
+   they dispute. Authorized through the **same PR-comment command gate as
+   every other `/command`**: the commenter must hold a live repo role at or
+   above `MinReplierRole` (or be in `AuthorizedRepliers`), verified via the
+   forge permission API, and the review bot's own comment can't self-approve
+   (WhoAmI loop-guard) — an arbitrary contributor cannot wave a finding
+   through. The status carries "approved by @user: reason" and links to the
+   comment as the audit trail. It does **not** launch a re-review. *(GitHub +
+   Forgejo today; GitLab `/revi approve` on a note is a follow-on.)*
 3. **Admin merge-queue bypass** — the last resort, always available to repo
    admins.
 

--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -102,11 +102,20 @@ block for an admin.
 
 ## Overriding a finding
 
-Today: push a fix (re-reviews → status flips green) or, for a disputed
-finding, an **admin** bypasses the merge queue. A trust-gated
-`/revi approve <reason>` PR command that force-greens the status with an
-audit trail is the planned fast-follow (a maintainer, not only an admin,
-resolving a false positive from the PR itself).
+Three ways, in order of preference:
+
+1. **Push a fix** — the status re-reviews on the new head (needs
+   `review_on_sync`) and flips green when the finding is gone.
+2. **`/revi approve [reason]`** — a **maintainer** comments this on the PR to
+   force-green the `revi/review` status on the current head, for a finding
+   they dispute. Trust-gated: the commenter must hold real repo rights
+   (`MinAuthorRole` / `AuthorAllowlist`, verified live via the forge
+   permission API) — an arbitrary contributor cannot wave a finding through.
+   The status carries "approved by @user: reason" and links to the comment as
+   the audit trail. It does **not** launch a re-review. *(GitHub + Forgejo
+   today; GitLab `/revi approve` on a note is a follow-on.)*
+3. **Admin merge-queue bypass** — the last resort, always available to repo
+   admins.
 
 ## <a name="questions"></a>Questions vs findings
 

--- a/pkg/server/webhooks_prforge.go
+++ b/pkg/server/webhooks_prforge.go
@@ -54,6 +54,13 @@ func (s *Server) handlePRForgeComment(ctx context.Context, w http.ResponseWriter
 		filtered("no slash-command")
 		return
 	}
+	// `/revi approve [reason]` is an OVERRIDE, not a re-review: a trusted
+	// maintainer force-greens the merge gate. Intercept before the
+	// command→bot routing so it never launches a run.
+	if reason, isApprove := reviewApproveReason(cmd, cmdArgs); isApprove {
+		s.handlePRForgeReviewApprove(ctx, w, cfg, provider, p, reason, payloadHash, srcIP)
+		return
+	}
 	route, ok := webhooks.ResolveCommandRoute(cfg, cmd, cmdArgs, s.cmdDiscovery())
 	if !ok {
 		filtered("no command route for /" + cmd)

--- a/pkg/server/webhooks_review_approve.go
+++ b/pkg/server/webhooks_review_approve.go
@@ -1,0 +1,109 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
+)
+
+// reviewGateContext is the commit-status check the /revi approve override
+// force-greens. It matches the context Revi posts (the bot pins "revi/review").
+// Living in the /revi command handler, this is intrinsically Revi-scoped —
+// consistent with the existing distinguished-bot coupling in this webhook layer
+// (defaultWebhookBotReviewPR et al., see CLAUDE.md known-debt).
+const reviewGateContext = "revi/review"
+
+// reviewApproveReason detects a `/revi approve [reason]` command and returns
+// the trailing reason. ok=false for any other command (so the normal /revi
+// re-review path is untouched).
+func reviewApproveReason(cmd, args string) (reason string, ok bool) {
+	if !strings.EqualFold(strings.TrimSpace(cmd), "revi") {
+		return "", false
+	}
+	fields := strings.Fields(args)
+	if len(fields) == 0 || !strings.EqualFold(fields[0], "approve") {
+		return "", false
+	}
+	// Everything after the "approve" token is the free-text reason.
+	rest := strings.TrimSpace(args)
+	rest = strings.TrimSpace(rest[len(fields[0]):])
+	return rest, true
+}
+
+// handlePRForgeReviewApprove handles `/revi approve [reason]` on a GitHub /
+// Forgejo PR comment: a trusted maintainer force-greens the revi/review merge
+// gate on the PR head (the human-arbitration escape hatch for a finding the
+// author disputes, backstopping the admin merge-queue bypass). It is NOT a
+// re-review — no bot launches. Every benign refusal is a 200/filtered so the
+// forge keeps the hook enabled; the status write goes through the bot's own
+// forge token (the same credential the command gate uses).
+func (s *Server) handlePRForgeReviewApprove(ctx context.Context, w http.ResponseWriter, cfg webhooks.Config, provider webhooks.Provider, p prforge.ParsedNote, reason, payloadHash, srcIP string) {
+	meta := prforgeNoteMeta(p)
+	filtered := func(why string) {
+		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, why)
+		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+	}
+	if !p.IsPullRequest {
+		filtered("/revi approve only applies on a pull request")
+		return
+	}
+	token, terr := s.resolveForgeToken(ctx, cfg, defaultWebhookBotReviewPR)
+	if terr != nil || token == "" {
+		filtered("no forge token to post the approval status (configure a forge_token binding)")
+		return
+	}
+	baseURL, refusal := prforgeBaseURL(cfg, p)
+	if refusal != "" {
+		filtered(refusal)
+		return
+	}
+	client := prforgeReplierClient(provider, s.forgeHTTPClient(), baseURL, token)
+
+	// Trust gate: the commenter must hold real repo rights (>= MinAuthorRole),
+	// verified live via CollaboratorPermission (fail-closed without a token).
+	// An arbitrary contributor must NOT be able to wave a finding through.
+	pc, _ := client.(forge.PermissionClient)
+	if !s.authorTrustGate().trusted(ctx, pc, string(provider), p.ProjectPath, p.AuthorLogin, "", cfg.MinAuthorRole, cfg.AuthorAllowlist) {
+		filtered("@" + p.AuthorLogin + " lacks maintainer rights to /revi approve")
+		return
+	}
+
+	gc, ok := client.(forgeGateClient)
+	if !ok {
+		filtered("provider " + string(provider) + " has no commit-status capability")
+		return
+	}
+	pr, err := gc.GetPullRequest(ctx, p.ProjectPath, int(p.IssueNumber))
+	if err != nil {
+		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusLaunchError, payloadHash, srcIP, "resolve PR head: "+err.Error())
+		httpError(w, http.StatusBadGateway, "could not resolve the PR head")
+		return
+	}
+	if strings.TrimSpace(pr.HeadSHA) == "" {
+		filtered("forge returned no head sha for the PR")
+		return
+	}
+	desc := "approved by @" + p.AuthorLogin
+	if reason != "" {
+		desc += ": " + reason
+	}
+	if err := gc.SetCommitStatus(ctx, p.ProjectPath, pr.HeadSHA, forge.CommitStatus{
+		State:       forge.CommitStateSuccess,
+		Context:     reviewGateContext,
+		Description: desc,
+		TargetURL:   p.CommentURL,
+	}); err != nil {
+		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusLaunchError, payloadHash, srcIP, "set commit status: "+err.Error())
+		httpError(w, http.StatusBadGateway, "could not post the approval status")
+		return
+	}
+	if s.logger != nil {
+		s.logger.Info("webhooks: %s %s#%d revi/review force-greened by @%s (%q)", provider, p.ProjectPath, p.IssueNumber, p.AuthorLogin, reason)
+	}
+	s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusLaunched, payloadHash, srcIP, "revi/review approved by @"+p.AuthorLogin)
+	writeJSONStatus(w, http.StatusOK, map[string]string{"status": "revi-approved"})
+}

--- a/pkg/server/webhooks_review_approve.go
+++ b/pkg/server/webhooks_review_approve.go
@@ -51,6 +51,35 @@ func (s *Server) handlePRForgeReviewApprove(ctx context.Context, w http.Response
 		filtered("/revi approve only applies on a pull request")
 		return
 	}
+	// The review bot must be permitted on this webhook — same admission the
+	// normal command path applies before authorizing a /command.
+	if !cfg.AllowsBot(defaultWebhookBotReviewPR) {
+		filtered("bot " + defaultWebhookBotReviewPR + " not permitted by this webhook")
+		return
+	}
+	// Authorize EXACTLY like every other PR-comment command (not the
+	// issue-author-trust gate): realWebhookPRForgeCommandGate checks the
+	// commenter's live repo role against MinReplierRole (or AuthorizedRepliers),
+	// AND rejects the review bot's own comment via a WhoAmI loop-guard so a
+	// status can't self-approve. A synthetic review-pr route carries the token
+	// binding + role threshold.
+	route := webhooks.CommandRoute{BotID: defaultWebhookBotReviewPR}
+	gate := s.webhookPRForgeCommandGate
+	if gate == nil {
+		gate = s.realWebhookPRForgeCommandGate
+	}
+	authorized, reason2, aerr := gate(ctx, cfg, provider, p, route)
+	if aerr != nil {
+		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusLaunchError, payloadHash, srcIP, "authz check: "+aerr.Error())
+		httpError(w, http.StatusBadGateway, "authorization check failed")
+		return
+	}
+	if !authorized {
+		filtered("@" + p.AuthorLogin + " not authorized to /revi approve (" + reason2 + ")")
+		return
+	}
+
+	// Authorized: resolve the client to post the approval status.
 	token, terr := s.resolveForgeToken(ctx, cfg, defaultWebhookBotReviewPR)
 	if terr != nil || token == "" {
 		filtered("no forge token to post the approval status (configure a forge_token binding)")
@@ -62,16 +91,6 @@ func (s *Server) handlePRForgeReviewApprove(ctx context.Context, w http.Response
 		return
 	}
 	client := prforgeReplierClient(provider, s.forgeHTTPClient(), baseURL, token)
-
-	// Trust gate: the commenter must hold real repo rights (>= MinAuthorRole),
-	// verified live via CollaboratorPermission (fail-closed without a token).
-	// An arbitrary contributor must NOT be able to wave a finding through.
-	pc, _ := client.(forge.PermissionClient)
-	if !s.authorTrustGate().trusted(ctx, pc, string(provider), p.ProjectPath, p.AuthorLogin, "", cfg.MinAuthorRole, cfg.AuthorAllowlist) {
-		filtered("@" + p.AuthorLogin + " lacks maintainer rights to /revi approve")
-		return
-	}
-
 	gc, ok := client.(forgeGateClient)
 	if !ok {
 		filtered("provider " + string(provider) + " has no commit-status capability")

--- a/pkg/server/webhooks_review_approve_test.go
+++ b/pkg/server/webhooks_review_approve_test.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
+)
+
+func TestReviewApproveReason(t *testing.T) {
+	cases := []struct {
+		cmd, args  string
+		wantReason string
+		wantOK     bool
+	}{
+		{"revi", "approve looks like a false positive", "looks like a false positive", true},
+		{"revi", "approve", "", true}, // bare approve, no reason
+		{"revi", "  approve   spaced  ", "spaced", true},
+		{"revi", "review the diff", "", false}, // a normal re-review is NOT an approve
+		{"revi", "", "", false},                // bare /revi re-review
+		{"revi", "approver", "", false},        // must be the exact token "approve"
+		{"billy", "approve x", "", false},      // another bot's command
+		{"REVI", "APPROVE done", "done", true}, // case-insensitive
+	}
+	for _, c := range cases {
+		reason, ok := reviewApproveReason(c.cmd, c.args)
+		if ok != c.wantOK || reason != c.wantReason {
+			t.Errorf("reviewApproveReason(%q,%q) = (%q,%v), want (%q,%v)", c.cmd, c.args, reason, ok, c.wantReason, c.wantOK)
+		}
+	}
+}
+
+// A `/revi approve` PR comment must be intercepted as an override — it must
+// NOT launch a re-review bot. Without a forge token bound in the test server it
+// filters gracefully (200), proving the approve branch ran instead of the
+// command→bot routing.
+func TestGitHubComment_ReviewApproveDoesNotLaunch(t *testing.T) {
+	s := newWebhookTestServer(t)
+	launched := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		launched++
+		return "run-x", nil
+	}
+	cfg, pt := ghConfig(t, s)
+
+	body := `{"action":"created","repository":{"full_name":"acme/widgets","clone_url":"https://github.com/acme/widgets.git"},"issue":{"number":7,"title":"t","body":"","state":"open","pull_request":{"html_url":"https://github.com/acme/widgets/pull/7"}},"comment":{"id":556,"body":"/revi approve dispute"},"sender":{"login":"alice"}}`
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), body, prforge.EventHeaderIssueComment, pt))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if launched != 0 {
+		t.Fatalf("/revi approve must NOT launch a bot (launched=%d)", launched)
+	}
+}

--- a/pkg/server/webhooks_review_approve_test.go
+++ b/pkg/server/webhooks_review_approve_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/SocialGouv/iterion/pkg/webhooks"
 	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
 )
 
@@ -54,5 +55,42 @@ func TestGitHubComment_ReviewApproveDoesNotLaunch(t *testing.T) {
 	}
 	if launched != 0 {
 		t.Fatalf("/revi approve must NOT launch a bot (launched=%d)", launched)
+	}
+}
+
+// /revi approve authorizes through the SAME PR-comment command gate as every
+// other /command (MinReplierRole / AuthorizedRepliers + WhoAmI loop-guard),
+// keyed on the review-pr route — NOT the issue-author-trust gate. An
+// unauthorized commenter is filtered and no status is posted.
+func TestGitHubComment_ReviewApprove_UsesCommandGate(t *testing.T) {
+	s := newWebhookTestServer(t)
+	var gateCalls int
+	var gotBot string
+	s.webhookPRForgeCommandGate = func(_ context.Context, _ webhooks.Config, _ webhooks.Provider, _ prforge.ParsedNote, route webhooks.CommandRoute) (bool, string, error) {
+		gateCalls++
+		gotBot = route.BotID
+		return false, "replier not authorized", nil // deny
+	}
+	launched := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		launched++
+		return "run-x", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	body := `{"action":"created","repository":{"full_name":"acme/widgets","clone_url":"https://github.com/acme/widgets.git"},"issue":{"number":7,"title":"t","body":"","state":"open","pull_request":{"html_url":"https://github.com/acme/widgets/pull/7"}},"comment":{"id":556,"body":"/revi approve dispute"},"sender":{"login":"mallory"}}`
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), body, prforge.EventHeaderIssueComment, pt))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if gateCalls != 1 {
+		t.Fatalf("approve must consult the PR-comment command gate exactly once (calls=%d)", gateCalls)
+	}
+	if gotBot != "review-pr" {
+		t.Fatalf("gate must be keyed on the review-pr route, got %q", gotBot)
+	}
+	if launched != 0 {
+		t.Fatalf("denied approve must not launch anything (launched=%d)", launched)
 	}
 }


### PR DESCRIPTION
Follow-up to the Revi merge gate (#291): a trusted maintainer comments /revi approve [reason] to force-green the revi/review status on the PR head (disputed finding) — no re-review, no admin bypass. Trust-gated via live CollaboratorPermission (fail-closed). GitHub+Forgejo; GitLab follow-on. Tests: parsing + interception-does-not-launch. docs/merge-gate.md updated.