### PR TITLE
fix(runner): a weekly cap parked four reviews with nothing coming back

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,9 +120,13 @@ jobs:
         run: go test -mod=vendor ./...
 
       - name: E2E tests
-        # Same budget as the Taskfile's test:e2e (240s) — a shared CI runner
-        # is slower than a dev machine, so a tighter CI timeout only buys flakes.
-        run: go test -mod=vendor -v -timeout 240s ./e2e/...
+        # Same budget as the Taskfile's test:e2e. The number bounds a HANG, not
+        # a slow machine: the suite legitimately runs ~170s on a dev box, so the
+        # old 240s left barely 1.4x headroom and a loaded shared runner crossed
+        # it — a 4m panic dump naming whichever test happened to be in flight,
+        # which reads as "that test is broken" and is not. A true hang still
+        # trips this; only the coin flip is gone.
+        run: go test -mod=vendor -v -timeout 600s ./e2e/...
 
   race:
     # Data-race detector pass. The `test` job runs CGO_ENABLED=0 with no

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -91,10 +91,13 @@ tasks:
     desc: Run end-to-end tests
     deps: [templates:dispatch-bots]
     cmds:
-      ## 240s: the ADR-058 v2 rollout added stub suites (docs-refresh's
-      ## six scenarios, feature-dev's five) that legitimately grew the
-      ## package past the old 120s budget.
-      - go test -v -timeout 240s ./e2e/...
+      ## The budget bounds a HANG, not a slow machine. The ADR-058 v2 rollout
+      ## added stub suites (docs-refresh's six scenarios, feature-dev's five)
+      ## that grew the package to ~170s on a dev box; at the old 240s a loaded
+      ## CI runner crossed it and produced a 4m panic dump naming whichever
+      ## test was in flight — a flake that reads as a broken test. A hung test
+      ## still trips 600s.
+      - go test -v -timeout 600s ./e2e/...
 
   test:e2e:ui:
     desc: Run the studio UI end-to-end tests (Playwright against the real server; skips when chromium isn't installed)

--- a/pkg/backend/delegate/claude_code_stream.go
+++ b/pkg/backend/delegate/claude_code_stream.go
@@ -831,20 +831,49 @@ var usageWindowSignals = []string{
 // keeps Kind = transient and a zero ResetAt — never a hard failure.
 func classifyRateLimit(text string, now time.Time) (kind string, resetAt time.Time) {
 	lower := strings.ToLower(text)
-	kind = RateLimitKindTransient
+	if !isUsageWindowText(lower) {
+		return RateLimitKindTransient, time.Time{}
+	}
+	return RateLimitKindUsageWindow, parseResetHint(lower, now)
+}
+
+// isUsageWindowText reports whether already-lowercased text carries one of the
+// window-exhaustion shapes. Extracted so the classifier and the flattened-error
+// fallback below share ONE definition of "the window is shut": two copies of
+// this drift, and the copy nobody exercises is the one that goes stale.
+func isUsageWindowText(lower string) bool {
 	if hitYourLimitRe.MatchString(lower) {
-		kind = RateLimitKindUsageWindow
+		return true
 	}
 	for _, sig := range usageWindowSignals {
 		if strings.Contains(lower, sig) {
-			kind = RateLimitKindUsageWindow
-			break
+			return true
 		}
 	}
-	if kind != RateLimitKindUsageWindow {
-		return kind, time.Time{}
+	return false
+}
+
+// UsageWindowInFlattenedError recovers the window signal from an error whose
+// TYPE did not survive — a layer that formatted with %v instead of wrapping
+// with %w, a store round-trip, an out-of-process hop.
+//
+// It is the last-resort evidence source: waiting is the only cure for a shut
+// window, so a run whose type was lost otherwise parks with nothing coming
+// back for it. Measured 2026-08-10: four reviews died on one Anthropic weekly
+// cap and not one armed a retry, leaving four pull requests on a required
+// check nobody would answer.
+//
+// Anchored on the marker ErrRateLimited itself prints, NOT on the window
+// wording alone. That anchor is what keeps the fallback from firing on an
+// agent that merely quotes "you've hit your weekly limit" in prose that ends
+// up inside some other error: in a path that PARKS a run for hours, a false
+// positive costs as much as the gap it closes.
+func UsageWindowInFlattenedError(text string) bool {
+	lower := strings.ToLower(text)
+	if !strings.Contains(lower, rateLimitedErrorMarker) {
+		return false
 	}
-	return kind, parseResetHint(lower, now)
+	return isUsageWindowText(lower)
 }
 
 // resetAbsRe matches an explicit absolute instant: "reset at

--- a/pkg/backend/delegate/delegate.go
+++ b/pkg/backend/delegate/delegate.go
@@ -1294,11 +1294,17 @@ const (
 	RateLimitKindTransient   = "transient"
 )
 
+// rateLimitedErrorMarker opens every ErrRateLimited rendering. Shared with
+// UsageWindowInFlattenedError, which reads it back out of a message some layer
+// formatted instead of wrapping: the two must not drift, or the last-resort
+// evidence silently stops matching the text it exists to recognise.
+const rateLimitedErrorMarker = "rate_limited"
+
 func (e *ErrRateLimited) Error() string {
 	if e.Provider != "" {
-		return "rate_limited (" + e.Provider + "): " + e.Detail
+		return rateLimitedErrorMarker + " (" + e.Provider + "): " + e.Detail
 	}
-	return "rate_limited: " + e.Detail
+	return rateLimitedErrorMarker + ": " + e.Detail
 }
 
 // ErrAuthFailed marks a credential the provider rejected — a dead or

--- a/pkg/runner/usage_retry.go
+++ b/pkg/runner/usage_retry.go
@@ -117,6 +117,15 @@ func usageWindowEvidence(execErr error) (resetAt time.Time, source string, ok bo
 		return rl.ResetAt, "typed_error", true
 	case runtimeCodeOf(execErr) == runtime.ErrCodeUsageLimitBlocked:
 		return time.Time{}, "runtime_code", true
+	// The flattened message, last. This source was DOCUMENTED above from the
+	// start and never implemented, so a host that had neither of the two
+	// above got no retry at all — the case the doc calls "not hypothetical".
+	// Measured 2026-08-10: four reviews died on one Anthropic weekly cap,
+	// every one of them carrying the provider's own words in run.Error, and
+	// not one armed a retry; four pull requests waited on a required check
+	// nobody would ever answer.
+	case delegate.UsageWindowInFlattenedError(execErr.Error()):
+		return time.Time{}, "flattened_text", true
 	}
 	return time.Time{}, "", false
 }

--- a/pkg/runner/usage_retry_chain_test.go
+++ b/pkg/runner/usage_retry_chain_test.go
@@ -1,0 +1,116 @@
+package runner
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/retrypolicy"
+	"github.com/SocialGouv/iterion/pkg/runtime"
+)
+
+// The production error text, verbatim from run 019fea23-9636 (2026-08-10):
+// four review runs died on one Anthropic weekly cap inside 90 seconds and NOT
+// ONE armed a retry (`retry_state: null` on all four), so four pull requests
+// kept a required check nobody would ever answer. The provider window had
+// reopened by 19:00 UTC the same day; nothing came back for it.
+const prodWeeklyLimitText = "You've hit your weekly limit · resets 7pm (UTC)"
+
+// wrapLikeProduction rebuilds the exact chain a cloud runner receives, layer
+// for layer: the delegate's typed error, the executor's backend wrapper
+// (executor_build_task.go), and the engine's RuntimeError, whose Message is
+// the %v-FLATTENED text and whose Cause is meant to carry the type through
+// (engine_exec.go).
+func wrapLikeProduction(inner error, code runtime.ErrorCode) error {
+	backend := fmt.Errorf("model: node %q: backend %q failed: %w", "reviewer_claude", "claude_code", inner)
+	return &runtime.RuntimeError{
+		Code:    code,
+		NodeID:  "reviewer_claude",
+		Cause:   backend,
+		Message: fmt.Sprintf("node %q execution failed: %v", "reviewer_claude", backend),
+	}
+}
+
+// The happy path, pinned so a regression in ANY layer's wrapping shows up
+// here: as long as every wrapper uses %w and RuntimeError.Unwrap returns its
+// Cause, the typed evidence survives from the delegate to the retry decision.
+func TestUsageWindowRetry_TypedErrorSurvivesTheProductionChain(t *testing.T) {
+	now := time.Date(2026, 8, 10, 5, 30, 0, 0, time.UTC)
+	inner := &delegate.ErrRateLimited{
+		Provider: "claude_code",
+		Detail:   prodWeeklyLimitText,
+		Kind:     delegate.RateLimitKindUsageWindow,
+	}
+	execErr := wrapLikeProduction(inner, runtime.ErrCodeExecutionFailed)
+
+	at, source, ok := usageWindowRetryAt(execErr, retrypolicy.Normalize(retrypolicy.Policy{}), now)
+	if !ok {
+		t.Fatalf("no retry armed for a weekly cap — the run parks forever and its PR waits on a check nobody answers")
+	}
+	if !at.After(now) {
+		t.Errorf("retry at %s is not after %s", at, now)
+	}
+	t.Logf("armed at %s via %s", at, source)
+}
+
+// The gap this test exists for. usageWindowRetryAt's own doc promises three
+// evidence sources — "the typed error […] the code […] and the flattened
+// message is a last resort for a host that has neither — which is not
+// hypothetical, since a runner with no dispatcher wired classifies nothing at
+// all." The third one was never implemented: usageWindowEvidence returned
+// false unless a typed error or a classified code survived.
+//
+// So on any host where the type does not make it through (a layer that
+// formats instead of wrapping, a store round-trip, an out-of-process hop) the
+// provider's own words — sitting right there in the message — were ignored,
+// and the run parked with nothing coming back for it. That is the shape of the
+// four dead reviews above: the text was in run.Error, the retry was null.
+func TestUsageWindowRetry_FallsBackToTheProvidersOwnWords(t *testing.T) {
+	now := time.Date(2026, 8, 10, 5, 30, 0, 0, time.UTC)
+	// A chain that carries the words but NOT the type — what a formatting
+	// layer anywhere in the stack leaves behind.
+	flattened := &runtime.RuntimeError{
+		Code:    runtime.ErrCodeExecutionFailed,
+		NodeID:  "reviewer_claude",
+		Message: "node \"reviewer_claude\" execution failed: model: node \"reviewer_claude\": backend \"claude_code\" failed: delegate: claude-code failed: rate_limited (claude_code): " + prodWeeklyLimitText,
+	}
+
+	at, source, ok := usageWindowRetryAt(flattened, retrypolicy.Normalize(retrypolicy.Policy{}), now)
+	if !ok {
+		t.Fatalf("the provider said the window is shut and when it reopens, and the run parked with nothing coming back for it")
+	}
+	// 7pm UTC the same day, plus a minute, plus jitter — must not be the
+	// blind one-hour wait when the text names the reset.
+	blind := now.Add(usageWindowBlindWait)
+	if !at.After(blind) {
+		t.Errorf("retry at %s looks like the blind wait (%s) — the parsed reset (7pm) was ignored, source=%s", at, blind, source)
+	}
+	t.Logf("armed at %s via %s", at, source)
+}
+
+// Nothing must widen into "any error is a usage window": an ordinary failure
+// that merely MENTIONS a limit, or a plain throttle, still gets today's
+// redelivery, not a multi-hour park.
+func TestUsageWindowRetry_DoesNotArmOnUnrelatedFailures(t *testing.T) {
+	now := time.Date(2026, 8, 10, 5, 30, 0, 0, time.UTC)
+	pol := retrypolicy.Normalize(retrypolicy.Policy{})
+	for name, msg := range map[string]string{
+		"a build failure":           `node "build" execution failed: exit status 1`,
+		"an agent discussing quota": `node "review" execution failed: the report explains how to raise your limit and mentions rate limit exceeded handling`,
+		"a schema error":            `node "review" execution failed: missing required field "verdict"`,
+		"a budget stop":             `budget exceeded: tokens (30/25)`,
+		// The anchor's whole job. An agent QUOTING the provider's wording —
+		// a review of this very code, a docs bot describing the retry
+		// behaviour — must not park its own run for hours. Only a message the
+		// delegate itself rendered (marker included) counts as evidence.
+		"an agent quoting the notice": `node "review" execution failed: missing required field "verdict" (the model wrote: You've hit your weekly limit · resets 7pm (UTC))`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := &runtime.RuntimeError{Code: runtime.ErrCodeExecutionFailed, Message: msg}
+			if _, _, ok := usageWindowRetryAt(err, pol, now); ok {
+				t.Fatalf("armed a usage-window park for %q — a plain failure now waits hours instead of being redelivered", msg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes the item left open by #387.

## The gap

`usageWindowRetryAt` documents three evidence sources for "the provider's window is shut" — the typed error, a classified runtime code, **"and the flattened message is a last resort for a host that has neither — which is not hypothetical, since a runner with no dispatcher wired classifies nothing at all."**

The third one was never implemented. `usageWindowEvidence` returned false unless a type or a code survived, so on any host where neither does, the provider's own words — sitting right there in `run.Error` — were ignored and the run parked with nothing to bring it back.

## Measured, not hypothetical

2026-08-10: four review runs died inside 90 seconds on one Anthropic weekly cap.

```
You've hit your weekly limit · resets 7pm (UTC)
```

All four: `failed_resumable`, `retry_state: null`, required check absent. The window reopened at 19:00 the same day and not one came back — four pull requests waiting on an answer nobody would ever give.

## The fix, and why it is anchored

The last-resort source is implemented, and keyed on the marker `ErrRateLimited` itself prints — **not** on the window wording alone. That anchor is the point: this path *parks a run for hours*, so an agent quoting "hit your weekly limit" in prose that lands inside some other error must not trip it. In a mechanism that blocks, a false positive costs as much as the gap it closes.

The window shapes come from one shared predicate (`isUsageWindowText`) that the live classifier also uses. The file already carries the scar of an evidence chain kept in two copies — the credential pool's silently dropped the text-parsed reset the retry path relies on.

## Pinned by

- the typed chain **rebuilt layer for layer** as production wraps it, so a wrapper that formats instead of wrapping shows up here rather than in production;
- the flattened chain with the verbatim production message (arms at 19:01 via `flattened_text+parsed_text` — it recovers the reset instant too);
- five failures that must still be redelivered rather than parked, including an agent quoting the notice.

## Also: the e2e CI budget

A timeout bounds a **hang**, not a slow machine. The suite legitimately runs ~172s on a dev box, and the 240s budget left 1.4× headroom — so a loaded shared runner crossed it and emitted a 4m panic dump naming whichever test happened to be in flight (`TestWholeImproveLoop_MRPathOnConverge`, 3s in). That reads as "that test is broken", and it is not. 600s; a true hang still trips it.

`go test ./...` is fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)