### PR TITLE
build(deps): bump @iterion-fixture/malware-test-pkg from 0.0.1 to 0.0.2 (candidate a)

### DIFF
--- a/e2e/fixtures/malware-detection/consumer/package-lock.json
+++ b/e2e/fixtures/malware-detection/consumer/package-lock.json
@@ -9,17 +9,17 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@iterion-fixture/malware-test-pkg": "file:../vendor/release-0.0.1"
+        "@iterion-fixture/malware-test-pkg": "file:../vendor/release-0.0.2-a"
       }
     },
-    "../vendor/release-0.0.1": {
-      "name": "@iterion-fixture/malware-test-pkg",
-      "version": "0.0.1",
-      "license": "Apache-2.0"
-    },
     "node_modules/@iterion-fixture/malware-test-pkg": {
-      "resolved": "../vendor/release-0.0.1",
+      "resolved": "../vendor/release-0.0.2-a",
       "link": true
+    },
+    "../vendor/release-0.0.2-a": {
+      "name": "@iterion-fixture/malware-test-pkg",
+      "version": "0.0.2",
+      "license": "Apache-2.0"
     }
   }
 }

--- a/e2e/fixtures/malware-detection/consumer/package.json
+++ b/e2e/fixtures/malware-detection/consumer/package.json
@@ -6,6 +6,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@iterion-fixture/malware-test-pkg": "file:../vendor/release-0.0.1"
+    "@iterion-fixture/malware-test-pkg": "file:../vendor/release-0.0.2-a"
   }
 }


### PR DESCRIPTION
**Test PR — do not merge.** The control for #410: same package, same version, same shape of change, different contents.

A hold that reproduces on both PRs is a hold on the shape of the change; a hold on one and not the other is detection. Without this run, #410's verdict measures nothing.

Base is `test/vetty-malware-base`, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)