### PR TITLE
fix(runtime): a failing llm half of llm_or_human degrades to the human pause

### DIFF
--- a/bots/catalog_model_specs_test.go
+++ b/bots/catalog_model_specs_test.go
@@ -1,0 +1,111 @@
+package bots
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/dsl/parser"
+	"github.com/SocialGouv/iterion/pkg/dsl/types"
+)
+
+// TestCatalogHumanLLMModelSpecsCarryAProvider pins a seam that only fails at
+// the moment a run needs it most.
+//
+// A human node's llm / llm_or_human half runs through the DIRECT generation
+// path (GenerateObjectDirect), which takes a "provider/model-id" spec and has
+// no backend to infer the provider from. An agent node is different: its
+// claude_code backend happily accepts a bare "claude-opus-5", which is why
+// the bare form reads correct everywhere else in a bot and survives every
+// review.
+//
+// Nothing catches the mismatch until the escalation path actually fires:
+// Vetty's `escalate` node carried a bare default from birth, every prior run
+// took the clean/committed routes around it, and the FIRST needs_decision
+// bump in production (a plugin-react major, 2026-08-04) crashed the run with
+// `invalid spec "claude-opus-5"` instead of asking the human — the exact
+// moment the workflow existed to hand over.
+func TestCatalogHumanLLMModelSpecsCarryAProvider(t *testing.T) {
+	var targets []string
+	for _, root := range []string{".", "../examples"} {
+		if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".bot") {
+				return nil
+			}
+			targets = append(targets, path)
+			return nil
+		}); err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+	if len(targets) == 0 {
+		t.Fatal("no catalog workflows found — discovery likely broke")
+	}
+
+	inspected := 0
+	for _, path := range targets {
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("%s: read: %v", path, err)
+			continue
+		}
+		pr := parser.Parse(path, string(src))
+		if pr.File == nil {
+			t.Logf("%s: not inspected (unparseable — the parse/compile test owns that)", path)
+			continue
+		}
+		cr := ir.Compile(pr.File)
+		if cr.Workflow == nil {
+			t.Logf("%s: not inspected (does not compile to a workflow)", path)
+			continue
+		}
+		for _, n := range cr.Workflow.Nodes {
+			h, ok := n.(*ir.HumanNode)
+			if !ok {
+				continue
+			}
+			if h.Interaction != types.InteractionLLM && h.Interaction != types.InteractionLLMOrHuman {
+				continue
+			}
+			for _, spec := range []string{h.InteractionModel, h.Model} {
+				if spec == "" {
+					continue
+				}
+				inspected++
+				if bareModelSpec(spec) {
+					t.Errorf("%s: human node %q (interaction: %s) declares model %q — the direct "+
+						"generation path needs \"provider/model-id\" (e.g. \"anthropic/claude-opus-5\"); "+
+						"a bare name crashes the run at the exact moment it tries to escalate",
+						path, h.ID, h.Interaction, spec)
+				}
+			}
+		}
+	}
+	if inspected == 0 {
+		t.Fatal("no llm-interaction human model specs inspected — either the fleet dropped them all or the IR shape changed")
+	}
+}
+
+// bareModelSpec reports whether a model spec (possibly an ${ENV:-default}
+// substitution) lacks the provider/ prefix. Only the DEFAULT half of a
+// substitution is judged: the env override is the operator's to get right at
+// set time, the default is what every unconfigured deployment runs.
+func bareModelSpec(spec string) bool {
+	s := strings.TrimSpace(spec)
+	// ${VAR:-default} → default; ${VAR} alone → nothing checkable statically.
+	if strings.HasPrefix(s, "${") && strings.HasSuffix(s, "}") {
+		inner := strings.TrimSuffix(strings.TrimPrefix(s, "${"), "}")
+		_, def, ok := strings.Cut(inner, ":-")
+		if !ok {
+			return false
+		}
+		s = strings.TrimSpace(def)
+	}
+	if s == "" {
+		return false
+	}
+	return !strings.Contains(s, "/")
+}

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -719,7 +719,10 @@ human escalate:
   interaction: llm_or_human
   ## The LLM half (auto-answers a routine question); a genuine
   ## architectural choice still pauses for a human.
-  model: "${VETTY_MODEL_ESCALATE:-claude-opus-5}"
+  ## provider/model-id, NOT a bare model name: a human node's llm half runs
+  ## through the direct claw generation path, which has no backend to infer
+  ## the provider from (an agent node's claude_code backend does).
+  model: "${VETTY_MODEL_ESCALATE:-anthropic/claude-opus-5}"
 
 ## verify_build — adaptive capture of the repo's build+tests into the
 ## out-of-tree verify.sh (it does NOT judge; the tool's exit code does).

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,11 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.6.1
+version: 2.6.2
+## 2.6.2 — the escalate node could never fire: its llm half passed a bare
+## "claude-opus-5" to the direct generation path, which requires
+## provider/model-id — every needs_decision bump crashed the run instead of
+## escalating (first exercised live 2026-08-04 on a plugin-react major).
 ## 2.6.1 — budget 75m → 2h: 75m killed the 15-module go workload at its
 ## LAST node (audit 5m + align 25m + verify 43m = 73m, dead at the commit
 ## with everything green behind it). The duration cap is a runaway guard,

--- a/pkg/runtime/engine_test.go
+++ b/pkg/runtime/engine_test.go
@@ -1764,6 +1764,93 @@ func TestHumanAutoOrPause_Pauses(t *testing.T) {
 	}
 }
 
+// The llm half of llm_or_human is an optimization; when it cannot run at all
+// (no credential for the direct generation path, a provider outage, a bad
+// model spec) the node must degrade to its HUMAN half, not kill the run — the
+// failure hits at the exact moment a hand-over was warranted. Observed in
+// production 2026-08-04: Vetty's first-ever escalation died on a 401 instead
+// of asking the operator.
+func TestHumanAutoOrPause_LLMFailureFallsBackToHumanPause(t *testing.T) {
+	wf := humanModeWorkflow(ir.InteractionLLMOrHuman)
+	exec := newStubExecutor()
+	exec.on("analyze", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"summary": "complex change"}, nil
+	})
+	exec.on("review", func(_ map[string]any) (map[string]any, error) {
+		return nil, errors.New(`model: invalid spec "claude-opus-5" (expected "provider/model-id")`)
+	})
+
+	s := tmpStore(t)
+	eng := New(wf, s, exec)
+
+	err := eng.Run(context.Background(), "run-aop-llmfail", nil)
+	if !errors.Is(err, ErrRunPaused) {
+		t.Fatalf("expected ErrRunPaused (the human half), got: %v", err)
+	}
+	r, err := s.LoadRun(context.Background(), "run-aop-llmfail")
+	if err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	if r.Status != store.RunStatusPausedWaitingHuman {
+		t.Fatalf("expected paused_waiting_human, got %s", r.Status)
+	}
+	// The degradation is visible, never silent.
+	events, err := s.LoadEvents(context.Background(), "run-aop-llmfail")
+	if err != nil {
+		t.Fatalf("load events: %v", err)
+	}
+	seen := false
+	for _, ev := range events {
+		if ev.Type == store.EventNodeRecovery {
+			seen = true
+		}
+	}
+	if !seen {
+		t.Error("no node_recovery event — the llm-half failure degraded silently")
+	}
+
+	// The human answers, the run completes: the node did its job.
+	exec.on("integrate", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"done": true}, nil
+	})
+	if err := eng.Resume(context.Background(), "run-aop-llmfail",
+		map[string]any{"approved": true, "reason": "human approved"}); err != nil {
+		t.Fatalf("resume failed: %v", err)
+	}
+	r, err = s.LoadRun(context.Background(), "run-aop-llmfail")
+	if err != nil {
+		t.Fatalf("load run after resume: %v", err)
+	}
+	if r.Status != store.RunStatusFinished {
+		t.Errorf("expected finished after the human answered, got %s", r.Status)
+	}
+}
+
+// A run being cancelled mid-llm-half is a stop, not a helper failure — it
+// must NOT be converted into a pause.
+func TestHumanAutoOrPause_CancellationStillFails(t *testing.T) {
+	wf := humanModeWorkflow(ir.InteractionLLMOrHuman)
+	exec := newStubExecutor()
+	exec.on("analyze", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"summary": "s"}, nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	exec.on("review", func(_ map[string]any) (map[string]any, error) {
+		cancel()
+		return nil, context.Canceled
+	})
+
+	s := tmpStore(t)
+	eng := New(wf, s, exec)
+	err := eng.Run(ctx, "run-aop-cancel", nil)
+	if errors.Is(err, ErrRunPaused) {
+		t.Fatal("a cancellation was converted into a human pause")
+	}
+	if err == nil {
+		t.Fatal("expected an error from the cancelled run")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // formatOutputPreview tests
 // ---------------------------------------------------------------------------

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -862,7 +862,29 @@ func (e *Engine) execAutoOrPauseHuman(ctx context.Context, rs *runState, nodeID 
 	execCtx := model.WithLoopIteration(ctx, iter)
 	output, err := e.executor.Execute(execCtx, node, nodeInput)
 	if err != nil {
-		return false, e.failRunWithCheckpoint(rs, nodeID, fmt.Sprintf("human node %q auto_or_pause execution failed: %v", nodeID, err))
+		// The llm half of llm_or_human is an OPTIMIZATION — it auto-answers
+		// the routine case so a human is only pulled in for a real decision.
+		// When that helper itself cannot run (no credential for the direct
+		// generation path, a provider outage, a bad model spec), killing the
+		// run inverts the node's whole purpose: it exists to hand over, and
+		// the failure hits at the exact moment a hand-over was warranted.
+		// Observed in production (2026-08-04): Vetty's first-ever escalation
+		// died on a 401 instead of asking the operator. So degrade to the
+		// human half — the same pause the LLM produces when it declines to
+		// answer. Cancellation still propagates: a run being stopped is not
+		// a helper failure.
+		if ctx.Err() != nil {
+			return false, e.failRunWithCheckpoint(rs, nodeID, fmt.Sprintf("human node %q auto_or_pause execution failed: %v", nodeID, err))
+		}
+		e.logger.Warn("human node %q: llm half failed (%v) — falling back to a human pause", nodeID, err)
+		_ = e.emit(rs.ctx, rs.runID, store.EventNodeRecovery, nodeID, map[string]any{
+			"strategy": "llm_or_human_fallback",
+			"reason":   err.Error(),
+		})
+		if perr := e.persistPause(rs, nodeID); perr != nil {
+			return false, perr
+		}
+		return true, nil
 	}
 
 	// Record budget usage.


### PR DESCRIPTION
Third live find from the Vetty backlog wave: with the escalate model spec fixed (#366), the re-run on #21 died on a **401** — this prod deployment has no direct-path anthropic credential (forfait OAuth only), so the llm half of `llm_or_human` can never run there. Killing the run inverts the node's purpose.

- On llm-half failure (except cancellation): warn + `node_recovery` event + **fall back to the human pause** — the exact same pause the llm produces when it declines to answer. The operator answers; the run continues.
- Tests: fallback pauses + resume completes; a cancellation is never converted into a pause.

Deployment-level companion (separate, infra-apps): `VETTY_MODEL_ESCALATE=openai/gpt-5.5` on the runner so the llm half actually works there (OPENAI_API_KEY is present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)