### PR TITLE
fix(vetty): a verify that overruns is a red build, not a crashed run

### DIFF
--- a/bots/dep-update-guard/main.bot
+++ b/bots/dep-update-guard/main.bot
@@ -144,6 +144,14 @@ vars:
   ## pollute the PR branch).
   scratch_dir: string = "${PROJECT_SCRATCH_DIR}/dep-update-guard"
 
+  ## Seconds the deterministic verify may run before it is called red.
+  ## Overridable because 20 minutes is a guess, not a property of the world:
+  ## a monorepo whose own CI takes longer would be held on a timeout that
+  ## says nothing about the bump. A timeout is reported as a red build
+  ## (exit 124) with whatever output the script produced first -- never as a
+  ## crashed node.
+  verify_timeout_s: int = 1200
+
 ## ─── Prompts ────────────────────────────────────────────────────
 
 prompt security_audit_system:
@@ -868,12 +876,22 @@ pre = tree_state()
 rc = 0
 out = ''
 reason = ''
+limit = int({{vars.verify_timeout_s}})
 try:
-    p = subprocess.run(['sh', script], cwd=ws, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=1200)
+    p = subprocess.run(['sh', script], cwd=ws, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=limit)
     out = p.stdout or ''
     rc = p.returncode
 except subprocess.TimeoutExpired as e:
-    out = (e.output or '') + chr(10) + '[verify timed out after 1200s]'
+    # e.output is BYTES on this path even though text=True was passed: the
+    # decode happens after communicate() returns normally, and a timeout
+    # attaches the raw buffer instead. Concatenating it to a str raises
+    # TypeError INSIDE this handler, which turns a red build into a crashed
+    # node -- observed 2026-08-13 on iterion#386, where a 20-minute verify
+    # ended the run failed_resumable with a traceback instead of a verdict.
+    partial = e.output or ''
+    if isinstance(partial, bytes):
+        partial = partial.decode('utf-8', 'replace')
+    out = partial + chr(10) + '[verify timed out after ' + str(limit) + 's]'
     rc = 124
 except Exception as e:
     out = 'verify_run could not execute the script: ' + str(e)

--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,15 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.7.5
+version: 2.7.6
+## 2.7.6 -- a verify that overruns is a red build, not a crashed run. The
+## TimeoutExpired handler concatenated e.output to a str, and on the timeout
+## path that attribute is BYTES even though text=True was passed (the decode
+## happens after communicate() returns normally). The TypeError fired inside
+## the handler, so iterion#386 ended failed_resumable with a traceback where
+## the verdict belonged. The partial output is decoded defensively now, and
+## the 20-minute limit became `verify_timeout_s` -- a repo whose own CI runs
+## longer was being held on a number that says nothing about its bump.
 ## 2.7.5 — a hold must say what broke. The report carried out[-4000:], a blind
 ## tail, and a test runner prints its per-package successes AFTER the package
 ## that failed: three holds on 2026-08-12 (iterion#394/#395/#411) reported

--- a/bots/dep_update_guard_verify_precheck_test.go
+++ b/bots/dep_update_guard_verify_precheck_test.go
@@ -43,10 +43,11 @@ func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 		LogTail          string `json:"log_tail"`
 	}
 
-	run := func(t *testing.T, ws, scratch string) verifyResult {
+	runWithTimeout := func(t *testing.T, ws, scratch, timeoutS string) verifyResult {
 		t.Helper()
 		cmd := strings.ReplaceAll(command, "{{vars.workspace_dir}}", ws)
 		cmd = strings.ReplaceAll(cmd, "{{vars.scratch_dir}}", scratch)
+		cmd = strings.ReplaceAll(cmd, "{{vars.verify_timeout_s}}", timeoutS)
 		out, err := exec.Command("sh", "-c", cmd).Output()
 		if err != nil {
 			t.Fatalf("verify_run failed to execute: %v (out %q)", err, out)
@@ -56,6 +57,10 @@ func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 			t.Fatalf("verify_run output is not verify_result JSON: %v (out %q)", uerr, out)
 		}
 		return res
+	}
+	run := func(t *testing.T, ws, scratch string) verifyResult {
+		t.Helper()
+		return runWithTimeout(t, ws, scratch, "1200")
 	}
 
 	// iterion#390: a base-image digest refresh on an unchanged tag. The
@@ -346,6 +351,37 @@ func TestDepUpdateGuardVerifyPrechecks(t *testing.T) {
 		res := run(t, ws, scratch)
 		if !strings.Contains(res.LogTail, "recipe for target build failed") {
 			t.Errorf("splitting the budget for a digest that does not exist lost the failure the old blind tail kept; got %d chars:\n%s", len(res.LogTail), res.LogTail)
+		}
+	})
+
+	// Observed live on iterion#386 (2026-08-13): a verify that ran past the
+	// limit ended the RUN, not the build. TimeoutExpired was caught, and then
+	// the handler itself raised — e.output is bytes on the timeout path even
+	// though text=True was passed, because the decode happens after
+	// communicate() returns normally and a timeout attaches the raw buffer.
+	// bytes + str is a TypeError, so a red build became a crashed node and a
+	// failed_resumable run with a traceback where the verdict should be.
+	t.Run("a verify that overruns is a red build, not a crashed node", func(t *testing.T) {
+		ws, scratch := t.TempDir(), t.TempDir()
+		// Emits output BEFORE hanging, so the partial-output path — the one
+		// that raised — is the path under test.
+		body := "#!/bin/sh\necho 'building the thing'\nsleep 30\n"
+		if err := os.WriteFile(filepath.Join(scratch, "verify.sh"), []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		res := runWithTimeout(t, ws, scratch, "1")
+		if res.Passed {
+			t.Error("a verify that never finished must not certify a build")
+		}
+		if res.ExitCode != 124 {
+			t.Errorf("a timeout is a red build with exit 124, got %d: %s", res.ExitCode, res.LogTail)
+		}
+		if !strings.Contains(res.LogTail, "timed out") {
+			t.Errorf("the excerpt must say the verify timed out, else the hold is unexplainable; got:\n%s", res.LogTail)
+		}
+		if !strings.Contains(res.LogTail, "building the thing") {
+			t.Errorf("the output produced before the timeout is the only clue to where it hung, and it was dropped; got:\n%s", res.LogTail)
 		}
 	})
 }

--- a/bots/issue-triage/skills/iterion-bot-catalog.md
+++ b/bots/issue-triage/skills/iterion-bot-catalog.md
@@ -321,7 +321,7 @@ audit ran and the build is green before anything is committed.
   alignment onto the PR branch. Not for human PRs (use Revi /
   review-pr), and not for proactively opening update PRs (that is
   Renovacy / secured-renovacy).
-- **Vars**: `arm_automerge` (bool), `automerge_method` (string), `base_ref` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_fix_iterations` (int), `post_to_board` (bool), `pr_author` (string), `pr_url` (string), `scope_notes` (string), `scratch_dir` (string), `workspace_dir` (string)
+- **Vars**: `arm_automerge` (bool), `automerge_method` (string), `base_ref` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_fix_iterations` (int), `post_to_board` (bool), `pr_author` (string), `pr_url` (string), `scope_notes` (string), `scratch_dir` (string), `verify_timeout_s` (int), `workspace_dir` (string)
 - **Path**: `bots/dep-update-guard/main.bot`
 
 ### `devbox-setup` — Devy

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -490,7 +490,7 @@ audit ran and the build is green before anything is committed.
   alignment onto the PR branch. Not for human PRs (use Revi /
   review-pr), and not for proactively opening update PRs (that is
   Renovacy / secured-renovacy).
-- **Vars**: `arm_automerge` (bool), `automerge_method` (string), `base_ref` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_fix_iterations` (int), `post_to_board` (bool), `pr_author` (string), `pr_url` (string), `scope_notes` (string), `scratch_dir` (string), `workspace_dir` (string)
+- **Vars**: `arm_automerge` (bool), `automerge_method` (string), `base_ref` (string), `forge_publish_token` (string), `forge_publish_url` (string), `gate_context` (string), `gate_enabled` (bool), `max_fix_iterations` (int), `post_to_board` (bool), `pr_author` (string), `pr_url` (string), `scope_notes` (string), `scratch_dir` (string), `verify_timeout_s` (int), `workspace_dir` (string)
 - **Path**: `bots/dep-update-guard/main.bot`
 
 ### `devbox-setup` — Devy


### PR DESCRIPTION
Found by monitoring today's backlog runs: **#386 ended `failed_resumable` with a traceback where a verdict belonged.**

```
subprocess.TimeoutExpired: Command [...] timed out after 1200 seconds
Traceback (most recent call last):
TypeError: can't concat str to bytes
```

The timeout *was* caught — and then the handler itself raised. `e.output` is **bytes** on the timeout path even though `text=True` was passed, because the decode happens after `communicate()` returns normally and a timeout attaches the raw buffer instead. `bytes + str` is a `TypeError`, so the one branch whose whole job is to turn an overrun into a red build was the branch that crashed the node.

This is the class this bot exists to get right: a failure that should be a **verdict** became a **crash**. Revi predicted it on #412 yesterday — asking whether an OOM would surface as a node failure rather than a red build — and I noted it honestly rather than acting. It answered itself by timeout instead, one day later.

**Two changes:**

1. The partial output is decoded defensively, so a timeout reports exit 124 with whatever the script printed before hanging — which is the only clue to *where* it hung.
2. The hardcoded `1200` became `verify_timeout_s`. Twenty minutes is a guess, not a property of the world: a monorepo whose own CI runs longer was being held on a number that says nothing about its bump. Per CLAUDE.md, a hardcoded constant bounding operator work with no override is a defect.

Pinned by `a verify that overruns is a red build, not a crashed node` — the fixture prints output *before* hanging, so the partial-output path (the one that raised) is the path under test. Removing the decode reddens it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)