### PR TITLE
fix(server+studio): show the paused node's instructions on review cards

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -929,6 +929,9 @@
           "depth": {
             "type": "integer"
           },
+          "instructions": {
+            "type": "string"
+          },
           "interaction_id": {
             "type": "string"
           },

--- a/pkg/server/pipeline_boards_progress.go
+++ b/pkg/server/pipeline_boards_progress.go
@@ -69,17 +69,71 @@ func (b *pipelineProjectionBuilder) runProgress(run *store.Run) (executed, total
 // executedNodes counts distinct nodes that started for a run (node_started
 // fires once per loop iteration, so dedup on node id).
 func (b *pipelineProjectionBuilder) executedNodes(runID string) int {
-	if b.rs == nil {
-		return 0
+	return b.scanRunEvents(runID).executedNodes
+}
+
+// runEventScan is the result of ONE walk over a run's event log.
+//
+// The projection is rebuilt from scratch on every poll (the studio polls
+// the board every 3s) and a paused run's log is among the longest the
+// store holds — FilesystemRunStore json.Unmarshals every line. Both
+// consumers, the node-progress count and a paused gate's instructions,
+// therefore share a single pass instead of walking the file twice.
+type runEventScan struct {
+	executedNodes int
+	// instructions holds the LAST human_input_requested text per key
+	// (see instructionScanKey). Last-wins is OUTRIGHT: a turn that
+	// carries no instructions stores "", so a stale question can never
+	// remain displayed above a live form asking something else. Two
+	// pause paths legitimately emit no text — a recovery pause
+	// (pauseForRecovery) and a turn whose instructions template renders
+	// empty (humanInstructionsExtra returns nil).
+	instructions map[string]string
+}
+
+// instructionScanKey namespaces interaction ids apart from node ids so the
+// two key spaces can share one map without colliding.
+func instructionScanKey(kind, id string) string {
+	return kind + "\x00" + id
+}
+
+// scanRunEvents walks a run's events once and memoizes the result for this
+// projection build.
+func (b *pipelineProjectionBuilder) scanRunEvents(runID string) *runEventScan {
+	if scan, ok := b.eventScans[runID]; ok {
+		return scan
 	}
-	seen := map[string]struct{}{}
-	_ = b.rs.ScanEvents(b.ctx, runID, func(e *store.Event) bool {
-		if e.Type == store.EventNodeStarted && e.NodeID != "" {
-			seen[e.NodeID] = struct{}{}
-		}
-		return true
-	})
-	return len(seen)
+	scan := &runEventScan{instructions: map[string]string{}}
+	if b.rs != nil {
+		seen := map[string]struct{}{}
+		_ = b.rs.ScanEvents(b.ctx, runID, func(e *store.Event) bool {
+			if e == nil {
+				return true
+			}
+			switch e.Type {
+			case store.EventNodeStarted:
+				if e.NodeID != "" {
+					seen[e.NodeID] = struct{}{}
+				}
+			case store.EventHumanInputRequested:
+				if e.NodeID == "" {
+					return true
+				}
+				text, _ := e.Data["instructions"].(string)
+				scan.instructions[instructionScanKey("node", e.NodeID)] = text
+				if id, ok := e.Data["interaction_id"].(string); ok && id != "" {
+					scan.instructions[instructionScanKey("interaction", id)] = text
+				}
+			}
+			return true
+		})
+		scan.executedNodes = len(seen)
+	}
+	if b.eventScans == nil {
+		b.eventScans = map[string]*runEventScan{}
+	}
+	b.eventScans[runID] = scan
+	return scan
 }
 
 // totalNodes compiles the run's workflow (memoized by file path) and

--- a/pkg/server/pipeline_boards_projection.go
+++ b/pkg/server/pipeline_boards_projection.go
@@ -644,6 +644,7 @@ func (b *pipelineProjectionBuilder) aggregateTree(root *store.Run) (treeExec, tr
 				NodeID:        run.Checkpoint.NodeID,
 				InteractionID: run.Checkpoint.InteractionID,
 				Questions:     cloneAnyMap(run.Checkpoint.InteractionQuestions),
+				Instructions:  b.pendingReviewInstructions(run),
 				UpdatedAt:     b.pendingReviewUpdatedAt(run),
 				Depth:         depth,
 			})
@@ -690,4 +691,47 @@ func (b *pipelineProjectionBuilder) pendingReviewUpdatedAt(run *store.Run) time.
 		return run.UpdatedAt
 	}
 	return run.CreatedAt
+}
+
+// pendingReviewInstructions returns the resolved `instructions:` text the
+// engine stamped on this pause's human_input_requested event.
+//
+// Why a scan: the resolved text rides ONLY on that event (doPause folds
+// humanInstructionsExtra into the event data). Neither the checkpoint nor
+// the interaction record carries it, so a card built from the checkpoint
+// alone has nothing to show — and for a bot whose whole operator-facing
+// question lives in `instructions:` that means an answer box with no
+// question above it. Reading it back from the event log also makes
+// already-paused runs render correctly, without waiting for a new pause.
+//
+// The last matching event wins: a review gate that resumes and re-pauses
+// on the same interaction ID emits a fresh event per turn, and the operator
+// must see the current turn. Matching prefers the checkpoint's interaction
+// id and falls back to the node id for pauses written before interaction
+// ids were stamped on the event.
+func (b *pipelineProjectionBuilder) pendingReviewInstructions(run *store.Run) string {
+	if b == nil || b.rs == nil || run == nil || run.Checkpoint == nil {
+		return ""
+	}
+	node := run.Checkpoint.NodeID
+	if node == "" {
+		return ""
+	}
+	wantInteraction := run.Checkpoint.InteractionID
+	found := ""
+	_ = b.rs.ScanEvents(b.ctx, run.ID, func(e *store.Event) bool {
+		if e == nil || e.Type != store.EventHumanInputRequested || e.NodeID != node {
+			return true
+		}
+		if wantInteraction != "" {
+			if id, ok := e.Data["interaction_id"].(string); ok && id != wantInteraction {
+				return true
+			}
+		}
+		if text, ok := e.Data["instructions"].(string); ok {
+			found = text
+		}
+		return true
+	})
+	return found
 }

--- a/pkg/server/pipeline_boards_projection.go
+++ b/pkg/server/pipeline_boards_projection.go
@@ -83,7 +83,11 @@ type pipelineProjectionBuilder struct {
 	issueOwnedRuns map[string]struct{}
 	nodeCountCache map[string]int
 	queuePositions map[string]int
-	cards          []PipelineBoardCard
+	// eventScans memoizes the single per-run event walk (node-progress
+	// count + paused gates' instructions) for the lifetime of one
+	// projection build, so the two consumers share ONE pass.
+	eventScans map[string]*runEventScan
+	cards      []PipelineBoardCard
 
 	// finalOutputMemo caches finished runs' resolved output across polls so a
 	// DONE card's output isn't re-probed from artifacts every tick (PR #193
@@ -696,19 +700,18 @@ func (b *pipelineProjectionBuilder) pendingReviewUpdatedAt(run *store.Run) time.
 // pendingReviewInstructions returns the resolved `instructions:` text the
 // engine stamped on this pause's human_input_requested event.
 //
-// Why a scan: the resolved text rides ONLY on that event (doPause folds
-// humanInstructionsExtra into the event data). Neither the checkpoint nor
-// the interaction record carries it, so a card built from the checkpoint
-// alone has nothing to show — and for a bot whose whole operator-facing
-// question lives in `instructions:` that means an answer box with no
-// question above it. Reading it back from the event log also makes
+// Why the event log: the resolved text rides ONLY on that event (doPause
+// folds humanInstructionsExtra into the event data). Neither the checkpoint
+// nor the interaction record carries it, so a card built from the
+// checkpoint alone has nothing to show — and for a bot whose whole
+// operator-facing question lives in `instructions:` that means an answer
+// box with no question above it. Reading it back from the log also makes
 // already-paused runs render correctly, without waiting for a new pause.
 //
-// The last matching event wins: a review gate that resumes and re-pauses
-// on the same interaction ID emits a fresh event per turn, and the operator
-// must see the current turn. Matching prefers the checkpoint's interaction
-// id and falls back to the node id for pauses written before interaction
-// ids were stamped on the event.
+// The checkpoint's interaction id is the precise key: a human node inside
+// a loop gets one interaction per iteration, and only the turn the
+// checkpoint points at may be shown. The node id is the fallback for
+// pauses written before interaction ids were stamped on the event.
 func (b *pipelineProjectionBuilder) pendingReviewInstructions(run *store.Run) string {
 	if b == nil || b.rs == nil || run == nil || run.Checkpoint == nil {
 		return ""
@@ -717,21 +720,14 @@ func (b *pipelineProjectionBuilder) pendingReviewInstructions(run *store.Run) st
 	if node == "" {
 		return ""
 	}
-	wantInteraction := run.Checkpoint.InteractionID
-	found := ""
-	_ = b.rs.ScanEvents(b.ctx, run.ID, func(e *store.Event) bool {
-		if e == nil || e.Type != store.EventHumanInputRequested || e.NodeID != node {
-			return true
+	scan := b.scanRunEvents(run.ID)
+	if id := run.Checkpoint.InteractionID; id != "" {
+		// Present-but-empty is a real answer here (the current turn
+		// carried no instructions), so honour it instead of falling
+		// through to a staler node-level entry.
+		if text, ok := scan.instructions[instructionScanKey("interaction", id)]; ok {
+			return text
 		}
-		if wantInteraction != "" {
-			if id, ok := e.Data["interaction_id"].(string); ok && id != wantInteraction {
-				return true
-			}
-		}
-		if text, ok := e.Data["instructions"].(string); ok {
-			found = text
-		}
-		return true
-	})
-	return found
+	}
+	return scan.instructions[instructionScanKey("node", node)]
 }

--- a/pkg/server/pipeline_boards_test.go
+++ b/pkg/server/pipeline_boards_test.go
@@ -1441,11 +1441,16 @@ func TestPipelineBoardPendingReviewCarriesResolvedInstructions(t *testing.T) {
 		}
 	})
 	rs := env.runStore(t)
-	// An earlier turn of the SAME gate, then the current one: the operator
-	// must see the current question, not the stale one.
+	// An earlier turn of the SAME gate, then the current one, then a pause
+	// on the same node belonging to ANOTHER interaction (what a human node
+	// inside a loop produces): the operator must see the turn the
+	// checkpoint points at — not the stale one, and not a sibling's. The
+	// last entry is what makes the interaction-id key load-bearing: drop
+	// it and this test still passes on node id alone.
 	for _, turn := range []struct{ id, text string }{
 		{"int-chat", "STALE first turn"},
 		{"int-chat", "Which scope do you want? **A** or **B**?"},
+		{"int-later-loop", "WRONG INTERACTION"},
 	} {
 		if _, err := rs.AppendEvent(context.Background(), "run-gate", store.Event{
 			Type:      store.EventHumanInputRequested,
@@ -1505,5 +1510,45 @@ func TestPipelineBoardPendingReviewWithoutInstructionsStaysEmpty(t *testing.T) {
 	}
 	if got := card.PendingReviews[0].Instructions; got != "" {
 		t.Fatalf("instructions = %q, want empty", got)
+	}
+}
+
+// A later turn on the SAME interaction that carries no instructions must
+// BLANK the card, not leave the previous turn's question standing. Two
+// pause paths legitimately emit no text — pauseForRecovery, and
+// humanInstructionsExtra returning nil when the template renders empty —
+// and interactionIDForPause hands every pause of a non-loop node the same
+// `<runID>_<nodeID>` id, so the stale text would otherwise sit as markdown
+// directly above a form asking something else: this PR's own failure mode,
+// in reverse.
+func TestPipelineBoardPendingReviewLaterTurnWithoutInstructionsBlanks(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	env.seedRun(t, "run-recovery", "interview", store.RunStatusPausedWaitingHuman, func(run *store.Run) {
+		run.FilePath = env.botPath
+		run.Checkpoint = &store.Checkpoint{NodeID: "chat", InteractionID: "int-chat"}
+	})
+	rs := env.runStore(t)
+	for _, turn := range []map[string]any{
+		{"interaction_id": "int-chat", "instructions": "The gate question"},
+		// A recovery pause on the same node/interaction: no instructions key.
+		{"interaction_id": "int-chat", "recovery_code": "E_TOOL", "recovery_reason": "boom"},
+	} {
+		if _, err := rs.AppendEvent(context.Background(), "run-recovery", store.Event{
+			Type:      store.EventHumanInputRequested,
+			RunID:     "run-recovery",
+			NodeID:    "chat",
+			Timestamp: time.Now().UTC(),
+			Data:      turn,
+		}); err != nil {
+			t.Fatalf("AppendEvent: %v", err)
+		}
+	}
+
+	card := findPipelineCard(t, env.projection(t).Cards, "run:run-recovery")
+	if len(card.PendingReviews) != 1 {
+		t.Fatalf("pending_reviews = %+v", card.PendingReviews)
+	}
+	if got := card.PendingReviews[0].Instructions; got != "" {
+		t.Fatalf("instructions = %q, want empty: the current turn carries none", got)
 	}
 }

--- a/pkg/server/pipeline_boards_test.go
+++ b/pkg/server/pipeline_boards_test.go
@@ -1420,3 +1420,90 @@ func TestPipelineBoardParentClosesIndependentlyOfChildren(t *testing.T) {
 		t.Fatalf("child lost its parent link: %q / %q", cCard.ParentIssueID, cCard.ParentTitle)
 	}
 }
+
+// The card must carry the paused node's resolved `instructions:` text.
+// It is the author's operator-facing question and rides ONLY on the
+// human_input_requested event — the checkpoint and the interaction record
+// don't keep it. Without it the card renders an answer box with nothing
+// above it, because the schema-driven form shows the node's OUTPUT fields
+// while `questions` holds its INBOUND data (regression: an app-concept
+// interview gate whose whole prompt is `instructions: {{input.reply}}`
+// showed a blank form on the board while the run console rendered it).
+func TestPipelineBoardPendingReviewCarriesResolvedInstructions(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	env.seedRun(t, "run-gate", "interview", store.RunStatusPausedWaitingHuman, func(run *store.Run) {
+		run.FilePath = env.botPath
+		run.Checkpoint = &store.Checkpoint{
+			NodeID:        "chat",
+			InteractionID: "int-chat",
+			// Inbound data only: the answer form never renders these.
+			InteractionQuestions: map[string]any{"reply": "Which scope do you want?"},
+		}
+	})
+	rs := env.runStore(t)
+	// An earlier turn of the SAME gate, then the current one: the operator
+	// must see the current question, not the stale one.
+	for _, turn := range []struct{ id, text string }{
+		{"int-chat", "STALE first turn"},
+		{"int-chat", "Which scope do you want? **A** or **B**?"},
+	} {
+		if _, err := rs.AppendEvent(context.Background(), "run-gate", store.Event{
+			Type:      store.EventHumanInputRequested,
+			RunID:     "run-gate",
+			NodeID:    "chat",
+			Timestamp: time.Now().UTC(),
+			Data: map[string]any{
+				"interaction_id": turn.id,
+				"instructions":   turn.text,
+			},
+		}); err != nil {
+			t.Fatalf("AppendEvent: %v", err)
+		}
+	}
+	// A pause of a DIFFERENT node must not leak into this review.
+	if _, err := rs.AppendEvent(context.Background(), "run-gate", store.Event{
+		Type:      store.EventHumanInputRequested,
+		RunID:     "run-gate",
+		NodeID:    "other_gate",
+		Timestamp: time.Now().UTC(),
+		Data:      map[string]any{"interaction_id": "int-other", "instructions": "WRONG NODE"},
+	}); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	card := findPipelineCard(t, env.projection(t).Cards, "run:run-gate")
+	if len(card.PendingReviews) != 1 {
+		t.Fatalf("pending_reviews = %+v, want the paused gate", card.PendingReviews)
+	}
+	got := card.PendingReviews[0].Instructions
+	if got != "Which scope do you want? **A** or **B**?" {
+		t.Fatalf("instructions = %q, want the current turn's resolved prompt", got)
+	}
+}
+
+// A node with no `instructions:` prompt emits no such field; the review
+// must then carry an empty string rather than borrowing another node's.
+func TestPipelineBoardPendingReviewWithoutInstructionsStaysEmpty(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	env.seedRun(t, "run-bare", "bare", store.RunStatusPausedWaitingHuman, func(run *store.Run) {
+		run.FilePath = env.botPath
+		run.Checkpoint = &store.Checkpoint{NodeID: "gate", InteractionID: "int-bare"}
+	})
+	if _, err := env.runStore(t).AppendEvent(context.Background(), "run-bare", store.Event{
+		Type:      store.EventHumanInputRequested,
+		RunID:     "run-bare",
+		NodeID:    "gate",
+		Timestamp: time.Now().UTC(),
+		Data:      map[string]any{"interaction_id": "int-bare"},
+	}); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	card := findPipelineCard(t, env.projection(t).Cards, "run:run-bare")
+	if len(card.PendingReviews) != 1 {
+		t.Fatalf("pending_reviews = %+v", card.PendingReviews)
+	}
+	if got := card.PendingReviews[0].Instructions; got != "" {
+		t.Fatalf("instructions = %q, want empty", got)
+	}
+}

--- a/pkg/server/pipeline_boards_types.go
+++ b/pkg/server/pipeline_boards_types.go
@@ -42,6 +42,14 @@ type PipelineBoardPendingReview struct {
 	NodeID        string         `json:"node_id,omitempty"`
 	InteractionID string         `json:"interaction_id,omitempty"`
 	Questions     map[string]any `json:"questions,omitempty"`
+	// Instructions is the resolved `instructions:` prompt of the paused
+	// human node — the author's operator-facing question. Questions above
+	// carries the node's INBOUND data, which the schema-driven form does
+	// not render (it renders the node's output fields), so for any bot
+	// that puts its whole question in `instructions:` this string is the
+	// only readable content on the card. Empty when the node declares no
+	// instructions prompt.
+	Instructions string `json:"instructions,omitempty"`
 	// UpdatedAt is when this exact pending turn joined the operator queue.
 	// Review gates reuse their interaction ID across dialogue turns, so the
 	// timestamp also versions the form on the Studio side.

--- a/studio/src/api/pipelineBoards.ts
+++ b/studio/src/api/pipelineBoards.ts
@@ -26,6 +26,14 @@ export interface PipelineBoardPendingReview {
   node_id?: string;
   interaction_id?: string;
   questions?: Record<string, unknown>;
+  /**
+   * Resolved `instructions:` prompt of the paused human node — the author's
+   * operator-facing question. `questions` above is the node's INBOUND data,
+   * which the schema-driven form does not render (it renders the node's
+   * OUTPUT fields), so for a bot that puts its whole question in
+   * `instructions:` this is the only readable content on the card.
+   */
+  instructions?: string;
   /** When this exact pending turn joined the FIFO review queue. */
   updated_at: string;
   depth: number;
@@ -342,6 +350,9 @@ function normalizePendingReviews(
         ? { interaction_id: text(source.interaction_id) }
         : {}),
       ...(questions ? { questions } : {}),
+      ...(text(source.instructions)
+        ? { instructions: text(source.instructions) }
+        : {}),
       updated_at: text(source.updated_at) ?? "",
       depth: Math.max(0, intValue(source.depth, 0)),
     };

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -4680,6 +4680,7 @@ export interface components {
         PipelineBoardPendingReview: {
             bot_id?: string;
             depth: number;
+            instructions?: string;
             interaction_id?: string;
             node_id?: string;
             questions?: {

--- a/studio/src/components/Runs/conversation/HumanPromptForm.test.tsx
+++ b/studio/src/components/Runs/conversation/HumanPromptForm.test.tsx
@@ -509,4 +509,52 @@ describe("HumanPromptForm — operator uploads at a gate", () => {
     const [, req] = resumeRun.mock.calls[0] as [string, Record<string, unknown>];
     expect("attachments" in req).toBe(false);
   });
+  // A board surface has no conversation around the form, so the paused
+  // node's `instructions:` text is the ONLY place the operator's question
+  // can appear: `questions` holds the node's INBOUND data and the
+  // schema-driven form renders its OUTPUT fields. Regression: an
+  // app-concept interview gate showed a bare "Message" box on the card
+  // while the run console rendered the full question.
+  it("renders the resolved instructions above the form", async () => {
+    getRunWorkflow.mockResolvedValue({
+      nodes: [{ id: "chat", output_schema: [{ name: "message", type: "string" }] }],
+      stale_hash: false,
+    });
+
+    renderWithClient(
+      <HumanPromptForm
+        runId="run-1"
+        nodeId="chat"
+        questions={{ reply: "inbound data the form never renders" }}
+        instructions={"Which scope do you want?\n\n- **A** narrow\n- **B** broad"}
+        sourceOverride={null}
+      />,
+    );
+
+    // findByText throws when absent, so reaching the assertion is the
+    // proof; the tag check pins that markdown rendered (a list item),
+    // not a raw string dumped into a paragraph.
+    const heading = await screen.findByText(/Which scope do you want\?/);
+    expect(heading).toBeTruthy();
+    expect(screen.getByText("narrow").closest("li")).toBeTruthy();
+  });
+
+  it("renders no instructions block when the node declares none", async () => {
+    getRunWorkflow.mockResolvedValue({
+      nodes: [{ id: "chat", output_schema: [{ name: "message", type: "string" }] }],
+      stale_hash: false,
+    });
+
+    const { container } = renderWithClient(
+      <HumanPromptForm
+        runId="run-1"
+        nodeId="chat"
+        questions={{ reply: "inbound only" }}
+        sourceOverride={null}
+      />,
+    );
+
+    await screen.findByRole("textbox");
+    expect(container.textContent).not.toContain("inbound only");
+  });
 });

--- a/studio/src/components/Runs/conversation/HumanPromptForm.tsx
+++ b/studio/src/components/Runs/conversation/HumanPromptForm.tsx
@@ -27,12 +27,20 @@ import { useRunStore } from "@/store/run";
 
 import PauseForm from "../PauseForm";
 import GateAttachments from "./GateAttachments";
+import MarkdownText from "./MarkdownText";
 import type { GateFileValue } from "@/components/shared/GateFileInput";
 
 interface Props {
   runId: string;
   nodeId: string;
   questions: Record<string, unknown>;
+  // Resolved `instructions:` text of the paused node — the author's
+  // operator-facing question, rendered as markdown above the form.
+  // The run console omits it because HumanQuestionCard already renders
+  // the same text as the turn's prompt; board surfaces, which have no
+  // conversation around the form, pass it so the operator sees what
+  // they are answering instead of a bare input.
+  instructions?: string;
   // Quick-action chips (skip / idk) the operator can pick instead of
   // typing a reply. Only meaningful on free-text-only turns. Default
   // = ["skip", "idk"]; pass empty to suppress.
@@ -77,6 +85,7 @@ export default function HumanPromptForm({
   runId,
   nodeId,
   questions,
+  instructions,
   quickActions = ["skip", "idk"],
   sourceOverride,
   onResumed,
@@ -386,6 +395,11 @@ export default function HumanPromptForm({
 
   return (
     <div className="space-y-2">
+      {instructions && (
+        <div className="text-body text-fg-default">
+          <MarkdownText value={instructions} size="sm" />
+        </div>
+      )}
       {staleHash && (
         <div className="text-caption text-warning-fg" role="status">
           The workflow source changed since this run started. Submit will still

--- a/studio/src/views/PipelineBoard/SequentialReviews.tsx
+++ b/studio/src/views/PipelineBoard/SequentialReviews.tsx
@@ -123,6 +123,7 @@ export function SequentialReviews({ card, onResolved }: Props) {
           runId={review.run_id}
           nodeId={review.node_id}
           questions={review.questions ?? {}}
+          instructions={review.instructions}
           sourceOverride={null}
           onResumed={handleResolved}
         />


### PR DESCRIPTION
## The bug

A board review card renders an answer box with **no question above it** — "Awaiting input", a run link, and an empty `Message` field. Observed on an app-concept interview gate: four parallel interviews paused, each with a full question, and the card showed nothing to answer.

## Why

The text was never lost — the projection already ships it inside `questions`:

```
cards.pending_reviews.questions: {'quick_replies': [...],
                                  'reply': "Salut 👋 Je cadre avec toi le **produit**…"}
```

But `HumanPromptForm` renders the paused node's **output** schema fields, while `questions` holds its **inbound** edge data. For a bot whose entire operator-facing prompt lives in `instructions:` — `prompt chat_instructions: {{input.reply}}` — the form has nothing to display. `formSpecFromSchema`'s description fallback (`questions[field.name]`) doesn't rescue it either: the output field is `message`, the context key is `reply`, no name match.

The run console doesn't show the defect because `HumanQuestionCard` renders the same text as the turn's prompt above the form. Board surfaces have no conversation around the form.

## The fix

The resolved instructions ride **only** on the `human_input_requested` event (`doPause` folds `humanInstructionsExtra` into the event data). Neither the checkpoint nor the interaction record keeps them, so the projection reads them back from the event log:

- `pendingReviewInstructions()` returns the **last** matching event for the run/node pair, preferring the checkpoint's interaction id and falling back to the node id. A review gate that resumes and re-pauses emits one event per turn — the operator must see the current one.
- Reading the event log rather than adding a write-path field means **already-paused runs render correctly**, with no need to wait for a fresh pause.
- `HumanPromptForm` gains an optional `instructions` prop rendered as markdown above the form. The run console keeps omitting it so the prompt isn't duplicated; `SequentialReviews` passes it.

## Tests

Both regression tests were verified to **fail without the fix** — Go reports `instructions = "", want the current turn's resolved prompt`, and the studio test finds no rendered prompt. Go coverage also pins the current-turn-wins rule, neighbouring-node isolation, and the empty result for a node declaring no prompt.

`go build ./...` clean, `go vet` clean, the whole `pkg/server` package green (3 consecutive runs), 21 studio tests green, `tsc` and `eslint` clean on the touched files. `openapi.json` / `schema.ts` regenerated — the diff is 4 lines, the new field only.

## Known gap

The native board's issue modal (`LastRunSection`) shares the defect and is **not** covered here: it builds on `getRun()`, whose response carries neither events nor instructions. Closing it needs either an extended run-detail API or persisting the text at pause time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
