### PR TITLE
feat: rewind a run in place to an earlier node

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1150,6 +1150,7 @@ iterion runs questions <run-id> [--store-dir]   # List a run's pending async (as
 iterion runs answer <run-id> <interaction-id> <answer> [--store-dir]  # Answer one pending async question (non-blocking; ADR-081)
 iterion resume --run-id --file [--answers-file] [--force]  # Resume paused/failed/cancelled run
 iterion fork --run-id <parent> --node <id> [--turn N] [--rewind-code]  # Fork a run at a prior LLM turn (resume with `iterion resume`)
+iterion rewind --run-id <id> [--auto | --node <id>] [--file]  # Re-anchor THIS run on an earlier node + invalidate downstream outputs/artifacts, then `iterion resume --force`. `--auto` diffs the edited .bot against the source the run executed and targets the change (bot-dev iteration; docs/resume.md)
 iterion diagram <file.bot> [--view]    # Generate Mermaid diagram (compact|detailed|full)
 iterion studio [--port] [--dir] [--bind] [--bots-path] [--no-browser-pane] [--max-concurrent-pipelines]  # Launch visual workflow editor (+ kanban /board, global /pipelines control-center board, /dispatcher dashboard, Browser pane, Launch modal, /bots gallery + per-bot home + guided builder at /bots/new). --max-concurrent-pipelines (default 3) caps concurrent root pipelines; excess wait in /pipelines Todo.
 iterion report --run-id <id> [--store-dir] [--output]  # Generate chronological run report

--- a/cmd/iterion/rewind.go
+++ b/cmd/iterion/rewind.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/spf13/cobra"
+)
+
+var rewindOpts struct {
+	runID     string
+	nodeID    string
+	auto      bool
+	keepFiles bool
+	file      string
+	storeDir  string
+}
+
+var rewindCmd = &cobra.Command{
+	Use:   "rewind",
+	Short: "Re-anchor a run on an earlier node and invalidate everything downstream (same run id)",
+	Long: `Rewind moves an existing run's checkpoint back to an already-executed node
+and drops the outputs of every node downstream of it, so the next resume
+re-executes from there instead of replaying the whole workflow.
+
+This is the loop for iterating on a bot's configuration: run it, see a node
+misbehave, fix the prompt/schema/edges in the .bot, rewind to that node, and
+resume — the upstream nodes you already paid for are kept.
+
+  # edit main.bot, then let iterion locate the edit:
+  iterion rewind --run-id RUN --auto
+  iterion resume --run-id RUN --force
+
+  # or target the pivot yourself:
+  iterion rewind --run-id RUN --node implement
+
+Rewind mutates THIS run — same id, same name, same lineage. Use 'iterion fork'
+instead when you want an alternative future in a new run with the original
+left intact.
+
+Downstream means forward-reachable from the pivot minus anything that can
+reach it back, so a loop's earlier stages survive for {{loop.*.previous_output}}.
+Budget accounting and loop counters are NOT refunded (raise them on resume with
+--max-cost-usd / --max-iterations).
+
+For a run with an isolated worktree (worktree: auto) the workspace is also
+restored to the state the pivot started from — a docs or code bot's real
+product is its files, not its output map. The restore is a revert: the prior
+tree is committed on top of HEAD and the current state is banked under a
+backup ref first, so nothing becomes unreachable. --keep-files opts out, and a
+run without a worktree says so rather than silently leaving the files.
+
+External effects (board cards, forge comments, pushed commits, already-launched
+subbot runs) are never undone.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if rewindOpts.runID == "" {
+			return fmt.Errorf("--run-id is required")
+		}
+		if rewindOpts.nodeID == "" && !rewindOpts.auto {
+			return fmt.Errorf("--node is required (or --auto to derive it from your edit)")
+		}
+		ctx := cmd.Context()
+		storeRoot := rewindOpts.storeDir
+		if storeRoot == "" {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("resolve cwd: %w", err)
+			}
+			storeRoot = store.ResolveStoreDir(cwd, "")
+		}
+		absStore, err := filepath.Abs(storeRoot)
+		if err != nil {
+			return fmt.Errorf("resolve store dir: %w", err)
+		}
+		svc, err := runview.NewService(absStore)
+		if err != nil {
+			return fmt.Errorf("open service: %w", err)
+		}
+		result, err := svc.Rewind(ctx, runview.RewindSpec{
+			RunID:      rewindOpts.runID,
+			NodeID:     rewindOpts.nodeID,
+			Auto:       rewindOpts.auto,
+			KeepFiles:  rewindOpts.keepFiles,
+			SourcePath: rewindOpts.file,
+		})
+		if err != nil {
+			return fmt.Errorf("rewind: %w", err)
+		}
+		p := newPrinter()
+		p.JSON(result)
+		if result.AutoTargeted {
+			for _, c := range result.Changes {
+				fmt.Fprintf(os.Stderr, "  changed: %s\n", c.String())
+			}
+		}
+		if result.PromotedFrom != "" {
+			fmt.Fprintf(os.Stderr, "  %q is inside a fan-out — anchored on its router %q so every branch replays\n",
+				result.PromotedFrom, result.NodeID)
+		}
+		fmt.Fprintf(os.Stderr, "rewound %s to %q (dropped: %s)\n",
+			result.RunID, result.NodeID, strings.Join(result.DroppedNodes, ", "))
+		if f := result.Files; f != nil {
+			if f.Reverted {
+				fmt.Fprintf(os.Stderr, "  workspace reverted to the state %q started from (backup: %s)\n", result.NodeID, f.BackupRef)
+			} else if f.SkipReason != "" {
+				fmt.Fprintf(os.Stderr, "  WARNING: files NOT reverted — %s\n", f.SkipReason)
+			}
+		}
+		for _, id := range result.OrphanedChildRuns {
+			fmt.Fprintf(os.Stderr, "  released child run %s (still alive — cancel it if it is burning budget)\n", id)
+		}
+		fmt.Fprintf(os.Stderr, "resume with: iterion resume --run-id %s%s\n",
+			result.RunID, forceHintFor(rewindOpts.file))
+		return nil
+	},
+}
+
+// forceHintFor nudges toward --force, since the overwhelmingly common
+// reason to rewind is that the .bot was (or is about to be) edited, and
+// resume refuses a source-hash mismatch without it.
+func forceHintFor(file string) string {
+	if file != "" {
+		return " --file " + file + " --force"
+	}
+	return " --force   # --force needed once the .bot source has changed"
+}
+
+func init() {
+	f := rewindCmd.Flags()
+	f.StringVar(&rewindOpts.runID, "run-id", "", "Run to rewind (mutated in place)")
+	f.StringVar(&rewindOpts.nodeID, "node", "", "Pivot node id (the node the run re-executes from)")
+	f.BoolVar(&rewindOpts.auto, "auto", false, "Derive the pivot by diffing your edited .bot against the source this run executed")
+	f.BoolVar(&rewindOpts.keepFiles, "keep-files", false, "Do not restore the workspace to the state the pivot started from")
+	f.StringVar(&rewindOpts.file, "file", "", "Workflow source to read the graph from (default: the run's persisted source)")
+	f.StringVar(&rewindOpts.storeDir, "store-dir", "", "Store directory override (default: managed store for the working directory)")
+	mustMarkRequired(rewindCmd, "run-id")
+	rootCmd.AddCommand(rewindCmd)
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -178,6 +178,26 @@ iterion fork --run-id PARENT --node implement --turn 0 --new-inputs inputs.json
 
 The new run is created in `cancelled` state at the selected conversation turn; resume it to execute. `--rewind-code` additionally requests the captured code snapshot where available. `--name` controls the friendly name.
 
+### `iterion rewind`
+
+```bash
+iterion rewind --run-id RUN --auto           # locate the edit itself
+iterion rewind --run-id RUN --node implement # or name the pivot
+iterion resume --run-id RUN --force          # after editing the .bot
+```
+
+Moves an existing run's checkpoint back onto an already-executed node and
+invalidates the outputs downstream of it, so the next resume replays from
+there. Same run id — use `fork` when you want the original left intact.
+`--auto` diffs your edited `.bot` against the source the run executed and
+rewinds to the earliest affected node — the bot-development loop in one step.
+`--node` accepts any node with a recorded output (including `tool` and
+`compute`, unlike fork's turn anchor); `--file` overrides the source the graph
+is read from. Budget accounting, loop counters, and `events.jsonl` are
+preserved; artifacts the dropped nodes published get a superseding `rewound`
+marker version. Files written into the workspace are NOT undone — see
+[resume](resume.md#rewind-resume-from-an-earlier-node).
+
 ### `iterion runs prune`
 
 ```bash

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -195,7 +195,9 @@ rewinds to the earliest affected node — the bot-development loop in one step.
 `compute`, unlike fork's turn anchor); `--file` overrides the source the graph
 is read from. Budget accounting, loop counters, and `events.jsonl` are
 preserved; artifacts the dropped nodes published get a superseding `rewound`
-marker version. Files written into the workspace are NOT undone — see
+marker version. For a `worktree: auto` run the workspace is also restored to the
+state the pivot started from — `--keep-files` opts out — while an in-place run's
+files are left alone and it says so. See
 [resume](resume.md#rewind-resume-from-an-earlier-node).
 
 ### `iterion runs prune`

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -126,6 +126,190 @@ The resume command accepts the same recovery-relevant controls as launch:
 When raising a budget, choose a cap above the amount already consumed. Merely
 repeating the old cap causes the re-executed node to hit the same guard.
 
+## Rewind: resume from an *earlier* node
+
+Resume always restarts at the checkpoint node. `iterion rewind` moves that
+checkpoint **backwards** onto a node the run already executed, so the next
+resume replays from there instead of from where the run stopped. It is the
+loop for iterating on a bot's configuration: run it, watch a node misbehave,
+fix the prompt/schema/edges, replay just the affected part.
+
+```bash
+# edit main.bot, then let iterion locate the edit:
+iterion rewind --run-id RUN_ID --auto
+iterion resume --run-id RUN_ID --force
+
+# or name the pivot yourself:
+iterion rewind --run-id RUN_ID --node implement
+```
+
+### `--auto`: rewind to the node you edited
+
+`--auto` diffs the workflow source the run executed against the source on disk
+now, and rewinds to the earliest node the edit affects — so the loop is *edit,
+rewind, resume*, with nothing to translate by hand. It prints what it detected,
+so you can confirm it understood the change before resuming.
+
+Detection is declaration-granular and resolves indirection:
+
+| You edited | `--auto` rewinds to |
+|---|---|
+| A node's prompt, model, schema ref, tools, command… | that node |
+| A shared `prompt` / `schema` / `cursor` body | every node referencing it, earliest first |
+| An edge (condition, `with` mapping, loop bound) | the node the edge leaves, which re-selects it |
+| `vars:`, `budget:`, `sandbox:`, `permission:`, `entry:` | the entry node — workflow scope reaches everything |
+| Several nodes on one chain | the upstream-most one, so a single pass tests them all |
+
+It errs toward reporting *more* nodes than strictly necessary: a false positive
+costs re-executing a node that did not need it, while a false negative would
+test the new configuration against stale downstream state — the failure the
+feature exists to prevent. Nodes the run never executed are ignored, and edits
+on independent fan-out branches are refused with the candidates named, since no
+single pivot covers them.
+
+`--auto` needs `Run.WorkflowSource`, the `.bot` text captured at launch
+(`WorkflowHash` only answers *whether* the source changed, never *which node*).
+Runs started before that capture existed refuse `--auto` and still accept
+`--node`. Comments and line shifts are not changes: the comparison runs on the
+AST encoder, which omits source spans.
+
+The run keeps its id, name, inputs, lineage, and budget accounting. Choose
+between the two operations by intent:
+
+| | `iterion fork` | `iterion rewind` |
+|---|---|---|
+| Run id | New child run | **Same run**, mutated |
+| Original | Untouched | Outputs downstream of the pivot invalidated |
+| Intent | An alternative future worth keeping side by side | "I misconfigured this — back up and replay" |
+| Anchor | Requires a **turn** checkpoint, so LLM nodes only | Any node with a recorded output, including `tool` and `compute` |
+| Audit | Two runs | One run plus a `run_rewound` event |
+
+### What gets invalidated
+
+The pivot's output is dropped, plus every node **forward-reachable from the
+pivot that cannot reach it back**. Subtracting the ancestors is what makes
+loops behave: in `implement -> verify -> implement as fix(3)`, `verify` is
+both downstream and upstream of `implement`, and its output is exactly what
+`implement` re-reads through `{{loop.fix.previous_output}}` on re-entry — so
+it survives. Over-dropping is as harmful as under-dropping, because a node
+whose output is deleted without re-executing before something reads it
+resolves to `nil` rather than to a re-run.
+
+Deliberately **not** reset:
+
+- **Budget accounting and loop counters.** Refunding them would make
+  rewind-then-resume an unbounded way around `max_cost_usd` and
+  `max_iterations`. Raise the caps on the resume instead
+  (`--max-cost-usd`, `--max-iterations`).
+- **Artifact versions.** Re-execution appends a new version, so the
+  superseded artifacts stay on disk and remain readable for comparison —
+  invalidation here is logical, not a delete.
+- **`events.jsonl`.** Append-only, never truncated. The dropped nodes' original
+  records stay in the timeline, and the `run_rewound` event
+  (`{from_node, to_node, dropped_nodes, code_rewound, code_ref}`) explains why
+  they are about to repeat.
+
+Reset, because carrying them into the replay would be wrong: any pending
+interaction (the rewound run never asked that question) and the backend
+session/conversation rehydration (the pivot must replay against the *edited*
+prompt, not the conversation the operator is trying to change).
+
+### Preconditions and limits
+
+The run must be `failed_resumable`, `cancelled`, `paused_operator`,
+`paused_waiting_human`, or `queued` — never `running`, whose engine owns the
+checkpoint and would overwrite the rewind at its next node boundary. Cancel or
+pause it first. The claim is a CAS, so a concurrent resume loses the race
+rather than being rewound out from under itself.
+
+The run is parked in `cancelled`. That is the one resumable status a cloud
+runner treats as "explicit resume required"; `failed_resumable` and
+`paused_operator` are auto-resumed on queue redelivery, which would race the
+operator's edit and execute the stale workflow.
+
+Rewind resolves "downstream" against the workflow source **as it is now**,
+which is why it performs no hash check — you rewind precisely because you
+edited the `.bot`. The resume that follows still needs `--force`. Pass
+`--file` when the source is not where the run recorded it.
+
+### Subbots and parallel branches
+
+A `subbot` node is an ordinary graph node, so the topology rules above apply to
+it unchanged. But the child run is tracked outside the checkpoint, in
+`Run.SubbotChildren` (**ADR-084**), and `ReattachSubbotChild` consults *only*
+that map and the child's status — never the parent's checkpoint, and before the
+child `.bot` is even compiled. Dropping the node's output is therefore not
+enough on its own: rewind also **releases the child pointers** of every dropped
+node, so the replay launches a fresh child against the edited child workflow
+instead of adopting the previous one. The released child run ids are reported
+(`orphaned_child_runs`); the runs themselves are left alone, so cancel one that
+is still burning budget.
+
+`--auto` does **not** see edits to a child `.bot`: it diffs the parent's source,
+and `SubbotNode.Source` points at a different file. After editing a child
+workflow, target the subbot node explicitly with `--node`.
+
+The checkpoint is granular to the **node**, never to the execution: at
+convergence the engine writes one entry per node id (last write wins), so N
+parallel executions of the same node collapse to one output. A rewind naming a
+node inside a fan-out body is therefore **promoted to the router** that
+orchestrates it, and the whole fan-out replays. Anchoring on the body node
+would replay it once, linearly, with no `each` context — silently testing one
+iteration instead of all of them. The promotion is reported as `promoted_from`;
+nested fan-outs promote to the outermost router, since an inner one re-run
+alone would itself lack the outer iteration's context.
+
+Sequential `loop` and `foreach` bodies need no promotion — they execute one at a
+time. Rewinding into one resumes at the **current** iteration, because loop
+counters are preserved; restarting the loop from zero would also refund the
+`max_iterations` budget.
+
+Two further limits worth planning around:
+
+- **Only engine state is rolled back.** Board cards, forge comments, pushed
+  commits, and already-launched subbot child runs are not. A rewound subbot
+  node re-runs and launches a *new* child; the old one stays, orphaned but
+  traceable.
+- **A rewind cannot target one branch of a fan-out.** The pivot is promoted to
+  the router and every branch replays (see above) — there is no per-branch
+  state to rewind to.
+
+### Files the dropped nodes produced
+
+A node's real product is often **not** its output map: a docs or code bot
+writes dozens of files and returns a summary. Rewinding the checkpoint alone
+would leave that half-written tree in place, and the replayed node would build
+on top of its own previous production instead of meeting its prior conditions.
+
+So a rewind also restores the workspace to the state the pivot started from.
+The anchor is `refs/iterion/runs/<run>/pre/<node>/<iter>`, written by
+`markPreNodeBoundary` when the node *starts* — distinct from
+`refs/…/nodes/<node>/<iter>`, written when it *finishes* and therefore holding
+that node's own output. The two bracket each node's effect. The pre-boundary
+marker is an alias of the previous boundary's snapshot commit (nothing touches
+the tree in between), so it costs one `update-ref` and no extra index walk.
+
+It is a **revert, not a reset**: the prior tree is committed on top of HEAD, so
+the run's own commits stay in `git log`, and the state at the instant of the
+rewind — uncommitted and untracked work included — is banked first under
+`refs/iterion/runs/<run>/rewind/<node>/<seq>`. Nothing the run ever had becomes
+unreachable. `--keep-files` opts out.
+
+Coverage is honest rather than silent, and it is narrower than it looks:
+
+| Run shape | Files restored? |
+|---|---|
+| `worktree: auto` (docs-refresh, feature-dev, wiki-gen, app-dev…) | yes |
+| in-place (the default — whole-improve-loop, modernize, review-pr…) | **no**, reported in `files.skip_reason` |
+| Gitignored paths (`dist/`, `.venv/`) | never — `git add -A` honours `.gitignore` |
+| Paths outside the workspace | never |
+
+An in-place run's workspace *is* the operator's live tree, which iterion
+deliberately does not snapshot — `git add -A` there would stage the operator's
+own work. Restoring files for those runs needs an iterion-owned workspace
+tracker (content-addressed, outside the repo, no git dependency), which does
+not exist yet; until then the rewind says so instead of pretending.
+
 ## Human and agent interaction resume
 
 For an ordinary `human` node, answers become that node's typed output and edge
@@ -167,5 +351,7 @@ failure; resume never reconstructs execution state by replaying events.
 | `pkg/runtime/resume.go` | Status dispatch, state/environment restoration, answer handling, and restart execution. |
 | `pkg/runtime/pause.go` | Operator and daily-cap checkpointed pauses. |
 | `pkg/cli/resume.go` | CLI admission, source reopening, overrides, locking, and stale-run takeover. |
+| `pkg/runview/rewind.go` | In-place rewind: pivot validation, downstream computation, checkpoint mutation, artifact tombstones. |
+| `pkg/runview/rewind_auto.go` | `--auto` targeting: declaration-granular source diff → impacted nodes → earliest pivot. |
 
 See also [persisted formats](persisted-formats.md), [human interaction](human-in-the-loop.md), [permissions](permissions.md), and [merge policy](merge-policy.md).

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -205,9 +205,11 @@ Deliberately **not** reset:
   superseded artifacts stay on disk and remain readable for comparison —
   invalidation here is logical, not a delete.
 - **`events.jsonl`.** Append-only, never truncated. The dropped nodes' original
-  records stay in the timeline, and the `run_rewound` event
-  (`{from_node, to_node, dropped_nodes, code_rewound, code_ref}`) explains why
-  they are about to repeat.
+  records stay in the timeline, and the `run_rewound` event explains why they
+  are about to repeat. Its payload is
+  `{from_node, to_node, dropped_nodes, tombstoned_artifacts, orphaned_child_runs,
+  promoted_from, files_reverted, files_ref, files_revert_commit,
+  files_backup_ref, files_skip_reason}`.
 
 Reset, because carrying them into the replay would be wrong: any pending
 interaction (the rewound run never asked that question) and the backend

--- a/e2e/rewind_resume_test.go
+++ b/e2e/rewind_resume_test.go
@@ -1,0 +1,152 @@
+package e2e
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// TestRewindThenResume_SkipsUpstreamNodes is the acceptance test for the
+// in-place rewind loop end to end: run → fail → rewind to a middle node →
+// resume, and assert the engine re-executes ONLY from the pivot.
+//
+// This is the property the whole feature exists for. Everything else
+// (checkpoint shape, dropped outputs) is a means to it: if `survey` and
+// `plan` execute a second time, the operator paid twice and the rewind
+// bought nothing over a plain re-run.
+func TestRewindThenResume_SkipsUpstreamNodes(t *testing.T) {
+	wf := compileFixtureStubSafe(t, "rewind_mini.bot")
+
+	storeDir := t.TempDir()
+	st, err := store.New(storeDir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+
+	// Pass 1: verify fails execution (a transient-style error, NOT the
+	// `fail` terminal node — reaching that is intentional termination and
+	// produces a non-resumable `failed` with the checkpoint cleared), so
+	// the run lands failed_resumable anchored on `verify`.
+	exec := newScenarioExecutor()
+	exec.on("verify", func(_ map[string]any) (map[string]any, error) {
+		return nil, errors.New("verify blew up")
+	})
+
+	const runID = "e2e-rewind-mini"
+	eng := runtime.New(wf, st, exec)
+	if err := eng.Run(context.Background(), runID, nil); err == nil {
+		t.Fatal("expected the run to fail (verify -> fail), got success")
+	}
+
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	if run.Checkpoint == nil {
+		t.Fatal("expected a checkpoint after the failing pass")
+	}
+	for _, id := range []string{"survey", "plan", "implement"} {
+		if exec.callCount(id) != 1 {
+			t.Fatalf("pass 1: %s called %d times, want 1", id, exec.callCount(id))
+		}
+	}
+
+	// The operator now edits main.bot and rewinds to `implement`.
+	svc, err := runview.NewService(storeDir, runview.WithLogger(iterlog.Nop()))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	result, err := svc.Rewind(context.Background(), runview.RewindSpec{
+		RunID:  runID,
+		NodeID: "implement",
+		// The e2e engine runs a compiled fixture with no persisted
+		// FilePath, so point the graph resolution at the source.
+		SourcePath: filepath.Join("testdata", "rewind_mini.bot"),
+	})
+	if err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+	if result.RunID != runID {
+		t.Fatalf("rewind minted run %q; it must mutate %q in place", result.RunID, runID)
+	}
+
+	// Pass 2: resume. `verify` now approves so the run can finish.
+	exec.on("verify", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"value": "approved", "ok": true}, nil
+	})
+	eng2 := runtime.New(wf, st, exec)
+	if err := eng2.Resume(context.Background(), runID, nil); err != nil {
+		t.Fatalf("resume after rewind: %v", err)
+	}
+
+	run, err = st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load run after resume: %v", err)
+	}
+	if run.Status != store.RunStatusFinished {
+		t.Errorf("status after rewind+resume = %s, want finished", run.Status)
+	}
+
+	// The point of the whole feature: upstream stays paid-for.
+	for _, id := range []string{"survey", "plan"} {
+		if n := exec.callCount(id); n != 1 {
+			t.Errorf("%s executed %d times across rewind+resume, want 1 — upstream must not replay", id, n)
+		}
+	}
+	// The pivot and its downstream do replay.
+	if n := exec.callCount("implement"); n != 2 {
+		t.Errorf("implement executed %d times, want 2 (once per pass) — the pivot must re-execute", n)
+	}
+	if n := exec.callCount("verify"); n != 2 {
+		t.Errorf("verify executed %d times, want 2 — downstream of the pivot must re-execute", n)
+	}
+
+	events, err := st.LoadEvents(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load events: %v", err)
+	}
+	if !hasEvent(events, store.EventRunRewound) {
+		t.Error("missing run_rewound event — the rewind must leave an audit marker")
+	}
+	// events.jsonl is append-only: the first pass's node_started records
+	// survive alongside the replayed ones.
+	if n := countEventType(events, store.EventNodeStarted); n < 6 {
+		t.Errorf("node_started count = %d, want >= 6 (4 first pass + 2 replayed) — history must not be truncated", n)
+	}
+	if !hasEvent(events, store.EventRunResumed) {
+		t.Error("missing run_resumed event")
+	}
+}
+
+// TestRewind_RefusesRunningRun_E2E guards the concurrency precondition
+// against the real store rather than a hand-built run doc.
+func TestRewind_RefusesRunningRun_E2E(t *testing.T) {
+	storeDir := t.TempDir()
+	st, err := store.New(storeDir)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	const runID = "e2e-rewind-running"
+	if _, err := st.CreateRun(context.Background(), runID, "rewind_mini", nil); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	// CreateRun parks a run in `running` by contract.
+	svc, err := runview.NewService(storeDir, runview.WithLogger(iterlog.Nop()))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	_, err = svc.Rewind(context.Background(), runview.RewindSpec{
+		RunID:      runID,
+		NodeID:     "implement",
+		SourcePath: filepath.Join("testdata", "rewind_mini.bot"),
+	})
+	if !errors.Is(err, runview.ErrRewindNotRewindable) {
+		t.Fatalf("Rewind on a running run: err = %v, want ErrRewindNotRewindable", err)
+	}
+}

--- a/e2e/testdata/rewind_mini.bot
+++ b/e2e/testdata/rewind_mini.bot
@@ -1,0 +1,41 @@
+## Minimal fixture for the in-place rewind path (runview.Service.Rewind):
+## a straight survey -> plan -> implement -> verify chain, so a rewind to
+## `implement` has an unambiguous upstream (survey, plan — must survive)
+## and downstream (verify — must be invalidated). Exercised by
+## rewind_resume_test.go with the scenario stub: no LLM, no sandbox, no
+## tools.
+
+schema note:
+  value: string
+
+schema check:
+  value: string
+  ok: bool
+
+agent survey:
+  model: "claude-opus-4-7"
+  output: note
+
+agent plan:
+  model: "claude-opus-4-7"
+  output: note
+
+agent implement:
+  model: "claude-opus-4-7"
+  output: note
+
+judge verify:
+  model: "claude-opus-4-7"
+  output: check
+
+workflow rewind_mini:
+  entry: survey
+
+  budget:
+    max_iterations: 20
+
+  survey -> plan
+  plan -> implement
+  implement -> verify
+  verify -> done when ok
+  verify -> fail

--- a/openapi.json
+++ b/openapi.json
@@ -5675,6 +5675,30 @@
         ]
       }
     },
+    "/api/runs/{id}/rewind": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "postRunsByIdRewind",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "POST /api/runs/{id}/rewind",
+        "tags": [
+          "runs"
+        ]
+      }
+    },
     "/api/runs/{id}/session-board": {
       "get": {
         "operationId": "getRunsByIdSessionBoard",

--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -84,6 +84,7 @@ type Engine struct {
 	onEvent                  func(evt store.Event)    // optional observer fired after every successful append
 	recoveryDispatch         RecoveryDispatch         // optional; consulted on node execution failure
 	workflowHash             string                   // SHA-256 of the .bot source, set via WithWorkflowHash
+	workflowSource           string                   // .bot text at launch, set via WithWorkflowSource (else read from filePath)
 	filePath                 string                   // absolute .bot source path, set via WithFilePath
 	parentRunID              string                   // immediate parent run, set via WithParentRunID for nested executions
 	parentNodeID             string                   // IR node id of the parent's subbot node that spawned this run, set via WithParentNodeID
@@ -265,7 +266,15 @@ type runState struct {
 	// still observes it. Distinct from the lossy cross-run pkg/eventbus.
 	events           *runEvents
 	artifactVersions map[string]int
-	budget           *SharedBudget // shared across branches, nil if no budget
+	// lastSnapshotCommit is the commit capturing the workspace as the
+	// previous node boundary left it, or "" meaning "identical to HEAD".
+	// The next node's pre-boundary marker aliases it, so recording
+	// "state before node N" costs one update-ref instead of a second
+	// index walk. Written and read only on the main execution path
+	// (fan-out branches never snapshot — workspace safety admits a
+	// single mutating branch), so it needs no lock.
+	lastSnapshotCommit string
+	budget             *SharedBudget // shared across branches, nil if no budget
 
 	// resourceSemaphores holds one buffered channel per declared workflow
 	// resource, pre-seeded with its tokens and shared by reference across all

--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -267,14 +267,24 @@ type runState struct {
 	events           *runEvents
 	artifactVersions map[string]int
 	// lastSnapshotCommit is the commit capturing the workspace as the
-	// previous node boundary left it, or "" meaning "identical to HEAD".
-	// The next node's pre-boundary marker aliases it, so recording
-	// "state before node N" costs one update-ref instead of a second
-	// index walk. Written and read only on the main execution path
-	// (fan-out branches never snapshot — workspace safety admits a
+	// previous node boundary left it, or "" meaning UNKNOWN (run start,
+	// resume, or just out of a special dispatch that may have mutated the
+	// tree). When it is known, the next node's pre-boundary marker aliases
+	// it, so recording "state before node N" costs one update-ref instead
+	// of a second index walk. Written and read only on the main execution
+	// path (fan-out branches never snapshot — workspace safety admits a
 	// single mutating branch), so it needs no lock.
 	lastSnapshotCommit string
-	budget             *SharedBudget // shared across branches, nil if no budget
+	// preMarked deduplicates markPreNodeBoundary per (node, loopIter):
+	// several dispatch paths bracket the same node — execLoop brackets
+	// every isSpecialDispatch kind, and execSpecialNode / the human-node
+	// path bracket it again. A second call is pure duplicated work (the
+	// same tree, hence the same ref target), but when lastSnapshotCommit
+	// is UNKNOWN each one runs a full `git add -A` index walk and leaves
+	// an orphan commit object. Same-key entries are dropped; a later loop
+	// iteration carries a different key and re-marks.
+	preMarked map[string]bool
+	budget    *SharedBudget // shared across branches, nil if no budget
 
 	// resourceSemaphores holds one buffered channel per declared workflow
 	// resource, pre-seeded with its tokens and shared by reference across all
@@ -388,6 +398,7 @@ func (e *Engine) newRunState(runID string, inputs map[string]any) *runState {
 		loopStaleness:      make(map[string]int),
 		roundRobinCounters: make(map[string]int),
 		artifactVersions:   make(map[string]int),
+		preMarked:          make(map[string]bool),
 		nodeAttempts:       make(map[string]map[ErrorCode]int),
 		budget:             newSharedBudget(e.workflow.Budget, e.logger),
 		resourceSemaphores: buildResourceSemaphores(e.workflow.Resources, e.workflow.ResourceMembers),

--- a/pkg/runtime/engine_exec.go
+++ b/pkg/runtime/engine_exec.go
@@ -60,11 +60,26 @@ func (e *Engine) execLoop(ctx context.Context, rs *runState, startNodeID string)
 				fmt.Sprintf("node %q not found", currentNodeID))
 		}
 
+		// A specially-dispatched node (fan-out, round-robin, LLM router,
+		// compute, review gate, subbot) is bracketed here rather than in
+		// execLoopAfterExec, which it never reaches. Two distinct needs:
+		// the node gets its OWN pre-marker so a rewind promoted to a
+		// router has an anchor at all, and the remembered anchor is
+		// invalidated afterwards because these paths DO mutate the tree —
+		// fan-out branches write, a non-isolated subbot child writes into
+		// the parent worktree, and the review gate squash-merges — while
+		// none of them refreshes lastSnapshotCommit. Aliasing across one
+		// makes a later rewind revert past that work while its outputs
+		// stay in the checkpoint.
+		if isSpecialDispatch(node) {
+			e.markPreNodeBoundary(rs, currentNodeID)
+		}
 		handled, terminate, next, err := e.execLoopDispatchSpecial(ctx, rs, currentNodeID, node)
 		if handled {
 			if terminate {
 				return err
 			}
+			rs.lastSnapshotCommit = ""
 			currentNodeID = next
 			continue
 		}
@@ -741,4 +756,24 @@ func (e *Engine) selectEdgeRS(rs *runState, fromNodeID string, output map[string
 	}
 
 	return selected.To, nil
+}
+
+// isSpecialDispatch reports whether a node is handled by
+// execLoopDispatchSpecial rather than the standard executor path.
+//
+// Those nodes never reach execLoopAfterExec, so nothing else brackets
+// them. Routers matter most: a rewind promotes any pivot inside a fan-out
+// body to its router, so without a marker here the single case where the
+// most files were written by the most nodes is the one that can never
+// restore them.
+func isSpecialDispatch(node ir.Node) bool {
+	switch n := node.(type) {
+	case *ir.RouterNode:
+		return n.RouterMode != ir.RouterCondition
+	case *ir.HumanNode:
+		return true
+	case *ir.ComputeNode, *ir.SubbotNode, *ir.EmitNode, *ir.WaitNode, *ir.AwaitAnswersNode:
+		return true
+	}
+	return false
 }

--- a/pkg/runtime/engine_exec.go
+++ b/pkg/runtime/engine_exec.go
@@ -262,6 +262,10 @@ func (e *Engine) execLoopRunNode(ctx context.Context, rs *runState, currentNodeI
 	if iterPath != "" {
 		payload["iteration_path"] = iterPath
 	}
+	// Bracket the node: record the workspace it starts from, so a rewind
+	// can restore its prior conditions (files included), not just its
+	// declared output.
+	e.markPreNodeBoundary(rs, currentNodeID)
 	if err := e.emit(rs.ctx, rs.runID, store.EventNodeStarted, currentNodeID, payload); err != nil {
 		return nil, false, err
 	}
@@ -552,8 +556,43 @@ func (e *Engine) snapshotAtNodeBoundary(rs *runState, nodeID string) {
 	}
 	loopIter := e.currentLoopIteration(nodeID, rs.loopCounters)
 	ref := nodeSnapshotRef(rs.runID, nodeID, loopIter)
-	if _, err := snapshotWorktree(e.workDir, ref); err != nil && e.logger != nil {
-		e.logger.Warn("snapshot: node %q iter %d: %v", nodeID, loopIter, err)
+	commit, err := snapshotWorktree(e.workDir, ref)
+	if err != nil {
+		if e.logger != nil {
+			e.logger.Warn("snapshot: node %q iter %d: %v", nodeID, loopIter, err)
+		}
+		return
+	}
+	// Remember the workspace as it stands now so the NEXT node's
+	// pre-boundary marker is a free alias of this commit. An empty SHA
+	// means the tree matched HEAD, so "" is the correct sentinel for
+	// "current state is HEAD" — HEAD may itself have moved if this node
+	// committed.
+	rs.lastSnapshotCommit = commit
+}
+
+// markPreNodeBoundary records the workspace a node is ABOUT to execute
+// against, under NodePreSnapshotRef. This is the anchor an in-place
+// rewind reverts to: NodeSnapshotRef is written after the node ran and
+// therefore holds that node's own production — a bot that writes docs or
+// code would be "rewound" onto the very files the rewind means to
+// discard.
+//
+// Nothing modifies the tree between the previous node's post-snapshot and
+// this call, so the state is already captured by rs.lastSnapshotCommit:
+// this is one `update-ref`, not a second O(filecount) index walk per node.
+func (e *Engine) markPreNodeBoundary(rs *runState, nodeID string) {
+	if e.workDir == "" || !rs.isWorktree {
+		return
+	}
+	target := rs.lastSnapshotCommit
+	if target == "" {
+		target = "HEAD"
+	}
+	loopIter := e.currentLoopIteration(nodeID, rs.loopCounters)
+	ref := store.NodePreSnapshotRef(rs.runID, nodeID, loopIter)
+	if out, err := runGit(e.workDir, "update-ref", ref, target); err != nil && e.logger != nil {
+		e.logger.Warn("pre-snapshot: node %q iter %d: %v\noutput: %s", nodeID, loopIter, err, out)
 	}
 }
 

--- a/pkg/runtime/engine_exec.go
+++ b/pkg/runtime/engine_exec.go
@@ -601,6 +601,21 @@ func (e *Engine) markPreNodeBoundary(rs *runState, nodeID string) {
 		return
 	}
 	loopIter := e.currentLoopIteration(nodeID, rs.loopCounters)
+	// Several dispatch paths bracket the same node: execLoop brackets every
+	// isSpecialDispatch kind, then execSpecialNode brackets the compute /
+	// subbot / emit / wait / await_answers kinds again, and the human path
+	// does the same. The repeat lands on the same tree, so it is pure
+	// duplicated work — but with lastSnapshotCommit UNKNOWN (its state
+	// after every special dispatch) each call pays a full `git add -A`
+	// index walk and leaves an orphan commit.
+	if rs.preMarked == nil {
+		rs.preMarked = make(map[string]bool)
+	}
+	key := fmt.Sprintf("%s\x00%d", nodeID, loopIter)
+	if rs.preMarked[key] {
+		return
+	}
+	rs.preMarked[key] = true
 	ref := store.NodePreSnapshotRef(rs.runID, nodeID, loopIter)
 	target := rs.lastSnapshotCommit
 	if target == "" {

--- a/pkg/runtime/engine_exec.go
+++ b/pkg/runtime/engine_exec.go
@@ -600,12 +600,36 @@ func (e *Engine) markPreNodeBoundary(rs *runState, nodeID string) {
 	if e.workDir == "" || !rs.isWorktree {
 		return
 	}
-	target := rs.lastSnapshotCommit
-	if target == "" {
-		target = "HEAD"
-	}
 	loopIter := e.currentLoopIteration(nodeID, rs.loopCounters)
 	ref := store.NodePreSnapshotRef(rs.runID, nodeID, loopIter)
+	target := rs.lastSnapshotCommit
+	if target == "" {
+		// "" means UNKNOWN, not "the tree equals HEAD" — the run just
+		// started, just resumed, or just came out of a special dispatch
+		// that mutated the tree. Only the first of those implies HEAD; in
+		// the other two the worktree carries uncommitted work HEAD does
+		// not, because the engine never commits the tree (snapshotWorktree
+		// only writes a ref). Aliasing HEAD there makes a later rewind
+		// `read-tree --reset` + `clean -fd` back to HEAD, deleting
+		// everything every fan-out branch and every earlier node produced
+		// — strictly worse than the stale alias this replaced, which would
+		// at least have restored the pre-fan-out tree.
+		//
+		// So capture the real state. snapshotWorktree returns "" and
+		// writes no ref only when the tree genuinely matches HEAD, which
+		// is the one case where aliasing is right.
+		commit, err := snapshotWorktree(e.workDir, ref)
+		if err != nil {
+			if e.logger != nil {
+				e.logger.Warn("pre-snapshot: node %q iter %d: %v", nodeID, loopIter, err)
+			}
+			return
+		}
+		if commit != "" {
+			return // snapshotWorktree already pointed the ref at it
+		}
+		target = "HEAD"
+	}
 	if out, err := runGit(e.workDir, "update-ref", ref, target); err != nil && e.logger != nil {
 		e.logger.Warn("pre-snapshot: node %q iter %d: %v\noutput: %s", nodeID, loopIter, err, out)
 	}

--- a/pkg/runtime/engine_options.go
+++ b/pkg/runtime/engine_options.go
@@ -153,6 +153,17 @@ func WithWorkflowHash(hash string) EngineOption {
 	return func(e *Engine) { e.workflowHash = hash }
 }
 
+// WithWorkflowSource records the .bot text as it is at launch, so a
+// later `iterion rewind --auto` can diff the edited workflow against
+// what this run actually executed and target the changed node.
+//
+// Callers that already hold the source (cloud launches, which receive it
+// uploaded rather than on disk) should pass it here; otherwise the
+// engine reads it from the path given to WithFilePath.
+func WithWorkflowSource(src string) EngineOption {
+	return func(e *Engine) { e.workflowSource = src }
+}
+
 // WithFilePath records the absolute .bot source path on the run
 // metadata so that resume (and the run console) can re-locate the
 // workflow without the caller having to thread it back through the

--- a/pkg/runtime/engine_run.go
+++ b/pkg/runtime/engine_run.go
@@ -12,6 +12,40 @@ import (
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
+// maxPersistedWorkflowSource caps the .bot text stamped onto a run.
+// A `.bot` is a few KB in practice; the cap only exists so a pathological
+// generated workflow cannot bloat every run document. Exceeding it
+// disables `rewind --auto` for that run, nothing else.
+const maxPersistedWorkflowSource = 1 << 20 // 1 MiB
+
+// resolveWorkflowSource returns the .bot text to persist on the run:
+// the explicitly supplied source when the caller had it in hand (cloud
+// launches receive it uploaded), else a best-effort read of filePath.
+//
+// Best-effort by design — this only powers `rewind --auto`'s ability to
+// name the changed node. A source we cannot read or that busts the cap
+// leaves the run auto-targetable=false and `--node` unaffected.
+func (e *Engine) resolveWorkflowSource() string {
+	if e.workflowSource != "" {
+		if len(e.workflowSource) > maxPersistedWorkflowSource {
+			return ""
+		}
+		return e.workflowSource
+	}
+	if e.filePath == "" {
+		return ""
+	}
+	info, err := os.Stat(e.filePath)
+	if err != nil || info.Size() > maxPersistedWorkflowSource {
+		return ""
+	}
+	b, err := os.ReadFile(e.filePath)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
 // Run executes the workflow. It creates a run, walks the graph from the
 // entry node, and returns when a terminal node is reached, a human pause
 // is hit (ErrRunPaused), or an error occurs.
@@ -227,6 +261,9 @@ func (e *Engine) runResolveDoc(ctx context.Context, runID string, inputs map[str
 		}
 		if e.filePath != "" {
 			run.FilePath = e.filePath
+		}
+		if src := e.resolveWorkflowSource(); src != "" {
+			run.WorkflowSource = src
 		}
 		if e.parentRunID != "" {
 			run.ParentRunID = e.parentRunID

--- a/pkg/runtime/engine_run.go
+++ b/pkg/runtime/engine_run.go
@@ -255,7 +255,7 @@ func (e *Engine) runResolveDoc(ctx context.Context, runID string, inputs map[str
 		}
 		run = created
 	}
-	if e.workflowHash != "" || e.filePath != "" || e.parentRunID != "" || e.parentNodeID != "" || e.runName != "" || e.mergeStrategy != "" || e.autoMerge || e.preset != "" || e.bundle != nil || e.source != nil || e.callbackURL != "" || len(e.modelOverrides) > 0 || e.workflow.Budget != nil {
+	if e.workflowHash != "" || e.workflowSource != "" || e.filePath != "" || e.parentRunID != "" || e.parentNodeID != "" || e.runName != "" || e.mergeStrategy != "" || e.autoMerge || e.preset != "" || e.bundle != nil || e.source != nil || e.callbackURL != "" || len(e.modelOverrides) > 0 || e.workflow.Budget != nil {
 		if e.workflowHash != "" {
 			run.WorkflowHash = e.workflowHash
 		}

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -656,6 +656,7 @@ func (e *Engine) resumeFromFailure(ctx context.Context, r *store.Run) error {
 
 	e.pushExecutorVars(rs.vars)
 
+	e.restampWorkflowSource(ctx, r)
 	loopErr := e.execLoop(ctx, rs, restartNodeID)
 	e.evictRunSessions(runID, loopErr)
 	// Mirrors resumeFromPause: a worktree run that fails resumably and
@@ -1645,4 +1646,29 @@ func (e *Engine) currentLoopIterationPath(nodeID string, loopCounters map[string
 // tag their log output as [NodeID#iter/...].
 func (e *Engine) ctxWithIteration(ctx context.Context, nodeID string, loopCounters map[string]int) context.Context {
 	return model.WithLoopIteration(ctx, e.currentLoopIteration(nodeID, loopCounters))
+}
+
+// restampWorkflowSource refreshes Run.WorkflowSource to the text this
+// resume is about to execute.
+//
+// Without it, `rewind --auto` compares against the source as it was at
+// the ORIGINAL launch, so every iteration re-reports the edits of the
+// previous ones: the second rewind of a session drops three nodes where
+// one was needed, the third more, and the cost grows monotonically —
+// precisely the loop the feature exists to cheapen.
+//
+// Only refreshed when the engine holds a source AND it actually differs,
+// so a plain resume touches nothing.
+func (e *Engine) restampWorkflowSource(ctx context.Context, r *store.Run) {
+	src := e.resolveWorkflowSource()
+	if src == "" || r == nil || src == r.WorkflowSource {
+		return
+	}
+	r.WorkflowSource = src
+	if e.workflowHash != "" {
+		r.WorkflowHash = e.workflowHash
+	}
+	if err := e.store.SaveRun(ctx, r); err != nil && e.logger != nil {
+		e.logger.Warn("resume: re-stamp workflow source for %s: %v", r.ID, err)
+	}
 }

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -1674,7 +1674,26 @@ func (e *Engine) restampWorkflowSource(ctx context.Context, r *store.Run) {
 	if e.workflowHash != "" {
 		r.WorkflowHash = e.workflowHash
 	}
-	if err := e.store.SaveRun(ctx, r); err != nil && e.logger != nil {
+	// Re-read before writing. BOTH call sites run AFTER the resume CAS
+	// flipped the run to `running` — and the claim helpers mutate their
+	// OWN copy (UpdateRunStatusIf → loadRunRaw), never the caller's `r`,
+	// which therefore still carries the pre-claim status. SaveRun writes
+	// the whole document, so saving `r` verbatim would silently undo the
+	// claim: the run persists as cancelled/paused_* for its entire
+	// execution, the Checkpoint and FinishedAt that the `running`
+	// transition deliberately cleared come back, and — worst — the
+	// duplicate-resume guard falls, letting a second concurrent resume
+	// claim the same run id and spawn a second engine on it.
+	fresh, lerr := e.store.LoadRun(ctx, r.ID)
+	if lerr != nil {
+		if e.logger != nil {
+			e.logger.Warn("resume: re-stamp workflow source for %s: reload: %v", r.ID, lerr)
+		}
+		return
+	}
+	fresh.WorkflowSource = r.WorkflowSource
+	fresh.WorkflowHash = r.WorkflowHash
+	if err := e.store.SaveRun(ctx, fresh); err != nil && e.logger != nil {
 		e.logger.Warn("resume: re-stamp workflow source for %s: %v", r.ID, err)
 	}
 }

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -260,6 +260,12 @@ func (e *Engine) resumeFromPause(ctx context.Context, r *store.Run, answers map[
 	// Init maps when the checkpoint deserialised with omitted fields
 	// (Mongo bson omitempty, legacy stores) — a nil map here would
 	// crash selectEdgeRS the first time it tries `rs.loopCounters[X]++`.
+	// Restamp here as well as on the failure path: a run resumed from a
+	// human pause with `--file X --force` executes the NEW source, and
+	// leaving Run.WorkflowSource at the launch text makes the next
+	// `rewind --auto` re-report edits that already ran — the same
+	// monotonically-growing pivot the failure path restamps to avoid.
+	e.restampWorkflowSource(ctx, r)
 	rs, sandboxCleanup, rbErr := e.resumeRebuildState(ctx, r, cp, outputs, artifactVersions)
 	if rbErr != nil {
 		return rbErr

--- a/pkg/runtime/resume_internal_test.go
+++ b/pkg/runtime/resume_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -324,5 +325,68 @@ func TestCurrentLoopIterationPath_FallbackToEdgeMembership(t *testing.T) {
 	// And currentLoopIteration mirrors that.
 	if it := e.currentLoopIteration("y", map[string]int{"L": 4}); it != 4 {
 		t.Errorf("currentLoopIteration fallback: got %d, want 4", it)
+	}
+}
+
+// ---- restampWorkflowSource ----
+
+// TestRestampWorkflowSource_PreservesTheResumeClaim is Revi's Rafe0da.
+//
+// Both call sites run AFTER the resume compare-and-set has flipped the run
+// to `running`, and the claim helpers mutate their OWN copy of the record
+// (UpdateRunStatusIf → loadRunRaw), never the caller's. Saving that stale
+// in-memory snapshot verbatim silently undid the claim: the run persisted
+// as cancelled/paused_* for its whole execution, the Checkpoint and
+// FinishedAt the `running` transition deliberately clears came back, and
+// the duplicate-resume guard fell — a second concurrent resume would find
+// a resumable status, win its CAS, and spawn a second engine on one run id.
+func TestRestampWorkflowSource_PreservesTheResumeClaim(t *testing.T) {
+	ctx := context.Background()
+	st := tmpStore(t)
+
+	finished := time.Now().UTC()
+	r := &store.Run{
+		ID:             "run-restamp",
+		Status:         store.RunStatusCancelled,
+		WorkflowSource: "old source",
+		Checkpoint:     &store.Checkpoint{NodeID: "implement"},
+		FinishedAt:     &finished,
+	}
+	if err := st.SaveRun(ctx, r); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+
+	// The claim, exactly as claimForResume performs it.
+	claimed, err := st.UpdateRunStatusIf(ctx, r.ID, store.RunStatusRunning, "",
+		[]store.RunStatus{store.RunStatusCancelled})
+	if err != nil || !claimed {
+		t.Fatalf("claim: claimed=%v err=%v", claimed, err)
+	}
+	// `r` is deliberately NOT refreshed — that is the caller's real state.
+
+	e := &Engine{store: st, workflowSource: "new source", workflowHash: "hash-new"}
+	e.restampWorkflowSource(ctx, r)
+
+	got, err := st.LoadRun(ctx, r.ID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.Status != store.RunStatusRunning {
+		t.Errorf("status = %q, want %q — the restamp reverted the resume claim, "+
+			"letting a second concurrent resume claim the same run",
+			got.Status, store.RunStatusRunning)
+	}
+	if got.Checkpoint != nil {
+		t.Errorf("checkpoint resurrected (%+v) — the running transition clears it", got.Checkpoint)
+	}
+	if got.FinishedAt != nil {
+		t.Errorf("finished_at resurrected (%v) — the studio duration ticker freezes on it", got.FinishedAt)
+	}
+	// The restamp must still have done its job.
+	if got.WorkflowSource != "new source" {
+		t.Errorf("workflow_source = %q, want %q", got.WorkflowSource, "new source")
+	}
+	if got.WorkflowHash != "hash-new" {
+		t.Errorf("workflow_hash = %q, want %q", got.WorkflowHash, "hash-new")
 	}
 }

--- a/pkg/runtime/snapshot.go
+++ b/pkg/runtime/snapshot.go
@@ -91,6 +91,23 @@ func snapshotWorktree(wtPath, ref string) (string, error) {
 	return commit, nil
 }
 
+// SnapshotWorktree is the exported form of snapshotWorktree for callers
+// outside the engine needing the exact same capture semantics. The
+// in-place rewind uses it to bank a worktree's uncommitted state before
+// reverting, so the revert loses nothing. Exported rather than
+// reimplemented because the plumbing is subtle (index restoration, the
+// two distinct no-op cases) and a divergent copy would rot.
+func SnapshotWorktree(wtPath, ref string) (string, error) {
+	return snapshotWorktree(wtPath, ref)
+}
+
+// RunGitIn runs a git command in a worktree on behalf of an out-of-engine
+// caller (the rewind's revert), reusing gitCmd's LC_ALL=C + process-group
+// detach so a `watchexec -r` SIGTERM cannot interrupt a ref update.
+func RunGitIn(wtPath string, args ...string) (string, error) {
+	return runGit(wtPath, args...)
+}
+
 // worktreeStateClean reports whether the worktree at wtPath has no
 // tracked changes from HEAD and no untracked files. Used as the fast
 // path in snapshotWorktree to skip the `git add -A` index walk when

--- a/pkg/runtime/special_node.go
+++ b/pkg/runtime/special_node.go
@@ -52,6 +52,7 @@ func (e *Engine) execSpecialNode(
 	for k, v := range extraStarted {
 		startedPayload[k] = v
 	}
+	e.markPreNodeBoundary(rs, nodeID)
 	if err := e.emit(rs.ctx, rs.runID, store.EventNodeStarted, nodeID, startedPayload); err != nil {
 		return "", err
 	}

--- a/pkg/runview/rewind.go
+++ b/pkg/runview/rewind.go
@@ -1,0 +1,657 @@
+package runview
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// ErrRewindNotRewindable is returned when the run's status forbids an
+// in-place rewind. Callers map it to 409.
+var ErrRewindNotRewindable = errors.New("runview: rewind: run is not in a rewindable status")
+
+// ErrRewindNodeNotReached is returned when the requested pivot node has
+// no recorded output and is not the current checkpoint anchor — i.e. the
+// run never got there, so there is nothing to rewind to. Callers map it
+// to 400.
+var ErrRewindNodeNotReached = errors.New("runview: rewind: node was never reached by this run")
+
+// ArtifactLabelRewound marks the marker version appended over a
+// published artifact whose producing node was invalidated by a rewind.
+const ArtifactLabelRewound = "rewound"
+
+// RewindSpec describes an IN-PLACE rewind — "I misconfigured the bot,
+// back up and replay from here" — as opposed to Fork's
+// "create-an-alternative-future", which mints a new run id.
+//
+// The run keeps its id, name, inputs, lineage, and budget accounting.
+// Only its checkpoint anchor and the state produced at or after NodeID
+// are invalidated, and it is parked in a resumable status. The caller
+// issues Resume separately (with --force when the .bot source was edited
+// in between, which is the whole point of the operation).
+type RewindSpec struct {
+	// RunID is the run to rewind. Required.
+	RunID string
+	// NodeID is the pivot: the already-executed node the run will
+	// re-execute from. Required unless Auto is set.
+	NodeID string
+	// Auto derives the pivot by diffing the workflow source this run
+	// executed against the source on disk now, and picking the earliest
+	// executed node the edit affects.
+	//
+	// This is the bot-development loop in one step: edit the .bot, rewind
+	// --auto, resume. Without it the operator has to translate "I changed
+	// implement's prompt" into "--node implement" on every iteration, and
+	// an edited edge or shared prompt has no obvious answer at all.
+	//
+	// Requires the run to carry Run.WorkflowSource (captured at launch).
+	// An explicit NodeID always wins.
+	Auto bool
+	// KeepFiles opts OUT of restoring the workspace.
+	//
+	// By default a rewind also undoes what the dropped nodes PRODUCED,
+	// not merely what they declared: the workspace is reverted to the
+	// state the pivot started from. For a bot whose real product is files
+	// — docs, code — the output map is only a summary, so rewinding the
+	// checkpoint alone would leave the half-written tree in place and the
+	// replayed node would build on top of itself.
+	//
+	// The revert is additive (the prior tree is committed on top of HEAD,
+	// and uncommitted work is banked first), so opting out is about
+	// intent — "replay this node against the current files" — never about
+	// safety.
+	KeepFiles bool
+	// SourcePath overrides the workflow source to compute the graph
+	// from. Empty resolves the run's persisted FilePath (via the bot
+	// catalog when needed), exactly like the studio's workflow view.
+	//
+	// The graph is needed to decide what "downstream of NodeID" means.
+	// Note this compiles the source AS IT IS NOW — deliberately: the
+	// operator rewinds precisely because they edited it, and the resume
+	// that follows executes the new graph too.
+	SourcePath string
+}
+
+// RewindResult is the response shape returned to HTTP / CLI callers.
+type RewindResult struct {
+	RunID string `json:"run_id"`
+	// FromNode is the checkpoint anchor the run carried before the
+	// rewind ("" when it had no checkpoint).
+	FromNode string `json:"from_node,omitempty"`
+	// NodeID is the new checkpoint anchor — the node resume re-executes.
+	NodeID string `json:"node_id"`
+	// DroppedNodes lists the nodes whose outputs were invalidated,
+	// sorted. Always contains NodeID.
+	DroppedNodes []string `json:"dropped_nodes"`
+	// TombstonedArtifacts lists the dropped nodes whose published
+	// artifact was superseded by a `rewound` marker version, sorted.
+	TombstonedArtifacts []string `json:"tombstoned_artifacts,omitempty"`
+	// OrphanedChildRuns lists child run ids the dropped subbot nodes had
+	// spawned and were still pointing at. The pointer is released so the
+	// replay launches a fresh child; the runs themselves are left alone
+	// (an in-flight one keeps going — cancel it if it is burning budget).
+	OrphanedChildRuns []string `json:"orphaned_child_runs,omitempty"`
+	// Files reports the workspace half of the rewind: whether it was
+	// restored, to which snapshot, the revert commit, the backup ref
+	// banking the pre-revert state, and — importantly — why it was
+	// skipped when it was.
+	Files *fileRevertResult `json:"files,omitempty"`
+	// Status is the run's status after the rewind (always resumable).
+	Status string `json:"status"`
+	// AutoTargeted reports that NodeID was derived from the source diff
+	// rather than supplied by the caller.
+	AutoTargeted bool `json:"auto_targeted,omitempty"`
+	// PromotedFrom is set when the requested pivot sat inside a fan-out
+	// body and NodeID was promoted to the router orchestrating it, so
+	// every parallel execution of that node replays instead of one.
+	PromotedFrom string `json:"promoted_from,omitempty"`
+	// Changes lists the workflow-source differences that selected the
+	// pivot. Populated only for an --auto rewind — it is what lets the
+	// operator confirm the tool understood the edit.
+	Changes []DeclChange `json:"changes,omitempty"`
+}
+
+// rewindableStatuses are the statuses an in-place rewind accepts. A
+// `running` run is deliberately excluded: its engine owns the checkpoint
+// and would overwrite the rewind at its next node boundary. Cancel or
+// pause it first.
+var rewindableStatuses = []store.RunStatus{
+	store.RunStatusFailedResumable,
+	store.RunStatusCancelled,
+	store.RunStatusPausedOperator,
+	store.RunStatusPausedWaitingHuman,
+	store.RunStatusQueued,
+}
+
+// Rewind re-anchors an existing run's checkpoint on an already-executed
+// node and invalidates every output downstream of it, so the next Resume
+// re-executes from there without replaying the upstream nodes that were
+// already paid for.
+//
+// It is the iteration counterpart of Fork: same "restart at node N"
+// effect, but on the SAME run id, because the operator is fixing a
+// misconfiguration rather than exploring an alternative. See
+// docs/resume.md § Rewind.
+//
+// The run is parked in `cancelled` — the one resumable status the cloud
+// runner treats as "explicit resume required" (see pkg/runner/loop.go:
+// failed_resumable and paused_operator are auto-resumed on queue
+// redelivery, which would race the operator's .bot edit and execute the
+// stale workflow).
+//
+// SCOPE: this rewinds ENGINE state (checkpoint outputs), the store
+// artifacts those nodes published, their subbot child pointers, and — for
+// a run with an isolated worktree — the workspace files, reverted to the
+// state the pivot started from. It does NOT undo external effects (board
+// cards, forge comments, pushed commits, already-launched child runs).
+//
+// A run WITHOUT a worktree keeps its files: its workspace is the
+// operator's live tree, which iterion deliberately does not snapshot
+// (doing so would stage the operator's own work through `git add -A`).
+// Those runs get a populated Files.SkipReason rather than silence.
+func (s *Service) Rewind(ctx context.Context, spec RewindSpec) (*RewindResult, error) {
+	if spec.RunID == "" {
+		return nil, errors.New("runview: rewind: run_id is required")
+	}
+	if spec.NodeID == "" && !spec.Auto {
+		return nil, errors.New("runview: rewind: node_id is required (or set auto to derive it from the source diff)")
+	}
+	run, err := s.store.LoadRun(ctx, spec.RunID)
+	if err != nil {
+		return nil, fmt.Errorf("load run: %w", err)
+	}
+	if !isRewindableStatus(run.Status) {
+		return nil, fmt.Errorf("%w: %s (rewindable: %s)",
+			ErrRewindNotRewindable, run.Status, joinStatuses(rewindableStatuses))
+	}
+	cp := run.Checkpoint
+	if cp == nil {
+		return nil, fmt.Errorf("runview: rewind: run %s has no checkpoint — nothing to rewind", spec.RunID)
+	}
+	// Compile the CURRENT source to learn the topology. Deliberately no
+	// workflow-hash check: rewinding after editing the .bot is the
+	// primary use case, and the hash guard belongs to resume (--force),
+	// which is where the operator asserts the edit is compatible.
+	sourcePath := spec.SourcePath
+	if sourcePath == "" {
+		sourcePath = resolveWorkflowPath(run)
+	}
+	if sourcePath == "" {
+		return nil, fmt.Errorf("runview: rewind: run %s has no workflow source path — pass one explicitly", spec.RunID)
+	}
+	wf, err := CompileWorkflow(sourcePath)
+	if err != nil {
+		return nil, fmt.Errorf("compile workflow %s (needed to resolve what is downstream of %q): %w",
+			sourcePath, spec.NodeID, err)
+	}
+	// Nodes this run actually executed — the search space for --auto and
+	// the validity domain for an explicit --node.
+	executed := map[string]bool{}
+	for id := range cp.Outputs {
+		executed[id] = true
+	}
+	if cp.NodeID != "" {
+		executed[cp.NodeID] = true
+	}
+
+	pivot := spec.NodeID
+	var changes []DeclChange
+	autoTargeted := false
+	if pivot == "" {
+		current, rerr := os.ReadFile(sourcePath)
+		if rerr != nil {
+			return nil, fmt.Errorf("read current workflow source %s: %w", sourcePath, rerr)
+		}
+		pivot, changes, err = resolveAutoPivot(run.WorkflowSource, string(current), wf, executed)
+		if err != nil {
+			return nil, err
+		}
+		autoTargeted = true
+	}
+
+	if _, ok := wf.Nodes[pivot]; !ok {
+		return nil, fmt.Errorf("runview: rewind: node %q is not in workflow %s", pivot, sourcePath)
+	}
+	// The pivot must be a node the run actually reached. Without this a
+	// typo silently parks the run on a node that never ran, and the
+	// resume then fails deep in the engine with a much worse message.
+	//
+	// Checked BEFORE the fan-out promotion below: a router does not always
+	// record an output of its own, so validating the promoted anchor would
+	// reject a perfectly good rewind. The body node having executed is
+	// proof enough that its router did.
+	if !executed[pivot] {
+		return nil, fmt.Errorf("%w: %q (reached: %s)",
+			ErrRewindNodeNotReached, pivot, joinSorted(mapKeys(cp.Outputs)))
+	}
+	// A pivot inside a fan-out body is promoted to the router that
+	// orchestrates it. The checkpoint keeps one output per node id, so N
+	// parallel executions of a body node collapse to a single entry;
+	// anchoring on the node would replay it once, linearly, with no `each`
+	// context — testing one iteration instead of all of them, silently.
+	// Re-running every instance is only expressible as "re-run the
+	// fan-out".
+	promotedFrom := ""
+	if router := fanOutRouterFor(wf, pivot); router != "" && router != pivot {
+		promotedFrom, pivot = pivot, router
+		if s.logger != nil {
+			s.logger.Info("rewind: %q is inside the fan-out of %q — anchoring on the router so every parallel execution replays",
+				promotedFrom, pivot)
+		}
+	}
+
+	dropped := downstreamOf(wf, pivot, cp.Outputs)
+	fromNode := cp.NodeID
+
+	// Workspace first: a git failure then leaves the run's engine state
+	// untouched, so the operator can fix the tree and retry the whole
+	// rewind. The reverse order could leave a rewound checkpoint pointing
+	// at un-rewound files.
+	files := &fileRevertResult{SkipReason: "keep_files requested"}
+	if !spec.KeepFiles {
+		files, err = revertWorkspace(run, wf, cp, pivot)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Claim the run before mutating. UpdateRunStatusIf is a CAS against
+	// the expected statuses, so a concurrent resume that already flipped
+	// this run to `running` loses the race instead of being rewound out
+	// from under itself. `cancelled` preserves the checkpoint through
+	// applyStatusTransition (unlike running/finished/failed, which nil
+	// it) — so this must run BEFORE the checkpoint write.
+	claimed, err := s.store.UpdateRunStatusIf(ctx, run.ID, store.RunStatusCancelled, "", rewindableStatuses)
+	if err != nil {
+		return nil, fmt.Errorf("claim run for rewind: %w", err)
+	}
+	if !claimed {
+		return nil, fmt.Errorf("%w: status changed under us — reload and retry", ErrRewindNotRewindable)
+	}
+
+	// Reserve the tombstone versions BEFORE persisting the checkpoint,
+	// but write the artifacts AFTER. WriteArtifact updates
+	// Run.ArtifactIndex inside run.json, so writing first and saving the
+	// run second would clobber that index with our stale in-memory copy.
+	tombstones := s.planArtifactTombstones(ctx, run.ID, cp, dropped)
+
+	// Release the subbot child pointers of the dropped nodes. Without
+	// this the rewind is silently a no-op for subbots: ReattachSubbotChild
+	// consults ONLY run.SubbotChildren and the child's status — never the
+	// parent's checkpoint (ADR-084 rejected the checkpoint as its home,
+	// since a parked subbot node has not finished) — and it runs before
+	// the child .bot is even compiled. So a re-executed subbot node would
+	// adopt the pre-rewind child and its output, and the edited child
+	// workflow would never run.
+	//
+	// The happy path already cleared the pointer when the child finished;
+	// what survives is exactly the interesting case — a child still
+	// parked on a human gate, or in flight.
+	orphaned := detachSubbotChildren(run, dropped)
+
+	applyRewind(cp, pivot, dropped)
+	for _, ts := range tombstones {
+		// The engine writes a node's next artifact at
+		// ArtifactVersions[node] and then increments
+		// (pkg/runtime/engine_exec.go), so the tombstone must reserve its
+		// slot — otherwise re-execution overwrites the marker and the
+		// "supersede" silently becomes a delete.
+		cp.ArtifactVersions[ts.nodeID] = ts.version + 1
+	}
+
+	run.Status = store.RunStatusCancelled
+	// Clear the stale failure message: the run is no longer "failed at
+	// verify", it is parked at the pivot awaiting a fresh execution.
+	run.Error = ""
+	run.Checkpoint = cp
+	run.UpdatedAt = time.Now().UTC()
+	if err := s.store.SaveRun(ctx, run); err != nil {
+		return nil, fmt.Errorf("save rewound run: %w", err)
+	}
+	if err := s.store.SaveCheckpoint(ctx, run.ID, cp); err != nil {
+		return nil, fmt.Errorf("save rewound checkpoint: %w", err)
+	}
+
+	tombstoned := s.writeArtifactTombstones(ctx, run.ID, pivot, tombstones)
+
+	// Append-only audit. events.jsonl is never truncated — the dropped
+	// nodes' original records stay, and this marker explains why they
+	// are about to appear a second time.
+	if _, err := s.store.AppendEvent(ctx, run.ID, store.Event{
+		Type:   store.EventRunRewound,
+		RunID:  run.ID,
+		NodeID: pivot,
+		Data: map[string]any{
+			"from_node":            fromNode,
+			"to_node":              pivot,
+			"dropped_nodes":        dropped,
+			"tombstoned_artifacts": tombstoned,
+			"orphaned_child_runs":  orphaned,
+			"promoted_from":        promotedFrom,
+			"files_reverted":       files.Reverted,
+			"files_ref":            files.Ref,
+			"files_revert_commit":  files.RevertCommit,
+			"files_backup_ref":     files.BackupRef,
+			"files_skip_reason":    files.SkipReason,
+		},
+	}); err != nil && s.logger != nil {
+		// Best-effort: the state mutation already landed and is the
+		// authority. Losing the marker degrades the audit trail, it
+		// does not corrupt the run.
+		s.logger.Warn("rewind: append run_rewound event for %s: %v", run.ID, err)
+	}
+	if s.logger != nil {
+		s.logger.Info("rewind: run %s re-anchored %q → %q, dropped %d node output(s), superseded %d artifact(s), released %d child run(s)",
+			run.ID, fromNode, pivot, len(dropped), len(tombstoned), len(orphaned))
+	}
+
+	return &RewindResult{
+		RunID:               run.ID,
+		FromNode:            fromNode,
+		NodeID:              pivot,
+		DroppedNodes:        dropped,
+		TombstonedArtifacts: tombstoned,
+		OrphanedChildRuns:   orphaned,
+		Files:               files,
+		Status:              string(store.RunStatusCancelled),
+		AutoTargeted:        autoTargeted,
+		PromotedFrom:        promotedFrom,
+		Changes:             changes,
+	}, nil
+}
+
+// applyRewind mutates cp in place: re-anchor on nodeID and invalidate
+// the dropped nodes' state.
+//
+// What is deliberately NOT reset, and why:
+//   - Budget counters (tokens / cost / iterations / elapsed) and
+//     CostUSDTotal: resume never resets them either. A rewind that
+//     refunded spend would make "rewind + resume" an unbounded way
+//     around max_cost_usd. Raise the cap on the resume instead.
+//   - LoopCounters: same argument for max_iterations. An exhausted loop
+//     stays exhausted; grant more with resume's --max-iterations.
+//   - LoopPreviousOutput / LoopCurrentOutput: the pivot may legitimately
+//     read {{loop.<name>.previous_output}} on its first re-execution.
+func applyRewind(cp *store.Checkpoint, nodeID string, dropped []string) {
+	cp.NodeID = nodeID
+	if cp.ArtifactVersions == nil {
+		cp.ArtifactVersions = map[string]int{}
+	}
+	for _, id := range dropped {
+		delete(cp.Outputs, id)
+		// A re-executed node gets a fresh recovery budget: it is being
+		// replayed because the WORKFLOW changed, so attempts spent
+		// against the old definition should not count against it.
+		delete(cp.NodeAttempts, id)
+	}
+	// Any pending interaction belonged to the node the run was parked
+	// on, which is at or downstream of the pivot. Carrying it over would
+	// make the resume try to answer a question the rewound run never
+	// asked.
+	cp.InteractionID = ""
+	cp.InteractionQuestions = nil
+	// Drop backend rehydration so the pivot restarts from a clean
+	// conversation. Fork pins these from a turn checkpoint because it
+	// resumes mid-turn; a rewind wants the node re-run from scratch
+	// against the edited prompt — replaying the old conversation would
+	// carry the very context the operator is trying to change.
+	cp.BackendName = ""
+	cp.BackendSessionID = ""
+	cp.BackendConversation = nil
+	cp.BackendPendingToolUseID = ""
+}
+
+// detachSubbotChildren removes, from the run's in-memory SubbotChildren
+// map, every entry belonging to a dropped node, and returns the child
+// run ids released (sorted, deduped). The caller persists the run
+// afterwards, so the removal rides the same SaveRun as the rest of the
+// rewind rather than racing it through ClearSubbotChild.
+//
+// Key shape is the engine's (pkg/runtime/special_node.go:subbotReattachKey):
+//
+//	sanitize(<node id>[@<loop=iter;…>][#<branch id>])
+//
+// so a node's entries are its sanitized id alone, or that id followed by
+// the '@' / '#' delimiter. Matching on the delimiter — not a bare prefix
+// — is what keeps node "run" from stealing node "run_child"'s entries.
+func detachSubbotChildren(run *store.Run, dropped []string) []string {
+	if len(run.SubbotChildren) == 0 {
+		return nil
+	}
+	prefixes := make(map[string]bool, len(dropped))
+	for _, id := range dropped {
+		prefixes[sanitizeSubbotKey(id)] = true
+	}
+	seen := map[string]bool{}
+	var released []string
+	for key, childID := range run.SubbotChildren {
+		head := key
+		if i := strings.IndexAny(key, "@#"); i >= 0 {
+			head = key[:i]
+		}
+		if !prefixes[head] {
+			continue
+		}
+		delete(run.SubbotChildren, key)
+		if childID != "" && !seen[childID] {
+			seen[childID] = true
+			released = append(released, childID)
+		}
+	}
+	if len(run.SubbotChildren) == 0 {
+		run.SubbotChildren = nil
+	}
+	sort.Strings(released)
+	return released
+}
+
+// sanitizeSubbotKey mirrors the engine's subbotKeySanitizer: '.' and '$'
+// are illegal in a Mongo field name and the key becomes a map key on the
+// parent run doc. Group-instantiated nodes carry dotted ids
+// ("pr.check"), so this is load-bearing, not cosmetic.
+var subbotKeyReplacer = strings.NewReplacer(".", "_", "$", "_")
+
+func sanitizeSubbotKey(nodeID string) string { return subbotKeyReplacer.Replace(nodeID) }
+
+// artifactTombstone is one reserved marker-version write.
+type artifactTombstone struct {
+	nodeID     string
+	version    int
+	supersedes int
+}
+
+// planArtifactTombstones decides which dropped nodes have a published
+// artifact that must be superseded, and reserves the version each marker
+// will occupy.
+//
+// Why supersede rather than delete: Run.ArtifactIndex is what
+// LoadLatestArtifact reads, and three consumers read through it — the
+// run-completion webhook payload (pkg/notify), a parent reading a
+// subbot's outputs back (pkg/runview/subbot.go), and the pipeline board's
+// progress projection (pkg/server). Leaving the index pointing at the
+// pre-rewind artifact makes those three serve output the checkpoint has
+// already invalidated. Appending a marker version fixes that while
+// keeping every earlier version on disk and readable, which is the same
+// append-only contract events.jsonl follows.
+func (s *Service) planArtifactTombstones(ctx context.Context, runID string, cp *store.Checkpoint, dropped []string) []artifactTombstone {
+	var out []artifactTombstone
+	for _, id := range dropped {
+		latest, err := s.store.LoadLatestArtifact(ctx, runID, id)
+		if err != nil || latest == nil {
+			// No artifact published by this node — nothing to supersede.
+			continue
+		}
+		if isRewoundArtifact(latest) {
+			// Already superseded by an earlier rewind that was never
+			// resumed; a second marker would add noise, not information.
+			continue
+		}
+		next := cp.ArtifactVersions[id]
+		if next <= latest.Version {
+			next = latest.Version + 1
+		}
+		out = append(out, artifactTombstone{nodeID: id, version: next, supersedes: latest.Version})
+	}
+	return out
+}
+
+// writeArtifactTombstones performs the reserved writes and returns the
+// node ids that were successfully superseded, sorted. Best-effort: the
+// checkpoint is the authority and has already landed, so a failed marker
+// write is logged rather than failing the whole rewind.
+func (s *Service) writeArtifactTombstones(ctx context.Context, runID, pivot string, tombstones []artifactTombstone) []string {
+	var done []string
+	for _, ts := range tombstones {
+		a := &store.Artifact{
+			RunID:   runID,
+			NodeID:  ts.nodeID,
+			Version: ts.version,
+			Labels:  []string{ArtifactLabelRewound},
+			Data: map[string]any{
+				"_rewound":     true,
+				"_rewound_to":  pivot,
+				"_supersedes":  ts.supersedes,
+				"_rewound_at":  time.Now().UTC().Format(time.RFC3339),
+				"_explanation": fmt.Sprintf("superseded by a rewind to %q; version %d holds the pre-rewind output", pivot, ts.supersedes),
+			},
+			WrittenAt: time.Now().UTC(),
+		}
+		if err := s.store.WriteArtifact(ctx, a); err != nil {
+			if s.logger != nil {
+				s.logger.Warn("rewind: supersede artifact %s/%s v%d: %v", runID, ts.nodeID, ts.version, err)
+			}
+			continue
+		}
+		done = append(done, ts.nodeID)
+	}
+	sort.Strings(done)
+	return done
+}
+
+// isRewoundArtifact reports whether an artifact is a rewind marker.
+func isRewoundArtifact(a *store.Artifact) bool {
+	for _, l := range a.Labels {
+		if l == ArtifactLabelRewound {
+			return true
+		}
+	}
+	return false
+}
+
+// downstreamOf computes the set of node ids whose outputs a rewind to
+// pivot must invalidate, restricted to nodes that actually have a
+// recorded output.
+//
+// The rule is `{pivot} ∪ (forward-reachable(pivot) \ backward-reachable(pivot))`.
+//
+// Subtracting the ancestors is what makes this correct in the presence
+// of loops. In `implement -> verify -> implement as fix(3)`, `verify` is
+// BOTH downstream and upstream of `implement`: it is reachable forward
+// (implement→verify) and it can reach implement (the back-edge). Its
+// output is exactly what `implement` reads back via
+// {{loop.fix.previous_output}} / {{outputs.verify}} on re-entry, so
+// dropping it would break the first re-execution with a missing
+// reference. A node that can reach the pivot always ran before it and
+// must survive.
+//
+// Over-dropping is as harmful as under-dropping here: a node whose
+// output is deleted but which does not re-execute before something
+// reads it resolves to nil, not to a re-run.
+func downstreamOf(wf *ir.Workflow, pivot string, outputs map[string]map[string]any) []string {
+	fwd := reachable(pivot, adjacency(wf, false))
+	bwd := reachable(pivot, adjacency(wf, true))
+
+	drop := map[string]bool{pivot: true}
+	for id := range fwd {
+		if !bwd[id] {
+			drop[id] = true
+		}
+	}
+	out := make([]string, 0, len(drop))
+	for id := range drop {
+		// Only report what was actually invalidated: a downstream node
+		// the run never reached has nothing to drop, and listing it
+		// would misrepresent the blast radius in the audit event.
+		if _, ok := outputs[id]; ok || id == pivot {
+			out = append(out, id)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// adjacency builds the successor (or, reversed, predecessor) map of the
+// workflow graph. Loop and foreach back-edges are included: they are
+// real execution paths, and the ancestor subtraction in downstreamOf —
+// not edge filtering — is what keeps cycles from over-dropping.
+func adjacency(wf *ir.Workflow, reverse bool) map[string][]string {
+	adj := make(map[string][]string, len(wf.Nodes))
+	for _, e := range wf.Edges {
+		if e == nil {
+			continue
+		}
+		from, to := e.From, e.To
+		if reverse {
+			from, to = to, from
+		}
+		adj[from] = append(adj[from], to)
+	}
+	return adj
+}
+
+// reachable returns every node reachable from start, EXCLUDING start
+// itself unless a cycle leads back to it.
+func reachable(start string, adj map[string][]string) map[string]bool {
+	seen := map[string]bool{}
+	queue := append([]string(nil), adj[start]...)
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		queue = append(queue, adj[id]...)
+	}
+	return seen
+}
+
+func isRewindableStatus(s store.RunStatus) bool {
+	for _, ok := range rewindableStatuses {
+		if s == ok {
+			return true
+		}
+	}
+	return false
+}
+
+func joinStatuses(ss []store.RunStatus) string {
+	out := make([]string, 0, len(ss))
+	for _, s := range ss {
+		out = append(out, string(s))
+	}
+	return strings.Join(out, ", ")
+}
+
+func mapKeys(m map[string]map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func joinSorted(ss []string) string {
+	sort.Strings(ss)
+	if len(ss) == 0 {
+		return "none"
+	}
+	return strings.Join(ss, ", ")
+}

--- a/pkg/runview/rewind.go
+++ b/pkg/runview/rewind.go
@@ -247,7 +247,7 @@ func (s *Service) Rewind(ctx context.Context, spec RewindSpec) (*RewindResult, e
 		}
 	}
 
-	dropped := downstreamOf(wf, pivot, cp.Outputs)
+	dropped, invalidated := downstreamOf(wf, pivot, cp.Outputs)
 	fromNode := cp.NodeID
 
 	// Workspace first: a git failure then leaves the run's engine state
@@ -294,9 +294,9 @@ func (s *Service) Rewind(ctx context.Context, spec RewindSpec) (*RewindResult, e
 	// The happy path already cleared the pointer when the child finished;
 	// what survives is exactly the interesting case — a child still
 	// parked on a human gate, or in flight.
-	orphaned := detachSubbotChildren(run, dropped)
+	orphaned := detachSubbotChildren(run, invalidated)
 
-	applyRewind(cp, pivot, dropped)
+	applyRewind(cp, pivot, dropped, invalidated)
 	for _, ts := range tombstones {
 		// The engine writes a node's next artifact at
 		// ArtifactVersions[node] and then increments
@@ -379,13 +379,18 @@ func (s *Service) Rewind(ctx context.Context, spec RewindSpec) (*RewindResult, e
 //     stays exhausted; grant more with resume's --max-iterations.
 //   - LoopPreviousOutput / LoopCurrentOutput: the pivot may legitimately
 //     read {{loop.<name>.previous_output}} on its first re-execution.
-func applyRewind(cp *store.Checkpoint, nodeID string, dropped []string) {
+func applyRewind(cp *store.Checkpoint, nodeID string, dropped, invalidated []string) {
 	cp.NodeID = nodeID
 	if cp.ArtifactVersions == nil {
 		cp.ArtifactVersions = map[string]int{}
 	}
 	for _, id := range dropped {
 		delete(cp.Outputs, id)
+	}
+	// Recovery budgets clear over the UNFILTERED set: a node that failed
+	// has attempts recorded and no output, so keying this on `dropped`
+	// would leave the budget of the very node that failed untouched.
+	for _, id := range invalidated {
 		// A re-executed node gets a fresh recovery budget: it is being
 		// replayed because the WORKFLOW changed, so attempts spent
 		// against the old definition should not count against it.
@@ -564,7 +569,7 @@ func isRewoundArtifact(a *store.Artifact) bool {
 // Over-dropping is as harmful as under-dropping here: a node whose
 // output is deleted but which does not re-execute before something
 // reads it resolves to nil, not to a re-run.
-func downstreamOf(wf *ir.Workflow, pivot string, outputs map[string]map[string]any) []string {
+func downstreamOf(wf *ir.Workflow, pivot string, outputs map[string]map[string]any) (dropped, invalidated []string) {
 	fwd := reachable(pivot, adjacency(wf, false))
 	bwd := reachable(pivot, adjacency(wf, true))
 
@@ -574,17 +579,24 @@ func downstreamOf(wf *ir.Workflow, pivot string, outputs map[string]map[string]a
 			drop[id] = true
 		}
 	}
-	out := make([]string, 0, len(drop))
 	for id := range drop {
-		// Only report what was actually invalidated: a downstream node
-		// the run never reached has nothing to drop, and listing it
-		// would misrepresent the blast radius in the audit event.
+		invalidated = append(invalidated, id)
+		// `dropped` is the REPORTING set: a downstream node the run never
+		// reached has no output to drop, and listing it would
+		// misrepresent the blast radius in the audit event.
+		//
+		// It is deliberately NOT the set used for cleanup. State that
+		// outlives a node's output — a parked subbot child, a recovery
+		// attempt counter — belongs precisely to nodes that did NOT
+		// complete, so filtering on "has an output" would skip exactly
+		// the ones that need clearing.
 		if _, ok := outputs[id]; ok || id == pivot {
-			out = append(out, id)
+			dropped = append(dropped, id)
 		}
 	}
-	sort.Strings(out)
-	return out
+	sort.Strings(dropped)
+	sort.Strings(invalidated)
+	return dropped, invalidated
 }
 
 // adjacency builds the successor (or, reversed, predecessor) map of the

--- a/pkg/runview/rewind.go
+++ b/pkg/runview/rewind.go
@@ -250,30 +250,28 @@ func (s *Service) Rewind(ctx context.Context, spec RewindSpec) (*RewindResult, e
 	dropped, invalidated := downstreamOf(wf, pivot, cp.Outputs)
 	fromNode := cp.NodeID
 
-	// Workspace first: a git failure then leaves the run's engine state
-	// untouched, so the operator can fix the tree and retry the whole
-	// rewind. The reverse order could leave a rewound checkpoint pointing
-	// at un-rewound files.
-	files := &fileRevertResult{SkipReason: "keep_files requested"}
-	if !spec.KeepFiles {
-		files, err = revertWorkspace(run, wf, cp, pivot)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// Claim the run before mutating. UpdateRunStatusIf is a CAS against
-	// the expected statuses, so a concurrent resume that already flipped
-	// this run to `running` loses the race instead of being rewound out
-	// from under itself. `cancelled` preserves the checkpoint through
-	// applyStatusTransition (unlike running/finished/failed, which nil
-	// it) — so this must run BEFORE the checkpoint write.
+	// Claim the run BEFORE touching anything, the worktree included. The
+	// CAS exists to make a concurrent resume safe; reverting first defeats
+	// it, because `git read-tree --reset` + `clean -fd` would already have
+	// run inside a worktree an engine is actively writing to before we
+	// discovered we lost the race. The original justification for going
+	// second — "a git failure leaves engine state untouched" — holds here
+	// too: `cancelled` preserves the checkpoint, so a revert failure after
+	// the claim leaves a resumable run carrying its pre-rewind state.
 	claimed, err := s.store.UpdateRunStatusIf(ctx, run.ID, store.RunStatusCancelled, "", rewindableStatuses)
 	if err != nil {
 		return nil, fmt.Errorf("claim run for rewind: %w", err)
 	}
 	if !claimed {
 		return nil, fmt.Errorf("%w: status changed under us — reload and retry", ErrRewindNotRewindable)
+	}
+
+	files := &fileRevertResult{SkipReason: "keep_files requested"}
+	if !spec.KeepFiles {
+		files, err = revertWorkspace(run, wf, cp, pivot)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Reserve the tombstone versions BEFORE persisting the checkpoint,

--- a/pkg/runview/rewind.go
+++ b/pkg/runview/rewind.go
@@ -319,6 +319,23 @@ func (s *Service) Rewind(ctx context.Context, spec RewindSpec) (*RewindResult, e
 
 	tombstoned := s.writeArtifactTombstones(ctx, run.ID, pivot, tombstones)
 
+	// Retire the async questions the dropped nodes posted. ADR-081's pair
+	// is level-triggered against the STORE, so clearing the checkpoint
+	// pointer alone leaves them live: the replayed await_answers would
+	// park on the union of its new questions and these abandoned ones, or
+	// fold pre-rewind answers into its output.
+	retireNodes := map[string]bool{}
+	for _, id := range dropped {
+		retireNodes[id] = true
+	}
+	if n, rerr := store.RetireAsyncInteractions(ctx, s.store, run.ID, retireNodes); rerr != nil {
+		if s.logger != nil {
+			s.logger.Warn("rewind: retire async interactions for %s: %v", run.ID, rerr)
+		}
+	} else if n > 0 && s.logger != nil {
+		s.logger.Info("rewind: retired %d abandoned async question(s)", n)
+	}
+
 	// Append-only audit. events.jsonl is never truncated — the dropped
 	// nodes' original records stay, and this marker explains why they
 	// are about to appear a second time.

--- a/pkg/runview/rewind.go
+++ b/pkg/runview/rewind.go
@@ -319,13 +319,19 @@ func (s *Service) Rewind(ctx context.Context, spec RewindSpec) (*RewindResult, e
 
 	tombstoned := s.writeArtifactTombstones(ctx, run.ID, pivot, tombstones)
 
-	// Retire the async questions the dropped nodes posted. ADR-081's pair
-	// is level-triggered against the STORE, so clearing the checkpoint
+	// Retire the async questions the invalidated nodes posted. ADR-081's
+	// pair is level-triggered against the STORE, so clearing the checkpoint
 	// pointer alone leaves them live: the replayed await_answers would
 	// park on the union of its new questions and these abandoned ones, or
 	// fold pre-rewind answers into its output.
+	//
+	// Keyed on `invalidated`, not `dropped`: a node that posted questions
+	// and then failed mid-execution — the canonical failed_resumable state
+	// a rewind is invoked on — has no output, so the output-filtered set
+	// would skip exactly the node whose questions are still pending. Same
+	// argument detachSubbotChildren and the NodeAttempts clear rest on.
 	retireNodes := map[string]bool{}
-	for _, id := range dropped {
+	for _, id := range invalidated {
 		retireNodes[id] = true
 	}
 	if n, rerr := store.RetireAsyncInteractions(ctx, s.store, run.ID, retireNodes); rerr != nil {

--- a/pkg/runview/rewind.go
+++ b/pkg/runview/rewind.go
@@ -310,6 +310,20 @@ func (s *Service) Rewind(ctx context.Context, spec RewindSpec) (*RewindResult, e
 	run.Error = ""
 	run.Checkpoint = cp
 	run.UpdatedAt = time.Now().UTC()
+	// Re-apply the stamp the claim performed. `run` was loaded BEFORE the
+	// CAS, and UpdateRunStatusIf mutates its own copy (loadRunRaw →
+	// applyStatusTransition), which sets FinishedAt for the `cancelled`
+	// transition. SaveRun is a full-document overwrite, so saving `run`
+	// verbatim drops it whenever the pre-rewind status was paused_* or
+	// queued — where FinishedAt was nil. The run then persists as
+	// cancelled with finished_at null, nothing heals it (healRun only
+	// nulls it for `running`), and the studio duration ticker runs
+	// forever because runs_stats falls back to now for the end.
+	//
+	// Same read-modify-write-across-a-CAS hazard this branch already fixed
+	// on the resume path (restampWorkflowSource).
+	finishedAt := run.UpdatedAt
+	run.FinishedAt = &finishedAt
 	if err := s.store.SaveRun(ctx, run); err != nil {
 		return nil, fmt.Errorf("save rewound run: %w", err)
 	}

--- a/pkg/runview/rewind_auto.go
+++ b/pkg/runview/rewind_auto.go
@@ -558,11 +558,20 @@ func fanOutRouterFor(wf *ir.Workflow, nodeID string) string {
 // the body, since it runs once rather than per-branch.
 func fanOutBody(wf *ir.Workflow, routerID string) map[string]bool {
 	adj := adjacency(wf, false)
-	inDegree := map[string]int{}
+	// DISTINCT sources, not edge count — the engine's own convergence
+	// detection counts distinct predecessors. Two edges from the SAME
+	// node (a when/else pair, or sibling `with` mappings) are routine
+	// inside a fan-out branch and are not a convergence there; counting
+	// them as one truncates the body and skips the router promotion.
+	inSources := map[string]map[string]bool{}
 	for _, e := range wf.Edges {
-		if e != nil {
-			inDegree[e.To]++
+		if e == nil {
+			continue
 		}
+		if inSources[e.To] == nil {
+			inSources[e.To] = map[string]bool{}
+		}
+		inSources[e.To][e.From] = true
 	}
 	body := map[string]bool{}
 	queue := append([]string(nil), adj[routerID]...)
@@ -576,7 +585,7 @@ func fanOutBody(wf *ir.Workflow, routerID string) map[string]bool {
 		if !ok {
 			continue
 		}
-		if isFanOutBoundary(wf, node, id, inDegree) {
+		if isFanOutBoundary(wf, node, id, inSources) {
 			// The boundary: excluded from the body, and not expanded
 			// past. Without the walk stopping here it would swallow the
 			// whole post-fan-out graph, and a rewind onto a node far
@@ -592,13 +601,14 @@ func fanOutBody(wf *ir.Workflow, routerID string) map[string]bool {
 // isFanOutBoundary reports whether a node ends a fan-out region.
 //
 // A declared `await:` is the explicit form, but the engine also treats
-// more than one distinct incoming source as a convergence point
+// more than one DISTINCT incoming source as a convergence point
 // (pkg/runtime/convergence.go), and nothing in the DSL requires the
-// annotation. Relying on `await:` alone happens to work for every bot
+// annotation. Distinct sources, not edge count: a when/else pair from one
+// predecessor is two edges and no convergence. Relying on `await:` alone happens to work for every bot
 // shipped today and silently over-promotes for any graph that converges
 // implicitly. Terminals end the region too — nothing runs per-branch
 // after them.
-func isFanOutBoundary(wf *ir.Workflow, node ir.Node, id string, inDegree map[string]int) bool {
+func isFanOutBoundary(wf *ir.Workflow, node ir.Node, id string, inSources map[string]map[string]bool) bool {
 	if ir.NodeAwaitMode(node) != ir.AwaitNone {
 		return true
 	}
@@ -606,7 +616,7 @@ func isFanOutBoundary(wf *ir.Workflow, node ir.Node, id string, inDegree map[str
 	case *ir.DoneNode, *ir.FailNode:
 		return true
 	}
-	return inDegree[id] > 1
+	return len(inSources[id]) > 1
 }
 
 // supervisorWatches returns the node ids a supervisor declaration

--- a/pkg/runview/rewind_auto.go
+++ b/pkg/runview/rewind_auto.go
@@ -92,6 +92,13 @@ func resolveAutoPivot(oldSrc, newSrc string, wf *ir.Workflow, executed map[strin
 		return "", changes, fmt.Errorf("%w: %s are on independent branches — pick one with --node",
 			ErrRewindAmbiguous, strings.Join(earliest, ", "))
 	}
+	if len(earliest) == 0 {
+		// Unreachable: earliestCandidates collapses cycles rather than
+		// eliminating them, so a non-empty candidate set always yields at
+		// least one survivor. Guarded anyway — indexing [0] here is what
+		// turned a graph-shape edge case into a panic once already.
+		return "", changes, fmt.Errorf("%w: could not order %s", ErrRewindAmbiguous, strings.Join(candidates, ", "))
+	}
 	return earliest[0], changes, nil
 }
 
@@ -349,13 +356,29 @@ func impactedNodes(changes []DeclChange, newFile *ast.File, wf *ir.Workflow) map
 // More than one survivor means the edits sit on branches that cannot
 // reach each other (a fan-out), where no single pivot covers them all.
 func earliestCandidates(wf *ir.Workflow, candidates []string) []string {
-	rev := adjacency(wf, true)
+	if len(candidates) == 0 {
+		return nil
+	}
+	fwdAdj, revAdj := adjacency(wf, false), adjacency(wf, true)
+	ancestors := make(map[string]map[string]bool, len(candidates))
+	descendants := make(map[string]map[string]bool, len(candidates))
+	for _, c := range candidates {
+		ancestors[c] = reachable(c, revAdj)
+		descendants[c] = reachable(c, fwdAdj)
+	}
+
 	var out []string
 	for _, c := range candidates {
-		ancestors := reachable(c, rev)
 		dominated := false
 		for _, other := range candidates {
-			if other != c && ancestors[other] {
+			// STRICTLY upstream: `other` reaches c, and c cannot reach
+			// back. The second half is what makes loops work. Without it,
+			// two edited nodes on a cycle are each other's ancestor, so
+			// both get eliminated — which used to leave the survivor set
+			// empty (a panic) and, worse, could silently elect an
+			// unrelated third candidate while dropping the loop edit
+			// entirely.
+			if other != c && ancestors[c][other] && !descendants[c][other] {
 				dominated = true
 				break
 			}
@@ -365,7 +388,59 @@ func earliestCandidates(wf *ir.Workflow, candidates []string) []string {
 		}
 	}
 	sort.Strings(out)
+	if len(out) <= 1 {
+		return out
+	}
+	// Survivors that can all reach each other are one cycle, not
+	// independent branches: replaying any of them replays the loop. Elect
+	// the one execution reaches first so the replay covers every edit.
+	if mutuallyReachable(out, descendants) {
+		return []string{nearestToEntry(wf, out, fwdAdj)}
+	}
 	return out
+}
+
+// mutuallyReachable reports whether every node can reach every other —
+// i.e. they belong to one strongly-connected component.
+func mutuallyReachable(nodes []string, descendants map[string]map[string]bool) bool {
+	for _, a := range nodes {
+		for _, b := range nodes {
+			if a != b && !descendants[a][b] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// nearestToEntry picks the candidate the workflow reaches in the fewest
+// hops from its entry, breaking ties by name so the choice is stable
+// across runs.
+func nearestToEntry(wf *ir.Workflow, candidates []string, fwdAdj map[string][]string) string {
+	dist := map[string]int{wf.Entry: 0}
+	queue := []string{wf.Entry}
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		for _, next := range fwdAdj[id] {
+			if _, seen := dist[next]; seen {
+				continue
+			}
+			dist[next] = dist[id] + 1
+			queue = append(queue, next)
+		}
+	}
+	best, bestDist := candidates[0], 1<<30
+	for _, c := range candidates {
+		d, ok := dist[c]
+		if !ok {
+			continue // unreachable from entry; never preferred
+		}
+		if d < bestDist || (d == bestDist && c < best) {
+			best, bestDist = c, d
+		}
+	}
+	return best
 }
 
 // summarizeChanges renders a change list for an error message.

--- a/pkg/runview/rewind_auto.go
+++ b/pkg/runview/rewind_auto.go
@@ -203,11 +203,44 @@ func declFingerprints(f *ast.File) map[string]string {
 	// runs on the raw parse. So the group body and its instantiations are
 	// fingerprinted here, and impactedNodes expands them to the real node
 	// ids — otherwise editing a group node is invisible.
+	//
+	// Both are encoded through their BODIES rather than directly: neither
+	// ast.MarshalFile's jsonFile nor unparse.Unparse carries a groups or
+	// uses field, so `&ast.File{Groups: …}` marshals to "{}" and put falls
+	// through to its "<unencodable N>" placeholder — which is derived from
+	// the declaration's ORDINAL POSITION and is therefore identical in the
+	// recorded and the edited source. diffDecls then saw no change, so
+	// `rewind --auto` on a group-body edit failed with "the workflow
+	// source is unchanged" and the operator resumed against the OLD node.
+	// A false negative, the direction this file's contract calls the
+	// dangerous one, and it silently disabled impactedNodes' whole
+	// group/use branch.
 	for _, d := range f.Groups {
-		put("group", d.Name, &ast.File{Groups: []*ast.GroupDecl{d}})
+		put("group", d.Name, &ast.File{
+			Agents:   d.Agents,
+			Judges:   d.Judges,
+			Routers:  d.Routers,
+			Humans:   d.Humans,
+			Tools:    d.Tools,
+			Computes: d.Computes,
+			// The body's edges ride in a synthetic workflow shell, which
+			// the encoder does know about.
+			Workflows: []*ast.WorkflowDecl{{Name: d.Name, Edges: d.Edges}},
+		})
 	}
 	for _, d := range f.Uses {
-		put("use", d.Group+" as "+d.Prefix, &ast.File{Uses: []*ast.UseDecl{d}})
+		// A use declares no body, so there is nothing encodable to
+		// fingerprint — fold everything that can change into the KEY
+		// instead, as edgeKey already does for edge mappings. Retuning a
+		// `with { … }` binding then surfaces as removed+added rather than
+		// vanishing.
+		key := d.Group + " as " + d.Prefix
+		for _, w := range d.With {
+			if w != nil {
+				key += " with " + w.Key + "=" + w.Value
+			}
+		}
+		put("use", key, &ast.File{Uses: []*ast.UseDecl{d}})
 	}
 	if f.Vars != nil {
 		put("vars", "", &ast.File{Vars: f.Vars})

--- a/pkg/runview/rewind_auto.go
+++ b/pkg/runview/rewind_auto.go
@@ -9,6 +9,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/dsl/ast"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+	"github.com/SocialGouv/iterion/pkg/dsl/unparse"
 )
 
 // ErrRewindNoSourceRecorded is returned when --auto is asked of a run
@@ -132,10 +133,20 @@ func declFingerprints(f *ast.File) map[string]string {
 	out := map[string]string{}
 	put := func(kind, name string, file *ast.File) {
 		b, err := ast.MarshalFile(file)
-		if err != nil {
-			// An unencodable declaration is treated as "always changed"
-			// rather than "never changed": erring toward re-execution is
-			// the safe direction.
+		// ast.MarshalFile is the faithful, Span-free encoder for most
+		// declarations — but its internal jsonFile is not a complete
+		// mirror of ast.File, so a kind it does not know about silently
+		// encodes to "{}" and every instance of it looks identical. That
+		// is a false NEGATIVE, the dangerous direction: an edit vanishes.
+		// Fall back to the unparser, which round-trips through .bot text
+		// and is therefore also Span-free.
+		if err != nil || string(b) == "{}" {
+			if text := unparse.Unparse(file); strings.TrimSpace(text) != "" {
+				out[kind+":"+name] = text
+				return
+			}
+			// Neither encoder can express it: treat as always-changed
+			// rather than never-changed.
 			out[kind+":"+name] = fmt.Sprintf("<unencodable %d>", len(out))
 			return
 		}
@@ -186,6 +197,17 @@ func declFingerprints(f *ast.File) map[string]string {
 	}
 	for _, d := range f.MCPServers {
 		put("mcp_server", d.Name, &ast.File{MCPServers: []*ast.MCPServerDecl{d}})
+	}
+	// Groups are compile-time macros: `use <group> as <prefix>` clones
+	// their nodes with dotted ids inside ir.Compile, long after this diff
+	// runs on the raw parse. So the group body and its instantiations are
+	// fingerprinted here, and impactedNodes expands them to the real node
+	// ids — otherwise editing a group node is invisible.
+	for _, d := range f.Groups {
+		put("group", d.Name, &ast.File{Groups: []*ast.GroupDecl{d}})
+	}
+	for _, d := range f.Uses {
+		put("use", d.Group+" as "+d.Prefix, &ast.File{Uses: []*ast.UseDecl{d}})
 	}
 	if f.Vars != nil {
 		put("vars", "", &ast.File{Vars: f.Vars})
@@ -248,6 +270,15 @@ func edgeKey(workflow string, e *ast.Edge) string {
 	}
 	if e.Foreach != nil {
 		key += " foreach " + e.Foreach.Name
+	}
+	// Two sibling edges can share (from, to, guard) and differ only in
+	// their data mapping — `split -> worker with {task:"A"}` next to
+	// `{task:"B"}`. Without the mapping in the key they collide in the
+	// fingerprint map, last one wins, and editing the first is invisible.
+	for _, w := range e.With {
+		if w != nil {
+			key += " with " + w.Key + "=" + w.Value
+		}
 	}
 	return key
 }
@@ -318,9 +349,28 @@ func impactedNodes(changes []DeclChange, newFile *ast.File, wf *ir.Workflow) map
 				impacted[wf.Entry] = true
 			}
 
+		case c.Kind == "supervisor":
+			// A supervisor names the nodes it watches; the reference runs
+			// from the supervisor OUTWARDS, so the name-search below would
+			// never find it. An unwatched supervisor covers the whole run.
+			watched := supervisorWatches(newFile, c.Name)
+			if len(watched) == 0 && wf.Entry != "" {
+				impacted[wf.Entry] = true
+			}
+			for _, id := range watched {
+				impacted[id] = true
+			}
+
+		case c.Kind == "group" || c.Kind == "use":
+			// Expand to the instantiated node ids ("<prefix>.<node>"),
+			// which is what the compiled graph actually contains.
+			for _, id := range groupInstanceNodes(newFile, c.Kind, c.Name) {
+				impacted[id] = true
+			}
+
 		default:
-			// A shared declaration (prompt, schema, cursor, supervisor,
-			// mcp_server): every node referencing it by name is affected.
+			// A shared declaration (prompt, schema, cursor, mcp_server):
+			// every node referencing it by name is affected.
 			// The reference shows up as a quoted JSON string in that
 			// node's canonical form, which covers system/user/input/output
 			// and any future field carrying a name — no per-field
@@ -508,6 +558,12 @@ func fanOutRouterFor(wf *ir.Workflow, nodeID string) string {
 // the body, since it runs once rather than per-branch.
 func fanOutBody(wf *ir.Workflow, routerID string) map[string]bool {
 	adj := adjacency(wf, false)
+	inDegree := map[string]int{}
+	for _, e := range wf.Edges {
+		if e != nil {
+			inDegree[e.To]++
+		}
+	}
 	body := map[string]bool{}
 	queue := append([]string(nil), adj[routerID]...)
 	for len(queue) > 0 {
@@ -520,13 +576,98 @@ func fanOutBody(wf *ir.Workflow, routerID string) map[string]bool {
 		if !ok {
 			continue
 		}
-		if ir.NodeAwaitMode(node) != ir.AwaitNone {
-			// Convergence: the boundary, excluded from the body and not
-			// expanded past.
+		if isFanOutBoundary(wf, node, id, inDegree) {
+			// The boundary: excluded from the body, and not expanded
+			// past. Without the walk stopping here it would swallow the
+			// whole post-fan-out graph, and a rewind onto a node far
+			// downstream would be promoted back to the router.
 			continue
 		}
 		body[id] = true
 		queue = append(queue, adj[id]...)
 	}
 	return body
+}
+
+// isFanOutBoundary reports whether a node ends a fan-out region.
+//
+// A declared `await:` is the explicit form, but the engine also treats
+// more than one distinct incoming source as a convergence point
+// (pkg/runtime/convergence.go), and nothing in the DSL requires the
+// annotation. Relying on `await:` alone happens to work for every bot
+// shipped today and silently over-promotes for any graph that converges
+// implicitly. Terminals end the region too — nothing runs per-branch
+// after them.
+func isFanOutBoundary(wf *ir.Workflow, node ir.Node, id string, inDegree map[string]int) bool {
+	if ir.NodeAwaitMode(node) != ir.AwaitNone {
+		return true
+	}
+	switch node.(type) {
+	case *ir.DoneNode, *ir.FailNode:
+		return true
+	}
+	return inDegree[id] > 1
+}
+
+// supervisorWatches returns the node ids a supervisor declaration
+// watches. Empty means "the whole run" (see pkg/supervise).
+func supervisorWatches(f *ast.File, name string) []string {
+	for _, s := range f.Supervisors {
+		if s != nil && s.Name == name {
+			return s.Watches
+		}
+	}
+	return nil
+}
+
+// groupInstanceNodes maps a changed group (or a changed instantiation of
+// one) to the node ids the compiler will produce: `<prefix>.<node>` for
+// every `use` of that group. See pkg/dsl/ir/expand_groups.go.
+func groupInstanceNodes(f *ast.File, kind, name string) []string {
+	groupName := name
+	if kind == "use" {
+		// name is "<group> as <prefix>".
+		groupName, _, _ = strings.Cut(name, " as ")
+		groupName = strings.TrimSpace(groupName)
+	}
+	var out []string
+	for _, u := range f.Uses {
+		if u == nil || u.Group != groupName {
+			continue
+		}
+		for _, g := range f.Groups {
+			if g == nil || g.Name != groupName {
+				continue
+			}
+			for _, n := range groupNodeNames(g) {
+				out = append(out, u.Prefix+"."+n)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// groupNodeNames lists the node declarations inside a group body.
+func groupNodeNames(g *ast.GroupDecl) []string {
+	var out []string
+	for _, d := range g.Agents {
+		out = append(out, d.Name)
+	}
+	for _, d := range g.Judges {
+		out = append(out, d.Name)
+	}
+	for _, d := range g.Routers {
+		out = append(out, d.Name)
+	}
+	for _, d := range g.Humans {
+		out = append(out, d.Name)
+	}
+	for _, d := range g.Tools {
+		out = append(out, d.Name)
+	}
+	for _, d := range g.Computes {
+		out = append(out, d.Name)
+	}
+	return out
 }

--- a/pkg/runview/rewind_auto.go
+++ b/pkg/runview/rewind_auto.go
@@ -1,0 +1,457 @@
+package runview
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ast"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+)
+
+// ErrRewindNoSourceRecorded is returned when --auto is asked of a run
+// launched before the workflow source was persisted (or whose source
+// could not be captured). Callers map it to 400 and point at --node.
+var ErrRewindNoSourceRecorded = errors.New("runview: rewind: this run recorded no workflow source, so the edit cannot be located")
+
+// ErrRewindNoChange is returned when --auto finds no difference between
+// the recorded source and the current one, or when every difference
+// lands on a node the run never executed.
+var ErrRewindNoChange = errors.New("runview: rewind: no change affects a node this run executed")
+
+// ErrRewindAmbiguous is returned when the edit touches several
+// independent branches, so there is no single earliest node to rewind
+// to. Callers map it to 400 and name the candidates.
+var ErrRewindAmbiguous = errors.New("runview: rewind: the edit affects independent branches")
+
+// DeclChange is one differing top-level declaration between the source a
+// run executed and the source on disk now.
+type DeclChange struct {
+	// Kind is the declaration kind: agent, judge, router, human, tool,
+	// compute, subbot, emit, wait, await_answers, prompt, schema, cursor,
+	// supervisor, mcp_server, vars, presets, attachments, secrets, edge,
+	// or workflow.
+	Kind string `json:"kind"`
+	// Name identifies the declaration (node id, prompt name, "a -> b" for
+	// an edge, the workflow name for workflow-level settings).
+	Name string `json:"name"`
+	// Change is "modified", "added", or "removed".
+	Change string `json:"change"`
+}
+
+func (c DeclChange) String() string { return c.Kind + " " + c.Name + " (" + c.Change + ")" }
+
+// resolveAutoPivot diffs the source a run executed against the source on
+// disk now, and returns the node to rewind to: the earliest node the run
+// actually executed that the edit affects.
+//
+// This is what makes the bot-development loop one step instead of two —
+// "I changed the prompt of implement" no longer has to be translated by
+// hand into "--node implement", and an edited edge or a shared prompt
+// resolves to the right pivot without the operator tracing references.
+//
+// Detection is declaration-granular and deliberately errs toward
+// reporting MORE nodes than strictly necessary: a false positive costs
+// re-executing a node that did not need it, while a false negative would
+// test the new configuration against stale downstream state — the exact
+// failure this feature exists to prevent.
+func resolveAutoPivot(oldSrc, newSrc string, wf *ir.Workflow, executed map[string]bool) (string, []DeclChange, error) {
+	if strings.TrimSpace(oldSrc) == "" {
+		return "", nil, ErrRewindNoSourceRecorded
+	}
+	oldFile, err := parseForDiff(oldSrc, "<recorded>")
+	if err != nil {
+		return "", nil, fmt.Errorf("parse the source this run executed: %w", err)
+	}
+	newFile, err := parseForDiff(newSrc, "<current>")
+	if err != nil {
+		return "", nil, fmt.Errorf("parse the current source: %w", err)
+	}
+
+	changes := diffDecls(declFingerprints(oldFile), declFingerprints(newFile))
+	if len(changes) == 0 {
+		return "", nil, fmt.Errorf("%w: the workflow source is unchanged", ErrRewindNoChange)
+	}
+
+	impacted := impactedNodes(changes, newFile, wf)
+	candidates := make([]string, 0, len(impacted))
+	for id := range impacted {
+		if executed[id] {
+			candidates = append(candidates, id)
+		}
+	}
+	sort.Strings(candidates)
+	if len(candidates) == 0 {
+		return "", changes, fmt.Errorf("%w: changed %s", ErrRewindNoChange, summarizeChanges(changes))
+	}
+
+	earliest := earliestCandidates(wf, candidates)
+	if len(earliest) > 1 {
+		return "", changes, fmt.Errorf("%w: %s are on independent branches — pick one with --node",
+			ErrRewindAmbiguous, strings.Join(earliest, ", "))
+	}
+	return earliest[0], changes, nil
+}
+
+// parseForDiff parses a source into an AST, refusing on hard parse
+// errors. The recorded source parsed once already (the run executed), so
+// a failure here means the CURRENT file is broken — worth surfacing
+// before the operator resumes into it.
+func parseForDiff(src, label string) (*ast.File, error) {
+	pr := parser.Parse(label, src)
+	for _, d := range pr.Diagnostics {
+		if d.Severity == parser.SeverityError {
+			return nil, fmt.Errorf("%s", d.Error())
+		}
+	}
+	if pr.File == nil {
+		return nil, fmt.Errorf("no workflow found")
+	}
+	return pr.File, nil
+}
+
+// declFingerprints canonicalises every top-level declaration to a string
+// keyed by "<kind>:<name>".
+//
+// The canonical form is the AST JSON encoder applied to a file holding
+// that single declaration. Reusing ast.MarshalFile rather than hand-rolling
+// a fingerprint matters twice over: it stays faithful as the DSL grows a
+// field (a hand-rolled one silently stops noticing), and it omits Span
+// fields, so inserting a line at the top of a .bot does not make every
+// declaration below it look edited.
+func declFingerprints(f *ast.File) map[string]string {
+	out := map[string]string{}
+	put := func(kind, name string, file *ast.File) {
+		b, err := ast.MarshalFile(file)
+		if err != nil {
+			// An unencodable declaration is treated as "always changed"
+			// rather than "never changed": erring toward re-execution is
+			// the safe direction.
+			out[kind+":"+name] = fmt.Sprintf("<unencodable %d>", len(out))
+			return
+		}
+		out[kind+":"+name] = string(b)
+	}
+
+	for _, d := range f.Agents {
+		put("agent", d.Name, &ast.File{Agents: []*ast.AgentDecl{d}})
+	}
+	for _, d := range f.Judges {
+		put("judge", d.Name, &ast.File{Judges: []*ast.JudgeDecl{d}})
+	}
+	for _, d := range f.Routers {
+		put("router", d.Name, &ast.File{Routers: []*ast.RouterDecl{d}})
+	}
+	for _, d := range f.Humans {
+		put("human", d.Name, &ast.File{Humans: []*ast.HumanDecl{d}})
+	}
+	for _, d := range f.Tools {
+		put("tool", d.Name, &ast.File{Tools: []*ast.ToolNodeDecl{d}})
+	}
+	for _, d := range f.Computes {
+		put("compute", d.Name, &ast.File{Computes: []*ast.ComputeDecl{d}})
+	}
+	for _, d := range f.Subbots {
+		put("subbot", d.Name, &ast.File{Subbots: []*ast.SubbotDecl{d}})
+	}
+	for _, d := range f.Emits {
+		put("emit", d.Name, &ast.File{Emits: []*ast.EmitDecl{d}})
+	}
+	for _, d := range f.Waits {
+		put("wait", d.Name, &ast.File{Waits: []*ast.WaitDecl{d}})
+	}
+	for _, d := range f.AwaitAnswers {
+		put("await_answers", d.Name, &ast.File{AwaitAnswers: []*ast.AwaitAnswersDecl{d}})
+	}
+	for _, d := range f.Prompts {
+		put("prompt", d.Name, &ast.File{Prompts: []*ast.PromptDecl{d}})
+	}
+	for _, d := range f.Schemas {
+		put("schema", d.Name, &ast.File{Schemas: []*ast.SchemaDecl{d}})
+	}
+	for _, d := range f.Cursors {
+		put("cursor", d.Name, &ast.File{Cursors: []*ast.CursorDecl{d}})
+	}
+	for _, d := range f.Supervisors {
+		put("supervisor", d.Name, &ast.File{Supervisors: []*ast.SupervisorDecl{d}})
+	}
+	for _, d := range f.MCPServers {
+		put("mcp_server", d.Name, &ast.File{MCPServers: []*ast.MCPServerDecl{d}})
+	}
+	if f.Vars != nil {
+		put("vars", "", &ast.File{Vars: f.Vars})
+	}
+	if f.Presets != nil {
+		put("presets", "", &ast.File{Presets: f.Presets})
+	}
+	if f.Attachments != nil {
+		put("attachments", "", &ast.File{Attachments: f.Attachments})
+	}
+	if f.Secrets != nil {
+		put("secrets", "", &ast.File{Secrets: f.Secrets})
+	}
+
+	// The workflow block splits in two: each edge on its own (so an edge
+	// edit blames its SOURCE node instead of the whole graph), and the
+	// remaining workflow-level settings as one unit.
+	for _, w := range f.Workflows {
+		if w == nil {
+			continue
+		}
+		for _, e := range w.Edges {
+			if e == nil {
+				continue
+			}
+			put("edge", edgeKey(w.Name, e), &ast.File{Workflows: []*ast.WorkflowDecl{{Name: w.Name, Edges: []*ast.Edge{e}}}})
+		}
+		shell := *w
+		shell.Edges = nil
+		put("workflow", w.Name, &ast.File{Workflows: []*ast.WorkflowDecl{&shell}})
+	}
+	return out
+}
+
+// edgeKey names an edge stably across edits. Two edges can share
+// (from, to) — a conditional pair, or an else branch — so the guard
+// participates in the identity; otherwise editing one would read as
+// editing both, and both source nodes would land in the impacted set.
+func edgeKey(workflow string, e *ast.Edge) string {
+	// Semantic fields ONLY: WhenClause/LoopClause/ForeachClause each carry
+	// a Span, and interpolating the whole struct would move the key every
+	// time a line is inserted above — making every edge read as
+	// removed-and-re-added on any edit anywhere in the file.
+	key := workflow + ":" + e.From + " -> " + e.To
+	switch {
+	case e.When != nil:
+		switch {
+		case e.When.Expr != "":
+			key += " when " + e.When.Expr
+		case e.When.Negated:
+			key += " when not " + e.When.Condition
+		default:
+			key += " when " + e.When.Condition
+		}
+	case e.IsElse:
+		key += " else"
+	}
+	if e.Loop != nil {
+		key += " as " + e.Loop.Name
+	}
+	if e.Foreach != nil {
+		key += " foreach " + e.Foreach.Name
+	}
+	return key
+}
+
+// diffDecls compares two fingerprint maps into a sorted change list.
+func diffDecls(oldFP, newFP map[string]string) []DeclChange {
+	var out []DeclChange
+	for key, newVal := range newFP {
+		oldVal, existed := oldFP[key]
+		switch {
+		case !existed:
+			out = append(out, declChangeFromKey(key, "added"))
+		case oldVal != newVal:
+			out = append(out, declChangeFromKey(key, "modified"))
+		}
+	}
+	for key := range oldFP {
+		if _, still := newFP[key]; !still {
+			out = append(out, declChangeFromKey(key, "removed"))
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func declChangeFromKey(key, change string) DeclChange {
+	kind, name, _ := strings.Cut(key, ":")
+	return DeclChange{Kind: kind, Name: name, Change: change}
+}
+
+// nodeDeclKinds are the declaration kinds that ARE graph nodes, so a
+// change maps straight onto the node of the same name.
+var nodeDeclKinds = map[string]bool{
+	"agent": true, "judge": true, "router": true, "human": true,
+	"tool": true, "compute": true, "subbot": true,
+	"emit": true, "wait": true, "await_answers": true,
+}
+
+// impactedNodes maps a change list onto the graph nodes it affects.
+func impactedNodes(changes []DeclChange, newFile *ast.File, wf *ir.Workflow) map[string]bool {
+	impacted := map[string]bool{}
+	fingerprints := declFingerprints(newFile)
+
+	for _, c := range changes {
+		switch {
+		case nodeDeclKinds[c.Kind]:
+			impacted[c.Name] = true
+
+		case c.Kind == "edge":
+			// An edge belongs to the node that routes over it: that node
+			// re-runs and re-selects. "wf:a -> b when ok" → "a".
+			_, rest, _ := strings.Cut(c.Name, ":")
+			if from, _, ok := strings.Cut(rest, " -> "); ok {
+				impacted[strings.TrimSpace(from)] = true
+			}
+
+		case c.Kind == "workflow" || c.Kind == "vars" || c.Kind == "presets" ||
+			c.Kind == "attachments" || c.Kind == "secrets":
+			// Workflow-scope settings (budget, sandbox, permission, entry,
+			// vars…) can reach any node, so the only safe pivot is the
+			// entry — the whole run is affected.
+			if wf.Entry != "" {
+				impacted[wf.Entry] = true
+			}
+
+		default:
+			// A shared declaration (prompt, schema, cursor, supervisor,
+			// mcp_server): every node referencing it by name is affected.
+			// The reference shows up as a quoted JSON string in that
+			// node's canonical form, which covers system/user/input/output
+			// and any future field carrying a name — no per-field
+			// enumeration to keep in sync with the DSL.
+			needle := `"` + c.Name + `"`
+			for key, fp := range fingerprints {
+				kind, name, _ := strings.Cut(key, ":")
+				if !nodeDeclKinds[kind] {
+					continue
+				}
+				if strings.Contains(fp, needle) {
+					impacted[name] = true
+				}
+			}
+		}
+	}
+
+	// Drop anything that is not a node in the compiled graph (a removed
+	// node, or a shared-decl name that coincides with nothing).
+	for id := range impacted {
+		if _, ok := wf.Nodes[id]; !ok {
+			delete(impacted, id)
+		}
+	}
+	return impacted
+}
+
+// earliestCandidates keeps the candidates that no OTHER candidate can
+// reach — the upstream-most edits. Rewinding to one of those replays
+// every other affected node downstream of it, so the whole edit is
+// tested in one pass.
+//
+// More than one survivor means the edits sit on branches that cannot
+// reach each other (a fan-out), where no single pivot covers them all.
+func earliestCandidates(wf *ir.Workflow, candidates []string) []string {
+	rev := adjacency(wf, true)
+	var out []string
+	for _, c := range candidates {
+		ancestors := reachable(c, rev)
+		dominated := false
+		for _, other := range candidates {
+			if other != c && ancestors[other] {
+				dominated = true
+				break
+			}
+		}
+		if !dominated {
+			out = append(out, c)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// summarizeChanges renders a change list for an error message.
+func summarizeChanges(changes []DeclChange) string {
+	parts := make([]string, 0, len(changes))
+	for _, c := range changes {
+		parts = append(parts, c.String())
+	}
+	return strings.Join(parts, ", ")
+}
+
+// fanOutRouterFor returns the outermost fan-out router whose body
+// contains nodeID, or "" when the node sits outside any fan-out region.
+//
+// Why a rewind must promote to it: the checkpoint holds ONE output per
+// node id (convergence merges branches last-write-wins), so N parallel
+// executions of a body node collapse to a single entry — there is no
+// per-branch state to rewind to. Re-executing "all of them" is only
+// expressible as "re-run the fan-out", and the fan-out is orchestrated by
+// the router, not by the body node. Anchoring on the body node instead
+// would replay it ONCE, linearly, with no `each` context — silently
+// testing one iteration instead of N.
+//
+// Outermost, not nearest: a nested inner router re-run on its own would
+// itself lack the outer iteration's context.
+func fanOutRouterFor(wf *ir.Workflow, nodeID string) string {
+	bodies := map[string]map[string]bool{}
+	for id, node := range wf.Nodes {
+		r, ok := node.(*ir.RouterNode)
+		if !ok || (r.RouterMode != ir.RouterFanOutAll && r.RouterMode != ir.RouterFanOutEach) {
+			continue
+		}
+		bodies[id] = fanOutBody(wf, id)
+	}
+	var containing []string
+	for routerID, body := range bodies {
+		if body[nodeID] {
+			containing = append(containing, routerID)
+		}
+	}
+	if len(containing) == 0 {
+		return ""
+	}
+	sort.Strings(containing)
+	// The outermost is the one no OTHER fan-out router's body contains.
+	for _, candidate := range containing {
+		nested := false
+		for _, other := range containing {
+			if other != candidate && bodies[other][candidate] {
+				nested = true
+				break
+			}
+		}
+		if !nested {
+			return candidate
+		}
+	}
+	return containing[0]
+}
+
+// fanOutBody walks forward from a fan-out router and returns the nodes
+// that execute inside its branches. The walk stops AT the convergence —
+// any node declaring `await:` — which is the boundary where branches
+// merge back into the main path; the convergence node itself is outside
+// the body, since it runs once rather than per-branch.
+func fanOutBody(wf *ir.Workflow, routerID string) map[string]bool {
+	adj := adjacency(wf, false)
+	body := map[string]bool{}
+	queue := append([]string(nil), adj[routerID]...)
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		if body[id] || id == routerID {
+			continue
+		}
+		node, ok := wf.Nodes[id]
+		if !ok {
+			continue
+		}
+		if ir.NodeAwaitMode(node) != ir.AwaitNone {
+			// Convergence: the boundary, excluded from the body and not
+			// expanded past.
+			continue
+		}
+		body[id] = true
+		queue = append(queue, adj[id]...)
+	}
+	return body
+}

--- a/pkg/runview/rewind_auto_test.go
+++ b/pkg/runview/rewind_auto_test.go
@@ -1,0 +1,267 @@
+package runview
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// autoBot is the fixture every --auto test edits: a straight chain with
+// a shared prompt and a conditional edge, so each detection path has
+// something to bite on.
+const autoBot = `prompt shared_review:
+  """
+  Review the work carefully.
+  """
+
+schema note:
+  value: string
+
+schema check:
+  value: string
+  ok: bool
+
+agent survey:
+  model: "claude-opus-4-7"
+  output: note
+
+agent plan:
+  model: "claude-opus-4-7"
+  output: note
+
+agent implement:
+  model: "claude-opus-4-7"
+  input: note
+  output: note
+
+judge verify:
+  model: "claude-opus-4-7"
+  system: shared_review
+  output: check
+
+workflow autobot:
+  entry: survey
+  survey -> plan
+  plan -> implement
+  implement -> verify
+  verify -> done when ok
+  verify -> fail
+`
+
+// seedAutoRun writes the fixture, parks a run that executed every node,
+// and returns the service, the bot path, and the run id.
+func seedAutoRun(t *testing.T, checkpointNode string, executedOutputs ...string) (*Service, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	botPath := filepath.Join(dir, "main.bot")
+	if err := os.WriteFile(botPath, []byte(autoBot), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	storeDir := filepath.Join(dir, "store")
+	st, err := store.New(storeDir)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	runID := "run-auto"
+	if _, err := st.CreateRun(context.Background(), runID, "autobot", nil); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	run.FilePath = botPath
+	// The source AS LAUNCHED — the whole point of Run.WorkflowSource.
+	run.WorkflowSource = autoBot
+	run.Status = store.RunStatusFailedResumable
+	run.Checkpoint = &store.Checkpoint{
+		NodeID:  checkpointNode,
+		Outputs: outputsOf(executedOutputs...),
+	}
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("save run: %v", err)
+	}
+	svc, err := NewService(storeDir)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return svc, botPath, runID
+}
+
+func editBot(t *testing.T, path, old, new string) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read bot: %v", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, old) {
+		t.Fatalf("fixture does not contain %q", old)
+	}
+	if err := os.WriteFile(path, []byte(strings.Replace(s, old, new, 1)), 0o644); err != nil {
+		t.Fatalf("write bot: %v", err)
+	}
+}
+
+// TestRewindAuto_TargetsEditedNode is the headline case: change one
+// node's model, and --auto rewinds to exactly that node.
+func TestRewindAuto_TargetsEditedNode(t *testing.T) {
+	svc, botPath, runID := seedAutoRun(t, "verify", "survey", "plan", "implement", "verify")
+	editBot(t, botPath, "agent implement:\n  model: \"claude-opus-4-7\"", "agent implement:\n  model: \"claude-opus-5\"")
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, Auto: true})
+	if err != nil {
+		t.Fatalf("Rewind --auto: %v", err)
+	}
+	if result.NodeID != "implement" {
+		t.Errorf("auto pivot = %q, want implement", result.NodeID)
+	}
+	if !result.AutoTargeted {
+		t.Error("expected AutoTargeted=true")
+	}
+	if len(result.Changes) == 0 {
+		t.Fatal("expected the detected changes to be reported back")
+	}
+	found := false
+	for _, c := range result.Changes {
+		if c.Kind == "agent" && c.Name == "implement" && c.Change == "modified" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("changes = %v, want agent implement (modified)", result.Changes)
+	}
+}
+
+// TestRewindAuto_SharedPromptTargetsReferencingNode: editing a prompt
+// body must blame the node that references it, not the prompt.
+func TestRewindAuto_SharedPromptTargetsReferencingNode(t *testing.T) {
+	svc, botPath, runID := seedAutoRun(t, "verify", "survey", "plan", "implement", "verify")
+	editBot(t, botPath, "Review the work carefully.", "Review the work with extreme suspicion.")
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, Auto: true})
+	if err != nil {
+		t.Fatalf("Rewind --auto: %v", err)
+	}
+	if result.NodeID != "verify" {
+		t.Errorf("auto pivot = %q, want verify (the only node referencing shared_review)", result.NodeID)
+	}
+}
+
+// TestRewindAuto_PicksEarliestOfSeveralEdits: two nodes edited on the
+// same chain must rewind to the upstream one, so a single pass tests
+// both.
+func TestRewindAuto_PicksEarliestOfSeveralEdits(t *testing.T) {
+	svc, botPath, runID := seedAutoRun(t, "verify", "survey", "plan", "implement", "verify")
+	editBot(t, botPath, "agent plan:\n  model: \"claude-opus-4-7\"", "agent plan:\n  model: \"claude-opus-5\"")
+	editBot(t, botPath, "agent implement:\n  model: \"claude-opus-4-7\"", "agent implement:\n  model: \"claude-opus-5\"")
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, Auto: true})
+	if err != nil {
+		t.Fatalf("Rewind --auto: %v", err)
+	}
+	if result.NodeID != "plan" {
+		t.Errorf("auto pivot = %q, want plan (upstream-most edit)", result.NodeID)
+	}
+}
+
+// TestRewindAuto_EditedEdgeBlamesSourceNode: an edge is re-selected by
+// the node it leaves, so that node is the pivot.
+func TestRewindAuto_EditedEdgeBlamesSourceNode(t *testing.T) {
+	svc, botPath, runID := seedAutoRun(t, "verify", "survey", "plan", "implement", "verify")
+	editBot(t, botPath, "  plan -> implement", `  plan -> implement with {value: "{{outputs.plan.value}}"}`)
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, Auto: true})
+	if err != nil {
+		t.Fatalf("Rewind --auto: %v", err)
+	}
+	if result.NodeID != "plan" {
+		t.Errorf("auto pivot = %q, want plan (the edge's source node re-selects it)", result.NodeID)
+	}
+}
+
+// TestRewindAuto_IgnoresUnexecutedNodes: an edit to a node the run never
+// reached is not a reason to rewind.
+func TestRewindAuto_IgnoresUnexecutedNodes(t *testing.T) {
+	// Only survey and plan ran — and the run is parked on plan, so
+	// `verify` is genuinely unreached (cp.NodeID counts as executed too).
+	svc, botPath, runID := seedAutoRun(t, "plan", "survey", "plan")
+	editBot(t, botPath, "judge verify:\n  model: \"claude-opus-4-7\"", "judge verify:\n  model: \"claude-opus-5\"")
+
+	_, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, Auto: true})
+	if !errors.Is(err, ErrRewindNoChange) {
+		t.Fatalf("err = %v, want ErrRewindNoChange (verify never executed)", err)
+	}
+}
+
+// TestRewindAuto_NoEditIsNotAnError_ButRefuses: rewinding with nothing
+// changed must say so rather than silently picking a node.
+func TestRewindAuto_NoEditRefuses(t *testing.T) {
+	svc, _, runID := seedAutoRun(t, "verify", "survey", "plan", "implement", "verify")
+
+	_, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, Auto: true})
+	if !errors.Is(err, ErrRewindNoChange) {
+		t.Fatalf("err = %v, want ErrRewindNoChange", err)
+	}
+}
+
+// TestRewindAuto_WithoutRecordedSource: a run launched before the source
+// was persisted must fail with a message that points at --node.
+func TestRewindAuto_WithoutRecordedSource(t *testing.T) {
+	svc, _, runID := seedAutoRun(t, "verify", "survey", "plan", "implement", "verify")
+	st := svc.RunStore()
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	run.WorkflowSource = ""
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	_, err = svc.Rewind(context.Background(), RewindSpec{RunID: runID, Auto: true})
+	if !errors.Is(err, ErrRewindNoSourceRecorded) {
+		t.Fatalf("err = %v, want ErrRewindNoSourceRecorded", err)
+	}
+}
+
+// TestRewindAuto_ExplicitNodeWins: --node overrides the diff entirely.
+func TestRewindAuto_ExplicitNodeWins(t *testing.T) {
+	svc, botPath, runID := seedAutoRun(t, "verify", "survey", "plan", "implement", "verify")
+	editBot(t, botPath, "agent implement:\n  model: \"claude-opus-4-7\"", "agent implement:\n  model: \"claude-opus-5\"")
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "plan", Auto: true})
+	if err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+	if result.NodeID != "plan" {
+		t.Errorf("pivot = %q, want plan (explicit --node wins over --auto)", result.NodeID)
+	}
+	if result.AutoTargeted {
+		t.Error("AutoTargeted must be false when the caller supplied the node")
+	}
+}
+
+// TestRewindAuto_LineShiftIsNotAChange guards the span-sensitivity trap:
+// inserting a comment at the top moves every declaration's position, and
+// must not read as "everything changed".
+func TestRewindAuto_LineShiftIsNotAChange(t *testing.T) {
+	svc, botPath, runID := seedAutoRun(t, "verify", "survey", "plan", "implement", "verify")
+	b, err := os.ReadFile(botPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if err := os.WriteFile(botPath, append([]byte("## a new comment line\n\n"), b...), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err = svc.Rewind(context.Background(), RewindSpec{RunID: runID, Auto: true})
+	if !errors.Is(err, ErrRewindNoChange) {
+		t.Fatalf("err = %v, want ErrRewindNoChange — a line shift is not a semantic edit", err)
+	}
+}

--- a/pkg/runview/rewind_auto_test.go
+++ b/pkg/runview/rewind_auto_test.go
@@ -399,3 +399,159 @@ func TestRewindAuto_LoopEditIsNotMaskedByAnIndependentOne(t *testing.T) {
 		t.Error("implement was not invalidated; the loop edit would go untested")
 	}
 }
+
+// supervisedBot exercises the three declaration kinds ast.MarshalFile
+// does not mirror. Editing any of them used to be invisible to --auto.
+const supervisedBot = `schema note:
+  value: string
+
+prompt watch_policy:
+  """
+  Intervene when the agent stalls.
+  """
+
+supervisor watchdog:
+  watches: [implement]
+  model: "claude-opus-4-7"
+  system: watch_policy
+  cooldown: "30s"
+
+agent survey:
+  model: "claude-opus-4-7"
+  output: note
+
+agent implement:
+  model: "claude-opus-4-7"
+  output: note
+
+workflow supervised:
+  entry: survey
+  survey -> implement
+  implement -> done
+`
+
+func seedSupervisedRun(t *testing.T, src string) (*Service, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	botPath := filepath.Join(dir, "main.bot")
+	if err := os.WriteFile(botPath, []byte(src), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	storeDir := filepath.Join(dir, "store")
+	st, err := store.New(storeDir)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	const runID = "run-sup"
+	if _, err := st.CreateRun(context.Background(), runID, "supervised", nil); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	run.FilePath = botPath
+	run.WorkflowSource = src
+	run.Status = store.RunStatusFailedResumable
+	run.Checkpoint = &store.Checkpoint{
+		NodeID:  "implement",
+		Outputs: outputsOf("survey", "implement", "split", "worker_a", "worker_b", "merge"),
+	}
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	svc, err := NewService(storeDir)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return svc, botPath, runID
+}
+
+// TestRewindAuto_SupervisorEditTargetsWatchedNode: a supervisor's
+// reference runs OUTWARDS (`watches: [implement]`), so the name-search
+// used for shared declarations would never find it.
+func TestRewindAuto_SupervisorEditTargetsWatchedNode(t *testing.T) {
+	svc, botPath, runID := seedSupervisedRun(t, supervisedBot)
+	editBot(t, botPath, `cooldown: "30s"`, `cooldown: "5s"`)
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, Auto: true})
+	if err != nil {
+		t.Fatalf("Rewind --auto: %v", err)
+	}
+	if result.NodeID != "implement" {
+		t.Errorf("pivot = %q, want implement (the watched node)", result.NodeID)
+	}
+	var sawSupervisor bool
+	for _, c := range result.Changes {
+		if c.Kind == "supervisor" && c.Name == "watchdog" {
+			sawSupervisor = true
+		}
+	}
+	if !sawSupervisor {
+		t.Errorf("changes = %v, want the supervisor edit detected", result.Changes)
+	}
+}
+
+// TestRewindAuto_UnchangedSupervisorIsNotAChange guards the other
+// direction: the fallback encoder must be stable, or every rewind on a
+// supervised bot would report a phantom edit.
+func TestRewindAuto_UnchangedSupervisorIsNotAChange(t *testing.T) {
+	svc, _, runID := seedSupervisedRun(t, supervisedBot)
+
+	_, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, Auto: true})
+	if !errors.Is(err, ErrRewindNoChange) {
+		t.Fatalf("err = %v, want ErrRewindNoChange — an untouched supervisor must not read as edited", err)
+	}
+}
+
+// TestRewindAuto_EdgeDataMappingIsPartOfIdentity: two sibling edges can
+// differ only in their `with` mapping. Without it in the key they collide
+// and editing the first is invisible.
+func TestRewindAuto_EdgeDataMappingIsPartOfIdentity(t *testing.T) {
+	const forkBot = `schema note:
+  value: string
+
+agent survey:
+  model: "claude-opus-4-7"
+  output: note
+
+router split:
+  mode: fan_out_all
+
+agent worker_a:
+  model: "claude-opus-4-7"
+  input: note
+  output: note
+
+agent worker_b:
+  model: "claude-opus-4-7"
+  input: note
+  output: note
+
+agent merge:
+  model: "claude-opus-4-7"
+  output: note
+  await: wait_all
+
+workflow forked:
+  entry: survey
+  survey -> split
+  split -> worker_a with {value: "ALPHA"}
+  split -> worker_b with {value: "BETA"}
+  worker_a -> merge
+  worker_b -> merge
+  merge -> done
+`
+	svc, botPath, runID := seedSupervisedRun(t, forkBot)
+	editBot(t, botPath, `split -> worker_a with {value: "ALPHA"}`, `split -> worker_a with {value: "GAMMA"}`)
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, Auto: true})
+	if err != nil {
+		t.Fatalf("Rewind --auto: %v", err)
+	}
+	// The edge leaves `split`, and split is a fan-out router, so the
+	// pivot is the router itself.
+	if result.NodeID != "split" {
+		t.Errorf("pivot = %q, want split", result.NodeID)
+	}
+}

--- a/pkg/runview/rewind_auto_test.go
+++ b/pkg/runview/rewind_auto_test.go
@@ -265,3 +265,137 @@ func TestRewindAuto_LineShiftIsNotAChange(t *testing.T) {
 		t.Fatalf("err = %v, want ErrRewindNoChange — a line shift is not a semantic edit", err)
 	}
 }
+
+// loopedAutoBot puts two nodes on a cycle, the shape that made --auto
+// panic: each is the other's ancestor, so a dominance rule that ignores
+// cycles eliminates both and leaves nothing to elect.
+const loopedAutoBot = `schema note:
+  value: string
+
+schema check:
+  value: string
+  ok: bool
+
+agent survey:
+  model: "claude-opus-4-7"
+  output: note
+
+agent implement:
+  model: "claude-opus-4-7"
+  output: note
+
+judge verify:
+  model: "claude-opus-4-7"
+  output: check
+
+workflow loopauto:
+  entry: survey
+  survey -> implement
+  implement -> verify
+  verify -> done when ok
+  verify -> implement as fix(3)
+`
+
+// TestRewindAuto_TwoEditsOnOneLoop is the regression guard for the panic:
+// editing two nodes that sit on the same cycle must elect one, not crash
+// and not silently give up.
+func TestRewindAuto_TwoEditsOnOneLoop(t *testing.T) {
+	dir := t.TempDir()
+	botPath := filepath.Join(dir, "main.bot")
+	if err := os.WriteFile(botPath, []byte(loopedAutoBot), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	storeDir := filepath.Join(dir, "store")
+	st, err := store.New(storeDir)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	const runID = "run-loop-auto"
+	if _, err := st.CreateRun(context.Background(), runID, "loopauto", nil); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	run.FilePath = botPath
+	run.WorkflowSource = loopedAutoBot
+	run.Status = store.RunStatusFailedResumable
+	run.Checkpoint = &store.Checkpoint{
+		NodeID:       "verify",
+		Outputs:      outputsOf("survey", "implement", "verify"),
+		LoopCounters: map[string]int{"fix": 1},
+	}
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	svc, err := NewService(storeDir)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	editBot(t, botPath, "agent implement:\n  model: \"claude-opus-4-7\"", "agent implement:\n  model: \"claude-opus-5\"")
+	editBot(t, botPath, "judge verify:\n  model: \"claude-opus-4-7\"", "judge verify:\n  model: \"claude-opus-5\"")
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, Auto: true})
+	if err != nil {
+		t.Fatalf("Rewind --auto on a loop: %v", err)
+	}
+	// Both edits are on the cycle; replaying either replays the loop, so
+	// the one execution reaches first is elected.
+	if result.NodeID != "implement" {
+		t.Errorf("pivot = %q, want implement (nearest the entry on the cycle)", result.NodeID)
+	}
+}
+
+// TestRewindAuto_LoopEditIsNotMaskedByAnIndependentOne guards the silent
+// half of the same bug: with cycle-mates eliminating each other, an
+// unrelated third candidate would win and the loop edit would vanish.
+func TestRewindAuto_LoopEditIsNotMaskedByAnIndependentOne(t *testing.T) {
+	dir := t.TempDir()
+	botPath := filepath.Join(dir, "main.bot")
+	if err := os.WriteFile(botPath, []byte(loopedAutoBot), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	storeDir := filepath.Join(dir, "store")
+	st, err := store.New(storeDir)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	const runID = "run-loop-mask"
+	if _, err := st.CreateRun(context.Background(), runID, "loopauto", nil); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	run.FilePath = botPath
+	run.WorkflowSource = loopedAutoBot
+	run.Status = store.RunStatusFailedResumable
+	run.Checkpoint = &store.Checkpoint{
+		NodeID:  "verify",
+		Outputs: outputsOf("survey", "implement", "verify"),
+	}
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	svc, err := NewService(storeDir)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	// survey is strictly upstream of the loop; implement is on it.
+	editBot(t, botPath, "agent survey:\n  model: \"claude-opus-4-7\"", "agent survey:\n  model: \"claude-opus-5\"")
+	editBot(t, botPath, "agent implement:\n  model: \"claude-opus-4-7\"", "agent implement:\n  model: \"claude-opus-5\"")
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, Auto: true})
+	if err != nil {
+		t.Fatalf("Rewind --auto: %v", err)
+	}
+	if result.NodeID != "survey" {
+		t.Fatalf("pivot = %q, want survey — the strictly-upstream edit must win", result.NodeID)
+	}
+	// And the loop edit is covered, because implement is downstream.
+	if !contains(result.DroppedNodes, "implement") {
+		t.Error("implement was not invalidated; the loop edit would go untested")
+	}
+}

--- a/pkg/runview/rewind_auto_test.go
+++ b/pkg/runview/rewind_auto_test.go
@@ -555,3 +555,113 @@ workflow forked:
 		t.Errorf("pivot = %q, want split", result.NodeID)
 	}
 }
+
+// groupBot exercises the compile-time macro path: `use … as …` clones the
+// group's nodes with dotted ids inside ir.Compile, long after the source
+// diff runs on the raw parse. Modelled on examples/composition.
+const groupBot = `schema pout:
+  id: string
+  ok: bool
+
+group gate_block(label):
+  tool gate:
+    command: ` + "`" + `printf '{"id":"%s","ok":true}' "{{params.label}}"` + "`" + `
+    output: pout
+
+use gate_block as r1 with { label: "T-42" }
+
+agent report:
+  model: "claude-opus-4-7"
+  output: pout
+
+workflow composed:
+  entry: r1.gate
+  r1.gate -> report
+  report  -> done
+`
+
+// seedGroupRun is seedAutoRun over groupBot, with the group instance and
+// the downstream node both executed.
+func seedGroupRun(t *testing.T) (*Service, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	botPath := filepath.Join(dir, "main.bot")
+	if err := os.WriteFile(botPath, []byte(groupBot), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	storeDir := filepath.Join(dir, "store")
+	st, err := store.New(storeDir)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	const runID = "run-group"
+	if _, err := st.CreateRun(context.Background(), runID, "composed", nil); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	run.FilePath = botPath
+	run.WorkflowSource = groupBot
+	run.Status = store.RunStatusFailedResumable
+	run.Checkpoint = &store.Checkpoint{
+		NodeID:  "report",
+		Outputs: outputsOf("r1.gate", "report"),
+	}
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("save run: %v", err)
+	}
+	svc, err := NewService(storeDir)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return svc, botPath, runID
+}
+
+// TestRewindAuto_GroupBodyEditIsSeen is Revi's R991318.
+//
+// Neither ast.MarshalFile's jsonFile nor the unparser carries a groups
+// field, so `&ast.File{Groups: …}` encoded to "{}" and put fell through
+// to its "<unencodable N>" placeholder — derived from the declaration's
+// ordinal position, hence IDENTICAL before and after the edit. diffDecls
+// saw nothing, `--auto` refused with "the workflow source is unchanged",
+// and the operator resumed against the old group node. A false negative,
+// which is the dangerous direction.
+func TestRewindAuto_GroupBodyEditIsSeen(t *testing.T) {
+	svc, botPath, runID := seedGroupRun(t)
+	editBot(t, botPath, `printf '{"id":"%s","ok":true}'`, `printf '{"id":"%s","ok":false}'`)
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, Auto: true})
+	if err != nil {
+		t.Fatalf("Rewind --auto on a group-body edit: %v", err)
+	}
+	if result.NodeID != "r1.gate" {
+		t.Errorf("auto pivot = %q, want the instantiated group node r1.gate", result.NodeID)
+	}
+	found := false
+	for _, c := range result.Changes {
+		if c.Kind == "group" && c.Name == "gate_block" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("changes = %v, want the group itself reported", result.Changes)
+	}
+}
+
+// TestRewindAuto_GroupParameterEditIsSeen: a `use … with { … }` binding
+// is the group's only tunable, and it lived in neither the key nor the
+// fingerprint — so retuning it was equally invisible.
+func TestRewindAuto_GroupParameterEditIsSeen(t *testing.T) {
+	svc, botPath, runID := seedGroupRun(t)
+	editBot(t, botPath, `with { label: "T-42" }`, `with { label: "T-99" }`)
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, Auto: true})
+	if err != nil {
+		t.Fatalf("Rewind --auto on a group-parameter edit: %v", err)
+	}
+	if result.NodeID != "r1.gate" {
+		t.Errorf("auto pivot = %q, want r1.gate", result.NodeID)
+	}
+}

--- a/pkg/runview/rewind_files.go
+++ b/pkg/runview/rewind_files.go
@@ -1,0 +1,158 @@
+package runview
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// fileRevertResult reports what the workspace half of a rewind did.
+type fileRevertResult struct {
+	Reverted     bool   `json:"reverted"`
+	Ref          string `json:"ref,omitempty"`
+	RevertCommit string `json:"revert_commit,omitempty"`
+	BackupRef    string `json:"backup_ref,omitempty"`
+	SkipReason   string `json:"skip_reason,omitempty"`
+}
+
+// revertWorkspace restores the files a run's workspace held just BEFORE
+// the pivot executed, so a replayed node meets its prior conditions
+// rather than its own previous production.
+//
+// This matters most for the nodes whose real product is NOT their output
+// map: a docs or code bot writes dozens of files and returns a summary.
+// Rewinding only the checkpoint would leave the half-written tree in
+// place and the replayed node would build on top of itself.
+//
+// Revert, not reset: the prior tree is committed ON TOP of HEAD, so the
+// run's committed history is preserved and readable, and the uncommitted
+// state at the instant of the rewind is banked under a backup ref first.
+// Nothing the run ever had becomes unreachable.
+//
+// Non-fatal by design when there is nothing to revert TO (a run with no
+// worktree, or a node with no recorded pre-boundary): the engine-state
+// rewind is still worth having, and the caller surfaces SkipReason so the
+// gap is loud rather than silent. A git command that FAILS is fatal —
+// "cannot" and "broke" are different answers.
+func revertWorkspace(run *store.Run, wf *ir.Workflow, cp *store.Checkpoint, pivot string) (*fileRevertResult, error) {
+	if !run.Worktree || run.WorkDir == "" {
+		return &fileRevertResult{SkipReason: "run has no isolated worktree — its workspace is the live tree, which iterion does not snapshot"}, nil
+	}
+	ref, ok := findPreNodeRef(run, wf, cp, pivot)
+	if !ok {
+		return &fileRevertResult{SkipReason: fmt.Sprintf(
+			"no pre-execution snapshot recorded for %q (run predates the pre-boundary marker, or the node ran outside the worktree)", pivot)}, nil
+	}
+
+	// Bank the current state — including uncommitted and untracked work —
+	// before touching anything, so the revert destroys nothing.
+	backupRef := store.RewindBackupRef(run.ID, pivot, nextRewindBackupSeq(run.WorkDir, run.ID, pivot))
+	if _, err := runtime.SnapshotWorktree(run.WorkDir, backupRef); err != nil {
+		return nil, fmt.Errorf("bank the current workspace before reverting: %w", err)
+	}
+
+	// Index + worktree := the pre-node tree. HEAD is untouched, so the
+	// commit below lands as a normal child of the current history.
+	if out, err := runtime.RunGitIn(run.WorkDir, "read-tree", "-u", "--reset", ref); err != nil {
+		return nil, fmt.Errorf("git read-tree %s: %w\noutput: %s", ref, err, out)
+	}
+	// Remove files created after the snapshot. No -x, so gitignored build
+	// output survives — `git add -A` honours .gitignore, so ignored paths
+	// were never in the snapshot to restore in the first place.
+	if out, err := runtime.RunGitIn(run.WorkDir, "clean", "-fd"); err != nil {
+		return nil, fmt.Errorf("git clean -fd: %w\noutput: %s", err, out)
+	}
+
+	tree, err := gitOut(run.WorkDir, "write-tree")
+	if err != nil {
+		return nil, err
+	}
+	headTree, err := gitOut(run.WorkDir, "rev-parse", "HEAD^{tree}")
+	if err != nil {
+		return nil, err
+	}
+	res := &fileRevertResult{Reverted: true, Ref: ref, BackupRef: backupRef}
+	if tree == headTree {
+		// The committed history already matches the pre-node state; the
+		// worktree is restored and there is nothing to record.
+		return res, nil
+	}
+	head, err := gitOut(run.WorkDir, "rev-parse", "HEAD")
+	if err != nil {
+		return nil, err
+	}
+	commit, err := gitOut(run.WorkDir, "commit-tree", tree, "-p", head,
+		"-m", fmt.Sprintf("iterion: rewind to %q (run %s)", pivot, run.ID))
+	if err != nil {
+		return nil, err
+	}
+	if out, err := runtime.RunGitIn(run.WorkDir, "update-ref", "HEAD", commit); err != nil {
+		return nil, fmt.Errorf("git update-ref HEAD %s: %w\noutput: %s", commit, err, out)
+	}
+	res.RevertCommit = commit
+	return res, nil
+}
+
+// findPreNodeRef locates the pivot's pre-execution snapshot, probing
+// downwards from the checkpoint's loop iteration: the counters record
+// where the run STOPPED, which can be past the last iteration the pivot
+// actually ran.
+func findPreNodeRef(run *store.Run, wf *ir.Workflow, cp *store.Checkpoint, pivot string) (string, bool) {
+	for iter := loopIterationOf(wf, pivot, cp.LoopCounters); iter >= 0; iter-- {
+		ref := store.NodePreSnapshotRef(run.ID, pivot, iter)
+		if _, err := runtime.RunGitIn(run.WorkDir, "rev-parse", "--verify", "--quiet", ref+"^{commit}"); err == nil {
+			return ref, true
+		}
+	}
+	return "", false
+}
+
+// loopIterationOf mirrors the engine's currentLoopIteration (unexported
+// in pkg/runtime): the max counter across every loop whose body contains
+// the node.
+func loopIterationOf(wf *ir.Workflow, nodeID string, counters map[string]int) int {
+	iter := 0
+	for name, loop := range wf.Loops {
+		if loop == nil || !loop.Body[nodeID] {
+			continue
+		}
+		if n := counters[name]; n > iter {
+			iter = n
+		}
+	}
+	return iter
+}
+
+// nextRewindBackupSeq counts existing backups for this (run, node) so
+// repeated rewinds each keep their own rather than overwriting.
+func nextRewindBackupSeq(workDir, runID, nodeID string) int {
+	prefix := store.RewindBackupRef(runID, nodeID, 0)
+	prefix = strings.TrimSuffix(prefix, "0")
+	out, err := runtime.RunGitIn(workDir, "for-each-ref", "--format=%(refname)", prefix)
+	if err != nil {
+		return 0
+	}
+	max := -1
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if n, cerr := strconv.Atoi(line[strings.LastIndex(line, "/")+1:]); cerr == nil && n > max {
+			max = n
+		}
+	}
+	return max + 1
+}
+
+func gitOut(workDir string, args ...string) (string, error) {
+	out, err := runtime.RunGitIn(workDir, args...)
+	if err != nil {
+		return "", fmt.Errorf("git %s: %w\noutput: %s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(out), nil
+}

--- a/pkg/runview/rewind_files.go
+++ b/pkg/runview/rewind_files.go
@@ -51,8 +51,16 @@ func revertWorkspace(run *store.Run, wf *ir.Workflow, cp *store.Checkpoint, pivo
 	// Bank the current state — including uncommitted and untracked work —
 	// before touching anything, so the revert destroys nothing.
 	backupRef := store.RewindBackupRef(run.ID, pivot, nextRewindBackupSeq(run.WorkDir, run.ID, pivot))
-	if _, err := runtime.SnapshotWorktree(run.WorkDir, backupRef); err != nil {
+	banked, err := runtime.SnapshotWorktree(run.WorkDir, backupRef)
+	if err != nil {
 		return nil, fmt.Errorf("bank the current workspace before reverting: %w", err)
+	}
+	if banked == "" {
+		// The tree already matched HEAD, so SnapshotWorktree wrote no ref.
+		// Reporting the name anyway hands the operator a recovery hint
+		// that resolves to nothing — and leaves nextRewindBackupSeq
+		// handing out the same number again.
+		backupRef = ""
 	}
 
 	// Index + worktree := the pre-node tree. HEAD is untouched, so the

--- a/pkg/runview/rewind_files.go
+++ b/pkg/runview/rewind_files.go
@@ -42,10 +42,9 @@ func revertWorkspace(run *store.Run, wf *ir.Workflow, cp *store.Checkpoint, pivo
 	if !run.Worktree || run.WorkDir == "" {
 		return &fileRevertResult{SkipReason: "run has no isolated worktree — its workspace is the live tree, which iterion does not snapshot"}, nil
 	}
-	ref, ok := findPreNodeRef(run, wf, cp, pivot)
-	if !ok {
-		return &fileRevertResult{SkipReason: fmt.Sprintf(
-			"no pre-execution snapshot recorded for %q (run predates the pre-boundary marker, or the node ran outside the worktree)", pivot)}, nil
+	ref, skip := findPreNodeRef(run, wf, cp, pivot)
+	if skip != "" {
+		return &fileRevertResult{SkipReason: skip}, nil
 	}
 
 	// Bank the current state — including uncommitted and untracked work —
@@ -109,19 +108,66 @@ func revertWorkspace(run *store.Run, wf *ir.Workflow, cp *store.Checkpoint, pivo
 // downwards from the checkpoint's loop iteration: the counters record
 // where the run STOPPED, which can be past the last iteration the pivot
 // actually ran.
-func findPreNodeRef(run *store.Run, wf *ir.Workflow, cp *store.Checkpoint, pivot string) (string, bool) {
-	for iter := loopIterationOf(wf, pivot, cp.LoopCounters); iter >= 0; iter-- {
-		ref := store.NodePreSnapshotRef(run.ID, pivot, iter)
-		if _, err := runtime.RunGitIn(run.WorkDir, "rev-parse", "--verify", "--quiet", ref+"^{commit}"); err == nil {
-			return ref, true
+// A non-empty skipReason means "do not revert" — never a silent
+// fallback to an older iteration.
+//
+// Probing DOWNWARDS is legitimate: the loop counters record where the run
+// STOPPED, which can be past the last iteration the pivot itself ran, so
+// the highest existing pre-marker at or below that is the right anchor.
+// What is NOT legitimate is landing below an iteration the pivot actually
+// executed. There the tree predates work whose outputs downstreamOf
+// deliberately keeps (loop-mates are ancestors of the pivot), so the
+// checkpoint would claim work whose files had been reverted away — and
+// the old code reported that as Reverted=true with no warning.
+//
+// The closing ref is what tells the two apart: `nodes/<pivot>/<n>` exists
+// iff the pivot completed iteration n. If one exists above the pre-marker
+// we settled on, the anchor is stale and we refuse.
+//
+// Two ordinary paths reach that: a workflow whose Loop.Body is empty
+// (loopIterationOf answered 0 for every node — now fixed by its
+// edge-endpoint fallback), and a run resumed from a human pause, where
+// the engine's markPreNodeBoundary is gated on rs.isWorktree, which that
+// path never sets — so nothing executed after the resume has a marker.
+//
+// Restoring the wrong tree is worse than restoring none: a SkipReason is
+// visible, a stale revert is not.
+func findPreNodeRef(run *store.Run, wf *ir.Workflow, cp *store.Checkpoint, pivot string) (ref string, skipReason string) {
+	want := loopIterationOf(wf, pivot, cp.LoopCounters)
+	found := -1
+	for iter := want; iter >= 0; iter-- {
+		candidate := store.NodePreSnapshotRef(run.ID, pivot, iter)
+		if _, err := runtime.RunGitIn(run.WorkDir, "rev-parse", "--verify", "--quiet", candidate+"^{commit}"); err == nil {
+			ref, found = candidate, iter
+			break
 		}
 	}
-	return "", false
+	if found < 0 {
+		return "", fmt.Sprintf(
+			"no pre-execution snapshot recorded for %q (run predates the pre-boundary marker, or the node ran outside the worktree)", pivot)
+	}
+	for iter := want; iter > found; iter-- {
+		post := store.NodeSnapshotRef(run.ID, pivot, iter)
+		if _, err := runtime.RunGitIn(run.WorkDir, "rev-parse", "--verify", "--quiet", post+"^{commit}"); err == nil {
+			return "", fmt.Sprintf(
+				"%q completed iteration %d but only iteration %d has a pre-execution snapshot — "+
+					"reverting to it would discard work the checkpoint still claims, so the workspace was left as-is "+
+					"(rewind with --keep-files to skip the workspace deliberately)",
+				pivot, iter, found)
+		}
+	}
+	return ref, ""
 }
 
 // loopIterationOf mirrors the engine's currentLoopIteration (unexported
 // in pkg/runtime): the max counter across every loop whose body contains
-// the node.
+// the node, falling back to loop-edge endpoints.
+//
+// The edge-endpoint half is not decoration. ir.Compile does not always
+// populate Loop.Body (older IRs, hand-written fixtures), and without the
+// fallback this answered 0 for every node in such a workflow — so the
+// pre-snapshot probe never looked above iteration 0 and a rewind of a
+// loop's third pass restored the tree from before its first.
 func loopIterationOf(wf *ir.Workflow, nodeID string, counters map[string]int) int {
 	iter := 0
 	for name, loop := range wf.Loops {
@@ -129,6 +175,17 @@ func loopIterationOf(wf *ir.Workflow, nodeID string, counters map[string]int) in
 			continue
 		}
 		if n := counters[name]; n > iter {
+			iter = n
+		}
+	}
+	for _, edge := range wf.Edges {
+		if edge == nil || edge.LoopName == "" {
+			continue
+		}
+		if edge.From != nodeID && edge.To != nodeID {
+			continue
+		}
+		if n := counters[edge.LoopName]; n > iter {
 			iter = n
 		}
 	}

--- a/pkg/runview/rewind_files_test.go
+++ b/pkg/runview/rewind_files_test.go
@@ -1,0 +1,236 @@
+package runview
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=iterion", "GIT_AUTHOR_EMAIL=iterion@example.test",
+		"GIT_COMMITTER_NAME=iterion", "GIT_COMMITTER_EMAIL=iterion@example.test",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func writeFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// TestRewind_RevertsWorkspaceToPreNodeState is the docs-bot case: a node
+// whose real product is FILES, not its output map.
+//
+// `generate_docs` writes a doc set; the run then fails downstream. The
+// rewind must put the workspace back to what the node started from —
+// otherwise the replayed node builds on top of its own previous output
+// and the operator is not testing the new configuration under the prior
+// conditions.
+func TestRewind_RevertsWorkspaceToPreNodeState(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	wt := filepath.Join(dir, "workspace")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	git(t, wt, "init", "-q", "-b", "main")
+	git(t, wt, "config", "user.email", "iterion@example.test")
+	git(t, wt, "config", "user.name", "iterion")
+	// Gitignored build output must survive the revert untouched.
+	writeFile(t, wt, ".gitignore", "site/\n")
+	writeFile(t, wt, "docs/intro.md", "intro v1\n")
+	git(t, wt, "add", "-A")
+	git(t, wt, "commit", "-q", "-m", "base")
+
+	botPath := filepath.Join(dir, "main.bot")
+	if err := os.WriteFile(botPath, []byte(linearBot), 0o644); err != nil {
+		t.Fatalf("write bot: %v", err)
+	}
+	storeDir := filepath.Join(dir, "store")
+	st, err := store.New(storeDir)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	const runID = "run-docs"
+	if _, err := st.CreateRun(context.Background(), runID, "linear", nil); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	// The engine's pre-boundary marker for `implement`: the workspace as
+	// it stood before that node ran.
+	preRef := store.NodePreSnapshotRef(runID, "implement", 0)
+	git(t, wt, "update-ref", preRef, "HEAD")
+
+	// `implement` now produces the doc set — a rewrite, a new file, and a
+	// deletion — plus some ignored build output.
+	writeFile(t, wt, "docs/intro.md", "intro v2 REWRITTEN\n")
+	writeFile(t, wt, "docs/api.md", "generated api page\n")
+	writeFile(t, wt, "site/index.html", "<html>built</html>")
+	git(t, wt, "add", "-A")
+	git(t, wt, "commit", "-q", "-m", "docs: regenerate")
+	// ...and leaves one file uncommitted, as an agent mid-run would.
+	writeFile(t, wt, "docs/uncommitted.md", "work in progress\n")
+	headBefore := git(t, wt, "rev-parse", "HEAD")
+
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	run.FilePath = botPath
+	run.Worktree = true
+	run.WorkDir = wt
+	run.Status = store.RunStatusFailedResumable
+	run.Checkpoint = &store.Checkpoint{
+		NodeID:  "verify",
+		Outputs: outputsOf("survey", "plan", "implement", "verify"),
+	}
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	svc, err := NewService(storeDir)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "implement"})
+	if err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+	if result.Files == nil || !result.Files.Reverted {
+		t.Fatalf("Files = %+v, want a completed revert", result.Files)
+	}
+
+	// The doc set is back to its pre-node state.
+	if got := readWorkspaceFile(t, wt, "docs/intro.md"); got != "intro v1\n" {
+		t.Errorf("docs/intro.md = %q, want the pre-node content", got)
+	}
+	if _, err := os.Stat(filepath.Join(wt, "docs/api.md")); !os.IsNotExist(err) {
+		t.Error("docs/api.md survived; a file the node CREATED must be removed")
+	}
+	if _, err := os.Stat(filepath.Join(wt, "docs/uncommitted.md")); !os.IsNotExist(err) {
+		t.Error("uncommitted work survived the revert")
+	}
+	// Gitignored build output is untouched: `git add -A` honours
+	// .gitignore, so it was never in the snapshot to restore.
+	if got := readWorkspaceFile(t, wt, "site/index.html"); got != "<html>built</html>" {
+		t.Errorf("gitignored site/index.html = %q, want it left alone", got)
+	}
+
+	// Revert, not reset: history is preserved and extended.
+	if result.Files.RevertCommit == "" {
+		t.Fatal("expected a revert commit")
+	}
+	parent := git(t, wt, "rev-parse", "HEAD^")
+	if parent != headBefore {
+		t.Errorf("revert commit's parent = %s, want the pre-rewind HEAD %s", parent, headBefore)
+	}
+	if !strings.Contains(git(t, wt, "log", "--oneline"), "docs: regenerate") {
+		t.Error("the node's own commit vanished from history; a rewind reverts, it does not rewrite")
+	}
+	// And nothing was lost: the banked ref still holds the state at the
+	// instant of the rewind, uncommitted file included.
+	if result.Files.BackupRef == "" {
+		t.Fatal("expected a backup ref banking the pre-revert state")
+	}
+	banked := git(t, wt, "show", "--name-only", "--format=", result.Files.BackupRef)
+	if !strings.Contains(banked, "docs/uncommitted.md") {
+		t.Errorf("backup ref does not carry the uncommitted work: %q", banked)
+	}
+}
+
+// TestRewind_NoWorktreeReportsSkip: an in-place run's workspace is the
+// operator's live tree, which iterion does not snapshot. The rewind must
+// say so rather than silently leaving the files.
+func TestRewind_NoWorktreeReportsSkip(t *testing.T) {
+	cp := &store.Checkpoint{
+		NodeID:  "verify",
+		Outputs: outputsOf("survey", "plan", "implement", "verify"),
+	}
+	svc, _, runID := seedRun(t, linearBot, cp, store.RunStatusFailedResumable)
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "implement"})
+	if err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+	if result.Files == nil || result.Files.Reverted {
+		t.Fatalf("Files = %+v, want a skip", result.Files)
+	}
+	if !strings.Contains(result.Files.SkipReason, "no isolated worktree") {
+		t.Errorf("SkipReason = %q, want it to name the missing worktree", result.Files.SkipReason)
+	}
+}
+
+// TestRewind_KeepFilesOptsOut leaves the workspace alone on request.
+func TestRewind_KeepFilesOptsOut(t *testing.T) {
+	cp := &store.Checkpoint{
+		NodeID:  "verify",
+		Outputs: outputsOf("survey", "plan", "implement", "verify"),
+	}
+	svc, _, runID := seedRun(t, linearBot, cp, store.RunStatusFailedResumable)
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "implement", KeepFiles: true})
+	if err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+	if result.Files.Reverted {
+		t.Error("workspace was reverted despite KeepFiles")
+	}
+}
+
+// TestSnapshotWorktree_ExportedRoundTrip guards the exported seam the
+// rewind depends on for banking state.
+func TestSnapshotWorktree_ExportedRoundTrip(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	wt := t.TempDir()
+	git(t, wt, "init", "-q", "-b", "main")
+	git(t, wt, "config", "user.email", "iterion@example.test")
+	git(t, wt, "config", "user.name", "iterion")
+	writeFile(t, wt, "a.txt", "one\n")
+	git(t, wt, "add", "-A")
+	git(t, wt, "commit", "-q", "-m", "base")
+
+	writeFile(t, wt, "b.txt", "two\n")
+	commit, err := runtime.SnapshotWorktree(wt, "refs/iterion/test/snap")
+	if err != nil {
+		t.Fatalf("SnapshotWorktree: %v", err)
+	}
+	if commit == "" {
+		t.Fatal("expected a snapshot commit for a dirty worktree")
+	}
+	if !strings.Contains(git(t, wt, "show", "--name-only", "--format=", commit), "b.txt") {
+		t.Error("snapshot does not carry the untracked file")
+	}
+}
+
+func readWorkspaceFile(t *testing.T, dir, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}

--- a/pkg/runview/rewind_files_test.go
+++ b/pkg/runview/rewind_files_test.go
@@ -234,3 +234,100 @@ func readWorkspaceFile(t *testing.T, dir, name string) string {
 	}
 	return string(b)
 }
+
+// TestRewind_RefusesAStalePreSnapshot is Revi's R7c488c.
+//
+// The probe walked down to iteration 0 and took the first ref that
+// resolved, with no bound and no signal. When the pivot had actually
+// completed a LATER iteration whose pre-marker was missing, that restored
+// the tree from before an earlier pass — while downstreamOf deliberately
+// keeps the loop-mates' outputs, so the checkpoint claimed work whose
+// files had just been reverted away. Reported as Reverted=true, silently.
+//
+// Two ordinary paths reach it: a workflow whose Loop.Body is empty, and a
+// run resumed from a human pause (markPreNodeBoundary is gated on
+// rs.isWorktree, which that path never sets).
+func TestRewind_RefusesAStalePreSnapshot(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	wt := filepath.Join(dir, "workspace")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	git(t, wt, "init", "-q", "-b", "main")
+	git(t, wt, "config", "user.email", "iterion@example.test")
+	git(t, wt, "config", "user.name", "iterion")
+	writeFile(t, wt, "docs/intro.md", "v1 — before the first pass\n")
+	git(t, wt, "add", "-A")
+	git(t, wt, "commit", "-q", "-m", "base")
+
+	botPath := filepath.Join(dir, "main.bot")
+	if err := os.WriteFile(botPath, []byte(loopedBot), 0o644); err != nil {
+		t.Fatalf("write bot: %v", err)
+	}
+	storeDir := filepath.Join(dir, "store")
+	st, err := store.New(storeDir)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	const runID = "run-stale"
+	if _, err := st.CreateRun(context.Background(), runID, "looped", nil); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	// Iteration 0 is fully bracketed.
+	git(t, wt, "update-ref", store.NodePreSnapshotRef(runID, "implement", 0), "HEAD")
+	writeFile(t, wt, "docs/intro.md", "v2 — produced by pass 0\n")
+	git(t, wt, "add", "-A")
+	git(t, wt, "commit", "-q", "-m", "pass 0")
+	git(t, wt, "update-ref", store.NodeSnapshotRef(runID, "implement", 0), "HEAD")
+
+	// Iteration 1 ran and COMPLETED, but its opening marker was never
+	// written — the resumed-from-pause shape.
+	writeFile(t, wt, "docs/intro.md", "v3 — produced by pass 1\n")
+	git(t, wt, "add", "-A")
+	git(t, wt, "commit", "-q", "-m", "pass 1")
+	git(t, wt, "update-ref", store.NodeSnapshotRef(runID, "implement", 1), "HEAD")
+
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	run.FilePath = botPath
+	run.Worktree = true
+	run.WorkDir = wt
+	run.Status = store.RunStatusFailedResumable
+	run.Checkpoint = &store.Checkpoint{
+		NodeID:       "verify",
+		Outputs:      outputsOf("survey", "plan", "implement", "verify"),
+		LoopCounters: map[string]int{"fix": 1},
+	}
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	svc, err := NewService(storeDir)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	res, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "implement"})
+	if err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+	if res.Files == nil {
+		t.Fatal("expected a files report")
+	}
+	if res.Files.Reverted {
+		t.Errorf("the workspace was reverted to iteration 0's snapshot even though "+
+			"%q completed iteration 1 — that discards work the checkpoint still claims", "implement")
+	}
+	if res.Files.SkipReason == "" {
+		t.Error("skipping the revert must say why; a silent no-op reads as success")
+	}
+	// The tree is untouched: pass 1's production is still there.
+	if got := readWorkspaceFile(t, wt, "docs/intro.md"); got != "v3 — produced by pass 1\n" {
+		t.Errorf("docs/intro.md = %q, want pass 1's content left in place", got)
+	}
+}

--- a/pkg/runview/rewind_test.go
+++ b/pkg/runview/rewind_test.go
@@ -727,22 +727,35 @@ func TestRewind_NoBackupRefWhenNothingWasBanked(t *testing.T) {
 // left the dropped nodes' questions live, so the replayed node would park
 // on the union of old and new — or fold pre-rewind answers into its
 // output.
+// Revi's Rf3cea6 sharpened it: the fixture must seed the questions on a
+// node that did NOT complete. Keying the retirement on the output-filtered
+// `dropped` set passes when the questions sit on the pivot (always in
+// `dropped`) yet skips exactly the canonical case — a node that posted
+// questions and then failed, which is the state a rewind is invoked on.
+// So `verify` here started, asked, and died without an output: it is in
+// `invalidated` only.
 func TestRewind_RetiresAbandonedAsyncQuestions(t *testing.T) {
 	cp := &store.Checkpoint{
 		NodeID:  "verify",
-		Outputs: outputsOf("survey", "plan", "implement", "verify"),
+		Outputs: outputsOf("survey", "plan", "implement"),
 	}
 	svc, st, runID := seedRun(t, linearBot, cp, store.RunStatusFailedResumable)
 	ctx := context.Background()
 
-	// One pending and one answered question from a node about to be
-	// dropped, plus one from an upstream node that survives.
+	// One pending and one answered question on the pivot, two on the
+	// uncompleted downstream node, plus one from an upstream node that
+	// survives.
 	answered := time.Now().UTC()
 	for _, in := range []*store.Interaction{
 		{ID: "q-pending", RunID: runID, NodeID: "implement", Kind: store.InteractionKindAsync,
 			Questions: map[string]any{"which": "approach?"}, RequestedAt: answered},
 		{ID: "q-answered", RunID: runID, NodeID: "implement", Kind: store.InteractionKindAsync,
 			Questions: map[string]any{"ok": "?"}, Answers: map[string]any{"ok": true},
+			RequestedAt: answered, AnsweredAt: &answered},
+		{ID: "q-nooutput", RunID: runID, NodeID: "verify", Kind: store.InteractionKindAsync,
+			Questions: map[string]any{"looks": "right?"}, RequestedAt: answered},
+		{ID: "q-nooutput-answered", RunID: runID, NodeID: "verify", Kind: store.InteractionKindAsync,
+			Questions: map[string]any{"ship": "?"}, Answers: map[string]any{"ship": true},
 			RequestedAt: answered, AnsweredAt: &answered},
 		{ID: "q-upstream", RunID: runID, NodeID: "plan", Kind: store.InteractionKindAsync,
 			Questions: map[string]any{"scope": "?"}, RequestedAt: answered},
@@ -769,6 +782,24 @@ func TestRewind_RetiresAbandonedAsyncQuestions(t *testing.T) {
 	}
 	if len(done) != 0 {
 		t.Errorf("%d pre-rewind answer(s) survived — the replayed node's output would mix them in", len(done))
+	}
+	// The load-bearing case: `verify` has no output, so it is in
+	// `invalidated` but not in `dropped`. Keying the retirement on the
+	// output-filtered set leaves these live.
+	orphanPending, err := store.ListPendingAsyncInteractions(ctx, st, runID, "verify")
+	if err != nil {
+		t.Fatalf("list pending (uncompleted node): %v", err)
+	}
+	if len(orphanPending) != 0 {
+		t.Errorf("%d pending question(s) survived on a node that never completed — "+
+			"retirement is keyed on the output-filtered set, which skips exactly this case", len(orphanPending))
+	}
+	orphanDone, err := store.ListAnsweredAsyncInteractions(ctx, st, runID, "verify")
+	if err != nil {
+		t.Fatalf("list answered (uncompleted node): %v", err)
+	}
+	if len(orphanDone) != 0 {
+		t.Errorf("%d pre-rewind answer(s) survived on a node that never completed", len(orphanDone))
 	}
 	// An upstream node's question is not the rewind's business.
 	up, err := store.ListPendingAsyncInteractions(ctx, st, runID, "plan")

--- a/pkg/runview/rewind_test.go
+++ b/pkg/runview/rewind_test.go
@@ -810,3 +810,47 @@ func TestRewind_RetiresAbandonedAsyncQuestions(t *testing.T) {
 		t.Errorf("upstream questions = %d, want 1 kept", len(up))
 	}
 }
+
+// TestRewind_KeepsTheFinishedAtTheClaimStamped is Revi's R95a324.
+//
+// `run` is loaded before the CAS; UpdateRunStatusIf mutates its OWN copy
+// (loadRunRaw → applyStatusTransition), which stamps FinishedAt for the
+// `cancelled` transition. SaveRun is a full-document overwrite, so saving
+// the pre-claim snapshot dropped that stamp whenever the pre-rewind
+// status was paused_* or queued — where FinishedAt was nil. The run then
+// persisted as cancelled with finished_at null; healRun only repairs
+// `running`, and runs_stats falls back to now for a run with no end, so
+// the studio duration ticker never stopped.
+//
+// The same read-modify-write-across-a-CAS hazard as Rafe0da, one path over.
+func TestRewind_KeepsTheFinishedAtTheClaimStamped(t *testing.T) {
+	cp := &store.Checkpoint{
+		NodeID:  "verify",
+		Outputs: outputsOf("survey", "plan", "implement", "verify"),
+	}
+	// paused_waiting_human is the case that bites: FinishedAt is nil there.
+	svc, st, runID := seedRun(t, linearBot, cp, store.RunStatusPausedWaitingHuman)
+	ctx := context.Background()
+
+	if before, err := st.LoadRun(ctx, runID); err != nil {
+		t.Fatalf("load: %v", err)
+	} else if before.FinishedAt != nil {
+		t.Fatalf("fixture: a paused run must start with finished_at nil, got %v", before.FinishedAt)
+	}
+
+	if _, err := svc.Rewind(ctx, RewindSpec{RunID: runID, NodeID: "implement"}); err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+
+	got, err := st.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got.Status != store.RunStatusCancelled {
+		t.Fatalf("status = %q, want cancelled", got.Status)
+	}
+	if got.FinishedAt == nil {
+		t.Error("finished_at is nil on a run parked by a rewind — the claim stamped it and " +
+			"the save dropped it, so the studio duration ticker runs forever")
+	}
+}

--- a/pkg/runview/rewind_test.go
+++ b/pkg/runview/rewind_test.go
@@ -549,3 +549,50 @@ func contains(ss []string, want string) bool {
 	}
 	return false
 }
+
+// TestRewind_ReleasesSubbotPointerOfUncompletedNode is the case the first
+// version of this feature got wrong, and that its own test masked.
+//
+// A surviving SubbotChildren entry means the subbot did NOT complete
+// (ClearSubbotChild fires on every successful consumption), so that node
+// has no output. Keying the cleanup on the output-filtered `dropped` list
+// therefore skipped exactly the entries that needed releasing — the
+// original test happened to seed the one configuration where pivot ==
+// subbot node, which is the only overlap between the two sets.
+func TestRewind_ReleasesSubbotPointerOfUncompletedNode(t *testing.T) {
+	cp := &store.Checkpoint{
+		NodeID: "verify",
+		// `implement` is downstream of the pivot but never completed: no
+		// output, yet a parked child.
+		Outputs:      outputsOf("survey", "plan"),
+		NodeAttempts: map[string]map[string]int{"implement": {"EXECUTION_FAILED": 3}},
+	}
+	svc, st, runID := seedRun(t, linearBot, cp, store.RunStatusPausedWaitingHuman)
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	run.SubbotChildren = map[string]string{"implement": "child-parked"}
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "plan"})
+	if err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+	got, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if _, still := got.SubbotChildren["implement"]; still {
+		t.Error("the parked child's pointer survived; the replay would re-attach to it and never run the edited child workflow")
+	}
+	if !contains(result.OrphanedChildRuns, "child-parked") {
+		t.Errorf("OrphanedChildRuns = %v, want the released child reported", result.OrphanedChildRuns)
+	}
+	// Same filter bug affected the recovery budget of the node that failed.
+	if _, still := got.Checkpoint.NodeAttempts["implement"]; still {
+		t.Error("NodeAttempts survived for the node that actually failed — its budget must reset on replay")
+	}
+}

--- a/pkg/runview/rewind_test.go
+++ b/pkg/runview/rewind_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -594,5 +595,125 @@ func TestRewind_ReleasesSubbotPointerOfUncompletedNode(t *testing.T) {
 	// Same filter bug affected the recovery budget of the node that failed.
 	if _, still := got.Checkpoint.NodeAttempts["implement"]; still {
 		t.Error("NodeAttempts survived for the node that actually failed — its budget must reset on replay")
+	}
+}
+
+// TestRewind_ClaimsBeforeTouchingTheWorktree is Revi's Re3455c.
+//
+// The CAS exists to make a concurrent resume safe. Reverting the worktree
+// first defeated it: `read-tree --reset` + `clean -fd` would already have
+// run inside a tree an engine was writing to before the lost race was
+// discovered. A run that is NOT claimable must therefore leave the
+// workspace untouched.
+func TestRewind_ClaimsBeforeTouchingTheWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	ws := filepath.Join(dir, "workspace")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	git(t, ws, "init", "-q", "-b", "main")
+	git(t, ws, "config", "user.email", "iterion@example.test")
+	git(t, ws, "config", "user.name", "iterion")
+	writeFile(t, ws, "live.txt", "the running node is writing this")
+	git(t, ws, "add", "-A")
+	git(t, ws, "commit", "-q", "-m", "base")
+	preRef := store.NodePreSnapshotRef("run-race", "implement", 0)
+	git(t, ws, "update-ref", preRef, "HEAD")
+	writeFile(t, ws, "live.txt", "MID-FLIGHT WORK")
+
+	botPath := filepath.Join(dir, "main.bot")
+	if err := os.WriteFile(botPath, []byte(linearBot), 0o644); err != nil {
+		t.Fatalf("write bot: %v", err)
+	}
+	storeDir := filepath.Join(dir, "store")
+	st, err := store.New(storeDir)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if _, err := st.CreateRun(context.Background(), "run-race", "linear", nil); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	run, err := st.LoadRun(context.Background(), "run-race")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	run.FilePath = botPath
+	run.Worktree = true
+	run.WorkDir = ws
+	// CreateRun parks a run in `running` — the state a concurrent resume
+	// would have flipped it to.
+	run.Status = store.RunStatusRunning
+	run.Checkpoint = &store.Checkpoint{NodeID: "verify", Outputs: outputsOf("survey", "plan", "implement")}
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	svc, err := NewService(storeDir)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	_, rerr := svc.Rewind(context.Background(), RewindSpec{RunID: "run-race", NodeID: "implement"})
+	if !errors.Is(rerr, ErrRewindNotRewindable) {
+		t.Fatalf("err = %v, want ErrRewindNotRewindable", rerr)
+	}
+	if got := readWorkspaceFile(t, ws, "live.txt"); got != "MID-FLIGHT WORK" {
+		t.Fatalf("live.txt = %q — the workspace of an unclaimable run was reverted anyway", got)
+	}
+}
+
+// TestRewind_NoBackupRefWhenNothingWasBanked is Revi's R5d2014: a clean
+// tree makes SnapshotWorktree write no ref, so reporting its name hands
+// the operator a recovery hint that resolves to nothing.
+func TestRewind_NoBackupRefWhenNothingWasBanked(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	ws := filepath.Join(dir, "workspace")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	git(t, ws, "init", "-q", "-b", "main")
+	git(t, ws, "config", "user.email", "iterion@example.test")
+	git(t, ws, "config", "user.name", "iterion")
+	writeFile(t, ws, "a.txt", "one")
+	git(t, ws, "add", "-A")
+	git(t, ws, "commit", "-q", "-m", "base")
+	git(t, ws, "update-ref", store.NodePreSnapshotRef("run-clean", "implement", 0), "HEAD")
+
+	botPath := filepath.Join(dir, "main.bot")
+	if err := os.WriteFile(botPath, []byte(linearBot), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	storeDir := filepath.Join(dir, "store")
+	st, err := store.New(storeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.CreateRun(context.Background(), "run-clean", "linear", nil); err != nil {
+		t.Fatal(err)
+	}
+	run, _ := st.LoadRun(context.Background(), "run-clean")
+	run.FilePath, run.Worktree, run.WorkDir = botPath, true, ws
+	run.Status = store.RunStatusFailedResumable
+	run.Checkpoint = &store.Checkpoint{NodeID: "verify", Outputs: outputsOf("survey", "plan", "implement")}
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+	svc, err := NewService(storeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: "run-clean", NodeID: "implement"})
+	if err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+	if result.Files.BackupRef != "" {
+		t.Errorf("BackupRef = %q for a clean tree — that ref was never written and does not resolve",
+			result.Files.BackupRef)
 	}
 }

--- a/pkg/runview/rewind_test.go
+++ b/pkg/runview/rewind_test.go
@@ -1,0 +1,551 @@
+package runview
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// linearBot: survey -> plan -> implement -> verify -> done.
+const linearBot = `schema out:
+  value: string
+
+agent survey:
+  model: "claude-opus-4-7"
+  output: out
+
+agent plan:
+  model: "claude-opus-4-7"
+  output: out
+
+agent implement:
+  model: "claude-opus-4-7"
+  output: out
+
+agent verify:
+  model: "claude-opus-4-7"
+  output: out
+
+workflow linear:
+  entry: survey
+  survey -> plan
+  plan -> implement
+  implement -> verify
+  verify -> done
+`
+
+// loopedBot: implement -> verify -> implement as fix(3). `verify` is both
+// downstream AND upstream of `implement`, which is the case the ancestor
+// subtraction in downstreamOf exists for.
+const loopedBot = `schema out:
+  value: string
+  ok: bool
+
+agent survey:
+  model: "claude-opus-4-7"
+  output: out
+
+agent implement:
+  model: "claude-opus-4-7"
+  output: out
+
+agent verify:
+  model: "claude-opus-4-7"
+  output: out
+
+workflow looped:
+  entry: survey
+  survey -> implement
+  implement -> verify
+  verify -> done when ok
+  verify -> implement as fix(3)
+`
+
+// fanOutBot: two parallel branches converging on merge.
+const fanOutBot = `schema out:
+  value: string
+
+agent survey:
+  model: "claude-opus-4-7"
+  output: out
+
+router split:
+  mode: fan_out_all
+
+agent branch_a:
+  model: "claude-opus-4-7"
+  output: out
+
+agent branch_b:
+  model: "claude-opus-4-7"
+  output: out
+
+agent merge:
+  model: "claude-opus-4-7"
+  output: out
+  await: wait_all
+
+workflow fanout:
+  entry: survey
+  survey -> split
+  split -> branch_a
+  split -> branch_b
+  branch_a -> merge
+  branch_b -> merge
+  merge -> done
+`
+
+// seedRun writes a bot fixture plus a run parked with the given
+// checkpoint, and returns the service, store, and run id.
+func seedRun(t *testing.T, botSrc string, cp *store.Checkpoint, status store.RunStatus) (*Service, store.RunStore, string) {
+	t.Helper()
+	dir := t.TempDir()
+	botPath := filepath.Join(dir, "main.bot")
+	if err := os.WriteFile(botPath, []byte(botSrc), 0o644); err != nil {
+		t.Fatalf("write bot fixture: %v", err)
+	}
+	logger := iterlog.Nop()
+	storeDir := filepath.Join(dir, "store")
+	st, err := store.New(storeDir, store.WithLogger(logger))
+	if err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	runID := "run-rewind-subject"
+	if _, err := st.CreateRun(context.Background(), runID, "wf", map[string]any{"x": 1}); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	run.FilePath = botPath
+	run.WorkflowHash = "hash-original"
+	run.Status = status
+	run.Error = "boom: verify failed"
+	run.Checkpoint = cp
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("save run: %v", err)
+	}
+	svc, err := NewService(storeDir, WithLogger(logger))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return svc, st, runID
+}
+
+func outputsOf(ids ...string) map[string]map[string]any {
+	m := map[string]map[string]any{}
+	for _, id := range ids {
+		m[id] = map[string]any{"value": id + "-output"}
+	}
+	return m
+}
+
+func keysOf(m map[string]map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestRewind_LinearDropsDownstream is the MVP acceptance path: rewind a
+// failed run to a middle node, and assert the run keeps its id while the
+// pivot and everything after it is invalidated and everything before it
+// survives.
+func TestRewind_LinearDropsDownstream(t *testing.T) {
+	cp := &store.Checkpoint{
+		NodeID:           "verify",
+		Outputs:          outputsOf("survey", "plan", "implement", "verify"),
+		Vars:             map[string]any{"workflow_var": "v"},
+		ArtifactVersions: map[string]int{"implement": 2},
+		NodeAttempts:     map[string]map[string]int{"verify": {"EXECUTION_FAILED": 2}, "survey": {"TIMEOUT": 1}},
+		BudgetTokensUsed: 4321,
+		BudgetCostUSD:    1.25,
+		CostUSDTotal:     1.25,
+	}
+	svc, st, runID := seedRun(t, linearBot, cp, store.RunStatusFailedResumable)
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "implement"})
+	if err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+	if result.RunID != runID {
+		t.Errorf("result.RunID = %q, want the SAME run id %q (rewind must not mint a run)", result.RunID, runID)
+	}
+	if result.FromNode != "verify" || result.NodeID != "implement" {
+		t.Errorf("re-anchor = %q → %q, want verify → implement", result.FromNode, result.NodeID)
+	}
+	wantDropped := []string{"implement", "verify"}
+	if got := result.DroppedNodes; len(got) != 2 || got[0] != wantDropped[0] || got[1] != wantDropped[1] {
+		t.Errorf("DroppedNodes = %v, want %v", got, wantDropped)
+	}
+
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load rewound run: %v", err)
+	}
+	if run.Status != store.RunStatusCancelled {
+		t.Errorf("status = %q, want cancelled (the one resumable status the cloud runner will not auto-resume)", run.Status)
+	}
+	if run.Error != "" {
+		t.Errorf("run.Error = %q, want cleared — the run is parked at the pivot, not failed", run.Error)
+	}
+	got := run.Checkpoint
+	if got == nil {
+		t.Fatal("checkpoint must survive the rewind")
+	}
+	if got.NodeID != "implement" {
+		t.Errorf("checkpoint.NodeID = %q, want implement", got.NodeID)
+	}
+	for _, dropped := range []string{"implement", "verify"} {
+		if _, ok := got.Outputs[dropped]; ok {
+			t.Errorf("output %q survived the rewind; want it invalidated", dropped)
+		}
+	}
+	for _, kept := range []string{"survey", "plan"} {
+		if _, ok := got.Outputs[kept]; !ok {
+			t.Errorf("upstream output %q was dropped; rewind must not force a replay of already-paid work", kept)
+		}
+	}
+	// Budget is NOT refunded — otherwise rewind+resume is an unbounded
+	// way around max_cost_usd.
+	if got.BudgetTokensUsed != 4321 || got.BudgetCostUSD != 1.25 || got.CostUSDTotal != 1.25 {
+		t.Errorf("budget accounting was reset (tokens=%d cost=%v total=%v), want it preserved",
+			got.BudgetTokensUsed, got.BudgetCostUSD, got.CostUSDTotal)
+	}
+	// Artifact versions keep counting up so re-execution appends a new
+	// version instead of overwriting the old one.
+	if got.ArtifactVersions["implement"] != 2 {
+		t.Errorf("ArtifactVersions[implement] = %d, want 2 preserved", got.ArtifactVersions["implement"])
+	}
+	// Recovery attempts reset for replayed nodes, survive for the rest.
+	if _, ok := got.NodeAttempts["verify"]; ok {
+		t.Error("NodeAttempts[verify] survived; a replayed node should get a fresh recovery budget")
+	}
+	if _, ok := got.NodeAttempts["survey"]; !ok {
+		t.Error("NodeAttempts[survey] was dropped; only replayed nodes reset")
+	}
+
+	// The audit marker must be appended, not a truncation of history.
+	events, err := st.LoadEvents(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load events: %v", err)
+	}
+	var found *store.Event
+	for _, evt := range events {
+		if evt.Type == store.EventRunRewound {
+			found = evt
+		}
+	}
+	if found == nil {
+		t.Fatal("no run_rewound event appended")
+	}
+	if found.NodeID != "implement" {
+		t.Errorf("run_rewound NodeID = %q, want implement", found.NodeID)
+	}
+	if found.Data["from_node"] != "verify" || found.Data["to_node"] != "implement" {
+		t.Errorf("run_rewound data = %v, want from verify to implement", found.Data)
+	}
+}
+
+// TestRewind_LoopKeepsCycleAncestor is the reason downstreamOf subtracts
+// ancestors. `verify` is forward-reachable from `implement` yet also
+// reaches it back through the fix() loop, and `implement` reads its
+// output on re-entry — dropping it would break the first replay.
+func TestRewind_LoopKeepsCycleAncestor(t *testing.T) {
+	cp := &store.Checkpoint{
+		NodeID:       "verify",
+		Outputs:      outputsOf("survey", "implement", "verify"),
+		LoopCounters: map[string]int{"fix": 2},
+	}
+	svc, st, runID := seedRun(t, loopedBot, cp, store.RunStatusFailedResumable)
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "implement"})
+	if err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+	if len(result.DroppedNodes) != 1 || result.DroppedNodes[0] != "implement" {
+		t.Fatalf("DroppedNodes = %v, want only [implement] — verify is a cycle ancestor and feeds {{loop.fix.previous_output}}",
+			result.DroppedNodes)
+	}
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	if _, ok := run.Checkpoint.Outputs["verify"]; !ok {
+		t.Error("verify's output was dropped; the pivot re-reads it on loop re-entry")
+	}
+	// Loop counters are not refunded: rewind must not become a way past
+	// max_iterations.
+	if run.Checkpoint.LoopCounters["fix"] != 2 {
+		t.Errorf("LoopCounters[fix] = %d, want 2 preserved", run.Checkpoint.LoopCounters["fix"])
+	}
+}
+
+// TestRewind_FanOutRewindIsAllOrNothing: naming one branch of a fan-out
+// invalidates the WHOLE fan-out, because promotion to the router is the
+// only way to replay every parallel execution. Partial-branch rewind was
+// the hazard, not the feature: at convergence the checkpoint keeps one
+// output per node id, so a surviving sibling's entry is a single
+// arbitrary branch's value, not an aggregate.
+func TestRewind_FanOutRewindIsAllOrNothing(t *testing.T) {
+	cp := &store.Checkpoint{
+		NodeID:  "merge",
+		Outputs: outputsOf("survey", "split", "branch_a", "branch_b", "merge"),
+	}
+	svc, st, runID := seedRun(t, fanOutBot, cp, store.RunStatusCancelled)
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "branch_a"})
+	if err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+	for _, id := range []string{"split", "branch_a", "branch_b", "merge"} {
+		if !contains(result.DroppedNodes, id) {
+			t.Errorf("%q survived; the fan-out replays as a unit", id)
+		}
+	}
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	if _, ok := run.Checkpoint.Outputs["survey"]; !ok {
+		t.Error("survey is upstream of the router and must survive")
+	}
+}
+
+// TestRewind_ClearsPendingInteractionAndBackendState: a run parked on a
+// human question must not carry that question — or the pivot's old
+// conversation — into the replay.
+func TestRewind_ClearsPendingInteractionAndBackendState(t *testing.T) {
+	cp := &store.Checkpoint{
+		NodeID:                  "verify",
+		Outputs:                 outputsOf("survey", "plan", "implement"),
+		InteractionID:           "int-42",
+		InteractionQuestions:    map[string]any{"approved": "Ship it?"},
+		BackendName:             "claw",
+		BackendSessionID:        "sess-1",
+		BackendConversation:     json.RawMessage(`[{"role":"assistant"}]`),
+		BackendPendingToolUseID: "tool-7",
+	}
+	svc, st, runID := seedRun(t, linearBot, cp, store.RunStatusPausedWaitingHuman)
+
+	if _, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "implement"}); err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	got := run.Checkpoint
+	if got.InteractionID != "" || got.InteractionQuestions != nil {
+		t.Errorf("pending interaction survived (%q / %v); the rewound run never asked it",
+			got.InteractionID, got.InteractionQuestions)
+	}
+	if got.BackendName != "" || got.BackendSessionID != "" || got.BackendConversation != nil || got.BackendPendingToolUseID != "" {
+		t.Error("backend rehydration survived; the pivot must replay against the edited prompt, not the old conversation")
+	}
+}
+
+// TestRewind_RejectsRunningRun: mutating the checkpoint of a run whose
+// engine owns it would be overwritten at the next node boundary.
+func TestRewind_RejectsRunningRun(t *testing.T) {
+	cp := &store.Checkpoint{NodeID: "verify", Outputs: outputsOf("survey", "plan", "implement")}
+	svc, _, runID := seedRun(t, linearBot, cp, store.RunStatusRunning)
+
+	_, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "implement"})
+	if !errors.Is(err, ErrRewindNotRewindable) {
+		t.Fatalf("Rewind on a running run: err = %v, want ErrRewindNotRewindable", err)
+	}
+}
+
+// TestRewind_RejectsUnreachedNode guards the typo case: parking a run on
+// a node it never executed defers the failure into the engine.
+func TestRewind_RejectsUnreachedNode(t *testing.T) {
+	cp := &store.Checkpoint{NodeID: "plan", Outputs: outputsOf("survey")}
+	svc, _, runID := seedRun(t, linearBot, cp, store.RunStatusFailedResumable)
+
+	_, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "verify"})
+	if !errors.Is(err, ErrRewindNodeNotReached) {
+		t.Fatalf("Rewind to an unreached node: err = %v, want ErrRewindNodeNotReached", err)
+	}
+}
+
+// TestRewind_RejectsNodeAbsentFromWorkflow: after an edit that removed
+// the node, the operator gets a clear message instead of a run parked on
+// a node the graph no longer has.
+func TestRewind_RejectsNodeAbsentFromWorkflow(t *testing.T) {
+	cp := &store.Checkpoint{NodeID: "verify", Outputs: outputsOf("survey", "plan", "implement", "verify")}
+	svc, _, runID := seedRun(t, linearBot, cp, store.RunStatusFailedResumable)
+
+	_, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "nonexistent"})
+	if err == nil {
+		t.Fatal("expected an error for a node absent from the workflow")
+	}
+}
+
+// TestRewind_PivotIsCurrentCheckpointNode: rewinding to the node the run
+// is already parked on is a legal no-op-ish call (it still clears that
+// node's stale output and backend state), so a "retry this node clean"
+// gesture does not need a special case.
+func TestRewind_PivotIsCurrentCheckpointNode(t *testing.T) {
+	cp := &store.Checkpoint{NodeID: "verify", Outputs: outputsOf("survey", "plan", "implement")}
+	svc, st, runID := seedRun(t, linearBot, cp, store.RunStatusFailedResumable)
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "verify"})
+	if err != nil {
+		t.Fatalf("Rewind to the current checkpoint node: %v", err)
+	}
+	if len(result.DroppedNodes) != 1 || result.DroppedNodes[0] != "verify" {
+		t.Errorf("DroppedNodes = %v, want [verify]", result.DroppedNodes)
+	}
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	if got := keysOf(run.Checkpoint.Outputs); len(got) != 3 {
+		t.Errorf("upstream outputs = %v, want survey/plan/implement preserved", got)
+	}
+}
+
+// TestRewind_ReleasesSubbotChildPointers is the subbot correctness case.
+//
+// ReattachSubbotChild consults ONLY run.SubbotChildren and the child's
+// status — never the parent's checkpoint — and it runs before the child
+// .bot is compiled. So dropping the subbot node's OUTPUT is not enough:
+// without releasing the pointer, a rewound subbot node adopts the
+// pre-rewind child and the edited child workflow never executes.
+func TestRewind_ReleasesSubbotChildPointers(t *testing.T) {
+	cp := &store.Checkpoint{
+		NodeID:  "verify",
+		Outputs: outputsOf("survey", "plan", "implement", "verify"),
+	}
+	svc, st, runID := seedRun(t, linearBot, cp, store.RunStatusPausedWaitingHuman)
+
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	// Pointers shaped like the engine's subbotReattachKey: bare, loop-
+	// qualified, and fan-out-branch-qualified. Plus one belonging to an
+	// UPSTREAM node, which must survive.
+	run.SubbotChildren = map[string]string{
+		"implement":                "child-implement",
+		"implement@fix=2":          "child-implement-iter2",
+		"implement#branch_split_0": "child-implement-branch",
+		"plan":                     "child-plan-upstream",
+		"implementation_helper":    "child-lookalike",
+	}
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("save run: %v", err)
+	}
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "implement"})
+	if err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+
+	got, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	for _, key := range []string{"implement", "implement@fix=2", "implement#branch_split_0"} {
+		if _, still := got.SubbotChildren[key]; still {
+			t.Errorf("subbot pointer %q survived; the replay would re-attach to the stale child", key)
+		}
+	}
+	// An upstream node's child is not downstream of the pivot.
+	if got.SubbotChildren["plan"] != "child-plan-upstream" {
+		t.Error("upstream subbot pointer was released; only dropped nodes lose theirs")
+	}
+	// Prefix matching must key on the '@'/'#' delimiter, not a bare
+	// prefix, or "implement" would steal "implementation_helper".
+	if got.SubbotChildren["implementation_helper"] != "child-lookalike" {
+		t.Error("a node whose id merely starts with the pivot's id lost its pointer")
+	}
+
+	wantOrphans := map[string]bool{"child-implement": true, "child-implement-iter2": true, "child-implement-branch": true}
+	if len(result.OrphanedChildRuns) != len(wantOrphans) {
+		t.Fatalf("OrphanedChildRuns = %v, want the three released children", result.OrphanedChildRuns)
+	}
+	for _, id := range result.OrphanedChildRuns {
+		if !wantOrphans[id] {
+			t.Errorf("unexpected orphaned child %q", id)
+		}
+	}
+}
+
+// TestRewind_PromotesFanOutBodyToRouter: the checkpoint holds one output
+// per node id, so a body node's N parallel executions collapse to one
+// entry. Anchoring there would replay it once, linearly — testing a
+// single iteration instead of all of them, with no signal. The rewind
+// promotes to the router so the whole fan-out replays.
+func TestRewind_PromotesFanOutBodyToRouter(t *testing.T) {
+	cp := &store.Checkpoint{
+		NodeID:  "merge",
+		Outputs: outputsOf("survey", "split", "branch_a", "branch_b", "merge"),
+	}
+	svc, st, runID := seedRun(t, fanOutBot, cp, store.RunStatusFailedResumable)
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "branch_a"})
+	if err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+	if result.NodeID != "split" {
+		t.Fatalf("pivot = %q, want split (the fan-out router)", result.NodeID)
+	}
+	if result.PromotedFrom != "branch_a" {
+		t.Errorf("PromotedFrom = %q, want branch_a", result.PromotedFrom)
+	}
+	// Promoting to the router means BOTH branches replay, not just the
+	// one that was named.
+	for _, id := range []string{"split", "branch_a", "branch_b", "merge"} {
+		if !contains(result.DroppedNodes, id) {
+			t.Errorf("%q survived; promoting to the router must invalidate the whole fan-out", id)
+		}
+	}
+	if contains(result.DroppedNodes, "survey") {
+		t.Error("survey is upstream of the router and must survive")
+	}
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if run.Checkpoint.NodeID != "split" {
+		t.Errorf("checkpoint anchored on %q, want split", run.Checkpoint.NodeID)
+	}
+}
+
+// TestRewind_NoPromotionOutsideFanOut: a node on the main path keeps the
+// pivot it was given.
+func TestRewind_NoPromotionOutsideFanOut(t *testing.T) {
+	cp := &store.Checkpoint{
+		NodeID:  "merge",
+		Outputs: outputsOf("survey", "split", "branch_a", "branch_b", "merge"),
+	}
+	svc, _, runID := seedRun(t, fanOutBot, cp, store.RunStatusFailedResumable)
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "merge"})
+	if err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+	if result.NodeID != "merge" || result.PromotedFrom != "" {
+		t.Errorf("pivot = %q (promoted from %q), want merge unpromoted — the convergence is outside the body",
+			result.NodeID, result.PromotedFrom)
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/runview/rewind_test.go
+++ b/pkg/runview/rewind_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -715,5 +716,66 @@ func TestRewind_NoBackupRefWhenNothingWasBanked(t *testing.T) {
 	if result.Files.BackupRef != "" {
 		t.Errorf("BackupRef = %q for a clean tree — that ref was never written and does not resolve",
 			result.Files.BackupRef)
+	}
+}
+
+// TestRewind_RetiresAbandonedAsyncQuestions is Revi's R0fee41.
+//
+// ADR-081's async pair is level-triggered against the STORE, not the
+// checkpoint: await_answers parks until the pending list is empty and
+// returns every answered record. Clearing only the checkpoint pointer
+// left the dropped nodes' questions live, so the replayed node would park
+// on the union of old and new — or fold pre-rewind answers into its
+// output.
+func TestRewind_RetiresAbandonedAsyncQuestions(t *testing.T) {
+	cp := &store.Checkpoint{
+		NodeID:  "verify",
+		Outputs: outputsOf("survey", "plan", "implement", "verify"),
+	}
+	svc, st, runID := seedRun(t, linearBot, cp, store.RunStatusFailedResumable)
+	ctx := context.Background()
+
+	// One pending and one answered question from a node about to be
+	// dropped, plus one from an upstream node that survives.
+	answered := time.Now().UTC()
+	for _, in := range []*store.Interaction{
+		{ID: "q-pending", RunID: runID, NodeID: "implement", Kind: store.InteractionKindAsync,
+			Questions: map[string]any{"which": "approach?"}, RequestedAt: answered},
+		{ID: "q-answered", RunID: runID, NodeID: "implement", Kind: store.InteractionKindAsync,
+			Questions: map[string]any{"ok": "?"}, Answers: map[string]any{"ok": true},
+			RequestedAt: answered, AnsweredAt: &answered},
+		{ID: "q-upstream", RunID: runID, NodeID: "plan", Kind: store.InteractionKindAsync,
+			Questions: map[string]any{"scope": "?"}, RequestedAt: answered},
+	} {
+		if err := st.WriteInteraction(ctx, in); err != nil {
+			t.Fatalf("seed interaction %s: %v", in.ID, err)
+		}
+	}
+
+	if _, err := svc.Rewind(ctx, RewindSpec{RunID: runID, NodeID: "implement"}); err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+
+	pending, err := store.ListPendingAsyncInteractions(ctx, st, runID, "implement")
+	if err != nil {
+		t.Fatalf("list pending: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Errorf("%d pending question(s) survived for the replayed node — await_answers would park on them", len(pending))
+	}
+	done, err := store.ListAnsweredAsyncInteractions(ctx, st, runID, "implement")
+	if err != nil {
+		t.Fatalf("list answered: %v", err)
+	}
+	if len(done) != 0 {
+		t.Errorf("%d pre-rewind answer(s) survived — the replayed node's output would mix them in", len(done))
+	}
+	// An upstream node's question is not the rewind's business.
+	up, err := store.ListPendingAsyncInteractions(ctx, st, runID, "plan")
+	if err != nil {
+		t.Fatalf("list upstream: %v", err)
+	}
+	if len(up) != 1 {
+		t.Errorf("upstream questions = %d, want 1 kept", len(up))
 	}
 }

--- a/pkg/server/runs.go
+++ b/pkg/server/runs.go
@@ -58,6 +58,7 @@ func (s *Server) registerRunRoutes() {
 	s.mux.HandleFunc("GET /api/runs/{id}/interactions/pending", s.handleListPendingInteractions)
 	s.mux.HandleFunc("POST /api/runs/{id}/interactions/{iid}/answer", s.handleAnswerInteraction)
 	s.mux.HandleFunc("POST /api/runs/{id}/fork", s.handleForkRun)
+	s.mux.HandleFunc("POST /api/runs/{id}/rewind", s.handleRewindRun)
 	s.mux.HandleFunc("GET /api/runs/{id}/skills", s.handleListRunSkills)
 	s.mux.HandleFunc("GET /api/runs/{id}/session-board", s.handleGetSessionBoard)
 	s.mux.HandleFunc("GET /api/runs/{id}/queue-messages", s.handleListQueuedMessages)

--- a/pkg/server/runs_control.go
+++ b/pkg/server/runs_control.go
@@ -280,12 +280,27 @@ func (s *Server) handleRewindRun(w http.ResponseWriter, r *http.Request) {
 	if s.logger != nil {
 		s.logger.Info("server: rewind run %q to node %q (auto=%v) from %s", id, req.NodeID, req.Auto, r.RemoteAddr)
 	}
+	sourcePath := req.SourcePath
+	if sourcePath != "" {
+		// The same audited containment boundary every other workflow-path
+		// surface uses. Without it this handler is an arbitrary-file-read
+		// primitive for any authenticated caller: the path goes straight
+		// into CompileWorkflow + os.ReadFile, and the parse diagnostic
+		// returned on failure quotes the offending token out of whatever
+		// file it managed to read.
+		resolved, perr := s.resolveWorkflowPath(sourcePath, "")
+		if perr != nil {
+			s.httpErrorFor(w, r, http.StatusBadRequest, "source_path: %v", perr)
+			return
+		}
+		sourcePath = resolved
+	}
 	result, err := s.runs.Rewind(r.Context(), runview.RewindSpec{
 		RunID:      id,
 		NodeID:     req.NodeID,
 		Auto:       req.Auto,
 		KeepFiles:  req.KeepFiles,
-		SourcePath: req.SourcePath,
+		SourcePath: sourcePath,
 	})
 	if err != nil {
 		switch {

--- a/pkg/server/runs_control.go
+++ b/pkg/server/runs_control.go
@@ -238,6 +238,76 @@ func (s *Server) handleForkRun(w http.ResponseWriter, r *http.Request) {
 	s.writeJSONFor(w, r, result)
 }
 
+// rewindRunRequest is the body of POST /api/runs/{id}/rewind. Mirrors
+// runview.RewindSpec, kept separate for the same reason as
+// forkRunRequest: the wire shape must be free to diverge from the
+// service struct.
+type rewindRunRequest struct {
+	NodeID     string `json:"node_id"`
+	Auto       bool   `json:"auto,omitempty"`
+	KeepFiles  bool   `json:"keep_files,omitempty"`
+	SourcePath string `json:"source_path,omitempty"`
+}
+
+// handleRewindRun re-anchors a run in place. Unlike fork it MUTATES the
+// addressed run, so it takes the handlePauseRun shape: a tenant-scoping
+// probe before the mutation, not just the one inside the service.
+func (s *Server) handleRewindRun(w http.ResponseWriter, r *http.Request) {
+	if !s.requireSafeOrigin(w, r) {
+		return
+	}
+	if s.rejectCrossStoreWrite(w, r) {
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "missing run id")
+		return
+	}
+	if _, err := s.runs.LoadRunCtx(r.Context(), id); err != nil {
+		s.httpErrorFor(w, r, http.StatusNotFound, "run not found: %v", err)
+		return
+	}
+	var req rewindRunRequest
+	if err := readJSON(r, &req); err != nil {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "decode rewind request: %v", err)
+		return
+	}
+	if req.NodeID == "" && !req.Auto {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "node_id is required (or auto:true)")
+		return
+	}
+	if s.logger != nil {
+		s.logger.Info("server: rewind run %q to node %q (auto=%v) from %s", id, req.NodeID, req.Auto, r.RemoteAddr)
+	}
+	result, err := s.runs.Rewind(r.Context(), runview.RewindSpec{
+		RunID:      id,
+		NodeID:     req.NodeID,
+		Auto:       req.Auto,
+		KeepFiles:  req.KeepFiles,
+		SourcePath: req.SourcePath,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, runview.ErrRewindNotRewindable):
+			// 409: the run is running or terminal — a state conflict the
+			// caller resolves by cancelling/pausing first, not a bad request.
+			s.httpErrorFor(w, r, http.StatusConflict, "rewind: %v", err)
+		case errors.Is(err, runview.ErrRewindNodeNotReached),
+			errors.Is(err, runview.ErrRewindNoSourceRecorded),
+			errors.Is(err, runview.ErrRewindNoChange),
+			errors.Is(err, runview.ErrRewindAmbiguous):
+			s.httpErrorFor(w, r, http.StatusBadRequest, "rewind: %v", err)
+		default:
+			s.httpErrorFor(w, r, http.StatusInternalServerError, "rewind: %v", err)
+		}
+		return
+	}
+	// 200, not 201: no new resource was created — that is the whole
+	// point of rewind versus fork.
+	s.writeJSONFor(w, r, result)
+}
+
 func (s *Server) handleListQueuedMessages(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {

--- a/pkg/server/runs_test.go
+++ b/pkg/server/runs_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -590,5 +591,56 @@ func TestArtifactFile_DispositionToggle(t *testing.T) {
 				t.Errorf("body = %q, want to contain %q", b, tc.wantBodyHas)
 			}
 		})
+	}
+}
+
+// TestRewindHandler_RefusesEscapingSourcePath is Revi's Rc48b6f.
+//
+// The handler forwarded a client-supplied source_path straight into
+// CompileWorkflow + os.ReadFile, bypassing the containment boundary every
+// other workflow-path surface goes through. That is an arbitrary-file
+// primitive for any authenticated caller, and the parse diagnostic
+// returned on failure echoes file content back.
+func TestRewindHandler_RefusesEscapingSourcePath(t *testing.T) {
+	srv, hs := newTestServer(t)
+	// A real, rewindable run with a checkpoint — otherwise Rewind fails at
+	// LoadRun and never reaches the path, and the test passes with or
+	// without the containment check (verified by mutation).
+	seedRun(t, srv, "rewindable", "wf", store.RunStatusFailedResumable)
+	st, err := store.New(srv.cfg.StoreDir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	run, err := st.LoadRun(context.Background(), "rewindable")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	run.Checkpoint = &store.Checkpoint{
+		NodeID:  "implement",
+		Outputs: map[string]map[string]any{"implement": {"v": 1}},
+	}
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	for _, escaping := range []string{"/etc/passwd", "../../../../etc/hostname"} {
+		body := strings.NewReader(`{"node_id":"implement","source_path":"` + escaping + `"}`)
+		resp, err := http.Post(hs.URL+"/api/runs/rewindable/rewind", "application/json", body)
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		payload, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			t.Errorf("source_path %q was accepted", escaping)
+		}
+		// The give-away of the old behaviour: the parser diagnostic quotes
+		// the offending token from the file it managed to read.
+		for _, leak := range []string{"root:", "unexpected token"} {
+			if strings.Contains(string(payload), leak) {
+				t.Errorf("response for %q leaked file content (%q): %s", escaping, leak, payload)
+			}
+		}
 	}
 }

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -109,6 +109,24 @@ const (
 	//     "runtime_code+parsed_text", "…+blind_wait") — the degraded
 	//     paths must be visible, not silent
 	EventRunRetryScheduled EventType = "run_retry_scheduled"
+	// EventRunRewound marks an in-place rewind: the operator re-anchored
+	// THIS run's checkpoint on an already-executed node and invalidated
+	// the outputs downstream of it, so the next resume re-executes from
+	// there (see runview.Service.Rewind). Distinct from a fork, which
+	// mints a NEW run id and leaves this one untouched.
+	//
+	// The event is the audit trail: events.jsonl stays append-only, so
+	// the superseded node_started / node_finished records of the dropped
+	// nodes remain in the timeline with this marker explaining why they
+	// are about to repeat. Data:
+	//   - from_node: the checkpoint node the run was anchored on before
+	//   - to_node: the new anchor (== NodeID on the event)
+	//   - dropped_nodes: node ids whose outputs were invalidated,
+	//     sorted; always includes to_node
+	//   - code_rewound: whether the worktree was git-reset to the node's
+	//     snapshot
+	//   - code_ref: the snapshot ref used when code_rewound is true
+	EventRunRewound EventType = "run_rewound"
 	// Review-&-merge gate events (interaction: review). The gate runs a
 	// companion↔human dialogue and squash-merges during the pause.
 	EventReviewTurn     EventType = "review_turn"    // data: {interaction_id, role, turn}

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -123,9 +123,19 @@ const (
 	//   - to_node: the new anchor (== NodeID on the event)
 	//   - dropped_nodes: node ids whose outputs were invalidated,
 	//     sorted; always includes to_node
-	//   - code_rewound: whether the worktree was git-reset to the node's
-	//     snapshot
-	//   - code_ref: the snapshot ref used when code_rewound is true
+	//   - tombstoned_artifacts: dropped nodes whose published artifact was
+	//     superseded by a `rewound` marker version, sorted
+	//   - orphaned_child_runs: subbot child run ids whose pointer was
+	//     released, sorted
+	//   - promoted_from: the requested pivot when it was promoted to the
+	//     router of the fan-out containing it ("" otherwise)
+	//   - files_reverted: whether the workspace was reverted to the pivot's
+	//     pre-execution snapshot
+	//   - files_ref / files_revert_commit / files_backup_ref: the snapshot
+	//     ref restored, the revert commit written on top of HEAD, and the
+	//     ref banking the pre-revert state
+	//   - files_skip_reason: why the workspace was left untouched (no
+	//     worktree, keep_files, or no recorded pre-boundary)
 	EventRunRewound EventType = "run_rewound"
 	// Review-&-merge gate events (interaction: review). The gate runs a
 	// companion↔human dialogue and squash-merges during the pause.

--- a/pkg/store/interactions_async.go
+++ b/pkg/store/interactions_async.go
@@ -49,6 +49,11 @@ func listAsyncInteractions(ctx context.Context, rs RunStore, runID, nodeID strin
 		if in.Kind != InteractionKindAsync || (in.AnsweredAt != nil) != answered {
 			continue
 		}
+		// A retired question is one the run no longer asks: it must park
+		// nothing and appear in no answer set.
+		if in.RetiredAt != nil {
+			continue
+		}
 		if nodeID != "" && in.NodeID != nodeID {
 			continue
 		}
@@ -105,4 +110,38 @@ func sortInteractionsByRequestedAt(ins []*Interaction) {
 	sort.SliceStable(ins, func(i, j int) bool {
 		return ins[i].RequestedAt.Before(ins[j].RequestedAt)
 	})
+}
+
+// RetireAsyncInteractions marks every async interaction of the given
+// nodes as no longer asked, and returns how many it retired.
+//
+// Used by an in-place rewind: the questions those nodes posted belong to
+// an execution that is being replayed, so leaving them live would make
+// the replayed await_answers park on the union of old and new, or fold
+// pre-rewind answers into its output.
+func RetireAsyncInteractions(ctx context.Context, rs RunStore, runID string, nodeIDs map[string]bool) (int, error) {
+	if len(nodeIDs) == 0 {
+		return 0, nil
+	}
+	ids, err := rs.ListInteractions(ctx, runID)
+	if err != nil {
+		return 0, fmt.Errorf("list interactions for run %s: %w", runID, err)
+	}
+	now := time.Now().UTC()
+	retired := 0
+	for _, id := range ids {
+		in, err := rs.LoadInteraction(ctx, runID, id)
+		if err != nil {
+			return retired, fmt.Errorf("load interaction %s/%s: %w", runID, id, err)
+		}
+		if in.Kind != InteractionKindAsync || in.RetiredAt != nil || !nodeIDs[in.NodeID] {
+			continue
+		}
+		in.RetiredAt = &now
+		if err := rs.WriteInteraction(ctx, in); err != nil {
+			return retired, fmt.Errorf("retire interaction %s/%s: %w", runID, id, err)
+		}
+		retired++
+	}
+	return retired, nil
 }

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -216,6 +216,16 @@ type Run struct {
 	WorkflowName   string            `json:"workflow_name" bson:"workflow_name"`
 	WorkflowHash   string            `json:"workflow_hash,omitempty" bson:"workflow_hash,omitempty"` // SHA-256 of the .bot source at run start
 	FilePath       string            `json:"file_path,omitempty" bson:"file_path,omitempty"`         // absolute .bot source path captured at launch (resume without re-supplying file)
+	// WorkflowSource is the .bot text as it was AT LAUNCH. WorkflowHash
+	// answers "did the source change since?"; this answers "which node
+	// changed", which is what `iterion rewind --auto` needs to target the
+	// edit. FilePath cannot serve: by the time you rewind, that file holds
+	// the NEW version — the whole reason you are rewinding.
+	//
+	// Best-effort and size-capped (see runtime.maxPersistedWorkflowSource):
+	// an unreadable or oversized source simply disables auto-targeting,
+	// leaving `--node` to work as before.
+	WorkflowSource string `json:"workflow_source,omitempty" bson:"workflow_source,omitempty"`
 	// Preset is the in-source preset name selected at launch via
 	// `--preset <name>` (or the studio Launch modal). Persisted so
 	// `iterion resume` re-applies the same parameter set without the

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -831,6 +831,17 @@ type Interaction struct {
 	// be enforced at the interaction layer too. Empty for legacy
 	// filesystem records.
 	TenantID string `json:"tenant_id,omitempty" bson:"tenant_id,omitempty"`
+	// RetiredAt marks a question the run no longer asks — set when a
+	// rewind invalidates the node that posted it.
+	//
+	// ADR-081's async pair is level-triggered against the STORE, not the
+	// checkpoint: await_answers parks until the pending list is empty and
+	// returns every answered record. So a rewind that only cleared the
+	// checkpoint pointer left its questions live, and the replayed node
+	// blocked on the union of its new questions and the abandoned ones —
+	// or mixed pre- and post-rewind answers into one output. A retired
+	// record is in neither list.
+	RetiredAt *time.Time `json:"retired_at,omitempty" bson:"retired_at,omitempty"`
 }
 
 // InteractionTurn is one message in a guided review-gate dialogue.

--- a/pkg/store/turn.go
+++ b/pkg/store/turn.go
@@ -20,6 +20,39 @@ func NodeSnapshotRef(runID, nodeID string, loopIter int) string {
 	return fmt.Sprintf("refs/iterion/runs/%s/nodes/%s/%d", runID, nodeID, loopIter)
 }
 
+// NodePreSnapshotRef names the worktree state as it was JUST BEFORE a
+// node executed.
+//
+//	refs/iterion/runs/<runID>/pre/<nodeID>/<loopIter>
+//
+// NodeSnapshotRef is written AFTER a node finishes, so the ref named for
+// a node holds that node's OWN production. Anything replaying a node from
+// its prior conditions — the in-place rewind — needs the state the node
+// started from, which is what this records. The two bracket each node's
+// effect on the workspace.
+//
+// The engine writes it as a cheap alias of the previous node boundary's
+// snapshot commit (nothing touches the tree between one node finishing
+// and the next starting), so marking it costs one `update-ref` and no
+// index walk.
+func NodePreSnapshotRef(runID, nodeID string, loopIter int) string {
+	return fmt.Sprintf("refs/iterion/runs/%s/pre/%s/%d", runID, nodeID, loopIter)
+}
+
+// RewindBackupRef names the commit banking a worktree's state at the
+// instant an in-place rewind reverted it.
+//
+//	refs/iterion/runs/<runID>/rewind/<nodeID>/<seq>
+//
+// The revert itself preserves committed history (it commits the prior
+// tree on top of HEAD), but the UNCOMMITTED work in the tree at that
+// instant would still be lost. This banks it first, so a rewind destroys
+// nothing: every state the run ever had stays reachable under
+// refs/iterion/runs/<run>/ and is swept by the same namespace GC.
+func RewindBackupRef(runID, nodeID string, seq int) string {
+	return fmt.Sprintf("refs/iterion/runs/%s/rewind/%s/%d", runID, nodeID, seq)
+}
+
 // TurnSnapshotRef is the per-turn counterpart of NodeSnapshotRef. Not
 // yet wired (Phase 5 stretch); reserved here so the namespace is
 // documented in one place.

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -2505,6 +2505,25 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/runs/{id}/rewind": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** POST /api/runs/{id}/rewind */
+        post: operations["postRunsByIdRewind"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/runs/{id}/session-board": {
         parameters: {
             query?: never;
@@ -8239,6 +8258,26 @@ export interface operations {
         };
     };
     postRunsByIdResume: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    postRunsByIdRewind: {
         parameters: {
             query?: never;
             header?: never;


### PR DESCRIPTION
Iterating on a bot's configuration meant relaunching from scratch: edit a prompt, and the only way to test it was to re-pay for every upstream node. `iterion rewind` re-anchors an existing run's checkpoint on a node it already executed and invalidates what the replay will regenerate, so `iterion resume` picks up from there.

Same run id — distinct from `iterion fork`, which mints a child for an alternative future and leaves the parent intact.

```bash
# edit main.bot, then let iterion locate the edit:
iterion rewind --run-id RUN --auto
  changed: agent implement (modified)
rewound RUN to "implement" (dropped: implement, verify)

iterion resume --run-id RUN --force
```

## `--auto`

Diffs the `.bot` on disk against the source the run executed and targets the edit, resolving indirection an operator would otherwise trace by hand:

| You edited | It rewinds to |
|---|---|
| A node's prompt, model, schema ref, command… | that node |
| A shared `prompt` / `schema` / `cursor` | every node referencing it, earliest first |
| A `supervisor` | the nodes it watches |
| A node inside a `group` | the instantiated `<prefix>.<node>` ids |
| An edge (guard, `with` mapping, loop bound) | the node that re-selects it |
| `vars:`, `budget:`, `sandbox:`, `entry:` | the entry node |
| Several nodes on one chain | the upstream-most, so one pass covers them all |

It errs toward reporting *more* nodes than needed: a false positive costs a re-execution, a false negative tests the new config against stale state. It needs the source as launched, so runs now persist it — `WorkflowHash` only answers *whether* it changed, never *which node*. The comparison runs on the AST encoder (Span-free), so an inserted comment is not "everything changed".

## What a replay invalidates

- **Checkpoint outputs** of the pivot and its downstream — "forward-reachable minus ancestors", so a loop's earlier stage survives for `{{loop.*.previous_output}}`.
- **Published artifacts** get a superseding `rewound` marker version rather than a delete, because `Run.ArtifactIndex` is what `LoadLatestArtifact` reads and three consumers would otherwise serve invalidated output.
- **Subbot child pointers**, without which `ReattachSubbotChild` adopts the pre-rewind child and never runs the edited child workflow.
- **Workspace files**, for a run with an isolated worktree, restored from a new pre-execution boundary ref. The existing per-node snapshot is written *after* a node finishes and holds that node's own production — reverting to it would restore exactly what the rewind means to discard. The restore is a revert: the prior tree is committed on top of HEAD and the current state banked first.

Preserved on purpose: budget accounting and loop counters (refunding them would make rewind+resume an unbounded way around `max_cost_usd` / `max_iterations`), and `events.jsonl`, which stays append-only with a `run_rewound` marker.

## Two guards worth naming

The run is parked in `cancelled` — the one resumable status a cloud runner treats as "explicit resume required"; `failed_resumable` and `paused_operator` are auto-resumed on queue redelivery, which would race the operator's edit and execute the stale workflow.

A pivot inside a fan-out body is promoted to its router: the checkpoint keeps one output per node id, so anchoring on the body node would replay it once, linearly, silently testing one iteration instead of all of them.

## Review

An adversarial multi-agent review over this branch produced 45 findings, 34 of which survived a refutation pass. The follow-up commits close them. Three are worth calling out because the original tests masked them:

- `--auto` **panicked on any bot with a loop** — two edited nodes on a cycle are each other's ancestor, both were eliminated, and the empty survivor set was indexed. The silent half was worse: an unrelated third candidate then won and the loop edit vanished from the replay.
- **Subbot pointers were never released.** A surviving `SubbotChildren` entry means the subbot did *not* complete, so it has no output — and the cleanup was keyed on the output-filtered set. The two are disjoint except when the pivot *is* the subbot node, which is exactly what the test seeded.
- `openapi.json` was stale, and its drift check is a required merge-queue check.

## Scope

Files produced by a node are restored only for a run with `worktree: auto`. An in-place run keeps its files and says so via `files.skip_reason` — its workspace is the operator's live checkout, which iterion deliberately does not snapshot. Covering those is #FOLLOWUP (the stacked branch).

External effects — board cards, forge comments, pushed commits, already-launched child runs — are never undone.

## Not included

No studio affordance yet. Its prerequisite is a `--dry-run` on the rewind: `RewindResult` already carries everything a preview needs, but there is no way to compute it without mutating.

Docs: [resume.md](docs/resume.md#rewind-resume-from-an-earlier-node), [cli-reference.md](docs/cli-reference.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)