### PR TITLE
fix(runview): reset dropped nodes' execution state on run_rewound

### DIFF
--- a/pkg/runview/snapshot.go
+++ b/pkg/runview/snapshot.go
@@ -507,6 +507,8 @@ func (b *SnapshotBuilder) Apply(evt *store.Event) {
 		b.accumulateActive(evt.Timestamp)
 	case store.EventRunCancelled:
 		b.handleRunCancelled(evt)
+	case store.EventRunRewound:
+		b.handleRunRewound(evt)
 	case store.EventRunInterrupted:
 		// Server drain — freeze the timer like a pause. The matching
 		// resume re-anchors. Without this case the event would fall
@@ -961,6 +963,91 @@ func (b *SnapshotBuilder) handleRunCancelled(evt *store.Event) {
 		reason = "run cancelled"
 	}
 	b.closeInFlightExecs(ExecStatusFailed, evt.Timestamp, evt.Seq, reason)
+}
+
+// handleRunRewound erases the execution state of every node the rewind
+// invalidated. Rewind (pkg/runview/rewind.go) deletes those nodes'
+// outputs from the checkpoint, but the snapshot is folded from the
+// append-only event log — the pre-rewind node_started / node_finished
+// records are still in the stream, and without this the canvas keeps
+// rendering the dropped nodes with their pre-rewind status, duration
+// and error as if the rewind had not happened.
+//
+// Deleting (rather than downgrading to a neutral status) is what
+// resets the node: with no execution left the canvas renders it as
+// never-run, and the node_started the post-rewind resume emits
+// recreates the exec cleanly — no dependence on the lastResumedSeq
+// pre-resume-artefact rule, which exists to triage duplicate
+// emissions, not to undo recorded state.
+func (b *SnapshotBuilder) handleRunRewound(evt *store.Event) {
+	b.accumulateActive(evt.Timestamp)
+	dropped := rewoundNodeIDs(evt.Data["dropped_nodes"])
+	if len(dropped) == 0 {
+		return
+	}
+	removed := map[string]bool{}
+	for id, exec := range b.execs {
+		if exec != nil && dropped[exec.IRNodeID] {
+			removed[id] = true
+			delete(b.execs, id)
+		}
+	}
+	if len(removed) == 0 {
+		return
+	}
+	kept := b.order[:0]
+	for _, id := range b.order {
+		if !removed[id] {
+			kept = append(kept, id)
+		}
+	}
+	b.order = kept
+	// Clear the (branch, node) → exec_id pointers and the legacy
+	// iteration counters of the dropped nodes so the post-rewind
+	// re-execution starts from a clean slate instead of attributing
+	// downstream events to (or numbering iterations after) an
+	// execution that no longer exists.
+	for branch, perNode := range b.lastExecID {
+		for nodeID := range perNode {
+			if dropped[nodeID] {
+				delete(perNode, nodeID)
+			}
+		}
+		if len(perNode) == 0 {
+			delete(b.lastExecID, branch)
+		}
+	}
+	for branch, counts := range b.nodeCount {
+		for nodeID := range counts {
+			if dropped[nodeID] {
+				delete(counts, nodeID)
+			}
+		}
+		if len(counts) == 0 {
+			delete(b.nodeCount, branch)
+		}
+	}
+}
+
+// rewoundNodeIDs normalises the run_rewound payload's dropped_nodes
+// field into a lookup set. As appended by Rewind it is a []string;
+// after a JSON round-trip through events.jsonl or Mongo it decodes
+// as []any.
+func rewoundNodeIDs(raw any) map[string]bool {
+	out := map[string]bool{}
+	switch v := raw.(type) {
+	case []string:
+		for _, id := range v {
+			out[id] = true
+		}
+	case []any:
+		for _, item := range v {
+			if id, ok := item.(string); ok {
+				out[id] = true
+			}
+		}
+	}
+	return out
 }
 
 // closeInFlightExecs terminates every execution still marked running

--- a/pkg/runview/snapshot_test.go
+++ b/pkg/runview/snapshot_test.go
@@ -1299,3 +1299,117 @@ func TestSnapshotReducer_FallbacksUsedDedupesByNode(t *testing.T) {
 		t.Errorf("second = %+v, want implement/run-fallback", got[1])
 	}
 }
+
+func TestSnapshotReducer_RunRewoundResetsDroppedNodes(t *testing.T) {
+	// The run_rewound event must erase the execution state of the nodes
+	// the rewind invalidated: the event log is append-only, so without a
+	// dedicated fold the canvas keeps rendering the dropped nodes with
+	// their pre-rewind status / duration / error (pkg/runview/rewind.go
+	// only touches the checkpoint).
+	b := NewSnapshotBuilder(&store.Run{ID: "r1", Status: store.RunStatusRunning})
+	events := []*store.Event{
+		evt(0, store.EventRunStarted, "", "", nil),
+		evt(1, store.EventNodeStarted, "", "analyze", map[string]any{"kind": "agent"}),
+		evt(2, store.EventNodeFinished, "", "analyze", nil),
+		evt(3, store.EventNodeStarted, "", "verify", map[string]any{"kind": "judge"}),
+		evt(4, store.EventNodeFinished, "", "verify", nil),
+		evt(5, store.EventNodeStarted, "", "report", map[string]any{"kind": "agent"}),
+		evt(6, store.EventNodeFinished, "", "report", nil),
+		// Rewind to "verify": verify (pivot) and everything downstream
+		// of it is invalidated; analyze survives.
+		evt(7, store.EventRunRewound, "", "verify", map[string]any{
+			"from_node":     "report",
+			"to_node":       "verify",
+			"dropped_nodes": []string{"report", "verify"},
+		}),
+	}
+	for _, e := range events {
+		b.Apply(e)
+	}
+	snap := b.Snapshot()
+	if got := len(snap.Executions); got != 1 {
+		t.Fatalf("Executions = %d, want 1 (only the pre-pivot node survives): %+v", got, snap.Executions)
+	}
+	if snap.Executions[0].IRNodeID != "analyze" || snap.Executions[0].Status != ExecStatusFinished {
+		t.Errorf("surviving exec = %+v, want analyze/finished", snap.Executions[0])
+	}
+
+	// The post-rewind resume re-executes the pivot: its node_started
+	// must recreate a clean running exec — and exactly once in the
+	// order slice (no duplicate emission from Snapshot()).
+	b.Apply(evt(8, store.EventRunResumed, "", "", nil))
+	b.Apply(evt(9, store.EventNodeStarted, "", "verify", map[string]any{"kind": "judge"}))
+	snap = b.Snapshot()
+	if got := len(snap.Executions); got != 2 {
+		t.Fatalf("Executions after resume = %d, want 2: %+v", got, snap.Executions)
+	}
+	replayed := snap.Executions[1]
+	if replayed.IRNodeID != "verify" || replayed.Status != ExecStatusRunning {
+		t.Errorf("replayed exec = %+v, want verify/running", replayed)
+	}
+	if replayed.FinishedAt != nil {
+		t.Errorf("replayed exec FinishedAt = %v, want nil (fresh attempt)", replayed.FinishedAt)
+	}
+	// And the replayed node finishes normally — the rewound exec must
+	// not linger anywhere to swallow the node_finished.
+	b.Apply(evt(10, store.EventNodeFinished, "", "verify", nil))
+	snap = b.Snapshot()
+	if snap.Executions[1].Status != ExecStatusFinished {
+		t.Errorf("replayed exec Status = %q, want finished", snap.Executions[1].Status)
+	}
+}
+
+func TestSnapshotReducer_RunRewoundLoopNodeDropsEveryIteration(t *testing.T) {
+	// A dropped node that ran N loop iterations produced N execs; the
+	// rewind invalidates the NODE, so every one of them goes.
+	b := NewSnapshotBuilder(&store.Run{ID: "r1"})
+	for i := int64(0); i < 3; i++ {
+		b.Apply(evt(i*2, store.EventNodeStarted, "", "fix", map[string]any{"kind": "agent"}))
+		b.Apply(evt(i*2+1, store.EventNodeFinished, "", "fix", nil))
+	}
+	if got := len(b.Snapshot().Executions); got != 3 {
+		t.Fatalf("pre-rewind Executions = %d, want 3", got)
+	}
+	b.Apply(evt(6, store.EventRunRewound, "", "fix", map[string]any{
+		"dropped_nodes": []string{"fix"},
+	}))
+	if got := len(b.Snapshot().Executions); got != 0 {
+		t.Fatalf("post-rewind Executions = %d, want 0: %+v", got, b.Snapshot().Executions)
+	}
+	// Re-execution numbers iterations from a clean slate (legacy
+	// no-`iteration`-field path): nodeCount was reset too.
+	b.Apply(evt(7, store.EventNodeStarted, "", "fix", map[string]any{"kind": "agent"}))
+	snap := b.Snapshot()
+	if got := len(snap.Executions); got != 1 {
+		t.Fatalf("post-resume Executions = %d, want 1", got)
+	}
+	if snap.Executions[0].LoopIteration != 0 {
+		t.Errorf("replayed LoopIteration = %d, want 0 (nodeCount reset)", snap.Executions[0].LoopIteration)
+	}
+}
+
+func TestSnapshotReducer_RunRewoundJSONDecodedPayload(t *testing.T) {
+	// After a round-trip through events.jsonl / Mongo, dropped_nodes
+	// decodes as []any, not []string — the fold must handle both.
+	b := NewSnapshotBuilder(&store.Run{ID: "r1"})
+	b.Apply(evt(0, store.EventNodeStarted, "", "verify", map[string]any{"kind": "judge"}))
+	b.Apply(evt(1, store.EventNodeFinished, "", "verify", nil))
+	b.Apply(evt(2, store.EventRunRewound, "", "verify", map[string]any{
+		"dropped_nodes": []any{"verify"},
+	}))
+	if got := len(b.Snapshot().Executions); got != 0 {
+		t.Fatalf("Executions = %d, want 0 (dropped_nodes decoded as []any)", got)
+	}
+}
+
+func TestSnapshotReducer_RunRewoundWithoutDroppedNodesIsANoOp(t *testing.T) {
+	// Defensive: a malformed or legacy run_rewound payload must not
+	// wipe unrelated executions.
+	b := NewSnapshotBuilder(&store.Run{ID: "r1"})
+	b.Apply(evt(0, store.EventNodeStarted, "", "analyze", map[string]any{"kind": "agent"}))
+	b.Apply(evt(1, store.EventNodeFinished, "", "analyze", nil))
+	b.Apply(evt(2, store.EventRunRewound, "", "analyze", nil))
+	if got := len(b.Snapshot().Executions); got != 1 {
+		t.Fatalf("Executions = %d, want 1 (no dropped_nodes → no-op)", got)
+	}
+}

--- a/studio/src/api/runs/events.ts
+++ b/studio/src/api/runs/events.ts
@@ -239,6 +239,19 @@ export interface RunCancelledEvent extends RunEventBase {
   };
 }
 
+export interface RunRewoundEvent extends RunEventBase {
+  type: "run_rewound";
+  data?: {
+    // Node ids whose state the rewind invalidated (checkpoint outputs,
+    // artifacts, child pointers) — the pivot is always included.
+    // Emitted by pkg/runview/rewind.go.
+    dropped_nodes?: string[];
+    from_node?: string;
+    to_node?: string;
+    [key: string]: unknown;
+  };
+}
+
 export interface BrowserSessionStartedEvent extends RunEventBase {
   type: "browser_session_started";
   data?: {
@@ -439,6 +452,7 @@ export type RunEvent =
   | RunFinishedEvent
   | RunFailedEvent
   | RunCancelledEvent
+  | RunRewoundEvent
   | BrowserSessionStartedEvent
   | BrowserSessionEndedEvent
   | BrowserScreenshotEvent

--- a/studio/src/lib/snapshotReducer.test.ts
+++ b/studio/src/lib/snapshotReducer.test.ts
@@ -99,3 +99,111 @@ describe("snapshotReducer terminal run events", () => {
     expect(byNode.b?.status).toBe("failed");
   });
 });
+
+describe("snapshotReducer run_rewound", () => {
+  const rewindEvents = (): RunEvent[] => [
+    nodeStarted(1, "analyze"),
+    {
+      seq: 2,
+      timestamp: "2026-05-14T12:00:30Z",
+      type: "node_finished",
+      run_id: "r1",
+      branch_id: "main",
+      node_id: "analyze",
+    },
+    nodeStarted(3, "verify", "2026-05-14T12:01:00Z"),
+    {
+      seq: 4,
+      timestamp: "2026-05-14T12:01:30Z",
+      type: "node_finished",
+      run_id: "r1",
+      branch_id: "main",
+      node_id: "verify",
+    },
+    nodeStarted(5, "report", "2026-05-14T12:02:00Z"),
+    {
+      seq: 6,
+      timestamp: "2026-05-14T12:02:30Z",
+      type: "node_finished",
+      run_id: "r1",
+      branch_id: "main",
+      node_id: "report",
+    },
+    {
+      seq: 7,
+      timestamp: "2026-05-14T12:03:00Z",
+      type: "run_rewound",
+      run_id: "r1",
+      branch_id: "main",
+      node_id: "verify",
+      data: { dropped_nodes: ["report", "verify"], to_node: "verify" },
+    },
+  ];
+
+  it("erases the dropped nodes' execs, keeps the pre-pivot ones", () => {
+    const out = buildExecutionsAt(rewindEvents(), 999);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.ir_node_id).toBe("analyze");
+    expect(out[0]?.status).toBe("finished");
+  });
+
+  it("scrubbing before the rewind still shows the pre-rewind state", () => {
+    const out = buildExecutionsAt(rewindEvents(), 6);
+    expect(out).toHaveLength(3);
+    const byNode = Object.fromEntries(out.map((e) => [e.ir_node_id, e]));
+    expect(byNode.verify?.status).toBe("finished");
+    expect(byNode.report?.status).toBe("finished");
+  });
+
+  it("a post-rewind node_started recreates a clean exec, renumbered from 0", () => {
+    const events = rewindEvents().concat([
+      nodeStarted(8, "verify", "2026-05-14T12:04:00Z"),
+    ]);
+    const out = buildExecutionsAt(events, 999);
+    expect(out).toHaveLength(2);
+    const verify = out.find((e) => e.ir_node_id === "verify");
+    expect(verify?.status).toBe("running");
+    expect(verify?.finished_at).toBeUndefined();
+    expect(verify?.loop_iteration).toBe(0);
+  });
+
+  it("drops every loop iteration of a rewound node", () => {
+    const events: RunEvent[] = [];
+    for (let i = 0; i < 3; i++) {
+      events.push(nodeStarted(i * 2 + 1, "fix"));
+      events.push({
+        seq: i * 2 + 2,
+        timestamp: "2026-05-14T12:00:30Z",
+        type: "node_finished",
+        run_id: "r1",
+        branch_id: "main",
+        node_id: "fix",
+      });
+    }
+    expect(buildExecutionsAt(events, 999)).toHaveLength(3);
+    events.push({
+      seq: 7,
+      timestamp: "2026-05-14T12:03:00Z",
+      type: "run_rewound",
+      run_id: "r1",
+      branch_id: "main",
+      node_id: "fix",
+      data: { dropped_nodes: ["fix"] },
+    });
+    expect(buildExecutionsAt(events, 999)).toHaveLength(0);
+  });
+
+  it("ignores a run_rewound without dropped_nodes", () => {
+    const events: RunEvent[] = [
+      nodeStarted(1, "a"),
+      {
+        seq: 2,
+        timestamp: "2026-05-14T12:01:00Z",
+        type: "run_rewound",
+        run_id: "r1",
+        branch_id: "main",
+      },
+    ];
+    expect(buildExecutionsAt(events, 999)).toHaveLength(1);
+  });
+});

--- a/studio/src/lib/snapshotReducer.ts
+++ b/studio/src/lib/snapshotReducer.ts
@@ -221,6 +221,33 @@ export function buildExecutionsAt(
         closeInFlightExecs(execs, "failed", evt.timestamp, evt.seq, reason);
         break;
       }
+      case "run_rewound": {
+        // Mirror of pkg/runview/snapshot.go::handleRunRewound: erase the
+        // executions of the nodes the rewind invalidated so the canvas
+        // renders them as never-run past this seq. Folding from scratch
+        // keeps the scrubber coherent both ways — a position BEFORE the
+        // rewind still shows the pre-rewind state, a position after it
+        // shows the reset.
+        const dropped = new Set(
+          (evt.data?.["dropped_nodes"] as string[] | undefined) ?? [],
+        );
+        if (dropped.size === 0) break;
+        for (const [id, e] of execs) {
+          if (dropped.has(e.ir_node_id)) execs.delete(id);
+        }
+        for (const [key, id] of lastExecID) {
+          if (!execs.has(id)) lastExecID.delete(key);
+        }
+        // Reset the legacy iteration counters of the dropped nodes
+        // (backend resets nodeCount too) so a post-rewind re-execution
+        // of an event stream without explicit `iteration` fields
+        // numbers from 0 again. Keys are `${branch} ${nodeId}` —
+        // see eventIter.stepIteration.
+        for (const key of counts.keys()) {
+          if (dropped.has(key.slice(key.indexOf(" ") + 1))) counts.delete(key);
+        }
+        break;
+      }
       default:
         break;
     }

--- a/studio/src/store/run/reducer.test.ts
+++ b/studio/src/store/run/reducer.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExecutionState, RunEvent, RunSnapshot } from "@/api/runs";
+
+import { execKey, reduceEvents } from "./reducer";
+
+// Minimal ReduceInput state: one finished exec for `analyze` (pre-pivot)
+// and one finished exec for `verify` (rewind pivot), plus the lookup
+// pointer node_started would have stamped.
+function baseExec(node: string, seq: number): ExecutionState {
+  return {
+    execution_id: `exec:main:${node}:0`,
+    ir_node_id: node,
+    branch_id: "main",
+    loop_iteration: 0,
+    status: "finished",
+    started_at: "2026-05-14T12:00:00Z",
+    finished_at: "2026-05-14T12:00:30Z",
+    current_event_seq: seq,
+    first_seq: seq - 1,
+    last_seq: seq,
+  };
+}
+
+function baseSnapshot(): RunSnapshot {
+  return {
+    run: {
+      id: "r1",
+      workflow_name: "wf",
+      status: "failed_resumable",
+      created_at: "2026-05-14T12:00:00Z",
+      updated_at: "2026-05-14T12:00:30Z",
+      active_duration_ms: 30_000,
+    },
+    executions: [baseExec("analyze", 2), baseExec("verify", 4)],
+    last_seq: 4,
+  };
+}
+
+function baseState() {
+  const executionsById = new Map<string, ExecutionState>();
+  for (const e of baseSnapshot().executions) {
+    executionsById.set(e.execution_id, e);
+  }
+  return {
+    events: [] as RunEvent[],
+    executionsById,
+    lastExecIDByNode: new Map([
+      [execKey("main", "analyze"), "exec:main:analyze:0"],
+      [execKey("main", "verify"), "exec:main:verify:0"],
+    ]),
+    inFlightToolsByExec: new Map(),
+    latestTodosByExec: new Map(),
+    todoHistoryByExec: new Map(),
+    snapshot: baseSnapshot() as RunSnapshot | null,
+    pendingHumanInput: null as {
+      interaction_id?: string;
+      node_id?: string;
+      questions?: Record<string, unknown>;
+    } | null,
+    queuedMessages: [],
+    browser: {
+      currentUrl: null,
+      scope: "external" as const,
+      source: null,
+      kind: undefined,
+      lastEventSeqSeen: null,
+      screenshots: [],
+      liveSession: null,
+    },
+    resultLinks: [],
+  };
+}
+
+function rewindEvent(seq: number, dropped: string[]): RunEvent {
+  return {
+    seq,
+    timestamp: "2026-05-14T12:05:00Z",
+    type: "run_rewound",
+    run_id: "r1",
+    branch_id: "main",
+    node_id: "verify",
+    data: { dropped_nodes: dropped, to_node: "verify" },
+  };
+}
+
+describe("reduceEvents run_rewound", () => {
+  it("erases the dropped nodes' execs and keeps the pre-pivot ones", () => {
+    const next = reduceEvents(baseState(), [rewindEvent(5, ["verify"])]);
+    const execs = [...(next.executionsById?.values() ?? [])];
+    expect(execs).toHaveLength(1);
+    expect(execs[0]?.ir_node_id).toBe("analyze");
+    // The snapshot's ordered executions reflect the deletion too.
+    expect(next.snapshot?.executions).toHaveLength(1);
+    expect(next.snapshot?.executions[0]?.ir_node_id).toBe("analyze");
+    // The (branch, node) → exec_id pointer of the dropped node is gone.
+    expect(next.lastExecIDByNode?.has(execKey("main", "verify"))).toBe(false);
+    expect(next.lastExecIDByNode?.has(execKey("main", "analyze"))).toBe(true);
+  });
+
+  it("parks the run as cancelled even when no exec matches", () => {
+    const next = reduceEvents(baseState(), [rewindEvent(5, ["nosuchnode"])]);
+    expect(next.snapshot?.run.status).toBe("cancelled");
+    expect(next.snapshot?.executions).toHaveLength(2);
+  });
+
+  it("drops a pending pause form belonging to a dropped node", () => {
+    const state = baseState();
+    state.pendingHumanInput = {
+      interaction_id: "i1",
+      node_id: "verify",
+      questions: {},
+    };
+    const next = reduceEvents(state, [rewindEvent(5, ["verify"])]);
+    expect(next.pendingHumanInput).toBeNull();
+  });
+
+  it("keeps a pending pause form of a surviving node", () => {
+    const state = baseState();
+    state.pendingHumanInput = {
+      interaction_id: "i1",
+      node_id: "analyze",
+      questions: {},
+    };
+    const next = reduceEvents(state, [rewindEvent(5, ["verify"])]);
+    expect(next.pendingHumanInput).toBeUndefined();
+  });
+
+  it("a post-rewind node_started recreates a clean running exec", () => {
+    const state = baseState();
+    const after = reduceEvents(state, [
+      rewindEvent(5, ["verify"]),
+      {
+        seq: 6,
+        timestamp: "2026-05-14T12:06:00Z",
+        type: "run_resumed",
+        run_id: "r1",
+        branch_id: "main",
+      },
+      {
+        seq: 7,
+        timestamp: "2026-05-14T12:06:01Z",
+        type: "node_started",
+        run_id: "r1",
+        branch_id: "main",
+        node_id: "verify",
+      },
+    ]);
+    const execs = [...(after.executionsById?.values() ?? [])];
+    const verify = execs.find((e) => e.ir_node_id === "verify");
+    expect(execs).toHaveLength(2);
+    expect(verify?.status).toBe("running");
+    expect(verify?.finished_at).toBeUndefined();
+    expect(after.snapshot?.executions).toHaveLength(2);
+  });
+});

--- a/studio/src/store/run/reducer.ts
+++ b/studio/src/store/run/reducer.ts
@@ -649,6 +649,50 @@ export function reduceEvents(
         runStatusOverride = "cancelled";
         break;
       }
+      case "run_rewound": {
+        // Mirror of pkg/runview/snapshot.go::handleRunRewound. The
+        // rewind deleted the dropped nodes' outputs from the checkpoint,
+        // but the event log is append-only: their pre-rewind
+        // node_started / node_finished records still fold in, and
+        // without this the canvas keeps the dropped nodes' pre-rewind
+        // status / duration / error as if nothing had happened.
+        // Deleting the execs (rather than downgrading them) renders
+        // the nodes as never-run; the post-rewind resume recreates
+        // them via a fresh node_started.
+        // Rewind parks the run as `cancelled` (resumable) without
+        // emitting a run_cancelled event — reflect that immediately
+        // instead of waiting for the next run.json refetch.
+        runStatusOverride = "cancelled";
+        const dropped = new Set(evt.data?.dropped_nodes ?? []);
+        if (dropped.size === 0) break;
+        const removedExecIds: string[] = [];
+        for (const e of executionsById.values()) {
+          if (dropped.has(e.ir_node_id)) removedExecIds.push(e.execution_id);
+        }
+        // A pause form belonging to a dropped node is dead — the rewind
+        // retired the interaction server-side.
+        if (pendingHumanInput && dropped.has(pendingHumanInput.node_id ?? "")) {
+          pendingHumanInput = null;
+        }
+        if (removedExecIds.length === 0) break;
+        ensureExecCopy();
+        for (const id of removedExecIds) {
+          executionsById.delete(id);
+          clearInFlightFor(id);
+          clearTodosFor(id);
+        }
+        // Drop the (branch, node) → exec_id pointers of the dropped
+        // nodes so post-rewind events don't attribute to an execution
+        // that no longer exists. todoHistoryByExec is deliberately
+        // kept: it is the Session board's never-cleared journey record.
+        ensureLastExecIDCopy();
+        for (const [key, id] of lastExecIDByNode) {
+          if (dropped.has(key.split("\t")[1] ?? "") || !executionsById.has(id)) {
+            lastExecIDByNode.delete(key);
+          }
+        }
+        break;
+      }
       case "run_paused": {
         // The engine emits the same event type for every pause flavour.
         // Operator pause (POST /api/runs/:id/pause) tags reason=operator


### PR DESCRIPTION
## Problem

After an in-place rewind (`iterion rewind` / `POST /api/runs/{id}/rewind`), the run's nodes kept the colours and infos (status, duration, error) of their pre-rewind executions instead of resetting to never-run.

Root cause: `Rewind` (`pkg/runview/rewind.go`) correctly deletes the dropped nodes' outputs from the **checkpoint** and appends a `run_rewound` event (with `dropped_nodes`) to the append-only event log. But node colours/infos on the canvas come from `ExecutionState`, folded from the event stream — and **none of the three reducers handled `run_rewound`**:

- `pkg/runview/snapshot.go` — `SnapshotBuilder.Apply` (REST snapshot / WS backend)
- `studio/src/store/run/reducer.ts` — `reduceEvents` (live WebSocket)
- `studio/src/lib/snapshotReducer.ts` — `buildExecutionsAt` (time-travel scrubber)

The pre-rewind `node_started`/`node_finished` records (never truncated, by design) kept folding in, so the dropped nodes rendered exactly as before the rewind.

## Fix

Fold `run_rewound` in all three reducers, mirroring each other as the codebase already requires:

- **Erase** every execution whose `ir_node_id` is in the event's `dropped_nodes` (the pivot is always included; every loop iteration of a dropped node goes). Deleting — rather than downgrading — renders the node as never-run, and the post-rewind resume's fresh `node_started` recreates the exec cleanly, without leaning on the `lastResumedSeq` pre-resume-artefact rule.
- Clear the `(branch, node) → exec_id` pointers and legacy iteration counters of dropped nodes so re-execution starts from a clean slate.
- Live store only: drop a pending pause form owned by a dropped node (the rewind retires the interaction server-side), and park the run status pill on `cancelled` — rewind emits no `run_cancelled` event, so the pill would otherwise stay stale until the next `run.json` refetch.
- Scrubber: folding from scratch keeps time-travel coherent — a position *before* the rewind still shows the pre-rewind state, a position *after* it shows the reset.
- `studio/src/api/runs/events.ts` gains the `RunRewoundEvent` union variant (typed `dropped_nodes`).

## Tests

- Backend (`pkg/runview/snapshot_test.go`): linear-run rewind keeps pre-pivot execs and drops pivot+downstream; post-rewind resume recreates a clean running exec with no duplicate `Snapshot()` emission; all loop iterations of a dropped node are erased and renumber from 0; JSON-decoded `[]any` payload handled; missing `dropped_nodes` is a no-op.
- Scrubber (`studio/src/lib/snapshotReducer.test.ts`): same folding contract, plus scrubbing to a seq *before* the rewind still shows the old state.
- Live store (`studio/src/store/run/reducer.test.ts`, new): exec erasure in `executionsById` **and** `snapshot.executions`, pointer cleanup, `cancelled` status even with no matching exec, pause-form drop/keep, clean re-creation on post-rewind `node_started`.

Verified: `go test ./pkg/runview ./pkg/server` ✓, `go vet` + `gofmt` ✓, `tsc -b` ✓, `eslint` (0 errors) ✓, full studio suite — 136 files / 1222 tests ✓.
