### PR TITLE
fix: a lost alignment must not merge as a clean bump (#400 post-mortem)

### DIFF
--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -511,6 +511,11 @@ schema commit_input:
 schema commit_check_output:
   ## did_commit: the branch head moved, and this run is what moved it.
   did_commit: bool
+  ## alignment_lost: `align` reported edits, and none of them reached the
+  ## branch. Reading the shas alone cannot tell that apart from "the bump
+  ## needed no alignment" — both land on an unmoved head — so without this
+  ## flag a vanished alignment is reported as a clean bump and merges.
+  alignment_lost: bool
 
 schema commit_output:
   committed: bool
@@ -864,10 +869,22 @@ compute validate_gate:
 ## `committed: true` having pushed nothing would otherwise make every
 ## user-facing string — the comment badge, the "what Vetty did" line, the
 ## required check's description — assert work that never happened.
+##
+## An unmoved head has TWO causes, and they are opposite verdicts: the bump
+## genuinely needed no alignment, or `align` produced one that never reached
+## the branch. The second is not hypothetical — the runner re-clones the repo
+## on every claim, so a run that dies between `align` and `commit` (a provider
+## usage window is the ordinary way) resumes on a tree where the alignment is
+## gone, while the checkpoint still replays `align.applied = true` downstream.
+## The shas cannot separate the two, so the check reads `align`'s own claim
+## alongside them: not to trust the agent — the sha comparison still decides
+## what was COMMITTED — but so that a claim contradicted by the branch blocks
+## instead of passing for a bump that never needed anything.
 compute commit_check:
   output: commit_check_output
   expr:
     did_commit: "outputs.commit.sha != '' && outputs.commit.sha != outputs.prepare.head_sha"
+    alignment_lost: "outputs.align.applied && !(outputs.commit.sha != '' && outputs.commit.sha != outputs.prepare.head_sha)"
 
 ## Commit the alignment onto the PR branch + push it back (token auth).
 agent commit:
@@ -933,6 +950,7 @@ tool post_feedback:
         "hold_security":  "\U0001F6D1 HOLD — supply-chain risk; not aligned/merged",
         "needs_decision": "\U0001F9ED Needs a human decision (architectural)",
         "hold_unstable":  "⚠️ HOLD — build/tests not green after alignment",
+        "hold_lost_alignment": "\U0001F6D1 HOLD — the alignment for this bump is NOT on the branch",
         "committed":      "✅ Aligned — code updated on this branch; review & merge",
         "clean":          "✅ Safe bump — no code alignment needed",
     }
@@ -954,6 +972,13 @@ tool post_feedback:
            "hold_security": "Held — no alignment, no commit.",
            "hold_unstable": "Held — build/tests not green.",
            "needs_decision": "Escalated for a human decision.",
+           # No cross-reference to a section title: `section()` renders nothing
+           # for an empty body, so citing one would dangle exactly when align
+           # reported no summary — and a reader who cannot find the section
+           # doubts the HOLD instead of acting on it.
+           "hold_lost_alignment": "Held — the code alignment this run produced for the bump is NOT on this branch: "
+                                  "nothing was committed and the head is still the bot's bump commit. Re-run Vetty on "
+                                  "this PR to redo it; merging as-is ships the bump without it.",
            "clean": "Nothing to align."}.get(s(verdict), "")
     did = (s(commit_summary) + " " if s(commit_summary) else "") + did + \
         " **Vetty never merges past a check** — whether this lands is the repo's own required checks' decision, " \
@@ -968,7 +993,8 @@ tool post_feedback:
     # state we did not anticipate, so it BLOCKS — a gate that fails open is
     # worse than no gate.
     GATE_BLOCKING = {"clean": 0, "committed": 0,
-                     "hold_security": 1, "hold_unstable": 1, "needs_decision": 1}
+                     "hold_security": 1, "hold_unstable": 1, "needs_decision": 1,
+                     "hold_lost_alignment": 1}
     gate_on = bool(gate_enabled)
     blocking = GATE_BLOCKING.get(s(verdict))
     if blocking is None:
@@ -981,6 +1007,7 @@ tool post_feedback:
         "committed": "supply-chain audit clean; alignment committed, build verified",
         "hold_security": "supply-chain risk: the bump was not applied",
         "hold_unstable": "build/tests not green after alignment",
+        "hold_lost_alignment": "the code alignment for this bump is missing from the branch",
         "needs_decision": "an architectural decision is pending a human",
     }.get(s(verdict), "")
     if s(verdict) not in GATE_BLOCKING:
@@ -1472,6 +1499,22 @@ workflow dep_update_guard:
   ## read, so it must name what happened: `committed` only when the branch
   ## head actually moved, `clean` when the bump needed no alignment. Both are
   ## green; they differ in what they claim was done.
+  ##
+  ## `hold_lost_alignment` is the third case and it is RED: `align` reported
+  ## edits the branch does not carry. It comes first because it is the only
+  ## one of the three that is not a statement about a healthy run — and
+  ## because an alignment that vanished is indistinguishable, from the shas
+  ## alone, from a bump that needed none. Merging it ships the bump WITHOUT
+  ## the code change that made it safe, which is exactly the failure a
+  ## dependency guard exists to prevent.
+  commit_check -> post_feedback when alignment_lost with {
+    pr_url: "{{vars.pr_url}}",
+    verdict: "hold_lost_alignment",
+    audit_summary: "{{outputs.security_audit.summary}}",
+    align_summary: "{{outputs.align.breaking_summary}}",
+    validate_summary: "deterministic verify green (exit 0); log tail: {{outputs.verify_run.log_tail}}",
+    commit_summary: "{{outputs.commit.summary}}"
+  }
   commit_check -> post_feedback when did_commit with {
     pr_url: "{{vars.pr_url}}",
     verdict: "committed",
@@ -1480,7 +1523,7 @@ workflow dep_update_guard:
     validate_summary: "deterministic verify green (exit 0); log tail: {{outputs.verify_run.log_tail}}",
     commit_summary: "{{outputs.commit.summary}}"
   }
-  commit_check -> post_feedback when not did_commit with {
+  commit_check -> post_feedback else with {
     pr_url: "{{vars.pr_url}}",
     verdict: "clean",
     audit_summary: "{{outputs.security_audit.summary}}",

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,7 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.6.5
+version: 2.7.0
 ## 2.6.5 — Revi hardening of the loop-back: budget 2h → 4h/$25 (a
 ## fix_verify cycle re-runs verify_build+verify_run, 30–50m each on the
 ## measured heavy case — without the raise heavy bumps would trade

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -2,6 +2,16 @@ name: dep-update-guard
 display_name: Vetty
 icon: 💂
 version: 2.7.0
+## 2.7.0 — a lost alignment no longer merges as a clean bump. commit_check
+## reads `align.applied` alongside the shas and routes the contradiction —
+## align claimed edits, the head did not move — to a fifth verdict,
+## `hold_lost_alignment`, blocking in the gate table and refused by
+## arm_automerge. An unmoved head has two opposite causes ("nothing to
+## align" and "the alignment vanished") and the shas alone cannot separate
+## them; the second happens whenever a run dies between align and commit,
+## since the runner re-clones on every claim while the checkpoint still
+## replays applied=true. Cost of learning it: SocialGouv/iterion#400 merged
+## an otel bump without the breaking-change fix this bot had written.
 ## 2.6.5 — Revi hardening of the loop-back: budget 2h → 4h/$25 (a
 ## fix_verify cycle re-runs verify_build+verify_run, 30–50m each on the
 ## measured heavy case — without the raise heavy bumps would trade

--- a/bots/dep_update_guard_automerge_test.go
+++ b/bots/dep_update_guard_automerge_test.go
@@ -464,6 +464,7 @@ func TestDepUpdateGuardArmAutomerge(t *testing.T) {
 		{"held bump", map[string]string{"{{input.verdict}}": `"hold_security"`}, "not green"},
 		{"unstable build", map[string]string{"{{input.verdict}}": `"hold_unstable"`}, "not green"},
 		{"pending human decision", map[string]string{"{{input.verdict}}": `"needs_decision"`}, "not green"},
+		{"alignment missing from the branch", map[string]string{"{{input.verdict}}": `"hold_lost_alignment"`}, "not green"},
 		{"unknown verdict", map[string]string{"{{input.verdict}}": `"probably_fine"`}, "not green"},
 		// A verdict whose status never reached the PR must not merge it: the
 		// gate is what the repo actually gates on.

--- a/bots/dep_update_guard_gate_test.go
+++ b/bots/dep_update_guard_gate_test.go
@@ -141,6 +141,41 @@ func TestDepUpdateGuardGateVerdict(t *testing.T) {
 		}
 	})
 
+	// iterion#400: `align` fixed an otel break, the run died on a usage window,
+	// the retry re-cloned, and the fix was gone. The verdict must not read like
+	// the bump needed nothing — the operator's next move is to re-run Vetty,
+	// and nothing on the PR would have told them so.
+	t.Run("hold_lost_alignment: names the missing work, and blocks", func(t *testing.T) {
+		got, _ := run(t, "hold_lost_alignment", "iterion/review", true)
+		if got.Gate == nil {
+			t.Fatal("no gate payload")
+		}
+		if got.Gate.BlockingCount == 0 {
+			t.Error("a bump whose alignment is missing must not be mergeable")
+		}
+		if strings.Contains(got.Gate.Note, "no alignment needed") {
+			t.Errorf("the check reports a missing alignment as a bump that needed none: %q", got.Gate.Note)
+		}
+		if !strings.Contains(got.Gate.Note, "missing") {
+			t.Errorf("note must say the alignment is missing, got %q", got.Gate.Note)
+		}
+		if !strings.Contains(got.Summary, "NOT on this branch") {
+			t.Errorf("the comment must state the alignment is absent:\n%s", got.Summary)
+		}
+		if !strings.Contains(got.Summary, "Re-run Vetty") {
+			t.Errorf("the comment must name the recovery, else the PR just sits red:\n%s", got.Summary)
+		}
+		// This case renders with an EMPTY align_summary, and `section()` emits
+		// nothing for an empty body. So the verdict message must not point at a
+		// section title to explain itself: a reader who cannot find what the
+		// comment cites doubts the HOLD rather than acting on it.
+		for _, title := range []string{"Code alignment", "Security & supply-chain", "Reliability"} {
+			if strings.Contains(got.Summary, `"`+title+`"`) && !strings.Contains(got.Summary, "## "+title) {
+				t.Errorf("the comment cites section %q, which it did not render:\n%s", title, got.Summary)
+			}
+		}
+	})
+
 	t.Run("committed: says so, in the badge and the check", func(t *testing.T) {
 		got, _ := run(t, "committed", "iterion/review", true)
 		if got.Gate == nil || !strings.Contains(got.Gate.Note, "alignment committed") {
@@ -160,6 +195,7 @@ func TestDepUpdateGuardGateVerdict(t *testing.T) {
 		{"hold_security", true},
 		{"hold_unstable", true},
 		{"needs_decision", true},
+		{"hold_lost_alignment", true},
 		// Not a verdict the graph can produce today. If one ever appears, the
 		// gate must refuse it rather than wave it through.
 		{"probably_fine", true},

--- a/bots/dep_update_guard_routing_test.go
+++ b/bots/dep_update_guard_routing_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/SocialGouv/iterion/pkg/dsl/expr"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/dsl/parser"
 )
@@ -60,8 +61,33 @@ func TestDepUpdateGuardVerdictRouting(t *testing.T) {
 		t.Errorf("did_commit trusts the commit agent's self-report: %q", decides)
 	}
 
-	// Both branches exist, each stamping the verdict that matches what it saw.
-	var sawCommitted, sawClean bool
+	// An unmoved head means "nothing to align" OR "the alignment vanished",
+	// and the shas cannot tell them apart. Separating them needs align's own
+	// claim, so the absence of that read is the whole defect — assert it is
+	// there, and that it is combined with the sha observation rather than
+	// replacing it.
+	var lost string
+	for _, e := range check.Exprs {
+		if e.Key == "alignment_lost" {
+			lost = e.Raw
+		}
+	}
+	if lost == "" {
+		t.Fatal("commit_check does not compute alignment_lost — a vanished alignment reads as a bump that needed none, and merges")
+	}
+	if !strings.Contains(lost, "outputs.align.applied") {
+		t.Errorf("alignment_lost does not read align's own claim, so it cannot detect a contradiction: %q", lost)
+	}
+	if !strings.Contains(lost, "outputs.commit.sha") || !strings.Contains(lost, "outputs.prepare.head_sha") {
+		t.Errorf("alignment_lost must be the CONTRADICTION between the claim and the shas, not the claim alone: %q", lost)
+	}
+
+	// The three branches exist, each stamping the verdict matching what it saw.
+	// `clean` is the else: it is the only one of the three that asserts a
+	// negative ("the bump needed nothing"), so it must be what is left when
+	// neither positive observation held — never a condition of its own that
+	// could match alongside them.
+	var sawCommitted, sawClean, sawLost bool
 	for _, e := range cr.Workflow.Edges {
 		if e.From != "commit_check" || e.To != "post_feedback" {
 			continue
@@ -73,15 +99,20 @@ func TestDepUpdateGuardVerdictRouting(t *testing.T) {
 			}
 		}
 		switch {
+		case e.Condition == "alignment_lost" && !e.Negated:
+			sawLost = true
+			if verdict != "hold_lost_alignment" {
+				t.Errorf("the alignment_lost branch stamps verdict %q, want \"hold_lost_alignment\"", verdict)
+			}
 		case e.Condition == "did_commit" && !e.Negated:
 			sawCommitted = true
 			if verdict != "committed" {
 				t.Errorf("the did_commit branch stamps verdict %q, want \"committed\"", verdict)
 			}
-		case e.Condition == "did_commit" && e.Negated:
+		case e.IsElse:
 			sawClean = true
 			if verdict != "clean" {
-				t.Errorf("the not-did_commit branch stamps verdict %q, want \"clean\"", verdict)
+				t.Errorf("the fallback branch stamps verdict %q, want \"clean\"", verdict)
 			}
 		}
 	}
@@ -90,5 +121,110 @@ func TestDepUpdateGuardVerdictRouting(t *testing.T) {
 	}
 	if !sawClean {
 		t.Error("no edge routes a no-op alignment to the clean verdict — every run would claim a commit")
+	}
+	if !sawLost {
+		t.Error("no edge routes a vanished alignment to hold_lost_alignment — it would be reported as a clean bump and merged")
+	}
+}
+
+// TestDepUpdateGuardLostAlignmentPredicate EVALUATES commit_check against the
+// four states it has to separate, instead of reading its source for the right
+// substrings. Grepping the expression proves the fields are mentioned; only
+// running it proves they combine into the right answer.
+//
+// The first case is SocialGouv/iterion#400 as it actually happened: `align`
+// wrote the otel WithEndpointURL fix, the run died on a provider usage window
+// before `commit`, the retry re-cloned the repo, and the alignment was gone.
+// The checkpoint still replayed applied=true, the shas still showed an unmoved
+// head — which is also exactly what a bump needing no alignment looks like.
+// The gate read the second meaning, went green, and the bump merged without
+// its fix.
+func TestDepUpdateGuardLostAlignmentPredicate(t *testing.T) {
+	src, err := os.ReadFile("dep-update-guard/main.bot")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	cr := ir.Compile(parser.Parse("dep-update-guard/main.bot", string(src)).File)
+	if cr.Workflow == nil {
+		t.Fatal("compile produced no Workflow")
+	}
+	check, ok := cr.Workflow.Nodes["commit_check"].(*ir.ComputeNode)
+	if !ok {
+		t.Fatalf("commit_check is %T, want a compute node", cr.Workflow.Nodes["commit_check"])
+	}
+
+	eval := func(t *testing.T, key string, applied bool, commitSHA, headSHA string) bool {
+		t.Helper()
+		outputs := map[string]map[string]any{
+			"align":   {"applied": applied},
+			"commit":  {"sha": commitSHA},
+			"prepare": {"head_sha": headSHA},
+		}
+		for _, e := range check.Exprs {
+			if e.Key != key {
+				continue
+			}
+			got, err := e.AST.EvalBool(&expr.Context{
+				Outputs: func(path []string) any {
+					if len(path) != 2 {
+						return nil
+					}
+					return outputs[path[0]][path[1]]
+				},
+			})
+			if err != nil {
+				t.Fatalf("eval %s: %v", key, err)
+			}
+			return got
+		}
+		t.Fatalf("commit_check has no %s expression", key)
+		return false
+	}
+
+	for _, tc := range []struct {
+		name       string
+		applied    bool
+		commitSHA  string
+		headSHA    string
+		wantLost   bool
+		wantCommit bool
+	}{
+		{
+			// iterion#400. The one the gate has to start catching.
+			name:    "align applied, head unmoved: the alignment vanished",
+			applied: true, commitSHA: "", headSHA: "ec2ff4b9e54e61f28f2cd43cd8281e18a5e0af0a",
+			wantLost: true, wantCommit: false,
+		},
+		{
+			// buildkit-operator#18: undici, security-only release, no
+			// consuming code. Same unmoved head, opposite meaning — this one
+			// is genuinely green and must stay mergeable.
+			name:    "align applied nothing, head unmoved: the bump needed no alignment",
+			applied: false, commitSHA: "", headSHA: "086571ac3a6a62f62947ee0f53201b43210ae6cb",
+			wantLost: false, wantCommit: false,
+		},
+		{
+			name:    "align applied and the head moved: committed",
+			applied: true, commitSHA: "aaaa111122223333444455556666777788889999", headSHA: "ec2ff4b9e54e61f28f2cd43cd8281e18a5e0af0a",
+			wantLost: false, wantCommit: true,
+		},
+		{
+			// The agent answering with HEAD's sha rather than "" is the same
+			// unmoved branch dressed as a commit. did_commit already compares
+			// the two shas for this reason; alignment_lost must inherit it
+			// rather than settle for a non-empty sha.
+			name:    "align applied, agent echoes the unchanged head sha",
+			applied: true, commitSHA: "ec2ff4b9e54e61f28f2cd43cd8281e18a5e0af0a", headSHA: "ec2ff4b9e54e61f28f2cd43cd8281e18a5e0af0a",
+			wantLost: true, wantCommit: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := eval(t, "alignment_lost", tc.applied, tc.commitSHA, tc.headSHA); got != tc.wantLost {
+				t.Errorf("alignment_lost = %v, want %v", got, tc.wantLost)
+			}
+			if got := eval(t, "did_commit", tc.applied, tc.commitSHA, tc.headSHA); got != tc.wantCommit {
+				t.Errorf("did_commit = %v, want %v", got, tc.wantCommit)
+			}
+		})
 	}
 }

--- a/docs/bot-runs/dep-update-guard.md
+++ b/docs/bot-runs/dep-update-guard.md
@@ -7,6 +7,84 @@ commit onto the PR branch, post the verdict comment. Never merges past a
 check — and only ever the commit it audited. See
 [bots/dep-update-guard/](../../bots/dep-update-guard/).
 
+## 2026-08-10/11 — the first Dependabot batch merged unattended, and the one that merged was the one to catch (run 019fecf3)
+
+- Status: **partial — the audit is production-grade, the verdict was not.**
+  Dependabot opened 11 PRs (#390–#400) at 18:26–18:33 UTC; one run each.
+  **#400 merged unattended at 21:04** (gate 20:50:18 → armed 20:50:23 → merge
+  queue 21:04:43). The other ten held RED and none merged: 8 `hold_unstable`,
+  2 `hold_security` (#393 TypeScript 7.0.2, #396 mongodb chart 16→19). Fail-
+  closed works. Same night, buildkit-operator **#18 (Renovate, undici
+  [security]) merged at 19:10** — 9s after the gate, no queue on that repo.
+  Renovate and Dependabot are now both proven, on both merge topologies.
+- Versions: Vetty 2.6.5 · iterion 3.36.1. Cost of run 019fecf3: **~$10.8**
+  (audit $2.24 + align $4.58 + verify_build $3.27 + commit $0.70).
+- **Value — the audit is the best this bot has produced.** On #400 (30 Go
+  modules) it found the decisive property nobody asked for: *this repo
+  vendors, so `go build -mod=vendor` never hash-checks `vendor/` and a clean
+  `go.sum` proves nothing*. It regenerated the vendor tree from checksum-
+  verified modules into a temp dir and diffed byte-for-byte. It caught a CVE
+  resolution absent from Dependabot's own table (grpc 1.81.1→1.83.0 clearing
+  GHSA-hrxh-6v49-42gf HIGH, transitive). It re-ran govulncheck under
+  `CGO_ENABLED=0` after a gcc failure "rather than report a hollow pass", and
+  refused to count 68 trivy hits confined to `e2e/fixtures/` — one of which is
+  the deliberate protestware detection fixture. On bko#18: npm trusted-
+  publisher OIDC with the *same* `oidcConfigId` across both versions (no
+  maintainer change — the classic compromise shape absent), SLSA provenance,
+  tarball sha512 vs lockfile integrity, byte-identical wasm blobs, and an
+  honest coverage-gap statement (trivy parsed 0 npm packages from
+  pnpm-lock.yaml, proven by a control run against the base — so trivy was NOT
+  counted as evidence).
+- **The defect: a lost alignment merged as a clean bump.** `align` (24 min,
+  $4.58) detected a real BREAKING change — otel 1.45's `WithEndpointURL` no
+  longer appends `/v1/traces` to a path-less endpoint — and wrote a
+  `withTracesPath` helper plus a regression test it verified red without the
+  fix. Then `commit` died on the forfait's session limit
+  (`USAGE_LIMIT_BLOCKED`), the retry resumed 24 min later, and **the runner
+  re-cloned**: `prepareRepoWorkspace` does `os.RemoveAll` + `git clone` on
+  every claim, and `executeRun` deletes the dir again on return. The
+  checkpoint restores node OUTPUTS, not files. The commit agent reported the
+  gap precisely in prose ("ACTION NEEDED: re-run alignment … spans silently
+  POST to /"), but `commit_check` read only the shas: unmoved head →
+  `did_commit=false` → verdict `clean` = "the bump needed no alignment" →
+  gate `success` → armed → merged. **The regression went to main.** Latent
+  only because no chart configures `OTEL_EXPORTER_OTLP_*`.
+- The irony worth keeping: the anti-façade rule that made `did_commit` read
+  shas instead of the agent's self-report is exactly what hid this. The truth
+  lived only in the agent's prose, and the graph does not read prose.
+- Engine + bot hardening (this change): `commit_check` now computes
+  `alignment_lost` = align claimed edits ∧ the head did not move, routed to a
+  fifth, BLOCKING verdict `hold_lost_alignment` (Vetty 2.7.0); the runner
+  emits `run_workspace_reset` when a repo-backed run re-executes (keyed on the
+  checkpoint, so a `running`-status redelivery counts too) so the discarded
+  tree stops being invisible.
+- **And the alignment itself was wrong** — found by the adversarial review of
+  this very fix, not by the run. Vetty's `withTracesPath` helper (which I
+  re-applied verbatim, so I repeated its mistake) re-implemented what the SDK
+  already does correctly: `otlpconfig.NewHTTPConfig` applies the env config
+  BEFORE explicit options, and it honours the OTLP spec's two DIFFERENT
+  endpoint semantics — `OTEL_EXPORTER_OTLP_ENDPOINT` is a base URL that gets
+  the signal path joined onto it, `…_TRACES_ENDPOINT` is used as-is. Passing
+  the resolved endpoint back through `WithEndpointURL` flattens both into one
+  reading; **that override was the bug's enabler, not its victim** (it is why
+  1.45's behaviour change reached us at all), and it left
+  `ENDPOINT=https://collector/otlp` POSTing to `/otlp` — the same silent loss
+  one level over. The real fix is to stop overriding. The premise Vetty
+  reasoned from was a false comment already in the file, claiming the SDK
+  honours only one of the two variables.
+- Lessons for next run: (1) a node that MUTATES the workspace and a node that
+  PERSISTS the mutation must not be separated by a resumable boundary without
+  a check that they agree — the gap between them is a pod restart wide;
+  (2) an agent's honest prose report is not a signal the graph can act on —
+  if it matters, it must reach a schema field a gate reads; (3) 8/10 PRs
+  landing on `hold_unstable` deserves its own look — fail-closed is correct
+  but a loop that holds everything delivers nothing; (4) **an aligner inherits
+  the consuming code's wrong assumptions** — Vetty read a comment asserting the
+  SDK ignored one of the two env vars, believed it, and wrote a fix around it.
+  It reproduced the file's existing false premise faithfully. Worth adding to
+  the align prompt: when a bump breaks a call site, check whether the call site
+  was right to exist.
+
 ## 2026-08-04/05 — the backlog majors + the Vite 8 alignment: capability proven, and the verify seam found its shape
 
 - Status: **capability validated; landing required four bot/engine fixes found

--- a/docs/persisted-formats.md
+++ b/docs/persisted-formats.md
@@ -148,7 +148,7 @@ emitter when a consumer needs an exact payload contract.
 
 | Family | Persisted event types |
 |---|---|
-| Run lifecycle/control | `run_started`, `run_paused`, `human_input_requested`, `human_answers_recorded`, `interaction_answered`, `run_resumed`, `run_auto_resumed`, `run_steered`, `run_health`, `run_finished`, `run_failed`, `run_cancelled`, `run_interrupted` |
+| Run lifecycle/control | `run_started`, `run_paused`, `human_input_requested`, `human_answers_recorded`, `interaction_answered`, `run_resumed`, `run_auto_resumed`, `run_retry_scheduled`, `run_workspace_reset`, `run_steered`, `run_health`, `run_finished`, `run_failed`, `run_cancelled`, `run_interrupted` |
 | Graph/budget/artifacts | `branch_started`, `branch_finished`, `branch_abandoned`, `node_started`, `node_recovery`, `node_verified_action`, `node_finished`, `edge_selected`, `join_ready`, `budget_warning`, `budget_exceeded`, `artifact_written`, `plan_written` |
 | LLM, delegation, and tools | `llm_request`, `llm_prompt`, `llm_retry`, `llm_step_finished`, `assistant_text`, `llm_compacted`, `tool_started`, `tool_called`, `tool_error`, `delegate_started`, `delegate_finished`, `delegate_error`, `delegate_retry`, `model_fallback` |
 | Review gate | `review_turn`, `review_verdict`, `review_merged` |

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -84,6 +84,31 @@ Treat restartable node effects as at-least-once: a node may run again. Tool
 commands should be idempotent or detect already-completed work, and coding
 agents should inspect the durable Git history before repeating an item.
 
+### The checkpoint restores outputs, not files
+
+A cloud run bound to a repository (`RepoURL` on the queue message) gets its
+workspace from a clone the runner makes on **every claim**: it `RemoveAll`s the
+per-run directory before cloning, and deletes it again when the run returns. A
+resume therefore starts from a pristine checkout of the run's ref — **anything
+an earlier node edited but did not commit is gone**, and the resume is normally
+claimed by a different pod anyway.
+
+The checkpoint still replays that node's *outputs*. So a downstream node reads
+"the previous node changed these files" against a tree where they no longer
+exist, and the two disagree with nothing failing. A re-executing run emits
+`run_workspace_reset` so the discarded tree is visible on the timeline —
+keyed on the checkpoint's existence rather than on the delivery being shaped
+as a resume, since a redelivery of a run still marked `running` re-clones the
+same way.
+
+The consequence for authoring: **do not separate a node that mutates the
+workspace from the node that persists the mutation by a resumable boundary
+unless something checks the two still agree.** Either commit inside the
+mutating node, or have the persisting step verify against the tree rather than
+against the upstream node's claim (`dep-update-guard`'s `commit_check` is the
+worked example — it compares `align.applied` with the branch head and blocks on
+a contradiction). Git is the durable state; an uncommitted working tree is not.
+
 ## Source integrity and bundles
 
 The launch stores a SHA-256 workflow hash. Resume recompiles the source and

--- a/docs/workflow_authoring_pitfalls.md
+++ b/docs/workflow_authoring_pitfalls.md
@@ -282,6 +282,27 @@ been seen red is a test whose sensitivity is unmeasured.
    metrics, the metrics are wrong.** Don't relax the goal to fit the
    output; sharpen the metrics and re-run.
 
+6. **Never separate the node that MUTATES the workspace from the node
+   that PERSISTS the mutation by a resumable boundary.** A cloud run
+   re-clones its repo on every claim, so a failure between the two —
+   a provider usage window is the ordinary way — resumes on a pristine
+   tree while the checkpoint faithfully replays the mutating node's
+   outputs. The persisting node then reports "nothing to commit", which
+   is indistinguishable from "there was nothing to do", and every
+   downstream verdict states the benign meaning. Either commit inside
+   the mutating node, or make the persisting step reconcile the upstream
+   CLAIM against the tree and treat a contradiction as blocking. Cost of
+   learning this: iterion#400 merged a dependency bump without the
+   breaking-change fix its own aligner had written
+   ([dep-update-guard bilan](bot-runs/dep-update-guard.md), 2026-08-10).
+
+7. **An agent's honest prose is not a signal the graph can act on.** In
+   that same run the commit agent described the missing alignment
+   exactly, and named the recovery — in the comment body. The gate reads
+   a schema field, so the PR merged green anyway. If a discovery has to
+   change an outcome, it must land in a typed output a deterministic
+   node reads; prose is for the human who arrives afterwards.
+
 ---
 
 ## Cross-checked rules from convergent methodologies (IACDM / AI-DLC 2026)

--- a/pkg/cloud/tracing/tracing.go
+++ b/pkg/cloud/tracing/tracing.go
@@ -58,15 +58,26 @@ func Init(ctx context.Context, serviceName string, logger *iterlog.Logger) (func
 		return func(context.Context) error { return nil }, nil
 	}
 
-	// Pass the resolved endpoint explicitly. Without this, the OTLP
-	// client only honours OTEL_EXPORTER_OTLP_ENDPOINT — so an
-	// operator who set the spec-canonical
-	// OTEL_EXPORTER_OTLP_TRACES_ENDPOINT (which we *do* check above
-	// for the guard) would silently send spans nowhere.
+	// Leave a URL-shaped endpoint to the SDK. Its own env parsing already
+	// implements the OTLP spec's TWO distinct endpoint semantics, and
+	// otlpconfig.NewHTTPConfig applies it BEFORE any explicit option:
+	//
+	//   - OTEL_EXPORTER_OTLP_ENDPOINT is a BASE url, so the signal path is
+	//     joined onto whatever path it carries (…/otlp → /otlp/v1/traces);
+	//   - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is used as-is (root path when
+	//     it carries none).
+	//
+	// Handing the resolved endpoint back through WithEndpointURL replaces
+	// both with one flattened reading, and that is what made the otel 1.45
+	// bump lose every span: 1.44 left a path-less URL's URLPath empty for
+	// cleanPath to fill, 1.45 pins it to "/". The env path was correct on
+	// both versions — the override was the bug's enabler, not its victim.
+	//
+	// The scheme-less `host:port` form is the exception: url.Parse yields no
+	// Host for it, so the env reader resolves an empty endpoint. WithEndpoint
+	// is what makes that shape work at all.
 	clientOpts := []otlptracehttp.Option{}
-	if strings.Contains(endpoint, "://") {
-		clientOpts = append(clientOpts, otlptracehttp.WithEndpointURL(endpoint))
-	} else {
+	if !strings.Contains(endpoint, "://") {
 		clientOpts = append(clientOpts, otlptracehttp.WithEndpoint(endpoint))
 	}
 	exp, err := otlptrace.New(ctx, otlptracehttp.NewClient(clientOpts...))

--- a/pkg/cloud/tracing/tracing.go
+++ b/pkg/cloud/tracing/tracing.go
@@ -75,10 +75,19 @@ func Init(ctx context.Context, serviceName string, logger *iterlog.Logger) (func
 	//
 	// The scheme-less `host:port` form is the exception: url.Parse yields no
 	// Host for it, so the env reader resolves an empty endpoint. WithEndpoint
-	// is what makes that shape work at all.
+	// is what makes that shape work at all — but it sets ONLY the host, and
+	// the env reader has meanwhile applied the per-signal variable's "no path
+	// part means the root path" rule to a value whose path it could not see,
+	// pinning URLPath to "/". cleanPath does not replace a non-empty path, so
+	// the signal path has to be restated. Nothing is lost by doing so: for
+	// this shape everything after the colon is opaque to url.Parse, so there
+	// is no operator-supplied path to preserve.
 	clientOpts := []otlptracehttp.Option{}
 	if !strings.Contains(endpoint, "://") {
-		clientOpts = append(clientOpts, otlptracehttp.WithEndpoint(endpoint))
+		clientOpts = append(clientOpts,
+			otlptracehttp.WithEndpoint(endpoint),
+			otlptracehttp.WithURLPath(defaultTracesPath),
+		)
 	}
 	exp, err := otlptrace.New(ctx, otlptracehttp.NewClient(clientOpts...))
 	if err != nil {
@@ -113,6 +122,10 @@ func Init(ctx context.Context, serviceName string, logger *iterlog.Logger) (func
 	}
 	return tp.Shutdown, nil
 }
+
+// defaultTracesPath mirrors the OTLP/HTTP spec's traces signal path, which the
+// exporter also uses as its own default.
+const defaultTracesPath = "/v1/traces"
 
 // envSampler reads OTEL_TRACES_SAMPLER / OTEL_TRACES_SAMPLER_ARG and
 // returns the matching tracesdk.Sampler. Falls back to parent-based

--- a/pkg/cloud/tracing/tracing_test.go
+++ b/pkg/cloud/tracing/tracing_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"go.opentelemetry.io/otel"
@@ -131,6 +132,7 @@ func TestInit_exportPath(t *testing.T) {
 		base     string // OTEL_EXPORTER_OTLP_ENDPOINT, "" = unset
 		signal   string // OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, "" = unset
 		suffix   string // appended to the test server URL
+		insecure bool   // OTEL_EXPORTER_OTLP_INSECURE, for the scheme-less shapes
 		wantPath string
 	}{
 		// The #400 regression, and the shape most operators write.
@@ -145,6 +147,23 @@ func TestInit_exportPath(t *testing.T) {
 		{name: "per-signal endpoint with a path", signal: "{srv}", suffix: "/v1/traces", wantPath: "/v1/traces"},
 		// Precedence: the per-signal variable wins over the base one.
 		{name: "per-signal wins over base", base: "http://127.0.0.1:1/wrong", signal: "{srv}", suffix: "/chosen", wantPath: "/chosen"},
+		// The scheme-less `host:port` shape. url.Parse gives it no Host, so
+		// the env reader resolves an EMPTY endpoint and WithEndpoint is what
+		// makes the shape work at all — but WithEndpoint sets only the host.
+		// For the per-signal variable the env reader has meanwhile applied its
+		// "no path part means the root path" rule to a value whose path it
+		// could not see, pinning URLPath to "/"; cleanPath will not replace a
+		// non-empty path. Left alone this lands on the collector root — the
+		// same silent loss, one shape over. There is no path to preserve here
+		// (everything after the colon is opaque to url.Parse), so the signal
+		// path is restated explicitly.
+		//
+		// These two run insecure: any scheme-less value parses as a scheme the
+		// SDK does not recognise, which it treats as TLS. That is the SDK's
+		// documented default for WithEndpoint and not what is under test, so
+		// the spec's own INSECURE toggle takes it out of the way.
+		{name: "base endpoint, host:port", base: "{host}", insecure: true, wantPath: "/v1/traces"},
+		{name: "per-signal endpoint, host:port", signal: "{host}", insecure: true, wantPath: "/v1/traces"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			paths := make(chan string, 4)
@@ -158,13 +177,29 @@ func TestInit_exportPath(t *testing.T) {
 			defer srv.Close()
 
 			subst := func(v string) string {
-				if v == "{srv}" {
+				switch v {
+				case "{srv}":
 					return srv.URL + tc.suffix
+				case "{host}":
+					// A NAME, not the listener's IP: url.Parse rejects
+					// "127.0.0.1:4318" outright ("first path segment cannot
+					// contain colon"), which makes the env reader skip and
+					// hides the very behaviour under test. "localhost:4318"
+					// parses — as scheme "localhost" — and is the shape an
+					// operator actually writes.
+					u, err := url.Parse(srv.URL)
+					if err != nil {
+						t.Fatalf("parse test server URL: %v", err)
+					}
+					return "localhost:" + u.Port() + tc.suffix
 				}
 				return v
 			}
 			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", subst(tc.base))
 			t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", subst(tc.signal))
+			if tc.insecure {
+				t.Setenv("OTEL_EXPORTER_OTLP_INSECURE", "true")
+			}
 
 			ctx := context.Background()
 			shutdown, err := Init(ctx, "iterion-test", nil)

--- a/pkg/cloud/tracing/tracing_test.go
+++ b/pkg/cloud/tracing/tracing_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"go.opentelemetry.io/otel"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -104,6 +105,89 @@ func TestInit_withFakeEndpoint_buildsTracerProvider(t *testing.T) {
 	}
 	if err := shutdown(context.Background()); err != nil {
 		t.Errorf("shutdown: %v", err)
+	}
+}
+
+// TestInit_exportPath asserts the path the exporter actually PUTS ON THE WIRE
+// for each endpoint shape the OTLP spec defines. That path is the only
+// observable that moves: every one of these configurations compiles, connects,
+// and looks healthy while silently POSTing spans somewhere no collector serves.
+//
+// The spec gives the two env vars DIFFERENT semantics
+// (https://opentelemetry.io/docs/specs/otel/protocol/exporter/):
+// OTEL_EXPORTER_OTLP_ENDPOINT is a base URL and the signal path is joined onto
+// it; OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is used as-is, with the root path when
+// it carries none. The SDK's env reader implements both. Init must therefore
+// NOT hand the resolved endpoint back through WithEndpointURL — explicit
+// options are applied after the env config and would flatten the two readings
+// into one.
+//
+// That flattening is what the otel 1.44 → 1.45 bump turned into span loss:
+// 1.44 left a path-less URL's URLPath empty for cleanPath to fill with the
+// default, 1.45 pins it to "/". Case 1 below is that regression.
+func TestInit_exportPath(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		base     string // OTEL_EXPORTER_OTLP_ENDPOINT, "" = unset
+		signal   string // OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, "" = unset
+		suffix   string // appended to the test server URL
+		wantPath string
+	}{
+		// The #400 regression, and the shape most operators write.
+		{name: "base endpoint, no path", base: "{srv}", wantPath: "/v1/traces"},
+		// A collector behind a reverse-proxy prefix. The signal path is
+		// joined onto the operator's prefix — dropping it POSTs to the
+		// prefix itself, which is the same silent loss one level over.
+		{name: "base endpoint with a prefix", base: "{srv}", suffix: "/otlp", wantPath: "/otlp/v1/traces"},
+		// Per-signal: used as-is. No path means the ROOT path, not the
+		// default signal path — "as-is" is the whole point of the variable.
+		{name: "per-signal endpoint, no path", signal: "{srv}", wantPath: "/"},
+		{name: "per-signal endpoint with a path", signal: "{srv}", suffix: "/v1/traces", wantPath: "/v1/traces"},
+		// Precedence: the per-signal variable wins over the base one.
+		{name: "per-signal wins over base", base: "http://127.0.0.1:1/wrong", signal: "{srv}", suffix: "/chosen", wantPath: "/chosen"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			paths := make(chan string, 4)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				select {
+				case paths <- r.URL.Path:
+				default:
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer srv.Close()
+
+			subst := func(v string) string {
+				if v == "{srv}" {
+					return srv.URL + tc.suffix
+				}
+				return v
+			}
+			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", subst(tc.base))
+			t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", subst(tc.signal))
+
+			ctx := context.Background()
+			shutdown, err := Init(ctx, "iterion-test", nil)
+			if err != nil {
+				t.Fatalf("Init: %v", err)
+			}
+			_, span := otel.Tracer("tracing-test").Start(ctx, "probe")
+			span.End()
+			// Shutdown flushes the batcher, so the export completes before
+			// we read — no polling, no sleep, no flake.
+			if err := shutdown(ctx); err != nil {
+				t.Fatalf("shutdown: %v", err)
+			}
+
+			select {
+			case got := <-paths:
+				if got != tc.wantPath {
+					t.Errorf("exporter POSTed to %q, want %q — spans go to a path the collector does not serve", got, tc.wantPath)
+				}
+			default:
+				t.Fatal("the collector received no export at all")
+			}
+		})
 	}
 }
 

--- a/pkg/runner/loop_gitws.go
+++ b/pkg/runner/loop_gitws.go
@@ -77,6 +77,53 @@ func (r *Runner) recordRunGitMeta(ctx context.Context, msg *queue.RunMessage, wo
 	}
 }
 
+// isReExecution reports whether this run has already executed nodes, so the
+// clone about to replace the workspace is discarding their uncommitted output.
+//
+// `msg.Resume` catches the ordinary resume publishes but not all re-executions:
+// a JetStream redelivery of a run still marked `running` — a pod that died
+// inside the orphan sweeper's window — re-clones with Resume nil. The
+// checkpoint is the fact that does not depend on how the delivery was shaped:
+// it exists if and only if a node boundary was already crossed.
+func (r *Runner) isReExecution(ctx context.Context, msg *queue.RunMessage) bool {
+	if msg.Resume != nil {
+		return true
+	}
+	run, err := r.cfg.Store.LoadRun(ctx, msg.RunID)
+	if err != nil {
+		// Say so rather than let "could not tell" read as "first attempt":
+		// silence here is the exact failure this marker exists to end.
+		r.cfg.Logger.Warn("runner: run %s: could not read the run to tell a first claim from a re-execution (%v) — not recording a workspace reset", msg.RunID, err)
+		return false
+	}
+	return run != nil && run.Checkpoint != nil
+}
+
+// recordWorkspaceReset puts the fresh-clone fact on a re-executing run's
+// timeline.
+//
+// It is observational, so a store that refuses the append must not sink the
+// run — but it is NOT decorative: it is the only trace that a node's
+// uncommitted output was discarded between two attempts, and a bot whose
+// contract is "node A edits, node B commits" reads exactly the same on both
+// sides of it unless something says otherwise. The pod log therefore carries
+// it too, and carries it FIRST: the append is precisely what fails when the
+// timeline is going to be missing the fact.
+func (r *Runner) recordWorkspaceReset(ctx context.Context, msg *queue.RunMessage) {
+	r.cfg.Logger.Warn("runner: run %s re-executing on a FRESH clone of %s — any file an earlier node edited but did not commit is gone (node outputs are restored from the checkpoint, the working tree is not)",
+		msg.RunID, strutil.FirstNonBlank(msg.RepoSHA, msg.RepoURL))
+	if _, err := r.cfg.Store.AppendEvent(ctx, msg.RunID, store.Event{
+		Type: store.EventRunWorkspaceReset,
+		Data: map[string]any{
+			"reason":   "resume",
+			"repo_url": msg.RepoURL,
+			"repo_sha": msg.RepoSHA,
+		},
+	}); err != nil {
+		r.cfg.Logger.Warn("runner: run %s: could not emit run_workspace_reset: %v", msg.RunID, err)
+	}
+}
+
 // prepareRepoWorkspace clones the run's RepoURL@RepoSHA into a fresh per-run
 // directory and returns its path. For a private repo it authenticates the
 // HTTPS clone with the bound forge token (forge_token / gitlab_token /
@@ -140,6 +187,15 @@ func (r *Runner) prepareRepoWorkspace(ctx context.Context, msg *queue.RunMessage
 	dir := filepath.Join(r.cfg.WorkDir, "repos", msg.RunID)
 	if err := os.RemoveAll(dir); err != nil {
 		return "", fmt.Errorf("clean repo dir: %w", err)
+	}
+	// A re-execution never inherits the previous attempt's tree: executeRun
+	// deletes this directory when the run returns, and the next claim is
+	// normally another pod anyway. The checkpoint restores node OUTPUTS, so a
+	// downstream node keeps reading "the previous node edited these files"
+	// against a tree where those edits no longer exist. That divergence used
+	// to be entirely silent — record it on the timeline.
+	if r.isReExecution(ctx, msg) {
+		r.recordWorkspaceReset(ctx, msg)
 	}
 	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
 		return "", fmt.Errorf("mkdir repo parent: %w", err)

--- a/pkg/runner/loop_gitws.go
+++ b/pkg/runner/loop_gitws.go
@@ -77,26 +77,32 @@ func (r *Runner) recordRunGitMeta(ctx context.Context, msg *queue.RunMessage, wo
 	}
 }
 
-// isReExecution reports whether this run has already executed nodes, so the
-// clone about to replace the workspace is discarding their uncommitted output.
+// reExecutionReason names why this claim is a re-execution — so the clone
+// about to replace the workspace is discarding an earlier node's uncommitted
+// output — or returns "" for a genuine first attempt, which has nothing to
+// lose.
 //
-// `msg.Resume` catches the ordinary resume publishes but not all re-executions:
-// a JetStream redelivery of a run still marked `running` — a pod that died
-// inside the orphan sweeper's window — re-clones with Resume nil. The
-// checkpoint is the fact that does not depend on how the delivery was shaped:
-// it exists if and only if a node boundary was already crossed.
-func (r *Runner) isReExecution(ctx context.Context, msg *queue.RunMessage) bool {
+// The two reasons are distinct facts and the marker carries whichever applies.
+// `msg.Resume` is the ordinary resume publish; it does not cover every
+// re-execution, since a JetStream redelivery of a run still marked `running` —
+// a pod that died inside the orphan sweeper's window — re-clones with Resume
+// nil. The checkpoint is the fact that does not depend on how the delivery was
+// shaped: it exists if and only if a node boundary was already crossed.
+func (r *Runner) reExecutionReason(ctx context.Context, msg *queue.RunMessage) string {
 	if msg.Resume != nil {
-		return true
+		return "resume"
 	}
 	run, err := r.cfg.Store.LoadRun(ctx, msg.RunID)
 	if err != nil {
 		// Say so rather than let "could not tell" read as "first attempt":
 		// silence here is the exact failure this marker exists to end.
 		r.cfg.Logger.Warn("runner: run %s: could not read the run to tell a first claim from a re-execution (%v) — not recording a workspace reset", msg.RunID, err)
-		return false
+		return ""
 	}
-	return run != nil && run.Checkpoint != nil
+	if run != nil && run.Checkpoint != nil {
+		return "redelivery"
+	}
+	return ""
 }
 
 // recordWorkspaceReset puts the fresh-clone fact on a re-executing run's
@@ -109,13 +115,13 @@ func (r *Runner) isReExecution(ctx context.Context, msg *queue.RunMessage) bool 
 // sides of it unless something says otherwise. The pod log therefore carries
 // it too, and carries it FIRST: the append is precisely what fails when the
 // timeline is going to be missing the fact.
-func (r *Runner) recordWorkspaceReset(ctx context.Context, msg *queue.RunMessage) {
-	r.cfg.Logger.Warn("runner: run %s re-executing on a FRESH clone of %s — any file an earlier node edited but did not commit is gone (node outputs are restored from the checkpoint, the working tree is not)",
-		msg.RunID, strutil.FirstNonBlank(msg.RepoSHA, msg.RepoURL))
+func (r *Runner) recordWorkspaceReset(ctx context.Context, msg *queue.RunMessage, reason string) {
+	r.cfg.Logger.Warn("runner: run %s re-executing (%s) on a FRESH clone of %s — any file an earlier node edited but did not commit is gone (node outputs are restored from the checkpoint, the working tree is not)",
+		msg.RunID, reason, strutil.FirstNonBlank(msg.RepoSHA, msg.RepoURL))
 	if _, err := r.cfg.Store.AppendEvent(ctx, msg.RunID, store.Event{
 		Type: store.EventRunWorkspaceReset,
 		Data: map[string]any{
-			"reason":   "resume",
+			"reason":   reason,
 			"repo_url": msg.RepoURL,
 			"repo_sha": msg.RepoSHA,
 		},
@@ -194,8 +200,8 @@ func (r *Runner) prepareRepoWorkspace(ctx context.Context, msg *queue.RunMessage
 	// downstream node keeps reading "the previous node edited these files"
 	// against a tree where those edits no longer exist. That divergence used
 	// to be entirely silent — record it on the timeline.
-	if r.isReExecution(ctx, msg) {
-		r.recordWorkspaceReset(ctx, msg)
+	if reason := r.reExecutionReason(ctx, msg); reason != "" {
+		r.recordWorkspaceReset(ctx, msg, reason)
 	}
 	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
 		return "", fmt.Errorf("mkdir repo parent: %w", err)

--- a/pkg/runner/workspace_reset_test.go
+++ b/pkg/runner/workspace_reset_test.go
@@ -1,0 +1,150 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// TestRecordWorkspaceReset pins the timeline marker for the one state a
+// re-executing repo-backed run cannot recover: its working tree.
+//
+// prepareRepoWorkspace deletes and re-clones the per-run repo dir on every
+// claim, and executeRun deletes it again when the run returns. So a run that
+// dies between two nodes comes back on a tree that kept nothing — while the
+// checkpoint faithfully replays the earlier node's outputs. A downstream node
+// then reads "the previous node edited these files" against a tree where they
+// no longer exist, and used to have no way to know.
+//
+// That happened on SocialGouv/iterion#400: Vetty's `align` node wrote an otel
+// fix, the run hit a provider usage window, the retry re-cloned, and the fix
+// was gone. Nothing anywhere said so.
+func TestRecordWorkspaceReset(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	r := &Runner{cfg: Config{Store: st, Logger: iterlog.Nop()}}
+	msg := &queue.RunMessage{
+		RunID:   "019fecf3-bdd4-70ef-8445-9bfba275f6c4",
+		RepoURL: "https://github.com/SocialGouv/iterion",
+		RepoSHA: "ec2ff4b9e54e61f28f2cd43cd8281e18a5e0af0a",
+	}
+
+	r.recordWorkspaceReset(context.Background(), msg)
+
+	events, err := st.LoadEvents(context.Background(), msg.RunID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	var found *store.Event
+	for i := range events {
+		if events[i].Type == store.EventRunWorkspaceReset {
+			found = events[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("no %s event on the timeline: a discarded working tree stays invisible", store.EventRunWorkspaceReset)
+	}
+	if got := found.Data["reason"]; got != "resume" {
+		t.Errorf("reason = %v, want \"resume\"", got)
+	}
+	// The ref matters: it is what the tree was re-anchored on, so it is how an
+	// operator tells "re-cloned at the same head" from "re-cloned at a head
+	// that moved under the run".
+	if got := found.Data["repo_sha"]; got != msg.RepoSHA {
+		t.Errorf("repo_sha = %v, want %q", got, msg.RepoSHA)
+	}
+}
+
+// failingAppend is a store whose event append always fails. Everything else is
+// the embedded real store, so only the one call under test degrades.
+type failingAppend struct {
+	store.RunStore
+}
+
+func (failingAppend) AppendEvent(context.Context, string, store.Event) (*store.Event, error) {
+	return nil, errors.New("mongo: connection refused")
+}
+
+// A store that refuses the append must not sink the run — the marker is
+// observational, and the run is already committed to re-executing.
+//
+// But "not fatal" must not mean "not reported": the append failing is EXACTLY
+// the case where the timeline will lack the fact, so the pod log has to carry
+// it. This asserts both lines, because a version that swallowed one would
+// otherwise pass while leaving the loss as invisible as before the fix.
+func TestRecordWorkspaceReset_storeFailureStillReportsToTheLog(t *testing.T) {
+	real, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	var logged strings.Builder
+	r := &Runner{cfg: Config{
+		Store:  failingAppend{RunStore: real},
+		Logger: iterlog.New(iterlog.LevelWarn, &logged),
+	}}
+
+	r.recordWorkspaceReset(context.Background(), &queue.RunMessage{
+		RunID:   "run-1",
+		RepoSHA: "ec2ff4b9e54e61f28f2cd43cd8281e18a5e0af0a",
+	})
+
+	out := logged.String()
+	for _, want := range []string{
+		"FRESH clone",                              // the fact itself
+		"could not emit run_workspace_reset",       // and that the timeline will not have it
+		"ec2ff4b9e54e61f28f2cd43cd8281e18a5e0af0a", // anchored on something identifiable
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log does not carry %q — the loss is silent again:\n%s", want, out)
+		}
+	}
+}
+
+// TestIsReExecution covers the predicate that decides whether the marker is
+// warranted. A first claim has nothing to lose; every later one does.
+//
+// The `running` case is the one `msg.Resume != nil` alone gets wrong: a
+// JetStream redelivery of a run whose pod died inside the orphan sweeper's
+// window arrives with Resume nil, re-clones all the same, and would have
+// discarded an earlier node's work with no marker at all.
+func TestIsReExecution(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		resume     *queue.ResumeSpec
+		checkpoint *store.Checkpoint
+		want       bool
+	}{
+		{name: "first claim: nothing has run yet", want: false},
+		{name: "explicit resume publish", resume: &queue.ResumeSpec{}, want: true},
+		{name: "redelivery with a checkpoint, no resume spec", checkpoint: &store.Checkpoint{NodeID: "commit"}, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st, err := store.New(t.TempDir())
+			if err != nil {
+				t.Fatalf("store.New: %v", err)
+			}
+			ctx := context.Background()
+			run, err := st.CreateRun(ctx, "run-1", "dep_update_guard", nil)
+			if err != nil {
+				t.Fatalf("CreateRun: %v", err)
+			}
+			if tc.checkpoint != nil {
+				if err := st.SaveCheckpoint(ctx, run.ID, tc.checkpoint); err != nil {
+					t.Fatalf("SaveCheckpoint: %v", err)
+				}
+			}
+			r := &Runner{cfg: Config{Store: st, Logger: iterlog.Nop()}}
+			got := r.isReExecution(ctx, &queue.RunMessage{RunID: run.ID, Resume: tc.resume})
+			if got != tc.want {
+				t.Errorf("isReExecution = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/runner/workspace_reset_test.go
+++ b/pkg/runner/workspace_reset_test.go
@@ -36,7 +36,7 @@ func TestRecordWorkspaceReset(t *testing.T) {
 		RepoSHA: "ec2ff4b9e54e61f28f2cd43cd8281e18a5e0af0a",
 	}
 
-	r.recordWorkspaceReset(context.Background(), msg)
+	r.recordWorkspaceReset(context.Background(), msg, "resume")
 
 	events, err := st.LoadEvents(context.Background(), msg.RunID)
 	if err != nil {
@@ -93,7 +93,7 @@ func TestRecordWorkspaceReset_storeFailureStillReportsToTheLog(t *testing.T) {
 	r.recordWorkspaceReset(context.Background(), &queue.RunMessage{
 		RunID:   "run-1",
 		RepoSHA: "ec2ff4b9e54e61f28f2cd43cd8281e18a5e0af0a",
-	})
+	}, "resume")
 
 	out := logged.String()
 	for _, want := range []string{
@@ -107,23 +107,23 @@ func TestRecordWorkspaceReset_storeFailureStillReportsToTheLog(t *testing.T) {
 	}
 }
 
-// TestIsReExecution covers the predicate that decides whether the marker is
-// warranted. A first claim has nothing to lose; every later one does.
+// TestReExecutionReason covers the predicate that decides whether the marker is
+// warranted, and which fact it names. A first claim has nothing to lose; every later one does.
 //
 // The `running` case is the one `msg.Resume != nil` alone gets wrong: a
 // JetStream redelivery of a run whose pod died inside the orphan sweeper's
 // window arrives with Resume nil, re-clones all the same, and would have
 // discarded an earlier node's work with no marker at all.
-func TestIsReExecution(t *testing.T) {
+func TestReExecutionReason(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
 		resume     *queue.ResumeSpec
 		checkpoint *store.Checkpoint
-		want       bool
+		want       string
 	}{
-		{name: "first claim: nothing has run yet", want: false},
-		{name: "explicit resume publish", resume: &queue.ResumeSpec{}, want: true},
-		{name: "redelivery with a checkpoint, no resume spec", checkpoint: &store.Checkpoint{NodeID: "commit"}, want: true},
+		{name: "first claim: nothing has run yet", want: ""},
+		{name: "explicit resume publish", resume: &queue.ResumeSpec{}, want: "resume"},
+		{name: "redelivery with a checkpoint, no resume spec", checkpoint: &store.Checkpoint{NodeID: "commit"}, want: "redelivery"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			st, err := store.New(t.TempDir())
@@ -141,9 +141,9 @@ func TestIsReExecution(t *testing.T) {
 				}
 			}
 			r := &Runner{cfg: Config{Store: st, Logger: iterlog.Nop()}}
-			got := r.isReExecution(ctx, &queue.RunMessage{RunID: run.ID, Resume: tc.resume})
+			got := r.reExecutionReason(ctx, &queue.RunMessage{RunID: run.ID, Resume: tc.resume})
 			if got != tc.want {
-				t.Errorf("isReExecution = %v, want %v", got, tc.want)
+				t.Errorf("reExecutionReason = %q, want %q — a marker that mislabels which fact it saw is worse than none", got, tc.want)
 			}
 		})
 	}

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -124,7 +124,8 @@ const (
 	// otherwise discard the work unannounced. Emitted once per claim, so N
 	// markers mean N delivery attempts — matching EventRunResumed, which the
 	// engine also emits per attempt. Data:
-	//   - reason: why the workspace is fresh ("resume")
+	//   - reason: which fact made this a re-execution — "resume" (an explicit
+	//     resume publish) or "redelivery" (a checkpoint with no resume spec)
 	//   - repo_url / repo_sha: what the clone was re-anchored on
 	EventRunWorkspaceReset EventType = "run_workspace_reset"
 	// EventRunRewound marks an in-place rewind: the operator re-anchored

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -109,6 +109,24 @@ const (
 	//     "runtime_code+parsed_text", "…+blind_wait") — the degraded
 	//     paths must be visible, not silent
 	EventRunRetryScheduled EventType = "run_retry_scheduled"
+	// EventRunWorkspaceReset marks a repo-backed run RE-EXECUTING from a
+	// FRESH clone. The runner deletes the per-run repo dir when a run
+	// returns and re-clones on every claim, so a second attempt never
+	// inherits the first one's working tree: whatever an earlier node edited
+	// but did not commit is gone. The checkpoint restores node OUTPUTS, so a
+	// downstream node still reads "the alignment was applied" while the
+	// files that carried it no longer exist — a divergence that is otherwise
+	// completely silent.
+	//
+	// Keyed on the checkpoint existing, not on the delivery carrying a resume
+	// spec: a redelivery of a run still marked `running` (a pod that died
+	// inside the orphan sweeper's window) re-clones the same way and would
+	// otherwise discard the work unannounced. Emitted once per claim, so N
+	// markers mean N delivery attempts — matching EventRunResumed, which the
+	// engine also emits per attempt. Data:
+	//   - reason: why the workspace is fresh ("resume")
+	//   - repo_url / repo_sha: what the clone was re-anchored on
+	EventRunWorkspaceReset EventType = "run_workspace_reset"
 	// EventRunRewound marks an in-place rewind: the operator re-anchored
 	// THIS run's checkpoint on an already-executed node and invalidated
 	// the outputs downstream of it, so the next resume re-executes from

--- a/studio/src/api/runs/events.ts
+++ b/studio/src/api/runs/events.ts
@@ -402,6 +402,7 @@ export type PassthroughEventType =
   | "run_steered"
   | "run_health"
   | "run_auto_resumed"
+  | "run_workspace_reset"
   | "review_turn"
   | "review_verdict"
   | "review_merged"


### PR DESCRIPTION
PR #400 merged unattended last night with a silent runtime regression on board. The supply-chain audit was excellent; the verdict was wrong. This closes the class, not just the instance.

## What happened

Vetty's `align` node detected a real breaking change in the otel 1.45 bump (`WithEndpointURL` no longer appends `/v1/traces` to a path-less endpoint), wrote the fix and a regression test it verified red without it. Then `commit` died on a provider usage window. The retry resumed 24 min later, **the runner re-cloned the repo**, and the alignment was gone.

`commit_check` read the shas alone: unmoved head → `did_commit=false` → verdict `clean` = *"the bump needed no alignment"* → gate `success` → armed → merged. The commit agent had reported the gap precisely — in prose, in the comment body. The graph does not read prose.

## Three fixes

**1. `commit_check` no longer conflates two opposite states.** An unmoved head means "nothing to align" *or* "the alignment vanished"; the shas cannot separate them. It now reads `align.applied` alongside them — not to trust the agent (the sha comparison still decides what was *committed*), but so a claim the branch contradicts blocks. New verdict `hold_lost_alignment`: blocking in the gate table, refused by `arm_automerge`. Vetty 2.7.0.

**2. The runner records the tree it throws away.** `prepareRepoWorkspace` `RemoveAll`s + re-clones on every claim and `executeRun` deletes the dir on return, so a second attempt never inherits the first one's working tree — while the checkpoint faithfully replays its outputs. `run_workspace_reset` now marks it, keyed on the **checkpoint** rather than on the delivery carrying a resume spec (a redelivery of a run still marked `running` re-clones the same way). Restoring the tree across pods is separate work; this ends the silence.

**3. The otel handling is fixed at the root — and the aligner's own fix was wrong.** The adversarial review of this PR caught it: `otlpconfig.NewHTTPConfig` applies the env config *before* explicit options and already honours the OTLP spec's two distinct endpoint semantics. Handing the resolved endpoint back through `WithEndpointURL` flattened them — **that override is why 1.45's change reached us at all**, and it separately lost every span for a collector behind a prefix (`ENDPOINT=https://collector/otlp` → POST to `/otlp`). Vetty reasoned from a false comment already in the file; I re-applied its fix verbatim and repeated the mistake. Now the URL form is left to the SDK.

## Verification

Both regression tests were confirmed **falsifiable** — shown red by reintroducing each bug:
- naive `alignment_lost` predicate → the "agent echoes the unchanged head sha" case fails
- explicit `WithEndpointURL` restored → `exporter POSTed to "/", want "/v1/traces"` *and* `POSTed to "/otlp", want "/otlp/v1/traces"`

`task lint` (0 issues), `task test`, `task test:e2e`, studio `tsc --noEmit`, `iterion validate` all green. Three adversarial review agents (opus, one per surface) reported **no critical or high findings**; their retained findings are applied here — the dangling section reference in the HOLD comment, a test that asserted nothing, the `Warn` silenced exactly when the store append fails, and the `running`-redelivery coverage gap.

Bilan: [docs/bot-runs/dep-update-guard.md](docs/bot-runs/dep-update-guard.md). Authoring rules that fall out: [docs/workflow_authoring_pitfalls.md](docs/workflow_authoring_pitfalls.md) §6–7, [docs/resume.md](docs/resume.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)