### PR TITLE
fix(review-pr): the stale-anchor guard compared a template string to a sha

### DIFF
--- a/bots/catalog_command_refs_test.go
+++ b/bots/catalog_command_refs_test.go
@@ -1,9 +1,11 @@
 package bots
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
@@ -16,10 +18,11 @@ var outputsRef = regexp.MustCompile(`\{\{\s*!?\s*outputs\.[A-Za-z0-9_.]+\s*\}\}`
 // TestCatalogToolCommandsResolveTheirRefs pins a seam that fails SILENTLY.
 //
 // A tool node's `command:` is resolved by resolveCommandTemplate
-// (pkg/backend/model/executor_tool.go), which substitutes {{input.X}} and
-// {{vars.X}} — and nothing else. An {{outputs.<node>.<field>}} ref belongs on
-// an EDGE mapping, where it does resolve; written inside a command body it
-// survives as literal text, and the shell happily passes that text on.
+// (pkg/backend/model/executor_tool.go), which substitutes {{input.X}},
+// {{vars.X}}, {{secrets.X}} and {{run.id}} — and nothing else. An
+// {{outputs.<node>.<field>}} ref belongs on an EDGE mapping, where it does
+// resolve; written inside a command body it survives as literal text, and the
+// shell happily passes that text on.
 //
 // Nothing catches it: the bot parses, compiles, validates and runs. The
 // failure only appears in production, as a value that is a template string
@@ -32,12 +35,22 @@ var outputsRef = regexp.MustCompile(`\{\{\s*!?\s*outputs\.[A-Za-z0-9_.]+\s*\}\}`
 // required check, every PR on the repo became unmergeable with no error
 // anywhere. Found by reading a run log, not by any test.
 func TestCatalogToolCommandsResolveTheirRefs(t *testing.T) {
-	teamBots, _ := filepath.Glob("*/main.bot")
-	demoMain, _ := filepath.Glob("../examples/*/main.bot")
-	demoLoose, _ := filepath.Glob("../examples/*.bot")
-	targets := append(append(teamBots, demoMain...), demoLoose...)
+	// Every .bot, not just each bundle's main: a subbot source is precisely
+	// where an unresolvable ref hides from a main.bot-only sweep.
+	var targets []string
+	for _, root := range []string{".", "../examples"} {
+		if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".bot") {
+				return nil
+			}
+			targets = append(targets, path)
+			return nil
+		}); err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
 	if len(targets) == 0 {
-		t.Fatal("no catalog workflows found — discovery glob likely broke")
+		t.Fatal("no catalog workflows found — discovery likely broke")
 	}
 
 	checked := 0
@@ -49,10 +62,14 @@ func TestCatalogToolCommandsResolveTheirRefs(t *testing.T) {
 		}
 		pr := parser.Parse(path, string(src))
 		if pr.File == nil {
-			continue // the parse/compile test owns that failure
+			t.Logf("%s: not inspected (unparseable — the parse/compile test owns that)", path)
+			continue
 		}
 		cr := ir.Compile(pr.File)
 		if cr.Workflow == nil {
+			// Named, not silent: a bot that stops compiling would otherwise
+			// drop out of this lint without a trace.
+			t.Logf("%s: not inspected (does not compile to a workflow)", path)
 			continue
 		}
 		for _, n := range cr.Workflow.Nodes {
@@ -60,14 +77,18 @@ func TestCatalogToolCommandsResolveTheirRefs(t *testing.T) {
 			if !ok {
 				continue
 			}
-			for _, body := range []string{tool.Command, tool.Script} {
+			// Postcondition rides the same resolver (executor_verified_action.go),
+			// and it is ADR-044's truth oracle: a literal there mis-decides the
+			// whole recovery ladder.
+			for _, body := range []string{tool.Command, tool.Script, tool.Postcondition} {
 				if body == "" {
 					continue
 				}
 				checked++
 				if m := outputsRef.FindString(body); m != "" {
 					t.Errorf("%s: node %q passes %s inside its command/script body; "+
-						"only {{input.X}} and {{vars.X}} are substituted there, so this "+
+						"only {{input.X}}, {{vars.X}}, {{secrets.X}} and {{run.id}} are "+
+						"substituted there, so this "+
 						"reaches the shell as literal text. Map it on the edge into this "+
 						"node and read it as {{input.<field>}}.", path, tool.ID, m)
 				}

--- a/bots/catalog_command_refs_test.go
+++ b/bots/catalog_command_refs_test.go
@@ -1,0 +1,80 @@
+package bots
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+)
+
+// outputsRef matches an {{outputs.<node>.<field>}} reference.
+var outputsRef = regexp.MustCompile(`\{\{\s*!?\s*outputs\.[A-Za-z0-9_.]+\s*\}\}`)
+
+// TestCatalogToolCommandsResolveTheirRefs pins a seam that fails SILENTLY.
+//
+// A tool node's `command:` is resolved by resolveCommandTemplate
+// (pkg/backend/model/executor_tool.go), which substitutes {{input.X}} and
+// {{vars.X}} — and nothing else. An {{outputs.<node>.<field>}} ref belongs on
+// an EDGE mapping, where it does resolve; written inside a command body it
+// survives as literal text, and the shell happily passes that text on.
+//
+// Nothing catches it: the bot parses, compiles, validates and runs. The
+// failure only appears in production, as a value that is a template string
+// pretending to be data.
+//
+// It has already shipped once. bots/review-pr's stale-anchor guard compared
+// REVIEWED_SHA={{outputs.diff_precheck.reviewed_sha}} against the real HEAD;
+// the literal never equals a sha, so every review skipped publishing — and
+// since that publish carries the merge-gate status, and revi/review is a
+// required check, every PR on the repo became unmergeable with no error
+// anywhere. Found by reading a run log, not by any test.
+func TestCatalogToolCommandsResolveTheirRefs(t *testing.T) {
+	teamBots, _ := filepath.Glob("*/main.bot")
+	demoMain, _ := filepath.Glob("../examples/*/main.bot")
+	demoLoose, _ := filepath.Glob("../examples/*.bot")
+	targets := append(append(teamBots, demoMain...), demoLoose...)
+	if len(targets) == 0 {
+		t.Fatal("no catalog workflows found — discovery glob likely broke")
+	}
+
+	checked := 0
+	for _, path := range targets {
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("%s: read: %v", path, err)
+			continue
+		}
+		pr := parser.Parse(path, string(src))
+		if pr.File == nil {
+			continue // the parse/compile test owns that failure
+		}
+		cr := ir.Compile(pr.File)
+		if cr.Workflow == nil {
+			continue
+		}
+		for _, n := range cr.Workflow.Nodes {
+			tool, ok := n.(*ir.ToolNode)
+			if !ok {
+				continue
+			}
+			for _, body := range []string{tool.Command, tool.Script} {
+				if body == "" {
+					continue
+				}
+				checked++
+				if m := outputsRef.FindString(body); m != "" {
+					t.Errorf("%s: node %q passes %s inside its command/script body; "+
+						"only {{input.X}} and {{vars.X}} are substituted there, so this "+
+						"reaches the shell as literal text. Map it on the edge into this "+
+						"node and read it as {{input.<field>}}.", path, tool.ID, m)
+				}
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no tool bodies inspected — the IR shape likely changed")
+	}
+}

--- a/bots/review-pr/main.bot
+++ b/bots/review-pr/main.bot
@@ -609,6 +609,11 @@ schema pr_gate_output:
 
 schema publish_input:
   pr_url: string
+  ## reviewed_sha: the worktree HEAD the findings anchor to. Comes in on the
+  ## EDGE: a tool `command:` resolves only {{input.X}} and {{vars.X}}, so an
+  ## {{outputs.…}} ref written there stays literal text and every comparison
+  ## against it is meaningless.
+  reviewed_sha: string
   findings: json
   questions: string
   total_findings: int
@@ -780,7 +785,7 @@ compute pr_gate:
 ## published is true ONLY on a 2xx from the endpoint, whose counts are
 ## forge-re-fetched (anti-façade), never self-estimated.
 tool publish_review:
-  command: `WS={{vars.workspace_dir}} REVIEWED_SHA={{outputs.diff_precheck.reviewed_sha}} PUB_URL={{vars.forge_publish_url}} PUB_TOKEN={{vars.forge_publish_token}} MODE={{vars.pr_review_mode}} PR_URL={{input.pr_url}} FINDINGS={{input.findings}} QUESTIONS={{input.questions}} CLAUDE_FINDINGS={{input.claude_findings}} GPT_FINDINGS={{input.gpt_findings}} GATE_ENABLED={{vars.gate_enabled}} GATE_SEVERITY={{vars.gate_severity}} GATE_CONTEXT={{vars.gate_context}} python3 -c "
+  command: `WS={{vars.workspace_dir}} REVIEWED_SHA={{input.reviewed_sha}} PUB_URL={{vars.forge_publish_url}} PUB_TOKEN={{vars.forge_publish_token}} MODE={{vars.pr_review_mode}} PR_URL={{input.pr_url}} FINDINGS={{input.findings}} QUESTIONS={{input.questions}} CLAUDE_FINDINGS={{input.claude_findings}} GPT_FINDINGS={{input.gpt_findings}} GATE_ENABLED={{vars.gate_enabled}} GATE_SEVERITY={{vars.gate_severity}} GATE_CONTEXT={{vars.gate_context}} python3 -c "
 import os, json, subprocess, urllib.request, urllib.error
 
 def emit(published, forge='unknown', review_url='', posted=0, sugg=0, skipped='', summary=''):
@@ -798,11 +803,17 @@ findings_parse_failed = False
 # Stale-review guard (#1): the findings' file:line anchors were computed
 # against the tree at REVIEWED_SHA. If the worktree HEAD has since moved (a
 # resume after the branch advanced), those anchors no longer match — refuse to
-# post a misaligned review rather than land comments on the wrong lines. Only
-# fires when we can positively read both SHAs and they differ (fail-open).
+# post a misaligned review rather than land comments on the wrong lines.
+#
+# It only ever fires on two REAL shas that differ. Anything else — an empty
+# value, or an unresolved template that reached us as literal text — means the
+# guard cannot evaluate itself, and a guard that cannot evaluate itself must
+# not swallow the review: the publish carries the gate status, and a status
+# that never lands blocks the PR for good.
 reviewed = os.environ.get('REVIEWED_SHA', '').strip()
 ws = os.environ.get('WS', '').strip()
-if reviewed and ws:
+looks_like_sha = len(reviewed) >= 7 and all(c in '0123456789abcdefABCDEF' for c in reviewed)
+if reviewed and ws and looks_like_sha:
     try:
         cur = subprocess.run(['git', '-C', ws, 'rev-parse', 'HEAD'],
                              capture_output=True, text=True).stdout.strip()
@@ -1062,6 +1073,7 @@ workflow review_pr:
   pr_gate -> done when not has_pr
   pr_gate -> publish_review when has_pr with {
     pr_url: "{{outputs.pr_gate.pr_url}}",
+    reviewed_sha: "{{outputs.diff_precheck.reviewed_sha}}",
     findings: "{{outputs.pr_gate.findings}}",
     questions: "{{outputs.pr_gate.questions}}",
     total_findings: "{{outputs.pr_gate.total_findings}}",

--- a/bots/review-pr/main.bot
+++ b/bots/review-pr/main.bot
@@ -610,9 +610,9 @@ schema pr_gate_output:
 schema publish_input:
   pr_url: string
   ## reviewed_sha: the worktree HEAD the findings anchor to. Comes in on the
-  ## EDGE: a tool `command:` resolves only {{input.X}} and {{vars.X}}, so an
-  ## {{outputs.…}} ref written there stays literal text and every comparison
-  ## against it is meaningless.
+  ## EDGE: a tool `command:` resolves {{input.X}}, {{vars.X}}, {{secrets.X}}
+  ## and {{run.id}} — an {{outputs.…}} ref written there is NOT one of them and
+  ## stays literal text, so every comparison against it is meaningless.
   reviewed_sha: string
   findings: json
   questions: string
@@ -813,6 +813,7 @@ findings_parse_failed = False
 reviewed = os.environ.get('REVIEWED_SHA', '').strip()
 ws = os.environ.get('WS', '').strip()
 looks_like_sha = len(reviewed) >= 7 and all(c in '0123456789abcdefABCDEF' for c in reviewed)
+stale_anchors = ''
 if reviewed and ws and looks_like_sha:
     try:
         cur = subprocess.run(['git', '-C', ws, 'rev-parse', 'HEAD'],
@@ -820,8 +821,7 @@ if reviewed and ws and looks_like_sha:
     except Exception:
         cur = ''
     if cur and cur != reviewed:
-        emit(False, skipped='tree changed since review (' + reviewed[:12] + ' -> ' + cur[:12] + '); the findings anchor to the reviewed tree, not HEAD. Re-run with the same pr_url for a fresh review.',
-             summary='publish skipped: the worktree HEAD moved after the reviewers judged it, so the inline anchors are stale. No comments posted.')
+        stale_anchors = reviewed[:12] + ' -> ' + cur[:12]
 
 try:
     findings = json.loads(os.environ.get('FINDINGS') or '[]')
@@ -915,6 +915,18 @@ if questions:
 elif not findings:
     summary.append('')
     summary.append('Reviewers verified the change end-to-end and raised no open questions.')
+
+# Stale anchors cost the inline comments, never the publish. The POST below
+# is what carries the merge-gate status, and a required status that never
+# lands blocks the PR for good — a far worse outcome than a review whose
+# file:line markers point at the wrong lines. So the anchors are dropped and
+# the summary says why, rather than the whole review being swallowed.
+if stale_anchors:
+    comments = []
+    summary.append('')
+    summary.append(chr(9888) + ' The worktree HEAD moved after the reviewers judged it (' + stale_anchors +
+                   '), so the inline anchors would land on the wrong lines. The findings are summarised '
+                   'above instead. Push again or comment /revi for a review of the current head.')
 
 payload = {'pr_url': pr, 'summary': nl.join(summary), 'mode': mode, 'comments': comments}
 

--- a/bots/review-pr/manifest.yaml
+++ b/bots/review-pr/manifest.yaml
@@ -1,7 +1,7 @@
 name: review-pr
 display_name: Revi
 icon: 🔎
-version: 0.5.5
+version: 0.5.6
 ## 0.5.5 — never LOSE findings when the merge step degrades, and never LIE
 ## about why the gate is red. Observed live on PR #300 (run 019fa02b): converge
 ## returned `findings` as the prose "See structured findings array." while

--- a/bots/review-pr/manifest.yaml
+++ b/bots/review-pr/manifest.yaml
@@ -2,6 +2,15 @@ name: review-pr
 display_name: Revi
 icon: 🔎
 version: 0.5.6
+## 0.5.6 — a review must never leave its required check absent. The stale-anchor
+## guard added in 0.5.5 read REVIEWED_SHA from an {{outputs.…}} ref written
+## inside a tool `command:`, which the engine does not substitute there: the
+## literal reached the shell, never equalled a sha, and every review skipped
+## publishing — so the revi/review status stopped landing and no PR on the repo
+## could merge, with no error anywhere. The sha now arrives on the edge as
+## {{input.reviewed_sha}}. And when the guard legitimately fires, it costs the
+## inline anchors only: the publish still happens, carrying the gate, because a
+## required status that never lands blocks a PR for good.
 ## 0.5.5 — never LOSE findings when the merge step degrades, and never LIE
 ## about why the gate is red. Observed live on PR #300 (run 019fa02b): converge
 ## returned `findings` as the prose "See structured findings array." while

--- a/bots/review_pr_stale_anchor_test.go
+++ b/bots/review_pr_stale_anchor_test.go
@@ -1,0 +1,169 @@
+package bots
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestReviewPRStaleAnchorStillPublishes pins what a review owes the PR it is
+// gating.
+//
+// `publish_review` is the ONE call that carries the merge-gate status, and
+// `revi/review` is a required check. So a publish that does not happen is not
+// a degraded review — it is a pull request nobody can merge, with no error on
+// the run, the PR or the check. That has now happened twice: once because an
+// unresolvable {{outputs.…}} ref made the stale-anchor guard fire on every run
+// (the tree had not moved at all), and once by design, because the guard's
+// intended path returned before the POST.
+//
+// Stale anchors therefore cost the inline comments and nothing else. The two
+// halves are asserted separately: the guard must fire on two real, differing
+// shas, and it must NOT fire on anything it cannot read as a sha.
+func TestReviewPRStaleAnchorStillPublishes(t *testing.T) {
+	for _, bin := range []string{"python3", "git"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not on PATH", bin)
+		}
+	}
+
+	// A workspace whose HEAD is a known sha, plus its parent to play "the tree
+	// moved on since the reviewers judged it".
+	ws := t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = ws
+		cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	git("init", "--quiet", "-b", "main")
+	if err := os.WriteFile(ws+"/a.txt", []byte("one\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", "-A")
+	git("commit", "-m", "one")
+	parent := git("rev-parse", "HEAD")
+	if err := os.WriteFile(ws+"/a.txt", []byte("two\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", "-A")
+	git("commit", "-m", "two")
+	head := git("rev-parse", "HEAD")
+
+	type published struct {
+		Summary  string           `json:"summary"`
+		Comments []map[string]any `json:"comments"`
+		Gate     map[string]any   `json:"gate"`
+	}
+
+	run := func(t *testing.T, reviewedSHA string) (published, bool, map[string]any) {
+		t.Helper()
+		var got published
+		var posted bool
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			posted = true
+			raw, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(raw, &got); err != nil {
+				t.Errorf("publish payload is not JSON: %v (%q)", err, raw)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"published": true, "review_url": "https://forge/review/1",
+				"comments_posted": len(got.Comments), "suggestions_posted": 0,
+				"gate_posted": got.Gate != nil, "gate_state": "success",
+			})
+		}))
+		defer srv.Close()
+
+		// One real finding, so "the comments were dropped" is distinguishable
+		// from "there were none".
+		findings := `[{"severity":"high","category":"correctness","title":"t","detail":"d","file":"a.txt","line":1}]`
+		body := toolCommand(t, "review-pr/main.bot", "publish_review")
+		for ref, val := range map[string]string{
+			"{{vars.workspace_dir}}":       ws,
+			"{{input.reviewed_sha}}":       reviewedSHA,
+			"{{vars.forge_publish_url}}":   srv.URL + "/api/v1/forge/publish-review",
+			"{{vars.forge_publish_token}}": "run-token",
+			"{{vars.pr_review_mode}}":      "comment",
+			"{{input.pr_url}}":             "https://github.com/acme/widgets/pull/7",
+			"{{input.findings}}":           findings,
+			"{{input.questions}}":          "",
+			"{{input.claude_findings}}":    findings,
+			"{{input.gpt_findings}}":       "[]",
+			"{{vars.gate_enabled}}":        "true",
+			"{{vars.gate_severity}}":       "high",
+			"{{vars.gate_context}}":        "revi/review",
+		} {
+			if !strings.Contains(body, ref) {
+				t.Fatalf("%s is no longer referenced by publish_review — the test wires nothing", ref)
+			}
+			// Shell-quote exactly as the engine does: a raw JSON value dropped
+			// into a command line is split on spaces and brace-expanded.
+			body = strings.ReplaceAll(body, ref, "'"+strings.ReplaceAll(val, "'", `'\''`)+"'")
+		}
+		out, err := exec.Command("sh", "-c", body).Output()
+		if err != nil {
+			t.Fatalf("publish_review failed: %v (out %q)", err, out)
+		}
+		var res map[string]any
+		if err := json.Unmarshal(out, &res); err != nil {
+			t.Fatalf("output is not publish_output JSON: %v (%q)", err, out)
+		}
+		return got, posted, res
+	}
+
+	t.Run("tree moved: drops the anchors, still publishes the gate", func(t *testing.T) {
+		got, posted, res := run(t, parent)
+		if !posted {
+			t.Fatal("no publish at all — the merge gate never lands and the PR is stuck for good")
+		}
+		if got.Gate == nil {
+			t.Error("published without a gate payload — the required status cannot be created")
+		}
+		if len(got.Comments) != 0 {
+			t.Errorf("posted %d inline comment(s) anchored to a tree that moved", len(got.Comments))
+		}
+		if !strings.Contains(got.Summary, "moved after the reviewers judged it") {
+			t.Errorf("the summary must say why the anchors are gone, got %q", got.Summary)
+		}
+		if res["published"] != true {
+			t.Errorf("published = %v, want true", res["published"])
+		}
+	})
+
+	t.Run("tree unchanged: keeps the anchors", func(t *testing.T) {
+		got, posted, _ := run(t, head)
+		if !posted || len(got.Comments) == 0 {
+			t.Fatalf("a review of the current head must post its inline comments (posted=%v, comments=%d)", posted, len(got.Comments))
+		}
+	})
+
+	// The value the guard reads is wiring, and wiring breaks. Anything it
+	// cannot read as a sha means the guard cannot evaluate itself — and a
+	// guard that cannot evaluate itself must not swallow the review.
+	for _, tc := range []struct{ name, sha string }{
+		{"unresolved template ref", "{{outputs.diff_precheck.reviewed_sha}}"},
+		{"empty", ""},
+		{"not hex", "not-a-sha-at-all"},
+	} {
+		t.Run("unreadable sha ("+tc.name+"): publishes normally", func(t *testing.T) {
+			got, posted, _ := run(t, tc.sha)
+			if !posted {
+				t.Fatal("swallowed the review over a value the guard could not evaluate")
+			}
+			if len(got.Comments) == 0 {
+				t.Error("dropped the inline comments over a value the guard could not evaluate")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Revi has published nothing since 14:41

Every review since the runner picked up #290's reviewed-SHA guard ends the same way:

```
publish skipped: the worktree HEAD moved after the reviewers judged it
skipped_reason: tree changed since review ({{outputs.di -> 7e63d543f360)
```

The truncation gives it away. The guard read `REVIEWED_SHA` from `{{outputs.diff_precheck.reviewed_sha}}` written inside a tool `command:` — and `resolveCommandTemplate` ([pkg/backend/model/executor_tool.go:668](pkg/backend/model/executor_tool.go#L668)) substitutes `{{input.X}}` and `{{vars.X}}`, nothing else. The ref survived as literal text, `[:12]` clipped it to `{{outputs.di`, and it obviously never equals a sha — so the guard fired on **every** run, against a tree that had not moved at all (`7e63d543f360` was both the reviewed sha and HEAD).

**Blast radius:** that publish is what posts the `revi/review` commit status, and `revi/review` is a required check on `main`. Since 14:41 every PR on this repo has been unmergeable — with no error on the run, on the PR, or on the check. Observed on #317; the run (`019faf0e`) reports `finished`.

## The fix

- The sha arrives on the **edge**, where `{{outputs.<node>.<field>}}` does resolve, and is read as `{{input.reviewed_sha}}`.
- The guard now only fires on something that is actually a sha. A guard that cannot evaluate itself must not swallow the review: blocking a PR for good is a far worse outcome than posting comments whose line anchors may be stale.

## The test that should have caught it

`TestCatalogToolCommandsResolveTheirRefs` — no catalog tool's `command:`/`script:` body may carry an `{{outputs.…}}` ref, across `bots/` and `examples/`. This seam fails silently: the bot parses, compiles, validates and runs; the value is just a template string pretending to be data. Verified by restoring the original line — the test names the node and the ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)