### PR TITLE
fix: wait out a provider quota window instead of burning 8 pods against it

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -375,7 +375,7 @@ tasks:
   test:live:feat:rtk:
     desc: 'Live e2e for the rtk command-output compression (needs rtk binary) feature (real cost).'
     cmds:
-      - go test -v -tags live -count=1 -run 'TestLive_Feat_Rtk$' -timeout 3m ./e2e/...
+      - go test -v -tags live -count=1 -run 'TestLive_Feat_Compress$' -timeout 3m ./e2e/...
 
   test:live:feat:budget-resume:
     desc: 'Live e2e for budget exceeded → raise cap → resume recovery (real cost).'

--- a/docs/bot-runs/docs-refresh.md
+++ b/docs/bot-runs/docs-refresh.md
@@ -42,6 +42,38 @@ reference self-host case.
   Fix is configuration only: set `vars: {open_mr: "true", mode:
   "incremental"}` on the schedule. Worth doing before next Monday — until
   then the weekly is pure cost.
+- **What was salvaged.** The commits are gone, but the campaign's five
+  `human_note` payloads were recovered from the run events before the run
+  aged out. Two were cheap and are fixed in this branch:
+  - `Taskfile.yml:378` — `test:live:feat:rtk` ran `-run 'TestLive_Feat_Rtk$'`,
+    which matches **no test** (the real one is `TestLive_Feat_Compress`).
+    `go test -run` with no match exits 0, so the target passed green while
+    executing nothing. Retargeted.
+  - `pkg/bundle/manifest.go` — the unknown-forge-event error listed two of
+    the three valid events, omitting `issue_labeled`, so an author
+    declaring a *valid* event was told it was unknown. The list is now
+    derived from `KnownForgeEvents` instead of hardcoded at the error site,
+    which is what let it drift.
+
+  Three are handed off (not `.md`-fixable, so outside Doki's writeable set):
+  - `bots/security-bots` — `reviewer_isolation` declares
+    `tools: [read_file, glob, grep]` on `claude_code`, which is a **no-op
+    under bypassPermissions**: the node keeps bash. The injection guarantee
+    rests solely on the `project_review_input` schema projection. If
+    bash-denial is meant as defense-in-depth, switch to the claw backend or
+    add `permission: deny`. The DSL comment (`main.bot:4101-4102`) repeats
+    the overstatement.
+  - CLAUDE.md and `docs/scheduling.md` say sec-audit findings are labeled
+    `source:sec-audit-self`, but the shipped bots hardcode
+    `source:sec-audit-source` / `-deps` and read no `label_source` var —
+    the self-audit distinction is **documented but unwired**.
+  - `docs/grammar/iterion_v1.ebnf` lags the shipped async surface; five
+    catalog `manifest.yaml` descriptions drifted from their `main.bot`.
+
+  Also worth noting as infrastructure: the **board MCP
+  (`mcp__iterion_board__*`) was unavailable in the cloud runner session** on
+  every pass, so Doki could not file any of these as board issues — which
+  is precisely why they nearly died with the pod.
 - Engine hardening: this run is one of the seven that exposed the
   usage-window retry defects (dead reset-aware wait, no recovery dispatcher
   in the cloud runner, unparseable dated reset hint). See

--- a/docs/bot-runs/docs-refresh.md
+++ b/docs/bot-runs/docs-refresh.md
@@ -13,6 +13,48 @@ promises ledgers persist the agent's adjudications; the opt-in
 `open_mr` tail publishes ONE PR. Runs on ANY repo; iterion is the
 reference self-host case.
 
+## 2026-07-27 — forfait weekly-cap catch-up, and the weekly schedule is throwing its work away (run 019fa533)
+
+- Status: **failed to deliver** — the run finished cleanly and produced
+  ~71 doc-alignment commits, and **every one of them was discarded**. Not a
+  regression: a standing misconfiguration of the prod weekly schedule, found
+  by looking past the green status.
+- Versions: bot v3.5.x · iterion prod `:edge`.
+- Why it ran: the Monday 04:00 weekly (`019fa1ba`) died at `campaign` on the
+  forfait **weekly** quota (`resets Jul 28, 9pm (UTC)`), one of seven prod
+  runs killed by the same wall that morning. Relaunched by hand at 20:11 via
+  a one-shot cloud schedule once the forfait was verified available.
+- Result: 3h10, 5 campaign passes committing 14 / 27 / 11 / 6 / 13 = **71
+  commits**, `docs_aligned: false` on every pass, `continuation_loop`
+  exhausted 4/4, then `mr_gate → open_mr: false` → `done`. No MR, no push,
+  no `final_commit`. The clone died with the pod.
+- **The finding.** The prod weekly schedule (`306ecbc6`, `0 4 * * 1`) carries
+  **`vars: null`**. Two defaults follow from that, and both are wrong for it:
+  - `open_mr: bool = false`, and `mr_gate` computes
+    `vars.open_mr || vars.pr_url` — both empty ⇒ the PR tail never runs.
+    **The schedule has never been able to deliver anything**; it has been
+    burning a multi-hour full sweep every Monday and dropping the result.
+  - `mode: string = "full"`, so it runs the whole-corpus sweep (3h+) rather
+    than the incremental delta the weekly cadence was designed around (see
+    the 2026-07-24 entries). The memory of this schedule being "hebdo
+    incrémental" refers to an earlier row; the current one was recreated
+    2026-07-24 without vars.
+  Fix is configuration only: set `vars: {open_mr: "true", mode:
+  "incremental"}` on the schedule. Worth doing before next Monday — until
+  then the weekly is pure cost.
+- Engine hardening: this run is one of the seven that exposed the
+  usage-window retry defects (dead reset-aware wait, no recovery dispatcher
+  in the cloud runner, unparseable dated reset hint). See
+  [feed-watch.md](feed-watch.md#2026-07-27--five-digests-lost-to-the-forfait-weekly-cap-recovered-by-hand)
+  for the full account; the fix ships as the `retry:` contract.
+- Lessons for next run:
+  - **A green run is not a delivered run.** `status: finished` here means
+    "the graph reached done", not "work landed". For Doki the delivery
+    signal is `open_mr`/`final_commit`, and both were empty.
+  - When a schedule is recreated, its `vars` do not come along. A bot whose
+    useful behaviour depends on non-default vars should say so loudly —
+    `mr_gate` deciding `false` in silence is what let this run for weeks.
+
 ## 2026-07-24 — amend-on-PR validated live END-TO-END + scope_check base fix (runs 019f9429 → 019f949a)
 
 - Status: **validated** (full amend-on-PR flow, live on a real iterion PR). Enabled by a scope_check base-derivation fix (v3.5.3) the dogfood surfaced.

--- a/docs/bot-runs/feed-watch.md
+++ b/docs/bot-runs/feed-watch.md
@@ -4,6 +4,72 @@
 
 Newest first. One section per dogfooded run.
 
+## 2026-07-27 — Five digests lost to the forfait weekly cap, recovered by hand (runs 019fa511 / 019fa523 / 019fa528 / 019fa52e / 019fa538)
+
+- Status: **validated (recovery)** — all five digests delivered; the engine
+  gap the incident exposed is fixed and tested.
+- Versions: bot 1.1.1 · iterion prod `:edge` · fix branch off `58dc015e0`.
+- What happened: on Monday 2026-07-27, **seven scheduled prod runs died on the
+  same wall** within 45 minutes — five feed-watch digests (cyber daily; ia,
+  tsjs, gopyrust, java weekly), the weekly Doki, and a review-pr — all with
+  `rate_limited (claude_code): You've hit your weekly limit · resets Jul 28,
+  9pm (UTC)`. Not a dead token: the forfait's **weekly quota**, exhausted.
+  The four weekly digests would not have retried until **2026-08-03**.
+- Method: the forfait was verified FIRST from a runner pod
+  (`kubectl exec … claude -p` against `claude-opus-4-8` → `OK`), which is
+  the cheap way to tell "quota reopened" from "token broken" before
+  launching anything. Recovery then went through **one-shot cloud schedules**
+  (`cron: CRON_TZ=UTC <m> <h> 27 7 *`, deleted after firing) rather than
+  `POST /api/runs`: a manual repo-targeted launch requires a `connection_id`
+  whose reachability check `SocialGouv/iterion-veille` fails (the GitHub App
+  installation only covers `SocialGouv/iterion`), while a schedule needs no
+  connection and resolves forge creds through the team's `forge_token`
+  binding — the path that has been cloning that repo daily for ten days.
+  First one-shot run doubled as the probe: monitored to completion before
+  creating the rest, staggered ~6 min apart.
+- Result: five runs, all `finished`, full digest path each time
+  (`load_pending → synthesize → verify_message → notify → commit_state`),
+  posts confirmed in Mattermost by the operator. State pushed to
+  `iterion-veille`, so the pending queues are correctly drained. The 11
+  prod schedules were left untouched (crons and next-fire times verified
+  after cleanup).
+- Findings / misses: a fresh digest run is **idempotent after this failure**
+  because `commit_state` runs only after `notify` — the failed runs never
+  advanced state, so the queue was intact and no item was lost or
+  double-posted. Worth remembering: for feed-watch, "relaunch" is always
+  safer than "resume" after a synthesize-stage failure, and it also picks up
+  everything collected since.
+- Engine hardening (the real yield — three defects, none visible from one
+  side alone):
+  1. **The reset-aware retry was dead code on every path.** The engine
+     flattened terminal failures into a string, destroying both the
+     classified code and the typed `*delegate.ErrRateLimited` that carries
+     `ResetAt` — so the `--auto-resume` loop's `errors.As` could never match.
+  2. **The cloud runner wired no recovery dispatcher at all**, so
+     `recovery.Classify` was never called on the one surface that runs
+     unattended.
+  3. **The reset parser could not read the shape a weekly cap prints.**
+     `resets Jul 28, 9pm (UTC)` matched nothing (the pattern required a digit
+     right after `resets`), yielding a zero `ResetAt` for precisely the
+     window whose reset is furthest away.
+  Consequence in production: each failure nak'd into **8 redeliveries** — one
+  fresh pod each, against a wall ~35h away — then parked in the DLQ. 11 of
+  the 30 DLQ entries were this exact cause, going back to 2026-07-21.
+  Fixed by the `retry:` work: the runner now acks and persists *when* to
+  come back, a server sweeper resumes at the reset, and the policy is
+  configurable on four layers (see
+  [docs/scheduling.md](../scheduling.md#retry--a-provider-quota-window-is-waited-out-not-re-attempted)).
+- Lessons for next run:
+  - **Verify the forfait before diagnosing anything else.** "Regenerated the
+    token" and "have quota again" are different claims; a weekly cap is
+    immune to a new token on the same account.
+  - A **daily** category is not automatically safe to skip in a catch-up.
+    Cyber was initially left to self-heal on the next tick on the grounds
+    that no item is lost — but for security watch, a day late *is* the loss.
+    Catch up time-sensitive categories explicitly.
+  - One-shot schedules are the reliable manual-launch path for a repo the
+    forge connection cannot reach. Delete them straight after firing.
+
 ## 2026-07-17 — Security hardening: prompt-injection gate + SSRF guard + link firewall (runs 019f7092 collect / 019f709e inject-digest)
 
 - Status: **validated (host)** — the five hardening mechanisms proven on real

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -293,6 +293,15 @@ A platform ceiling (`ITERION_CLOUD_RETRY_MAX_ATTEMPTS`,
 resolved policy, so a tenant cannot reserve a hundred attempts over thirty
 days on their own schedule.
 
+> **Local vs cloud — the wait is held differently.** In cloud mode the
+> intent is durable, so nothing extra is needed. On a **host-crontab**
+> schedule the wait is held *in-process* by the bounded auto-resume loop,
+> which stays **opt-in**: the `retry_*` fields on a `schedules.yaml` entry
+> *shape* that wait, they do not enable it. Add `--auto-resume N` (or
+> `ITERION_AUTO_RESUME`) to turn it on. The reason it is not on by default
+> is that a local `iterion run` blocks your terminal, and silently sleeping
+> it for 33 hours is not a default anyone would want.
+
 **Choosing a value.** The question a bot author is answering is *is this
 output still worth having late?* A weekly digest is (`resume`); a "what
 changed in the last hour" report is not (`usage_window: off` — let the next

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -284,7 +284,7 @@ each one overrides only the fields it actually sets:
 | priority | layer | where |
 |---|---|---|
 | 1 | per-run override | launch API / CLI |
-| 2 | launching surface | a cloud schedule row, a trigger subscription, a webhook config, a `schedules.yaml` entry |
+| 2 | launching surface | a cloud schedule row, a trigger subscription, a webhook config, a `schedules.yaml` entry — each exposes the same four `retry_*` fields |
 | 3 | the bot | `retry:` in the bundle's `manifest.yaml` |
 | 4 | machine default | `ITERION_RETRY_USAGE_WINDOW` / `_MAX_ATTEMPTS` / `_MAX_WAIT` / `_JITTER` |
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -256,6 +256,63 @@ Idempotence stays with the workflow (mutate the state you poll — e.g.
 the bot relabels the issue), exactly like the dispatcher's tracker
 loop: the guard is a gate + input source, not a dedup engine.
 
+## Retry — a provider quota window is waited out, not re-attempted
+
+A scheduled run that dies because the LLM provider's quota window is
+exhausted (the Anthropic forfait 5h / session / daily / **weekly** caps) is
+not a failure of the run: nothing about it is wrong, it just arrived while
+the door was shut. Retrying it inside a node's retry budget, or handing it
+back to the work queue, cannot help — a weekly reset can be **seven days**
+away, and each attempt costs a fresh pod against a wall that will not move.
+
+So iterion **waits for the reset and resumes**, and the wait is durable
+(cloud mode: the intent lives in the run document, a server-side sweeper
+acts on it). The schedule itself is unaffected: it keeps firing on its own
+cadence, and the retry is about the run that already failed.
+
+```yaml
+retry:
+  usage_window: resume   # resume (default) | off
+  max_attempts: 5        # over the run's WHOLE lifetime; never reset
+  max_wait: 192h         # cap on how far ahead a retry may be scheduled (8d)
+  jitter: 10m            # spread runs that share one reset instant
+```
+
+**Where to declare it.** The same block is accepted on four layers, and
+each one overrides only the fields it actually sets:
+
+| priority | layer | where |
+|---|---|---|
+| 1 | per-run override | launch API / CLI |
+| 2 | launching surface | a cloud schedule row, a trigger subscription, a webhook config, a `schedules.yaml` entry |
+| 3 | the bot | `retry:` in the bundle's `manifest.yaml` |
+| 4 | machine default | `ITERION_RETRY_USAGE_WINDOW` / `_MAX_ATTEMPTS` / `_MAX_WAIT` / `_JITTER` |
+
+A platform ceiling (`ITERION_CLOUD_RETRY_MAX_ATTEMPTS`,
+`ITERION_CLOUD_RETRY_MAX_WAIT`) is applied **last** and can only *lower* a
+resolved policy, so a tenant cannot reserve a hundred attempts over thirty
+days on their own schedule.
+
+**Choosing a value.** The question a bot author is answering is *is this
+output still worth having late?* A weekly digest is (`resume`); a "what
+changed in the last hour" report is not (`usage_window: off` — let the next
+tick produce a fresh one). `max_wait` is the honest expression of that:
+`36h` says "if it cannot run by tomorrow, do not bother".
+
+**What you see.** The run stays `failed_resumable` while it waits, with a
+`run_retry_scheduled` event naming the instant, the attempt number and how
+the instant was derived. When the window reopens the run emits
+`run_auto_resumed` and continues from its checkpoint — the same pair the
+CLI's in-process `--auto-resume` loop writes, so the timeline reads
+identically local and cloud. A run that stops retrying records **why**
+(budget spent, admission denied, source no longer resolvable) rather than
+going quiet.
+
+Not covered by this: a budget cap (`max_cost_usd` and friends) still needs
+a human to raise the cap and resume — retrying the same cap would re-fail
+instantly. Nor an auth failure, which is a credential problem time does not
+fix.
+
 ## Retention — pair recurring schedules with `iterion runs prune`
 
 Every scheduled run persists forever under `<store-dir>/runs/<run_id>/`;

--- a/openapi.json
+++ b/openapi.json
@@ -1402,6 +1402,13 @@
           "repo_root": {
             "type": "string"
           },
+          "retry_after": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "retry_attempts": {
+            "type": "integer"
+          },
           "shard_count": {
             "type": "integer"
           },

--- a/pkg/backend/delegate/claude_code_stream.go
+++ b/pkg/backend/delegate/claude_code_stream.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"regexp"
 	"strconv"
@@ -846,6 +847,18 @@ func classifyRateLimit(text string, now time.Time) (kind string, resetAt time.Ti
 	return kind, parseResetHint(lower, now)
 }
 
+// resetAbsRe matches an explicit absolute instant: "reset at
+// 2026-05-13 07:38:08" (the ZAI facade shape). Tried FIRST because the
+// looser clock pattern below would otherwise chew the "20" out of "2026"
+// and report hour 20 of today.
+var resetAbsRe = regexp.MustCompile(`reset[s]?(?: at)?\s+(\d{4})-(\d{2})-(\d{2})[ t](\d{1,2}):(\d{2})(?::(\d{2}))?`)
+
+// resetDateRe matches the DATED shape a weekly cap prints: "resets Jul 28,
+// 9pm (UTC)", "resets december 30, 11pm". The month name is what makes this
+// distinct from resetClockRe — which requires a digit right after "resets"
+// and so matches none of these.
+var resetDateRe = regexp.MustCompile(`reset[s]?(?: at)?\s+([a-z]{3,9})\.?\s+(\d{1,2})\s*,?\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?`)
+
 // resetClockRe matches the clock-time reset hints observed in forfait
 // notices: "resets 3pm", "resets 10:30am (UTC)", "reset at 7pm".
 var resetClockRe = regexp.MustCompile(`reset[s]?(?: at)?\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?`)
@@ -853,30 +866,73 @@ var resetClockRe = regexp.MustCompile(`reset[s]?(?: at)?\s+(\d{1,2})(?::(\d{2}))
 // resetWindowRe matches the window-duration shape: "reached for 5 hour".
 var resetWindowRe = regexp.MustCompile(`for\s+(\d{1,2})\s*hour`)
 
+// monthNames maps the three-letter prefix of a month name to its number,
+// which covers both the abbreviated ("Jul") and full ("december") forms
+// the CLI has been observed to print.
+var monthNames = map[string]time.Month{
+	"jan": time.January, "feb": time.February, "mar": time.March,
+	"apr": time.April, "may": time.May, "jun": time.June,
+	"jul": time.July, "aug": time.August, "sep": time.September,
+	"oct": time.October, "nov": time.November, "dec": time.December,
+}
+
+// resetDateTrustWindow bounds how far a year-inferred reset instant may
+// sit from now to be believed. Every real window (5h, session, daily,
+// weekly) resets within days, so a candidate months away means the text
+// was not a reset hint after all — better to report "no hint" and let the
+// caller fall back to a bounded wait than to return a confidently wrong
+// instant it would then wait on.
+const resetDateTrustWindow = 45 * 24 * time.Hour
+
+// ParseResetHint extracts the reset instant from a provider usage-window
+// notice, reporting whether anything parsed. Exported so a host that only
+// has the flattened error text (rather than the typed *ErrRateLimited) can
+// still recover the instant instead of re-implementing the patterns.
+func ParseResetHint(text string, now time.Time) (time.Time, bool) {
+	at := parseResetHint(strings.ToLower(text), now)
+	return at, !at.IsZero()
+}
+
 // parseResetHint extracts the next reset instant from a usage-window
 // notice, interpreting bare clock times as the NEXT occurrence (UTC —
 // the forfait notices print UTC). Zero when nothing parses.
 func parseResetHint(lower string, now time.Time) time.Time {
-	if m := resetClockRe.FindStringSubmatch(lower); m != nil {
-		hour, _ := strconv.Atoi(m[1])
-		minute := 0
-		if m[2] != "" {
-			minute, _ = strconv.Atoi(m[2])
+	nowUTC := now.UTC()
+	// An absolute instant is unambiguous: take it verbatim, with no
+	// plausibility window. A value already in the past is a legitimate
+	// answer (the window has reopened) and the caller floors it.
+	if m := resetAbsRe.FindStringSubmatch(lower); m != nil {
+		year, _ := strconv.Atoi(m[1])
+		month, _ := strconv.Atoi(m[2])
+		day, _ := strconv.Atoi(m[3])
+		hour, _ := strconv.Atoi(m[4])
+		minute, _ := strconv.Atoi(m[5])
+		second := 0
+		if m[6] != "" {
+			second, _ = strconv.Atoi(m[6])
 		}
-		switch m[3] {
-		case "pm":
-			if hour < 12 {
-				hour += 12
-			}
-		case "am":
-			if hour == 12 {
-				hour = 0
-			}
+		if month >= 1 && month <= 12 && day >= 1 && day <= 31 && hour <= 23 && minute <= 59 && second <= 59 {
+			return time.Date(year, time.Month(month), day, hour, minute, second, 0, time.UTC)
 		}
-		if hour > 23 || minute > 59 {
+		return time.Time{}
+	}
+	if m := resetDateRe.FindStringSubmatch(lower); m != nil {
+		if month, ok := monthNames[m[1][:3]]; ok {
+			day, _ := strconv.Atoi(m[2])
+			hour, minute, ok := clockTo24h(m[3], m[4], m[5])
+			if ok && day >= 1 && day <= 31 {
+				return inferResetYear(month, day, hour, minute, nowUTC)
+			}
 			return time.Time{}
 		}
-		nowUTC := now.UTC()
+		// A leading word that is not a month means this is not the dated
+		// shape; fall through to the bare-clock pattern below.
+	}
+	if m := resetClockRe.FindStringSubmatch(lower); m != nil {
+		hour, minute, ok := clockTo24h(m[1], m[2], m[3])
+		if !ok {
+			return time.Time{}
+		}
 		at := time.Date(nowUTC.Year(), nowUTC.Month(), nowUTC.Day(), hour, minute, 0, 0, time.UTC)
 		if !at.After(nowUTC) {
 			at = at.Add(24 * time.Hour)
@@ -886,10 +942,62 @@ func parseResetHint(lower string, now time.Time) time.Time {
 	if m := resetWindowRe.FindStringSubmatch(lower); m != nil {
 		hours, _ := strconv.Atoi(m[1])
 		if hours > 0 {
-			return now.UTC().Add(time.Duration(hours) * time.Hour)
+			return nowUTC.Add(time.Duration(hours) * time.Hour)
 		}
 	}
 	return time.Time{}
+}
+
+// clockTo24h converts a matched clock triple (hour, optional minute,
+// optional am/pm marker) to 24-hour values, reporting whether the result
+// is a valid time of day.
+func clockTo24h(rawHour, rawMinute, meridiem string) (hour, minute int, ok bool) {
+	hour, _ = strconv.Atoi(rawHour)
+	if rawMinute != "" {
+		minute, _ = strconv.Atoi(rawMinute)
+	}
+	switch meridiem {
+	case "pm":
+		if hour < 12 {
+			hour += 12
+		}
+	case "am":
+		if hour == 12 {
+			hour = 0
+		}
+	}
+	if hour > 23 || minute > 59 {
+		return 0, 0, false
+	}
+	return hour, minute, true
+}
+
+// inferResetYear resolves a month/day/clock with no year against now,
+// picking the candidate year that lands closest to now (so a late-December
+// notice naming January rolls forward, and an early-January notice naming
+// December rolls back). Returns zero when even the closest candidate falls
+// outside resetDateTrustWindow.
+func inferResetYear(month time.Month, day, hour, minute int, nowUTC time.Time) time.Time {
+	var best time.Time
+	bestDelta := time.Duration(math.MaxInt64)
+	for _, year := range []int{nowUTC.Year() - 1, nowUTC.Year(), nowUTC.Year() + 1} {
+		at := time.Date(year, month, day, hour, minute, 0, 0, time.UTC)
+		// Reject a normalized date (e.g. Feb 31 → Mar 3).
+		if at.Month() != month || at.Day() != day {
+			continue
+		}
+		delta := at.Sub(nowUTC)
+		if delta < 0 {
+			delta = -delta
+		}
+		if delta < bestDelta {
+			best, bestDelta = at, delta
+		}
+	}
+	if bestDelta > resetDateTrustWindow {
+		return time.Time{}
+	}
+	return best
 }
 
 // toolUseDetail extracts a short single-line summary from tool input for

--- a/pkg/backend/delegate/usage_limit_test.go
+++ b/pkg/backend/delegate/usage_limit_test.go
@@ -52,6 +52,24 @@ func TestClassifyRateLimit(t *testing.T) {
 			text:     "You've hit your limit",
 			wantKind: RateLimitKindUsageWindow,
 		},
+		{
+			// The shape a WEEKLY cap actually prints: a month name and day
+			// before the clock. Seven scheduled prod runs died on this on
+			// 2026-07-27 with the reset ~35h out.
+			name:      "weekly limit with dated reset",
+			text:      "You've hit your weekly limit · resets Jul 28, 9pm (UTC)",
+			wantKind:  RateLimitKindUsageWindow,
+			wantReset: time.Date(2026, 7, 28, 21, 0, 0, 0, time.UTC),
+		},
+		{
+			// An explicit absolute instant needs no year inference, so it is
+			// taken verbatim. Previously the clock pattern chewed the "20" out
+			// of "2026" and produced hour 20 of TODAY.
+			name:      "zai absolute reset instant",
+			text:      "Usage limit reached for 5 hour. Your limit will reset at 2026-05-13 07:38:08",
+			wantKind:  RateLimitKindUsageWindow,
+			wantReset: time.Date(2026, 5, 13, 7, 38, 8, 0, time.UTC),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -73,5 +91,80 @@ func TestParseResetHint_ClockRollsToNextDay(t *testing.T) {
 	want := time.Date(2026, 7, 18, 15, 0, 0, 0, time.UTC)
 	if !got.Equal(want) {
 		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+// TestParseResetHint_DatedShape covers the month-name shape and its year
+// inference. A reset is always within days, so a candidate that lands
+// implausibly far from now means the text was not really a reset hint —
+// returning zero (caller falls back to a bounded wait) beats returning a
+// confidently wrong instant.
+func TestParseResetHint_DatedShape(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		now  time.Time
+		want time.Time
+	}{
+		{
+			name: "same year, days ahead",
+			text: "resets jul 28, 9pm (utc)",
+			now:  time.Date(2026, 7, 27, 6, 0, 0, 0, time.UTC),
+			want: time.Date(2026, 7, 28, 21, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "december to january rolls the year forward",
+			text: "resets jan 2, 10am (utc)",
+			now:  time.Date(2026, 12, 30, 23, 0, 0, 0, time.UTC),
+			want: time.Date(2027, 1, 2, 10, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "january seeing december rolls the year back",
+			text: "resets dec 30, 11pm (utc)",
+			now:  time.Date(2027, 1, 2, 1, 0, 0, 0, time.UTC),
+			want: time.Date(2026, 12, 30, 23, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "full month name",
+			text: "resets december 30, 11pm",
+			now:  time.Date(2026, 12, 29, 1, 0, 0, 0, time.UTC),
+			want: time.Date(2026, 12, 30, 23, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "implausibly distant candidate is not trusted",
+			text: "resets may 12, 9pm (utc)",
+			now:  time.Date(2026, 7, 17, 14, 0, 0, 0, time.UTC),
+			want: time.Time{},
+		},
+		{
+			name: "unknown month falls through to the bare clock",
+			text: "resets 9pm",
+			now:  time.Date(2026, 7, 17, 14, 0, 0, 0, time.UTC),
+			want: time.Date(2026, 7, 17, 21, 0, 0, 0, time.UTC),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseResetHint(tt.text, tt.now); !got.Equal(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseResetHint_Exported asserts the exported wrapper reports
+// parse success separately, so a caller can distinguish "no hint" from
+// "hint that happens to be the zero time" and log the degraded path.
+func TestParseResetHint_Exported(t *testing.T) {
+	now := time.Date(2026, 7, 27, 6, 0, 0, 0, time.UTC)
+	got, ok := ParseResetHint("You've hit your weekly limit · resets Jul 28, 9pm (UTC)", now)
+	if !ok {
+		t.Fatal("ok = false, want true for a dated weekly notice")
+	}
+	if want := time.Date(2026, 7, 28, 21, 0, 0, 0, time.UTC); !got.Equal(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	if _, ok := ParseResetHint("node \"synthesize\" execution failed: something else", now); ok {
+		t.Fatal("ok = true for a message with no reset hint, want false")
 	}
 }

--- a/pkg/backend/model/hooks_tool_input_test.go
+++ b/pkg/backend/model/hooks_tool_input_test.go
@@ -66,4 +66,3 @@ func TestRecentInputsStaysBounded(t *testing.T) {
 		t.Errorf("map non bornee: %d entrees pour un plafond de %d", n, maxRecentInputs)
 	}
 }
-

--- a/pkg/bundle/manifest.go
+++ b/pkg/bundle/manifest.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -360,6 +361,20 @@ var KnownForgeEvents = map[string]bool{
 	ForgeEventIssueLabeled:       true,
 }
 
+// knownForgeEventNames lists the accepted events, sorted for a stable
+// message. Derived from KnownForgeEvents rather than spelled out at the
+// error site: the hardcoded version named only two of the three and stayed
+// wrong while validation correctly accepted all three, so a bot author
+// declaring the valid `issue_labeled` was told it was unknown.
+func knownForgeEventNames() []string {
+	names := make([]string, 0, len(KnownForgeEvents))
+	for name := range KnownForgeEvents {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 // knownForgeScopeKeys / knownForgeScopeLevels constrain a manifest
 // forge.token_scopes block. The provisioner unions the keys across the
 // bots co-enabled on a repo and translates them to the tightest OAuth
@@ -670,7 +685,7 @@ func validateInvocations(invs []Invocation) error {
 				return fmt.Errorf("invocations[%d]: kind=forge requires a forge: block", idx)
 			}
 			if !KnownForgeEvents[inv.Forge.Event] {
-				return fmt.Errorf("invocations[%d].forge: unknown event %q (known: %s, %s)", idx, inv.Forge.Event, ForgeEventPullRequest, ForgeEventPullRequestComment)
+				return fmt.Errorf("invocations[%d].forge: unknown event %q (known: %s)", idx, inv.Forge.Event, strings.Join(knownForgeEventNames(), ", "))
 			}
 			if inv.Command != nil || inv.Schedule != nil || inv.Keepalive != nil {
 				return fmt.Errorf("invocations[%d]: kind=forge must not set a command:/schedule:/keepalive: block", idx)

--- a/pkg/bundle/manifest.go
+++ b/pkg/bundle/manifest.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"go.yaml.in/yaml/v2"
+
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 )
 
 // CurrentManifestSchema is the manifest schema version this build understands.
@@ -173,6 +175,53 @@ type Manifest struct {
 	// manifests load without the DSL, so an unknown name is a soft
 	// authoring mistake for the studio to surface, never a load error.
 	Launch *LaunchHints `yaml:"launch,omitempty"`
+
+	// Retry is the bot author's opinion on what should happen when one of
+	// this bot's runs dies because the provider's quota window is exhausted
+	// (pkg/retrypolicy). It is the BOT layer of the retry precedence chain,
+	// below a schedule's row and above the machine default — a launch
+	// surface overrides only the fields it sets.
+	//
+	// This lives in the manifest rather than the DSL on purpose: retry
+	// decides whether a NEW run is launched, which is orchestration, not
+	// workflow semantics. Everything on the `workflow` block (compress,
+	// permission, worktree, sandbox, budget) changes how nodes execute
+	// INSIDE a run, and a DSL field would land in ir.Workflow — which the
+	// engine reads, pulling it toward being retry-aware. The precedent is
+	// InvocationKeepalive.StaleAfter: a schedgate field already declared
+	// here and defaulted down into a Subscription.
+	//
+	// The relevant author knowledge is whether the output is worth having
+	// late: a weekly digest is (retry it after the reset), a "what changed
+	// in the last hour" report is not (usage_window: off).
+	Retry *RetrySpec `yaml:"retry,omitempty"`
+}
+
+// RetrySpec is the manifest shape of a retrypolicy.Policy. It is declared
+// as its own type (rather than embedding retrypolicy.Policy) so the YAML
+// surface stays independent of the shared struct's json/bson tags, matching
+// how every other host declares these fields flat and projects them.
+type RetrySpec struct {
+	UsageWindow string `yaml:"usage_window,omitempty" json:"usage_window,omitempty"`
+	MaxAttempts int    `yaml:"max_attempts,omitempty" json:"max_attempts,omitempty"`
+	MaxWait     string `yaml:"max_wait,omitempty" json:"max_wait,omitempty"`
+	Jitter      string `yaml:"jitter,omitempty" json:"jitter,omitempty"`
+}
+
+// RetryPolicy projects the manifest's retry block. A nil block yields the
+// zero Policy, i.e. "this layer sets nothing" — deliberately NOT normalized,
+// since filling defaults here would make the bot appear to pin fields the
+// author left open and mask the machine default.
+func (m *Manifest) RetryPolicy() retrypolicy.Policy {
+	if m == nil || m.Retry == nil {
+		return retrypolicy.Policy{}
+	}
+	return retrypolicy.Policy{
+		UsageWindow: m.Retry.UsageWindow,
+		MaxAttempts: m.Retry.MaxAttempts,
+		MaxWait:     m.Retry.MaxWait,
+		Jitter:      m.Retry.Jitter,
+	}
 }
 
 // LaunchHints is a bot's declared launch-form opinion (manifest
@@ -783,6 +832,12 @@ func decodeManifest(body []byte, srcLabel string) (*Manifest, error) {
 		return nil, fmt.Errorf("bundle: manifest %s: %w", srcLabel, err)
 	}
 	if err := validateRepoRequirement(m.Repo); err != nil {
+		return nil, fmt.Errorf("bundle: manifest %s: %w", srcLabel, err)
+	}
+	// A typo in retry: must fail at parse time, next to its source. Left
+	// unvalidated it would surface days later as a silently-defaulted
+	// policy on a run nobody is watching.
+	if err := retrypolicy.Validate(m.RetryPolicy()); err != nil {
 		return nil, fmt.Errorf("bundle: manifest %s: %w", srcLabel, err)
 	}
 	return &m, nil

--- a/pkg/cli/auto_resume.go
+++ b/pkg/cli/auto_resume.go
@@ -12,6 +12,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
 	"github.com/SocialGouv/iterion/pkg/backend/forfait"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -50,22 +51,41 @@ type autoResumeConfig struct {
 	// rather than burn attempts against a wall. <= 0 disables the check.
 	// Best-effort — an unavailable usage endpoint never blocks (see forfait).
 	ForfaitCapPct float64
+	// Retry is the shared retry contract (pkg/retrypolicy). It supplies the
+	// horizon for a provider usage window, which is the one dimension this
+	// loop could not express on its own: the cap used to be a hard 5h
+	// constant — shorter than the weekly window it is meant to wait out.
+	Retry retrypolicy.Policy
 }
 
 // resolveAutoResume builds the config from the flag + env + budget flags.
 // A non-zero flag wins; a zero flag falls back to ITERION_AUTO_RESUME; the
 // default is 0 (off).
-func resolveAutoResume(flagN int, budget BudgetOverrides) autoResumeConfig {
+func resolveAutoResume(flagN int, budget BudgetOverrides, override retrypolicy.Policy) autoResumeConfig {
 	n := flagN
 	if n == 0 {
 		if env := envAutoResume(); env > 0 {
 			n = env
 		}
 	}
+	pol, _ := retrypolicy.Resolve(
+		retrypolicy.Layer{Source: retrypolicy.SourceRunOverride, Policy: override},
+		retrypolicy.Layer{Source: retrypolicy.SourceEnv, Policy: retrypolicy.FromEnv()},
+	)
+	// The CLI loop stays OPT-IN: --auto-resume / ITERION_AUTO_RESUME is the
+	// gate, and n == 0 means off. The retry policy deliberately does NOT
+	// turn it on — its defaults describe what an unattended cloud run should
+	// do, and inheriting them here would start auto-resuming every local
+	// `iterion run` that nobody asked to be retried. What the policy DOES
+	// contribute is the horizon (max_wait) and the usage-window opt-out.
+	if n > 0 {
+		pol.MaxAttempts = n
+	}
 	return autoResumeConfig{
 		MaxAttempts:   n,
 		BudgetRaised:  !budget.IsZero(),
 		ForfaitCapPct: forfait.CapPctFromEnv(),
+		Retry:         pol,
 	}
 }
 
@@ -112,6 +132,9 @@ func gateAutoResume(code runtime.ErrorCode, cfg autoResumeConfig, budgetResumed 
 	if !autoResumeRetryableCodes[code] {
 		return autoResumeGate{reason: "not auto-recoverable (code " + nonEmptyCode(code) + ") — leaving run failed_resumable for manual review"}
 	}
+	if code == runtime.ErrCodeUsageLimitBlocked && !cfg.Retry.Enabled() {
+		return autoResumeGate{reason: "provider usage window exhausted and retry.usage_window is off — leaving run failed_resumable"}
+	}
 	if code == runtime.ErrCodeBudgetExceeded {
 		if !cfg.BudgetRaised {
 			return autoResumeGate{reason: "budget exceeded and no raised --max-* cap provided — stopping (re-run with a higher cap, e.g. --max-duration 4h)"}
@@ -150,24 +173,27 @@ func autoResumeBackoff(attempt int) time.Duration {
 // attempt).
 const usageLimitFallbackDelay = 15 * time.Minute
 
-// usageLimitMaxDelay caps a parsed reset hint so a mis-parsed
-// timestamp can never sleep the loop for days.
-const usageLimitMaxDelay = 5 * time.Hour
-
 // usageLimitDelay picks the wait for a USAGE_LIMIT_BLOCKED resume:
 // honor the provider's parsed reset instant (plus a small margin) when
 // present, else the window-scale fallback. Clamped to
 // [fallback floor when hint is in the past, usageLimitMaxDelay].
-func usageLimitDelay(err error, now time.Time) time.Duration {
+func usageLimitDelay(err error, pol retrypolicy.Policy, now time.Time) time.Duration {
 	delay := usageLimitFallbackDelay
 	var rl *delegate.ErrRateLimited
 	if errors.As(err, &rl) && !rl.ResetAt.IsZero() {
 		if until := rl.ResetAt.Sub(now) + time.Minute; until > 0 {
 			delay = until
 		}
+	} else if at, ok := delegate.ParseResetHint(err.Error(), now); ok {
+		// The typed error did not survive to here, but the notice text may
+		// still carry the instant — the same structure-first, string-last
+		// order the cloud runner uses.
+		if until := at.Sub(now) + time.Minute; until > 0 {
+			delay = until
+		}
 	}
-	if delay > usageLimitMaxDelay {
-		delay = usageLimitMaxDelay
+	if max := pol.MaxWaitDuration(); delay > max {
+		delay = max
 	}
 	return delay
 }
@@ -232,7 +258,7 @@ func autoResumeLoop(
 			// Reset-aware wait: retrying inside the forfait window can
 			// never succeed, so the delay tracks the provider's reset
 			// hint instead of the exponential backoff.
-			delay = usageLimitDelay(err, time.Now())
+			delay = usageLimitDelay(err, cfg.Retry, time.Now())
 			logger.Warn("auto-resume: provider usage window exhausted; waiting %s for the quota reset",
 				delay.Round(time.Minute))
 		}

--- a/pkg/cli/auto_resume_test.go
+++ b/pkg/cli/auto_resume_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"errors"
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 	"testing"
 	"time"
 
@@ -11,30 +12,30 @@ import (
 func TestResolveAutoResume(t *testing.T) {
 	t.Run("flag wins over env", func(t *testing.T) {
 		t.Setenv("ITERION_AUTO_RESUME", "2")
-		cfg := resolveAutoResume(5, BudgetOverrides{})
+		cfg := resolveAutoResume(5, BudgetOverrides{}, retrypolicy.Policy{})
 		if cfg.MaxAttempts != 5 {
 			t.Errorf("MaxAttempts = %d, want 5", cfg.MaxAttempts)
 		}
 	})
 	t.Run("env fallback when flag 0", func(t *testing.T) {
 		t.Setenv("ITERION_AUTO_RESUME", "3")
-		cfg := resolveAutoResume(0, BudgetOverrides{})
+		cfg := resolveAutoResume(0, BudgetOverrides{}, retrypolicy.Policy{})
 		if cfg.MaxAttempts != 3 {
 			t.Errorf("MaxAttempts = %d, want 3", cfg.MaxAttempts)
 		}
 	})
 	t.Run("default off", func(t *testing.T) {
 		t.Setenv("ITERION_AUTO_RESUME", "")
-		cfg := resolveAutoResume(0, BudgetOverrides{})
+		cfg := resolveAutoResume(0, BudgetOverrides{}, retrypolicy.Policy{})
 		if cfg.MaxAttempts != 0 {
 			t.Errorf("MaxAttempts = %d, want 0 (off)", cfg.MaxAttempts)
 		}
 	})
 	t.Run("budgetRaised reflects --max-* flags", func(t *testing.T) {
-		if resolveAutoResume(1, BudgetOverrides{}).BudgetRaised {
+		if resolveAutoResume(1, BudgetOverrides{}, retrypolicy.Policy{}).BudgetRaised {
 			t.Error("BudgetRaised should be false with no overrides")
 		}
-		if !resolveAutoResume(1, BudgetOverrides{MaxDuration: "4h"}).BudgetRaised {
+		if !resolveAutoResume(1, BudgetOverrides{MaxDuration: "4h"}, retrypolicy.Policy{}).BudgetRaised {
 			t.Error("BudgetRaised should be true with --max-duration")
 		}
 	})

--- a/pkg/cli/auto_resume_usage_limit_test.go
+++ b/pkg/cli/auto_resume_usage_limit_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/runtime/recovery"
 )
@@ -45,7 +46,7 @@ func TestUsageLimitDelay(t *testing.T) {
 			Kind:    delegate.RateLimitKindUsageWindow,
 			ResetAt: now.Add(90 * time.Minute),
 		})
-		got := usageLimitDelay(err, now)
+		got := usageLimitDelay(err, defaultRetryPolicy(), now)
 		if got < 90*time.Minute || got > 92*time.Minute {
 			t.Fatalf("delay = %s, want ~91m", got)
 		}
@@ -53,7 +54,7 @@ func TestUsageLimitDelay(t *testing.T) {
 
 	t.Run("no hint falls back to window-scale wait", func(t *testing.T) {
 		err := wrapAsRuntime(&delegate.ErrRateLimited{Kind: delegate.RateLimitKindUsageWindow})
-		if got := usageLimitDelay(err, now); got != usageLimitFallbackDelay {
+		if got := usageLimitDelay(err, defaultRetryPolicy(), now); got != usageLimitFallbackDelay {
 			t.Fatalf("delay = %s, want %s", got, usageLimitFallbackDelay)
 		}
 	})
@@ -63,20 +64,41 @@ func TestUsageLimitDelay(t *testing.T) {
 			Kind:    delegate.RateLimitKindUsageWindow,
 			ResetAt: now.Add(-time.Hour),
 		})
-		if got := usageLimitDelay(err, now); got != usageLimitFallbackDelay {
+		if got := usageLimitDelay(err, defaultRetryPolicy(), now); got != usageLimitFallbackDelay {
 			t.Fatalf("delay = %s, want fallback", got)
 		}
 	})
 
-	t.Run("mis-parsed far-future hint is capped", func(t *testing.T) {
+	// A weekly forfait cap resets up to seven days out. The horizon used to
+	// be a hard 5h constant, so the loop could never actually wait one out;
+	// it now comes from the policy, whose default covers a week.
+	t.Run("a multi-day reset is honored, not clamped to hours", func(t *testing.T) {
 		err := wrapAsRuntime(&delegate.ErrRateLimited{
 			Kind:    delegate.RateLimitKindUsageWindow,
 			ResetAt: now.Add(72 * time.Hour),
 		})
-		if got := usageLimitDelay(err, now); got != usageLimitMaxDelay {
-			t.Fatalf("delay = %s, want cap %s", got, usageLimitMaxDelay)
+		got := usageLimitDelay(err, defaultRetryPolicy(), now)
+		if got < 72*time.Hour || got > 73*time.Hour {
+			t.Fatalf("delay = %s, want ~72h", got)
 		}
 	})
+
+	t.Run("the policy horizon caps an implausible hint", func(t *testing.T) {
+		err := wrapAsRuntime(&delegate.ErrRateLimited{
+			Kind:    delegate.RateLimitKindUsageWindow,
+			ResetAt: now.Add(30 * 24 * time.Hour),
+		})
+		pol := retrypolicy.Normalize(retrypolicy.Policy{MaxWait: "36h"})
+		if got := usageLimitDelay(err, pol, now); got != 36*time.Hour {
+			t.Fatalf("delay = %s, want the policy cap 36h", got)
+		}
+	})
+}
+
+// defaultRetryPolicy is the normalized zero policy — what a run with no
+// retry configuration anywhere gets.
+func defaultRetryPolicy() retrypolicy.Policy {
+	return retrypolicy.Normalize(retrypolicy.Policy{})
 }
 
 // wrapAsRuntime mirrors how the executor surfaces backend errors: the

--- a/pkg/cli/resume.go
+++ b/pkg/cli/resume.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -68,6 +69,10 @@ type ResumeOptions struct {
 	// RunOptions.AutoResume so `iterion resume` can itself keep re-driving a
 	// transient-failing run without a human in the loop. See auto_resume.go.
 	AutoResume int
+	// Retry is the per-run retry override (pkg/retrypolicy), the highest
+	// layer of the chain. Zero value inherits ITERION_RETRY_* then the
+	// package defaults.
+	Retry retrypolicy.Policy
 }
 
 // RunResumeWithFile resumes a paused run using a workflow file and answers.
@@ -278,7 +283,7 @@ func RunResumeWithFile(ctx context.Context, iterFile string, opts ResumeOptions,
 	}
 
 	err = eng.Resume(ctx, opts.RunID, answers)
-	err = autoResumeLoop(ctx, eng, s, opts.RunID, resolveAutoResume(opts.AutoResume, opts.Budget), err, logger)
+	err = autoResumeLoop(ctx, eng, s, opts.RunID, resolveAutoResume(opts.AutoResume, opts.Budget, opts.Retry), err, logger)
 	return reportResumeOutcome(p, s, opts.RunID, err, map[string]any{
 		"run_id":   opts.RunID,
 		"workflow": wf.Name,

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -22,6 +22,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/dsl/workflowfile"
 	"github.com/SocialGouv/iterion/pkg/git"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 	"github.com/SocialGouv/iterion/pkg/reviewtopology"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/runtime/recovery"
@@ -123,6 +124,10 @@ type RunOptions struct {
 	// (capped exponential backoff) and re-invokes resume in-process up to N
 	// times, re-using this run's exact overrides. See auto_resume.go.
 	AutoResume int
+	// Retry is the per-run retry override (pkg/retrypolicy), the highest
+	// layer of the chain. Zero value inherits ITERION_RETRY_* then the
+	// package defaults.
+	Retry retrypolicy.Policy
 	// SkipMCPHealth downgrades a failing MCP startup health-check from a
 	// fatal error to a warning: the check still runs (its diagnostics are
 	// logged) but a failure no longer aborts the run. Set by --skip-mcp-health
@@ -370,7 +375,7 @@ func RunRun(ctx context.Context, opts RunOptions, p *Printer) error {
 
 	err = eng.Run(ctx, runID, inputs)
 	err = runInteractiveResumeLoop(ctx, eng, s, runID, opts.NoInteractive, err)
-	err = autoResumeLoop(ctx, eng, s, runID, resolveAutoResume(opts.AutoResume, opts.Budget), err, logger)
+	err = autoResumeLoop(ctx, eng, s, runID, resolveAutoResume(opts.AutoResume, opts.Budget, opts.Retry), err, logger)
 
 	runResult := map[string]any{
 		"run_id":   runID,

--- a/pkg/cli/schedule.go
+++ b/pkg/cli/schedule.go
@@ -14,6 +14,7 @@ import (
 
 	yaml "go.yaml.in/yaml/v2"
 
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 	"github.com/SocialGouv/iterion/pkg/schedgate"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -67,6 +68,21 @@ type ScheduleEntry struct {
 	GuardTimeout  string `yaml:"guard_timeout,omitempty"`
 	GuardVar      string `yaml:"guard_var,omitempty"`
 	StaleAfter    string `yaml:"stale_after,omitempty"`
+
+	// Retry policy (pkg/retrypolicy) for a run this schedule launches that
+	// dies on an exhausted provider usage window. Declared flat like the
+	// schedgate fields above; project with retryPolicy(). Only the fields
+	// set here override the machine default.
+	//
+	// Note the surface difference: locally the wait is held in-process by
+	// the bounded auto-resume loop, so it needs `--auto-resume N` (or
+	// ITERION_AUTO_RESUME) to be on at all — these fields shape that wait
+	// rather than enabling it. In cloud mode the wait is durable and needs
+	// no such opt-in.
+	RetryUsageWindow string `yaml:"retry_usage_window,omitempty"`
+	RetryMaxAttempts int    `yaml:"retry_max_attempts,omitempty"`
+	RetryMaxWait     string `yaml:"retry_max_wait,omitempty"`
+	RetryJitter      string `yaml:"retry_jitter,omitempty"`
 }
 
 // policy projects the entry's schedgate fields into a normalized Policy.
@@ -79,6 +95,18 @@ func (e ScheduleEntry) policy() schedgate.Policy {
 		GuardVar:      e.GuardVar,
 		StaleAfter:    e.StaleAfter,
 	})
+}
+
+// retryPolicy projects the entry's retry fields. Not normalized — this is
+// one layer of a precedence chain, and defaults filled here would
+// masquerade as an explicit per-schedule choice.
+func (e ScheduleEntry) retryPolicy() retrypolicy.Policy {
+	return retrypolicy.Policy{
+		UsageWindow: e.RetryUsageWindow,
+		MaxAttempts: e.RetryMaxAttempts,
+		MaxWait:     e.RetryMaxWait,
+		Jitter:      e.RetryJitter,
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -408,6 +436,7 @@ func RunScheduleRun(ctx context.Context, p *Printer, opts ScheduleRunOptions) er
 		StoreDir:      e.StoreDir,
 		Sandbox:       e.Sandbox,
 		NoInteractive: true, // cron has no TTY — never block on a human pause
+		Retry:         e.retryPolicy(),
 	}
 	if e.Timeout != "" {
 		d, err := time.ParseDuration(e.Timeout)

--- a/pkg/cloud/metrics/metrics.go
+++ b/pkg/cloud/metrics/metrics.go
@@ -53,6 +53,16 @@ type Registry struct {
 	LaunchDeniedTotal       *prometheus.CounterVec // reason (org_suspended|monthly_run_quota_exceeded|…)
 	RunsOrphanRecovered     prometheus.Counter
 	DLQDepth                prometheus.Gauge
+	// Provider usage-window retries. The pair is what makes the wait
+	// auditable: scheduled counts runs parked for a later reset, resumed
+	// counts the ones a sweeper actually brought back. A growing gap means
+	// runs are being armed and never resumed — the failure mode this whole
+	// path exists to avoid, and one that is otherwise silent because a
+	// parked run just sits there as failed_resumable.
+	RunsUsageWindowBlocked prometheus.Counter
+	RunsRetryScheduled     prometheus.Counter
+	RunsRetryResumed       *prometheus.CounterVec // result (enqueued|abandoned|failed)
+	RunsRetryPending       prometheus.Gauge
 }
 
 // New registers the metrics on a fresh registry. Each call gives a
@@ -130,6 +140,22 @@ func New() *Registry {
 		Name: "iterion_runs_orphan_recovered_total",
 		Help: "Stranded queued/running runs the sweeper flipped to failed_resumable.",
 	})
+	r.RunsUsageWindowBlocked = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "iterion_runs_usage_window_blocked_total",
+		Help: "Runs that failed because the LLM provider's quota window was exhausted.",
+	})
+	r.RunsRetryScheduled = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "iterion_runs_retry_scheduled_total",
+		Help: "Automatic retries armed for a run waiting on a provider quota reset.",
+	})
+	r.RunsRetryResumed = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "iterion_runs_retry_resumed_total",
+		Help: "Outcomes of the retry sweeper acting on a due run, by result.",
+	}, []string{"result"})
+	r.RunsRetryPending = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "iterion_runs_retry_pending",
+		Help: "Runs currently armed for an automatic retry (sampled each sweep).",
+	})
 	r.DLQDepth = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "iterion_dlq_depth",
 		Help: "Messages currently parked on the runs DLQ stream.",
@@ -143,6 +169,8 @@ func New() *Registry {
 		r.WebhookDeliveriesTotal, r.WebhookThrottledTotal,
 		r.AuthLoginsTotal, r.AuthPasswordResetsTotal,
 		r.LaunchDeniedTotal, r.RunsOrphanRecovered, r.DLQDepth,
+		r.RunsUsageWindowBlocked, r.RunsRetryScheduled,
+		r.RunsRetryResumed, r.RunsRetryPending,
 	)
 	return r
 }

--- a/pkg/cloudsched/schedule.go
+++ b/pkg/cloudsched/schedule.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/robfig/cron/v3"
 
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 	"github.com/SocialGouv/iterion/pkg/schedgate"
 )
 
@@ -47,6 +48,16 @@ type ScheduledBot struct {
 	// StaleAfter is the keepalive silence cutoff (Go duration); empty defaults
 	// to schedgate.DefaultStaleAfter. Only meaningful with Overlap=keepalive.
 	StaleAfter string `bson:"stale_after,omitempty" json:"stale_after,omitempty"`
+
+	// Retry policy (pkg/retrypolicy) for a run this schedule launches that
+	// dies on an exhausted provider usage window. Declared flat like the
+	// schedgate fields above so the row stays queryable; project with
+	// RetryPolicy(). Empty fields inherit the bot's manifest, then the
+	// machine default — this layer only overrides what it sets.
+	RetryUsageWindow string `bson:"retry_usage_window,omitempty" json:"retry_usage_window,omitempty"`
+	RetryMaxAttempts int    `bson:"retry_max_attempts,omitempty" json:"retry_max_attempts,omitempty"`
+	RetryMaxWait     string `bson:"retry_max_wait,omitempty" json:"retry_max_wait,omitempty"`
+	RetryJitter      string `bson:"retry_jitter,omitempty" json:"retry_jitter,omitempty"`
 
 	// NextFireAt is the next UTC instant this schedule is due. The ticker
 	// CAS-advances it the moment it claims a tick, so a second replica racing
@@ -104,7 +115,13 @@ type SchedulePatch struct {
 	GuardTimeout    *string
 	GuardVar        *string
 	StaleAfter      *string
-	UpdatedAt       time.Time
+	// Retry policy fields; nil = leave untouched. An explicit empty string
+	// (or 0) clears the field so the schedule stops overriding the bot.
+	RetryUsageWindow *string
+	RetryMaxAttempts *int
+	RetryMaxWait     *string
+	RetryJitter      *string
+	UpdatedAt        time.Time
 }
 
 // ErrNotFound is returned by Get/Delete for an unknown id.
@@ -181,6 +198,18 @@ func applySchedulePatch(sb *ScheduledBot, patch SchedulePatch) {
 	if patch.StaleAfter != nil {
 		sb.StaleAfter = *patch.StaleAfter
 	}
+	if patch.RetryUsageWindow != nil {
+		sb.RetryUsageWindow = *patch.RetryUsageWindow
+	}
+	if patch.RetryMaxAttempts != nil {
+		sb.RetryMaxAttempts = *patch.RetryMaxAttempts
+	}
+	if patch.RetryMaxWait != nil {
+		sb.RetryMaxWait = *patch.RetryMaxWait
+	}
+	if patch.RetryJitter != nil {
+		sb.RetryJitter = *patch.RetryJitter
+	}
 	if !patch.UpdatedAt.IsZero() {
 		sb.UpdatedAt = patch.UpdatedAt
 	}
@@ -197,4 +226,17 @@ func (sb ScheduledBot) Policy() schedgate.Policy {
 		GuardVar:      sb.GuardVar,
 		StaleAfter:    sb.StaleAfter,
 	})
+}
+
+// RetryPolicy projects the schedule's retry fields. Deliberately NOT
+// normalized: this is one layer of a precedence chain, and filling defaults
+// here would make the schedule appear to set fields it left open, masking
+// the bot's manifest and the machine default.
+func (sb ScheduledBot) RetryPolicy() retrypolicy.Policy {
+	return retrypolicy.Policy{
+		UsageWindow: sb.RetryUsageWindow,
+		MaxAttempts: sb.RetryMaxAttempts,
+		MaxWait:     sb.RetryMaxWait,
+		Jitter:      sb.RetryJitter,
+	}
 }

--- a/pkg/retrypolicy/env.go
+++ b/pkg/retrypolicy/env.go
@@ -1,0 +1,75 @@
+package retrypolicy
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Environment variables. The ITERION_RETRY_* set is the machine-wide
+// DEFAULT layer (lowest priority, overridable by a bot or a schedule); the
+// ITERION_CLOUD_RETRY_* set is the platform CEILING (applied last, can only
+// lower). Keeping them as two distinct prefixes is deliberate: an operator
+// raising a default and a platform capping a tenant are opposite intents,
+// and one variable cannot serve both.
+const (
+	EnvUsageWindow = "ITERION_RETRY_USAGE_WINDOW"
+	EnvMaxAttempts = "ITERION_RETRY_MAX_ATTEMPTS"
+	EnvMaxWait     = "ITERION_RETRY_MAX_WAIT"
+	EnvJitter      = "ITERION_RETRY_JITTER"
+
+	EnvCeilingMaxAttempts = "ITERION_CLOUD_RETRY_MAX_ATTEMPTS"
+	EnvCeilingMaxWait     = "ITERION_CLOUD_RETRY_MAX_WAIT"
+)
+
+// FromEnv builds the machine-wide default layer. Unset or unparseable
+// values are left empty so the package defaults apply — a typo in an env
+// var must not silently disable retries, and Validate is not reachable from
+// here (there is no request to reject).
+func FromEnv() Policy {
+	return Policy{
+		UsageWindow: strings.TrimSpace(os.Getenv(EnvUsageWindow)),
+		MaxAttempts: envPositiveInt(EnvMaxAttempts),
+		MaxWait:     envDuration(EnvMaxWait),
+		Jitter:      envDuration(EnvJitter),
+	}
+}
+
+// CeilingFromEnv builds the platform ceiling. A zero field means "no
+// ceiling on this dimension".
+func CeilingFromEnv() Ceiling {
+	c := Ceiling{MaxAttempts: envPositiveInt(EnvCeilingMaxAttempts)}
+	if raw := envDuration(EnvCeilingMaxWait); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+			c.MaxWait = d
+		}
+	}
+	return c
+}
+
+func envPositiveInt(name string) int {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return n
+}
+
+// envDuration returns the raw value only when it parses as a positive
+// duration, so an unparseable env var falls through to the default instead
+// of failing a Validate call far from its source.
+func envDuration(name string) string {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return ""
+	}
+	if d, err := time.ParseDuration(raw); err != nil || d < 0 {
+		return ""
+	}
+	return raw
+}

--- a/pkg/retrypolicy/policy.go
+++ b/pkg/retrypolicy/policy.go
@@ -1,0 +1,266 @@
+// Package retrypolicy is the shared "should this failed run be retried,
+// and when?" contract — the after-the-failure counterpart to pkg/schedgate's
+// before-the-launch gate. Like schedgate it is pure: no I/O, no store, no
+// clock of its own. Each surface keeps its own persistence (a schedule row
+// in Mongo, a schedules.yaml entry, a bot manifest) and projects onto the
+// same Policy.
+//
+// It exists because a provider usage window (the Anthropic forfait 5h /
+// session / daily / weekly caps) cannot clear inside a node's retry budget
+// or a message-queue redelivery window: a weekly reset is up to seven days
+// out. Blind redelivery against that wall just burns pods — on 2026-07-27,
+// seven scheduled prod runs each reprovisioned eight pods against a reset
+// ~35h away before parking in the DLQ. The cure is to wait for the reset,
+// which means the wait must be durable and its shape must be configurable
+// by whoever owns the schedule, the bot, or the platform.
+package retrypolicy
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// UsageWindow policy values. Empty normalizes to UsageWindowResume: a run
+// that died only because the provider's quota window was exhausted is the
+// clearest possible case for an automatic retry — nothing about the run is
+// wrong, and the operator would otherwise re-launch it by hand. Off is the
+// explicit opt-out for a run whose output is worthless late (a "what
+// changed in the last hour" digest, say).
+const (
+	UsageWindowResume = "resume"
+	UsageWindowOff    = "off"
+)
+
+// Defaults.
+const (
+	// DefaultMaxAttempts bounds how many times a single run may be retried
+	// across its whole lifetime. The counter is never reset, so this is a
+	// hard anti-loop ceiling, not a per-window allowance.
+	DefaultMaxAttempts = 5
+	// DefaultMaxWait caps how far ahead a retry may be scheduled. The
+	// longest real window is weekly, so eight days covers it with room for
+	// timezone skew in the provider's reset notice while still refusing an
+	// absurd "retry in three months" from a misparsed hint.
+	DefaultMaxWait = 8 * 24 * time.Hour
+	// DefaultJitter spreads retries that share one reset instant. Several
+	// schedules commonly die on the same window (five feed-watch digests
+	// did), and resuming them simultaneously at the reset can exhaust the
+	// fresh window immediately.
+	DefaultJitter = 10 * time.Minute
+)
+
+// Policy is the retry contract shared by every surface that can own one.
+// Zero value is legal (resume with the defaults); Normalize promotes it to
+// explicit values. All fields are additive on their host schemas — old
+// manifests and old rows load unchanged.
+//
+// Fields are named by FAILURE CLASS rather than as one boolean so a future
+// class (network_transient, tool_failed_transient) becomes a sibling field
+// instead of a schema break.
+type Policy struct {
+	// UsageWindow selects what happens when a run fails because the
+	// provider's quota window is exhausted: "resume" (default) waits for
+	// the reset and resumes, "off" leaves the run failed_resumable for the
+	// operator.
+	UsageWindow string `yaml:"usage_window,omitempty" json:"usage_window,omitempty" bson:"usage_window,omitempty"`
+	// MaxAttempts bounds retries over the run's whole lifetime. 0 means
+	// unset (inherit / default); use UsageWindow "off" to disable retries
+	// rather than a zero count, so "disabled" is never ambiguous with
+	// "not configured here".
+	MaxAttempts int `yaml:"max_attempts,omitempty" json:"max_attempts,omitempty" bson:"max_attempts,omitempty"`
+	// MaxWait caps how far ahead a retry may be scheduled (Go duration
+	// string, default 8d). A reset further out than this is clamped, not
+	// refused: waiting the cap and re-checking beats dropping the run.
+	MaxWait string `yaml:"max_wait,omitempty" json:"max_wait,omitempty" bson:"max_wait,omitempty"`
+	// Jitter is the maximum random delay added to a computed retry instant
+	// (Go duration string, default 10m) so runs sharing a reset do not all
+	// resume at once. "0s" disables it.
+	Jitter string `yaml:"jitter,omitempty" json:"jitter,omitempty" bson:"jitter,omitempty"`
+}
+
+// Normalize returns p with defaults applied. Idempotent; never returns a
+// Policy with an empty UsageWindow, MaxWait or Jitter.
+func Normalize(p Policy) Policy {
+	if p.UsageWindow == "" {
+		p.UsageWindow = UsageWindowResume
+	}
+	if p.MaxAttempts == 0 {
+		p.MaxAttempts = DefaultMaxAttempts
+	}
+	if p.MaxWait == "" {
+		p.MaxWait = DefaultMaxWait.String()
+	}
+	if p.Jitter == "" {
+		p.Jitter = DefaultJitter.String()
+	}
+	return p
+}
+
+// Validate reports whether p is coherent. Errors are user-facing and name
+// the offending field.
+func Validate(p Policy) error {
+	switch p.UsageWindow {
+	case "", UsageWindowResume, UsageWindowOff:
+	default:
+		return fmt.Errorf("retrypolicy: invalid usage_window %q (want %q or %q)", p.UsageWindow, UsageWindowResume, UsageWindowOff)
+	}
+	if p.MaxAttempts < 0 {
+		return fmt.Errorf("retrypolicy: max_attempts must be >= 1 when set (got %d; use usage_window=%s to disable retries)", p.MaxAttempts, UsageWindowOff)
+	}
+	if err := validatePositiveDuration("max_wait", p.MaxWait); err != nil {
+		return err
+	}
+	// Jitter alone may legitimately be zero ("0s" = never spread).
+	if s := strings.TrimSpace(p.Jitter); s != "" {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return fmt.Errorf("retrypolicy: invalid jitter %q: %w", p.Jitter, err)
+		}
+		if d < 0 {
+			return fmt.Errorf("retrypolicy: jitter must be >= 0 (got %q)", p.Jitter)
+		}
+	}
+	return nil
+}
+
+func validatePositiveDuration(field, raw string) error {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return fmt.Errorf("retrypolicy: invalid %s %q: %w", field, raw, err)
+	}
+	if d <= 0 {
+		return fmt.Errorf("retrypolicy: %s must be > 0 (got %q)", field, raw)
+	}
+	return nil
+}
+
+// Enabled reports whether a usage-window failure should be retried.
+func (p Policy) Enabled() bool {
+	p = Normalize(p)
+	return p.UsageWindow == UsageWindowResume && p.MaxAttempts > 0
+}
+
+// MaxWaitDuration resolves the retry-horizon cap, falling back to the
+// default on empty or unparseable values (Validate rejects the latter
+// upstream; the fallback keeps runtime behavior total).
+func (p Policy) MaxWaitDuration() time.Duration {
+	d, err := time.ParseDuration(strings.TrimSpace(p.MaxWait))
+	if err != nil || d <= 0 {
+		return DefaultMaxWait
+	}
+	return d
+}
+
+// JitterDuration resolves the retry spread. Unlike MaxWait, an explicit
+// zero is meaningful (no spread) and is preserved; only an empty or
+// unparseable value falls back to the default.
+func (p Policy) JitterDuration() time.Duration {
+	s := strings.TrimSpace(p.Jitter)
+	if s == "" {
+		return DefaultJitter
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d < 0 {
+		return DefaultJitter
+	}
+	return d
+}
+
+// Layer is one contributor to a resolved Policy, tagged with a label used
+// for provenance reporting.
+type Layer struct {
+	// Source names the layer for provenance ("run_override", "schedule",
+	// "bot", "env", "default").
+	Source string
+	Policy Policy
+}
+
+// Provenance labels for the layers Resolve is normally called with.
+const (
+	SourceRunOverride = "run_override"
+	SourceSchedule    = "schedule"
+	SourceBot         = "bot"
+	SourceEnv         = "env"
+	SourceDefault     = "default"
+	SourceCeiling     = "platform_ceiling"
+)
+
+// Resolve overlays layers FIELD BY FIELD, highest priority first, and
+// reports which layer won each field.
+//
+// Per-field (rather than whole-struct) overlay is what makes the chain
+// usable: a schedule that only pins max_wait must not silently discard the
+// bot's usage_window choice. It mirrors how the permission gate resolves
+// its mode with first-non-empty-wins while merging its rule lists.
+//
+// The returned map is keyed by the wire field name ("usage_window",
+// "max_attempts", "max_wait", "jitter") so an API can show an operator why
+// an effective value is what it is — a four-layer policy is undebuggable
+// otherwise.
+func Resolve(layers ...Layer) (Policy, map[string]string) {
+	var out Policy
+	src := make(map[string]string, 4)
+	for _, l := range layers {
+		if out.UsageWindow == "" && strings.TrimSpace(l.Policy.UsageWindow) != "" {
+			out.UsageWindow = strings.TrimSpace(l.Policy.UsageWindow)
+			src["usage_window"] = l.Source
+		}
+		if out.MaxAttempts == 0 && l.Policy.MaxAttempts != 0 {
+			out.MaxAttempts = l.Policy.MaxAttempts
+			src["max_attempts"] = l.Source
+		}
+		if out.MaxWait == "" && strings.TrimSpace(l.Policy.MaxWait) != "" {
+			out.MaxWait = strings.TrimSpace(l.Policy.MaxWait)
+			src["max_wait"] = l.Source
+		}
+		if out.Jitter == "" && strings.TrimSpace(l.Policy.Jitter) != "" {
+			out.Jitter = strings.TrimSpace(l.Policy.Jitter)
+			src["jitter"] = l.Source
+		}
+	}
+	out = Normalize(out)
+	for _, f := range []string{"usage_window", "max_attempts", "max_wait", "jitter"} {
+		if _, ok := src[f]; !ok {
+			src[f] = SourceDefault
+		}
+	}
+	return out, src
+}
+
+// Ceiling is a platform-imposed bound that can only LOWER a resolved
+// policy, never raise it. It is applied AFTER Resolve so a tenant cannot
+// reserve a hundred attempts over thirty days by declaring them on their
+// own schedule — the same ordering the cloud budget ceiling uses (tenant
+// override first, platform clamp second).
+type Ceiling struct {
+	MaxAttempts int           // 0 = unbounded
+	MaxWait     time.Duration // 0 = unbounded
+}
+
+// IsZero reports whether the ceiling constrains nothing.
+func (c Ceiling) IsZero() bool { return c.MaxAttempts <= 0 && c.MaxWait <= 0 }
+
+// Clamp lowers p to fit c, recording any field it changed in src (which may
+// be nil). A ceiling never enables a retry that the policy disabled, and
+// never raises a value the policy set lower.
+func Clamp(p Policy, c Ceiling, src map[string]string) Policy {
+	p = Normalize(p)
+	if c.MaxAttempts > 0 && p.MaxAttempts > c.MaxAttempts {
+		p.MaxAttempts = c.MaxAttempts
+		if src != nil {
+			src["max_attempts"] = SourceCeiling
+		}
+	}
+	if c.MaxWait > 0 && p.MaxWaitDuration() > c.MaxWait {
+		p.MaxWait = c.MaxWait.String()
+		if src != nil {
+			src["max_wait"] = SourceCeiling
+		}
+	}
+	return p
+}

--- a/pkg/retrypolicy/policy.go
+++ b/pkg/retrypolicy/policy.go
@@ -184,6 +184,8 @@ type Layer struct {
 const (
 	SourceRunOverride = "run_override"
 	SourceSchedule    = "schedule"
+	SourceWebhook     = "webhook"
+	SourceTrigger     = "trigger"
 	SourceBot         = "bot"
 	SourceEnv         = "env"
 	SourceDefault     = "default"

--- a/pkg/retrypolicy/policy.go
+++ b/pkg/retrypolicy/policy.go
@@ -105,8 +105,11 @@ func Validate(p Policy) error {
 	default:
 		return fmt.Errorf("retrypolicy: invalid usage_window %q (want %q or %q)", p.UsageWindow, UsageWindowResume, UsageWindowOff)
 	}
+	// 0 is "unset" (Normalize fills the default), NOT "zero retries" — an
+	// author who means "never retry" writes usage_window: off. Only a
+	// negative is an error, and the message must not imply otherwise.
 	if p.MaxAttempts < 0 {
-		return fmt.Errorf("retrypolicy: max_attempts must be >= 1 when set (got %d; use usage_window=%s to disable retries)", p.MaxAttempts, UsageWindowOff)
+		return fmt.Errorf("retrypolicy: max_attempts cannot be negative (got %d; omit it to inherit the default, or set usage_window=%s to disable retries)", p.MaxAttempts, UsageWindowOff)
 	}
 	if err := validatePositiveDuration("max_wait", p.MaxWait); err != nil {
 		return err

--- a/pkg/retrypolicy/policy_test.go
+++ b/pkg/retrypolicy/policy_test.go
@@ -1,0 +1,266 @@
+package retrypolicy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNormalizeIsIdempotentAndFillsDefaults(t *testing.T) {
+	once := Normalize(Policy{})
+	if once.UsageWindow != UsageWindowResume {
+		t.Errorf("usage_window = %q, want %q", once.UsageWindow, UsageWindowResume)
+	}
+	if once.MaxAttempts != DefaultMaxAttempts {
+		t.Errorf("max_attempts = %d, want %d", once.MaxAttempts, DefaultMaxAttempts)
+	}
+	if once.MaxWaitDuration() != DefaultMaxWait {
+		t.Errorf("max_wait = %v, want %v", once.MaxWaitDuration(), DefaultMaxWait)
+	}
+	if once.JitterDuration() != DefaultJitter {
+		t.Errorf("jitter = %v, want %v", once.JitterDuration(), DefaultJitter)
+	}
+	if twice := Normalize(once); twice != once {
+		t.Errorf("Normalize not idempotent: %+v vs %+v", twice, once)
+	}
+}
+
+func TestNormalizePreservesExplicitValues(t *testing.T) {
+	p := Normalize(Policy{UsageWindow: UsageWindowOff, MaxAttempts: 2, MaxWait: "3h", Jitter: "0s"})
+	if p.UsageWindow != UsageWindowOff || p.MaxAttempts != 2 {
+		t.Errorf("explicit fields overwritten: %+v", p)
+	}
+	if p.MaxWaitDuration() != 3*time.Hour {
+		t.Errorf("max_wait = %v, want 3h", p.MaxWaitDuration())
+	}
+	// An explicit zero jitter is meaningful (never spread) and must survive.
+	if p.JitterDuration() != 0 {
+		t.Errorf("jitter = %v, want 0", p.JitterDuration())
+	}
+}
+
+func TestEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		p    Policy
+		want bool
+	}{
+		{"zero value retries", Policy{}, true},
+		{"explicit resume", Policy{UsageWindow: UsageWindowResume}, true},
+		{"off disables", Policy{UsageWindow: UsageWindowOff}, false},
+		{"off wins over an attempt count", Policy{UsageWindow: UsageWindowOff, MaxAttempts: 9}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.p.Enabled(); got != tt.want {
+				t.Errorf("Enabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		p       Policy
+		wantErr bool
+	}{
+		{"zero value is legal", Policy{}, false},
+		{"resume with bounds", Policy{UsageWindow: UsageWindowResume, MaxAttempts: 3, MaxWait: "36h", Jitter: "1m"}, false},
+		{"off is legal", Policy{UsageWindow: UsageWindowOff}, false},
+		{"zero jitter is legal", Policy{Jitter: "0s"}, false},
+		{"unknown usage_window", Policy{UsageWindow: "retry"}, true},
+		{"negative attempts", Policy{MaxAttempts: -1}, true},
+		{"unparseable max_wait", Policy{MaxWait: "soon"}, true},
+		{"zero max_wait", Policy{MaxWait: "0s"}, true},
+		{"unparseable jitter", Policy{Jitter: "a bit"}, true},
+		{"negative jitter", Policy{Jitter: "-1m"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(tt.p)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate(%+v) error = %v, wantErr %v", tt.p, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestAccessorsAreTotal pins that a value Validate would have rejected still
+// yields a usable duration at runtime, so a corrupted row can never panic or
+// produce a zero wait that hot-loops the sweeper.
+func TestAccessorsAreTotal(t *testing.T) {
+	bad := Policy{MaxWait: "not-a-duration", Jitter: "also-not"}
+	if got := bad.MaxWaitDuration(); got != DefaultMaxWait {
+		t.Errorf("MaxWaitDuration() = %v, want the default %v", got, DefaultMaxWait)
+	}
+	if got := bad.JitterDuration(); got != DefaultJitter {
+		t.Errorf("JitterDuration() = %v, want the default %v", got, DefaultJitter)
+	}
+}
+
+// TestResolveIsPerField is the core of the configurability contract: each
+// layer wins only the fields it actually sets, so a schedule pinning one
+// field cannot silently discard the bot's choice on another.
+func TestResolveIsPerField(t *testing.T) {
+	got, src := Resolve(
+		Layer{Source: SourceRunOverride, Policy: Policy{MaxAttempts: 1}},
+		Layer{Source: SourceSchedule, Policy: Policy{MaxWait: "36h"}},
+		Layer{Source: SourceBot, Policy: Policy{UsageWindow: UsageWindowOff, MaxAttempts: 7, MaxWait: "200h"}},
+		Layer{Source: SourceEnv, Policy: Policy{Jitter: "2m"}},
+	)
+
+	if got.MaxAttempts != 1 {
+		t.Errorf("max_attempts = %d, want 1 (run override wins)", got.MaxAttempts)
+	}
+	if got.MaxWaitDuration() != 36*time.Hour {
+		t.Errorf("max_wait = %v, want 36h (schedule wins over bot)", got.MaxWaitDuration())
+	}
+	if got.UsageWindow != UsageWindowOff {
+		t.Errorf("usage_window = %q, want %q (only the bot set it)", got.UsageWindow, UsageWindowOff)
+	}
+	if got.JitterDuration() != 2*time.Minute {
+		t.Errorf("jitter = %v, want 2m (only env set it)", got.JitterDuration())
+	}
+
+	want := map[string]string{
+		"max_attempts": SourceRunOverride,
+		"max_wait":     SourceSchedule,
+		"usage_window": SourceBot,
+		"jitter":       SourceEnv,
+	}
+	for field, wantSrc := range want {
+		if src[field] != wantSrc {
+			t.Errorf("provenance[%s] = %q, want %q", field, src[field], wantSrc)
+		}
+	}
+}
+
+func TestResolveEmptyLayersDoNotOverwrite(t *testing.T) {
+	got, src := Resolve(
+		Layer{Source: SourceRunOverride, Policy: Policy{}},
+		Layer{Source: SourceSchedule, Policy: Policy{}},
+		Layer{Source: SourceBot, Policy: Policy{MaxAttempts: 4}},
+	)
+	if got.MaxAttempts != 4 {
+		t.Errorf("max_attempts = %d, want 4 (empty higher layers must not win)", got.MaxAttempts)
+	}
+	if src["max_attempts"] != SourceBot {
+		t.Errorf("provenance = %q, want %q", src["max_attempts"], SourceBot)
+	}
+	// Fields nobody set are attributed to the default, not to the last layer.
+	if src["usage_window"] != SourceDefault {
+		t.Errorf("provenance[usage_window] = %q, want %q", src["usage_window"], SourceDefault)
+	}
+}
+
+func TestResolveNoLayersYieldsDefaults(t *testing.T) {
+	got, src := Resolve()
+	if got != Normalize(Policy{}) {
+		t.Errorf("Resolve() = %+v, want the normalized zero value", got)
+	}
+	for _, f := range []string{"usage_window", "max_attempts", "max_wait", "jitter"} {
+		if src[f] != SourceDefault {
+			t.Errorf("provenance[%s] = %q, want %q", f, src[f], SourceDefault)
+		}
+	}
+}
+
+// TestClampOnlyLowers is the multi-tenant safeguard: the platform ceiling
+// must be able to cut a tenant's request down, and must never raise it.
+func TestClampOnlyLowers(t *testing.T) {
+	ceiling := Ceiling{MaxAttempts: 3, MaxWait: 24 * time.Hour}
+
+	src := map[string]string{"max_attempts": SourceSchedule, "max_wait": SourceSchedule}
+	lowered := Clamp(Policy{MaxAttempts: 50, MaxWait: "720h"}, ceiling, src)
+	if lowered.MaxAttempts != 3 {
+		t.Errorf("max_attempts = %d, want 3 (clamped)", lowered.MaxAttempts)
+	}
+	if lowered.MaxWaitDuration() != 24*time.Hour {
+		t.Errorf("max_wait = %v, want 24h (clamped)", lowered.MaxWaitDuration())
+	}
+	if src["max_attempts"] != SourceCeiling || src["max_wait"] != SourceCeiling {
+		t.Errorf("clamped fields must be attributed to the ceiling, got %v", src)
+	}
+
+	// Below the ceiling: untouched, and provenance is preserved.
+	src2 := map[string]string{"max_attempts": SourceBot, "max_wait": SourceBot}
+	kept := Clamp(Policy{MaxAttempts: 2, MaxWait: "2h"}, ceiling, src2)
+	if kept.MaxAttempts != 2 || kept.MaxWaitDuration() != 2*time.Hour {
+		t.Errorf("a policy under the ceiling must be untouched, got %+v", kept)
+	}
+	if src2["max_attempts"] != SourceBot || src2["max_wait"] != SourceBot {
+		t.Errorf("provenance must survive a no-op clamp, got %v", src2)
+	}
+}
+
+func TestClampNeverEnablesADisabledPolicy(t *testing.T) {
+	got := Clamp(Policy{UsageWindow: UsageWindowOff}, Ceiling{MaxAttempts: 9, MaxWait: time.Hour}, nil)
+	if got.Enabled() {
+		t.Error("a ceiling must not re-enable a policy the owner turned off")
+	}
+}
+
+func TestClampWithZeroCeilingIsANoOp(t *testing.T) {
+	p := Normalize(Policy{MaxAttempts: 50, MaxWait: "720h"})
+	if got := Clamp(p, Ceiling{}, nil); got != p {
+		t.Errorf("Clamp with a zero ceiling changed the policy: %+v vs %+v", got, p)
+	}
+	if !(Ceiling{}).IsZero() {
+		t.Error("zero Ceiling should report IsZero")
+	}
+}
+
+func TestClampAcceptsNilProvenance(t *testing.T) {
+	// The sweeper clamps without tracking provenance; a nil map must not panic.
+	got := Clamp(Policy{MaxAttempts: 50}, Ceiling{MaxAttempts: 2}, nil)
+	if got.MaxAttempts != 2 {
+		t.Errorf("max_attempts = %d, want 2", got.MaxAttempts)
+	}
+}
+
+func TestFromEnv(t *testing.T) {
+	t.Setenv(EnvUsageWindow, "off")
+	t.Setenv(EnvMaxAttempts, "2")
+	t.Setenv(EnvMaxWait, "12h")
+	t.Setenv(EnvJitter, "30s")
+
+	p := FromEnv()
+	if p.UsageWindow != UsageWindowOff || p.MaxAttempts != 2 || p.MaxWait != "12h" || p.Jitter != "30s" {
+		t.Errorf("FromEnv() = %+v, want the env values", p)
+	}
+	if err := Validate(p); err != nil {
+		t.Errorf("Validate(FromEnv()) = %v, want nil", err)
+	}
+}
+
+// TestFromEnvIgnoresGarbage pins that a typo in an env var falls through to
+// the package defaults rather than disabling retries or poisoning Validate
+// far from the variable's source.
+func TestFromEnvIgnoresGarbage(t *testing.T) {
+	t.Setenv(EnvMaxAttempts, "lots")
+	t.Setenv(EnvMaxWait, "whenever")
+	t.Setenv(EnvJitter, "-5m")
+
+	p := FromEnv()
+	if p.MaxAttempts != 0 || p.MaxWait != "" || p.Jitter != "" {
+		t.Errorf("FromEnv() = %+v, want unparseable values dropped to empty", p)
+	}
+	if got := Normalize(p).MaxAttempts; got != DefaultMaxAttempts {
+		t.Errorf("normalized max_attempts = %d, want the default %d", got, DefaultMaxAttempts)
+	}
+}
+
+func TestCeilingFromEnv(t *testing.T) {
+	t.Setenv(EnvCeilingMaxAttempts, "4")
+	t.Setenv(EnvCeilingMaxWait, "48h")
+	c := CeilingFromEnv()
+	if c.MaxAttempts != 4 || c.MaxWait != 48*time.Hour {
+		t.Errorf("CeilingFromEnv() = %+v, want {4 48h}", c)
+	}
+
+	t.Setenv(EnvCeilingMaxAttempts, "0")
+	t.Setenv(EnvCeilingMaxWait, "")
+	if c := CeilingFromEnv(); !c.IsZero() {
+		t.Errorf("CeilingFromEnv() = %+v, want a zero ceiling", c)
+	}
+}

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -48,6 +48,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/queue"
 	natsq "github.com/SocialGouv/iterion/pkg/queue/nats"
 	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/runtime/recovery"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
 	"github.com/SocialGouv/iterion/pkg/secrets"
@@ -1131,6 +1132,14 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage) error {
 		// runner that is itself the isolation boundary beats a bot's inline
 		// sandbox block, so the run executes directly in the runner pod.
 		runtime.WithSandboxOverride(r.cfg.SandboxOverride),
+		// Recovery recipes. Every other host wires these (pkg/cli/run.go,
+		// pkg/runview, pkg/dispatcher); the cloud runner did not, so
+		// recovery.Classify was never called on the one surface that runs
+		// unattended — no transient-network backoff, no compaction retry,
+		// and every terminal failure reported as EXECUTION_FAILED whatever
+		// its cause. Cloud runs got strictly less recovery than a local
+		// `iterion run` of the same bot.
+		runtime.WithRecoveryDispatch(recovery.Dispatch(recovery.DefaultRecipes())),
 	}
 	// Sandbox-run observer: registers the live sandbox Run so the mid-run
 	// credential refreshers can write rotated tokens THROUGH into the

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -841,6 +841,15 @@ func (r *Runner) processOne(parent context.Context, delivery *natsq.Delivery) {
 	r.fireCompletionNotifier(msg)
 	r.fireOutcomeEvent(msg, err)
 
+	// Checked BEFORE the DLQ park so a usage-window failure on the FINAL
+	// delivery still arms a retry instead of being parked: the window is
+	// exactly the condition that makes every prior delivery useless, so
+	// reaching delivery 8 is evidence for retrying later, not against it.
+	if handled, retryStatus := r.parkUsageLimitRetry(runCtx, err, delivery, msg, logger); handled {
+		finalStatus = retryStatus
+		return
+	}
+
 	if handled, dlqStatus := r.parkOnDLQOnFinalDelivery(err, delivery, msg, logger); handled {
 		finalStatus = dlqStatus
 		return

--- a/pkg/runner/usage_retry.go
+++ b/pkg/runner/usage_retry.go
@@ -40,6 +40,11 @@ const (
 	// it as UTC, so a "reset" instant can land slightly in the past; a
 	// small floor absorbs that without a second guess at the timezone.
 	usageWindowFloor = 5 * time.Minute
+	// usageRetryStoreTimeout bounds the detached store writes that arm the
+	// retry. Generous enough for a Mongo round trip on a slow day, short
+	// enough that a wedged store cannot hold the delivery past its ack
+	// deadline.
+	usageRetryStoreTimeout = 10 * time.Second
 	// usageWindowBlindWait is the fallback when the provider told us a
 	// window is exhausted but nothing in the text parses as a reset time.
 	// Deliberately bounded and short-ish: one wasted pod an hour beats
@@ -143,32 +148,84 @@ func (r *Runner) parkUsageLimitRetry(
 	msg *queue.RunMessage,
 	logger *iterlog.Logger,
 ) (bool, string) {
+	outcome := r.armUsageWindowRetry(ctx, execErr, msg.RunID, logger)
+	switch outcome {
+	case usageRetryNotApplicable:
+		return false, ""
+	case usageRetryExhausted:
+		ackTerminal(logger, delivery, "ack-usage-limit-exhausted", msg.RunID)
+		return true, "usage_limit_exhausted"
+	default:
+		ackTerminal(logger, delivery, "ack-usage-limit-retry", msg.RunID)
+		return true, "usage_limit_retry"
+	}
+}
+
+// usageRetryOutcome is what armUsageWindowRetry decided, so the delivery
+// handling stays in one place and the decision half is testable without a
+// live JetStream delivery.
+type usageRetryOutcome int
+
+const (
+	// usageRetryNotApplicable: not a usage window, or the intent could not
+	// be persisted — the caller must fall through to nak/DLQ.
+	usageRetryNotApplicable usageRetryOutcome = iota
+	// usageRetryArmed: a retry is durably scheduled.
+	usageRetryArmed
+	// usageRetryExhausted: the attempt budget is spent (or the run is no
+	// longer resumable) — ack, but nothing will come back on its own.
+	usageRetryExhausted
+)
+
+// armUsageWindowRetry is the decide-and-persist half: everything except
+// finalizing the delivery.
+func (r *Runner) armUsageWindowRetry(
+	ctx context.Context,
+	execErr error,
+	runID string,
+	logger *iterlog.Logger,
+) usageRetryOutcome {
 	retryStore := store.AsRunRetryStore(r.cfg.Store)
 	if retryStore == nil {
-		return false, "" // local/filesystem store: no durable retry surface
+		return usageRetryNotApplicable // local/filesystem store: no durable retry surface
 	}
 
-	runMeta, err := r.cfg.Store.LoadRun(ctx, msg.RunID)
+	// The run context is ALREADY CANCELLED by the time we get here: the
+	// caller must stop the heartbeat before finalizing the delivery, and
+	// that cancel is what stops it. Every store call below would therefore
+	// fail instantly on a cancelled context, we would log a warning and
+	// fall through — arming no retry, ever, in production, while the unit
+	// tests (which exercise the pure decision and the sweeper) stayed
+	// green. So detach: values (tenant/owner identity, needed by the Mongo
+	// tenant filter) are preserved, cancellation is not. Same reasoning as
+	// the engine's post-cancellation checkpoint write.
+	//
+	// Detaching HERE rather than at the call site is deliberate — the next
+	// caller would otherwise trip the same wire.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), usageRetryStoreTimeout)
+	defer cancel()
+
+	runMeta, err := r.cfg.Store.LoadRun(ctx, runID)
 	if err != nil {
 		// Without the run doc we cannot read the policy; treating that as
 		// "no retry" is the honest degradation.
-		logger.Warn("runner: run %s: cannot read retry policy (%v) — falling back to redelivery", msg.RunID, err)
-		return false, ""
+		logger.Warn("runner: run %s: cannot read retry policy (%v) — falling back to redelivery", runID, err)
+		return usageRetryNotApplicable
 	}
 	pol := runRetryPolicy(runMeta)
 
 	at, source, ok := usageWindowRetryAt(execErr, pol, time.Now().UTC())
 	if !ok {
-		return false, ""
+		return usageRetryNotApplicable
 	}
 	if r.cfg.Metrics != nil {
 		r.cfg.Metrics.RunsUsageWindowBlocked.Inc()
 	}
 
-	scheduled, attempt, err := retryStore.ScheduleRunRetry(ctx, msg.RunID, at, "usage_window", string(runtime.ErrCodeUsageLimitBlocked), pol.MaxAttempts)
+	scheduled, attempt, err := retryStore.ScheduleRunRetry(ctx, runID, at, "usage_window", string(runtime.ErrCodeUsageLimitBlocked), pol.MaxAttempts)
 	if err != nil {
-		logger.Error("runner: run %s: could not persist the usage-window retry (%v) — falling back to redelivery so the run is not lost", msg.RunID, err)
-		return false, ""
+		logger.Error("runner: run %s: could not persist the usage-window retry (%v) — falling back to redelivery so the run is not lost", runID, err)
+		return usageRetryNotApplicable
 	}
 	if !scheduled {
 		// Either the attempt budget is spent or the run is no longer
@@ -176,25 +233,23 @@ func (r *Runner) parkUsageLimitRetry(
 		// redelivery would re-hit the same wall, and say why in the run's
 		// own error field so it does not just go quiet.
 		reason := fmt.Sprintf("usage-window retries exhausted (max %d) — resume manually once the provider quota resets", pol.MaxAttempts)
-		if abandonErr := retryStore.AbandonRunRetry(ctx, msg.RunID, reason); abandonErr != nil {
-			logger.Warn("runner: run %s: could not record the exhausted retry budget: %v", msg.RunID, abandonErr)
+		if abandonErr := retryStore.AbandonRunRetry(ctx, runID, reason); abandonErr != nil {
+			logger.Warn("runner: run %s: could not record the exhausted retry budget: %v", runID, abandonErr)
 		}
-		logger.Warn("runner: run %s: %s", msg.RunID, reason)
-		ackTerminal(logger, delivery, "ack-usage-limit-exhausted", msg.RunID)
-		return true, "usage_limit_exhausted"
+		logger.Warn("runner: run %s: %s", runID, reason)
+		return usageRetryExhausted
 	}
 
 	if r.cfg.Metrics != nil {
 		r.cfg.Metrics.RunsRetryScheduled.Inc()
 	}
-	if emitErr := r.emitRetryScheduled(ctx, msg.RunID, at, attempt, pol, source); emitErr != nil {
+	if emitErr := r.emitRetryScheduled(ctx, runID, at, attempt, pol, source); emitErr != nil {
 		// Observational only — the durable intent is already committed.
-		logger.Warn("runner: run %s: could not emit run_retry_scheduled: %v", msg.RunID, emitErr)
+		logger.Warn("runner: run %s: could not emit run_retry_scheduled: %v", runID, emitErr)
 	}
 	logger.Warn("runner: run %s hit the provider usage window — retry %d/%d armed for %s (reset source: %s), NOT redelivering",
-		msg.RunID, attempt, pol.MaxAttempts, at.Format(time.RFC3339), source)
-	ackTerminal(logger, delivery, "ack-usage-limit-retry", msg.RunID)
-	return true, "usage_limit_retry"
+		runID, attempt, pol.MaxAttempts, at.Format(time.RFC3339), source)
+	return usageRetryArmed
 }
 
 // emitRetryScheduled records the armed retry on the run's timeline so the

--- a/pkg/runner/usage_retry.go
+++ b/pkg/runner/usage_retry.go
@@ -161,6 +161,9 @@ func (r *Runner) parkUsageLimitRetry(
 	if !ok {
 		return false, ""
 	}
+	if r.cfg.Metrics != nil {
+		r.cfg.Metrics.RunsUsageWindowBlocked.Inc()
+	}
 
 	scheduled, attempt, err := retryStore.ScheduleRunRetry(ctx, msg.RunID, at, "usage_window", string(runtime.ErrCodeUsageLimitBlocked), pol.MaxAttempts)
 	if err != nil {
@@ -181,6 +184,9 @@ func (r *Runner) parkUsageLimitRetry(
 		return true, "usage_limit_exhausted"
 	}
 
+	if r.cfg.Metrics != nil {
+		r.cfg.Metrics.RunsRetryScheduled.Inc()
+	}
 	if emitErr := r.emitRetryScheduled(ctx, msg.RunID, at, attempt, pol, source); emitErr != nil {
 		// Observational only — the durable intent is already committed.
 		logger.Warn("runner: run %s: could not emit run_retry_scheduled: %v", msg.RunID, emitErr)

--- a/pkg/runner/usage_retry.go
+++ b/pkg/runner/usage_retry.go
@@ -1,0 +1,209 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	natsq "github.com/SocialGouv/iterion/pkg/queue/nats"
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
+	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// Usage-window carve-out.
+//
+// A run that dies because the provider's quota window is exhausted must NOT
+// go down the generic nak path. Naking hands it back to JetStream, which
+// redelivers up to MaxDeliver times within AckWait each — one fresh pod per
+// attempt, each re-hitting a wall that cannot move for hours or days, then a
+// DLQ park. Measured on 2026-07-27: seven scheduled runs, eight pods each,
+// against a reset ~35h away.
+//
+// So we ACK (the run is already a good failed_resumable checkpoint) and
+// persist WHEN to come back. The server-side sweeper owns the wait, because
+// it is the only thing that outlives the pod by days.
+//
+// This mirrors the ErrBudgetExceeded carve-out next to it in
+// classifyExecResult: same reasoning (redelivery cannot help, and costs a
+// pod), different remedy (a budget needs a human to raise a cap; a quota
+// window just needs time).
+
+const (
+	// usageWindowFloor keeps a retry from being scheduled effectively now.
+	// The provider's notice may name a non-UTC zone while the parser reads
+	// it as UTC, so a "reset" instant can land slightly in the past; a
+	// small floor absorbs that without a second guess at the timezone.
+	usageWindowFloor = 5 * time.Minute
+	// usageWindowBlindWait is the fallback when the provider told us a
+	// window is exhausted but nothing in the text parses as a reset time.
+	// Deliberately bounded and short-ish: one wasted pod an hour beats
+	// either giving up on the run or waiting a speculative week.
+	usageWindowBlindWait = time.Hour
+)
+
+// usageWindowRetryAt decides WHEN a usage-window failure should be retried,
+// or reports false when it should not be. Pure, so the ordering of its
+// evidence sources is testable.
+//
+// The sources are tried structure-first, string-last on purpose. The typed
+// error is authoritative when it survives to here; the code is authoritative
+// when a recovery dispatcher classified it; and the flattened message is a
+// last resort for a host that has neither — which is not hypothetical, since
+// a runner with no dispatcher wired classifies nothing at all.
+func usageWindowRetryAt(execErr error, pol retrypolicy.Policy, now time.Time) (time.Time, string, bool) {
+	if execErr == nil || !pol.Enabled() {
+		return time.Time{}, "", false
+	}
+
+	var at time.Time
+	var source string
+
+	var rl *delegate.ErrRateLimited
+	switch {
+	case errors.As(execErr, &rl) && rl.Kind == delegate.RateLimitKindUsageWindow:
+		at, source = rl.ResetAt, "typed_error"
+	case runtimeCodeOf(execErr) == runtime.ErrCodeUsageLimitBlocked:
+		source = "runtime_code"
+	default:
+		return time.Time{}, "", false
+	}
+
+	// A usage window with no usable reset instant still gets a retry — the
+	// window is real, only its end is unknown.
+	if at.IsZero() {
+		if parsed, ok := delegate.ParseResetHint(execErr.Error(), now); ok {
+			at, source = parsed, source+"+parsed_text"
+		} else {
+			at, source = now.Add(usageWindowBlindWait), source+"+blind_wait"
+		}
+	} else {
+		// Come back just after the reset, not exactly on it.
+		at = at.Add(time.Minute)
+	}
+
+	// Spread runs that share one reset instant. Several schedules commonly
+	// die on the same window (five feed-watch digests did), and resuming
+	// them simultaneously can exhaust the fresh window immediately.
+	if j := pol.JitterDuration(); j > 0 {
+		at = at.Add(rand.N(j))
+	}
+	if floor := now.Add(usageWindowFloor); at.Before(floor) {
+		at = floor
+	}
+	if ceiling := now.Add(pol.MaxWaitDuration()); at.After(ceiling) {
+		at = ceiling
+	}
+	return at.UTC(), source, true
+}
+
+// runtimeCodeOf extracts the RuntimeError code from an error chain, or "".
+func runtimeCodeOf(err error) runtime.ErrorCode {
+	var rtErr *runtime.RuntimeError
+	if errors.As(err, &rtErr) && rtErr != nil {
+		return rtErr.Code
+	}
+	return ""
+}
+
+// runRetryPolicy resolves the retry policy for a run. The policy was
+// resolved across all its layers at LAUNCH and snapshotted on the run doc,
+// so the runner just reads it — it never has to know that schedules,
+// manifests or bindings exist. A run predating the snapshot (nil) gets the
+// package defaults plus the platform ceiling, which is also what a run
+// launched by a surface that does not resolve policies gets.
+func runRetryPolicy(r *store.Run) retrypolicy.Policy {
+	var pol retrypolicy.Policy
+	if r != nil && r.RetryPolicy != nil {
+		pol = retrypolicy.Policy{
+			UsageWindow: r.RetryPolicy.UsageWindow,
+			MaxAttempts: r.RetryPolicy.MaxAttempts,
+			MaxWait:     r.RetryPolicy.MaxWait,
+			Jitter:      r.RetryPolicy.Jitter,
+		}
+	}
+	return retrypolicy.Clamp(retrypolicy.Normalize(pol), retrypolicy.CeilingFromEnv(), nil)
+}
+
+// parkUsageLimitRetry arms a durable retry for a usage-window failure and
+// acks the delivery. Reports handled=false when this is not that case, or
+// when the intent could NOT be persisted — the caller then falls through to
+// today's nak/DLQ behaviour. That fall-through is the important half: acking
+// without a durable intent would drop the run silently, which is strictly
+// worse than the wasted redeliveries this whole change exists to avoid.
+func (r *Runner) parkUsageLimitRetry(
+	ctx context.Context,
+	execErr error,
+	delivery *natsq.Delivery,
+	msg *queue.RunMessage,
+	logger *iterlog.Logger,
+) (bool, string) {
+	retryStore := store.AsRunRetryStore(r.cfg.Store)
+	if retryStore == nil {
+		return false, "" // local/filesystem store: no durable retry surface
+	}
+
+	runMeta, err := r.cfg.Store.LoadRun(ctx, msg.RunID)
+	if err != nil {
+		// Without the run doc we cannot read the policy; treating that as
+		// "no retry" is the honest degradation.
+		logger.Warn("runner: run %s: cannot read retry policy (%v) — falling back to redelivery", msg.RunID, err)
+		return false, ""
+	}
+	pol := runRetryPolicy(runMeta)
+
+	at, source, ok := usageWindowRetryAt(execErr, pol, time.Now().UTC())
+	if !ok {
+		return false, ""
+	}
+
+	scheduled, attempt, err := retryStore.ScheduleRunRetry(ctx, msg.RunID, at, "usage_window", string(runtime.ErrCodeUsageLimitBlocked), pol.MaxAttempts)
+	if err != nil {
+		logger.Error("runner: run %s: could not persist the usage-window retry (%v) — falling back to redelivery so the run is not lost", msg.RunID, err)
+		return false, ""
+	}
+	if !scheduled {
+		// Either the attempt budget is spent or the run is no longer
+		// resumable (an operator got there first). Ack either way: a
+		// redelivery would re-hit the same wall, and say why in the run's
+		// own error field so it does not just go quiet.
+		reason := fmt.Sprintf("usage-window retries exhausted (max %d) — resume manually once the provider quota resets", pol.MaxAttempts)
+		if abandonErr := retryStore.AbandonRunRetry(ctx, msg.RunID, reason); abandonErr != nil {
+			logger.Warn("runner: run %s: could not record the exhausted retry budget: %v", msg.RunID, abandonErr)
+		}
+		logger.Warn("runner: run %s: %s", msg.RunID, reason)
+		ackTerminal(logger, delivery, "ack-usage-limit-exhausted", msg.RunID)
+		return true, "usage_limit_exhausted"
+	}
+
+	if emitErr := r.emitRetryScheduled(ctx, msg.RunID, at, attempt, pol, source); emitErr != nil {
+		// Observational only — the durable intent is already committed.
+		logger.Warn("runner: run %s: could not emit run_retry_scheduled: %v", msg.RunID, emitErr)
+	}
+	logger.Warn("runner: run %s hit the provider usage window — retry %d/%d armed for %s (reset source: %s), NOT redelivering",
+		msg.RunID, attempt, pol.MaxAttempts, at.Format(time.RFC3339), source)
+	ackTerminal(logger, delivery, "ack-usage-limit-retry", msg.RunID)
+	return true, "usage_limit_retry"
+}
+
+// emitRetryScheduled records the armed retry on the run's timeline so the
+// wait is visible rather than looking like a dead run.
+func (r *Runner) emitRetryScheduled(ctx context.Context, runID string, at time.Time, attempt int, pol retrypolicy.Policy, source string) error {
+	_, err := r.cfg.Store.AppendEvent(ctx, runID, store.Event{
+		Type: store.EventRunRetryScheduled,
+		Data: map[string]any{
+			"code":         string(runtime.ErrCodeUsageLimitBlocked),
+			"reason":       "usage_window",
+			"retry_after":  at.Format(time.RFC3339),
+			"attempt":      attempt,
+			"max_attempts": pol.MaxAttempts,
+			"reset_source": source,
+		},
+	})
+	return err
+}

--- a/pkg/runner/usage_retry_test.go
+++ b/pkg/runner/usage_retry_test.go
@@ -1,0 +1,247 @@
+package runner
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
+	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+var retryNow = time.Date(2026, 7, 27, 6, 0, 0, 0, time.UTC)
+
+// noJitter isolates the instant arithmetic from the spread. Jitter has its
+// own test; mixing them would force every expectation into a range.
+func noJitter(p retrypolicy.Policy) retrypolicy.Policy {
+	p.Jitter = "0s"
+	return retrypolicy.Normalize(p)
+}
+
+func weeklyWindowErr(resetAt time.Time) error {
+	return &delegate.ErrRateLimited{
+		Provider: delegate.BackendClaudeCode,
+		Detail:   "You've hit your weekly limit · resets Jul 28, 9pm (UTC)",
+		Kind:     delegate.RateLimitKindUsageWindow,
+		ResetAt:  resetAt,
+	}
+}
+
+func TestUsageWindowRetryAt(t *testing.T) {
+	reset := time.Date(2026, 7, 28, 21, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		err        error
+		pol        retrypolicy.Policy
+		wantOK     bool
+		wantAt     time.Time
+		wantSource string
+	}{
+		{
+			name:       "typed error carries the reset instant",
+			err:        weeklyWindowErr(reset),
+			pol:        noJitter(retrypolicy.Policy{}),
+			wantOK:     true,
+			wantAt:     reset.Add(time.Minute),
+			wantSource: "typed_error",
+		},
+		{
+			// What a real failure looks like once the engine has wrapped it:
+			// a RuntimeError carrying the typed cause.
+			name: "typed cause survives a RuntimeError wrapper",
+			err: &runtime.RuntimeError{
+				Code:    runtime.ErrCodeUsageLimitBlocked,
+				Message: `node "synthesize" execution failed`,
+				Cause:   weeklyWindowErr(reset),
+			},
+			pol:        noJitter(retrypolicy.Policy{}),
+			wantOK:     true,
+			wantAt:     reset.Add(time.Minute),
+			wantSource: "typed_error",
+		},
+		{
+			name:       "wrapped with %w still resolves",
+			err:        fmt.Errorf("branch failed: %w", weeklyWindowErr(reset)),
+			pol:        noJitter(retrypolicy.Policy{}),
+			wantOK:     true,
+			wantAt:     reset.Add(time.Minute),
+			wantSource: "typed_error",
+		},
+		{
+			// The classified-but-flattened case: no typed cause left, but the
+			// message still holds the notice. This is the fallback that keeps
+			// the feature working on a host whose error plumbing lost the type.
+			name: "code only, instant recovered from the message",
+			err: &runtime.RuntimeError{
+				Code:    runtime.ErrCodeUsageLimitBlocked,
+				Message: `node "synthesize" execution failed: rate_limited (claude_code): You've hit your weekly limit · resets Jul 28, 9pm (UTC)`,
+			},
+			pol:        noJitter(retrypolicy.Policy{}),
+			wantOK:     true,
+			wantAt:     reset,
+			wantSource: "runtime_code+parsed_text",
+		},
+		{
+			name: "usage window with no parseable instant still retries, bounded",
+			err: &runtime.RuntimeError{
+				Code:    runtime.ErrCodeUsageLimitBlocked,
+				Message: "quota exhausted, no further detail",
+			},
+			pol:        noJitter(retrypolicy.Policy{}),
+			wantOK:     true,
+			wantAt:     retryNow.Add(usageWindowBlindWait),
+			wantSource: "runtime_code+blind_wait",
+		},
+		{
+			// A reset already behind us (or a timezone the parser read as
+			// UTC) must not schedule a retry in the past.
+			name:       "past instant is floored",
+			err:        weeklyWindowErr(retryNow.Add(-3 * time.Hour)),
+			pol:        noJitter(retrypolicy.Policy{}),
+			wantOK:     true,
+			wantAt:     retryNow.Add(usageWindowFloor),
+			wantSource: "typed_error",
+		},
+		{
+			name:       "instant beyond max_wait is clamped",
+			err:        weeklyWindowErr(retryNow.Add(30 * 24 * time.Hour)),
+			pol:        noJitter(retrypolicy.Policy{MaxWait: "36h"}),
+			wantOK:     true,
+			wantAt:     retryNow.Add(36 * time.Hour),
+			wantSource: "typed_error",
+		},
+		{
+			name:   "a transient throttle is not a usage window",
+			err:    &delegate.ErrRateLimited{Kind: delegate.RateLimitKindTransient, Detail: "slow down"},
+			pol:    noJitter(retrypolicy.Policy{}),
+			wantOK: false,
+		},
+		{
+			name:   "an unrelated failure is not retried",
+			err:    &runtime.RuntimeError{Code: runtime.ErrCodeExecutionFailed, Message: "tool blew up"},
+			pol:    noJitter(retrypolicy.Policy{}),
+			wantOK: false,
+		},
+		{
+			name:   "no error",
+			err:    nil,
+			pol:    noJitter(retrypolicy.Policy{}),
+			wantOK: false,
+		},
+		{
+			// The opt-out has to be a real opt-out: policy off means the run
+			// falls back to today's redelivery behaviour untouched.
+			name:   "policy off disables the carve-out entirely",
+			err:    weeklyWindowErr(reset),
+			pol:    noJitter(retrypolicy.Policy{UsageWindow: retrypolicy.UsageWindowOff}),
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			at, source, ok := usageWindowRetryAt(tt.err, tt.pol, retryNow)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if !at.Equal(tt.wantAt) {
+				t.Errorf("at = %v, want %v", at, tt.wantAt)
+			}
+			if source != tt.wantSource {
+				t.Errorf("source = %q, want %q", source, tt.wantSource)
+			}
+		})
+	}
+}
+
+// TestUsageWindowRetryAt_JitterStaysInBand pins the spread: several runs
+// dying on one reset must not all come back at the same instant, and the
+// spread must stay inside the configured band.
+func TestUsageWindowRetryAt_JitterStaysInBand(t *testing.T) {
+	reset := retryNow.Add(30 * time.Hour)
+	pol := retrypolicy.Normalize(retrypolicy.Policy{Jitter: "10m"})
+	base := reset.Add(time.Minute)
+
+	seen := map[time.Time]bool{}
+	for i := 0; i < 200; i++ {
+		at, _, ok := usageWindowRetryAt(weeklyWindowErr(reset), pol, retryNow)
+		if !ok {
+			t.Fatal("ok = false")
+		}
+		if at.Before(base) || !at.Before(base.Add(10*time.Minute)) {
+			t.Fatalf("at = %v, want within [%v, %v)", at, base, base.Add(10*time.Minute))
+		}
+		seen[at] = true
+	}
+	if len(seen) < 2 {
+		t.Error("jitter produced a single instant across 200 draws — runs sharing a reset would stampede")
+	}
+}
+
+// TestUsageWindowRetryAt_JitterNeverPushesPastMaxWait pins the ordering of
+// the clamps: the spread is applied first, the ceiling last, so jitter can
+// never carry a retry beyond the operator's declared horizon.
+func TestUsageWindowRetryAt_JitterNeverPushesPastMaxWait(t *testing.T) {
+	pol := retrypolicy.Normalize(retrypolicy.Policy{MaxWait: "2h", Jitter: "30m"})
+	ceiling := retryNow.Add(2 * time.Hour)
+	for i := 0; i < 100; i++ {
+		at, _, ok := usageWindowRetryAt(weeklyWindowErr(retryNow.Add(90*time.Minute)), pol, retryNow)
+		if !ok {
+			t.Fatal("ok = false")
+		}
+		if at.After(ceiling) {
+			t.Fatalf("at = %v exceeds max_wait ceiling %v", at, ceiling)
+		}
+	}
+}
+
+// TestRunRetryPolicy_ReadsTheLaunchSnapshot pins that the runner takes the
+// policy resolved at launch and never re-derives it — it has no access to
+// schedules or manifests, by design.
+func TestRunRetryPolicy_ReadsTheLaunchSnapshot(t *testing.T) {
+	got := runRetryPolicy(&store.Run{RetryPolicy: &store.RunRetryPolicy{
+		UsageWindow: retrypolicy.UsageWindowResume,
+		MaxAttempts: 2,
+		MaxWait:     "36h",
+		Jitter:      "1m",
+	}})
+	if got.MaxAttempts != 2 || got.MaxWaitDuration() != 36*time.Hour || got.JitterDuration() != time.Minute {
+		t.Errorf("policy = %+v, want the snapshot's values", got)
+	}
+}
+
+func TestRunRetryPolicy_NilSnapshotFallsBackToDefaults(t *testing.T) {
+	// Runs launched before the snapshot existed, and surfaces that do not
+	// resolve a policy, must still retry rather than silently opt out.
+	got := runRetryPolicy(&store.Run{})
+	if !got.Enabled() {
+		t.Error("a run with no policy snapshot must still be retryable")
+	}
+	if got.MaxAttempts != retrypolicy.DefaultMaxAttempts {
+		t.Errorf("max_attempts = %d, want the default %d", got.MaxAttempts, retrypolicy.DefaultMaxAttempts)
+	}
+	if runRetryPolicy(nil).MaxAttempts != retrypolicy.DefaultMaxAttempts {
+		t.Error("a nil run must not panic and must yield the defaults")
+	}
+}
+
+// TestRunRetryPolicy_PlatformCeilingLowers pins that a tenant cannot exceed
+// the platform bound by declaring a bigger one on their own schedule.
+func TestRunRetryPolicy_PlatformCeilingLowers(t *testing.T) {
+	t.Setenv(retrypolicy.EnvCeilingMaxAttempts, "2")
+	t.Setenv(retrypolicy.EnvCeilingMaxWait, "6h")
+
+	got := runRetryPolicy(&store.Run{RetryPolicy: &store.RunRetryPolicy{MaxAttempts: 50, MaxWait: "720h"}})
+	if got.MaxAttempts != 2 {
+		t.Errorf("max_attempts = %d, want 2 (platform ceiling)", got.MaxAttempts)
+	}
+	if got.MaxWaitDuration() != 6*time.Hour {
+		t.Errorf("max_wait = %v, want 6h (platform ceiling)", got.MaxWaitDuration())
+	}
+}

--- a/pkg/runner/usage_retry_test.go
+++ b/pkg/runner/usage_retry_test.go
@@ -1,11 +1,15 @@
 package runner
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"io"
 	"testing"
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -245,3 +249,102 @@ func TestRunRetryPolicy_PlatformCeilingLowers(t *testing.T) {
 		t.Errorf("max_wait = %v, want 6h (platform ceiling)", got.MaxWaitDuration())
 	}
 }
+
+// --- the cancelled-context regression ---------------------------------
+//
+// processOne must stop the heartbeat before finalizing the delivery, and the
+// cancel that stops it is the run context's. So by the time the carve-out
+// runs, its ctx is ALREADY CANCELLED. The first version passed that ctx
+// straight to the store: every call failed instantly, the code logged a
+// warning and fell through, and no retry was ever armed in production —
+// while the pure-decision and sweeper tests stayed green. Found by review,
+// not by tests, which is exactly why this one exists.
+
+// cancelAwareStore fails every call when its context is cancelled, the way
+// a real Mongo client does.
+type cancelAwareStore struct {
+	store.RunStore
+	run     *store.Run
+	armed   bool
+	armedAt time.Time
+	calls   int
+}
+
+func (c *cancelAwareStore) LoadRun(ctx context.Context, _ string) (*store.Run, error) {
+	c.calls++
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return c.run, nil
+}
+
+func (c *cancelAwareStore) ScheduleRunRetry(ctx context.Context, _ string, at time.Time, _, _ string, _ int) (bool, int, error) {
+	if err := ctx.Err(); err != nil {
+		return false, 0, err
+	}
+	c.armed, c.armedAt = true, at
+	return true, 1, nil
+}
+
+func (c *cancelAwareStore) ClaimRunRetry(ctx context.Context, _ string, _ time.Time) (bool, error) {
+	return false, ctx.Err()
+}
+
+func (c *cancelAwareStore) ClearRunRetry(ctx context.Context, _ string) error { return ctx.Err() }
+
+func (c *cancelAwareStore) AbandonRunRetry(ctx context.Context, _, _ string) error { return ctx.Err() }
+
+func (c *cancelAwareStore) AppendEvent(ctx context.Context, _ string, _ store.Event) (*store.Event, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return &store.Event{}, nil
+}
+
+func TestArmUsageWindowRetry_SurvivesACancelledContext(t *testing.T) {
+	st := &cancelAwareStore{run: &store.Run{ID: "run-a", Status: store.RunStatusFailedResumable}}
+	r := &Runner{cfg: Config{Store: st}}
+
+	// Exactly what the call site hands over: a context already cancelled.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got := r.armUsageWindowRetry(ctx, weeklyWindowErr(time.Now().UTC().Add(30*time.Hour)), "run-a", iterlog.New(iterlog.LevelError, io.Discard))
+	if got != usageRetryArmed {
+		t.Fatalf("outcome = %v, want usageRetryArmed — a cancelled ctx must not disable the carve-out", got)
+	}
+	if !st.armed {
+		t.Fatal("no retry persisted: the store calls ran on the cancelled context")
+	}
+	if st.armedAt.IsZero() {
+		t.Error("retry armed with a zero instant")
+	}
+}
+
+// TestArmUsageWindowRetry_NotAUsageWindow pins that an unrelated failure
+// still falls through to the caller's nak/DLQ path.
+func TestArmUsageWindowRetry_NotAUsageWindow(t *testing.T) {
+	st := &cancelAwareStore{run: &store.Run{ID: "run-b", Status: store.RunStatusFailedResumable}}
+	r := &Runner{cfg: Config{Store: st}}
+
+	got := r.armUsageWindowRetry(context.Background(), errors.New("tool blew up"), "run-b", iterlog.New(iterlog.LevelError, io.Discard))
+	if got != usageRetryNotApplicable {
+		t.Errorf("outcome = %v, want usageRetryNotApplicable", got)
+	}
+	if st.armed {
+		t.Error("armed a retry for a failure that is not a usage window")
+	}
+}
+
+// TestArmUsageWindowRetry_NoRetryStoreFallsThrough pins the local-mode path:
+// a store with no durable retry surface must not swallow the delivery.
+func TestArmUsageWindowRetry_NoRetryStoreFallsThrough(t *testing.T) {
+	r := &Runner{cfg: Config{Store: plainStore{}}}
+	got := r.armUsageWindowRetry(context.Background(), weeklyWindowErr(time.Now().UTC().Add(time.Hour)), "run-c", iterlog.New(iterlog.LevelError, io.Discard))
+	if got != usageRetryNotApplicable {
+		t.Errorf("outcome = %v, want usageRetryNotApplicable", got)
+	}
+}
+
+// plainStore satisfies store.RunStore without store.RunRetryStore.
+type plainStore struct{ store.RunStore }

--- a/pkg/runtime/engine_exec.go
+++ b/pkg/runtime/engine_exec.go
@@ -387,14 +387,28 @@ func (e *Engine) execLoopRunNode(ctx context.Context, rs *runState, currentNodeI
 		// failure produces failed_resumable as before. The run-ID-
 		// enriched ctx is passed so Compact() can locate the per-
 		// node session.
-		retry, recoveryErr := e.handleNodeFailure(execCtx, rs, currentNodeID, execErr)
+		retry, code, recoveryErr := e.handleNodeFailure(execCtx, rs, currentNodeID, execErr)
 		if recoveryErr != nil {
 			return nil, false, recoveryErr
 		}
 		if retry {
 			return nil, true, nil
 		}
-		return nil, false, e.failRunWithCheckpoint(rs, currentNodeID, fmt.Sprintf("node %q execution failed: %v", currentNodeID, execErr))
+		// Fail terminally carrying BOTH the classified code and the
+		// original error as Cause: a host deciding how to recover needs
+		// the typed cause (e.g. *delegate.ErrRateLimited and its
+		// ResetAt), and flattening it into the message loses that for
+		// good. The Message text stays byte-identical — the DLQ reason,
+		// the run doc's error field and operator greps all key on it.
+		if code == "" {
+			code = ErrCodeExecutionFailed
+		}
+		return nil, false, e.failRunErrWithCheckpoint(rs, currentNodeID, &RuntimeError{
+			Code:    code,
+			NodeID:  currentNodeID,
+			Cause:   execErr,
+			Message: fmt.Sprintf("node %q execution failed: %v", currentNodeID, execErr),
+		})
 	}
 
 	// Reset per-node retry counters on success so a future failure

--- a/pkg/runtime/recovery/usage_limit_seam_test.go
+++ b/pkg/runtime/recovery/usage_limit_seam_test.go
@@ -1,0 +1,181 @@
+package recovery
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// This file guards the delegate → Classify → engine-failure SEAM, which no
+// other test crosses. Each half was covered in isolation and the join was
+// not, which is how the engine came to flatten every terminal failure into
+// an EXECUTION_FAILED string: `Classify` correctly returned
+// USAGE_LIMIT_BLOCKED, and the code plus the typed cause were both dropped
+// on the way out. That made the reset-aware wait in the run-level
+// auto-resume loop unreachable — it matches on the typed
+// *delegate.ErrRateLimited and on the runtime code, and saw neither.
+
+// usageWindowExecutor fails the target node with the supplied error, always.
+type usageWindowExecutor struct {
+	target  string
+	failErr error
+	calls   int
+}
+
+func (u *usageWindowExecutor) Execute(_ context.Context, node ir.Node, _ map[string]any) (map[string]any, error) {
+	if node.NodeID() != u.target {
+		return map[string]any{}, nil
+	}
+	u.calls++
+	return nil, u.failErr
+}
+
+func seamWorkflow() *ir.Workflow {
+	return &ir.Workflow{
+		Name:  "usage_limit_seam",
+		Entry: "synthesize",
+		Nodes: map[string]ir.Node{
+			"synthesize": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "synthesize"}},
+			"done":       &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{{From: "synthesize", To: "done"}},
+	}
+}
+
+func seamStore(t *testing.T) store.RunStore {
+	t.Helper()
+	s, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	return s
+}
+
+// weeklyLimitErr reproduces what the claude_code delegate returns when the
+// forfait weekly window is exhausted (the shape that killed seven scheduled
+// prod runs on 2026-07-27).
+func weeklyLimitErr(resetAt time.Time) error {
+	return &delegate.ErrRateLimited{
+		Provider: delegate.BackendClaudeCode,
+		Detail:   "You've hit your weekly limit · resets Jul 28, 9pm (UTC)",
+		Kind:     delegate.RateLimitKindUsageWindow,
+		ResetAt:  resetAt,
+	}
+}
+
+// TestUsageWindowFailure_PreservesCodeAndCause is the seam test: with a
+// dispatcher wired, a usage-window failure must reach the host carrying BOTH
+// the classified code and the typed cause (with its ResetAt intact), and the
+// run must be resumable.
+func TestUsageWindowFailure_PreservesCodeAndCause(t *testing.T) {
+	resetAt := time.Date(2026, 7, 28, 21, 0, 0, 0, time.UTC)
+	exec := &usageWindowExecutor{target: "synthesize", failErr: weeklyLimitErr(resetAt)}
+
+	s := seamStore(t)
+	eng := runtime.New(seamWorkflow(), s, exec,
+		runtime.WithRecoveryDispatch(Dispatch(DefaultRecipes())))
+
+	err := eng.Run(context.Background(), "run-usage-window", nil)
+	if err == nil {
+		t.Fatal("expected a terminal error from the exhausted usage window")
+	}
+
+	// A usage window cannot clear inside a node's retry budget, so the
+	// recipe must fail terminally on the first attempt rather than burn
+	// retries against the wall.
+	if exec.calls != 1 {
+		t.Errorf("executor calls = %d, want 1 (no in-node retry against a usage window)", exec.calls)
+	}
+
+	var rtErr *runtime.RuntimeError
+	if !errors.As(err, &rtErr) {
+		t.Fatalf("expected a *runtime.RuntimeError, got %T: %v", err, err)
+	}
+	if rtErr.Code != runtime.ErrCodeUsageLimitBlocked {
+		t.Errorf("code = %s, want %s", rtErr.Code, runtime.ErrCodeUsageLimitBlocked)
+	}
+
+	// The load-bearing assertion: the typed cause survives to the host, so
+	// a reset-aware retry can read ResetAt instead of guessing.
+	var rl *delegate.ErrRateLimited
+	if !errors.As(err, &rl) {
+		t.Fatalf("errors.As did not recover *delegate.ErrRateLimited from %v", err)
+	}
+	if !rl.ResetAt.Equal(resetAt) {
+		t.Errorf("ResetAt = %v, want %v", rl.ResetAt, resetAt)
+	}
+	if rl.Kind != delegate.RateLimitKindUsageWindow {
+		t.Errorf("Kind = %q, want %q", rl.Kind, delegate.RateLimitKindUsageWindow)
+	}
+
+	// The run must be resumable, and the emitted run_failed event must carry
+	// the real code — that event is what an operator and the studio read.
+	r, loadErr := s.LoadRun(context.Background(), "run-usage-window")
+	if loadErr != nil {
+		t.Fatalf("LoadRun: %v", loadErr)
+	}
+	if r.Status != store.RunStatusFailedResumable {
+		t.Errorf("status = %v, want %v", r.Status, store.RunStatusFailedResumable)
+	}
+	assertRunFailedCode(t, s, "run-usage-window", string(runtime.ErrCodeUsageLimitBlocked))
+
+	// The persisted message keeps the historical wording: the DLQ text, the
+	// run doc's error field and operator greps all key on it.
+	if want := `node "synthesize" execution failed:`; len(r.Error) < len(want) || r.Error[:len(want)] != want {
+		t.Errorf("run error = %q, want it to start with %q", r.Error, want)
+	}
+}
+
+// TestUsageWindowFailure_NoDispatcherKeepsExecutionFailed pins the other
+// half of the contract: a host that wires no dispatcher (as the cloud runner
+// did) classifies nothing, and the failure must stay EXECUTION_FAILED rather
+// than acquire a code out of thin air.
+func TestUsageWindowFailure_NoDispatcherKeepsExecutionFailed(t *testing.T) {
+	exec := &usageWindowExecutor{
+		target:  "synthesize",
+		failErr: weeklyLimitErr(time.Date(2026, 7, 28, 21, 0, 0, 0, time.UTC)),
+	}
+
+	s := seamStore(t)
+	eng := runtime.New(seamWorkflow(), s, exec) // no WithRecoveryDispatch
+
+	err := eng.Run(context.Background(), "run-no-dispatch", nil)
+	if err == nil {
+		t.Fatal("expected a terminal error")
+	}
+	var rtErr *runtime.RuntimeError
+	if !errors.As(err, &rtErr) {
+		t.Fatalf("expected a *runtime.RuntimeError, got %T: %v", err, err)
+	}
+	if rtErr.Code != runtime.ErrCodeExecutionFailed {
+		t.Errorf("code = %s, want %s", rtErr.Code, runtime.ErrCodeExecutionFailed)
+	}
+}
+
+// assertRunFailedCode asserts the run_failed event carries the given code.
+func assertRunFailedCode(t *testing.T, s store.RunStore, runID, wantCode string) {
+	t.Helper()
+	events, err := s.LoadEvents(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	for _, ev := range events {
+		if ev.Type != store.EventRunFailed {
+			continue
+		}
+		if got, _ := ev.Data["code"].(string); got != wantCode {
+			t.Errorf("run_failed code = %q, want %q", got, wantCode)
+		}
+		if resumable, _ := ev.Data["resumable"].(bool); !resumable {
+			t.Error("run_failed resumable = false, want true")
+		}
+		return
+	}
+	t.Fatal("no run_failed event found")
+}

--- a/pkg/runtime/recovery_dispatch.go
+++ b/pkg/runtime/recovery_dispatch.go
@@ -12,13 +12,20 @@ import (
 // handleNodeFailure consults the recovery dispatcher (when wired) and
 // applies the resulting RecoveryAction. Returns:
 //
-//   - (true, nil)   → caller should `continue` and re-execute the same node.
-//   - (false, nil)  → caller should fail terminally (failRunWithCheckpoint).
-//   - (false, err)  → terminal outcome already produced (ErrRunPaused for
+//   - (true, code, nil)   → caller should `continue` and re-execute the same node.
+//   - (false, code, nil)  → caller should fail terminally (failRunWithCheckpoint).
+//   - (false, code, err)  → terminal outcome already produced (ErrRunPaused for
 //     RecoveryPauseForHuman, or a context cancellation).
-func (e *Engine) handleNodeFailure(ctx context.Context, rs *runState, nodeID string, execErr error) (bool, error) {
+//
+// The classified code is returned so a terminal failure carries the REAL
+// cause (USAGE_LIMIT_BLOCKED, CONTEXT_LENGTH_EXCEEDED, …) instead of a
+// blanket EXECUTION_FAILED. Hosts branch on it — a provider usage window
+// needs a reset-aware wait, a transient blip an immediate retry — and they
+// cannot tell those apart from a flattened string. An empty code means no
+// dispatcher was wired, so nothing classified the failure.
+func (e *Engine) handleNodeFailure(ctx context.Context, rs *runState, nodeID string, execErr error) (bool, ErrorCode, error) {
 	if e.recoveryDispatch == nil {
-		return false, nil
+		return false, "", nil
 	}
 
 	if rs.nodeAttempts == nil {
@@ -71,20 +78,20 @@ func (e *Engine) handleNodeFailure(ctx context.Context, rs *runState, nodeID str
 			case <-timer.C:
 			case <-ctx.Done():
 				timer.Stop()
-				return false, e.handleContextDoneWithCheckpoint(rs, nodeID, ctx.Err())
+				return false, code, e.handleContextDoneWithCheckpoint(rs, nodeID, ctx.Err())
 			}
 		}
-		return true, nil
+		return true, code, nil
 
 	case RecoveryPauseForHuman:
 		reason := action.Reason
 		if reason == "" {
 			reason = fmt.Sprintf("recovery: %s", code)
 		}
-		return false, e.pauseForRecovery(rs, nodeID, code, reason, execErr)
+		return false, code, e.pauseForRecovery(rs, nodeID, code, reason, execErr)
 	}
 
-	return false, nil
+	return false, code, nil
 }
 
 // tryCompact invokes the optional Compactor on the executor and

--- a/pkg/runview/service.go
+++ b/pkg/runview/service.go
@@ -303,6 +303,14 @@ type RunSummary struct {
 	// belongs to another process or to a previous boot — Cancel won't
 	// reach it from here.
 	Active bool `json:"active"`
+	// RetryAfter is when a failed_resumable run will be resumed
+	// automatically, once its provider quota window reopens. Nil means no
+	// retry is armed — which is the whole point of surfacing it: a row
+	// that will resume in 33h and a row that never will are otherwise
+	// indistinguishable, both just "failed_resumable". RetryAttempts is
+	// the run's position in its attempt budget.
+	RetryAfter    *time.Time `json:"retry_after,omitempty"`
+	RetryAttempts int        `json:"retry_attempts,omitempty"`
 	// Worktree finalization summary (only populated for `worktree:
 	// auto` runs that reached a clean exit). See store.Run for the
 	// full semantics.

--- a/pkg/runview/service.go
+++ b/pkg/runview/service.go
@@ -92,6 +92,13 @@ type LaunchSpec struct {
 	// / "auto" resolves from detected provider credentials at launch;
 	// "mono"/"dual" force it. See pkg/reviewtopology.
 	ReviewMode string
+	// RetryPolicy is the retry contract already RESOLVED across its layers
+	// by the launch site (per-run override → launching surface → bot
+	// manifest → machine default, clamped by the platform ceiling). It is
+	// snapshotted verbatim onto the run document so the runner can read it
+	// without knowing schedules or manifests exist. Nil = the consumer
+	// applies pkg/retrypolicy's defaults.
+	RetryPolicy *store.RunRetryPolicy
 	// ModelOverrides are launch-time per-node/-group backend+model overrides
 	// (studio Launch dropdowns). Each entry targets nodes by selector (node id,
 	// id glob, or kind keyword agent|judge) and wins over the node's DSL

--- a/pkg/runview/service_runs.go
+++ b/pkg/runview/service_runs.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/runview/runstream"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -214,7 +215,26 @@ func summarizeRun(r *store.Run, active bool) RunSummary {
 		ShardIndex:        r.ShardIndex,
 		ShardCount:        r.ShardCount,
 		ShardLabel:        r.ShardLabel,
+		RetryAfter:        retryAfterOf(r),
+		RetryAttempts:     retryAttemptsOf(r),
 	}
+}
+
+// retryAfterOf / retryAttemptsOf project the run's retry bookkeeping,
+// tolerating every "not armed" shape (no state, no instant) so a caller
+// never has to nil-walk two levels.
+func retryAfterOf(r *store.Run) *time.Time {
+	if r == nil || r.RetryState == nil {
+		return nil
+	}
+	return r.RetryState.RetryAfter
+}
+
+func retryAttemptsOf(r *store.Run) int {
+	if r == nil || r.RetryState == nil {
+		return 0
+	}
+	return r.RetryState.Attempts
 }
 
 // BuildChildrenFromStore returns the shard/child subtree of a run read

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -561,6 +561,15 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 		src := *spec.SourceRef // copy: never share the caller's pointer
 		r.Source = &src
 	}
+	// Same "the queued doc is the only carrier" reasoning as Source above:
+	// the RunMessage has no retry field, and the launch site is the only
+	// place that could see every layer of the policy. A value lost here
+	// leaves the runner falling back to defaults for a run whose owner
+	// asked for something else.
+	if spec.RetryPolicy != nil {
+		rp := *spec.RetryPolicy // copy: never share the caller's pointer
+		r.RetryPolicy = &rp
+	}
 	// 1b. Resolve BYOK credentials and seal them under a fresh
 	//     secrets_ref. Empty ref means "no team-scoped credentials
 	//     configured" — the runner falls back to env. This runs BEFORE the

--- a/pkg/server/resume_source.go
+++ b/pkg/server/resume_source.go
@@ -1,0 +1,31 @@
+package server
+
+import "fmt"
+
+// resolveResumeSource turns a run's persisted file path (plus any inline
+// source the caller already has) into the (absolute path, source) pair
+// runview.ResumeSpec needs.
+//
+// Shared by the operator-initiated resume handler and the retry sweeper so
+// the cloud-mode rule lives in one place: a server pod has no operator
+// filesystem, so a resume must carry inline source UNLESS the path names a
+// catalog bundle baked into the image, which the pod can read itself.
+// Duplicating that rule is how the automated path would quietly diverge
+// from the manual one.
+func (s *Server) resolveResumeSource(filePath, source string) (string, string, error) {
+	if filePath == "" && source == "" {
+		return "", "", fmt.Errorf("file_path or source is required (run has no persisted FilePath)")
+	}
+	if s.cfg.Mode == "cloud" && source == "" {
+		if src, _, _, ok := s.catalogBotSource("", filePath); ok {
+			source = src
+		} else {
+			return "", "", fmt.Errorf("cloud mode: source or a catalog bot is required (file_path is not portable across the server pod's filesystem)")
+		}
+	}
+	absPath, err := s.resolveWorkflowPath(filePath, source)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid file_path: %w", err)
+	}
+	return absPath, source, nil
+}

--- a/pkg/server/retry_resolve.go
+++ b/pkg/server/retry_resolve.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// Launch-time resolution of a run's retry policy.
+//
+// The chain cannot be resolved anywhere else. A bot cannot probe the
+// schedule that launched it; a schedule row does not know the bot's
+// manifest; the runner sees neither and must not have to. Only the launch
+// site sees every layer at once — the same reason the review topology is
+// resolved out of band here rather than in the DSL.
+//
+// So it is resolved once, at launch, and snapshotted on the run document.
+// The runner then reads the doc it already loads: no queue-schema bump, no
+// lookups from the pod, and a permanent record of what the run was promised
+// even if the schedule is edited or deleted afterwards.
+
+// resolveRunRetryPolicy resolves the effective retry policy for a launch and
+// returns the snapshot to persist on the run.
+//
+// `higher` carries the layers the CALLER knows about, highest priority
+// first — typically a per-run override and/or the launching surface's own
+// policy (a schedule row, a trigger subscription). The bot manifest, the
+// machine default and the platform ceiling are appended here so no launch
+// site has to remember them, and so a site that passes nothing still gets a
+// correct policy rather than an empty one.
+func (s *Server) resolveRunRetryPolicy(botID string, higher ...retrypolicy.Layer) *store.RunRetryPolicy {
+	layers := make([]retrypolicy.Layer, 0, len(higher)+2)
+	layers = append(layers, higher...)
+	if m := s.botManifest(botID); m != nil {
+		layers = append(layers, retrypolicy.Layer{Source: retrypolicy.SourceBot, Policy: m.RetryPolicy()})
+	}
+	layers = append(layers, retrypolicy.Layer{Source: retrypolicy.SourceEnv, Policy: retrypolicy.FromEnv()})
+
+	pol, sources := retrypolicy.Resolve(layers...)
+	pol = retrypolicy.Clamp(pol, retrypolicy.CeilingFromEnv(), sources)
+
+	return &store.RunRetryPolicy{
+		UsageWindow: pol.UsageWindow,
+		MaxAttempts: pol.MaxAttempts,
+		MaxWait:     pol.MaxWait,
+		Jitter:      pol.Jitter,
+		Sources:     sources,
+	}
+}

--- a/pkg/server/retry_sweeper.go
+++ b/pkg/server/retry_sweeper.go
@@ -80,6 +80,12 @@ func (s *Server) sweepDueRetries(ctx context.Context, lister retryDueLister, res
 		s.warnf("retry sweeper: scan: %v", err)
 		return
 	}
+	if s.cfg.Metrics != nil {
+		// Sampled, not authoritative: the batch cap bounds what one pass
+		// sees. A gauge that sits at the cap is itself the signal that
+		// retries are arriving faster than they are being resumed.
+		s.cfg.Metrics.RunsRetryPending.Set(float64(len(refs)))
+	}
 	for _, ref := range refs {
 		s.resumeDueRetry(ctx, retryStore, resumer, ref)
 	}
@@ -135,6 +141,7 @@ func (s *Server) resumeDueRetry(ctx context.Context, retryStore store.RunRetrySt
 		return
 	}
 
+	s.countRetry("enqueued")
 	s.auditRetry(ref, "run.retry.enqueued", map[string]any{
 		"attempt": retryAttempts(ref),
 		"reason":  retryReason(ref),
@@ -148,6 +155,7 @@ func (s *Server) abandonRetry(ctx context.Context, retryStore store.RunRetryStor
 	if err := retryStore.AbandonRunRetry(ctx, runID, reason); err != nil {
 		s.warnf("retry sweeper: abandon %s: %v", runID, err)
 	}
+	s.countRetry("abandoned")
 	s.auditSystem(tenantID, "retry-sweeper", "run.retry.abandoned", "run", runID, map[string]any{"reason": reason})
 	s.warnf("retry sweeper: run %s: %s", runID, reason)
 }
@@ -166,6 +174,7 @@ func (s *Server) reArmRetry(ctx context.Context, retryStore store.RunRetryStore,
 		s.abandonRetry(ctx, retryStore, ref.TenantID, ref.ID, fmt.Sprintf("auto-retry gave up after a failed resume: %v", cause))
 		return
 	}
+	s.countRetry("failed")
 	s.auditRetry(ref, "run.retry.failed", map[string]any{"error": cause.Error()})
 	s.warnf("retry sweeper: run %s: resume failed (%v) — retrying at %s", ref.ID, cause, at.Format(time.RFC3339))
 }
@@ -213,6 +222,14 @@ func retryLaunchCtx(ctx context.Context, ref mongostore.RetryDueRef) context.Con
 // run id, so "what happened to my Monday digest" is one query.
 func (s *Server) auditRetry(ref mongostore.RetryDueRef, action string, meta map[string]any) {
 	s.auditSystem(ref.TenantID, "retry-sweeper", action, "run", ref.ID, meta)
+}
+
+// countRetry records a sweeper outcome. Nil-safe: local mode has no
+// metrics registry.
+func (s *Server) countRetry(result string) {
+	if s.cfg.Metrics != nil {
+		s.cfg.Metrics.RunsRetryResumed.WithLabelValues(result).Inc()
+	}
 }
 
 func (s *Server) warnf(format string, args ...any) {

--- a/pkg/server/retry_sweeper.go
+++ b/pkg/server/retry_sweeper.go
@@ -108,11 +108,17 @@ func (s *Server) resumeDueRetry(ctx context.Context, retryStore store.RunRetrySt
 	}
 
 	// An automatic resume spends real money, so it passes the same
-	// admission gate as the operator-initiated one. A denial is permanent
-	// for this window (a quota is not going to un-exceed itself within the
-	// wait), so abandon with the reason rather than re-arming into a loop.
+	// admission gate as the operator-initiated one. Whether a denial ends
+	// the retry depends on the denial: a monthly quota refills on the 1st
+	// and a concurrency/rate cap clears in minutes, so abandoning on those
+	// would throw the run away for a condition that resolves itself. A
+	// suspended org or a missing workspace needs a human.
 	adm, deny := s.gateLaunch(retryLaunchCtx(runCtx, ref))
 	if deny != nil {
+		if retryDenialIsTransient(deny.reason) {
+			s.reArmRetry(runCtx, retryStore, ref, fmt.Errorf("admission deferred: %s", deny.reason))
+			return
+		}
 		s.abandonRetry(runCtx, retryStore, ref.TenantID, ref.ID, fmt.Sprintf("auto-retry abandoned: %s", deny.reason))
 		return
 	}
@@ -141,6 +147,13 @@ func (s *Server) resumeDueRetry(ctx context.Context, retryStore store.RunRetrySt
 		return
 	}
 
+	// The claim was a lease, not a disarm (so a pod death before this point
+	// leaves the retry re-claimable). Now that the resume is enqueued, clear
+	// it — otherwise a past retry_after would survive and re-fire the moment
+	// this run failed again for an unrelated reason.
+	if err := retryStore.ClearRunRetry(runCtx, ref.ID); err != nil {
+		s.warnf("retry sweeper: clear %s: %v", ref.ID, err)
+	}
 	s.countRetry("enqueued")
 	s.auditRetry(ref, "run.retry.enqueued", map[string]any{
 		"attempt": retryAttempts(ref),
@@ -148,6 +161,19 @@ func (s *Server) resumeDueRetry(ctx context.Context, retryStore store.RunRetrySt
 	})
 	s.infof("retry sweeper: run %s (tenant %s) resumed after its provider quota window reopened (attempt %d)",
 		ref.ID, ref.TenantID, retryAttempts(ref))
+}
+
+// retryDenialIsTransient reports whether an admission denial is expected to
+// clear on its own, so the retry should be deferred rather than dropped.
+// Unknown reasons are treated as PERMANENT: a new denial code that silently
+// re-armed forever would be worse than one that stops and says why.
+func retryDenialIsTransient(reason string) bool {
+	switch reason {
+	case denyMonthlyRunQuota, denyMonthlyCostCap, denyConcurrencyCap, denyLaunchRateLimited:
+		return true
+	default:
+		return false
+	}
 }
 
 // abandonRetry records a permanent stop and audits it.

--- a/pkg/server/retry_sweeper.go
+++ b/pkg/server/retry_sweeper.go
@@ -1,0 +1,220 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+	mongostore "github.com/SocialGouv/iterion/pkg/store/mongo"
+)
+
+// Retry sweeper: the half of the usage-window retry that outlives the pod.
+//
+// The runner acks a quota-blocked run and persists WHEN to come back; nothing
+// in the pod can hold a multi-day timer, and the work queue cannot either (a
+// 24h max age, no delayed nak, against a weekly reset up to seven days out).
+// So the wait lives in Mongo and this sweeper is what acts on it — the same
+// shape as the orphan sweeper next door, and for the same reason: some run
+// state can only be reconciled by something that keeps running.
+
+const (
+	// retrySweepInterval matches the orphan sweeper's cadence. A minute of
+	// latency on a wait measured in hours is free, and the scan is a single
+	// indexed query.
+	retrySweepInterval = 60 * time.Second
+	// retrySweepBatch bounds one pass. Several schedules routinely die on
+	// one reset, and resuming all of them in the same second is how you
+	// exhaust the freshly-reopened window immediately — the jitter at arm
+	// time spreads them, and this caps the worst case regardless.
+	retrySweepBatch = 5
+	// retryReenqueueBackoff re-arms a retry whose resume failed for a
+	// reason that may not be permanent (a transient publish error).
+	retryReenqueueBackoff = 15 * time.Minute
+)
+
+// retryDueLister is the store capability the sweeper scans with
+// (implemented by the Mongo store; local mode has no durable retry state
+// and no sweeper).
+type retryDueLister interface {
+	ListRunsDueForRetry(ctx context.Context, before time.Time, limit int) ([]mongostore.RetryDueRef, error)
+}
+
+// runRetrySweeper ticks sweepDueRetries until ctx is cancelled. Started by
+// ListenAndServe in cloud mode when the store carries retry state.
+func (s *Server) runRetrySweeper(ctx context.Context, lister retryDueLister) {
+	t := time.NewTicker(retrySweepInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.sweepDueRetries(ctx, lister, time.Now().UTC())
+		}
+	}
+}
+
+// sweepDueRetries performs one pass. Extracted (with an injectable clock)
+// for tests.
+func (s *Server) sweepDueRetries(ctx context.Context, lister retryDueLister, now time.Time) {
+	retryStore := store.AsRunRetryStore(s.cfg.Store)
+	if retryStore == nil || s.runs == nil {
+		return
+	}
+	// Platform-level scan; the per-run tenant comes back on each ref and is
+	// re-stamped before every write below.
+	refs, err := lister.ListRunsDueForRetry(store.WithoutTenantFilter(ctx), now, retrySweepBatch)
+	if err != nil {
+		s.warnf("retry sweeper: scan: %v", err)
+		return
+	}
+	for _, ref := range refs {
+		s.resumeDueRetry(ctx, retryStore, ref)
+	}
+}
+
+// resumeDueRetry claims one due retry and re-enqueues the run's resume.
+func (s *Server) resumeDueRetry(ctx context.Context, retryStore store.RunRetryStore, ref mongostore.RetryDueRef) {
+	runCtx := store.WithIdentity(ctx, ref.TenantID, "retry-sweeper")
+
+	// Claim first, act second. The CAS is what makes this safe to run on
+	// every replica: the loser simply moves on, and an operator who resumed
+	// the run in the meantime has already invalidated the claim.
+	won, err := retryStore.ClaimRunRetry(runCtx, ref.ID, ref.RetryAfter())
+	if err != nil {
+		s.warnf("retry sweeper: claim %s: %v", ref.ID, err)
+		return
+	}
+	if !won {
+		return
+	}
+
+	// An automatic resume spends real money, so it passes the same
+	// admission gate as the operator-initiated one. A denial is permanent
+	// for this window (a quota is not going to un-exceed itself within the
+	// wait), so abandon with the reason rather than re-arming into a loop.
+	adm, deny := s.gateLaunch(retryLaunchCtx(runCtx, ref))
+	if deny != nil {
+		s.abandonRetry(runCtx, retryStore, ref.TenantID, ref.ID, fmt.Sprintf("auto-retry abandoned: %s", deny.reason))
+		return
+	}
+
+	filePath, source, err := s.resolveResumeSource(ref.FilePath, "")
+	if err != nil {
+		// A bot removed from the catalog will never resolve; re-arming
+		// would just re-fail every 15 minutes forever.
+		adm.rollback(s.logger)
+		s.abandonRetry(runCtx, retryStore, ref.TenantID, ref.ID, fmt.Sprintf("auto-retry abandoned: %v", err))
+		return
+	}
+
+	if _, err := s.runs.Resume(runCtx, runview.ResumeSpec{
+		RunID:    ref.ID,
+		FilePath: filePath,
+		Source:   source,
+	}); err != nil {
+		// Could be transient (a publish blip) or permanent (the bot was
+		// redeployed and the workflow hash moved). We do NOT pass Force:
+		// resuming a checkpoint against a workflow that changed underneath
+		// is how a run silently does the wrong thing. Re-arm within the
+		// attempt budget and surface the error verbatim.
+		adm.rollback(s.logger)
+		s.reArmRetry(runCtx, retryStore, ref, err)
+		return
+	}
+
+	s.auditRetry(ref, "run.retry.enqueued", map[string]any{
+		"attempt": retryAttempts(ref),
+		"reason":  retryReason(ref),
+	})
+	s.infof("retry sweeper: run %s (tenant %s) resumed after its provider quota window reopened (attempt %d)",
+		ref.ID, ref.TenantID, retryAttempts(ref))
+}
+
+// abandonRetry records a permanent stop and audits it.
+func (s *Server) abandonRetry(ctx context.Context, retryStore store.RunRetryStore, tenantID, runID, reason string) {
+	if err := retryStore.AbandonRunRetry(ctx, runID, reason); err != nil {
+		s.warnf("retry sweeper: abandon %s: %v", runID, err)
+	}
+	s.auditSystem(tenantID, "retry-sweeper", "run.retry.abandoned", "run", runID, map[string]any{"reason": reason})
+	s.warnf("retry sweeper: run %s: %s", runID, reason)
+}
+
+// reArmRetry gives a failed resume another chance inside the attempt
+// budget. ScheduleRunRetry's own budget check is what stops this looping.
+func (s *Server) reArmRetry(ctx context.Context, retryStore store.RunRetryStore, ref mongostore.RetryDueRef, cause error) {
+	maxAttempts := s.retryMaxAttempts(ctx, ref.ID)
+	at := time.Now().UTC().Add(retryReenqueueBackoff)
+	scheduled, _, err := retryStore.ScheduleRunRetry(ctx, ref.ID, at, retryReason(ref), retryCode(ref), maxAttempts)
+	if err != nil {
+		s.warnf("retry sweeper: re-arm %s: %v", ref.ID, err)
+		return
+	}
+	if !scheduled {
+		s.abandonRetry(ctx, retryStore, ref.TenantID, ref.ID, fmt.Sprintf("auto-retry gave up after a failed resume: %v", cause))
+		return
+	}
+	s.auditRetry(ref, "run.retry.failed", map[string]any{"error": cause.Error()})
+	s.warnf("retry sweeper: run %s: resume failed (%v) — retrying at %s", ref.ID, cause, at.Format(time.RFC3339))
+}
+
+// retryMaxAttempts reads the run's launch-time attempt budget. Falls back
+// to the package default when the run predates the snapshot, so a re-arm is
+// still bounded.
+func (s *Server) retryMaxAttempts(ctx context.Context, runID string) int {
+	r, err := s.cfg.Store.LoadRun(ctx, runID)
+	if err != nil || r == nil || r.RetryPolicy == nil || r.RetryPolicy.MaxAttempts <= 0 {
+		return retrypolicy.DefaultMaxAttempts
+	}
+	return r.RetryPolicy.MaxAttempts
+}
+
+func retryAttempts(ref mongostore.RetryDueRef) int {
+	if ref.RetryState == nil {
+		return 0
+	}
+	return ref.RetryState.Attempts
+}
+
+func retryReason(ref mongostore.RetryDueRef) string {
+	if ref.RetryState == nil || ref.RetryState.Reason == "" {
+		return "usage_window"
+	}
+	return ref.RetryState.Reason
+}
+
+func retryCode(ref mongostore.RetryDueRef) string {
+	if ref.RetryState == nil {
+		return ""
+	}
+	return ref.RetryState.Code
+}
+
+// retryLaunchCtx stamps the synthetic identity the admission gate reads.
+// The run's own tenant and owner are used so the retry is metered against
+// the same org as the original launch, not against the platform.
+func retryLaunchCtx(ctx context.Context, ref mongostore.RetryDueRef) context.Context {
+	return auth.WithIdentity(ctx, auth.Identity{TeamID: ref.TenantID, UserID: ref.OwnerID})
+}
+
+// auditRetry records a sweeper decision on the team's audit trail, keyed by
+// run id, so "what happened to my Monday digest" is one query.
+func (s *Server) auditRetry(ref mongostore.RetryDueRef, action string, meta map[string]any) {
+	s.auditSystem(ref.TenantID, "retry-sweeper", action, "run", ref.ID, meta)
+}
+
+func (s *Server) warnf(format string, args ...any) {
+	if s.logger != nil {
+		s.logger.Warn(format, args...)
+	}
+}
+
+func (s *Server) infof(format string, args ...any) {
+	if s.logger != nil {
+		s.logger.Info(format, args...)
+	}
+}

--- a/pkg/server/retry_sweeper.go
+++ b/pkg/server/retry_sweeper.go
@@ -36,6 +36,14 @@ const (
 	retryReenqueueBackoff = 15 * time.Minute
 )
 
+// runResumer is the slice of runview.Service the sweeper uses. Narrowed to
+// one method so the sweeper's failure branches (lost claim, denied
+// admission, unresolvable source, failed publish) are testable without
+// standing up a run service.
+type runResumer interface {
+	Resume(ctx context.Context, spec runview.ResumeSpec) (*runview.LaunchResult, error)
+}
+
 // retryDueLister is the store capability the sweeper scans with
 // (implemented by the Mongo store; local mode has no durable retry state
 // and no sweeper).
@@ -53,16 +61,16 @@ func (s *Server) runRetrySweeper(ctx context.Context, lister retryDueLister) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			s.sweepDueRetries(ctx, lister, time.Now().UTC())
+			s.sweepDueRetries(ctx, lister, s.runs, time.Now().UTC())
 		}
 	}
 }
 
 // sweepDueRetries performs one pass. Extracted (with an injectable clock)
 // for tests.
-func (s *Server) sweepDueRetries(ctx context.Context, lister retryDueLister, now time.Time) {
+func (s *Server) sweepDueRetries(ctx context.Context, lister retryDueLister, resumer runResumer, now time.Time) {
 	retryStore := store.AsRunRetryStore(s.cfg.Store)
-	if retryStore == nil || s.runs == nil {
+	if retryStore == nil || resumer == nil {
 		return
 	}
 	// Platform-level scan; the per-run tenant comes back on each ref and is
@@ -73,12 +81,12 @@ func (s *Server) sweepDueRetries(ctx context.Context, lister retryDueLister, now
 		return
 	}
 	for _, ref := range refs {
-		s.resumeDueRetry(ctx, retryStore, ref)
+		s.resumeDueRetry(ctx, retryStore, resumer, ref)
 	}
 }
 
 // resumeDueRetry claims one due retry and re-enqueues the run's resume.
-func (s *Server) resumeDueRetry(ctx context.Context, retryStore store.RunRetryStore, ref mongostore.RetryDueRef) {
+func (s *Server) resumeDueRetry(ctx context.Context, retryStore store.RunRetryStore, resumer runResumer, ref mongostore.RetryDueRef) {
 	runCtx := store.WithIdentity(ctx, ref.TenantID, "retry-sweeper")
 
 	// Claim first, act second. The CAS is what makes this safe to run on
@@ -112,7 +120,7 @@ func (s *Server) resumeDueRetry(ctx context.Context, retryStore store.RunRetrySt
 		return
 	}
 
-	if _, err := s.runs.Resume(runCtx, runview.ResumeSpec{
+	if _, err := resumer.Resume(runCtx, runview.ResumeSpec{
 		RunID:    ref.ID,
 		FilePath: filePath,
 		Source:   source,

--- a/pkg/server/retry_sweeper_test.go
+++ b/pkg/server/retry_sweeper_test.go
@@ -1,0 +1,288 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+	mongostore "github.com/SocialGouv/iterion/pkg/store/mongo"
+)
+
+// The sweeper is the half of the retry that can lose a run: it claims,
+// gates, resolves and re-enqueues, and every one of those can fail. What
+// these tests pin is that each failure lands somewhere legible — resumed,
+// re-armed with a reason, or abandoned with a reason — and never silently.
+
+type fakeRetryLister struct{ refs []mongostore.RetryDueRef }
+
+func (f *fakeRetryLister) ListRunsDueForRetry(_ context.Context, _ time.Time, limit int) ([]mongostore.RetryDueRef, error) {
+	if limit > 0 && len(f.refs) > limit {
+		return f.refs[:limit], nil
+	}
+	return f.refs, nil
+}
+
+// fakeRetryStore records the sweeper's decisions. Embedding store.RunStore
+// leaves every unused method nil — a call to one panics loudly rather than
+// passing silently, which is what we want from a fake.
+type fakeRetryStore struct {
+	store.RunStore
+	mu sync.Mutex
+
+	claimWins map[string]bool // run id -> does the claim win
+	loadRun   map[string]*store.Run
+
+	claimed   []string
+	abandoned map[string]string
+	rearmed   map[string]time.Time
+	armBudget map[string]int // run id -> max attempts seen by ScheduleRunRetry
+	armOK     bool
+}
+
+func newFakeRetryStore() *fakeRetryStore {
+	return &fakeRetryStore{
+		claimWins: map[string]bool{},
+		loadRun:   map[string]*store.Run{},
+		abandoned: map[string]string{},
+		rearmed:   map[string]time.Time{},
+		armBudget: map[string]int{},
+		armOK:     true,
+	}
+}
+
+func (f *fakeRetryStore) ClaimRunRetry(ctx context.Context, runID string, _ time.Time) (bool, error) {
+	// The sweeper must stamp the run's tenant before any write — the mongo
+	// store panics otherwise, so assert it here rather than discover it in
+	// production.
+	if tenant, ok := store.TenantFromContext(ctx); !ok || tenant == "" {
+		panic("retry sweeper: claim without tenant ctx")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if !f.claimWins[runID] {
+		return false, nil
+	}
+	f.claimed = append(f.claimed, runID)
+	return true, nil
+}
+
+func (f *fakeRetryStore) ScheduleRunRetry(_ context.Context, runID string, at time.Time, _, _ string, maxAttempts int) (bool, int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.armBudget[runID] = maxAttempts
+	if !f.armOK {
+		return false, 0, nil
+	}
+	f.rearmed[runID] = at
+	return true, 2, nil
+}
+
+func (f *fakeRetryStore) AbandonRunRetry(_ context.Context, runID, reason string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.abandoned[runID] = reason
+	return nil
+}
+
+func (f *fakeRetryStore) LoadRun(_ context.Context, id string) (*store.Run, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if r, ok := f.loadRun[id]; ok {
+		return r, nil
+	}
+	return &store.Run{ID: id}, nil
+}
+
+// fakeResumer captures what the sweeper asked runview to resume.
+type fakeResumer struct {
+	mu      sync.Mutex
+	calls   []runview.ResumeSpec
+	failing error
+}
+
+func (f *fakeResumer) Resume(_ context.Context, spec runview.ResumeSpec) (*runview.LaunchResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, spec)
+	if f.failing != nil {
+		return nil, f.failing
+	}
+	return &runview.LaunchResult{RunID: spec.RunID}, nil
+}
+
+func dueRef(id string, at time.Time) mongostore.RetryDueRef {
+	return mongostore.RetryDueRef{
+		ID:       id,
+		TenantID: "team-1",
+		OwnerID:  "user-1",
+		FilePath: "bots/feed-watch/main.bot",
+		RetryState: &store.RunRetryState{
+			RetryAfter: &at,
+			Reason:     "usage_window",
+			Code:       "USAGE_LIMIT_BLOCKED",
+			Attempts:   1,
+		},
+	}
+}
+
+func TestSweepDueRetries_ResumesAClaimedRun(t *testing.T) {
+	st := newFakeRetryStore()
+	st.claimWins["run-a"] = true
+	resumer := &fakeResumer{}
+	s := newRetrySweeperServer(t, st, resumer)
+
+	at := time.Now().UTC().Add(-time.Minute)
+	s.sweepDueRetries(context.Background(), &fakeRetryLister{refs: []mongostore.RetryDueRef{dueRef("run-a", at)}}, resumer, time.Now().UTC())
+
+	if len(resumer.calls) != 1 {
+		t.Fatalf("Resume called %d times, want 1", len(resumer.calls))
+	}
+	if got := resumer.calls[0].RunID; got != "run-a" {
+		t.Errorf("resumed %q, want run-a", got)
+	}
+	// A multi-day wait can outlive a bot redeploy; forcing past the hash
+	// check would resume a checkpoint against a workflow that moved.
+	if resumer.calls[0].Force {
+		t.Error("Force = true — an automatic resume must never skip the workflow-hash check")
+	}
+	if len(st.abandoned) != 0 {
+		t.Errorf("unexpected abandon: %v", st.abandoned)
+	}
+}
+
+func TestSweepDueRetries_LostClaimDoesNotResume(t *testing.T) {
+	st := newFakeRetryStore() // claimWins empty → every claim loses
+	resumer := &fakeResumer{}
+	s := newRetrySweeperServer(t, st, resumer)
+
+	at := time.Now().UTC().Add(-time.Minute)
+	s.sweepDueRetries(context.Background(), &fakeRetryLister{refs: []mongostore.RetryDueRef{dueRef("run-a", at)}}, resumer, time.Now().UTC())
+
+	if len(resumer.calls) != 0 {
+		t.Fatalf("Resume called %d times after losing the claim, want 0 — two replicas would double-resume", len(resumer.calls))
+	}
+}
+
+func TestSweepDueRetries_FailedResumeReArmsWithinBudget(t *testing.T) {
+	st := newFakeRetryStore()
+	st.claimWins["run-a"] = true
+	st.loadRun["run-a"] = &store.Run{ID: "run-a", RetryPolicy: &store.RunRetryPolicy{MaxAttempts: 4}}
+	resumer := &fakeResumer{failing: errors.New("publish blip")}
+	s := newRetrySweeperServer(t, st, resumer)
+
+	at := time.Now().UTC().Add(-time.Minute)
+	s.sweepDueRetries(context.Background(), &fakeRetryLister{refs: []mongostore.RetryDueRef{dueRef("run-a", at)}}, resumer, time.Now().UTC())
+
+	if _, ok := st.rearmed["run-a"]; !ok {
+		t.Fatal("a failed resume must re-arm, not drop the run")
+	}
+	// The re-arm has to respect the run's own budget, not a fresh default,
+	// or a failing resume could loop past the operator's ceiling.
+	if got := st.armBudget["run-a"]; got != 4 {
+		t.Errorf("re-arm budget = %d, want the run's 4", got)
+	}
+	if len(st.abandoned) != 0 {
+		t.Errorf("re-armable failure must not abandon: %v", st.abandoned)
+	}
+}
+
+func TestSweepDueRetries_ExhaustedBudgetAbandonsWithAReason(t *testing.T) {
+	st := newFakeRetryStore()
+	st.claimWins["run-a"] = true
+	st.armOK = false // budget spent: ScheduleRunRetry refuses
+	resumer := &fakeResumer{failing: errors.New("publish blip")}
+	s := newRetrySweeperServer(t, st, resumer)
+
+	at := time.Now().UTC().Add(-time.Minute)
+	s.sweepDueRetries(context.Background(), &fakeRetryLister{refs: []mongostore.RetryDueRef{dueRef("run-a", at)}}, resumer, time.Now().UTC())
+
+	// The resume must actually have been attempted: otherwise this test
+	// would pass on any earlier abandon (an unresolvable source, say) and
+	// prove nothing about the attempt budget.
+	if len(resumer.calls) != 1 {
+		t.Fatalf("Resume called %d times, want 1 before the budget check", len(resumer.calls))
+	}
+	reason, ok := st.abandoned["run-a"]
+	if !ok {
+		t.Fatal("a run out of attempts must be abandoned, not left armed")
+	}
+	if reason == "" {
+		t.Error("abandon reason empty — a run that stops retrying must say why")
+	}
+}
+
+func TestSweepDueRetries_UnresolvableSourceAbandons(t *testing.T) {
+	st := newFakeRetryStore()
+	st.claimWins["run-a"] = true
+	resumer := &fakeResumer{}
+	s := newRetrySweeperServer(t, st, resumer)
+	s.cfg.Mode = "cloud" // cloud + no catalog match → source unresolvable
+
+	ref := dueRef("run-a", time.Now().UTC().Add(-time.Minute))
+	ref.FilePath = "bots/deleted-bot/main.bot"
+	s.sweepDueRetries(context.Background(), &fakeRetryLister{refs: []mongostore.RetryDueRef{ref}}, resumer, time.Now().UTC())
+
+	if len(resumer.calls) != 0 {
+		t.Errorf("resumed despite an unresolvable source: %+v", resumer.calls)
+	}
+	if _, ok := st.abandoned["run-a"]; !ok {
+		t.Fatal("an unresolvable source is permanent — abandon, do not re-arm every 15 minutes forever")
+	}
+	if _, ok := st.rearmed["run-a"]; ok {
+		t.Error("a permanently unresolvable run must not be re-armed")
+	}
+}
+
+func TestSweepDueRetries_RespectsTheBatchCap(t *testing.T) {
+	st := newFakeRetryStore()
+	var refs []mongostore.RetryDueRef
+	at := time.Now().UTC().Add(-time.Minute)
+	for _, id := range []string{"r1", "r2", "r3", "r4", "r5", "r6", "r7"} {
+		st.claimWins[id] = true
+		refs = append(refs, dueRef(id, at))
+	}
+	resumer := &fakeResumer{}
+	s := newRetrySweeperServer(t, st, resumer)
+
+	s.sweepDueRetries(context.Background(), &fakeRetryLister{refs: refs}, resumer, time.Now().UTC())
+
+	// Several schedules routinely share one reset; resuming all of them at
+	// once is how the freshly-reopened window is exhausted immediately.
+	if len(resumer.calls) > retrySweepBatch {
+		t.Fatalf("resumed %d runs in one pass, want at most %d", len(resumer.calls), retrySweepBatch)
+	}
+}
+
+func TestSweepDueRetries_NoRetryStoreIsANoOp(t *testing.T) {
+	// Local/filesystem mode has no durable retry surface; the sweeper must
+	// simply not run rather than panic on a missing capability.
+	s := &Server{cfg: Config{Store: plainRunStore{}}}
+	s.sweepDueRetries(context.Background(), &fakeRetryLister{refs: []mongostore.RetryDueRef{
+		dueRef("run-a", time.Now().UTC().Add(-time.Minute)),
+	}}, &fakeResumer{}, time.Now().UTC())
+}
+
+// plainRunStore satisfies store.RunStore without RunRetryStore.
+type plainRunStore struct{ store.RunStore }
+
+// newRetrySweeperServer builds a local-mode server whose WorkDir holds the
+// fixture bot, so resolveResumeSource succeeds and the tests exercise the
+// branch they name rather than all funnelling into "source unresolvable".
+func newRetrySweeperServer(t *testing.T, st store.RunStore, resumer runResumer) *Server {
+	t.Helper()
+	_ = resumer // passed per-call, not stored on the Server
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "bots", "feed-watch"), 0o755); err != nil {
+		t.Fatalf("mkdir fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "bots", "feed-watch", "main.bot"), []byte("workflow w:\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return &Server{cfg: Config{Store: st, WorkDir: dir}}
+}

--- a/pkg/server/retry_sweeper_test.go
+++ b/pkg/server/retry_sweeper_test.go
@@ -39,6 +39,7 @@ type fakeRetryStore struct {
 	loadRun   map[string]*store.Run
 
 	claimed   []string
+	cleared   []string
 	abandoned map[string]string
 	rearmed   map[string]time.Time
 	armBudget map[string]int // run id -> max attempts seen by ScheduleRunRetry
@@ -81,6 +82,13 @@ func (f *fakeRetryStore) ScheduleRunRetry(_ context.Context, runID string, at ti
 	}
 	f.rearmed[runID] = at
 	return true, 2, nil
+}
+
+func (f *fakeRetryStore) ClearRunRetry(_ context.Context, runID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cleared = append(f.cleared, runID)
+	return nil
 }
 
 func (f *fakeRetryStore) AbandonRunRetry(_ context.Context, runID, reason string) error {
@@ -153,6 +161,28 @@ func TestSweepDueRetries_ResumesAClaimedRun(t *testing.T) {
 	}
 	if len(st.abandoned) != 0 {
 		t.Errorf("unexpected abandon: %v", st.abandoned)
+	}
+	// The claim is a lease, so the successful resume is what disarms it —
+	// otherwise a past retry_after survives and re-fires the next time this
+	// run fails for any unrelated reason.
+	if len(st.cleared) != 1 || st.cleared[0] != "run-a" {
+		t.Errorf("cleared = %v, want [run-a] after a successful resume", st.cleared)
+	}
+}
+
+// TestSweepDueRetries_TransientDenialReArms pins the denial classification: a
+// monthly quota refills on the 1st and a concurrency cap clears in minutes,
+// so those must defer the retry rather than throw the run away.
+func TestSweepDueRetries_TransientDenialReArms(t *testing.T) {
+	for _, reason := range []string{denyMonthlyRunQuota, denyMonthlyCostCap, denyConcurrencyCap, denyLaunchRateLimited} {
+		if !retryDenialIsTransient(reason) {
+			t.Errorf("%s classified permanent — the run would be dropped for a condition that clears itself", reason)
+		}
+	}
+	for _, reason := range []string{denyOrgSuspended, denyNoWorkspace, "some_future_code"} {
+		if retryDenialIsTransient(reason) {
+			t.Errorf("%s classified transient — it needs a human, and re-arming would loop forever", reason)
+		}
 	}
 }
 

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -445,33 +445,16 @@ func (s *Server) handleResumeRun(w http.ResponseWriter, r *http.Request) {
 	filePath := req.FilePath
 	if filePath == "" {
 		filePath = runMeta.FilePath
-		if filePath == "" && req.Source == "" {
-			s.httpErrorFor(w, r, http.StatusBadRequest, "file_path or source is required (run has no persisted FilePath)")
-			span.SetStatus(codes.Error, "missing file_path/source")
-			return
-		}
 	}
-	// Cloud mode has no operator filesystem, so resume must carry inline
-	// source — UNLESS the run's (persisted) FilePath is a catalog bundle
-	// present on the pod, which we read off the pod FS just like launch.
-	// The run's BotID is already persisted + propagated by SubmitResume, so
-	// the runner still mirrors skills; here we only need the source bytes.
-	if s.cfg.Mode == "cloud" && req.Source == "" {
-		if src, _, _, ok := s.catalogBotSource("", filePath); ok {
-			req.Source = src
-		}
-	}
-	if s.cfg.Mode == "cloud" && req.Source == "" {
-		s.httpErrorFor(w, r, http.StatusBadRequest, "cloud mode: source or a catalog bot is required (file_path is not portable across the server pod's filesystem)")
-		span.SetStatus(codes.Error, "cloud mode requires source")
-		return
-	}
-	absPath, pathErr := s.resolveWorkflowPath(filePath, req.Source)
+	// Shared with the retry sweeper so the automated resume resolves its
+	// source exactly like this one (see resolveResumeSource).
+	absPath, resolvedSource, pathErr := s.resolveResumeSource(filePath, req.Source)
 	if pathErr != nil {
-		s.httpErrorFor(w, r, http.StatusBadRequest, "invalid file_path: %v", pathErr)
-		span.SetStatus(codes.Error, "invalid file_path")
+		s.httpErrorFor(w, r, http.StatusBadRequest, "%v", pathErr)
+		span.SetStatus(codes.Error, "resume source unresolvable")
 		return
 	}
+	req.Source = resolvedSource
 	timeout, err := parseTimeout(req.Timeout)
 	if err != nil {
 		s.httpErrorFor(w, r, http.StatusBadRequest, "invalid timeout: %v", err)

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -344,22 +344,28 @@ func (s *Server) handleLaunchRun(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res, err := s.runs.Launch(ctx, runview.LaunchSpec{
-		FilePath:           absPath,
-		Source:             req.Source,
-		BotID:              botID,
-		RunID:              req.RunID,
-		Vars:               req.Vars,
-		Preset:             req.Preset,
-		Timeout:            timeout,
-		MergeInto:          req.MergeInto,
-		BranchName:         req.BranchName,
-		MergeStrategy:      store.MergeStrategy(req.MergeStrategy),
-		AutoMerge:          req.AutoMerge,
-		AttachmentPromote:  promote,
-		Backend:            req.Backend,
-		Compress:           req.Compress,
-		Permission:         req.Permission,
-		ReviewMode:         req.ReviewMode,
+		FilePath:          absPath,
+		Source:            req.Source,
+		BotID:             botID,
+		RunID:             req.RunID,
+		Vars:              req.Vars,
+		Preset:            req.Preset,
+		Timeout:           timeout,
+		MergeInto:         req.MergeInto,
+		BranchName:        req.BranchName,
+		MergeStrategy:     store.MergeStrategy(req.MergeStrategy),
+		AutoMerge:         req.AutoMerge,
+		AttachmentPromote: promote,
+		Backend:           req.Backend,
+		Compress:          req.Compress,
+		Permission:        req.Permission,
+		ReviewMode:        req.ReviewMode,
+		// The manual path resolves the retry chain like every automated
+		// one. Skipping it here would let a bot declaring
+		// `retry: usage_window: off` be auto-retried anyway whenever a
+		// human pressed Launch — a declared directive silently violated on
+		// the one path where the author is watching.
+		RetryPolicy:        s.resolveRunRetryPolicy(botID),
 		ModelOverrides:     req.ModelOverrides,
 		Budget:             budget,
 		ParentRunID:        req.ParentRunID,

--- a/pkg/server/schedules_routes.go
+++ b/pkg/server/schedules_routes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/bundle"
 	"github.com/SocialGouv/iterion/pkg/cloudsched"
 	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 	"github.com/SocialGouv/iterion/pkg/schedgate"
 )
 
@@ -46,6 +47,12 @@ type createScheduleReq struct {
 	GuardTimeout  string `json:"guard_timeout,omitempty"`
 	GuardVar      string `json:"guard_var,omitempty"`
 	StaleAfter    string `json:"stale_after,omitempty"`
+	// Retry policy (pkg/retrypolicy; validated on create). Only the fields
+	// set here override the bot's manifest and the machine default.
+	RetryUsageWindow string `json:"retry_usage_window,omitempty"`
+	RetryMaxAttempts int    `json:"retry_max_attempts,omitempty"`
+	RetryMaxWait     string `json:"retry_max_wait,omitempty"`
+	RetryJitter      string `json:"retry_jitter,omitempty"`
 }
 
 type updateScheduleReq struct {
@@ -63,6 +70,12 @@ type updateScheduleReq struct {
 	GuardTimeout  *string `json:"guard_timeout,omitempty"`
 	GuardVar      *string `json:"guard_var,omitempty"`
 	StaleAfter    *string `json:"stale_after,omitempty"`
+	// Retry policy (pkg/retrypolicy; the merged result is validated against
+	// the row's current values on update).
+	RetryUsageWindow *string `json:"retry_usage_window,omitempty"`
+	RetryMaxAttempts *int    `json:"retry_max_attempts,omitempty"`
+	RetryMaxWait     *string `json:"retry_max_wait,omitempty"`
+	RetryJitter      *string `json:"retry_jitter,omitempty"`
 }
 
 // scheduleNow returns the UTC instant used for CreatedAt / UpdatedAt and to
@@ -148,6 +161,15 @@ func (s *Server) handleCreateSchedule(w http.ResponseWriter, r *http.Request) {
 		httpError(w, http.StatusBadRequest, "%s", err.Error())
 		return
 	}
+	if err := retrypolicy.Validate(retrypolicy.Policy{
+		UsageWindow: req.RetryUsageWindow,
+		MaxAttempts: req.RetryMaxAttempts,
+		MaxWait:     req.RetryMaxWait,
+		Jitter:      req.RetryJitter,
+	}); err != nil {
+		httpError(w, http.StatusBadRequest, "%s", err.Error())
+		return
+	}
 	now := s.scheduleNow()
 	sb := cloudsched.ScheduledBot{
 		ID:              uuid.NewString(),
@@ -169,6 +191,10 @@ func (s *Server) handleCreateSchedule(w http.ResponseWriter, r *http.Request) {
 		GuardTimeout:      req.GuardTimeout,
 		GuardVar:          req.GuardVar,
 		StaleAfter:        req.StaleAfter,
+		RetryUsageWindow:  req.RetryUsageWindow,
+		RetryMaxAttempts:  req.RetryMaxAttempts,
+		RetryMaxWait:      req.RetryMaxWait,
+		RetryJitter:       req.RetryJitter,
 		CreatedBy:         id.UserID,
 		CreatedAt:         now,
 		UpdatedAt:         now,
@@ -289,6 +315,25 @@ func (s *Server) handleUpdateSchedule(w http.ResponseWriter, r *http.Request) {
 		httpError(w, http.StatusBadRequest, "%s", err.Error())
 		return
 	}
+	// Same merge-then-validate for the retry policy: a patch touching one
+	// retry field must not be able to leave the row incoherent.
+	mergedRetry := cur.RetryPolicy()
+	if req.RetryUsageWindow != nil {
+		mergedRetry.UsageWindow = *req.RetryUsageWindow
+	}
+	if req.RetryMaxAttempts != nil {
+		mergedRetry.MaxAttempts = *req.RetryMaxAttempts
+	}
+	if req.RetryMaxWait != nil {
+		mergedRetry.MaxWait = *req.RetryMaxWait
+	}
+	if req.RetryJitter != nil {
+		mergedRetry.Jitter = *req.RetryJitter
+	}
+	if err := retrypolicy.Validate(mergedRetry); err != nil {
+		httpError(w, http.StatusBadRequest, "%s", err.Error())
+		return
+	}
 	now := s.scheduleNow()
 	patch := cloudsched.SchedulePatch{UpdatedAt: now}
 	patch.Overlap = req.Overlap
@@ -297,6 +342,10 @@ func (s *Server) handleUpdateSchedule(w http.ResponseWriter, r *http.Request) {
 	patch.GuardTimeout = req.GuardTimeout
 	patch.GuardVar = req.GuardVar
 	patch.StaleAfter = req.StaleAfter
+	patch.RetryUsageWindow = req.RetryUsageWindow
+	patch.RetryMaxAttempts = req.RetryMaxAttempts
+	patch.RetryMaxWait = req.RetryMaxWait
+	patch.RetryJitter = req.RetryJitter
 	// cron and interval_seconds are mutually exclusive cadences; whichever
 	// the request provides recomputes NextFireAt and clears the other. The
 	// exclusive switch (not two independent ifs) makes each patch field set

--- a/pkg/server/schedules_routes_test.go
+++ b/pkg/server/schedules_routes_test.go
@@ -220,7 +220,7 @@ func TestBuildScheduledLaunchSpec(t *testing.T) {
 		RepoURL: "https://example.com/repo.git",
 		RepoRef: "feat/x",
 	}
-	spec := buildScheduledLaunchSpec(sb, "/tmp/feed-watch/main.bot", "workflow: {}")
+	spec := buildScheduledLaunchSpec(sb, "/tmp/feed-watch/main.bot", "workflow: {}", nil)
 	if spec.FilePath != "/tmp/feed-watch/main.bot" || spec.Source != "workflow: {}" {
 		t.Errorf("source pass-through: %+v", spec)
 	}

--- a/pkg/server/server_lifecycle.go
+++ b/pkg/server/server_lifecycle.go
@@ -217,6 +217,21 @@ func (s *Server) ListenAndServe() error {
 			s.runQueueSweeper(ctx, lister, s.queue)
 		}()
 	}
+	// Retry sweeper (cloud only): resumes runs whose provider quota window
+	// has reopened. Needs only the store — unlike the orphan sweeper it
+	// asks no question of the queue, because the retry instant was decided
+	// when the run failed. Multi-replica-safe via the store CAS.
+	if lister, ok := s.cfg.Store.(retryDueLister); ok && s.runs != nil {
+		go func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go func() {
+				<-s.shutdown
+				cancel()
+			}()
+			s.runRetrySweeper(ctx, lister)
+		}()
+	}
 	// Cloud scheduler: fire due cron-scheduled bots. Multi-replica-safe via the
 	// store CAS (no leader election). Absent in local mode (ScheduledBots nil).
 	if s.cfg.ScheduledBots != nil {

--- a/pkg/server/server_lifecycle.go
+++ b/pkg/server/server_lifecycle.go
@@ -75,7 +75,7 @@ func (s *Server) ListenAndServe() error {
 		}
 		var launcher trigger.Launcher
 		if s.runs != nil {
-			launcher = newServiceLauncher(s.runs, s.effectivePaths(), s.logger)
+			launcher = newServiceLauncher(s.runs, s.effectivePaths(), s.logger, s.resolveRunRetryPolicy)
 		}
 		s.triggerCoord = StartTriggerCoordinator(s.cfg.NativeTrackerStore, s.cfg.TriggerStore, nudger, launcher, s.scheduleGate(), s.cfg.EventsBus, s.logger)
 	}
@@ -87,7 +87,7 @@ func (s *Server) ListenAndServe() error {
 	if s.cfg.NativeTrackerStore == nil && s.cfg.CloudBoardCoordinator != nil && s.cfg.TriggerStore != nil && s.runs != nil {
 		s.cloudTriggerCoord = StartCloudTriggerCoordinator(
 			s.cfg.CloudBoardCoordinator, s.cfg.TriggerStore,
-			newServiceLauncher(s.runs, s.effectivePaths(), s.logger),
+			newServiceLauncher(s.runs, s.effectivePaths(), s.logger, s.resolveRunRetryPolicy),
 			s.cfg.EventsBus, s.logger)
 	}
 	// Wire the run-completion source onto the process's single event spine

--- a/pkg/server/trigger_launcher.go
+++ b/pkg/server/trigger_launcher.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/botregistry"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
 	"github.com/SocialGouv/iterion/pkg/trigger"
 )
 
@@ -22,10 +24,15 @@ type serviceLauncher struct {
 	runs   *runview.Service
 	paths  []string
 	logger *iterlog.Logger
+	// resolveRetry folds the plan's binding-level retry policy together
+	// with the bot manifest, the machine default and the platform ceiling.
+	// Injected rather than reached for, because the launcher deliberately
+	// holds no *Server.
+	resolveRetry func(botID string, higher ...retrypolicy.Layer) *store.RunRetryPolicy
 }
 
-func newServiceLauncher(runs *runview.Service, paths []string, logger *iterlog.Logger) *serviceLauncher {
-	return &serviceLauncher{runs: runs, paths: paths, logger: logger}
+func newServiceLauncher(runs *runview.Service, paths []string, logger *iterlog.Logger, resolveRetry func(string, ...retrypolicy.Layer) *store.RunRetryPolicy) *serviceLauncher {
+	return &serviceLauncher{runs: runs, paths: paths, logger: logger, resolveRetry: resolveRetry}
 }
 
 func (l *serviceLauncher) Launch(ctx context.Context, plan trigger.LaunchPlan) (string, error) {
@@ -46,11 +53,25 @@ func (l *serviceLauncher) Launch(ctx context.Context, plan trigger.LaunchPlan) (
 		KeyOverrides:    plan.KeyOverrides,
 		SecretOverrides: plan.SecretOverrides,
 		SourceRef:       plan.SourceRef,
+		RetryPolicy:     l.retryPolicyFor(plan),
 	})
 	if err != nil {
 		return "", err
 	}
 	return res.RunID, nil
+}
+
+// retryPolicyFor resolves the run's retry contract, tolerating a launcher
+// built without a resolver (tests) by leaving the field nil — the consumer
+// then applies the package defaults.
+func (l *serviceLauncher) retryPolicyFor(plan trigger.LaunchPlan) *store.RunRetryPolicy {
+	if l.resolveRetry == nil {
+		return nil
+	}
+	return l.resolveRetry(plan.BotID, retrypolicy.Layer{
+		Source: retrypolicy.SourceTrigger,
+		Policy: plan.Retry,
+	})
 }
 
 var _ trigger.Launcher = (*serviceLauncher)(nil)

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -510,7 +510,11 @@ func (s *Server) insertAndLaunchWebhook(
 	// 3. Launch.
 	launch := s.webhookLaunchBot
 	if launch == nil {
-		launch = s.realWebhookLaunchBot
+		// A closure over cfg rather than a bare method reference: the real
+		// launcher needs the webhook's own retry policy, and threading it
+		// as a ninth positional parameter would churn every test fake of
+		// this seam for one field.
+		launch = s.webhookLauncherFor(cfg)
 	}
 	// Deterministic forge review publishing: a review-shaped delivery
 	// carries a pr_url var — mint a per-run publish grant scoped to the

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -15,6 +15,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/botregistry"
 	"github.com/SocialGouv/iterion/pkg/cloudsched"
 	"github.com/SocialGouv/iterion/pkg/knowledge"
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/secrets"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -774,7 +775,11 @@ func (s *Server) launchScheduledBot(ctx context.Context, sb cloudsched.Scheduled
 	if err != nil {
 		return err
 	}
-	_, err = s.runs.Launch(ctx, buildScheduledLaunchSpec(sb, path, source))
+	retry := s.resolveRunRetryPolicy(sb.BotID, retrypolicy.Layer{
+		Source: retrypolicy.SourceSchedule,
+		Policy: sb.RetryPolicy(),
+	})
+	_, err = s.runs.Launch(ctx, buildScheduledLaunchSpec(sb, path, source, retry))
 	return err
 }
 
@@ -783,7 +788,7 @@ func (s *Server) launchScheduledBot(ctx context.Context, sb cloudsched.Scheduled
 // the schedule's Vars + repo binding onto the LaunchSpec so the runner clones
 // the pinned repo (mandatory for stateful bots persisting state to git) and
 // stamps the BotID for the publisher's credential-resolution path.
-func buildScheduledLaunchSpec(sb cloudsched.ScheduledBot, path, source string) runview.LaunchSpec {
+func buildScheduledLaunchSpec(sb cloudsched.ScheduledBot, path, source string, retry *store.RunRetryPolicy) runview.LaunchSpec {
 	return runview.LaunchSpec{
 		FilePath: path,
 		Source:   source,
@@ -791,6 +796,11 @@ func buildScheduledLaunchSpec(sb cloudsched.ScheduledBot, path, source string) r
 		Vars:     sb.Vars,
 		RepoURL:  sb.RepoURL,
 		RepoRef:  sb.RepoRef,
+		// Resolved by the caller across the schedule row, the bot manifest
+		// and the machine default — the schedule is the layer an operator
+		// reaches for when one bot's cadence needs different retry limits
+		// from the same bot on another cadence.
+		RetryPolicy: retry,
 		// Typed provenance: the schedgate overlap gate counts this
 		// schedule's live runs through source.schedule_id.
 		SourceRef: &store.RunSource{

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -811,10 +811,19 @@ func buildScheduledLaunchSpec(sb cloudsched.ScheduledBot, path, source string, r
 	}
 }
 
-// realWebhookLaunchBot is the production launch path for an inbound
-// webhook: resolve the bot's source and submit it through the run
+// webhookLauncherFor builds the production launch path for one inbound
+// webhook config. It is a closure rather than a plain method because the
+// launch needs the config's retry policy, which the seam's positional
+// signature does not carry.
+func (s *Server) webhookLauncherFor(cfg webhooks.Config) func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+	return func(ctx context.Context, botID string, vars map[string]string, repoURL, repoRef, projectPath string, keyOverrides, secretOverrides map[string]string) (string, error) {
+		return s.launchWebhookBot(ctx, cfg, botID, vars, repoURL, repoRef, projectPath, keyOverrides, secretOverrides)
+	}
+}
+
+// launchWebhookBot resolves the bot's source and submits it through the run
 // service (which, in cloud mode, routes to the publisher).
-func (s *Server) realWebhookLaunchBot(ctx context.Context, botID string, vars map[string]string, repoURL, repoRef, projectPath string, keyOverrides, secretOverrides map[string]string) (string, error) {
+func (s *Server) launchWebhookBot(ctx context.Context, cfg webhooks.Config, botID string, vars map[string]string, repoURL, repoRef, projectPath string, keyOverrides, secretOverrides map[string]string) (string, error) {
 	if s.runs == nil {
 		return "", errors.New("run service unavailable")
 	}
@@ -832,6 +841,13 @@ func (s *Server) realWebhookLaunchBot(ctx context.Context, botID string, vars ma
 		BotID:           botID,
 		KeyOverrides:    keyOverrides,
 		SecretOverrides: secretOverrides,
+		// A webhook-launched run is often the one an author is waiting on,
+		// so the config's own horizon usually wants to be shorter than a
+		// nightly's — hence the layer.
+		RetryPolicy: s.resolveRunRetryPolicy(botID, retrypolicy.Layer{
+			Source: retrypolicy.SourceWebhook,
+			Policy: cfg.RetryPolicy(),
+		}),
 	})
 	if err != nil {
 		return "", err

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -95,6 +95,20 @@ const (
 	//   - delay_ms: backoff waited before this attempt
 	//   - reason: "auto"
 	EventRunAutoResumed EventType = "run_auto_resumed"
+	// EventRunRetryScheduled marks a durable retry armed for a run that
+	// failed on an exhausted provider quota window. It is the "we are
+	// waiting, not dead" marker: without it a failed_resumable row that
+	// will resume in 33h is indistinguishable from one that never will.
+	// The resume itself emits EventRunAutoResumed, so the pair reads the
+	// same on the timeline as the CLI's in-process auto-resume loop. Data:
+	//   - code: the RuntimeError code that armed it (USAGE_LIMIT_BLOCKED)
+	//   - reason: the failure class ("usage_window")
+	//   - retry_after: RFC3339 instant the retry becomes eligible
+	//   - attempt / max_attempts: position in the run's attempt budget
+	//   - reset_source: how the instant was derived ("typed_error",
+	//     "runtime_code+parsed_text", "…+blind_wait") — the degraded
+	//     paths must be visible, not silent
+	EventRunRetryScheduled EventType = "run_retry_scheduled"
 	// Review-&-merge gate events (interaction: review). The gate runs a
 	// companion↔human dialogue and squash-merges during the pause.
 	EventReviewTurn     EventType = "review_turn"    // data: {interaction_id, role, turn}

--- a/pkg/store/mongo/conformance_test.go
+++ b/pkg/store/mongo/conformance_test.go
@@ -59,13 +59,17 @@ func TestConformance_Mongo(t *testing.T) {
 // runs land on disjoint databases (Go test packages run sequentially
 // per package, but the same package's t.Parallel() subtests can
 // otherwise collide).
+// bsonNonce returns a per-call unique suffix for a test database name.
+//
+// It returns the FULL ObjectID hex, not a prefix: the leading 8 hex chars of
+// an ObjectID are its timestamp in SECONDS, so a prefix makes every test
+// starting within the same second share one database — and therefore each
+// other's data. That went unnoticed while no test asserted on a
+// platform-wide scan; the retry sweeper's due-list does, and saw its
+// neighbours' runs.
 func bsonNonce(t *testing.T) string {
 	t.Helper()
-	id := bson.NewObjectID().Hex()
-	if len(id) < 8 {
-		return id
-	}
-	return id[:8]
+	return bson.NewObjectID().Hex()
 }
 
 // inMemoryBlob is a hash-map blob.Client implementation suitable for

--- a/pkg/store/mongo/runs_retry.go
+++ b/pkg/store/mongo/runs_retry.go
@@ -1,0 +1,183 @@
+package mongo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// Mongo half of store.RunRetryStore: arming and claiming the durable
+// retry a usage-window failure needs.
+//
+// The wait cannot live in the work queue. That stream is a work queue with
+// a 24h max age and exposes no delayed-nak, while a weekly quota window can
+// reset up to seven days out — so blind redelivery just burns one pod per
+// attempt against a wall that cannot move (measured: eight pods per run,
+// then a DLQ park). Mongo is the only place a multi-day intent survives,
+// and a periodic sweeper is the only thing that can act on it.
+
+// retryStateField is the run document's embedded retry-state path. Kept in
+// one constant because every filter and update below has to agree on it.
+const retryStateField = "retry_state"
+
+func retryPath(field string) string { return retryStateField + "." + field }
+
+// ScheduleRunRetry arms a retry, conditioning on the run still being
+// failed_resumable and under its attempt budget. Both preconditions are in
+// the FILTER rather than checked first and written second: an operator
+// resuming the run by hand between the two would otherwise have their
+// resume silently re-armed.
+func (s *Store) ScheduleRunRetry(ctx context.Context, runID string, at time.Time, reason, code string, maxAttempts int) (bool, int, error) {
+	if maxAttempts <= 0 {
+		return false, 0, nil
+	}
+	now := time.Now().UTC()
+	filter := withTenantFilter(ctx, bson.M{
+		"_id":    runID,
+		"status": string(store.RunStatusFailedResumable),
+		// The absent case needs its own branch: Mongo's comparison
+		// operators are type-bracketed, so {$lt: n} does NOT match a
+		// document where the field is missing. A run that never retried has
+		// no retry_state.attempts, so a bare $lt would refuse to arm the
+		// FIRST retry of every run — silently disabling the whole feature.
+		"$or": []bson.M{
+			{retryPath("attempts"): bson.M{"$exists": false}},
+			{retryPath("attempts"): bson.M{"$lt": maxAttempts}},
+		},
+	})
+	update := bson.M{
+		"$set": bson.M{
+			retryPath("retry_after"): at.UTC(),
+			retryPath("reason"):      reason,
+			retryPath("code"):        code,
+			"updated_at":             now,
+		},
+		"$unset": bson.M{
+			// A fresh arming supersedes the previous failure note and claim.
+			retryPath("last_error"): "",
+			retryPath("claimed_at"): "",
+		},
+		"$inc": bson.M{retryPath("attempts"): 1, "version": 1},
+	}
+	var updated struct {
+		RetryState *store.RunRetryState `bson:"retry_state"`
+	}
+	err := s.runs.FindOneAndUpdate(ctx, filter, update,
+		options.FindOneAndUpdate().
+			SetReturnDocument(options.After).
+			SetProjection(bson.M{retryStateField: 1}),
+	).Decode(&updated)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			// Not failed_resumable any more, or out of attempts. Both are
+			// ordinary outcomes the caller reports rather than errors.
+			return false, 0, nil
+		}
+		return false, 0, fmt.Errorf("store/mongo: schedule retry %s: %w", runID, err)
+	}
+	attempt := 0
+	if updated.RetryState != nil {
+		attempt = updated.RetryState.Attempts
+	}
+	return true, attempt, nil
+}
+
+// ClaimRunRetry takes an armed retry, conditioning on the retry_after value
+// the caller read. First writer wins; every other replica sees won=false.
+// This is the whole concurrency story — no lease, no leader election.
+func (s *Store) ClaimRunRetry(ctx context.Context, runID string, expectedAfter time.Time) (bool, error) {
+	now := time.Now().UTC()
+	filter := withTenantFilter(ctx, bson.M{
+		"_id":                    runID,
+		"status":                 string(store.RunStatusFailedResumable),
+		retryPath("retry_after"): expectedAfter.UTC(),
+	})
+	update := bson.M{
+		"$set": bson.M{
+			retryPath("claimed_at"): now,
+			"updated_at":            now,
+		},
+		// Disarming inside the same update is what makes the claim
+		// exclusive: a second claimer no longer matches the filter.
+		"$unset": bson.M{retryPath("retry_after"): ""},
+		"$inc":   bson.M{"version": 1},
+	}
+	res, err := s.runs.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return false, fmt.Errorf("store/mongo: claim retry %s: %w", runID, err)
+	}
+	return res.MatchedCount > 0, nil
+}
+
+// AbandonRunRetry records why a run stopped retrying and leaves it
+// disarmed. Not conditioned on status: by the time we abandon, the reason
+// is already permanent, and the note matters more than the race.
+func (s *Store) AbandonRunRetry(ctx context.Context, runID, reason string) error {
+	now := time.Now().UTC()
+	update := bson.M{
+		"$set": bson.M{
+			retryPath("last_error"): reason,
+			"updated_at":            now,
+		},
+		"$unset": bson.M{retryPath("retry_after"): ""},
+		"$inc":   bson.M{"version": 1},
+	}
+	if _, err := s.runs.UpdateOne(ctx, withTenantFilter(ctx, bson.M{"_id": runID}), update); err != nil {
+		return fmt.Errorf("store/mongo: abandon retry %s: %w", runID, err)
+	}
+	return nil
+}
+
+// RetryDueRef is one row of ListRunsDueForRetry: the run identity plus what
+// the sweeper needs to re-enqueue a resume without a second read.
+type RetryDueRef struct {
+	ID         string               `bson:"_id"`
+	TenantID   string               `bson:"tenant_id"`
+	OwnerID    string               `bson:"owner_id"`
+	BotID      string               `bson:"bot_id"`
+	FilePath   string               `bson:"file_path"`
+	RetryState *store.RunRetryState `bson:"retry_state"`
+}
+
+// RetryAfter returns the armed instant, or the zero time when absent.
+func (r RetryDueRef) RetryAfter() time.Time {
+	if r.RetryState == nil || r.RetryState.RetryAfter == nil {
+		return time.Time{}
+	}
+	return *r.RetryState.RetryAfter
+}
+
+// ListRunsDueForRetry returns runs whose armed retry instant has arrived,
+// oldest first. Platform-scoped (the sweeper runs outside any tenant
+// context), so callers pass store.WithoutTenantFilter — mirroring
+// ListStaleActiveRuns.
+func (s *Store) ListRunsDueForRetry(ctx context.Context, before time.Time, limit int) ([]RetryDueRef, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	cur, err := s.runs.Find(ctx,
+		withTenantFilter(ctx, bson.M{
+			"status":                 string(store.RunStatusFailedResumable),
+			retryPath("retry_after"): bson.M{"$lte": before.UTC()},
+		}),
+		options.Find().
+			SetProjection(bson.M{"_id": 1, "tenant_id": 1, "owner_id": 1, "bot_id": 1, "file_path": 1, retryStateField: 1}).
+			SetSort(bson.M{retryPath("retry_after"): 1}).
+			SetLimit(int64(limit)))
+	if err != nil {
+		return nil, fmt.Errorf("store/mongo: list runs due for retry: %w", err)
+	}
+	defer cur.Close(ctx)
+	var out []RetryDueRef
+	if err := cur.All(ctx, &out); err != nil {
+		return nil, fmt.Errorf("store/mongo: decode runs due for retry: %w", err)
+	}
+	return out, nil
+}

--- a/pkg/store/mongo/runs_retry.go
+++ b/pkg/store/mongo/runs_retry.go
@@ -27,6 +27,14 @@ import (
 // one constant because every filter and update below has to agree on it.
 const retryStateField = "retry_state"
 
+// retryClaimLease bounds how long a claimed-but-not-resumed retry stays
+// off-limits. The claim is a LEASE, not a delete: if it disarmed the retry
+// outright, a server pod dying between the claim and the resume would strand
+// the run forever — retry_after gone, so no scan ever lists it again, and
+// nothing else reconciles a claimed-but-idle row. With a lease, that run
+// simply becomes claimable again once the lease lapses.
+const retryClaimLease = 10 * time.Minute
+
 func retryPath(field string) string { return retryStateField + "." + field }
 
 // ScheduleRunRetry arms a retry, conditioning on the run still being
@@ -89,31 +97,54 @@ func (s *Store) ScheduleRunRetry(ctx context.Context, runID string, at time.Time
 	return true, attempt, nil
 }
 
-// ClaimRunRetry takes an armed retry, conditioning on the retry_after value
-// the caller read. First writer wins; every other replica sees won=false.
-// This is the whole concurrency story — no lease, no leader election.
+// ClaimRunRetry leases an armed retry, conditioning on the retry_after value
+// the caller read AND on no live lease existing. First writer wins; every
+// other replica sees won=false — no leader election.
+//
+// It deliberately LEAVES retry_after in place. Unsetting it here would make
+// the claim exclusive too, but a pod dying before the resume landed would
+// then strand the run permanently. Keeping it means the worst case is a
+// retry that fires one lease later. The successful resume is what clears it
+// (ClearRunRetry).
 func (s *Store) ClaimRunRetry(ctx context.Context, runID string, expectedAfter time.Time) (bool, error) {
 	now := time.Now().UTC()
 	filter := withTenantFilter(ctx, bson.M{
 		"_id":                    runID,
 		"status":                 string(store.RunStatusFailedResumable),
 		retryPath("retry_after"): expectedAfter.UTC(),
+		"$or": []bson.M{
+			{retryPath("claimed_at"): bson.M{"$exists": false}},
+			{retryPath("claimed_at"): bson.M{"$lt": now.Add(-retryClaimLease)}},
+		},
 	})
 	update := bson.M{
 		"$set": bson.M{
 			retryPath("claimed_at"): now,
 			"updated_at":            now,
 		},
-		// Disarming inside the same update is what makes the claim
-		// exclusive: a second claimer no longer matches the filter.
-		"$unset": bson.M{retryPath("retry_after"): ""},
-		"$inc":   bson.M{"version": 1},
+		"$inc": bson.M{"version": 1},
 	}
 	res, err := s.runs.UpdateOne(ctx, filter, update)
 	if err != nil {
 		return false, fmt.Errorf("store/mongo: claim retry %s: %w", runID, err)
 	}
 	return res.MatchedCount > 0, nil
+}
+
+// ClearRunRetry disarms a retry that has been acted on — the successful
+// resume's counterpart to the lease taken by ClaimRunRetry. Without it a
+// retry_after in the past would survive on the row and re-fire the moment
+// the resumed run failed again for an unrelated reason.
+func (s *Store) ClearRunRetry(ctx context.Context, runID string) error {
+	update := bson.M{
+		"$unset": bson.M{retryPath("retry_after"): "", retryPath("claimed_at"): ""},
+		"$set":   bson.M{"updated_at": time.Now().UTC()},
+		"$inc":   bson.M{"version": 1},
+	}
+	if _, err := s.runs.UpdateOne(ctx, withTenantFilter(ctx, bson.M{"_id": runID}), update); err != nil {
+		return fmt.Errorf("store/mongo: clear retry %s: %w", runID, err)
+	}
+	return nil
 }
 
 // AbandonRunRetry records why a run stopped retrying and leaves it

--- a/pkg/store/mongo/runs_retry_test.go
+++ b/pkg/store/mongo/runs_retry_test.go
@@ -1,0 +1,316 @@
+package mongo
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// These tests run against a real Mongo replica set because the behaviour
+// under test IS Mongo's: the arm/claim pair is a compare-and-swap expressed
+// as a conditional update, and the one thing that can silently break it is a
+// filter that does not match what we think it matches. Notably, comparison
+// operators are type-bracketed — {$lt: n} does not match a document whose
+// field is absent — which would refuse to arm the FIRST retry of every run
+// and disable the feature with no error anywhere.
+//
+//	docker run -d -p 27077:27017 mongo:8.0 --replSet rs0 --bind_ip_all
+//	# then rs.initiate()
+//	ITERION_TEST_MONGO_URI='mongodb://localhost:27077/?replicaSet=rs0' \
+//	    devbox run -- go test ./pkg/store/mongo/ -run TestRunRetry
+
+// retryTenant scopes the fixtures. Runs are tenant-scoped in cloud mode and
+// the store panics on a tenant-less query, so the tests exercise the same
+// scoping production uses — only the sweeper's platform-wide scan opts out.
+const retryTenant = "team-retry"
+
+func retryCtx() context.Context {
+	return store.WithTenant(context.Background(), retryTenant)
+}
+
+func retryTestStore(t *testing.T) *Store {
+	t.Helper()
+	uri := os.Getenv("ITERION_TEST_MONGO_URI")
+	if uri == "" {
+		t.Skip("ITERION_TEST_MONGO_URI not set; skipping Mongo retry tests")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	s, err := New(ctx, Config{
+		URI:      uri,
+		Database: "iterion_retry_" + bsonNonce(t),
+		Blob:     newInMemoryBlob(),
+	})
+	if err != nil {
+		t.Fatalf("connect mongo: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close(context.Background()) })
+	return s
+}
+
+// seedFailedResumable creates a run and drives it to failed_resumable, the
+// only status from which a retry may be armed.
+func seedFailedResumable(t *testing.T, s *Store, runID string) {
+	t.Helper()
+	ctx := retryCtx()
+	r, err := s.CreateRun(ctx, runID, "feed_watch", nil)
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	// FilePath is what the sweeper resolves the workflow source from, so the
+	// fixture has to carry one.
+	r.FilePath = "bots/some-bot/main.bot"
+	if err := s.SaveRun(ctx, r); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+	if err := s.FailRunResumable(ctx, runID, &store.Checkpoint{NodeID: "synthesize"}, "usage window exhausted"); err != nil {
+		t.Fatalf("FailRunResumable: %v", err)
+	}
+}
+
+// TestRunRetry_ArmsFirstAttemptWithNoPriorState is the regression test for
+// the type-bracketing trap: a run with no retry_state at all must still arm.
+func TestRunRetry_ArmsFirstAttemptWithNoPriorState(t *testing.T) {
+	s := retryTestStore(t)
+	ctx := retryCtx()
+	seedFailedResumable(t, s, "run-first-arm")
+
+	at := time.Now().UTC().Add(30 * time.Hour).Truncate(time.Millisecond)
+	scheduled, attempt, err := s.ScheduleRunRetry(ctx, "run-first-arm", at, "usage_window", "USAGE_LIMIT_BLOCKED", 5)
+	if err != nil {
+		t.Fatalf("ScheduleRunRetry: %v", err)
+	}
+	if !scheduled {
+		t.Fatal("scheduled = false for a run with no prior retry_state — the attempts filter does not match a missing field")
+	}
+	if attempt != 1 {
+		t.Errorf("attempt = %d, want 1", attempt)
+	}
+
+	r, err := s.LoadRun(ctx, "run-first-arm")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.RetryState == nil || r.RetryState.RetryAfter == nil {
+		t.Fatal("retry state not persisted")
+	}
+	if !r.RetryState.RetryAfter.Equal(at) {
+		t.Errorf("retry_after = %v, want %v", r.RetryState.RetryAfter, at)
+	}
+	if r.RetryState.Code != "USAGE_LIMIT_BLOCKED" || r.RetryState.Reason != "usage_window" {
+		t.Errorf("reason/code = %q/%q, want usage_window/USAGE_LIMIT_BLOCKED", r.RetryState.Reason, r.RetryState.Code)
+	}
+	// Arming must not resurrect the run: only the sweeper's resume does that.
+	if r.Status != store.RunStatusFailedResumable {
+		t.Errorf("status = %v, want failed_resumable", r.Status)
+	}
+}
+
+// TestRunRetry_AttemptsAreMonotonicAndBounded pins the anti-loop bound.
+func TestRunRetry_AttemptsAreMonotonicAndBounded(t *testing.T) {
+	s := retryTestStore(t)
+	ctx := retryCtx()
+	seedFailedResumable(t, s, "run-bounded")
+
+	at := time.Now().UTC().Add(time.Hour)
+	for i := 1; i <= 2; i++ {
+		scheduled, attempt, err := s.ScheduleRunRetry(ctx, "run-bounded", at, "usage_window", "USAGE_LIMIT_BLOCKED", 2)
+		if err != nil {
+			t.Fatalf("arm %d: %v", i, err)
+		}
+		if !scheduled || attempt != i {
+			t.Fatalf("arm %d: scheduled=%v attempt=%d, want true/%d", i, scheduled, attempt, i)
+		}
+	}
+	// Budget spent: the third arming must refuse, and must not be an error.
+	scheduled, _, err := s.ScheduleRunRetry(ctx, "run-bounded", at, "usage_window", "USAGE_LIMIT_BLOCKED", 2)
+	if err != nil {
+		t.Fatalf("arm past budget returned an error: %v", err)
+	}
+	if scheduled {
+		t.Error("scheduled = true past the attempt budget, want false")
+	}
+}
+
+// TestRunRetry_RefusesWhenNotResumable covers the operator race: someone
+// resumed the run by hand, so the run is no longer failed_resumable and the
+// retry must not be re-armed behind them.
+func TestRunRetry_RefusesWhenNotResumable(t *testing.T) {
+	s := retryTestStore(t)
+	ctx := retryCtx()
+	seedFailedResumable(t, s, "run-resumed-by-hand")
+	if err := s.UpdateRunStatus(ctx, "run-resumed-by-hand", store.RunStatusRunning, ""); err != nil {
+		t.Fatalf("UpdateRunStatus: %v", err)
+	}
+
+	scheduled, _, err := s.ScheduleRunRetry(ctx, "run-resumed-by-hand", time.Now().UTC().Add(time.Hour), "usage_window", "USAGE_LIMIT_BLOCKED", 5)
+	if err != nil {
+		t.Fatalf("ScheduleRunRetry: %v", err)
+	}
+	if scheduled {
+		t.Error("scheduled = true for a running run, want false")
+	}
+}
+
+// TestRunRetry_ClaimIsExclusive is the multi-replica contract: many
+// sweepers, exactly one resume.
+func TestRunRetry_ClaimIsExclusive(t *testing.T) {
+	s := retryTestStore(t)
+	ctx := retryCtx()
+	seedFailedResumable(t, s, "run-claim")
+
+	at := time.Now().UTC().Add(-time.Minute).Truncate(time.Millisecond) // already due
+	if scheduled, _, err := s.ScheduleRunRetry(ctx, "run-claim", at, "usage_window", "USAGE_LIMIT_BLOCKED", 5); err != nil || !scheduled {
+		t.Fatalf("arm: scheduled=%v err=%v", scheduled, err)
+	}
+
+	const replicas = 8
+	var wg sync.WaitGroup
+	wins := make([]bool, replicas)
+	errs := make([]error, replicas)
+	wg.Add(replicas)
+	for i := 0; i < replicas; i++ {
+		go func(i int) {
+			defer wg.Done()
+			wins[i], errs[i] = s.ClaimRunRetry(ctx, "run-claim", at)
+		}(i)
+	}
+	wg.Wait()
+
+	won := 0
+	for i := range wins {
+		if errs[i] != nil {
+			t.Fatalf("replica %d: %v", i, errs[i])
+		}
+		if wins[i] {
+			won++
+		}
+	}
+	if won != 1 {
+		t.Fatalf("%d replicas won the claim, want exactly 1", won)
+	}
+
+	// A claim disarms the retry, so a later sweep does not see it again.
+	due, err := s.ListRunsDueForRetry(store.WithoutTenantFilter(ctx), time.Now().UTC(), 10)
+	if err != nil {
+		t.Fatalf("ListRunsDueForRetry: %v", err)
+	}
+	for _, d := range due {
+		if d.ID == "run-claim" {
+			t.Error("a claimed run is still listed as due")
+		}
+	}
+}
+
+// TestRunRetry_ClaimRejectsStaleExpectation covers the re-arm race: the
+// retry instant moved between read and claim, so the claim must lose rather
+// than resume against a stale plan.
+func TestRunRetry_ClaimRejectsStaleExpectation(t *testing.T) {
+	s := retryTestStore(t)
+	ctx := retryCtx()
+	seedFailedResumable(t, s, "run-stale-claim")
+
+	stale := time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond)
+	fresh := time.Now().UTC().Add(-time.Minute).Truncate(time.Millisecond)
+	if _, _, err := s.ScheduleRunRetry(ctx, "run-stale-claim", stale, "usage_window", "USAGE_LIMIT_BLOCKED", 5); err != nil {
+		t.Fatalf("arm stale: %v", err)
+	}
+	if _, _, err := s.ScheduleRunRetry(ctx, "run-stale-claim", fresh, "usage_window", "USAGE_LIMIT_BLOCKED", 5); err != nil {
+		t.Fatalf("re-arm fresh: %v", err)
+	}
+
+	won, err := s.ClaimRunRetry(ctx, "run-stale-claim", stale)
+	if err != nil {
+		t.Fatalf("ClaimRunRetry: %v", err)
+	}
+	if won {
+		t.Error("won = true against a stale retry_after, want false")
+	}
+	if won, err := s.ClaimRunRetry(ctx, "run-stale-claim", fresh); err != nil || !won {
+		t.Errorf("claim with the current value: won=%v err=%v, want true/nil", won, err)
+	}
+}
+
+// TestRunRetry_ListDueOrdersAndFilters pins what the sweeper scans: only
+// armed runs whose instant has arrived, oldest first.
+func TestRunRetry_ListDueOrdersAndFilters(t *testing.T) {
+	s := retryTestStore(t)
+	ctx := retryCtx()
+	now := time.Now().UTC()
+
+	seedFailedResumable(t, s, "run-due-late")
+	seedFailedResumable(t, s, "run-due-early")
+	seedFailedResumable(t, s, "run-not-yet")
+	seedFailedResumable(t, s, "run-never-armed")
+
+	arm := func(id string, at time.Time) {
+		t.Helper()
+		if scheduled, _, err := s.ScheduleRunRetry(ctx, id, at, "usage_window", "USAGE_LIMIT_BLOCKED", 5); err != nil || !scheduled {
+			t.Fatalf("arm %s: scheduled=%v err=%v", id, scheduled, err)
+		}
+	}
+	arm("run-due-late", now.Add(-time.Minute))
+	arm("run-due-early", now.Add(-time.Hour))
+	arm("run-not-yet", now.Add(time.Hour))
+
+	due, err := s.ListRunsDueForRetry(store.WithoutTenantFilter(ctx), now, 10)
+	if err != nil {
+		t.Fatalf("ListRunsDueForRetry: %v", err)
+	}
+	var ids []string
+	for _, d := range due {
+		ids = append(ids, d.ID)
+	}
+	if len(ids) != 2 || ids[0] != "run-due-early" || ids[1] != "run-due-late" {
+		t.Fatalf("due = %v, want [run-due-early run-due-late] (oldest first, future and unarmed excluded)", ids)
+	}
+	// The sweeper needs the armed instant to CAS on, without a second read.
+	if got := due[0].RetryAfter(); got.IsZero() {
+		t.Error("RetryAfter() is zero — the sweeper cannot claim without it")
+	}
+	if due[0].FilePath == "" {
+		t.Error("FilePath not projected — the sweeper cannot resolve the workflow source")
+	}
+}
+
+// TestRunRetry_AbandonDisarmsAndExplains pins that a run which stops
+// retrying says why instead of going quiet.
+func TestRunRetry_AbandonDisarmsAndExplains(t *testing.T) {
+	s := retryTestStore(t)
+	ctx := retryCtx()
+	seedFailedResumable(t, s, "run-abandon")
+	if _, _, err := s.ScheduleRunRetry(ctx, "run-abandon", time.Now().UTC().Add(-time.Minute), "usage_window", "USAGE_LIMIT_BLOCKED", 5); err != nil {
+		t.Fatalf("arm: %v", err)
+	}
+
+	if err := s.AbandonRunRetry(ctx, "run-abandon", "auto-retry abandoned: monthly run quota reached"); err != nil {
+		t.Fatalf("AbandonRunRetry: %v", err)
+	}
+	r, err := s.LoadRun(ctx, "run-abandon")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.RetryState == nil || r.RetryState.RetryAfter != nil {
+		t.Error("retry still armed after abandon")
+	}
+	if r.RetryState.LastError == "" {
+		t.Error("LastError empty — an abandoned retry must record why")
+	}
+	// Attempts stay spent: abandoning is not a refund.
+	if r.RetryState.Attempts != 1 {
+		t.Errorf("attempts = %d, want 1", r.RetryState.Attempts)
+	}
+}
+
+// TestRunRetry_StoreCapabilityIsDetectable pins the nil-check contract every
+// caller relies on.
+func TestRunRetry_StoreCapabilityIsDetectable(t *testing.T) {
+	s := retryTestStore(t)
+	if store.AsRunRetryStore(s) == nil {
+		t.Error("the Mongo store must satisfy store.RunRetryStore")
+	}
+}

--- a/pkg/store/mongo/runs_retry_test.go
+++ b/pkg/store/mongo/runs_retry_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"go.mongodb.org/mongo-driver/v2/bson"
+
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -194,15 +196,93 @@ func TestRunRetry_ClaimIsExclusive(t *testing.T) {
 		t.Fatalf("%d replicas won the claim, want exactly 1", won)
 	}
 
-	// A claim disarms the retry, so a later sweep does not see it again.
+	// The claim is a LEASE: the row stays armed (so a claimer that dies
+	// cannot strand it) but a second claim loses while the lease is live.
+	due, err := s.ListRunsDueForRetry(store.WithoutTenantFilter(ctx), time.Now().UTC(), 10)
+	if err != nil {
+		t.Fatalf("ListRunsDueForRetry: %v", err)
+	}
+	var stillListed bool
+	for _, d := range due {
+		if d.ID == "run-claim" {
+			stillListed = true
+		}
+	}
+	if !stillListed {
+		t.Error("the claimed run left the due set — a claimer that dies would strand it forever")
+	}
+	if won, err := s.ClaimRunRetry(ctx, "run-claim", at); err != nil || won {
+		t.Errorf("re-claim under a live lease: won=%v err=%v, want false/nil", won, err)
+	}
+}
+
+// TestRunRetry_ClearDisarmsAfterAResume pins the lease's counterpart: once
+// the resume is enqueued the retry must leave the due set, or a past
+// retry_after would re-fire the next time this run failed for any reason.
+func TestRunRetry_ClearDisarmsAfterAResume(t *testing.T) {
+	s := retryTestStore(t)
+	ctx := retryCtx()
+	seedFailedResumable(t, s, "run-clear")
+
+	at := time.Now().UTC().Add(-time.Minute).Truncate(time.Millisecond)
+	if _, _, err := s.ScheduleRunRetry(ctx, "run-clear", at, "usage_window", "USAGE_LIMIT_BLOCKED", 5); err != nil {
+		t.Fatalf("arm: %v", err)
+	}
+	if won, err := s.ClaimRunRetry(ctx, "run-clear", at); err != nil || !won {
+		t.Fatalf("claim: won=%v err=%v", won, err)
+	}
+	if err := s.ClearRunRetry(ctx, "run-clear"); err != nil {
+		t.Fatalf("ClearRunRetry: %v", err)
+	}
+
 	due, err := s.ListRunsDueForRetry(store.WithoutTenantFilter(ctx), time.Now().UTC(), 10)
 	if err != nil {
 		t.Fatalf("ListRunsDueForRetry: %v", err)
 	}
 	for _, d := range due {
-		if d.ID == "run-claim" {
-			t.Error("a claimed run is still listed as due")
+		if d.ID == "run-clear" {
+			t.Error("a cleared retry is still listed as due")
 		}
+	}
+	r, _ := s.LoadRun(ctx, "run-clear")
+	if r.RetryState != nil && r.RetryState.RetryAfter != nil {
+		t.Error("retry_after survived the clear")
+	}
+	// Attempts stay spent — clearing is not a refund.
+	if r.RetryState == nil || r.RetryState.Attempts != 1 {
+		t.Errorf("attempts = %v, want 1", r.RetryState)
+	}
+}
+
+// TestRunRetry_StrandedClaimRecoversAfterTheLease is the durability case the
+// lease exists for: a sweeper that claims and then dies must not take the
+// run with it.
+func TestRunRetry_StrandedClaimRecoversAfterTheLease(t *testing.T) {
+	s := retryTestStore(t)
+	ctx := retryCtx()
+	seedFailedResumable(t, s, "run-stranded")
+
+	at := time.Now().UTC().Add(-time.Minute).Truncate(time.Millisecond)
+	if _, _, err := s.ScheduleRunRetry(ctx, "run-stranded", at, "usage_window", "USAGE_LIMIT_BLOCKED", 5); err != nil {
+		t.Fatalf("arm: %v", err)
+	}
+	if won, err := s.ClaimRunRetry(ctx, "run-stranded", at); err != nil || !won {
+		t.Fatalf("first claim: won=%v err=%v", won, err)
+	}
+	// Simulate the pod dying right after the claim: nothing cleared, and the
+	// lease is now stale.
+	stale := time.Now().UTC().Add(-2 * retryClaimLease)
+	if _, err := s.runs.UpdateOne(ctx, bson.M{"_id": "run-stranded"},
+		bson.M{"$set": bson.M{retryPath("claimed_at"): stale}}); err != nil {
+		t.Fatalf("age the lease: %v", err)
+	}
+
+	won, err := s.ClaimRunRetry(ctx, "run-stranded", at)
+	if err != nil {
+		t.Fatalf("re-claim: %v", err)
+	}
+	if !won {
+		t.Fatal("a stranded claim never becomes re-claimable — the run is lost for good")
 	}
 }
 

--- a/pkg/store/mongo/runs_retry_test.go
+++ b/pkg/store/mongo/runs_retry_test.go
@@ -337,13 +337,19 @@ func TestRunRetry_ListDueOrdersAndFilters(t *testing.T) {
 	arm("run-due-early", now.Add(-time.Hour))
 	arm("run-not-yet", now.Add(time.Hour))
 
-	due, err := s.ListRunsDueForRetry(store.WithoutTenantFilter(ctx), now, 10)
+	due, err := s.ListRunsDueForRetry(store.WithoutTenantFilter(ctx), now, 50)
 	if err != nil {
 		t.Fatalf("ListRunsDueForRetry: %v", err)
 	}
+	// Scoped to this test's own runs: the scan is platform-wide by design,
+	// so asserting on the whole result would couple this test to whatever
+	// else shares the database.
+	mine := map[string]bool{"run-due-late": true, "run-due-early": true, "run-not-yet": true, "run-never-armed": true}
 	var ids []string
 	for _, d := range due {
-		ids = append(ids, d.ID)
+		if mine[d.ID] {
+			ids = append(ids, d.ID)
+		}
 	}
 	if len(ids) != 2 || ids[0] != "run-due-early" || ids[1] != "run-due-late" {
 		t.Fatalf("due = %v, want [run-due-early run-due-late] (oldest first, future and unarmed excluded)", ids)

--- a/pkg/store/retry.go
+++ b/pkg/store/retry.go
@@ -14,7 +14,7 @@ import (
 // never crosses a queue and retries in-process instead, so there is
 // nothing to sweep there. Callers MUST nil-check via AsRunRetryStore.
 //
-// Both methods are compare-and-swap by design. Arming conditions on the
+// Arming and claiming are compare-and-swap by design. Arming conditions on the
 // run still being failed_resumable and under its attempt budget, so a run
 // an operator resumed by hand in the meantime is not re-armed behind their
 // back. Claiming conditions on the exact retry_after value it read, which
@@ -27,10 +27,15 @@ type RunRetryStore interface {
 	// exhausted budget are ordinary outcomes, not failures. The returned
 	// attempt is the 1-based number of the retry just armed.
 	ScheduleRunRetry(ctx context.Context, runID string, at time.Time, reason, code string, maxAttempts int) (scheduled bool, attempt int, err error)
-	// ClaimRunRetry takes ownership of an armed retry, conditioning on
-	// expectedAfter matching what the caller read. The winner sees
-	// won=true and the retry disarmed; every loser sees won=false.
+	// ClaimRunRetry LEASES an armed retry, conditioning on expectedAfter
+	// matching what the caller read and on no live lease existing. The
+	// winner sees won=true; every loser sees won=false. The retry stays
+	// armed on purpose: a caller that dies before acting would otherwise
+	// strand the run with nothing left to re-list it.
 	ClaimRunRetry(ctx context.Context, runID string, expectedAfter time.Time) (won bool, err error)
+	// ClearRunRetry disarms a retry that has been acted on (the successful
+	// resume's counterpart to ClaimRunRetry's lease).
+	ClearRunRetry(ctx context.Context, runID string) error
 	// AbandonRunRetry records why a run will not be retried again and
 	// leaves the retry disarmed. Used when the cause is permanent
 	// (admission denied, source no longer resolvable) so the run says why

--- a/pkg/store/retry.go
+++ b/pkg/store/retry.go
@@ -1,0 +1,50 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// RunRetryStore is an optional interface a store implements to arm and
+// claim automatic retries for runs that failed on a provider quota window.
+//
+// It is deliberately a CAPABILITY rather than part of RunStore: the wait
+// can be days long, so it needs a durable row a periodic sweeper can scan,
+// which only the cloud (Mongo) store has. The local/filesystem runtime
+// never crosses a queue and retries in-process instead, so there is
+// nothing to sweep there. Callers MUST nil-check via AsRunRetryStore.
+//
+// Both methods are compare-and-swap by design. Arming conditions on the
+// run still being failed_resumable and under its attempt budget, so a run
+// an operator resumed by hand in the meantime is not re-armed behind their
+// back. Claiming conditions on the exact retry_after value it read, which
+// is what makes "exactly one replica resumes this run" true without a
+// leader election — the same shape cloudsched's tick claim uses.
+type RunRetryStore interface {
+	// ScheduleRunRetry arms a retry at `at`, iff the run is still
+	// failed_resumable and has attempts left. Returns scheduled=false
+	// (with no error) when either precondition fails — a lost race and an
+	// exhausted budget are ordinary outcomes, not failures. The returned
+	// attempt is the 1-based number of the retry just armed.
+	ScheduleRunRetry(ctx context.Context, runID string, at time.Time, reason, code string, maxAttempts int) (scheduled bool, attempt int, err error)
+	// ClaimRunRetry takes ownership of an armed retry, conditioning on
+	// expectedAfter matching what the caller read. The winner sees
+	// won=true and the retry disarmed; every loser sees won=false.
+	ClaimRunRetry(ctx context.Context, runID string, expectedAfter time.Time) (won bool, err error)
+	// AbandonRunRetry records why a run will not be retried again and
+	// leaves the retry disarmed. Used when the cause is permanent
+	// (admission denied, source no longer resolvable) so the run says why
+	// it stopped instead of going quiet.
+	AbandonRunRetry(ctx context.Context, runID, reason string) error
+}
+
+// AsRunRetryStore returns s as RunRetryStore when the backend can host
+// durable retry state, or nil otherwise. Callers MUST nil-check
+// (filesystem / local stores return nil).
+func AsRunRetryStore(s RunStore) RunRetryStore {
+	if s == nil {
+		return nil
+	}
+	r, _ := s.(RunRetryStore)
+	return r
+}

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -137,6 +137,51 @@ type RunBudgetRaises struct {
 	MaxDuration   string  `json:"max_duration,omitempty" bson:"max_duration,omitempty"`
 }
 
+// RunRetryPolicy is the launch-time snapshot of the effective retry
+// contract (pkg/retrypolicy), plus where each field came from. The
+// provenance map is not decoration: a four-layer chain is undebuggable
+// without it, and "why is this run waiting 8 days" must be answerable
+// without replaying the launch.
+type RunRetryPolicy struct {
+	UsageWindow string `json:"usage_window,omitempty" bson:"usage_window,omitempty"`
+	MaxAttempts int    `json:"max_attempts,omitempty" bson:"max_attempts,omitempty"`
+	MaxWait     string `json:"max_wait,omitempty" bson:"max_wait,omitempty"`
+	Jitter      string `json:"jitter,omitempty" bson:"jitter,omitempty"`
+	// Sources maps each field name to the layer that won it
+	// ("run_override", "schedule", "bot", "env", "default",
+	// "platform_ceiling").
+	Sources map[string]string `json:"sources,omitempty" bson:"sources,omitempty"`
+}
+
+// RunRetryState is the live retry bookkeeping for a run whose failure is
+// waiting on a provider quota window to reopen.
+//
+// Attempts is MONOTONIC over the run's whole lifetime and is never reset:
+// it is the anti-loop bound, so a run that trips the window on three
+// separate resumes has spent three of its attempts. RetryAfter is unset
+// (nil) once a sweeper claims the retry, which is what makes the claim a
+// compare-and-swap: two replicas cannot both win it.
+type RunRetryState struct {
+	// RetryAfter is when the run becomes eligible for an automatic
+	// resume. Nil = nothing armed (never armed, already claimed, or
+	// deliberately abandoned).
+	RetryAfter *time.Time `json:"retry_after,omitempty" bson:"retry_after,omitempty"`
+	// Reason names the failure class that armed this retry
+	// ("usage_window").
+	Reason string `json:"reason,omitempty" bson:"reason,omitempty"`
+	// Code is the RuntimeError code that armed it
+	// ("USAGE_LIMIT_BLOCKED").
+	Code string `json:"code,omitempty" bson:"code,omitempty"`
+	// Attempts counts retries armed for this run, ever.
+	Attempts int `json:"attempts,omitempty" bson:"attempts,omitempty"`
+	// LastError records why the most recent automatic resume did not
+	// happen (admission denied, unresolvable source, a Resume error), so
+	// a run that stops retrying says why instead of going quiet.
+	LastError string `json:"last_error,omitempty" bson:"last_error,omitempty"`
+	// ClaimedAt stamps when a sweeper last took the retry.
+	ClaimedAt *time.Time `json:"claimed_at,omitempty" bson:"claimed_at,omitempty"`
+}
+
 type Run struct {
 	FormatVersion int    `json:"format_version" bson:"format_version"`
 	ID            string `json:"id" bson:"_id"`
@@ -208,6 +253,19 @@ type Run struct {
 	// rebuilt); raise-only vs the workflow's declared budget. Nil for
 	// runs never raised.
 	BudgetRaises *RunBudgetRaises `json:"budget_raises,omitempty" bson:"budget_raises,omitempty"`
+	// RetryPolicy is the retry contract RESOLVED AT LAUNCH from every
+	// layer that can own one (per-run override → launch surface → bot
+	// manifest → machine default, then clamped by the platform ceiling).
+	// It is resolved server-side because only the launch site can see all
+	// the layers, and snapshotted here because the run doc is the one
+	// carrier every consumer already loads — the runner reads it from the
+	// doc it fetches anyway, so no queue-schema bump is needed and it
+	// never has to query schedules. Nil for runs launched before this
+	// existed; treat nil as the package defaults.
+	RetryPolicy *RunRetryPolicy `json:"retry_policy,omitempty" bson:"retry_policy,omitempty"`
+	// RetryState is the live retry bookkeeping for this run (cloud only).
+	// Nil until a retryable failure arms one. See RunRetryState.
+	RetryState *RunRetryState `json:"retry_state,omitempty" bson:"retry_state,omitempty"`
 	// DeletedAt is the Mongo-side durable tombstone (the filesystem
 	// twin is the .deleted marker file): DeleteRun strips the run's
 	// data and leaves a skeleton doc carrying this stamp, so a late

--- a/pkg/trigger/evaluator.go
+++ b/pkg/trigger/evaluator.go
@@ -138,6 +138,7 @@ func (e *Evaluator) buildPlan(sub Subscription, ev Event) LaunchPlan {
 		RepoURL:         ev.Subject.URL,
 		RepoRef:         ev.Subject.Ref,
 		Event:           ev,
+		Retry:           sub.RetryPolicy(),
 	}
 }
 

--- a/pkg/trigger/launcher.go
+++ b/pkg/trigger/launcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -33,6 +34,12 @@ type LaunchPlan struct {
 	// overlap gate can count this schedule's live runs; other paths
 	// leave it nil.
 	SourceRef *store.RunSource
+	// Retry is the subscription's own retry policy (pkg/retrypolicy) — the
+	// binding layer of the precedence chain. Zero value means the
+	// subscription pins nothing and the bot's manifest / machine default
+	// decide. Carried on the plan rather than re-read by the launcher
+	// because the evaluator is what holds the subscription.
+	Retry retrypolicy.Policy
 }
 
 // Launcher launches a run directly (ExecutionDirect). The production impl

--- a/pkg/trigger/scheduler.go
+++ b/pkg/trigger/scheduler.go
@@ -305,6 +305,7 @@ func (s *Scheduler) fire(ctx context.Context, sub Subscription) {
 		Vars:            vars,
 		KeyOverrides:    sub.KeyOverrides,
 		SecretOverrides: sub.SecretOverrides,
+		Retry:           sub.RetryPolicy(),
 		Event: Event{
 			ID:         "schedule:" + sub.ID,
 			Source:     SourceSchedule,

--- a/pkg/trigger/subscription.go
+++ b/pkg/trigger/subscription.go
@@ -9,6 +9,7 @@ import (
 	"github.com/robfig/cron/v3"
 
 	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 	"github.com/SocialGouv/iterion/pkg/schedgate"
 )
 
@@ -131,6 +132,14 @@ type Subscription struct {
 	// normalizes to schedgate.DefaultStaleAfter. Only meaningful with
 	// Overlap == keepalive.
 	StaleAfter string `json:"stale_after,omitempty" bson:"stale_after,omitempty"`
+	// Retry policy (pkg/retrypolicy) for a run this subscription launches
+	// that dies on an exhausted provider usage window. This is the
+	// binding-level layer: it sits above the bot's manifest and below a
+	// per-run override, and only the fields set here override anything.
+	RetryUsageWindow string `json:"retry_usage_window,omitempty" bson:"retry_usage_window,omitempty"`
+	RetryMaxAttempts int    `json:"retry_max_attempts,omitempty" bson:"retry_max_attempts,omitempty"`
+	RetryMaxWait     string `json:"retry_max_wait,omitempty" bson:"retry_max_wait,omitempty"`
+	RetryJitter      string `json:"retry_jitter,omitempty" bson:"retry_jitter,omitempty"`
 	// Origin records where this subscription came from so dedup and cleanup
 	// are possible: "forge:<repo_integration_id>" (orchestrator-generated,
 	// deleted by Origin on deprovision), "operator" (studio), "schedule.yaml"
@@ -174,6 +183,18 @@ func (s Subscription) Policy() schedgate.Policy {
 		GuardVar:      s.GuardVar,
 		StaleAfter:    s.StaleAfter,
 	})
+}
+
+// RetryPolicy projects the subscription's retry fields. Not normalized —
+// this is one layer of a precedence chain, and defaults filled here would
+// masquerade as an explicit binding-level choice.
+func (s Subscription) RetryPolicy() retrypolicy.Policy {
+	return retrypolicy.Policy{
+		UsageWindow: s.RetryUsageWindow,
+		MaxAttempts: s.RetryMaxAttempts,
+		MaxWait:     s.RetryMaxWait,
+		Jitter:      s.RetryJitter,
+	}
 }
 
 // EffectiveMode returns the subscription's execution mode, defaulting an empty

--- a/pkg/webhooks/types.go
+++ b/pkg/webhooks/types.go
@@ -14,6 +14,8 @@ package webhooks
 import (
 	"strings"
 	"time"
+
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 )
 
 // Provider identifies the external event source.
@@ -191,6 +193,20 @@ type Config struct {
 	// bot identities. See docs/byok.md.
 	SecretOverrides map[string]string `bson:"secret_overrides,omitempty" json:"secret_overrides,omitempty"`
 
+	// Retry policy (pkg/retrypolicy) for a run launched through this
+	// webhook that dies on an exhausted provider usage window. The
+	// launch-surface layer, same role the equivalent fields play on a
+	// schedule row or a trigger subscription: only what is set here
+	// overrides the bot's manifest and the machine default.
+	//
+	// A webhook-launched run is often the one an author is WAITING on (a
+	// PR review), so a shorter max_wait than a nightly's is usually the
+	// right call — a review that lands three days late is not a review.
+	RetryUsageWindow string `bson:"retry_usage_window,omitempty" json:"retry_usage_window,omitempty"`
+	RetryMaxAttempts int    `bson:"retry_max_attempts,omitempty" json:"retry_max_attempts,omitempty"`
+	RetryMaxWait     string `bson:"retry_max_wait,omitempty" json:"retry_max_wait,omitempty"`
+	RetryJitter      string `bson:"retry_jitter,omitempty" json:"retry_jitter,omitempty"`
+
 	// AuthorizedRepliers + MinReplierRole gate who may "talk back" to the bot
 	// via a note (a /revi command or a reply): a note author is authorized
 	// when they are in AuthorizedRepliers (usernames with/without @, or numeric
@@ -348,3 +364,15 @@ const (
 	StatusLaunched      = "launched"
 	StatusLaunchError   = "launch_error"
 )
+
+// RetryPolicy projects the webhook's retry fields. Not normalized — this
+// is one layer of a precedence chain, and defaults filled here would
+// masquerade as an explicit per-webhook choice.
+func (c Config) RetryPolicy() retrypolicy.Policy {
+	return retrypolicy.Policy{
+		UsageWindow: c.RetryUsageWindow,
+		MaxAttempts: c.RetryMaxAttempts,
+		MaxWait:     c.RetryMaxWait,
+		Jitter:      c.RetryJitter,
+	}
+}

--- a/studio/src/api/runs/types.ts
+++ b/studio/src/api/runs/types.ts
@@ -66,6 +66,12 @@ export interface RunSummary {
   finished_at?: string;
   error?: string;
   active: boolean;
+  // When a failed_resumable run will be resumed automatically, once the
+  // provider quota window that killed it reopens. Absent when no retry is
+  // armed — which is the distinction worth rendering: a run that resumes
+  // in 33h and one that never will are both "failed_resumable" otherwise.
+  retry_after?: string;
+  retry_attempts?: number;
   // Worktree finalization summary; empty for non-worktree runs or
   // runs that never reached a clean exit.
   final_commit?: string;

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -4831,6 +4831,9 @@ export interface components {
             project_path?: string;
             queue_position?: number;
             repo_root?: string;
+            /** Format: date-time */
+            retry_after?: string;
+            retry_attempts?: number;
             shard_count?: number;
             shard_index?: number;
             shard_label?: string;

--- a/studio/src/components/Runs/runList/RunListCard.tsx
+++ b/studio/src/components/Runs/runList/RunListCard.tsx
@@ -14,6 +14,8 @@ import { BotAvatar } from "./BotAvatar";
 import {
   formatDuration,
   friendlyLabel,
+  retryAttemptLabel,
+  retryHint,
   shortRunID,
   workflowDisplay,
 } from "./runListFormat";
@@ -44,6 +46,13 @@ export const RunListCard = memo(function RunListCard({
         <Badge variant={STATUS_VARIANT[run.status]}>
           {labelForStatus(run.status)}
         </Badge>
+        {/* A parked run is waiting, not dead — say so next to the status
+            that would otherwise read as final. */}
+        {retryHint(run) && (
+          <Badge variant="info" title={retryAttemptLabel(run)}>
+            {retryHint(run)}
+          </Badge>
+        )}
         <SourceBadge run={run} />
         {run.active && (
           <LiveDot tone="live" size="sm" label="Active in this process" />

--- a/studio/src/components/Runs/runList/runListFormat.test.ts
+++ b/studio/src/components/Runs/runList/runListFormat.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import type { RunSummary } from "@/api/runs";
+
+import { retryAttemptLabel, retryHint } from "./runListFormat";
+
+// A run parked on an exhausted provider quota window stays
+// failed_resumable while it waits. Without this hint it is visually
+// identical to a run that will never come back — which is how an operator
+// ends up resuming by hand something already scheduled, or writing off
+// something that was going to recover on its own.
+
+const NOW = Date.parse("2026-07-27T06:00:00Z");
+
+function run(over: Partial<RunSummary> = {}): RunSummary {
+  return {
+    id: "019fa228",
+    workflow_name: "feed_watch",
+    status: "failed_resumable",
+    created_at: "2026-07-27T06:00:00Z",
+    updated_at: "2026-07-27T06:00:00Z",
+    active: false,
+    ...over,
+  } as RunSummary;
+}
+
+describe("retryHint", () => {
+  it("is empty when no retry is armed", () => {
+    expect(retryHint(run(), NOW)).toBe("");
+  });
+
+  it("renders hours for a same-day-ish reset", () => {
+    // The incident's shape: a weekly cap resetting ~39h out.
+    expect(
+      retryHint(run({ retry_after: "2026-07-28T21:00:00Z" }), NOW),
+    ).toBe("retrying in 39h");
+  });
+
+  it("renders minutes under an hour", () => {
+    expect(
+      retryHint(run({ retry_after: "2026-07-27T06:45:00Z" }), NOW),
+    ).toBe("retrying in 45m");
+  });
+
+  it("renders days past 48h so a weekly wait stays readable", () => {
+    expect(
+      retryHint(run({ retry_after: "2026-08-02T06:00:00Z" }), NOW),
+    ).toBe("retrying in 6d");
+  });
+
+  it("never renders a negative duration", () => {
+    // The sweeper polls, so "due" and "running again" are a minute apart.
+    expect(
+      retryHint(run({ retry_after: "2026-07-27T05:00:00Z" }), NOW),
+    ).toBe("retrying soon");
+  });
+
+  it("rounds a sub-minute wait up rather than showing 0m", () => {
+    expect(
+      retryHint(run({ retry_after: "2026-07-27T06:00:20Z" }), NOW),
+    ).toBe("retrying in 1m");
+  });
+
+  it("ignores an unparseable instant instead of rendering NaN", () => {
+    expect(retryHint(run({ retry_after: "not-a-date" }), NOW)).toBe("");
+  });
+});
+
+describe("retryAttemptLabel", () => {
+  it("is empty when nothing has been attempted", () => {
+    expect(retryAttemptLabel(run())).toBe("");
+    expect(retryAttemptLabel(run({ retry_attempts: 0 }))).toBe("");
+  });
+
+  it("names the attempt for the tooltip", () => {
+    expect(retryAttemptLabel(run({ retry_attempts: 2 }))).toBe(
+      "automatic retry 2",
+    );
+  });
+});

--- a/studio/src/components/Runs/runList/runListFormat.ts
+++ b/studio/src/components/Runs/runList/runListFormat.ts
@@ -86,3 +86,33 @@ export function formatDuration(startISO: string, endISO?: string): string {
   const remMin = minutes % 60;
   return `${hours}h ${remMin}m`;
 }
+
+// retryHint renders the pending automatic retry of a run parked on an
+// exhausted provider quota window ("retrying in 33h"), or "" when none is
+// armed.
+//
+// This is the whole reason the field is surfaced: a failed_resumable row
+// that WILL resume and one that never will are otherwise identical, so a
+// waiting run reads as a dead one and gets resumed by hand — or worse,
+// written off. An instant already in the past renders as "retrying soon"
+// rather than a negative duration: the sweeper polls, so "due" and
+// "running again" are a minute apart.
+export function retryHint(run: RunSummary, now: number = Date.now()): string {
+  if (!run.retry_after) return "";
+  const at = Date.parse(run.retry_after);
+  if (Number.isNaN(at)) return "";
+  const ms = at - now;
+  if (ms <= 0) return "retrying soon";
+  const minutes = Math.round(ms / 60000);
+  if (minutes < 60) return `retrying in ${Math.max(1, minutes)}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `retrying in ${hours}h`;
+  return `retrying in ${Math.round(hours / 24)}d`;
+}
+
+// retryAttemptLabel renders the run's position in its attempt budget, for
+// the tooltip beside retryHint. Empty when nothing has been attempted.
+export function retryAttemptLabel(run: RunSummary): string {
+  if (!run.retry_attempts) return "";
+  return `automatic retry ${run.retry_attempts}`;
+}


### PR DESCRIPTION
## Why

On Monday 2026-07-27, **seven scheduled prod runs died within 45 minutes** on the same wall:

```
rate_limited (claude_code): You've hit your weekly limit · resets Jul 28, 9pm (UTC)
```

Five feed-watch digests, the weekly Doki, and a review-pr. Not a dead token — the forfait's **weekly quota**. The four weekly digests would not have retried until 2026-08-03.

Worse than "no retry": each failure nak'd into **8 JetStream redeliveries** — one fresh pod per attempt, against a reset ~35h away — then parked in the DLQ. 11 of the 30 DLQ entries were this exact cause, going back to 2026-07-21.

## Three defects, none visible from one side alone

The repo already claimed to have a reset-aware wait. It could not work on any path:

1. **The typed error was flattened.** A terminal node failure was rebuilt as a plain string, destroying both the classified code and the `*delegate.ErrRateLimited` carrying `ResetAt` — so `errors.As` in the auto-resume loop could never match, and every host saw `EXECUTION_FAILED` whatever the cause.
2. **The cloud runner wired no recovery dispatcher.** Every other host does; `recovery.Classify` was never called on the one surface that runs unattended.
3. **The reset parser could not read the shape a weekly cap prints.** `resets Jul 28, 9pm (UTC)` matched nothing (the pattern required a digit right after `resets`), yielding a zero `ResetAt` for precisely the window whose reset is furthest away.

A fourth was introduced and caught here: the Mongo attempts filter used a bare `{$lt: n}`, and comparison operators are type-bracketed — it does not match a document where the field is absent. **Every run's first retry would have been silently refused.** Found by testing against a real replica set; verified both ways.

## What ships

- **The runner acks and persists when to come back** instead of naking into 8 doomed pods — same shape as the `ErrBudgetExceeded` carve-out beside it. Failing to persist falls THROUGH to today's behaviour rather than acking, because acking without a durable intent drops the run silently.
- **A server sweeper resumes at the reset.** The wait cannot live in the queue (24h max age, no delayed nak, vs a 7-day reset), so it lives in Mongo. Claim-then-act CAS makes it multi-replica safe; it never passes `Force`, because after a multi-day wait a hash mismatch means the bot was redeployed.
- **`pkg/retrypolicy`** — configurable on six wired surfaces (per-run override → schedule row / webhook config / trigger subscription / `schedules.yaml` → bot `manifest.yaml` → env), resolved **per field** with provenance, plus a platform ceiling that can only lower.
- **The wait is visible**: `retry_after` on `RunSummary`, rendered as "retrying in 39h" beside the status; `run_retry_scheduled` + `run_auto_resumed` events; team audit `run.retry.*`; four metrics (scheduled vs resumed as a deliberate pair — a growing gap is the silent failure mode).
- **`WithRecoveryDispatch` wired into the cloud runner**, which had been getting strictly less recovery than a local `iterion run` of the same bot.

## Also here

Two fixes salvaged from the Doki catch-up run whose 71 commits were discarded:
- `Taskfile.yml` `test:live:feat:rtk` ran `-run 'TestLive_Feat_Rtk$'`, matching **no test**. `go test -run` with no match exits 0, so a live-cost target passed green while executing nothing.
- The unknown-forge-event error listed two of the three valid events, so an author declaring the valid `issue_labeled` was told it was unknown. Now derived from `KnownForgeEvents`.

## Verification

`task check` green (1031 tests, golangci-lint included). Mongo CAS proven against a real replica set. The seam test crossing delegate → `Classify` → engine failure fails before the fix and passes after — that seam was untested, which is how both defects survived.

**Not yet proven live**: "1 pod instead of 8" needs this deployed. Bilans in `docs/bot-runs/{feed-watch,docs-refresh}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
