### PR TITLE
fix(runtime): an edge mapping wrapped in literal text lost the literal

### DIFF
--- a/pkg/runtime/engine_resolve.go
+++ b/pkg/runtime/engine_resolve.go
@@ -166,13 +166,89 @@ func (e *Engine) buildNodeInputRS(nodeID string, sc resolveScope) map[string]any
 }
 
 // resolveMapping resolves a DataMapping's references to concrete values.
-// For simplicity in the minimal runtime, if there is exactly one ref we
-// return the resolved value directly; otherwise we return the raw template.
+//
+// A template that is nothing but a single reference — "{{outputs.n.field}}"
+// — passes the referenced value through with its type intact, because a
+// mapping must be able to carry an object, an array, a bool or a number
+// into a typed field, not just text.
+//
+// Every other template is interpolated: each reference is rendered into
+// the surrounding literal text. Returning the reference alone would drop
+// that text ("app-concept/{{outputs.seed.token}}/resolved" collapsing to
+// the bare token), and returning the raw template would leave a
+// multi-reference path like "{{vars.scratch_dir}}/{{run.id}}/topics"
+// unresolved — both silently, as a plausible-looking value.
 func (e *Engine) resolveMapping(dm *ir.DataMapping, sc resolveScope) any {
-	if len(dm.Refs) == 1 {
+	if len(dm.Refs) == 0 {
+		return dm.Raw
+	}
+	// Spans come from Raw rather than from each Ref's own Raw field:
+	// hand-built IR (tests, generators) routinely fills DataMapping.Raw
+	// and leaves Ref.Raw empty, and an empty needle would splice the
+	// value in front of every character.
+	spans := templateSpans(dm.Raw)
+	if len(spans) != len(dm.Refs) {
+		if len(dm.Refs) == 1 {
+			return e.resolveRef(dm.Refs[0], sc)
+		}
+		return dm.Raw
+	}
+	if len(spans) == 1 && spans[0].start == 0 && spans[0].end == len(dm.Raw) {
 		return e.resolveRef(dm.Refs[0], sc)
 	}
-	return dm.Raw
+	var b strings.Builder
+	prev := 0
+	for i, sp := range spans {
+		b.WriteString(dm.Raw[prev:sp.start])
+		b.WriteString(renderMappingValue(e.resolveRef(dm.Refs[i], sc)))
+		prev = sp.end
+	}
+	b.WriteString(dm.Raw[prev:])
+	return b.String()
+}
+
+// templateSpan marks one `{{…}}` block in a template, end-exclusive.
+type templateSpan struct{ start, end int }
+
+// templateSpans locates every `{{…}}` block, using the same left-to-right
+// fence scan as ir.ParseRefs so the spans line up one-for-one with the
+// refs that call produced.
+func templateSpans(s string) []templateSpan {
+	var spans []templateSpan
+	for i := 0; ; {
+		start := strings.Index(s[i:], "{{")
+		if start == -1 {
+			return spans
+		}
+		start += i
+		end := strings.Index(s[start:], "}}")
+		if end == -1 {
+			return spans
+		}
+		end += start + 2
+		spans = append(spans, templateSpan{start: start, end: end})
+		i = end
+	}
+}
+
+// renderMappingValue converts a resolved reference to the text spliced
+// into an interpolated mapping template. It mirrors the substitution
+// rules the prompt renderer applies (model.formatValue): strings verbatim,
+// nil as empty, everything else as compact JSON so a structured value
+// stays machine-readable instead of degrading to Go's %v syntax.
+func renderMappingValue(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case nil:
+		return ""
+	default:
+		b, err := json.Marshal(val)
+		if err != nil {
+			return fmt.Sprintf("%v", val)
+		}
+		return string(b)
+	}
 }
 
 // resolveRef resolves a single Ref to a concrete value. The runState

--- a/pkg/runtime/engine_resolve_mapping_test.go
+++ b/pkg/runtime/engine_resolve_mapping_test.go
@@ -1,0 +1,150 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+)
+
+// mapping compiles a `with` template the way the IR compiler does
+// (compileWithMappings), so these tests exercise the exact DataMapping
+// shape the engine sees at run time.
+func mapping(t *testing.T, raw string) *ir.DataMapping {
+	t.Helper()
+	refs, err := ir.ParseRefs(raw)
+	if err != nil {
+		t.Fatalf("ParseRefs(%q): %v", raw, err)
+	}
+	return &ir.DataMapping{Key: "field", Refs: refs, Raw: raw}
+}
+
+// A template made of exactly one reference must hand the value over
+// untouched — mappings carry typed payloads into typed fields, so
+// stringifying here would break every object/bool/number binding.
+func TestResolveMapping_WholeReferencePreservesType(t *testing.T) {
+	e := &Engine{}
+	sc := resolveScope{outputs: map[string]map[string]any{
+		"seed": {
+			"obj":  map[string]any{"a": 1},
+			"list": []any{"x", "y"},
+			"flag": true,
+			"n":    int64(42),
+			"text": "AAA",
+		},
+	}}
+
+	for _, tc := range []struct {
+		raw  string
+		want any
+	}{
+		{"{{outputs.seed.text}}", "AAA"},
+		{"{{outputs.seed.flag}}", true},
+		{"{{outputs.seed.n}}", int64(42)},
+	} {
+		if got := e.resolveMapping(mapping(t, tc.raw), sc); got != tc.want {
+			t.Errorf("resolveMapping(%q) = %#v, want %#v", tc.raw, got, tc.want)
+		}
+	}
+
+	if got := e.resolveMapping(mapping(t, "{{outputs.seed.obj}}"), sc); got == nil {
+		t.Error("resolveMapping of a whole-object reference returned nil")
+	} else if _, ok := got.(map[string]any); !ok {
+		t.Errorf("resolveMapping of a whole-object reference = %T, want map[string]any", got)
+	}
+}
+
+// The regression this file exists for: a reference wrapped in literal
+// text used to collapse to the bare value, dropping everything around
+// it. app-concept's runtime canary caught it, but every composite
+// mapping in every bot was silently corrupted the same way — scratch
+// paths, Git branch names, error messages.
+func TestResolveMapping_InterpolatesSurroundingLiterals(t *testing.T) {
+	e := &Engine{}
+	sc := resolveScope{
+		vars: map[string]any{"scratch_dir": "/tmp/iterion-scratch"},
+		outputs: map[string]map[string]any{
+			"seed":     {"token": "mapping-v1"},
+			"dispatch": {"ticket": map[string]any{"id": "T-7"}},
+		},
+	}
+
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "single reference between literals",
+			raw:  "app-concept/{{outputs.seed.token}}/resolved",
+			want: "app-concept/mapping-v1/resolved",
+		},
+		{
+			name: "reference with a trailing literal only",
+			raw:  "{{outputs.seed.token}}/topics",
+			want: "mapping-v1/topics",
+		},
+		{
+			name: "several references and literals",
+			raw:  "{{vars.scratch_dir}}/x/{{outputs.seed.token}}/topics",
+			want: "/tmp/iterion-scratch/x/mapping-v1/topics",
+		},
+		{
+			name: "adjacent references",
+			raw:  "{{vars.scratch_dir}}{{outputs.seed.token}}",
+			want: "/tmp/iterion-scratchmapping-v1",
+		},
+		{
+			name: "same reference twice",
+			raw:  "{{outputs.seed.token}}/{{outputs.seed.token}}",
+			want: "mapping-v1/mapping-v1",
+		},
+		{
+			name: "drilled path inside a literal",
+			raw:  "iterion/squad/t/{{outputs.dispatch.ticket.id}}",
+			want: "iterion/squad/t/T-7",
+		},
+		{
+			name: "inner whitespace is part of the reference",
+			raw:  "a/{{ outputs.seed.token }}/b",
+			want: "a/mapping-v1/b",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := e.resolveMapping(mapping(t, tc.raw), sc); got != tc.want {
+				t.Errorf("resolveMapping(%q) = %#v, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// A template with no reference at all is a literal and must survive
+// verbatim.
+func TestResolveMapping_LiteralPassesThrough(t *testing.T) {
+	e := &Engine{}
+	if got := e.resolveMapping(mapping(t, "just/a/path"), resolveScope{}); got != "just/a/path" {
+		t.Errorf("resolveMapping of a literal = %#v, want %q", got, "just/a/path")
+	}
+}
+
+// An unresolvable reference renders as empty rather than leaking the
+// `{{…}}` template into the target field, where it would later read as
+// a plausible literal path or branch name.
+func TestResolveMapping_MissingReferenceRendersEmpty(t *testing.T) {
+	e := &Engine{}
+	sc := resolveScope{outputs: map[string]map[string]any{}}
+	if got := e.resolveMapping(mapping(t, "a/{{outputs.absent.field}}/b"), sc); got != "a//b" {
+		t.Errorf("resolveMapping with a missing ref = %#v, want %q", got, "a//b")
+	}
+}
+
+// Structured values spliced into a larger template render as compact
+// JSON, matching what the prompt renderer does.
+func TestResolveMapping_StructuredValueRendersAsJSON(t *testing.T) {
+	e := &Engine{}
+	sc := resolveScope{outputs: map[string]map[string]any{
+		"seed": {"list": []any{"x", "y"}},
+	}}
+	if got := e.resolveMapping(mapping(t, "items=[{{outputs.seed.list}}]"), sc); got != `items=[["x","y"]]` {
+		t.Errorf("resolveMapping of a structured value = %#v, want %q", got, `items=[["x","y"]]`)
+	}
+}


### PR DESCRIPTION
## The defect

`resolveMapping` never interpolated:

```go
func (e *Engine) resolveMapping(dm *ir.DataMapping, sc resolveScope) any {
	if len(dm.Refs) == 1 {
		return e.resolveRef(dm.Refs[0], sc)
	}
	return dm.Raw
}
```

One reference → its value, with everything around it dropped. Two or more → the raw template, unresolved. Only a mapping whose entire value is a single `{{…}}` came out right, which is why this survived: that is the shape almost every mapping has.

Observed on `v3.18.0`, with a three-case workflow:

| template | got | expected |
|---|---|---|
| `{{outputs.seed.a}}` | `AAA` | `AAA` |
| `x/{{outputs.seed.a}}/y` | `AAA` | `x/AAA/y` |
| `x/{{outputs.seed.a}}/y/{{outputs.seed.b}}/z` | `x/{{outputs.seed.a}}/y/{{outputs.seed.b}}/z` | `x/AAA/y/BBB/z` |

## Why it matters

The two broken shapes are how a bot builds a path, a branch name or an error message:

```
out_dir: "{{vars.scratch_dir}}/{{run.id}}/topics"
branch:  "iterion/squad/{{run.id}}/t/{{outputs.dispatch.ticket.id}}"
reason:  "Scoping blocked: {{outputs.topics_gate.errors}}"
```

The first reached the node as the literal string `{{vars.scratch_dir}}/{{run.id}}/topics` and was used as a directory path. The second yielded a bare ticket id as a branch name. Nothing failed loudly — every value looked plausible enough for the run to keep going.

This is not hypothetical for bots outside this repo either: a downstream `app-concept` bundle carries a deliberate canary (a mapping composing `"<name>/{{outputs.seed.token}}/resolved"`, compared against the expected constant in a deterministic preflight) precisely so it refuses to start rather than run with corrupted mappings. That gate is what surfaced this.

## The fix

Interpolate each reference into the surrounding text, and keep the whole-value passthrough when the template is nothing but one reference — mappings must still carry objects, arrays, bools and numbers into typed fields, so that path may not stringify.

Spans are scanned from `DataMapping.Raw` with the same fence walk as `ir.ParseRefs`, rather than read from each `Ref.Raw`. Hand-built IR (several tests in `pkg/runtime`, and any generator) fills the mapping's `Raw` and leaves the refs' own `Raw` empty; using it as a replacement needle splices the value in front of every character. Scanning the template keeps the refs and the spans aligned one-for-one by construction.

## Tests

`resolveMapping` had no test at all. Added `pkg/runtime/engine_resolve_mapping_test.go` covering the typed passthrough (string/bool/int64/object), both broken shapes, adjacent and repeated references, drilled paths, whitespace inside the fences, an unresolvable reference (renders empty — never the leaked template) and a structured value spliced into a larger string.

Verified: `go test ./...` and `go test ./e2e/...` green, `gofmt`/`go vet` clean, and the three-case workflow above now returns `whole=[AAA] wrapped=[x/AAA/y] multi=[x/AAA/y/BBB/z]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
