### PR TITLE
fix(pipelines): stop leaking review-scope banners when stepping turns

### DIFF
--- a/studio/src/views/PipelineBoard/ReviewScopePanel.test.tsx
+++ b/studio/src/views/PipelineBoard/ReviewScopePanel.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const getReviewScope = vi.hoisted(() => vi.fn());
+
+vi.mock("@/api/runs", () => ({
+  getReviewScope: (...args: unknown[]) => getReviewScope(...args),
+  workspaceFileURL: () => "",
+}));
+
+vi.mock("@/components/Runs/FileDiffDialog", () => ({
+  default: () => null,
+}));
+
+vi.mock("./ImagePreview", () => ({
+  ImagePreviewDialog: () => null,
+}));
+
+import { ReviewScopePanel } from "./ReviewScopePanel";
+
+function client() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function wrap(ui: React.ReactElement, qc: QueryClient) {
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+}
+
+afterEach(() => {
+  cleanup();
+  getReviewScope.mockReset();
+});
+
+describe("ReviewScopePanel", () => {
+  it("renders the unavailable reason instead of a silent empty panel", async () => {
+    getReviewScope.mockResolvedValue({
+      run_id: "run-1",
+      gate_seq: 1,
+      base_ref: "",
+      head_ref: "",
+      available: false,
+      reason: "this run captured no workspace snapshots at all",
+      groups: [],
+      total_files: 0,
+    });
+    render(wrap(<ReviewScopePanel runId="run-1" pauseKey="k1" />, client()));
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toContain(
+        "this run captured no workspace snapshots at all",
+      );
+    });
+  });
+
+  it("does not reuse a cached scope when pauseKey changes on the same run", async () => {
+    getReviewScope
+      .mockResolvedValueOnce({
+        run_id: "run-1",
+        gate_seq: 1,
+        base_ref: "",
+        head_ref: "",
+        available: true,
+        groups: [],
+        total_files: 0,
+      })
+      .mockResolvedValueOnce({
+        run_id: "run-1",
+        gate_seq: 2,
+        base_ref: "",
+        head_ref: "",
+        available: true,
+        groups: [],
+        total_files: 0,
+      });
+    const qc = client();
+    const view = render(wrap(<ReviewScopePanel runId="run-1" pauseKey="gate-1" />, qc));
+    await waitFor(() => {
+      expect(screen.getByText(/Nothing changed in the workspace/)).toBeTruthy();
+    });
+    expect(getReviewScope).toHaveBeenCalledTimes(1);
+
+    view.rerender(wrap(<ReviewScopePanel runId="run-1" pauseKey="gate-1" />, qc));
+    expect(getReviewScope).toHaveBeenCalledTimes(1);
+
+    view.rerender(wrap(<ReviewScopePanel runId="run-1" pauseKey="gate-2" />, qc));
+    await waitFor(() => {
+      expect(getReviewScope).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/studio/src/views/PipelineBoard/SequentialReviews.test.tsx
+++ b/studio/src/views/PipelineBoard/SequentialReviews.test.tsx
@@ -231,20 +231,33 @@ describe("SequentialReviews", () => {
     // Two siblings used to share reviewKey. React's remaining-children
     // map keeps only the last child per key, so Next unmounted the form
     // and leaked every previous ReviewScopePanel.
+    const card = cardWithReviews(3);
+    const first = card.pending_reviews?.[0];
+    const second = card.pending_reviews?.[1];
+    if (!first || !second) throw new Error("test requires three pending reviews");
     render(
       withClient(
-        <SequentialReviews card={cardWithReviews(3)} onResolved={() => {}} />,
+        <SequentialReviews card={card} onResolved={() => {}} />,
       ),
     );
     expect(screen.getAllByTestId("review-scope")).toHaveLength(1);
     expect(screen.getByTestId("review-scope").getAttribute("data-scope-run-id")).toBe(
       "run-0",
     );
+    expect(screen.getByTestId("review-scope").getAttribute("data-pause-key")).toBe(
+      pendingReviewVersionKey(first),
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Next review" }));
     expect(screen.getAllByTestId("review-scope")).toHaveLength(1);
     expect(screen.getByTestId("review-scope").getAttribute("data-scope-run-id")).toBe(
       "run-1",
+    );
+    // pauseKey cache-keys the scope query. The Fragment remounts the
+    // panel, but a remount does not evict react-query's entry — without
+    // a per-turn pauseKey a second gate on the same run_id reuses N-1.
+    expect(screen.getByTestId("review-scope").getAttribute("data-pause-key")).toBe(
+      pendingReviewVersionKey(second),
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Next review" }));
@@ -252,6 +265,9 @@ describe("SequentialReviews", () => {
     expect(screen.getAllByTestId("review-scope")).toHaveLength(1);
     expect(screen.getByTestId("review-scope").getAttribute("data-scope-run-id")).toBe(
       "run-1",
+    );
+    expect(screen.getByTestId("review-scope").getAttribute("data-pause-key")).toBe(
+      pendingReviewVersionKey(second),
     );
     expect(screen.getByTestId("human-prompt").getAttribute("data-run-id")).toBe("run-1");
   });

--- a/studio/src/views/PipelineBoard/SequentialReviews.test.tsx
+++ b/studio/src/views/PipelineBoard/SequentialReviews.test.tsx
@@ -57,6 +57,19 @@ vi.mock("@/components/Runs/conversation/HumanPromptForm", () => ({
   ),
 }));
 
+// Distinct from the form mock so the stepper test can count leftover
+// panels. data-scope-run-id (not data-run-id) keeps the static-markup
+// assertions on the form from matching this stand-in.
+vi.mock("./ReviewScopePanel", () => ({
+  ReviewScopePanel: (props: { runId: string; pauseKey?: string }) => (
+    <div
+      data-testid="review-scope"
+      data-scope-run-id={props.runId}
+      data-pause-key={props.pauseKey ?? ""}
+    />
+  ),
+}));
+
 import {
   clampReviewIndex,
   pendingReviewVersionKey,
@@ -212,5 +225,34 @@ describe("SequentialReviews", () => {
       ),
     );
     expect(html).toBe("");
+  });
+
+  it("replaces the review-scope panel when stepping to another turn", () => {
+    // Two siblings used to share reviewKey. React's remaining-children
+    // map keeps only the last child per key, so Next unmounted the form
+    // and leaked every previous ReviewScopePanel.
+    render(
+      withClient(
+        <SequentialReviews card={cardWithReviews(3)} onResolved={() => {}} />,
+      ),
+    );
+    expect(screen.getAllByTestId("review-scope")).toHaveLength(1);
+    expect(screen.getByTestId("review-scope").getAttribute("data-scope-run-id")).toBe(
+      "run-0",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Next review" }));
+    expect(screen.getAllByTestId("review-scope")).toHaveLength(1);
+    expect(screen.getByTestId("review-scope").getAttribute("data-scope-run-id")).toBe(
+      "run-1",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Next review" }));
+    fireEvent.click(screen.getByRole("button", { name: "Previous review" }));
+    expect(screen.getAllByTestId("review-scope")).toHaveLength(1);
+    expect(screen.getByTestId("review-scope").getAttribute("data-scope-run-id")).toBe(
+      "run-1",
+    );
+    expect(screen.getByTestId("human-prompt").getAttribute("data-run-id")).toBe("run-1");
   });
 });

--- a/studio/src/views/PipelineBoard/SequentialReviews.tsx
+++ b/studio/src/views/PipelineBoard/SequentialReviews.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { Fragment, useMemo, useState } from "react";
 import { Link } from "wouter";
 
 import type { PipelineBoardCard } from "@/api/pipelineBoards";
@@ -118,36 +118,36 @@ export function SequentialReviews({ card, onResolved }: Props) {
         </div>
       )}
 
-      {review.run_id && (
-        // Keyed AND cache-keyed on reviewKey, like the answer form below:
-        // a run that reaches a second gate keeps the same run_id, so
-        // without both the panel is reconciled in place and keeps serving
-        // the previous gate's file list — the operator would approve
-        // gate N while looking at gate N-1.
-        <ReviewScopePanel
-          key={reviewKey}
-          runId={review.run_id}
-          pauseKey={reviewKey}
-          live
-        />
-      )}
+      {/* One key for the pair. Sibling keys must be unique: React's
+          remaining-children map keeps only the last child per key, so a
+          shared reviewKey leaked every previous ReviewScopePanel when
+          stepping turns. pauseKey still cache-keys the scope query — a
+          second gate on the same run_id would otherwise reuse gate N-1. */}
+      <Fragment key={reviewKey}>
+        {review.run_id && (
+          <ReviewScopePanel
+            runId={review.run_id}
+            pauseKey={reviewKey}
+            live
+          />
+        )}
 
-      {review.run_id && review.node_id ? (
-        <HumanPromptForm
-          key={reviewKey}
-          runId={review.run_id}
-          nodeId={review.node_id}
-          questions={review.questions ?? {}}
-          instructions={review.instructions}
-          sourceOverride={null}
-          onResumed={handleResolved}
-        />
-      ) : (
-        <InlineBanner tone="warning" layout="inline">
-          This pause has no node identifier, so it cannot be answered inline. Open the run
-          console to inspect it.
-        </InlineBanner>
-      )}
+        {review.run_id && review.node_id ? (
+          <HumanPromptForm
+            runId={review.run_id}
+            nodeId={review.node_id}
+            questions={review.questions ?? {}}
+            instructions={review.instructions}
+            sourceOverride={null}
+            onResumed={handleResolved}
+          />
+        ) : (
+          <InlineBanner tone="warning" layout="inline">
+            This pause has no node identifier, so it cannot be answered inline. Open the run
+            console to inspect it.
+          </InlineBanner>
+        )}
+      </Fragment>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- On the Pipelines card drawer, stepping Prev/Next through pending human reviews stacked another `No file diff for this review: this run captured no workspace snapshots at all` banner each time.
- Cause: `ReviewScopePanel` and `HumanPromptForm` were siblings with the **same** React `key`. React's remaining-children map keeps only the last child per key, so the form remounted and every previous scope panel leaked.
- Fix: key the pair as one `Fragment` so both remount together. `pauseKey` still cache-keys the scope query so a second gate on the same `run_id` cannot reuse gate N-1.
- Regression test: Next / Prev leaves exactly one review-scope panel mounted.

## Validation

- `pnpm exec vitest run src/views/PipelineBoard/SequentialReviews.test.tsx` — 7 passed
- Reproduced on the shorts Pipelines board (Ulysse, 52 pending reviews): each Next added a real DOM `role="status"` banner before the fix.