### PR TITLE
feat(usage-cap): stop below the provider's wall, at a percentage you choose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,11 @@ the hours this one spent.
   client (Claude Code, desktop, Cursor): `iterion mcp` setup, the
   `local_*`/`remote_*` tool families, detached-launch semantics,
   `--read-only`, and the `remote_api` escape hatch.
+- [docs/usage-caps.md](docs/usage-caps.md) — capping the LLM
+  subscription below the provider's own wall (`ITERION_USAGE_CAP_*`:
+  soft on the 5h window, hard on the weekly one), where the numbers
+  come from, and the KEDA emergency brake. Read it when bots are eating
+  the forfait an operator also works on.
 - [docs/merge-gate.md](docs/merge-gate.md) — the required check's full life:
   the in-flight claim at launch, the verdict, and the two triggers that
   guarantee a dead review still answers (outcome event + 1-min sweep).

--- a/cmd/iterion/runner.go
+++ b/cmd/iterion/runner.go
@@ -22,6 +22,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/runner"
 	"github.com/SocialGouv/iterion/pkg/secrets"
 	mongostore "github.com/SocialGouv/iterion/pkg/store/mongo"
+	"github.com/SocialGouv/iterion/pkg/usagecap"
 	"github.com/spf13/cobra"
 )
 
@@ -220,6 +221,22 @@ func runRunner(cmd *cobra.Command, _ []string) error {
 		Logger:  logger,
 	})
 
+	// Usage cap: the operator's ceiling on the LLM subscription's own
+	// five-hour / weekly windows. A malformed policy stops the runner
+	// here — every wrong answer downstream fails open, and a fleet that
+	// silently stopped honouring its cap is what this guards against.
+	usageCapPolicy, err := usagecap.FromEnv()
+	if err != nil {
+		return fmt.Errorf("runner: %w", err)
+	}
+	usageCapStore := usagecap.NewMongoStore(st.DB())
+	if usageCapPolicy.Enabled() {
+		if err := usagecap.EnsureSchema(rootCtx, st.DB()); err != nil {
+			return fmt.Errorf("runner: ensure usage_windows schema: %w", err)
+		}
+		logger.Info("runner: usage cap armed — %s", usageCapPolicy)
+	}
+
 	// Bots: where bot-qualified runs resolve their bundle so skills/
 	// mirror into the workspace — same env contract as the server
 	// (the official image sets ITERION_BOTS_PATH=/opt/iterion/bots).
@@ -255,6 +272,8 @@ func runRunner(cmd *cobra.Command, _ []string) error {
 		MemoryStore:       memStore,
 		OrgUsage:          orgUsageCounter,
 		CredPool:          credBroker,
+		UsageCapPolicy:    usageCapPolicy,
+		UsageCaps:         usageCapStore,
 		BotsPaths:         botsPaths,
 		// Sandbox-by-default: the runner is a product entry point like
 		// `iterion run` — an unset ITERION_SANDBOX_DEFAULT resolves to

--- a/docs/usage-caps.md
+++ b/docs/usage-caps.md
@@ -1,0 +1,138 @@
+# Usage caps — stop below the provider's wall
+
+An LLM subscription ("forfait") meters two rolling windows, five hours and
+seven days, and refuses every call once one is exhausted. iterion already
+survives that refusal: the run parks and a durable retry resumes it when the
+window reopens ([scheduling.md](scheduling.md#retry)). What it could not do
+was stop *before* the wall — and the wall is rarely where an operator wants
+to be, because the same subscription usually pays for their own interactive
+work. A fleet of bots that drives it to 100% takes the human down with it.
+
+A **usage cap** is a percentage the operator chooses, enforced from the
+provider's own telemetry.
+
+```sh
+# The recommended posture. Two variables is the whole configuration.
+export ITERION_USAGE_CAP_5H_PCT=85
+export ITERION_USAGE_CAP_WEEK_PCT=75
+```
+
+Nothing is capped by default: an unset cap leaves runs bounded only by the
+provider, which is the historical behaviour.
+
+## The two postures
+
+The windows fail differently, so they default to different postures.
+
+| Window | Default mode | What it does |
+|---|---|---|
+| five-hour | `soft` | Never interrupts work in flight; no NEW run starts |
+| weekly | `hard` | Stops the run where it stands, and starts nothing new |
+
+A five-hour window refills soon, so killing a half-finished run to save
+minutes of quota trades a lot for a little. A weekly window that runs out on
+a Tuesday is a dead week, and the run that would have finished is worth less
+than the four days of headroom it would have eaten.
+
+Either posture ends a capped run the same way: `failed_resumable`, with a
+durable retry armed for the instant the window reopens. **A capped run is not
+a lost run; it is a run that waits.** The cap reuses the provider-refusal
+path wholesale rather than inventing a recovery of its own.
+
+## Configuration
+
+| Variable | Values | Default |
+|---|---|---|
+| `ITERION_USAGE_CAP_5H_PCT` | `0`–`100` (`0`/unset = no cap) | unset |
+| `ITERION_USAGE_CAP_5H_MODE` | `off` \| `soft` \| `hard` | `soft` |
+| `ITERION_USAGE_CAP_WEEK_PCT` | `0`–`100` (`0`/unset = no cap) | unset |
+| `ITERION_USAGE_CAP_WEEK_MODE` | `off` \| `soft` \| `hard` | `hard` |
+| `ITERION_USAGE_CAP` | `off` disarms both caps | unset |
+
+A malformed value **refuses to start** rather than falling back to no cap:
+every wrong answer here fails open, and a guard silently disabled by a typo
+is the failure the feature exists to prevent.
+
+There is deliberately **no per-run flag and no DSL field**. The cap protects
+a credential and the deployment that owns it, not a run — a bot able to lift
+the guard would not be a guard. `ITERION_USAGE_CAP=off` is the escape hatch,
+and it belongs to whoever runs the deployment.
+
+### Which windows a cap governs
+
+The provider reports six windows. `five_hour` is the 5h cap; `seven_day`,
+`seven_day_opus`, `seven_day_sonnet` and `seven_day_overage_included` are all
+governed by the weekly cap — a run refused on the per-model weekly sub-limit
+is refused, whatever the all-models number says. `overage` is **not** capped
+here: it is metered money, not subscription quota, and `--max-cost-usd` is
+what bounds money.
+
+## Where the numbers come from
+
+Claude Code emits a `rate_limit_event` on its stream-json output whenever the
+provider's usage numbers move, carrying `{status, rateLimitType, utilization,
+resetsAt}`. `utilization` is a fraction (0..1); `resetsAt` is Unix seconds.
+That is the only place a subscription's remaining headroom is observable
+from outside the provider — the metered API returns `anthropic-ratelimit-*`
+headers, but a CLI-driven session hides them, and `GET /api/oauth/usage`
+requires a `user:profile` scope that a `claude setup-token` credential does
+not carry.
+
+Consequences worth knowing:
+
+- The cap is **claude_code-shaped today**. Other backends have no equivalent
+  telemetry surface; a run on `claw` or `pi` is not capped.
+- A reading **expires at its own reset instant**. Past it the window has
+  rolled over and the number describes a window that no longer exists, so a
+  stale reading stops blocking by itself — no sweeper, no TTL to tune.
+
+## What it looks like when it fires
+
+- a `usage_cap` event on the run's timeline (`window`, `percent`, `cap`,
+  `mode`, `stopped`, `resets_at`) — the only thing that distinguishes "the
+  provider refused us" from "we stopped ourselves";
+- a warn line in `run.log`: `usage cap: seven_day window at 76% ≥ 75%
+  (week, hard), resets 2026-08-18T21:00:00Z`;
+- the run's own error, carrying the same sentence;
+- then the ordinary wait: `run_retry_scheduled` with `retry_after` at the
+  window's reopening, and `run_auto_resumed` when it fires.
+
+## Cloud
+
+Every pod sees only its own session, so readings are shared through the
+`usage_windows` collection (one document per credential and window, newest
+wins). A claimed run consults it **before** cloning a repo or starting a
+container and parks for free when there is no headroom — otherwise each pod
+would rediscover the ceiling by spending against it.
+
+The ledger is keyed per credential: a tenant that brought its own
+subscription is never blocked by what another tenant spent, and runs falling
+back to the deployment's own credential share one meter, which is correct —
+they really are one subscription.
+
+The pre-flight **fails open** on every uncertainty (no ledger, an unreadable
+ledger, nothing measured yet, a rolled-over reading). A cap exists to protect
+a subscription from a fleet, not to strand the fleet on a bookkeeping outage;
+the in-run guard still stands behind it, so failing open costs one call.
+
+A local CLI or studio run keeps the same policy on a process-local ledger,
+and a second run in the same process starts already knowing what the first
+one measured. There the launch is **refused outright** (`429`, with the
+reason and the reopening instant) rather than parked: the operator is
+present, so an immediate answer beats a queued one.
+
+## Emergency brake
+
+The cap governs iterion. To stop **everything** on a cloud deployment,
+including runs already claimed, freeze the runner instead — queued work
+piles up in NATS and resumes intact on unfreeze:
+
+```sh
+kubectl -n iterion annotate scaledobject iterion-runner \
+  autoscaling.keda.sh/paused-replicas="0" --overwrite   # freeze
+kubectl -n iterion annotate scaledobject iterion-runner \
+  autoscaling.keda.sh/paused-replicas-                  # thaw
+```
+
+Cancel in-flight runs *before* freezing: a pod killed mid-run ends
+`failed` (not resumable), where a cancel checkpoints it.

--- a/pkg/backend/delegate/claude_code_stream.go
+++ b/pkg/backend/delegate/claude_code_stream.go
@@ -14,6 +14,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/backend/delegate/claudesdk"
 	"github.com/SocialGouv/iterion/pkg/backend/thinktokens"
 	"github.com/SocialGouv/iterion/pkg/backend/tooldisplay"
+	"github.com/SocialGouv/iterion/pkg/usagecap"
 
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 )
@@ -374,6 +375,14 @@ func (b *ClaudeCodeBackend) runSession(ctx context.Context, prompt string, task 
 				result = m
 				progressed = true // a turn completed
 				backfillEmptyResult(result, lastAssistantText)
+			case *claudesdk.RateLimitEvent:
+				// The provider's own account of how much of the
+				// subscription is left. Not progress: it arrives on a
+				// timer of the CLI's own, and letting it reset the
+				// forward-progress watchdog would mask a spinning session.
+				if err := b.handleRateLimitEvent(m, task, cancelStream); err != nil {
+					return result, meta, err
+				}
 			default:
 				if it.msg != nil {
 					b.Logger.Debug("[%s#%d/claude-code] 📨 %T message", task.NodeID, task.Iteration, it.msg)
@@ -511,6 +520,42 @@ func (b *ClaudeCodeBackend) handleSystemMessage(m *claudesdk.SystemMessage, task
 		b.Logger.Debug("[%s#%d/claude-code] ⚙️  system/%s session=%s",
 			task.NodeID, task.Iteration, m.Subtype, m.SessionID)
 	}
+}
+
+// handleRateLimitEvent turns the CLI's rate_limit_event into a
+// usagecap.Reading and hands it to the executor's hook, which owns the
+// policy. A hook that answers with an error is stopping the session on a
+// usage cap: cancel the stream and surface the error so the run parks the
+// way a real provider refusal would — the whole point being that iterion
+// decided it, hours before the provider would have.
+//
+// No hook means nobody is watching, and a session must never fail for lack
+// of an observer.
+func (b *ClaudeCodeBackend) handleRateLimitEvent(m *claudesdk.RateLimitEvent, task Task, cancelStream context.CancelFunc) error {
+	if m == nil || task.Hooks.OnUsageWindow == nil {
+		return nil
+	}
+	r := usagecap.Reading{
+		Window:     usagecap.Window(m.Info.RateLimitType),
+		Status:     m.Info.Status,
+		ObservedAt: time.Now().UTC(),
+	}
+	if m.Info.Utilization != nil {
+		r.Utilization = *m.Info.Utilization
+	}
+	if m.Info.ResetsAt != nil {
+		r.ResetsAt = time.Unix(*m.Info.ResetsAt, 0).UTC()
+	}
+	// Debug, not info: the CLI emits one of these whenever the numbers
+	// move, and the operator-facing line is the executor's — it is the
+	// only layer that knows whether this reading crossed anything.
+	b.Logger.Debug("[%s#%d/claude-code] 📊 usage %s %.0f%% status=%s",
+		task.NodeID, task.Iteration, r.Window, r.Percent(), r.Status)
+	if err := task.Hooks.OnUsageWindow(r); err != nil {
+		cancelStream()
+		return err
+	}
+	return nil
 }
 
 // handleAssistantMessage processes a streamed AssistantMessage: logs its

--- a/pkg/backend/delegate/claude_code_usage_test.go
+++ b/pkg/backend/delegate/claude_code_usage_test.go
@@ -1,0 +1,110 @@
+package delegate
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate/claudesdk"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/usagecap"
+)
+
+func ptrF(v float64) *float64 { return &v }
+func ptrI(v int64) *int64     { return &v }
+
+// The two scale conversions are the whole risk of this handler: the CLI
+// reports utilization as a FRACTION and resetsAt as Unix SECONDS. Reading
+// either wrong turns a cap into a number that means nothing — 0.92 read as
+// 92% consumed vs 0.92% consumed decides whether a run stops.
+func TestHandleRateLimitEvent_Conversion(t *testing.T) {
+	var got usagecap.Reading
+	b := &ClaudeCodeBackend{Logger: iterlog.Nop()}
+	task := Task{NodeID: "implement", Hooks: TaskHooks{
+		OnUsageWindow: func(r usagecap.Reading) error { got = r; return nil },
+	}}
+
+	err := b.handleRateLimitEvent(&claudesdk.RateLimitEvent{
+		Info: claudesdk.RateLimitInfo{
+			Status:        "allowed_warning",
+			RateLimitType: "seven_day",
+			Utilization:   ptrF(0.92),
+			ResetsAt:      ptrI(1787086800),
+		},
+	}, task, func() {})
+	if err != nil {
+		t.Fatalf("observer returning nil must let the session run on, got %v", err)
+	}
+	if got.Window != usagecap.WindowSevenDay {
+		t.Errorf("window = %q", got.Window)
+	}
+	if got.Utilization != 0.92 || got.Percent() != 92 {
+		t.Errorf("utilization = %v (%.0f%%), want the fraction 0.92 read as 92%%", got.Utilization, got.Percent())
+	}
+	if want := time.Unix(1787086800, 0).UTC(); !got.ResetsAt.Equal(want) {
+		t.Errorf("resetsAt = %v, want %v — epoch SECONDS", got.ResetsAt, want)
+	}
+	if got.Status != "allowed_warning" || got.ObservedAt.IsZero() {
+		t.Errorf("reading = %+v, want the status carried and an observation instant", got)
+	}
+}
+
+// A refusal carries a status and nothing else. Absent numbers must stay
+// zero-valued rather than being invented, and the policy layer decides.
+func TestHandleRateLimitEvent_AbsentNumbers(t *testing.T) {
+	var got usagecap.Reading
+	b := &ClaudeCodeBackend{Logger: iterlog.Nop()}
+	task := Task{Hooks: TaskHooks{OnUsageWindow: func(r usagecap.Reading) error { got = r; return nil }}}
+
+	if err := b.handleRateLimitEvent(&claudesdk.RateLimitEvent{
+		Info: claudesdk.RateLimitInfo{Status: "rejected", RateLimitType: "five_hour"},
+	}, task, func() {}); err != nil {
+		t.Fatal(err)
+	}
+	if got.Utilization != 0 || !got.ResetsAt.IsZero() {
+		t.Errorf("reading = %+v, want absent numbers left absent", got)
+	}
+	if got.Status != usagecap.StatusRejected {
+		t.Errorf("status = %q, want the refusal carried through", got.Status)
+	}
+}
+
+// The enforcement seam: the backend reports and obeys, the executor decides.
+func TestHandleRateLimitEvent_HookErrorAbortsTheSession(t *testing.T) {
+	sentinel := errors.New("usage cap: week at 99%")
+	cancelled := false
+	b := &ClaudeCodeBackend{Logger: iterlog.Nop()}
+	task := Task{Hooks: TaskHooks{OnUsageWindow: func(usagecap.Reading) error { return sentinel }}}
+
+	err := b.handleRateLimitEvent(&claudesdk.RateLimitEvent{
+		Info: claudesdk.RateLimitInfo{Status: "allowed_warning", RateLimitType: "seven_day", Utilization: ptrF(0.99)},
+	}, task, func() { cancelled = true })
+
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want the hook's own error surfaced verbatim", err)
+	}
+	if !cancelled {
+		// Without this the CLI subprocess keeps streaming — and keeps
+		// spending — after iterion decided to stop.
+		t.Error("the stream must be cancelled when the cap fires")
+	}
+}
+
+// Nobody watching must never be a reason for a session to fail.
+func TestHandleRateLimitEvent_NoObserver(t *testing.T) {
+	b := &ClaudeCodeBackend{Logger: iterlog.Nop()}
+	cancelled := false
+	if err := b.handleRateLimitEvent(&claudesdk.RateLimitEvent{
+		Info: claudesdk.RateLimitInfo{Status: "rejected"},
+	}, Task{}, func() { cancelled = true }); err != nil {
+		t.Fatalf("unexpected error with no hook wired: %v", err)
+	}
+	if cancelled {
+		t.Error("cancelled a session with no cap configured")
+	}
+	if err := b.handleRateLimitEvent(nil, Task{Hooks: TaskHooks{
+		OnUsageWindow: func(usagecap.Reading) error { return errors.New("must not run") },
+	}}, func() {}); err != nil {
+		t.Fatalf("a nil event must be ignored, got %v", err)
+	}
+}

--- a/pkg/backend/delegate/claudesdk/message.go
+++ b/pkg/backend/delegate/claudesdk/message.go
@@ -7,7 +7,7 @@ import (
 
 // Message is a sealed interface for NDJSON messages from the CLI.
 // Concrete types: [SystemMessage], [AssistantMessage], [UserMessage],
-// [ResultMessage], [StreamEvent].
+// [ResultMessage], [StreamEvent], [RateLimitEvent].
 type Message interface {
 	messageType() string
 	sealed()
@@ -224,6 +224,43 @@ type StreamEvent struct {
 func (*StreamEvent) messageType() string { return "stream_event" }
 func (*StreamEvent) sealed()             {}
 
+// RateLimitInfo is the CLI's view of one provider usage window, emitted
+// whenever the numbers change. It is the only place a subscription's
+// remaining headroom is observable from outside the provider: the metered
+// API returns rate-limit headers, but a CLI-driven session hides them.
+//
+// Every field but Status is optional on the wire — a "rejected" can arrive
+// with no utilization and no reset instant — so the pointers are load
+// bearing: 0 and "absent" are different answers here.
+type RateLimitInfo struct {
+	// Status is "allowed", "allowed_warning" or "rejected".
+	Status string `json:"status"`
+	// RateLimitType names the window: five_hour, seven_day,
+	// seven_day_opus, seven_day_sonnet, seven_day_overage_included,
+	// overage.
+	RateLimitType string `json:"rateLimitType,omitempty"`
+	// Utilization is the FRACTION of the window consumed (0..1), not a
+	// percentage.
+	Utilization *float64 `json:"utilization,omitempty"`
+	// ResetsAt is a Unix timestamp in SECONDS.
+	ResetsAt *int64 `json:"resetsAt,omitempty"`
+	// OverageStatus / OverageResetsAt describe the paid spill-over
+	// channel, carried for diagnostics.
+	OverageStatus   string `json:"overageStatus,omitempty"`
+	OverageResetsAt *int64 `json:"overageResetsAt,omitempty"`
+}
+
+// RateLimitEvent reports a change in the provider's usage-window state.
+type RateLimitEvent struct {
+	Type      string        `json:"type"` // "rate_limit_event"
+	UUID      string        `json:"uuid"`
+	SessionID string        `json:"session_id"`
+	Info      RateLimitInfo `json:"rate_limit_info"`
+}
+
+func (*RateLimitEvent) messageType() string { return "rate_limit_event" }
+func (*RateLimitEvent) sealed()             {}
+
 // unmarshalMessage dispatches a raw JSON line to the correct Message type.
 func unmarshalMessage(data []byte) (Message, error) {
 	var probe struct {
@@ -253,6 +290,10 @@ func unmarshalMessage(data []byte) (Message, error) {
 		msg = &m
 	case "stream_event":
 		var m StreamEvent
+		err = json.Unmarshal(data, &m)
+		msg = &m
+	case "rate_limit_event":
+		var m RateLimitEvent
 		err = json.Unmarshal(data, &m)
 		msg = &m
 	default:

--- a/pkg/backend/delegate/claudesdk/protocol.go
+++ b/pkg/backend/delegate/claudesdk/protocol.go
@@ -45,7 +45,7 @@ func isControlResponse(rm *rawMessage) bool {
 // isMessage returns true if the line is a regular message (not control protocol).
 func isMessage(rm *rawMessage) bool {
 	switch rm.Type {
-	case "system", "assistant", "user", "result", "stream_event":
+	case "system", "assistant", "user", "result", "stream_event", "rate_limit_event":
 		return true
 	}
 	return false

--- a/pkg/backend/delegate/claudesdk/ratelimit_test.go
+++ b/pkg/backend/delegate/claudesdk/ratelimit_test.go
@@ -1,0 +1,63 @@
+package claudesdk
+
+import (
+	"testing"
+)
+
+// The wire shape is the CLI's own schema (claude 2.1.220):
+//
+//	{type: "rate_limit_event", rate_limit_info: {status, rateLimitType,
+//	 utilization, resetsAt}, uuid, session_id}
+//
+// Utilization is a FRACTION, resetsAt is Unix SECONDS, and every field but
+// status is optional — reading any of those three wrong turns a cap into a
+// number that means nothing.
+func TestUnmarshalRateLimitEvent(t *testing.T) {
+	line := []byte(`{"type":"rate_limit_event","rate_limit_info":{"status":"allowed_warning","rateLimitType":"seven_day","utilization":0.92,"resetsAt":1787086800},"uuid":"c0ffee","session_id":"sess-1"}`)
+
+	msg, err := unmarshalMessage(line)
+	if err != nil {
+		t.Fatalf("unmarshalMessage: %v", err)
+	}
+	ev, ok := msg.(*RateLimitEvent)
+	if !ok {
+		t.Fatalf("got %T, want *RateLimitEvent", msg)
+	}
+	if ev.Info.Status != "allowed_warning" || ev.Info.RateLimitType != "seven_day" {
+		t.Errorf("info = %+v", ev.Info)
+	}
+	if ev.Info.Utilization == nil || *ev.Info.Utilization != 0.92 {
+		t.Errorf("utilization = %v, want the raw fraction 0.92", ev.Info.Utilization)
+	}
+	if ev.Info.ResetsAt == nil || *ev.Info.ResetsAt != 1787086800 {
+		t.Errorf("resetsAt = %v, want the epoch seconds verbatim", ev.Info.ResetsAt)
+	}
+	if ev.SessionID != "sess-1" {
+		t.Errorf("session_id = %q", ev.SessionID)
+	}
+}
+
+// A refusal arrives with a status and nothing else. Defaulting the absent
+// utilization to 0 would read as "0% consumed" — the opposite of the truth —
+// so the pointer must stay nil and let the policy layer decide.
+func TestUnmarshalRateLimitEvent_RejectedWithoutNumbers(t *testing.T) {
+	msg, err := unmarshalMessage([]byte(`{"type":"rate_limit_event","rate_limit_info":{"status":"rejected"},"uuid":"u","session_id":"s"}`))
+	if err != nil {
+		t.Fatalf("unmarshalMessage: %v", err)
+	}
+	ev := msg.(*RateLimitEvent)
+	if ev.Info.Status != "rejected" {
+		t.Fatalf("status = %q", ev.Info.Status)
+	}
+	if ev.Info.Utilization != nil || ev.Info.ResetsAt != nil {
+		t.Errorf("absent fields must stay absent, got %+v", ev.Info)
+	}
+}
+
+// The session read loop drops anything isMessage rejects, so a type missing
+// from that list never reaches a consumer however well it parses.
+func TestRateLimitEventIsRoutedAsAMessage(t *testing.T) {
+	if !isMessage(&rawMessage{Type: "rate_limit_event"}) {
+		t.Fatal("rate_limit_event must be routed to the message stream")
+	}
+}

--- a/pkg/backend/delegate/delegate.go
+++ b/pkg/backend/delegate/delegate.go
@@ -19,6 +19,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/plugin"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
 	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/usagecap"
 )
 
 // Backend name constants used for registration and dispatch.
@@ -1038,6 +1039,19 @@ type TaskHooks struct {
 	// while it works. Runs on the stream-handling goroutine: must not
 	// block.
 	OnAssistantText func(text string)
+
+	// OnUsageWindow fires when the backend observes the provider's own
+	// usage-window telemetry — how much of the subscription's five-hour
+	// and weekly windows is spent (claude_code's rate_limit_event; other
+	// backends have no equivalent surface yet).
+	//
+	// Returning a non-nil error ABORTS the session with that error. That
+	// is the enforcement seam for a usage cap: the backend reports and
+	// obeys, the executor decides. Returning nil lets the session run on,
+	// which is what an observer-only caller does.
+	//
+	// Runs on the stream-handling goroutine: must not block.
+	OnUsageWindow func(usagecap.Reading) error
 }
 
 // TurnFinishedInfo is the payload of the TaskHooks.OnTurnFinished
@@ -1286,6 +1300,14 @@ type ErrRateLimited struct {
 	// text ("resets 3pm", "reset at 2026-07-17 19:00"). Zero when not
 	// parseable — callers must not depend on it.
 	ResetAt time.Time
+	// SelfImposed marks a refusal iterion RAISED rather than received: the
+	// operator's usage cap firing below the provider's own wall (see
+	// pkg/usagecap). Everything downstream — park, durable retry, resume —
+	// treats it exactly like the provider's refusal, which is the point.
+	// The one behaviour it must change is the in-place retry: re-issuing
+	// the call would spend precisely the quota the cap exists to protect,
+	// and the provider would answer it perfectly happily.
+	SelfImposed bool
 }
 
 // ErrRateLimited.Kind values.

--- a/pkg/backend/model/events.go
+++ b/pkg/backend/model/events.go
@@ -76,6 +76,19 @@ type AssistantTextInfo struct {
 	Iteration int
 }
 
+// UsageCapInfo describes a usage-cap crossing, passed to the OnUsageCap
+// hook. Stopped distinguishes the two postures: a soft cap fires this event
+// and lets the run finish, a hard cap fires it and ends the run.
+type UsageCapInfo struct {
+	Window   string
+	Family   string
+	Percent  float64
+	Cap      float64
+	Mode     string
+	Stopped  bool
+	ResetsAt time.Time
+}
+
 // LLMToolCallInfo describes a tool call execution, passed to the OnToolCall hook.
 type LLMToolCallInfo struct {
 	ToolName  string

--- a/pkg/backend/model/executor.go
+++ b/pkg/backend/model/executor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/knowledge"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
+	"github.com/SocialGouv/iterion/pkg/usagecap"
 )
 
 // ---------------------------------------------------------------------------
@@ -134,6 +135,12 @@ type ClawExecutor struct {
 	permAskRules   []string
 	permDenyRules  []string
 	permEnvDefault string
+
+	// usageGuard enforces the operator's subscription usage cap from the
+	// provider's own telemetry (pkg/usagecap). Nil = no cap, so the run is
+	// bounded only by the provider's wall. Shared across the run's nodes:
+	// the windows it watches are the credential's, not a node's.
+	usageGuard *usagecap.Guard
 
 	// sandbox is the live [sandbox.Run] for the current iterion run,
 	// or nil when the workflow doesn't activate a sandbox. The engine
@@ -385,6 +392,13 @@ func WithAutoMemoryOverride(mode string) ClawExecutorOption {
 // pass the Mongo store, which is what makes MEMORY.md survive the pod.
 func WithAutoMemoryStore(ms knowledge.MemoryStore) ClawExecutorOption {
 	return func(e *ClawExecutor) { e.autoMemStore = ms }
+}
+
+// WithUsageGuard arms the operator's subscription usage cap for this run
+// (see pkg/usagecap). Nil — the default — leaves the run governed only by
+// the provider's own wall, which is the historical behaviour.
+func WithUsageGuard(g *usagecap.Guard) ClawExecutorOption {
+	return func(e *ClawExecutor) { e.usageGuard = g }
 }
 
 // WithRewriteChain sets the active rewriter chain (the enabled rewriter
@@ -934,6 +948,52 @@ func (e *ClawExecutor) delegateHooksFor(nodeID string, backendName string, itera
 		fn := e.hooks.OnAssistantText
 		h.OnAssistantText = func(text string) {
 			fn(nodeID, AssistantTextInfo{Text: text, Iteration: iteration})
+		}
+	}
+	// Usage cap: the backend reports the provider's own window telemetry,
+	// the guard decides. A hard cap answers with the same usage-window
+	// error a real refusal produces, so the run parks and a durable retry
+	// resumes it once the window reopens — the operator's ceiling reuses
+	// the provider's recovery path rather than inventing one.
+	if e.usageGuard != nil {
+		guard := e.usageGuard
+		capHook := e.hooks.OnUsageCap
+		h.OnUsageWindow = func(r usagecap.Reading) error {
+			d := guard.Observe(r)
+			if !d.Blocked {
+				return nil
+			}
+			if capHook != nil {
+				capHook(nodeID, UsageCapInfo{
+					Window:   string(d.Window),
+					Family:   string(d.Family),
+					Percent:  d.Percent,
+					Cap:      d.Cap,
+					Mode:     string(guard.Policy().For(d.Family).Mode),
+					Stopped:  d.Stop,
+					ResetsAt: d.ResetsAt,
+				})
+			}
+			if !d.Stop {
+				// Soft: this run keeps its half-done work; the pre-flight
+				// gate is what stops the NEXT one from starting.
+				if e.logger != nil {
+					e.logger.Warn("[%s#%d/%s] %s — finishing this run, starting no new work",
+						nodeID, iteration, backendName, d.Reason)
+				}
+				return nil
+			}
+			if e.logger != nil {
+				e.logger.Warn("[%s#%d/%s] %s — stopping the run; it resumes when the window reopens",
+					nodeID, iteration, backendName, d.Reason)
+			}
+			return &delegate.ErrRateLimited{
+				Provider:    backendName,
+				Detail:      d.Reason,
+				Kind:        delegate.RateLimitKindUsageWindow,
+				ResetAt:     d.ResetsAt,
+				SelfImposed: true,
+			}
 		}
 	}
 	if e.hooks.OnLLMTurnCapture != nil {

--- a/pkg/backend/model/executor_hooks.go
+++ b/pkg/backend/model/executor_hooks.go
@@ -111,9 +111,15 @@ type EventHooks struct {
 	// an opaque []byte (JSON-encoded []api.Message) so EventHooks
 	// stays neutral to the wire format.
 	OnLLMTurnCapture func(nodeID string, info LLMTurnCaptureInfo)
-	OnLLMCompacted   func(nodeID string, info LLMCompactInfo)
-	OnToolStarted    func(nodeID string, info LLMToolStartedInfo)
-	OnToolCall       func(nodeID string, info LLMToolCallInfo)
+	// OnUsageCap fires when a reading of the provider's subscription
+	// telemetry crosses an operator-configured cap (pkg/usagecap). Purely
+	// observational — the executor has already decided whether to stop the
+	// run by the time it fires — but it is the only place the timeline
+	// learns that iterion stopped itself rather than being refused.
+	OnUsageCap     func(nodeID string, info UsageCapInfo)
+	OnLLMCompacted func(nodeID string, info LLMCompactInfo)
+	OnToolStarted  func(nodeID string, info LLMToolStartedInfo)
+	OnToolCall     func(nodeID string, info LLMToolCallInfo)
 	// OnToolNodeResult is called for direct tool nodes (not LLM tool loops)
 	// with full input/output content for detailed logging.
 	OnToolNodeResult func(nodeID string, toolName string, input []byte, output string, elapsed time.Duration, err error)

--- a/pkg/backend/model/executor_retry.go
+++ b/pkg/backend/model/executor_retry.go
@@ -73,7 +73,13 @@ func isDelegateRetryable(err error) bool {
 	}
 	var rateLimited *delegate.ErrRateLimited
 	if errors.As(err, &rateLimited) {
-		return true
+		// Except when iterion raised it: re-issuing the call would spend
+		// exactly the quota the operator's cap exists to protect, and the
+		// provider — still under its own wall — would serve it. The run
+		// parks instead and a durable retry brings it back once the window
+		// has really reopened (pkg/runner/usage_retry.go). A refusal that
+		// came FROM the provider keeps its historical in-place budget.
+		return !rateLimited.SelfImposed
 	}
 	// Transient connectivity failure (DNS / TCP / TLS / upstream 5xx) — a
 	// net.Error, a wrapped syscall errno, or a stringified marker bubbled up

--- a/pkg/backend/model/hooks.go
+++ b/pkg/backend/model/hooks.go
@@ -476,6 +476,23 @@ func (h *storeHooks) onAssistantText(nodeID string, info AssistantTextInfo) {
 	})
 }
 
+// onUsageCap implements the OnUsageCap hook: it records that the
+// operator's own ceiling — not the provider's — is what governed this run.
+func (h *storeHooks) onUsageCap(nodeID string, info UsageCapInfo) {
+	data := map[string]any{
+		"window":  info.Window,
+		"family":  info.Family,
+		"percent": info.Percent,
+		"cap":     info.Cap,
+		"mode":    info.Mode,
+		"stopped": info.Stopped,
+	}
+	if !info.ResetsAt.IsZero() {
+		data["resets_at"] = info.ResetsAt.UTC().Format(time.RFC3339)
+	}
+	h.emit(nodeID, store.EventUsageCap, data)
+}
+
 // isLikelyStructuredPayload reports whether text is a bare JSON object
 // or array — the shape of a structured-output answer rather than
 // human-facing narration.
@@ -968,6 +985,7 @@ func NewStoreEventHooks(ctx context.Context, emitter EventEmitter, runID string,
 		OnLLMRetry:         h.onLLMRetry,
 		OnLLMStepFinish:    h.onLLMStepFinish,
 		OnAssistantText:    h.onAssistantText,
+		OnUsageCap:         h.onUsageCap,
 		OnLLMTurnCapture:   h.onLLMTurnCapture,
 		OnLLMCompacted:     h.onLLMCompacted,
 		OnToolStarted:      h.onToolStarted,

--- a/pkg/backend/model/usage_cap_test.go
+++ b/pkg/backend/model/usage_cap_test.go
@@ -1,0 +1,153 @@
+package model
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/usagecap"
+)
+
+func capPolicy() usagecap.Policy {
+	return usagecap.Policy{
+		FiveHour: usagecap.WindowPolicy{MaxPercent: 85, Mode: usagecap.ModeSoft},
+		Week:     usagecap.WindowPolicy{MaxPercent: 75, Mode: usagecap.ModeHard},
+	}
+}
+
+func usageHook(t *testing.T, guard *usagecap.Guard, hooks EventHooks) func(usagecap.Reading) error {
+	t.Helper()
+	opts := []ClawExecutorOption{WithUsageGuard(guard)}
+	opts = append(opts, WithEventHooks(hooks))
+	e := NewClawExecutor(NewRegistry(), &ir.Workflow{}, opts...)
+	h := e.delegateHooksFor("implement", delegate.BackendClaudeCode, 0)
+	if h.OnUsageWindow == nil {
+		t.Fatal("OnUsageWindow not wired — the backend would observe the provider and tell nobody")
+	}
+	return h.OnUsageWindow
+}
+
+// The whole point of the hard posture: iterion raises the SAME error the
+// provider raises at its own wall, so the run parks and a durable retry
+// brings it back — no new recovery path to get right.
+func TestUsageGuardBridge_HardCapRaisesAUsageWindowError(t *testing.T) {
+	resets := time.Date(2026, 8, 18, 21, 0, 0, 0, time.UTC)
+	hook := usageHook(t, usagecap.NewGuard(capPolicy(), nil), EventHooks{})
+
+	err := hook(usagecap.Reading{
+		Window:      usagecap.WindowSevenDay,
+		Utilization: 0.76,
+		Status:      usagecap.StatusWarning,
+		ResetsAt:    resets,
+	})
+	if err == nil {
+		t.Fatal("want an error stopping the session at 76% against a 75% hard cap")
+	}
+	var rl *delegate.ErrRateLimited
+	if !errors.As(err, &rl) {
+		t.Fatalf("got %T (%v), want *delegate.ErrRateLimited", err, err)
+	}
+	// Kind is what routes the run to the park-and-resume path instead of
+	// the DLQ; ResetAt is when it comes back.
+	if rl.Kind != delegate.RateLimitKindUsageWindow {
+		t.Errorf("Kind = %q, want %q", rl.Kind, delegate.RateLimitKindUsageWindow)
+	}
+	if !rl.ResetAt.Equal(resets) {
+		t.Errorf("ResetAt = %v, want %v", rl.ResetAt, resets)
+	}
+}
+
+// Soft is the promise that a half-finished run is never sacrificed to save
+// minutes of a window that refills soon.
+func TestUsageGuardBridge_SoftCapLetsTheRunFinish(t *testing.T) {
+	hook := usageHook(t, usagecap.NewGuard(capPolicy(), nil), EventHooks{})
+	if err := hook(usagecap.Reading{
+		Window:      usagecap.WindowFiveHour,
+		Utilization: 0.99,
+		Status:      usagecap.StatusWarning,
+	}); err != nil {
+		t.Fatalf("soft cap returned %v — it must not stop work in flight", err)
+	}
+}
+
+func TestUsageGuardBridge_UnderTheCapIsSilent(t *testing.T) {
+	var fired []UsageCapInfo
+	hook := usageHook(t, usagecap.NewGuard(capPolicy(), nil), EventHooks{
+		OnUsageCap: func(_ string, info UsageCapInfo) { fired = append(fired, info) },
+	})
+	if err := hook(usagecap.Reading{Window: usagecap.WindowSevenDay, Utilization: 0.40}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fired) != 0 {
+		t.Fatalf("emitted %d cap events below the cap, want none", len(fired))
+	}
+}
+
+// The timeline must be able to tell "the provider refused us" from "we
+// stopped ourselves" — both end a run the same way otherwise.
+func TestUsageGuardBridge_EmitsTheCrossing(t *testing.T) {
+	var fired []UsageCapInfo
+	hooks := EventHooks{OnUsageCap: func(_ string, info UsageCapInfo) { fired = append(fired, info) }}
+	hook := usageHook(t, usagecap.NewGuard(capPolicy(), nil), hooks)
+
+	_ = hook(usagecap.Reading{Window: usagecap.WindowFiveHour, Utilization: 0.90})
+	_ = hook(usagecap.Reading{Window: usagecap.WindowSevenDay, Utilization: 0.90})
+
+	if len(fired) != 2 {
+		t.Fatalf("got %d cap events, want 2", len(fired))
+	}
+	if fired[0].Stopped || fired[0].Mode != string(usagecap.ModeSoft) {
+		t.Errorf("5h crossing = %+v, want a soft, non-stopping event", fired[0])
+	}
+	if !fired[1].Stopped || fired[1].Mode != string(usagecap.ModeHard) {
+		t.Errorf("week crossing = %+v, want a hard, stopping event", fired[1])
+	}
+	if fired[1].Percent != 90 || fired[1].Cap != 75 {
+		t.Errorf("percent/cap = %v/%v, want 90/75 on the operator-facing scale", fired[1].Percent, fired[1].Cap)
+	}
+}
+
+func TestUsageGuardBridge_NoGuardNoHook(t *testing.T) {
+	e := NewClawExecutor(NewRegistry(), &ir.Workflow{})
+	if h := e.delegateHooksFor("implement", delegate.BackendClaudeCode, 0); h.OnUsageWindow != nil {
+		t.Fatal("a run with no cap must not carry a usage hook at all")
+	}
+}
+
+// Retrying a cap in place would spend exactly the quota it protects — and
+// the provider, still under its own wall, would serve the call. A refusal
+// that came FROM the provider keeps its historical in-place budget (the
+// fallback chain of ADR-087 depends on it).
+func TestSelfImposedRefusalIsNotLocallyRetried(t *testing.T) {
+	capped := &delegate.ErrRateLimited{
+		Kind:        delegate.RateLimitKindUsageWindow,
+		SelfImposed: true,
+		Detail:      "usage cap: seven_day window at 76% ≥ 75%",
+	}
+	if isDelegateRetryable(capped) {
+		t.Error("iterion's own cap must not be retried in place")
+	}
+	providerWall := &delegate.ErrRateLimited{Kind: delegate.RateLimitKindUsageWindow, Detail: "weekly limit"}
+	if !isDelegateRetryable(providerWall) {
+		t.Error("a provider refusal keeps its existing in-place budget")
+	}
+	if !isDelegateRetryable(&delegate.ErrRateLimited{Kind: delegate.RateLimitKindTransient}) {
+		t.Error("a plain throttle is still worth retrying soon")
+	}
+}
+
+// The bridge must stamp it, or the run burns its retry budget against the
+// cap before parking.
+func TestUsageGuardBridge_MarksTheErrorSelfImposed(t *testing.T) {
+	hook := usageHook(t, usagecap.NewGuard(capPolicy(), nil), EventHooks{})
+	err := hook(usagecap.Reading{Window: usagecap.WindowSevenDay, Utilization: 0.99})
+	var rl *delegate.ErrRateLimited
+	if !errors.As(err, &rl) || !rl.SelfImposed {
+		t.Fatalf("err = %v (self-imposed=%v), want a self-imposed refusal", err, rl != nil && rl.SelfImposed)
+	}
+	if isDelegateRetryable(err) {
+		t.Error("the cap error must not be locally retryable")
+	}
+}

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -54,6 +54,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/secrets"
 	"github.com/SocialGouv/iterion/pkg/store"
 	"github.com/SocialGouv/iterion/pkg/trigger"
+	"github.com/SocialGouv/iterion/pkg/usagecap"
 )
 
 const tracerName = "github.com/SocialGouv/iterion/pkg/runner"
@@ -450,6 +451,17 @@ type Config struct {
 	// keeps the STORE record fresh, and the runner re-reads it via
 	// RunBundle.GenericSecretRefs. nil → no refresh (snapshot only).
 	GenericSecrets secrets.GenericSecretStore
+
+	// UsageCapPolicy is the operator's ceiling on the LLM subscription's
+	// own usage windows (pkg/usagecap), resolved machine-wide at startup.
+	// The zero value caps nothing, which leaves runs bounded only by the
+	// provider's wall — the historical behaviour.
+	UsageCapPolicy usagecap.Policy
+	// UsageCaps is where readings of those windows are shared across
+	// replicas, so a pod can park a run before spending anything on
+	// rediscovering a ceiling another pod already hit. nil disables the
+	// pre-flight; the in-run guard still applies.
+	UsageCaps usagecap.Store
 
 	// OrgUsage, when non-nil, receives each run's accumulated LLM
 	// cost/tokens into the org's monthly bucket at the end of every
@@ -1157,6 +1169,15 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 		defer cleanup()
 	}
 
+	// Usage cap, pre-flight. Placed after the credentials (which name the
+	// subscription this run would draw on) and before the clone and the
+	// container: at this point the run has cost nothing yet, so a capped
+	// run parks for free instead of paying a workspace and one LLM call to
+	// rediscover a ceiling another pod already measured.
+	if capErr := r.usageCapPreflight(ctx, msg, r.cfg.Logger); capErr != nil {
+		return capErr
+	}
+
 	// Workspace: an inbound webhook/repo-bound run carries RepoURL/RepoSHA —
 	// clone it into a per-run dir (authed with the bound forge token for a
 	// private repo) and point the engine there so ${PROJECT_DIR} is the repo
@@ -1612,6 +1633,10 @@ func (r *Runner) buildExecutor(ctx context.Context, msg *queue.RunMessage, wf *i
 		// DSL says `on` would run with memory on — the knob failing open.
 		AutoMemory:  msg.AutoMemory,
 		MemoryStore: r.cfg.MemoryStore,
+		// The operator's subscription ceiling, published to the shared
+		// store as this run measures it — the pod is where the provider's
+		// telemetry is observable, and the only place it can be captured.
+		UsageGuard: r.usageGuardFor(ctx, msg, logger),
 	})
 	if err != nil {
 		return nil, nil, err

--- a/pkg/runner/usage_cap.go
+++ b/pkg/runner/usage_cap.go
@@ -1,0 +1,131 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/usagecap"
+)
+
+// The operator's subscription cap, runner side.
+//
+// Two jobs live here. The first is PUBLISHING what a run measures: every
+// pod sees only its own session, so without a shared record each of them
+// rediscovers the ceiling by spending against it. The second is the
+// PRE-FLIGHT: a claimed run asks what the fleet already knows before it
+// clones a repo or starts a container, and parks for free when the answer
+// is "no headroom".
+//
+// Parking reuses the provider-refusal path wholesale (usage_retry.go): the
+// run is marked failed_resumable with the cap as its error, a durable retry
+// is armed for the instant the window reopens, and the delivery is acked.
+// The operator's ceiling therefore inherits, for free, the one property
+// that matters — a capped run is not lost, it is waiting.
+
+// usageCapKey identifies the credential whose windows a run draws on.
+//
+// A tenant that brought its own subscription must not be blocked by what
+// another tenant spent, and runs that fall back to the deployment's own
+// credential must be pooled together — they really are one meter. The run's
+// resolved credentials answer both: a bundle carrying an Anthropic key or
+// OAuth dir is the tenant's own, anything else is the platform's.
+func usageCapKey(ctx context.Context, msg *queue.RunMessage) string {
+	scope := usagecap.ScopePlatform
+	if creds, ok := secrets.CredentialsFromContext(ctx); ok {
+		if creds.APIKey(secrets.ProviderAnthropic) != "" || creds.OAuthDir(delegate.BackendClaudeCode) != "" {
+			scope = usagecap.TenantScope(msg.TenantID)
+		}
+	}
+	return usagecap.Key(delegate.BackendClaudeCode, scope)
+}
+
+// usageGuardFor builds the guard for one run: the machine-wide policy, with
+// every reading published to the shared store under the run's credential
+// key. Returns nil when no cap is configured, which keeps the whole feature
+// out of the way of a deployment that never asked for it.
+func (r *Runner) usageGuardFor(ctx context.Context, msg *queue.RunMessage, logger *iterlog.Logger) *usagecap.Guard {
+	if !r.cfg.UsageCapPolicy.Enabled() {
+		return nil
+	}
+	key := usageCapKey(ctx, msg)
+	store := r.cfg.UsageCaps
+	return usagecap.NewGuard(r.cfg.UsageCapPolicy, func(reading usagecap.Reading) {
+		if store == nil {
+			return
+		}
+		// Detached: the reading that stops a run arrives exactly as that
+		// run's context is about to be cancelled, and it is the single
+		// most valuable thing to publish.
+		wctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), usageCapStoreTimeout)
+		defer cancel()
+		if err := store.Record(wctx, key, reading); err != nil && logger != nil {
+			// Best effort by design: an unpublished reading costs the next
+			// pod a wasted call, never this run its correctness.
+			logger.Warn("runner: publish usage reading (%s): %v", key, err)
+		}
+	})
+}
+
+// usageCapStoreTimeout bounds the shared-store round trips. Short: a wedged
+// store must never hold a run's stream goroutine, and both callers degrade
+// safely (publish is best effort, pre-flight fails open).
+const usageCapStoreTimeout = 5 * time.Second
+
+// usageCapPreflight reports the error a claimed run should fail with when
+// the operator's cap leaves no headroom, or nil to proceed.
+//
+// It FAILS OPEN on every uncertainty — no policy, no store, an unreadable
+// store, nothing measured yet, a reading whose window has since rolled over.
+// A cap exists to protect a subscription from a fleet of bots, not to strand
+// the fleet when its bookkeeping is unavailable: the mid-run guard is still
+// armed behind it, so the worst case of failing open is one wasted call.
+func (r *Runner) usageCapPreflight(ctx context.Context, msg *queue.RunMessage, logger *iterlog.Logger) error {
+	pol := r.cfg.UsageCapPolicy
+	if !pol.Enabled() || r.cfg.UsageCaps == nil {
+		return nil
+	}
+	rctx, cancel := context.WithTimeout(ctx, usageCapStoreTimeout)
+	defer cancel()
+	key := usageCapKey(ctx, msg)
+	readings, err := r.cfg.UsageCaps.Latest(rctx, key)
+	if err != nil {
+		if logger != nil {
+			logger.Warn("runner: usage-cap pre-flight read (%s): %v — proceeding", key, err)
+		}
+		return nil
+	}
+	d := usagecap.Preflight(readings, pol, time.Now().UTC(), usagecap.DefaultMaxAge)
+	if !d.Blocked {
+		return nil
+	}
+	if logger != nil {
+		logger.Warn("runner: run %s not started — %s", msg.RunID, d.Reason)
+	}
+	// The status flip is what makes the retry armable: ScheduleRunRetry
+	// conditions on failed_resumable, and a run stopped before its first
+	// node has never been marked anything. Without this the retry silently
+	// fails to arm and the run is acked into nothing.
+	if r.cfg.Store != nil {
+		sctx, scancel := context.WithTimeout(context.WithoutCancel(ctx), usageCapStoreTimeout)
+		defer scancel()
+		sctx = store.WithIdentity(sctx, msg.TenantID, msg.OwnerID)
+		if _, serr := r.cfg.Store.UpdateRunStatusIf(sctx, msg.RunID, store.RunStatusFailedResumable,
+			d.Reason,
+			[]store.RunStatus{store.RunStatusRunning, store.RunStatusQueued}); serr != nil && logger != nil {
+			logger.Warn("runner: usage-cap status flip for %s: %v", msg.RunID, serr)
+		}
+	}
+	return &delegate.ErrRateLimited{
+		Provider:    delegate.BackendClaudeCode,
+		Detail:      fmt.Sprintf("%s (not started)", d.Reason),
+		Kind:        delegate.RateLimitKindUsageWindow,
+		ResetAt:     d.ResetsAt,
+		SelfImposed: true,
+	}
+}

--- a/pkg/runner/usage_cap_test.go
+++ b/pkg/runner/usage_cap_test.go
@@ -1,0 +1,234 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/usagecap"
+)
+
+// capStatusStore records the status flip the pre-flight must perform: the
+// durable retry conditions on failed_resumable, so a run stopped before its
+// first node has to be MARKED before the park path can arm anything.
+type capStatusStore struct {
+	store.RunStore
+	gotStatus store.RunStatus
+	gotErr    string
+	gotFrom   []store.RunStatus
+	calls     int
+}
+
+func (s *capStatusStore) UpdateRunStatusIf(_ context.Context, _ string, status store.RunStatus, runErr string, from []store.RunStatus) (bool, error) {
+	s.calls++
+	s.gotStatus = status
+	s.gotErr = runErr
+	s.gotFrom = from
+	return true, nil
+}
+
+type failingCapStore struct{ usagecap.Store }
+
+func (failingCapStore) Latest(context.Context, string) ([]usagecap.Reading, error) {
+	return nil, errors.New("store unavailable")
+}
+
+func capTestPolicy() usagecap.Policy {
+	return usagecap.Policy{
+		FiveHour: usagecap.WindowPolicy{MaxPercent: 85, Mode: usagecap.ModeSoft},
+		Week:     usagecap.WindowPolicy{MaxPercent: 75, Mode: usagecap.ModeHard},
+	}
+}
+
+func capRunner(pol usagecap.Policy, caps usagecap.Store, rs store.RunStore) *Runner {
+	return &Runner{cfg: Config{
+		Logger:         iterlog.Nop(),
+		UsageCapPolicy: pol,
+		UsageCaps:      caps,
+		Store:          rs,
+	}}
+}
+
+func TestUsageCapPreflight_BlocksBeforeSpendingAnything(t *testing.T) {
+	ctx := t.Context()
+	resets := time.Now().UTC().Add(30 * time.Hour)
+	caps := usagecap.NewMemStore()
+	key := usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform)
+	if err := caps.Record(ctx, key, usagecap.Reading{
+		Window:      usagecap.WindowSevenDay,
+		Utilization: 0.92,
+		Status:      usagecap.StatusWarning,
+		ResetsAt:    resets,
+		ObservedAt:  time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rs := &capStatusStore{}
+	r := capRunner(capTestPolicy(), caps, rs)
+
+	err := r.usageCapPreflight(ctx, &queue.RunMessage{RunID: "run-1"}, iterlog.Nop())
+	if err == nil {
+		t.Fatal("want the run refused: the weekly window is at 92% against a 75% cap")
+	}
+	var rl *delegate.ErrRateLimited
+	if !errors.As(err, &rl) {
+		t.Fatalf("got %T, want *delegate.ErrRateLimited so the park path recognises it", err)
+	}
+	// Kind is what routes it to the usage-window park (and away from the
+	// DLQ); SelfImposed keeps it out of the in-place retry budget.
+	if rl.Kind != delegate.RateLimitKindUsageWindow || !rl.SelfImposed {
+		t.Errorf("kind=%q self-imposed=%v", rl.Kind, rl.SelfImposed)
+	}
+	if !rl.ResetAt.Equal(resets) {
+		t.Errorf("ResetAt = %v, want the window's own reopening %v", rl.ResetAt, resets)
+	}
+	if rs.calls != 1 || rs.gotStatus != store.RunStatusFailedResumable {
+		t.Fatalf("status flip: calls=%d status=%q — without failed_resumable the retry cannot arm", rs.calls, rs.gotStatus)
+	}
+	if rs.gotErr == "" {
+		t.Error("the run must say why it did not start")
+	}
+	// Only a run this pod has just claimed may be flipped: an operator who
+	// paused or cancelled it in the meantime must win.
+	if len(rs.gotFrom) == 0 {
+		t.Error("the flip must be conditional on the run still being claimed")
+	}
+}
+
+// Failing open is the deliberate posture: the mid-run guard still stands
+// behind the pre-flight, so an unavailable ledger costs one call — while
+// failing closed would strand a whole fleet on a bookkeeping outage.
+func TestUsageCapPreflight_FailsOpen(t *testing.T) {
+	fresh := func() usagecap.Reading {
+		return usagecap.Reading{
+			Window:      usagecap.WindowSevenDay,
+			Utilization: 0.99,
+			ObservedAt:  time.Now().UTC(),
+			ResetsAt:    time.Now().UTC().Add(time.Hour),
+		}
+	}
+	stale := func() usagecap.Reading {
+		r := fresh()
+		// Window already rolled over: the number describes a window that no
+		// longer exists.
+		r.ResetsAt = time.Now().UTC().Add(-time.Minute)
+		r.ObservedAt = time.Now().UTC().Add(-2 * time.Hour)
+		return r
+	}
+	tests := []struct {
+		name  string
+		pol   usagecap.Policy
+		caps  func(*testing.T) usagecap.Store
+		store store.RunStore
+	}{
+		{
+			name: "no cap configured",
+			pol:  usagecap.Policy{},
+			caps: func(t *testing.T) usagecap.Store {
+				s := usagecap.NewMemStore()
+				_ = s.Record(t.Context(), usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform), fresh())
+				return s
+			},
+		},
+		{
+			name: "no shared store",
+			pol:  capTestPolicy(),
+			caps: func(*testing.T) usagecap.Store { return nil },
+		},
+		{
+			name: "store unreadable",
+			pol:  capTestPolicy(),
+			caps: func(*testing.T) usagecap.Store { return failingCapStore{} },
+		},
+		{
+			name: "nothing measured yet",
+			pol:  capTestPolicy(),
+			caps: func(*testing.T) usagecap.Store { return usagecap.NewMemStore() },
+		},
+		{
+			name: "the measured window has rolled over",
+			pol:  capTestPolicy(),
+			caps: func(t *testing.T) usagecap.Store {
+				s := usagecap.NewMemStore()
+				_ = s.Record(t.Context(), usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform), stale())
+				return s
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rs := &capStatusStore{}
+			r := capRunner(tt.pol, tt.caps(t), rs)
+			if err := r.usageCapPreflight(t.Context(), &queue.RunMessage{RunID: "run-1"}, iterlog.Nop()); err != nil {
+				t.Fatalf("blocked the run: %v", err)
+			}
+			if rs.calls != 0 {
+				t.Errorf("flipped the run's status %d times without blocking it", rs.calls)
+			}
+		})
+	}
+}
+
+// One tenant's own subscription is a different meter from the deployment's:
+// merging them would let one tenant's spend park another's runs, and would
+// consult the wrong ledger for both.
+func TestUsageCapKey_SeparatesTenantCredentialsFromThePlatform(t *testing.T) {
+	msg := &queue.RunMessage{TenantID: "team-7"}
+
+	if got := usageCapKey(context.Background(), msg); got != usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform) {
+		t.Errorf("no credentials in ctx = %q, want the platform meter", got)
+	}
+
+	own := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		APIKeys: map[secrets.Provider]string{secrets.ProviderAnthropic: "sk-tenant"},
+	})
+	if got := usageCapKey(own, msg); got != usagecap.Key(delegate.BackendClaudeCode, usagecap.TenantScope("team-7")) {
+		t.Errorf("tenant BYOK = %q, want the tenant's own meter", got)
+	}
+
+	// A bundle carrying only unrelated secrets still runs on the
+	// deployment's subscription.
+	unrelated := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		Generic: map[string]string{"forge_token": "x"},
+	})
+	if got := usageCapKey(unrelated, msg); got != usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform) {
+		t.Errorf("unrelated secrets = %q, want the platform meter", got)
+	}
+}
+
+func TestUsageGuardFor_NilWithoutAPolicy(t *testing.T) {
+	r := capRunner(usagecap.Policy{}, usagecap.NewMemStore(), nil)
+	if g := r.usageGuardFor(context.Background(), &queue.RunMessage{}, iterlog.Nop()); g != nil {
+		t.Fatal("a deployment that configured no cap must not carry a guard")
+	}
+}
+
+// What a pod measures has to reach the ledger, or every other pod keeps
+// rediscovering the ceiling by spending against it.
+func TestUsageGuardFor_PublishesUnderTheRunsCredentialKey(t *testing.T) {
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		APIKeys: map[secrets.Provider]string{secrets.ProviderAnthropic: "sk-tenant"},
+	})
+	caps := usagecap.NewMemStore()
+	r := capRunner(capTestPolicy(), caps, nil)
+
+	g := r.usageGuardFor(ctx, &queue.RunMessage{TenantID: "team-7"}, iterlog.Nop())
+	if g == nil {
+		t.Fatal("want a guard")
+	}
+	g.Observe(usagecap.Reading{Window: usagecap.WindowFiveHour, Utilization: 0.5, ObservedAt: time.Now().UTC()})
+
+	got, err := caps.Latest(ctx, usagecap.Key(delegate.BackendClaudeCode, usagecap.TenantScope("team-7")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Utilization != 0.5 {
+		t.Fatalf("ledger = %+v, want the reading under the tenant's key", got)
+	}
+}

--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -62,6 +62,14 @@ var ErrRunPausedOperator = errors.New("runtime: run paused by operator")
 // HTTP layer translates this to 503 Service Unavailable.
 var ErrServerDraining = errors.New("runtime: server draining")
 
+// ErrUsageCapped is returned by the runview Service when the operator's
+// subscription usage cap (pkg/usagecap) leaves no headroom to start new
+// work. The HTTP layer translates it to 429 Too Many Requests — the run was
+// refused by a quota, and the caller may retry once the window reopens
+// (the error text says when). A run already claimed by a cloud runner takes
+// the other road instead: it parks with a durable retry.
+var ErrUsageCapped = errors.New("runtime: usage cap reached")
+
 // NodeExecutor is the abstraction called by the engine to actually run a
 // node (LLM call, tool invocation, etc.). The runtime itself is agnostic
 // to the concrete implementation — tests supply stubs, production code

--- a/pkg/runview/executor.go
+++ b/pkg/runview/executor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/secrets"
 	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/usagecap"
 )
 
 // rewriteChainFromPlugins loads the plugin registry and builds the command-
@@ -130,6 +131,14 @@ type ExecutorSpec struct {
 	// "off"), highest-priority input to automemory.Resolve (above node/workflow
 	// DSL and ITERION_AUTO_MEMORY). See docs/memory-and-knowledge.md.
 	AutoMemory string
+
+	// UsageGuard enforces the operator's subscription usage cap
+	// (pkg/usagecap) for this run. The cloud runner injects one backed by
+	// the shared Mongo store, so every pod sees what the others learned;
+	// nil makes BuildExecutor resolve the machine-wide policy from the
+	// environment onto a process-local store, which is exactly right for
+	// a CLI run and inert when no cap is configured.
+	UsageGuard *usagecap.Guard
 
 	// Permission is the run-level tool-permission-gate mode override
 	// ("", "off", "ask", "deny"), highest-priority input to the gate's
@@ -329,6 +338,13 @@ func BuildExecutor(spec ExecutorSpec) (*model.ClawExecutor, error) {
 		model.WithRewriteChain(rewriteChainFromPlugins(spec.Logger)),
 		model.WithPermissionOverride(spec.Permission),
 		model.WithPermissionRules(spec.PermissionAllow, spec.PermissionAsk, spec.PermissionDeny),
+	}
+	usageGuard, err := resolveUsageGuard(spec)
+	if err != nil {
+		return nil, err
+	}
+	if usageGuard != nil {
+		opts = append(opts, model.WithUsageGuard(usageGuard))
 	}
 	if sid := resolveSourceIssueID(spec); sid != "" {
 		opts = append(opts, model.WithSourceIssueID(sid))

--- a/pkg/runview/service_launch.go
+++ b/pkg/runview/service_launch.go
@@ -114,6 +114,16 @@ func (s *Service) Launch(parent context.Context, spec LaunchSpec) (*LaunchResult
 		return &LaunchResult{RunID: runID, Done: closed, QueuePosition: pos}, nil
 	}
 
+	// Usage cap, local path: a cap that stops runs mid-flight but lets new
+	// ones start is not a cap. Placed after the cloud hand-off because a
+	// queued run is governed by the RUNNER's pre-flight instead, which
+	// reads the shared ledger and parks the run with a retry rather than
+	// refusing it — here the operator is present, so an immediate refusal
+	// is the honest answer.
+	if blocked, reason := LocalUsagePreflight(); blocked {
+		return nil, fmt.Errorf("%w: %s", runtime.ErrUsageCapped, reason)
+	}
+
 	if detachedEnabled() {
 		return s.launchDetached(parent, runID, spec)
 	}

--- a/pkg/runview/usagecap.go
+++ b/pkg/runview/usagecap.go
@@ -1,0 +1,73 @@
+package runview
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/usagecap"
+)
+
+// localUsageStore is the process-local record of what this machine has
+// learned about its own subscription windows. A cloud pod never reaches it
+// (the runner injects a Mongo-backed guard instead); a laptop or a
+// single-process studio has nothing else, and sharing readings between two
+// runs of the same process is precisely the useful part — the second run
+// starts already knowing what the first one measured.
+var (
+	localUsageStoreOnce sync.Once
+	localUsageStore     *usagecap.MemStore
+)
+
+func processUsageStore() *usagecap.MemStore {
+	localUsageStoreOnce.Do(func() { localUsageStore = usagecap.NewMemStore() })
+	return localUsageStore
+}
+
+// resolveUsageGuard returns the guard governing this run: the caller's when
+// it injected one (the cloud runner, which knows which credential the run
+// draws on), otherwise one built from the machine-wide policy.
+//
+// A malformed policy is an error rather than an absent cap: every wrong
+// answer here fails open, and a guard silently disabled by a typo is the
+// failure the whole package exists to prevent.
+func resolveUsageGuard(spec ExecutorSpec) (*usagecap.Guard, error) {
+	if spec.UsageGuard != nil {
+		return spec.UsageGuard, nil
+	}
+	pol, err := usagecap.FromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("runview: usage cap: %w", err)
+	}
+	if !pol.Enabled() {
+		return nil, nil
+	}
+	store := processUsageStore()
+	key := usagecap.Key("", usagecap.ScopeLocal)
+	if spec.Logger != nil {
+		spec.Logger.Info("usage cap armed: %s", pol)
+	}
+	return usagecap.NewGuard(pol, func(r usagecap.Reading) {
+		// Best effort: an unrecorded reading costs the NEXT run a
+		// pre-flight, never this one its correctness.
+		_ = store.Record(context.Background(), key, r)
+	}), nil
+}
+
+// LocalUsagePreflight reports whether the machine-wide cap currently blocks
+// new work, from what earlier runs in this process observed. Empty reason
+// means "go ahead" — including when no cap is configured, or when nothing
+// has been measured yet.
+func LocalUsagePreflight() (blocked bool, reason string) {
+	pol, err := usagecap.FromEnv()
+	if err != nil || !pol.Enabled() {
+		return false, ""
+	}
+	readings, err := processUsageStore().Latest(context.Background(), usagecap.Key("", usagecap.ScopeLocal))
+	if err != nil {
+		return false, ""
+	}
+	d := usagecap.Preflight(readings, pol, time.Now().UTC(), usagecap.DefaultMaxAge)
+	return d.Blocked, d.Reason
+}

--- a/pkg/runview/usagecap_test.go
+++ b/pkg/runview/usagecap_test.go
@@ -1,0 +1,66 @@
+package runview
+
+import (
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/usagecap"
+)
+
+// The process ledger is deliberately global (a laptop's whole world), so
+// this test only ever writes readings that are inert unless the cap env is
+// set — which t.Setenv scopes to the test.
+func recordLocal(t *testing.T, util float64) {
+	t.Helper()
+	if err := processUsageStore().Record(t.Context(), usagecap.Key("", usagecap.ScopeLocal), usagecap.Reading{
+		Window:      usagecap.WindowSevenDay,
+		Utilization: util,
+		Status:      usagecap.StatusWarning,
+		ResetsAt:    time.Now().UTC().Add(24 * time.Hour),
+		ObservedAt:  time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLocalUsagePreflight(t *testing.T) {
+	t.Run("no cap configured", func(t *testing.T) {
+		recordLocal(t, 0.99)
+		if blocked, _ := LocalUsagePreflight(); blocked {
+			t.Fatal("blocked with no cap configured — the feature must be inert until asked for")
+		}
+	})
+
+	t.Run("over the cap", func(t *testing.T) {
+		t.Setenv(usagecap.EnvWeek, "75")
+		recordLocal(t, 0.99)
+		blocked, reason := LocalUsagePreflight()
+		if !blocked {
+			t.Fatal("want the launch refused at 99% against a 75% cap")
+		}
+		if reason == "" {
+			t.Error("a refusal must say why, and when the window reopens")
+		}
+	})
+
+	t.Run("under the cap", func(t *testing.T) {
+		t.Setenv(usagecap.EnvWeek, "75")
+		recordLocal(t, 0.10)
+		if blocked, reason := LocalUsagePreflight(); blocked {
+			t.Fatalf("blocked at 10%%: %s", reason)
+		}
+	})
+
+	// A cap nobody can read is not a cap: a malformed policy must not
+	// silently degrade into "no cap" here either. Failing open is the
+	// deliberate choice for the LAUNCH gate (the run itself still carries
+	// the guard, and BuildExecutor refuses the run loudly), so this pins
+	// the intent rather than an accident.
+	t.Run("malformed policy does not block", func(t *testing.T) {
+		t.Setenv(usagecap.EnvWeek, "not-a-number")
+		recordLocal(t, 0.99)
+		if blocked, _ := LocalUsagePreflight(); blocked {
+			t.Fatal("a malformed policy must not block launches; BuildExecutor is what refuses the run")
+		}
+	})
+}

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -422,6 +422,13 @@ func (s *Server) handleLaunchRun(w http.ResponseWriter, r *http.Request) {
 			span.SetStatus(codes.Error, "server draining")
 			return
 		}
+		if errors.Is(err, runtime.ErrUsageCapped) {
+			// A quota refusal, not a malformed request: the same launch
+			// succeeds once the window reopens, and the message says when.
+			s.httpErrorFor(w, r, http.StatusTooManyRequests, "%v", err)
+			span.SetStatus(codes.Error, "usage cap reached")
+			return
+		}
 		s.httpErrorFor(w, r, http.StatusBadRequest, "launch: %v", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "launch failed")

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -109,6 +109,18 @@ const (
 	//     "runtime_code+parsed_text", "…+blind_wait") — the degraded
 	//     paths must be visible, not silent
 	EventRunRetryScheduled EventType = "run_retry_scheduled"
+	// EventUsageCap marks the provider's subscription telemetry crossing a
+	// cap the OPERATOR set, below the provider's own wall (see
+	// pkg/usagecap). It is the difference between "the provider refused
+	// us" and "we stopped ourselves", which nothing else on the timeline
+	// can tell apart — both end the run the same way. Data:
+	//   - window: the provider's window name (five_hour, seven_day, …)
+	//   - family: the cap that governs it ("5h" | "week")
+	//   - percent / cap: observed utilization vs the configured ceiling
+	//   - mode: "soft" (nothing new starts) or "hard" (this run stops)
+	//   - stopped: whether THIS run was ended by the cap
+	//   - resets_at: RFC3339 instant the window reopens, when known
+	EventUsageCap EventType = "usage_cap"
 	// EventRunWorkspaceReset marks a repo-backed run RE-EXECUTING from a
 	// FRESH clone. The runner deletes the per-run repo dir when a run
 	// returns and re-clones on every claim, so a second attempt never

--- a/pkg/usagecap/env.go
+++ b/pkg/usagecap/env.go
@@ -1,0 +1,73 @@
+package usagecap
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Environment variables. The cap is a property of the CREDENTIAL and of the
+// deployment that owns it — not of a run — so it is configured machine-wide
+// and there is deliberately no per-run flag and no DSL field: a bot must not
+// be able to lift the guard that protects the operator's subscription.
+//
+// Setting the two _PCT variables is enough; the modes default to the posture
+// each window deserves (5h soft, week hard — see the package doc).
+const (
+	EnvEnabled  = "ITERION_USAGE_CAP"           // "off" disables both caps
+	EnvFiveHour = "ITERION_USAGE_CAP_5H_PCT"    // 0–100, 0/unset = no cap
+	EnvFiveMode = "ITERION_USAGE_CAP_5H_MODE"   // off|soft|hard (default soft)
+	EnvWeek     = "ITERION_USAGE_CAP_WEEK_PCT"  // 0–100, 0/unset = no cap
+	EnvWeekMode = "ITERION_USAGE_CAP_WEEK_MODE" // off|soft|hard (default hard)
+)
+
+// Default enforcement postures, applied when only a percentage is set.
+const (
+	DefaultFiveHourMode = ModeSoft
+	DefaultWeekMode     = ModeHard
+)
+
+// FromEnv resolves the machine-wide policy.
+//
+// A malformed value is an ERROR, not a fallback: every wrong answer here
+// fails open (no cap), and a guard that silently stopped guarding because of
+// a typo is worse than one that refuses to start. Callers surface it.
+func FromEnv() (Policy, error) {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv(EnvEnabled)), "off") {
+		return Policy{}, nil
+	}
+	var errs []error
+	five, err := windowFromEnv(EnvFiveHour, EnvFiveMode, DefaultFiveHourMode)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	week, err := windowFromEnv(EnvWeek, EnvWeekMode, DefaultWeekMode)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	if len(errs) > 0 {
+		return Policy{}, errors.Join(errs...)
+	}
+	return Policy{FiveHour: five, Week: week}, nil
+}
+
+func windowFromEnv(pctVar, modeVar string, defMode Mode) (WindowPolicy, error) {
+	raw := strings.TrimSpace(os.Getenv(pctVar))
+	mode, err := ParseMode(os.Getenv(modeVar), defMode)
+	if err != nil {
+		return WindowPolicy{}, fmt.Errorf("%s: %w", modeVar, err)
+	}
+	if raw == "" {
+		return WindowPolicy{Mode: mode}, nil
+	}
+	pct, err := strconv.ParseFloat(strings.TrimSuffix(raw, "%"), 64)
+	if err != nil {
+		return WindowPolicy{}, fmt.Errorf("%s: %q is not a percentage (want 0–100)", pctVar, raw)
+	}
+	if pct < 0 || pct > 100 {
+		return WindowPolicy{}, fmt.Errorf("%s: %g is out of range (want 0–100)", pctVar, pct)
+	}
+	return WindowPolicy{MaxPercent: pct, Mode: mode}, nil
+}

--- a/pkg/usagecap/env_test.go
+++ b/pkg/usagecap/env_test.go
@@ -1,0 +1,165 @@
+package usagecap
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFromEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want Policy
+	}{
+		{
+			name: "unset is inert",
+			env:  nil,
+			want: Policy{
+				FiveHour: WindowPolicy{Mode: DefaultFiveHourMode},
+				Week:     WindowPolicy{Mode: DefaultWeekMode},
+			},
+		},
+		{
+			// The shipped recommendation: two variables, and each window
+			// gets the posture it deserves without saying so.
+			name: "percentages alone pick soft 5h / hard week",
+			env:  map[string]string{EnvFiveHour: "85", EnvWeek: "75"},
+			want: Policy{
+				FiveHour: WindowPolicy{MaxPercent: 85, Mode: ModeSoft},
+				Week:     WindowPolicy{MaxPercent: 75, Mode: ModeHard},
+			},
+		},
+		{
+			name: "modes are overridable per window",
+			env: map[string]string{
+				EnvFiveHour: "90", EnvFiveMode: "hard",
+				EnvWeek: "70", EnvWeekMode: "soft",
+			},
+			want: Policy{
+				FiveHour: WindowPolicy{MaxPercent: 90, Mode: ModeHard},
+				Week:     WindowPolicy{MaxPercent: 70, Mode: ModeSoft},
+			},
+		},
+		{
+			name: "a percent sign is tolerated",
+			env:  map[string]string{EnvWeek: "75%"},
+			want: Policy{
+				FiveHour: WindowPolicy{Mode: DefaultFiveHourMode},
+				Week:     WindowPolicy{MaxPercent: 75, Mode: DefaultWeekMode},
+			},
+		},
+		{
+			// The kill switch: one variable disarms both caps without
+			// having to remember what the percentages were.
+			name: "the master switch wins over configured caps",
+			env:  map[string]string{EnvEnabled: "OFF", EnvFiveHour: "85", EnvWeek: "75"},
+			want: Policy{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			got, err := FromEnv()
+			if err != nil {
+				t.Fatalf("FromEnv: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("FromEnv() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// A typo must not read as "no cap": every wrong answer here fails open, and
+// a guard silently disabled is the failure this package exists to prevent.
+func TestFromEnv_MalformedIsAnError(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{"not a number", map[string]string{EnvWeek: "seventy-five"}, EnvWeek},
+		{"above 100", map[string]string{EnvWeek: "175"}, EnvWeek},
+		{"negative", map[string]string{EnvFiveHour: "-5"}, EnvFiveHour},
+		{"unknown mode", map[string]string{EnvWeek: "75", EnvWeekMode: "hrad"}, EnvWeekMode},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			got, err := FromEnv()
+			if err == nil {
+				t.Fatalf("FromEnv() = %+v, nil — a malformed cap must be refused, not ignored", got)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error %q does not name the offending variable %q", err, tt.want)
+			}
+			if got.Enabled() {
+				t.Error("a refused policy must not come back armed")
+			}
+		})
+	}
+}
+
+func TestParseMode(t *testing.T) {
+	for _, in := range []string{"soft", "SOFT", " soft "} {
+		if got, err := ParseMode(in, ModeHard); err != nil || got != ModeSoft {
+			t.Errorf("ParseMode(%q) = %q, %v", in, got, err)
+		}
+	}
+	if got, _ := ParseMode("", ModeHard); got != ModeHard {
+		t.Errorf("empty should fall back to the supplied default, got %q", got)
+	}
+	if _, err := ParseMode("nope", ModeHard); err == nil {
+		t.Error("want an error on an unknown mode")
+	}
+}
+
+func TestMemStore(t *testing.T) {
+	ctx := t.Context()
+	s := NewMemStore()
+	key := Key("claude_code", ScopePlatform)
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+
+	if got, err := s.Latest(ctx, "unknown"); err != nil || len(got) != 0 {
+		t.Fatalf("Latest(unknown) = %v, %v — an unknown key means 'nothing learned', not an error", got, err)
+	}
+	if err := s.Record(ctx, key, Reading{Window: WindowSevenDay, Utilization: 0.5, ObservedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	// Several pods observe the same credential at once and the network does
+	// not preserve order: a late-arriving OLD reading must not undo a newer
+	// one, or a fleet could talk itself back under the cap.
+	if err := s.Record(ctx, key, Reading{Window: WindowSevenDay, Utilization: 0.1, ObservedAt: now.Add(-time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Latest(ctx, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Utilization != 0.5 {
+		t.Fatalf("Latest = %+v, want the newer 0.5 reading to survive", got)
+	}
+	if err := s.Record(ctx, key, Reading{Window: WindowFiveHour, Utilization: 0.2, ObservedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := s.Latest(ctx, key); len(got) != 2 {
+		t.Fatalf("Latest = %+v, want one reading per window", got)
+	}
+}
+
+func TestKeyScoping(t *testing.T) {
+	// A tenant's own subscription is a different meter from the
+	// deployment's: merging them would let one tenant's spend park
+	// another's runs.
+	if Key("claude_code", TenantScope("t1")) == Key("claude_code", ScopePlatform) {
+		t.Fatal("tenant and platform credentials must not share a key")
+	}
+	if Key("claude_code", TenantScope("")) != Key("claude_code", ScopePlatform) {
+		t.Fatal("a run with no tenant falls back to the platform meter")
+	}
+}

--- a/pkg/usagecap/mongo.go
+++ b/pkg/usagecap/mongo.go
@@ -1,0 +1,127 @@
+package usagecap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/SocialGouv/iterion/pkg/internal/mongoutil"
+)
+
+const colUsageWindows = "usage_windows"
+
+// usageRetentionDays evicts readings long after they could still matter. A
+// weekly window is seven days; a fortnight of retention keeps the collection
+// from growing without bound while never dropping a live reading.
+const usageRetentionDays = 14
+
+// MongoStore is the cloud Store: one document per (credential key, window),
+// readable by every replica.
+//
+// The cloud twin ships with the feature rather than after it — a guard that
+// only shares its readings inside one process is exactly the hole a runner
+// fleet falls through, since no two runs land on the same pod.
+type MongoStore struct{ col *mongo.Collection }
+
+// NewMongoStore binds the store to a database.
+func NewMongoStore(db *mongo.Database) *MongoStore {
+	return &MongoStore{col: db.Collection(colUsageWindows)}
+}
+
+// EnsureSchema creates the indexes idempotently.
+func EnsureSchema(ctx context.Context, db *mongo.Database) error {
+	col := db.Collection(colUsageWindows)
+	if _, err := col.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{Keys: bson.D{{Key: "key", Value: 1}},
+			Options: options.Index().SetName("usage_windows_key")},
+		{Keys: bson.D{{Key: "observed_at", Value: 1}},
+			Options: options.Index().SetName("usage_windows_ttl").
+				SetExpireAfterSeconds(int32(usageRetentionDays * 24 * 60 * 60))},
+	}); err != nil && !mongoutil.IsIndexConflict(err) {
+		return fmt.Errorf("usagecap: ensure indexes: %w", err)
+	}
+	return nil
+}
+
+type readingDoc struct {
+	Key         string    `bson:"key"`
+	Window      string    `bson:"window"`
+	Utilization float64   `bson:"utilization"`
+	Status      string    `bson:"status"`
+	ResetsAt    time.Time `bson:"resets_at,omitempty"`
+	ObservedAt  time.Time `bson:"observed_at"`
+}
+
+func docID(key string, w Window) string { return key + "#" + string(w) }
+
+// Record upserts the reading, refusing to regress a window to an older
+// observation. The freshness condition lives in the FILTER, not in a
+// read-then-write: several pods observe the same credential concurrently and
+// the loser of that race must be dropped, not applied.
+func (s *MongoStore) Record(ctx context.Context, key string, r Reading) error {
+	if r.ObservedAt.IsZero() {
+		r.ObservedAt = time.Now().UTC()
+	}
+	filter := bson.M{
+		"_id": docID(key, r.Window),
+		// An absent observed_at is the first write for this window: Mongo
+		// comparison operators are type-bracketed and would not match a
+		// missing field, so the "never seen" case needs its own branch or
+		// the very first reading never lands.
+		"$or": []bson.M{
+			{"observed_at": bson.M{"$exists": false}},
+			{"observed_at": bson.M{"$lte": r.ObservedAt.UTC()}},
+		},
+	}
+	update := bson.M{"$set": bson.M{
+		"key":         key,
+		"window":      string(r.Window),
+		"utilization": r.Utilization,
+		"status":      r.Status,
+		"resets_at":   r.ResetsAt.UTC(),
+		"observed_at": r.ObservedAt.UTC(),
+	}}
+	_, err := s.col.UpdateOne(ctx, filter, update, options.UpdateOne().SetUpsert(true))
+	if err != nil {
+		// A concurrent upsert that lost the race raises a duplicate key on
+		// _id — the newer reading is already stored, which is the outcome
+		// this call wanted.
+		if mongo.IsDuplicateKeyError(err) {
+			return nil
+		}
+		return fmt.Errorf("usagecap: record %s: %w", docID(key, r.Window), err)
+	}
+	return nil
+}
+
+// Latest returns the newest reading per window for a credential key.
+func (s *MongoStore) Latest(ctx context.Context, key string) ([]Reading, error) {
+	cur, err := s.col.Find(ctx, bson.M{"key": key})
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("usagecap: latest %s: %w", key, err)
+	}
+	defer func() { _ = cur.Close(ctx) }()
+	var docs []readingDoc
+	if err := cur.All(ctx, &docs); err != nil {
+		return nil, fmt.Errorf("usagecap: latest %s: decode: %w", key, err)
+	}
+	out := make([]Reading, 0, len(docs))
+	for _, d := range docs {
+		out = append(out, Reading{
+			Window:      Window(d.Window),
+			Utilization: d.Utilization,
+			Status:      d.Status,
+			ResetsAt:    d.ResetsAt,
+			ObservedAt:  d.ObservedAt,
+		})
+	}
+	return out, nil
+}

--- a/pkg/usagecap/store.go
+++ b/pkg/usagecap/store.go
@@ -1,0 +1,106 @@
+package usagecap
+
+import (
+	"context"
+	"strings"
+	"sync"
+)
+
+// Store shares what one process learned about a credential's usage windows
+// with every other process that might spend it.
+//
+// Without it the guard still works, but only from inside a run: each pod
+// discovers the wall by hitting it once. With it, a pod that is about to
+// start work asks first and parks for free.
+//
+// Implementations must be safe for concurrent use and must not let an
+// out-of-order write regress a window to an older reading — several pods
+// observe the same credential at once, and the network does not preserve
+// order.
+type Store interface {
+	// Record stores a reading for a credential key, keeping the newest
+	// per window.
+	Record(ctx context.Context, key string, r Reading) error
+	// Latest returns the newest reading per window for a credential key.
+	// An unknown key is not an error: it means "nothing learned yet",
+	// which must read as "not blocked".
+	Latest(ctx context.Context, key string) ([]Reading, error)
+}
+
+// Key identifies the credential whose windows a reading describes.
+//
+// The scope is what keeps one tenant's BYOK subscription from blocking
+// another's: readings only merge when they genuinely come from the same
+// meter. Runs that fall back to the deployment's own credential share
+// ScopePlatform, and merging THOSE is not a compromise but the point — they
+// really are one subscription.
+func Key(backend, scope string) string {
+	backend = strings.TrimSpace(backend)
+	scope = strings.TrimSpace(scope)
+	if backend == "" {
+		backend = "unknown"
+	}
+	if scope == "" {
+		scope = ScopePlatform
+	}
+	return backend + "|" + scope
+}
+
+const (
+	// ScopePlatform is the deployment's own credential — the env-provided
+	// subscription every run falls back to.
+	ScopePlatform = "platform"
+	// ScopeLocal is a single-process CLI run.
+	ScopeLocal = "local"
+	// ScopeTenantPrefix prefixes a tenant that brought its own credential.
+	ScopeTenantPrefix = "tenant:"
+)
+
+// TenantScope builds the scope for a tenant's own credential.
+func TenantScope(tenantID string) string {
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		return ScopePlatform
+	}
+	return ScopeTenantPrefix + tenantID
+}
+
+// MemStore is an in-process Store: the local CLI's whole world, and the
+// tests' substitute for Mongo.
+type MemStore struct {
+	mu   sync.RWMutex
+	data map[string]map[Window]Reading
+}
+
+// NewMemStore builds an empty in-process store.
+func NewMemStore() *MemStore {
+	return &MemStore{data: map[string]map[Window]Reading{}}
+}
+
+// Record keeps the newest reading per window.
+func (s *MemStore) Record(_ context.Context, key string, r Reading) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	byWindow, ok := s.data[key]
+	if !ok {
+		byWindow = map[Window]Reading{}
+		s.data[key] = byWindow
+	}
+	if prev, ok := byWindow[r.Window]; ok && prev.ObservedAt.After(r.ObservedAt) {
+		return nil
+	}
+	byWindow[r.Window] = r
+	return nil
+}
+
+// Latest returns the newest reading per window.
+func (s *MemStore) Latest(_ context.Context, key string) ([]Reading, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	byWindow := s.data[key]
+	out := make([]Reading, 0, len(byWindow))
+	for _, r := range byWindow {
+		out = append(out, r)
+	}
+	return out, nil
+}

--- a/pkg/usagecap/usagecap.go
+++ b/pkg/usagecap/usagecap.go
@@ -1,0 +1,397 @@
+// Package usagecap stops a deployment from spending its LLM subscription
+// down to the provider's own wall.
+//
+// A subscription ("forfait") meters two rolling windows — five hours and
+// seven days — and refuses every call once one is exhausted. iterion already
+// survives that refusal: the run parks and a durable retry resumes it when
+// the window reopens (pkg/runner/usage_retry.go). What it could not do is
+// stop BEFORE the wall, and the wall is not where an operator wants to be:
+// the same subscription usually pays for their own interactive work, so a
+// fleet of bots that drives it to 100% takes the human down with it.
+//
+// So this package reads the provider's own telemetry — the utilization each
+// window reports on every call — and enforces a percentage the operator
+// chose. Two enforcement postures, because the two windows fail differently:
+//
+//   - SOFT (the five-hour window's default): never interrupt work in flight,
+//     but start nothing new. A five-hour window refills soon; killing a
+//     half-finished run to save minutes of quota trades a lot for a little.
+//   - HARD (the weekly window's default): stop the run where it stands. A
+//     weekly window that runs out on a Tuesday is a dead week — the run that
+//     would have finished is worth less than the four days of headroom it
+//     would have eaten.
+//
+// Both postures end the same way for the run: the caller turns a Stop
+// decision into the same usage-window error the provider itself would have
+// produced, so the existing park-and-resume machinery carries it home
+// untouched. A capped run is not a lost run; it is a run that waits.
+//
+// Nothing here talks to a provider. Readings are pushed in by whoever
+// observes them (the claude_code stream carries a rate_limit_event), and
+// pushed out to a Store so a pod that is about to start work can consult
+// what another pod learned.
+package usagecap
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Window is one of the provider's metered usage windows, named as the
+// provider names it on the wire.
+type Window string
+
+const (
+	// WindowFiveHour is the rolling five-hour session window.
+	WindowFiveHour Window = "five_hour"
+	// WindowSevenDay is the rolling weekly window, all models.
+	WindowSevenDay Window = "seven_day"
+	// WindowSevenDayOpus / WindowSevenDaySonnet are per-model weekly
+	// sub-limits: a run can be refused on one of them while the
+	// all-models window still has room, so they are capped as members of
+	// the weekly family rather than ignored.
+	WindowSevenDayOpus   Window = "seven_day_opus"
+	WindowSevenDaySonnet Window = "seven_day_sonnet"
+	// WindowSevenDayOverageIncluded is the weekly window as measured with
+	// the paid overage channel folded in.
+	WindowSevenDayOverageIncluded Window = "seven_day_overage_included"
+	// WindowOverage is the metered pay-as-you-go channel that some plans
+	// can spill into. Deliberately NOT capped here: it is money, not
+	// subscription quota, and the budget flags (--max-cost-usd) are what
+	// bound money.
+	WindowOverage Window = "overage"
+)
+
+// Family groups the windows that share one operator-facing cap. An
+// operator thinks in "my 5h" and "my week", not in six wire names.
+type Family string
+
+const (
+	FamilyFiveHour Family = "5h"
+	FamilyWeek     Family = "week"
+	// FamilyNone marks a window no cap applies to.
+	FamilyNone Family = ""
+)
+
+// FamilyOf maps a wire window onto the cap that governs it.
+func FamilyOf(w Window) Family {
+	switch w {
+	case WindowFiveHour:
+		return FamilyFiveHour
+	case WindowSevenDay, WindowSevenDayOpus, WindowSevenDaySonnet, WindowSevenDayOverageIncluded:
+		return FamilyWeek
+	default:
+		// Includes WindowOverage and any window a future CLI adds: an
+		// unknown window is not silently folded into a cap that was never
+		// meant to govern it.
+		return FamilyNone
+	}
+}
+
+// Mode is how hard a cap bites.
+type Mode string
+
+const (
+	// ModeOff records readings but never blocks. The zero value, so a
+	// zero Policy is inert — a cap nobody configured must never surprise
+	// anyone.
+	ModeOff Mode = "off"
+	// ModeSoft blocks work that has not started; work in flight runs on.
+	ModeSoft Mode = "soft"
+	// ModeHard additionally stops work in flight at the next observation.
+	ModeHard Mode = "hard"
+)
+
+// ParseMode reads an operator-supplied mode, case- and space-insensitive.
+// An empty string yields the supplied fallback; anything unrecognised is an
+// error rather than a silent downgrade — a typo'd "hrad" that quietly
+// disabled the guard is exactly the failure this package exists to prevent.
+func ParseMode(s string, fallback Mode) (Mode, error) {
+	switch v := Mode(strings.ToLower(strings.TrimSpace(s))); v {
+	case "":
+		return fallback, nil
+	case ModeOff, ModeSoft, ModeHard:
+		return v, nil
+	default:
+		return fallback, fmt.Errorf("usagecap: unknown mode %q (want off|soft|hard)", s)
+	}
+}
+
+// WindowPolicy is the cap for one family.
+type WindowPolicy struct {
+	// MaxPercent is the utilization ceiling, 0–100. Zero means no cap,
+	// whatever Mode says.
+	MaxPercent float64
+	// Mode is the enforcement posture at and above MaxPercent.
+	Mode Mode
+}
+
+// Enabled reports whether this policy can ever block.
+func (p WindowPolicy) Enabled() bool {
+	return p.MaxPercent > 0 && (p.Mode == ModeSoft || p.Mode == ModeHard)
+}
+
+// Policy is the full operator configuration.
+type Policy struct {
+	FiveHour WindowPolicy
+	Week     WindowPolicy
+}
+
+// For returns the policy governing a family (zero value for FamilyNone).
+func (p Policy) For(f Family) WindowPolicy {
+	switch f {
+	case FamilyFiveHour:
+		return p.FiveHour
+	case FamilyWeek:
+		return p.Week
+	default:
+		return WindowPolicy{}
+	}
+}
+
+// Enabled reports whether any cap can block.
+func (p Policy) Enabled() bool { return p.FiveHour.Enabled() || p.Week.Enabled() }
+
+// String renders the policy for a log line.
+func (p Policy) String() string {
+	if !p.Enabled() {
+		return "usage caps off"
+	}
+	part := func(name string, wp WindowPolicy) string {
+		if !wp.Enabled() {
+			return name + "=off"
+		}
+		return fmt.Sprintf("%s=%.0f%%/%s", name, wp.MaxPercent, wp.Mode)
+	}
+	return part("5h", p.FiveHour) + " " + part("week", p.Week)
+}
+
+// Reading is one observation of one window, as the provider reported it.
+type Reading struct {
+	// Window is the provider's own window name.
+	Window Window
+	// Utilization is the fraction consumed, 0..1 — the scale the provider
+	// uses. Percent() is the operator-facing form.
+	Utilization float64
+	// Status is the provider's own verdict: allowed, allowed_warning or
+	// rejected. Carried through so a "rejected" can block even when the
+	// utilization number is missing.
+	Status string
+	// ResetsAt is when this window rolls over. Zero when the provider did
+	// not say, which is what makes a reading unbounded in time — see
+	// Fresh.
+	ResetsAt time.Time
+	// ObservedAt is when iterion saw the reading.
+	ObservedAt time.Time
+}
+
+// Provider status values.
+const (
+	StatusAllowed  = "allowed"
+	StatusWarning  = "allowed_warning"
+	StatusRejected = "rejected"
+)
+
+// Percent is the utilization on the 0–100 scale operators configure in.
+func (r Reading) Percent() float64 { return r.Utilization * 100 }
+
+// Fresh reports whether a reading still describes the current window.
+//
+// A reading dies at its own reset instant: past it the window has rolled
+// over and the old number describes a window that no longer exists. That is
+// what keeps a stale reading from blocking a deployment forever — the guard
+// forgets by itself, with no sweeper and no TTL to tune.
+//
+// A reading with no reset instant cannot expire that way, so it falls back
+// to maxAge. Without that fallback an undated reading would be immortal.
+func (r Reading) Fresh(now time.Time, maxAge time.Duration) bool {
+	if r.ObservedAt.IsZero() {
+		return false
+	}
+	if !r.ResetsAt.IsZero() {
+		return now.Before(r.ResetsAt)
+	}
+	return now.Sub(r.ObservedAt) < maxAge
+}
+
+// DefaultMaxAge bounds how long a reading with no reset instant is trusted.
+// Short enough that a wrong block heals within one five-hour window, long
+// enough to cover the gap between two runs on a quiet deployment.
+const DefaultMaxAge = time.Hour
+
+// Decision is what a policy says about a reading (or a set of them).
+type Decision struct {
+	// Blocked is true when a cap is met or exceeded: no NEW work should
+	// start against this credential.
+	Blocked bool
+	// Stop is true when the cap that fired is HARD: work already in
+	// flight must end too. Never true without Blocked.
+	Stop bool
+	// Window / Family / Percent / Cap describe the cap that fired.
+	Window  Window
+	Family  Family
+	Percent float64
+	Cap     float64
+	// ResetsAt is when the blocking window reopens — the instant the
+	// caller arms a retry for. Zero when the provider did not say.
+	ResetsAt time.Time
+	// Reason is a one-line human explanation, safe for a log line, a run
+	// error and an event payload.
+	Reason string
+}
+
+// evaluate applies a policy to a single reading.
+func evaluate(r Reading, pol Policy) Decision {
+	fam := FamilyOf(r.Window)
+	wp := pol.For(fam)
+	if !wp.Enabled() {
+		return Decision{}
+	}
+	pct := r.Percent()
+	// A provider that has already refused is over any cap the operator
+	// could have set, whatever the utilization number says (it is
+	// optional on the wire, so "rejected with no number" is a real shape).
+	rejected := r.Status == StatusRejected
+	if !rejected && pct < wp.MaxPercent {
+		return Decision{}
+	}
+	d := Decision{
+		Blocked:  true,
+		Stop:     wp.Mode == ModeHard,
+		Window:   r.Window,
+		Family:   fam,
+		Percent:  pct,
+		Cap:      wp.MaxPercent,
+		ResetsAt: r.ResetsAt,
+	}
+	switch {
+	case rejected && pct == 0:
+		d.Reason = fmt.Sprintf("usage cap: provider rejected on the %s window (%s cap %.0f%%, %s)",
+			r.Window, fam, wp.MaxPercent, wp.Mode)
+	default:
+		d.Reason = fmt.Sprintf("usage cap: %s window at %.0f%% ≥ %.0f%% (%s, %s)",
+			r.Window, pct, wp.MaxPercent, fam, wp.Mode)
+	}
+	if !r.ResetsAt.IsZero() {
+		d.Reason += ", resets " + r.ResetsAt.UTC().Format(time.RFC3339)
+	}
+	return d
+}
+
+// Guard is the per-process enforcement point. It remembers the latest
+// reading per window, evaluates each new one against the policy, and
+// publishes what it learns so other processes can pre-flight against it.
+//
+// Safe for concurrent use: readings arrive on a backend's stream goroutine
+// while the run executes elsewhere.
+type Guard struct {
+	pol   Policy
+	sink  func(Reading)
+	mu    sync.Mutex
+	seen  map[Window]Reading
+	fired bool
+}
+
+// NewGuard builds a guard. sink, when non-nil, receives every reading —
+// the seam the runner uses to publish into a shared Store. It is called
+// on the observing goroutine and must not block.
+func NewGuard(pol Policy, sink func(Reading)) *Guard {
+	return &Guard{pol: pol, sink: sink, seen: map[Window]Reading{}}
+}
+
+// Policy returns the guard's configuration.
+func (g *Guard) Policy() Policy {
+	if g == nil {
+		return Policy{}
+	}
+	return g.pol
+}
+
+// Observe records a reading and reports what the policy makes of it. A nil
+// guard observes nothing and blocks nothing, so callers need no nil check.
+func (g *Guard) Observe(r Reading) Decision {
+	if g == nil {
+		return Decision{}
+	}
+	if r.ObservedAt.IsZero() {
+		r.ObservedAt = time.Now().UTC()
+	}
+	g.mu.Lock()
+	g.seen[r.Window] = r
+	g.mu.Unlock()
+
+	// Publish before deciding: a reading that stops THIS run is exactly
+	// the one the next pod most needs, and a Stop decision unwinds the
+	// caller fast.
+	if g.sink != nil {
+		g.sink(r)
+	}
+
+	d := evaluate(r, g.pol)
+	if d.Stop {
+		g.mu.Lock()
+		g.fired = true
+		g.mu.Unlock()
+	}
+	return d
+}
+
+// Fired reports whether a hard cap has stopped this guard's work. Lets a
+// caller distinguish "the run failed" from "iterion stopped the run".
+func (g *Guard) Fired() bool {
+	if g == nil {
+		return false
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.fired
+}
+
+// Latest returns the readings seen so far, newest per window.
+func (g *Guard) Latest() []Reading {
+	if g == nil {
+		return nil
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	out := make([]Reading, 0, len(g.seen))
+	for _, r := range g.seen {
+		out = append(out, r)
+	}
+	return out
+}
+
+// Preflight answers "may new work start against this credential" from
+// previously stored readings. It is the cheap gate: no pod, no clone, no
+// call. Stale readings are ignored (see Reading.Fresh), so a deployment
+// that has not run in days is never blocked by what it learned then.
+//
+// When several windows block, the one that reopens LAST wins: coming back
+// before every blocking window has reopened would just park the run again.
+func Preflight(readings []Reading, pol Policy, now time.Time, maxAge time.Duration) Decision {
+	if !pol.Enabled() {
+		return Decision{}
+	}
+	if maxAge <= 0 {
+		maxAge = DefaultMaxAge
+	}
+	var worst Decision
+	for _, r := range readings {
+		if !r.Fresh(now, maxAge) {
+			continue
+		}
+		d := evaluate(r, pol)
+		if !d.Blocked {
+			continue
+		}
+		switch {
+		case !worst.Blocked:
+			worst = d
+		case d.ResetsAt.After(worst.ResetsAt):
+			worst = d
+		}
+	}
+	return worst
+}

--- a/pkg/usagecap/usagecap_test.go
+++ b/pkg/usagecap/usagecap_test.go
@@ -1,0 +1,221 @@
+package usagecap
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func reading(w Window, util float64, resets time.Time) Reading {
+	return Reading{
+		Window:      w,
+		Utilization: util,
+		Status:      StatusAllowed,
+		ResetsAt:    resets,
+		ObservedAt:  time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+// Jo's shipped posture: 85% soft on the five-hour window, 75% hard on the
+// weekly one.
+func joPolicy() Policy {
+	return Policy{
+		FiveHour: WindowPolicy{MaxPercent: 85, Mode: ModeSoft},
+		Week:     WindowPolicy{MaxPercent: 75, Mode: ModeHard},
+	}
+}
+
+func TestFamilyOf(t *testing.T) {
+	tests := []struct {
+		window Window
+		want   Family
+	}{
+		{WindowFiveHour, FamilyFiveHour},
+		{WindowSevenDay, FamilyWeek},
+		// The per-model weekly sub-limits are real walls: a run refused on
+		// the opus weekly limit is refused, whatever the all-models number
+		// says. They belong to the weekly cap.
+		{WindowSevenDayOpus, FamilyWeek},
+		{WindowSevenDaySonnet, FamilyWeek},
+		{WindowSevenDayOverageIncluded, FamilyWeek},
+		// Overage is money, not subscription quota — the budget flags bound
+		// it, not this package.
+		{WindowOverage, FamilyNone},
+		{Window("something_new"), FamilyNone},
+	}
+	for _, tt := range tests {
+		if got := FamilyOf(tt.window); got != tt.want {
+			t.Errorf("FamilyOf(%q) = %q, want %q", tt.window, got, tt.want)
+		}
+	}
+}
+
+func TestObserve_SoftAndHardPostures(t *testing.T) {
+	resets := time.Date(2026, 8, 18, 21, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		reading     Reading
+		wantBlocked bool
+		wantStop    bool
+	}{
+		{"5h under its cap", reading(WindowFiveHour, 0.80, resets), false, false},
+		{"5h at its cap blocks softly", reading(WindowFiveHour, 0.85, resets), true, false},
+		{"5h far over stays soft", reading(WindowFiveHour, 0.99, resets), true, false},
+		{"week under its cap", reading(WindowSevenDay, 0.74, resets), false, false},
+		{"week at its cap stops the run", reading(WindowSevenDay, 0.75, resets), true, true},
+		{"weekly opus sub-limit stops too", reading(WindowSevenDayOpus, 0.92, resets), true, true},
+		{"overage is not capped here", reading(WindowOverage, 1.0, resets), false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGuard(joPolicy(), nil)
+			d := g.Observe(tt.reading)
+			if d.Blocked != tt.wantBlocked || d.Stop != tt.wantStop {
+				t.Fatalf("blocked=%v stop=%v, want blocked=%v stop=%v (reason %q)",
+					d.Blocked, d.Stop, tt.wantBlocked, tt.wantStop, d.Reason)
+			}
+			if d.Stop != g.Fired() {
+				t.Errorf("Fired() = %v, want %v", g.Fired(), d.Stop)
+			}
+			if d.Blocked {
+				if d.ResetsAt != resets {
+					t.Errorf("ResetsAt = %v, want %v — the retry instant must survive the decision", d.ResetsAt, resets)
+				}
+				if !strings.Contains(d.Reason, "usage cap") {
+					t.Errorf("Reason = %q, want it to name the cap", d.Reason)
+				}
+			}
+		})
+	}
+}
+
+// A rejected status carries no utilization number of its own. Reading it as
+// 0% would let the guard wave through the one case it exists for.
+func TestObserve_RejectedWithoutUtilization(t *testing.T) {
+	g := NewGuard(joPolicy(), nil)
+	d := g.Observe(Reading{
+		Window:     WindowSevenDay,
+		Status:     StatusRejected,
+		ObservedAt: time.Now().UTC(),
+	})
+	if !d.Blocked || !d.Stop {
+		t.Fatalf("blocked=%v stop=%v, want both true for a provider rejection", d.Blocked, d.Stop)
+	}
+}
+
+func TestObserve_DisabledPolicyNeverBlocks(t *testing.T) {
+	for _, pol := range []Policy{
+		{},
+		{Week: WindowPolicy{MaxPercent: 75, Mode: ModeOff}},
+		{Week: WindowPolicy{MaxPercent: 0, Mode: ModeHard}},
+	} {
+		g := NewGuard(pol, nil)
+		if d := g.Observe(reading(WindowSevenDay, 1.0, time.Time{})); d.Blocked {
+			t.Fatalf("policy %+v blocked at 100%% — an unconfigured cap must be inert", pol)
+		}
+	}
+}
+
+func TestObserve_PublishesEveryReading(t *testing.T) {
+	var got []Reading
+	g := NewGuard(joPolicy(), func(r Reading) { got = append(got, r) })
+	g.Observe(reading(WindowFiveHour, 0.10, time.Time{}))
+	g.Observe(reading(WindowSevenDay, 0.99, time.Time{}))
+	if len(got) != 2 {
+		t.Fatalf("published %d readings, want 2 — the one that stops a run is the one the next pod needs", len(got))
+	}
+}
+
+func TestObserve_StampsObservedAt(t *testing.T) {
+	g := NewGuard(Policy{}, nil)
+	g.Observe(Reading{Window: WindowFiveHour, Utilization: 0.1})
+	latest := g.Latest()
+	if len(latest) != 1 || latest[0].ObservedAt.IsZero() {
+		t.Fatalf("latest = %+v, want one reading with a non-zero ObservedAt", latest)
+	}
+}
+
+func TestReadingFresh(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		r    Reading
+		want bool
+	}{
+		{"never observed", Reading{}, false},
+		{"window still open", Reading{ObservedAt: now.Add(-time.Hour), ResetsAt: now.Add(time.Hour)}, true},
+		// Past its reset the window has rolled over: the number describes a
+		// window that no longer exists, so it must stop blocking by itself.
+		{"window rolled over", Reading{ObservedAt: now.Add(-2 * time.Hour), ResetsAt: now.Add(-time.Minute)}, false},
+		{"undated but recent", Reading{ObservedAt: now.Add(-time.Minute)}, true},
+		{"undated and stale", Reading{ObservedAt: now.Add(-2 * time.Hour)}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.r.Fresh(now, DefaultMaxAge); got != tt.want {
+				t.Errorf("Fresh = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPreflight(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	soon := now.Add(2 * time.Hour)
+	late := now.Add(30 * time.Hour)
+
+	t.Run("nothing measured yet", func(t *testing.T) {
+		if d := Preflight(nil, joPolicy(), now, DefaultMaxAge); d.Blocked {
+			t.Fatal("blocked with no readings — an unmeasured deployment must not be stranded")
+		}
+	})
+
+	t.Run("a soft cap also stops new work", func(t *testing.T) {
+		d := Preflight([]Reading{reading(WindowFiveHour, 0.90, soon)}, joPolicy(), now, DefaultMaxAge)
+		if !d.Blocked || d.Stop {
+			t.Fatalf("blocked=%v stop=%v, want blocked without stop: soft means 'start nothing new'", d.Blocked, d.Stop)
+		}
+	})
+
+	t.Run("stale readings are ignored", func(t *testing.T) {
+		rolled := reading(WindowSevenDay, 0.99, now.Add(-time.Minute))
+		if d := Preflight([]Reading{rolled}, joPolicy(), now, DefaultMaxAge); d.Blocked {
+			t.Fatal("blocked on a window that already rolled over")
+		}
+	})
+
+	t.Run("the latest reopening wins", func(t *testing.T) {
+		d := Preflight([]Reading{
+			reading(WindowFiveHour, 0.90, soon),
+			reading(WindowSevenDay, 0.99, late),
+		}, joPolicy(), now, DefaultMaxAge)
+		if !d.Blocked {
+			t.Fatal("want blocked")
+		}
+		// Coming back at the 5h reset would just park the run again on the
+		// weekly window.
+		if !d.ResetsAt.Equal(late) {
+			t.Fatalf("ResetsAt = %v, want the last window to reopen (%v)", d.ResetsAt, late)
+		}
+	})
+}
+
+func TestPolicyString(t *testing.T) {
+	if got := (Policy{}).String(); got != "usage caps off" {
+		t.Errorf("String() = %q", got)
+	}
+	got := joPolicy().String()
+	if !strings.Contains(got, "5h=85%/soft") || !strings.Contains(got, "week=75%/hard") {
+		t.Errorf("String() = %q, want both caps and their modes", got)
+	}
+}
+
+func TestNilGuardIsInert(t *testing.T) {
+	var g *Guard
+	if d := g.Observe(reading(WindowSevenDay, 1.0, time.Time{})); d.Blocked {
+		t.Fatal("a nil guard blocked")
+	}
+	if g.Fired() || g.Latest() != nil || g.Policy().Enabled() {
+		t.Fatal("a nil guard must answer as an absent cap, so callers need no nil check")
+	}
+}

--- a/studio/src/components/Runs/eventLog/eventModel.ts
+++ b/studio/src/components/Runs/eventLog/eventModel.ts
@@ -16,6 +16,10 @@ export const EVENT_BADGE: Record<string, string> = {
   artifact_written: "bg-accent-soft text-fg-default",
   human_input_requested: "bg-warning-soft text-warning-fg",
   budget_warning: "bg-warning-soft text-warning-fg",
+  // The operator's own subscription ceiling, hit below the provider's
+  // wall. Warning-coloured: the run either stops or is the last one to
+  // start, and either way it is a decision iterion took.
+  usage_cap: "bg-warning-soft text-warning-fg",
   budget_exceeded: "bg-danger-soft text-danger-fg",
   // A route change, not a failure — the run continues on another
   // model/backend. Warning-coloured because the primary route is gone.


### PR DESCRIPTION
## Why

A subscription meters two rolling windows (5h, 7d) and refuses every call once one is exhausted. iterion already survived that refusal — the run parks and a durable retry resumes it when the window reopens. It could not stop **before** the wall, and the wall is rarely where an operator wants to be: the same subscription usually pays for their own interactive work, so a fleet of bots that drives it to 100% takes the human down with it.

Measured on 2026-08-17: the weekly forfait hit 100% at 03:57 UTC, parking 12 runs; the operator was at 92% with headroom for their own work down to 95%.

## What

`ITERION_USAGE_CAP_5H_PCT=85` + `ITERION_USAGE_CAP_WEEK_PCT=75` is the whole configuration. Off by default.

| Window | Default mode | Behaviour |
|---|---|---|
| five-hour | `soft` | never interrupts work in flight; no NEW run starts |
| weekly | `hard` | stops the run where it stands |

The postures differ because the windows do: a 5h window refills soon, so killing a half-finished run to save minutes trades a lot for a little; a weekly window that runs out on a Tuesday is a dead week.

**Both end a capped run as the provider's own refusal does**, so the existing park-and-resume path carries it home untouched — a capped run is not a lost run, it is a run that waits. The one behaviour that had to differ is the in-place retry: re-issuing the call would spend exactly the quota the cap protects, and the provider would serve it. Hence `SelfImposed` on `ErrRateLimited`; a real provider refusal keeps its historical budget (ADR-087's chain semantics are untouched).

## Where the numbers come from

`claude_code` emits `rate_limit_event` on its stream-json output: `{status, rateLimitType, utilization (fraction 0..1), resetsAt (epoch seconds)}`. That is the only place a subscription's headroom is observable from outside the provider — a CLI session hides the API's `anthropic-ratelimit-*` headers, and `GET /api/oauth/usage` needs a `user:profile` scope a `claude setup-token` credential does not carry (verified live: 403). Consequence: the cap is claude_code-shaped today.

## Cloud

Readings are shared through a Mongo `usage_windows` ledger keyed per credential, so a claimed run parks **before** cloning a repo or starting a container instead of rediscovering the ceiling by spending against it. A tenant's own subscription never blocks another's. The pre-flight **fails open** on every uncertainty — a cap protects a subscription from a fleet, not the reverse — and a reading expires at its own reset instant, so a stale number stops blocking with no sweeper to tune.

## Scope

No per-run flag and no DSL field: the cap protects a credential and the deployment that owns it, and a bot able to lift the guard would not be a guard. `ITERION_USAGE_CAP=off` is the escape hatch.

Docs: [docs/usage-caps.md](docs/usage-caps.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)