### PR TITLE
fix(runview): let a fork replace its dead parent on the pipeline board

### DIFF
--- a/pkg/runview/fork.go
+++ b/pkg/runview/fork.go
@@ -131,14 +131,19 @@ func (s *Service) Fork(ctx context.Context, spec ForkSpec) (*ForkResult, error) 
 	// from). Without this the pipeline card keeps pointing at the dead
 	// parent forever, with no way to re-attach the live fork.
 	//
-	// Only the issue fields travel. ScheduleID/ScheduleName are
-	// deliberately dropped: the schedgate overlap gate queries ScheduleID
-	// (ListRunsBySchedule), so a live recovery fork would otherwise
-	// silently skip every subsequent tick of its schedule (overlap: skip,
-	// the default) — or be cancelled by it (overlap: supersede).
-	if parent.Source != nil {
+	// Only the issue fields travel, and only when there IS an issue:
+	//   - Kind is the parent's TRIGGER classification, not provenance —
+	//     carrying it would make deriveSourceKind report the fork as
+	//     "dispatcher"/"schedule" instead of "fork" (the board-launch
+	//     path deliberately leaves it empty for the same reason, see
+	//     pkg/server/pipeline_admission.go);
+	//   - ScheduleID/ScheduleName feed the schedgate overlap gate
+	//     (ListRunsBySchedule), so a live recovery fork would otherwise
+	//     silently skip every subsequent tick of its schedule
+	//     (overlap: skip, the default) — or be cancelled by it
+	//     (overlap: supersede).
+	if parent.Source != nil && parent.Source.IssueID != "" {
 		child.Source = &store.RunSource{
-			Kind:            parent.Source.Kind,
 			IssueID:         parent.Source.IssueID,
 			IssueIdentifier: parent.Source.IssueIdentifier,
 			IssueTitle:      parent.Source.IssueTitle,

--- a/pkg/runview/fork.go
+++ b/pkg/runview/fork.go
@@ -126,14 +126,23 @@ func (s *Service) Fork(ctx context.Context, spec ForkSpec) (*ForkResult, error) 
 	child.ForkedFrom = parent.ID
 	child.ParentRunID = parent.ID
 	// A fork REPLACES the parent's future — it is the recovery path for a
-	// run that can no longer continue — so it inherits the originating
-	// Source (typically the board issue the parent was dispatched from).
-	// Without this the pipeline card keeps pointing at the dead parent
-	// forever, with no way to re-attach the live fork. Copy the struct:
-	// aliasing the parent's pointer would couple two persisted records.
+	// run that can no longer continue — so it inherits the ISSUE
+	// provenance (typically the board issue the parent was dispatched
+	// from). Without this the pipeline card keeps pointing at the dead
+	// parent forever, with no way to re-attach the live fork.
+	//
+	// Only the issue fields travel. ScheduleID/ScheduleName are
+	// deliberately dropped: the schedgate overlap gate queries ScheduleID
+	// (ListRunsBySchedule), so a live recovery fork would otherwise
+	// silently skip every subsequent tick of its schedule (overlap: skip,
+	// the default) — or be cancelled by it (overlap: supersede).
 	if parent.Source != nil {
-		src := *parent.Source
-		child.Source = &src
+		child.Source = &store.RunSource{
+			Kind:            parent.Source.Kind,
+			IssueID:         parent.Source.IssueID,
+			IssueIdentifier: parent.Source.IssueIdentifier,
+			IssueTitle:      parent.Source.IssueTitle,
+		}
 	}
 	child.ForkAnchor = &store.ForkAnchor{
 		NodeID:     spec.NodeID,

--- a/pkg/runview/fork.go
+++ b/pkg/runview/fork.go
@@ -125,6 +125,16 @@ func (s *Service) Fork(ctx context.Context, spec ForkSpec) (*ForkResult, error) 
 	}
 	child.ForkedFrom = parent.ID
 	child.ParentRunID = parent.ID
+	// A fork REPLACES the parent's future — it is the recovery path for a
+	// run that can no longer continue — so it inherits the originating
+	// Source (typically the board issue the parent was dispatched from).
+	// Without this the pipeline card keeps pointing at the dead parent
+	// forever, with no way to re-attach the live fork. Copy the struct:
+	// aliasing the parent's pointer would couple two persisted records.
+	if parent.Source != nil {
+		src := *parent.Source
+		child.Source = &src
+	}
 	child.ForkAnchor = &store.ForkAnchor{
 		NodeID:     spec.NodeID,
 		LoopIter:   turn.LoopIter,

--- a/pkg/runview/fork_test.go
+++ b/pkg/runview/fork_test.go
@@ -108,15 +108,26 @@ func TestFork_HappyPath(t *testing.T) {
 	if child.Source == nil {
 		t.Fatal("child.Source = nil, want inherited from the parent so the board card follows the fork")
 	}
-	if child.Source == parent.Source {
-		t.Error("child.Source aliases the parent's pointer, want an independent copy")
+	if child.Source.IssueID != "native:issue-1" {
+		t.Errorf("child.Source = %+v, want issue provenance on native:issue-1", child.Source)
 	}
-	if child.Source.IssueID != "native:issue-1" || child.Source.Kind != store.RunSourceKindDispatcher {
-		t.Errorf("child.Source = %+v, want dispatcher source on native:issue-1", child.Source)
+	if child.Source.Kind != "" {
+		t.Errorf("child.Source.Kind = %q, want empty — Kind is the parent's trigger classification; the fork's own is \"fork\" via ForkedFrom", child.Source.Kind)
 	}
 	if child.Source.ScheduleID != "" || child.Source.ScheduleName != "" {
 		t.Errorf("child.Source inherited the schedule identity (%q/%q) — the schedgate overlap gate must not see the fork",
 			child.Source.ScheduleID, child.Source.ScheduleName)
+	}
+	// The parent's own record must survive the inheritance untouched.
+	// Comparing pointers here could never fail — Fork loads its own copy
+	// of the parent from the store — so re-read the persisted parent.
+	parentAfter, err := st.LoadRun(context.Background(), parentID)
+	if err != nil {
+		t.Fatalf("reload parent: %v", err)
+	}
+	if parentAfter.Source == nil || parentAfter.Source.Kind != store.RunSourceKindDispatcher ||
+		parentAfter.Source.IssueID != "native:issue-1" || parentAfter.Source.ScheduleID != "nightly" {
+		t.Errorf("parent.Source = %+v, want the parent's own source left intact", parentAfter.Source)
 	}
 	children, err := svc.ListChildren(context.Background(), parentID)
 	if err != nil {
@@ -198,5 +209,61 @@ func TestFork_LatestTurn(t *testing.T) {
 	}
 	if result.ForkAnchor.TurnIndex != 2 {
 		t.Errorf("latest turn anchor = %d, want 2", result.ForkAnchor.TurnIndex)
+	}
+}
+
+// TestFork_IssueLessParentMintsNoSource: a parent whose Source carries no
+// IssueID (e.g. schedule-launched: Kind + ScheduleID only) gives the fork
+// NO Source at all. Inheriting a Kind-only shell would relabel the fork
+// as a scheduled run — provenance it does not have — and buy nothing for
+// the board fix, which keys on IssueID alone.
+func TestFork_IssueLessParentMintsNoSource(t *testing.T) {
+	dir := t.TempDir()
+	logger := iterlog.Nop()
+	st, err := store.New(dir, store.WithLogger(logger))
+	if err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	parentID := "run-fork-sched"
+	if _, err := st.CreateRun(context.Background(), parentID, "wf", nil); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	parent, _ := st.LoadRun(context.Background(), parentID)
+	parent.Checkpoint = &store.Checkpoint{NodeID: "nodeA", Outputs: map[string]map[string]any{}}
+	parent.Status = store.RunStatusCancelled
+	parent.Source = &store.RunSource{
+		Kind:         store.RunSourceKindSchedule,
+		ScheduleID:   "nightly",
+		ScheduleName: "Nightly",
+	}
+	if err := st.SaveRun(context.Background(), parent); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := st.WriteTurn(context.Background(), &store.TurnCheckpoint{
+		RunID:     parentID,
+		NodeID:    "nodeA",
+		Backend:   "claw",
+		WrittenAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("write turn: %v", err)
+	}
+	svc, err := NewService(dir, WithLogger(logger))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	result, err := svc.Fork(context.Background(), ForkSpec{
+		RunID:     parentID,
+		NodeID:    "nodeA",
+		TurnIndex: -1,
+	})
+	if err != nil {
+		t.Fatalf("Fork: %v", err)
+	}
+	child, err := st.LoadRun(context.Background(), result.NewRunID)
+	if err != nil {
+		t.Fatalf("load child: %v", err)
+	}
+	if child.Source != nil {
+		t.Errorf("child.Source = %+v, want nil for an issue-less parent (no phantom schedule provenance)", child.Source)
 	}
 }

--- a/pkg/runview/fork_test.go
+++ b/pkg/runview/fork_test.go
@@ -42,12 +42,18 @@ func TestFork_HappyPath(t *testing.T) {
 	parent.Status = store.RunStatusCancelled
 	// The parent was dispatched from a board issue: the fork must carry
 	// the same source edge, or the pipeline card keeps pointing at the
-	// dead parent with no way to re-attach the live fork.
+	// dead parent with no way to re-attach the live fork. The schedule
+	// fields are deliberately set too — to prove they do NOT travel:
+	// ScheduleID feeds the schedgate overlap gate, so inheriting it
+	// would wire the recovery fork into the schedule's skip/supersede
+	// decisions.
 	parent.Source = &store.RunSource{
 		Kind:            store.RunSourceKindDispatcher,
 		IssueID:         "native:issue-1",
 		IssueIdentifier: "issue-1",
 		IssueTitle:      "Ship it",
+		ScheduleID:      "nightly",
+		ScheduleName:    "Nightly",
 	}
 	if err := st.SaveRun(context.Background(), parent); err != nil {
 		t.Fatalf("save parent: %v", err)
@@ -107,6 +113,10 @@ func TestFork_HappyPath(t *testing.T) {
 	}
 	if child.Source.IssueID != "native:issue-1" || child.Source.Kind != store.RunSourceKindDispatcher {
 		t.Errorf("child.Source = %+v, want dispatcher source on native:issue-1", child.Source)
+	}
+	if child.Source.ScheduleID != "" || child.Source.ScheduleName != "" {
+		t.Errorf("child.Source inherited the schedule identity (%q/%q) — the schedgate overlap gate must not see the fork",
+			child.Source.ScheduleID, child.Source.ScheduleName)
 	}
 	children, err := svc.ListChildren(context.Background(), parentID)
 	if err != nil {

--- a/pkg/runview/fork_test.go
+++ b/pkg/runview/fork_test.go
@@ -40,6 +40,15 @@ func TestFork_HappyPath(t *testing.T) {
 	}
 	parent.WorkflowHash = "hash-abc"
 	parent.Status = store.RunStatusCancelled
+	// The parent was dispatched from a board issue: the fork must carry
+	// the same source edge, or the pipeline card keeps pointing at the
+	// dead parent with no way to re-attach the live fork.
+	parent.Source = &store.RunSource{
+		Kind:            store.RunSourceKindDispatcher,
+		IssueID:         "native:issue-1",
+		IssueIdentifier: "issue-1",
+		IssueTitle:      "Ship it",
+	}
 	if err := st.SaveRun(context.Background(), parent); err != nil {
 		t.Fatalf("save parent: %v", err)
 	}
@@ -89,6 +98,15 @@ func TestFork_HappyPath(t *testing.T) {
 	}
 	if child.ParentRunID != parentID {
 		t.Errorf("child.ParentRunID = %q, want %q", child.ParentRunID, parentID)
+	}
+	if child.Source == nil {
+		t.Fatal("child.Source = nil, want inherited from the parent so the board card follows the fork")
+	}
+	if child.Source == parent.Source {
+		t.Error("child.Source aliases the parent's pointer, want an independent copy")
+	}
+	if child.Source.IssueID != "native:issue-1" || child.Source.Kind != store.RunSourceKindDispatcher {
+		t.Errorf("child.Source = %+v, want dispatcher source on native:issue-1", child.Source)
 	}
 	children, err := svc.ListChildren(context.Background(), parentID)
 	if err != nil {

--- a/pkg/server/pipeline_admission.go
+++ b/pkg/server/pipeline_admission.go
@@ -253,8 +253,11 @@ func (s *Server) reconcileFinishedTickets(ctx context.Context, board native.Boar
 			continue
 		}
 		// Adopt the fork as the current attempt so the pointer converges
-		// with what the card already shows.
-		if err := board.SetLastRun(iss.ID, fork.ID, ""); err != nil {
+		// with what the card already shows. The fork's own workdir is
+		// stamped too — unlike launch-time call sites passing "", the run
+		// has already executed, and LastWorkdir feeds the studio's
+		// inspect-the-diff link.
+		if err := board.SetLastRun(iss.ID, fork.ID, fork.WorkDir); err != nil {
 			s.logger.Warn("pipeline admission: adopt finished fork %s for ticket %s: %v", fork.ID, iss.ID, err)
 			continue
 		}

--- a/pkg/server/pipeline_admission.go
+++ b/pkg/server/pipeline_admission.go
@@ -219,7 +219,26 @@ func (s *Server) reconcileFinishedTickets(ctx context.Context, board native.Boar
 			continue
 		}
 		if r.Status != store.RunStatusFinished {
-			continue
+			// The pointer may have been superseded by a recovery fork: a
+			// fork never becomes LastRunID on its own (the dispatcher only
+			// stamps its own attempts), so a finished one would strand the
+			// ticket in in_progress forever — the card reads Closed while
+			// every dependent parks in waiting_deps. Only look when the
+			// pointer's run is TERMINAL: a live one is still the attempt.
+			if !r.Status.IsTerminal() {
+				continue
+			}
+			fork := newestFinishedIssueFork(ctx, rs, iss, r)
+			if fork == nil {
+				continue
+			}
+			// Adopt the fork as the current attempt so the pointer
+			// converges with what the card already shows.
+			if err := board.SetLastRun(iss.ID, fork.ID, ""); err != nil {
+				s.logger.Warn("pipeline admission: adopt finished fork %s for ticket %s: %v", fork.ID, iss.ID, err)
+				continue
+			}
+			r = fork
 		}
 		if _, err := board.SetState(iss.ID, native.StateDone); err != nil {
 			s.logger.Warn("pipeline admission: file finished ticket %s (run %s): %v", iss.ID, iss.LastRunID, err)
@@ -227,6 +246,37 @@ func (s *Server) reconcileFinishedTickets(ctx context.Context, board native.Boar
 		}
 		s.logger.Info("pipeline admission: ticket %s finished cleanly (run %s) — filed as done", iss.ID, iss.LastRunID)
 	}
+}
+
+// newestFinishedIssueFork returns the newest fork (ForkedFrom != "")
+// sourced from the issue that actually ran to completion — the card's
+// real outcome when the dispatcher's own pointer failed. FinishedAt must
+// be set: Fork() parks every child as cancelled via SaveRun without it,
+// and a parked shell has delivered nothing. Forks older than the run the
+// pointer names belong to a previous attempt chain and are ignored.
+// Returns nil when no such run exists.
+func newestFinishedIssueFork(ctx context.Context, rs store.RunStore, iss *native.Issue, current *store.Run) *store.Run {
+	ids, err := rs.ListRunsBySourceIssue(ctx, iss.ID)
+	if err != nil {
+		return nil
+	}
+	var best *store.Run
+	for _, id := range ids {
+		r, err := rs.LoadRun(ctx, id)
+		if err != nil || r == nil {
+			continue
+		}
+		if r.ForkedFrom == "" || r.Status != store.RunStatusFinished || r.FinishedAt == nil {
+			continue
+		}
+		if !r.CreatedAt.After(current.CreatedAt) {
+			continue
+		}
+		if best == nil || r.CreatedAt.After(best.CreatedAt) {
+			best = r
+		}
+	}
+	return best
 }
 
 // warnAdmissionSkipOnce logs a ready ticket whose bot the current catalog

--- a/pkg/server/pipeline_admission.go
+++ b/pkg/server/pipeline_admission.go
@@ -210,6 +210,12 @@ func (s *Server) reconcileFinishedTickets(ctx context.Context, board native.Boar
 	if rs == nil {
 		return
 	}
+	// First pass: file tickets whose pointer run finished, and collect
+	// the stuck ones (in_progress with a TERMINAL-but-not-finished
+	// pointer) for fork adoption. One LoadRun per ticket — the
+	// pre-existing per-tick cost, NOT a store scan.
+	var stuck []*native.Issue
+	pointers := map[string]*store.Run{}
 	for _, iss := range issues {
 		if iss == nil || iss.State != native.StateInProgress || iss.LastRunID == "" {
 			continue
@@ -219,56 +225,107 @@ func (s *Server) reconcileFinishedTickets(ctx context.Context, board native.Boar
 			continue
 		}
 		if r.Status != store.RunStatusFinished {
-			// The pointer may have been superseded by a recovery fork: a
-			// fork never becomes LastRunID on its own (the dispatcher only
-			// stamps its own attempts), so a finished one would strand the
-			// ticket in in_progress forever — the card reads Closed while
-			// every dependent parks in waiting_deps. Only look when the
-			// pointer's run is TERMINAL: a live one is still the attempt.
-			if !r.Status.IsTerminal() {
-				continue
+			if r.Status.IsTerminal() {
+				stuck = append(stuck, iss)
+				pointers[iss.ID] = r
 			}
-			fork := newestFinishedIssueFork(ctx, rs, iss, r)
-			if fork == nil {
-				continue
-			}
-			// Adopt the fork as the current attempt so the pointer
-			// converges with what the card already shows.
-			if err := board.SetLastRun(iss.ID, fork.ID, ""); err != nil {
-				s.logger.Warn("pipeline admission: adopt finished fork %s for ticket %s: %v", fork.ID, iss.ID, err)
-				continue
-			}
-			r = fork
-		}
-		if _, err := board.SetState(iss.ID, native.StateDone); err != nil {
-			s.logger.Warn("pipeline admission: file finished ticket %s (run %s): %v", iss.ID, iss.LastRunID, err)
 			continue
 		}
-		s.logger.Info("pipeline admission: ticket %s finished cleanly (run %s) — filed as done", iss.ID, iss.LastRunID)
+		s.fileFinishedTicket(board, iss, r.ID)
+	}
+	if len(stuck) == 0 {
+		// No stuck ticket means no fork adoption is possible. Bailing
+		// here keeps an idle board at ZERO store scans per tick — the
+		// same guard admitReadyPipelines applies below, and it must hold
+		// even though this sweep runs before it.
+		return
+	}
+	// The pointer may have been superseded by a recovery fork: a fork
+	// never becomes LastRunID on its own (the dispatcher only stamps
+	// its own attempts), so a finished one would strand the ticket in
+	// in_progress forever — the card reads Closed while every dependent
+	// parks in waiting_deps. The index is shared by every stuck ticket
+	// and rebuilt at most once per finishedForksIndexTTL.
+	forks := s.finishedForksByIssue(ctx, rs)
+	for _, iss := range stuck {
+		fork := newestFinishedIssueFork(forks[iss.ID], pointers[iss.ID])
+		if fork == nil {
+			continue
+		}
+		// Adopt the fork as the current attempt so the pointer converges
+		// with what the card already shows.
+		if err := board.SetLastRun(iss.ID, fork.ID, ""); err != nil {
+			s.logger.Warn("pipeline admission: adopt finished fork %s for ticket %s: %v", fork.ID, iss.ID, err)
+			continue
+		}
+		s.fileFinishedTicket(board, iss, fork.ID)
 	}
 }
 
-// newestFinishedIssueFork returns the newest fork (ForkedFrom != "")
-// sourced from the issue that actually ran to completion — the card's
-// real outcome when the dispatcher's own pointer failed. FinishedAt must
-// be set: Fork() parks every child as cancelled via SaveRun without it,
-// and a parked shell has delivered nothing. Forks older than the run the
-// pointer names belong to a previous attempt chain and are ignored.
-// Returns nil when no such run exists.
-func newestFinishedIssueFork(ctx context.Context, rs store.RunStore, iss *native.Issue, current *store.Run) *store.Run {
-	ids, err := rs.ListRunsBySourceIssue(ctx, iss.ID)
-	if err != nil {
-		return nil
+// fileFinishedTicket moves the ticket to done (cascading the waiting_deps
+// promotion of its dependents) and logs the run the ticket was ACTUALLY
+// filed for — after a fork adoption that is the fork, not the dead
+// parent iss.LastRunID still names (the board mutates its own copy of
+// the issue on SetLastRun).
+func (s *Server) fileFinishedTicket(board native.BoardStore, iss *native.Issue, runID string) {
+	if _, err := board.SetState(iss.ID, native.StateDone); err != nil {
+		s.logger.Warn("pipeline admission: file finished ticket %s (run %s): %v", iss.ID, runID, err)
+		return
 	}
-	var best *store.Run
+	s.logger.Info("pipeline admission: ticket %s finished cleanly (run %s) — filed as done", iss.ID, runID)
+}
+
+// finishedForksIndexTTL bounds how often the by-issue index of finished
+// recovery forks is rebuilt while at least one ticket is stuck on a
+// failed pointer: one full store scan per TTL instead of one per stuck
+// ticket per 2s admission tick.
+const finishedForksIndexTTL = 30 * time.Second
+
+// finishedForksByIssue indexes every fork (ForkedFrom != "") that
+// ACTUALLY ran to completion, keyed by its Source.IssueID. FinishedAt
+// must be set: Fork() parks every child as cancelled via SaveRun without
+// it, and a parked shell has delivered nothing. Memoized for
+// finishedForksIndexTTL; the caller's stuck-ticket bail keeps an idle
+// board from ever reaching here.
+func (s *Server) finishedForksByIssue(ctx context.Context, rs store.RunStore) map[string][]*store.Run {
+	s.finishedForksMu.Lock()
+	defer s.finishedForksMu.Unlock()
+	if s.finishedForks != nil && time.Since(s.finishedForksAt) < finishedForksIndexTTL {
+		return s.finishedForks
+	}
+	byIssue := map[string][]*store.Run{}
+	ids, err := rs.ListRuns(ctx)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("pipeline admission: list runs for the fork index: %v", err)
+		}
+		return byIssue
+	}
 	for _, id := range ids {
 		r, err := rs.LoadRun(ctx, id)
 		if err != nil || r == nil {
 			continue
 		}
-		if r.ForkedFrom == "" || r.Status != store.RunStatusFinished || r.FinishedAt == nil {
+		if r.ForkedFrom == "" || r.Source == nil || r.Source.IssueID == "" {
 			continue
 		}
+		if r.Status != store.RunStatusFinished || r.FinishedAt == nil {
+			continue
+		}
+		byIssue[r.Source.IssueID] = append(byIssue[r.Source.IssueID], r)
+	}
+	s.finishedForks = byIssue
+	s.finishedForksAt = time.Now()
+	return byIssue
+}
+
+// newestFinishedIssueFork picks the newest candidate newer than the run
+// the ticket's pointer names — anything older belongs to a previous
+// attempt chain. Candidates are pre-filtered by finishedForksByIssue.
+// Returns nil when no fork qualifies.
+func newestFinishedIssueFork(candidates []*store.Run, current *store.Run) *store.Run {
+	var best *store.Run
+	for _, r := range candidates {
 		if !r.CreatedAt.After(current.CreatedAt) {
 			continue
 		}

--- a/pkg/server/pipeline_admission_sweep_test.go
+++ b/pkg/server/pipeline_admission_sweep_test.go
@@ -3,7 +3,9 @@ package server
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
@@ -30,6 +32,17 @@ func (f *fakeSweepRunStore) LoadRun(_ context.Context, id string) (*store.Run, e
 		return nil, fmt.Errorf("run %s not found", id)
 	}
 	return r, nil
+}
+
+func (f *fakeSweepRunStore) ListRunsBySourceIssue(_ context.Context, issueID string) ([]string, error) {
+	var ids []string
+	for id, r := range f.runs {
+		if r.Source != nil && r.Source.IssueID == issueID {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids, nil
 }
 
 func newSweepTestServer() *Server {
@@ -124,5 +137,97 @@ func TestReconcileFinishedTickets_SkipsUnlinkedAndMissingRuns(t *testing.T) {
 		if got.State != native.StateInProgress {
 			t.Fatalf("ticket %s state = %q, want in_progress (best-effort skip)", id, got.State)
 		}
+	}
+}
+
+// A dispatcher run that fails and is recovered via fork: the fork never
+// becomes LastRunID on its own, so without the adoption the ticket would
+// strand in in_progress (dependents parked in waiting_deps) while the
+// card already reads Closed. The sweep must adopt the newest fork that
+// ACTUALLY finished — a parked, never-resumed fork (cancelled, no
+// FinishedAt) has delivered nothing and must not qualify.
+func TestReconcileFinishedTickets_AdoptsFinishedFork(t *testing.T) {
+	board, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocker, _ := board.Create(native.Issue{Title: "epic", State: native.StateInProgress, Bot: "town-dev"})
+	dependent, _ := board.Create(native.Issue{
+		Title: "next epic", State: native.StateWaitingDeps, Bot: "town-dev",
+		Blockers: []string{blocker.ID},
+	})
+	if err := board.SetLastRun(blocker.ID, "run-parent", ""); err != nil {
+		t.Fatal(err)
+	}
+	older := time.Now().Add(-time.Hour)
+	ended := older.Add(50 * time.Minute)
+	rs := &fakeSweepRunStore{runs: map[string]*store.Run{
+		"run-parent": {
+			ID: "run-parent", Status: store.RunStatusFailed, CreatedAt: older,
+			Source: &store.RunSource{Kind: store.RunSourceKindDispatcher, IssueID: blocker.ID},
+		},
+		"run-fork": {
+			ID: "run-fork", Status: store.RunStatusFinished, CreatedAt: older.Add(30 * time.Minute),
+			FinishedAt: &ended, ForkedFrom: "run-parent",
+			Source: &store.RunSource{IssueID: blocker.ID},
+		},
+		// Newer but parked: cancelled via Fork()'s initial SaveRun, no
+		// FinishedAt — must not win over the fork that really finished.
+		"run-fork-parked": {
+			ID: "run-fork-parked", Status: store.RunStatusCancelled, CreatedAt: older.Add(40 * time.Minute),
+			ForkedFrom: "run-fork",
+			Source:     &store.RunSource{IssueID: blocker.ID},
+		},
+	}}
+
+	issues, err := board.List(native.ListFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newSweepTestServer().reconcileFinishedTickets(context.Background(), board, rs, issues)
+
+	got, _ := board.Get(blocker.ID)
+	if got.State != native.StateDone {
+		t.Fatalf("ticket state = %q, want done (the finished fork is the card's outcome)", got.State)
+	}
+	if got.LastRunID != "run-fork" {
+		t.Errorf("LastRunID = %q, want run-fork adopted as the current attempt", got.LastRunID)
+	}
+	dep, _ := board.Get(dependent.ID)
+	if dep.State != native.StateBacklog {
+		t.Fatalf("dependent state = %q, want backlog (auto-promoted)", dep.State)
+	}
+}
+
+// The parked-fork-only case: nothing actually finished, so the ticket
+// stays with the operator.
+func TestReconcileFinishedTickets_ParkedForkAloneDoesNotFile(t *testing.T) {
+	board, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	iss, _ := board.Create(native.Issue{Title: "epic", State: native.StateInProgress, Bot: "town-dev"})
+	if err := board.SetLastRun(iss.ID, "run-parent", ""); err != nil {
+		t.Fatal(err)
+	}
+	older := time.Now().Add(-time.Hour)
+	rs := &fakeSweepRunStore{runs: map[string]*store.Run{
+		"run-parent": {
+			ID: "run-parent", Status: store.RunStatusFailed, CreatedAt: older,
+			Source: &store.RunSource{Kind: store.RunSourceKindDispatcher, IssueID: iss.ID},
+		},
+		"run-fork-parked": {
+			ID: "run-fork-parked", Status: store.RunStatusCancelled, CreatedAt: older.Add(30 * time.Minute),
+			ForkedFrom: "run-parent",
+			Source:     &store.RunSource{IssueID: iss.ID},
+		},
+	}}
+
+	issues, _ := board.List(native.ListFilter{})
+	newSweepTestServer().reconcileFinishedTickets(context.Background(), board, rs, issues)
+
+	got, _ := board.Get(iss.ID)
+	if got.State != native.StateInProgress {
+		t.Fatalf("ticket state = %q, want in_progress (a parked fork delivered nothing)", got.State)
 	}
 }

--- a/pkg/server/pipeline_admission_sweep_test.go
+++ b/pkg/server/pipeline_admission_sweep_test.go
@@ -20,10 +20,12 @@ import (
 // the sweep's contract against a real filesystem board.
 
 // fakeSweepRunStore serves LoadRun from a map; everything else is unreachable
-// in these tests (nil via the embedded interface).
+// in these tests (nil via the embedded interface). listCalls counts the full
+// store scans — the sweep's contract is that an idle board pays none.
 type fakeSweepRunStore struct {
 	store.RunStore
-	runs map[string]*store.Run
+	runs      map[string]*store.Run
+	listCalls int
 }
 
 func (f *fakeSweepRunStore) LoadRun(_ context.Context, id string) (*store.Run, error) {
@@ -34,12 +36,11 @@ func (f *fakeSweepRunStore) LoadRun(_ context.Context, id string) (*store.Run, e
 	return r, nil
 }
 
-func (f *fakeSweepRunStore) ListRunsBySourceIssue(_ context.Context, issueID string) ([]string, error) {
-	var ids []string
-	for id, r := range f.runs {
-		if r.Source != nil && r.Source.IssueID == issueID {
-			ids = append(ids, id)
-		}
+func (f *fakeSweepRunStore) ListRuns(_ context.Context) ([]string, error) {
+	f.listCalls++
+	ids := make([]string, 0, len(f.runs))
+	for id := range f.runs {
+		ids = append(ids, id)
 	}
 	sort.Strings(ids)
 	return ids, nil
@@ -229,5 +230,56 @@ func TestReconcileFinishedTickets_ParkedForkAloneDoesNotFile(t *testing.T) {
 	got, _ := board.Get(iss.ID)
 	if got.State != native.StateInProgress {
 		t.Fatalf("ticket state = %q, want in_progress (a parked fork delivered nothing)", got.State)
+	}
+}
+
+// The fork index is only built when a ticket is actually stuck on a
+// terminal pointer — an idle or in-flight board must not pay a full
+// store scan per admission tick (Rc2c8ed: K stuck tickets × one scan
+// per 2s tick, forever, on an IDLE board).
+func TestReconcileFinishedTickets_NoStuckTicketSkipsTheScan(t *testing.T) {
+	board, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	iss, _ := board.Create(native.Issue{Title: "epic", State: native.StateInProgress, Bot: "town-dev"})
+	if err := board.SetLastRun(iss.ID, "run-live", ""); err != nil {
+		t.Fatal(err)
+	}
+	rs := &fakeSweepRunStore{runs: map[string]*store.Run{
+		"run-live": {ID: "run-live", Status: store.RunStatusRunning},
+	}}
+
+	issues, _ := board.List(native.ListFilter{})
+	newSweepTestServer().reconcileFinishedTickets(context.Background(), board, rs, issues)
+	if rs.listCalls != 0 {
+		t.Errorf("ListRuns called %d times with no stuck ticket, want 0 (idle board pays no scan)", rs.listCalls)
+	}
+}
+
+// Two sweeps within the TTL share one index build, even with a stuck
+// ticket present.
+func TestReconcileFinishedTickets_ForkIndexIsMemoized(t *testing.T) {
+	board, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	iss, _ := board.Create(native.Issue{Title: "epic", State: native.StateInProgress, Bot: "town-dev"})
+	if err := board.SetLastRun(iss.ID, "run-parent", ""); err != nil {
+		t.Fatal(err)
+	}
+	rs := &fakeSweepRunStore{runs: map[string]*store.Run{
+		"run-parent": {
+			ID: "run-parent", Status: store.RunStatusFailed, CreatedAt: time.Now().Add(-time.Hour),
+			Source: &store.RunSource{Kind: store.RunSourceKindDispatcher, IssueID: iss.ID},
+		},
+	}}
+
+	issues, _ := board.List(native.ListFilter{})
+	srv := newSweepTestServer()
+	srv.reconcileFinishedTickets(context.Background(), board, rs, issues)
+	srv.reconcileFinishedTickets(context.Background(), board, rs, issues)
+	if rs.listCalls != 1 {
+		t.Errorf("ListRuns called %d times over 2 sweeps, want 1 (index memoized within the TTL)", rs.listCalls)
 	}
 }

--- a/pkg/server/pipeline_boards_progress.go
+++ b/pkg/server/pipeline_boards_progress.go
@@ -324,6 +324,17 @@ func pipelineTicketHoldsSlot(issue *native.Issue, root *store.Run, terminalState
 	if _, terminal := terminalStates[issue.State]; terminal {
 		return false
 	}
+	// A recovery fork EXECUTING for the ticket occupies the slot its dead
+	// parent held: forks start via Service.Resume, which never touches
+	// pipelineQueue, so nothing else accounts for them — without this the
+	// ticket reads 0 active + 0 reserved while the fork runs, and the
+	// admission loop over-admits past max-concurrent-pipelines. A
+	// terminal fork is out of the race: a parked shell never becomes the
+	// root (FinishedAt-gated in the projection) and a finished one
+	// closed the card.
+	if root.ForkedFrom != "" && !root.Status.IsTerminal() {
+		return true
+	}
 	if root.Status != store.RunStatusFailed && root.Status != store.RunStatusFailedResumable {
 		return false
 	}

--- a/pkg/server/pipeline_boards_progress_test.go
+++ b/pkg/server/pipeline_boards_progress_test.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// A recovery fork EXECUTING for the ticket occupies the slot its dead
+// parent held: forks start via Resume, which never consults
+// pipelineQueue, so nothing else accounts for them — and the admission
+// loop would over-admit past max-concurrent-pipelines (R00ef2c).
+func TestPipelineTicketHoldsSlotRunningFork(t *testing.T) {
+	issue := &native.Issue{ID: "native:1", Bot: "review", State: native.StateInProgress}
+	terminal := map[string]struct{}{}
+	cases := []struct {
+		name string
+		root *store.Run
+		want bool
+	}{
+		{"running fork holds", &store.Run{ForkedFrom: "p", Status: store.RunStatusRunning}, true},
+		{"paused fork holds", &store.Run{ForkedFrom: "p", Status: store.RunStatusPausedWaitingHuman}, true},
+		{"failed parent holds", &store.Run{Status: store.RunStatusFailed}, true},
+		{"finished fork releases", &store.Run{ForkedFrom: "p", Status: store.RunStatusFinished}, false},
+		{"parked fork shell releases", &store.Run{ForkedFrom: "p", Status: store.RunStatusCancelled}, false},
+		{"running non-fork does not hold", &store.Run{Status: store.RunStatusRunning}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pipelineTicketHoldsSlot(issue, tc.root, terminal); got != tc.want {
+				t.Errorf("pipelineTicketHoldsSlot(%+v) = %v, want %v", tc.root, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/server/pipeline_boards_projection.go
+++ b/pkg/server/pipeline_boards_projection.go
@@ -398,7 +398,15 @@ func (b *pipelineProjectionBuilder) currentRunForIssue(issue *native.Issue) *sto
 		return sourceCandidates[i].CreatedAt.Before(sourceCandidates[j].CreatedAt)
 	})
 	if current == nil && len(sourceCandidates) > 0 {
-		return sourceCandidates[len(sourceCandidates)-1]
+		// The same shell gate as the loop below: with the parent's record
+		// gone (pruned/deleted) a never-resumed fork would otherwise
+		// become the card root unconditionally.
+		for i := len(sourceCandidates) - 1; i >= 0; i-- {
+			if !pipelineForkShell(sourceCandidates[i]) {
+				return sourceCandidates[i]
+			}
+		}
+		return nil
 	}
 	for _, candidate := range sourceCandidates {
 		if current == nil || candidate.ID == current.ID || !candidate.CreatedAt.After(baseline) {
@@ -439,6 +447,16 @@ func pipelineCardEligible(run *store.Run) bool {
 		return true
 	}
 	return run.ForkedFrom != ""
+}
+
+// pipelineForkShell reports a run that is a fork in name only so far:
+// created (and terminal-parked as `cancelled`) but never executed.
+// Fork()'s initial SaveRun stamps no FinishedAt; only a real status
+// transition (applyStatusTransition) does, so FinishedAt is what
+// discriminates the parked shell from a fork that actually ran and
+// ended.
+func pipelineForkShell(run *store.Run) bool {
+	return run.ForkedFrom != "" && run.Status.IsTerminal() && run.FinishedAt == nil
 }
 
 func (b *pipelineProjectionBuilder) attemptsForIssue(issue *native.Issue, current *store.Run) []PipelineBoardAttempt {

--- a/pkg/server/pipeline_boards_projection.go
+++ b/pkg/server/pipeline_boards_projection.go
@@ -387,7 +387,7 @@ func (b *pipelineProjectionBuilder) currentRunForIssue(issue *native.Issue) *sto
 	// prefer a newer, non-terminal run sourced from this issue.
 	sourceCandidates := make([]*store.Run, 0, 1)
 	for _, run := range b.runs {
-		if run.Source != nil && run.Source.IssueID == issue.ID && pipelineParentRunID(run) == "" {
+		if run.Source != nil && run.Source.IssueID == issue.ID && pipelineCardEligible(run) {
 			sourceCandidates = append(sourceCandidates, run)
 		}
 	}
@@ -401,13 +401,33 @@ func (b *pipelineProjectionBuilder) currentRunForIssue(issue *native.Issue) *sto
 		return sourceCandidates[len(sourceCandidates)-1]
 	}
 	for _, candidate := range sourceCandidates {
-		if current == nil || candidate.ID == current.ID || candidate.Status.IsTerminal() || !candidate.CreatedAt.After(baseline) {
+		if current == nil || candidate.ID == current.ID || !candidate.CreatedAt.After(baseline) {
+			continue
+		}
+		// A terminal candidate never supersedes the dispatcher's pointer —
+		// except a fork: it is the card's recovery path, and when it ends
+		// it IS the card's latest outcome. Nothing else ever updates the
+		// pointer for it (the dispatcher only knows its own attempts), so
+		// skipping it would pin the card on the dead parent forever.
+		if candidate.Status.IsTerminal() && candidate.ForkedFrom == "" {
 			continue
 		}
 		current = candidate
 		baseline = candidate.CreatedAt
 	}
 	return current
+}
+
+// pipelineCardEligible reports whether a run sourced from an issue may
+// become the card's current run. Child runs are excluded so fan-out
+// shards and subbot children don't pollute the card — they ADD to the
+// card's run. A fork is the opposite case: it REPLACES a run that can no
+// longer continue, so it stays eligible despite carrying a parent edge.
+func pipelineCardEligible(run *store.Run) bool {
+	if pipelineParentRunID(run) == "" {
+		return true
+	}
+	return run.ForkedFrom != ""
 }
 
 func (b *pipelineProjectionBuilder) attemptsForIssue(issue *native.Issue, current *store.Run) []PipelineBoardAttempt {

--- a/pkg/server/pipeline_boards_projection.go
+++ b/pkg/server/pipeline_boards_projection.go
@@ -405,11 +405,22 @@ func (b *pipelineProjectionBuilder) currentRunForIssue(issue *native.Issue) *sto
 			continue
 		}
 		// A terminal candidate never supersedes the dispatcher's pointer —
-		// except a fork: it is the card's recovery path, and when it ends
-		// it IS the card's latest outcome. Nothing else ever updates the
-		// pointer for it (the dispatcher only knows its own attempts), so
-		// skipping it would pin the card on the dead parent forever.
-		if candidate.Status.IsTerminal() && candidate.ForkedFrom == "" {
+		// except a fork that ACTUALLY ran: it is the card's recovery path,
+		// and when it ends it IS the card's latest outcome. Nothing else
+		// ever updates the pointer for it (the dispatcher only knows its
+		// own attempts), so skipping it would pin the card on the dead
+		// parent forever.
+		//
+		// FinishedAt discriminates "ran and ended" from "parked shell":
+		// Fork() parks every child as `cancelled` — itself a terminal
+		// status — via SaveRun, which never stamps FinishedAt; only a real
+		// status transition (applyStatusTransition) does. Without the gate,
+		// a never-resumed fork would hijack the card the instant it is
+		// created: the parent's failure message — the very reason the
+		// operator is forking — would vanish from the card, and the
+		// restart slot the failed parent holds (pipelineReservedSet reuses
+		// this function) would be silently released.
+		if candidate.Status.IsTerminal() && (candidate.ForkedFrom == "" || candidate.FinishedAt == nil) {
 			continue
 		}
 		current = candidate

--- a/pkg/server/pipeline_boards_test.go
+++ b/pkg/server/pipeline_boards_test.go
@@ -785,12 +785,58 @@ func TestPipelineBoardTerminalForkSupersedesFailedParent(t *testing.T) {
 		run.Source = &store.RunSource{Kind: store.RunSourceKindDispatcher, IssueID: issue.ID}
 		run.ForkedFrom = "run-parent"
 		run.ParentRunID = "run-parent"
+		// A run that really ended carries FinishedAt (stamped by the
+		// status transition). A parked, never-resumed fork does not —
+		// see TestPipelineBoardParkedForkKeepsFailedParent.
+		ended := run.CreatedAt.Add(10 * time.Minute)
+		run.FinishedAt = &ended
 	})
 
 	projection := env.projection(t)
 	card := findPipelineCard(t, projection.Cards, "run:run-fork")
 	if card.IssueID != issue.ID {
 		t.Errorf("finished fork card issue = %q, want %q — the fork is the card's latest outcome", card.IssueID, issue.ID)
+	}
+}
+
+// A fork that was created but never resumed is parked in `cancelled` —
+// itself a terminal status — and must NOT supersede the failed parent:
+// the parent's failure is the very reason the operator is forking, and
+// the fork may be abandoned before it ever runs. FinishedAt (stamped
+// only by real status transitions, never by Fork's initial SaveRun)
+// discriminates the parked shell from a fork that actually ended.
+func TestPipelineBoardParkedForkKeepsFailedParent(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	issue, err := env.board.Create(native.Issue{Title: "Dispatch me", Bot: "review"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	older := time.Now().Add(-time.Hour)
+	env.seedRun(t, "run-parent", "review", store.RunStatusFailed, func(run *store.Run) {
+		run.FilePath = env.botPath
+		run.Source = &store.RunSource{Kind: store.RunSourceKindDispatcher, IssueID: issue.ID}
+		run.CreatedAt = older
+	})
+	if err := env.board.SetLastRun(issue.ID, "run-parent", ""); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+	// The parked fork: status cancelled (how Fork() parks every child),
+	// FinishedAt nil because it never executed.
+	env.seedRun(t, "run-fork", "review", store.RunStatusCancelled, func(run *store.Run) {
+		run.FilePath = env.botPath
+		run.Source = &store.RunSource{Kind: store.RunSourceKindDispatcher, IssueID: issue.ID}
+		run.ForkedFrom = "run-parent"
+		run.ParentRunID = "run-parent"
+	})
+
+	projection := env.projection(t)
+	if hasPipelineCard(projection.Cards, "run:run-fork") {
+		t.Error("a parked, never-resumed fork must not become the card root")
+	}
+	// The failed parent stays the card's visible outcome.
+	card := findPipelineCard(t, projection.Cards, "task:"+issue.ID)
+	if len(card.Attempts) == 0 || card.Attempts[len(card.Attempts)-1].RunID != "run-parent" {
+		t.Errorf("attempts = %+v, want the failed parent kept as the card's latest attempt", card.Attempts)
 	}
 }
 

--- a/pkg/server/pipeline_boards_test.go
+++ b/pkg/server/pipeline_boards_test.go
@@ -713,6 +713,87 @@ func TestPipelineBoardAssociatesInflightSourceAndStandaloneRun(t *testing.T) {
 	}
 }
 
+// A fork of a card's dead run replaces it on the card: the fork inherits
+// the issue's source edge, and its parent link — the structural mark that
+// excludes shards and subbot children — must not exclude IT, since a fork
+// replaces the card's run instead of fanning out of it.
+func TestPipelineBoardForkReplacesFailedParent(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	issue, err := env.board.Create(native.Issue{Title: "Dispatch me", Bot: "review"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	older := time.Now().Add(-time.Hour)
+	env.seedRun(t, "run-parent", "review", store.RunStatusFailed, func(run *store.Run) {
+		run.FilePath = env.botPath
+		run.Source = &store.RunSource{Kind: store.RunSourceKindDispatcher, IssueID: issue.ID}
+		run.CreatedAt = older
+	})
+	// The dispatcher stamps the attempt end BEFORE any fork exists — the
+	// fork is the recovery gesture for a run that can no longer continue,
+	// so it is always created after the parent's attempt was registered.
+	if err := env.board.SetLastRun(issue.ID, "run-parent", ""); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+	env.seedRun(t, "run-fork", "review", store.RunStatusRunning, func(run *store.Run) {
+		run.FilePath = env.botPath
+		run.Source = &store.RunSource{Kind: store.RunSourceKindDispatcher, IssueID: issue.ID}
+		run.ForkedFrom = "run-parent"
+		run.ParentRunID = "run-parent"
+	})
+	// A shard (fan-out child: parent edge, NO fork mark) with a source
+	// edge stays excluded even when it is the newest run of the issue.
+	env.seedRun(t, "run-shard", "review", store.RunStatusRunning, func(run *store.Run) {
+		run.FilePath = env.botPath
+		run.Source = &store.RunSource{Kind: store.RunSourceKindDispatcher, IssueID: issue.ID}
+		run.ParentRunID = "run-parent"
+	})
+
+	projection := env.projection(t)
+	card := findPipelineCard(t, projection.Cards, "run:run-fork")
+	if card.IssueID != issue.ID {
+		t.Errorf("fork card issue = %q, want %q — the fork should carry the card, not the dead parent", card.IssueID, issue.ID)
+	}
+	if hasPipelineCard(projection.Cards, "run:run-shard") {
+		t.Error("shard must not become a card root — only forks replace the parent")
+	}
+}
+
+// A fork that has ENDED is still the card's latest outcome: nothing else
+// ever updates the pointer for it (the dispatcher only knows its own
+// attempts), so a finished fork supersedes the failed parent even though
+// terminal candidates are otherwise ignored.
+func TestPipelineBoardTerminalForkSupersedesFailedParent(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	issue, err := env.board.Create(native.Issue{Title: "Dispatch me", Bot: "review"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	older := time.Now().Add(-time.Hour)
+	env.seedRun(t, "run-parent", "review", store.RunStatusFailed, func(run *store.Run) {
+		run.FilePath = env.botPath
+		run.Source = &store.RunSource{Kind: store.RunSourceKindDispatcher, IssueID: issue.ID}
+		run.CreatedAt = older
+	})
+	// Same ordering as production: the dispatcher stamps the attempt end
+	// first; the fork is minted afterwards as the recovery gesture.
+	if err := env.board.SetLastRun(issue.ID, "run-parent", ""); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+	env.seedRun(t, "run-fork", "review", store.RunStatusFinished, func(run *store.Run) {
+		run.FilePath = env.botPath
+		run.Source = &store.RunSource{Kind: store.RunSourceKindDispatcher, IssueID: issue.ID}
+		run.ForkedFrom = "run-parent"
+		run.ParentRunID = "run-parent"
+	})
+
+	projection := env.projection(t)
+	card := findPipelineCard(t, projection.Cards, "run:run-fork")
+	if card.IssueID != issue.ID {
+		t.Errorf("finished fork card issue = %q, want %q — the fork is the card's latest outcome", card.IssueID, issue.ID)
+	}
+}
+
 // A child whose parent belongs to another bot folds into that parent; it is
 // never promoted to its own root card.
 func TestPipelineBoardFoldsChildOfAnotherBot(t *testing.T) {

--- a/pkg/server/pipeline_boards_test.go
+++ b/pkg/server/pipeline_boards_test.go
@@ -1694,3 +1694,30 @@ func TestPipelineBoardPendingReviewLaterTurnWithoutInstructionsBlanks(t *testing
 		t.Fatalf("instructions = %q, want empty: the current turn carries none", got)
 	}
 }
+
+// With the parent's record gone (pruned/deleted), the current==nil early
+// return must apply the same shell gate: a never-resumed fork is not the
+// card's outcome.
+func TestPipelineBoardParkedForkWithoutParentRecord(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	issue, err := env.board.Create(native.Issue{Title: "Dispatch me", Bot: "review"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The pointer names a run record the store no longer serves.
+	if err := env.board.SetLastRun(issue.ID, "run-gone", ""); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+	env.seedRun(t, "run-fork", "review", store.RunStatusCancelled, func(run *store.Run) {
+		run.FilePath = env.botPath
+		run.Source = &store.RunSource{IssueID: issue.ID}
+		run.ForkedFrom = "run-gone"
+		run.ParentRunID = "run-gone"
+		// No FinishedAt: created by Fork() and never resumed.
+	})
+
+	projection := env.projection(t)
+	if hasPipelineCard(projection.Cards, "run:run-fork") {
+		t.Error("a parked fork shell must not become the card root even when the parent's record is gone")
+	}
+}

--- a/pkg/server/pipeline_reservations.go
+++ b/pkg/server/pipeline_reservations.go
@@ -46,20 +46,26 @@ func (m *pipelineReservedMemo) invalidate() {
 
 // pipelineReservedSet reports the ticket ids currently holding a slot.
 //
-// The predicate mirrors pipelineLaneForRoot exactly — a card that reserves
-// without rendering in the needs-attention lane would be an invisible held
+// The predicate mirrors pipelineLaneForRoot as closely as possible — a card
+// that reserves without rendering its holder would be an invisible held
 // slot, which is the worst way this feature can fail. A ticket reserves iff:
 //
 //   - it names a bot (otherwise it is a plain backlog item, not a pipeline);
-//   - its current run's status is failed or failed_resumable;
 //   - its ticket state is NOT terminal (Close files the ticket, which is how
 //     the reservation is released);
-//   - nothing in its run tree is parked on a human review (the tree is alive
-//     and already holds a real slot);
+//   - its current run's status is failed or failed_resumable, OR its
+//     current run is a NON-TERMINAL recovery fork: a fork starts via
+//     Resume, which never enters pipelineQueue, so nothing else accounts
+//     for it — and the fork inherits the slot its dead parent held (the
+//     card shows it in In progress, ReservesSlot set, so the holder stays
+//     visible);
 //   - the failure was not caused by iterion itself — a drain or the boot
 //     orphan sweep flips every in-flight run at once, and reserving for those
 //     would wedge the board on every restart, i.e. on every .go save under
-//     `task studio:dev`.
+//     `task studio:dev`;
+//   - nothing in its run tree is parked on a human review (the tree is alive
+//     and already holds a real slot) — UNLESS the root is a non-terminal
+//     fork, which holds no queue slot and must keep the reservation.
 func (s *Server) pipelineReservedSet(boardStore native.BoardStore, runs *runview.Service) map[string]struct{} {
 	return s.pipelineReservedSetMemo(s.currentPipelineReservedMemo(), boardStore, runs)
 }
@@ -140,7 +146,14 @@ func (s *Server) pipelineReservedSetMemo(
 		if !pipelineTicketHoldsSlot(issue, root, terminal) {
 			continue
 		}
-		if pipelineTreeAwaitingHuman(issue, runIndex) {
+		// The awaiting-human release assumes the live tree already holds
+		// a real queue slot — FALSE for a fork, which starts via Resume
+		// and never enters pipelineQueue. A fork parked on a human gate
+		// (or forked from a parent stuck paused_waiting_human, which the
+		// tree walk also sees) would otherwise lose the slot again and
+		// over-admit past max-concurrent-pipelines. Keep the reservation
+		// whenever the resolved root is a non-terminal fork.
+		if pipelineTreeAwaitingHuman(issue, runIndex) && (root == nil || root.ForkedFrom == "" || root.Status.IsTerminal()) {
 			continue
 		}
 		set[issue.ID] = struct{}{}

--- a/pkg/server/pipeline_reservations_test.go
+++ b/pkg/server/pipeline_reservations_test.go
@@ -1,0 +1,178 @@
+package server
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// seedReservedRun creates one run in the store behind the runview service.
+func seedReservedRun(t *testing.T, st store.RunStore, id string, mutate func(*store.Run)) {
+	t.Helper()
+	if _, err := st.CreateRun(context.Background(), id, "review", nil); err != nil {
+		t.Fatalf("CreateRun(%s): %v", id, err)
+	}
+	run, err := st.LoadRun(context.Background(), id)
+	if err != nil {
+		t.Fatalf("LoadRun(%s): %v", id, err)
+	}
+	mutate(run)
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun(%s): %v", id, err)
+	}
+}
+
+// The reserved set is composed as holdsSlot && !treeAwaitingHuman — and
+// the tree walk sees BOTH the fork and its dead parent (the fork
+// inherits Source.IssueID and carries ParentRunID). The pre-existing
+// release assumes the live tree holds a real queue slot, which a fork
+// never does (Resume never enters pipelineQueue): a fork parked on a
+// human gate, or forked from a parent stuck paused_waiting_human, must
+// KEEP the reservation or admission over-admits (R5bc762).
+func TestPipelineReservedSetKeepsNonTerminalForkDespiteHumanGate(t *testing.T) {
+	dir := t.TempDir()
+	board, err := native.NewStore(filepath.Join(dir, "board"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.New(filepath.Join(dir, "runs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runs, err := runview.NewService(filepath.Join(dir, "runs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	issue, err := board.Create(native.Issue{Title: "epic", Bot: "review", State: native.StateInProgress})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := board.SetLastRun(issue.ID, "run-parent", ""); err != nil {
+		t.Fatal(err)
+	}
+	older := time.Now().Add(-time.Hour)
+	seedReservedRun(t, st, "run-parent", func(run *store.Run) {
+		run.Status = store.RunStatusFailed
+		run.CreatedAt = older
+		run.Source = &store.RunSource{Kind: store.RunSourceKindDispatcher, IssueID: issue.ID}
+	})
+	// The fork is parked ON A HUMAN GATE: alive, non-terminal, and the
+	// tree walk sees it.
+	seedReservedRun(t, st, "run-fork", func(run *store.Run) {
+		run.Status = store.RunStatusPausedWaitingHuman
+		// Created after the SetLastRun above (default: now) — the
+		// production ordering: a fork is always minted after the
+		// parent's attempt was registered.
+		run.ForkedFrom = "run-parent"
+		run.ParentRunID = "run-parent"
+		run.Source = &store.RunSource{IssueID: issue.ID}
+	})
+
+	srv := &Server{logger: iterlog.New(iterlog.LevelError, nil)}
+	set := srv.pipelineReservedSetMemo(&pipelineReservedMemo{}, board, runs)
+	if _, reserved := set[issue.ID]; !reserved {
+		t.Error("a non-terminal fork parked on a human gate must keep the ticket's reserved slot (it holds no queue slot)")
+	}
+}
+
+// Same shape with a parent stuck paused_waiting_human forever: the tree
+// walk triggers on the PARENT this time. The fork runs — it must keep
+// the slot for the same reason.
+func TestPipelineReservedSetKeepsRunningForkDespitePausedParent(t *testing.T) {
+	dir := t.TempDir()
+	board, err := native.NewStore(filepath.Join(dir, "board"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.New(filepath.Join(dir, "runs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runs, err := runview.NewService(filepath.Join(dir, "runs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	issue, err := board.Create(native.Issue{Title: "epic", Bot: "review", State: native.StateInProgress})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := board.SetLastRun(issue.ID, "run-parent", ""); err != nil {
+		t.Fatal(err)
+	}
+	older := time.Now().Add(-time.Hour)
+	seedReservedRun(t, st, "run-parent", func(run *store.Run) {
+		run.Status = store.RunStatusFailed
+		run.CreatedAt = older
+		run.Source = &store.RunSource{Kind: store.RunSourceKindDispatcher, IssueID: issue.ID}
+	})
+	// A SECOND run of the ticket tree, forever paused on a human gate.
+	seedReservedRun(t, st, "run-paused-sibling", func(run *store.Run) {
+		run.Status = store.RunStatusPausedWaitingHuman
+		run.CreatedAt = older.Add(10 * time.Minute)
+		run.ParentRunID = "run-parent"
+		run.Source = &store.RunSource{IssueID: issue.ID}
+	})
+	seedReservedRun(t, st, "run-fork", func(run *store.Run) {
+		run.Status = store.RunStatusRunning
+		// Created after the SetLastRun above (default: now), as in
+		// production: the fork post-dates the parent's attempt.
+		run.ForkedFrom = "run-parent"
+		run.ParentRunID = "run-parent"
+		run.Source = &store.RunSource{IssueID: issue.ID}
+	})
+
+	srv := &Server{logger: iterlog.New(iterlog.LevelError, nil)}
+	set := srv.pipelineReservedSetMemo(&pipelineReservedMemo{}, board, runs)
+	if _, reserved := set[issue.ID]; !reserved {
+		t.Error("a running fork must keep the reserved slot even when a sibling of its tree awaits a human")
+	}
+}
+
+// The pre-existing behavior is preserved for non-fork trees: a failed
+// ticket whose tree awaits a human does NOT reserve (the live run holds
+// a real queue slot).
+func TestPipelineReservedSetReleasesNonForkTreeAwaitingHuman(t *testing.T) {
+	dir := t.TempDir()
+	board, err := native.NewStore(filepath.Join(dir, "board"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	st, err := store.New(filepath.Join(dir, "runs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runs, err := runview.NewService(filepath.Join(dir, "runs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	issue, err := board.Create(native.Issue{Title: "epic", Bot: "review", State: native.StateInProgress})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := board.SetLastRun(issue.ID, "run-parent", ""); err != nil {
+		t.Fatal(err)
+	}
+	older := time.Now().Add(-time.Hour)
+	seedReservedRun(t, st, "run-parent", func(run *store.Run) {
+		run.Status = store.RunStatusFailed
+		run.CreatedAt = older
+		run.Source = &store.RunSource{Kind: store.RunSourceKindDispatcher, IssueID: issue.ID}
+	})
+	seedReservedRun(t, st, "run-child", func(run *store.Run) {
+		run.Status = store.RunStatusPausedWaitingHuman
+		run.CreatedAt = older.Add(10 * time.Minute)
+		run.ParentRunID = "run-parent"
+	})
+
+	srv := &Server{logger: iterlog.New(iterlog.LevelError, nil)}
+	set := srv.pipelineReservedSetMemo(&pipelineReservedMemo{}, board, runs)
+	if _, reserved := set[issue.ID]; reserved {
+		t.Error("a non-fork tree parked on a human gate must NOT reserve (pre-existing behavior)")
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -96,6 +96,15 @@ type Server struct {
 	pipelineReservedMu sync.RWMutex
 	pipelineReserved   *pipelineReservedMemo
 
+	// finishedForks memoizes the by-issue index of finished recovery forks
+	// used by reconcileFinishedTickets' fork adoption (see
+	// pipeline_admission.go). Without it a board with K tickets stuck on a
+	// failed pointer would pay K full run-store scans per admission tick —
+	// the index costs one scan per finishedForksIndexTTL instead.
+	finishedForksMu sync.Mutex
+	finishedForksAt time.Time
+	finishedForks   map[string][]*store.Run
+
 	// finalOutputMemo caches finished runs' resolved board output. A finished
 	// run is terminal, so its final_answer/latest-artifact output never
 	// changes — computing it once per run (instead of on every 3s poll, each


### PR DESCRIPTION
## Problème (#374)

Un run lancé depuis une carte du board et rattrapé par `fork` **disparaissait définitivement de sa carte** : la carte continuait d'afficher le run mort, sans moyen de l'en détacher, pendant que le fork — la récupération réelle — tournait invisible. `fork` étant le seul moyen de rattraper un run terminal (cf. #373), la récupération se payait par la perte du suivi board.

Deux conditions cumulatives que le fork ne pouvait pas satisfaire (`pipeline_boards_projection.go`) :

- **`Source.IssueID`** : `fork` ne recopiait pas le lien au ticket — le run naissait avec `Source == nil`.
- **`pipelineParentRunID(run) == ""`** : la projection exclut volontairement tout run enfant « pour que shards et forks ne polluent pas les cartes ». L'exclusion des shards est légitime (un shard de fan-out s'ajoute au run de la carte) ; elle attrapait au passage le fork, qui est le cas inverse — un fork *remplace* le run de la carte.

## Correctif

1. **Le fork hérite `Source` du parent** (copie indépendante, pas d'alias) : le lien au ticket survit à la récupération.
2. **La projection distingue fork et shard** via `ForkedFrom` : seul un fork reste éligible malgré l'arête parent — un shard ou un enfant subbot reste exclu.
3. **Un fork terminal plus récent remplace le pointeur du dispatcher** : rien d'autre ne met à jour la carte pour un fork, donc un fork terminé est le dernier état connu de la carte (sinon la carte resterait épinglée sur l'échec du parent même après un fork réussi).

Le point 1 seul ne suffisait pas (la seconde condition excluait toujours le fork) — d'où les trois changements ensemble.

## Tests

- `TestFork_HappyPath` étendu : héritage de `Source` (copie indépendante, `IssueID` + `Kind` préservés)
- `TestPipelineBoardForkReplacesFailedParent` : le fork running porte la carte ; un shard avec `Source` reste exclu même s'il est le plus récent
- `TestPipelineBoardTerminalForkSupersedesFailedParent` : un fork terminé remplace le parent mort

Closes #374