### PR TITLE
build(deps): bump node-ipc from 9.2.1 to 10.1.1

### DIFF
--- a/e2e/fixtures/malware-detection/registry/package-lock.json
+++ b/e2e/fixtures/malware-detection/registry/package-lock.json
@@ -9,14 +9,16 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "node-ipc": "9.2.1"
+        "node-ipc": "10.1.1"
       }
     },
     "node_modules/node-ipc": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-9.2.1.tgz",
-      "integrity": "sha512-mJzaM6O3xHf9VT8BULvJSbdVbmHUKRNOH7zDDkCrA1/T+CVjq2WVIDfLt0azZRXpgArJtl3rtmEozrbXPZ9GaQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-10.1.1.tgz",
+      "integrity": "sha512-7v6FDXRtBHmRMxxJ6+lhWHzeKNBlNS5p4FBdGePV0Q5/xc3PXmIBkO9k0Q1KP6QSe6bGHsTBwHA8KkBpzNXmJg==",
       "dependencies": {
+        "@achrinza/event-pubsub": "5.0.5",
+        "@node-ipc/js-queue": "2.0.3",
         "event-pubsub": "4.3.0",
         "js-message": "1.0.7",
         "js-queue": "2.0.2"

--- a/e2e/fixtures/malware-detection/registry/package.json
+++ b/e2e/fixtures/malware-detection/registry/package.json
@@ -6,6 +6,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "node-ipc": "9.2.1"
+    "node-ipc": "10.1.1"
   }
 }


### PR DESCRIPTION
**Test PR — do not merge.** The other half of the anti-malware experiment: a bump whose verdict is discoverable **only by lookup**.

Unlike #410, nothing in this tree says the target is bad — no payload to read, no directory name, no README entry. `node-ipc@10.1.1` is a real published release whose contents are ordinary-looking; what makes it malicious is the advisory (GHSA-97m3-w2cp-4xx6 / CVE-2022-23812, the destructive `peacenotwar` payload). So this tests the registry-advisory path — OSV — rather than the source-reading path #410 exercised.

Expected: `hold_security`, citing the advisory.

Base is `main`, and this stays draft. The fixture it moves lives at `e2e/fixtures/malware-detection/registry/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)