### PR TITLE
feat(feed-watch): a digest dates the window it covers, not today

### DIFF
--- a/bots/feed-watch/main.bot
+++ b/bots/feed-watch/main.bot
@@ -182,6 +182,12 @@ prompt synthesize_system:
   5. Keep message_markdown under ~10000 characters. If
      input.overflow_count > 0, state that N older queued items were
      dropped unprocessed.
+  6. Date the digest for the window it COVERS, not for today. When
+     input.span_days > 1 the queue drained here accumulated over that
+     many days (a shut usage window, a paused schedule, a feed that came
+     back): title it as covering input.oldest_published → today, and do
+     not present items as breaking. When span_days <= 1 it is an ordinary
+     daily digest — title it with today's date as usual.
 
   RULES:
   - Every entry must correspond to input items. NEVER invent an item,
@@ -208,7 +214,8 @@ prompt synthesize_user:
   Compose the "{{input.digest_title}}" digest — {{input.items_count}}
   queued item(s) for category "{{input.category}}"
   ({{input.overflow_count}} older queued item(s) overflowed and were
-  dropped from this digest). Follow the editorial guidance and the system
+  dropped from this digest). This queue spans {{input.span_days}} day(s);
+  its oldest item is dated {{input.oldest_published}}. Follow the editorial guidance and the system
   procedure. Everything you need is inlined below — do NOT read files or
   run shell commands to find it (the run's permission policy forbids them,
   and it is unnecessary: the queue is here).
@@ -288,6 +295,13 @@ schema pending_output:
   ## Queue items beyond max_items (dropped from this digest AND from
   ## the queue — the digest message states the count).
   overflow_count: int
+  ## The window this queue actually spans: date of its oldest item
+  ## (YYYY-MM-DD, "" when no item carries a parsable date) and its age in
+  ## whole days. A digest drains a QUEUE, not a day — after a gap the
+  ## oldest item can be days old, and presenting it as today's news is
+  ## wrong. Read by the synthesis prompt to date the digest honestly.
+  oldest_published: string
+  span_days: int
   ## Every queued item id at snapshot time — commit_state clears
   ## exactly these, so items collected mid-digest survive.
   snapshot_ids: string[]
@@ -310,6 +324,8 @@ schema synthesize_input:
   items: json
   items_count: int
   overflow_count: int
+  oldest_published: string
+  span_days: int
   recent_topics: string
   editorial: string
   editorial_nonce: string
@@ -749,7 +765,7 @@ tool load_pending:
   output: pending_output
   language: py
   script: |
-    import json, os, fcntl
+    import json, os, fcntl, email.utils, datetime
     null = None; true = True; false = False  # JSON-literal shim for missing refs
     category = {{input.category}}
     editorial = {{input.editorial}}
@@ -885,12 +901,37 @@ tool load_pending:
     # per-run nonce fence. The LLM learns the nonce only from its trusted
     # system prompt, so editorial text cannot forge the closing marker to
     # break out and be read as instructions.
+    # How wide a window this queue actually spans. A digest drains a
+    # QUEUE, not a day: after any gap — a shut usage window, a paused
+    # schedule, a broken feed — the oldest item can be days old, and
+    # presenting it as today's news is simply wrong. Computed here, from
+    # the items themselves, so the LLM is told the span rather than left
+    # to infer it from datelines it must not trust.
+    def _pub_dt(it):
+        raw = (it.get('published') or '').strip()
+        if not raw:
+            return None
+        try:
+            d = email.utils.parsedate_to_datetime(raw)
+        except Exception:
+            return None
+        if d is None:
+            return None
+        return d if d.tzinfo else d.replace(tzinfo=datetime.timezone.utc)
+    _dts = [d for d in (_pub_dt(i) for i in items) if d is not None]
+    oldest_published, span_days = '', 0
+    if _dts:
+        oldest = min(_dts)
+        oldest_published = oldest.date().isoformat()
+        span_days = max(0, (datetime.datetime.now(datetime.timezone.utc) - oldest).days)
+
     nonce = os.urandom(8).hex()
     editorial_fenced = ('<<<UNTRUSTED_EDITORIAL ' + nonce + '>>>' + chr(10) +
                         (editorial or '') + chr(10) +
                         '<<<END_UNTRUSTED_EDITORIAL ' + nonce + '>>>')
     print(json.dumps({'has_items': bool(items), 'category': category, 'items': items,
                       'items_count': len(items), 'overflow_count': overflow,
+                      'oldest_published': oldest_published, 'span_days': span_days,
                       'snapshot_ids': snapshot_ids, 'recent_topics': chr(10).join(recent),
                       'editorial': editorial_fenced, 'editorial_nonce': nonce,
                       'digest_title': digest_title, 'sinks': sinks},
@@ -1215,6 +1256,8 @@ workflow feed_watch:
     items: "{{outputs.load_pending.items}}",
     items_count: "{{outputs.load_pending.items_count}}",
     overflow_count: "{{outputs.load_pending.overflow_count}}",
+    oldest_published: "{{outputs.load_pending.oldest_published}}",
+    span_days: "{{outputs.load_pending.span_days}}",
     recent_topics: "{{outputs.load_pending.recent_topics}}",
     editorial: "{{outputs.load_pending.editorial}}",
     editorial_nonce: "{{outputs.load_pending.editorial_nonce}}"

--- a/bots/feed-watch/manifest.yaml
+++ b/bots/feed-watch/manifest.yaml
@@ -1,7 +1,7 @@
 name: feed-watch
 display_name: Vigie
 icon: 🔭
-version: 1.1.2
+version: 1.2.0
 description: |
   Universal feed-watch + digest bot (Huginn-style veille pipeline as a
   single bot). Two run modes over one file-backed state in the target

--- a/docs/bot-runs/feed-watch.md
+++ b/docs/bot-runs/feed-watch.md
@@ -4,6 +4,94 @@
 
 Newest first. One section per dogfooded run.
 
+## 2026-08-18 — Vigie silent since 13 Aug: the collect stopped finding anything new (runs 01a00e17, 01a00e4e)
+
+- Status: **partially diagnosed — re-seeded, root cause NOT closed**
+- Versions: bot 1.1.2 → 1.2.0 · iterion v3.46.0 (`ab3c760`)
+- Method: no LLM spent. Production run artifacts read through
+  `iterion remote api`, the state repo cloned and replayed locally, plus a
+  two-clone end-to-end test of the state hand-off against a local bare remote.
+
+### What the operator saw
+
+Nothing posted to Mattermost after 13 Aug. The runs kept firing and kept
+reporting `finished`.
+
+### What was actually happening
+
+`finished` is not `delivered`. A digest whose queue is empty exits at
+`plan → load_pending → done` — zero LLM, zero post, green status. Every
+`cyber` digest from 14 to 17 Aug did exactly that.
+
+The queue was empty because **the collect stopped finding new items on
+13 Aug around midday**, and never resumed:
+
+| | |
+|---|---|
+| Last state push | `d3223c4` collect 13/08 05:02, then `8726232` digest 06:02 — **nothing until 17/08 11:20** |
+| Every collect since | `new_count: 0`, `duplicate_count: ~969`, `committed: false` |
+| Same collect, run locally off the same git HEAD | **+247 new items** |
+
+The forge push history chains cleanly (`before` → `head`, no force-push), so
+nothing was overwritten: those collects genuinely had nothing to commit.
+
+**Not** the usage cap: that only began refusing runs on 17/08 17:00 — four
+days into the silence. It made things worse (it also refuses `collect`, a
+documented zero-LLM mode) but it is not the cause.
+
+### Hypotheses killed along the way
+
+- **User-Agent / anti-bot** — false. The bot's real UA gets 200 from
+  BleepingComputer, DarkReading and Threatpost. An earlier test that sent
+  *no* UA produced the 403 that suggested it.
+- **A persistent runner workspace holding an out-of-band state** — the
+  runner has a single `emptyDir`, nothing survives a pod. And `ia` delivered
+  75 items on 17/08 while `cyber` saw zero the same morning: a storage-wide
+  divergence cannot be that selective.
+- **The bot's own state hand-off** — proven sound. Two clones against a local
+  bare remote: collect finds 247, commits, pushes; a fresh clone reads back
+  `cyber=96, ia=48`. The chain crosses git correctly.
+
+### What remains open
+
+The prod collect fetches ~969 items (61–63 feeds OK) and matches **all** of
+them against a `seen.json` frozen at 13 Aug. From this workstation the same
+feeds yield 247 unseen ones. The remaining explanation compatible with every
+fact is that the HTTP responses received **from inside the cluster** are
+stale. Confirming it needs one outbound fetch from a pod — refused here
+without named authorization, so it is still to do:
+
+```sh
+kubectl --context ovh-prod -n iterion exec <a runner or server pod> -- \
+  sh -c 'wget -qO- https://krebsonsecurity.com/feed/ | grep -c "<item>"'
+# then compare the newest <pubDate> with what the same feed serves outside
+```
+
+### Actions taken
+
+- **State re-seeded** (`ffb5077..3780fa5`): 222 items back in the queues
+  (cyber 87, design-systems 49, ia 26), recomputed by a local zero-LLM
+  collect. Unblocks the next digest; does not fix the cause.
+- **Engine** — the usage cap no longer refuses a run that cannot call a model
+  (`ir.Workflow.UsesLLM`, PR #451). A refused `collect` is material lost for
+  good: a feed serves a short window and does not remember what nobody
+  fetched.
+- **Bot 1.2.0** — a digest now dates the window it covers (`span_days`,
+  `oldest_published`, PR #452). Measured on the real queue: oldest item
+  13/08, span 5 days.
+
+### Lessons
+
+- **`finished` is not `delivered`.** The empty-queue early exit is correct
+  behaviour and completely silent; nothing alerts when a daily digest posts
+  nothing several days running. That gap is what let this last five days.
+- **Read the schedule before calling a gap a failure.** `cyber` is daily;
+  `ia`/`tsjs`/`gopyrust`/`java` run Mondays, `design-*`/`ux-metier`/`a11y`
+  Wednesdays. Four categories being quiet from 13 to 16 Aug was the plan,
+  not a symptom — an early misreading here cost a full pass.
+- `hnrss.org` has been 502 since at least 17/08 (6–8 feeds). Third-party
+  outage, no effect on the silence.
+
 ## 2026-08-03 — Java digest rejected by its own link firewall: redirect-serving feeds (run 019fc65e)
 
 - Status: **failed (diagnosed + fixed)** — the Monday java digest died on


### PR DESCRIPTION
## Why

A digest drains a **queue**, not a day. The distinction is invisible until something interrupts the run — a shut usage window, a paused schedule, a feed that came back — and then the queue holds days of material that the digest presents as this morning's news: dated today, ranked as breaking.

Vigie's cyber queue at the time of writing:

```
items: 87   dated: 81
oldest_published: 2026-08-13   span_days: 5
```

Tomorrow's digest would have led on five-day-old CERT-FR advisories as fresh.

## What changes

`load_pending` computes the window from **the items themselves** — the oldest parsable publication date and its age in whole days — and passes `oldest_published` + `span_days` to the synthesis step. A new rule in the system prompt: when `span_days > 1`, title the digest for the window it covers (`oldest_published` → today) and stop presenting items as breaking. At a day or less, nothing changes — an ordinary daily digest with today's date.

Deliberate choices:
- read from the items, **never** from the clock alone and never from a dateline the (untrusted) editorial could influence;
- an item whose date does not parse is **skipped, not guessed** — 6 of those 87 carry none, and they cost nothing;
- no new node, no new LLM call: the span rides the input the synthesis step already receives.

## A correction to something I said earlier

Reviewing this, I had told the operator that overflow items stay in the queue for the next digest. They do not: `commit_state` clears every id in `snapshot_ids`, overflow included, exactly as the schema comment already says. Nothing to fix in the code — the mistake was mine, in conversation, and it matters because it changes what `max_digest_items` costs you after a long gap. It does not bite here (87 items against a cap of 150), but it would on a wider backlog.

## Validation

`iterion validate` OK · `go test ./bots/...` green (catalog universality: no stack- or repo-specific default introduced) · span computation verified against the real production queue, output quoted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
