### PR TITLE
fix(review-pr): publish_review shell exit-127 on multi-question reviews

### DIFF
--- a/bots/review-pr/main.bot
+++ b/bots/review-pr/main.bot
@@ -428,9 +428,12 @@ prompt emit_system:
       `replacement` exactly as given. This is the same set you reported —
       do not re-summarise or drop fields.
     - `questions`: the merged, de-duplicated non-blocking questions as a
-      JSON array of strings (empty `[]` when none). Carried forward so
-      the PR summary can show what the reviewers verified/assumed even on
-      a 0-finding review. NOT findings — they never gate or reach the board.
+      SINGLE STRING with ONE QUESTION PER LINE (newline-separated), NOT a
+      JSON array — empty string "" when none. (A downstream shell step
+      interpolates this value; a scalar string is shell-safe, an array is
+      not.) Carried forward so the PR summary can show what the reviewers
+      verified/assumed even on a 0-finding review. NOT findings — they never
+      gate or reach the board.
 
 prompt emit_user:
   Workspace:          {{vars.workspace_dir}}
@@ -484,10 +487,14 @@ schema emit_output:
   ## per-object shape the reviewers emit (file/line/line_end/severity/
   ## category/title/detail/suggestion/replacement/confidence/reviewers).
   findings: json
-  ## Merged non-blocking questions (JSON array of strings) — the
-  ## falsifiability channel surfaced in the report + PR summary body,
-  ## never on the board and never gating.
-  questions: json
+  ## Merged non-blocking questions, ONE PER LINE in a single string (NOT a
+  ## JSON array): an all-string array decodes to []string, which the tool-node
+  ## command substitution space-joins instead of JSON-encoding, breaking the
+  ## downstream publish shell (a question landing in command position → exit
+  ## 127). A scalar string is shell-escaped as one safe token. The
+  ## falsifiability channel surfaced in the report + PR summary body, never on
+  ## the board and never gating.
+  questions: string
 
 schema diff_precheck_output:
   is_empty: bool
@@ -501,20 +508,22 @@ schema diff_precheck_output:
 schema pr_gate_input:
   pr_url: string
   findings: json
-  questions: json
+  ## questions is a scalar string (one question per line), NOT a json array —
+  ## see emit_output.questions for why (shell-safety of the publish command).
+  questions: string
   total_findings: int
 
 schema pr_gate_output:
   has_pr: bool
   pr_url: string
   findings: json
-  questions: json
+  questions: string
   total_findings: int
 
 schema publish_input:
   pr_url: string
   findings: json
-  questions: json
+  questions: string
   total_findings: int
 
 schema publish_output:
@@ -676,13 +685,10 @@ except ValueError:
 if not isinstance(findings, list):
     findings = []
     findings_parse_failed = True
-try:
-    questions = json.loads(os.environ.get('QUESTIONS') or '[]')
-except ValueError:
-    questions = []
-if not isinstance(questions, list):
-    questions = []
-questions = [str(q).strip() for q in questions if str(q).strip()]
+# QUESTIONS arrives as a newline-separated string (NOT JSON): a json array of
+# strings would be space-joined by the tool-command substitution and break this
+# shell (a question in command position -> exit 127). One question per line.
+questions = [q.strip() for q in (os.environ.get('QUESTIONS') or '').split(chr(10)) if q.strip()]
 if not url or not tok:
     emit(False, skipped='no forge publish endpoint bound to this run: launch through an iterion server with a team forge connection covering the PR repo, so it injects forge_publish_url/forge_publish_token', summary='publish skipped: run holds no server-side forge publish grant (and never uses workspace tokens to post).')
 

--- a/bots/review-pr/manifest.yaml
+++ b/bots/review-pr/manifest.yaml
@@ -1,7 +1,14 @@
 name: review-pr
 display_name: Revi
 icon: 🔎
-version: 0.5.0
+version: 0.5.1
+## 0.5.1 — fix: publish_review shell exit-127 crash. The v0.5.0 `questions`
+## channel passed a json array of strings via QUESTIONS={{input.questions}};
+## a tool-node substitution space-joins an all-string array (known engine bug,
+## executor_tool.go:1047) so the 2nd+ question landed in shell command position
+## → the whole review crashed. Questions now flow as a scalar newline-joined
+## string (shell-safe as one escaped token). Found by dogfooding the gate's own
+## PR #292, whose review literally raised a "/revi approve …" question.
 ## 0.5.0 — merge gate: the deterministic publish step posts a "revi/review"
 ## commit status on the PR head SHA (success when 0 findings meet
 ## `gate_severity`, else failure). List that context in branch protection to


### PR DESCRIPTION
Found by dogfooding the merge gate's own PR #292 in prod: Revi crashed at `publish_review` with `exit status 127` — the review of the gate literally raised a `/revi approve …` question that landed in shell command position.

## Root cause
The v0.5.0 `questions` channel passed a JSON array of strings via `QUESTIONS={{input.questions}}`. A `json`-typed field holding an all-string array decodes to `[]string`, which the tool-command substitution **space-joins** instead of JSON-encoding (known engine bug, `executor_tool.go:1047`) — so the 2nd+ question became a shell command → `exit 127`, crashing the whole review (no forge review, no `revi/review` gate status). `findings` escaped this because they are object arrays (JSON-encoded to one token).

## Fix
`questions` now flows as a **scalar newline-joined string** end-to-end (`emit_output → pr_gate → publish_input`), shell-escaped as one safe token; publish splits on newlines. Proven locally: the exact #292 payload (a `/revi approve …` question + apostrophes) survives the shell (exit 0) where it was exit 127.

The deeper engine bug (all-string `[]any` space-join) stays documented + deferred (it needs output coercion / an additive shell-quoted-JSON form; can't blanket-flip because `git add -- {{input.files}}` sites rely on space-join).

🤖 Generated with [Claude Code](https://claude.com/claude-code)