### PR TITLE
feat(studio): open image, video and audio in the same preview dialog

### DIFF
--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -108,8 +108,9 @@ in the edge's `with {}`:
 
 The gate's inbound payload renderer previews any value carrying an
 `attachment` name plus one corroborating field. Images, audio and video
-play inline; JSON, markdown and other text (`.txt`, `.csv`, `.yaml`,
-`.log`, …) are shown in the gate (long bodies start folded). `.xml`,
+open a preview dialog from a clickable tile; JSON, markdown and other
+text (`.txt`, `.csv`, `.yaml`, `.log`, …) are shown in the gate (long
+bodies start folded). `.xml`,
 `.html`, `.svg` and `.js` stay a download: `neutralizeActiveMIME`
 downgrades them so the attachment route cannot serve executable bytes
 inline, and the studio preview classifier matches that set. A zip or

--- a/studio/src/components/Runs/conversation/GateInboundFile.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundFile.tsx
@@ -1,8 +1,11 @@
-import { DownloadIcon, FileIcon } from "@radix-ui/react-icons";
+import { DownloadIcon, FileIcon, SpeakerLoudIcon } from "@radix-ui/react-icons";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { attachmentURL, fetchAttachment } from "@/api/runs";
-import { ImagePreviewDialog } from "@/views/PipelineBoard/ImagePreview";
+import {
+  MediaPreviewDialog,
+  type MediaPreviewKind,
+} from "@/views/PipelineBoard/ImagePreview";
 import { CopyButton, Spinner } from "@/components/ui";
 import { errorMessage } from "@/lib/errorHints";
 import { formatBytes } from "@/lib/format";
@@ -37,8 +40,9 @@ interface Props {
  * before — never a broken image.
  *
  * Text, markdown and JSON are shown inline (same fold as the inbound
- * payload renderer). Images, audio and video keep their media players.
- * Anything else stays a download — a zip at a gate is not a preview.
+ * payload renderer). Images, audio and video open a preview dialog —
+ * the same popup as produced-elements media. Anything else stays a
+ * download — a zip at a gate is not a preview.
  */
 export default function GateInboundFile({ runId, file }: Props) {
   const label = file.filename || file.attachment || file.path || "file";
@@ -48,9 +52,10 @@ export default function GateInboundFile({ runId, file }: Props) {
     label,
     file.mime,
   );
-  const [zoomed, setZoomed] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
   const mime = contentType || file.mime || "";
   const kind = classifyAttachmentPreview(contentType, file.mime, label);
+  const mediaKind = mediaPreviewKind(mime);
 
   const meta = (
     <span className="text-micro text-fg-subtle">
@@ -119,23 +124,24 @@ export default function GateInboundFile({ runId, file }: Props) {
     );
   }
 
-  if (blobURL && mime.startsWith("image/")) {
+  if (blobURL && mediaKind) {
     return (
       <div className="space-y-1">
         <button
           type="button"
-          onClick={() => setZoomed(true)}
-          className="block max-w-full rounded border border-border-subtle bg-surface-0 p-1 hover:border-border-strong"
+          onClick={() => setPreviewOpen(true)}
+          className="block max-w-full rounded border border-border-subtle bg-surface-0 p-1 text-left hover:border-border-strong"
           title={`Open ${label}`}
         >
-          <img src={blobURL} alt={label} className="max-h-64 max-w-full object-contain" />
+          <MediaThumb kind={mediaKind} src={blobURL} label={label} />
         </button>
         {meta}
-        {zoomed && (
-          <ImagePreviewDialog
+        {previewOpen && (
+          <MediaPreviewDialog
+            kind={mediaKind}
             open
             onOpenChange={(open) => {
-              if (!open) setZoomed(false);
+              if (!open) setPreviewOpen(false);
             }}
             src={blobURL}
             alt={label}
@@ -148,34 +154,54 @@ export default function GateInboundFile({ runId, file }: Props) {
     );
   }
 
-  if (blobURL && mime.startsWith("audio/")) {
-    return (
-      <div className="space-y-1">
-        <audio controls src={blobURL} className="w-full">
-          Your browser cannot play this audio file.
-        </audio>
-        {meta}
-      </div>
-    );
-  }
-
-  if (blobURL && mime.startsWith("video/")) {
-    return (
-      <div className="space-y-1">
-        <video controls src={blobURL} className="max-h-64 max-w-full rounded">
-          Your browser cannot play this video file.
-        </video>
-        {meta}
-      </div>
-    );
-  }
-
   return (
     <div className="flex flex-wrap items-center gap-2">
       <FileIcon className="shrink-0 text-fg-subtle" />
       {meta}
       {download}
     </div>
+  );
+}
+
+function mediaPreviewKind(mime: string): MediaPreviewKind | null {
+  if (mime.startsWith("image/")) return "image";
+  if (mime.startsWith("video/")) return "video";
+  if (mime.startsWith("audio/")) return "audio";
+  return null;
+}
+
+function MediaThumb({
+  kind,
+  src,
+  label,
+}: {
+  kind: MediaPreviewKind;
+  src: string;
+  label: string;
+}) {
+  if (kind === "image") {
+    return <img src={src} alt={label} className="max-h-64 max-w-full object-contain" />;
+  }
+  if (kind === "video") {
+    return (
+      <span className="relative block">
+        <video
+          src={src}
+          muted
+          preload="metadata"
+          className="pointer-events-none max-h-32 max-w-full rounded"
+        />
+        <span className="absolute inset-x-0 bottom-0 bg-surface-0/80 px-1.5 py-0.5 text-micro text-fg-default">
+          Open preview
+        </span>
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 px-2 py-1.5 text-micro text-fg-default">
+      <SpeakerLoudIcon className="shrink-0" />
+      Open preview
+    </span>
   );
 }
 

--- a/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
+++ b/studio/src/components/Runs/conversation/GateInboundPayload.test.tsx
@@ -174,6 +174,68 @@ describe("GateInboundPayload", () => {
     vi.unstubAllGlobals();
   });
 
+  it("opens a video attachment in the media preview dialog", async () => {
+    fetchAttachment.mockResolvedValue({
+      blob: new Blob(["fake-mp4"], { type: "video/mp4" }),
+      contentType: "video/mp4",
+    });
+    const createObjectURL = vi.fn(() => "blob:clip");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", { ...URL, createObjectURL, revokeObjectURL });
+
+    render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{
+          clip_file: {
+            attachment: "clip-file-abcd",
+            filename: "shot.mp4",
+            mime: "video/mp4",
+            size: 4096,
+          },
+        }}
+        inputFields={[{ name: "clip_file", type: "file" }]}
+      />,
+    );
+
+    const open = await screen.findByRole("button", { name: /open preview/i });
+    expect(document.querySelector("video[controls]")).toBeNull();
+    fireEvent.click(open);
+    expect(document.querySelector("dialog video[controls], video[controls]")).toBeTruthy();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("opens an audio attachment in the media preview dialog", async () => {
+    fetchAttachment.mockResolvedValue({
+      blob: new Blob(["fake-wav"], { type: "audio/wav" }),
+      contentType: "audio/wav",
+    });
+    const createObjectURL = vi.fn(() => "blob:track");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", { ...URL, createObjectURL, revokeObjectURL });
+
+    render(
+      <GateInboundPayload
+        runId="run-1"
+        questions={{
+          bed_file: {
+            attachment: "bed-file-abcd",
+            filename: "sea.wav",
+            mime: "audio/wav",
+            size: 2048,
+          },
+        }}
+        inputFields={[{ name: "bed_file", type: "file" }]}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /open preview/i }));
+    expect(document.querySelector("audio[controls]")).toBeTruthy();
+
+    vi.unstubAllGlobals();
+  });
+
   it("previews a JSON attachment instead of offering only a download", async () => {
     fetchAttachment.mockResolvedValue({
       blob: new Blob(['{"subject":"Ulysse","chapters":[1,2]}'], { type: "application/json" }),

--- a/studio/src/views/PipelineBoard/ArtifactFilePreviewDialog.test.tsx
+++ b/studio/src/views/PipelineBoard/ArtifactFilePreviewDialog.test.tsx
@@ -5,6 +5,13 @@ import type { PreviewState } from "@/components/Runs/usePreview";
 
 vi.mock("./ImagePreview", () => ({
   ImagePreviewDialog: ({ alt }: { alt: string }) => <img alt={alt} />,
+  MediaPreviewDialog: ({
+    alt,
+    kind,
+  }: {
+    alt: string;
+    kind?: string;
+  }) => (kind === "image" || !kind ? <img alt={alt} /> : <div data-kind={kind}>{alt}</div>),
 }));
 
 import {

--- a/studio/src/views/PipelineBoard/ArtifactFilePreviewDialog.tsx
+++ b/studio/src/views/PipelineBoard/ArtifactFilePreviewDialog.tsx
@@ -6,7 +6,7 @@ import { Dialog, Spinner } from "@/components/ui";
 import { formatBytes } from "@/lib/format";
 
 import type { ProducedFileKind } from "./fileKind";
-import { ImagePreviewDialog } from "./ImagePreview";
+import { MediaPreviewDialog, type MediaPreviewKind } from "./ImagePreview";
 
 interface Props {
   preview: PreviewState;
@@ -33,9 +33,11 @@ export function ArtifactFilePreviewDialog({
     </span>
   );
 
-  if (isImagePreview(preview, kind) && preview.blobURL) {
+  const mediaKind = mediaKindOf(preview, kind);
+  if (mediaKind && preview.blobURL) {
     return (
-      <ImagePreviewDialog
+      <MediaPreviewDialog
+        kind={mediaKind}
         open
         onOpenChange={(open) => {
           if (!open) onClose();
@@ -73,10 +75,16 @@ export function ArtifactFilePreviewDialog({
   );
 }
 
-function isImagePreview(preview: PreviewState, kind: ProducedFileKind): boolean {
-  if (preview.loading || preview.error || !preview.blobURL) return false;
-  if (preview.textBody !== null) return false;
-  return preview.contentType.startsWith("image/") || kind === "image";
+function mediaKindOf(
+  preview: PreviewState,
+  kind: ProducedFileKind,
+): MediaPreviewKind | null {
+  if (preview.loading || preview.error || !preview.blobURL) return null;
+  if (preview.textBody !== null) return null;
+  if (preview.contentType.startsWith("image/") || kind === "image") return "image";
+  if (preview.contentType.startsWith("audio/") || kind === "audio") return "audio";
+  if (preview.contentType.startsWith("video/") || kind === "video") return "video";
+  return null;
 }
 
 // Content-Type wins over the declared/extension kind. The kind remains a

--- a/studio/src/views/PipelineBoard/ArtifactFilePreviewDialog.tsx
+++ b/studio/src/views/PipelineBoard/ArtifactFilePreviewDialog.tsx
@@ -78,13 +78,13 @@ export function ArtifactFilePreviewDialog({
 function mediaKindOf(
   preview: PreviewState,
   kind: ProducedFileKind,
-): MediaPreviewKind | null {
-  if (preview.loading || preview.error || !preview.blobURL) return null;
-  if (preview.textBody !== null) return null;
+): MediaPreviewKind | undefined {
+  if (preview.loading || preview.error || !preview.blobURL) return undefined;
+  if (preview.textBody !== null) return undefined;
   if (preview.contentType.startsWith("image/") || kind === "image") return "image";
   if (preview.contentType.startsWith("audio/") || kind === "audio") return "audio";
   if (preview.contentType.startsWith("video/") || kind === "video") return "video";
-  return null;
+  return undefined;
 }
 
 // Content-Type wins over the declared/extension kind. The kind remains a

--- a/studio/src/views/PipelineBoard/ImagePreview.tsx
+++ b/studio/src/views/PipelineBoard/ImagePreview.tsx
@@ -7,6 +7,135 @@ const ZOOM_MIN = 0.5;
 const ZOOM_MAX = 5;
 const ZOOM_STEP = 0.25;
 
+export type MediaPreviewKind = "image" | "video" | "audio";
+
+// MediaPreviewDialog is the /pipelines popup for every media attachment:
+// image (zoom + pan), video, or audio. ImagePreviewDialog keeps the
+// image-only call sites unchanged.
+export function MediaPreviewDialog({
+  open,
+  onOpenChange,
+  src,
+  alt,
+  title,
+  description,
+  downloadHref,
+  footerExtra,
+  kind = "image",
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  src: string;
+  alt: string;
+  title?: ReactNode;
+  description?: ReactNode;
+  downloadHref?: string;
+  footerExtra?: ReactNode;
+  kind?: MediaPreviewKind;
+}) {
+  if (kind !== "image") {
+    return (
+      <PlaybackPreviewDialog
+        key={src}
+        open={open}
+        onOpenChange={onOpenChange}
+        src={src}
+        title={title}
+        description={description}
+        downloadHref={downloadHref}
+        footerExtra={footerExtra}
+        kind={kind}
+      />
+    );
+  }
+  return (
+    <ImagePreviewDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      src={src}
+      alt={alt}
+      title={title}
+      description={description}
+      downloadHref={downloadHref}
+      footerExtra={footerExtra}
+    />
+  );
+}
+
+function PlaybackPreviewDialog({
+  open,
+  onOpenChange,
+  src,
+  title,
+  description,
+  downloadHref,
+  footerExtra,
+  kind,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  src: string;
+  title?: ReactNode;
+  description?: ReactNode;
+  downloadHref?: string;
+  footerExtra?: ReactNode;
+  kind: Exclude<MediaPreviewKind, "image">;
+}) {
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}
+      widthClass={kind === "video" ? "max-w-5xl" : "max-w-3xl"}
+      title={title}
+      description={description}
+      footer={
+        <div className="flex w-full flex-wrap items-center justify-end gap-2">
+          {footerExtra}
+          {downloadHref && (
+            <a
+              href={downloadHref}
+              download
+              className="inline-flex items-center gap-1 rounded-md border border-border-default px-2.5 py-1 text-xs font-medium text-fg-default hover:bg-surface-2"
+            >
+              <DownloadIcon /> Download
+            </a>
+          )}
+        </div>
+      }
+    >
+      {loadError ? (
+        <div className="py-6 text-center text-xs text-danger-fg">{loadError}</div>
+      ) : kind === "video" ? (
+        <div className="flex items-center justify-center rounded-md bg-surface-0 p-3">
+          <video
+            controls
+            autoPlay
+            src={src}
+            className="max-h-[min(70vh,720px)] max-w-full"
+            onError={() => setLoadError("Could not load this video file for playback.")}
+          >
+            Your browser cannot play this video file.
+          </video>
+        </div>
+      ) : (
+        <div className="flex items-center justify-center rounded-md bg-surface-0 p-6">
+          <audio
+            controls
+            autoPlay
+            src={src}
+            className="w-full"
+            onError={() => setLoadError("Could not load this audio file for playback.")}
+          >
+            Your browser cannot play this audio file.
+          </audio>
+        </div>
+      )}
+    </Dialog>
+  );
+}
+
 // ImagePreviewDialog shows a full-viewport-safe image viewer with zoom
 // (+/−, wheel, double-click) and pan-by-drag when zoomed. Used by ticket
 // input thumbnails and produced-elements previews on /pipelines only.

--- a/studio/src/views/PipelineBoard/ProducedElements.tsx
+++ b/studio/src/views/PipelineBoard/ProducedElements.tsx
@@ -139,6 +139,7 @@ export function ProducedElements({ runIds, status }: Props) {
   // content type is generic (older stores serving application/octet-stream).
   const [previewRunId, setPreviewRunId] = useState("");
   const [previewKind, setPreviewKind] = useState<ProducedFileKind>("other");
+  const playableKind = preview ? mediaKindOf(preview, previewKind) : undefined;
   const handlePreview = (item: ProducedItem) => {
     setPreviewRunId(item.runId);
     setPreviewKind(item.kind);
@@ -241,9 +242,9 @@ export function ProducedElements({ runIds, status }: Props) {
         </Suspense>
       )}
 
-      {preview && isPlayableMedia(preview, previewKind) && preview.blobURL ? (
+      {preview && playableKind && preview.blobURL ? (
         <MediaPreviewDialog
-          kind={mediaKindOf(preview, previewKind)}
+          kind={playableKind}
           open
           onOpenChange={(open) => {
             if (!open) closePreview();
@@ -288,20 +289,16 @@ export function ProducedElements({ runIds, status }: Props) {
   );
 }
 
-function isPlayableMedia(preview: PreviewState, kind: ProducedFileKind): boolean {
-  return mediaKindOf(preview, kind) !== null && !!preview.blobURL;
-}
-
 function mediaKindOf(
   preview: PreviewState,
   kind: ProducedFileKind,
-): MediaPreviewKind | null {
-  if (preview.loading || preview.error || !preview.blobURL) return null;
-  if (preview.textBody !== null) return null;
+): MediaPreviewKind | undefined {
+  if (preview.loading || preview.error || !preview.blobURL) return undefined;
+  if (preview.textBody !== null) return undefined;
   if (preview.contentType.startsWith("image/") || kind === "image") return "image";
   if (preview.contentType.startsWith("audio/") || kind === "audio") return "audio";
   if (preview.contentType.startsWith("video/") || kind === "video") return "video";
-  return null;
+  return undefined;
 }
 
 // KIND_ICON maps a produced kind to its row glyph. Media kinds (image/audio/

--- a/studio/src/views/PipelineBoard/ProducedElements.tsx
+++ b/studio/src/views/PipelineBoard/ProducedElements.tsx
@@ -30,7 +30,7 @@ import { usePreview, type PreviewState } from "@/components/Runs/usePreview";
 import { formatBytes, formatRelative } from "@/lib/format";
 
 import { producedKindLabel, type ProducedFileKind } from "./fileKind";
-import { ImagePreviewDialog } from "./ImagePreview";
+import { MediaPreviewDialog, type MediaPreviewKind } from "./ImagePreview";
 import {
   aggregateProducedItems,
   type ProducedItem,
@@ -241,8 +241,9 @@ export function ProducedElements({ runIds, status }: Props) {
         </Suspense>
       )}
 
-      {preview && isImagePreview(preview, previewKind) && preview.blobURL ? (
-        <ImagePreviewDialog
+      {preview && isPlayableMedia(preview, previewKind) && preview.blobURL ? (
+        <MediaPreviewDialog
+          kind={mediaKindOf(preview, previewKind)}
           open
           onOpenChange={(open) => {
             if (!open) closePreview();
@@ -287,10 +288,20 @@ export function ProducedElements({ runIds, status }: Props) {
   );
 }
 
-function isImagePreview(preview: PreviewState, kind: ProducedFileKind): boolean {
-  if (preview.loading || preview.error || !preview.blobURL) return false;
-  if (preview.textBody !== null) return false;
-  return preview.contentType.startsWith("image/") || kind === "image";
+function isPlayableMedia(preview: PreviewState, kind: ProducedFileKind): boolean {
+  return mediaKindOf(preview, kind) !== null && !!preview.blobURL;
+}
+
+function mediaKindOf(
+  preview: PreviewState,
+  kind: ProducedFileKind,
+): MediaPreviewKind | null {
+  if (preview.loading || preview.error || !preview.blobURL) return null;
+  if (preview.textBody !== null) return null;
+  if (preview.contentType.startsWith("image/") || kind === "image") return "image";
+  if (preview.contentType.startsWith("audio/") || kind === "audio") return "audio";
+  if (preview.contentType.startsWith("video/") || kind === "video") return "video";
+  return null;
 }
 
 // KIND_ICON maps a produced kind to its row glyph. Media kinds (image/audio/

--- a/studio/src/views/PipelineBoard/ReviewScopePanel.tsx
+++ b/studio/src/views/PipelineBoard/ReviewScopePanel.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ChevronRightIcon, DownloadIcon } from "@radix-ui/react-icons";
+import { ChevronRightIcon } from "@radix-ui/react-icons";
 
 import { getReviewScope, workspaceFileURL, type RunFile } from "@/api/runs";
 import FileDiffDialog from "@/components/Runs/FileDiffDialog";
@@ -11,7 +11,7 @@ import {
   producedKindLabel,
   type ProducedFileKind,
 } from "./fileKind";
-import { ImagePreviewDialog } from "./ImagePreview";
+import { MediaPreviewDialog, type MediaPreviewKind } from "./ImagePreview";
 
 const POLL_INTERVAL_MS = 5000;
 
@@ -60,7 +60,8 @@ function isMediaKind(kind: ProducedFileKind): boolean {
  *
  * The list itself sits in a closed-by-default accordion: a media pipeline can
  * produce dozens of files and the form below is the action the operator needs
- * first. Opening a row plays media (audio/video/image) or opens a text diff.
+ * first. Opening a row opens the media preview dialog (audio/video/image)
+ * or a text diff.
  */
 export function ReviewScopePanel({ runId, live, pauseKey }: Props) {
   const [diffFile, setDiffFile] = useState<RunFile | null>(null);
@@ -283,7 +284,6 @@ function WorkspaceMediaDialog({
     () => workspaceFileURL(runId, file.path, { gate, download: true }),
     [runId, file.path, gate],
   );
-  const [loadError, setLoadError] = useState<string | null>(null);
 
   const description = (
     <span>
@@ -292,9 +292,10 @@ function WorkspaceMediaDialog({
     </span>
   );
 
-  if (kind === "image") {
+  if (isMediaKind(kind)) {
     return (
-      <ImagePreviewDialog
+      <MediaPreviewDialog
+        kind={kind as MediaPreviewKind}
         open
         onOpenChange={(open) => {
           if (!open) onClose();
@@ -317,51 +318,10 @@ function WorkspaceMediaDialog({
       widthClass="max-w-3xl"
       title={<span className="font-mono text-xs">{file.path}</span>}
       description={description}
-      footer={
-        <a
-          href={downloadHref}
-          download
-          className="inline-flex items-center gap-1 rounded-md border border-border-default px-2.5 py-1 text-xs font-medium text-fg-default hover:bg-surface-2"
-        >
-          <DownloadIcon /> Download
-        </a>
-      }
     >
-      {loadError ? (
-        <div className="py-6 text-center text-xs text-danger-fg">{loadError}</div>
-      ) : kind === "audio" ? (
-        <div className="flex items-center justify-center rounded bg-surface-0 p-6">
-          <audio
-            controls
-            autoPlay
-            src={src}
-            className="w-full"
-            onError={() =>
-              setLoadError("Could not load this audio file for playback.")
-            }
-          >
-            Your browser cannot play this audio file.
-          </audio>
-        </div>
-      ) : kind === "video" ? (
-        <div className="flex items-center justify-center rounded bg-surface-0 p-3">
-          <video
-            controls
-            autoPlay
-            src={src}
-            className="max-h-[70vh] max-w-full"
-            onError={() =>
-              setLoadError("Could not load this video file for playback.")
-            }
-          >
-            Your browser cannot play this video file.
-          </video>
-        </div>
-      ) : (
-        <div className="flex h-32 items-center justify-center gap-2 text-xs text-fg-subtle">
-          <Spinner /> Loading…
-        </div>
-      )}
+      <div className="flex h-32 items-center justify-center gap-2 text-xs text-fg-subtle">
+        <Spinner /> Loading…
+      </div>
     </Dialog>
   );
 }


### PR DESCRIPTION
## Why

On `/pipelines`, a human gate that receives a video (a Kling clip, a map proxy) used to play it **inline** in the review form. Images already opened a popup. Audio stayed an inline player too. Reviewing a shot meant a 16-rem player buried in the card.

## What

`MediaPreviewDialog` is the single popup for every media kind:

- **image** — existing zoom/pan viewer
- **video** — large player with controls
- **audio** — player with controls

The inbound file tile (`clip_file`, a keyframe PNG, a wav) is now a click target. It does not play in place. The same dialog is used from the review-scope file list and from Produced elements.

## Test

- Video and audio attachments on a human gate open the dialog (`GateInboundPayload` tests)
- Existing image / PDF / octet-stream preview tests still pass