### PR TITLE
fix(dep-update-guard): the drift-gate precheck loops back instead of discarding the run

### DIFF
--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -482,6 +482,9 @@ schema escalate_output:
   decision: string
   guidance: string
 
+schema verify_feedback_input:
+  precheck_feedback: string
+
 schema verify_plan:
   prepared: bool
   summary: string
@@ -749,6 +752,7 @@ agent verify_build:
   backend: "claude_code"
   model: "${VETTY_MODEL_VALIDATE:-claude-opus-5}"
   reasoning_effort: "${VETTY_EFFORT_VALIDATE:-medium}"
+  input: verify_feedback_input
   output: verify_plan
   system: verify_system
   user: verify_user
@@ -838,13 +842,14 @@ if rc == 0:
             fresh = sorted(post - pre)
             if fresh:
                 rc = 4
-                out = out + chr(10) + 'UNCOMMITTED REGEN OUTPUT: a green verify left new changes in the tree; commit (or gitignore) them:' + chr(10) + chr(10).join(fresh[:50])
+                reason = 'UNCOMMITTED REGEN OUTPUT: a green verify left new changes in the tree; make verify.sh clean up after its regen (or the repo gitignore them):' + chr(10) + chr(10).join(fresh[:50])
+                out = out + chr(10) + reason
 try:
     with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
         lf.write(out)
 except OSError:
     pass
-print(json.dumps({'passed': rc == 0, 'skipped': False, 'exit_code': rc, 'precheck_rejected': rc == 3, 'precheck_reason': (reason if rc == 3 else ''), 'log_tail': out[-4000:]}))
+print(json.dumps({'passed': rc == 0, 'skipped': False, 'exit_code': rc, 'precheck_rejected': rc in (3, 4), 'precheck_reason': (reason if rc in (3, 4) else ''), 'log_tail': out[-4000:]}))
 "`
   output: verify_result
 
@@ -1382,8 +1387,10 @@ workflow dep_update_guard:
   ## not a performance target; the cost cap is the real spend bound.
   budget:
     max_parallel_branches: 1
-    max_duration: "2h"
-    max_cost_usd: 20
+    ## 3h: the heavy go case measured 73m for ONE audit→align→verify pass,
+    ## and the fix_verify loop may add up to two more verify cycles.
+    max_duration: "3h"
+    max_cost_usd: 25
 
   ## Scanners + build toolchain live in the sec sandbox image. One
   ## sandbox for the whole run; network open by default so the auditors

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -842,14 +842,13 @@ if rc == 0:
             fresh = sorted(post - pre)
             if fresh:
                 rc = 4
-                reason = 'UNCOMMITTED REGEN OUTPUT: a green verify left new changes in the tree; make verify.sh clean up after its regen (or the repo gitignore them):' + chr(10) + chr(10).join(fresh[:50])
-                out = out + chr(10) + reason
+                out = out + chr(10) + 'UNCOMMITTED REGEN OUTPUT: a green verify left new changes in the tree; commit (or gitignore) them:' + chr(10) + chr(10).join(fresh[:50])
 try:
     with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
         lf.write(out)
 except OSError:
     pass
-print(json.dumps({'passed': rc == 0, 'skipped': False, 'exit_code': rc, 'precheck_rejected': rc in (3, 4), 'precheck_reason': (reason if rc in (3, 4) else ''), 'log_tail': out[-4000:]}))
+print(json.dumps({'passed': rc == 0, 'skipped': False, 'exit_code': rc, 'precheck_rejected': rc == 3, 'precheck_reason': (reason if rc == 3 else ''), 'log_tail': out[-4000:]}))
 "`
   output: verify_result
 
@@ -1387,9 +1386,11 @@ workflow dep_update_guard:
   ## not a performance target; the cost cap is the real spend bound.
   budget:
     max_parallel_branches: 1
-    ## 3h: the heavy go case measured 73m for ONE audit→align→verify pass,
-    ## and the fix_verify loop may add up to two more verify cycles.
-    max_duration: "3h"
+    ## 4h: the heavy go case measured 73m for ONE audit→align→verify pass,
+    ## a fix_verify cycle re-runs verify_build+verify_run (30–50m each), and
+    ## commit/publish still need room after two of them. The duration cap is
+    ## a runaway guard, not a target; $25 is the spend bound.
+    max_duration: "4h"
     max_cost_usd: 25
 
   ## Scanners + build toolchain live in the sec sandbox image. One

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -319,6 +319,14 @@ prompt verify_system:
 prompt verify_user:
   Repository to verify: {{vars.workspace_dir}}
 
+  Precheck feedback (empty on the first pass): {{input.precheck_feedback}}
+  If non-empty, your PREVIOUS verify.sh was rejected by the deterministic
+  precheck for exactly that reason. AMEND the existing script at
+  `{{vars.scratch_dir}}/verify.sh` to fix precisely what it names (do not
+  start over, do not relax anything else). §1b gates are repo-wide: they
+  are NEVER scoped out by bump relevance — a studio-only bump still runs
+  the repo's Go/openapi drift gate.
+
   Capture the repo's real build + bump-relevant tests into
   `{{vars.scratch_dir}}/verify.sh` (out-of-tree — see the
   `verify-build` + `dependency-pr-guard` skills). The deterministic
@@ -487,6 +495,8 @@ schema verify_result:
   skipped: bool
   exit_code: int
   log_tail: string
+  precheck_rejected: bool
+  precheck_reason: string
 
 schema validate_gate_output:
   stable: bool
@@ -760,7 +770,7 @@ except OSError:
     pass
 script = os.path.join(scratch, 'verify.sh')
 if not os.path.exists(script):
-    print(json.dumps({'passed': False, 'skipped': True, 'exit_code': 1, 'log_tail': 'verify_build produced no verify.sh -- refusing to commit an unverified alignment (fail-closed: this gate is the only path to commit).'}))
+    print(json.dumps({'passed': False, 'skipped': True, 'exit_code': 1, 'precheck_rejected': False, 'precheck_reason': '', 'log_tail': 'verify_build produced no verify.sh -- refusing to commit an unverified alignment (fail-closed: this gate is the only path to commit).'}))
     raise SystemExit(0)
 def tree_state():
     try:
@@ -773,6 +783,7 @@ def tree_state():
 pre = tree_state()
 rc = 0
 out = ''
+reason = ''
 try:
     p = subprocess.run(['sh', script], cwd=ws, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=1200)
     out = p.stdout or ''
@@ -819,7 +830,8 @@ if rc == 0:
             vs = ''
         if not has_drift_gate(vs):
             rc = 3
-            out = out + chr(10) + 'DRIFT GATE MISSING: CI (' + ci_hit + ') enforces a codegen-drift gate but ' + script + ' has none -- edit the script per the verify-build skill section 1b (run the repo regen command, then: git diff --exit-code).'
+            reason = 'DRIFT GATE MISSING: CI (' + ci_hit + ') enforces a codegen-drift gate but ' + script + ' has none -- edit the script per the verify-build skill section 1b (run the repo regen command, then: git diff --exit-code).'
+            out = out + chr(10) + reason
     if rc == 0 and pre is not None:
         post = tree_state()
         if post is not None:
@@ -832,7 +844,7 @@ try:
         lf.write(out)
 except OSError:
     pass
-print(json.dumps({'passed': rc == 0, 'skipped': False, 'exit_code': rc, 'log_tail': out[-4000:]}))
+print(json.dumps({'passed': rc == 0, 'skipped': False, 'exit_code': rc, 'precheck_rejected': rc == 3, 'precheck_reason': (reason if rc == 3 else ''), 'log_tail': out[-4000:]}))
 "`
   output: verify_result
 
@@ -1410,7 +1422,7 @@ workflow dep_update_guard:
     human_question: "{{outputs.align.human_question}}",
     breaking_summary: "{{outputs.align.breaking_summary}}"
   }
-  align_gate -> verify_build when not needs_human
+  align_gate -> verify_build when not needs_human with { precheck_feedback: "" }
 
   ## Escalation → comment with the open decision (no commit).
   escalate -> post_feedback with {
@@ -1422,7 +1434,15 @@ workflow dep_update_guard:
   }
 
   verify_build -> verify_run
-  verify_run -> validate_gate
+  ## The precheck rejecting verify.sh (rc=3: a CI drift gate the script
+  ## does not mirror) is an AUTHORSHIP defect, not a red build — feed the
+  ## exact rejection back so the agent amends its script in-loop instead
+  ## of the whole alignment being discarded at the verdict. Bounded; on
+  ## exhaustion the else edge falls through to the hold path as before.
+  verify_run -> verify_build as fix_verify(2) when precheck_rejected with {
+    precheck_feedback: "{{outputs.verify_run.precheck_reason}}"
+  }
+  verify_run -> validate_gate else
 
   ## Green → commit the alignment onto the PR branch.
   validate_gate -> commit when stable with {

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -2,12 +2,15 @@ name: dep-update-guard
 display_name: Vetty
 icon: 💂
 version: 2.6.5
-## 2.6.5 — Revi follow-ups on the loop-back: budget 2h → 3h/$25 (the
-## loop can add two verify cycles to a 73m heavy pass — without the raise
-## heavy bumps would trade hold_unstable for BUDGET_EXCEEDED); rc=4
-## (uncommitted regen output) joins the loop-back as the same authorship
-## class; verify_build gains an input schema so the feedback wiring is
-## compile-checked instead of silently feeding nothing on a typo.
+## 2.6.5 — Revi hardening of the loop-back: budget 2h → 4h/$25 (a
+## fix_verify cycle re-runs verify_build+verify_run, 30–50m each on the
+## measured heavy case — without the raise heavy bumps would trade
+## hold_unstable for BUDGET_EXCEEDED); verify_build gains an input schema
+## so the feedback wiring is compile-checked. rc=4 deliberately does NOT
+## loop back: it is a DELTA check whose baseline swallows first-pass
+## leftovers on retry (the loop would permanently defeat the gate), and
+## its remedy — commit the regen output — belongs to the alignment, not
+## to the verify script.
 ## 2.6.4 — the drift-gate precheck LOOPS BACK instead of discarding the
 ## run: rc=3 (verify.sh missing a CI-enforced drift gate) now re-enters
 ## verify_build with the exact rejection as feedback (bounded ×2, else →

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,14 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.6.3
+version: 2.6.4
+## 2.6.4 — the drift-gate precheck LOOPS BACK instead of discarding the
+## run: rc=3 (verify.sh missing a CI-enforced drift gate) now re-enters
+## verify_build with the exact rejection as feedback (bounded ×2, else →
+## hold as before). Twice in one day the aligner's correct migration was
+## thrown away because the precheck fired at verdict time — an authorship
+## defect is now self-healed in-loop, and §1b is spelled repo-wide (never
+## scoped out by bump relevance).
 ## 2.6.3 — verify.sh mirrors CI's exact strictness (skill §1c). Three
 ## consecutive re-audits of one PR produced three DIFFERENT authored
 ## verify.sh defects (env-dependent test, missing §1b drift gate, then

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,13 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.6.4
+version: 2.6.5
+## 2.6.5 — Revi follow-ups on the loop-back: budget 2h → 3h/$25 (the
+## loop can add two verify cycles to a 73m heavy pass — without the raise
+## heavy bumps would trade hold_unstable for BUDGET_EXCEEDED); rc=4
+## (uncommitted regen output) joins the loop-back as the same authorship
+## class; verify_build gains an input schema so the feedback wiring is
+## compile-checked instead of silently feeding nothing on a typo.
 ## 2.6.4 — the drift-gate precheck LOOPS BACK instead of discarding the
 ## run: rc=3 (verify.sh missing a CI-enforced drift gate) now re-enters
 ## verify_build with the exact rejection as feedback (bounded ×2, else →


### PR DESCRIPTION
Structural fix for the #19 verify oscillation (companion to #369): rc=3 (verify.sh missing a CI-enforced drift gate) is an AUTHORSHIP defect, not a red build — it now re-enters `verify_build` with the exact rejection as feedback (bounded ×2, `else` → hold as before), instead of discarding the whole alignment at verdict time. §1b spelled repo-wide (never scoped out by bump relevance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)