### PR TITLE
fix(server): relaunch claim is per-bot; rune-safe reason truncation

### DIFF
--- a/pkg/server/forge_gate_reconcile.go
+++ b/pkg/server/forge_gate_reconcile.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/SocialGouv/iterion/pkg/eventbus"
 	"github.com/SocialGouv/iterion/pkg/forge"
@@ -49,9 +50,17 @@ func gateInterruptedDescriptionFor(run *store.Run) string {
 	if reason == "" {
 		return gateInterruptedDescription
 	}
+	// Truncate on a rune boundary: run.Error routinely carries provider prose
+	// (accents, ellipses), and a raw byte slice can split a multi-byte rune
+	// into invalid UTF-8 that some forges reject with a 422 — turning a long
+	// reason into no synthetic status at all.
 	const maxReason = 60
 	if len(reason) > maxReason {
-		reason = reason[:maxReason-1] + "…"
+		cut := maxReason - 1
+		for cut > 0 && !utf8.RuneStart(reason[cut]) {
+			cut--
+		}
+		reason = reason[:cut] + "…"
 	}
 	return gateDiedDescriptionPrefix + reason + ") — push again or comment the bot's command to re-run"
 }

--- a/pkg/server/forge_gate_reconcile_test.go
+++ b/pkg/server/forge_gate_reconcile_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/SocialGouv/iterion/pkg/forge"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -286,6 +287,23 @@ func TestGateReconcile_FailedResumable(t *testing.T) {
 			t.Fatalf("posted %d statuses, want 1 — an abandoned retry never comes back", gc.setCalls)
 		}
 	})
+}
+
+// A long reason is truncated on a RUNE boundary: provider prose carries
+// accents, and invalid UTF-8 in a status description is a forge 422 — a long
+// reason must never cost the synthetic status itself.
+func TestGateReconcile_ReasonTruncationIsRuneSafe(t *testing.T) {
+	long := "budget exceeded: durée écoulée éééééééééééééééééééééééé — provider était injoignable pendant la fenêtre"
+	got := gateInterruptedDescriptionFor(&store.Run{Error: long})
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncated description is not valid UTF-8: %q", got)
+	}
+	if !strings.HasPrefix(got, gateDiedDescriptionPrefix) || !strings.Contains(got, "…") {
+		t.Errorf("unexpected shape: %q", got)
+	}
+	if !isSyntheticGateInterruption(got) {
+		t.Errorf("truncated description no longer recognized as synthetic: %q", got)
+	}
 }
 
 // The synthetic marker must be recognized in both its shapes and must never

--- a/pkg/server/forge_gate_relaunch.go
+++ b/pkg/server/forge_gate_relaunch.go
@@ -135,10 +135,15 @@ func (s *Server) relaunchDeadGateRun(ctx context.Context, d deadGateRun) {
 		SubjectURL:  d.prURL,
 		SubjectSHA:  d.pr.HeadSHA,
 	}
-	// One relaunch per (team, repo, PR, head) — EVER. A second death on the
-	// same head replays as a duplicate of this key, which is the signal that
-	// automation is out of moves for this revision.
-	idem := knowledge.ChecksumHex([]byte(fmt.Sprintf("gaterelaunch|%s|%s|%d|%s", d.grant.TeamID, d.repo, d.number, d.pr.HeadSHA)))
+	// One relaunch per (team, repo, PR, head, BOT) — EVER. A second death of
+	// the same bot on the same head replays as a duplicate of this key, which
+	// is the signal that automation is out of moves for this revision. The
+	// bot id is part of the key because a repo's gate context is shared and
+	// the publish grant is minted for ANY bot launched with a pr_url: two
+	// different gating bots dying on one head are two independent recoveries,
+	// and folding them onto one key would deny the second its relaunch while
+	// filing a board card that names the wrong run.
+	idem := knowledge.ChecksumHex([]byte(fmt.Sprintf("gaterelaunch|%s|%s|%d|%s|%s", d.grant.TeamID, d.repo, d.number, d.pr.HeadSHA, botID)))
 	res := s.launchWebhookTarget(launchCtx, nil, cfg, meta, forgeLaunchTarget{
 		BotID:   botID,
 		IdemKey: idem,

--- a/pkg/server/forge_gate_relaunch_test.go
+++ b/pkg/server/forge_gate_relaunch_test.go
@@ -121,7 +121,9 @@ func TestGateRelaunch(t *testing.T) {
 		}
 		return run.ID
 	}
-	relaunchIdem := knowledge.ChecksumHex([]byte("gaterelaunch|" + team + "|" + repo + "|7|" + head))
+	// The bot id is part of the claim key: two gating bots on one head are two
+	// independent recoveries.
+	relaunchIdem := knowledge.ChecksumHex([]byte("gaterelaunch|" + team + "|" + repo + "|7|" + head + "|" + botID))
 
 	t.Run("a dead gating run posts its failure and is relaunched once", func(t *testing.T) {
 		w := build(t, nil)


### PR DESCRIPTION
Follow-ups from Revi's review of #357 — the two findings kept as real:

- **R41df5e**: the relaunch idempotency key now includes the bot id — a repo's gate context is shared, so two gating bots dying on one head are two independent recoveries; one key denied the second its relaunch and filed a board card naming the wrong run.
- **R60c7c8**: the synthetic-status reason truncates on a rune boundary — invalid UTF-8 in a status description is a forge 422, and a long reason must never cost the synthetic status itself.

The other two findings are answered with reasons on #357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)