### PR TITLE
fix(usagecap): "contains a model node" is not "will call one"

### DIFF
--- a/docs/usage-caps.md
+++ b/docs/usage-caps.md
@@ -99,10 +99,15 @@ Consequences worth knowing:
 
 ## What a cap does NOT stop
 
-**A workflow that cannot call a model is never blocked.** The cap governs a
-model subscription; a run with no agent, judge, `llm` router, model-answered
-human node, agent recovery rung, subbot or supervisor cannot draw on it, so
-refusing that run would protect nothing.
+**A run is only refused in advance when it could not possibly avoid
+spending.** The cap governs a model subscription, and it blocks at launch
+only if EVERY path from the workflow's entry to a terminal passes through
+something that can call a model — an agent, a judge, an `llm` router, a
+model-answered human node, an agent recovery rung, a subbot, a supervisor.
+
+If any model-free path exists, the run starts and the **mid-run** guard stops
+it at the actual call. That costs a pod and a clone in the worst case, and it
+is the price of not refusing work that would never have been billed.
 
 The distinction is not cosmetic. A zero-LLM run is often the half of a bot
 that *gathers* — and gathered material is not recoverable by retrying later.
@@ -112,12 +117,23 @@ material permanently gone, while the `digest` half it feeds waits on a queue
 that stays empty. Between 2026-08-17 and 2026-08-18 that is exactly what
 happened.
 
-The predicate is [`ir.Workflow.UsesLLM`](../pkg/dsl/ir/uses_llm.go) and it is
-deliberately conservative: every uncertainty answers "yes, it spends". A
-subbot counts because its child `.bot` is a separate source the parent does
-not carry; a supervisor counts even when no graph node does, because it
-watches with a model of its own. So the predicate can only ever spare a
-workflow provably free of model calls — it can never hand a spender a pass.
+**Why "every path" and not "contains a model node".** A two-mode bot carries
+both halves in ONE `.bot`: Vigie's `collect` polls feeds with tool nodes,
+`digest` synthesises with an agent, and a router picks between them from a
+field the `plan` node produces at RUNTIME — not from a var, so no launch-time
+analysis can predict it. A predicate asking merely "does this graph contain
+an agent?" answers yes for both halves and refuses the collect half too. That
+is exactly the defect that silenced the production veille, and shipping the
+weaker predicate first did not fix it.
+
+The predicate is [`ir.Workflow.AlwaysReachesLLM`](../pkg/dsl/ir/uses_llm.go),
+walking forward from the entry and treating a model-calling node as a wall:
+reaching a terminal without hitting one proves a model-free path exists. It
+stays conservative in the direction that matters — an unwalkable graph, a
+missing entry, a dangling edge or a supervisor all answer "true", keeping
+today's refusal rather than opening the gate. (`UsesLLM` still exists for the
+plain "does this graph contain one?" question; the two deliberately disagree
+on a two-mode bot, which is the whole point.)
 
 Both pre-flights apply it: the cloud runner's (which has the compiled
 workflow in hand) and the local launch path's (which compiles only when the

--- a/pkg/dsl/ir/feedwatch_shape_test.go
+++ b/pkg/dsl/ir/feedwatch_shape_test.go
@@ -1,0 +1,35 @@
+package ir
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAlwaysReachesLLM_TheRealTwoModeBot is the regression lock for the
+// defect the FIRST attempt at this guard shipped with.
+//
+// feed-watch carries both halves of a two-mode bot in one `.bot`: `collect`
+// polls feeds with tool nodes and never calls a model, `digest` synthesises
+// with an agent. A predicate that asks "does this graph CONTAIN an LLM
+// node?" answers yes for both, so the collect half kept being refused by a
+// cap it could not have spent against — which is what silenced the
+// production veille for five days.
+//
+// Reading the real bot rather than a hand-built fixture is the point: the
+// first fix passed every synthetic test and still failed here.
+func TestAlwaysReachesLLM_TheRealTwoModeBot(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "bots", "feed-watch", "main.bot")
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("catalog bot not readable from here: %v", err)
+	}
+	w := mustCompile(t, string(src))
+
+	if !w.UsesLLM() {
+		t.Fatal("precondition: the bot does contain an agent node (synthesize)")
+	}
+	if w.AlwaysReachesLLM() {
+		t.Error("feed-watch has a model-free path (mode=collect); a pre-flight cap must not refuse it")
+	}
+}

--- a/pkg/dsl/ir/uses_llm.go
+++ b/pkg/dsl/ir/uses_llm.go
@@ -1,27 +1,30 @@
 package ir
 
-// UsesLLM reports whether executing this workflow can result in at least
-// one model call.
+// This file answers two different questions about model spend, and the
+// distinction between them is the whole point.
 //
-// It exists for the guards that protect a *model* budget — the operator's
-// subscription cap first among them. Such a guard refusing to start a
-// workflow that would never call a model protects nothing and costs
-// everything: the zero-LLM half of a two-mode bot (a feed collector that
-// only polls RSS and appends to a queue) stops running while the window is
-// shut, and the material it was supposed to bank is simply lost, because a
-// feed serves a short window and does not remember what nobody fetched.
+//   UsesLLM          — "does this workflow contain a node that can call a
+//                      model?" A property of the graph.
+//   AlwaysReachesLLM — "will EVERY run of this workflow reach one?" A
+//                      property of every path through the graph.
 //
-// The answer is deliberately CONSERVATIVE: every uncertainty returns true,
-// so a guard keeps blocking exactly what it blocks today and this predicate
-// can only ever open the door for a workflow provably free of model calls.
-// A subbot is the clearest case — its child `.bot` is a separate source
-// this workflow does not carry, so it counts as LLM-using on principle.
+// A guard that refuses work BEFORE it starts — the operator's subscription
+// cap — must ask the second. The first is not enough, and the gap between
+// them is not academic: a two-mode bot carries both halves in one `.bot`,
+// and refusing its zero-LLM half because the LLM half exists in the same
+// file is exactly the defect this pair was written to close.
+
+// UsesLLM reports whether the workflow contains at least one node that can
+// call a model, anywhere in the graph, reachable or not.
+//
+// Deliberately CONSERVATIVE: every uncertainty answers true. A subbot
+// counts because its child `.bot` is a separate source this workflow does
+// not carry; a supervisor counts even when no graph node does, because it
+// watches with a model of its own.
 func (w *Workflow) UsesLLM() bool {
 	if w == nil {
 		return false
 	}
-	// A supervisor is an LLM agent watching the run from the side; it can
-	// wake and spend even when no graph node ever would.
 	if len(w.Supervisors) > 0 {
 		return true
 	}
@@ -31,6 +34,83 @@ func (w *Workflow) UsesLLM() bool {
 		}
 	}
 	return false
+}
+
+// AlwaysReachesLLM reports whether EVERY path from the entry node to a
+// terminal passes through a node that can call a model — i.e. whether this
+// workflow is incapable of running without spending.
+//
+// It is the predicate a pre-flight guard needs. Refusing a run in advance
+// is only defensible when the run could not possibly avoid the thing being
+// guarded; when some path avoids it, the honest answer is to let the run
+// start and let the MID-RUN guard stop it at the actual call. That costs a
+// pod and a clone in the worst case, and it is the price of not refusing
+// work that would never have been billed.
+//
+// The routing that decides which path a run takes is usually not knowable
+// here — Vigie's `plan -> fetch_feeds when collect` branches on a field the
+// `plan` node produces at runtime, not on a var — so this deliberately does
+// not try to predict it. It asks the weaker, decidable question: does a
+// model-free path exist at all?
+//
+// Conservative in the direction that matters: an empty or unreachable
+// graph, a workflow whose entry is missing, or any shape this cannot walk
+// answers true, keeping today's behaviour rather than opening the gate.
+func (w *Workflow) AlwaysReachesLLM() bool {
+	if w == nil || len(w.Nodes) == 0 {
+		return true
+	}
+	// A supervisor is armed for the whole run whatever path it takes, so
+	// no path avoids the spend.
+	if len(w.Supervisors) > 0 {
+		return true
+	}
+	entry := w.Entry
+	if entry == "" || w.Nodes[entry] == nil {
+		return true
+	}
+
+	// Walk forward from the entry, treating an LLM node as a WALL: paths
+	// through it spend, so they are not explored. Reaching a terminal
+	// without hitting a wall proves a model-free path exists.
+	out := map[string][]string{}
+	for _, e := range w.Edges {
+		if e != nil {
+			out[e.From] = append(out[e.From], e.To)
+		}
+	}
+	seen := map[string]bool{entry: true}
+	stack := []string{entry}
+	for len(stack) > 0 {
+		id := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		node := w.Nodes[id]
+		if node == nil {
+			// An edge into a node the workflow does not define: unwalkable,
+			// so refuse to conclude "a free path exists" from it.
+			return true
+		}
+		if nodeUsesLLM(node) {
+			continue // wall
+		}
+		switch node.(type) {
+		case *DoneNode, *FailNode:
+			return false // a terminal reached without spending
+		}
+		next := out[id]
+		if len(next) == 0 {
+			// A dead end that is not a terminal — the runtime would fail
+			// here rather than finish. Not a proof of a free path.
+			continue
+		}
+		for _, to := range next {
+			if !seen[to] {
+				seen[to] = true
+				stack = append(stack, to)
+			}
+		}
+	}
+	return true
 }
 
 // nodeUsesLLM answers for one node. Kept separate so the reasoning per node

--- a/pkg/dsl/ir/uses_llm_test.go
+++ b/pkg/dsl/ir/uses_llm_test.go
@@ -115,3 +115,89 @@ func TestWorkflowUsesLLM_SupervisorCountsWithoutAnyLLMNode(t *testing.T) {
 		t.Error("a supervisor watches with a model — the workflow spends")
 	}
 }
+
+// TestAlwaysReachesLLM covers the pre-flight predicate. The asymmetry is
+// inverted from UsesLLM: a false POSITIVE only preserves today's refusal,
+// while a false negative lets a run start that will spend — which the
+// mid-run guard still catches, so the cost is a pod, not a bill.
+func TestAlwaysReachesLLM(t *testing.T) {
+	// entry -> a -> done, with `a` swapped per case.
+	build := func(a Node) *Workflow {
+		w := &Workflow{
+			Name: "w", Entry: "a",
+			Nodes: map[string]Node{"a": a, "done": &DoneNode{BaseNode: BaseNode{ID: "done"}}},
+			Edges: []*Edge{{From: "a", To: "done"}},
+		}
+		return w
+	}
+	if got := build(&ToolNode{BaseNode: BaseNode{ID: "a"}, Command: "true"}).AlwaysReachesLLM(); got {
+		t.Error("a tool-only line reaches a terminal without spending")
+	}
+	if got := build(&AgentNode{BaseNode: BaseNode{ID: "a"}}).AlwaysReachesLLM(); !got {
+		t.Error("the only path goes through an agent — every run spends")
+	}
+
+	// The shape that matters, and the one the first fix got wrong: ONE
+	// workflow, two modes. A router sends collect down a tool-only branch
+	// and digest through an agent. Some runs spend, some cannot — so no run
+	// may be refused before it has chosen.
+	twoMode := &Workflow{
+		Name: "two_mode", Entry: "plan",
+		Nodes: map[string]Node{
+			"plan":  &ToolNode{BaseNode: BaseNode{ID: "plan"}, Command: "true"},
+			"fetch": &ToolNode{BaseNode: BaseNode{ID: "fetch"}, Command: "true"},
+			"synth": &AgentNode{BaseNode: BaseNode{ID: "synth"}},
+			"done":  &DoneNode{BaseNode: BaseNode{ID: "done"}},
+			"fail":  &FailNode{BaseNode: BaseNode{ID: "fail"}},
+		},
+		Edges: []*Edge{
+			{From: "plan", To: "fetch", Condition: "collect"},
+			{From: "plan", To: "synth", Condition: "digest"},
+			{From: "fetch", To: "done"},
+			{From: "synth", To: "done"},
+			{From: "plan", To: "fail"},
+		},
+	}
+	if twoMode.AlwaysReachesLLM() {
+		t.Error("a two-mode workflow has a model-free path; it must not be refused in advance")
+	}
+	// It still CONTAINS an LLM node — the two predicates must disagree here,
+	// which is the entire reason both exist.
+	if !twoMode.UsesLLM() {
+		t.Error("UsesLLM must still see the agent node")
+	}
+
+	// Conservative shapes: refuse to conclude "free path" from a graph this
+	// cannot walk.
+	for name, w := range map[string]*Workflow{
+		"nil":           nil,
+		"no nodes":      {Name: "w", Entry: "a"},
+		"missing entry": {Name: "w", Entry: "ghost", Nodes: map[string]Node{"a": &ToolNode{BaseNode: BaseNode{ID: "a"}}}},
+		"dangling edge": {Name: "w", Entry: "a", Nodes: map[string]Node{"a": &ToolNode{BaseNode: BaseNode{ID: "a"}}}, Edges: []*Edge{{From: "a", To: "ghost"}}},
+		"dead end":      {Name: "w", Entry: "a", Nodes: map[string]Node{"a": &ToolNode{BaseNode: BaseNode{ID: "a"}}}},
+	} {
+		if !w.AlwaysReachesLLM() {
+			t.Errorf("%s: must stay conservative and answer true", name)
+		}
+	}
+
+	// A supervisor spends whatever path the graph takes.
+	sup := build(&ToolNode{BaseNode: BaseNode{ID: "a"}, Command: "true"})
+	sup.Supervisors = []*Supervisor{{Name: "watch"}}
+	if !sup.AlwaysReachesLLM() {
+		t.Error("a supervisor is armed on every path")
+	}
+
+	// A cycle must not hang the walk.
+	loop := &Workflow{
+		Name: "loop", Entry: "a",
+		Nodes: map[string]Node{
+			"a": &ToolNode{BaseNode: BaseNode{ID: "a"}, Command: "true"},
+			"b": &ToolNode{BaseNode: BaseNode{ID: "b"}, Command: "true"},
+		},
+		Edges: []*Edge{{From: "a", To: "b"}, {From: "b", To: "a"}},
+	}
+	if !loop.AlwaysReachesLLM() {
+		t.Error("a cycle reaching no terminal proves no free path")
+	}
+}

--- a/pkg/runner/usage_cap.go
+++ b/pkg/runner/usage_cap.go
@@ -91,12 +91,14 @@ func (r *Runner) usageCapPreflight(ctx context.Context, wf *ir.Workflow, msg *qu
 	if !pol.Enabled() || r.cfg.UsageCaps == nil {
 		return nil
 	}
-	// A workflow that cannot call a model has nothing to draw on the
-	// subscription this cap protects. Blocking it would protect nothing and
-	// lose whatever it was supposed to do meanwhile — for a feed collector,
-	// material that no later run can recover, since a feed only serves a
-	// short window. The mid-run guard stays armed either way.
-	if !wf.UsesLLM() {
+	// Refuse in advance only what could not possibly avoid spending. A
+	// workflow with any model-free path — the collect half of a two-mode
+	// feed bot, say — is let through and stopped by the MID-RUN guard if it
+	// actually reaches a model call. Blocking it here protects nothing and
+	// loses what it was there to do: for a collector, material no later run
+	// recovers, since a feed serves a short window and does not remember
+	// what nobody fetched.
+	if !wf.AlwaysReachesLLM() {
 		if logger != nil {
 			logger.Debug("runner: run %s makes no model call — usage cap not applied", msg.RunID)
 		}

--- a/pkg/runner/usage_cap_test.go
+++ b/pkg/runner/usage_cap_test.go
@@ -65,7 +65,9 @@ func capLLMWorkflow() *ir.Workflow {
 		Entry: "think",
 		Nodes: map[string]ir.Node{
 			"think": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "think"}},
+			"done":  &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
 		},
+		Edges: []*ir.Edge{{From: "think", To: "done"}},
 	}
 }
 
@@ -259,6 +261,7 @@ func capToolOnlyWorkflow() *ir.Workflow {
 			"dedup": &ir.ToolNode{BaseNode: ir.BaseNode{ID: "dedup"}, Command: "true"},
 			"done":  &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
 		},
+		Edges: []*ir.Edge{{From: "fetch", To: "dedup"}, {From: "dedup", To: "done"}},
 	}
 }
 

--- a/pkg/runview/service_launch.go
+++ b/pkg/runview/service_launch.go
@@ -124,7 +124,7 @@ func (s *Service) Launch(parent context.Context, spec LaunchSpec) (*LaunchResult
 		// …unless this workflow cannot call a model at all, in which case
 		// the cap guards nothing it could spend. The compile is paid ONLY
 		// on the blocked path, so the common case stays free.
-		if wf, _, err := compileForLaunch(spec.FilePath, spec.Source); err != nil || wf.UsesLLM() {
+		if wf, _, err := compileForLaunch(spec.FilePath, spec.Source); err != nil || wf.AlwaysReachesLLM() {
 			return nil, fmt.Errorf("%w: %s", runtime.ErrUsageCapped, reason)
 		}
 	}


### PR DESCRIPTION
Follow-up to #451, which fixed the wrong half of the problem.

## What #451 got wrong

It asked whether a workflow **contains** a node that can call a model. That is not the question a pre-flight needs — and on the very bot it was written for, it answers wrong.

A two-mode bot carries both halves in one `.bot`. Vigie's `collect` polls feeds through tool nodes and never reaches a model; `digest` synthesises with an agent; the router picks between them from a field the `plan` node produces **at runtime**:

```
plan -> fetch_feeds when collect     ## `collect` is plan's OUTPUT, not a var
plan -> load_pending when digest
```

So nothing at launch can predict which half a run takes. Containing an agent, `feed-watch` stayed refused in *both* modes — including the collect half, whose loss is permanent: a feed serves a short window and does not remember what nobody fetched.

Verified against production after #451 was deployed (`iterion version --commit` in the runner pod: `436d1130`, which contains `e88f65e7`): a fresh collect run was refused with the same `usage cap: seven_day window at 98%` as before.

## The right question

Refuse in advance only a workflow that **cannot possibly** run without spending.

`AlwaysReachesLLM` walks forward from the entry treating a model-calling node as a **wall**. Reaching a terminal without hitting one proves a model-free path exists → the run is let through, and the **mid-run** guard stops it at the actual call if it goes that way. Worst case: a pod and a clone spent on a run that turns out to spend. That is the price of not refusing work that would never have been billed.

Conservative wherever it cannot see — all of these answer `true` and keep today's refusal:

| shape | why |
|---|---|
| unwalkable graph / no nodes | nothing to conclude from |
| missing or unknown entry | ditto |
| edge into an undefined node | ditto |
| cycle reaching no terminal | no free path proven |
| any supervisor | armed on every path |

`UsesLLM` stays for the plain "does this graph contain one?" question. The two predicates **deliberately disagree** on a two-mode bot — that disagreement is the entire point, and a test asserts it.

## Tests

- `TestAlwaysReachesLLM` — one-node lines both ways, the two-mode router shape, every conservative shape above, the supervisor case, and a cycle.
- **`TestAlwaysReachesLLM_TheRealTwoModeBot`** reads `bots/feed-watch/main.bot` itself rather than a fixture. The first attempt passed every synthetic test and still failed on the real shape, so the lock is the real file.

Verified red before the fix by substituting the old predicate:

```
--- FAIL: TestAlwaysReachesLLM_TheRealTwoModeBot
    feed-watch has a model-free path (mode=collect); a pre-flight cap must not refuse it
```

`task lint` clean · `task test` green. `TestProcessBoardCardCarriesPRLaunchContext` fails here as on `main` — the phantom-run defect fixed by #437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
