### PR TITLE
test: make the two worst flakes measure their invariant, not the clock

### DIFF
--- a/pkg/runtime/fan_out_each_test.go
+++ b/pkg/runtime/fan_out_each_test.go
@@ -361,6 +361,20 @@ func TestResourceLease_DistinctInstances(t *testing.T) {
 	maxConcurrent := 0
 	var violations []string
 
+	// Saturation is FORCED, not hoped for. Asserting that three leases were
+	// once held at the same instant, while letting each handler release on a
+	// sleep, tests the scheduler's timing rather than the pool: on a loaded
+	// runner a holder can release before the third acquires, and the run is
+	// perfectly correct with a high-water mark of two. Every holder now waits
+	// until the pool is full before releasing, so a pool that CANNOT saturate
+	// is the only way to miss it.
+	//
+	// The later items cannot deadlock on this: the channel is closed for good
+	// by the first full batch, and the bound is a safety valve for the case
+	// where saturation never happens — which the assertion below reports.
+	saturated := make(chan struct{})
+	var saturate sync.Once
+
 	exec := newStubExecutor()
 	exec.on("entry", func(_ map[string]any) (map[string]any, error) {
 		return map[string]any{"items": items}, nil
@@ -381,10 +395,17 @@ func TestResourceLease_DistinctInstances(t *testing.T) {
 			if len(held) > maxConcurrent {
 				maxConcurrent = len(held)
 			}
+			if len(held) == len(pool) {
+				saturate.Do(func() { close(saturated) })
+			}
 		}
 		mu.Unlock()
 
-		time.Sleep(15 * time.Millisecond) // hold the lease so contention is observable
+		// Hold the lease until the pool is provably full (or we give up).
+		select {
+		case <-saturated:
+		case <-time.After(10 * time.Second):
+		}
 
 		mu.Lock()
 		delete(held, id)

--- a/pkg/runview/runstream/iface.go
+++ b/pkg/runview/runstream/iface.go
@@ -22,6 +22,7 @@ package runstream
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -29,7 +30,27 @@ import (
 // MaxEventsPerPage caps the number of events a single replay batch (and
 // a single store LoadEventsRange page) carries. One WS envelope ships at
 // most this many events. Aliased by pkg/runview.MaxEventsPerPage.
-const MaxEventsPerPage = 25000
+//
+// Adjustable, so a test can prove the pagination BOUNDARY without paying for
+// the page size: covering it honestly means seeding more events than fit in
+// one page, and at 25000 that was a 33-second test whose replay window then
+// had to be widened until it was really measuring throughput on a loaded
+// runner. Shrink it with SetMaxEventsPerPageForTest.
+//
+// Atomic because replay goroutines read it while a test's cleanup restores it.
+var maxEventsPerPage atomic.Int64
+
+func init() { maxEventsPerPage.Store(25000) }
+
+// MaxEventsPerPage returns the current page cap.
+func MaxEventsPerPage() int { return int(maxEventsPerPage.Load()) }
+
+// SetMaxEventsPerPageForTest lowers the page cap for the duration of a test
+// and returns a restore func. Test-only: production has no reason to move it.
+func SetMaxEventsPerPageForTest(n int) func() {
+	prev := maxEventsPerPage.Swap(int64(n))
+	return func() { maxEventsPerPage.Store(prev) }
+}
 
 // ErrLogsUnsupported is returned by SubscribeLogs on a source that was
 // constructed without a log backend (a MongoSource with no run_logs

--- a/pkg/runview/runstream/mongo.go
+++ b/pkg/runview/runstream/mongo.go
@@ -249,7 +249,7 @@ func (m *MongoSource) backfillEvents(ctx context.Context, runID string, fromSeq 
 		if e.Seq > maxSeq {
 			maxSeq = e.Seq
 		}
-		if len(batch) >= MaxEventsPerPage {
+		if len(batch) >= MaxEventsPerPage() {
 			if err := flush(); err != nil {
 				return maxSeq, err
 			}

--- a/pkg/runview/runstream/replay.go
+++ b/pkg/runview/runstream/replay.go
@@ -22,7 +22,7 @@ func ReplayEvents(ctx context.Context, st store.RunStore, runID string, fromSeq 
 	maxReplayed := fromSeq - 1
 	next := fromSeq
 	for {
-		page, err := st.LoadEventsRange(ctx, runID, next, 0, MaxEventsPerPage)
+		page, err := st.LoadEventsRange(ctx, runID, next, 0, MaxEventsPerPage())
 		if len(page) > 0 {
 			if !pipe.Ship(ctx, page) {
 				return maxReplayed, ctx.Err()
@@ -34,7 +34,7 @@ func ReplayEvents(ctx context.Context, st store.RunStore, runID string, fromSeq 
 		if err != nil {
 			return maxReplayed, err
 		}
-		if len(page) < MaxEventsPerPage {
+		if len(page) < MaxEventsPerPage() {
 			return maxReplayed, nil
 		}
 		next = maxReplayed + 1

--- a/pkg/runview/service_runs.go
+++ b/pkg/runview/service_runs.go
@@ -356,10 +356,15 @@ func (s *Service) SnapshotCtx(ctx context.Context, runID string) (*RunSnapshot, 
 // Callers paginate by passing the next page's `from` as
 // previous_last.Seq+1; len(out) == cap means "more available".
 //
-// The canonical constant lives in runstream (the streaming seam batches
+// The canonical value lives in runstream (the streaming seam batches
 // replay pages at the same size); this alias keeps the historical
 // runview.MaxEventsPerPage name working for the HTTP/WS layer.
-const MaxEventsPerPage = runstream.MaxEventsPerPage
+func MaxEventsPerPage() int { return runstream.MaxEventsPerPage() }
+
+// SetMaxEventsPerPageForTest lowers the page cap for the duration of a test
+// and returns a restore func. One knob, read through one accessor, so a test
+// cannot read one value while the streaming seam paginates on another.
+func SetMaxEventsPerPageForTest(n int) func() { return runstream.SetMaxEventsPerPageForTest(n) }
 
 // LoadEvents returns events in [from, to] (inclusive on from, exclusive
 // on to), capped at MaxEventsPerPage. Pass to=0 for "no upper bound".
@@ -371,10 +376,10 @@ const MaxEventsPerPage = runstream.MaxEventsPerPage
 // Uses context.Background — does NOT carry caller identity. Use
 // LoadEventsCtx from cloud HTTP/WS handlers.
 func (s *Service) LoadEvents(runID string, from, to int64) ([]*store.Event, error) {
-	return s.store.LoadEventsRange(context.Background(), runID, from, to, MaxEventsPerPage)
+	return s.store.LoadEventsRange(context.Background(), runID, from, to, MaxEventsPerPage())
 }
 
 // LoadEventsCtx is the tenant-aware variant of LoadEvents.
 func (s *Service) LoadEventsCtx(ctx context.Context, runID string, from, to int64) ([]*store.Event, error) {
-	return s.store.LoadEventsRange(ctx, runID, from, to, MaxEventsPerPage)
+	return s.store.LoadEventsRange(ctx, runID, from, to, MaxEventsPerPage())
 }

--- a/pkg/server/runs_detail.go
+++ b/pkg/server/runs_detail.go
@@ -124,7 +124,7 @@ func (s *Server) handleGetRunEvents(w http.ResponseWriter, r *http.Request) {
 		s.httpErrorFor(w, r, http.StatusBadRequest, "%v", err)
 		return
 	} else if xs != nil {
-		events, err := xs.LoadEventsRange(r.Context(), id, from, to, runview.MaxEventsPerPage)
+		events, err := xs.LoadEventsRange(r.Context(), id, from, to, runview.MaxEventsPerPage())
 		if err != nil {
 			s.httpErrorFor(w, r, http.StatusInternalServerError, "load events from cross-store: %v", err)
 			return

--- a/pkg/server/runs_ws_test.go
+++ b/pkg/server/runs_ws_test.go
@@ -301,6 +301,15 @@ func decodeEventEnvelope(t *testing.T, env runWSEnvelope) []store.Event {
 }
 
 func TestRunsWS_ReplayPaginatesPastMaxEventsPerPage(t *testing.T) {
+	// Shrink the page rather than pay for it. What is under test is the
+	// BOUNDARY — that replay keeps going past one page — and at the
+	// production cap of 25000 the only way to reach it was to seed 25050
+	// events one at a time: 33 seconds, most of it store I/O, after which the
+	// replay window had to be widened until the test was really measuring
+	// throughput on a loaded runner. It went red on PRs that touch nothing
+	// here.
+	t.Cleanup(runview.SetMaxEventsPerPageForTest(60))
+
 	srv, hs := newTestServer(t)
 	st, err := store.New(srv.cfg.StoreDir)
 	if err != nil {
@@ -315,7 +324,7 @@ func TestRunsWS_ReplayPaginatesPastMaxEventsPerPage(t *testing.T) {
 	// silently dropped the tail past the cap, including any terminal
 	// run_failed/run_finished — leaving the studio's pill stuck on
 	// whatever pre-terminal status the last replayed event implied.
-	n := runview.MaxEventsPerPage + 50
+	n := runview.MaxEventsPerPage() + 50
 	for i := 0; i < n; i++ {
 		evt := store.Event{Type: store.EventNodeStarted, RunID: runID, NodeID: "x"}
 		if _, err := st.AppendEvent(context.Background(), runID, evt); err != nil {
@@ -340,7 +349,7 @@ func TestRunsWS_ReplayPaginatesPastMaxEventsPerPage(t *testing.T) {
 	// enough to fail under a full `./...` -race run, where this package
 	// competes with every other one — which made the merge queue red at
 	// random on changes that touch nothing here.
-	deadline := time.Now().Add(90 * time.Second)
+	deadline := time.Now().Add(90 * time.Second) // safety net, not a measurement
 	for time.Now().Before(deadline) && received < n {
 		env := readEnvelope(t, c, wsTypeEvent, wsTypeEventBatch, wsTypeTerminated)
 		if env.Type == wsTypeTerminated {
@@ -353,7 +362,7 @@ func TestRunsWS_ReplayPaginatesPastMaxEventsPerPage(t *testing.T) {
 	}
 	if received != n {
 		t.Errorf("received = %d events, want %d (replay must paginate past MaxEventsPerPage=%d)",
-			received, n, runview.MaxEventsPerPage)
+			received, n, runview.MaxEventsPerPage())
 	}
 	if want := int64(n - 1); lastSeq != want {
 		t.Errorf("lastSeq = %d, want %d (terminal event must reach the client)", lastSeq, want)


### PR DESCRIPTION
Both went red on PRs that touch nothing near them, and both were timing assertions wearing an invariant's clothes.

## `TestResourceLease_DistinctInstances`

Asserted `maxConcurrent == len(pool)` — that three leases were once held at the *same instant* — while each holder released on a 15ms sleep. On a loaded runner a holder can release before the third acquires, and the run is perfectly correct with a high-water mark of two.

Saturation is now **forced**: every holder waits until the pool is provably full before releasing, so a pool that *cannot* saturate is the only way to miss it. The later items cannot deadlock on it — the channel is closed for good by the first full batch, and the bound is a safety valve for the case the assertion then reports.

## `TestRunsWS_ReplayPaginatesPastMaxEventsPerPage`

Tested the pagination **boundary** by paying for the page size: `MaxEventsPerPage + 50` = 25050 events appended one at a time. **33 seconds**, almost all store I/O.

The tell was already in the file — the replay window had been widened from 20s to 90s because the first value *"was short enough to fail under a full `./...` -race run, where this package competes with every other one"*. At that point it is measuring throughput on a shared runner, not pagination.

The cap is now adjustable and the test shrinks it to 60, seeding 110 events. Same boundary, **0.1s instead of 33s** — and it stops being the reason a `-count=10` run blows the 10-minute package timeout.

The cap is read by replay goroutines while the test's cleanup restores it, so it is an `atomic.Int64` behind an accessor rather than a bare var — the race detector caught the first attempt, which is the honest way to find that out.

## Verification

- `TestResourceLease_DistinctInstances`: `-race -count=5` green.
- `TestRunsWS_...`: `-race -count=3` green, 0.10s each.
- `pkg/runview/... pkg/server pkg/runtime` with `-race`: green.

Closes the test half of `native:a196254f` (the CI-config half is #319).

🤖 Generated with [Claude Code](https://claude.com/claude-code)