### PR TITLE
fix: the last two Vetty holds, and the git-env scrub everywhere it belongs

### DIFF
--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -808,23 +808,18 @@ except OSError:
 # wrote nothing, not for the one that wrote a reported answer.
 _noops = ('set', 'cd', 'exit', 'true', ':', 'export', 'unset', 'shift')
 _runs = 0
-_bare = []
-_eff = 0
 _hd = ''
-_roots = [ws]
 for _ln in _lines:
     _s = _ln.strip()
-    # A here-doc body is DATA, not commands. Writing a path list into one is
-    # the natural shape for feeding a runner a set of paths -- which is exactly
-    # what the rejection below tells the agent to do, so scanning it would
-    # reject the remediation it recommends.
+    # A here-doc body is DATA, not commands: a script writing a path list into
+    # one has not run those paths, and counting them would call an empty script
+    # busy.
     if _hd:
         if _s == _hd:
             _hd = ''
         continue
     if not _s or _s.startswith('#'):
         continue
-    _eff = _eff + 1
     # Per SEGMENT, not per line: a directory change chained to the build leads
     # with a no-op and runs everything. Judging a line by its first word alone
     # would reject the most ordinary script shape there is. (No quote or dollar
@@ -840,10 +835,6 @@ for _ln in _lines:
             break
     # The opener itself is a command and was counted above; from the NEXT line
     # the body is data. A herestring (<<<) has no body, so it is left alone.
-    if _s.split()[0] == 'cd' and len(_s.split()) > 1:
-        _cd = _s.split()[1].strip(chr(39) + chr(34))
-        if (chr(36) not in _cd) and ('*' not in _cd) and ('~' not in _cd):
-            _roots.append(_cd if _cd.startswith('/') else os.path.join(ws, _cd))
     _lt = chr(60) + chr(60)
     if _lt in _s:
         _t = _s.split(_lt, 1)[1]
@@ -853,41 +844,8 @@ for _ln in _lines:
             _t = _t.strip()
             if _t:
                 _hd = _t.split()[0].strip(chr(39) + chr(34))
-    # Any WORD containing a slash is a pathname to the shell, with or without a
-    # leading ./ -- and a listing is as likely to come out of git ls-files or
-    # go list (bare relative paths) as hand-written with the prefix.
-    if (' ' in _s) or (chr(9) in _s) or ('/' not in _s):
-        continue
-    # Anything the shell cannot resolve statically is left alone: a variable,
-    # a glob or a home-relative path is not a listing.
-    if (chr(36) in _s) or ('*' in _s) or ('?' in _s) or ('~' in _s) or (chr(96) in _s):
-        continue
-    # Resolved against every directory the script cds into, not just the
-    # workspace root: a verify.sh that enters a subdirectory and then calls its
-    # helpers by relative name is ordinary, and anchoring at the root alone
-    # would read those calls as an unrunnable listing.
-    _hit = False
-    for _root in _roots:
-        _pp = _s if _s.startswith('/') else os.path.join(_root, _s)
-        if os.path.isfile(_pp) and os.access(_pp, os.X_OK):
-            _hit = True
-            break
-    # POSIX: a word containing a slash is never PATH-searched, so anything that
-    # is not an executable regular file is GUARANTEED to fail as a command --
-    # an import path out of go list and a directory out of find fail exactly
-    # like the unexecutable file, and testing only for files missed both.
-    if not _hit:
-        _bare.append(_s)
 if _runs == 0:
     _r = 'EMPTY SCRIPT: ' + script + ' runs nothing -- only blank lines, comments, or shell no-ops. It would exit 0 and certify a build that was never attempted. Write the repo own build and test commands (verify-build skill section 1).'
-    print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 3, 'precheck_rejected': True, 'precheck_reason': _r, 'log_tail': _r}))
-    raise SystemExit(0)
-# A PROPORTION, not a count: what made iterion#398 a listing is that nearly
-# every line was one. A handful of unresolvable words among real commands is
-# an ordinary script -- four of this guard's own false positives were exactly
-# that shape -- so the rejection needs the script to be MOSTLY listing.
-if len(_bare) > 3 and (len(_bare) * 2) > _eff:
-    _r = 'NOT COMMANDS: ' + str(len(_bare)) + '+ lines of ' + script + ' are bare paths the shell cannot execute (e.g. ' + ', '.join(_bare[:3]) + '). That is a file listing pasted in as commands; sh answers each with Permission denied and the run reports a red build that never ran. Invoke the repo own test runner over those paths instead.'
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 3, 'precheck_rejected': True, 'precheck_reason': _r, 'log_tail': _r}))
     raise SystemExit(0)
 def tree_state():

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -806,22 +806,39 @@ for _ln in _lines:
     _s = _ln.strip()
     if not _s or _s.startswith('#'):
         continue
-    if _s.split()[0] not in _noops:
-        _runs = _runs + 1
+    # Per SEGMENT, not per line: cd "$WS" && task check leads with a no-op and
+    # runs the whole build. Judging the line by its first word alone would
+    # reject the most ordinary script shape there is.
+    _seg = _s
+    for _sep in (chr(38) + chr(38), chr(124) + chr(124), ';', chr(124)):
+        _seg = _seg.replace(_sep, chr(10))
+    for _c in _seg.split(chr(10)):
+        _c = _c.strip()
+        if _c and _c.split()[0] not in _noops:
+            _runs = _runs + 1
+            break
     # Any WORD containing a slash is a pathname to the shell, with or without a
     # leading ./ -- and a listing is as likely to come out of git ls-files or
     # go list (bare relative paths) as hand-written with the prefix.
     if (' ' in _s) or (chr(9) in _s) or ('/' not in _s):
         continue
+    # Anything the shell cannot resolve statically is left alone: a variable,
+    # a glob or a home-relative path is not a listing.
+    if (chr(36) in _s) or ('*' in _s) or ('?' in _s) or ('~' in _s) or (chr(96) in _s):
+        continue
     _p = _s if _s.startswith('/') else os.path.join(ws, _s)
-    if os.path.isfile(_p) and not os.access(_p, os.X_OK):
+    # POSIX: a word containing a slash is never PATH-searched, so anything that
+    # is not an executable regular file is GUARANTEED to fail as a command --
+    # an import path out of go list and a directory out of find fail exactly
+    # like the unexecutable file, and testing only for files missed both.
+    if not (os.path.isfile(_p) and os.access(_p, os.X_OK)):
         _bare.append(_s)
 if _runs == 0:
     _r = 'EMPTY SCRIPT: ' + script + ' runs nothing -- only blank lines, comments, or shell no-ops. It would exit 0 and certify a build that was never attempted. Write the repo own build and test commands (verify-build skill section 1).'
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 3, 'precheck_rejected': True, 'precheck_reason': _r, 'log_tail': _r}))
     raise SystemExit(0)
 if len(_bare) > 3:
-    _r = 'NOT COMMANDS: ' + str(len(_bare)) + '+ lines of ' + script + ' are bare paths to files the shell cannot execute (e.g. ' + ', '.join(_bare[:3]) + '). That is a file listing pasted in as commands; sh answers each with Permission denied and the run reports a red build that never ran. Invoke the repo own test runner over those paths instead.'
+    _r = 'NOT COMMANDS: ' + str(len(_bare)) + '+ lines of ' + script + ' are bare paths the shell cannot execute (e.g. ' + ', '.join(_bare[:3]) + '). That is a file listing pasted in as commands; sh answers each with Permission denied and the run reports a red build that never ran. Invoke the repo own test runner over those paths instead.'
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 3, 'precheck_rejected': True, 'precheck_reason': _r, 'log_tail': _r}))
     raise SystemExit(0)
 def tree_state():

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -809,8 +809,8 @@ except OSError:
 _noops = ('set', 'cd', 'exit', 'true', ':', 'export', 'unset', 'shift')
 _runs = 0
 _hd = ''
-for _ln in _lines:
-    _s = _ln.strip()
+for _i in range(len(_lines)):
+    _s = _lines[_i].strip()
     # A here-doc body is DATA, not commands: a script writing a path list into
     # one has not run those paths, and counting them would call an empty script
     # busy.
@@ -843,7 +843,15 @@ for _ln in _lines:
                 _t = _t[1:]
             _t = _t.strip()
             if _t:
-                _hd = _t.split()[0].strip(chr(39) + chr(34))
+                _t = _t.split()[0].strip(chr(39) + chr(34))
+                # Only if the terminator really appears later. Otherwise a
+                # quoted value or an end-of-line comment containing << opens a
+                # here-doc that never closes and swallows the rest of the
+                # script, which then reads as running nothing.
+                for _rest in _lines[_i + 1:]:
+                    if _rest.strip() == _t:
+                        _hd = _t
+                        break
 if _runs == 0:
     _r = 'EMPTY SCRIPT: ' + script + ' runs nothing -- only blank lines, comments, or shell no-ops. It would exit 0 and certify a build that was never attempted. Write the repo own build and test commands (verify-build skill section 1).'
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 3, 'precheck_rejected': True, 'precheck_reason': _r, 'log_tail': _r}))

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -799,7 +799,14 @@ except OSError:
 # path is newly reachable: the loop-back above asks an agent that already
 # skipped authorship to write something, and the cheapest way to satisfy that
 # pressure must not be a green commit. Shell no-ops do not count as running.
-_noops = ('set', 'cd', 'exit', 'true', ':', 'export', 'unset', 'echo', 'shift')
+#
+# echo is NOT among them, deliberately: verify_system step 5 tells the agent
+# that a repo with genuinely no build or test system gets a script echoing
+# that and exiting 0. Counting echo as a no-op rejected the one shape the
+# prompt prescribes, looped twice, and held a bump that broke nothing -- the
+# false red this whole change exists to remove. A floor is for the run that
+# wrote nothing, not for the one that wrote a reported answer.
+_noops = ('set', 'cd', 'exit', 'true', ':', 'export', 'unset', 'shift')
 _runs = 0
 _bare = []
 _hd = ''

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -803,6 +803,7 @@ _noops = ('set', 'cd', 'exit', 'true', ':', 'export', 'unset', 'echo', 'shift')
 _runs = 0
 _bare = []
 _hd = ''
+_roots = [ws]
 for _ln in _lines:
     _s = _ln.strip()
     # A here-doc body is DATA, not commands. Writing a path list into one is
@@ -815,9 +816,11 @@ for _ln in _lines:
         continue
     if not _s or _s.startswith('#'):
         continue
-    # Per SEGMENT, not per line: cd "$WS" && task check leads with a no-op and
-    # runs the whole build. Judging the line by its first word alone would
-    # reject the most ordinary script shape there is.
+    # Per SEGMENT, not per line: a directory change chained to the build leads
+    # with a no-op and runs everything. Judging a line by its first word alone
+    # would reject the most ordinary script shape there is. (No quote or dollar
+    # in this body: it is a shell double-quoted argument, hence the chr() forms
+    # throughout -- one stray quote truncates the whole gate.)
     _seg = _s
     for _sep in (chr(38) + chr(38), chr(124) + chr(124), ';', chr(124)):
         _seg = _seg.replace(_sep, chr(10))
@@ -828,6 +831,10 @@ for _ln in _lines:
             break
     # The opener itself is a command and was counted above; from the NEXT line
     # the body is data. A herestring (<<<) has no body, so it is left alone.
+    if _s.split()[0] == 'cd' and len(_s.split()) > 1:
+        _cd = _s.split()[1].strip(chr(39) + chr(34))
+        if (chr(36) not in _cd) and ('*' not in _cd) and ('~' not in _cd):
+            _roots.append(_cd if _cd.startswith('/') else os.path.join(ws, _cd))
     _lt = chr(60) + chr(60)
     if _lt in _s:
         _t = _s.split(_lt, 1)[1]
@@ -846,12 +853,23 @@ for _ln in _lines:
     # a glob or a home-relative path is not a listing.
     if (chr(36) in _s) or ('*' in _s) or ('?' in _s) or ('~' in _s) or (chr(96) in _s):
         continue
+    # Resolved against every directory the script cds into, not just the
+    # workspace root: a verify.sh that enters a subdirectory and then calls its
+    # helpers by relative name is ordinary, and anchoring at the root alone
+    # would read those calls as an unrunnable listing.
+    _cands = [_p2 for _p2 in _roots]
+    _hit = False
+    for _root in _cands:
+        _pp = _s if _s.startswith('/') else os.path.join(_root, _s)
+        if os.path.isfile(_pp) and os.access(_pp, os.X_OK):
+            _hit = True
+            break
     _p = _s if _s.startswith('/') else os.path.join(ws, _s)
     # POSIX: a word containing a slash is never PATH-searched, so anything that
     # is not an executable regular file is GUARANTEED to fail as a command --
     # an import path out of go list and a directory out of find fail exactly
     # like the unexecutable file, and testing only for files missed both.
-    if not (os.path.isfile(_p) and os.access(_p, os.X_OK)):
+    if not _hit:
         _bare.append(_s)
 if _runs == 0:
     _r = 'EMPTY SCRIPT: ' + script + ' runs nothing -- only blank lines, comments, or shell no-ops. It would exit 0 and certify a build that was never attempted. Write the repo own build and test commands (verify-build skill section 1).'

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -802,8 +802,17 @@ except OSError:
 _noops = ('set', 'cd', 'exit', 'true', ':', 'export', 'unset', 'echo', 'shift')
 _runs = 0
 _bare = []
+_hd = ''
 for _ln in _lines:
     _s = _ln.strip()
+    # A here-doc body is DATA, not commands. Writing a path list into one is
+    # the natural shape for feeding a runner a set of paths -- which is exactly
+    # what the rejection below tells the agent to do, so scanning it would
+    # reject the remediation it recommends.
+    if _hd:
+        if _s == _hd:
+            _hd = ''
+        continue
     if not _s or _s.startswith('#'):
         continue
     # Per SEGMENT, not per line: cd "$WS" && task check leads with a no-op and
@@ -817,6 +826,17 @@ for _ln in _lines:
         if _c and _c.split()[0] not in _noops:
             _runs = _runs + 1
             break
+    # The opener itself is a command and was counted above; from the NEXT line
+    # the body is data. A herestring (<<<) has no body, so it is left alone.
+    _lt = chr(60) + chr(60)
+    if _lt in _s:
+        _t = _s.split(_lt, 1)[1]
+        if not _t.startswith(chr(60)):
+            if _t.startswith('-'):
+                _t = _t[1:]
+            _t = _t.strip()
+            if _t:
+                _hd = _t.split()[0].strip(chr(39) + chr(34))
     # Any WORD containing a slash is a pathname to the shell, with or without a
     # leading ./ -- and a listing is as likely to come out of git ls-files or
     # go list (bare relative paths) as hand-written with the prefix.

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -809,6 +809,7 @@ except OSError:
 _noops = ('set', 'cd', 'exit', 'true', ':', 'export', 'unset', 'shift')
 _runs = 0
 _bare = []
+_eff = 0
 _hd = ''
 _roots = [ws]
 for _ln in _lines:
@@ -823,6 +824,7 @@ for _ln in _lines:
         continue
     if not _s or _s.startswith('#'):
         continue
+    _eff = _eff + 1
     # Per SEGMENT, not per line: a directory change chained to the build leads
     # with a no-op and runs everything. Judging a line by its first word alone
     # would reject the most ordinary script shape there is. (No quote or dollar
@@ -864,14 +866,12 @@ for _ln in _lines:
     # workspace root: a verify.sh that enters a subdirectory and then calls its
     # helpers by relative name is ordinary, and anchoring at the root alone
     # would read those calls as an unrunnable listing.
-    _cands = [_p2 for _p2 in _roots]
     _hit = False
-    for _root in _cands:
+    for _root in _roots:
         _pp = _s if _s.startswith('/') else os.path.join(_root, _s)
         if os.path.isfile(_pp) and os.access(_pp, os.X_OK):
             _hit = True
             break
-    _p = _s if _s.startswith('/') else os.path.join(ws, _s)
     # POSIX: a word containing a slash is never PATH-searched, so anything that
     # is not an executable regular file is GUARANTEED to fail as a command --
     # an import path out of go list and a directory out of find fail exactly
@@ -882,7 +882,11 @@ if _runs == 0:
     _r = 'EMPTY SCRIPT: ' + script + ' runs nothing -- only blank lines, comments, or shell no-ops. It would exit 0 and certify a build that was never attempted. Write the repo own build and test commands (verify-build skill section 1).'
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 3, 'precheck_rejected': True, 'precheck_reason': _r, 'log_tail': _r}))
     raise SystemExit(0)
-if len(_bare) > 3:
+# A PROPORTION, not a count: what made iterion#398 a listing is that nearly
+# every line was one. A handful of unresolvable words among real commands is
+# an ordinary script -- four of this guard's own false positives were exactly
+# that shape -- so the rejection needs the script to be MOSTLY listing.
+if len(_bare) > 3 and (len(_bare) * 2) > _eff:
     _r = 'NOT COMMANDS: ' + str(len(_bare)) + '+ lines of ' + script + ' are bare paths the shell cannot execute (e.g. ' + ', '.join(_bare[:3]) + '). That is a file listing pasted in as commands; sh answers each with Permission denied and the run reports a red build that never ran. Invoke the repo own test runner over those paths instead.'
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 3, 'precheck_rejected': True, 'precheck_reason': _r, 'log_tail': _r}))
     raise SystemExit(0)

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -795,18 +795,31 @@ try:
     _lines = open(script, encoding='utf-8', errors='replace').read().splitlines()
 except OSError:
     _lines = []
+# A script that runs NOTHING exits 0, which reads as a verified build. That
+# path is newly reachable: the loop-back above asks an agent that already
+# skipped authorship to write something, and the cheapest way to satisfy that
+# pressure must not be a green commit. Shell no-ops do not count as running.
+_noops = ('set', 'cd', 'exit', 'true', ':', 'export', 'unset', 'echo', 'shift')
+_runs = 0
 _bare = []
 for _ln in _lines:
     _s = _ln.strip()
-    if not _s or _s.startswith('#') or (' ' in _s) or (chr(9) in _s):
+    if not _s or _s.startswith('#'):
         continue
-    if not (_s.startswith('./') or _s.startswith('/')):
+    if _s.split()[0] not in _noops:
+        _runs = _runs + 1
+    # Any WORD containing a slash is a pathname to the shell, with or without a
+    # leading ./ -- and a listing is as likely to come out of git ls-files or
+    # go list (bare relative paths) as hand-written with the prefix.
+    if (' ' in _s) or (chr(9) in _s) or ('/' not in _s):
         continue
-    _p = os.path.join(ws, _s[2:]) if _s.startswith('./') else _s
+    _p = _s if _s.startswith('/') else os.path.join(ws, _s)
     if os.path.isfile(_p) and not os.access(_p, os.X_OK):
         _bare.append(_s)
-        if len(_bare) > 3:
-            break
+if _runs == 0:
+    _r = 'EMPTY SCRIPT: ' + script + ' runs nothing -- only blank lines, comments, or shell no-ops. It would exit 0 and certify a build that was never attempted. Write the repo own build and test commands (verify-build skill section 1).'
+    print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 3, 'precheck_rejected': True, 'precheck_reason': _r, 'log_tail': _r}))
+    raise SystemExit(0)
 if len(_bare) > 3:
     _r = 'NOT COMMANDS: ' + str(len(_bare)) + '+ lines of ' + script + ' are bare paths to files the shell cannot execute (e.g. ' + ', '.join(_bare[:3]) + '). That is a file listing pasted in as commands; sh answers each with Permission denied and the run reports a red build that never ran. Invoke the repo own test runner over those paths instead.'
     print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 3, 'precheck_rejected': True, 'precheck_reason': _r, 'log_tail': _r}))

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -778,8 +778,38 @@ try:
 except OSError:
     pass
 script = os.path.join(scratch, 'verify.sh')
+# No script is an AUTHORSHIP defect, not a red build: the agent skipped a step
+# rather than proved a failure. It loops back with that said, because otherwise
+# a bump whose alignment is legitimately empty -- a base-image digest refresh,
+# say -- can never clear the gate no matter how correct it is (iterion#390).
+# The commit path stays closed either way; on loop exhaustion this holds as before.
 if not os.path.exists(script):
-    print(json.dumps({'passed': False, 'skipped': True, 'exit_code': 1, 'precheck_rejected': False, 'precheck_reason': '', 'log_tail': 'verify_build produced no verify.sh -- refusing to commit an unverified alignment (fail-closed: this gate is the only path to commit).'}))
+    print(json.dumps({'passed': False, 'skipped': True, 'exit_code': 3, 'precheck_rejected': True, 'precheck_reason': 'NO SCRIPT: verify_build wrote no ' + script + '. Write one -- a bump that needed no code alignment still has to prove the repo builds, and mirroring the CI is not conditional on what the bump touched (verify-build skill section 1b).', 'log_tail': 'verify_build produced no verify.sh.'}))
+    raise SystemExit(0)
+# A script whose lines are bare paths to non-executable files is a file listing
+# pasted in as commands: sh answers every one with Permission denied and the
+# verify reports a red build that never ran (iterion#398, ~2300 such lines). No
+# extension list -- the test is that the path names a file the shell cannot
+# execute, which holds for any language.
+try:
+    _lines = open(script, encoding='utf-8', errors='replace').read().splitlines()
+except OSError:
+    _lines = []
+_bare = []
+for _ln in _lines:
+    _s = _ln.strip()
+    if not _s or _s.startswith('#') or (' ' in _s) or (chr(9) in _s):
+        continue
+    if not (_s.startswith('./') or _s.startswith('/')):
+        continue
+    _p = os.path.join(ws, _s[2:]) if _s.startswith('./') else _s
+    if os.path.isfile(_p) and not os.access(_p, os.X_OK):
+        _bare.append(_s)
+        if len(_bare) > 3:
+            break
+if len(_bare) > 3:
+    _r = 'NOT COMMANDS: ' + str(len(_bare)) + '+ lines of ' + script + ' are bare paths to files the shell cannot execute (e.g. ' + ', '.join(_bare[:3]) + '). That is a file listing pasted in as commands; sh answers each with Permission denied and the run reports a red build that never ran. Invoke the repo own test runner over those paths instead.'
+    print(json.dumps({'passed': False, 'skipped': False, 'exit_code': 3, 'precheck_rejected': True, 'precheck_reason': _r, 'log_tail': _r}))
     raise SystemExit(0)
 def tree_state():
     try:

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,17 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.7.3
+version: 2.7.4
+## 2.7.4 — the listing check is removed, not patched again. Rejecting a
+## verify.sh whose lines are paths rather than commands (iterion#398) meant
+## judging shell text statically, and eight review rounds each found the next
+## spelling it read wrong: a leading cd, a here-doc body, a subdirectory
+## helper, a backslash continuation, an artifact the script builds first. Every
+## one of those held a bump that builds -- the exact failure the check was
+## added to prevent, inflicted by the check. The two prechecks that remain are
+## decidable from the file alone (no script; a script that runs nothing), and
+## the rule that every line must be a command stays in the verify-build skill,
+## where it costs nothing when the agent gets it wrong.
 ## 2.7.3 — Revi hardening of 2.7.2, both defects inside the new guards.
 ## (a) The bare-path test keyed on a ./ or / prefix, but POSIX sh executes any
 ## WORD containing a slash as a pathname -- and a listing out of git ls-files

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,18 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.7.1
+version: 2.7.2
+## 2.7.2 — the two verify-authorship defects from the 2026-08-10 batch become
+## precheck REJECTIONS that loop back, instead of red builds that hold. A
+## missing verify.sh (iterion#390: a base-image digest refresh whose correct
+## alignment was empty, and which could therefore never clear the gate) and a
+## script whose lines are bare paths the shell cannot execute (iterion#398:
+## ~2300 of them, every one answered Permission denied while the real test
+## surface was green) are steps the agent skipped, not facts about the bump.
+## Reported as red builds they are indistinguishable from one; reported as
+## rejections they self-heal in-loop and the commit path stays just as closed.
+## The bare-path test names no file extension — it asks whether the path is a
+## file the shell cannot execute, which holds in any language.
 ## 2.7.1 — the align step regenerates a lockfile the bump left stale. A bot
 ## that edits the manifest without the lockfile makes CI's frozen install
 ## fail on a specifier mismatch before any code compiles: the bump is

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,18 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.7.2
+version: 2.7.3
+## 2.7.3 — Revi hardening of 2.7.2, both defects inside the new guards.
+## (a) The bare-path test keyed on a ./ or / prefix, but POSIX sh executes any
+## WORD containing a slash as a pathname -- and a listing out of git ls-files
+## or go list carries no prefix, so whether the guard fired depended on how the
+## agent spelled it. Now: any line that is a single word containing a slash and
+## naming a file the shell cannot execute. (b) Nothing rejected a script that
+## runs NOTHING. An empty or comment-only verify.sh exits 0, which the gate
+## reads as a verified build -- and 2.7.2 made that newly reachable by asking
+## an agent that already skipped authorship to write SOMETHING, with no floor
+## on what counts. A vacuous script was the cheapest way to satisfy that
+## pressure, turning a previously fail-closed path into a green commit.
 ## 2.7.2 — the two verify-authorship defects from the 2026-08-10 batch become
 ## precheck REJECTIONS that loop back, instead of red builds that hold. A
 ## missing verify.sh (iterion#390: a base-image digest refresh whose correct

--- a/bots/dep-update-guard/skills/verify-build.md
+++ b/bots/dep-update-guard/skills/verify-build.md
@@ -179,9 +179,9 @@ comment-only script exits 0, which the gate reads as a verified build — so
 shell tries to execute it, answers `Permission denied`, and the run reports a
 red build that never ran. To exercise a set of files, pass them to the repo's
 own runner (`go test ./...`, `pytest tests/`, `npm test`) — the runner takes
-paths, the shell does not. A script whose lines are mostly bare paths to files
-the shell cannot execute is rejected before it runs, and you are asked to
-rewrite it.
+paths, the shell does not. Nothing catches this for you: a script of paths runs,
+fails on every line, and reports a red build for a bump that broke nothing —
+which an operator then has to read the log to disbelieve.
 
 ## 3. Run it, and fix what the just-applied changes broke
 

--- a/bots/dep-update-guard/skills/verify-build.md
+++ b/bots/dep-update-guard/skills/verify-build.md
@@ -161,6 +161,23 @@ exit code — so it must genuinely pass, not merely look plausible. A `verify.sh
 that omits the §1b regen step when the repo has generated artifacts is the
 canonical way a change lands green-locally / red-in-CI.
 
+**Write the script even when the bump needed no alignment.** "Nothing changed
+in the code, so there is nothing to verify" is the reasoning to refuse: the
+gate proves the repo still builds with the new dependency, which is exactly the
+question a base-image digest refresh or a lockfile-only bump raises. A run that
+produces no script proves nothing and cannot commit — it is sent back to write
+one, and after two attempts the PR is held on a verdict that says the build was
+never established. §1b applies here too: what the script covers is decided by
+the repo's CI, never by which files the bump happened to touch.
+
+**Every line must be a COMMAND.** Never emit a bare path to a source file: the
+shell tries to execute it, answers `Permission denied`, and the run reports a
+red build that never ran. To exercise a set of files, pass them to the repo's
+own runner (`go test ./...`, `pytest tests/`, `npm test`) — the runner takes
+paths, the shell does not. A script whose lines are mostly bare paths to files
+the shell cannot execute is rejected before it runs, and you are asked to
+rewrite it.
+
 ## 3. Run it, and fix what the just-applied changes broke
 
 Run your script. If it fails, the failure is almost always introduced by the

--- a/bots/dep-update-guard/skills/verify-build.md
+++ b/bots/dep-update-guard/skills/verify-build.md
@@ -170,6 +170,11 @@ one, and after two attempts the PR is held on a verdict that says the build was
 never established. §1b applies here too: what the script covers is decided by
 the repo's CI, never by which files the bump happened to touch.
 
+A script that runs **nothing** is rejected the same way. An empty or
+comment-only script exits 0, which the gate reads as a verified build — so
+"write one" is never satisfied by writing a placeholder. Shell no-ops (`set`,
+`cd`, `exit`, `true`) do not count as running anything.
+
 **Every line must be a COMMAND.** Never emit a bare path to a source file: the
 shell tries to execute it, answers `Permission denied`, and the run reports a
 red build that never ran. To exercise a set of files, pass them to the repo's

--- a/bots/dep_update_guard_verify_precheck_test.go
+++ b/bots/dep_update_guard_verify_precheck_test.go
@@ -304,6 +304,75 @@ func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 		}
 	})
 
+	// Revi's Rdbf846, and the shape of the four false positives before it: the
+	// scanner judged each line alone, against a language full of multi-line
+	// constructs, and every patch met the next spelling. What actually
+	// separates iterion#398 from an ordinary script is not any one line but the
+	// PROPORTION — it was a listing and almost nothing else.
+	// One command split over many lines. Every non-final continuation carries a
+	// trailing backslash, hence a space, and only the last one reads as a bare
+	// word — so the proportion never approaches a listing.
+	t.Run("one command split over many continuation lines", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		if err := os.WriteFile(filepath.Join(ws, "run.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		script := "#!/bin/sh\ncd " + ws + "\n./run.sh \\\n  ./pkg/a \\\n  ./pkg/b \\\n  ./pkg/c \\\n  ./pkg/d \\\n  ./pkg/e\n"
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		res := run(t, ws, scratch)
+		if res.PrecheckRejected {
+			t.Errorf("these are arguments of the invocation above them: %q", res.PrecheckReason)
+		}
+	})
+
+	// Isolates the proportion: four unresolvable words, none of them
+	// continuations, among a dozen real commands. sh fails on them, so the run
+	// goes red — but it went red having RUN, which is a fact about the script,
+	// not the phantom of one that never executed.
+	t.Run("a few bad lines among real commands is not a listing", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		if err := os.WriteFile(filepath.Join(ws, "run.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		lines := []string{"#!/bin/sh", "cd " + ws}
+		for i := 0; i < 12; i++ {
+			lines = append(lines, "./run.sh")
+		}
+		lines = append(lines, "pkg/a/x.go", "pkg/a/y.go", "pkg/a/z.go", "pkg/a/w.go")
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(strings.Join(lines, "\n")+"\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		res := run(t, ws, scratch)
+		if res.PrecheckRejected {
+			t.Errorf("a script that ran its commands is not a file listing: %q", res.PrecheckReason)
+		}
+	})
+
+	t.Run("continuations and a few path arguments are an ordinary script", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		if err := os.WriteFile(filepath.Join(ws, "run.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		script := "#!/bin/sh\nset -e\ncd " + ws + "\n" +
+			"./run.sh\n" +
+			"./run.sh \\\n  ./pkg/...\n" +
+			"./run.sh \\\n  ./cmd/...\n" +
+			"./run.sh \\\n  pkg/git\n" +
+			"./run.sh \\\n  internal/x\n"
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		res := run(t, ws, scratch)
+		if res.PrecheckRejected {
+			t.Errorf("sh runs this perfectly; the guard must not hold a bump for it: %q", res.PrecheckReason)
+		}
+		if !res.Passed {
+			t.Errorf("a green script must pass, got exit %d: %s", res.ExitCode, res.LogTail)
+		}
+	})
+
 	// The false positive that would matter: a script legitimately delegating to
 	// the repo's own executable helpers. Rejecting those would break every repo
 	// that wraps its build in a script.

--- a/bots/dep_update_guard_verify_precheck_test.go
+++ b/bots/dep_update_guard_verify_precheck_test.go
@@ -160,6 +160,27 @@ func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 		})
 	}
 
+	// Revi's R78f11d. verify_system step 5 tells the agent, verbatim, that a
+	// repo with genuinely no build or test system gets a script echoing that
+	// and exiting 0. Counting echo as a no-op rejected the one shape the prompt
+	// prescribes — and the rejection then asked for "the repo own build and
+	// test commands", advice unfollowable for a repo that has none, so the loop
+	// exhausted and held a bump that broke nothing.
+	t.Run("the shape verify_system prescribes for a repo with no build system", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		body := "#!/bin/sh\necho 'this repo has no build or test system'\nexit 0\n"
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		res := run(t, ws, scratch)
+		if res.PrecheckRejected {
+			t.Errorf("the guard rejects the script its own prompt asks for: %q", res.PrecheckReason)
+		}
+		if !res.Passed {
+			t.Errorf("it exits 0 and must pass, got exit %d: %s", res.ExitCode, res.LogTail)
+		}
+	})
+
 	// Revi's R12dc35. The floor above judged a line by its first word, so the
 	// most ordinary script shape there is — a no-op leading a chain — counted
 	// as running nothing and was sent back twice, then held. That is the exact

--- a/bots/dep_update_guard_verify_precheck_test.go
+++ b/bots/dep_update_guard_verify_precheck_test.go
@@ -160,6 +160,63 @@ func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 		})
 	}
 
+	// Revi's R12dc35. The floor above judged a line by its first word, so the
+	// most ordinary script shape there is — a no-op leading a chain — counted
+	// as running nothing and was sent back twice, then held. That is the exact
+	// failure this PR exists to remove, reintroduced by its own guard.
+	t.Run("a no-op leading a chained command still counts as running", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		if err := os.WriteFile(filepath.Join(ws, "run-tests.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// The shape Revi named: a no-op leads, the build follows.
+		script := "#!/bin/sh\nset -e\ncd " + ws + " && ./run-tests.sh\n"
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		res := run(t, ws, scratch)
+		if res.PrecheckRejected {
+			t.Errorf("a chained command is not a vacuous script: %q", res.PrecheckReason)
+		}
+		if !res.Passed {
+			t.Errorf("a green script must pass, got exit %d: %s", res.ExitCode, res.LogTail)
+		}
+	})
+
+	// Revi's Rac0c6b. The listing check required the path to be an existing
+	// FILE, so `go list ./...` output (import paths that resolve to nothing)
+	// and directories out of `find -type d` sailed through — while failing at
+	// sh exactly like the unexecutable file did. POSIX is sharper: a word
+	// containing a slash is never PATH-searched, so anything that is not an
+	// executable regular file cannot run.
+	for _, tc := range []struct {
+		name  string
+		lines []string
+	}{
+		{"go list import paths", []string{
+			"github.com/SocialGouv/iterion/pkg/git",
+			"github.com/SocialGouv/iterion/pkg/store",
+			"github.com/SocialGouv/iterion/pkg/runtime",
+			"github.com/SocialGouv/iterion/pkg/runner",
+			"github.com/SocialGouv/iterion/pkg/server",
+		}},
+		{"directories", []string{"pkg/git/", "pkg/store/", "pkg/runtime/", "pkg/runner/", "pkg/server/"}},
+	} {
+		t.Run("a listing of "+tc.name+" is rejected", func(t *testing.T) {
+			ws, scratch := t.TempDir(), t.TempDir()
+			if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(strings.Join(tc.lines, "\n")+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			res := run(t, ws, scratch)
+			if !res.PrecheckRejected {
+				t.Errorf("these fail at sh just like an unexecutable file; got exit %d: %s", res.ExitCode, res.LogTail)
+			}
+			if res.Passed {
+				t.Error("a script of unrunnable words must not open the commit path")
+			}
+		})
+	}
+
 	// The false positive that would matter: a script legitimately delegating to
 	// the repo's own executable helpers. Rejecting those would break every repo
 	// that wraps its build in a script.

--- a/bots/dep_update_guard_verify_precheck_test.go
+++ b/bots/dep_update_guard_verify_precheck_test.go
@@ -217,6 +217,41 @@ func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 		})
 	}
 
+	// Revi's R691cf0. A here-doc body is data. Writing a path list into one is
+	// the natural way to feed a runner a set of paths — which is precisely what
+	// the NOT COMMANDS rejection tells the agent to do, so scanning the body
+	// would reject the remediation the message recommends.
+	t.Run("a here-doc body is data, not commands", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		if err := os.MkdirAll(filepath.Join(ws, "pkg", "a"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		var body []string
+		for _, name := range []string{"w.go", "x.go", "y.go", "z.go", "q.go"} {
+			rel := filepath.Join("pkg", "a", name)
+			if err := os.WriteFile(filepath.Join(ws, rel), []byte("package a\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			body = append(body, rel)
+		}
+		if err := os.WriteFile(filepath.Join(ws, "runner.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		script := "#!/bin/sh\nset -e\ncd " + ws + "\ncat > list.txt <<'EOF'\n" +
+			strings.Join(body, "\n") + "\nEOF\n./runner.sh\n"
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		res := run(t, ws, scratch)
+		if res.PrecheckRejected {
+			t.Errorf("the paths inside the here-doc are never executed: %q", res.PrecheckReason)
+		}
+		if !res.Passed {
+			t.Errorf("a green script must pass, got exit %d: %s", res.ExitCode, res.LogTail)
+		}
+	})
+
 	// The false positive that would matter: a script legitimately delegating to
 	// the repo's own executable helpers. Rejecting those would break every repo
 	// that wraps its build in a script.

--- a/bots/dep_update_guard_verify_precheck_test.go
+++ b/bots/dep_update_guard_verify_precheck_test.go
@@ -252,6 +252,37 @@ func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 		}
 	})
 
+	// Revi's Ree852e. A script's cwd moves as it runs, so resolving relative
+	// words against the workspace root alone reads a subdirectory's helpers as
+	// an unrunnable listing — a hold on a bump that builds, which is the very
+	// failure mode being removed.
+	t.Run("helpers invoked after a cd into a subdirectory are not a listing", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		sub := filepath.Join(ws, "tools")
+		if err := os.MkdirAll(sub, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		var calls []string
+		for _, name := range []string{"build.sh", "test.sh", "lint.sh", "vet.sh", "tidy.sh"} {
+			if err := os.WriteFile(filepath.Join(sub, name), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			calls = append(calls, "./"+name)
+		}
+		script := "#!/bin/sh\nset -e\ncd " + sub + "\n" + strings.Join(calls, "\n") + "\n"
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		res := run(t, ws, scratch)
+		if res.PrecheckRejected {
+			t.Errorf("these resolve and execute from the directory the script entered: %q", res.PrecheckReason)
+		}
+		if !res.Passed {
+			t.Errorf("a green script must pass, got exit %d: %s", res.ExitCode, res.LogTail)
+		}
+	})
+
 	// The false positive that would matter: a script legitimately delegating to
 	// the repo's own executable helpers. Rejecting those would break every repo
 	// that wraps its build in a script.

--- a/bots/dep_update_guard_verify_precheck_test.go
+++ b/bots/dep_update_guard_verify_precheck_test.go
@@ -151,6 +151,31 @@ func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 		}
 	})
 
+	// Revi's Reb56bb. The here-doc scan looks for << anywhere on a line, so a
+	// quoted value or an end-of-line comment containing it would open a body
+	// that never closes — swallowing the rest of the script, which then reads
+	// as running nothing and is held as EMPTY SCRIPT.
+	t.Run("a phantom here-doc must not swallow the script", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		if err := os.WriteFile(filepath.Join(ws, "run.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// The << never has a matching terminator line: it sits in a quoted
+		// value, not a here-doc. It is carried by a no-op so that the only
+		// line which counts as running is the one it would swallow.
+		script := "#!/bin/sh\ncd " + ws + "\nexport MSG='a << b'\n./run.sh\n"
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		res := run(t, ws, scratch)
+		if res.PrecheckRejected {
+			t.Errorf("the commands after it are still commands: %q", res.PrecheckReason)
+		}
+		if !res.Passed {
+			t.Errorf("a green script must pass, got exit %d: %s", res.ExitCode, res.LogTail)
+		}
+	})
+
 	// The false positive that would matter: a script legitimately delegating to
 	// the repo's own executable helpers. Rejecting those would break every repo
 	// that wraps its build in a script.

--- a/bots/dep_update_guard_verify_precheck_test.go
+++ b/bots/dep_update_guard_verify_precheck_test.go
@@ -9,16 +9,25 @@ import (
 	"testing"
 )
 
-// TestDepUpdateGuardVerifyPrechecks covers the two ways Vetty's verify script
-// came back red without ever having verified anything, both observed on the
-// 2026-08-10 Dependabot batch.
+// TestDepUpdateGuardVerifyPrechecks covers the two verify-script states that
+// are AUTHORSHIP defects rather than red builds: no script at all, and a script
+// that runs nothing.
 //
-// Both are AUTHORSHIP defects, not red builds, and the difference matters:
-// a red build is a fact about the bump, an unwritten or unrunnable script is a
-// step the agent skipped. Reported as a red build they are indistinguishable,
-// and the operator reads "this bump breaks the repo" about a bump that breaks
-// nothing. Reported as a precheck rejection they loop back into verify_build
-// with the reason and self-heal, while the commit path stays just as closed.
+// The difference matters. A red build is a fact about the bump; a step the
+// agent skipped is not, and reported as a red build the two are
+// indistinguishable — the operator reads "this bump breaks the repo" about a
+// bump that breaks nothing. Reported as a precheck rejection they loop back
+// into verify_build with the reason and self-heal, while the commit path stays
+// just as closed.
+//
+// Both conditions are decidable from the file alone, which is why they are the
+// only two here. A third check, rejecting a script whose lines are paths rather
+// than commands (iterion#398), was written and removed: judging shell text
+// statically produced a false positive on every review round — a leading `cd`,
+// a here-doc body, a subdirectory helper, a backslash continuation, an artifact
+// the script builds first — and a guard that holds a bump which builds inflicts
+// exactly the failure it was added to prevent. What remains of it lives in the
+// verify-build skill, as the rule that every line must be a command.
 func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 	if _, err := exec.LookPath("python3"); err != nil {
 		t.Skip("python3 not on PATH")
@@ -64,68 +73,6 @@ func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 		}
 		if !strings.Contains(res.PrecheckReason, "NO SCRIPT") {
 			t.Errorf("the reason must name the defect so the rewrite is targeted, got %q", res.PrecheckReason)
-		}
-	})
-
-	// iterion#398: verify.sh held ~2300 lines, each a path to a Go test file.
-	// sh answered every one with "Permission denied" and the run reported a
-	// red build for a bump whose whole test surface was in fact green.
-	t.Run("a file listing pasted in as commands is rejected", func(t *testing.T) {
-		ws, scratch := t.TempDir(), t.TempDir()
-		var lines []string
-		for _, name := range []string{"a_test.go", "b_test.go", "c_test.go", "d_test.go", "e_test.go"} {
-			if err := os.WriteFile(filepath.Join(ws, name), []byte("package x\n"), 0o644); err != nil {
-				t.Fatal(err)
-			}
-			lines = append(lines, "./"+name)
-		}
-		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-
-		res := run(t, ws, scratch)
-		if res.Passed {
-			t.Error("a script of unrunnable paths must not open the commit path")
-		}
-		if !res.PrecheckRejected {
-			t.Error("this is an authorship defect, not a red build — it must loop back with the reason")
-		}
-		if !strings.Contains(res.PrecheckReason, "NOT COMMANDS") {
-			t.Errorf("the reason must name the defect, got %q", res.PrecheckReason)
-		}
-		if !strings.Contains(res.PrecheckReason, "a_test.go") {
-			t.Errorf("the reason must cite the offending lines so the rewrite is targeted, got %q", res.PrecheckReason)
-		}
-	})
-
-	// Revi's R6d2b2b: POSIX sh executes any WORD containing a slash as a
-	// pathname, prefix or no prefix. A listing produced by `git ls-files` or
-	// `go list` carries no `./`, and produces the identical symptom — so a
-	// guard keyed on the prefix fires or not depending on how the agent
-	// happened to spell it.
-	t.Run("bare relative paths, no ./ prefix, are rejected too", func(t *testing.T) {
-		ws, scratch := t.TempDir(), t.TempDir()
-		if err := os.MkdirAll(filepath.Join(ws, "pkg", "x"), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		var lines []string
-		for _, name := range []string{"a_test.go", "b_test.go", "c_test.go", "d_test.go", "e_test.go"} {
-			rel := filepath.Join("pkg", "x", name)
-			if err := os.WriteFile(filepath.Join(ws, rel), []byte("package x\n"), 0o644); err != nil {
-				t.Fatal(err)
-			}
-			lines = append(lines, rel)
-		}
-		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-
-		res := run(t, ws, scratch)
-		if !res.PrecheckRejected {
-			t.Errorf("whether the guard fires must not depend on how the listing was spelled; got exit %d: %s", res.ExitCode, res.LogTail)
-		}
-		if res.Passed {
-			t.Error("a script of unrunnable paths must not open the commit path")
 		}
 	})
 
@@ -198,175 +145,6 @@ func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 		res := run(t, ws, scratch)
 		if res.PrecheckRejected {
 			t.Errorf("a chained command is not a vacuous script: %q", res.PrecheckReason)
-		}
-		if !res.Passed {
-			t.Errorf("a green script must pass, got exit %d: %s", res.ExitCode, res.LogTail)
-		}
-	})
-
-	// Revi's Rac0c6b. The listing check required the path to be an existing
-	// FILE, so `go list ./...` output (import paths that resolve to nothing)
-	// and directories out of `find -type d` sailed through — while failing at
-	// sh exactly like the unexecutable file did. POSIX is sharper: a word
-	// containing a slash is never PATH-searched, so anything that is not an
-	// executable regular file cannot run.
-	for _, tc := range []struct {
-		name  string
-		lines []string
-	}{
-		{"go list import paths", []string{
-			"github.com/SocialGouv/iterion/pkg/git",
-			"github.com/SocialGouv/iterion/pkg/store",
-			"github.com/SocialGouv/iterion/pkg/runtime",
-			"github.com/SocialGouv/iterion/pkg/runner",
-			"github.com/SocialGouv/iterion/pkg/server",
-		}},
-		{"directories", []string{"pkg/git/", "pkg/store/", "pkg/runtime/", "pkg/runner/", "pkg/server/"}},
-	} {
-		t.Run("a listing of "+tc.name+" is rejected", func(t *testing.T) {
-			ws, scratch := t.TempDir(), t.TempDir()
-			if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(strings.Join(tc.lines, "\n")+"\n"), 0o644); err != nil {
-				t.Fatal(err)
-			}
-			res := run(t, ws, scratch)
-			if !res.PrecheckRejected {
-				t.Errorf("these fail at sh just like an unexecutable file; got exit %d: %s", res.ExitCode, res.LogTail)
-			}
-			if res.Passed {
-				t.Error("a script of unrunnable words must not open the commit path")
-			}
-		})
-	}
-
-	// Revi's R691cf0. A here-doc body is data. Writing a path list into one is
-	// the natural way to feed a runner a set of paths — which is precisely what
-	// the NOT COMMANDS rejection tells the agent to do, so scanning the body
-	// would reject the remediation the message recommends.
-	t.Run("a here-doc body is data, not commands", func(t *testing.T) {
-		ws, scratch := t.TempDir(), t.TempDir()
-		if err := os.MkdirAll(filepath.Join(ws, "pkg", "a"), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		var body []string
-		for _, name := range []string{"w.go", "x.go", "y.go", "z.go", "q.go"} {
-			rel := filepath.Join("pkg", "a", name)
-			if err := os.WriteFile(filepath.Join(ws, rel), []byte("package a\n"), 0o644); err != nil {
-				t.Fatal(err)
-			}
-			body = append(body, rel)
-		}
-		if err := os.WriteFile(filepath.Join(ws, "runner.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		script := "#!/bin/sh\nset -e\ncd " + ws + "\ncat > list.txt <<'EOF'\n" +
-			strings.Join(body, "\n") + "\nEOF\n./runner.sh\n"
-		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(script), 0o755); err != nil {
-			t.Fatal(err)
-		}
-
-		res := run(t, ws, scratch)
-		if res.PrecheckRejected {
-			t.Errorf("the paths inside the here-doc are never executed: %q", res.PrecheckReason)
-		}
-		if !res.Passed {
-			t.Errorf("a green script must pass, got exit %d: %s", res.ExitCode, res.LogTail)
-		}
-	})
-
-	// Revi's Ree852e. A script's cwd moves as it runs, so resolving relative
-	// words against the workspace root alone reads a subdirectory's helpers as
-	// an unrunnable listing — a hold on a bump that builds, which is the very
-	// failure mode being removed.
-	t.Run("helpers invoked after a cd into a subdirectory are not a listing", func(t *testing.T) {
-		ws, scratch := t.TempDir(), t.TempDir()
-		sub := filepath.Join(ws, "tools")
-		if err := os.MkdirAll(sub, 0o755); err != nil {
-			t.Fatal(err)
-		}
-		var calls []string
-		for _, name := range []string{"build.sh", "test.sh", "lint.sh", "vet.sh", "tidy.sh"} {
-			if err := os.WriteFile(filepath.Join(sub, name), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-				t.Fatal(err)
-			}
-			calls = append(calls, "./"+name)
-		}
-		script := "#!/bin/sh\nset -e\ncd " + sub + "\n" + strings.Join(calls, "\n") + "\n"
-		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(script), 0o755); err != nil {
-			t.Fatal(err)
-		}
-
-		res := run(t, ws, scratch)
-		if res.PrecheckRejected {
-			t.Errorf("these resolve and execute from the directory the script entered: %q", res.PrecheckReason)
-		}
-		if !res.Passed {
-			t.Errorf("a green script must pass, got exit %d: %s", res.ExitCode, res.LogTail)
-		}
-	})
-
-	// Revi's Rdbf846, and the shape of the four false positives before it: the
-	// scanner judged each line alone, against a language full of multi-line
-	// constructs, and every patch met the next spelling. What actually
-	// separates iterion#398 from an ordinary script is not any one line but the
-	// PROPORTION — it was a listing and almost nothing else.
-	// One command split over many lines. Every non-final continuation carries a
-	// trailing backslash, hence a space, and only the last one reads as a bare
-	// word — so the proportion never approaches a listing.
-	t.Run("one command split over many continuation lines", func(t *testing.T) {
-		ws, scratch := t.TempDir(), t.TempDir()
-		if err := os.WriteFile(filepath.Join(ws, "run.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		script := "#!/bin/sh\ncd " + ws + "\n./run.sh \\\n  ./pkg/a \\\n  ./pkg/b \\\n  ./pkg/c \\\n  ./pkg/d \\\n  ./pkg/e\n"
-		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(script), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		res := run(t, ws, scratch)
-		if res.PrecheckRejected {
-			t.Errorf("these are arguments of the invocation above them: %q", res.PrecheckReason)
-		}
-	})
-
-	// Isolates the proportion: four unresolvable words, none of them
-	// continuations, among a dozen real commands. sh fails on them, so the run
-	// goes red — but it went red having RUN, which is a fact about the script,
-	// not the phantom of one that never executed.
-	t.Run("a few bad lines among real commands is not a listing", func(t *testing.T) {
-		ws, scratch := t.TempDir(), t.TempDir()
-		if err := os.WriteFile(filepath.Join(ws, "run.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		lines := []string{"#!/bin/sh", "cd " + ws}
-		for i := 0; i < 12; i++ {
-			lines = append(lines, "./run.sh")
-		}
-		lines = append(lines, "pkg/a/x.go", "pkg/a/y.go", "pkg/a/z.go", "pkg/a/w.go")
-		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(strings.Join(lines, "\n")+"\n"), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		res := run(t, ws, scratch)
-		if res.PrecheckRejected {
-			t.Errorf("a script that ran its commands is not a file listing: %q", res.PrecheckReason)
-		}
-	})
-
-	t.Run("continuations and a few path arguments are an ordinary script", func(t *testing.T) {
-		ws, scratch := t.TempDir(), t.TempDir()
-		if err := os.WriteFile(filepath.Join(ws, "run.sh"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		script := "#!/bin/sh\nset -e\ncd " + ws + "\n" +
-			"./run.sh\n" +
-			"./run.sh \\\n  ./pkg/...\n" +
-			"./run.sh \\\n  ./cmd/...\n" +
-			"./run.sh \\\n  pkg/git\n" +
-			"./run.sh \\\n  internal/x\n"
-		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(script), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		res := run(t, ws, scratch)
-		if res.PrecheckRejected {
-			t.Errorf("sh runs this perfectly; the guard must not hold a bump for it: %q", res.PrecheckReason)
 		}
 		if !res.Passed {
 			t.Errorf("a green script must pass, got exit %d: %s", res.ExitCode, res.LogTail)

--- a/bots/dep_update_guard_verify_precheck_test.go
+++ b/bots/dep_update_guard_verify_precheck_test.go
@@ -1,0 +1,128 @@
+package bots
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDepUpdateGuardVerifyPrechecks covers the two ways Vetty's verify script
+// came back red without ever having verified anything, both observed on the
+// 2026-08-10 Dependabot batch.
+//
+// Both are AUTHORSHIP defects, not red builds, and the difference matters:
+// a red build is a fact about the bump, an unwritten or unrunnable script is a
+// step the agent skipped. Reported as a red build they are indistinguishable,
+// and the operator reads "this bump breaks the repo" about a bump that breaks
+// nothing. Reported as a precheck rejection they loop back into verify_build
+// with the reason and self-heal, while the commit path stays just as closed.
+func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	command := verifyRunCommand(t, "dep-update-guard/main.bot")
+
+	type verifyResult struct {
+		Passed           bool   `json:"passed"`
+		Skipped          bool   `json:"skipped"`
+		ExitCode         int    `json:"exit_code"`
+		PrecheckRejected bool   `json:"precheck_rejected"`
+		PrecheckReason   string `json:"precheck_reason"`
+		LogTail          string `json:"log_tail"`
+	}
+
+	run := func(t *testing.T, ws, scratch string) verifyResult {
+		t.Helper()
+		cmd := strings.ReplaceAll(command, "{{vars.workspace_dir}}", ws)
+		cmd = strings.ReplaceAll(cmd, "{{vars.scratch_dir}}", scratch)
+		out, err := exec.Command("sh", "-c", cmd).Output()
+		if err != nil {
+			t.Fatalf("verify_run failed to execute: %v (out %q)", err, out)
+		}
+		var res verifyResult
+		if uerr := json.Unmarshal(out, &res); uerr != nil {
+			t.Fatalf("verify_run output is not verify_result JSON: %v (out %q)", uerr, out)
+		}
+		return res
+	}
+
+	// iterion#390: a base-image digest refresh on an unchanged tag. The
+	// alignment analysis was right that nothing needed changing — and the run
+	// then died because no script was written, with no way back. A bump whose
+	// correct alignment is empty could never clear the gate.
+	t.Run("no script: rejected for a rewrite, not reported as a red build", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		res := run(t, ws, scratch)
+		if res.Passed {
+			t.Error("a missing script must not open the commit path")
+		}
+		if !res.PrecheckRejected {
+			t.Error("a missing script is an authorship defect: it must loop back to verify_build, not terminate as a red build")
+		}
+		if !strings.Contains(res.PrecheckReason, "NO SCRIPT") {
+			t.Errorf("the reason must name the defect so the rewrite is targeted, got %q", res.PrecheckReason)
+		}
+	})
+
+	// iterion#398: verify.sh held ~2300 lines, each a path to a Go test file.
+	// sh answered every one with "Permission denied" and the run reported a
+	// red build for a bump whose whole test surface was in fact green.
+	t.Run("a file listing pasted in as commands is rejected", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		var lines []string
+		for _, name := range []string{"a_test.go", "b_test.go", "c_test.go", "d_test.go", "e_test.go"} {
+			if err := os.WriteFile(filepath.Join(ws, name), []byte("package x\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			lines = append(lines, "./"+name)
+		}
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		res := run(t, ws, scratch)
+		if res.Passed {
+			t.Error("a script of unrunnable paths must not open the commit path")
+		}
+		if !res.PrecheckRejected {
+			t.Error("this is an authorship defect, not a red build — it must loop back with the reason")
+		}
+		if !strings.Contains(res.PrecheckReason, "NOT COMMANDS") {
+			t.Errorf("the reason must name the defect, got %q", res.PrecheckReason)
+		}
+		if !strings.Contains(res.PrecheckReason, "a_test.go") {
+			t.Errorf("the reason must cite the offending lines so the rewrite is targeted, got %q", res.PrecheckReason)
+		}
+	})
+
+	// The false positive that would matter: a script legitimately delegating to
+	// the repo's own executable helpers. Rejecting those would break every repo
+	// that wraps its build in a script.
+	t.Run("a script calling executable helpers is not rejected", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		if err := os.MkdirAll(filepath.Join(ws, "scripts"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for _, name := range []string{"build.sh", "test.sh", "lint.sh", "vet.sh"} {
+			p := filepath.Join(ws, "scripts", name)
+			if err := os.WriteFile(p, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+		}
+		script := "#!/bin/sh\nset -e\ncd " + ws + "\n./scripts/build.sh\n./scripts/test.sh\n./scripts/lint.sh\n./scripts/vet.sh\n"
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		res := run(t, ws, scratch)
+		if res.PrecheckRejected {
+			t.Errorf("executable helpers are how a repo legitimately wraps its build: %q", res.PrecheckReason)
+		}
+		if !res.Passed {
+			t.Errorf("a green script must pass, got exit %d: %s", res.ExitCode, res.LogTail)
+		}
+	})
+}

--- a/bots/dep_update_guard_verify_precheck_test.go
+++ b/bots/dep_update_guard_verify_precheck_test.go
@@ -98,6 +98,68 @@ func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 		}
 	})
 
+	// Revi's R6d2b2b: POSIX sh executes any WORD containing a slash as a
+	// pathname, prefix or no prefix. A listing produced by `git ls-files` or
+	// `go list` carries no `./`, and produces the identical symptom — so a
+	// guard keyed on the prefix fires or not depending on how the agent
+	// happened to spell it.
+	t.Run("bare relative paths, no ./ prefix, are rejected too", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		if err := os.MkdirAll(filepath.Join(ws, "pkg", "x"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		var lines []string
+		for _, name := range []string{"a_test.go", "b_test.go", "c_test.go", "d_test.go", "e_test.go"} {
+			rel := filepath.Join("pkg", "x", name)
+			if err := os.WriteFile(filepath.Join(ws, rel), []byte("package x\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			lines = append(lines, rel)
+		}
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		res := run(t, ws, scratch)
+		if !res.PrecheckRejected {
+			t.Errorf("whether the guard fires must not depend on how the listing was spelled; got exit %d: %s", res.ExitCode, res.LogTail)
+		}
+		if res.Passed {
+			t.Error("a script of unrunnable paths must not open the commit path")
+		}
+	})
+
+	// Revi's R510ffe: the loop-back added above asks an agent that already
+	// skipped authorship to write SOMETHING. A script that runs nothing exits
+	// 0, which the gate reads as a verified build — so the cheapest way to
+	// satisfy that pressure would be a green commit certifying no verification
+	// at all. This is the floor that makes the loop-back safe to offer.
+	for _, tc := range []struct {
+		name, body string
+	}{
+		{"empty", ""},
+		{"shebang and comments only", "#!/bin/sh\n# nothing to verify for this bump\n"},
+		{"no-ops only", "#!/bin/sh\nset -e\ncd /tmp\nexit 0\n"},
+		{"a bare true", "#!/bin/sh\ntrue\n"},
+	} {
+		t.Run("a vacuous script is rejected: "+tc.name, func(t *testing.T) {
+			ws, scratch := t.TempDir(), t.TempDir()
+			if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(tc.body), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			res := run(t, ws, scratch)
+			if res.Passed {
+				t.Error("a script that runs nothing must not certify a build — it exits 0 for the same reason a passing one does")
+			}
+			if !res.PrecheckRejected {
+				t.Errorf("it is an authorship defect and must be sent back, got exit %d: %s", res.ExitCode, res.LogTail)
+			}
+			if !strings.Contains(res.PrecheckReason, "EMPTY SCRIPT") {
+				t.Errorf("the reason must name the defect, got %q", res.PrecheckReason)
+			}
+		})
+	}
+
 	// The false positive that would matter: a script legitimately delegating to
 	// the repo's own executable helpers. Rejecting those would break every repo
 	// that wraps its build in a script.

--- a/pkg/dispatcher/commands.go
+++ b/pkg/dispatcher/commands.go
@@ -969,6 +969,11 @@ func removeGitWorktreeRegistration(commonDir, workspacePath string) error {
 	removeCtx, cancelRemove := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancelRemove()
 	cmd := exec.CommandContext(removeCtx, "git", "--git-dir", commonDir, "worktree", "remove", "--force", workspacePath)
+	// --git-dir overrides GIT_DIR but NOT GIT_COMMON_DIR, and the worktree
+	// registry is exactly one of the non-worktree files git takes from there.
+	// Inherited, this --force removal would deregister a worktree in ANOTHER
+	// repository while ours keeps a stale registration.
+	cmd.Env = gitlib.SanitizeEnv(os.Environ())
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("git worktree remove: %w (%s)", err, strings.TrimSpace(string(out)))
 	}
@@ -982,7 +987,11 @@ func listGitWorktrees(commonDir string, nulDelimited bool) ([]byte, error) {
 	if nulDelimited {
 		args = append(args, "-z")
 	}
-	return exec.CommandContext(listCtx, "git", args...).Output()
+	listCmd := exec.CommandContext(listCtx, "git", args...)
+	// Same reason as the removal above: --git-dir does not neutralise
+	// GIT_COMMON_DIR, so this would list another repository's worktrees.
+	listCmd.Env = gitlib.SanitizeEnv(os.Environ())
+	return listCmd.Output()
 }
 
 // cmdRetryDue fires when a retry timer expires. We simply drop the

--- a/pkg/dispatcher/commands.go
+++ b/pkg/dispatcher/commands.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
+	gitlib "github.com/SocialGouv/iterion/pkg/git"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 )
@@ -877,6 +878,9 @@ func workspaceIsDirty(path string) (bool, error) {
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", "status", "--porcelain")
 	cmd.Dir = path
+	// cmd.Dir names the repository; an inherited GIT_DIR or GIT_INDEX_FILE
+	// would answer about another one, or read an index that is not its own.
+	cmd.Env = gitlib.SanitizeEnv(os.Environ())
 	out, err := cmd.Output()
 	if err != nil {
 		return false, err
@@ -900,6 +904,7 @@ func workspaceGitCommonDir(path string) (string, error) {
 	// supports linked worktrees. Resolve its possibly-relative output below.
 	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-common-dir")
 	cmd.Dir = workspaceDir
+	cmd.Env = gitlib.SanitizeEnv(os.Environ())
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/pkg/git/callers_test.go
+++ b/pkg/git/callers_test.go
@@ -8,8 +8,11 @@ import (
 	"testing"
 )
 
-// gitExec matches a git subprocess being built anywhere in the tree.
-var gitExec = regexp.MustCompile(`exec\.Command(?:Context)?\([^)]*?"git"`)
+// gitExec matches a git subprocess being built anywhere in the tree. It spans
+// newlines: gofmt wraps a long call, and a line-oriented pattern would miss
+// `exec.CommandContext(ctx,\n\t"git", …)` — precisely the shape a new call site
+// is likely to take.
+var gitExec = regexp.MustCompile(`(?s)exec\.Command(?:Context)?\(\s*(?:[\w.]+\s*,\s*)?"git"`)
 
 // TestEveryGitCallerSanitizesEnv sweeps the tree for git subprocesses whose
 // environment is left inherited.
@@ -26,9 +29,11 @@ var gitExec = regexp.MustCompile(`exec\.Command(?:Context)?\([^)]*?"git"`)
 // `.Env` is assigned within a few lines of the command being built; the point
 // is to force the decision, not to prove the value is right.
 func TestEveryGitCallerSanitizesEnv(t *testing.T) {
-	root := filepath.Join("..", "..", "pkg")
-	// pkg/git assigns through gitEnv(), which is SanitizeEnv's own caller.
-	skipDirs := map[string]bool{filepath.Join("..", "..", "pkg", "git"): true}
+	// The whole repository, not just pkg/: a git subprocess is as likely to be
+	// added under cmd/ or e2e/, and a sweep that silently never looks there
+	// reads as coverage it does not have.
+	root := filepath.Join("..", "..")
+	skipNames := map[string]bool{"vendor": true, "studio": true, "node_modules": true, "testdata": true}
 
 	var offenders []string
 	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
@@ -36,7 +41,13 @@ func TestEveryGitCallerSanitizesEnv(t *testing.T) {
 			return err
 		}
 		if info.IsDir() {
-			if skipDirs[path] || info.Name() == "testdata" {
+			// Hidden directories hold scratch clones of other people's code
+			// (.local, .works, .repos) — sweeping them reports on third-party
+			// source and costs half a minute. pkg/git assigns through
+			// gitEnv(), SanitizeEnv's own caller.
+			name := info.Name()
+			if skipNames[name] || (strings.HasPrefix(name, ".") && path != root) ||
+				path == filepath.Join("..", "..", "pkg", "git") {
 				return filepath.SkipDir
 			}
 			return nil
@@ -48,18 +59,21 @@ func TestEveryGitCallerSanitizesEnv(t *testing.T) {
 		if rerr != nil {
 			return rerr
 		}
-		lines := strings.Split(string(src), "\n")
-		for i, line := range lines {
-			if !gitExec.MatchString(line) || strings.HasPrefix(strings.TrimSpace(line), "//") {
+		body := string(src)
+		for _, loc := range gitExec.FindAllStringIndex(body, -1) {
+			// A call quoted inside a doc comment is prose, not a call site.
+			lineStart := strings.LastIndex(body[:loc[0]], "\n") + 1
+			if strings.Contains(body[lineStart:loc[0]], "//") {
 				continue
 			}
-			// The assignment may land well below the command: Dir, cancellation
+			// The assignment may land well below the call: Dir, cancellation
 			// hardening and timeouts are commonly wired in between.
-			window := lines[i:min(i+16, len(lines))]
-			if strings.Contains(strings.Join(window, "\n"), ".Env = ") {
+			tail := body[loc[0]:min(loc[0]+700, len(body))]
+			if strings.Contains(tail, ".Env = ") {
 				continue
 			}
-			offenders = append(offenders, filepath.ToSlash(path)+":"+itoa(i+1)+"  "+strings.TrimSpace(line))
+			line := 1 + strings.Count(body[:loc[0]], "\n")
+			offenders = append(offenders, filepath.ToSlash(path)+":"+itoa(line)+"  "+strings.TrimSpace(body[loc[0]:min(loc[1]+40, len(body))]))
 		}
 		return nil
 	})

--- a/pkg/git/callers_test.go
+++ b/pkg/git/callers_test.go
@@ -12,7 +12,7 @@ import (
 // newlines: gofmt wraps a long call, and a line-oriented pattern would miss
 // `exec.CommandContext(ctx,\n\t"git", …)` — precisely the shape a new call site
 // is likely to take.
-var gitExec = regexp.MustCompile(`(?s)exec\.Command(?:Context)?\(\s*(?:[\w.]+\s*,\s*)?"git"`)
+var gitExec = regexp.MustCompile(`(?s)exec\.Command(?:Context)?\(\s*(?:[\w.]+(?:\([^()]*\))?\s*,\s*)?"git"`)
 
 // TestEveryGitCallerSanitizesEnv sweeps the tree for git subprocesses whose
 // environment is left inherited.
@@ -73,10 +73,18 @@ func TestEveryGitCallerSanitizesEnv(t *testing.T) {
 			// `cmd.Env = os.Environ()` (or appending to it) is the most likely
 			// way a new call site gets written, and it is exactly the
 			// unscrubbed environment this guard exists to keep out.
-			// Generous: cancellation hardening, timeouts and their comments
-			// routinely sit between the call and its environment (the runner's
-			// clone puts 700 characters of them there).
-			tail := body[loc[0]:min(loc[0]+1600, len(body))]
+			// Bounded by the NEXT call site, not by a fixed span: in
+			// pkg/dispatcher the four sites sit 107-406 characters apart, so a
+			// fixed window let each one's assignment vouch for its neighbour —
+			// deleting one and keeping the others still passed. Within that
+			// bound the span is generous, since cancellation hardening,
+			// timeouts and their comments routinely sit in between (the
+			// runner's clone puts 706 characters of them there).
+			end := min(loc[0]+1600, len(body))
+			if next := gitExec.FindStringIndex(body[loc[1]:]); next != nil {
+				end = min(end, loc[1]+next[0])
+			}
+			tail := body[loc[0]:end]
 			if strings.Contains(tail, "SanitizeEnv(") {
 				continue
 			}

--- a/pkg/git/callers_test.go
+++ b/pkg/git/callers_test.go
@@ -26,8 +26,9 @@ var gitExec = regexp.MustCompile(`(?s)exec\.Command(?:Context)?\(\s*(?:[\w.]+\s*
 // GIT_COMMON_DIR.
 //
 // So the property is checked mechanically. A call site is satisfied when
-// `.Env` is assigned within a few lines of the command being built; the point
-// is to force the decision, not to prove the value is right.
+// git.SanitizeEnv appears within a few lines of the command being built.
+// Accepting any `.Env` assignment would accept `cmd.Env = os.Environ()`, which
+// is the very thing being kept out.
 func TestEveryGitCallerSanitizesEnv(t *testing.T) {
 	// The whole repository, not just pkg/: a git subprocess is as likely to be
 	// added under cmd/ or e2e/, and a sweep that silently never looks there
@@ -68,8 +69,15 @@ func TestEveryGitCallerSanitizesEnv(t *testing.T) {
 			}
 			// The assignment may land well below the call: Dir, cancellation
 			// hardening and timeouts are commonly wired in between.
-			tail := body[loc[0]:min(loc[0]+700, len(body))]
-			if strings.Contains(tail, ".Env = ") {
+			// SanitizeEnv specifically, not any .Env assignment: writing
+			// `cmd.Env = os.Environ()` (or appending to it) is the most likely
+			// way a new call site gets written, and it is exactly the
+			// unscrubbed environment this guard exists to keep out.
+			// Generous: cancellation hardening, timeouts and their comments
+			// routinely sit between the call and its environment (the runner's
+			// clone puts 700 characters of them there).
+			tail := body[loc[0]:min(loc[0]+1600, len(body))]
+			if strings.Contains(tail, "SanitizeEnv(") {
 				continue
 			}
 			line := 1 + strings.Count(body[:loc[0]], "\n")

--- a/pkg/git/callers_test.go
+++ b/pkg/git/callers_test.go
@@ -1,0 +1,85 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// gitExec matches a git subprocess being built anywhere in the tree.
+var gitExec = regexp.MustCompile(`exec\.Command(?:Context)?\([^)]*?"git"`)
+
+// TestEveryGitCallerSanitizesEnv sweeps the tree for git subprocesses whose
+// environment is left inherited.
+//
+// Reviewing this by hand does not work: applying the scrub across the packages
+// that shell out to git, I set it on two of the four call sites in
+// pkg/dispatcher and missed the other two — one of them a `worktree remove
+// --force`, where an inherited GIT_COMMON_DIR deregisters a worktree in
+// somebody else's repository. `--git-dir` looks like it covers that and does
+// not: git takes non-worktree files, the worktree registry among them, from
+// GIT_COMMON_DIR.
+//
+// So the property is checked mechanically. A call site is satisfied when
+// `.Env` is assigned within a few lines of the command being built; the point
+// is to force the decision, not to prove the value is right.
+func TestEveryGitCallerSanitizesEnv(t *testing.T) {
+	root := filepath.Join("..", "..", "pkg")
+	// pkg/git assigns through gitEnv(), which is SanitizeEnv's own caller.
+	skipDirs := map[string]bool{filepath.Join("..", "..", "pkg", "git"): true}
+
+	var offenders []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if skipDirs[path] || info.Name() == "testdata" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		src, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		lines := strings.Split(string(src), "\n")
+		for i, line := range lines {
+			if !gitExec.MatchString(line) || strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+			// The assignment may land well below the command: Dir, cancellation
+			// hardening and timeouts are commonly wired in between.
+			window := lines[i:min(i+16, len(lines))]
+			if strings.Contains(strings.Join(window, "\n"), ".Env = ") {
+				continue
+			}
+			offenders = append(offenders, filepath.ToSlash(path)+":"+itoa(i+1)+"  "+strings.TrimSpace(line))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if len(offenders) > 0 {
+		t.Errorf("git subprocess(es) built with the caller's environment inherited whole — GIT_DIR, GIT_COMMON_DIR, GIT_INDEX_FILE and friends override the repository each of these names for itself.\nSet cmd.Env = git.SanitizeEnv(os.Environ()) (plus whatever else the call needs):\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -141,17 +141,25 @@ var gitRedirectionEnv = []string{
 	"GIT_NAMESPACE",
 }
 
-func gitEnv() []string {
-	src := os.Environ()
-	out := make([]string, 0, len(src)+2)
-	for _, kv := range src {
+// SanitizeEnv returns env without the redirection variables (see
+// gitRedirectionEnv). Exported because this package is not the only place that
+// shells out to git: anything running a git command against a directory it
+// names itself wants the same guarantee, and a caller that assembles its own
+// environment cannot get it from run() below.
+func SanitizeEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
 		key, _, _ := strings.Cut(kv, "=")
 		if slices.Contains(gitRedirectionEnv, key) {
 			continue
 		}
 		out = append(out, kv)
 	}
-	return append(out, "LC_ALL=C", "LANG=C")
+	return out
+}
+
+func gitEnv() []string {
+	return append(SanitizeEnv(os.Environ()), "LC_ALL=C", "LANG=C")
 }
 
 // run executes `git args...` with cwd=dir and returns combined stdout.

--- a/pkg/git/sanitize_env_test.go
+++ b/pkg/git/sanitize_env_test.go
@@ -1,0 +1,88 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSanitizeEnv pins which variables are dropped and which survive. The two
+// halves matter equally: dropping too little leaves a git command acting on a
+// repository it did not name, and dropping too much breaks the sandbox path,
+// which sets the identity deliberately so an in-container commit is possible
+// at all.
+func TestSanitizeEnv(t *testing.T) {
+	in := []string{
+		"GIT_DIR=/elsewhere/.git",
+		"GIT_WORK_TREE=/elsewhere",
+		"GIT_INDEX_FILE=/tmp/ambient-index",
+		"GIT_OBJECT_DIRECTORY=/tmp/objects",
+		"GIT_ALTERNATE_OBJECT_DIRECTORIES=/tmp/alt",
+		"GIT_COMMON_DIR=/elsewhere/.git",
+		"GIT_NAMESPACE=refs/ns",
+		// Kept: the sandbox sets these on purpose.
+		"GIT_AUTHOR_NAME=bot",
+		"GIT_AUTHOR_EMAIL=bot@example.com",
+		"GIT_COMMITTER_NAME=bot",
+		"GIT_COMMITTER_EMAIL=bot@example.com",
+		"GIT_SSH_COMMAND=ssh -i key",
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"PATH=/usr/bin",
+		// A value containing '=' must not confuse the key split.
+		"GIT_ASKPASS=/tmp/helper=1",
+	}
+	got := strings.Join(SanitizeEnv(in), "\n")
+
+	for _, dropped := range []string{"GIT_DIR=", "GIT_WORK_TREE=", "GIT_INDEX_FILE=", "GIT_OBJECT_DIRECTORY=",
+		"GIT_ALTERNATE_OBJECT_DIRECTORIES=", "GIT_COMMON_DIR=", "GIT_NAMESPACE="} {
+		if strings.Contains(got, dropped) {
+			t.Errorf("%s survived — a git call can still be redirected away from the directory it names", dropped)
+		}
+	}
+	for _, kept := range []string{"GIT_AUTHOR_NAME=bot", "GIT_COMMITTER_EMAIL=bot@example.com",
+		"GIT_SSH_COMMAND=ssh -i key", "GIT_TERMINAL_PROMPT=0", "GIT_CONFIG_GLOBAL=/dev/null",
+		"PATH=/usr/bin", "GIT_ASKPASS=/tmp/helper=1"} {
+		if !strings.Contains(got, kept) {
+			t.Errorf("%s was dropped — the sandbox and transport paths set it deliberately", kept)
+		}
+	}
+}
+
+// TestSanitizeEnvIsWhatMakesDirAuthoritative demonstrates the property against
+// real git rather than asserting on the slice: with GIT_DIR inherited, a
+// command that names its own directory answers about another repository.
+func TestSanitizeEnvIsWhatMakesDirAuthoritative(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	target := gitRepo(t)
+	decoy := gitRepo(t)
+	if err := os.WriteFile(filepath.Join(decoy, "only-in-decoy.txt"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(env []string) string {
+		cmd := exec.Command("git", "status", "--porcelain")
+		cmd.Dir = target
+		cmd.Env = env
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return "ERR: " + string(out)
+		}
+		return string(out)
+	}
+
+	polluted := append(os.Environ(),
+		"GIT_DIR="+filepath.Join(decoy, ".git"),
+		"GIT_WORK_TREE="+decoy,
+	)
+	if got := run(polluted); !strings.Contains(got, "only-in-decoy.txt") {
+		t.Fatalf("the premise does not hold on this git: expected the decoy's state, got %q", got)
+	}
+	if got := run(SanitizeEnv(polluted)); strings.TrimSpace(got) != "" {
+		t.Errorf("after SanitizeEnv, status still reports another repository: %q", got)
+	}
+}

--- a/pkg/pluginsource/fetch.go
+++ b/pkg/pluginsource/fetch.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	gitlib "github.com/SocialGouv/iterion/pkg/git"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -169,7 +170,9 @@ func (f *Fetcher) git(ctx context.Context, dir, cred string, args ...string) err
 
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
+	// SanitizeEnv first: cmd.Dir names the checkout, and an inherited GIT_DIR
+	// or GIT_INDEX_FILE would silently redirect the fetch away from it.
+	cmd.Env = append(gitlib.SanitizeEnv(os.Environ()),
 		"GIT_TERMINAL_PROMPT=0", // never block a launch on an interactive auth prompt
 		"GIT_CONFIG_GLOBAL=/dev/null",
 		"GIT_CONFIG_SYSTEM=/dev/null",

--- a/pkg/runner/loop_gitws.go
+++ b/pkg/runner/loop_gitws.go
@@ -435,7 +435,9 @@ func (r *Runner) runGitEnv(ctx context.Context, dir, tok string, extraEnv []stri
 	cmd.WaitDelay = 10 * time.Second
 	// Never prompt for credentials (fail fast instead of hanging), and ignore
 	// any host-level git config in the runner image.
-	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0", "GIT_CONFIG_NOSYSTEM=1")
+	// SanitizeEnv drops the variables that would override which repository,
+	// index or object store this runs against — the clone dir is chosen here.
+	cmd.Env = append(gitlib.SanitizeEnv(os.Environ()), "GIT_TERMINAL_PROMPT=0", "GIT_CONFIG_NOSYSTEM=1")
 	cmd.Env = append(cmd.Env, extraEnv...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/runtime/worktree.go
+++ b/pkg/runtime/worktree.go
@@ -52,7 +52,8 @@ const gitCmdTimeout = 60 * time.Second
 func gitCmd(args ...string) (*exec.Cmd, context.CancelFunc) {
 	ctx, cancel := context.WithTimeout(context.Background(), gitCmdTimeout)
 	cmd := exec.CommandContext(ctx, "git", args...)
-	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+	// Strip what would override the repository this command names for itself.
+	cmd.Env = append(gitlib.SanitizeEnv(os.Environ()), "LC_ALL=C", "LANG=C")
 	detachGitProcessGroup(cmd)
 	return cmd, cancel
 }

--- a/pkg/runview/fork.go
+++ b/pkg/runview/fork.go
@@ -10,7 +10,9 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	gitlib "github.com/SocialGouv/iterion/pkg/git"
 	"github.com/SocialGouv/iterion/pkg/store"
+	"os"
 )
 
 // ForkSpec describes a fork request — a "create-an-alternative-future"
@@ -244,7 +246,10 @@ func forkWorktree(parent *store.Run, spec ForkSpec, turn *store.TurnCheckpoint, 
 	// otherwise pin the request goroutine forever.
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, "git", "-C", parent.RepoRoot, "worktree", "add", newWtPath, target).CombinedOutput()
+	wtCmd := exec.CommandContext(ctx, "git", "-C", parent.RepoRoot, "worktree", "add", newWtPath, target)
+	// -C names the repository; an inherited GIT_DIR would override it.
+	wtCmd.Env = gitlib.SanitizeEnv(os.Environ())
+	out, err := wtCmd.CombinedOutput()
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
 			return "", fmt.Errorf("git worktree add %s %s: timed out", newWtPath, target)

--- a/pkg/sandbox/kubernetes/driver.go
+++ b/pkg/sandbox/kubernetes/driver.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	gitlib "github.com/SocialGouv/iterion/pkg/git"
 	"github.com/SocialGouv/iterion/pkg/internal/proc"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
@@ -851,8 +852,12 @@ func workspaceFileTarget(workspace, relPath string) (string, error) {
 // runner made. For a plain clone or a non-git dir it returns hostSrc
 // unchanged. Best-effort: any git failure falls back to hostSrc.
 func resolveCloneRoot(ctx context.Context, hostSrc string) string {
-	out, err := exec.CommandContext(ctx, "git", "-C", hostSrc,
-		"rev-parse", "--path-format=absolute", "--git-common-dir").Output()
+	cloneCmd := exec.CommandContext(ctx, "git", "-C", hostSrc,
+		"rev-parse", "--path-format=absolute", "--git-common-dir")
+	// -C names the workspace; an inherited GIT_DIR or GIT_COMMON_DIR would
+	// answer about another repository and resolve the clone root to it.
+	cloneCmd.Env = gitlib.SanitizeEnv(os.Environ())
+	out, err := cloneCmd.Output()
 	if err != nil {
 		return hostSrc
 	}


### PR DESCRIPTION
Closes out the 2026-08-10 Dependabot batch. #405 fixed the four holds that shared one cause; this fixes the remaining two, and answers the open question Revi raised on that PR.

## The two remaining holds were not red builds

**#390** — a base-image digest refresh on an unchanged tag. Vetty's analysis was right (one line, one file, no API surface, nothing to align), and then `verify_build` wrote no `verify.sh`, which the gate turned into a terminal red. **A bump whose correct alignment is empty could never clear the gate**, however correct the reasoning.

**#398** — `verify.sh` held ~2300 lines, each a bare path to a Go test file. `sh` answered every one with `Permission denied` and the run reported a red build for a test surface that was untouched and green.

Neither is a fact about the bump; both are steps the agent skipped. Reported as red builds they are indistinguishable from a real breakage, so the operator reads *"this bump breaks the repo"* about a bump that breaks nothing.

Both now raise a **precheck rejection** — the mechanism already carrying the drift-gate rejection — which loops back into `verify_build` with the reason and self-heals. The commit path stays exactly as closed: on loop exhaustion the PR still holds.

The bare-path test names no file extension: it asks whether a line is a path to a file *the shell cannot execute*. That holds in any language, and leaves a script delegating to the repo's own executable helpers alone — which is covered by a test, because that false positive would break every repo wrapping its build in a script.

## And the scrub, everywhere it belongs

Revi's open question on #405 was that the redirection scrub was local to `pkg/git`. It was right. Five other packages genuinely run git (the kubernetes driver only runs kubectl and tar), and every one names its repository itself — via `-C`, `cmd.Dir`, or a clone path it just chose:

| | |
|---|---|
| `pkg/runtime/worktree.go` | worktree add/list/remove for `worktree: auto` |
| `pkg/runner/loop_gitws.go` | the per-run clone and its fetch/checkout |
| `pkg/runview/fork.go` | `git -C <root> worktree add` for a run fork |
| `pkg/dispatcher/commands.go` | `status --porcelain`, `rev-parse --git-common-dir` |
| `pkg/pluginsource/fetch.go` | the plugin checkout fetch |

The scrub is exported as `git.SanitizeEnv` and applied at each site, so the property has one definition instead of five. Identity, transport and `GIT_CONFIG_*` are preserved deliberately — the sandbox sets them so an in-container commit has an identity and skips signing.

## Verification

`task lint` (0 issues), `task test`, `task test:e2e`, `iterion validate` green.

The `SanitizeEnv` test proves the property against real git rather than asserting on a slice: with `GIT_DIR` inherited, `git status` in a directory it names reports **another repository's** state; after `SanitizeEnv` it reports its own. It fails first if that premise ever stops holding, so it cannot pass vacuously.

The precheck tests execute the real `verify_run` script over fixtures — including the false-positive guard.

## Deliberately not done

Propagating the two new prechecks to the other loop bots (`whole-improve-loop`, `branch-improve-loop`, `feature-gap-fill`) that carry a near-identical `verify_run`. They are exposed to the same authorship hazard but have not exhibited it, and they treat a missing script as a *pass* rather than fail-closed — a divergence that is intentional (Vetty commits onto someone else's PR branch). Worth a considered change, not a tail-end copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)