### PR TITLE
ci: stop losing the runner image, and stop testing every commit twice

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -28,9 +28,22 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  # Only the latest binary matters for the rolling :edge, and there is no base
-  # build to protect here — cancel a superseded refold instead of queueing it.
-  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
+  # NEVER cancel: this workflow builds the artifact prod actually deploys, and
+  # a cancelled build leaves `:edge` silently pointing at an older commit while
+  # both runs report "completed".
+  #
+  # Cancelling looked safe — only the latest binary matters for a rolling tag —
+  # but GitHub evaluates `concurrency:` BEFORE a job's `if:`, so a run that is
+  # about to skip still takes the slot and kills the one that was building.
+  # That is not a corner case: release-it pushes its `[skip ci]` brew-tap commit
+  # straight after the release commit, GitHub reports the skipped image.yml as
+  # `completed`, and the resulting workflow_run cancelled the real build on
+  # every release. Measured 2026-07-30: b74d06bf cancelled by 44189ef1, which
+  # then skipped — no runner image at all for the commit being shipped.
+  #
+  # Queueing instead costs one build's wait and keeps the ordering, so the
+  # newest commit still ends up as `:edge`.
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,23 @@
 name: 🧪 Tests
 
+# One run per commit, not two. An unfiltered `push:` alongside `pull_request:`
+# ran the whole suite twice for every PR commit — same sha, two runs, escaping
+# each other's concurrency group because their refs differ
+# (refs/heads/<branch> vs refs/pull/N/merge). That doubled the runner cost and,
+# worse, doubled the exposure to a timing-sensitive test: one run green, the
+# other red on the same commit is enough to redden the PR and disarm auto-merge.
+#
+# `merge_group` is load-bearing: test/race/vendor-check/mongo-conformance/
+# golangci are REQUIRED checks, and the queue branch
+# (gh-readonly-queue/main/...) used to get them from that unfiltered push. A
+# queue build with no checks waits for a context that never arrives and
+# dequeues the PR after the 60-minute timeout.
 on:
   push:
+    branches: [main]
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read


### PR DESCRIPTION
Same change as #319, re-opened from a fresh branch to isolate why that one received **zero** Actions runs — including workflows it does not touch.

See #319 for the full rationale (runner image cancelled by a run that then skips; tests.yml running the suite twice per commit; `merge_group:` added because the merge queue took its required checks from the unfiltered push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)