### PR TITLE
fix(runview): stop the skip-run and finalize log loops

### DIFF
--- a/pkg/runtime/worktree.go
+++ b/pkg/runtime/worktree.go
@@ -1000,6 +1000,16 @@ func RecoverFinalize(ctx context.Context, st store.RunStore, r *store.Run, logge
 	if r.FinalBranch != "" || r.FinalCommit != "" {
 		return nil // already finalized
 	}
+	// A worktree already removed (operator cleanup, manual
+	// `git worktree remove`, store GC) leaves nothing to promote, and
+	// that state is permanent — the reconcile loop scans every terminal
+	// run on every tick, so reaching finalizeWorktree here re-logs the
+	// same "cannot read worktree HEAD" warning every minute per deleted
+	// worktree. Skip quietly; an EXISTING worktree with an unreadable
+	// HEAD still warns from finalizeWorktree below.
+	if _, err := os.Stat(r.WorkDir); err != nil {
+		return nil
+	}
 	// Finalize any terminally-stopped run that left work in the
 	// worktree. The happy path is `finished` (the original case that
 	// motivated RecoverFinalize). `cancelled` also benefits: when the

--- a/pkg/runtime/worktree.go
+++ b/pkg/runtime/worktree.go
@@ -1007,7 +1007,13 @@ func RecoverFinalize(ctx context.Context, st store.RunStore, r *store.Run, logge
 	// same "cannot read worktree HEAD" warning every minute per deleted
 	// worktree. Skip quietly; an EXISTING worktree with an unreadable
 	// HEAD still warns from finalizeWorktree below.
-	if _, err := os.Stat(r.WorkDir); err != nil {
+	//
+	// Gated on ENOENT only: a stat failure on an existing path (EACCES
+	// on a parent, EIO/ESTALE on an unavailable mount) is recoverable —
+	// the run's commits may still be promotable once the mount or the
+	// permissions are fixed — so it falls through to finalizeWorktree's
+	// warning instead of vanishing silently.
+	if _, err := os.Stat(r.WorkDir); os.IsNotExist(err) {
 		return nil
 	}
 	// Finalize any terminally-stopped run that left work in the

--- a/pkg/runtime/worktree_test.go
+++ b/pkg/runtime/worktree_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"os/exec"
@@ -8,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -676,6 +678,37 @@ func TestRecoverFinalize_SkipsNonWorktree(t *testing.T) {
 	}
 	if r.FinalCommit != "" || r.FinalBranch != "" {
 		t.Errorf("non-worktree path mutated state: %+v", r)
+	}
+}
+
+// TestRecoverFinalize_GoneWorktreeIsQuiet — a terminal run whose
+// worktree was removed (operator cleanup, `git worktree remove`, store
+// GC) has nothing left to promote, and that state is permanent: the
+// reconcile loop scans it on every tick, so the recovery must skip it
+// SILENTLY instead of re-logging "cannot read worktree HEAD" every
+// minute per deleted worktree.
+func TestRecoverFinalize_GoneWorktreeIsQuiet(t *testing.T) {
+	st, _ := store.New(t.TempDir())
+	r := &store.Run{
+		ID:       "run_gone_wt",
+		Status:   store.RunStatusFinished,
+		Worktree: true,
+		WorkDir:  filepath.Join(t.TempDir(), "removed"),
+		RepoRoot: t.TempDir(),
+	}
+	var buf bytes.Buffer
+	logger := iterlog.New(iterlog.LevelDebug, &buf)
+	// Three ticks, as the reconcile loop would do.
+	for i := 0; i < 3; i++ {
+		if err := RecoverFinalize(context.Background(), st, r, logger); err != nil {
+			t.Fatalf("gone-worktree path errored on tick %d: %v", i, err)
+		}
+	}
+	if buf.Len() != 0 {
+		t.Errorf("gone worktree logged over repeated ticks, want silence; got:\n%s", buf.String())
+	}
+	if r.FinalCommit != "" || r.FinalBranch != "" {
+		t.Errorf("gone-worktree path mutated state: %+v", r)
 	}
 }
 

--- a/pkg/runview/service.go
+++ b/pkg/runview/service.go
@@ -432,6 +432,11 @@ type Service struct {
 	broker  *EventBroker
 	manager *Manager
 
+	// skipRunLogged dedupes the "skip run" diagnostic emitted when a
+	// listed run fails to load: the same stale/corrupt id is reported
+	// once per service lifetime instead of on every UI poll.
+	skipRunLogged sync.Map
+
 	// sandboxDefault is the global sandbox default injected into every
 	// in-process engine this service launches (see WithSandboxDefault).
 	// Empty = neutral (no default), the contract tests rely on.

--- a/pkg/runview/service_runs.go
+++ b/pkg/runview/service_runs.go
@@ -129,15 +129,23 @@ func (s *Service) ListRunRecordsCtx(ctx context.Context, f ListFilter) ([]*store
 	return out, nil
 }
 
-// logSkippedRun reports a run id the listing had to skip — once per
-// (id, category). ListRuns keeps returning ids whose document is gone
-// (manual deletion, partial purge, migration), so without dedup every
-// UI poll re-logs the same line: several WARN lines per second,
+// skipWarnRelogAfter bounds how often the same unreadable run is
+// re-reported. A memoise-forever Warn would silence a genuinely corrupt
+// document forever after ONE transient blip (mongo server-selection,
+// EMFILE/EACCES) marked its id; re-logging on an interval keeps the
+// diagnostic alive without letting a UI poll loop flood the log.
+const skipWarnRelogAfter = 10 * time.Minute
+
+// logSkippedRun reports a run id the listing had to skip, deduplicated
+// per (id, category). ListRuns keeps returning ids whose document is
+// gone (manual deletion, partial purge, migration), so without dedup
+// every UI poll re-logs the same line: several WARN lines per second,
 // indefinitely, drowning the instance log.
 //
 // A missing document (ErrRunNotFound) is a stale index entry, not a
-// corrupt run: Debug. Only an unreadable document rates a Warn — and
-// even that only once, since a corrupt run.json does not heal itself.
+// corrupt run: Debug, once — it cannot heal without the id leaving the
+// listing anyway. Only an unreadable document rates a Warn, at most
+// once per skipWarnRelogAfter.
 func (s *Service) logSkippedRun(id string, err error) {
 	if s.logger == nil {
 		return
@@ -151,16 +159,21 @@ func (s *Service) logSkippedRun(id string, err error) {
 	// A context error means the CALLER went away (or a deadline blew),
 	// not that this document is unreadable — and the listing loop keeps
 	// iterating, so ONE cancelled request would mark every remaining id
-	// "corrupt" and permanently silence the real diagnostic for them
-	// (the mongo store honours the caller's ctx; cloud mode is exactly
-	// where the log flood was observed). Report it without memoising.
+	// "corrupt" (the mongo store honours the caller's ctx; cloud mode is
+	// exactly where the log flood was observed). Report it without
+	// memoising.
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		s.logger.Debug("runview: skip run %s (store call interrupted): %v", id, err)
 		return
 	}
-	if _, dup := s.skipRunLogged.LoadOrStore("corrupt:"+id, struct{}{}); !dup {
-		s.logger.Warn("runview: skip run %s: %v", id, err)
+	key := "corrupt:" + id
+	if last, ok := s.skipRunLogged.Load(key); ok {
+		if ts, ok := last.(time.Time); ok && time.Since(ts) < skipWarnRelogAfter {
+			return
+		}
 	}
+	s.skipRunLogged.Store(key, time.Now())
+	s.logger.Warn("runview: skip run %s: %v", id, err)
 }
 
 // ListCtx is the tenant-aware variant of List: propagates the caller's

--- a/pkg/runview/service_runs.go
+++ b/pkg/runview/service_runs.go
@@ -2,6 +2,7 @@ package runview
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -105,9 +106,7 @@ func (s *Service) ListRunRecordsCtx(ctx context.Context, f ListFilter) ([]*store
 		r, err := s.store.LoadRun(ctx, id)
 		if err != nil {
 			// A single corrupt run.json shouldn't break the whole listing.
-			if s.logger != nil {
-				s.logger.Warn("runview: skip run %s: %v", id, err)
-			}
+			s.logSkippedRun(id, err)
 			continue
 		}
 		if !matchesFilter(r, f) {
@@ -128,6 +127,30 @@ func (s *Service) ListRunRecordsCtx(ctx context.Context, f ListFilter) ([]*store
 		out = out[:f.Limit]
 	}
 	return out, nil
+}
+
+// logSkippedRun reports a run id the listing had to skip — once per
+// (id, category). ListRuns keeps returning ids whose document is gone
+// (manual deletion, partial purge, migration), so without dedup every
+// UI poll re-logs the same line: several WARN lines per second,
+// indefinitely, drowning the instance log.
+//
+// A missing document (ErrRunNotFound) is a stale index entry, not a
+// corrupt run: Debug. Only an unreadable document rates a Warn — and
+// even that only once, since a corrupt run.json does not heal itself.
+func (s *Service) logSkippedRun(id string, err error) {
+	if s.logger == nil {
+		return
+	}
+	if errors.Is(err, store.ErrRunNotFound) {
+		if _, dup := s.skipRunLogged.LoadOrStore("gone:"+id, struct{}{}); !dup {
+			s.logger.Debug("runview: skip run %s (stale index entry, logged once): %v", id, err)
+		}
+		return
+	}
+	if _, dup := s.skipRunLogged.LoadOrStore("corrupt:"+id, struct{}{}); !dup {
+		s.logger.Warn("runview: skip run %s: %v", id, err)
+	}
 }
 
 // ListCtx is the tenant-aware variant of List: propagates the caller's

--- a/pkg/runview/service_runs.go
+++ b/pkg/runview/service_runs.go
@@ -148,6 +148,16 @@ func (s *Service) logSkippedRun(id string, err error) {
 		}
 		return
 	}
+	// A context error means the CALLER went away (or a deadline blew),
+	// not that this document is unreadable — and the listing loop keeps
+	// iterating, so ONE cancelled request would mark every remaining id
+	// "corrupt" and permanently silence the real diagnostic for them
+	// (the mongo store honours the caller's ctx; cloud mode is exactly
+	// where the log flood was observed). Report it without memoising.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		s.logger.Debug("runview: skip run %s (store call interrupted): %v", id, err)
+		return
+	}
 	if _, dup := s.skipRunLogged.LoadOrStore("corrupt:"+id, struct{}{}); !dup {
 		s.logger.Warn("runview: skip run %s: %v", id, err)
 	}

--- a/pkg/runview/service_runs_skip_log_test.go
+++ b/pkg/runview/service_runs_skip_log_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -117,5 +118,37 @@ func TestLogSkippedRunDoesNotMemoizeTransientErrors(t *testing.T) {
 	svc.logSkippedRun("run-transient", errors.New("store: decode run run-transient: invalid character"))
 	if !strings.Contains(buf.String(), "⚠️") {
 		t.Errorf("a later corrupt document for the same id must still Warn\nlog:\n%s", buf.String())
+	}
+}
+
+// The Warn dedup is time-boxed, not once-forever: a transient blip
+// (mongo server-selection, EMFILE) that marked an id must not silence
+// its diagnostic for the process lifetime — after the interval, the
+// same unreadable run warns again.
+func TestLogSkippedRunRelogsWarnAfterInterval(t *testing.T) {
+	var buf bytes.Buffer
+	logger := iterlog.New(iterlog.LevelDebug, &buf)
+	svc := &Service{logger: logger}
+
+	decodeErr := errors.New("store: decode run run-x: invalid character")
+	svc.logSkippedRun("run-x", decodeErr)
+	svc.logSkippedRun("run-x", decodeErr) // inside the interval — deduped
+	warnCount := func() int {
+		n := 0
+		for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+			if strings.Contains(line, "run-x") && strings.Contains(line, "⚠️") {
+				n++
+			}
+		}
+		return n
+	}
+	if got := warnCount(); got != 1 {
+		t.Fatalf("warn count inside the interval = %d, want 1", got)
+	}
+	// Simulate the interval elapsing (the map holds the last-log time).
+	svc.skipRunLogged.Store("corrupt:run-x", time.Now().Add(-skipWarnRelogAfter-time.Second))
+	svc.logSkippedRun("run-x", decodeErr)
+	if got := warnCount(); got != 2 {
+		t.Errorf("warn count after the interval = %d, want 2 (the diagnostic re-arms)", got)
 	}
 }

--- a/pkg/runview/service_runs_skip_log_test.go
+++ b/pkg/runview/service_runs_skip_log_test.go
@@ -1,0 +1,83 @@
+package runview
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// A run id whose document is gone is a stale index entry, not a corrupt
+// run: it logs once at Debug — never at Warn — and is not re-logged on
+// every UI poll. A genuinely unreadable document rates a Warn, also
+// once: a corrupt run.json does not heal between two polls, and the
+// repeated lines were drowning the instance log (several per second).
+func TestListRunRecordsCtxSkipsStaleAndCorruptRunsQuietly(t *testing.T) {
+	dir := t.TempDir()
+	storeDir := filepath.Join(dir, "store")
+	var buf bytes.Buffer
+	logger := iterlog.New(iterlog.LevelDebug, &buf)
+	st, err := store.New(storeDir, store.WithLogger(logger))
+	if err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+	// One healthy run so the listing has something to return.
+	if _, err := st.CreateRun(context.Background(), "run-ok", "wf", nil); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	// Stale index entry: the id exists, run.json does not.
+	if err := os.MkdirAll(filepath.Join(storeDir, "runs", "run-gone"), 0o755); err != nil {
+		t.Fatalf("mkdir stale run: %v", err)
+	}
+	// Corrupt document: present but unreadable.
+	corruptDir := filepath.Join(storeDir, "runs", "run-corrupt")
+	if err := os.MkdirAll(corruptDir, 0o755); err != nil {
+		t.Fatalf("mkdir corrupt run: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(corruptDir, "run.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("write corrupt run.json: %v", err)
+	}
+
+	svc, err := NewService(storeDir, WithLogger(logger))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	// Three polls, as the UI would do.
+	for i := 0; i < 3; i++ {
+		runs, err := svc.ListRunRecordsCtx(context.Background(), ListFilter{})
+		if err != nil {
+			t.Fatalf("ListRunRecordsCtx #%d: %v", i, err)
+		}
+		if len(runs) != 1 || runs[0].ID != "run-ok" {
+			t.Fatalf("listing #%d = %+v, want only run-ok", i, runs)
+		}
+	}
+
+	log := buf.String()
+	lineCount := func(id string) int {
+		n := 0
+		for _, line := range strings.Split(strings.TrimRight(log, "\n"), "\n") {
+			if strings.Contains(line, id) {
+				n++
+				if id == "run-gone" && !strings.Contains(line, "🔍") {
+					t.Errorf("stale run-gone must log at Debug (🔍), got: %s", line)
+				}
+				if id == "run-corrupt" && !strings.Contains(line, "⚠️") {
+					t.Errorf("corrupt run-corrupt must log at Warn (⚠️), got: %s", line)
+				}
+			}
+		}
+		return n
+	}
+	if got := lineCount("run-gone"); got != 1 {
+		t.Errorf("run-gone logged on %d lines over 3 polls, want 1 (log-once)\nlog:\n%s", got, log)
+	}
+	if got := lineCount("run-corrupt"); got != 1 {
+		t.Errorf("run-corrupt logged on %d lines over 3 polls, want 1 (log-once)\nlog:\n%s", got, log)
+	}
+}

--- a/pkg/runview/service_runs_skip_log_test.go
+++ b/pkg/runview/service_runs_skip_log_test.go
@@ -3,6 +3,8 @@ package runview
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -79,5 +81,41 @@ func TestListRunRecordsCtxSkipsStaleAndCorruptRunsQuietly(t *testing.T) {
 	}
 	if got := lineCount("run-corrupt"); got != 1 {
 		t.Errorf("run-corrupt logged on %d lines over 3 polls, want 1 (log-once)\nlog:\n%s", got, log)
+	}
+}
+
+// A context-derived failure (client disconnect, request deadline — the
+// mongo store honours the caller's ctx) is transient: the document may
+// be perfectly readable. It must be reported WITHOUT memoising —
+// otherwise one cancelled listing marks every remaining id "corrupt"
+// and permanently silences the diagnostic the Warn branch exists for.
+func TestLogSkippedRunDoesNotMemoizeTransientErrors(t *testing.T) {
+	var buf bytes.Buffer
+	logger := iterlog.New(iterlog.LevelDebug, &buf)
+	svc := &Service{logger: logger}
+
+	ctxErr := fmt.Errorf("store/mongo: find run: %w", context.Canceled)
+	for i := 0; i < 3; i++ {
+		svc.logSkippedRun("run-transient", ctxErr)
+	}
+	log := buf.String()
+	lineCount := 0
+	for _, line := range strings.Split(strings.TrimRight(log, "\n"), "\n") {
+		if strings.Contains(line, "run-transient") {
+			lineCount++
+			if strings.Contains(line, "⚠️") {
+				t.Errorf("a transient ctx error must not rate a Warn, got: %s", line)
+			}
+		}
+	}
+	if lineCount != 3 {
+		t.Errorf("transient error logged %d times over 3 calls, want 3 (reported, never memoised)\nlog:\n%s", lineCount, log)
+	}
+
+	// And a genuinely unreadable document for the SAME id still warns:
+	// the transient calls must not have consumed its one Warn slot.
+	svc.logSkippedRun("run-transient", errors.New("store: decode run run-transient: invalid character"))
+	if !strings.Contains(buf.String(), "⚠️") {
+		t.Errorf("a later corrupt document for the same id must still Warn\nlog:\n%s", buf.String())
 	}
 }


### PR DESCRIPTION
## Problème (#375)

Des ids de run dont le `run.json` n'existait plus restaient listés par le store et étaient rechargés **à chaque poll de l'UI**, chacun produisant une ligne `WARN` — plusieurs lignes par seconde, indéfiniment. Sur une instance active, `instances/<projet>.log` atteignait 50 Mo et devenait inexploitable. Symptôme voisin : `runtime: finalize: cannot read worktree HEAD` rebouclait toutes les minutes sur des worktrees supprimés.

La tolérance aux runs illisibles (un run corrompu ne casse pas le listing) était la bonne décision ; le problème était ailleurs :

1. **`ListRuns` continue de renvoyer des ids sans document** — jamais réconciliés.
2. **Le warn n'était pas dédupliqué** — le même id, la même erreur, à chaque appel.

## Correctif

- **Listing runview** (`ListRunRecordsCtx`) : distinction **« introuvable » vs « corrompu »**. Un `run.json` absent (`errors.Is(err, store.ErrRunNotFound)`) est une entrée d'index périmée, pas un document corrompu → `Debug`, journalisé **une fois par id**. Seul un JSON illisible rate un `Warn` — lui aussi une seule fois (un run.json corrompu ne guérit pas entre deux polls). Dédup via une `sync.Map` de service indexée par (catégorie, id).
- **`RecoverFinalize`** : un worktree supprimé (cleanup opérateur, `git worktree remove`, GC du store) est un état **permanent** sans rien à promouvoir → skip silencieux au lieu du `WARN` à chaque tick. Un worktree **existant** mais illisible continue d'avertir depuis `finalizeWorktree`.

Non retenu (piste 3 du ticket, optionnelle) : la commande `iterion store prune` de réconciliation de l'index — la dédup règle le bruit sans toucher au store.

## Tests

- `TestListRunRecordsCtxSkipsStaleAndCorruptRunsQuietly` : sur 3 polls, l'id périmé loggue une fois en `Debug`, l'id corrompu une fois en `Warn`, le listing reste correct
- `TestRecoverFinalize_GoneWorktreeIsQuiet` : 3 ticks sur un worktree supprimé → silence complet, aucune mutation

Closes #375