### PR TITLE
fix(gate): a review in flight is indistinguishable from one that never ran

### DIFF
--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -28,13 +28,23 @@ status.
 ## How it works
 
 ```
-PR opened / pushed ──▶ Revi runs (selected reviewer topology → merge → publish)
+PR opened / pushed ──▶ launch claims the head:  revi/review = pending
+                              │                 ("review in progress")
+                              ▼
+                       Revi runs (selected reviewer topology → merge → publish)
                               │
                               ├─ inline comments  (advisory)
                               └─ revi/review status on the head SHA
                                     success  ⟺  0 findings ≥ gate_severity
                                     failure  ⟺  ≥1 finding  ≥ gate_severity
+
+               run dies without publishing ──▶ reconciler posts failure
+                                               (event + 1-min sweep)
 ```
+
+The context is claimed at launch and answered at the end, so the check is never
+silent while a review is running — see [the in-flight
+claim](#inflight) and [the repair](#interrupted).
 
 1. **Trigger.** Revi auto-reviews on PR `opened`/`reopened`. For the gate to
    track fixes, enable **`ReviewOnSync`** on the webhook so a push
@@ -303,12 +313,44 @@ Revi separates two channels:
   residual risk hides) and are surfaced in the report + the PR review summary
   body. They **never** become findings, reach the board, or gate a merge.
 
+## <a name="inflight"></a>The check says "running" while the review runs
+
+A review takes minutes. For all of them the gate context used to carry **no
+status at all**, and a forge renders that as *"Expected — waiting for status to
+be reported"* — the same rendering as a review that was never launched, a bot
+that crashed on boot, and a webhook that never fired. Read next to Revi's
+review comment on the *previous* commit, it looks exactly like "the bot
+commented but the gate never went green".
+
+So the launch **claims** the context: the moment a run is admitted on a
+revision, the server posts `pending` on that head, described as *review in
+progress — the verdict will replace this*, pointed at the live run console. The
+absence of a status once again means what it says.
+
+Two rules keep the claim from doing harm:
+
+- **It never overwrites a verdict.** A repo pins one gate context precisely so
+  a required check can span several bots ([below](#one-gate)), so a second bot
+  launching on a head another bot already judged must not blank that judgment
+  back to "running". It writes only over nothing, over a previous claim, or
+  over a synthetic interruption (a fresh review on that head IS the recovery).
+  A provider iterion cannot read statuses back from is left alone.
+- **Every consumer knows the marker.** A guard written as "this head already
+  has a status, so someone answered" would read the claim as a verdict —
+  which would make posting it *worse* than the absence, by silencing the very
+  repair below. The reconciler therefore treats its own claim as unanswered.
+
+The claim is not a substitute for the repair: a run that dies still holding it
+leaves a `pending` nothing will resolve, which blocks a required check exactly
+like an absent one. It makes the window legible; the next section is what
+closes it.
+
 ## <a name="interrupted"></a>A review that dies still leaves a verdict
 
-A required check that is **absent** is indistinguishable from one still
-running: the pull request waits for a context that will never arrive, and no
-error appears on the run, the PR or the check. That is worse than a red check,
-because nothing points at the cause.
+A required check that is **absent** — or stuck on the in-flight claim above —
+is indistinguishable from one still running: the pull request waits for a
+context that will never arrive, and no error appears on the run, the PR or the
+check. That is worse than a red check, because nothing points at the cause.
 
 It happened twice in one day in production. A rolling deploy drained a review
 mid-flight (the lame-duck drain is not deployed, so a rollout cancels in-flight
@@ -360,6 +402,50 @@ that from doing harm of its own:
 
 A paused run is not reconciled: it is expected to resume and post its own
 verdict.
+
+### Two triggers, because one event is not a guarantee
+
+The repair is driven by a run-outcome event on the internal bus — and that bus
+is **lossy by design**. Every other consumer carries a reconciliation net for
+exactly that reason (usernotify's 2-minute sweep, the dispatcher's 30s poll
+behind its board fast path, the retry sweeper because no in-pod timer survives
+a rollout). The merge gate — the one consumer whose miss *blocks a pull
+request* — had none: a dropped event left the check absent forever, with the
+run reading `failed_resumable` and nothing anywhere saying a PR was waiting.
+
+Observed 2026-08-10: four review runs died on one provider weekly cap inside 90
+seconds, all four gates stayed absent for hours, and the reconciler had left no
+trace of having considered any of them.
+
+So a **sweep** offers the same runs to the same repair a second time: every
+minute, terminal runs in a bounded window (a 3-minute grace so the two paths
+race only on the dropped ones, a 60-minute lookback so it never reaches back
+and paints a failure onto a long-merged PR). The repair re-reads the live
+status before writing, so the redundant offer costs one API read.
+
+Telling "already answered" from "must escalate" is what makes the second offer
+safe. A synthetic failure deliberately does *not* stand the repair down — that
+is how a **second** death on one head (a relaunched run dying too) escalates
+instead of mistaking the first death's marker for an answer. But the same run
+re-offered every minute is already answered. The status's target URL names the
+run it speaks for, which separates the two with no bookkeeping a second replica
+would not share.
+
+Finally, when a repair genuinely declines to act, **it says so**. Every branch
+past "this run held a publish grant and died" now logs the reason it is posting
+nothing (`forge gate: run … held a grant on … but posts nothing: …`). Those
+branches used to return silently, which is why the four blocked PRs above were
+indistinguishable from four runs that gated nothing.
+
+### The verdict survives a long quota wait
+
+A run parked on a provider usage window is resumed by the retry sweeper up to
+`retrypolicy.DefaultMaxWait` later — a **weekly** forfait cap resets as much as
+seven days out. The per-run publish grant has to outlive that: at a flat 24h it
+expired long before the resumed run reached its publish node, so the review
+completed and then had no way to post the verdict it had computed. The grant's
+TTL is therefore derived from the max retry wait, plus a margin for the resumed
+run itself.
 
 ### The dead review is re-run — once per head
 

--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -335,10 +335,20 @@ Two rules keep the claim from doing harm:
   back to "running". It writes only over nothing, over a previous claim, or
   over a synthetic interruption (a fresh review on that head IS the recovery).
   A provider iterion cannot read statuses back from is left alone.
-- **Every consumer knows the marker.** A guard written as "this head already
-  has a status, so someone answered" would read the claim as a verdict —
-  which would make posting it *worse* than the absence, by silencing the very
-  repair below. The reconciler therefore treats its own claim as unanswered.
+- **Every consumer knows the marker, and whose it is.** A guard written as
+  "this head already has a status, so someone answered" would read the claim as
+  a verdict — which would make posting it *worse* than the absence, by
+  silencing the repair below. But the mirror error is just as bad: treating
+  *any* claim as unanswered lets a dead run paint "review died" over a review
+  that is running right now (the recovery run this repair itself launched, or a
+  second bot sharing the repo's one context). So every status iterion writes
+  names the run it speaks for, in its target URL, and ownership decides:
+  **its own claim** is unanswered and gets repaired; **another run's** means
+  somebody is working — stand down.
+
+  A corollary: with no `PublicURL` configured a status cannot name its run, so
+  the launch does not claim at all. The check then behaves exactly as it did
+  before this feature — an ambiguous claim would be worse than none.
 
 The claim is not a substitute for the repair: a run that dies still holding it
 leaves a `pending` nothing will resolve, which blocks a required check exactly
@@ -430,6 +440,14 @@ instead of mistaking the first death's marker for an answer. But the same run
 re-offered every minute is already answered. The status's target URL names the
 run it speaks for, which separates the two with no bookkeeping a second replica
 would not share.
+
+The sweep is **not elected** — the repair is idempotent by re-reading the live
+status, so a leader would buy nothing. One consequence needs care: the
+relaunch's once-per-head bound is a read-then-insert claim, so two replicas
+offering one dead run give a launch and a *duplicate*. A duplicate alone is
+therefore not evidence the replacement died; the board card that tells a human
+"automation is out of moves" is filed only once the named run has itself
+stopped.
 
 Finally, when a repair genuinely declines to act, **it says so**. Every branch
 past "this run held a publish grant and died" now logs the reason it is posting

--- a/pkg/server/forge_gate_pending.go
+++ b/pkg/server/forge_gate_pending.go
@@ -1,0 +1,113 @@
+package server
+
+import (
+	"context"
+	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// A required check has three states an operator can act on — green, red, and
+// "running". A review only ever posted the first two, at the very END of a run
+// that takes minutes. Between the push and the verdict the context is simply
+// ABSENT, which the forge renders as "Expected — waiting for status to be
+// reported": the same rendering as a review that was never launched, a bot
+// that crashed on boot, and a webhook that never fired.
+//
+// The reconciler next door already names this exact ambiguity ("an absent
+// required check is indistinguishable from one still running") and closes it
+// from one side only, once the run is dead. This closes it from the other: the
+// launch itself claims the context, so the absence of a status once again
+// means what it says — nothing is reviewing this revision.
+//
+// The marker is deliberately a real `pending`, not a comment: it carries the
+// run URL, so the operator lands on the live console instead of guessing which
+// run owes the check.
+const gateInFlightDescription = "review in progress — the verdict will replace this"
+
+// isGateInFlight reports whether a status is this server's own in-flight
+// marker rather than a verdict a bot posted.
+//
+// Every consumer that asks "does this head already have an answer?" MUST route
+// through here. The marker is a `pending` with a non-empty description, so a
+// guard written as `state != "" → someone already answered` reads it as a
+// verdict and stands down — which would make posting the marker actively
+// harmful: it would silence the very reconciler that exists to un-stick the
+// PR. The predicate keeps "claimed" and "answered" distinct.
+func isGateInFlight(st forge.CommitStatus) bool {
+	return st.State == forge.CommitStatePending &&
+		strings.TrimSpace(st.Description) == gateInFlightDescription
+}
+
+// markGateInFlight claims the repo's gate context on the revision a freshly
+// launched run is about to review.
+//
+// Best-effort and deliberately silent about launches that owe no gate: the
+// vast majority carry no gate_context at all. It only ever writes over NOTHING
+// or over a previous in-flight marker — never over a verdict. That guard is
+// what makes it safe under a gate context SHARED by several bots (the repo
+// pins one context precisely so a required check can span them): a second bot
+// launching on a head another bot already judged must not blank that judgment
+// back to "running".
+// The run URL is built from cfg.PublicURL rather than the request, so a claim
+// and the reconciler's later failure name the run identically — the target URL
+// is what tells "already answered" from "must escalate" over there.
+func (s *Server) markGateInFlight(ctx context.Context, teamID, botID string, vars map[string]string, runID string) {
+	if s == nil || s.forgeConnections == nil || vars == nil {
+		return
+	}
+	gateCtx := strings.TrimSpace(vars["gate_context"])
+	prURL := strings.TrimSpace(vars["pr_url"])
+	if gateCtx == "" || prURL == "" {
+		return
+	}
+	// The revision, not the PR. A status is posted on a sha, and the head can
+	// move between this launch and the verdict; claiming the head the run was
+	// handed keeps the marker and the verdict on the same commit.
+	sha := strings.TrimSpace(vars["head_sha"])
+	if sha == "" {
+		return
+	}
+	host, repo, _, err := forge.ParsePullURL(prURL)
+	if err != nil {
+		return
+	}
+	conn, ok := s.forgeConnectionForPR(ctx, teamID, "", host, repo)
+	if !ok {
+		return
+	}
+	gc, err := s.gateClientFor(ctx, conn)
+	if err != nil || gc == nil {
+		if s.logger != nil && err != nil {
+			s.logger.Warn("forge gate: cannot claim %s on %s@%s for run %s: %v — the check stays absent while the review runs",
+				gateCtx, repo, shortSHA(sha), runID, err)
+		}
+		return
+	}
+	// Read before write: an unreadable status list means we cannot tell a
+	// verdict from an absence, and blanking a real verdict is worse than
+	// leaving the in-flight window unlabelled.
+	cur, readable, err := gateStatusOn(ctx, gc, repo, sha, gateCtx)
+	if err != nil || !readable {
+		return
+	}
+	if cur.State != "" && !isGateInFlight(cur) && !isSyntheticGateInterruption(cur.Description) {
+		return
+	}
+	st := forge.CommitStatus{
+		State:       forge.CommitStatePending,
+		Context:     gateCtx,
+		Description: gateInFlightDescription,
+		TargetURL:   gateRunURL(strings.TrimRight(strings.TrimSpace(s.cfg.PublicURL), "/"), runID),
+	}
+	if err := gc.SetCommitStatus(ctx, repo, sha, st); err != nil {
+		if s.logger != nil {
+			s.logger.Warn("forge gate: run %s could not claim %s on %s@%s: %v — the check stays absent while the review runs",
+				runID, gateCtx, repo, shortSHA(sha), err)
+		}
+		return
+	}
+	if s.logger != nil {
+		s.logger.Info("forge gate: run %s claimed %s=pending on %s@%s (bot %s)", runID, gateCtx, repo, shortSHA(sha), botID)
+	}
+}

--- a/pkg/server/forge_gate_pending.go
+++ b/pkg/server/forge_gate_pending.go
@@ -68,6 +68,21 @@ func (s *Server) markGateInFlight(ctx context.Context, teamID, botID string, var
 	if sha == "" {
 		return
 	}
+	// An UNATTRIBUTABLE claim must never exist. Ownership of a status is read
+	// off its target URL (gateStatusSpeaksFor), so a claim posted without one
+	// cannot be told from another run's — and the reconciler would have to
+	// choose between painting "review died" over a live review and leaving a
+	// PR stuck on a pending nothing resolves. Neither is acceptable, so with
+	// no PublicURL configured the launch simply does not claim: the check
+	// behaves exactly as it did before this feature existed.
+	runURL := gateRunURL(strings.TrimRight(strings.TrimSpace(s.cfg.PublicURL), "/"), runID)
+	if runURL == "" {
+		if s.logger != nil {
+			s.logger.Warn("forge gate: not claiming %s for run %s — PublicURL is unset, so the claim could not name the run and nothing could later tell it from another run's",
+				gateCtx, runID)
+		}
+		return
+	}
 	host, repo, _, err := forge.ParsePullURL(prURL)
 	if err != nil {
 		return
@@ -98,7 +113,7 @@ func (s *Server) markGateInFlight(ctx context.Context, teamID, botID string, var
 		State:       forge.CommitStatePending,
 		Context:     gateCtx,
 		Description: gateInFlightDescription,
-		TargetURL:   gateRunURL(strings.TrimRight(strings.TrimSpace(s.cfg.PublicURL), "/"), runID),
+		TargetURL:   runURL,
 	}
 	if err := gc.SetCommitStatus(ctx, repo, sha, st); err != nil {
 		if s.logger != nil {

--- a/pkg/server/forge_gate_pending_test.go
+++ b/pkg/server/forge_gate_pending_test.go
@@ -132,29 +132,98 @@ func TestMarkGateInFlight_NoOpsWithoutAGateOrARevision(t *testing.T) {
 	}
 }
 
-// The regression the marker creates if it is not accounted for: the reconciler
-// stands down on any status it did not recognise as its own, so a run that
-// died still holding its claim would look "already answered" and the PR would
-// wait on a pending that nothing will ever resolve. Strictly worse than the
+// A claim is not an answer, but WHOSE claim it is decides everything.
+//
+// Own claim: the regression the marker creates if it is not accounted for. The
+// reconciler stands down on any status it did not recognise as unanswered, so
+// a run that died still holding its claim would look "already answered" and
+// the PR would wait on a pending nothing resolves — strictly worse than the
 // absent check the marker was introduced to fix.
-func TestGateReconcile_TreatsItsOwnInFlightClaimAsUnanswered(t *testing.T) {
-	gc := &listingGateClient{
-		fakeGateClient: fakeGateClient{headSHA: "deadbeef"},
-		statuses: []forge.CommitStatus{
-			{Context: "iterion/review", State: forge.CommitStatePending, Description: gateInFlightDescription},
-		},
+//
+// Another run's claim: the mirror hazard, and the one that actually shipped
+// broken. The repair's own recovery relaunches a bot, whose launch claims the
+// head; the sweep then re-offers the DEAD run minutes later and would paint
+// "review died" over a review that is running right now — and re-enter a
+// relaunch whose idempotency key is spent, filing a board card telling a human
+// the automation is out of moves while the replacement is alive and working.
+// The same clobber happens whenever two bots share the repo's one gate
+// context, which is the documented reason a repo pins one.
+func TestGateReconcile_ActsOnItsOwnClaimAndLeavesAnotherRunsAlone(t *testing.T) {
+	claim := func(targetURL string) forge.CommitStatus {
+		return forge.CommitStatus{
+			Context:     "iterion/review",
+			State:       forge.CommitStatePending,
+			Description: gateInFlightDescription,
+			TargetURL:   targetURL,
+		}
 	}
-	s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+	t.Run("its own claim — nobody else will answer it", func(t *testing.T) {
+		gc := &listingGateClient{
+			fakeGateClient: fakeGateClient{headSHA: "deadbeef"},
+			statuses:       []forge.CommitStatus{claim("https://iterion.test/runs/run-gating")},
+		}
+		s, runID := gateReconcileFixture(t, gatingInputs(), gc)
 
-	if err := s.reconcileGateForRun(context.Background(), terminalEvent(runID)); err != nil {
-		t.Fatalf("reconcile: %v", err)
-	}
-	if gc.setCalls != 1 {
-		t.Fatalf("posted %d statuses, want 1 — the PR is left waiting on a pending nothing will resolve", gc.setCalls)
-	}
-	if gc.last.State != forge.CommitStateFailure {
-		t.Errorf("state = %q, want failure — the run died without answering its own claim", gc.last.State)
-	}
+		if err := s.reconcileGateForRun(context.Background(), terminalEvent(runID)); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if gc.setCalls != 1 {
+			t.Fatalf("posted %d statuses, want 1 — the PR is left waiting on a pending nothing will resolve", gc.setCalls)
+		}
+		if gc.last.State != forge.CommitStateFailure {
+			t.Errorf("state = %q, want failure — the run died without answering its own claim", gc.last.State)
+		}
+	})
+	t.Run("another run's claim — a live review must not be blamed", func(t *testing.T) {
+		gc := &listingGateClient{
+			fakeGateClient: fakeGateClient{headSHA: "deadbeef"},
+			statuses:       []forge.CommitStatus{claim("https://iterion.test/runs/run-the-replacement")},
+		}
+		s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+
+		if err := s.reconcileGateForRun(context.Background(), terminalEvent(runID)); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if gc.setCalls != 0 {
+			t.Fatalf("posted %d statuses, want 0 — \"review died\" was painted over a review that is running, and the recovery re-entered", gc.setCalls)
+		}
+	})
+}
+
+// With no PublicURL configured a status cannot name the run it speaks for, so
+// "mine" and "another run's" become the same observation. The launch therefore
+// does not claim at all (the check behaves as it did before the feature), and
+// the repair stands down on an existing synthetic failure rather than re-post
+// and re-enter the recovery on every one of the sweep's ~57 passes per hour.
+func TestGateWithoutPublicURL_ClaimsNothingAndDoesNotLoop(t *testing.T) {
+	t.Run("the launch posts no unattributable claim", func(t *testing.T) {
+		gc := &listingGateClient{}
+		s := inFlightFixture(t, gc)
+		s.cfg.PublicURL = ""
+
+		s.markGateInFlight(context.Background(), "team1", "review-pr", inFlightVars(), "run-42")
+
+		if gc.setCalls != 0 {
+			t.Fatalf("posted %d statuses, want 0 — an unattributable claim can never be told from another run's", gc.setCalls)
+		}
+	})
+	t.Run("the repair does not re-post over an existing synthetic failure", func(t *testing.T) {
+		gc := &listingGateClient{
+			fakeGateClient: fakeGateClient{headSHA: "deadbeef"},
+			statuses: []forge.CommitStatus{
+				{Context: "iterion/review", State: forge.CommitStateFailure, Description: gateInterruptedDescription},
+			},
+		}
+		s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+		s.cfg.PublicURL = ""
+
+		if err := s.reconcileGateForRun(context.Background(), terminalEvent(runID)); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if gc.setCalls != 0 {
+			t.Fatalf("posted %d statuses, want 0 — every sweep pass would re-post and re-enter the recovery", gc.setCalls)
+		}
+	})
 }
 
 // A run parked on a provider usage window is resumed by the retry sweeper up

--- a/pkg/server/forge_gate_pending_test.go
+++ b/pkg/server/forge_gate_pending_test.go
@@ -1,0 +1,176 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
+)
+
+// inFlightVars is a review-shaped launch: the repo pinned a gate context and
+// the lane resolved the revision to review.
+func inFlightVars() map[string]string {
+	return map[string]string{
+		"pr_url":       "https://github.com/o/r/pull/42",
+		"gate_context": "iterion/review",
+		"head_sha":     "deadbeef",
+	}
+}
+
+func inFlightFixture(t *testing.T, gc forgeGateClient) *Server {
+	t.Helper()
+	s, _ := newForgePublishTestServer(t)
+	s.cfg.PublicURL = "https://iterion.test"
+	s.forgeGateClientFor = func(context.Context, forge.Connection) (forgeGateClient, error) {
+		return gc, nil
+	}
+	return s
+}
+
+// The window between the push and the verdict is minutes long. With no status
+// on the head the forge renders the required check as "Expected — waiting for
+// status to be reported", which is byte-identical to a review that was never
+// launched at all. Claiming the context at launch is what separates the two.
+func TestMarkGateInFlight_ClaimsAnAbsentCheck(t *testing.T) {
+	gc := &listingGateClient{}
+	s := inFlightFixture(t, gc)
+
+	s.markGateInFlight(context.Background(), "team1", "review-pr", inFlightVars(), "run-42")
+
+	if gc.setCalls != 1 {
+		t.Fatalf("posted %d statuses, want 1 — the check stays absent for the whole review", gc.setCalls)
+	}
+	if gc.last.State != forge.CommitStatePending {
+		t.Errorf("state = %q, want pending — the review has not answered yet", gc.last.State)
+	}
+	if gc.last.Context != "iterion/review" {
+		t.Errorf("context = %q, want the gate the repo pinned", gc.last.Context)
+	}
+	if !isGateInFlight(gc.last) {
+		t.Errorf("status %q is not recognisable as the in-flight marker — the reconciler would read it as a verdict and stand down", gc.last.Description)
+	}
+	if gc.last.TargetURL != "https://iterion.test/runs/run-42" {
+		t.Errorf("target url = %q, want the live run console", gc.last.TargetURL)
+	}
+	if gc.lastSHA != "deadbeef" {
+		t.Errorf("posted on %q, want the revision the run was handed", gc.lastSHA)
+	}
+}
+
+// A repo pins ONE gate context precisely so a required check can span several
+// bots. A second bot launching on a head another bot has already judged must
+// not blank that judgment back to "running" — the verdict would be lost and
+// the merge gate would reopen on a PR that was legitimately red.
+func TestMarkGateInFlight_NeverOverwritesAVerdict(t *testing.T) {
+	for _, verdict := range []forge.CommitState{forge.CommitStateSuccess, forge.CommitStateFailure} {
+		gc := &listingGateClient{statuses: []forge.CommitStatus{
+			{Context: "iterion/review", State: verdict, Description: "3 blocking finding(s) ≥high"},
+		}}
+		s := inFlightFixture(t, gc)
+
+		s.markGateInFlight(context.Background(), "team1", "review-pr", inFlightVars(), "run-42")
+
+		if gc.setCalls != 0 {
+			t.Errorf("%s verdict: posted %d statuses, want 0 — a bot's judgment was blanked to pending", verdict, gc.setCalls)
+		}
+	}
+}
+
+// The synthetic failure means "a review died here"; a fresh review starting on
+// that same head is exactly the recovery, so the claim replaces it. Same for a
+// stale claim of its own: re-reviewing a head must re-point the check at the
+// run that is actually working.
+func TestMarkGateInFlight_ReplacesAnInterruptionAndItsOwnStaleClaim(t *testing.T) {
+	cases := map[string]forge.CommitStatus{
+		"synthetic interruption": {Context: "iterion/review", State: forge.CommitStateFailure, Description: gateInterruptedDescription},
+		"its own stale claim":    {Context: "iterion/review", State: forge.CommitStatePending, Description: gateInFlightDescription},
+	}
+	for name, existing := range cases {
+		t.Run(name, func(t *testing.T) {
+			gc := &listingGateClient{statuses: []forge.CommitStatus{existing}}
+			s := inFlightFixture(t, gc)
+
+			s.markGateInFlight(context.Background(), "team1", "review-pr", inFlightVars(), "run-99")
+
+			if gc.setCalls != 1 {
+				t.Fatalf("posted %d statuses, want 1 — a live review must claim the check", gc.setCalls)
+			}
+			if !isGateInFlight(gc.last) {
+				t.Errorf("status = %s/%q, want the in-flight marker", gc.last.State, gc.last.Description)
+			}
+			if gc.last.TargetURL != "https://iterion.test/runs/run-99" {
+				t.Errorf("target url = %q, want the run that is actually working", gc.last.TargetURL)
+			}
+		})
+	}
+}
+
+// A launch that gates nothing must cost no forge traffic: most runs carry no
+// gate_context, and a claim on a head we were not given is a status on the
+// wrong commit.
+func TestMarkGateInFlight_NoOpsWithoutAGateOrARevision(t *testing.T) {
+	cases := map[string]func(map[string]string){
+		"no gate context": func(v map[string]string) { delete(v, "gate_context") },
+		"no head sha":     func(v map[string]string) { delete(v, "head_sha") },
+		"no pr url":       func(v map[string]string) { delete(v, "pr_url") },
+	}
+	for name, strip := range cases {
+		t.Run(name, func(t *testing.T) {
+			gc := &listingGateClient{}
+			s := inFlightFixture(t, gc)
+			vars := inFlightVars()
+			strip(vars)
+
+			s.markGateInFlight(context.Background(), "team1", "review-pr", vars, "run-42")
+
+			if gc.setCalls != 0 || gc.listCalls != 0 {
+				t.Errorf("%d posts / %d reads, want none — a launch that gates nothing must not touch the forge", gc.setCalls, gc.listCalls)
+			}
+		})
+	}
+}
+
+// The regression the marker creates if it is not accounted for: the reconciler
+// stands down on any status it did not recognise as its own, so a run that
+// died still holding its claim would look "already answered" and the PR would
+// wait on a pending that nothing will ever resolve. Strictly worse than the
+// absent check the marker was introduced to fix.
+func TestGateReconcile_TreatsItsOwnInFlightClaimAsUnanswered(t *testing.T) {
+	gc := &listingGateClient{
+		fakeGateClient: fakeGateClient{headSHA: "deadbeef"},
+		statuses: []forge.CommitStatus{
+			{Context: "iterion/review", State: forge.CommitStatePending, Description: gateInFlightDescription},
+		},
+	}
+	s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+
+	if err := s.reconcileGateForRun(context.Background(), terminalEvent(runID)); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if gc.setCalls != 1 {
+		t.Fatalf("posted %d statuses, want 1 — the PR is left waiting on a pending nothing will resolve", gc.setCalls)
+	}
+	if gc.last.State != forge.CommitStateFailure {
+		t.Errorf("state = %q, want failure — the run died without answering its own claim", gc.last.State)
+	}
+}
+
+// A run parked on a provider usage window is resumed by the retry sweeper up
+// to retrypolicy.DefaultMaxWait later — a weekly forfait cap resets as much as
+// seven days out. If the publish grant dies first, the resumed review runs to
+// completion and then cannot post the verdict it computed: the required check
+// keeps whatever the interruption left, and the PR waits on an answer that
+// exists. The grant must outlive the longest wait the retry machinery can
+// schedule.
+func TestForgePublishGrantOutlivesTheLongestRetryWait(t *testing.T) {
+	if forgePublishDefaultTTL <= retrypolicy.DefaultMaxWait {
+		t.Fatalf("publish grant TTL %s <= max retry wait %s — a review resumed after a long quota window cannot post its verdict",
+			forgePublishDefaultTTL, retrypolicy.DefaultMaxWait)
+	}
+	// And with room for the resumed run itself, not merely one second more.
+	if margin := forgePublishDefaultTTL - retrypolicy.DefaultMaxWait; margin < 6*time.Hour {
+		t.Errorf("margin over the max retry wait is %s — too tight for the resumed run to finish and publish", margin)
+	}
+}

--- a/pkg/server/forge_gate_reconcile.go
+++ b/pkg/server/forge_gate_reconcile.go
@@ -123,7 +123,19 @@ func (s *Server) attachGateReconciler(bus eventbus.Bus) (func(), error) {
 // reconcileGateForRun is the eventbus handler. It is deliberately quiet about
 // runs that owed nothing: most runs hold no publish grant at all.
 func (s *Server) reconcileGateForRun(ctx context.Context, ev trigger.Event) error {
-	runID := strings.TrimSpace(ev.Subject.ID)
+	return s.reconcileGateForRunID(ctx, strings.TrimSpace(ev.Subject.ID), "event")
+}
+
+// reconcileGateForRunID is the repair itself, reachable from either of its two
+// triggers: the run-outcome event (immediate) and the periodic sweep (the net
+// under it). `via` names which one, because a repair that only ever fires from
+// the sweep is a broken event path, and the two are indistinguishable in the
+// logs otherwise.
+//
+// Idempotent by construction: it re-reads the live status on the head and
+// stands down unless the check is still unanswered, so the two triggers racing
+// on the same run costs one redundant read.
+func (s *Server) reconcileGateForRunID(ctx context.Context, runID, via string) error {
 	if runID == "" || s.cfg.Store == nil || s.forgePublishTokens == nil || s.forgeConnections == nil {
 		return nil
 	}
@@ -154,9 +166,29 @@ func (s *Server) reconcileGateForRun(ctx context.Context, ev trigger.Event) erro
 	if token == "" || prURL == "" {
 		return nil // not a gating run
 	}
+
+	// Past this line the run held a publish grant and died: it MAY owe a
+	// verdict, and every remaining branch that declines to post one is a
+	// decision to leave a pull request waiting. Those branches used to return
+	// bare nil, so a PR stuck behind an absent check produced not one line
+	// anywhere — the failure and the healthy "owed nothing" path were the same
+	// silence, and four blocked PRs could not be told apart from four runs
+	// that never gated anything. Naming the reason is what makes the next
+	// occurrence a grep instead of an investigation.
+	abstain := func(format string, args ...any) error {
+		if s.logger != nil {
+			s.logger.Warn("forge gate: run %s (via %s) held a grant on %s but posts nothing: "+format,
+				append([]any{runID, via, prURL}, args...)...)
+		}
+		return nil
+	}
+
 	grant, ok := s.forgePublishTokens.lookup(token)
 	if !ok {
-		return nil // grant already expired or revoked; nothing to speak for
+		// The grant outlives the longest retry wait by construction
+		// (forgePublishDefaultTTL), so reaching here means the run sat dead
+		// longer than that, or the token store lost it.
+		return abstain("its publish grant is expired or revoked")
 	}
 
 	// Holding a grant is NOT owing a verdict. The server mints one for any bot
@@ -179,7 +211,7 @@ func (s *Server) reconcileGateForRun(ctx context.Context, ev trigger.Event) erro
 
 	host, repo, number, err := forge.ParsePullURL(prURL)
 	if err != nil {
-		return nil
+		return abstain("its pr_url does not parse: %v", err)
 	}
 	// pr_url is a LAUNCH VAR — whoever launched the run chose it, and
 	// injectForgePublishVars deliberately honours a caller-pinned token. So
@@ -189,30 +221,32 @@ func (s *Server) reconcileGateForRun(ctx context.Context, ev trigger.Event) erro
 	// whole org). A red check is not a merge, but it is precisely the blast
 	// radius the grant exists to bound.
 	if !strings.EqualFold(strings.TrimSpace(repo), strings.TrimSpace(grant.Repo)) {
-		if s.logger != nil {
-			s.logger.Warn("forge gate: run %s carries a grant for %s but a pr_url on %s — refusing to post outside the grant's repo",
-				runID, grant.Repo, repo)
-		}
-		return nil
+		return abstain("its grant covers %s — refusing to post outside the grant's repo", grant.Repo)
 	}
 	conn, err := s.forgeConnections.Get(store.WithoutTenantFilter(ctx), grant.ConnectionID)
-	if err != nil || conn.TenantID != grant.TeamID {
-		return nil
+	if err != nil {
+		return abstain("its connection %s is unreadable: %v", grant.ConnectionID, err)
+	}
+	if conn.TenantID != grant.TeamID {
+		return abstain("its connection %s belongs to another tenant", grant.ConnectionID)
 	}
 	if connHost := hostOfURL(conn.BaseURL()); connHost == "" || !strings.EqualFold(connHost, host) {
-		return nil
+		return abstain("its connection points at %q, not %q", hostOfURL(conn.BaseURL()), host)
 	}
 	gc, err := s.gateClientFor(ctx, conn)
-	if err != nil || gc == nil {
-		if s.logger != nil {
-			s.logger.Warn("forge gate: cannot reach %s to reconcile run %s: %v", repo, runID, err)
-		}
-		return nil
+	if err != nil {
+		return abstain("the forge client for %s is unreachable: %v", repo, err)
+	}
+	if gc == nil {
+		return abstain("provider %s cannot post commit statuses", conn.Provider)
 	}
 
 	pr, err := gc.GetPullRequest(ctx, repo, number)
-	if err != nil || strings.TrimSpace(pr.HeadSHA) == "" {
-		return nil
+	if err != nil {
+		return abstain("the pull request is unreadable: %v", err)
+	}
+	if strings.TrimSpace(pr.HeadSHA) == "" {
+		return abstain("the forge returned no head sha")
 	}
 	// Only the revision this run was reviewing. Between its start and its
 	// death the head routinely moves — the author pushes a fix, a brancher
@@ -224,8 +258,17 @@ func (s *Server) reconcileGateForRun(ctx context.Context, ev trigger.Event) erro
 	// reviewed cannot speak for any of them. (An earlier version treated an
 	// absent value as "no constraint", which made the guard vacuous — nothing
 	// set the var at the time, so it never once fired outside its own test.)
+	//
+	// Not routed through abstain(): a head that moved while the review ran is
+	// the ORDINARY case (every re-push does it), and the newer head already
+	// has its own review claiming its own check. Warning on it would bury the
+	// branches that mean something under routine noise.
 	reviewed := runInputString(run, "head_sha")
 	if reviewed == "" || !strings.EqualFold(reviewed, pr.HeadSHA) {
+		if s.logger != nil {
+			s.logger.Debug("forge gate: run %s reviewed %s but %s is now at %s — leaving the newer head to its own review",
+				runID, shortSHA(reviewed), prURL, shortSHA(pr.HeadSHA))
+		}
 		return nil
 	}
 	// The forge is the authority on whether the verdict landed — not any
@@ -237,25 +280,42 @@ func (s *Server) reconcileGateForRun(ctx context.Context, ev trigger.Event) erro
 	// posted", and go silent right where the recovery runs out.
 	gate, readable, err := gateStatusOn(ctx, gc, repo, pr.HeadSHA, gateCtx)
 	if err != nil {
-		if s.logger != nil {
-			s.logger.Warn("forge gate: cannot read statuses on %s@%s: %v", repo, pr.HeadSHA[:7], err)
-		}
-		return nil
+		return abstain("the statuses on %s@%s are unreadable: %v", repo, shortSHA(pr.HeadSHA), err)
 	}
 	if !readable {
 		// Cannot tell absent from posted: overwriting a real success with a
 		// synthetic failure is a worse outcome than leaving a stuck PR stuck.
-		return nil
+		return abstain("provider %s cannot list commit statuses, so a verdict cannot be told from an absence", conn.Provider)
 	}
-	if gate.State != "" && !isSyntheticGateInterruption(gate.Description) {
-		return nil
+	// The in-flight marker is a CLAIM, not an answer: the launch posts it so
+	// the window between push and verdict stops reading as "nothing happened".
+	// A run that died still holding its own claim is exactly the run this
+	// repair exists for, so it must not count as "already posted".
+	runURL := gateRunURL(strings.TrimRight(strings.TrimSpace(s.cfg.PublicURL), "/"), runID)
+	if gate.State != "" && !isGateInFlight(gate) {
+		if !isSyntheticGateInterruption(gate.Description) {
+			return nil // a real verdict
+		}
+		// A synthetic failure deliberately does NOT stand this repair down in
+		// general: when a relaunched run dies too, the second death must still
+		// be answered and escalated rather than mistake the first death's
+		// marker for an answer. But that argument is about a DIFFERENT run on
+		// the same head. The same run offered twice — the event and the sweep
+		// racing, or the sweep re-reading its own window every minute for an
+		// hour — is already answered, and re-posting would spam the forge and
+		// re-enter the recovery on every pass. The target URL names the run
+		// the failure speaks for, so it tells the two apart without any
+		// bookkeeping a second replica would not share.
+		if runURL != "" && strings.EqualFold(strings.TrimSpace(gate.TargetURL), runURL) {
+			return nil
+		}
 	}
 
 	st := forge.CommitStatus{
 		State:       forge.CommitStateFailure,
 		Context:     gateCtx,
 		Description: gateInterruptedDescriptionFor(run),
-		TargetURL:   gateRunURL(strings.TrimRight(strings.TrimSpace(s.cfg.PublicURL), "/"), runID),
+		TargetURL:   runURL,
 	}
 	if err := gc.SetCommitStatus(ctx, repo, pr.HeadSHA, st); err != nil {
 		if s.logger != nil {

--- a/pkg/server/forge_gate_reconcile.go
+++ b/pkg/server/forge_gate_reconcile.go
@@ -31,6 +31,14 @@ import (
 // operator can act on.
 const gateReconcilerName = "forge-gate-reconcile"
 
+// The two triggers of the same repair. Which one fired decides how loudly a
+// declined repair speaks: the event fires once per run, the sweep re-offers
+// the same run every minute for its whole lookback.
+const (
+	gateTriggerEvent = "event"
+	gateTriggerSweep = "sweep"
+)
+
 // gateInterruptedDescription is what the operator reads on the check. It has
 // to carry the remedy: whoever finds it has no other clue about what happened.
 const gateInterruptedDescription = "review ended without a verdict — push again or comment the bot's command to re-run"
@@ -123,7 +131,7 @@ func (s *Server) attachGateReconciler(bus eventbus.Bus) (func(), error) {
 // reconcileGateForRun is the eventbus handler. It is deliberately quiet about
 // runs that owed nothing: most runs hold no publish grant at all.
 func (s *Server) reconcileGateForRun(ctx context.Context, ev trigger.Event) error {
-	return s.reconcileGateForRunID(ctx, strings.TrimSpace(ev.Subject.ID), "event")
+	return s.reconcileGateForRunID(ctx, strings.TrimSpace(ev.Subject.ID), gateTriggerEvent)
 }
 
 // reconcileGateForRunID is the repair itself, reachable from either of its two
@@ -175,10 +183,22 @@ func (s *Server) reconcileGateForRunID(ctx context.Context, runID, via string) e
 	// silence, and four blocked PRs could not be told apart from four runs
 	// that never gated anything. Naming the reason is what makes the next
 	// occurrence a grep instead of an investigation.
+	//
+	// Warn on the EVENT path only. The sweep re-offers the same run every
+	// minute for the whole lookback, so a run sitting in a permanent abstain
+	// branch — a lost grant, an unreachable forge — would log the identical
+	// line ~60 times an hour per replica and bury the branches that carry new
+	// information, defeating the point of naming the reason at all. The event
+	// fires once per run, which is exactly one line per occurrence.
 	abstain := func(format string, args ...any) error {
 		if s.logger != nil {
-			s.logger.Warn("forge gate: run %s (via %s) held a grant on %s but posts nothing: "+format,
-				append([]any{runID, via, prURL}, args...)...)
+			msg := "forge gate: run %s (via %s) held a grant on %s but posts nothing: " + format
+			args = append([]any{runID, via, prURL}, args...)
+			if via == gateTriggerSweep {
+				s.logger.Debug(msg, args...)
+			} else {
+				s.logger.Warn(msg, args...)
+			}
 		}
 		return nil
 	}
@@ -287,27 +307,55 @@ func (s *Server) reconcileGateForRunID(ctx context.Context, runID, via string) e
 		// synthetic failure is a worse outcome than leaving a stuck PR stuck.
 		return abstain("provider %s cannot list commit statuses, so a verdict cannot be told from an absence", conn.Provider)
 	}
-	// The in-flight marker is a CLAIM, not an answer: the launch posts it so
-	// the window between push and verdict stops reading as "nothing happened".
-	// A run that died still holding its own claim is exactly the run this
-	// repair exists for, so it must not count as "already posted".
+	// Whether this run still owes an answer is decided by WHO the status on the
+	// head belongs to, not merely by its state. Every status iterion writes
+	// carries the run it speaks for in its target URL, which is what makes the
+	// question answerable across replicas with no shared bookkeeping.
 	runURL := gateRunURL(strings.TrimRight(strings.TrimSpace(s.cfg.PublicURL), "/"), runID)
-	if gate.State != "" && !isGateInFlight(gate) {
-		if !isSyntheticGateInterruption(gate.Description) {
-			return nil // a real verdict
-		}
-		// A synthetic failure deliberately does NOT stand this repair down in
-		// general: when a relaunched run dies too, the second death must still
-		// be answered and escalated rather than mistake the first death's
-		// marker for an answer. But that argument is about a DIFFERENT run on
-		// the same head. The same run offered twice — the event and the sweep
-		// racing, or the sweep re-reading its own window every minute for an
-		// hour — is already answered, and re-posting would spam the forge and
-		// re-enter the recovery on every pass. The target URL names the run
-		// the failure speaks for, so it tells the two apart without any
-		// bookkeeping a second replica would not share.
-		if runURL != "" && strings.EqualFold(strings.TrimSpace(gate.TargetURL), runURL) {
+	switch {
+	case gate.State == "":
+		// Nothing on the head: this run owes the answer.
+
+	case !isGateInFlight(gate) && !isSyntheticGateInterruption(gate.Description):
+		return nil // a real verdict — never overwrite one
+
+	case isGateInFlight(gate):
+		// A CLAIM is not an answer, so a run that died still holding its OWN
+		// claim is exactly what this repair exists for. But a claim belonging
+		// to a DIFFERENT run means someone else is actively reviewing this
+		// head right now — the recovery run this repair just launched, or a
+		// second bot sharing the repo's one gate context. Painting "review
+		// died" over it reports a death that did not happen, and re-enters a
+		// relaunch whose idempotency key is already spent, which files a board
+		// card telling a human the automation is out of moves while the other
+		// run is alive and working.
+		if !gateStatusSpeaksFor(gate, runURL) {
+			if s.logger != nil {
+				s.logger.Debug("forge gate: run %s died on %s@%s but another run holds the in-flight claim — leaving the live review alone",
+					runID, repo, shortSHA(pr.HeadSHA))
+			}
 			return nil
+		}
+
+	default: // a synthetic interruption
+		// It deliberately does NOT stand this repair down in general: when a
+		// relaunched run dies too, the second death must still be answered and
+		// escalated rather than mistake the first death's marker for an
+		// answer. That argument is about a DIFFERENT run on the same head. The
+		// same run offered twice — the event and the sweep racing, or the sweep
+		// re-reading its window every minute for an hour — is already answered.
+		if gateStatusSpeaksFor(gate, runURL) {
+			return nil
+		}
+		// Unattributable: with no PublicURL configured every status is written
+		// with an empty target URL, so "mine" and "another run's" are the same
+		// observation. Repairing then re-posts and re-enters the recovery on
+		// every sweep pass — dozens of forge writes and false escalations per
+		// stuck run. Standing down costs the second-death escalation only, and
+		// only on a deployment that has not set PublicURL.
+		if runURL == "" {
+			return abstain("a synthetic failure is already on %s@%s and PublicURL is unset, so it cannot be told from this run's own — set PublicURL to enable second-death escalation",
+				repo, shortSHA(pr.HeadSHA))
 		}
 	}
 
@@ -336,6 +384,24 @@ func (s *Server) reconcileGateForRunID(ctx context.Context, runID, via string) e
 		repo: repo, number: number, pr: pr, gateCtx: gateCtx, prURL: prURL,
 	})
 	return nil
+}
+
+// gateStatusSpeaksFor reports whether a status iterion wrote belongs to the
+// run at runURL. Every status this package posts — the in-flight claim and the
+// synthetic failure alike — points at the run it speaks for, so ownership is
+// readable straight off the forge, with no bookkeeping a second replica would
+// not share and a restart would lose.
+//
+// False when runURL is empty (no PublicURL configured) or the status carries
+// no target URL: ownership is then unknowable, and each caller decides which
+// way that ambiguity is safe to resolve rather than having a bare string
+// compare silently pick one.
+func gateStatusSpeaksFor(st forge.CommitStatus, runURL string) bool {
+	target := strings.TrimSpace(st.TargetURL)
+	if runURL == "" || target == "" {
+		return false
+	}
+	return strings.EqualFold(target, runURL)
 }
 
 // gateRunURL points the check at the run that owed it, so the operator lands

--- a/pkg/server/forge_gate_relaunch.go
+++ b/pkg/server/forge_gate_relaunch.go
@@ -164,6 +164,22 @@ func (s *Server) relaunchDeadGateRun(ctx context.Context, d deadGateRun) {
 		// board card is how they find out a gate is dying REPEATEDLY, which
 		// is a deeper problem (a structurally short budget, a recurring
 		// provider quota, a bot defect) than any single death.
+		//
+		// But "duplicate" alone does not mean the replacement died: the
+		// idempotency claim is a read-then-insert, and the gate sweep runs
+		// unelected on every replica, so two passes landing on one dead run
+		// give one StatusLaunched and one StatusDuplicate — for a relaunch
+		// that just SUCCEEDED. Escalating on that files a card telling a human
+		// the automation is out of moves while the replacement is alive and
+		// reviewing. The card is worth filing only once the named run has
+		// itself stopped without answering.
+		if alive, why := s.relaunchStillRunning(launchCtx, res.RunID); alive {
+			if s.logger != nil {
+				s.logger.Debug("gate relaunch: %s on %s#%d@%s already has a relaunch in flight (run %s, %s) — not escalating",
+					d.gateCtx, d.repo, d.number, shortSHA(d.pr.HeadSHA), res.RunID, why)
+			}
+			return
+		}
 		s.logWarn("gate relaunch: %s on %s#%d@%s already got its one relaunch (run %s) and died again — escalating to the board",
 			d.gateCtx, d.repo, d.number, shortSHA(d.pr.HeadSHA), res.RunID)
 		s.escalateDeadGateToBoard(d, res.RunID, "the automatic relaunch died too")
@@ -234,4 +250,31 @@ func (s *Server) escalateDeadGateToBoard(d deadGateRun, priorRelaunchRunID, why 
 	if s.logger != nil {
 		s.logger.Info("gate relaunch: board card filed for %s on %s#%d@%s", d.gateCtx, d.repo, d.number, shortSHA(d.pr.HeadSHA))
 	}
+}
+
+// relaunchStillRunning reports whether the run an idempotency claim named is
+// still working, and a short phrase saying how it was decided.
+//
+// The claim is a read-then-insert, and the gate sweep runs unelected on every
+// replica, so a StatusDuplicate does NOT by itself mean the replacement died:
+// two passes on one dead run give one launch and one duplicate for the SAME,
+// live, replacement. Escalation is a message to a human ("automation is out of
+// moves"), so it must be false only in the direction that stays quiet: an
+// unknown run — never launched, already pruned, unreadable store — is reported
+// as NOT running, which preserves the escalation this branch exists for.
+func (s *Server) relaunchStillRunning(ctx context.Context, runID string) (bool, string) {
+	runID = strings.TrimSpace(runID)
+	if runID == "" || s.cfg.Store == nil {
+		return false, "no run named"
+	}
+	run, err := s.cfg.Store.LoadRun(store.WithoutTenantFilter(ctx), runID)
+	if err != nil || run == nil {
+		return false, "run unreadable"
+	}
+	switch run.Status {
+	case store.RunStatusQueued, store.RunStatusRunning,
+		store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator:
+		return true, string(run.Status)
+	}
+	return false, string(run.Status)
 }

--- a/pkg/server/forge_gate_relaunch_test.go
+++ b/pkg/server/forge_gate_relaunch_test.go
@@ -131,8 +131,19 @@ func TestGateRelaunch(t *testing.T) {
 		if err := w.s.reconcileGateForRun(context.Background(), terminalEvent(runID)); err != nil {
 			t.Fatalf("reconcile: %v", err)
 		}
-		if w.gc.setCalls != 1 {
-			t.Fatalf("posted %d statuses, want 1 — the failure lands BEFORE any recovery", w.gc.setCalls)
+		// Two statuses, and their ORDER is the contract: the synthetic failure
+		// lands BEFORE any recovery (so the PR is never blind even when the
+		// relaunch cannot happen), and the recovery run then claims the check
+		// back to "running" — a review really is in flight again, and leaving
+		// a red cross up would misreport a verdict that was never reached.
+		if w.gc.setCalls != 2 {
+			t.Fatalf("posted %d statuses, want 2 (failure, then the recovery's claim)", w.gc.setCalls)
+		}
+		if got := w.gc.posted[0]; got.State != forge.CommitStateFailure || !isSyntheticGateInterruption(got.Description) {
+			t.Fatalf("first status = %s/%q, want the synthetic failure BEFORE any recovery", got.State, got.Description)
+		}
+		if got := w.gc.posted[1]; !isGateInFlight(got) {
+			t.Fatalf("second status = %s/%q, want the relaunched run's in-flight claim", got.State, got.Description)
 		}
 		if *w.launched != 1 {
 			t.Fatalf("launched %d runs, want 1 — the dead review's bot must be re-run", *w.launched)

--- a/pkg/server/forge_gate_relaunch_test.go
+++ b/pkg/server/forge_gate_relaunch_test.go
@@ -207,6 +207,44 @@ func TestGateRelaunch(t *testing.T) {
 		}
 	})
 
+	// "Duplicate" is not "the replacement died". The idempotency claim is a
+	// read-then-insert and the gate sweep runs UNELECTED on every replica, so
+	// two passes landing on one dead run give one launch and one duplicate —
+	// for the same, live, replacement. Escalating on that files a card telling
+	// a human the automation is out of moves while the replacement is alive and
+	// reviewing.
+	t.Run("a relaunch still in flight does not escalate", func(t *testing.T) {
+		w := build(t, nil)
+		alive, err := w.s.cfg.Store.CreateRun(context.Background(), "run-prior-relaunch", "dep_update_guard", map[string]any{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		alive.Status = store.RunStatusRunning
+		if err := w.s.cfg.Store.SaveRun(context.Background(), alive); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.s.webhookDeliveries.Insert(context.Background(), webhooks.Delivery{
+			ID: "d-inflight", TenantID: team, WebhookID: "w1", IdempotencyKey: relaunchIdem,
+			Status: webhooks.StatusLaunched, RunID: alive.ID,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		w.gc.statuses = []forge.CommitStatus{{
+			Context: gateNm, State: forge.CommitStateFailure,
+			Description: gateInterruptedDescription,
+		}}
+		runID := seedDeadRun(t, w.s)
+		_ = w.s.reconcileGateForRun(context.Background(), terminalEvent(runID))
+
+		cards, err := w.board.List(native.ListFilter{Labels: []string{gateRelaunchLabel}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(cards) != 0 {
+			t.Fatalf("board cards = %d, want 0 — a human was told automation is out of moves while run %s is still reviewing", len(cards), alive.ID)
+		}
+	})
+
 	t.Run("a real red verdict is left alone entirely", func(t *testing.T) {
 		w := build(t, nil)
 		// Vetty's own red verdict — the review HAPPENED. Nothing to reconcile,

--- a/pkg/server/forge_gate_sweeper.go
+++ b/pkg/server/forge_gate_sweeper.go
@@ -50,10 +50,20 @@ const (
 	// failure onto pull requests that have long since merged or moved on.
 	gateSweepLookback = 60 * time.Minute
 
-	// gateSweepBatch bounds one pass. Each candidate can cost a few forge
+	// gateSweepBatch bounds one PAGE. Each candidate can cost a few forge
 	// round-trips, and the overwhelming majority are runs that gate nothing
 	// and exit on a local field read.
 	gateSweepBatch = 200
+
+	// gateSweepMaxPages bounds a pass. The window is paged with the `before`
+	// cursor the query was built for, because a single page is not a bound —
+	// it is a silent truncation that repeats: the rows come back newest-first,
+	// so a dead gating run pushed off the page would be pushed off again on
+	// every subsequent pass and never examined at all. (The reused query also
+	// returns every currently-paused run with no time bound, which consumes
+	// rows without ever being a candidate.) The cap keeps one slow pass from
+	// outliving its own ticker.
+	gateSweepMaxPages = 10
 )
 
 // gateSweepLister is the store capability the sweep scans with — the same
@@ -89,33 +99,44 @@ func (s *Server) sweepGates(ctx context.Context, lister gateSweepLister, now tim
 	if lister == nil || s.cfg.Store == nil {
 		return
 	}
-	refs, err := lister.ListNotifiableRuns(
-		store.WithoutTenantFilter(ctx),
-		now.Add(-gateSweepLookback),
-		now.Add(-gateSweepGrace),
-		gateSweepBatch,
-	)
-	if err != nil {
-		s.warnf("merge-gate sweeper: scan: %v", err)
-		return
-	}
-	if len(refs) == gateSweepBatch {
-		// The window is bounded and so is the batch, so a full page means the
-		// oldest candidates of this window were not examined. Saying so beats
-		// a silent truncation that reads as "everything was covered".
-		s.warnf("merge-gate sweeper: batch full at %d runs — the oldest candidates in the %s window were not examined this pass",
-			gateSweepBatch, gateSweepLookback)
-	}
-	for _, ref := range refs {
-		select {
-		case <-ctx.Done():
+	since := now.Add(-gateSweepLookback)
+	before := now.Add(-gateSweepGrace)
+	for page := 0; page < gateSweepMaxPages; page++ {
+		refs, err := lister.ListNotifiableRuns(store.WithoutTenantFilter(ctx), since, before, gateSweepBatch)
+		if err != nil {
+			s.warnf("merge-gate sweeper: scan: %v", err)
 			return
-		default:
 		}
-		// Every guard that decides whether this run owes anything lives in the
-		// reconciler; the sweep's only job is to offer the run again. Runs that
-		// gate nothing — the vast majority of any window — exit on a local
-		// field read with no forge traffic.
-		_ = s.reconcileGateForRunID(ctx, ref.ID, "sweep")
+		oldest := before
+		for _, ref := range refs {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			// Every guard that decides whether this run owes anything lives in
+			// the reconciler; the sweep's only job is to offer the run again.
+			// Runs that gate nothing — the vast majority of any window — exit
+			// on a local field read with no forge traffic.
+			_ = s.reconcileGateForRunID(ctx, ref.ID, gateTriggerSweep)
+			if !ref.UpdatedAt.IsZero() && ref.UpdatedAt.Before(oldest) {
+				oldest = ref.UpdatedAt
+			}
+		}
+		if len(refs) < gateSweepBatch {
+			return // window exhausted
+		}
+		// Rows come back newest-first, so the next page starts at the oldest
+		// row of this one. A page that fails to advance the cursor (every row
+		// sharing one timestamp, or none carrying it) would otherwise re-scan
+		// the same rows until the page cap.
+		if !oldest.Before(before) {
+			s.warnf("merge-gate sweeper: cursor stalled at %s with a full page — the remaining candidates in the %s window were not examined this pass",
+				before.Format(time.RFC3339), gateSweepLookback)
+			return
+		}
+		before = oldest
 	}
+	s.warnf("merge-gate sweeper: stopped after %d pages of %d — the oldest candidates in the %s window were not examined this pass",
+		gateSweepMaxPages, gateSweepBatch, gateSweepLookback)
 }

--- a/pkg/server/forge_gate_sweeper.go
+++ b/pkg/server/forge_gate_sweeper.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+	mongostore "github.com/SocialGouv/iterion/pkg/store/mongo"
+)
+
+// The gate reconciler's net.
+//
+// The repair next door is driven by ONE run-outcome event on the internal bus.
+// That bus is lossy by design and the repo says so in every other place it is
+// consumed: usernotify carries a 2-minute reconciliation sweep for exactly the
+// episodes it drops, the dispatcher's 30s poll backs its board fast path, and
+// the retry sweeper exists because no in-pod timer survives a rollout. The
+// merge gate — the one consumer whose miss BLOCKS A PULL REQUEST — had no such
+// net: a dropped event, a replica that took the queue-group delivery mid-
+// shutdown, or a handler that returned early meant the required check stayed
+// absent forever, with the run showing `failed_resumable` and nothing anywhere
+// saying a PR was waiting on it.
+//
+// Observed 2026-08-10: four review runs died on one provider weekly cap within
+// 90 seconds; all four PRs kept an absent required check for hours, and the
+// reconciler had left no trace of having considered any of them.
+//
+// So the same run is offered to the same repair twice, from two independent
+// paths. reconcileGateForRunID re-reads the live status before it writes, so
+// the second offer costs one API read and changes nothing when the first
+// worked.
+
+const (
+	// gateSweepInterval is the latency an operator waits, worst case, between
+	// a review dying and its check turning red. A minute matches the retry and
+	// orphan sweepers; the scan is one indexed query over a bounded window.
+	gateSweepInterval = 60 * time.Second
+
+	// gateSweepGrace keeps the sweep off runs the event path is still handling.
+	// The handler does forge round-trips (get PR, list statuses, post), so a
+	// run that ended seconds ago is not yet evidence of a miss — without this
+	// the two paths would race on every single run instead of only on the
+	// dropped ones.
+	gateSweepGrace = 3 * time.Minute
+
+	// gateSweepLookback bounds how far back a pass reaches. It has to exceed
+	// the interval by enough to cover a replica restart or a slow pass without
+	// a run slipping through the gap between two windows — but it is NOT
+	// unbounded: re-offering week-old runs would mean posting a synthetic
+	// failure onto pull requests that have long since merged or moved on.
+	gateSweepLookback = 60 * time.Minute
+
+	// gateSweepBatch bounds one pass. Each candidate can cost a few forge
+	// round-trips, and the overwhelming majority are runs that gate nothing
+	// and exit on a local field read.
+	gateSweepBatch = 200
+)
+
+// gateSweepLister is the store capability the sweep scans with — the same
+// bounded-window terminal-run query the usernotify sweep uses, reused rather
+// than duplicated so both nets share one index. Implemented by the Mongo
+// store; the local store has no cloud gate to reconcile and no sweeper.
+type gateSweepLister interface {
+	ListNotifiableRuns(ctx context.Context, since, before time.Time, limit int) ([]mongostore.NotifiableRunRef, error)
+}
+
+// runGateSweeper ticks sweepGates until ctx is cancelled. Started by
+// ListenAndServe alongside the event-driven reconciler.
+//
+// It announces itself for the reason the retry sweeper does: "no PR is stuck"
+// and "every stuck PR is invisible" produce identical silence otherwise.
+func (s *Server) runGateSweeper(ctx context.Context, lister gateSweepLister) {
+	s.infof("merge-gate sweeper: re-offering dead gating runs to the reconciler (every %s, %s grace, %s lookback) — the net under the lossy outcome event",
+		gateSweepInterval, gateSweepGrace, gateSweepLookback)
+	t := time.NewTicker(gateSweepInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			s.sweepGates(ctx, lister, time.Now().UTC())
+		}
+	}
+}
+
+// sweepGates performs one pass. Extracted (with an injectable clock) for tests.
+func (s *Server) sweepGates(ctx context.Context, lister gateSweepLister, now time.Time) {
+	if lister == nil || s.cfg.Store == nil {
+		return
+	}
+	refs, err := lister.ListNotifiableRuns(
+		store.WithoutTenantFilter(ctx),
+		now.Add(-gateSweepLookback),
+		now.Add(-gateSweepGrace),
+		gateSweepBatch,
+	)
+	if err != nil {
+		s.warnf("merge-gate sweeper: scan: %v", err)
+		return
+	}
+	if len(refs) == gateSweepBatch {
+		// The window is bounded and so is the batch, so a full page means the
+		// oldest candidates of this window were not examined. Saying so beats
+		// a silent truncation that reads as "everything was covered".
+		s.warnf("merge-gate sweeper: batch full at %d runs — the oldest candidates in the %s window were not examined this pass",
+			gateSweepBatch, gateSweepLookback)
+	}
+	for _, ref := range refs {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		// Every guard that decides whether this run owes anything lives in the
+		// reconciler; the sweep's only job is to offer the run again. Runs that
+		// gate nothing — the vast majority of any window — exit on a local
+		// field read with no forge traffic.
+		_ = s.reconcileGateForRunID(ctx, ref.ID, "sweep")
+	}
+}

--- a/pkg/server/forge_gate_sweeper_test.go
+++ b/pkg/server/forge_gate_sweeper_test.go
@@ -147,6 +147,77 @@ func TestGateReconcile_SyntheticFailureStandsDownOnlyForItsOwnRun(t *testing.T) 
 	})
 }
 
+// pagingLister serves a backlog one page at a time, honouring the `before`
+// cursor exactly as the Mongo query does (newest-first, strictly older than
+// the cursor).
+type pagingLister struct {
+	all      []mongostore.NotifiableRunRef // newest first
+	requests []time.Time                   // the `before` of each call
+}
+
+func (p *pagingLister) ListNotifiableRuns(_ context.Context, _, before time.Time, limit int) ([]mongostore.NotifiableRunRef, error) {
+	p.requests = append(p.requests, before)
+	out := []mongostore.NotifiableRunRef{}
+	for _, r := range p.all {
+		if r.UpdatedAt.Before(before) && len(out) < limit {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+// A single page is not a bound, it is a silent truncation that REPEATS. Rows
+// come back newest-first, so a dead gating run pushed off the page is pushed
+// off again on every subsequent pass: its check is never repaired and the
+// batch-full warning fires forever with no recovery. The window has to be
+// paged with the cursor the query was built for.
+func TestGateSweep_PagesTheWindowInsteadOfStarvingOldCandidates(t *testing.T) {
+	gc := &listingGateClient{fakeGateClient: fakeGateClient{headSHA: "deadbeef"}}
+	s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	// A full first page of runs that gate nothing, then the real candidate
+	// sitting just behind it — exactly the row a single page would drop.
+	lister := &pagingLister{}
+	for i := 0; i < gateSweepBatch; i++ {
+		lister.all = append(lister.all, mongostore.NotifiableRunRef{
+			ID:        "filler",
+			UpdatedAt: now.Add(-gateSweepGrace - time.Duration(i+1)*time.Second),
+		})
+	}
+	lister.all = append(lister.all, mongostore.NotifiableRunRef{
+		ID:        runID,
+		UpdatedAt: now.Add(-gateSweepGrace - time.Duration(gateSweepBatch+1)*time.Second),
+	})
+
+	s.sweepGates(context.Background(), lister, now)
+
+	if len(lister.requests) < 2 {
+		t.Fatalf("scanned %d page(s) — a full page must advance the cursor, or the oldest candidate is never examined", len(lister.requests))
+	}
+	if gc.setCalls != 1 {
+		t.Fatalf("posted %d statuses, want 1 — the candidate behind the first page was starved", gc.setCalls)
+	}
+}
+
+// A page that cannot advance the cursor (every row sharing one timestamp) must
+// stop and say so, not re-scan the same rows up to the page cap.
+func TestGateSweep_StopsWhenTheCursorCannotAdvance(t *testing.T) {
+	s, _ := gateReconcileFixture(t, gatingInputs(), &listingGateClient{})
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	stuck := &fakeGateSweepLister{}
+	for i := 0; i < gateSweepBatch; i++ {
+		// Zero UpdatedAt: nothing to advance the cursor with.
+		stuck.refs = append(stuck.refs, mongostore.NotifiableRunRef{ID: "no-timestamp"})
+	}
+
+	s.sweepGates(context.Background(), stuck, now)
+
+	if stuck.calls != 1 {
+		t.Fatalf("scanned %d times, want 1 — a stalled cursor re-scanned the same rows", stuck.calls)
+	}
+}
+
 // A scan that fails must not take the ticker down with it: the next pass is
 // the recovery, and a sweeper that exits on one Mongo hiccup silently stops
 // being a net at all.

--- a/pkg/server/forge_gate_sweeper_test.go
+++ b/pkg/server/forge_gate_sweeper_test.go
@@ -1,0 +1,156 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+	mongostore "github.com/SocialGouv/iterion/pkg/store/mongo"
+)
+
+type fakeGateSweepLister struct {
+	refs  []mongostore.NotifiableRunRef
+	err   error
+	calls int
+	since time.Time
+	// before is the upper bound the sweep asked for — the grace that keeps it
+	// off runs the event path may still be handling.
+	before time.Time
+	limit  int
+}
+
+func (f *fakeGateSweepLister) ListNotifiableRuns(_ context.Context, since, before time.Time, limit int) ([]mongostore.NotifiableRunRef, error) {
+	f.calls++
+	f.since, f.before, f.limit = since, before, limit
+	return f.refs, f.err
+}
+
+// The reason the sweep exists: the reconciler's only trigger is one event on a
+// bus that is lossy by design. When that event is dropped — a replica taking
+// the queue-group delivery mid-shutdown, a handler that never ran — the
+// required check stays absent and the pull request waits forever, with nothing
+// anywhere saying so. Offering the same run again from a poll is what makes
+// the repair survive a lost event.
+func TestGateSweep_ReconcilesARunWhoseEventWasLost(t *testing.T) {
+	gc := &listingGateClient{fakeGateClient: fakeGateClient{headSHA: "deadbeef"}}
+	s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+	lister := &fakeGateSweepLister{refs: []mongostore.NotifiableRunRef{{ID: runID}}}
+
+	// No event was ever delivered for this run.
+	s.sweepGates(context.Background(), lister, time.Now().UTC())
+
+	if gc.setCalls != 1 {
+		t.Fatalf("posted %d statuses, want 1 — a dropped outcome event leaves the PR blocked forever", gc.setCalls)
+	}
+	if gc.last.State != forge.CommitStateFailure {
+		t.Errorf("state = %q, want failure — the review did not happen", gc.last.State)
+	}
+}
+
+// The two triggers race on every run that ends. The repair re-reads the live
+// status before writing, so the loser of the race must find a verdict and
+// stand down rather than post a second one.
+func TestGateSweep_IsIdempotentWithTheEventPath(t *testing.T) {
+	gc := &listingGateClient{fakeGateClient: fakeGateClient{headSHA: "deadbeef"}}
+	s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+
+	if err := s.reconcileGateForRun(context.Background(), terminalEvent(runID)); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	// The event path posted a synthetic failure; feed the status back so the
+	// sweep sees the same head state the forge would now report.
+	gc.statuses = []forge.CommitStatus{gc.last}
+	before := gc.setCalls
+
+	s.sweepGates(context.Background(), &fakeGateSweepLister{refs: []mongostore.NotifiableRunRef{{ID: runID}}}, time.Now().UTC())
+
+	if gc.setCalls != before {
+		t.Fatalf("posted %d more statuses, want 0 — the sweep must not double-post behind the event path", gc.setCalls-before)
+	}
+}
+
+// Both bounds carry a decision. The grace keeps the sweep off runs the event
+// path is still working through (a repair does several forge round-trips), so
+// the two paths race only on the dropped ones. The lookback is what stops the
+// sweep reaching back into history and painting a synthetic failure onto pull
+// requests that merged days ago.
+func TestGateSweep_WindowIsBoundedOnBothSides(t *testing.T) {
+	s, _ := gateReconcileFixture(t, gatingInputs(), &listingGateClient{})
+	lister := &fakeGateSweepLister{}
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+
+	s.sweepGates(context.Background(), lister, now)
+
+	if lister.calls != 1 {
+		t.Fatalf("scanned %d times, want 1", lister.calls)
+	}
+	if got, want := lister.before, now.Add(-gateSweepGrace); !got.Equal(want) {
+		t.Errorf("upper bound = %s, want %s — without the grace the sweep races the event path on every run", got, want)
+	}
+	if got, want := lister.since, now.Add(-gateSweepLookback); !got.Equal(want) {
+		t.Errorf("lower bound = %s, want %s — an unbounded reach posts failures onto long-merged PRs", got, want)
+	}
+	if lister.since.After(lister.before) {
+		t.Error("empty window: the lookback must exceed the grace or nothing is ever examined")
+	}
+	// A pass must also outreach its own cadence, or a run that ends in the gap
+	// between two windows is never examined by either.
+	if gateSweepLookback <= gateSweepInterval+gateSweepGrace {
+		t.Errorf("lookback %s <= interval %s + grace %s — runs fall through the gap between passes",
+			gateSweepLookback, gateSweepInterval, gateSweepGrace)
+	}
+}
+
+// The discrimination the repeated offer forced, in both directions. A
+// synthetic failure is not a verdict, so it does not stand the repair down in
+// general — that is what lets a SECOND death on the same head (a relaunched
+// run dying too) escalate instead of mistaking the first death's marker for an
+// answer. But the same run offered again is already answered. The target URL
+// names the run the failure speaks for, which separates the two without
+// bookkeeping a second replica would not share.
+func TestGateReconcile_SyntheticFailureStandsDownOnlyForItsOwnRun(t *testing.T) {
+	interruption := func(targetURL string) forge.CommitStatus {
+		return forge.CommitStatus{
+			Context:     "iterion/review",
+			State:       forge.CommitStateFailure,
+			Description: gateInterruptedDescription,
+			TargetURL:   targetURL,
+		}
+	}
+	t.Run("its own — already answered, stand down", func(t *testing.T) {
+		gc := &listingGateClient{
+			fakeGateClient: fakeGateClient{headSHA: "deadbeef"},
+			statuses:       []forge.CommitStatus{interruption("https://iterion.test/runs/run-gating")},
+		}
+		s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+		if err := s.reconcileGateForRun(context.Background(), terminalEvent(runID)); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if gc.setCalls != 0 {
+			t.Fatalf("posted %d statuses, want 0 — every sweep pass would re-post and re-enter the recovery", gc.setCalls)
+		}
+	})
+	t.Run("another run's — the second death must still escalate", func(t *testing.T) {
+		gc := &listingGateClient{
+			fakeGateClient: fakeGateClient{headSHA: "deadbeef"},
+			statuses:       []forge.CommitStatus{interruption("https://iterion.test/runs/some-earlier-run")},
+		}
+		s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+		if err := s.reconcileGateForRun(context.Background(), terminalEvent(runID)); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if gc.setCalls != 1 {
+			t.Fatalf("posted %d statuses, want 1 — the repair goes silent exactly where the recovery runs out", gc.setCalls)
+		}
+	})
+}
+
+// A scan that fails must not take the ticker down with it: the next pass is
+// the recovery, and a sweeper that exits on one Mongo hiccup silently stops
+// being a net at all.
+func TestGateSweep_SurvivesAScanError(t *testing.T) {
+	s, _ := gateReconcileFixture(t, gatingInputs(), &listingGateClient{})
+	s.sweepGates(context.Background(), &fakeGateSweepLister{err: errors.New("mongo down")}, time.Now().UTC())
+}

--- a/pkg/server/forge_publish.go
+++ b/pkg/server/forge_publish.go
@@ -43,14 +43,24 @@ import (
 // actually been computed. The grant therefore has to outlive the longest wait
 // the retry machinery can schedule, plus a margin for the resumed run itself.
 //
-// The cost is a wider window for a leaked token. It is bounded by what the
-// grant can do — post a review and a commit status on ONE repo, re-enforced
-// against the grant's (team, connection, repo) at every use — and a run that
-// ends normally revokes its grant on the way out.
+// The cost is a wider window for a leaked token, and it is NOT offset by early
+// revocation: nothing in this tree calls Revoke outside its own test, so the
+// TTL is the only bound there is. What limits the damage is what the grant can
+// do — post a review and a commit status on ONE repo, re-enforced against the
+// grant's (team, connection, repo) at every use.
 const forgePublishDefaultTTL = retrypolicy.DefaultMaxWait + 24*time.Hour
 
-// forgePublishMaxTokens bounds the in-memory registry.
-const forgePublishMaxTokens = 1024
+// forgePublishMaxTokens bounds the in-memory registry (the backend used when
+// no Valkey is configured).
+//
+// It scales with the TTL because Register only evicts EXPIRED entries before
+// checking the cap, so the ceiling is really "gating launches per TTL": at a
+// flat 1024 the 9-day TTL would saturate at ~114 launches/day, and saturation
+// is not graceful — Register errors, injectForgePublishVars hands the run no
+// grant, and the run cannot publish its verdict. Worse now that the launch has
+// already claimed the check: the reconciler needs the grant to speak, so it
+// abstains (no token ⇒ "not a gating run") and the claim is never answered.
+const forgePublishMaxTokens = 1024 * int(forgePublishDefaultTTL/(24*time.Hour))
 
 // ForgePublishGrant scopes one run's publish token: reviews may only be
 // posted through this team's connection, on this repo.

--- a/pkg/server/forge_publish.go
+++ b/pkg/server/forge_publish.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -28,10 +29,25 @@ import (
 // MCP HTTP transport's X-Iterion-Run token pattern (mcp_board_handler.go).
 // ---------------------------------------------------------------------------
 
-// forgePublishDefaultTTL caps how long a publish grant stays alive. Same
-// rationale as boardMCPDefaultTTL: long enough for any realistic run, short
-// enough that a leaked token from a crashed run expires on its own.
-const forgePublishDefaultTTL = 24 * time.Hour
+// forgePublishDefaultTTL caps how long a publish grant stays alive: long
+// enough for any realistic run, short enough that a leaked token from a
+// crashed run expires on its own.
+//
+// "Any realistic run" is NOT the run's wall-clock budget. A run blocked on a
+// provider usage window is parked and resumed by the retry sweeper up to
+// retrypolicy.DefaultMaxWait later — a weekly forfait cap resets as much as
+// seven days out. At the previous flat 24h the grant was dead long before the
+// resumed run reached its publish node, so the review completed and then had
+// no way to post its verdict or its gate status: the required check stayed on
+// whatever the interruption left it, and the PR waited on an answer that had
+// actually been computed. The grant therefore has to outlive the longest wait
+// the retry machinery can schedule, plus a margin for the resumed run itself.
+//
+// The cost is a wider window for a leaked token. It is bounded by what the
+// grant can do — post a review and a commit status on ONE repo, re-enforced
+// against the grant's (team, connection, repo) at every use — and a run that
+// ends normally revokes its grant on the way out.
+const forgePublishDefaultTTL = retrypolicy.DefaultMaxWait + 24*time.Hour
 
 // forgePublishMaxTokens bounds the in-memory registry.
 const forgePublishMaxTokens = 1024

--- a/pkg/server/forge_publish_gate_test.go
+++ b/pkg/server/forge_publish_gate_test.go
@@ -29,11 +29,16 @@ var (
 // fakeGateClient records the merge-gate calls (head-SHA lookup + commit-status
 // write) — the seam the gate tests use instead of a live forge.
 type fakeGateClient struct {
-	headSHA  string
-	getErr   error
-	setErr   error
-	last     forge.CommitStatus
-	lastSHA  string
+	headSHA string
+	getErr  error
+	setErr  error
+	last    forge.CommitStatus
+	lastSHA string
+	// posted keeps every status in order: several now land on one head (the
+	// launch's in-flight claim, then the verdict — or a synthetic failure then
+	// the recovery's fresh claim), and only the SEQUENCE distinguishes a
+	// correct hand-off from a status that overwrote something it should not.
+	posted   []forge.CommitStatus
 	setCalls int
 }
 
@@ -44,6 +49,7 @@ func (f *fakeGateClient) GetPullRequest(context.Context, string, int) (forge.Pul
 func (f *fakeGateClient) SetCommitStatus(_ context.Context, _, sha string, st forge.CommitStatus) error {
 	f.setCalls++
 	f.lastSHA, f.last = sha, st
+	f.posted = append(f.posted, st)
 	return f.setErr
 }
 

--- a/pkg/server/server_lifecycle.go
+++ b/pkg/server/server_lifecycle.go
@@ -260,6 +260,27 @@ func (s *Server) ListenAndServe() error {
 		s.warnf("retry sweeper NOT started: the store does not implement ListRunsDueForRetry — " +
 			"runs parked on a provider quota window will never resume on their own")
 	}
+	// Merge-gate sweeper (cloud only): the reconciliation net under the
+	// reconciler's lossy outcome event. Same shape and cadence as the retry
+	// sweeper next door, and needed for the same reason — a required check
+	// nobody answers blocks a pull request indefinitely, and a dropped event
+	// leaves no trace saying so.
+	if lister, ok := s.cfg.Store.(gateSweepLister); ok && s.forgePublishTokens != nil && s.forgeConnections != nil {
+		go func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go func() {
+				<-s.shutdown
+				cancel()
+			}()
+			s.runGateSweeper(ctx, lister)
+		}()
+	} else if s.cfg.ScheduledBots != nil && s.forgePublishTokens != nil {
+		// Cloud mode with gating wired but no sweep: the event path is then the
+		// SOLE trigger, and its misses are exactly the invisible ones.
+		s.warnf("merge-gate sweeper NOT started: the store does not implement ListNotifiableRuns — " +
+			"a review whose outcome event is dropped will leave its required check absent forever")
+	}
 	// Cloud scheduler: fire due cron-scheduled bots. Multi-replica-safe via the
 	// store CAS (no leader election). Absent in local mode (ScheduledBots nil).
 	if s.cfg.ScheduledBots != nil {

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -935,6 +935,12 @@ func (s *Server) launchWebhookTarget(
 	s.updateWebhookDelivery(ctx, delivery)
 	s.markWebhookOutcome(cfg.Provider, webhooks.StatusLaunched)
 
+	// Claim the repo's gate context on the revision this run is about to
+	// review, so the minutes between the push and the verdict read as
+	// "running" instead of as the absence they are indistinguishable from.
+	// After the launch, because the marker carries the run's URL.
+	s.markGateInFlight(ctx, cfg.TenantID, botID, vars, runID)
+
 	// Mirror the launch onto the trigger spine (observational; carries
 	// launched_run_id so the evaluator never re-launches). Unifies forge with
 	// board/run/schedule sources; no-op without the spine wired.


### PR DESCRIPTION
## The report

On [buildkit-operator#19](https://github.com/SocialGouv/buildkit-operator/pull/19), Revi commented and the gate looked like it never went green. It had: `iterion/review=success` landed on every head, ~2s after each review comment.

What was actually seen is the **window between the push and the verdict**. A review takes ~9 minutes, and for all of it the required context carries **no status** — which GitHub renders as *"Expected — waiting for status to be reported"*. Byte-identical to a review that was never launched, and displayed right under the reviewer's comment on the *previous* commit.

## Three gaps

Each one alone leaves a pull request waiting on an answer that never arrives.

**1. No in-flight state.** The launch now *claims* the repo's gate context on the revision it is about to review, pointed at the live run console. It writes only over nothing, over a previous claim, or over a synthetic interruption — **never over a verdict**, which matters because a repo pins one context precisely so a required check can span several bots.

**2. The verdict did not survive a long quota wait.** A run parked on a provider usage window resumes up to `retrypolicy.DefaultMaxWait` later — a **weekly** forfait cap resets as much as seven days out — but the publish grant expired at a flat 24h. The resumed review ran to completion and then could not post what it had computed. The TTL now derives from the longest wait the retry machinery can schedule, plus a margin.

**3. The reconciler had no net.** Its only trigger was one run-outcome event on a bus that is **lossy by design**, while every other consumer of that bus carries a reconciliation sweep for exactly that reason (usernotify's 2-min sweep, the dispatcher's 30s poll, the retry sweeper). A 1-minute sweep over a bounded window (3-min grace, 60-min lookback) now offers the same runs to the same repair a second time.

> Observed 2026-08-10: four review runs died on one provider weekly cap inside 90 seconds. All four gates stayed absent for hours — and the reconciler had left **no trace** of having considered any of them, because every branch that declined to act returned a bare `nil`. Those branches now name their reason.

## Two hazards the design created, and closed

- The claim is a `pending` **with a description**, so a guard reading *"this head has a status, someone answered"* would take it for a verdict and silence the very repair that un-sticks the PR. `isGateInFlight` keeps "claimed" and "answered" distinct.
- A synthetic failure deliberately does **not** stand the repair down, so that a *second* death on one head escalates instead of mistaking the first death's marker for an answer. Under a sweep re-reading its window every minute, that meant re-posting and re-entering the recovery on every pass. The status target URL names the run it speaks for, which separates "already answered" from "must escalate" — with no bookkeeping a second replica would not share.

## Verification

- `task lint` → 0 issues
- `./pkg/...`, `./e2e/...`, `./bots/...`, `./cmd/...` → green
- 11 new tests, including both directions of the escalation discrimination and a guard pinning the grant TTL against `retrypolicy.DefaultMaxWait`

One unrelated flake surfaced under the full `./...` run only: `TestMCPServer_DetachedRunSurvivesServerExit` passes in isolation (3× modified tree, 5× clean tree) and touches no forge/gate/webhook path.

## Not covered here

The four runs above had `retry_state: null` despite the default being `usage_window: resume` — **no retry was armed for a weekly limit**. That is the remaining link for a dead review to re-post its verdict unattended after a quota reset; the rest of the chain (surviving grant, sweep, reclaim) is now ready for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)