### PR TITLE
feat(studio): render a human gate's inbound payload so operators see what they are validating

### DIFF
--- a/docs/human-in-the-loop.md
+++ b/docs/human-in-the-loop.md
@@ -93,6 +93,14 @@ human approve_plan:
   output: approval_decision
 ```
 
+> **Adding `input:` to an existing gate is a compile-affecting change.**
+> Once a node declares an input schema, every `{{input.X}}` reference in
+> its prompts is checked against it — an `X` the schema does not declare
+> is a hard error (`C034`, *field not found in input schema*). So the
+> schema must enumerate **every** key the node's prompts interpolate, not
+> just the ones you want typed. Leaving `input:` off keeps the payload
+> rendering (inferred from each value's shape) with no such constraint.
+
 Two kinds of key are never repeated as review context:
 
 - **engine-owned plumbing** — queued operator messages, the permission

--- a/docs/human-in-the-loop.md
+++ b/docs/human-in-the-loop.md
@@ -93,9 +93,16 @@ human approve_plan:
   output: approval_decision
 ```
 
-Engine-owned keys (queued operator messages, the permission marker,
-ad-hoc attachments, the `ask_user` question itself) are plumbing and are
-never displayed as review context.
+Two kinds of key are never repeated as review context:
+
+- **engine-owned plumbing** — queued operator messages, the permission
+  marker, ad-hoc attachments, the `ask_user` question, the recovery
+  acknowledgement;
+- **anything the gate's `instructions:` prompt already interpolates.**
+  The engine substitutes `{{input.<key>}}` into the instructions markdown
+  shown right above, so a gate written the old way (Nexie's
+  `chat_instructions` is literally `{{input.reply}}`) shows that value
+  once, not twice.
 
 ## Try it — a minimal example
 

--- a/docs/human-in-the-loop.md
+++ b/docs/human-in-the-loop.md
@@ -47,6 +47,56 @@ a `string` as a free-text area:
 
 ![Human form — a string field rendered as a text area](images/studio/hitl-form-text.png)
 
+## What the operator is validating — the gate's inbound payload
+
+The output schema is the *answer*. What the gate **receives** is a
+separate thing: the engine resolves the node's incoming edges at pause
+time (`with { plan: "{{outputs.plan.body}}" }`) and persists the resolved
+map on the interaction. The studio renders it read-only above the form,
+under **"What you're reviewing"** — on the run console, the pipeline
+board, and the kanban card alike.
+
+```
+agent draft_plan:
+  output: plan_out
+
+human approve_plan:
+  instructions: approve_instructions
+  output: approval_decision
+
+workflow ship:
+  entry: draft_plan
+  draft_plan -> approve_plan with {
+    plan: "{{outputs.draft_plan.body}}",       ## → shown as markdown
+    findings: "{{outputs.draft_plan.report}}", ## → shown as folded JSON
+  }
+```
+
+This needs **no authoring change**: any gate that already maps data in
+gets it. Rendering follows the value's shape — prose as markdown,
+objects/arrays as collapsible pretty JSON, an operator upload as a real
+preview (image, audio, video) rather than a path.
+
+Declaring an `input:` schema on the gate is optional and only sharpens
+two things: the reading order (the author's field order wins over
+alphabetical), and the type when the shape is ambiguous — `json` for a
+payload that arrived as a JSON string, `file` for a bare path.
+
+```
+schema review_context:
+  plan: string
+  findings: json
+  mockup: file
+
+human approve_plan:
+  input: review_context        ## types the payload; never collected from the operator
+  output: approval_decision
+```
+
+Engine-owned keys (queued operator messages, the permission marker,
+ad-hoc attachments, the `ask_user` question itself) are plumbing and are
+never displayed as review context.
+
 ## Try it — a minimal example
 
 [`examples/human-in-the-loop.bot`](../examples/human-in-the-loop.bot) is

--- a/openapi.json
+++ b/openapi.json
@@ -1538,6 +1538,12 @@
             },
             "type": "array"
           },
+          "instruction_inputs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "isolated": {
             "type": "boolean"
           },

--- a/openapi.json
+++ b/openapi.json
@@ -1532,6 +1532,12 @@
           "id": {
             "type": "string"
           },
+          "input_schema": {
+            "items": {
+              "$ref": "#/components/schemas/WireSchemaField"
+            },
+            "type": "array"
+          },
           "isolated": {
             "type": "boolean"
           },

--- a/pkg/runview/workflow_export.go
+++ b/pkg/runview/workflow_export.go
@@ -3,6 +3,7 @@ package runview
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/SocialGouv/iterion/pkg/bundle"
@@ -48,10 +49,22 @@ type WireNode struct {
 	// instead of the author having to stringify it into `instructions:`.
 	// Absent when the node declares no input schema; the studio then
 	// falls back to inferring a renderer from each value's shape.
-	InputFields  []WireSchemaField `json:"input_schema,omitempty"`
-	OutputFields []WireSchemaField `json:"output_schema,omitempty"`
-	Source       string            `json:"source,omitempty"`
-	Isolated     bool              `json:"isolated,omitempty"`
+	InputFields []WireSchemaField `json:"input_schema,omitempty"`
+	// InstructionInputs names the inbound keys the HumanNode's
+	// `instructions:` prompt already interpolates (`{{input.<key>}}`,
+	// substituted by Engine.renderHumanInstructions against the very same
+	// resolved map). The studio skips them when rendering the inbound
+	// payload, so a gate whose instructions embed its input — the
+	// historical workaround, and still 13 gates across 8 shipped catalog
+	// bots — shows that value once, not twice.
+	//
+	// Wire-side rather than a text-containment check in the browser
+	// because the run console never receives the resolved instructions
+	// string, only the board does.
+	InstructionInputs []string          `json:"instruction_inputs,omitempty"`
+	OutputFields      []WireSchemaField `json:"output_schema,omitempty"`
+	Source            string            `json:"source,omitempty"`
+	Isolated          bool              `json:"isolated,omitempty"`
 }
 
 // WireSchemaField projects an ir.SchemaField as JSON. Type uses the
@@ -269,11 +282,49 @@ func projectNode(id string, n ir.Node, wf *ir.Workflow) WireNode {
 		}
 	case *ir.HumanNode:
 		out.InputFields = projectSchemaFields(v.InputSchema, wf)
+		out.InstructionInputs = projectInstructionInputs(v.Instructions, wf)
 		out.OutputFields = projectSchemaFields(v.OutputSchema, wf)
 	case *ir.SubbotNode:
 		out.Source = v.Source
 		out.Isolated = v.Isolated
 	}
+	return out
+}
+
+// projectInstructionInputs returns the sorted, de-duplicated top-level
+// `input.*` keys a human node's instructions prompt interpolates.
+//
+// Only the FIRST path segment matters: `{{input.plan.title}}` consumes
+// the `plan` item as far as the operator is concerned — the payload
+// renderer works per top-level key, not per leaf.
+//
+// Returns nil for an unset or unknown prompt name, which the studio
+// reads as "nothing already shown".
+func projectInstructionInputs(promptName string, wf *ir.Workflow) []string {
+	if promptName == "" || wf == nil {
+		return nil
+	}
+	p, ok := wf.Prompts[promptName]
+	if !ok || p == nil {
+		return nil
+	}
+	seen := make(map[string]bool)
+	out := make([]string, 0, len(p.TemplateRefs))
+	for _, ref := range p.TemplateRefs {
+		if ref == nil || ref.Kind != ir.RefInput || len(ref.Path) == 0 {
+			continue
+		}
+		key := ref.Path[0]
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, key)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	sort.Strings(out)
 	return out
 }
 

--- a/pkg/runview/workflow_export.go
+++ b/pkg/runview/workflow_export.go
@@ -34,15 +34,24 @@ type WireWorkflow struct {
 // are populated for subbot nodes — the child .bot path relative to the
 // parent file, and whether the child is workspace-isolated (parallel-safe).
 type WireNode struct {
-	ID              string            `json:"id"`
-	Kind            string            `json:"kind"`
-	Description     string            `json:"description,omitempty"`
-	Model           string            `json:"model,omitempty"`
-	Backend         string            `json:"backend,omitempty"`
-	ReasoningEffort string            `json:"reasoning_effort,omitempty"`
-	OutputFields    []WireSchemaField `json:"output_schema,omitempty"`
-	Source          string            `json:"source,omitempty"`
-	Isolated        bool              `json:"isolated,omitempty"`
+	ID              string `json:"id"`
+	Kind            string `json:"kind"`
+	Description     string `json:"description,omitempty"`
+	Model           string `json:"model,omitempty"`
+	Backend         string `json:"backend,omitempty"`
+	ReasoningEffort string `json:"reasoning_effort,omitempty"`
+	// InputFields is the HumanNode's declared `input_schema`, the TYPE
+	// of the payload the gate receives (Interaction.Questions carries
+	// the resolved values). The studio renders that payload above the
+	// answer form so the operator sees what they are validating —
+	// `json` fields as structured data, `file` fields as previews —
+	// instead of the author having to stringify it into `instructions:`.
+	// Absent when the node declares no input schema; the studio then
+	// falls back to inferring a renderer from each value's shape.
+	InputFields  []WireSchemaField `json:"input_schema,omitempty"`
+	OutputFields []WireSchemaField `json:"output_schema,omitempty"`
+	Source       string            `json:"source,omitempty"`
+	Isolated     bool              `json:"isolated,omitempty"`
 }
 
 // WireSchemaField projects an ir.SchemaField as JSON. Type uses the
@@ -234,8 +243,8 @@ const IRWorkflowEndpointPath = "/api/runs/{id}/workflow"
 // expansions become "" — the run console treats that as "fall back to
 // the registry default" via its capability prefetch.
 //
-// wf is needed to resolve HumanNode output_schema names against
-// wf.Schemas; pass nil when only LLM nodes are projected.
+// wf is needed to resolve HumanNode input_schema/output_schema names
+// against wf.Schemas; pass nil when only LLM nodes are projected.
 func projectNode(id string, n ir.Node, wf *ir.Workflow) WireNode {
 	out := WireNode{ID: id, Kind: n.NodeKind().String()}
 	// Every ir node embeds BaseNode, which promotes NodeDescription; the
@@ -259,6 +268,7 @@ func projectNode(id string, n ir.Node, wf *ir.Workflow) WireNode {
 			out.ReasoningEffort = ir.ResolveEffortLiteral(v.ReasoningEffort)
 		}
 	case *ir.HumanNode:
+		out.InputFields = projectSchemaFields(v.InputSchema, wf)
 		out.OutputFields = projectSchemaFields(v.OutputSchema, wf)
 	case *ir.SubbotNode:
 		out.Source = v.Source

--- a/pkg/runview/workflow_export_test.go
+++ b/pkg/runview/workflow_export_test.go
@@ -34,6 +34,105 @@ workflow parent:
   produce_episode -> done
 `
 
+// A human gate's declared `input:` schema must reach the wire alongside
+// its `output:` schema. The studio types the gate's INBOUND payload
+// (Interaction.Questions) with it — a `json` field renders as structured
+// data, a `file` field as a preview — so the operator sees what they are
+// validating instead of the author stringifying it into `instructions:`.
+const humanGateSchemaExportSrc = `
+schema draft_out:
+  plan: json
+  summary: string
+
+schema gate_in:
+  plan: json
+  summary: string
+  mockup: file
+
+schema gate_out:
+  approved: bool
+  notes: string
+
+prompt draft_system:
+  Draft the plan.
+
+agent draft:
+  system: draft_system
+  input: gate_in
+  output: draft_out
+
+human gate:
+  input: gate_in
+  output: gate_out
+  interaction: human
+
+workflow gated:
+  entry: draft
+  draft -> gate with {
+    plan: "{{outputs.draft.plan}}",
+    summary: "{{outputs.draft.summary}}",
+  }
+  gate -> done when approved
+  gate -> fail when not approved
+`
+
+func TestBuildWireWorkflow_HumanNodeInputSchemaProjection(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gated.bot")
+	if err := os.WriteFile(path, []byte(humanGateSchemaExportSrc), 0o644); err != nil {
+		t.Fatalf("write gated bot: %v", err)
+	}
+
+	wire, err := buildWireWorkflowFromRun(&store.Run{ID: "r1", FilePath: path}, nil)
+	if err != nil {
+		t.Fatalf("buildWireWorkflowFromRun: %v", err)
+	}
+
+	var gate, draft *WireNode
+	for i := range wire.Nodes {
+		switch wire.Nodes[i].ID {
+		case "gate":
+			gate = &wire.Nodes[i]
+		case "draft":
+			draft = &wire.Nodes[i]
+		}
+	}
+	if gate == nil {
+		t.Fatalf("human node missing from projection: %+v", wire.Nodes)
+	}
+
+	wantIn := map[string]string{"plan": "json", "summary": "string", "mockup": "file"}
+	if len(gate.InputFields) != len(wantIn) {
+		t.Fatalf("input_schema = %+v, want %d fields", gate.InputFields, len(wantIn))
+	}
+	for _, f := range gate.InputFields {
+		want, ok := wantIn[f.Name]
+		if !ok {
+			t.Errorf("unexpected input field %q", f.Name)
+			continue
+		}
+		if f.Type != want {
+			t.Errorf("input field %q type = %q, want %q", f.Name, f.Type, want)
+		}
+	}
+
+	// The output schema still projects — the answer form depends on it.
+	if len(gate.OutputFields) != 2 {
+		t.Errorf("output_schema = %+v, want 2 fields", gate.OutputFields)
+	}
+
+	// input_schema stays a human-node projection: an agent node declaring
+	// the very same schema as its INPUT must not gain the field (nothing
+	// renders a payload for a node that never pauses, and the wire stays
+	// as small as the canvas needs it).
+	if draft == nil {
+		t.Fatalf("agent node missing from projection: %+v", wire.Nodes)
+	}
+	if len(draft.InputFields) != 0 {
+		t.Errorf("agent node carries input_schema: %+v", draft.InputFields)
+	}
+}
+
 func TestBuildWireWorkflow_SubbotNodeProjection(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "parent.bot")

--- a/pkg/runview/workflow_export_test.go
+++ b/pkg/runview/workflow_export_test.go
@@ -53,15 +53,21 @@ schema gate_out:
   approved: bool
   notes: string
 
-prompt draft_system:
-  Draft the plan.
-
-agent draft:
-  system: draft_system
+## A tool node, not an agent: CI has no LLM credential, and an agent
+## without model/backend is a C018 compile error there.
+tool draft:
+  command: ` + "`printf '{\"plan\":{},\"summary\":\"s\"}'`" + `
   input: gate_in
   output: draft_out
 
+## Interpolates ONE of the three inbound keys — the historical
+## stringify-it-into-instructions workaround. That key must project as
+## already-shown so the studio does not render it a second time.
+prompt gate_instructions:
+  Approve the plan for {{input.summary}}?
+
 human gate:
+  instructions: gate_instructions
   input: gate_in
   output: gate_out
   interaction: human
@@ -119,6 +125,14 @@ func TestBuildWireWorkflow_HumanNodeInputSchemaProjection(t *testing.T) {
 	// The output schema still projects — the answer form depends on it.
 	if len(gate.OutputFields) != 2 {
 		t.Errorf("output_schema = %+v, want 2 fields", gate.OutputFields)
+	}
+
+	// The instructions prompt interpolates `summary` and nothing else, so
+	// exactly that key is reported as already-shown. Getting this wrong in
+	// either direction is a real defect: too few duplicates the value on
+	// screen, too many hides payload the operator must see.
+	if len(gate.InstructionInputs) != 1 || gate.InstructionInputs[0] != "summary" {
+		t.Errorf("instruction_inputs = %v, want [summary]", gate.InstructionInputs)
 	}
 
 	// input_schema stays a human-node projection: an agent node declaring

--- a/studio/src/api/runs/types.ts
+++ b/studio/src/api/runs/types.ts
@@ -562,6 +562,11 @@ export interface WireNode {
   // Absent when the node declares no input schema; the renderer then
   // infers from each value's shape.
   input_schema?: WireSchemaField[];
+  // Human-node only: the inbound keys the node's `instructions:` prompt
+  // already interpolates (`{{input.<key>}}`). Skipped when rendering the
+  // inbound payload so a gate that embeds its input in its instructions
+  // — the historical workaround — shows it once, not twice.
+  instruction_inputs?: string[];
   output_schema?: WireSchemaField[];
   // Subbot-only (contract C2): the child .bot file this node runs, and
   // whether the child executes in an isolated workspace. Both absent

--- a/studio/src/api/runs/types.ts
+++ b/studio/src/api/runs/types.ts
@@ -555,6 +555,13 @@ export interface WireNode {
   model?: string;
   backend?: string;
   reasoning_effort?: string;
+  // Human-node only: the gate's declared `input_schema`, i.e. the TYPE
+  // of the payload it receives (the values themselves ride the pause's
+  // `questions` map). Drives how the inbound payload is rendered above
+  // the answer form — `json` as structured data, `file` as a preview.
+  // Absent when the node declares no input schema; the renderer then
+  // infers from each value's shape.
+  input_schema?: WireSchemaField[];
   output_schema?: WireSchemaField[];
   // Subbot-only (contract C2): the child .bot file this node runs, and
   // whether the child executes in an isolated workspace. Both absent

--- a/studio/src/api/runs/uploads.ts
+++ b/studio/src/api/runs/uploads.ts
@@ -1,14 +1,48 @@
 // Extracted from api/runs.ts to keep that file focused.
 // Server info + attachment staging: getServerInfo for the BackendStatusPill /
-// LaunchView, uploadAttachment for the staged-upload XHR (with progress).
+// LaunchView, uploadAttachment for the staged-upload XHR (with progress),
+// and read-back of a promoted run attachment (gate payload previews).
 
 import type { ServerInfo, StagedUpload } from "../types";
-import { BASE_URL, request } from "./client";
+import { apiURL, BASE_URL, extractErrorMessage, request } from "./client";
 import type { UploadOptions } from "./types";
 
 /** GET /api/server/info — mode, version, upload limits. */
 export async function getServerInfo(): Promise<ServerInfo> {
   return request("/server/info");
+}
+
+/**
+ * URL of one promoted run attachment (GET /api/runs/{id}/attachments/{name}).
+ *
+ * Distinct from artifactFileURL: an attachment is addressed by its
+ * declared NAME, not by a workspace-relative path — the path a file
+ * descriptor carries points at the host (or the sandbox bind-mount) and
+ * is not reachable from a browser at all.
+ */
+export function attachmentURL(runId: string, name: string): string {
+  return apiURL(
+    `/runs/${encodeURIComponent(runId)}/attachments/${encodeURIComponent(name)}`,
+  );
+}
+
+/**
+ * Fetch an attachment's bytes through the auth-aware surface (cookies +
+ * Bearer), for inline preview. The server sends the sniffed MIME, which
+ * is authoritative over any client-side guess from the filename.
+ */
+export async function fetchAttachment(
+  runId: string,
+  name: string,
+): Promise<{ blob: Blob; contentType: string }> {
+  const res = await fetch(attachmentURL(runId, name), { credentials: "include" });
+  if (!res.ok) {
+    throw new Error(`API error ${res.status}: ${await extractErrorMessage(res)}`);
+  }
+  return {
+    blob: await res.blob(),
+    contentType: res.headers.get("Content-Type") ?? "application/octet-stream",
+  };
 }
 
 /**

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -4873,6 +4873,7 @@ export interface components {
             backend?: string;
             description?: string;
             id: string;
+            input_schema?: components["schemas"]["WireSchemaField"][];
             isolated?: boolean;
             kind: string;
             model?: string;

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -4874,6 +4874,7 @@ export interface components {
             description?: string;
             id: string;
             input_schema?: components["schemas"]["WireSchemaField"][];
+            instruction_inputs?: string[];
             isolated?: boolean;
             kind: string;
             model?: string;

--- a/studio/src/components/Runs/conversation/GateInboundFile.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundFile.tsx
@@ -1,0 +1,203 @@
+import { DownloadIcon, FileIcon } from "@radix-ui/react-icons";
+import { useEffect, useState } from "react";
+
+import { attachmentURL, fetchAttachment } from "@/api/runs";
+import { ImagePreviewDialog } from "@/views/PipelineBoard/ImagePreview";
+import { Spinner } from "@/components/ui";
+import { errorMessage } from "@/lib/errorHints";
+import { formatBytes } from "@/lib/format";
+import type { GateInboundFileRef } from "@/lib/gateInbound";
+
+interface Props {
+  runId: string;
+  file: GateInboundFileRef;
+}
+
+/**
+ * One `file`-typed value of a gate's inbound payload, rendered as media
+ * rather than as a path.
+ *
+ * The path a file descriptor carries is where the RUNNING NODES read the
+ * bytes — a host path, or the sandbox bind-mount path inside the
+ * container. Neither is reachable from a browser, so the only fetchable
+ * handle is the attachment NAME, served by
+ * `GET /api/runs/{id}/attachments/{name}`. A descriptor without one
+ * (a bare `--answer x=@file` path, an LLM-answered gate) degrades to the
+ * filename + path, which is still strictly more than the operator saw
+ * before — never a broken image.
+ */
+export default function GateInboundFile({ runId, file }: Props) {
+  const { blobURL, contentType, loading, error } = useAttachmentBlob(
+    runId,
+    file.attachment,
+  );
+  const [zoomed, setZoomed] = useState(false);
+  const label = file.filename || file.attachment || file.path || "file";
+  const mime = contentType || file.mime || "";
+
+  const meta = (
+    <span className="text-micro text-fg-subtle">
+      {label}
+      {file.size ? ` · ${formatBytes(file.size)}` : ""}
+      {mime ? ` · ${mime}` : ""}
+    </span>
+  );
+
+  if (!file.attachment) {
+    // Not fetchable — show what we know instead of a dead <img>.
+    return (
+      <div className="flex items-center gap-1.5 text-micro text-fg-muted">
+        <FileIcon className="shrink-0" />
+        <code className="truncate" title={file.path || label}>
+          {label}
+        </code>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-micro text-fg-subtle">
+        <Spinner /> Loading {label}…
+      </div>
+    );
+  }
+
+  if (error || !blobURL) {
+    return (
+      <div className="space-y-0.5">
+        <div className="text-micro text-danger-fg" role="alert">
+          Couldn't load {label}: {error ?? "no content"}
+        </div>
+        <a
+          href={attachmentURL(runId, file.attachment)}
+          download={label}
+          className="inline-flex items-center gap-1 text-micro text-accent-text hover:underline"
+        >
+          <DownloadIcon /> Download instead
+        </a>
+      </div>
+    );
+  }
+
+  if (mime.startsWith("image/")) {
+    return (
+      <div className="space-y-1">
+        <button
+          type="button"
+          onClick={() => setZoomed(true)}
+          className="block max-w-full rounded border border-border-subtle bg-surface-0 p-1 hover:border-border-strong"
+          title={`Open ${label}`}
+        >
+          <img src={blobURL} alt={label} className="max-h-64 max-w-full object-contain" />
+        </button>
+        {meta}
+        {zoomed && (
+          <ImagePreviewDialog
+            open
+            onOpenChange={(open) => {
+              if (!open) setZoomed(false);
+            }}
+            src={blobURL}
+            alt={label}
+            title={<span className="font-mono text-xs">{label}</span>}
+            description={meta}
+            downloadHref={attachmentURL(runId, file.attachment)}
+          />
+        )}
+      </div>
+    );
+  }
+
+  if (mime.startsWith("audio/")) {
+    return (
+      <div className="space-y-1">
+        <audio controls src={blobURL} className="w-full">
+          Your browser cannot play this audio file.
+        </audio>
+        {meta}
+      </div>
+    );
+  }
+
+  if (mime.startsWith("video/")) {
+    return (
+      <div className="space-y-1">
+        <video controls src={blobURL} className="max-h-64 max-w-full rounded">
+          Your browser cannot play this video file.
+        </video>
+        {meta}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <FileIcon className="shrink-0 text-fg-subtle" />
+      {meta}
+      <a
+        href={attachmentURL(runId, file.attachment)}
+        download={label}
+        className="inline-flex items-center gap-1 text-micro text-accent-text hover:underline"
+      >
+        <DownloadIcon /> Download
+      </a>
+    </div>
+  );
+}
+
+interface BlobState {
+  blobURL: string | null;
+  contentType: string;
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Fetch an attachment into an ObjectURL, revoking it on unmount.
+ *
+ * A gate can disappear mid-fetch (the operator advances to the next
+ * queued review, the run resumes), so the in-flight response is
+ * invalidated on cleanup — otherwise it commits state on a dead
+ * component and leaks an orphaned ObjectURL. Same discipline as
+ * usePreview.
+ *
+ * Callers must give the component a `key` derived from the attachment so
+ * a different file remounts it: the hook does not re-enter its loading
+ * state when `name` changes under a live instance.
+ */
+function useAttachmentBlob(runId: string, name: string | undefined): BlobState {
+  const [state, setState] = useState<BlobState>(() => ({
+    blobURL: null,
+    contentType: "",
+    loading: !!name,
+    error: null,
+  }));
+
+  useEffect(() => {
+    if (!name) return;
+    let cancelled = false;
+    let created: string | null = null;
+    fetchAttachment(runId, name)
+      .then(({ blob, contentType }) => {
+        if (cancelled) return;
+        created = URL.createObjectURL(blob);
+        setState({ blobURL: created, contentType, loading: false, error: null });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setState({
+          blobURL: null,
+          contentType: "",
+          loading: false,
+          error: errorMessage(err),
+        });
+      });
+    return () => {
+      cancelled = true;
+      if (created) URL.revokeObjectURL(created);
+    };
+  }, [runId, name]);
+
+  return state;
+}

--- a/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
@@ -81,16 +81,28 @@ describe("GateInboundPayload", () => {
     expect(screen.getByText(/"id": 19/)).toBeTruthy();
   });
 
-  it("skips keys the instructions prompt already interpolates", () => {
+  it("skips a key whose value the rendered instructions already show", () => {
     render(
       <GateInboundPayload
         runId="run-1"
         questions={{ reply: "the whole answer, already on screen", plan: "the plan" }}
         instructionInputs={["reply"]}
+        instructionsText="the whole answer, already on screen"
       />,
     );
     expect(screen.getByText("the plan")).toBeTruthy();
     expect(screen.queryByText(/already on screen/)).toBeNull();
+  });
+
+  it("keeps that key on a surface that renders no instructions", () => {
+    render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{ reply: "the whole answer" }}
+        instructionInputs={["reply"]}
+      />,
+    );
+    expect(screen.getByText("the whole answer")).toBeTruthy();
   });
 
   // Folding prose is a height clamp, never a slice of the source: cutting

--- a/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
@@ -81,6 +81,43 @@ describe("GateInboundPayload", () => {
     expect(screen.getByText(/"id": 19/)).toBeTruthy();
   });
 
+  it("skips keys the instructions prompt already interpolates", () => {
+    render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{ reply: "the whole answer, already on screen", plan: "the plan" }}
+        instructionInputs={["reply"]}
+      />,
+    );
+    expect(screen.getByText("the plan")).toBeTruthy();
+    expect(screen.queryByText(/already on screen/)).toBeNull();
+  });
+
+  // Folding prose is a height clamp, never a slice of the source: cutting
+  // markdown at line 12 inside a fenced block renders an unterminated
+  // fence that swallows the rest of the payload.
+  it("folds long prose without truncating the markdown source", () => {
+    const text = [
+      "Here is the migration:",
+      "```go",
+      ...Array.from({ length: 15 }, (_, i) => `line${i} := true`),
+      "```",
+      "Ends with a closed fence.",
+    ].join("\n");
+
+    const { container } = render(
+      <GateInboundPayload runId="run-1" questions={{ plan: text }} />,
+    );
+
+    // Folded (a toggle is offered)…
+    expect(screen.getByRole("button", { name: /show all \d+ lines/i })).toBeTruthy();
+    // …yet the whole source is rendered: the fence closed, so the trailing
+    // paragraph is a paragraph and not code.
+    const tail = screen.getByText("Ends with a closed fence.");
+    expect(tail.closest("code")).toBeNull();
+    expect(container.querySelector("code")?.textContent).toContain("line14 := true");
+  });
+
   it("shows a short payload expanded — no click needed to read it", () => {
     render(<GateInboundPayload runId="run-1" questions={{ counts: { high: 2 } }} />);
     expect(screen.getByText(/"high": 2/)).toBeTruthy();

--- a/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fetchAttachment = vi.fn();
+
+vi.mock("@/api/runs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/runs")>();
+  return {
+    ...actual,
+    fetchAttachment: (...args: unknown[]) => fetchAttachment(...args),
+  };
+});
+
+import GateInboundPayload from "./GateInboundPayload";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("GateInboundPayload", () => {
+  it("renders the gate's inbound payload with humanized labels", () => {
+    render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{
+          plan: "## Steps\n\nShip the migration",
+          review_notes: "Watch the rollback path",
+        }}
+      />,
+    );
+    expect(screen.getByRole("heading", { name: /what you're reviewing/i })).toBeTruthy();
+    expect(screen.getByText("Plan")).toBeTruthy();
+    expect(screen.getByText("Review notes")).toBeTruthy();
+    expect(screen.getByText("Ship the migration")).toBeTruthy();
+    expect(screen.getByText("Watch the rollback path")).toBeTruthy();
+  });
+
+  it("renders nothing when the payload is empty or pure plumbing", () => {
+    const { container, rerender } = render(
+      <GateInboundPayload runId="run-1" questions={{}} />,
+    );
+    expect(container.firstChild).toBeNull();
+
+    rerender(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{
+          _queued_operator_messages: ["ping"],
+          _permission: { tool: "Bash" },
+        }}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("never shows plumbing keys alongside real content", () => {
+    render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{ plan: "Ship it", _queued_operator_messages: ["hurry up"] }}
+      />,
+    );
+    expect(screen.getByText("Ship it")).toBeTruthy();
+    expect(screen.queryByText(/hurry up/)).toBeNull();
+    expect(screen.queryByText(/queued operator messages/i)).toBeNull();
+  });
+
+  it("pretty-prints a structured value and folds a long one behind a toggle", () => {
+    const findings = Array.from({ length: 20 }, (_, i) => ({ id: i, sev: "high" }));
+    render(<GateInboundPayload runId="run-1" questions={{ findings }} />);
+
+    const toggle = screen.getByRole("button", { name: /show all \d+ lines/i });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    // Folded: the tail of the array is not in the DOM yet.
+    expect(screen.queryByText(/"id": 19/)).toBeNull();
+
+    fireEvent.click(toggle);
+    expect(screen.getByRole("button", { name: /show less/i })).toBeTruthy();
+    expect(screen.getByText(/"id": 19/)).toBeTruthy();
+  });
+
+  it("shows a short payload expanded — no click needed to read it", () => {
+    render(<GateInboundPayload runId="run-1" questions={{ counts: { high: 2 } }} />);
+    expect(screen.getByText(/"high": 2/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /show all/i })).toBeNull();
+  });
+
+  it("previews an image-typed field instead of printing its path", async () => {
+    fetchAttachment.mockResolvedValue({
+      blob: new Blob(["fake-png"], { type: "image/png" }),
+      contentType: "image/png",
+    });
+    // jsdom has no createObjectURL.
+    const createObjectURL = vi.fn(() => "blob:mockup");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", { ...URL, createObjectURL, revokeObjectURL });
+
+    render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{
+          mockup: {
+            attachment: "gate.mockup",
+            filename: "sketch.png",
+            // The descriptor's path is where the RUNNING NODES read the
+            // bytes — never fetchable from a browser, never displayed as
+            // the preview source.
+            path: "/run/iterion/attachments/gate.mockup/sketch.png",
+            mime: "image/png",
+            size: 2048,
+          },
+        }}
+        inputFields={[{ name: "mockup", type: "file" }]}
+      />,
+    );
+
+    const img = await screen.findByRole("img", { name: "sketch.png" });
+    expect(img.getAttribute("src")).toBe("blob:mockup");
+    expect(fetchAttachment).toHaveBeenCalledWith("run-1", "gate.mockup");
+    expect(screen.queryByText(/run\/iterion\/attachments/)).toBeNull();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("degrades to the filename when a file value has no fetchable attachment", async () => {
+    render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{ spec: "docs/spec.md" }}
+        inputFields={[{ name: "spec", type: "file" }]}
+      />,
+    );
+    expect(screen.getByText("spec.md")).toBeTruthy();
+    // Nothing to fetch — an unfetchable path must not produce a request
+    // (or a broken <img>).
+    await waitFor(() => expect(fetchAttachment).not.toHaveBeenCalled());
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("surfaces a failed attachment fetch with a download fallback", async () => {
+    fetchAttachment.mockRejectedValue(new Error("API error 404: attachment not found"));
+    render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{ mockup: { attachment: "gate.mockup", filename: "sketch.png" } }}
+        inputFields={[{ name: "mockup", type: "file" }]}
+      />,
+    );
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.getByText(/attachment not found/)).toBeTruthy();
+    expect(screen.getByRole("link", { name: /download instead/i })).toBeTruthy();
+  });
+});

--- a/studio/src/components/Runs/conversation/GateInboundPayload.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundPayload.tsx
@@ -19,12 +19,14 @@ interface Props {
   /** The node's declared `input_schema`, when it has one. */
   inputFields?: WireSchemaField[] | null;
   /**
-   * Keys the node's `instructions:` prompt already interpolates. Skipped
-   * here so a gate that embeds its input in its instructions (13 gates
-   * across 8 shipped catalog bots — Nexie's `chat_instructions` is
-   * literally `{{input.reply}}`) shows the value once, not twice.
+   * Keys the node's `instructions:` prompt interpolates. Paired with
+   * `instructionsText` to skip a value that is already on screen — 13
+   * gates across 8 shipped catalog bots inline their input this way
+   * (Nexie's `chat_instructions` is literally `{{input.reply}}`).
    */
   instructionInputs?: string[] | null;
+  /** The instructions text actually rendered above the form, if any. */
+  instructionsText?: string | null;
 }
 
 /**
@@ -47,10 +49,11 @@ export default function GateInboundPayload({
   questions,
   inputFields,
   instructionInputs,
+  instructionsText,
 }: Props) {
   const items = useMemo(
-    () => gateInboundItems(questions, inputFields, instructionInputs),
-    [questions, inputFields, instructionInputs],
+    () => gateInboundItems(questions, inputFields, { instructionInputs, instructionsText }),
+    [questions, inputFields, instructionInputs, instructionsText],
   );
   if (items.length === 0) return null;
 
@@ -109,11 +112,19 @@ const COLLAPSE_AFTER_LINES = 12;
 // fold is a CSS clamp, so it is deliberately approximate.
 const COLLAPSED_MAX_HEIGHT = "16rem";
 
+// Past this many characters the folded preview skips markdown entirely.
+// A gate can be mapped a whole `git diff` — one of this feature's own
+// motivating cases — and parsing hundreds of KB through react-markdown +
+// rehype-highlight to then clamp it to ~16rem is work thrown away. The
+// operator opts into that cost by expanding.
+const MARKDOWN_PARSE_BUDGET = 20_000;
+
 function CollapsibleText({ text }: { text: string }) {
   const lines = text.split("\n");
   const long = lines.length > COLLAPSE_AFTER_LINES;
   const [open, setOpen] = useState(!long);
   const folded = long && !open;
+  const heavy = text.length > MARKDOWN_PARSE_BUDGET;
   return (
     <div className="min-w-0">
       {/*
@@ -126,7 +137,13 @@ function CollapsibleText({ text }: { text: string }) {
         className={folded ? "relative overflow-hidden" : undefined}
         style={folded ? { maxHeight: COLLAPSED_MAX_HEIGHT } : undefined}
       >
-        <MarkdownText value={text} size="sm" />
+        {folded && heavy ? (
+          <pre className="whitespace-pre-wrap break-words font-mono text-micro leading-relaxed">
+            {text.slice(0, MARKDOWN_PARSE_BUDGET)}
+          </pre>
+        ) : (
+          <MarkdownText value={text} size="sm" />
+        )}
         {folded && (
           <div
             aria-hidden="true"

--- a/studio/src/components/Runs/conversation/GateInboundPayload.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundPayload.tsx
@@ -1,0 +1,168 @@
+import { ChevronDownIcon, ChevronRightIcon } from "@radix-ui/react-icons";
+import { useMemo, useState } from "react";
+
+import type { WireSchemaField } from "@/api/runs";
+import { CopyButton } from "@/components/ui";
+import {
+  formatJSONValue,
+  gateInboundItems,
+  type GateInboundItem,
+} from "@/lib/gateInbound";
+
+import GateInboundFile from "./GateInboundFile";
+import MarkdownText from "./MarkdownText";
+
+interface Props {
+  runId: string;
+  /** The paused node's resolved INBOUND data (store.Interaction.Questions). */
+  questions: Record<string, unknown> | null | undefined;
+  /** The node's declared `input_schema`, when it has one. */
+  inputFields?: WireSchemaField[] | null;
+}
+
+/**
+ * What the operator is being asked to validate, rendered above the answer
+ * form.
+ *
+ * The pause already carries this data — the engine resolves the node's
+ * incoming `with {}` mappings and stores them on the interaction — but
+ * the form is driven by the node's OUTPUT schema, so until now the
+ * payload reached the browser and was dropped on the floor (iterion#332).
+ * A gate that already receives `with {plan: "{{outputs.plan.body}}"}`
+ * therefore starts showing the plan with no authoring change at all.
+ *
+ * Long payloads start collapsed: a gate whose whole question is in
+ * `instructions:` must not be pushed off-screen by a diff it also
+ * happens to receive.
+ */
+export default function GateInboundPayload({ runId, questions, inputFields }: Props) {
+  const items = useMemo(
+    () => gateInboundItems(questions, inputFields),
+    [questions, inputFields],
+  );
+  if (items.length === 0) return null;
+
+  return (
+    <section
+      className="rounded-md border border-border-subtle bg-surface-1/60 px-2 py-1.5"
+      aria-label="Review context"
+    >
+      <h4 className="mb-1 text-micro font-medium uppercase tracking-wide text-fg-subtle">
+        What you're reviewing
+      </h4>
+      <dl className="space-y-1.5">
+        {items.map((item) => (
+          <div key={item.key} className="min-w-0">
+            <dt className="text-micro font-medium text-fg-muted" title={item.key}>
+              {humanizeKey(item.key)}
+            </dt>
+            <dd className="min-w-0 text-body text-fg-default">
+              <GateInboundValue runId={runId} item={item} />
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+function GateInboundValue({ runId, item }: { runId: string; item: GateInboundItem }) {
+  switch (item.kind) {
+    case "file":
+      // Keyed on the file's identity: a payload that swaps one
+      // attachment for another (a re-answered gate producing a new
+      // upload) must remount the fetch, not keep showing the old blob.
+      return item.file ? (
+        <GateInboundFile
+          key={item.file.attachment ?? item.file.path ?? item.key}
+          runId={runId}
+          file={item.file}
+        />
+      ) : null;
+    case "json":
+      return <JSONBlock value={item.value} />;
+    case "scalar":
+      return <span className="break-words">{item.text}</span>;
+    case "markdown":
+      return <CollapsibleText text={item.text ?? ""} />;
+  }
+}
+
+// Above this many lines a value is folded by default — enough to read a
+// short plan in place, short enough that three of them still leave the
+// answer form on screen.
+const COLLAPSE_AFTER_LINES = 12;
+
+function CollapsibleText({ text }: { text: string }) {
+  const lines = text.split("\n");
+  const long = lines.length > COLLAPSE_AFTER_LINES;
+  const [open, setOpen] = useState(!long);
+  const shown = open ? text : lines.slice(0, COLLAPSE_AFTER_LINES).join("\n");
+  return (
+    <div className="min-w-0">
+      <MarkdownText value={shown} size="sm" />
+      {long && (
+        <Toggle
+          open={open}
+          onToggle={() => setOpen((v) => !v)}
+          closedLabel={`Show all ${lines.length} lines`}
+        />
+      )}
+    </div>
+  );
+}
+
+function JSONBlock({ value }: { value: unknown }) {
+  const text = useMemo(() => formatJSONValue(value), [value]);
+  const lines = text.split("\n");
+  const long = lines.length > COLLAPSE_AFTER_LINES;
+  const [open, setOpen] = useState(!long);
+  const shown = open ? text : lines.slice(0, COLLAPSE_AFTER_LINES).join("\n");
+  return (
+    <div className="min-w-0 space-y-0.5">
+      <div className="flex items-start gap-1">
+        <pre className="min-w-0 flex-1 overflow-x-auto whitespace-pre-wrap break-words rounded bg-surface-0 p-1.5 font-mono text-micro leading-relaxed">
+          {shown}
+        </pre>
+        <CopyButton value={text} variant="icon" label="Copy JSON" copiedLabel="Copied" />
+      </div>
+      {long && (
+        <Toggle
+          open={open}
+          onToggle={() => setOpen((v) => !v)}
+          closedLabel={`Show all ${lines.length} lines`}
+        />
+      )}
+    </div>
+  );
+}
+
+function Toggle({
+  open,
+  onToggle,
+  closedLabel,
+}: {
+  open: boolean;
+  onToggle: () => void;
+  closedLabel: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={open}
+      className="inline-flex items-center gap-0.5 text-micro text-accent-text hover:underline"
+    >
+      {open ? <ChevronDownIcon /> : <ChevronRightIcon />}
+      {open ? "Show less" : closedLabel}
+    </button>
+  );
+}
+
+// humanizeKey turns a `with {}` mapping key into a label:
+// "review_notes" → "Review notes". The raw key stays in the title
+// attribute so an operator can still map it back to the .bot.
+function humanizeKey(key: string): string {
+  const words = key.replace(/[_-]+/g, " ").trim();
+  return words ? words.charAt(0).toUpperCase() + words.slice(1) : key;
+}

--- a/studio/src/components/Runs/conversation/GateInboundPayload.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundPayload.tsx
@@ -18,6 +18,13 @@ interface Props {
   questions: Record<string, unknown> | null | undefined;
   /** The node's declared `input_schema`, when it has one. */
   inputFields?: WireSchemaField[] | null;
+  /**
+   * Keys the node's `instructions:` prompt already interpolates. Skipped
+   * here so a gate that embeds its input in its instructions (13 gates
+   * across 8 shipped catalog bots — Nexie's `chat_instructions` is
+   * literally `{{input.reply}}`) shows the value once, not twice.
+   */
+  instructionInputs?: string[] | null;
 }
 
 /**
@@ -35,10 +42,15 @@ interface Props {
  * `instructions:` must not be pushed off-screen by a diff it also
  * happens to receive.
  */
-export default function GateInboundPayload({ runId, questions, inputFields }: Props) {
+export default function GateInboundPayload({
+  runId,
+  questions,
+  inputFields,
+  instructionInputs,
+}: Props) {
   const items = useMemo(
-    () => gateInboundItems(questions, inputFields),
-    [questions, inputFields],
+    () => gateInboundItems(questions, inputFields, instructionInputs),
+    [questions, inputFields, instructionInputs],
   );
   if (items.length === 0) return null;
 
@@ -93,14 +105,35 @@ function GateInboundValue({ runId, item }: { runId: string; item: GateInboundIte
 // answer form on screen.
 const COLLAPSE_AFTER_LINES = 12;
 
+// Roughly COLLAPSE_AFTER_LINES of prose at the `sm` line-height. The
+// fold is a CSS clamp, so it is deliberately approximate.
+const COLLAPSED_MAX_HEIGHT = "16rem";
+
 function CollapsibleText({ text }: { text: string }) {
   const lines = text.split("\n");
   const long = lines.length > COLLAPSE_AFTER_LINES;
   const [open, setOpen] = useState(!long);
-  const shown = open ? text : lines.slice(0, COLLAPSE_AFTER_LINES).join("\n");
+  const folded = long && !open;
   return (
     <div className="min-w-0">
-      <MarkdownText value={shown} size="sm" />
+      {/*
+        Folded with a height clamp, NOT by slicing the source: markdown
+        has multi-line constructs, and cutting at line 12 inside a fenced
+        code block would render an unterminated fence — swallowing the
+        rest of the payload into a code block that never closes.
+      */}
+      <div
+        className={folded ? "relative overflow-hidden" : undefined}
+        style={folded ? { maxHeight: COLLAPSED_MAX_HEIGHT } : undefined}
+      >
+        <MarkdownText value={text} size="sm" />
+        {folded && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent to-surface-1"
+          />
+        )}
+      </div>
       {long && (
         <Toggle
           open={open}

--- a/studio/src/components/Runs/conversation/HumanPromptForm.test.tsx
+++ b/studio/src/components/Runs/conversation/HumanPromptForm.test.tsx
@@ -641,6 +641,82 @@ describe("HumanPromptForm — the gate's inbound payload", () => {
     expect(context?.textContent).not.toContain("Nexie's whole answer");
   });
 
+  // The kanban card (LastRunSection) rebuilds the pause from the
+  // checkpoint, which never carries the resolved instructions — it passes
+  // neither `instructions` nor `shownPrompt`. Suppressing there would
+  // hide the value on every surface, which is exactly the blind-answering
+  // this feature removes.
+  it("still shows an interpolated value where no instructions are rendered", async () => {
+    getRunWorkflow.mockResolvedValue({
+      nodes: [
+        {
+          id: "chat",
+          instruction_inputs: ["reply"],
+          output_schema: [{ name: "message", type: "string" }],
+        },
+      ],
+      stale_hash: false,
+    });
+
+    const { container } = renderWithClient(
+      <HumanPromptForm
+        runId="run-1"
+        nodeId="chat"
+        questions={{ reply: "Nexie's whole answer" }}
+        sourceOverride={null}
+      />,
+    );
+
+    await screen.findByRole("textbox");
+    const context = container.querySelector("section[aria-label='Review context']");
+    expect(context?.textContent).toContain("Nexie's whole answer");
+  });
+
+  // The run console renders the prompt itself and hands it down. When a
+  // bot resolver's humanRenderHints replaced the instructions, that text
+  // does NOT contain the value — so nothing may be suppressed.
+  it("suppresses against the caller-rendered prompt, and only when it matches", async () => {
+    getRunWorkflow.mockResolvedValue({
+      nodes: [
+        {
+          id: "chat",
+          instruction_inputs: ["reply"],
+          output_schema: [{ name: "message", type: "string" }],
+        },
+      ],
+      stale_hash: false,
+    });
+
+    const { container, rerender } = renderWithClient(
+      <HumanPromptForm
+        runId="run-1"
+        nodeId="chat"
+        questions={{ reply: "Nexie's whole answer" }}
+        shownPrompt="Nexie's whole answer"
+        sourceOverride={null}
+      />,
+    );
+    await screen.findByRole("textbox");
+    expect(container.querySelector("section[aria-label='Review context']")).toBeNull();
+
+    rerender(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <HumanPromptForm
+          runId="run-1"
+          nodeId="chat"
+          questions={{ reply: "Nexie's whole answer" }}
+          shownPrompt="What would you like to do next?"
+          sourceOverride={null}
+        />
+      </QueryClientProvider>,
+    );
+    await waitFor(() =>
+      expect(
+        container.querySelector("section[aria-label='Review context']")?.textContent,
+      ).toContain("Nexie's whole answer"),
+    );
+  });
+
   it("works with no declared input_schema — the payload is typed by shape", async () => {
     getRunWorkflow.mockResolvedValue({
       nodes: [{ id: "gate", output_schema: [{ name: "notes", type: "string" }] }],

--- a/studio/src/components/Runs/conversation/HumanPromptForm.test.tsx
+++ b/studio/src/components/Runs/conversation/HumanPromptForm.test.tsx
@@ -510,11 +510,11 @@ describe("HumanPromptForm — operator uploads at a gate", () => {
     expect("attachments" in req).toBe(false);
   });
   // A board surface has no conversation around the form, so the paused
-  // node's `instructions:` text is the ONLY place the operator's question
-  // can appear: `questions` holds the node's INBOUND data and the
-  // schema-driven form renders its OUTPUT fields. Regression: an
-  // app-concept interview gate showed a bare "Message" box on the card
-  // while the run console rendered the full question.
+  // node's `instructions:` text carries the operator's question: the
+  // schema-driven form renders the node's OUTPUT fields, and `questions`
+  // (its INBOUND data) is rendered as review context, not as the ask.
+  // Regression: an app-concept interview gate showed a bare "Message"
+  // box on the card while the run console rendered the full question.
   it("renders the resolved instructions above the form", async () => {
     getRunWorkflow.mockResolvedValue({
       nodes: [{ id: "chat", output_schema: [{ name: "message", type: "string" }] }],
@@ -549,12 +549,119 @@ describe("HumanPromptForm — operator uploads at a gate", () => {
       <HumanPromptForm
         runId="run-1"
         nodeId="chat"
-        questions={{ reply: "inbound only" }}
+        questions={{}}
+        instructions={undefined}
         sourceOverride={null}
       />,
     );
 
     await screen.findByRole("textbox");
-    expect(container.textContent).not.toContain("inbound only");
+    // The instructions slot is the only prose above the form; with none
+    // declared and an empty payload, nothing precedes the fields.
+    expect(container.querySelector("section[aria-label='Review context']")).toBeNull();
+    expect(container.textContent).not.toContain("Which scope");
+  });
+});
+
+// iterion#332 — the pause already carries the node's resolved INBOUND
+// data; until now the schema-driven form dropped it and the operator
+// answered blind unless the author had stringified it into
+// `instructions:`.
+describe("HumanPromptForm — the gate's inbound payload", () => {
+  it("renders the inbound payload above the answer form", async () => {
+    getRunWorkflow.mockResolvedValue({
+      nodes: [
+        {
+          id: "gate",
+          input_schema: [
+            { name: "plan", type: "string" },
+            { name: "findings", type: "json" },
+          ],
+          output_schema: [
+            { name: "approved", type: "bool" },
+            { name: "notes", type: "string" },
+          ],
+        },
+      ],
+      stale_hash: false,
+    });
+
+    renderWithClient(
+      <HumanPromptForm
+        runId="run-1"
+        nodeId="gate"
+        questions={{
+          plan: "Migrate the webhook signature check",
+          findings: { high: 2 },
+          _queued_operator_messages: ["plumbing, never shown"],
+        }}
+        sourceOverride={null}
+      />,
+    );
+
+    // The verdict controls still render — the context is added above the
+    // form, never in place of it.
+    expect(await screen.findByRole("button", { name: "Approve" })).toBeTruthy();
+    expect(screen.getByText(/Migrate the webhook signature check/)).toBeTruthy();
+    expect(screen.getByText(/"high": 2/)).toBeTruthy();
+    expect(screen.queryByText(/plumbing, never shown/)).toBeNull();
+  });
+
+  it("works with no declared input_schema — the payload is typed by shape", async () => {
+    getRunWorkflow.mockResolvedValue({
+      nodes: [{ id: "gate", output_schema: [{ name: "notes", type: "string" }] }],
+      stale_hash: false,
+    });
+
+    renderWithClient(
+      <HumanPromptForm
+        runId="run-1"
+        nodeId="gate"
+        questions={{ diff: "diff --git a/x b/x\n+added" }}
+        sourceOverride={null}
+      />,
+    );
+
+    expect(await screen.findByText(/diff --git/)).toBeTruthy();
+  });
+
+  it("stays out of the way of an ask_user pause (PauseForm renders the question)", async () => {
+    getRunWorkflow.mockResolvedValue({
+      nodes: [{ id: "agent_node", output_schema: [{ name: "result", type: "string" }] }],
+      stale_hash: false,
+    });
+
+    const { container } = renderWithClient(
+      <HumanPromptForm
+        runId="run-1"
+        nodeId="agent_node"
+        questions={{ ask_user_response: "Which DB should I target?" }}
+        sourceOverride={null}
+      />,
+    );
+
+    await screen.findByRole("textbox");
+    expect(container.querySelector("section[aria-label='Review context']")).toBeNull();
+    // The question itself is still shown once, by PauseForm.
+    expect(screen.getAllByText(/Which DB should I target\?/)).toHaveLength(1);
+  });
+
+  it("stays out of the way of the schema-less fallback (PauseForm renders the same map)", async () => {
+    getRunWorkflow.mockResolvedValue({
+      nodes: [{ id: "gate", output_schema: [] }],
+      stale_hash: false,
+    });
+
+    const { container } = renderWithClient(
+      <HumanPromptForm
+        runId="run-1"
+        nodeId="gate"
+        questions={{ plan: "Ship it" }}
+        sourceOverride={null}
+      />,
+    );
+
+    await screen.findByRole("textbox");
+    expect(container.querySelector("section[aria-label='Review context']")).toBeNull();
   });
 });

--- a/studio/src/components/Runs/conversation/HumanPromptForm.test.tsx
+++ b/studio/src/components/Runs/conversation/HumanPromptForm.test.tsx
@@ -607,6 +607,40 @@ describe("HumanPromptForm — the gate's inbound payload", () => {
     expect(screen.queryByText(/plumbing, never shown/)).toBeNull();
   });
 
+  // Nexie's `chat_instructions` is literally `{{input.reply}}`: the
+  // engine substitutes the reply into the instructions the operator
+  // already reads, so rendering it again below would double it.
+  it("does not repeat a value the node's instructions already interpolate", async () => {
+    getRunWorkflow.mockResolvedValue({
+      nodes: [
+        {
+          id: "chat",
+          instruction_inputs: ["reply"],
+          output_schema: [{ name: "message", type: "string" }],
+        },
+      ],
+      stale_hash: false,
+    });
+
+    const { container } = renderWithClient(
+      <HumanPromptForm
+        runId="run-1"
+        nodeId="chat"
+        questions={{ reply: "Nexie's whole answer", plan: "and a plan" }}
+        instructions={"Nexie's whole answer"}
+        sourceOverride={null}
+      />,
+    );
+
+    await screen.findByRole("textbox");
+    // Shown exactly once — as the instructions, not again as context.
+    expect(screen.getAllByText(/Nexie's whole answer/)).toHaveLength(1);
+    // The rest of the payload is still surfaced.
+    const context = container.querySelector("section[aria-label='Review context']");
+    expect(context?.textContent).toContain("and a plan");
+    expect(context?.textContent).not.toContain("Nexie's whole answer");
+  });
+
   it("works with no declared input_schema — the payload is typed by shape", async () => {
     getRunWorkflow.mockResolvedValue({
       nodes: [{ id: "gate", output_schema: [{ name: "notes", type: "string" }] }],

--- a/studio/src/components/Runs/conversation/HumanPromptForm.tsx
+++ b/studio/src/components/Runs/conversation/HumanPromptForm.tsx
@@ -27,6 +27,7 @@ import { useRunStore } from "@/store/run";
 
 import PauseForm from "../PauseForm";
 import GateAttachments from "./GateAttachments";
+import GateInboundPayload from "./GateInboundPayload";
 import MarkdownText from "./MarkdownText";
 import type { GateFileValue } from "@/components/shared/GateFileInput";
 
@@ -104,6 +105,7 @@ export default function HumanPromptForm({
 
   const {
     fields,
+    inputFields,
     loading,
     staleHash,
     error: schemaError,
@@ -399,6 +401,20 @@ export default function HumanPromptForm({
         <div className="text-body text-fg-default">
           <MarkdownText value={instructions} size="sm" />
         </div>
+      )}
+      {/*
+        The gate's INBOUND payload — the plan / diff / mockup the operator
+        is validating (iterion#332). Suppressed on the PauseForm branches:
+        an ask_user pause carries the agent's question here, and a
+        schema-less gate has PauseForm render the very same map as its
+        answerable fields, so showing it twice would be noise.
+      */}
+      {!isAskUserPause && !useFallback && (
+        <GateInboundPayload
+          runId={runId}
+          questions={questions}
+          inputFields={inputFields}
+        />
       )}
       {staleHash && (
         <div className="text-caption text-warning-fg" role="status">

--- a/studio/src/components/Runs/conversation/HumanPromptForm.tsx
+++ b/studio/src/components/Runs/conversation/HumanPromptForm.tsx
@@ -106,6 +106,7 @@ export default function HumanPromptForm({
   const {
     fields,
     inputFields,
+    instructionInputs,
     loading,
     staleHash,
     error: schemaError,
@@ -408,12 +409,19 @@ export default function HumanPromptForm({
         an ask_user pause carries the agent's question here, and a
         schema-less gate has PauseForm render the very same map as its
         answerable fields, so showing it twice would be noise.
+
+        `loading` is part of that guard, not an optimisation: until the
+        schema lands we cannot know which branch we are on, and rendering
+        early would flash the payload as read-only context on a
+        schema-less gate a moment before PauseForm claims the same map as
+        its answer fields.
       */}
-      {!isAskUserPause && !useFallback && (
+      {!isAskUserPause && !loading && !useFallback && (
         <GateInboundPayload
           runId={runId}
           questions={questions}
           inputFields={inputFields}
+          instructionInputs={instructionInputs}
         />
       )}
       {staleHash && (

--- a/studio/src/components/Runs/conversation/HumanPromptForm.tsx
+++ b/studio/src/components/Runs/conversation/HumanPromptForm.tsx
@@ -42,6 +42,15 @@ interface Props {
   // conversation around the form, pass it so the operator sees what
   // they are answering instead of a bare input.
   instructions?: string;
+  // The operator-facing prompt the CALLER already rendered above this
+  // form, when it renders one itself instead of passing `instructions`.
+  // The run console does exactly that (HumanQuestionCard renders
+  // `message.prompt`), and the two together are the only reliable answer
+  // to "is the gate's instructions text on screen?" — which decides
+  // whether an inbound value it interpolates may be skipped as already
+  // shown. The kanban card passes neither and cannot: it rebuilds the
+  // pause from the checkpoint, which never carries the resolved text.
+  shownPrompt?: string;
   // Quick-action chips (skip / idk) the operator can pick instead of
   // typing a reply. Only meaningful on free-text-only turns. Default
   // = ["skip", "idk"]; pass empty to suppress.
@@ -87,6 +96,7 @@ export default function HumanPromptForm({
   nodeId,
   questions,
   instructions,
+  shownPrompt,
   quickActions = ["skip", "idk"],
   sourceOverride,
   onResumed,
@@ -422,6 +432,7 @@ export default function HumanPromptForm({
           questions={questions}
           inputFields={inputFields}
           instructionInputs={instructionInputs}
+          instructionsText={instructions ?? shownPrompt}
         />
       )}
       {staleHash && (

--- a/studio/src/components/Runs/conversation/HumanQuestionCard.tsx
+++ b/studio/src/components/Runs/conversation/HumanQuestionCard.tsx
@@ -95,6 +95,12 @@ export default function HumanQuestionCard({ runId, message, isActive }: Props) {
         runId={runId}
         nodeId={message.nodeId}
         questions={message.questions ?? {}}
+        // The prompt this card just rendered above the form. Passed (not
+        // re-rendered) so the payload block knows what is already on
+        // screen — `message.prompt` is the resolved instructions, EXCEPT
+        // when a bot resolver's humanRenderHints replaced it, which is
+        // exactly the case where nothing may be suppressed.
+        shownPrompt={message.prompt}
         quickActions={message.quickActions}
       />
     </div>

--- a/studio/src/hooks/useHumanNodeSchema.ts
+++ b/studio/src/hooks/useHumanNodeSchema.ts
@@ -5,6 +5,11 @@ import { getRunWorkflow, type WireSchemaField, type WireWorkflow } from "@/api/r
 
 interface State {
   fields: WireSchemaField[] | null;
+  // inputFields types the gate's INBOUND payload (the pause's questions
+  // map) so it can be rendered above the answer form. Independent of
+  // `fields`: a gate commonly declares an output schema and no input
+  // schema, in which case the renderer infers from each value's shape.
+  inputFields: WireSchemaField[] | null;
   loading: boolean;
   staleHash: boolean;
   error: string | null;
@@ -17,11 +22,17 @@ export interface HumanNodeSchema extends State {
   reload: () => void;
 }
 
-const initial: State = { fields: null, loading: false, staleHash: false, error: null };
+const initial: State = {
+  fields: null,
+  inputFields: null,
+  loading: false,
+  staleHash: false,
+  error: null,
+};
 
 // useHumanNodeSchema returns the output_schema fields for the paused
-// human node. Callers MUST distinguish three outcomes, never conflate
-// them:
+// human node (plus its input_schema, which types the inbound payload).
+// Callers MUST distinguish three outcomes, never conflate them:
 //   - loading=true                      → don't render the form yet
 //   - loading=false && error!=null      → the fetch FAILED; surface it
 //     and offer reload() — do NOT silently fall back (a fallback form
@@ -53,21 +64,16 @@ export function useHumanNodeSchema(
   // isPending (not isLoading): whenever we have neither data nor a
   // settled error, report loading — never the "no schema" fallback.
   if (query.isPending && !query.error) {
-    return { fields: null, loading: true, staleHash: false, error: null, reload };
+    return { ...initial, loading: true, reload };
   }
   if (query.error) {
-    return {
-      fields: null,
-      loading: false,
-      staleHash: false,
-      error: errorMessage(query.error),
-      reload,
-    };
+    return { ...initial, error: errorMessage(query.error), reload };
   }
   const wf = query.data;
   const node = wf?.nodes.find((n) => n.id === nodeId);
   return {
     fields: node?.output_schema ?? null,
+    inputFields: node?.input_schema ?? null,
     loading: false,
     staleHash: !!wf?.stale_hash,
     error: null,

--- a/studio/src/hooks/useHumanNodeSchema.ts
+++ b/studio/src/hooks/useHumanNodeSchema.ts
@@ -10,6 +10,9 @@ interface State {
   // `fields`: a gate commonly declares an output schema and no input
   // schema, in which case the renderer infers from each value's shape.
   inputFields: WireSchemaField[] | null;
+  // Inbound keys the node's `instructions:` prompt already interpolates.
+  // The payload renderer skips them so the value is not shown twice.
+  instructionInputs: string[] | null;
   loading: boolean;
   staleHash: boolean;
   error: string | null;
@@ -25,6 +28,7 @@ export interface HumanNodeSchema extends State {
 const initial: State = {
   fields: null,
   inputFields: null,
+  instructionInputs: null,
   loading: false,
   staleHash: false,
   error: null,
@@ -74,6 +78,7 @@ export function useHumanNodeSchema(
   return {
     fields: node?.output_schema ?? null,
     inputFields: node?.input_schema ?? null,
+    instructionInputs: node?.instruction_inputs ?? null,
     loading: false,
     staleHash: !!wf?.stale_hash,
     error: null,

--- a/studio/src/lib/gateInbound.test.ts
+++ b/studio/src/lib/gateInbound.test.ts
@@ -70,6 +70,27 @@ describe("gateInboundItems — plumbing is never shown", () => {
     expect(items.map((i) => i.key)).toEqual(["notes"]);
   });
 
+  // The historical workaround — Nexie's `chat_instructions` is literally
+  // `{{input.reply}}`, and 12 other catalog gates inline their input the
+  // same way. Those values are already on screen as the instructions
+  // markdown; repeating them below is the duplication this feature is
+  // supposed to REMOVE.
+  it("drops keys the instructions prompt already interpolates", () => {
+    const items = gateInboundItems(
+      { reply: "Nexie's whole answer", findings: { high: 2 } },
+      null,
+      ["reply"],
+    );
+    expect(items.map((i) => i.key)).toEqual(["findings"]);
+  });
+
+  it("keeps everything when the instructions interpolate nothing", () => {
+    for (const consumed of [undefined, null, []]) {
+      const items = gateInboundItems({ reply: "a", plan: "b" }, null, consumed);
+      expect(items.map((i) => i.key)).toEqual(["plan", "reply"]);
+    }
+  });
+
   it("returns nothing for an absent or fully-reserved payload", () => {
     expect(gateInboundItems(undefined, null)).toEqual([]);
     expect(gateInboundItems({}, null)).toEqual([]);
@@ -189,6 +210,30 @@ describe("asFileRef", () => {
     expect(asFileRef([1, 2, 3], false)).toBeNull();
     expect(asFileRef(null, true)).toBeNull();
     expect(asFileRef("   ", true)).toBeNull();
+  });
+
+  // A bare `attachment` key is not proof of a descriptor: misreading a
+  // structured payload as a file swaps the data the gate exists to show
+  // for a 404 banner. Real descriptors always carry corroboration
+  // (filename+mime+size+sha256 from the promotion path, path from the
+  // engine), so requiring it costs nothing.
+  it("requires corroboration before reading an object as a file descriptor", () => {
+    expect(
+      asFileRef({ attachment: "screenshot.png", note: "the triage item" }, false),
+    ).toBeNull();
+    // …and such a payload stays visible, as JSON.
+    const [item] = gateInboundItems(
+      { finding: { attachment: "screenshot.png", note: "the triage item" } },
+      null,
+    );
+    expect(item?.kind).toBe("json");
+
+    // Corroborated by a descriptor field…
+    expect(
+      asFileRef({ attachment: "gate.shot", mime: "image/png" }, false)?.attachment,
+    ).toBe("gate.shot");
+    // …or by the declared schema type.
+    expect(asFileRef({ attachment: "gate.shot" }, true)?.attachment).toBe("gate.shot");
   });
 
   it("classifies an upload descriptor as a file item end to end", () => {

--- a/studio/src/lib/gateInbound.test.ts
+++ b/studio/src/lib/gateInbound.test.ts
@@ -75,18 +75,64 @@ describe("gateInboundItems — plumbing is never shown", () => {
   // same way. Those values are already on screen as the instructions
   // markdown; repeating them below is the duplication this feature is
   // supposed to REMOVE.
-  it("drops keys the instructions prompt already interpolates", () => {
+  it("drops a key whose value the rendered instructions already show", () => {
     const items = gateInboundItems(
       { reply: "Nexie's whole answer", findings: { high: 2 } },
       null,
-      ["reply"],
+      { instructionInputs: ["reply"], instructionsText: "Nexie's whole answer" },
     );
     expect(items.map((i) => i.key)).toEqual(["findings"]);
   });
 
+  // The premise of the suppression is that the value is visible above the
+  // form. Where no instructions are rendered — the kanban card rebuilds
+  // the pause from the checkpoint, which never carries the resolved text
+  // — suppressing would hide it on EVERY surface. That is the
+  // blind-answering this feature exists to remove.
+  it("keeps the key when no instructions text is on screen", () => {
+    for (const instructionsText of [undefined, null, ""]) {
+      const items = gateInboundItems({ reply: "the answer" }, null, {
+        instructionInputs: ["reply"],
+        instructionsText,
+      });
+      expect(items.map((i) => i.key)).toEqual(["reply"]);
+    }
+  });
+
+  // A bot resolver's humanRenderHints.prompt replaces the resolved
+  // instructions in the run console: the reference exists, the text does
+  // not contain the value, so it must still be shown.
+  it("keeps the key when the displayed prompt does not contain the value", () => {
+    const items = gateInboundItems({ reply: "the answer" }, null, {
+      instructionInputs: ["reply"],
+      instructionsText: "What would you like to do next?",
+    });
+    expect(items.map((i) => i.key)).toEqual(["reply"]);
+  });
+
+  it("matches the engine's rendered forms for arrays and objects", () => {
+    // Scalar array → bullet list (renderInstructionValue).
+    expect(
+      gateInboundItems({ epics: ["one", "two"] }, null, {
+        instructionInputs: ["epics"],
+        instructionsText: "Epics:\n- one\n- two\n\nApprove?",
+      }),
+    ).toEqual([]);
+    // Object → fenced JSON block.
+    expect(
+      gateInboundItems({ counts: { high: 2 } }, null, {
+        instructionInputs: ["counts"],
+        instructionsText: '```json\n{\n  "high": 2\n}\n```',
+      }),
+    ).toEqual([]);
+  });
+
   it("keeps everything when the instructions interpolate nothing", () => {
-    for (const consumed of [undefined, null, []]) {
-      const items = gateInboundItems({ reply: "a", plan: "b" }, null, consumed);
+    for (const instructionInputs of [undefined, null, []]) {
+      const items = gateInboundItems({ reply: "a", plan: "b" }, null, {
+        instructionInputs,
+        instructionsText: "a and b are inlined here",
+      });
       expect(items.map((i) => i.key)).toEqual(["plan", "reply"]);
     }
   });

--- a/studio/src/lib/gateInbound.test.ts
+++ b/studio/src/lib/gateInbound.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  asFileRef,
+  formatJSONValue,
+  gateInboundItems,
+  isGatePlumbingKey,
+  type GateInboundItem,
+} from "./gateInbound";
+
+// Asserts the payload produced exactly one item and hands it back —
+// a silent empty list would otherwise pass every `item.x` assertion
+// below as `undefined`.
+function only(items: GateInboundItem[]): GateInboundItem {
+  expect(items).toHaveLength(1);
+  const [item] = items;
+  if (!item) throw new Error("expected one inbound item");
+  return item;
+}
+
+describe("isGatePlumbingKey", () => {
+  it("rejects the reserved underscore family and ask_user_response", () => {
+    for (const key of [
+      "_queued_operator_messages",
+      "_ask_user_options",
+      "_ask_user_allow_free_text",
+      "_permission",
+      "_attachments",
+      "ask_user_response",
+      "acknowledge_recovery",
+    ]) {
+      expect(isGatePlumbingKey(key)).toBe(true);
+    }
+  });
+
+  it("keeps authored mapping keys", () => {
+    for (const key of ["plan", "diff", "review_notes", "mockup"]) {
+      expect(isGatePlumbingKey(key)).toBe(false);
+    }
+  });
+});
+
+describe("gateInboundItems — plumbing is never shown", () => {
+  it("drops reserved keys while keeping the author's payload", () => {
+    const items = gateInboundItems(
+      {
+        plan: "Ship the thing",
+        _queued_operator_messages: ["hurry up"],
+        _permission: { tool: "Bash" },
+        ask_user_response: "Which DB?",
+      },
+      null,
+    );
+    expect(items.map((i) => i.key)).toEqual(["plan"]);
+  });
+
+  it("drops values that carry nothing rather than rendering empty rows", () => {
+    const items = gateInboundItems(
+      {
+        // `with {}` mappings the engine deliberately keeps as nil — a
+        // valid mapping, but no content to review.
+        pushback: null,
+        previous: "",
+        findings: [],
+        meta: {},
+        notes: "real content",
+      },
+      null,
+    );
+    expect(items.map((i) => i.key)).toEqual(["notes"]);
+  });
+
+  it("returns nothing for an absent or fully-reserved payload", () => {
+    expect(gateInboundItems(undefined, null)).toEqual([]);
+    expect(gateInboundItems({}, null)).toEqual([]);
+    expect(gateInboundItems({ _permission: { tool: "Bash" } }, null)).toEqual([]);
+  });
+});
+
+describe("gateInboundItems — kinds", () => {
+  it("infers kinds from the value shape when no input schema is declared", () => {
+    const items = gateInboundItems(
+      {
+        summary: "One short line",
+        plan: "# Plan\n\nStep one\nStep two",
+        findings: [{ id: 1 }],
+        counts: { high: 2 },
+        approved: true,
+        score: 0.8,
+      },
+      null,
+    );
+    const byKey = Object.fromEntries(items.map((i) => [i.key, i.kind]));
+    expect(byKey).toEqual({
+      summary: "scalar",
+      plan: "markdown",
+      findings: "json",
+      counts: "json",
+      approved: "scalar",
+      score: "scalar",
+    });
+    // Nothing was declared, so nothing claims to be typed.
+    expect(items.every((i) => !i.typed)).toBe(true);
+  });
+
+  it("treats a long single-line string as prose, not a chip", () => {
+    const long = "x".repeat(200);
+    const item = only(gateInboundItems({ summary: long }, null));
+    expect(item.kind).toBe("markdown");
+  });
+
+  it("honours a declared json field whose value arrived as a JSON string", () => {
+    const item = only(
+      gateInboundItems({ report: '{"high": 2, "low": 5}' }, [
+        { name: "report", type: "json" },
+      ]),
+    );
+    expect(item.kind).toBe("json");
+    expect(item.typed).toBe(true);
+    expect(item.value).toEqual({ high: 2, low: 5 });
+  });
+
+  it("leaves a declared json field that is not JSON as text", () => {
+    const item = only(
+      gateInboundItems({ report: "not json at all" }, [{ name: "report", type: "json" }]),
+    );
+    expect(item.kind).toBe("scalar");
+    expect(item.value).toBe("not json at all");
+  });
+
+  it("orders declared fields first (author's reading order), then the rest alphabetically", () => {
+    const items = gateInboundItems(
+      { zeta: "z", plan: "p", alpha: "a", summary: "s" },
+      [
+        { name: "summary", type: "string" },
+        { name: "plan", type: "string" },
+      ],
+    );
+    expect(items.map((i) => i.key)).toEqual(["summary", "plan", "alpha", "zeta"]);
+  });
+
+  it("skips declared fields the payload does not carry", () => {
+    const items = gateInboundItems({ plan: "p" }, [
+      { name: "plan", type: "string" },
+      { name: "mockup", type: "file" },
+    ]);
+    expect(items.map((i) => i.key)).toEqual(["plan"]);
+  });
+});
+
+describe("asFileRef", () => {
+  it("reads the descriptor the resume path writes", () => {
+    expect(
+      asFileRef(
+        {
+          attachment: "gate.mockup",
+          path: "/run/iterion/attachments/gate.mockup/sketch.png",
+          filename: "sketch.png",
+          mime: "image/png",
+          size: 2048,
+        },
+        false,
+      ),
+    ).toEqual({
+      attachment: "gate.mockup",
+      path: "/run/iterion/attachments/gate.mockup/sketch.png",
+      filename: "sketch.png",
+      mime: "image/png",
+      size: 2048,
+    });
+  });
+
+  it("derives a filename from the path when the descriptor omits it", () => {
+    const ref = asFileRef({ attachment: "gate.track", path: "/tmp/a/theme.mp3" }, false);
+    expect(ref?.filename).toBe("theme.mp3");
+  });
+
+  it("reads a bare path string ONLY when the schema declares the field a file", () => {
+    expect(asFileRef("docs/plan.md", true)).toEqual({
+      path: "docs/plan.md",
+      filename: "plan.md",
+    });
+    // A prose field is not a path just because it has no spaces.
+    expect(asFileRef("docs/plan.md", false)).toBeNull();
+  });
+
+  it("does not mistake an ordinary object payload for a file", () => {
+    expect(asFileRef({ high: 2, low: 5 }, false)).toBeNull();
+    expect(asFileRef([1, 2, 3], false)).toBeNull();
+    expect(asFileRef(null, true)).toBeNull();
+    expect(asFileRef("   ", true)).toBeNull();
+  });
+
+  it("classifies an upload descriptor as a file item end to end", () => {
+    const item = only(
+      gateInboundItems({ mockup: { attachment: "gate.mockup", filename: "sketch.png" } }, [
+        { name: "mockup", type: "file" },
+      ]),
+    );
+    expect(item.kind).toBe("file");
+    expect(item.file?.attachment).toBe("gate.mockup");
+  });
+});
+
+describe("formatJSONValue", () => {
+  it("pretty-prints", () => {
+    expect(formatJSONValue({ a: 1 })).toBe('{\n  "a": 1\n}');
+  });
+
+  it("never throws on a cyclic value", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(() => formatJSONValue(cyclic)).not.toThrow();
+  });
+});

--- a/studio/src/lib/gateInbound.ts
+++ b/studio/src/lib/gateInbound.ts
@@ -101,10 +101,17 @@ export function asFileRef(value: unknown, declaredFile: boolean): GateInboundFil
   const desc = value as Record<string, unknown>;
   const attachment = typeof desc.attachment === "string" ? desc.attachment : undefined;
   const path = typeof desc.path === "string" ? desc.path : undefined;
-  // A descriptor is identified by carrying at least one of the two
-  // locators; a plain `json` payload that happens to be an object is not
-  // a file just because the schema is silent.
-  if (!attachment && !(declaredFile && path)) return null;
+  // An attachment name alone is not enough: a legitimate structured
+  // payload can carry an `attachment` key of its own (a triage item
+  // naming a screenshot), and misreading it as a descriptor would
+  // replace the data the gate exists to show with a 404 banner. Real
+  // descriptors always carry corroboration — filename/mime/size from the
+  // HTTP promotion path, path from the engine — so requiring it costs
+  // nothing.
+  const corroborated =
+    !!attachment &&
+    (declaredFile || "path" in desc || "mime" in desc || "size" in desc || "sha256" in desc);
+  if (!corroborated && !(declaredFile && path)) return null;
   const filename =
     typeof desc.filename === "string" && desc.filename
       ? desc.filename
@@ -141,8 +148,16 @@ function basename(p: string): string {
 export function gateInboundItems(
   questions: Record<string, unknown> | null | undefined,
   inputFields: WireSchemaField[] | null | undefined,
+  // Keys the node's `instructions:` prompt already interpolates
+  // (`{{input.<key>}}`, projected as WireNode.instruction_inputs). The
+  // engine substitutes them into the operator-facing instructions
+  // rendered right above this block, so repeating them here would show
+  // the same plan/reply/PRD twice — the exact duplication this feature
+  // exists to REMOVE.
+  alreadyShown?: readonly string[] | null,
 ): GateInboundItem[] {
   if (!questions) return [];
+  const consumed = new Set(alreadyShown ?? []);
   const typeByName = new Map<string, string>();
   for (const f of inputFields ?? []) typeByName.set(f.name, f.type);
 
@@ -154,7 +169,7 @@ export function gateInboundItems(
 
   const items: GateInboundItem[] = [];
   for (const key of keys) {
-    if (isGatePlumbingKey(key)) continue;
+    if (isGatePlumbingKey(key) || consumed.has(key)) continue;
     const value = questions[key];
     if (isEmptyValue(value)) continue;
     const declared = typeByName.get(key);

--- a/studio/src/lib/gateInbound.ts
+++ b/studio/src/lib/gateInbound.ts
@@ -145,19 +145,25 @@ function basename(p: string): string {
  * valid mapping the engine deliberately keeps, but an empty row is
  * noise, not context.
  */
+export interface GateInboundOptions {
+  /**
+   * Keys the node's `instructions:` prompt interpolates (`{{input.<key>}}`,
+   * projected as `WireNode.instruction_inputs`).
+   */
+  instructionInputs?: readonly string[] | null;
+  /**
+   * The operator-facing instructions text ACTUALLY on screen above the
+   * form — the resolved prompt, not the template.
+   */
+  instructionsText?: string | null;
+}
+
 export function gateInboundItems(
   questions: Record<string, unknown> | null | undefined,
   inputFields: WireSchemaField[] | null | undefined,
-  // Keys the node's `instructions:` prompt already interpolates
-  // (`{{input.<key>}}`, projected as WireNode.instruction_inputs). The
-  // engine substitutes them into the operator-facing instructions
-  // rendered right above this block, so repeating them here would show
-  // the same plan/reply/PRD twice — the exact duplication this feature
-  // exists to REMOVE.
-  alreadyShown?: readonly string[] | null,
+  options?: GateInboundOptions,
 ): GateInboundItem[] {
   if (!questions) return [];
-  const consumed = new Set(alreadyShown ?? []);
   const typeByName = new Map<string, string>();
   for (const f of inputFields ?? []) typeByName.set(f.name, f.type);
 
@@ -169,13 +175,64 @@ export function gateInboundItems(
 
   const items: GateInboundItem[] = [];
   for (const key of keys) {
-    if (isGatePlumbingKey(key) || consumed.has(key)) continue;
+    if (isGatePlumbingKey(key)) continue;
     const value = questions[key];
     if (isEmptyValue(value)) continue;
+    if (alreadyOnScreen(key, value, options)) continue;
     const declared = typeByName.get(key);
     items.push(classify(key, value, declared));
   }
   return items;
+}
+
+/**
+ * Whether this key's value is ALREADY visible above the form, because the
+ * engine substituted it into the gate's `instructions:` prompt.
+ *
+ * Two conditions, both required, and the pair matters:
+ *
+ *  - the key is in `instruction_inputs` — the wire's statement that the
+ *    prompt references `{{input.<key>}}` at all. Containment alone would
+ *    false-positive on a short value ("true", "2") that happens to occur
+ *    in unrelated prose;
+ *  - one of the value's rendered forms actually occurs in the text on
+ *    screen. The reference existing is NOT proof the text is displayed:
+ *    the kanban card renders no instructions at all (it rebuilds the
+ *    pause from the checkpoint, which never carries the resolved text),
+ *    and a bot resolver's `humanRenderHints.prompt` replaces them in the
+ *    run console. Suppressing there would hide the payload on every
+ *    surface — the blind-answering this feature exists to remove.
+ *
+ * So the failure mode is deliberately one-sided: when in doubt, show it.
+ * A value rendered twice is redundant; a value rendered nowhere is the bug.
+ */
+function alreadyOnScreen(
+  key: string,
+  value: unknown,
+  options: GateInboundOptions | undefined,
+): boolean {
+  const text = options?.instructionsText;
+  if (!text || !options?.instructionInputs?.includes(key)) return false;
+  return renderedInstructionForms(value).some((form) => form !== "" && text.includes(form));
+}
+
+/**
+ * The shapes `Engine.renderInstructionValue` (pkg/runtime/resume.go) can
+ * substitute into the instructions markdown, so containment is checked
+ * against what the operator actually reads. Kept as a list rather than a
+ * single string because a scalar array renders as a bullet list while any
+ * nested structure renders as a fenced JSON block.
+ */
+function renderedInstructionForms(value: unknown): string[] {
+  if (value === null || value === undefined) return [];
+  if (typeof value === "string") return [value];
+  if (typeof value === "boolean" || typeof value === "number") return [String(value)];
+  if (Array.isArray(value)) {
+    const nested = value.some((v) => v !== null && typeof v === "object");
+    if (nested) return [formatJSONValue(value)];
+    return [value.map((v) => `- ${String(v)}`).join("\n")];
+  }
+  return [formatJSONValue(value)];
 }
 
 function isEmptyValue(value: unknown): boolean {
@@ -188,7 +245,11 @@ function isEmptyValue(value: unknown): boolean {
 
 function classify(key: string, value: unknown, declared: string | undefined): GateInboundItem {
   const typed = declared !== undefined;
-  const file = asFileRef(value, declared === "file");
+  // An explicit non-file declaration wins outright: if the author says
+  // this field is `json`, a descriptor-shaped value inside it is data,
+  // and swapping it for a file fetch would hide it behind a 404.
+  const declaredNonFile = typed && declared !== "file";
+  const file = declaredNonFile ? null : asFileRef(value, declared === "file");
   if (file) return { key, kind: "file", value, file, typed };
 
   if (typeof value === "string") {

--- a/studio/src/lib/gateInbound.ts
+++ b/studio/src/lib/gateInbound.ts
@@ -1,0 +1,218 @@
+// Typing of a human gate's INBOUND payload — the data the operator is
+// being asked to validate.
+//
+// Where it comes from: `Engine.persistPause` resolves the paused node's
+// incoming edges (`with { plan: "{{outputs.plan.body}}" }`) and stores
+// the result verbatim as `store.Interaction.Questions`. That map reaches
+// the browser on every paused gate — as the `human_input_requested`
+// event payload in the run console, and as
+// `PipelineBoardPendingReview.Questions` on the board.
+//
+// Why this file exists: the answer form is driven by the node's OUTPUT
+// schema (the verdict the operator produces), so nothing rendered the
+// inbound half. A gate reviewing a generated plan, a diff or a rendered
+// mockup had to stringify it into `instructions:` or the operator
+// answered blind (iterion#332).
+//
+// The kind is resolved from the node's declared `input_schema` when it
+// has one, and inferred from the value's shape otherwise — most gates
+// declare no input schema, and "no schema" must not mean "no rendering".
+
+import type { WireSchemaField } from "@/api/runs";
+import { ASK_USER_RESPONSE_KEY, isReservedQuestionKey } from "@/lib/askUserOptions";
+
+/** How one inbound value should be presented. */
+export type GateInboundKind =
+  | "markdown" // prose / long text — rendered through MarkdownText
+  | "json" // object, array, or a `json`-typed field — pretty-printed, collapsible
+  | "file" // an operator upload / attachment descriptor — previewed
+  | "scalar"; // bool, number, short single-line string — inline
+
+/** A file value, normalised across the two shapes the engine emits. */
+export interface GateInboundFileRef {
+  /** Run-attachment name (`{attachment: "gate.mockup"}`), when present. */
+  attachment?: string;
+  /** Filesystem path the RUNNING NODES see. Never fetchable from a browser. */
+  path?: string;
+  filename?: string;
+  mime?: string;
+  size?: number;
+}
+
+export interface GateInboundItem {
+  /** The `with {}` key — also the display label. */
+  key: string;
+  kind: GateInboundKind;
+  /** Raw value, untouched. */
+  value: unknown;
+  /** Populated iff kind === "file". */
+  file?: GateInboundFileRef;
+  /** Populated iff kind === "markdown" | "scalar" — the text to render. */
+  text?: string;
+  /** True when the schema declared the kind; false when it was inferred. */
+  typed: boolean;
+}
+
+// A single-line string this short reads better inline than as a
+// markdown block; above it, prose formatting earns its keep.
+const SCALAR_MAX_LEN = 120;
+
+// Engine-synthesised question keys that are the ASK itself, not data the
+// gate received. Both are already rendered as the turn's prompt (run
+// console) or as the answerable field (PauseForm); repeating them as
+// "review context" would just double them up.
+//
+//   - ask_user_response — the agent's own question on an ask_user pause.
+//     Not underscore-prefixed for wire-compat reasons.
+//   - acknowledge_recovery — the graceful-failure pause's guidance
+//     ("re-authenticate, then resume…"), written by
+//     pkg/runtime/recovery_dispatch.go.
+const SYNTHETIC_QUESTION_KEYS = new Set([ASK_USER_RESPONSE_KEY, "acknowledge_recovery"]);
+
+/**
+ * Keys that are runtime plumbing rather than gate content.
+ *
+ * `_`-prefixed keys are the reserved family (queued operator messages,
+ * ask_user options, the permission marker, ad-hoc attachments), plus the
+ * synthetic asks above.
+ */
+export function isGatePlumbingKey(key: string): boolean {
+  return isReservedQuestionKey(key) || SYNTHETIC_QUESTION_KEYS.has(key);
+}
+
+/**
+ * Normalise a value into a file reference, or null when it is not one.
+ *
+ * Two legitimate shapes (mirrors pkg/backend/model/validate.go):
+ *   - the descriptor the resume path writes after promoting an upload:
+ *     `{attachment, path, filename, mime, size, sha256}`
+ *   - a bare path string (an LLM-answered gate, or `--answer x=@file`)
+ *
+ * A bare string is only read as a file when the SCHEMA says so — a
+ * gate's prose field would otherwise be mistaken for a path.
+ */
+export function asFileRef(value: unknown, declaredFile: boolean): GateInboundFileRef | null {
+  if (typeof value === "string") {
+    const path = value.trim();
+    if (!declaredFile || !path) return null;
+    return { path, filename: basename(path) };
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const desc = value as Record<string, unknown>;
+  const attachment = typeof desc.attachment === "string" ? desc.attachment : undefined;
+  const path = typeof desc.path === "string" ? desc.path : undefined;
+  // A descriptor is identified by carrying at least one of the two
+  // locators; a plain `json` payload that happens to be an object is not
+  // a file just because the schema is silent.
+  if (!attachment && !(declaredFile && path)) return null;
+  const filename =
+    typeof desc.filename === "string" && desc.filename
+      ? desc.filename
+      : path
+        ? basename(path)
+        : attachment;
+  return {
+    attachment,
+    path,
+    filename,
+    mime: typeof desc.mime === "string" ? desc.mime : undefined,
+    size: typeof desc.size === "number" ? desc.size : undefined,
+  };
+}
+
+function basename(p: string): string {
+  const cut = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
+  return cut >= 0 ? p.slice(cut + 1) : p;
+}
+
+/**
+ * Build the ordered render list for a gate's inbound payload.
+ *
+ * Ordering follows the declared input schema first (the author's own
+ * order, which is the reading order they intended), then any remaining
+ * keys alphabetically — an undeclared payload is otherwise at the mercy
+ * of JSON key order, which is stable per run but arbitrary across bots.
+ *
+ * Values that carry nothing (null, undefined, empty string, empty
+ * object/array) are dropped: a `with {}` mapping resolving to nil is a
+ * valid mapping the engine deliberately keeps, but an empty row is
+ * noise, not context.
+ */
+export function gateInboundItems(
+  questions: Record<string, unknown> | null | undefined,
+  inputFields: WireSchemaField[] | null | undefined,
+): GateInboundItem[] {
+  if (!questions) return [];
+  const typeByName = new Map<string, string>();
+  for (const f of inputFields ?? []) typeByName.set(f.name, f.type);
+
+  const declaredOrder = (inputFields ?? []).map((f) => f.name);
+  const rest = Object.keys(questions)
+    .filter((k) => !declaredOrder.includes(k))
+    .sort();
+  const keys = [...declaredOrder.filter((k) => k in questions), ...rest];
+
+  const items: GateInboundItem[] = [];
+  for (const key of keys) {
+    if (isGatePlumbingKey(key)) continue;
+    const value = questions[key];
+    if (isEmptyValue(value)) continue;
+    const declared = typeByName.get(key);
+    items.push(classify(key, value, declared));
+  }
+  return items;
+}
+
+function isEmptyValue(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === "string") return value.trim() === "";
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value === "object") return Object.keys(value as object).length === 0;
+  return false;
+}
+
+function classify(key: string, value: unknown, declared: string | undefined): GateInboundItem {
+  const typed = declared !== undefined;
+  const file = asFileRef(value, declared === "file");
+  if (file) return { key, kind: "file", value, file, typed };
+
+  if (typeof value === "string") {
+    // A `json`-typed field whose value arrived as a JSON string is still
+    // structured data to the operator — parse it back so it renders as
+    // such instead of as a wall of escaped text.
+    if (declared === "json") {
+      const parsed = tryParseJSON(value);
+      if (parsed !== undefined) return { key, kind: "json", value: parsed, typed };
+    }
+    const oneLine = !value.includes("\n");
+    if (oneLine && value.length <= SCALAR_MAX_LEN) {
+      return { key, kind: "scalar", value, text: value, typed };
+    }
+    return { key, kind: "markdown", value, text: value, typed };
+  }
+
+  if (typeof value === "boolean" || typeof value === "number") {
+    return { key, kind: "scalar", value, text: String(value), typed };
+  }
+
+  return { key, kind: "json", value, typed };
+}
+
+function tryParseJSON(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return undefined;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Stable pretty-printed form for a `json` item (never throws). */
+export function formatJSONValue(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/studio/src/views/Board/issueModal/LastRunSection.test.tsx
+++ b/studio/src/views/Board/issueModal/LastRunSection.test.tsx
@@ -93,9 +93,15 @@ describe("LastRunSection answer-from-board affordance", () => {
     await waitFor(() => expect(screen.getByText(/environment/i)).toBeTruthy());
     expect(screen.getByText(/staging/i)).toBeTruthy();
     expect(screen.getByText(/production/i)).toBeTruthy();
-    // The checkpoint context vars must NOT be rendered as answer fields.
-    expect(screen.queryByText(/change_summary/i)).toBeNull();
-    expect(screen.queryByText(/checkout-api/i)).toBeNull();
+    // The checkpoint context vars must NOT be rendered as answer fields…
+    expect(screen.queryByLabelText(/change_summary/i)).toBeNull();
+    expect(screen.queryByLabelText(/service/i)).toBeNull();
+    // …but they ARE shown, read-only, as the review context above the
+    // form: they are exactly what the operator is validating (iterion#332).
+    const context = document.querySelector("section[aria-label='Review context']");
+    expect(context).toBeTruthy();
+    expect(context?.textContent).toContain("checkout-api");
+    expect(context?.textContent).toContain("bump sdk");
   });
 
   it("shows only the plain last-run panel when the run is not paused", async () => {


### PR DESCRIPTION
Closes #332 — palier 1 (no DSL change).

## The gap

The data pipe already existed end to end: `Engine.persistPause` computes the human node's fully-resolved input (the `{{outputs.x.y}}` values mapped by its incoming `with {}` clauses), stores it as `store.Interaction.Questions`, and the projection republishes it as `PipelineBoardPendingReview.Questions`. The payload reached the browser on every paused gate — and was dropped on the floor, because the schema-driven form renders the node's **output** fields.

So a gate reviewing a generated plan, a diff, a rendered mockup or a computed verdict had to stringify it into `instructions:`, or the operator answered blind.

## What this does

Renders that payload read-only above the form, under **"What you're reviewing"**:

| Value | Rendering |
|---|---|
| prose | markdown (reuses `MarkdownText`), folded past 12 lines |
| object / array / `json` field | pretty-printed, collapsible, copy button |
| `file` field | real preview — image / audio / video, fetched from `GET /api/runs/{id}/attachments/{name}` |
| bool, number, short string | inline |

It hangs off `HumanPromptForm`, so **every surface gets it at once** — the run console's human turn (`HumanQuestionCard`), the pipeline board (`SequentialReviews`), and the kanban card (`LastRunSection`) — and **every existing bot gains it with zero authoring change**: a gate that already receives `with {plan: "{{outputs.plan.body}}"}` starts showing the plan.

## Two decisions worth reviewing

**Typing is optional.** `input_schema` is newly projected onto the wire (human nodes only — nothing renders a payload for a node that never pauses), but most gates declare none. So the renderer infers the kind from the value's shape by default; a declared schema only sharpens the reading order (author's field order beats alphabetical) and disambiguates the two ambiguous cases — a `json` field that arrived as a JSON string, and a bare path in a `file` field. "No schema" must not mean "no rendering".

**A file's `path` is never the preview source.** The descriptor's path is where the *running nodes* read the bytes — a host path, or the sandbox bind-mount path inside the container. Neither is reachable from a browser, so the only fetchable handle is the attachment NAME. A descriptor without one (a `--answer x=@file` path, an LLM-answered gate) degrades to filename + path rather than producing a broken `<img>`.

## Suppression

Rendered only on the schema-driven branch. On an `ask_user` pause and on the schema-less `PauseForm` fallback, the very same map is already rendered (as the prompt / as the answerable fields) — showing it twice would be noise.

Plumbing keys are never displayed: the reserved `_*` family (`_queued_operator_messages`, `_ask_user_options`, `_permission`, `_attachments`) plus the two synthetic asks the engine writes, `ask_user_response` and `acknowledge_recovery` — both already shown as the turn's prompt.

## Acceptance

- [x] a paused gate renders its inbound payload on the board and in the run console
- [x] file/image-typed fields render as previews, not paths
- [x] plumbing keys are not shown
- [x] no regression — full Go suite + all 128 studio test files (1119 tests) green

One existing assertion was updated, deliberately: `LastRunSection.test.tsx` proved "the checkpoint context vars are not the form" by asserting their values were absent from the DOM entirely. That invariant is now expressed properly — they are not *answer fields* (`queryByLabelText`), and they *are* present in the read-only review-context section, which is the point of this issue.

## Verified on a real run

Built the binary + SPA, ran a gate to `paused_waiting_human`, and confirmed `GET /api/runs/{id}/workflow` now carries the gate's `input_schema` alongside its `output_schema`.

## Follow-ups (unchanged, out of scope)

- The JSON block rolls its own collapse; once #331 / #335 lands, it can adopt the shared `ExpandableValue`.
- Palier 2 (a declarative `show:` / `review_context:` block on human nodes) stays a separate issue + ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)