### PR TITLE
fix(review-pr): harden emit findings contract (JSON array, not prose)

### DIFF
--- a/bots/review-pr/main.bot
+++ b/bots/review-pr/main.bot
@@ -420,13 +420,27 @@ prompt emit_system:
       post_to_board is false).
     - `failed_issues`: any board creates the runtime rejected.
     - `findings`: the FINAL merged/threshold/capped finding set as a
-      JSON array, in the SAME per-object shape the reviewers emitted —
-      preserve `file`, `line`, `line_end`, `severity`, `category`,
-      `title`, `detail`, `suggestion`, `replacement`, `confidence`, and
-      add `"reviewers": "claude" | "gpt" | "both"`. A downstream step may
-      publish these onto a forge PR, so keep `line`/`line_end` and any
-      `replacement` exactly as given. This is the same set you reported —
-      do not re-summarise or drop fields.
+      MACHINE-PARSED **JSON ARRAY OF OBJECTS** — NEVER a prose sentence,
+      NEVER a summary STRING like "4 findings kept (1 high, 2 medium)".
+      A deterministic downstream step runs `JSON.parse` on this exact
+      value to count blocking findings and post inline PR comments: a
+      string (or anything that is not a `[...]` array) fails the parse,
+      which FAIL-CLOSES the merge gate AND drops every finding from the
+      review. Emit the array itself, `[]` when there are none. Same
+      per-object shape the reviewers emitted — preserve `file`, `line`,
+      `line_end`, `severity`, `category`, `title`, `detail`, `suggestion`,
+      `replacement`, `confidence`, and add
+      `"reviewers": "claude" | "gpt" | "both"`. Keep `line`/`line_end` and
+      any `replacement` exactly as given; do not re-summarise or drop
+      fields. Example (the WHOLE value, verbatim shape):
+        [
+          {"file":"pkg/x/y.go","line":42,"line_end":42,"severity":"high",
+           "category":"correctness","title":"nil deref on empty input",
+           "detail":"…","suggestion":"guard len==0","replacement":"",
+           "confidence":"high","reviewers":"both"}
+        ]
+      (Contrast: `questions` below is a newline-joined STRING; `findings`
+      is an ARRAY. Do not swap their shapes.)
     - `questions`: the merged, de-duplicated non-blocking questions as a
       SINGLE STRING with ONE QUESTION PER LINE (newline-separated), NOT a
       JSON array — empty string "" when none. (A downstream shell step

--- a/bots/review-pr/manifest.yaml
+++ b/bots/review-pr/manifest.yaml
@@ -1,7 +1,18 @@
 name: review-pr
 display_name: Revi
 icon: 🔎
-version: 0.5.3
+version: 0.5.4
+## 0.5.4 — emit reliability: harden the `findings` output contract. The
+## converge/emit LLM sometimes returned `findings` as a PROSE STRING ("4
+## findings kept (1 high…)") instead of the JSON array the schema intends —
+## `findings: json` accepts a string, so nothing rejected it. Downstream that
+## fails JSON.parse → the gate FAIL-CLOSES (blocking=1) and every finding is
+## dropped from the review (0 inline comments), even though total_findings was
+## right. Found live on PR #292 (run 019f98ed): status failure/1-blocking with
+## a "0 findings kept" body. The prompt now emphatically demands a JSON ARRAY
+## OF OBJECTS with a verbatim example and contrasts it with the newline-string
+## `questions` (the likely source of the shape swap). Fail-closed already made
+## this SAFE (never a false green); this makes it not lose findings.
 ## 0.5.3 — declare the `statuses: write` forge scope the merge gate needs
 ## (advisory/provisioning hint; the runtime does not read it). Live e2e on
 ## prod proved the full chain — Revi reviews, the bot sends the gate verdict,


### PR DESCRIPTION
Found live on the merge gate's own PR #292 (run 019f98ed): `revi/review` posted **failure | 1 blocking finding** while the review body said *0 findings kept*.

## Root cause
The converge/emit LLM returned `findings` as a **prose string** ("4 findings kept (0 critical, 1 high, 2 medium, 1 low)…") instead of the JSON array of objects the schema intends. `findings: json` accepts a string (the DSL has no object-array type), so nothing rejected it. Downstream, `publish_review`'s `JSON.parse(FINDINGS)` fails → `findings_parse_failed` → the gate **fail-closes** (blocking=1) AND every finding is dropped from the review (0 inline comments), even though `total_findings=4` was correct.

## Why it's safe today, and the fix
The fail-closed behaviour made this **safe** (never a false green) and `publish_health` bannered the degradation — but the findings were lost. Fix: the emit prompt now emphatically demands a **JSON ARRAY OF OBJECTS** with a verbatim example, warns that a string fails the parse, and contrasts it with the newline-STRING `questions` field directly above it (the likely source of the shape swap). No schema change is possible (`json` accepts any JSON value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)