### PR TITLE
feat(plugin): ship codeindex as a builtin plugin

### DIFF
--- a/Dockerfile.runner-devbox
+++ b/Dockerfile.runner-devbox
@@ -59,6 +59,18 @@ ARG FIRECRAWL_MCP_VERSION=3.22.3
 RUN --mount=type=cache,target=/root/.npm \
     npm install -g "firecrawl-mcp@${FIRECRAWL_MCP_VERSION}"
 
+# Pre-install codeindex (shipped `codeindex` builtin plugin) for the same
+# cold-start reason as firecrawl above: its MCP server must answer tools/list
+# immediately, and its `lifecycle` index runs before the workflow starts.
+# The global install ALSO puts `codeindex` on PATH, which is what the plugin's
+# rewriter locates — without it the rewriter degrades to passthrough (harmless,
+# but it contributes nothing). Version PINNED and MUST match all three pins in
+# pkg/plugin/builtin/codeindex/plugin.yaml.
+# renovate: datasource=npm depName=@maxgfr/codeindex versioning=npm
+ARG CODEINDEX_VERSION=2.17.0
+RUN --mount=type=cache,target=/root/.npm \
+    npm install -g "@maxgfr/codeindex@${CODEINDEX_VERSION}"
+
 # gh + glab (Revi posts reviews from the runner pod) + kubectl (parity with the
 # base runner image; also used by the k8s sandbox driver if ever enabled).
 ARG GLAB_VERSION=1.102.0

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -8,8 +8,8 @@ out-of-process** packages. A plugin never injects Go code (iterion ships static
 
 Plugins are installable-by-default, uninstallable, replaceable, and composable —
 `rtk` (the command-output compressor) ships as a plugin enabled by default; the
-knowledge-graph explorers `graphify` and `repo-falcon` and the web toolkit
-`firecrawl` (Firecrawl search/scrape/crawl MCP — see
+knowledge-graph explorers `graphify`, `repo-falcon` and `codeindex` and the web
+toolkit `firecrawl` (Firecrawl search/scrape/crawl MCP — see
 [web-search.md](web-search.md)) ship disabled.
 
 ## Contribution kinds (v1)
@@ -49,7 +49,7 @@ A single plugin may contribute several kinds (repo-falcon ships `mcp_servers` +
 ## Where plugins live
 
 - **Builtins** are embedded in the binary under `pkg/plugin/builtin/<name>/`
-  (`rtk`, `graphify`, `repo-falcon`, `firecrawl`).
+  (`rtk`, `graphify`, `repo-falcon`, `codeindex`, `firecrawl`).
 - **Installed** plugins live under `~/.iterion/plugins/<name>/` (a directory
   with a `plugin.yaml`). `iterion plugin install <path|git-url>` puts them there.
 - **Enable/disable state** is persisted in `~/.iterion/plugins.yaml`; the
@@ -254,7 +254,7 @@ Diagnostic `C102` flags an invalid `compress:` value.
 
 ## Knowledge-graph explorers
 
-Two are shipped as disabled builtins; enable either to give agents code-graph
+Three are shipped as disabled builtins; enable any to give agents code-graph
 context:
 
 - **repo-falcon** — a deterministic Go MCP server. Enabling it injects the
@@ -265,11 +265,32 @@ context:
 - **graphify** — a CLI + skill that builds a queryable graph (`graphify-out/`)
   spanning code and docs; the skill guides agents to `graphify query` / read the
   report. Its `lifecycle` builds/updates the graph.
+- **codeindex** — a deterministic, zero-dependency repo-indexing engine
+  distributed on npm (`@maxgfr/codeindex`, version-pinned `npx` like
+  `firecrawl`). It is the **broadest** contributor shipped: `mcp_servers`
+  (26 tools — link-graph, symbols, callers, references, BM25/semantic search,
+  hotspots, change coupling, complexity, dead code, architecture rules, agent
+  memories and symbolic edits), `lifecycle` (incremental `.codeindex/`
+  artifacts), `skills`, `commands` (`/codeindex-map`, `/codeindex-impact`,
+  `/codeindex-risk`), `agents` (`codebase-cartographer`) **and** a `rewriter`.
+  Its MCP server is pinned to the workspace (`mcp --repo {{workspace}}`), so
+  agents never pass an absolute path. Its rewriter maps a tree-wide `grep -r` /
+  `rg` onto the indexed equivalent — it locates a real `codeindex` binary
+  (Homebrew, `npm -g`, or the runner image's pre-installed global) and degrades
+  to passthrough when none is present, so it never pays `npx` startup on a
+  per-command hook. Priming the index first turns MCP activation into a load
+  rather than a rebuild, which is what `auto_index: true` does before a run.
 
 ```sh
 iterion plugin enable repo-falcon
 iterion plugin run repo-falcon index   # build the snapshot for this workspace
 # now any bot run exposes falcon_* tools to its agents
+
+iterion plugin enable codeindex
+iterion plugin run codeindex index     # writes <workspace>/.codeindex/
+iterion plugin config codeindex --set max_files=50000   # large monorepo
+# optional: RRF-fused semantic search instead of lexical-only
+iterion plugin config codeindex --set embed_endpoint=http://iterion-codeindex-embed:8756
 ```
 
 ## CLI

--- a/pkg/plugin/builtin/codeindex/agents/codebase-cartographer.md
+++ b/pkg/plugin/builtin/codeindex/agents/codebase-cartographer.md
@@ -1,0 +1,49 @@
+---
+name: codebase-cartographer
+description: Use to answer "where is X handled", "what calls Y", "what breaks if I change Z" or "how is this repo organized" against a large codebase. Queries the codeindex index instead of reading files, so it answers structural questions without spending context on source.
+tools: mcp__codeindex__repo_map, mcp__codeindex__scan_summary, mcp__codeindex__workspaces, mcp__codeindex__search, mcp__codeindex__grep, mcp__codeindex__find_symbol, mcp__codeindex__symbols_overview, mcp__codeindex__find_references, mcp__codeindex__callers, mcp__codeindex__coupling, mcp__codeindex__hotspots, mcp__codeindex__complexity, mcp__codeindex__mermaid, mcp__codeindex__dead_code, mcp__codeindex__check_rules, Read
+---
+
+# Codebase cartographer
+
+You answer structural questions about this codebase from the **codeindex**
+index. The server is pinned to this workspace: omit the `repo` argument on every
+tool call.
+
+Your value is that you resolve a question **without** loading the codebase into
+context. Query the index first; read source only to confirm a specific detail
+the index cannot settle, and read the narrowest slice that settles it.
+
+## Method
+
+1. **Locate** — `search` for concept-shaped questions ("where is auth
+   handled"), `grep` only for exact literals, `find_symbol` when you have a
+   name. `find_symbol(includeBody: true)` usually removes the need to read the
+   file at all.
+2. **Expand** — `symbols_overview` for what a file declares, `find_references`
+   and `callers` for who depends on it.
+3. **Contextualize** — `repo_map` / `workspaces` / `mermaid` when the question
+   is about organization; `coupling`, `hotspots`, `complexity` when it is about
+   risk.
+4. **Confirm** — `Read` only the specific lines the index pointed you at.
+
+## Reporting
+
+Answer the question that was asked, directly and first. Then the evidence.
+
+Cite `file:line` for every claim that came from the index — the caller who
+dispatched you should be able to jump straight there.
+
+Distinguish tiers of confidence explicitly, because the index does:
+`callSites` are resolved bindings; `referencingFiles` are mentions that may be
+homonyms; `dead_code` gives candidates, never proof.
+
+State what you could not determine. This is **static analysis, not an LSP** —
+reflection, dynamic dispatch, code generation, string-keyed lookup and
+runtime wiring are invisible to it. When a question depends on any of those,
+say so rather than presenting a confident partial answer. If `scan_summary`
+reports `capped: true`, the walk hit its file limit and your coverage is
+incomplete — surface that up front.
+
+Do not modify files. You are read-only, even though the plugin's MCP server also
+exposes symbolic-edit tools; those are not in your tool list.

--- a/pkg/plugin/builtin/codeindex/commands/codeindex-impact.md
+++ b/pkg/plugin/builtin/codeindex/commands/codeindex-impact.md
@@ -1,0 +1,39 @@
+---
+description: Blast radius of changing a symbol or file, from the codeindex index — callers, references and hidden change coupling.
+argument-hint: "<symbol name or file path>"
+---
+
+# Impact of changing $ARGUMENTS
+
+Determine what breaks if `$ARGUMENTS` changes, using the `codeindex` MCP tools.
+The server is pinned to this workspace, so omit the `repo` argument.
+
+If `$ARGUMENTS` is empty, ask what to analyze and stop.
+
+**If it looks like a file path:**
+
+1. `symbols_overview(file)` — what the file declares.
+2. `find_references()` on each exported symbol — who depends on them.
+3. `coupling()` — files that historically change together with this one.
+4. `complexity(file)` — how risky the file itself is to touch.
+
+**If it looks like a symbol:**
+
+1. `find_symbol(namePath, includeBody: true)` — the declaration and its source.
+   If several match, list the candidates and ask which one before continuing.
+2. `find_references(name)` — the three tiers.
+3. `callers(name)` — the precise call sites.
+4. `coupling()` — what else tends to move with the defining file.
+
+Report:
+
+- **Definition** — where it lives, what it is.
+- **Direct callers** — the line-precise `callSites`. These are the bindings the
+  index actually resolved; treat them as the reliable tier.
+- **Weaker references** — `referencingFiles` (identifier or doc mentions, and
+  possibly homonyms). Label them as such; do not merge them into the tier above.
+- **Hidden coupling** — high-`strength` pairs from `coupling()`: files that
+  change together without any import edge between them.
+- **Verdict** — is this a safe local change or a wide one, and what to verify by
+  hand. Static analysis does not see reflection, dynamic dispatch or string-keyed
+  lookups; say where that limit applies here rather than implying full coverage.

--- a/pkg/plugin/builtin/codeindex/commands/codeindex-map.md
+++ b/pkg/plugin/builtin/codeindex/commands/codeindex-map.md
@@ -1,0 +1,36 @@
+---
+description: Orient in this codebase from the codeindex index — structure, entry points and where the weight sits.
+argument-hint: "[module or directory to focus on]"
+---
+
+# Map this codebase
+
+Build an orientation briefing using the `codeindex` MCP tools. The server is
+pinned to this workspace, so omit the `repo` argument everywhere.
+
+If `$ARGUMENTS` names a module or directory, scope the whole briefing to it
+(pass it as `scope`, or as `module` to `mermaid`); otherwise cover the repo.
+
+1. `list_memories()` — if a previous run already wrote a project map, read it
+   and build on it instead of starting over.
+2. `scan_summary()` — size, languages, HEAD commit. Note if `capped` is true:
+   the walk hit its file limit and everything below is partial.
+3. `workspaces()` — if this is a monorepo, report the packages, their dependency
+   direction and any cycle. Do not treat the repo as one unit when it is not.
+4. `repo_map(budgetTokens: 2000)` — the load-bearing files and their exported
+   signatures.
+5. `mermaid()` — the module graph.
+
+Then write the briefing:
+
+- **What this is** — one paragraph, grounded in what you actually saw.
+- **Structure** — the modules/packages and what each owns.
+- **Entry points** — where execution starts, and the main flows.
+- **Where the weight sits** — the highest-centrality files from `repo_map`, and
+  what makes them load-bearing.
+- **Diagram** — the mermaid graph.
+- **Unknowns** — anything the index could not settle. Say so plainly rather
+  than filling the gap with a plausible guess.
+
+Finish by offering to `write_memory("project-map", …)` so the next run starts
+from this instead of re-deriving it.

--- a/pkg/plugin/builtin/codeindex/commands/codeindex-risk.md
+++ b/pkg/plugin/builtin/codeindex/commands/codeindex-risk.md
@@ -1,0 +1,38 @@
+---
+description: Where the risk concentrates in this codebase — churn hotspots, complexity, hidden coupling and dead code.
+argument-hint: "[git ref to measure churn since, e.g. v1.2.0]"
+---
+
+# Risk report
+
+Find where this codebase is most likely to break, using the `codeindex` MCP
+tools. The server is pinned to this workspace, so omit the `repo` argument.
+
+If `$ARGUMENTS` names a git ref, pass it as `since` to every churn-based tool so
+the report covers that window rather than all history.
+
+1. `hotspots(since)` — churn × size. Where the work concentrates.
+2. `complexity(risk: true)` — complexity × churn. Complicated code that also
+   keeps changing.
+3. `coupling(since)` — files that change together. High `strength` with no
+   import edge means an undocumented dependency.
+4. `dead_code()` — the `unreferenced` and `uncalled` tiers.
+5. `check_rules(rules)` — if the repo has an architecture-rules config, validate
+   it; otherwise at minimum run the `cycles` and `orphans` builtins.
+
+Report, most actionable first:
+
+- **Hotspots** — file, why it ranks, what it owns.
+- **Risky complexity** — the overlap of complex and churning. This is where
+  defects cluster; be concrete about which functions.
+- **Hidden coupling** — pairs with high strength and no import relationship,
+  with a guess at why, marked as a guess.
+- **Structural violations** — cycles, orphans, forbidden edges.
+- **Dead code candidates** — keep the two tiers separate and state plainly that
+  neither is proof: reflection, dynamic dispatch, string-keyed lookup and
+  external consumers are all invisible to static analysis. Recommend
+  verification, not deletion.
+
+Close with the three changes that would most reduce risk, and what each costs.
+Rank by evidence you actually gathered — if the data does not support a ranking,
+say so instead of inventing one.

--- a/pkg/plugin/builtin/codeindex/plugin.yaml
+++ b/pkg/plugin/builtin/codeindex/plugin.yaml
@@ -1,0 +1,87 @@
+name: codeindex
+version: 1.0.0
+description: Deterministic repo-indexing engine (26 MCP tools) — link-graph, symbols, callers, indexed search, hotspots, symbolic edits
+author: maxgfr (https://github.com/maxgfr/codeindex)
+schema_version: 1
+default_enabled: false
+auto_index: true
+config:
+  - key: embed_endpoint
+    label: Embedding endpoint URL
+    type: string
+    description: >-
+      Base URL of a codeindex embedding server (e.g. http://iterion-codeindex-embed:8756),
+      which upgrades the `search` tool from lexical BM25 to RRF-fused semantic
+      search. Leave empty for keyless lexical search — the default, and the only
+      tier that needs no extra deployment.
+    default: ""
+  - key: max_files
+    label: Max files walked
+    type: int
+    description: >-
+      Cap on files walked when building the index. The engine reports a `capped`
+      flag rather than silently truncating, so raise this for a large monorepo.
+    default: "20000"
+contributes:
+  mcp_servers:
+    - name: codeindex
+      transport: stdio
+      command: npx
+      # Version PINNED (supply-chain: never resolve a moving `latest`). Must
+      # match Dockerfile.runner-devbox's CODEINDEX_VERSION so the cloud runner
+      # reuses its warm pre-installed global instead of downloading.
+      args:
+        - -y
+        # renovate: datasource=npm depName=@maxgfr/codeindex versioning=npm
+        - "@maxgfr/codeindex@2.17.0"
+        - mcp
+        # Pin the server to the workspace so all 26 tools take `repo` as
+        # optional — agents never have to know the absolute checkout path.
+        - --repo
+        - "{{workspace}}"
+      env:
+        CODEINDEX_EMBED_ENDPOINT: "{{config.embed_endpoint}}"
+  rewriters:
+    # Maps a tree-wide `grep -r` / `rg` onto the indexed equivalent: bounded,
+    # structured, gitignore-correct hits instead of an unbounded wall of text.
+    # `locate` finds a real binary (brew / npm -g / the runner image's global);
+    # when none is present the chain degrades to passthrough, so this contributes
+    # nothing rather than paying npx startup on every shell command.
+    - id: codeindex
+      locate:
+        env: ITERION_CODEINDEX_BIN
+        bin: codeindex
+        paths:
+          - ~/.local/bin/codeindex
+          - /usr/local/bin/codeindex
+          - /opt/homebrew/bin/codeindex
+      invoke:
+        argv: ["rewrite", "{{command}}"]
+        timeout_ms: 5000
+        # codeindex exits 1 with empty stdout when it has no opinion, so only
+        # 0 carries a rewrite — the default, stated here for clarity.
+        apply_exit_codes: [0]
+        modes:
+          on: {}
+          # Denser output: a tighter hit cap for the same query.
+          ultra:
+            inject_flag: "--max-hits 40"
+      sandbox_mount: /usr/local/bin/codeindex
+  lifecycle:
+    # `index` is incremental (cache.json + an artifact fastpath), so refresh is
+    # the same command: an unchanged repo rewrites nothing and costs one walk.
+    # EVERY version occurrence in this file carries its own renovate comment —
+    # the regex manager captures the version on the line following the comment,
+    # so an unannotated occurrence would silently go stale.
+    # renovate: datasource=npm depName=@maxgfr/codeindex versioning=npm
+    index: "npx -y @maxgfr/codeindex@2.17.0 index --repo {{workspace}} --out {{workspace}}/.codeindex --max-files {{config.max_files}}"
+    # renovate: datasource=npm depName=@maxgfr/codeindex versioning=npm
+    refresh: "npx -y @maxgfr/codeindex@2.17.0 index --repo {{workspace}} --out {{workspace}}/.codeindex --max-files {{config.max_files}}"
+  skills:
+    - skills/code-index.md
+  commands:
+    - commands/codeindex-map.md
+    - commands/codeindex-impact.md
+    - commands/codeindex-risk.md
+  agents:
+    - agents/codebase-cartographer.md

--- a/pkg/plugin/builtin/codeindex/skills/code-index.md
+++ b/pkg/plugin/builtin/codeindex/skills/code-index.md
@@ -1,0 +1,96 @@
+---
+name: code-index
+description: Query the codeindex repo index (symbols, callers, references, indexed search, hotspots, complexity, architecture rules) via the codeindex MCP tools before reading or grepping code.
+---
+
+# Code index (codeindex)
+
+This workspace has a **deterministic repo index** built by codeindex and served
+over MCP. Before grepping the whole tree or guessing how symbols connect, query
+the index — it answers structural questions from pre-built artifacts, with no
+LLM and no full-text scan.
+
+The tools are exposed under the `codeindex` server. The server is **pinned to
+this workspace**, so every tool's `repo` argument is optional — omit it.
+(Iterion namespaces them `mcp.codeindex.*` for the claw backend and
+`mcp__codeindex__*` for the claude_code backend; they appear in your tool list
+automatically when the plugin is enabled.)
+
+## Orient before you read
+
+- **`repo_map(budgetTokens)`** — the densest single read of an unfamiliar
+  codebase: highest-PageRank files with their key exported signatures, fitted to
+  a token budget. Start here.
+- **`scan_summary()`** — file count, language histogram, HEAD commit. Confirms
+  what you are actually looking at.
+- **`workspaces()`** — monorepo packages, their dependency graph and a
+  topological build order. Run this before assuming the repo is one unit.
+- **`mermaid(module)`** — module graph as a diagram, optionally focused.
+
+## Find things
+
+- **`search(query)`** — ranked lexical search (BM25) over symbol names, path
+  segments and markdown headings. This is the right tool for *"where is auth
+  handled?"*. Prefer it over `grep` for concept-shaped questions.
+- **`grep(pattern)`** — regex over file contents when you need exact literal
+  matches. Returns bounded, sorted `(file, line, text)` hits.
+- **`find_symbol(namePath)`** — declarations by name or `Class/method` path;
+  `includeBody: true` returns the source, so you often need no file read at all.
+- **`symbols_overview(file)`** — every symbol declared in ONE file, in
+  declaration order. The fastest way to understand a file without reading it.
+
+## Before you change anything
+
+- **`find_references(name)`** — the blast radius, in three labeled tiers: `defs`,
+  line-precise `callSites`, and file-level `referencingFiles`. Confidence drops
+  across the tiers and the labels say so — trust `callSites` over
+  `referencingFiles`, which can include homonyms.
+- **`callers(name)`** — the call-site index for one symbol.
+- **`dead_code()`** — candidates in two honest tiers: `unreferenced` (nothing
+  binds or mentions it) and `uncalled` (referenced in a type or re-export
+  position but never called). Neither tier is proof; verify before deleting.
+
+## Judge risk
+
+- **`hotspots()`** — churn × size: where changes and defects concentrate.
+- **`coupling()`** — files that repeatedly change together. Hidden dependencies
+  that no import statement reveals — check this before a "small" edit.
+- **`complexity(file)`** — cyclomatic estimates, most complex first;
+  `risk: true` ranks complexity × churn instead.
+- **`check_rules(rules)`** — validate forbidden edges, import cycles and orphans
+  against the link-graph. A CI-gate-shaped answer to "did I break the layering?"
+
+## Edit symbolically
+
+`replace_symbol_body`, `insert_after_symbol`, `insert_before_symbol` operate on
+AST line spans by name path, so you do not have to reproduce surrounding context
+the way a text patch does. Supply the full declaration including indentation.
+Ambiguity is an error listing the candidates — qualify with `file`.
+
+## Remember across runs
+
+`write_memory` / `read_memory` / `list_memories` persist short markdown notes
+under `.codeindex/memories/`. Call `list_memories()` early and read what looks
+relevant; write back the project map, build commands or conventions you had to
+work out, so the next run does not re-derive them.
+
+## Workflow
+
+1. `list_memories()`, then `repo_map()` to orient.
+2. `search()` to locate the area; `find_symbol(includeBody)` to read just the
+   declaration you need.
+3. For anything you plan to change: `find_references()` for blast radius, then
+   `coupling()` if the file is load-bearing.
+4. Edit — symbolically where it fits.
+5. `write_memory()` for anything worth not re-deriving.
+
+## Trust and staleness
+
+Everything is **static analysis, not an LSP**: bindings are extracted and
+resolved, never executed. Edge and reference tiers carry explicit confidence
+labels — read them rather than treating every hit as certain.
+
+The index is built and refreshed by the plugin's lifecycle (`index`/`refresh`),
+incrementally. If a lookup returns nothing for a symbol you know exists, the
+index may be stale or the walk may have been capped (`scan_summary` reports
+`capped`) — say so and fall back to reading the source directly.

--- a/pkg/plugin/codeindex_test.go
+++ b/pkg/plugin/codeindex_test.go
@@ -1,0 +1,159 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The codeindex builtin is the broadest contributor shipped (mcp_servers +
+// rewriters + lifecycle + skills + commands + agents), so it is also the one
+// most able to rot silently: a renamed markdown file still parses, and a
+// version pin that drifts out of lockstep with the runner image still runs —
+// it just quietly downloads a second copy at cold start. These tests pin the
+// invariants that no schema check would catch.
+
+func TestCodeindexBuiltinContributions(t *testing.T) {
+	t.Setenv("ITERION_HOME", t.TempDir())
+	reg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	p, ok := reg.Get("codeindex")
+	if !ok {
+		t.Fatal("builtin \"codeindex\" missing")
+	}
+
+	// A knowledge-graph explorer is opt-in, like its peers.
+	if reg.IsEnabled("codeindex") {
+		t.Error("codeindex should be disabled by default")
+	}
+	if !p.Manifest.AutoIndex {
+		t.Error("auto_index should be true: priming .codeindex/ turns MCP activation into a load, not a rebuild")
+	}
+
+	// The MCP server must pin the workspace, otherwise every tool call needs an
+	// absolute path the agent has no way to know.
+	mcps := p.Manifest.Contributes.MCPServers
+	if len(mcps) != 1 || mcps[0].Name != "codeindex" {
+		t.Fatalf("mcp_servers = %+v, want one named codeindex", mcps)
+	}
+	args := strings.Join(mcps[0].Args, " ")
+	for _, want := range []string{"mcp", "--repo", "{{workspace}}"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("mcp args %q missing %q", args, want)
+		}
+	}
+	if mcps[0].Command != "npx" {
+		t.Errorf("mcp command = %q, want npx", mcps[0].Command)
+	}
+
+	// The rewriter must locate a real binary rather than shelling out to npx:
+	// it runs on EVERY shell command, where npx startup would dominate.
+	rw := p.Manifest.Contributes.Rewriters
+	if len(rw) != 1 || rw[0].ID != "codeindex" {
+		t.Fatalf("rewriters = %+v, want one with id codeindex", rw)
+	}
+	if rw[0].Locate.Bin != "codeindex" || rw[0].Locate.Env == "" || len(rw[0].Locate.Paths) == 0 {
+		t.Errorf("rewriter locate = %+v, want env + bin + paths", rw[0].Locate)
+	}
+	if rw[0].SandboxMount == "" {
+		t.Error("rewriter needs a sandbox_mount or it cannot run in a sandboxed run")
+	}
+
+	if lc := p.Manifest.Contributes.Lifecycle; lc == nil || lc.Index == "" || lc.Refresh == "" {
+		t.Fatalf("lifecycle = %+v, want index and refresh", lc)
+	}
+
+	// Every declared markdown path must actually resolve in the embedded FS.
+	for _, kind := range MirrorKinds {
+		files, err := p.MirrorFiles(kind)
+		if err != nil {
+			t.Fatalf("MirrorFiles(%s): %v", kind.Name, err)
+		}
+		if len(files) == 0 {
+			t.Errorf("codeindex contributes no %s files", kind.Name)
+		}
+		for _, f := range files {
+			if len(f.Content) == 0 {
+				t.Errorf("%s %q is empty", kind.Name, f.Name)
+			}
+		}
+	}
+}
+
+// repoRoot walks up from the package dir to the module root.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	return dir
+}
+
+// Every @maxgfr/codeindex pin — the three in plugin.yaml and the runner image's
+// ARG — must agree. A drifted pin is not a build failure: the runtime `npx`
+// silently downloads a different version than the one baked into the image,
+// which is exactly the cold-start race the pre-install exists to prevent.
+func TestCodeindexVersionPinsInLockstep(t *testing.T) {
+	root := repoRoot(t)
+	pinRe := regexp.MustCompile(`@maxgfr/codeindex@(\d+\.\d+\.\d+)`)
+	argRe := regexp.MustCompile(`ARG CODEINDEX_VERSION=(\d+\.\d+\.\d+)`)
+
+	manifest, err := os.ReadFile(filepath.Join(root, "pkg/plugin/builtin/codeindex/plugin.yaml"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	pins := pinRe.FindAllStringSubmatch(string(manifest), -1)
+	if len(pins) < 3 {
+		t.Fatalf("expected the mcp arg + both lifecycle commands to pin a version, got %d", len(pins))
+	}
+	want := pins[0][1]
+	for _, p := range pins {
+		if p[1] != want {
+			t.Errorf("plugin.yaml pins both %s and %s", want, p[1])
+		}
+	}
+
+	dockerfile, err := os.ReadFile(filepath.Join(root, "Dockerfile.runner-devbox"))
+	if err != nil {
+		t.Fatalf("read Dockerfile.runner-devbox: %v", err)
+	}
+	m := argRe.FindStringSubmatch(string(dockerfile))
+	if m == nil {
+		t.Fatal("Dockerfile.runner-devbox has no CODEINDEX_VERSION ARG — the runner would cold-download on every pod")
+	}
+	if m[1] != want {
+		t.Errorf("Dockerfile pins %s but plugin.yaml pins %s — runtime npx would fetch a second copy", m[1], want)
+	}
+}
+
+// A renovate regex-manager pin only updates the version on the line FOLLOWING
+// its comment. An occurrence without its own comment goes stale silently, and
+// a file absent from managerFilePatterns is never scanned at all.
+func TestCodeindexPinsAreRenovateTracked(t *testing.T) {
+	root := repoRoot(t)
+	manifestPath := filepath.Join(root, "pkg/plugin/builtin/codeindex/plugin.yaml")
+	manifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	// Mirrors renovate.json's matchStrings.
+	tracked := regexp.MustCompile(`# renovate: datasource=\S+ depName=\S+(?: versioning=\S+)?\s+[^\n]*?(\d+\.\d+\.\d+)`)
+	nTracked := len(tracked.FindAllString(string(manifest), -1))
+	nPins := len(regexp.MustCompile(`@maxgfr/codeindex@\d+\.\d+\.\d+`).FindAllString(string(manifest), -1))
+	if nTracked != nPins {
+		t.Errorf("%d version pins but %d renovate comments — every pin needs its own", nPins, nTracked)
+	}
+
+	renovate, err := os.ReadFile(filepath.Join(root, "renovate.json"))
+	if err != nil {
+		t.Fatalf("read renovate.json: %v", err)
+	}
+	if !strings.Contains(string(renovate), "pkg/plugin/builtin/codeindex/plugin") {
+		t.Error("renovate.json managerFilePatterns does not cover the codeindex plugin manifest")
+	}
+}

--- a/renovate.json
+++ b/renovate.json
@@ -28,10 +28,11 @@
     },
     {
       "customType": "regex",
-      "description": "Inline `# renovate: datasource=… depName=… versioning=…` pins. Captures the version on the line right after the comment, in ANY file (e.g. the pinned firecrawl-mcp in Dockerfile.runner-devbox's ARG and pkg/plugin/builtin/firecrawl/plugin.yaml's npx arg — both MUST stay in lockstep, so a bump PR touches both). To pin another tool anywhere, drop the same comment above its version line.",
+      "description": "Inline `# renovate: datasource=… depName=… versioning=…` pins. Captures the version on the line right after the comment, in ANY file (e.g. the pinned firecrawl-mcp in Dockerfile.runner-devbox's ARG and pkg/plugin/builtin/firecrawl/plugin.yaml's npx arg — both MUST stay in lockstep, so a bump PR touches both; same for @maxgfr/codeindex in the codeindex plugin). To pin another tool anywhere, drop the same comment above its version line AND add the file here — a path missing from this list is a pin that silently goes stale.",
       "managerFilePatterns": [
         "/(^|/)Dockerfile\\.runner-devbox$/",
-        "/(^|/)pkg/plugin/builtin/firecrawl/plugin\\.yaml$/"
+        "/(^|/)pkg/plugin/builtin/firecrawl/plugin\\.yaml$/",
+        "/(^|/)pkg/plugin/builtin/codeindex/plugin\\.yaml$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+[^\\n]*?(?<currentValue>\\d+\\.\\d+\\.\\d+)"


### PR DESCRIPTION
## What

Wires [codeindex](https://github.com/maxgfr/codeindex) — a deterministic, zero-dependency repo-indexing engine distributed on npm — in as a **disabled-by-default builtin**, alongside the other knowledge-graph explorers (`repo-falcon`, `graphify`).

```sh
iterion plugin enable codeindex
iterion plugin run codeindex index     # writes <workspace>/.codeindex/
```

## Why it's worth a builtin slot

It is the **broadest contributor shipped so far** — the first plugin to exercise five contribution kinds at once, so it also doubles as an end-to-end exercise of the `contributes:` design:

| kind | what it adds |
|---|---|
| `mcp_servers` | 26 tools: link-graph, symbols, callers, references, BM25 + optional semantic search, hotspots, change coupling, complexity, dead code, architecture rules, agent memories, symbolic edits |
| `lifecycle` | incremental `.codeindex/` artifacts (`auto_index: true`) |
| `skills` | `code-index.md` — when to use which tool, and how far to trust it |
| `commands` | `/codeindex-map`, `/codeindex-impact`, `/codeindex-risk` |
| `agents` | `codebase-cartographer` — read-only, answers structural questions without spending context on source |
| `rewriters` | maps a tree-wide `grep -r` / `rg` onto the indexed equivalent |

## Design notes

**The MCP server is pinned to the workspace.** `mcp --repo {{workspace}}` makes `repo` optional on all 26 tools, so agents never have to know the absolute checkout path. This required an upstream change (below).

**The rewriter contributes no `sandbox_mount`.** rtk bind-mounts its host binary because it is a single static executable; codeindex is a Node bundle whose bin entry imports `./engine.mjs` as a *sibling*. Mounting only the bin path would land a module that cannot resolve its own import — and would shadow the working global the runner image installs at that exact path. This is the "production images may bake the binary in instead" case `addRewriterMounts` already anticipates.

**The rewriter deliberately does *not* use npx.** It runs on every shell command, where npx startup would dominate a 5 s budget — so it `locate`s a real binary (Homebrew / `npm -g` / the runner image's pre-installed global) and degrades to **passthrough** when none is found. Enabling the plugin without a binary costs nothing rather than breaking shells.

**`index` == `refresh`** because the engine is incremental (`cache.json` + an artifact fastpath): an unchanged repo rewrites nothing and costs one walk. Priming turns MCP activation into a load rather than a rebuild.

## Supply chain

Follows the `firecrawl` precedent: the version is **pinned** (never a moving `latest`), and `Dockerfile.runner-devbox` pre-installs the same version so runtime `npx` reuses the warm global instead of cold-downloading — the same discovery race the firecrawl pre-install exists to prevent.

Two failure modes here break nothing at build time and so are covered by tests instead:

- a pin drifting out of lockstep with the runner image → runtime silently fetches a *second* copy;
- the renovate regex manager only updates the version on the line **following** its comment, so a pin without its own comment goes stale silently, and a file missing from `managerFilePatterns` is never scanned at all.

`TestCodeindexVersionPinsInLockstep` and `TestCodeindexPinsAreRenovateTracked` assert both.

## Upstream changes (already released)

`repo`-optional pinning did not exist; it was added upstream and published as **`@maxgfr/codeindex@2.17.1`** ([maxgfr/codeindex@a205c34](https://github.com/maxgfr/codeindex/commit/a205c34)):

- `mcp --repo <dir>` — binds the server to one repo; `repo` leaves every tool's `required` set and its description names the default, so a client omitting it is spec-correct rather than relying on server leniency. An explicit per-call `repo` still wins. Unpinned behaviour is byte-compatible.
- `mcp --server-name <name>` — exposes the existing `serverInfo` override to the CLI, so a host can embed the server under its own identity without a JS shim.
- `rewrite '<command line>'` — the rewriter contract, deliberately conservative: any shell metacharacter, unknown flag, non-recursive `grep` or multi-path search **refuses** the rewrite. A refusal is free; a wrong rewrite silently changes what the agent asked for.
- fix: `grep` now honours `--scope`, documented as global sugar but silently dropped there alone.
- fix (**2.17.1**): global flags are accepted *before* the subcommand. `codeindex --repo /x scan` used to fail with "unknown flag: scan". This was also a correctness bug for this plugin: `inject_flag` splices a flag in right after the binary name, so `ultra` mode emitted `codeindex --max-hits 40 grep foo` — a command that could not run. Caught on a review pass over this PR, not by manifest validation.

## Verification

- `go vet -mod=vendor ./...` — clean.
- `go test -mod=vendor ./pkg/plugin/... ./pkg/backend/mcp/...` — pass, incl. 3 new tests.
- Full `go test -mod=vendor ./...`: 4 packages fail (`dispatcher/native`, `runtime`, `schedgate`, `server`) — **identically on unmodified `main`** in this environment (macOS `/private/var` symlink, missing Mongo). Unrelated to this change.
- End-to-end against the **published** package, via the exact invocation in the manifest:

```console
$ npx -y @maxgfr/codeindex@2.17.1 mcp --repo <workspace>
tools: 26 | scan_summary.required: []
call-without-repo OK, files=3828
```
