### PR TITLE
fix(runtime): keep DSL-fail runs rewindable by preserving the checkpoint

### DIFF
--- a/docs/persisted-formats.md
+++ b/docs/persisted-formats.md
@@ -77,7 +77,7 @@ features can legitimately be absent.
 | `paused_waiting_human` | A durable interaction is waiting for answers. | Resume with answers. |
 | `paused_operator` | Soft operator or daily-spend-cap pause with no pending human form. | Runtime-restorable checkpoint; see [resume](resume.md). |
 | `finished` | Reached `done`. | Terminal. |
-| `failed` | Intentional `fail` or failure without resumable persisted state. | Terminal. |
+| `failed` | Intentional `fail` or failure without resumable persisted state. | Terminal (no auto-resume), but the checkpoint is preserved so an explicit `rewind` can recover it; runs failed before that preservation have none and stay unrecoverable. |
 | `failed_resumable` | Failure with a restart checkpoint, or an entry restart marker. | Resume without answers. |
 | `cancelled` | User interruption with state preserved when possible. | Resume without answers. |
 

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -222,11 +222,18 @@ prompt, not the conversation the operator is trying to change).
 
 ### Preconditions and limits
 
-The run must be `failed_resumable`, `cancelled`, `paused_operator`,
+The run must be `failed`, `failed_resumable`, `cancelled`, `paused_operator`,
 `paused_waiting_human`, or `queued` — never `running`, whose engine owns the
 checkpoint and would overwrite the rewind at its next node boundary. Cancel or
 pause it first. The claim is a CAS, so a concurrent resume loses the race
 rather than being rewound out from under itself.
+
+`failed` stays semantically distinct from `failed_resumable`: the graph
+deliberately abandoned the run (no auto-resume), it did not crash. But the
+distinction no longer destroys the recovery point — a run that reaches the
+DSL `fail` node keeps its checkpoint, so an explicit rewind can still recover
+it. Runs that failed **before** that preservation existed carry no checkpoint
+and stay unrecoverable (`run ... has no checkpoint — nothing to rewind`).
 
 The run is parked in `cancelled`. That is the one resumable status a cloud
 runner treats as "explicit resume required"; `failed_resumable` and

--- a/pkg/runtime/engine_exec.go
+++ b/pkg/runtime/engine_exec.go
@@ -150,7 +150,7 @@ func (e *Engine) execLoopDispatchSpecial(ctx context.Context, rs *runState, curr
 		if emErr := e.emitTerminalNodeEvents(rs, currentNodeID); emErr != nil {
 			return true, true, "", emErr
 		}
-		return true, true, "", e.failRun(rs.ctx, rs.runID, currentNodeID, "workflow reached fail node")
+		return true, true, "", e.failRunDeliberate(rs, currentNodeID, "workflow reached fail node")
 
 	case *ir.HumanNode:
 		switch n.Interaction {

--- a/pkg/runtime/engine_test.go
+++ b/pkg/runtime/engine_test.go
@@ -2388,6 +2388,56 @@ func TestInteractionDepthGuardFailsRunaway(t *testing.T) {
 	}
 }
 
+// A run routed to the DSL fail node is terminal — status failed, no
+// auto-resume — but keeps its checkpoint: the graph abandoning a run is
+// not a crash, the on-disk state is coherent, and an explicit operator
+// rewind must stay possible.
+func TestFailNodePreservesCheckpoint(t *testing.T) {
+	wf := &ir.Workflow{
+		Name:  "wf-fail-node",
+		Entry: "step",
+		Nodes: map[string]ir.Node{
+			"step": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "step"}},
+			"fail": &ir.FailNode{BaseNode: ir.BaseNode{ID: "fail"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "step", To: "fail"},
+		},
+		Schemas: map[string]*ir.Schema{},
+		Prompts: map[string]*ir.Prompt{},
+		Vars:    map[string]*ir.Var{},
+	}
+
+	s := tmpStore(t)
+	exec := newStubExecutor()
+	exec.on("step", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"value": "paid-for-output"}, nil
+	})
+	eng := New(wf, s, exec)
+
+	err := eng.Run(context.Background(), "run-fail-node", nil)
+	if err == nil {
+		t.Fatal("expected a terminal error from the fail node, got nil")
+	}
+
+	r, loadErr := s.LoadRun(context.Background(), "run-fail-node")
+	if loadErr != nil {
+		t.Fatalf("LoadRun: %v", loadErr)
+	}
+	if r.Status != store.RunStatusFailed {
+		t.Errorf("Status = %q, want failed (terminal, NOT failed_resumable)", r.Status)
+	}
+	if r.Checkpoint == nil {
+		t.Fatal("Checkpoint = nil after fail node, want preserved for rewind")
+	}
+	if r.Checkpoint.NodeID != "fail" {
+		t.Errorf("Checkpoint.NodeID = %q, want fail", r.Checkpoint.NodeID)
+	}
+	if got := r.Checkpoint.Outputs["step"]["value"]; got != "paid-for-output" {
+		t.Errorf("Checkpoint.Outputs[step].value = %v, want paid-for-output", got)
+	}
+}
+
 // sameJSON returns true when two JSON byte slices encode the same value
 // regardless of whitespace formatting (run.json round-trips through
 // MarshalIndent on disk).

--- a/pkg/runtime/run_failure.go
+++ b/pkg/runtime/run_failure.go
@@ -85,6 +85,32 @@ func (e *Engine) emitRunFailedAndReturn(ctx context.Context, runID, nodeID, reas
 	return &RuntimeError{Code: code, Message: reason, NodeID: nodeID}
 }
 
+// failRunDeliberate handles the DSL FailNode: the graph routed here on
+// purpose, so the run is terminal — status failed, no auto-resume — but
+// the checkpoint is preserved. The state on disk is coherent (the fail
+// node is reached from a normal node boundary) and an explicit operator
+// rewind remains possible, same as a cancelled run. Falls back to a
+// plain checkpoint-less failure if the write fails.
+func (e *Engine) failRunDeliberate(rs *runState, nodeID, reason string) error {
+	cp := buildCheckpoint(rs, nodeID)
+	if storeErr := e.store.FailRunTerminal(rs.ctx, rs.runID, cp, reason); storeErr != nil {
+		e.logger.Error("failed to persist terminal failure: %v", storeErr)
+		return e.failRun(rs.ctx, rs.runID, nodeID, reason)
+	}
+	if err := e.emit(rs.ctx, rs.runID, store.EventRunFailed, nodeID, map[string]any{
+		"error":      reason,
+		"code":       string(ErrCodeExecutionFailed),
+		"rewindable": true,
+	}); err != nil {
+		e.logger.Warn("failed to emit run_failed event: %v", err)
+	}
+	return &RuntimeError{
+		Code:    ErrCodeExecutionFailed,
+		Message: reason,
+		NodeID:  nodeID,
+	}
+}
+
 // failRunWithCheckpoint marks a run as failed_resumable with a checkpoint,
 // enabling resume from the last completed node. Falls back to a regular
 // (non-resumable) failure if the checkpoint write fails.

--- a/pkg/runview/rewind.go
+++ b/pkg/runview/rewind.go
@@ -122,7 +122,15 @@ type RewindResult struct {
 // `running` run is deliberately excluded: its engine owns the checkpoint
 // and would overwrite the rewind at its next node boundary. Cancel or
 // pause it first.
+//
+// `failed` is included: a run that reached the DSL fail node is terminal
+// (no auto-resume — the graph deliberately abandoned it, which is not the
+// same as "it crashed"), but its checkpoint is preserved, so an explicit
+// operator rewind can still recover it. Runs failed BEFORE that
+// preservation existed carry no checkpoint and are rejected one check
+// later with "nothing to rewind".
 var rewindableStatuses = []store.RunStatus{
+	store.RunStatusFailed,
 	store.RunStatusFailedResumable,
 	store.RunStatusCancelled,
 	store.RunStatusPausedOperator,

--- a/pkg/runview/rewind_files.go
+++ b/pkg/runview/rewind_files.go
@@ -374,14 +374,30 @@ func (s *Service) RestoreWorkspaceSnapshot(ctx context.Context, runID, snapshotI
 		return nil, fmt.Errorf("runview: run %s has no recorded workspace", runID)
 	}
 	switch {
-	case run.Status == store.RunStatusFinished || run.Status == store.RunStatusFailed:
-		// Terminal and non-resumable: no engine can claim it, so there is
-		// nothing to race with. Checked FIRST: `failed` is in
-		// rewindableStatuses (a rewind re-anchors it), and matching the
-		// claim arm below would flip the run to `cancelled` and wipe
-		// run.Error — the only record of why it failed — for what is
-		// here a pure workspace operation.
+	case run.Status == store.RunStatusFinished:
+		// Terminal and genuinely unclaimable: `finished` is in no
+		// resumable/rewindable path, so nothing can race the restore.
 		return s.restoreBanked(run, snapshotID)
+	case run.Status == store.RunStatusFailed:
+		// Terminal but REWINDABLE: a concurrent `rewind` + `resume` can
+		// claim the run and start an engine while the restore rewrites
+		// its workspace — so the old "nothing to race with" shortcut no
+		// longer holds. A real claim is not an option either: the CAS
+		// would flip the run to `cancelled` and wipe run.Error (the only
+		// record of why it failed) for what is here a pure workspace
+		// operation. Re-check at the last moment and refuse if the run
+		// moved; the sliver that remains — the restore itself — is the
+		// same exposure any external workspace mutation has, and the
+		// operator's own race to make.
+		fresh, lerr := s.store.LoadRun(ctx, runID)
+		if lerr != nil {
+			return nil, fmt.Errorf("reload run before restore: %w", lerr)
+		}
+		if fresh.Status != store.RunStatusFailed {
+			return nil, fmt.Errorf("%w: status changed under us (%s → %s) — reload and retry",
+				ErrRewindNotRewindable, run.Status, fresh.Status)
+		}
+		return s.restoreBanked(fresh, snapshotID)
 	case isRewindableStatus(run.Status):
 		// CLAIM before touching the workspace, exactly as Rewind does and
 		// for the same reason: reading the status and acting on it leaves

--- a/pkg/runview/rewind_files.go
+++ b/pkg/runview/rewind_files.go
@@ -374,6 +374,14 @@ func (s *Service) RestoreWorkspaceSnapshot(ctx context.Context, runID, snapshotI
 		return nil, fmt.Errorf("runview: run %s has no recorded workspace", runID)
 	}
 	switch {
+	case run.Status == store.RunStatusFinished || run.Status == store.RunStatusFailed:
+		// Terminal and non-resumable: no engine can claim it, so there is
+		// nothing to race with. Checked FIRST: `failed` is in
+		// rewindableStatuses (a rewind re-anchors it), and matching the
+		// claim arm below would flip the run to `cancelled` and wipe
+		// run.Error — the only record of why it failed — for what is
+		// here a pure workspace operation.
+		return s.restoreBanked(run, snapshotID)
 	case isRewindableStatus(run.Status):
 		// CLAIM before touching the workspace, exactly as Rewind does and
 		// for the same reason: reading the status and acting on it leaves
@@ -394,10 +402,6 @@ func (s *Service) RestoreWorkspaceSnapshot(ctx context.Context, runID, snapshotI
 		if !claimed {
 			return nil, fmt.Errorf("%w: status changed under us — reload and retry", ErrRewindNotRewindable)
 		}
-		return s.restoreBanked(run, snapshotID)
-	case run.Status == store.RunStatusFinished || run.Status == store.RunStatusFailed:
-		// Terminal and non-resumable: no engine can claim it, so there is
-		// nothing to race with.
 		return s.restoreBanked(run, snapshotID)
 	}
 	return nil, fmt.Errorf("%w: %s — stop the run before restoring its workspace", ErrRewindNotRewindable, run.Status)

--- a/pkg/runview/rewind_files_test.go
+++ b/pkg/runview/rewind_files_test.go
@@ -422,3 +422,72 @@ func TestRewind_RefusesAStalePreSnapshot(t *testing.T) {
 		t.Errorf("docs/intro.md = %q, want pass 1's content left in place", got)
 	}
 }
+
+// TestRestoreWorkspaceSnapshot_FailedRunKeepsItsStatus is Revi's Rce9422.
+//
+// Adding `failed` to rewindableStatuses must not reroute a terminal
+// failed run through RestoreWorkspaceSnapshot's claim arm: a workspace
+// restore on such a run is a pure file operation (no engine can claim
+// it), and the claim would flip the run to `cancelled` — misreporting a
+// failure as an operator cancellation on every status surface — and
+// wipe run.Error, the only record of why the run failed.
+func TestRestoreWorkspaceSnapshot_FailedRunKeepsItsStatus(t *testing.T) {
+	dir := t.TempDir()
+	ws := filepath.Join(dir, "workspace")
+	writeFile(t, ws, "docs/intro.md", "intro v1\n")
+
+	storeDir := filepath.Join(dir, "store")
+	st, err := store.New(storeDir)
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	const runID = "run-restore-failed"
+	if _, err := st.CreateRun(context.Background(), runID, "linear", nil); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	svc, err := NewService(storeDir)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	if svc.workspaceTracker == nil {
+		t.Fatal("a filesystem-backed service must wire workspace versioning")
+	}
+	snap, err := svc.workspaceTracker.Capture(runID, ws, "pre:implement:0")
+	if err != nil {
+		t.Fatalf("seed capture: %v", err)
+	}
+
+	// The run wrote on, then reached the fail node.
+	writeFile(t, ws, "docs/intro.md", "intro v2 REWRITTEN\n")
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	run.WorkDir = ws
+	run.Status = store.RunStatusFailed
+	run.Error = "workflow reached fail node"
+	run.Checkpoint = &store.Checkpoint{
+		NodeID:  "fail",
+		Outputs: outputsOf("survey", "plan", "implement"),
+	}
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	if _, err := svc.RestoreWorkspaceSnapshot(context.Background(), runID, snap.ID); err != nil {
+		t.Fatalf("RestoreWorkspaceSnapshot: %v", err)
+	}
+	if got := readWorkspaceFile(t, ws, "docs/intro.md"); got != "intro v1\n" {
+		t.Errorf("docs/intro.md = %q, want the snapshot content restored", got)
+	}
+	after, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if after.Status != store.RunStatusFailed {
+		t.Errorf("status = %q, want failed — a workspace restore must not reclassify the run", after.Status)
+	}
+	if after.Error != "workflow reached fail node" {
+		t.Errorf("run.Error = %q, want the failure message preserved", after.Error)
+	}
+}

--- a/pkg/runview/rewind_test.go
+++ b/pkg/runview/rewind_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -364,6 +365,42 @@ func TestRewind_RejectsRunningRun(t *testing.T) {
 	_, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "implement"})
 	if !errors.Is(err, ErrRewindNotRewindable) {
 		t.Fatalf("Rewind on a running run: err = %v, want ErrRewindNotRewindable", err)
+	}
+}
+
+// TestRewind_AcceptsFailedRun: a terminal `failed` run (the DSL fail-node
+// path) is rewindable. The run is over — no auto-resume — but its
+// checkpoint is a coherent recovery point, and rewind is exactly the
+// explicit operator action that uses it.
+func TestRewind_AcceptsFailedRun(t *testing.T) {
+	cp := &store.Checkpoint{NodeID: "verify", Outputs: outputsOf("survey", "plan", "implement", "verify")}
+	svc, st, runID := seedRun(t, linearBot, cp, store.RunStatusFailed)
+
+	result, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "implement"})
+	if err != nil {
+		t.Fatalf("Rewind: %v", err)
+	}
+	if result.FromNode != "verify" || result.NodeID != "implement" {
+		t.Errorf("re-anchor = %q → %q, want verify → implement", result.FromNode, result.NodeID)
+	}
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("load rewound run: %v", err)
+	}
+	if run.Status != store.RunStatusCancelled {
+		t.Errorf("status = %q, want cancelled (parked, resumable)", run.Status)
+	}
+}
+
+// TestRewind_FailedRunWithoutCheckpoint: runs failed BEFORE the
+// checkpoint preservation existed carry no checkpoint and stay
+// unrecoverable — the rejection must say why, not blame the status.
+func TestRewind_FailedRunWithoutCheckpoint(t *testing.T) {
+	svc, _, runID := seedRun(t, linearBot, nil, store.RunStatusFailed)
+
+	_, err := svc.Rewind(context.Background(), RewindSpec{RunID: runID, NodeID: "implement"})
+	if err == nil || !strings.Contains(err.Error(), "no checkpoint") {
+		t.Errorf("Rewind error = %v, want a no-checkpoint rejection", err)
 	}
 }
 

--- a/pkg/store/iface.go
+++ b/pkg/store/iface.go
@@ -121,6 +121,10 @@ type RunStore interface {
 	SaveCheckpoint(ctx context.Context, id string, cp *Checkpoint) error
 	PauseRun(ctx context.Context, id string, cp *Checkpoint) error
 	FailRunResumable(ctx context.Context, id string, cp *Checkpoint, runErr string) error
+	// FailRunTerminal is FailRunResumable's terminal counterpart: status
+	// failed (no auto-resume) but the checkpoint is kept so the run stays
+	// rewindable on an explicit operator action.
+	FailRunTerminal(ctx context.Context, id string, cp *Checkpoint, runErr string) error
 
 	// Events (append-only, monotonic seq per run)
 	AppendEvent(ctx context.Context, runID string, evt Event) (*Event, error)

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -731,3 +731,35 @@ func (s *Store) FailRunResumable(ctx context.Context, id string, cp *store.Check
 	}
 	return nil
 }
+
+// FailRunTerminal writes the checkpoint, flips status to failed, and
+// records the failure reason. The run is terminal — no auto-resume — but
+// the checkpoint is preserved so the operator can still rewind it
+// explicitly. Same atomic cancelled-guard as FailRunResumable.
+func (s *Store) FailRunTerminal(ctx context.Context, id string, cp *store.Checkpoint, runErr string) error {
+	now := time.Now().UTC()
+	update := bson.M{
+		"$set": bson.M{
+			"status":      store.RunStatusFailed,
+			"checkpoint":  cp,
+			"error":       runErr,
+			"updated_at":  now,
+			"finished_at": now,
+		},
+		"$inc": bson.M{"version": 1},
+	}
+	filter := withTenantFilter(ctx, bson.M{"_id": id, "status": bson.M{"$ne": store.RunStatusCancelled}})
+	res, err := s.runs.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return fmt.Errorf("store/mongo: fail terminal %s: %w", id, err)
+	}
+	if res.MatchedCount == 0 {
+		// Either the run is gone, or it is already cancelled and stays so.
+		// Distinguish, since a genuine miss must still surface.
+		if _, gerr := s.LoadRun(ctx, id); gerr == nil {
+			return nil
+		}
+		return fmt.Errorf("store/mongo: run %s not found", id)
+	}
+	return nil
+}

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -357,8 +357,13 @@ func (s *FilesystemRunStore) applyStatusTransition(r *Run, status RunStatus, run
 		// stale terminal timestamp and freezes mid-run.
 		r.FinishedAt = nil
 	}
-	// Clear checkpoint when leaving paused state (preserved for failed_resumable and cancelled).
-	if status == RunStatusRunning || status == RunStatusFinished || status == RunStatusFailed {
+	// Clear checkpoint when leaving paused state (preserved for
+	// failed_resumable, cancelled, and failed). `failed` keeps its
+	// checkpoint on purpose: a run that reached the DSL fail node is
+	// terminal (no auto-resume) but stays rewindable on an explicit
+	// operator action — its on-disk state is coherent, there is no
+	// technical reason to destroy the recovery point.
+	if status == RunStatusRunning || status == RunStatusFinished {
 		r.Checkpoint = nil
 	}
 	return s.writeRun(r)
@@ -416,6 +421,33 @@ func (s *FilesystemRunStore) FailRunResumable(ctx context.Context, id string, cp
 	}
 	r.Checkpoint = cp
 	r.Status = RunStatusFailedResumable
+	r.Error = runErr
+	t := time.Now().UTC()
+	r.UpdatedAt = t
+	r.FinishedAt = &t
+	return s.writeRun(r)
+}
+
+// FailRunTerminal atomically sets the checkpoint, error message, and status
+// to failed in a single write. Unlike FailRunResumable the run is terminal —
+// no auto-resume — but the checkpoint is preserved so the operator can still
+// rewind it explicitly (a run that reached the DSL fail node has a coherent
+// on-disk state worth recovering from).
+func (s *FilesystemRunStore) FailRunTerminal(ctx context.Context, id string, cp *Checkpoint, runErr string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	r, err := s.loadRunRaw(id)
+	if err != nil {
+		return err
+	}
+	// Same guard as FailRunResumable: an operator cancel is terminal and
+	// outranks a failure racing in behind it. Cancelled stands.
+	if r.Status == RunStatusCancelled {
+		return nil
+	}
+	r.Checkpoint = cp
+	r.Status = RunStatusFailed
 	r.Error = runErr
 	t := time.Now().UTC()
 	r.UpdatedAt = t

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -1461,9 +1461,8 @@ func TestSaveCheckpointRoundTrip(t *testing.T) {
 	}
 }
 
-// failed_resumable must RETAIN the checkpoint (the resume entry point) —
-// distinct from the plain `failed` path which clears it. This is the
-// behaviour that makes a failed run recoverable.
+// failed_resumable must RETAIN the checkpoint (the resume entry point).
+// This is the behaviour that makes a failed run recoverable.
 func TestFailRunResumable(t *testing.T) {
 	s := tmpStore(t)
 	ctx := context.Background()
@@ -1489,6 +1488,93 @@ func TestFailRunResumable(t *testing.T) {
 	}
 	if r.FinishedAt == nil {
 		t.Error("FinishedAt = nil, want set")
+	}
+}
+
+// A terminal `failed` run keeps its checkpoint too: the run is over (no
+// auto-resume) but the recovery point survives so an explicit rewind can
+// still pick it up. FailRunTerminal is the atomic write used by the DSL
+// fail-node path.
+func TestFailRunTerminal(t *testing.T) {
+	s := tmpStore(t)
+	ctx := context.Background()
+	mustCreateRun(t, s, "run-ft")
+
+	cp := &Checkpoint{NodeID: "node-f"}
+	if err := s.FailRunTerminal(ctx, "run-ft", cp, "workflow reached fail node"); err != nil {
+		t.Fatalf("FailRunTerminal: %v", err)
+	}
+
+	r, err := s.LoadRun(ctx, "run-ft")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.Status != RunStatusFailed {
+		t.Errorf("Status = %q, want failed", r.Status)
+	}
+	if r.Error != "workflow reached fail node" {
+		t.Errorf("Error = %q, want %q", r.Error, "workflow reached fail node")
+	}
+	if r.Checkpoint == nil || r.Checkpoint.NodeID != "node-f" {
+		t.Errorf("Checkpoint = %+v, want preserved with NodeID node-f", r.Checkpoint)
+	}
+	if r.FinishedAt == nil {
+		t.Error("FinishedAt = nil, want set")
+	}
+}
+
+// An operator cancel outranks a terminal failure racing in behind it:
+// FailRunTerminal on a cancelled run is a no-op.
+func TestFailRunTerminalCancelledWins(t *testing.T) {
+	s := tmpStore(t)
+	ctx := context.Background()
+	mustCreateRun(t, s, "run-ft-cancel")
+	if err := s.UpdateRunStatus(ctx, "run-ft-cancel", RunStatusCancelled, "operator stop"); err != nil {
+		t.Fatalf("UpdateRunStatus: %v", err)
+	}
+
+	if err := s.FailRunTerminal(ctx, "run-ft-cancel", &Checkpoint{NodeID: "node-f"}, "late failure"); err != nil {
+		t.Fatalf("FailRunTerminal: %v", err)
+	}
+	r, err := s.LoadRun(ctx, "run-ft-cancel")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.Status != RunStatusCancelled {
+		t.Errorf("Status = %q, want cancelled (cancel outranks a late failure)", r.Status)
+	}
+}
+
+// UpdateRunStatus(failed) preserves an existing checkpoint, while the
+// running/finished transitions keep clearing it.
+func TestUpdateRunStatusFailedKeepsCheckpoint(t *testing.T) {
+	s := tmpStore(t)
+	ctx := context.Background()
+	mustCreateRun(t, s, "run-keep-cp")
+
+	if err := s.SaveCheckpoint(ctx, "run-keep-cp", &Checkpoint{NodeID: "node-a"}); err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+	if err := s.UpdateRunStatus(ctx, "run-keep-cp", RunStatusFailed, "boom"); err != nil {
+		t.Fatalf("UpdateRunStatus(failed): %v", err)
+	}
+	r, err := s.LoadRun(ctx, "run-keep-cp")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.Checkpoint == nil || r.Checkpoint.NodeID != "node-a" {
+		t.Errorf("Checkpoint = %+v after failed transition, want preserved", r.Checkpoint)
+	}
+
+	if err := s.UpdateRunStatus(ctx, "run-keep-cp", RunStatusFinished, ""); err != nil {
+		t.Fatalf("UpdateRunStatus(finished): %v", err)
+	}
+	r, err = s.LoadRun(ctx, "run-keep-cp")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.Checkpoint != nil {
+		t.Errorf("Checkpoint = %+v after finished transition, want cleared", r.Checkpoint)
 	}
 }
 

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -54,6 +54,7 @@ type Opts struct {
 func RunWithOpts(t *testing.T, factory Factory, opts Opts) {
 	t.Run("CreateLoadRoundTrip", func(t *testing.T) { testCreateLoad(t, factory(t), opts) })
 	t.Run("StatusTransitions", func(t *testing.T) { testStatusTransitions(t, factory(t)) })
+	t.Run("FailRunTerminal", func(t *testing.T) { testFailRunTerminal(t, factory(t)) })
 	t.Run("EventSeqMonotone", func(t *testing.T) { testEventSeqMonotone(t, factory(t)) })
 	t.Run("EventSeqUnderConcurrency", func(t *testing.T) { testEventSeqConcurrent(t, factory(t)) })
 	t.Run("EventDataDecodeShape", func(t *testing.T) { testEventDataDecodeShape(t, factory(t)) })
@@ -964,6 +965,55 @@ func testStatusTransitions(t *testing.T, s store.RunStore) {
 	}
 	if r.FinishedAt == nil {
 		t.Errorf("FinishedAt: expected set on terminal status")
+	}
+}
+
+// testFailRunTerminal pins the checkpoint-preserving terminal failure on
+// BOTH store twins: status failed + checkpoint retained + FinishedAt set,
+// and the atomic cancelled-outranks guard. The DSL fail-node path depends
+// on this for rewind to stay possible on cloud deployments.
+func testFailRunTerminal(t *testing.T, s store.RunStore) {
+	t.Helper()
+	if _, err := s.CreateRun(testCtx(), "run_ft", "demo", nil); err != nil {
+		t.Fatal(err)
+	}
+	cp := &store.Checkpoint{NodeID: "node-f"}
+	if err := s.FailRunTerminal(testCtx(), "run_ft", cp, "workflow reached fail node"); err != nil {
+		t.Fatalf("FailRunTerminal: %v", err)
+	}
+	r, err := s.LoadRun(testCtx(), "run_ft")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.Status != store.RunStatusFailed {
+		t.Errorf("Status: got %q, want failed", r.Status)
+	}
+	if r.Error != "workflow reached fail node" {
+		t.Errorf("Error: got %q, want the failure reason", r.Error)
+	}
+	if r.Checkpoint == nil || r.Checkpoint.NodeID != "node-f" {
+		t.Errorf("Checkpoint: got %+v, want preserved with NodeID node-f", r.Checkpoint)
+	}
+	if r.FinishedAt == nil {
+		t.Errorf("FinishedAt: expected set on terminal status")
+	}
+
+	// An operator cancel outranks a terminal failure racing in behind it.
+	if _, err := s.CreateRun(testCtx(), "run_ft_cancel", "demo", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpdateRunStatus(testCtx(), "run_ft_cancel", store.RunStatusCancelled, "operator stop"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.FailRunTerminal(testCtx(), "run_ft_cancel", cp, "late failure"); err != nil {
+		t.Fatalf("FailRunTerminal on a cancelled run: %v", err)
+	}
+	r, err = s.LoadRun(testCtx(), "run_ft_cancel")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.Status != store.RunStatusCancelled {
+		t.Errorf("Status after a late failure: got %q, want cancelled", r.Status)
 	}
 }
 


### PR DESCRIPTION
## Problème (#373)

Un run qui atteint le nœud `fail` était **définitivement irrécupérable** : ni `resume`, ni `rewind`, ni `cancel` pour se ramener dans un statut rewindable — alors que l'état sur disque était cohérent et les instantanés d'espace de travail existaient toujours.

Causes :
1. Le nœud `fail` écrivait `failed` sans construire de checkpoint (`failRun` → `UpdateRunStatus`).
2. La transition de statut purgeait le checkpoint existant sur `RunStatusFailed` (`applyStatusTransition`).
3. `rewind` refusait `failed` de façon purement mécanique — et un nœud outil qui **lève une exception** (`failed_resumable` + checkpoint) était mieux traité que le nœud d'échec du DSL.

## Correctif

Un `fail` délibéré n'est pas un crash : le statut reste terminal (`failed`, pas d'auto-resume — la distinction sémantique avec `failed_resumable` est conservée), mais on ne détruit plus le point de reprise.

- **store** : nouvelle écriture atomique `FailRunTerminal` (statut `failed` + checkpoint, même garde « cancelled gagne » que `FailRunResumable`, impl. filesystem + mongo) ; `applyStatusTransition` ne purge plus le checkpoint sur `failed`.
- **engine** : le cas `FailNode` passe par `failRunDeliberate` — checkpoint construit et persisté, événement `run_failed` avec `rewindable: true`.
- **runview** : `failed` rejoint `rewindableStatuses` ; un `rewind` explicite ré-ancre le run et le parque en `cancelled`, prêt pour `resume`.

**Limite (annoncée dans le ticket)** : les runs déjà en `failed` n'ont plus de checkpoint et restent irrécupérables — `rewind` les rejette avec « no checkpoint — nothing to rewind ».

## Tests

- `TestFailRunTerminal`, `TestFailRunTerminalCancelledWins`, `TestUpdateRunStatusFailedKeepsCheckpoint` (store)
- `TestFailNodePreservesCheckpoint` (engine : statut `failed`, checkpoint + outputs préservés)
- `TestRewind_AcceptsFailedRun`, `TestRewind_FailedRunWithoutCheckpoint` (runview)

Docs mises à jour : `docs/resume.md`, `docs/persisted-formats.md`.

Closes #373