### PR TITLE
feat(runtime): a tool node can hand a file it produced to the run

### DIFF
--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -84,9 +84,9 @@ echo "[iterion] attachment=$PWD/exports/final.mp4 name=final_video mime=video/mp
 
 | Token   | Required | Notes                                                                    |
 | ------- | -------- | ------------------------------------------------------------------------ |
-| `<path>` | yes     | First token after `attachment=`. Host-absolute path to a readable file.  |
-| `name`  | optional | The handle `/api/runs/{id}/attachments/{name}` serves. Defaults to the file's base name without its extension, sanitised to `[A-Za-z0-9_-]`. |
-| `mime`  | optional | Stored as-is when well formed; otherwise sniffed from the extension, falling back to `application/octet-stream`. |
+| `<path>` | yes     | Everything up to the first `name=` / `mime=` token, so a path may contain spaces. Host-absolute, readable, and at most 50 MB. |
+| `name`  | optional | The handle `/api/runs/{id}/attachments/{name}` serves. Defaults to the file's base name without its extension, sanitised to `[A-Za-z0-9_-]`. A name the run already carries is **never overwritten** — the directive is skipped with a warning, so a tool cannot clobber an operator's upload or an earlier iteration's deliverable. |
+| `mime`  | optional | Stored as-is when well formed; otherwise sniffed from the extension, falling back to `application/octet-stream`. Types the browser would EXECUTE (html, xhtml, svg, xml, javascript) are downgraded to `application/octet-stream`: the serve route replies `Content-Disposition: inline` with no nosniff, and tool stdout is not a trusted channel. |
 
 The runtime reads the bytes and persists them through the same
 `WriteAttachment` path as an upload, so the result is an ordinary run

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -66,6 +66,54 @@ unknown attachment name produces `C053`.
 | C053 | `{{attachments.X}}` references an undeclared attachment                |
 | C054 | unknown sub-field after `attachments.<name>.` (only `path`, `url`, `mime`, `size`, `sha256` are valid) |
 
+## A tool node hands over a file it produced
+
+The three sources above all bring bytes **in** from a person: the launch
+form, a `file`-typed gate field, the 📎 button. A workflow that
+*generates* a deliverable — a rendered video, an audio mix, a chart, a
+PDF — had no way to put it in front of a reviewer, because a human gate
+previews a `file` value by fetching
+`GET /api/runs/{id}/attachments/{name}` and the path a tool knows is a
+host or bind-mount path the browser cannot reach.
+
+A tool node declares one by printing a directive on stdout:
+
+```sh
+echo "[iterion] attachment=$PWD/exports/final.mp4 name=final_video mime=video/mp4"
+```
+
+| Token   | Required | Notes                                                                    |
+| ------- | -------- | ------------------------------------------------------------------------ |
+| `<path>` | yes     | First token after `attachment=`. Host-absolute path to a readable file.  |
+| `name`  | optional | The handle `/api/runs/{id}/attachments/{name}` serves. Defaults to the file's base name without its extension, sanitised to `[A-Za-z0-9_-]`. |
+| `mime`  | optional | Stored as-is when well formed; otherwise sniffed from the extension, falling back to `application/octet-stream`. |
+
+The runtime reads the bytes and persists them through the same
+`WriteAttachment` path as an upload, so the result is an ordinary run
+attachment: same storage layout, same serving route, same presigning.
+One line per file; other stdout is left alone.
+
+Failures are **non-fatal** — a missing or unreadable file is logged and
+skipped, never enough to fail the tool node. The tool's own output is
+its contract with the workflow; the directive is only how the bytes
+reach a human.
+
+To show it at a gate, return a descriptor from the same node and map it
+in the edge's `with {}`:
+
+```json
+{"attachment": "final_video", "filename": "final.mp4",
+ "mime": "video/mp4", "size": 57948692}
+```
+
+The gate's inbound payload renderer previews any value carrying an
+`attachment` name plus one corroborating field. Declaring the field as
+`file` in the gate's input schema sharpens the reading order; it is not
+required.
+
+> This is the writing counterpart of `[iterion] preview_screenshot=`,
+> which promotes a browser capture the same way.
+
 ## Upload protocol
 
 The Launch modal uploads each attachment immediately on selection via

--- a/docs/human-in-the-loop.md
+++ b/docs/human-in-the-loop.md
@@ -238,6 +238,18 @@ forcing one would strand an operator re-answering a gate whose file
 arrived on an earlier pass. Branch on the field if the workflow truly
 cannot proceed without it.
 
+### Showing the operator a file the workflow produced
+
+The sections above collect bytes **from** the operator. The reverse —
+putting a generated deliverable in front of them — goes through the same
+attachment store: a tool node prints
+`[iterion] attachment=<path> name=<n>` on stdout, the runtime persists
+the file, and the gate's inbound payload previews it as audio, video or
+image. See [attachments.md](attachments.md#a-tool-node-hands-over-a-file-it-produced).
+
+A path alone is never enough: it points at the host or the sandbox
+bind-mount, and no browser can fetch either.
+
 ### Ad-hoc attachments — no DSL at all
 
 Every ordinary human gate carries a **📎 Attach a file** button, whether

--- a/pkg/backend/model/hooks.go
+++ b/pkg/backend/model/hooks.go
@@ -858,6 +858,15 @@ func (h *storeHooks) onToolNodeResult(nodeID string, toolName string, input []by
 					h.runID, nodeID, dir, h.logger,
 				)
 			}
+			// A tool that GENERATED a deliverable hands it over the same
+			// way, so a downstream human gate can show it rather than
+			// print a path the browser cannot reach.
+			for _, dir := range scanToolAttachments(output) {
+				publishToolAttachment(
+					h.ctx, h.attachmentSink, h.emitter,
+					h.runID, nodeID, dir, h.logger,
+				)
+			}
 		}
 	}
 }

--- a/pkg/backend/model/tool_attachment.go
+++ b/pkg/backend/model/tool_attachment.go
@@ -31,6 +31,14 @@ import (
 // runtime reads the bytes and persists them.
 const toolAttachmentDirective = "[iterion] attachment="
 
+// maxToolAttachmentBytes bounds what a directive may copy into the run
+// store. FilesystemRunStore.WriteAttachment documents the cap as the
+// caller's job and simply io.Copy's the body, so without this a
+// directive naming a 40 GB render would fill the store silently. The
+// value matches the cloud store's own default, so a bot behaves the
+// same locally and in cloud mode.
+const maxToolAttachmentBytes = 50 * 1024 * 1024
+
 // AttachmentDirective is one parsed `[iterion] attachment=...` line.
 // Path is host-absolute. Name defaults to the file's base name,
 // sanitised; MIME is sniffed from the extension when absent.
@@ -38,6 +46,30 @@ type AttachmentDirective struct {
 	Path string
 	Name string
 	MIME string
+}
+
+// attachmentDirectiveKeys are the trailing `key=value` tokens the
+// directive accepts. Anything else belongs to the PATH — see
+// splitAttachmentTail.
+var attachmentDirectiveKeys = []string{"name", "mime"}
+
+// splitAttachmentTail separates the path from the trailing options.
+//
+// The shared scanner splits on whitespace, which breaks the moment a
+// path contains a space — and exported media routinely does
+// ("final cut.mp4"). The failure was the worst possible one: os.Open on
+// a truncated path, a warning, and the file skipped — exactly the empty
+// gate this verb exists to prevent. So the path is everything up to the
+// first recognised ` key=` token.
+func splitAttachmentTail(tokens []string) (string, []string) {
+	for index := 1; index < len(tokens); index++ {
+		for _, key := range attachmentDirectiveKeys {
+			if strings.HasPrefix(tokens[index], key+"=") {
+				return strings.Join(tokens[:index], " "), tokens[index:]
+			}
+		}
+	}
+	return strings.Join(tokens, " "), nil
 }
 
 // scanToolAttachments walks tool stdout and returns one directive per
@@ -50,8 +82,9 @@ func scanToolAttachments(output string) []AttachmentDirective {
 	}
 	found := make([]AttachmentDirective, 0, len(lines))
 	for _, tokens := range lines {
-		dir := AttachmentDirective{Path: tokens[0]}
-		for _, kv := range tokens[1:] {
+		path, options := splitAttachmentTail(tokens)
+		dir := AttachmentDirective{Path: path}
+		for _, kv := range options {
 			eq := strings.IndexByte(kv, '=')
 			if eq <= 0 {
 				continue
@@ -68,6 +101,29 @@ func scanToolAttachments(output string) []AttachmentDirective {
 	return found
 }
 
+// neutralizeActiveMIME downgrades any type the browser would EXECUTE
+// when `/api/runs/{id}/attachments/{name}` serves it back with
+// `Content-Disposition: inline` — that route sets neither nosniff nor a
+// CSP, and accepts a request carrying no Origin header at all.
+//
+// A tool's stdout is not a trusted channel: it carries fetched pages,
+// catted files and LLM-written text, any line of which can carry a
+// directive. Without this, `mime=text/html` plants a same-origin script
+// in the studio. The operator-upload path defends the same invariant by
+// SNIFFING the bytes against AllowedUploadMIMEs; this path cannot sniff
+// (it never reads the content) so it downgrades instead — the
+// deliverable still reaches the gate, as a download rather than a
+// preview.
+func neutralizeActiveMIME(m string) string {
+	switch strings.ToLower(m) {
+	case "text/html", "application/xhtml+xml", "image/svg+xml",
+		"text/xml", "application/xml",
+		"text/javascript", "application/javascript", "application/x-javascript":
+		return "application/octet-stream"
+	}
+	return m
+}
+
 // attachmentMIME resolves the stored MIME: the directive's own value
 // when it is well formed, else a sniff from the extension. An unknown
 // extension yields the generic binary type rather than a lie — the
@@ -75,15 +131,22 @@ func scanToolAttachments(output string) []AttachmentDirective {
 func attachmentMIME(dir AttachmentDirective) string {
 	if declared := strings.TrimSpace(dir.MIME); declared != "" {
 		if parsed, _, err := mime.ParseMediaType(declared); err == nil && parsed != "" {
-			return parsed
+			return neutralizeActiveMIME(parsed)
 		}
 	}
 	if byExt := mime.TypeByExtension(filepath.Ext(dir.Path)); byExt != "" {
 		if parsed, _, err := mime.ParseMediaType(byExt); err == nil && parsed != "" {
-			return parsed
+			return neutralizeActiveMIME(parsed)
 		}
 	}
 	return "application/octet-stream"
+}
+
+// AttachmentLister is the optional read half of the attachment
+// capability. When the sink implements it too, publishToolAttachment
+// refuses to overwrite a name the run already carries.
+type AttachmentLister interface {
+	ListAttachments(ctx context.Context, runID string) ([]store.AttachmentRecord, error)
 }
 
 // publishToolAttachment reads the file a tool declared and persists it
@@ -101,12 +164,20 @@ func publishToolAttachment(
 	dir AttachmentDirective,
 	logger *iterlog.Logger,
 ) {
-	f, err := os.Open(dir.Path)
+	info, err := os.Stat(dir.Path)
 	if err != nil {
-		logger.Warn("Tool attachment [%s]: open %s: %v", nodeID, dir.Path, err)
+		logger.Warn("Tool attachment [%s]: stat %s: %v", nodeID, dir.Path, err)
 		return
 	}
-	defer f.Close()
+	if info.IsDir() {
+		logger.Warn("Tool attachment [%s]: %s is a directory", nodeID, dir.Path)
+		return
+	}
+	if info.Size() > maxToolAttachmentBytes {
+		logger.Warn("Tool attachment [%s]: %s is %d bytes, over the %d cap — skipped",
+			nodeID, dir.Path, info.Size(), int64(maxToolAttachmentBytes))
+		return
+	}
 
 	// The name is the handle the gate's descriptor will carry, so it must
 	// survive the store's path sanitisation unchanged. A caller that
@@ -122,6 +193,33 @@ func publishToolAttachment(
 		name = fmt.Sprintf("attachment-%s", sanitizeAttachmentSegment(nodeID))
 	}
 
+	// WriteAttachment overwrites unconditionally and documents duplicate
+	// handling as the caller's job. Two ways that bites here: a directive
+	// can take over the name of an operator's own upload, and a loop that
+	// regenerates the same deliverable can hand a gate reviewing pass N-1
+	// the bytes of pass N. A STABLE name is the whole point of this verb,
+	// so the collision is refused rather than suffixed away — the author
+	// gets a warning naming the fix.
+	if lister, ok := sink.(AttachmentLister); ok {
+		if existing, listErr := lister.ListAttachments(ctx, runID); listErr == nil {
+			for _, rec := range existing {
+				if rec.Name == name {
+					logger.Warn(
+						"Tool attachment [%s]: %q already exists on this run — skipped "+
+							"(publish a revision under its own name=)", nodeID, name)
+					return
+				}
+			}
+		}
+	}
+
+	f, err := os.Open(dir.Path)
+	if err != nil {
+		logger.Warn("Tool attachment [%s]: open %s: %v", nodeID, dir.Path, err)
+		return
+	}
+	defer f.Close()
+
 	rec := store.AttachmentRecord{
 		Name:             name,
 		OriginalFilename: filepath.Base(dir.Path),
@@ -133,7 +231,7 @@ func publishToolAttachment(
 	}
 
 	_, _ = emitter.AppendEvent(ctx, runID, store.Event{
-		Type:   store.EventBrowserScreenshot,
+		Type:   store.EventRunAttachmentPublished,
 		RunID:  runID,
 		NodeID: nodeID,
 		Data: map[string]any{

--- a/pkg/backend/model/tool_attachment.go
+++ b/pkg/backend/model/tool_attachment.go
@@ -1,0 +1,146 @@
+package model
+
+import (
+	"context"
+	"fmt"
+	"mime"
+	"os"
+	"path/filepath"
+	"strings"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// toolAttachmentDirective is the line prefix a tool node uses to hand a
+// file it produced to the run, so a downstream human gate can SHOW it.
+//
+// Shape: `[iterion] attachment=<path> [name=<n>] [mime=<type/subtype>]`
+//
+// Why this exists. A gate renders its inbound payload (iterion#332), and
+// a `file`-typed value is previewed by fetching
+// `GET /api/runs/{id}/attachments/{name}` — the descriptor's path is a
+// host or bind-mount path and is never reachable from a browser. So a
+// workflow that GENERATES a deliverable (a rendered video, an audio mix,
+// a chart) had no way to put it in front of the reviewer: attachments
+// only entered a run at launch or from an operator's own upload.
+//
+// This is the writing counterpart of `preview_screenshot=`, which
+// already promotes a browser capture the same way. Same protocol, same
+// store API, no new surface: a tool prints one line per file, the
+// runtime reads the bytes and persists them.
+const toolAttachmentDirective = "[iterion] attachment="
+
+// AttachmentDirective is one parsed `[iterion] attachment=...` line.
+// Path is host-absolute. Name defaults to the file's base name,
+// sanitised; MIME is sniffed from the extension when absent.
+type AttachmentDirective struct {
+	Path string
+	Name string
+	MIME string
+}
+
+// scanToolAttachments walks tool stdout and returns one directive per
+// matching line. Reading the file and persisting it is the runtime
+// hook's job, exactly as for screenshots.
+func scanToolAttachments(output string) []AttachmentDirective {
+	lines := scanDirectiveLines(output, toolAttachmentDirective)
+	if len(lines) == 0 {
+		return nil
+	}
+	found := make([]AttachmentDirective, 0, len(lines))
+	for _, tokens := range lines {
+		dir := AttachmentDirective{Path: tokens[0]}
+		for _, kv := range tokens[1:] {
+			eq := strings.IndexByte(kv, '=')
+			if eq <= 0 {
+				continue
+			}
+			switch kv[:eq] {
+			case "name":
+				dir.Name = kv[eq+1:]
+			case "mime":
+				dir.MIME = kv[eq+1:]
+			}
+		}
+		found = append(found, dir)
+	}
+	return found
+}
+
+// attachmentMIME resolves the stored MIME: the directive's own value
+// when it is well formed, else a sniff from the extension. An unknown
+// extension yields the generic binary type rather than a lie — the
+// studio falls back to a download link, which is still usable.
+func attachmentMIME(dir AttachmentDirective) string {
+	if declared := strings.TrimSpace(dir.MIME); declared != "" {
+		if parsed, _, err := mime.ParseMediaType(declared); err == nil && parsed != "" {
+			return parsed
+		}
+	}
+	if byExt := mime.TypeByExtension(filepath.Ext(dir.Path)); byExt != "" {
+		if parsed, _, err := mime.ParseMediaType(byExt); err == nil && parsed != "" {
+			return parsed
+		}
+	}
+	return "application/octet-stream"
+}
+
+// publishToolAttachment reads the file a tool declared and persists it
+// as a run attachment, so the studio can fetch it through the existing
+// `/api/runs/{id}/attachments/{name}` route.
+//
+// Failures are logged and non-fatal: a missing or unreadable file must
+// never abort a tool node. The tool's own output is the contract with
+// the workflow; the directive is how the bytes reach a human.
+func publishToolAttachment(
+	ctx context.Context,
+	sink AttachmentWriter,
+	emitter EventEmitter,
+	runID, nodeID string,
+	dir AttachmentDirective,
+	logger *iterlog.Logger,
+) {
+	f, err := os.Open(dir.Path)
+	if err != nil {
+		logger.Warn("Tool attachment [%s]: open %s: %v", nodeID, dir.Path, err)
+		return
+	}
+	defer f.Close()
+
+	// The name is the handle the gate's descriptor will carry, so it must
+	// survive the store's path sanitisation unchanged. A caller that
+	// supplies nothing gets the file's base name, which is what an
+	// operator would recognise in the review.
+	name := sanitizeAttachmentSegment(dir.Name)
+	if name == "" {
+		name = sanitizeAttachmentSegment(strings.TrimSuffix(
+			filepath.Base(dir.Path), filepath.Ext(dir.Path),
+		))
+	}
+	if name == "" {
+		name = fmt.Sprintf("attachment-%s", sanitizeAttachmentSegment(nodeID))
+	}
+
+	rec := store.AttachmentRecord{
+		Name:             name,
+		OriginalFilename: filepath.Base(dir.Path),
+		MIME:             attachmentMIME(dir),
+	}
+	if err := sink.WriteAttachment(ctx, runID, rec, f); err != nil {
+		logger.Warn("Tool attachment [%s]: write %s: %v", nodeID, name, err)
+		return
+	}
+
+	_, _ = emitter.AppendEvent(ctx, runID, store.Event{
+		Type:   store.EventBrowserScreenshot,
+		RunID:  runID,
+		NodeID: nodeID,
+		Data: map[string]any{
+			"attachment_name": name,
+			"source":          "tool-stdout",
+			"mime":            rec.MIME,
+		},
+	})
+	logger.Logf(iterlog.LevelInfo, "📎", "Tool attachment [%s]: %s", nodeID, name)
+}

--- a/pkg/backend/model/tool_attachment_test.go
+++ b/pkg/backend/model/tool_attachment_test.go
@@ -135,3 +135,130 @@ func TestPublishToolAttachmentDerivesTheNameAndSurvivesFailures(t *testing.T) {
 		AttachmentDirective{Path: filepath.Join(dir, "absent.mp4")}, logger,
 	)
 }
+
+func TestSplitAttachmentTailKeepsSpacesInThePath(t *testing.T) {
+	// Exported media routinely carries spaces. Before this, the shared
+	// whitespace scanner truncated the path and the file was skipped with
+	// a warning — the exact empty gate this verb removes.
+	got := scanToolAttachments(
+		"[iterion] attachment=/exports/final cut.mp4 name=final_video mime=video/mp4",
+	)
+	if len(got) != 1 {
+		t.Fatalf("scanToolAttachments = %#v, want 1 directive", got)
+	}
+	want := AttachmentDirective{
+		Path: "/exports/final cut.mp4", Name: "final_video", MIME: "video/mp4",
+	}
+	if got[0] != want {
+		t.Errorf("directive = %#v, want %#v", got[0], want)
+	}
+
+	// …and with no options at all, the whole tail is the path.
+	bare := scanToolAttachments("[iterion] attachment=/exports/final cut.mp4")
+	if len(bare) != 1 || bare[0].Path != "/exports/final cut.mp4" {
+		t.Errorf("bare spaced path = %#v", bare)
+	}
+}
+
+func TestActiveMIMEIsNeutralisedBeforeStorage(t *testing.T) {
+	// The serve route replies `Content-Disposition: inline` with no
+	// nosniff and no CSP, so an executable type would run in the
+	// studio's own origin. Tool stdout is not a trusted channel.
+	for _, declared := range []string{
+		"text/html", "image/svg+xml", "application/xhtml+xml",
+		"text/javascript", "application/javascript", "TEXT/HTML",
+	} {
+		got := attachmentMIME(AttachmentDirective{Path: "/tmp/x.bin", MIME: declared})
+		if got != "application/octet-stream" {
+			t.Errorf("attachmentMIME(%q) = %q, want application/octet-stream", declared, got)
+		}
+	}
+	// A .html path must not smuggle it back in through the extension.
+	if got := attachmentMIME(AttachmentDirective{Path: "/tmp/report.html"}); got != "application/octet-stream" {
+		t.Errorf("sniffed html = %q, want application/octet-stream", got)
+	}
+	// Media the gate is meant to preview is untouched.
+	for path, want := range map[string]string{
+		"/tmp/a.mp4": "video/mp4", "/tmp/a.mp3": "audio/mpeg", "/tmp/a.png": "image/png",
+	} {
+		if got := attachmentMIME(AttachmentDirective{Path: path}); got != want {
+			t.Errorf("attachmentMIME(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+// listingSink adds the optional read half so the collision guard engages.
+type listingSink struct {
+	recordingSink
+	existing []store.AttachmentRecord
+}
+
+func (s *listingSink) ListAttachments(
+	context.Context, string,
+) ([]store.AttachmentRecord, error) {
+	return s.existing, nil
+}
+
+func TestPublishToolAttachmentRefusesToClobberAnExistingName(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "final.mp4")
+	if err := os.WriteFile(path, []byte("new bytes"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	logger := iterlog.New(iterlog.LevelError, os.Stderr)
+
+	// An operator's own upload already holds the name: it must survive.
+	taken := &listingSink{existing: []store.AttachmentRecord{{Name: "final"}}}
+	publishToolAttachment(
+		context.Background(), taken, nopEmitter{}, "run-1", "publish",
+		AttachmentDirective{Path: path}, logger,
+	)
+	if taken.rec.Name != "" || taken.body != nil {
+		t.Errorf("existing attachment was clobbered: %#v", taken.rec)
+	}
+
+	// A free name goes through.
+	free := &listingSink{existing: []store.AttachmentRecord{{Name: "something_else"}}}
+	publishToolAttachment(
+		context.Background(), free, nopEmitter{}, "run-1", "publish",
+		AttachmentDirective{Path: path}, logger,
+	)
+	if free.rec.Name != "final" {
+		t.Errorf("free name did not publish: %#v", free.rec)
+	}
+}
+
+func TestPublishToolAttachmentSkipsWhatIsTooLargeOrNotAFile(t *testing.T) {
+	dir := t.TempDir()
+	logger := iterlog.New(iterlog.LevelError, os.Stderr)
+
+	// A directory is not a deliverable.
+	sink := &recordingSink{}
+	publishToolAttachment(
+		context.Background(), sink, nopEmitter{}, "run-1", "publish",
+		AttachmentDirective{Path: dir}, logger,
+	)
+	if sink.rec.Name != "" {
+		t.Errorf("a directory was published: %#v", sink.rec)
+	}
+
+	// Over the cap: skipped rather than copied into the store. The file
+	// is sparse so the test costs no real bytes.
+	big := filepath.Join(dir, "huge.mp4")
+	f, err := os.Create(big)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := f.Truncate(maxToolAttachmentBytes + 1); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	f.Close()
+	over := &recordingSink{}
+	publishToolAttachment(
+		context.Background(), over, nopEmitter{}, "run-1", "publish",
+		AttachmentDirective{Path: big}, logger,
+	)
+	if over.rec.Name != "" {
+		t.Errorf("an oversized file was published: %#v", over.rec)
+	}
+}

--- a/pkg/backend/model/tool_attachment_test.go
+++ b/pkg/backend/model/tool_attachment_test.go
@@ -1,0 +1,137 @@
+package model
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+func TestScanToolAttachmentsParsesNameAndMIME(t *testing.T) {
+	out := `building the mix…
+[iterion] attachment=/tmp/mix.mp3 name=audio_fr mime=audio/mpeg
+some other log line
+[iterion] attachment=/tmp/final.mp4
+[iterion] attachment=
+done`
+	got := scanToolAttachments(out)
+	if len(got) != 2 {
+		t.Fatalf("scanToolAttachments = %d directives, want 2: %#v", len(got), got)
+	}
+	if got[0] != (AttachmentDirective{Path: "/tmp/mix.mp3", Name: "audio_fr", MIME: "audio/mpeg"}) {
+		t.Errorf("first directive = %#v", got[0])
+	}
+	// A bare path is legal: name and MIME are derived later.
+	if got[1] != (AttachmentDirective{Path: "/tmp/final.mp4"}) {
+		t.Errorf("second directive = %#v", got[1])
+	}
+	if scanToolAttachments("nothing to see") != nil {
+		t.Error("plain output must not yield directives")
+	}
+}
+
+func TestAttachmentMIMEPrefersTheDeclaredValueThenTheExtension(t *testing.T) {
+	cases := []struct {
+		name string
+		dir  AttachmentDirective
+		want string
+	}{
+		{"declared wins", AttachmentDirective{Path: "/tmp/a.bin", MIME: "audio/mpeg"}, "audio/mpeg"},
+		{"declared with params", AttachmentDirective{Path: "/tmp/a.bin", MIME: "text/plain; charset=utf-8"}, "text/plain"},
+		{"sniffed from extension", AttachmentDirective{Path: "/tmp/clip.mp4"}, "video/mp4"},
+		{"garbage declaration falls back", AttachmentDirective{Path: "/tmp/clip.mp4", MIME: "not a mime"}, "video/mp4"},
+		{"unknown stays honest", AttachmentDirective{Path: "/tmp/thing.zzz"}, "application/octet-stream"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := attachmentMIME(tc.dir); got != tc.want {
+				t.Errorf("attachmentMIME = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// recordingSink captures what the hook asked the store to persist.
+type recordingSink struct {
+	rec  store.AttachmentRecord
+	body []byte
+	err  error
+}
+
+func (s *recordingSink) WriteAttachment(
+	_ context.Context, _ string, rec store.AttachmentRecord, body io.Reader,
+) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.rec = rec
+	s.body, _ = io.ReadAll(body)
+	return nil
+}
+
+type nopEmitter struct{}
+
+func (nopEmitter) AppendEvent(context.Context, string, store.Event) (*store.Event, error) {
+	return &store.Event{}, nil
+}
+
+func TestPublishToolAttachmentStoresTheBytesUnderAUsableName(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mix preview.mp3")
+	if err := os.WriteFile(path, []byte("ID3 fake audio"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	sink := &recordingSink{}
+	logger := iterlog.New(iterlog.LevelError, os.Stderr)
+
+	publishToolAttachment(
+		context.Background(), sink, nopEmitter{}, "run-1", "publish_audio",
+		AttachmentDirective{Path: path, Name: "audio_fr", MIME: "audio/mpeg"}, logger,
+	)
+
+	if sink.rec.Name != "audio_fr" {
+		t.Errorf("attachment name = %q, want audio_fr", sink.rec.Name)
+	}
+	if sink.rec.MIME != "audio/mpeg" {
+		t.Errorf("MIME = %q", sink.rec.MIME)
+	}
+	if sink.rec.OriginalFilename != "mix preview.mp3" {
+		t.Errorf("original filename = %q", sink.rec.OriginalFilename)
+	}
+	if string(sink.body) != "ID3 fake audio" {
+		t.Errorf("stored bytes = %q", sink.body)
+	}
+}
+
+func TestPublishToolAttachmentDerivesTheNameAndSurvivesFailures(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "final cut.mp4")
+	if err := os.WriteFile(path, []byte("mp4"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	logger := iterlog.New(iterlog.LevelError, os.Stderr)
+
+	// No name given: the file's stem becomes the handle, sanitised — the
+	// gate's descriptor carries this exact string.
+	sink := &recordingSink{}
+	publishToolAttachment(
+		context.Background(), sink, nopEmitter{}, "run-1", "publish",
+		AttachmentDirective{Path: path}, logger,
+	)
+	if sink.rec.Name != "final-cut" {
+		t.Errorf("derived name = %q, want final-cut", sink.rec.Name)
+	}
+	if sink.rec.MIME != "video/mp4" {
+		t.Errorf("derived MIME = %q, want video/mp4", sink.rec.MIME)
+	}
+
+	// A missing file must never abort the tool node.
+	publishToolAttachment(
+		context.Background(), &recordingSink{}, nopEmitter{}, "run-1", "publish",
+		AttachmentDirective{Path: filepath.Join(dir, "absent.mp4")}, logger,
+	)
+}

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -276,6 +276,21 @@ const (
 	//   - tool_call_id: optional, used by PR 3 to correlate with the
 	//     Playwright tool call that produced the frame
 	EventBrowserScreenshot EventType = "browser_screenshot"
+	// EventRunAttachmentPublished fires when a tool node hands a file
+	// it produced to the run via `[iterion] attachment=<path>`. The
+	// bytes are persisted as a regular attachment; this event carries
+	// only the pointer, so a downstream gate can show the deliverable.
+	//
+	// Deliberately NOT EventBrowserScreenshot: that one means "an image
+	// of a preview URL", and the studio appends it to the Browser
+	// pane's screenshot filmstrip. An mp4 or a pdf announced there
+	// would render as a broken <img>, open the Browser pane on a run
+	// that never opened a browser, and evict real captures from the
+	// scrubber. Data:
+	//   - attachment_name: store.AttachmentRecord.Name of the file
+	//   - mime: the stored (already neutralised) media type
+	//   - source: "tool-stdout"
+	EventRunAttachmentPublished EventType = "run_attachment_published"
 	// EventBrowserSessionStarted fires when the runtime attaches a
 	// Chromium instance to a node and registers it in the
 	// BrowserRegistry. The studio uses this signal to flip the


### PR DESCRIPTION
## The gap

A human gate previews a `file` value by fetching `GET /api/runs/{id}/attachments/{name}` — the descriptor's path is a host or sandbox bind-mount path, and [as #336 put it](https://github.com/SocialGouv/iterion/pull/336) it *"is not reachable from a browser at all"*.

So attachments only ever entered a run from a **person**: the launch form, a `file`-typed gate field, the 📎 button.

A workflow that **generates** a deliverable — a rendered video, an audio mix, a chart, a PDF — therefore had no way to show it to its own reviewer. Authors work around it by printing paths into `instructions:`, which the operator cannot open from the browser. I hit this on a video pipeline: every gate published its media, verified SHA-256, refused to continue if one was missing… and the reviewer saw nothing but a collapsed JSON blob.

## The change

Add the writing counterpart of `[iterion] preview_screenshot=`, which already promotes a browser capture the same way:

```
[iterion] attachment=<path> [name=<n>] [mime=<type/subtype>]
```

```sh
echo "[iterion] attachment=$PWD/exports/final.mp4 name=final_video mime=video/mp4"
```

The runtime reads the bytes and persists them through the same `WriteAttachment` path as an upload, so the result is an **ordinary run attachment** — same storage layout, same serving route, same presigning.

No new API surface: the stdout-directive protocol and its shared `scanDirectiveLines` scanner already existed. Only this verb was missing.

## Design notes

- **`name`** defaults to the file's base name without extension, sanitised to the segment charset — so the handle the gate's descriptor carries survives the store's own sanitisation unchanged.
- **`mime`** is honoured when well formed, else sniffed from the extension, else `application/octet-stream`. Never a fabricated type: the studio falls back to a download link for what it cannot render, which is better than a broken `<audio>`.
- **Failures are non-fatal.** A missing or unreadable file is logged and skipped, never enough to fail the tool node — a best-effort hand-off, exactly as for screenshots.

To show it at a gate, the node returns a descriptor and the edge maps it in its `with {}`:

```json
{"attachment": "final_video", "filename": "final.mp4", "mime": "video/mp4", "size": 57948692}
```

which `asFileRef` accepts (an `attachment` name plus one corroborating field).

## Tests

`pkg/backend/model/tool_attachment_test.go` — 4 tests covering the parser (interleaved log lines, a bare path, an empty directive), MIME resolution (declared / with params / sniffed / garbage / unknown), the actual write under a usable name, and name derivation plus tolerance to a missing file.

`go build ./...` clean, `go test ./pkg/backend/model/` green, `go vet` clean.

## Docs

`docs/attachments.md` gains its own section — including the descriptor shape to return for a gate — cross-referenced from `docs/human-in-the-loop.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)