### PR TITLE
fix: a malformed review comment no longer costs the review and the merge gate

### DIFF
--- a/pkg/server/forge_publish.go
+++ b/pkg/server/forge_publish.go
@@ -174,6 +174,14 @@ type publishReviewResponse struct {
 	GateContext string `json:"gate_context,omitempty"`
 	GateSHA     string `json:"gate_sha,omitempty"`
 	GateError   string `json:"gate_error,omitempty"`
+	// SkippedReason explains a publish that did not land (a forge error).
+	// Present with published=false; the gate may still have been posted.
+	SkippedReason string `json:"skipped_reason,omitempty"`
+	// DroppedComments lists comments the request carried that could not be
+	// anchored (no path, no positive line, or no body). They are dropped
+	// rather than fatal, but reported so the caller's output contract can be
+	// fixed instead of the loss going unnoticed.
+	DroppedComments []string `json:"dropped_comments,omitempty"`
 }
 
 // handleForgePublishReview authenticates the per-run token, validates the
@@ -223,11 +231,34 @@ func (s *Server) handleForgePublishReview(w http.ResponseWriter, r *http.Request
 		httpError(w, http.StatusBadRequest, "nothing to publish: summary and comments are both empty")
 		return
 	}
+	// Unanchorable comments are DROPPED, not fatal. Rejecting the batch on
+	// one bad entry cost a whole review — and, because the merge gate is
+	// posted after a successful publish, the gate status with it. A reviewer
+	// that legitimately produces a finding it cannot anchor to a file+line
+	// (an architectural observation, a cross-file concern) must not be able
+	// to take the anchored findings and the merge signal down with it.
+	//
+	// They are reported back in the response (dropped_comments) rather than
+	// swallowed: the bot's output contract is still wrong, and a silent drop
+	// would hide that.
+	kept := make([]publishReviewComment, 0, len(req.Comments))
+	var droppedComments []string
 	for i, c := range req.Comments {
 		if strings.TrimSpace(c.Path) == "" || c.Line <= 0 || strings.TrimSpace(c.Body) == "" {
-			httpError(w, http.StatusBadRequest, "comment %d: path, positive line and body are required", i)
-			return
+			droppedComments = append(droppedComments,
+				fmt.Sprintf("comment %d: needs a path, a positive line and a body", i))
+			continue
 		}
+		kept = append(kept, c)
+	}
+	req.Comments = kept
+	// Everything unpublishable is only a hard error when NOTHING is left to
+	// say — a review with no summary and no anchorable comment has no
+	// content, which is a different failure from a malformed one.
+	if strings.TrimSpace(req.Summary) == "" && len(req.Comments) == 0 {
+		httpError(w, http.StatusBadRequest, "nothing publishable: summary is empty and every comment was unanchorable (%s)",
+			strings.Join(droppedComments, "; "))
+		return
 	}
 
 	conn, err := s.forgeConnections.Get(r.Context(), grant.ConnectionID)
@@ -263,9 +294,29 @@ func (s *Server) handleForgePublishReview(w http.ResponseWriter, r *http.Request
 		review.Body += "\n\n" + forge.FoldCommentsMarkdown(toForgeComments(req.Comments))
 	}
 
-	res, err := rc.CreatePullReview(r.Context(), grant.Repo, number, review)
-	if err != nil {
-		httpError(w, http.StatusBadGateway, "create pull review: %v", err)
+	res, reviewErr := rc.CreatePullReview(r.Context(), grant.Repo, number, review)
+	if reviewErr != nil {
+		// The gate is a COUNT the bot already computed; it does not depend on
+		// the comments landing. Post it before giving up, then report the
+		// publish failure. Coupling the two meant one forge hiccup left the
+		// PR's required check permanently absent — indistinguishable from
+		// "never reviewed", and unblockable by another review.
+		gate := s.postGateStatus(r.Context(), conn, grant.Repo, number, req.Gate, "")
+		if s.logger != nil {
+			s.logger.Warn("forge publish: %s %s#%d review failed (%v); gate posted=%v state=%q",
+				conn.Provider, grant.Repo, number, reviewErr, gate.posted, gate.state)
+		}
+		writeJSONStatus(w, http.StatusBadGateway, publishReviewResponse{
+			Published:       false,
+			Provider:        string(conn.Provider),
+			SkippedReason:   fmt.Sprintf("create pull review: %v", reviewErr),
+			DroppedComments: droppedComments,
+			GatePosted:      gate.posted,
+			GateState:       gate.state,
+			GateContext:     gate.context,
+			GateSHA:         gate.sha,
+			GateError:       gate.errText,
+		})
 		return
 	}
 	if s.logger != nil {
@@ -293,6 +344,7 @@ func (s *Server) handleForgePublishReview(w http.ResponseWriter, r *http.Request
 		SuggestionsPosted: res.SuggestionsPosted,
 		Verified:          res.Verified,
 		Fallback:          res.Fallback,
+		DroppedComments:   droppedComments,
 		GatePosted:        gate.posted,
 		GateState:         gate.state,
 		GateContext:       gate.context,

--- a/pkg/server/forge_publish_test.go
+++ b/pkg/server/forge_publish_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -140,7 +141,10 @@ func TestForgePublishReview_ValidationFailures(t *testing.T) {
 		{"repo mismatch", `{"pr_url": "https://github.com/other/repo/pull/42", "summary": "x"}`, http.StatusForbidden},
 		{"bad mode", `{"pr_url": "https://github.com/o/r/pull/42", "summary": "x", "mode": "yolo"}`, http.StatusBadRequest},
 		{"empty payload", `{"pr_url": "https://github.com/o/r/pull/42"}`, http.StatusBadRequest},
-		{"bad comment", `{"pr_url": "https://github.com/o/r/pull/42", "summary": "x", "comments": [{"path": "", "line": 0, "body": ""}]}`, http.StatusBadRequest},
+		// A malformed comment is no longer fatal when there is still
+		// something to say — see TestForgePublishReview_DropsUnanchorableComments.
+		// It stays fatal only when nothing publishable remains.
+		{"unanchorable comment and no summary", `{"pr_url": "https://github.com/o/r/pull/42", "comments": [{"path": "", "line": 0, "body": ""}]}`, http.StatusBadRequest},
 	}
 	for _, tc := range cases {
 		w := httptest.NewRecorder()
@@ -282,5 +286,88 @@ func TestForgePublishReview_HostMismatchRejected(t *testing.T) {
 	}
 	if fake.calls != 0 {
 		t.Fatal("forge client must not be reached on host mismatch")
+	}
+}
+
+// A reviewer legitimately produces findings it cannot anchor to a file+line
+// (an architectural observation, a cross-file concern). Rejecting the batch
+// on one of those used to cost the whole review — and, because the merge gate
+// is posted after a successful publish, the required check with it. That is
+// how PR #304 ended up with a permanently absent revi/review status.
+func TestForgePublishReview_DropsUnanchorableComments(t *testing.T) {
+	s, fake := newForgePublishTestServer(t)
+	registerPublishToken(t, s, "tok1", ForgePublishGrant{TeamID: "team1", ConnectionID: "conn1", Repo: "o/r"})
+
+	body := `{
+  "pr_url": "https://github.com/o/r/pull/42",
+  "summary": "review summary",
+  "comments": [
+    {"path": "a.go", "line": 3, "body": "anchored finding"},
+    {"path": "", "line": 0, "body": "architectural observation with nowhere to hang"},
+    {"path": "b.go", "line": 0, "body": "no line"}
+  ]
+}`
+	w := httptest.NewRecorder()
+	s.handleForgePublishReview(w, publishReq("tok1", body))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	var res publishReviewResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !res.Published {
+		t.Error("published = false: the anchored finding and the summary must still land")
+	}
+	if len(res.DroppedComments) != 2 {
+		t.Errorf("dropped_comments = %v, want 2 — a silent drop hides the caller's broken contract", res.DroppedComments)
+	}
+	// Only the anchorable comment reaches the forge.
+	if len(fake.in.Comments) != 1 || fake.in.Comments[0].Path != "a.go" {
+		t.Errorf("forge received %+v, want only the a.go comment", fake.in.Comments)
+	}
+}
+
+// The gate is a COUNT the bot already computed; it does not depend on the
+// comments landing. Coupling them meant one forge hiccup left the PR's
+// required check absent — indistinguishable from "never reviewed", and
+// unblockable by another review.
+func TestForgePublishReview_GatePostedEvenWhenTheReviewFails(t *testing.T) {
+	s, fake := newForgePublishTestServer(t)
+	registerPublishToken(t, s, "tok1", ForgePublishGrant{TeamID: "team1", ConnectionID: "conn1", Repo: "o/r"})
+	fake.err = errors.New("forge exploded")
+
+	gate := &fakeGateClient{headSHA: "deadbeef"}
+	s.forgeGateClientFor = func(_ context.Context, _ forge.Connection) (forgeGateClient, error) {
+		return gate, nil
+	}
+
+	body := `{
+  "pr_url": "https://github.com/o/r/pull/42",
+  "summary": "review summary",
+  "gate": {"enabled": true, "context": "revi/review", "blocking_count": 0, "threshold": "high", "total_findings": 2}
+}`
+	w := httptest.NewRecorder()
+	s.handleForgePublishReview(w, publishReq("tok1", body))
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502 — the publish failure must still be reported", w.Code)
+	}
+	var res publishReviewResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if res.Published {
+		t.Error("published = true despite a forge error")
+	}
+	if res.SkippedReason == "" {
+		t.Error("skipped_reason empty: a failed publish must say why")
+	}
+	if !res.GatePosted {
+		t.Fatal("gate_posted = false — the required check stays absent and the PR can never merge")
+	}
+	if gate.setCalls == 0 {
+		t.Error("the forge never received a commit status")
 	}
 }


### PR DESCRIPTION
## Why

Found by hitting it live on #304, which had to be merged with an admin bypass because of it.

`revi/review` is a **required** check. The merge gate that posts it was only reached **after a successful publish** — so any publish failure left the required context permanently **absent** on the PR head: indistinguishable from "never reviewed", and unblockable by another review, because every review failed the same way.

The trigger was the second coupling: comment validation was **all-or-nothing**. Revi legitimately produces findings it cannot anchor to a file+line (its own first review on #304 had a section titled *"Findings that could not be anchored inline"*). One such comment sent as inline → `400 comment 1: path, positive line and body are required` → the whole review lost, and the gate with it.

## What changes

- **Unanchorable comments are dropped, not fatal**, and reported back in `dropped_comments`. Dropped rather than fatal so one bad entry cannot take the anchored findings down; reported rather than swallowed because the caller's output contract is still wrong and a silent drop would hide it. It stays a hard error only when *nothing publishable* remains — a different failure from a malformed one.
- **The gate is posted even when the publish fails.** It is a count the bot already computed; it does not depend on the comments landing. The response now reports both halves (`published=false` + `skipped_reason` + `gate_posted`), so a caller can tell "review didn't land" from "gate didn't post".

## Verification

`task check` green apart from one flake (see below). Both new tests were checked in **both directions** — they fail with the coupling restored and pass with it removed:

- `TestForgePublishReview_DropsUnanchorableComments` — the anchored finding and the summary still land, the two unanchorable ones are reported, and only the anchorable comment reaches the forge.
- `TestForgePublishReview_GatePostedEvenWhenTheReviewFails` — 502 is still returned (the failure is not hidden) but `gate_posted=true` and the forge did receive a commit status.

`TestForgePublishReview_ValidationFailures` is updated: a malformed comment *with a summary* is no longer a 400. The 400 case is now "unanchorable comment **and** no summary".

### Note on the flake

`pkg/cli`'s subbot test failed once in my local `task check` and passes 2/2 on re-run, on a branch that touches only `forge_publish.go`. It is the **fourth distinct** timing-sensitive test to flake during this work (after `pkg/runview` park/resume, `TestDispatcherE2E_CancelInFlight`, and `TestRunsWS_AlertEventBypassesSnapshotDedup` on main). With `test`/`race` as required checks behind a merge queue, that churn is worth its own fix — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
