### PR TITLE
feat(forge): iterion remote forge refresh — re-sync a connection's grants now

### DIFF
--- a/cmd/iterion/remote_webhooks.go
+++ b/cmd/iterion/remote_webhooks.go
@@ -141,6 +141,24 @@ var remoteForgeConnectionsCmd = &cobra.Command{
 	}),
 }
 
+var remoteForgeRefreshCmd = &cobra.Command{
+	Use:   "refresh <conn-id>",
+	Short: "Re-probe a GitHub-App connection and re-sync its granted permissions now",
+	Long: "Re-probe the installation and re-sync the stored granted permissions " +
+		"immediately, so a just-changed App permission (e.g. Commit statuses: write " +
+		"for the merge gate) is picked up without waiting for the periodic refresh " +
+		"worker or a server restart. Prints what the installation GRANTS vs what the " +
+		"minted token CARRIES (they differ, and the token is what acts).",
+	Args: cobra.ExactArgs(1),
+	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
+		base, err := teamBase(cmd, c, "/forge/connections")
+		if err != nil {
+			return err
+		}
+		return cli.RemoteForgeRefresh(cmd.Context(), c, p, base+"/"+args[0]+"/refresh")
+	}),
+}
+
 var remoteForgeRepoBotsCmd = &cobra.Command{
 	Use:   "repo-bots [create|preview|delete <integration-id>]",
 	Short: "Repo↔bot provisioning (forge integrations)",
@@ -227,6 +245,6 @@ func init() {
 		remoteWebhooksListCmd, remoteWebhooksGetCmd, remoteWebhooksCreateCmd,
 		remoteWebhooksUpdateCmd, remoteWebhooksDeleteCmd, remoteWebhooksRotateCmd, remoteWebhooksDeliveriesCmd,
 	)
-	remoteForgeCmd.AddCommand(remoteForgeConnectionsCmd, remoteForgeRepoBotsCmd, remoteForgeOAuthAppsCmd, remoteForgeIntegrationsCmd)
+	remoteForgeCmd.AddCommand(remoteForgeRefreshCmd, remoteForgeConnectionsCmd, remoteForgeRepoBotsCmd, remoteForgeOAuthAppsCmd, remoteForgeIntegrationsCmd)
 	remoteCmd.AddCommand(remoteWebhooksCmd, remoteForgeCmd)
 }

--- a/openapi.json
+++ b/openapi.json
@@ -6522,6 +6522,38 @@
         }
       ]
     },
+    "/api/teams/{id}/forge/connections/{conn_id}/refresh": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "in": "path",
+          "name": "conn_id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "postTeamsByIdForgeConnectionsByConnIdRefresh",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "POST /api/teams/{id}/forge/connections/{conn_id}/refresh",
+        "tags": [
+          "teams"
+        ]
+      }
+    },
     "/api/teams/{id}/forge/connections/{conn_id}/repos": {
       "get": {
         "operationId": "getTeamsByIdForgeConnectionsByConnIdRepos",

--- a/pkg/cli/remote_forge.go
+++ b/pkg/cli/remote_forge.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"context"
+	"sort"
+)
+
+type remoteForgeRefreshResult struct {
+	InstallationAccount     string            `json:"installation_account"`
+	ManageInstallURL        string            `json:"manage_install_url"`
+	GrantedPermissions      map[string]string `json:"granted_permissions"`
+	TokenPermissions        map[string]string `json:"token_permissions"`
+	MissingPermissions      []string          `json:"missing_permissions"`
+	TokenMissingPermissions []string          `json:"token_missing_permissions"`
+	LiveError               string            `json:"live_error"`
+}
+
+// RemoteForgeRefresh POSTs to a connection's /refresh endpoint, which re-probes
+// the GitHub-App installation and re-syncs the stored granted permissions
+// immediately — so a just-changed App permission (e.g. Commit statuses: write
+// for the merge gate) is picked up without waiting for the periodic refresh
+// worker or restarting the server. Prints what the installation GRANTS vs what
+// the minted TOKEN carries (they differ, and the token is what acts).
+func RemoteForgeRefresh(ctx context.Context, c *RemoteClient, p *Printer, path string) error {
+	var res remoteForgeRefreshResult
+	if _, err := c.Call(ctx, "POST", path, nil, &res); err != nil {
+		return err
+	}
+	if p.Format == OutputJSON {
+		p.JSON(res)
+		return nil
+	}
+	p.Header("Forge connection refreshed")
+	if res.InstallationAccount != "" {
+		p.KV("installation", res.InstallationAccount)
+	}
+	keys := map[string]bool{}
+	for k := range res.GrantedPermissions {
+		keys[k] = true
+	}
+	for k := range res.TokenPermissions {
+		keys[k] = true
+	}
+	ordered := make([]string, 0, len(keys))
+	for k := range keys {
+		ordered = append(ordered, k)
+	}
+	sort.Strings(ordered)
+	rows := make([][]string, 0, len(ordered))
+	for _, k := range ordered {
+		rows = append(rows, []string{k, res.GrantedPermissions[k], res.TokenPermissions[k]})
+	}
+	p.Table([]string{"PERMISSION", "GRANTED", "TOKEN"}, rows)
+	if res.LiveError != "" {
+		p.Line("live probe error: %s", res.LiveError)
+	}
+	return nil
+}

--- a/pkg/server/forge_refresh_route.go
+++ b/pkg/server/forge_refresh_route.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/forge"
+	forgegithub "github.com/SocialGouv/iterion/pkg/forge/github"
+)
+
+// handleForgeConnectionRefresh re-probes a GitHub-App connection's live state
+// and re-syncs the stored GrantedPermissions immediately, so an owner who just
+// changed the App's permissions on the forge (e.g. granted Commit statuses:
+// write for the merge gate) doesn't have to wait for the periodic refresh
+// worker — or restart the server — for iterion to pick them up. It also forces
+// a fresh installation-token mint so the last-minted-token observability
+// reflects the new grants. The connection store is shared, so the re-synced
+// grant is visible to every replica at once — no cross-pod cache to flush.
+// Team-scoped, same auth as the connection health view.
+func (s *Server) handleForgeConnectionRefresh(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	teamID := r.PathValue("id")
+	if !s.canViewTeam(r.Context(), id, teamID) {
+		httpError(w, http.StatusForbidden, "not a member")
+		return
+	}
+	if s.forgeConnections == nil {
+		httpError(w, http.StatusNotFound, "forge integrations disabled")
+		return
+	}
+	conn, ok := s.forgeConnForTenant(w, r, teamID, r.PathValue("conn_id"))
+	if !ok {
+		return
+	}
+	if conn.Kind != forge.KindGitHubApp || conn.InstallationID == 0 {
+		httpError(w, http.StatusBadRequest, "refresh applies to GitHub-App connections only")
+		return
+	}
+	cfg, _, hasApp := s.githubAppConfigForConnection(r.Context(), conn)
+	if !hasApp {
+		httpError(w, http.StatusBadGateway, "no github app available for this connection")
+		return
+	}
+	inst, err := forgegithub.InstallationInfo(r.Context(), s.forgeHTTPClient(),
+		forgegithub.APIBaseFor(conn.BaseURL()), cfg, conn.InstallationID, time.Now().UTC())
+	if err != nil {
+		httpError(w, http.StatusBadGateway, "probe installation: %v", err)
+		return
+	}
+	// Re-sync the stored grant with the live one (the mint reads it).
+	s.syncGrantedPermissions(r.Context(), conn, inst.Permissions)
+
+	out := forgeConnectionHealth{
+		Status:              string(conn.Status),
+		StatusReason:        conn.StatusReason,
+		Provider:            string(conn.Provider),
+		Kind:                string(conn.Kind),
+		AccountLogin:        conn.AccountLogin,
+		AppSlug:             conn.AppSlug,
+		InstallationID:      conn.InstallationID,
+		InstallationAccount: inst.Login,
+		ManageInstallURL:    inst.HTMLURL,
+		GrantedPermissions:  inst.Permissions,
+		MissingPermissions:  forgegithub.MissingDeliveryPermissions(inst.Permissions),
+	}
+	// Force a fresh token mint so the observability reflects the new grants
+	// (forgeAdminFor builds a fresh client → rest() mints on first use).
+	if admin, err := s.forgeAdminFor(r.Context(), conn); err == nil {
+		if _, err := admin.ListRepos(r.Context(), forge.RepoQuery{}); err != nil {
+			out.LiveError = err.Error()
+		}
+	}
+	if tokenPerms, ok := forgegithub.LastMintedPermissions(conn.InstallationID); ok {
+		out.TokenPermissions = tokenPerms
+		out.TokenMissingPermissions = forgegithub.MissingDeliveryPermissions(tokenPerms)
+	}
+	writeJSON(w, out)
+}

--- a/pkg/server/forge_routes.go
+++ b/pkg/server/forge_routes.go
@@ -8,6 +8,7 @@ func (s *Server) registerForgeRoutes() {
 	s.mux.Handle("GET /api/teams/{id}/forge/repos", s.requireAuth(http.HandlerFunc(s.handleListTeamForgeRepos)))
 	s.mux.Handle("POST /api/teams/{id}/forge/repos", s.requireAuth(http.HandlerFunc(s.handleCreateForgeRepo)))
 	s.mux.Handle("GET /api/teams/{id}/forge/connections/{conn_id}/health", s.requireAuth(http.HandlerFunc(s.handleForgeConnectionHealth)))
+	s.mux.Handle("POST /api/teams/{id}/forge/connections/{conn_id}/refresh", s.requireAuth(http.HandlerFunc(s.handleForgeConnectionRefresh)))
 	s.mux.Handle("GET /api/teams/{id}/forge/connections", s.requireAuth(http.HandlerFunc(s.handleListForgeConnections)))
 	s.mux.Handle("POST /api/teams/{id}/forge/connections", s.requireAuth(http.HandlerFunc(s.handleConnectForge)))
 	s.mux.Handle("DELETE /api/teams/{id}/forge/connections/{conn_id}", s.requireAuth(http.HandlerFunc(s.handleDeleteForgeConnection)))

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -2983,6 +2983,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/teams/{id}/forge/connections/{conn_id}/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                conn_id: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** POST /api/teams/{id}/forge/connections/{conn_id}/refresh */
+        post: operations["postTeamsByIdForgeConnectionsByConnIdRefresh"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/teams/{id}/forge/connections/{conn_id}/repos": {
         parameters: {
             query?: never;
@@ -8961,6 +8981,27 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["forgeConnectionHealth"];
                 };
+            };
+        };
+    };
+    postTeamsByIdForgeConnectionsByConnIdRefresh: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                conn_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };


### PR DESCRIPTION
Operability tool motivated by the merge-gate rollout: after changing a GitHub App's permissions (e.g. granting *Commit statuses: write*), an operator had to wait for the periodic refresh worker — or restart the whole server — for iterion to pick up the new grant. This adds a targeted, explicit refresh.

- `POST /api/teams/{id}/forge/connections/{conn_id}/refresh`: re-probes the installation, re-syncs the stored `GrantedPermissions`, forces a fresh token mint, returns what the installation **GRANTS** vs what the minted **TOKEN** carries (the two differ — the token is what acts).
- CLI: `iterion remote forge refresh <conn-id>`.

Chosen over a generic *clear-all-caches* command: targeted, bounded, and correct in multi-replica — the connection store is shared, so the re-synced grant is visible to every replica at once; there's no long-lived forge-token cache to flush (`forgeAdminFor` mints per call). It addresses the actual class of pain ("I changed App permissions, make iterion pick them up") rather than the vague one.

Note: a pre-existing test failure on `main` (`config_share_derive_test.go` — *config path must be set*) is unrelated to this change (it fails on a clean checkout too); flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)