### PR TITLE
docs(bilan): the 10/08 batch closes, and what the tail taught

### DIFF
--- a/docs/bot-runs/dep-update-guard.md
+++ b/docs/bot-runs/dep-update-guard.md
@@ -7,6 +7,62 @@ commit onto the PR branch, post the verdict comment. Never merges past a
 check — and only ever the commit it audited. See
 [bots/dep-update-guard/](../../bots/dep-update-guard/).
 
+## 2026-08-13 — the batch closes: 11 PRs resolved, and three operational lessons
+
+- Status: **the 10/08 Dependabot batch is fully resolved**, mostly overnight and
+  unattended. Vetty **2.7.5** · iterion **v3.40.3**.
+
+| outcome | PRs |
+|---|---|
+| merged through the lane | #394 (with Vetty's alignment), #393, #397, #399, #416 |
+| green, in the merge queue | #390 |
+| green after a recreate | #395 |
+| held on its own merits | #396 (`hold_security`, mongodb chart 16→19) |
+| closed as obsolete | #391, #398, #415 |
+
+The morning's whole red class — `build/tests not green after alignment` — is
+gone once the base tree could pass its own tests in the sandbox. Nothing was
+tuned in Vetty to achieve it.
+
+**#390 is the case worth reading**, because it is the shape a digest bump takes
+when the audit is doing real work: SLSA v0.2 attestations on both digests naming
+the same upstream source commit, build history identical but for the Debian
+snapshot timestamp, the **Go compiler layer bit-identical** (`diff_id
+033cd45a…`), 257 advisories resolved and 0 introduced. It then disclosed three
+coverage gaps (no daemon for osv-scanner's image mode, no cosign so signatures
+were not cryptographically verified, no crane/skopeo so it used the raw registry
+API) and two things the operator would want but did not ask for: the pin already
+trails upstream by two rebuilds, and upstream dropped mips64le/s390x from the
+manifest list — neither of which this repo's arches care about.
+
+### Three lessons, all operational
+
+- **A batch sharing one lockfile can only merge serially.** Each merge rewrites
+  `pnpm-lock.yaml`, which invalidates every other PR's lockfile alignment: #395
+  and #415 went `DIRTY` *because the lane was working*. Dependabot then refuses
+  to rebase them — "edited by someone other than Dependabot", since Vetty
+  committed there — and `gh pr update-branch` cannot resolve the conflict
+  either. **`@dependabot recreate` is the way out**: it regenerates the branch
+  from current `main` and discards the stale alignment, which Vetty redoes on
+  the fresh head. Expect this on every batch touching a shared lockfile; it is
+  not a failure.
+- **On a merge-queue repo, `autoMergeRequest` is always null**, even when
+  `arm_automerge` reports `armed: true` — arming performs an *enqueue*, not an
+  auto-merge. Reading the wrong field cost two investigations here. The question
+  is answered by:
+
+  ```sh
+  gh api graphql -f query='query { repository(owner:"…", name:"…") {
+    pullRequest(number:390) { isInMergeQueue
+    mergeQueueEntry { state position estimatedTimeToMerge } } } }'
+  ```
+
+- **A flaky non-required check is worse than a failing one.** `cloud-e2e` is
+  green on `main` and failed on #399, #412 and #417 — the last being a
+  documentation-only PR that cannot break it. The queue merges past it, so it
+  blocks nothing; but it makes every PR read `UNSTABLE` and costs a diagnosis
+  each time. Filed as `native:8f1821b3`.
+
 ## 2026-08-12 (evening) — both missing proofs land: an alignment merged, and the advisory path fires blind
 
 - Status: **validated.** The two things this bot had never been seen to do, it

--- a/docs/bot-runs/dep-update-guard.md
+++ b/docs/bot-runs/dep-update-guard.md
@@ -15,7 +15,7 @@ check — and only ever the commit it audited. See
 | outcome | PRs |
 |---|---|
 | merged through the lane | #394 (with Vetty's alignment), #393, #397, #399, #416 |
-| green, in the merge queue | #390 |
+| merged after a re-run under 2.7.5 | #390 |
 | green after a recreate | #395 |
 | held on its own merits | #396 (`hold_security`, mongodb chart 16→19) |
 | closed as obsolete | #391, #398, #415 |
@@ -24,7 +24,9 @@ The morning's whole red class — `build/tests not green after alignment` — is
 gone once the base tree could pass its own tests in the sandbox. Nothing was
 tuned in Vetty to achieve it.
 
-**#390 is the case worth reading**, because it is the shape a digest bump takes
+**#390 is the case worth reading** (run `019ff9c3-9b5b-741e-8692-d7a288b1a296`;
+`iterion report --run-id 019ff9c3…` reconstructs it), because it is the shape a
+digest bump takes
 when the audit is doing real work: SLSA v0.2 attestations on both digests naming
 the same upstream source commit, build history identical but for the Debian
 snapshot timestamp, the **Go compiler layer bit-identical** (`diff_id
@@ -37,15 +39,18 @@ manifest list — neither of which this repo's arches care about.
 
 ### Three lessons, all operational
 
-- **A batch sharing one lockfile can only merge serially.** Each merge rewrites
-  `pnpm-lock.yaml`, which invalidates every other PR's lockfile alignment: #395
+- **PRs sharing one lockfile can only merge serially** — the constraint is per
+  lockfile, not per batch: #397 (the GitHub-Actions group) merged alongside the
+  others without touching `pnpm-lock.yaml` and never conflicted. Within the pnpm
+  subset, each merge rewrites the lockfile and invalidates every other PR's
+  alignment: #395
   and #415 went `DIRTY` *because the lane was working*. Dependabot then refuses
   to rebase them — "edited by someone other than Dependabot", since Vetty
   committed there — and `gh pr update-branch` cannot resolve the conflict
   either. **`@dependabot recreate` is the way out**: it regenerates the branch
   from current `main` and discards the stale alignment, which Vetty redoes on
-  the fresh head. Expect this on every batch touching a shared lockfile; it is
-  not a failure.
+  the fresh head. Expect it whenever two PRs in flight touch the same lockfile;
+  it is not a failure.
 - **On a merge-queue repo, `autoMergeRequest` is always null**, even when
   `arm_automerge` reports `armed: true` — arming performs an *enqueue*, not an
   auto-merge. Reading the wrong field cost two investigations here. The question
@@ -58,10 +63,17 @@ manifest list — neither of which this repo's arches care about.
   ```
 
 - **A flaky non-required check is worse than a failing one.** `cloud-e2e` is
-  green on `main` and failed on #399, #412 and #417 — the last being a
-  documentation-only PR that cannot break it. The queue merges past it, so it
-  blocks nothing; but it makes every PR read `UNSTABLE` and costs a diagnosis
-  each time. Filed as `native:8f1821b3`.
+  green on `main` and failed on
+  [#399](https://github.com/SocialGouv/iterion/actions/runs/31629807903/job/94225394077)
+  and on
+  [#417](https://github.com/SocialGouv/iterion/actions/runs/31638317750/job/94254159369)
+  — the latter a **documentation-only PR that cannot break it**. Both links are
+  the failing jobs themselves, because a re-run replaces the check rollup and
+  the evidence for a flake disappears exactly when someone comes to check it.
+  The queue merges past this job, so it blocks nothing; but it makes every PR
+  read `UNSTABLE` and costs a diagnosis each time. Filed on the deployment board
+  as `native:8f1821b3` — which lives outside this repo, so the evidence is
+  duplicated here rather than only referenced.
 
 ## 2026-08-12 (evening) — both missing proofs land: an alignment merged, and the advisory path fires blind
 


### PR DESCRIPTION
Closes out the batch the last two bilans were about: **11 PRs resolved**, most overnight and unattended.

| outcome | PRs |
|---|---|
| merged through the lane | #394 (with Vetty's alignment), #393, #397, #399, #416 |
| green, in the merge queue | #390 |
| green after a recreate | #395 |
| held on its own merits | #396 |
| closed as obsolete | #391, #398, #415 |

The entire `build/tests not green after alignment` class disappeared once the base tree could pass its own tests inside the sandbox. **Nothing was tuned in Vetty to achieve that** — which is the point worth recording.

#390 is the one worth reading as a sample of the audit doing real work on a bump that looks trivial: SLSA attestations on both digests naming the same upstream source commit, the Go compiler layer bit-identical, 257 advisories resolved and 0 introduced, three disclosed coverage gaps, and two unsolicited operator notes (the pin trails upstream by two rebuilds; upstream dropped two platforms this repo doesn't target).

Three operational lessons, none of them about the bot's judgement:

1. **A batch sharing one lockfile merges serially.** Each merge invalidates the others' alignment — #395/#415 went DIRTY *because the lane was working*. Dependabot then refuses to rebase a branch Vetty committed to, and `update-branch` can't resolve it; `@dependabot recreate` is the way out.
2. **`autoMergeRequest` is always null on a merge-queue repo**, even when arming succeeded, because arming *enqueues*. That cost two investigations; the right GraphQL query is recorded.
3. **A flaky non-required check is worse than a failing one** — `cloud-e2e`, green on main, red on a docs-only PR. Filed as `native:8f1821b3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)