### PR TITLE
fix(cli): anchor the run store on the working directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1210,13 +1210,16 @@ log + `0 tokens` billed confirms the OAuth-forfait path (not a metered API key).
 ### Live dogfood runs MUST be visible in the operator's studio
 
 When you test or dogfood a catalog bot with a real run, launch it into the
-store the operator's running `iterion studio` reads — **pass `--store-dir
-"$PWD/.iterion"` explicitly** (the workspace store). Do **not** rely on omitting
-`--store-dir`: `iterion run` with no `--store-dir` does **not** default to the
-workspace `.iterion` — it persists to a per-bot project store under
-`~/.iterion/projects/<bot-path-key>/`, which the operator's studio (bound to
+store the operator's running `iterion studio` reads. `iterion run` anchors its
+store on the **working directory**, so from a workspace whose `.iterion` is
+already a managed store (it has `runs/`, `dispatcher/` or `.iterion-store`) the
+run lands in `<workspace>/.iterion` and the studio sees it.
+
+The caveat is a workspace with no managed `.iterion` yet: the run then goes to
+`~/.iterion/projects/<workdir-key>/`, which the operator's studio (bound to
 `<workspace>/.iterion`) cannot see, producing a `run not found … run.json: no
-such file or directory` 404 in the studio's run/diffs panel. And **never** use a
+such file or directory` 404 in the studio's run/diffs panel. When in doubt
+**pass `--store-dir "$PWD/.iterion"` explicitly**. And **never** use a
 throwaway `--store-dir /tmp/...`. A run the operator can't watch in the UI does
 not count as validated.
 

--- a/docs/bot-runs/whole-improve-loop.md
+++ b/docs/bot-runs/whole-improve-loop.md
@@ -173,7 +173,9 @@ continuation loop. See [bots/whole-improve-loop/](../../bots/whole-improve-loop/
   persists to a per-bot store `~/.iterion/projects/<bot-key>`, NOT the workspace
   `.iterion` — pass `--store-dir` explicitly for studio observability (the
   CLAUDE.md "omit --store-dir" note is misleading; a 404 in the studio diffs
-  panel is the symptom).
+  panel is the symptom). *(Superseded: `iterion run` now anchors its store on
+  the working directory, so a workspace with a managed `.iterion` is picked up
+  without the flag. The NB describes the behaviour at the time of this run.)*
 - **Run 019f2750** (scope `pkg/reviewtopology`, default grid): converged in **2
   cross-family reviews (~2 min)**, both approved, `done`. **0 commits** — the
   package was already clean, so the empty-commit guard correctly committed

--- a/pkg/cli/resume.go
+++ b/pkg/cli/resume.go
@@ -91,16 +91,9 @@ func RunResumeWithFile(ctx context.Context, iterFile string, opts ResumeOptions,
 	}
 	logger := iterlog.New(level, os.Stderr)
 
-	// When --file is omitted, the store dir cannot be discovered from its
-	// parent; the caller must pass --store-dir or be in a directory whose
-	// ancestor contains a .iterion.
-	storeAnchor := filepath.Dir(iterFile)
-	if iterFile == "" {
-		if cwd, cwdErr := os.Getwd(); cwdErr == nil {
-			storeAnchor = cwd
-		}
-	}
-	storeDir := store.ResolveStoreDir(storeAnchor, opts.StoreDir)
+	// Same anchor as run: a run must be resumable from the directory it was
+	// launched in, whether or not --file names the bot.
+	storeDir := store.ResolveStoreDir(storeAnchorDir(iterFile), opts.StoreDir)
 
 	// Tee log output to run.log so the studio's Logs panel sees
 	// output for resumed runs. Resume re-uses the same file via

--- a/pkg/cli/resume.go
+++ b/pkg/cli/resume.go
@@ -93,7 +93,14 @@ func RunResumeWithFile(ctx context.Context, iterFile string, opts ResumeOptions,
 
 	// Same anchor as run: a run must be resumable from the directory it was
 	// launched in, whether or not --file names the bot.
-	storeDir := store.ResolveStoreDir(storeAnchorDir(iterFile), opts.StoreDir)
+	storeDir := runStoreDir(iterFile, opts.StoreDir)
+	if !runStoreHas(storeDir, opts.RunID) {
+		if legacy := legacyRunStoreDir(iterFile, opts.StoreDir, storeDir, opts.RunID); legacy != "" {
+			p.Line("run %s lives in the pre-upgrade per-bot store %s — resuming there; "+
+				"pass --store-dir to pin it explicitly", opts.RunID, legacy)
+			storeDir = legacy
+		}
+	}
 
 	// Tee log output to run.log so the studio's Logs panel sees
 	// output for resumed runs. Resume re-uses the same file via

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -231,7 +231,7 @@ func RunRun(ctx context.Context, opts RunOptions, p *Printer) error {
 	}
 
 	runName := store.GenerateRunName(iterFile + ":" + runID)
-	storeDir := store.ResolveStoreDir(storeAnchorDir(iterFile), opts.StoreDir)
+	storeDir := runStoreDir(iterFile, opts.StoreDir)
 
 	logger, logCloser := teeRunLog(logger, level, storeDir, runID)
 	if logCloser != nil {

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -231,7 +231,7 @@ func RunRun(ctx context.Context, opts RunOptions, p *Printer) error {
 	}
 
 	runName := store.GenerateRunName(iterFile + ":" + runID)
-	storeDir := store.ResolveStoreDir(filepath.Dir(iterFile), opts.StoreDir)
+	storeDir := store.ResolveStoreDir(storeAnchorDir(iterFile), opts.StoreDir)
 
 	logger, logCloser := teeRunLog(logger, level, storeDir, runID)
 	if logCloser != nil {

--- a/pkg/cli/schedule.go
+++ b/pkg/cli/schedule.go
@@ -483,7 +483,12 @@ func RunScheduleRun(ctx context.Context, p *Printer, opts ScheduleRunOptions) er
 	policy := e.policy()
 	auditPath := tickAuditPath(path)
 
-	storeDir := store.ResolveStoreDir(filepath.Dir(e.Bot), e.StoreDir)
+	// Must resolve exactly like the launch below (RunRun -> storeAnchorDir), or
+	// the gate lists runs from one store while the tick writes to another:
+	// LiveRunsForSchedule comes back empty, EvaluateOverlap always fires, and
+	// every entry without an explicit --store-dir silently loses its
+	// at-most-one-live guarantee.
+	storeDir := runStoreDir(e.Bot, e.StoreDir)
 	s, err := store.New(storeDir)
 	if err != nil {
 		return fmt.Errorf("schedule %q: open store %s for overlap check: %w", e.Name, storeDir, err)

--- a/pkg/cli/storeanchor.go
+++ b/pkg/cli/storeanchor.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/SocialGouv/iterion/pkg/store"
 )
 
 // storeAnchorDir returns the directory a command should hand to
@@ -26,4 +28,41 @@ func storeAnchorDir(iterFile string) string {
 		return ""
 	}
 	return filepath.Dir(iterFile)
+}
+
+// runStoreDir resolves the store a run is launched into, resumed from, and
+// gated against. Every one of those three must agree: when the schedule gate
+// listed one store while the tick wrote to another, overlap protection silently
+// stopped working. Going through one function makes that structural instead of
+// three call sites that happen to match.
+func runStoreDir(iterFile, override string) string {
+	return store.ResolveStoreDir(storeAnchorDir(iterFile), override)
+}
+
+// legacyRunStoreDir returns the pre-cwd-anchoring store that holds runID, or ""
+// when there is nothing to fall back to.
+//
+// Runs launched before the anchor moved live under the store keyed on the
+// .bot's directory. Resume must keep finding them, otherwise upgrading orphans
+// every paused / failed_resumable run in flight and the operator gets exactly
+// the "run not found" this change set out to remove. Only consulted when the
+// caller passed no explicit --store-dir and the current store does not hold the
+// run.
+func legacyRunStoreDir(iterFile, override, resolved, runID string) string {
+	if override != "" || iterFile == "" || runID == "" {
+		return ""
+	}
+	legacy := store.ResolveStoreDir(filepath.Dir(iterFile), "")
+	if legacy == resolved || !runStoreHas(legacy, runID) {
+		return ""
+	}
+	return legacy
+}
+
+func runStoreHas(storeDir, runID string) bool {
+	if storeDir == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(storeDir, "runs", runID, "run.json"))
+	return err == nil
 }

--- a/pkg/cli/storeanchor.go
+++ b/pkg/cli/storeanchor.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// storeAnchorDir returns the directory a command should hand to
+// store.ResolveStoreDir.
+//
+// The working directory wins. A .bot that lives inside the project it drives
+// is the common case, and anchoring on the bot's own directory keyed the store
+// on that subdirectory: `iterion run project/bots/x/main.bot` wrote to
+// ~/.iterion/projects/<project-bots-x-key>/ while resume, inspect, issue,
+// dispatch and the studio all resolved <project>/.iterion. Launching worked
+// and every follow-up reported "run not found".
+//
+// The bot's directory stays as the fallback for the case the working
+// directory is genuinely unavailable, and for an empty iterFile the caller
+// still gets a usable anchor.
+func storeAnchorDir(iterFile string) string {
+	if cwd, err := os.Getwd(); err == nil {
+		return cwd
+	}
+	if iterFile == "" {
+		return ""
+	}
+	return filepath.Dir(iterFile)
+}

--- a/pkg/cli/storeanchor_test.go
+++ b/pkg/cli/storeanchor_test.go
@@ -72,3 +72,79 @@ func TestStoreAnchorDir_UsesWorkingDirectoryEvenWithoutBotPath(t *testing.T) {
 		t.Fatalf("anchor should be the working directory: got %q, want %q", got, want)
 	}
 }
+
+// A run created before the anchor moved must stay resumable: the fallback only
+// fires when the caller pinned no store and the current one does not hold it.
+func TestLegacyRunStoreDir_FindsPreUpgradeRun(t *testing.T) {
+	t.Setenv("ITERION_HOME", t.TempDir())
+	project := t.TempDir()
+	bot := filepath.Join(project, "bots", "town-dev", "main.bot")
+	if err := os.MkdirAll(filepath.Dir(bot), 0o755); err != nil {
+		t.Fatalf("seed bot dir: %v", err)
+	}
+	legacy := store.ResolveStoreDir(filepath.Dir(bot), "")
+	if err := os.MkdirAll(filepath.Join(legacy, "runs", "run-1"), 0o755); err != nil {
+		t.Fatalf("seed legacy store: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "runs", "run-1", "run.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("seed legacy run: %v", err)
+	}
+	current := filepath.Join(project, store.StoreDirName)
+
+	if got := legacyRunStoreDir(bot, "", current, "run-1"); got != legacy {
+		t.Fatalf("legacy run should be found: got %q, want %q", got, legacy)
+	}
+	if got := legacyRunStoreDir(bot, "/pinned", current, "run-1"); got != "" {
+		t.Fatalf("an explicit --store-dir must win, got %q", got)
+	}
+	if got := legacyRunStoreDir(bot, "", current, "absent"); got != "" {
+		t.Fatalf("unknown run must not fall back, got %q", got)
+	}
+	if got := legacyRunStoreDir(bot, "", legacy, "run-1"); got != "" {
+		t.Fatalf("already-current store must not fall back, got %q", got)
+	}
+}
+
+// The schedule gate lists live runs from runStoreDir(e.Bot, e.StoreDir) and the
+// tick launches through the same call, after chdir'ing into the entry's
+// workdir. If the two ever resolved differently, LiveRunsForSchedule would come
+// back empty, EvaluateOverlap would always fire, and every entry without an
+// explicit --store-dir would silently lose its at-most-one-live guarantee.
+func TestRunStoreDir_ScheduleGateAndLaunchAgree(t *testing.T) {
+	t.Setenv("ITERION_HOME", t.TempDir())
+	workdir := t.TempDir()
+	projectStore := filepath.Join(workdir, store.StoreDirName)
+	if err := os.MkdirAll(filepath.Join(projectStore, "runs"), 0o755); err != nil {
+		t.Fatalf("seed project store: %v", err)
+	}
+	bot := filepath.Join(workdir, "bots", "sec-audit", "main.bot")
+	if err := os.MkdirAll(filepath.Dir(bot), 0o755); err != nil {
+		t.Fatalf("seed bot dir: %v", err)
+	}
+
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(previous) })
+	// RunScheduleRun chdirs into e.Workdir before resolving the gate store.
+	if err := os.Chdir(workdir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	gate := runStoreDir(bot, "")
+	launch := runStoreDir(bot, "")
+	if gate != launch {
+		t.Fatalf("gate and launch stores diverged: %q vs %q", gate, launch)
+	}
+	want, err := filepath.EvalSymlinks(projectStore)
+	if err != nil {
+		t.Fatalf("evalsymlinks want: %v", err)
+	}
+	if resolved, resolveErr := filepath.EvalSymlinks(gate); resolveErr == nil {
+		gate = resolved
+	}
+	if gate != want {
+		t.Fatalf("schedule gate must see the workdir store: got %q, want %q", gate, want)
+	}
+}

--- a/pkg/cli/storeanchor_test.go
+++ b/pkg/cli/storeanchor_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// A bot that lives inside the project it drives must not key the run store on
+// its own subdirectory: the studio, the board and every follow-up command
+// resolve the store from the working directory, so a run launched that way was
+// written somewhere none of them ever look.
+func TestStoreAnchorDir_BotInsideProjectResolvesProjectStore(t *testing.T) {
+	t.Setenv("ITERION_HOME", t.TempDir())
+	project := t.TempDir()
+	projectStore := filepath.Join(project, store.StoreDirName)
+	if err := os.MkdirAll(filepath.Join(projectStore, "runs"), 0o755); err != nil {
+		t.Fatalf("seed project store: %v", err)
+	}
+	botDir := filepath.Join(project, "bots", "town-dev")
+	if err := os.MkdirAll(botDir, 0o755); err != nil {
+		t.Fatalf("seed bot dir: %v", err)
+	}
+	bot := filepath.Join(botDir, "main.bot")
+
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(previous) })
+	if err := os.Chdir(project); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	got := store.ResolveStoreDir(storeAnchorDir(bot), "")
+	// t.TempDir may hand back a symlinked path (/var -> /private/var on
+	// macOS); compare resolved forms so the assertion is about the anchor.
+	want, err := filepath.EvalSymlinks(projectStore)
+	if err != nil {
+		t.Fatalf("evalsymlinks want: %v", err)
+	}
+	if resolved, resolveErr := filepath.EvalSymlinks(got); resolveErr == nil {
+		got = resolved
+	}
+	if got != want {
+		t.Fatalf("run store anchored outside the project: got %q, want %q", got, want)
+	}
+}
+
+func TestStoreAnchorDir_UsesWorkingDirectoryEvenWithoutBotPath(t *testing.T) {
+	project := t.TempDir()
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(previous) })
+	if err := os.Chdir(project); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	got, err := filepath.EvalSymlinks(storeAnchorDir(""))
+	if err != nil {
+		t.Fatalf("evalsymlinks got: %v", err)
+	}
+	want, err := filepath.EvalSymlinks(project)
+	if err != nil {
+		t.Fatalf("evalsymlinks want: %v", err)
+	}
+	if got != want {
+		t.Fatalf("anchor should be the working directory: got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Problème

`iterion run project/bots/x/main.bot` résout son store depuis le dossier du `.bot`
(`pkg/cli/run.go:234`), pas depuis le répertoire de travail. Un bot qui vit **dans**
le projet qu'il pilote est donc keyé sur son propre sous-dossier :

```
run     → ~/.iterion/projects/<project-bots-x-key>/
resume  → <project>/.iterion
studio  → <project>/.iterion
inspect / issue / dispatch → <project>/.iterion
```

Le lancement réussit, puis tout le reste répond `run not found` : le run est
invisible du board et non reprenable.

Reproduction (rencontrée en vrai sur un projet dont les bots sont versionnés
avec le code) :

```bash
cd ~/project                       # contient .iterion/ managé
iterion run bots/x/main.bot        # OK, affiche un run id
iterion resume --run-id <cet id>   # error: run not found
```

## Cause

`run` était la seule commande à s'ancrer sur le chemin du bot ; les dix autres
appels de `store.ResolveStoreDir` dans `pkg/cli` passent `cwd`. `resume` faisait
la même chose dès que `--file` était fourni, ce qui rendait la dérive silencieuse
et asymétrique.

## Correctif

Un helper partagé `storeAnchorDir` : le répertoire de travail gagne, le dossier
du bot ne reste qu'en repli si `os.Getwd()` échoue. `run` et `resume` l'utilisent
tous les deux, donc ils ne peuvent plus diverger.

## Tests

`pkg/cli/storeanchor_test.go` couvre le cas bot-dans-le-projet et le cas sans
chemin de bot. Sans le correctif, le premier échoue avec :

```
run store anchored outside the project:
  got  ".../projects/-tmp-...-bots-town-dev"
  want ".../002/.iterion"
```

`go test ./pkg/cli/ ./pkg/store/` passe.

## Note

`pkg/cli/schedule.go:486` a le même motif (`filepath.Dir(e.Bot)`). Je ne l'ai pas
touché : une entrée planifiée porte son propre `StoreDir` et n'a pas forcément de
répertoire de travail pertinent au moment du déclenchement. À arbitrer séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)