### PR TITLE
fix(studio): file in-progress pipeline tickets as done when their run finishes

### DIFF
--- a/pkg/server/pipeline_admission.go
+++ b/pkg/server/pipeline_admission.go
@@ -85,6 +85,12 @@ func (s *Server) admitReadyPipelines() {
 		s.logger.Warn("pipeline admission: list tickets: %v", err)
 		return
 	}
+	// File tickets whose run finished while nobody was watching BEFORE
+	// computing the ready set. SetState(done) cascades the waiting_deps
+	// promotion of satisfied dependents — an auto_ready dependent unblocked
+	// here becomes launchable on the next tick (this tick's `issues` view is
+	// already stale for it).
+	s.reconcileFinishedTickets(context.Background(), board, runs.RunStore(), issues)
 	ready := make([]*native.Issue, 0)
 	for _, iss := range issues {
 		if iss == nil {
@@ -186,6 +192,40 @@ func pipelineTicketLaunchable(ctx context.Context, rs store.RunStore, iss *nativ
 	default:
 		// failed / failed_resumable / cancelled → retry-able.
 		return true
+	}
+}
+
+// reconcileFinishedTickets files tickets whose last run reached a clean
+// finish into done. launchTicketNow moves a ticket to in_progress at launch
+// and nothing ever moves it out: the run's terminal status drives the
+// /pipelines column, but the TICKET state is what hard blockers count
+// (native.BlockerSatisfied accepts only done) — so without this sweep a
+// finished ticket strands in in_progress forever and every dependent parks
+// in waiting_deps. Mirrors the cloud board dispatcher's processCard
+// (success → doneState) and the local dispatcher's finishRun. Only a clean
+// finish closes the ticket: failed/cancelled runs stay with the operator
+// (needs-attention retry, or close), and an unreadable run record is left
+// alone (best-effort).
+func (s *Server) reconcileFinishedTickets(ctx context.Context, board native.BoardStore, rs store.RunStore, issues []*native.Issue) {
+	if rs == nil {
+		return
+	}
+	for _, iss := range issues {
+		if iss == nil || iss.State != native.StateInProgress || iss.LastRunID == "" {
+			continue
+		}
+		r, err := rs.LoadRun(ctx, iss.LastRunID)
+		if err != nil || r == nil {
+			continue
+		}
+		if r.Status != store.RunStatusFinished {
+			continue
+		}
+		if _, err := board.SetState(iss.ID, native.StateDone); err != nil {
+			s.logger.Warn("pipeline admission: file finished ticket %s (run %s): %v", iss.ID, iss.LastRunID, err)
+			continue
+		}
+		s.logger.Info("pipeline admission: ticket %s finished cleanly (run %s) — filed as done", iss.ID, iss.LastRunID)
 	}
 }
 

--- a/pkg/server/pipeline_admission_sweep_test.go
+++ b/pkg/server/pipeline_admission_sweep_test.go
@@ -1,0 +1,128 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// The admission loop owns the full lifecycle of the tickets it launches:
+// launchTicketNow moves a ticket to in_progress, and reconcileFinishedTickets
+// must file it into done once its run finishes cleanly. Without that second
+// half the ticket strands in in_progress forever and every dependent parks in
+// waiting_deps — native.BlockerSatisfied counts ONLY done. These tests pin
+// the sweep's contract against a real filesystem board.
+
+// fakeSweepRunStore serves LoadRun from a map; everything else is unreachable
+// in these tests (nil via the embedded interface).
+type fakeSweepRunStore struct {
+	store.RunStore
+	runs map[string]*store.Run
+}
+
+func (f *fakeSweepRunStore) LoadRun(_ context.Context, id string) (*store.Run, error) {
+	r, ok := f.runs[id]
+	if !ok {
+		return nil, fmt.Errorf("run %s not found", id)
+	}
+	return r, nil
+}
+
+func newSweepTestServer() *Server {
+	return &Server{logger: iterlog.New(iterlog.LevelError, nil)}
+}
+
+func TestReconcileFinishedTickets_FilesDoneAndUnblocksDependents(t *testing.T) {
+	board, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocker, _ := board.Create(native.Issue{Title: "epic", State: native.StateInProgress, Bot: "town-dev"})
+	dependent, _ := board.Create(native.Issue{
+		Title: "next epic", State: native.StateWaitingDeps, Bot: "town-dev",
+		Blockers: []string{blocker.ID},
+	})
+	if err := board.SetLastRun(blocker.ID, "run-1", ""); err != nil {
+		t.Fatal(err)
+	}
+	rs := &fakeSweepRunStore{runs: map[string]*store.Run{
+		"run-1": {ID: "run-1", Status: store.RunStatusFinished},
+	}}
+
+	issues, err := board.List(native.ListFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newSweepTestServer().reconcileFinishedTickets(context.Background(), board, rs, issues)
+
+	got, _ := board.Get(blocker.ID)
+	if got.State != native.StateDone {
+		t.Fatalf("finished ticket state = %q, want done", got.State)
+	}
+	// SetState(done) must cascade: the satisfied dependent leaves waiting_deps.
+	dep, _ := board.Get(dependent.ID)
+	if dep.State != native.StateBacklog {
+		t.Fatalf("dependent state = %q, want backlog (auto-promoted)", dep.State)
+	}
+}
+
+func TestReconcileFinishedTickets_LeavesNonFinishedRuns(t *testing.T) {
+	statuses := map[string]store.RunStatus{
+		"run-running":   store.RunStatusRunning,
+		"run-paused":    store.RunStatusPausedWaitingHuman,
+		"run-failed":    store.RunStatusFailed,
+		"run-resumable": store.RunStatusFailedResumable,
+		"run-cancelled": store.RunStatusCancelled,
+	}
+	for runID, st := range statuses {
+		t.Run(string(st), func(t *testing.T) {
+			board, err := native.NewStore(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			iss, _ := board.Create(native.Issue{Title: "epic", State: native.StateInProgress, Bot: "town-dev"})
+			if err := board.SetLastRun(iss.ID, runID, ""); err != nil {
+				t.Fatal(err)
+			}
+			rs := &fakeSweepRunStore{runs: map[string]*store.Run{
+				runID: {ID: runID, Status: st},
+			}}
+			issues, _ := board.List(native.ListFilter{})
+			newSweepTestServer().reconcileFinishedTickets(context.Background(), board, rs, issues)
+
+			got, _ := board.Get(iss.ID)
+			if got.State != native.StateInProgress {
+				t.Fatalf("status %s: ticket state = %q, want in_progress (operator-owned)", st, got.State)
+			}
+		})
+	}
+}
+
+func TestReconcileFinishedTickets_SkipsUnlinkedAndMissingRuns(t *testing.T) {
+	board, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// In-progress but never launched: no last run to consult.
+	noRun, _ := board.Create(native.Issue{Title: "manual", State: native.StateInProgress, Bot: "town-dev"})
+	// Linked to a run record the store can no longer serve.
+	gone, _ := board.Create(native.Issue{Title: "stale link", State: native.StateInProgress, Bot: "town-dev"})
+	if err := board.SetLastRun(gone.ID, "run-vanished", ""); err != nil {
+		t.Fatal(err)
+	}
+	rs := &fakeSweepRunStore{runs: map[string]*store.Run{}}
+
+	issues, _ := board.List(native.ListFilter{})
+	newSweepTestServer().reconcileFinishedTickets(context.Background(), board, rs, issues)
+
+	for _, id := range []string{noRun.ID, gone.ID} {
+		got, _ := board.Get(id)
+		if got.State != native.StateInProgress {
+			t.Fatalf("ticket %s state = %q, want in_progress (best-effort skip)", id, got.State)
+		}
+	}
+}


### PR DESCRIPTION
## Problème

La boucle d'admission du studio (`launchTicketNow`) passe un ticket lancé en `in_progress` et pose `last_run_id`… puis plus rien ne fait sortir le ticket de cet état. Le statut du run pilote bien la colonne affichée sur `/pipelines` (un run `finished` apparaît en succès dans `closed`), mais les dépendances dures ne regardent que l'état du **ticket** : `native.BlockerSatisfied` n'accepte que `done`.

Conséquence observée en production locale : un run terminé avec succès (gate humain accepté inclus) laisse sa carte en `in_progress` indéfiniment, et toutes les cartes dépendantes restent en `waiting_deps` — affichées « blocked » sur `/pipelines` — sans qu'aucune action automatique ne les libère. Seule une transition manuelle (`iterion issue move --to done` ou drag sur `/board`) débloquait la chaîne.

## Correctif

`admitReadyPipelines` exécute désormais un sweep (`reconcileFinishedTickets`) avant de calculer l'ensemble des tickets prêts : tout ticket `in_progress` dont le dernier run est `finished` est basculé en `done` via `SetState`, ce qui déclenche la cascade existante de promotion `waiting_deps → backlog/ready` des dépendants satisfaits.

Choix délibérés :

- **Seul un run `finished` ferme le ticket** : les runs `failed` / `failed_resumable` / `cancelled` restent à la main de l'opérateur (lane needs-attention, retry ou close) — aucun changement de comportement sur les échecs.
- **Lecture du run best-effort** : un enregistrement illisible ou disparu laisse le ticket en place.
- Le sweep partage les gates de la boucle d'admission : il s'efface quand un dispatcher externe (`iterion dispatch`) possède le board, qui a déjà sa propre mécanique de fin de run.
- Sémantique alignée sur le cloud (`processCard` : succès → `doneState`) et sur le dispatcher local (`finishRun`).

Le sweep est idempotent et tourne au rythme de la boucle (2 s), donc il couvre aussi le rattrapage après un redémarrage du studio survenu entre la fin du run et la transition manquée.

## Tests

Nouveaux tests dans `pkg/server/pipeline_admission_sweep_test.go` (board filesystem réel) :

- ticket `in_progress` + run `finished` → `done`, et le dépendant en `waiting_deps` est auto-promu en `backlog` ;
- runs `running` / `paused_waiting_human` / `failed` / `failed_resumable` / `cancelled` → le ticket reste `in_progress` ;
- ticket sans `last_run_id` ou run illisible → ignoré.

`go vet` + `go test ./pkg/server/` : verts.