### PR TITLE
fix(server): resume dispatcher child gates from persisted source

### DIFF
--- a/pkg/server/resume_source.go
+++ b/pkg/server/resume_source.go
@@ -4,7 +4,9 @@ import "fmt"
 
 // resolveResumeSource turns a run's persisted file path (plus any inline
 // source the caller already has) into the (absolute path, source) pair
-// runview.ResumeSpec needs.
+// runview.ResumeSpec needs. persistedSource is the trusted launch snapshot;
+// it is only used when an implicit local resume cannot safely resolve the
+// recorded path.
 //
 // Shared by the operator-initiated resume handler and the retry sweeper so
 // the cloud-mode rule lives in one place: a server pod has no operator
@@ -12,7 +14,7 @@ import "fmt"
 // catalog bundle baked into the image, which the pod can read itself.
 // Duplicating that rule is how the automated path would quietly diverge
 // from the manual one.
-func (s *Server) resolveResumeSource(filePath, source string) (string, string, error) {
+func (s *Server) resolveResumeSource(filePath, source, persistedSource string) (string, string, error) {
 	if filePath == "" && source == "" {
 		return "", "", fmt.Errorf("file_path or source is required (run has no persisted FilePath)")
 	}
@@ -24,6 +26,19 @@ func (s *Server) resolveResumeSource(filePath, source string) (string, string, e
 		}
 	}
 	absPath, err := s.resolveWorkflowPath(filePath, source)
+	// Dispatcher worktrees live under the managed store, outside the
+	// Studio's WorkDir. A child subbot records that absolute path, then the
+	// pipeline board resumes its human gate without sending source. The path
+	// containment check correctly refuses to open the foreign path, but the
+	// run already carries the exact launch source as trusted persisted data.
+	// Materialise that snapshot into the server-owned inline cache instead.
+	// An explicit source always wins; this fallback only repairs implicit
+	// resume of a path the Studio cannot safely resolve.
+	if err != nil && source == "" && persistedSource != "" {
+		if persistedPath, persistedErr := s.resolveWorkflowPath(filePath, persistedSource); persistedErr == nil {
+			return persistedPath, persistedSource, nil
+		}
+	}
 	if err != nil {
 		return "", "", fmt.Errorf("invalid file_path: %w", err)
 	}

--- a/pkg/server/resume_source_test.go
+++ b/pkg/server/resume_source_test.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+func TestResolveResumeSourceFallsBackToPersistedLaunchSource(t *testing.T) {
+	workDir := t.TempDir()
+	storeDir := filepath.Join(t.TempDir(), ".iterion")
+	srv := New(Config{
+		WorkDir:                 workDir,
+		StoreDir:                storeDir,
+		SkipProjectRegistration: true,
+	}, iterlog.New(iterlog.LevelError, os.Stderr))
+
+	outsidePath := filepath.Join(t.TempDir(), "dispatcher", "worktree", "child.bot")
+	persistedSource := "workflow child:\n  entry: done\n"
+
+	if _, err := srv.safePath(outsidePath); err == nil {
+		t.Fatalf("test setup invalid: %q should escape WorkDir", outsidePath)
+	}
+
+	resolvedPath, resolvedSource, err := srv.resolveResumeSource(
+		outsidePath, "", persistedSource,
+	)
+	if err != nil {
+		t.Fatalf("resolveResumeSource() error = %v", err)
+	}
+	if resolvedSource != persistedSource {
+		t.Errorf("resolved source = %q, want persisted launch source", resolvedSource)
+	}
+	if !pathContains(srv.inlineSourceCacheDir(), resolvedPath) {
+		t.Errorf("resolved path = %q, want server-owned inline cache", resolvedPath)
+	}
+	got, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		t.Fatalf("read materialised source: %v", err)
+	}
+	if string(got) != persistedSource {
+		t.Errorf("materialised source = %q, want %q", got, persistedSource)
+	}
+}
+
+func TestResolveResumeSourceExplicitSourceWinsOverPersistedFallback(t *testing.T) {
+	workDir := t.TempDir()
+	storeDir := filepath.Join(t.TempDir(), ".iterion")
+	srv := New(Config{
+		WorkDir:                 workDir,
+		StoreDir:                storeDir,
+		SkipProjectRegistration: true,
+	}, iterlog.New(iterlog.LevelError, os.Stderr))
+
+	outsidePath := filepath.Join(t.TempDir(), "dispatcher", "worktree", "child.bot")
+	explicitSource := "workflow edited:\n  entry: done\n"
+	persistedSource := "workflow original:\n  entry: done\n"
+
+	_, resolvedSource, err := srv.resolveResumeSource(
+		outsidePath, explicitSource, persistedSource,
+	)
+	if err != nil {
+		t.Fatalf("resolveResumeSource() error = %v", err)
+	}
+	if resolvedSource != explicitSource {
+		t.Errorf("resolved source = %q, want explicit source %q", resolvedSource, explicitSource)
+	}
+}

--- a/pkg/server/retry_sweeper.go
+++ b/pkg/server/retry_sweeper.go
@@ -133,7 +133,7 @@ func (s *Server) resumeDueRetry(ctx context.Context, retryStore store.RunRetrySt
 		return
 	}
 
-	filePath, source, err := s.resolveResumeSource(ref.FilePath, "")
+	filePath, source, err := s.resolveResumeSource(ref.FilePath, "", "")
 	if err != nil {
 		// A bot removed from the catalog will never resolve; re-arming
 		// would just re-fail every 15 minutes forever.

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -490,7 +490,7 @@ func (s *Server) handleResumeRun(w http.ResponseWriter, r *http.Request) {
 	}
 	// Shared with the retry sweeper so the automated resume resolves its
 	// source exactly like this one (see resolveResumeSource).
-	absPath, resolvedSource, pathErr := s.resolveResumeSource(filePath, req.Source)
+	absPath, resolvedSource, pathErr := s.resolveResumeSource(filePath, req.Source, runMeta.WorkflowSource)
 	if pathErr != nil {
 		s.httpErrorFor(w, r, http.StatusBadRequest, "%v", pathErr)
 		span.SetStatus(codes.Error, "resume source unresolvable")

--- a/pkg/server/runs_resume_error_test.go
+++ b/pkg/server/runs_resume_error_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/runview"
@@ -176,5 +177,86 @@ workflow resume_hash:
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusAccepted {
 		t.Fatalf("forced status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+}
+
+func TestResumeRun_DispatcherChildOutsideWorkDirUsesPersistedSource(t *testing.T) {
+	t.Setenv("ITERION_RUNS_DETACHED", "0")
+	srv, httpServer := newTestServer(t)
+
+	const source = `
+schema gate_out:
+  approved: bool
+
+human gate:
+  output: gate_out
+  interaction: human
+
+workflow dispatcher_child:
+  entry: gate
+  gate -> done when approved
+  gate -> fail when not approved
+`
+
+	botPath := filepath.Join(srv.cfg.WorkDir, "dispatcher_child.bot")
+	if err := os.WriteFile(botPath, []byte(source), 0o644); err != nil {
+		t.Fatalf("write workflow: %v", err)
+	}
+	const runID = "run-dispatcher-child-outside-workdir"
+	launched, err := srv.runs.Launch(context.Background(), runview.LaunchSpec{
+		RunID:       runID,
+		FilePath:    botPath,
+		ParentRunID: "parent-run",
+	})
+	if err != nil {
+		t.Fatalf("launch child: %v", err)
+	}
+	select {
+	case <-launched.Done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("child did not reach its human gate")
+	}
+
+	// Dispatcher child bots execute from issue worktrees under the managed
+	// store, not beneath the Studio's WorkDir. The pipeline board omits source
+	// when it answers their human gates, so resume must use the launch snapshot
+	// already persisted on the child run.
+	outsidePath := filepath.Join(t.TempDir(), "dispatcher", "worktree", "child.bot")
+	if _, err := srv.safePath(outsidePath); err == nil {
+		t.Fatalf("test setup invalid: %q should escape WorkDir", outsidePath)
+	}
+
+	st, err := store.New(srv.cfg.StoreDir)
+	if err != nil {
+		t.Fatalf("open run store: %v", err)
+	}
+	run, err := st.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if run.Status != store.RunStatusPausedWaitingHuman {
+		t.Fatalf("status = %q, want %q", run.Status, store.RunStatusPausedWaitingHuman)
+	}
+	if run.WorkflowSource == "" {
+		t.Fatal("launch did not persist WorkflowSource")
+	}
+	run.FilePath = outsidePath
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+
+	resp, err := http.Post(
+		httpServer.URL+"/api/runs/"+runID+"/resume",
+		"application/json",
+		bytes.NewBufferString(`{"answers":{"approved":true}}`),
+	)
+	if err != nil {
+		t.Fatalf("POST resume: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		var refusal map[string]any
+		decodeJSONResp(t, resp, &refusal)
+		t.Fatalf("status = %d, want %d; body = %#v", resp.StatusCode, http.StatusAccepted, refusal)
 	}
 }

--- a/pkg/server/runs_resume_error_test.go
+++ b/pkg/server/runs_resume_error_test.go
@@ -213,8 +213,8 @@ workflow dispatcher_child:
 	}
 	select {
 	case <-launched.Done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("child did not reach its human gate")
+	case <-time.After(30 * time.Second):
+		t.Fatal("child did not reach its human gate within 30s")
 	}
 
 	// Dispatcher child bots execute from issue worktrees under the managed

--- a/pkg/server/runs_resume_error_test.go
+++ b/pkg/server/runs_resume_error_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/runview"
@@ -198,25 +197,7 @@ workflow dispatcher_child:
   gate -> fail when not approved
 `
 
-	botPath := filepath.Join(srv.cfg.WorkDir, "dispatcher_child.bot")
-	if err := os.WriteFile(botPath, []byte(source), 0o644); err != nil {
-		t.Fatalf("write workflow: %v", err)
-	}
 	const runID = "run-dispatcher-child-outside-workdir"
-	launched, err := srv.runs.Launch(context.Background(), runview.LaunchSpec{
-		RunID:       runID,
-		FilePath:    botPath,
-		ParentRunID: "parent-run",
-	})
-	if err != nil {
-		t.Fatalf("launch child: %v", err)
-	}
-	select {
-	case <-launched.Done:
-	case <-time.After(30 * time.Second):
-		t.Fatal("child did not reach its human gate within 30s")
-	}
-
 	// Dispatcher child bots execute from issue worktrees under the managed
 	// store, not beneath the Studio's WorkDir. The pipeline board omits source
 	// when it answers their human gates, so resume must use the launch snapshot
@@ -230,19 +211,33 @@ workflow dispatcher_child:
 	if err != nil {
 		t.Fatalf("open run store: %v", err)
 	}
-	run, err := st.LoadRun(context.Background(), runID)
+	ctx := context.Background()
+	if _, err := st.CreateRun(ctx, runID, "dispatcher_child", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	run, err := st.LoadRun(ctx, runID)
 	if err != nil {
 		t.Fatalf("LoadRun: %v", err)
 	}
-	if run.Status != store.RunStatusPausedWaitingHuman {
-		t.Fatalf("status = %q, want %q", run.Status, store.RunStatusPausedWaitingHuman)
-	}
-	if run.WorkflowSource == "" {
-		t.Fatal("launch did not persist WorkflowSource")
+	_, workflowHash, err := runview.CompileWorkflowFromSource(outsidePath, source)
+	if err != nil {
+		t.Fatalf("compile workflow: %v", err)
 	}
 	run.FilePath = outsidePath
-	if err := st.SaveRun(context.Background(), run); err != nil {
+	run.WorkflowHash = workflowHash
+	run.WorkflowSource = source
+	run.ParentRunID = "parent-run"
+	if err := st.SaveRun(ctx, run); err != nil {
 		t.Fatalf("SaveRun: %v", err)
+	}
+	if err := st.PauseRun(ctx, runID, &store.Checkpoint{
+		NodeID:           "gate",
+		Outputs:          map[string]map[string]any{},
+		LoopCounters:     map[string]int{},
+		ArtifactVersions: map[string]int{},
+		Vars:             map[string]any{},
+	}); err != nil {
+		t.Fatalf("PauseRun: %v", err)
 	}
 
 	resp, err := http.Post(


### PR DESCRIPTION
## Summary

- fall back to the trusted workflow source persisted at launch when an implicit resume cannot resolve the recorded local path
- keep explicit resume sources authoritative
- cover both source resolution and the pipeline-board HTTP resume path for a paused dispatcher child

## Problem

Dispatcher child runs can persist a `.bot` path inside an issue worktree under the managed store. That path is outside the Studio workspace. When the pipeline board answers a human gate, it intentionally sends no source, so `POST /api/runs/{id}/resume` rejects the persisted path with HTTP 400: `invalid file_path: path escapes working directory`.

The run already stores the exact launch-time `workflow_source`. This change materializes that trusted snapshot into the server-owned inline-source cache only when an implicit local resume cannot safely resolve the recorded path.

## Tests

- `go test ./pkg/server ./pkg/runview`
- end-to-end server regression: launch a child into a real human pause, replace its path with an out-of-workspace dispatcher path, then resume it through the HTTP endpoint without sending source