### PR TITLE
fix(forge): keep the issue-lane label allowlist across re-provisions

### DIFF
--- a/docs/forge-integrations.md
+++ b/docs/forge-integrations.md
@@ -160,6 +160,15 @@ by signed state + an agent-binding cookie:
 | PATCH | `/repo-bots/{integration_id}` | update an integration's bot set |
 | DELETE | `/repo-bots/{integration_id}` | disable |
 
+Both write routes also carry the repo's **operator-owned** settings —
+`launch_vars`, `overlap`, `hold_labels`, `label_allowlist`,
+`auto_fix_on_gate_failure`. They live on the integration because provisioning
+rebuilds the whole webhook config from the manifests: anything set only on that
+config is wiped by the next enable/update. Omitting a field keeps the stored
+value; an explicit empty list clears it. `label_allowlist` is the one that
+decides which freshly-applied issue label dispatches the implementer (empty =
+any label does).
+
 ## Provider support
 
 | Provider | Mode(s) | Status |

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -274,7 +274,13 @@ Every webhook carries four selection filters plus a bot-agnostic hold gate
 - **`label_allowlist`** — for the `issues` (labeled) path only: which
   freshly-applied label fires (e.g. `["implement"]`). Empty = any label;
   case-insensitive; a bare `*` matches everything. No effect on the
-  `pull_request` / `issue_comment` paths.
+  `pull_request` / `issue_comment` paths. On a **provisioned** webhook, set
+  it through the integration (`label_allowlist` on
+  `POST/PATCH /api/teams/{id}/forge/repo-bots`) rather than the webhook
+  config: provisioning rebuilds that config from the manifests, so a
+  narrowing living only there is dropped by the next bot-set change — and
+  that regression is fail-*open*. An allowlist already PATCHed onto the
+  config is adopted onto the integration by the next provision.
 - **`hold_labels`** — a **bot-agnostic suppression** set. When the
   triggering PR or issue carries any of these labels, the auto-launch
   lanes (PR-open review, merge-queue auto-heal, auto-implement-on-open)

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -219,14 +219,24 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 	// label allowlist were webhook-config PATCHes before they lived on the
 	// integration, and that is still what the webhook API accepts. Read it once
 	// — the adoption backfills below and the idempotent path's divergence check
-	// both need it. A failed read is not fatal here (a fresh provision has no
-	// config yet); the idempotent path re-raises it before writing anything.
+	// both need it.
 	var prevCfg webhooks.Config
-	var prevCfgErr error
 	hasPrevCfg := false
 	if hasExisting && existing.WebhookID != "" {
-		if prevCfg, prevCfgErr = o.Webhooks.Get(ctx, existing.WebhookID); prevCfgErr == nil {
-			hasPrevCfg = true
+		prev, gerr := o.Webhooks.Get(ctx, existing.WebhookID)
+		switch {
+		case gerr == nil:
+			prevCfg, hasPrevCfg = prev, true
+		case errors.Is(gerr, webhooks.ErrNotFound):
+			// The integration points at a config that is gone; the rebuild
+			// below recreates it, and there is nothing to adopt.
+		default:
+			// Any other failure is transient or unknown, and carrying on would
+			// rebuild the config from the manifests WITHOUT the operator
+			// settings it still carries — losing the repo's narrowing silently
+			// and fail-OPEN, which is the very defect this path exists to
+			// prevent. Refuse rather than guess.
+			return ProvisionResult{}, fmt.Errorf("forge: read webhook %s (the repo's operator settings live there): %w", existing.WebhookID, gerr)
 		}
 	}
 
@@ -235,13 +245,25 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 	// is lost at the next enable. A nil request map means "leave them alone",
 	// not "clear them" — enabling one more bot must not silently drop the
 	// repo's own settings.
+	// Each of the four resolves the same way — request, then the integration,
+	// then the config that still enforces the repo's choice. The last step is
+	// what keeps a setting made the documented way (a webhook PATCH) from
+	// being rebuilt away, and it is required of EVERY field the write block
+	// below stamps: one that skipped it would be re-written from an empty
+	// integration and dropped the moment any other field changes.
 	operatorVars := req.LaunchVars
 	if operatorVars == nil && hasExisting {
 		operatorVars = existing.LaunchVars
+		if len(operatorVars) == 0 && hasPrevCfg {
+			operatorVars = prevCfg.OperatorLaunchVars
+		}
 	}
 	operatorOverlap := req.Overlap
 	if operatorOverlap == "" && hasExisting {
 		operatorOverlap = existing.Overlap
+		if operatorOverlap == "" && hasPrevCfg {
+			operatorOverlap = prevCfg.Overlap
+		}
 	}
 	operatorHold := req.HoldLabels
 	if operatorHold == nil && hasExisting {
@@ -314,25 +336,28 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		}
 		// A changed operator override is a real mutation even when the bot set
 		// is not — without this the short-circuit would silently ignore it.
-		// The comparison runs against BOTH stores, because they can diverge: an
-		// explicit request that already matches the (empty) integration while
-		// the config still enforces the old value would otherwise return 200
-		// having changed nothing — the operator reads the widening back from
-		// the API while the lane stays narrowed.
+		// The label sets are also compared against the CONFIG, because the two
+		// stores legitimately diverge there: an explicit request that already
+		// matches the (empty) integration while the config still enforces the
+		// old value would otherwise return 200 having changed nothing — the
+		// operator reads the widening back from the API while the lane stays
+		// narrowed. Only these two qualify: comparing a field that has no
+		// adoption backfill (overlap, launch vars) would read the config's
+		// value as a difference to erase, turning a benign no-op into a write
+		// that drops a policy set the documented way.
 		changed := !maps.Equal(operatorVars, existing.LaunchVars) || operatorOverlap != existing.Overlap ||
 			operatorAutoFix != existing.AutoFixOnGateFailure || !slices.Equal(operatorHold, existing.HoldLabels) ||
 			!slices.Equal(operatorLabels, existing.LabelAllowlist)
 		if hasPrevCfg {
 			changed = changed || !slices.Equal(operatorLabels, prevCfg.LabelAllowlist) ||
-				!slices.Equal(operatorHold, prevCfg.HoldLabels) || operatorOverlap != prevCfg.Overlap ||
-				!maps.Equal(operatorVars, prevCfg.OperatorLaunchVars)
+				!slices.Equal(operatorHold, prevCfg.HoldLabels)
 		}
 		if changed {
-			// The config is the enforcement half, so a failed read cannot be
-			// skipped: writing only the integration would leave the repo running
-			// the previous settings while the API reports the new ones.
+			// The config is the enforcement half, so it cannot be skipped:
+			// writing only the integration would leave the repo running the
+			// previous settings while the API reports the new ones.
 			if !hasPrevCfg {
-				return ProvisionResult{}, fmt.Errorf("forge: read webhook %s to apply the repo's operator settings: %w", existing.WebhookID, prevCfgErr)
+				return ProvisionResult{}, fmt.Errorf("forge: integration %s claims webhook %q, which does not exist — cannot apply the repo's operator settings", existing.ID, existing.WebhookID)
 			}
 			existing.LaunchVars = operatorVars
 			existing.Overlap = operatorOverlap

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -314,16 +314,24 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 			if uerr := o.Integrations.Update(ctx, existing); uerr != nil {
 				return ProvisionResult{}, fmt.Errorf("forge: update integration launch vars: %w", uerr)
 			}
-			if cfg, gerr := o.Webhooks.Get(ctx, existing.WebhookID); gerr == nil {
-				cfg.LaunchVars = nilIfEmpty(manifestLaunchVars(desiredBots, frByBot))
-				cfg.OperatorLaunchVars = nilIfEmpty(maps.Clone(operatorVars))
-				cfg.Overlap = operatorOverlap
-				cfg.HoldLabels = operatorHold
-				cfg.LabelAllowlist = operatorLabels
-				cfg.UpdatedAt = o.clock()
-				if uerr := o.Webhooks.Update(ctx, cfg); uerr != nil {
-					return ProvisionResult{}, fmt.Errorf("forge: update webhook launch vars: %w", uerr)
-				}
+			// The integration now says one thing and the config still says
+			// another, so a failed read here cannot be skipped: the operator's
+			// settings are enforced from the CONFIG, and a divergence would
+			// leave the repo running the previous ones while the API reports
+			// the new ones. Surface it instead of returning a success that
+			// only half applied.
+			cfg, gerr := o.Webhooks.Get(ctx, existing.WebhookID)
+			if gerr != nil {
+				return ProvisionResult{}, fmt.Errorf("forge: read webhook %s to apply the repo's operator settings: %w", existing.WebhookID, gerr)
+			}
+			cfg.LaunchVars = nilIfEmpty(manifestLaunchVars(desiredBots, frByBot))
+			cfg.OperatorLaunchVars = nilIfEmpty(maps.Clone(operatorVars))
+			cfg.Overlap = operatorOverlap
+			cfg.HoldLabels = operatorHold
+			cfg.LabelAllowlist = operatorLabels
+			cfg.UpdatedAt = o.clock()
+			if uerr := o.Webhooks.Update(ctx, cfg); uerr != nil {
+				return ProvisionResult{}, fmt.Errorf("forge: update webhook operator settings: %w", uerr)
 			}
 		}
 		// Backfill the per-bot routing table onto a config provisioned before

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -149,6 +149,10 @@ type ProvisionRequest struct {
 	// HoldLabels is the operator's per-repo automation pause. Nil means "keep
 	// what the repo already has" — the same rule as LaunchVars.
 	HoldLabels []string
+	// LabelAllowlist narrows which freshly-applied issue label dispatches the
+	// implementer. Nil means "keep what the repo already has"; a non-nil empty
+	// slice widens it back to any label — the same rule as HoldLabels.
+	LabelAllowlist []string
 
 	// AutoFix opts the repo into the zero-touch lane (a red merge gate launches
 	// the repo's fixer). A nil pointer means "leave the repo's current choice
@@ -236,6 +240,19 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 			}
 		}
 	}
+	operatorLabels := req.LabelAllowlist
+	if operatorLabels == nil && hasExisting {
+		operatorLabels = existing.LabelAllowlist
+		// Same backfill as the pause above: narrowing the issue lane was a
+		// webhook-config PATCH before it lived here, and that is still the
+		// documented gesture. Dropping it on re-provision fails OPEN — the repo
+		// silently returns to "any label dispatches the implementer".
+		if len(operatorLabels) == 0 {
+			if prev, gerr := o.Webhooks.Get(ctx, existing.WebhookID); gerr == nil {
+				operatorLabels = prev.LabelAllowlist
+			}
+		}
+	}
 	operatorAutoFix := hasExisting && existing.AutoFixOnGateFailure
 	if req.AutoFix != nil {
 		operatorAutoFix = *req.AutoFix
@@ -286,10 +303,12 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		// A changed operator override is a real mutation even when the bot set
 		// is not — without this the short-circuit would silently ignore it.
 		if !maps.Equal(operatorVars, existing.LaunchVars) || operatorOverlap != existing.Overlap ||
-			operatorAutoFix != existing.AutoFixOnGateFailure || !slices.Equal(operatorHold, existing.HoldLabels) {
+			operatorAutoFix != existing.AutoFixOnGateFailure || !slices.Equal(operatorHold, existing.HoldLabels) ||
+			!slices.Equal(operatorLabels, existing.LabelAllowlist) {
 			existing.LaunchVars = operatorVars
 			existing.Overlap = operatorOverlap
 			existing.HoldLabels = operatorHold
+			existing.LabelAllowlist = operatorLabels
 			existing.AutoFixOnGateFailure = operatorAutoFix
 			existing.UpdatedAt = o.clock()
 			if uerr := o.Integrations.Update(ctx, existing); uerr != nil {
@@ -300,6 +319,7 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 				cfg.OperatorLaunchVars = nilIfEmpty(maps.Clone(operatorVars))
 				cfg.Overlap = operatorOverlap
 				cfg.HoldLabels = operatorHold
+				cfg.LabelAllowlist = operatorLabels
 				cfg.UpdatedAt = o.clock()
 				if uerr := o.Webhooks.Update(ctx, cfg); uerr != nil {
 					return ProvisionResult{}, fmt.Errorf("forge: update webhook launch vars: %w", uerr)
@@ -441,6 +461,7 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		ProjectAllowlist:   []string{req.RepoFullName},
 		EventAllowlist:     nativeEvents,
 		AuthorAllowlist:    authorAllowlist,
+		LabelAllowlist:     operatorLabels,
 		ReviewOnSync:       reviewOnSync,
 		ForgeBaseURL:       conn.BaseURL(),
 		RateLimit:          webhooks.Rate{Rate: 1, Burst: 10},
@@ -514,6 +535,7 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		LaunchVars:           nilIfEmpty(maps.Clone(operatorVars)),
 		Overlap:              operatorOverlap,
 		HoldLabels:           operatorHold,
+		LabelAllowlist:       operatorLabels,
 		AutoFixOnGateFailure: operatorAutoFix,
 		CreatedBy:            req.ActorID,
 		CreatedAt:            now,

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -214,6 +214,22 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		desiredBots = dedupSorted(append(append([]string{}, existing.BotIDs...), req.BotIDs...))
 	}
 
+	// The provisioned config is where these settings are ENFORCED, and it can
+	// legitimately hold a value the integration does not: hold labels and the
+	// label allowlist were webhook-config PATCHes before they lived on the
+	// integration, and that is still what the webhook API accepts. Read it once
+	// — the adoption backfills below and the idempotent path's divergence check
+	// both need it. A failed read is not fatal here (a fresh provision has no
+	// config yet); the idempotent path re-raises it before writing anything.
+	var prevCfg webhooks.Config
+	var prevCfgErr error
+	hasPrevCfg := false
+	if hasExisting && existing.WebhookID != "" {
+		if prevCfg, prevCfgErr = o.Webhooks.Get(ctx, existing.WebhookID); prevCfgErr == nil {
+			hasPrevCfg = true
+		}
+	}
+
 	// Operator overrides survive a re-provision: Provision rewrites the whole
 	// webhook config from the manifests, so anything PATCHed onto the webhook
 	// is lost at the next enable. A nil request map means "leave them alone",
@@ -234,10 +250,8 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		// they lived here, and that is still what the webhook API PATCHes. A
 		// provision that read only the integration would wipe a pause an
 		// operator had set the documented way — so adopt it instead.
-		if len(operatorHold) == 0 {
-			if prev, gerr := o.Webhooks.Get(ctx, existing.WebhookID); gerr == nil {
-				operatorHold = prev.HoldLabels
-			}
+		if len(operatorHold) == 0 && hasPrevCfg {
+			operatorHold = prevCfg.HoldLabels
 		}
 	}
 	operatorLabels := req.LabelAllowlist
@@ -247,10 +261,8 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		// webhook-config PATCH before it lived here, and that is still the
 		// documented gesture. Dropping it on re-provision fails OPEN — the repo
 		// silently returns to "any label dispatches the implementer".
-		if len(operatorLabels) == 0 {
-			if prev, gerr := o.Webhooks.Get(ctx, existing.WebhookID); gerr == nil {
-				operatorLabels = prev.LabelAllowlist
-			}
+		if len(operatorLabels) == 0 && hasPrevCfg {
+			operatorLabels = prevCfg.LabelAllowlist
 		}
 	}
 	operatorAutoFix := hasExisting && existing.AutoFixOnGateFailure
@@ -302,9 +314,26 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		}
 		// A changed operator override is a real mutation even when the bot set
 		// is not — without this the short-circuit would silently ignore it.
-		if !maps.Equal(operatorVars, existing.LaunchVars) || operatorOverlap != existing.Overlap ||
+		// The comparison runs against BOTH stores, because they can diverge: an
+		// explicit request that already matches the (empty) integration while
+		// the config still enforces the old value would otherwise return 200
+		// having changed nothing — the operator reads the widening back from
+		// the API while the lane stays narrowed.
+		changed := !maps.Equal(operatorVars, existing.LaunchVars) || operatorOverlap != existing.Overlap ||
 			operatorAutoFix != existing.AutoFixOnGateFailure || !slices.Equal(operatorHold, existing.HoldLabels) ||
-			!slices.Equal(operatorLabels, existing.LabelAllowlist) {
+			!slices.Equal(operatorLabels, existing.LabelAllowlist)
+		if hasPrevCfg {
+			changed = changed || !slices.Equal(operatorLabels, prevCfg.LabelAllowlist) ||
+				!slices.Equal(operatorHold, prevCfg.HoldLabels) || operatorOverlap != prevCfg.Overlap ||
+				!maps.Equal(operatorVars, prevCfg.OperatorLaunchVars)
+		}
+		if changed {
+			// The config is the enforcement half, so a failed read cannot be
+			// skipped: writing only the integration would leave the repo running
+			// the previous settings while the API reports the new ones.
+			if !hasPrevCfg {
+				return ProvisionResult{}, fmt.Errorf("forge: read webhook %s to apply the repo's operator settings: %w", existing.WebhookID, prevCfgErr)
+			}
 			existing.LaunchVars = operatorVars
 			existing.Overlap = operatorOverlap
 			existing.HoldLabels = operatorHold
@@ -314,16 +343,7 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 			if uerr := o.Integrations.Update(ctx, existing); uerr != nil {
 				return ProvisionResult{}, fmt.Errorf("forge: update integration launch vars: %w", uerr)
 			}
-			// The integration now says one thing and the config still says
-			// another, so a failed read here cannot be skipped: the operator's
-			// settings are enforced from the CONFIG, and a divergence would
-			// leave the repo running the previous ones while the API reports
-			// the new ones. Surface it instead of returning a success that
-			// only half applied.
-			cfg, gerr := o.Webhooks.Get(ctx, existing.WebhookID)
-			if gerr != nil {
-				return ProvisionResult{}, fmt.Errorf("forge: read webhook %s to apply the repo's operator settings: %w", existing.WebhookID, gerr)
-			}
+			cfg := prevCfg
 			cfg.LaunchVars = nilIfEmpty(manifestLaunchVars(desiredBots, frByBot))
 			cfg.OperatorLaunchVars = nilIfEmpty(maps.Clone(operatorVars))
 			cfg.Overlap = operatorOverlap
@@ -495,9 +515,9 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 
 	createdConfig := false
 	if hasExisting && existing.WebhookID != "" {
-		if old, gerr := o.Webhooks.Get(ctx, webhookID); gerr == nil {
-			cfg.CreatedAt = old.CreatedAt
-			cfg.CreatedBy = old.CreatedBy
+		if hasPrevCfg {
+			cfg.CreatedAt = prevCfg.CreatedAt
+			cfg.CreatedBy = prevCfg.CreatedBy
 		}
 		cfg.RotatedAt = &now
 		if err := o.Webhooks.Update(ctx, cfg); err != nil {

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -336,21 +336,23 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		}
 		// A changed operator override is a real mutation even when the bot set
 		// is not — without this the short-circuit would silently ignore it.
-		// The label sets are also compared against the CONFIG, because the two
-		// stores legitimately diverge there: an explicit request that already
-		// matches the (empty) integration while the config still enforces the
-		// old value would otherwise return 200 having changed nothing — the
-		// operator reads the widening back from the API while the lane stays
-		// narrowed. Only these two qualify: comparing a field that has no
-		// adoption backfill (overlap, launch vars) would read the config's
-		// value as a difference to erase, turning a benign no-op into a write
-		// that drops a policy set the documented way.
+		// Compared against BOTH stores, which is only sound because every field
+		// resolved above ends at the config when the integration says nothing:
+		// a silent request therefore already equals the config value and
+		// signals no difference to erase. What the config half catches is the
+		// EXPLICIT request that happens to match an empty integration while the
+		// config still enforces the old value — `label_allowlist: []` sent to
+		// widen a lane narrowed the documented way. Without it the call returns
+		// 200 having written nothing, and the operator reads an open lane back
+		// from an API whose enforcement surface still filters.
 		changed := !maps.Equal(operatorVars, existing.LaunchVars) || operatorOverlap != existing.Overlap ||
 			operatorAutoFix != existing.AutoFixOnGateFailure || !slices.Equal(operatorHold, existing.HoldLabels) ||
 			!slices.Equal(operatorLabels, existing.LabelAllowlist)
 		if hasPrevCfg {
 			changed = changed || !slices.Equal(operatorLabels, prevCfg.LabelAllowlist) ||
-				!slices.Equal(operatorHold, prevCfg.HoldLabels)
+				!slices.Equal(operatorHold, prevCfg.HoldLabels) ||
+				operatorOverlap != prevCfg.Overlap ||
+				!maps.Equal(operatorVars, prevCfg.OperatorLaunchVars)
 		}
 		if changed {
 			// The config is the enforcement half, so it cannot be skipped:

--- a/pkg/forge/orchestrator_label_allowlist_test.go
+++ b/pkg/forge/orchestrator_label_allowlist_test.go
@@ -1,0 +1,154 @@
+package forge
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+// TestProvisionKeepsTheOperatorLabelAllowlist: narrowing the issue-labeled lane
+// (only `implement` dispatches the implementer, not every triage label) is a
+// webhook-config PATCH, and Provision rebuilds that config from the manifests.
+// Enabling one more bot therefore wiped the narrowing — silently, and fail-OPEN:
+// the repo went back to "any label on any issue starts a feature-dev campaign".
+func TestProvisionKeepsTheOperatorLabelAllowlist(t *testing.T) {
+	o, _, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	res, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The operator narrows the lane the documented way: a PATCH on the webhook.
+	cfg, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.LabelAllowlist = []string{"implement"}
+	if err := o.Webhooks.Update(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Later: one more bot is enabled on the same repo — the full (non
+	// short-circuit) provision path, which rewrites the config as a whole.
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"revi-converse"}, ActorID: "u1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(after.LabelAllowlist, []string{"implement"}) {
+		t.Errorf("LabelAllowlist was wiped by the re-provision (%v). An empty allowlist "+
+			"matches EVERY label, so the repo silently returns to dispatching the "+
+			"implementer on any label an operator adds to any issue.", after.LabelAllowlist)
+	}
+	// It must also land on the integration, which is what makes it durable for
+	// every FURTHER provision (the config adoption above only fires once).
+	integ, err := o.Integrations.Get(ctx, res.IntegrationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(integ.LabelAllowlist, []string{"implement"}) {
+		t.Errorf("the adopted allowlist was not persisted on the integration: %v", integ.LabelAllowlist)
+	}
+}
+
+// TestProvisionKeepsLabelAllowlistOnTheIdempotentPath: re-enabling the SAME
+// bots takes the short-circuit, which writes the operator fields back onto the
+// config. It must carry the allowlist too — otherwise the cheap no-op path is
+// exactly what re-widens the lane.
+func TestProvisionKeepsLabelAllowlistOnTheIdempotentPath(t *testing.T) {
+	o, _, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	res, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1", LabelAllowlist: []string{"implement"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	after, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(after.LabelAllowlist, []string{"implement"}) {
+		t.Errorf("the idempotent re-provision widened the issue lane back to any label: %v", after.LabelAllowlist)
+	}
+}
+
+// TestProvisionSetsAndClearsLabelAllowlist: the operator owns the field in both
+// directions. Nil says nothing (keep), a non-nil list narrows, and a non-nil
+// EMPTY list is the explicit widening — without that distinction there is no
+// way back to "any label" once a repo has been narrowed.
+func TestProvisionSetsAndClearsLabelAllowlist(t *testing.T) {
+	o, _, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	res, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.LabelAllowlist) != 0 {
+		t.Fatalf("a fresh provision must not invent an allowlist: %v", cfg.LabelAllowlist)
+	}
+
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1", LabelAllowlist: []string{"implement", "ship-it"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	integ, err := o.Integrations.Get(ctx, res.IntegrationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(integ.LabelAllowlist, []string{"implement", "ship-it"}) {
+		t.Fatalf("allowlist not applied: %v", integ.LabelAllowlist)
+	}
+
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1", LabelAllowlist: []string{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	integ, err = o.Integrations.Get(ctx, res.IntegrationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(integ.LabelAllowlist) != 0 {
+		t.Fatalf("an explicit empty allowlist must widen the lane back: %v", integ.LabelAllowlist)
+	}
+	cfg, err = o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.LabelAllowlist) != 0 {
+		t.Fatalf("the widening did not reach the webhook config: %v", cfg.LabelAllowlist)
+	}
+}

--- a/pkg/forge/orchestrator_label_allowlist_test.go
+++ b/pkg/forge/orchestrator_label_allowlist_test.go
@@ -52,7 +52,9 @@ func TestProvisionKeepsTheOperatorLabelAllowlist(t *testing.T) {
 			"implementer on any label an operator adds to any issue.", after.LabelAllowlist)
 	}
 	// It must also land on the integration, which is what makes it durable for
-	// every FURTHER provision (the config adoption above only fires once).
+	// every FURTHER provision: the config adoption re-fires only while the
+	// integration's own allowlist is empty, so persisting it here is what ends
+	// the dependency on the config still carrying the operator's choice.
 	integ, err := o.Integrations.Get(ctx, res.IntegrationID)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/forge/orchestrator_label_allowlist_test.go
+++ b/pkg/forge/orchestrator_label_allowlist_test.go
@@ -141,6 +141,54 @@ func TestProvisionWidensALabelAllowlistThatLivesOnlyOnTheConfig(t *testing.T) {
 	}
 }
 
+// TestProvisionKeepsAConfigOnlyOverlapWhileAdoptingAnAllowlist: adopting the
+// label allowlist makes the idempotent path WRITE where it used to no-op, so
+// every other operator field the write stamps must resolve from the config too.
+// Overlap is the sharp one: it is fail-open (no policy = launch every delivery),
+// and a repo that set it the documented way (a webhook PATCH) stores nothing on
+// the integration — so a write driven by the allowlist would stamp "" over it.
+func TestProvisionKeepsAConfigOnlyOverlapWhileAdoptingAnAllowlist(t *testing.T) {
+	o, _, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	res, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Overlap = "supersede"
+	cfg.LabelAllowlist = []string{"implement"}
+	if err := o.Webhooks.Update(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	// A studio bot-set PATCH: same bots, no operator field in the request.
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	after, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Overlap != "supersede" {
+		t.Errorf("overlap dropped to %q — an empty policy launches every delivery, "+
+			"so a re-review webhook now runs a bot per push in a burst", after.Overlap)
+	}
+	if !slices.Equal(after.LabelAllowlist, []string{"implement"}) {
+		t.Errorf("allowlist lost while keeping overlap: %v", after.LabelAllowlist)
+	}
+}
+
 // TestProvisionSetsAndClearsLabelAllowlist: the operator owns the field in both
 // directions. Nil says nothing (keep), a non-nil list narrows, and a non-nil
 // EMPTY list is the explicit widening — without that distinction there is no

--- a/pkg/forge/orchestrator_label_allowlist_test.go
+++ b/pkg/forge/orchestrator_label_allowlist_test.go
@@ -95,6 +95,52 @@ func TestProvisionKeepsLabelAllowlistOnTheIdempotentPath(t *testing.T) {
 	}
 }
 
+// TestProvisionWidensALabelAllowlistThatLivesOnlyOnTheConfig: the legacy state
+// this branch exists to handle — the narrowing sits on the webhook config while
+// the integration stores none. An operator widening it back with an explicit
+// empty list matches the (empty) integration, so a mutation check that only
+// compared the two would find no change, skip the write, and return 200 with
+// the lane still narrowed: the API would report a widening that never reached
+// the surface enforcing it.
+func TestProvisionWidensALabelAllowlistThatLivesOnlyOnTheConfig(t *testing.T) {
+	o, _, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	res, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.LabelAllowlist = []string{"implement"}
+	if err := o.Webhooks.Update(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Same bots, same events → the idempotent short-circuit, with an explicit
+	// widening in the request.
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"review-pr"}, ActorID: "u1", LabelAllowlist: []string{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	after, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after.LabelAllowlist) != 0 {
+		t.Errorf("the explicit widening never reached the webhook config: %v — the lane "+
+			"stays narrowed while the API reports it open", after.LabelAllowlist)
+	}
+}
+
 // TestProvisionSetsAndClearsLabelAllowlist: the operator owns the field in both
 // directions. Nil says nothing (keep), a non-nil list narrows, and a non-nil
 // EMPTY list is the explicit widening — without that distinction there is no

--- a/pkg/forge/orchestrator_label_allowlist_test.go
+++ b/pkg/forge/orchestrator_label_allowlist_test.go
@@ -164,6 +164,7 @@ func TestProvisionKeepsAConfigOnlyOverlapWhileAdoptingAnAllowlist(t *testing.T) 
 		t.Fatal(err)
 	}
 	cfg.Overlap = "supersede"
+	cfg.OperatorLaunchVars = map[string]string{"gate_context": "revi/review"}
 	cfg.LabelAllowlist = []string{"implement"}
 	if err := o.Webhooks.Update(ctx, cfg); err != nil {
 		t.Fatal(err)
@@ -184,8 +185,22 @@ func TestProvisionKeepsAConfigOnlyOverlapWhileAdoptingAnAllowlist(t *testing.T) 
 		t.Errorf("overlap dropped to %q — an empty policy launches every delivery, "+
 			"so a re-review webhook now runs a bot per push in a burst", after.Overlap)
 	}
+	if after.OperatorLaunchVars["gate_context"] != "revi/review" {
+		t.Errorf("operator launch vars dropped (%v) — the repo's merge gate is named "+
+			"there, so every later run posts its status under the wrong context",
+			after.OperatorLaunchVars)
+	}
 	if !slices.Equal(after.LabelAllowlist, []string{"implement"}) {
 		t.Errorf("allowlist lost while keeping overlap: %v", after.LabelAllowlist)
+	}
+	// Both must also have landed on the integration — the config half only
+	// carries them until the first adoption.
+	integ, err := o.Integrations.Get(ctx, res.IntegrationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if integ.Overlap != "supersede" || integ.LaunchVars["gate_context"] != "revi/review" {
+		t.Errorf("adoption did not persist overlap/launch vars: overlap=%q vars=%v", integ.Overlap, integ.LaunchVars)
 	}
 }
 

--- a/pkg/forge/repo_integration_store.go
+++ b/pkg/forge/repo_integration_store.go
@@ -55,6 +55,15 @@ type RepoIntegration struct {
 	// zero-touch lane below.
 	HoldLabels []string `bson:"hold_labels,omitempty" json:"hold_labels,omitempty"`
 
+	// LabelAllowlist narrows the issue-labeled lane to the labels this repo
+	// treats as "dispatch the implementer" (e.g. ["implement"]); empty means
+	// ANY freshly-applied label launches it. It lives here, not only on the
+	// webhook config, for the same reason as HoldLabels: Provision rebuilds
+	// that config from the manifests, so a narrowing set only on the config is
+	// wiped by the next enable — and that regression is both silent and
+	// fail-OPEN, turning every triage label back into a feature-dev campaign.
+	LabelAllowlist []string `bson:"label_allowlist,omitempty" json:"label_allowlist,omitempty"`
+
 	// AutoFixOnGateFailure opts this repo into the ZERO-TOUCH lane: when a review
 	// leaves the merge gate red, the enabled bot that consumes reviews is
 	// launched on that head to answer the findings, with no human command.

--- a/pkg/server/forge_provisioning_routes.go
+++ b/pkg/server/forge_provisioning_routes.go
@@ -65,6 +65,11 @@ type forgeEnableReq struct {
 	// HoldLabels is the repo's automation pause; nil keeps the current set
 	// (forge.RepoIntegration.HoldLabels).
 	HoldLabels []string `json:"hold_labels,omitempty"`
+
+	// LabelAllowlist narrows which freshly-applied issue label dispatches the
+	// implementer (e.g. ["implement"]); nil keeps the current set
+	// (forge.RepoIntegration.LabelAllowlist).
+	LabelAllowlist []string `json:"label_allowlist,omitempty"`
 }
 
 func (s *Server) handleEnableForgeRepoBots(w http.ResponseWriter, r *http.Request) {
@@ -88,16 +93,17 @@ func (s *Server) handleEnableForgeRepoBots(w http.ResponseWriter, r *http.Reques
 	}
 	ctx := store.WithTenant(r.Context(), teamID)
 	res, err := s.forgeOrchestrator.Provision(ctx, forge.ProvisionRequest{
-		TenantID:      teamID,
-		ConnectionID:  req.ConnectionID,
-		RepoFullName:  strings.TrimSpace(req.Repo),
-		BotIDs:        req.BotIDs,
-		ScheduleCrons: req.ScheduleCrons,
-		LaunchVars:    req.LaunchVars,
-		Overlap:       req.Overlap,
-		AutoFix:       req.AutoFixOnGateFailure,
-		HoldLabels:    req.HoldLabels,
-		ActorID:       id.UserID,
+		TenantID:       teamID,
+		ConnectionID:   req.ConnectionID,
+		RepoFullName:   strings.TrimSpace(req.Repo),
+		BotIDs:         req.BotIDs,
+		ScheduleCrons:  req.ScheduleCrons,
+		LaunchVars:     req.LaunchVars,
+		Overlap:        req.Overlap,
+		AutoFix:        req.AutoFixOnGateFailure,
+		HoldLabels:     req.HoldLabels,
+		LabelAllowlist: req.LabelAllowlist,
+		ActorID:        id.UserID,
 	})
 	if err != nil {
 		s.writeForgeProvisionError(w, err)
@@ -135,6 +141,11 @@ type forgeUpdateReq struct {
 	// HoldLabels is the repo's automation pause; nil keeps the current set
 	// (forge.RepoIntegration.HoldLabels).
 	HoldLabels []string `json:"hold_labels,omitempty"`
+
+	// LabelAllowlist narrows which freshly-applied issue label dispatches the
+	// implementer (e.g. ["implement"]); nil keeps the current set
+	// (forge.RepoIntegration.LabelAllowlist).
+	LabelAllowlist []string `json:"label_allowlist,omitempty"`
 }
 
 func (s *Server) handleUpdateForgeRepoBots(w http.ResponseWriter, r *http.Request) {
@@ -160,17 +171,18 @@ func (s *Server) handleUpdateForgeRepoBots(w http.ResponseWriter, r *http.Reques
 	}
 	ctx := store.WithTenant(r.Context(), teamID)
 	res, err := s.forgeOrchestrator.Provision(ctx, forge.ProvisionRequest{
-		TenantID:      teamID,
-		ConnectionID:  ri.ConnectionID,
-		RepoFullName:  ri.RepoFullName,
-		BotIDs:        req.BotIDs,
-		ScheduleCrons: req.ScheduleCrons,
-		LaunchVars:    req.LaunchVars,
-		Overlap:       req.Overlap,
-		AutoFix:       req.AutoFixOnGateFailure,
-		HoldLabels:    req.HoldLabels,
-		ActorID:       id.UserID,
-		Replace:       true,
+		TenantID:       teamID,
+		ConnectionID:   ri.ConnectionID,
+		RepoFullName:   ri.RepoFullName,
+		BotIDs:         req.BotIDs,
+		ScheduleCrons:  req.ScheduleCrons,
+		LaunchVars:     req.LaunchVars,
+		Overlap:        req.Overlap,
+		AutoFix:        req.AutoFixOnGateFailure,
+		HoldLabels:     req.HoldLabels,
+		LabelAllowlist: req.LabelAllowlist,
+		ActorID:        id.UserID,
+		Replace:        true,
 	})
 	if err != nil {
 		s.writeForgeProvisionError(w, err)

--- a/pkg/server/forge_routes_label_allowlist_test.go
+++ b/pkg/server/forge_routes_label_allowlist_test.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// TestForgeRepoBots_LabelAllowlistSurvivesABotSetUpdate pins the INGRESS for the
+// issue-lane narrowing. The studio's Integrations tab PATCHes bot_ids and
+// nothing else, which re-provisions the repo — so an allowlist that lived only
+// on the webhook config was wiped by a bot toggle, and the failure is
+// fail-open: every label dispatches the implementer again, with no error to
+// notice. The field is operator-owned on the integration, so an absent one
+// keeps the stored set and an explicit one replaces it.
+func TestForgeRepoBots_LabelAllowlistSurvivesABotSetUpdate(t *testing.T) {
+	gl := newMockGitLab()
+	srv := gl.server()
+	defer srv.Close()
+
+	s := newForgeTestServer(t)
+	ctx := superAdminCtx()
+
+	w := httptest.NewRecorder()
+	s.handleConnectForge(w, forgeReq(ctx, "POST", "/api/teams/t1/forge/connections",
+		`{"provider":"gitlab","mode":"pat","forge_base_url":"`+srv.URL+`","pat":"glpat-token"}`, "t1"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("connect: code=%d body=%s", w.Code, w.Body.String())
+	}
+	var connResp forgeConnectResp
+	if err := json.Unmarshal(w.Body.Bytes(), &connResp); err != nil {
+		t.Fatal(err)
+	}
+
+	// Enable with the narrowing: only `implement` dispatches the implementer.
+	w = httptest.NewRecorder()
+	s.handleEnableForgeRepoBots(w, forgeReq(ctx, "POST", "/api/teams/t1/forge/repo-bots",
+		`{"connection_id":"`+connResp.Connection.ID+`","repo":"group/api","bot_ids":["review-pr"],"label_allowlist":["implement"]}`, "t1"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("enable: code=%d body=%s", w.Code, w.Body.String())
+	}
+	var res forge.ProvisionResult
+	if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := s.webhookConfigs.Get(context.Background(), res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(cfg.LabelAllowlist, []string{"implement"}) {
+		t.Fatalf("label_allowlist did not reach the webhook config: %v", cfg.LabelAllowlist)
+	}
+
+	// The studio's gesture: PATCH the bot set, saying nothing about labels.
+	patch := forgeReq(ctx, "PATCH", "/api/teams/t1/forge/repo-bots/"+res.IntegrationID,
+		`{"bot_ids":["review-pr"]}`, "t1")
+	patch.SetPathValue("integration_id", res.IntegrationID)
+	w = httptest.NewRecorder()
+	s.handleUpdateForgeRepoBots(w, patch)
+	if w.Code != http.StatusOK {
+		t.Fatalf("update: code=%d body=%s", w.Code, w.Body.String())
+	}
+	cfg, err = s.webhookConfigs.Get(context.Background(), res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(cfg.LabelAllowlist, []string{"implement"}) {
+		t.Errorf("a bot-set update widened the issue lane back to any label: %v", cfg.LabelAllowlist)
+	}
+
+	// An explicit list replaces it — the operator still owns the field.
+	patch = forgeReq(ctx, "PATCH", "/api/teams/t1/forge/repo-bots/"+res.IntegrationID,
+		`{"bot_ids":["review-pr"],"label_allowlist":["ship-it"]}`, "t1")
+	patch.SetPathValue("integration_id", res.IntegrationID)
+	w = httptest.NewRecorder()
+	s.handleUpdateForgeRepoBots(w, patch)
+	if w.Code != http.StatusOK {
+		t.Fatalf("update with allowlist: code=%d body=%s", w.Code, w.Body.String())
+	}
+	integ, err := s.forgeIntegrations.Get(context.Background(), res.IntegrationID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(integ.LabelAllowlist, []string{"ship-it"}) {
+		t.Errorf("explicit label_allowlist not applied: %v", integ.LabelAllowlist)
+	}
+}


### PR DESCRIPTION
## Le défaut

Narrowing which freshly-applied issue label dispatches the implementer
(`label_allowlist`) was a webhook-config PATCH, and `Provision` rebuilds that
config as a whole literal from the manifests. Any bot-set change — the studio
Integrations tab PATCHes `bot_ids` and nothing else — therefore dropped the
narrowing.

The regression is silent **and fail-open**: an empty allowlist matches *every*
label, so the repo goes back to starting a feature-dev campaign on any label
added to any issue. `launch_vars`, `overlap`, `hold_labels` and
`auto_fix_on_gate_failure` already live on the integration for exactly this
reason; the allowlist did not.

## Le fix

`label_allowlist` becomes operator-owned on `RepoIntegration`, following the
`hold_labels` template:

- nil in the request keeps the stored set, an explicit list replaces it, an
  explicit empty list widens the lane back to any label;
- propagated on **both** provision paths — the full rebuild and the idempotent
  short-circuit;
- an allowlist already PATCHed onto the webhook config is **adopted** onto the
  integration by the next provision instead of being wiped, so a repo narrowed
  the documented way heals itself rather than silently re-widening.

Exposed on `POST` / `PATCH /api/teams/{id}/forge/repo-bots`.

## Vérification

The three orchestrator tests were confirmed red before the fix (config writes
neutralised):

```
--- FAIL: TestProvisionKeepsTheOperatorLabelAllowlist
    LabelAllowlist was wiped by the re-provision ([]).
--- FAIL: TestProvisionKeepsLabelAllowlistOnTheIdempotentPath
    the idempotent re-provision widened the issue lane back to any label: []
```

Green after: `pkg/forge/...`, `pkg/server`, `pkg/webhooks/...`, `go build ./...`,
`golangci-lint run` (0 issues), no OpenAPI/schema.ts drift. The route test
replays the exact gesture that broke it — `PATCH /repo-bots/{id}` with `bot_ids`
alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)