### PR TITLE
fix(review-pr): a mono review must not report cross-family confirmation

### DIFF
--- a/bots/review-pr/main.bot
+++ b/bots/review-pr/main.bot
@@ -785,7 +785,7 @@ compute pr_gate:
 ## published is true ONLY on a 2xx from the endpoint, whose counts are
 ## forge-re-fetched (anti-façade), never self-estimated.
 tool publish_review:
-  command: `WS={{vars.workspace_dir}} REVIEWED_SHA={{input.reviewed_sha}} PUB_URL={{vars.forge_publish_url}} PUB_TOKEN={{vars.forge_publish_token}} MODE={{vars.pr_review_mode}} PR_URL={{input.pr_url}} FINDINGS={{input.findings}} QUESTIONS={{input.questions}} CLAUDE_FINDINGS={{input.claude_findings}} GPT_FINDINGS={{input.gpt_findings}} GATE_ENABLED={{vars.gate_enabled}} GATE_SEVERITY={{vars.gate_severity}} GATE_CONTEXT={{vars.gate_context}} python3 -c "
+  command: `WS={{vars.workspace_dir}} REVIEWED_SHA={{input.reviewed_sha}} PUB_URL={{vars.forge_publish_url}} PUB_TOKEN={{vars.forge_publish_token}} MODE={{vars.pr_review_mode}} REVIEW_MODE={{vars.review_mode}} PR_URL={{input.pr_url}} FINDINGS={{input.findings}} QUESTIONS={{input.questions}} CLAUDE_FINDINGS={{input.claude_findings}} GPT_FINDINGS={{input.gpt_findings}} GATE_ENABLED={{vars.gate_enabled}} GATE_SEVERITY={{vars.gate_severity}} GATE_CONTEXT={{vars.gate_context}} python3 -c "
 import os, json, subprocess, urllib.request, urllib.error
 
 def emit(published, forge='unknown', review_url='', posted=0, sugg=0, skipped='', summary=''):
@@ -904,9 +904,20 @@ elif findings_parse_failed:
     summary.append(chr(9888) + ' DEGRADED: the review produced findings but their machine-readable form was unreadable, and no reviewer fallback was available. Nothing could be anchored inline; the merge gate fails closed.')
 for sev in sorted(counts, key=lambda s: sev_rank.get(s, 9)):
     summary.append('- ' + sev + ': ' + str(counts[sev]))
+# Cross-confirmation only exists when two families actually reviewed. The
+# topology predicate is the same one the graph routes on (anything not 'dual'
+# runs a single reviewer), so mono cannot report it. Saying '0 cross-confirmed'
+# there reads as 'two families looked and agreed on nothing' — a claim about a
+# review that never happened.
+dual = str(os.environ.get('REVIEW_MODE', '')).strip().lower() == 'dual'
 cross_n = len([f for f in findings if isinstance(f, dict) and str(f.get('reviewers') or '') == 'both'])
 summary.append('')
-summary.append(str(cross_n) + ' finding(s) cross-confirmed by both model families.' if findings else 'No blocking findings.')
+if not findings:
+    summary.append('No blocking findings.')
+elif dual:
+    summary.append(str(cross_n) + ' finding(s) cross-confirmed by both model families.')
+else:
+    summary.append('Reviewed by a single model family (mono topology): no finding is cross-confirmed, and none is meant to be.')
 if questions:
     summary.append('')
     summary.append('### Open questions (non-blocking — reviewer assumptions to confirm)')

--- a/bots/review-pr/manifest.yaml
+++ b/bots/review-pr/manifest.yaml
@@ -1,7 +1,13 @@
 name: review-pr
 display_name: Revi
 icon: 🔎
-version: 0.5.6
+version: 0.5.7
+## 0.5.7 — the review comment stops reporting a comparison that never happened.
+## Mono is the default topology (one family reviews), yet every comment ended
+## with "0 finding(s) cross-confirmed by both model families" — which reads as
+## two families having looked and agreed on nothing. It now names the topology
+## it actually ran under, and reports cross-confirmation only when two families
+## really reviewed.
 ## 0.5.6 — a review must never leave its required check absent. The stale-anchor
 ## guard added in 0.5.5 read REVIEWED_SHA from an {{outputs.…}} ref written
 ## inside a tool `command:`, which the engine does not substitute there: the

--- a/bots/review_pr_stale_anchor_test.go
+++ b/bots/review_pr_stale_anchor_test.go
@@ -95,6 +95,7 @@ func TestReviewPRStaleAnchorStillPublishes(t *testing.T) {
 			"{{vars.forge_publish_url}}":   srv.URL + "/api/v1/forge/publish-review",
 			"{{vars.forge_publish_token}}": "run-token",
 			"{{vars.pr_review_mode}}":      "comment",
+			"{{vars.review_mode}}":         "mono",
 			"{{input.pr_url}}":             "https://github.com/acme/widgets/pull/7",
 			"{{input.findings}}":           findings,
 			"{{input.questions}}":          "",
@@ -138,6 +139,20 @@ func TestReviewPRStaleAnchorStillPublishes(t *testing.T) {
 		}
 		if res["published"] != true {
 			t.Errorf("published = %v, want true", res["published"])
+		}
+	})
+
+	// A mono review has one family, so "0 cross-confirmed" would describe a
+	// comparison that never took place. Observed on
+	// socialgouv/buildkit-operator#6, whose comment reported it under the
+	// default topology.
+	t.Run("mono topology: claims no cross-confirmation", func(t *testing.T) {
+		got, _, _ := run(t, head)
+		if strings.Contains(got.Summary, "cross-confirmed by both model families") {
+			t.Errorf("a single-family review reports a cross-family comparison:\n%s", got.Summary)
+		}
+		if !strings.Contains(got.Summary, "single model family") {
+			t.Errorf("the summary should name the topology it ran under:\n%s", got.Summary)
 		}
 	})
 


### PR DESCRIPTION
Spotted by jo on [socialgouv/buildkit-operator#6](https://github.com/SocialGouv/buildkit-operator/pull/6): Revi's comment ends with

> 0 finding(s) cross-confirmed by both model families.

under the **default mono topology**, where a single family reviews. `review_mode` defaults to `mono` ([main.bot:177](bots/review-pr/main.bot#L177)) and the graph routes accordingly — the run in question ran `reviewer_claude` alone, no `fan`, no `reviewer_gpt`.

So the line describes a comparison that never took place. A reader takes "0 cross-confirmed" as *two families looked and agreed on nothing*, which is a much weaker signal than *one family reviewed, and cross-confirmation was never on the table*.

The summary now names the topology it ran under and reports cross-confirmation only when two families really reviewed. The predicate is the same one the graph routes on (anything not `dual` runs a single reviewer), so the comment cannot disagree with the run that produced it.

Test: `TestReviewPRStaleAnchorStillPublishes/mono_topology` drives the real publish body under `review_mode=mono` and asserts the cross-family sentence is absent and the topology is stated. Verified by restoring the unconditional line — it fails with the exact text the live PR displayed.

Same class as #317: a message asserting work that did not happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)