### PR TITLE
feat(cloud): carry loop_budget_guard onto the queue and into detached runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -431,8 +431,11 @@ work that preceded it; the prices ride the checkpoint. Visible as a
 `budget_warning` carrying `reason: loop_budget_guard`. Precedence mirrors
 `compress:` minus the node level (a loop is not a node): CLI
 `--loop-budget-guard` → workflow `loop_budget_guard:` →
-`ITERION_LOOP_BUDGET_GUARD` → on. Diagnostic C133. The 90%-hard-limit and
-exceeded checks remain the backstop for a single node that overruns. See
+`ITERION_LOOP_BUDGET_GUARD` → on. Diagnostic C133. Like `auto_memory:` and
+unlike `compress:`, the run-level override **travels onto the cloud queue**
+(`RunMessage.loop_budget_guard`, schema v7) and into a detached subprocess,
+so a pod never re-decides it. The 90%-hard-limit and exceeded checks remain
+the backstop for a single node that overruns. See
 [docs/dsl.md](docs/dsl.md#budget-and-loop-back-edges).
 
 ### Backend selection

--- a/cmd/iterion/remote_runs.go
+++ b/cmd/iterion/remote_runs.go
@@ -44,25 +44,26 @@ var remoteRunsListCmd = &cobra.Command{
 }
 
 var (
-	remoteLaunchBot            string
-	remoteLaunchVars           []string
-	remoteLaunchPreset         string
-	remoteLaunchTimeout        string
-	remoteLaunchBackend        string
-	remoteLaunchCompress       string
-	remoteLaunchAutoMemory     string
-	remoteLaunchPermission     string
-	remoteLaunchReviewMode     string
-	remoteLaunchMergeInto      string
-	remoteLaunchBranch         string
-	remoteLaunchMergeStrategy  string
-	remoteLaunchAutoMerge      bool
-	remoteLaunchAttach         []string
-	remoteLaunchModelOverrides string
-	remoteLaunchCallbackURL    string
-	remoteLaunchCallbackToken  string
-	remoteLaunchFollow         bool
-	remoteLaunchInterval       time.Duration
+	remoteLaunchBot             string
+	remoteLaunchVars            []string
+	remoteLaunchPreset          string
+	remoteLaunchTimeout         string
+	remoteLaunchBackend         string
+	remoteLaunchCompress        string
+	remoteLaunchAutoMemory      string
+	remoteLaunchLoopBudgetGuard string
+	remoteLaunchPermission      string
+	remoteLaunchReviewMode      string
+	remoteLaunchMergeInto       string
+	remoteLaunchBranch          string
+	remoteLaunchMergeStrategy   string
+	remoteLaunchAutoMerge       bool
+	remoteLaunchAttach          []string
+	remoteLaunchModelOverrides  string
+	remoteLaunchCallbackURL     string
+	remoteLaunchCallbackToken   string
+	remoteLaunchFollow          bool
+	remoteLaunchInterval        time.Duration
 )
 
 var remoteRunsLaunchCmd = &cobra.Command{
@@ -93,6 +94,7 @@ var remoteRunsLaunchCmd = &cobra.Command{
 			Backend:            remoteLaunchBackend,
 			Compress:           remoteLaunchCompress,
 			AutoMemory:         remoteLaunchAutoMemory,
+			LoopBudgetGuard:    remoteLaunchLoopBudgetGuard,
 			Permission:         remoteLaunchPermission,
 			ReviewMode:         remoteLaunchReviewMode,
 			MergeInto:          remoteLaunchMergeInto,
@@ -440,6 +442,7 @@ func init() {
 	remoteRunsLaunchCmd.Flags().StringVar(&remoteLaunchBackend, "backend", "", "Backend override (claude_code|claw)")
 	remoteRunsLaunchCmd.Flags().StringVar(&remoteLaunchCompress, "compress", "", "Compression override (on|ultra|off)")
 	remoteRunsLaunchCmd.Flags().StringVar(&remoteLaunchAutoMemory, "auto-memory", "", "Auto-memory (MEMORY.md) override (on|off)")
+	remoteRunsLaunchCmd.Flags().StringVar(&remoteLaunchLoopBudgetGuard, "loop-budget-guard", "", "Loop back-edge affordability guard override (on|off): refuse a loop iteration the budget cannot fund so the run exits through its own tail")
 	remoteRunsLaunchCmd.Flags().StringVar(&remoteLaunchPermission, "permission", "", "Permission gate override (off|ask|deny)")
 	remoteRunsLaunchCmd.Flags().StringVar(&remoteLaunchReviewMode, "review-mode", "", "Review topology (auto|mono|dual)")
 	remoteRunsLaunchCmd.Flags().StringVar(&remoteLaunchMergeInto, "merge-into", "", "Worktree finalization target (current|none|<branch>)")

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -515,6 +515,13 @@ value is diagnostic **C133**, not a silent fall back to the default. The
 90%-hard-limit and exceeded checks stay as the backstop for a single node
 that overruns on its own.
 
+The run-level override **travels** — onto the cloud queue
+(`RunMessage.loop_budget_guard`, schema v7) and into a detached
+subprocess — so a runner pod re-resolving the chain from its own empty
+environment cannot quietly replace what the operator asked for. It is not
+persisted on the run, so `iterion resume --loop-budget-guard` must
+re-state it.
+
 ```iter
 workflow campaign:
   entry: work

--- a/pkg/cli/remote_runs.go
+++ b/pkg/cli/remote_runs.go
@@ -67,20 +67,21 @@ func RemoteRunsList(ctx context.Context, c *RemoteClient, p *Printer, opts Remot
 
 // RemoteRunsLaunchOptions mirrors the POST /api/runs body the CLI fills.
 type RemoteRunsLaunchOptions struct {
-	FilePath      string // local .bot file; read and sent inline as source
-	BotID         string // catalog bot id (alternative to FilePath)
-	Vars          map[string]string
-	Preset        string
-	Timeout       string
-	Backend       string
-	Compress      string
-	AutoMemory    string
-	Permission    string
-	ReviewMode    string
-	MergeInto     string
-	BranchName    string
-	MergeStrategy string
-	AutoMerge     bool
+	FilePath        string // local .bot file; read and sent inline as source
+	BotID           string // catalog bot id (alternative to FilePath)
+	Vars            map[string]string
+	Preset          string
+	Timeout         string
+	Backend         string
+	Compress        string
+	AutoMemory      string
+	LoopBudgetGuard string
+	Permission      string
+	ReviewMode      string
+	MergeInto       string
+	BranchName      string
+	MergeStrategy   string
+	AutoMerge       bool
 	// Attach maps attachment name -> local file path; each is uploaded
 	// to /api/runs/uploads first and referenced by upload id.
 	Attach             map[string]string
@@ -111,18 +112,19 @@ func RemoteRunsLaunch(ctx context.Context, c *RemoteClient, p *Printer, opts Rem
 		req["vars"] = opts.Vars
 	}
 	for k, v := range map[string]string{
-		"preset":         opts.Preset,
-		"timeout":        opts.Timeout,
-		"backend":        opts.Backend,
-		"compress":       opts.Compress,
-		"auto_memory":    opts.AutoMemory,
-		"permission":     opts.Permission,
-		"review_mode":    opts.ReviewMode,
-		"merge_into":     opts.MergeInto,
-		"branch_name":    opts.BranchName,
-		"merge_strategy": opts.MergeStrategy,
-		"callback_url":   opts.CallbackURL,
-		"callback_token": opts.CallbackToken,
+		"preset":            opts.Preset,
+		"timeout":           opts.Timeout,
+		"backend":           opts.Backend,
+		"compress":          opts.Compress,
+		"auto_memory":       opts.AutoMemory,
+		"loop_budget_guard": opts.LoopBudgetGuard,
+		"permission":        opts.Permission,
+		"review_mode":       opts.ReviewMode,
+		"merge_into":        opts.MergeInto,
+		"branch_name":       opts.BranchName,
+		"merge_strategy":    opts.MergeStrategy,
+		"callback_url":      opts.CallbackURL,
+		"callback_token":    opts.CallbackToken,
 	} {
 		if v != "" {
 			req[k] = v

--- a/pkg/queue/types.go
+++ b/pkg/queue/types.go
@@ -39,7 +39,15 @@ import (
 // value, so an operator who asked for `off` on a bot whose DSL says `on` gets a
 // run that reads and writes shared memory anyway — the one thing the knob
 // exists to prevent, failing OPEN and in silence.
-const SchemaVersion = 6
+// v=7 (2026-08-11): added LoopBudgetGuard so a launch-time
+// `--loop-budget-guard` decision reaches the runner. Same direction of
+// failure as v=6, one layer down: dropping the field makes the run fall back
+// to the workflow's own value, so an operator who asked for `off` on a bot
+// that says nothing gets the guard anyway — and one who asked for `on` on a
+// bot declaring `off` gets a run that can still strand its work at the cap.
+// The knob decides whether a loop stops early or dies at its ceiling, which
+// is exactly the kind of choice that must not be quietly re-made on the pod.
+const SchemaVersion = 7
 
 // RunMessage is the JSON envelope published on
 // `iterion.queue.runs`. The runner deserialises it, takes the
@@ -79,11 +87,15 @@ type RunMessage struct {
 	// AutoMemory is the launch-time auto-memory (MEMORY.md) override — the
 	// wire half of the knob's strongest precedence level. Empty means the
 	// caller expressed nothing and the workflow/env decide.
-	AutoMemory     string        `json:"auto_memory,omitempty"`
-	BackendConfig  BackendConfig `json:"backend"`
-	Resume         *ResumeSpec   `json:"resume,omitempty"`
-	Trace          TraceContext  `json:"trace"`
-	PublishedAtRFC string        `json:"published_at"`
+	AutoMemory string `json:"auto_memory,omitempty"`
+	// LoopBudgetGuard is the launch-time back-edge affordability override —
+	// the wire half of that knob's strongest precedence level. Empty means
+	// the caller expressed nothing and the workflow/env decide.
+	LoopBudgetGuard string        `json:"loop_budget_guard,omitempty"`
+	BackendConfig   BackendConfig `json:"backend"`
+	Resume          *ResumeSpec   `json:"resume,omitempty"`
+	Trace           TraceContext  `json:"trace"`
+	PublishedAtRFC  string        `json:"published_at"`
 	// TenantID is the team_id the run belongs to. Required in v=2.
 	// Runners verify the loaded run document's tenant_id matches
 	// before claiming the lock; a mismatch is treated as a corrupted

--- a/pkg/queue/types_test.go
+++ b/pkg/queue/types_test.go
@@ -1,6 +1,7 @@
 package queue
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -168,7 +169,48 @@ func TestSchemaVersionConstant(t *testing.T) {
 	// decision reaches the runner instead of being replaced by the workflow's
 	// own value — a drop there turns a hermetic `off` into a run that reads
 	// and writes shared memory.
-	if SchemaVersion != 6 {
-		t.Errorf("SchemaVersion = %d, want 6 (bump intentionally)", SchemaVersion)
+	// v=7 (2026-08-11) added LoopBudgetGuard for the same reason one layer
+	// down: dropped, the pod re-decides whether a loop stops early or dies at
+	// its ceiling, overruling the operator who said otherwise.
+	if SchemaVersion != 7 {
+		t.Errorf("SchemaVersion = %d, want 7 (bump intentionally)", SchemaVersion)
+	}
+}
+
+// TestRunMessage_LoopBudgetGuardSurvivesTheWire is the composition that
+// matters for a knob whose whole point is to not be re-decided elsewhere:
+// an operator's explicit value must come out of the envelope exactly as it
+// went in, and an unset one must stay unset (so the workflow/env still
+// decide) rather than materialising as a value nobody chose.
+func TestRunMessage_LoopBudgetGuardSurvivesTheWire(t *testing.T) {
+	for _, want := range []string{"off", "on", ""} {
+		in := RunMessage{
+			V:              SchemaVersion,
+			RunID:          "r1",
+			WorkflowName:   "w",
+			WorkflowHash:   "h",
+			IRCompiled:     json.RawMessage(`{}`),
+			TenantID:       "t1",
+			PublishedAtRFC: "2026-08-11T00:00:00Z",
+
+			LoopBudgetGuard: want,
+		}
+		blob, err := json.Marshal(in)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if want == "" && bytes.Contains(blob, []byte("loop_budget_guard")) {
+			t.Error("an unset guard was serialised — the receiver would read a choice nobody made")
+		}
+		var out RunMessage
+		if err := json.Unmarshal(blob, &out); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if out.LoopBudgetGuard != want {
+			t.Errorf("LoopBudgetGuard = %q after the round trip, want %q", out.LoopBudgetGuard, want)
+		}
+		if err := out.Validate(); err != nil {
+			t.Errorf("validate: %v", err)
+		}
 	}
 }

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -1319,6 +1319,11 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 		// runner that is itself the isolation boundary beats a bot's inline
 		// sandbox block, so the run executes directly in the runner pod.
 		runtime.WithSandboxOverride(r.cfg.SandboxOverride),
+		// The launch-time decision, carried on the wire (schema v7). Without
+		// it the pod resolves the guard from the workflow and its own (empty)
+		// environment, so an operator's `--loop-budget-guard off` on a bot
+		// that declares nothing would run guarded anyway.
+		runtime.WithLoopBudgetGuard(msg.LoopBudgetGuard),
 		// Recovery recipes. Every other host wires these (pkg/cli/run.go,
 		// pkg/runview, pkg/dispatcher); the cloud runner did not, so
 		// recovery.Classify was never called on the one surface that runs

--- a/pkg/runview/detached.go
+++ b/pkg/runview/detached.go
@@ -79,6 +79,12 @@ type detachedSpec struct {
 	// so anything not passed here is silently replaced by the workflow's own
 	// value — which for `off` means running with memory ON.
 	AutoMemory string
+	// LoopBudgetGuard forwards the run-level back-edge affordability
+	// override as the CLI's --loop-budget-guard flag, for the same reason
+	// AutoMemory is forwarded: the subprocess re-resolves the knob from
+	// scratch, so anything not passed here is replaced by the workflow's
+	// own value.
+	LoopBudgetGuard string
 	// Budget forwards launch-time budget overrides as the CLI's
 	// --max-* flags, so the detached runner applies the same caps the
 	// in-process path would. Launch only; nil = no override.
@@ -105,6 +111,9 @@ func buildRunnerCmd(ctx context.Context, bin string, spec detachedSpec) (*exec.C
 		if spec.AutoMemory != "" {
 			args = append(args, "--auto-memory", spec.AutoMemory)
 		}
+		if spec.LoopBudgetGuard != "" {
+			args = append(args, "--loop-budget-guard", spec.LoopBudgetGuard)
+		}
 		if b := spec.Budget; b != nil {
 			if b.MaxCostUSD > 0 {
 				args = append(args, "--max-cost-usd", strconv.FormatFloat(b.MaxCostUSD, 'f', -1, 64))
@@ -126,6 +135,9 @@ func buildRunnerCmd(ctx context.Context, bin string, spec detachedSpec) (*exec.C
 		args = append(args, "resume", "--background", "--no-interactive", "--run-id", spec.RunID, "--file", spec.FilePath)
 		if spec.AutoMemory != "" {
 			args = append(args, "--auto-memory", spec.AutoMemory)
+		}
+		if spec.LoopBudgetGuard != "" {
+			args = append(args, "--loop-budget-guard", spec.LoopBudgetGuard)
 		}
 		if spec.Force {
 			args = append(args, "--force")
@@ -315,16 +327,17 @@ func (s *Service) launchDetached(parent context.Context, runID string, spec Laun
 	s.prepareRunLogNoFile(runID)
 
 	res, err := s.spawnDetached(parent, detachedSpec{
-		Command:    runnerCommandRun,
-		RunID:      runID,
-		FilePath:   spec.FilePath,
-		Vars:       spec.Vars,
-		StoreDir:   s.storeDir,
-		Timeout:    spec.Timeout,
-		MergeInto:  spec.MergeInto,
-		BranchName: spec.BranchName,
-		AutoMemory: spec.AutoMemory,
-		Budget:     spec.Budget,
+		Command:         runnerCommandRun,
+		RunID:           runID,
+		FilePath:        spec.FilePath,
+		Vars:            spec.Vars,
+		StoreDir:        s.storeDir,
+		Timeout:         spec.Timeout,
+		MergeInto:       spec.MergeInto,
+		BranchName:      spec.BranchName,
+		AutoMemory:      spec.AutoMemory,
+		LoopBudgetGuard: spec.LoopBudgetGuard,
+		Budget:          spec.Budget,
 	})
 	if err != nil {
 		// The doc was pre-created above; without a runner it would sit
@@ -360,14 +373,15 @@ func (s *Service) resumeDetached(parent context.Context, spec ResumeSpec) (*Laun
 	}
 
 	res, err := s.spawnDetached(parent, detachedSpec{
-		Command:    runnerCommandResume,
-		RunID:      spec.RunID,
-		FilePath:   spec.FilePath,
-		Answers:    answers,
-		StoreDir:   s.storeDir,
-		AutoMemory: spec.AutoMemory,
-		Force:      spec.Force,
-		Timeout:    spec.Timeout,
+		Command:         runnerCommandResume,
+		RunID:           spec.RunID,
+		FilePath:        spec.FilePath,
+		Answers:         answers,
+		StoreDir:        s.storeDir,
+		AutoMemory:      spec.AutoMemory,
+		LoopBudgetGuard: spec.LoopBudgetGuard,
+		Force:           spec.Force,
+		Timeout:         spec.Timeout,
 	})
 	if err != nil {
 		s.dropRunLog(spec.RunID)

--- a/pkg/runview/service.go
+++ b/pkg/runview/service.go
@@ -87,6 +87,10 @@ type LaunchSpec struct {
 	// "off") from the studio Launch toggle. "" inherits the workflow/node
 	// `auto_memory:` DSL then ITERION_AUTO_MEMORY.
 	AutoMemory string
+	// LoopBudgetGuard is the run-level back-edge affordability override
+	// ("", "on", "off"). "" inherits the workflow `loop_budget_guard:` then
+	// ITERION_LOOP_BUDGET_GUARD.
+	LoopBudgetGuard string
 	// Permission is the run-level tool-permission-gate mode override
 	// ("", "off", "ask", "deny") from the studio Launch toggle. ""
 	// inherits the workflow/node `permission:` DSL then
@@ -318,6 +322,9 @@ type ResumeSpec struct {
 	// back to the workflow's own value — turning memory on for a run the
 	// operator had launched hermetically.
 	AutoMemory string
+	// LoopBudgetGuard re-states the run-level back-edge affordability
+	// override ("", "on", "off"), for the same reason AutoMemory does.
+	LoopBudgetGuard string
 }
 
 // RunSummary is the lightweight per-row shape returned by List.

--- a/pkg/runview/service_launch.go
+++ b/pkg/runview/service_launch.go
@@ -267,7 +267,7 @@ func (s *Service) startInProcess(parent context.Context, runID string, spec Laun
 		spec.AttachmentPromote, spec.Preset, toRunModelOverrides(spec.ModelOverrides),
 		spec.ParentRunID,
 		precreateInputs,
-		launchExtras{workDir: spec.WorkDir, dailyCap: spec.DailyCap, source: spec.SourceRef, onOutcome: spec.OnOutcome, observers: spec.ExtraObservers},
+		launchExtras{workDir: spec.WorkDir, dailyCap: spec.DailyCap, source: spec.SourceRef, onOutcome: spec.OnOutcome, observers: spec.ExtraObservers, loopBudgetGuard: spec.LoopBudgetGuard},
 		s.store,
 		func(ctx context.Context, eng *runtime.Engine) error {
 			return eng.Run(ctx, runID, inputs)
@@ -441,7 +441,7 @@ func (s *Service) Resume(parent context.Context, spec ResumeSpec) (*LaunchResult
 		nil, r.Preset, nil,
 		r.ParentRunID,
 		nil,
-		launchExtras{},
+		launchExtras{loopBudgetGuard: spec.LoopBudgetGuard},
 		nil,
 		func(ctx context.Context, eng *runtime.Engine) error {
 			// Re-validate under the lock acquired by spawnRun (TOCTOU
@@ -752,6 +752,10 @@ type launchExtras struct {
 	// dispatcher's stall heartbeat the full store-level event stream
 	// without wrapping the store.
 	observers []func(store.Event)
+	// loopBudgetGuard mirrors LaunchSpec/ResumeSpec.LoopBudgetGuard: the
+	// run-level override for the back-edge affordability guard, the level
+	// above the workflow's own `loop_budget_guard:`.
+	loopBudgetGuard string
 }
 
 // engineOptions builds the standard option set for both Launch and
@@ -776,6 +780,9 @@ func (s *Service) engineOptions(runLogger *iterlog.Logger, hash, filePath, runNa
 	// stays neutral, mirroring the engine's own contract.
 	if s.sandboxDefault != "" {
 		opts = append(opts, runtime.WithSandboxDefault(s.sandboxDefault))
+	}
+	if ex.loopBudgetGuard != "" {
+		opts = append(opts, runtime.WithLoopBudgetGuard(ex.loopBudgetGuard))
 	}
 	// Per-launch WorkDir (ADR-046) overrides the service default; the
 	// dispatcher points it at the per-issue worktree so ${PROJECT_DIR}

--- a/pkg/runview/service_launch_loop_budget_test.go
+++ b/pkg/runview/service_launch_loop_budget_test.go
@@ -1,0 +1,130 @@
+package runview
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// loopBudgetBot is the campaign shape with no LLM in it: each pass is a
+// shell node that reports its own token usage, the gate never converges,
+// and a delivery tail sits on the fall-through the loop exits through.
+// Three passes fit under the cap; the fourth does not.
+const loopBudgetBot = `
+schema pass_out:
+  n: int
+
+schema gate_out:
+  converged: bool
+
+schema deliver_out:
+  delivered: bool
+
+tool work:
+  command: ` + "`printf '{\"n\":1,\"_tokens\":3000}'`" + `
+  output: pass_out
+
+compute gate:
+  output: gate_out
+  expr:
+    converged: "false"
+
+tool deliver:
+  command: ` + "`printf '{\"delivered\":true}'`" + `
+  output: deliver_out
+
+workflow loop_budget_demo:
+  budget:
+    max_tokens: 10000
+  entry: work
+  work -> gate
+  gate -> deliver when converged
+  gate -> work as passes(6)
+  gate -> deliver
+  deliver -> done
+`
+
+func writeLoopBudgetBot(t *testing.T, dir string) string {
+	t.Helper()
+	botPath := filepath.Join(dir, "loop_budget_demo.bot")
+	if err := os.WriteFile(botPath, []byte(loopBudgetBot), 0o644); err != nil {
+		t.Fatalf("write bot: %v", err)
+	}
+	return botPath
+}
+
+// launchLoopBudgetRun runs the bot once with the given run-level override
+// and reports the terminal status and whether the delivery tail executed.
+func launchLoopBudgetRun(t *testing.T, guard string) (store.RunStatus, bool) {
+	t.Helper()
+	dir := t.TempDir()
+	botPath := writeLoopBudgetBot(t, dir)
+
+	svc, err := NewService(dir, WithLogger(iterlog.Nop()))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	res, err := svc.Launch(context.Background(), LaunchSpec{
+		FilePath:        botPath,
+		LoopBudgetGuard: guard,
+	})
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	select {
+	case <-res.Done:
+	case <-time.After(60 * time.Second):
+		t.Fatal("run goroutine did not exit")
+	}
+
+	r, err := svc.store.LoadRun(context.Background(), res.RunID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	events, err := svc.store.LoadEvents(context.Background(), res.RunID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	delivered := false
+	for _, ev := range events {
+		if ev.NodeID == "deliver" && ev.Type == store.EventNodeFinished {
+			delivered = true
+		}
+	}
+	return r.Status, delivered
+}
+
+// TestLaunch_LoopBudgetGuardOverrideReachesTheEngine is the plumbing test
+// for a knob whose whole purpose is to not be re-decided downstream. The
+// same bot, launched twice through the same Service, must behave
+// differently on the strength of LaunchSpec.LoopBudgetGuard alone —
+// otherwise the field is decoration and the workflow silently wins.
+func TestLaunch_LoopBudgetGuardOverrideReachesTheEngine(t *testing.T) {
+	t.Setenv("ITERION_LOOP_BUDGET_GUARD", "")
+
+	t.Run("unset: guarded, exits through the delivery tail", func(t *testing.T) {
+		status, delivered := launchLoopBudgetRun(t, "")
+		if status != store.RunStatusFinished {
+			t.Errorf("status = %q, want %q", status, store.RunStatusFinished)
+		}
+		if !delivered {
+			t.Error("delivery tail did not run — the banked work was stranded")
+		}
+	})
+
+	t.Run("off: runs at the cap and strands the tail", func(t *testing.T) {
+		status, delivered := launchLoopBudgetRun(t, "off")
+		if status != store.RunStatusFailedResumable {
+			t.Errorf("status = %q, want %q — the override did not reach the engine", status, store.RunStatusFailedResumable)
+		}
+		if delivered {
+			t.Error("delivery tail ran with the guard off, want it stranded (that is what off means)")
+		}
+	})
+}

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -765,20 +765,21 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 	}
 	contributions = p.appendTenantBotSkills(ctx, contributions, tenantID, spec.BotID)
 	msg := &queue.RunMessage{
-		V:              queue.SchemaVersion,
-		Contributions:  contributions,
-		RunID:          runID,
-		WorkflowName:   wf.Name,
-		WorkflowHash:   hash,
-		IRCompiled:     body,
-		Vars:           varsAsAny(spec.Vars),
-		SecretsRef:     creds.secretsRef,
-		AutoMemory:     spec.AutoMemory,
-		BackendConfig:  queue.BackendConfig{Default: queue.BackendClaw},
-		PublishedAtRFC: time.Now().UTC().Format(time.RFC3339Nano),
-		TenantID:       tenantID,
-		OrgID:          orgID,
-		OwnerID:        ownerID,
+		V:               queue.SchemaVersion,
+		Contributions:   contributions,
+		RunID:           runID,
+		WorkflowName:    wf.Name,
+		WorkflowHash:    hash,
+		IRCompiled:      body,
+		Vars:            varsAsAny(spec.Vars),
+		SecretsRef:      creds.secretsRef,
+		AutoMemory:      spec.AutoMemory,
+		LoopBudgetGuard: spec.LoopBudgetGuard,
+		BackendConfig:   queue.BackendConfig{Default: queue.BackendClaw},
+		PublishedAtRFC:  time.Now().UTC().Format(time.RFC3339Nano),
+		TenantID:        tenantID,
+		OrgID:           orgID,
+		OwnerID:         ownerID,
 		// Cap. 3 sharding: when this run is a child shard, the runner
 		// pod that picks it up sees its place in the set so the studio
 		// can group siblings and so a future event-based aggregator
@@ -958,8 +959,9 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 			Answers: spec.Answers,
 			Force:   spec.Force,
 		},
-		SecretsRef: creds.secretsRef,
-		AutoMemory: spec.AutoMemory,
+		SecretsRef:      creds.secretsRef,
+		AutoMemory:      spec.AutoMemory,
+		LoopBudgetGuard: spec.LoopBudgetGuard,
 		// A resume re-acquires from the pool, so it re-inherits the donor's
 		// CURRENT remaining allowance as its cost ceiling — a run that was
 		// paused for a day must not come back holding yesterday's budget.

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -84,6 +84,10 @@ type launchRunRequest struct {
 	// ("on"|"off"). Empty inherits the workflow/node auto_memory: DSL then
 	// ITERION_AUTO_MEMORY. See docs/memory-and-knowledge.md.
 	AutoMemory string `json:"auto_memory,omitempty"`
+	// LoopBudgetGuard is the run-level override for the loop back-edge
+	// affordability guard ("on"|"off"). Empty inherits the workflow
+	// loop_budget_guard: DSL then ITERION_LOOP_BUDGET_GUARD. See docs/dsl.md.
+	LoopBudgetGuard string `json:"loop_budget_guard,omitempty"`
 	// Permission is the run-level tool-permission-gate mode override
 	// ("off"|"ask"|"deny"). Empty inherits the workflow/node permission:
 	// DSL then ITERION_PERMISSION. See docs/permissions.md.
@@ -380,6 +384,7 @@ func (s *Server) handleLaunchRun(w http.ResponseWriter, r *http.Request) {
 		Backend:           req.Backend,
 		Compress:          req.Compress,
 		AutoMemory:        req.AutoMemory,
+		LoopBudgetGuard:   req.LoopBudgetGuard,
 		Permission:        req.Permission,
 		ReviewMode:        req.ReviewMode,
 		// The manual path resolves the retry chain like every automated


### PR DESCRIPTION
Follow-up to #404, closing the last gap: the run-level override stopped at the launch boundary.

A cloud pod re-resolves every knob from the workflow and its own (empty) environment. So `--loop-budget-guard off` on a bot that declares nothing **ran guarded anyway**, and `on` against a bot declaring `off` could still strand its work at the cap. An operator's explicit choice, quietly re-made elsewhere — exactly the failure `auto_memory` closed at schema v6, and the thing CLAUDE.md names ("never silently replace an operator's explicit choice").

## What

`RunMessage.loop_budget_guard`, **schema v6 → v7**, plus the `--loop-budget-guard` arg on the detached-subprocess path. Every surface that can launch a run now carries the decision:

- HTTP `LaunchRequest.loop_budget_guard` → `runview.LaunchSpec` / `ResumeSpec`
- `iterion remote runs launch --loop-budget-guard`
- the in-process `Service` (`launchExtras` → `runtime.WithLoopBudgetGuard`)
- the detached CLI subprocess (`--loop-budget-guard` argv)
- the cloud publisher (launch **and** resume) → the runner pod

The version bump is deliberate and behaves as designed: `ErrSchemaVersion` is treated as **transient**, so a v7 message a not-yet-upgraded runner rejects is redelivered rather than dropped.

## Tests

- `TestLaunch_LoopBudgetGuardOverrideReachesTheEngine` — the composition, and the one that would have caught this: the **same bot** launched twice through the same `Service` must behave differently on the strength of `LaunchSpec.LoopBudgetGuard` alone (unset → finishes through the delivery tail; `off` → dies at the cap with the tail unreached). No LLM: each pass is a shell node reporting its own `_tokens`. **Verified non-vacuous** — removing the `engineOptions` wiring makes the `off` subtest fail.
- `TestRunMessage_LoopBudgetGuardSurvivesTheWire` — the value comes out of the envelope as it went in, and an unset one stays **absent** from the JSON rather than materialising as a choice nobody made.
- `TestSchemaVersionConstant` pinned to 7 with the rationale.

Full `task lint` / `task test` / `task test:e2e` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)