### PR TITLE
fix(runtime): a run drained before its first node is resumable

### DIFF
--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -437,7 +437,6 @@ type resumeBackendState struct {
 // classification, minus the checkpoint, which no node has yet earned —
 // resume then restarts from the entry, which it is built to do.
 func (e *Engine) markFailedBestEffort(ctx context.Context, runID, phase string, cause error) {
-	msg := fmt.Sprintf("%s: %v", phase, cause)
 	writeCtx := context.WithoutCancel(ctx)
 	status, msg := setupFailureStatus(ctx, phase, cause)
 	var err error

--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -427,21 +427,69 @@ type resumeBackendState struct {
 // and a lost flip costs an operator round trip — or waits for the
 // periodic orphan reconcile. Attempts run on a detached ctx: the run
 // ctx being dead is one of the very triggers that lands here.
+// The status it writes is not always `failed`. Setup runs on the same
+// ctx the node loop does, so the same two interruptions reach it — and
+// they mean the same thing here as there: a runner drained mid-rollout,
+// or an operator cancelling, has not produced a workflow failure. Marked
+// terminal, such a run cannot be resumed, and for a review that means the
+// merge gate it owed stays absent for good. The node loop already
+// classifies both (handleContextDoneWithCheckpoint); this is that
+// classification, minus the checkpoint, which no node has yet earned —
+// resume then restarts from the entry, which it is built to do.
 func (e *Engine) markFailedBestEffort(ctx context.Context, runID, phase string, cause error) {
 	msg := fmt.Sprintf("%s: %v", phase, cause)
 	writeCtx := context.WithoutCancel(ctx)
+	status, msg := setupFailureStatus(ctx, phase, cause)
 	var err error
 	for attempt, delay := 0, 500*time.Millisecond; attempt < 3; attempt, delay = attempt+1, delay*4 {
 		if attempt > 0 {
 			time.Sleep(delay)
 		}
-		if err = e.store.UpdateRunStatus(writeCtx, runID, store.RunStatusFailed, msg); err == nil {
+		if err = e.store.UpdateRunStatus(writeCtx, runID, status, msg); err == nil {
 			return
 		}
 	}
 	if e.logger != nil {
-		e.logger.Warn("runtime: failed to record run %s as failed during %s after 3 attempts: %v (original cause: %v — the run stays running until the orphan reconcile catches it)", runID, phase, err, cause)
+		e.logger.Warn("runtime: failed to record run %s as %s during %s after 3 attempts: %v (original cause: %v — the run stays running until the orphan reconcile catches it)", runID, status, phase, err, cause)
 	}
+}
+
+// setupFailureStatus classifies a pre-execLoop failure, mirroring what
+// handleContextDoneWithCheckpoint decides inside a node.
+//
+//   - the run ctx cancelled with ErrRunInterrupted (runner drain, lost
+//     heartbeat) — infrastructure took the run away: failed_resumable, so
+//     the ordinary retry puts it on a healthy pod;
+//   - the run ctx cancelled by an operator: cancelled, which is resumable
+//     too and says who stopped it;
+//   - anything else — a real setup error: failed, as before.
+//
+// It reads the CTX, not just the error: a drain kills the work by
+// cancelling, so what surfaces is whatever the interrupted step returned
+// (a killed `kubectl exec`, a half-written worktree), never the cause.
+func setupFailureStatus(ctx context.Context, phase string, cause error) (store.RunStatus, string) {
+	if ctx == nil || ctx.Err() == nil {
+		return store.RunStatusFailed, fmt.Sprintf("%s: %v", phase, cause)
+	}
+	if errors.Is(context.Cause(ctx), ErrRunInterrupted) {
+		return store.RunStatusFailedResumable, fmt.Sprintf("%s interrupted before the first node (resumable): %v", phase, cause)
+	}
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return store.RunStatusCancelled, fmt.Sprintf("%s cancelled before the first node: %v", phase, cause)
+	}
+	return store.RunStatusFailed, fmt.Sprintf("%s: %v", phase, cause)
+}
+
+// setupErr decorates the error a setup phase returns so an interruption
+// stays recognisable to the runner: it NAKs on ErrRunInterrupted (the run
+// is redelivered to a healthy pod) and ACKs on anything else. Without it
+// the status written above would say resumable while the queue had
+// already dropped the run — the two halves have to agree.
+func (e *Engine) setupErr(ctx context.Context, err error) error {
+	if ctx != nil && ctx.Err() != nil && errors.Is(context.Cause(ctx), ErrRunInterrupted) {
+		return fmt.Errorf("%w: %v", ErrRunInterrupted, err)
+	}
+	return err
 }
 
 // newRunState builds a runState with all maps allocated. Resume paths

--- a/pkg/runtime/engine_run.go
+++ b/pkg/runtime/engine_run.go
@@ -88,7 +88,7 @@ func (e *Engine) Run(ctx context.Context, runID string, inputs map[string]any) (
 	// spun up for a doomed run.
 	if err := e.validateVarEnums(run.Inputs); err != nil {
 		e.markFailedBestEffort(ctx, runID, "var validation", err)
-		return fmt.Errorf("runtime: var validation: %w", err)
+		return e.setupErr(ctx, fmt.Errorf("runtime: var validation: %w", err))
 	}
 
 	// Worktree setup stays inline: the finalizeOnExit defer must
@@ -138,7 +138,7 @@ func (e *Engine) Run(ctx context.Context, runID string, inputs map[string]any) (
 			wtc, cleanup, wtErr := setupWorktree(e.store.Root(), runID, e.workDir, e.logger)
 			if wtErr != nil {
 				e.markFailedBestEffort(ctx, runID, "worktree setup", wtErr)
-				return fmt.Errorf("runtime: worktree setup: %w", wtErr)
+				return e.setupErr(ctx, fmt.Errorf("runtime: worktree setup: %w", wtErr))
 			}
 			e.workDir = wtc.wtPath
 			worktreeCleanup = cleanup
@@ -174,7 +174,7 @@ func (e *Engine) Run(ctx context.Context, runID string, inputs map[string]any) (
 	sandboxCleanup, sbErr := e.startSandbox(ctx, runID, repoRoot, wtCtx.gitDir, inputs)
 	if sbErr != nil {
 		e.markFailedBestEffort(ctx, runID, "sandbox start", sbErr)
-		return fmt.Errorf("runtime: sandbox: %w", sbErr)
+		return e.setupErr(ctx, fmt.Errorf("runtime: sandbox: %w", sbErr))
 	}
 	defer sandboxCleanup()
 
@@ -185,7 +185,7 @@ func (e *Engine) Run(ctx context.Context, runID string, inputs map[string]any) (
 	// caps only; expression / unbounded caps emit 0 (max unknown).
 	if err := e.emit(ctx, runID, store.EventRunStarted, "", loopBoundsPayload(e.workflow)); err != nil {
 		e.markFailedBestEffort(ctx, runID, "emit run_started", err)
-		return fmt.Errorf("runtime: emit run_started: %w", err)
+		return e.setupErr(ctx, fmt.Errorf("runtime: emit run_started: %w", err))
 	}
 
 	rs := e.runInitState(ctx, runID, inputs)
@@ -335,12 +335,12 @@ func (e *Engine) runResolveDoc(ctx context.Context, runID string, inputs map[str
 func (e *Engine) runPromoteAttachments(ctx context.Context, runID string, run *store.Run) (*store.Run, error) {
 	if err := promoteBundleAttachmentDefaults(ctx, e.store, runID, e.workflow, e.bundle, e.logger); err != nil {
 		e.markFailedBestEffort(ctx, runID, "bundle attachment defaults", err)
-		return nil, fmt.Errorf("runtime: bundle attachment defaults: %w", err)
+		return nil, e.setupErr(ctx, fmt.Errorf("runtime: bundle attachment defaults: %w", err))
 	}
 	if e.attachmentPromote != nil {
 		if err := e.attachmentPromote(ctx, runID); err != nil {
 			e.markFailedBestEffort(ctx, runID, "attachment promote", err)
-			return nil, fmt.Errorf("runtime: promote attachments: %w", err)
+			return nil, e.setupErr(ctx, fmt.Errorf("runtime: promote attachments: %w", err))
 		}
 	}
 	if reloaded, err := e.store.LoadRun(ctx, runID); err == nil {
@@ -395,7 +395,7 @@ func (e *Engine) runPersistWorkspace(ctx context.Context, runID string, run *sto
 		}
 		if err := e.store.SaveRun(ctx, run); err != nil {
 			e.markFailedBestEffort(ctx, runID, "save work dir", err)
-			return fmt.Errorf("runtime: save work dir: %w", err)
+			return e.setupErr(ctx, fmt.Errorf("runtime: save work dir: %w", err))
 		}
 	}
 	// Push workDir into the executor so backend subprocesses (claude_code,

--- a/pkg/runtime/setup_failure_status_test.go
+++ b/pkg/runtime/setup_failure_status_test.go
@@ -1,0 +1,93 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// Setup runs on the same ctx the node loop does, so the same two
+// interruptions reach it — and mean the same thing. Marked terminal, a
+// drained run cannot be resumed at all, and a review that owed a merge gate
+// never gets to post one.
+func TestSetupFailureStatus(t *testing.T) {
+	boom := errors.New("kubectl exec: signal: killed")
+
+	interrupted, cancelInterrupted := context.WithCancelCause(context.Background())
+	cancelInterrupted(ErrRunInterrupted)
+	operator, cancelOperator := context.WithCancel(context.Background())
+	cancelOperator()
+
+	for _, tc := range []struct {
+		name   string
+		ctx    context.Context
+		want   store.RunStatus
+		reason string
+	}{
+		{"a runner drain is resumable", interrupted, store.RunStatusFailedResumable, "interrupted"},
+		{"an operator cancel says so", operator, store.RunStatusCancelled, "cancelled"},
+		{"a real setup error still fails", context.Background(), store.RunStatusFailed, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, msg := setupFailureStatus(tc.ctx, "sandbox start", boom)
+			if got != tc.want {
+				t.Fatalf("status = %q, want %q (msg %q)", got, tc.want, msg)
+			}
+			if !strings.Contains(msg, "sandbox start") || !strings.Contains(msg, boom.Error()) {
+				t.Errorf("the message must keep the phase and the cause; got %q", msg)
+			}
+		})
+	}
+}
+
+// The status and the error have to agree: the runner NAKs on
+// ErrRunInterrupted (redelivered to a healthy pod) and ACKs otherwise, so a
+// run recorded resumable whose error lost the marker would be dropped by the
+// queue and never come back.
+func TestSetupErr_KeepsTheInterruptionMarker(t *testing.T) {
+	e := &Engine{}
+	inner := errors.New("worktree half-written")
+
+	drained, cancel := context.WithCancelCause(context.Background())
+	cancel(ErrRunInterrupted)
+	if err := e.setupErr(drained, inner); !errors.Is(err, ErrRunInterrupted) {
+		t.Fatalf("a drained setup must stay recognisable to the runner, got %v", err)
+	}
+	if err := e.setupErr(context.Background(), inner); errors.Is(err, ErrRunInterrupted) {
+		t.Fatalf("an ordinary setup error must not claim an interruption: %v", err)
+	}
+}
+
+// The composition: the engine driven with a drained ctx must leave the run
+// resumable in the STORE and return an error the runner will nak.
+func TestEngineRun_SetupDrainLeavesTheRunResumable(t *testing.T) {
+	s := tmpStore(t)
+	eng := New(devboxTestWorkflow(), s, newStubExecutor(),
+		WithWorkDir(t.TempDir()),
+		WithSandboxOverride("none"),
+		WithLogger(iterlog.Nop()),
+	)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(ErrRunInterrupted)
+
+	const runID = "run-drained-in-setup"
+	err := eng.Run(ctx, runID, nil)
+	if err == nil {
+		t.Fatal("a drained run must not report success")
+	}
+	if !errors.Is(err, ErrRunInterrupted) {
+		t.Fatalf("the runner naks on ErrRunInterrupted; got %v", err)
+	}
+	run, lerr := s.LoadRun(context.Background(), runID)
+	if lerr != nil {
+		t.Fatalf("load run: %v", lerr)
+	}
+	if run.Status != store.RunStatusFailedResumable {
+		t.Fatalf("status = %q, want failed_resumable (a drain is not a workflow failure)", run.Status)
+	}
+}


### PR DESCRIPTION
## What happened in production

A rolling deploy restarted the runner pods at 14:14Z. A review that had started at 13:49 was mid-**sandbox postCreate** — installing the *target repo's* devbox toolchain (319 nix paths, 406 MiB down / 1.8 GiB unpacked, because the repo under review declares the whole dev chain). The `kubectl exec` carrying that install was killed with the pod, and the run ended:

```
sandbox start: runtime: sandbox: start: kubernetes: postCreate: postCreateCommand exited -1
```

`exited -1` is a signal, not an exit code — the drain, seen from the other side. And the run was recorded **`failed`**: terminal.

## The defect

Setup runs on the same ctx the node loop does, so the same two interruptions reach it. The node loop already tells them apart (`handleContextDoneWithCheckpoint`): `failed_resumable` for a drain (`ErrRunInterrupted`), `cancelled` for an operator. Every **pre-execLoop** phase — var validation, worktree setup, sandbox start, `run_started`, attachments — wrote a flat terminal `failed` instead.

Terminal is the wrong answer for infrastructure taking the run away:

- the run **cannot be resumed at all** — the status is not in the resumable set;
- a review that owed a merge gate never gets to post one, so **the required check stays absent** with no error anywhere. That is the hole `docs/merge-gate.md` exists to close, reached through a door nobody had classified.

## The fix

`setupFailureStatus` mirrors the node loop's decision, minus the checkpoint — no node has earned one, and resume restarts from the entry, which it is built to do.

`setupErr` is the half that makes it actually work: **the status and the error have to agree.** The runner NAKs on `ErrRunInterrupted` (redelivered to a healthy pod) and ACKs on anything else, so a run recorded resumable whose error lost the marker would be dropped by the queue and never come back.

## Tests

- `TestSetupFailureStatus` — the three-way table (drain / operator cancel / real setup error), asserting the message keeps both the phase and the cause.
- `TestSetupErr_KeepsTheInterruptionMarker` — verified to FAIL with the marker suppressed (`got worktree half-written`).
- `TestEngineRun_SetupDrainLeavesTheRunResumable` — the composition: the engine driven with a drained ctx must leave `failed_resumable` **in the store** and return an error the runner will nak.

## Not fixed here

Reviewing a repo that declares a heavy devbox toolchain still installs 1.8 GiB before the first node, which is what made this window wide enough to hit. Worth a separate look — a read-only reviewer arguably needs none of it — but that is a policy question, not this bug.