### PR TITLE
fix(runtime,runner): a budget death is terminal-acked, never redelivered

### DIFF
--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -1351,9 +1351,14 @@ workflow dep_update_guard:
   ## The clean re-audit of an npm group already runs ~30m; 40m killed a
   ## 15-module go run mid-audit in production (2026-08-03, run 019fc8e5),
   ## which with a required gate context left the PR silently unmergeable.
+  ## 75m then killed the SAME workload at its very last node (2026-08-04,
+  ## run 019fcc30-b9be: audit 5m + align 25m + verify_build 30m + verify_run
+  ## 13m = 73m, dead at the commit with everything green behind it — the
+  ## worst possible point to run dry). The duration cap is a runaway guard,
+  ## not a performance target; the cost cap is the real spend bound.
   budget:
     max_parallel_branches: 1
-    max_duration: "75m"
+    max_duration: "2h"
     max_cost_usd: 20
 
   ## Scanners + build toolchain live in the sec sandbox image. One

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,11 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.6.0
+version: 2.6.1
+## 2.6.1 — budget 75m → 2h: 75m killed the 15-module go workload at its
+## LAST node (audit 5m + align 25m + verify 43m = 73m, dead at the commit
+## with everything green behind it). The duration cap is a runaway guard,
+## not a performance target; $20 stays the real spend bound.
 ## 2.6.0 — land on merge-queue repos, survive the heavy case. (a)
 ## `arm_automerge` arms FIRST (enablePullRequestAutoMerge — "merge when
 ## ready" on queue repos, so a queue-protected base enqueues instead of

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -316,7 +316,16 @@ func classifyExecResult(execErr error, runID string) execOutcome {
 	// The operator resumes MANUALLY with a raised cap
 	// (`iterion resume --max-duration/--max-cost-usd`), the documented
 	// "budget exceeded → raise the cap + resume" recovery.
-	if errors.Is(execErr, runtime.ErrBudgetExceeded) {
+	//
+	// Matched by sentinel AND by RuntimeError code: the engine has two budget
+	// exits (the branch scheduler wraps the sentinel, the per-node pre-check
+	// historically did not), and a budget death that misses this carve-out is
+	// naked into exactly the redelivery loop described above — observed live
+	// on 2026-08-04 (run 019fcc30-b9be: six ~40s resume/refail turns at a 96%
+	// duration hard limit, each re-provisioning a sandbox). The code match
+	// also covers a mixed-version deploy where an older engine produced the
+	// unwrapped shape.
+	if errors.Is(execErr, runtime.ErrBudgetExceeded) || runtimeCodeOf(execErr) == runtime.ErrCodeBudgetExceeded {
 		return execOutcome{
 			finalStatus: "budget_exceeded",
 			op:          "ack-budget-exceeded",

--- a/pkg/runner/loop_test.go
+++ b/pkg/runner/loop_test.go
@@ -401,6 +401,15 @@ func TestClassifyExecResult(t *testing.T) {
 		// the one interruption-shaped outcome that must NOT come back.
 		{"budget exceeded acks (no auto-resume)", runtime.ErrBudgetExceeded, "budget_exceeded", actionAck},
 		{"wrapped budget exceeded acks", fmt.Errorf("%w: duration (7201/7200)", runtime.ErrBudgetExceeded), "budget_exceeded", actionAck},
+		// The engine's per-node budget pre-check historically produced a bare
+		// RuntimeError (code only, no sentinel Cause) — and that shape naked
+		// into the exact redelivery loop this carve-out forbids (run
+		// 019fcc30-b9be: six ~40s resume/refail turns at a 96% duration hard
+		// limit). The code match is what catches it, including from an older
+		// engine in a mixed-version deploy.
+		{"bare runtime-error budget code acks", &runtime.RuntimeError{
+			Code: runtime.ErrCodeBudgetExceeded, Message: "budget hard limit reached: duration at 96%",
+		}, "budget_exceeded", actionAck},
 		// Precedence, pinned rather than left to the order of the ifs: if an
 		// error ever carries BOTH, budget must win. Interrupted Naks for
 		// auto-resume, and auto-resuming a spent budget re-fails instantly on

--- a/pkg/runtime/budget.go
+++ b/pkg/runtime/budget.go
@@ -394,11 +394,19 @@ func (e *Engine) checkBudgetBeforeExec(rs *runState, nodeID string) error {
 			"limit":      hl.limit,
 			"hard_limit": true,
 		})
+		// Cause carries the sentinel: the cloud runner's terminal-ack carve-out
+		// matches errors.Is(err, ErrBudgetExceeded), and without it a budget
+		// death here was naked back to JetStream — observed in production as a
+		// resume/refail loop at ~40s a turn, each turn re-provisioning a
+		// sandbox to instantly re-hit the same spent budget. The branch
+		// scheduler's twin checks already wrap the sentinel; these two were
+		// the only budget exits that did not.
 		return e.failRunErrWithCheckpoint(rs, nodeID, &RuntimeError{
 			Code:    ErrCodeBudgetExceeded,
 			Message: fmt.Sprintf("budget hard limit reached: %s at %.0f%% (%.0f/%.0f)", hl.dimension, (hl.used/hl.limit)*100, hl.used, hl.limit),
 			NodeID:  nodeID,
 			Hint:    fmt.Sprintf("increase the %s budget or optimize the workflow; new executions are blocked at 90%% to prevent concurrent overage", hl.dimension),
+			Cause:   ErrBudgetExceeded,
 		})
 	}
 
@@ -463,5 +471,6 @@ func (e *Engine) failBudgetExceeded(rs *runState, nodeID string, exc *budgetChec
 		Message: fmt.Sprintf("budget exceeded: %s (%.0f/%.0f)", exc.dimension, exc.used, exc.limit),
 		NodeID:  nodeID,
 		Hint:    fmt.Sprintf("increase the %s budget or optimize the workflow", exc.dimension),
+		Cause:   ErrBudgetExceeded,
 	})
 }


### PR DESCRIPTION
Second wave from the live Vetty e2e retest (after #357/#358):

- **Engine**: the per-node budget checks built a bare `RuntimeError` (code only, no sentinel `Cause`), so the runner's terminal-ack carve-out missed it and naked the delivery — observed live as six ~40s resume/refail turns at a 96% duration hard limit, each re-provisioning a sandbox to re-hit the same spent budget (run 019fcc30-b9be on #354). Both engine exits now wrap `ErrBudgetExceeded`, and the runner also matches the RuntimeError code (mixed-version deploys).
- **Vetty 2.6.1**: budget 75m → 2h — 75m killed the 15-module go workload at its LAST node (audit 5m + align 25m + verify 43m, dead at the commit with everything green behind it). Duration stays a runaway guard; $20 is the spend bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)