### PR TITLE
fix(server,dep-update-guard): a dead merge-gate run recovers instead of silently blocking its PR

### DIFF
--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -1088,20 +1088,27 @@ print(json.dumps({'degraded': degraded or gate_degraded, 'banner': banner}))
 ## have landed green too, because arming on a verdict whose status never
 ## reached the PR would merge on a check nobody can see.
 ##
-## Two forge calls, and the choice between them is the forge's own answer,
-## never a judgement of this bot:
-##   - checks still pending  → enablePullRequestAutoMerge, which hands the
-##     decision to the repo's required checks;
-##   - forge reports CLEAN   → mergePullRequest pinned to the exact head we
-##     reviewed. CLEAN means "mergeable and passing commit status", so there
-##     is nothing left to wait for — and GitHub REFUSES to arm auto-merge in
-##     that state ("Pull request is in clean status"). Since the audit takes
-##     longer than CI, this is the ordinary case: without it the bot would
-##     arm nothing and merge nothing, ever.
+## Three forge calls, and the choice between them is the forge's own answer,
+## never a judgement of this bot. Arming comes FIRST, always:
+##   - enablePullRequestAutoMerge hands the decision to the repo's required
+##     checks — and on a merge-queue-protected base it is "merge when ready",
+##     which enqueues the PR instead of merging it directly. A queue REJECTS
+##     a direct merge outright, so arm-first is what makes this bot work on
+##     both repo shapes (observed 2026-08-03: two audited-green PRs on a
+##     queue repo that a merge-now-first ordering could never have landed).
+##   - the base has a merge queue and arming was refused → enqueuePullRequest
+##     pinned to the exact head we reviewed (expectedHeadOid).
+##   - no queue and the forge refused to arm because the PR is CLEAN
+##     ("Pull request is in clean status" — mergeable, every commit status
+##     passing, nothing left to wait for) → mergePullRequest pinned to the
+##     exact head we reviewed. Since the audit takes longer than CI, this is
+##     the ordinary no-queue case: without it the bot would arm nothing and
+##     merge nothing, ever.
 ## There is deliberately no path to PUT /pulls/{n}/merge: that merges
 ## whatever the state, bypassing every pending check, which is precisely what
 ## this bot exists to prevent. expectedHeadOid is the equivalent guarantee on
-## the GraphQL side — a push landing mid-decision aborts the merge.
+## the GraphQL side — a push landing mid-decision aborts the merge (and the
+## enqueue).
 tool arm_automerge:
   input: automerge_input
   output: automerge_output
@@ -1183,9 +1190,16 @@ tool arm_automerge:
     at = chr(36)
     q = ("query(@owner: String!, @name: String!, @number: Int!) { "
          "repository(owner: @owner, name: @name) { "
-         "pullRequest(number: @number) { id headRefOid mergeable mergeStateStatus "
-         "autoMergeRequest { enabledAt } } "
+         "pullRequest(number: @number) { id headRefOid baseRefName mergeable mergeStateStatus "
+         "autoMergeRequest { enabledAt } mergeQueueEntry { id } } "
          "} }").replace("@", at)
+    # A non-null mergeQueue on the PR's base branch is what makes this a
+    # queue-protected repo: direct merges are rejected there, enqueueing is
+    # the only door, and the forge is the authority on which shape this is.
+    queue_q = ("query(@owner: String!, @name: String!, @branch: String!) { "
+               "repository(owner: @owner, name: @name) { "
+               "mergeQueue(branch: @branch) { id } "
+               "} }").replace("@", at)
     arm_mut = ("mutation(@id: ID!, @method: PullRequestMergeMethod!) { "
                "enablePullRequestAutoMerge(input: { pullRequestId: @id, mergeMethod: @method }) "
                "{ clientMutationId } }").replace("@", at)
@@ -1194,10 +1208,27 @@ tool arm_automerge:
     merge_mut = ("mutation(@id: ID!, @method: PullRequestMergeMethod!, @oid: GitObjectID!) { "
                  "mergePullRequest(input: { pullRequestId: @id, mergeMethod: @method, "
                  "expectedHeadOid: @oid }) { clientMutationId } }").replace("@", at)
+    # Same pin on the queue door: enqueue this exact commit or nothing.
+    enqueue_mut = ("mutation(@id: ID!, @oid: GitObjectID!) { "
+                   "enqueuePullRequest(input: { pullRequestId: @id, expectedHeadOid: @oid }) "
+                   "{ clientMutationId } }").replace("@", at)
 
     def read_pr():
         data = graphql(q, {"owner": owner, "name": repo, "number": num})
         return ((data.get("repository") or {}).get("pullRequest") or {})
+
+    def base_has_merge_queue(pr):
+        branch = s(pr.get("baseRefName"))
+        if not branch:
+            return False
+        try:
+            data = graphql(queue_q, {"owner": owner, "name": repo, "branch": branch})
+            return bool((data.get("repository") or {}).get("mergeQueue"))
+        except Exception:
+            # An older GHES without the field, or a transient read failure:
+            # treat as no queue and let the no-queue path speak. Its own
+            # errors are reported, never swallowed.
+            return False
 
     # A merge may only ever target the commit THIS run audited and gated.
     # Re-reading the head does not give that commit: the audit takes minutes,
@@ -1222,17 +1253,19 @@ tool arm_automerge:
             return False
         return a[:n] == b[:n]
 
-    def merge_now(pr, why):
+    def vouched_sha(pr, act):
+        # The commit any merge or enqueue may target: the one THIS run
+        # audited, gated, and can still see at the branch head.
         head = s(pr.get("headRefOid"))
         gated = s(gate_sha)
         # What THIS run read, and what it pushed if it aligned anything.
         mine = s(committed_sha) or s(audited_sha)
         if not gated:
-            out(False, "no gated sha to merge against - merging the current head would "
-                       "ship a commit this run never audited")
+            out(False, "no gated sha to " + act + " against - acting on the current head "
+                       "would ship a commit this run never audited")
         if not mine:
-            out(False, "this run cannot name the commit it audited - refusing to merge "
-                       "on a sha it cannot vouch for")
+            out(False, "this run cannot name the commit it audited - refusing to " + act +
+                       " on a sha it cannot vouch for")
         # gate_sha comes from the FORGE (the head at publish time), not from
         # this run: a push landing between the alignment and the status read
         # would carry the gate onto a commit no auditor ever saw. It is only
@@ -1243,8 +1276,17 @@ tool arm_automerge:
         if head and not same_commit(head, gated):
             out(False, "the branch moved after the audit (gated " + gated[:12] +
                        ", head is now " + head[:12] + ") - the new head has not been audited")
+        return gated
+
+    def merge_now(pr, why):
+        gated = vouched_sha(pr, "merge")
         graphql(merge_mut, {"id": pr.get("id"), "method": s(method).upper() or "SQUASH",
                             "oid": gated})
+        out(True, why)
+
+    def enqueue_now(pr, why):
+        gated = vouched_sha(pr, "enqueue")
+        graphql(enqueue_mut, {"id": pr.get("id"), "oid": gated})
         out(True, why)
 
     # Ready to merge means every required check the forge knows about is
@@ -1260,14 +1302,27 @@ tool arm_automerge:
             out(False, "pull request not found via the forge API")
         if pr.get("autoMergeRequest"):
             out(True, "auto-merge was already armed")
-        if ready(pr):
-            merge_now(pr, "merged: the forge reported every required check already green")
+        if pr.get("mergeQueueEntry"):
+            out(True, "already in the merge queue")
+        # Arm FIRST, whatever the state. On a queue repo this is "merge when
+        # ready" and covers CLEAN too; on a plain repo a CLEAN PR is refused
+        # ("clean status") and falls through to the pinned direct merge. The
+        # ordering matters: a merge-now-first bot direct-merges into a queue's
+        # rejection and never lands anything on a queue-protected repo.
         try:
             graphql(arm_mut, {"id": node_id, "method": s(method).upper() or "SQUASH"})
         except Exception as arm_err:
-            # The forge refuses to arm a PR with nothing left to wait for. The
-            # state can flip between the read above and this call, so re-read
-            # rather than trusting the first answer.
+            if base_has_merge_queue(pr):
+                # The queue is the only door here; a direct merge would be
+                # rejected outright. Enqueue the audited commit or nothing.
+                pr = read_pr()
+                if pr.get("mergeQueueEntry"):
+                    out(True, "already in the merge queue")
+                enqueue_now(pr, "enqueued: the merge queue decides from here "
+                                "(arming was refused: " + str(arm_err)[:120] + ")")
+            # No queue: the one refusal that means "nothing left to wait for"
+            # is the CLEAN state. The state can flip between the read above
+            # and this call, so re-read rather than trusting the first answer.
             if "clean status" not in str(arm_err).lower():
                 raise
             pr = read_pr()
@@ -1291,10 +1346,15 @@ tool arm_automerge:
 workflow dep_update_guard:
   entry: prepare
 
+  ## Sized for the heavy case, not the median: a grouped go bump of 15
+  ## modules needing a real code alignment plus the repo's full test suite.
+  ## The clean re-audit of an npm group already runs ~30m; 40m killed a
+  ## 15-module go run mid-audit in production (2026-08-03, run 019fc8e5),
+  ## which with a required gate context left the PR silently unmergeable.
   budget:
     max_parallel_branches: 1
-    max_duration: "40m"
-    max_cost_usd: 15
+    max_duration: "75m"
+    max_cost_usd: 20
 
   ## Scanners + build toolchain live in the sec sandbox image. One
   ## sandbox for the whole run; network open by default so the auditors

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,16 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.5.0
+version: 2.6.0
+## 2.6.0 — land on merge-queue repos, survive the heavy case. (a)
+## `arm_automerge` arms FIRST (enablePullRequestAutoMerge — "merge when
+## ready" on queue repos, so a queue-protected base enqueues instead of
+## hitting the queue's direct-merge rejection); a queue refusal falls back
+## to enqueuePullRequest pinned to the audited sha, and only a no-queue
+## CLEAN refusal takes the pinned direct merge. (b) Budget 40m/$15 →
+## 75m/$20: the clean npm re-audit already ran ~30m, and a 15-module go
+## group with a needed alignment died mid-audit at 40m in production —
+## with a required gate context, that left the PR silently unmergeable.
 ## 2.1.0 — classify, gate, arm. (a) The bump classifier only knew package
 ## manifests, so a PR moving a base-image digest, a devbox pin, a task-runner
 ## tool or a composite action matched nothing — and did not stop, because

--- a/bots/dep_update_guard_automerge_test.go
+++ b/bots/dep_update_guard_automerge_test.go
@@ -15,11 +15,14 @@ import (
 // TestDepUpdateGuardArmAutomerge pins the one node in the fleet that can end
 // with code merged into a default branch. Two properties carry all the weight:
 //
-//   - it never merges past a check. Which of the two forge calls it makes is
-//     the forge's own answer: auto-merge while checks are pending, a merge
-//     pinned to the reviewed head only once the forge itself reports CLEAN
-//     (mergeable and passing commit status), which is the state where it
-//     refuses to arm auto-merge at all.
+//   - it never merges past a check. Which of the three forge calls it makes
+//     is the forge's own answer, and arming is always tried first (on a
+//     merge-queue base it is "merge when ready" — the only door a queue
+//     leaves open): auto-merge while there is anything left to wait for; on
+//     a refusal, an enqueue pinned to the reviewed head when the base has a
+//     merge queue; a direct merge pinned to the reviewed head only when
+//     there is no queue and the forge itself reported CLEAN (mergeable and
+//     passing commit status), the state where it refuses to arm at all.
 //   - it is fail-closed everywhere: off by default, green verdict required,
 //     the gate must actually have landed green, GitHub only, and every refusal
 //     carries a reason so an un-merged PR is never a mystery.
@@ -55,7 +58,8 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 	// blocked is the state where checks are still running: auto-merge is
 	// exactly what it is for.
 	blocked := map[string]any{
-		"id": "PR_node_1", "headRefOid": "d34db33f", "autoMergeRequest": nil,
+		"id": "PR_node_1", "headRefOid": "d34db33f", "baseRefName": "main",
+		"autoMergeRequest": nil, "mergeQueueEntry": nil,
 		"mergeable": "MERGEABLE", "mergeStateStatus": "BLOCKED",
 	}
 	withState := func(over map[string]any) map[string]any {
@@ -72,9 +76,11 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 	// runWith drives the node against a stub forge holding `pr`. A non-empty
 	// armErr makes the auto-merge mutation fail with that message, and `after`
 	// (when set) is the state served on any read that follows — the flip a
-	// finishing check produces mid-decision.
-	runWith := func(t *testing.T, subs map[string]string, pr map[string]any, armErr string, after map[string]any) (map[string]any, []call, []string) {
+	// finishing check produces mid-decision. An optional trailing true makes
+	// the base branch merge-queue-protected.
+	runWith := func(t *testing.T, subs map[string]string, pr map[string]any, armErr string, after map[string]any, queueProtected ...bool) (map[string]any, []call, []string) {
 		t.Helper()
+		hasQueue := len(queueProtected) > 0 && queueProtected[0]
 		var calls []call
 		var paths []string
 		state := pr
@@ -136,6 +142,26 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 				}
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"data": map[string]any{"mergePullRequest": map[string]any{"clientMutationId": nil}},
+				})
+			case strings.Contains(body.Query, "enqueuePullRequest"):
+				// The queue door carries the same pin as the direct merge, for
+				// the same reason: enqueue the audited commit or nothing.
+				if !regexp.MustCompile(`expectedHeadOid:\s*\$oid`).MatchString(body.Query) {
+					t.Errorf("enqueue mutation is not pinned to the oid variable: %s", body.Query)
+				}
+				if body.Variables["oid"] != state["headRefOid"] {
+					t.Errorf("enqueue pinned to %v, want the reviewed head %v", body.Variables["oid"], state["headRefOid"])
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"data": map[string]any{"enqueuePullRequest": map[string]any{"clientMutationId": nil}},
+				})
+			case strings.Contains(body.Query, "mergeQueue("):
+				var mq map[string]any
+				if hasQueue {
+					mq = map[string]any{"id": "MQ_1"}
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"data": map[string]any{"repository": map[string]any{"mergeQueue": mq}},
 				})
 			default:
 				_ = json.NewEncoder(w).Encode(map[string]any{
@@ -226,19 +252,22 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 		}
 	})
 
-	// The ordinary case: the audit outlives CI, so by the time the bot decides,
-	// the forge has nothing left to wait for and refuses to arm auto-merge. A
-	// bot that only ever armed would merge nothing, ever.
-	t.Run("forge reports CLEAN: merges pinned to the reviewed head", func(t *testing.T) {
-		res, calls, _ := runWith(t, nil, withState(map[string]any{"mergeStateStatus": "CLEAN"}), "", nil)
+	// The ordinary no-queue case: the audit outlives CI, so by the time the
+	// bot decides, the forge has nothing left to wait for and REFUSES to arm
+	// auto-merge ("clean status") — that refusal is what routes to the pinned
+	// direct merge. Arming is still attempted first: on a queue-protected
+	// repo the same call succeeds ("merge when ready"), and skipping it there
+	// would walk straight into the queue's direct-merge rejection.
+	t.Run("forge reports CLEAN: arm refused, merges pinned to the reviewed head", func(t *testing.T) {
+		res, calls, _ := runWith(t, nil, withState(map[string]any{"mergeStateStatus": "CLEAN"}), cleanRefusal, nil)
 		if res["armed"] != true {
 			t.Fatalf("want merged, got %v", res)
 		}
+		if !queried(calls, "enablePullRequestAutoMerge") {
+			t.Fatal("arming must be attempted first — it is what lands the queue-repo case")
+		}
 		if !queried(calls, "mergePullRequest") {
 			t.Fatal("a PR the forge reports CLEAN must be merged, not left open forever")
-		}
-		if queried(calls, "enablePullRequestAutoMerge") {
-			t.Error("armed auto-merge on a CLEAN PR — the forge rejects that outright")
 		}
 	})
 
@@ -273,7 +302,7 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 	// unreviewed dependency commit this bot exists to catch.
 	t.Run("branch moved after the gate: merges nothing", func(t *testing.T) {
 		res, calls, _ := runWith(t, nil, withState(map[string]any{
-			"mergeStateStatus": "CLEAN", "headRefOid": "0ther5ha"}), "", nil)
+			"mergeStateStatus": "CLEAN", "headRefOid": "0ther5ha"}), cleanRefusal, nil)
 		if queried(calls, "mergePullRequest") {
 			t.Fatal("merged a head that was never audited")
 		}
@@ -293,7 +322,7 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 		res, calls, _ := runWith(t, map[string]string{
 			"{{input.gate_sha}}":    `"f0re1gn5"`,
 			"{{input.audited_sha}}": `"d34db33f"`,
-		}, withState(map[string]any{"mergeStateStatus": "CLEAN", "headRefOid": "f0re1gn5"}), "", nil)
+		}, withState(map[string]any{"mergeStateStatus": "CLEAN", "headRefOid": "f0re1gn5"}), cleanRefusal, nil)
 		if queried(calls, "mergePullRequest") {
 			t.Fatal("merged a commit the gate covered but this run never audited")
 		}
@@ -316,7 +345,7 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 			"{{input.gate_sha}}":      `"` + full + `"`,
 			"{{input.audited_sha}}":   `"d34db33f"`,
 			"{{input.committed_sha}}": `"a11gned0"`,
-		}, withState(map[string]any{"mergeStateStatus": "CLEAN", "headRefOid": full}), "", nil)
+		}, withState(map[string]any{"mergeStateStatus": "CLEAN", "headRefOid": full}), cleanRefusal, nil)
 		if !queried(calls, "mergePullRequest") {
 			t.Fatalf("refused the merge on an abbreviated sha: %v", res)
 		}
@@ -333,7 +362,7 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 			"{{input.gate_sha}}":      `"` + full + `"`,
 			"{{input.audited_sha}}":   `"d34db33f"`,
 			"{{input.committed_sha}}": `"a11gne"`,
-		}, withState(map[string]any{"mergeStateStatus": "CLEAN", "headRefOid": full}), "", nil)
+		}, withState(map[string]any{"mergeStateStatus": "CLEAN", "headRefOid": full}), cleanRefusal, nil)
 		if queried(calls, "mergePullRequest") {
 			t.Fatalf("merged on a 6-hex prefix: %v", res)
 		}
@@ -348,7 +377,7 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 			"{{input.gate_sha}}":      `"a11gned0"`,
 			"{{input.audited_sha}}":   `"d34db33f"`,
 			"{{input.committed_sha}}": `"a11gned0"`,
-		}, withState(map[string]any{"mergeStateStatus": "CLEAN", "headRefOid": "a11gned0"}), "", nil)
+		}, withState(map[string]any{"mergeStateStatus": "CLEAN", "headRefOid": "a11gned0"}), cleanRefusal, nil)
 		if !queried(calls, "mergePullRequest") {
 			t.Fatal("the commit Vetty pushed and gated must be mergeable")
 		}
@@ -361,7 +390,7 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 		// Without a gate there is no anchor for "the commit we audited", so the
 		// merge path has nothing safe to target.
 		res, calls, _ := runWith(t, map[string]string{"{{input.gate_sha}}": `""`},
-			withState(map[string]any{"mergeStateStatus": "CLEAN"}), "", nil)
+			withState(map[string]any{"mergeStateStatus": "CLEAN"}), cleanRefusal, nil)
 		if queried(calls, "mergePullRequest") {
 			t.Fatal("merged with no audited sha to pin to")
 		}
@@ -379,6 +408,50 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 		}
 		if res["armed"] != false {
 			t.Fatalf("want a refusal, got %v", res)
+		}
+	})
+
+	// A merge queue rejects direct merges outright, so on a queue-protected
+	// base the refusal-to-arm falls back to the queue's own door — pinned to
+	// the audited head exactly like the direct merge is.
+	t.Run("queue repo, arming refused: enqueues pinned, never merges directly", func(t *testing.T) {
+		res, calls, _ := runWith(t, nil, withState(map[string]any{"mergeStateStatus": "CLEAN"}),
+			"Pull request is already in clean status", nil, true)
+		if res["armed"] != true {
+			t.Fatalf("want enqueued, got %v", res)
+		}
+		if !queried(calls, "enqueuePullRequest") {
+			t.Fatal("a queue-protected PR must go through the queue door")
+		}
+		if queried(calls, "mergePullRequest") {
+			t.Fatal("direct-merged on a queue-protected base — the queue rejects that, and bypassing it would skip the merge-group checks")
+		}
+		if reason, _ := res["reason"].(string); !strings.Contains(reason, "merge queue") {
+			t.Errorf("reason = %q, want it to say the queue decides from here", reason)
+		}
+	})
+
+	t.Run("queue repo, branch moved after the gate: enqueues nothing", func(t *testing.T) {
+		res, calls, _ := runWith(t, nil, withState(map[string]any{
+			"mergeStateStatus": "CLEAN", "headRefOid": "0ther5ha"}), cleanRefusal, nil, true)
+		if queried(calls, "enqueuePullRequest") {
+			t.Fatal("enqueued a head that was never audited")
+		}
+		if res["armed"] != false {
+			t.Fatalf("want a refusal, got %v", res)
+		}
+	})
+
+	t.Run("already in the merge queue: touches nothing", func(t *testing.T) {
+		res, calls, _ := runWith(t, nil, withState(map[string]any{
+			"mergeQueueEntry": map[string]any{"id": "MQE_1"}}), "", nil, true)
+		if res["armed"] != true {
+			t.Fatalf("want acknowledged as armed, got %v", res)
+		}
+		for _, needle := range []string{"enablePullRequestAutoMerge", "mergePullRequest", "enqueuePullRequest"} {
+			if queried(calls, needle) {
+				t.Errorf("called %s on a PR already queued", needle)
+			}
 		}
 	})
 

--- a/docs/bot-runs/dep-update-guard.md
+++ b/docs/bot-runs/dep-update-guard.md
@@ -7,6 +7,63 @@ commit onto the PR branch, post the verdict comment. Never merges past a
 check — and only ever the commit it audited. See
 [bots/dep-update-guard/](../../bots/dep-update-guard/).
 
+## 2026-08-03/04 — first Dependabot batch on iterion itself: 2 exemplary audits, 1 silent death, 0 merges
+
+- Status: **partial — the audits were the best this bot has produced; everything
+  around them broke.** Fixes shipped as v2.6.0 + engine PR #357.
+- Versions: bot 2.5.0 · iterion prod `:edge` (v3.24.0 era) · runs `019fc8e2`/
+  `019fc8e5`/`019fc8ed` (PR-open) then `019fc924`/`019fc927` (post-align re-audits)
+- Method: webhook-triggered on the 3 grouped Dependabot PRs of 2026-08-03
+  (#353 studio npm ×29, #354 go ×15, #355 npm root ×33), `gate_context:
+  revi/review` (required check + merge queue on main), `arm_automerge` NOT set.
+- Result, per PR:
+  - **#353 / #355 — audit exemplary, then stranded.** Tarballs extracted and
+    content-scanned, sha512 byte-matched against the registry, SLSA provenance
+    predicates decoded (the react org-rename and the radix "new releaser"
+    maintainer-change flags each investigated and cleared, not waved through),
+    CVE differential (dompurify net −14/+3, brace-expansion ×6 HIGH resolved),
+    esbuild 0.26 parameter-property lowering aligned (`b2459da8` — the staled
+    go:embed pi-ext bundle) and a workspace lockfile regenerated (`15823337`).
+    The alignment push self-superseded the run (`overlap: supersede`) and the
+    fresh runs re-audited the final head clean — the supersede property doing
+    its job. Then: `revi/review=success`, PR mergeable… and nobody to enqueue
+    it. `arm_automerge` was off on this repo, and would not have worked anyway
+    (see misses).
+  - **#354 — the silent-death case, end to end.** Usage window at launch →
+    `run_retry_scheduled` (retrypolicy ✓) → resumed 36 min later → died on the
+    bot's own `max_duration: 40m` mid-`security_audit` → `failed_resumable`
+    that nothing resumes (the auto-retry covers usage windows only) → no gate
+    status ever posted → required check absent → **PR silently unmergeable,
+    indefinitely**. The MCP go-sdk 1.6.1→1.7.0 alignment (`TestManagerHealthCheckHTTP`,
+    ping `_meta protocolVersion`) was never reached.
+- Value: the supply-chain audits are production-grade — and the batch was a
+  live probe of every seam around the audit, which is where all four defects
+  sat.
+- Findings / misses:
+  1. Gate reconciler skipped ALL `failed_resumable` runs ("it will resume") —
+     false for budget/exhausted/plain failures. The exact silent-block class
+     the bko handover predicted.
+  2. 40m/$15 budget too short for the heavy case (a CLEAN npm re-audit alone
+     runs ~30m).
+  3. `arm_automerge` was merge-now-first on CLEAN, which a merge queue rejects
+     — the bot could never land anything on a queue-protected repo.
+  4. Config: the iterion integration never set `arm_automerge: "true"` (bko
+     had it), so green audits stopped at "ready".
+- Engine hardening (PR #357 + bot v2.6.0): reconciler skips only ARMED
+  retries and carries the death reason on the synthetic failure; a dead gate
+  run relaunches its bot once per (PR, head) through the webhook tail; a
+  second death files a deduped `source:gate-reconcile` board card; the retry
+  sweeper republishes the outcome on permanent abandon; autofix ignores
+  synthetic failures; arm-first automerge with pinned `enqueuePullRequest`
+  fallback; budget 75m/$20. Adversarial review (opus) caught 2 real defects
+  pre-merge — the reconciler standing down on its own synthetic marker (the
+  board escalation was unreachable), and an abandon-failure republish loop.
+- Lessons for next run: a required gate makes EVERY death loud or the lane is
+  a trap — "resumable" must mean "something is actually coming back"; budget
+  the outlier, not the median; on a queue repo, arming IS the merge path (the
+  queue is the only door); an audit-side success is only half the loop — the
+  merge side needs its own e2e proof per repo shape.
+
 ## 2026-07-31 — v2.5.0 on three heritage PRs, and the rebase that would have stalled every one of them
 
 - Status: **validated, with one real gap found and closed.** Two of three PRs

--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -221,7 +221,7 @@ check that is *absent* rather than red. If a fixer posts nothing, look at the
 run's inputs for `forge_publish_url` and `gate_context` before looking at the
 bot.
 
-### Zero-touch: letting a red gate launch the fixer itself (opt-in)
+### <a name="autofix"></a>Zero-touch: letting a red gate launch the fixer itself (opt-in)
 
 By default nothing happens when the gate goes red: the findings are on the pull
 request and the developer decides — fix them, argue one, or hand the work over
@@ -341,9 +341,15 @@ that from doing harm of its own:
   starts a fresh review. A newer head is a newer review's responsibility, so
   the run must name the revision it read (`head_sha`, stamped at launch) and
   the reconciler abstains when it does not.
-- **It leaves resumable and paused runs alone.** The cloud runner republishes
-  a run outcome on every delivery attempt, before deciding to retry, so a
-  transient rate limit is not a dead run.
+- **It leaves paused runs and ARMED retries alone — and nothing else.** A
+  `failed_resumable` run whose usage-window retry is armed (persisted before
+  the outcome event fires) will resume and post its own verdict. One with no
+  retry armed — budget exceeded, retries exhausted, a plain execution failure —
+  has nothing coming back for it and IS reconciled: skipping those left a
+  Vetty-gated PR silently unmergeable for hours in production (2026-08-03,
+  a 15-module go bump whose audit died on the run's own duration budget).
+  When the retry sweeper permanently abandons a retry, it republishes the run
+  outcome so this rule fires then too.
 - **It stays inside the grant's scope.** `pr_url` is a launch var, and the
   server honours a caller-pinned publish token, so the repo and forge host are
   re-checked against the grant exactly as the publish endpoint checks them. A
@@ -354,3 +360,27 @@ that from doing harm of its own:
 
 A paused run is not reconciled: it is expected to resume and post its own
 verdict.
+
+### The dead review is re-run — once per head
+
+The synthetic `failure` makes the interruption visible; on an automated lane
+(a Dependabot PR guarded by Vetty) nobody is watching to act on it. So after
+posting it, the server relaunches the SAME bot on the same pull request —
+crash-recovery of a launch the webhook already admitted, re-run through the
+same tail (idempotency claim, quota metering, fresh publish grant, hold-label
+veto, `overlap: supersede`). The bound is the idempotency key itself: **one
+relaunch per (PR, head sha), ever.** The fresh run posts the real verdict over
+the synthetic failure when it completes.
+
+When the one relaunch is already spent and the gate dies AGAIN on the same
+head — or the relaunch cannot start at all — the problem graduates to the
+team's board: a card labelled `source:gate-reconcile` (deduped per PR+head)
+naming the dead runs, the failure reason, and the remedy. A required check
+dying repeatedly on one revision is a structural signal (a run budget too
+short for the workload, a recurring provider quota, a bot defect), which is a
+human's call, and the board is where Nexie and the operator will actually see
+it.
+
+The auto-fix lane ([above](#autofix)) deliberately ignores these synthetic
+failures: `review died` means there are no findings to fix, so the recovery is
+re-running the REVIEWER (this lane), never launching the fixer.

--- a/pkg/server/forge_gate_autofix.go
+++ b/pkg/server/forge_gate_autofix.go
@@ -96,9 +96,15 @@ func (s *Server) autofixForRun(ctx context.Context, ev trigger.Event) error {
 		return nil
 	}
 	// A run that will resume is still expected to post its own verdict; acting
-	// on the interim state would fire on a gate that is about to change.
-	if run.Status == store.RunStatusFailedResumable ||
-		run.Status == store.RunStatusPausedWaitingHuman || run.Status == store.RunStatusPausedOperator {
+	// on the interim state would fire on a gate that is about to change. Only
+	// an ARMED retry makes that true (same distinction as the reconciler): a
+	// failed_resumable with nothing coming back for it is final, and a red
+	// verdict it did post before dying deserves its fix pass.
+	if run.Status == store.RunStatusPausedWaitingHuman || run.Status == store.RunStatusPausedOperator {
+		return nil
+	}
+	if run.Status == store.RunStatusFailedResumable &&
+		run.RetryState != nil && run.RetryState.RetryAfter != nil {
 		return nil
 	}
 
@@ -171,8 +177,16 @@ func (s *Server) autofixForRun(ctx context.Context, ev trigger.Event) error {
 	// which a second replica would not share and a restart would lose. No read
 	// capability means abstain: launching a fixer on a gate we cannot see would
 	// be acting on a guess.
-	state, readable, err := gateStatusOn(ctx, gc, repo, pr.HeadSHA, gateCtx)
-	if err != nil || !readable || state != forge.CommitStateFailure {
+	gate, readable, err := gateStatusOn(ctx, gc, repo, pr.HeadSHA, gateCtx)
+	if err != nil || !readable || gate.State != forge.CommitStateFailure {
+		return nil
+	}
+	// A SYNTHETIC failure — the reconciler's "the review died without a
+	// verdict" marker — is not a verdict either. There are no findings behind
+	// it for a fixer to address; recovery for a review that never happened is
+	// the relaunch lane's job (re-run the REVIEWER), and launching the fixer
+	// here would push code against an instruction to fix nothing.
+	if isSyntheticGateInterruption(gate.Description) {
 		return nil
 	}
 
@@ -292,27 +306,27 @@ func (s *Server) reviewFixerFor(integration forge.RepoIntegration) string {
 	return ""
 }
 
-// gateStatusOn reports the state of ctxName on sha; an ABSENT context is the
-// zero state. readable=false means the provider cannot list statuses at ALL —
+// gateStatusOn reports the status of ctxName on sha; an ABSENT context is the
+// zero status. readable=false means the provider cannot list statuses at ALL —
 // deliberately distinct from "absent", because the two callers assume opposite
 // things from it: the reconciler treats unreadable as "already posted" (never
 // overwrite a verdict it cannot see), this lane treats it as "abstain" (never
 // launch on a gate it cannot see).
-func gateStatusOn(ctx context.Context, gc forgeGateClient, repo, sha, ctxName string) (state forge.CommitState, readable bool, err error) {
+func gateStatusOn(ctx context.Context, gc forgeGateClient, repo, sha, ctxName string) (st forge.CommitStatus, readable bool, err error) {
 	lister, ok := gc.(forge.CommitStatusLister)
 	if !ok {
-		return "", false, nil
+		return forge.CommitStatus{}, false, nil
 	}
 	sts, err := lister.ListCommitStatuses(ctx, repo, sha)
 	if err != nil {
-		return "", false, err
+		return forge.CommitStatus{}, false, err
 	}
-	for _, st := range sts {
-		if strings.EqualFold(strings.TrimSpace(st.Context), ctxName) {
-			return st.State, true, nil
+	for _, s := range sts {
+		if strings.EqualFold(strings.TrimSpace(s.Context), ctxName) {
+			return s, true, nil
 		}
 	}
-	return "", true, nil
+	return forge.CommitStatus{}, true, nil
 }
 
 // pullRequestHoldLabel reports the hold label present on the PR, if any. An

--- a/pkg/server/forge_gate_autofix_test.go
+++ b/pkg/server/forge_gate_autofix_test.go
@@ -443,20 +443,11 @@ func TestGateStatusOnSeparatesUnreadableFromAbsent(t *testing.T) {
 	if readable {
 		t.Error("a client that cannot list statuses must not report a readable gate")
 	}
-	// Unreadable must read as "already posted" for the reconciler, or it would
-	// paint a synthetic failure over a verdict it never saw.
-	if posted, err := gateAlreadyPosted(ctx, noListGateClient{}, "acme/widgets", "abc", "iterion/review"); err != nil || !posted {
-		t.Errorf("gateAlreadyPosted = %v (%v), want true on an unreadable provider", posted, err)
-	}
-
 	// Readable but absent is a different fact: nothing has posted yet.
 	empty := stubGateClient{head: "abc", ctxName: "other/check", state: forge.CommitStateSuccess}
 	st, readable, err := gateStatusOn(ctx, empty, "acme/widgets", "abc", "iterion/review")
 	if err != nil || !readable || st.State != "" {
 		t.Errorf("gateStatusOn = (%q, %v, %v), want the zero state, readable, no error", st.State, readable, err)
-	}
-	if posted, err := gateAlreadyPosted(ctx, empty, "acme/widgets", "abc", "iterion/review"); err != nil || posted {
-		t.Errorf("gateAlreadyPosted = %v (%v), want false when the context is absent", posted, err)
 	}
 }
 

--- a/pkg/server/forge_gate_autofix_test.go
+++ b/pkg/server/forge_gate_autofix_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/forge"
@@ -190,9 +191,31 @@ func TestAutofixRefusesWhatItMust(t *testing.T) {
 		})
 	}
 
-	// A resumable failure is not a dead run: the runner republishes the outcome
-	// before deciding to retry, and the gate it left is about to change.
-	t.Run("a resumable failure is not a verdict", func(t *testing.T) {
+	// The reconciler's synthetic failure means "the review DIED", not "the
+	// review found problems". There are no findings behind it, so launching a
+	// fixer would push code against an instruction to fix nothing — recovery
+	// for a dead review is the relaunch lane's job (re-run the REVIEWER).
+	t.Run("a synthetic interruption is not a verdict to fix", func(t *testing.T) {
+		w := build(t, nil)
+		// After build: the fixture pins its own gate client last.
+		w.s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) {
+			return stubGateClient{head: head, state: forge.CommitStateFailure, ctxName: gateNm,
+				desc: gateInterruptedDescription}, nil
+		}
+		runID := seedRun(t, w.s, "reviewer-bot", gatingInputs)
+		_ = w.s.autofixForRun(context.Background(), trigger.Event{
+			Source: trigger.SourceRun, Kind: trigger.KindRunFinished,
+			Subject: trigger.Subject{ID: runID},
+		})
+		if *w.launched != 0 {
+			t.Error("launched a fixer on a review that never happened")
+		}
+	})
+
+	// A resumable failure whose retry is ARMED is not a dead run: the sweeper
+	// will resume it and the gate it left is about to change. (One with no
+	// retry armed is final — same distinction the reconciler applies.)
+	t.Run("an armed retry is not a verdict", func(t *testing.T) {
 		w := build(t, nil)
 		id, err := store.GenerateRunID()
 		if err != nil {
@@ -204,6 +227,8 @@ func TestAutofixRefusesWhatItMust(t *testing.T) {
 		}
 		run.BotID = "reviewer-bot"
 		run.Status = store.RunStatusFailedResumable
+		at := time.Now().UTC().Add(time.Hour)
+		run.RetryState = &store.RunRetryState{RetryAfter: &at, Reason: "usage_window"}
 		if err := w.s.cfg.Store.SaveRun(context.Background(), run); err != nil {
 			t.Fatal(err)
 		}
@@ -372,6 +397,7 @@ type stubGateClient struct {
 	head    string
 	state   forge.CommitState
 	ctxName string
+	desc    string
 }
 
 func (c stubGateClient) GetPullRequest(_ context.Context, _ string, number int) (forge.PullRef, error) {
@@ -381,7 +407,7 @@ func (c stubGateClient) SetCommitStatus(context.Context, string, string, forge.C
 	return nil
 }
 func (c stubGateClient) ListCommitStatuses(context.Context, string, string) ([]forge.CommitStatus, error) {
-	return []forge.CommitStatus{{Context: c.ctxName, State: c.state}}, nil
+	return []forge.CommitStatus{{Context: c.ctxName, State: c.state, Description: c.desc}}, nil
 }
 
 // TestReviewFixerIsDerivedNotNamed: the lane must pick the fixer from what a bot
@@ -425,9 +451,9 @@ func TestGateStatusOnSeparatesUnreadableFromAbsent(t *testing.T) {
 
 	// Readable but absent is a different fact: nothing has posted yet.
 	empty := stubGateClient{head: "abc", ctxName: "other/check", state: forge.CommitStateSuccess}
-	state, readable, err := gateStatusOn(ctx, empty, "acme/widgets", "abc", "iterion/review")
-	if err != nil || !readable || state != "" {
-		t.Errorf("gateStatusOn = (%q, %v, %v), want the zero state, readable, no error", state, readable, err)
+	st, readable, err := gateStatusOn(ctx, empty, "acme/widgets", "abc", "iterion/review")
+	if err != nil || !readable || st.State != "" {
+		t.Errorf("gateStatusOn = (%q, %v, %v), want the zero state, readable, no error", st.State, readable, err)
 	}
 	if posted, err := gateAlreadyPosted(ctx, empty, "acme/widgets", "abc", "iterion/review"); err != nil || posted {
 		t.Errorf("gateAlreadyPosted = %v (%v), want false when the context is absent", posted, err)

--- a/pkg/server/forge_gate_reconcile.go
+++ b/pkg/server/forge_gate_reconcile.go
@@ -34,6 +34,40 @@ const gateReconcilerName = "forge-gate-reconcile"
 // to carry the remedy: whoever finds it has no other clue about what happened.
 const gateInterruptedDescription = "review ended without a verdict — push again or comment the bot's command to re-run"
 
+// gateInterruptedDescriptionFor prefixes the remedy with WHY the run died when
+// the run doc can say (budget exceeded, provider error, …). GitHub truncates
+// commit-status descriptions at 140 characters, so the reason is bounded and
+// the remedy — the part the operator cannot reconstruct — keeps priority.
+func gateInterruptedDescriptionFor(run *store.Run) string {
+	reason := ""
+	if run != nil {
+		reason = strings.TrimSpace(run.Error)
+	}
+	if i := strings.IndexByte(reason, '\n'); i >= 0 {
+		reason = strings.TrimSpace(reason[:i])
+	}
+	if reason == "" {
+		return gateInterruptedDescription
+	}
+	const maxReason = 60
+	if len(reason) > maxReason {
+		reason = reason[:maxReason-1] + "…"
+	}
+	return gateDiedDescriptionPrefix + reason + ") — push again or comment the bot's command to re-run"
+}
+
+// gateDiedDescriptionPrefix opens the reasoned form of the synthetic status.
+const gateDiedDescriptionPrefix = "review died ("
+
+// isSyntheticGateInterruption reports whether a gate status description is one
+// of the reconciler's own synthetic failures — a review that never happened —
+// as opposed to a real verdict a bot posted. The auto-fix lane keys off it:
+// there are no findings behind a synthetic failure for a fixer to address.
+func isSyntheticGateInterruption(description string) bool {
+	d := strings.TrimSpace(description)
+	return d == gateInterruptedDescription || strings.HasPrefix(d, gateDiedDescriptionPrefix)
+}
+
 // startGateReconciler attaches the reconciler to the event spine. It rides the
 // same bus as the notification dispatcher — the shared cloud NATSBus, whose
 // queue-group delivery hands each run outcome to exactly one replica, or the
@@ -88,11 +122,21 @@ func (s *Server) reconcileGateForRun(ctx context.Context, ev trigger.Event) erro
 	if err != nil || run == nil {
 		return nil
 	}
-	// A resumable failure is not a dead run: the cloud runner republishes the
-	// outcome on every delivery attempt, before it decides to retry, and
-	// `iterion resume` picks one up locally. Such a run is still expected to
-	// post its own verdict — the same reason paused is not reconciled.
-	if run.Status == store.RunStatusFailedResumable || run.Status == store.RunStatusPausedWaitingHuman || run.Status == store.RunStatusPausedOperator {
+	// A paused run is expected to resume and post its own verdict.
+	if run.Status == store.RunStatusPausedWaitingHuman || run.Status == store.RunStatusPausedOperator {
+		return nil
+	}
+	// A resumable failure is only "not dead" when something will actually
+	// resume it. The runner arms a durable retry for usage-window failures
+	// (persisted BEFORE the outcome event fires — pkg/runner/loop.go parks
+	// first, then fires), and that armed retry is the whole promise. Every
+	// other failed_resumable — budget exceeded, retries exhausted, a plain
+	// execution failure — sits until a human notices, which with an absent
+	// required check is never. Observed in production 2026-08-03: a Vetty run
+	// died on its own duration budget mid-audit and the PR it gated stayed
+	// silently unmergeable. Those runs ARE dead; reconcile them.
+	if run.Status == store.RunStatusFailedResumable &&
+		run.RetryState != nil && run.RetryState.RetryAfter != nil {
 		return nil
 	}
 
@@ -192,7 +236,7 @@ func (s *Server) reconcileGateForRun(ctx context.Context, ev trigger.Event) erro
 	st := forge.CommitStatus{
 		State:       forge.CommitStateFailure,
 		Context:     gateCtx,
-		Description: gateInterruptedDescription,
+		Description: gateInterruptedDescriptionFor(run),
 		TargetURL:   gateRunURL(strings.TrimRight(strings.TrimSpace(s.cfg.PublicURL), "/"), runID),
 	}
 	if err := gc.SetCommitStatus(ctx, repo, pr.HeadSHA, st); err != nil {
@@ -205,6 +249,14 @@ func (s *Server) reconcileGateForRun(ctx context.Context, ev trigger.Event) erro
 	if s.logger != nil {
 		s.logger.Info("forge gate: run %s ended without a verdict; posted %s=failure on %s so the PR is not stuck waiting", runID, gateCtx, prURL)
 	}
+	// The failure status is the truth; the relaunch is the recovery. Posted
+	// first so the PR is never blind even when the relaunch cannot happen
+	// (local mode, quota, hold label) — the fresh run overwrites the failure
+	// with its own verdict when it completes.
+	s.relaunchDeadGateRun(ctx, deadGateRun{
+		run: run, grant: grant, conn: conn, gc: gc,
+		repo: repo, number: number, pr: pr, gateCtx: gateCtx, prURL: prURL,
+	})
 	return nil
 }
 
@@ -212,11 +264,11 @@ func (s *Server) reconcileGateForRun(ctx context.Context, ev trigger.Event) erro
 // a read capability it says "posted": overwriting a real success with a
 // synthetic failure is a worse outcome than leaving a stuck PR stuck.
 func gateAlreadyPosted(ctx context.Context, gc forgeGateClient, repo, sha, ctxName string) (bool, error) {
-	state, readable, err := gateStatusOn(ctx, gc, repo, sha, ctxName)
+	st, readable, err := gateStatusOn(ctx, gc, repo, sha, ctxName)
 	if err != nil {
 		return false, err
 	}
-	return !readable || state != "", nil
+	return !readable || st.State != "", nil
 }
 
 // gateRunURL points the check at the run that owed it, so the operator lands

--- a/pkg/server/forge_gate_reconcile.go
+++ b/pkg/server/forge_gate_reconcile.go
@@ -221,15 +221,24 @@ func (s *Server) reconcileGateForRun(ctx context.Context, ev trigger.Event) erro
 	}
 	// The forge is the authority on whether the verdict landed — not any
 	// bookkeeping of ours, which a second replica would not share and a
-	// restart would lose.
-	posted, err := gateAlreadyPosted(ctx, gc, repo, pr.HeadSHA, gateCtx)
+	// restart would lose. Only a REAL verdict stands the reconciler down: its
+	// own synthetic failure does not, or the second death on a head — the
+	// relaunched run dying too, exactly the case that must escalate to the
+	// board — would find the marker from the first death, read it as "already
+	// posted", and go silent right where the recovery runs out.
+	gate, readable, err := gateStatusOn(ctx, gc, repo, pr.HeadSHA, gateCtx)
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Warn("forge gate: cannot read statuses on %s@%s: %v", repo, pr.HeadSHA[:7], err)
 		}
 		return nil
 	}
-	if posted {
+	if !readable {
+		// Cannot tell absent from posted: overwriting a real success with a
+		// synthetic failure is a worse outcome than leaving a stuck PR stuck.
+		return nil
+	}
+	if gate.State != "" && !isSyntheticGateInterruption(gate.Description) {
 		return nil
 	}
 
@@ -258,17 +267,6 @@ func (s *Server) reconcileGateForRun(ctx context.Context, ev trigger.Event) erro
 		repo: repo, number: number, pr: pr, gateCtx: gateCtx, prURL: prURL,
 	})
 	return nil
-}
-
-// gateAlreadyPosted reports whether ctxName is already present on sha. Without
-// a read capability it says "posted": overwriting a real success with a
-// synthetic failure is a worse outcome than leaving a stuck PR stuck.
-func gateAlreadyPosted(ctx context.Context, gc forgeGateClient, repo, sha, ctxName string) (bool, error) {
-	st, readable, err := gateStatusOn(ctx, gc, repo, sha, ctxName)
-	if err != nil {
-		return false, err
-	}
-	return !readable || st.State != "", nil
 }
 
 // gateRunURL points the check at the run that owed it, so the operator lands

--- a/pkg/server/forge_gate_reconcile_test.go
+++ b/pkg/server/forge_gate_reconcile_test.go
@@ -3,7 +3,9 @@ package server
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/forge"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -197,12 +199,9 @@ func TestGateReconcile_NeedsThePinnedContextToActAtAll(t *testing.T) {
 	}
 }
 
-// A resumable failure is not a dead run: the cloud runner republishes the
-// outcome on every delivery attempt, BEFORE it decides to retry. Painting the
-// check red there contradicts a review that is about to run again.
-func TestGateReconcile_LeavesResumableAndPausedRunsAlone(t *testing.T) {
+// A paused run is expected to resume and post its own verdict.
+func TestGateReconcile_LeavesPausedRunsAlone(t *testing.T) {
 	for _, st := range []store.RunStatus{
-		store.RunStatusFailedResumable,
 		store.RunStatusPausedWaitingHuman,
 		store.RunStatusPausedOperator,
 	} {
@@ -217,6 +216,94 @@ func TestGateReconcile_LeavesResumableAndPausedRunsAlone(t *testing.T) {
 				t.Fatalf("%s: wrote a verdict over a run that is expected to post its own (%d writes)", st, gc.setCalls)
 			}
 		})
+	}
+}
+
+// A resumable failure is only "not dead" while a retry is actually ARMED. The
+// runner arms one for usage-window failures (persisted before the outcome
+// event fires); everything else — budget exceeded, exhausted attempts, a
+// plain execution failure — has nothing coming back for it, and skipping
+// those left a PR silently unmergeable behind an absent required check
+// (observed in production, Vetty run 019fc8e5 on 2026-08-03).
+func TestGateReconcile_FailedResumable(t *testing.T) {
+	setStatus := func(t *testing.T, s *Server, runID string, retry *store.RunRetryState, runErr string) {
+		t.Helper()
+		run, err := s.cfg.Store.LoadRun(context.Background(), runID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		run.Status = store.RunStatusFailedResumable
+		run.Error = runErr
+		run.RetryState = retry
+		if err := s.cfg.Store.SaveRun(context.Background(), run); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("an armed retry stands the reconciler down", func(t *testing.T) {
+		gc := &listingGateClient{fakeGateClient: fakeGateClient{headSHA: "deadbeef"}}
+		s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+		at := time.Now().UTC().Add(time.Hour)
+		setStatus(t, s, runID, &store.RunRetryState{RetryAfter: &at, Reason: "usage_window"}, "usage window shut")
+		_ = s.reconcileGateForRun(context.Background(), terminalEvent(runID))
+		if gc.setCalls != 0 {
+			t.Fatalf("wrote a verdict over a run whose retry is armed and about to resume (%d writes)", gc.setCalls)
+		}
+	})
+
+	t.Run("no retry armed means the run is dead — reconcile it", func(t *testing.T) {
+		gc := &listingGateClient{fakeGateClient: fakeGateClient{headSHA: "deadbeef"}}
+		s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+		setStatus(t, s, runID, nil, "budget exceeded: duration (2401987036905/2400000000000)")
+		if err := s.reconcileGateForRun(context.Background(), terminalEvent(runID)); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if gc.setCalls != 1 {
+			t.Fatalf("posted %d statuses, want 1 — nothing resumes a budget-exceeded run on its own", gc.setCalls)
+		}
+		if gc.last.State != forge.CommitStateFailure {
+			t.Errorf("state = %q, want failure", gc.last.State)
+		}
+		// The reason is on the check: whoever finds it must not have to dig
+		// through run storage to learn WHY the review died.
+		if !strings.Contains(gc.last.Description, "budget exceeded") {
+			t.Errorf("description %q does not carry the failure reason", gc.last.Description)
+		}
+		if !isSyntheticGateInterruption(gc.last.Description) {
+			t.Errorf("description %q is not recognizable as synthetic — the auto-fix lane would treat it as a real verdict", gc.last.Description)
+		}
+	})
+
+	t.Run("an abandoned retry is dead too", func(t *testing.T) {
+		gc := &listingGateClient{fakeGateClient: fakeGateClient{headSHA: "deadbeef"}}
+		s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+		setStatus(t, s, runID, &store.RunRetryState{
+			RetryAfter: nil, Reason: "usage_window", Attempts: 3,
+			LastError: "usage-window retries exhausted (max 3)",
+		}, "usage limit blocked")
+		_ = s.reconcileGateForRun(context.Background(), terminalEvent(runID))
+		if gc.setCalls != 1 {
+			t.Fatalf("posted %d statuses, want 1 — an abandoned retry never comes back", gc.setCalls)
+		}
+	})
+}
+
+// The synthetic marker must be recognized in both its shapes and must never
+// swallow a real verdict.
+func TestGateReconcile_SyntheticMarker(t *testing.T) {
+	for _, tc := range []struct {
+		desc string
+		want bool
+	}{
+		{gateInterruptedDescription, true},
+		{"review died (budget exceeded: duration…) — push again or comment the bot's command to re-run", true},
+		{"no blocking findings (≥high); 4 total", false},
+		{"supply-chain audit clean; no alignment needed, build verified", false},
+		{"", false},
+	} {
+		if got := isSyntheticGateInterruption(tc.desc); got != tc.want {
+			t.Errorf("isSyntheticGateInterruption(%q) = %v, want %v", tc.desc, got, tc.want)
+		}
 	}
 }
 

--- a/pkg/server/forge_gate_relaunch.go
+++ b/pkg/server/forge_gate_relaunch.go
@@ -1,0 +1,232 @@
+package server
+
+import (
+	"fmt"
+	"strings"
+
+	"context"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/identity"
+	"github.com/SocialGouv/iterion/pkg/knowledge"
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+)
+
+// Relaunching a dead gating run closes the recovery loop the reconciler only
+// half-closes: the synthetic failure status makes the interruption VISIBLE,
+// but somebody still has to re-run the bot, and on an automated dependency
+// lane there is no somebody. So when a gating run dies without a verdict, the
+// same bot is relaunched on the same pull request — once per head, ever.
+//
+// This is crash-recovery of a launch that was already decided, not a new
+// authority: the webhook admitted this bot on this PR when the event arrived,
+// and the relaunch re-runs exactly that decision through exactly the same
+// tail (idempotency claim, quota metering, publish grant, hold-label veto).
+// The once-per-head bound is the idempotency key itself — if the relaunched
+// run dies on the same head too, the claim is already spent, the synthetic
+// failure stays, and the problem graduates to the board (below) for a human.
+const gateRelaunchEventKind = "gate_relaunch"
+
+// gateRelaunchLabel marks the board cards this lane creates, so an operator
+// (or Nexie) can find every gate that died past recovery in one query.
+const gateRelaunchLabel = "source:gate-reconcile"
+
+// deadGateRun carries what reconcileGateForRun already resolved about the dead
+// run, so the relaunch re-validates nothing it does not have to.
+type deadGateRun struct {
+	run     *store.Run
+	grant   ForgePublishGrant
+	conn    forge.Connection
+	gc      forgeGateClient
+	repo    string
+	number  int
+	pr      forge.PullRef
+	gateCtx string
+	prURL   string
+}
+
+// relaunchDeadGateRun relaunches the bot that owed the (now synthetically
+// failed) gate, bounded to one attempt per (PR, head sha). Every refusal is
+// deliberate and most are silent: this runs on a bus goroutine after the
+// visible failure status has already landed, so nothing here can make the PR
+// blind — only less automatic.
+func (s *Server) relaunchDeadGateRun(ctx context.Context, d deadGateRun) {
+	if s == nil || d.run == nil || s.forgeIntegrations == nil || s.webhookConfigs == nil || s.webhookDeliveries == nil {
+		return // local mode: no integrations/webhook spine to relaunch through
+	}
+	if d.pr.State != "" && d.pr.State != "open" {
+		return
+	}
+	botID := strings.TrimSpace(d.run.BotID)
+	if botID == "" {
+		botID = strings.TrimSpace(d.grant.Bot)
+	}
+	if botID == "" {
+		return // cannot name the bot to re-run
+	}
+
+	integration, err := s.forgeIntegrations.GetByConnRepo(store.WithoutTenantFilter(ctx), d.grant.TeamID, d.grant.ConnectionID, d.repo)
+	if err != nil {
+		return
+	}
+	// The repo must still have this bot enabled: an operator who removed it
+	// since the original launch has revoked exactly the decision this lane
+	// replays.
+	enabled := false
+	for _, id := range integration.BotIDs {
+		if strings.EqualFold(id, botID) {
+			enabled = true
+			break
+		}
+	}
+	if !enabled {
+		return
+	}
+	cfg, err := s.webhookConfigs.Get(store.WithoutTenantFilter(ctx), integration.WebhookID)
+	if err != nil || !cfg.AllowsBot(botID) {
+		return
+	}
+	// The hold label is the operator's per-PR pause on ALL automation. Fails
+	// CLOSED, like the auto-fix lane and unlike the best-effort veto on human
+	// commands: an unattended launch skipped on a briefly unreachable forge is
+	// recovered by the next push; a launch past a pause the operator set is not.
+	if len(cfg.HoldLabels) > 0 {
+		held, readErr := s.pullRequestHoldLabel(ctx, d.conn, d.repo, d.number, cfg.HoldLabels)
+		if readErr != nil {
+			s.logWarn("gate relaunch: cannot read labels on %s#%d (%v) — not relaunching, since the hold label could not be ruled out", d.repo, d.number, readErr)
+			return
+		}
+		if held != "" {
+			return
+		}
+	}
+
+	// The original run's inputs ARE the launch decision being replayed — the
+	// PR facts, the operator's pinned gate_context/arm_automerge, the bot's
+	// own vars. Only the per-run publish grant is dropped: the launch tail
+	// mints a fresh one (and would overwrite a stale copy anyway).
+	vars := make(map[string]string, len(d.run.Inputs))
+	for k, v := range d.run.Inputs {
+		if k == forgePublishVarToken || k == forgePublishVarURL {
+			continue
+		}
+		if sv, ok := v.(string); ok {
+			vars[k] = sv
+		}
+	}
+
+	actor := "gaterelaunch:" + cfg.ID
+	launchCtx := auth.WithIdentity(ctx, auth.Identity{
+		UserID: actor,
+		TeamID: d.grant.TeamID,
+		Role:   identity.RoleMember,
+		Kind:   auth.KindWebhook,
+	})
+	launchCtx = store.WithIdentity(launchCtx, d.grant.TeamID, actor)
+
+	meta := webhookEventMeta{
+		Kind:        gateRelaunchEventKind,
+		Action:      "review_died",
+		ProjectPath: d.repo,
+		SubjectID:   fmt.Sprintf("pr:%d", d.number),
+		SubjectURL:  d.prURL,
+		SubjectSHA:  d.pr.HeadSHA,
+	}
+	// One relaunch per (team, repo, PR, head) — EVER. A second death on the
+	// same head replays as a duplicate of this key, which is the signal that
+	// automation is out of moves for this revision.
+	idem := knowledge.ChecksumHex([]byte(fmt.Sprintf("gaterelaunch|%s|%s|%d|%s", d.grant.TeamID, d.repo, d.number, d.pr.HeadSHA)))
+	res := s.launchWebhookTarget(launchCtx, nil, cfg, meta, forgeLaunchTarget{
+		BotID:   botID,
+		IdemKey: idem,
+		Vars:    vars,
+		RepoURL: forge.CloneURLFor(d.conn.BaseURL(), d.repo),
+		RepoRef: d.pr.SourceBranch,
+	}, "", "")
+
+	switch res.Status {
+	case webhooks.StatusLaunched:
+		if s.logger != nil {
+			s.logger.Info("gate relaunch: %s died on %s#%d@%s without a verdict → relaunched %s (run %s)",
+				d.gateCtx, d.repo, d.number, shortSHA(d.pr.HeadSHA), botID, res.RunID)
+		}
+	case webhooks.StatusDuplicate:
+		// The one attempt this head gets was already spent (res.RunID names
+		// it). The failure status stays; a human decides from here — and the
+		// board card is how they find out a gate is dying REPEATEDLY, which
+		// is a deeper problem (a structurally short budget, a recurring
+		// provider quota, a bot defect) than any single death.
+		s.logWarn("gate relaunch: %s on %s#%d@%s already got its one relaunch (run %s) and died again — escalating to the board",
+			d.gateCtx, d.repo, d.number, shortSHA(d.pr.HeadSHA), res.RunID)
+		s.escalateDeadGateToBoard(d, res.RunID, "the automatic relaunch died too")
+	default:
+		why := strings.TrimSpace(res.Error)
+		if why == "" {
+			why = res.Status
+		}
+		s.logWarn("gate relaunch: could not relaunch %s on %s#%d@%s (%s) — escalating to the board",
+			botID, d.repo, d.number, shortSHA(d.pr.HeadSHA), why)
+		s.escalateDeadGateToBoard(d, "", "the automatic relaunch could not start: "+why)
+	}
+}
+
+// escalateDeadGateToBoard leaves a board card when the relaunch lane is out of
+// moves: the gate died, the one automatic re-run either died too or could not
+// start, and from here only a human can unstick the PR. Best-effort by
+// construction — the synthetic failure status is already on the PR, so a board
+// that cannot be written costs visibility, never correctness.
+//
+// One card per (PR, head): a closed card means a human already dealt with this
+// revision, and a fresh death on the SAME head adds nothing they don't know.
+func (s *Server) escalateDeadGateToBoard(d deadGateRun, priorRelaunchRunID, why string) {
+	if s.cfg.CloudBoardFor == nil {
+		s.logWarn("gate relaunch: no board on this deployment — %s#%d stays red with no card; the failure status carries the remedy", d.repo, d.number)
+		return
+	}
+	board := s.cfg.CloudBoardFor(d.grant.TeamID)
+	if board == nil {
+		s.logWarn("gate relaunch: no board for team %s — %s#%d stays red with no card", d.grant.TeamID, d.repo, d.number)
+		return
+	}
+	dedup := fmt.Sprintf("gate-dead:%s#%d@%s", d.repo, d.number, shortSHA(d.pr.HeadSHA))
+	if existing, err := board.List(native.ListFilter{Labels: []string{dedup}}); err == nil && len(existing) > 0 {
+		return
+	}
+
+	reason := strings.TrimSpace(d.run.Error)
+	if reason == "" {
+		reason = "(no error recorded on the run)"
+	}
+	base := strings.TrimRight(strings.TrimSpace(s.cfg.PublicURL), "/")
+	body := fmt.Sprintf(
+		"The merge gate `%s` on %s#%d died without posting a verdict, and the automatic recovery is exhausted: %s.\n\n"+
+			"- Pull request: %s\n"+
+			"- Head audited: `%s`\n"+
+			"- Dead run: %s — `%s`\n",
+		d.gateCtx, d.repo, d.number, why,
+		d.prURL,
+		d.pr.HeadSHA,
+		gateRunURL(base, d.run.ID), reason)
+	if priorRelaunchRunID != "" {
+		body += fmt.Sprintf("- Relaunched run (also dead): %s\n", gateRunURL(base, priorRelaunchRunID))
+	}
+	body += "\nA required check dying twice on one revision usually means a structural problem — " +
+		"a run budget too short for this workload, a recurring provider quota, or a bot defect. " +
+		"Fix the cause, then push or comment the bot's command to re-run; the synthetic `failure` " +
+		"status on the PR is overwritten by the next real verdict."
+
+	if _, err := board.Create(native.Issue{
+		Title:  truncate(fmt.Sprintf("Merge gate %s keeps dying on %s#%d", d.gateCtx, d.repo, d.number), 120),
+		Body:   body,
+		Labels: []string{gateRelaunchLabel, dedup},
+	}); err != nil {
+		s.logWarn("gate relaunch: board card create failed for %s#%d: %v", d.repo, d.number, err)
+		return
+	}
+	if s.logger != nil {
+		s.logger.Info("gate relaunch: board card filed for %s on %s#%d@%s", d.gateCtx, d.repo, d.number, shortSHA(d.pr.HeadSHA))
+	}
+}

--- a/pkg/server/forge_gate_relaunch_test.go
+++ b/pkg/server/forge_gate_relaunch_test.go
@@ -1,0 +1,194 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/knowledge"
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+)
+
+// The relaunch lane is the recovery half of the reconciler: a gating run that
+// died without a verdict gets its bot re-run ONCE per head, through the same
+// admission tail as any webhook launch, and a head whose one attempt is spent
+// graduates to a board card instead of looping. Pinned here: the launch fires
+// with the original run's inputs (minus the per-run grant), the once-per-head
+// bound holds, the board card dedups, and a bot the repo no longer enables is
+// never relaunched.
+func TestGateRelaunch(t *testing.T) {
+	const (
+		team   = "t1"
+		repo   = "acme/widgets"
+		prURL  = "https://github.com/acme/widgets/pull/7"
+		head   = "cafe1234cafe1234cafe1234cafe1234cafe1234"
+		gateNm = "revi/review"
+		botID  = "dep-update-guard"
+	)
+
+	type world struct {
+		s        *Server
+		gc       *listingGateClient
+		board    native.BoardStore
+		launched *int
+		lastVars *map[string]string
+	}
+	build := func(t *testing.T, tune func(*Server, *forge.RepoIntegration, *webhooks.Config)) world {
+		t.Helper()
+		s := newWebhookTestServer(t)
+
+		rs, err := store.New(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		s.cfg.Store = rs
+		s.cfg.PublicURL = "https://iterion.test"
+
+		conns := forge.NewMemoryConnectionStore()
+		conn := forge.Connection{ID: "c1", TenantID: team, Provider: forge.ProviderGitHub}
+		if err := conns.Create(context.Background(), conn); err != nil {
+			t.Fatal(err)
+		}
+		s.forgeConnections = conns
+		s.forgePublishTokens = NewForgePublishTokenRegistry()
+		s.forgePublishTokens.Register("run-token", ForgePublishGrant{TeamID: team, ConnectionID: "c1", Repo: repo})
+
+		ints := forge.NewMemoryRepoIntegrationStore()
+		integ := forge.RepoIntegration{
+			ID: "i1", TenantID: team, ConnectionID: "c1", RepoFullName: repo,
+			BotIDs: []string{botID}, WebhookID: "w1",
+			LaunchVars: map[string]string{gateContextVar: gateNm},
+		}
+		cfg := webhooks.Config{ID: "w1", TenantID: team, BotIDs: []string{botID}}
+		if tune != nil {
+			tune(s, &integ, &cfg)
+		}
+		if err := ints.Create(context.Background(), integ); err != nil {
+			t.Fatal(err)
+		}
+		s.forgeIntegrations = ints
+		if err := s.webhookConfigs.Create(context.Background(), cfg); err != nil {
+			t.Fatal(err)
+		}
+
+		gc := &listingGateClient{fakeGateClient: fakeGateClient{headSHA: head}}
+		s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) {
+			return gc, nil
+		}
+
+		board, err := native.NewStore(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		s.cfg.CloudBoardFor = func(string) native.BoardStore { return board }
+
+		launched := 0
+		var lastVars map[string]string
+		s.webhookLaunchBot = func(_ context.Context, _ string, vars map[string]string, _, _, _ string, _, _ map[string]string) (string, error) {
+			launched++
+			lastVars = vars
+			return "run-relaunched", nil
+		}
+		return world{s: s, gc: gc, board: board, launched: &launched, lastVars: &lastVars}
+	}
+
+	deadInputs := map[string]any{
+		"pr_url":             prURL,
+		"gate_context":       gateNm,
+		"head_sha":           head,
+		"arm_automerge":      "true", // the operator's pinned vars must survive the relaunch
+		forgePublishVarToken: "run-token",
+		forgePublishVarURL:   "https://iterion.test/api/v1/forge/publish-review",
+	}
+	seedDeadRun := func(t *testing.T, s *Server) string {
+		t.Helper()
+		id, err := store.GenerateRunID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		run, err := s.cfg.Store.CreateRun(context.Background(), id, "dep_update_guard", deadInputs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		run.BotID = botID
+		run.Status = store.RunStatusFailedResumable // dead: no retry armed
+		run.Error = "budget exceeded: duration (2401987036905/2400000000000)"
+		if err := s.cfg.Store.SaveRun(context.Background(), run); err != nil {
+			t.Fatal(err)
+		}
+		return run.ID
+	}
+	relaunchIdem := knowledge.ChecksumHex([]byte("gaterelaunch|" + team + "|" + repo + "|7|" + head))
+
+	t.Run("a dead gating run posts its failure and is relaunched once", func(t *testing.T) {
+		w := build(t, nil)
+		runID := seedDeadRun(t, w.s)
+		if err := w.s.reconcileGateForRun(context.Background(), terminalEvent(runID)); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if w.gc.setCalls != 1 {
+			t.Fatalf("posted %d statuses, want 1 — the failure lands BEFORE any recovery", w.gc.setCalls)
+		}
+		if *w.launched != 1 {
+			t.Fatalf("launched %d runs, want 1 — the dead review's bot must be re-run", *w.launched)
+		}
+		vars := *w.lastVars
+		if vars["pr_url"] != prURL || vars["arm_automerge"] != "true" {
+			t.Errorf("relaunch dropped original launch vars: %v", vars)
+		}
+		if tok := vars[forgePublishVarToken]; tok == "" || tok == "run-token" {
+			t.Errorf("publish token = %q — the tail must mint a FRESH grant, not reuse the dead run's", tok)
+		}
+		// The claim is durable: the delivery row under the per-head key is
+		// what makes attempt two impossible.
+		if d, err := w.s.webhookDeliveries.GetByIdempotencyKey(context.Background(), relaunchIdem); err != nil || d.RunID != "run-relaunched" {
+			t.Errorf("no durable claim under the per-head key (%v, %+v)", err, d)
+		}
+	})
+
+	t.Run("the second death on the same head escalates to the board instead", func(t *testing.T) {
+		w := build(t, nil)
+		// The head's one attempt is already spent.
+		if err := w.s.webhookDeliveries.Insert(context.Background(), webhooks.Delivery{
+			ID: "d-spent", TenantID: team, WebhookID: "w1", IdempotencyKey: relaunchIdem,
+			Status: webhooks.StatusLaunched, RunID: "run-prior-relaunch",
+		}); err != nil {
+			t.Fatal(err)
+		}
+		runID := seedDeadRun(t, w.s)
+		_ = w.s.reconcileGateForRun(context.Background(), terminalEvent(runID))
+		if *w.launched != 0 {
+			t.Fatalf("launched %d runs, want 0 — one relaunch per head, ever", *w.launched)
+		}
+		cards, err := w.board.List(native.ListFilter{Labels: []string{gateRelaunchLabel}})
+		if err != nil || len(cards) != 1 {
+			t.Fatalf("board cards = %d (%v), want exactly 1", len(cards), err)
+		}
+		if !strings.Contains(cards[0].Body, "run-prior-relaunch") || !strings.Contains(cards[0].Body, "budget exceeded") {
+			t.Errorf("the card must name the dead runs and the reason; got body:\n%s", cards[0].Body)
+		}
+
+		// A third death on the same head adds no second card.
+		w.gc.statuses = nil // the synthetic failure was "lost" so the reconciler acts again
+		runID2 := seedDeadRun(t, w.s)
+		_ = w.s.reconcileGateForRun(context.Background(), terminalEvent(runID2))
+		cards, err = w.board.List(native.ListFilter{Labels: []string{gateRelaunchLabel}})
+		if err != nil || len(cards) != 1 {
+			t.Fatalf("board cards after a third death = %d (%v), want still 1", len(cards), err)
+		}
+	})
+
+	t.Run("a bot the repo no longer enables is not relaunched", func(t *testing.T) {
+		w := build(t, func(_ *Server, i *forge.RepoIntegration, _ *webhooks.Config) {
+			i.BotIDs = []string{"someone-else"}
+		})
+		runID := seedDeadRun(t, w.s)
+		_ = w.s.reconcileGateForRun(context.Background(), terminalEvent(runID))
+		if *w.launched != 0 {
+			t.Fatal("relaunched a bot the operator has since removed from the repo")
+		}
+	})
+}

--- a/pkg/server/forge_gate_relaunch_test.go
+++ b/pkg/server/forge_gate_relaunch_test.go
@@ -149,19 +149,33 @@ func TestGateRelaunch(t *testing.T) {
 		}
 	})
 
+	// The natural second-death sequence: the first death posted the synthetic
+	// failure and spent the head's one relaunch; now the RELAUNCHED run dies
+	// too. The gate carries the reconciler's own marker — which must not read
+	// as "already posted", or this exact case would go silent right where the
+	// recovery runs out (found adversarially: an earlier version stood down on
+	// its own synthetic status and the board escalation was unreachable).
 	t.Run("the second death on the same head escalates to the board instead", func(t *testing.T) {
 		w := build(t, nil)
-		// The head's one attempt is already spent.
+		// The head's one attempt is already spent…
 		if err := w.s.webhookDeliveries.Insert(context.Background(), webhooks.Delivery{
 			ID: "d-spent", TenantID: team, WebhookID: "w1", IdempotencyKey: relaunchIdem,
 			Status: webhooks.StatusLaunched, RunID: "run-prior-relaunch",
 		}); err != nil {
 			t.Fatal(err)
 		}
+		// …and the gate still shows the first death's synthetic failure.
+		w.gc.statuses = []forge.CommitStatus{{
+			Context: gateNm, State: forge.CommitStateFailure,
+			Description: gateInterruptedDescription,
+		}}
 		runID := seedDeadRun(t, w.s)
 		_ = w.s.reconcileGateForRun(context.Background(), terminalEvent(runID))
 		if *w.launched != 0 {
 			t.Fatalf("launched %d runs, want 0 — one relaunch per head, ever", *w.launched)
+		}
+		if w.gc.setCalls != 1 {
+			t.Fatalf("posted %d statuses, want 1 — the synthetic failure is refreshed with the newest death's reason", w.gc.setCalls)
 		}
 		cards, err := w.board.List(native.ListFilter{Labels: []string{gateRelaunchLabel}})
 		if err != nil || len(cards) != 1 {
@@ -172,12 +186,29 @@ func TestGateRelaunch(t *testing.T) {
 		}
 
 		// A third death on the same head adds no second card.
-		w.gc.statuses = nil // the synthetic failure was "lost" so the reconciler acts again
 		runID2 := seedDeadRun(t, w.s)
 		_ = w.s.reconcileGateForRun(context.Background(), terminalEvent(runID2))
 		cards, err = w.board.List(native.ListFilter{Labels: []string{gateRelaunchLabel}})
 		if err != nil || len(cards) != 1 {
 			t.Fatalf("board cards after a third death = %d (%v), want still 1", len(cards), err)
+		}
+	})
+
+	t.Run("a real red verdict is left alone entirely", func(t *testing.T) {
+		w := build(t, nil)
+		// Vetty's own red verdict — the review HAPPENED. Nothing to reconcile,
+		// nothing to relaunch, nothing for the board.
+		w.gc.statuses = []forge.CommitStatus{{
+			Context: gateNm, State: forge.CommitStateFailure,
+			Description: "1 blocking finding (≥high)",
+		}}
+		runID := seedDeadRun(t, w.s)
+		_ = w.s.reconcileGateForRun(context.Background(), terminalEvent(runID))
+		if w.gc.setCalls != 0 || *w.launched != 0 {
+			t.Fatalf("touched a PR whose gate carries a real verdict (posts=%d launches=%d)", w.gc.setCalls, *w.launched)
+		}
+		if cards, _ := w.board.List(native.ListFilter{Labels: []string{gateRelaunchLabel}}); len(cards) != 0 {
+			t.Fatalf("filed %d cards over a real verdict", len(cards))
 		}
 	})
 

--- a/pkg/server/retry_sweeper.go
+++ b/pkg/server/retry_sweeper.go
@@ -10,6 +10,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/store"
 	mongostore "github.com/SocialGouv/iterion/pkg/store/mongo"
+	"github.com/SocialGouv/iterion/pkg/trigger"
 )
 
 // Retry sweeper: the half of the usage-window retry that outlives the pod.
@@ -193,6 +194,20 @@ func (s *Server) abandonRetry(ctx context.Context, retryStore store.RunRetryStor
 	s.countRetry("abandoned")
 	s.auditSystem(tenantID, "retry-sweeper", "run.retry.abandoned", "run", runID, map[string]any{"reason": reason})
 	s.warnf("retry sweeper: run %s: %s", runID, reason)
+
+	// The run's terminal event fired back when it FAILED — while a retry was
+	// still armed, so every outcome consumer that defers to an armed retry
+	// (the merge-gate reconciler foremost) deliberately stood down. Abandoning
+	// is the moment the run becomes permanently dead, and nothing else fires
+	// for it: republish the outcome so those consumers get the event they
+	// were promised. The episode-keyed dedup in each consumer absorbs the
+	// replay for anyone who already acted.
+	if bus := s.eventsBus(); bus != nil && s.cfg.Store != nil {
+		ev := trigger.BuildRunOutcome(ctx, s.cfg.Store, runID, fmt.Errorf("%s", reason))
+		if err := bus.Publish(ctx, ev); err != nil {
+			s.warnf("retry sweeper: republish outcome for abandoned run %s: %v", runID, err)
+		}
+	}
 }
 
 // reArmRetry gives a failed resume another chance inside the attempt

--- a/pkg/server/retry_sweeper.go
+++ b/pkg/server/retry_sweeper.go
@@ -189,7 +189,12 @@ func retryDenialIsTransient(reason string) bool {
 // abandonRetry records a permanent stop and audits it.
 func (s *Server) abandonRetry(ctx context.Context, retryStore store.RunRetryStore, tenantID, runID, reason string) {
 	if err := retryStore.AbandonRunRetry(ctx, runID, reason); err != nil {
+		// The abandon did not land: the retry stays claimable, the next sweep
+		// tick walks this path again, and republishing NOW would repeat on
+		// every tick until the write finally sticks. The single republish
+		// belongs to the tick that actually makes the stop permanent.
 		s.warnf("retry sweeper: abandon %s: %v", runID, err)
+		return
 	}
 	s.countRetry("abandoned")
 	s.auditSystem(tenantID, "retry-sweeper", "run.retry.abandoned", "run", runID, map[string]any{"reason": reason})

--- a/pkg/server/retry_sweeper_test.go
+++ b/pkg/server/retry_sweeper_test.go
@@ -13,9 +13,11 @@ import (
 	dto "github.com/prometheus/client_model/go"
 
 	"github.com/SocialGouv/iterion/pkg/cloud/metrics"
+	"github.com/SocialGouv/iterion/pkg/eventbus"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/store"
 	mongostore "github.com/SocialGouv/iterion/pkg/store/mongo"
+	"github.com/SocialGouv/iterion/pkg/trigger"
 )
 
 // The sweeper is the half of the retry that can lose a run: it claims,
@@ -270,6 +272,45 @@ func TestSweepDueRetries_UnresolvableSourceAbandons(t *testing.T) {
 	}
 	if _, ok := st.rearmed["run-a"]; ok {
 		t.Error("a permanently unresolvable run must not be re-armed")
+	}
+}
+
+// Abandoning is the moment a run becomes permanently dead — its terminal event
+// fired while a retry was still armed, so consumers that defer to an armed
+// retry (the merge-gate reconciler foremost) stood down and nothing else ever
+// fires for it. The abandon must therefore republish the run outcome, or a
+// gating run whose retries die here leaves its required check absent forever.
+func TestSweepDueRetries_AbandonRepublishesTheRunOutcome(t *testing.T) {
+	st := newFakeRetryStore()
+	st.claimWins["run-a"] = true
+	resumer := &fakeResumer{}
+	s := newRetrySweeperServer(t, st, resumer)
+	s.cfg.Mode = "cloud"
+
+	bus := eventbus.NewInProcBus(nil)
+	s.cfg.EventsBus = bus
+	got := make(chan trigger.Event, 1)
+	if _, err := bus.Subscribe("probe", trigger.Matcher{
+		Sources: []trigger.Source{trigger.SourceRun},
+		Kinds:   []string{trigger.KindRunFailed},
+	}, func(_ context.Context, ev trigger.Event) error {
+		got <- ev
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ref := dueRef("run-a", time.Now().UTC().Add(-time.Minute))
+	ref.FilePath = "bots/deleted-bot/main.bot" // unresolvable → abandon
+	s.sweepDueRetries(context.Background(), &fakeRetryLister{refs: []mongostore.RetryDueRef{ref}}, resumer, time.Now().UTC())
+
+	select {
+	case ev := <-got:
+		if ev.Subject.ID != "run-a" {
+			t.Errorf("republished outcome for %q, want run-a", ev.Subject.ID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no run outcome republished on abandon — the reconciler never learns the run is permanently dead")
 	}
 }
 


### PR DESCRIPTION
## Why

The 2026-08-03 Dependabot batch exposed the gap end-to-end on this very repo: Vetty's run for #354 (go group, MCP SDK alignment needed) hit a provider usage window, auto-retried (✓), then died on its own 40m duration budget — `failed_resumable`, which nothing ever resumes for a budget failure. The gate reconciler deliberately skipped `failed_resumable`, so `revi/review` (a REQUIRED check) never appeared and #354 has been silently unmergeable since. Meanwhile #353/#355 sat audited-green but unmerged: `arm_automerge` direct-merges when the forge reports CLEAN, which a merge-queue base rejects outright.

## What

**Engine (pkg/server):**
- The reconciler skips `failed_resumable` ONLY when a retry is actually armed (`RetryState.RetryAfter` non-nil — persisted before the outcome event fires). Budget-exceeded / exhausted / plain-failed runs are reconciled: synthetic `failure` carrying the run's error reason.
- New relaunch lane: after posting the failure, the same bot is re-run on the same PR through the shared webhook tail — **once per (PR, head sha), ever** (idempotency claim); hold-label veto fails closed.
- When the one relaunch is spent and the gate dies again (or the relaunch cannot start), a deduped `source:gate-reconcile` board card names the dead runs, reason and remedy.
- The autofix lane ignores synthetic `review died` failures (no findings to fix — the relaunch lane re-runs the REVIEWER) and applies the same armed-retry distinction.
- The retry sweeper republishes the run outcome when it permanently abandons a retry, so gate consumers that stood down on the armed retry fire then.

**Bot (dep-update-guard 2.6.0):**
- `arm_automerge` arms FIRST ("merge when ready" on queue repos); a queue refusal falls back to `enqueuePullRequest` pinned to the audited sha; only a no-queue clean-status refusal takes the pinned direct merge.
- Budget 40m/$15 → 75m/$20 (the clean npm re-audit already runs ~30m; the 15-module go case died mid-audit).

## Review

Adversarial review (opus) confirmed 2 defects, both fixed in the last commit: the reconciler stood down on its own synthetic failure (making the second-death board escalation unreachable), and the sweeper republished on a failed abandon write.

## Test

`task check` green (reconcile/relaunch/autofix/sweeper suites extended; automerge stub covers queue-CLEAN→enqueue-pinned, no-queue-CLEAN→merge-pinned, moved-head refusals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)