### PR TITLE
fix(dep-update-guard): verify.sh mirrors CI's exact strictness

### DIFF
--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -330,6 +330,15 @@ prompt verify_user:
   MUST mirror it — run the regen command(s), then fail on drift; the
   deterministic precheck rejects a gateless verify.sh otherwise.
 
+  EQUALLY MANDATORY (skill section 1c): mirror CI's exact STRICTNESS —
+  never stricter, never looser. Copy the CI step's invocation flags
+  verbatim (prefer the repo's own umbrella target, e.g. `task check`);
+  do NOT invent thresholds CI does not enforce (no --max-warnings 0 on
+  a lint CI tolerates warnings from, no promoting advisories to
+  failures). Before any exit-relevant line, ask: "would the repo's CI
+  be red on this exact tree for this reason?" — if you cannot name the
+  CI step that fails, your script must not fail there.
+
 prompt commit_system:
   You commit the code ALIGNMENT produced for this dependency bump onto
   the PR's OWN branch and push it back, so the dependency bot's PR now

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,15 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.6.2
+version: 2.6.3
+## 2.6.3 — verify.sh mirrors CI's exact strictness (skill §1c). Three
+## consecutive re-audits of one PR produced three DIFFERENT authored
+## verify.sh defects (env-dependent test, missing §1b drift gate, then
+## eslint failed on 534 pre-existing warnings / 0 errors while CI was
+## green): the aligner's work was discarded each time by a verify that
+## disagreed with the repo's own definition of green. The skill + prompt
+## now pin the litmus: no exit-relevant line without the CI step that
+## reds on it.
 ## 2.6.2 — the escalate node could never fire: its llm half passed a bare
 ## "claude-opus-5" to the direct generation path, which requires
 ## provider/model-id — every needs_decision bump crashed the run instead of

--- a/bots/dep-update-guard/skills/verify-build.md
+++ b/bots/dep-update-guard/skills/verify-build.md
@@ -94,6 +94,32 @@ red-in-CI. This is not optional whenever the repo commits generated artifacts:
   `<the repo's regen command> && git diff --exit-code -- <the generated
   paths>` — a non-empty diff means stale, which is a real red.
 
+## 1c. Mirror CI's exact strictness — never stricter, never looser
+
+CI is the reference in BOTH directions. Copying CI's *commands* but changing
+their *thresholds* produces a verify.sh that disagrees with the repo's own
+definition of green, and both signs of that disagreement have shipped a wrong
+verdict in production:
+
+- **Never stricter.** Do not invent failure thresholds the repo's CI does not
+  enforce: no `--max-warnings 0` on a lint step whose CI run tolerates
+  warnings, no promoting `go vet`/lint advisories to failures, no `-Werror`
+  the build doesn't set. A tree with 500 pre-existing lint warnings that CI
+  passes MUST pass verify.sh too — a stricter script red-flags a bump for
+  debt it did not create (observed live: a vite bump held `hold_unstable`
+  because verify.sh failed eslint on 534 pre-existing warnings / **0
+  errors**, while the repo's CI on the same tree was fully green). Copy the
+  exact invocation — flags included — from the CI step or the task-runner
+  target CI calls; when in doubt, run the repo's own umbrella target
+  (`task check`, `make ci`) INSTEAD of hand-assembling steps.
+- **Never looser** is §1b: every gate CI enforces (drift, fmt, lint-as-error
+  where CI makes it one) must be present — the precheck rejects a gateless
+  script.
+
+Litmus test before writing `exit`-relevant lines: "would the repo's CI, on
+this exact tree, be red for this reason?" If you cannot point at the CI step
+that fails, your script must not fail there either.
+
 If you changed code that feeds a generator (a new HTTP route, a new exported
 type in a schema-bearing package), regenerating and committing the output is
 part of the work — the gate is here to force it. (iterion specifically:

--- a/pkg/backend/cost/cost_test.go
+++ b/pkg/backend/cost/cost_test.go
@@ -8,7 +8,48 @@ import (
 	"time"
 )
 
+// liveCacheDir returns a cache root for a test that needs claw's live
+// registry ENABLED, so $XDG_CACHE_HOME has to point at a real directory.
+//
+// It deliberately does NOT use t.TempDir(). EstimateUSD reaches
+// clawapi.LookupModelPricing, which calls MaybeRefreshLive — a DETACHED
+// goroutine that resolves $XDG_CACHE_HOME only when it runs and re-creates
+// <root>/claw-code-go through MkdirAll on its way to the cache file. That
+// write can land while t.TempDir()'s RemoveAll is walking the tree, failing
+// an otherwise-green test with "TempDir RemoveAll cleanup: ... directory not
+// empty" (observed on the merge queue, 2026-08-04, run 30944201638).
+// Retrying absorbs the race; a directory we still cannot remove is a few
+// bytes left in os.TempDir(), never a red test.
+func liveCacheDir(t *testing.T) string {
+	t.Helper()
+	root, err := os.MkdirTemp("", "cost-live-cache-")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() {
+		for attempt := 0; ; attempt++ {
+			err := os.RemoveAll(root)
+			if err == nil {
+				return
+			}
+			if attempt == 4 {
+				t.Logf("leaving %s behind (claw's async refresh re-created it): %v", root, err)
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	})
+	return root
+}
+
 func TestEstimateUSD(t *testing.T) {
+	// Pin the static table as the only price source. Without this the
+	// assertions below are machine-dependent: on a host whose claw live
+	// cache already holds claude-haiku-4-5 & co, EstimateUSD answers from
+	// the live registry (it is consulted FIRST) and every exact figure
+	// here becomes a third party's number. Disabling also keeps the async
+	// refresh goroutine from ever starting — see liveCacheDir.
+	t.Setenv("CLAW_DISABLE_LIVE_REGISTRY", "1")
 	cases := []struct {
 		name        string
 		model       string
@@ -50,6 +91,7 @@ func TestEstimateUSD(t *testing.T) {
 }
 
 func TestAnnotate(t *testing.T) {
+	t.Setenv("CLAW_DISABLE_LIVE_REGISTRY", "1") // static table only — see TestEstimateUSD
 	t.Run("known model writes _cost_usd", func(t *testing.T) {
 		out := map[string]any{}
 		total := Annotate(out, "claude-haiku-4-5", 1000, 500)
@@ -87,6 +129,7 @@ func TestAnnotate(t *testing.T) {
 }
 
 func TestAnnotateWithUSD(t *testing.T) {
+	t.Setenv("CLAW_DISABLE_LIVE_REGISTRY", "1") // static table only — see TestEstimateUSD
 	t.Run("provider-computed cost wins over the estimate", func(t *testing.T) {
 		out := map[string]any{}
 		total := AnnotateWithUSD(out, "claude-haiku-4-5", 1000, 500, 0.42)
@@ -137,7 +180,7 @@ func TestEstimateUSD_PrefersLiveRegistry(t *testing.T) {
 	// Seed claw's live cache with rates that intentionally differ from
 	// the static gpt-5 entry so we can verify which source EstimateUSD
 	// trusted.
-	dir := t.TempDir()
+	dir := liveCacheDir(t)
 	t.Setenv("XDG_CACHE_HOME", dir)
 	clawDir := filepath.Join(dir, "claw-code-go")
 	if err := os.MkdirAll(clawDir, 0o755); err != nil {
@@ -176,7 +219,13 @@ func TestEstimateUSD_PrefersLiveRegistry(t *testing.T) {
 // when the live cache has no entry for the model, EstimateUSD falls
 // back to the static table seeded in this package.
 func TestEstimateUSD_FallsBackToStaticTable(t *testing.T) {
-	t.Setenv("XDG_CACHE_HOME", t.TempDir()) // empty cache dir
+	// "No live source" is expressed with claw's own switch rather than an
+	// empty XDG_CACHE_HOME: an empty cache dir left the registry ENABLED,
+	// so the lookup fired a real network refresh whose detached goroutine
+	// then wrote the fetched cache back into this test's temp dir — racing
+	// its removal and, worse, sometimes populating the very cache the test
+	// asserts is absent.
+	t.Setenv("CLAW_DISABLE_LIVE_REGISTRY", "1")
 	got := EstimateUSD("gpt-5", 1_000_000, 1_000_000)
 	if got != 11.25 {
 		t.Errorf("static fallback: got %v, want 11.25", got)


### PR DESCRIPTION
Root-cause of the #19 (Vite 8) verify oscillation: three re-audits, three different authored verify.sh defects (env-dependent test → #368; missing §1b drift gate → precheck caught; eslint failing on 534 pre-existing warnings / 0 errors while CI was green). The alignment itself succeeded every time — the verify authorship variance discarded it.

Skill §1c + MANDATORY prompt block: mirror CI's exact strictness, never stricter, never looser; no exit-relevant line without the CI step that reds on it. Vetty 2.6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)