### PR TITLE
feat(studio): preview JSON, markdown and text on human gates

### DIFF
--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -108,8 +108,12 @@ in the edge's `with {}`:
 
 The gate's inbound payload renderer previews any value carrying an
 `attachment` name plus one corroborating field. Images, audio and video
-play inline; JSON, markdown and other text are shown in the gate (long
-bodies start folded). A zip or other binary stays a download. Declaring
+play inline; JSON, markdown and other text (`.txt`, `.csv`, `.yaml`,
+`.log`, …) are shown in the gate (long bodies start folded). `.xml`,
+`.html`, `.svg` and `.js` stay a download: `neutralizeActiveMIME`
+downgrades them so the attachment route cannot serve executable bytes
+inline, and the studio preview classifier matches that set. A zip or
+other binary stays a download. Declaring
 the field as `file` in the gate's input schema sharpens the reading
 order; it is not required.
 

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -107,9 +107,11 @@ in the edge's `with {}`:
 ```
 
 The gate's inbound payload renderer previews any value carrying an
-`attachment` name plus one corroborating field. Declaring the field as
-`file` in the gate's input schema sharpens the reading order; it is not
-required.
+`attachment` name plus one corroborating field. Images, audio and video
+play inline; JSON, markdown and other text are shown in the gate (long
+bodies start folded). A zip or other binary stays a download. Declaring
+the field as `file` in the gate's input schema sharpens the reading
+order; it is not required.
 
 > This is the writing counterpart of `[iterion] preview_screenshot=`,
 > which promotes a browser capture the same way.

--- a/docs/human-in-the-loop.md
+++ b/docs/human-in-the-loop.md
@@ -246,7 +246,9 @@ attachment store: a tool node prints
 `[iterion] attachment=<path> name=<n>` on stdout, the runtime persists
 the file, and the gate's inbound payload previews it: images, audio and
 video as media; JSON, markdown and other text inline (folded when long).
-Anything else stays a download. See
+`.xml` / `.html` / `.svg` / `.js` stay a download (`neutralizeActiveMIME`
+downgrades them; the studio keeps the same carve-out). Anything else
+stays a download. See
 [attachments.md](attachments.md#a-tool-node-hands-over-a-file-it-produced).
 
 A path alone is never enough: it points at the host or the sandbox

--- a/docs/human-in-the-loop.md
+++ b/docs/human-in-the-loop.md
@@ -244,8 +244,10 @@ The sections above collect bytes **from** the operator. The reverse —
 putting a generated deliverable in front of them — goes through the same
 attachment store: a tool node prints
 `[iterion] attachment=<path> name=<n>` on stdout, the runtime persists
-the file, and the gate's inbound payload previews it as audio, video or
-image. See [attachments.md](attachments.md#a-tool-node-hands-over-a-file-it-produced).
+the file, and the gate's inbound payload previews it: images, audio and
+video as media; JSON, markdown and other text inline (folded when long).
+Anything else stays a download. See
+[attachments.md](attachments.md#a-tool-node-hands-over-a-file-it-produced).
 
 A path alone is never enough: it points at the host or the sandbox
 bind-mount, and no browser can fetch either.

--- a/studio/src/components/Runs/conversation/GateInboundFile.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundFile.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon, ChevronRightIcon, DownloadIcon, FileIcon } from "@radix-ui/react-icons";
+import { DownloadIcon, FileIcon } from "@radix-ui/react-icons";
 import { useEffect, useMemo, useState } from "react";
 
 import { attachmentURL, fetchAttachment } from "@/api/runs";
@@ -9,6 +9,13 @@ import { formatBytes } from "@/lib/format";
 import type { GateInboundFileRef } from "@/lib/gateInbound";
 import { prettyJSON, textPreviewKind } from "@/lib/textPreview";
 
+import {
+  COLLAPSE_AFTER_LINES,
+  COLLAPSED_MAX_HEIGHT,
+  JSON_PRETTY_BUDGET,
+  MARKDOWN_PARSE_BUDGET,
+  Toggle,
+} from "./gateInboundFold";
 import MarkdownText from "./MarkdownText";
 
 interface Props {
@@ -172,27 +179,20 @@ export default function GateInboundFile({ runId, file }: Props) {
   );
 }
 
-// Matches GateInboundPayload: enough to read a short plan, short enough
-// that two files plus the answer form still fit on screen.
-const COLLAPSE_AFTER_LINES = 12;
-const COLLAPSED_MAX_HEIGHT = "16rem";
-const MARKDOWN_PARSE_BUDGET = 20_000;
-
 function TextBody({ kind, text }: { kind: NonNullable<ReturnType<typeof textPreviewKind>>; text: string }) {
-  // Skip pretty-print past the parse budget: a 50 MiB JSON.parse during
-  // render would freeze the gate before the fold can help.
+  // Skip pretty-print only past JSON_PRETTY_BUDGET. Sharing the 20 KB
+  // markdown budget left a typical outline.json minified.
   const shown = useMemo(() => {
-    if (kind !== "json" || text.length > MARKDOWN_PARSE_BUDGET) return text;
+    if (kind !== "json" || text.length > JSON_PRETTY_BUDGET) return text;
     return prettyJSON(text);
   }, [kind, text]);
-  const lines = shown.split("\n");
+  const lines = useMemo(() => shown.split("\n"), [shown]);
   const long = lines.length > COLLAPSE_AFTER_LINES || shown.length > MARKDOWN_PARSE_BUDGET;
   const [open, setOpen] = useState(!long);
   const folded = long && !open;
   const heavyMd = kind === "markdown" && shown.length > MARKDOWN_PARSE_BUDGET;
-  // Markdown keeps the CSS clamp (slicing mid-fence swallows the rest
-  // of the payload). json/text slice so a multi-MB log never enters the
-  // DOM while folded — matching GateInboundPayload.JSONBlock.
+  // Markdown keeps the CSS clamp (slicing mid-fence swallows the rest).
+  // json/text slice so a multi-MB log never enters the folded <pre>.
   const preview = folded
     ? lines.slice(0, COLLAPSE_AFTER_LINES).join("\n").slice(0, MARKDOWN_PARSE_BUDGET)
     : shown;
@@ -223,19 +223,13 @@ function TextBody({ kind, text }: { kind: NonNullable<ReturnType<typeof textPrev
         )}
       </div>
       {long && (
-        <button
-          type="button"
-          onClick={() => setOpen((v) => !v)}
-          aria-expanded={open}
-          className="inline-flex items-center gap-0.5 text-micro text-accent-text hover:underline"
-        >
-          {open ? <ChevronDownIcon /> : <ChevronRightIcon />}
-          {open
-            ? "Show less"
-            : lines.length > COLLAPSE_AFTER_LINES
-              ? `Show all ${lines.length} lines`
-              : "Show all"}
-        </button>
+        <Toggle
+          open={open}
+          onToggle={() => setOpen((v) => !v)}
+          closedLabel={
+            lines.length > COLLAPSE_AFTER_LINES ? `Show all ${lines.length} lines` : "Show all"
+          }
+        />
       )}
     </div>
   );

--- a/studio/src/components/Runs/conversation/GateInboundFile.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundFile.tsx
@@ -14,6 +14,7 @@ import {
   COLLAPSED_MAX_HEIGHT,
   JSON_PRETTY_BUDGET,
   MARKDOWN_PARSE_BUDGET,
+  TEXT_PREVIEW_BYTE_BUDGET,
   Toggle,
 } from "./gateInboundFold";
 import MarkdownText from "./MarkdownText";
@@ -50,7 +51,7 @@ export default function GateInboundFile({ runId, file }: Props) {
   );
   const [zoomed, setZoomed] = useState(false);
   const mime = contentType || file.mime || "";
-  const kind = textPreviewKind(mime, label);
+  const kind = classifyAttachmentPreview(contentType, file.mime, label);
 
   const meta = (
     <span className="text-micro text-fg-subtle">
@@ -90,11 +91,11 @@ export default function GateInboundFile({ runId, file }: Props) {
     );
   }
 
-  if (error || (!blobURL && textBody === null)) {
+  if (error) {
     return (
       <div className="space-y-0.5">
         <div className="text-micro text-danger-fg" role="alert">
-          Couldn't load {label}: {error ?? "no content"}
+          Couldn't load {label}: {error}
         </div>
         <a
           href={attachmentURL(runId, file.attachment)}
@@ -243,6 +244,22 @@ interface BlobState {
   error: string | null;
 }
 
+/** fetchAttachment defaults a missing header to octet-stream, so
+ *  `contentType || declaredMime` never sees the descriptor. Fall back
+ *  only when the server type is generic; a real image/zip stays media. */
+function classifyAttachmentPreview(
+  contentType: string,
+  declaredMime: string | undefined,
+  filename: string,
+): ReturnType<typeof textPreviewKind> {
+  const fromServer = textPreviewKind(contentType, filename);
+  if (fromServer) return fromServer;
+  const [rawType] = contentType.toLowerCase().split(";");
+  const ct = (rawType ?? "").trim();
+  if (ct !== "" && ct !== "application/octet-stream") return null;
+  return textPreviewKind(declaredMime ?? "", filename);
+}
+
 /**
  * Fetch an attachment as text (documents / JSON) or as an ObjectURL
  * (media). Same generation discipline as usePreview: a gate can
@@ -273,8 +290,20 @@ function useAttachmentBlob(
     fetchAttachment(runId, name)
       .then(async ({ blob, contentType }) => {
         if (cancelled) return;
-        const kind = textPreviewKind(contentType || declaredMime || "", filename);
+        const kind = classifyAttachmentPreview(contentType, declaredMime, filename);
         if (kind) {
+          if (blob.size > TEXT_PREVIEW_BYTE_BUDGET) {
+            // Too large to decode into a JS string. Fall through to
+            // the download row — do not ObjectURL a text body.
+            setState({
+              blobURL: null,
+              textBody: null,
+              contentType,
+              loading: false,
+              error: null,
+            });
+            return;
+          }
           const textBody = await blob.text();
           if (cancelled) return;
           setState({

--- a/studio/src/components/Runs/conversation/GateInboundFile.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundFile.tsx
@@ -1,5 +1,5 @@
-import { DownloadIcon, FileIcon } from "@radix-ui/react-icons";
-import { useEffect, useState } from "react";
+import { ChevronDownIcon, ChevronRightIcon, DownloadIcon, FileIcon } from "@radix-ui/react-icons";
+import { useEffect, useMemo, useState } from "react";
 
 import { attachmentURL, fetchAttachment } from "@/api/runs";
 import { ImagePreviewDialog } from "@/views/PipelineBoard/ImagePreview";
@@ -7,6 +7,9 @@ import { Spinner } from "@/components/ui";
 import { errorMessage } from "@/lib/errorHints";
 import { formatBytes } from "@/lib/format";
 import type { GateInboundFileRef } from "@/lib/gateInbound";
+import { prettyJSON, textPreviewKind } from "@/lib/textPreview";
+
+import MarkdownText from "./MarkdownText";
 
 interface Props {
   runId: string;
@@ -25,15 +28,22 @@ interface Props {
  * (a bare `--answer x=@file` path, an LLM-answered gate) degrades to the
  * filename + path, which is still strictly more than the operator saw
  * before — never a broken image.
+ *
+ * Text, markdown and JSON are shown inline (same fold as the inbound
+ * payload renderer). Images, audio and video keep their media players.
+ * Anything else stays a download — a zip at a gate is not a preview.
  */
 export default function GateInboundFile({ runId, file }: Props) {
-  const { blobURL, contentType, loading, error } = useAttachmentBlob(
+  const label = file.filename || file.attachment || file.path || "file";
+  const { blobURL, textBody, contentType, loading, error } = useAttachmentBlob(
     runId,
     file.attachment,
+    label,
+    file.mime,
   );
   const [zoomed, setZoomed] = useState(false);
-  const label = file.filename || file.attachment || file.path || "file";
   const mime = contentType || file.mime || "";
+  const kind = textPreviewKind(mime, label);
 
   const meta = (
     <span className="text-micro text-fg-subtle">
@@ -42,6 +52,16 @@ export default function GateInboundFile({ runId, file }: Props) {
       {mime ? ` · ${mime}` : ""}
     </span>
   );
+
+  const download = file.attachment ? (
+    <a
+      href={attachmentURL(runId, file.attachment)}
+      download={label}
+      className="inline-flex items-center gap-1 text-micro text-accent-text hover:underline"
+    >
+      <DownloadIcon /> Download
+    </a>
+  ) : null;
 
   if (!file.attachment) {
     // Not fetchable — show what we know instead of a dead <img>.
@@ -63,7 +83,7 @@ export default function GateInboundFile({ runId, file }: Props) {
     );
   }
 
-  if (error || !blobURL) {
+  if (error || (!blobURL && textBody === null)) {
     return (
       <div className="space-y-0.5">
         <div className="text-micro text-danger-fg" role="alert">
@@ -80,7 +100,19 @@ export default function GateInboundFile({ runId, file }: Props) {
     );
   }
 
-  if (mime.startsWith("image/")) {
+  if (textBody !== null && kind) {
+    return (
+      <div className="space-y-1">
+        <TextBody kind={kind} text={textBody} />
+        <div className="flex flex-wrap items-center gap-2">
+          {meta}
+          {download}
+        </div>
+      </div>
+    );
+  }
+
+  if (blobURL && mime.startsWith("image/")) {
     return (
       <div className="space-y-1">
         <button
@@ -109,7 +141,7 @@ export default function GateInboundFile({ runId, file }: Props) {
     );
   }
 
-  if (mime.startsWith("audio/")) {
+  if (blobURL && mime.startsWith("audio/")) {
     return (
       <div className="space-y-1">
         <audio controls src={blobURL} className="w-full">
@@ -120,7 +152,7 @@ export default function GateInboundFile({ runId, file }: Props) {
     );
   }
 
-  if (mime.startsWith("video/")) {
+  if (blobURL && mime.startsWith("video/")) {
     return (
       <div className="space-y-1">
         <video controls src={blobURL} className="max-h-64 max-w-full rounded">
@@ -135,40 +167,86 @@ export default function GateInboundFile({ runId, file }: Props) {
     <div className="flex flex-wrap items-center gap-2">
       <FileIcon className="shrink-0 text-fg-subtle" />
       {meta}
-      <a
-        href={attachmentURL(runId, file.attachment)}
-        download={label}
-        className="inline-flex items-center gap-1 text-micro text-accent-text hover:underline"
+      {download}
+    </div>
+  );
+}
+
+// Matches GateInboundPayload: enough to read a short plan, short enough
+// that two files plus the answer form still fit on screen.
+const COLLAPSE_AFTER_LINES = 12;
+const COLLAPSED_MAX_HEIGHT = "16rem";
+const MARKDOWN_PARSE_BUDGET = 20_000;
+
+function TextBody({ kind, text }: { kind: NonNullable<ReturnType<typeof textPreviewKind>>; text: string }) {
+  const shown = useMemo(() => (kind === "json" ? prettyJSON(text) : text), [kind, text]);
+  const lines = shown.split("\n");
+  const long = lines.length > COLLAPSE_AFTER_LINES;
+  const [open, setOpen] = useState(!long);
+  const folded = long && !open;
+  const heavy = kind === "markdown" && shown.length > MARKDOWN_PARSE_BUDGET;
+
+  return (
+    <div className="min-w-0">
+      <div
+        className={folded ? "relative overflow-hidden" : undefined}
+        style={folded ? { maxHeight: COLLAPSED_MAX_HEIGHT } : undefined}
       >
-        <DownloadIcon /> Download
-      </a>
+        {kind === "markdown" && !(folded && heavy) ? (
+          <MarkdownText value={shown} size="sm" />
+        ) : (
+          <pre className="min-w-0 overflow-x-auto whitespace-pre-wrap break-words rounded bg-surface-0 p-1.5 font-mono text-micro leading-relaxed">
+            {folded && heavy ? shown.slice(0, MARKDOWN_PARSE_BUDGET) : shown}
+          </pre>
+        )}
+        {folded && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent to-surface-1"
+          />
+        )}
+      </div>
+      {long && (
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          className="inline-flex items-center gap-0.5 text-micro text-accent-text hover:underline"
+        >
+          {open ? <ChevronDownIcon /> : <ChevronRightIcon />}
+          {open ? "Show less" : `Show all ${lines.length} lines`}
+        </button>
+      )}
     </div>
   );
 }
 
 interface BlobState {
   blobURL: string | null;
+  textBody: string | null;
   contentType: string;
   loading: boolean;
   error: string | null;
 }
 
 /**
- * Fetch an attachment into an ObjectURL, revoking it on unmount.
- *
- * A gate can disappear mid-fetch (the operator advances to the next
- * queued review, the run resumes), so the in-flight response is
- * invalidated on cleanup — otherwise it commits state on a dead
- * component and leaks an orphaned ObjectURL. Same discipline as
- * usePreview.
+ * Fetch an attachment as text (documents / JSON) or as an ObjectURL
+ * (media). Same generation discipline as usePreview: a gate can
+ * disappear mid-fetch.
  *
  * Callers must give the component a `key` derived from the attachment so
  * a different file remounts it: the hook does not re-enter its loading
  * state when `name` changes under a live instance.
  */
-function useAttachmentBlob(runId: string, name: string | undefined): BlobState {
+function useAttachmentBlob(
+  runId: string,
+  name: string | undefined,
+  filename: string,
+  declaredMime: string | undefined,
+): BlobState {
   const [state, setState] = useState<BlobState>(() => ({
     blobURL: null,
+    textBody: null,
     contentType: "",
     loading: !!name,
     error: null,
@@ -179,15 +257,35 @@ function useAttachmentBlob(runId: string, name: string | undefined): BlobState {
     let cancelled = false;
     let created: string | null = null;
     fetchAttachment(runId, name)
-      .then(({ blob, contentType }) => {
+      .then(async ({ blob, contentType }) => {
         if (cancelled) return;
+        const kind = textPreviewKind(contentType || declaredMime || "", filename);
+        if (kind) {
+          const textBody = await blob.text();
+          if (cancelled) return;
+          setState({
+            blobURL: null,
+            textBody,
+            contentType,
+            loading: false,
+            error: null,
+          });
+          return;
+        }
         created = URL.createObjectURL(blob);
-        setState({ blobURL: created, contentType, loading: false, error: null });
+        setState({
+          blobURL: created,
+          textBody: null,
+          contentType,
+          loading: false,
+          error: null,
+        });
       })
       .catch((err: unknown) => {
         if (cancelled) return;
         setState({
           blobURL: null,
+          textBody: null,
           contentType: "",
           loading: false,
           error: errorMessage(err),
@@ -197,7 +295,7 @@ function useAttachmentBlob(runId: string, name: string | undefined): BlobState {
       cancelled = true;
       if (created) URL.revokeObjectURL(created);
     };
-  }, [runId, name]);
+  }, [runId, name, filename, declaredMime]);
 
   return state;
 }

--- a/studio/src/components/Runs/conversation/GateInboundFile.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundFile.tsx
@@ -1,5 +1,5 @@
 import { DownloadIcon, FileIcon } from "@radix-ui/react-icons";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { attachmentURL, fetchAttachment } from "@/api/runs";
 import { ImagePreviewDialog } from "@/views/PipelineBoard/ImagePreview";
@@ -12,7 +12,6 @@ import { prettyJSON, textPreviewKind } from "@/lib/textPreview";
 import {
   COLLAPSE_AFTER_LINES,
   COLLAPSED_MAX_HEIGHT,
-  JSON_PRETTY_BUDGET,
   MARKDOWN_PARSE_BUDGET,
   TEXT_PREVIEW_BYTE_BUDGET,
   Toggle,
@@ -181,12 +180,9 @@ export default function GateInboundFile({ runId, file }: Props) {
 }
 
 function TextBody({ kind, text }: { kind: NonNullable<ReturnType<typeof textPreviewKind>>; text: string }) {
-  // Skip pretty-print only past JSON_PRETTY_BUDGET. Sharing the 20 KB
-  // markdown budget left a typical outline.json minified.
-  const shown = useMemo(() => {
-    if (kind !== "json" || text.length > JSON_PRETTY_BUDGET) return text;
-    return prettyJSON(text);
-  }, [kind, text]);
+  // Inlined bodies are already ≤ TEXT_PREVIEW_BYTE_BUDGET, so pretty-print
+  // every JSON attachment — text.length cannot exceed the byte cap.
+  const shown = useMemo(() => (kind === "json" ? prettyJSON(text) : text), [kind, text]);
   const lines = useMemo(() => shown.split("\n"), [shown]);
   const long = lines.length > COLLAPSE_AFTER_LINES || shown.length > MARKDOWN_PARSE_BUDGET;
   const [open, setOpen] = useState(!long);
@@ -265,9 +261,10 @@ function classifyAttachmentPreview(
  * (media). Same generation discipline as usePreview: a gate can
  * disappear mid-fetch.
  *
- * Callers must give the component a `key` derived from the attachment so
- * a different file remounts it: the hook does not re-enter its loading
- * state when `name` changes under a live instance.
+ * Effect deps are runId+name only. Filename and declaredMime feed
+ * classification through refs. The parent keys this component on the
+ * attachment name, so a different file remounts; changing mime under a
+ * live instance must not revoke a still-rendered ObjectURL.
  */
 function useAttachmentBlob(
   runId: string,
@@ -275,6 +272,11 @@ function useAttachmentBlob(
   filename: string,
   declaredMime: string | undefined,
 ): BlobState {
+  const filenameRef = useRef(filename);
+  const declaredMimeRef = useRef(declaredMime);
+  filenameRef.current = filename;
+  declaredMimeRef.current = declaredMime;
+
   const [state, setState] = useState<BlobState>(() => ({
     blobURL: null,
     textBody: null,
@@ -287,10 +289,21 @@ function useAttachmentBlob(
     if (!name) return;
     let cancelled = false;
     let created: string | null = null;
+    setState({
+      blobURL: null,
+      textBody: null,
+      contentType: "",
+      loading: true,
+      error: null,
+    });
     fetchAttachment(runId, name)
       .then(async ({ blob, contentType }) => {
         if (cancelled) return;
-        const kind = classifyAttachmentPreview(contentType, declaredMime, filename);
+        const kind = classifyAttachmentPreview(
+          contentType,
+          declaredMimeRef.current,
+          filenameRef.current,
+        );
         if (kind) {
           if (blob.size > TEXT_PREVIEW_BYTE_BUDGET) {
             // Too large to decode into a JS string. Fall through to
@@ -338,7 +351,7 @@ function useAttachmentBlob(
       cancelled = true;
       if (created) URL.revokeObjectURL(created);
     };
-  }, [runId, name, filename, declaredMime]);
+  }, [runId, name]);
 
   return state;
 }

--- a/studio/src/components/Runs/conversation/GateInboundFile.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundFile.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { attachmentURL, fetchAttachment } from "@/api/runs";
 import { ImagePreviewDialog } from "@/views/PipelineBoard/ImagePreview";
-import { Spinner } from "@/components/ui";
+import { CopyButton, Spinner } from "@/components/ui";
 import { errorMessage } from "@/lib/errorHints";
 import { formatBytes } from "@/lib/format";
 import type { GateInboundFileRef } from "@/lib/gateInbound";
@@ -179,31 +179,47 @@ const COLLAPSED_MAX_HEIGHT = "16rem";
 const MARKDOWN_PARSE_BUDGET = 20_000;
 
 function TextBody({ kind, text }: { kind: NonNullable<ReturnType<typeof textPreviewKind>>; text: string }) {
-  const shown = useMemo(() => (kind === "json" ? prettyJSON(text) : text), [kind, text]);
+  // Skip pretty-print past the parse budget: a 50 MiB JSON.parse during
+  // render would freeze the gate before the fold can help.
+  const shown = useMemo(() => {
+    if (kind !== "json" || text.length > MARKDOWN_PARSE_BUDGET) return text;
+    return prettyJSON(text);
+  }, [kind, text]);
   const lines = shown.split("\n");
-  const long = lines.length > COLLAPSE_AFTER_LINES;
+  const long = lines.length > COLLAPSE_AFTER_LINES || shown.length > MARKDOWN_PARSE_BUDGET;
   const [open, setOpen] = useState(!long);
   const folded = long && !open;
-  const heavy = kind === "markdown" && shown.length > MARKDOWN_PARSE_BUDGET;
+  const heavyMd = kind === "markdown" && shown.length > MARKDOWN_PARSE_BUDGET;
+  // Markdown keeps the CSS clamp (slicing mid-fence swallows the rest
+  // of the payload). json/text slice so a multi-MB log never enters the
+  // DOM while folded — matching GateInboundPayload.JSONBlock.
+  const preview = folded
+    ? lines.slice(0, COLLAPSE_AFTER_LINES).join("\n").slice(0, MARKDOWN_PARSE_BUDGET)
+    : shown;
 
   return (
     <div className="min-w-0">
-      <div
-        className={folded ? "relative overflow-hidden" : undefined}
-        style={folded ? { maxHeight: COLLAPSED_MAX_HEIGHT } : undefined}
-      >
-        {kind === "markdown" && !(folded && heavy) ? (
-          <MarkdownText value={shown} size="sm" />
-        ) : (
-          <pre className="min-w-0 overflow-x-auto whitespace-pre-wrap break-words rounded bg-surface-0 p-1.5 font-mono text-micro leading-relaxed">
-            {folded && heavy ? shown.slice(0, MARKDOWN_PARSE_BUDGET) : shown}
-          </pre>
-        )}
-        {folded && (
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent to-surface-1"
-          />
+      <div className={kind === "json" ? "flex items-start gap-1" : undefined}>
+        <div
+          className={folded ? "relative min-w-0 flex-1 overflow-hidden" : "min-w-0 flex-1"}
+          style={folded ? { maxHeight: COLLAPSED_MAX_HEIGHT } : undefined}
+        >
+          {kind === "markdown" && !(folded && heavyMd) ? (
+            <MarkdownText value={shown} size="sm" />
+          ) : (
+            <pre className="min-w-0 overflow-x-auto whitespace-pre-wrap break-words rounded bg-surface-0 p-1.5 font-mono text-micro leading-relaxed">
+              {folded ? preview : shown}
+            </pre>
+          )}
+          {folded && (
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent to-surface-1"
+            />
+          )}
+        </div>
+        {kind === "json" && (
+          <CopyButton value={shown} variant="icon" label="Copy JSON" copiedLabel="Copied" />
         )}
       </div>
       {long && (
@@ -214,7 +230,11 @@ function TextBody({ kind, text }: { kind: NonNullable<ReturnType<typeof textPrev
           className="inline-flex items-center gap-0.5 text-micro text-accent-text hover:underline"
         >
           {open ? <ChevronDownIcon /> : <ChevronRightIcon />}
-          {open ? "Show less" : `Show all ${lines.length} lines`}
+          {open
+            ? "Show less"
+            : lines.length > COLLAPSE_AFTER_LINES
+              ? `Show all ${lines.length} lines`
+              : "Show all"}
         </button>
       )}
     </div>

--- a/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
@@ -258,6 +258,50 @@ describe("GateInboundPayload", () => {
     expect(screen.getByText(/ch_19/)).toBeTruthy();
   });
 
+  it("pretty-prints a mid-size JSON outline and still slices the fold", async () => {
+    const outline = {
+      subject: "Ulysse",
+      chapters: Array.from({ length: 400 }, (_, i) => ({
+        id: `ch_${i}`,
+        title: `Chapter ${i}`,
+        events: ["land", "sea", "return"],
+      })),
+    };
+    const raw = JSON.stringify(outline);
+    expect(raw.length).toBeGreaterThan(20_000);
+    expect(raw.length).toBeLessThan(2_000_000);
+
+    fetchAttachment.mockResolvedValue({
+      blob: new Blob([raw], { type: "application/json" }),
+      contentType: "application/json",
+    });
+
+    const { container } = render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{
+          outline_file: {
+            attachment: "outline-mid",
+            filename: "outline.json",
+            mime: "application/json",
+          },
+        }}
+        inputFields={[{ name: "outline_file", type: "file" }]}
+      />,
+    );
+
+    const toggle = await screen.findByRole("button", { name: /show all \d+ lines/i });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    const pre = container.querySelector("pre");
+    expect(pre?.textContent).toMatch(/\n\s+"subject": "Ulysse"/);
+    expect(pre?.textContent).not.toBe(raw);
+    expect(pre?.textContent?.length ?? 0).toBeLessThanOrEqual(20_000);
+    expect(screen.queryByText(/"id": "ch_399"/)).toBeNull();
+
+    fireEvent.click(toggle);
+    expect(screen.getByText(/"id": "ch_399"/)).toBeTruthy();
+  });
+
   it("folds a single-line attachment larger than the parse budget", async () => {
     const body = "x".repeat(25_000);
     fetchAttachment.mockResolvedValue({
@@ -317,6 +361,37 @@ describe("GateInboundPayload", () => {
     expect(await screen.findByRole("link", { name: /download/i })).toBeTruthy();
     expect(screen.queryByText("<root/>")).toBeNull();
     expect(screen.queryByRole("button", { name: /show all/i })).toBeNull();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("leaves a zip as a download-only row", async () => {
+    fetchAttachment.mockResolvedValue({
+      blob: new Blob(["PK"], { type: "application/zip" }),
+      contentType: "application/zip",
+    });
+    const createObjectURL = vi.fn(() => "blob:zip");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", { ...URL, createObjectURL, revokeObjectURL });
+
+    render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{
+          bundle: {
+            attachment: "bundle-zip",
+            filename: "bundle.zip",
+            mime: "application/zip",
+          },
+        }}
+        inputFields={[{ name: "bundle", type: "file" }]}
+      />,
+    );
+
+    expect(await screen.findByRole("link", { name: /download/i })).toBeTruthy();
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(screen.queryByRole("button", { name: /show all/i })).toBeNull();
+    expect(screen.queryByText("PK")).toBeNull();
 
     vi.unstubAllGlobals();
   });

--- a/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
@@ -251,8 +251,74 @@ describe("GateInboundPayload", () => {
 
     const toggle = await screen.findByRole("button", { name: /show all \d+ lines/i });
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    // Folded <pre> is a slice, not a CSS clamp over the whole body.
+    expect(screen.queryByText(/ch_19/)).toBeNull();
     fireEvent.click(toggle);
     expect(screen.getByRole("button", { name: /show less/i })).toBeTruthy();
+    expect(screen.getByText(/ch_19/)).toBeTruthy();
+  });
+
+  it("folds a single-line attachment larger than the parse budget", async () => {
+    const body = "x".repeat(25_000);
+    fetchAttachment.mockResolvedValue({
+      blob: new Blob([body], { type: "text/plain" }),
+      contentType: "text/plain",
+    });
+
+    const { container } = render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{
+          log_file: {
+            attachment: "log-huge",
+            filename: "trace.log",
+            mime: "text/plain",
+          },
+        }}
+        inputFields={[{ name: "log_file", type: "file" }]}
+      />,
+    );
+
+    const toggle = await screen.findByRole("button", { name: /^show all$/i });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    const pre = container.querySelector("pre");
+    expect(pre).toBeTruthy();
+    expect(pre?.textContent?.length ?? 0).toBeLessThanOrEqual(20_000);
+    expect(pre?.textContent?.length ?? 0).toBeLessThan(body.length);
+
+    fireEvent.click(toggle);
+    expect(screen.getByRole("button", { name: /show less/i })).toBeTruthy();
+    expect(container.querySelector("pre")?.textContent).toBe(body);
+  });
+
+  it("does not inline-preview a neutralized XML attachment", async () => {
+    fetchAttachment.mockResolvedValue({
+      blob: new Blob(["<root/>"], { type: "application/octet-stream" }),
+      contentType: "application/octet-stream",
+    });
+    const createObjectURL = vi.fn(() => "blob:xml");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", { ...URL, createObjectURL, revokeObjectURL });
+
+    render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{
+          spec: {
+            attachment: "spec-xml",
+            filename: "data.xml",
+            mime: "application/octet-stream",
+          },
+        }}
+        inputFields={[{ name: "spec", type: "file" }]}
+      />,
+    );
+
+    expect(await screen.findByRole("link", { name: /download/i })).toBeTruthy();
+    expect(screen.queryByText("<root/>")).toBeNull();
+    expect(screen.queryByRole("button", { name: /show all/i })).toBeNull();
+
+    vi.unstubAllGlobals();
   });
 
   it("degrades to the filename when a file value has no fetchable attachment", async () => {

--- a/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@/api/runs", async (importOriginal) => {
   };
 });
 
+import { TEXT_PREVIEW_BYTE_BUDGET } from "./gateInboundFold";
 import GateInboundPayload from "./GateInboundPayload";
 
 afterEach(() => {
@@ -199,6 +200,86 @@ describe("GateInboundPayload", () => {
     expect(screen.getByRole("link", { name: /download/i })).toBeTruthy();
     expect(screen.queryByRole("img")).toBeNull();
     expect(fetchAttachment).toHaveBeenCalledWith("run-1", "outline_file-609b6784");
+  });
+
+  it("does not inline a text attachment larger than the byte budget", async () => {
+    const blob = new Blob(["do-not-decode"], { type: "text/plain" });
+    Object.defineProperty(blob, "size", { value: TEXT_PREVIEW_BYTE_BUDGET + 1 });
+    fetchAttachment.mockResolvedValue({ blob, contentType: "text/plain" });
+
+    const { container } = render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{
+          log_file: {
+            attachment: "log-huge-bytes",
+            filename: "build.log",
+            mime: "text/plain",
+            size: TEXT_PREVIEW_BYTE_BUDGET + 1,
+          },
+        }}
+        inputFields={[{ name: "log_file", type: "file" }]}
+      />,
+    );
+
+    expect(await screen.findByRole("link", { name: /download/i })).toBeTruthy();
+    expect(screen.queryByText("do-not-decode")).toBeNull();
+    expect(screen.queryByRole("button", { name: /show all/i })).toBeNull();
+    expect(container.querySelector("pre")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("previews an extension-less markdown file from the declared mime", async () => {
+    fetchAttachment.mockResolvedValue({
+      blob: new Blob(["# Brief to review"], { type: "application/octet-stream" }),
+      contentType: "application/octet-stream",
+    });
+
+    render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{
+          brief: {
+            attachment: "brief-noext",
+            filename: "brief",
+            mime: "text/markdown",
+          },
+        }}
+        inputFields={[{ name: "brief", type: "file" }]}
+      />,
+    );
+
+    expect(await screen.findByRole("heading", { name: /brief to review/i })).toBeTruthy();
+  });
+
+  it("keeps a neutralized XML attachment as download even with a declared text/xml mime", async () => {
+    fetchAttachment.mockResolvedValue({
+      blob: new Blob(["<root/>"], { type: "application/octet-stream" }),
+      contentType: "application/octet-stream",
+    });
+    const createObjectURL = vi.fn(() => "blob:xml");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", { ...URL, createObjectURL, revokeObjectURL });
+
+    render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{
+          spec: {
+            attachment: "spec-xml-declared",
+            filename: "data.xml",
+            mime: "text/xml",
+          },
+        }}
+        inputFields={[{ name: "spec", type: "file" }]}
+      />,
+    );
+
+    expect(await screen.findByRole("link", { name: /download/i })).toBeTruthy();
+    expect(screen.queryByText("<root/>")).toBeNull();
+    expect(screen.queryByRole("button", { name: /show all/i })).toBeNull();
+
+    vi.unstubAllGlobals();
   });
 
   it("previews a markdown brief as prose, not as a download-only row", async () => {

--- a/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
@@ -173,6 +173,88 @@ describe("GateInboundPayload", () => {
     vi.unstubAllGlobals();
   });
 
+  it("previews a JSON attachment instead of offering only a download", async () => {
+    fetchAttachment.mockResolvedValue({
+      blob: new Blob(['{"subject":"Ulysse","chapters":[1,2]}'], { type: "application/json" }),
+      contentType: "application/json",
+    });
+
+    render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{
+          outline_file: {
+            attachment: "outline_file-609b6784",
+            filename: "outline.json",
+            path: "/host/state/films/x/outline.json",
+            mime: "application/json",
+            size: 48,
+          },
+        }}
+        inputFields={[{ name: "outline_file", type: "file" }]}
+      />,
+    );
+
+    expect(await screen.findByText(/"subject": "Ulysse"/)).toBeTruthy();
+    expect(screen.getByRole("link", { name: /download/i })).toBeTruthy();
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(fetchAttachment).toHaveBeenCalledWith("run-1", "outline_file-609b6784");
+  });
+
+  it("previews a markdown brief as prose, not as a download-only row", async () => {
+    fetchAttachment.mockResolvedValue({
+      blob: new Blob(["# Découpage à valider\n\nCe que tu juges"], { type: "text/plain" }),
+      contentType: "text/plain",
+    });
+
+    render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{
+          brief_file: {
+            attachment: "brief_file-da9c85f7",
+            filename: "outline_review.md",
+            mime: "text/plain",
+            size: 40,
+          },
+        }}
+        inputFields={[{ name: "brief_file", type: "file" }]}
+      />,
+    );
+
+    expect(await screen.findByRole("heading", { name: /découpage à valider/i })).toBeTruthy();
+    expect(screen.getByText("Ce que tu juges")).toBeTruthy();
+  });
+
+  it("folds a long JSON attachment behind a toggle", async () => {
+    const chapters = Object.fromEntries(
+      Array.from({ length: 20 }, (_, i) => [`ch_${i}`, { events: ["a", "b"] }]),
+    );
+    fetchAttachment.mockResolvedValue({
+      blob: new Blob([JSON.stringify({ chapters })], { type: "application/json" }),
+      contentType: "application/json",
+    });
+
+    render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{
+          outline_file: {
+            attachment: "outline_file-long",
+            filename: "outline.json",
+            mime: "application/json",
+          },
+        }}
+        inputFields={[{ name: "outline_file", type: "file" }]}
+      />,
+    );
+
+    const toggle = await screen.findByRole("button", { name: /show all \d+ lines/i });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(toggle);
+    expect(screen.getByRole("button", { name: /show less/i })).toBeTruthy();
+  });
+
   it("degrades to the filename when a file value has no fetchable attachment", async () => {
     render(
       <GateInboundPayload

--- a/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
@@ -350,7 +350,7 @@ describe("GateInboundPayload", () => {
     };
     const raw = JSON.stringify(outline);
     expect(raw.length).toBeGreaterThan(20_000);
-    expect(raw.length).toBeLessThan(2_000_000);
+    expect(raw.length).toBeLessThan(TEXT_PREVIEW_BYTE_BUDGET);
 
     fetchAttachment.mockResolvedValue({
       blob: new Blob([raw], { type: "application/json" }),

--- a/studio/src/components/Runs/conversation/GateInboundPayload.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundPayload.tsx
@@ -1,4 +1,3 @@
-import { ChevronDownIcon, ChevronRightIcon } from "@radix-ui/react-icons";
 import { useMemo, useState } from "react";
 
 import type { WireSchemaField } from "@/api/runs";
@@ -10,6 +9,12 @@ import {
 } from "@/lib/gateInbound";
 
 import GateInboundFile from "./GateInboundFile";
+import {
+  COLLAPSE_AFTER_LINES,
+  COLLAPSED_MAX_HEIGHT,
+  MARKDOWN_PARSE_BUDGET,
+  Toggle,
+} from "./gateInboundFold";
 import MarkdownText from "./MarkdownText";
 
 interface Props {
@@ -103,22 +108,6 @@ function GateInboundValue({ runId, item }: { runId: string; item: GateInboundIte
   }
 }
 
-// Above this many lines a value is folded by default — enough to read a
-// short plan in place, short enough that three of them still leave the
-// answer form on screen.
-const COLLAPSE_AFTER_LINES = 12;
-
-// Roughly COLLAPSE_AFTER_LINES of prose at the `sm` line-height. The
-// fold is a CSS clamp, so it is deliberately approximate.
-const COLLAPSED_MAX_HEIGHT = "16rem";
-
-// Past this many characters the folded preview skips markdown entirely.
-// A gate can be mapped a whole `git diff` — one of this feature's own
-// motivating cases — and parsing hundreds of KB through react-markdown +
-// rehype-highlight to then clamp it to ~16rem is work thrown away. The
-// operator opts into that cost by expanding.
-const MARKDOWN_PARSE_BUDGET = 20_000;
-
 function CollapsibleText({ text }: { text: string }) {
   const lines = text.split("\n");
   const long = lines.length > COLLAPSE_AFTER_LINES;
@@ -184,28 +173,6 @@ function JSONBlock({ value }: { value: unknown }) {
         />
       )}
     </div>
-  );
-}
-
-function Toggle({
-  open,
-  onToggle,
-  closedLabel,
-}: {
-  open: boolean;
-  onToggle: () => void;
-  closedLabel: string;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onToggle}
-      aria-expanded={open}
-      className="inline-flex items-center gap-0.5 text-micro text-accent-text hover:underline"
-    >
-      {open ? <ChevronDownIcon /> : <ChevronRightIcon />}
-      {open ? "Show less" : closedLabel}
-    </button>
   );
 }
 

--- a/studio/src/components/Runs/conversation/gateInboundFold.tsx
+++ b/studio/src/components/Runs/conversation/gateInboundFold.tsx
@@ -7,10 +7,8 @@ export const COLLAPSED_MAX_HEIGHT = "16rem";
 /** Folded markdown skips react-markdown past this; also the json/text DOM slice. */
 export const MARKDOWN_PARSE_BUDGET = 20_000;
 
-/** Skip prettyJSON only above this. A few MB of parse+stringify is cheap; 20 KB is not. */
-export const JSON_PRETTY_BUDGET = 2_000_000;
-
-/** Do not blob.text() / line-split an attachment larger than this. */
+/** Do not blob.text() / line-split an attachment larger than this.
+ *  Inlined JSON is always pretty-printed; UTF-8 length cannot exceed this. */
 export const TEXT_PREVIEW_BYTE_BUDGET = 2_000_000;
 
 export function Toggle({

--- a/studio/src/components/Runs/conversation/gateInboundFold.tsx
+++ b/studio/src/components/Runs/conversation/gateInboundFold.tsx
@@ -10,6 +10,9 @@ export const MARKDOWN_PARSE_BUDGET = 20_000;
 /** Skip prettyJSON only above this. A few MB of parse+stringify is cheap; 20 KB is not. */
 export const JSON_PRETTY_BUDGET = 2_000_000;
 
+/** Do not blob.text() / line-split an attachment larger than this. */
+export const TEXT_PREVIEW_BYTE_BUDGET = 2_000_000;
+
 export function Toggle({
   open,
   onToggle,

--- a/studio/src/components/Runs/conversation/gateInboundFold.tsx
+++ b/studio/src/components/Runs/conversation/gateInboundFold.tsx
@@ -1,0 +1,33 @@
+import { ChevronDownIcon, ChevronRightIcon } from "@radix-ui/react-icons";
+
+/** Enough to read a short plan; two files plus the answer form still fit. */
+export const COLLAPSE_AFTER_LINES = 12;
+export const COLLAPSED_MAX_HEIGHT = "16rem";
+
+/** Folded markdown skips react-markdown past this; also the json/text DOM slice. */
+export const MARKDOWN_PARSE_BUDGET = 20_000;
+
+/** Skip prettyJSON only above this. A few MB of parse+stringify is cheap; 20 KB is not. */
+export const JSON_PRETTY_BUDGET = 2_000_000;
+
+export function Toggle({
+  open,
+  onToggle,
+  closedLabel,
+}: {
+  open: boolean;
+  onToggle: () => void;
+  closedLabel: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={open}
+      className="inline-flex items-center gap-0.5 text-micro text-accent-text hover:underline"
+    >
+      {open ? <ChevronDownIcon /> : <ChevronRightIcon />}
+      {open ? "Show less" : closedLabel}
+    </button>
+  );
+}

--- a/studio/src/lib/textPreview.test.ts
+++ b/studio/src/lib/textPreview.test.ts
@@ -28,6 +28,16 @@ describe("textPreviewKind", () => {
     expect(textPreviewKind("application/zip", "bundle.zip")).toBeNull();
     expect(textPreviewKind("", "Makefile")).toBeNull();
   });
+
+  it("does not re-preview types neutralizeActiveMIME downgrades", () => {
+    expect(textPreviewKind("application/octet-stream", "data.xml")).toBeNull();
+    expect(textPreviewKind("application/xml", "cfg.xml")).toBeNull();
+    expect(textPreviewKind("text/xml", "x")).toBeNull();
+    expect(textPreviewKind("text/html", "page.html")).toBeNull();
+    expect(textPreviewKind("image/svg+xml", "icon.svg")).toBeNull();
+    expect(textPreviewKind("text/javascript", "app.js")).toBeNull();
+    expect(textPreviewKind("application/octet-stream", "notes.txt")).toBe("text");
+  });
 });
 
 describe("prettyJSON", () => {

--- a/studio/src/lib/textPreview.test.ts
+++ b/studio/src/lib/textPreview.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { prettyJSON, textPreviewKind } from "./textPreview";
+
+describe("textPreviewKind", () => {
+  it("classifies JSON from mime or extension", () => {
+    expect(textPreviewKind("application/json", "outline.json")).toBe("json");
+    expect(textPreviewKind("application/octet-stream", "tokens.json")).toBe("json");
+    expect(textPreviewKind("application/json; charset=utf-8", "x")).toBe("json");
+  });
+
+  it("classifies markdown from mime or extension", () => {
+    expect(textPreviewKind("text/markdown", "brief")).toBe("markdown");
+    expect(textPreviewKind("text/plain", "outline_review.md")).toBe("markdown");
+    expect(textPreviewKind("", "notes.mdx")).toBe("markdown");
+  });
+
+  it("classifies other text documents", () => {
+    expect(textPreviewKind("text/plain", "notes.txt")).toBe("text");
+    expect(textPreviewKind("application/yaml", "cfg.yaml")).toBe("text");
+    expect(textPreviewKind("", "log.csv")).toBe("text");
+  });
+
+  it("leaves media and unknowns to the download fallback", () => {
+    expect(textPreviewKind("image/png", "shot.png")).toBeNull();
+    expect(textPreviewKind("video/mp4", "clip.mp4")).toBeNull();
+    expect(textPreviewKind("audio/wav", "mix.wav")).toBeNull();
+    expect(textPreviewKind("application/zip", "bundle.zip")).toBeNull();
+    expect(textPreviewKind("", "Makefile")).toBeNull();
+  });
+});
+
+describe("prettyJSON", () => {
+  it("indents valid JSON and leaves invalid bodies alone", () => {
+    expect(prettyJSON('{"a":1}')).toBe('{\n  "a": 1\n}');
+    expect(prettyJSON("not json")).toBe("not json");
+  });
+});

--- a/studio/src/lib/textPreview.test.ts
+++ b/studio/src/lib/textPreview.test.ts
@@ -31,12 +31,18 @@ describe("textPreviewKind", () => {
 
   it("does not re-preview types neutralizeActiveMIME downgrades", () => {
     expect(textPreviewKind("application/octet-stream", "data.xml")).toBeNull();
+    expect(textPreviewKind("application/octet-stream", "page.html")).toBeNull();
+    expect(textPreviewKind("application/octet-stream", "icon.svg")).toBeNull();
+    expect(textPreviewKind("", "x.xml")).toBeNull();
+    expect(textPreviewKind("", "page.html")).toBeNull();
+    expect(textPreviewKind("", "icon.svg")).toBeNull();
     expect(textPreviewKind("application/xml", "cfg.xml")).toBeNull();
     expect(textPreviewKind("text/xml", "x")).toBeNull();
     expect(textPreviewKind("text/html", "page.html")).toBeNull();
     expect(textPreviewKind("image/svg+xml", "icon.svg")).toBeNull();
     expect(textPreviewKind("text/javascript", "app.js")).toBeNull();
     expect(textPreviewKind("application/octet-stream", "notes.txt")).toBe("text");
+    expect(textPreviewKind("text/plain", "notes.txt")).toBe("text");
   });
 });
 

--- a/studio/src/lib/textPreview.ts
+++ b/studio/src/lib/textPreview.ts
@@ -1,0 +1,51 @@
+// Which inbound attachments a human gate can render inline as text.
+// Images / audio / video stay on the media path; everything else that
+// is a document or structured payload used to collapse to "Download".
+
+export type TextPreviewKind = "json" | "markdown" | "text";
+
+const JSON_EXTS = new Set(["json", "jsonl", "ndjson"]);
+const MARKDOWN_EXTS = new Set(["md", "mdx", "markdown"]);
+const TEXT_EXTS = new Set(["yml", "yaml", "txt", "csv", "tsv", "toml", "xml", "log"]);
+
+function extension(filename: string): string {
+  const base = filename.slice(Math.max(filename.lastIndexOf("/"), filename.lastIndexOf("\\")) + 1);
+  const dot = base.lastIndexOf(".");
+  if (dot <= 0) return "";
+  return base.slice(dot + 1).toLowerCase();
+}
+
+function mimeType(mime: string): string {
+  return mime.toLowerCase().split(";")[0].trim();
+}
+
+/** How to render an attachment, or null when it is not inline-text. */
+export function textPreviewKind(mime: string, filename = ""): TextPreviewKind | null {
+  const m = mimeType(mime);
+  const ext = extension(filename);
+
+  if (m === "application/json" || JSON_EXTS.has(ext)) return "json";
+  if (m === "text/markdown" || m === "text/x-markdown" || MARKDOWN_EXTS.has(ext)) {
+    return "markdown";
+  }
+  if (
+    m.startsWith("text/") ||
+    m === "application/yaml" ||
+    m === "application/x-yaml" ||
+    m === "application/xml" ||
+    m === "application/toml" ||
+    TEXT_EXTS.has(ext)
+  ) {
+    return "text";
+  }
+  return null;
+}
+
+/** Pretty-print JSON when the body is valid; otherwise leave it raw. */
+export function prettyJSON(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}

--- a/studio/src/lib/textPreview.ts
+++ b/studio/src/lib/textPreview.ts
@@ -16,7 +16,8 @@ function extension(filename: string): string {
 }
 
 function mimeType(mime: string): string {
-  return mime.toLowerCase().split(";")[0].trim();
+  const [type] = mime.toLowerCase().split(";");
+  return (type ?? "").trim();
 }
 
 /** How to render an attachment, or null when it is not inline-text. */

--- a/studio/src/lib/textPreview.ts
+++ b/studio/src/lib/textPreview.ts
@@ -6,7 +6,23 @@ export type TextPreviewKind = "json" | "markdown" | "text";
 
 const JSON_EXTS = new Set(["json", "jsonl", "ndjson"]);
 const MARKDOWN_EXTS = new Set(["md", "mdx", "markdown"]);
-const TEXT_EXTS = new Set(["yml", "yaml", "txt", "csv", "tsv", "toml", "xml", "log"]);
+const TEXT_EXTS = new Set(["yml", "yaml", "txt", "csv", "tsv", "toml", "log"]);
+
+// Keep in lockstep with neutralizeActiveMIME (pkg/backend/model/tool_attachment.go).
+// Those types are stored as application/octet-stream so the attachment
+// route will not serve them as a preview. Matching by extension or the
+// catch-all text/* prefix must not undo that.
+const ACTIVE_MIMES = new Set([
+  "text/html",
+  "application/xhtml+xml",
+  "image/svg+xml",
+  "text/xml",
+  "application/xml",
+  "text/javascript",
+  "application/javascript",
+  "application/x-javascript",
+]);
+const ACTIVE_EXTS = new Set(["html", "htm", "xhtml", "svg", "xml", "js", "mjs", "cjs"]);
 
 function extension(filename: string): string {
   const base = filename.slice(Math.max(filename.lastIndexOf("/"), filename.lastIndexOf("\\")) + 1);
@@ -25,6 +41,8 @@ export function textPreviewKind(mime: string, filename = ""): TextPreviewKind | 
   const m = mimeType(mime);
   const ext = extension(filename);
 
+  if (ACTIVE_MIMES.has(m) || ACTIVE_EXTS.has(ext)) return null;
+
   if (m === "application/json" || JSON_EXTS.has(ext)) return "json";
   if (m === "text/markdown" || m === "text/x-markdown" || MARKDOWN_EXTS.has(ext)) {
     return "markdown";
@@ -33,7 +51,6 @@ export function textPreviewKind(mime: string, filename = ""): TextPreviewKind | 
     m.startsWith("text/") ||
     m === "application/yaml" ||
     m === "application/x-yaml" ||
-    m === "application/xml" ||
     m === "application/toml" ||
     TEXT_EXTS.has(ext)
   ) {


### PR DESCRIPTION
## Summary

Human gates already render inbound `file` fields as media (image / audio / video). Everything else — including the `outline.json` of a planner review — fell through to a **Download** row. The operator could not read the document they were asked to approve.

This PR shows JSON, markdown and other text inline in **What you're reviewing**, with the same fold used for long inbound payloads. Binaries stay a download.

## What changed

- `textPreviewKind()` classifies an attachment from MIME and filename (`.json`, `.md`, `text/*`, yaml/xml/csv…).
- `GateInboundFile` fetches those bodies as text: pretty-printed JSON, markdown prose, or a `<pre>`. Long files start folded.
- Images, audio and video are unchanged.
- Docs (`human-in-the-loop.md`, `attachments.md`) no longer claim the preview is media-only.

## Test plan

- [x] `vitest` — `textPreview.test.ts` + `GateInboundPayload.test.tsx` (JSON inline, markdown headings, long JSON fold, existing image / error cases)
- [ ] Studio: pause a run on a human gate that maps a `.json` or `.md` attachment and confirm the body is readable without downloading
- [ ] Same gate with a `.png` / `.wav` / `.mp4` still uses the media player
- [ ] A `.zip` still offers Download only