### PR TITLE
fix(forge): a GitLab gate claim over an existing claim is claimed, not failed

### DIFF
--- a/pkg/forge/gitlab/status.go
+++ b/pkg/forge/gitlab/status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/SocialGouv/iterion/pkg/forge"
 )
@@ -32,9 +33,41 @@ func (c *AdminClient) SetCommitStatus(ctx context.Context, repo, sha string, st 
 		return err
 	}
 	if code/100 != 2 {
+		// GitLab's commit-status state machine refuses pending → pending
+		// ("Cannot transition status via :enqueue from :pending", HTTP 400)
+		// where GitHub accepts the same POST as a no-op. The only writer that
+		// posts pending is the merge gate's in-flight CLAIM, and a claim asks
+		// for a state that is ALREADY true here — a second bot on the shared
+		// gate context, or a relaunch onto a head someone already claimed. So
+		// confirm the existing status really is pending and report success:
+		// the gate is claimed either way, and failing left the check reading
+		// "absent" while a review was in fact running.
+		//
+		// Deliberately narrow: only for a pending write, only after READING
+		// the live status back. Any other 4xx, and a pending write over any
+		// other state, still surfaces.
+		if code == http.StatusBadRequest && st.State == forge.CommitStatePending && c.pendingAlreadyOn(ctx, repo, sha, st.Context) {
+			return nil
+		}
 		return statusErr("set commit status", code)
 	}
 	return nil
+}
+
+// pendingAlreadyOn reports whether ctxName already carries a pending status on
+// sha. Read-only, best-effort: an unreadable status list answers false, so a
+// rejected write is reported rather than assumed benign.
+func (c *AdminClient) pendingAlreadyOn(ctx context.Context, repo, sha, ctxName string) bool {
+	sts, err := c.ListCommitStatuses(ctx, repo, sha)
+	if err != nil {
+		return false
+	}
+	for _, s := range sts {
+		if strings.EqualFold(strings.TrimSpace(s.Context), strings.TrimSpace(ctxName)) {
+			return s.State == forge.CommitStatePending
+		}
+	}
+	return false
 }
 
 // ListCommitStatuses returns the statuses already present on sha

--- a/pkg/forge/gitlab/status_assert_test.go
+++ b/pkg/forge/gitlab/status_assert_test.go
@@ -80,3 +80,87 @@ func TestListCommitStatuses_ErrorStatus(t *testing.T) {
 		t.Fatal("want an error on a non-2xx response, got nil")
 	}
 }
+
+// GitLab refuses pending → pending ("Cannot transition status via :enqueue
+// from :pending", HTTP 400) where GitHub takes the same POST as a no-op. The
+// merge gate's in-flight claim is the only writer that posts pending, and it
+// asks for a state that is already true — so the claim must read as claimed,
+// not as a failure that leaves the check reading "absent".
+func TestSetCommitStatus_PendingOverPendingIsClaimed(t *testing.T) {
+	var posts int
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v4/projects/grp%2Fproj/statuses/abc", func(w http.ResponseWriter, r *http.Request) {
+		posts++
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message": "Cannot transition status via :enqueue from :pending (Reason(s): Status cannot transition via \"enqueue\")",
+		})
+	})
+	mux.HandleFunc("GET /api/v4/projects/grp%2Fproj/repository/commits/abc/statuses", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": 1, "status": "pending", "name": "iterion/review"},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := &AdminClient{HTTP: srv.Client(), BaseURL: srv.URL, Token: "t"}
+	err := c.SetCommitStatus(context.Background(), "grp/proj", "abc", forge.CommitStatus{
+		State: forge.CommitStatePending, Context: "iterion/review",
+	})
+	if err != nil {
+		t.Fatalf("a claim over an existing pending claim must succeed, got %v", err)
+	}
+	if posts != 1 {
+		t.Fatalf("want exactly one POST attempt, got %d", posts)
+	}
+}
+
+// The narrowing that keeps the case above from swallowing real failures: the
+// same 400 with the context sitting on any other state still surfaces, since
+// the claim did NOT take and the gate would otherwise read as claimed.
+func TestSetCommitStatus_PendingOverOtherStateStillFails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v4/projects/grp%2Fproj/statuses/abc", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": "Cannot transition status via :enqueue from :running"})
+	})
+	mux.HandleFunc("GET /api/v4/projects/grp%2Fproj/repository/commits/abc/statuses", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": 1, "status": "success", "name": "iterion/review"},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := &AdminClient{HTTP: srv.Client(), BaseURL: srv.URL, Token: "t"}
+	if err := c.SetCommitStatus(context.Background(), "grp/proj", "abc", forge.CommitStatus{
+		State: forge.CommitStatePending, Context: "iterion/review",
+	}); err == nil {
+		t.Fatal("want the rejection to surface when the context is not already pending")
+	}
+}
+
+// A verdict write (the state the gate actually gates on) never takes the
+// already-claimed path: a rejected verdict is a real failure.
+func TestSetCommitStatus_VerdictRejectionSurfaces(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/v4/projects/grp%2Fproj/statuses/abc", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": "Cannot transition status"})
+	})
+	mux.HandleFunc("GET /api/v4/projects/grp%2Fproj/repository/commits/abc/statuses", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": 1, "status": "pending", "name": "iterion/review"},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := &AdminClient{HTTP: srv.Client(), BaseURL: srv.URL, Token: "t"}
+	if err := c.SetCommitStatus(context.Background(), "grp/proj", "abc", forge.CommitStatus{
+		State: forge.CommitStateFailure, Context: "iterion/review",
+	}); err == nil {
+		t.Fatal("want a rejected verdict to surface")
+	}
+}


### PR DESCRIPTION
## The defect

GitLab's commit-status state machine **refuses `pending` → `pending`**:

```
HTTP 400 {"message":"Cannot transition status via :enqueue from :pending
          (Reason(s): Status cannot transition via \"enqueue\")"}
```

GitHub accepts the same POST as a no-op, so the merge gate's in-flight **claim** is idempotent there and not here. Observed live on a self-hosted GitLab 19.2 while wiring two bots onto one gate context:

```
forge gate: run … could not claim iterion/review on <repo>@<sha>:
  gitlab: set commit status: HTTP 400 — the check stays absent while the review runs
```

The claim is the placeholder that tells a reader "a review is running on this head". Losing it means the check reads **absent** during exactly the window it exists to cover.

## The fix

The only writer that posts `pending` is that claim, and a rejected claim here means the state it asked for is **already true**. So on a 400 for a pending write, `SetCommitStatus` reads the status back and, if the context is already pending, reports success.

Deliberately narrow — the guard only applies to a **pending** write and only **after the read agrees**:

| write | live state | result |
|---|---|---|
| `pending` | already `pending` | success (claimed) |
| `pending` | anything else | rejection surfaces |
| verdict (`failure`/`success`) | any | rejection surfaces |

A verdict is what the gate actually gates on; a rejected verdict is a real failure and stays one.

## Verified against the live instance

- `pending` → `pending` → **400** with that exact message
- `pending` → `failed` → **200** (the ordinary verdict path, untouched)
- `failed` → `pending` → **200** (a re-review claiming a head that already carries a verdict, untouched)

Tests reproduce the transition table over `httptest`, including the two paths that must keep failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)