### PR TITLE
docs(bot-runs): the two bilans of the merge-gate work

### DIFF
--- a/docs/bot-runs/dep-update-guard.md
+++ b/docs/bot-runs/dep-update-guard.md
@@ -7,6 +7,90 @@ commit onto the PR branch, post the verdict comment. Never merges past a
 check — and only ever the commit it audited. See
 [bots/dep-update-guard/](../../bots/dep-update-guard/).
 
+## 2026-07-31 — v2.5.0 on three heritage PRs, and the rebase that would have stalled every one of them
+
+- Status: **validated, with one real gap found and closed.** Two of three PRs
+  audited and merged by the bot; the third armed and is waiting on a rebase.
+- Versions: bot 2.5.0 (first live runs of this version) · iterion
+  `v3.17.1+d337007d1`, runner `sha256:9c7203cc`
+- Method: `/vetty` on the three heritage PRs of `SocialGouv/buildkit-operator`
+  — those opened under the OLD `github-actions[bot]` identity, before the
+  dedicated Renovate App. #6 alone first (run `019fb413`), then #4 and #7
+  together (`019fb6a0-7d9e` / `019fb6a0-77d9`).
+- Result: #6 audited in 16m20s and **merged by the forge App at 17:46:27Z**,
+  two seconds before the run ended, on the sha it audited (`ef333c66`). #4
+  merged at 05:38:35Z. #7 posted `SAFE`, armed auto-merge (SQUASH, 05:37:59Z)
+  and is not merged — see below.
+- Cost: **~$1 per PR audited** ($1.31 for #6, $1.93 for the pair). Cheap enough
+  that auditing on every dependency PR is not a budget question.
+
+### Why they needed Vetty at all, having already been reviewed
+
+All four heritage PRs carried `iterion/review=SUCCESS` — from **Revi**, a code
+reviewer, reached by a maintainer's `/revi`. That is not the same question.
+Revi reads a diff; Vetty asks whether the artifact on the other end of a
+version bump is what it claims to be. Merging on Revi's verdict would have
+skipped the supply-chain control this whole chain exists for, while looking
+fully green.
+
+### The audit is real, not a shape
+
+For jq 1.8.1 → 1.8.2, Vetty established that the upstream release exists
+(`jqlang/jq` tag `jq-1.8.2`, non-draft), that it was cut by the **same**
+automation as 1.8.0 and 1.8.1 — no unexpected-author or compromised-maintainer
+signal — that the locked nixpkgs commit exists, that its commit date matches
+the lock's `last_modified` byte for byte, and that its `package.nix` declares
+`version = "1.8.2"`. For helm 4.2.1 → 4.2.3: the derivation at commit
+`7525d999` declares `4.2.3`, builds `helm/helm` at tag `v4.2.3` with a pinned
+source hash, and the upstream delta is exactly 2 commits / 3 files matching the
+release notes verbatim.
+
+It also answered, with evidence, the open question Revi had left that morning
+on #6 about whether `devbox.lock` came from a real nix resolution.
+
+### The gap: a rebase silently ends the loop
+
+`review_on_sync` was **off** on the integration, and Vetty's invocation is
+`actions: [opened, reopened]`. So:
+
+1. Renovate rebases a PR — routine, it happens whenever the base moves;
+2. new head sha, and no bot relaunches ([webhooks_github.go](../../pkg/server/webhooks_github.go)
+   filters a `synchronize` when `ReviewOnSync` is false);
+3. `iterion/review` is **required** and is posted on the old sha;
+4. the armed auto-merge can therefore never fire, and nothing says so.
+
+Every Renovate PR that needs a rebase before it merges lands in this. The one
+proven run (#15, 2026-07-29) merged before its base moved, which is why it was
+never hit. #5 and #7 are sitting in it right now.
+
+Fixed by enabling `review_on_sync` on the integration — the pairing
+[CLAUDE.md](../../CLAUDE.md) already prescribes for a required gate. Worth
+knowing: `BotRule.Actions` is deliberately *recorded but not enforced*, with
+`"synchronize" for the merge gate` named in its doc comment as the reason, so
+the handler's reviewability gate stays authoritative and this wiring works.
+
+### Second observation: a batch of PRs touching one lock file serializes badly
+
+The three PRs all bumped `devbox.json` + `devbox.lock`. #6 and #4 merged; #7
+was audited and armed, then turned `CONFLICTING` because the two merges landed
+under it. Vetty was right — it armed rather than forcing a merge — but the
+outcome is a PR that now needs a Renovate rebase to move, and (before the fix
+above) would have waited forever for it.
+
+### Lessons for next run
+
+1. **Reviewed is not audited.** A dependency PR carrying a green review from a
+   code reviewer has answered a different question. Do not let a shared gate
+   context blur the two.
+2. **Arming auto-merge is a weaker guarantee than merging.** The `merge_now`
+   path pins `expectedHeadOid` to the audited sha; `enablePullRequestAutoMerge`
+   pins nothing, so GitHub would merge whatever the head becomes. What restores
+   the guarantee is the *required* gate — provided it re-lands on each new
+   head, which is precisely what `review_on_sync` buys. The two settings are
+   one mechanism, not two options.
+3. A batch of dependency PRs touching the same lock file will conflict with
+   each other. Expect the tail of a batch to need a rebase round.
+
 ## 2026-07-29 — v2.4.0: the loop closed — Renovate → audit → gate → merge, unattended (run 019faef9)
 
 - Status: **VALIDATED** — the first dependency PR to travel the whole chain

--- a/docs/bot-runs/review-pr.md
+++ b/docs/bot-runs/review-pr.md
@@ -6,6 +6,82 @@ finding is published to the native board (label `source:revi`); with `--var
 pr_url` it also posts an inline forge review. Never edits or commits. See
 [bots/review-pr/](../../bots/review-pr/).
 
+## 2026-07-30 — Revi had stopped publishing on every repo, and finished green doing it
+
+- Status: **defect found and fixed** — the runs were fine, the publishing step
+  was dead. Found while wiring `iterion/review` as a required check, which is
+  the only reason it surfaced at all.
+- Versions: bot review-pr 0.5.6 · iterion `main` @ `7b87b5f37` + `34bd00879`
+- Method: `/revi` on buildkit-operator #4 (run `019fb403-530a`, 2m42s) and #7
+  (`019fb403-5f28`, 3m39s), plus the iterion PRs of the day (#323 →
+  `019fb408`, ~12min). Cloud prod, mono topology.
+- Result: after the fix, all three posted their review **and** their commit
+  status. Before it, every one of them finished `finished` having posted
+  nothing. Verbatim from #323 — both fixes visible in one line:
+
+  > ## Code review by Revi (iterion)
+  > 4 finding(s) kept after threshold/cap. — medium: 2, low: 2
+  > Reviewed by a single model family (mono topology): no finding is
+  > cross-confirmed, and none is meant to be.
+
+  with `revi/review=SUCCESS` on the head.
+
+### The defect: a template that never resolved
+
+`publish_review` built its guard input as `REVIEWED_SHA={{outputs.…}}` inside a
+tool node's `command:`. That body is resolved by
+[resolveCommandTemplate](../../pkg/backend/model/executor_tool.go), which
+substitutes `{{input.X}}`, `{{vars.X}}`, `{{secrets.X}}` and `{{run.id}}` —
+**`{{outputs.…}}` resolves only in edge mappings**. Written in a body it
+survives as literal text.
+
+So the stale-anchor guard compared the literal string `{{outputs.…}}` to the
+PR's head sha, concluded the anchors were stale, and skipped the whole publish:
+review, inline comments, and gate status. No error anywhere — the node
+succeeded, the run finished, and the PR simply never heard from Revi. This had
+been true **repo-wide**, on every review, for as long as the guard existed.
+
+Had the required check been switched on before this was found, it would have
+blocked every pull request on the repo — an outage caused by a check that was
+never posted, on runs reporting success.
+
+### Second defect on the same path: the guard took the gate down with it
+
+Even a *genuinely* stale anchor set skipped the entire publish. But a stale
+inline anchor only means the line numbers moved — it says nothing about the
+verdict. Dropping the gate along with the comments turns a cosmetic problem
+into a permanently absent required check. `stale_anchors` now drops the inline
+comments and **keeps publishing** the summary and the status.
+
+### Third: mono claimed a cross-family confirmation that never happened
+
+The summary printed `N finding(s) cross-confirmed by both model families` even
+in mono topology, where one family ran. Spotted by jo on the real comment on
+buildkit-operator #6 — the reviewer was describing a corroboration it had no
+way to perform. Mono now says so in as many words.
+
+### Guards added
+
+- `bots/catalog_command_refs_test.go` — catalog-wide: **no** `{{outputs.…}}` in
+  any tool `command:`/`script:`/`postcondition:`, walking every `.bot`. The
+  class, not the instance: the same silent no-op was available to every bot in
+  the catalog.
+- `bots/review_pr_stale_anchor_test.go` — drives the real publish body against
+  a stub, shell-quoting substitutions the way the engine does, so the guard is
+  exercised on the code that ships rather than on a paraphrase of it.
+
+### Lessons for next run
+
+1. **`{{outputs.…}}` in a command body is a silent no-op**, not an error. Any
+   comparison against one is a comparison against a constant string — it will
+   take whichever branch that constant happens to select, forever.
+2. **A guard that suppresses output must never suppress the verdict.** Degrade
+   the part that is unsafe (the anchors), keep the part a required check
+   depends on.
+3. A bot that publishes nothing looks exactly like a bot with nothing to say.
+   Neither the run status, nor the logs, nor a green test suite distinguished
+   them here — making the check *required* is what finally did.
+
 ## 2026-07-08 — GitHub PR webhook e2e on iterion cloud prod
 
 - Status: **validated — full end-to-end via the inbound webhook.**


### PR DESCRIPTION
Two dated bilans for runs that are otherwise unrecoverable — the artifacts under `.iterion/runs/` are gitignored.

**Revi** — the publish step had been dead repo-wide. `REVIEWED_SHA={{outputs.…}}` in a tool node's `command:` never resolves (that body only substitutes input/vars/secrets/run), so the stale-anchor guard compared a literal template string to the head sha, concluded "stale", and skipped the review, the inline comments and the gate status. Every run finished green having posted nothing. Records the two companion defects and the catalog-wide lint added for the class.

**Vetty** — three heritage PRs on `buildkit-operator`, each already carrying a green `iterion/review` from Revi, which answers a different question than a supply-chain audit. Two audited and merged by the bot at ~$1 each. The runs exposed that with `review_on_sync` off, a Renovate rebase produces a head no bot reviews, so the required gate is absent there and the armed auto-merge can never fire — silently, on every PR needing a rebase. Also notes that `enablePullRequestAutoMerge` pins no sha, so the "merge only what was audited" guarantee on that path rests entirely on a required gate that re-lands on each head.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)