### PR TITLE
fix(credpool): a donated credential must reach the agent, and be accounted for

### DIFF
--- a/docs/credential-pool.md
+++ b/docs/credential-pool.md
@@ -283,6 +283,23 @@ A donor's credential is never returned by any of these — it stays sealed in
   guard only covers `claw`/`pi` (`secrets.GuardSubscriptionOAuth`); a lent
   Claude forfait still works on `claude_code`, which is its native path.
   Correct, and worth knowing before you conclude the pool is off.
+- **A donation must survive the sandbox boundary.** A lent credential is
+  materialised as a FILE on the runner, and the kubernetes driver has no
+  host filesystem to bind-mount it from — so it is delivered as a file
+  secret and seeded into `CODEX_HOME` / `CLAUDE_CONFIG_DIR` inside the
+  container, and the sandboxed claw runner is handed the run's own keys
+  rather than the pod's. Before that, a pool-served run took its donor's
+  lease and then quietly spent the PLATFORM's ambient `OPENAI_API_KEY`
+  instead; wherever that key works, the substitution is invisible and
+  every donor's ledger reads $0 forever. Guarded by
+  `TestForwardableProviderEnv_runCredentialsBeatTheAmbientOnes` and
+  `TestAddCodexOAuthSecretFile`.
+- **An auth failure can be absorbed by recovery.** A rejected credential
+  usually becomes a human pause, so by report time the error says only
+  "paused" — the donor would never be parked and their dead credential
+  would stay first in the rotation, pausing run after run at a run unit
+  each. The runner watches the engine's own `node_recovery` classification
+  for this.
 - **The spend signal must be live.** Delegate backends only report cost
   because `DelegateInfo.CostUSD` rides the `delegate_finished` event into
   the runner's per-run totals. If a future change drops that field, every

--- a/pkg/backend/model/claw_backend.go
+++ b/pkg/backend/model/claw_backend.go
@@ -1019,6 +1019,10 @@ var providerCredentialEnvVars = []string{
 	// from ZAI_API_KEY when no other anthropic auth is present;
 	// ANTHROPIC_AUTH_TOKEN/ANTHROPIC_BASE_URL cover the explicit BYOK path.
 	"ZAI_API_KEY",
+	// xai's provider reads XAI_API_KEY from env, so this is the only
+	// channel into the container — and the pool can grant a donated xai
+	// key, which is METERED and billed to its lender.
+	"XAI_API_KEY",
 	"ANTHROPIC_AUTH_TOKEN",
 	"ANTHROPIC_BASE_URL",
 	"GEMINI_API_KEY",
@@ -1051,6 +1055,7 @@ var byokEnvVar = map[secrets.Provider]string{
 	secrets.ProviderAnthropic: "ANTHROPIC_API_KEY",
 	secrets.ProviderAzure:     "AZURE_OPENAI_API_KEY",
 	secrets.ProviderZAI:       "ZAI_API_KEY",
+	secrets.ProviderXAI:       "XAI_API_KEY",
 }
 
 // forwardableProviderEnv builds the env map ClawBackend hands to
@@ -1095,7 +1100,15 @@ func forwardableProviderEnv(ctx context.Context) map[string]string {
 	// THIS RUN.
 	if creds.OAuthDir(string(secrets.OAuthKindCodex)) != "" {
 		env["CODEX_HOME"] = secrets.CodexSandboxConfigDir
-		env["ITERION_OPENAI_USE_OAUTH"] = "1"
+		// Forced ONLY when the run resolved no OpenAI key of its own. A
+		// tenant can hold both a BYOK key and a connected forfait, and the
+		// host resolver spends the KEY in that case — forcing here would
+		// make the same run spend the opposite instrument depending on
+		// whether it happened to be sandboxed, quietly draining a
+		// subscription the tenant did not choose to use.
+		if creds.APIKeys[secrets.ProviderOpenAI] == "" {
+			env["ITERION_OPENAI_USE_OAUTH"] = "1"
+		}
 	}
 	return env
 }

--- a/pkg/backend/model/claw_backend.go
+++ b/pkg/backend/model/claw_backend.go
@@ -1106,7 +1106,10 @@ func forwardableProviderEnv(ctx context.Context) map[string]string {
 		// make the same run spend the opposite instrument depending on
 		// whether it happened to be sandboxed, quietly draining a
 		// subscription the tenant did not choose to use.
-		if creds.APIKeys[secrets.ProviderOpenAI] == "" {
+		// …and never against the operator's explicit kill switch:
+		// ITERION_OPENAI_USE_OAUTH=0 is a machine-wide refusal to spend any
+		// subscription, which a per-run credential does not get to overrule.
+		if creds.APIKeys[secrets.ProviderOpenAI] == "" && os.Getenv("ITERION_OPENAI_USE_OAUTH") != "0" {
 			env["ITERION_OPENAI_USE_OAUTH"] = "1"
 		}
 	}

--- a/pkg/backend/model/claw_backend.go
+++ b/pkg/backend/model/claw_backend.go
@@ -898,7 +898,7 @@ func (b *ClawBackend) executeViaSandboxRunner(ctx context.Context, task delegate
 	// finds nothing and bails with "API key required for OpenAI-
 	// compatible provider". Pass through only the keys we know
 	// providers consume: anything else stays on the host.
-	runnerEnv := forwardableProviderEnv()
+	runnerEnv := forwardableProviderEnv(ctx)
 	cmd := run.Command(ctx, []string{"iterion", "__claw-runner"}, sandbox.ExecOpts{
 		KeepStdinOpen: true,
 		Env:           runnerEnv,
@@ -1043,17 +1043,59 @@ var providerCredentialEnvVars = []string{
 	"ANTHROPIC_CUSTOM_HEADERS",
 }
 
+// byokEnvVar names the environment variable claw's registry reads for a
+// provider's key inside the container. A provider absent here has no
+// env-based BYOK path, so a tenant key for it cannot be forwarded.
+var byokEnvVar = map[secrets.Provider]string{
+	secrets.ProviderOpenAI:    "OPENAI_API_KEY",
+	secrets.ProviderAnthropic: "ANTHROPIC_API_KEY",
+	secrets.ProviderAzure:     "AZURE_OPENAI_API_KEY",
+	secrets.ProviderZAI:       "ZAI_API_KEY",
+}
+
 // forwardableProviderEnv builds the env map ClawBackend hands to
 // sandbox.Run.Command so the in-container runner can reach the same
 // provider APIs as the host. Empty entries are skipped — we never
 // inject a name=<empty> pair, since some providers treat that as
 // "auth attempted but invalid" instead of "no auth".
-func forwardableProviderEnv() map[string]string {
+//
+// The RUN's own resolved credentials override the ambient ones. Inside
+// the container the runner rebuilds its registry from env alone — ctx
+// never crosses the process boundary — so without this a sandboxed node
+// silently authenticates as the HOST: a tenant's BYOK key is ignored in
+// favour of the pod's platform key, and a lent subscription is bypassed
+// entirely while its donor's lease has already been taken. The failure is
+// invisible whenever the ambient key happens to work, which is the worst
+// possible shape for a billing boundary.
+func forwardableProviderEnv(ctx context.Context) map[string]string {
 	env := map[string]string{}
 	for _, name := range providerCredentialEnvVars {
 		if v := os.Getenv(name); v != "" {
 			env[name] = v
 		}
+	}
+	creds, ok := secrets.CredentialsFromContext(ctx)
+	if !ok {
+		return env
+	}
+	for provider, key := range creds.APIKeys {
+		if key == "" {
+			continue
+		}
+		if name := byokEnvVar[provider]; name != "" {
+			env[name] = key
+		}
+	}
+	// A resolved ChatGPT forfait (the tenant's own, or one lent through the
+	// credential pool) is delivered into the sandbox as a file by
+	// runtime.addCodexOAuthSecretFile. Point the in-container runner at it
+	// and force the OAuth path: the ambient OPENAI_API_KEY would otherwise
+	// win by the documented "an explicit env key is deliberate" rule, which
+	// is true of a machine default and false of a credential resolved FOR
+	// THIS RUN.
+	if creds.OAuthDir(string(secrets.OAuthKindCodex)) != "" {
+		env["CODEX_HOME"] = secrets.CodexSandboxConfigDir
+		env["ITERION_OPENAI_USE_OAUTH"] = "1"
 	}
 	return env
 }

--- a/pkg/backend/model/claw_sandbox_env_test.go
+++ b/pkg/backend/model/claw_sandbox_env_test.go
@@ -1,0 +1,71 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+// Inside the sandbox the claw runner rebuilds its registry from ENV alone —
+// ctx does not cross a process boundary. So whatever forwardableProviderEnv
+// omits, the node authenticates without.
+//
+// Measured on prod before this: a pool-served run (019fcc09) reached the
+// pod with its donated ChatGPT credential materialised, then spent the
+// PLATFORM's OPENAI_API_KEY instead, because only ambient env crossed. The
+// donor's lease had already been taken. Whenever the ambient key happens to
+// work, that substitution is completely invisible — which is the worst
+// possible shape for a billing boundary.
+func TestForwardableProviderEnv_runCredentialsBeatTheAmbientOnes(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "platform-key")
+	t.Setenv("ANTHROPIC_API_KEY", "platform-anthropic")
+
+	t.Run("no credentials in ctx leaves the ambient env alone", func(t *testing.T) {
+		env := forwardableProviderEnv(context.Background())
+		if env["OPENAI_API_KEY"] != "platform-key" {
+			t.Errorf("OPENAI_API_KEY = %q, want the ambient value passed through", env["OPENAI_API_KEY"])
+		}
+		if _, ok := env["CODEX_HOME"]; ok {
+			t.Error("CODEX_HOME set with no resolved forfait")
+		}
+	})
+
+	t.Run("a tenant's BYOK key overrides the platform's", func(t *testing.T) {
+		ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+			APIKeys: map[secrets.Provider]string{secrets.ProviderOpenAI: "tenant-key"},
+		})
+		env := forwardableProviderEnv(ctx)
+		if env["OPENAI_API_KEY"] != "tenant-key" {
+			t.Errorf("OPENAI_API_KEY = %q, want the tenant's own key — a sandboxed node billed the platform instead", env["OPENAI_API_KEY"])
+		}
+		// Providers the run resolved nothing for keep the ambient value:
+		// the run is not asserting anything about them.
+		if env["ANTHROPIC_API_KEY"] != "platform-anthropic" {
+			t.Errorf("ANTHROPIC_API_KEY = %q, want the ambient value untouched", env["ANTHROPIC_API_KEY"])
+		}
+	})
+
+	t.Run("a resolved ChatGPT forfait wins over an ambient key", func(t *testing.T) {
+		ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+			OAuthCredentialFiles: map[string]string{string(secrets.OAuthKindCodex): "/host/tmp/whatever"},
+		})
+		env := forwardableProviderEnv(ctx)
+		if env["CODEX_HOME"] != secrets.CodexSandboxConfigDir {
+			t.Errorf("CODEX_HOME = %q, want the in-sandbox seeded dir (the HOST path does not exist in the container)", env["CODEX_HOME"])
+		}
+		if env["ITERION_OPENAI_USE_OAUTH"] != "1" {
+			t.Error("the forfait must be forced: an ambient OPENAI_API_KEY would otherwise win by the " +
+				"\"an explicit env key is deliberate\" rule, which is true of a machine default and false of a per-run credential")
+		}
+	})
+
+	t.Run("an empty resolved key never blanks the ambient one", func(t *testing.T) {
+		ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+			APIKeys: map[secrets.Provider]string{secrets.ProviderOpenAI: ""},
+		})
+		if got := forwardableProviderEnv(ctx)["OPENAI_API_KEY"]; got != "platform-key" {
+			t.Errorf("OPENAI_API_KEY = %q — an absent resolution must not read as 'authenticate with nothing'", got)
+		}
+	})
+}

--- a/pkg/credpool/broker.go
+++ b/pkg/credpool/broker.go
@@ -517,7 +517,9 @@ func (b *Broker) supersedeOpenLeases(ctx context.Context, runID string, now time
 		return
 	}
 	for _, l := range open {
-		if _, cerr := b.leases.Close(ctx, l.ID, l.CostUSD, OutcomeSuperseded, now); cerr != nil {
+		// Zero, not l.CostUSD: Close ADDS, and whatever this lease already
+		// carries was recorded when it was charged.
+		if _, cerr := b.leases.Close(ctx, l.ID, 0, OutcomeSuperseded, now); cerr != nil {
 			b.logger.Warn("credpool: could not supersede lease %s of run %s: %v", l.ID, runID, cerr)
 		}
 	}
@@ -644,6 +646,12 @@ func (b *Broker) Report(ctx context.Context, runID string, out Outcome) error {
 	// while their ledger recorded a single attempt. Charge now; the
 	// attempt that finally settles the run closes.
 	if out.Interim {
+		// Onto the lease as well as the ledger: the lease IS the donor's
+		// audit trail, and a redelivered run whose trail showed only the
+		// last attempt would contradict the ceilings it was charged against.
+		if err := b.leases.AddCost(ctx, lease.ID, out.CostUSD); err != nil {
+			b.logger.Warn("credpool: could not record the interim spend of run %s on lease %s: %v", runID, lease.ID, err)
+		}
 		return b.chargeAndReact(ctx, lease, out, now, runID)
 	}
 

--- a/pkg/credpool/broker.go
+++ b/pkg/credpool/broker.go
@@ -586,6 +586,13 @@ type Outcome struct {
 	// could parse one from ConditionUsageWindow. Zero falls back to a
 	// bounded blind wait.
 	CooldownUntil time.Time
+	// Interim marks an attempt that spent the credential but does NOT
+	// settle the run: the queue will redeliver the same sealed bundle, so
+	// the next attempt executes on the same lease. The spend is charged,
+	// the lease stays open. Without it a flapping backend could run a
+	// contributor's subscription once per delivery while their ledger
+	// recorded one attempt — and their ceilings would never see the rest.
+	Interim bool
 }
 
 // Condition is the part of an attempt's outcome that changes a donor's
@@ -629,6 +636,17 @@ func (b *Broker) Report(ctx context.Context, runID string, out Outcome) error {
 		outcome = string(ConditionAuthFailed)
 	}
 
+	// An INTERIM report: this attempt spent the donor's credential but the
+	// run keeps the same lease, because the queue will redeliver the very
+	// same sealed bundle to another pod. Closing here would make every
+	// redelivered attempt's spend invisible — no open lease left to report
+	// against — so a run could burn a contributor's quota once per delivery
+	// while their ledger recorded a single attempt. Charge now; the
+	// attempt that finally settles the run closes.
+	if out.Interim {
+		return b.chargeAndReact(ctx, lease, out, now, runID)
+	}
+
 	// Close FIRST, and charge only if this call is the one that closed it.
 	// A run can be reported twice — a redelivery whose first pod was merely
 	// slow, a cancel racing a finish — and reading "still open" then
@@ -645,6 +663,13 @@ func (b *Broker) Report(ctx context.Context, runID string, out Outcome) error {
 		return nil // another report got there first; it did the charging
 	}
 
+	return b.chargeAndReact(ctx, lease, out, now, runID)
+}
+
+// chargeAndReact debits the donor for what an attempt consumed and applies
+// what that attempt says about their credential. Shared by the closing and
+// interim report paths.
+func (b *Broker) chargeAndReact(ctx context.Context, lease Lease, out Outcome, now time.Time, runID string) error {
 	if out.CostUSD > 0 || out.InputTokens > 0 || out.OutputTokens > 0 {
 		// Charged against the lease's ACQUISITION instant, not now: a run
 		// that starts at 23:50 and ends at 00:10 must debit the day whose

--- a/pkg/credpool/broker_integrity_test.go
+++ b/pkg/credpool/broker_integrity_test.go
@@ -703,3 +703,57 @@ func TestAcquire_lentKeyIsReadableFromAnotherTenant(t *testing.T) {
 		t.Errorf("the donor's pledge was parked as %q by a successful draw", fresh.Health)
 	}
 }
+
+// A run whose attempt is redelivered keeps its lease: the queue hands the
+// SAME sealed bundle to the next pod, so the donor's credential runs
+// again. Closing on the first attempt made every later one invisible —
+// nothing left open to report against — so a flapping backend could spend
+// a contributor's subscription once per delivery while their ledger
+// recorded a single attempt.
+func TestReport_interimAttemptChargesButKeepsTheLeaseOpen(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxUSDPerDay: 10})
+
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	// Attempt 1 dies transiently and will be redelivered.
+	if err := h.broker.Report(ctx, "run-1", Outcome{CostUSD: 2, Interim: true}); err != nil {
+		t.Fatalf("interim Report: %v", err)
+	}
+	// Attempt 2 runs on the same bundle, spends more, and settles the run.
+	if err := h.broker.Report(ctx, "run-1", Outcome{CostUSD: 3}); err != nil {
+		t.Fatalf("closing Report: %v", err)
+	}
+
+	day, _, _ := h.ledger.Usage(ctx, PledgeID("alice", SourceOAuth, "claude_code"), h.now)
+	if day.CostUSD != 5 {
+		t.Errorf("donor charged $%v, want $5 — the redelivered attempt spent their credential unmetered", day.CostUSD)
+	}
+	open, err := h.leases.ListOpenByRun(ctx, "run-1")
+	if err != nil {
+		t.Fatalf("leases: %v", err)
+	}
+	if len(open) != 0 {
+		t.Errorf("%d lease(s) still open after the settling report", len(open))
+	}
+}
+
+// An interim report must not free the donor's slot either: the run is
+// still theirs until something settles it.
+func TestReport_interimAttemptStillHoldsTheDonorsSlot(t *testing.T) {
+	h := newHarness(t)
+	ctx := context.Background()
+	h.donor(t, "alice", Limits{MaxConcurrentRuns: 1})
+
+	if _, err := h.broker.Acquire(ctx, h.request("run-1")); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := h.broker.Report(ctx, "run-1", Outcome{CostUSD: 1, Interim: true}); err != nil {
+		t.Fatalf("interim Report: %v", err)
+	}
+	if _, err := h.broker.Acquire(ctx, h.request("run-2")); !errors.Is(err, ErrNoDonor) {
+		t.Errorf("a second run took the slot a redelivering run still holds: %v", err)
+	}
+}

--- a/pkg/credpool/broker_integrity_test.go
+++ b/pkg/credpool/broker_integrity_test.go
@@ -738,6 +738,15 @@ func TestReport_interimAttemptChargesButKeepsTheLeaseOpen(t *testing.T) {
 	if len(open) != 0 {
 		t.Errorf("%d lease(s) still open after the settling report", len(open))
 	}
+	// The lease is the donor's audit trail; it must agree with the ledger.
+	hist, err := h.leases.ListByDonor(ctx, "alice", 10)
+	if err != nil || len(hist) != 1 {
+		t.Fatalf("donor history = (%d, %v), want 1 lease", len(hist), err)
+	}
+	if hist[0].CostUSD != 5 {
+		t.Errorf("the donor's record of the run reads $%v, want $5 — it under-reports what their ledger was charged",
+			hist[0].CostUSD)
+	}
 }
 
 // An interim report must not free the donor's slot either: the run is

--- a/pkg/credpool/memory.go
+++ b/pkg/credpool/memory.go
@@ -229,12 +229,24 @@ func (s *MemoryLeaseStore) Close(_ context.Context, leaseID string, costUSD floa
 		return false, nil
 	}
 	l.Closed = true
-	l.CostUSD = costUSD
+	l.CostUSD += costUSD
 	l.Outcome = outcome
 	t := when.UTC()
 	l.ClosedAt = &t
 	s.m[leaseID] = l
 	return true, nil
+}
+
+func (s *MemoryLeaseStore) AddCost(_ context.Context, leaseID string, costUSD float64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	l, ok := s.m[leaseID]
+	if !ok {
+		return ErrNotFound
+	}
+	l.CostUSD += costUSD
+	s.m[leaseID] = l
+	return nil
 }
 
 func (s *MemoryLeaseStore) LiveCommitment(_ context.Context, pledgeID, excludeRunID string, now time.Time) (int, float64, error) {

--- a/pkg/credpool/mongo.go
+++ b/pkg/credpool/mongo.go
@@ -253,12 +253,18 @@ func (s *MongoLeaseStore) Close(ctx context.Context, leaseID string, costUSD flo
 	// charges nothing.
 	res, err := s.col.UpdateOne(ctx,
 		bson.M{"_id": leaseID, "closed": false},
-		bson.M{"$set": bson.M{
-			"closed":    true,
-			"cost_usd":  costUSD,
-			"outcome":   outcome,
-			"closed_at": when.UTC(),
-		}})
+		bson.M{
+			// cost_usd is INCREMENTED, not set: an attempt that was
+			// redelivered already charged its share through AddCost, and a
+			// $set would erase it — leaving the donor's per-lease audit
+			// trail disagreeing with their ledger on exactly the runs this
+			// accounting exists for.
+			"$inc": bson.M{"cost_usd": costUSD},
+			"$set": bson.M{
+				"closed":    true,
+				"outcome":   outcome,
+				"closed_at": when.UTC(),
+			}})
 	if err != nil {
 		return false, fmt.Errorf("credpool: close lease: %w", err)
 	}
@@ -270,6 +276,20 @@ func (s *MongoLeaseStore) Close(ctx context.Context, leaseID string, costUSD flo
 		return false, ErrNotFound
 	}
 	return false, nil
+}
+
+// AddCost accumulates an interim attempt's spend onto an OPEN lease, so
+// the donor's audit trail matches their ledger for a redelivered run.
+func (s *MongoLeaseStore) AddCost(ctx context.Context, leaseID string, costUSD float64) error {
+	if costUSD == 0 {
+		return nil
+	}
+	if _, err := s.col.UpdateOne(ctx,
+		bson.M{"_id": leaseID, "closed": false},
+		bson.M{"$inc": bson.M{"cost_usd": costUSD}}); err != nil {
+		return fmt.Errorf("credpool: accumulate lease cost: %w", err)
+	}
+	return nil
 }
 
 func (s *MongoLeaseStore) LiveCommitment(ctx context.Context, pledgeID, excludeRunID string, now time.Time) (int, float64, error) {

--- a/pkg/credpool/store.go
+++ b/pkg/credpool/store.go
@@ -67,8 +67,12 @@ type LeaseStore interface {
 	HasServedAttempt(ctx context.Context, runID, pledgeID string) (bool, error)
 	// Close marks a lease reported and frees its slot. It is a CAS on
 	// "still open": the caller may only charge the donor when it wins,
-	// which is what stops a redelivered report double-charging.
+	// which is what stops a redelivered report double-charging. costUSD is
+	// ADDED to whatever interim charges the lease already carries.
 	Close(ctx context.Context, leaseID string, costUSD float64, outcome string, when time.Time) (won bool, err error)
+	// AddCost accumulates an interim attempt's spend on a still-open lease,
+	// so a redelivered run's audit trail matches the donor's ledger.
+	AddCost(ctx context.Context, leaseID string, costUSD float64) error
 	// LiveCommitment reports what a pledge currently has at stake: how many
 	// live (unclosed, unexpired) leases it holds, and the total allowance
 	// already handed to them. Derived from the leases rather than

--- a/pkg/runner/credpool_spend_test.go
+++ b/pkg/runner/credpool_spend_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"github.com/SocialGouv/iterion/pkg/cloud/metrics"
 	"github.com/SocialGouv/iterion/pkg/credpool"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/queue"
 	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/runtime/recovery"
 	"github.com/SocialGouv/iterion/pkg/secrets"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -103,7 +105,7 @@ func TestRecordPoolSpend_chargesTheDonorAndClosesTheLease(t *testing.T) {
 	h := newPoolHarness(t, credpool.Limits{MaxUSDPerDay: 10, MaxConcurrentRuns: 1})
 	ctx := context.Background()
 
-	h.runner.recordPoolSpend(&queue.RunMessage{RunID: "run-1", TenantID: "team-1"}, usageWith(1.5, 900), nil)
+	h.runner.recordPoolSpend(&queue.RunMessage{RunID: "run-1", TenantID: "team-1"}, usageWith(1.5, 900), nil, false)
 
 	day, _, err := h.ledger.Usage(ctx, credpool.PledgeID("donor", credpool.SourceOAuth, "claude_code"), time.Now().UTC())
 	if err != nil {
@@ -126,7 +128,7 @@ func TestRecordPoolSpend_chargesTheDonorAndClosesTheLease(t *testing.T) {
 // vast majority of them.
 func TestRecordPoolSpend_unleasedRunIsANoOp(t *testing.T) {
 	h := newPoolHarness(t, credpool.Limits{})
-	h.runner.recordPoolSpend(&queue.RunMessage{RunID: "run-elsewhere"}, usageWith(2, 100), nil)
+	h.runner.recordPoolSpend(&queue.RunMessage{RunID: "run-elsewhere"}, usageWith(2, 100), nil, false)
 	day, _, _ := h.ledger.Usage(context.Background(), credpool.PledgeID("donor", credpool.SourceOAuth, "claude_code"), time.Now().UTC())
 	if day.CostUSD != 0 {
 		t.Errorf("charged %v for a run that holds no lease", day.CostUSD)
@@ -136,7 +138,7 @@ func TestRecordPoolSpend_unleasedRunIsANoOp(t *testing.T) {
 // No pool wired at all — the common deployment. Must not panic or block.
 func TestRecordPoolSpend_noPoolIsANoOp(t *testing.T) {
 	r := &Runner{cfg: Config{Logger: iterlog.New(iterlog.LevelError, nil)}}
-	r.recordPoolSpend(&queue.RunMessage{RunID: "run-1"}, usageWith(1, 10), nil)
+	r.recordPoolSpend(&queue.RunMessage{RunID: "run-1"}, usageWith(1, 10), nil, false)
 }
 
 // The condition mapping decides whether a donor keeps their place. Getting
@@ -209,7 +211,7 @@ func TestRecordPoolSpend_usageWindowRestsTheDonor(t *testing.T) {
 		&queue.RunMessage{RunID: "run-1", TenantID: "team-1"},
 		usageWith(0.2, 50),
 		&delegate.ErrRateLimited{Kind: delegate.RateLimitKindUsageWindow, ResetAt: reset},
-	)
+		false)
 
 	p, err := h.pledges.Get(ctx, credpool.PledgeID("donor", credpool.SourceOAuth, "claude_code"))
 	if err != nil {
@@ -230,27 +232,46 @@ func TestRecordPoolSpend_usageWindowRestsTheDonor(t *testing.T) {
 // pause must still park the donor.
 //
 // Measured on prod: a lent credential whose token had expired stayed
-// `active` and first in the pool's rotation after two runs, because by
-// the time the runner reports, execErr says only "paused" — the rejection
-// is nowhere in it. Each subsequent run would take another unit of the
-// donor's daily quota and pause on the same dead credential.
+// `active` and first in the pool's rotation after two runs, because by the
+// time the runner reports, execErr says only "paused" — the rejection is
+// nowhere in it.
 //
-// Driven through the production event path (the engine's own
-// node_recovery event, carrying the code recovery.Classify assigned), not
-// a hand-set flag: the flag is exactly what the test must prove gets set.
+// Driven by a REAL engine writing through the store the runner hands it.
+// The signal is an ENGINE event (node_recovery), and the first version of
+// this fix wired the tap onto the executor's emitter only, leaving the
+// engine writing to the raw store — the capability was dead in production
+// while a test that called observe() by hand stayed green.
 func TestRecordPoolSpend_authFailureAbsorbedByRecoveryStillParksTheDonor(t *testing.T) {
 	h := newPoolHarness(t, credpool.Limits{MaxUSDPerDay: 10})
 	ctx := context.Background()
 
 	usage := newMetricsEmitter(&recordingEmitter{}, metrics.New())
-	usage.observe(store.Event{
-		Type:   store.EventNodeRecovery,
-		NodeID: "n1",
-		Data:   map[string]any{"code": string(runtime.ErrCodeAuthFailed), "attempt": 1},
-	})
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	wf := &ir.Workflow{
+		Name:  "auth_probe",
+		Entry: "agent",
+		Nodes: map[string]ir.Node{
+			"agent": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "agent"}},
+			"done":  &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{{From: "agent", To: "done"}},
+	}
+	// The engine gets the SAME wrapper the runner builds. If that wiring
+	// regresses, this test goes red.
+	eng := runtime.New(wf, observingStore{RunStore: st, observe: usage.observe},
+		authRejectingExecutor{},
+		runtime.WithRecoveryDispatch(recovery.Dispatch(recovery.DefaultRecipes())))
+	_ = eng.Run(ctx, "run-1", map[string]any{})
 
-	// The attempt ends PAUSED, not on the auth error.
-	h.runner.recordPoolSpend(&queue.RunMessage{RunID: "run-1", TenantID: "team-1"}, usage, runtime.ErrRunPaused)
+	if !usage.SawAuthFailure() {
+		t.Fatal("the engine's own auth classification never reached the runner's observer")
+	}
+
+	// The attempt ends PAUSED, not on the auth error — the prod shape.
+	h.runner.recordPoolSpend(&queue.RunMessage{RunID: "run-1", TenantID: "team-1"}, usage, runtime.ErrRunPaused, false)
 
 	p, err := h.pledges.Get(ctx, credpool.PledgeID("donor", credpool.SourceOAuth, "claude_code"))
 	if err != nil {
@@ -261,12 +282,20 @@ func TestRecordPoolSpend_authFailureAbsorbedByRecoveryStillParksTheDonor(t *test
 	}
 }
 
+// authRejectingExecutor fails every node the way a provider rejecting a
+// credential does.
+type authRejectingExecutor struct{}
+
+func (authRejectingExecutor) Execute(context.Context, ir.Node, map[string]any) (map[string]any, error) {
+	return nil, &delegate.ErrAuthFailed{Provider: "claw", Detail: "401 token expired"}
+}
+
 // The mirror: an ordinary workflow failure says nothing about the
 // credential and must not cost the donor their place.
 func TestRecordPoolSpend_ordinaryFailureLeavesTheDonorAlone(t *testing.T) {
 	h := newPoolHarness(t, credpool.Limits{MaxUSDPerDay: 10})
 	h.runner.recordPoolSpend(&queue.RunMessage{RunID: "run-1", TenantID: "team-1"},
-		usageWith(1, 10), errors.New("the bot's own logic failed"))
+		usageWith(1, 10), errors.New("the bot's own logic failed"), false)
 
 	p, err := h.pledges.Get(context.Background(), credpool.PledgeID("donor", credpool.SourceOAuth, "claude_code"))
 	if err != nil {

--- a/pkg/runner/credpool_spend_test.go
+++ b/pkg/runner/credpool_spend_test.go
@@ -261,8 +261,11 @@ func TestRecordPoolSpend_authFailureAbsorbedByRecoveryStillParksTheDonor(t *test
 	}
 	// The engine gets the SAME wrapper the runner builds. If that wiring
 	// regresses, this test goes red.
-	eng := runtime.New(wf, observingStore{RunStore: st, observe: usage.observe},
-		authRejectingExecutor{},
+	// Wired exactly as the runner wires it: the raw store plus the engine's
+	// event-observer seam. A store decorator would have hidden the store's
+	// optional capabilities from the engine's own probes.
+	eng := runtime.New(wf, st, authRejectingExecutor{},
+		runtime.WithEventObserver(usage.observe),
 		runtime.WithRecoveryDispatch(recovery.Dispatch(recovery.DefaultRecipes())))
 	_ = eng.Run(ctx, "run-1", map[string]any{})
 

--- a/pkg/runner/credpool_spend_test.go
+++ b/pkg/runner/credpool_spend_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/queue"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/store"
 )
 
 // poolHarness wires a real broker with one donor who is already serving a
@@ -222,5 +223,56 @@ func TestRecordPoolSpend_usageWindowRestsTheDonor(t *testing.T) {
 		Wants: []credpool.Credential{{Source: credpool.SourceOAuth, Ref: string(secrets.OAuthKindClaudeCode)}},
 	}); !errors.Is(err, credpool.ErrNoDonor) {
 		t.Errorf("next Acquire = %v, want ErrNoDonor while the donor rests", err)
+	}
+}
+
+// An auth rejection that the RECOVERY machinery converts into a human
+// pause must still park the donor.
+//
+// Measured on prod: a lent credential whose token had expired stayed
+// `active` and first in the pool's rotation after two runs, because by
+// the time the runner reports, execErr says only "paused" — the rejection
+// is nowhere in it. Each subsequent run would take another unit of the
+// donor's daily quota and pause on the same dead credential.
+//
+// Driven through the production event path (the engine's own
+// node_recovery event, carrying the code recovery.Classify assigned), not
+// a hand-set flag: the flag is exactly what the test must prove gets set.
+func TestRecordPoolSpend_authFailureAbsorbedByRecoveryStillParksTheDonor(t *testing.T) {
+	h := newPoolHarness(t, credpool.Limits{MaxUSDPerDay: 10})
+	ctx := context.Background()
+
+	usage := newMetricsEmitter(&recordingEmitter{}, metrics.New())
+	usage.observe(store.Event{
+		Type:   store.EventNodeRecovery,
+		NodeID: "n1",
+		Data:   map[string]any{"code": string(runtime.ErrCodeAuthFailed), "attempt": 1},
+	})
+
+	// The attempt ends PAUSED, not on the auth error.
+	h.runner.recordPoolSpend(&queue.RunMessage{RunID: "run-1", TenantID: "team-1"}, usage, runtime.ErrRunPaused)
+
+	p, err := h.pledges.Get(ctx, credpool.PledgeID("donor", credpool.SourceOAuth, "claude_code"))
+	if err != nil {
+		t.Fatalf("pledge: %v", err)
+	}
+	if p.ConsecutiveAuthFailures == 0 {
+		t.Fatal("the rejection never reached the donor's health counter — a dead lent credential stays first in the rotation")
+	}
+}
+
+// The mirror: an ordinary workflow failure says nothing about the
+// credential and must not cost the donor their place.
+func TestRecordPoolSpend_ordinaryFailureLeavesTheDonorAlone(t *testing.T) {
+	h := newPoolHarness(t, credpool.Limits{MaxUSDPerDay: 10})
+	h.runner.recordPoolSpend(&queue.RunMessage{RunID: "run-1", TenantID: "team-1"},
+		usageWith(1, 10), errors.New("the bot's own logic failed"))
+
+	p, err := h.pledges.Get(context.Background(), credpool.PledgeID("donor", credpool.SourceOAuth, "claude_code"))
+	if err != nil {
+		t.Fatalf("pledge: %v", err)
+	}
+	if p.ConsecutiveAuthFailures != 0 {
+		t.Errorf("auth failures = %d — a bot failing on its own logic blamed the donor's credential", p.ConsecutiveAuthFailures)
 	}
 }

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -997,7 +997,13 @@ func (r *Runner) processOne(parent context.Context, delivery *natsq.Delivery) {
 		return
 	}
 
-	r.recordPoolSpend(msg, usage, err, outcome.action == actionNak)
+	// Interim only when JetStream will really redeliver. A Nak does not
+	// imply one: ErrRunInterrupted (drain / lost heartbeat) is exempt from
+	// the DLQ park above, so on its LAST permitted delivery it Naks into
+	// nothing — and a lease left open there strands the donor's slot and
+	// committed allowance until the 12h TTL.
+	redeliverable := r.cfg.NATS != nil && delivery.NumDelivered() < r.cfg.NATS.MaxDeliver()
+	r.recordPoolSpend(msg, usage, err, outcome.action == actionNak && redeliverable)
 
 	if outcomeSideEffectsFire(err, outcome.action) {
 		fireOutcome()
@@ -1363,9 +1369,15 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 	if steerCh := r.steerChannelFor(msg.RunID); steerCh != nil {
 		engineOpts = append(engineOpts, runtime.WithOverrideChannel(steerCh))
 	}
-	// The engine writes THROUGH the metrics emitter: its own events (chiefly
-	// node_recovery) carry classifications nothing else reports.
-	engine := runtime.New(wf, observingStore{RunStore: r.cfg.Store, observe: usage.observe}, executor, engineOpts...)
+	// The engine's own events (chiefly node_recovery) carry classifications
+	// nothing else reports. Observed through the engine's dedicated seam
+	// rather than a store decorator: a decorator's method set is the
+	// INTERFACE's, which would hide the concrete store's optional
+	// capabilities (RunFilesStore, InteractionAnswerCAS, …) from the
+	// type-assertion probes inside the engine — silently, since each one
+	// degrades rather than errors.
+	engineOpts = append(engineOpts, runtime.WithEventObserver(usage.observe))
+	engine := runtime.New(wf, r.cfg.Store, executor, engineOpts...)
 	// Publish the engine so the store's Event.ActiveMs stamping reads
 	// this run's monotonic active elapsed; drop it when the run returns.
 	r.registerRunEngine(msg.RunID, engine)

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -936,7 +936,8 @@ func (r *Runner) processOne(parent context.Context, delivery *natsq.Delivery) {
 		<-hbDone
 	}()
 
-	err := r.executeRun(runCtx, msg)
+	var usage *metricsEmitter
+	err := r.executeRun(runCtx, msg, &usage)
 	// Stop the heartbeat before finalizing (Ack/Nak) the delivery. The
 	// heartbeat issues periodic InProgress() on this same delivery to
 	// hold the JetStream ack deadline open; draining it here guarantees
@@ -975,17 +976,28 @@ func (r *Runner) processOne(parent context.Context, delivery *natsq.Delivery) {
 	// delivery still arms a retry instead of being parked: the window is
 	// exactly the condition that makes every prior delivery useless, so
 	// reaching delivery 8 is evidence for retrying later, not against it.
+	// Close the credential-pool lease unless JetStream is about to hand the
+	// SAME sealed bundle to another pod — the only case where a later
+	// attempt still runs on this lease and can report against it. A parked
+	// delivery (usage-window retry, DLQ) is final for this bundle: an armed
+	// retry re-publishes and acquires afresh, and a DLQ'd run never comes
+	// back. Reporting `interim` there would strand the donor's slot and
+	// committed allowance until the 12h lease TTL.
 	if handled, retryStatus := r.parkUsageLimitRetry(runCtx, err, delivery, msg, logger); handled {
+		r.recordPoolSpend(msg, usage, err, false)
 		fireOutcome()
 		finalStatus = retryStatus
 		return
 	}
 
 	if handled, dlqStatus := r.parkOnDLQOnFinalDelivery(err, delivery, msg, logger); handled {
+		r.recordPoolSpend(msg, usage, err, false)
 		fireOutcome()
 		finalStatus = dlqStatus
 		return
 	}
+
+	r.recordPoolSpend(msg, usage, err, outcome.action == actionNak)
 
 	if outcomeSideEffectsFire(err, outcome.action) {
 		fireOutcome()
@@ -1079,7 +1091,12 @@ func (r *Runner) fireOutcomeEvent(msg *queue.RunMessage, execErr error) {
 // attempt ended: a credential pool must know whether it was a provider
 // quota window or a rejected credential that stopped the run, not merely
 // how much it cost.
-func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage) (execErr error) {
+// usageOut, when non-nil, receives the run's metrics emitter as soon as it
+// exists so the CALLER can report pool spend once it knows the delivery's
+// real disposition. The pool report cannot live in this function's defer:
+// whether an attempt is the last one — parked on the DLQ rather than
+// redelivered — is decided above, after this returns.
+func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut **metricsEmitter) (execErr error) {
 	// Honour the publisher's per-run wall-clock budget. Without this,
 	// queue.RunMessage.TimeoutSec — wired from `iterion run --timeout`
 	// and the studio Launch modal — has no effect in cloud mode: the
@@ -1263,14 +1280,14 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage) (execErr
 	if err != nil {
 		return err
 	}
+	if usageOut != nil {
+		*usageOut = usage
+	}
 	// Charge the run's spend whatever the outcome — paused, cancelled and
-	// failed attempts incurred real LLM spend. The org's monthly bucket
-	// always; a lending contributor's ledger too when this run drew on the
-	// credential pool.
-	defer func() {
-		r.recordOrgSpend(msg, usage)
-		r.recordPoolSpend(msg, usage, execErr)
-	}()
+	// failed attempts incurred real LLM spend. The credential pool's half is
+	// reported by the caller instead, which alone knows whether this
+	// delivery is the last one.
+	defer func() { r.recordOrgSpend(msg, usage) }()
 
 	engineOpts := []runtime.EngineOption{
 		runtime.WithLogger(runLogger),
@@ -1346,7 +1363,9 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage) (execErr
 	if steerCh := r.steerChannelFor(msg.RunID); steerCh != nil {
 		engineOpts = append(engineOpts, runtime.WithOverrideChannel(steerCh))
 	}
-	engine := runtime.New(wf, r.cfg.Store, executor, engineOpts...)
+	// The engine writes THROUGH the metrics emitter: its own events (chiefly
+	// node_recovery) carry classifications nothing else reports.
+	engine := runtime.New(wf, observingStore{RunStore: r.cfg.Store, observe: usage.observe}, executor, engineOpts...)
 	// Publish the engine so the store's Event.ActiveMs stamping reads
 	// this run's monotonic active elapsed; drop it when the run returns.
 	r.registerRunEngine(msg.RunID, engine)

--- a/pkg/runner/loop_metrics.go
+++ b/pkg/runner/loop_metrics.go
@@ -9,6 +9,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/backend/cost"
 	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"github.com/SocialGouv/iterion/pkg/cloud/metrics"
+	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -45,6 +46,16 @@ type metricsEmitter struct {
 	runCostUSD      float64
 	runInputTokens  int64
 	runOutputTokens int64
+
+	// sawAuthFailure records that the provider rejected this run's
+	// credential at some point, even if the attempt did not END on that
+	// error. Recovery converts an auth failure into a human pause, so by
+	// the time the runner reports, execErr is ErrRunPaused and the
+	// rejection is invisible — which left a dead lent credential first in
+	// the pool's rotation, pausing run after run and burning a unit of its
+	// donor's daily quota each time (measured on prod: 2 runs, credential
+	// dead, pledge still "active").
+	sawAuthFailure bool
 }
 
 // modelRate is the per-token cost (USD) for a given model, derived
@@ -187,6 +198,15 @@ func (m *metricsEmitter) observe(evt store.Event) {
 		if costDelta > 0 && m.reg != nil {
 			m.reg.LLMCostUSDTotal.WithLabelValues(backend, normalizeModelLabel(modelName)).Add(costDelta)
 		}
+	case store.EventNodeRecovery:
+		// The engine already classified the failure here (typed, from
+		// recovery.Classify) — this is the only place the reason survives
+		// once recovery turns an auth rejection into a pause.
+		if code, _ := evt.Data["code"].(string); code == string(runtime.ErrCodeAuthFailed) {
+			m.mu.Lock()
+			m.sawAuthFailure = true
+			m.mu.Unlock()
+		}
 	case store.EventDelegateFinished:
 		backend, _ := evt.Data["backend"].(string)
 		if backend == "" {
@@ -236,6 +256,14 @@ func (m *metricsEmitter) RunTotals() (costUSD float64, inputTokens, outputTokens
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.runCostUSD, m.runInputTokens, m.runOutputTokens
+}
+
+// SawAuthFailure reports whether the provider rejected this run's
+// credential at any point during the attempt.
+func (m *metricsEmitter) SawAuthFailure() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.sawAuthFailure
 }
 
 func (m *metricsEmitter) lookupModel(nodeID string) string {

--- a/pkg/runner/loop_metrics.go
+++ b/pkg/runner/loop_metrics.go
@@ -77,6 +77,25 @@ func newMetricsEmitter(inner model.EventEmitter, reg *metrics.Registry) *metrics
 	}
 }
 
+// observingStore is the run's event store with the metrics emitter tapped
+// into AppendEvent.
+//
+// The executor writes through the emitter, but the ENGINE writes straight
+// to its own store — and node_recovery, the only place a recovery-absorbed
+// auth failure is still named, is an ENGINE event. Handing the engine the
+// raw store left that classification unobserved on the cloud path (the
+// local path already wraps), so the donor of a rejected credential was
+// never parked no matter what the emitter did with it.
+type observingStore struct {
+	store.RunStore
+	observe func(store.Event)
+}
+
+func (s observingStore) AppendEvent(ctx context.Context, runID string, evt store.Event) (*store.Event, error) {
+	s.observe(evt)
+	return s.RunStore.AppendEvent(ctx, runID, evt)
+}
+
 // rateForLocked returns the cached per-token rates for the given model,
 // resolving once via cost.EstimateUSD. Called under m.mu.
 func (m *metricsEmitter) rateForLocked(modelName string) modelRate {

--- a/pkg/runner/loop_metrics.go
+++ b/pkg/runner/loop_metrics.go
@@ -77,24 +77,10 @@ func newMetricsEmitter(inner model.EventEmitter, reg *metrics.Registry) *metrics
 	}
 }
 
-// observingStore is the run's event store with the metrics emitter tapped
-// into AppendEvent.
-//
-// The executor writes through the emitter, but the ENGINE writes straight
+// The executor writes through this emitter, but the ENGINE writes straight
 // to its own store — and node_recovery, the only place a recovery-absorbed
-// auth failure is still named, is an ENGINE event. Handing the engine the
-// raw store left that classification unobserved on the cloud path (the
-// local path already wraps), so the donor of a rejected credential was
-// never parked no matter what the emitter did with it.
-type observingStore struct {
-	store.RunStore
-	observe func(store.Event)
-}
-
-func (s observingStore) AppendEvent(ctx context.Context, runID string, evt store.Event) (*store.Event, error) {
-	s.observe(evt)
-	return s.RunStore.AppendEvent(ctx, runID, evt)
-}
+// auth failure is still named, is an ENGINE event. The runner therefore
+// also registers observe via runtime.WithEventObserver (see loop.go).
 
 // rateForLocked returns the cached per-token rates for the given model,
 // resolving once via cost.EstimateUSD. Called under m.mu.

--- a/pkg/runner/loop_spend.go
+++ b/pkg/runner/loop_spend.go
@@ -2,12 +2,13 @@ package runner
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
 	"github.com/SocialGouv/iterion/pkg/credpool"
 	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/runtime/recovery"
 )
 
 // recordOrgSpend charges the run's accumulated LLM consumption to the
@@ -56,6 +57,17 @@ func (r *Runner) recordPoolSpend(msg *queue.RunMessage, usage *metricsEmitter, e
 	}
 	costUSD, in, out := usage.RunTotals()
 	condition, cooldownUntil := classifyPoolCondition(execErr, time.Now().UTC())
+	// An auth rejection the recovery machinery absorbed into a human pause
+	// leaves execErr saying only "paused". Without this the donor's dead
+	// credential stays first in the rotation and pauses the next run too,
+	// costing them a unit of their daily quota every time.
+	if condition == credpool.ConditionOK && usage.SawAuthFailure() {
+		condition = credpool.ConditionAuthFailed
+	}
+	// An attempt that Naks is redelivered on the SAME sealed bundle, so the
+	// next pod runs on this very lease. Closing it here would leave every
+	// redelivered attempt with nothing to report against.
+	interim := classifyExecResult(execErr, msg.RunID).action == actionNak
 	bg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := r.cfg.CredPool.Report(bg, msg.RunID, credpool.Outcome{
@@ -64,6 +76,7 @@ func (r *Runner) recordPoolSpend(msg *queue.RunMessage, usage *metricsEmitter, e
 		OutputTokens:  out,
 		Condition:     condition,
 		CooldownUntil: cooldownUntil,
+		Interim:       interim,
 	}); err != nil {
 		r.cfg.Logger.Warn("runner: credential-pool report for run %s: %v (the donor's slot frees on lease expiry)", msg.RunID, err)
 	}
@@ -93,8 +106,12 @@ func classifyPoolCondition(execErr error, now time.Time) (credpool.Condition, ti
 		}
 		return credpool.ConditionUsageWindow, at
 	}
-	var auth *delegate.ErrAuthFailed
-	if errors.As(execErr, &auth) {
+	// Asked through recovery.Classify rather than a local type switch: it
+	// is the engine's single source of truth for "the provider rejected
+	// this credential", and it recognises the raw 401/403 an in-process
+	// backend surfaces as well as the typed ErrAuthFailed the CLI ones
+	// raise. A local check for the type alone missed claw entirely.
+	if recovery.Classify(execErr) == runtime.ErrCodeAuthFailed {
 		return credpool.ConditionAuthFailed, time.Time{}
 	}
 	return credpool.ConditionOK, time.Time{}

--- a/pkg/runner/loop_spend.go
+++ b/pkg/runner/loop_spend.go
@@ -51,7 +51,12 @@ func (r *Runner) recordOrgSpend(msg *queue.RunMessage, usage *metricsEmitter) {
 // ctx and best-effort for the same reason as recordOrgSpend: accounting
 // must never turn a finished run into a failed one. The lease's own TTL
 // plus the server-side sweeper are the backstop if this write is lost.
-func (r *Runner) recordPoolSpend(msg *queue.RunMessage, usage *metricsEmitter, execErr error) {
+// interim says this attempt does NOT settle the run: the queue will
+// redeliver the same sealed bundle, so the next pod runs on this very
+// lease. Decided by the caller, which is the only place the delivery's
+// real disposition is known — a run on its last permitted delivery is
+// parked, not redelivered.
+func (r *Runner) recordPoolSpend(msg *queue.RunMessage, usage *metricsEmitter, execErr error, interim bool) {
 	if r.cfg.CredPool == nil || usage == nil {
 		return
 	}
@@ -64,10 +69,6 @@ func (r *Runner) recordPoolSpend(msg *queue.RunMessage, usage *metricsEmitter, e
 	if condition == credpool.ConditionOK && usage.SawAuthFailure() {
 		condition = credpool.ConditionAuthFailed
 	}
-	// An attempt that Naks is redelivered on the SAME sealed bundle, so the
-	// next pod runs on this very lease. Closing it here would leave every
-	// redelivered attempt with nothing to report against.
-	interim := classifyExecResult(execErr, msg.RunID).action == actionNak
 	bg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := r.cfg.CredPool.Report(bg, msg.RunID, credpool.Outcome{

--- a/pkg/runtime/sandbox.go
+++ b/pkg/runtime/sandbox.go
@@ -442,6 +442,12 @@ func resolveAndStartSandbox(ctx context.Context, p SandboxParams) (*activeSandbo
 	if err != nil {
 		return nil, fmt.Errorf("runtime: sandbox: claude forfait delivery: %w", err)
 	}
+	// Same for a resolved ChatGPT forfait, so a sandboxed claw/codex node
+	// authenticates as the RUN rather than as the pod.
+	codexOAuthMounted, err := addCodexOAuthSecretFile(ctx, spec)
+	if err != nil {
+		return nil, fmt.Errorf("runtime: sandbox: chatgpt forfait delivery: %w", err)
+	}
 
 	// Optionally start the network proxy. When the workflow has no
 	// explicit network policy, default to the iterion-default
@@ -517,6 +523,15 @@ func resolveAndStartSandbox(ctx context.Context, p SandboxParams) (*activeSandbo
 		}
 		if logger != nil {
 			logger.Info("runtime: sandbox: claude forfait credentials delivered (CLAUDE_CONFIG_DIR=%s)", secrets.ClaudeCodeSandboxConfigDir)
+		}
+	}
+	if codexOAuthMounted {
+		if err := seedCodexConfigDir(ctx, run); err != nil {
+			active.shutdown(ctx, logger)
+			return nil, err
+		}
+		if logger != nil {
+			logger.Info("runtime: sandbox: chatgpt forfait credentials delivered (CODEX_HOME=%s)", secrets.CodexSandboxConfigDir)
 		}
 	}
 

--- a/pkg/runtime/sandbox_secret_files.go
+++ b/pkg/runtime/sandbox_secret_files.go
@@ -109,62 +109,109 @@ func addSecretFileMounts(ctx context.Context, spec *sandbox.Spec, wf *ir.Workflo
 // Callers must only invoke this for a real (non-noop) driver: the noop
 // path rejects any SecretFiles.
 func addClaudeOAuthSecretFile(ctx context.Context, spec *sandbox.Spec) (bool, error) {
+	return addOAuthSecretFile(ctx, spec, oauthDelivery{
+		kind:       string(secrets.OAuthKindClaudeCode),
+		fileName:   ".credentials.json",
+		secretName: secrets.ClaudeCodeOAuthSecretName,
+		mountPath:  secrets.ClaudeCodeOAuthSandboxMountPath,
+		label:      "Claude",
+	})
+}
+
+// addCodexOAuthSecretFile is the same delivery for a resolved ChatGPT
+// (Codex) forfait — the tenant's own, or one lent through the credential
+// pool. Without it a sandboxed claw/codex node cannot see the resolved
+// subscription at all (the host temp dir does not exist in the container)
+// and silently authenticates with whatever ambient key the pod carries:
+// the platform pays, the tenant's or donor's credential goes unused, and
+// nothing in the run says so.
+func addCodexOAuthSecretFile(ctx context.Context, spec *sandbox.Spec) (bool, error) {
+	return addOAuthSecretFile(ctx, spec, oauthDelivery{
+		kind:       string(secrets.OAuthKindCodex),
+		fileName:   "auth.json",
+		secretName: secrets.CodexOAuthSecretName,
+		mountPath:  secrets.CodexOAuthSandboxMountPath,
+		label:      "ChatGPT",
+	})
+}
+
+// oauthDelivery describes one forfait kind's in-sandbox delivery.
+type oauthDelivery struct {
+	kind       string
+	fileName   string
+	secretName string
+	mountPath  string
+	label      string
+}
+
+func addOAuthSecretFile(ctx context.Context, spec *sandbox.Spec, d oauthDelivery) (bool, error) {
 	creds, ok := secrets.CredentialsFromContext(ctx)
 	if !ok {
 		return false, nil
 	}
-	dir := creds.OAuthDir(string(secrets.OAuthKindClaudeCode))
+	dir := creds.OAuthDir(d.kind)
 	if dir == "" {
 		return false, nil
 	}
-	payload, err := os.ReadFile(filepath.Join(dir, ".credentials.json"))
+	payload, err := os.ReadFile(filepath.Join(dir, d.fileName))
 	if err != nil {
-		return false, fmt.Errorf("read materialised claude forfait credentials: %w", err)
+		return false, fmt.Errorf("read materialised %s forfait credentials: %w", d.label, err)
 	}
 	for _, sf := range spec.SecretFiles {
-		if sf.Name == secrets.ClaudeCodeOAuthSecretName {
-			return false, fmt.Errorf("file secret name %q is reserved for the Claude forfait delivery; rename the workflow secret", sf.Name)
+		if sf.Name == d.secretName {
+			return false, fmt.Errorf("file secret name %q is reserved for the %s forfait delivery; rename the workflow secret", sf.Name, d.label)
 		}
-		if sf.MountPath == secrets.ClaudeCodeOAuthSandboxMountPath {
-			return false, fmt.Errorf("file secret %q mount_path %q collides with the Claude forfait delivery path", sf.Name, sf.MountPath)
+		if sf.MountPath == d.mountPath {
+			return false, fmt.Errorf("file secret %q mount_path %q collides with the %s forfait delivery path", sf.Name, sf.MountPath, d.label)
 		}
 	}
 	spec.SecretFiles = append(spec.SecretFiles, sandbox.SecretFileMount{
-		Name:      secrets.ClaudeCodeOAuthSecretName,
-		MountPath: secrets.ClaudeCodeOAuthSandboxMountPath,
+		Name:      d.secretName,
+		MountPath: d.mountPath,
 		Value:     payload,
 	})
 	return true, nil
 }
 
-// seedClaudeConfigScript copies the read-only forfait mount into a
-// WRITABLE CLAUDE_CONFIG_DIR ($1 = config dir, $2 = mounted payload).
-// The claude CLI persists session state — and its own token refreshes —
-// under its config dir, so pointing it at the read-only secret mount
-// would break it; the seeded copy is owner-only (0700 dir / 0600 file)
+// seedForfaitConfigScript copies a read-only forfait mount into a WRITABLE
+// config dir ($1 = config dir, $2 = mounted payload, $3 = file name).
+// These CLIs persist session state — and their own token refreshes —
+// under their config dir, so pointing them at the read-only secret mount
+// would break them; the seeded copy is owner-only (0700 dir / 0600 file)
 // and rewritten mid-run by the runner's forfait refresher through the
 // same exec seam.
-const seedClaudeConfigScript = `set -e
+const seedForfaitConfigScript = `set -e
 umask 077
 mkdir -p "$1"
-cp "$2" "$1/.credentials.json"
-chmod 600 "$1/.credentials.json"`
+cp "$2" "$1/$3"
+chmod 600 "$1/$3"`
 
 // seedClaudeConfigDir runs [seedClaudeConfigScript] inside the freshly
 // started sandbox. Hard error on failure: the run resolved a forfait
 // credential, so a half-delivered config dir must fail the boot loudly
 // rather than surface hours later as an auth error mid-workflow.
 func seedClaudeConfigDir(ctx context.Context, run sandbox.Run) error {
+	return seedForfaitConfigDir(ctx, run, "claude",
+		secrets.ClaudeCodeSandboxConfigDir, secrets.ClaudeCodeOAuthSandboxMountPath, ".credentials.json")
+}
+
+// seedCodexConfigDir is the same for the ChatGPT forfait: CODEX_HOME must
+// be writable because the reader may rotate the token in place.
+func seedCodexConfigDir(ctx context.Context, run sandbox.Run) error {
+	return seedForfaitConfigDir(ctx, run, "codex",
+		secrets.CodexSandboxConfigDir, secrets.CodexOAuthSandboxMountPath, "auth.json")
+}
+
+func seedForfaitConfigDir(ctx context.Context, run sandbox.Run, label, dir, mount, fileName string) error {
 	res, err := run.Exec(ctx, []string{
-		"sh", "-c", seedClaudeConfigScript, "sh",
-		secrets.ClaudeCodeSandboxConfigDir, secrets.ClaudeCodeOAuthSandboxMountPath,
+		"sh", "-c", seedForfaitConfigScript, "sh", dir, mount, fileName,
 	}, sandbox.ExecOpts{})
 	if err != nil {
-		return fmt.Errorf("runtime: sandbox: seed claude config dir: %w", err)
+		return fmt.Errorf("runtime: sandbox: seed %s config dir: %w", label, err)
 	}
 	if res.ExitCode != 0 {
-		return fmt.Errorf("runtime: sandbox: seed claude config dir: exited %d: %s",
-			res.ExitCode, strings.TrimSpace(string(res.Stderr)))
+		return fmt.Errorf("runtime: sandbox: seed %s config dir: exited %d: %s",
+			label, res.ExitCode, strings.TrimSpace(string(res.Stderr)))
 	}
 	return nil
 }

--- a/pkg/runtime/sandbox_secret_files_test.go
+++ b/pkg/runtime/sandbox_secret_files_test.go
@@ -184,8 +184,8 @@ func TestSeedClaudeConfigDir(t *testing.T) {
 	if err := seedClaudeConfigDir(context.Background(), ok); err != nil {
 		t.Fatalf("seedClaudeConfigDir: %v", err)
 	}
-	want := []string{"sh", "-c", seedClaudeConfigScript, "sh",
-		secretspkg.ClaudeCodeSandboxConfigDir, secretspkg.ClaudeCodeOAuthSandboxMountPath}
+	want := []string{"sh", "-c", seedForfaitConfigScript, "sh",
+		secretspkg.ClaudeCodeSandboxConfigDir, secretspkg.ClaudeCodeOAuthSandboxMountPath, ".credentials.json"}
 	if len(ok.gotCmd) != len(want) {
 		t.Fatalf("cmd = %v", ok.gotCmd)
 	}
@@ -200,4 +200,56 @@ func TestSeedClaudeConfigDir(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "exited 1") {
 		t.Fatalf("expected a hard exited-1 error, got %v", err)
 	}
+}
+
+// A resolved ChatGPT forfait — the tenant's own, or one lent through the
+// credential pool — must reach a sandboxed node. Before this delivery
+// existed the host temp dir simply did not exist inside the container, so
+// the node fell back to the pod's ambient OPENAI_API_KEY: the platform
+// paid, the resolved credential went unused, and nothing said so. Measured
+// on prod (run 019fcc09): sandboxed → "429 no credits" from the platform
+// key, unsandboxed → "401 token expired" from the lent subscription.
+func TestAddCodexOAuthSecretFile(t *testing.T) {
+	t.Run("no credentials in ctx is a silent no-op", func(t *testing.T) {
+		var spec sandbox.Spec
+		added, err := addCodexOAuthSecretFile(context.Background(), &spec)
+		if err != nil || added || len(spec.SecretFiles) != 0 {
+			t.Fatalf("added=%v err=%v spec=%+v — want a silent no-op", added, err, spec.SecretFiles)
+		}
+	})
+
+	t.Run("materialised forfait is mounted on the ADR-070 channel", func(t *testing.T) {
+		dir := t.TempDir()
+		payload := `{"tokens":{"access_token":"tok","account_id":"acct"},"auth_mode":"chatgpt"}`
+		if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte(payload), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		ctx := secretspkg.WithCredentials(context.Background(), secretspkg.Credentials{
+			OAuthCredentialFiles: map[string]string{string(secretspkg.OAuthKindCodex): dir},
+		})
+		var spec sandbox.Spec
+		added, err := addCodexOAuthSecretFile(ctx, &spec)
+		if err != nil || !added {
+			t.Fatalf("added=%v err=%v", added, err)
+		}
+		if len(spec.SecretFiles) != 1 {
+			t.Fatalf("SecretFiles = %+v", spec.SecretFiles)
+		}
+		sf := spec.SecretFiles[0]
+		if sf.Name != secretspkg.CodexOAuthSecretName ||
+			sf.MountPath != secretspkg.CodexOAuthSandboxMountPath ||
+			string(sf.Value) != payload {
+			t.Fatalf("forfait mount mis-built: name=%q path=%q", sf.Name, sf.MountPath)
+		}
+	})
+
+	t.Run("unreadable auth.json is a hard error", func(t *testing.T) {
+		ctx := secretspkg.WithCredentials(context.Background(), secretspkg.Credentials{
+			OAuthCredentialFiles: map[string]string{string(secretspkg.OAuthKindCodex): filepath.Join(t.TempDir(), "gone")},
+		})
+		var spec sandbox.Spec
+		if _, err := addCodexOAuthSecretFile(ctx, &spec); err == nil {
+			t.Fatal("expected a hard error: the run RESOLVED a forfait, so degrading to the ambient key silently is the defect")
+		}
+	})
 }

--- a/pkg/secrets/files.go
+++ b/pkg/secrets/files.go
@@ -39,6 +39,22 @@ const (
 	// in-sandbox claude CLI reads (and the runner's mid-run refresher
 	// rewrites through the sandbox exec seam).
 	ClaudeCodeSandboxCredentialsPath = ClaudeCodeSandboxConfigDir + "/.credentials.json"
+
+	// The same three for the ChatGPT (Codex) forfait. Without them a
+	// sandboxed node has no way to see a resolved subscription — the host
+	// temp dir does not exist in the container — and silently falls back to
+	// whatever ambient key the pod carries.
+	CodexOAuthSecretName = "codex-oauth"
+	// CodexOAuthSandboxMountPath keeps the payload under SecretFilesMountDir
+	// for the same reason as the Claude one: the k8s driver projects that
+	// directory volume and can refresh it mid-run.
+	CodexOAuthSandboxMountPath = SecretFilesMountDir + "/codex-oauth/auth.json"
+	// CodexSandboxConfigDir is the writable in-sandbox CODEX_HOME seeded
+	// from the mount above.
+	CodexSandboxConfigDir = "/tmp/iterion-codex-config"
+	// CodexSandboxAuthPath is the seeded auth.json the in-sandbox reader
+	// (claw's registry, or the codex CLI) opens.
+	CodexSandboxAuthPath = CodexSandboxConfigDir + "/auth.json"
 )
 
 var secretFileNameSanitizer = regexp.MustCompile(`[^A-Za-z0-9_.-]+`)


### PR DESCRIPTION
Three defects a **live end-to-end run on production** surfaced (PR #350 / #356 shipped the pool; this fixes what the first real draw exposed). None was reachable by reading: the chain works right up to the runner pod and breaks in the layer below it.

## 1. A sandboxed node authenticated as the POD, not as the run

Credentials resolved for a run live in ctx and are materialised as files. Inside the sandbox the claw runner rebuilds its registry from **env alone** — ctx does not cross a process boundary — and only the pod's ambient env was forwarded. So a pool-served run took its donor's lease, materialised their subscription, and then spent the **platform's** `OPENAI_API_KEY`. A tenant's own BYOK key was ignored the same way.

Proven by A/B on one bot, same run otherwise:
- `sandbox: auto` → `429 You have no credits remaining` (the platform key)
- `sandbox: none` → `401 Provided authentication token is expired` (the lent subscription)

Wherever the ambient key happens to work, the substitution is **invisible**: the operator sees pooled runs succeeding, the platform pays, and every donor's ledger reads $0 forever.

Fix: a resolved ChatGPT forfait is delivered into the sandbox on the same ADR-070 file-secret channel the Claude one already used and seeded into a writable `CODEX_HOME`; the run's own keys override the ambient ones in the forwarded env, with the forfait forced — *"an explicit env key is deliberate"* is true of a machine default and false of a per-run credential.

## 2. An auth failure absorbed by recovery never parked the donor

Recovery turns a rejected credential into a human pause, so by report time `execErr` says only "paused". Measured on prod: dead lent token, **2 runs consumed** off the donor's daily quota, pledge still `active` and first in the rotation — it would have paused run after run. The runner now reads the engine's own `node_recovery` classification, and `classifyPoolCondition` asks `recovery.Classify` instead of matching one error type, which also fixes claw's raw 401 never classifying at all.

## 3. A redelivered attempt spent the donation unmetered (R005cff)

The lease closed on the first attempt, so every redelivery — same sealed bundle, same donated credential — had nothing open to report against. An interim report now charges the spend and keeps the lease; the attempt that settles the run closes it.

Each fix has a regression test verified by reintroducing the defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)