### PR TITLE
fix(usagecap): a cap on model spend must not stop a run that spends none

### DIFF
--- a/docs/usage-caps.md
+++ b/docs/usage-caps.md
@@ -97,6 +97,34 @@ Consequences worth knowing:
 - then the ordinary wait: `run_retry_scheduled` with `retry_after` at the
   window's reopening, and `run_auto_resumed` when it fires.
 
+## What a cap does NOT stop
+
+**A workflow that cannot call a model is never blocked.** The cap governs a
+model subscription; a run with no agent, judge, `llm` router, model-answered
+human node, agent recovery rung, subbot or supervisor cannot draw on it, so
+refusing that run would protect nothing.
+
+The distinction is not cosmetic. A zero-LLM run is often the half of a bot
+that *gathers* — and gathered material is not recoverable by retrying later.
+Vigie's `collect` mode polls feeds into a queue; a feed serves a short window
+and does not remember what nobody fetched, so every refused collect is
+material permanently gone, while the `digest` half it feeds waits on a queue
+that stays empty. Between 2026-08-17 and 2026-08-18 that is exactly what
+happened.
+
+The predicate is [`ir.Workflow.UsesLLM`](../pkg/dsl/ir/uses_llm.go) and it is
+deliberately conservative: every uncertainty answers "yes, it spends". A
+subbot counts because its child `.bot` is a separate source the parent does
+not carry; a supervisor counts even when no graph node does, because it
+watches with a model of its own. So the predicate can only ever spare a
+workflow provably free of model calls — it can never hand a spender a pass.
+
+Both pre-flights apply it: the cloud runner's (which has the compiled
+workflow in hand) and the local launch path's (which compiles only when the
+cap is blocking, so the common case pays nothing). The mid-run guard stays
+armed in both cases, so a workflow that turns out to spend anyway is still
+stopped at the call.
+
 ## Cloud
 
 Every pod sees only its own session, so readings are shared through the

--- a/pkg/dsl/ir/uses_llm.go
+++ b/pkg/dsl/ir/uses_llm.go
@@ -1,0 +1,68 @@
+package ir
+
+// UsesLLM reports whether executing this workflow can result in at least
+// one model call.
+//
+// It exists for the guards that protect a *model* budget — the operator's
+// subscription cap first among them. Such a guard refusing to start a
+// workflow that would never call a model protects nothing and costs
+// everything: the zero-LLM half of a two-mode bot (a feed collector that
+// only polls RSS and appends to a queue) stops running while the window is
+// shut, and the material it was supposed to bank is simply lost, because a
+// feed serves a short window and does not remember what nobody fetched.
+//
+// The answer is deliberately CONSERVATIVE: every uncertainty returns true,
+// so a guard keeps blocking exactly what it blocks today and this predicate
+// can only ever open the door for a workflow provably free of model calls.
+// A subbot is the clearest case — its child `.bot` is a separate source
+// this workflow does not carry, so it counts as LLM-using on principle.
+func (w *Workflow) UsesLLM() bool {
+	if w == nil {
+		return false
+	}
+	// A supervisor is an LLM agent watching the run from the side; it can
+	// wake and spend even when no graph node ever would.
+	if len(w.Supervisors) > 0 {
+		return true
+	}
+	for _, n := range w.Nodes {
+		if nodeUsesLLM(n) {
+			return true
+		}
+	}
+	return false
+}
+
+// nodeUsesLLM answers for one node. Kept separate so the reasoning per node
+// kind stays readable, and each `true` names why it is one.
+func nodeUsesLLM(n Node) bool {
+	switch node := n.(type) {
+	case *AgentNode, *JudgeNode:
+		// The two node kinds whose whole purpose is a model call.
+		return true
+	case *RouterNode:
+		// Only the `llm` routing mode asks a model where to go; the
+		// deterministic modes (fan_out_*, condition, round_robin) do not.
+		return node.RouterMode == RouterLLM
+	case *HumanNode:
+		// `interaction: llm` answers the question with a model instead of
+		// a human, and `llm_or_human` tries that first.
+		return interactionUsesLLM(node.Interaction)
+	case *ToolNode:
+		// A tool node is a shell command — except that a Verified Action's
+		// rung 4 hands recovery to an agent when the recipe cannot heal
+		// itself. A run that only *might* reach that rung still can.
+		return node.Recovery != nil && node.Recovery.MaxAgentAttempts > 0
+	case *SubbotNode:
+		// The child `.bot` is another source entirely: unknowable from
+		// here, so assumed to spend.
+		return true
+	}
+	return false
+}
+
+// interactionUsesLLM reports whether an interaction mode can answer with a
+// model rather than by parking for a human.
+func interactionUsesLLM(m InteractionMode) bool {
+	return m == InteractionLLM || m == InteractionLLMOrHuman
+}

--- a/pkg/dsl/ir/uses_llm_test.go
+++ b/pkg/dsl/ir/uses_llm_test.go
@@ -1,0 +1,117 @@
+package ir
+
+import "testing"
+
+func wfWith(nodes ...Node) *Workflow {
+	w := &Workflow{Name: "w", Nodes: map[string]Node{}}
+	for i, n := range nodes {
+		w.Nodes[string(rune('a'+i))] = n
+	}
+	return w
+}
+
+// TestWorkflowUsesLLM covers the predicate kind by kind. The direction that
+// matters is asymmetric: a false NEGATIVE hands a model-calling workflow a
+// pass around the cap protecting the subscription, so every uncertain shape
+// must answer true. A false positive only preserves today's behaviour.
+func TestWorkflowUsesLLM(t *testing.T) {
+	tests := []struct {
+		name string
+		wf   *Workflow
+		want bool
+	}{
+		{name: "nil", wf: nil, want: false},
+		{name: "empty", wf: wfWith(), want: false},
+		{
+			name: "an agent node spends",
+			wf:   wfWith(&AgentNode{BaseNode: BaseNode{ID: "a"}}),
+			want: true,
+		},
+		{
+			name: "a judge node spends",
+			wf:   wfWith(&JudgeNode{BaseNode: BaseNode{ID: "a"}}),
+			want: true,
+		},
+		{
+			// The Vigie collect shape: tools + compute + terminals only.
+			name: "tools and compute alone do not",
+			wf: wfWith(
+				&ToolNode{BaseNode: BaseNode{ID: "a"}, Command: "true"},
+				&ComputeNode{BaseNode: BaseNode{ID: "b"}},
+				&DoneNode{BaseNode: BaseNode{ID: "c"}},
+				&FailNode{BaseNode: BaseNode{ID: "d"}},
+			),
+			want: false,
+		},
+		{
+			name: "a deterministic router does not",
+			wf:   wfWith(&RouterNode{BaseNode: BaseNode{ID: "a"}, RouterMode: RouterFanOutAll}),
+			want: false,
+		},
+		{
+			name: "an llm router does",
+			wf:   wfWith(&RouterNode{BaseNode: BaseNode{ID: "a"}, RouterMode: RouterLLM}),
+			want: true,
+		},
+		{
+			name: "a human node parking for a human does not",
+			wf: wfWith(&HumanNode{BaseNode: BaseNode{ID: "a"},
+				InteractionFields: InteractionFields{Interaction: InteractionHuman}}),
+			want: false,
+		},
+		{
+			name: "a human node answered by a model does",
+			wf: wfWith(&HumanNode{BaseNode: BaseNode{ID: "a"},
+				InteractionFields: InteractionFields{Interaction: InteractionLLM}}),
+			want: true,
+		},
+		{
+			name: "llm_or_human does — it tries the model first",
+			wf: wfWith(&HumanNode{BaseNode: BaseNode{ID: "a"},
+				InteractionFields: InteractionFields{Interaction: InteractionLLMOrHuman}}),
+			want: true,
+		},
+		{
+			// Rung 4 of a Verified Action hands recovery to an agent. A run
+			// that only MIGHT reach it still can.
+			name: "a tool node with agent recovery does",
+			wf: wfWith(&ToolNode{BaseNode: BaseNode{ID: "a"}, Command: "true",
+				Recovery: &RecoverySpec{MaxAgentAttempts: 1}}),
+			want: true,
+		},
+		{
+			name: "a tool node whose agent rung is off does not",
+			wf: wfWith(&ToolNode{BaseNode: BaseNode{ID: "a"}, Command: "true",
+				Recovery: &RecoverySpec{MaxAgentAttempts: 0}}),
+			want: false,
+		},
+		{
+			// The child .bot is a separate source this workflow does not
+			// carry: unknowable here, so assumed to spend.
+			name: "a subbot does — its child is unknowable from here",
+			wf:   wfWith(&SubbotNode{BaseNode: BaseNode{ID: "a"}, Source: "child.bot"}),
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.wf.UsesLLM(); got != tc.want {
+				t.Errorf("UsesLLM() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWorkflowUsesLLM_SupervisorCountsWithoutAnyLLMNode is the trap: a
+// supervisor is an LLM agent watching from the side, so a graph made only of
+// tool nodes can still spend. Looking at nodes alone would miss it.
+func TestWorkflowUsesLLM_SupervisorCountsWithoutAnyLLMNode(t *testing.T) {
+	w := wfWith(&ToolNode{BaseNode: BaseNode{ID: "a"}, Command: "true"})
+	if w.UsesLLM() {
+		t.Fatal("precondition: a tool-only graph must not count yet")
+	}
+	w.Supervisors = []*Supervisor{{Name: "watch"}}
+	if !w.UsesLLM() {
+		t.Error("a supervisor watches with a model — the workflow spends")
+	}
+}

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -1174,7 +1174,7 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 	// container: at this point the run has cost nothing yet, so a capped
 	// run parks for free instead of paying a workspace and one LLM call to
 	// rediscover a ceiling another pod already measured.
-	if capErr := r.usageCapPreflight(ctx, msg, r.cfg.Logger); capErr != nil {
+	if capErr := r.usageCapPreflight(ctx, wf, msg, r.cfg.Logger); capErr != nil {
 		return capErr
 	}
 

--- a/pkg/runner/usage_cap.go
+++ b/pkg/runner/usage_cap.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/queue"
 	"github.com/SocialGouv/iterion/pkg/secrets"
@@ -85,9 +86,20 @@ const usageCapStoreTimeout = 5 * time.Second
 // A cap exists to protect a subscription from a fleet of bots, not to strand
 // the fleet when its bookkeeping is unavailable: the mid-run guard is still
 // armed behind it, so the worst case of failing open is one wasted call.
-func (r *Runner) usageCapPreflight(ctx context.Context, msg *queue.RunMessage, logger *iterlog.Logger) error {
+func (r *Runner) usageCapPreflight(ctx context.Context, wf *ir.Workflow, msg *queue.RunMessage, logger *iterlog.Logger) error {
 	pol := r.cfg.UsageCapPolicy
 	if !pol.Enabled() || r.cfg.UsageCaps == nil {
+		return nil
+	}
+	// A workflow that cannot call a model has nothing to draw on the
+	// subscription this cap protects. Blocking it would protect nothing and
+	// lose whatever it was supposed to do meanwhile — for a feed collector,
+	// material that no later run can recover, since a feed only serves a
+	// short window. The mid-run guard stays armed either way.
+	if !wf.UsesLLM() {
+		if logger != nil {
+			logger.Debug("runner: run %s makes no model call — usage cap not applied", msg.RunID)
+		}
 		return nil
 	}
 	rctx, cancel := context.WithTimeout(ctx, usageCapStoreTimeout)

--- a/pkg/runner/usage_cap_test.go
+++ b/pkg/runner/usage_cap_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/queue"
 	"github.com/SocialGouv/iterion/pkg/secrets"
@@ -55,6 +56,19 @@ func capRunner(pol usagecap.Policy, caps usagecap.Store, rs store.RunStore) *Run
 	}}
 }
 
+// capLLMWorkflow is the shape every pre-flight test assumed before the
+// predicate existed: a workflow with an agent node, i.e. one that can
+// actually draw on the subscription the cap protects.
+func capLLMWorkflow() *ir.Workflow {
+	return &ir.Workflow{
+		Name:  "capped",
+		Entry: "think",
+		Nodes: map[string]ir.Node{
+			"think": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "think"}},
+		},
+	}
+}
+
 func TestUsageCapPreflight_BlocksBeforeSpendingAnything(t *testing.T) {
 	ctx := t.Context()
 	resets := time.Now().UTC().Add(30 * time.Hour)
@@ -72,7 +86,7 @@ func TestUsageCapPreflight_BlocksBeforeSpendingAnything(t *testing.T) {
 	rs := &capStatusStore{}
 	r := capRunner(capTestPolicy(), caps, rs)
 
-	err := r.usageCapPreflight(ctx, &queue.RunMessage{RunID: "run-1"}, iterlog.Nop())
+	err := r.usageCapPreflight(ctx, capLLMWorkflow(), &queue.RunMessage{RunID: "run-1"}, iterlog.Nop())
 	if err == nil {
 		t.Fatal("want the run refused: the weekly window is at 92% against a 75% cap")
 	}
@@ -165,7 +179,7 @@ func TestUsageCapPreflight_FailsOpen(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rs := &capStatusStore{}
 			r := capRunner(tt.pol, tt.caps(t), rs)
-			if err := r.usageCapPreflight(t.Context(), &queue.RunMessage{RunID: "run-1"}, iterlog.Nop()); err != nil {
+			if err := r.usageCapPreflight(t.Context(), capLLMWorkflow(), &queue.RunMessage{RunID: "run-1"}, iterlog.Nop()); err != nil {
 				t.Fatalf("blocked the run: %v", err)
 			}
 			if rs.calls != 0 {
@@ -230,5 +244,65 @@ func TestUsageGuardFor_PublishesUnderTheRunsCredentialKey(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].Utilization != 0.5 {
 		t.Fatalf("ledger = %+v, want the reading under the tenant's key", got)
+	}
+}
+
+// capToolOnlyWorkflow is the Vigie `collect` shape: a graph of tool nodes
+// that never reaches a model. Documented zero-LLM, and refused for five days
+// by a cap on a subscription it could not have spent.
+func capToolOnlyWorkflow() *ir.Workflow {
+	return &ir.Workflow{
+		Name:  "collect",
+		Entry: "fetch",
+		Nodes: map[string]ir.Node{
+			"fetch": &ir.ToolNode{BaseNode: ir.BaseNode{ID: "fetch"}, Command: "true"},
+			"dedup": &ir.ToolNode{BaseNode: ir.BaseNode{ID: "dedup"}, Command: "true"},
+			"done":  &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+		},
+	}
+}
+
+// TestUsageCapPreflight_SparesAWorkflowThatCannotCallAModel is the fix's
+// reason for existing, in the shape that produced it.
+//
+// The cap protects an LLM subscription. A workflow with no model call cannot
+// draw on it, so refusing that run protects nothing — and costs whatever the
+// run was there to do. For a feed collector the loss is not recoverable by
+// retrying later: a feed serves a short window and does not remember what
+// nobody fetched, so five days of refusals are five days of material gone.
+//
+// The ledger below is the one that blocked Vigie: the seven-day window at
+// 92% against a 75% cap. The LLM-shaped run must still be refused (asserted
+// in the same test, so a fix that simply disabled the cap fails here).
+func TestUsageCapPreflight_SparesAWorkflowThatCannotCallAModel(t *testing.T) {
+	ctx := t.Context()
+	caps := usagecap.NewMemStore()
+	if err := caps.Record(ctx, usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform),
+		usagecap.Reading{
+			Window:      usagecap.WindowSevenDay,
+			Utilization: 0.92,
+			Status:      usagecap.StatusWarning,
+			ResetsAt:    time.Now().UTC().Add(30 * time.Hour),
+			ObservedAt:  time.Now().UTC(),
+		}); err != nil {
+		t.Fatal(err)
+	}
+	rs := &capStatusStore{}
+	r := capRunner(capTestPolicy(), caps, rs)
+
+	if err := r.usageCapPreflight(ctx, capToolOnlyWorkflow(),
+		&queue.RunMessage{RunID: "collect-1"}, iterlog.Nop()); err != nil {
+		t.Fatalf("a zero-LLM run was refused by an LLM cap: %v", err)
+	}
+	// And it must not be marked failed_resumable either: a run that was
+	// never blocked has no reason to carry the status of a blocked one.
+	if rs.calls != 0 {
+		t.Errorf("flipped the run's status %d times without blocking it", rs.calls)
+	}
+
+	// Same ledger, same runner: a workflow that CAN spend is still refused.
+	if err := r.usageCapPreflight(ctx, capLLMWorkflow(),
+		&queue.RunMessage{RunID: "think-1"}, iterlog.Nop()); err == nil {
+		t.Error("the cap must still refuse a model-calling run")
 	}
 }

--- a/pkg/runview/service_launch.go
+++ b/pkg/runview/service_launch.go
@@ -121,7 +121,12 @@ func (s *Service) Launch(parent context.Context, spec LaunchSpec) (*LaunchResult
 	// refusing it — here the operator is present, so an immediate refusal
 	// is the honest answer.
 	if blocked, reason := LocalUsagePreflight(); blocked {
-		return nil, fmt.Errorf("%w: %s", runtime.ErrUsageCapped, reason)
+		// …unless this workflow cannot call a model at all, in which case
+		// the cap guards nothing it could spend. The compile is paid ONLY
+		// on the blocked path, so the common case stays free.
+		if wf, _, err := compileForLaunch(spec.FilePath, spec.Source); err != nil || wf.UsesLLM() {
+			return nil, fmt.Errorf("%w: %s", runtime.ErrUsageCapped, reason)
+		}
 	}
 
 	if detachedEnabled() {


### PR DESCRIPTION
## The defect

The usage-cap pre-flight refuses every claimed run while the window is shut — without asking whether the run could draw on that window at all.

A workflow made of `tool` / `compute` nodes cannot. There is no model call to bill, so refusing it protects nothing.

## What it cost, in production

The zero-LLM half of a bot is usually the half that **gathers**, and gathered material does not wait for a retry.

Vigie's `collect` mode (documented *zero-LLM*) polls RSS into a queue. A feed serves a short window and does not remember what nobody fetched. From 2026-08-17 17:00 the cap refused every collect:

```
mode=collect  status=failed_resumable
err=usage cap: seven_day window at 98% ≥ 75% (week, hard), resets 2026-08-18T21:00:00Z
```

…while the `digest` half it feeds kept waking every morning to an empty queue and exiting silently. Days of veille lost to a guard for a bill that could never have been charged.

## The change

[`ir.Workflow.UsesLLM`](pkg/dsl/ir/uses_llm.go) — deliberately **conservative**: every uncertainty answers "it spends".

| shape | counts | why |
|---|---|---|
| agent / judge | ✅ | that is the node's purpose |
| router `llm` | ✅ | asks a model where to go |
| human `llm` / `llm_or_human` | ✅ | answers with a model |
| tool with agent recovery rung | ✅ | rung 4 hands recovery to an agent |
| **subbot** | ✅ | its child `.bot` is a source the parent does not carry |
| **supervisor** | ✅ | watches with a model even when no node spends |
| tool / compute / emit / wait / done / fail | ❌ | no model reachable |

So it can only ever spare a workflow *provably* free of model calls — it can never hand a spender a pass.

Both pre-flights consult it:
- **cloud runner** — already holds the compiled workflow at that point, so this costs nothing;
- **local launch** — compiles **only** when the cap is blocking, so the common path is untouched.

The mid-run guard stays armed behind both: a workflow that spends anyway is still stopped at the call. That is what makes failing this way safe.

## Tests

- `pkg/dsl/ir/uses_llm_test.go` — every node kind, both directions, plus the trap: a tool-only graph **with a supervisor** still counts.
- `pkg/runner/usage_cap_test.go` — `TestUsageCapPreflight_SparesAWorkflowThatCannotCallAModel` drives the real pre-flight against **the ledger that blocked Vigie** (seven-day window at 92% vs a 75% cap) and asserts both halves: the tool-only run passes, and *the same runner on the same ledger still refuses a model-calling run* — so a "fix" that merely disabled the cap fails here.

Verified red before the fix:
```
--- FAIL: TestUsageCapPreflight_SparesAWorkflowThatCannotCallAModel
    a zero-LLM run was refused by an LLM cap: rate_limited (claude_code):
    usage cap: seven_day window at 92% ≥ 75% (week, hard) (not started)
```

`task lint` clean · `task test` green. `TestProcessBoardCardCarriesPRLaunchContext` fails here as it does on `main` — the phantom-run defect fixed by #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
