### PR TITLE
fix(store): a directory holding only a lock is not a run

### DIFF
--- a/pkg/cli/runs_prune.go
+++ b/pkg/cli/runs_prune.go
@@ -133,7 +133,9 @@ func RunPrune(opts PruneOptions, p *Printer) error {
 	}
 
 	ctx := context.Background()
-	ids, err := s.ListRuns(ctx)
+	// The janitor's listing, not the readers': a directory with no
+	// loadable run.json is exactly what this sweep must surface.
+	ids, err := s.ListRunDirs(ctx)
 	if err != nil {
 		return fmt.Errorf("list runs: %w", err)
 	}

--- a/pkg/runview/service_runs_skip_log_test.go
+++ b/pkg/runview/service_runs_skip_log_test.go
@@ -15,11 +15,16 @@ import (
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
-// A run id whose document is gone is a stale index entry, not a corrupt
-// run: it logs once at Debug — never at Warn — and is not re-logged on
-// every UI poll. A genuinely unreadable document rates a Warn, also
-// once: a corrupt run.json does not heal between two polls, and the
-// repeated lines were drowning the instance log (several per second).
+// A genuinely unreadable document rates a Warn, and only once: a corrupt
+// run.json does not heal between two polls, and the repeated lines were
+// drowning the instance log (several per second).
+//
+// A directory with no run.json is not seeded here any more: the store no
+// longer lists one at all (see TestListRuns_SkipsALockedButNeverCreatedRun),
+// so it never reaches this layer. The Debug-once path it used to exercise
+// remains for the case that is genuinely racy rather than permanent — a run
+// listed and then deleted between the list and the load — which no fixture
+// can stage deterministically.
 func TestListRunRecordsCtxSkipsStaleAndCorruptRunsQuietly(t *testing.T) {
 	dir := t.TempDir()
 	storeDir := filepath.Join(dir, "store")
@@ -32,10 +37,6 @@ func TestListRunRecordsCtxSkipsStaleAndCorruptRunsQuietly(t *testing.T) {
 	// One healthy run so the listing has something to return.
 	if _, err := st.CreateRun(context.Background(), "run-ok", "wf", nil); err != nil {
 		t.Fatalf("create run: %v", err)
-	}
-	// Stale index entry: the id exists, run.json does not.
-	if err := os.MkdirAll(filepath.Join(storeDir, "runs", "run-gone"), 0o755); err != nil {
-		t.Fatalf("mkdir stale run: %v", err)
 	}
 	// Corrupt document: present but unreadable.
 	corruptDir := filepath.Join(storeDir, "runs", "run-corrupt")
@@ -67,18 +68,12 @@ func TestListRunRecordsCtxSkipsStaleAndCorruptRunsQuietly(t *testing.T) {
 		for _, line := range strings.Split(strings.TrimRight(log, "\n"), "\n") {
 			if strings.Contains(line, id) {
 				n++
-				if id == "run-gone" && !strings.Contains(line, "🔍") {
-					t.Errorf("stale run-gone must log at Debug (🔍), got: %s", line)
-				}
 				if id == "run-corrupt" && !strings.Contains(line, "⚠️") {
 					t.Errorf("corrupt run-corrupt must log at Warn (⚠️), got: %s", line)
 				}
 			}
 		}
 		return n
-	}
-	if got := lineCount("run-gone"); got != 1 {
-		t.Errorf("run-gone logged on %d lines over 3 polls, want 1 (log-once)\nlog:\n%s", got, log)
 	}
 	if got := lineCount("run-corrupt"); got != 1 {
 		t.Errorf("run-corrupt logged on %d lines over 3 polls, want 1 (log-once)\nlog:\n%s", got, log)

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -532,7 +532,34 @@ func (s *FilesystemRunStore) mutateSubbotChildren(runID string, apply func(map[s
 }
 
 // ListRuns returns the IDs of all persisted runs.
-func (s *FilesystemRunStore) ListRuns(_ context.Context) ([]string, error) {
+// ListRuns returns the ids of the runs in the store: directories that
+// carry a run.json, which is the authoritative identity of a run (see
+// CreateRun). Everything listed here loads.
+//
+// That last property is the point. LockRun mkdirs the run directory to
+// place its .lock, so an id that is locked and then never created — an
+// abandoned launch, a crash between the lock and the first write —
+// leaves a directory carrying only that lock. Listed as a run it is a
+// permanent phantom: every LoadRun on it fails, and a consumer that
+// reads the first id it is handed waits on a run that will never load.
+//
+// A caller whose job is precisely to find the leftovers — the retention
+// sweep — wants the opposite and asks ListRunDirs.
+func (s *FilesystemRunStore) ListRuns(ctx context.Context) ([]string, error) {
+	return s.listRunEntries(ctx, true)
+}
+
+// ListRunDirs returns every run directory in the store, including those
+// with no readable run.json. It is the janitor's view: a partial delete,
+// a crash before the first write, or an abandoned lock leaves a
+// directory that a retention sweep must be able to SEE (and report)
+// rather than silently step over. Tombstoned runs stay excluded — those
+// are deliberate deletions, not leftovers.
+func (s *FilesystemRunStore) ListRunDirs(ctx context.Context) ([]string, error) {
+	return s.listRunEntries(ctx, false)
+}
+
+func (s *FilesystemRunStore) listRunEntries(_ context.Context, requireDoc bool) ([]string, error) {
 	runsDir := filepath.Join(s.root, "runs")
 	entries, err := os.ReadDir(runsDir)
 	if err != nil {
@@ -548,17 +575,10 @@ func (s *FilesystemRunStore) ListRuns(_ context.Context) ([]string, error) {
 		if s.runDeleted(e.Name()) {
 			continue
 		}
-		// Nor is a directory that holds no run.json a run. LockRun
-		// mkdirs the run dir to place its .lock, so an id that is
-		// locked and then never created — an abandoned launch, a crash
-		// between the lock and the first write — leaves a directory
-		// carrying only `.lock`. It is indistinguishable from a real
-		// run here and permanent, so every consumer that reads the
-		// first id it is handed stalls on a run that will never load.
-		// run.json is the authoritative identity of a run (see
-		// CreateRun); absent it, there is nothing to list.
-		if _, err := os.Stat(s.runJSONPath(e.Name())); err != nil {
-			continue
+		if requireDoc {
+			if _, err := os.Stat(s.runJSONPath(e.Name())); err != nil {
+				continue
+			}
 		}
 		ids = append(ids, e.Name())
 	}

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -548,6 +548,18 @@ func (s *FilesystemRunStore) ListRuns(_ context.Context) ([]string, error) {
 		if s.runDeleted(e.Name()) {
 			continue
 		}
+		// Nor is a directory that holds no run.json a run. LockRun
+		// mkdirs the run dir to place its .lock, so an id that is
+		// locked and then never created — an abandoned launch, a crash
+		// between the lock and the first write — leaves a directory
+		// carrying only `.lock`. It is indistinguishable from a real
+		// run here and permanent, so every consumer that reads the
+		// first id it is handed stalls on a run that will never load.
+		// run.json is the authoritative identity of a run (see
+		// CreateRun); absent it, there is nothing to list.
+		if _, err := os.Stat(s.runJSONPath(e.Name())); err != nil {
+			continue
+		}
 		ids = append(ids, e.Name())
 	}
 	sort.Strings(ids)

--- a/pkg/store/store_run_phantom_test.go
+++ b/pkg/store/store_run_phantom_test.go
@@ -1,0 +1,68 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+// LockRun mkdirs the run directory to place its .lock, so an id that is locked
+// and never created leaves a directory holding only that lock. Listed as a run,
+// it is a permanent phantom: it never loads, and a consumer that inspects the
+// first id it is handed waits forever on it while the real run sits behind it.
+func TestListRuns_SkipsALockedButNeverCreatedRun(t *testing.T) {
+	s, err := New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	lock, err := s.LockRun(ctx, "01-locked-never-created")
+	if err != nil {
+		t.Fatalf("lock: %v", err)
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	if _, err := s.CreateRun(ctx, "02-real", "wf", map[string]any{"k": "v"}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	ids, err := s.ListRuns(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "02-real" {
+		t.Fatalf("only the created run is a run; got %v", ids)
+	}
+	// The guarantee that matters downstream: every id listed loads.
+	for _, id := range ids {
+		if _, err := s.LoadRun(ctx, id); err != nil {
+			t.Fatalf("listed id %s must load, got %v", id, err)
+		}
+	}
+}
+
+// A run that IS created keeps its lock without becoming unlistable — the skip
+// keys on run.json, not on the absence of a lock.
+func TestListRuns_ListsACreatedRunThatHoldsItsLock(t *testing.T) {
+	s, err := New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if _, err := s.CreateRun(ctx, "01-real", "wf", nil); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	lock, err := s.LockRun(ctx, "01-real")
+	if err != nil {
+		t.Fatalf("lock: %v", err)
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	ids, err := s.ListRuns(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "01-real" {
+		t.Fatalf("a locked, created run stays listed; got %v", ids)
+	}
+}

--- a/pkg/store/store_run_phantom_test.go
+++ b/pkg/store/store_run_phantom_test.go
@@ -66,3 +66,60 @@ func TestListRuns_ListsACreatedRunThatHoldsItsLock(t *testing.T) {
 		t.Fatalf("a locked, created run stays listed; got %v", ids)
 	}
 }
+
+// The two listings answer different questions, and the retention sweep needs
+// the second one: a leftover it cannot see is a leftover it can neither report
+// nor let an operator clean up.
+func TestListRunDirs_SeesWhatListRunsFilters(t *testing.T) {
+	s, err := New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	lock, err := s.LockRun(ctx, "01-leftover")
+	if err != nil {
+		t.Fatalf("lock: %v", err)
+	}
+	defer func() { _ = lock.Unlock() }()
+	if _, err := s.CreateRun(ctx, "02-real", "wf", nil); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	dirs, err := s.ListRunDirs(ctx)
+	if err != nil {
+		t.Fatalf("list dirs: %v", err)
+	}
+	if len(dirs) != 2 || dirs[0] != "01-leftover" || dirs[1] != "02-real" {
+		t.Fatalf("the janitor sees every directory; got %v", dirs)
+	}
+	runs, err := s.ListRuns(ctx)
+	if err != nil {
+		t.Fatalf("list runs: %v", err)
+	}
+	if len(runs) != 1 || runs[0] != "02-real" {
+		t.Fatalf("readers see only runs; got %v", runs)
+	}
+}
+
+// A deliberate deletion is not a leftover: neither listing resurrects it.
+func TestListRunDirs_StillExcludesTombstones(t *testing.T) {
+	s, err := New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if _, err := s.CreateRun(ctx, "01-gone", "wf", nil); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := s.DeleteRun(ctx, "01-gone"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	dirs, err := s.ListRunDirs(ctx)
+	if err != nil {
+		t.Fatalf("list dirs: %v", err)
+	}
+	if len(dirs) != 0 {
+		t.Fatalf("a tombstoned run stays out of both listings; got %v", dirs)
+	}
+}


### PR DESCRIPTION
## The defect

`LockRun` mkdirs the run directory to place its `.lock`. So an id that is **locked and then never created** — an abandoned launch, a crash between the lock and the first write — leaves a directory carrying nothing but that lock. `ListRuns` reported it as a run, **permanently**:

```
runs/01a00f0a-…/.lock        ← listed as a run; every LoadRun on it fails
runs/01a00fa9-…/run.json     ← the real, finished run, behind it
```

Any consumer that reads the first id it is handed then waits on a run that will never load. That is exactly what made **`TestProcessBoardCardCarriesPRLaunchContext` fail on main** — it burned its full 30s deadline inspecting `ids[0]` while the run it was waiting for sat right behind, already `finished`.

## The fix

`run.json` is the authoritative identity of a run (see `CreateRun`), so `ListRuns` skips a directory without one — the same reasoning the tombstone skip immediately above it already applies, extended to the other way a phantom is born.

## Tests

- `TestListRuns_SkipsALockedButNeverCreatedRun` — verified to FAIL before the fix (`got [01-locked-never-created 02-real]`); also asserts the property downstream actually depends on: **every id listed loads**.
- `TestListRuns_ListsACreatedRunThatHoldsItsLock` — the skip keys on `run.json`, not on the absence of a lock; a live run holding its own lock stays listed.
- `TestProcessBoardCardCarriesPRLaunchContext` passes again, untouched.

## One test adapted

`pkg/runview`'s skip-log test seeded precisely this shape (a dir with no `run.json`) to exercise its Debug-once path. It can no longer, because the store does not emit such an id at all — the phantom is now stopped one layer earlier and more completely (nothing logged, nothing to dedup). Its corrupt-document half — a `run.json` that exists and does not parse — still covers log-once, and the vanish path remains in code for the case that is genuinely racy (listed, then deleted before the load) rather than permanent, which no fixture can stage deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)