### PR TITLE
fix(dep-update-guard): the escalate node could never fire — bare model spec

### DIFF
--- a/bots/catalog_model_specs_test.go
+++ b/bots/catalog_model_specs_test.go
@@ -1,0 +1,111 @@
+package bots
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+	"github.com/SocialGouv/iterion/pkg/dsl/types"
+)
+
+// TestCatalogHumanLLMModelSpecsCarryAProvider pins a seam that only fails at
+// the moment a run needs it most.
+//
+// A human node's llm / llm_or_human half runs through the DIRECT generation
+// path (GenerateObjectDirect), which takes a "provider/model-id" spec and has
+// no backend to infer the provider from. An agent node is different: its
+// claude_code backend happily accepts a bare "claude-opus-5", which is why
+// the bare form reads correct everywhere else in a bot and survives every
+// review.
+//
+// Nothing catches the mismatch until the escalation path actually fires:
+// Vetty's `escalate` node carried a bare default from birth, every prior run
+// took the clean/committed routes around it, and the FIRST needs_decision
+// bump in production (a plugin-react major, 2026-08-04) crashed the run with
+// `invalid spec "claude-opus-5"` instead of asking the human — the exact
+// moment the workflow existed to hand over.
+func TestCatalogHumanLLMModelSpecsCarryAProvider(t *testing.T) {
+	var targets []string
+	for _, root := range []string{".", "../examples"} {
+		if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".bot") {
+				return nil
+			}
+			targets = append(targets, path)
+			return nil
+		}); err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+	if len(targets) == 0 {
+		t.Fatal("no catalog workflows found — discovery likely broke")
+	}
+
+	inspected := 0
+	for _, path := range targets {
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("%s: read: %v", path, err)
+			continue
+		}
+		pr := parser.Parse(path, string(src))
+		if pr.File == nil {
+			t.Logf("%s: not inspected (unparseable — the parse/compile test owns that)", path)
+			continue
+		}
+		cr := ir.Compile(pr.File)
+		if cr.Workflow == nil {
+			t.Logf("%s: not inspected (does not compile to a workflow)", path)
+			continue
+		}
+		for _, n := range cr.Workflow.Nodes {
+			h, ok := n.(*ir.HumanNode)
+			if !ok {
+				continue
+			}
+			if h.Interaction != types.InteractionLLM && h.Interaction != types.InteractionLLMOrHuman {
+				continue
+			}
+			for _, spec := range []string{h.InteractionModel, h.Model} {
+				if spec == "" {
+					continue
+				}
+				inspected++
+				if bareModelSpec(spec) {
+					t.Errorf("%s: human node %q (interaction: %s) declares model %q — the direct "+
+						"generation path needs \"provider/model-id\" (e.g. \"anthropic/claude-opus-5\"); "+
+						"a bare name crashes the run at the exact moment it tries to escalate",
+						path, h.ID, h.Interaction, spec)
+				}
+			}
+		}
+	}
+	if inspected == 0 {
+		t.Fatal("no llm-interaction human model specs inspected — either the fleet dropped them all or the IR shape changed")
+	}
+}
+
+// bareModelSpec reports whether a model spec (possibly an ${ENV:-default}
+// substitution) lacks the provider/ prefix. Only the DEFAULT half of a
+// substitution is judged: the env override is the operator's to get right at
+// set time, the default is what every unconfigured deployment runs.
+func bareModelSpec(spec string) bool {
+	s := strings.TrimSpace(spec)
+	// ${VAR:-default} → default; ${VAR} alone → nothing checkable statically.
+	if strings.HasPrefix(s, "${") && strings.HasSuffix(s, "}") {
+		inner := strings.TrimSuffix(strings.TrimPrefix(s, "${"), "}")
+		_, def, ok := strings.Cut(inner, ":-")
+		if !ok {
+			return false
+		}
+		s = strings.TrimSpace(def)
+	}
+	if s == "" {
+		return false
+	}
+	return !strings.Contains(s, "/")
+}

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -719,7 +719,10 @@ human escalate:
   interaction: llm_or_human
   ## The LLM half (auto-answers a routine question); a genuine
   ## architectural choice still pauses for a human.
-  model: "${VETTY_MODEL_ESCALATE:-claude-opus-5}"
+  ## provider/model-id, NOT a bare model name: a human node's llm half runs
+  ## through the direct claw generation path, which has no backend to infer
+  ## the provider from (an agent node's claude_code backend does).
+  model: "${VETTY_MODEL_ESCALATE:-anthropic/claude-opus-5}"
 
 ## verify_build — adaptive capture of the repo's build+tests into the
 ## out-of-tree verify.sh (it does NOT judge; the tool's exit code does).

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,11 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.6.1
+version: 2.6.2
+## 2.6.2 — the escalate node could never fire: its llm half passed a bare
+## "claude-opus-5" to the direct generation path, which requires
+## provider/model-id — every needs_decision bump crashed the run instead of
+## escalating (first exercised live 2026-08-04 on a plugin-react major).
 ## 2.6.1 — budget 75m → 2h: 75m killed the 15-module go workload at its
 ## LAST node (audit 5m + align 25m + verify 43m = 73m, dead at the commit
 ## with everything green behind it). The duration cap is a runaway guard,


### PR DESCRIPTION
Found live on the backlog wave (#21, plugin-react 4→6): the FIRST `needs_decision` verdict in production crashed the run — `escalate`'s llm half passed a bare `claude-opus-5` to the direct generation path, which requires `provider/model-id`. The node was unreachable-by-luck until a major actually warranted escalation.

- `${VETTY_MODEL_ESCALATE:-anthropic/claude-opus-5}` (Vetty 2.6.2)
- New catalog lint (`catalog_model_specs_test.go`): every llm-interaction human node's model default must carry a provider prefix — verified red on the old spec, green on the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)