### PR TITLE
fix(plugin): repair two codeindex rewriter defects

### DIFF
--- a/Dockerfile.runner-devbox
+++ b/Dockerfile.runner-devbox
@@ -67,7 +67,7 @@ RUN --mount=type=cache,target=/root/.npm \
 # but it contributes nothing). Version PINNED and MUST match all three pins in
 # pkg/plugin/builtin/codeindex/plugin.yaml.
 # renovate: datasource=npm depName=@maxgfr/codeindex versioning=npm
-ARG CODEINDEX_VERSION=2.17.0
+ARG CODEINDEX_VERSION=2.17.1
 RUN --mount=type=cache,target=/root/.npm \
     npm install -g "@maxgfr/codeindex@${CODEINDEX_VERSION}"
 

--- a/pkg/plugin/builtin/codeindex/plugin.yaml
+++ b/pkg/plugin/builtin/codeindex/plugin.yaml
@@ -33,7 +33,7 @@ contributes:
       args:
         - -y
         # renovate: datasource=npm depName=@maxgfr/codeindex versioning=npm
-        - "@maxgfr/codeindex@2.17.0"
+        - "@maxgfr/codeindex@2.17.1"
         - mcp
         # Pin the server to the workspace so all 26 tools take `repo` as
         # optional — agents never have to know the absolute checkout path.
@@ -63,10 +63,20 @@ contributes:
         apply_exit_codes: [0]
         modes:
           on: {}
-          # Denser output: a tighter hit cap for the same query.
+          # Denser output: a tighter hit cap for the same query. The flag is
+          # spliced in right after the binary name, so it lands BEFORE the
+          # subcommand — which codeindex accepts as of 2.17.1.
           ultra:
             inject_flag: "--max-hits 40"
-      sandbox_mount: /usr/local/bin/codeindex
+      # NO sandbox_mount, deliberately. rtk can bind-mount its host binary into
+      # the container because it is a single static executable; codeindex is a
+      # Node bundle whose bin entry `import`s ./engine.mjs as a SIBLING file.
+      # Mounting only the bin path would land a module that cannot resolve its
+      # own import — and worse, it would shadow the working global that
+      # Dockerfile.runner-devbox installs at exactly /usr/local/bin/codeindex.
+      # This is the "production images may bake the binary in instead" case
+      # addRewriterMounts already anticipates; sandboxed runs use the in-image
+      # install, and a host-only install degrades to passthrough.
   lifecycle:
     # `index` is incremental (cache.json + an artifact fastpath), so refresh is
     # the same command: an unchanged repo rewrites nothing and costs one walk.
@@ -74,9 +84,9 @@ contributes:
     # the regex manager captures the version on the line following the comment,
     # so an unannotated occurrence would silently go stale.
     # renovate: datasource=npm depName=@maxgfr/codeindex versioning=npm
-    index: "npx -y @maxgfr/codeindex@2.17.0 index --repo {{workspace}} --out {{workspace}}/.codeindex --max-files {{config.max_files}}"
+    index: "npx -y @maxgfr/codeindex@2.17.1 index --repo {{workspace}} --out {{workspace}}/.codeindex --max-files {{config.max_files}}"
     # renovate: datasource=npm depName=@maxgfr/codeindex versioning=npm
-    refresh: "npx -y @maxgfr/codeindex@2.17.0 index --repo {{workspace}} --out {{workspace}}/.codeindex --max-files {{config.max_files}}"
+    refresh: "npx -y @maxgfr/codeindex@2.17.1 index --repo {{workspace}} --out {{workspace}}/.codeindex --max-files {{config.max_files}}"
   skills:
     - skills/code-index.md
   commands:

--- a/pkg/plugin/codeindex_test.go
+++ b/pkg/plugin/codeindex_test.go
@@ -59,8 +59,13 @@ func TestCodeindexBuiltinContributions(t *testing.T) {
 	if rw[0].Locate.Bin != "codeindex" || rw[0].Locate.Env == "" || len(rw[0].Locate.Paths) == 0 {
 		t.Errorf("rewriter locate = %+v, want env + bin + paths", rw[0].Locate)
 	}
-	if rw[0].SandboxMount == "" {
-		t.Error("rewriter needs a sandbox_mount or it cannot run in a sandboxed run")
+	// Deliberately NO sandbox_mount: codeindex's bin entry imports ./engine.mjs
+	// as a sibling, so bind-mounting the bin path alone yields a module that
+	// cannot resolve its own import — and it would shadow the working global the
+	// runner image installs at that very path. Asserted so a future "every
+	// rewriter should mount its binary" cleanup cannot silently reintroduce it.
+	if rw[0].SandboxMount != "" {
+		t.Errorf("sandbox_mount = %q, want empty: a Node bundle is not a self-contained binary", rw[0].SandboxMount)
 	}
 
 	if lc := p.Manifest.Contributes.Lifecycle; lc == nil || lc.Index == "" || lc.Refresh == "" {


### PR DESCRIPTION
Follow-up to #296. Two defects in the codeindex rewriter, both found on a review pass **after** #296 went green — neither is catchable by manifest validation or the Go tests, which is why they slipped through.

Both are on `main` today.

## 1. `ultra` mode emitted a command that cannot run

iterion splices `inject_flag` in right after the binary name, so the rewriter produced:

```console
$ codeindex --max-hits 40 grep foo --scope src
codeindex: unknown flag: grep
```

codeindex only accepted flags *after* the subcommand. So in `ultra` mode the rewriter replaced a working `grep -r` with a **guaranteed failure** — strictly worse than not rewriting, and it breaks the agent's shell rather than merely failing to compress.

The root cause was broader than this plugin: `codeindex --repo /x scan` failed too, with a baffling `unknown flag: scan`. Fixed upstream in **codeindex 2.17.1** — global flags are now accepted in either position, with explicit flag arity so a flag's *value* is never mistaken for the subcommand (`--repo /x scan` resolves to `scan`, never `/x`). Pins bumped 2.17.0 → 2.17.1 in all four places.

## 2. `sandbox_mount` would shadow the runner's working install

`sandbox_mount` was copied from rtk without checking that the analogy held. It does not:

- **rtk** is a single static executable → bind-mounting the host binary works.
- **codeindex** is a Node bundle whose bin entry does `import { runCli } from "./engine.mjs"` — a **sibling** file.

Bind-mounting only the bin path lands a module that cannot resolve its own import. Worse, it mounts *over* `/usr/local/bin/codeindex` — exactly where `Dockerfile.runner-devbox` installs the working global — so a sandboxed run would go from working to broken.

This is the case `addRewriterMounts` already anticipates in its own comment: *"Production images may bake the binary in instead (the host then has none → no-op)."* The mount is removed; sandboxed runs use the in-image install, and a host-only install degrades to passthrough as intended.

`TestCodeindexBuiltinContributions` now asserts the mount stays **empty**, so a later "every rewriter should mount its binary" sweep cannot silently reintroduce it.

## Verification

- `go vet -mod=vendor ./pkg/plugin/...` — clean; `go test -mod=vendor ./pkg/plugin/...` — pass.
- The previously-broken ultra command, against the published package:

```console
$ npx -y @maxgfr/codeindex@2.17.1 --max-hits 40 grep func --repo <dir>
[ { "file": "gopkg/main.go", "line": 10, ... } ]
```
