### PR TITLE
feat(reviews+deps): one merge gate per repo, and Vetty guards Renovate PRs end-to-end

### DIFF
--- a/bots/adr-cartograph/skills/verify-build.md
+++ b/bots/adr-cartograph/skills/verify-build.md
@@ -22,7 +22,17 @@ and the correct toolchain:
 
 - **Task runner / Makefile** — `Taskfile.yml` → `task build` / `task test` /
   `task check`; `Makefile` → `make build` / `make test`; `Justfile` → `just …`.
-  This is almost always the right answer when present.
+  This is almost always the right answer when present. List the targets that
+  actually exist (`task --list`, `make -qp`, `just --list`) instead of assuming
+  the conventional names: plenty of repos have `test` and `lint` but no `check`
+  umbrella, and a verify.sh calling a target that does not exist fails for a
+  reason that has nothing to do with the change under test.
+- **A gate CI runs inline is still a gate.** When CI invokes something the task
+  runner does not expose — a coverage threshold script, a schema check, a
+  shell assertion — copy that invocation into verify.sh verbatim. `task test`
+  passing while CI's `go test … && bash hack/coverage.sh cover.out 85` fails is
+  a green local verify on a red change, which is the exact failure the
+  deterministic gate exists to prevent.
 - **Pinned toolchain — honour it or the build fails on a version mismatch.**
   `devbox.json` → prefix with `devbox run -- …`. `.tool-versions` (asdf/mise),
   `.nvmrc`, `flake.nix`, `mise.toml` → activate accordingly. For Go: if

--- a/bots/app-dev/skills/verify-build.md
+++ b/bots/app-dev/skills/verify-build.md
@@ -22,7 +22,17 @@ and the correct toolchain:
 
 - **Task runner / Makefile** — `Taskfile.yml` → `task build` / `task test` /
   `task check`; `Makefile` → `make build` / `make test`; `Justfile` → `just …`.
-  This is almost always the right answer when present.
+  This is almost always the right answer when present. List the targets that
+  actually exist (`task --list`, `make -qp`, `just --list`) instead of assuming
+  the conventional names: plenty of repos have `test` and `lint` but no `check`
+  umbrella, and a verify.sh calling a target that does not exist fails for a
+  reason that has nothing to do with the change under test.
+- **A gate CI runs inline is still a gate.** When CI invokes something the task
+  runner does not expose — a coverage threshold script, a schema check, a
+  shell assertion — copy that invocation into verify.sh verbatim. `task test`
+  passing while CI's `go test … && bash hack/coverage.sh cover.out 85` fails is
+  a green local verify on a red change, which is the exact failure the
+  deterministic gate exists to prevent.
 - **Pinned toolchain — honour it or the build fails on a version mismatch.**
   `devbox.json` → prefix with `devbox run -- …`. `.tool-versions` (asdf/mise),
   `.nvmrc`, `flake.nix`, `mise.toml` → activate accordingly. For Go: if

--- a/bots/branch-improve-loop/skills/verify-build.md
+++ b/bots/branch-improve-loop/skills/verify-build.md
@@ -22,7 +22,17 @@ and the correct toolchain:
 
 - **Task runner / Makefile** — `Taskfile.yml` → `task build` / `task test` /
   `task check`; `Makefile` → `make build` / `make test`; `Justfile` → `just …`.
-  This is almost always the right answer when present.
+  This is almost always the right answer when present. List the targets that
+  actually exist (`task --list`, `make -qp`, `just --list`) instead of assuming
+  the conventional names: plenty of repos have `test` and `lint` but no `check`
+  umbrella, and a verify.sh calling a target that does not exist fails for a
+  reason that has nothing to do with the change under test.
+- **A gate CI runs inline is still a gate.** When CI invokes something the task
+  runner does not expose — a coverage threshold script, a schema check, a
+  shell assertion — copy that invocation into verify.sh verbatim. `task test`
+  passing while CI's `go test … && bash hack/coverage.sh cover.out 85` fails is
+  a green local verify on a red change, which is the exact failure the
+  deterministic gate exists to prevent.
 - **Pinned toolchain — honour it or the build fails on a version mismatch.**
   `devbox.json` → prefix with `devbox run -- …`. `.tool-versions` (asdf/mise),
   `.nvmrc`, `flake.nix`, `mise.toml` → activate accordingly. For Go: if

--- a/bots/dep-update-guard/devbox.json
+++ b/bots/dep-update-guard/devbox.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.17.2/.schema/devbox.schema.json",
+  "packages": [
+    "go-containerregistry@0.21.6"
+  ],
+  "env": {
+    "DEVBOX_NO_PROMPT": "true"
+  }
+}

--- a/bots/dep-update-guard/devbox.lock
+++ b/bots/dep-update-guard/devbox.lock
@@ -1,0 +1,89 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2026-07-24T05:48:35Z",
+      "resolved": "github:NixOS/nixpkgs/335f0738cb2fa9708f3f428e39d2eae975d1338d?lastModified=1784872115&narHash=sha256-THPEF2po0fsoH8gNtp%2BAe0XFDJH3N%2Fol7xO3v6VMTJU%3D"
+    },
+    "go-containerregistry@0.21.6": {
+      "last_modified": "2026-07-23T05:10:05Z",
+      "resolved": "github:NixOS/nixpkgs/7525d999cd850b9a488817abc89c75dc733acf17#go-containerregistry",
+      "source": "devbox-search",
+      "version": "0.21.6",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/782bxm18ffjgh5f0h5qr5daycrqsg6fz-go-containerregistry-0.21.6",
+              "default": true
+            },
+            {
+              "name": "crane",
+              "path": "/nix/store/0hkyimfphs5ibi65biwzfv97ljay2gp8-go-containerregistry-0.21.6-crane"
+            },
+            {
+              "name": "gcrane",
+              "path": "/nix/store/1vhagy5vzrrkh10wsf0nm3dxxks3j9qq-go-containerregistry-0.21.6-gcrane"
+            }
+          ],
+          "store_path": "/nix/store/782bxm18ffjgh5f0h5qr5daycrqsg6fz-go-containerregistry-0.21.6"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/mzxblyfmk0nz9z1nvd96mw8fgka6mxr1-go-containerregistry-0.21.6",
+              "default": true
+            },
+            {
+              "name": "gcrane",
+              "path": "/nix/store/5wpy1kacznvn8y20wgq36z8pkfjr8zhb-go-containerregistry-0.21.6-gcrane"
+            },
+            {
+              "name": "crane",
+              "path": "/nix/store/fypsnj5vhavy099rll5wx53phcl8xqwd-go-containerregistry-0.21.6-crane"
+            }
+          ],
+          "store_path": "/nix/store/mzxblyfmk0nz9z1nvd96mw8fgka6mxr1-go-containerregistry-0.21.6"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/l80xya29xp87kndj8hn2niw4qjm98p7y-go-containerregistry-0.21.6",
+              "default": true
+            },
+            {
+              "name": "crane",
+              "path": "/nix/store/bwd0aidl32sxxihmnrrnd9i1czh5acvk-go-containerregistry-0.21.6-crane"
+            },
+            {
+              "name": "gcrane",
+              "path": "/nix/store/bj5vdr5lzq874hflzd8fl73q698s9gv9-go-containerregistry-0.21.6-gcrane"
+            }
+          ],
+          "store_path": "/nix/store/l80xya29xp87kndj8hn2niw4qjm98p7y-go-containerregistry-0.21.6"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hczn0apy17cxc5xdv6qf6hi6ndl9p08l-go-containerregistry-0.21.6",
+              "default": true
+            },
+            {
+              "name": "crane",
+              "path": "/nix/store/x10mi2vz59ga5ksj51qp3i5gsdkxk5w0-go-containerregistry-0.21.6-crane"
+            },
+            {
+              "name": "gcrane",
+              "path": "/nix/store/mjsa6hy802jqafp6q6aaj14hybf25xlb-go-containerregistry-0.21.6-gcrane"
+            }
+          ],
+          "store_path": "/nix/store/hczn0apy17cxc5xdv6qf6hi6ndl9p08l-go-containerregistry-0.21.6"
+        }
+      }
+    }
+  }
+}

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -89,6 +89,36 @@ vars:
   ## default — Vetty's primary sink is the PR comment.
   post_to_board: bool = false
 
+  ## MERGE GATE. When set, the feedback step also posts a commit status on
+  ## the PR head SHA carrying Vetty's verdict: `success` only when the bump
+  ## was audited safe AND the deterministic verify gate was green. Add the
+  ## context to the repo's required checks to make it BLOCK the merge; leave
+  ## it out and it is an advisory check. The verdict is a TABLE over the
+  ## verdict the graph already computed — never a judgment made here.
+  ##
+  ## A run's forge_token can never post a status (the runtime token is minted
+  ## without that permission on purpose), so the gate necessarily rides the
+  ## server's publish endpoint below. No endpoint, no gate — stated as such
+  ## rather than silently skipped.
+  gate_enabled: bool = true
+
+  ## The commit-status CONTEXT — the name in the repo's required checks. A
+  ## required check applies to EVERY PR, so on a repo where a reviewer takes
+  ## the human PRs and Vetty takes the bot's, both must post the SAME
+  ## context: whichever bot did not run would otherwise leave the check
+  ## permanently absent and block the PR. Pin the shared name per repo via
+  ## the integration's launch_vars.
+  gate_context: string = "vetty/deps"
+
+  ## Deterministic forge publish grant — INJECTED BY THE ITERION SERVER at
+  ## launch when the run's team has a forge connection covering pr_url's
+  ## repo. Declaring them here is the whole opt-in (undeclared launch vars
+  ## are dropped by the IR, so the injection is safe and generic). Empty on
+  ## a local run → the feedback falls back to a direct forge comment, with
+  ## no gate.
+  forge_publish_url: string = ""
+  forge_publish_token: string = ""
+
   ## Out-of-tree scratch for the deterministic gate’s verify script/log
   ## (${PROJECT_SCRATCH_DIR} resolves outside the PR checkout — never
   ## pollute the PR branch).
@@ -455,12 +485,21 @@ schema feedback_output:
   comment_url: string
   skipped_reason: string
   summary: string
+  ## gate_posted: the commit status carrying the verdict actually landed.
+  gate_posted: bool
+  gate_state: string
+  ## gate_skipped_reason: why no status landed. A gate that is required and
+  ## absent blocks the PR forever, so the reason has to be visible.
+  gate_skipped_reason: string
 
 schema feedback_health_input:
   posted: bool
   comment_url: string
   skipped_reason: string
   pr_url: string
+  gate_enabled: bool
+  gate_posted: bool
+  gate_skipped_reason: string
 
 schema feedback_health_output:
   degraded: bool
@@ -762,13 +801,20 @@ tool post_feedback:
     escalation = {{input.escalation}}
     commit_summary = {{input.commit_summary}}
     token_ref = {{secrets.forge_token.path}}
+    pub_url = {{vars.forge_publish_url}}
+    pub_token = {{vars.forge_publish_token}}
+    gate_enabled = {{vars.gate_enabled}}
+    gate_context = {{vars.gate_context}}
 
     def s(x):
         return (x or "").strip() if isinstance(x, str) else ("" if x is None else str(x).strip())
 
-    def out(posted, comment_url="", skipped_reason="", summary=""):
+    def out(posted, comment_url="", skipped_reason="", summary="",
+            gate_posted=False, gate_state="", gate_skipped_reason=""):
         print(json.dumps({"posted": bool(posted), "comment_url": comment_url or "",
-                          "skipped_reason": skipped_reason or "", "summary": summary or ""}))
+                          "skipped_reason": skipped_reason or "", "summary": summary or "",
+                          "gate_posted": bool(gate_posted), "gate_state": gate_state or "",
+                          "gate_skipped_reason": gate_skipped_reason or ""}))
         raise SystemExit(0)
 
     if not s(pr_url):
@@ -800,21 +846,77 @@ tool post_feedback:
            "hold_unstable": "Held — build/tests not green.",
            "needs_decision": "Escalated for a human decision.",
            "clean": "Nothing to align."}.get(s(verdict), "")
-    did = (s(commit_summary) + " " if s(commit_summary) else "") + did + " **Vetty did NOT merge.**"
+    did = (s(commit_summary) + " " if s(commit_summary) else "") + did + \
+        " **Vetty never merges** — it reports a verdict; the merge stays with the repo's own required checks."
     section("What Vetty did", did)
     parts.append("_\U0001F916 Posted by Vetty (dep-update-guard) — deterministic feedback._")
     body = "\n".join(parts)
+
+    # DETERMINISTIC gate verdict: a table over the verdict the graph already
+    # computed from audit_gate / align_gate / validate_gate. Never a judgment
+    # made here, and never a re-read of a model field. An unknown verdict is a
+    # state we did not anticipate, so it BLOCKS — a gate that fails open is
+    # worse than no gate.
+    GATE_BLOCKING = {"clean": 0, "committed": 0,
+                     "hold_security": 1, "hold_unstable": 1, "needs_decision": 1}
+    gate_on = bool(gate_enabled)
+    blocking = GATE_BLOCKING.get(s(verdict))
+    if blocking is None:
+        blocking = 1
+    gate_note = {
+        "hold_security": "supply-chain risk: the bump was not applied",
+        "hold_unstable": "build/tests not green after alignment",
+        "needs_decision": "an architectural decision is pending a human",
+    }.get(s(verdict), "")
+    if s(verdict) not in GATE_BLOCKING:
+        gate_note = "unrecognised verdict " + (s(verdict) or "(empty)") + " - the gate fails closed"
+
+    # The server's publish endpoint is the ONLY path that can post a status:
+    # the run's own forge_token is minted without the statuses permission.
+    if s(pub_url) and s(pub_token):
+        endpoint = s(pub_url).rstrip("/") + "/api/v1/forge/publish-review"
+        payload = {"pr_url": s(pr_url), "summary": body, "mode": "summary", "comments": []}
+        if gate_on:
+            payload["gate"] = {"enabled": True, "context": s(gate_context) or "vetty/deps",
+                               "blocking_count": blocking, "threshold": "verdict"}
+            if gate_note:
+                payload["gate"]["note"] = gate_note
+        req = urllib.request.Request(
+            endpoint, data=json.dumps(payload).encode("utf-8"), method="POST",
+            headers={"Content-Type": "application/json", "X-Iterion-Run": s(pub_token),
+                     "User-Agent": "vetty-dep-update-guard"})
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                res = json.loads(resp.read().decode("utf-8"))
+            out(bool(res.get("published")),
+                comment_url=str(res.get("review_url") or ""),
+                skipped_reason=str(res.get("skipped_reason") or ""),
+                summary="verdict=" + s(verdict) + "; published via the iterion forge-publish endpoint",
+                gate_posted=bool(res.get("gate_posted")),
+                gate_state=str(res.get("gate_state") or ""),
+                gate_skipped_reason=str(res.get("gate_error") or ""))
+        except urllib.error.HTTPError as e:
+            detail = ""
+            try: detail = e.read().decode("utf-8")[:300]
+            except Exception: pass
+            # Fall through to the direct comment: the verdict still has to
+            # reach the PR. The gate cannot follow it there.
+            gate_fallback = "publish endpoint HTTP %s: %s" % (e.code, detail)
+        except Exception as e:
+            gate_fallback = "publish endpoint error: " + str(e)
+    else:
+        gate_fallback = "no forge publish grant (local run) - a run token cannot post a commit status"
 
     token = ""
     tref = s(token_ref)
     if tref:
         token = (open(tref).read().strip() if os.path.exists(tref) else tref)
     if not token:
-        out(False, skipped_reason="no forge_token bound — cannot post")
+        out(False, skipped_reason="no forge_token bound — cannot post", gate_skipped_reason=gate_fallback)
 
     m = re.match(r"https?://([^/]+)/([^/]+)/([^/]+)/(?:pull|pulls|-/merge_requests|merge_requests)/(\d+)", s(pr_url))
     if not m:
-        out(False, skipped_reason="unparseable pr_url: " + s(pr_url))
+        out(False, skipped_reason="unparseable pr_url: " + s(pr_url), gate_skipped_reason=gate_fallback)
     host, owner, repo, num = m.group(1), m.group(2), m.group(3), m.group(4)
     if host == "github.com":
         api = "https://api.github.com/repos/%s/%s/issues/%s/comments" % (owner, repo, num)
@@ -826,32 +928,42 @@ tool post_feedback:
     req = urllib.request.Request(api, data=json.dumps({"body": body}).encode("utf-8"), method="POST", headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
-            payload = json.loads(resp.read().decode("utf-8"))
-        out(True, comment_url=(payload.get("html_url") or payload.get("url") or ""),
-            summary="verdict=" + s(verdict) + "; comment posted")
+            created = json.loads(resp.read().decode("utf-8"))
+        out(True, comment_url=(created.get("html_url") or created.get("url") or ""),
+            summary="verdict=" + s(verdict) + "; comment posted",
+            gate_skipped_reason=gate_fallback)
     except urllib.error.HTTPError as e:
         detail = ""
         try: detail = e.read().decode("utf-8")[:300]
         except Exception: pass
-        out(False, skipped_reason="forge POST HTTP %s: %s" % (e.code, detail))
+        out(False, skipped_reason="forge POST HTTP %s: %s" % (e.code, detail), gate_skipped_reason=gate_fallback)
     except Exception as e:
-        out(False, skipped_reason="forge POST error: " + str(e))
+        out(False, skipped_reason="forge POST error: " + str(e), gate_skipped_reason=gate_fallback)
 
 ## Deterministic anti-façade gate: a PR target was given but nothing
 ## posted → loud banner (informational; the audit/align already ran).
 tool feedback_health:
-  command: `POSTED={{input.posted}} URL={{input.comment_url}} SKIPPED={{input.skipped_reason}} PR={{input.pr_url}} python3 -c "
+  command: `POSTED={{input.posted}} URL={{input.comment_url}} SKIPPED={{input.skipped_reason}} PR={{input.pr_url}} GATE_ON={{input.gate_enabled}} GATE_POSTED={{input.gate_posted}} GATE_SKIPPED={{input.gate_skipped_reason}} python3 -c "
 import os, json, sys
 posted = os.environ.get('POSTED','false') == 'true'
 pr = os.environ.get('PR','')
 skipped = os.environ.get('SKIPPED','')
+gate_on = os.environ.get('GATE_ON','false') == 'true'
+gate_posted = os.environ.get('GATE_POSTED','false') == 'true'
+gate_skipped = os.environ.get('GATE_SKIPPED','')
 degraded = (pr != '') and (not posted)
+# A gate that is REQUIRED and absent leaves the PR blocked with no way
+# forward but an admin bypass, and looks identical to never having run. It
+# is a louder failure than a missing comment, not a quieter one.
+gate_degraded = (pr != '') and gate_on and (not gate_posted)
 if degraded:
     banner = chr(9888) + ' FEEDBACK NOT POSTED: a PR url was given but no comment landed (reason: ' + (skipped or 'none') + '). Check forge_token + the PR url.'
+elif gate_degraded:
+    banner = chr(9888) + ' MERGE GATE NOT POSTED: the verdict comment landed but no commit status did (reason: ' + (gate_skipped or 'none') + '). If the context is a required check, the PR stays blocked until a re-run posts it.'
 else:
     banner = 'feedback OK: ' + (os.environ.get('URL','') or ('skipped — ' + (skipped or 'no pr_url')))
 sys.stderr.write(banner + chr(10))
-print(json.dumps({'degraded': degraded, 'banner': banner}))
+print(json.dumps({'degraded': degraded or gate_degraded, 'banner': banner}))
 "`
   input: feedback_health_input
   output: feedback_health_output
@@ -946,6 +1058,9 @@ workflow dep_update_guard:
     posted: "{{outputs.post_feedback.posted}}",
     comment_url: "{{outputs.post_feedback.comment_url}}",
     skipped_reason: "{{outputs.post_feedback.skipped_reason}}",
-    pr_url: "{{vars.pr_url}}"
+    pr_url: "{{vars.pr_url}}",
+    gate_enabled: "{{vars.gate_enabled}}",
+    gate_posted: "{{outputs.post_feedback.gate_posted}}",
+    gate_skipped_reason: "{{outputs.post_feedback.gate_skipped_reason}}"
   }
   feedback_health -> done

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -1071,17 +1071,20 @@ tool arm_automerge:
             raise RuntimeError(str(payload["errors"])[:300])
         return payload.get("data") or {}
 
-    # Written with a placeholder sigil and swapped to the GraphQL one at
-    # runtime: a doubled brace anywhere in this file is a template reference,
-    # and a GraphQL block that produced one would be substituted away before
-    # python ever saw it.
-    q = ("query(:owner: String!, :name: String!, :number: Int!) { "
-         "repository(owner: :owner, name: :name) { "
-         "pullRequest(number: :number) { id autoMergeRequest { enabledAt } } "
-         "} }").replace(":", "$")
-    mut = ("mutation(:id: ID!, :method: PullRequestMergeMethod!) { "
-           "enablePullRequestAutoMerge(input: { pullRequestId: :id, mergeMethod: :method }) "
-           "{ clientMutationId } }").replace(":", "$")
+    # The variable sigil is written as @ and swapped at runtime: a doubled
+    # brace anywhere in this file is a template reference, and a GraphQL block
+    # that produced one would be substituted away before python ever saw it.
+    # The placeholder must NOT be a character GraphQL already uses — a colon
+    # separates every field and argument, so swapping colons corrupts the
+    # whole query into something the API rejects.
+    at = chr(36)
+    q = ("query(@owner: String!, @name: String!, @number: Int!) { "
+         "repository(owner: @owner, name: @name) { "
+         "pullRequest(number: @number) { id autoMergeRequest { enabledAt } } "
+         "} }").replace("@", at)
+    mut = ("mutation(@id: ID!, @method: PullRequestMergeMethod!) { "
+           "enablePullRequestAutoMerge(input: { pullRequestId: @id, mergeMethod: @method }) "
+           "{ clientMutationId } }").replace("@", at)
     try:
         data = graphql(q, {"owner": owner, "name": repo, "number": num})
         pr = ((data.get("repository") or {}).get("pullRequest") or {})

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -110,6 +110,21 @@ vars:
   ## the integration's launch_vars.
   gate_context: string = "vetty/deps"
 
+  ## AUTO-MERGE ARMING (opt-in, OFF by default so the catalog behaviour is
+  ## unchanged). When true AND the verdict is green AND the gate landed green,
+  ## Vetty asks the forge to merge the PR *once its own required checks pass*.
+  ## It never merges: the only call made is enablePullRequestAutoMerge, which
+  ## hands the decision to the repo's required checks. The immediate-merge REST
+  ## endpoint is deliberately never used — that would bypass CI, which is the
+  ## opposite of the guarantee this bot exists to provide.
+  ##
+  ## For this to mean anything the repo MUST require at least one check on the
+  ## target branch; with none, a forge merges an armed PR straight away.
+  arm_automerge: bool = false
+
+  ## Merge method asked for when arming. Must be one the repo allows.
+  automerge_method: string [enum: "squash", "merge", "rebase"] = "squash"
+
   ## Deterministic forge publish grant — INJECTED BY THE ITERION SERVER at
   ## launch when the run's team has a forge connection covering pr_url's
   ## repo. Declaring them here is the whole opt-in (undeclared launch vars
@@ -481,6 +496,9 @@ schema feedback_input:
   escalation: string
 
 schema feedback_output:
+  ## verdict echoed back: the graph stamps it per-edge as a literal, so a
+  ## downstream node has no other way to read what was actually reported.
+  verdict: string
   posted: bool
   comment_url: string
   skipped_reason: string
@@ -504,6 +522,20 @@ schema feedback_health_input:
 schema feedback_health_output:
   degraded: bool
   banner: string
+
+schema automerge_input:
+  pr_url: string
+  verdict: string
+  gate_posted: bool
+  gate_state: string
+
+schema automerge_output:
+  ## armed: the forge accepted the auto-merge request (it merges when its own
+  ## required checks pass — Vetty never merges anything itself).
+  armed: bool
+  ## reason: why it was not armed. Always populated when armed is false, so a
+  ## PR sitting un-merged is never a mystery.
+  reason: string
 
 ## ─── Nodes ──────────────────────────────────────────────────────
 
@@ -811,7 +843,8 @@ tool post_feedback:
 
     def out(posted, comment_url="", skipped_reason="", summary="",
             gate_posted=False, gate_state="", gate_skipped_reason=""):
-        print(json.dumps({"posted": bool(posted), "comment_url": comment_url or "",
+        print(json.dumps({"verdict": s(verdict),
+                          "posted": bool(posted), "comment_url": comment_url or "",
                           "skipped_reason": skipped_reason or "", "summary": summary or "",
                           "gate_posted": bool(gate_posted), "gate_state": gate_state or "",
                           "gate_skipped_reason": gate_skipped_reason or ""}))
@@ -968,6 +1001,108 @@ print(json.dumps({'degraded': degraded or gate_degraded, 'banner': banner}))
   input: feedback_health_input
   output: feedback_health_output
 
+## Ask the forge to merge this PR once ITS OWN required checks pass.
+## DETERMINISTIC (no LLM), opt-in, GitHub-only, and fail-closed at every
+## step: a green verdict is necessary but not sufficient — the gate has to
+## have landed green too, because arming on a verdict whose status never
+## reached the PR would merge on a check nobody can see.
+##
+## The ONLY forge call is enablePullRequestAutoMerge. There is deliberately
+## no path to PUT /pulls/{n}/merge: that merges immediately, bypassing every
+## pending check, which is precisely what this bot exists to prevent.
+tool arm_automerge:
+  input: automerge_input
+  output: automerge_output
+  language: py
+  script: |
+    import json, os, re, urllib.request, urllib.error
+    null = None; true = True; false = False  # JSON-literal shim for missing refs
+    enabled = {{vars.arm_automerge}}
+    method = {{vars.automerge_method}}
+    pr_url = {{input.pr_url}}
+    verdict = {{input.verdict}}
+    gate_posted = {{input.gate_posted}}
+    gate_state = {{input.gate_state}}
+    gate_on = {{vars.gate_enabled}}
+    token_ref = {{secrets.forge_token.path}}
+
+    def s(x):
+        return (x or "").strip() if isinstance(x, str) else ("" if x is None else str(x).strip())
+
+    def out(armed, reason=""):
+        print(json.dumps({"armed": bool(armed), "reason": reason or ""}))
+        raise SystemExit(0)
+
+    if not bool(enabled):
+        out(False, "arm_automerge is off (default)")
+    if s(verdict) not in ("clean", "committed"):
+        out(False, "verdict " + (s(verdict) or "(empty)") + " is not green")
+    # The gate is what a repo makes required. Arming while it is missing would
+    # merge on the strength of a verdict the PR never displayed.
+    if bool(gate_on) and not bool(gate_posted):
+        out(False, "the merge gate did not land - not arming on a verdict the PR cannot show")
+    if bool(gate_on) and s(gate_state) and s(gate_state) != "success":
+        out(False, "merge gate is " + s(gate_state))
+
+    m = re.match(r"https?://([^/]+)/([^/]+)/([^/]+)/(?:pull|pulls)/(\d+)", s(pr_url))
+    if not m:
+        out(False, "auto-merge arming is GitHub-only; no-op for " + (s(pr_url) or "(no pr_url)"))
+    host, owner, repo, num = m.group(1), m.group(2), m.group(3), int(m.group(4))
+    if host != "github.com":
+        out(False, "auto-merge arming is GitHub-only; no-op for " + host)
+
+    token = ""
+    tref = s(token_ref)
+    if tref:
+        token = (open(tref).read().strip() if os.path.exists(tref) else tref)
+    if not token:
+        out(False, "no forge_token bound")
+
+    def graphql(query, variables):
+        req = urllib.request.Request(
+            "https://api.github.com/graphql",
+            data=json.dumps({"query": query, "variables": variables}).encode("utf-8"),
+            method="POST",
+            headers={"Authorization": "Bearer " + token, "Content-Type": "application/json",
+                     "User-Agent": "vetty-dep-update-guard"})
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+        if payload.get("errors"):
+            raise RuntimeError(str(payload["errors"])[:300])
+        return payload.get("data") or {}
+
+    # Written with a placeholder sigil and swapped to the GraphQL one at
+    # runtime: a doubled brace anywhere in this file is a template reference,
+    # and a GraphQL block that produced one would be substituted away before
+    # python ever saw it.
+    q = ("query(:owner: String!, :name: String!, :number: Int!) { "
+         "repository(owner: :owner, name: :name) { "
+         "pullRequest(number: :number) { id autoMergeRequest { enabledAt } } "
+         "} }").replace(":", "$")
+    mut = ("mutation(:id: ID!, :method: PullRequestMergeMethod!) { "
+           "enablePullRequestAutoMerge(input: { pullRequestId: :id, mergeMethod: :method }) "
+           "{ clientMutationId } }").replace(":", "$")
+    try:
+        data = graphql(q, {"owner": owner, "name": repo, "number": num})
+        pr = ((data.get("repository") or {}).get("pullRequest") or {})
+        node_id = pr.get("id")
+        if not node_id:
+            out(False, "pull request not found via the forge API")
+        if pr.get("autoMergeRequest"):
+            out(True, "auto-merge was already armed")
+        graphql(mut, {"id": node_id, "method": s(method).upper() or "SQUASH"})
+        out(True, "")
+    except urllib.error.HTTPError as e:
+        detail = ""
+        try: detail = e.read().decode("utf-8")[:300]
+        except Exception: pass
+        out(False, "forge HTTP %s: %s" % (e.code, detail))
+    except Exception as e:
+        # The usual cause is auto-merge disabled on the repo, or a merge method
+        # the repo does not allow. Reported, never swallowed: an un-merged PR
+        # must always carry its reason.
+        out(False, "auto-merge request refused: " + str(e))
+
 ## ─── Workflow ───────────────────────────────────────────────────
 
 workflow dep_update_guard:
@@ -1063,4 +1198,10 @@ workflow dep_update_guard:
     gate_posted: "{{outputs.post_feedback.gate_posted}}",
     gate_skipped_reason: "{{outputs.post_feedback.gate_skipped_reason}}"
   }
-  feedback_health -> done
+  feedback_health -> arm_automerge with {
+    pr_url: "{{vars.pr_url}}",
+    verdict: "{{outputs.post_feedback.verdict}}",
+    gate_posted: "{{outputs.post_feedback.gate_posted}}",
+    gate_state: "{{outputs.post_feedback.gate_state}}"
+  }
+  arm_automerge -> done

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -163,8 +163,20 @@ prompt security_audit_user:
   Changed dep files:
   {{input.dep_files}}
 
-  Bump diff (manifest/lockfile changes):
+  Bump diff:
   {{input.bump_summary}}
+
+  ### Scope caveats — read before you conclude
+  - `no_manifest = {{input.no_manifest}}`. When true, NO file matched a known
+    manifest signature, so the diff above is the PR's FULL change set rather
+    than an isolated manifest bump. Identify what actually moved (an image
+    digest, a pinned tool, an inline version) from the diff itself, and say in
+    `summary` that the scope was inferred. Never report a package-level read
+    you did not perform.
+  - `degraded = {{input.degraded}}` ({{input.degraded_reason}}). When true the
+    diff is NOT the true base..HEAD bump — the base could not be resolved, so
+    the range is approximate and may miss or over-include changes. Say so in
+    `summary`, and let that uncertainty count against `safe`.
 
   Run the auditors per the skills, then emit `audit_output`.
 
@@ -329,19 +341,32 @@ prompt escalate_instructions:
 ## ─── Schemas ────────────────────────────────────────────────────
 
 schema prepare_output:
-  ## is_empty: no diff vs base (defensive — nothing to do).
+  ## is_empty: no diff vs base AND the base resolved — the only case that
+  ## may end the run early. A degraded scope never reports empty.
   is_empty: bool
   ## dep_files: changed dependency manifests/lockfiles (the audit scope).
   dep_files: string[]
   changed_files: int
-  ## bump_summary: the manifest/lockfile diff text (sized for a prompt).
+  ## bump_summary: the diff text under audit (sized for a prompt). Never
+  ## empty when files changed — see no_manifest.
   bump_summary: string
   ## has_non_dep_changes: the PR also touches non-dependency files.
   has_non_dep_changes: bool
+  ## no_manifest: nothing matched a known manifest signature, so the scope
+  ## widened to the full diff. The audit is broader and less certain about
+  ## WHICH package moved — say so rather than claim a clean read.
+  no_manifest: bool
+  ## degraded: the diff is not the true base..HEAD bump (base unreachable).
+  degraded: bool
+  degraded_reason: string
 
 schema audit_input:
   bump_summary: string
   dep_files: string[]
+  ## Scope caveats the auditor must weigh before claiming a clean read.
+  no_manifest: bool
+  degraded: bool
+  degraded_reason: string
 
 schema audit_output:
   verdict: string [enum: "safe", "suspicious", "malicious"]
@@ -445,34 +470,93 @@ schema feedback_health_output:
 
 ## Deterministic bump detector (no LLM): diff the PR branch against the
 ## merge-base of base_ref + HEAD, list the changed files, and classify
-## which are dependency manifests/lockfiles. Output drives the audit
-## scope. On any ambiguity (base_ref absent) it reports is_empty=false so
-## the audit still runs — never wrongly skips.
+## which are dependency manifests/lockfiles. Output drives the audit scope.
+##
+## Two silent-failure modes this node is built to avoid, because each ends
+## a run that LOOKS successful:
+##  - a bump whose files match no pattern would reach the auditor with an
+##    EMPTY diff, and the verdict would be a façade. `no_manifest` widens
+##    the scope to the full diff instead of handing over nothing.
+##  - an unresolvable base (shallow clone, base ref not fetched) yields no
+##    changed files, which reads as "nothing to do" and ends the run mute.
+##    It degrades LOUDLY: is_empty stays false, `degraded` says why.
 tool prepare:
   command: `WS={{vars.workspace_dir}} BASE={{vars.base_ref}} python3 -c "
 import os, subprocess, json, re
 os.chdir(os.environ['WS'])
 base = os.environ.get('BASE', 'main') or 'main'
-mb = subprocess.run(['git','merge-base',base,'HEAD'], capture_output=True, text=True).stdout.strip()
-ref = mb if mb else base
-names = subprocess.run(['git','diff','--name-only',ref], capture_output=True, text=True).stdout
+
+def git(args):
+    p = subprocess.run(['git'] + args, capture_output=True, text=True)
+    return p.returncode, p.stdout
+
+degraded = ''
+rc, mb = git(['merge-base', base, 'HEAD'])
+mb = mb.strip()
+if rc == 0 and mb:
+    ref = mb
+elif git(['rev-parse', '--verify', '--quiet', base])[0] == 0:
+    ref = base
+elif git(['rev-parse', '--verify', '--quiet', 'HEAD~1'])[0] == 0:
+    # Base unreachable (shallow clone / base ref not fetched): fall back to
+    # the branch tip's own parent so the audit still sees a real diff.
+    ref, degraded = 'HEAD~1', 'base ' + base + ' is unreachable; scoped to HEAD~1..HEAD instead'
+else:
+    ref, degraded = '', 'base ' + base + ' is unreachable and HEAD has no parent; scoped to HEAD itself'
+
+def diff(paths):
+    args = ['diff', ref, '--'] + paths if ref else ['show', '--format=', 'HEAD', '--'] + paths
+    return git(args)[1]
+
+if ref:
+    rc, names = git(['diff', '--name-only', ref])
+    if rc != 0:
+        degraded, names = 'git diff against ' + ref + ' failed', ''
+else:
+    names = git(['show', '--name-only', '--format=', 'HEAD'])[1]
 files = [f for f in names.splitlines() if f.strip()]
-# Dependency manifest / lockfile signatures across ecosystems.
+
+# Dependency manifest / lockfile signatures across ecosystems. Container
+# images, pinned toolchains, task runners and CI action pins are dependencies
+# too: Renovate updates all of them, and a bump there is exactly as able to
+# pull in hostile code as a package bump.
 pats = [r'(^|/)package\.json$', r'(^|/)(package-lock\.json|npm-shrinkwrap\.json|yarn\.lock|pnpm-lock\.yaml)$',
         r'(^|/)go\.(mod|sum)$', r'(^|/)(requirements[^/]*\.txt|Pipfile(\.lock)?|poetry\.lock|pyproject\.toml|uv\.lock)$',
         r'(^|/)(Gemfile(\.lock)?)$', r'(^|/)(composer\.(json|lock))$', r'(^|/)Cargo\.(toml|lock)$',
         r'(^|/)(pom\.xml|build\.gradle(\.kts)?|gradle\.lockfile)$', r'(^|/)mix\.(exs|lock)$',
-        r'(^|/)Chart\.(yaml|lock)$', r'(^|/)(values[^/]*\.ya?ml)$', r'(^|/)\.github/workflows/.+\.ya?ml$']
+        r'(^|/)Chart\.(yaml|lock)$', r'(^|/)(values[^/]*\.ya?ml)$', r'(^|/)\.github/workflows/.+\.ya?ml$',
+        r'(^|/)(Dockerfile|Containerfile)[^/]*$', r'(^|/)devbox\.(json|lock)$',
+        r'(^|/)Taskfile[^/]*\.ya?ml$', r'(^|/)\.tool-versions$', r'(^|/)flake\.(nix|lock)$',
+        r'(^|/)action\.ya?ml$', r'(^|/)\.pre-commit-config\.ya?ml$', r'(^|/)renovate\.json5?$']
 rx = [re.compile(p) for p in pats]
 dep = [f for f in files if any(r.search(f) for r in rx)]
-non = [f for f in files if f not in dep]
-# Bump diff text, capped so it fits a prompt.
+
+if not dep:
+    # Renovate custom managers pin versions inline on ANY filename, opted in
+    # with a '# renovate:' annotation on the preceding line. Catch those by
+    # content so a repo's own convention doesn't fall through unaudited.
+    for f in files:
+        try:
+            if os.path.getsize(f) <= 262144:
+                with open(f, errors='replace') as fh:
+                    if 'renovate:' in fh.read():
+                        dep.append(f)
+        except OSError:
+            pass
+
+no_manifest = not dep
+# Never hand the auditor an empty diff: with nothing recognised, the WHOLE
+# change set is the audit scope.
+scope = dep if dep else files
 summary = ''
-if dep:
-    d = subprocess.run(['git','diff',ref,'--']+dep, capture_output=True, text=True).stdout
+if scope:
+    d = diff(scope)
     summary = d[:18000] + ('\n…(truncated)…' if len(d) > 18000 else '')
-print(json.dumps({'is_empty': len(files)==0, 'dep_files': dep, 'changed_files': len(files),
-                  'bump_summary': summary, 'has_non_dep_changes': len(non)>0}))
+non = [f for f in files if f not in dep]
+print(json.dumps({'is_empty': len(files)==0 and not degraded, 'dep_files': dep,
+                  'changed_files': len(files), 'bump_summary': summary,
+                  'has_non_dep_changes': len(non)>0, 'no_manifest': no_manifest,
+                  'degraded': bool(degraded), 'degraded_reason': degraded}))
 "`
   output: prepare_output
 
@@ -792,7 +876,10 @@ workflow dep_update_guard:
   prepare -> done when is_empty
   prepare -> security_audit when not is_empty with {
     bump_summary: "{{outputs.prepare.bump_summary}}",
-    dep_files: "{{outputs.prepare.dep_files}}"
+    dep_files: "{{outputs.prepare.dep_files}}",
+    no_manifest: "{{outputs.prepare.no_manifest}}",
+    degraded: "{{outputs.prepare.degraded}}",
+    degraded_reason: "{{outputs.prepare.degraded_reason}}"
   }
 
   ## Deterministic verdict gate.

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,29 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.0.0
+version: 2.1.0
+## 2.1.0 — classify, gate, arm. (a) The bump classifier only knew package
+## manifests, so a PR moving a base-image digest, a devbox pin, a task-runner
+## tool or a composite action matched nothing — and did not stop, because
+## "no file changed" and "no manifest matched" were the same flag. Those runs
+## reached the auditor with an EMPTY diff and came back "safe": a façade on a
+## diff nobody read (3 of 4 open Renovate PRs on the first repo tried). The
+## list now covers them, a content pass catches custom-manager pins on any
+## filename, and when nothing matches `no_manifest` widens the scope to the
+## full diff instead of handing over nothing. An unresolvable base likewise
+## degrades loudly rather than reading as "nothing to do". (b) The verdict
+## becomes a MERGE GATE: a commit status carrying it, via the server's
+## publish endpoint (a run's forge_token can never post one). The state is a
+## table over the verdict the graph already computed and fails closed on
+## anything unexpected. `gate_context` is a var so several bots fill ONE
+## required check, each for the PRs it owns. (c) `arm_automerge` (opt-in,
+## default off): on a green verdict WITH a landed green gate, ask the forge
+## to merge once ITS OWN required checks pass. Vetty still never merges —
+## the immediate-merge endpoint is deliberately unreachable. (d) Skills gain
+## the dependencies that are not packages (container digests, Nix pins, Helm
+## charts, pinned Actions) and the bundle ships a devbox project for crane,
+## since the sandbox image has no registry client.
+##
 ## 2.0.0 — ADR-058 calibrated pass. The v1 `validate` agent (an LLM
 ## re-running the build and SELF-REPORTING stable:true) is replaced by
 ## the deterministic verify_build/verify_run gate shared with the other

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -62,7 +62,19 @@ forge:
   webhook:
     # React ONLY to the dependency bots, never human PRs. Maps to
     # webhooks.Config.AuthorAllowlist via the orchestrator.
-    author_allowlist: ["dependabot[bot]", "renovate[bot]"]
+    #
+    # The leading "*" is a suffix wildcard. Self-hosting Renovate/Dependabot
+    # under an org GitHub App is the usual way to make their PRs trigger CI
+    # (a GITHUB_TOKEN-authored PR does not), and doing so RENAMES the bot —
+    # "acme-renovate[bot]" instead of "renovate[bot]". Matching the family
+    # keeps those repos covered without naming any one organisation's App.
+    author_allowlist:
+      ["dependabot[bot]", "*dependabot[bot]", "renovate[bot]", "*renovate[bot]"]
+    # These authors are MINE against any bot co-enabled on the same repo: a
+    # general reviewer must not also review the PRs Vetty already guards.
+    # Provisioning materialises this into the other bots' author denylist, so
+    # a reviewer's manifest never has to know Vetty exists.
+    author_scope: exclusive
     launch_vars:
       post_to_board: "false"
   rationale: |

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -58,6 +58,13 @@ forge:
   token_scopes:
     pull_requests: write     # post the review comment
     repository: write        # push the code alignment onto the PR branch
+    statuses: write          # post the merge-gate commit status carrying the
+                             # verdict (GitHub App perm "Commit statuses: Read
+                             # and write"). Declaring it also tells the
+                             # provisioner this bot can be a REQUIRED check, so
+                             # the repo's webhook re-reviews on every push —
+                             # a gate that does not follow the head SHA blocks
+                             # the PR it guards.
   secret: forge_token
   webhook:
     # React ONLY to the dependency bots, never human PRs. Maps to

--- a/bots/dep-update-guard/skills/package-managers.md
+++ b/bots/dep-update-guard/skills/package-managers.md
@@ -65,6 +65,75 @@ read the project's CI / scripts to see which one the team actually
 maintains. The maintained one wins; the others are stale and not
 authoritative.
 
+## Dependencies that are not packages
+
+A package manager is not the only thing that pulls foreign code into a
+build. These four are updated by the same bots, bump the same way, and are
+exactly as able to execute code you did not review — treat them with the
+same rigour, not as "config changes".
+
+| File | What moved | Where the truth is |
+|---|---|---|
+| `Dockerfile` / `Containerfile` | base-image tag or `@sha256:` digest | the registry manifest + the image's own layers |
+| `devbox.json` / `devbox.lock` | a Nix package pin | nixhub.io / the nixpkgs commit in the lock |
+| `Chart.yaml` / `values*.yaml` | a chart version or an image tag | the chart repo + the image it references |
+| `.github/workflows/*`, `action.yml` | an Action pinned by tag or SHA | the action's repo at that ref |
+
+### Container image digests
+
+A digest bump is *usually* a rebuild of the same version — and that is
+precisely why it is worth checking rather than waving through: the tag did
+not change, so nothing else signals that the contents did.
+
+Resolve what actually moved:
+
+```sh
+# The bot's own devbox provides crane; the sandbox image has no registry
+# client of its own.
+crane digest golang:1.26                 # what the tag points at NOW
+crane manifest golang:1.26@sha256:<old>  # the pinned one
+crane config  golang:1.26@sha256:<new> | jq '.history[-3:], .config.Entrypoint, .config.User'
+```
+
+What to look at, in order: does the new digest still correspond to the tag
+the Dockerfile names (a digest that no tag resolves to is a red flag); did
+`User`, `Entrypoint` or `Cmd` change (a base image that stops dropping root
+is a real regression); did the last history entries gain a step that fetches
+something at build time. `trivy image --scanners vuln <ref>` gives the CVE
+delta between old and new — run it on both and diff, since the interesting
+answer is what the bump *fixes* versus what it *introduces*.
+
+If no registry client resolves, say so in the summary rather than implying
+you inspected the image. An unverified digest is a real caveat, not a detail.
+
+### Nix / devbox pins
+
+`devbox.json` carries the human-readable pin (`jq@1.8.2`); `devbox.lock`
+carries the resolved nixpkgs commit — the lock is what actually determines
+the bits. Check the version really exists on nixhub for that package, and
+that the lock's `resolved` URL and the version in `devbox.json` agree; a
+lock pointing at a commit unrelated to the stated version is the signal
+worth escalating. `devbox install --dry-run` (or `devbox info <pkg>`)
+confirms the pin resolves at all.
+
+### Helm charts
+
+A chart bump can change rendered manifests far beyond the version string.
+`helm template` the old and new charts with the repo's own values and diff
+the output — that is the real change set. Pay attention to anything that
+touches RBAC, `securityContext`, `hostPath`/`hostNetwork`, or a new image
+reference: a chart that quietly grants a ClusterRole is a supply-chain event
+even when the package itself is fine.
+
+### Pinned Actions
+
+An Action pinned by SHA that moves to another SHA is a code change in a
+build step that already holds a token. Read the diff between the two refs
+(`gh api repos/<owner>/<repo>/compare/<old>...<new>`), and give particular
+weight to changes in what it exfiltrates, what it writes, and any new
+network call. A tag that was re-pointed to a different commit without a
+release is the classic Action-hijack shape.
+
 ## Cache locations — keep them OUT of the workspace
 
 Most package managers default a cache (downloaded archives, compiled

--- a/bots/dep-update-guard/skills/verify-build.md
+++ b/bots/dep-update-guard/skills/verify-build.md
@@ -22,7 +22,17 @@ and the correct toolchain:
 
 - **Task runner / Makefile** — `Taskfile.yml` → `task build` / `task test` /
   `task check`; `Makefile` → `make build` / `make test`; `Justfile` → `just …`.
-  This is almost always the right answer when present.
+  This is almost always the right answer when present. List the targets that
+  actually exist (`task --list`, `make -qp`, `just --list`) instead of assuming
+  the conventional names: plenty of repos have `test` and `lint` but no `check`
+  umbrella, and a verify.sh calling a target that does not exist fails for a
+  reason that has nothing to do with the change under test.
+- **A gate CI runs inline is still a gate.** When CI invokes something the task
+  runner does not expose — a coverage threshold script, a schema check, a
+  shell assertion — copy that invocation into verify.sh verbatim. `task test`
+  passing while CI's `go test … && bash hack/coverage.sh cover.out 85` fails is
+  a green local verify on a red change, which is the exact failure the
+  deterministic gate exists to prevent.
 - **Pinned toolchain — honour it or the build fails on a version mismatch.**
   `devbox.json` → prefix with `devbox run -- …`. `.tool-versions` (asdf/mise),
   `.nvmrc`, `flake.nix`, `mise.toml` → activate accordingly. For Go: if

--- a/bots/dep_update_guard_automerge_test.go
+++ b/bots/dep_update_guard_automerge_test.go
@@ -27,10 +27,16 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 	}
 	script := toolScript(t, "dep-update-guard/main.bot", "arm_automerge")
 
-	// The source must not even contain the immediate-merge endpoint: the
-	// guarantee should be readable, not merely untested.
-	if strings.Contains(script, "/merge") && !strings.Contains(script, "enablePullRequestAutoMerge") {
-		t.Fatal("arm_automerge must not reference a direct merge endpoint")
+	// The source must not even contain a way to merge outright: the guarantee
+	// should be readable, not merely untested. Asserted on each forbidden
+	// marker on its own — a conjunction with "does it also mention the
+	// auto-merge mutation" is always false, since that mutation is the node's
+	// only forge call, and would let the single most dangerous regression
+	// this bot can have sail through.
+	for _, forbidden := range []string{"mergePullRequest", `/merge"`, "/merge'", "/merge%s", "/merge?"} {
+		if strings.Contains(script, forbidden) {
+			t.Fatalf("arm_automerge must not reference a direct merge endpoint (%q)", forbidden)
+		}
 	}
 
 	type call struct {
@@ -51,6 +57,15 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 			}
 			_ = json.Unmarshal(raw, &body)
 			calls = append(calls, call{query: body.Query, vars: body.Variables})
+			// The stub answered success for ANY body, so a query corrupted into
+			// invalid GraphQL passed CI while being rejected by the real API —
+			// the feature was green here and dead in production. Reject
+			// anything the API would.
+			if err := assertValidGraphQL(body.Query); err != "" {
+				t.Errorf("invalid GraphQL sent: %s\nquery: %s", err, body.Query)
+				w.WriteHeader(400)
+				return
+			}
 			if strings.Contains(body.Query, "enablePullRequestAutoMerge") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{"enablePullRequestAutoMerge": map[string]any{"clientMutationId": nil}},
@@ -170,4 +185,42 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 			t.Fatalf("a clean bump with a green gate arms too: %v", res)
 		}
 	})
+}
+
+// assertValidGraphQL catches the corruption class that got past the original
+// stub: a sigil swap that also rewrote GraphQL's own separators, producing a
+// query the real API rejects while the test answered success to anything. It
+// is not a parser — it checks the invariants a careless string substitution
+// breaks. Returns "" when the query looks well-formed.
+func assertValidGraphQL(q string) string {
+	if strings.TrimSpace(q) == "" {
+		return "empty query"
+	}
+	// Every declared variable is `$name: Type` and every use `$name` — never
+	// `$name$`, which is exactly what swapping colons produces.
+	for _, frag := range strings.Split(q, "$")[1:] {
+		name := frag
+		for i, r := range frag {
+			isNameRune := r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+			if !isNameRune {
+				name = frag[:i]
+				break
+			}
+		}
+		if name == "" {
+			return "empty variable name after $"
+		}
+		if strings.HasPrefix(strings.TrimPrefix(frag, name), "$") {
+			return "variable $" + name + " is followed by another $ (a separator was rewritten)"
+		}
+	}
+	// Fields and arguments are separated by a colon; if the swap ate them,
+	// none are left where the query needs them.
+	if !strings.Contains(q, ": ") {
+		return "no `: ` separator left in the query"
+	}
+	if strings.Count(q, "{") != strings.Count(q, "}") {
+		return "unbalanced braces"
+	}
+	return ""
 }

--- a/bots/dep_update_guard_automerge_test.go
+++ b/bots/dep_update_guard_automerge_test.go
@@ -1,0 +1,173 @@
+package bots
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestDepUpdateGuardArmAutomerge pins the one node in the fleet that can end
+// with code merged into a default branch. Two properties carry all the weight:
+//
+//   - it NEVER merges. The only forge call it may make is
+//     enablePullRequestAutoMerge, which hands the decision to the repo's own
+//     required checks. A direct merge call would bypass CI — the opposite of
+//     what this bot exists to guarantee.
+//   - it is fail-closed everywhere: off by default, green verdict required,
+//     the gate must actually have landed green, GitHub only, and every refusal
+//     carries a reason so an un-merged PR is never a mystery.
+func TestDepUpdateGuardArmAutomerge(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	script := toolScript(t, "dep-update-guard/main.bot", "arm_automerge")
+
+	// The source must not even contain the immediate-merge endpoint: the
+	// guarantee should be readable, not merely untested.
+	if strings.Contains(script, "/merge") && !strings.Contains(script, "enablePullRequestAutoMerge") {
+		t.Fatal("arm_automerge must not reference a direct merge endpoint")
+	}
+
+	type call struct {
+		query string
+		vars  map[string]any
+	}
+
+	run := func(t *testing.T, subs map[string]string) (map[string]any, []call, []string) {
+		t.Helper()
+		var calls []call
+		var paths []string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			paths = append(paths, r.Method+" "+r.URL.Path)
+			raw, _ := io.ReadAll(r.Body)
+			var body struct {
+				Query     string         `json:"query"`
+				Variables map[string]any `json:"variables"`
+			}
+			_ = json.Unmarshal(raw, &body)
+			calls = append(calls, call{query: body.Query, vars: body.Variables})
+			if strings.Contains(body.Query, "enablePullRequestAutoMerge") {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"data": map[string]any{"enablePullRequestAutoMerge": map[string]any{"clientMutationId": nil}},
+				})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"repository": map[string]any{
+					"pullRequest": map[string]any{"id": "PR_node_1", "autoMergeRequest": nil},
+				}},
+			})
+		}))
+		defer srv.Close()
+
+		base := map[string]string{
+			"{{vars.arm_automerge}}":       "True",
+			"{{vars.automerge_method}}":    `"squash"`,
+			"{{input.pr_url}}":             `"https://github.com/acme/widgets/pull/7"`,
+			"{{input.verdict}}":            `"committed"`,
+			"{{input.gate_posted}}":        "True",
+			"{{input.gate_state}}":         `"success"`,
+			"{{vars.gate_enabled}}":        "True",
+			"{{secrets.forge_token.path}}": `"ghs_test"`,
+		}
+		for k, v := range subs {
+			base[k] = v
+		}
+		body := script
+		for ref, val := range base {
+			body = strings.ReplaceAll(body, ref, val)
+		}
+		// Point the GraphQL endpoint at the stub without touching the logic.
+		body = strings.ReplaceAll(body, `"https://api.github.com/graphql"`, `"`+srv.URL+`/graphql"`)
+		if strings.Contains(body, "{{") {
+			t.Fatalf("unsubstituted ref: %s", firstRef(body))
+		}
+
+		f, err := os.CreateTemp(t.TempDir(), "arm-*.py")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.WriteString(body); err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+		out, err := exec.Command("python3", f.Name()).Output()
+		if err != nil {
+			t.Fatalf("arm_automerge failed: %v (out %q)", err, out)
+		}
+		var res map[string]any
+		if err := json.Unmarshal(out, &res); err != nil {
+			t.Fatalf("output is not automerge_output JSON: %v (%q)", err, out)
+		}
+		return res, calls, paths
+	}
+
+	t.Run("green verdict + green gate arms via the auto-merge mutation", func(t *testing.T) {
+		res, calls, _ := run(t, nil)
+		if res["armed"] != true {
+			t.Fatalf("want armed, got %v", res)
+		}
+		var armed bool
+		for _, c := range calls {
+			if strings.Contains(c.query, "enablePullRequestAutoMerge") {
+				armed = true
+				if c.vars["method"] != "SQUASH" {
+					t.Errorf("merge method = %v, want SQUASH", c.vars["method"])
+				}
+			}
+			// The whole guarantee: nothing may merge the PR outright.
+			if strings.Contains(c.query, "mergePullRequest") {
+				t.Fatal("arm_automerge must never call mergePullRequest — that bypasses the checks")
+			}
+		}
+		if !armed {
+			t.Fatal("no enablePullRequestAutoMerge call was made")
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		subs map[string]string
+		want string
+	}{
+		{"off by default", map[string]string{"{{vars.arm_automerge}}": "False"}, "off"},
+		{"held bump", map[string]string{"{{input.verdict}}": `"hold_security"`}, "not green"},
+		{"unstable build", map[string]string{"{{input.verdict}}": `"hold_unstable"`}, "not green"},
+		{"pending human decision", map[string]string{"{{input.verdict}}": `"needs_decision"`}, "not green"},
+		{"unknown verdict", map[string]string{"{{input.verdict}}": `"probably_fine"`}, "not green"},
+		// A verdict whose status never reached the PR must not merge it: the
+		// gate is what the repo actually gates on.
+		{"gate never landed", map[string]string{"{{input.gate_posted}}": "False"}, "did not land"},
+		{"gate red", map[string]string{"{{input.gate_state}}": `"failure"`}, "merge gate is failure"},
+		{"non-github forge", map[string]string{"{{input.pr_url}}": `"https://gitlab.com/a/b/-/merge_requests/3"`}, "GitHub-only"},
+		{"no token", map[string]string{"{{secrets.forge_token.path}}": `""`}, "no forge_token"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, calls, _ := run(t, tc.subs)
+			if res["armed"] != false {
+				t.Fatalf("must not arm: %v", res)
+			}
+			reason, _ := res["reason"].(string)
+			if !strings.Contains(reason, tc.want) {
+				t.Errorf("reason = %q, want it to mention %q", reason, tc.want)
+			}
+			if len(calls) != 0 {
+				t.Errorf("must not touch the forge at all, made %d call(s)", len(calls))
+			}
+		})
+	}
+
+	t.Run("a clean bump arms too", func(t *testing.T) {
+		// "clean" (safe bump, nothing to align) is as green as "committed" —
+		// it must not need a code change to be mergeable.
+		res, _, _ := run(t, map[string]string{"{{input.verdict}}": `"clean"`})
+		if res["armed"] != true {
+			t.Fatalf("a clean bump with a green gate arms too: %v", res)
+		}
+	})
+}

--- a/bots/dep_update_guard_gate_test.go
+++ b/bots/dep_update_guard_gate_test.go
@@ -1,0 +1,265 @@
+package bots
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+)
+
+// TestDepUpdateGuardGateVerdict pins the merge gate Vetty posts. The gate is
+// the thing a repo can make a REQUIRED check, so two properties matter more
+// than anything else in the bot:
+//
+//   - it is a TABLE over the verdict the graph already computed, never a
+//     judgment made at publish time — otherwise the deterministic gates
+//     upstream are decorative;
+//   - it fails CLOSED. A gate that reports success on a state nobody
+//     anticipated is worse than no gate: it converts an unknown into a merge.
+//
+// The test runs the real script against a stub of the server's publish
+// endpoint and asserts the payload that actually goes over the wire.
+func TestDepUpdateGuardGateVerdict(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	script := toolScript(t, "dep-update-guard/main.bot", "post_feedback")
+
+	type gate struct {
+		Enabled       bool   `json:"enabled"`
+		Context       string `json:"context"`
+		BlockingCount int    `json:"blocking_count"`
+		Note          string `json:"note"`
+	}
+	type published struct {
+		PRURL   string `json:"pr_url"`
+		Summary string `json:"summary"`
+		Gate    *gate  `json:"gate"`
+	}
+
+	run := func(t *testing.T, verdict, gateContext string, gateEnabled bool) (published, map[string]any) {
+		t.Helper()
+		var got published
+		var seen bool
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			seen = true
+			if tok := r.Header.Get("X-Iterion-Run"); tok != "run-token" {
+				t.Errorf("publish must authenticate with the run grant, got %q", tok)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode publish payload: %v", err)
+			}
+			state := "success"
+			if got.Gate != nil && got.Gate.BlockingCount > 0 {
+				state = "failure"
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"published": true, "review_url": "https://forge/review/1",
+				"gate_posted": got.Gate != nil, "gate_state": state,
+			})
+		}))
+		defer srv.Close()
+
+		body := script
+		for ref, val := range map[string]string{
+			"{{input.pr_url}}":             `"https://github.com/acme/widgets/pull/7"`,
+			"{{input.verdict}}":            `"` + verdict + `"`,
+			"{{input.audit_summary}}":      `"audited"`,
+			"{{input.cves}}":               `""`,
+			"{{input.malware_signals}}":    `""`,
+			"{{input.align_summary}}":      `""`,
+			"{{input.validate_summary}}":   `""`,
+			"{{input.escalation}}":         `""`,
+			"{{input.commit_summary}}":     `""`,
+			"{{secrets.forge_token.path}}": `""`,
+			"{{vars.forge_publish_url}}":   `"` + srv.URL + `"`,
+			"{{vars.forge_publish_token}}": `"run-token"`,
+			"{{vars.gate_enabled}}":        boolLit(gateEnabled),
+			"{{vars.gate_context}}":        `"` + gateContext + `"`,
+		} {
+			body = strings.ReplaceAll(body, ref, val)
+		}
+		if strings.Contains(body, "{{") {
+			t.Fatalf("unsubstituted ref left in the script: %s", firstRef(body))
+		}
+
+		f, err := os.CreateTemp(t.TempDir(), "feedback-*.py")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.WriteString(body); err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+		out, err := exec.Command("python3", f.Name()).Output()
+		if err != nil {
+			t.Fatalf("post_feedback failed: %v (out %q)", err, out)
+		}
+		var res map[string]any
+		if err := json.Unmarshal(out, &res); err != nil {
+			t.Fatalf("post_feedback output is not feedback_output JSON: %v (%q)", err, out)
+		}
+		if gateEnabled && !seen {
+			t.Fatal("the gate can only ride the server publish endpoint — a run token cannot post a status")
+		}
+		return got, res
+	}
+
+	for _, tc := range []struct {
+		verdict     string
+		wantBlocked bool
+	}{
+		{"clean", false},
+		{"committed", false},
+		{"hold_security", true},
+		{"hold_unstable", true},
+		{"needs_decision", true},
+		// Not a verdict the graph can produce today. If one ever appears, the
+		// gate must refuse it rather than wave it through.
+		{"probably_fine", true},
+		{"", true},
+	} {
+		t.Run("verdict="+tc.verdict, func(t *testing.T) {
+			pub, res := run(t, tc.verdict, "iterion/review", true)
+			if pub.Gate == nil {
+				t.Fatal("no gate in the publish payload")
+			}
+			blocked := pub.Gate.BlockingCount > 0
+			if blocked != tc.wantBlocked {
+				t.Errorf("verdict %q: blocking_count=%d, want blocked=%v", tc.verdict, pub.Gate.BlockingCount, tc.wantBlocked)
+			}
+			if pub.Gate.Context != "iterion/review" {
+				t.Errorf("gate context = %q, want the pinned shared name", pub.Gate.Context)
+			}
+			if res["gate_posted"] != true {
+				t.Errorf("gate_posted must report what the server did: %v", res)
+			}
+			wantState := "success"
+			if tc.wantBlocked {
+				wantState = "failure"
+			}
+			if res["gate_state"] != wantState {
+				t.Errorf("gate_state = %v, want %s", res["gate_state"], wantState)
+			}
+		})
+	}
+
+	t.Run("unknown verdict says why it blocked", func(t *testing.T) {
+		pub, _ := run(t, "probably_fine", "iterion/review", true)
+		if !strings.Contains(pub.Gate.Note, "fails closed") {
+			t.Errorf("an operator must be able to tell an unrecognised verdict from a real finding, got note %q", pub.Gate.Note)
+		}
+	})
+
+	t.Run("gate disabled publishes the review without a status", func(t *testing.T) {
+		pub, res := run(t, "committed", "iterion/review", false)
+		if pub.Gate != nil {
+			t.Errorf("gate_enabled=false must post no status, got %+v", pub.Gate)
+		}
+		if res["posted"] != true {
+			t.Errorf("the verdict must still reach the PR: %v", res)
+		}
+	})
+
+	// No publish grant (a local CLI run) → the verdict still reaches the PR
+	// through the direct forge comment, and the missing gate is REPORTED
+	// rather than silently absent.
+	t.Run("no publish grant falls back and says so", func(t *testing.T) {
+		body := script
+		for ref, val := range map[string]string{
+			"{{input.pr_url}}":             `"https://github.com/acme/widgets/pull/7"`,
+			"{{input.verdict}}":            `"committed"`,
+			"{{input.audit_summary}}":      `"audited"`,
+			"{{input.cves}}":               `""`,
+			"{{input.malware_signals}}":    `""`,
+			"{{input.align_summary}}":      `""`,
+			"{{input.validate_summary}}":   `""`,
+			"{{input.escalation}}":         `""`,
+			"{{input.commit_summary}}":     `""`,
+			"{{secrets.forge_token.path}}": `""`,
+			"{{vars.forge_publish_url}}":   `""`,
+			"{{vars.forge_publish_token}}": `""`,
+			"{{vars.gate_enabled}}":        `True`,
+			"{{vars.gate_context}}":        `"iterion/review"`,
+		} {
+			body = strings.ReplaceAll(body, ref, val)
+		}
+		f, err := os.CreateTemp(t.TempDir(), "feedback-*.py")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.WriteString(body); err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+		out, err := exec.Command("python3", f.Name()).Output()
+		if err != nil {
+			t.Fatalf("post_feedback failed: %v (out %q)", err, out)
+		}
+		var res map[string]any
+		if err := json.Unmarshal(out, &res); err != nil {
+			t.Fatalf("not JSON: %v (%q)", err, out)
+		}
+		if res["gate_posted"] != false {
+			t.Errorf("no grant → no gate, got %v", res)
+		}
+		if reason, _ := res["gate_skipped_reason"].(string); reason == "" {
+			t.Errorf("a missing gate must say why — a required check that is absent blocks the PR: %v", res)
+		}
+	})
+}
+
+func boolLit(b bool) string {
+	if b {
+		return "True"
+	}
+	return "False"
+}
+
+func firstRef(s string) string {
+	i := strings.Index(s, "{{")
+	if i < 0 {
+		return ""
+	}
+	j := strings.Index(s[i:], "}}")
+	if j < 0 {
+		return s[i:]
+	}
+	return s[i : i+j+2]
+}
+
+// toolScript extracts a tool node's `script:` body (language: py) from a
+// compiled bundle, the counterpart of toolCommand for script-form nodes.
+func toolScript(t *testing.T, rel, node string) string {
+	t.Helper()
+	src, err := os.ReadFile(rel)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	pr := parser.Parse(rel, string(src))
+	if pr.File == nil {
+		t.Fatalf("parse produced no File")
+	}
+	cr := ir.Compile(pr.File)
+	if cr.Workflow == nil {
+		t.Fatalf("compile produced no Workflow")
+	}
+	raw, ok := cr.Workflow.Nodes[node]
+	if !ok {
+		t.Fatalf("no %s node", node)
+	}
+	tn, ok := raw.(*ir.ToolNode)
+	if !ok {
+		t.Fatalf("%s is %T, want *ir.ToolNode", node, raw)
+	}
+	if strings.TrimSpace(tn.Script) == "" {
+		t.Fatalf("%s has no script body", node)
+	}
+	return tn.Script
+}

--- a/bots/dep_update_guard_prepare_test.go
+++ b/bots/dep_update_guard_prepare_test.go
@@ -1,0 +1,174 @@
+package bots
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDepUpdateGuardPrepareClassifies guards the deterministic bump detector
+// that scopes Vetty's whole run. It is the highest-consequence node in the
+// bot: `prepare` decides WHAT the supply-chain auditor reads, and it fails
+// silently in both directions.
+//
+//   - A dependency PR whose changed files match no known manifest pattern
+//     still reaches the auditor — with an EMPTY bump_summary. The auditor
+//     then renders a verdict on a diff nobody read: a façade "safe".
+//   - A failed merge-base (shallow clone, base ref not fetched) yields no
+//     changed files at all, which reads as "nothing to do" and ends the run
+//     mute — no comment, and with a merge gate armed, a check pending forever.
+//
+// Both are what this test pins, against a real git tree.
+func TestDepUpdateGuardPrepareClassifies(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	command := toolCommand(t, "dep-update-guard/main.bot", "prepare")
+
+	type prepareResult struct {
+		IsEmpty      bool     `json:"is_empty"`
+		DepFiles     []string `json:"dep_files"`
+		ChangedFiles int      `json:"changed_files"`
+		BumpSummary  string   `json:"bump_summary"`
+		NoManifest   bool     `json:"no_manifest"`
+		Degraded     bool     `json:"degraded"`
+	}
+
+	run := func(t *testing.T, ws, base string) prepareResult {
+		t.Helper()
+		cmd := strings.ReplaceAll(command, "{{vars.workspace_dir}}", ws)
+		cmd = strings.ReplaceAll(cmd, "{{vars.base_ref}}", base)
+		out, err := exec.Command("sh", "-c", cmd).Output()
+		if err != nil {
+			t.Fatalf("prepare failed to execute: %v (out %q)", err, out)
+		}
+		var res prepareResult
+		if uerr := json.Unmarshal(out, &res); uerr != nil {
+			t.Fatalf("prepare output is not prepare_output JSON: %v (out %q)", uerr, out)
+		}
+		return res
+	}
+
+	git := func(t *testing.T, ws string, args ...string) {
+		t.Helper()
+		full := append([]string{"-C", ws}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v (%s)", args, err, out)
+		}
+	}
+
+	// bumpRepo builds a repo with a `main` baseline and a PR commit on top
+	// that rewrites each named file — the shape of a Renovate PR.
+	bumpRepo := func(t *testing.T, files map[string]string) string {
+		t.Helper()
+		ws := t.TempDir()
+		git(t, ws, "init", "-q", "-b", "main")
+		git(t, ws, "config", "user.email", "t@example.com")
+		git(t, ws, "config", "user.name", "t")
+		if err := os.WriteFile(filepath.Join(ws, "README.md"), []byte("base\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		git(t, ws, "add", "-A")
+		git(t, ws, "commit", "-qm", "base")
+
+		for name, body := range files {
+			p := filepath.Join(ws, name)
+			if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		git(t, ws, "checkout", "-q", "-b", "renovate/bump")
+		git(t, ws, "add", "-A")
+		git(t, ws, "commit", "-qm", "chore(deps): bump", "--allow-empty")
+		return ws
+	}
+
+	// Every one of these is a real Renovate manager on a real repo. The
+	// Docker/devbox/Taskfile ones were invisible to the classifier, so those
+	// PRs reached the auditor with nothing to audit.
+	for _, tc := range []struct {
+		name string
+		file string
+		body string
+	}{
+		{"go modules", "go.mod", "module x\n\ngo 1.26\n\nrequire k8s.io/api v0.34.1\n"},
+		{"npm lockfile", "pnpm-lock.yaml", "lockfileVersion: 9\n"},
+		{"dockerfile digest pin", "cmd/buildd/Dockerfile", "FROM golang:1.26@sha256:3aff665\n"},
+		{"containerfile", "Containerfile", "FROM alpine@sha256:abc\n"},
+		{"devbox toolchain", "devbox.json", "{\"packages\": [\"jq@1.8.2\"]}\n"},
+		{"devbox lock", "devbox.lock", "{\"lockfile_version\": \"1\"}\n"},
+		{"task runner pins", "Taskfile.yml", "# renovate: datasource=go depName=x\ntasks:\n  lint:\n    cmds: [go run x@v2.12.2]\n"},
+		{"asdf tool versions", ".tool-versions", "golang 1.26.4\n"},
+		{"nix flake lock", "flake.lock", "{\"nodes\": {}}\n"},
+		{"composite action pin", "action.yml", "runs:\n  using: node24\n"},
+		{"helm chart", "deploy/helm/app/Chart.yaml", "apiVersion: v2\nversion: 1.2.3\n"},
+		{"helm values image tag", "deploy/helm/app/values.yaml", "image:\n  tag: v1.2.3\n"},
+		{"workflow action digest", ".github/workflows/ci.yml", "jobs:\n  t:\n    steps:\n      - uses: actions/checkout@abc123\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ws := bumpRepo(t, map[string]string{tc.file: tc.body})
+			res := run(t, ws, "main")
+
+			if res.IsEmpty {
+				t.Fatalf("%s: reported is_empty on a real bump", tc.file)
+			}
+			if len(res.DepFiles) != 1 || res.DepFiles[0] != tc.file {
+				t.Errorf("dep_files = %v, want [%s]", res.DepFiles, tc.file)
+			}
+			// The auditor's whole input. Empty here is the façade-verdict bug.
+			if !strings.Contains(res.BumpSummary, tc.file) {
+				t.Errorf("bump_summary must carry the %s diff, got %q", tc.file, res.BumpSummary)
+			}
+		})
+	}
+
+	// A PR touching files no pattern recognises must still hand the auditor
+	// the real diff — widened to the FULL change set — and say so, rather
+	// than pass an empty string off as "audited".
+	t.Run("unrecognised manifest widens to the full diff", func(t *testing.T) {
+		ws := bumpRepo(t, map[string]string{"vendor.conf": "pkg 1.2.3\n"})
+		res := run(t, ws, "main")
+
+		if res.IsEmpty {
+			t.Fatal("reported is_empty on a real change")
+		}
+		if !res.NoManifest {
+			t.Error("no_manifest must flag that nothing matched, so the audit can widen its scope")
+		}
+		if !strings.Contains(res.BumpSummary, "vendor.conf") {
+			t.Errorf("bump_summary must fall back to the full diff, got %q", res.BumpSummary)
+		}
+	})
+
+	// A merge-base that cannot be resolved must degrade LOUDLY. Reporting
+	// "no diff" here is what makes the run end mute.
+	t.Run("unresolvable base degrades loudly", func(t *testing.T) {
+		ws := bumpRepo(t, map[string]string{"go.mod": "module x\n"})
+		res := run(t, ws, "origin/does-not-exist")
+
+		if res.IsEmpty {
+			t.Error("an unresolvable base must not read as an empty diff — that ends the run silently")
+		}
+		if !res.Degraded {
+			t.Error("an unresolvable base must be reported as degraded")
+		}
+	})
+
+	// A PR with genuinely no diff is the one case that may end the run early.
+	t.Run("truly empty diff", func(t *testing.T) {
+		ws := bumpRepo(t, nil)
+		if res := run(t, ws, "main"); !res.IsEmpty {
+			t.Errorf("an empty PR must report is_empty, got %+v", res)
+		}
+	})
+}

--- a/bots/feature-dev/skills/verify-build.md
+++ b/bots/feature-dev/skills/verify-build.md
@@ -22,7 +22,17 @@ and the correct toolchain:
 
 - **Task runner / Makefile** — `Taskfile.yml` → `task build` / `task test` /
   `task check`; `Makefile` → `make build` / `make test`; `Justfile` → `just …`.
-  This is almost always the right answer when present.
+  This is almost always the right answer when present. List the targets that
+  actually exist (`task --list`, `make -qp`, `just --list`) instead of assuming
+  the conventional names: plenty of repos have `test` and `lint` but no `check`
+  umbrella, and a verify.sh calling a target that does not exist fails for a
+  reason that has nothing to do with the change under test.
+- **A gate CI runs inline is still a gate.** When CI invokes something the task
+  runner does not expose — a coverage threshold script, a schema check, a
+  shell assertion — copy that invocation into verify.sh verbatim. `task test`
+  passing while CI's `go test … && bash hack/coverage.sh cover.out 85` fails is
+  a green local verify on a red change, which is the exact failure the
+  deterministic gate exists to prevent.
 - **Pinned toolchain — honour it or the build fails on a version mismatch.**
   `devbox.json` → prefix with `devbox run -- …`. `.tool-versions` (asdf/mise),
   `.nvmrc`, `flake.nix`, `mise.toml` → activate accordingly. For Go: if

--- a/bots/feature-gap-fill/skills/verify-build.md
+++ b/bots/feature-gap-fill/skills/verify-build.md
@@ -22,7 +22,17 @@ and the correct toolchain:
 
 - **Task runner / Makefile** — `Taskfile.yml` → `task build` / `task test` /
   `task check`; `Makefile` → `make build` / `make test`; `Justfile` → `just …`.
-  This is almost always the right answer when present.
+  This is almost always the right answer when present. List the targets that
+  actually exist (`task --list`, `make -qp`, `just --list`) instead of assuming
+  the conventional names: plenty of repos have `test` and `lint` but no `check`
+  umbrella, and a verify.sh calling a target that does not exist fails for a
+  reason that has nothing to do with the change under test.
+- **A gate CI runs inline is still a gate.** When CI invokes something the task
+  runner does not expose — a coverage threshold script, a schema check, a
+  shell assertion — copy that invocation into verify.sh verbatim. `task test`
+  passing while CI's `go test … && bash hack/coverage.sh cover.out 85` fails is
+  a green local verify on a red change, which is the exact failure the
+  deterministic gate exists to prevent.
 - **Pinned toolchain — honour it or the build fails on a version mismatch.**
   `devbox.json` → prefix with `devbox run -- …`. `.tool-versions` (asdf/mise),
   `.nvmrc`, `flake.nix`, `mise.toml` → activate accordingly. For Go: if

--- a/bots/issue-triage/skills/iterion-bot-catalog.md
+++ b/bots/issue-triage/skills/iterion-bot-catalog.md
@@ -668,7 +668,7 @@ or commits code — that is the improve-loops' job (Billy / Willy).
   auto-fixed. Read-only: Revi reports; Billy (branch-improve-loop)
   reviews AND fixes AND commits.
 - **Triggers**: review-pr, pr-review, review
-- **Vars**: `base_ref` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_enabled` (bool), `gate_severity` (string), `max_findings` (int), `post_to_board` (bool), `pr_review_mode` (string), `pr_url` (string), `report_path` (string), `scope_notes` (string), `severity_threshold` (string), `workspace_dir` (string)
+- **Vars**: `base_ref` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `gate_severity` (string), `max_findings` (int), `post_to_board` (bool), `pr_review_mode` (string), `pr_url` (string), `report_path` (string), `scope_notes` (string), `severity_threshold` (string), `workspace_dir` (string)
 - **Path**: `bots/review-pr/main.bot`
 
 ### `rgaa-audit` — Acci

--- a/bots/issue-triage/skills/iterion-bot-catalog.md
+++ b/bots/issue-triage/skills/iterion-bot-catalog.md
@@ -281,7 +281,7 @@ audit ran and the build is green before anything is committed.
   alignment onto the PR branch. Not for human PRs (use Revi /
   review-pr), and not for proactively opening update PRs (that is
   Renovacy / secured-renovacy).
-- **Vars**: `base_ref` (string), `max_fix_iterations` (int), `post_to_board` (bool), `pr_author` (string), `pr_url` (string), `scope_notes` (string), `scratch_dir` (string), `workspace_dir` (string)
+- **Vars**: `base_ref` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_fix_iterations` (int), `post_to_board` (bool), `pr_author` (string), `pr_url` (string), `scope_notes` (string), `scratch_dir` (string), `workspace_dir` (string)
 - **Path**: `bots/dep-update-guard/main.bot`
 
 ### `devbox-setup` — Devy

--- a/bots/issue-triage/skills/iterion-bot-catalog.md
+++ b/bots/issue-triage/skills/iterion-bot-catalog.md
@@ -281,7 +281,7 @@ audit ran and the build is green before anything is committed.
   alignment onto the PR branch. Not for human PRs (use Revi /
   review-pr), and not for proactively opening update PRs (that is
   Renovacy / secured-renovacy).
-- **Vars**: `base_ref` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_fix_iterations` (int), `post_to_board` (bool), `pr_author` (string), `pr_url` (string), `scope_notes` (string), `scratch_dir` (string), `workspace_dir` (string)
+- **Vars**: `arm_automerge` (bool), `automerge_method` (string), `base_ref` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_fix_iterations` (int), `post_to_board` (bool), `pr_author` (string), `pr_url` (string), `scope_notes` (string), `scratch_dir` (string), `workspace_dir` (string)
 - **Path**: `bots/dep-update-guard/main.bot`
 
 ### `devbox-setup` — Devy

--- a/bots/review-pr/main.bot
+++ b/bots/review-pr/main.bot
@@ -175,6 +175,16 @@ vars:
   ## the reviewer's own bar (see review_system), so high is the sane floor.
   gate_severity: string [enum: "low", "medium", "high", "critical"] = "high"
 
+  ## The commit-status CONTEXT the gate posts under — the name that appears
+  ## in the repo's required checks. A required check applies to EVERY PR, so
+  ## a repo where different bots review different PRs (a dependency guard on
+  ## the bot's PRs, this reviewer on the humans') must give them ONE shared
+  ## context, or whichever bot did not run leaves the check permanently
+  ## absent and blocks the PR. Set it per repo via the integration's
+  ## launch_vars (durable across re-provisioning), the same value on every
+  ## bot that can gate. The default keeps this bot's historical name.
+  gate_context: string = "revi/review"
+
   ## Deterministic forge publish grant — INJECTED BY THE ITERION SERVER
   ## at launch when the run's team has a forge connection covering
   ## pr_url's repo (studio/API launches and inbound webhooks both
@@ -692,7 +702,7 @@ compute pr_gate:
 ## published is true ONLY on a 2xx from the endpoint, whose counts are
 ## forge-re-fetched (anti-façade), never self-estimated.
 tool publish_review:
-  command: `PUB_URL={{vars.forge_publish_url}} PUB_TOKEN={{vars.forge_publish_token}} MODE={{vars.pr_review_mode}} PR_URL={{input.pr_url}} FINDINGS={{input.findings}} QUESTIONS={{input.questions}} CLAUDE_FINDINGS={{input.claude_findings}} GPT_FINDINGS={{input.gpt_findings}} GATE_ENABLED={{vars.gate_enabled}} GATE_SEVERITY={{vars.gate_severity}} python3 -c "
+  command: `PUB_URL={{vars.forge_publish_url}} PUB_TOKEN={{vars.forge_publish_token}} MODE={{vars.pr_review_mode}} PR_URL={{input.pr_url}} FINDINGS={{input.findings}} QUESTIONS={{input.questions}} CLAUDE_FINDINGS={{input.claude_findings}} GPT_FINDINGS={{input.gpt_findings}} GATE_ENABLED={{vars.gate_enabled}} GATE_SEVERITY={{vars.gate_severity}} GATE_CONTEXT={{vars.gate_context}} python3 -c "
 import os, json, urllib.request, urllib.error
 
 def emit(published, forge='unknown', review_url='', posted=0, sugg=0, skipped='', summary=''):
@@ -804,6 +814,10 @@ payload = {'pr_url': pr, 'summary': nl.join(summary), 'mode': mode, 'comments': 
 # Deterministic merge-gate verdict: count findings at/above the blocking
 # severity floor. The server maps 0 blocking -> success, >0 -> failure on the
 # revi/review commit status. Questions never count.
+# Resolved unconditionally: the summary below reads it whenever the server
+# reports a posted gate, and a NameError in this deterministic final step
+# would cost the whole review.
+gate_ctx = str(os.environ.get('GATE_CONTEXT', '')).strip() or 'revi/review'
 gate_enabled = str(os.environ.get('GATE_ENABLED', '')).strip().lower() in ('1', 'true', 'yes', 'on')
 if gate_enabled:
     gate_sev = str(os.environ.get('GATE_SEVERITY', 'high')).strip().lower() or 'high'
@@ -835,7 +849,7 @@ if gate_enabled:
                 rank = 0
             if rank <= floor:
                 blocking += 1
-    payload['gate'] = {'enabled': True, 'context': 'revi/review',
+    payload['gate'] = {'enabled': True, 'context': gate_ctx,
                        'blocking_count': blocking, 'threshold': gate_sev,
                        'total_findings': len(findings)}
     # Never let the status describe an unreadable review as a real blocking
@@ -868,7 +882,7 @@ s = 'posted ' + str(posted) + ' inline comment(s), ' + str(sugg) + ' with one-cl
 if fallback:
     s = s + ' fallback=' + fallback + ': rejected inline anchors were folded into the review summary body, not dropped.'
 if bool(res.get('gate_posted')):
-    s = s + ' merge gate: revi/review=' + str(res.get('gate_state') or '') + ' on ' + str(res.get('gate_sha') or '')[:12] + '.'
+    s = s + ' merge gate: ' + gate_ctx + '=' + str(res.get('gate_state') or '') + ' on ' + str(res.get('gate_sha') or '')[:12] + '.'
 elif str(res.get('gate_error') or ''):
     s = s + ' merge gate NOT posted: ' + str(res.get('gate_error')) + '.'
 emit(bool(res.get('published')), forge=str(res.get('provider') or 'unknown'),

--- a/bots/secured-renovacy/skills/package-managers.md
+++ b/bots/secured-renovacy/skills/package-managers.md
@@ -65,6 +65,75 @@ read the project's CI / scripts to see which one the team actually
 maintains. The maintained one wins; the others are stale and not
 authoritative.
 
+## Dependencies that are not packages
+
+A package manager is not the only thing that pulls foreign code into a
+build. These four are updated by the same bots, bump the same way, and are
+exactly as able to execute code you did not review — treat them with the
+same rigour, not as "config changes".
+
+| File | What moved | Where the truth is |
+|---|---|---|
+| `Dockerfile` / `Containerfile` | base-image tag or `@sha256:` digest | the registry manifest + the image's own layers |
+| `devbox.json` / `devbox.lock` | a Nix package pin | nixhub.io / the nixpkgs commit in the lock |
+| `Chart.yaml` / `values*.yaml` | a chart version or an image tag | the chart repo + the image it references |
+| `.github/workflows/*`, `action.yml` | an Action pinned by tag or SHA | the action's repo at that ref |
+
+### Container image digests
+
+A digest bump is *usually* a rebuild of the same version — and that is
+precisely why it is worth checking rather than waving through: the tag did
+not change, so nothing else signals that the contents did.
+
+Resolve what actually moved:
+
+```sh
+# The bot's own devbox provides crane; the sandbox image has no registry
+# client of its own.
+crane digest golang:1.26                 # what the tag points at NOW
+crane manifest golang:1.26@sha256:<old>  # the pinned one
+crane config  golang:1.26@sha256:<new> | jq '.history[-3:], .config.Entrypoint, .config.User'
+```
+
+What to look at, in order: does the new digest still correspond to the tag
+the Dockerfile names (a digest that no tag resolves to is a red flag); did
+`User`, `Entrypoint` or `Cmd` change (a base image that stops dropping root
+is a real regression); did the last history entries gain a step that fetches
+something at build time. `trivy image --scanners vuln <ref>` gives the CVE
+delta between old and new — run it on both and diff, since the interesting
+answer is what the bump *fixes* versus what it *introduces*.
+
+If no registry client resolves, say so in the summary rather than implying
+you inspected the image. An unverified digest is a real caveat, not a detail.
+
+### Nix / devbox pins
+
+`devbox.json` carries the human-readable pin (`jq@1.8.2`); `devbox.lock`
+carries the resolved nixpkgs commit — the lock is what actually determines
+the bits. Check the version really exists on nixhub for that package, and
+that the lock's `resolved` URL and the version in `devbox.json` agree; a
+lock pointing at a commit unrelated to the stated version is the signal
+worth escalating. `devbox install --dry-run` (or `devbox info <pkg>`)
+confirms the pin resolves at all.
+
+### Helm charts
+
+A chart bump can change rendered manifests far beyond the version string.
+`helm template` the old and new charts with the repo's own values and diff
+the output — that is the real change set. Pay attention to anything that
+touches RBAC, `securityContext`, `hostPath`/`hostNetwork`, or a new image
+reference: a chart that quietly grants a ClusterRole is a supply-chain event
+even when the package itself is fine.
+
+### Pinned Actions
+
+An Action pinned by SHA that moves to another SHA is a code change in a
+build step that already holds a token. Read the diff between the two refs
+(`gh api repos/<owner>/<repo>/compare/<old>...<new>`), and give particular
+weight to changes in what it exfiltrates, what it writes, and any new
+network call. A tag that was re-pointed to a different commit without a
+release is the classic Action-hijack shape.
+
 ## Cache locations — keep them OUT of the workspace
 
 Most package managers default a cache (downloaded archives, compiled

--- a/bots/secured-renovacy/skills/verify-build.md
+++ b/bots/secured-renovacy/skills/verify-build.md
@@ -22,7 +22,17 @@ and the correct toolchain:
 
 - **Task runner / Makefile** — `Taskfile.yml` → `task build` / `task test` /
   `task check`; `Makefile` → `make build` / `make test`; `Justfile` → `just …`.
-  This is almost always the right answer when present.
+  This is almost always the right answer when present. List the targets that
+  actually exist (`task --list`, `make -qp`, `just --list`) instead of assuming
+  the conventional names: plenty of repos have `test` and `lint` but no `check`
+  umbrella, and a verify.sh calling a target that does not exist fails for a
+  reason that has nothing to do with the change under test.
+- **A gate CI runs inline is still a gate.** When CI invokes something the task
+  runner does not expose — a coverage threshold script, a schema check, a
+  shell assertion — copy that invocation into verify.sh verbatim. `task test`
+  passing while CI's `go test … && bash hack/coverage.sh cover.out 85` fails is
+  a green local verify on a red change, which is the exact failure the
+  deterministic gate exists to prevent.
 - **Pinned toolchain — honour it or the build fails on a version mismatch.**
   `devbox.json` → prefix with `devbox run -- …`. `.tool-versions` (asdf/mise),
   `.nvmrc`, `flake.nix`, `mise.toml` → activate accordingly. For Go: if

--- a/bots/test-coverage/skills/verify-build.md
+++ b/bots/test-coverage/skills/verify-build.md
@@ -22,7 +22,17 @@ and the correct toolchain:
 
 - **Task runner / Makefile** — `Taskfile.yml` → `task build` / `task test` /
   `task check`; `Makefile` → `make build` / `make test`; `Justfile` → `just …`.
-  This is almost always the right answer when present.
+  This is almost always the right answer when present. List the targets that
+  actually exist (`task --list`, `make -qp`, `just --list`) instead of assuming
+  the conventional names: plenty of repos have `test` and `lint` but no `check`
+  umbrella, and a verify.sh calling a target that does not exist fails for a
+  reason that has nothing to do with the change under test.
+- **A gate CI runs inline is still a gate.** When CI invokes something the task
+  runner does not expose — a coverage threshold script, a schema check, a
+  shell assertion — copy that invocation into verify.sh verbatim. `task test`
+  passing while CI's `go test … && bash hack/coverage.sh cover.out 85` fails is
+  a green local verify on a red change, which is the exact failure the
+  deterministic gate exists to prevent.
 - **Pinned toolchain — honour it or the build fails on a version mismatch.**
   `devbox.json` → prefix with `devbox run -- …`. `.tool-versions` (asdf/mise),
   `.nvmrc`, `flake.nix`, `mise.toml` → activate accordingly. For Go: if

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -837,7 +837,7 @@ or commits code — that is the improve-loops' job (Billy / Willy).
   auto-fixed. Read-only: Revi reports; Billy (branch-improve-loop)
   reviews AND fixes AND commits.
 - **Triggers**: review-pr, pr-review, review
-- **Vars**: `base_ref` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_enabled` (bool), `gate_severity` (string), `max_findings` (int), `post_to_board` (bool), `pr_review_mode` (string), `pr_url` (string), `report_path` (string), `scope_notes` (string), `severity_threshold` (string), `workspace_dir` (string)
+- **Vars**: `base_ref` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `gate_severity` (string), `max_findings` (int), `post_to_board` (bool), `pr_review_mode` (string), `pr_url` (string), `report_path` (string), `scope_notes` (string), `severity_threshold` (string), `workspace_dir` (string)
 - **Path**: `bots/review-pr/main.bot`
 
 ### `rgaa-audit` — Acci

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -450,7 +450,7 @@ audit ran and the build is green before anything is committed.
   alignment onto the PR branch. Not for human PRs (use Revi /
   review-pr), and not for proactively opening update PRs (that is
   Renovacy / secured-renovacy).
-- **Vars**: `base_ref` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_fix_iterations` (int), `post_to_board` (bool), `pr_author` (string), `pr_url` (string), `scope_notes` (string), `scratch_dir` (string), `workspace_dir` (string)
+- **Vars**: `arm_automerge` (bool), `automerge_method` (string), `base_ref` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_fix_iterations` (int), `post_to_board` (bool), `pr_author` (string), `pr_url` (string), `scope_notes` (string), `scratch_dir` (string), `workspace_dir` (string)
 - **Path**: `bots/dep-update-guard/main.bot`
 
 ### `devbox-setup` — Devy

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -450,7 +450,7 @@ audit ran and the build is green before anything is committed.
   alignment onto the PR branch. Not for human PRs (use Revi /
   review-pr), and not for proactively opening update PRs (that is
   Renovacy / secured-renovacy).
-- **Vars**: `base_ref` (string), `max_fix_iterations` (int), `post_to_board` (bool), `pr_author` (string), `pr_url` (string), `scope_notes` (string), `scratch_dir` (string), `workspace_dir` (string)
+- **Vars**: `base_ref` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_fix_iterations` (int), `post_to_board` (bool), `pr_author` (string), `pr_url` (string), `scope_notes` (string), `scratch_dir` (string), `workspace_dir` (string)
 - **Path**: `bots/dep-update-guard/main.bot`
 
 ### `devbox-setup` — Devy

--- a/bots/whole-improve-loop/skills/verify-build.md
+++ b/bots/whole-improve-loop/skills/verify-build.md
@@ -22,7 +22,17 @@ and the correct toolchain:
 
 - **Task runner / Makefile** — `Taskfile.yml` → `task build` / `task test` /
   `task check`; `Makefile` → `make build` / `make test`; `Justfile` → `just …`.
-  This is almost always the right answer when present.
+  This is almost always the right answer when present. List the targets that
+  actually exist (`task --list`, `make -qp`, `just --list`) instead of assuming
+  the conventional names: plenty of repos have `test` and `lint` but no `check`
+  umbrella, and a verify.sh calling a target that does not exist fails for a
+  reason that has nothing to do with the change under test.
+- **A gate CI runs inline is still a gate.** When CI invokes something the task
+  runner does not expose — a coverage threshold script, a schema check, a
+  shell assertion — copy that invocation into verify.sh verbatim. `task test`
+  passing while CI's `go test … && bash hack/coverage.sh cover.out 85` fails is
+  a green local verify on a red change, which is the exact failure the
+  deterministic gate exists to prevent.
 - **Pinned toolchain — honour it or the build fails on a version mismatch.**
   `devbox.json` → prefix with `devbox run -- …`. `.tool-versions` (asdf/mise),
   `.nvmrc`, `flake.nix`, `mise.toml` → activate accordingly. For Go: if

--- a/cmd/iterion/models.go
+++ b/cmd/iterion/models.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/SocialGouv/iterion/pkg/cli"
 	"github.com/spf13/cobra"
 )
@@ -26,7 +29,21 @@ Examples:
   iterion models anthropic/glm-5.2                # resolve one model
   iterion models openai/gpt-5.5 --json            # machine-readable
   iterion models --refresh                        # refresh cache, then list`,
-	Args: cobra.MaximumNArgs(1),
+	// `models` is both a leaf (it takes a model spec) and a group (it has
+	// `pricing`), so MaximumNArgs(1) read `iterion models pricng` as a model
+	// id and answered "unknown model" — a typo silently mistaken for a
+	// lookup. A model spec is always `provider/model-id`; anything else in
+	// that position is meant to be a subcommand, so name the ones that exist.
+	Args: func(c *cobra.Command, args []string) error {
+		if err := cobra.MaximumNArgs(1)(c, args); err != nil {
+			return err
+		}
+		if len(args) == 1 && !strings.Contains(args[0], "/") {
+			return fmt.Errorf("unknown subcommand %q for %q (a model is %q; see --help)",
+				args[0], c.CommandPath(), "provider/model-id")
+		}
+		return nil
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opts := cli.ModelsOptions{Refresh: modelsOpts.refresh}
 		if len(args) == 1 {

--- a/docs/bot-runs/dep-update-guard.md
+++ b/docs/bot-runs/dep-update-guard.md
@@ -6,6 +6,73 @@ consuming code, prove the tree with the deterministic verify gate,
 commit onto the PR branch, post the verdict comment. Never merges. See
 [bots/dep-update-guard/](../../bots/dep-update-guard/).
 
+## 2026-07-28 — v2.1.0: the classifier was auditing empty diffs, and the gate could never work (no run; defects found by inspection + adversarial review)
+
+- Status: **partial** — code validated locally and by review; no live cloud run
+  yet (the target repo is not in the forge App's installation scope, which
+  needs an Organization Owner).
+- Versions: bot 2.0.0 → 2.1.0 · iterion PR #306 (7 commits)
+- Method: wiring Vetty onto `socialgouv/buildkit-operator`'s Renovate PRs
+  end-to-end (audit → align → verdict → gate → auto-merge). Deterministic
+  nodes exercised against real fixtures; Revi reviewed the branch.
+
+### What the attempt actually found
+
+The bot did not fail loudly on this repo — it would have reported **"safe" on
+three of the four open Renovate PRs without reading anything**. `prepare`
+only recognised package manifests, so a PR moving a Dockerfile digest, a
+`devbox.json` pin or a `Taskfile.yml` tool matched nothing. Crucially it did
+not stop: `is_empty` means "no files changed", not "no manifest matched", so
+the run continued and handed the auditor an empty `bump_summary`. Verified on
+the real `renovate/golang-1.26` branch: 3 Dockerfiles, a 1684-char diff where
+the old classifier produced an empty string.
+
+Lesson worth keeping: **a scope flag and a coverage flag are not the same
+flag.** Conflating them is what turns "we found nothing to look at" into "we
+looked and found nothing".
+
+### Engine defects this surfaced
+
+- `review_on_sync` was **unreachable** — absent from the webhook API request
+  type (a PATCH carrying it returned 200 and changed nothing) and never set by
+  provisioning, so it could only ever be false in production. Since a commit
+  status lives on one SHA, that made every merge gate self-defeating: the
+  status went absent from the head after any push. Observed live on
+  SocialGouv/iterion#300 (20 checks green, PR blocked). Now derived from the
+  declared `statuses` scope.
+- A PR event could only launch **one** bot, via a hardcoded fallback, and the
+  shared author allowlist was nil'd as soon as one co-enabled bot was open —
+  so a dependency guard co-enabled with a reviewer was silently dropped along
+  with its author filter.
+- Author routing read the event **sender**, not the PR author, so a human
+  pushing a fix onto a dependency PR handed it to the wrong bot.
+
+### The adversarial review earned its keep
+
+Revi found four defects on the branch, two of which would have shipped broken:
+
+- `arm_automerge` sent **syntactically invalid GraphQL** (a sigil swap that
+  also rewrote GraphQL's own separators). The feature was dead, and the test
+  certified it green — the stub answered success to any body. The fix now
+  includes a stub that rejects what the API would, verified by reintroducing
+  the bug and watching the test fail.
+- The `ReviewOnSync` derivation ran only on a *fresh* provision, while the
+  already-provisioned repo — the production case — hits the idempotent
+  short-circuit. The fix fixed nothing that was already deployed.
+
+Lesson: **a test whose stub accepts anything certifies nothing.** Both of
+those were green in CI and broken in production; the pattern is a test that
+asserts on what we sent rather than on what a real peer would accept.
+
+### Lessons for next run
+
+- Point it at an npm/pypi PR: live validation is still Go/Docker-only.
+- The gate context must be pinned per repo (`launch_vars.gate_context`), the
+  same value on every bot that can gate — a per-bot required check deadlocks
+  whichever PRs that bot does not review.
+- `arm_automerge` is only safe on a repo that requires at least one check;
+  with none, a forge merges an armed PR immediately.
+
 ## 2026-07-14 — cloud run on a real Dependabot go-minor-patch PR (#182); excellent audit/align/verify, wired via `/vetty` command (run 019f60cf)
 
 - Status: **VALIDATED (cloud, real forge PR)** — Vetty ran end-to-end on a live

--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -93,21 +93,55 @@ Webhook config ([`pkg/webhooks/types.go`](../pkg/webhooks/types.go)):
 
 ## Activating the blocking gate on a repo
 
-The code posts the status unconditionally (advisory). To make it **block**:
+The code posts the status unconditionally (advisory). To make it **block**,
+add the gate's context to the branch-protection ruleset's required status
+checks (for this repo, the "main protected — merge queue" ruleset — see
+[merge-policy.md](merge-policy.md)):
 
-1. Enable `review_on_sync` on the repo's inbound webhook.
-2. Add `revi/review` to the branch-protection ruleset's required status
-   checks (for this repo, the "main protected — merge queue" ruleset — see
-   [merge-policy.md](merge-policy.md)). Example with `gh`:
+```sh
+# inspect the current ruleset, add the context to required_status_checks,
+# then PUT it back:
+gh api repos/OWNER/REPO/rulesets/<id>
+```
 
-   ```sh
-   # inspect the current ruleset, add "revi/review" to required_status_checks,
-   # then PUT it back:
-   gh api repos/OWNER/REPO/rulesets/<id>
-   ```
+Re-review on push is **not** something you have to remember: a status lives
+on one commit, so a gate that did not follow the head would leave the check
+absent — indistinguishable from "never reviewed" and unblockable by another
+review. Provisioning therefore turns `review_on_sync` on by itself for any
+repo where a co-enabled bot declares the `statuses` scope. The field is
+still settable per webhook (`review_on_sync` on the webhook API) for the
+cases the derivation does not cover.
 
 Repo admins keep their merge-queue bypass, so a stuck gate is never a hard
 block for an admin.
+
+## One gate, several bots
+
+A required check applies to **every** pull request. So on a repo where
+different bots review different PRs — a dependency guard (Vetty) on the
+update bot's PRs, the reviewer on the humans' — neither bot's own context
+can be the required one: whichever bot did not run leaves the check
+permanently absent and blocks the PR. Requiring both is worse, since each
+then blocks the other's PRs.
+
+Give them the same context instead. `gate_context` is a var on every bot
+that can gate (`revi/review` on Revi, `vetty/deps` on Vetty by default), so
+the repo declares one shared name and each bot fills it for the PRs it owns:
+
+```sh
+iterion remote forge repo-bots create --data '{
+  "connection_id": "<conn-id>",
+  "repo": "owner/repo",
+  "bot_ids": ["review-pr", "dep-update-guard"],
+  "launch_vars": { "gate_context": "iterion/review" }}'
+```
+
+Pin it through the **integration's** `launch_vars`, not the webhook's:
+provisioning rewrites the whole webhook config from the bots' manifests, so
+an override PATCHed onto the webhook is dropped at the next enable. The
+integration's launch vars are persisted and re-applied on every provision.
+
+Then require `iterion/review` — one check, whichever bot owns the PR.
 
 ## Overriding a finding
 

--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -136,6 +136,12 @@ iterion remote forge repo-bots create --data '{
   "launch_vars": { "gate_context": "iterion/review" }}'
 ```
 
+A review webhook is also where `overlap: supersede` earns its keep: with
+re-review on push, a burst of commits launches a run per push and the earlier
+ones reach a verdict about code that no longer exists. Set it on the same
+call (`"overlap": "supersede"`); it is persisted on the integration like the
+launch vars, so a later `bots enable` does not silently drop it.
+
 Pin it through the **integration's** `launch_vars`, not the webhook's:
 provisioning rewrites the whole webhook config from the bots' manifests, so
 an override PATCHed onto the webhook is dropped at the next enable. The

--- a/docs/workflow_authoring_pitfalls.md
+++ b/docs/workflow_authoring_pitfalls.md
@@ -227,6 +227,35 @@ In every row, the metric was a faithful measurement of **the surface
 property** but a poor proxy for **the underlying goal**. The agent satisfied
 the metrics. The goal stayed unmet.
 
+### The empty-input façade (2026-07, dep-update-guard)
+
+A variant worth its own name, because nothing in the workflow was gaming
+anything: the auditor was handed an **empty diff** and dutifully reported
+"safe". Its classifier only recognised package manifests, so a PR moving a
+container digest or a pinned tool matched nothing — and the run did not stop,
+because the flag guarding the exit meant "no files changed", not "no manifest
+recognised". Three of four real Renovate PRs would have been waved through by
+an agent that had read nothing.
+
+**A scope flag and a coverage flag are not the same flag.** Conflating them
+converts "we found nothing to look at" into "we looked and found nothing" —
+and the second is indistinguishable from success. When a node narrows what a
+downstream agent sees, it owes that agent an explicit signal that the
+narrowing found nothing, and the agent owes the reader a verdict that says so.
+
+### A stub that accepts anything certifies nothing
+
+The same change shipped an auto-merge step whose GraphQL was syntactically
+invalid — every request would have been rejected by the real API. It passed
+CI: the test's stub answered success to any body and only substring-matched
+the query. The feature was green in the suite and dead in production.
+
+A test double is a *claim about what a real peer accepts*. When it accepts
+strictly more than the real one, the test measures only that the code ran.
+Assert on what actually goes over the wire, and check the fix by
+reintroducing the bug and watching the test fail — a test that has never
+been seen red is a test whose sensitivity is unmeasured.
+
 ---
 
 ## Practical rules to internalize

--- a/pkg/bundle/manifest.go
+++ b/pkg/bundle/manifest.go
@@ -442,6 +442,33 @@ type ForgeWebhookHints struct {
 	// any author). A dependency-PR bot sets ["dependabot[bot]",
 	// "renovate[bot]"] so it reacts only to the dependency bots, not humans.
 	AuthorAllowlist []string `yaml:"author_allowlist,omitempty"`
+
+	// AuthorScope declares how AuthorAllowlist interacts with the OTHER bots
+	// co-enabled on the same repo webhook:
+	//
+	//   "shared" (default/empty) — other bots also react to these authors.
+	//   "exclusive"              — the authors I claim are MINE: provisioning
+	//                              adds them to every other co-enabled bot's
+	//                              author denylist, so a general reviewer
+	//                              stops double-reviewing the PRs this bot
+	//                              owns. The reviewer's own manifest stays
+	//                              free of any knowledge that this bot exists.
+	//
+	// Only meaningful together with a non-empty AuthorAllowlist.
+	AuthorScope string `yaml:"author_scope,omitempty"`
+}
+
+// Author-scope vocabulary for ForgeWebhookHints.AuthorScope.
+const (
+	AuthorScopeShared    = "shared"
+	AuthorScopeExclusive = "exclusive"
+)
+
+// IsExclusiveAuthors reports whether this bot claims its allowlisted authors
+// exclusively against the other bots sharing the repo webhook.
+func (h *ForgeWebhookHints) IsExclusiveAuthors() bool {
+	return h != nil && len(h.AuthorAllowlist) > 0 &&
+		strings.EqualFold(strings.TrimSpace(h.AuthorScope), AuthorScopeExclusive)
 }
 
 // SecretName returns the workflow-secret name this bot binds its forge
@@ -897,6 +924,13 @@ func validateForgeRequirements(f *ForgeRequirements) error {
 		}
 		if !knownForgeScopeLevels[level] {
 			return fmt.Errorf("forge.token_scopes[%s]: invalid level %q (want read, write, or admin)", key, level)
+		}
+	}
+	if f.Webhook != nil {
+		switch scope := strings.ToLower(strings.TrimSpace(f.Webhook.AuthorScope)); scope {
+		case "", AuthorScopeShared, AuthorScopeExclusive:
+		default:
+			return fmt.Errorf("forge.webhook.author_scope: unknown value %q (known: %s, %s)", scope, AuthorScopeShared, AuthorScopeExclusive)
 		}
 	}
 	return nil

--- a/pkg/bundle/manifest.go
+++ b/pkg/bundle/manifest.go
@@ -379,13 +379,19 @@ func knownForgeEventNames() []string {
 // forge.token_scopes block. The provisioner unions the keys across the
 // bots co-enabled on a repo and translates them to the tightest OAuth
 // scope / GitHub-App permission that satisfies the union.
+// ForgeScopeStatuses is the token scope a bot declares when it posts a commit
+// status. Declaring it means the bot can be a REQUIRED check, which the
+// provisioner has to account for beyond the token itself — a gate that does
+// not follow the head SHA blocks the PR it guards.
+const ForgeScopeStatuses = "statuses"
+
 var (
 	knownForgeScopeKeys = map[string]bool{
-		"pull_requests": true,
-		"repository":    true,
-		"issues":        true,
-		"webhooks":      true,
-		"statuses":      true, // commit statuses (the revi/review merge gate)
+		"pull_requests":    true,
+		"repository":       true,
+		"issues":           true,
+		"webhooks":         true,
+		ForgeScopeStatuses: true, // commit statuses (the merge gate)
 	}
 	knownForgeScopeLevels = map[string]bool{
 		"read":  true,

--- a/pkg/cli/schedule.go
+++ b/pkg/cli/schedule.go
@@ -211,14 +211,15 @@ func validateScheduleEntry(e ScheduleEntry) error {
 			return fmt.Errorf("invalid timeout %q: %w", e.Timeout, err)
 		}
 	}
-	if err := schedgate.Validate(schedgate.Policy{
+	// canReap=false: the host-cron tick drops GateOutcome.ReapRunIDs.
+	if err := schedgate.ValidateReapable(schedgate.Policy{
 		Overlap:       e.Overlap,
 		MaxConcurrent: e.MaxConcurrent,
 		Guard:         e.Guard,
 		GuardTimeout:  e.GuardTimeout,
 		GuardVar:      e.GuardVar,
 		StaleAfter:    e.StaleAfter,
-	}); err != nil {
+	}, false); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -257,7 +257,8 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 				return ProvisionResult{}, fmt.Errorf("forge: update integration launch vars: %w", uerr)
 			}
 			if cfg, gerr := o.Webhooks.Get(ctx, existing.WebhookID); gerr == nil {
-				cfg.LaunchVars = nilIfEmpty(mergeStringMaps(manifestLaunchVars(desiredBots, frByBot), operatorVars))
+				cfg.LaunchVars = nilIfEmpty(manifestLaunchVars(desiredBots, frByBot))
+				cfg.OperatorLaunchVars = nilIfEmpty(maps.Clone(operatorVars))
 				cfg.UpdatedAt = o.clock()
 				if uerr := o.Webhooks.Update(ctx, cfg); uerr != nil {
 					return ProvisionResult{}, fmt.Errorf("forge: update webhook launch vars: %w", uerr)
@@ -366,21 +367,7 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 
 	botRules := resolveBotRules(desiredBots, frByBot, invByBot)
 
-	// A bot that declares `statuses` posts a commit status, i.e. it can be a
-	// REQUIRED check. A required check lives on one head SHA: if the bot does
-	// not re-run when the author pushes a fix, the status is simply absent
-	// from the new head — indistinguishable from "never reviewed" — and the
-	// PR is blocked with no way forward but an admin bypass. Observed live on
-	// SocialGouv/iterion#300. So re-review on sync is not an operator
-	// preference here, it is what makes a gate survivable; it turns on from
-	// the DECLARED capability, never from a bot id.
-	reviewOnSync := false
-	for _, b := range desiredBots {
-		if fr := frByBot[b]; fr != nil && fr.TokenScopes[bundle.ForgeScopeStatuses] != "" {
-			reviewOnSync = true
-			break
-		}
-	}
+	reviewOnSync := anyBotGatesMerges(desiredBots, frByBot)
 
 	// Mint a fresh iwh_ on every mutating provision (create OR event-widen):
 	// it keeps the forge hook secret and the iterion config hash in lockstep
@@ -398,32 +385,33 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 
 	now := o.clock()
 	cfg := webhooks.Config{
-		ID:               webhookID,
-		TenantID:         req.TenantID,
-		Name:             provisionedWebhookName(conn.Provider, req.RepoFullName),
-		Provider:         webhooks.Provider(conn.Provider),
-		SignMode:         signModeFor(conn.Provider),
-		Enabled:          true,
-		TokenHash:        hash,
-		TokenLast4:       last4,
-		Fingerprint:      fingerprint,
-		BotIDs:           desiredBots,
-		DefaultBotID:     singleBotDefault(desiredBots),
-		BotRules:         botRules,
-		ProjectAllowlist: []string{req.RepoFullName},
-		EventAllowlist:   nativeEvents,
-		AuthorAllowlist:  authorAllowlist,
-		ReviewOnSync:     reviewOnSync,
-		ForgeBaseURL:     conn.BaseURL(),
-		RateLimit:        webhooks.Rate{Rate: 1, Burst: 10},
-		LaunchVars:       nilIfEmpty(mergeStringMaps(launchVars, operatorVars)),
-		SecretOverrides:  secretOverrides,
-		MinReplierRole:   minRole,
-		CommandMap:       commandMap,
-		ProvisionedBy:    "forge:" + conn.ID,
-		CreatedBy:        req.ActorID,
-		CreatedAt:        now,
-		UpdatedAt:        now,
+		ID:                 webhookID,
+		TenantID:           req.TenantID,
+		Name:               provisionedWebhookName(conn.Provider, req.RepoFullName),
+		Provider:           webhooks.Provider(conn.Provider),
+		SignMode:           signModeFor(conn.Provider),
+		Enabled:            true,
+		TokenHash:          hash,
+		TokenLast4:         last4,
+		Fingerprint:        fingerprint,
+		BotIDs:             desiredBots,
+		DefaultBotID:       singleBotDefault(desiredBots),
+		BotRules:           botRules,
+		ProjectAllowlist:   []string{req.RepoFullName},
+		EventAllowlist:     nativeEvents,
+		AuthorAllowlist:    authorAllowlist,
+		ReviewOnSync:       reviewOnSync,
+		ForgeBaseURL:       conn.BaseURL(),
+		RateLimit:          webhooks.Rate{Rate: 1, Burst: 10},
+		LaunchVars:         nilIfEmpty(launchVars),
+		OperatorLaunchVars: nilIfEmpty(maps.Clone(operatorVars)),
+		SecretOverrides:    secretOverrides,
+		MinReplierRole:     minRole,
+		CommandMap:         commandMap,
+		ProvisionedBy:      "forge:" + conn.ID,
+		CreatedBy:          req.ActorID,
+		CreatedAt:          now,
+		UpdatedAt:          now,
 	}
 	if cfg.SignMode == webhooks.SignModeHMAC {
 		sealed, err := webhooks.SealHMACSecret(o.Sealer, cfg.ID, plaintext)
@@ -940,29 +928,61 @@ func buildBotRules(bots []string, frByBot map[string]*bundle.ForgeRequirements, 
 	return rules
 }
 
-// backfillBotRules reconciles a webhook config's per-bot routing table when
-// the bot/event set is otherwise unchanged. It rewrites the config ONLY when
-// the table actually differs, so the common re-enable stays a true no-op.
+// backfillBotRules reconciles what a webhook config derives from its bots'
+// manifests, when the bot/event set is otherwise unchanged: the per-bot
+// routing table and whether a push must re-review. It rewrites the config
+// ONLY when something actually differs, so the common re-enable stays a true
+// no-op.
+//
+// Both reconciliations exist for the same reason — the ALREADY-provisioned
+// repo is the production case, and it reaches the short-circuit, not the full
+// path. A derivation that only runs on a fresh provision fixes nothing that
+// is already deployed.
 func (o *Orchestrator) backfillBotRules(ctx context.Context, webhookID string, bots []string, frByBot map[string]*bundle.ForgeRequirements, invByBot map[string][]bundle.Invocation) error {
 	if webhookID == "" {
 		return nil
 	}
 	want := resolveBotRules(bots, frByBot, invByBot)
+	wantSync := anyBotGatesMerges(bots, frByBot)
 	cfg, err := o.Webhooks.Get(ctx, webhookID)
 	if err != nil {
 		// A missing config is reported by the surrounding provision paths; a
 		// backfill is best-effort reconciliation, not the authority on it.
 		return nil //nolint:nilerr
 	}
-	if reflect.DeepEqual(cfg.BotRules, want) {
+	if reflect.DeepEqual(cfg.BotRules, want) && (!wantSync || cfg.ReviewOnSync) {
 		return nil
 	}
 	cfg.BotRules = want
+	// Only ever turned ON: an operator who deliberately disabled re-review on
+	// a repo whose bots gate must not have it silently re-enabled under them.
+	if wantSync {
+		cfg.ReviewOnSync = true
+	}
 	cfg.UpdatedAt = o.clock()
 	if err := o.Webhooks.Update(ctx, cfg); err != nil {
 		return fmt.Errorf("forge: backfill bot rules on webhook %s: %w", webhookID, err)
 	}
 	return nil
+}
+
+// anyBotGatesMerges reports whether any of these bots declares the `statuses`
+// scope — i.e. posts a commit status, i.e. can be a REQUIRED check.
+//
+// A required check lives on ONE head SHA: if the bot does not re-run when the
+// author pushes a fix, the status is simply absent from the new head —
+// indistinguishable from "never reviewed" — and the PR is blocked with no way
+// forward but an admin bypass (observed live on SocialGouv/iterion#300). So
+// re-review on sync is not an operator preference on such a repo, it is what
+// makes the gate survivable. Derived from the DECLARED capability, never from
+// a bot id.
+func anyBotGatesMerges(bots []string, frByBot map[string]*bundle.ForgeRequirements) bool {
+	for _, b := range bots {
+		if fr := frByBot[b]; fr != nil && fr.TokenScopes[bundle.ForgeScopeStatuses] != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveBotRules derives the complete per-bot routing table — events, author
@@ -1013,15 +1033,6 @@ func manifestLaunchVars(bots []string, frByBot map[string]*bundle.ForgeRequireme
 			maps.Copy(out, fr.Webhook.LaunchVars)
 		}
 	}
-	return out
-}
-
-// mergeStringMaps returns base with overlay applied on top (overlay wins),
-// without mutating either.
-func mergeStringMaps(base, overlay map[string]string) map[string]string {
-	out := make(map[string]string, len(base)+len(overlay))
-	maps.Copy(out, base)
-	maps.Copy(out, overlay)
 	return out
 }
 

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -231,6 +233,15 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 				return ProvisionResult{}, fmt.Errorf("forge: bind %s for bot %s: %w", frByBot[b].SecretName(), b, err)
 			}
 		}
+		// Backfill the per-bot routing table onto a config provisioned before
+		// BotRules existed. Without this the short-circuit is exactly what
+		// keeps an already-provisioned repo on the legacy single-bot path
+		// forever: re-enabling the same bots is a no-op, so the rules would
+		// never appear in production even though every test passes. Config
+		// write only — no token mint, no forge hook call.
+		if err := o.backfillBotRules(ctx, existing.WebhookID, desiredBots, frByBot, invByBot); err != nil {
+			return ProvisionResult{}, err
+		}
 		// An explicit cron override is a schedule mutation even when the
 		// bot/event set is unchanged — without this, re-enabling with a new
 		// cadence would be silently ignored by the idempotent short-circuit.
@@ -322,6 +333,8 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		return ProvisionResult{}, err
 	}
 
+	botRules := resolveBotRules(desiredBots, frByBot, invByBot)
+
 	// Mint a fresh iwh_ on every mutating provision (create OR event-widen):
 	// it keeps the forge hook secret and the iterion config hash in lockstep
 	// without ever needing the prior plaintext. The operator never sees it —
@@ -349,6 +362,7 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		Fingerprint:      fingerprint,
 		BotIDs:           desiredBots,
 		DefaultBotID:     singleBotDefault(desiredBots),
+		BotRules:         botRules,
 		ProjectAllowlist: []string{req.RepoFullName},
 		EventAllowlist:   nativeEvents,
 		AuthorAllowlist:  authorAllowlist,
@@ -816,6 +830,138 @@ func unionAllEvents(bots []string, frByBot map[string]*bundle.ForgeRequirements,
 	out := make([]string, 0, len(set))
 	for e := range set {
 		out = append(out, e)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// buildBotRules materialises one webhooks.BotRule per co-enabled bot: the
+// events it claims, its own author filter, and its own manifest launch vars.
+// This is what lets one repo webhook serve several bots that react to
+// DIFFERENT PRs — the flattened Config fields can only express a single
+// winner, so without rules a dependency guard and a reviewer sharing a repo
+// collapse into whichever one the legacy selection picks.
+//
+// The event set is derived in this order, and the order matters:
+//  1. the bot's kind=forge invocations (the typed routing contract);
+//  2. else its forge: block events MINUS the comment event — a manifest with
+//     a forge: block and no invocations must keep launching (third-party
+//     bots), but a comment must never auto-launch a bot: comments route
+//     through CommandMap;
+//  3. else no events — a command/board-only bot, reachable but never
+//     auto-launched.
+func buildBotRules(bots []string, frByBot map[string]*bundle.ForgeRequirements, invByBot map[string][]bundle.Invocation) []webhooks.BotRule {
+	rules := make([]webhooks.BotRule, 0, len(bots))
+	for _, b := range bots {
+		fr := frByBot[b]
+		rule := webhooks.BotRule{BotID: b}
+		if fr != nil && fr.Webhook != nil {
+			rule.AuthorAllowlist = append([]string(nil), fr.Webhook.AuthorAllowlist...)
+			rule.LaunchVars = nilIfEmpty(maps.Clone(fr.Webhook.LaunchVars))
+		}
+
+		eventSet := map[string]bool{}
+		actionSet := map[string]bool{}
+		for _, inv := range invByBot[b] {
+			if inv.Kind != bundle.InvocationKindForge || inv.Forge == nil {
+				continue
+			}
+			eventSet[inv.Forge.Event] = true
+			for _, a := range inv.Forge.Actions {
+				actionSet[a] = true
+			}
+			if rule.Mode == "" {
+				rule.Mode = string(inv.EffectiveMode())
+			}
+			if inv.Board != nil {
+				rule.LabelAllowlist = dedupSorted(append(rule.LabelAllowlist, inv.Board.AllLabels...))
+			}
+		}
+		if len(eventSet) == 0 && fr != nil {
+			for _, e := range fr.Events {
+				if e != bundle.ForgeEventPullRequestComment {
+					eventSet[e] = true
+				}
+			}
+		}
+		rule.Events = sortedKeys(eventSet)
+		rule.Actions = sortedKeys(actionSet)
+		rules = append(rules, rule)
+	}
+	return rules
+}
+
+// backfillBotRules reconciles a webhook config's per-bot routing table when
+// the bot/event set is otherwise unchanged. It rewrites the config ONLY when
+// the table actually differs, so the common re-enable stays a true no-op.
+func (o *Orchestrator) backfillBotRules(ctx context.Context, webhookID string, bots []string, frByBot map[string]*bundle.ForgeRequirements, invByBot map[string][]bundle.Invocation) error {
+	if webhookID == "" {
+		return nil
+	}
+	want := resolveBotRules(bots, frByBot, invByBot)
+	cfg, err := o.Webhooks.Get(ctx, webhookID)
+	if err != nil {
+		// A missing config is reported by the surrounding provision paths; a
+		// backfill is best-effort reconciliation, not the authority on it.
+		return nil //nolint:nilerr
+	}
+	if reflect.DeepEqual(cfg.BotRules, want) {
+		return nil
+	}
+	cfg.BotRules = want
+	cfg.UpdatedAt = o.clock()
+	if err := o.Webhooks.Update(ctx, cfg); err != nil {
+		return fmt.Errorf("forge: backfill bot rules on webhook %s: %w", webhookID, err)
+	}
+	return nil
+}
+
+// resolveBotRules derives the complete per-bot routing table — events, author
+// filters and the exclusive claims resolved against each other — from the
+// bots' manifests. Pure: same inputs always yield the same table, so callers
+// can compare it against a stored one to decide whether a config needs a
+// backfill.
+func resolveBotRules(bots []string, frByBot map[string]*bundle.ForgeRequirements, invByBot map[string][]bundle.Invocation) []webhooks.BotRule {
+	exclusive := map[string][]string{}
+	for _, b := range bots {
+		if fr := frByBot[b]; fr != nil && fr.Webhook.IsExclusiveAuthors() {
+			exclusive[b] = append([]string(nil), fr.Webhook.AuthorAllowlist...)
+		}
+	}
+	return applyExclusiveAuthors(buildBotRules(bots, frByBot, invByBot), exclusive)
+}
+
+// applyExclusiveAuthors materialises each bot's exclusive author claim into
+// every OTHER rule's denylist, so a general reviewer stops double-reviewing
+// the PRs a dependency guard owns WITHOUT the reviewer's manifest naming that
+// guard. Storing the denylist (rather than deriving it per request) keeps the
+// suppression auditable in the config the studio renders.
+//
+// Idempotent and order-independent; a bot never denies itself.
+func applyExclusiveAuthors(rules []webhooks.BotRule, exclusiveByBot map[string][]string) []webhooks.BotRule {
+	if len(exclusiveByBot) == 0 {
+		return rules
+	}
+	for i := range rules {
+		var deny []string
+		for bot, authors := range exclusiveByBot {
+			if bot == rules[i].BotID {
+				continue
+			}
+			deny = append(deny, authors...)
+		}
+		rules[i].AuthorDenylist = dedupSorted(deny)
+	}
+	return rules
+}
+
+func sortedKeys(set map[string]bool) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
 	}
 	sort.Strings(out)
 	return out

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -140,6 +140,11 @@ type ProvisionRequest struct {
 	// ScheduleCrons overrides a bot's schedule cron (botID → 5-field cron) for
 	// the operator's chosen cadence; falls back to the manifest suggested_cron.
 	ScheduleCrons map[string]string
+	// LaunchVars are operator overrides stamped onto every run this repo's
+	// bots launch, layered after their manifest vars. Persisted on the
+	// integration and re-applied on every Provision (see
+	// RepoIntegration.LaunchVars). Nil leaves the stored ones untouched.
+	LaunchVars map[string]string
 	// Replace makes BotIDs the EXACT desired set instead of a union with the
 	// existing integration's bots — the per-bot unbind path. The webhook
 	// events, command map and schedules reconcile down accordingly. Removing
@@ -191,6 +196,16 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		desiredBots = dedupSorted(append(append([]string{}, existing.BotIDs...), req.BotIDs...))
 	}
 
+	// Operator overrides survive a re-provision: Provision rewrites the whole
+	// webhook config from the manifests, so anything PATCHed onto the webhook
+	// is lost at the next enable. A nil request map means "leave them alone",
+	// not "clear them" — enabling one more bot must not silently drop the
+	// repo's own settings.
+	operatorVars := req.LaunchVars
+	if operatorVars == nil && hasExisting {
+		operatorVars = existing.LaunchVars
+	}
+
 	// Resolve every bot's forge requirements (its optional forge: block for
 	// credentials/scopes) AND its invocations (the typed routing contract).
 	// A bot is auto-provisionable when it has a forge: block OR a
@@ -231,6 +246,22 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		for _, b := range desiredBots {
 			if err := o.ensureBotBinding(ctx, req.TenantID, b, frByBot[b].SecretName(), existing.ManagedSecretID); err != nil {
 				return ProvisionResult{}, fmt.Errorf("forge: bind %s for bot %s: %w", frByBot[b].SecretName(), b, err)
+			}
+		}
+		// A changed operator override is a real mutation even when the bot set
+		// is not — without this the short-circuit would silently ignore it.
+		if !maps.Equal(operatorVars, existing.LaunchVars) {
+			existing.LaunchVars = operatorVars
+			existing.UpdatedAt = o.clock()
+			if uerr := o.Integrations.Update(ctx, existing); uerr != nil {
+				return ProvisionResult{}, fmt.Errorf("forge: update integration launch vars: %w", uerr)
+			}
+			if cfg, gerr := o.Webhooks.Get(ctx, existing.WebhookID); gerr == nil {
+				cfg.LaunchVars = nilIfEmpty(mergeStringMaps(manifestLaunchVars(desiredBots, frByBot), operatorVars))
+				cfg.UpdatedAt = o.clock()
+				if uerr := o.Webhooks.Update(ctx, cfg); uerr != nil {
+					return ProvisionResult{}, fmt.Errorf("forge: update webhook launch vars: %w", uerr)
+				}
 			}
 		}
 		// Backfill the per-bot routing table onto a config provisioned before
@@ -385,7 +416,7 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		ReviewOnSync:     reviewOnSync,
 		ForgeBaseURL:     conn.BaseURL(),
 		RateLimit:        webhooks.Rate{Rate: 1, Burst: 10},
-		LaunchVars:       nilIfEmpty(launchVars),
+		LaunchVars:       nilIfEmpty(mergeStringMaps(launchVars, operatorVars)),
 		SecretOverrides:  secretOverrides,
 		MinReplierRole:   minRole,
 		CommandMap:       commandMap,
@@ -449,6 +480,7 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		HookID:           hookID,
 		HookURL:          hookURL,
 		ManagedSecretID:  managedSecretID,
+		LaunchVars:       nilIfEmpty(maps.Clone(operatorVars)),
 		CreatedBy:        req.ActorID,
 		CreatedAt:        now,
 		UpdatedAt:        now,
@@ -970,6 +1002,27 @@ func applyExclusiveAuthors(rules []webhooks.BotRule, exclusiveByBot map[string][
 		rules[i].AuthorDenylist = dedupSorted(deny)
 	}
 	return rules
+}
+
+// manifestLaunchVars re-derives the union of the bots' own manifest launch
+// vars — the layer the operator's overrides sit on top of.
+func manifestLaunchVars(bots []string, frByBot map[string]*bundle.ForgeRequirements) map[string]string {
+	out := map[string]string{}
+	for _, b := range bots {
+		if fr := frByBot[b]; fr != nil && fr.Webhook != nil {
+			maps.Copy(out, fr.Webhook.LaunchVars)
+		}
+	}
+	return out
+}
+
+// mergeStringMaps returns base with overlay applied on top (overlay wins),
+// without mutating either.
+func mergeStringMaps(base, overlay map[string]string) map[string]string {
+	out := make(map[string]string, len(base)+len(overlay))
+	maps.Copy(out, base)
+	maps.Copy(out, overlay)
+	return out
 }
 
 func sortedKeys(set map[string]bool) []string {

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -145,6 +145,9 @@ type ProvisionRequest struct {
 	// integration and re-applied on every Provision (see
 	// RepoIntegration.LaunchVars). Nil leaves the stored ones untouched.
 	LaunchVars map[string]string
+	// Overlap is the operator's concurrency policy for this repo's webhook
+	// (pkg/schedgate vocabulary). Empty leaves the stored one untouched.
+	Overlap string
 	// Replace makes BotIDs the EXACT desired set instead of a union with the
 	// existing integration's bots — the per-bot unbind path. The webhook
 	// events, command map and schedules reconcile down accordingly. Removing
@@ -205,6 +208,10 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 	if operatorVars == nil && hasExisting {
 		operatorVars = existing.LaunchVars
 	}
+	operatorOverlap := req.Overlap
+	if operatorOverlap == "" && hasExisting {
+		operatorOverlap = existing.Overlap
+	}
 
 	// Resolve every bot's forge requirements (its optional forge: block for
 	// credentials/scopes) AND its invocations (the typed routing contract).
@@ -250,8 +257,9 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		}
 		// A changed operator override is a real mutation even when the bot set
 		// is not — without this the short-circuit would silently ignore it.
-		if !maps.Equal(operatorVars, existing.LaunchVars) {
+		if !maps.Equal(operatorVars, existing.LaunchVars) || operatorOverlap != existing.Overlap {
 			existing.LaunchVars = operatorVars
+			existing.Overlap = operatorOverlap
 			existing.UpdatedAt = o.clock()
 			if uerr := o.Integrations.Update(ctx, existing); uerr != nil {
 				return ProvisionResult{}, fmt.Errorf("forge: update integration launch vars: %w", uerr)
@@ -259,6 +267,7 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 			if cfg, gerr := o.Webhooks.Get(ctx, existing.WebhookID); gerr == nil {
 				cfg.LaunchVars = nilIfEmpty(manifestLaunchVars(desiredBots, frByBot))
 				cfg.OperatorLaunchVars = nilIfEmpty(maps.Clone(operatorVars))
+				cfg.Overlap = operatorOverlap
 				cfg.UpdatedAt = o.clock()
 				if uerr := o.Webhooks.Update(ctx, cfg); uerr != nil {
 					return ProvisionResult{}, fmt.Errorf("forge: update webhook launch vars: %w", uerr)
@@ -405,6 +414,7 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		RateLimit:          webhooks.Rate{Rate: 1, Burst: 10},
 		LaunchVars:         nilIfEmpty(launchVars),
 		OperatorLaunchVars: nilIfEmpty(maps.Clone(operatorVars)),
+		Overlap:            operatorOverlap,
 		SecretOverrides:    secretOverrides,
 		MinReplierRole:     minRole,
 		CommandMap:         commandMap,
@@ -469,6 +479,7 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		HookURL:          hookURL,
 		ManagedSecretID:  managedSecretID,
 		LaunchVars:       nilIfEmpty(maps.Clone(operatorVars)),
+		Overlap:          operatorOverlap,
 		CreatedBy:        req.ActorID,
 		CreatedAt:        now,
 		UpdatedAt:        now,

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -335,6 +335,22 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 
 	botRules := resolveBotRules(desiredBots, frByBot, invByBot)
 
+	// A bot that declares `statuses` posts a commit status, i.e. it can be a
+	// REQUIRED check. A required check lives on one head SHA: if the bot does
+	// not re-run when the author pushes a fix, the status is simply absent
+	// from the new head — indistinguishable from "never reviewed" — and the
+	// PR is blocked with no way forward but an admin bypass. Observed live on
+	// SocialGouv/iterion#300. So re-review on sync is not an operator
+	// preference here, it is what makes a gate survivable; it turns on from
+	// the DECLARED capability, never from a bot id.
+	reviewOnSync := false
+	for _, b := range desiredBots {
+		if fr := frByBot[b]; fr != nil && fr.TokenScopes[bundle.ForgeScopeStatuses] != "" {
+			reviewOnSync = true
+			break
+		}
+	}
+
 	// Mint a fresh iwh_ on every mutating provision (create OR event-widen):
 	// it keeps the forge hook secret and the iterion config hash in lockstep
 	// without ever needing the prior plaintext. The operator never sees it —
@@ -366,6 +382,7 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		ProjectAllowlist: []string{req.RepoFullName},
 		EventAllowlist:   nativeEvents,
 		AuthorAllowlist:  authorAllowlist,
+		ReviewOnSync:     reviewOnSync,
 		ForgeBaseURL:     conn.BaseURL(),
 		RateLimit:        webhooks.Rate{Rate: 1, Burst: 10},
 		LaunchVars:       nilIfEmpty(launchVars),

--- a/pkg/forge/orchestrator_botrules_test.go
+++ b/pkg/forge/orchestrator_botrules_test.go
@@ -216,6 +216,58 @@ func TestProvision_NoGatingBotLeavesReviewOnSyncAlone(t *testing.T) {
 	}
 }
 
+// Provision rebuilds the webhook config as a whole literal, so anything an
+// operator set only on the config is wiped by the next enable. That drift
+// already bit review_on_sync and launch_vars; overlap is the third field of
+// the same shape, and it lands on exactly the webhooks worth setting it on.
+func TestProvision_OperatorOverlapSurvivesReprovision(t *testing.T) {
+	o, _, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	res, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"dep-guard"}, ActorID: "u1",
+		Overlap:    "supersede",
+		LaunchVars: map[string]string{"gate_context": "iterion/review"},
+	})
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	assertPinned := func(t *testing.T, when string) {
+		t.Helper()
+		cfg, err := o.Webhooks.Get(ctx, res.WebhookID)
+		if err != nil {
+			t.Fatalf("%s: get config: %v", when, err)
+		}
+		if cfg.Overlap != "supersede" {
+			t.Errorf("%s: overlap = %q, want the operator's pin", when, cfg.Overlap)
+		}
+		if cfg.OperatorLaunchVars["gate_context"] != "iterion/review" {
+			t.Errorf("%s: gate_context lost: %v", when, cfg.OperatorLaunchVars)
+		}
+	}
+	assertPinned(t, "after the first provision")
+
+	// A MUTATING re-provision (one more bot) rebuilds the whole config.
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"dep-guard", "review-pr"}, ActorID: "u1",
+	}); err != nil {
+		t.Fatalf("re-provision: %v", err)
+	}
+	assertPinned(t, "after enabling one more bot")
+
+	// And a NO-OP re-provision must not drop them either.
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"dep-guard", "review-pr"}, ActorID: "u1",
+	}); err != nil {
+		t.Fatalf("no-op re-provision: %v", err)
+	}
+	assertPinned(t, "after a no-op re-provision")
+}
+
 // The migration guard: re-enabling an unchanged bot set short-circuits, so
 // without an explicit backfill an already-provisioned repo would stay on the
 // legacy single-bot path forever — tests green, production unchanged.

--- a/pkg/forge/orchestrator_botrules_test.go
+++ b/pkg/forge/orchestrator_botrules_test.go
@@ -1,0 +1,156 @@
+package forge
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+)
+
+func ruleFor(t *testing.T, rules []webhooks.BotRule, botID string) webhooks.BotRule {
+	t.Helper()
+	for _, r := range rules {
+		if r.BotID == botID {
+			return r
+		}
+	}
+	t.Fatalf("no rule for %q in %+v", botID, rules)
+	return webhooks.BotRule{}
+}
+
+// Two bots on one repo webhook each keep their OWN author filter and their own
+// launch vars — the property the flattened Config fields cannot express.
+func TestProvision_BotRulesPerBotRouting(t *testing.T) {
+	o, _, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	res, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"dep-guard", "review-pr"}, ActorID: "u1",
+	})
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	cfg, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatalf("get webhook config: %v", err)
+	}
+	if len(cfg.BotRules) != 2 {
+		t.Fatalf("want one rule per bot, got %+v", cfg.BotRules)
+	}
+
+	guard := ruleFor(t, cfg.BotRules, "dep-guard")
+	if !sameSet(guard.AuthorAllowlist, []string{"dependabot[bot]", "*renovate[bot]"}) {
+		t.Errorf("guard keeps its own allowlist even though the shared one re-opened: %v", guard.AuthorAllowlist)
+	}
+	// The comment event must NEVER reach a rule: it routes through CommandMap,
+	// so leaking it here would auto-launch the bot on every PR comment.
+	if !sameSet(guard.Events, []string{bundle.ForgeEventPullRequest}) {
+		t.Errorf("guard events = %v, want pull_request only", guard.Events)
+	}
+
+	reviewer := ruleFor(t, cfg.BotRules, "review-pr")
+	if len(reviewer.AuthorAllowlist) != 0 {
+		t.Errorf("reviewer declares no allowlist → stays open, got %v", reviewer.AuthorAllowlist)
+	}
+	if !sameSet(reviewer.AuthorDenylist, []string{"dependabot[bot]", "*renovate[bot]"}) {
+		t.Errorf("the guard's exclusive claim must land on the reviewer's denylist, got %v", reviewer.AuthorDenylist)
+	}
+	if guard.LaunchVars["pr_review_mode"] != "" {
+		t.Errorf("the reviewer's vars leaked into the guard: %v", guard.LaunchVars)
+	}
+	if reviewer.LaunchVars["pr_review_mode"] != "summary" {
+		t.Errorf("the reviewer lost its own vars: %v", reviewer.LaunchVars)
+	}
+
+	// And the routing this produces is the whole point.
+	if got := cfg.RulesForEvent(bundle.ForgeEventPullRequest, "socialgouv-renovate[bot]"); len(got) != 1 || got[0].BotID != "dep-guard" {
+		t.Errorf("a self-hosted renovate App PR must route to the guard alone, got %+v", got)
+	}
+	if got := cfg.RulesForEvent(bundle.ForgeEventPullRequest, "alice"); len(got) != 1 || got[0].BotID != "review-pr" {
+		t.Errorf("a human PR must route to the reviewer alone, got %+v", got)
+	}
+}
+
+// A bot with a forge: block and no invocations must keep launching, and a
+// bot claiming its authors alone must not deny itself.
+func TestProvision_BotRulesSingleBotNoSelfDeny(t *testing.T) {
+	o, _, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	res, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"dep-guard"}, ActorID: "u1",
+	})
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	cfg, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatalf("get webhook config: %v", err)
+	}
+	guard := ruleFor(t, cfg.BotRules, "dep-guard")
+	if len(guard.AuthorDenylist) != 0 {
+		t.Errorf("a bot must never deny itself, got %v", guard.AuthorDenylist)
+	}
+	if got := cfg.RulesForEvent(bundle.ForgeEventPullRequest, "renovate[bot]"); len(got) != 1 {
+		t.Errorf("the sole bot must still claim its own PRs, got %+v", got)
+	}
+}
+
+// The migration guard: re-enabling an unchanged bot set short-circuits, so
+// without an explicit backfill an already-provisioned repo would stay on the
+// legacy single-bot path forever — tests green, production unchanged.
+func TestProvision_NoOpReprovisionBackfillsBotRules(t *testing.T) {
+	o, fa, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	res, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"dep-guard", "review-pr"}, ActorID: "u1",
+	})
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+
+	// Simulate a config written before BotRules existed.
+	cfg, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatalf("get webhook config: %v", err)
+	}
+	priorHash := cfg.TokenHash
+	cfg.BotRules = nil
+	if err := o.Webhooks.Update(ctx, cfg); err != nil {
+		t.Fatalf("seed legacy config: %v", err)
+	}
+	hooksBefore := len(fa.hooks)
+
+	res2, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"dep-guard", "review-pr"}, ActorID: "u1",
+	})
+	if err != nil {
+		t.Fatalf("re-provision: %v", err)
+	}
+	if res2.Created {
+		t.Errorf("an unchanged bot set must stay a no-op provision")
+	}
+	after, err := o.Webhooks.Get(ctx, res2.WebhookID)
+	if err != nil {
+		t.Fatalf("get webhook config 2: %v", err)
+	}
+	if len(after.BotRules) != 2 {
+		t.Fatalf("the short-circuit must still backfill the routing table, got %+v", after.BotRules)
+	}
+	// A backfill is a config write only: no fresh token, no forge hook call.
+	if after.TokenHash != priorHash {
+		t.Errorf("backfill must not mint a new token")
+	}
+	if len(fa.hooks) != hooksBefore {
+		t.Errorf("backfill must not touch the forge hook")
+	}
+}

--- a/pkg/forge/orchestrator_botrules_test.go
+++ b/pkg/forge/orchestrator_botrules_test.go
@@ -145,6 +145,77 @@ func TestProvision_StatusesScopeEnablesReviewOnSync(t *testing.T) {
 	}
 }
 
+// The same migration guard for re-review: a repo already provisioned with a
+// gating bot reaches the SHORT-CIRCUIT, never the full path. A derivation that
+// only runs on a fresh provision leaves every deployed repo with the bug it
+// was written to close — the PR blocked on a status stuck to an old head.
+func TestProvision_NoOpReprovisionBackfillsReviewOnSync(t *testing.T) {
+	o, _, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	res, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/gated",
+		BotIDs: []string{"gate-bot"}, ActorID: "u1",
+	})
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	// Simulate the deployed state: provisioned before the derivation existed.
+	cfg, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatalf("get webhook config: %v", err)
+	}
+	cfg.ReviewOnSync = false
+	cfg.BotRules = nil
+	if err := o.Webhooks.Update(ctx, cfg); err != nil {
+		t.Fatalf("seed legacy config: %v", err)
+	}
+
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/gated",
+		BotIDs: []string{"gate-bot"}, ActorID: "u1",
+	}); err != nil {
+		t.Fatalf("re-provision: %v", err)
+	}
+	after, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatalf("get webhook config 2: %v", err)
+	}
+	if !after.ReviewOnSync {
+		t.Fatal("a gating bot on an already-provisioned repo must gain re-review on push")
+	}
+}
+
+// A repo whose bots post no status keeps re-review off: it costs a run per
+// push, and nothing there needs a status to follow the head.
+func TestProvision_NoGatingBotLeavesReviewOnSyncAlone(t *testing.T) {
+	o, _, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	res, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"dep-guard"}, ActorID: "u1",
+	})
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"dep-guard"}, ActorID: "u1",
+	}); err != nil {
+		t.Fatalf("re-provision: %v", err)
+	}
+	cfg, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatalf("get webhook config: %v", err)
+	}
+	if cfg.ReviewOnSync {
+		t.Error("no bot posts a status here — re-review on push must stay off")
+	}
+}
+
 // The migration guard: re-enabling an unchanged bot set short-circuits, so
 // without an explicit backfill an already-provisioned repo would stay on the
 // legacy single-bot path forever — tests green, production unchanged.

--- a/pkg/forge/orchestrator_botrules_test.go
+++ b/pkg/forge/orchestrator_botrules_test.go
@@ -101,6 +101,50 @@ func TestProvision_BotRulesSingleBotNoSelfDeny(t *testing.T) {
 	}
 }
 
+// A bot that declares `statuses` can be a REQUIRED check, and a required
+// check lives on ONE head SHA: if the bot does not re-run when the author
+// pushes a fix, the status is absent from the new head — indistinguishable
+// from "never reviewed" — and the PR is blocked with no way out but an admin
+// bypass. That is SocialGouv/iterion#300. Provisioning must therefore turn
+// re-review-on-sync on from the declared capability.
+func TestProvision_StatusesScopeEnablesReviewOnSync(t *testing.T) {
+	o, _, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	// dep-guard declares no `statuses` scope → no gate → no forced re-review.
+	res, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"dep-guard"}, ActorID: "u1",
+	})
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	cfg, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatalf("get webhook config: %v", err)
+	}
+	if cfg.ReviewOnSync {
+		t.Error("no bot posts a commit status → re-review on sync must stay off (it costs a run per push)")
+	}
+
+	// gate-bot does → every push must re-evaluate the gate on the new head.
+	res2, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/gated",
+		BotIDs: []string{"gate-bot"}, ActorID: "u1",
+	})
+	if err != nil {
+		t.Fatalf("provision gated: %v", err)
+	}
+	cfg2, err := o.Webhooks.Get(ctx, res2.WebhookID)
+	if err != nil {
+		t.Fatalf("get webhook config 2: %v", err)
+	}
+	if !cfg2.ReviewOnSync {
+		t.Error("a bot declaring statuses:write gates merges — its status must follow the head SHA")
+	}
+}
+
 // The migration guard: re-enabling an unchanged bot set short-circuits, so
 // without an explicit backfill an already-provisioned repo would stay on the
 // legacy single-bot path forever — tests green, production unchanged.

--- a/pkg/forge/orchestrator_test.go
+++ b/pkg/forge/orchestrator_test.go
@@ -107,6 +107,13 @@ func testBotLookup(botID string) (*bundle.ForgeRequirements, error) {
 				AuthorScope:     bundle.AuthorScopeExclusive,
 			},
 		}, nil
+	case "gate-bot":
+		// Declares `statuses` → posts a commit status → can be a required check.
+		return &bundle.ForgeRequirements{
+			Events:      []string{bundle.ForgeEventPullRequest},
+			TokenScopes: map[string]string{"pull_requests": "write", "statuses": "write"},
+			Secret:      "forge_token",
+		}, nil
 	case "no-forge-bot":
 		return nil, nil
 	default:

--- a/pkg/forge/orchestrator_test.go
+++ b/pkg/forge/orchestrator_test.go
@@ -103,7 +103,8 @@ func testBotLookup(botID string) (*bundle.ForgeRequirements, error) {
 			TokenScopes: map[string]string{"pull_requests": "write", "repository": "write"},
 			Secret:      "forge_token",
 			Webhook: &bundle.ForgeWebhookHints{
-				AuthorAllowlist: []string{"dependabot[bot]", "renovate[bot]"},
+				AuthorAllowlist: []string{"dependabot[bot]", "*renovate[bot]"},
+				AuthorScope:     bundle.AuthorScopeExclusive,
 			},
 		}, nil
 	case "no-forge-bot":
@@ -369,7 +370,7 @@ func TestProvision_AuthorAllowlist(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get webhook config: %v", err)
 	}
-	if !sameSet(cfg.AuthorAllowlist, []string{"dependabot[bot]", "renovate[bot]"}) {
+	if !sameSet(cfg.AuthorAllowlist, []string{"dependabot[bot]", "*renovate[bot]"}) {
 		t.Errorf("author allowlist = %v, want the dep bots", cfg.AuthorAllowlist)
 	}
 

--- a/pkg/forge/repo_integration_store.go
+++ b/pkg/forge/repo_integration_store.go
@@ -46,6 +46,13 @@ type RepoIntegration struct {
 	// exactly one required check and each bot fills it for the PRs it owns.
 	LaunchVars map[string]string `bson:"launch_vars,omitempty" json:"launch_vars,omitempty"`
 
+	// Overlap is the operator's concurrency policy for this repo's webhook
+	// (pkg/schedgate vocabulary; empty = allow, the historical behaviour).
+	// Persisted here for the same reason as LaunchVars: Provision rebuilds the
+	// webhook config as a whole literal, so anything set only on the config is
+	// wiped by the next enable.
+	Overlap string `bson:"overlap,omitempty" json:"overlap,omitempty"`
+
 	// SyncIssuesEnabled, when true, makes the forge→board sync worker mirror
 	// this repo's forge issues into the team's kanban board (one-way: forge is
 	// the source; a card's column is operator-owned once created). Toggled per

--- a/pkg/forge/repo_integration_store.go
+++ b/pkg/forge/repo_integration_store.go
@@ -36,6 +36,16 @@ type RepoIntegration struct {
 	// API (useless without the master key, but no reason to surface it).
 	ManagedSecretID string `bson:"managed_secret_id,omitempty" json:"-"`
 
+	// LaunchVars are the operator's per-repo overrides for every run this
+	// integration launches, layered LAST (after the bots' own manifest vars),
+	// and re-applied on every Provision. Provisioning rewrites the whole
+	// webhook config from the manifests, so an override PATCHed onto the
+	// webhook is silently lost at the next enable/update — persisting it here
+	// is what makes a per-repo choice durable. The canonical case is naming
+	// this repo's merge gate: with several bots able to post it, the repo has
+	// exactly one required check and each bot fills it for the PRs it owns.
+	LaunchVars map[string]string `bson:"launch_vars,omitempty" json:"launch_vars,omitempty"`
+
 	// SyncIssuesEnabled, when true, makes the forge→board sync worker mirror
 	// this repo's forge issues into the team's kanban board (one-way: forge is
 	// the source; a card's column is operator-owned once created). Toggled per

--- a/pkg/schedgate/gate.go
+++ b/pkg/schedgate/gate.go
@@ -49,11 +49,13 @@ type GateOutcome struct {
 	// Proceed it is left undecided — "fired" is only true after the
 	// launch attempt, which the caller owns.
 	Record TickRecord
-	// ReapRunIDs lists keepalive runs found stale (silent past
-	// StaleAfter) at this tick. The caller cancels them via its store so
-	// the zombies free resources; schedgate stays I/O-free. Non-empty
-	// only on the keepalive path, and only alongside Proceed (a stale
-	// run no longer blocks, so the tick fires a fresh one).
+	// ReapRunIDs lists the runs the caller must cancel at this tick. The
+	// caller does it via its own store so schedgate stays I/O-free. Two
+	// policies populate it, both alongside Proceed:
+	//   - keepalive: runs found stale (silent past StaleAfter) — zombies that
+	//     no longer block, so a fresh run fires and they are reaped;
+	//   - supersede: the LIVE runs, which the newer tick has made obsolete.
+	// Empty on every other policy.
 	ReapRunIDs []string
 }
 
@@ -71,12 +73,20 @@ func Apply(ctx context.Context, in GateInput) GateOutcome {
 		} else {
 			live = LiveRunsForSchedule(ctx, in.Lister, in.ScheduleID, in.Logger)
 		}
-		if decision, blocking := EvaluateOverlap(live, policy); decision == DecisionSkipOverlap {
+		switch decision, blocking := EvaluateOverlap(live, policy); decision {
+		case DecisionSkipOverlap:
 			rec := in.Record
 			rec.Decision = TickSkippedOverlap
 			rec.BlockingRunID = blocking
 			rec.Reason = fmt.Sprintf("blocked by live run %s (%d live, overlap=%s)", blocking, len(live), policy.Overlap)
 			return GateOutcome{Record: rec}
+		case DecisionSupersede:
+			// The newest tick wins: hand the live runs to the caller's cancel
+			// path (the same one keepalive uses to reap zombies) and fire.
+			// Falling through to Proceed without this would give supersede
+			// `allow` semantics — every tick firing alongside the runs it was
+			// supposed to replace — while the policy promises at-most-one-live.
+			reap = append(reap, live...)
 		}
 	}
 

--- a/pkg/schedgate/gate_test.go
+++ b/pkg/schedgate/gate_test.go
@@ -122,3 +122,38 @@ func TestApply(t *testing.T) {
 		}
 	})
 }
+
+// supersede lives in the SHARED vocabulary, so Validate accepts it on the
+// host-cron, cloud-schedule and trigger surfaces too — all of which go through
+// Apply. Without a branch here it fell through to Proceed with nothing to
+// cancel, i.e. `allow` semantics on three surfaces while the policy promises
+// at-most-one-live. The reap list is how a policy tells the caller to cancel.
+func TestApplySupersedeReapsTheLiveRuns(t *testing.T) {
+	out := Apply(context.Background(), GateInput{
+		Policy:     Policy{Overlap: OverlapSupersede},
+		ScheduleID: "s1",
+		Lister: &fakeLister{
+			ids: []string{"run-old", "run-older"},
+			runs: map[string]*store.Run{
+				"run-old":   {ID: "run-old", Status: store.RunStatusRunning},
+				"run-older": {ID: "run-older", Status: store.RunStatusRunning},
+			},
+		},
+	})
+	if !out.Proceed {
+		t.Fatal("supersede fires: the new tick is the one that matters")
+	}
+	if len(out.ReapRunIDs) != 2 {
+		t.Fatalf("the live runs must be handed to the caller to cancel, got %v", out.ReapRunIDs)
+	}
+	// skip must keep blocking — the two policies are opposites, not variants.
+	if blocked := Apply(context.Background(), GateInput{
+		Policy: Policy{Overlap: OverlapSkip}, ScheduleID: "s1",
+		Lister: &fakeLister{
+			ids:  []string{"run-old"},
+			runs: map[string]*store.Run{"run-old": {ID: "run-old", Status: store.RunStatusRunning}},
+		},
+	}); blocked.Proceed {
+		t.Fatal("skip must still block while a run is live")
+	}
+}

--- a/pkg/schedgate/policy.go
+++ b/pkg/schedgate/policy.go
@@ -26,10 +26,18 @@ import (
 // fresh run, and surfaced for reaping. It is what keeps a bot
 // continuously alive across short, individually-budgeted runs rather
 // than one immortal run.
+//
+// OverlapSupersede is the "only the newest input matters" policy: also
+// at-most-one-live, but the NEW work wins — the live run for the same key is
+// cancelled and the fresh one fires. Skip has it backwards for event-driven
+// work: when three pushes land in two minutes, skipping keeps the run that is
+// analysing the OLDEST code and drops the one that matches what is actually
+// on the branch.
 const (
 	OverlapSkip      = "skip"
 	OverlapAllow     = "allow"
 	OverlapKeepalive = "keepalive"
+	OverlapSupersede = "supersede"
 )
 
 // Guard defaults.
@@ -103,6 +111,10 @@ func Validate(p Policy) error {
 		if p.MaxConcurrent < 0 {
 			return fmt.Errorf("schedgate: max_concurrent must be >= 1 when set (0 = unlimited)")
 		}
+	case OverlapSupersede:
+		if p.MaxConcurrent != 0 {
+			return fmt.Errorf("schedgate: max_concurrent is invalid with overlap=supersede (at-most-one-live is the whole point)")
+		}
 	case OverlapKeepalive:
 		if p.MaxConcurrent != 0 {
 			return fmt.Errorf("schedgate: max_concurrent is invalid with overlap=keepalive (at-most-one-live is the whole point)")
@@ -117,7 +129,7 @@ func Validate(p Policy) error {
 			}
 		}
 	default:
-		return fmt.Errorf("schedgate: invalid overlap %q (want %q, %q or %q)", p.Overlap, OverlapSkip, OverlapAllow, OverlapKeepalive)
+		return fmt.Errorf("schedgate: invalid overlap %q (want %q, %q, %q or %q)", p.Overlap, OverlapSkip, OverlapAllow, OverlapKeepalive, OverlapSupersede)
 	}
 	if p.StaleAfter != "" && p.Overlap != OverlapKeepalive {
 		return fmt.Errorf("schedgate: stale_after is only valid with overlap=keepalive")
@@ -169,6 +181,11 @@ const (
 	DecisionFire Decision = iota
 	// DecisionSkipOverlap means firing would exceed the overlap policy.
 	DecisionSkipOverlap
+	// DecisionSupersede means fire, but cancel the live runs first: they are
+	// working on input the new tick has made obsolete. The caller performs the
+	// cancellation — schedgate has no I/O — and the returned ids are the runs
+	// to cancel, oldest first.
+	DecisionSupersede
 )
 
 // EvaluateOverlap decides whether a tick may fire given the schedule's
@@ -188,6 +205,9 @@ func EvaluateOverlap(liveIDs []string, p Policy) (Decision, string) {
 			return DecisionFire, ""
 		}
 		return DecisionSkipOverlap, liveIDs[0]
+	case OverlapSupersede:
+		// The newest input wins: the caller cancels the live runs and fires.
+		return DecisionSupersede, liveIDs[0]
 	default: // OverlapSkip and OverlapKeepalive: at-most-one-live.
 		// For keepalive, staleness has already emptied the live set
 		// upstream (LiveAndStaleRunsForSchedule), so any run reaching

--- a/pkg/schedgate/policy.go
+++ b/pkg/schedgate/policy.go
@@ -145,6 +145,26 @@ func Validate(p Policy) error {
 	return nil
 }
 
+// ValidateReapable is Validate plus the one thing Validate cannot know: some
+// launch surfaces have no way to cancel a live run, and `supersede` is
+// meaningless without one — it would silently degrade to `allow`, firing
+// alongside the very runs it promised to replace.
+//
+// A surface passes canReap=false when it drops GateOutcome.ReapRunIDs (the
+// host-cron path, and cloud schedules where the NATS lease is the liveness
+// authority). Rejecting at write time is the fail-closed choice: an operator
+// gets "not supported here" instead of semantics quietly inverted under them.
+func ValidateReapable(p Policy, canReap bool) error {
+	if err := Validate(p); err != nil {
+		return err
+	}
+	if p.Overlap == OverlapSupersede && !canReap {
+		return fmt.Errorf("schedgate: overlap=%s is not supported on this surface (it cannot cancel a live run); use %s or %s",
+			OverlapSupersede, OverlapSkip, OverlapAllow)
+	}
+	return nil
+}
+
 // GuardTimeoutDuration resolves the policy's guard timeout, falling
 // back to the default on empty or unparseable values (Validate rejects
 // the latter upstream; the fallback keeps runtime behavior total).

--- a/pkg/schedgate/policy_test.go
+++ b/pkg/schedgate/policy_test.go
@@ -127,3 +127,28 @@ func TestEvaluateOverlap(t *testing.T) {
 		})
 	}
 }
+
+// supersede is meaningless on a surface that cannot cancel a live run: it
+// would fire alongside the runs it promised to replace, i.e. `allow` while the
+// policy documents at-most-one-live. Two of the three schedule surfaces drop
+// GateOutcome.ReapRunIDs today, so the vocabulary being shared is exactly why
+// this has to be rejected at write time rather than discovered at tick time.
+func TestValidateReapable(t *testing.T) {
+	sup := Policy{Overlap: OverlapSupersede}
+	if err := ValidateReapable(sup, true); err != nil {
+		t.Fatalf("a surface that reaps accepts supersede: %v", err)
+	}
+	err := ValidateReapable(sup, false)
+	if err == nil {
+		t.Fatal("a surface that cannot cancel must reject supersede, not degrade to allow")
+	}
+	if !strings.Contains(err.Error(), OverlapSkip) || !strings.Contains(err.Error(), OverlapAllow) {
+		t.Errorf("the error must name what to use instead, got %q", err)
+	}
+	// Every other policy is unaffected by the surface's capability.
+	for _, p := range []Policy{{}, {Overlap: OverlapSkip}, {Overlap: OverlapAllow}, {Overlap: OverlapKeepalive}} {
+		if err := ValidateReapable(p, false); err != nil {
+			t.Errorf("%q must stay valid on any surface: %v", p.Overlap, err)
+		}
+	}
+}

--- a/pkg/server/forge_provisioning_routes.go
+++ b/pkg/server/forge_provisioning_routes.go
@@ -47,6 +47,12 @@ type forgeEnableReq struct {
 	// from the enable dialog's cron picker; empty falls back to the manifest
 	// suggested_cron.
 	ScheduleCrons map[string]string `json:"schedule_crons,omitempty"`
+	// LaunchVars are operator overrides stamped onto every run this repo's
+	// bots launch, layered after their manifest vars and re-applied on every
+	// re-provision. Nil leaves the stored ones untouched. The canonical use is
+	// naming this repo's merge gate (`gate_context`) so several bots fill ONE
+	// required check, each for the PRs it owns.
+	LaunchVars map[string]string `json:"launch_vars,omitempty"`
 }
 
 func (s *Server) handleEnableForgeRepoBots(w http.ResponseWriter, r *http.Request) {
@@ -75,6 +81,7 @@ func (s *Server) handleEnableForgeRepoBots(w http.ResponseWriter, r *http.Reques
 		RepoFullName:  strings.TrimSpace(req.Repo),
 		BotIDs:        req.BotIDs,
 		ScheduleCrons: req.ScheduleCrons,
+		LaunchVars:    req.LaunchVars,
 		ActorID:       id.UserID,
 	})
 	if err != nil {
@@ -95,6 +102,12 @@ type forgeUpdateReq struct {
 	// ScheduleCrons follows forgeEnableReq semantics for bots (re)gaining a
 	// schedule through this update.
 	ScheduleCrons map[string]string `json:"schedule_crons,omitempty"`
+	// LaunchVars are operator overrides stamped onto every run this repo's
+	// bots launch, layered after their manifest vars and re-applied on every
+	// re-provision. Nil leaves the stored ones untouched. The canonical use is
+	// naming this repo's merge gate (`gate_context`) so several bots fill ONE
+	// required check, each for the PRs it owns.
+	LaunchVars map[string]string `json:"launch_vars,omitempty"`
 }
 
 func (s *Server) handleUpdateForgeRepoBots(w http.ResponseWriter, r *http.Request) {
@@ -125,6 +138,7 @@ func (s *Server) handleUpdateForgeRepoBots(w http.ResponseWriter, r *http.Reques
 		RepoFullName:  ri.RepoFullName,
 		BotIDs:        req.BotIDs,
 		ScheduleCrons: req.ScheduleCrons,
+		LaunchVars:    req.LaunchVars,
 		ActorID:       id.UserID,
 		Replace:       true,
 	})

--- a/pkg/server/forge_provisioning_routes.go
+++ b/pkg/server/forge_provisioning_routes.go
@@ -53,6 +53,10 @@ type forgeEnableReq struct {
 	// naming this repo's merge gate (`gate_context`) so several bots fill ONE
 	// required check, each for the PRs it owns.
 	LaunchVars map[string]string `json:"launch_vars,omitempty"`
+	// Overlap is the repo's launch concurrency policy (pkg/schedgate
+	// vocabulary: allow | skip | supersede). Empty leaves the stored one
+	// untouched; on a review webhook `supersede` is the one worth setting.
+	Overlap string `json:"overlap,omitempty"`
 }
 
 func (s *Server) handleEnableForgeRepoBots(w http.ResponseWriter, r *http.Request) {
@@ -82,6 +86,7 @@ func (s *Server) handleEnableForgeRepoBots(w http.ResponseWriter, r *http.Reques
 		BotIDs:        req.BotIDs,
 		ScheduleCrons: req.ScheduleCrons,
 		LaunchVars:    req.LaunchVars,
+		Overlap:       req.Overlap,
 		ActorID:       id.UserID,
 	})
 	if err != nil {
@@ -108,6 +113,10 @@ type forgeUpdateReq struct {
 	// naming this repo's merge gate (`gate_context`) so several bots fill ONE
 	// required check, each for the PRs it owns.
 	LaunchVars map[string]string `json:"launch_vars,omitempty"`
+	// Overlap is the repo's launch concurrency policy (pkg/schedgate
+	// vocabulary: allow | skip | supersede). Empty leaves the stored one
+	// untouched; on a review webhook `supersede` is the one worth setting.
+	Overlap string `json:"overlap,omitempty"`
 }
 
 func (s *Server) handleUpdateForgeRepoBots(w http.ResponseWriter, r *http.Request) {
@@ -139,6 +148,7 @@ func (s *Server) handleUpdateForgeRepoBots(w http.ResponseWriter, r *http.Reques
 		BotIDs:        req.BotIDs,
 		ScheduleCrons: req.ScheduleCrons,
 		LaunchVars:    req.LaunchVars,
+		Overlap:       req.Overlap,
 		ActorID:       id.UserID,
 		Replace:       true,
 	})

--- a/pkg/server/schedules_routes.go
+++ b/pkg/server/schedules_routes.go
@@ -150,14 +150,16 @@ func (s *Server) handleCreateSchedule(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if err := schedgate.Validate(schedgate.Policy{
+	// canReap=false: the cloud gate drops ReapRunIDs — the NATS lease is the
+	// liveness authority there (see schedules_gate.go).
+	if err := schedgate.ValidateReapable(schedgate.Policy{
 		Overlap:       overlap,
 		MaxConcurrent: req.MaxConcurrent,
 		Guard:         req.Guard,
 		GuardTimeout:  req.GuardTimeout,
 		GuardVar:      req.GuardVar,
 		StaleAfter:    req.StaleAfter,
-	}); err != nil {
+	}, false); err != nil {
 		httpError(w, http.StatusBadRequest, "%s", err.Error())
 		return
 	}
@@ -311,7 +313,7 @@ func (s *Server) handleUpdateSchedule(w http.ResponseWriter, r *http.Request) {
 	if req.StaleAfter != nil {
 		merged.StaleAfter = *req.StaleAfter
 	}
-	if err := schedgate.Validate(merged); err != nil {
+	if err := schedgate.ValidateReapable(merged, false); err != nil {
 		httpError(w, http.StatusBadRequest, "%s", err.Error())
 		return
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -152,6 +152,10 @@ type Server struct {
 	// webhookLaunchBot overrides the inbound-webhook launch path (test
 	// seam). nil → realWebhookLaunchBot (resolve bot source + s.runs.Launch).
 	webhookLaunchBot func(ctx context.Context, botID string, vars map[string]string, repoURL, repoRef, projectPath string, keyOverrides, secretOverrides map[string]string) (string, error)
+
+	// webhookCancelRun cancels a run superseded by a newer delivery. Same
+	// test-seam shape as webhookLaunchBot; nil → s.runs.Cancel.
+	webhookCancelRun func(runID string) error
 	// scheduleClock overrides the wall clock the schedules CRUD stamps on
 	// CreatedAt / UpdatedAt / NextFireAt (test seam — tests need a
 	// deterministic instant to assert NextFire jumps to the expected slot).

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -347,8 +347,18 @@ func forgePREventTargets(
 	targets := make([]forgeLaunchTarget, 0, len(rules))
 	for _, rule := range rules {
 		vars := reviewPRVars(prURL, baseRef, scopeNotes, nil, extra)
+		// cfg.LaunchVars is the UNION of every co-enabled bot's manifest vars,
+		// so it only applies where a rule carries none of its own — layering it
+		// over the rule would let one bot's value win for the other, which is
+		// exactly what the per-bot table exists to prevent. The operator's own
+		// overrides are a separate layer and always win.
+		for k, v := range cfg.LaunchVars {
+			if _, pinned := rule.LaunchVars[k]; !pinned {
+				vars[k] = v
+			}
+		}
 		mergeVarsInto(vars, rule.LaunchVars)
-		mergeVarsInto(vars, cfg.LaunchVars)
+		mergeVarsInto(vars, cfg.OperatorLaunchVars)
 		targets = append(targets, forgeLaunchTarget{
 			BotID:   rule.BotID,
 			IdemKey: forgeIdemKey(idemBase, rule.BotID, cfg.HasBotRules()),

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -101,6 +101,23 @@ type webhookEventMeta struct {
 	SenderHandle string // username for audit (logged only, never in delivery audit row v1)
 }
 
+// applyWebhookVarLayers puts the two webhook-level var layers onto a
+// handler-built base, in the only order that keeps them meaning what they say:
+//
+//   - cfg.LaunchVars is the UNION of every co-enabled bot's manifest vars, so
+//     it fills in only where nothing more specific is pinned;
+//   - cfg.OperatorLaunchVars is the repo's own choice and always wins.
+//
+// Every launch lane goes through here. The operator layer is what pins a
+// repo's shared gate_context, and a lane that skipped it would post its status
+// under the bot's default context — leaving the required one stale, which is
+// exactly what a manual /revi is supposed to repair.
+func applyWebhookVarLayers(vars map[string]string, cfg webhooks.Config) map[string]string {
+	mergeVarsInto(vars, cfg.LaunchVars)
+	mergeVarsInto(vars, cfg.OperatorLaunchVars)
+	return vars
+}
+
 // mergeVarsInto copies every key from src into dst (overwriting on
 // collision) and returns dst. A nil src is a no-op. Used by the
 // webhook launch-vars builders to layer overlays (context vars,

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -294,6 +295,70 @@ func (s *Server) resolveReviewBot(
 	return s.checkBotPermitted(ctx, w, cfg, meta, botID, payloadHash, srcIP)
 }
 
+// resolveForgeEventBots returns every bot to launch for a forge EVENT
+// delivery (never a command — those route through CommandMap). Rule-driven
+// when the config carries a per-bot routing table; otherwise the legacy
+// single-bot fallback, so a pre-BotRules config behaves EXACTLY as before.
+//
+// It writes no HTTP response. An empty result means nothing matched: the
+// caller records a `filtered` delivery + 200 (never a 4xx — a 403 on a forge
+// hook is what makes GitHub disable it).
+func (s *Server) resolveForgeEventBots(cfg webhooks.Config, event, author string) []webhooks.BotRule {
+	if cfg.HasBotRules() {
+		return cfg.RulesForEvent(event, author)
+	}
+	botID := cfg.SelectBot()
+	if botID == "" {
+		botID = defaultWebhookBotReviewPR
+		if s.logger != nil {
+			s.logger.Warn("webhooks: config %s carries no bot_rules — falling back to the pinned review default %q; re-provision the integration to route per bot", cfg.ID, botID)
+		}
+	}
+	if !cfg.AllowsBot(botID) {
+		return nil
+	}
+	return []webhooks.BotRule{{BotID: botID}}
+}
+
+// forgeIdemKey derives a delivery's idempotency key for one bot. A fan-out
+// delivery produces N runs, so the key MUST carry the bot: otherwise the
+// second bot reads the first one's claim as a replay and never launches. A
+// legacy (no BotRules) delivery keeps the historical bot-less key byte for
+// byte, so an in-flight redelivery across the upgrade still dedupes.
+func forgeIdemKey(base, botID string, multi bool) string {
+	if !multi {
+		return knowledge.ChecksumHex([]byte(base))
+	}
+	return knowledge.ChecksumHex([]byte(base + "|" + botID))
+}
+
+// forgePREventTargets turns the resolved rules into launch targets for a
+// PR-shaped delivery. Each target gets a FRESH vars map layered
+// base < rule.LaunchVars < cfg.LaunchVars (the operator pin always wins) —
+// sharing one map would hand every bot the same publish grant, since
+// injectForgePublishVars mutates in place.
+func forgePREventTargets(
+	cfg webhooks.Config,
+	rules []webhooks.BotRule,
+	idemBase, prURL, baseRef, scopeNotes, cloneURL, sourceBranch string,
+	extra map[string]string,
+) []forgeLaunchTarget {
+	targets := make([]forgeLaunchTarget, 0, len(rules))
+	for _, rule := range rules {
+		vars := reviewPRVars(prURL, baseRef, scopeNotes, nil, extra)
+		mergeVarsInto(vars, rule.LaunchVars)
+		mergeVarsInto(vars, cfg.LaunchVars)
+		targets = append(targets, forgeLaunchTarget{
+			BotID:   rule.BotID,
+			IdemKey: forgeIdemKey(idemBase, rule.BotID, cfg.HasBotRules()),
+			Vars:    vars,
+			RepoURL: cloneURL,
+			RepoRef: sourceBranch,
+		})
+	}
+	return targets
+}
+
 // selectIssueLabeledBot picks the bot for a freshly-labeled issue. Unlike a
 // PR (which carries a diff to REVIEW), an issue must be TURNED INTO one, so
 // the reviewer default is wrong here. Precedence: an operator-pinned
@@ -419,6 +484,182 @@ func (s *Server) insertAndLaunchWebhook(
 	payloadHash string,
 	srcIP string,
 ) {
+	res := s.launchWebhookTarget(ctx, r, cfg, meta, forgeLaunchTarget{
+		BotID: botID, IdemKey: idemKey, Vars: vars, RepoURL: repoURL, RepoRef: repoRef,
+	}, payloadHash, srcIP)
+	if res.Status == webhooks.StatusLaunched {
+		s.scheduleForgeBoardProjection(meta.ProjectPath)
+	}
+	s.writeSingleLaunchResult(w, r, res)
+}
+
+// writeSingleLaunchResult reproduces, byte for byte, the response the
+// single-bot tail has always written — the shape provider handlers and the
+// studio still parse.
+func (s *Server) writeSingleLaunchResult(w http.ResponseWriter, r *http.Request, res webhookLaunchResult) {
+	switch {
+	case res.denial != nil:
+		s.writeLaunchDenial(w, r, res.denial)
+	case res.Status == webhooks.StatusDuplicate:
+		writeJSONStatus(w, http.StatusOK, map[string]string{
+			"status": webhooks.StatusDuplicate, "run_id": res.RunID, "delivery_id": res.DeliveryID,
+		})
+	case res.Status == webhooks.StatusLaunched:
+		writeJSONStatus(w, http.StatusAccepted, map[string]string{
+			"status": webhooks.StatusLaunched, "run_id": res.RunID, "delivery_id": res.DeliveryID,
+		})
+	default:
+		httpError(w, res.httpStatus, "%s", res.Error)
+	}
+}
+
+// forgeLaunchTarget is one resolved (bot, idempotency key, vars) triple of a
+// delivery. Vars MUST be a per-bot map: injectForgePublishVars mutates it in
+// place, so a map shared across bots would hand every run the same publish
+// grant.
+type forgeLaunchTarget struct {
+	BotID   string
+	IdemKey string
+	Vars    map[string]string
+	RepoURL string
+	RepoRef string
+}
+
+// webhookLaunchResult is one bot's outcome inside a (possibly multi-bot)
+// delivery. denial/httpStatus carry what the single-bot shell needs to write
+// the historical response verbatim.
+type webhookLaunchResult struct {
+	BotID      string `json:"bot"`
+	Status     string `json:"status"`
+	RunID      string `json:"run_id,omitempty"`
+	DeliveryID string `json:"delivery_id,omitempty"`
+	Error      string `json:"error,omitempty"`
+
+	denial     *launchDenial
+	httpStatus int
+}
+
+// scheduleForgeBoardProjection kicks the near-real-time forge→board refresh
+// for a repo. Once per DELIVERY, never once per bot: a fan-out would otherwise
+// queue N identical projections against the 16-slot semaphore.
+func (s *Server) scheduleForgeBoardProjection(repo string) {
+	if s.cfg.CloudBoardFor == nil || s.forgeIntegrations == nil {
+		return
+	}
+	select {
+	case forgeProjectionSem <- struct{}{}:
+		go func() {
+			defer func() { <-forgeProjectionSem }()
+			// Fresh background context (not derived from the request ctx) so the
+			// goroutine neither is cancelled by the response nor keeps the
+			// request's scoped values alive for its 30s lifetime.
+			pctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			s.projectForgeWebhookToBoard(pctx, repo)
+		}()
+	default:
+		// Concurrency cap reached — skip the fast path; the periodic
+		// forge→board sweep will reconcile this repo's cards.
+		if s.logger != nil {
+			s.logger.Debug("webhooks: forge→board fast-path projection skipped for %s (concurrency cap); periodic sweep will reconcile", repo)
+		}
+	}
+}
+
+// insertAndLaunchWebhookMulti runs one target per bot and writes ONE
+// aggregated response. Every target gets an entry — a fan-out never drops a
+// bot silently. On an org-scoped denial it stops (the next bot would be denied
+// identically) and marks the untried bots "skipped".
+func (s *Server) insertAndLaunchWebhookMulti(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	cfg webhooks.Config,
+	meta webhookEventMeta,
+	targets []forgeLaunchTarget,
+	payloadHash string,
+	srcIP string,
+) {
+	if len(targets) == 1 {
+		t := targets[0]
+		s.insertAndLaunchWebhook(ctx, w, r, cfg, meta, t.IdemKey, t.BotID, t.Vars, t.RepoURL, t.RepoRef, payloadHash, srcIP)
+		return
+	}
+
+	results := make([]webhookLaunchResult, 0, len(targets))
+	var firstDenial *launchDenial
+	for i, t := range targets {
+		res := s.launchWebhookTarget(ctx, r, cfg, meta, t, payloadHash, srcIP)
+		results = append(results, res)
+		if res.denial == nil {
+			continue
+		}
+		// Denials are org-scoped (concurrency, launch rate, monthly quota,
+		// cost cap) — retrying the next bot would deny identically and
+		// re-record the same terminal row.
+		firstDenial = res.denial
+		for _, skipped := range targets[i+1:] {
+			results = append(results, webhookLaunchResult{BotID: skipped.BotID, Status: "skipped"})
+		}
+		break
+	}
+
+	launched := 0
+	var firstRunID, firstDeliveryID string
+	for _, res := range results {
+		if res.Status != webhooks.StatusLaunched {
+			continue
+		}
+		launched++
+		if firstRunID == "" {
+			firstRunID, firstDeliveryID = res.RunID, res.DeliveryID
+		}
+	}
+	if launched > 0 {
+		s.scheduleForgeBoardProjection(meta.ProjectPath)
+	}
+
+	switch {
+	case launched > 0:
+		// A sibling failure is not fatal: its row is StatusLaunchError, which
+		// the replay check treats as retryable, so a redelivery relaunches
+		// exactly the bots that failed.
+		writeJSONStatus(w, http.StatusAccepted, map[string]any{
+			"status": webhooks.StatusLaunched, "run_id": firstRunID,
+			"delivery_id": firstDeliveryID, "launches": results,
+		})
+	case firstDenial != nil:
+		s.writeLaunchDenial(w, r, firstDenial)
+	default:
+		status, code := webhooks.StatusDuplicate, http.StatusOK
+		for _, res := range results {
+			if res.Status == webhooks.StatusLaunchError || res.httpStatus >= 500 {
+				status, code = webhooks.StatusLaunchError, http.StatusBadGateway
+				break
+			}
+		}
+		writeJSONStatus(w, code, map[string]any{
+			"status": status, "run_id": firstRunID, "delivery_id": firstDeliveryID, "launches": results,
+		})
+	}
+}
+
+// launchWebhookTarget is the per-bot core of the tail: replay check →
+// admission → delivery row → publish grant → launch → trigger-spine emit. It
+// writes no HTTP response and schedules no board projection, so it composes
+// for one bot or N.
+func (s *Server) launchWebhookTarget(
+	ctx context.Context,
+	r *http.Request,
+	cfg webhooks.Config,
+	meta webhookEventMeta,
+	t forgeLaunchTarget,
+	payloadHash string,
+	srcIP string,
+) webhookLaunchResult {
+	idemKey, botID, vars := t.IdemKey, t.BotID, t.Vars
+	out := webhookLaunchResult{BotID: botID}
+
 	// 1. Idempotency replay check — BEFORE metering. gateLaunch performs the
 	// per-org quota CAS *increment* (the increment IS the metering), so a
 	// forge redelivery of an already-processed event (lost ack, operator
@@ -440,10 +681,9 @@ func (s *Server) insertAndLaunchWebhook(
 		if existing, err := s.webhookDeliveries.GetByIdempotencyKey(ctx, idemKey); err == nil {
 			if existing.Status != webhooks.StatusLaunchError {
 				s.markWebhookOutcome(cfg.Provider, webhooks.StatusDuplicate)
-				writeJSONStatus(w, http.StatusOK, map[string]string{
-					"status": webhooks.StatusDuplicate, "run_id": existing.RunID, "delivery_id": existing.ID,
-				})
-				return
+				out.Status = webhooks.StatusDuplicate
+				out.RunID, out.DeliveryID = existing.RunID, existing.ID
+				return out
 			}
 			ex := existing
 			reusePriorFailure = &ex
@@ -457,8 +697,10 @@ func (s *Server) insertAndLaunchWebhook(
 	adm, d := s.gateLaunch(ctx)
 	if d != nil {
 		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusLaunchError, payloadHash, srcIP, d.reason)
-		s.writeLaunchDenial(w, r, d)
-		return
+		out.Status = webhooks.StatusLaunchError
+		out.Error = d.reason
+		out.denial = d
+		return out
 	}
 
 	// 3. Idempotency insert (durable dedupe backstop for concurrent
@@ -474,8 +716,11 @@ func (s *Server) insertAndLaunchWebhook(
 		delivery.ReceivedAt = reusePriorFailure.ReceivedAt
 		if s.webhookDeliveries != nil {
 			if err := s.webhookDeliveries.Update(ctx, delivery); err != nil {
-				httpError(w, http.StatusInternalServerError, "reset failed delivery: %v", err)
-				return
+				adm.rollback(s.logger)
+				out.Status = webhooks.StatusLaunchError
+				out.Error = fmt.Sprintf("reset failed delivery: %v", err)
+				out.httpStatus = http.StatusInternalServerError
+				return out
 			}
 		}
 	} else if s.webhookDeliveries != nil {
@@ -493,17 +738,21 @@ func (s *Server) insertAndLaunchWebhook(
 				// surface it as a 500 instead.
 				existing, gerr := s.webhookDeliveries.GetByIdempotencyKey(ctx, idemKey)
 				if gerr != nil {
-					httpError(w, http.StatusInternalServerError, "lookup duplicate delivery: %v", gerr)
-					return
+					out.Status = webhooks.StatusLaunchError
+					out.Error = fmt.Sprintf("lookup duplicate delivery: %v", gerr)
+					out.httpStatus = http.StatusInternalServerError
+					return out
 				}
 				s.markWebhookOutcome(cfg.Provider, webhooks.StatusDuplicate)
-				writeJSONStatus(w, http.StatusOK, map[string]string{
-					"status": webhooks.StatusDuplicate, "run_id": existing.RunID, "delivery_id": existing.ID,
-				})
-				return
+				out.Status = webhooks.StatusDuplicate
+				out.RunID, out.DeliveryID = existing.RunID, existing.ID
+				return out
 			}
-			httpError(w, http.StatusInternalServerError, "record delivery: %v", err)
-			return
+			adm.rollback(s.logger)
+			out.Status = webhooks.StatusLaunchError
+			out.Error = fmt.Sprintf("record delivery: %v", err)
+			out.httpStatus = http.StatusInternalServerError
+			return out
 		}
 	}
 
@@ -524,14 +773,17 @@ func (s *Server) insertAndLaunchWebhook(
 	// meta.ProjectPath is the forge slug already parsed by the provider
 	// handler — thread it onto the launch so the run is filterable by
 	// repository in the studio.
-	runID, lerr := launch(ctx, botID, vars, repoURL, repoRef, meta.ProjectPath, cfg.KeyOverrides, cfg.SecretOverrides)
+	runID, lerr := launch(ctx, botID, vars, t.RepoURL, t.RepoRef, meta.ProjectPath, cfg.KeyOverrides, cfg.SecretOverrides)
 	if lerr != nil {
 		delivery.Status = webhooks.StatusLaunchError
 		delivery.Error = lerr.Error()
 		s.updateWebhookDelivery(ctx, delivery)
 		s.markWebhookOutcome(cfg.Provider, webhooks.StatusLaunchError)
-		httpError(w, http.StatusBadGateway, "launch failed: %v", lerr)
-		return
+		out.Status = webhooks.StatusLaunchError
+		out.Error = fmt.Sprintf("launch failed: %v", lerr)
+		out.DeliveryID = delivery.ID
+		out.httpStatus = http.StatusBadGateway
+		return out
 	}
 	launchedAt := time.Now().UTC()
 	delivery.Status = webhooks.StatusLaunched
@@ -543,37 +795,12 @@ func (s *Server) insertAndLaunchWebhook(
 	// Mirror the launch onto the trigger spine (observational; carries
 	// launched_run_id so the evaluator never re-launches). Unifies forge with
 	// board/run/schedule sources; no-op without the spine wired.
-	s.emitForgeTriggerEvent(ctx, cfg, meta, botID, vars, repoURL, repoRef, runID)
-
-	// Near-real-time forge→board projection: refresh the affected repo's cards
-	// now instead of at the next periodic sweep. Detached context + goroutine so
-	// it never delays the webhook ack; best-effort, no-op without the cloud board.
-	if s.cfg.CloudBoardFor != nil && s.forgeIntegrations != nil {
-		repo := meta.ProjectPath
-		select {
-		case forgeProjectionSem <- struct{}{}:
-			go func() {
-				defer func() { <-forgeProjectionSem }()
-				// Fresh background context (not derived from the request ctx) so the
-				// goroutine neither is cancelled by the response nor keeps the
-				// request's scoped values alive for its 30s lifetime.
-				pctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-				defer cancel()
-				s.projectForgeWebhookToBoard(pctx, repo)
-			}()
-		default:
-			// Concurrency cap reached — skip the fast path; the periodic
-			// forge→board sweep will reconcile this repo's cards.
-			if s.logger != nil {
-				s.logger.Debug("webhooks: forge→board fast-path projection skipped for %s (concurrency cap); periodic sweep will reconcile", repo)
-			}
-		}
-	}
+	s.emitForgeTriggerEvent(ctx, cfg, meta, botID, vars, t.RepoURL, t.RepoRef, runID)
 
 	if s.logger != nil {
 		s.logger.Info("webhooks: %s/%s %s launched %s run=%s", cfg.Provider, meta.ProjectPath, meta.SubjectID, botID, runID)
 	}
-	writeJSONStatus(w, http.StatusAccepted, map[string]string{
-		"status": webhooks.StatusLaunched, "run_id": runID, "delivery_id": delivery.ID,
-	})
+	out.Status = webhooks.StatusLaunched
+	out.RunID, out.DeliveryID = runID, delivery.ID
+	return out
 }

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/SocialGouv/iterion/pkg/knowledge"
+	"github.com/SocialGouv/iterion/pkg/schedgate"
 	"github.com/SocialGouv/iterion/pkg/store"
 	"github.com/SocialGouv/iterion/pkg/webhooks"
 )
@@ -539,6 +540,64 @@ type webhookLaunchResult struct {
 	httpStatus int
 }
 
+// supersedeLiveRuns cancels the runs a fresh delivery has made obsolete, when
+// the webhook opts into overlap=supersede.
+//
+// The key is (webhook, subject, bot) — ONE pull request's runs of ONE bot, not
+// the repo's. Two PRs must review concurrently, and two different bots on the
+// same PR are doing different jobs; neither supersedes the other.
+//
+// Best-effort by construction: a cancel that fails must not stop the new run
+// from launching, because the new run is the one carrying the current truth.
+// Every outcome is logged — a superseded run is a real event an operator will
+// see in the run list and needs to be able to explain.
+func (s *Server) supersedeLiveRuns(ctx context.Context, cfg webhooks.Config, meta webhookEventMeta, botID string) {
+	cancel := s.webhookCancelRun
+	if cancel == nil && s.runs != nil {
+		cancel = s.runs.Cancel
+	}
+	if cfg.Overlap == "" || s.webhookDeliveries == nil || cancel == nil {
+		return
+	}
+	if decision, _ := schedgate.EvaluateOverlap([]string{"probe"}, cfg.OverlapPolicy()); decision != schedgate.DecisionSupersede {
+		return
+	}
+	if meta.SubjectID == "" {
+		return // no subject to scope the supersede to; never cancel repo-wide
+	}
+	recent, err := s.webhookDeliveries.ListByWebhook(ctx, cfg.TenantID, cfg.ID, supersedeLookback)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("webhooks: supersede lookup failed for %s %s: %v", cfg.ID, meta.SubjectID, err)
+		}
+		return
+	}
+	for _, d := range recent {
+		if d.RunID == "" || d.BotID != botID || d.SubjectID != meta.SubjectID {
+			continue
+		}
+		if d.Status != webhooks.StatusLaunched {
+			continue
+		}
+		// Cancel is a no-op on a run that already finished, so the delivery
+		// row's status is enough of a filter — no run lookup needed.
+		if cerr := cancel(d.RunID); cerr != nil {
+			if s.logger != nil {
+				s.logger.Debug("webhooks: supersede could not cancel run %s (likely already finished): %v", d.RunID, cerr)
+			}
+			continue
+		}
+		if s.logger != nil {
+			s.logger.Info("webhooks: superseded run %s (%s on %s) — a newer delivery for the same subject arrived", d.RunID, botID, meta.SubjectID)
+		}
+	}
+}
+
+// supersedeLookback bounds the delivery scan behind a supersede check. A PR's
+// live runs are necessarily among the most recent deliveries on its webhook,
+// and an unbounded scan would put the whole delivery history on the hot path.
+const supersedeLookback = 50
+
 // scheduleForgeBoardProjection kicks the near-real-time forge→board refresh
 // for a repo. Once per DELIVERY, never once per bot: a fan-out would otherwise
 // queue N identical projections against the 16-slot semaphore.
@@ -689,6 +748,11 @@ func (s *Server) launchWebhookTarget(
 			reusePriorFailure = &ex
 		}
 	}
+
+	// 1b. Supersede: this delivery's input makes the live run for the same
+	// subject obsolete (a newer commit on the same PR). Cancel before
+	// metering, so the superseded run's slot is freed for the fresh one.
+	s.supersedeLiveRuns(ctx, cfg, meta, botID)
 
 	// 2. Run-launch admission. Only reached for a genuinely new delivery
 	// (replays were filtered in step 1), so the quota CAS fires once per

--- a/pkg/server/webhooks_fanout_test.go
+++ b/pkg/server/webhooks_fanout_test.go
@@ -1,0 +1,332 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
+)
+
+// The fan-out lane: one repo webhook, two bots, each reacting to ITS OWN
+// authors. These tests pin the properties that make it safe — a delivery must
+// never launch a bot whose author filter excludes the sender, never drop a bot
+// whose filter admits it, and never let two bots share one idempotency claim.
+
+const ghRenovatePR = `{
+  "action": "opened",
+  "number": 8,
+  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+  "pull_request": {"number": 8, "title": "chore(deps): bump lib", "body": "renovate",
+    "html_url": "https://github.com/acme/widgets/pull/8", "state": "open",
+    "head": {"ref": "renovate/lib-1.x", "sha": "def456"}, "base": {"ref": "main"}},
+  "sender": {"login": "socialgouv-renovate[bot]"}
+}`
+
+// fanoutConfig is ghConfig plus the two-bot routing table the orchestrator
+// produces for a repo with a dependency guard (author-exclusive) and a general
+// reviewer (open) co-enabled.
+func fanoutConfig(t *testing.T, s *Server) (webhooks.Config, string) {
+	t.Helper()
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"dep-update-guard", "review-pr"}
+	cfg.DefaultBotID = "" // >1 bot → the legacy selection is ambiguous
+	depAuthors := []string{"dependabot[bot]", "*renovate[bot]"}
+	cfg.BotRules = []webhooks.BotRule{
+		{
+			BotID:           "dep-update-guard",
+			Events:          []string{bundle.ForgeEventPullRequest},
+			AuthorAllowlist: depAuthors,
+			LaunchVars:      map[string]string{"post_to_board": "false", "max_fix_iterations": "2"},
+		},
+		{
+			BotID:          "review-pr",
+			Events:         []string{bundle.ForgeEventPullRequest},
+			AuthorDenylist: depAuthors, // materialised from the guard's exclusive claim
+			LaunchVars:     map[string]string{"pr_review_mode": "inline"},
+		},
+	}
+	return cfg, pt
+}
+
+type launchRecord struct {
+	bot  string
+	vars map[string]string
+}
+
+// recordingLauncher installs a launcher capturing every (bot, vars) launch and
+// returns the slice it appends to.
+func fanoutLauncher(s *Server) *[]launchRecord {
+	var got []launchRecord
+	s.webhookLaunchBot = func(_ context.Context, bot string, vars map[string]string, _, _, _ string, _, _ map[string]string) (string, error) {
+		got = append(got, launchRecord{bot: bot, vars: vars})
+		return "run-" + bot, nil
+	}
+	return &got
+}
+
+func botsOf(recs []launchRecord) []string {
+	out := make([]string, 0, len(recs))
+	for _, r := range recs {
+		out = append(out, r.bot)
+	}
+	return out
+}
+
+func TestFanOut_RenovatePRLaunchesOnlyTheGuard(t *testing.T) {
+	s := newWebhookTestServer(t)
+	got := fanoutLauncher(s)
+	cfg, pt := fanoutConfig(t, s)
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghRenovatePR, prforge.EventHeaderPullRequest, pt))
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	if bots := botsOf(*got); len(bots) != 1 || bots[0] != "dep-update-guard" {
+		t.Fatalf("renovate PR must launch only the guard, got %v", bots)
+	}
+}
+
+func TestFanOut_HumanPRLaunchesOnlyTheReviewer(t *testing.T) {
+	s := newWebhookTestServer(t)
+	got := fanoutLauncher(s)
+	cfg, pt := fanoutConfig(t, s)
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghOpenPR, prforge.EventHeaderPullRequest, pt))
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	if bots := botsOf(*got); len(bots) != 1 || bots[0] != "review-pr" {
+		t.Fatalf("human PR must launch only the reviewer, got %v", bots)
+	}
+}
+
+func TestFanOut_BothMatchLaunchesBoth(t *testing.T) {
+	s := newWebhookTestServer(t)
+	got := fanoutLauncher(s)
+	cfg, pt := fanoutConfig(t, s)
+	// Drop the exclusivity: both rules now admit any author.
+	cfg.BotRules[0].AuthorAllowlist = nil
+	cfg.BotRules[1].AuthorDenylist = nil
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghOpenPR, prforge.EventHeaderPullRequest, pt))
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	bots := botsOf(*got)
+	if len(bots) != 2 {
+		t.Fatalf("both rules match → 2 launches, got %v", bots)
+	}
+	var body struct {
+		Status   string `json:"status"`
+		Launches []struct {
+			Bot    string `json:"bot"`
+			Status string `json:"status"`
+			RunID  string `json:"run_id"`
+		} `json:"launches"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v (%s)", err, w.Body.String())
+	}
+	if body.Status != webhooks.StatusLaunched || len(body.Launches) != 2 {
+		t.Fatalf("aggregate response: %s", w.Body.String())
+	}
+	if body.Launches[0].RunID == body.Launches[1].RunID {
+		t.Fatalf("each bot must get its own run: %s", w.Body.String())
+	}
+}
+
+// The single most likely way to ship this broken: if both bots claimed the
+// same idempotency key, the second would read the first one's claim as a
+// replay and never launch.
+func TestFanOut_PerBotIdempotencyKeysDiffer(t *testing.T) {
+	base := "gh|t1|ghw|acme/widgets|8|def456"
+	a := forgeIdemKey(base, "dep-update-guard", true)
+	b := forgeIdemKey(base, "review-pr", true)
+	if a == b {
+		t.Fatalf("fan-out keys must differ, both = %s", a)
+	}
+	// A legacy (no BotRules) delivery must keep the historical bot-less key
+	// byte for byte, so a redelivery in flight across the upgrade dedupes.
+	if legacy := forgeIdemKey(base, "review-pr", false); legacy == b {
+		t.Fatalf("legacy key must not carry the bot: %s", legacy)
+	}
+}
+
+func TestFanOut_VarsAreIsolatedPerBot(t *testing.T) {
+	s := newWebhookTestServer(t)
+	got := fanoutLauncher(s)
+	cfg, pt := fanoutConfig(t, s)
+	cfg.BotRules[0].AuthorAllowlist = nil
+	cfg.BotRules[1].AuthorDenylist = nil
+	cfg.LaunchVars = map[string]string{"scope_notes": "operator pin"}
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghOpenPR, prforge.EventHeaderPullRequest, pt))
+
+	recs := *got
+	if len(recs) != 2 {
+		t.Fatalf("want 2 launches, got %v", botsOf(recs))
+	}
+	byBot := map[string]map[string]string{}
+	for _, r := range recs {
+		byBot[r.bot] = r.vars
+	}
+	// injectForgePublishVars mutates the vars map in place, so a shared map
+	// would hand both runs the same grant AND leak each bot's vars.
+	if &recs[0].vars == &recs[1].vars {
+		t.Fatal("bots must not share a vars map")
+	}
+	if _, leaked := byBot["review-pr"]["max_fix_iterations"]; leaked {
+		t.Fatalf("the guard's manifest var leaked into the reviewer: %v", byBot["review-pr"])
+	}
+	if got := byBot["dep-update-guard"]["max_fix_iterations"]; got != "2" {
+		t.Fatalf("the guard lost its own manifest var: %v", byBot["dep-update-guard"])
+	}
+	for bot, vars := range byBot {
+		if vars["scope_notes"] != "operator pin" {
+			t.Fatalf("%s: operator LaunchVars must win last, got %q", bot, vars["scope_notes"])
+		}
+	}
+}
+
+// A config written before BotRules existed must behave EXACTLY as before:
+// one launch of the pinned review default, historical response shape.
+func TestFanOut_LegacyConfigUnchanged(t *testing.T) {
+	s := newWebhookTestServer(t)
+	got := fanoutLauncher(s)
+	cfg, pt := ghConfig(t, s) // BotIDs = ["review-pr"], no BotRules
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghOpenPR, prforge.EventHeaderPullRequest, pt))
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	if bots := botsOf(*got); len(bots) != 1 || bots[0] != "review-pr" {
+		t.Fatalf("legacy config: want one review-pr launch, got %v", bots)
+	}
+	if body := w.Body.String(); strings.Contains(body, "launches") {
+		t.Fatalf("legacy config must keep the historical single response shape: %s", body)
+	}
+}
+
+// A redelivery relaunches ONLY the bot whose launch failed; the one that
+// succeeded stays deduped.
+func TestFanOut_PartialFailureRetriesOnlyTheFailedBot(t *testing.T) {
+	s := newWebhookTestServer(t)
+	cfg, pt := fanoutConfig(t, s)
+	cfg.BotRules[0].AuthorAllowlist = nil
+	cfg.BotRules[1].AuthorDenylist = nil
+
+	var got []launchRecord
+	failReviewer := true
+	s.webhookLaunchBot = func(_ context.Context, bot string, vars map[string]string, _, _, _ string, _, _ map[string]string) (string, error) {
+		got = append(got, launchRecord{bot: bot, vars: vars})
+		if bot == "review-pr" && failReviewer {
+			return "", context.DeadlineExceeded
+		}
+		return "run-" + bot, nil
+	}
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghOpenPR, prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("a sibling failure must not fail the delivery: code=%d body=%s", w.Code, w.Body.String())
+	}
+	if len(got) != 2 {
+		t.Fatalf("first delivery: want both attempted, got %v", botsOf(got))
+	}
+
+	failReviewer = false
+	got = nil
+	w2 := httptest.NewRecorder()
+	s.handleGitHubWebhook(w2, ghReq(ghCtx(cfg), ghOpenPR, prforge.EventHeaderPullRequest, pt))
+	if bots := botsOf(got); len(bots) != 1 || bots[0] != "review-pr" {
+		t.Fatalf("redelivery must relaunch only the failed bot, got %v", bots)
+	}
+}
+
+func TestFanOut_ReplayLaunchesNothing(t *testing.T) {
+	s := newWebhookTestServer(t)
+	got := fanoutLauncher(s)
+	cfg, pt := fanoutConfig(t, s)
+	cfg.BotRules[0].AuthorAllowlist = nil
+	cfg.BotRules[1].AuthorDenylist = nil
+
+	for range 2 {
+		w := httptest.NewRecorder()
+		s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghOpenPR, prforge.EventHeaderPullRequest, pt))
+	}
+	if bots := botsOf(*got); len(bots) != 2 {
+		t.Fatalf("replay must not relaunch, got %v", bots)
+	}
+}
+
+// The fork-PR and iterion-bot-author guards run BEFORE the fan-out: no rule,
+// however permissive, may re-open those lanes.
+func TestFanOut_ForkPRStillBlocked(t *testing.T) {
+	s := newWebhookTestServer(t)
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		t.Fatal("fork PR must not launch any bot")
+		return "", nil
+	}
+	cfg, pt := fanoutConfig(t, s)
+	cfg.BlockForkPRs = true
+	forkPR := strings.Replace(ghOpenPR,
+		`"head": {"ref": "feature/x", "sha": "abc123"}`,
+		`"head": {"ref": "feature/x", "sha": "abc123", "repo": {"full_name": "mallory/widgets"}}`, 1)
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), forkPR, prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), webhooks.StatusFiltered) {
+		t.Fatalf("fork PR: code=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestRulesForEvent(t *testing.T) {
+	rules := []webhooks.BotRule{
+		{BotID: "guard", Events: []string{bundle.ForgeEventPullRequest}, AuthorAllowlist: []string{"*renovate[bot]"}},
+		{BotID: "reviewer", Events: []string{bundle.ForgeEventPullRequest}, AuthorDenylist: []string{"*renovate[bot]"}},
+		{BotID: "commander"}, // command-only: claims no event
+		{BotID: "not-enabled", Events: []string{bundle.ForgeEventPullRequest}},
+	}
+	cfg := webhooks.Config{BotIDs: []string{"guard", "reviewer", "commander"}, BotRules: rules}
+
+	for _, tc := range []struct {
+		name, event, author string
+		want                []string
+	}{
+		{"hosted renovate → guard", bundle.ForgeEventPullRequest, "renovate[bot]", []string{"guard"}},
+		{"self-hosted app → guard", bundle.ForgeEventPullRequest, "socialgouv-renovate[bot]", []string{"guard"}},
+		{"human → reviewer", bundle.ForgeEventPullRequest, "alice", []string{"reviewer"}},
+		{"comment event claims nobody", bundle.ForgeEventPullRequestComment, "alice", nil},
+		{"unknown event", "push", "alice", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []string
+			for _, r := range cfg.RulesForEvent(tc.event, tc.author) {
+				got = append(got, r.BotID)
+			}
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Fatalf("want %v, got %v", tc.want, got)
+			}
+		})
+	}
+
+	// A rule for a bot the webhook no longer permits must never launch.
+	if rs := cfg.RulesForEvent(bundle.ForgeEventPullRequest, "nobody-special"); len(rs) != 1 || rs[0].BotID != "reviewer" {
+		t.Fatalf("a de-scoped bot must be excluded, got %v", rs)
+	}
+}

--- a/pkg/server/webhooks_fanout_test.go
+++ b/pkg/server/webhooks_fanout_test.go
@@ -24,8 +24,23 @@ const ghRenovatePR = `{
   "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
   "pull_request": {"number": 8, "title": "chore(deps): bump lib", "body": "renovate",
     "html_url": "https://github.com/acme/widgets/pull/8", "state": "open",
-    "head": {"ref": "renovate/lib-1.x", "sha": "def456"}, "base": {"ref": "main"}},
+    "head": {"ref": "renovate/lib-1.x", "sha": "def456"}, "base": {"ref": "main"},
+    "user": {"login": "socialgouv-renovate[bot]"}},
   "sender": {"login": "socialgouv-renovate[bot]"}
+}`
+
+// A human pushing a fix onto the dependency bot's PR: the SENDER is the human,
+// the PR is still the bot's. Routing on the sender would hand the delivery to
+// the reviewer and let it fill the shared gate context on a dependency PR.
+const ghRenovatePRHumanPush = `{
+  "action": "synchronize",
+  "number": 8,
+  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+  "pull_request": {"number": 8, "title": "chore(deps): bump lib", "body": "renovate",
+    "html_url": "https://github.com/acme/widgets/pull/8", "state": "open",
+    "head": {"ref": "renovate/lib-1.x", "sha": "fff999"}, "base": {"ref": "main"},
+    "user": {"login": "socialgouv-renovate[bot]"}},
+  "sender": {"login": "alice"}
 }`
 
 // fanoutConfig is ghConfig plus the two-bot routing table the orchestrator
@@ -91,6 +106,20 @@ func TestFanOut_RenovatePRLaunchesOnlyTheGuard(t *testing.T) {
 	}
 	if bots := botsOf(*got); len(bots) != 1 || bots[0] != "dep-update-guard" {
 		t.Fatalf("renovate PR must launch only the guard, got %v", bots)
+	}
+}
+
+func TestFanOut_APushByAHumanKeepsTheBotsPR(t *testing.T) {
+	s := newWebhookTestServer(t)
+	got := fanoutLauncher(s)
+	cfg, pt := fanoutConfig(t, s)
+	cfg.ReviewOnSync = true // a synchronize only reviews when this is on
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghRenovatePRHumanPush, prforge.EventHeaderPullRequest, pt))
+
+	if bots := botsOf(*got); len(bots) != 1 || bots[0] != "dep-update-guard" {
+		t.Fatalf("the PR belongs to the dependency bot whoever pushed to it, got %v", bots)
 	}
 }
 

--- a/pkg/server/webhooks_fanout_test.go
+++ b/pkg/server/webhooks_fanout_test.go
@@ -170,7 +170,11 @@ func TestFanOut_VarsAreIsolatedPerBot(t *testing.T) {
 	cfg, pt := fanoutConfig(t, s)
 	cfg.BotRules[0].AuthorAllowlist = nil
 	cfg.BotRules[1].AuthorDenylist = nil
-	cfg.LaunchVars = map[string]string{"scope_notes": "operator pin"}
+	cfg.OperatorLaunchVars = map[string]string{"scope_notes": "operator pin"}
+	// The manifest UNION carries a key one bot pins for itself: the union must
+	// not override that bot's own value (that is the collision BotRule exists
+	// to prevent), but must still reach the bot that declares nothing.
+	cfg.LaunchVars = map[string]string{"max_fix_iterations": "99"}
 
 	w := httptest.NewRecorder()
 	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghOpenPR, prforge.EventHeaderPullRequest, pt))
@@ -188,11 +192,11 @@ func TestFanOut_VarsAreIsolatedPerBot(t *testing.T) {
 	if &recs[0].vars == &recs[1].vars {
 		t.Fatal("bots must not share a vars map")
 	}
-	if _, leaked := byBot["review-pr"]["max_fix_iterations"]; leaked {
-		t.Fatalf("the guard's manifest var leaked into the reviewer: %v", byBot["review-pr"])
-	}
 	if got := byBot["dep-update-guard"]["max_fix_iterations"]; got != "2" {
-		t.Fatalf("the guard lost its own manifest var: %v", byBot["dep-update-guard"])
+		t.Fatalf("the cross-bot union overrode the guard's own value: %v", byBot["dep-update-guard"])
+	}
+	if got := byBot["review-pr"]["max_fix_iterations"]; got != "99" {
+		t.Fatalf("a bot pinning nothing still gets the union value, got %q", got)
 	}
 	for bot, vars := range byBot {
 		if vars["scope_notes"] != "operator pin" {

--- a/pkg/server/webhooks_generic.go
+++ b/pkg/server/webhooks_generic.go
@@ -100,14 +100,13 @@ func (s *Server) handleGenericWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 	idemKey := knowledge.ChecksumHex([]byte(fmt.Sprintf("generic|%s|%s|%s", cfg.TenantID, cfg.ID, dedup)))
 
-	// Var merge: body vars first, then config overrides (config wins).
+	// Var merge: body vars first, then the webhook's own layers (config wins,
+	// operator overrides last — see applyWebhookVarLayers).
 	vars := make(map[string]string, len(req.Vars)+len(cfg.LaunchVars))
 	for k, v := range req.Vars {
 		vars[k] = v
 	}
-	for k, v := range cfg.LaunchVars {
-		vars[k] = v
-	}
+	applyWebhookVarLayers(vars, cfg)
 
 	s.insertAndLaunchWebhook(ctx, w, r, cfg, meta, idemKey, botID, vars, req.RepoURL, req.RepoRef, payloadHash, srcIP)
 }

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/SocialGouv/iterion/pkg/bundle"
 	"github.com/SocialGouv/iterion/pkg/knowledge"
 	"github.com/SocialGouv/iterion/pkg/webhooks"
 	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
@@ -154,21 +155,28 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 		return
 	}
 
-	// PR-open auto-lane = REVIEW ONLY (Revi). Billy is NEVER auto-launched on a
+	// PR-open auto-lane = REVIEW ONLY. Billy is NEVER auto-launched on a
 	// PR-open — it runs on a deliberate `/billy` comment (or the narrow
-	// merge-queue auto-heal above). resolveReviewBot gates AllowsBot.
-	botID, ok := s.resolveReviewBot(ctx, w, cfg, meta, payloadHash, srcIP)
-	if !ok {
+	// merge-queue auto-heal above). With a per-bot routing table the lane fans
+	// out to every bot claiming the pull_request event whose OWN author filter
+	// admits this author, so a dependency guard and a reviewer share the repo
+	// and each takes its own PRs.
+	rules := s.resolveForgeEventBots(cfg, bundle.ForgeEventPullRequest, p.SenderLogin)
+	if len(rules) == 0 {
+		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, "no enabled bot claims this PR (event/author routing)")
+		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
 		return
 	}
 
-	// Idempotency: one launch per (tenant, webhook, repo, PR#, head sha).
-	idemKey := knowledge.ChecksumHex([]byte(fmt.Sprintf("%s%s|%s|%s|%d|%s", idemPrefix, cfg.TenantID, cfg.ID, p.ProjectPath, p.PRNumber, p.HeadSHA)))
+	// Idempotency base: one launch per (tenant, webhook, repo, PR#, head sha)
+	// — per bot once the delivery fans out (see forgeIdemKey).
+	idemBase := fmt.Sprintf("%s%s|%s|%s|%d|%s", idemPrefix, cfg.TenantID, cfg.ID, p.ProjectPath, p.PRNumber, p.HeadSHA)
 
 	scopeNotes := strings.TrimSpace(p.Title + "\n\n" + p.Description)
-	vars := reviewPRVars(p.PRURL, p.TargetBranch, scopeNotes, cfg.LaunchVars, map[string]string{"pr_author": p.SenderLogin, "source_branch": p.SourceBranch})
+	targets := forgePREventTargets(cfg, rules, idemBase, p.PRURL, p.TargetBranch, scopeNotes, p.CloneURL, p.SourceBranch,
+		map[string]string{"pr_author": p.SenderLogin, "source_branch": p.SourceBranch})
 
-	s.insertAndLaunchWebhook(ctx, w, r, cfg, meta, idemKey, botID, vars, p.CloneURL, p.SourceBranch, payloadHash, srcIP)
+	s.insertAndLaunchWebhookMulti(ctx, w, r, cfg, meta, targets, payloadHash, srcIP)
 }
 
 // handleGitHubIssues handles a verified inbound GitHub `issues` delivery. Two

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -138,7 +138,10 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 	if !reviewable ||
 		!webhooks.MatchEvent(cfg.EventAllowlist, "pull_request", "pull_request") ||
 		!webhooks.MatchProject(cfg.ProjectAllowlist, p.ProjectPath) ||
-		!webhooks.MatchAuthor(cfg.AuthorAllowlist, p.SenderLogin) {
+		// The PR's AUTHOR, not the pusher: on a synchronize the sender is
+		// whoever pushed, so filtering on it would drop a dependency bot's PR
+		// the moment a human pushed a fix onto it.
+		!webhooks.MatchAuthor(cfg.AuthorAllowlist, p.Author()) {
 		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, "")
 		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
 		return
@@ -148,6 +151,9 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 	// Featurly… through the tenant's forge integration) already converged inside
 	// its own loop — auto-reviewing it wastes budget and adds noise. Filter it
 	// (a human can still run `/revi` on it manually).
+	// Deliberately the SENDER, not the PR author: the point is to skip a PR
+	// our own loop produced and already converged, but once a human pushes
+	// onto it there is human work to review again.
 	if s.isIterionForgeBotAuthor(ctx, cfg, p.SenderLogin) {
 		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP,
 			"PR authored by iterion's forge bot — auto-review skipped (self-produced; run /revi to force a review)")
@@ -161,7 +167,7 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 	// out to every bot claiming the pull_request event whose OWN author filter
 	// admits this author, so a dependency guard and a reviewer share the repo
 	// and each takes its own PRs.
-	rules := s.resolveForgeEventBots(cfg, bundle.ForgeEventPullRequest, p.SenderLogin)
+	rules := s.resolveForgeEventBots(cfg, bundle.ForgeEventPullRequest, p.Author())
 	if len(rules) == 0 {
 		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, "no enabled bot claims this PR (event/author routing)")
 		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
@@ -174,7 +180,7 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 
 	scopeNotes := strings.TrimSpace(p.Title + "\n\n" + p.Description)
 	targets := forgePREventTargets(cfg, rules, idemBase, p.PRURL, p.TargetBranch, scopeNotes, p.CloneURL, p.SourceBranch,
-		map[string]string{"pr_author": p.SenderLogin, "source_branch": p.SourceBranch})
+		map[string]string{"pr_author": p.Author(), "source_branch": p.SourceBranch})
 
 	s.insertAndLaunchWebhookMulti(ctx, w, r, cfg, meta, targets, payloadHash, srcIP)
 }

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -126,7 +126,7 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 				"interleaved merge). Keep the PR's own change intact; only reconcile it with the new base. "+
 				"Push so the PR can re-enter the merge queue.\n\n%s",
 			p.DequeueReason, p.TargetBranch, p.TargetBranch, strings.TrimSpace(p.Title+"\n\n"+p.Description))
-		healVars := branchImproveVars(p.TargetBranch, p.SourceBranch, p.PRURL, mission, false, cfg.LaunchVars)
+		healVars := applyWebhookVarLayers(branchImproveVars(p.TargetBranch, p.SourceBranch, p.PRURL, mission, false, nil), cfg)
 		s.insertAndLaunchWebhook(ctx, w, r, cfg, meta, healIdem, branchImproveBotID, healVars, p.CloneURL, p.SourceBranch, payloadHash, srcIP)
 		return
 	}
@@ -253,7 +253,7 @@ func (s *Server) handleGitHubIssues(w http.ResponseWriter, r *http.Request, cfg 
 	// runner clones the repo's default branch; featurly's worktree: auto
 	// branches from there.
 	route := s.boardRouteForLabel(botID)
-	vars := issueLabeledVars(p, cfg.LaunchVars, route.ArgsVar)
+	vars := applyWebhookVarLayers(issueLabeledVars(p, nil, route.ArgsVar), cfg)
 	s.dispatchInvocation(ctx, w, r, cfg, meta, idemKey, route, vars, p.CloneURL, "", payloadHash, srcIP)
 }
 

--- a/pkg/server/webhooks_github_test.go
+++ b/pkg/server/webhooks_github_test.go
@@ -652,11 +652,18 @@ func TestGitHubWebhook_BotNotAllowed(t *testing.T) {
 	cfg, pt := ghConfig(t, s)
 	// SelectBot() returns "" when there are multiple non-default bots
 	// → handler falls back to defaultWebhookBotReviewPR. Pin two bots
-	// that exclude review-pr so the AllowsBot gate fires.
+	// that exclude review-pr so the bot-scope gate fires.
 	cfg.BotIDs = []string{"some-other-bot", "and-another"}
 	w := httptest.NewRecorder()
 	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghOpenPR, prforge.EventHeaderPullRequest, pt))
-	if w.Code != http.StatusForbidden {
+	// A delivery no enabled bot claims is FILTERED (200), not rejected: a 4xx
+	// on a forge hook is what makes GitHub disable it after repeated
+	// deliveries, and "nobody wants this PR" is a routing outcome, not a
+	// client error. The launcher assertion above is what proves nothing ran.
+	if w.Code != http.StatusOK {
 		t.Fatalf("bot not allowed: code=%d body=%s", w.Code, w.Body.String())
+	}
+	if got := w.Body.String(); !strings.Contains(got, webhooks.StatusFiltered) {
+		t.Fatalf("bot not allowed: want filtered status, got %s", got)
 	}
 }

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -110,6 +110,12 @@ func (s *Server) handleGitLabMergeRequestEvent(ctx context.Context, w http.Respo
 
 	// Same per-bot fan-out as the GitHub PR lane — this MR lane is a separate
 	// function, so parity is not free and must be kept explicitly.
+	//
+	// Routes on the event actor rather than the MR's author, unlike GitHub:
+	// GitLab's merge_request payload carries only `author_id`, so resolving
+	// the author's username would need an extra API call on the hot path. The
+	// difference shows only on a re-review triggered by someone other than
+	// the MR author, which needs ReviewOnSync to be on in the first place.
 	rules := s.resolveForgeEventBots(cfg, bundle.ForgeEventPullRequest, p.SenderUsername)
 	if len(rules) == 0 {
 		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, "no enabled bot claims this MR (event/author routing)")

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -170,7 +170,7 @@ func (s *Server) handleGitLabIssueEvent(ctx context.Context, w http.ResponseWrit
 	idemKey := knowledge.ChecksumHex([]byte(fmt.Sprintf("gl|issue|%s|%s|%d|%d|%s", cfg.TenantID, cfg.ID, p.ProjectID, p.IssueIID, label)))
 
 	route := s.boardRouteForLabel(botID)
-	vars := gitlabIssueLabeledVars(p, cfg.LaunchVars, route.ArgsVar)
+	vars := applyWebhookVarLayers(gitlabIssueLabeledVars(p, nil, route.ArgsVar), cfg)
 	// An issue carries no MR source branch — the bot opens its MR from the
 	// project default branch (finalize_mr cuts the branch from there).
 	s.dispatchInvocation(ctx, w, r, cfg, meta, idemKey, route, vars, p.CloneURL, p.DefaultBranch, payloadHash, srcIP)
@@ -317,7 +317,7 @@ func (s *Server) handleGitLabNote(ctx context.Context, w http.ResponseWriter, r 
 	// always reaches revi-converse — replyInThread implies the bot is enabled
 	// (the early gate above). `/revi <question>` with the converse bot absent
 	// falls back to re-review (matching pre-A5 behaviour).
-	vars := s.buildGitLabNoteVars(p, cmd, cmdArgs, cfg.LaunchVars)
+	vars := applyWebhookVarLayers(s.buildGitLabNoteVars(p, cmd, cmdArgs, nil), cfg)
 	question := cmdArgs
 	if replyInThread {
 		question = strings.TrimSpace(p.NoteBody)
@@ -408,9 +408,9 @@ func (s *Server) handleGitLabCommandNote(ctx context.Context, w http.ResponseWri
 	if s.logger != nil {
 		s.logger.Debug("webhooks: gitlab note %s/%s (/%s) by %s → %s (%s)", p.ProjectPath, surface, cmd, p.AuthorUsername, route.BotID, reason)
 	}
-	vars := buildCommandVars(p, route, cmdArgs, cfg.LaunchVars)
+	vars := applyWebhookVarLayers(buildCommandVars(p, route, cmdArgs, nil), cfg)
 	if surface == "issue" {
-		vars = buildGitLabIssueCommandVars(p, route, cmdArgs, cfg.LaunchVars)
+		vars = applyWebhookVarLayers(buildGitLabIssueCommandVars(p, route, cmdArgs, nil), cfg)
 	} else {
 		stampBranchImprovePushBack(vars, route.BotID, p.SourceBranch, cfg.BranchImproveAsPR)
 		// `/billy` on an MR seeds the run with Revi's most recent review of it

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/SocialGouv/iterion/pkg/botregistry"
+	"github.com/SocialGouv/iterion/pkg/bundle"
 	"github.com/SocialGouv/iterion/pkg/cloudsched"
 	"github.com/SocialGouv/iterion/pkg/knowledge"
 	"github.com/SocialGouv/iterion/pkg/retrypolicy"
@@ -107,19 +108,26 @@ func (s *Server) handleGitLabMergeRequestEvent(ctx context.Context, w http.Respo
 		return
 	}
 
-	botID, ok := s.resolveReviewBot(ctx, w, cfg, meta, payloadHash, srcIP)
-	if !ok {
+	// Same per-bot fan-out as the GitHub PR lane — this MR lane is a separate
+	// function, so parity is not free and must be kept explicitly.
+	rules := s.resolveForgeEventBots(cfg, bundle.ForgeEventPullRequest, p.SenderUsername)
+	if len(rules) == 0 {
+		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, "no enabled bot claims this MR (event/author routing)")
+		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
 		return
 	}
 
-	// Idempotency: one launch per (tenant, webhook, project, MR, head sha).
-	// "mr|" prefix keeps the key space disjoint from the Note hook
-	// ("note|") so a /revi on the same MR can't collide with the open.
-	idemKey := knowledge.ChecksumHex([]byte(fmt.Sprintf("mr|%s|%s|%d|%d|%s", cfg.TenantID, cfg.ID, p.ProjectID, p.MRIID, p.HeadSHA)))
+	// Idempotency: one launch per (tenant, webhook, project, MR, head sha) —
+	// per bot once the delivery fans out. The "mr|" prefix keeps the key space
+	// disjoint from the Note hook ("note|") so a /revi on the same MR can't
+	// collide with the open.
+	idemBase := fmt.Sprintf("mr|%s|%s|%d|%d|%s", cfg.TenantID, cfg.ID, p.ProjectID, p.MRIID, p.HeadSHA)
 
-	vars := reviewPRVars(p.MRURL, p.TargetBranch, strings.TrimSpace(p.Title+"\n\n"+p.Description), cfg.LaunchVars, map[string]string{"pr_author": p.SenderUsername, "source_branch": p.SourceBranch})
+	targets := forgePREventTargets(cfg, rules, idemBase, p.MRURL, p.TargetBranch,
+		strings.TrimSpace(p.Title+"\n\n"+p.Description), p.CloneURL, p.SourceBranch,
+		map[string]string{"pr_author": p.SenderUsername, "source_branch": p.SourceBranch})
 
-	s.insertAndLaunchWebhook(ctx, w, r, cfg, meta, idemKey, botID, vars, p.CloneURL, p.SourceBranch, payloadHash, srcIP)
+	s.insertAndLaunchWebhookMulti(ctx, w, r, cfg, meta, targets, payloadHash, srcIP)
 }
 
 // handleGitLabIssueEvent handles a verified GitLab "Issue Hook". GitLab has no

--- a/pkg/server/webhooks_prforge.go
+++ b/pkg/server/webhooks_prforge.go
@@ -110,7 +110,7 @@ func (s *Server) handlePRForgeComment(ctx context.Context, w http.ResponseWriter
 		pr = &resolved
 		repoRef = resolved.SourceBranch
 	}
-	vars := buildPRForgeCommandVars(p, pr, route, cmdArgs, cfg.LaunchVars)
+	vars := applyWebhookVarLayers(buildPRForgeCommandVars(p, pr, route, cmdArgs, nil), cfg)
 	if pr != nil {
 		stampBranchImprovePushBack(vars, route.BotID, pr.SourceBranch, cfg.BranchImproveAsPR)
 		// `/billy` on a PR picks up where Revi left off: seed the run with the

--- a/pkg/server/webhooks_routes.go
+++ b/pkg/server/webhooks_routes.go
@@ -50,6 +50,7 @@ type webhookConfigReq struct {
 	AuthorAllowlist     []string          `json:"author_allowlist,omitempty"`
 	LabelAllowlist      []string          `json:"label_allowlist,omitempty"`
 	BlockForkPRs        *bool             `json:"block_fork_prs,omitempty"`
+	ReviewOnSync        *bool             `json:"review_on_sync,omitempty"`
 	AutoImplementOnOpen *bool             `json:"auto_implement_on_open,omitempty"`
 	BranchImproveAsPR   *bool             `json:"branch_improve_as_pr,omitempty"`
 	RateLimit           *webhooks.Rate    `json:"rate_limit,omitempty"`
@@ -247,6 +248,7 @@ func (s *Server) handleCreateWebhook(w http.ResponseWriter, r *http.Request) {
 		AuthorAllowlist:     req.AuthorAllowlist,
 		LabelAllowlist:      req.LabelAllowlist,
 		BlockForkPRs:        req.BlockForkPRs != nil && *req.BlockForkPRs,
+		ReviewOnSync:        req.ReviewOnSync != nil && *req.ReviewOnSync,
 		AutoImplementOnOpen: req.AutoImplementOnOpen != nil && *req.AutoImplementOnOpen,
 		RateLimit:           rate,
 		LaunchVars:          req.LaunchVars,
@@ -410,6 +412,9 @@ func (s *Server) handleUpdateWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.LabelAllowlist != nil {
 		cfg.LabelAllowlist = req.LabelAllowlist
+	}
+	if req.ReviewOnSync != nil {
+		cfg.ReviewOnSync = *req.ReviewOnSync
 	}
 	if req.BlockForkPRs != nil {
 		cfg.BlockForkPRs = *req.BlockForkPRs

--- a/pkg/server/webhooks_routes.go
+++ b/pkg/server/webhooks_routes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/schedgate"
 	"github.com/SocialGouv/iterion/pkg/webhooks"
 )
 
@@ -51,6 +52,7 @@ type webhookConfigReq struct {
 	LabelAllowlist      []string          `json:"label_allowlist,omitempty"`
 	BlockForkPRs        *bool             `json:"block_fork_prs,omitempty"`
 	ReviewOnSync        *bool             `json:"review_on_sync,omitempty"`
+	Overlap             *string           `json:"overlap,omitempty"`
 	AutoImplementOnOpen *bool             `json:"auto_implement_on_open,omitempty"`
 	BranchImproveAsPR   *bool             `json:"branch_improve_as_pr,omitempty"`
 	RateLimit           *webhooks.Rate    `json:"rate_limit,omitempty"`
@@ -61,6 +63,16 @@ type webhookConfigReq struct {
 	AuthorizedRepliers  []string          `json:"authorized_repliers,omitempty"`
 	MinReplierRole      *string           `json:"min_replier_role,omitempty"`
 	ForgeBaseURL        *string           `json:"forge_base_url,omitempty"`
+}
+
+// overlapOrEmpty resolves an optional overlap policy. Empty is meaningful
+// here — a webhook with no policy launches every delivery, which is the
+// historical behaviour every existing webhook relies on.
+func overlapOrEmpty(v *string) string {
+	if v == nil {
+		return ""
+	}
+	return strings.TrimSpace(*v)
 }
 
 // supportedProviders is the closed enum the create endpoint accepts.
@@ -249,6 +261,7 @@ func (s *Server) handleCreateWebhook(w http.ResponseWriter, r *http.Request) {
 		LabelAllowlist:      req.LabelAllowlist,
 		BlockForkPRs:        req.BlockForkPRs != nil && *req.BlockForkPRs,
 		ReviewOnSync:        req.ReviewOnSync != nil && *req.ReviewOnSync,
+		Overlap:             overlapOrEmpty(req.Overlap),
 		AutoImplementOnOpen: req.AutoImplementOnOpen != nil && *req.AutoImplementOnOpen,
 		RateLimit:           rate,
 		LaunchVars:          req.LaunchVars,
@@ -415,6 +428,13 @@ func (s *Server) handleUpdateWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.ReviewOnSync != nil {
 		cfg.ReviewOnSync = *req.ReviewOnSync
+	}
+	if req.Overlap != nil {
+		cfg.Overlap = strings.TrimSpace(*req.Overlap)
+		if err := schedgate.Validate(cfg.OverlapPolicy()); cfg.Overlap != "" && err != nil {
+			httpError(w, http.StatusBadRequest, "%v", err)
+			return
+		}
 	}
 	if req.BlockForkPRs != nil {
 		cfg.BlockForkPRs = *req.BlockForkPRs

--- a/pkg/server/webhooks_supersede_test.go
+++ b/pkg/server/webhooks_supersede_test.go
@@ -106,6 +106,37 @@ func TestSupersede(t *testing.T) {
 		}
 	})
 
+	// The repo's pinned gate context must reach EVERY lane. A manual /revi is
+	// the documented escape hatch when the gate is red; if that lane launched
+	// with the bot's default context it would post a status the repo does not
+	// require and leave the required one stale — the escape hatch making the
+	// deadlock permanent.
+	t.Run("the operator pin reaches the command lane too", func(t *testing.T) {
+		s := newWebhookTestServer(t)
+		got := fanoutLauncher(s)
+		cfg, pt := ghConfig(t, s)
+		cfg.OperatorLaunchVars = map[string]string{"gate_context": "iterion/review"}
+		cfg.CommandMap = map[string][]webhooks.CommandRoute{
+			"revi": {{BotID: "review-pr", Scope: "pr"}},
+		}
+		comment := `{
+		  "action": "created",
+		  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+		  "issue": {"number": 7, "html_url": "https://github.com/acme/widgets/pull/7",
+		    "pull_request": {"url": "https://api.github.com/repos/acme/widgets/pulls/7"}},
+		  "comment": {"id": 1, "body": "/revi", "user": {"login": "alice"}},
+		  "sender": {"login": "alice"}
+		}`
+		w := httptest.NewRecorder()
+		s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), comment, "issue_comment", pt))
+
+		for _, rec := range *got {
+			if rec.vars["gate_context"] != "iterion/review" {
+				t.Fatalf("%s launched without the repo's pinned gate context: %v", rec.bot, rec.vars)
+			}
+		}
+	})
+
 	t.Run("scoping", func(t *testing.T) {
 		// EvaluateOverlap is the shared decision; assert the vocabulary is the
 		// one every other launch surface already speaks.

--- a/pkg/server/webhooks_supersede_test.go
+++ b/pkg/server/webhooks_supersede_test.go
@@ -1,0 +1,173 @@
+package server
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/schedgate"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
+)
+
+// With re-review on push, a burst of commits launches a run per push and the
+// earlier ones analyse code that no longer exists — wasted budget, and a
+// verdict posted on a dead commit. overlap=supersede keeps the run that
+// matches what is actually on the branch.
+//
+// The scoping is what makes it safe: the key is (webhook, subject, bot), so
+// two PRs never supersede each other and two bots on one PR never supersede
+// each other either — they are doing different jobs.
+func TestSupersede(t *testing.T) {
+	// A second push on the SAME PR carries a new head SHA, hence a new
+	// idempotency key and a genuine second launch.
+	pushOn := func(sha string) string {
+		return `{
+		  "action": "opened", "number": 7,
+		  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+		  "pull_request": {"number": 7, "title": "T", "body": "b",
+		    "html_url": "https://github.com/acme/widgets/pull/7", "state": "open",
+		    "head": {"ref": "feature/x", "sha": "` + sha + `"}, "base": {"ref": "main"}},
+		  "sender": {"login": "alice"}
+		}`
+	}
+	otherPR := `{
+	  "action": "opened", "number": 9,
+	  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+	  "pull_request": {"number": 9, "title": "T", "body": "b",
+	    "html_url": "https://github.com/acme/widgets/pull/9", "state": "open",
+	    "head": {"ref": "feature/y", "sha": "yyy111"}, "base": {"ref": "main"}},
+	  "sender": {"login": "alice"}
+	}`
+
+	deliver := func(t *testing.T, s *Server, cfg webhooks.Config, pt, body string) {
+		t.Helper()
+		w := httptest.NewRecorder()
+		s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), body, prforge.EventHeaderPullRequest, pt))
+	}
+
+	t.Run("a newer delivery cancels the stale run", func(t *testing.T) {
+		s := newWebhookTestServer(t)
+		got := fanoutLauncher(s)
+		var cancelled []string
+		s.webhookCancelRun = func(runID string) error {
+			cancelled = append(cancelled, runID)
+			return nil
+		}
+		cfg, pt := ghConfig(t, s)
+		cfg.Overlap = schedgate.OverlapSupersede
+
+		deliver(t, s, cfg, pt, pushOn("sha-old"))
+		if len(cancelled) != 0 {
+			t.Fatalf("the first delivery has nothing to supersede, cancelled %v", cancelled)
+		}
+		deliver(t, s, cfg, pt, pushOn("sha-new"))
+
+		if bots := botsOf(*got); len(bots) != 2 {
+			t.Fatalf("both pushes must launch (the new one carries the current truth), got %v", bots)
+		}
+		if len(cancelled) != 1 || cancelled[0] != "run-review-pr" {
+			t.Fatalf("the stale run must be cancelled, got %v", cancelled)
+		}
+	})
+
+	// A cancel that fails must never stop the new run: the new run is the one
+	// carrying the current truth.
+	t.Run("a failing cancel does not block the launch", func(t *testing.T) {
+		s := newWebhookTestServer(t)
+		got := fanoutLauncher(s)
+		s.webhookCancelRun = func(string) error { return context.DeadlineExceeded }
+		cfg, pt := ghConfig(t, s)
+		cfg.Overlap = schedgate.OverlapSupersede
+
+		deliver(t, s, cfg, pt, pushOn("sha-old"))
+		deliver(t, s, cfg, pt, pushOn("sha-new"))
+		if bots := botsOf(*got); len(bots) != 2 {
+			t.Fatalf("a failed cancel must not cost the new review, got %v", bots)
+		}
+	})
+
+	// The historical contract: a webhook with no policy launches every
+	// delivery. Promoting that silently would drop deliveries operators rely
+	// on, so an empty Overlap must never cancel anything.
+	t.Run("no policy never cancels", func(t *testing.T) {
+		s := newWebhookTestServer(t)
+		fanoutLauncher(s)
+		var cancelled []string
+		s.webhookCancelRun = func(runID string) error {
+			cancelled = append(cancelled, runID)
+			return nil
+		}
+		cfg, pt := ghConfig(t, s) // Overlap == ""
+		deliver(t, s, cfg, pt, pushOn("sha-old"))
+		deliver(t, s, cfg, pt, pushOn("sha-new"))
+		if len(cancelled) != 0 {
+			t.Fatalf("an unset policy must cancel nothing, got %v", cancelled)
+		}
+	})
+
+	t.Run("scoping", func(t *testing.T) {
+		// EvaluateOverlap is the shared decision; assert the vocabulary is the
+		// one every other launch surface already speaks.
+		if d, _ := schedgate.EvaluateOverlap([]string{"r1"}, schedgate.Policy{Overlap: schedgate.OverlapSupersede}); d != schedgate.DecisionSupersede {
+			t.Fatalf("supersede must decide DecisionSupersede, got %v", d)
+		}
+		if d, _ := schedgate.EvaluateOverlap(nil, schedgate.Policy{Overlap: schedgate.OverlapSupersede}); d != schedgate.DecisionFire {
+			t.Fatalf("nothing live → plain fire, got %v", d)
+		}
+		if err := schedgate.Validate(schedgate.Policy{Overlap: schedgate.OverlapSupersede, MaxConcurrent: 2}); err == nil {
+			t.Fatal("max_concurrent with supersede is incoherent and must be rejected")
+		}
+	})
+
+	t.Run("a different PR is never superseded", func(t *testing.T) {
+		s := newWebhookTestServer(t)
+		got := fanoutLauncher(s)
+		cfg, pt := ghConfig(t, s)
+		cfg.Overlap = schedgate.OverlapSupersede
+
+		var cancelled []string
+		s.webhookCancelRun = func(runID string) error {
+			cancelled = append(cancelled, runID)
+			return nil
+		}
+		deliver(t, s, cfg, pt, pushOn("sha-old"))
+		deliver(t, s, cfg, pt, otherPR)
+		if bots := botsOf(*got); len(bots) != 2 {
+			t.Fatalf("two distinct PRs must both review, got %v", bots)
+		}
+		if len(cancelled) != 0 {
+			t.Fatalf("PR #9 must not cancel PR #7's review, got %v", cancelled)
+		}
+	})
+
+	t.Run("two bots on one PR do not supersede each other", func(t *testing.T) {
+		s := newWebhookTestServer(t)
+		got := fanoutLauncher(s)
+		cfg, pt := fanoutConfig(t, s)
+		cfg.Overlap = schedgate.OverlapSupersede
+		cfg.BotRules[0].AuthorAllowlist = nil
+		cfg.BotRules[1].AuthorDenylist = nil
+		var cancelled []string
+		s.webhookCancelRun = func(runID string) error {
+			cancelled = append(cancelled, runID)
+			return nil
+		}
+
+		deliver(t, s, cfg, pt, pushOn("sha-one"))
+		if len(cancelled) != 0 {
+			t.Fatalf("bots on the same PR must not cancel each other, got %v", cancelled)
+		}
+		bots := botsOf(*got)
+		if len(bots) != 2 {
+			t.Fatalf("both bots claim this PR and do different jobs, got %v", bots)
+		}
+		seen := map[string]bool{}
+		for _, b := range bots {
+			seen[b] = true
+		}
+		if !seen["dep-update-guard"] || !seen["review-pr"] {
+			t.Fatalf("each bot must survive the other's supersede, got %v", bots)
+		}
+	})
+}

--- a/pkg/webhooks/match.go
+++ b/pkg/webhooks/match.go
@@ -54,8 +54,26 @@ func MatchProject(allowlist []string, projectPath string) bool {
 // to a dependency bot's PRs while ignoring human PRs on the same repo. A
 // "*" entry matches all (explicit allow-all). An empty login never matches a
 // non-empty allowlist (an author we couldn't identify is not on the list).
+//
+// A leading "*" is a suffix wildcard: "*renovate[bot]" matches both the
+// hosted "renovate[bot]" and a self-hosted App identity like
+// "acme-renovate[bot]". Self-hosting Renovate/Dependabot under an org App is
+// the common way to make their PRs trigger CI, and it renames the bot — so a
+// dependency-guard bot has to recognise the family, not one fixed login.
 func MatchAuthor(allowlist []string, login string) bool {
 	return matchCaseInsensitiveAllowlist(allowlist, login)
+}
+
+// MatchAuthorRule is MatchAuthor plus a denylist: a denied login never
+// matches, even when the allowlist is empty (= open). Deny is how a bot that
+// claims a set of authors EXCLUSIVELY (a dependency-PR guard) keeps a general
+// reviewer off the PRs it owns, without the reviewer's manifest having to know
+// that guard exists. See BotRule.
+func MatchAuthorRule(allow, deny []string, login string) bool {
+	if len(deny) > 0 && strings.TrimSpace(login) != "" && matchCaseInsensitiveAllowlist(deny, login) {
+		return false
+	}
+	return matchCaseInsensitiveAllowlist(allow, login)
 }
 
 // MatchLabel reports whether a freshly-applied issue label triggers a
@@ -71,8 +89,9 @@ func MatchLabel(allowlist []string, label string) bool {
 
 // matchCaseInsensitiveAllowlist is the shared body behind MatchAuthor and
 // MatchLabel: empty allowlist matches all; otherwise a trimmed, case-
-// insensitive match against value, with "*" as an explicit allow-all and
-// an empty value never matching a non-empty allowlist.
+// insensitive match against value, with "*" as an explicit allow-all, a
+// leading "*" as a suffix wildcard, and an empty value never matching a
+// non-empty allowlist.
 func matchCaseInsensitiveAllowlist(allowlist []string, value string) bool {
 	if len(allowlist) == 0 {
 		return true
@@ -83,7 +102,17 @@ func matchCaseInsensitiveAllowlist(allowlist []string, value string) bool {
 		if pat == "*" {
 			return true
 		}
-		if value != "" && strings.EqualFold(pat, value) {
+		if value == "" {
+			continue
+		}
+		if suffix, ok := strings.CutPrefix(pat, "*"); ok {
+			if suffix != "" && len(value) >= len(suffix) &&
+				strings.EqualFold(suffix, value[len(value)-len(suffix):]) {
+				return true
+			}
+			continue
+		}
+		if strings.EqualFold(pat, value) {
 			return true
 		}
 	}

--- a/pkg/webhooks/match_test.go
+++ b/pkg/webhooks/match_test.go
@@ -93,3 +93,54 @@ func TestMatchLabel(t *testing.T) {
 		t.Fatal("empty applied label must not match a non-empty allowlist")
 	}
 }
+
+// A self-hosted Renovate/Dependabot runs under an org App, which renames the
+// bot ("acme-renovate[bot]"), so a dependency-guard must match the family.
+func TestMatchAuthorSuffixWildcard(t *testing.T) {
+	list := []string{"dependabot[bot]", "*renovate[bot]"}
+	for _, tc := range []struct {
+		login string
+		want  bool
+	}{
+		{"renovate[bot]", true},
+		{"socialgouv-renovate[bot]", true},
+		{"SocialGouv-Renovate[Bot]", true},
+		{"dependabot[bot]", true},
+		{"alice", false},
+		{"renovate-helper", false},
+		{"", false},
+	} {
+		if got := MatchAuthor(list, tc.login); got != tc.want {
+			t.Errorf("MatchAuthor(%q) = %v, want %v", tc.login, got, tc.want)
+		}
+	}
+	// A bare "*" stays an explicit allow-all, not a suffix match on "".
+	if !MatchAuthor([]string{"*"}, "anyone") {
+		t.Error(`"*" must still allow all`)
+	}
+}
+
+func TestMatchAuthorRule(t *testing.T) {
+	deny := []string{"*renovate[bot]"}
+	for _, tc := range []struct {
+		name        string
+		allow, deny []string
+		login       string
+		want        bool
+	}{
+		{"no filter is open", nil, nil, "alice", true},
+		{"deny beats an empty (open) allowlist", nil, deny, "renovate[bot]", false},
+		{"deny beats an explicit allow", []string{"renovate[bot]"}, deny, "renovate[bot]", false},
+		{"deny leaves others alone", nil, deny, "alice", true},
+		{"allow still filters", []string{"alice"}, nil, "bob", false},
+		// An author we could not identify must not be swallowed by a "*" deny:
+		// that would silently black-hole every unattributed delivery.
+		{"empty login vs wildcard deny", nil, []string{"*"}, "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MatchAuthorRule(tc.allow, tc.deny, tc.login); got != tc.want {
+				t.Errorf("MatchAuthorRule(%v, %v, %q) = %v, want %v", tc.allow, tc.deny, tc.login, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/webhooks/prforge/events.go
+++ b/pkg/webhooks/prforge/events.go
@@ -46,8 +46,12 @@ type PullRequest struct {
 	// auto-launch a bot — the author is still iterating; the trigger is the
 	// `ready_for_review` action (or open/reopen while not draft).
 	Draft bool `json:"draft"`
-	Head  Ref  `json:"head"`
-	Base  Ref  `json:"base"`
+	// User is who OPENED the pull request. Distinct from the event sender on
+	// every action but `opened`: on a push to an existing PR the sender is
+	// whoever pushed, which is not who the PR belongs to.
+	User Sender `json:"user"`
+	Head Ref    `json:"head"`
+	Base Ref    `json:"base"`
 }
 
 type Ref struct {

--- a/pkg/webhooks/prforge/parser.go
+++ b/pkg/webhooks/prforge/parser.go
@@ -25,6 +25,13 @@ type Parsed struct {
 	HeadSHA      string
 	State        string
 	SenderLogin  string
+	// AuthorLogin is who OPENED the pull request. On `opened` it equals
+	// SenderLogin; on a push to an existing PR the sender is whoever pushed,
+	// which is not whose PR it is. Author-based routing (which bot owns this
+	// PR) must read THIS — otherwise a human pushing a fix to a dependency
+	// bot's PR hands the delivery to the wrong bot. Empty when the payload
+	// omits it; callers fall back to SenderLogin.
+	AuthorLogin string
 	// HeadRepoFullName is the "owner/repo" the PR's head branch lives in. It
 	// differs from ProjectPath (the base repo) for a fork PR; empty when the
 	// payload omits head.repo. Read by IsCrossRepo for the fork guard.
@@ -86,10 +93,21 @@ func ParsePullRequest(body []byte) (Parsed, error) {
 		HeadSHA:          pr.Head.SHA,
 		State:            pr.State,
 		SenderLogin:      e.Sender.Login,
+		AuthorLogin:      pr.User.Login,
 		HeadRepoFullName: pr.Head.Repo.FullName,
 		DequeueReason:    e.Reason,
 		Draft:            pr.Draft,
 	}, nil
+}
+
+// Author returns the login author-based routing must use: the PR's own
+// author, falling back to the event sender when a payload omits it (older
+// Forgejo/Gitea versions, hand-crafted redeliveries).
+func (p Parsed) Author() string {
+	if p.AuthorLogin != "" {
+		return p.AuthorLogin
+	}
+	return p.SenderLogin
 }
 
 // IsCrossRepo reports whether the PR's head branch lives in a DIFFERENT repo

--- a/pkg/webhooks/types.go
+++ b/pkg/webhooks/types.go
@@ -85,6 +85,17 @@ type Config struct {
 	WildcardBots bool     `bson:"wildcard_bots,omitempty" json:"wildcard_bots,omitempty"`
 	DefaultBotID string   `bson:"default_bot_id,omitempty" json:"default_bot_id,omitempty"`
 
+	// BotRules is the per-bot routing table for the event-driven lanes. When
+	// non-empty it REPLACES the single-bot SelectBot path: one delivery fans
+	// out to every rule that claims the event and admits the author, so a
+	// dependency-guard and a reviewer can share one repo webhook and each
+	// react to its own PRs. Nil on every config written before this field
+	// existed → the legacy single-bot path, byte-identical. Written only by
+	// the forge orchestrator (never by the webhook CRUD layer): the rules are
+	// derived from the co-enabled bots' manifests, so hand-editing them would
+	// re-open the drift the CommandMap design already closed.
+	BotRules []BotRule `bson:"bot_rules,omitempty" json:"bot_rules,omitempty"`
+
 	// CommandMap routes a /slash-command (lowercase key, no leading slash) to
 	// the bot(s) that claim it. Computed by the forge orchestrator from the
 	// co-enabled bots' manifest invocations (kind=command), so a comment
@@ -245,6 +256,93 @@ func (c *Config) AllowsBot(botID string) bool {
 		}
 	}
 	return false
+}
+
+// BotRule is one bot's OWN routing contract on a shared repo webhook: which
+// forge events it claims, whose PRs it reacts to, and the launch vars its
+// manifest declares. The forge orchestrator materialises one rule per
+// co-enabled bot, so an inbound delivery fans out to EVERY bot whose own rule
+// matches — each with its own author filter and its own vars, instead of the
+// single winner a flattened config could express.
+//
+// Events use the NORMALIZED vocabulary (bundle.ForgeEvent*, e.g.
+// "pull_request"), never a provider-native name, so one rule set serves
+// github / gitlab / forgejo identically.
+type BotRule struct {
+	BotID string `bson:"bot_id" json:"bot_id"`
+
+	// Events this bot claims, normalized. Empty = claims no event lane: a
+	// command-only bot is routed by CommandMap and never auto-launched.
+	Events []string `bson:"events,omitempty" json:"events,omitempty"`
+
+	// Actions narrows the trigger inside an event ("opened", "reopened").
+	// RECORDED BUT NOT ENFORCED: the forge also sends actions a manifest never
+	// lists but the lanes depend on ("ready_for_review" on a draft flip,
+	// "synchronize" for the merge gate), so the handler's own reviewability
+	// gate stays authoritative and this is documentation until the canonical
+	// action mapping lands.
+	Actions []string `bson:"actions,omitempty" json:"actions,omitempty"`
+
+	// AuthorAllowlist restricts which PR/MR author logins fire THIS bot.
+	// Empty = open. Same matcher as Config.AuthorAllowlist (MatchAuthor).
+	AuthorAllowlist []string `bson:"author_allowlist,omitempty" json:"author_allowlist,omitempty"`
+	// AuthorDenylist suppresses this bot for these logins; deny beats allow.
+	// Materialised by the orchestrator from another co-enabled bot's exclusive
+	// author claim (manifest forge.webhook.author_scope: exclusive) — stored
+	// rather than computed per request so the suppression is auditable.
+	AuthorDenylist []string `bson:"author_denylist,omitempty" json:"author_denylist,omitempty"`
+
+	// LabelAllowlist narrows the issue-labeled lane for this bot. Empty = any.
+	LabelAllowlist []string `bson:"label_allowlist,omitempty" json:"label_allowlist,omitempty"`
+
+	// LaunchVars are THIS bot's manifest forge.webhook.launch_vars, kept per
+	// bot so two bots' vars cannot collide in one flat map.
+	LaunchVars map[string]string `bson:"launch_vars,omitempty" json:"launch_vars,omitempty"`
+
+	// Mode mirrors the invocation's execution mode ("direct" | "board").
+	Mode string `bson:"mode,omitempty" json:"mode,omitempty"`
+}
+
+// MatchesEvent reports whether this rule claims a normalized event kind.
+func (r BotRule) MatchesEvent(event string) bool {
+	if event == "" {
+		return false
+	}
+	for _, e := range r.Events {
+		if e == "*" || strings.EqualFold(strings.TrimSpace(e), event) {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchesAuthor applies this rule's own author filter (deny beats allow,
+// empty allowlist = open).
+func (r BotRule) MatchesAuthor(login string) bool {
+	return MatchAuthorRule(r.AuthorAllowlist, r.AuthorDenylist, login)
+}
+
+// HasBotRules reports whether this config carries a per-bot routing table. A
+// config without one predates the field and must keep the legacy single-bot
+// behaviour, idempotency keys included.
+func (c *Config) HasBotRules() bool { return c != nil && len(c.BotRules) > 0 }
+
+// RulesForEvent returns, in provision order, every rule claiming event whose
+// author filter admits author and whose bot the webhook still permits
+// (AllowsBot — belt to the provisioning braces, since bot scope and rules are
+// written together but read long after).
+func (c *Config) RulesForEvent(event, author string) []BotRule {
+	if !c.HasBotRules() {
+		return nil
+	}
+	var out []BotRule
+	for _, r := range c.BotRules {
+		if !r.MatchesEvent(event) || !r.MatchesAuthor(author) || !c.AllowsBot(r.BotID) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
 }
 
 // SelectBot resolves which bot a delivery should launch: the explicit

--- a/pkg/webhooks/types.go
+++ b/pkg/webhooks/types.go
@@ -188,6 +188,14 @@ type Config struct {
 	RateLimit        Rate `bson:"rate_limit" json:"rate_limit"`
 	MonthlyCallLimit int  `bson:"monthly_call_limit,omitempty" json:"monthly_call_limit,omitempty"` // 0 = inherit org
 
+	// OperatorLaunchVars are the per-repo overrides an operator pinned on the
+	// integration, kept SEPARATE from LaunchVars (which is the union of every
+	// co-enabled bot's manifest vars). Layering that union last would undo the
+	// per-bot isolation BotRule.LaunchVars exists for: two bots declaring the
+	// same key with different values would both run with whichever won the
+	// union. Precedence is base < the bot's own rule vars < these.
+	OperatorLaunchVars map[string]string `bson:"operator_launch_vars,omitempty" json:"operator_launch_vars,omitempty"`
+
 	// LaunchVars are stamped onto every run launched through this webhook
 	// (e.g. severity_threshold), overriding the handler-derived vars.
 	LaunchVars map[string]string `bson:"launch_vars,omitempty" json:"launch_vars,omitempty"`

--- a/pkg/webhooks/types.go
+++ b/pkg/webhooks/types.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/retrypolicy"
+	"github.com/SocialGouv/iterion/pkg/schedgate"
 )
 
 // Provider identifies the external event source.
@@ -203,6 +204,22 @@ type Config struct {
 	// several webhooks for the same bot post under different forge tokens /
 	// bot identities. See docs/byok.md.
 	SecretOverrides map[string]string `bson:"secret_overrides,omitempty" json:"secret_overrides,omitempty"`
+
+	// Overlap is the concurrency policy for runs this webhook launches,
+	// keyed on (webhook, subject, bot) — one PR's reviews, not the whole
+	// repo's. Vocabulary shared with every other launch surface
+	// (pkg/schedgate): "allow" | "skip" | "supersede".
+	//
+	// EMPTY means allow, NOT schedgate's "skip" default. A webhook is
+	// event-driven: every delivery has always launched, and silently
+	// promoting that to at-most-one-live would drop deliveries operators
+	// currently rely on. The gate applies only when explicitly set.
+	//
+	// "supersede" is the one worth setting on a review webhook: with
+	// re-review on push, three pushes in two minutes launch three runs, two
+	// of which analyse stale code and post their verdict on dead commits.
+	// Superseding keeps the run that matches what is actually on the branch.
+	Overlap string `bson:"overlap,omitempty" json:"overlap,omitempty"`
 
 	// Retry policy (pkg/retrypolicy) for a run launched through this
 	// webhook that dies on an exhausted provider usage window. The
@@ -462,6 +479,14 @@ const (
 	StatusLaunched      = "launched"
 	StatusLaunchError   = "launch_error"
 )
+
+// OverlapPolicy projects the webhook's overlap field onto the shared
+// launch-surface policy. Not normalized: schedgate's zero value means "skip"
+// and a webhook's means "allow", so the caller checks Overlap != "" before
+// evaluating rather than letting Normalize impose the wrong default here.
+func (c Config) OverlapPolicy() schedgate.Policy {
+	return schedgate.Policy{Overlap: c.Overlap}
+}
 
 // RetryPolicy projects the webhook's retry fields. Not normalized — this
 // is one layer of a precedence chain, and defaults filled here would


### PR DESCRIPTION
Automating review + supply-chain audit + code alignment on a repo's Renovate
PRs turned out to need five things fixed first. Each commit stands alone.

## The gate could never work (`review_on_sync`)

A commit status lives on one commit, so a bot posting a REQUIRED check must
re-run on every push or the status is simply absent from the new head —
indistinguishable from "never reviewed", and unblockable by another review.
`ReviewOnSync` is what opts a push back into review, and it was unreachable:
absent from `webhookConfigReq` (a PATCH carrying it returned 200 and changed
nothing) and never set by `Provision`. It could only ever be false in
production.

Observed live on #300: every `pull_request/synchronize` filtered at 200,
`revi/review` present on five earlier commits and absent from the head, PR
blocked with 20 checks green. Provisioning now derives it from a DECLARED
capability — any co-enabled bot requesting the `statuses` scope gates merges
— and the field is settable through the API.

## One repo, one gate, several bots

A required check applies to EVERY PR. So a repo where a dependency guard
takes the bot's PRs and a reviewer takes the humans' cannot make either
bot's own context required: whichever one did not run blocks the PR
forever. Requiring both is worse.

`gate_context` becomes a var, so the bots that can gate a repo post the SAME
context and the repo has one required check that whichever bot owns the PR
fills. Revi keeps `revi/review` as its default — nothing already relying on
it changes.

Pinning that shared name needed somewhere durable: `Provision` rewrites the
whole webhook config from the manifests, so an override PATCHed onto the
webhook is dropped at the next enable (same class of bug as
`review_on_sync`). Operator launch vars are now persisted on the repo
integration and re-applied on every provision.

## A PR event could only ever launch one bot

`SelectBot()` returns "" as soon as two bots are enabled, so the lane fell
back to the hardcoded `review-pr`. Co-enabling a guard and a reviewer lost
the guard entirely, and the shared `AuthorAllowlist` — the union of every
bot's, nil as soon as one is open — discarded the guard's author filter too.

`Config` now carries a per-bot routing table. A delivery fans out to every
rule that claims the event and admits the author, each with a FRESH vars map
(`injectForgePublishVars` mutates in place) and its OWN idempotency key —
without that the second bot reads the first one's claim as a replay and
never launches. A bot claims its authors exclusively via
`forge.webhook.author_scope`, materialised into the others' denylist, so a
reviewer's manifest never names the guard.

Empty `BotRules` = a config written before this existed: the legacy path and
its idempotency keys are byte-identical, and the idempotent short-circuit
backfills the table — without that, re-enabling an unchanged bot set is a
no-op and no provisioned repo would ever migrate.

**Contract change**: a delivery no enabled bot claims is now filtered (200)
instead of 403 — a 4xx on a forge hook is what makes GitHub disable it.

## Vetty was auditing empty diffs

Its classifier only knew package manifests, so a PR moving a base-image
digest, a devbox pin, a Taskfile tool or a composite action matched nothing.
Those runs did not stop — `is_empty` means "no files changed", not "no
manifest matched" — so the auditor got an EMPTY `bump_summary` and returned
"safe": a façade on a diff nobody read. That was 3 of the 4 open Renovate
PRs on the first repo tried. Verified against the real
`renovate/golang-1.26` branch: 3 Dockerfiles, 1684-char diff, where it
previously produced nothing.

Also: a failed `git merge-base` produced no changed files, read as
`is_empty`, and ended the run mute.

## Vetty's verdict now reaches the merge decision

A commit status carrying it (a table over the verdict the graph already
computed, failing closed on anything unexpected), and — opt-in, off by
default — `arm_automerge`, which asks the forge to merge once ITS OWN
required checks pass. It never merges: only `enablePullRequestAutoMerge`,
never the immediate-merge endpoint, with a test that fails if a merge
mutation is ever issued.

---

`task check` green, `golangci-lint` 0 issues. New tests exercise the real
python bodies against fixtures and a stubbed publish endpoint, and the
classifier + fan-out tests were written red first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)