### PR TITLE
feat(credpool): mutualise contributors' unused LLM subscription quota

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,11 @@ the hours this one spent.
   `/api/me/oauth/*` endpoints; fixes `401`/`429` on cloud runs).
 - [docs/web-search.md](docs/web-search.md) — sovereign web search tiers
   (SearXNG → Firecrawl) + the `ITERION_WEB_SEARCH` resolver.
+- [docs/credential-pool.md](docs/credential-pool.md) — mutualising
+  contributors' unused Claude/ChatGPT quota: the pledge (ceilings, sharing
+  window, kill switch), the audience policy deciding who may draw, the
+  fourth credential tier in `cloudpublisher`, and why the run's own
+  `max_cost_usd` is the enforcement.
 
 ## Development setup
 
@@ -147,6 +152,7 @@ Other top-level directories: `studio/` (React/Vite frontend), `examples/` (.bot 
 - `pkg/auth/` — Operator authentication primitives (SSO, session cookies, password reset) for cloud-mode endpoints. Mints the JWT carrying `(OrgID, OrgRole, TeamID, Role)`; `SwitchOrg`/`SwitchTeam` re-issue it (org-then-team validation).
 - `pkg/audit/` — Tenant + platform audit log (control-plane mutations; Mongo TTL store, `/api/teams/{id}/audit` + `/api/admin/audit`)
 - `pkg/orgusage/` — Per-org monthly run/cost counters (Mongo CAS) feeding the launch gate + usage views (see [docs/quotas-and-limits.md](docs/quotas-and-limits.md))
+- `pkg/credpool/` — **Mutualised credential pool**: LLM subscriptions individual contributors *lend* to a deployment. A `Pledge` is one donor's standing offer of a credential they already connected (`pkg/secrets` OAuth), bounded by ceilings THEY set (spend/day + /week, runs/day, concurrency, sharing window, bot allow-list) and revocable instantly. The `Broker` is the **fourth and last** credential tier in `cloudpublisher.resolveAndSealCredentials` — consulted only when a run resolved NO key of its own — and picks the least-consumed eligible pledge by *fraction of what each offered*, records a `Lease` (the concurrency unit AND the donor's audit trail), and hands back the blob for the ordinary sealing path. `Audience` decides who may draw: a union of independent predicates (`teams` / `orgs` / `contributors` reciprocity / `all_teams`) whose zero value is "the owning org only". Enforcement is the run's own `max_cost_usd`, clamped to the donor's remaining allowance — the post-hoc ledger charge is the final truth but arrives too late to protect anyone. Dollar figures are ESTIMATES (a subscription bills nothing per call); the hard guard is the provider's usage window, which puts a donor to rest until its reset. **Depends on the delegate cost signal reaching `metricsEmitter.RunTotals` — without it every donor reads $0 forever.** See [docs/credential-pool.md](docs/credential-pool.md)
 - `pkg/pat/` — Personal access tokens (`iap_` bearers for programmatic API access)
 - `pkg/mail/` — Stdlib SMTP mailer (invitations + password reset) with a log fallback when unconfigured
 - `pkg/usernotify/` — User-addressed notifications for run lifecycle moments (run paused on a human form, finished/failed/cancelled): `Dispatcher` consumes run-outcome `trigger.Event`s from the eventbus spine (queue group `usernotify` on NATS ⇒ one replica per event), resolves recipients (run owner + per-user team-wide opt-in prefs), dedups per episode via the `sent_notifications` first-writer-wins claim, and fans out to `Sink`s — `webpush/` (VAPID Web Push to per-browser subscriptions, cloud) ships; desktop (Wails OS notification) and email are future sinks on the same interface. A 2-min reconciliation sweep replays episodes the lossy bus dropped. Shared event authority: `trigger.BuildRunOutcome` (used by both `runview.emitRunOutcome` and the runner's `fireOutcomeEvent`). Enabled iff `ITERION_WEBPUSH_VAPID_{PUBLIC,PRIVATE}_KEY` are set (`iterion server webpush-keys` mints a pair). See [docs/notifications.md](docs/notifications.md)
@@ -1196,7 +1202,9 @@ Then pilot: `iterion remote runs launch <file.bot> --follow` (uploads inline,
 or `--bot <catalog id>`), plus `runs`, `bots`, `board`, `issues`, `labels`,
 `dispatcher`, `schedules`, `triggers`, `secrets`, `api-keys`, `bindings`,
 `teams`, `orgs`, `webhooks`, `forge`, `audit`, `usage`, `memory`, `admin`,
-`sso`, `plugins`. `iterion remote api <METHOD> <path>` is the raw escape hatch
+`sso`, `plugins`, `pool` (lend/pause/withdraw your LLM subscription to the
+shared credential pool — [docs/credential-pool.md](docs/credential-pool.md)).
+`iterion remote api <METHOD> <path>` is the raw escape hatch
 for any endpoint. Headless auth (CI): `--token <iap_…>` (a PAT) or
 `--email/--password` (mints a CLI token).
 

--- a/cmd/iterion/remote_pool.go
+++ b/cmd/iterion/remote_pool.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"github.com/SocialGouv/iterion/pkg/cli"
+	"github.com/SocialGouv/iterion/pkg/credpool"
+	"github.com/spf13/cobra"
+)
+
+// remote pool — lend an LLM subscription to the instance's mutualised
+// credential pool, and see what it served.
+//
+// The terms are the donor's: every ceiling is optional and 0 means "no
+// limit on that axis". Nothing here handles the credential itself; that
+// was connected once via the OAuth flow and stays sealed server-side.
+
+var remotePoolCmd = &cobra.Command{
+	Use:   "pool",
+	Short: "Share your LLM subscription with the instance's credential pool",
+	Long: "Lend the unused part of your Claude or ChatGPT subscription so runs with no\n" +
+		"credential of their own can use it. You set the ceilings, you can see every\n" +
+		"run it served, and `pause` stops it taking effect at the next launch.\n\n" +
+		"Spend figures are ESTIMATES: a subscription bills nothing per call, so cost is\n" +
+		"derived from token counts.",
+}
+
+var remotePoolStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show your contributions and what they have given",
+	Args:  cobra.NoArgs,
+	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
+		return cli.RemotePoolStatus(cmd.Context(), c, p)
+	}),
+}
+
+var remotePoolHistoryCmd = &cobra.Command{
+	Use:   "history",
+	Short: "List the runs your quota served",
+	Args:  cobra.NoArgs,
+	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
+		return cli.RemotePoolHistory(cmd.Context(), c, p)
+	}),
+}
+
+var (
+	remotePoolKind       string
+	remotePoolUSDPerDay  float64
+	remotePoolUSDPerWeek float64
+	remotePoolRunsPerDay int
+	remotePoolConcurrent int
+	remotePoolFromHour   int
+	remotePoolToHour     int
+	remotePoolBots       []string
+)
+
+var remotePoolShareCmd = &cobra.Command{
+	Use:   "share",
+	Short: "Start (or update) sharing a connected subscription",
+	Long: "Every limit is optional; leaving one out means no limit on that axis.\n" +
+		"--from-hour/--to-hour restrict sharing to a local time range (19 → 8 shares\n" +
+		"overnight); leave both at 0 to share around the clock.",
+	Args: cobra.NoArgs,
+	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
+		in := cli.PoolPledgeInput{
+			Enabled: true,
+			Limits: credpool.Limits{
+				MaxUSDPerDay:      remotePoolUSDPerDay,
+				MaxUSDPerWeek:     remotePoolUSDPerWeek,
+				MaxRunsPerDay:     remotePoolRunsPerDay,
+				MaxConcurrentRuns: remotePoolConcurrent,
+			},
+			Bots: remotePoolBots,
+		}
+		if remotePoolFromHour != 0 || remotePoolToHour != 0 {
+			in.Window = &credpool.Window{
+				StartHour: remotePoolFromHour,
+				EndHour:   remotePoolToHour,
+				Timezone:  cli.LocalTimezone(),
+			}
+		}
+		return cli.RemotePoolShare(cmd.Context(), c, p, remotePoolKind, in)
+	}),
+}
+
+var remotePoolPauseCmd = &cobra.Command{
+	Use:   "pause",
+	Short: "Stop serving new runs, keeping your terms for later",
+	Args:  cobra.NoArgs,
+	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
+		return cli.RemotePoolPause(cmd.Context(), c, p, remotePoolKind, false)
+	}),
+}
+
+var remotePoolResumeCmd = &cobra.Command{
+	Use:   "resume",
+	Short: "Resume a paused contribution with its previous terms",
+	Args:  cobra.NoArgs,
+	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
+		return cli.RemotePoolPause(cmd.Context(), c, p, remotePoolKind, true)
+	}),
+}
+
+var remotePoolWithdrawCmd = &cobra.Command{
+	Use:   "withdraw",
+	Short: "Remove your contribution entirely",
+	Args:  cobra.NoArgs,
+	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
+		return cli.RemotePoolWithdraw(cmd.Context(), c, p, remotePoolKind)
+	}),
+}
+
+var remotePoolDonorsCmd = &cobra.Command{
+	Use:   "donors",
+	Short: "Operator view: the pool's policy and who is lending to it",
+	Args:  cobra.NoArgs,
+	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
+		team, err := c.ResolveTeam(cmd.Context(), remoteTeamFlag)
+		if err != nil {
+			return err
+		}
+		return cli.RemotePoolDonors(cmd.Context(), c, p, team)
+	}),
+}
+
+func init() {
+	kindFlagged := []*cobra.Command{
+		remotePoolShareCmd, remotePoolPauseCmd, remotePoolResumeCmd, remotePoolWithdrawCmd,
+	}
+	for _, c := range kindFlagged {
+		c.Flags().StringVar(&remotePoolKind, "kind", "claude_code", "Subscription to share (claude_code|codex)")
+	}
+	remotePoolShareCmd.Flags().Float64Var(&remotePoolUSDPerDay, "max-usd-day", 0, "Estimated spend ceiling per day (0 = no limit)")
+	remotePoolShareCmd.Flags().Float64Var(&remotePoolUSDPerWeek, "max-usd-week", 0, "Estimated spend ceiling per week (0 = no limit)")
+	remotePoolShareCmd.Flags().IntVar(&remotePoolRunsPerDay, "max-runs-day", 0, "Runs you will serve per day (0 = no limit)")
+	remotePoolShareCmd.Flags().IntVar(&remotePoolConcurrent, "max-concurrent", 0, "Runs served at once (0 = no limit)")
+	remotePoolShareCmd.Flags().IntVar(&remotePoolFromHour, "from-hour", 0, "Share from this local hour (with --to-hour)")
+	remotePoolShareCmd.Flags().IntVar(&remotePoolToHour, "to-hour", 0, "Share until this local hour (exclusive)")
+	remotePoolShareCmd.Flags().StringSliceVar(&remotePoolBots, "bots", nil, "Only these bot ids may use it (default: any)")
+	remotePoolDonorsCmd.Flags().StringVar(&remoteTeamFlag, "team", "", "Team id (default: switched/active team)")
+
+	remotePoolCmd.AddCommand(
+		remotePoolStatusCmd, remotePoolHistoryCmd, remotePoolShareCmd,
+		remotePoolPauseCmd, remotePoolResumeCmd, remotePoolWithdrawCmd, remotePoolDonorsCmd,
+	)
+	remoteCmd.AddCommand(remotePoolCmd)
+}

--- a/cmd/iterion/runner.go
+++ b/cmd/iterion/runner.go
@@ -213,7 +213,7 @@ func runRunner(cmd *cobra.Command, _ []string) error {
 		Pools:   credpool.NewMongoPoolStore(st.DB()),
 		Pledges: credpool.NewMongoPledgeStore(st.DB()),
 		Leases:  credpool.NewMongoLeaseStore(st.DB()),
-		Ledger:  credpool.NewMongoLedger(st.DB()),
+		Ledger:  credpool.NewMongoLedger(st.DB()).WithLogger(logger),
 		OAuth:   secrets.NewMongoOAuthStore(st.DB()),
 		Sealer:  sealer,
 		Logger:  logger,

--- a/cmd/iterion/runner.go
+++ b/cmd/iterion/runner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/cloud/metrics"
 	"github.com/SocialGouv/iterion/pkg/cloud/tracing"
 	iterconfig "github.com/SocialGouv/iterion/pkg/config"
+	"github.com/SocialGouv/iterion/pkg/credpool"
 	"github.com/SocialGouv/iterion/pkg/eventbus"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/orgusage"
@@ -205,6 +206,19 @@ func runRunner(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("runner: ensure org_usage schema: %w", err)
 	}
 
+	// Credential pool: a run served by a contributor's lent subscription
+	// must report what it spent, or the donor's ledger never moves and
+	// their concurrency slot only frees on lease expiry.
+	credBroker := credpool.NewBroker(credpool.BrokerConfig{
+		Pools:   credpool.NewMongoPoolStore(st.DB()),
+		Pledges: credpool.NewMongoPledgeStore(st.DB()),
+		Leases:  credpool.NewMongoLeaseStore(st.DB()),
+		Ledger:  credpool.NewMongoLedger(st.DB()),
+		OAuth:   secrets.NewMongoOAuthStore(st.DB()),
+		Sealer:  sealer,
+		Logger:  logger,
+	})
+
 	// Bots: where bot-qualified runs resolve their bundle so skills/
 	// mirror into the workspace — same env contract as the server
 	// (the official image sets ITERION_BOTS_PATH=/opt/iterion/bots).
@@ -239,6 +253,7 @@ func runRunner(cmd *cobra.Command, _ []string) error {
 		GenericSecrets:    secrets.NewMongoGenericSecretStore(st.DB()),
 		MemoryStore:       memStore,
 		OrgUsage:          orgUsageCounter,
+		CredPool:          credBroker,
 		BotsPaths:         botsPaths,
 		// Sandbox-by-default: the runner is a product entry point like
 		// `iterion run` — an unset ITERION_SANDBOX_DEFAULT resolves to

--- a/cmd/iterion/server.go
+++ b/cmd/iterion/server.go
@@ -624,7 +624,7 @@ func buildCloudStores(ctx context.Context, st *mongostore.Store, logger *iterlog
 		credPools:      credpool.NewMongoPoolStore(st.DB()),
 		credPledges:    credpool.NewMongoPledgeStore(st.DB()),
 		credLeases:     credpool.NewMongoLeaseStore(st.DB()),
-		credLedger:     credpool.NewMongoLedger(st.DB()),
+		credLedger:     credpool.NewMongoLedger(st.DB()).WithLogger(logger),
 		audit:          audit.NewMongoStore(st.DB()),
 		pat:            pat.NewMongoStore(st.DB()),
 		memory:         mongostore.NewMongoMemoryStore(st.DB()).WithLogger(logger),

--- a/cmd/iterion/server.go
+++ b/cmd/iterion/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/cloudsched"
 	iterconfig "github.com/SocialGouv/iterion/pkg/config"
 	"github.com/SocialGouv/iterion/pkg/configshare"
+	"github.com/SocialGouv/iterion/pkg/credpool"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/boardmongo"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/eventbus"
@@ -299,6 +300,20 @@ func runServer(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	// The mutualised credential pool: contributor-lent subscriptions a run
+	// with no credential of its own can draw on. One broker shared by the
+	// publisher (selection at launch) and the server (abandoned-lease
+	// sweeper), so both see the same stores.
+	credBroker := credpool.NewBroker(credpool.BrokerConfig{
+		Pools:   stores.credPools,
+		Pledges: stores.credPledges,
+		Leases:  stores.credLeases,
+		Ledger:  stores.credLedger,
+		OAuth:   stores.oauth,
+		Sealer:  sealer,
+		Logger:  logger,
+	})
+
 	pub, err := cloudpublisher.New(cloudpublisher.Config{
 		NATS:             natsConn,
 		Store:            st,
@@ -315,6 +330,7 @@ func runServer(cmd *cobra.Command, _ []string) error {
 		Identity:         authStack.identityStore,
 		PluginSources:    newPluginSourceResolver(stores, sealer, logger),
 		BotSources:       stores.botSources,
+		CredPool:         credBroker,
 	})
 	if err != nil {
 		return fmt.Errorf("server: build cloud publisher: %w", err)
@@ -486,6 +502,11 @@ func runServer(cmd *cobra.Command, _ []string) error {
 		ConfigShares:           stores.configShares,
 		OrgUsage:               stores.orgUsage,
 		OrgDefaults:            orgLimitDefaultsFromEnv(),
+		CredPoolBroker:         credBroker,
+		CredPoolPools:          stores.credPools,
+		CredPoolPledges:        stores.credPledges,
+		CredPoolLeases:         stores.credLeases,
+		CredPoolLedger:         stores.credLedger,
 		Audit:                  stores.audit,
 		Marketplace:            stores.marketplace,
 		Redis:                  redisClient,
@@ -559,6 +580,10 @@ type cloudStores struct {
 	desktopTickets   *desktopsso.MongoStore
 	wsTickets        *wsticket.MongoStore
 	orgUsage         *orgusage.MongoCounter
+	credPools        *credpool.MongoPoolStore
+	credPledges      *credpool.MongoPledgeStore
+	credLeases       *credpool.MongoLeaseStore
+	credLedger       *credpool.MongoLedger
 	audit            *audit.MongoStore
 	marketplace      marketplace.Store
 	pat              *pat.MongoStore
@@ -596,6 +621,10 @@ func buildCloudStores(ctx context.Context, st *mongostore.Store, logger *iterlog
 		desktopTickets: desktopsso.NewMongoStore(st.DB(), 2*time.Minute),
 		wsTickets:      wsticket.NewMongoStore(st.DB(), time.Minute),
 		orgUsage:       orgusage.NewMongoCounter(st.DB()),
+		credPools:      credpool.NewMongoPoolStore(st.DB()),
+		credPledges:    credpool.NewMongoPledgeStore(st.DB()),
+		credLeases:     credpool.NewMongoLeaseStore(st.DB()),
+		credLedger:     credpool.NewMongoLedger(st.DB()),
 		audit:          audit.NewMongoStore(st.DB()),
 		pat:            pat.NewMongoStore(st.DB()),
 		memory:         mongostore.NewMongoMemoryStore(st.DB()).WithLogger(logger),
@@ -628,6 +657,7 @@ func buildCloudStores(ctx context.Context, st *mongostore.Store, logger *iterlog
 		{"desktop_sso_tickets", s.desktopTickets.EnsureSchema},
 		{"ws_tickets", s.wsTickets.EnsureSchema},
 		{"org_usage", func(c context.Context) error { return orgusage.EnsureSchema(c, st.DB()) }},
+		{"cred_pool", func(c context.Context) error { return credpool.EnsureSchema(c, st.DB()) }},
 		{"audit", func(c context.Context) error { return audit.EnsureSchema(c, st.DB()) }},
 		{"board", func(c context.Context) error { return boardmongo.EnsureSchema(c, st.DB()) }},
 		{"trigger_subscriptions", func(c context.Context) error { return trigger.NewMongoSubscriptionStore(st.DB()).EnsureSchema(c) }},

--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -23,6 +23,13 @@ Kimi and Grok are outside this sealed-credential matrix: their delegates rely
 on the CLI's own inherited environment/config. Legacy Codex consumes its own
 uploaded Codex credential.
 
+A **fourth** source exists when the deployment runs a credential pool: a run
+that resolves none of the three above may draw on a **contributor's lent
+subscription** (`pkg/credpool`). It reaches the runner as an ordinary OAuth
+blob — indistinguishable from a personal forfait — but is metered against
+the lender's own ceilings and the run's `max_cost_usd` is clamped to what
+remains of them. See [credential-pool.md](credential-pool.md).
+
 ## Decision shortcut
 
 - **Sovereign `web_search` / any claw feature** → needs claw. An Anthropic

--- a/docs/credential-pool.md
+++ b/docs/credential-pool.md
@@ -1,0 +1,253 @@
+# Credential pool — mutualising contributors' unused LLM quota
+
+How developers lend the unused part of their Claude Pro/Max or ChatGPT
+subscription to an iterion deployment, and how a run with no credential of
+its own draws on it.
+
+Read [cloud-llm-credentials.md](cloud-llm-credentials.md) first: the pool is
+the **fourth and last** tier of the credential resolution described there.
+
+## The one-paragraph model
+
+A contributor connects their subscription through the ordinary personal
+OAuth flow, then makes a **pledge**: a standing offer of that credential
+bounded by ceilings *they* choose (spend per day and per week, runs per day,
+runs at once, an optional sharing window, an optional bot allow-list). At
+launch, a run that has neither a BYOK key nor a personal/org forfait asks
+the **broker** for a donor; it picks the least-consumed eligible pledge,
+records a **lease** against the run, and hands the credential to the
+ordinary sealing path — the runner cannot tell it apart from a personal
+forfait. When the attempt ends, the runner reports what it spent, which
+charges the donor's ledger and frees their concurrency slot.
+
+## What this is not
+
+- **Not an invoice.** On a subscription the CLI bills nothing per call, so
+  the dollar figures are ESTIMATES derived from token counts
+  (`pkg/backend/cost`). They are the right unit for sharing fairly between
+  donors; they are not what anyone is charged. Say "≈$1.80" in any UI.
+- **Not a way around a provider's quota.** The hard limit remains the
+  provider's own usage window. When one is hit, the donor is put to rest
+  until its reset — that cooldown, not the dollar ceiling, is what actually
+  protects a lender from being drained.
+- **Not neutral on licensing.** A Claude or ChatGPT subscription is an
+  **individual licence**. Pooling one across people is a deployment owner's
+  decision. The mechanism is built so it stays an informed one — explicit
+  pledge, ceilings set by the lender, kill switch effective at the next
+  launch, and a per-donor log of every run served — but the decision itself
+  is yours, and the same "dev/test, not production automation" caveat that
+  the org-shared forfait already carries applies with more force here.
+
+## Resolution order (where the pool sits)
+
+`resolveAndSealCredentials`
+([pkg/server/cloudpublisher/publisher.go](../pkg/server/cloudpublisher/publisher.go)):
+
+1. **BYOK API keys** — team-scoped, personal-first.
+2. **Personal OAuth forfait** — the run owner's own.
+3. **Org OAuth forfait** — `secrets.OrgOwnerKey(tenant)`, the fallback for
+   automated runs whose owner is a synthetic identity.
+4. **Pool** — only when steps 1–3 produced **nothing at all**. Spending a
+   contributor's lent subscription while the tenant holds a usable key of
+   its own would take a donation nobody needed.
+
+Kind preference within the pool: `claude_code` first (a lent Claude forfait
+runs natively there), then `codex`.
+
+## Enforcement: the run's own budget is the ceiling
+
+A grant carries the donor's **remaining allowance**, and the launch clamps
+the run's `max_cost_usd` to it (`clampBudgetToGrant`). The engine then stops
+the run on its own budget. Post-hoc ledger accounting is the final truth,
+but it arrives too late to protect anyone — the clamp is what does.
+
+The clamp only ever **lowers**: the tightest of (launch override, the bot's
+declared budget, the allowance) wins. A donor who set no spend cap grants an
+allowance of `0`, which means *no ceiling*, not "nothing left" (an exhausted
+donor is never selected in the first place).
+
+## Availability rules
+
+A pledge is skipped when it is paused, unhealthy, inside a cooldown, outside
+its sharing window, or when the requested bot is not in its allow-list.
+Among the rest, selection ranks by the **fraction of what each donor
+offered** that has been consumed today — so a modest pledge is not drained
+before a generous one — with least-recently-served as the tie-break.
+
+Two states are set from a run's outcome:
+
+| Outcome | Effect on the donor |
+|---|---|
+| `ErrRateLimited{usage_window}` | Rest until the provider's reset (+1 min), or a bounded 1 h blind wait when no reset parsed. |
+| `ErrAuthFailed`, twice in a row | Held out of the pool (`health: auth_failed`) until they reconnect. One blip never evicts anyone. |
+| Anything else (including a plain workflow failure) | Nothing — a bot that failed on its own logic says nothing about the credential. |
+
+## What a donor's admission costs them, and when it comes back
+
+An acquisition consumes three things at once: a unit of the daily run
+quota, a concurrency slot, and — until the run reports — the whole
+allowance it was granted. That last one is what stops ten runs launched
+together from each being handed the same "remaining" and spending it ten
+times over: a live lease's `granted_cost_usd` counts against the next
+admission.
+
+They come back on three paths, and the distinction matters:
+
+| Path | Slot + committed allowance | Daily run unit |
+|---|---|---|
+| `Report` — the run finished (however it ended) | freed | **kept** (it ran) |
+| `Release` — the launch failed after the grant, so no run ever existed | freed | **returned** |
+| sweeper — the pod died without reporting | freed | **kept** (it ran) |
+
+`Report` closes the lease with a compare-and-set and charges the donor only
+if it wins, so a redelivered report cannot debit twice. A resumed run
+*renews* its admission instead of taking a second one: it is the same run,
+and charging it again would let one flaky run that resumes a few times
+consume a contributor's whole day.
+
+**One lease document per attempt**, never reused. A run that resumes —
+onto the same donor or another — leaves every finished attempt's record
+intact, because that record is the donor's only evidence for a charge
+already on their ledger. Acquiring *supersedes* whatever was still marked
+as serving that run (a pod that died without reporting leaves its lease
+open), so a run never holds two open leases and "who is serving this run",
+hence who gets charged, is never ambiguous.
+
+An attempt records whether it consumed a run unit, so releasing a **resume**
+gives nothing back: it renewed rather than consumed, and refunding it would
+mint quota out of a failed launch. An **abandoned** attempt does not count
+as a prior admission either — nothing ever learned what it spent, so the
+next attempt is admitted as new rather than renewing indefinitely against a
+record that means nothing.
+
+Concurrency and committed spend are **derived** from live leases, never
+accumulated in a counter, so an abandoned run cannot permanently consume
+either. The abandoned-lease sweeper
+([pkg/server/credpool_sweeper.go](../pkg/server/credpool_sweeper.go)) closes
+leases past their TTL every 2 minutes; no spend is charged for a run that
+never reported, because inventing a figure would misreport a donation in
+the direction that costs the donor.
+
+**Two residual behaviours, stated plainly rather than papered over:**
+
+- Two acquisitions that read a donor's state at the same instant can both
+  be admitted, so a cap can be exceeded by one in-flight run under
+  simultaneous launches. The committed-allowance accounting bounds the
+  damage to a single overshoot rather than N; closing it entirely needs a
+  distributed lock the deployment shape does not justify.
+- The spend caps are per **calendar day / ISO week**, not per run. A run
+  that starts at 23:00 and resumes after midnight can spend up to the daily
+  cap on each of the two days. Each day honours the ceiling the donor set;
+  a single long run is not separately bounded.
+
+## Audience — who may draw on a pool
+
+A pool belongs to an org. `Audience` is a **union of independent
+predicates**, each separately togglable, with the strictest default:
+
+| Field | Admits |
+|---|---|
+| *(nothing set)* | Only teams of the owning org. **The default.** |
+| `teams: [...]` | Those team ids, wherever they live. |
+| `orgs: [...]` | Every team under those orgs. |
+| `contributors: true` | Any user with an **active** pledge, wherever they launch from — the reciprocity dial ("lend to borrow"). Pausing your own sharing stops your borrowing too. |
+| `all_teams: true` | Every team on the instance. |
+
+Selection scans the enabled pools and applies each audience, so a pool that
+opens itself to another org is genuinely reachable from there; the
+requester's own org pool wins when several would serve.
+
+## Operator cookbook
+
+Admission is handled by the **existing GitHub team-gating**, not by anything
+in this package: create an orgsso GitHub row mapping the contributors'
+GitHub team to the iterion team you want them to land in
+([pkg/auth/oidc_service.go](../pkg/auth/oidc_service.go) →
+`FindGitHubGrantingOrgs`). An allow-listed contributor then signs in with
+GitHub and is already a member — with the default audience they can both
+lend and borrow, with no extra setup.
+
+```sh
+# 1. Operator: create/enable the pool for the org (default audience:
+#    the org's own teams only).
+iterion remote api PUT /api/teams/<team-id>/pool --data '{"enabled":true}'
+
+# Widen it only if you mean to — this lets more runs spend contributors'
+# personal subscriptions:
+iterion remote api PUT /api/teams/<team-id>/pool \
+  --data '{"enabled":true,"audience":{"contributors":true}}'
+
+# 2. Contributor: connect the subscription (once), then pledge it.
+iterion remote api POST /api/me/oauth/claude_code/authorize/start
+iterion remote pool share --kind claude_code \
+  --max-usd-day 5 --max-usd-week 20 --max-runs-day 10 --max-concurrent 1 \
+  --from-hour 19 --to-hour 8          # optional: lend it overnight
+
+# 3. Contributor: watch, pause, withdraw.
+iterion remote pool status
+iterion remote pool history           # every run your quota served
+iterion remote pool pause             # keeps your terms for later
+iterion remote pool withdraw
+
+# 4. Operator: who is lending, and how they are doing.
+iterion remote pool donors
+```
+
+Studio equivalents: **Account settings → Share my quota** for a contributor,
+**Team → Credential pool** for an operator.
+
+## REST surface
+
+| Endpoint | Who | Purpose |
+|---|---|---|
+| `GET /api/me/pool` | donor | Own pledges + today/this-week consumption |
+| `PUT /api/me/pool/{kind}` | donor | Create/update terms. Clears a parked health state ONLY when the credential was genuinely re-connected since — the signal is the record's `created_at` (stamped by connect/paste), never `updated_at`, which the token-refresh worker bumps hourly for a subscription the provider may have revoked |
+| `DELETE /api/me/pool/{kind}` | donor | Withdraw |
+| `GET /api/me/pool/history` | donor | The runs this quota served |
+| `GET /api/teams/{id}/pool` | member | Pool policy. The donor roster is included only for org admins — who lends, and how much, is the contributors' business |
+| `PUT /api/teams/{id}/pool` | **org** admin | Enable/disable + audience. The pool document is org-keyed, so this is an org-level decision and is audited on the org |
+
+A donor's credential is never returned by any of these — it stays sealed in
+`pkg/secrets` and is only ever unsealed into a run bundle.
+
+## Gotchas that will cost time
+
+- **A pledge without a connected subscription is refused, not stored.**
+  `PUT /api/me/pool/{kind}` returns 409 when the OAuth record is missing, so
+  nobody believes they are contributing when they are not.
+- **`ITERION_FORBID_SUBSCRIPTION_OAUTH=1` does not disable the pool.** That
+  guard only covers `claw`/`pi` (`secrets.GuardSubscriptionOAuth`); a lent
+  Claude forfait still works on `claude_code`, which is its native path.
+  Correct, and worth knowing before you conclude the pool is off.
+- **The spend signal must be live.** Delegate backends only report cost
+  because `DelegateInfo.CostUSD` rides the `delegate_finished` event into
+  the runner's per-run totals. If a future change drops that field, every
+  donor silently reads "0 consumed" and no ceiling ever trips — the
+  regression tests for this are in
+  [pkg/runner/metrics_test.go](../pkg/runner/metrics_test.go).
+- **Spend is charged to the day that ADMITTED the run**, not the day it
+  finished, or a run crossing midnight would leak past its donor's daily cap.
+- **A contribution joins the donor's OWN org's pool, or none.** There is no
+  "the instance runs one pool, use that" fallback: on a multi-tenant
+  instance it would enrol a personal subscription into a stranger's org.
+  A user whose org has no pool is told so.
+- **Disconnecting a subscription withdraws the pledge with it.** Consent is
+  given for a specific connected credential; leaving the terms behind would
+  let them rebind to whatever is connected next under the same key. The
+  cascade is best-effort — a degraded pool store never blocks a
+  disconnection, and a pledge left behind is parked at the next acquisition.
+- **The estimate is a floor, and one case makes it lower than you'd think.**
+  A delegate call that is retried for a schema mismatch reports only the
+  first attempt's cost (the `delegate_finished` hook fires once) — the same
+  under-count the token figures have always had. Donors are never
+  over-charged; they may be slightly under-charged.
+- **Cloud only.** The pool lives on the launch path of the cloud publisher;
+  a local `iterion run` resolves credentials from the local store and never
+  consults it.
+
+## Related
+
+- [cloud-llm-credentials.md](cloud-llm-credentials.md) — the other three tiers.
+- [quotas-and-limits.md](quotas-and-limits.md) — the per-org run/cost caps,
+  which are unrelated and stack on top.
+- [backends.md](backends.md) — which backend can use which credential kind.

--- a/openapi.json
+++ b/openapi.json
@@ -3532,6 +3532,70 @@
         ]
       }
     },
+    "/api/me/pool": {
+      "get": {
+        "operationId": "getMePool",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "GET /api/me/pool",
+        "tags": [
+          "me"
+        ]
+      }
+    },
+    "/api/me/pool/history": {
+      "get": {
+        "operationId": "getMePoolHistory",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "GET /api/me/pool/history",
+        "tags": [
+          "me"
+        ]
+      }
+    },
+    "/api/me/pool/{kind}": {
+      "delete": {
+        "operationId": "deleteMePoolByKind",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "DELETE /api/me/pool/{kind}",
+        "tags": [
+          "me"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "kind",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "put": {
+        "operationId": "putMePoolByKind",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "PUT /api/me/pool/{kind}",
+        "tags": [
+          "me"
+        ]
+      }
+    },
     "/api/me/secrets": {
       "get": {
         "operationId": "getMeSecrets",
@@ -7189,6 +7253,42 @@
           }
         },
         "summary": "PATCH /api/teams/{id}/plugin-sources/{source_id}",
+        "tags": [
+          "teams"
+        ]
+      }
+    },
+    "/api/teams/{id}/pool": {
+      "get": {
+        "operationId": "getTeamsByIdPool",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "GET /api/teams/{id}/pool",
+        "tags": [
+          "teams"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "put": {
+        "operationId": "putTeamsByIdPool",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "PUT /api/teams/{id}/pool",
         "tags": [
           "teams"
         ]

--- a/pkg/backend/cost/cost.go
+++ b/pkg/backend/cost/cost.go
@@ -151,6 +151,32 @@ func Annotate(output map[string]any, model string, inputTokens, outputTokens int
 	return totalTokens
 }
 
+// USDFromOutput reads back the `_cost_usd` key Annotate / AnnotateWithUSD
+// wrote onto a generation output. Returns 0 when the key is absent — which
+// this package deliberately uses to mean "no cost data" (unknown model)
+// rather than "$0", so callers must treat a zero as unknown and not as a
+// measured free call.
+func USDFromOutput(output map[string]any) float64 {
+	if output == nil {
+		return 0
+	}
+	switch v := output["_cost_usd"].(type) {
+	case float64:
+		if v > 0 {
+			return v
+		}
+	case int:
+		if v > 0 {
+			return float64(v)
+		}
+	case int64:
+		if v > 0 {
+			return float64(v)
+		}
+	}
+	return 0
+}
+
 // StaticRate returns the committed fallback rate for a model, and whether the
 // table carries one at all. Exported so the pricing audit can compare what is
 // committed against what the spec aggregator publishes: the two silently

--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -508,7 +508,10 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, task Task) (result Resu
 		detail := strings.TrimSpace(*rm.Result)
 		b.Logger.Error("[%s#%d/claude-code] authentication failed — failing fast: %.160s",
 			task.NodeID, task.Iteration, detail)
-		return result, fmt.Errorf("claude-code: authentication failed (check the forfait CLAUDE_CODE_OAUTH_TOKEN or the Anthropic API key): %s", detail)
+		return result, &ErrAuthFailed{
+			Provider: BackendClaudeCode,
+			Detail:   fmt.Sprintf("check the forfait CLAUDE_CODE_OAUTH_TOKEN or the Anthropic API key: %s", detail),
+		}
 	}
 
 	// Quota / usage-window guard on the RESULT. The forfait's weekly / session /

--- a/pkg/backend/delegate/delegate.go
+++ b/pkg/backend/delegate/delegate.go
@@ -1271,6 +1271,27 @@ func (e *ErrRateLimited) Error() string {
 	return "rate_limited: " + e.Detail
 }
 
+// ErrAuthFailed marks a credential the provider rejected — a dead or
+// expired OAuth token, a revoked API key. Distinct from ErrTransient
+// (retrying cannot revive a dead credential) and from ErrRateLimited
+// (waiting cannot either): the only cure is a new credential.
+//
+// Typed because callers must be able to ACT on it rather than parse prose:
+// the credential pool holds a donor whose subscription keeps being rejected
+// out of rotation, which is not something a message-substring match should
+// decide.
+type ErrAuthFailed struct {
+	Provider string // "claude_code", "codex", …
+	Detail   string // the upstream message, for diagnostics
+}
+
+func (e *ErrAuthFailed) Error() string {
+	if e.Provider != "" {
+		return "authentication failed (" + e.Provider + "): " + e.Detail
+	}
+	return "authentication failed: " + e.Detail
+}
+
 // ErrTransient marks a backend failure the dispatcher should retry
 // (subprocess killed by OOM, peer reset, network blip, …). CLI
 // backends wrap stderr-matched indicators in this type so the executor's

--- a/pkg/backend/delegate/pi.go
+++ b/pkg/backend/delegate/pi.go
@@ -845,10 +845,18 @@ func piClassifyFailure(m pisdk.Message) error {
 		return piRateLimited(msg)
 	case status == 408, status == 409, status >= 500:
 		return &ErrTransient{Provider: BackendPi, Reason: fmt.Sprintf("upstream %d", status), Detail: msg}
-	case status == 401, status == 403, status == 402:
-		// Deterministic: a credential or billing problem. Retrying burns
-		// attempts against a failure that cannot resolve itself.
-		return fmt.Errorf("pi: auth/billing rejected (%d): %s", status, msg)
+	case status == 401, status == 403:
+		// Deterministic: the credential was rejected. Retrying burns
+		// attempts against a failure that cannot resolve itself. Typed so
+		// callers can ACT on it — the credential pool holds a donor whose
+		// subscription keeps being rejected out of rotation, which no
+		// message-substring match should be deciding.
+		return &ErrAuthFailed{Provider: BackendPi, Detail: fmt.Sprintf("upstream %d: %s", status, msg)}
+	case status == 402:
+		// Payment required: the credential is fine, the balance is not.
+		// Deliberately NOT ErrAuthFailed — that would tell a lending donor
+		// to "reconnect", which does not refill an account.
+		return fmt.Errorf("pi: payment required (%d): %s", status, msg)
 	case status >= 400:
 		return fmt.Errorf("pi: upstream %d: %s", status, msg)
 	}

--- a/pkg/backend/model/executor_hooks.go
+++ b/pkg/backend/model/executor_hooks.go
@@ -3,6 +3,7 @@ package model
 import (
 	"time"
 
+	"github.com/SocialGouv/iterion/pkg/backend/cost"
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
 )
 
@@ -35,6 +36,12 @@ type DelegateInfo struct {
 	Error              error         // non-nil for OnDelegateError
 	Attempt            int           // 1-based retry number (for OnDelegateRetry)
 	Delay              time.Duration // backoff delay (for OnDelegateRetry)
+	// CostUSD is the delegation's LLM spend, read back from the `_cost_usd`
+	// the backend annotated onto its output — the CLI's own figure when it
+	// reports one, else the token estimate. Zero means the price table did
+	// not know the model, NOT a free call: observers must skip rather than
+	// record a $0 sample.
+	CostUSD float64
 }
 
 // delegateInfoFromResult fills the result-derived fields of a DelegateInfo —
@@ -52,6 +59,7 @@ func delegateInfoFromResult(backendName string, result delegate.Result) Delegate
 		RawOutputLen:       result.RawOutputLen,
 		ParseFallback:      result.ParseFallback,
 		FormattingPassUsed: result.FormattingPassUsed,
+		CostUSD:            cost.USDFromOutput(result.Output),
 	}
 }
 

--- a/pkg/backend/model/executor_hooks_cost_test.go
+++ b/pkg/backend/model/executor_hooks_cost_test.go
@@ -1,0 +1,47 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+)
+
+// A delegation's cost lives on the result output as `_cost_usd` — the CLI's
+// own figure when it reports one, else the token estimate a subscription
+// session falls back to. DelegateInfo must carry it, because the hook payload
+// is the only path by which a delegate backend's spend reaches the runner's
+// per-run totals (and from there the org cost cap and the credential pool).
+func TestDelegateInfoFromResult_carriesCost(t *testing.T) {
+	cases := []struct {
+		name   string
+		output map[string]any
+		want   float64
+	}{
+		{
+			name:   "priced delegation",
+			output: map[string]any{"_cost_usd": 0.4242, "_tokens": 1200},
+			want:   0.4242,
+		},
+		{
+			// Annotate omits the key when the price table doesn't know the
+			// model. That must read back as "no data" (0), never as a
+			// measured free call.
+			name:   "unpriced model omits the key",
+			output: map[string]any{"_tokens": 1200},
+			want:   0,
+		},
+		{
+			name:   "no output at all",
+			output: nil,
+			want:   0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := delegateInfoFromResult("claude_code", delegate.Result{Output: tc.output})
+			if got.CostUSD != tc.want {
+				t.Errorf("CostUSD = %v, want %v", got.CostUSD, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/backend/model/hooks.go
+++ b/pkg/backend/model/hooks.go
@@ -748,6 +748,11 @@ func (h *storeHooks) onDelegateFinished(nodeID string, info DelegateInfo) {
 		"parse_fallback":       info.ParseFallback,
 		"formatting_pass_used": info.FormattingPassUsed,
 	}
+	// Omitted when the price table did not know the model, so an observer
+	// can tell "no cost data" from a measured $0 by the key's absence.
+	if info.CostUSD > 0 {
+		data["cost_usd"] = info.CostUSD
+	}
 	if h.logger.IsEnabled(iterlog.LevelTrace) && info.Stderr != "" {
 		data["stderr"] = iterlog.Truncate(info.Stderr, maxFieldSize)
 	}

--- a/pkg/cli/remote_pool.go
+++ b/pkg/cli/remote_pool.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/credpool"
+)
+
+// Credential-pool CLI: lending an LLM subscription to the shared pool and
+// watching what it served. The credential itself is never touched here —
+// it was connected once through the OAuth flow and stays sealed
+// server-side; what these commands set are the donor's TERMS.
+
+// PoolPledgeInput is the PUT body of /api/me/pool/{kind}. The ceilings and
+// window are the DOMAIN types, not a wire mirror of them: a second copy of
+// the shape is a second thing to keep in step every time it changes.
+type PoolPledgeInput struct {
+	Enabled bool             `json:"enabled"`
+	Limits  credpool.Limits  `json:"limits"`
+	Window  *credpool.Window `json:"window,omitempty"`
+	Bots    []string         `json:"bots,omitempty"`
+}
+
+// poolPledgeView is the slice of the response the CLI reads back when it
+// needs the CURRENT terms (pause must not silently reset the ceilings a
+// donor set).
+type poolPledgeView struct {
+	Kind    string           `json:"kind"`
+	Enabled bool             `json:"enabled"`
+	Limits  credpool.Limits  `json:"limits"`
+	Window  *credpool.Window `json:"window,omitempty"`
+	Bots    []string         `json:"bots,omitempty"`
+}
+
+// RemotePoolStatus prints the caller's own contributions and what they
+// have served.
+func RemotePoolStatus(ctx context.Context, c *RemoteClient, p *Printer) error {
+	return RemoteGetPrint(ctx, c, p, "/api/me/pool")
+}
+
+// RemotePoolHistory prints what the caller's quota actually ran.
+func RemotePoolHistory(ctx context.Context, c *RemoteClient, p *Printer) error {
+	return RemoteGetPrint(ctx, c, p, "/api/me/pool/history")
+}
+
+// RemotePoolShare creates or updates a contribution.
+func RemotePoolShare(ctx context.Context, c *RemoteClient, p *Printer, kind string, in PoolPledgeInput) error {
+	if kind == "" {
+		return fmt.Errorf("--kind is required (claude_code|codex)")
+	}
+	raw, err := c.Call(ctx, "PUT", "/api/me/pool/"+kind, in, nil)
+	if err != nil {
+		return err
+	}
+	PrintRemoteJSON(p, raw)
+	return nil
+}
+
+// RemotePoolPause flips a contribution off WITHOUT discarding its terms:
+// it reads the stored pledge back and re-sends it with enabled=false, so
+// resuming later does not require the donor to retype their ceilings.
+func RemotePoolPause(ctx context.Context, c *RemoteClient, p *Printer, kind string, enabled bool) error {
+	if kind == "" {
+		return fmt.Errorf("--kind is required (claude_code|codex)")
+	}
+	raw, err := c.Call(ctx, "GET", "/api/me/pool", nil, nil)
+	if err != nil {
+		return err
+	}
+	var body struct {
+		Pledges []poolPledgeView `json:"pledges"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return fmt.Errorf("decode pledges: %w", err)
+	}
+	var current *poolPledgeView
+	for i := range body.Pledges {
+		if body.Pledges[i].Kind == kind {
+			current = &body.Pledges[i]
+			break
+		}
+	}
+	if current == nil {
+		return fmt.Errorf("you have no %s contribution to change", kind)
+	}
+	return RemotePoolShare(ctx, c, p, kind, PoolPledgeInput{
+		Enabled: enabled,
+		Limits:  current.Limits,
+		Window:  current.Window,
+		Bots:    current.Bots,
+	})
+}
+
+// RemotePoolWithdraw removes a contribution entirely.
+func RemotePoolWithdraw(ctx context.Context, c *RemoteClient, p *Printer, kind string) error {
+	if kind == "" {
+		return fmt.Errorf("--kind is required (claude_code|codex)")
+	}
+	return RemoteSendPrint(ctx, c, p, "DELETE", "/api/me/pool/"+kind, nil)
+}
+
+// RemotePoolDonors prints the operator view: the pool's policy and who is
+// lending to it.
+func RemotePoolDonors(ctx context.Context, c *RemoteClient, p *Printer, teamID string) error {
+	return RemoteGetPrint(ctx, c, p, "/api/teams/"+teamID+"/pool")
+}
+
+// LocalTimezone returns the host's IANA zone name so a donor's sharing
+// hours mean what they read on their own clock. Falls back to UTC when the
+// host cannot name its zone (a bare container), which is honest: an
+// unnamed zone would otherwise be silently reinterpreted.
+func LocalTimezone() string {
+	if loc := time.Local.String(); loc != "" && loc != "Local" {
+		return loc
+	}
+	return "UTC"
+}

--- a/pkg/credpool/broker.go
+++ b/pkg/credpool/broker.go
@@ -165,7 +165,7 @@ func (b *Broker) acquireKind(ctx context.Context, pool Pool, candidates []Pledge
 		if p.UserID == req.UserID {
 			continue
 		}
-		if ok, _ := p.Available(now, req.BotID); ok {
+		if ok, _ := p.AvailableForLaunch(now, req.BotID); ok {
 			eligible = append(eligible, p)
 		}
 	}

--- a/pkg/credpool/broker.go
+++ b/pkg/credpool/broker.go
@@ -1,0 +1,689 @@
+package credpool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+// ErrNoDonor is returned by Acquire when no pledge could serve the request.
+// It is an ordinary outcome, not a failure: the caller falls through to
+// whatever it would have done with no pool at all (env credentials, or a
+// visible "no credentials" at the LLM call site). Callers should log it and
+// carry on, never abort the launch on it.
+var ErrNoDonor = errors.New("credpool: no eligible donor")
+
+// Broker selects a donor for a run and closes the loop when it ends.
+//
+// A nil *Broker is a valid "pool disabled" value: every method is
+// nil-receiver-safe, so call sites need no nil checks — the same
+// convention as runtime.DailyCapGuard.
+type Broker struct {
+	pools   PoolStore
+	pledges PledgeStore
+	leases  LeaseStore
+	ledger  Ledger
+	oauth   secrets.OAuthStore
+	sealer  secrets.Sealer
+	logger  *iterlog.Logger
+	now     func() time.Time
+	// leaseTTL bounds an unreported lease. Overridable for tests.
+	leaseTTL time.Duration
+}
+
+// BrokerConfig bundles the Broker's dependencies.
+type BrokerConfig struct {
+	Pools   PoolStore
+	Pledges PledgeStore
+	Leases  LeaseStore
+	Ledger  Ledger
+	// OAuth + Sealer are how a granted pledge becomes an actual credential
+	// blob: the record is stored sealed and bound to its owner, exactly as
+	// for a personal or org forfait.
+	OAuth  secrets.OAuthStore
+	Sealer secrets.Sealer
+	Logger *iterlog.Logger
+	// Now overrides the clock (tests). Defaults to time.Now().UTC().
+	Now func() time.Time
+	// LeaseTTL overrides DefaultLeaseTTL.
+	LeaseTTL time.Duration
+}
+
+// NewBroker builds a Broker. Returns nil — a usable "pool disabled" value —
+// when any store required to serve a credential is missing, so a deployment
+// that never configured a pool simply never has one.
+func NewBroker(cfg BrokerConfig) *Broker {
+	if cfg.Pools == nil || cfg.Pledges == nil || cfg.Leases == nil || cfg.Ledger == nil ||
+		cfg.OAuth == nil || cfg.Sealer == nil {
+		return nil
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = iterlog.New(iterlog.LevelInfo, nil)
+	}
+	if cfg.Now == nil {
+		cfg.Now = func() time.Time { return time.Now().UTC() }
+	}
+	if cfg.LeaseTTL <= 0 {
+		cfg.LeaseTTL = DefaultLeaseTTL
+	}
+	return &Broker{
+		pools: cfg.Pools, pledges: cfg.Pledges, leases: cfg.Leases, ledger: cfg.Ledger,
+		oauth: cfg.OAuth, sealer: cfg.Sealer, logger: cfg.Logger,
+		now: cfg.Now, leaseTTL: cfg.LeaseTTL,
+	}
+}
+
+// Request describes the run asking for a donated credential.
+type Request struct {
+	RunID string
+	// OrgID / TenantID / UserID identify the requester for the audience
+	// check and for the donor's history.
+	OrgID    string
+	TenantID string
+	UserID   string
+	BotID    string
+	// Kinds are the credential kinds that would serve this run, in
+	// preference order. A run asks once for all of them: they share the
+	// same pool, audience and candidate list, so re-resolving per kind
+	// would be the same three queries again for a different in-memory
+	// filter.
+	Kinds []secrets.OAuthKind
+}
+
+// Grant is a served donation.
+type Grant struct {
+	PledgeID string
+	DonorID  string
+	Kind     string
+	// Payload is the verbatim credentials blob, unsealed. The caller seals
+	// it into the run bundle exactly like a personal or org forfait — it
+	// must never be logged, persisted in the clear, or returned over an
+	// API.
+	Payload []byte
+	// RemainingUSD is what was left of the donor's tightest spend cap.
+	// Zero means the donor set no spend cap, NOT "nothing left" — callers
+	// clamping a run budget must treat zero as "no ceiling from the pool".
+	RemainingUSD float64
+}
+
+// Acquire finds a donor for req and records the lease. Returns ErrNoDonor
+// when the pool is off, the requester is out of audience, or no pledge is
+// currently eligible.
+func (b *Broker) Acquire(ctx context.Context, req Request) (*Grant, error) {
+	if b == nil {
+		return nil, ErrNoDonor
+	}
+	if req.RunID == "" {
+		return nil, fmt.Errorf("credpool: acquire without a run id")
+	}
+	if len(req.Kinds) == 0 {
+		return nil, fmt.Errorf("credpool: acquire without a credential kind")
+	}
+	for _, k := range req.Kinds {
+		if !k.Valid() {
+			return nil, fmt.Errorf("credpool: unknown credential kind %q", k)
+		}
+	}
+	now := b.now()
+
+	pool, candidates, err := b.resolvePool(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, kind := range req.Kinds {
+		grant, err := b.acquireKind(ctx, pool, candidates, req, kind, now)
+		if err != nil {
+			return nil, err
+		}
+		if grant != nil {
+			return grant, nil
+		}
+	}
+	return nil, ErrNoDonor
+}
+
+// acquireKind tries one credential kind against an already-resolved
+// candidate list. Returns (nil, nil) when no donor of that kind can serve —
+// the caller falls through to the next kind.
+func (b *Broker) acquireKind(ctx context.Context, pool Pool, candidates []Pledge, req Request, kind secrets.OAuthKind, now time.Time) (*Grant, error) {
+	eligible := make([]Pledge, 0, len(candidates))
+	for _, p := range candidates {
+		if p.Kind != string(kind) {
+			continue
+		}
+		// A donor never serves their own run: they would be lending to
+		// themselves, consuming pool bookkeeping for nothing and skewing
+		// the fairness ranking against the other donors.
+		if p.UserID == req.UserID {
+			continue
+		}
+		if ok, _ := p.Available(now, req.BotID); ok {
+			eligible = append(eligible, p)
+		}
+	}
+	if len(eligible) == 0 {
+		return nil, nil
+	}
+
+	ranked, err := b.rank(ctx, eligible, now)
+	if err != nil {
+		return nil, err
+	}
+
+	// Walk the ranking: a donor whose ledger refuses (raced to their cap,
+	// concurrency full) simply yields to the next.
+	for _, p := range ranked {
+		grant, err := b.tryPledge(ctx, pool, p, req, now)
+		if err != nil {
+			b.logger.Warn("credpool: pledge %s unusable for run %s: %v", p.ID, req.RunID, err)
+			continue
+		}
+		if grant != nil {
+			return grant, nil
+		}
+	}
+	return nil, nil
+}
+
+// resolvePool finds the pool serving this request, with its pledges.
+//
+// Selection scans the ENABLED pools and applies each one's audience,
+// rather than looking up the requester's own org: a pool that opens itself
+// to other teams/orgs — or to contributors wherever they launch from — must
+// be reachable FROM those places, otherwise every audience dial beyond the
+// owning org is unreachable configuration. A deployment runs a handful of
+// pools, so this is a small list, and the requester's own org pool wins
+// when several would serve.
+func (b *Broker) resolvePool(ctx context.Context, req Request) (Pool, []Pledge, error) {
+	pools, err := b.pools.ListEnabled(ctx)
+	if err != nil {
+		return Pool{}, nil, err
+	}
+	if len(pools) == 0 {
+		return Pool{}, nil, ErrNoDonor
+	}
+	// Own-org pool first: a team drawing on its own pool must not be
+	// diverted to a community one that happens to sort earlier.
+	sort.SliceStable(pools, func(i, j int) bool {
+		own := func(p Pool) bool { return req.OrgID != "" && p.OrgID == req.OrgID }
+		if own(pools[i]) != own(pools[j]) {
+			return own(pools[i])
+		}
+		return pools[i].ID < pools[j].ID
+	})
+	now := b.now()
+	for _, pool := range pools {
+		candidates, err := b.pledges.ListByPool(ctx, pool.ID)
+		if err != nil {
+			return Pool{}, nil, err
+		}
+		hasActivePledge := false
+		if pool.Audience.NeedsPledgeLookup() && req.UserID != "" {
+			for _, p := range candidates {
+				if p.UserID != req.UserID {
+					continue
+				}
+				// Reciprocity is earned by an ACTIVE contribution: a donor
+				// who switched their own sharing off stops borrowing too.
+				if ok, _ := p.Available(now, ""); ok {
+					hasActivePledge = true
+					break
+				}
+			}
+		}
+		if pool.Audience.Allows(pool.OrgID, req.OrgID, req.TenantID, req.UserID, hasActivePledge) {
+			return pool, candidates, nil
+		}
+	}
+	return Pool{}, nil, ErrNoDonor
+}
+
+// rank orders eligible pledges by fairness: least consumed today first
+// (as a fraction of what the donor offered, so a small pledge is not
+// drained before a large one), ties broken by least-recently served.
+func (b *Broker) rank(ctx context.Context, eligible []Pledge, now time.Time) ([]Pledge, error) {
+	ids := make([]string, 0, len(eligible))
+	for _, p := range eligible {
+		ids = append(ids, p.ID)
+	}
+	usage, err := b.ledger.UsageMany(ctx, ids, now)
+	if err != nil {
+		return nil, err
+	}
+	score := func(p Pledge) float64 {
+		u := usage[p.ID]
+		switch {
+		case p.Limits.MaxUSDPerDay > 0:
+			return u.CostUSD / p.Limits.MaxUSDPerDay
+		case p.Limits.MaxRunsPerDay > 0:
+			return float64(u.Runs) / float64(p.Limits.MaxRunsPerDay)
+		default:
+			// An uncapped pledge has no ratio to speak of; rank it by raw
+			// spend so it still rotates instead of absorbing everything.
+			return u.CostUSD
+		}
+	}
+	ranked := make([]Pledge, len(eligible))
+	copy(ranked, eligible)
+	sort.SliceStable(ranked, func(i, j int) bool {
+		si, sj := score(ranked[i]), score(ranked[j])
+		if si != sj {
+			return si < sj
+		}
+		li, lj := ranked[i].LastServedAt, ranked[j].LastServedAt
+		switch {
+		case li == nil && lj == nil:
+			return ranked[i].ID < ranked[j].ID
+		case li == nil:
+			return true
+		case lj == nil:
+			return false
+		default:
+			return li.Before(*lj)
+		}
+	})
+	return ranked, nil
+}
+
+// tryPledge attempts one donor: concurrency + ledger admission, then
+// unsealing the credential and recording the lease. Returns (nil, nil) when
+// the donor declined for a quota reason — the caller moves on.
+func (b *Broker) tryPledge(ctx context.Context, pool Pool, p Pledge, req Request, now time.Time) (*Grant, error) {
+	// What this donor already has at stake: the runs they are serving and
+	// the allowance promised to them. Both bound this admission — without
+	// the promised half, ten runs launched together would each be handed
+	// the same "remaining" and could spend it ten times over.
+	//
+	// The asking run's own lease is excluded: a resume re-acquires while
+	// still holding one, and counting it would let a run be refused by
+	// itself.
+	liveRuns, committed, err := b.leases.LiveCommitment(ctx, p.ID, req.RunID, now)
+	if err != nil {
+		return nil, err
+	}
+	live := LiveCommitment{Runs: liveRuns, CommittedUSD: committed}
+
+	// A run this donor already admitted (a resume) renews its allowance
+	// instead of consuming a second unit of "runs per day": it is the same
+	// run, and charging it again would let one flaky run that resumes a few
+	// times eat a contributor's whole day. An ABANDONED attempt does not
+	// count as admitted — nothing ever learned what it spent, so renewing
+	// against it forever would let a crash-looping run draw unmetered.
+	readmitting, err := b.leases.HasServedAttempt(ctx, req.RunID, p.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	var remaining float64
+	var deny DenyReason
+	if readmitting { //nolint:staticcheck // reads better than an inverted condition
+		remaining, deny, err = b.ledger.Renew(ctx, p.ID, now, p.Limits, live)
+	} else {
+		remaining, deny, err = b.ledger.Reserve(ctx, p.ID, now, p.Limits, live)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if deny != DenyNone {
+		b.logger.Debug("credpool: pledge %s declined run %s (%s)", p.ID, req.RunID, deny)
+		return nil, nil
+	}
+
+	// From here on, any failure must give back whatever was consumed.
+	// Renew consumed nothing, so it has nothing to return.
+	release := func() {
+		if !readmitting {
+			b.releaseReservation(ctx, p.ID, now)
+		}
+	}
+
+	rec, err := b.oauth.Get(ctx, p.UserID, secrets.OAuthKind(p.Kind))
+	if err != nil {
+		release()
+		// The donor pledged a credential they since disconnected. Park the
+		// pledge rather than re-discovering this on every launch.
+		if errors.Is(err, secrets.ErrOAuthNotFound) {
+			b.markUnhealthy(ctx, p, HealthTokenExpired, "the connected subscription was disconnected — reconnect it to resume sharing")
+			return nil, nil
+		}
+		return nil, err
+	}
+	// An expired token with no way to renew is dead: the refresh worker
+	// skips it, so it will never come back on its own.
+	if rec.NotRefreshable && rec.AccessTokenExpiresAt != nil && !now.Before(*rec.AccessTokenExpiresAt) {
+		release()
+		b.markUnhealthy(ctx, p, HealthTokenExpired, "the connected subscription expired and carries no refresh token — reconnect it to resume sharing")
+		return nil, nil
+	}
+	payload, err := secrets.OpenOAuthPayload(b.sealer, rec.UserID, rec.Kind, rec.SealedPayload)
+	if err != nil {
+		release()
+		return nil, fmt.Errorf("credpool: unseal donated credential: %w", err)
+	}
+
+	// Supersede whatever was still serving this run. A pod that died
+	// without reporting leaves its lease open; leaving it so would give the
+	// run two open leases, and then "who is serving this run" — hence who
+	// gets charged — is decided by whichever the store happens to return.
+	b.supersedeOpenLeases(ctx, req.RunID, now)
+
+	lease := Lease{
+		ID:              uuid.NewString(),
+		RunID:           req.RunID,
+		PledgeID:        p.ID,
+		PoolID:          pool.ID,
+		DonorID:         p.UserID,
+		Kind:            p.Kind,
+		TenantID:        req.TenantID,
+		RequesterID:     req.UserID,
+		BotID:           req.BotID,
+		GrantedCostUSD:  remaining,
+		ConsumedRunUnit: !readmitting,
+		AcquiredAt:      now,
+		ExpiresAt:       now.Add(b.leaseTTL),
+	}
+	if err := b.leases.Put(ctx, lease); err != nil {
+		release()
+		return nil, fmt.Errorf("credpool: record lease: %w", err)
+	}
+
+	// Best-effort fairness bookkeeping; a miss only costs tie-break
+	// precision on the next selection.
+	if err := b.pledges.TouchLastServed(ctx, p.ID, now); err != nil {
+		b.logger.Warn("credpool: could not stamp last_served_at on pledge %s: %v", p.ID, err)
+	}
+
+	b.logger.Info("credpool: run %s served by donor %s (kind=%s, allowance=$%.2f)", req.RunID, p.UserID, p.Kind, remaining)
+	return &Grant{
+		PledgeID:     p.ID,
+		DonorID:      p.UserID,
+		Kind:         p.Kind,
+		Payload:      payload,
+		RemainingUSD: remaining,
+	}, nil
+}
+
+// supersedeOpenLeases closes any lease still marked as serving this run.
+// Their donors get their slot and committed allowance back; the run unit
+// stays consumed, because those attempts did run. Best-effort: a miss only
+// costs a slot until the lease TTL.
+func (b *Broker) supersedeOpenLeases(ctx context.Context, runID string, now time.Time) {
+	open, err := b.leases.ListOpenByRun(ctx, runID)
+	if err != nil {
+		b.logger.Warn("credpool: could not check the open leases of run %s: %v", runID, err)
+		return
+	}
+	for _, l := range open {
+		if _, cerr := b.leases.Close(ctx, l.ID, l.CostUSD, OutcomeSuperseded, now); cerr != nil {
+			b.logger.Warn("credpool: could not supersede lease %s of run %s: %v", l.ID, runID, cerr)
+		}
+	}
+}
+
+// releaseReservation gives back one admitted-but-unused run unit.
+func (b *Broker) releaseReservation(ctx context.Context, pledgeID string, when time.Time) {
+	if rerr := b.ledger.ReleaseRun(context.WithoutCancel(ctx), pledgeID, when); rerr != nil {
+		b.logger.Warn("credpool: could not release the reserved unit of pledge %s: %v (its daily run count over-reports by one)", pledgeID, rerr)
+	}
+}
+
+// Release undoes an acquisition whose run never started — a launch that
+// failed after the credential was granted (the run document could not be
+// saved, the queue publish failed).
+//
+// Without it the donor keeps paying for a run that never existed: the lease
+// holds a concurrency slot and its promised allowance until the TTL, and
+// the daily run unit is consumed for good, because nothing else ever
+// revisits it. A donor could be locked out for the day by a Mongo blip.
+//
+// Idempotent and best-effort: it is called from error paths that must
+// surface their OWN error, not this one.
+func (b *Broker) Release(ctx context.Context, runID string) {
+	if b == nil || runID == "" {
+		return
+	}
+	ctx = context.WithoutCancel(ctx)
+	lease, err := b.leases.GetOpenByRun(ctx, runID)
+	if err != nil {
+		if !errors.Is(err, ErrNotFound) {
+			b.logger.Warn("credpool: could not look up the lease of abandoned run %s: %v", runID, err)
+		}
+		return
+	}
+	won, err := b.leases.Close(ctx, lease.ID, 0, OutcomeNotLaunched, b.now())
+	if err != nil {
+		b.logger.Warn("credpool: could not release the lease of abandoned run %s: %v", runID, err)
+		return
+	}
+	if !won {
+		return
+	}
+	// Only an admission that TOOK a run unit gives one back. A resume
+	// renewed rather than consumed, so refunding it would mint quota out of
+	// a failed launch and let the donor be drawn on past their own ceiling.
+	if lease.ConsumedRunUnit {
+		b.releaseReservation(ctx, lease.PledgeID, lease.AcquiredAt)
+	}
+	b.logger.Info("credpool: run %s never launched — returned donor %s's admission", runID, lease.DonorID)
+}
+
+// Outcome is what a finished attempt reports back to the pool.
+//
+// Condition is pre-classified by the caller rather than derived here: the
+// backend error types live in pkg/backend/delegate, and the runner already
+// classifies them for its usage-window retry. Keeping that knowledge at the
+// boundary leaves this package a pure domain — stores, limits, fairness —
+// with no dependency on the execution stack.
+type Outcome struct {
+	CostUSD      float64
+	InputTokens  int64
+	OutputTokens int64
+	Condition    Condition
+	// CooldownUntil is the provider's own reset instant, when the caller
+	// could parse one from ConditionUsageWindow. Zero falls back to a
+	// bounded blind wait.
+	CooldownUntil time.Time
+}
+
+// Condition is the part of an attempt's outcome that changes a donor's
+// availability.
+type Condition string
+
+const (
+	// ConditionOK — the credential worked; nothing to do but charge it.
+	ConditionOK Condition = ""
+	// ConditionUsageWindow — the provider's subscription quota window is
+	// exhausted. Waiting is the only cure, so the donor rests until reset.
+	ConditionUsageWindow Condition = "usage_window"
+	// ConditionAuthFailed — the provider rejected the credential.
+	ConditionAuthFailed Condition = "auth_failed"
+)
+
+// Report closes a run's lease: it charges the donor's ledger, frees the
+// concurrency slot, and applies whatever the outcome says about the
+// donor's availability. Idempotent — a redelivered report finds the lease
+// already closed and does nothing.
+//
+// Never returns an error for "this run had no lease": most runs don't.
+func (b *Broker) Report(ctx context.Context, runID string, out Outcome) error {
+	if b == nil || runID == "" {
+		return nil
+	}
+	lease, err := b.leases.GetOpenByRun(ctx, runID)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil
+		}
+		return err
+	}
+	now := b.now()
+
+	outcome := "ok"
+	switch out.Condition {
+	case ConditionUsageWindow:
+		outcome = string(ConditionUsageWindow)
+	case ConditionAuthFailed:
+		outcome = string(ConditionAuthFailed)
+	}
+
+	// Close FIRST, and charge only if this call is the one that closed it.
+	// A run can be reported twice — a redelivery whose first pod was merely
+	// slow, a cancel racing a finish — and reading "still open" then
+	// charging would debit the donor once per report. The CAS is the
+	// arbiter: exactly one caller wins it, exactly one charge lands.
+	won, err := b.leases.Close(ctx, lease.ID, out.CostUSD, outcome, now)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil
+		}
+		return fmt.Errorf("credpool: close lease: %w", err)
+	}
+	if !won {
+		return nil // another report got there first; it did the charging
+	}
+
+	if out.CostUSD > 0 || out.InputTokens > 0 || out.OutputTokens > 0 {
+		// Charged against the lease's ACQUISITION instant, not now: a run
+		// that starts at 23:50 and ends at 00:10 must debit the day whose
+		// allowance admitted it, or the donor's daily cap silently leaks
+		// across the boundary.
+		if err := b.ledger.AddSpend(ctx, lease.PledgeID, lease.AcquiredAt, out.CostUSD, out.InputTokens, out.OutputTokens); err != nil {
+			// The lease is already closed, so this spend will never be
+			// retried — say so loudly rather than under-reporting a
+			// donation in silence.
+			b.logger.Error("credpool: run %s spent $%.4f on donor %s but the charge failed: %v (their ledger under-reports it)", runID, out.CostUSD, lease.DonorID, err)
+			return fmt.Errorf("credpool: charge donor: %w", err)
+		}
+	}
+
+	switch out.Condition {
+	case ConditionUsageWindow:
+		b.applyCooldown(ctx, lease.PledgeID, out.CooldownUntil, now)
+	case ConditionAuthFailed:
+		b.noteAuthFailure(ctx, lease.PledgeID)
+	default:
+		b.clearAuthFailures(ctx, lease.PledgeID)
+	}
+	return nil
+}
+
+// ReleaseExpired closes leases whose run never reported. Returns how many
+// were freed. Without it a pod killed mid-run would hold a donor's
+// concurrency slot until the lease document is evicted.
+func (b *Broker) ReleaseExpired(ctx context.Context, limit int) (int, error) {
+	if b == nil {
+		return 0, nil
+	}
+	now := b.now()
+	expired, err := b.leases.ListExpired(ctx, now, limit)
+	if err != nil {
+		return 0, err
+	}
+	freed := 0
+	for _, l := range expired {
+		// No spend is charged: the run never told us what it consumed, and
+		// inventing a number would misreport the donor's contribution in
+		// the direction that costs them. The run WAS served, so its unit of
+		// the daily run quota stays consumed — unlike Release, which undoes
+		// an admission whose run never started.
+		won, err := b.leases.Close(ctx, l.ID, 0, OutcomeAbandoned, now)
+		if err != nil {
+			b.logger.Warn("credpool: could not close abandoned lease %s: %v", l.ID, err)
+			continue
+		}
+		if !won {
+			continue
+		}
+		freed++
+		b.logger.Warn("credpool: lease for run %s expired without a report — freed donor %s's slot (spend unaccounted)", l.RunID, l.DonorID)
+	}
+	return freed, nil
+}
+
+// ---------------------------------------------------------------------------
+// Donor availability transitions
+// ---------------------------------------------------------------------------
+
+// authFailureThreshold is how many consecutive rejected-credential
+// outcomes park a pledge. Two, not one: a single blip (a provider hiccup,
+// a token mid-refresh) must not evict a donor who did nothing wrong.
+const authFailureThreshold = 2
+
+// blindCooldown is the rest imposed when the provider says a window is
+// exhausted but not when it reopens. Bounded and short-ish: one wasted
+// selection an hour beats both guessing a week and re-hitting the same
+// wall on every launch. Mirrors the runner's usageWindowBlindWait.
+const blindCooldown = time.Hour
+
+// applyCooldown holds the donor out until the provider's window resets.
+func (b *Broker) applyCooldown(ctx context.Context, pledgeID string, until, now time.Time) {
+	if !until.IsZero() {
+		// Come back just after the reset, not exactly on it.
+		until = until.Add(time.Minute)
+	}
+	// Also covers a reset instant that parses into the past — the provider's
+	// notice may name a zone the parser read as UTC, and a cooldown already
+	// elapsed is no cooldown at all.
+	if until.IsZero() || !until.After(now) {
+		until = now.Add(blindCooldown)
+	}
+	p, gerr := b.pledges.Get(ctx, pledgeID)
+	if gerr != nil {
+		b.logger.Warn("credpool: cannot apply cooldown to pledge %s: %v", pledgeID, gerr)
+		return
+	}
+	p.CooldownUntil = &until
+	if uerr := b.pledges.Upsert(ctx, p); uerr != nil {
+		b.logger.Warn("credpool: cannot persist cooldown for pledge %s: %v", pledgeID, uerr)
+		return
+	}
+	b.logger.Info("credpool: donor %s hit their provider quota window — resting until %s", p.UserID, until.Format(time.RFC3339))
+}
+
+// noteAuthFailure counts a rejected credential and parks the pledge once
+// the failures are no longer plausibly transient.
+func (b *Broker) noteAuthFailure(ctx context.Context, pledgeID string) {
+	p, err := b.pledges.Get(ctx, pledgeID)
+	if err != nil {
+		return
+	}
+	p.ConsecutiveAuthFailures++
+	if p.ConsecutiveAuthFailures >= authFailureThreshold {
+		p.Health = HealthAuthFailed
+		p.HealthDetail = "the provider rejected this subscription on consecutive runs — reconnect it to resume sharing"
+		b.logger.Warn("credpool: donor %s's credential was rejected %d times — held out of the pool", p.UserID, p.ConsecutiveAuthFailures)
+	}
+	if err := b.pledges.Upsert(ctx, p); err != nil {
+		b.logger.Warn("credpool: cannot persist auth failure for pledge %s: %v", pledgeID, err)
+	}
+}
+
+// clearAuthFailures resets the counter after a run that authenticated
+// fine, so unrelated failures spread over weeks never accumulate into an
+// eviction.
+func (b *Broker) clearAuthFailures(ctx context.Context, pledgeID string) {
+	p, err := b.pledges.Get(ctx, pledgeID)
+	if err != nil || p.ConsecutiveAuthFailures == 0 {
+		return
+	}
+	p.ConsecutiveAuthFailures = 0
+	if err := b.pledges.Upsert(ctx, p); err != nil {
+		b.logger.Warn("credpool: cannot reset auth failures for pledge %s: %v", pledgeID, err)
+	}
+}
+
+func (b *Broker) markUnhealthy(ctx context.Context, p Pledge, h Health, detail string) {
+	p.Health = h
+	p.HealthDetail = detail
+	if err := b.pledges.Upsert(ctx, p); err != nil {
+		b.logger.Warn("credpool: cannot mark pledge %s as %s: %v", p.ID, h, err)
+	}
+}

--- a/pkg/credpool/broker_integrity_test.go
+++ b/pkg/credpool/broker_integrity_test.go
@@ -1,0 +1,454 @@
+package credpool
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// Regressions for defects an adversarial review found in the accounting.
+// Each one silently spent or withheld a contributor's quota, which is the
+// only kind of bug this feature cannot ship with.
+
+// A run can be reported twice — a redelivery whose first pod was merely
+// slow, a cancel racing a finish. Reading "still open" and then charging
+// debits the donor once per report; the close CAS has to be the arbiter.
+func TestReport_secondReportDoesNotChargeAgain(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxUSDPerDay: 10})
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+
+	// Two reports racing: both observed the lease open before either
+	// closed it. Simulated by reporting twice — the first closes.
+	for i := 0; i < 2; i++ {
+		if err := h.broker.Report(ctx, "run-1", Outcome{CostUSD: 2}); err != nil {
+			t.Fatalf("Report %d: %v", i, err)
+		}
+	}
+	day, _, _ := h.ledger.Usage(ctx, PledgeID("alice", "claude_code"), h.now)
+	if day.CostUSD != 2 {
+		t.Errorf("donor charged %v, want 2 — a second report double-charged them", day.CostUSD)
+	}
+}
+
+// A run that resumes is the SAME run. Counting a fresh unit of "runs per
+// day" for every attempt let one flaky run eat a contributor's whole day.
+func TestAcquire_resumeDoesNotConsumeASecondRunUnit(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxRunsPerDay: 2})
+
+	// One run, admitted then resumed three times.
+	for i := 0; i < 4; i++ {
+		if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+			t.Fatalf("acquire attempt %d: %v", i, err)
+		}
+	}
+	day, _, _ := h.ledger.Usage(ctx, PledgeID("alice", "claude_code"), h.now)
+	if day.Runs != 1 {
+		t.Errorf("day runs = %d, want 1 — resuming re-consumed the donor's run quota", day.Runs)
+	}
+	// And the donor's second genuine run is still available to someone else.
+	if _, err := h.broker.Acquire(ctx, h.request("run-2")); err != nil {
+		t.Errorf("a genuinely new run was refused: %v", err)
+	}
+}
+
+// Concurrent launches used to each read the same "remaining" and each be
+// granted it in full: N runs could spend the daily cap N times over. The
+// allowance already promised to live leases must count against the next.
+func TestAcquire_inFlightAllowanceIsNotHandedOutTwice(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxUSDPerDay: 5})
+
+	first, err := h.broker.Acquire(ctx, h.request("run-1"))
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	if first.RemainingUSD != 5 {
+		t.Fatalf("first allowance = %v, want the full 5", first.RemainingUSD)
+	}
+	// Nothing has been REPORTED yet — the whole cap is promised to run-1.
+	if _, err := h.broker.Acquire(ctx, h.request("run-2")); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("second Acquire = %v, want ErrNoDonor — the donor's cap was promised twice", err)
+	}
+
+	// Once run-1 reports well under its allowance, the rest is lendable.
+	if err := h.broker.Report(ctx, "run-1", Outcome{CostUSD: 1}); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	third, err := h.broker.Acquire(ctx, h.request("run-3"))
+	if err != nil {
+		t.Fatalf("third Acquire: %v", err)
+	}
+	if third.RemainingUSD != 4 {
+		t.Errorf("allowance after a $1 run = %v, want 4", third.RemainingUSD)
+	}
+}
+
+// An exhausted donor must be refused, never granted an allowance of 0 —
+// zero on the wire means "no ceiling", so handing it out would turn a
+// spent contributor into an unlimited one.
+func TestAcquire_exhaustedDonorIsRefusedNotGrantedZero(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxUSDPerDay: 5})
+	if err := h.ledger.AddSpend(ctx, PledgeID("alice", "claude_code"), h.now, 5, 0, 0); err != nil {
+		t.Fatalf("seed spend: %v", err)
+	}
+	grant, err := h.broker.Acquire(ctx, h.request("run-1"))
+	if !errors.Is(err, ErrNoDonor) {
+		t.Fatalf("Acquire = (%+v, %v), want ErrNoDonor", grant, err)
+	}
+}
+
+// A launch that fails after the credential was granted must give the
+// admission back: the run never happened, so it must not cost the donor a
+// slot, an allowance, or a unit of their daily quota.
+func TestRelease_returnsAnAdmissionWhoseRunNeverStarted(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxRunsPerDay: 1, MaxUSDPerDay: 5, MaxConcurrentRuns: 1})
+
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	h.broker.Release(ctx, "run-1")
+
+	day, _, _ := h.ledger.Usage(ctx, PledgeID("alice", "claude_code"), h.now)
+	if day.Runs != 0 {
+		t.Errorf("day runs = %d, want 0 — the donor paid for a run that never launched", day.Runs)
+	}
+	grant, err := h.broker.Acquire(ctx, h.request("run-2"))
+	if err != nil {
+		t.Fatalf("the donor stayed locked out after a failed launch: %v", err)
+	}
+	if grant.RemainingUSD != 5 {
+		t.Errorf("allowance = %v, want the full 5 back", grant.RemainingUSD)
+	}
+}
+
+// Release is called from error paths that must surface their own error, so
+// it has to tolerate every shape of "nothing to release".
+func TestRelease_isSafeOnAnythingElse(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{})
+	h.broker.Release(ctx, "")            // no run
+	h.broker.Release(ctx, "run-unknown") // never acquired
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := h.broker.Report(ctx, "run-1", Outcome{CostUSD: 1}); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	h.broker.Release(ctx, "run-1") // already closed — must not refund
+	day, _, _ := h.ledger.Usage(ctx, PledgeID("alice", "claude_code"), h.now)
+	if day.Runs != 1 {
+		t.Errorf("day runs = %d, want 1 — a released-after-report run gave back a unit it had used", day.Runs)
+	}
+}
+
+// The donor's record of a run is the only place their charge is
+// explainable. A resume onto a DIFFERENT donor used to overwrite it,
+// leaving money on the first donor's ledger with nothing to account for it.
+func TestAcquire_resumeOnAnotherDonorKeepsTheFirstOnesRecord(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxUSDPerDay: 5})
+	h.donor(t, "bob", Limits{MaxUSDPerDay: 5})
+
+	first, err := h.broker.Acquire(ctx, h.request("run-1"))
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	if err := h.broker.Report(ctx, "run-1", Outcome{
+		CostUSD: 2, Condition: ConditionUsageWindow, CooldownUntil: h.now.Add(3 * time.Hour),
+	}); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+
+	// The first donor is now resting, so the resume lands on the other.
+	second, err := h.broker.Acquire(ctx, h.request("run-1"))
+	if err != nil {
+		t.Fatalf("resume Acquire: %v", err)
+	}
+	if second.DonorID == first.DonorID {
+		t.Fatalf("resume picked the resting donor %q", second.DonorID)
+	}
+
+	// The first donor's history must still explain their $2.
+	history, err := h.leases.ListByDonor(ctx, first.DonorID, 10)
+	if err != nil {
+		t.Fatalf("history: %v", err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("first donor has %d lease(s), want 1 — their record was overwritten", len(history))
+	}
+	if history[0].CostUSD != 2 || history[0].RunID != "run-1" {
+		t.Errorf("record = (run %q, $%v), want (run-1, $2)", history[0].RunID, history[0].CostUSD)
+	}
+	day, _, _ := h.ledger.Usage(ctx, PledgeID(first.DonorID, "claude_code"), h.now)
+	if day.CostUSD != 2 {
+		t.Errorf("first donor's ledger = %v, want 2 (and it must match their history)", day.CostUSD)
+	}
+}
+
+// Reporting a run whose lease moved to another donor must charge the donor
+// that actually served the attempt.
+func TestReport_chargesTheDonorServingTheCurrentAttempt(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxUSDPerDay: 5})
+	h.donor(t, "bob", Limits{MaxUSDPerDay: 5})
+
+	first, _ := h.broker.Acquire(ctx, h.request("run-1"))
+	_ = h.broker.Report(ctx, "run-1", Outcome{
+		CostUSD: 1, Condition: ConditionUsageWindow, CooldownUntil: h.now.Add(3 * time.Hour),
+	})
+	second, err := h.broker.Acquire(ctx, h.request("run-1"))
+	if err != nil {
+		t.Fatalf("resume Acquire: %v", err)
+	}
+	if err := h.broker.Report(ctx, "run-1", Outcome{CostUSD: 3}); err != nil {
+		t.Fatalf("second Report: %v", err)
+	}
+
+	firstDay, _, _ := h.ledger.Usage(ctx, PledgeID(first.DonorID, "claude_code"), h.now)
+	secondDay, _, _ := h.ledger.Usage(ctx, PledgeID(second.DonorID, "claude_code"), h.now)
+	if firstDay.CostUSD != 1 {
+		t.Errorf("%s charged %v, want 1 (only their own attempt)", first.DonorID, firstDay.CostUSD)
+	}
+	if secondDay.CostUSD != 3 {
+		t.Errorf("%s charged %v, want 3 (the attempt they served)", second.DonorID, secondDay.CostUSD)
+	}
+}
+
+// The sweeper frees an abandoned run's slot but must NOT refund its run
+// unit: that run was served, whatever it failed to report.
+func TestReleaseExpired_keepsTheRunUnitOfAServedRun(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxRunsPerDay: 2, MaxConcurrentRuns: 1})
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	h.now = h.now.Add(DefaultLeaseTTL + time.Minute)
+	if _, err := h.broker.ReleaseExpired(ctx, 10); err != nil {
+		t.Fatalf("ReleaseExpired: %v", err)
+	}
+	day, _, _ := h.ledger.Usage(ctx, PledgeID("alice", "claude_code"), h.now.Add(-DefaultLeaseTTL-time.Minute))
+	if day.Runs != 1 {
+		t.Errorf("day runs = %d, want 1 — a served run's quota was refunded", day.Runs)
+	}
+}
+
+// A donor serving a resumed run must not be blocked by their own
+// concurrency cap: the run holds one lease, which is its own.
+func TestAcquire_resumeIsNotBlockedByItsOwnConcurrencySlot(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxConcurrentRuns: 1})
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Errorf("resume was refused by its own lease: %v", err)
+	}
+}
+
+func TestLimitsDeny_countsCommittedSpend(t *testing.T) {
+	lim := Limits{MaxUSDPerDay: 10}
+	// $6 spent, $5 promised to a live run → the next admission would put
+	// the donor over, so it must be refused rather than granted $4.
+	if _, deny := decide(lim, 1, 6, 0, LiveCommitment{CommittedUSD: 5}); deny != DenyCostPerDay {
+		t.Errorf("deny = %q, want cost_per_day", deny)
+	}
+	if remaining, deny := decide(lim, 1, 6, 0, LiveCommitment{}); deny != DenyNone || remaining != 4 {
+		t.Errorf("decide = (%v, %q), want (4, none)", remaining, deny)
+	}
+}
+
+func TestBrokerRelease_nilIsSafe(t *testing.T) {
+	var b *Broker
+	b.Release(context.Background(), "run-1")
+}
+
+// Round-2 regressions: defects found in the round-1 FIXES themselves.
+
+// A pod killed mid-run leaves its lease open. If the resume then acquires a
+// different donor, the run holds two open leases and "who is serving it" —
+// hence who gets charged — was decided by whichever the store happened to
+// return first (a randomised map iteration in memory). Acquiring must
+// supersede what it replaces.
+func TestAcquire_supersedesAnOrphanedOpenLease(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxUSDPerDay: 5})
+	h.donor(t, "bob", Limits{MaxUSDPerDay: 5})
+
+	first, err := h.broker.Acquire(ctx, h.request("run-1"))
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	// No Report — the pod died. Park the first donor so the resume must
+	// pick the other one.
+	p, _ := h.pledges.Get(ctx, PledgeID(first.DonorID, "claude_code"))
+	p.Health = HealthAuthFailed
+	if err := h.pledges.Upsert(ctx, p); err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	second, err := h.broker.Acquire(ctx, h.request("run-1"))
+	if err != nil {
+		t.Fatalf("resume Acquire: %v", err)
+	}
+	if second.DonorID == first.DonorID {
+		t.Fatalf("resume picked the parked donor %q", second.DonorID)
+	}
+
+	open, err := h.leases.ListOpenByRun(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(open) != 1 {
+		t.Fatalf("run-1 holds %d open leases, want 1 — the charged donor would be arbitrary", len(open))
+	}
+	if open[0].DonorID != second.DonorID {
+		t.Errorf("open lease belongs to %q, want the donor now serving (%q)", open[0].DonorID, second.DonorID)
+	}
+
+	// And the report charges that donor, not the orphan.
+	if err := h.broker.Report(ctx, "run-1", Outcome{CostUSD: 3}); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	orphan, _, _ := h.ledger.Usage(ctx, PledgeID(first.DonorID, "claude_code"), h.now)
+	serving, _, _ := h.ledger.Usage(ctx, PledgeID(second.DonorID, "claude_code"), h.now)
+	if orphan.CostUSD != 0 {
+		t.Errorf("%s was charged %v for work they did not serve", first.DonorID, orphan.CostUSD)
+	}
+	if serving.CostUSD != 3 {
+		t.Errorf("%s charged %v, want 3", second.DonorID, serving.CostUSD)
+	}
+}
+
+// Re-admitting a donor used to overwrite the finished attempt's record,
+// which both erased the evidence for a charge already on their ledger and
+// re-opened the lease — re-arming the close CAS so a redelivered report
+// could charge a second time.
+func TestAcquire_readmissionKeepsTheFinishedAttemptsRecord(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxUSDPerDay: 10})
+
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := h.broker.Report(ctx, "run-1", Outcome{CostUSD: 2}); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("resume Acquire: %v", err)
+	}
+
+	hist, _ := h.leases.ListByDonor(ctx, "alice", 10)
+	if len(hist) != 2 {
+		t.Fatalf("history = %d lease(s), want 2 (one per attempt)", len(hist))
+	}
+	var charged int
+	for _, l := range hist {
+		if l.Closed && l.CostUSD == 2 {
+			charged++
+		}
+	}
+	if charged != 1 {
+		t.Errorf("the finished attempt's $2 record is gone — the donor's ledger no longer reconciles")
+	}
+
+	// A redelivery of the FIRST attempt must not charge again.
+	if err := h.broker.Report(ctx, "run-1", Outcome{CostUSD: 2}); err != nil {
+		t.Fatalf("second Report: %v", err)
+	}
+	day, _, _ := h.ledger.Usage(ctx, PledgeID("alice", "claude_code"), h.now)
+	if day.CostUSD != 4 {
+		// 2 (attempt 1) + 2 (attempt 2, legitimately reported) = 4.
+		t.Errorf("charged %v, want 4", day.CostUSD)
+	}
+}
+
+// Releasing a RESUME must not hand back a run unit it never took: that
+// would mint quota out of a failed launch and let the donor be drawn on
+// past the ceiling they set.
+func TestRelease_doesNotRefundARenewedAdmission(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxRunsPerDay: 1})
+
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil { // resume
+		t.Fatalf("resume Acquire: %v", err)
+	}
+	h.broker.Release(ctx, "run-1") // the resume's launch failed
+
+	day, _, _ := h.ledger.Usage(ctx, PledgeID("alice", "claude_code"), h.now)
+	if day.Runs != 1 {
+		t.Errorf("day runs = %d, want 1 — releasing a resume refunded a unit it never took", day.Runs)
+	}
+	// The donor's 1-run-per-day ceiling still holds.
+	if _, err := h.broker.Acquire(ctx, h.request("run-2")); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("a second run was admitted past a MaxRunsPerDay=1 pledge: %v", err)
+	}
+}
+
+// A run whose attempts keep being abandoned (crash-looping pod) must be
+// charged as new each time, not renew forever against a record that never
+// learned what it spent.
+func TestAcquire_abandonedAttemptDoesNotEarnAFreeReadmission(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxRunsPerDay: 2})
+
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	h.now = h.now.Add(DefaultLeaseTTL + time.Minute)
+	if _, err := h.broker.ReleaseExpired(ctx, 10); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	// Same run, new attempt: the previous one told us nothing, so it counts.
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("second Acquire: %v", err)
+	}
+	day, _, _ := h.ledger.Usage(ctx, PledgeID("alice", "claude_code"), h.now)
+	if day.Runs != 1 {
+		t.Fatalf("day runs = %d on the new day, want 1", day.Runs)
+	}
+	prior, _, _ := h.ledger.Usage(ctx, PledgeID("alice", "claude_code"), h.now.Add(-DefaultLeaseTTL-time.Minute))
+	if prior.Runs != 1 {
+		t.Errorf("the abandoned attempt's unit = %d, want 1 (it was served)", prior.Runs)
+	}
+}
+
+// The memory store is the semantic reference; an empty excludeRunID must
+// mean "exclude nothing", not "skip every lease with an empty run id".
+func TestLiveCommitment_emptyExcludeCountsEverything(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxUSDPerDay: 5})
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	runs, committed, err := h.leases.LiveCommitment(ctx, PledgeID("alice", "claude_code"), "", h.now)
+	if err != nil {
+		t.Fatalf("LiveCommitment: %v", err)
+	}
+	if runs != 1 || committed != 5 {
+		t.Errorf("LiveCommitment = (%d, %v), want (1, 5)", runs, committed)
+	}
+}

--- a/pkg/credpool/broker_integrity_test.go
+++ b/pkg/credpool/broker_integrity_test.go
@@ -452,3 +452,54 @@ func TestLiveCommitment_emptyExcludeCountsEverything(t *testing.T) {
 		t.Errorf("LiveCommitment = (%d, %v), want (1, 5)", runs, committed)
 	}
 }
+
+// A donor who restricted their contribution to certain bots must not have
+// it handed to an inline workflow. `LaunchSpec.BotID` is empty for every
+// plain `.bot` run — a file the requester uploaded — so treating empty as
+// "no filter" on the launch path failed OPEN on the one input the
+// requester fully controls.
+func TestAcquire_botAllowListFailsClosedForAnInlineWorkflow(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{}, func(p *Pledge) { p.Bots = []string{"review-pr"} })
+
+	inline := h.request("run-1")
+	inline.BotID = "" // an uploaded .bot: no catalog id
+	if _, err := h.broker.Acquire(ctx, inline); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("Acquire = %v, want ErrNoDonor — an inline workflow got a bot-restricted contribution", err)
+	}
+
+	// A bot outside the list is refused too, and the allowed one is served.
+	other := h.request("run-2")
+	other.BotID = "feature-dev"
+	if _, err := h.broker.Acquire(ctx, other); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("Acquire = %v, want ErrNoDonor for a bot outside the list", err)
+	}
+	allowed := h.request("run-3")
+	allowed.BotID = "review-pr"
+	if _, err := h.broker.Acquire(ctx, allowed); err != nil {
+		t.Errorf("the allow-listed bot was refused: %v", err)
+	}
+
+	// A pledge with NO allow-list still serves an inline workflow.
+	h2 := newHarness(t)
+	h2.donor(t, "bob", Limits{})
+	open := h2.request("run-1")
+	open.BotID = ""
+	if _, err := h2.broker.Acquire(ctx, open); err != nil {
+		t.Errorf("an unrestricted pledge refused an inline workflow: %v", err)
+	}
+}
+
+// The display form keeps its meaning: asking "is this pledge available at
+// all" must not report a bot-restricted contribution as filtered.
+func TestAvailable_emptyBotIDStillMeansIgnoreTheFilterForDisplay(t *testing.T) {
+	p := Pledge{Enabled: true, Health: HealthOK, Bots: []string{"review-pr"}}
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	if ok, status := p.Available(now, ""); !ok {
+		t.Errorf("Available = (%v, %s), want available — the status view asks with no bot", ok, status)
+	}
+	if ok, _ := p.AvailableForLaunch(now, ""); ok {
+		t.Error("AvailableForLaunch must fail closed on an empty bot id")
+	}
+}

--- a/pkg/credpool/broker_test.go
+++ b/pkg/credpool/broker_test.go
@@ -1,0 +1,717 @@
+package credpool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+type harness struct {
+	broker  *Broker
+	pools   *MemoryPoolStore
+	pledges *MemoryPledgeStore
+	leases  *MemoryLeaseStore
+	ledger  *MemoryLedger
+	oauth   *secrets.MemoryOAuthStore
+	sealer  secrets.Sealer
+	now     time.Time
+}
+
+const testOrg = "org-1"
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+	h := &harness{
+		pools:   NewMemoryPoolStore(),
+		pledges: NewMemoryPledgeStore(),
+		leases:  NewMemoryLeaseStore(),
+		ledger:  NewMemoryLedger(),
+		oauth:   secrets.NewMemoryOAuthStore(),
+		now:     time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC),
+	}
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	h.sealer = sealer
+	h.broker = NewBroker(BrokerConfig{
+		Pools: h.pools, Pledges: h.pledges, Leases: h.leases, Ledger: h.ledger,
+		OAuth: h.oauth, Sealer: sealer,
+		Logger: iterlog.New(iterlog.LevelError, nil),
+		Now:    func() time.Time { return h.now },
+	})
+	if h.broker == nil {
+		t.Fatal("NewBroker returned nil with every dependency wired")
+	}
+	if err := h.pools.Upsert(context.Background(), Pool{ID: "pool-1", OrgID: testOrg, Enabled: true}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	return h
+}
+
+func (h *harness) donor(t *testing.T, userID string, lim Limits, mutate ...func(*Pledge)) Pledge {
+	t.Helper()
+	ctx := context.Background()
+	// A real sealed credential, shaped like the blob Claude Code writes —
+	// the broker must unseal exactly what the OAuth store holds.
+	blob, _ := json.Marshal(map[string]any{
+		"claudeAiOauth": map[string]any{"accessToken": "sk-ant-oat-" + userID},
+	})
+	sealed, err := secrets.SealOAuthPayload(h.sealer, userID, secrets.OAuthKindClaudeCode, blob)
+	if err != nil {
+		t.Fatalf("seal donor credential: %v", err)
+	}
+	if err := h.oauth.Upsert(ctx, secrets.OAuthRecord{
+		UserID: userID, Kind: secrets.OAuthKindClaudeCode, SealedPayload: sealed,
+	}); err != nil {
+		t.Fatalf("seed oauth: %v", err)
+	}
+	p := Pledge{
+		ID: PledgeID(userID, string(secrets.OAuthKindClaudeCode)), PoolID: "pool-1",
+		UserID: userID, Kind: string(secrets.OAuthKindClaudeCode),
+		Enabled: true, Health: HealthOK, Limits: lim,
+	}
+	for _, m := range mutate {
+		m(&p)
+	}
+	if err := h.pledges.Upsert(ctx, p); err != nil {
+		t.Fatalf("seed pledge: %v", err)
+	}
+	return p
+}
+
+func (h *harness) request(runID string) Request {
+	return Request{
+		RunID: runID, OrgID: testOrg, TenantID: "team-1", UserID: "requester",
+		BotID: "docs-refresh", Kinds: []secrets.OAuthKind{secrets.OAuthKindClaudeCode},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestBroker_nilIsDisabled(t *testing.T) {
+	var b *Broker
+	if _, err := b.Acquire(context.Background(), Request{RunID: "r"}); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("nil broker Acquire = %v, want ErrNoDonor", err)
+	}
+	if err := b.Report(context.Background(), "r", Outcome{}); err != nil {
+		t.Errorf("nil broker Report = %v, want nil", err)
+	}
+	if n, err := b.ReleaseExpired(context.Background(), 10); n != 0 || err != nil {
+		t.Errorf("nil broker ReleaseExpired = (%d, %v), want (0, nil)", n, err)
+	}
+}
+
+func TestBroker_acquireServesTheDonorsRealCredential(t *testing.T) {
+	h := newHarness(t)
+	h.donor(t, "alice", Limits{MaxUSDPerDay: 5})
+
+	grant, err := h.broker.Acquire(context.Background(), h.request("run-1"))
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if grant.DonorID != "alice" {
+		t.Errorf("donor = %q, want alice", grant.DonorID)
+	}
+	// The payload must be the donor's actual blob, unsealed — not a stub
+	// the test handed in. This is what ends up in the run bundle.
+	var got map[string]map[string]string
+	if err := json.Unmarshal(grant.Payload, &got); err != nil {
+		t.Fatalf("granted payload is not the stored credential JSON: %v", err)
+	}
+	if got["claudeAiOauth"]["accessToken"] != "sk-ant-oat-alice" {
+		t.Errorf("granted token = %q, want alice's", got["claudeAiOauth"]["accessToken"])
+	}
+	if grant.RemainingUSD != 5 {
+		t.Errorf("allowance = %v, want the full 5 (nothing spent yet)", grant.RemainingUSD)
+	}
+
+	// The lease is the accountability record: who ran what on whose quota.
+	lease, err := h.leases.GetOpenByRun(context.Background(), "run-1")
+	if err != nil {
+		t.Fatalf("lease not recorded: %v", err)
+	}
+	if lease.DonorID != "alice" || lease.RequesterID != "requester" || lease.BotID != "docs-refresh" {
+		t.Errorf("lease = %+v, want the donor/requester/bot triple", lease)
+	}
+}
+
+func TestBroker_noPoolOrDisabledPool(t *testing.T) {
+	h := newHarness(t)
+	h.donor(t, "alice", Limits{})
+
+	// Unknown org.
+	req := h.request("run-1")
+	req.OrgID = "org-nope"
+	if _, err := h.broker.Acquire(context.Background(), req); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("unknown org = %v, want ErrNoDonor", err)
+	}
+
+	// Operator master switch off.
+	_ = h.pools.Upsert(context.Background(), Pool{ID: "pool-1", OrgID: testOrg, Enabled: false})
+	if _, err := h.broker.Acquire(context.Background(), h.request("run-2")); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("disabled pool = %v, want ErrNoDonor", err)
+	}
+}
+
+func TestBroker_killSwitchTakesEffectAtNextAcquire(t *testing.T) {
+	h := newHarness(t)
+	p := h.donor(t, "alice", Limits{})
+
+	if _, err := h.broker.Acquire(context.Background(), h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	p.Enabled = false
+	if err := h.pledges.Upsert(context.Background(), p); err != nil {
+		t.Fatalf("flip kill switch: %v", err)
+	}
+	if _, err := h.broker.Acquire(context.Background(), h.request("run-2")); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("after the kill switch = %v, want ErrNoDonor", err)
+	}
+}
+
+func TestBroker_fairnessPrefersTheLeastConsumedDonor(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxUSDPerDay: 10})
+	h.donor(t, "bob", Limits{MaxUSDPerDay: 10})
+
+	// Alice has already given $8 of her 10 today; Bob nothing.
+	if err := h.ledger.AddSpend(ctx, PledgeID("alice", "claude_code"), h.now, 8, 0, 0); err != nil {
+		t.Fatalf("seed spend: %v", err)
+	}
+	grant, err := h.broker.Acquire(ctx, h.request("run-1"))
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if grant.DonorID != "bob" {
+		t.Errorf("served by %q, want bob (the least consumed)", grant.DonorID)
+	}
+}
+
+func TestBroker_fairnessIsProportional(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	// A generous donor and a modest one. Ranking on RAW spend would drain
+	// the modest pledge first; ranking on the fraction of what each
+	// OFFERED is what makes a small contribution safe to make.
+	h.donor(t, "generous", Limits{MaxUSDPerDay: 100})
+	h.donor(t, "modest", Limits{MaxUSDPerDay: 2})
+
+	// Generous gave $20 (20% of their offer); modest gave $1 (50%).
+	_ = h.ledger.AddSpend(ctx, PledgeID("generous", "claude_code"), h.now, 20, 0, 0)
+	_ = h.ledger.AddSpend(ctx, PledgeID("modest", "claude_code"), h.now, 1, 0, 0)
+
+	grant, err := h.broker.Acquire(ctx, h.request("run-1"))
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if grant.DonorID != "generous" {
+		t.Errorf("served by %q, want generous (20%% consumed vs modest's 50%%)", grant.DonorID)
+	}
+}
+
+func TestBroker_exhaustedDonorYieldsToTheNext(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxUSDPerDay: 5})
+	h.donor(t, "bob", Limits{MaxUSDPerDay: 5})
+	// Alice is spent; she must be skipped, not fail the acquisition.
+	_ = h.ledger.AddSpend(ctx, PledgeID("alice", "claude_code"), h.now, 5, 0, 0)
+
+	grant, err := h.broker.Acquire(ctx, h.request("run-1"))
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if grant.DonorID != "bob" {
+		t.Errorf("served by %q, want bob (alice is at her cap)", grant.DonorID)
+	}
+}
+
+func TestBroker_everyDonorExhausted(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxUSDPerDay: 5})
+	_ = h.ledger.AddSpend(ctx, PledgeID("alice", "claude_code"), h.now, 5, 0, 0)
+
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("Acquire = %v, want ErrNoDonor", err)
+	}
+	// A refused admission must not leave the donor's run counter inflated —
+	// otherwise a run-per-day cap would erode with every rejected launch.
+	day, _, err := h.ledger.Usage(ctx, PledgeID("alice", "claude_code"), h.now)
+	if err != nil {
+		t.Fatalf("usage: %v", err)
+	}
+	if day.Runs != 0 {
+		t.Errorf("day runs = %d, want 0 — the refused reservation was not rolled back", day.Runs)
+	}
+}
+
+func TestBroker_concurrencyCap(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxConcurrentRuns: 1})
+
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	if _, err := h.broker.Acquire(ctx, h.request("run-2")); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("second concurrent Acquire = %v, want ErrNoDonor", err)
+	}
+	// Reporting the first run frees the slot.
+	if err := h.broker.Report(ctx, "run-1", Outcome{CostUSD: 0.5}); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if _, err := h.broker.Acquire(ctx, h.request("run-3")); err != nil {
+		t.Errorf("after release = %v, want a grant", err)
+	}
+}
+
+func TestBroker_runsPerDayCap(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxRunsPerDay: 2})
+
+	for i, run := range []string{"run-1", "run-2"} {
+		if _, err := h.broker.Acquire(ctx, h.request(run)); err != nil {
+			t.Fatalf("Acquire %d: %v", i, err)
+		}
+		if err := h.broker.Report(ctx, run, Outcome{}); err != nil {
+			t.Fatalf("Report %d: %v", i, err)
+		}
+	}
+	if _, err := h.broker.Acquire(ctx, h.request("run-3")); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("third run = %v, want ErrNoDonor (cap is 2/day)", err)
+	}
+	// A new day reopens the offer with no intervention.
+	h.now = h.now.Add(24 * time.Hour)
+	if _, err := h.broker.Acquire(ctx, h.request("run-4")); err != nil {
+		t.Errorf("next day = %v, want a grant", err)
+	}
+}
+
+func TestBroker_donorNeverServesTheirOwnRun(t *testing.T) {
+	h := newHarness(t)
+	h.donor(t, "alice", Limits{})
+
+	req := h.request("run-1")
+	req.UserID = "alice"
+	if _, err := h.broker.Acquire(context.Background(), req); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("Acquire = %v, want ErrNoDonor — a donor lending to themselves is bookkeeping for nothing", err)
+	}
+}
+
+func TestBroker_reportChargesTheDonorAndClosesTheLease(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxUSDPerDay: 10})
+
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := h.broker.Report(ctx, "run-1", Outcome{CostUSD: 1.25, InputTokens: 1000, OutputTokens: 200}); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+
+	day, week, err := h.ledger.Usage(ctx, PledgeID("alice", "claude_code"), h.now)
+	if err != nil {
+		t.Fatalf("usage: %v", err)
+	}
+	if day.CostUSD != 1.25 || week.CostUSD != 1.25 {
+		t.Errorf("day/week cost = %v/%v, want 1.25 in both buckets", day.CostUSD, week.CostUSD)
+	}
+	if day.InputTokens != 1000 || day.OutputTokens != 200 {
+		t.Errorf("tokens = %d/%d, want 1000/200", day.InputTokens, day.OutputTokens)
+	}
+
+	// The next grant sees the reduced allowance — this is the number that
+	// becomes the next run's cost ceiling.
+	grant, err := h.broker.Acquire(ctx, h.request("run-2"))
+	if err != nil {
+		t.Fatalf("second Acquire: %v", err)
+	}
+	if grant.RemainingUSD != 8.75 {
+		t.Errorf("allowance = %v, want 8.75", grant.RemainingUSD)
+	}
+}
+
+func TestBroker_reportIsIdempotent(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxUSDPerDay: 10})
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if err := h.broker.Report(ctx, "run-1", Outcome{CostUSD: 2}); err != nil {
+			t.Fatalf("Report %d: %v", i, err)
+		}
+	}
+	day, _, _ := h.ledger.Usage(ctx, PledgeID("alice", "claude_code"), h.now)
+	if day.CostUSD != 2 {
+		t.Errorf("cost = %v, want 2 — a redelivered report double-charged the donor", day.CostUSD)
+	}
+}
+
+func TestBroker_reportWithoutLeaseIsNotAnError(t *testing.T) {
+	h := newHarness(t)
+	// Most runs never touch the pool; reporting them must be a no-op, not
+	// an error the runner has to special-case.
+	if err := h.broker.Report(context.Background(), "run-unknown", Outcome{CostUSD: 3}); err != nil {
+		t.Errorf("Report on an unleased run = %v, want nil", err)
+	}
+}
+
+func TestBroker_spendIsChargedToTheDayThatAdmittedTheRun(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.now = time.Date(2026, 8, 3, 23, 50, 0, 0, time.UTC)
+	h.donor(t, "alice", Limits{MaxUSDPerDay: 10})
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+
+	// The run crosses midnight before reporting.
+	acquired := h.now
+	h.now = h.now.Add(30 * time.Minute)
+	if err := h.broker.Report(ctx, "run-1", Outcome{CostUSD: 4}); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+
+	day, _, _ := h.ledger.Usage(ctx, PledgeID("alice", "claude_code"), acquired)
+	if day.CostUSD != 4 {
+		t.Errorf("spend landed on the wrong day: %s shows %v, want 4 — a run admitted under yesterday's allowance must debit yesterday",
+			dayKey(acquired), day.CostUSD)
+	}
+	next, _, _ := h.ledger.Usage(ctx, PledgeID("alice", "claude_code"), h.now)
+	if next.CostUSD != 0 {
+		t.Errorf("%s shows %v, want 0", dayKey(h.now), next.CostUSD)
+	}
+}
+
+func TestBroker_usageWindowPutsTheDonorToRest(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{})
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+
+	reset := h.now.Add(3 * time.Hour)
+	if err := h.broker.Report(ctx, "run-1", Outcome{
+		Condition: ConditionUsageWindow, CooldownUntil: reset,
+	}); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if _, err := h.broker.Acquire(ctx, h.request("run-2")); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("during cooldown = %v, want ErrNoDonor", err)
+	}
+	// Past the reset the donor returns on their own — no background job.
+	h.now = reset.Add(2 * time.Minute)
+	if _, err := h.broker.Acquire(ctx, h.request("run-3")); err != nil {
+		t.Errorf("after the reset = %v, want a grant", err)
+	}
+}
+
+func TestBroker_usageWindowWithoutAResetUsesABoundedWait(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{})
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	// The provider said "exhausted" but nothing parsed as a reset instant.
+	if err := h.broker.Report(ctx, "run-1", Outcome{Condition: ConditionUsageWindow}); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	p, _ := h.pledges.Get(ctx, PledgeID("alice", "claude_code"))
+	if p.CooldownUntil == nil || !p.CooldownUntil.After(h.now) {
+		t.Fatalf("cooldown = %v, want a bounded future instant", p.CooldownUntil)
+	}
+	if p.CooldownUntil.After(h.now.Add(2 * time.Hour)) {
+		t.Errorf("blind cooldown = %v, want something short (≈1h), not a speculative week", p.CooldownUntil)
+	}
+}
+
+func TestBroker_repeatedAuthFailuresParkTheDonor(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{})
+
+	// Drive the reported condition through the public path for the first
+	// failure, then the transition directly — what matters here is the
+	// threshold, not which donor the ranking happened to pick.
+	id := PledgeID("alice", "claude_code")
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := h.broker.Report(ctx, "run-1", Outcome{Condition: ConditionAuthFailed}); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	p, _ := h.pledges.Get(ctx, id)
+	if p.Health != HealthOK {
+		t.Errorf("one failure parked the donor (%s) — a single blip must not evict someone who did nothing wrong", p.Health)
+	}
+
+	if _, err := h.broker.Acquire(ctx, h.request("run-2")); err != nil {
+		t.Fatalf("second Acquire: %v", err)
+	}
+	if err := h.broker.Report(ctx, "run-2", Outcome{Condition: ConditionAuthFailed}); err != nil {
+		t.Fatalf("second Report: %v", err)
+	}
+	p, _ = h.pledges.Get(ctx, id)
+	if p.Health != HealthAuthFailed {
+		t.Errorf("health = %s, want auth_failed after repeated rejections", p.Health)
+	}
+	if p.HealthDetail == "" {
+		t.Error("an unhealthy pledge must tell the donor what to do about it")
+	}
+	// And it must actually leave the rotation.
+	if _, err := h.broker.Acquire(ctx, h.request("run-3")); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("a parked donor was still selected: %v", err)
+	}
+}
+
+func TestBroker_successResetsTheAuthFailureStreak(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{})
+	id := PledgeID("alice", "claude_code")
+
+	h.broker.noteAuthFailure(ctx, id)
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := h.broker.Report(ctx, "run-1", Outcome{CostUSD: 0.1}); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	p, _ := h.pledges.Get(ctx, id)
+	if p.ConsecutiveAuthFailures != 0 {
+		t.Errorf("streak = %d, want 0 — unrelated failures weeks apart must not accumulate into an eviction", p.ConsecutiveAuthFailures)
+	}
+}
+
+func TestBroker_disconnectedCredentialParksThePledge(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{})
+	// The donor disconnected the subscription but left the pledge behind.
+	if err := h.oauth.Delete(ctx, "alice", secrets.OAuthKindClaudeCode); err != nil {
+		t.Fatalf("delete oauth: %v", err)
+	}
+
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("Acquire = %v, want ErrNoDonor", err)
+	}
+	p, _ := h.pledges.Get(ctx, PledgeID("alice", "claude_code"))
+	if p.Health != HealthTokenExpired {
+		t.Errorf("health = %s, want token_expired — re-discovering this on every launch is wasted work", p.Health)
+	}
+	// And the reservation must have been given back.
+	day, _, _ := h.ledger.Usage(ctx, PledgeID("alice", "claude_code"), h.now)
+	if day.Runs != 0 {
+		t.Errorf("day runs = %d, want 0 — the reserved unit leaked", day.Runs)
+	}
+}
+
+func TestBroker_expiredNonRefreshableCredentialIsParked(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{})
+	rec, _ := h.oauth.Get(ctx, "alice", secrets.OAuthKindClaudeCode)
+	past := h.now.Add(-time.Hour)
+	rec.AccessTokenExpiresAt = &past
+	rec.NotRefreshable = true
+	_ = h.oauth.Upsert(ctx, rec)
+
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("Acquire = %v, want ErrNoDonor", err)
+	}
+	p, _ := h.pledges.Get(ctx, PledgeID("alice", "claude_code"))
+	if p.Health != HealthTokenExpired {
+		t.Errorf("health = %s, want token_expired", p.Health)
+	}
+}
+
+func TestBroker_releaseExpiredFreesAbandonedLeases(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxConcurrentRuns: 1})
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	// The pod is killed: nothing ever reports. Without the sweeper the
+	// donor's only slot would stay consumed.
+	h.now = h.now.Add(DefaultLeaseTTL + time.Minute)
+	freed, err := h.broker.ReleaseExpired(ctx, 10)
+	if err != nil {
+		t.Fatalf("ReleaseExpired: %v", err)
+	}
+	if freed != 1 {
+		t.Errorf("freed = %d, want 1", freed)
+	}
+	if _, err := h.broker.Acquire(ctx, h.request("run-2")); err != nil {
+		t.Errorf("after the sweep = %v, want a grant", err)
+	}
+	// No spend is invented for a run that never reported.
+	lease, _ := h.leases.GetOpenByRun(ctx, "run-1")
+	if lease.RunID != "" {
+		t.Fatalf("run-1 still holds an open lease after the sweep: %+v", lease)
+	}
+	hist, _ := h.leases.ListByDonor(ctx, "alice", 10)
+	var swept *Lease
+	for i := range hist {
+		if hist[i].RunID == "run-1" {
+			swept = &hist[i]
+		}
+	}
+	if swept == nil {
+		t.Fatal("run-1's lease vanished from the donor's history")
+	}
+	if swept.CostUSD != 0 || swept.Outcome != OutcomeAbandoned {
+		t.Errorf("abandoned lease = (%v, %q), want (0, \"abandoned\")", swept.CostUSD, swept.Outcome)
+	}
+}
+
+func TestBroker_resumeReplacesTheLeaseInsteadOfStacking(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxConcurrentRuns: 1})
+
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+	// A resume re-acquires for the SAME run. One live lease per run, or the
+	// donor's concurrency slot would be consumed twice by one run.
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("re-Acquire on resume: %v", err)
+	}
+	live, _, err := h.leases.LiveCommitment(ctx, PledgeID("alice", "claude_code"), "", h.now)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if live != 1 {
+		t.Errorf("live leases = %d, want 1", live)
+	}
+}
+
+func TestBroker_kindIsHonoured(t *testing.T) {
+	h := newHarness(t)
+	h.donor(t, "alice", Limits{}) // claude_code only
+
+	req := h.request("run-1")
+	req.Kinds = []secrets.OAuthKind{secrets.OAuthKindCodex}
+	if _, err := h.broker.Acquire(context.Background(), req); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("Acquire = %v, want ErrNoDonor — a claude_code pledge cannot serve a codex request", err)
+	}
+}
+
+// Every audience dial beyond the owning org must be REACHABLE from where
+// it admits. Resolving the pool by the requester's own org made all of them
+// dead configuration — the setting could be saved and displayed while never
+// changing a single launch.
+func TestBroker_audienceDialsReachAcrossOrgs(t *testing.T) {
+	foreign := func(runID string) Request {
+		return Request{
+			RunID: runID, OrgID: "org-elsewhere", TenantID: "team-x", UserID: "dave",
+			Kinds: []secrets.OAuthKind{secrets.OAuthKindClaudeCode},
+		}
+	}
+	cases := []struct {
+		name string
+		aud  Audience
+	}{
+		{"team allow-list", Audience{Teams: []string{"team-x"}}},
+		{"org allow-list", Audience{Orgs: []string{"org-elsewhere"}}},
+		{"all teams", Audience{AllTeams: true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t)
+			ctx := context.Background()
+			h.donor(t, "alice", Limits{})
+			if _, err := h.broker.Acquire(ctx, foreign("run-0")); !errors.Is(err, ErrNoDonor) {
+				t.Fatalf("baseline (default audience) = %v, want ErrNoDonor", err)
+			}
+			if err := h.pools.Upsert(ctx, Pool{ID: "pool-1", OrgID: testOrg, Enabled: true, Audience: tc.aud}); err != nil {
+				t.Fatalf("set audience: %v", err)
+			}
+			if _, err := h.broker.Acquire(ctx, foreign("run-1")); err != nil {
+				t.Errorf("Acquire = %v, want a grant — this audience dial is unreachable", err)
+			}
+		})
+	}
+}
+
+// When several pools would serve, the requester's own org pool wins: a team
+// must not be diverted onto a community pool that happens to sort earlier.
+func TestBroker_ownOrgPoolWinsOverACommunityOne(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	// "pool-0" sorts before "pool-1" and admits everyone.
+	if err := h.pools.Upsert(ctx, Pool{
+		ID: "pool-0", OrgID: "org-community", Enabled: true, Audience: Audience{AllTeams: true},
+	}); err != nil {
+		t.Fatalf("seed community pool: %v", err)
+	}
+	h.donor(t, "alice", Limits{}) // in pool-1, the requester's own org pool
+
+	grant, err := h.broker.Acquire(ctx, h.request("run-1"))
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	lease, _ := h.leases.GetOpenByRun(ctx, "run-1")
+	if lease.PoolID != "pool-1" {
+		t.Errorf("served by pool %q (donor %s), want the requester's own org pool", lease.PoolID, grant.DonorID)
+	}
+}
+
+func TestBroker_reciprocityAdmitsAForeignDonor(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{})
+	h.donor(t, "carol", Limits{})
+
+	// Carol launches from a team outside the pool's org.
+	req := Request{
+		RunID: "run-1", OrgID: "org-elsewhere", TenantID: "team-x", UserID: "carol",
+		Kinds: []secrets.OAuthKind{secrets.OAuthKindClaudeCode},
+	}
+	if _, err := h.broker.Acquire(ctx, req); !errors.Is(err, ErrNoDonor) {
+		t.Fatalf("with reciprocity off = %v, want ErrNoDonor", err)
+	}
+
+	_ = h.pools.Upsert(ctx, Pool{
+		ID: "pool-1", OrgID: testOrg, Enabled: true,
+		Audience: Audience{Contributors: true},
+	})
+	grant, err := h.broker.Acquire(ctx, req)
+	if err != nil {
+		t.Fatalf("with reciprocity on = %v, want a grant", err)
+	}
+	if grant.DonorID != "alice" {
+		t.Errorf("served by %q, want alice (carol cannot serve herself)", grant.DonorID)
+	}
+
+	// Reciprocity is earned by an ACTIVE contribution: pausing your own
+	// sharing stops your borrowing too.
+	carol, _ := h.pledges.Get(ctx, PledgeID("carol", "claude_code"))
+	carol.Enabled = false
+	_ = h.pledges.Upsert(ctx, carol)
+	req.RunID = "run-2"
+	if _, err := h.broker.Acquire(ctx, req); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("paused contributor = %v, want ErrNoDonor", err)
+	}
+}

--- a/pkg/credpool/credpool.go
+++ b/pkg/credpool/credpool.go
@@ -336,19 +336,38 @@ func (p Pledge) Available(now time.Time, botID string) (bool, Status) {
 	if !p.Window.Open(now) {
 		return false, StatusOutOfHours
 	}
-	if len(p.Bots) > 0 && botID != "" {
-		allowed := false
-		for _, b := range p.Bots {
-			if b == botID {
-				allowed = true
-				break
-			}
-		}
-		if !allowed {
-			return false, StatusBotFiltered
-		}
+	if len(p.Bots) > 0 && botID != "" && !p.servesBot(botID) {
+		return false, StatusBotFiltered
 	}
 	return true, StatusActive
+}
+
+// AvailableForLaunch is Available as the ACQUISITION path must ask it.
+//
+// The difference is the empty bot id. Available treats it as "ignore the
+// allow-list", which is what the donor-facing status views want. On a
+// launch it means the opposite: `LaunchSpec.BotID` is empty for every
+// plain `.bot` run — an inline workflow the requester uploaded, i.e. the
+// arbitrary-code case — so skipping the filter there would hand a donor
+// who pledged `bots: [review-pr]` to any file a requester cares to submit.
+// The one input the requester fully controls must fail CLOSED.
+func (p Pledge) AvailableForLaunch(now time.Time, botID string) (bool, Status) {
+	if ok, status := p.Available(now, botID); !ok {
+		return false, status
+	}
+	if len(p.Bots) > 0 && !p.servesBot(botID) {
+		return false, StatusBotFiltered
+	}
+	return true, StatusActive
+}
+
+func (p Pledge) servesBot(botID string) bool {
+	for _, b := range p.Bots {
+		if b == botID {
+			return true
+		}
+	}
+	return false
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/credpool/credpool.go
+++ b/pkg/credpool/credpool.go
@@ -1,0 +1,483 @@
+// Package credpool mutualises LLM subscription credentials that
+// individual developers lend to a deployment.
+//
+// A developer connects their Claude Code / Codex subscription through the
+// ordinary personal OAuth flow (pkg/secrets, /api/me/oauth/…), then makes a
+// Pledge: the standing offer of that credential, bounded by limits THEY set
+// (spend per day and per week, runs per day, concurrent runs, an optional
+// time window, an optional bot allow-list) and revocable at any moment.
+//
+// At launch, a run that has neither its own BYOK key nor a personal/org
+// forfait asks the Broker for a donor. The Broker picks the least-consumed
+// eligible pledge, records a Lease against the run, and hands back the
+// verbatim credential blob — which the caller seals into the run bundle
+// exactly like the two other credential tiers. When the attempt ends, the
+// runner reports what it spent; that closes the lease and decrements the
+// donor's allowance.
+//
+// # What this package deliberately does not pretend
+//
+// The dollar figures are ESTIMATES. On a subscription the CLI bills nothing
+// per call, so the cost of a delegation is derived from its token counts
+// (pkg/backend/cost). They are the right unit for sharing fairly between
+// donors; they are not an invoice. The hard signal is the provider's own
+// quota window — an ErrRateLimited(usage_window) puts the donor on cooldown
+// until its reset, which is the guard that actually protects a lender.
+//
+// # Trust posture
+//
+// A subscription is an individual licence. Pooling one across people is a
+// deployment owner's decision, not a neutral technical detail, so every
+// mechanism here is built to keep the lender in control and informed:
+// nothing is shared without an explicit pledge, Enabled=false takes effect
+// at the next acquisition, limits are the lender's own numbers, and every
+// lease is attributable (which run, which bot, which requester).
+package credpool
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/clock"
+	"github.com/SocialGouv/iterion/pkg/orgusage"
+)
+
+// ---------------------------------------------------------------------------
+// Pool
+// ---------------------------------------------------------------------------
+
+// Pool is one org's mutualised credential pool. A deployment normally runs
+// exactly one (id == the owning org id); the type carries an explicit ID so
+// a deployment can run several without a schema change.
+type Pool struct {
+	ID    string `bson:"_id" json:"id"`
+	OrgID string `bson:"org_id" json:"org_id"`
+	Name  string `bson:"name,omitempty" json:"name,omitempty"`
+	// Enabled is the operator-side master switch, independent of the
+	// per-donor one. Off = the pool tier is skipped entirely.
+	Enabled   bool      `bson:"enabled" json:"enabled"`
+	Audience  Audience  `bson:"audience" json:"audience"`
+	CreatedAt time.Time `bson:"created_at" json:"created_at"`
+	UpdatedAt time.Time `bson:"updated_at" json:"updated_at"`
+}
+
+// Audience decides who may draw on a pool. The four predicates are
+// independent and evaluated as a UNION, so a deployment composes the policy
+// it wants instead of picking from a fixed menu — and every field left at
+// its zero value narrows rather than widens.
+//
+// The zero Audience means "only teams of the owning org", which is the
+// strictest useful policy and therefore the default.
+type Audience struct {
+	// Teams is an explicit allow-list of team ids.
+	Teams []string `bson:"teams,omitempty" json:"teams,omitempty"`
+	// Orgs admits every team under these org ids. The pool's own OrgID is
+	// always admitted and need not be repeated here.
+	Orgs []string `bson:"orgs,omitempty" json:"orgs,omitempty"`
+	// Contributors admits any user who is themselves an active donor to
+	// this pool, whichever team they launch from — the reciprocity dial
+	// ("lend to borrow").
+	Contributors bool `bson:"contributors,omitempty" json:"contributors,omitempty"`
+	// AllTeams admits every team on the instance. The widest setting;
+	// meaningful for a deployment that IS a shared community instance.
+	AllTeams bool `bson:"all_teams,omitempty" json:"all_teams,omitempty"`
+}
+
+// Allows reports whether a run launched by userID, from teamID under orgID,
+// may draw on a pool owned by poolOrgID. hasActivePledge is the caller's
+// answer to "is this user themselves a donor", consulted only when the
+// Contributors dial is on (so the caller can skip that lookup otherwise).
+func (a Audience) Allows(poolOrgID, orgID, teamID, userID string, hasActivePledge bool) bool {
+	if a.AllTeams {
+		return true
+	}
+	// The owning org is implicit: a pool always serves its own org.
+	if orgID != "" && orgID == poolOrgID {
+		return true
+	}
+	for _, id := range a.Orgs {
+		if id != "" && id == orgID {
+			return true
+		}
+	}
+	for _, id := range a.Teams {
+		if id != "" && id == teamID {
+			return true
+		}
+	}
+	if a.Contributors && userID != "" && hasActivePledge {
+		return true
+	}
+	return false
+}
+
+// NeedsPledgeLookup reports whether evaluating this audience requires
+// knowing if the requester is a donor. Lets the caller skip that query for
+// the common (reciprocity-off) case.
+func (a Audience) NeedsPledgeLookup() bool { return a.Contributors }
+
+// ---------------------------------------------------------------------------
+// Pledge
+// ---------------------------------------------------------------------------
+
+// Health is a pledge's sticky operational state. Transient unavailability
+// (a cooldown, a closed time window) is NOT stored here — it is derived, so
+// a pledge never needs a background job to come back to life.
+type Health string
+
+const (
+	// HealthOK — usable.
+	HealthOK Health = "ok"
+	// HealthTokenExpired — the stored credential expired and carries no
+	// refresh token; only the donor reconnecting can revive it.
+	HealthTokenExpired Health = "token_expired"
+	// HealthAuthFailed — the provider rejected the credential on
+	// consecutive runs. Held out of the pool until the donor reconnects,
+	// so a dead token cannot poison every launch.
+	HealthAuthFailed Health = "auth_failed"
+)
+
+// Status is the display-level state of a pledge: Health, refined by the
+// transient conditions.
+type Status string
+
+const (
+	StatusActive     Status = "active"
+	StatusPaused     Status = "paused"  // donor switched sharing off
+	StatusCooling    Status = "cooling" // provider quota window exhausted
+	StatusOutOfHours Status = "out_of_hours"
+	StatusExhausted  Status = "exhausted" // limits reached for the period
+	StatusUnhealthy  Status = "unhealthy" // token expired / auth failing
+	// StatusBotFiltered — the donor is sharing, but not with the bot that
+	// asked. Distinct from paused so the UI never tells a willing
+	// contributor their contribution is off.
+	StatusBotFiltered Status = "bot_filtered"
+)
+
+// Limits are the ceilings a donor sets on their own contribution. Every
+// field is optional; zero means "no limit on this axis".
+type Limits struct {
+	// MaxUSDPerDay / MaxUSDPerWeek cap ESTIMATED spend (see the package
+	// doc). The remaining daily allowance also becomes the launched run's
+	// own cost budget, so a single run cannot blow past the pledge.
+	MaxUSDPerDay  float64 `bson:"max_usd_per_day,omitempty" json:"max_usd_per_day,omitempty"`
+	MaxUSDPerWeek float64 `bson:"max_usd_per_week,omitempty" json:"max_usd_per_week,omitempty"`
+	// MaxRunsPerDay caps how many runs may be served, independent of cost.
+	MaxRunsPerDay int `bson:"max_runs_per_day,omitempty" json:"max_runs_per_day,omitempty"`
+	// MaxConcurrentRuns caps simultaneously-served runs — the dial that
+	// keeps a donor's own interactive session responsive.
+	MaxConcurrentRuns int `bson:"max_concurrent_runs,omitempty" json:"max_concurrent_runs,omitempty"`
+}
+
+// Validate rejects negative ceilings and a weekly cap below the daily one
+// (which would make the daily cap a lie).
+func (l Limits) Validate() error {
+	if l.MaxUSDPerDay < 0 || l.MaxUSDPerWeek < 0 {
+		return fmt.Errorf("credpool: spend limits cannot be negative")
+	}
+	if l.MaxRunsPerDay < 0 || l.MaxConcurrentRuns < 0 {
+		return fmt.Errorf("credpool: run limits cannot be negative")
+	}
+	if l.MaxUSDPerDay > 0 && l.MaxUSDPerWeek > 0 && l.MaxUSDPerWeek < l.MaxUSDPerDay {
+		return fmt.Errorf("credpool: weekly cap ($%.2f) is below the daily cap ($%.2f)", l.MaxUSDPerWeek, l.MaxUSDPerDay)
+	}
+	return nil
+}
+
+// Window restricts sharing to certain local hours and weekdays — the
+// "borrow it while I sleep" dial.
+type Window struct {
+	// Timezone is an IANA location name; empty means UTC. An unresolvable
+	// name is treated as UTC rather than closing the window, so a typo
+	// cannot silently withdraw a donor's contribution.
+	Timezone string `bson:"timezone,omitempty" json:"timezone,omitempty"`
+	// StartHour is inclusive, EndHour exclusive, both in local time.
+	// Equal values mean "all day". StartHour > EndHour wraps midnight
+	// (19→8 is the evening-through-morning case donors actually want).
+	StartHour int `bson:"start_hour" json:"start_hour"`
+	EndHour   int `bson:"end_hour" json:"end_hour"`
+	// Weekdays restricts to these days (time.Weekday values, Sunday=0).
+	// Empty means every day.
+	Weekdays []int `bson:"weekdays,omitempty" json:"weekdays,omitempty"`
+}
+
+// Validate bounds the hour and weekday values.
+func (w *Window) Validate() error {
+	if w == nil {
+		return nil
+	}
+	if w.StartHour < 0 || w.StartHour > 23 || w.EndHour < 0 || w.EndHour > 23 {
+		return fmt.Errorf("credpool: window hours must be in 0..23")
+	}
+	for _, d := range w.Weekdays {
+		if d < 0 || d > 6 {
+			return fmt.Errorf("credpool: weekday %d out of range (0=Sunday..6=Saturday)", d)
+		}
+	}
+	if w.Timezone != "" {
+		if _, err := time.LoadLocation(w.Timezone); err != nil {
+			return fmt.Errorf("credpool: unknown timezone %q", w.Timezone)
+		}
+	}
+	return nil
+}
+
+// Open reports whether now falls inside the window. A nil Window is always
+// open.
+func (w *Window) Open(now time.Time) bool {
+	if w == nil {
+		return true
+	}
+	loc := time.UTC
+	if w.Timezone != "" {
+		if l, err := time.LoadLocation(w.Timezone); err == nil {
+			loc = l
+		}
+	}
+	local := now.In(loc)
+	if len(w.Weekdays) > 0 {
+		match := false
+		for _, d := range w.Weekdays {
+			if time.Weekday(d) == local.Weekday() {
+				match = true
+				break
+			}
+		}
+		if !match {
+			return false
+		}
+	}
+	if w.StartHour == w.EndHour {
+		return true // all day
+	}
+	h := local.Hour()
+	if w.StartHour < w.EndHour {
+		return h >= w.StartHour && h < w.EndHour
+	}
+	// Wraps midnight.
+	return h >= w.StartHour || h < w.EndHour
+}
+
+// Pledge is one donor's standing offer of one connected subscription.
+// Keyed by (UserID, Kind) — the same partition the credential itself uses
+// in pkg/secrets, so a pledge can never point at a credential that is not
+// the donor's own.
+type Pledge struct {
+	ID     string `bson:"_id" json:"id"`
+	PoolID string `bson:"pool_id" json:"pool_id"`
+	UserID string `bson:"user_id" json:"user_id"`
+	// Kind mirrors secrets.OAuthKind ("claude_code" / "codex"). Held as a
+	// string so this package does not depend on pkg/secrets — the broker
+	// converts at the boundary.
+	Kind string `bson:"kind" json:"kind"`
+	// Enabled is the donor's kill switch. Effective at the next
+	// acquisition; runs already in flight finish on the credential they
+	// were granted (killing them mid-way would waste the spend already
+	// incurred without giving the donor anything back).
+	Enabled bool    `bson:"enabled" json:"enabled"`
+	Limits  Limits  `bson:"limits" json:"limits"`
+	Window  *Window `bson:"window,omitempty" json:"window,omitempty"`
+	// Bots optionally restricts which bot ids this credential may run.
+	// Empty means any bot the pool serves.
+	Bots []string `bson:"bots,omitempty" json:"bots,omitempty"`
+	// CooldownUntil holds the pledge out of the pool until the provider's
+	// quota window resets. Set from ErrRateLimited.ResetAt.
+	CooldownUntil *time.Time `bson:"cooldown_until,omitempty" json:"cooldown_until,omitempty"`
+	Health        Health     `bson:"health" json:"health"`
+	// HealthDetail carries the last diagnostic, shown to the donor so an
+	// unhealthy pledge is actionable instead of merely absent.
+	HealthDetail string `bson:"health_detail,omitempty" json:"health_detail,omitempty"`
+	// ConsecutiveAuthFailures drives the flip to HealthAuthFailed. Reset
+	// by any successful run, so one transient blip does not evict a donor.
+	ConsecutiveAuthFailures int        `bson:"consecutive_auth_failures,omitempty" json:"consecutive_auth_failures,omitempty"`
+	LastServedAt            *time.Time `bson:"last_served_at,omitempty" json:"last_served_at,omitempty"`
+	CreatedAt               time.Time  `bson:"created_at" json:"created_at"`
+	UpdatedAt               time.Time  `bson:"updated_at" json:"updated_at"`
+}
+
+// PledgeID is the deterministic id for a (user, kind) pledge, matching how
+// pkg/secrets keys the credential it lends.
+func PledgeID(userID, kind string) string { return userID + "|" + kind }
+
+// Validate checks a donor-supplied pledge before it is stored.
+func (p Pledge) Validate() error {
+	if strings.TrimSpace(p.UserID) == "" {
+		return fmt.Errorf("credpool: pledge has no user")
+	}
+	if strings.TrimSpace(p.Kind) == "" {
+		return fmt.Errorf("credpool: pledge has no credential kind")
+	}
+	if err := p.Limits.Validate(); err != nil {
+		return err
+	}
+	return p.Window.Validate()
+}
+
+// Cooling reports whether the pledge is inside a provider-quota cooldown.
+func (p Pledge) Cooling(now time.Time) bool {
+	return p.CooldownUntil != nil && now.Before(*p.CooldownUntil)
+}
+
+// Available reports whether the pledge can be considered for selection at
+// all, ignoring consumption (which the ledger owns). The reason is a stable
+// token, surfaced to the donor and in the acquisition trace so "why did
+// nobody serve this run" is answerable.
+func (p Pledge) Available(now time.Time, botID string) (bool, Status) {
+	if !p.Enabled {
+		return false, StatusPaused
+	}
+	if p.Health != HealthOK && p.Health != "" {
+		return false, StatusUnhealthy
+	}
+	if p.Cooling(now) {
+		return false, StatusCooling
+	}
+	if !p.Window.Open(now) {
+		return false, StatusOutOfHours
+	}
+	if len(p.Bots) > 0 && botID != "" {
+		allowed := false
+		for _, b := range p.Bots {
+			if b == botID {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return false, StatusBotFiltered
+		}
+	}
+	return true, StatusActive
+}
+
+// ---------------------------------------------------------------------------
+// Lease
+// ---------------------------------------------------------------------------
+
+// Lease records ONE ATTEMPT of a run drawing on a pledge. It is the
+// concurrency unit (live leases per pledge), the in-flight spend commitment,
+// AND the donor's audit trail (which run, which bot, for whom, what it cost).
+//
+// One document per attempt, never reused. Two earlier designs failed:
+// keying by run alone let a resume onto a different donor erase the first
+// donor's record — money on their ledger with nothing to explain it — and
+// keying by (run, pledge) let a re-admission overwrite a CLOSED lease back
+// to open, which both wiped the finished attempt's cost and re-armed the
+// close CAS so a redelivered report could charge again.
+//
+// The invariant is enforced elsewhere instead: acquiring supersedes any
+// still-open lease of the same run, so a run never holds two open leases
+// and "who is serving this run" is never ambiguous.
+type Lease struct {
+	ID       string `bson:"_id" json:"id"`
+	RunID    string `bson:"run_id" json:"run_id"`
+	PledgeID string `bson:"pledge_id" json:"pledge_id"`
+	PoolID   string `bson:"pool_id" json:"pool_id"`
+	// DonorID is the lending user; denormalised so the donor's "what did
+	// my quota run" view is a single indexed query.
+	DonorID string `bson:"donor_id" json:"donor_id"`
+	Kind    string `bson:"kind" json:"kind"`
+	// TenantID / RequesterID / BotID are the accountability triple: which
+	// team, which person, which bot consumed the donation.
+	TenantID    string `bson:"tenant_id,omitempty" json:"tenant_id,omitempty"`
+	RequesterID string `bson:"requester_id,omitempty" json:"requester_id,omitempty"`
+	BotID       string `bson:"bot_id,omitempty" json:"bot_id,omitempty"`
+	// GrantedCostUSD is the allowance handed to this run (what remained of
+	// the donor's daily cap). It is not only for display: while the lease
+	// is open this is the donor's COMMITTED but unspent exposure, and the
+	// next admission subtracts it — without that, N runs launched together
+	// would each be granted the same remaining allowance and could spend
+	// it N times over.
+	GrantedCostUSD float64 `bson:"granted_cost_usd,omitempty" json:"granted_cost_usd,omitempty"`
+	// ConsumedRunUnit records whether admitting this attempt took a unit of
+	// the donor's daily run quota. A re-admission (a resume) does not, so
+	// releasing it must not hand one back — that would mint quota out of a
+	// failed launch and let the donor exceed the ceiling they set.
+	ConsumedRunUnit bool `bson:"consumed_run_unit,omitempty" json:"consumed_run_unit,omitempty"`
+	// Closed marks a lease whose run reported back. Closed leases are kept
+	// (they are the donor's history) but stop counting toward concurrency.
+	Closed  bool    `bson:"closed" json:"closed"`
+	CostUSD float64 `bson:"cost_usd,omitempty" json:"cost_usd,omitempty"`
+	// Outcome is a short token describing how the run ended for the pool
+	// ("ok", "usage_window", "auth_failed"), for the donor's history view.
+	Outcome    string     `bson:"outcome,omitempty" json:"outcome,omitempty"`
+	AcquiredAt time.Time  `bson:"acquired_at" json:"acquired_at"`
+	ClosedAt   *time.Time `bson:"closed_at,omitempty" json:"closed_at,omitempty"`
+	// ExpiresAt bounds an abandoned lease. A pod killed mid-run never
+	// reports, so without this the donor would lose a concurrency slot
+	// permanently; the sweeper closes anything past this instant.
+	ExpiresAt time.Time `bson:"expires_at" json:"expires_at"`
+}
+
+// Lease outcomes. Free-form for display, but these three are load-bearing:
+// the pool reads them back.
+const (
+	// OutcomeAbandoned — the run never reported; the sweeper closed it.
+	// Its spend is unknown, so a later attempt is admitted as new rather
+	// than renewing an accounting record that means nothing.
+	OutcomeAbandoned = "abandoned"
+	// OutcomeSuperseded — a later attempt of the same run took over.
+	OutcomeSuperseded = "superseded"
+	// OutcomeNotLaunched — the grant was returned; the run never started.
+	OutcomeNotLaunched = "not_launched"
+)
+
+// DefaultLeaseTTL bounds how long an unreported lease keeps consuming a
+// donor's concurrency slot. Generous enough for a long agent run, short
+// enough that a lost pod frees the slot the same day.
+const DefaultLeaseTTL = 12 * time.Hour
+
+// LeaseRetention is how long closed leases are kept as donor-visible
+// history before Mongo's TTL evicts them.
+const LeaseRetention = 90 * 24 * time.Hour
+
+// ---------------------------------------------------------------------------
+// Period keys
+// ---------------------------------------------------------------------------
+
+// dayKey buckets an instant into its UTC day — the same partition key
+// the runtime's daily spend ledger uses.
+func dayKey(when time.Time) string { return clock.DayKey(when) }
+
+// weekKey buckets an instant into its ISO year-week, so a "per week" cap
+// resets on a stable boundary regardless of month length.
+func weekKey(when time.Time) string {
+	y, w := when.UTC().ISOWeek()
+	return fmt.Sprintf("%04d-W%02d", y, w)
+}
+
+// dayStart / weekStart are stored on each ledger document so a TTL index
+// can evict stale periods.
+func dayStart(when time.Time) time.Time {
+	u := when.UTC()
+	return time.Date(u.Year(), u.Month(), u.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+func weekStart(when time.Time) time.Time {
+	u := dayStart(when)
+	// Monday-anchored, matching ISOWeek.
+	offset := (int(u.Weekday()) + 6) % 7
+	return u.AddDate(0, 0, -offset)
+}
+
+// ledgerKey is the document id for one (pledge, period) bucket.
+func ledgerKey(pledgeID, period, key string) string {
+	return pledgeID + "|" + period + "|" + key
+}
+
+const (
+	periodDay  = "d"
+	periodWeek = "w"
+)
+
+// CostToMillis converts USD to integer thousandths so Mongo $inc stays
+// integral (a float $inc accumulates drift). Shared with orgusage rather
+// than mirrored: the two quota systems must round money identically, and a
+// second copy is a place for that to quietly stop being true.
+func CostToMillis(usd float64) int64 { return orgusage.CostToMillis(usd) }
+
+func millisToCost(m int64) float64 { return float64(m) / 1000 }
+
+// LedgerRetentionDays bounds how long period documents are kept.
+const LedgerRetentionDays = 400

--- a/pkg/credpool/credpool.go
+++ b/pkg/credpool/credpool.go
@@ -423,6 +423,25 @@ const (
 	OutcomeNotLaunched = "not_launched"
 )
 
+// nonAdmissionOutcomes are the closes that must NOT count as "this pledge
+// already admitted this run".
+//
+//   - abandoned: nothing ever learned what it spent, so renewing against it
+//     forever would let a crash-looping run draw unmetered.
+//   - not_launched: Release already gave its run unit back, so treating it
+//     as an admission would let the next attempt renew against a unit that
+//     no longer exists — and slip past the donor's daily ceiling.
+var nonAdmissionOutcomes = []string{OutcomeAbandoned, OutcomeNotLaunched}
+
+func isNonAdmission(outcome string) bool {
+	for _, o := range nonAdmissionOutcomes {
+		if outcome == o {
+			return true
+		}
+	}
+	return false
+}
+
 // DefaultLeaseTTL bounds how long an unreported lease keeps consuming a
 // donor's concurrency slot. Generous enough for a long agent run, short
 // enough that a lost pod frees the slot the same day.

--- a/pkg/credpool/credpool_test.go
+++ b/pkg/credpool/credpool_test.go
@@ -1,0 +1,263 @@
+package credpool
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAudienceAllows(t *testing.T) {
+	const (
+		poolOrg  = "org-pool"
+		otherOrg = "org-other"
+	)
+	cases := []struct {
+		name    string
+		aud     Audience
+		orgID   string
+		teamID  string
+		userID  string
+		isDonor bool
+		want    bool
+	}{
+		{
+			// The zero audience is the strictest useful policy, and the
+			// default a freshly created pool carries.
+			name: "zero audience serves the owning org only",
+			aud:  Audience{}, orgID: poolOrg, teamID: "t1", want: true,
+		},
+		{
+			name: "zero audience refuses a foreign org",
+			aud:  Audience{}, orgID: otherOrg, teamID: "t1", want: false,
+		},
+		{
+			name: "explicit team allow-list",
+			aud:  Audience{Teams: []string{"t9"}}, orgID: otherOrg, teamID: "t9", want: true,
+		},
+		{
+			name: "explicit team allow-list refuses another team",
+			aud:  Audience{Teams: []string{"t9"}}, orgID: otherOrg, teamID: "t8", want: false,
+		},
+		{
+			name: "org allow-list",
+			aud:  Audience{Orgs: []string{otherOrg}}, orgID: otherOrg, teamID: "t8", want: true,
+		},
+		{
+			name: "reciprocity admits an active donor from anywhere",
+			aud:  Audience{Contributors: true}, orgID: otherOrg, teamID: "t8", userID: "u1", isDonor: true, want: true,
+		},
+		{
+			name: "reciprocity refuses a non-donor",
+			aud:  Audience{Contributors: true}, orgID: otherOrg, teamID: "t8", userID: "u1", isDonor: false, want: false,
+		},
+		{
+			name: "all-teams admits everyone",
+			aud:  Audience{AllTeams: true}, orgID: otherOrg, teamID: "t8", want: true,
+		},
+		{
+			// The predicates are a union: any one of them admitting is
+			// enough, which is what makes the policy composable.
+			name: "union: team list admits even when the org does not",
+			aud:  Audience{Orgs: []string{"org-nope"}, Teams: []string{"t8"}}, orgID: otherOrg, teamID: "t8", want: true,
+		},
+		{
+			// An empty org id must not accidentally match an empty entry.
+			name: "empty ids never match",
+			aud:  Audience{Orgs: []string{""}, Teams: []string{""}}, orgID: "", teamID: "", want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.aud.Allows(poolOrg, tc.orgID, tc.teamID, tc.userID, tc.isDonor)
+			if got != tc.want {
+				t.Errorf("Allows = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAudienceNeedsPledgeLookup(t *testing.T) {
+	if (Audience{}).NeedsPledgeLookup() {
+		t.Error("the default audience must not cost a pledge lookup on every launch")
+	}
+	if !(Audience{Contributors: true}).NeedsPledgeLookup() {
+		t.Error("reciprocity needs the donor lookup")
+	}
+}
+
+func TestWindowOpen(t *testing.T) {
+	// 2026-08-03 is a Monday.
+	at := func(h int) time.Time { return time.Date(2026, 8, 3, h, 30, 0, 0, time.UTC) }
+
+	cases := []struct {
+		name string
+		w    *Window
+		now  time.Time
+		want bool
+	}{
+		{"nil window is always open", nil, at(3), true},
+		{"equal hours mean all day", &Window{StartHour: 9, EndHour: 9}, at(3), true},
+		{"inside a daytime range", &Window{StartHour: 9, EndHour: 18}, at(12), true},
+		{"before a daytime range", &Window{StartHour: 9, EndHour: 18}, at(8), false},
+		{"end hour is exclusive", &Window{StartHour: 9, EndHour: 18}, at(18), false},
+		// The case donors actually ask for: lend it overnight.
+		{"wraps midnight, late evening", &Window{StartHour: 19, EndHour: 8}, at(23), true},
+		{"wraps midnight, early morning", &Window{StartHour: 19, EndHour: 8}, at(2), true},
+		{"wraps midnight, closed midday", &Window{StartHour: 19, EndHour: 8}, at(12), false},
+		{"weekday match", &Window{Weekdays: []int{int(time.Monday)}}, at(12), true},
+		{"weekday mismatch", &Window{Weekdays: []int{int(time.Sunday)}}, at(12), false},
+		{
+			// A typo in the timezone must not silently withdraw a donation.
+			"unknown timezone falls back to UTC rather than closing",
+			&Window{Timezone: "Mars/Olympus", StartHour: 9, EndHour: 18}, at(12), true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.w.Open(tc.now); got != tc.want {
+				t.Errorf("Open = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWindowOpen_honoursTimezone(t *testing.T) {
+	// 06:30 UTC is 08:30 in Paris (CEST) — inside a 8→18 local window,
+	// outside it if the window were read as UTC.
+	w := &Window{Timezone: "Europe/Paris", StartHour: 8, EndHour: 18}
+	if !w.Open(time.Date(2026, 8, 3, 6, 30, 0, 0, time.UTC)) {
+		t.Error("window must be evaluated in the donor's timezone")
+	}
+}
+
+func TestLimitsValidate(t *testing.T) {
+	if err := (Limits{MaxUSDPerDay: 5, MaxUSDPerWeek: 20}).Validate(); err != nil {
+		t.Errorf("valid limits rejected: %v", err)
+	}
+	if err := (Limits{MaxUSDPerDay: -1}).Validate(); err == nil {
+		t.Error("negative spend cap accepted")
+	}
+	// A weekly cap under the daily one makes the daily figure a lie — the
+	// donor would see "$10/day" and get $3 on the first day only.
+	if err := (Limits{MaxUSDPerDay: 10, MaxUSDPerWeek: 3}).Validate(); err == nil {
+		t.Error("weekly cap below the daily cap accepted")
+	}
+}
+
+func TestPledgeAvailable(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	base := Pledge{Enabled: true, Health: HealthOK}
+
+	cases := []struct {
+		name   string
+		mutate func(*Pledge)
+		botID  string
+		wantOK bool
+		want   Status
+	}{
+		{"healthy and enabled", func(*Pledge) {}, "", true, StatusActive},
+		{"kill switch", func(p *Pledge) { p.Enabled = false }, "", false, StatusPaused},
+		{"unhealthy token", func(p *Pledge) { p.Health = HealthTokenExpired }, "", false, StatusUnhealthy},
+		{
+			"inside a provider cooldown",
+			func(p *Pledge) { t := now.Add(time.Hour); p.CooldownUntil = &t },
+			"", false, StatusCooling,
+		},
+		{
+			// An elapsed cooldown must free the donor with no background
+			// job: availability is derived, never stored.
+			"elapsed cooldown is available again",
+			func(p *Pledge) { t := now.Add(-time.Minute); p.CooldownUntil = &t },
+			"", true, StatusActive,
+		},
+		{
+			"outside the sharing window",
+			func(p *Pledge) { p.Window = &Window{StartHour: 19, EndHour: 8} },
+			"", false, StatusOutOfHours,
+		},
+		{
+			"bot allow-list match",
+			func(p *Pledge) { p.Bots = []string{"docs-refresh"} },
+			"docs-refresh", true, StatusActive,
+		},
+		{
+			// Distinct from paused: the donor IS sharing, just not with
+			// this bot. Telling them "paused" would be a lie about their
+			// own contribution.
+			"bot outside the allow-list",
+			func(p *Pledge) { p.Bots = []string{"docs-refresh"} },
+			"feature-dev", false, StatusBotFiltered,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := base
+			tc.mutate(&p)
+			ok, status := p.Available(now, tc.botID)
+			if ok != tc.wantOK || status != tc.want {
+				t.Errorf("Available = (%v, %s), want (%v, %s)", ok, status, tc.wantOK, tc.want)
+			}
+		})
+	}
+}
+
+func TestRemainingAllowance(t *testing.T) {
+	cases := []struct {
+		name       string
+		lim        Limits
+		day, week  float64
+		wantRem    float64
+		wantCapped bool
+	}{
+		{"no cap at all", Limits{}, 3, 10, 0, false},
+		{"daily cap only", Limits{MaxUSDPerDay: 5}, 2, 0, 3, true},
+		{
+			// The tightest cap must win: a nearly-spent week bounds today
+			// even when the daily figure looks generous.
+			"weekly cap is tighter than daily",
+			Limits{MaxUSDPerDay: 5, MaxUSDPerWeek: 20}, 1, 19, 1, true,
+		},
+		{"daily cap is tighter than weekly", Limits{MaxUSDPerDay: 5, MaxUSDPerWeek: 100}, 4, 10, 1, true},
+		{"overspend clamps to zero, never negative", Limits{MaxUSDPerDay: 5}, 7, 0, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rem, capped := remainingAllowance(tc.lim, tc.day, tc.week)
+			if rem != tc.wantRem || capped != tc.wantCapped {
+				t.Errorf("remainingAllowance = (%v, %v), want (%v, %v)", rem, capped, tc.wantRem, tc.wantCapped)
+			}
+		})
+	}
+}
+
+func TestPeriodKeys(t *testing.T) {
+	// A week bucket must not roll over mid-week: Monday and the following
+	// Sunday belong to the same ISO week.
+	mon := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+	sun := time.Date(2026, 8, 9, 23, 59, 0, 0, time.UTC)
+	if weekKey(mon) != weekKey(sun) {
+		t.Errorf("Monday %s and Sunday %s landed in different weeks", weekKey(mon), weekKey(sun))
+	}
+	if weekKey(sun.Add(time.Minute)) == weekKey(sun) {
+		t.Error("the next Monday must open a new week bucket")
+	}
+	if got := weekStart(sun); !got.Equal(mon) {
+		t.Errorf("weekStart = %s, want the Monday %s", got, mon)
+	}
+	if dayKey(mon) == dayKey(sun) {
+		t.Error("distinct days must bucket distinctly")
+	}
+}
+
+func TestCostToMillis(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want int64
+	}{
+		{0, 0}, {-1, 0}, {1, 1000}, {0.4242, 424}, {0.0004, 0}, {2.9995, 3000},
+	}
+	for _, tc := range cases {
+		if got := CostToMillis(tc.in); got != tc.want {
+			t.Errorf("CostToMillis(%v) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}

--- a/pkg/credpool/memory.go
+++ b/pkg/credpool/memory.go
@@ -209,7 +209,7 @@ func (s *MemoryLeaseStore) HasServedAttempt(_ context.Context, runID, pledgeID s
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, l := range s.m {
-		if l.RunID == runID && l.PledgeID == pledgeID && l.Outcome != OutcomeAbandoned {
+		if l.RunID == runID && l.PledgeID == pledgeID && !isNonAdmission(l.Outcome) {
 			return true, nil
 		}
 	}

--- a/pkg/credpool/memory.go
+++ b/pkg/credpool/memory.go
@@ -1,0 +1,419 @@
+package credpool
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+)
+
+// The in-process stores back local mode and tests. Their semantics are the
+// contract the Mongo implementations must match — when the two drift, this
+// file is the one that is right.
+
+// ---------------------------------------------------------------------------
+// Pools
+// ---------------------------------------------------------------------------
+
+type MemoryPoolStore struct {
+	mu sync.Mutex
+	m  map[string]Pool
+}
+
+func NewMemoryPoolStore() *MemoryPoolStore { return &MemoryPoolStore{m: map[string]Pool{}} }
+
+func (s *MemoryPoolStore) GetByOrg(_ context.Context, orgID string) (Pool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, p := range s.m {
+		if p.OrgID == orgID {
+			return p, nil
+		}
+	}
+	return Pool{}, ErrNotFound
+}
+
+func (s *MemoryPoolStore) ListEnabled(_ context.Context) ([]Pool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []Pool
+	for _, p := range s.m {
+		if p.Enabled {
+			out = append(out, p)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+func (s *MemoryPoolStore) Upsert(_ context.Context, p Pool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now().UTC()
+	if existing, ok := s.m[p.ID]; ok {
+		p.CreatedAt = existing.CreatedAt
+	} else if p.CreatedAt.IsZero() {
+		p.CreatedAt = now
+	}
+	p.UpdatedAt = now
+	s.m[p.ID] = p
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Pledges
+// ---------------------------------------------------------------------------
+
+type MemoryPledgeStore struct {
+	mu sync.Mutex
+	m  map[string]Pledge
+}
+
+func NewMemoryPledgeStore() *MemoryPledgeStore { return &MemoryPledgeStore{m: map[string]Pledge{}} }
+
+func (s *MemoryPledgeStore) Get(_ context.Context, id string) (Pledge, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.m[id]
+	if !ok {
+		return Pledge{}, ErrNotFound
+	}
+	return p, nil
+}
+
+func (s *MemoryPledgeStore) ListByPool(_ context.Context, poolID string) ([]Pledge, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []Pledge
+	for _, p := range s.m {
+		if p.PoolID == poolID {
+			out = append(out, p)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+func (s *MemoryPledgeStore) ListByUser(_ context.Context, userID string) ([]Pledge, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []Pledge
+	for _, p := range s.m {
+		if p.UserID == userID {
+			out = append(out, p)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+func (s *MemoryPledgeStore) Upsert(_ context.Context, p Pledge) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if p.ID == "" {
+		p.ID = PledgeID(p.UserID, p.Kind)
+	}
+	now := time.Now().UTC()
+	if existing, ok := s.m[p.ID]; ok {
+		p.CreatedAt = existing.CreatedAt
+	} else if p.CreatedAt.IsZero() {
+		p.CreatedAt = now
+	}
+	p.UpdatedAt = now
+	s.m[p.ID] = p
+	return nil
+}
+
+func (s *MemoryPledgeStore) TouchLastServed(_ context.Context, id string, when time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p, ok := s.m[id]
+	if !ok {
+		return ErrNotFound
+	}
+	t := when.UTC()
+	p.LastServedAt = &t
+	p.UpdatedAt = t
+	s.m[id] = p
+	return nil
+}
+
+func (s *MemoryPledgeStore) Delete(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.m[id]; !ok {
+		return ErrNotFound
+	}
+	delete(s.m, id)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Leases
+// ---------------------------------------------------------------------------
+
+type MemoryLeaseStore struct {
+	mu sync.Mutex
+	m  map[string]Lease
+}
+
+func NewMemoryLeaseStore() *MemoryLeaseStore { return &MemoryLeaseStore{m: map[string]Lease{}} }
+
+func (s *MemoryLeaseStore) Put(_ context.Context, l Lease) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if l.ID == "" {
+		return ErrNotFound
+	}
+	s.m[l.ID] = l
+	return nil
+}
+
+func (s *MemoryLeaseStore) Get(_ context.Context, leaseID string) (Lease, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	l, ok := s.m[leaseID]
+	if !ok {
+		return Lease{}, ErrNotFound
+	}
+	return l, nil
+}
+
+func (s *MemoryLeaseStore) GetOpenByRun(ctx context.Context, runID string) (Lease, error) {
+	open, err := s.ListOpenByRun(ctx, runID)
+	if err != nil {
+		return Lease{}, err
+	}
+	if len(open) == 0 {
+		return Lease{}, ErrNotFound
+	}
+	return open[0], nil // newest first
+}
+
+func (s *MemoryLeaseStore) ListOpenByRun(_ context.Context, runID string) ([]Lease, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []Lease
+	for _, l := range s.m {
+		if l.RunID == runID && !l.Closed {
+			out = append(out, l)
+		}
+	}
+	// Newest first: a map's iteration order is randomised, and picking
+	// arbitrarily here would charge an arbitrary donor.
+	sort.Slice(out, func(i, j int) bool { return out[i].AcquiredAt.After(out[j].AcquiredAt) })
+	return out, nil
+}
+
+func (s *MemoryLeaseStore) HasServedAttempt(_ context.Context, runID, pledgeID string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, l := range s.m {
+		if l.RunID == runID && l.PledgeID == pledgeID && l.Outcome != OutcomeAbandoned {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *MemoryLeaseStore) Close(_ context.Context, leaseID string, costUSD float64, outcome string, when time.Time) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	l, ok := s.m[leaseID]
+	if !ok {
+		return false, ErrNotFound
+	}
+	if l.Closed {
+		// Already reported. Losing this race is how a redelivered report
+		// learns not to charge the donor a second time.
+		return false, nil
+	}
+	l.Closed = true
+	l.CostUSD = costUSD
+	l.Outcome = outcome
+	t := when.UTC()
+	l.ClosedAt = &t
+	s.m[leaseID] = l
+	return true, nil
+}
+
+func (s *MemoryLeaseStore) LiveCommitment(_ context.Context, pledgeID, excludeRunID string, now time.Time) (int, float64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n, committed := 0, 0.0
+	for _, l := range s.m {
+		if excludeRunID != "" && l.RunID == excludeRunID {
+			continue
+		}
+		if l.PledgeID == pledgeID && !l.Closed && now.Before(l.ExpiresAt) {
+			n++
+			committed += l.GrantedCostUSD
+		}
+	}
+	return n, committed, nil
+}
+
+func (s *MemoryLeaseStore) ListExpired(_ context.Context, now time.Time, limit int) ([]Lease, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []Lease
+	for _, l := range s.m {
+		if !l.Closed && !now.Before(l.ExpiresAt) {
+			out = append(out, l)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ExpiresAt.Before(out[j].ExpiresAt) })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func (s *MemoryLeaseStore) ListByDonor(_ context.Context, donorID string, limit int) ([]Lease, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []Lease
+	for _, l := range s.m {
+		if l.DonorID == donorID {
+			out = append(out, l)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].AcquiredAt.After(out[j].AcquiredAt) })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Ledger
+// ---------------------------------------------------------------------------
+
+type memBucket struct {
+	runs                     int
+	costMillis               int64
+	inputTokens, outputToken int64
+}
+
+type MemoryLedger struct {
+	mu sync.Mutex
+	m  map[string]*memBucket
+}
+
+func NewMemoryLedger() *MemoryLedger { return &MemoryLedger{m: map[string]*memBucket{}} }
+
+func (l *MemoryLedger) bucket(key string) *memBucket {
+	b, ok := l.m[key]
+	if !ok {
+		b = &memBucket{}
+		l.m[key] = b
+	}
+	return b
+}
+
+func (l *MemoryLedger) Reserve(_ context.Context, pledgeID string, when time.Time, lim Limits, live LiveCommitment) (float64, DenyReason, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if lim.MaxConcurrentRuns > 0 && live.Runs >= lim.MaxConcurrentRuns {
+		return 0, DenyConcurrency, nil
+	}
+	day := l.bucket(ledgerKey(pledgeID, periodDay, dayKey(when)))
+	week := l.bucket(ledgerKey(pledgeID, periodWeek, weekKey(when)))
+
+	// day.runs+1 — the judgement covers the admission at hand.
+	remaining, deny := decide(lim, day.runs+1, millisToCost(day.costMillis), millisToCost(week.costMillis), live)
+	if deny != DenyNone {
+		return 0, deny, nil
+	}
+	day.runs++
+	return remaining, DenyNone, nil
+}
+
+func (l *MemoryLedger) Renew(_ context.Context, pledgeID string, when time.Time, lim Limits, live LiveCommitment) (float64, DenyReason, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if lim.MaxConcurrentRuns > 0 && live.Runs >= lim.MaxConcurrentRuns {
+		return 0, DenyConcurrency, nil
+	}
+	day := l.bucket(ledgerKey(pledgeID, periodDay, dayKey(when)))
+	week := l.bucket(ledgerKey(pledgeID, periodWeek, weekKey(when)))
+	// runsAfterAdmit = 0 skips the run-count ceiling: this run was already
+	// counted when it was first admitted.
+	return decideRenew(lim, millisToCost(day.costMillis), millisToCost(week.costMillis), live)
+}
+
+// decideRenew is decide() with the run-count ceiling left out.
+func decideRenew(lim Limits, daySpent, weekSpent float64, live LiveCommitment) (float64, DenyReason, error) {
+	remaining, deny := decide(Limits{
+		MaxUSDPerDay:  lim.MaxUSDPerDay,
+		MaxUSDPerWeek: lim.MaxUSDPerWeek,
+	}, 0, daySpent, weekSpent, live)
+	return remaining, deny, nil
+}
+
+func (l *MemoryLedger) ReleaseRun(_ context.Context, pledgeID string, when time.Time) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if b, ok := l.m[ledgerKey(pledgeID, periodDay, dayKey(when))]; ok && b.runs > 0 {
+		b.runs--
+	}
+	return nil
+}
+
+func (l *MemoryLedger) AddSpend(_ context.Context, pledgeID string, when time.Time, costUSD float64, in, out int64) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	millis := CostToMillis(costUSD)
+	if millis == 0 && in <= 0 && out <= 0 {
+		return nil
+	}
+	for _, key := range []string{
+		ledgerKey(pledgeID, periodDay, dayKey(when)),
+		ledgerKey(pledgeID, periodWeek, weekKey(when)),
+	} {
+		b := l.bucket(key)
+		b.costMillis += millis
+		if in > 0 {
+			b.inputTokens += in
+		}
+		if out > 0 {
+			b.outputToken += out
+		}
+	}
+	return nil
+}
+
+func (l *MemoryLedger) Usage(_ context.Context, pledgeID string, when time.Time) (Usage, Usage, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.usageLocked(pledgeID, periodDay, dayKey(when)), l.usageLocked(pledgeID, periodWeek, weekKey(when)), nil
+}
+
+func (l *MemoryLedger) usageLocked(pledgeID, period, key string) Usage {
+	u := Usage{Period: periodName(period), Key: key}
+	if b, ok := l.m[ledgerKey(pledgeID, period, key)]; ok {
+		u.Runs = b.runs
+		u.CostUSD = millisToCost(b.costMillis)
+		u.InputTokens = b.inputTokens
+		u.OutputTokens = b.outputToken
+	}
+	return u
+}
+
+func (l *MemoryLedger) UsageMany(_ context.Context, pledgeIDs []string, when time.Time) (map[string]Usage, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	key := dayKey(when)
+	out := make(map[string]Usage, len(pledgeIDs))
+	for _, id := range pledgeIDs {
+		out[id] = l.usageLocked(id, periodDay, key)
+	}
+	return out, nil
+}
+
+func periodName(period string) string {
+	if period == periodWeek {
+		return "week"
+	}
+	return "day"
+}

--- a/pkg/credpool/mongo.go
+++ b/pkg/credpool/mongo.go
@@ -239,7 +239,7 @@ func (s *MongoLeaseStore) HasServedAttempt(ctx context.Context, runID, pledgeID 
 	n, err := s.col.CountDocuments(ctx, bson.M{
 		"run_id":    runID,
 		"pledge_id": pledgeID,
-		"outcome":   bson.M{"$ne": OutcomeAbandoned},
+		"outcome":   bson.M{"$nin": nonAdmissionOutcomes},
 	})
 	if err != nil {
 		return false, fmt.Errorf("credpool: prior attempt lookup: %w", err)

--- a/pkg/credpool/mongo.go
+++ b/pkg/credpool/mongo.go
@@ -1,0 +1,562 @@
+package credpool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/SocialGouv/iterion/pkg/internal/mongoutil"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+// Collection names.
+const (
+	colPools   = "cred_pools"
+	colPledges = "cred_pledges"
+	colLeases  = "cred_leases"
+	colLedger  = "cred_pool_usage"
+)
+
+// EnsureSchema creates every index this package needs, idempotently.
+func EnsureSchema(ctx context.Context, db *mongo.Database) error {
+	specs := []struct {
+		col   string
+		model []mongo.IndexModel
+	}{
+		{colPools, []mongo.IndexModel{
+			{Keys: bson.D{{Key: "org_id", Value: 1}}, Options: options.Index().SetName("pool_org")},
+		}},
+		{colPledges, []mongo.IndexModel{
+			{Keys: bson.D{{Key: "pool_id", Value: 1}}, Options: options.Index().SetName("pledge_pool")},
+			{Keys: bson.D{{Key: "user_id", Value: 1}}, Options: options.Index().SetName("pledge_user")},
+		}},
+		{colLeases, []mongo.IndexModel{
+			// The concurrency + commitment reading: live leases of one pledge.
+			{Keys: bson.D{{Key: "pledge_id", Value: 1}, {Key: "closed", Value: 1}, {Key: "expires_at", Value: 1}},
+				Options: options.Index().SetName("lease_live")},
+			// "which donor is serving this run right now", newest first.
+			{Keys: bson.D{{Key: "run_id", Value: 1}, {Key: "closed", Value: 1}, {Key: "acquired_at", Value: -1}},
+				Options: options.Index().SetName("lease_run")},
+			// The sweeper's scan.
+			{Keys: bson.D{{Key: "closed", Value: 1}, {Key: "expires_at", Value: 1}},
+				Options: options.Index().SetName("lease_expiry")},
+			// The donor's history view.
+			{Keys: bson.D{{Key: "donor_id", Value: 1}, {Key: "acquired_at", Value: -1}},
+				Options: options.Index().SetName("lease_donor")},
+			// "has this pledge already admitted this run" (the resume test).
+			{Keys: bson.D{{Key: "run_id", Value: 1}, {Key: "pledge_id", Value: 1}},
+				Options: options.Index().SetName("lease_run_pledge")},
+			// Retention. Anchored on acquired_at so a lease is evicted a
+			// fixed time after it was granted whether or not it ever
+			// closed — an abandoned lease must not become immortal.
+			{Keys: bson.D{{Key: "acquired_at", Value: 1}},
+				Options: options.Index().SetName("lease_ttl").SetExpireAfterSeconds(int32(LeaseRetention / time.Second))},
+		}},
+		{colLedger, []mongo.IndexModel{
+			{Keys: bson.D{{Key: "period_start", Value: 1}},
+				Options: options.Index().SetName("ledger_ttl").SetExpireAfterSeconds(int32(LedgerRetentionDays * 24 * 60 * 60))},
+		}},
+	}
+	for _, s := range specs {
+		if _, err := db.Collection(s.col).Indexes().CreateMany(ctx, s.model); err != nil && !mongoutil.IsIndexConflict(err) {
+			return fmt.Errorf("credpool: ensure %s indexes: %w", s.col, err)
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Pools
+// ---------------------------------------------------------------------------
+
+type MongoPoolStore struct{ col *mongo.Collection }
+
+func NewMongoPoolStore(db *mongo.Database) *MongoPoolStore {
+	return &MongoPoolStore{col: db.Collection(colPools)}
+}
+
+func (s *MongoPoolStore) GetByOrg(ctx context.Context, orgID string) (Pool, error) {
+	return mongoutil.FindOne[Pool](ctx, s.col, bson.M{"org_id": orgID}, ErrNotFound, "credpool: get pool by org")
+}
+
+func (s *MongoPoolStore) ListEnabled(ctx context.Context) ([]Pool, error) {
+	return mongoutil.FindAllSorted[Pool](ctx, s.col, bson.M{"enabled": true}, "_id",
+		"credpool: list enabled pools", "credpool: decode pool")
+}
+
+func (s *MongoPoolStore) Upsert(ctx context.Context, p Pool) error {
+	now := time.Now().UTC()
+	p.UpdatedAt = now
+	if p.CreatedAt.IsZero() {
+		p.CreatedAt = now
+	}
+	set, err := mongoutil.SetBodyWithoutID(p, "credpool: pool")
+	if err != nil {
+		return err
+	}
+	delete(set, "created_at") // never rewrite the original creation instant
+	_, err = s.col.UpdateOne(ctx, bson.M{"_id": p.ID}, bson.M{
+		"$set":         set,
+		"$setOnInsert": bson.M{"_id": p.ID, "created_at": p.CreatedAt},
+	}, options.UpdateOne().SetUpsert(true))
+	if err != nil {
+		return fmt.Errorf("credpool: upsert pool: %w", err)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Pledges
+// ---------------------------------------------------------------------------
+
+type MongoPledgeStore struct{ col *mongo.Collection }
+
+func NewMongoPledgeStore(db *mongo.Database) *MongoPledgeStore {
+	return &MongoPledgeStore{col: db.Collection(colPledges)}
+}
+
+func (s *MongoPledgeStore) Get(ctx context.Context, id string) (Pledge, error) {
+	return mongoutil.FindOne[Pledge](ctx, s.col, bson.M{"_id": id}, ErrNotFound, "credpool: get pledge")
+}
+
+func (s *MongoPledgeStore) ListByPool(ctx context.Context, poolID string) ([]Pledge, error) {
+	return mongoutil.FindAllSorted[Pledge](ctx, s.col, bson.M{"pool_id": poolID}, "_id",
+		"credpool: list pledges", "credpool: decode pledge")
+}
+
+func (s *MongoPledgeStore) ListByUser(ctx context.Context, userID string) ([]Pledge, error) {
+	return mongoutil.FindAllSorted[Pledge](ctx, s.col, bson.M{"user_id": userID}, "_id",
+		"credpool: list user pledges", "credpool: decode pledge")
+}
+
+func (s *MongoPledgeStore) Upsert(ctx context.Context, p Pledge) error {
+	if p.ID == "" {
+		p.ID = PledgeID(p.UserID, p.Kind)
+	}
+	now := time.Now().UTC()
+	p.UpdatedAt = now
+	if p.CreatedAt.IsZero() {
+		p.CreatedAt = now
+	}
+	set, err := mongoutil.SetBodyWithoutID(p, "credpool: pledge")
+	if err != nil {
+		return err
+	}
+	delete(set, "created_at")
+	// A nil cooldown/window must actually clear a previously-set value —
+	// omitempty drops the key from the marshalled body, so $unset it.
+	unset := bson.M{}
+	if p.CooldownUntil == nil {
+		unset["cooldown_until"] = ""
+	}
+	if p.Window == nil {
+		unset["window"] = ""
+	}
+	update := bson.M{
+		"$set":         set,
+		"$setOnInsert": bson.M{"_id": p.ID, "created_at": p.CreatedAt},
+	}
+	if len(unset) > 0 {
+		update["$unset"] = unset
+	}
+	if _, err := s.col.UpdateOne(ctx, bson.M{"_id": p.ID}, update, options.UpdateOne().SetUpsert(true)); err != nil {
+		return fmt.Errorf("credpool: upsert pledge: %w", err)
+	}
+	return nil
+}
+
+func (s *MongoPledgeStore) TouchLastServed(ctx context.Context, id string, when time.Time) error {
+	t := when.UTC()
+	return mongoutil.UpdateOneChecked(ctx, s.col, bson.M{"_id": id},
+		bson.M{"$set": bson.M{"last_served_at": t, "updated_at": t}},
+		ErrNotFound, "credpool: touch pledge")
+}
+
+func (s *MongoPledgeStore) Delete(ctx context.Context, id string) error {
+	return mongoutil.DeleteOneChecked(ctx, s.col, bson.M{"_id": id}, ErrNotFound, "credpool: delete pledge")
+}
+
+// ---------------------------------------------------------------------------
+// Leases
+// ---------------------------------------------------------------------------
+
+type MongoLeaseStore struct{ col *mongo.Collection }
+
+func NewMongoLeaseStore(db *mongo.Database) *MongoLeaseStore {
+	return &MongoLeaseStore{col: db.Collection(colLeases)}
+}
+
+func (s *MongoLeaseStore) Put(ctx context.Context, l Lease) error {
+	if l.ID == "" {
+		return fmt.Errorf("credpool: lease without an id")
+	}
+	// Insert: every attempt gets its own record, so a finished attempt's
+	// cost and outcome — the donor's evidence for the charge on their
+	// ledger — is never overwritten by a later one.
+	if _, err := s.col.InsertOne(ctx, l); err != nil {
+		return fmt.Errorf("credpool: put lease: %w", err)
+	}
+	return nil
+}
+
+func (s *MongoLeaseStore) Get(ctx context.Context, leaseID string) (Lease, error) {
+	return mongoutil.FindOne[Lease](ctx, s.col, bson.M{"_id": leaseID}, ErrNotFound, "credpool: get lease")
+}
+
+func (s *MongoLeaseStore) GetOpenByRun(ctx context.Context, runID string) (Lease, error) {
+	open, err := s.ListOpenByRun(ctx, runID)
+	if err != nil {
+		return Lease{}, err
+	}
+	if len(open) == 0 {
+		return Lease{}, ErrNotFound
+	}
+	return open[0], nil // newest first
+}
+
+func (s *MongoLeaseStore) ListOpenByRun(ctx context.Context, runID string) ([]Lease, error) {
+	// Newest first: an unsorted FindOne would pick arbitrarily, and that
+	// choice decides which donor gets charged.
+	cur, err := s.col.Find(ctx, bson.M{"run_id": runID, "closed": false},
+		options.Find().SetSort(bson.D{{Key: "acquired_at", Value: -1}}))
+	if err != nil {
+		return nil, fmt.Errorf("credpool: list open leases: %w", err)
+	}
+	defer cur.Close(ctx)
+	var out []Lease
+	if err := cur.All(ctx, &out); err != nil {
+		return nil, fmt.Errorf("credpool: decode open leases: %w", err)
+	}
+	return out, nil
+}
+
+func (s *MongoLeaseStore) HasServedAttempt(ctx context.Context, runID, pledgeID string) (bool, error) {
+	n, err := s.col.CountDocuments(ctx, bson.M{
+		"run_id":    runID,
+		"pledge_id": pledgeID,
+		"outcome":   bson.M{"$ne": OutcomeAbandoned},
+	})
+	if err != nil {
+		return false, fmt.Errorf("credpool: prior attempt lookup: %w", err)
+	}
+	return n > 0, nil
+}
+
+func (s *MongoLeaseStore) Close(ctx context.Context, leaseID string, costUSD float64, outcome string, when time.Time) (bool, error) {
+	// Conditional on closed:false — winning this CAS is what earns the
+	// right to charge the donor, so a redelivered report loses it and
+	// charges nothing.
+	res, err := s.col.UpdateOne(ctx,
+		bson.M{"_id": leaseID, "closed": false},
+		bson.M{"$set": bson.M{
+			"closed":    true,
+			"cost_usd":  costUSD,
+			"outcome":   outcome,
+			"closed_at": when.UTC(),
+		}})
+	if err != nil {
+		return false, fmt.Errorf("credpool: close lease: %w", err)
+	}
+	if res.MatchedCount > 0 {
+		return true, nil
+	}
+	n, cerr := s.col.CountDocuments(ctx, bson.M{"_id": leaseID})
+	if cerr == nil && n == 0 {
+		return false, ErrNotFound
+	}
+	return false, nil
+}
+
+func (s *MongoLeaseStore) LiveCommitment(ctx context.Context, pledgeID, excludeRunID string, now time.Time) (int, float64, error) {
+	filter := bson.M{
+		"pledge_id":  pledgeID,
+		"closed":     false,
+		"expires_at": bson.M{"$gt": now.UTC()},
+	}
+	if excludeRunID != "" {
+		filter["run_id"] = bson.M{"$ne": excludeRunID}
+	}
+	cur, err := s.col.Aggregate(ctx, []bson.M{
+		{"$match": filter},
+		{"$group": bson.M{
+			"_id":       nil,
+			"runs":      bson.M{"$sum": 1},
+			"committed": bson.M{"$sum": "$granted_cost_usd"},
+		}},
+	})
+	if err != nil {
+		return 0, 0, fmt.Errorf("credpool: live commitment: %w", err)
+	}
+	defer cur.Close(ctx)
+	var out []struct {
+		Runs      int     `bson:"runs"`
+		Committed float64 `bson:"committed"`
+	}
+	if err := cur.All(ctx, &out); err != nil {
+		return 0, 0, fmt.Errorf("credpool: decode live commitment: %w", err)
+	}
+	if len(out) == 0 {
+		return 0, 0, nil
+	}
+	return out[0].Runs, out[0].Committed, nil
+}
+
+func (s *MongoLeaseStore) ListExpired(ctx context.Context, now time.Time, limit int) ([]Lease, error) {
+	opts := options.Find().SetSort(bson.D{{Key: "expires_at", Value: 1}})
+	if limit > 0 {
+		opts = opts.SetLimit(int64(limit))
+	}
+	cur, err := s.col.Find(ctx, bson.M{"closed": false, "expires_at": bson.M{"$lte": now.UTC()}}, opts)
+	if err != nil {
+		return nil, fmt.Errorf("credpool: list expired leases: %w", err)
+	}
+	defer cur.Close(ctx)
+	var out []Lease
+	if err := cur.All(ctx, &out); err != nil {
+		return nil, fmt.Errorf("credpool: decode expired leases: %w", err)
+	}
+	return out, nil
+}
+
+func (s *MongoLeaseStore) ListByDonor(ctx context.Context, donorID string, limit int) ([]Lease, error) {
+	opts := options.Find().SetSort(bson.D{{Key: "acquired_at", Value: -1}})
+	if limit > 0 {
+		opts = opts.SetLimit(int64(limit))
+	}
+	cur, err := s.col.Find(ctx, bson.M{"donor_id": donorID}, opts)
+	if err != nil {
+		return nil, fmt.Errorf("credpool: list donor leases: %w", err)
+	}
+	defer cur.Close(ctx)
+	var out []Lease
+	if err := cur.All(ctx, &out); err != nil {
+		return nil, fmt.Errorf("credpool: decode donor leases: %w", err)
+	}
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Ledger
+// ---------------------------------------------------------------------------
+
+// MongoLedger is the production Ledger. One document per (pledge, period);
+// the daily run counter is bumped through findOneAndUpdate so the admission
+// decision reads a post-increment document — the same CAS strategy as
+// orgusage.MongoCounter.
+type MongoLedger struct {
+	col    *mongo.Collection
+	logger *iterlog.Logger
+}
+
+func NewMongoLedger(db *mongo.Database) *MongoLedger {
+	return &MongoLedger{col: db.Collection(colLedger)}
+}
+
+// WithLogger lets the ledger report a lost rollback, which would otherwise
+// silently inflate a donor's daily run count.
+func (l *MongoLedger) WithLogger(lg *iterlog.Logger) *MongoLedger { l.logger = lg; return l }
+
+type ledgerDoc struct {
+	Runs         int       `bson:"runs"`
+	CostMillis   int64     `bson:"cost_usd_millis"`
+	InputTokens  int64     `bson:"input_tokens"`
+	OutputTokens int64     `bson:"output_tokens"`
+	PeriodStart  time.Time `bson:"period_start"`
+}
+
+func (l *MongoLedger) Reserve(ctx context.Context, pledgeID string, when time.Time, lim Limits, live LiveCommitment) (float64, DenyReason, error) {
+	// Concurrency first: it is the cheapest refusal and the one a donor
+	// most expects to be immediate.
+	if lim.MaxConcurrentRuns > 0 && live.Runs >= lim.MaxConcurrentRuns {
+		return 0, DenyConcurrency, nil
+	}
+	dayID := ledgerKey(pledgeID, periodDay, dayKey(when))
+	var day ledgerDoc
+	err := l.col.FindOneAndUpdate(ctx,
+		bson.M{"_id": dayID},
+		bson.M{
+			"$inc":         bson.M{"runs": 1},
+			"$setOnInsert": bson.M{"period_start": dayStart(when)},
+		},
+		options.FindOneAndUpdate().SetUpsert(true).SetReturnDocument(options.After),
+	).Decode(&day)
+	if err != nil {
+		return 0, DenyNone, fmt.Errorf("credpool: reserve: %w", err)
+	}
+
+	// The weekly bucket only ever caps COST, which AddSpend accumulates
+	// after the fact — so it is a plain read, no increment to roll back.
+	// Skipped entirely for a donor who set no weekly cap (the common
+	// shape): it would be a round trip per candidate, per launch, whose
+	// result nothing reads.
+	var week ledgerDoc
+	if lim.MaxUSDPerWeek > 0 {
+		werr := l.col.FindOne(ctx, bson.M{"_id": ledgerKey(pledgeID, periodWeek, weekKey(when))}).Decode(&week)
+		if werr != nil && !errors.Is(werr, mongo.ErrNoDocuments) {
+			l.rollback(ctx, dayID)
+			return 0, DenyNone, fmt.Errorf("credpool: reserve (week): %w", werr)
+		}
+	}
+
+	// day.Runs is already post-increment, which is the count decide judges.
+	remaining, deny := decide(lim, day.Runs, millisToCost(day.CostMillis), millisToCost(week.CostMillis), live)
+	if deny != DenyNone {
+		l.rollback(ctx, dayID)
+		return 0, deny, nil
+	}
+	return remaining, DenyNone, nil
+}
+
+// Renew re-checks the spend caps for an already-admitted run: two plain
+// reads, no increment and nothing to roll back.
+func (l *MongoLedger) Renew(ctx context.Context, pledgeID string, when time.Time, lim Limits, live LiveCommitment) (float64, DenyReason, error) {
+	if lim.MaxConcurrentRuns > 0 && live.Runs >= lim.MaxConcurrentRuns {
+		return 0, DenyConcurrency, nil
+	}
+	day, err := l.readBucket(ctx, pledgeID, periodDay, dayKey(when))
+	if err != nil {
+		return 0, DenyNone, err
+	}
+	week, err := l.readBucket(ctx, pledgeID, periodWeek, weekKey(when))
+	if err != nil {
+		return 0, DenyNone, err
+	}
+	return decideRenew(lim, day.CostUSD, week.CostUSD, live)
+}
+
+// rollback releases an optimistically-consumed run unit. Detached ctx: a
+// cancelled request must still give the quota back, else a refused
+// admission leaves the donor's counter permanently inflated.
+//
+// A lost rollback is exactly that inflation, and it is invisible from the
+// donor's side — so it is reported rather than swallowed.
+func (l *MongoLedger) rollback(ctx context.Context, dayID string) {
+	if _, err := l.col.UpdateOne(context.WithoutCancel(ctx), bson.M{"_id": dayID}, bson.M{"$inc": bson.M{"runs": -1}}); err != nil && l.logger != nil {
+		l.logger.Warn("credpool: could not roll back the reserved run unit of %s: %v (this donor's daily run count now over-reports by one)", dayID, err)
+	}
+}
+
+func (l *MongoLedger) ReleaseRun(ctx context.Context, pledgeID string, when time.Time) error {
+	// No upsert, and a floor at zero: decrementing a fresh (or TTL-evicted)
+	// document would drive the count NEGATIVE, which silently hands the
+	// donor extra runs for the rest of the day. The memory ledger has the
+	// same guard — the two must decide identically.
+	_, err := l.col.UpdateOne(ctx,
+		bson.M{"_id": ledgerKey(pledgeID, periodDay, dayKey(when)), "runs": bson.M{"$gt": 0}},
+		bson.M{"$inc": bson.M{"runs": -1}})
+	if err != nil {
+		return fmt.Errorf("credpool: release run: %w", err)
+	}
+	return nil
+}
+
+func (l *MongoLedger) AddSpend(ctx context.Context, pledgeID string, when time.Time, costUSD float64, in, out int64) error {
+	inc := bson.M{}
+	if m := CostToMillis(costUSD); m > 0 {
+		inc["cost_usd_millis"] = m
+	}
+	if in > 0 {
+		inc["input_tokens"] = in
+	}
+	if out > 0 {
+		inc["output_tokens"] = out
+	}
+	if len(inc) == 0 {
+		return nil
+	}
+	for _, b := range []struct {
+		id    string
+		start time.Time
+	}{
+		{ledgerKey(pledgeID, periodDay, dayKey(when)), dayStart(when)},
+		{ledgerKey(pledgeID, periodWeek, weekKey(when)), weekStart(when)},
+	} {
+		if _, err := l.col.UpdateOne(ctx, bson.M{"_id": b.id}, bson.M{
+			"$inc":         inc,
+			"$setOnInsert": bson.M{"period_start": b.start},
+		}, options.UpdateOne().SetUpsert(true)); err != nil {
+			return fmt.Errorf("credpool: add spend: %w", err)
+		}
+	}
+	return nil
+}
+
+func (l *MongoLedger) Usage(ctx context.Context, pledgeID string, when time.Time) (Usage, Usage, error) {
+	day, err := l.readBucket(ctx, pledgeID, periodDay, dayKey(when))
+	if err != nil {
+		return Usage{}, Usage{}, err
+	}
+	week, err := l.readBucket(ctx, pledgeID, periodWeek, weekKey(when))
+	if err != nil {
+		return Usage{}, Usage{}, err
+	}
+	return day, week, nil
+}
+
+func (l *MongoLedger) readBucket(ctx context.Context, pledgeID, period, key string) (Usage, error) {
+	u := Usage{Period: periodName(period), Key: key}
+	var doc ledgerDoc
+	err := l.col.FindOne(ctx, bson.M{"_id": ledgerKey(pledgeID, period, key)}).Decode(&doc)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return u, nil
+	}
+	if err != nil {
+		return u, fmt.Errorf("credpool: usage: %w", err)
+	}
+	u.Runs = doc.Runs
+	u.CostUSD = millisToCost(doc.CostMillis)
+	u.InputTokens = doc.InputTokens
+	u.OutputTokens = doc.OutputTokens
+	return u, nil
+}
+
+func (l *MongoLedger) UsageMany(ctx context.Context, pledgeIDs []string, when time.Time) (map[string]Usage, error) {
+	key := dayKey(when)
+	out := make(map[string]Usage, len(pledgeIDs))
+	ids := make([]string, 0, len(pledgeIDs))
+	byDocID := make(map[string]string, len(pledgeIDs))
+	for _, p := range pledgeIDs {
+		// Absent buckets must still appear as zero usage: a donor who has
+		// served nothing today is the LEAST consumed, and dropping them
+		// here would rank them last instead of first.
+		out[p] = Usage{Period: "day", Key: key}
+		id := ledgerKey(p, periodDay, key)
+		ids = append(ids, id)
+		byDocID[id] = p
+	}
+	if len(ids) == 0 {
+		return out, nil
+	}
+	cur, err := l.col.Find(ctx, bson.M{"_id": bson.M{"$in": ids}})
+	if err != nil {
+		return nil, fmt.Errorf("credpool: usage many: %w", err)
+	}
+	defer cur.Close(ctx)
+	for cur.Next(ctx) {
+		var raw struct {
+			ID        string `bson:"_id"`
+			ledgerDoc `bson:",inline"`
+		}
+		if err := cur.Decode(&raw); err != nil {
+			return nil, fmt.Errorf("credpool: decode usage: %w", err)
+		}
+		pledgeID, ok := byDocID[raw.ID]
+		if !ok {
+			continue
+		}
+		out[pledgeID] = Usage{
+			Period:       "day",
+			Key:          key,
+			Runs:         raw.Runs,
+			CostUSD:      millisToCost(raw.CostMillis),
+			InputTokens:  raw.InputTokens,
+			OutputTokens: raw.OutputTokens,
+		}
+	}
+	return out, cur.Err()
+}

--- a/pkg/credpool/store.go
+++ b/pkg/credpool/store.go
@@ -1,0 +1,219 @@
+package credpool
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrNotFound is the shared sentinel for every store in this package.
+var ErrNotFound = errors.New("credpool: not found")
+
+// PoolStore persists pools.
+type PoolStore interface {
+	// GetByOrg returns the pool an org OWNS — the lookup the management
+	// API uses. NOT the launch path's lookup: a pool whose audience opens
+	// it to other orgs must be reachable from those orgs, so selection
+	// goes through ListEnabled instead.
+	GetByOrg(ctx context.Context, orgID string) (Pool, error)
+	// ListEnabled returns every pool currently accepting requests. The
+	// broker filters them by audience in Go, because the audience is a
+	// union of predicates (including "is the requester themselves a
+	// donor") that no single index can answer.
+	ListEnabled(ctx context.Context) ([]Pool, error)
+	Upsert(ctx context.Context, p Pool) error
+}
+
+// PledgeStore persists donors' offers.
+type PledgeStore interface {
+	Get(ctx context.Context, pledgeID string) (Pledge, error)
+	// ListByPool returns every pledge attached to a pool, enabled or not —
+	// the operator roster. Selection filters on top.
+	ListByPool(ctx context.Context, poolID string) ([]Pledge, error)
+	// ListByUser returns a donor's own pledges (one per credential kind).
+	ListByUser(ctx context.Context, userID string) ([]Pledge, error)
+	Upsert(ctx context.Context, p Pledge) error
+	Delete(ctx context.Context, pledgeID string) error
+	// TouchLastServed stamps the fairness tie-break instant. A dedicated
+	// single-field write, not an Upsert: this runs on the launch path for
+	// every acquisition, and rewriting the whole document there would also
+	// let a stale in-flight copy clobber a concurrent change — a donor
+	// pausing, or a cooldown just set by a finishing run.
+	TouchLastServed(ctx context.Context, pledgeID string, when time.Time) error
+}
+
+// LeaseStore persists the run↔pledge bindings.
+type LeaseStore interface {
+	// Put inserts an attempt's lease. Leases are never reused: a finished
+	// attempt's record is the donor's evidence for the charge on their
+	// ledger, and re-opening it would both erase that and re-arm the close
+	// CAS that keeps a redelivered report from charging twice.
+	Put(ctx context.Context, l Lease) error
+	// Get returns one lease by id.
+	Get(ctx context.Context, leaseID string) (Lease, error)
+	// GetOpenByRun returns the run's currently-open lease — what a
+	// finishing run reports against. Acquiring supersedes any earlier open
+	// lease of the same run, so there is normally exactly one; the MOST
+	// RECENT wins if that invariant is ever broken, because guessing
+	// arbitrarily would charge an arbitrary donor.
+	GetOpenByRun(ctx context.Context, runID string) (Lease, error)
+	// ListOpenByRun returns every open lease of a run, so acquiring can
+	// supersede the ones it replaces.
+	ListOpenByRun(ctx context.Context, runID string) ([]Lease, error)
+	// HasServedAttempt reports whether this pledge already admitted this
+	// run — the test for "this is a resume, not a new run". An abandoned
+	// attempt does not count: nothing ever learned what it spent, so the
+	// next attempt is charged as new rather than renewing indefinitely.
+	HasServedAttempt(ctx context.Context, runID, pledgeID string) (bool, error)
+	// Close marks a lease reported and frees its slot. It is a CAS on
+	// "still open": the caller may only charge the donor when it wins,
+	// which is what stops a redelivered report double-charging.
+	Close(ctx context.Context, leaseID string, costUSD float64, outcome string, when time.Time) (won bool, err error)
+	// LiveCommitment reports what a pledge currently has at stake: how many
+	// live (unclosed, unexpired) leases it holds, and the total allowance
+	// already handed to them. Derived from the leases rather than
+	// accumulated in a counter, so an abandoned run can never leave a slot
+	// or an allowance permanently consumed.
+	//
+	// excludeRunID is the run currently asking. A resume re-acquires for a
+	// run that still holds its own lease; counting that would let a run be
+	// refused by itself, silently dropping its donor at every resume of a
+	// pledge whose concurrency cap is 1.
+	LiveCommitment(ctx context.Context, pledgeID, excludeRunID string, now time.Time) (runs int, committedUSD float64, err error)
+	// ListExpired returns live leases past their expiry, for the sweeper.
+	ListExpired(ctx context.Context, now time.Time, limit int) ([]Lease, error)
+	// ListByDonor returns a donor's recent leases, newest first — the
+	// "what did my quota run" history.
+	ListByDonor(ctx context.Context, donorID string, limit int) ([]Lease, error)
+}
+
+// Usage is one pledge's consumption within a period.
+type Usage struct {
+	// Period is "day" or "week"; Key is its bucket ("2026-08-03",
+	// "2026-W31").
+	Period       string  `json:"period"`
+	Key          string  `json:"key"`
+	Runs         int     `json:"runs"`
+	CostUSD      float64 `json:"cost_usd"`
+	InputTokens  int64   `json:"input_tokens"`
+	OutputTokens int64   `json:"output_tokens"`
+}
+
+// Ledger meters per-pledge consumption and enforces the donor's limits.
+//
+// Shape and CAS strategy mirror pkg/orgusage deliberately: one document per
+// (pledge, period), all increments through findOneAndUpdate/$inc, so an
+// operator reasoning about one quota system can reason about the other.
+type Ledger interface {
+	// Reserve admits one run against pledgeID's limits and meters it.
+	//
+	// The daily bucket is the atomic one: the run counter is incremented
+	// and both daily caps are read off the SAME post-increment document,
+	// then rolled back on refusal. The weekly cap and the concurrency
+	// reading are checked around it and are soft by nature — a run's
+	// future spend is unknowable, so in-flight runs always finish and only
+	// new admissions are refused.
+	//
+	// remainingUSD is what is left of the tightest spend cap; it becomes
+	// the admitted run's own cost budget. Zero means the donor set no
+	// spend cap at all — the caller must NOT read it as "nothing left".
+	Reserve(ctx context.Context, pledgeID string, when time.Time, l Limits, live LiveCommitment) (remainingUSD float64, deny DenyReason, err error)
+	// Renew re-checks the SPEND caps for a run this pledge already
+	// admitted, without counting a second run against the daily run quota.
+	// A resumed run is the same run: charging the donor another unit of
+	// "runs per day" for it would let one flaky run that resumes a few
+	// times consume a contributor's entire day.
+	Renew(ctx context.Context, pledgeID string, when time.Time, l Limits, live LiveCommitment) (remainingUSD float64, deny DenyReason, err error)
+	// ReleaseRun undoes a Reserve whose run was never created.
+	ReleaseRun(ctx context.Context, pledgeID string, when time.Time) error
+	// AddSpend records what a served run actually consumed, into both the
+	// day and week buckets.
+	AddSpend(ctx context.Context, pledgeID string, when time.Time, costUSD float64, inputTokens, outputTokens int64) error
+	// Usage reads one pledge's day and week buckets.
+	Usage(ctx context.Context, pledgeID string, when time.Time) (day Usage, week Usage, err error)
+	// UsageMany reads the day bucket of several pledges at once — the
+	// selection path needs every candidate's consumption to rank them, and
+	// doing that one query per donor would put N round trips on every
+	// launch.
+	UsageMany(ctx context.Context, pledgeIDs []string, when time.Time) (map[string]Usage, error)
+}
+
+// DenyReason says which limit refused an admission. Stable tokens: they
+// reach the donor's UI and the acquisition trace.
+type DenyReason string
+
+const (
+	DenyNone        DenyReason = ""
+	DenyRunsPerDay  DenyReason = "runs_per_day"
+	DenyCostPerDay  DenyReason = "cost_per_day"
+	DenyCostPerWeek DenyReason = "cost_per_week"
+	DenyConcurrency DenyReason = "concurrency"
+)
+
+// LiveCommitment is what a pledge already has at stake across its open
+// leases: the runs it is serving, and the allowance handed to them but not
+// yet spent. Both bound the next admission.
+type LiveCommitment struct {
+	Runs         int
+	CommittedUSD float64
+}
+
+// Deny is the single expression of "has this donor given all they offered".
+//
+// It is THE rule: both ledger implementations enforce admission with it,
+// and the donor's status projection displays with it. Keeping one copy is
+// what stops a UI reading "sharing" while the ledger refuses every run —
+// and makes a new limit axis a one-line change instead of three.
+//
+// runsAfterAdmit is the day's run count INCLUDING the admission being
+// judged: the Mongo ledger reads it post-increment, the memory ledger and
+// the display add one themselves.
+func (l Limits) Deny(runsAfterAdmit int, daySpent, weekSpent float64) DenyReason {
+	switch {
+	case l.MaxRunsPerDay > 0 && runsAfterAdmit > l.MaxRunsPerDay:
+		return DenyRunsPerDay
+	case l.MaxUSDPerDay > 0 && daySpent >= l.MaxUSDPerDay:
+		return DenyCostPerDay
+	case l.MaxUSDPerWeek > 0 && weekSpent >= l.MaxUSDPerWeek:
+		return DenyCostPerWeek
+	}
+	return DenyNone
+}
+
+// decide is the admission judgement both ledgers share: spend already
+// accounted PLUS spend already promised to in-flight runs, against the
+// donor's ceilings.
+//
+// The returned allowance is what THIS run may spend. A capped donor with
+// nothing left denies rather than granting zero — zero on the wire means
+// "no ceiling", so handing it out here would turn an exhausted donor into
+// an unlimited one.
+func decide(l Limits, runsAfterAdmit int, daySpent, weekSpent float64, live LiveCommitment) (float64, DenyReason) {
+	if deny := l.Deny(runsAfterAdmit, daySpent+live.CommittedUSD, weekSpent+live.CommittedUSD); deny != DenyNone {
+		return 0, deny
+	}
+	remaining, capped := remainingAllowance(l, daySpent+live.CommittedUSD, weekSpent+live.CommittedUSD)
+	if capped && remaining <= 0 {
+		return 0, DenyCostPerDay
+	}
+	return remaining, DenyNone
+}
+
+// remainingAllowance returns what is left of the donor's spend caps given
+// the current day and week consumption, and whether any cap is set at all.
+// The tightest of the two wins — a weekly budget nearly spent must bound
+// today's run even when the daily cap looks generous.
+func remainingAllowance(l Limits, daySpent, weekSpent float64) (remaining float64, capped bool) {
+	if l.MaxUSDPerDay > 0 {
+		remaining, capped = l.MaxUSDPerDay-daySpent, true
+	}
+	if l.MaxUSDPerWeek > 0 {
+		if w := l.MaxUSDPerWeek - weekSpent; !capped || w < remaining {
+			remaining, capped = w, true
+		}
+	}
+	if capped && remaining < 0 {
+		remaining = 0
+	}
+	return remaining, capped
+}

--- a/pkg/internal/mongoutil/find.go
+++ b/pkg/internal/mongoutil/find.go
@@ -140,3 +140,20 @@ func DeleteOneChecked(ctx context.Context, coll *mongo.Collection, filter bson.M
 	}
 	return nil
 }
+
+// SetBodyWithoutID marshals a document into a `$set` body with `_id`
+// removed. Mongo rejects an update that touches `_id` ("Mod on _id not
+// allowed"), so an upsert that keeps the id in `$setOnInsert` must strip it
+// from the `$set` half — a dance every store here performs identically.
+func SetBodyWithoutID(v any, what string) (bson.M, error) {
+	raw, err := bson.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("%s: marshal: %w", what, err)
+	}
+	var body bson.M
+	if err := bson.Unmarshal(raw, &body); err != nil {
+		return nil, fmt.Errorf("%s: re-decode: %w", what, err)
+	}
+	delete(body, "_id")
+	return body, nil
+}

--- a/pkg/orgusage/orgusage.go
+++ b/pkg/orgusage/orgusage.go
@@ -25,9 +25,10 @@ type MonthlyUsage struct {
 	Runs int `json:"runs"`
 	// CostUSD is the metered LLM spend accumulated by runners. Claw
 	// (in-process) nodes are metered precisely; delegate backends
-	// (claude_code) report tokens without a price table, so their
-	// cost contribution is zero — treat this as a floor, not an
-	// exact invoice.
+	// contribute the figure their CLI reported, or a token estimate
+	// when it reports none (a subscription session bills nothing per
+	// call). A node whose model the price table cannot price adds
+	// nothing — treat this as a floor, not an exact invoice.
 	CostUSD      float64 `json:"cost_usd"`
 	InputTokens  int64   `json:"input_tokens"`
 	OutputTokens int64   `json:"output_tokens"`

--- a/pkg/runner/credpool_spend_test.go
+++ b/pkg/runner/credpool_spend_test.go
@@ -1,0 +1,226 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/backend/model"
+	"github.com/SocialGouv/iterion/pkg/cloud/metrics"
+	"github.com/SocialGouv/iterion/pkg/credpool"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+// poolHarness wires a real broker with one donor who is already serving a
+// run, so the runner's report closes a genuine lease.
+type poolHarness struct {
+	runner  *Runner
+	broker  *credpool.Broker
+	pledges *credpool.MemoryPledgeStore
+	ledger  *credpool.MemoryLedger
+	leases  *credpool.MemoryLeaseStore
+}
+
+func newPoolHarness(t *testing.T, limits credpool.Limits) *poolHarness {
+	t.Helper()
+	ctx := context.Background()
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	oauth := secrets.NewMemoryOAuthStore()
+	blob := []byte(`{"claudeAiOauth":{"accessToken":"sk-ant-donated"}}`)
+	sealed, err := secrets.SealOAuthPayload(sealer, "donor", secrets.OAuthKindClaudeCode, blob)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if err := oauth.Upsert(ctx, secrets.OAuthRecord{
+		UserID: "donor", Kind: secrets.OAuthKindClaudeCode, SealedPayload: sealed,
+	}); err != nil {
+		t.Fatalf("seed oauth: %v", err)
+	}
+
+	pools := credpool.NewMemoryPoolStore()
+	if err := pools.Upsert(ctx, credpool.Pool{ID: "pool-1", OrgID: "org-1", Enabled: true}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	pledges := credpool.NewMemoryPledgeStore()
+	if err := pledges.Upsert(ctx, credpool.Pledge{
+		ID: credpool.PledgeID("donor", "claude_code"), PoolID: "pool-1",
+		UserID: "donor", Kind: "claude_code",
+		Enabled: true, Health: credpool.HealthOK, Limits: limits,
+	}); err != nil {
+		t.Fatalf("seed pledge: %v", err)
+	}
+	leases := credpool.NewMemoryLeaseStore()
+	ledger := credpool.NewMemoryLedger()
+	broker := credpool.NewBroker(credpool.BrokerConfig{
+		Pools: pools, Pledges: pledges, Leases: leases, Ledger: ledger,
+		OAuth: oauth, Sealer: sealer, Logger: iterlog.New(iterlog.LevelError, nil),
+	})
+	if broker == nil {
+		t.Fatal("broker is nil with every dependency wired")
+	}
+	// The run is already served — exactly the state the runner reports on.
+	if _, err := broker.Acquire(ctx, credpool.Request{
+		RunID: "run-1", OrgID: "org-1", TenantID: "team-1", UserID: "requester",
+		Kinds: []secrets.OAuthKind{secrets.OAuthKindClaudeCode},
+	}); err != nil {
+		t.Fatalf("seed lease: %v", err)
+	}
+	return &poolHarness{
+		runner: &Runner{cfg: Config{
+			CredPool: broker,
+			Logger:   iterlog.New(iterlog.LevelError, nil),
+		}},
+		broker: broker, pledges: pledges, ledger: ledger, leases: leases,
+	}
+}
+
+// usageWith drives the PRODUCTION hook so the reported cost is the one the
+// real chain produces, not a number the test typed in.
+func usageWith(costUSD float64, tokens int) *metricsEmitter {
+	usage := newMetricsEmitter(&recordingEmitter{}, metrics.New())
+	hooks := model.NewStoreEventHooks(
+		context.Background(), usage, "run-1", iterlog.New(iterlog.LevelError, nil), nil,
+	)
+	hooks.OnDelegateFinished("n1", model.DelegateInfo{
+		BackendName: "claude_code", Tokens: tokens, CostUSD: costUSD,
+	})
+	return usage
+}
+
+// The closing half of the loop: what a delegate run actually spent must
+// land on the lending contributor's ledger, and free their slot.
+func TestRecordPoolSpend_chargesTheDonorAndClosesTheLease(t *testing.T) {
+	h := newPoolHarness(t, credpool.Limits{MaxUSDPerDay: 10, MaxConcurrentRuns: 1})
+	ctx := context.Background()
+
+	h.runner.recordPoolSpend(&queue.RunMessage{RunID: "run-1", TenantID: "team-1"}, usageWith(1.5, 900), nil)
+
+	day, _, err := h.ledger.Usage(ctx, credpool.PledgeID("donor", "claude_code"), time.Now().UTC())
+	if err != nil {
+		t.Fatalf("usage: %v", err)
+	}
+	if day.CostUSD != 1.5 {
+		t.Errorf("donor charged %v, want 1.5 — the delegate run's spend never reached the pool", day.CostUSD)
+	}
+	hist, err := h.leases.ListByDonor(ctx, "donor", 10)
+	if err != nil || len(hist) != 1 {
+		t.Fatalf("donor history = (%d, %v), want 1 lease", len(hist), err)
+	}
+	lease := hist[0]
+	if !lease.Closed {
+		t.Error("lease still open — the donor's concurrency slot stays consumed")
+	}
+}
+
+// A run that never touched the pool must report harmlessly: that is the
+// vast majority of them.
+func TestRecordPoolSpend_unleasedRunIsANoOp(t *testing.T) {
+	h := newPoolHarness(t, credpool.Limits{})
+	h.runner.recordPoolSpend(&queue.RunMessage{RunID: "run-elsewhere"}, usageWith(2, 100), nil)
+	day, _, _ := h.ledger.Usage(context.Background(), credpool.PledgeID("donor", "claude_code"), time.Now().UTC())
+	if day.CostUSD != 0 {
+		t.Errorf("charged %v for a run that holds no lease", day.CostUSD)
+	}
+}
+
+// No pool wired at all — the common deployment. Must not panic or block.
+func TestRecordPoolSpend_noPoolIsANoOp(t *testing.T) {
+	r := &Runner{cfg: Config{Logger: iterlog.New(iterlog.LevelError, nil)}}
+	r.recordPoolSpend(&queue.RunMessage{RunID: "run-1"}, usageWith(1, 10), nil)
+}
+
+// The condition mapping decides whether a donor keeps their place. Getting
+// it wrong either evicts someone whose credential is fine, or keeps
+// hammering a subscription whose quota window is shut.
+func TestClassifyPoolCondition(t *testing.T) {
+	cases := []struct {
+		name        string
+		err         error
+		want        credpool.Condition
+		wantHasTime bool
+	}{
+		{"success", nil, credpool.ConditionOK, false},
+		{
+			// A workflow that failed on its own logic says nothing about
+			// the donor's credential.
+			"an ordinary workflow failure does not blame the donor",
+			errors.New("node judge failed: schema validation"), credpool.ConditionOK, false,
+		},
+		{
+			"provider quota window, with a reset instant",
+			&delegate.ErrRateLimited{Kind: delegate.RateLimitKindUsageWindow, ResetAt: time.Now().Add(3 * time.Hour)},
+			credpool.ConditionUsageWindow, true,
+		},
+		{
+			"a plain throttle is not a quota window",
+			&delegate.ErrRateLimited{Kind: delegate.RateLimitKindTransient},
+			credpool.ConditionOK, false,
+		},
+		{
+			// The recovery dispatcher may have re-typed it by the time it
+			// reaches the runner.
+			"quota window re-typed as a runtime code",
+			&runtime.RuntimeError{Code: runtime.ErrCodeUsageLimitBlocked},
+			credpool.ConditionUsageWindow, false,
+		},
+		{
+			"rejected credential",
+			&delegate.ErrAuthFailed{Provider: "claude_code", Detail: "401"},
+			credpool.ConditionAuthFailed, false,
+		},
+		{
+			// Errors are wrapped many layers deep by the time they surface.
+			"wrapped rejected credential",
+			fmt.Errorf("run failed: %w", &delegate.ErrAuthFailed{Provider: "claude_code"}),
+			credpool.ConditionAuthFailed, false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, at := classifyPoolCondition(tc.err, time.Now().UTC())
+			if got != tc.want {
+				t.Errorf("condition = %q, want %q", got, tc.want)
+			}
+			if at.IsZero() == tc.wantHasTime {
+				t.Errorf("reset instant present = %v, want %v", !at.IsZero(), tc.wantHasTime)
+			}
+		})
+	}
+}
+
+// End to end through the runner: a usage-window failure must put the donor
+// to rest, so the next run does not walk into the same closed window.
+func TestRecordPoolSpend_usageWindowRestsTheDonor(t *testing.T) {
+	h := newPoolHarness(t, credpool.Limits{})
+	ctx := context.Background()
+	reset := time.Now().UTC().Add(2 * time.Hour)
+
+	h.runner.recordPoolSpend(
+		&queue.RunMessage{RunID: "run-1", TenantID: "team-1"},
+		usageWith(0.2, 50),
+		&delegate.ErrRateLimited{Kind: delegate.RateLimitKindUsageWindow, ResetAt: reset},
+	)
+
+	p, err := h.pledges.Get(ctx, credpool.PledgeID("donor", "claude_code"))
+	if err != nil {
+		t.Fatalf("pledge: %v", err)
+	}
+	if p.CooldownUntil == nil || !p.CooldownUntil.After(time.Now().UTC()) {
+		t.Fatalf("cooldown = %v, want a future instant", p.CooldownUntil)
+	}
+	if _, err := h.broker.Acquire(ctx, credpool.Request{
+		RunID: "run-2", OrgID: "org-1", TenantID: "team-1", UserID: "requester",
+		Kinds: []secrets.OAuthKind{secrets.OAuthKindClaudeCode},
+	}); !errors.Is(err, credpool.ErrNoDonor) {
+		t.Errorf("next Acquire = %v, want ErrNoDonor while the donor rests", err)
+	}
+}

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -36,6 +36,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/botregistry"
 	"github.com/SocialGouv/iterion/pkg/bundle"
 	"github.com/SocialGouv/iterion/pkg/cloud/metrics"
+	"github.com/SocialGouv/iterion/pkg/credpool"
 	"github.com/SocialGouv/iterion/pkg/dsl/ast"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/eventbus"
@@ -446,6 +447,12 @@ type Config struct {
 	// execution attempt (the billing source of truth — Prometheus
 	// counters above stay tenant-unlabelled). nil → no org metering.
 	OrgUsage orgusage.Counter
+
+	// CredPool, when non-nil, receives the spend of a run served by a
+	// lending contributor's pooled subscription, closing its lease and
+	// freeing the donor's concurrency slot. nil → runs never draw on a
+	// pool, or the deployment has none.
+	CredPool *credpool.Broker
 
 	// Events, when non-nil, receives a run-outcome trigger.Event
 	// (run.finished/failed/cancelled/paused) after every execution
@@ -1067,7 +1074,12 @@ func (r *Runner) fireOutcomeEvent(msg *queue.RunMessage, execErr error) {
 // executeRun hydrates the IR from the message, builds the runtime
 // engine + Claw executor, then dispatches to Run or Resume based on
 // the message shape.
-func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage) error {
+//
+// The return is named so the deferred spend accounting can see how the
+// attempt ended: a credential pool must know whether it was a provider
+// quota window or a rejected credential that stopped the run, not merely
+// how much it cost.
+func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage) (execErr error) {
 	// Honour the publisher's per-run wall-clock budget. Without this,
 	// queue.RunMessage.TimeoutSec — wired from `iterion run --timeout`
 	// and the studio Launch modal — has no effect in cloud mode: the
@@ -1251,9 +1263,14 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage) error {
 	if err != nil {
 		return err
 	}
-	// Charge the org's monthly usage whatever the outcome — paused,
-	// cancelled and failed attempts incurred real LLM spend.
-	defer r.recordOrgSpend(msg, usage)
+	// Charge the run's spend whatever the outcome — paused, cancelled and
+	// failed attempts incurred real LLM spend. The org's monthly bucket
+	// always; a lending contributor's ledger too when this run drew on the
+	// credential pool.
+	defer func() {
+		r.recordOrgSpend(msg, usage)
+		r.recordPoolSpend(msg, usage, execErr)
+	}()
 
 	engineOpts := []runtime.EngineOption{
 		runtime.WithLogger(runLogger),

--- a/pkg/runner/loop_metrics.go
+++ b/pkg/runner/loop_metrics.go
@@ -39,9 +39,9 @@ type metricsEmitter struct {
 	modelByNode  map[string]string
 	priceByModel map[string]modelRate
 
-	// Per-run accumulation for org metering. Cost covers claw steps
-	// only (delegate backends report tokens without a price table) —
-	// a floor, not an exact invoice; documented on orgusage.
+	// Per-run accumulation for org metering. Covers both claw steps and
+	// delegate calls; a node whose model the price table cannot price
+	// contributes nothing, so this is a floor, not an exact invoice.
 	runCostUSD      float64
 	runInputTokens  int64
 	runOutputTokens int64
@@ -193,6 +193,14 @@ func (m *metricsEmitter) observe(evt store.Event) {
 			backend = "delegate"
 		}
 		tokensF := toFloat(evt.Data["tokens"])
+		// The delegate already priced this call (its own CLI figure, or the
+		// token estimate a subscription session falls back to) and carries
+		// the result on the event. Accumulating it here is what keeps a
+		// claude_code run from reporting $0 spend for the whole attempt —
+		// which is what every downstream consumer of RunTotals (org monthly
+		// cost cap, credential-pool quota) is metering on. Absent key = the
+		// price table didn't know the model, so nothing is recorded.
+		costDelta := toFloat(evt.Data["cost_usd"])
 
 		// Single critical section: resolve the per-node model name and
 		// accumulate the aggregated token count. Prometheus write
@@ -200,11 +208,15 @@ func (m *metricsEmitter) observe(evt store.Event) {
 		m.mu.Lock()
 		modelName := m.modelByNode[evt.NodeID]
 		m.runInputTokens += int64(tokensF)
+		m.runCostUSD += costDelta
 		m.mu.Unlock()
 
 		// Delegate events report a single aggregated token count;
 		// label as input so a sum across directions stays meaningful.
 		m.addTokens(backend, modelName, "input", evt.Data["tokens"])
+		if costDelta > 0 && m.reg != nil {
+			m.reg.LLMCostUSDTotal.WithLabelValues(backend, normalizeModelLabel(modelName)).Add(costDelta)
+		}
 	}
 }
 

--- a/pkg/runner/loop_metrics.go
+++ b/pkg/runner/loop_metrics.go
@@ -200,7 +200,17 @@ func (m *metricsEmitter) observe(evt store.Event) {
 		// which is what every downstream consumer of RunTotals (org monthly
 		// cost cap, credential-pool quota) is metering on. Absent key = the
 		// price table didn't know the model, so nothing is recorded.
-		costDelta := toFloat(evt.Data["cost_usd"])
+		//
+		// claw is excluded. It is an in-process backend but still dispatches
+		// through the same observability hook, so it emits BOTH a
+		// llm_step_finished per step (priced above, off the same table) and
+		// this delegation total — counting both would charge every claw run
+		// twice, tripping an org's monthly cap at half its budget and
+		// draining a lending donor at twice the rate they agreed to.
+		var costDelta float64
+		if backend != "claw" {
+			costDelta = toFloat(evt.Data["cost_usd"])
+		}
 
 		// Single critical section: resolve the per-node model name and
 		// accumulate the aggregated token count. Prometheus write

--- a/pkg/runner/loop_spend.go
+++ b/pkg/runner/loop_spend.go
@@ -2,8 +2,11 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"time"
 
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/credpool"
 	"github.com/SocialGouv/iterion/pkg/queue"
 )
 
@@ -36,4 +39,63 @@ func (r *Runner) recordOrgSpend(msg *queue.RunMessage, usage *metricsEmitter) {
 	if err := r.cfg.OrgUsage.AddSpend(bg, key, time.Now().UTC(), costUSD, in, out); err != nil {
 		r.cfg.Logger.Warn("runner: org spend record for %s (run %s): %v", key, msg.RunID, err)
 	}
+}
+
+// recordPoolSpend closes the run's credential-pool lease: it charges the
+// lending contributor's ledger, frees their concurrency slot, and reports
+// the two conditions that must change their availability.
+//
+// A no-op for the vast majority of runs, which hold no lease — the broker
+// looks the run up by id and returns quietly when there is none. Detached
+// ctx and best-effort for the same reason as recordOrgSpend: accounting
+// must never turn a finished run into a failed one. The lease's own TTL
+// plus the server-side sweeper are the backstop if this write is lost.
+func (r *Runner) recordPoolSpend(msg *queue.RunMessage, usage *metricsEmitter, execErr error) {
+	if r.cfg.CredPool == nil || usage == nil {
+		return
+	}
+	costUSD, in, out := usage.RunTotals()
+	condition, cooldownUntil := classifyPoolCondition(execErr, time.Now().UTC())
+	bg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := r.cfg.CredPool.Report(bg, msg.RunID, credpool.Outcome{
+		CostUSD:       costUSD,
+		InputTokens:   in,
+		OutputTokens:  out,
+		Condition:     condition,
+		CooldownUntil: cooldownUntil,
+	}); err != nil {
+		r.cfg.Logger.Warn("runner: credential-pool report for run %s: %v (the donor's slot frees on lease expiry)", msg.RunID, err)
+	}
+}
+
+// classifyPoolCondition maps a terminal execution error onto what it means
+// for the credential that produced it. The backend error types live in
+// pkg/backend/delegate, so this translation belongs at the runner boundary
+// rather than inside pkg/credpool.
+//
+// Everything that is neither a quota window nor a rejected credential is
+// ConditionOK: a workflow that failed on its own logic says nothing about
+// the donor, and must not cost them their place in the rotation.
+func classifyPoolCondition(execErr error, now time.Time) (credpool.Condition, time.Time) {
+	if execErr == nil {
+		return credpool.ConditionOK, time.Time{}
+	}
+	// Same evidence chain the usage-window retry arms on, including its
+	// text-parsed fallback — a runner with no dispatcher classifies
+	// nothing, and the pool must still rest the donor rather than send the
+	// next run into the same shut window.
+	if at, _, ok := usageWindowEvidence(execErr); ok {
+		if at.IsZero() {
+			if parsed, pok := delegate.ParseResetHint(execErr.Error(), now); pok {
+				at = parsed
+			}
+		}
+		return credpool.ConditionUsageWindow, at
+	}
+	var auth *delegate.ErrAuthFailed
+	if errors.As(execErr, &auth) {
+		return credpool.ConditionAuthFailed, time.Time{}
+	}
+	return credpool.ConditionOK, time.Time{}
 }

--- a/pkg/runner/metrics_test.go
+++ b/pkg/runner/metrics_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"github.com/SocialGouv/iterion/pkg/cloud/metrics"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -245,5 +246,63 @@ func TestMetricsEmitter_lookupModel_emptyNodeID(t *testing.T) {
 	m := newMetricsEmitter(&recordingEmitter{}, metrics.New())
 	if got := m.lookupModel(""); got != "" {
 		t.Errorf("lookupModel(\"\") = %q, want empty", got)
+	}
+}
+
+// A delegate backend's spend must reach RunTotals — that number is what
+// charges the org's monthly cost cap and what decrements a credential-pool
+// donor's quota. It used to stop at the tokens: the whole attempt of a
+// claude_code run reported $0, so no cap could ever trip.
+//
+// The event here is produced by the PRODUCTION hook (model.NewStoreEventHooks
+// → OnDelegateFinished), not hand-assembled, so the test fails if either side
+// of the join drifts — the emitter dropping the field, or the consumer
+// reading a different key.
+func TestMetricsEmitter_delegateFinished_costReachesRunTotals(t *testing.T) {
+	inner := &recordingEmitter{}
+	usage := newMetricsEmitter(inner, metrics.New())
+
+	hooks := model.NewStoreEventHooks(
+		context.Background(), usage, "run-4", iterlog.New(iterlog.LevelError, nil), nil,
+	)
+	hooks.OnDelegateFinished("n1", model.DelegateInfo{
+		BackendName: "claude_code",
+		Tokens:      1200,
+		CostUSD:     0.4242,
+	})
+
+	if len(inner.events) != 1 {
+		t.Fatalf("inner emitter received %d events, want 1", len(inner.events))
+	}
+	if got := inner.events[0].Data["cost_usd"]; got != 0.4242 {
+		t.Errorf("emitted cost_usd = %v, want 0.4242 — the hook is dropping the delegation's cost", got)
+	}
+
+	costUSD, in, _ := usage.RunTotals()
+	if costUSD != 0.4242 {
+		t.Errorf("RunTotals cost = %v, want 0.4242 — delegate spend is not charged to the run", costUSD)
+	}
+	if in != 1200 {
+		t.Errorf("RunTotals input tokens = %d, want 1200", in)
+	}
+}
+
+// The counterpart: an unpriced model omits `_cost_usd`, so the hook omits
+// `cost_usd`, so the run's cost stays at zero rather than recording a
+// fabricated free call.
+func TestMetricsEmitter_delegateFinished_unpricedStaysZero(t *testing.T) {
+	inner := &recordingEmitter{}
+	usage := newMetricsEmitter(inner, metrics.New())
+
+	hooks := model.NewStoreEventHooks(
+		context.Background(), usage, "run-5", iterlog.New(iterlog.LevelError, nil), nil,
+	)
+	hooks.OnDelegateFinished("n1", model.DelegateInfo{BackendName: "claude_code", Tokens: 900})
+
+	if _, present := inner.events[0].Data["cost_usd"]; present {
+		t.Error("cost_usd present for an unpriced delegation — 'no data' must stay distinguishable from $0")
+	}
+	if costUSD, _, _ := usage.RunTotals(); costUSD != 0 {
+		t.Errorf("RunTotals cost = %v, want 0", costUSD)
 	}
 }

--- a/pkg/runner/metrics_test.go
+++ b/pkg/runner/metrics_test.go
@@ -306,3 +306,51 @@ func TestMetricsEmitter_delegateFinished_unpricedStaysZero(t *testing.T) {
 		t.Errorf("RunTotals cost = %v, want 0", costUSD)
 	}
 }
+
+// claw is in-process but still dispatches through the delegate hook, so it
+// emits BOTH a per-step llm_step_finished and a delegation total. Counting
+// both charged every claw run twice: an org's monthly cap would trip at
+// half its budget, and a lending donor would be drained at twice the rate
+// they agreed to.
+func TestMetricsEmitter_clawCostIsNotCountedTwice(t *testing.T) {
+	inner := &recordingEmitter{}
+	usage := newMetricsEmitter(inner, metrics.New())
+	ctx := context.Background()
+
+	// A claw node: a priced step, then the delegation total for the same work.
+	_, _ = usage.AppendEvent(ctx, "run-1", store.Event{
+		Type: store.EventLLMRequest, RunID: "run-1", NodeID: "n1",
+		Data: map[string]any{"model": "claude-sonnet-4-6"},
+	})
+	_, _ = usage.AppendEvent(ctx, "run-1", store.Event{
+		Type: store.EventLLMStepFinished, RunID: "run-1", NodeID: "n1",
+		Data: map[string]any{"input_tokens": float64(1000), "output_tokens": float64(500)},
+	})
+	perStep, _, _ := usage.RunTotals()
+	if perStep <= 0 {
+		t.Fatalf("the step itself priced to %v — the test cannot show a double count", perStep)
+	}
+
+	_, _ = usage.AppendEvent(ctx, "run-1", store.Event{
+		Type: store.EventDelegateFinished, RunID: "run-1", NodeID: "n1",
+		Data: map[string]any{"backend": "claw", "tokens": float64(1500), "cost_usd": perStep},
+	})
+
+	total, _, _ := usage.RunTotals()
+	if total != perStep {
+		t.Errorf("cost = %v after the delegation total, want %v — claw was charged twice", total, perStep)
+	}
+}
+
+// A CLI delegate has no per-step events, so its delegation total is the
+// only cost signal and must still be counted.
+func TestMetricsEmitter_cliDelegateCostIsStillCounted(t *testing.T) {
+	usage := newMetricsEmitter(&recordingEmitter{}, metrics.New())
+	_, _ = usage.AppendEvent(context.Background(), "run-2", store.Event{
+		Type: store.EventDelegateFinished, RunID: "run-2", NodeID: "n1",
+		Data: map[string]any{"backend": "claude_code", "tokens": float64(900), "cost_usd": 0.42},
+	})
+	if cost, _, _ := usage.RunTotals(); cost != 0.42 {
+		t.Errorf("cost = %v, want 0.42", cost)
+	}
+}

--- a/pkg/runner/usage_retry.go
+++ b/pkg/runner/usage_retry.go
@@ -66,23 +66,15 @@ func usageWindowRetryAt(execErr error, pol retrypolicy.Policy, now time.Time) (t
 		return time.Time{}, "", false
 	}
 
-	var at time.Time
-	var source string
-
-	var rl *delegate.ErrRateLimited
-	switch {
-	case errors.As(execErr, &rl) && rl.Kind == delegate.RateLimitKindUsageWindow:
-		at, source = rl.ResetAt, "typed_error"
-	case runtimeCodeOf(execErr) == runtime.ErrCodeUsageLimitBlocked:
-		source = "runtime_code"
-	default:
+	at, source, ok := usageWindowEvidence(execErr)
+	if !ok {
 		return time.Time{}, "", false
 	}
 
 	// A usage window with no usable reset instant still gets a retry — the
 	// window is real, only its end is unknown.
 	if at.IsZero() {
-		if parsed, ok := delegate.ParseResetHint(execErr.Error(), now); ok {
+		if parsed, pok := delegate.ParseResetHint(execErr.Error(), now); pok {
 			at, source = parsed, source+"+parsed_text"
 		} else {
 			at, source = now.Add(usageWindowBlindWait), source+"+blind_wait"
@@ -105,6 +97,28 @@ func usageWindowRetryAt(execErr error, pol retrypolicy.Policy, now time.Time) (t
 		at = ceiling
 	}
 	return at.UTC(), source, true
+}
+
+// usageWindowEvidence answers the one question "did this error mean the
+// provider's quota window is shut, and when does it reopen".
+//
+// Shared because two consumers ask it: the retry arming below, and the
+// credential pool deciding whether to rest a donor. Two copies of an
+// evidence chain drift — the pool's did, silently dropping the text-parsed
+// reset the retry path relies on.
+//
+// Sources are tried structure-first, string-last on purpose. The typed
+// error is authoritative when it survives to here; the code is
+// authoritative when a recovery dispatcher classified it.
+func usageWindowEvidence(execErr error) (resetAt time.Time, source string, ok bool) {
+	var rl *delegate.ErrRateLimited
+	switch {
+	case errors.As(execErr, &rl) && rl.Kind == delegate.RateLimitKindUsageWindow:
+		return rl.ResetAt, "typed_error", true
+	case runtimeCodeOf(execErr) == runtime.ErrCodeUsageLimitBlocked:
+		return time.Time{}, "runtime_code", true
+	}
+	return time.Time{}, "", false
 }
 
 // runtimeCodeOf extracts the RuntimeError code from an error chain, or "".

--- a/pkg/runtime/recovery/recovery.go
+++ b/pkg/runtime/recovery/recovery.go
@@ -352,6 +352,15 @@ func Classify(err error) runtime.ErrorCode {
 	if errors.As(err, &rerr) {
 		return rerr.Code
 	}
+	// A credential the provider rejected. Checked by TYPE, before any
+	// message matching: the needles below only catch the wordings that
+	// happen to be in the list today, so a backend that reports "upstream
+	// 401" instead of "API error 401" would be retried against a dead
+	// credential rather than paused for re-auth.
+	var authFailed *delegate.ErrAuthFailed
+	if errors.As(err, &authFailed) {
+		return runtime.ErrCodeAuthFailed
+	}
 	var rateLimited *delegate.ErrRateLimited
 	if errors.As(err, &rateLimited) {
 		if rateLimited.Kind == delegate.RateLimitKindUsageWindow {

--- a/pkg/secrets/oauth.go
+++ b/pkg/secrets/oauth.go
@@ -326,18 +326,12 @@ func (s *MongoOAuthStore) Upsert(ctx context.Context, rec OAuthRecord) error {
 	if rec.CreatedAt.IsZero() {
 		rec.CreatedAt = rec.UpdatedAt
 	}
-	// Marshal rec, then strip _id from the $set body so we don't
-	// fight Mongo's "Mod on _id not allowed" guard on subsequent
-	// updates. _id only lives in $setOnInsert.
-	raw, err := bson.Marshal(rec)
+	// _id lives only in $setOnInsert: Mongo rejects an update that touches
+	// it on a subsequent upsert.
+	setBody, err := mongoutil.SetBodyWithoutID(rec, "secrets: oauth")
 	if err != nil {
-		return fmt.Errorf("secrets: marshal oauth: %w", err)
+		return err
 	}
-	var setBody bson.M
-	if err := bson.Unmarshal(raw, &setBody); err != nil {
-		return fmt.Errorf("secrets: re-decode oauth: %w", err)
-	}
-	delete(setBody, "_id")
 
 	_, err = s.coll.UpdateOne(
 		ctx,

--- a/pkg/secrets/oauth_pending.go
+++ b/pkg/secrets/oauth_pending.go
@@ -145,15 +145,10 @@ func (s *MongoOAuthPendingStore) Put(ctx context.Context, rec OAuthPending) erro
 	if rec.CreatedAt.IsZero() {
 		rec.CreatedAt = time.Now().UTC()
 	}
-	raw, err := bson.Marshal(rec)
+	setBody, err := mongoutil.SetBodyWithoutID(rec, "secrets: oauth pending")
 	if err != nil {
-		return fmt.Errorf("secrets: marshal oauth pending: %w", err)
+		return err
 	}
-	var setBody bson.M
-	if err := bson.Unmarshal(raw, &setBody); err != nil {
-		return fmt.Errorf("secrets: re-decode oauth pending: %w", err)
-	}
-	delete(setBody, "_id")
 	_, err = s.coll.UpdateOne(
 		ctx,
 		bson.M{"owner_key": rec.OwnerKey, "kind": rec.Kind},

--- a/pkg/server/cloudpublisher/credpool_tier_test.go
+++ b/pkg/server/cloudpublisher/credpool_tier_test.go
@@ -1,0 +1,241 @@
+package cloudpublisher
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/credpool"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// poolFixture wires a REAL broker over in-memory stores and a real sealer,
+// with one donor whose credential is genuinely sealed in the OAuth store.
+// Nothing here hands the publisher a credential directly: if the tier is
+// not wired end to end, the bundle comes back empty.
+type poolFixture struct {
+	pub     *Publisher
+	rs      *secrets.MemoryRunSecretsStore
+	sealer  secrets.Sealer
+	pledges *credpool.MemoryPledgeStore
+	ledger  *credpool.MemoryLedger
+}
+
+const (
+	poolOrg  = "org-1"
+	poolTeam = "team-1"
+)
+
+func newPoolFixture(t *testing.T, limits credpool.Limits) *poolFixture {
+	t.Helper()
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	ctx := context.Background()
+
+	oauth := secrets.NewMemoryOAuthStore()
+	seedOAuth(t, oauth, sealer, "donor", "sk-ant-donated")
+
+	pools := credpool.NewMemoryPoolStore()
+	if err := pools.Upsert(ctx, credpool.Pool{ID: "pool-1", OrgID: poolOrg, Enabled: true}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	pledges := credpool.NewMemoryPledgeStore()
+	if err := pledges.Upsert(ctx, credpool.Pledge{
+		ID: credpool.PledgeID("donor", "claude_code"), PoolID: "pool-1",
+		UserID: "donor", Kind: "claude_code",
+		Enabled: true, Health: credpool.HealthOK, Limits: limits,
+	}); err != nil {
+		t.Fatalf("seed pledge: %v", err)
+	}
+	ledger := credpool.NewMemoryLedger()
+
+	broker := credpool.NewBroker(credpool.BrokerConfig{
+		Pools: pools, Pledges: pledges, Leases: credpool.NewMemoryLeaseStore(), Ledger: ledger,
+		OAuth: oauth, Sealer: sealer, Logger: testLogger(),
+	})
+	if broker == nil {
+		t.Fatal("broker is nil with every dependency wired")
+	}
+	rs := secrets.NewMemoryRunSecretsStore()
+	return &poolFixture{
+		pub: &Publisher{
+			// Deliberately NO oauthForfait / apiKeys: this fixture is a
+			// tenant with no credential of its own, which is the only
+			// condition under which the pool is meant to step in.
+			runSecrets: rs,
+			sealer:     sealer,
+			credPool:   broker,
+			logger:     iterlog.New(iterlog.LevelError, nil),
+		},
+		rs: rs, sealer: sealer, pledges: pledges, ledger: ledger,
+	}
+}
+
+// resolve runs the real credential-resolution path and opens the sealed
+// bundle the runner would receive.
+func (f *poolFixture) resolve(t *testing.T, runID string, wf *ir.Workflow) (secrets.RunBundle, credResolution) {
+	t.Helper()
+	ctx := store.WithTenant(context.Background(), poolTeam)
+	creds, err := f.pub.resolveAndSealCredentials(ctx, runID, poolOrg, poolTeam, "requester", "docs-refresh", wf, nil, nil)
+	if err != nil {
+		t.Fatalf("resolveAndSealCredentials: %v", err)
+	}
+	if creds.secretsRef == "" {
+		return secrets.RunBundle{}, creds
+	}
+	rec, err := f.rs.Get(ctx, creds.secretsRef)
+	if err != nil {
+		t.Fatalf("RunSecrets.Get: %v", err)
+	}
+	bundle, err := secrets.OpenRunBundle(f.sealer, runID, rec.SealedBundle)
+	if err != nil {
+		t.Fatalf("OpenRunBundle: %v", err)
+	}
+	return bundle, creds
+}
+
+// The whole point of the tier: a tenant with no credential of its own ends
+// up with a donor's, sealed into the bundle the runner will materialise.
+func TestPoolTier_credentiallessRunGetsADonorsSubscription(t *testing.T) {
+	f := newPoolFixture(t, credpool.Limits{MaxUSDPerDay: 5})
+
+	bundle, creds := f.resolve(t, "run-1", nil)
+
+	blob := bundle.OAuthCredentials["claude_code"]
+	if len(blob) == 0 {
+		t.Fatal("no pooled credential in the sealed bundle — the tier is not wired")
+	}
+	var got map[string]map[string]string
+	if err := json.Unmarshal(blob, &got); err != nil {
+		t.Fatalf("bundle credential is not the donor's stored blob: %v", err)
+	}
+	if got["claudeAiOauth"]["accessToken"] != "sk-ant-donated" {
+		t.Errorf("token = %q, want the donor's", got["claudeAiOauth"]["accessToken"])
+	}
+	if creds.grant == nil || creds.grant.DonorID != "donor" {
+		t.Fatalf("grant = %+v, want the donor's", creds.grant)
+	}
+}
+
+// The enforcement half: the run's cost budget must be capped at what
+// remains of the donor's allowance, or a single run could spend the whole
+// pledge and the overspend would only be discovered afterwards.
+func TestPoolTier_runBudgetIsCappedAtTheDonorsAllowance(t *testing.T) {
+	f := newPoolFixture(t, credpool.Limits{MaxUSDPerDay: 5})
+	// The donor has already given $3 today.
+	if err := f.ledger.AddSpend(context.Background(), credpool.PledgeID("donor", "claude_code"), time.Now().UTC(), 3, 0, 0); err != nil {
+		t.Fatalf("seed spend: %v", err)
+	}
+
+	_, creds := f.resolve(t, "run-1", nil)
+	if creds.grant == nil {
+		t.Fatal("no grant")
+	}
+	budget := clampBudgetToGrant(nil, nil, creds.grant, testLogger(), "run-1")
+	if budget == nil || budget.MaxCostUSD != 2 {
+		t.Fatalf("wire budget = %+v, want MaxCostUSD 2 (the $5 pledge minus the $3 already given)", budget)
+	}
+}
+
+// The clamp must only ever LOWER. A bot that declares a small budget under
+// a generous allowance must keep its own figure, not be raised to it.
+func TestClampBudgetToGrant_neverRaises(t *testing.T) {
+	grant := &credpool.Grant{RemainingUSD: 50}
+	cases := []struct {
+		name     string
+		override *ir.BudgetOverrides
+		wf       *ir.Workflow
+		want     float64
+	}{
+		{"no budget anywhere takes the allowance", nil, nil, 50},
+		{
+			"the workflow's own declared budget wins when tighter",
+			nil, &ir.Workflow{Budget: &ir.Budget{MaxCostUSD: 2}}, 2,
+		},
+		{
+			"a launch override wins when tighter",
+			&ir.BudgetOverrides{MaxCostUSD: 1}, &ir.Workflow{Budget: &ir.Budget{MaxCostUSD: 8}}, 1,
+		},
+		{
+			"the allowance wins when it is the tightest",
+			&ir.BudgetOverrides{MaxCostUSD: 900}, &ir.Workflow{Budget: &ir.Budget{MaxCostUSD: 800}}, 50,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := clampBudgetToGrant(tc.override, tc.wf, grant, testLogger(), "run-1")
+			if got == nil || got.MaxCostUSD != tc.want {
+				t.Errorf("MaxCostUSD = %+v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A donor who set no spend cap grants an allowance of 0 — which means "no
+// ceiling", not "nothing left". Reading it as a ceiling would publish a run
+// budget of zero and stop the run before its first node.
+func TestClampBudgetToGrant_uncappedDonorImposesNoCeiling(t *testing.T) {
+	wf := &ir.Workflow{Budget: &ir.Budget{MaxCostUSD: 7}}
+	got := clampBudgetToGrant(nil, wf, &credpool.Grant{RemainingUSD: 0}, testLogger(), "run-1")
+	if got != nil && got.MaxCostUSD != 0 {
+		t.Errorf("budget = %+v, want no cost override imposed", got)
+	}
+}
+
+// No grant at all (no pool, or nobody available) must leave the caller's
+// budget exactly as it was.
+func TestClampBudgetToGrant_noGrantPassesThrough(t *testing.T) {
+	in := &ir.BudgetOverrides{MaxCostUSD: 12, MaxTokens: 999}
+	got := clampBudgetToGrant(in, nil, nil, testLogger(), "run-1")
+	if got == nil || got.MaxCostUSD != 12 || got.MaxTokens != 999 {
+		t.Errorf("budget = %+v, want the caller's own overrides untouched", got)
+	}
+}
+
+// The pool is a LAST resort: spending a contributor's lent subscription
+// while the tenant holds a usable key of its own would take a donation
+// nobody needed.
+func TestPoolTier_skippedWhenTheTenantHasItsOwnCredential(t *testing.T) {
+	f := newPoolFixture(t, credpool.Limits{MaxUSDPerDay: 5})
+	// Give the tenant its own personal forfait.
+	own := secrets.NewMemoryOAuthStore()
+	seedOAuth(t, own, f.sealer, "requester", "sk-ant-own")
+	f.pub.oauthForfait = own
+
+	bundle, creds := f.resolve(t, "run-1", nil)
+	if creds.grant != nil {
+		t.Error("the pool was drawn on although the tenant had its own credential")
+	}
+	if got := string(bundle.OAuthCredentials["claude_code"]); !contains(got, "sk-ant-own") {
+		t.Errorf("bundle carries %q, want the tenant's own credential", got)
+	}
+}
+
+// A paused donor must not be served, and the run must proceed exactly as
+// it would with no pool at all — never fail.
+func TestPoolTier_pausedDonorLeavesTheRunCredentialless(t *testing.T) {
+	f := newPoolFixture(t, credpool.Limits{})
+	ctx := context.Background()
+	p, err := f.pledges.Get(ctx, credpool.PledgeID("donor", "claude_code"))
+	if err != nil {
+		t.Fatalf("get pledge: %v", err)
+	}
+	p.Enabled = false
+	if err := f.pledges.Upsert(ctx, p); err != nil {
+		t.Fatalf("pause pledge: %v", err)
+	}
+
+	bundle, creds := f.resolve(t, "run-1", nil)
+	if creds.grant != nil {
+		t.Error("a paused donor was served")
+	}
+	if len(bundle.OAuthCredentials) != 0 {
+		t.Errorf("bundle = %+v, want no credentials", bundle.OAuthCredentials)
+	}
+}

--- a/pkg/server/cloudpublisher/oauth_fallback_test.go
+++ b/pkg/server/cloudpublisher/oauth_fallback_test.go
@@ -32,14 +32,14 @@ func seedOAuth(t *testing.T, st secrets.OAuthStore, sealer secrets.Sealer, owner
 func resolveBundle(t *testing.T, p *Publisher, runSecrets *secrets.MemoryRunSecretsStore, sealer secrets.Sealer, runID, tenant, owner string) secrets.RunBundle {
 	t.Helper()
 	ctx := store.WithTenant(context.Background(), tenant)
-	ref, err := p.resolveAndSealCredentials(ctx, runID, tenant, owner, "", nil, nil, nil)
+	creds, err := p.resolveAndSealCredentials(ctx, runID, "", tenant, owner, "", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("resolveAndSealCredentials: %v", err)
 	}
-	if ref == "" {
+	if creds.secretsRef == "" {
 		return secrets.RunBundle{}
 	}
-	rec, err := runSecrets.Get(ctx, ref)
+	rec, err := runSecrets.Get(ctx, creds.secretsRef)
 	if err != nil {
 		t.Fatalf("RunSecrets.Get: %v", err)
 	}

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/botsource"
 	"github.com/SocialGouv/iterion/pkg/cloud/metrics"
+	"github.com/SocialGouv/iterion/pkg/credpool"
 	"github.com/SocialGouv/iterion/pkg/dsl/ast"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/dsl/parser"
@@ -93,6 +94,10 @@ type Config struct {
 	// Contributions channel — the runner's baked BotsPaths cannot resolve a
 	// tenant bundle, so this is the only way its skills mirror into the workspace.
 	BotSources botsource.Store
+	// CredPool, when non-nil, lets a run with no credential of its own
+	// draw on a contributor's lent subscription (pkg/credpool). Nil — the
+	// default — simply means no pool tier.
+	CredPool *credpool.Broker
 	// Identity, when non-nil, lets the publisher resolve a run's team
 	// to its parent org so the RunMessage carries the org id the launch
 	// gate metered the run on. The runner charges LLM spend to that key
@@ -130,6 +135,7 @@ type Publisher struct {
 	forgeConns     forge.ConnectionStore
 	pluginSources  *pluginsource.Resolver
 	botSources     botsource.Store
+	credPool       *credpool.Broker
 	identity       TeamResolver
 
 	// orgCache memoizes team → org id so the publish hot path doesn't
@@ -221,6 +227,7 @@ func New(cfg Config) (*Publisher, error) {
 		forgeConns:     cfg.ForgeConnections,
 		pluginSources:  cfg.PluginSources,
 		botSources:     cfg.BotSources,
+		credPool:       cfg.CredPool,
 		identity:       cfg.Identity,
 	}, nil
 }
@@ -305,12 +312,13 @@ func (p *Publisher) appBotLoginForForgeToken(ctx context.Context, tenantID strin
 
 // resolveAndSealCredentials looks up every provider key visible to
 // (tenantID, ownerID), pairs it with any OAuth-forfait the owner has
-// connected, seals the resulting bundle, and persists it under a
-// fresh secrets ref. Returns the ref or an empty string when no
-// credentials are available — the runner then falls back to env.
-func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, tenantID, ownerID, botID string, wf *ir.Workflow, keyOverrides, secretOverrides map[string]string) (string, error) {
+// connected — falling back to a contributor's pooled subscription when the
+// tenant has none — seals the resulting bundle, and persists it under a
+// fresh secrets ref. An empty ref means no credentials are available; the
+// runner then falls back to env.
+func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID, tenantID, ownerID, botID string, wf *ir.Workflow, keyOverrides, secretOverrides map[string]string) (credResolution, error) {
 	if p.runSecrets == nil || p.sealer == nil {
-		return "", nil
+		return credResolution{}, nil
 	}
 	// Defence in depth: every caller (SubmitLaunch, SubmitResume)
 	// already derives tenantID from either auth.FromContext or the
@@ -321,7 +329,7 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, tenant
 		if runID != "" && p.logger != nil {
 			p.logger.Warn("cloudpublisher: refusing to seal credentials for run %s without a tenant_id", runID)
 		}
-		return "", nil
+		return credResolution{}, nil
 	}
 	bundle := secrets.RunBundle{
 		APIKeys:            map[secrets.Provider]string{},
@@ -344,7 +352,7 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, tenant
 		}
 		resolved, err := secrets.Resolve(ctx, p.apiKeys, tenantID, ownerID, allKnownProviders, overrides, p.sealer)
 		if err != nil {
-			return "", fmt.Errorf("cloudpublisher: resolve creds: %w", err)
+			return credResolution{}, fmt.Errorf("cloudpublisher: resolve creds: %w", err)
 		}
 		now := time.Now().UTC()
 		usedIDs := make([]string, 0, len(resolved))
@@ -380,7 +388,7 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, tenant
 		names := genericSecretNamesForWorkflow(wf)
 		resolved, err := secrets.ResolveGenericWithBindings(ctx, p.genericSecrets, p.botBindings, tenantID, ownerID, botID, names, secretOverrides, p.sealer, p.logger)
 		if err != nil {
-			return "", fmt.Errorf("cloudpublisher: resolve workflow secrets: %w", err)
+			return credResolution{}, fmt.Errorf("cloudpublisher: resolve workflow secrets: %w", err)
 		}
 		// Required-secret launch gate: a non-`optional` declared secret with no
 		// inline value MUST resolve to a non-empty value. If it resolves to
@@ -395,7 +403,7 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, tenant
 			}
 		}
 		if missing := secrets.UnresolvedRequired(requiredSecretNamesForWorkflow(wf), haveValue); len(missing) > 0 {
-			return "", secrets.RequiredSecretsError(missing, "this team/bot")
+			return credResolution{}, secrets.RequiredSecretsError(missing, "this team/bot")
 		}
 		now := time.Now().UTC()
 		usedIDs := make([]string, 0, len(resolved))
@@ -481,13 +489,26 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, tenant
 		addOAuth(secrets.OrgOwnerKey(tenantID), "org")
 	}
 
+	// 4. Mutualised pool — the LAST resort, and only for a run that has no
+	//    credential of its own at all. Spending a contributor's lent
+	//    subscription while the tenant holds a usable key of its own would
+	//    be taking a donation nobody needed; "the tenant is out of
+	//    credentials" is the condition the pool exists for.
+	res := credResolution{}
+	if len(bundle.APIKeys) == 0 && len(bundle.OAuthCredentials) == 0 {
+		if grant := p.acquireFromPool(ctx, runID, orgID, tenantID, ownerID, botID); grant != nil {
+			bundle.OAuthCredentials[grant.Kind] = grant.Payload
+			res.grant = grant
+		}
+	}
+
 	if len(bundle.APIKeys) == 0 && len(bundle.GenericSecrets) == 0 && len(bundle.OAuthCredentials) == 0 {
-		return "", nil
+		return res, nil
 	}
 
 	sealed, err := secrets.SealRunBundle(p.sealer, runID, bundle)
 	if err != nil {
-		return "", fmt.Errorf("cloudpublisher: seal bundle: %w", err)
+		return res, fmt.Errorf("cloudpublisher: seal bundle: %w", err)
 	}
 	ref := secrets.NewSecretsRef()
 	now := time.Now().UTC()
@@ -500,9 +521,56 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, tenant
 		ExpiresAt:    now.Add(secrets.DefaultRunSecretsTTL),
 	}
 	if err := p.runSecrets.Put(ctx, rec); err != nil {
-		return "", fmt.Errorf("cloudpublisher: persist run secrets: %w", err)
+		return res, fmt.Errorf("cloudpublisher: persist run secrets: %w", err)
 	}
-	return ref, nil
+	res.secretsRef = ref
+	return res, nil
+}
+
+// credResolution is what resolving a run's credentials produced: the sealed
+// bundle's ref, plus the pool grant when a contributor's subscription was
+// what made the run possible. The grant travels back to the caller because
+// it carries the donor's remaining allowance, which must become the run's
+// own cost ceiling.
+type credResolution struct {
+	secretsRef string
+	grant      *credpool.Grant
+}
+
+// poolKindPreference is the order the pool is asked for a credential when a
+// run has none. claude_code first: it is the native path for a Claude
+// subscription (the CLI IS Claude Code), so a lent Claude forfait works
+// there without spending anyone's extra-usage balance.
+var poolKindPreference = []secrets.OAuthKind{secrets.OAuthKindClaudeCode, secrets.OAuthKindCodex}
+
+// acquireFromPool asks the credential pool for a donor. Returns nil when no
+// pool is wired, none serves this requester, or every donor is currently
+// unavailable — all ordinary outcomes that must let the launch proceed
+// exactly as it would have without a pool.
+func (p *Publisher) acquireFromPool(ctx context.Context, runID, orgID, tenantID, ownerID, botID string) *credpool.Grant {
+	if p.credPool == nil {
+		return nil
+	}
+	grant, err := p.credPool.Acquire(ctx, credpool.Request{
+		RunID:    runID,
+		OrgID:    orgID,
+		TenantID: tenantID,
+		UserID:   ownerID,
+		BotID:    botID,
+		Kinds:    poolKindPreference,
+	})
+	if err != nil {
+		if !errors.Is(err, credpool.ErrNoDonor) {
+			// A store failure must not fail the launch: the pool is a
+			// best-effort extra tier, and a run with no credential still
+			// surfaces a legible error at the LLM call site.
+			p.logger.Warn("cloudpublisher: credential pool lookup for run %s: %v", runID, err)
+		}
+		return nil
+	}
+	p.logger.Info("cloudpublisher: run %s runs on a pooled contributor credential (donor=%s kind=%s allowance=$%.2f)",
+		runID, grant.DonorID, grant.Kind, grant.RemainingUSD)
+	return grant
 }
 
 // SubmitLaunch persists the run as queued in Mongo, then publishes
@@ -576,9 +644,27 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 	//     run record is persisted so a required-secret launch failure leaves
 	//     NO run record behind (never a stray queued/running run for a launch
 	//     that could not resolve its mandatory credentials).
-	secretsRef, err := p.resolveAndSealCredentials(ctx, runID, tenantID, ownerID, spec.BotID, wf, spec.KeyOverrides, spec.SecretOverrides)
+	orgID := p.orgIDForTeam(ctx, tenantID)
+	creds, err := p.resolveAndSealCredentials(ctx, runID, orgID, tenantID, ownerID, spec.BotID, wf, spec.KeyOverrides, spec.SecretOverrides)
 	if err != nil {
 		return 0, err
+	}
+	// A run served by the pool may not spend more than what remains of its
+	// donor's allowance. This is the enforcement: the engine stops the run
+	// on its own cost budget, instead of the overspend being discovered
+	// after the fact when the donor is already out of pocket.
+	budget := clampBudgetToGrant(spec.Budget, wf, creds.grant, p.logger, runID)
+	// A donor's admission is consumed the moment it is granted. Every exit
+	// below this point is a launch that will never happen, so it must be
+	// returned — otherwise a Mongo blip during a burst can silently spend a
+	// contributor's whole daily quota on runs that never ran.
+	launched := false
+	if creds.grant != nil {
+		defer func() {
+			if !launched {
+				p.credPool.Release(ctx, runID)
+			}
+		}()
 	}
 
 	if err := p.store.SaveRun(ctx, r); err != nil {
@@ -609,11 +695,11 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 		WorkflowHash:   hash,
 		IRCompiled:     body,
 		Vars:           varsAsAny(spec.Vars),
-		SecretsRef:     secretsRef,
+		SecretsRef:     creds.secretsRef,
 		BackendConfig:  queue.BackendConfig{Default: queue.BackendClaw},
 		PublishedAtRFC: time.Now().UTC().Format(time.RFC3339Nano),
 		TenantID:       tenantID,
-		OrgID:          p.orgIDForTeam(ctx, tenantID),
+		OrgID:          orgID,
 		OwnerID:        ownerID,
 		// Cap. 3 sharding: when this run is a child shard, the runner
 		// pod that picks it up sees its place in the set so the studio
@@ -633,7 +719,7 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 		RepoURL: spec.RepoURL,
 		RepoSHA: spec.RepoRef,
 		BotID:   spec.BotID,
-		Budget:  budgetForWire(spec.Budget),
+		Budget:  budget,
 	}
 	if err := p.publish(ctx, msg); err != nil {
 		pubErr := fmt.Errorf("cloudpublisher: publish: %w", err)
@@ -647,6 +733,7 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 		}
 		return 0, pubErr
 	}
+	launched = true
 	if p.metrics != nil {
 		p.metrics.RunsCreatedTotal.WithLabelValues(string(store.RunStatusQueued)).Inc()
 	}
@@ -755,7 +842,17 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 	// remain durable across pause/failure/TTL republishes.
 	secretsCtx := store.WithTenant(ctx, prior.TenantID)
 	secretsCtx = store.WithOwner(secretsCtx, prior.OwnerID)
-	secretsRef, secretsErr := p.resolveAndSealCredentials(secretsCtx, spec.RunID, prior.TenantID, prior.OwnerID, prior.BotID, wf, prior.KeyOverrides, prior.SecretOverrides)
+	priorOrgID := p.orgIDForTeam(ctx, prior.TenantID)
+	creds, secretsErr := p.resolveAndSealCredentials(secretsCtx, spec.RunID, priorOrgID, prior.TenantID, prior.OwnerID, prior.BotID, wf, prior.KeyOverrides, prior.SecretOverrides)
+	// Armed before the error check — see SubmitLaunch.
+	republished := false
+	if creds.grant != nil {
+		defer func() {
+			if !republished {
+				p.credPool.Release(ctx, spec.RunID)
+			}
+		}()
+	}
 	if secretsErr != nil {
 		return secretsErr
 	}
@@ -783,7 +880,11 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 			Answers: spec.Answers,
 			Force:   spec.Force,
 		},
-		SecretsRef:     secretsRef,
+		SecretsRef: creds.secretsRef,
+		// A resume re-acquires from the pool, so it re-inherits the donor's
+		// CURRENT remaining allowance as its cost ceiling — a run that was
+		// paused for a day must not come back holding yesterday's budget.
+		Budget:         clampBudgetToGrant(nil, wf, creds.grant, p.logger, spec.RunID),
 		BackendConfig:  queue.BackendConfig{Default: queue.BackendClaw},
 		PublishedAtRFC: time.Now().UTC().Format(time.RFC3339Nano),
 		// Carry the prior run's tenant onto the resume publication so
@@ -793,7 +894,7 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 		// and the resumed attempt's spend must charge that team's org,
 		// not the resumer's.
 		TenantID: prior.TenantID,
-		OrgID:    p.orgIDForTeam(ctx, prior.TenantID),
+		OrgID:    priorOrgID,
 		OwnerID:  prior.OwnerID,
 		// Preserve webhook/cloud source metadata so a resumed runner can
 		// reconstruct the same workspace as the original launch. ProjectPath
@@ -819,6 +920,7 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 		}
 		return fmt.Errorf("cloudpublisher: republish: %w", err)
 	}
+	republished = true
 	if p.metrics != nil {
 		p.metrics.RunsCreatedTotal.WithLabelValues("resumed").Inc()
 	}
@@ -1021,6 +1123,45 @@ func (p *Publisher) goSafeDetached(label string, fn func()) {
 		}()
 		fn()
 	}()
+}
+
+// clampBudgetToGrant caps a run's cost budget at what remains of its
+// donor's allowance, and returns the wire form.
+//
+// This is what makes a pledge an actual ceiling rather than a hope: the
+// engine enforces max_cost_usd as the run proceeds, so a run that would
+// exhaust the donation stops itself. The post-hoc ledger charge is the
+// final truth, but it arrives too late to protect anyone.
+//
+// A grant with RemainingUSD == 0 means the donor set NO spend cap, not
+// "nothing left" (an exhausted donor is never selected in the first
+// place) — so it imposes no ceiling. Otherwise the tightest of the
+// requested override, the workflow's own declared budget, and the
+// allowance wins; the clamp only ever lowers.
+func clampBudgetToGrant(o *ir.BudgetOverrides, wf *ir.Workflow, grant *credpool.Grant, logger *iterlog.Logger, runID string) *queue.BudgetOverrides {
+	if grant == nil || grant.RemainingUSD <= 0 {
+		return budgetForWire(o)
+	}
+	effective := ir.BudgetOverrides{}
+	if o != nil {
+		effective = *o
+	}
+	// What the run would have spent up to, absent the pool: a launch
+	// override replaces the workflow's own figure (ApplyBudgetOverrides
+	// semantics), and zero means unlimited.
+	resolved := ir.Budget{MaxCostUSD: effective.MaxCostUSD}
+	if resolved.MaxCostUSD <= 0 && wf != nil && wf.Budget != nil {
+		resolved.MaxCostUSD = wf.Budget.MaxCostUSD
+	}
+	// The donor's allowance is a ceiling like any other, so it goes through
+	// the same primitive the platform ceiling uses: lower what exceeds it,
+	// impose it on a run that declared nothing, never raise.
+	resolved.ClampToCeiling(&ir.Budget{MaxCostUSD: grant.RemainingUSD})
+	if effective.MaxCostUSD != resolved.MaxCostUSD && logger != nil {
+		logger.Info("cloudpublisher: run %s cost budget capped at $%.2f by its donor's remaining allowance", runID, resolved.MaxCostUSD)
+	}
+	effective.MaxCostUSD = resolved.MaxCostUSD
+	return budgetForWire(&effective)
 }
 
 // budgetForWire converts launch-time budget overrides to their queue wire

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -646,18 +646,13 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 	//     that could not resolve its mandatory credentials).
 	orgID := p.orgIDForTeam(ctx, tenantID)
 	creds, err := p.resolveAndSealCredentials(ctx, runID, orgID, tenantID, ownerID, spec.BotID, wf, spec.KeyOverrides, spec.SecretOverrides)
-	if err != nil {
-		return 0, err
-	}
-	// A run served by the pool may not spend more than what remains of its
-	// donor's allowance. This is the enforcement: the engine stops the run
-	// on its own cost budget, instead of the overspend being discovered
-	// after the fact when the donor is already out of pocket.
-	budget := clampBudgetToGrant(spec.Budget, wf, creds.grant, p.logger, runID)
-	// A donor's admission is consumed the moment it is granted. Every exit
-	// below this point is a launch that will never happen, so it must be
-	// returned — otherwise a Mongo blip during a burst can silently spend a
-	// contributor's whole daily quota on runs that never ran.
+	// A donor's admission is consumed the moment it is granted. Armed BEFORE
+	// the error check: resolveAndSealCredentials can fail AFTER acquiring —
+	// sealing the bundle, persisting it — and still returns the grant. Every
+	// exit below is a launch that will never happen, so it must be returned,
+	// or one Mongo write blip spends a contributor's daily quota and holds
+	// their concurrency slot for the lease's whole 12h life, on a run that
+	// never ran.
 	launched := false
 	if creds.grant != nil {
 		defer func() {
@@ -666,6 +661,14 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 			}
 		}()
 	}
+	if err != nil {
+		return 0, err
+	}
+	// A run served by the pool may not spend more than what remains of its
+	// donor's allowance. This is the enforcement: the engine stops the run
+	// on its own cost budget, instead of the overspend being discovered
+	// after the fact when the donor is already out of pocket.
+	budget := clampBudgetToGrant(spec.Budget, wf, creds.grant, p.logger, runID)
 
 	if err := p.store.SaveRun(ctx, r); err != nil {
 		return 0, fmt.Errorf("cloudpublisher: save run: %w", err)

--- a/pkg/server/cloudpublisher/publisher_secrets_test.go
+++ b/pkg/server/cloudpublisher/publisher_secrets_test.go
@@ -44,14 +44,14 @@ func TestResolveAndSealCredentials_GenericWorkflowSecrets(t *testing.T) {
 		"kubeconfig": {As: "file"},
 	}}
 	ctx := store.WithTenant(context.Background(), "team")
-	ref, err := p.resolveAndSealCredentials(ctx, "run-1", "team", "alice", "", wf, nil, nil)
+	creds, err := p.resolveAndSealCredentials(ctx, "run-1", "", "team", "alice", "", wf, nil, nil)
 	if err != nil {
 		t.Fatalf("resolveAndSealCredentials: %v", err)
 	}
-	if ref == "" {
+	if creds.secretsRef == "" {
 		t.Fatal("expected secrets ref")
 	}
-	rec, err := runSecrets.Get(ctx, ref)
+	rec, err := runSecrets.Get(ctx, creds.secretsRef)
 	if err != nil {
 		t.Fatalf("RunSecrets.Get: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestResolveAndSealCredentials_RequiredSecretUnresolvedFails(t *testing.T) {
 		"test_e2e_canary": {As: "file"}, // non-optional, no inline value
 	}}
 	ctx := store.WithTenant(context.Background(), "team")
-	_, err = p.resolveAndSealCredentials(ctx, "run-1", "team", "alice", "", wf, nil, nil)
+	_, err = p.resolveAndSealCredentials(ctx, "run-1", "", "team", "alice", "", wf, nil, nil)
 	if err == nil {
 		t.Fatal("expected launch to fail for an unresolved required secret")
 	}
@@ -246,13 +246,13 @@ func TestResolveAndSealCredentials_OptionalSecretUnresolvedSkips(t *testing.T) {
 		"test_e2e_canary": {As: "file", Optional: true},
 	}}
 	ctx := store.WithTenant(context.Background(), "team")
-	ref, err := p.resolveAndSealCredentials(ctx, "run-1", "team", "alice", "", wf, nil, nil)
+	creds, err := p.resolveAndSealCredentials(ctx, "run-1", "", "team", "alice", "", wf, nil, nil)
 	if err != nil {
 		t.Fatalf("optional unresolved secret must not fail launch: %v", err)
 	}
 	// No credentials of any kind → empty ref (runner falls back to env).
-	if ref != "" {
-		t.Fatalf("expected empty ref for an all-unresolved optional secret, got %q", ref)
+	if creds.secretsRef != "" {
+		t.Fatalf("expected empty ref for an all-unresolved optional secret, got %q", creds.secretsRef)
 	}
 }
 

--- a/pkg/server/credpool_routes.go
+++ b/pkg/server/credpool_routes.go
@@ -1,0 +1,502 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/credpool"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+// Credential-pool endpoints — two audiences, deliberately separate.
+//
+//   - /api/me/pool/… belongs to the DONOR. It is where someone lends their
+//     subscription, sets the ceilings, watches what their quota served, and
+//     switches it off. Everything here is scoped to the caller's own user
+//     id; a donor can never read or touch another's pledge.
+//   - /api/teams/{id}/pool belongs to the OPERATOR: the pool's existence,
+//     its audience policy, and the roster of who is lending.
+//
+// A donor's credential itself is never exposed by any of these — it stays
+// sealed in pkg/secrets and is only ever unsealed into a run bundle.
+func (s *Server) registerCredPoolRoutes() {
+	s.mux.Handle("GET /api/me/pool", s.requireAuth(http.HandlerFunc(s.handleGetMyPledges)))
+	s.mux.Handle("PUT /api/me/pool/{kind}", s.requireAuth(http.HandlerFunc(s.handlePutMyPledge)))
+	s.mux.Handle("DELETE /api/me/pool/{kind}", s.requireAuth(http.HandlerFunc(s.handleDeleteMyPledge)))
+	s.mux.Handle("GET /api/me/pool/history", s.requireAuth(http.HandlerFunc(s.handleMyPoolHistory)))
+
+	s.mux.Handle("GET /api/teams/{id}/pool", s.requireAuth(http.HandlerFunc(s.handleGetTeamPool)))
+	s.mux.Handle("PUT /api/teams/{id}/pool", s.requireAuth(http.HandlerFunc(s.handlePutTeamPool)))
+}
+
+// ---------------------------------------------------------------------------
+// Views
+// ---------------------------------------------------------------------------
+
+// pledgeView is what a donor sees about their own contribution: the terms
+// they set, the live state, and what has been drawn today and this week.
+type pledgeView struct {
+	Kind string `json:"kind"`
+	// Connected reports whether the donor still has a credential of this
+	// kind connected. A pledge without one is inert — say so rather than
+	// showing an "active" contribution that can never be served.
+	Connected bool             `json:"connected"`
+	Enabled   bool             `json:"enabled"`
+	Status    string           `json:"status"`
+	Limits    credpool.Limits  `json:"limits"`
+	Window    *credpool.Window `json:"window,omitempty"`
+	Bots      []string         `json:"bots,omitempty"`
+	Health    string           `json:"health"`
+	// HealthDetail tells the donor what to do about an unhealthy pledge.
+	HealthDetail  string  `json:"health_detail,omitempty"`
+	CooldownUntil *string `json:"cooldown_until,omitempty"`
+	LastServedAt  *string `json:"last_served_at,omitempty"`
+	// Usage figures are ESTIMATES (see pkg/credpool's doc): on a
+	// subscription the provider bills nothing per call, so spend is derived
+	// from token counts. The UI must present them as approximate.
+	Today     usageView `json:"today"`
+	ThisWeek  usageView `json:"this_week"`
+	UpdatedAt string    `json:"updated_at,omitempty"`
+}
+
+type usageView struct {
+	Runs         int     `json:"runs"`
+	CostUSD      float64 `json:"cost_usd"`
+	InputTokens  int64   `json:"input_tokens"`
+	OutputTokens int64   `json:"output_tokens"`
+}
+
+// leaseView is one entry of a donor's history: which bot ran, for which
+// team, and what it drew. The requester is named because accountability is
+// the counterpart of the trust a donor extends.
+type leaseView struct {
+	RunID       string  `json:"run_id"`
+	BotID       string  `json:"bot_id,omitempty"`
+	TenantID    string  `json:"tenant_id,omitempty"`
+	RequesterID string  `json:"requester_id,omitempty"`
+	CostUSD     float64 `json:"cost_usd"`
+	Outcome     string  `json:"outcome,omitempty"`
+	Closed      bool    `json:"closed"`
+	AcquiredAt  string  `json:"acquired_at"`
+}
+
+// poolView is the operator's read of a pool: its policy plus the roster,
+// with each donor's live state. Donors are identified but their limits are
+// their own business — the operator sees availability, not terms.
+type poolView struct {
+	ID       string            `json:"id"`
+	OrgID    string            `json:"org_id"`
+	Name     string            `json:"name,omitempty"`
+	Enabled  bool              `json:"enabled"`
+	Audience credpool.Audience `json:"audience"`
+	Donors   []donorView       `json:"donors"`
+}
+
+type donorView struct {
+	UserID        string  `json:"user_id"`
+	Kind          string  `json:"kind"`
+	Status        string  `json:"status"`
+	Health        string  `json:"health"`
+	CooldownUntil *string `json:"cooldown_until,omitempty"`
+	LastServedAt  *string `json:"last_served_at,omitempty"`
+	TodayRuns     int     `json:"today_runs"`
+	TodayCostUSD  float64 `json:"today_cost_usd"`
+}
+
+// ---------------------------------------------------------------------------
+// Donor endpoints (/api/me/pool)
+// ---------------------------------------------------------------------------
+
+func (s *Server) handleGetMyPledges(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	pledges, err := s.credPoolPledges.ListByUser(r.Context(), id.UserID)
+	if err != nil {
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	now := time.Now().UTC()
+	connected := s.connectedKinds(r, id.UserID)
+	views := make([]pledgeView, 0, len(pledges))
+	for _, p := range pledges {
+		views = append(views, s.toPledgeView(r, p, now, connected[p.Kind]))
+	}
+	writeJSON(w, struct {
+		Pledges []pledgeView `json:"pledges"`
+		// PoolID is the pool a new pledge would join, so the UI can tell a
+		// user whether lending is even available to them.
+		PoolID string `json:"pool_id,omitempty"`
+	}{Pledges: views, PoolID: s.poolIDForUser(r)})
+}
+
+// pledgeRequest is the donor-supplied body. Every limit is optional; zero
+// means "no limit on this axis", which is a deliberate choice the UI must
+// make legible rather than a default we invent for them.
+type pledgeRequest struct {
+	Enabled *bool            `json:"enabled"`
+	Limits  credpool.Limits  `json:"limits"`
+	Window  *credpool.Window `json:"window"`
+	Bots    []string         `json:"bots"`
+}
+
+func (s *Server) handlePutMyPledge(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	kind := secrets.OAuthKind(r.PathValue("kind"))
+	if !kind.Valid() {
+		httpError(w, http.StatusBadRequest, "unknown credential kind %q", kind)
+		return
+	}
+	var req pledgeRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 64*1024)).Decode(&req); err != nil {
+		httpError(w, http.StatusBadRequest, "bad json: %v", err)
+		return
+	}
+	// Lending requires actually having connected the subscription. Refusing
+	// here — rather than storing an inert pledge — is what stops a donor
+	// believing they are contributing when they are not.
+	rec, err := s.oauthStore.Get(r.Context(), id.UserID, kind)
+	if err != nil {
+		if errors.Is(err, secrets.ErrOAuthNotFound) {
+			httpError(w, http.StatusConflict, "connect your %s subscription before sharing it", kind)
+			return
+		}
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	poolID := s.poolIDForUser(r)
+	if poolID == "" {
+		httpError(w, http.StatusNotFound, "no credential pool accepts contributions on this instance")
+		return
+	}
+
+	pledgeID := credpool.PledgeID(id.UserID, string(kind))
+	p, err := s.credPoolPledges.Get(r.Context(), pledgeID)
+	if err != nil && !errors.Is(err, credpool.ErrNotFound) {
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	p.ID, p.PoolID, p.UserID, p.Kind = pledgeID, poolID, id.UserID, string(kind)
+	p.Limits, p.Window, p.Bots = req.Limits, req.Window, req.Bots
+	if req.Enabled != nil {
+		p.Enabled = *req.Enabled
+	}
+	if reconnected(p, rec) {
+		p.Health, p.HealthDetail, p.ConsecutiveAuthFailures = credpool.HealthOK, "", 0
+	} else {
+		s.logger.Info("credential pool: %s updated terms but their %s credential is still parked (%s)", id.UserID, kind, p.Health)
+	}
+	if err := p.Validate(); err != nil {
+		httpError(w, http.StatusBadRequest, "%s", err.Error())
+		return
+	}
+	if err := s.credPoolPledges.Upsert(r.Context(), p); err != nil {
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	s.logger.Info("credential pool: %s %s their %s subscription", id.UserID, enabledVerb(p.Enabled), kind)
+	// The connection was just verified above; don't re-read it.
+	writeJSON(w, s.toPledgeView(r, p, time.Now().UTC(), true))
+}
+
+// reconnected reports whether a pledge's parked state may be cleared: the
+// credential must have been RE-CONNECTED since the pledge was parked.
+//
+// The signal is CreatedAt, not UpdatedAt. Only sealOAuthRecord — the
+// connect and paste paths — stamps CreatedAt; UpdatedAt is bumped every
+// time the background worker rotates the access token, roughly hourly. A
+// provider can keep refreshing tokens for a subscription it has otherwise
+// revoked, so trusting UpdatedAt would let a dead credential un-park itself
+// on the next tick and burn another round of borrowers' runs discovering
+// the 401 — indefinitely.
+//
+// A healthy pledge is always "clear".
+func reconnected(p credpool.Pledge, rec secrets.OAuthRecord) bool {
+	if p.Health == credpool.HealthOK || p.Health == "" {
+		return true
+	}
+	return rec.CreatedAt.After(p.UpdatedAt)
+}
+
+func enabledVerb(enabled bool) string {
+	if enabled {
+		return "is sharing"
+	}
+	return "paused sharing of"
+}
+
+func (s *Server) handleDeleteMyPledge(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	kind := r.PathValue("kind")
+	if err := s.credPoolPledges.Delete(r.Context(), credpool.PledgeID(id.UserID, kind)); err != nil {
+		if errors.Is(err, credpool.ErrNotFound) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	s.logger.Info("credential pool: %s withdrew their %s contribution", id.UserID, kind)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleMyPoolHistory answers "what did my quota actually run". Without
+// this the donation is a blank cheque; with it, lending stays an informed
+// decision the donor can revisit.
+func (s *Server) handleMyPoolHistory(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	leases, err := s.credPoolLeases.ListByDonor(r.Context(), id.UserID, 100)
+	if err != nil {
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	views := make([]leaseView, 0, len(leases))
+	for _, l := range leases {
+		views = append(views, leaseView{
+			RunID:       l.RunID,
+			BotID:       l.BotID,
+			TenantID:    l.TenantID,
+			RequesterID: l.RequesterID,
+			CostUSD:     l.CostUSD,
+			Outcome:     l.Outcome,
+			Closed:      l.Closed,
+			AcquiredAt:  l.AcquiredAt.Format(time.RFC3339),
+		})
+	}
+	writeJSON(w, struct {
+		Leases []leaseView `json:"leases"`
+	}{Leases: views})
+}
+
+// poolIDForUser resolves the pool a caller's contribution joins: the one
+// owned by their ACTIVE ORG, and nothing else.
+//
+// There is deliberately no "the instance has only one pool, use that"
+// fallback. On a multi-tenant instance that would attach a contributor's
+// personal subscription to a stranger's org the moment their own org had no
+// pool — a donation made to someone they never chose, which no amount of
+// later configuration can retroactively consent to. "" means the UI says so
+// plainly instead.
+func (s *Server) poolIDForUser(r *http.Request) string {
+	id, _ := auth.FromContext(r.Context())
+	if id.OrgID == "" {
+		return ""
+	}
+	p, err := s.credPoolPools.GetByOrg(r.Context(), id.OrgID)
+	if err != nil {
+		if !errors.Is(err, credpool.ErrNotFound) {
+			s.logger.Warn("credential pool: resolve pool of org %s: %v", id.OrgID, err)
+		}
+		return ""
+	}
+	return p.ID
+}
+
+// connectedKinds reports which credential kinds a user still has
+// connected, in ONE read — a per-pledge lookup would be a query per row of
+// the donor's own dashboard.
+func (s *Server) connectedKinds(r *http.Request, userID string) map[string]bool {
+	out := map[string]bool{}
+	records, err := s.oauthStore.ListByUser(r.Context(), userID)
+	if err != nil {
+		s.logger.Warn("credential pool: list oauth connections of %s: %v", userID, err)
+		return out
+	}
+	for _, rec := range records {
+		out[string(rec.Kind)] = true
+	}
+	return out
+}
+
+func (s *Server) toPledgeView(r *http.Request, p credpool.Pledge, now time.Time, connected bool) pledgeView {
+	v := pledgeView{
+		Kind:          p.Kind,
+		Enabled:       p.Enabled,
+		Limits:        p.Limits,
+		Window:        p.Window,
+		Bots:          p.Bots,
+		Health:        string(p.Health),
+		HealthDetail:  p.HealthDetail,
+		CooldownUntil: optRFC3339(p.CooldownUntil),
+		LastServedAt:  optRFC3339(p.LastServedAt),
+	}
+	if !p.UpdatedAt.IsZero() {
+		v.UpdatedAt = p.UpdatedAt.Format(time.RFC3339)
+	}
+	v.Connected = connected
+	_, status := p.Available(now, "")
+	v.Status = string(status)
+	if day, week, err := s.credPoolLedger.Usage(r.Context(), p.ID, now); err == nil {
+		v.Today = toUsageView(day)
+		v.ThisWeek = toUsageView(week)
+		// A donor at their ceiling reads "exhausted", not "active" — the
+		// ledger, not the pledge, holds that truth. Asked through the SAME
+		// rule the ledger admits with (would the next run be refused?), so
+		// the display can never claim "sharing" while every launch is
+		// turned away.
+		if status == credpool.StatusActive &&
+			p.Limits.Deny(day.Runs+1, day.CostUSD, week.CostUSD) != credpool.DenyNone {
+			v.Status = string(credpool.StatusExhausted)
+		}
+	}
+	return v
+}
+
+func toUsageView(u credpool.Usage) usageView {
+	return usageView{Runs: u.Runs, CostUSD: u.CostUSD, InputTokens: u.InputTokens, OutputTokens: u.OutputTokens}
+}
+
+// ---------------------------------------------------------------------------
+// Operator endpoints (/api/teams/{id}/pool)
+// ---------------------------------------------------------------------------
+
+func (s *Server) handleGetTeamPool(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	teamID := r.PathValue("id")
+	if !s.canViewTeam(r.Context(), id, teamID) {
+		httpError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+	orgID := s.orgIDForPoolTeam(r, teamID)
+	if orgID == "" {
+		httpError(w, http.StatusNotFound, "this team has no parent org to own a pool")
+		return
+	}
+	// Who lends, and how much they have given, is the contributors' own
+	// business: an ordinary member sees the policy, not the roster.
+	withDonors := s.canManageOrg(r.Context(), id, orgID)
+	pool, err := s.credPoolPools.GetByOrg(r.Context(), orgID)
+	if err != nil {
+		if errors.Is(err, credpool.ErrNotFound) {
+			// Not an error: describe the pool that WOULD be created, so the
+			// UI renders the same form for the first save as for later ones.
+			writeJSON(w, poolView{OrgID: orgID, Donors: []donorView{}})
+			return
+		}
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	writeJSON(w, s.toPoolView(r, pool, withDonors))
+}
+
+type poolRequest struct {
+	Name     *string            `json:"name"`
+	Enabled  *bool              `json:"enabled"`
+	Audience *credpool.Audience `json:"audience"`
+}
+
+func (s *Server) handlePutTeamPool(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	teamID := r.PathValue("id")
+	orgID := s.orgIDForPoolTeam(r, teamID)
+	if orgID == "" {
+		httpError(w, http.StatusNotFound, "this team has no parent org to own a pool")
+		return
+	}
+	// The pool document is keyed by ORG, so this route mutates policy for
+	// every team under it. Gating on the addressed team would let an admin
+	// of any one team widen who may spend the whole org's contributed
+	// subscriptions — a decision that belongs to the org.
+	if !s.canManageOrg(r.Context(), id, orgID) {
+		httpError(w, http.StatusForbidden, "changing the credential pool is an org-level decision")
+		return
+	}
+	var req poolRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 64*1024)).Decode(&req); err != nil {
+		httpError(w, http.StatusBadRequest, "bad json: %v", err)
+		return
+	}
+	pool, err := s.credPoolPools.GetByOrg(r.Context(), orgID)
+	if err != nil {
+		if !errors.Is(err, credpool.ErrNotFound) {
+			httpError(w, http.StatusInternalServerError, "%s", err.Error())
+			return
+		}
+		pool = credpool.Pool{ID: orgID, OrgID: orgID}
+	}
+	if req.Name != nil {
+		pool.Name = strings.TrimSpace(*req.Name)
+	}
+	if req.Enabled != nil {
+		pool.Enabled = *req.Enabled
+	}
+	if req.Audience != nil {
+		pool.Audience = *req.Audience
+	}
+	if err := s.credPoolPools.Upsert(r.Context(), pool); err != nil {
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	// Widening who may spend contributors' subscriptions is exactly the
+	// kind of decision that must leave a trace — recorded on the ORG, since
+	// that is who the pool belongs to and who must be able to see it.
+	s.auditOrg(r, orgID, "credpool.updated", "cred_pool", pool.ID, map[string]any{
+		"enabled":      pool.Enabled,
+		"all_teams":    pool.Audience.AllTeams,
+		"contributors": pool.Audience.Contributors,
+		"teams":        len(pool.Audience.Teams),
+		"orgs":         len(pool.Audience.Orgs),
+	})
+	writeJSON(w, s.toPoolView(r, pool, true))
+}
+
+// orgIDForPoolTeam resolves the org that owns a team's pool, preferring
+// the JWT's active org (no extra read) and falling back to the team row.
+func (s *Server) orgIDForPoolTeam(r *http.Request, teamID string) string {
+	id, _ := auth.FromContext(r.Context())
+	if id.OrgID != "" && id.TeamID == teamID {
+		return id.OrgID
+	}
+	st := s.authStore()
+	if st == nil {
+		return ""
+	}
+	t, err := st.GetTeam(r.Context(), teamID)
+	if err != nil {
+		return ""
+	}
+	return t.OrgID
+}
+
+func (s *Server) toPoolView(r *http.Request, pool credpool.Pool, withDonors bool) poolView {
+	v := poolView{
+		ID: pool.ID, OrgID: pool.OrgID, Name: pool.Name,
+		Enabled: pool.Enabled, Audience: pool.Audience,
+		Donors: []donorView{},
+	}
+	if !withDonors {
+		return v
+	}
+	pledges, err := s.credPoolPledges.ListByPool(r.Context(), pool.ID)
+	if err != nil {
+		s.logger.Warn("credential pool: list donors of %s: %v", pool.ID, err)
+		return v
+	}
+	now := time.Now().UTC()
+	ids := make([]string, 0, len(pledges))
+	for _, p := range pledges {
+		ids = append(ids, p.ID)
+	}
+	usage, err := s.credPoolLedger.UsageMany(r.Context(), ids, now)
+	if err != nil {
+		s.logger.Warn("credential pool: donor usage of %s: %v", pool.ID, err)
+	}
+	for _, p := range pledges {
+		_, status := p.Available(now, "")
+		u := usage[p.ID]
+		v.Donors = append(v.Donors, donorView{
+			UserID:        p.UserID,
+			Kind:          p.Kind,
+			Status:        string(status),
+			Health:        string(p.Health),
+			CooldownUntil: optRFC3339(p.CooldownUntil),
+			LastServedAt:  optRFC3339(p.LastServedAt),
+			TodayRuns:     u.Runs,
+			TodayCostUSD:  u.CostUSD,
+		})
+	}
+	return v
+}

--- a/pkg/server/credpool_routes.go
+++ b/pkg/server/credpool_routes.go
@@ -334,11 +334,18 @@ func (s *Server) toPledgeView(r *http.Request, p credpool.Pledge, now time.Time,
 		v.ThisWeek = toUsageView(week)
 		// A donor at their ceiling reads "exhausted", not "active" — the
 		// ledger, not the pledge, holds that truth. Asked through the SAME
-		// rule the ledger admits with (would the next run be refused?), so
-		// the display can never claim "sharing" while every launch is
-		// turned away.
+		// inputs the ledger admits with, INCLUDING the allowance already
+		// promised to in-flight runs: without that term a donor whose
+		// remaining budget is fully committed would read "Sharing" while
+		// every new launch is refused.
+		committed := 0.0
+		if s.credPoolLeases != nil {
+			if _, c, cerr := s.credPoolLeases.LiveCommitment(r.Context(), p.ID, "", now); cerr == nil {
+				committed = c
+			}
+		}
 		if status == credpool.StatusActive &&
-			p.Limits.Deny(day.Runs+1, day.CostUSD, week.CostUSD) != credpool.DenyNone {
+			p.Limits.Deny(day.Runs+1, day.CostUSD+committed, week.CostUSD+committed) != credpool.DenyNone {
 			v.Status = string(credpool.StatusExhausted)
 		}
 	}

--- a/pkg/server/credpool_routes_test.go
+++ b/pkg/server/credpool_routes_test.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/credpool"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+// Regressions for consent defects an adversarial review found. Both let a
+// contributor's subscription be used in a way they had not agreed to.
+
+// A parked credential must not return to service just because its donor
+// touched their terms. Only a genuine reconnection clears it — otherwise
+// other people's runs rediscover the same dead token, one at a time.
+func TestReconnected(t *testing.T) {
+	parked := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name      string
+		health    credpool.Health
+		connected time.Time // rec.CreatedAt — stamped only by a real connect
+		refreshed time.Time // rec.UpdatedAt — bumped hourly by the worker
+		want      bool
+	}{
+		{"a healthy pledge is always clear", credpool.HealthOK, parked.Add(-time.Hour), parked.Add(time.Hour), true},
+		{"an unset health is treated as healthy", "", parked.Add(-time.Hour), parked.Add(time.Hour), true},
+		{
+			"parked, credential untouched — stays parked",
+			credpool.HealthAuthFailed, parked.Add(-time.Hour), parked.Add(-time.Hour), false,
+		},
+		{
+			// THE defect: a provider can keep rotating tokens for a
+			// subscription it has revoked. Trusting the refresh timestamp
+			// let a dead credential un-park itself every hour and burn
+			// another round of borrowers' runs on the same 401.
+			"parked, only the token refresh moved — stays parked",
+			credpool.HealthAuthFailed, parked.Add(-time.Hour), parked.Add(6 * time.Hour), false,
+		},
+		{
+			"parked, genuinely reconnected since — cleared",
+			credpool.HealthAuthFailed, parked.Add(time.Minute), parked.Add(time.Minute), true,
+		},
+		{
+			"an expired token that was reconnected — cleared",
+			credpool.HealthTokenExpired, parked.Add(time.Minute), parked.Add(time.Minute), true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := credpool.Pledge{Health: tc.health, UpdatedAt: parked}
+			rec := secrets.OAuthRecord{CreatedAt: tc.connected, UpdatedAt: tc.refreshed}
+			if got := reconnected(p, rec); got != tc.want {
+				t.Errorf("reconnected = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A contribution joins the pool of the donor's OWN org, never a stranger's.
+// A "the instance has only one pool, use that" fallback would attach a
+// personal subscription to an org the donor never chose.
+func TestPoolIDForUser_neverAttachesToAnotherOrgsPool(t *testing.T) {
+	ctx := context.Background()
+	pools := credpool.NewMemoryPoolStore()
+	if err := pools.Upsert(ctx, credpool.Pool{ID: "pool-other", OrgID: "org-other", Enabled: true}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	s := &Server{credPoolPools: pools, logger: iterlog.New(iterlog.LevelError, nil)}
+
+	// A user of an org with no pool of its own gets nothing, even though
+	// exactly one pool exists on the instance.
+	r := httptest.NewRequest("GET", "/api/me/pool", nil)
+	r = r.WithContext(auth.WithIdentity(ctx, auth.Identity{UserID: "alice", OrgID: "org-mine"}))
+	if got := s.poolIDForUser(r); got != "" {
+		t.Errorf("pool = %q, want none — alice was enrolled into another org's pool", got)
+	}
+
+	// Their own org's pool resolves normally.
+	if err := pools.Upsert(ctx, credpool.Pool{ID: "pool-mine", OrgID: "org-mine", Enabled: true}); err != nil {
+		t.Fatalf("seed own: %v", err)
+	}
+	if got := s.poolIDForUser(r); got != "pool-mine" {
+		t.Errorf("pool = %q, want pool-mine", got)
+	}
+
+	// No active org at all → nothing.
+	r2 := httptest.NewRequest("GET", "/api/me/pool", nil)
+	r2 = r2.WithContext(auth.WithIdentity(ctx, auth.Identity{UserID: "bob"}))
+	if got := s.poolIDForUser(r2); got != "" {
+		t.Errorf("pool = %q, want none for a user with no active org", got)
+	}
+}
+
+// The donor roster is the contributors' business, not every org member's.
+func TestToPoolView_hidesTheRosterFromNonManagers(t *testing.T) {
+	ctx := context.Background()
+	pledges := credpool.NewMemoryPledgeStore()
+	if err := pledges.Upsert(ctx, credpool.Pledge{
+		ID: credpool.PledgeID("alice", "claude_code"), PoolID: "pool-1",
+		UserID: "alice", Kind: "claude_code", Enabled: true, Health: credpool.HealthOK,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	s := &Server{
+		credPoolPledges: pledges,
+		credPoolLedger:  credpool.NewMemoryLedger(),
+		logger:          iterlog.New(iterlog.LevelError, nil),
+	}
+	r := httptest.NewRequest("GET", "/api/teams/team-1/pool", nil)
+	r = r.WithContext(auth.WithIdentity(ctx, auth.Identity{UserID: "carol"}))
+	pool := credpool.Pool{ID: "pool-1", OrgID: "org-1", Enabled: true}
+
+	if v := s.toPoolView(r, pool, false); len(v.Donors) != 0 {
+		t.Errorf("a non-manager saw %d donor(s) — who lends is not org-wide public information", len(v.Donors))
+	}
+	if v := s.toPoolView(r, pool, true); len(v.Donors) != 1 {
+		t.Errorf("a manager saw %d donor(s), want 1", len(v.Donors))
+	}
+}

--- a/pkg/server/credpool_sweeper.go
+++ b/pkg/server/credpool_sweeper.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"context"
+	"time"
+)
+
+// Abandoned-lease sweeper.
+//
+// A run that draws on the credential pool holds a lease against its donor
+// for as long as it runs — that lease IS the donor's concurrency reading.
+// A runner pod killed at the wrong instant (eviction, OOM, a node going
+// away) never reports, so without a sweeper the donor would keep a slot
+// consumed by a run that no longer exists, and a contributor who offered
+// "one run at a time" would silently stop being able to serve any.
+//
+// Each lease carries its own expiry, so the sweep is a plain scan: close
+// anything live and past its instant. No spend is charged for those runs —
+// nothing told us what they consumed, and inventing a figure would
+// misreport a contributor's donation in the direction that costs them.
+//
+// Multi-replica-safe: closing a lease is conditional on it still being
+// open, so two replicas sweeping the same instant produce one close.
+
+const (
+	// credPoolSweepInterval is how often abandoned leases are collected.
+	// Frequent enough that a donor's slot comes back within minutes of the
+	// lease expiring, cheap enough to be irrelevant (one indexed query).
+	credPoolSweepInterval = 2 * time.Minute
+	// credPoolSweepBatch bounds one pass so a large backlog is drained
+	// over several ticks rather than in one long transaction.
+	credPoolSweepBatch = 200
+)
+
+// runCredPoolSweeper loops until ctx is cancelled. Started by
+// ListenAndServe when a credential pool is wired.
+func (s *Server) runCredPoolSweeper(ctx context.Context) {
+	t := time.NewTicker(credPoolSweepInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.sweepCredPoolLeases(ctx)
+		}
+	}
+}
+
+// sweepCredPoolLeases performs one pass. Extracted for tests.
+func (s *Server) sweepCredPoolLeases(ctx context.Context) {
+	if s.credPool == nil {
+		return
+	}
+	freed, err := s.credPool.ReleaseExpired(ctx, credPoolSweepBatch)
+	if err != nil {
+		s.logger.Warn("credential pool: sweep abandoned leases: %v", err)
+		return
+	}
+	if freed > 0 {
+		s.logger.Info("credential pool: freed %d abandoned lease(s) — their donors can serve again", freed)
+	}
+}

--- a/pkg/server/oauth_routes.go
+++ b/pkg/server/oauth_routes.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/credpool"
 	"github.com/SocialGouv/iterion/pkg/secrets"
 )
 
@@ -357,6 +359,22 @@ func (s *Server) deleteOAuthForOwner(w http.ResponseWriter, r *http.Request, own
 	if !kind.Valid() {
 		httpError(w, http.StatusBadRequest, "unknown oauth kind")
 		return
+	}
+	// Consent is given for a SPECIFIC connected subscription. Disconnecting
+	// it withdraws that consent, so the pledge goes with it — otherwise the
+	// terms would sit there waiting to be rebound to whatever credential is
+	// connected next under the same key, which could be a different account
+	// entirely.
+	//
+	// Best-effort: disconnecting is the user's actual request, and a
+	// degraded pool store must not trap them into keeping a credential
+	// connected. A pledge left behind is caught at acquisition, which parks
+	// it the first time its credential turns up missing. Only personal
+	// scopes can hold a pledge — an org owner key never does.
+	if s.credPoolPledges != nil && !strings.HasPrefix(ownerKey, secrets.OrgOwnerPrefix) {
+		if err := s.credPoolPledges.Delete(r.Context(), credpool.PledgeID(ownerKey, string(kind))); err != nil && !errors.Is(err, credpool.ErrNotFound) {
+			s.logger.Warn("credential pool: could not withdraw %s's %s contribution on disconnect: %v (it is parked at the next acquisition)", ownerKey, kind, err)
+		}
 	}
 	if err := s.oauthStore.Delete(r.Context(), ownerKey, kind); err != nil {
 		if errors.Is(err, secrets.ErrOAuthNotFound) {

--- a/pkg/server/openapi_spec.go
+++ b/pkg/server/openapi_spec.go
@@ -9,6 +9,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/audit"
 	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/auth/orgsso"
+	"github.com/SocialGouv/iterion/pkg/credpool"
 	"github.com/SocialGouv/iterion/pkg/forge"
 	"github.com/SocialGouv/iterion/pkg/orgusage"
 	"github.com/SocialGouv/iterion/pkg/pat"
@@ -65,6 +66,10 @@ func BuildOpenAPISpec() (map[string]any, error) {
 		PATs:              pat.NewMemoryStore(),
 		TriggerStore:      trigger.NewMemorySubscriptionStore(),
 		OrgUsage:          orgusage.NewMemoryCounter(),
+		CredPoolPools:     credpool.NewMemoryPoolStore(),
+		CredPoolPledges:   credpool.NewMemoryPledgeStore(),
+		CredPoolLeases:    credpool.NewMemoryLeaseStore(),
+		CredPoolLedger:    credpool.NewMemoryLedger(),
 		Audit:             audit.NewMemoryStore(),
 		Store:             runStore,
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/botsource"
 	"github.com/SocialGouv/iterion/pkg/bundle"
 	"github.com/SocialGouv/iterion/pkg/configshare"
+	"github.com/SocialGouv/iterion/pkg/credpool"
 	"github.com/SocialGouv/iterion/pkg/forge"
 	"github.com/SocialGouv/iterion/pkg/knowledge"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
@@ -126,6 +127,11 @@ type Server struct {
 	webhookCounter    webhooks.Counter
 	orgUsage          orgusage.Counter
 	orgDefaults       OrgLimitDefaults
+	credPool          *credpool.Broker
+	credPoolPools     credpool.PoolStore
+	credPoolPledges   credpool.PledgeStore
+	credPoolLeases    credpool.LeaseStore
+	credPoolLedger    credpool.Ledger
 	auditStore        audit.Store
 	pats              pat.Store
 	queue             *natsq.Conn
@@ -378,6 +384,11 @@ func New(cfg Config, logger *iterlog.Logger) *Server {
 		webhookCounter:    cfg.WebhookCounter,
 		orgUsage:          cfg.OrgUsage,
 		orgDefaults:       cfg.OrgDefaults,
+		credPool:          cfg.CredPoolBroker,
+		credPoolPools:     cfg.CredPoolPools,
+		credPoolPledges:   cfg.CredPoolPledges,
+		credPoolLeases:    cfg.CredPoolLeases,
+		credPoolLedger:    cfg.CredPoolLedger,
 		auditStore:        cfg.Audit,
 		pats:              cfg.PATs,
 		queue:             cfg.Queue,

--- a/pkg/server/server_config.go
+++ b/pkg/server/server_config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/cloud/orgsweep"
 	"github.com/SocialGouv/iterion/pkg/cloudsched"
 	"github.com/SocialGouv/iterion/pkg/configshare"
+	"github.com/SocialGouv/iterion/pkg/credpool"
 	"github.com/SocialGouv/iterion/pkg/dispatcher"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/boardmongo"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
@@ -150,6 +151,17 @@ type Config struct {
 	// gateLaunch quota checks and increments the month's run counter;
 	// the usage REST views read it back. nil → no metering (local mode).
 	OrgUsage orgusage.Counter
+
+	// CredPool* wire the mutualised credential pool (pkg/credpool): the
+	// contributor-lent LLM subscriptions a run with no credential of its
+	// own can draw on. All four must be non-nil together — the stores back
+	// the donor + operator REST surfaces, the Broker backs selection and
+	// the abandoned-lease sweeper. nil → no pool tier anywhere.
+	CredPoolBroker  *credpool.Broker
+	CredPoolPools   credpool.PoolStore
+	CredPoolPledges credpool.PledgeStore
+	CredPoolLeases  credpool.LeaseStore
+	CredPoolLedger  credpool.Ledger
 
 	// Audit, when non-nil, persists control-plane mutations (org
 	// status, secrets/bindings/webhooks CRUD, member changes…) and

--- a/pkg/server/server_lifecycle.go
+++ b/pkg/server/server_lifecycle.go
@@ -224,6 +224,19 @@ func (s *Server) ListenAndServe() error {
 			s.runQueueSweeper(ctx, lister, s.queue)
 		}()
 	}
+	// Abandoned-lease sweeper: gives a lending contributor back the
+	// concurrency slot of a run whose pod died without reporting.
+	if s.credPool != nil {
+		go func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go func() {
+				<-s.shutdown
+				cancel()
+			}()
+			s.runCredPoolSweeper(ctx)
+		}()
+	}
 	// Retry sweeper (cloud only): resumes runs whose provider quota window
 	// has reopened. Needs only the store — unlike the orphan sweeper it
 	// asks no question of the queue, because the retry instant was decided

--- a/pkg/server/server_routes.go
+++ b/pkg/server/server_routes.go
@@ -263,6 +263,12 @@ func (s *Server) routes() {
 		if s.authStore() != nil {
 			s.registerOAuthTeamRoutes()
 		}
+		// Mutualised credential pool. Rides the same gating: lending a
+		// subscription starts by connecting one, so a deployment without
+		// the OAuth surface has nothing to pool.
+		if s.credPoolPools != nil && s.credPoolPledges != nil && s.credPoolLeases != nil && s.credPoolLedger != nil {
+			s.registerCredPoolRoutes()
+		}
 	}
 
 	// Dispatcher + native tracker — both optional. Each handler is

--- a/studio/src/api/credpool.ts
+++ b/studio/src/api/credpool.ts
@@ -1,0 +1,146 @@
+// Credential-pool API client: lending an LLM subscription to the shared
+// pool, and the operator view of who is lending.
+//
+// The credential itself never appears here — it stays sealed server-side
+// and is only ever unsealed into a run's bundle. What travels is the
+// donor's TERMS and what has been drawn against them.
+
+import { request as send } from "./client";
+import type { OAuthKind } from "./byok";
+
+/** Every ceiling is optional; 0 means "no limit on this axis". */
+export interface PoolLimits {
+  max_usd_per_day?: number;
+  max_usd_per_week?: number;
+  max_runs_per_day?: number;
+  max_concurrent_runs?: number;
+}
+
+/** Hours/days the contribution is shareable in. Absent = always. */
+export interface PoolWindow {
+  timezone?: string;
+  /** Inclusive start, exclusive end, local time. Equal = all day; start > end wraps midnight. */
+  start_hour: number;
+  end_hour: number;
+  /** time.Weekday values (Sunday = 0). Empty = every day. */
+  weekdays?: number[];
+}
+
+export interface PoolUsage {
+  runs: number;
+  cost_usd: number;
+  input_tokens: number;
+  output_tokens: number;
+}
+
+export type PledgeStatus =
+  | "active"
+  | "paused"
+  | "cooling"
+  | "out_of_hours"
+  | "exhausted"
+  | "unhealthy"
+  | "bot_filtered";
+
+export interface PledgeView {
+  kind: OAuthKind;
+  /** False when the subscription behind this pledge is no longer connected. */
+  connected: boolean;
+  enabled: boolean;
+  status: PledgeStatus;
+  limits: PoolLimits;
+  window?: PoolWindow;
+  bots?: string[];
+  health: string;
+  health_detail?: string;
+  cooldown_until?: string;
+  last_served_at?: string;
+  /** ESTIMATED spend — a subscription bills nothing per call, so this is derived from tokens. */
+  today: PoolUsage;
+  this_week: PoolUsage;
+  updated_at?: string;
+}
+
+export interface PledgeLease {
+  run_id: string;
+  bot_id?: string;
+  tenant_id?: string;
+  requester_id?: string;
+  cost_usd: number;
+  outcome?: string;
+  closed: boolean;
+  acquired_at: string;
+}
+
+export interface PledgeInput {
+  enabled: boolean;
+  limits: PoolLimits;
+  window?: PoolWindow | null;
+  bots?: string[];
+}
+
+export async function listMyPledges(): Promise<{ pledges: PledgeView[]; pool_id?: string }> {
+  const res = await send<{ pledges: PledgeView[]; pool_id?: string }>("/me/pool");
+  return { pledges: res.pledges ?? [], pool_id: res.pool_id };
+}
+
+export async function savePledge(kind: OAuthKind, input: PledgeInput): Promise<PledgeView> {
+  return send(`/me/pool/${encodeURIComponent(kind)}`, {
+    method: "PUT",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function withdrawPledge(kind: OAuthKind): Promise<void> {
+  await send(`/me/pool/${encodeURIComponent(kind)}`, { method: "DELETE" });
+}
+
+export async function listMyPoolHistory(): Promise<PledgeLease[]> {
+  const res = await send<{ leases: PledgeLease[] }>("/me/pool/history");
+  return res.leases ?? [];
+}
+
+// ---- Operator surface ----
+
+/** Who may draw on the pool. A union of independent predicates. */
+export interface PoolAudience {
+  teams?: string[];
+  orgs?: string[];
+  /** Reciprocity: any active donor may draw, wherever they launch from. */
+  contributors?: boolean;
+  all_teams?: boolean;
+}
+
+export interface PoolDonor {
+  user_id: string;
+  kind: OAuthKind;
+  status: PledgeStatus;
+  health: string;
+  cooldown_until?: string;
+  last_served_at?: string;
+  today_runs: number;
+  today_cost_usd: number;
+}
+
+export interface PoolView {
+  id: string;
+  org_id: string;
+  name?: string;
+  enabled: boolean;
+  audience: PoolAudience;
+  donors: PoolDonor[];
+}
+
+export async function getTeamPool(teamID: string): Promise<PoolView> {
+  return send(`/teams/${encodeURIComponent(teamID)}/pool`);
+}
+
+export async function saveTeamPool(
+  teamID: string,
+  input: { name?: string; enabled?: boolean; audience?: PoolAudience },
+): Promise<PoolView> {
+  return send(`/teams/${encodeURIComponent(teamID)}/pool`, {
+    method: "PUT",
+    body: JSON.stringify(input),
+  });
+}

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -973,6 +973,60 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/me/pool": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** GET /api/me/pool */
+        get: operations["getMePool"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/me/pool/history": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** GET /api/me/pool/history */
+        get: operations["getMePoolHistory"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/me/pool/{kind}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                kind: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        /** PUT /api/me/pool/{kind} */
+        put: operations["putMePoolByKind"];
+        post?: never;
+        /** DELETE /api/me/pool/{kind} */
+        delete: operations["deleteMePoolByKind"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/me/secrets": {
         parameters: {
             query?: never;
@@ -3281,6 +3335,26 @@ export interface paths {
         head?: never;
         /** PATCH /api/teams/{id}/plugin-sources/{source_id} */
         patch: operations["patchTeamsByIdPluginSourcesBySourceId"];
+        trace?: never;
+    };
+    "/api/teams/{id}/pool": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** GET /api/teams/{id}/pool */
+        get: operations["getTeamsByIdPool"];
+        /** PUT /api/teams/{id}/pool */
+        put: operations["putTeamsByIdPool"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
         trace?: never;
     };
     "/api/teams/{id}/secrets": {
@@ -6338,6 +6412,82 @@ export interface operations {
             query?: never;
             header?: never;
             path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getMePool: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getMePoolHistory: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    putMePoolByKind: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                kind: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    deleteMePoolByKind: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                kind: string;
+            };
             cookie?: never;
         };
         requestBody?: never;
@@ -9504,6 +9654,46 @@ export interface operations {
             path: {
                 id: string;
                 source_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getTeamsByIdPool: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    putTeamsByIdPool: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
             };
             cookie?: never;
         };

--- a/studio/src/views/account/SettingsPage.tsx
+++ b/studio/src/views/account/SettingsPage.tsx
@@ -11,6 +11,7 @@ import { useConfirm } from "@/hooks/useConfirm";
 import ApiKeysPanel from "./ApiKeys";
 import NotificationsPanel from "./NotificationsPanel";
 import OAuthConnections from "./OAuthConnections";
+import SharedQuota from "./SharedQuota";
 import TokensPanel from "./TokensPanel";
 import {
   ApiError,
@@ -28,7 +29,7 @@ import { useAuth } from "@/auth/AuthContext";
 import { useServerInfoStore } from "@/store/serverInfo";
 import { useHeaderSlot } from "@/components/shared/useHeaderSlot";
 
-type Tab = "api-keys" | "oauth" | "tokens" | "notifications" | "profile";
+type Tab = "api-keys" | "oauth" | "shared-quota" | "tokens" | "notifications" | "profile";
 
 export default function SettingsPage() {
   const { user } = useAuth();
@@ -57,6 +58,9 @@ export default function SettingsPage() {
     { id: "api-keys", label: "API keys (BYOK)" },
     { id: "oauth", label: "OAuth subscriptions" },
   ];
+  // Lending a subscription starts by connecting one, so this tab sits
+  // next to the connections and only where an auth stack exists.
+  if (showAuthTabs) tabs.push({ id: "shared-quota", label: "Share my quota" });
   if (showAuthTabs) tabs.push({ id: "tokens", label: "Access tokens" });
   if (serverInfo?.web_push_enabled) tabs.push({ id: "notifications", label: "Notifications" });
   tabs.push({ id: "profile", label: "Profile" });
@@ -76,6 +80,7 @@ export default function SettingsPage() {
         <div className="bg-surface-0">
           {tab === "api-keys" && <ApiKeysPanel />}
           {tab === "oauth" && <OAuthConnections />}
+          {tab === "shared-quota" && showAuthTabs && <SharedQuota />}
           {tab === "tokens" && showAuthTabs && <TokensPanel />}
           {tab === "notifications" && serverInfo?.web_push_enabled && <NotificationsPanel />}
           {tab === "profile" && (

--- a/studio/src/views/account/SharedQuota.tsx
+++ b/studio/src/views/account/SharedQuota.tsx
@@ -1,0 +1,387 @@
+import { errorMessage } from "@/lib/errorHints";
+import { formatCost, formatDateTime } from "@/lib/format";
+import { useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { FieldLabel } from "@/components/ui/FieldLabel";
+import { InlineBanner } from "@/components/ui/InlineBanner";
+import { Input } from "@/components/ui/Input";
+import { Meter } from "@/components/ui/Meter";
+import { TBody, THead, Table, Td, Th, Tr } from "@/components/ui/Table";
+import PanelLoading from "@/components/shared/PanelLoading";
+import { useConfirm } from "@/hooks/useConfirm";
+import { useUIStore } from "@/store/ui";
+import type { OAuthKind } from "@/api/byok";
+import {
+  listMyPledges,
+  listMyPoolHistory,
+  savePledge,
+  withdrawPledge,
+  type PledgeInput,
+  type PledgeLease,
+  type PledgeStatus,
+  type PledgeView,
+  type PoolLimits,
+} from "@/api/credpool";
+
+const KIND_LABEL: Record<OAuthKind, string> = {
+  claude_code: "Claude Pro / Max",
+  codex: "ChatGPT (Codex)",
+};
+
+// The same caveat the org-shared forfait already carries. Lending a
+// personal subscription to other people goes a step further than sharing
+// one inside an org, so the wording stays in front of the donor rather
+// than buried in docs.
+const TOS_NOTICE =
+  "A Claude or ChatGPT subscription is an individual licence. Sharing yours is a convenience for developing and testing bots — not a production-automation credential. You stay in control: the ceilings below are yours, and pausing takes effect on the next run.";
+
+const STATUS_COPY: Record<PledgeStatus, { label: string; tone: "success" | "warning" | "neutral" | "danger" }> = {
+  active: { label: "Sharing", tone: "success" },
+  paused: { label: "Paused", tone: "neutral" },
+  cooling: { label: "Resting until your quota window reopens", tone: "warning" },
+  out_of_hours: { label: "Outside your sharing hours", tone: "neutral" },
+  exhausted: { label: "Ceiling reached for now", tone: "warning" },
+  unhealthy: { label: "Needs reconnecting", tone: "danger" },
+  bot_filtered: { label: "Sharing, but not with this bot", tone: "neutral" },
+};
+
+/** Blank input = "no limit on this axis", which the API encodes as 0. */
+function numOrZero(s: string): number {
+  const n = Number(s);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+const showNum = (v?: number) => (v && v > 0 ? String(v) : "");
+
+export default function SharedQuota() {
+  const queryClient = useQueryClient();
+  const query = useQuery({ queryKey: ["my-pledges"], queryFn: listMyPledges });
+  const history = useQuery<PledgeLease[]>({
+    queryKey: ["my-pool-history"],
+    queryFn: listMyPoolHistory,
+  });
+  const [err, setErr] = useState<string | null>(null);
+  const { confirm, dialog } = useConfirm();
+  const addToast = useUIStore((s) => s.addToast);
+
+  const pledges = query.data?.pledges ?? [];
+  const poolAvailable = Boolean(query.data?.pool_id);
+
+  const reload = () => {
+    setErr(null);
+    void queryClient.invalidateQueries({ queryKey: ["my-pledges"] });
+    void queryClient.invalidateQueries({ queryKey: ["my-pool-history"] });
+  };
+
+  const onSaved = (message: string) => {
+    addToast(message, "success");
+    reload();
+  };
+
+  return (
+    <div className="space-y-4">
+      {dialog}
+      <div>
+        <h2 className="text-lg font-semibold">Share my quota</h2>
+        <p className="text-sm text-fg-muted mt-1">
+          Lend the unused part of your Claude or ChatGPT subscription so other runs on this
+          instance can use it. You set the ceilings, you see everything it ran, and you can stop
+          at any moment.
+        </p>
+      </div>
+
+      <InlineBanner tone="warning" layout="inline">
+        {TOS_NOTICE}
+      </InlineBanner>
+
+      {err && (
+        <InlineBanner tone="danger" layout="inline">
+          {err}
+        </InlineBanner>
+      )}
+
+      {!poolAvailable && !query.isLoading && (
+        <InlineBanner tone="info" layout="inline">
+          No credential pool accepts contributions on this instance yet — ask an operator to
+          enable one for your workspace.
+        </InlineBanner>
+      )}
+
+      {query.isFetching && pledges.length === 0 ? (
+        <PanelLoading />
+      ) : (
+        <div className="space-y-4">
+          {(["claude_code", "codex"] as OAuthKind[]).map((kind) => (
+            <PledgeCard
+              key={kind}
+              kind={kind}
+              pledge={pledges.find((p) => p.kind === kind)}
+              disabled={!poolAvailable}
+              onError={setErr}
+              onSaved={onSaved}
+              confirm={confirm}
+            />
+          ))}
+        </div>
+      )}
+
+      <HistoryTable leases={history.data ?? []} />
+    </div>
+  );
+}
+
+function PledgeCard({
+  kind,
+  pledge,
+  disabled,
+  onError,
+  onSaved,
+  confirm,
+}: {
+  kind: OAuthKind;
+  pledge?: PledgeView;
+  disabled: boolean;
+  onError: (msg: string | null) => void;
+  onSaved: (msg: string) => void;
+  confirm: ReturnType<typeof useConfirm>["confirm"];
+}) {
+  const [limits, setLimits] = useState<PoolLimits>({});
+  const [hours, setHours] = useState<{ start: string; end: string }>({ start: "", end: "" });
+  const [busy, setBusy] = useState(false);
+
+  // Re-seed the form whenever the server's view changes, so a save or a
+  // reload shows what is actually stored rather than stale local edits.
+  useEffect(() => {
+    setLimits(pledge?.limits ?? {});
+    setHours({
+      start: pledge?.window ? String(pledge.window.start_hour) : "",
+      end: pledge?.window ? String(pledge.window.end_hour) : "",
+    });
+  }, [pledge]);
+
+  const status = pledge?.status;
+  const copy = status ? STATUS_COPY[status] : null;
+
+  const buildInput = (enabled: boolean): PledgeInput => {
+    const start = numOrZero(hours.start);
+    const end = numOrZero(hours.end);
+    return {
+      enabled,
+      limits,
+      // Both blank (or equal) means "any time" — send no window at all
+      // rather than a 0→0 range the reader would have to special-case.
+      window:
+        hours.start === "" && hours.end === ""
+          ? null
+          : {
+              start_hour: start,
+              end_hour: end,
+              timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            },
+      bots: pledge?.bots,
+    };
+  };
+
+  const save = async (enabled: boolean) => {
+    setBusy(true);
+    onError(null);
+    try {
+      await savePledge(kind, buildInput(enabled));
+      onSaved(enabled ? `Sharing your ${KIND_LABEL[kind]} quota.` : "Sharing paused.");
+    } catch (e) {
+      onError(errorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const withdraw = async () => {
+    const ok = await confirm({
+      title: "Stop sharing?",
+      message:
+        "Your contribution is withdrawn and no new run will use it. Runs already in flight finish on the credential they were granted.",
+      confirmLabel: "Stop sharing",
+      confirmVariant: "danger",
+    });
+    if (!ok) return;
+    onError(null);
+    try {
+      await withdrawPledge(kind);
+      onSaved("Contribution withdrawn.");
+    } catch (e) {
+      onError(errorMessage(e));
+    }
+  };
+
+  return (
+    <div className="bg-surface-1 border border-border-subtle rounded p-4 space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <h3 className="font-medium">{KIND_LABEL[kind]}</h3>
+          {pledge && !pledge.connected && (
+            <div className="text-xs text-fg-muted">
+              Subscription no longer connected — reconnect it under “OAuth subscriptions”.
+            </div>
+          )}
+        </div>
+        {copy ? <Badge variant={copy.tone}>{copy.label}</Badge> : <Badge variant="neutral">Not shared</Badge>}
+      </div>
+
+      {pledge?.health_detail && (
+        <InlineBanner tone="warning" layout="inline">
+          {pledge.health_detail}
+        </InlineBanner>
+      )}
+
+      {pledge && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <Meter
+            label="Given today"
+            value={pledge.today.cost_usd}
+            max={pledge.limits.max_usd_per_day}
+            formatValue={formatCost}
+            formatMax={formatCost}
+            size="sm"
+            hint="Estimated: a subscription bills nothing per call, so this is derived from token counts."
+          />
+          <Meter
+            label="Given this week"
+            value={pledge.this_week.cost_usd}
+            max={pledge.limits.max_usd_per_week}
+            formatValue={formatCost}
+            formatMax={formatCost}
+            size="sm"
+            hint="Estimated, same caveat as the daily figure."
+          />
+          <div className="text-xs text-fg-muted">
+            {pledge.today.runs} run(s) served today
+            {pledge.last_served_at && ` · last ${formatDateTime(pledge.last_served_at)}`}
+          </div>
+          {pledge.cooldown_until && (
+            <div className="text-xs text-fg-muted">
+              Resting until {formatDateTime(pledge.cooldown_until)}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div>
+          <FieldLabel help="Blank = no daily ceiling.">Max $ / day</FieldLabel>
+          <Input
+            inputMode="decimal"
+            placeholder="no limit"
+            value={showNum(limits.max_usd_per_day)}
+            onChange={(e) => setLimits({ ...limits, max_usd_per_day: numOrZero(e.target.value) })}
+          />
+        </div>
+        <div>
+          <FieldLabel help="Blank = no weekly ceiling. Must not be below the daily one.">
+            Max $ / week
+          </FieldLabel>
+          <Input
+            inputMode="decimal"
+            placeholder="no limit"
+            value={showNum(limits.max_usd_per_week)}
+            onChange={(e) => setLimits({ ...limits, max_usd_per_week: numOrZero(e.target.value) })}
+          />
+        </div>
+        <div>
+          <FieldLabel help="Blank = no cap on how many runs you serve per day.">
+            Max runs / day
+          </FieldLabel>
+          <Input
+            inputMode="numeric"
+            placeholder="no limit"
+            value={showNum(limits.max_runs_per_day)}
+            onChange={(e) => setLimits({ ...limits, max_runs_per_day: numOrZero(e.target.value) })}
+          />
+        </div>
+        <div>
+          <FieldLabel help="Keeps your own sessions responsive. Blank = no cap.">
+            Max runs at once
+          </FieldLabel>
+          <Input
+            inputMode="numeric"
+            placeholder="no limit"
+            value={showNum(limits.max_concurrent_runs)}
+            onChange={(e) =>
+              setLimits({ ...limits, max_concurrent_runs: numOrZero(e.target.value) })
+            }
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <div>
+          <FieldLabel help="Local time. Leave both blank to share around the clock; 19 → 8 shares overnight.">
+            Share from (hour)
+          </FieldLabel>
+          <Input
+            inputMode="numeric"
+            placeholder="any"
+            value={hours.start}
+            onChange={(e) => setHours({ ...hours, start: e.target.value })}
+          />
+        </div>
+        <div>
+          <FieldLabel>Until (hour)</FieldLabel>
+          <Input
+            inputMode="numeric"
+            placeholder="any"
+            value={hours.end}
+            onChange={(e) => setHours({ ...hours, end: e.target.value })}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2 items-center">
+        <Button variant="primary" disabled={disabled || busy} onClick={() => void save(true)}>
+          {pledge?.enabled ? "Update terms" : "Start sharing"}
+        </Button>
+        {pledge?.enabled && (
+          <Button variant="secondary" disabled={busy} onClick={() => void save(false)}>
+            Pause sharing
+          </Button>
+        )}
+        {pledge && (
+          <Button variant="danger" disabled={busy} onClick={() => void withdraw()}>
+            Stop &amp; withdraw
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function HistoryTable({ leases }: { leases: PledgeLease[] }) {
+  if (leases.length === 0) return null;
+  return (
+    <section className="space-y-2">
+      <h3 className="font-medium text-sm">What your quota ran</h3>
+      <div className="border border-border-subtle rounded">
+        <Table caption="Runs served by your shared quota" density="sm">
+          <THead className="bg-surface-1">
+            <Th>When</Th>
+            <Th>Bot</Th>
+            <Th>Requested by</Th>
+            <Th align="right">Cost (est.)</Th>
+            <Th>Outcome</Th>
+          </THead>
+          <TBody>
+            {leases.map((l) => (
+              <Tr key={l.run_id}>
+                <Td className="whitespace-nowrap">{formatDateTime(l.acquired_at)}</Td>
+                <Td>{l.bot_id || "—"}</Td>
+                <Td>{l.requester_id || "—"}</Td>
+                <Td align="right">{l.closed ? formatCost(l.cost_usd) : "running…"}</Td>
+                <Td>{l.outcome || (l.closed ? "ok" : "")}</Td>
+              </Tr>
+            ))}
+          </TBody>
+        </Table>
+      </div>
+    </section>
+  );
+}

--- a/studio/src/views/account/SharedQuota.tsx
+++ b/studio/src/views/account/SharedQuota.tsx
@@ -371,7 +371,7 @@ function HistoryTable({ leases }: { leases: PledgeLease[] }) {
           </THead>
           <TBody>
             {leases.map((l) => (
-              <Tr key={l.run_id}>
+              <Tr key={`${l.run_id}-${l.acquired_at}`}>
                 <Td className="whitespace-nowrap">{formatDateTime(l.acquired_at)}</Td>
                 <Td>{l.bot_id || "—"}</Td>
                 <Td>{l.requester_id || "—"}</Td>

--- a/studio/src/views/teams/TeamPage.tsx
+++ b/studio/src/views/teams/TeamPage.tsx
@@ -26,6 +26,7 @@ import InviteLinkPanel from "@/components/shared/InviteLinkPanel";
 
 
 import AuditTab from "./tabs/AuditTab";
+import CredPoolTab from "./tabs/CredPoolTab";
 import MemoryTab from "./tabs/MemoryTab";
 
 // config_editor is prepended (index 0) so it reads as the least-privileged
@@ -45,11 +46,12 @@ function roleLabel(role: string): string {
 // resources: who can access this team, its API keys, audit and memory. The
 // integration surfaces (forges, webhooks, secrets, bot bindings, model
 // providers) moved to their own top-level destination (/integrations).
-type Tab = "members" | "api-keys" | "audit" | "memory";
+type Tab = "members" | "api-keys" | "cred-pool" | "audit" | "memory";
 
 const TABS: Array<{ id: Tab; label: string }> = [
   { id: "members", label: "Team access" },
   { id: "api-keys", label: "API keys" },
+  { id: "cred-pool", label: "Credential pool" },
   { id: "audit", label: "Audit log" },
   { id: "memory", label: "Memory" },
 ];
@@ -128,6 +130,9 @@ export default function TeamPage() {
           {tab === "members" && <Members teamID={team.team_id} canManage={canManage} />}
           {tab === "api-keys" && (
             <ApiKeysPanel team={{ id: team.team_id, name: team.team_name }} />
+          )}
+          {tab === "cred-pool" && (
+            <CredPoolTab teamID={team.team_id} canManage={canManage} />
           )}
           {tab === "audit" && <AuditTab teamID={team.team_id} canManage={canManage} />}
           {tab === "memory" && <MemoryTab teamID={team.team_id} />}

--- a/studio/src/views/teams/tabs/CredPoolTab.tsx
+++ b/studio/src/views/teams/tabs/CredPoolTab.tsx
@@ -1,0 +1,224 @@
+import { errorMessage } from "@/lib/errorHints";
+import { formatCost, formatDateTime } from "@/lib/format";
+import { useEffect, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Badge } from "@/components/ui/Badge";
+import { Button } from "@/components/ui/Button";
+import { Checkbox } from "@/components/ui/Checkbox";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { FieldLabel } from "@/components/ui/FieldLabel";
+import { InlineBanner } from "@/components/ui/InlineBanner";
+import { Input } from "@/components/ui/Input";
+import { TBody, THead, Table, Td, Th, Tr } from "@/components/ui/Table";
+import PanelLoading from "@/components/shared/PanelLoading";
+import { useUIStore } from "@/store/ui";
+import {
+  getTeamPool,
+  saveTeamPool,
+  type PledgeStatus,
+  type PoolAudience,
+  type PoolView,
+} from "@/api/credpool";
+
+const STATUS_TONE: Record<PledgeStatus, "success" | "warning" | "neutral" | "danger"> = {
+  active: "success",
+  paused: "neutral",
+  cooling: "warning",
+  out_of_hours: "neutral",
+  exhausted: "warning",
+  unhealthy: "danger",
+  bot_filtered: "neutral",
+};
+
+const csv = (v?: string[]) => (v ?? []).join(", ");
+const parseCsv = (s: string) =>
+  s
+    .split(",")
+    .map((x) => x.trim())
+    .filter(Boolean);
+
+export default function CredPoolTab({
+  teamID,
+  canManage,
+}: {
+  teamID: string;
+  canManage: boolean;
+}) {
+  const queryClient = useQueryClient();
+  const query = useQuery<PoolView>({
+    queryKey: ["team-pool", teamID],
+    queryFn: () => getTeamPool(teamID),
+  });
+  const [err, setErr] = useState<string | null>(null);
+  const [enabled, setEnabled] = useState(false);
+  const [audience, setAudience] = useState<PoolAudience>({});
+  const [teamsCsv, setTeamsCsv] = useState("");
+  const [orgsCsv, setOrgsCsv] = useState("");
+  const [busy, setBusy] = useState(false);
+  const addToast = useUIStore((s) => s.addToast);
+
+  const pool = query.data;
+  useEffect(() => {
+    setEnabled(pool?.enabled ?? false);
+    setAudience(pool?.audience ?? {});
+    setTeamsCsv(csv(pool?.audience?.teams));
+    setOrgsCsv(csv(pool?.audience?.orgs));
+  }, [pool]);
+
+  const save = async () => {
+    setBusy(true);
+    setErr(null);
+    try {
+      await saveTeamPool(teamID, {
+        enabled,
+        audience: { ...audience, teams: parseCsv(teamsCsv), orgs: parseCsv(orgsCsv) },
+      });
+      addToast("Credential pool updated.", "success");
+      void queryClient.invalidateQueries({ queryKey: ["team-pool", teamID] });
+    } catch (e) {
+      setErr(errorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (query.isLoading) return <PanelLoading />;
+  if (query.error && !query.isFetching) {
+    return (
+      <InlineBanner tone="danger" layout="inline">
+        {errorMessage(query.error)}
+      </InlineBanner>
+    );
+  }
+
+  const donors = pool?.donors ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold">Credential pool</h2>
+        <p className="text-sm text-fg-muted mt-1">
+          Contributors can lend their Claude or ChatGPT subscription to this org. A run with no
+          credential of its own then draws on the least-used available contribution, capped by the
+          ceilings that contributor set. Each donor keeps their own kill switch.
+        </p>
+      </div>
+
+      <InlineBanner tone="warning" layout="inline">
+        Widening the audience below lets more runs spend contributors&apos; personal
+        subscriptions. Those are individual licences — keep the pool to work the contributors
+        signed up for, and prefer API keys for production automation.
+      </InlineBanner>
+
+      {err && (
+        <InlineBanner tone="danger" layout="inline">
+          {err}
+        </InlineBanner>
+      )}
+
+      <section className="bg-surface-1 border border-border-subtle rounded p-4 space-y-3">
+        <Checkbox
+          label="Pool enabled"
+          help="Master switch, independent of each contributor's own. Off = no run ever draws on the pool."
+          checked={enabled}
+          disabled={!canManage}
+          onChange={(e) => setEnabled(e.target.checked)}
+        />
+
+        <div className="space-y-2">
+          <h3 className="text-sm font-medium">Who may draw on it</h3>
+          <p className="text-xs text-fg-muted">
+            These are independent options, combined as a union. With none of them set, only teams
+            of this org may draw — the strictest setting, and the default.
+          </p>
+          <Checkbox
+            label="Contributors may draw (reciprocity)"
+            help="Anyone actively lending to this pool may use it, whichever team they launch from. Pausing your own sharing stops your borrowing too."
+            checked={audience.contributors ?? false}
+            disabled={!canManage}
+            onChange={(e) => setAudience({ ...audience, contributors: e.target.checked })}
+          />
+          <Checkbox
+            label="Every team on this instance may draw"
+            help="The widest setting. Only meaningful for an instance that IS a shared community deployment."
+            checked={audience.all_teams ?? false}
+            disabled={!canManage}
+            onChange={(e) => setAudience({ ...audience, all_teams: e.target.checked })}
+          />
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <FieldLabel help="Comma-separated team ids allowed to draw, on top of this org's own teams.">
+                Extra team ids
+              </FieldLabel>
+              <Input
+                value={teamsCsv}
+                disabled={!canManage}
+                placeholder="team-abc, team-def"
+                onChange={(e) => setTeamsCsv(e.target.value)}
+              />
+            </div>
+            <div>
+              <FieldLabel help="Comma-separated org ids whose every team may draw.">
+                Extra org ids
+              </FieldLabel>
+              <Input
+                value={orgsCsv}
+                disabled={!canManage}
+                placeholder="org-xyz"
+                onChange={(e) => setOrgsCsv(e.target.value)}
+              />
+            </div>
+          </div>
+        </div>
+
+        {canManage && (
+          <Button variant="primary" loading={busy} onClick={() => void save()}>
+            Save pool settings
+          </Button>
+        )}
+      </section>
+
+      <section className="space-y-2">
+        <h3 className="text-sm font-medium">Contributors</h3>
+        {donors.length === 0 ? (
+          <EmptyState
+            title="No contributions yet"
+            message="A contributor lends their subscription from Account settings → Share my quota."
+          />
+        ) : (
+          <div className="border border-border-subtle rounded">
+            <Table caption="Contributors lending to this pool" density="sm">
+              <THead className="bg-surface-1">
+                <Th>Contributor</Th>
+                <Th>Subscription</Th>
+                <Th>State</Th>
+                <Th align="right">Runs today</Th>
+                <Th align="right">Given today (est.)</Th>
+                <Th>Last served</Th>
+              </THead>
+              <TBody>
+                {donors.map((d) => (
+                  <Tr key={`${d.user_id}-${d.kind}`}>
+                    <Td>{d.user_id}</Td>
+                    <Td>{d.kind}</Td>
+                    <Td>
+                      <Badge variant={STATUS_TONE[d.status] ?? "neutral"}>{d.status}</Badge>
+                      {d.cooldown_until && (
+                        <span className="text-fg-muted ml-2">
+                          until {formatDateTime(d.cooldown_until)}
+                        </span>
+                      )}
+                    </Td>
+                    <Td align="right">{d.today_runs}</Td>
+                    <Td align="right">{formatCost(d.today_cost_usd)}</Td>
+                    <Td>{d.last_served_at ? formatDateTime(d.last_served_at) : "—"}</Td>
+                  </Tr>
+                ))}
+              </TBody>
+            </Table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
Developers lend the unused part of their Claude Pro/Max or ChatGPT subscription; a run with no credential of its own draws on it, bounded by ceilings **the lender sets** and revocable at any moment.

## Shape

`pkg/credpool` is the domain — a `Pledge` (spend/day + /week, runs/day, concurrency, sharing window, bot allow-list), a `Broker` picking the least-consumed eligible donor by the *fraction of what each offered*, and a `Lease` per attempt that is at once the concurrency unit, the in-flight spend commitment, and the donor's audit trail.

It plugs in as the **fourth and last** credential tier in `cloudpublisher.resolveAndSealCredentials`, consulted only when a run resolved none of its own — a contribution is never taken when nobody needed it.

**Enforcement is the run's own `max_cost_usd`**, clamped to the donor's remaining allowance through the existing `ir.Budget.ClampToCeiling`. The engine stops the run itself; the post-hoc ledger charge would arrive too late to protect anyone.

**Audience** is a union of independent predicates (`teams` / `orgs` / `contributors` reciprocity / `all_teams`) whose zero value serves the owning org alone. Admission of contributors reuses the existing GitHub team-gating — no new auth code.

## Two prerequisites the feature did not have

- **Delegate backends reported no cost at all.** Every donor would have read `$0 consumed` forever and no ceiling would ever have tripped. `DelegateInfo` now carries the `_cost_usd` the backend already computed, through the `delegate_finished` event into the runner's per-run totals. Side benefit: `orgusage` stops under-counting every `claude_code` run.
- **A rejected credential was an untyped `fmt.Errorf`**, so the pool could only have guessed at prose. `delegate.ErrAuthFailed` makes it a type callers can act on; `recovery.Classify` now matches it *before* its substring needles.

## Honest limits, documented not papered over

Dollar figures are **estimates** — a subscription bills nothing per call, so cost is derived from tokens. The hard guard is the provider's own usage window, which rests a donor until its reset. Two residual behaviours are stated in the docs: a simultaneous-launch race can overshoot a cap by one in-flight run, and the caps are per calendar day/ISO week rather than per run.

A subscription is an **individual licence**. The mechanism keeps the lender in control — explicit pledge, their own ceilings, kill switch effective at the next launch, a per-donor log of every run served — but the decision to pool one is the deployment owner's, and the UI says so.

## Review history

Two adversarial passes ran on this branch. The first found 11 defects (permanent quota lockout on a failed launch, double-charge on a redelivered report, resume re-consuming quota, lease history destruction, cross-org donation via a fallback, org policy mutable by any team admin…). The second reviewed *the fixes themselves* and found 9 more — including that the un-parking rule keyed on `updated_at`, which the token-refresh worker bumps hourly, so a revoked credential un-parked itself every hour. All fixed, with 18 regression tests.

`task check` green, `golangci-lint` 0 issues.

Surfaces: `/api/me/pool` + `/api/teams/{id}/pool`, studio **Share my quota** + the operator pool view, `iterion remote pool`, [docs/credential-pool.md](docs/credential-pool.md).

Not yet exercised end-to-end against a live cloud instance — that needs two accounts and is the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)