### PR TITLE
fix(dispatcher): never mint a sibling run for a live last_run

### DIFF
--- a/docs/adr/014-dispatcher-paused-run-parking.md
+++ b/docs/adr/014-dispatcher-paused-run-parking.md
@@ -113,14 +113,15 @@ asymmetry between the two execution paths.
 The non-obvious trade-off: a parked issue **stays claimed**, and the
 dispatcher stops tracking it. Two accepted costs follow. (a) Across a daemon
 restart the claim is swept (`isStaleLocalMarker` fires once the owning pid
-dies), so the issue is re-dispatched **fresh once** and re-parks at the same
-point — benign, and consistent with the existing crash-recovery model. (b)
-If the operator resumes the run to completion out-of-band, the claim lingers
-until the next restart or a manual release (the dispatcher is no longer
-watching that run). We chose **claim-as-parking** over a new state machine
-because it is correct in-process with no schema/UI churn, and degrades
-gracefully; full out-of-band-resume reconciliation and a distinct
-"waiting for input" surface are the deferred follow-up.
+dies). `in_progress` stays eligible (crash-recovery), but the dispatcher
+**re-parks** a paused `last_run` instead of minting a sibling from entry —
+a planner restarted from `init_film` is not "the same pause". (b)
+If the operator resumes the run to completion out-of-band, the parked
+sweep (`reconcileParked`) files the card; a resume that re-pauses is
+re-parked by `reconcileStrandedPaused`. We chose **claim-as-parking**
+over a new state machine because it is correct in-process with no
+schema/UI churn; the awaiting-input column and the stranded-pause
+sweep closed the original follow-ups.
 
 ## Consequences
 

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -162,6 +162,28 @@ lifecycle: run `finished` → `agent.completed_state`, hard `failed` →
 genuinely still awaits the operator. The cloud board coordinator runs
 the same sweep for cloud-launched cards.
 
+A reboot (new PID) drops the park-claim. `in_progress` stays eligible
+for crash-recovery, but a live `last_run` is **never** replaced by a
+sibling planner from the workflow entry:
+
+| `last_run` status | On the next tick / boot |
+|---|---|
+| `paused_waiting_human` / `paused_operator` | Re-park: `awaiting_input`, same `last_run`, no auto-resume (no answers). |
+| `running` / `queued` | Hold. Do not mint. After orphan promotion the run becomes resumable. |
+| `failed_resumable` / `cancelled` | Resume the **same** run id. |
+| `finished` | Do not relaunch. File the ticket (`completed_state`). |
+| none, or hard `failed`, and the ticket is explicitly eligible | The only legitimate fresh run. |
+
+The stranded-pause sweep (`reconcileStrandedPaused`) also runs while
+the dispatcher is **paused**, so a studio restart with `desired: paused`
+re-parks without dispatching. An out-of-band `iterion resume --force`
+that re-pauses on a later human node is picked up by the same sweep —
+the dispatcher worker already returned when the run first parked, so
+`finishRun` is not in the loop.
+
+To really start over: cancel or finish the old run, or drag a
+hard-failed ticket back to `ready`. A reboot is not a from-scratch.
+
 ### In-progress transition (`agent.running_state`)
 
 After `tracker.Claim` succeeds, the dispatcher transitions the issue
@@ -285,12 +307,13 @@ without requiring an observed retirement transition.
 Directories created by older versions directly under
 `<workspace.root>/<sanitized-issue-id>/` are deliberately not adopted or
 deleted: the old sanitizer was many-to-one, so ownership cannot be proven from
-the name. A resumable run with only such a legacy/unowned workspace is restarted
-fresh in v2 while the old directory is left untouched for operator recovery.
-This loss of resume continuity is an accepted one-time migration cost. To
-reclaim legacy directories, first confirm that no active/resumable run still
-references them, then inspect and move or delete them manually; automatic
-cleanup would risk deleting a different issue's colliding legacy workspace.
+the name. A resumable run with only such a legacy/unowned workspace is **not**
+restarted fresh — that would mint a sibling planner and replay the prefix.
+Dispatch is deferred (visible as a skip) and the old directory is left
+untouched for operator recovery. To reclaim legacy directories, first confirm
+that no active/resumable run still references them, then inspect and move or
+delete them manually; automatic cleanup would risk deleting a different
+issue's colliding legacy workspace.
 The resolver also refuses workspaces whose symlink resolution lands outside the
 configured root.
 

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -424,6 +424,27 @@ re-invoked after the answer:
 This keeps multi-turn interaction attached to the same node rather than
 mistaking the pause for a completed human node.
 
+## Dispatcher and last_run
+
+A run is durable across a studio or dispatcher restart. If the board card
+still points at that run (`issue.last_run`) and the status is live or
+waiting, the dispatcher **does not mint a new run id**.
+
+| `last_run` | Dispatcher action |
+|---|---|
+| `paused_waiting_human` / `paused_operator` | Re-park the card in `awaiting_input`. No auto-resume (no answers). |
+| `running` / `queued` | Hold. Never start a sibling from the workflow entry. |
+| `failed_resumable` / `cancelled` | `Engine.Resume` on the **same** id. |
+| `finished` | Do not relaunch; file the ticket. |
+| none, or hard `failed` + ticket explicitly back in `ready` | Fresh run. |
+
+`iterion resume --force` (or the studio force-resume) continues **this**
+run after a bot edit. If that resume parks again on a later human node,
+the next dispatcher tick re-parks the same card — it does not start the
+workflow over. To throw the work away, cancel or finish the old run first.
+
+See [dispatcher](dispatcher.md#paused-runs--the-awaiting_input-column--parked-sweep).
+
 ## Failure behavior
 
 Most runtime errors use the checkpoint-aware failure path: LLM/delegate errors,

--- a/pkg/dispatcher/commands.go
+++ b/pkg/dispatcher/commands.go
@@ -395,8 +395,23 @@ func (c *Dispatcher) finishRun(ctx context.Context, issueID string, err error) {
 	// ErrRunPaused / ErrRunPausedOperator instead of naking for retry
 	// (pkg/runner/loop.go). The retained claim is reclaimed only by the
 	// stale-claim sweep once THIS daemon's pid dies (isStaleLocalMarker), so
-	// a live dispatcher never re-dispatches a parked issue; after a restart
-	// it degrades to a single fresh re-run that re-parks at the same point.
+	// a live dispatcher never re-dispatches a parked issue. After a
+	// restart the stale-claim sweep drops the claim; dispatch then
+	// re-parks (awaiting-input, same last_run) instead of minting a
+	// fresh run from entry — a planner restarted from init_film is
+	// not "the same pause".
+	if isResumeSourceChanged(err) {
+		// The bot source changed since this run started. Minting a
+		// sibling from entry would replay the prefix (agents, tools,
+		// already-paid artefacts). Park: keep the claim, keep last_run,
+		// do not retry. The operator resumes THIS run with --force or
+		// cancels it before asking for a new one.
+		c.stampLastRun(issueID, r)
+		c.logger.Warn("dispatcher: %s bot source changed (run=%s) — refusing a fresh sibling. Resume with --force from the run console, or cancel this run before a new dispatch.", r.Identifier, r.RunID)
+		c.fireSnapshot()
+		return
+	}
+
 	if errors.Is(err, runtime.ErrRunPaused) || errors.Is(err, runtime.ErrRunPausedOperator) {
 		c.stampLastRun(issueID, r)
 		c.setAwaitingInput(issueID, true)

--- a/pkg/dispatcher/commands_paused_test.go
+++ b/pkg/dispatcher/commands_paused_test.go
@@ -139,3 +139,66 @@ func TestFinishRun_PausedForInputIsParkedNotRetried(t *testing.T) {
 		})
 	}
 }
+
+// TestFinishRun_SourceChangedParksNoSibling: a doomed resume (bot
+// source changed) must not mint a sibling from entry. The ticket stays
+// claimed on the same last_run so the operator can resume --force.
+func TestFinishRun_SourceChangedParksNoSibling(t *testing.T) {
+	const issueID = "fake:source-changed-1"
+	ft := newFakeTracker()
+	ft.add(tracker.Issue{
+		ID: issueID, Identifier: "fake#src",
+		Title: "bot edited", WorkflowState: "in_progress",
+	})
+	if err := ft.Claim(context.Background(), issueID, "test"); err != nil {
+		t.Fatalf("seed claim: %v", err)
+	}
+
+	dir := t.TempDir()
+	wsDir := filepath.Join(dir, "ws")
+	cfg := &Config{
+		Name:     "test",
+		Workflow: filepath.Join(t.TempDir(), "fake.bot"),
+		Tracker:  TrackerConfig{Kind: "fake"},
+		Polling:  PollingConfig{IntervalMS: 50},
+		Agent: AgentConfig{
+			MaxConcurrent: 4, MaxRetryBackoffMS: 1000,
+			RunningState: "in_progress", FailedState: "blocked",
+		},
+		Workspace: WorkspaceConfig{Root: wsDir},
+	}
+	cfg.applyDefaults()
+	ws, err := NewWorkspaces(wsDir)
+	if err != nil {
+		t.Fatalf("NewWorkspaces: %v", err)
+	}
+	c, err := New(Options{
+		Config: cfg, Tracker: ft, Runner: &StubRunner{},
+		Workspaces: ws, Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{}),
+		HostMarker: "test",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c.state.running[issueID] = &runningEntry{
+		IssueID: issueID, Identifier: "fake#src", RunID: "run-src-1",
+		WorkflowState: "in_progress", WorkspacePath: filepath.Join(wsDir, "x"),
+		StartedAt: time.Now(), Attempt: 0, TransitionedFromState: "ready",
+	}
+	c.state.slotsByState["in_progress"] = 1
+
+	c.finishRun(context.Background(), issueID, runtime.ErrWorkflowSourceChanged)
+
+	ft.mu.Lock()
+	_, claimed := ft.claims[issueID]
+	ft.mu.Unlock()
+	if !claimed {
+		t.Error("claim was released — a source-changed ticket would be re-dispatched")
+	}
+	if _, queued := c.state.retries[issueID]; queued {
+		t.Error("a retry was scheduled — next attempt would mint a sibling")
+	}
+	if _, stillRunning := c.state.running[issueID]; stillRunning {
+		t.Error("issue still tracked as running")
+	}
+}

--- a/pkg/dispatcher/loop.go
+++ b/pkg/dispatcher/loop.go
@@ -22,7 +22,8 @@ import (
 //
 // When the dispatcher is paused, the dispatch step is skipped — runs
 // already in flight continue, stall detection still fires, retries
-// still queue. Paused means "no new work", not "stop everything".
+// still queue, and stranded paused last_runs are re-parked. Paused
+// means "no new work", not "stop everything".
 func (c *Dispatcher) tick(ctx context.Context) {
 	cfg := c.cfg.Load()
 	c.state.lastTickAt = time.Now().UTC()
@@ -30,6 +31,9 @@ func (c *Dispatcher) tick(ctx context.Context) {
 	c.reconcileStalled(ctx, cfg)
 	c.refreshRunningStates(ctx)
 	c.reconcileParked(ctx)
+	// Reclaim paused last_runs even while dispatch is suspended: a
+	// reboot with desired=paused must re-park, never mint a sibling.
+	c.reconcileStrandedPaused(ctx)
 
 	if c.paused.Load() {
 		c.fireSnapshot()
@@ -382,6 +386,14 @@ func (c *Dispatcher) dispatch(ctx context.Context, iss tracker.Issue) {
 		return
 	}
 
+	// A studio restart drops the claim that parked a human/operator
+	// pause. in_progress stays eligible, and paused_waiting_human is
+	// not resumable — without this guard we minted a NEW run from
+	// entry and rewrote the planner. Re-park; do not start fresh.
+	if c.reparkClaimedIfLastRunWaiting(iss) {
+		return
+	}
+
 	runID, resumeFromRunID, attempt, ok := c.resolveRunID(ctx, iss)
 	if !ok {
 		return
@@ -662,18 +674,42 @@ func (c *Dispatcher) resolveRunID(ctx context.Context, iss tracker.Issue) (runID
 			// Pre-v2 paths were derived through a many-to-one sanitizer, so
 			// ownership cannot be proven from the directory name. Never run
 			// hooks in a new v2 workspace while Engine.Resume silently restores
-			// a different legacy/missing WorkDir; restart safely instead and
-			// leave the old directory untouched for operator recovery.
-			c.logger.Warn(
-				"dispatcher: %s run %s has no managed v2 workspace ownership — starting fresh; legacy/unowned workspace left untouched",
-				iss.Identifier,
-				resumeFromRunID,
-			)
-			resumeFromRunID = ""
+			// a different legacy/missing WorkDir — and never mint a sibling
+			// from entry either: a live last_run is durable. Defer; leave
+			// the old directory untouched for operator recovery.
+			reason := fmt.Sprintf("run %s has no managed v2 workspace ownership — refusing a fresh sibling", resumeFromRunID)
+			c.logger.Warn("dispatcher: %s: %s; legacy/unowned workspace left untouched", iss.Identifier, reason)
+			c.recordDispatchSkip(iss, reason)
+			c.releaseClaim(ctx, iss.ID, iss.Identifier)
+			return "", "", attempt, false
 		}
 	}
 	if resumeFromRunID != "" {
 		return resumeFromRunID, resumeFromRunID, attempt, true
+	}
+	// About to mint. A live / waiting / still-resumable last_run must
+	// never become a sibling planner from entry — not on reboot, not
+	// because a retry entry dropped PrevRunID, not because the
+	// workspace probe failed open.
+	if prev := c.lastRunID(iss.ID); prev != "" {
+		if status := c.runStatusOnDisk(prev); lastRunForbidsFresh(status) {
+			reason := fmt.Sprintf("last run %s is %s — refusing a fresh sibling", prev, status)
+			if _, already := c.state.dispatchSkips[iss.ID]; !already {
+				c.logger.Warn("dispatcher: %s: %s", iss.Identifier, reason)
+			}
+			c.recordDispatchSkip(iss, reason)
+			if status == store.RunStatusFinished {
+				if target := c.cfg.Load().Agent.CompletedState; target != "" && target != iss.WorkflowState {
+					if err := c.tracker.UpdateState(ctx, iss.ID, target); err != nil {
+						c.logger.Warn("dispatcher: %s last run finished, move to %q: %v", iss.Identifier, target, err)
+					} else {
+						c.logger.Info("dispatcher: %s last run %s already finished — filed as %q, refusing a fresh sibling", iss.Identifier, prev, target)
+					}
+				}
+			}
+			c.releaseClaim(ctx, iss.ID, iss.Identifier)
+			return "", "", attempt, false
+		}
 	}
 	freshID, err := store.GenerateRunID()
 	if err != nil {

--- a/pkg/dispatcher/manager.go
+++ b/pkg/dispatcher/manager.go
@@ -134,14 +134,12 @@ func NewManager(opts ManagerOptions) (*Manager, error) {
 	intent := resolveBootIntent(persisted, m.cfg != nil)
 	switch intent {
 	case DesiredRunning, DesiredPaused:
-		if startErr := m.Start(); startErr != nil {
+		// Pause BEFORE the actor's first tick when restoring a paused
+		// session. Start-then-Pause raced the immediate boot tick and
+		// minted sibling runs for in_progress tickets whose last_run
+		// was still paused_waiting_human.
+		if startErr := m.start(intent == DesiredPaused); startErr != nil {
 			opts.Logger.Warn("manager: auto-start declined: %v", startErr)
-			break
-		}
-		if intent == DesiredPaused {
-			if pauseErr := m.Pause(); pauseErr != nil {
-				opts.Logger.Warn("manager: restore pause after auto-start: %v", pauseErr)
-			}
 		}
 	}
 	return m, nil
@@ -251,6 +249,13 @@ var ErrAlreadyRunning = errors.New("manager: already running")
 // an error and stays in StateError when the start sequence fails (bad
 // workflow, missing tracker creds, port conflict, …).
 func (m *Manager) Start() error {
+	return m.start(false)
+}
+
+// start is Start with an optional already-paused actor. paused=true
+// sets the flag BEFORE the actor loop so the immediate first tick
+// cannot dispatch (or mint a sibling) before Pause() would have run.
+func (m *Manager) start(paused bool) error {
 	m.mu.Lock()
 	if m.cur != nil {
 		m.mu.Unlock()
@@ -302,18 +307,30 @@ func (m *Manager) Start() error {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	if paused {
+		c.paused.Store(true)
+	}
 	c.Start(ctx)
 
 	m.mu.Lock()
 	m.cur = c
 	m.runner = runner
 	m.cancel = cancel
-	m.state = ManagerStateRunning
+	if paused {
+		m.state = ManagerStatePaused
+	} else {
+		m.state = ManagerStateRunning
+	}
 	m.lastErr = nil
 	m.startedAt = time.Now().UTC()
 	m.mu.Unlock()
-	m.persistDesired(DesiredRunning)
-	m.logger.Info("manager: dispatcher started (workflow=%s, tracker=%s)", cfg.Workflow, trk.Name())
+	if paused {
+		m.persistDesired(DesiredPaused)
+		m.logger.Info("manager: dispatcher started paused (workflow=%s, tracker=%s)", cfg.Workflow, trk.Name())
+	} else {
+		m.persistDesired(DesiredRunning)
+		m.logger.Info("manager: dispatcher started (workflow=%s, tracker=%s)", cfg.Workflow, trk.Name())
+	}
 	return nil
 }
 

--- a/pkg/dispatcher/manager_autostart_test.go
+++ b/pkg/dispatcher/manager_autostart_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 )
 
 // seedManagerFixture writes the minimum on-disk state for NewManager to
@@ -129,6 +132,51 @@ func TestNewManager_RestoresPersistedPausedState(t *testing.T) {
 	defer m.Stop()
 	if got := m.Status().State; got != ManagerStatePaused {
 		t.Errorf("state = %q, want paused (persisted paused)", got)
+	}
+	if cur := m.Current(); cur == nil || !cur.IsPaused() {
+		t.Error("actor must be started already-paused so the first tick cannot dispatch")
+	}
+}
+
+// TestNewManager_RestoresPausedWithoutDispatching is the boot race
+// behind issue 426: Start-then-Pause let the immediate first tick
+// mint a sibling for an eligible ticket. Restoring desired=paused
+// must set the flag before that tick.
+func TestNewManager_RestoresPausedWithoutDispatching(t *testing.T) {
+	t.Setenv("ITERION_DISPATCHER_AUTOSTART", "")
+	dir := seedManagerFixture(t)
+	ns := newTestNativeStore(t, dir)
+	iss, err := ns.Create(native.Issue{Title: "do not launch", State: native.StateReady})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := saveDesiredState(runtimeStatePath(dir), DesiredPaused); err != nil {
+		t.Fatalf("seed runtime state: %v", err)
+	}
+	m, err := NewManager(ManagerOptions{
+		StoreDir:    dir,
+		NativeStore: ns,
+		Logger:      newTestLogger(),
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer m.Stop()
+	if got := m.Status().State; got != ManagerStatePaused {
+		t.Fatalf("state = %q, want paused", got)
+	}
+	// The actor's first tick is immediate and asynchronous. Give it
+	// time to run; a raced Start-then-Pause would have claimed this.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		got, gerr := ns.Get(iss.ID)
+		if gerr != nil {
+			t.Fatalf("Get: %v", gerr)
+		}
+		if got.State != native.StateReady || got.Claim != "" {
+			t.Fatalf("paused boot dispatched: state=%q claim=%q", got.State, got.Claim)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }
 

--- a/pkg/dispatcher/native/adapter.go
+++ b/pkg/dispatcher/native/adapter.go
@@ -115,6 +115,46 @@ func (a *Adapter) Release(ctx context.Context, id, marker string) error {
 	return a.store.Release(id, marker)
 }
 
+// ListForRepark returns cards this dispatcher may re-park after a
+// reboot or an out-of-band resume: any eligible state (plus
+// in_progress, the crash-recovery lane) that already has a last_run
+// and is unclaimed or claimed by marker. Cards already in
+// awaiting_input stay with ListAwaitingInput / reconcileParked.
+// Consumed by reconcileStrandedPaused via optional-interface assertion.
+func (a *Adapter) ListForRepark(marker string) ([]tracker.Issue, error) {
+	b := a.store.Board()
+	seen := make(map[string]bool, len(b.States))
+	states := make([]string, 0, len(b.States))
+	for _, s := range b.States {
+		if !s.Eligible && s.Name != StateInProgress {
+			continue
+		}
+		if s.Name == StateAwaitingInput || seen[s.Name] {
+			continue
+		}
+		seen[s.Name] = true
+		states = append(states, s.Name)
+	}
+	if len(states) == 0 {
+		return nil, nil
+	}
+	issues, err := a.store.List(ListFilter{States: states})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]tracker.Issue, 0, len(issues))
+	for _, iss := range issues {
+		if iss.LastRunID == "" {
+			continue
+		}
+		if iss.Claim != "" && iss.Claim != marker {
+			continue
+		}
+		out = append(out, toTrackerIssue(iss))
+	}
+	return out, nil
+}
+
 // ListAwaitingInput returns the cards parked in the awaiting-input
 // column that this dispatcher may reconcile: unclaimed (post-restart,
 // after the stale-claim sweep) or claimed by the given marker. Cards

--- a/pkg/dispatcher/native/adapter_test.go
+++ b/pkg/dispatcher/native/adapter_test.go
@@ -153,6 +153,52 @@ func TestAdapterComment(t *testing.T) {
 	}
 }
 
+func TestListForRepark(t *testing.T) {
+	a, s := newAdapter(t)
+	ready, _ := s.Create(native.Issue{Title: "ready", State: native.StateReady})
+	if err := s.SetLastRun(ready.ID, "run-ready", ""); err != nil {
+		t.Fatalf("SetLastRun ready: %v", err)
+	}
+	progress, _ := s.Create(native.Issue{Title: "wip", State: native.StateInProgress})
+	if err := s.SetLastRun(progress.ID, "run-wip", ""); err != nil {
+		t.Fatalf("SetLastRun progress: %v", err)
+	}
+	parked, _ := s.Create(native.Issue{Title: "parked", State: native.StateAwaitingInput})
+	if err := s.SetLastRun(parked.ID, "run-parked", ""); err != nil {
+		t.Fatalf("SetLastRun parked: %v", err)
+	}
+	theirs, _ := s.Create(native.Issue{Title: "theirs", State: native.StateInProgress})
+	if err := s.SetLastRun(theirs.ID, "run-theirs", ""); err != nil {
+		t.Fatalf("SetLastRun theirs: %v", err)
+	}
+	if err := s.Claim(theirs.ID, "other-host"); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	fresh, _ := s.Create(native.Issue{Title: "fresh", State: native.StateReady})
+	_, _ = s.Create(native.Issue{Title: "inbox", State: native.StateInbox})
+
+	got, err := a.ListForRepark("me")
+	if err != nil {
+		t.Fatalf("ListForRepark: %v", err)
+	}
+	ids := map[string]bool{}
+	for _, iss := range got {
+		ids[iss.ID] = true
+	}
+	if !ids[ready.ID] || !ids[progress.ID] {
+		t.Fatalf("want ready + in_progress with last_run, got %+v", ids)
+	}
+	if ids[parked.ID] {
+		t.Error("awaiting_input belongs to ListAwaitingInput, not ListForRepark")
+	}
+	if ids[theirs.ID] {
+		t.Error("another daemon's claim must be excluded")
+	}
+	if ids[fresh.ID] {
+		t.Error("a card with no last_run cannot be re-parked")
+	}
+}
+
 func TestAdapterUpdateState(t *testing.T) {
 	a, s := newAdapter(t)
 	iss, _ := s.Create(native.Issue{Title: "x", State: "ready"})

--- a/pkg/dispatcher/parked.go
+++ b/pkg/dispatcher/parked.go
@@ -2,6 +2,8 @@ package dispatcher
 
 import (
 	"context"
+	"errors"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
@@ -78,6 +80,114 @@ func (c *Dispatcher) reconcileParked(ctx context.Context) {
 			c.logger.Warn("dispatcher: parked sweep release %s: %v", iss.Identifier, err)
 		}
 		c.claims.Remove(iss.ID)
+		moved = true
+	}
+	if moved {
+		c.fireSnapshot()
+	}
+}
+
+// lastRunID is the tracker's persisted last_run pointer, or "" when
+// the adapter has no lookup (github/forgejo) or the card has never
+// been dispatched. Native-only today, same seam as stampLastRun.
+func (c *Dispatcher) lastRunID(issueID string) string {
+	look, ok := c.tracker.(interface {
+		LastRunForIssue(id string) (string, error)
+	})
+	if !ok {
+		return ""
+	}
+	runID, err := look.LastRunForIssue(issueID)
+	if err != nil || runID == "" {
+		return ""
+	}
+	return runID
+}
+
+// reparkToAwaitingInput moves a card whose last_run is still paused
+// back to the awaiting-input column, same run id. Caller owns the
+// claim (so ListCandidates stays away even if the column is missing).
+func (c *Dispatcher) reparkToAwaitingInput(iss tracker.Issue, runID string) {
+	c.stampLastRun(iss.ID, &runningEntry{
+		IssueID: iss.ID, Identifier: iss.Identifier, RunID: runID,
+	})
+	c.setAwaitingInput(iss.ID, true)
+	c.moveToAwaitingInput(iss.ID, iss.Identifier)
+	c.logger.Info(
+		"dispatcher: %s last run %s is still paused — re-parked in awaiting-input, refusing a fresh run",
+		iss.Identifier, runID,
+	)
+}
+
+// reparkClaimedIfLastRunWaiting stops a fresh dispatch when last_run is
+// already paused for a human or the operator. The ticket must already
+// be claimed by this tick (so ListCandidates stays away). Returns true
+// when the caller must abort — the card is parked again, same run.
+func (c *Dispatcher) reparkClaimedIfLastRunWaiting(iss tracker.Issue) bool {
+	runID := c.lastRunID(iss.ID)
+	if runID == "" {
+		return false
+	}
+	switch c.runStatusOnDisk(runID) {
+	case store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator:
+	default:
+		return false
+	}
+	c.reparkToAwaitingInput(iss, runID)
+	c.fireSnapshot()
+	return true
+}
+
+// reconcileStrandedPaused re-parks eligible cards whose last_run is
+// still paused for a human or the operator. The usual case is a
+// studio reboot: SweepStaleClaims dropped the park-claim, in_progress
+// is eligible, and without this sweep the next dispatch would mint a
+// sibling from entry. Also catches an out-of-band `iterion resume`
+// that re-paused on a later human node — the dispatcher worker had
+// already returned, so finishRun never moved the card.
+//
+// Runs on every tick, including while paused: reclaim is re-park,
+// never a fresh run.
+func (c *Dispatcher) reconcileStrandedPaused(ctx context.Context) {
+	lister, ok := c.tracker.(interface {
+		ListForRepark(marker string) ([]tracker.Issue, error)
+	})
+	if !ok {
+		return
+	}
+	cards, err := lister.ListForRepark(c.hostMarker)
+	if err != nil {
+		c.logger.Warn("dispatcher: stranded-pause sweep list: %v", err)
+		return
+	}
+	moved := false
+	for _, iss := range cards {
+		if _, running := c.state.running[iss.ID]; running {
+			continue
+		}
+		runID := c.lastRunID(iss.ID)
+		if runID == "" {
+			continue
+		}
+		switch c.runStatusOnDisk(runID) {
+		case store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator:
+		default:
+			continue
+		}
+		// Claim before the column move so a concurrent tick cannot
+		// dispatch if awaiting_input is missing on a custom board.
+		c.claims.Record(claimEntry{
+			IssueID: iss.ID, Identifier: iss.Identifier,
+			Marker: c.hostMarker, ClaimedAt: time.Now().UTC(),
+		})
+		if err := c.tracker.Claim(ctx, iss.ID, c.hostMarker); err != nil {
+			c.claims.Remove(iss.ID)
+			if !errors.Is(err, tracker.ErrClaimConflict) {
+				c.logger.Warn("dispatcher: stranded-pause claim %s: %v", iss.Identifier, err)
+			}
+			continue
+		}
+		c.reparkToAwaitingInput(iss, runID)
 		moved = true
 	}
 	if moved {

--- a/pkg/dispatcher/parked_test.go
+++ b/pkg/dispatcher/parked_test.go
@@ -3,10 +3,12 @@ package dispatcher
 import (
 	"bytes"
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -191,4 +193,296 @@ func TestReconcileParked_SkipsOtherDaemonsClaims(t *testing.T) {
 	if got.State != native.StateAwaitingInput || got.Claim != "other-host-9" {
 		t.Errorf("another daemon's parked card must be untouched, got state=%q claim=%q", got.State, got.Claim)
 	}
+}
+
+// TestDispatch_RefusesFreshRunWhenLastRunIsPaused is the reboot
+// regression: a human/operator pause survived on disk, the ticket is
+// still in_progress (claim died with the old PID), and dispatch must
+// re-park instead of minting a planner from init_film.
+func TestDispatch_RefusesFreshRunWhenLastRunIsPaused(t *testing.T) {
+	for _, status := range []store.RunStatus{
+		store.RunStatusPausedWaitingHuman,
+		store.RunStatusPausedOperator,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			dir := t.TempDir()
+			runStore, err := store.New(dir)
+			if err != nil {
+				t.Fatalf("store.New: %v", err)
+			}
+			run, err := runStore.CreateRun(context.Background(), "run-paused-keep", "wf", nil)
+			if err != nil {
+				t.Fatalf("CreateRun: %v", err)
+			}
+			run.Status = status
+			if err := runStore.SaveRun(context.Background(), run); err != nil {
+				t.Fatalf("SaveRun: %v", err)
+			}
+
+			ns, err := native.NewStore(filepath.Join(dir, "dispatcher"))
+			if err != nil {
+				t.Fatalf("native.NewStore: %v", err)
+			}
+			iss, err := ns.Create(native.Issue{Title: "ulysse", State: native.StateInProgress})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			if err := ns.SetLastRun(iss.ID, "run-paused-keep", ""); err != nil {
+				t.Fatalf("SetLastRun: %v", err)
+			}
+
+			launched := 0
+			runner := &StubRunner{Handler: func(context.Context, DispatchSpec) error {
+				launched++
+				return nil
+			}}
+			cfg := &Config{
+				Name:     "test",
+				Workflow: filepath.Join(t.TempDir(), "fake.bot"),
+				Tracker:  TrackerConfig{Kind: "native"},
+				Polling:  PollingConfig{IntervalMS: 50},
+				Agent: AgentConfig{
+					MaxConcurrent:  4,
+					RunningState:   "in_progress",
+					CompletedState: "review",
+					FailedState:    "blocked",
+				},
+				Workspace: WorkspaceConfig{Root: filepath.Join(dir, "ws")},
+			}
+			cfg.applyDefaults()
+			ws, err := NewWorkspaces(cfg.Workspace.Root)
+			if err != nil {
+				t.Fatalf("NewWorkspaces: %v", err)
+			}
+			c, err := New(Options{
+				Config: cfg, Tracker: native.NewAdapter(ns), Runner: runner,
+				Workspaces: ws, Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{}),
+				HostMarker: "test-host-1", StoreDir: dir,
+			})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+
+			c.dispatch(context.Background(), tracker.Issue{
+				ID: iss.ID, Identifier: iss.ID, Title: iss.Title,
+				WorkflowState: native.StateInProgress,
+			})
+
+			if launched != 0 {
+				t.Fatalf("dispatcher launched %d fresh run(s), want 0", launched)
+			}
+			got, err := ns.Get(iss.ID)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if got.State != native.StateAwaitingInput {
+				t.Errorf("card state = %q, want %q", got.State, native.StateAwaitingInput)
+			}
+			if got.LastRunID != "run-paused-keep" {
+				t.Errorf("last_run = %q, want the paused run", got.LastRunID)
+			}
+			if got.Claim == "" {
+				t.Errorf("re-parked card must keep the new claim so it is not a candidate")
+			}
+			if !got.AwaitingInput {
+				t.Errorf("awaiting-input badge must be set")
+			}
+			if _, running := c.state.running[iss.ID]; running {
+				t.Errorf("issue must not be tracked as a live worker")
+			}
+		})
+	}
+}
+
+func TestReconcileStrandedPaused_ReparksInProgressEvenWhenPaused(t *testing.T) {
+	fx := newLastRunFixture(t, store.RunStatusPausedWaitingHuman, native.StateInProgress)
+
+	fx.disp.paused.Store(true)
+	fx.disp.tick(context.Background())
+
+	if fx.launched != 0 {
+		t.Fatalf("paused tick launched %d run(s), want 0", fx.launched)
+	}
+	got, err := fx.board.Get(fx.issue.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != native.StateAwaitingInput {
+		t.Errorf("card state = %q, want %q", got.State, native.StateAwaitingInput)
+	}
+	if got.LastRunID != fx.runID {
+		t.Errorf("last_run = %q, want %q", got.LastRunID, fx.runID)
+	}
+	if got.Claim == "" {
+		t.Error("re-parked card must be claimed")
+	}
+	if !got.AwaitingInput {
+		t.Error("awaiting-input badge must be set")
+	}
+}
+
+func TestDispatch_RefusesFreshRunWhenLastRunIsStillLive(t *testing.T) {
+	for _, status := range []store.RunStatus{
+		store.RunStatusRunning,
+		store.RunStatusQueued,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			fx := newLastRunFixture(t, status, native.StateInProgress)
+			fx.disp.dispatch(context.Background(), tracker.Issue{
+				ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
+				WorkflowState: native.StateInProgress,
+			})
+			if fx.launched != 0 {
+				t.Fatalf("status %s launched %d fresh run(s), want 0", status, fx.launched)
+			}
+			got, err := fx.board.Get(fx.issue.ID)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if got.LastRunID != fx.runID {
+				t.Errorf("last_run = %q, want the existing run", got.LastRunID)
+			}
+			if _, running := fx.disp.state.running[fx.issue.ID]; running {
+				t.Error("issue must not be tracked as a live worker")
+			}
+		})
+	}
+}
+
+func TestDispatch_FilesFinishedLastRunInsteadOfMinting(t *testing.T) {
+	fx := newLastRunFixture(t, store.RunStatusFinished, native.StateInProgress)
+	fx.disp.dispatch(context.Background(), tracker.Issue{
+		ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
+		WorkflowState: native.StateInProgress,
+	})
+	if fx.launched != 0 {
+		t.Fatalf("finished last_run launched %d fresh run(s), want 0", fx.launched)
+	}
+	got, err := fx.board.Get(fx.issue.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != "review" {
+		t.Errorf("card state = %q, want review (completed_state)", got.State)
+	}
+	if got.LastRunID != fx.runID {
+		t.Errorf("last_run = %q, want the finished run", got.LastRunID)
+	}
+}
+
+func TestDispatch_ResumesFailedResumableSameID(t *testing.T) {
+	fx := newLastRunFixture(t, store.RunStatusFailedResumable, native.StateInProgress)
+	if _, _, err := fx.disp.workspaces.CreateForRun(fx.issue.ID, fx.runID); err != nil {
+		t.Fatalf("CreateForRun: %v", err)
+	}
+	fx.disp.dispatch(context.Background(), tracker.Issue{
+		ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
+		WorkflowState: native.StateInProgress,
+	})
+	fx.disp.workersWG.Wait()
+	if fx.launched != 1 {
+		t.Fatalf("resumable last_run launched %d time(s), want 1 resume", fx.launched)
+	}
+	if fx.lastSpec.RunID != fx.runID || fx.lastSpec.ResumeFromRunID != fx.runID {
+		t.Errorf("spec run=%q resumeFrom=%q, want both %q", fx.lastSpec.RunID, fx.lastSpec.ResumeFromRunID, fx.runID)
+	}
+}
+
+func TestDispatch_RefusesFreshSiblingWhenWorkspaceUnmanaged(t *testing.T) {
+	fx := newLastRunFixture(t, store.RunStatusFailedResumable, native.StateInProgress)
+	// A directory exists but no v2 ownership marker — the historic
+	// "starting fresh" path. Must defer, not mint.
+	legacy := filepath.Join(fx.disp.workspaces.root, "not-a-v2-workspace")
+	if err := os.MkdirAll(legacy, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	fx.disp.dispatch(context.Background(), tracker.Issue{
+		ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
+		WorkflowState: native.StateInProgress,
+	})
+	if fx.launched != 0 {
+		t.Fatalf("unmanaged workspace launched %d fresh run(s), want 0", fx.launched)
+	}
+	if _, skipped := fx.disp.state.dispatchSkips[fx.issue.ID]; !skipped {
+		t.Error("unmanaged resume must surface as a dispatch skip")
+	}
+	got, err := fx.board.Get(fx.issue.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.LastRunID != fx.runID {
+		t.Errorf("last_run = %q, want the existing run", got.LastRunID)
+	}
+}
+
+type lastRunFixture struct {
+	disp     *Dispatcher
+	board    *native.Store
+	issue    *native.Issue
+	runID    string
+	launched int
+	lastSpec DispatchSpec
+}
+
+func newLastRunFixture(t *testing.T, status store.RunStatus, cardState string) *lastRunFixture {
+	t.Helper()
+	dir := t.TempDir()
+	runStore, err := store.New(dir)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	const runID = "run-keep-me"
+	run, err := runStore.CreateRun(context.Background(), runID, "wf", nil)
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	run.Status = status
+	if err := runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+	ns, err := native.NewStore(filepath.Join(dir, "dispatcher"))
+	if err != nil {
+		t.Fatalf("native.NewStore: %v", err)
+	}
+	iss, err := ns.Create(native.Issue{Title: "ulysse", State: cardState})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := ns.SetLastRun(iss.ID, runID, ""); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+	fx := &lastRunFixture{board: ns, issue: iss, runID: runID}
+	runner := &StubRunner{Handler: func(_ context.Context, spec DispatchSpec) error {
+		fx.lastSpec = spec
+		fx.launched++
+		return nil
+	}}
+	cfg := &Config{
+		Name:     "test",
+		Workflow: filepath.Join(t.TempDir(), "fake.bot"),
+		Tracker:  TrackerConfig{Kind: "native"},
+		Polling:  PollingConfig{IntervalMS: 50},
+		Agent: AgentConfig{
+			MaxConcurrent:  4,
+			RunningState:   "in_progress",
+			CompletedState: "review",
+			FailedState:    "blocked",
+		},
+		Workspace: WorkspaceConfig{Root: filepath.Join(dir, "ws")},
+	}
+	cfg.applyDefaults()
+	ws, err := NewWorkspaces(cfg.Workspace.Root)
+	if err != nil {
+		t.Fatalf("NewWorkspaces: %v", err)
+	}
+	c, err := New(Options{
+		Config: cfg, Tracker: native.NewAdapter(ns), Runner: runner,
+		Workspaces: ws, Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{}),
+		HostMarker: "test-host-1", StoreDir: dir,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	fx.disp = c
+	return fx
 }

--- a/pkg/dispatcher/retry.go
+++ b/pkg/dispatcher/retry.go
@@ -39,12 +39,13 @@ const sandboxParkDelay = 1 * time.Hour
 // When the prior run terminated in a resumable status (failed_resumable,
 // cancelled, paused_operator), prev.RunID is captured on the retry
 // entry so the next dispatch resumes the same run via
-// runtime.Engine.Resume instead of minting a fresh one. The engine's
-// resume machinery picks up at the failing node, reuses the worktree
-// the prior run created, and avoids re-executing upstream nodes
-// (which can be expensive — a feature_dev plan node can spend $5 and
-// 10 minutes on workspace exploration before producing its first
-// artifact).
+// runtime.Engine.Resume instead of minting a fresh one. A live last_run
+// is never discarded to mint a sibling planner from entry — see
+// lastRunForbidsFresh. The engine's resume machinery picks up at the
+// failing node, reuses the worktree the prior run created, and avoids
+// re-executing upstream nodes (which can be expensive — a feature_dev
+// plan node can spend $5 and 10 minutes on workspace exploration
+// before producing its first artifact).
 func (c *Dispatcher) scheduleRetry(issueID string, prev *runningEntry, runErr error) {
 	cfg := c.cfg.Load()
 	// prevAttempt is the attempt index of the run that just failed. It
@@ -86,21 +87,10 @@ func (c *Dispatcher) scheduleRetry(issueID string, prev *runningEntry, runErr er
 		errStr = runErr.Error()
 	}
 	prevRunID := c.resumableRunID(prev.RunID)
-	// The prior run may be resumable by status (failed_resumable /
-	// cancelled / paused_operator), but if resume already FAILED because
-	// the bot's workflow source changed since that run started, resuming
-	// again is futile — the runtime rejects it identically every attempt
-	// ("workflow source has changed ... re-run from scratch or use
-	// --force", pkg/runtime/resume.go). Drop the resume pointer so the
-	// next attempt mints a fresh runID instead of looping on the same
-	// doomed resume. Bot edits are routine in a dev/dogfood loop, so this
-	// otherwise strands every issue whose last run is failed_resumable.
-	if isResumeSourceChanged(runErr) {
-		if prevRunID != "" {
-			c.logger.Info("dispatcher: %s prior run %s not resumable (bot source changed) — retrying from scratch", prev.Identifier, prevRunID)
-		}
-		prevRunID = ""
-	}
+	// Source-changed is parked in finishRun (keep last_run, no sibling).
+	// If it still reaches here, keep the resume pointer: minting a
+	// planner from entry is worse than retrying a doomed resume.
+	// lastRunForbidsFresh still refuses GenerateRunID.
 	c.state.retries[issueID] = &retryEntry{
 		IssueID:    issueID,
 		Identifier: prev.Identifier,
@@ -123,20 +113,44 @@ func (c *Dispatcher) scheduleRetry(issueID string, prev *runningEntry, runErr er
 // isResumeSourceChanged reports whether runErr is the runtime's refusal
 // to resume because the bot's workflow source changed since the prior
 // run started (pkg/runtime/resume.go: "workflow source has changed ...
-// re-run from scratch or use --force"). Such a run cannot be resumed as-
-// is; the dispatcher must retry FRESH rather than reschedule the same
-// doomed resume. The runtime exposes a typed sentinel in-process and retains a
-// compatibility fallback for detached/mixed-version boundaries that flatten
-// errors to text.
+// re-run from scratch or use --force"). finishRun parks the ticket
+// instead of minting a sibling: the operator resumes THIS run with
+// --force, or cancels it before asking for a new one. The runtime
+// exposes a typed sentinel in-process and retains a compatibility
+// fallback for detached/mixed-version boundaries that flatten errors
+// to text.
 func isResumeSourceChanged(err error) bool {
 	return runtime.IsWorkflowSourceChanged(err)
 }
 
+// lastRunForbidsFresh reports statuses that still own the ticket: the
+// dispatcher must re-park, resume, or hold — never mint a sibling
+// planner from the workflow entry. The only legitimate fresh run is
+// no last_run, or a hard-failed / vanished last_run plus an
+// explicitly eligible ticket.
+func lastRunForbidsFresh(status store.RunStatus) bool {
+	switch status {
+	case store.RunStatusPausedWaitingHuman,
+		store.RunStatusPausedOperator,
+		store.RunStatusRunning,
+		store.RunStatusQueued,
+		store.RunStatusFinished,
+		store.RunStatusFailedResumable,
+		store.RunStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
 // resumableRunID returns the runID iff the corresponding run record
-// can be resumed by the runtime — i.e. its on-disk status is
-// failed_resumable, cancelled, or paused_operator. Returns "" if the
-// run is missing, terminal-without-checkpoint (failed), or any error
-// reading the store; the dispatcher then falls back to a fresh run.
+// can be auto-resumed by the dispatcher — i.e. its on-disk status is
+// failed_resumable, cancelled, or paused_operator. paused_waiting_human
+// is deliberately excluded (no answers → immediate re-pause); that
+// status is re-parked, not resumed. Returns "" if the run is missing,
+// hard-failed, or any error reading the store. An empty result is NOT
+// a licence to mint a sibling: resolveRunID still consults
+// lastRunForbidsFresh before GenerateRunID.
 // Best-effort: store IO errors are debug-logged, never fatal.
 func (c *Dispatcher) resumableRunID(runID string) string {
 	if runID == "" || c.storeDir == "" {

--- a/pkg/dispatcher/retry_resume_test.go
+++ b/pkg/dispatcher/retry_resume_test.go
@@ -4,7 +4,31 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/store"
 )
+
+func TestLastRunForbidsFresh(t *testing.T) {
+	for _, status := range []store.RunStatus{
+		store.RunStatusPausedWaitingHuman,
+		store.RunStatusPausedOperator,
+		store.RunStatusRunning,
+		store.RunStatusQueued,
+		store.RunStatusFinished,
+		store.RunStatusFailedResumable,
+		store.RunStatusCancelled,
+	} {
+		if !lastRunForbidsFresh(status) {
+			t.Errorf("lastRunForbidsFresh(%s) = false, want true", status)
+		}
+	}
+	if lastRunForbidsFresh(store.RunStatusFailed) {
+		t.Error("hard-failed last_run may start fresh when the ticket is explicitly eligible")
+	}
+	if lastRunForbidsFresh("") {
+		t.Error("unknown/unreadable status must not block a fresh run")
+	}
+}
 
 func TestIsResumeSourceChanged(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Why

Fixes #426.

A studio / dispatcher restart (new PID) dropped the claim that parked a human or operator pause. `in_progress` stayed eligible for crash-recovery, `paused_waiting_human` was not in `resumableRunID`, and the next tick minted a **new** run from the workflow entry. The old run stayed paused. Two runs, one ticket.

`docs/resume.md` already says a run is durable. The dispatcher did not honour that on boot.

## Invariant

If `issue.last_run` exists and is still live or waiting, the dispatcher **never** mints a sibling planner from entry.

| last_run | Action |
|---|---|
| `paused_waiting_human` / `paused_operator` | Re-park: `awaiting_input`, same run, no auto-resume |
| `running` / `queued` | Hold. Do not mint |
| `failed_resumable` / `cancelled` | Resume the **same** id |
| `finished` | File the ticket. Do not relaunch |
| none, or hard `failed` + ticket explicitly back in `ready` | Only legitimate fresh run |

To really start over: cancel or finish the old run, then put the ticket in `ready`. A reboot is not a from-scratch.

## What changed

- After claim, a paused last_run is re-parked instead of calling `resolveRunID`.
- `reconcileStrandedPaused` runs on every tick, **including while paused**, so a reboot with `desired: paused` re-parks without dispatching. Also catches an out-of-band `iterion resume --force` that re-pauses on a later human node.
- Unmanaged v2 workspace: **defer**, do not mint a sibling « to restart safely ».
- Bot source changed: park, keep last_run. Operator `resume --force` on **this** run.
- Restoring `desired: paused` sets the flag **before** the actor's first tick (no more Start-then-Pause race).

## Test plan

- [x] `go test ./pkg/dispatcher/ ./pkg/dispatcher/native/`
- Repro from #426: bot with a late `human` gate → pause → leave ticket `in_progress` → restart studio → expect `re-parked in awaiting-input, refusing a fresh run`, same `last_run`, zero new `dispatching …`.