### PR TITLE
fix(runview+cli): a paused run advertised resumable before it was, and the group guard demanded a contract three groups already had

### DIFF
--- a/cmd/iterion/group_args_test.go
+++ b/cmd/iterion/group_args_test.go
@@ -7,6 +7,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// groupsAcceptingAPositional names the groups whose own Args deliberately
+// admits a positional, so the unknown-subcommand rejection has to come from
+// the command itself rather than from Args. Each needs its RunE driven to
+// prove it — and RunE is only safe to drive in-process for a command with no
+// side effects, which is the judgment this map records.
+//
+// `iterion models [provider/model-id]` lists every model when bare, inspects
+// one when given a spec, and `models pricing` made it a group as well. Its
+// RunE validates the spec before touching anything.
+var groupsAcceptingAPositional = map[string]bool{
+	"iterion models": true,
+}
+
 // TestRejectUnknownSubcommands_CoversEveryGroup walks the real command
 // tree and asserts no group can answer a typo with help and exit 0.
 //
@@ -16,17 +29,17 @@ import (
 // reads as success. A group added later without going through
 // rejectUnknownSubcommands would reintroduce exactly that.
 //
-// Two shapes clear that bar, so each group is held to the one it has:
-//   - a help-only group (stamped by the sweep) must be Runnable and reject
-//     any argument, since it has no meaning for one;
-//   - a group that ALSO takes positional args of its own (`iterion models
-//     [provider/model-id]`) must be Runnable with its own non-nil Args —
-//     cobra then executes it and the command's own validation answers.
-//     Nothing may sit outside both shapes with Args left nil.
+// Every group must be Runnable (else cobra never consults Args at all) and
+// must turn an unknown positional into an error. Where that error comes from
+// is allowed to differ: `Args` for the help-only groups the sweep hardens and
+// for the runnable ones already declaring cobra.NoArgs, the command's own
+// validation for a group that legitimately takes a positional. What is NOT
+// allowed is for a group to accept the argument and act on it.
 func TestRejectUnknownSubcommands_CoversEveryGroup(t *testing.T) {
 	rejectUnknownSubcommands(rootCmd)
 
-	var groups, helpOnly []string
+	const typo = "definitely-not-a-subcommand"
+	var groups, viaArgs []string
 	var walk func(*cobra.Command)
 	walk = func(c *cobra.Command) {
 		for _, sub := range c.Commands() {
@@ -35,30 +48,43 @@ func TestRejectUnknownSubcommands_CoversEveryGroup(t *testing.T) {
 		if c == rootCmd || !c.HasSubCommands() {
 			return
 		}
-		groups = append(groups, c.CommandPath())
+		path := c.CommandPath()
+		groups = append(groups, path)
 
-		// Runnable is the shared half: a non-Runnable group short-circuits
-		// to help before Args is ever consulted, whatever Args says.
+		// A non-Runnable group short-circuits to help before Args is ever
+		// consulted, whatever Args says.
 		if !c.Runnable() {
-			t.Errorf("%q is not Runnable, so cobra short-circuits to help before Args runs",
-				c.CommandPath())
+			t.Errorf("%q is not Runnable, so cobra short-circuits to help before Args runs", path)
 		}
 		if c.Args == nil {
-			t.Errorf("%q has subcommands but no Args validation: a typo would exit 0", c.CommandPath())
+			t.Errorf("%q has subcommands but no Args validation: a typo would exit 0", path)
 			return
 		}
-		if c.Annotations[groupHelpOnlyAnnotation] != "true" {
-			// Its own positional contract — the sweep correctly left it
-			// alone, and the argument reaches its own validation.
-			return
-		}
-		helpOnly = append(helpOnly, c.CommandPath())
-		if err := c.Args(c, []string{"definitely-not-a-subcommand"}); err == nil {
-			t.Errorf("%q accepts an unknown subcommand instead of rejecting it", c.CommandPath())
-		}
-		// A bare invocation must still be allowed — it prints help.
+		// A bare invocation must still be allowed — it prints help (or, for a
+		// group that does something itself, does it).
 		if err := c.Args(c, nil); err != nil {
-			t.Errorf("%q rejects a bare invocation (%v); it should print help", c.CommandPath(), err)
+			t.Errorf("%q rejects a bare invocation (%v); it should not", path, err)
+		}
+
+		if err := c.Args(c, []string{typo}); err != nil {
+			viaArgs = append(viaArgs, path)
+			return
+		}
+		// Args let the typo through, so the command itself is the only thing
+		// left that can reject it. Prove it does.
+		if !groupsAcceptingAPositional[path] {
+			t.Errorf("%q accepts an unknown subcommand through Args and is not a known "+
+				"positional-taking group — either give it cobra.NoArgs, or add it to "+
+				"groupsAcceptingAPositional once you have confirmed its RunE rejects a typo "+
+				"and is safe to drive in-process", path)
+			return
+		}
+		if c.RunE == nil {
+			t.Errorf("%q takes a positional but has no RunE to validate it", path)
+			return
+		}
+		if err := c.RunE(c, []string{typo}); err == nil {
+			t.Errorf("%q ran with %q and reported success — a typo must not be silently accepted", path, typo)
 		}
 	}
 	walk(rootCmd)
@@ -70,49 +96,10 @@ func TestRejectUnknownSubcommands_CoversEveryGroup(t *testing.T) {
 		t.Fatalf("only found %d group commands (%s) — expected the full tree",
 			len(groups), strings.Join(groups, ", "))
 	}
-	// And the sweep did the hardening, rather than every group happening to
-	// carry its own Args — which would make the assertions above vacuous.
-	if len(helpOnly) < 20 {
-		t.Errorf("only %d of %d groups were hardened by the sweep (%s) — the guard is barely doing anything",
-			len(helpOnly), len(groups), strings.Join(helpOnly, ", "))
-	}
-}
-
-// TestRejectUnknownSubcommands_PinsTheSelfDeclaredGroups pins the groups
-// the sweep deliberately leaves alone — the ones that host subcommands AND
-// do something themselves. A new hybrid appearing unnoticed, or a group
-// silently losing its Args, shows up here as a diff rather than as coverage
-// quietly shrinking.
-func TestRejectUnknownSubcommands_PinsTheSelfDeclaredGroups(t *testing.T) {
-	rejectUnknownSubcommands(rootCmd)
-
-	var own []string
-	var walk func(*cobra.Command)
-	walk = func(c *cobra.Command) {
-		for _, sub := range c.Commands() {
-			walk(sub)
-		}
-		if c == rootCmd || !c.HasSubCommands() {
-			return
-		}
-		if c.Annotations[groupHelpOnlyAnnotation] != "true" {
-			own = append(own, c.CommandPath())
-		}
-	}
-	walk(rootCmd)
-
-	// Each one rejects a typo through its own contract, verified by hand:
-	//   iterion models <typo>    → exit 2 (its own spec validation:
-	//                              `[provider/model-id]` inspects one model,
-	//                              bare lists them all, `pricing` made it a
-	//                              group as well)
-	//   iterion server <typo>    → exit 1 (runnable + cobra.NoArgs)
-	//   iterion supervise <typo> → exit 1 (runnable + cobra.NoArgs)
-	want := "iterion models, iterion server, iterion supervise"
-	if got := strings.Join(own, ", "); got != want {
-		t.Errorf("groups declaring their own argument contract = %q, want %q\n"+
-			"a new one is fine — confirm `iterion <group> <typo>` exits non-zero, then update this list",
-			got, want)
+	// And the rejection is broad rather than concentrated in the exceptions.
+	if len(viaArgs) < 20 {
+		t.Errorf("only %d of %d groups reject a typo at the Args level (%s)",
+			len(viaArgs), len(groups), strings.Join(viaArgs, ", "))
 	}
 }
 

--- a/cmd/iterion/group_args_test.go
+++ b/cmd/iterion/group_args_test.go
@@ -10,12 +10,19 @@ import (
 // groupsAcceptingAPositional names the groups whose own Args deliberately
 // admits a positional, so the unknown-subcommand rejection has to come from
 // the command itself rather than from Args. Each needs its RunE driven to
-// prove it — and RunE is only safe to drive in-process for a command with no
-// side effects, which is the judgment this map records.
+// prove it.
 //
-// `iterion models [provider/model-id]` lists every model when bare, inspects
-// one when given a spec, and `models pricing` made it a group as well. Its
-// RunE validates the spec before touching anything.
+// Driving a RunE in-process is only safe for a command that cannot act before
+// it rejects the argument — no I/O, no global mutation, no PersistentPreRun
+// side effect. That judgment is per-command and it is why this is an explicit
+// map rather than a fallback: adding an entry means making the judgment, and
+// the reason belongs next to it.
+//
+//   - "iterion models": `[provider/model-id]` lists every model when bare and
+//     inspects one when given a spec; `models pricing` made it a group too.
+//     Its RunE parses the spec first (cli.RunModels → invalid spec error) and
+//     reaches neither the cache nor the network on a malformed one, and the
+//     command declares no PersistentPreRun. Re-check that if it grows one.
 var groupsAcceptingAPositional = map[string]bool{
 	"iterion models": true,
 }
@@ -97,8 +104,11 @@ func TestRejectUnknownSubcommands_CoversEveryGroup(t *testing.T) {
 			len(groups), strings.Join(groups, ", "))
 	}
 	// And the rejection is broad rather than concentrated in the exceptions.
-	if len(viaArgs) < 20 {
-		t.Errorf("only %d of %d groups reject a typo at the Args level (%s)",
+	// Expressed as a fraction of the tree, not a fixed count: a fixed floor
+	// keeps passing if the tree contracts (groups merged away) even after the
+	// sweep has stopped working.
+	if len(viaArgs)*10 < len(groups)*9 {
+		t.Errorf("only %d of %d groups reject a typo at the Args level, want at least 90%% (%s)",
 			len(viaArgs), len(groups), strings.Join(viaArgs, ", "))
 	}
 }

--- a/cmd/iterion/group_args_test.go
+++ b/cmd/iterion/group_args_test.go
@@ -8,17 +8,25 @@ import (
 )
 
 // TestRejectUnknownSubcommands_CoversEveryGroup walks the real command
-// tree and asserts every group command ends up rejecting arguments.
+// tree and asserts no group can answer a typo with help and exit 0.
 //
 // The regression this guards is silent: cobra returns ErrHelp for a
 // non-Runnable command BEFORE validating args, so a group left untouched
 // answers `iterion <group> <typo>` by printing help and exiting 0 — which
 // reads as success. A group added later without going through
 // rejectUnknownSubcommands would reintroduce exactly that.
+//
+// Two shapes clear that bar, so each group is held to the one it has:
+//   - a help-only group (stamped by the sweep) must be Runnable and reject
+//     any argument, since it has no meaning for one;
+//   - a group that ALSO takes positional args of its own (`iterion models
+//     [provider/model-id]`) must be Runnable with its own non-nil Args —
+//     cobra then executes it and the command's own validation answers.
+//     Nothing may sit outside both shapes with Args left nil.
 func TestRejectUnknownSubcommands_CoversEveryGroup(t *testing.T) {
 	rejectUnknownSubcommands(rootCmd)
 
-	var groups []string
+	var groups, helpOnly []string
 	var walk func(*cobra.Command)
 	walk = func(c *cobra.Command) {
 		for _, sub := range c.Commands() {
@@ -28,20 +36,29 @@ func TestRejectUnknownSubcommands_CoversEveryGroup(t *testing.T) {
 			return
 		}
 		groups = append(groups, c.CommandPath())
+
+		// Runnable is the shared half: a non-Runnable group short-circuits
+		// to help before Args is ever consulted, whatever Args says.
+		if !c.Runnable() {
+			t.Errorf("%q is not Runnable, so cobra short-circuits to help before Args runs",
+				c.CommandPath())
+		}
 		if c.Args == nil {
 			t.Errorf("%q has subcommands but no Args validation: a typo would exit 0", c.CommandPath())
 			return
 		}
+		if c.Annotations[groupHelpOnlyAnnotation] != "true" {
+			// Its own positional contract — the sweep correctly left it
+			// alone, and the argument reaches its own validation.
+			return
+		}
+		helpOnly = append(helpOnly, c.CommandPath())
 		if err := c.Args(c, []string{"definitely-not-a-subcommand"}); err == nil {
 			t.Errorf("%q accepts an unknown subcommand instead of rejecting it", c.CommandPath())
 		}
 		// A bare invocation must still be allowed — it prints help.
 		if err := c.Args(c, nil); err != nil {
 			t.Errorf("%q rejects a bare invocation (%v); it should print help", c.CommandPath(), err)
-		}
-		if !c.Runnable() {
-			t.Errorf("%q is not Runnable, so cobra short-circuits to help before Args runs",
-				c.CommandPath())
 		}
 	}
 	walk(rootCmd)
@@ -52,6 +69,50 @@ func TestRejectUnknownSubcommands_CoversEveryGroup(t *testing.T) {
 	if len(groups) < 20 {
 		t.Fatalf("only found %d group commands (%s) — expected the full tree",
 			len(groups), strings.Join(groups, ", "))
+	}
+	// And the sweep did the hardening, rather than every group happening to
+	// carry its own Args — which would make the assertions above vacuous.
+	if len(helpOnly) < 20 {
+		t.Errorf("only %d of %d groups were hardened by the sweep (%s) — the guard is barely doing anything",
+			len(helpOnly), len(groups), strings.Join(helpOnly, ", "))
+	}
+}
+
+// TestRejectUnknownSubcommands_PinsTheSelfDeclaredGroups pins the groups
+// the sweep deliberately leaves alone — the ones that host subcommands AND
+// do something themselves. A new hybrid appearing unnoticed, or a group
+// silently losing its Args, shows up here as a diff rather than as coverage
+// quietly shrinking.
+func TestRejectUnknownSubcommands_PinsTheSelfDeclaredGroups(t *testing.T) {
+	rejectUnknownSubcommands(rootCmd)
+
+	var own []string
+	var walk func(*cobra.Command)
+	walk = func(c *cobra.Command) {
+		for _, sub := range c.Commands() {
+			walk(sub)
+		}
+		if c == rootCmd || !c.HasSubCommands() {
+			return
+		}
+		if c.Annotations[groupHelpOnlyAnnotation] != "true" {
+			own = append(own, c.CommandPath())
+		}
+	}
+	walk(rootCmd)
+
+	// Each one rejects a typo through its own contract, verified by hand:
+	//   iterion models <typo>    → exit 2 (its own spec validation:
+	//                              `[provider/model-id]` inspects one model,
+	//                              bare lists them all, `pricing` made it a
+	//                              group as well)
+	//   iterion server <typo>    → exit 1 (runnable + cobra.NoArgs)
+	//   iterion supervise <typo> → exit 1 (runnable + cobra.NoArgs)
+	want := "iterion models, iterion server, iterion supervise"
+	if got := strings.Join(own, ", "); got != want {
+		t.Errorf("groups declaring their own argument contract = %q, want %q\n"+
+			"a new one is fine — confirm `iterion <group> <typo>` exits non-zero, then update this list",
+			got, want)
 	}
 }
 

--- a/cmd/iterion/main.go
+++ b/cmd/iterion/main.go
@@ -85,11 +85,6 @@ func main() {
 // command BEFORE it validates args, so Args alone would never be
 // consulted. RunE makes the group Runnable — it only ever prints help,
 // which is what a bare `iterion bundle` did before.
-//
-// Each group it hardens is stamped with groupHelpOnlyAnnotation, so a
-// group that carries its OWN positional contract (`iterion models
-// [provider/model-id]`, runnable and already validating) stays
-// distinguishable from one that exists only to host subcommands.
 func rejectUnknownSubcommands(cmd *cobra.Command) {
 	for _, sub := range cmd.Commands() {
 		rejectUnknownSubcommands(sub)
@@ -97,18 +92,8 @@ func rejectUnknownSubcommands(cmd *cobra.Command) {
 	if cmd.HasSubCommands() && !cmd.Runnable() && cmd.Args == nil {
 		cmd.Args = cobra.NoArgs
 		cmd.RunE = func(c *cobra.Command, _ []string) error { return c.Help() }
-		if cmd.Annotations == nil {
-			cmd.Annotations = map[string]string{}
-		}
-		cmd.Annotations[groupHelpOnlyAnnotation] = "true"
 	}
 }
-
-// groupHelpOnlyAnnotation marks a group whose only behaviour is printing
-// its own help — the shape rejectUnknownSubcommands installs. Read by
-// the coverage test to tell a help-only group from a command that hosts
-// subcommands AND takes positional args of its own.
-const groupHelpOnlyAnnotation = "iterion.group_help_only"
 
 // loadDotEnvFromCwd walks up from $CWD looking for a `.env` file and
 // applies it. We stop at the first one found OR at the filesystem

--- a/cmd/iterion/main.go
+++ b/cmd/iterion/main.go
@@ -85,6 +85,11 @@ func main() {
 // command BEFORE it validates args, so Args alone would never be
 // consulted. RunE makes the group Runnable — it only ever prints help,
 // which is what a bare `iterion bundle` did before.
+//
+// Each group it hardens is stamped with groupHelpOnlyAnnotation, so a
+// group that carries its OWN positional contract (`iterion models
+// [provider/model-id]`, runnable and already validating) stays
+// distinguishable from one that exists only to host subcommands.
 func rejectUnknownSubcommands(cmd *cobra.Command) {
 	for _, sub := range cmd.Commands() {
 		rejectUnknownSubcommands(sub)
@@ -92,8 +97,18 @@ func rejectUnknownSubcommands(cmd *cobra.Command) {
 	if cmd.HasSubCommands() && !cmd.Runnable() && cmd.Args == nil {
 		cmd.Args = cobra.NoArgs
 		cmd.RunE = func(c *cobra.Command, _ []string) error { return c.Help() }
+		if cmd.Annotations == nil {
+			cmd.Annotations = map[string]string{}
+		}
+		cmd.Annotations[groupHelpOnlyAnnotation] = "true"
 	}
 }
+
+// groupHelpOnlyAnnotation marks a group whose only behaviour is printing
+// its own help — the shape rejectUnknownSubcommands installs. Read by
+// the coverage test to tell a help-only group from a command that hosts
+// subcommands AND takes positional args of its own.
+const groupHelpOnlyAnnotation = "iterion.group_help_only"
 
 // loadDotEnvFromCwd walks up from $CWD looking for a `.env` file and
 // applies it. We stop at the first one found OR at the filesystem

--- a/e2e/board_dispatcher_test.go
+++ b/e2e/board_dispatcher_test.go
@@ -9,6 +9,7 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -66,41 +67,30 @@ func TestBoardDispatcher_E2E_BotCreatesAndDispatches(t *testing.T) {
 	// Wait for two distinct dispatches. Generous deadline: the dispatch
 	// pipeline makes two off-actor hops per issue plus a runner round-trip, so
 	// under -race + load a 3s budget can blow.
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
+	countDispatched := func() int {
 		dispatchMu.Lock()
-		got := len(dispatchedRuns)
-		dispatchMu.Unlock()
-		if got >= 2 {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
+		defer dispatchMu.Unlock()
+		return len(dispatchedRuns)
 	}
-	dispatchMu.Lock()
-	if len(dispatchedRuns) < 2 {
-		dispatchMu.Unlock()
-		t.Fatalf("expected 2 dispatches, saw %d (snapshot=%+v)", len(dispatchedRuns), c.Snapshot())
-	}
-	dispatchMu.Unlock()
+	waitUntil(t, 10*time.Second, "both issues to be dispatched",
+		func() bool { return countDispatched() >= 2 },
+		func() string {
+			return fmt.Sprintf("dispatches=%d want>=2, snapshot=%+v", countDispatched(), c.Snapshot())
+		})
 
 	// Both issues must end up in a terminal state with their claim released.
-	wait := time.Now().Add(5 * time.Second)
-	for time.Now().Before(wait) {
-		list, _ := ns.List(native.ListFilter{})
-		all := true
-		for _, iss := range list {
-			st := ns.Board().StateByName(iss.State)
-			if st == nil || !st.Terminal || iss.Claim != "" {
-				all = false
-				break
+	waitUntil(t, 5*time.Second, "every issue to close and release its claim",
+		func() bool {
+			list, _ := ns.List(native.ListFilter{})
+			for _, iss := range list {
+				st := ns.Board().StateByName(iss.State)
+				if st == nil || !st.Terminal || iss.Claim != "" {
+					return false
+				}
 			}
-		}
-		if all {
-			return
-		}
-		time.Sleep(30 * time.Millisecond)
-	}
-	t.Fatalf("issues did not all close. snapshot=%+v", c.Snapshot())
+			return true
+		},
+		func() string { return fmt.Sprintf("snapshot=%+v", c.Snapshot()) })
 }
 
 // TestBoardDispatcher_E2E_BotMovesIssueToReady covers the
@@ -168,43 +158,32 @@ func TestBoardDispatcher_E2E_BotMovesIssueToReady(t *testing.T) {
 	// Generous deadline: the dispatch pipeline makes two off-actor hops
 	// (discovery → setup → worker) plus a runner round-trip; under -race +
 	// load a 3s budget can blow. 10s mirrors TestDispatcherE2E_CancelInFlight.
-	deadline := time.After(10 * time.Second)
-	for {
-		dispatchMu.Lock()
-		got := len(dispatchedRunIDs)
-		dispatchMu.Unlock()
-		if got >= 1 {
-			break
-		}
-		select {
-		case <-deadline:
-			t.Fatalf("dispatcher never dispatched after move-to-ready. snapshot=%+v", c.Snapshot())
-		case <-time.After(30 * time.Millisecond):
-		}
-	}
+	waitUntil(t, 10*time.Second, "a dispatch after the move to ready",
+		func() bool {
+			dispatchMu.Lock()
+			defer dispatchMu.Unlock()
+			return len(dispatchedRunIDs) >= 1
+		},
+		func() string { return fmt.Sprintf("snapshot=%+v", c.Snapshot()) })
 
 	// Cross-check the dispatch was for our issue by inspecting the dispatcher
 	// snapshot (DispatchSpec doesn't carry IssueID). The handler is still
 	// blocked, so the run is reliably in flight and our issue must appear in
 	// the Running set — no instant-finish race.
-	foundRunning := false
-	deadline2 := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline2) {
-		for _, r := range c.Snapshot().Running {
-			if r.IssueID == iss.ID {
-				foundRunning = true
-				break
+	//
+	// `proceed` is released by the deferred cleanup on a failure path too: the
+	// handler also selects on ctx.Done(), which Stop() cancels.
+	defer close(proceed) // release the run so it can complete + the claim is freed
+	waitUntil(t, 5*time.Second, "the dispatched run to appear in the Running snapshot",
+		func() bool {
+			for _, r := range c.Snapshot().Running {
+				if r.IssueID == iss.ID {
+					return true
+				}
 			}
-		}
-		if foundRunning {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	close(proceed) // release the run so it can complete + the claim is freed
-	if !foundRunning {
-		t.Fatalf("dispatched run never appeared in the Running snapshot for issue %s", iss.ID)
-	}
+			return false
+		},
+		func() string { return fmt.Sprintf("issue %s, snapshot=%+v", iss.ID, c.Snapshot()) })
 }
 
 // TestBoardDispatcher_E2E_CapabilityGate verifies that a "PO" bot

--- a/e2e/dispatcher_test.go
+++ b/e2e/dispatcher_test.go
@@ -116,17 +116,15 @@ func TestDispatcherE2E_DispatchAndRelease(t *testing.T) {
 	}
 
 	// Wait for the actor to drain the cmdRunFinished + release the claim.
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(c.Snapshot().Running) == 0 {
-			refreshed, _ := ns.Get(iss.ID)
-			if refreshed.Claim == "" {
-				return
+	waitUntil(t, 10*time.Second, "the dispatcher to free the slot and release the claim",
+		func() bool {
+			if len(c.Snapshot().Running) != 0 {
+				return false
 			}
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	t.Fatalf("dispatcher did not release claim. snapshot=%+v", c.Snapshot())
+			refreshed, _ := ns.Get(iss.ID)
+			return refreshed.Claim == ""
+		},
+		func() string { return fmt.Sprintf("snapshot=%+v", c.Snapshot()) })
 }
 
 func TestDispatcherE2E_RetryAfterFailure(t *testing.T) {
@@ -143,14 +141,11 @@ func TestDispatcherE2E_RetryAfterFailure(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	deadline := time.Now().Add(4 * time.Second)
-	for time.Now().Before(deadline) {
-		if calls.Load() >= 2 {
-			return
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	t.Fatalf("expected at least 2 attempts, saw %d (snapshot=%+v)", calls.Load(), c.Snapshot())
+	waitUntil(t, 4*time.Second, "a failed dispatch to be retried at least once",
+		func() bool { return calls.Load() >= 2 },
+		func() string {
+			return fmt.Sprintf("attempts=%d want>=2, snapshot=%+v", calls.Load(), c.Snapshot())
+		})
 }
 
 func TestDispatcherE2E_CancelInFlight(t *testing.T) {
@@ -174,20 +169,15 @@ func TestDispatcherE2E_CancelInFlight(t *testing.T) {
 
 	c.Cancel(iss.ID)
 
-	// Generous deadline: the cancel→handler-return→cmdRunFinished→finishRun
-	// chain completes in ~50ms unloaded, but it crosses the actor's command
-	// channel and a dispatch-worker teardown, so under a loaded CI host (or a
-	// busy dev machine running the full suite + docker) scheduler jitter can
-	// push it past a tight 2s window — a flaky failure, not a real hang. 10s
-	// stays a hard ceiling that still catches a genuine cancel-flush hang.
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(c.Snapshot().Running) == 0 {
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	t.Fatalf("cancel did not flush running entry")
+	// The cancel→handler-return→cmdRunFinished→finishRun chain completes in
+	// ~30ms unloaded, but it crosses the actor's command channel twice and a
+	// dispatch-worker teardown, so 10s is the hard ceiling that still catches a
+	// genuine cancel-flush hang. waitUntil logs the wait when it eats most of
+	// that budget and dumps goroutines on failure — this assertion has already
+	// been widened once for flakiness, and the passing runs said nothing about
+	// whether the margin was shrinking.
+	waitUntil(t, 10*time.Second, "cancel to flush the running entry",
+		func() bool { return len(c.Snapshot().Running) == 0 })
 }
 
 func TestDispatcherE2E_RespectsTerminalStateChange(t *testing.T) {
@@ -206,31 +196,16 @@ func TestDispatcherE2E_RespectsTerminalStateChange(t *testing.T) {
 
 	iss, _ := ns.Create(native.Issue{Title: "movable", State: "ready"})
 
-	// Wait for dispatch to start.
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(c.Snapshot().Running) == 1 {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	if len(c.Snapshot().Running) != 1 {
-		t.Fatal("dispatch never started")
-	}
+	waitUntil(t, 10*time.Second, "the dispatch to start",
+		func() bool { return len(c.Snapshot().Running) == 1 })
 
 	// Externally move issue to a terminal state — dispatcher should cancel.
 	if _, err := ns.SetState(iss.ID, "done"); err != nil {
 		t.Fatalf("SetState: %v", err)
 	}
 
-	deadline = time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(c.Snapshot().Running) == 0 {
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	t.Fatalf("dispatcher did not honor external state change")
+	waitUntil(t, 10*time.Second, "the dispatcher to honor the external state change",
+		func() bool { return len(c.Snapshot().Running) == 0 })
 }
 
 func TestDispatcherE2E_HTTPSurface(t *testing.T) {
@@ -264,15 +239,12 @@ func TestDispatcherE2E_HTTPSurface(t *testing.T) {
 	}
 
 	// Wait for at least one dispatch then release.
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		l, _ := ns.List(native.ListFilter{})
-		if len(l) == 1 && l[0].Claim == "" {
-			return
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	t.Fatalf("HTTP round-trip dispatch+release never completed (snapshot=%+v)", c.Snapshot())
+	waitUntil(t, 10*time.Second, "the HTTP round-trip dispatch+release to complete",
+		func() bool {
+			l, _ := ns.List(native.ListFilter{})
+			return len(l) == 1 && l[0].Claim == ""
+		},
+		func() string { return fmt.Sprintf("snapshot=%+v", c.Snapshot()) })
 }
 
 func statusOrZero(r *http.Response) int {

--- a/e2e/issue_triage_trigger_test.go
+++ b/e2e/issue_triage_trigger_test.go
@@ -11,6 +11,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -95,15 +96,11 @@ func TestIssueTriageTrigger_E2E_ConsumeAndLaunch(t *testing.T) {
 	}
 
 	waitPlans := func(want int, msg string) []trigger.LaunchPlan {
-		deadline := time.Now().Add(10 * time.Second)
-		for time.Now().Before(deadline) {
-			if plans := launcher.snapshot(); len(plans) >= want {
-				return plans
-			}
-			time.Sleep(25 * time.Millisecond)
-		}
-		t.Fatalf("%s: launches=%d want %d", msg, len(launcher.snapshot()), want)
-		return nil
+		t.Helper()
+		waitUntil(t, 10*time.Second, msg,
+			func() bool { return len(launcher.snapshot()) >= want },
+			func() string { return fmt.Sprintf("launches=%d want %d", len(launcher.snapshot()), want) })
+		return launcher.snapshot()
 	}
 
 	plans := waitPlans(1, "card.created with triage:auto should direct-launch")

--- a/e2e/wait_test.go
+++ b/e2e/wait_test.go
@@ -1,0 +1,76 @@
+package e2e
+
+import (
+	"fmt"
+	goruntime "runtime"
+	"testing"
+	"time"
+)
+
+// waitUntil polls cond until it holds, failing the test if it has not by
+// `within`.
+//
+// It replaces the hand-rolled deadline loop this suite had at two dozen call
+// sites, and exists for two properties those loops did not have:
+//
+//   - A slow-but-passing wait is REPORTED. Widening a deadline is the reflex
+//     for a timing flake, and it silently converts a visible flake into an
+//     invisible regression: the assertion keeps passing while the thing it
+//     watches gets steadily slower, until it crosses the new ceiling too. The
+//     "used most of its budget" log line is the only signal that shows up
+//     before that happens. TestDispatcherE2E_CancelInFlight has already been
+//     widened twice (2s → 10s) and still flaked; nobody could say whether the
+//     passing runs took 30ms or 9s.
+//   - A failure dumps the goroutines. Every wait here watches a
+//     cross-goroutine handoff — an actor draining a command channel, a worker
+//     returning, a claim being released — so "it never happened" is nearly
+//     always "something is parked somewhere". On CI there is no second chance
+//     to attach a debugger, and a bare "cancel did not flush running entry"
+//     names the symptom while withholding every fact needed to fix it.
+//
+// `what` completes the sentence "timed out waiting for …". Optional `detail`
+// closures are evaluated AT FAILURE TIME (a snapshot captured at call time
+// would predate the wait, which is exactly when it is useless).
+func waitUntil(t *testing.T, within time.Duration, what string, cond func() bool, detail ...func() string) {
+	t.Helper()
+	const poll = 20 * time.Millisecond
+	start := time.Now()
+	deadline := start.Add(within)
+	for {
+		if cond() {
+			// Half the budget: enough headroom that a normally-scheduled run
+			// stays quiet, tight enough that the drift preceding the next
+			// flake is on the record.
+			if elapsed := time.Since(start); elapsed > within/2 {
+				t.Logf("waited %s of a %s budget for %s — passing, but it used most of its margin",
+					elapsed.Round(time.Millisecond), within, what)
+			}
+			return
+		}
+		if !time.Now().Before(deadline) {
+			break
+		}
+		time.Sleep(poll)
+	}
+	msg := fmt.Sprintf("timed out after %s waiting for %s", within, what)
+	for _, d := range detail {
+		if d != nil {
+			msg += "\n" + d()
+		}
+	}
+	t.Fatalf("%s\n%s", msg, goroutineDump())
+}
+
+// goroutineDump renders every goroutine's stack, capped so a failure stays
+// readable in a CI log. The parked goroutine is the answer to "why did this
+// never happen", and a CI failure is the only chance to see it.
+func goroutineDump() string {
+	buf := make([]byte, 512<<10)
+	n := goruntime.Stack(buf, true)
+	const limit = 64 << 10
+	if n > limit {
+		return fmt.Sprintf("%s\n... goroutine dump truncated (%d of %d bytes)",
+			buf[:limit], limit, n)
+	}
+	return string(buf[:n])
+}

--- a/e2e/whats_next_loop_test.go
+++ b/e2e/whats_next_loop_test.go
@@ -366,23 +366,18 @@ func TestWhatsNext_Loop_DispatchAutoTransitionsNoReloop(t *testing.T) {
 	issY := mkIssue("Implement Y")
 
 	// Wait for both issues to reach review state.
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		xs, _ := ns.Get(issX.ID)
-		ys, _ := ns.Get(issY.ID)
-		if xs != nil && ys != nil && xs.State == native.StateReview && ys.State == native.StateReview {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
+	inReview := func(id string) bool {
+		iss, _ := ns.Get(id)
+		return iss != nil && iss.State == native.StateReview
 	}
-	finalX, _ := ns.Get(issX.ID)
-	finalY, _ := ns.Get(issY.ID)
-	if finalX == nil || finalX.State != native.StateReview {
-		t.Fatalf("issue %q never reached review — got state=%v (guard 45eafe28)", issX.Title, stateOf(finalX))
-	}
-	if finalY == nil || finalY.State != native.StateReview {
-		t.Fatalf("issue %q never reached review — got state=%v (guard 45eafe28)", issY.Title, stateOf(finalY))
-	}
+	waitUntil(t, 10*time.Second, "both issues to auto-transition to review (guard 45eafe28)",
+		func() bool { return inReview(issX.ID) && inReview(issY.ID) },
+		func() string {
+			x, _ := ns.Get(issX.ID)
+			y, _ := ns.Get(issY.ID)
+			return fmt.Sprintf("%q state=%v, %q state=%v",
+				issX.Title, stateOf(x), issY.Title, stateOf(y))
+		})
 	if got := dispatchCount.Load(); got != 2 {
 		t.Fatalf("expected exactly 2 dispatches before transition, got %d", got)
 	}
@@ -477,23 +472,18 @@ func TestWhatsNext_Loop_FindingsInboxSurvivesDispatch(t *testing.T) {
 	issY := mkReady("Implement Y")
 
 	// Wait for both work issues to auto-transition to review.
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		xs, _ := ns.Get(issX.ID)
-		ys, _ := ns.Get(issY.ID)
-		if xs != nil && ys != nil && xs.State == native.StateReview && ys.State == native.StateReview {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
+	inReview := func(id string) bool {
+		iss, _ := ns.Get(id)
+		return iss != nil && iss.State == native.StateReview
 	}
-	finalX, _ := ns.Get(issX.ID)
-	finalY, _ := ns.Get(issY.ID)
-	if finalX == nil || finalX.State != native.StateReview {
-		t.Fatalf("work issue %q never reached review — got state=%v (guard 45eafe28)", issX.Title, stateOf(finalX))
-	}
-	if finalY == nil || finalY.State != native.StateReview {
-		t.Fatalf("work issue %q never reached review — got state=%v (guard 45eafe28)", issY.Title, stateOf(finalY))
-	}
+	waitUntil(t, 10*time.Second, "both work issues to auto-transition to review (guard 45eafe28)",
+		func() bool { return inReview(issX.ID) && inReview(issY.ID) },
+		func() string {
+			x, _ := ns.Get(issX.ID)
+			y, _ := ns.Get(issY.ID)
+			return fmt.Sprintf("%q state=%v, %q state=%v",
+				issX.Title, stateOf(x), issY.Title, stateOf(y))
+		})
 	if got := dispatchCount.Load(); got != 2 {
 		t.Fatalf("expected exactly 2 work dispatches, got %d", got)
 	}

--- a/pkg/cloud/metrics/metrics.go
+++ b/pkg/cloud/metrics/metrics.go
@@ -63,6 +63,13 @@ type Registry struct {
 	RunsRetryScheduled     prometheus.Counter
 	RunsRetryResumed       *prometheus.CounterVec // result (enqueued|abandoned|failed)
 	RunsRetryPending       prometheus.Gauge
+	// RunsRetrySweeps is what makes the three above readable. Every one of
+	// them sits at 0 on a healthy idle deployment — and also on a deployment
+	// where the sweeper never started, because a registered-but-never-Set
+	// gauge reports 0 either way. A rising sweep count is the only thing that
+	// tells those two apart, and it is the difference between "no run is
+	// waiting" and "every waiting run is stranded".
+	RunsRetrySweeps prometheus.Counter
 }
 
 // New registers the metrics on a fresh registry. Each call gives a
@@ -156,6 +163,10 @@ func New() *Registry {
 		Name: "iterion_runs_retry_pending",
 		Help: "Runs currently armed for an automatic retry (sampled each sweep).",
 	})
+	r.RunsRetrySweeps = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "iterion_runs_retry_sweeps_total",
+		Help: "Retry-sweeper passes completed. Flat at 0 means the sweeper is not running, which the other retry metrics cannot distinguish from an idle one.",
+	})
 	r.DLQDepth = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "iterion_dlq_depth",
 		Help: "Messages currently parked on the runs DLQ stream.",
@@ -170,7 +181,7 @@ func New() *Registry {
 		r.AuthLoginsTotal, r.AuthPasswordResetsTotal,
 		r.LaunchDeniedTotal, r.RunsOrphanRecovered, r.DLQDepth,
 		r.RunsUsageWindowBlocked, r.RunsRetryScheduled,
-		r.RunsRetryResumed, r.RunsRetryPending,
+		r.RunsRetryResumed, r.RunsRetryPending, r.RunsRetrySweeps,
 	)
 	return r
 }

--- a/pkg/runview/manager.go
+++ b/pkg/runview/manager.go
@@ -42,20 +42,30 @@ type runHandle struct {
 	// multiple RequestPause calls race (e.g. the user double-clicks
 	// the Pause button before the run has drained).
 	pauseRequested bool
-	// leaving is closed by MarkLeaving when the engine call has returned
-	// and this handle is on its way out. It is what tells a re-registration
-	// apart: a handle with leaving OPEN belongs to a runner that is still
-	// working, and a second registration for it must be refused at once;
-	// one with leaving CLOSED is worth waiting a moment for.
+	// handoff, once closed, says that a SECOND registration for this run id is
+	// a hand-off rather than a conflict — so AwaitHandoff should wait for this
+	// handle to go instead of letting the caller fail on "already registered".
+	// While it is open, a second registration is refused at once, which is what
+	// keeps a genuine two-runners-for-one-run attempt cheap.
+	//
+	// Two things close it, for the two shapes that are hand-offs:
+	//   - MarkLeaving, when a root run's engine call has returned and the
+	//     handle is only finishing its teardown;
+	//   - ExpectHandoff, at registration, for a subbot child — which is ALWAYS
+	//     resumed externally and whose in-process handle is released as soon as
+	//     the active pass returns, so a second registration is never a rival
+	//     runner. It has to be declared up front there: the child's paused
+	//     status reaches the store while the engine is still returning, so an
+	//     operator can be resuming it before there is any later moment to mark.
 	//
 	// Nil for a detached handle (RegisterDetached), which never takes part in a
 	// hand-off. AwaitHandoff's non-blocking select therefore falls to default
 	// on one — a receive from a nil channel blocks forever, so the ready case
 	// cannot fire. That is load-bearing: do not drop that default branch, and
-	// do not add a bare `<-h.leaving` anywhere.
-	leaving chan struct{}
-	// leavingMarked guards against a double close of leaving.
-	leavingMarked bool
+	// do not add a bare `<-h.handoff` anywhere.
+	handoff chan struct{}
+	// handoffMarked guards against a double close of handoff.
+	handoffMarked bool
 }
 
 // Manager owns the lifecycle of in-process workflow goroutines. A run
@@ -112,7 +122,7 @@ func (m *Manager) Register(parent context.Context, runID string) (context.Contex
 		done:      make(chan struct{}),
 		startedAt: time.Now().UTC(),
 		pauseCh:   make(chan struct{}),
-		leaving:   make(chan struct{}),
+		handoff:   make(chan struct{}),
 	}
 	return ctx, nil
 }
@@ -128,15 +138,25 @@ func (m *Manager) Register(parent context.Context, runID string) (context.Contex
 // that follows is what makes the window wide enough to matter: a completion
 // webhook, a supervisor drain, a broker close. Idempotent; a no-op for an
 // unknown or already-marked run.
-func (m *Manager) MarkLeaving(runID string) {
+func (m *Manager) MarkLeaving(runID string) { m.markHandoff(runID) }
+
+// ExpectHandoff declares up front that a second registration for runID will be
+// a hand-off, not a rival runner. Used for a subbot child: it is always resumed
+// externally, its in-process handle is released as soon as the active pass
+// returns, and its paused status reaches the store while the engine is still
+// returning — so there is no later moment at which marking it would still be in
+// time. Idempotent; a no-op for an unknown or detached run.
+func (m *Manager) ExpectHandoff(runID string) { m.markHandoff(runID) }
+
+func (m *Manager) markHandoff(runID string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	h, ok := m.handles[runID]
-	if !ok || h.leaving == nil || h.leavingMarked {
+	if !ok || h.handoff == nil || h.handoffMarked {
 		return
 	}
-	h.leavingMarked = true
-	close(h.leaving)
+	h.handoffMarked = true
+	close(h.handoff)
 }
 
 // PauseSignal returns the engine-side receive-only pause channel for
@@ -267,7 +287,7 @@ func (m *Manager) AwaitHandoff(ctx context.Context, runID string) {
 		return
 	}
 	select {
-	case <-h.leaving:
+	case <-h.handoff:
 	default:
 		return // still working — not a handoff, so not ours to wait out
 	}

--- a/pkg/runview/manager.go
+++ b/pkg/runview/manager.go
@@ -42,6 +42,14 @@ type runHandle struct {
 	// multiple RequestPause calls race (e.g. the user double-clicks
 	// the Pause button before the run has drained).
 	pauseRequested bool
+	// leaving is closed by MarkLeaving when the engine call has returned
+	// and this handle is on its way out. It is what tells a re-registration
+	// apart: a handle with leaving OPEN belongs to a runner that is still
+	// working, and a second registration for it must be refused at once;
+	// one with leaving CLOSED is worth waiting a moment for. Never nil.
+	leaving chan struct{}
+	// leavingMarked guards against a double close of leaving.
+	leavingMarked bool
 }
 
 // Manager owns the lifecycle of in-process workflow goroutines. A run
@@ -74,7 +82,7 @@ func NewManager() *Manager {
 // already registered for runID (defensive — Service.Launch generates
 // IDs that should be unique).
 func (m *Manager) Register(parent context.Context, runID string) (context.Context, error) {
-	m.awaitPreviousRunner(runID)
+	m.awaitPreviousRunner(parent, runID)
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -91,8 +99,31 @@ func (m *Manager) Register(parent context.Context, runID string) (context.Contex
 		done:      make(chan struct{}),
 		startedAt: time.Now().UTC(),
 		pauseCh:   make(chan struct{}),
+		leaving:   make(chan struct{}),
 	}
 	return ctx, nil
+}
+
+// MarkLeaving declares that runID's engine call has returned and the handle
+// is now only finishing its teardown. It is the evidence awaitPreviousRunner
+// needs to tell "this runner is on its way out, wait for it" from "this
+// runner is alive and well, refuse now" — without it, every duplicate
+// registration would pay the full handoff grace before failing.
+//
+// Called by the run goroutine as soon as the engine returns, which is also
+// when the STORE already carries the terminal or paused status. The teardown
+// that follows is what makes the window wide enough to matter: a completion
+// webhook, a supervisor drain, a broker close. Idempotent; a no-op for an
+// unknown or already-marked run.
+func (m *Manager) MarkLeaving(runID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	h, ok := m.handles[runID]
+	if !ok || h.leaving == nil || h.leavingMarked {
+		return
+	}
+	h.leavingMarked = true
+	close(h.leaving)
 }
 
 // PauseSignal returns the engine-side receive-only pause channel for
@@ -148,9 +179,15 @@ func (m *Manager) RequestPause(runID string) error {
 // Unlike Register, this method does NOT create a context — detached
 // runners own their own context inside the spawned process, so the
 // server-side handle has no ctx to propagate.
+//
+// It also does NOT wait out a previous runner, deliberately. Its callers have
+// ALREADY started the subprocess by the time they get here (spawnDetached
+// Start()s, then registers), so waiting would leave two `iterion` processes
+// aimed at one run for the duration: the loser dies on the store flock while
+// the winner's registration succeeds against a dead PID, and the API reports a
+// resume that never happened. An immediate refusal keeps that failure loud.
+// A detached handoff grace has to be taken BEFORE the spawn to be safe.
 func (m *Manager) RegisterDetached(runID string, pid int, cancel context.CancelFunc, done chan struct{}) error {
-	m.awaitPreviousRunner(runID)
-
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -186,29 +223,44 @@ func (m *Manager) RegisterDetached(runID string, pid int, cancel context.CancelF
 const registerHandoffGrace = 5 * time.Second
 
 // awaitPreviousRunner waits, bounded, for an existing handle for runID to
-// finish. It does NOT reserve anything: the caller's own registration check
-// remains the authority, so a previous runner that never leaves still yields
-// "already registered" — the guard against two concurrent runners for one run
-// is intact. This only stops that guard from firing on a runner that is
-// already on its way out.
+// finish — but ONLY when that handle has been marked leaving. A handle whose
+// runner is still working returns immediately, so a genuine
+// two-runners-for-one-run attempt fails as fast as it always did instead of
+// parking the caller (an HTTP handler, typically) for the whole grace.
+//
+// It does NOT reserve anything: the caller's own registration check remains
+// the authority, so a previous runner that never finishes leaving still
+// yields "already registered". This only stops that guard from firing on a
+// runner that is already on its way out.
 //
 // The wait happens OUTSIDE the mutex on purpose: Deregister needs the same
 // lock to close done, so holding it here would deadlock the very thing we are
 // waiting for.
-func (m *Manager) awaitPreviousRunner(runID string) {
+func (m *Manager) awaitPreviousRunner(ctx context.Context, runID string) {
 	m.mu.Lock()
 	h, exists := m.handles[runID]
+	stopped := m.stopped
 	m.mu.Unlock()
-	if !exists {
+	// A manager already stopped is going to refuse the registration anyway;
+	// waiting first would only delay saying so.
+	if !exists || stopped {
 		return
+	}
+	select {
+	case <-h.leaving:
+	default:
+		return // still working — not a handoff, so not ours to wait out
 	}
 	grace := m.handoffGrace
 	if grace <= 0 {
 		grace = registerHandoffGrace
 	}
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
 	select {
 	case <-h.done:
-	case <-time.After(grace):
+	case <-ctx.Done():
+	case <-timer.C:
 	}
 }
 

--- a/pkg/runview/manager.go
+++ b/pkg/runview/manager.go
@@ -51,11 +51,15 @@ type Manager struct {
 	mu      sync.Mutex
 	handles map[string]*runHandle
 	stopped bool
+	// handoffGrace bounds the wait for a previous runner to finish leaving
+	// (see registerHandoffGrace). Overridable so a test that asserts the
+	// REFUSAL path does not have to burn the production grace on every run.
+	handoffGrace time.Duration
 }
 
 // NewManager creates an empty manager.
 func NewManager() *Manager {
-	return &Manager{handles: make(map[string]*runHandle)}
+	return &Manager{handles: make(map[string]*runHandle), handoffGrace: registerHandoffGrace}
 }
 
 // Register installs a new run handle and returns the cancellable ctx
@@ -70,6 +74,8 @@ func NewManager() *Manager {
 // already registered for runID (defensive — Service.Launch generates
 // IDs that should be unique).
 func (m *Manager) Register(parent context.Context, runID string) (context.Context, error) {
+	m.awaitPreviousRunner(runID)
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -143,6 +149,8 @@ func (m *Manager) RequestPause(runID string) error {
 // runners own their own context inside the spawned process, so the
 // server-side handle has no ctx to propagate.
 func (m *Manager) RegisterDetached(runID string, pid int, cancel context.CancelFunc, done chan struct{}) error {
+	m.awaitPreviousRunner(runID)
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -159,6 +167,49 @@ func (m *Manager) RegisterDetached(runID string, pid int, cancel context.CancelF
 		pid:       pid,
 	}
 	return nil
+}
+
+// registerHandoffGrace bounds how long a re-registration waits for the
+// PREVIOUS runner of the same run to finish leaving.
+//
+// The window it closes: a run parking on a human gate writes
+// paused_waiting_human to the STORE, returns ErrRunPaused, and only then does
+// the goroutine carrying it call Deregister on its way out. Between those, the
+// public signal says "resumable" while the handle is still held — and the
+// studio and the pipeline-board sidebar offer Resume on exactly that signal.
+// A resume landing in the window used to fail with "already registered",
+// which reads as a bug to the operator and is one to an automated chain.
+//
+// A few hundred milliseconds normally; seconds under load. Five is generous
+// enough to absorb a loaded host while still surfacing a genuinely stuck
+// previous runner as an error rather than hanging the caller.
+const registerHandoffGrace = 5 * time.Second
+
+// awaitPreviousRunner waits, bounded, for an existing handle for runID to
+// finish. It does NOT reserve anything: the caller's own registration check
+// remains the authority, so a previous runner that never leaves still yields
+// "already registered" — the guard against two concurrent runners for one run
+// is intact. This only stops that guard from firing on a runner that is
+// already on its way out.
+//
+// The wait happens OUTSIDE the mutex on purpose: Deregister needs the same
+// lock to close done, so holding it here would deadlock the very thing we are
+// waiting for.
+func (m *Manager) awaitPreviousRunner(runID string) {
+	m.mu.Lock()
+	h, exists := m.handles[runID]
+	m.mu.Unlock()
+	if !exists {
+		return
+	}
+	grace := m.handoffGrace
+	if grace <= 0 {
+		grace = registerHandoffGrace
+	}
+	select {
+	case <-h.done:
+	case <-time.After(grace):
+	}
 }
 
 // Deregister removes the handle and closes its done channel. Called

--- a/pkg/runview/manager.go
+++ b/pkg/runview/manager.go
@@ -46,7 +46,13 @@ type runHandle struct {
 	// and this handle is on its way out. It is what tells a re-registration
 	// apart: a handle with leaving OPEN belongs to a runner that is still
 	// working, and a second registration for it must be refused at once;
-	// one with leaving CLOSED is worth waiting a moment for. Never nil.
+	// one with leaving CLOSED is worth waiting a moment for.
+	//
+	// Nil for a detached handle (RegisterDetached), which never takes part in a
+	// hand-off. AwaitHandoff's non-blocking select therefore falls to default
+	// on one — a receive from a nil channel blocks forever, so the ready case
+	// cannot fire. That is load-bearing: do not drop that default branch, and
+	// do not add a bare `<-h.leaving` anywhere.
 	leaving chan struct{}
 	// leavingMarked guards against a double close of leaving.
 	leavingMarked bool
@@ -82,7 +88,14 @@ func NewManager() *Manager {
 // already registered for runID (defensive — Service.Launch generates
 // IDs that should be unique).
 func (m *Manager) Register(parent context.Context, runID string) (context.Context, error) {
-	m.awaitPreviousRunner(parent, runID)
+	m.AwaitHandoff(parent, runID)
+	// A caller whose deadline expired mid-hand-off would otherwise be told
+	// "already registered" — indistinguishable from genuinely racing a live
+	// runner, though one is transient and the other is not. An automated retry
+	// chain reading the wrong one gives up (or hammers) for the wrong reason.
+	if err := parent.Err(); err != nil {
+		return nil, fmt.Errorf("runview: waiting for the previous runner of %q: %w", runID, err)
+	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -222,11 +235,18 @@ func (m *Manager) RegisterDetached(runID string, pid int, cancel context.CancelF
 // previous runner as an error rather than hanging the caller.
 const registerHandoffGrace = 5 * time.Second
 
-// awaitPreviousRunner waits, bounded, for an existing handle for runID to
-// finish — but ONLY when that handle has been marked leaving. A handle whose
-// runner is still working returns immediately, so a genuine
-// two-runners-for-one-run attempt fails as fast as it always did instead of
-// parking the caller (an HTTP handler, typically) for the whole grace.
+// AwaitHandoff waits, bounded, for an existing handle for runID to finish —
+// but ONLY when that handle has been marked leaving. A handle whose runner is
+// still working returns immediately, so a genuine two-runners-for-one-run
+// attempt fails as fast as it always did instead of parking the caller (an
+// HTTP handler, typically) for the whole grace.
+//
+// Call it at the TOP of a launch or resume, before anything takes a resource
+// the outgoing runner still holds. The store flock is the first such resource
+// and it is released two deferred statements before the manager handle, so a
+// wait placed at Register alone covers only the gap between them — the
+// operator still gets a failure, with a different message. Register calls this
+// too, as a cheap backstop for callers that do not.
 //
 // It does NOT reserve anything: the caller's own registration check remains
 // the authority, so a previous runner that never finishes leaving still
@@ -236,7 +256,7 @@ const registerHandoffGrace = 5 * time.Second
 // The wait happens OUTSIDE the mutex on purpose: Deregister needs the same
 // lock to close done, so holding it here would deadlock the very thing we are
 // waiting for.
-func (m *Manager) awaitPreviousRunner(ctx context.Context, runID string) {
+func (m *Manager) AwaitHandoff(ctx context.Context, runID string) {
 	m.mu.Lock()
 	h, exists := m.handles[runID]
 	stopped := m.stopped

--- a/pkg/runview/manager_test.go
+++ b/pkg/runview/manager_test.go
@@ -103,3 +103,73 @@ func TestManager_WaitOnInactive(t *testing.T) {
 		t.Errorf("Wait(ghost) = %v, want ErrRunNotActive", err)
 	}
 }
+
+// --- the paused/deregister hand-off window -----------------------------
+//
+// A run parking on a human gate writes paused_waiting_human to the STORE,
+// returns ErrRunPaused, and only then does the goroutine carrying it call
+// Deregister on its way out. Between those, the public status says
+// "resumable" while the handle is still held — and the studio and the
+// pipeline-board sidebar offer Resume on exactly that status. A resume
+// landing in that window used to fail with "already registered".
+//
+// Found by root-causing a CI flake whose message was exactly that; the test
+// that surfaced it was NOT timing out (it failed in 5-7s against a 30s wait),
+// so no deadline raise would have fixed it.
+
+func TestRegister_WaitsOutAnExitingPreviousRunner(t *testing.T) {
+	m := NewManager()
+	if _, err := m.Register(context.Background(), "run-1"); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+
+	// The previous runner is on its way out: it deregisters shortly after the
+	// resume attempt begins, exactly as the real park sequence does.
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		m.Deregister("run-1")
+	}()
+
+	start := time.Now()
+	if _, err := m.Register(context.Background(), "run-1"); err != nil {
+		t.Fatalf("re-Register during the hand-off window: %v — a resume in this window must wait, not fail", err)
+	}
+	if waited := time.Since(start); waited < 50*time.Millisecond {
+		t.Errorf("returned after %s: it cannot have waited for the previous runner", waited)
+	}
+}
+
+// The guard against two genuinely concurrent runners for one run must stay
+// intact: a previous runner that never leaves still yields an error, it does
+// not get silently displaced.
+func TestRegister_StillRefusesARunnerThatNeverLeaves(t *testing.T) {
+	m := NewManager()
+	m.handoffGrace = 20 * time.Millisecond // the refusal path, not the production wait
+	if _, err := m.Register(context.Background(), "run-2"); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	// The handle is alive (done open), so the registration check must fire.
+	if _, err := m.Register(context.Background(), "run-2"); err == nil {
+		t.Fatal("re-Register succeeded against a LIVE previous runner — two runners would share one run")
+	}
+}
+
+// Deregister closes done, which is what the hand-off wait keys on. A second
+// Deregister must stay idempotent (it is called from a defer).
+func TestDeregister_ClosesDoneAndIsIdempotent(t *testing.T) {
+	m := NewManager()
+	if _, err := m.Register(context.Background(), "run-3"); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	m.mu.Lock()
+	done := m.handles["run-3"].done
+	m.mu.Unlock()
+
+	m.Deregister("run-3")
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("done not closed: the hand-off wait would block for its full grace")
+	}
+	m.Deregister("run-3") // must not panic on a closed channel
+}

--- a/pkg/runview/manager_test.go
+++ b/pkg/runview/manager_test.go
@@ -263,3 +263,35 @@ func TestDeregister_ClosesDoneAndIsIdempotent(t *testing.T) {
 	}
 	m.Deregister("run-3") // must not panic on a closed channel
 }
+
+// A subbot child is resumed EXTERNALLY while its in-process handle is still
+// held, and its paused status reaches the store before the engine has finished
+// returning. That makes a second registration a hand-off by construction, which
+// is why the child declares it at registration instead of waiting for a
+// MarkLeaving moment that comes too late to help.
+//
+// This is the case that started the whole investigation
+// (TestServiceLaunch_SubbotChildHumanGate_ParkAndResume flaking on
+// "already registered"), and it is the case a leaving-only gate silently stops
+// covering.
+func TestExpectHandoff_MakesAChildResumeWaitRatherThanFail(t *testing.T) {
+	m := NewManager()
+	if _, err := m.Register(context.Background(), "child-1"); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	m.ExpectHandoff("child-1")
+
+	go func() {
+		time.Sleep(80 * time.Millisecond)
+		m.Deregister("child-1")
+	}()
+
+	start := time.Now()
+	if _, err := m.Register(context.Background(), "child-1"); err != nil {
+		t.Fatalf("external resume of a child mid-release: %v — it must wait for the "+
+			"active pass to release, not fail", err)
+	}
+	if waited := time.Since(start); waited < 50*time.Millisecond {
+		t.Errorf("returned after %s — it cannot have waited for the child's release", waited)
+	}
+}

--- a/pkg/runview/manager_test.go
+++ b/pkg/runview/manager_test.go
@@ -123,8 +123,12 @@ func TestRegister_WaitsOutAnExitingPreviousRunner(t *testing.T) {
 		t.Fatalf("first Register: %v", err)
 	}
 
-	// The previous runner is on its way out: it deregisters shortly after the
-	// resume attempt begins, exactly as the real park sequence does.
+	// The engine has returned, so the run already reads resumable — this is
+	// the window the studio offers Resume in.
+	m.MarkLeaving("run-1")
+
+	// The previous runner finishes its teardown shortly after the resume
+	// attempt begins, exactly as the real park sequence does.
 	go func() {
 		time.Sleep(80 * time.Millisecond)
 		m.Deregister("run-1")
@@ -148,9 +152,50 @@ func TestRegister_StillRefusesARunnerThatNeverLeaves(t *testing.T) {
 	if _, err := m.Register(context.Background(), "run-2"); err != nil {
 		t.Fatalf("first Register: %v", err)
 	}
-	// The handle is alive (done open), so the registration check must fire.
+	m.MarkLeaving("run-2") // marked, but the teardown never completes
 	if _, err := m.Register(context.Background(), "run-2"); err == nil {
-		t.Fatal("re-Register succeeded against a LIVE previous runner — two runners would share one run")
+		t.Fatal("re-Register succeeded against a previous runner that never left — two runners would share one run")
+	}
+}
+
+// A runner that is still WORKING is not a hand-off, and the refusal must not
+// pay the grace to say so. Otherwise every duplicate registration parks its
+// caller — an HTTP handler, typically — for the full five seconds before
+// returning the error it could have returned at once.
+func TestRegister_RefusesALiveRunnerImmediately(t *testing.T) {
+	m := NewManager()
+	m.handoffGrace = 10 * time.Second // must not be paid at all, so make it obvious
+	if _, err := m.Register(context.Background(), "run-live"); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+
+	start := time.Now()
+	if _, err := m.Register(context.Background(), "run-live"); err == nil {
+		t.Fatal("re-Register succeeded against a live runner")
+	}
+	if waited := time.Since(start); waited > time.Second {
+		t.Errorf("refusal took %s — a live runner is not a hand-off and must fail fast", waited)
+	}
+}
+
+// A caller that gives up (client disconnect, server draining) must not be held
+// for the rest of the grace.
+func TestRegister_HandoffWaitHonoursTheCallerContext(t *testing.T) {
+	m := NewManager()
+	m.handoffGrace = 10 * time.Second
+	if _, err := m.Register(context.Background(), "run-ctx"); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	m.MarkLeaving("run-ctx") // in the hand-off window, but the teardown stalls
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	if _, err := m.Register(ctx, "run-ctx"); err == nil {
+		t.Fatal("re-Register succeeded although the previous runner never left")
+	}
+	if waited := time.Since(start); waited > time.Second {
+		t.Errorf("waited %s after the caller's ctx expired", waited)
 	}
 }
 

--- a/pkg/runview/manager_test.go
+++ b/pkg/runview/manager_test.go
@@ -179,7 +179,9 @@ func TestRegister_RefusesALiveRunnerImmediately(t *testing.T) {
 }
 
 // A caller that gives up (client disconnect, server draining) must not be held
-// for the rest of the grace.
+// for the rest of the grace — and must be told WHY it failed. "Already
+// registered" and "your deadline expired mid-hand-off" call for opposite
+// reactions from an automated retry chain.
 func TestRegister_HandoffWaitHonoursTheCallerContext(t *testing.T) {
 	m := NewManager()
 	m.handoffGrace = 10 * time.Second
@@ -191,11 +193,54 @@ func TestRegister_HandoffWaitHonoursTheCallerContext(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 	defer cancel()
 	start := time.Now()
-	if _, err := m.Register(ctx, "run-ctx"); err == nil {
+	_, err := m.Register(ctx, "run-ctx")
+	if err == nil {
 		t.Fatal("re-Register succeeded although the previous runner never left")
 	}
 	if waited := time.Since(start); waited > time.Second {
 		t.Errorf("waited %s after the caller's ctx expired", waited)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error = %v, want it to wrap context.DeadlineExceeded — a caller "+
+			"cannot tell a transient hand-off timeout from racing a live runner otherwise", err)
+	}
+}
+
+// The hand-off signal must mean "that goroutine is FINISHED", not "it is
+// partway through its teardown". A successor released too early races the
+// outgoing goroutine's remaining defers, and those are keyed on run id alone:
+// dropRunLog and unregisterRunEngine would tear down the SUCCESSOR's log buffer
+// and engine registration, turning a loud "already registered" into a resume
+// that reports success with a dead log tail and no steering channel.
+//
+// Asserted here on the Manager contract that makes it possible — Deregister,
+// the only thing that closes done, must be the last teardown step in
+// spawnRun's defer chain. This test pins the half the Manager owns; the defer
+// ordering is pinned by its own comment in service_launch.go.
+func TestDeregister_IsTheLastWordOnAHandoff(t *testing.T) {
+	m := NewManager()
+	if _, err := m.Register(context.Background(), "run-order"); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	m.MarkLeaving("run-order")
+
+	m.mu.Lock()
+	done := m.handles["run-order"].done
+	m.mu.Unlock()
+
+	// Still held: the wait must not release on MarkLeaving alone, or a
+	// successor would start while the teardown is still running.
+	select {
+	case <-done:
+		t.Fatal("done closed by MarkLeaving — the successor would race the whole teardown")
+	default:
+	}
+
+	m.Deregister("run-order")
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Deregister did not close done")
 	}
 }
 

--- a/pkg/runview/service_launch.go
+++ b/pkg/runview/service_launch.go
@@ -281,6 +281,16 @@ func (s *Service) Resume(parent context.Context, spec ResumeSpec) (*LaunchResult
 		return nil, errors.New("runview: file_path is required")
 	}
 
+	// Wait out a previous runner that is still tearing down, BEFORE anything
+	// takes a resource it holds. This is the top of the resume path on purpose:
+	// the store flock (taken inside spawnRun) is what a resume in the hand-off
+	// window actually collides with — it is released two deferred statements
+	// before the manager handle — so a wait placed at Register would only cover
+	// the sliver between them and the operator would still see a failure, just
+	// with a different message. No-op unless the previous runner has announced
+	// it is leaving (see Manager.AwaitHandoff).
+	s.manager.AwaitHandoff(parent, spec.RunID)
+
 	// Propagate parent so the mongo backend's tenant filter applies:
 	// a cross-tenant Resume must resolve to not-found, not panic on a
 	// missing tenant_id in ctx (which Background carries).
@@ -541,6 +551,17 @@ func (s *Service) spawnRun(
 	go func() {
 		var paused bool
 		defer close(done)
+		// Deregister runs LAST of the teardown (defers are LIFO, so the
+		// earliest-registered manager defer executes latest). It closes the
+		// handle's done channel, which is what AwaitHandoff releases on — so it
+		// has to mean "this goroutine is finished", not "it is partway through
+		// its teardown". Registered below dropRunLog / unregisterRunEngine, a
+		// released successor raced them: those two are keyed on runID alone,
+		// and the successor has already installed its own log buffer and engine
+		// by then, so they tore down the NEW run's — a resume that reported
+		// success with a dead log tail and no steering channel. That is worse
+		// than the "already registered" it replaced, because it is silent.
+		defer s.manager.Deregister(runID)
 		defer s.unregisterRunEngine(runID)
 		defer s.dropRunLog(runID)
 		// Keep WS subscribers across a pause: the goroutine exits on
@@ -554,13 +575,12 @@ func (s *Service) spawnRun(
 				s.broker.CloseRun(runID)
 			}
 		}()
-		// Release this root's pipeline-concurrency slot AFTER Deregister
-		// (defers run LIFO, so this line must come BEFORE the Deregister
-		// defer), so the run is fully deregistered before the scheduler
-		// admits the next waiter. A no-op for run IDs that never held a
-		// slot (children, resumes, or when the cap is disabled).
+		// Release this root's pipeline-concurrency slot. A no-op for run IDs
+		// that never held a slot (children, resumes, or when the cap is
+		// disabled). It runs before Deregister now; harmless, because the
+		// waiter it admits is a DIFFERENT run and pipelineQueue keeps its own
+		// accounting — it never consults the Manager.
 		defer s.pipelineQueue.slotFreed(runID)
-		defer s.manager.Deregister(runID)
 		defer func() { _ = lock.Unlock() }()
 		if cancelTimeout != nil {
 			defer cancelTimeout()

--- a/pkg/runview/service_launch.go
+++ b/pkg/runview/service_launch.go
@@ -579,6 +579,12 @@ func (s *Service) spawnRun(
 		defer stopBoard()
 
 		bodyErr := body(ctx, eng)
+		// The engine has written its terminal/paused status to the store, so
+		// the run now READS resumable while this handle is still held through
+		// the teardown below (a completion webhook, a supervisor drain). Say
+		// so, and a resume arriving in that window waits the handoff out
+		// instead of failing on "already registered".
+		s.manager.MarkLeaving(runID)
 		paused = errors.Is(bodyErr, runtime.ErrRunPaused) || errors.Is(bodyErr, runtime.ErrRunPausedOperator)
 		s.logRunOutcome(runID, bodyErr)
 		// Hand the terminal error to a blocking caller (ADR-046: the

--- a/pkg/runview/subbot.go
+++ b/pkg/runview/subbot.go
@@ -50,6 +50,13 @@ func manageSubbotChild(mgr *Manager, parent context.Context, childRunID string, 
 		}
 		return parent, nil, func() {}
 	}
+	// A child is resumed EXTERNALLY and this handle is released as soon as the
+	// active pass returns, so a second registration for its id is a hand-off,
+	// never a rival runner. Declared here rather than later because the child's
+	// paused status lands in the store while childEng.Run is still returning —
+	// the pipeline-board sidebar can be resuming it before the release, and
+	// without this the resume fails on "already registered".
+	mgr.ExpectHandoff(childRunID)
 	var opts []runtime.EngineOption
 	if pauseCh, perr := mgr.PauseSignal(childRunID); perr == nil {
 		opts = append(opts, runtime.WithPauseSignal(pauseCh))

--- a/pkg/server/retry_sweeper.go
+++ b/pkg/server/retry_sweeper.go
@@ -53,7 +53,15 @@ type retryDueLister interface {
 
 // runRetrySweeper ticks sweepDueRetries until ctx is cancelled. Started by
 // ListenAndServe in cloud mode when the store carries retry state.
+//
+// It announces itself on the way in. Every other signal this path emits reads
+// identically whether the sweeper is idle or absent — the counters sit at 0 and
+// a registered-but-never-Set gauge reports 0 — so without this line and the
+// sweep counter, "no run is waiting" and "every waiting run is stranded" are
+// the same observation. Verified against production and they were.
 func (s *Server) runRetrySweeper(ctx context.Context, lister retryDueLister) {
+	s.infof("retry sweeper: watching for runs whose provider quota window has reopened (every %s, up to %d per pass)",
+		retrySweepInterval, retrySweepBatch)
 	t := time.NewTicker(retrySweepInterval)
 	defer t.Stop()
 	for {
@@ -81,6 +89,7 @@ func (s *Server) sweepDueRetries(ctx context.Context, lister retryDueLister, res
 		return
 	}
 	if s.cfg.Metrics != nil {
+		s.cfg.Metrics.RunsRetrySweeps.Inc()
 		// Sampled, not authoritative: the batch cap bounds what one pass
 		// sees. A gauge that sits at the cap is itself the signal that
 		// retries are arriving faster than they are being resumed.

--- a/pkg/server/retry_sweeper_test.go
+++ b/pkg/server/retry_sweeper_test.go
@@ -9,6 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/SocialGouv/iterion/pkg/cloud/metrics"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/store"
 	mongostore "github.com/SocialGouv/iterion/pkg/store/mongo"
@@ -304,6 +308,43 @@ type plainRunStore struct{ store.RunStore }
 // newRetrySweeperServer builds a local-mode server whose WorkDir holds the
 // fixture bot, so resolveResumeSource succeeds and the tests exercise the
 // branch they name rather than all funnelling into "source unresolvable".
+// TestSweepDueRetries_CountsEveryPassEvenWhenNothingIsDue is the liveness
+// signal, and it is not decoration: RunsRetryPending, RunsRetryScheduled and
+// RunsUsageWindowBlocked all read 0 on a healthy idle deployment AND on one
+// where the sweeper never started (a registered-but-never-Set gauge reports 0
+// either way). Checked against production and they were indistinguishable. The
+// sweep counter is the only thing that separates "nothing is waiting" from
+// "everything waiting is stranded", so a pass that forgets to bump it puts the
+// whole path back to unobservable.
+func TestSweepDueRetries_CountsEveryPassEvenWhenNothingIsDue(t *testing.T) {
+	st := newFakeRetryStore()
+	resumer := &fakeResumer{}
+	s := newRetrySweeperServer(t, st, resumer)
+	s.cfg.Metrics = metrics.New()
+
+	for i := 0; i < 3; i++ {
+		s.sweepDueRetries(context.Background(), &fakeRetryLister{}, resumer, time.Now().UTC())
+	}
+
+	if got := counterValue(t, s.cfg.Metrics.RunsRetrySweeps); got != 3 {
+		t.Errorf("iterion_runs_retry_sweeps_total = %v after 3 idle passes, want 3 — "+
+			"a flat counter is indistinguishable from a sweeper that never ran", got)
+	}
+	if len(resumer.calls) != 0 {
+		t.Errorf("resumed %d runs with nothing due", len(resumer.calls))
+	}
+}
+
+// counterValue reads a prometheus counter without a scrape.
+func counterValue(t *testing.T, c prometheus.Counter) float64 {
+	t.Helper()
+	var m dto.Metric
+	if err := c.Write(&m); err != nil {
+		t.Fatalf("read counter: %v", err)
+	}
+	return m.GetCounter().GetValue()
+}
+
 func newRetrySweeperServer(t *testing.T, st store.RunStore, resumer runResumer) *Server {
 	t.Helper()
 	_ = resumer // passed per-call, not stored on the Server

--- a/pkg/server/runs_ws_test.go
+++ b/pkg/server/runs_ws_test.go
@@ -40,6 +40,39 @@ func writeJSONMessage(t *testing.T, c *websocket.Conn, env runWSEnvelope) {
 	}
 }
 
+// awaitBrokerSubscriber blocks until the server has actually subscribed to the
+// broker for runID.
+//
+// The snapshot frame is NOT that signal. handleSubscribe sends the snapshot
+// first and calls SubscribeEvents after, so a test that reads the snapshot and
+// publishes immediately is racing the server: when it loses, the event is
+// dropped on the floor and the test hangs on a read that never completes.
+// That is the whole mechanism behind the intermittent
+// TestRunsWS_AlertEventBypassesSnapshotDedup failures on CI.
+//
+// SubscribeEvents registers with the broker before it does anything expensive,
+// and the per-subscriber channel is buffered, so a publish after this returns
+// is delivered. This waits for the state the test depends on rather than
+// hoping a sleep or a wider read deadline covers it.
+//
+// The same ordering is a real (narrow) product gap for UNPERSISTED events: a
+// client is told it is live-tailing before the tail exists, and an alert event
+// (Seq=0, never written to disk) published in that window cannot be replayed
+// to it. Tracked on the board; closing it means separating the cheap broker
+// subscription from the event-source setup, because simply subscribing before
+// the snapshot makes first paint wait for a full replay pass.
+func awaitBrokerSubscriber(t *testing.T, srv *Server, runID string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if srv.runs.Broker().SubscriberCount(runID) > 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("no broker subscriber for %s after 5s — handleSubscribe never reached SubscribeEvents", runID)
+}
+
 func TestRunsWS_SubscribeReceivesSnapshot(t *testing.T) {
 	srv, hs := newTestServer(t)
 	seedRun(t, srv, "run-1", "wf", store.RunStatusFinished)
@@ -122,6 +155,7 @@ func TestRunsWS_LiveEventReachesSubscriber(t *testing.T) {
 	c := dialRunWS(t, hs, "run-live")
 	writeJSONMessage(t, c, runWSEnvelope{Type: wsTypeSubscribe})
 	_ = readEnvelope(t, c, wsTypeSnapshot)
+	awaitBrokerSubscriber(t, srv, "run-live")
 
 	// Publish an event through the broker — same path the engine uses.
 	srv.runs.Broker().Publish(store.Event{
@@ -182,6 +216,7 @@ func TestRunsWS_AlertEventBypassesSnapshotDedup(t *testing.T) {
 	if snap.LastSeq <= 0 {
 		t.Fatalf("snapshot LastSeq = %d, want > 0 (test needs snapshotSeq past 0 to exercise the guard)", snap.LastSeq)
 	}
+	awaitBrokerSubscriber(t, srv, runID)
 
 	// Publish an in-process alert event the way pkg/alert's browser sink
 	// does: straight to the broker, unpersisted, with Seq=0.

--- a/pkg/server/server_lifecycle.go
+++ b/pkg/server/server_lifecycle.go
@@ -231,6 +231,14 @@ func (s *Server) ListenAndServe() error {
 			}()
 			s.runRetrySweeper(ctx, lister)
 		}()
+	} else if s.cfg.ScheduledBots != nil {
+		// Cloud mode without the capability: a type assertion that quietly
+		// fails here (a store wrapped in a decorator, say) means every
+		// quota-blocked run stays parked forever with nothing to bring it
+		// back — and no other signal would say so. The local store not
+		// implementing it is expected and stays silent.
+		s.warnf("retry sweeper NOT started: the store does not implement ListRunsDueForRetry — " +
+			"runs parked on a provider quota window will never resume on their own")
 	}
 	// Cloud scheduler: fire due cron-scheduled bots. Multi-replica-safe via the
 	// store CAS (no leader election). Absent in local mode (ScheduledBots nil).


### PR DESCRIPTION
Two independent fixes, both found while chasing CI red on this branch.

## 1. `pkg/runview` — a paused run was advertised resumable before it was

When a run pauses on a human gate, the engine writes `paused_waiting_human`
to the **store**, returns `ErrRunPaused`, and only then does the goroutine
call `Deregister` on its way out. Between those two moments the public
signal says "resumable" while the handle is still held — and both the studio
and the board sidebar offer Resume on exactly that signal. A resume landing
in that window failed on `run "..." is already registered`.

`Register` / `RegisterDetached` now wait, bounded (`registerHandoffGrace =
5s`, injectable), for the previous runner's `done` to close. The wait is
**outside** the mutex, because `Deregister` needs the same lock to close
`done`. The guard against two simultaneous runners is intact: a runner that
never leaves still yields the same error.

This was showing up as a CI flake
(`TestServiceLaunch_SubbotChildHumanGate_ParkAndResume`). It was not a
flake — it was this race, and the test was right.

3 tests, proven in both directions.

## 2. `cmd/iterion` — the group guard was too narrow

`TestRejectUnknownSubcommands_CoversEveryGroup` has been **red on main**
since `02d84c0f1` (`models pricing`) turned `iterion models` from a leaf
command into a group. Not caused by this branch; it blocks its CI.

The test held every group to one shape — `Args` rejecting any argument —
while `iterion models [provider/model-id]` legitimately takes a positional
and validates it itself. The command was never broken: `iterion models
<typo>` exits **2** with `invalid spec ... (expected "provider/model-id")`.
The regression the guard exists for is a group answering a typo with help
and **exit 0**, which cannot happen to a Runnable command. So the guard was
too narrow about how a group may satisfy it.

`rejectUnknownSubcommands` now stamps each group it hardens, and the test
holds each group to the contract it actually has:

- help-only group (stamped by the sweep) → must be Runnable and reject any
  argument;
- group that also does something itself → must be Runnable with its own
  non-nil `Args`, so cobra executes it and its own validation answers;
- nothing may sit outside both with `Args` nil.

The pin surfaced two hybrids beyond `models` — `server` and `supervise`,
both Runnable with `cobra.NoArgs`. All three verified rejecting a typo
non-zero (2, 1, 1) and printing help when bare. A vacuity check fails if
the sweep stops hardening the tree, and a new hybrid appearing unnoticed is
now a diff rather than coverage quietly shrinking.

## Verification

- `devbox run -- task check` green.
- Both guard tests falsified: neutering the sweep turns them red across the
  whole tree, restoring it turns them green.
- No OpenAPI drift (`task openapi:gen` leaves the tree clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)