### PR TITLE
fix(tool): a `json` field holding a list broke out of its shell assignment

### DIFF
--- a/pkg/backend/model/executor_tool.go
+++ b/pkg/backend/model/executor_tool.go
@@ -337,7 +337,7 @@ func (e *ClawExecutor) shellRecipe(ctx context.Context, node *ir.ToolNode, input
 			// input/vars/secrets namespaces, so a direct run ref would survive
 			// into the command verbatim.
 			expandedCommand = resolveRunRefs(expandedCommand, RunIDFromContext(ctx), node.CommandRefs, shellEscapeValue)
-			resolved := resolveCommandTemplate(expandedCommand, node.CommandRefs, input, e.vars, e.secretGuard)
+			resolved := resolveCommandTemplate(expandedCommand, node.CommandRefs, e.jsonFieldsAsText(node, input), e.vars, e.secretGuard)
 			// Compression (tool nodes): node-level opt-in ONLY — compresses
 			// command output only when the node's own `compress:` is on/ultra (a
 			// run override can force-off as a kill switch, never force-on), so a
@@ -1001,6 +1001,74 @@ func resolveBracedEnvBody(body string) string {
 		return defaultVal
 	}
 	return ""
+}
+
+// jsonFieldsAsText pre-encodes every input value whose schema field is
+// declared `json` into its compact JSON text, so shell substitution
+// renders it as ONE token.
+//
+// Without it, a `json` field holding an all-string list reaches
+// shellEscapeValue's scalar-slice arm and space-joins:
+//
+//	QUICK={{input.quick_replies}} python3 -c "json.loads(os.environ['QUICK'])"
+//
+// resolves to `QUICK='Go' 'TypeScript' python3 …`, so sh reads only the
+// first word as the assignment and runs `TypeScript` as the command —
+// exit 127, with a fragment of model-authored prose as the error. The
+// author declared `json` and parses JSON; the space-join silently
+// contradicts both.
+//
+// Scoped to `json`-declared fields on purpose. The scalar-slice
+// space-join is load-bearing for `string[]` fields — `git add --
+// {{input.files}}` and friends need one shell word per element — and an
+// agent's structured output arrives as []any either way, so the declared
+// type is the only thing that distinguishes the two intents. Values
+// already textual (string, nil) and fields the schema does not declare
+// are returned untouched, and the input map is only copied when a field
+// actually changes.
+//
+// Shell command bodies only: `script:` contexts JSON-encode values
+// themselves, and pre-encoding here would double-encode them.
+func (e *ClawExecutor) jsonFieldsAsText(node *ir.ToolNode, input map[string]any) map[string]any {
+	if node == nil || node.InputSchema == "" || len(input) == 0 {
+		return input
+	}
+	schema := e.schemas[node.InputSchema]
+	if schema == nil {
+		return input
+	}
+	out := input
+	copied := false
+	for _, f := range schema.Fields {
+		if f == nil || f.Type != ir.FieldTypeJSON {
+			continue
+		}
+		v, ok := out[f.Name]
+		if !ok {
+			continue
+		}
+		switch v.(type) {
+		case nil, string:
+			// Already a single token; re-encoding would add quotes the
+			// author never wrote.
+			continue
+		}
+		b, err := json.Marshal(v)
+		if err != nil {
+			// Unmarshalable value — leave the existing behaviour rather
+			// than dropping the field.
+			continue
+		}
+		if !copied {
+			cloned := make(map[string]any, len(input))
+			for k, val := range input {
+				cloned[k] = val
+			}
+			out, copied = cloned, true
+		}
+		out[f.Name] = string(b)
+	}
+	return out
 }
 
 // shellEscapeValue formats val for safe interpolation into a sh -c command.

--- a/pkg/backend/model/executor_tool.go
+++ b/pkg/backend/model/executor_tool.go
@@ -1112,18 +1112,19 @@ func shellEscapeValue(val any) string {
 		if len(v) == 0 {
 			return ""
 		}
-		// KNOWN BUG (deferred — see memory project_bot_dogfood_campaign + the
-		// 3-option design): an all-string []interface{} (the shape a `json`-typed
-		// schema field decodes to) falls through to the space-join below, so a
-		// `KEY={{input.langs}} … python3 json.loads(KEY)` tool node gets
-		// `KEY=Go TypeScript` and the shell runs `TypeScript` (exit 127). Object
-		// arrays already JSON-encode via sliceHasComplexElement. Can't just flip
-		// the all-string case to JSON: the 7 `git add -- {{input.files}}` sites
-		// rely on space-join, and agent outputs aren't type-coerced (string[]
-		// schema → []interface{} here, indistinguishable from a json field).
-		// Fix needs output coercion + arm-flip, OR an additive shell-quoted-JSON
-		// template form, OR per-site `'{{!input.x}}'`; all need a sec-image Seki
-		// run to validate (shape-dependent: langs as list vs dict).
+		// An all-string []interface{} space-joins here. That is correct for a
+		// `string[]` field — `git add -- {{input.files}}` needs one shell word
+		// per element — and wrong for a `json` one, where the author writes
+		// `KEY={{input.langs}} … python3 json.loads(KEY)` and gets
+		// `KEY=Go TypeScript`, so sh runs `TypeScript` (exit 127). Both shapes
+		// arrive as []any, so this function cannot tell them apart.
+		// RESOLVED one frame up instead of here: jsonFieldsAsText pre-encodes
+		// the values whose schema field is declared `json`, on both shell
+		// command bodies (shellRecipe and runPostcondition), leaving this
+		// arm's space-join intact for `string[]`. Object arrays keep
+		// JSON-encoding below regardless of the declaration.
+		// Still uncovered: `{{vars.x}}` on a `json`-declared var, and input
+		// keys an edge delivers to a node that declares no `input:` schema.
 		if sliceHasComplexElement(v) {
 			// Mixed or complex slice → JSON-encode as a single shell token.
 			b, err := json.Marshal(v)

--- a/pkg/backend/model/executor_tool_jsonfield_test.go
+++ b/pkg/backend/model/executor_tool_jsonfield_test.go
@@ -1,0 +1,109 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+)
+
+func jsonFieldExecutor(fields ...*ir.SchemaField) *ClawExecutor {
+	return &ClawExecutor{schemas: map[string]*ir.Schema{
+		"gate_in": {Name: "gate_in", Fields: fields},
+	}}
+}
+
+func jsonFieldNode() *ir.ToolNode {
+	return &ir.ToolNode{SchemaFields: ir.SchemaFields{InputSchema: "gate_in"}}
+}
+
+// The regression: a `json` field holding an all-string list reached
+// shellEscapeValue's scalar-slice arm and space-joined, so
+// `KEY={{input.x}} cmd` assigned only the first word and ran the second
+// as a command (exit 127).
+func TestJSONFieldsAsText_StringListBecomesOneToken(t *testing.T) {
+	e := jsonFieldExecutor(&ir.SchemaField{Name: "quick_replies", Type: ir.FieldTypeJSON})
+	in := map[string]any{"quick_replies": []any{"Go", "Fail-open partout: comma"}}
+
+	out := e.jsonFieldsAsText(jsonFieldNode(), in)
+
+	got, ok := out["quick_replies"].(string)
+	if !ok {
+		t.Fatalf("quick_replies = %T, want string", out["quick_replies"])
+	}
+	if want := `["Go","Fail-open partout: comma"]`; got != want {
+		t.Errorf("quick_replies = %q, want %q", got, want)
+	}
+	if resolved := shellEscapeValue(out["quick_replies"]); resolved != `'["Go","Fail-open partout: comma"]'` {
+		t.Errorf("shell rendering = %s, want a single quoted token", resolved)
+	}
+	// The caller's map must not be mutated.
+	if _, still := in["quick_replies"].([]any); !still {
+		t.Error("jsonFieldsAsText mutated the caller's input map")
+	}
+}
+
+// A `string[]` field keeps the space-join that `git add -- {{input.files}}`
+// sites depend on — the declared type is the only signal separating the
+// two intents, since an agent's output arrives as []any either way.
+func TestJSONFieldsAsText_LeavesNonJSONFieldsAlone(t *testing.T) {
+	e := jsonFieldExecutor(&ir.SchemaField{Name: "files", Type: ir.FieldTypeStringArray})
+	in := map[string]any{"files": []any{"a.go", "b.go"}}
+
+	out := e.jsonFieldsAsText(jsonFieldNode(), in)
+
+	if _, isString := out["files"].(string); isString {
+		t.Fatalf("files was JSON-encoded, want the slice preserved")
+	}
+	if resolved := shellEscapeValue(out["files"]); resolved != `'a.go' 'b.go'` {
+		t.Errorf("shell rendering = %s, want two space-joined tokens", resolved)
+	}
+}
+
+// Values that are already a single token stay untouched: re-encoding a
+// string would add quotes the author never wrote.
+func TestJSONFieldsAsText_TextualValuesUntouched(t *testing.T) {
+	e := jsonFieldExecutor(
+		&ir.SchemaField{Name: "payload", Type: ir.FieldTypeJSON},
+		&ir.SchemaField{Name: "absent", Type: ir.FieldTypeJSON},
+	)
+	in := map[string]any{"payload": `{"already":"json"}`}
+
+	out := e.jsonFieldsAsText(jsonFieldNode(), in)
+
+	if got := out["payload"]; got != `{"already":"json"}` {
+		t.Errorf("payload = %#v, want it unchanged", got)
+	}
+	if _, present := out["absent"]; present {
+		t.Error("a schema field missing from the input was invented")
+	}
+}
+
+// Object-valued json fields already JSON-encoded downstream; the result
+// must stay a single token and must not double-encode.
+func TestJSONFieldsAsText_ObjectStaysSingleToken(t *testing.T) {
+	e := jsonFieldExecutor(&ir.SchemaField{Name: "cfg", Type: ir.FieldTypeJSON})
+	in := map[string]any{"cfg": map[string]any{"k": "v"}}
+
+	out := e.jsonFieldsAsText(jsonFieldNode(), in)
+
+	if got := out["cfg"]; got != `{"k":"v"}` {
+		t.Errorf("cfg = %#v, want %q", got, `{"k":"v"}`)
+	}
+	if resolved := shellEscapeValue(out["cfg"]); resolved != `'{"k":"v"}'` {
+		t.Errorf("shell rendering = %s, want a single quoted token", resolved)
+	}
+}
+
+// No schema, no declared field, or an empty input: the map passes
+// through untouched rather than being rebuilt.
+func TestJSONFieldsAsText_NoSchemaPassesThrough(t *testing.T) {
+	e := &ClawExecutor{schemas: map[string]*ir.Schema{}}
+	in := map[string]any{"x": []any{"a", "b"}}
+
+	if out := e.jsonFieldsAsText(jsonFieldNode(), in); len(out) != 1 {
+		t.Errorf("unknown schema changed the input map: %#v", out)
+	}
+	if out := e.jsonFieldsAsText(&ir.ToolNode{}, in); len(out) != 1 {
+		t.Errorf("schemaless node changed the input map: %#v", out)
+	}
+}

--- a/pkg/backend/model/executor_tool_jsonfield_test.go
+++ b/pkg/backend/model/executor_tool_jsonfield_test.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
@@ -105,5 +107,94 @@ func TestJSONFieldsAsText_NoSchemaPassesThrough(t *testing.T) {
 	}
 	if out := e.jsonFieldsAsText(&ir.ToolNode{}, in); len(out) != 1 {
 		t.Errorf("schemaless node changed the input map: %#v", out)
+	}
+}
+
+// The wiring, not just the helper: deleting the jsonFieldsAsText call in
+// shellRecipe reverts the whole fix, and every test above stays green
+// because the helper remains correct in isolation. These resolve a real
+// command template through the real recipe closures.
+func jsonFieldRecipeNode(command, script string) *ir.ToolNode {
+	return &ir.ToolNode{
+		BaseNode:     ir.BaseNode{ID: "gate"},
+		SchemaFields: ir.SchemaFields{InputSchema: "gate_in"},
+		Command:      command,
+		CommandRefs:  mustRefs(command),
+		Script:       script,
+		ScriptRefs:   mustRefs(script),
+	}
+}
+
+func mustRefs(s string) []*ir.Ref {
+	if s == "" {
+		return nil
+	}
+	refs, err := ir.ParseRefs(s)
+	if err != nil {
+		panic(err)
+	}
+	return refs
+}
+
+func TestShellRecipe_PreEncodesJSONFields(t *testing.T) {
+	e := jsonFieldExecutor(
+		&ir.SchemaField{Name: "quick_replies", Type: ir.FieldTypeJSON},
+		&ir.SchemaField{Name: "files", Type: ir.FieldTypeStringArray},
+	)
+	node := jsonFieldRecipeNode(`QUICK={{input.quick_replies}} FILES={{input.files}} run`, "")
+	input := map[string]any{
+		"quick_replies": []any{"Go", "Fail-open partout"},
+		"files":         []any{"a.go", "b.go"},
+	}
+
+	resolve, _ := e.shellRecipe(context.Background(), node, input)
+	got := resolve()
+
+	wantJSON := `QUICK='["Go","Fail-open partout"]'`
+	if !strings.Contains(got, wantJSON) {
+		t.Errorf("shellRecipe resolved to %q, want it to contain %q", got, wantJSON)
+	}
+	// The string[] field must still space-join: `git add -- {{input.files}}`
+	// depends on one shell word per element.
+	if wantJoin := `FILES='a.go' 'b.go'`; !strings.Contains(got, wantJoin) {
+		t.Errorf("shellRecipe resolved to %q, want it to contain %q", got, wantJoin)
+	}
+}
+
+func TestPostconditionRecipe_PreEncodesJSONFields(t *testing.T) {
+	e := jsonFieldExecutor(&ir.SchemaField{Name: "ids", Type: ir.FieldTypeJSON})
+	node := &ir.ToolNode{
+		BaseNode:      ir.BaseNode{ID: "gate"},
+		SchemaFields:  ir.SchemaFields{InputSchema: "gate_in"},
+		Postcondition: `IDS={{input.ids}} check`,
+	}
+	node.PostcondRefs = mustRefs(node.Postcondition)
+
+	expanded := expandBracedEnv(node.Postcondition)
+	got := resolveCommandTemplate(expanded, node.PostcondRefs,
+		e.jsonFieldsAsText(node, map[string]any{"ids": []any{"T-1", "T-2"}}), nil)
+
+	if want := `IDS='["T-1","T-2"]'`; !strings.Contains(got, want) {
+		t.Errorf("postcondition resolved to %q, want it to contain %q", got, want)
+	}
+}
+
+// script: bodies JSON-encode values themselves, so pre-encoding there
+// would double-encode. This pins the scoping claim the doc comment makes.
+func TestScriptRecipe_DoesNotPreEncodeJSONFields(t *testing.T) {
+	e := jsonFieldExecutor(&ir.SchemaField{Name: "ids", Type: ir.FieldTypeJSON})
+	node := jsonFieldRecipeNode("", `const ids = {{input.ids}};`)
+	node.Language = "js"
+
+	resolve, _ := e.scriptRecipe(context.Background(), node, map[string]any{
+		"ids": []any{"T-1", "T-2"},
+	})
+	got := resolve()
+
+	if want := `const ids = ["T-1","T-2"];`; !strings.Contains(got, want) {
+		t.Errorf("scriptRecipe resolved to %q, want it to contain %q (no double encoding)", got, want)
+	}
+	if strings.Contains(got, `"[\"T-1\"`) || strings.Contains(got, `'["T-1"`) {
+		t.Errorf("scriptRecipe double-encoded the json field: %q", got)
 	}
 }

--- a/pkg/backend/model/executor_verified_action.go
+++ b/pkg/backend/model/executor_verified_action.go
@@ -176,7 +176,11 @@ func (e *ClawExecutor) runPostcondition(ctx context.Context, node *ir.ToolNode, 
 	resolve := func() string {
 		expanded := expandBracedEnv(node.Postcondition)
 		expanded = resolveRunRefs(expanded, RunIDFromContext(ctx), node.PostcondRefs, shellEscapeValue)
-		return resolveCommandTemplate(expanded, node.PostcondRefs, input, e.vars, e.secretGuard)
+		// A postcondition is the node's second shell command body, resolved
+		// with the same escaper, and its refs are validated against the same
+		// input schema — so a `json`-declared field holding a list breaks out
+		// of its assignment here exactly as it does in the command itself.
+		return resolveCommandTemplate(expanded, node.PostcondRefs, e.jsonFieldsAsText(node, input), e.vars, e.secretGuard)
 	}
 	buildCmd := func(resolved string) (*exec.Cmd, func(), error) {
 		materialized, env := e.secretGuard.MaterializeShellEnv(resolved)


### PR DESCRIPTION
## The defect

A schema field declared `json` reaches `shellEscapeValue` as `[]any` and falls into the scalar-slice arm, which space-joins individually-quoted elements. In an assignment position that is not one value — it is several words:

```
QUICK={{input.quick_replies}} python3 -c "json.loads(os.environ['QUICK'])"
```

resolves to `QUICK='Go' 'Fail-open partout: …' python3 …`. `sh` takes only the first word as the assignment and runs the second as a command:

```
shell command failed: exit status 127
stderr: bash: line 1: Fail-open partout: comma…: command not found
```

The author declared `json` and parses JSON; the space-join contradicts both, and does it silently until the shell chokes on whatever prose the model happened to emit.

Hit in the wild on a bot whose consolidation gate validates a `quick_replies: json` field — the run died at the gate after the operator had already answered four interviews.

## Why it was deferred

The comment above the arm describes this exact failure (`KEY=Go TypeScript`, exit 127) and why the obvious repair does not work: encoding every all-string `[]any` as JSON breaks the `git add -- {{input.files}}` sites that need one shell word per element, and an agent's structured output arrives as `[]any` whether the field was declared `string[]` or `json` — indistinguishable at that point.

## The fix

The declared type is the missing signal, and it is already reachable one frame up: `ClawExecutor` holds the workflow's schemas and `ToolNode` names its input schema. So encode by **declaration**, not by shape.

`jsonFieldsAsText` pre-encodes only the values whose schema field is declared `json`, immediately before shell substitution:

- `json` field + list/object → one JSON token
- `string[]` field → untouched, keeps the space-join
- already textual (`string`, `nil`) → untouched; re-encoding would add quotes the author never wrote
- field absent from the input, or no schema → untouched
- the input map is copied only when a field actually changes

Scoped to shell command bodies. `script:` contexts JSON-encode values themselves, so pre-encoding there would double-encode.

## Tests

New `pkg/backend/model/executor_tool_jsonfield_test.go`: the regression itself (string list → single token, asserted through `shellEscapeValue`), the `string[]` space-join that must survive, textual values left alone, object fields staying one token, absent fields not invented, no-schema pass-through, and non-mutation of the caller's map.

`go test ./...` green, `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
