### PR TITLE
fix(runtime): decline a loop back-edge the budget cannot fund

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -419,6 +419,17 @@ src -> dst with {field: "{{ref}}"}      # data mapping
 
 **Budget block:** `max_parallel_branches`, `max_duration`, `max_cost_usd`, `max_tokens`, `max_iterations`. Each is overridable at run time without editing the `.bot` via the matching `iterion run`/`resume` flag (`--max-cost-usd`, `--max-tokens`, `--max-duration`, `--max-iterations`, `--max-parallel-branches`) — non-zero flag wins, zero inherits; precedence is DSL → recipe/preset → CLI flag. Lets you re-budget any bot per run (e.g. `--max-cost-usd 120 --max-duration 4h`) and is the mechanism behind the "budget exceeded → raise the cap + resume" recovery.
 
+A loop's **back-edge is declined when the budget cannot fund another
+iteration** — priced by what the previous one consumed, on every capped
+axis. The run then leaves through its own exit path (the fall-through
+that also serves loop exhaustion), so a campaign bot's delivery tail
+still opens its PR with the work committed in stride, instead of the run
+dying mid-pass on `BUDGET_EXCEEDED` and stranding it on a clone that
+dies with the pod. Visible as a `budget_warning` carrying `reason:
+loop_budget_guard`; `ITERION_LOOP_BUDGET_GUARD=off` is the escape hatch;
+the 90%-hard-limit and exceeded checks remain the backstop for a single
+node that overruns. See [docs/dsl.md](docs/dsl.md#budget-and-loop-back-edges).
+
 ### Backend selection
 
 Six backends are wired:

--- a/bots/docs-refresh/main.bot
+++ b/bots/docs-refresh/main.bot
@@ -1146,17 +1146,23 @@ workflow docs_refresh:
   budget:
     max_parallel_branches: 1
     ## Self-orchestrated passes (the campaign fans out sub-auditors on
-    ## ultracode) are COMPREHENSIVE and long — ~70 min / ~$16 per pass
-    ## on a large corpus (live: run 019f8e08 aligned 40 docs in pass 1).
-    ## The old 2h/$60 caps guillotined it mid-pass-2 as a hard
-    ## failed_resumable BEFORE finalize — losing all 40 in-pod commits
-    ## (the exporter only runs on a clean finalize; see the export-on-
-    ## failure engine gap). Give the asymptote room to reach GRACEFUL
-    ## exhaustion (which finalizes + exports) within budget: a few big
-    ## passes fit here, and max_passes below is lowered to match so the
-    ## run exhausts and ships rather than getting axed by the cap.
+    ## ultracode) are COMPREHENSIVE and long — one pass aligns a large
+    ## corpus (live: 40 docs) and costs $16 to $60+ depending on how
+    ## much drift it finds. The ceiling holds max_passes of those, so
+    ## the asymptote converges on its own terms rather than stopping
+    ## wherever the cap happens to fall. A run on an OAuth forfait
+    ## spends no money at all here — the figure prices tokens against a
+    ## subscription already paid for, and the provider's own usage
+    ## window is what actually bounds it.
+    ##
+    ## The engine declines a back-edge it cannot fund (priced by the
+    ## previous pass), so exhausting this ceiling routes the run through
+    ## mr_gate → the PR tail with the alignments it committed in stride.
+    ## Before that guard existed, a cap reached mid-pass was a hard
+    ## failed_resumable BEFORE finalize and every in-pod commit died
+    ## with the clone — the shape of the 2026-08-03 and -08-10 weeklies.
     max_duration: "6h"
-    max_cost_usd: 120
+    max_cost_usd: 400
 
   compaction:
     threshold: 0.9

--- a/bots/docs-refresh/manifest.yaml
+++ b/bots/docs-refresh/manifest.yaml
@@ -1,7 +1,16 @@
 name: docs-refresh
 display_name: Doki
 icon: 📚
-version: 3.5.4
+version: 3.5.5
+## 3.5.5 — max_cost_usd 120 → 400, sized to hold max_passes comprehensive
+## passes. The two scheduled weeklies (2026-08-03, -08-10) both died on the
+## $120 cap mid-pass — 31 and 29 alignment commits stranded on a clone that
+## died with the pod, no PR either time — while spending nothing real: prod
+## runs the OAuth forfait, so the figure prices tokens against a plan
+## already paid for and the provider's usage window is the true bound. The
+## engine's back-edge affordability guard (same change) makes the higher
+## ceiling safe: exhausting it now routes through mr_gate → the PR tail
+## instead of stranding the work.
 ## 3.5.4 — the `/doki` comment command is now a DIRECT, PR-scoped action
 ## (was board/any), mirroring `/revi`: a developer comments `/doki` on a PR
 ## and docs-refresh launches immediately on the PR head (no tracking card),

--- a/docs/bot-runs/docs-refresh.md
+++ b/docs/bot-runs/docs-refresh.md
@@ -13,6 +13,85 @@ promises ledgers persist the agent's adjudications; the opt-in
 `open_mr` tail publishes ONE PR. Runs on ANY repo; iterion is the
 reference self-host case.
 
+## 2026-08-11 — the two prod weeklies both died on the cost cap, 60 commits stranded (runs 019fc5c7, 019fe9d3)
+
+- Status: **failed to deliver, twice**. Read after the fact, from the runs
+  alone — nobody was watching either Monday. The 2026-07-27 configuration
+  fix landed and worked; the schedule then failed one layer down.
+- Versions: bot 3.5.4 (baked catalog, `/opt/iterion/bots/docs-refresh/main.bot`)
+  · iterion prod `:edge` · backend `claude_code` on the OAuth forfait.
+- Method: prod cloud schedule `306ecbc6`, `0 4 * * 1`, repo
+  `SocialGouv/iterion.git`, vars `{mode: incremental, open_mr: "true"}`.
+
+| Run | Window (UTC) | Passes | Commits | Died at |
+|---|---|---|---|---|
+| `019fc5c7` (08-03) | 04:00 → 20:20 | 4 | 31 | cost_usd 128/120 |
+| `019fe9d3` (08-10) | 04:00 → 21:36 | 3 | 29 | cost_usd **231**/120 |
+
+- Result: `failed_resumable` both times, `final_branch` and `final_commit`
+  empty, no PR either week. The PR tail is the only push path
+  (`mr_gate → forge_auth_probe → finalize_mr`), and a hard budget death at
+  `campaign` never reaches it — so ~60 real alignment commits died with
+  their pods. Neither run was resumed.
+- **The schedule config is NOT the problem this time.** The `vars: null`
+  defect of 2026-07-27 is fixed: both runs carry `mode: incremental` and
+  `open_mr: true`, and the cron fired to the second (04:00:02, 04:00:03).
+  Everything up to the cap worked. What is left is the cap itself.
+
+### Three things the events say
+
+- **The ceiling prices an estimate, not money.** Both runs are forfait:
+  `rate_limited (claude_code): You've hit your weekly limit · resets 7pm
+  (UTC)`, then `session limit · resets 8:40pm`. A subscription bills
+  nothing per call, so `$231` values tokens against a plan already paid
+  for. The gate killed a run that cost zero, and the provider's usage
+  window was already bounding it.
+- **The overshoot is structural, not marginal: +92%.** The budget is
+  checked BETWEEN nodes. Pass 3 started with `budget_warning … used:
+  96.96` — $23 of headroom — for a `campaign` node that is a whole
+  claude_code session and had just cost $63. The engine let a pass start
+  that it could not fund, then discovered the fact $111 later. The 90%
+  hard limit does not catch this: 80.8% is under it.
+- **The usage-window retry works, and is why a 6h budget spans 17h.**
+  Each `USAGE_LIMIT_BLOCKED` parks the run and re-launches the node after
+  the reset (visible as iterations 1 and 2 each starting twice), and
+  parked time does not count against `max_duration`. The retry is not the
+  problem — it is what carried the run far enough to reach the cap.
+
+### Engine hardening
+
+- **Back-edge affordability guard** (this change,
+  [pkg/runtime/loop_budget.go](../../pkg/runtime/loop_budget.go)): a loop's
+  back-edge is declined when the budget cannot fund another iteration,
+  priced by what the previous one consumed, on every capped axis. The run
+  leaves through its own exit path — for Doki `gate → mr_gate`, the same
+  fall-through that already served loop exhaustion — so the PR tail ships
+  what was banked. Applied to 08-10's numbers it declines the third pass
+  at $97/$120 and opens a PR with the 29 commits. Generic: every v2
+  campaign bot banks work in stride and has this exposure. Visible as
+  `budget_warning{reason: loop_budget_guard}`; `ITERION_LOOP_BUDGET_GUARD=off`
+  is the escape hatch.
+- Budget raised 120 → 400 (bot 3.5.5) so the asymptote converges on its own
+  terms. Safe now only because of the guard above — a higher ceiling used
+  to mean a bigger pile of stranded commits.
+- **Already fixed, and the runs prove it.** 08-03 shows the resume/refail
+  loop: `campaign` restarted **9 times** at pass 4, 8 `budget_exceeded`
+  events, each turn re-provisioning a sandbox to instantly re-hit the same
+  spent budget. 08-10 has exactly one. `fix/budget-terminal-ack` (#361,
+  merged 08-04) landed between the two — this is its live confirmation.
+
+### Lessons for next run
+
+- **A budget cap is a delivery decision, not just a spend decision.** On a
+  bot that banks work in stride, where the cap falls decides whether the
+  run ships or throws everything away. That is the engine's job to get
+  right, not the operator's to size around — hence the guard.
+- **An unattended schedule needs an alert, not a reader.** Three weeks of
+  Monday runs produced nothing and nobody knew until someone asked. The
+  07-27 lesson was "a green run is not a delivered run"; the sharper
+  version is that `final_commit` empty on a bot with `open_mr: true` is a
+  detectable condition, and nothing is watching for it.
+
 ## 2026-07-31 — closing run 019fae96: where the yield curve turns (run 019fae96, cont.)
 
 - Status: **partial, deliberately stopped**. Never reached `converged`. The run

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -467,6 +467,35 @@ workflow review:
 
 Workflow controls are `vars`, `attachments`, `entry`, `default_backend`, `tool_policy`, `capabilities`, `skills`, `mcp`, `budget`, `resources`, `compaction`, `interaction`, `worktree`, `compress`, `permission`, `allow`, `ask`, `deny`, and `sandbox`.
 
+#### Budget and loop back-edges
+
+A loop's back-edge is declined when the budget can no longer fund another
+iteration. The runtime prices one iteration by what the previous one
+consumed — the distance between two consecutive arrivals at the loop's
+decision point, on every axis the workflow actually caps (`max_cost_usd`,
+`max_tokens`, `max_iterations`, `max_duration`) — and skips the back-edge
+when what is left is less than that. The run then leaves through its own
+exit path: for the campaign shape below, the `gate -> publish` fall-through
+that also serves loop exhaustion.
+
+```iter
+  gate -> publish when converged
+  gate -> work as passes(4)
+  gate -> publish            # exhausted, or unaffordable: ship what is banked
+```
+
+This matters for any loop that banks work as it goes (commits in stride, a
+published report, a PR opened by a tail node). Without it a loop starts an
+iteration it cannot pay for, dies mid-iteration on `BUDGET_EXCEEDED`, and
+the tail that would have delivered the work never runs.
+
+The decline is visible, never silent: a `budget_warning` event carrying
+`reason: loop_budget_guard` with the loop, the blocking dimension, the
+remaining allowance and the price of the last iteration. It is on by
+default; `ITERION_LOOP_BUDGET_GUARD=off` restores the run-until-you-hit-the-wall
+behaviour. The 90%-hard-limit and exceeded checks stay as the backstop for a
+single node that overruns on its own.
+
 ### Edge forms
 
 ```iter

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -474,9 +474,12 @@ iteration. The runtime prices one iteration by what the previous one
 consumed — the distance between two consecutive arrivals at the loop's
 decision point, on every axis the workflow actually caps (`max_cost_usd`,
 `max_tokens`, `max_iterations`, `max_duration`) — and skips the back-edge
-when what is left is less than that. The run then leaves through its own
-exit path: for the campaign shape below, the `gate -> publish` fall-through
-that also serves loop exhaustion.
+once another iteration would reach the threshold where the engine stops
+starting nodes at all (90% of the cap). Stopping merely before the cap
+would not be enough: the run would fall through into an exit path that
+same threshold then refuses. The run instead leaves through its own exit
+path with room to walk it — for the campaign shape below, the
+`gate -> publish` fall-through that also serves loop exhaustion.
 
 ```iter
   gate -> publish when converged
@@ -489,12 +492,22 @@ published report, a PR opened by a tail node). Without it a loop starts an
 iteration it cannot pay for, dies mid-iteration on `BUDGET_EXCEEDED`, and
 the tail that would have delivered the work never runs.
 
+A loop is priced from the moment it is **entered**, and re-priced on each
+re-entry — so a loop reached late in a run (a second phase) is charged for
+its own iterations, never for the work that preceded it, and a nested loop
+re-entered per outer iteration starts fresh. A loop that has not been
+measured yet reports nothing rather than guessing. The prices ride the
+checkpoint, so a resumed run keeps measuring across the pause.
+
 The decline is visible, never silent: a `budget_warning` event carrying
 `reason: loop_budget_guard` with the loop, the blocking dimension, the
-remaining allowance and the price of the last iteration. It is on by
-default; `ITERION_LOOP_BUDGET_GUARD=off` restores the run-until-you-hit-the-wall
-behaviour. The 90%-hard-limit and exceeded checks stay as the backstop for a
-single node that overruns on its own.
+remaining allowance, the price of the last iteration, and the axis's
+`used`/`limit` (durations in seconds, with an explicit `unit`). A
+conditional back-edge is only priced on a crossing where its `when`
+actually holds. It is on by default; `ITERION_LOOP_BUDGET_GUARD=off`
+restores the run-until-you-hit-the-wall behaviour. The 90%-hard-limit and
+exceeded checks stay as the backstop for a single node that overruns on
+its own.
 
 ### Edge forms
 

--- a/openapi.json
+++ b/openapi.json
@@ -112,6 +112,15 @@
             "additionalProperties": {},
             "type": "object"
           },
+          "loop_budget_marks": {
+            "additionalProperties": {
+              "additionalProperties": {
+                "type": "number"
+              },
+              "type": "object"
+            },
+            "type": "object"
+          },
           "loop_counters": {
             "additionalProperties": {
               "type": "integer"

--- a/pkg/runtime/budget.go
+++ b/pkg/runtime/budget.go
@@ -282,6 +282,50 @@ func (b *SharedBudget) DurationStatus() (used, limit float64, bounded bool) {
 	return float64(time.Since(b.startedAt)), float64(b.maxDuration), true
 }
 
+// budgetAxis is one enforced budget dimension's standing: what the run
+// has consumed on it, and what it has left before the cap.
+type budgetAxis struct {
+	used      float64
+	remaining float64
+}
+
+// budgetDimensions lists the enforceable axes in the order checkLocked
+// evaluates them, so a caller reporting "which axis stopped me" reports
+// the same one every time.
+var budgetDimensions = []string{"iterations", "tokens", "cost_usd", "duration"}
+
+// Axes reports used + remaining for every ENFORCED dimension, keyed by
+// the names in budgetDimensions (duration in nanoseconds, as float64,
+// matching budgetCheckResult). An axis with no limit is absent: a caller
+// pricing future work only compares against caps that can actually stop
+// it. An overrun axis reports remaining 0, never negative. Nil-safe.
+func (b *SharedBudget) Axes() map[string]budgetAxis {
+	if b == nil {
+		return nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	axes := make(map[string]budgetAxis, len(budgetDimensions))
+	add := func(dimension string, used, limit float64) {
+		if limit <= 0 {
+			return
+		}
+		remaining := limit - used
+		if remaining < 0 {
+			remaining = 0
+		}
+		axes[dimension] = budgetAxis{used: used, remaining: remaining}
+	}
+
+	add("iterations", float64(b.iterationsUsed), float64(b.maxIterations))
+	add("tokens", float64(b.tokensUsed), float64(b.maxTokens))
+	add("cost_usd", b.costUsed, b.maxCostUSD)
+	add("duration", float64(time.Since(b.startedAt)), float64(b.maxDuration))
+
+	return axes
+}
+
 func (b *SharedBudget) checkLocked() []budgetCheckResult {
 	var results []budgetCheckResult
 

--- a/pkg/runtime/checkpoint.go
+++ b/pkg/runtime/checkpoint.go
@@ -51,6 +51,10 @@ func restoreBudgetAccounting(rs *runState, cp *store.Checkpoint) {
 	}
 	rs.budget.Restore(cp.BudgetTokensUsed, cp.BudgetCostUSD, cp.BudgetIterationsUsed, time.Duration(cp.BudgetElapsedNS))
 	rs.costUSDTotal = cp.CostUSDTotal
+	// Rebase the loop-affordability baseline onto what the resume starts
+	// from, so the first back-edge crossing prices its pass by that pass
+	// and not by every pass the run ever made.
+	captureBudgetSessionBase(rs)
 }
 
 // serializeNodeAttempts converts the runState's typed-key bucket into a

--- a/pkg/runtime/checkpoint.go
+++ b/pkg/runtime/checkpoint.go
@@ -16,6 +16,7 @@ func buildCheckpoint(rs *runState, nodeID string) *store.Checkpoint {
 		RoundRobinCounters: rs.roundRobinCounters,
 		LoopPreviousOutput: rs.loopPreviousOutput,
 		LoopCurrentOutput:  rs.loopCurrentOutput,
+		LoopBudgetMarks:    snapshotLoopBudgetMarks(rs),
 		ArtifactVersions:   rs.artifactVersions,
 		Vars:               rs.vars,
 		NodeAttempts:       serializeNodeAttempts(rs.nodeAttempts),
@@ -51,10 +52,10 @@ func restoreBudgetAccounting(rs *runState, cp *store.Checkpoint) {
 	}
 	rs.budget.Restore(cp.BudgetTokensUsed, cp.BudgetCostUSD, cp.BudgetIterationsUsed, time.Duration(cp.BudgetElapsedNS))
 	rs.costUSDTotal = cp.CostUSDTotal
-	// Rebase the loop-affordability baseline onto what the resume starts
-	// from, so the first back-edge crossing prices its pass by that pass
-	// and not by every pass the run ever made.
-	captureBudgetSessionBase(rs)
+	// Consumption is continuous across the pause, so the persisted loop
+	// prices stay comparable to it and the first crossing after a resume
+	// is measured like any other.
+	restoreLoopBudgetMarks(rs, cp.LoopBudgetMarks)
 }
 
 // serializeNodeAttempts converts the runState's typed-key bucket into a

--- a/pkg/runtime/edges.go
+++ b/pkg/runtime/edges.go
@@ -87,6 +87,57 @@ func (e *Engine) evaluateEdges(fromNodeID, logPrefix string, output map[string]a
 	return unconditional
 }
 
+// unitSuffix renders a display unit for log interpolation (" seconds"),
+// or nothing for the axes that carry their own.
+func unitSuffix(unit string) string {
+	if unit == "" {
+		return ""
+	}
+	return " " + unit
+}
+
+// edgeConditionHolds reports whether a `when` clause admits this edge as
+// a candidate. Unconditional and `else` edges always qualify — their
+// fallback role is settled later, by the selection order.
+//
+// Loop and foreach back-edges consult this BEFORE their own bookkeeping:
+// a conditional back-edge whose condition is false was never a candidate,
+// and must not be priced against the budget or reported as a loop that
+// could not be funded. The verdict matches what the selection code below
+// would conclude for the same edge, so an early skip here is the same
+// decision taken sooner.
+func (e *Engine) edgeConditionHolds(edge *ir.Edge, fromNodeID, logPrefix string, output map[string]any, rs *runState, exprCtx **expr.Context) bool {
+	if edge.Expression != nil {
+		if *exprCtx == nil {
+			*exprCtx = e.exprContext(rs, output)
+		}
+		ok, err := edge.Expression.EvalBool(*exprCtx)
+		if err != nil {
+			// Selection reports the failure; staying quiet here avoids
+			// logging the same broken expression twice per crossing.
+			return false
+		}
+		return ok
+	}
+	if edge.Condition == "" {
+		return true
+	}
+	val, ok := output[edge.Condition]
+	if !ok {
+		return false
+	}
+	boolVal, isBool := val.(bool)
+	if !isBool {
+		e.logger.Warn("%s: node %q: condition field %q is %T, expected bool — edge to %q skipped",
+			logPrefix, fromNodeID, edge.Condition, val, edge.To)
+		return false
+	}
+	if edge.Negated {
+		boolVal = !boolVal
+	}
+	return boolVal
+}
+
 // evaluateEdgesWithLoopsRS is the rs-aware variant: it evaluates edge `when`
 // expressions against the full runState (vars, outputs, artifacts, loop, run)
 // while still falling back to the simple boolean-field check when the edge
@@ -104,7 +155,7 @@ func (e *Engine) evaluateEdgesWithLoopsRS(fromNodeID, logPrefix string, output m
 
 		if edge.LoopName != "" {
 			loop, ok := e.workflow.Loops[edge.LoopName]
-			if ok {
+			if ok && e.edgeConditionHolds(edge, fromNodeID, logPrefix, output, rs, &exprCtx) {
 				maxIter := e.resolveLoopMax(loop, rs)
 				if rs.loopCounters[edge.LoopName] >= maxIter {
 					kind := "exhausted"
@@ -133,13 +184,22 @@ func (e *Engine) evaluateEdgesWithLoopsRS(fromNodeID, logPrefix string, output m
 				// against what the budget has left. Skipping the back-edge
 				// hands the run to its exit path with the work it banked,
 				// where dying mid-iteration on the hard cap would strand it.
-				if dim, need, have := e.loopBudgetShortfall(edge.LoopName, rs); dim != "" {
-					e.logger.Warn("%s: node %q: edge to %q skipped — loop %q cannot fund another iteration (%s: %.2f left, last one took %.2f), falling through to the exit path",
-						logPrefix, fromNodeID, edge.To, edge.LoopName, dim, have, need)
-					if err := e.emit(rs.ctx, rs.runID, store.EventBudgetWarning, fromNodeID, map[string]any{
+				if v := e.loopBudgetShortfall(edge.LoopName, rs); v != nil {
+					spent, remaining, used, limit, unit := v.display()
+					e.logger.Warn("%s: node %q: edge to %q skipped — loop %q cannot fund another iteration (%s: %.2f%s left, last one took %.2f%s), falling through to the exit path",
+						logPrefix, fromNodeID, edge.To, edge.LoopName, v.dimension, remaining, unitSuffix(unit), spent, unitSuffix(unit))
+					data := map[string]any{
 						"loop": edge.LoopName, "reason": "loop_budget_guard",
-						"dimension": dim, "remaining": have, "needed": need,
-					}); err != nil {
+						"dimension": v.dimension, "remaining": remaining, "needed": spent,
+						// used/limit are what every other budget_warning
+						// carries — the run report and the alert manager
+						// render the axis from them.
+						"used": used, "limit": limit,
+					}
+					if unit != "" {
+						data["unit"] = unit
+					}
+					if err := e.emit(rs.ctx, rs.runID, store.EventBudgetWarning, fromNodeID, data); err != nil {
 						e.logger.Warn("failed to emit loop_budget_guard warning: %v", err)
 					}
 					continue

--- a/pkg/runtime/edges.go
+++ b/pkg/runtime/edges.go
@@ -129,6 +129,21 @@ func (e *Engine) evaluateEdgesWithLoopsRS(fromNodeID, logPrefix string, output m
 					}
 					continue
 				}
+				// Affordability: another iteration priced by the last one
+				// against what the budget has left. Skipping the back-edge
+				// hands the run to its exit path with the work it banked,
+				// where dying mid-iteration on the hard cap would strand it.
+				if dim, need, have := e.loopBudgetShortfall(edge.LoopName, rs); dim != "" {
+					e.logger.Warn("%s: node %q: edge to %q skipped — loop %q cannot fund another iteration (%s: %.2f left, last one took %.2f), falling through to the exit path",
+						logPrefix, fromNodeID, edge.To, edge.LoopName, dim, have, need)
+					if err := e.emit(rs.ctx, rs.runID, store.EventBudgetWarning, fromNodeID, map[string]any{
+						"loop": edge.LoopName, "reason": "loop_budget_guard",
+						"dimension": dim, "remaining": have, "needed": need,
+					}); err != nil {
+						e.logger.Warn("failed to emit loop_budget_guard warning: %v", err)
+					}
+					continue
+				}
 			}
 		}
 

--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -283,8 +283,17 @@ type runState struct {
 	// and how many consecutive crossings it has been unchanged. Reset when the
 	// signal changes or the loop is re-entered. Not persisted across resume —
 	// a resumed run simply starts its stall window fresh.
-	loopProgressSig    map[string]string
-	loopStaleness      map[string]int
+	loopProgressSig map[string]string
+	loopStaleness   map[string]int
+	// loopBudgetMarks prices one iteration of each loop: the budget
+	// consumption snapshot taken at that loop's previous back-edge
+	// decision, per enforced dimension. budgetSessionBase is what this
+	// execution session started from (nil — reading as 0 — for a fresh
+	// run, the restored consumption for a resumed one), and stands in
+	// as the previous mark on a loop's first crossing. Not persisted:
+	// a resumed run re-prices from its own first pass.
+	loopBudgetMarks    map[string]loopBudgetMark
+	budgetSessionBase  loopBudgetMark
 	roundRobinCounters map[string]int
 	// events is the run-scoped reliable event registry backing the emit/wait
 	// node primitives (ADR-051). Sticky: a wait that arrives after the emit
@@ -444,6 +453,7 @@ func (e *Engine) newRunState(runID string, inputs map[string]any) *runState {
 		loopCurrentOutput:  make(map[string]map[string]any),
 		loopProgressSig:    make(map[string]string),
 		loopStaleness:      make(map[string]int),
+		loopBudgetMarks:    make(map[string]loopBudgetMark),
 		roundRobinCounters: make(map[string]int),
 		artifactVersions:   make(map[string]int),
 		preMarked:          make(map[string]bool),

--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -285,15 +285,11 @@ type runState struct {
 	// a resumed run simply starts its stall window fresh.
 	loopProgressSig map[string]string
 	loopStaleness   map[string]int
-	// loopBudgetMarks prices one iteration of each loop: the budget
-	// consumption snapshot taken at that loop's previous back-edge
-	// decision, per enforced dimension. budgetSessionBase is what this
-	// execution session started from (nil — reading as 0 — for a fresh
-	// run, the restored consumption for a resumed one), and stands in
-	// as the previous mark on a loop's first crossing. Not persisted:
-	// a resumed run re-prices from its own first pass.
+	// loopBudgetMarks prices one iteration of each loop: what the run had
+	// consumed, per enforced budget dimension, when that loop was entered
+	// or last crossed its back-edge. Persisted on the checkpoint, so a
+	// resumed run keeps measuring across the pause.
 	loopBudgetMarks    map[string]loopBudgetMark
-	budgetSessionBase  loopBudgetMark
 	roundRobinCounters map[string]int
 	// events is the run-scoped reliable event registry backing the emit/wait
 	// node primitives (ADR-051). Sticky: a wait that arrives after the emit

--- a/pkg/runtime/engine_exec.go
+++ b/pkg/runtime/engine_exec.go
@@ -30,6 +30,11 @@ func (e *Engine) execLoop(ctx context.Context, rs *runState, startNodeID string)
 	// nil ctx.Done()). Setting it here covers every caller.
 	rs.ctx = ctx
 
+	// Baseline the loop prices before anything runs, so a loop containing
+	// the workflow entry — entered by no edge — is measured from zero.
+	// Covers every caller for the same reason rs.ctx is pinned here.
+	e.baselineUnpricedLoops(rs)
+
 	currentNodeID := startNodeID
 
 	for {
@@ -788,6 +793,12 @@ func (e *Engine) selectEdgeRS(rs *runState, fromNodeID string, output map[string
 			if !loop.Entries[selected.To] || loop.Body[selected.From] {
 				continue
 			}
+			// Entering the body from outside re-bases the loop's price:
+			// its first back-edge crossing must cost one iteration, not
+			// everything the run spent before this loop existed. Outside
+			// the re-entry branch below — a FIRST entry needs the
+			// baseline just as much, and leaves the counter at 0.
+			markLoopBudget(rs, loopName)
 			if prior, ok := rs.loopCounters[loopName]; ok && prior > 0 {
 				e.logger.Debug("loop %q: re-entered via edge %s→%s — counter reset from %d", loopName, selected.From, selected.To, prior)
 				rs.loopCounters[loopName] = 0
@@ -810,6 +821,10 @@ func (e *Engine) selectEdgeRS(rs *runState, fromNodeID string, output map[string
 
 	if selected.LoopName != "" {
 		rs.loopCounters[selected.LoopName] = rs.loopCounters[selected.LoopName] + 1
+		// The crossing is committed: price the iteration that starts here
+		// from this point. Done on the SELECTED edge only, so evaluating a
+		// sibling back-edge cannot move the mark or leave it a zero price.
+		markLoopBudget(rs, selected.LoopName)
 		// Rotate snapshots so {{loop.<name>.previous_output}} reads the
 		// snapshot from the PRIOR traversal (one iteration behind), not the
 		// current one. The current iteration's source output is staged in

--- a/pkg/runtime/loop_budget.go
+++ b/pkg/runtime/loop_budget.go
@@ -1,0 +1,95 @@
+package runtime
+
+import (
+	"os"
+	"strings"
+)
+
+// loopBudgetMark records what a run had consumed, per enforced budget
+// dimension, at one loop back-edge decision. The distance between two
+// consecutive marks is what that loop's body cost in between — the
+// price of one more iteration.
+type loopBudgetMark map[string]float64
+
+// loopBudgetGuardEnabled reports whether the back-edge affordability
+// guard is active. It is on by default and turned off with
+// ITERION_LOOP_BUDGET_GUARD=off|0|false — the escape hatch for an
+// operator who would rather a loop run until it hits the cap head-on.
+func loopBudgetGuardEnabled() bool {
+	switch strings.TrimSpace(strings.ToLower(os.Getenv("ITERION_LOOP_BUDGET_GUARD"))) {
+	case "off", "0", "false", "no":
+		return false
+	}
+	return true
+}
+
+// loopBudgetShortfall reports the budget dimension that can no longer
+// fund another iteration of loopName — "" while the loop is still
+// affordable. It also re-marks the loop for the next crossing, so it
+// must be called exactly once per back-edge decision.
+//
+// One iteration is priced by what the PREVIOUS one consumed: the
+// distance between this crossing's consumption and the last mark's (the
+// session baseline for the first crossing, so a resumed run prices a
+// pass by what IT ran, not by everything since the original launch).
+//
+// The engine already refuses to start a node past 90% of a budget — but
+// it does so by FAILING the run, and a campaign bot's delivery tail
+// (open the PR, publish the report) then never runs: the work it
+// committed in stride is stranded on a clone that dies with the pod.
+// Declining the back-edge instead routes the run out through its own
+// exit path with what it has banked. The exceeded and hard-limit checks
+// stay as the backstop for a single node that overruns on its own.
+func (e *Engine) loopBudgetShortfall(loopName string, rs *runState) (dimension string, need, have float64) {
+	if !loopBudgetGuardEnabled() {
+		return "", 0, 0
+	}
+	axes := rs.budget.Axes()
+	if len(axes) == 0 {
+		return "", 0, 0
+	}
+
+	previous, marked := rs.loopBudgetMarks[loopName]
+	if !marked {
+		previous = rs.budgetSessionBase
+	}
+
+	mark := make(loopBudgetMark, len(axes))
+	for dim, axis := range axes {
+		mark[dim] = axis.used
+	}
+	rs.loopBudgetMarks[loopName] = mark
+
+	for _, dim := range budgetDimensions {
+		axis, enforced := axes[dim]
+		if !enforced {
+			continue
+		}
+		spent := axis.used - previous[dim]
+		// A dimension the last iteration did not move cannot be the one
+		// that starves the next; only a measured burn prices a pass.
+		if spent > 0 && axis.remaining < spent {
+			return dim, spent, axis.remaining
+		}
+	}
+
+	return "", 0, 0
+}
+
+// captureBudgetSessionBase records what this execution session STARTED
+// from, per enforced dimension. Zero for a fresh run (the nil map reads
+// as 0 everywhere); the restored consumption for a resumed one, so the
+// first back-edge crossing after a resume prices its pass by that pass
+// alone. Called once, after the checkpoint has seeded the budget and
+// before any node runs.
+func captureBudgetSessionBase(rs *runState) {
+	axes := rs.budget.Axes()
+	if len(axes) == 0 {
+		return
+	}
+	base := make(loopBudgetMark, len(axes))
+	for dim, axis := range axes {
+		base[dim] = axis.used
+	}
+	rs.budgetSessionBase = base
+}

--- a/pkg/runtime/loop_budget.go
+++ b/pkg/runtime/loop_budget.go
@@ -3,13 +3,37 @@ package runtime
 import (
 	"os"
 	"strings"
+	"time"
 )
 
 // loopBudgetMark records what a run had consumed, per enforced budget
-// dimension, at one loop back-edge decision. The distance between two
-// consecutive marks is what that loop's body cost in between — the
-// price of one more iteration.
+// dimension, at one point in a loop's life: the moment it was entered,
+// or its last back-edge crossing. The distance to the next crossing is
+// what one iteration of that loop cost.
 type loopBudgetMark map[string]float64
+
+// loopBudgetVerdict describes a loop iteration the budget cannot fund.
+// spent is what the previous iteration consumed on the blocking axis;
+// used/limit are the run's standing on it, carried so the ordinary
+// budget_warning consumers (run report, alert manager) render the event
+// like any other.
+type loopBudgetVerdict struct {
+	dimension string
+	spent     float64
+	remaining float64
+	used      float64
+	limit     float64
+}
+
+// display converts an axis's figures to operator units. Durations are
+// tracked in nanoseconds; every other axis is already in its own unit.
+func (v loopBudgetVerdict) display() (spent, remaining, used, limit float64, unit string) {
+	if v.dimension == "duration" {
+		s := float64(time.Second)
+		return v.spent / s, v.remaining / s, v.used / s, v.limit / s, "seconds"
+	}
+	return v.spent, v.remaining, v.used, v.limit, ""
+}
 
 // loopBudgetGuardEnabled reports whether the back-edge affordability
 // guard is active. It is on by default and turned off with
@@ -24,14 +48,18 @@ func loopBudgetGuardEnabled() bool {
 }
 
 // loopBudgetShortfall reports the budget dimension that can no longer
-// fund another iteration of loopName — "" while the loop is still
-// affordable. It also re-marks the loop for the next crossing, so it
-// must be called exactly once per back-edge decision.
+// fund another iteration of loopName, or nil while the loop is still
+// affordable. It is a pure READ: marking is the business of the paths
+// that know a loop was entered or its back-edge actually taken
+// (markLoopBudget), so evaluating an edge that is not selected can
+// neither move a loop's price nor arm a sibling edge with a zero one.
 //
-// One iteration is priced by what the PREVIOUS one consumed: the
-// distance between this crossing's consumption and the last mark's (the
-// session baseline for the first crossing, so a resumed run prices a
-// pass by what IT ran, not by everything since the original launch).
+// One iteration is priced by what the previous one consumed: the
+// distance between the run's consumption now and the loop's last mark.
+// A loop with no mark has not been measured yet — it reports no
+// shortfall rather than guessing, because the alternative (pricing from
+// run start) charges a late-entered loop for everything that ran before
+// it existed and declines its very first crossing.
 //
 // The engine already refuses to start a node past 90% of a budget — but
 // it does so by FAILING the run, and a campaign bot's delivery tail
@@ -40,25 +68,18 @@ func loopBudgetGuardEnabled() bool {
 // Declining the back-edge instead routes the run out through its own
 // exit path with what it has banked. The exceeded and hard-limit checks
 // stay as the backstop for a single node that overruns on its own.
-func (e *Engine) loopBudgetShortfall(loopName string, rs *runState) (dimension string, need, have float64) {
+func (e *Engine) loopBudgetShortfall(loopName string, rs *runState) *loopBudgetVerdict {
 	if !loopBudgetGuardEnabled() {
-		return "", 0, 0
+		return nil
 	}
 	axes := rs.budget.Axes()
 	if len(axes) == 0 {
-		return "", 0, 0
+		return nil
 	}
-
 	previous, marked := rs.loopBudgetMarks[loopName]
 	if !marked {
-		previous = rs.budgetSessionBase
+		return nil
 	}
-
-	mark := make(loopBudgetMark, len(axes))
-	for dim, axis := range axes {
-		mark[dim] = axis.used
-	}
-	rs.loopBudgetMarks[loopName] = mark
 
 	for _, dim := range budgetDimensions {
 		axis, enforced := axes[dim]
@@ -68,28 +89,95 @@ func (e *Engine) loopBudgetShortfall(loopName string, rs *runState) (dimension s
 		spent := axis.used - previous[dim]
 		// A dimension the last iteration did not move cannot be the one
 		// that starves the next; only a measured burn prices a pass.
-		if spent > 0 && axis.remaining < spent {
-			return dim, spent, axis.remaining
+		if spent <= 0 {
+			continue
+		}
+		limit := axis.used + axis.remaining
+		// Decline once another iteration would land at or past the
+		// threshold where the engine refuses to START any node
+		// (checkBudgetBeforeExec's 90% hard limit). Stopping merely
+		// before the CAP would not be enough: the run would fall
+		// through into an exit path the hard limit then refuses, which
+		// strands the banked work just as surely as overrunning. This
+		// also subsumes "the next iteration does not fit at all".
+		if axis.used+spent >= budgetHardThreshold*limit {
+			return &loopBudgetVerdict{
+				dimension: dim,
+				spent:     spent,
+				remaining: axis.remaining,
+				used:      axis.used,
+				limit:     limit,
+			}
 		}
 	}
 
-	return "", 0, 0
+	return nil
 }
 
-// captureBudgetSessionBase records what this execution session STARTED
-// from, per enforced dimension. Zero for a fresh run (the nil map reads
-// as 0 everywhere); the restored consumption for a resumed one, so the
-// first back-edge crossing after a resume prices its pass by that pass
-// alone. Called once, after the checkpoint has seeded the budget and
-// before any node runs.
-func captureBudgetSessionBase(rs *runState) {
+// markLoopBudget re-bases a loop's price on the run's consumption right
+// now. Called when the loop is ENTERED from outside (so its first
+// crossing prices its first iteration, not the whole run that preceded
+// it) and each time its back-edge is actually taken.
+func markLoopBudget(rs *runState, loopName string) {
 	axes := rs.budget.Axes()
 	if len(axes) == 0 {
 		return
 	}
-	base := make(loopBudgetMark, len(axes))
+	mark := make(loopBudgetMark, len(axes))
 	for dim, axis := range axes {
-		base[dim] = axis.used
+		mark[dim] = axis.used
 	}
-	rs.budgetSessionBase = base
+	rs.loopBudgetMarks[loopName] = mark
+}
+
+// baselineUnpricedLoops bases every not-yet-priced loop at the run's
+// current consumption. Called once before this session executes a node.
+//
+// It is the right baseline for a loop whose body contains the workflow
+// entry: execution starts INSIDE it, no edge ever enters it, so nothing
+// else would mark it — and at that moment the run has consumed nothing,
+// which is exactly what its first iteration will be measured against.
+// Loops entered later are re-marked at their entry edge, and a loop
+// whose price survived on the checkpoint keeps it.
+func (e *Engine) baselineUnpricedLoops(rs *runState) {
+	for loopName := range e.workflow.Loops {
+		if _, priced := rs.loopBudgetMarks[loopName]; priced {
+			continue
+		}
+		markLoopBudget(rs, loopName)
+	}
+}
+
+// restoreLoopBudgetMarks rehydrates the loop prices from a checkpoint so
+// a resumed run keeps pricing iterations across the pause. Consumption
+// is restored alongside (SharedBudget.Restore), so the marks stay
+// comparable. A checkpoint carrying none — an older format, or a resume
+// from the workflow entry — leaves every loop unmarked, which reports no
+// shortfall until each has been measured once in this session.
+func restoreLoopBudgetMarks(rs *runState, marks map[string]map[string]float64) {
+	for loopName, mark := range marks {
+		if len(mark) == 0 {
+			continue
+		}
+		rs.loopBudgetMarks[loopName] = loopBudgetMark(mark)
+	}
+}
+
+// snapshotLoopBudgetMarks projects the loop prices for persistence.
+// Returns nil when nothing has been marked, so checkpoints stay compact.
+func snapshotLoopBudgetMarks(rs *runState) map[string]map[string]float64 {
+	if len(rs.loopBudgetMarks) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]float64, len(rs.loopBudgetMarks))
+	for loopName, mark := range rs.loopBudgetMarks {
+		if len(mark) == 0 {
+			continue
+		}
+		out[loopName] = cloneMap(map[string]float64(mark))
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/pkg/runtime/loop_budget_test.go
+++ b/pkg/runtime/loop_budget_test.go
@@ -1,0 +1,215 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// campaignShapedWorkflow builds the graph every v2 campaign bot uses: a
+// costly pass, a gate that decides, a back-edge for another pass, and a
+// delivery tail reached BOTH when the gate converges and when the loop
+// stops. maxCost bounds the run; the pass never converges, so what ends
+// the loop is the only question the test asks.
+func campaignShapedWorkflow(maxCost float64) *ir.Workflow {
+	return &ir.Workflow{
+		Name:  "campaign_shaped",
+		Entry: "pass",
+		Nodes: map[string]ir.Node{
+			"pass":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "pass"}},
+			"gate":    &ir.ComputeNode{BaseNode: ir.BaseNode{ID: "gate"}},
+			"deliver": &ir.ToolNode{BaseNode: ir.BaseNode{ID: "deliver"}},
+			"done":    &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "pass", To: "gate"},
+			{From: "gate", To: "deliver", Condition: "converged"},
+			{From: "gate", To: "pass", LoopName: "continuation"},
+			{From: "gate", To: "deliver"},
+			{From: "deliver", To: "done"},
+		},
+		Schemas: map[string]*ir.Schema{},
+		Prompts: map[string]*ir.Prompt{},
+		Vars:    map[string]*ir.Var{},
+		Loops: map[string]*ir.Loop{
+			"continuation": {Name: "continuation", MaxIterations: 10},
+		},
+		Budget: &ir.Budget{MaxCostUSD: maxCost},
+	}
+}
+
+// TestLoopBudgetGuard_FallsThroughToDeliveryTail is the composition the
+// guard exists for: a campaign loop whose next pass costs more than the
+// budget has left must leave through its own exit path — running the
+// delivery tail that publishes what it banked — instead of dying
+// mid-pass on the hard cap with the tail unreached.
+//
+// $10 cap, $4 a pass: pass 1 leaves $6 (affordable), pass 2 leaves $2
+// (not), so the back-edge is declined at the second crossing.
+func TestLoopBudgetGuard_FallsThroughToDeliveryTail(t *testing.T) {
+	wf := campaignShapedWorkflow(10.0)
+
+	var passes, delivered int
+	exec := newStubExecutor()
+	exec.on("pass", func(_ map[string]any) (map[string]any, error) {
+		passes++
+		return map[string]any{"ok": true, "_cost_usd": 4.0}, nil
+	})
+	exec.on("gate", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"converged": false}, nil
+	})
+	exec.on("deliver", func(_ map[string]any) (map[string]any, error) {
+		delivered++
+		return map[string]any{"published": true}, nil
+	})
+
+	s := tmpStore(t)
+	eng := New(wf, s, exec)
+	if err := eng.Run(context.Background(), "run-loop-budget-guard", nil); err != nil {
+		t.Fatalf("run should finish through the delivery tail, got: %v", err)
+	}
+
+	if passes != 2 {
+		t.Errorf("ran %d passes, want 2 (the third is unaffordable)", passes)
+	}
+	if delivered != 1 {
+		t.Fatalf("delivery tail ran %d times, want 1 — the banked work was stranded", delivered)
+	}
+
+	run, err := s.LoadRun(context.Background(), "run-loop-budget-guard")
+	if err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	if run.Status != store.RunStatusFinished {
+		t.Errorf("status = %q, want %q", run.Status, store.RunStatusFinished)
+	}
+
+	// The decline is loud: an operator reading the events must be able to
+	// tell "stopped early, on purpose" from "converged".
+	events, err := s.LoadEvents(context.Background(), "run-loop-budget-guard")
+	if err != nil {
+		t.Fatalf("load events: %v", err)
+	}
+	var guard map[string]any
+	for _, ev := range events {
+		if ev.Type == store.EventBudgetWarning && ev.Data["reason"] == "loop_budget_guard" {
+			guard = ev.Data
+		}
+	}
+	if guard == nil {
+		t.Fatal("no budget_warning{reason: loop_budget_guard} event — the early exit is silent")
+	}
+	if guard["dimension"] != "cost_usd" {
+		t.Errorf("guard dimension = %v, want cost_usd", guard["dimension"])
+	}
+	if guard["loop"] != "continuation" {
+		t.Errorf("guard loop = %v, want continuation", guard["loop"])
+	}
+}
+
+// TestLoopBudgetGuard_OffRestoresTheStrandingFailure is the control: it
+// re-introduces the defect through the documented escape hatch and
+// checks the test above is not passing vacuously. With the guard off the
+// same workflow starts a pass it cannot pay for, dies on the hard cap,
+// and never reaches its delivery tail.
+func TestLoopBudgetGuard_OffRestoresTheStrandingFailure(t *testing.T) {
+	t.Setenv("ITERION_LOOP_BUDGET_GUARD", "off")
+
+	wf := campaignShapedWorkflow(10.0)
+
+	var delivered int
+	exec := newStubExecutor()
+	exec.on("pass", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"ok": true, "_cost_usd": 4.0}, nil
+	})
+	exec.on("gate", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"converged": false}, nil
+	})
+	exec.on("deliver", func(_ map[string]any) (map[string]any, error) {
+		delivered++
+		return map[string]any{"published": true}, nil
+	})
+
+	eng := New(wf, tmpStore(t), exec)
+	err := eng.Run(context.Background(), "run-loop-budget-guard-off", nil)
+	if err == nil {
+		t.Fatal("expected the unguarded run to die on the cost budget")
+	}
+	if !strings.Contains(err.Error(), "budget exceeded") {
+		t.Errorf("error = %v, want a budget-exceeded failure", err)
+	}
+	if delivered != 0 {
+		t.Errorf("delivery tail ran %d times unguarded, want 0 (that is the defect)", delivered)
+	}
+}
+
+// TestLoopBudgetShortfall_PricesOneIterationAtATime covers the pricing
+// rule directly: each crossing is priced by the distance to the previous
+// mark, not by everything the run has spent.
+func TestLoopBudgetShortfall_PricesOneIterationAtATime(t *testing.T) {
+	wf := campaignShapedWorkflow(10.0)
+	eng := newEngineWith(t, wf)
+	rs := eng.newRunState("r", nil)
+	rs.budget = newSharedBudget(wf.Budget, eng.logger)
+
+	// Crossing 1 after a $4 pass: $6 left covers another $4.
+	rs.budget.RecordUsage(0, 4.0)
+	if dim, _, _ := eng.loopBudgetShortfall("continuation", rs); dim != "" {
+		t.Fatalf("first crossing reported a %q shortfall with $6 left for a $4 pass", dim)
+	}
+
+	// Crossing 2 after a second $4 pass: $2 left cannot cover $4. The
+	// price is the LAST pass ($4), not the run total ($8).
+	rs.budget.RecordUsage(0, 4.0)
+	dim, need, have := eng.loopBudgetShortfall("continuation", rs)
+	if dim != "cost_usd" {
+		t.Fatalf("second crossing = %q, want a cost_usd shortfall", dim)
+	}
+	if need != 4.0 {
+		t.Errorf("priced the next pass at %.2f, want 4.00 (the last one, not the total)", need)
+	}
+	if have != 2.0 {
+		t.Errorf("remaining = %.2f, want 2.00", have)
+	}
+}
+
+// TestLoopBudgetShortfall_ResumeRebasesTheBaseline guards the resume
+// path: a run that resumes with most of its budget already spent must
+// price its next pass by the pass it just ran, not by the consumption it
+// inherited from the checkpoint — which would decline the back-edge on
+// the first crossing of every resumed run.
+func TestLoopBudgetShortfall_ResumeRebasesTheBaseline(t *testing.T) {
+	wf := campaignShapedWorkflow(100.0)
+	eng := newEngineWith(t, wf)
+	rs := eng.newRunState("r", nil)
+	rs.budget = newSharedBudget(wf.Budget, eng.logger)
+
+	// Resume carrying $70 of prior spend, then run a $5 pass. $30 left
+	// covers another $5 — but only if the inherited $70 is not counted
+	// as this pass's price.
+	restoreBudgetAccounting(rs, &store.Checkpoint{BudgetCostUSD: 70.0})
+	rs.budget.RecordUsage(0, 5.0)
+
+	if dim, need, have := eng.loopBudgetShortfall("continuation", rs); dim != "" {
+		t.Fatalf("resumed run declined its back-edge: %s needs %.2f, has %.2f — the baseline was not rebased", dim, need, have)
+	}
+}
+
+// TestLoopBudgetShortfall_IgnoresUnenforcedAxes checks the guard only
+// speaks for caps that exist: a workflow that budgets cost alone must
+// never be stopped by a token or duration figure nobody bounded.
+func TestLoopBudgetShortfall_IgnoresUnenforcedAxes(t *testing.T) {
+	wf := campaignShapedWorkflow(1000.0)
+	eng := newEngineWith(t, wf)
+	rs := eng.newRunState("r", nil)
+	rs.budget = newSharedBudget(wf.Budget, eng.logger)
+
+	// A pass burning a large token count against an unlimited token axis.
+	rs.budget.RecordUsage(5_000_000, 1.0)
+	if dim, _, _ := eng.loopBudgetShortfall("continuation", rs); dim != "" {
+		t.Fatalf("reported a %q shortfall on an axis the workflow does not cap", dim)
+	}
+}

--- a/pkg/runtime/loop_budget_test.go
+++ b/pkg/runtime/loop_budget_test.go
@@ -12,9 +12,9 @@ import (
 // campaignShapedWorkflow builds the graph every v2 campaign bot uses: a
 // costly pass, a gate that decides, a back-edge for another pass, and a
 // delivery tail reached BOTH when the gate converges and when the loop
-// stops. maxCost bounds the run; the pass never converges, so what ends
-// the loop is the only question the test asks.
-func campaignShapedWorkflow(maxCost float64) *ir.Workflow {
+// stops. maxTokens bounds the run; the pass never converges, so what
+// ends the loop is the only question the test asks.
+func campaignShapedWorkflow(maxTokens int) *ir.Workflow {
 	return &ir.Workflow{
 		Name:  "campaign_shaped",
 		Entry: "pass",
@@ -35,36 +35,45 @@ func campaignShapedWorkflow(maxCost float64) *ir.Workflow {
 		Prompts: map[string]*ir.Prompt{},
 		Vars:    map[string]*ir.Var{},
 		Loops: map[string]*ir.Loop{
-			"continuation": {Name: "continuation", MaxIterations: 10},
+			"continuation": {
+				Name:          "continuation",
+				MaxIterations: 10,
+				Entries:       map[string]bool{"pass": true},
+				Body:          map[string]bool{"pass": true, "gate": true},
+			},
 		},
-		Budget: &ir.Budget{MaxCostUSD: maxCost},
+		Budget: &ir.Budget{MaxTokens: maxTokens},
 	}
 }
 
-// TestLoopBudgetGuard_FallsThroughToDeliveryTail is the composition the
-// guard exists for: a campaign loop whose next pass costs more than the
-// budget has left must leave through its own exit path — running the
-// delivery tail that publishes what it banked — instead of dying
-// mid-pass on the hard cap with the tail unreached.
-//
-// $10 cap, $4 a pass: pass 1 leaves $6 (affordable), pass 2 leaves $2
-// (not), so the back-edge is declined at the second crossing.
-func TestLoopBudgetGuard_FallsThroughToDeliveryTail(t *testing.T) {
-	wf := campaignShapedWorkflow(10.0)
-
-	var passes, delivered int
-	exec := newStubExecutor()
+// costingExecutor wires a stub whose `pass` burns a fixed token count,
+// whose `gate` never converges, and whose `deliver` records that the
+// delivery tail was reached. The counters it returns are the assertions.
+func costingExecutor(passTokens int) (exec *stubExecutor, passes, delivered *int) {
+	p, d := 0, 0
+	exec = newStubExecutor()
 	exec.on("pass", func(_ map[string]any) (map[string]any, error) {
-		passes++
-		return map[string]any{"ok": true, "_cost_usd": 4.0}, nil
+		p++
+		return map[string]any{"ok": true, "_tokens": passTokens}, nil
 	})
 	exec.on("gate", func(_ map[string]any) (map[string]any, error) {
 		return map[string]any{"converged": false}, nil
 	})
 	exec.on("deliver", func(_ map[string]any) (map[string]any, error) {
-		delivered++
+		d++
 		return map[string]any{"published": true}, nil
 	})
+	return exec, &p, &d
+}
+
+// TestLoopBudgetGuard_FallsThroughToDeliveryTail is the composition the
+// guard exists for: a campaign loop whose next pass would exhaust the
+// budget must leave through its own exit path — running the delivery
+// tail that publishes what it banked — instead of dying mid-pass with
+// the tail unreached.
+func TestLoopBudgetGuard_FallsThroughToDeliveryTail(t *testing.T) {
+	wf := campaignShapedWorkflow(10_000)
+	exec, passes, delivered := costingExecutor(3_000)
 
 	s := tmpStore(t)
 	eng := New(wf, s, exec)
@@ -72,11 +81,11 @@ func TestLoopBudgetGuard_FallsThroughToDeliveryTail(t *testing.T) {
 		t.Fatalf("run should finish through the delivery tail, got: %v", err)
 	}
 
-	if passes != 2 {
-		t.Errorf("ran %d passes, want 2 (the third is unaffordable)", passes)
+	if *passes < 2 {
+		t.Errorf("ran %d passes, want at least 2 — the guard stopped the loop too early", *passes)
 	}
-	if delivered != 1 {
-		t.Fatalf("delivery tail ran %d times, want 1 — the banked work was stranded", delivered)
+	if *delivered != 1 {
+		t.Fatalf("delivery tail ran %d times, want 1 — the banked work was stranded", *delivered)
 	}
 
 	run, err := s.LoadRun(context.Background(), "run-loop-budget-guard")
@@ -87,8 +96,8 @@ func TestLoopBudgetGuard_FallsThroughToDeliveryTail(t *testing.T) {
 		t.Errorf("status = %q, want %q", run.Status, store.RunStatusFinished)
 	}
 
-	// The decline is loud: an operator reading the events must be able to
-	// tell "stopped early, on purpose" from "converged".
+	// The decline is loud, and carries what every budget_warning consumer
+	// (run report, alert manager) reads.
 	events, err := s.LoadEvents(context.Background(), "run-loop-budget-guard")
 	if err != nil {
 		t.Fatalf("load events: %v", err)
@@ -102,28 +111,98 @@ func TestLoopBudgetGuard_FallsThroughToDeliveryTail(t *testing.T) {
 	if guard == nil {
 		t.Fatal("no budget_warning{reason: loop_budget_guard} event — the early exit is silent")
 	}
-	if guard["dimension"] != "cost_usd" {
-		t.Errorf("guard dimension = %v, want cost_usd", guard["dimension"])
+	for _, key := range []string{"dimension", "loop", "remaining", "needed", "used", "limit"} {
+		if _, ok := guard[key]; !ok {
+			t.Errorf("guard event is missing %q", key)
+		}
 	}
-	if guard["loop"] != "continuation" {
-		t.Errorf("guard loop = %v, want continuation", guard["loop"])
+	if guard["dimension"] != "tokens" || guard["loop"] != "continuation" {
+		t.Errorf("guard = %v/%v, want tokens/continuation", guard["dimension"], guard["loop"])
 	}
 }
 
 // TestLoopBudgetGuard_OffRestoresTheStrandingFailure is the control: it
 // re-introduces the defect through the documented escape hatch and
 // checks the test above is not passing vacuously. With the guard off the
-// same workflow starts a pass it cannot pay for, dies on the hard cap,
-// and never reaches its delivery tail.
+// same workflow starts a pass it cannot pay for, dies on the budget, and
+// never reaches its delivery tail.
 func TestLoopBudgetGuard_OffRestoresTheStrandingFailure(t *testing.T) {
 	t.Setenv("ITERION_LOOP_BUDGET_GUARD", "off")
 
-	wf := campaignShapedWorkflow(10.0)
+	wf := campaignShapedWorkflow(10_000)
+	exec, _, delivered := costingExecutor(3_000)
 
-	var delivered int
+	eng := New(wf, tmpStore(t), exec)
+	err := eng.Run(context.Background(), "run-loop-budget-guard-off", nil)
+	if err == nil {
+		t.Fatal("expected the unguarded run to die on the token budget")
+	}
+	if !strings.Contains(err.Error(), "budget") {
+		t.Errorf("error = %v, want a budget failure", err)
+	}
+	if *delivered != 0 {
+		t.Errorf("delivery tail ran %d times unguarded, want 0 (that is the defect)", *delivered)
+	}
+}
+
+// sequentialLoopsWorkflow puts an expensive prologue in front of a loop,
+// so the loop is ENTERED long after the run started spending. This is
+// secured-renovacy's shape: a Phase-2 review loop whose first crossing
+// happens after all of Phase 1.
+func sequentialLoopsWorkflow(maxTokens int) *ir.Workflow {
+	return &ir.Workflow{
+		Name:  "sequential_loops",
+		Entry: "prologue",
+		Nodes: map[string]ir.Node{
+			"prologue": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "prologue"}},
+			"pass":     &ir.AgentNode{BaseNode: ir.BaseNode{ID: "pass"}},
+			"gate":     &ir.ComputeNode{BaseNode: ir.BaseNode{ID: "gate"}},
+			"deliver":  &ir.ToolNode{BaseNode: ir.BaseNode{ID: "deliver"}},
+			"done":     &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "prologue", To: "pass"},
+			{From: "pass", To: "gate"},
+			{From: "gate", To: "deliver", Condition: "converged"},
+			{From: "gate", To: "pass", LoopName: "phase2"},
+			{From: "gate", To: "deliver"},
+			{From: "deliver", To: "done"},
+		},
+		Schemas: map[string]*ir.Schema{},
+		Prompts: map[string]*ir.Prompt{},
+		Vars:    map[string]*ir.Var{},
+		Loops: map[string]*ir.Loop{
+			"phase2": {
+				Name:          "phase2",
+				MaxIterations: 10,
+				Entries:       map[string]bool{"pass": true},
+				Body:          map[string]bool{"pass": true, "gate": true},
+			},
+		},
+		Budget: &ir.Budget{MaxTokens: maxTokens},
+	}
+}
+
+// TestLoopBudgetGuard_LateEnteredLoopIsPricedFromItsEntry is the
+// regression for the pricing baseline. A loop entered after an expensive
+// prologue must be priced by ITS OWN iterations, not by everything the
+// run spent before it existed — otherwise any loop first crossed past
+// the halfway mark of a budget is declined outright and never iterates,
+// which silently turns a review loop into a single-shot body.
+func TestLoopBudgetGuard_LateEnteredLoopIsPricedFromItsEntry(t *testing.T) {
+	wf := sequentialLoopsWorkflow(20_000)
+
+	var prologues, passes, delivered int
 	exec := newStubExecutor()
+	// The prologue alone burns 60% of the budget.
+	exec.on("prologue", func(_ map[string]any) (map[string]any, error) {
+		prologues++
+		return map[string]any{"ok": true, "_tokens": 12_000}, nil
+	})
+	// Each loop iteration is cheap — several fit in what is left.
 	exec.on("pass", func(_ map[string]any) (map[string]any, error) {
-		return map[string]any{"ok": true, "_cost_usd": 4.0}, nil
+		passes++
+		return map[string]any{"ok": true, "_tokens": 1_000}, nil
 	})
 	exec.on("gate", func(_ map[string]any) (map[string]any, error) {
 		return map[string]any{"converged": false}, nil
@@ -134,82 +213,181 @@ func TestLoopBudgetGuard_OffRestoresTheStrandingFailure(t *testing.T) {
 	})
 
 	eng := New(wf, tmpStore(t), exec)
-	err := eng.Run(context.Background(), "run-loop-budget-guard-off", nil)
-	if err == nil {
-		t.Fatal("expected the unguarded run to die on the cost budget")
-	}
-	if !strings.Contains(err.Error(), "budget exceeded") {
-		t.Errorf("error = %v, want a budget-exceeded failure", err)
-	}
-	if delivered != 0 {
-		t.Errorf("delivery tail ran %d times unguarded, want 0 (that is the defect)", delivered)
-	}
-}
-
-// TestLoopBudgetShortfall_PricesOneIterationAtATime covers the pricing
-// rule directly: each crossing is priced by the distance to the previous
-// mark, not by everything the run has spent.
-func TestLoopBudgetShortfall_PricesOneIterationAtATime(t *testing.T) {
-	wf := campaignShapedWorkflow(10.0)
-	eng := newEngineWith(t, wf)
-	rs := eng.newRunState("r", nil)
-	rs.budget = newSharedBudget(wf.Budget, eng.logger)
-
-	// Crossing 1 after a $4 pass: $6 left covers another $4.
-	rs.budget.RecordUsage(0, 4.0)
-	if dim, _, _ := eng.loopBudgetShortfall("continuation", rs); dim != "" {
-		t.Fatalf("first crossing reported a %q shortfall with $6 left for a $4 pass", dim)
+	if err := eng.Run(context.Background(), "run-late-loop", nil); err != nil {
+		t.Fatalf("run should finish through the delivery tail, got: %v", err)
 	}
 
-	// Crossing 2 after a second $4 pass: $2 left cannot cover $4. The
-	// price is the LAST pass ($4), not the run total ($8).
-	rs.budget.RecordUsage(0, 4.0)
-	dim, need, have := eng.loopBudgetShortfall("continuation", rs)
-	if dim != "cost_usd" {
-		t.Fatalf("second crossing = %q, want a cost_usd shortfall", dim)
+	if prologues != 1 {
+		t.Fatalf("prologue ran %d times, want 1", prologues)
 	}
-	if need != 4.0 {
-		t.Errorf("priced the next pass at %.2f, want 4.00 (the last one, not the total)", need)
+	if passes < 3 {
+		t.Errorf("the late-entered loop iterated %d times, want at least 3 — it was priced by the prologue instead of by its own body", passes)
 	}
-	if have != 2.0 {
-		t.Errorf("remaining = %.2f, want 2.00", have)
+	if delivered != 1 {
+		t.Errorf("delivery tail ran %d times, want 1", delivered)
 	}
 }
 
-// TestLoopBudgetShortfall_ResumeRebasesTheBaseline guards the resume
-// path: a run that resumes with most of its budget already spent must
-// price its next pass by the pass it just ran, not by the consumption it
-// inherited from the checkpoint — which would decline the back-edge on
-// the first crossing of every resumed run.
-func TestLoopBudgetShortfall_ResumeRebasesTheBaseline(t *testing.T) {
-	wf := campaignShapedWorkflow(100.0)
-	eng := newEngineWith(t, wf)
+// TestLoopBudgetGuard_ReEnteredLoopReBasesItsPrice covers the nested
+// shape: an inner loop re-entered on each outer iteration must be
+// re-priced at each entry. Carrying the mark from the previous instance
+// prices its first crossing by everything that ran in between — the
+// whole of the outer iteration — and declines it.
+func TestLoopBudgetGuard_ReEnteredLoopReBasesItsPrice(t *testing.T) {
+	wf := sequentialLoopsWorkflow(20_000)
+	eng := New(wf, tmpStore(t), newStubExecutor())
 	rs := eng.newRunState("r", nil)
 	rs.budget = newSharedBudget(wf.Budget, eng.logger)
+	eng.baselineUnpricedLoops(rs)
 
-	// Resume carrying $70 of prior spend, then run a $5 pass. $30 left
-	// covers another $5 — but only if the inherited $70 is not counted
-	// as this pass's price.
-	restoreBudgetAccounting(rs, &store.Checkpoint{BudgetCostUSD: 70.0})
-	rs.budget.RecordUsage(0, 5.0)
+	// An outer iteration runs and the inner loop is entered: the entry
+	// re-bases its price on what has been consumed by then.
+	rs.budget.RecordUsage(9_000, 0)
+	markLoopBudget(rs, "phase2")
 
-	if dim, need, have := eng.loopBudgetShortfall("continuation", rs); dim != "" {
-		t.Fatalf("resumed run declined its back-edge: %s needs %.2f, has %.2f — the baseline was not rebased", dim, need, have)
+	// One cheap inner iteration, then its first crossing of this instance.
+	rs.budget.RecordUsage(1_000, 0)
+	if v := eng.loopBudgetShortfall("phase2", rs); v != nil {
+		t.Fatalf("re-entered loop declined its first crossing: %s priced at %.0f with %.0f left — the mark was not re-based at entry",
+			v.dimension, v.spent, v.remaining)
 	}
 }
 
-// TestLoopBudgetShortfall_IgnoresUnenforcedAxes checks the guard only
-// speaks for caps that exist: a workflow that budgets cost alone must
-// never be stopped by a token or duration figure nobody bounded.
-func TestLoopBudgetShortfall_IgnoresUnenforcedAxes(t *testing.T) {
-	wf := campaignShapedWorkflow(1000.0)
-	eng := newEngineWith(t, wf)
+// TestLoopBudgetGuard_ConditionalBackEdgeIsNotPricedWhenItDoesNotMatch
+// covers a conditional back-edge (secured-renovacy's `when not
+// was_batch as package_loop(50)`). On a crossing where the condition is
+// false the edge was never a candidate, so it must not be reported as a
+// loop the budget could not fund — an operator reading that would be
+// told the wrong thing about a pure routing decision.
+func TestLoopBudgetGuard_ConditionalBackEdgeIsNotPricedWhenItDoesNotMatch(t *testing.T) {
+	wf := campaignShapedWorkflow(10_000)
+	// Make the back-edge conditional on `again`, which the gate denies.
+	for _, e := range wf.Edges {
+		if e.LoopName == "continuation" {
+			e.Condition = "again"
+		}
+	}
+
+	var delivered int
+	exec := newStubExecutor()
+	exec.on("pass", func(_ map[string]any) (map[string]any, error) {
+		// Spend enough that an unconditional guard WOULD decline.
+		return map[string]any{"ok": true, "_tokens": 8_000}, nil
+	})
+	exec.on("gate", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"converged": false, "again": false}, nil
+	})
+	exec.on("deliver", func(_ map[string]any) (map[string]any, error) {
+		delivered++
+		return map[string]any{"published": true}, nil
+	})
+
+	s := tmpStore(t)
+	eng := New(wf, s, exec)
+	if err := eng.Run(context.Background(), "run-cond-backedge", nil); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if delivered != 1 {
+		t.Fatalf("delivery tail ran %d times, want 1", delivered)
+	}
+
+	events, err := s.LoadEvents(context.Background(), "run-cond-backedge")
+	if err != nil {
+		t.Fatalf("load events: %v", err)
+	}
+	for _, ev := range events {
+		if ev.Type == store.EventBudgetWarning && ev.Data["reason"] == "loop_budget_guard" {
+			t.Fatal("reported a loop-budget decline for a back-edge whose `when` was false — it was never a candidate")
+		}
+	}
+}
+
+// TestLoopBudgetGuard_MarksSurviveResume is the regression for the
+// resume path. The checkpoint is written after EVERY successful node,
+// including a loop's cheap decision node, so a resume can land there and
+// cross the back-edge immediately. Without the persisted price that
+// crossing measures nothing, reports no shortfall, and launches a full
+// pass on an almost-spent budget — the exact stranding the guard exists
+// to prevent, on the documented "raise the cap + resume" recovery path.
+func TestLoopBudgetGuard_MarksSurviveResume(t *testing.T) {
+	wf := campaignShapedWorkflow(10_000)
+	eng := New(wf, tmpStore(t), newStubExecutor())
+
+	// A run that has spent 8k of its 10k, with the loop last priced at 5k
+	// (so one iteration costs 3k).
+	origin := eng.newRunState("r", nil)
+	origin.budget = newSharedBudget(wf.Budget, eng.logger)
+	origin.budget.RecordUsage(5_000, 0)
+	markLoopBudget(origin, "continuation")
+	origin.budget.RecordUsage(3_000, 0)
+
+	cp := buildCheckpoint(origin, "gate")
+	if len(cp.LoopBudgetMarks) == 0 {
+		t.Fatal("checkpoint carries no loop budget marks")
+	}
+
+	// Resume: consumption and prices are restored together.
+	resumed := eng.newRunState("r", nil)
+	resumed.budget = newSharedBudget(wf.Budget, eng.logger)
+	restoreBudgetAccounting(resumed, cp)
+	eng.baselineUnpricedLoops(resumed)
+
+	v := eng.loopBudgetShortfall("continuation", resumed)
+	if v == nil {
+		t.Fatal("resumed run reported no shortfall: it would launch a 3k pass with 2k left, stranding the work")
+	}
+	if v.dimension != "tokens" {
+		t.Errorf("shortfall dimension = %q, want tokens", v.dimension)
+	}
+}
+
+// TestLoopBudgetGuard_UnpricedLoopIsNotDeclined states the rule for a
+// loop with no measurement: report nothing rather than guess. Guessing
+// from run start is what charges a loop for work that predates it.
+func TestLoopBudgetGuard_UnpricedLoopIsNotDeclined(t *testing.T) {
+	wf := campaignShapedWorkflow(10_000)
+	eng := New(wf, tmpStore(t), newStubExecutor())
 	rs := eng.newRunState("r", nil)
 	rs.budget = newSharedBudget(wf.Budget, eng.logger)
 
-	// A pass burning a large token count against an unlimited token axis.
-	rs.budget.RecordUsage(5_000_000, 1.0)
-	if dim, _, _ := eng.loopBudgetShortfall("continuation", rs); dim != "" {
-		t.Fatalf("reported a %q shortfall on an axis the workflow does not cap", dim)
+	rs.budget.RecordUsage(9_500, 0)
+	if v := eng.loopBudgetShortfall("continuation", rs); v != nil {
+		t.Fatalf("declined an unmeasured loop on a %s guess", v.dimension)
+	}
+}
+
+// TestLoopBudgetGuard_IgnoresUnenforcedAxes checks the guard only speaks
+// for caps that exist: a workflow that budgets tokens alone must never
+// be stopped by a cost figure nobody bounded.
+func TestLoopBudgetGuard_IgnoresUnenforcedAxes(t *testing.T) {
+	wf := campaignShapedWorkflow(1_000_000)
+	eng := New(wf, tmpStore(t), newStubExecutor())
+	rs := eng.newRunState("r", nil)
+	rs.budget = newSharedBudget(wf.Budget, eng.logger)
+	eng.baselineUnpricedLoops(rs)
+
+	// A pass burning real dollars against an unlimited cost axis.
+	rs.budget.RecordUsage(1_000, 500.0)
+	if v := eng.loopBudgetShortfall("continuation", rs); v != nil {
+		t.Fatalf("reported a %q shortfall on an axis the workflow does not cap", v.dimension)
+	}
+}
+
+// TestLoopBudgetVerdict_DurationDisplayIsInSeconds guards the operator
+// signal: durations are tracked in nanoseconds, and the event is the
+// only thing telling someone why their run stopped iterating.
+func TestLoopBudgetVerdict_DurationDisplayIsInSeconds(t *testing.T) {
+	v := loopBudgetVerdict{dimension: "duration", spent: 4.5e12, remaining: 3.6e12, used: 3.6e12, limit: 7.2e12}
+	spent, remaining, _, _, unit := v.display()
+	if unit != "seconds" {
+		t.Errorf("unit = %q, want seconds", unit)
+	}
+	if spent != 4500 || remaining != 3600 {
+		t.Errorf("display = %.0f/%.0f, want 4500/3600 seconds", spent, remaining)
+	}
+
+	plain := loopBudgetVerdict{dimension: "tokens", spent: 3000, remaining: 2000}
+	if s, r, _, _, u := plain.display(); u != "" || s != 3000 || r != 2000 {
+		t.Errorf("non-duration axis was converted: %.0f/%.0f %q", s, r, u)
 	}
 }

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -702,8 +702,16 @@ type Checkpoint struct {
 	// snapshot and the very next iteration would see nil.
 	LoopPreviousOutput map[string]map[string]any `json:"loop_previous_output,omitempty" bson:"loop_previous_output,omitempty"`
 	LoopCurrentOutput  map[string]map[string]any `json:"loop_current_output,omitempty" bson:"loop_current_output,omitempty"`
-	ArtifactVersions   map[string]int            `json:"artifact_versions" bson:"artifact_versions"` // next artifact version per node
-	Vars               map[string]any            `json:"vars" bson:"vars"`                           // resolved workflow variables
+	// LoopBudgetMarks preserves what each loop had consumed, per budget
+	// dimension, at its last back-edge crossing (or at loop entry) — the
+	// basis on which the runtime prices one more iteration against the
+	// budget's remaining allowance. Without it a resume landing on a
+	// loop's decision node would cross with no measurement and launch a
+	// pass the budget cannot fund, which is exactly the stranding the
+	// affordability guard exists to prevent.
+	LoopBudgetMarks  map[string]map[string]float64 `json:"loop_budget_marks,omitempty" bson:"loop_budget_marks,omitempty"`
+	ArtifactVersions map[string]int                `json:"artifact_versions" bson:"artifact_versions"` // next artifact version per node
+	Vars             map[string]any                `json:"vars" bson:"vars"`                           // resolved workflow variables
 	// InteractionQuestions embeds the questions from the interaction record
 	// so that resume is self-sufficient even if the interaction file is deleted.
 	InteractionQuestions map[string]any `json:"interaction_questions,omitempty" bson:"interaction_questions,omitempty"`

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -4638,6 +4638,11 @@ export interface components {
             interaction_questions?: {
                 [key: string]: unknown;
             };
+            loop_budget_marks?: {
+                [key: string]: {
+                    [key: string]: number;
+                };
+            };
             loop_counters: {
                 [key: string]: number;
             };


### PR DESCRIPTION
## Why

iterion's own docs-refresh weeklies died on their cost cap two Mondays running (`019fc5c7` 08-03, `019fe9d3` 08-10) and delivered nothing either time. 31 and 29 real doc-alignment commits were stranded on clones that died with their pods, because a hard `BUDGET_EXCEEDED` at the `campaign` node never reaches the bot's PR tail — the only push path.

The cap was doing this while the run spent **no money**: prod runs the OAuth forfait, so `$231/$120` prices tokens against a plan already paid for, and the provider's own usage window (`You've hit your weekly limit · resets 7pm (UTC)`) is what actually bounds the run.

The overshoot was structural, not marginal — **+92%**. The budget is checked *between* nodes: pass 3 started with `budget_warning … used: 96.96` (\$23 of headroom) for a `campaign` node that is a whole claude_code session and had just cost \$63. The 90% hard limit doesn't catch it — 80.8% is under the line.

## What

Price one loop iteration by what the previous one consumed — the distance between two arrivals at the loop's decision point, on every axis the workflow actually caps — and **decline the back-edge when what's left is less than that**. The run leaves through its own exit path: the fall-through that already serves loop exhaustion.

```
  gate -> publish when converged
  gate -> work as passes(4)
  gate -> publish            # exhausted, or unaffordable: ship what is banked
```

Applied to 08-10's numbers it declines the third pass at \$97/\$120 and opens a PR with the 29 commits.

This sits beside the existing liveness-stall guard in `evaluateEdgesWithLoopsRS`, which declines a back-edge for the same structural reason. Generic — every v2 campaign bot banks work in stride and has this exposure.

- A **resumed** run rebases its baseline off the checkpoint, so the first crossing prices the pass it just ran, not every pass the run ever made.
- The decline is loud: `budget_warning{reason: loop_budget_guard}` with the loop, blocking dimension, remaining allowance and the price of the last iteration.
- Escape hatch: `ITERION_LOOP_BUDGET_GUARD=off`.
- The 90%-hard-limit and exceeded checks stay as the backstop for a single node that overruns on its own.

Also raises docs-refresh's ceiling 120 → 400 (bot 3.5.5) — safe to raise only *because* of the guard — and files the bilan for both dead weeklies.

## Tests

5 new tests in `pkg/runtime/loop_budget_test.go`, including the composition (a campaign-shaped graph reaches its delivery tail instead of dying) and a **non-vacuity control** that re-introduces the defect through the escape hatch and asserts the tail is never reached. Full `task lint` / `task test` / `task test:e2e` green.

## Incidental confirmation

The 08-03 run shows the resume/refail loop live — `campaign` restarted **9 times** at pass 4, 8 `budget_exceeded` events, each turn re-provisioning a sandbox to instantly re-hit the same spent budget. 08-10 has exactly one. `fix/budget-terminal-ack` (#361) landed between the two; this is its confirmation in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)