### PR TITLE
fix: make paused resumes reliable and compact run details

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1361,6 +1361,49 @@ func TestResume_Success(t *testing.T) {
 	}
 }
 
+func TestResume_OperatorPausedWithoutAnswers(t *testing.T) {
+	dir := t.TempDir()
+	botPath := writeFixture(t, dir, "operator.bot", `
+workflow operator_resume:
+  entry: done
+`)
+	storeDir := filepath.Join(dir, "store")
+	s, _ := store.New(storeDir)
+	r, _ := s.CreateRun(
+		context.Background(),
+		"operator-paused",
+		"operator_resume",
+		nil,
+	)
+	_ = s.SaveCheckpoint(
+		context.Background(),
+		r.ID,
+		&store.Checkpoint{NodeID: "done"},
+	)
+	_ = s.UpdateRunStatus(
+		context.Background(),
+		r.ID,
+		store.RunStatusPausedOperator,
+		"paused by operator",
+	)
+
+	p, _ := newTestPrinter(cli.OutputHuman)
+	err := cli.RunResumeWithFile(
+		context.Background(),
+		botPath,
+		cli.ResumeOptions{RunID: r.ID, StoreDir: storeDir},
+		p,
+	)
+	if err != nil {
+		t.Fatalf("operator resume error: %v", err)
+	}
+
+	r, _ = s.LoadRun(context.Background(), r.ID)
+	if r.Status != store.RunStatusFinished {
+		t.Errorf("expected finished, got %s", r.Status)
+	}
+}
+
 func TestResume_NotPaused(t *testing.T) {
 	dir := t.TempDir()
 	botPath := writeFixture(t, dir, "test.bot", humanWorkflow)

--- a/pkg/cli/resume.go
+++ b/pkg/cli/resume.go
@@ -130,7 +130,7 @@ func RunResumeWithFile(ctx context.Context, iterFile string, opts ResumeOptions,
 	switch r.Status {
 	case store.RunStatusPausedWaitingHuman:
 		// OK — requires answers
-	case store.RunStatusFailedResumable, store.RunStatusCancelled:
+	case store.RunStatusFailedResumable, store.RunStatusCancelled, store.RunStatusPausedOperator:
 		resumingFromFailure = true
 	case store.RunStatusRunning:
 		// Status=running on a run whose engine actually died is the
@@ -254,7 +254,10 @@ func RunResumeWithFile(ctx context.Context, iterFile string, opts ResumeOptions,
 	if err != nil {
 		return fmt.Errorf("cannot reload run: %w", err)
 	}
-	if r.Status != store.RunStatusPausedWaitingHuman && r.Status != store.RunStatusFailedResumable && r.Status != store.RunStatusCancelled {
+	if r.Status != store.RunStatusPausedWaitingHuman &&
+		r.Status != store.RunStatusFailedResumable &&
+		r.Status != store.RunStatusCancelled &&
+		r.Status != store.RunStatusPausedOperator {
 		return fmt.Errorf("run %q can no longer be resumed (status: %s)", opts.RunID, r.Status)
 	}
 

--- a/pkg/runview/detached.go
+++ b/pkg/runview/detached.go
@@ -336,10 +336,8 @@ func (s *Service) launchDetached(parent context.Context, runID string, spec Laun
 
 // resumeDetached is the Resume counterpart to launchDetached.
 func (s *Service) resumeDetached(parent context.Context, spec ResumeSpec) (*LaunchResult, error) {
-	if _, _, err := CompileWorkflowWithHash(spec.FilePath); err != nil {
-		return nil, err
-	}
-
+	// Service.Resume already compiled the workflow and synchronously checked
+	// its hash before dispatching to this asynchronous subprocess path.
 	s.prepareRunLogNoFile(spec.RunID)
 
 	answers, convErr := resumeAnswersToStrings(spec.Answers)

--- a/pkg/runview/service_launch.go
+++ b/pkg/runview/service_launch.go
@@ -267,9 +267,9 @@ func (s *Service) startInProcess(parent context.Context, runID string, spec Laun
 		})
 }
 
-// Resume re-enters a paused, failed_resumable, or cancelled run with
-// optional answers. The .bot source must be supplied (and must hash-
-// match the original unless spec.Force).
+// Resume re-enters a human-paused, operator-paused, failed_resumable,
+// or cancelled run with optional answers. The .bot source must be
+// supplied (and must hash-match the original unless spec.Force).
 func (s *Service) Resume(parent context.Context, spec ResumeSpec) (*LaunchResult, error) {
 	if s.draining.Load() {
 		return nil, runtime.ErrServerDraining
@@ -305,15 +305,26 @@ func (s *Service) Resume(parent context.Context, spec ResumeSpec) (*LaunchResult
 		return nil, err
 	}
 
+	// Compile and validate the workflow hash before handing the resume to
+	// any asynchronous execution path. Engine.Resume keeps the same check as
+	// a defence-in-depth/TOCTOU guard, but doing it only inside spawnRun's
+	// goroutine makes the HTTP API return 202 before a mismatch is known. The
+	// studio then treats the human answer as accepted and hides the form even
+	// though the run remains paused. A synchronous error lets the existing UI
+	// preserve the answer and offer its explicit force-resume retry.
+	wf, hash, err := compileForLaunch(spec.FilePath, spec.Source)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateResumeWorkflowHash(r, hash, spec.Force); err != nil {
+		return nil, err
+	}
+
 	// Cloud-mode resume: republish the RunMessage with ResumeSpec
 	// set so the runner pool re-enters the engine via Engine.Resume.
 	// Plan §F (T-33). CAS protection on the Mongo checkpoint lives
 	// in MongoRunStore.SaveCheckpoint (CASVersion increment).
 	if s.publisher != nil {
-		wf, hash, err := compileForLaunch(spec.FilePath, spec.Source)
-		if err != nil {
-			return nil, err
-		}
 		if err := s.publisher.SubmitResume(parent, spec, wf, hash); err != nil {
 			return nil, err
 		}
@@ -324,16 +335,6 @@ func (s *Service) Resume(parent context.Context, spec ResumeSpec) (*LaunchResult
 
 	if detachedEnabled() {
 		return s.resumeDetached(parent, spec)
-	}
-
-	// Honour spec.Source when supplied (cloud-mode callers materialise
-	// .bot contents inline; the runner pod may have no FilePath on
-	// disk). The publish path above already uses compileForLaunch for
-	// the same reason — this branch was the only one still routing
-	// through the disk-only CompileWorkflowWithHash.
-	wf, hash, err := compileForLaunch(spec.FilePath, spec.Source)
-	if err != nil {
-		return nil, err
 	}
 
 	_, runLogger := s.prepareRunLog(spec.RunID)
@@ -400,11 +401,34 @@ func validateResumable(r *store.Run, answers map[string]any) error {
 			return fmt.Errorf("no answers provided; resume of paused run requires answers")
 		}
 		return nil
-	case store.RunStatusFailedResumable, store.RunStatusCancelled:
+	case store.RunStatusPausedOperator, store.RunStatusFailedResumable, store.RunStatusCancelled:
 		return nil
 	default:
 		return fmt.Errorf("run %q cannot be resumed (status: %s)", r.ID, r.Status)
 	}
+}
+
+// validateResumeWorkflowHash is the synchronous Service.Resume preflight for
+// the engine's workflow-hash guard. Keep the runtime check too: it protects
+// direct Engine.Resume callers and remains the final check inside the locked
+// resume goroutine.
+func validateResumeWorkflowHash(r *store.Run, currentHash string, force bool) error {
+	if force || r.WorkflowHash == "" || currentHash == "" || r.WorkflowHash == currentHash {
+		return nil
+	}
+	return fmt.Errorf(
+		"runtime: workflow source has changed since run %q was started (expected hash %s, got %s); re-run from scratch or use --force",
+		r.ID,
+		shortWorkflowHash(r.WorkflowHash),
+		shortWorkflowHash(currentHash),
+	)
+}
+
+func shortWorkflowHash(hash string) string {
+	if len(hash) > 12 {
+		return hash[:12]
+	}
+	return hash
 }
 
 // spawnRun owns the lock + register + goroutine + defer-cleanup

--- a/pkg/runview/service_launch_operator_resume_test.go
+++ b/pkg/runview/service_launch_operator_resume_test.go
@@ -1,0 +1,142 @@
+package runview
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+type operatorResumePublisher struct {
+	resumeCalls int
+}
+
+func (*operatorResumePublisher) SubmitLaunch(context.Context, string, LaunchSpec, *ir.Workflow, string) (int, error) {
+	return 1, nil
+}
+
+func (*operatorResumePublisher) CancelRun(context.Context, string) error { return nil }
+
+func (p *operatorResumePublisher) SubmitResume(context.Context, ResumeSpec, *ir.Workflow, string) error {
+	p.resumeCalls++
+	return nil
+}
+
+func TestValidateResumable_AcceptsPausedOperatorWithoutAnswers(t *testing.T) {
+	r := &store.Run{ID: "run-operator-paused", Status: store.RunStatusPausedOperator}
+	if err := validateResumable(r, nil); err != nil {
+		t.Fatalf("validateResumable(paused_operator, nil) = %v, want nil", err)
+	}
+}
+
+func seedPausedOperatorRun(t *testing.T, svc *Service, runID, workflowHash string) {
+	t.Helper()
+	if _, err := svc.store.CreateRun(context.Background(), runID, "operator_resume", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	r, err := svc.store.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	r.WorkflowHash = workflowHash
+	if err := svc.store.SaveRun(context.Background(), r); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+	if err := svc.store.SaveCheckpoint(context.Background(), runID, &store.Checkpoint{NodeID: "done"}); err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+	if err := svc.store.UpdateRunStatus(context.Background(), runID, store.RunStatusPausedOperator, "paused by operator"); err != nil {
+		t.Fatalf("UpdateRunStatus: %v", err)
+	}
+}
+
+func TestResume_AcceptsPausedOperatorWithoutAnswers(t *testing.T) {
+	dir := t.TempDir()
+	botPath := filepath.Join(dir, "operator_resume.bot")
+	const source = `
+workflow operator_resume:
+  entry: done
+`
+	if err := os.WriteFile(botPath, []byte(source), 0o644); err != nil {
+		t.Fatalf("write bot: %v", err)
+	}
+
+	publisher := &operatorResumePublisher{}
+	svc, err := NewService(dir, WithLogger(iterlog.Nop()), WithLaunchPublisher(publisher))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	const runID = "run-operator-paused"
+	_, workflowHash, err := CompileWorkflowWithHash(botPath)
+	if err != nil {
+		t.Fatalf("CompileWorkflowWithHash: %v", err)
+	}
+	seedPausedOperatorRun(t, svc, runID, workflowHash)
+
+	res, err := svc.Resume(context.Background(), ResumeSpec{RunID: runID, FilePath: botPath})
+	if err != nil {
+		t.Fatalf("Resume paused_operator: %v", err)
+	}
+	if res.RunID != runID {
+		t.Errorf("Resume RunID = %q, want %q", res.RunID, runID)
+	}
+	if publisher.resumeCalls != 1 {
+		t.Errorf("SubmitResume calls = %d, want 1", publisher.resumeCalls)
+	}
+}
+
+func TestResume_RejectsWorkflowHashMismatchBeforePublishing(t *testing.T) {
+	dir := t.TempDir()
+	botPath := filepath.Join(dir, "operator_resume.bot")
+	const source = `
+workflow operator_resume:
+  entry: done
+`
+	if err := os.WriteFile(botPath, []byte(source), 0o644); err != nil {
+		t.Fatalf("write bot: %v", err)
+	}
+
+	publisher := &operatorResumePublisher{}
+	svc, err := NewService(dir, WithLogger(iterlog.Nop()), WithLaunchPublisher(publisher))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	const runID = "run-operator-stale"
+	seedPausedOperatorRun(t, svc, runID, strings.Repeat("0", 64))
+
+	_, err = svc.Resume(context.Background(), ResumeSpec{RunID: runID, FilePath: botPath})
+	if err == nil {
+		t.Fatal("Resume with a stale workflow hash returned nil, want a synchronous error")
+	}
+	if !strings.Contains(err.Error(), "workflow source has changed") {
+		t.Fatalf("Resume error = %v, want workflow hash mismatch", err)
+	}
+	if publisher.resumeCalls != 0 {
+		t.Fatalf("SubmitResume calls after stale preflight = %d, want 0", publisher.resumeCalls)
+	}
+	r, loadErr := svc.store.LoadRun(context.Background(), runID)
+	if loadErr != nil {
+		t.Fatalf("LoadRun after rejected resume: %v", loadErr)
+	}
+	if r.Status != store.RunStatusPausedOperator {
+		t.Fatalf("status after rejected resume = %q, want paused_operator", r.Status)
+	}
+
+	if _, err := svc.Resume(context.Background(), ResumeSpec{
+		RunID:    runID,
+		FilePath: botPath,
+		Force:    true,
+	}); err != nil {
+		t.Fatalf("forced Resume with a stale workflow hash: %v", err)
+	}
+	if publisher.resumeCalls != 1 {
+		t.Fatalf("SubmitResume calls after forced resume = %d, want 1", publisher.resumeCalls)
+	}
+}

--- a/pkg/runview/service_resume_hash_test.go
+++ b/pkg/runview/service_resume_hash_test.go
@@ -1,0 +1,112 @@
+package runview
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+func TestResume_RejectsWorkflowHashMismatchSynchronouslyBeforeSpawn(t *testing.T) {
+	dir := t.TempDir()
+	botPath := filepath.Join(dir, "pause_demo.bot")
+	if err := os.WriteFile(botPath, []byte(pausingBot), 0o644); err != nil {
+		t.Fatalf("write bot: %v", err)
+	}
+
+	svc, err := NewService(dir, WithLogger(iterlog.Nop()))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	launched, err := svc.Launch(context.Background(), LaunchSpec{FilePath: botPath})
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	select {
+	case <-launched.Done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("run did not reach its human pause")
+	}
+
+	before, err := svc.store.LoadRun(context.Background(), launched.RunID)
+	if err != nil {
+		t.Fatalf("LoadRun before resume: %v", err)
+	}
+	if before.Status != store.RunStatusPausedWaitingHuman {
+		t.Fatalf("status before resume = %q, want paused_waiting_human", before.Status)
+	}
+	if before.Checkpoint == nil || before.Checkpoint.InteractionID == "" {
+		t.Fatal("paused run has no interaction checkpoint")
+	}
+
+	// A harmless source edit still changes the persisted workflow hash and
+	// must require the operator's explicit force confirmation.
+	changedSource := "## workflow edited after the gate opened\n" + pausingBot
+	if err := os.WriteFile(botPath, []byte(changedSource), 0o644); err != nil {
+		t.Fatalf("rewrite bot: %v", err)
+	}
+
+	answers := map[string]any{"approve": true}
+	_, err = svc.Resume(context.Background(), ResumeSpec{
+		RunID:    launched.RunID,
+		FilePath: botPath,
+		Answers:  answers,
+	})
+	if err == nil {
+		t.Fatal("Resume with a stale workflow hash returned nil, want a synchronous error")
+	}
+	if !strings.Contains(err.Error(), "workflow source has changed") {
+		t.Fatalf("Resume error = %v, want workflow hash mismatch", err)
+	}
+	if svc.manager.Active(launched.RunID) {
+		t.Fatal("stale resume registered an active run before rejecting the hash")
+	}
+
+	afterReject, err := svc.store.LoadRun(context.Background(), launched.RunID)
+	if err != nil {
+		t.Fatalf("LoadRun after rejected resume: %v", err)
+	}
+	if afterReject.Status != store.RunStatusPausedWaitingHuman {
+		t.Fatalf("status after rejected resume = %q, want paused_waiting_human", afterReject.Status)
+	}
+	interaction, err := svc.store.LoadInteraction(
+		context.Background(),
+		launched.RunID,
+		before.Checkpoint.InteractionID,
+	)
+	if err != nil {
+		t.Fatalf("LoadInteraction after rejected resume: %v", err)
+	}
+	if interaction.AnsweredAt != nil || len(interaction.Answers) != 0 {
+		t.Fatalf("rejected resume recorded answers: %#v", interaction.Answers)
+	}
+
+	forced, err := svc.Resume(context.Background(), ResumeSpec{
+		RunID:    launched.RunID,
+		FilePath: botPath,
+		Answers:  answers,
+		Force:    true,
+	})
+	if err != nil {
+		t.Fatalf("forced Resume: %v", err)
+	}
+	select {
+	case <-forced.Done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("forced resume did not finish")
+	}
+
+	finished, err := svc.store.LoadRun(context.Background(), launched.RunID)
+	if err != nil {
+		t.Fatalf("LoadRun after forced resume: %v", err)
+	}
+	if finished.Status != store.RunStatusFinished {
+		t.Fatalf("status after forced resume = %q (error %q), want finished", finished.Status, finished.Error)
+	}
+}

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -717,10 +717,10 @@ func (p *Publisher) CancelRun(ctx context.Context, runID string) error {
 // runner picks it up and dispatches to engine.Resume which threads
 // the answers in.
 //
-// On publish failure the run is reverted to failed_resumable so the
-// studio surfaces an actionable error instead of leaving a "queued"
-// row that no runner will ever pick up. Mirrors the rollback pattern
-// in SubmitLaunch.
+// On publish failure the run is reverted to its prior resumable status
+// so the studio surfaces an actionable error instead of leaving a
+// "queued" row that no runner will ever pick up. Mirrors the rollback
+// pattern in SubmitLaunch.
 func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, wf *ir.Workflow, hash string) error {
 	body, err := marshalIRFromSpec(spec.FilePath, spec.Source)
 	if err != nil {
@@ -728,7 +728,8 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 	}
 	// Capture the prior status so we can roll back to the right
 	// resumable state if publish fails — the user could be resuming
-	// from paused_waiting_human, failed_resumable, or cancelled.
+	// from paused_waiting_human, paused_operator, failed_resumable, or
+	// cancelled.
 	prior, loadErr := p.store.LoadRun(ctx, spec.RunID)
 	if loadErr != nil {
 		return fmt.Errorf("cloudpublisher: load prior run %s: %w", spec.RunID, loadErr)
@@ -799,7 +800,7 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 		// when the prior status wasn't itself resumable.
 		rollback := priorStatus
 		switch rollback {
-		case store.RunStatusPausedWaitingHuman, store.RunStatusFailedResumable, store.RunStatusCancelled:
+		case store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator, store.RunStatusFailedResumable, store.RunStatusCancelled:
 			// keep as-is
 		default:
 			rollback = store.RunStatusFailedResumable

--- a/pkg/server/cloudpublisher/publisher_resume_test.go
+++ b/pkg/server/cloudpublisher/publisher_resume_test.go
@@ -1,0 +1,60 @@
+package cloudpublisher
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+func TestSubmitResume_PublishFailureRestoresOperatorPause(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+
+	ctx := store.WithIdentity(context.Background(), "team", "alice")
+	const runID = "run-operator-paused"
+	if err := st.SaveRun(ctx, &store.Run{
+		ID:       runID,
+		TenantID: "team",
+		OwnerID:  "alice",
+		Status:   store.RunStatusPausedOperator,
+	}); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+
+	p := &Publisher{
+		store: st,
+		publishRun: func(context.Context, *queue.RunMessage) error {
+			return errors.New("nats unavailable")
+		},
+	}
+	wf := &ir.Workflow{Name: "operator_resume"}
+	spec := runview.ResumeSpec{
+		RunID:    runID,
+		FilePath: "operator_resume.bot",
+		Source:   "workflow operator_resume:\n  entry: done\n",
+	}
+
+	err = p.SubmitResume(ctx, spec, wf, "hash")
+	if err == nil {
+		t.Fatal("SubmitResume returned nil, want publish failure")
+	}
+	if !strings.Contains(err.Error(), "nats unavailable") {
+		t.Fatalf("SubmitResume error = %v, want publish failure", err)
+	}
+
+	r, err := st.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.Status != store.RunStatusPausedOperator {
+		t.Fatalf("status after publish failure = %s, want paused_operator", r.Status)
+	}
+}

--- a/studio/src/components/Runs/RunHeader.tsx
+++ b/studio/src/components/Runs/RunHeader.tsx
@@ -34,6 +34,7 @@ import ForkedFromRow from "./runHeader/ForkedFromRow";
 import RunChildrenPanel from "./runHeader/RunChildrenPanel";
 import NotesRow from "./runHeader/NotesRow";
 import ResultLinksRow from "./runHeader/ResultLinksRow";
+import RunInformationAccordion from "./runHeader/RunInformationAccordion";
 import RunNameEditor from "./runHeader/RunNameEditor";
 import RunTagsRow from "./runHeader/RunTagsRow";
 import SourceTicketRow from "./runHeader/SourceTicketRow";
@@ -404,14 +405,6 @@ export default function RunHeader({ run, active, wsState, onResetLayout, bare = 
           {/* run id lives on the copy-id button (row 1) + the Overview's
               Advanced details — no need to repeat the raw string here. */}
         </div>
-        {/* Row 3: the resolved backend/model chip row — one chip per
-            distinct pair the run's LLM nodes ran on. Nothing renders for
-            tool/compute-only runs. */}
-        {run.backends_used && run.backends_used.length > 0 && (
-          <BackendsUsedRow backends={run.backends_used} />
-        )}
-        {/* Row 4: operator-assigned filter/group tags (chips). */}
-        <RunTagsRow runId={run.id} />
       </div>
       {error && (
         <InlineBanner
@@ -426,32 +419,42 @@ export default function RunHeader({ run, active, wsState, onResetLayout, bare = 
       {liveStreamExpected && (
         <WSDisconnectBanner state={wsState} onReconnect={requestWsReconnect} />
       )}
-      {/* Headline result-links (opened PR, live deploy) — the run's
-          "what did it produce" at a glance, the topmost outcome bar above
-          the detailed deployment/finalization rows. */}
-      <ResultLinksRow links={resultLinks} />
-      {/* What the run shipped, above where its commits landed: the live
-          URL is the operator's destination at the end of a deploy run. */}
-      {run.deployment && <DeploymentRow deployment={run.deployment} />}
-      {showFinalization && <FinalizationRow run={run} />}
-      {shellEligible && (
-        <div className="shrink-0 px-4 py-1.5 bg-surface-2/40 border-b border-border-default flex items-center gap-2 text-micro">
-          <span className="text-fg-muted">worktree preserved</span>
-          <button
-            type="button"
-            className="text-accent hover:underline"
-            onClick={() => setShellOpen(true)}
-            title="Open an interactive shell in the run's preserved worktree (local mode)"
-          >
-            Open post-mortem shell
-          </button>
+      <RunInformationAccordion>
+        <div className="shrink-0 border-b border-border-default px-3 py-2 sm:px-4 flex flex-col gap-1.5 text-sm">
+          {/* Resolved backend/model chips. Nothing renders for
+              tool/compute-only runs. */}
+          {run.backends_used && run.backends_used.length > 0 && (
+            <BackendsUsedRow backends={run.backends_used} />
+          )}
+          <RunTagsRow runId={run.id} />
         </div>
-      )}
-      {run.forked_from && <ForkedFromRow run={run} />}
-      <RunChildrenPanel run={run} />
-      {run.source?.issue_id && <SourceTicketRow source={run.source} />}
-      <ErrorHintRow run={run} onResume={() => setResumeOpen(true)} />
-      <NotesRow runId={run.id} />
+        {/* Headline result-links (opened PR, live deploy) — the run's
+            "what did it produce" at a glance, above the detailed
+            deployment/finalization rows. */}
+        <ResultLinksRow links={resultLinks} />
+        {/* What the run shipped, above where its commits landed: the live
+            URL is the operator's destination at the end of a deploy run. */}
+        {run.deployment && <DeploymentRow deployment={run.deployment} />}
+        {showFinalization && <FinalizationRow run={run} />}
+        {shellEligible && (
+          <div className="shrink-0 px-4 py-1.5 bg-surface-2/40 border-b border-border-default flex items-center gap-2 text-micro">
+            <span className="text-fg-muted">worktree preserved</span>
+            <button
+              type="button"
+              className="text-accent hover:underline"
+              onClick={() => setShellOpen(true)}
+              title="Open an interactive shell in the run's preserved worktree (local mode)"
+            >
+              Open post-mortem shell
+            </button>
+          </div>
+        )}
+        {run.forked_from && <ForkedFromRow run={run} />}
+        <RunChildrenPanel run={run} />
+        {run.source?.issue_id && <SourceTicketRow source={run.source} />}
+        <ErrorHintRow run={run} onResume={() => setResumeOpen(true)} />
+        <NotesRow runId={run.id} />
+      </RunInformationAccordion>
 
       {canResume && (
         <ResumeDialog

--- a/studio/src/components/Runs/conversation/HumanPromptForm.test.tsx
+++ b/studio/src/components/Runs/conversation/HumanPromptForm.test.tsx
@@ -127,4 +127,74 @@ describe("HumanPromptForm — schema fetch failure (iterion#244)", () => {
       ),
     );
   });
+
+  it("replays the exact approval answer with force after a stale-workflow rejection", async () => {
+    getRunWorkflow.mockResolvedValue({
+      nodes: [
+        {
+          id: "approve_audio",
+          output_schema: [
+            { name: "approved", type: "bool" },
+            { name: "reviewer", type: "string" },
+            { name: "notes", type: "string" },
+          ],
+        },
+      ],
+      stale_hash: true,
+    });
+    resumeRun
+      .mockRejectedValueOnce(
+        new Error(
+          'runtime: workflow source has changed since run "run-1" was started',
+        ),
+      )
+      .mockResolvedValueOnce({ run_id: "run-1", status: "running" });
+
+    renderWithClient(
+      <HumanPromptForm
+        runId="run-1"
+        nodeId="approve_audio"
+        questions={{}}
+        sourceOverride={null}
+      />,
+    );
+
+    const textboxes = await screen.findAllByRole("textbox");
+    expect(textboxes).toHaveLength(2);
+    const [reviewer, notes] = textboxes;
+    if (!reviewer || !notes) {
+      throw new Error("reviewer and notes fields were not rendered");
+    }
+    fireEvent.change(reviewer, { target: { value: "Victor" } });
+    fireEvent.change(notes, {
+      target: { value: "Corriger la formulation de la scène 6." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Reject" }));
+
+    const answers = {
+      approved: false,
+      reviewer: "Victor",
+      notes: "Corriger la formulation de la scène 6.",
+    };
+    await waitFor(() =>
+      expect(resumeRun).toHaveBeenNthCalledWith(1, "run-1", {
+        answers,
+        source: undefined,
+      }),
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Resume with updated workflow (force)",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(resumeRun).toHaveBeenNthCalledWith(2, "run-1", {
+        answers,
+        source: undefined,
+        force: true,
+      }),
+    );
+  });
 });

--- a/studio/src/components/Runs/runHeader/RunInformationAccordion.test.tsx
+++ b/studio/src/components/Runs/runHeader/RunInformationAccordion.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import RunInformationAccordion from "./RunInformationAccordion";
+
+afterEach(cleanup);
+
+function disclosure(container: HTMLElement) {
+  const details = container.querySelector("details");
+  const summary = screen.getByText("Run information").closest("summary");
+  if (!details || !summary) {
+    throw new Error("Run information disclosure was not rendered");
+  }
+  return { details, summary };
+}
+
+describe("RunInformationAccordion", () => {
+  it("is closed by default and expands from its summary", () => {
+    const { container } = render(
+      <RunInformationAccordion>
+        <div>Children and notes</div>
+      </RunInformationAccordion>,
+    );
+    const { details, summary } = disclosure(container);
+
+    expect(details.open).toBe(false);
+
+    fireEvent.click(summary);
+    expect(details.open).toBe(true);
+  });
+
+  it("keeps its contents mounted across an open/close cycle", () => {
+    const { container } = render(
+      <RunInformationAccordion>
+        <textarea aria-label="Add a run note" defaultValue="draft note" />
+      </RunInformationAccordion>,
+    );
+    const { details, summary } = disclosure(container);
+    const draft = screen.getByLabelText("Add a run note");
+
+    fireEvent.click(summary);
+    fireEvent.click(summary);
+
+    expect(details.open).toBe(false);
+    expect(screen.getByLabelText("Add a run note")).toBe(draft);
+  });
+});

--- a/studio/src/components/Runs/runHeader/RunInformationAccordion.tsx
+++ b/studio/src/components/Runs/runHeader/RunInformationAccordion.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+import { ChevronRightIcon } from "@radix-ui/react-icons";
+
+// Compact disclosure for the secondary run metadata rendered between the
+// identity/actions header and the metrics bar. A native <details> keeps the
+// contents mounted while collapsed, so loaded children and note drafts survive
+// an open/close cycle without occupying diagram space.
+export default function RunInformationAccordion({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <details className="group shrink-0">
+      <summary className="flex cursor-pointer list-none select-none items-center gap-1.5 border-t border-border-default px-3 py-1.5 text-micro font-medium uppercase tracking-wide text-fg-muted transition-colors hover:bg-surface-2/40 hover:text-fg-default focus:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-accent sm:px-4 [&::-webkit-details-marker]:hidden">
+        <ChevronRightIcon
+          className="h-3 w-3 shrink-0 text-fg-subtle transition-transform duration-[var(--motion-fast)] group-open:rotate-90"
+          aria-hidden
+        />
+        Run information
+      </summary>
+      <div className="border-t border-border-default">{children}</div>
+    </details>
+  );
+}

--- a/studio/src/views/PipelineBoard/PipelineColumns.test.tsx
+++ b/studio/src/views/PipelineBoard/PipelineColumns.test.tsx
@@ -74,6 +74,7 @@ import {
   isTicketEditable,
   moveTicket,
 } from "./PipelineColumns";
+import { resumePipelineRun } from "./resumePipelineRun";
 
 // Three fixed lanes: Opened (backlog + ready staging), In progress, Closed
 // (success + failure).
@@ -124,6 +125,53 @@ beforeEach(() => {
   pauseRunMock.mockReset();
   resumeRunMock.mockReset();
   cancelRunMock.mockReset();
+});
+
+describe("resumePipelineRun", () => {
+  it("resumes normally when the workflow source is unchanged", async () => {
+    resumeRunMock.mockResolvedValueOnce({ run_id: "r1", status: "running" });
+
+    await resumePipelineRun("r1", vi.fn());
+
+    expect(resumeRunMock).toHaveBeenCalledOnce();
+    expect(resumeRunMock).toHaveBeenCalledWith("r1", {});
+  });
+
+  it("asks before retrying a stale run with the current workflow", async () => {
+    resumeRunMock
+      .mockRejectedValueOnce(
+        new Error("runtime: workflow source has changed since this run was started"),
+      )
+      .mockResolvedValueOnce({ run_id: "r1", status: "running" });
+    const confirmUpdatedWorkflow = vi.fn().mockResolvedValue(true);
+
+    await resumePipelineRun("r1", confirmUpdatedWorkflow);
+
+    expect(confirmUpdatedWorkflow).toHaveBeenCalledOnce();
+    expect(resumeRunMock).toHaveBeenNthCalledWith(1, "r1", {});
+    expect(resumeRunMock).toHaveBeenNthCalledWith(2, "r1", { force: true });
+  });
+
+  it("does not force-resume when the operator declines", async () => {
+    resumeRunMock.mockRejectedValueOnce(
+      new Error("runtime: workflow source has changed since this run was started"),
+    );
+
+    await resumePipelineRun("r1", vi.fn().mockResolvedValue(false));
+
+    expect(resumeRunMock).toHaveBeenCalledOnce();
+  });
+
+  it("does not hide unrelated resume errors", async () => {
+    const error = new Error("cannot be resumed (status: finished)");
+    resumeRunMock.mockRejectedValueOnce(error);
+    const confirmUpdatedWorkflow = vi.fn();
+
+    await expect(
+      resumePipelineRun("r1", confirmUpdatedWorkflow),
+    ).rejects.toBe(error);
+    expect(confirmUpdatedWorkflow).not.toHaveBeenCalled();
+  });
 });
 
 describe("PipelineColumns", () => {

--- a/studio/src/views/PipelineBoard/PipelineColumns.tsx
+++ b/studio/src/views/PipelineBoard/PipelineColumns.tsx
@@ -15,7 +15,7 @@ import {
   markPipelineTaskReady,
   resetPipelineTask,
 } from "@/api/pipelineBoards";
-import { cancelRun, pauseRun, resumeRun } from "@/api/runs";
+import { cancelRun, pauseRun } from "@/api/runs";
 import type { UnifiedStatus } from "@/components/Runs/runStatusClasses";
 import {
   Badge,
@@ -65,6 +65,7 @@ import { QueueBanner } from "./QueueBanner";
 import { faceTags } from "./cardTags";
 import { formatChildrenSummary } from "./planGroups";
 import { hasOpenDeps } from "./queueSummary";
+import { resumePipelineRun } from "./resumePipelineRun";
 
 // Re-export capabilities for existing tests.
 export {
@@ -242,7 +243,17 @@ export function PipelineColumns({
   const actions: PipelineCardActions = {
     // Pause / Resume are reversible — no confirm friction.
     onPause: (card) => void runAction(() => pauseRun(card.run_id as string)),
-    onResume: (card) => void runAction(() => resumeRun(card.run_id as string, {})),
+    onResume: (card) =>
+      void runAction(() =>
+        resumePipelineRun(card.run_id as string, () =>
+          confirm({
+            title: "Workflow changed since this run started",
+            message:
+              "Resume from the saved checkpoint using the current workflow source?",
+            confirmLabel: "Resume with updated workflow",
+          }),
+        ),
+      ),
     onStop: async (card) => {
       if (
         !(await confirm({

--- a/studio/src/views/PipelineBoard/resumePipelineRun.ts
+++ b/studio/src/views/PipelineBoard/resumePipelineRun.ts
@@ -1,0 +1,18 @@
+import { resumeRun } from "@/api/runs";
+import { errorMessage } from "@/lib/errorHints";
+
+// Operator-paused runs normally resume against the source they started with.
+// If that source has changed, make the potentially surprising force-resume an
+// explicit second step instead of leaving the board at an opaque HTTP 400.
+export async function resumePipelineRun(
+  runId: string,
+  confirmUpdatedWorkflow: () => Promise<boolean>,
+): Promise<void> {
+  try {
+    await resumeRun(runId, {});
+  } catch (error) {
+    if (!/source has changed/i.test(errorMessage(error))) throw error;
+    if (!(await confirmUpdatedWorkflow())) return;
+    await resumeRun(runId, { force: true });
+  }
+}


### PR DESCRIPTION
## Summary

- allow operator-paused runs to resume through service and CLI paths
- reject stale workflow resumes synchronously so human answers remain available for an explicit forced retry
- confirm forced resumes from pipeline cards when the workflow source changed
- preserve operator pause status when a cloud republish fails
- collapse secondary run information above the diagram by default

## Validation

- go test ./pkg/runview ./pkg/cli -count=1
- go test ./pkg/server/cloudpublisher -count=1
- Studio Vitest suite: 117 files, 1029 tests
- Studio TypeScript build
- Studio production Vite build
- targeted Studio ESLint: no errors