### PR TITLE
fix(pluginsource): publish a plugin checkout atomically, one clone per key

### DIFF
--- a/pkg/pluginsource/fetch.go
+++ b/pkg/pluginsource/fetch.go
@@ -37,7 +37,7 @@ type Fetcher struct {
 	CredentialFor func(ctx context.Context, s PluginSource) (string, error)
 
 	mu       sync.Mutex
-	keyLocks map[string]*sync.Mutex
+	keyGates map[string]chan struct{}
 }
 
 // Fetch returns a local path containing the source's repository at its ref.
@@ -53,7 +53,10 @@ func (f *Fetcher) Fetch(ctx context.Context, s PluginSource) (string, error) {
 	key := cacheKey(s)
 	dest := filepath.Join(f.CacheDir, key)
 
-	unlock := f.lockKey(key)
+	unlock, err := f.lockKey(ctx, key)
+	if err != nil {
+		return "", fmt.Errorf("pluginsource: waiting on a concurrent fetch of %q: %w", s.Name, err)
+	}
 	defer unlock()
 
 	// A pinned ref makes the checkout immutable, so an existing tree is
@@ -101,17 +104,27 @@ func (f *Fetcher) Fetch(ctx context.Context, s PluginSource) (string, error) {
 // publish moves a finished checkout onto its cache path. A moving ref replaces
 // an older tree, so the previous one is renamed aside first and deleted after
 // the swap — never before, so a failed rename leaves the old tree serving.
+//
+// The in-process gate does not cover a second process sharing the cache dir, so
+// a publisher that loses the race finds the path already holding an equivalent
+// checkout and keeps it rather than failing the launch.
 func publish(staging, dest string) error {
 	retired := ""
 	if _, err := os.Stat(dest); err == nil {
 		retired = dest + ".retired-" + filepath.Base(staging)
 		if err := os.Rename(dest, retired); err != nil {
-			return err
+			if !os.IsNotExist(err) {
+				return err
+			}
+			retired = "" // someone else retired it first
 		}
 	}
 	if err := os.Rename(staging, dest); err != nil {
 		if retired != "" {
 			_ = os.Rename(retired, dest)
+		}
+		if _, statErr := os.Stat(filepath.Join(dest, ".git")); statErr == nil {
+			return nil
 		}
 		return err
 	}
@@ -123,19 +136,27 @@ func publish(staging, dest string) error {
 
 // lockKey serialises fetches of the same (url, ref) within this process, so N
 // concurrent launches on a cold pod cost one clone instead of N racing ones.
-func (f *Fetcher) lockKey(key string) func() {
+//
+// Waiting honours ctx. Each attempt is bounded by FetchTimeout, so against a
+// hung remote a queue of waiters would otherwise burn that timeout one after
+// another, unable to give up even once the launch that wanted them is gone.
+func (f *Fetcher) lockKey(ctx context.Context, key string) (func(), error) {
 	f.mu.Lock()
-	if f.keyLocks == nil {
-		f.keyLocks = map[string]*sync.Mutex{}
+	if f.keyGates == nil {
+		f.keyGates = map[string]chan struct{}{}
 	}
-	l, ok := f.keyLocks[key]
+	gate, ok := f.keyGates[key]
 	if !ok {
-		l = &sync.Mutex{}
-		f.keyLocks[key] = l
+		gate = make(chan struct{}, 1)
+		f.keyGates[key] = gate
 	}
 	f.mu.Unlock()
-	l.Lock()
-	return l.Unlock
+	select {
+	case gate <- struct{}{}:
+		return func() { <-gate }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 // git runs one git command. The credential is injected via an askpass helper

--- a/pkg/pluginsource/fetch.go
+++ b/pkg/pluginsource/fetch.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -34,20 +35,33 @@ type Fetcher struct {
 	// secret VALUE, which the fetcher passes to git without logging it.
 	// Nil (or a nil return) means "public repository".
 	CredentialFor func(ctx context.Context, s PluginSource) (string, error)
+
+	mu       sync.Mutex
+	keyLocks map[string]*sync.Mutex
 }
 
 // Fetch returns a local path containing the source's repository at its ref.
+//
+// The checkout is built in a temporary sibling and moved into place with a
+// single rename, so `dest` only ever exists fully populated. Building in place
+// would publish the directory at `git init` time — a concurrent launch would
+// then be handed a tree with a .git and nothing else.
 func (f *Fetcher) Fetch(ctx context.Context, s PluginSource) (string, error) {
 	if f.CacheDir == "" {
 		return "", fmt.Errorf("pluginsource: fetcher has no cache dir")
 	}
-	dest := filepath.Join(f.CacheDir, cacheKey(s))
+	key := cacheKey(s)
+	dest := filepath.Join(f.CacheDir, key)
+
+	unlock := f.lockKey(key)
+	defer unlock()
+
 	// A pinned ref makes the checkout immutable, so an existing tree is
 	// authoritative and we skip the network entirely.
 	if _, err := os.Stat(filepath.Join(dest, ".git")); err == nil && s.PinnedRef() {
 		return dest, nil
 	}
-	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
+	if err := os.MkdirAll(f.CacheDir, 0o700); err != nil {
 		return "", err
 	}
 
@@ -60,35 +74,68 @@ func (f *Fetcher) Fetch(ctx context.Context, s PluginSource) (string, error) {
 		cred = c
 	}
 
-	if _, err := os.Stat(filepath.Join(dest, ".git")); err == nil {
-		// Moving ref: refresh in place.
-		if err := f.git(ctx, dest, cred, "fetch", "--depth", "1", "origin", s.Ref); err != nil {
-			return "", err
-		}
-		if err := f.git(ctx, dest, cred, "checkout", "--force", "FETCH_HEAD"); err != nil {
-			return "", err
-		}
-		return dest, nil
+	staging, err := os.MkdirTemp(f.CacheDir, "."+key+".staging-")
+	if err != nil {
+		return "", err
 	}
+	defer os.RemoveAll(staging) // no-op once the rename has moved it away
 
-	if err := os.MkdirAll(dest, 0o700); err != nil {
+	if err := f.git(ctx, staging, cred, "init", "--quiet"); err != nil {
 		return "", err
 	}
-	if err := f.git(ctx, dest, cred, "init", "--quiet"); err != nil {
+	if err := f.git(ctx, staging, cred, "remote", "add", "origin", s.GitURL); err != nil {
 		return "", err
 	}
-	if err := f.git(ctx, dest, cred, "remote", "add", "origin", s.GitURL); err != nil {
+	if err := f.git(ctx, staging, cred, "fetch", "--depth", "1", "origin", s.Ref); err != nil {
 		return "", err
 	}
-	if err := f.git(ctx, dest, cred, "fetch", "--depth", "1", "origin", s.Ref); err != nil {
-		_ = os.RemoveAll(dest) // don't leave a half-initialised cache entry behind
+	if err := f.git(ctx, staging, cred, "checkout", "--force", "FETCH_HEAD"); err != nil {
 		return "", err
 	}
-	if err := f.git(ctx, dest, cred, "checkout", "--force", "FETCH_HEAD"); err != nil {
-		_ = os.RemoveAll(dest)
-		return "", err
+	if err := publish(staging, dest); err != nil {
+		return "", fmt.Errorf("pluginsource: publish checkout for %q: %w", s.Name, err)
 	}
 	return dest, nil
+}
+
+// publish moves a finished checkout onto its cache path. A moving ref replaces
+// an older tree, so the previous one is renamed aside first and deleted after
+// the swap — never before, so a failed rename leaves the old tree serving.
+func publish(staging, dest string) error {
+	retired := ""
+	if _, err := os.Stat(dest); err == nil {
+		retired = dest + ".retired-" + filepath.Base(staging)
+		if err := os.Rename(dest, retired); err != nil {
+			return err
+		}
+	}
+	if err := os.Rename(staging, dest); err != nil {
+		if retired != "" {
+			_ = os.Rename(retired, dest)
+		}
+		return err
+	}
+	if retired != "" {
+		_ = os.RemoveAll(retired)
+	}
+	return nil
+}
+
+// lockKey serialises fetches of the same (url, ref) within this process, so N
+// concurrent launches on a cold pod cost one clone instead of N racing ones.
+func (f *Fetcher) lockKey(key string) func() {
+	f.mu.Lock()
+	if f.keyLocks == nil {
+		f.keyLocks = map[string]*sync.Mutex{}
+	}
+	l, ok := f.keyLocks[key]
+	if !ok {
+		l = &sync.Mutex{}
+		f.keyLocks[key] = l
+	}
+	f.mu.Unlock()
+	l.Lock()
+	return l.Unlock
 }
 
 // git runs one git command. The credential is injected via an askpass helper

--- a/pkg/pluginsource/pluginsource_test.go
+++ b/pkg/pluginsource/pluginsource_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -192,6 +193,127 @@ func TestFetcher_FetchesAndCachesPinnedRef(t *testing.T) {
 	if again != path {
 		t.Errorf("cache path changed: %q vs %q", again, path)
 	}
+}
+
+// A cold pod takes several launches at once, and every one of them fetches the
+// same source. Each must be handed a COMPLETE tree: publishing the directory
+// before the checkout lands (what `git init` in place does) hands the losers a
+// bare .git, and the plugin loader then reports the tree as having no
+// plugin.yaml — a launch-blocking 502 whose message names the wrong cause.
+func TestFetcher_ConcurrentFetchesAllSeeCompleteTree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	origin := gitOrigin(t, "v1.0.0")
+
+	f := &Fetcher{CacheDir: t.TempDir()}
+	s := validSource()
+	s.GitURL, s.Ref = origin, "v1.0.0"
+
+	const n = 12
+	paths := make([]string, n)
+	errs := make([]error, n)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			paths[i], errs[i] = f.Fetch(context.Background(), s)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for i := range n {
+		if errs[i] != nil {
+			t.Fatalf("fetch %d: %v", i, errs[i])
+		}
+		body, err := os.ReadFile(filepath.Join(paths[i], "skills", "deploy-target.md"))
+		if err != nil || string(body) != "playbook\n" {
+			t.Fatalf("fetch %d was handed an incomplete checkout at %q: %v %q", i, paths[i], err, body)
+		}
+	}
+
+	// No staging or retired leftovers: the cache holds exactly the checkout.
+	entries, err := os.ReadDir(f.CacheDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("cache dir should hold only the checkout, got %v", names)
+	}
+}
+
+// A moving ref re-fetches, and the new tree must replace the old one wholesale
+// rather than being assembled in place under a concurrent reader's feet.
+func TestFetcher_MovingRefSwapsInTheNewTree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	origin := gitOrigin(t, "")
+
+	f := &Fetcher{CacheDir: t.TempDir()}
+	s := validSource()
+	s.GitURL, s.Ref = origin, "main"
+
+	first, err := f.Fetch(context.Background(), s)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(origin, "skills", "deploy-target.md"), []byte("revised\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, origin, "add", "-A")
+	gitRun(t, origin, "commit", "-m", "revise")
+
+	second, err := f.Fetch(context.Background(), s)
+	if err != nil {
+		t.Fatalf("refetch: %v", err)
+	}
+	if second != first {
+		t.Errorf("cache path changed across a moving-ref refresh: %q vs %q", second, first)
+	}
+	body, err := os.ReadFile(filepath.Join(second, "skills", "deploy-target.md"))
+	if err != nil || string(body) != "revised\n" {
+		t.Fatalf("moving ref did not pick up the new commit: %v %q", err, body)
+	}
+}
+
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+}
+
+// gitOrigin builds a one-commit plugin repo, tagged when tag is non-empty.
+func gitOrigin(t *testing.T, tag string) string {
+	t.Helper()
+	origin := t.TempDir()
+	gitRun(t, origin, "init", "--quiet", "-b", "main")
+	if err := os.MkdirAll(filepath.Join(origin, "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(origin, "skills", "deploy-target.md"), []byte("playbook\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, origin, "add", "-A")
+	gitRun(t, origin, "commit", "-m", "init")
+	if tag != "" {
+		gitRun(t, origin, "tag", tag)
+	}
+	return origin
 }
 
 func TestFetcher_MissingRefFailsLoudly(t *testing.T) {

--- a/pkg/pluginsource/pluginsource_test.go
+++ b/pkg/pluginsource/pluginsource_test.go
@@ -250,6 +250,80 @@ func TestFetcher_ConcurrentFetchesAllSeeCompleteTree(t *testing.T) {
 	}
 }
 
+// The in-process gate cannot help across processes, and the cache dir is
+// shared (/tmp/iterion-plugin-sources): separate Fetchers over one dir are the
+// case where only the staging+rename publish protects the reader. Building in
+// place instead makes the racers collide inside the same .git.
+func TestFetcher_SeparateFetchersSharingACacheDirNeverSeeAPartialTree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	origin := gitOrigin(t, "v1.0.0")
+	cache := t.TempDir()
+	s := validSource()
+	s.GitURL, s.Ref = origin, "v1.0.0"
+
+	const n = 8
+	paths := make([]string, n)
+	errs := make([]error, n)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			f := &Fetcher{CacheDir: cache} // a distinct fetcher: no shared gate
+			<-start
+			paths[i], errs[i] = f.Fetch(context.Background(), s)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for i := range n {
+		if errs[i] != nil {
+			t.Fatalf("fetch %d: %v", i, errs[i])
+		}
+		body, err := os.ReadFile(filepath.Join(paths[i], "skills", "deploy-target.md"))
+		if err != nil || string(body) != "playbook\n" {
+			t.Fatalf("fetch %d was handed an incomplete checkout at %q: %v %q", i, paths[i], err, body)
+		}
+	}
+}
+
+// A waiter must be able to give up. Each attempt is bounded by FetchTimeout, so
+// a queue of waiters on a hung remote burns it once per waiter — and the launch
+// that wanted the plugin may be long gone.
+func TestFetcher_WaiterHonoursCancellation(t *testing.T) {
+	f := &Fetcher{CacheDir: t.TempDir()}
+	release, err := f.lockKey(context.Background(), "some-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// Waited for rather than called inline: the regression is a block, not a
+	// wrong return, and a test that hangs says much less than one that fails.
+	waited := make(chan error, 1)
+	go func() {
+		release, err := f.lockKey(ctx, "some-key")
+		if release != nil {
+			release()
+		}
+		waited <- err
+	}()
+	select {
+	case err := <-waited:
+		if err == nil {
+			t.Fatal("a cancelled waiter took the gate instead of giving up")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("a cancelled waiter queued behind the in-flight fetch instead of giving up")
+	}
+}
+
 // A moving ref re-fetches, and the new tree must replace the old one wholesale
 // rather than being assembled in place under a concurrent reader's feet.
 func TestFetcher_MovingRefSwapsInTheNewTree(t *testing.T) {


### PR DESCRIPTION
## The failure

A launch on a freshly rolled server pod returned:

```
502 {"error":"launch failed: pluginsource: load \"deploy-k8s-msociaux\":
 plugin: \"/tmp/iterion-plugin-sources/deploy-k8s-msociaux-f983185d32fc1e50\"
 has no plugin.yaml and no skills/ or top-level *.md to install as a skill library"}
```

The repository at that pinned tag **does** have `plugin.yaml` and `skills/`. The message names the wrong cause.

`Fetch` built the checkout in place, and `git init` creates `.git` before the fetch and checkout land. The early return treated the presence of `.git` as "this tree is complete", so a concurrent launch was handed a directory holding nothing but `.git`. Five launches hit the same cold pod within 4 seconds; two pods ended up with a valid tree, one served the empty one. The run row was already written when the launch died, so the run sat `queued` forever — no error surfaced on it.

Same shape as a crashed fetch: `.git` present, content absent, and with a pinned ref that entry is authoritative forever.

## The fix

- The checkout is built in a staging sibling and moved into place with a single `rename`, so the cache path only ever exists fully populated. A moving ref renames the old tree aside first and deletes it only after the swap, so a failed rename leaves the previous tree serving rather than nothing.
- Fetches of the same `(url, ref)` serialise on a per-key lock: N concurrent launches cost one clone instead of N racing ones.

## Tests

`TestFetcher_ConcurrentFetchesAllSeeCompleteTree` runs 12 concurrent fetches and asserts every returned path holds the actual file, plus that no staging or retired leftovers remain. Verified by reintroducing the in-place build — the test fails; with the fix it passes under `-race`.

`TestFetcher_MovingRefSwapsInTheNewTree` covers the branch case the rewrite touches: same cache path, new content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)