### PR TITLE
feat(forge): GitLab reads commit statuses, and a repo launch URL is canonical

### DIFF
--- a/pkg/forge/gitlab/status.go
+++ b/pkg/forge/gitlab/status.go
@@ -37,6 +37,73 @@ func (c *AdminClient) SetCommitStatus(ctx context.Context, repo, sha string, st 
 	return nil
 }
 
+// ListCommitStatuses returns the statuses already present on sha
+// (GET /projects/:id/repository/commits/:sha/statuses). Reading before
+// writing is what lets a reconciler tell "no verdict was ever posted" from
+// "a verdict is already there" — without it, repairing a missing check could
+// overwrite a real one.
+//
+// Unlike GitHub's combined-status endpoint, GitLab returns EVERY status row
+// on the commit — one per (name, pipeline) attempt, retries included — so the
+// result is deduplicated per name keeping the newest row (highest id): a gate
+// reader handed the raw history could match a stale verdict first.
+func (c *AdminClient) ListCommitStatuses(ctx context.Context, repo, sha string) ([]forge.CommitStatus, error) {
+	var rows []struct {
+		ID          int64  `json:"id"`
+		Status      string `json:"status"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		TargetURL   string `json:"target_url"`
+	}
+	code, err := c.do(ctx, http.MethodGet,
+		"/projects/"+projectID(repo)+"/repository/commits/"+url.PathEscape(sha)+"/statuses?per_page=100", nil, &rows)
+	if err != nil {
+		return nil, err
+	}
+	if code/100 != 2 {
+		return nil, statusErr("list commit statuses", code)
+	}
+	byName := map[string]int{} // name → index into out/ids
+	out := make([]forge.CommitStatus, 0, len(rows))
+	ids := make([]int64, 0, len(rows))
+	for _, r := range rows {
+		st := forge.CommitStatus{
+			State:       commitStateFromGitLab(r.Status),
+			Context:     r.Name,
+			Description: r.Description,
+			TargetURL:   r.TargetURL,
+		}
+		if i, ok := byName[r.Name]; ok {
+			if r.ID > ids[i] {
+				out[i], ids[i] = st, r.ID
+			}
+			continue
+		}
+		byName[r.Name] = len(out)
+		out = append(out, st)
+		ids = append(ids, r.ID)
+	}
+	return out, nil
+}
+
+// commitStateFromGitLab maps GitLab's wire status vocabulary back onto the
+// normalized CommitState — the read-side inverse of gitlabCommitState,
+// widened to the job states GitLab reports but iterion never posts.
+// In-flight states read as pending; canceled/skipped/unknown read as error:
+// an abandoned check is unevaluated, never a verdict.
+func commitStateFromGitLab(s string) forge.CommitState {
+	switch s {
+	case "success":
+		return forge.CommitStateSuccess
+	case "failed":
+		return forge.CommitStateFailure
+	case "pending", "created", "running", "waiting_for_resource", "preparing", "scheduled", "manual":
+		return forge.CommitStatePending
+	default: // canceled, skipped, anything future
+		return forge.CommitStateError
+	}
+}
+
 // gitlabCommitState maps the normalized CommitState onto GitLab's wire
 // vocabulary (pending|running|success|failed|canceled). Unknown → "failed"
 // so a miswired gate blocks rather than silently passes.

--- a/pkg/forge/gitlab/status.go
+++ b/pkg/forge/gitlab/status.go
@@ -43,10 +43,12 @@ func (c *AdminClient) SetCommitStatus(ctx context.Context, repo, sha string, st 
 // "a verdict is already there" — without it, repairing a missing check could
 // overwrite a real one.
 //
-// Unlike GitHub's combined-status endpoint, GitLab returns EVERY status row
-// on the commit — one per (name, pipeline) attempt, retries included — so the
-// result is deduplicated per name keeping the newest row (highest id): a gate
-// reader handed the raw history could match a stale verdict first.
+// GitLab's default scope already serves the latest row per name (history
+// needs all=true, which this deliberately does not pass) — verified live on
+// GitLab 19.2. The per-name dedup keeping the newest row (highest id) is
+// defense in depth for the shapes the default scope can still produce (one
+// row per pipeline carrying the same name): a gate reader handed more than
+// one row per name could match a stale verdict first.
 func (c *AdminClient) ListCommitStatuses(ctx context.Context, repo, sha string) ([]forge.CommitStatus, error) {
 	var rows []struct {
 		ID          int64  `json:"id"`

--- a/pkg/forge/gitlab/status_assert_test.go
+++ b/pkg/forge/gitlab/status_assert_test.go
@@ -1,15 +1,82 @@
 package gitlab
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/forge"
 )
 
-// The admin client must satisfy the merge-gate commit-status capability.
+// The admin client must satisfy the merge-gate commit-status capabilities:
+// write (post a verdict) and read (repair without overwriting a real one).
 var _ forge.CommitStatusClient = (*AdminClient)(nil)
+var _ forge.CommitStatusLister = (*AdminClient)(nil)
 
 func TestSetCommitStatusInterface(t *testing.T) {
-	// Compile-time assertion above is the real check; this keeps the file a
+	// Compile-time assertions above are the real check; this keeps the file a
 	// valid test unit.
+}
+
+// GitLab returns every status row on the commit (retries included), so the
+// lister must keep only the newest row per name — regardless of the order the
+// API returns them in — and map GitLab's wire states onto the normalized
+// vocabulary.
+func TestListCommitStatuses_DedupAndStateMapping(t *testing.T) {
+	mux := http.NewServeMux()
+	// Subgroup path: the project id is the URL-escaped full path.
+	mux.HandleFunc("GET /api/v4/projects/grp%2Fsub%2Fproj/repository/commits/abc123/statuses",
+		func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				// Old failed attempt of the gate, then its newer green retry —
+				// newest-first here, oldest-first below, to pin order-independence.
+				{"id": 12, "status": "success", "name": "iterion/review", "description": "0 findings", "target_url": "https://x/2"},
+				{"id": 7, "status": "failed", "name": "iterion/review", "description": "2 findings", "target_url": "https://x/1"},
+				{"id": 3, "status": "running", "name": "ci/build", "description": "", "target_url": ""},
+				{"id": 9, "status": "canceled", "name": "ci/lint", "description": "", "target_url": ""},
+			})
+		})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := &AdminClient{HTTP: srv.Client(), BaseURL: srv.URL, Token: "t"}
+	sts, err := c.ListCommitStatuses(context.Background(), "grp/sub/proj", "abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sts) != 3 {
+		t.Fatalf("want 3 deduplicated statuses, got %d: %+v", len(sts), sts)
+	}
+	byName := map[string]forge.CommitStatus{}
+	for _, s := range sts {
+		byName[s.Context] = s
+	}
+	gate := byName["iterion/review"]
+	if gate.State != forge.CommitStateSuccess || gate.Description != "0 findings" || gate.TargetURL != "https://x/2" {
+		t.Fatalf("gate must be the newest row (id 12): %+v", gate)
+	}
+	if byName["ci/build"].State != forge.CommitStatePending {
+		t.Fatalf("running must read as pending: %+v", byName["ci/build"])
+	}
+	if byName["ci/lint"].State != forge.CommitStateError {
+		t.Fatalf("canceled must read as error: %+v", byName["ci/lint"])
+	}
+}
+
+func TestListCommitStatuses_ErrorStatus(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v4/projects/grp%2Fproj/repository/commits/abc/statuses",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "403 Forbidden"})
+		})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := &AdminClient{HTTP: srv.Client(), BaseURL: srv.URL, Token: "t"}
+	if _, err := c.ListCommitStatuses(context.Background(), "grp/proj", "abc"); err == nil {
+		t.Fatal("want an error on a non-2xx response, got nil")
+	}
 }

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/forge"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -342,6 +343,13 @@ func (s *Server) handleLaunchRun(w http.ResponseWriter, r *http.Request) {
 		}
 		repoSecretOverrides = map[string]string{"forge_token": secID}
 		repoProjectPath = strings.TrimSuffix(strings.TrimPrefix(req.RepoURL, base+"/"), ".git")
+		// Canonicalize to the .git clone URL: the runner clones with
+		// http.followRedirects=false (SSRF hardening), and GitLab 301s a
+		// bare repo path to its .git twin — which that git config turns
+		// into a hard clone failure. GitHub serves both, so the trap only
+		// springs on GitLab; canonicalizing here keeps the launch request
+		// tolerant of either spelling.
+		req.RepoURL = forge.CloneURLFor(base, repoProjectPath)
 	}
 
 	// A launch that targets a pull request gets the repo's launch policy (its


### PR DESCRIPTION
## What

Two GitLab-parity gaps, both hit while wiring the first GitLab (self-hosted) repos onto a cloud instance:

1. **\`ListCommitStatuses\` for GitLab** (\`pkg/forge/gitlab/status.go\`) — the \`CommitStatusLister\` capability, mirror of \`pkg/forge/github/status.go\`. Without it, on GitLab:
   - the **gate reconciler abstains**: a review that dies leaves the required context absent forever (the exact hole ADR'd and closed for GitHub);
   - the **auto-fix lane never launches** — it refuses to act on a gate it cannot read (\`gateStatusOn\` → \`readable=false\` → abstain).

   GitLab's endpoint returns **every** status row on the commit (one per (name, pipeline) attempt, retries included), unlike GitHub's combined endpoint — so the result is deduplicated per \`name\` keeping the newest row (highest id): a gate reader handed raw history could match a stale verdict first. State mapping is the read-side inverse of \`gitlabCommitState\`, widened to the job states GitLab reports but iterion never posts (in-flight → \`pending\`; \`canceled\`/\`skipped\`/unknown → \`error\`: an abandoned check is unevaluated, never a verdict).

2. **Repo-targeted launch canonicalizes \`repo_url\` to the \`.git\` clone URL** (\`pkg/server/runs_launch.go\`) — the runner clones with \`http.followRedirects=false\` (SSRF hardening), and GitLab 301s a bare repo path to its \`.git\` twin, which that config turns into a hard clone failure. Observed live: an 8/8-delivery DLQ park on the first GitLab repo-targeted launch (run \`019ffad9\`). GitHub serves both spellings, so the trap only springs on GitLab; canonicalizing keeps the launch request tolerant of either. (Proof by the same launch re-run with \`.git\`: clone OK, review ran.)

## Tests

- \`pkg/forge/gitlab/status_assert_test.go\`: compile-time \`CommitStatusLister\` assertion + httptest covering dedup-keep-newest (order-independent), state mapping (\`running\`→pending, \`canceled\`→error), subgroup path escaping, and non-2xx error.
- The canonicalization is one line through the already-shipped \`forge.CloneURLFor\`; validated live on the GitLab instance (bare URL failed with 301, \`.git\` URL cloned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)