### PR TITLE
fix(byok): a key created for another team is stamped with THAT team

### DIFF
--- a/pkg/secrets/byok_mongo_test.go
+++ b/pkg/secrets/byok_mongo_test.go
@@ -108,3 +108,47 @@ func TestMongoApiKey_GetOwnedRefusesWhatIsNotYours(t *testing.T) {
 		})
 	}
 }
+
+// The store stamps tenant_id from the CONTEXT and filters reads by it, so a
+// key created under one tenant's context but scoped to another team is
+// unreachable by the team it was meant to fund — a run there resolves nothing
+// and falls back to the platform credential, silently. This pins the contract
+// the api-keys HTTP layer must honour: create under the context of the team
+// the key is FOR.
+func TestMongoApiKey_ScopeWithoutMatchingTenantIsUnreachable(t *testing.T) {
+	s, ctx := mongoKeyStore(t)
+
+	// The defect shape: written under team-a's context, scoped to team-b.
+	if err := s.Create(store.WithTenant(ctx, "team-a"), ApiKey{
+		ID: "mis-stamped", ScopeTeamID: "team-b",
+		Provider: ProviderAnthropic, Name: "meant for team-b", IsDefault: true,
+	}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := s.ListByTeam(store.WithTenant(ctx, "team-b"), "team-b", "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("a key stamped with another tenant must NOT be reachable as team-b's, got %d", len(got))
+	}
+
+	// The correct shape: written under the context of the team it is for.
+	if err := s.Create(store.WithTenant(ctx, "team-b"), ApiKey{
+		ID: "well-stamped", ScopeTeamID: "team-b",
+		Provider: ProviderAnthropic, Name: "for team-b", IsDefault: true,
+	}); err != nil {
+		t.Fatalf("create scoped: %v", err)
+	}
+	got, err = s.ListByTeam(store.WithTenant(ctx, "team-b"), "team-b", "")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "well-stamped" {
+		t.Fatalf("team-b must see exactly its own key, got %+v", got)
+	}
+	// And it stays invisible to the other tenant.
+	if other, err := s.ListByTeam(store.WithTenant(ctx, "team-a"), "team-b", ""); err != nil || len(other) != 0 {
+		t.Fatalf("team-a must not see team-b's key (err=%v, n=%d)", err, len(other))
+	}
+}

--- a/pkg/secrets/byok_mongo_test.go
+++ b/pkg/secrets/byok_mongo_test.go
@@ -147,8 +147,19 @@ func TestMongoApiKey_ScopeWithoutMatchingTenantIsUnreachable(t *testing.T) {
 	if len(got) != 1 || got[0].ID != "well-stamped" {
 		t.Fatalf("team-b must see exactly its own key, got %+v", got)
 	}
-	// And it stays invisible to the other tenant.
-	if other, err := s.ListByTeam(store.WithTenant(ctx, "team-a"), "team-b", ""); err != nil || len(other) != 0 {
-		t.Fatalf("team-a must not see team-b's key (err=%v, n=%d)", err, len(other))
+	// From team-a's context the WELL-stamped key is out of reach — while the
+	// mis-stamped one still answers, which is the whole asymmetry: the row is
+	// visible to whoever created it and not to whoever it belongs to.
+	other, err := s.ListByTeam(store.WithTenant(ctx, "team-a"), "team-b", "")
+	if err != nil {
+		t.Fatalf("list from team-a: %v", err)
+	}
+	for _, k := range other {
+		if k.ID == "well-stamped" {
+			t.Fatalf("team-b's key must not be reachable from team-a's context")
+		}
+	}
+	if len(other) != 1 || other[0].ID != "mis-stamped" {
+		t.Fatalf("the mis-stamped row is the one that answers here, got %+v", other)
 	}
 }

--- a/pkg/server/byok_routes.go
+++ b/pkg/server/byok_routes.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/store"
 )
 
 // registerBYOKRoutes wires every /api/teams/:id/api-keys and
@@ -83,6 +84,26 @@ func (s *Server) writeApiKeyList(w http.ResponseWriter, keys []secrets.ApiKey, e
 	return true
 }
 
+// apiKeyTenantCtx scopes the store context to the team a route names in its
+// path, instead of the caller's ACTIVE team that requireAuth stamped.
+//
+// The api-keys store derives tenant_id from the context — on write it stamps
+// the row, on read it filters. So a key created for a team other than the
+// caller's active one used to land as (scope_team = target, tenant_id =
+// caller's active team): listable from the context that created it, and
+// INVISIBLE to the runs of the team it was meant to fund. Nothing failed —
+// the run simply resolved no key and fell back to the platform credential,
+// which is the one shape a credential bug must never take.
+//
+// Routes with no {id} (the /api/me family) keep the active team: there the
+// caller's own tenant IS the scope.
+func apiKeyTenantCtx(r *http.Request) context.Context {
+	if teamID := r.PathValue("id"); teamID != "" {
+		return store.WithTenant(r.Context(), teamID)
+	}
+	return r.Context()
+}
+
 func (s *Server) handleListTeamApiKeys(w http.ResponseWriter, r *http.Request) {
 	id, _ := auth.FromContext(r.Context())
 	teamID := r.PathValue("id")
@@ -92,7 +113,7 @@ func (s *Server) handleListTeamApiKeys(w http.ResponseWriter, r *http.Request) {
 	}
 	// Team admins see all team-wide keys + their own user-scoped
 	// keys (matches BYOK plan). Members only see what's visible.
-	keys, err := s.apiKeys.ListByTeam(r.Context(), teamID, id.UserID)
+	keys, err := s.apiKeys.ListByTeam(apiKeyTenantCtx(r), teamID, id.UserID)
 	s.writeApiKeyList(w, keys, err)
 }
 
@@ -163,12 +184,13 @@ func (s *Server) handleCreateApiKey(w http.ResponseWriter, r *http.Request, team
 		CreatedAt:    now,
 		Fingerprint:  secrets.FingerprintSHA256(req.Secret),
 	}
-	if err := s.apiKeys.Create(r.Context(), key); err != nil {
+	ctx := apiKeyTenantCtx(r)
+	if err := s.apiKeys.Create(ctx, key); err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
 	}
 	if req.IsDefault {
-		if err := s.apiKeys.ClearDefault(r.Context(), teamID, userID, provider, keyID); err != nil {
+		if err := s.apiKeys.ClearDefault(ctx, teamID, userID, provider, keyID); err != nil {
 			httpError(w, http.StatusInternalServerError, "key %s created but clearing previous default failed: %v", keyID, err)
 			return
 		}
@@ -180,7 +202,8 @@ func (s *Server) handleCreateApiKey(w http.ResponseWriter, r *http.Request, team
 func (s *Server) handleUpdateApiKey(w http.ResponseWriter, r *http.Request) {
 	id, _ := auth.FromContext(r.Context())
 	keyID := r.PathValue("key_id")
-	key, err := s.apiKeys.Get(r.Context(), keyID)
+	ctx := apiKeyTenantCtx(r)
+	key, err := s.apiKeys.Get(ctx, keyID)
 	if err != nil {
 		if errors.Is(err, secrets.ErrApiKeyNotFound) {
 			httpError(w, http.StatusNotFound, "key not found")
@@ -215,12 +238,12 @@ func (s *Server) handleUpdateApiKey(w http.ResponseWriter, r *http.Request) {
 	if req.IsDefault != nil {
 		key.IsDefault = *req.IsDefault
 	}
-	if err := s.apiKeys.Update(r.Context(), key); err != nil {
+	if err := s.apiKeys.Update(ctx, key); err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
 	}
 	if key.IsDefault {
-		if err := s.apiKeys.ClearDefault(r.Context(), key.ScopeTeamID, key.ScopeUserID, key.Provider, key.ID); err != nil {
+		if err := s.apiKeys.ClearDefault(ctx, key.ScopeTeamID, key.ScopeUserID, key.Provider, key.ID); err != nil {
 			httpError(w, http.StatusInternalServerError, "key updated but clearing previous default failed: %v", err)
 			return
 		}
@@ -232,7 +255,8 @@ func (s *Server) handleUpdateApiKey(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleDeleteApiKey(w http.ResponseWriter, r *http.Request) {
 	id, _ := auth.FromContext(r.Context())
 	keyID := r.PathValue("key_id")
-	key, err := s.apiKeys.Get(r.Context(), keyID)
+	ctx := apiKeyTenantCtx(r)
+	key, err := s.apiKeys.Get(ctx, keyID)
 	if err != nil {
 		if errors.Is(err, secrets.ErrApiKeyNotFound) {
 			w.WriteHeader(http.StatusNoContent)
@@ -245,7 +269,7 @@ func (s *Server) handleDeleteApiKey(w http.ResponseWriter, r *http.Request) {
 		httpError(w, http.StatusForbidden, "cannot delete this key")
 		return
 	}
-	if err := s.apiKeys.Delete(r.Context(), key.ID); err != nil {
+	if err := s.apiKeys.Delete(ctx, key.ID); err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
 	}

--- a/pkg/server/byok_routes_test.go
+++ b/pkg/server/byok_routes_test.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// tenantSpyKeyStore records the tenant the handler put on the context of each
+// write — the value the real (Mongo) store stamps onto the row and later
+// filters reads by.
+type tenantSpyKeyStore struct {
+	secrets.ApiKeyStore
+	createTenant string
+}
+
+func (s *tenantSpyKeyStore) Create(ctx context.Context, k secrets.ApiKey) error {
+	s.createTenant, _ = store.TenantFromContext(ctx)
+	return s.ApiKeyStore.Create(ctx, k)
+}
+
+// The composition the unit tests below cannot show: a team admin creating a key
+// FOR another team must have it stamped with THAT team, or the runs it funds
+// resolve nothing and fall back to the platform credential without a word.
+func TestCreateTeamApiKey_StampsThePathTeam(t *testing.T) {
+	sealer, err := secrets.NewAESGCMSealer(bytes.Repeat([]byte{3}, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spy := &tenantSpyKeyStore{ApiKeyStore: secrets.NewMemoryApiKeyStore()}
+	srv := &Server{apiKeys: spy, sealer: sealer}
+
+	body := `{"provider":"anthropic","name":"for-team-b","secret":"sk-ant-api-x"}`
+	r := httptest.NewRequest("POST", "/api/teams/team-b/api-keys", strings.NewReader(body))
+	r.SetPathValue("id", "team-b")
+	// What requireAuth stamps: the caller's ACTIVE team, which is NOT the one
+	// the key is for. A super-admin identity clears canManageTeam without a
+	// membership store.
+	ctx := auth.WithIdentity(r.Context(), auth.Identity{UserID: "u1", IsSuperAdmin: true, TeamID: "team-a"})
+	r = r.WithContext(store.WithTenant(ctx, "team-a"))
+
+	w := httptest.NewRecorder()
+	srv.handleCreateTeamApiKey(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("create: status %d body %s", w.Code, w.Body.String())
+	}
+	if spy.createTenant != "team-b" {
+		t.Fatalf("the row must be stamped with the team it is scoped to; got tenant %q", spy.createTenant)
+	}
+}
+
+// The api-keys store derives tenant_id from the context: on write it stamps
+// the row, on read it filters. requireAuth stamps the CALLER'S ACTIVE team, so
+// a route that names a different team in its path has to re-scope — otherwise
+// a key created for that team is stamped with the caller's, and the runs it
+// was meant to fund resolve nothing at all.
+func TestApiKeyTenantCtx_UsesThePathTeamNotTheActiveOne(t *testing.T) {
+	r, err := http.NewRequest("POST", "/api/teams/team-b/api-keys", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.SetPathValue("id", "team-b")
+	r = r.WithContext(store.WithTenant(r.Context(), "team-a")) // what requireAuth stamped
+
+	got, ok := store.TenantFromContext(apiKeyTenantCtx(r))
+	if !ok || got != "team-b" {
+		t.Fatalf("want the path team team-b, got %q (ok=%v)", got, ok)
+	}
+}
+
+// The /api/me family names no team: there the caller's active tenant IS the
+// scope, and re-scoping would have nothing to scope to.
+func TestApiKeyTenantCtx_KeepsTheActiveTeamWhenNoPathTeam(t *testing.T) {
+	r, err := http.NewRequest("POST", "/api/me/api-keys", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r = r.WithContext(store.WithTenant(r.Context(), "team-a"))
+
+	got, ok := store.TenantFromContext(apiKeyTenantCtx(r))
+	if !ok || got != "team-a" {
+		t.Fatalf("want the active team team-a, got %q (ok=%v)", got, ok)
+	}
+}


### PR DESCRIPTION
## The defect

The api-keys store derives `tenant_id` from the **context** — `MongoApiKeyStore.Create` stamps the row from it, every read filters by it — and `requireAuth` stamps the **caller's ACTIVE team**. The team-scoped routes (`/api/teams/{id}/api-keys`) never re-scoped, so a key created for a team other than the caller's own landed as:

```
scope_team = <target team>      tenant_id = <caller's active team>
```

Listable from the context that created it (which is why it looks fine in the UI/CLI), and **invisible to the runs of the team it was meant to fund**.

## Why it matters more than a 404 would

Nothing failed. `secrets.Resolve` found no key for the run's tenant, so the run **fell back to the platform credential** — the one shape a credential defect must never take: a whole team's work billed to the wrong subscription, with a green log and no error anywhere.

Found on a deployment where a sponsor's key had been placed on a dedicated team precisely to keep its billing separate. A `claw` probe on that team answered `401 x-api-key header is required` — which [docs/cloud-llm-credentials.md](docs/cloud-llm-credentials.md) documents as the symptom of a team with **no key at all**.

## The fix

`apiKeyTenantCtx(r)` scopes the store context to the team the route names in its path; the four team-scoped handlers (list / create / update / delete) use it for every store call. The `/api/me` family keeps the active team — there the caller's own tenant *is* the scope.

## Tests

- **Composition** (`TestCreateTeamApiKey_StampsThePathTeam`): drives the real handler with a spy store that records the tenant on the write context, with the caller active in `team-a` and the path naming `team-b`. Verified to FAIL on the pre-fix code (`got tenant "team-a"`) and pass after — it pins the wiring, not a helper.
- **Unit**: the seam keeps the active team when no path team exists (`/api/me`).
- **Store contract** (`pkg/secrets`, mongo-conformance): a row whose `tenant_id` does not match its `scope_team` is unreachable by that team, while a correctly-stamped one is visible to it and to nobody else. This is the fact that makes the HTTP fix necessary, pinned where the in-memory store cannot show it.

## Migration note

Rows already written with the wrong `tenant_id` stay orphaned: after this change they are invisible from **both** contexts. They are reachable one last time from the creating team's context (`DELETE /api/teams/<creating-team>/api-keys/<id>` before deploy), or can be re-created against the intended team afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)