### PR TITLE
fix(dep-update-guard): publish to the endpoint the server injected, not under it

### DIFF
--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -907,7 +907,10 @@ tool post_feedback:
     # The server's publish endpoint is the ONLY path that can post a status:
     # the run's own forge_token is minted without the statuses permission.
     if s(pub_url) and s(pub_token):
-        endpoint = s(pub_url).rstrip("/") + "/api/v1/forge/publish-review"
+        # The server injects the FULL endpoint URL, not a base — use it
+        # verbatim. Appending a path produces a URL that misses the
+        # auth-exempt route and is answered by the global auth middleware.
+        endpoint = s(pub_url)
         payload = {"pr_url": s(pr_url), "summary": body, "mode": "summary", "comments": []}
         if gate_on:
             payload["gate"] = {"enabled": True, "context": s(gate_context) or "vetty/deps",

--- a/bots/dep_update_guard_gate_test.go
+++ b/bots/dep_update_guard_gate_test.go
@@ -48,6 +48,14 @@ func TestDepUpdateGuardGateVerdict(t *testing.T) {
 		var got published
 		var seen bool
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// The server registers exactly ONE path, and it is the only one
+			// exempt from the auth middleware. A stub answering any path let a
+			// bot post to a URL that production rejects with 401.
+			if r.URL.Path != "/api/v1/forge/publish-review" {
+				t.Errorf("published to %q, want the endpoint path — anything else hits the auth middleware", r.URL.Path)
+				w.WriteHeader(404)
+				return
+			}
 			seen = true
 			if tok := r.Header.Get("X-Iterion-Run"); tok != "run-token" {
 				t.Errorf("publish must authenticate with the run grant, got %q", tok)
@@ -78,7 +86,7 @@ func TestDepUpdateGuardGateVerdict(t *testing.T) {
 			"{{input.escalation}}":         `""`,
 			"{{input.commit_summary}}":     `""`,
 			"{{secrets.forge_token.path}}": `""`,
-			"{{vars.forge_publish_url}}":   `"` + srv.URL + `"`,
+			"{{vars.forge_publish_url}}":   `"` + srv.URL + `/api/v1/forge/publish-review"`,
 			"{{vars.forge_publish_token}}": `"run-token"`,
 			"{{vars.gate_enabled}}":        boolLit(gateEnabled),
 			"{{vars.gate_context}}":        `"` + gateContext + `"`,


### PR DESCRIPTION
Caught on Vetty's first live run against a real Renovate PR.

`forge_publish_url` is the FULL endpoint URL, not a base — Revi uses it
verbatim. Vetty appended the path to it, so it POSTed to
`…/api/v1/forge/publish-review/api/v1/forge/publish-review`. That is not the
auth-exempt route, so the global auth middleware answered 401 and no commit
status was ever posted.

The test could not have caught it: the httptest stub answered on ANY path, so
a URL production rejects passed CI. Same shape as the invalid-GraphQL defect
that shipped green on the previous PR — a double that accepts more than the
real peer measures only that the code ran. The stub now answers exactly the
one path the server registers, and the test was checked against the defect
(it reproduces the doubled path observed in production).

Worth recording: the rest of the chain behaved exactly as designed on that
run. The verdict comment landed, `feedback_health` raised the missing-gate
banner, and `arm_automerge` refused with *"the merge gate did not land — not
arming on a verdict the PR cannot show"*. Fail-closed held on the first real
run; only the gate itself was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)