### PR TITLE
fix(forge): request statuses:write in the runtime App token (unblocks merge gate)

### DIFF
--- a/bots/review-pr/manifest.yaml
+++ b/bots/review-pr/manifest.yaml
@@ -1,7 +1,14 @@
 name: review-pr
 display_name: Revi
 icon: 🔎
-version: 0.5.2
+version: 0.5.3
+## 0.5.3 — declare the `statuses: write` forge scope the merge gate needs
+## (advisory/provisioning hint; the runtime does not read it). Live e2e on
+## prod proved the full chain — Revi reviews, the bot sends the gate verdict,
+## the server resolves the head SHA and calls SetCommitStatus — but the
+## GitHub App lacked "Commit statuses: write", so the status 403'd
+## "insufficient scope" (non-fatal: the review still posts, the gate advises
+## instead of blocking). Grant the App perm + re-accept the install to enforce.
 ## 0.5.2 — fix: SECOND publish_review shell bug (silent empty output → no
 ## publish, no gate status, publish_health then crashes). A python COMMENT in
 ## the publish_review body contained double-quote characters ("high"/"blocker"
@@ -66,6 +73,11 @@ forge:
   token_scopes:
     pull_requests: write     # post the review + inline ```suggestion blocks
     repository: read         # clone + read the diff
+    statuses: write          # post the revi/review merge-gate commit status
+                             # (GitHub App perm "Commit statuses: Read and
+                             # write"; without it SetCommitStatus 403s
+                             # "insufficient scope" and the gate silently
+                             # advises instead of blocking)
   secret: forge_token        # cross-ref with main.bot `secrets: { forge_token }`
   webhook:
     launch_vars:

--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -48,6 +48,15 @@ PR opened / pushed ──▶ Revi runs (2 reviewers → merge → publish)
    call — no workspace credential, no ~1h token freeze). Forge-agnostic:
    GitHub commit-status / GitLab commit status / Forgejo commit status all
    expose the same primitive ([`pkg/forge/status.go`](../pkg/forge/status.go)).
+
+   > **Forge permission (required).** Posting a commit status needs write on
+   > statuses: a **GitHub App** must grant **Commit statuses: Read and write**
+   > (a token connection needs `repo:status`); GitLab/Forgejo tokens need `api`
+   > / `write:repository`. Without it `SetCommitStatus` returns 403
+   > *insufficient scope* — the review still posts and the failure is reported
+   > (`gate_error`) + logged (`forge gate: … not posted: … insufficient
+   > scope`), so the gate silently *advises* instead of blocking. Grant the
+   > permission and re-accept the installation before relying on the gate.
 4. **Enforcement.** List `revi/review` in the repo's **required status
    checks** (branch-protection ruleset). Until you do, the status is a
    harmless advisory check you can preview on every PR.

--- a/pkg/bundle/manifest.go
+++ b/pkg/bundle/manifest.go
@@ -321,6 +321,7 @@ var (
 		"repository":    true,
 		"issues":        true,
 		"webhooks":      true,
+		"statuses":      true, // commit statuses (the revi/review merge gate)
 	}
 	knownForgeScopeLevels = map[string]bool{
 		"read":  true,
@@ -822,7 +823,7 @@ func validateForgeRequirements(f *ForgeRequirements) error {
 	}
 	for key, level := range f.TokenScopes {
 		if !knownForgeScopeKeys[key] {
-			return fmt.Errorf("forge.token_scopes: unknown scope %q (known: pull_requests, repository, issues, webhooks)", key)
+			return fmt.Errorf("forge.token_scopes: unknown scope %q (known: pull_requests, repository, issues, webhooks, statuses)", key)
 		}
 		if !knownForgeScopeLevels[level] {
 			return fmt.Errorf("forge.token_scopes[%s]: invalid level %q (want read, write, or admin)", key, level)

--- a/pkg/forge/github/app_client.go
+++ b/pkg/forge/github/app_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -395,9 +396,22 @@ func (a *AppClient) rest(ctx context.Context) (*AdminClient, error) {
 	if a.token == "" || a.clock().After(a.exp.Add(-60*time.Second)) {
 		// Least-privilege: pin the management token to iterion's minimal
 		// permission set (webhook + metadata + code + PR), never the
-		// installation's full grant.
+		// installation's full grant — plus the OPTIONAL statuses:write the
+		// merge gate needs to post its revi/review commit status.
+		perms := map[string]string{"statuses": "write"}
+		for k, v := range RuntimeInstallationPermissions() {
+			perms[k] = v
+		}
 		tok, exp, err := MintInstallationToken(ctx, a.HTTP, a.apiBase(), a.Cfg, a.InstallationID, a.clock(),
-			&InstallationTokenOptions{Permissions: RuntimeInstallationPermissions()})
+			&InstallationTokenOptions{Permissions: perms})
+		if errors.Is(err, forge.ErrPermissionsNotGranted) {
+			// An installation created before the merge gate (or one that
+			// declined statuses:write) still works — the gate then advises
+			// instead of blocking (SetCommitStatus 403s, non-fatal). Retry with
+			// the core baseline so every other capability keeps functioning.
+			tok, exp, err = MintInstallationToken(ctx, a.HTTP, a.apiBase(), a.Cfg, a.InstallationID, a.clock(),
+				&InstallationTokenOptions{Permissions: RuntimeInstallationPermissions()})
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/forge/github/app_manifest.go
+++ b/pkg/forge/github/app_manifest.go
@@ -66,6 +66,10 @@ type AppManifestOptions struct {
 // grant when opts.AllowRepoCreation asks for the create-repo capability.
 func BuildAppManifest(name, homeURL, redirectURL string, opts ...AppManifestOptions) AppManifest {
 	perms := RuntimeInstallationPermissions()
+	// statuses:write lets Revi post its revi/review merge-gate commit status.
+	// Optional at runtime (the mint falls back without it — see AppClient.rest),
+	// but requested at App creation so new installations grant it up front.
+	perms["statuses"] = "write"
 	for _, o := range opts {
 		if o.AllowRepoCreation {
 			perms["administration"] = "write"

--- a/pkg/forge/github/app_test.go
+++ b/pkg/forge/github/app_test.go
@@ -238,3 +238,67 @@ func TestAppClient_CreateHookUsesInstallationToken(t *testing.T) {
 		t.Errorf("expected 1 token mint (cached), got %d", mints)
 	}
 }
+
+// AppClient.rest requests the OPTIONAL statuses:write (the merge-gate commit
+// status) on top of the core baseline, and — when the installation did not
+// grant it (422 permissions-not-granted) — falls back to the core set so every
+// other capability keeps working (the gate then advises, non-fatal). This is
+// the multi-tenant safety guarantee: a third-party install without statuses is
+// never broken by the gate feature.
+func TestAppClientRest_StatusesFallback(t *testing.T) {
+	pemStr, _ := testKeyPEM(t)
+	var reqPerms []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		perms, _ := body["permissions"].(map[string]any)
+		reqPerms = append(reqPerms, perms)
+		if _, wantsStatuses := perms["statuses"]; wantsStatuses {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "The permissions requested are not granted to this installation."})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"token": "ghs_core", "expires_at": "2099-01-01T00:00:00Z"})
+	}))
+	defer srv.Close()
+	a := &AppClient{HTTP: srv.Client(), WebBaseURL: srv.URL, Cfg: AppConfig{AppID: 42, PrivateKeyPEM: pemStr}, InstallationID: 99, Now: func() time.Time { return time.Unix(1700000000, 0) }}
+	rc, err := a.rest(context.Background())
+	if err != nil {
+		t.Fatalf("rest fell over instead of falling back: %v", err)
+	}
+	if rc == nil || rc.Token != "ghs_core" {
+		t.Fatalf("expected the core-set token after fallback, got %+v", rc)
+	}
+	if len(reqPerms) != 2 {
+		t.Fatalf("expected 2 mint attempts (statuses, then core), got %d", len(reqPerms))
+	}
+	if _, ok := reqPerms[0]["statuses"]; !ok {
+		t.Errorf("first attempt must request statuses:write, got %v", reqPerms[0])
+	}
+	if _, ok := reqPerms[1]["statuses"]; ok {
+		t.Errorf("fallback attempt must DROP statuses, got %v", reqPerms[1])
+	}
+	if reqPerms[1]["pull_requests"] != "write" {
+		t.Errorf("fallback must keep the core baseline, got %v", reqPerms[1])
+	}
+}
+
+// When the installation DOES grant statuses:write, the first mint succeeds and
+// the token carries it — the gate can post for real (no fallback, one request).
+func TestAppClientRest_StatusesGranted(t *testing.T) {
+	pemStr, _ := testKeyPEM(t)
+	var attempts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		_ = json.NewEncoder(w).Encode(map[string]any{"token": "ghs_full", "expires_at": "2099-01-01T00:00:00Z"})
+	}))
+	defer srv.Close()
+	a := &AppClient{HTTP: srv.Client(), WebBaseURL: srv.URL, Cfg: AppConfig{AppID: 42, PrivateKeyPEM: pemStr}, InstallationID: 99, Now: func() time.Time { return time.Unix(1700000000, 0) }}
+	rc, err := a.rest(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rc.Token != "ghs_full" || attempts != 1 {
+		t.Fatalf("granted statuses → one successful mint, got token=%q attempts=%d", rc.Token, attempts)
+	}
+}


### PR DESCRIPTION
Live prod e2e of the merge gate (#291) proved the full chain works end-to-end — Revi reviews → bot sends the deterministic gate verdict → server resolves the head SHA → `SetCommitStatus` — but the status did not land: the GitHub App lacks **Commit statuses: write**, so `SetCommitStatus` returns 403 *insufficient scope*.

The code handles it exactly as designed (non-fatal: the review still posts, `gate_error` set, logged `forge gate: … not posted: … insufficient scope`) so the gate **advises instead of blocking** until the permission is granted.

- Declare `statuses: write` in review-pr `forge.token_scopes` (advisory/provisioning hint; runtime does not read it).
- Document the required forge permission per provider in docs/merge-gate.md.

**Enforcement still needs (operator):** grant the iterion GitHub App *Commit statuses: Read and write* + re-accept the installation, then add `revi/review` to the required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)