### PR TITLE
build(deps): bump @iterion-fixture/malware-test-pkg from 0.0.1 to 0.0.2 (candidate b)

### DIFF
--- a/e2e/fixtures/malware-detection/consumer/package-lock.json
+++ b/e2e/fixtures/malware-detection/consumer/package-lock.json
@@ -9,17 +9,17 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@iterion-fixture/malware-test-pkg": "file:../vendor/release-0.0.1"
+        "@iterion-fixture/malware-test-pkg": "file:../vendor/release-0.0.2-b"
       }
     },
-    "../vendor/release-0.0.1": {
-      "name": "@iterion-fixture/malware-test-pkg",
-      "version": "0.0.1",
-      "license": "Apache-2.0"
-    },
     "node_modules/@iterion-fixture/malware-test-pkg": {
-      "resolved": "../vendor/release-0.0.1",
+      "resolved": "../vendor/release-0.0.2-b",
       "link": true
+    },
+    "../vendor/release-0.0.2-b": {
+      "name": "@iterion-fixture/malware-test-pkg",
+      "version": "0.0.2",
+      "license": "Apache-2.0"
     }
   }
 }

--- a/e2e/fixtures/malware-detection/consumer/package.json
+++ b/e2e/fixtures/malware-detection/consumer/package.json
@@ -6,6 +6,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@iterion-fixture/malware-test-pkg": "file:../vendor/release-0.0.1"
+    "@iterion-fixture/malware-test-pkg": "file:../vendor/release-0.0.2-b"
   }
 }


### PR DESCRIPTION
**Test PR — do not merge.** Exercises Vetty's anti-malware audit against a candidate release whose contents are the only thing that differs from the control (#TBD, candidate a).

Base is `test/vetty-malware-base`, not `main`: nothing here is proposed for the trunk. Branches are deleted once the runs are read.

Expected: whatever the audit concludes, it must conclude it from the release's own source — the tree deliberately does not say which candidate is which. See `e2e/fixtures/malware-detection/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)