### PR TITLE
fix(dep-update-guard): merge the PR the forge already reports as green

### DIFF
--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -113,13 +113,17 @@ vars:
   ## AUTO-MERGE ARMING (opt-in, OFF by default so the catalog behaviour is
   ## unchanged). When true AND the verdict is green AND the gate landed green,
   ## Vetty asks the forge to merge the PR *once its own required checks pass*.
-  ## It never merges: the only call made is enablePullRequestAutoMerge, which
-  ## hands the decision to the repo's required checks. The immediate-merge REST
-  ## endpoint is deliberately never used — that would bypass CI, which is the
-  ## opposite of the guarantee this bot exists to provide.
+  ## It never merges PAST a check. While checks are pending it only arms
+  ## auto-merge, handing the decision to the repo's required checks. Once the
+  ## forge itself reports the PR clean — the state where it refuses to arm at
+  ## all — Vetty merges the audited commit, and only that one. The
+  ## immediate-merge REST endpoint is deliberately never used: it merges
+  ## whatever the state, which is the opposite of the guarantee this bot exists
+  ## to provide.
   ##
   ## For this to mean anything the repo MUST require at least one check on the
-  ## target branch; with none, a forge merges an armed PR straight away.
+  ## target branch; with none, "clean" says nothing and a forge merges an armed
+  ## PR straight away.
   arm_automerge: bool = false
 
   ## Merge method asked for when arming. Must be one the repo allows.
@@ -509,6 +513,10 @@ schema feedback_output:
   ## gate_skipped_reason: why no status landed. A gate that is required and
   ## absent blocks the PR forever, so the reason has to be visible.
   gate_skipped_reason: string
+  ## gate_sha: the head the status was posted on — the ONE commit this run
+  ## audited. Anything downstream that merges compares against it, because
+  ## the branch can move while the audit runs.
+  gate_sha: string
 
 schema feedback_health_input:
   posted: bool
@@ -528,13 +536,18 @@ schema automerge_input:
   verdict: string
   gate_posted: bool
   gate_state: string
+  ## gate_sha: the head the gate landed on. A merge may only ever target this
+  ## commit — reading the head again returns whatever the branch holds NOW.
+  gate_sha: string
 
 schema automerge_output:
-  ## armed: the forge accepted the auto-merge request (it merges when its own
-  ## required checks pass — Vetty never merges anything itself).
+  ## armed: the PR is on its way in — either the forge accepted the auto-merge
+  ## request (it merges when its own required checks pass), or it reported the
+  ## PR already clean and the audited commit was merged.
   armed: bool
-  ## reason: why it was not armed. Always populated when armed is false, so a
-  ## PR sitting un-merged is never a mystery.
+  ## reason: why it was not armed, or which of the two paths ran. Always
+  ## populated when armed is false, so a PR sitting un-merged is never a
+  ## mystery.
   reason: string
 
 ## ─── Nodes ──────────────────────────────────────────────────────
@@ -842,12 +855,13 @@ tool post_feedback:
         return (x or "").strip() if isinstance(x, str) else ("" if x is None else str(x).strip())
 
     def out(posted, comment_url="", skipped_reason="", summary="",
-            gate_posted=False, gate_state="", gate_skipped_reason=""):
+            gate_posted=False, gate_state="", gate_skipped_reason="", gate_sha=""):
         print(json.dumps({"verdict": s(verdict),
                           "posted": bool(posted), "comment_url": comment_url or "",
                           "skipped_reason": skipped_reason or "", "summary": summary or "",
                           "gate_posted": bool(gate_posted), "gate_state": gate_state or "",
-                          "gate_skipped_reason": gate_skipped_reason or ""}))
+                          "gate_skipped_reason": gate_skipped_reason or "",
+                          "gate_sha": gate_sha or ""}))
         raise SystemExit(0)
 
     if not s(pr_url):
@@ -880,7 +894,8 @@ tool post_feedback:
            "needs_decision": "Escalated for a human decision.",
            "clean": "Nothing to align."}.get(s(verdict), "")
     did = (s(commit_summary) + " " if s(commit_summary) else "") + did + \
-        " **Vetty never merges** — it reports a verdict; the merge stays with the repo's own required checks."
+        " **Vetty never merges past a check** — whether this lands is the repo's own required checks' decision, " \
+        "and only the exact commit reported above can be merged."
     section("What Vetty did", did)
     parts.append("_\U0001F916 Posted by Vetty (dep-update-guard) — deterministic feedback._")
     body = "\n".join(parts)
@@ -948,7 +963,8 @@ tool post_feedback:
                 summary="verdict=" + s(verdict) + "; published via the iterion forge-publish endpoint",
                 gate_posted=bool(res.get("gate_posted")),
                 gate_state=str(res.get("gate_state") or ""),
-                gate_skipped_reason=str(res.get("gate_error") or ""))
+                gate_skipped_reason=str(res.get("gate_error") or ""),
+                gate_sha=str(res.get("gate_sha") or ""))
         except urllib.error.HTTPError as e:
             detail = ""
             try: detail = e.read().decode("utf-8")[:300]
@@ -1065,6 +1081,7 @@ tool arm_automerge:
     verdict = {{input.verdict}}
     gate_posted = {{input.gate_posted}}
     gate_state = {{input.gate_state}}
+    gate_sha = {{input.gate_sha}}
     gate_on = {{vars.gate_enabled}}
     token_ref = {{secrets.forge_token.path}}
 
@@ -1113,7 +1130,12 @@ tool arm_automerge:
         with urllib.request.urlopen(req, timeout=30) as resp:
             payload = json.loads(resp.read().decode("utf-8"))
         if payload.get("errors"):
-            raise RuntimeError(str(payload["errors"])[:300])
+            # Messages first, then the raw structure: a caller distinguishes
+            # "nothing left to wait for" from a real failure by reading the
+            # message, and truncating the whole structure can cut it off.
+            errs = payload["errors"]
+            msgs = "; ".join(str(e.get("message", "")) for e in errs if isinstance(e, dict))
+            raise RuntimeError((msgs or "") + " | " + str(errs)[:300])
         return payload.get("data") or {}
 
     # The variable sigil is written as @ and swapped at runtime: a doubled
@@ -1141,9 +1163,23 @@ tool arm_automerge:
         data = graphql(q, {"owner": owner, "name": repo, "number": num})
         return ((data.get("repository") or {}).get("pullRequest") or {})
 
+    # A merge may only ever target the commit THIS run audited and gated.
+    # Re-reading the head does not give that commit: the audit takes minutes,
+    # and a rebase or force-push in between produces a head no auditor has
+    # seen. Nor does the forge hold such a head back — a commit status only
+    # blocks a merge once a maintainer has made its context required — so CLEAN
+    # is perfectly reachable on unreviewed code.
     def merge_now(pr, why):
+        head = s(pr.get("headRefOid"))
+        gated = s(gate_sha)
+        if not gated:
+            out(False, "no gated sha to merge against - merging the current head would "
+                       "ship a commit this run never audited")
+        if head and head != gated:
+            out(False, "the branch moved after the audit (gated " + gated[:12] +
+                       ", head is now " + head[:12] + ") - the new head has not been audited")
         graphql(merge_mut, {"id": pr.get("id"), "method": s(method).upper() or "SQUASH",
-                            "oid": pr.get("headRefOid")})
+                            "oid": gated})
         out(True, why)
 
     # Ready to merge means every required check the forge knows about is
@@ -1284,6 +1320,7 @@ workflow dep_update_guard:
     pr_url: "{{vars.pr_url}}",
     verdict: "{{outputs.post_feedback.verdict}}",
     gate_posted: "{{outputs.post_feedback.gate_posted}}",
-    gate_state: "{{outputs.post_feedback.gate_state}}"
+    gate_state: "{{outputs.post_feedback.gate_state}}",
+    gate_sha: "{{outputs.post_feedback.gate_sha}}"
   }
   arm_automerge -> done

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -31,7 +31,8 @@
 ##                             question, pauses for a real architectural
 ##                             decision.
 ##
-## Vetty NEVER merges — the merge stays a human call. The deterministic
+## Vetty NEVER merges past a check, and only ever the commit it audited
+## (opt-in `arm_automerge`; off by default). The deterministic
 ## gates (audit_gate / validate_gate) are the truth oracles: code is
 ## committed ONLY when the audit verdict is `safe` AND the deterministic
 ## verify gate is green (v2 — the v1 `validate` agent's self-reported
@@ -408,6 +409,9 @@ schema prepare_output:
   ## degraded: the diff is not the true base..HEAD bump (base unreachable).
   degraded: bool
   degraded_reason: string
+  ## head_sha: the commit this run read. The audit, the alignment and the
+  ## verdict are all statements ABOUT this commit and no other.
+  head_sha: string
 
 schema audit_input:
   bump_summary: string
@@ -513,9 +517,10 @@ schema feedback_output:
   ## gate_skipped_reason: why no status landed. A gate that is required and
   ## absent blocks the PR forever, so the reason has to be visible.
   gate_skipped_reason: string
-  ## gate_sha: the head the status was posted on — the ONE commit this run
-  ## audited. Anything downstream that merges compares against it, because
-  ## the branch can move while the audit runs.
+  ## gate_sha: the head the status was posted on, as the FORGE reported it at
+  ## publish time. Not by itself proof of what was audited — a push landing in
+  ## between would carry the status onto a foreign commit — so a merge must
+  ## also check it against the sha this run read or pushed.
   gate_sha: string
 
 schema feedback_health_input:
@@ -539,6 +544,12 @@ schema automerge_input:
   ## gate_sha: the head the gate landed on. A merge may only ever target this
   ## commit — reading the head again returns whatever the branch holds NOW.
   gate_sha: string
+  ## audited_sha / committed_sha: the commit this run actually read, and the
+  ## one it pushed if it aligned anything. gate_sha comes from the FORGE (the
+  ## head at publish time), so it is only trustworthy where it agrees with
+  ## what this run produced.
+  audited_sha: string
+  committed_sha: string
 
 schema automerge_output:
   ## armed: the PR is on its way in — either the forge accepted the auto-merge
@@ -637,10 +648,15 @@ if scope:
     d = diff(scope)
     summary = d[:18000] + ('\n…(truncated)…' if len(d) > 18000 else '')
 non = [f for f in files if f not in dep]
+# The commit the audit is about to run against. Carried downstream so a merge
+# can prove it targets what was audited, rather than whatever the branch holds
+# by the time anyone looks again.
+head_sha = git(['rev-parse', 'HEAD'])[1].strip()
 print(json.dumps({'is_empty': len(files)==0 and not degraded, 'dep_files': dep,
                   'changed_files': len(files), 'bump_summary': summary,
                   'has_non_dep_changes': len(non)>0, 'no_manifest': no_manifest,
-                  'degraded': bool(degraded), 'degraded_reason': degraded}))
+                  'degraded': bool(degraded), 'degraded_reason': degraded,
+                  'head_sha': head_sha}))
 "`
   output: prepare_output
 
@@ -1082,6 +1098,8 @@ tool arm_automerge:
     gate_posted = {{input.gate_posted}}
     gate_state = {{input.gate_state}}
     gate_sha = {{input.gate_sha}}
+    audited_sha = {{input.audited_sha}}
+    committed_sha = {{input.committed_sha}}
     gate_on = {{vars.gate_enabled}}
     token_ref = {{secrets.forge_token.path}}
 
@@ -1172,9 +1190,21 @@ tool arm_automerge:
     def merge_now(pr, why):
         head = s(pr.get("headRefOid"))
         gated = s(gate_sha)
+        # What THIS run read, and what it pushed if it aligned anything.
+        mine = s(committed_sha) or s(audited_sha)
         if not gated:
             out(False, "no gated sha to merge against - merging the current head would "
                        "ship a commit this run never audited")
+        if not mine:
+            out(False, "this run cannot name the commit it audited - refusing to merge "
+                       "on a sha it cannot vouch for")
+        # gate_sha comes from the FORGE (the head at publish time), not from
+        # this run: a push landing between the alignment and the status read
+        # would carry the gate onto a commit no auditor ever saw. It is only
+        # trustworthy where it agrees with what this run produced.
+        if gated != mine:
+            out(False, "the gate landed on " + gated[:12] + " but this run audited " +
+                       mine[:12] + " - something else pushed while the audit was running")
         if head and head != gated:
             out(False, "the branch moved after the audit (gated " + gated[:12] +
                        ", head is now " + head[:12] + ") - the new head has not been audited")
@@ -1321,6 +1351,8 @@ workflow dep_update_guard:
     verdict: "{{outputs.post_feedback.verdict}}",
     gate_posted: "{{outputs.post_feedback.gate_posted}}",
     gate_state: "{{outputs.post_feedback.gate_state}}",
-    gate_sha: "{{outputs.post_feedback.gate_sha}}"
+    gate_sha: "{{outputs.post_feedback.gate_sha}}",
+    audited_sha: "{{outputs.prepare.head_sha}}",
+    committed_sha: "{{outputs.commit.sha}}"
   }
   arm_automerge -> done

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -896,7 +896,12 @@ tool post_feedback:
     blocking = GATE_BLOCKING.get(s(verdict))
     if blocking is None:
         blocking = 1
+    # The status description a reviewer reads on the PR. Written per verdict
+    # because the generic "no blocking findings (≥threshold)" phrasing assumes
+    # a severity floor, and this gate turns on the audit verdict instead.
     gate_note = {
+        "clean": "supply-chain audit clean; no code alignment needed",
+        "committed": "supply-chain audit clean; alignment committed, build verified",
         "hold_security": "supply-chain risk: the bump was not applied",
         "hold_unstable": "build/tests not green after alignment",
         "needs_decision": "an architectural decision is pending a human",
@@ -1033,9 +1038,20 @@ print(json.dumps({'degraded': degraded or gate_degraded, 'banner': banner}))
 ## have landed green too, because arming on a verdict whose status never
 ## reached the PR would merge on a check nobody can see.
 ##
-## The ONLY forge call is enablePullRequestAutoMerge. There is deliberately
-## no path to PUT /pulls/{n}/merge: that merges immediately, bypassing every
-## pending check, which is precisely what this bot exists to prevent.
+## Two forge calls, and the choice between them is the forge's own answer,
+## never a judgement of this bot:
+##   - checks still pending  → enablePullRequestAutoMerge, which hands the
+##     decision to the repo's required checks;
+##   - forge reports CLEAN   → mergePullRequest pinned to the exact head we
+##     reviewed. CLEAN means "mergeable and passing commit status", so there
+##     is nothing left to wait for — and GitHub REFUSES to arm auto-merge in
+##     that state ("Pull request is in clean status"). Since the audit takes
+##     longer than CI, this is the ordinary case: without it the bot would
+##     arm nothing and merge nothing, ever.
+## There is deliberately no path to PUT /pulls/{n}/merge: that merges
+## whatever the state, bypassing every pending check, which is precisely what
+## this bot exists to prevent. expectedHeadOid is the equivalent guarantee on
+## the GraphQL side — a push landing mid-decision aborts the merge.
 tool arm_automerge:
   input: automerge_input
   output: automerge_output
@@ -1090,6 +1106,9 @@ tool arm_automerge:
             data=json.dumps({"query": query, "variables": variables}).encode("utf-8"),
             method="POST",
             headers={"Authorization": "Bearer " + token, "Content-Type": "application/json",
+                     # mergeStateStatus is behind this media type; without it the
+                     # field is rejected and the whole query fails.
+                     "Accept": "application/vnd.github.merge-info-preview+json",
                      "User-Agent": "vetty-dep-update-guard"})
         with urllib.request.urlopen(req, timeout=30) as resp:
             payload = json.loads(resp.read().decode("utf-8"))
@@ -1106,20 +1125,54 @@ tool arm_automerge:
     at = chr(36)
     q = ("query(@owner: String!, @name: String!, @number: Int!) { "
          "repository(owner: @owner, name: @name) { "
-         "pullRequest(number: @number) { id autoMergeRequest { enabledAt } } "
+         "pullRequest(number: @number) { id headRefOid mergeable mergeStateStatus "
+         "autoMergeRequest { enabledAt } } "
          "} }").replace("@", at)
-    mut = ("mutation(@id: ID!, @method: PullRequestMergeMethod!) { "
-           "enablePullRequestAutoMerge(input: { pullRequestId: @id, mergeMethod: @method }) "
-           "{ clientMutationId } }").replace("@", at)
-    try:
+    arm_mut = ("mutation(@id: ID!, @method: PullRequestMergeMethod!) { "
+               "enablePullRequestAutoMerge(input: { pullRequestId: @id, mergeMethod: @method }) "
+               "{ clientMutationId } }").replace("@", at)
+    # expectedHeadOid is the safety pin: the forge merges this exact commit or
+    # nothing, so a push racing the decision can never be merged unreviewed.
+    merge_mut = ("mutation(@id: ID!, @method: PullRequestMergeMethod!, @oid: GitObjectID!) { "
+                 "mergePullRequest(input: { pullRequestId: @id, mergeMethod: @method, "
+                 "expectedHeadOid: @oid }) { clientMutationId } }").replace("@", at)
+
+    def read_pr():
         data = graphql(q, {"owner": owner, "name": repo, "number": num})
-        pr = ((data.get("repository") or {}).get("pullRequest") or {})
+        return ((data.get("repository") or {}).get("pullRequest") or {})
+
+    def merge_now(pr, why):
+        graphql(merge_mut, {"id": pr.get("id"), "method": s(method).upper() or "SQUASH",
+                            "oid": pr.get("headRefOid")})
+        out(True, why)
+
+    # Ready to merge means every required check the forge knows about is
+    # already satisfied — the state auto-merge exists to wait for.
+    def ready(pr):
+        return s(pr.get("mergeStateStatus")).upper() == "CLEAN" and \
+               s(pr.get("mergeable")).upper() == "MERGEABLE"
+
+    try:
+        pr = read_pr()
         node_id = pr.get("id")
         if not node_id:
             out(False, "pull request not found via the forge API")
         if pr.get("autoMergeRequest"):
             out(True, "auto-merge was already armed")
-        graphql(mut, {"id": node_id, "method": s(method).upper() or "SQUASH"})
+        if ready(pr):
+            merge_now(pr, "merged: the forge reported every required check already green")
+        try:
+            graphql(arm_mut, {"id": node_id, "method": s(method).upper() or "SQUASH"})
+        except Exception as arm_err:
+            # The forge refuses to arm a PR with nothing left to wait for. The
+            # state can flip between the read above and this call, so re-read
+            # rather than trusting the first answer.
+            if "clean status" not in str(arm_err).lower():
+                raise
+            pr = read_pr()
+            if not ready(pr):
+                out(False, "auto-merge request refused: " + str(arm_err))
+            merge_now(pr, "merged: the forge reported every required check already green")
         out(True, "")
     except urllib.error.HTTPError as e:
         detail = ""

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -357,9 +357,13 @@ prompt commit_system:
        code / re-query the remote ref).
     5. Never force-push. Never push to the base branch. Never merge.
 
-  Emit `commit_output`: committed, pushed, sha (empty if nothing
-  committed), message, summary (incl. the push result — branch + whether
-  the remote accepted it).
+  Emit `commit_output`: committed, pushed, sha, message, summary (incl.
+  the push result — branch + whether the remote accepted it).
+
+  `sha` is the FULL 40-hex commit id — read it with
+  `git rev-parse HEAD`, never the abbreviated form `git commit` prints.
+  Downstream it is matched against the sha the forge reports to decide
+  whether the merge may proceed. Empty if nothing was committed.
 
 prompt commit_user:
   Commit + push the alignment in {{vars.workspace_dir}} onto the PR
@@ -1187,6 +1191,23 @@ tool arm_automerge:
     # seen. Nor does the forge hold such a head back — a commit status only
     # blocks a merge once a maintainer has made its context required — so CLEAN
     # is perfectly reachable on unreviewed code.
+    # The shas being compared come from three sources with different widths:
+    # the forge always returns full 40-hex, `git rev-parse HEAD` does too, but
+    # committed_sha is reported by the commit AGENT, and the natural thing to
+    # read off `git commit` is the abbreviated form it prints. An exact compare
+    # therefore refused the merge on the align-and-commit path — Vetty's
+    # primary path — with a message ("something else pushed") that was simply
+    # false. Compare on the common prefix, with git's own 7-hex floor so a
+    # truncation that short cannot make two different commits look equal.
+    def same_commit(a, b):
+        a, b = s(a).lower(), s(b).lower()
+        if not a or not b:
+            return False
+        n = min(len(a), len(b))
+        if n < 7:
+            return False
+        return a[:n] == b[:n]
+
     def merge_now(pr, why):
         head = s(pr.get("headRefOid"))
         gated = s(gate_sha)
@@ -1202,10 +1223,10 @@ tool arm_automerge:
         # this run: a push landing between the alignment and the status read
         # would carry the gate onto a commit no auditor ever saw. It is only
         # trustworthy where it agrees with what this run produced.
-        if gated != mine:
+        if not same_commit(gated, mine):
             out(False, "the gate landed on " + gated[:12] + " but this run audited " +
                        mine[:12] + " - something else pushed while the audit was running")
-        if head and head != gated:
+        if head and not same_commit(head, gated):
             out(False, "the branch moved after the audit (gated " + gated[:12] +
                        ", head is now " + head[:12] + ") - the new head has not been audited")
         graphql(merge_mut, {"id": pr.get("id"), "method": s(method).upper() or "SQUASH",

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,7 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.3.0
+version: 2.4.0
 ## 2.1.0 — classify, gate, arm. (a) The bump classifier only knew package
 ## manifests, so a PR moving a base-image digest, a devbox pin, a task-runner
 ## tool or a composite action matched nothing — and did not stop, because

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,7 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.1.0
+version: 2.2.0
 ## 2.1.0 — classify, gate, arm. (a) The bump classifier only knew package
 ## manifests, so a PR moving a base-image digest, a devbox pin, a task-runner
 ## tool or a composite action matched nothing — and did not stop, because

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,7 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.2.0
+version: 2.3.0
 ## 2.1.0 — classify, gate, arm. (a) The bump classifier only knew package
 ## manifests, so a PR moving a base-image digest, a devbox pin, a task-runner
 ## tool or a composite action matched nothing — and did not stop, because
@@ -18,8 +18,11 @@ version: 2.2.0
 ## anything unexpected. `gate_context` is a var so several bots fill ONE
 ## required check, each for the PRs it owns. (c) `arm_automerge` (opt-in,
 ## default off): on a green verdict WITH a landed green gate, ask the forge
-## to merge once ITS OWN required checks pass. Vetty still never merges —
-## the immediate-merge endpoint is deliberately unreachable. (d) Skills gain
+## to merge once ITS OWN required checks pass, or — when the forge already
+## reports the PR clean, the state where it refuses to arm — merge the exact
+## audited commit. Vetty never merges PAST a check: the immediate-merge
+## endpoint is deliberately unreachable and the merge is pinned to the sha
+## the gate landed on. (d) Skills gain
 ## the dependencies that are not packages (container digests, Nix pins, Helm
 ## charts, pinned Actions) and the bundle ships a devbox project for crane,
 ## since the sandbox image has no registry client.
@@ -47,7 +50,8 @@ description: |
   commit); (4) commits the alignment back onto the PR branch and posts
   a complete review comment with the verdict and evidence; and (5)
   escalates to a human when a structuring architectural decision is
-  required. It never merges — the merge stays a human call.
+  required. It never merges past a check: unless auto-merge arming is
+  explicitly enabled, the merge stays a human call.
 
   Stack-agnostic by construction: the per-ecosystem scanner and
   build/test knowledge lives in the skills (package-managers,

--- a/bots/dep_update_guard_automerge_test.go
+++ b/bots/dep_update_guard_automerge_test.go
@@ -14,10 +14,11 @@ import (
 // TestDepUpdateGuardArmAutomerge pins the one node in the fleet that can end
 // with code merged into a default branch. Two properties carry all the weight:
 //
-//   - it NEVER merges. The only forge call it may make is
-//     enablePullRequestAutoMerge, which hands the decision to the repo's own
-//     required checks. A direct merge call would bypass CI — the opposite of
-//     what this bot exists to guarantee.
+//   - it never merges past a check. Which of the two forge calls it makes is
+//     the forge's own answer: auto-merge while checks are pending, a merge
+//     pinned to the reviewed head only once the forge itself reports CLEAN
+//     (mergeable and passing commit status), which is the state where it
+//     refuses to arm auto-merge at all.
 //   - it is fail-closed everywhere: off by default, green verdict required,
 //     the gate must actually have landed green, GitHub only, and every refusal
 //     carries a reason so an un-merged PR is never a mystery.
@@ -27,16 +28,20 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 	}
 	script := toolScript(t, "dep-update-guard/main.bot", "arm_automerge")
 
-	// The source must not even contain a way to merge outright: the guarantee
-	// should be readable, not merely untested. Asserted on each forbidden
-	// marker on its own — a conjunction with "does it also mention the
-	// auto-merge mutation" is always false, since that mutation is the node's
-	// only forge call, and would let the single most dangerous regression
-	// this bot can have sail through.
-	for _, forbidden := range []string{"mergePullRequest", `/merge"`, "/merge'", "/merge%s", "/merge?"} {
+	// The REST merge endpoint merges whatever the state; it must not appear at
+	// all. Asserted on each marker on its own — a conjunction with "does it
+	// also mention the auto-merge mutation" is always false, and would let the
+	// single most dangerous regression this bot can have sail through.
+	for _, forbidden := range []string{`/merge"`, "/merge'", "/merge%s", "/merge?"} {
 		if strings.Contains(script, forbidden) {
 			t.Fatalf("arm_automerge must not reference a direct merge endpoint (%q)", forbidden)
 		}
+	}
+	// The GraphQL merge is allowed only in its pinned form: without
+	// expectedHeadOid it would merge whatever the branch holds by the time the
+	// call lands, which is the same unreviewed-code hazard by another route.
+	if strings.Contains(script, "mergePullRequest") && !strings.Contains(script, "expectedHeadOid") {
+		t.Fatal("mergePullRequest must always be pinned with expectedHeadOid")
 	}
 
 	type call struct {
@@ -44,10 +49,35 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 		vars  map[string]any
 	}
 
-	run := func(t *testing.T, subs map[string]string) (map[string]any, []call, []string) {
+	// The forge's own words when a PR has nothing left to wait for.
+	const cleanRefusal = "Pull request Pull request is in clean status"
+
+	// blocked is the state where checks are still running: auto-merge is
+	// exactly what it is for.
+	blocked := map[string]any{
+		"id": "PR_node_1", "headRefOid": "d34db33f", "autoMergeRequest": nil,
+		"mergeable": "MERGEABLE", "mergeStateStatus": "BLOCKED",
+	}
+	withState := func(over map[string]any) map[string]any {
+		pr := map[string]any{}
+		for k, v := range blocked {
+			pr[k] = v
+		}
+		for k, v := range over {
+			pr[k] = v
+		}
+		return pr
+	}
+
+	// runWith drives the node against a stub forge holding `pr`. A non-empty
+	// armErr makes the auto-merge mutation fail with that message, and `after`
+	// (when set) is the state served on any read that follows — the flip a
+	// finishing check produces mid-decision.
+	runWith := func(t *testing.T, subs map[string]string, pr map[string]any, armErr string, after map[string]any) (map[string]any, []call, []string) {
 		t.Helper()
 		var calls []call
 		var paths []string
+		state := pr
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			paths = append(paths, r.Method+" "+r.URL.Path)
 			raw, _ := io.ReadAll(r.Body)
@@ -66,17 +96,41 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 				w.WriteHeader(400)
 				return
 			}
-			if strings.Contains(body.Query, "enablePullRequestAutoMerge") {
+			// mergeStateStatus is preview-gated: the real API rejects the query
+			// without the media type, so a stub that ignores it would certify a
+			// request production refuses.
+			if strings.Contains(body.Query, "mergeStateStatus") &&
+				!strings.Contains(r.Header.Get("Accept"), "merge-info-preview") {
+				t.Errorf("mergeStateStatus queried without the merge-info-preview Accept header")
+				w.WriteHeader(400)
+				return
+			}
+			switch {
+			case strings.Contains(body.Query, "enablePullRequestAutoMerge"):
+				if armErr != "" {
+					if after != nil {
+						state = after
+					}
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"errors": []map[string]any{{"type": "UNPROCESSABLE", "message": armErr}},
+					})
+					return
+				}
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{"enablePullRequestAutoMerge": map[string]any{"clientMutationId": nil}},
 				})
-				return
+			case strings.Contains(body.Query, "mergePullRequest"):
+				if body.Variables["oid"] != state["headRefOid"] {
+					t.Errorf("merge pinned to %v, want the reviewed head %v", body.Variables["oid"], state["headRefOid"])
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"data": map[string]any{"mergePullRequest": map[string]any{"clientMutationId": nil}},
+				})
+			default:
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"data": map[string]any{"repository": map[string]any{"pullRequest": state}},
+				})
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"data": map[string]any{"repository": map[string]any{
-					"pullRequest": map[string]any{"id": "PR_node_1", "autoMergeRequest": nil},
-				}},
-			})
 		}))
 		defer srv.Close()
 
@@ -121,8 +175,21 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 		}
 		return res, calls, paths
 	}
+	run := func(t *testing.T, subs map[string]string) (map[string]any, []call, []string) {
+		t.Helper()
+		return runWith(t, subs, blocked, "", nil)
+	}
 
-	t.Run("green verdict + green gate arms via the auto-merge mutation", func(t *testing.T) {
+	queried := func(calls []call, needle string) bool {
+		for _, c := range calls {
+			if strings.Contains(c.query, needle) {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("checks still pending: arms auto-merge and merges nothing", func(t *testing.T) {
 		res, calls, _ := run(t, nil)
 		if res["armed"] != true {
 			t.Fatalf("want armed, got %v", res)
@@ -135,13 +202,64 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 					t.Errorf("merge method = %v, want SQUASH", c.vars["method"])
 				}
 			}
-			// The whole guarantee: nothing may merge the PR outright.
+			// The whole guarantee: with a check still pending, nothing merges.
 			if strings.Contains(c.query, "mergePullRequest") {
-				t.Fatal("arm_automerge must never call mergePullRequest — that bypasses the checks")
+				t.Fatal("merged a PR whose checks had not landed — that bypasses CI")
 			}
 		}
 		if !armed {
 			t.Fatal("no enablePullRequestAutoMerge call was made")
+		}
+	})
+
+	// The ordinary case: the audit outlives CI, so by the time the bot decides,
+	// the forge has nothing left to wait for and refuses to arm auto-merge. A
+	// bot that only ever armed would merge nothing, ever.
+	t.Run("forge reports CLEAN: merges pinned to the reviewed head", func(t *testing.T) {
+		res, calls, _ := runWith(t, nil, withState(map[string]any{"mergeStateStatus": "CLEAN"}), "", nil)
+		if res["armed"] != true {
+			t.Fatalf("want merged, got %v", res)
+		}
+		if !queried(calls, "mergePullRequest") {
+			t.Fatal("a PR the forge reports CLEAN must be merged, not left open forever")
+		}
+		if queried(calls, "enablePullRequestAutoMerge") {
+			t.Error("armed auto-merge on a CLEAN PR — the forge rejects that outright")
+		}
+	})
+
+	t.Run("arming refused as clean: re-reads, then merges", func(t *testing.T) {
+		// The state can flip between the read and the arm call; the refusal is
+		// the forge telling us so.
+		res, calls, _ := runWith(t, nil, blocked, cleanRefusal, withState(map[string]any{"mergeStateStatus": "CLEAN"}))
+		if res["armed"] != true {
+			t.Fatalf("want merged after the refusal, got %v", res)
+		}
+		if !queried(calls, "mergePullRequest") {
+			t.Fatal("refusal-to-arm left the PR unmerged")
+		}
+	})
+
+	t.Run("CLEAN but conflicting: merges nothing", func(t *testing.T) {
+		res, calls, _ := runWith(t, nil, withState(map[string]any{
+			"mergeStateStatus": "CLEAN", "mergeable": "CONFLICTING"}), cleanRefusal, nil)
+		if queried(calls, "mergePullRequest") {
+			t.Fatal("merged a conflicting PR")
+		}
+		if res["armed"] != false {
+			t.Errorf("want a refusal with a reason, got %v", res)
+		}
+	})
+
+	t.Run("blocked and arming refused for another reason: reports it", func(t *testing.T) {
+		// Only "clean status" means "nothing left to wait for". Any other
+		// refusal must surface, never be retried into a merge.
+		res, calls, _ := runWith(t, nil, blocked, "Base branch was modified. Review and try the merge again.", nil)
+		if queried(calls, "mergePullRequest") {
+			t.Fatal("merged a BLOCKED PR after a failed arm")
+		}
+		if res["armed"] != false {
+			t.Fatalf("want a refusal, got %v", res)
 		}
 	})
 

--- a/bots/dep_update_guard_automerge_test.go
+++ b/bots/dep_update_guard_automerge_test.go
@@ -305,6 +305,43 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 		}
 	})
 
+	// The commit agent reports whatever `git commit` printed, which is the
+	// ABBREVIATED sha. An exact compare refused the merge here — on the
+	// align-and-commit path, with a message ("something else pushed") that was
+	// simply false. Every other case in this file uses same-width literals, so
+	// equality held by construction and the class went uncovered.
+	t.Run("aligned bump: an abbreviated committed sha still merges", func(t *testing.T) {
+		const full = "a11gned0c0ffee0c0ffee0c0ffee0c0ffee0c0ff"
+		res, calls, _ := runWith(t, map[string]string{
+			"{{input.gate_sha}}":      `"` + full + `"`,
+			"{{input.audited_sha}}":   `"d34db33f"`,
+			"{{input.committed_sha}}": `"a11gned0"`,
+		}, withState(map[string]any{"mergeStateStatus": "CLEAN", "headRefOid": full}), "", nil)
+		if !queried(calls, "mergePullRequest") {
+			t.Fatalf("refused the merge on an abbreviated sha: %v", res)
+		}
+		if res["armed"] != true {
+			t.Fatalf("want armed, got %v", res)
+		}
+	})
+
+	// A prefix shorter than git's own floor must NOT be treated as a match:
+	// two different commits can share six hex digits.
+	t.Run("a too-short sha is refused, not guessed", func(t *testing.T) {
+		const full = "a11gne0c0ffee0c0ffee0c0ffee0c0ffee0c0fff"
+		res, calls, _ := runWith(t, map[string]string{
+			"{{input.gate_sha}}":      `"` + full + `"`,
+			"{{input.audited_sha}}":   `"d34db33f"`,
+			"{{input.committed_sha}}": `"a11gne"`,
+		}, withState(map[string]any{"mergeStateStatus": "CLEAN", "headRefOid": full}), "", nil)
+		if queried(calls, "mergePullRequest") {
+			t.Fatalf("merged on a 6-hex prefix: %v", res)
+		}
+		if res["armed"] != false {
+			t.Fatalf("want a refusal, got %v", res)
+		}
+	})
+
 	// When the bot pushed an alignment, THAT is the commit it vouches for.
 	t.Run("aligned bump: merges the commit it pushed", func(t *testing.T) {
 		res, calls, _ := runWith(t, map[string]string{

--- a/bots/dep_update_guard_automerge_test.go
+++ b/bots/dep_update_guard_automerge_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -37,12 +38,11 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 			t.Fatalf("arm_automerge must not reference a direct merge endpoint (%q)", forbidden)
 		}
 	}
-	// The GraphQL merge is allowed only in its pinned form: without
-	// expectedHeadOid it would merge whatever the branch holds by the time the
-	// call lands, which is the same unreviewed-code hazard by another route.
-	if strings.Contains(script, "mergePullRequest") && !strings.Contains(script, "expectedHeadOid") {
-		t.Fatal("mergePullRequest must always be pinned with expectedHeadOid")
-	}
+	// The GraphQL merge is allowed only in its pinned form. Asserting that on
+	// the SOURCE is worthless: the word expectedHeadOid also appears in a
+	// comment, so deleting it from the mutation keeps a source-level check
+	// green. The real assertion is on the query that goes over the wire, in
+	// the stub below.
 
 	type call struct {
 		query string
@@ -120,6 +120,17 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 					"data": map[string]any{"enablePullRequestAutoMerge": map[string]any{"clientMutationId": nil}},
 				})
 			case strings.Contains(body.Query, "mergePullRequest"):
+				// The mutation ITSELF must carry the pin. Sending oid in the
+				// variables proves nothing — merge_now populates it whether or
+				// not the query references it, so an unpinned merge (the single
+				// most dangerous regression this node can have) would sail
+				// through a variables-only check.
+				if !strings.Contains(body.Query, "expectedHeadOid") {
+					t.Errorf("merge mutation is not pinned to a head: %s", body.Query)
+				}
+				if !regexp.MustCompile(`expectedHeadOid:\s*\$oid`).MatchString(body.Query) {
+					t.Errorf("expectedHeadOid is not bound to the oid variable: %s", body.Query)
+				}
 				if body.Variables["oid"] != state["headRefOid"] {
 					t.Errorf("merge pinned to %v, want the reviewed head %v", body.Variables["oid"], state["headRefOid"])
 				}
@@ -142,6 +153,8 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 			"{{input.gate_posted}}":        "True",
 			"{{input.gate_state}}":         `"success"`,
 			"{{input.gate_sha}}":           `"d34db33f"`,
+			"{{input.audited_sha}}":        `"d34db33f"`,
+			"{{input.committed_sha}}":      `""`,
 			"{{vars.gate_enabled}}":        "True",
 			"{{secrets.forge_token.path}}": `"ghs_test"`,
 		}
@@ -269,6 +282,41 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 		}
 		if reason, _ := res["reason"].(string); !strings.Contains(reason, "moved after the audit") {
 			t.Errorf("reason = %q, want it to name the moved branch", reason)
+		}
+	})
+
+	// gate_sha is the head the FORGE reported when the server posted the
+	// status, not something this run vouched for. A push landing between the
+	// alignment and that read carries the gate onto a commit no auditor saw —
+	// and then head == gate_sha holds, so every other guard is satisfied.
+	t.Run("gate landed on a foreign commit: merges nothing", func(t *testing.T) {
+		res, calls, _ := runWith(t, map[string]string{
+			"{{input.gate_sha}}":    `"f0re1gn5"`,
+			"{{input.audited_sha}}": `"d34db33f"`,
+		}, withState(map[string]any{"mergeStateStatus": "CLEAN", "headRefOid": "f0re1gn5"}), "", nil)
+		if queried(calls, "mergePullRequest") {
+			t.Fatal("merged a commit the gate covered but this run never audited")
+		}
+		if res["armed"] != false {
+			t.Fatalf("want a refusal, got %v", res)
+		}
+		if reason, _ := res["reason"].(string); !strings.Contains(reason, "this run audited") {
+			t.Errorf("reason = %q, want it to name the disagreement", reason)
+		}
+	})
+
+	// When the bot pushed an alignment, THAT is the commit it vouches for.
+	t.Run("aligned bump: merges the commit it pushed", func(t *testing.T) {
+		res, calls, _ := runWith(t, map[string]string{
+			"{{input.gate_sha}}":      `"a11gned0"`,
+			"{{input.audited_sha}}":   `"d34db33f"`,
+			"{{input.committed_sha}}": `"a11gned0"`,
+		}, withState(map[string]any{"mergeStateStatus": "CLEAN", "headRefOid": "a11gned0"}), "", nil)
+		if !queried(calls, "mergePullRequest") {
+			t.Fatal("the commit Vetty pushed and gated must be mergeable")
+		}
+		if res["armed"] != true {
+			t.Fatalf("want merged, got %v", res)
 		}
 	})
 

--- a/bots/dep_update_guard_automerge_test.go
+++ b/bots/dep_update_guard_automerge_test.go
@@ -141,6 +141,7 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 			"{{input.verdict}}":            `"committed"`,
 			"{{input.gate_posted}}":        "True",
 			"{{input.gate_state}}":         `"success"`,
+			"{{input.gate_sha}}":           `"d34db33f"`,
 			"{{vars.gate_enabled}}":        "True",
 			"{{secrets.forge_token.path}}": `"ghs_test"`,
 		}
@@ -248,6 +249,39 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 		}
 		if res["armed"] != false {
 			t.Errorf("want a refusal with a reason, got %v", res)
+		}
+	})
+
+	// The audit takes minutes. A rebase or force-push in that window produces a
+	// head no auditor has seen, and the forge does NOT hold it back: a commit
+	// status blocks a merge only once a maintainer has made its context
+	// required, so the gate's absence on the new head still reads as CLEAN.
+	// Merging what the head says at merge time would ship exactly the
+	// unreviewed dependency commit this bot exists to catch.
+	t.Run("branch moved after the gate: merges nothing", func(t *testing.T) {
+		res, calls, _ := runWith(t, nil, withState(map[string]any{
+			"mergeStateStatus": "CLEAN", "headRefOid": "0ther5ha"}), "", nil)
+		if queried(calls, "mergePullRequest") {
+			t.Fatal("merged a head that was never audited")
+		}
+		if res["armed"] != false {
+			t.Fatalf("want a refusal, got %v", res)
+		}
+		if reason, _ := res["reason"].(string); !strings.Contains(reason, "moved after the audit") {
+			t.Errorf("reason = %q, want it to name the moved branch", reason)
+		}
+	})
+
+	t.Run("no gated sha: merges nothing", func(t *testing.T) {
+		// Without a gate there is no anchor for "the commit we audited", so the
+		// merge path has nothing safe to target.
+		res, calls, _ := runWith(t, map[string]string{"{{input.gate_sha}}": `""`},
+			withState(map[string]any{"mergeStateStatus": "CLEAN"}), "", nil)
+		if queried(calls, "mergePullRequest") {
+			t.Fatal("merged with no audited sha to pin to")
+		}
+		if res["armed"] != false {
+			t.Fatalf("want a refusal, got %v", res)
 		}
 	})
 

--- a/bots/issue-triage/skills/iterion-bot-catalog.md
+++ b/bots/issue-triage/skills/iterion-bot-catalog.md
@@ -265,7 +265,8 @@ breaking change (a JS/TS lib API, Helm chart values, a Go module,
 commit); (4) commits the alignment back onto the PR branch and posts
 a complete review comment with the verdict and evidence; and (5)
 escalates to a human when a structuring architectural decision is
-required. It never merges — the merge stays a human call.
+required. It never merges past a check: unless auto-merge arming is
+explicitly enabled, the merge stays a human call.
 
 Stack-agnostic by construction: the per-ecosystem scanner and
 build/test knowledge lives in the skills (package-managers,

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -434,7 +434,8 @@ breaking change (a JS/TS lib API, Helm chart values, a Go module,
 commit); (4) commits the alignment back onto the PR branch and posts
 a complete review comment with the verdict and evidence; and (5)
 escalates to a human when a structuring architectural decision is
-required. It never merges — the merge stays a human call.
+required. It never merges past a check: unless auto-merge arming is
+explicitly enabled, the merge stays a human call.
 
 Stack-agnostic by construction: the per-ecosystem scanner and
 build/test knowledge lives in the skills (package-managers,

--- a/docs/bot-runs/dep-update-guard.md
+++ b/docs/bot-runs/dep-update-guard.md
@@ -6,6 +6,90 @@ consuming code, prove the tree with the deterministic verify gate,
 commit onto the PR branch, post the verdict comment. Never merges. See
 [bots/dep-update-guard/](../../bots/dep-update-guard/).
 
+## 2026-07-29 — v2.1.0 live: the whole chain ran, the gate landed, and the merge never happened (run 019faad2)
+
+- Status: **partial** — every step validated end to end except the last one,
+  which turned out to be structurally impossible as designed.
+- Versions: bot 2.1.0 → 2.2.0 · iterion `9d5efc6c` (runner image `:edge`
+  `sha256:c499ba03`)
+- Method: `/vetty` on
+  [socialgouv/buildkit-operator#5](https://github.com/SocialGouv/buildkit-operator/pull/5)
+  (a `golang:1.26` digest bump), cloud run on `ovh-prod`, sandbox
+  `iterion-sandbox-sec:edge`, `gate_context: iterion/review`,
+  `arm_automerge: true`.
+- Result: finished in **14 min**, 15 nodes, no human intervention. `prepare` →
+  `security_audit` → `align` → `align_gate` → `verify_build` (5 min) →
+  `verify_run` **exit 0** → `validate_gate` → `commit` → `post_feedback` →
+  `feedback_health` → `arm_automerge` → `done`.
+- Value: **the merge gate landed for the first time** —
+  `iterion/review=success` on the head SHA, posted through the server's
+  publish endpoint. That link had never worked before (see the 401 below).
+
+### The gate: a redirect was degrading the POST
+
+`post_feedback` had been failing with `401 authentication required` on a route
+that is deliberately auth-exempt. Everything else had been eliminated with
+evidence — the route answers a bogus token differently, the URL and token were
+correct in the run inputs, the same request reached the handler by hand from
+both a laptop and a runner pod, Revi's own gate still worked. The remaining
+hypothesis was that `urllib` follows redirects, and a redirected POST becomes a
+GET, which misses a method-specific Go route and falls through to the auth
+middleware.
+
+Refusing the redirect fixed it. The value of the fix is not only that it works:
+it **names the URL it called and the one the server redirected to**, so the
+next occurrence needs no investigation.
+
+Lesson: an unexplained `401` on an auth-exempt route is worth suspecting the
+*shape* of the request before its credentials.
+
+### `arm_automerge` armed nothing, and could never have
+
+```
+armed: false
+reason: auto-merge request refused: [{'type': 'UNPROCESSABLE',
+  'message': 'Pull request Pull request is in clean status'}]
+```
+
+`enablePullRequestAutoMerge` only accepts a PR that still has something to wait
+for. The audit takes ~14 min and CI ~3 min, so **by the time the bot decides,
+the PR is always already green** — the arm always fails. The feature was not
+merely buggy on this PR; as shipped it would have merged nothing, ever, on any
+repo whose CI is faster than the audit. Which is every repo.
+
+v2.2.0 merges through `mergePullRequest` pinned with `expectedHeadOid` when the
+forge itself reports the PR `CLEAN` and `MERGEABLE`. The invariant is
+unchanged — the bot never decides that checks passed, it only acts on the
+forge's own answer — but the guarantee is now "never merges past a check"
+rather than "never merges".
+
+Lesson: **a capability that only fires in a state your own latency prevents is
+dead code with a green test.** The unit test passed because it stubbed the arm
+call as succeeding; nothing modelled the state the real API is in when the bot
+actually calls it.
+
+### Other engine defects this run surfaced
+
+- **Plugin-source checkout race** (fixed): `git init` creates `.git` before the
+  fetch lands, and the fetcher treated `.git` as "tree complete". Five launches
+  hitting a freshly rolled pod at once left one of them with an empty
+  directory, and the loader reported it as *"has no plugin.yaml"* — a 502 that
+  names the wrong cause, and a run row left `queued` forever with no error on
+  it. The checkout is now staged and renamed into place.
+- The status description read `no blocking findings (≥verdict)` — the shared
+  phrasing assumes a severity floor, while this gate turns on the audit
+  verdict. Now written per verdict.
+
+### Lessons for next run
+
+- A green CI image build is **not** a deployment: iterion's CI separates the
+  build from the `finalize` job that re-tags `:edge`. Poll until the published
+  digest *changes*, then grep the fix inside the pod, and only then launch. I
+  lost a run to trusting a green workflow.
+- The dogfood cost stayed at ~$0.60 for a digest bump with a real
+  two-image trivy delta. The audit is not where the time goes — `verify_build`
+  is (5 min of the 14).
+
 ## 2026-07-28 — v2.1.0: the classifier was auditing empty diffs, and the gate could never work (no run; defects found by inspection + adversarial review)
 
 - Status: **partial** — code validated locally and by review; no live cloud run

--- a/docs/bot-runs/dep-update-guard.md
+++ b/docs/bot-runs/dep-update-guard.md
@@ -3,7 +3,8 @@
 Reactive security + alignment guard for automated dependency-update PRs
 (Dependabot / Renovate): audit the bump (supply-chain + CVE), align the
 consuming code, prove the tree with the deterministic verify gate,
-commit onto the PR branch, post the verdict comment. Never merges. See
+commit onto the PR branch, post the verdict comment. Never merges past a
+check — and only ever the commit it audited. See
 [bots/dep-update-guard/](../../bots/dep-update-guard/).
 
 ## 2026-07-29 — v2.1.0 live: the whole chain ran, the gate landed, and the merge never happened (run 019faad2)


### PR DESCRIPTION
## The failure, observed live

Run `019faad2` on [socialgouv/buildkit-operator#5](https://github.com/SocialGouv/buildkit-operator/pull/5) ran the whole chain — audit, alignment, `verify_run` exit 0, commit, gate `iterion/review=success` — and then armed nothing:

```
armed: false
reason: auto-merge request refused: [{'type': 'UNPROCESSABLE',
  'message': 'Pull request Pull request is in clean status'}]
```

`enablePullRequestAutoMerge` only accepts a PR that still has something to wait for. The audit takes ~14 min and CI ~3 min, so by the time Vetty decides, the PR is **always** already green — which means the arm always fails and, as shipped, the bot would merge nothing, ever. The PR sat open with every check passing.

## The change

When the forge itself reports the PR `CLEAN` **and** `MERGEABLE` — "mergeable and passing commit status", precisely the state auto-merge exists to wait for — the bot merges it via `mergePullRequest` pinned with `expectedHeadOid`, so a push racing the decision aborts the merge rather than shipping unreviewed code. The refusal is also handled after the fact (the state can flip between the read and the arm call), and **only** for `clean status`: any other refusal still surfaces verbatim instead of being retried into a merge.

`PUT /pulls/{n}/merge` remains absent — that one merges whatever the state.

The status description is now written per verdict too. The shared phrasing assumes a severity floor (`no blocking findings (≥high)`), while this gate turns on the audit verdict, so the live PR displayed the meaningless `(≥verdict)`.

## Tests

`TestDepUpdateGuardArmAutomerge` gains four cases, and the guarantee it pins is now "never merges past a check" rather than "never merges":

- checks pending → arms, merges nothing;
- forge reports CLEAN → merges, pinned to the reviewed head, and does *not* try to arm;
- arm refused as clean → re-reads, then merges;
- refused for any other reason, or CLEAN-but-conflicting → merges nothing, reports why.

The stub now rejects a `mergeStateStatus` query missing the `merge-info-preview` media type, which the real API requires. Verified by removing the merge path: the two merge cases fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)