### PR TITLE
feat(feed-watch): a digest that has nothing to say, says so

### DIFF
--- a/bots/feed-watch/main.bot
+++ b/bots/feed-watch/main.bot
@@ -99,6 +99,13 @@ vars:
   ## deliver nothing. The message stays in the run artifacts.
   dry_run: bool = false
 
+  ## A digest that finds an empty queue exits without posting — correct,
+  ## and completely silent. Run after run that reads exactly like a healthy
+  ## quiet week, so a broken collector goes unnoticed for days (it did:
+  ## 2026-08-13 → 18). After this many days without a DELIVERED digest, the
+  ## bot says so on the same sinks, at most once per window. 0 disables.
+  silence_alert_days: int = 3
+
   ## Commit (and push) the state dir after each mutation. Needs the
   ## state_dir NOT gitignored and push credentials on the workspace.
   state_commit: bool = false
@@ -286,6 +293,7 @@ schema pending_input:
   workspace: string
   state_dir: string
   max_items: int
+  silence_alert_days: int
 
 schema pending_output:
   has_items: bool
@@ -304,6 +312,12 @@ schema pending_output:
   span_days: int
   ## Every queued item id at snapshot time — commit_state clears
   ## exactly these, so items collected mid-digest survive.
+  ## Days since this category last DELIVERED a digest (read from
+  ## digests.jsonl), and whether that silence is now worth announcing.
+  ## Only meaningful on the empty-queue path — a digest that posts is
+  ## not silent, and a category that has never posted is not either.
+  silence_days: int
+  silence_alert: bool
   snapshot_ids: string[]
   ## Previous digests (headline + excerpt) — the semantic-dedup context.
   recent_topics: string
@@ -356,6 +370,16 @@ schema notify_input:
   dry_run: bool
   category: string
   digest_title: string
+
+schema silence_input:
+  category: string
+  digest_title: string
+  sinks: json
+  silence_days: int
+  dry_run: bool
+  workspace: string
+  state_dir: string
+  state_commit: bool
 
 schema notify_output:
   posted: bool
@@ -925,6 +949,56 @@ tool load_pending:
         oldest_published = oldest.date().isoformat()
         span_days = max(0, (datetime.datetime.now(datetime.timezone.utc) - oldest).days)
 
+    # A digest that finds nothing exits here, posting nothing. Correct —
+    # and indistinguishable from a healthy quiet week, run after run. So
+    # when the queue is empty, ask how long this category has actually been
+    # silent, from the digests it is RECORDED to have delivered.
+    #
+    # digests.jsonl is the oracle rather than a counter of empty runs: it
+    # measures what a reader would have seen, survives the collect/digest
+    # split, and needs no new state. A category that never delivered has no
+    # baseline to be late against, so it stays quiet.
+    silence_days, silence_alert = 0, False
+    alert_after = int({{input.silence_alert_days}} or 0)
+    if not items and alert_after > 0:
+        last_ts = ''
+        dpath = os.path.join(cdir, 'digests.jsonl')
+        if os.path.exists(dpath):
+            with open(dpath, encoding='utf-8') as fh:
+                for ln in fh:
+                    ln = ln.strip()
+                    if not ln:
+                        continue
+                    try:
+                        last_ts = json.loads(ln).get('ts') or last_ts
+                    except Exception:
+                        pass
+        if last_ts:
+            try:
+                then = datetime.datetime.fromisoformat(last_ts)
+                if then.tzinfo is None:
+                    then = then.replace(tzinfo=datetime.timezone.utc)
+                silence_days = max(0, (datetime.datetime.now(datetime.timezone.utc) - then).days)
+            except Exception:
+                silence_days = 0
+        # Once per window, not once per run: a daily category would
+        # otherwise shout every morning for as long as it stays broken,
+        # which trains the reader to ignore exactly the signal that matters.
+        if silence_days >= alert_after:
+            spath = os.path.join(cdir, 'silence.json')
+            since_alert = alert_after
+            if os.path.exists(spath):
+                try:
+                    with open(spath, encoding='utf-8') as fh:
+                        prev = json.load(fh).get('last_alert_ts') or ''
+                    at = datetime.datetime.fromisoformat(prev)
+                    if at.tzinfo is None:
+                        at = at.replace(tzinfo=datetime.timezone.utc)
+                    since_alert = (datetime.datetime.now(datetime.timezone.utc) - at).days
+                except Exception:
+                    since_alert = alert_after
+            silence_alert = since_alert >= alert_after
+
     nonce = os.urandom(8).hex()
     editorial_fenced = ('<<<UNTRUSTED_EDITORIAL ' + nonce + '>>>' + chr(10) +
                         (editorial or '') + chr(10) +
@@ -932,6 +1006,7 @@ tool load_pending:
     print(json.dumps({'has_items': bool(items), 'category': category, 'items': items,
                       'items_count': len(items), 'overflow_count': overflow,
                       'oldest_published': oldest_published, 'span_days': span_days,
+                      'silence_days': silence_days, 'silence_alert': silence_alert,
                       'snapshot_ids': snapshot_ids, 'recent_topics': chr(10).join(recent),
                       'editorial': editorial_fenced, 'editorial_nonce': nonce,
                       'digest_title': digest_title, 'sinks': sinks},
@@ -1092,6 +1167,106 @@ tool notify:
          'summary': 'delivered ' + str(delivered) + '/' + str(len(payloads)) +
                     ((' -- FAILED: ' + '; '.join(failures)) if failures else '')})
 
+## Announce this category's OWN silence, deterministically and without an
+## LLM: the queue is empty and no digest has been delivered for
+## silence_alert_days. It posts to the SAME sinks the digest uses, because
+## a warning nobody reads is the failure it exists to prevent — and it
+## stamps silence.json so a broken category warns once per window instead
+## of every morning.
+##
+## Written after 2026-08-13→18, when the collector stopped feeding the
+## queue and five daily digests exited green, posting nothing and telling
+## nobody. `finished` is not `delivered`.
+tool notify_silence:
+  input: silence_input
+  output: notify_output
+  language: py
+  script: |
+    import json, os, datetime, subprocess, urllib.request
+    null = None; true = True; false = False  # JSON-literal shim for missing refs
+    category = {{input.category}}
+    digest_title = {{input.digest_title}}
+    sinks = {{input.sinks}} or []
+    silence_days = int({{input.silence_days}} or 0)
+    dry_run = {{input.dry_run}}
+    ws = {{input.workspace}}
+    state_dir = {{input.state_dir}}
+    state_commit = {{input.state_commit}}
+    webhooks_file = {{secrets.webhooks.path}}
+
+    def out(o):
+        print(json.dumps(o, ensure_ascii=False))
+        raise SystemExit(0)
+
+    title = digest_title or category
+    text = (':warning: **' + title + ' — aucune veille depuis ' + str(silence_days) +
+            ' jour(s)**' + chr(10) + chr(10) +
+            "La file de la catégorie `" + category + "` est vide : le digest s'exécute " +
+            "normalement mais n'a rien à publier. Cela signale en général une collecte " +
+            "interrompue (flux en panne, run bloqué), pas une actualité calme." + chr(10) +
+            chr(10) + "_Message automatique — il ne se répétera pas avant " +
+            str(silence_days and silence_days or 0) + " jour(s)._")
+    if not sinks:
+        out({'posted': False, 'dry_run': bool(dry_run), 'delivered': 0, 'targets': [],
+             'summary': 'silence of ' + str(silence_days) + 'd for ' + category +
+                        ' -- no sinks configured, nothing announced'})
+    payloads = [((s.get('webhook') or ''),
+                 {'text': text, 'channel': s.get('channel') or '',
+                  'username': s.get('username') or 'Vigie',
+                  'icon_emoji': ':warning:'}) for s in sinks]
+    if dry_run:
+        for name, p in payloads:
+            print('DRY-RUN silence -> webhook=' + name + ' channel=' + p['channel'])
+        out({'posted': False, 'dry_run': True, 'delivered': 0,
+             'targets': [n for n, _ in payloads],
+             'summary': 'dry-run: silence alert prepared for ' + category +
+                        ' (' + str(silence_days) + 'd), nothing posted'})
+    whmap = {}
+    if webhooks_file and os.path.exists(webhooks_file):
+        with open(webhooks_file, encoding='utf-8') as fh:
+            whmap = json.load(fh)
+    delivered, failures, targets = 0, [], []
+    for name, p in payloads:
+        url = whmap.get(name)
+        if not url:
+            failures.append(name + ': not in the bound webhooks secret')
+            continue
+        req = urllib.request.Request(url, data=json.dumps(p).encode('utf-8'),
+                                     headers={'Content-Type': 'application/json',
+                                              'User-Agent': 'feed-watch (iterion)'}, method='POST')
+        try:
+            with urllib.request.urlopen(req, timeout=20):
+                delivered += 1
+                targets.append(name + '->' + (p['channel'] or 'default'))
+        except Exception as e:
+            failures.append(name + ': ' + type(e).__name__ + ': ' + str(e)[:200])
+    # Stamp the window even when every post failed: retrying the same
+    # unreachable webhook every morning adds noise, not information, and
+    # the failure is already on the run.
+    cdir = os.path.join(ws, state_dir, category)
+    os.makedirs(cdir, exist_ok=True)
+    with open(os.path.join(cdir, 'silence.json'), 'w', encoding='utf-8') as fh:
+        json.dump({'last_alert_ts': datetime.datetime.now(datetime.timezone.utc)
+                   .replace(microsecond=0).isoformat(),
+                   'silence_days': silence_days,
+                   'delivered': delivered}, fh, ensure_ascii=False)
+    if state_commit:
+        try:
+            subprocess.run(['git', '-C', ws, 'add', state_dir], check=True)
+            if subprocess.run(['git', '-C', ws, 'diff', '--cached', '--quiet']).returncode != 0:
+                subprocess.run(['git', '-C', ws, 'commit', '-m',
+                                'chore(feed-watch): silence alert ' + category +
+                                ' (' + str(silence_days) + 'd)'], check=True)
+                subprocess.run(['git', '-C', ws, 'push', 'origin', 'HEAD'])
+        except Exception as e:
+            # Best effort: an unstamped window costs one duplicate alert,
+            # never the alert itself.
+            print('feed-watch: could not persist silence.json: ' + str(e)[:200])
+    out({'posted': delivered > 0, 'dry_run': False, 'delivered': delivered, 'targets': targets,
+         'summary': 'silence alert for ' + category + ' (' + str(silence_days) + 'd): delivered ' +
+                    str(delivered) + '/' + str(len(payloads)) +
+                    ((' -- FAILED: ' + '; '.join(failures)) if failures else '')})
+
 ## Clear EXACTLY the digested snapshot from the queue (items collected
 ## mid-digest survive — safer than Huginn's retained_events:0, which
 ## clears whatever is there), archive the digest for future semantic
@@ -1232,7 +1407,8 @@ workflow feed_watch:
     sinks: "{{outputs.plan.sinks}}",
     workspace: "{{vars.workspace_dir}}",
     state_dir: "{{vars.state_dir}}",
-    max_items: "{{vars.max_digest_items}}"
+    max_items: "{{vars.max_digest_items}}",
+    silence_alert_days: "{{vars.silence_alert_days}}"
   }
 
   ## Unreachable (plan hard-fails on an invalid mode) — the compiler
@@ -1249,6 +1425,21 @@ workflow feed_watch:
   dedup_queue -> done
 
   ## Empty queue → done with zero LLM cost.
+  ## An empty queue that has stayed empty too long is news in itself —
+  ## announce it, then stop. Ordered before the plain empty-queue exit so
+  ## the guard actually gets a chance to fire.
+  load_pending -> notify_silence when silence_alert with {
+    category: "{{outputs.load_pending.category}}",
+    digest_title: "{{outputs.load_pending.digest_title}}",
+    sinks: "{{outputs.load_pending.sinks}}",
+    silence_days: "{{outputs.load_pending.silence_days}}",
+    dry_run: "{{vars.dry_run}}",
+    workspace: "{{vars.workspace_dir}}",
+    state_dir: "{{vars.state_dir}}",
+    state_commit: "{{vars.state_commit}}"
+  }
+  notify_silence -> done
+
   load_pending -> done when not has_items
   load_pending -> synthesize when has_items with {
     category: "{{outputs.load_pending.category}}",

--- a/bots/feed-watch/main.bot
+++ b/bots/feed-watch/main.bot
@@ -249,6 +249,11 @@ schema plan_output:
   editorial: string
   digest_title: string
   sinks: json
+  ## Optional per-category template for the silence warning. Empty falls
+  ## back to the built-in English text: this bot bakes in no language, and
+  ## the one message whose whole value is that a human reads it must not be
+  ## the exception. Placeholders: {title} {category} {days} {window}.
+  silence_message: string
 
 schema fetch_input:
   targets: json
@@ -376,6 +381,12 @@ schema silence_input:
   digest_title: string
   sinks: json
   silence_days: int
+  ## The suppression window actually enforced (silence_alert_days). The
+  ## message must state THIS, not silence_days: an alert that misreports
+  ## its own cadence spends the trust it exists to build.
+  silence_window: int
+  ## Operator-supplied message template ("" = the built-in English text).
+  silence_message: string
   dry_run: bool
   workspace: string
   state_dir: string
@@ -434,7 +445,7 @@ if not isinstance(cats, dict) or not cats:
 if category and category not in cats:
     raise SystemExit('feed-watch: unknown category ' + repr(category) + ' -- config has: ' + ', '.join(sorted(cats)))
 collect = mode == 'collect'
-targets, editorial, title, sinks = [], '', '', []
+targets, editorial, title, sinks, silence_message = [], '', '', [], ''
 if collect:
     keys = [category] if category else sorted(cats)
     targets = [{'key': k, 'feeds': (cats[k].get('feeds') or [])} for k in keys]
@@ -445,7 +456,8 @@ else:
     editorial = c.get('editorial') or ''
     title = c.get('digest_title') or category
     sinks = c.get('sinks') or []
-print(json.dumps({'collect': collect, 'digest': not collect, 'category': category, 'targets': targets, 'editorial': editorial, 'digest_title': title, 'sinks': sinks}, ensure_ascii=False))
+    silence_message = c.get('silence_message') or ''
+print(json.dumps({'collect': collect, 'digest': not collect, 'category': category, 'targets': targets, 'editorial': editorial, 'digest_title': title, 'sinks': sinks, 'silence_message': silence_message}, ensure_ascii=False))
 "`
   output: plan_output
 
@@ -1188,6 +1200,8 @@ tool notify_silence:
     digest_title = {{input.digest_title}}
     sinks = {{input.sinks}} or []
     silence_days = int({{input.silence_days}} or 0)
+    silence_window = int({{input.silence_window}} or 0)
+    silence_message = {{input.silence_message}} or ''
     dry_run = {{input.dry_run}}
     ws = {{input.workspace}}
     state_dir = {{input.state_dir}}
@@ -1199,13 +1213,18 @@ tool notify_silence:
         raise SystemExit(0)
 
     title = digest_title or category
-    text = (':warning: **' + title + ' — aucune veille depuis ' + str(silence_days) +
-            ' jour(s)**' + chr(10) + chr(10) +
-            "La file de la catégorie `" + category + "` est vide : le digest s'exécute " +
-            "normalement mais n'a rien à publier. Cela signale en général une collecte " +
-            "interrompue (flux en panne, run bloqué), pas une actualité calme." + chr(10) +
-            chr(10) + "_Message automatique — il ne se répétera pas avant " +
-            str(silence_days and silence_days or 0) + " jour(s)._")
+    # English by default and overridable per category, because this bot
+    # bakes in no language (see the header) and this is the one message
+    # whose entire value is that a human reads and acts on it.
+    default_text = (':warning: **{title} — nothing to report for {days} day(s)**' + chr(10) + chr(10) +
+                    'The `{category}` queue is empty: the digest runs normally but has nothing '
+                    'to publish. That usually means collection stopped (a dead feed, a blocked '
+                    'run), not a quiet news week.' + chr(10) + chr(10) +
+                    '_Automatic message — it will not repeat for {window} day(s)._')
+    text = (silence_message or default_text)
+    for k, v in (('{title}', title), ('{category}', category),
+                 ('{days}', str(silence_days)), ('{window}', str(silence_window))):
+        text = text.replace(k, v)
     if not sinks:
         out({'posted': False, 'dry_run': bool(dry_run), 'delivered': 0, 'targets': [],
              'summary': 'silence of ' + str(silence_days) + 'd for ' + category +
@@ -1251,17 +1270,53 @@ tool notify_silence:
                    'silence_days': silence_days,
                    'delivered': delivered}, fh, ensure_ascii=False)
     if state_commit:
+        # Same contract as commit_state's _commit_push_state, not a weaker
+        # copy of it: refuse to commit anything outside the state dir, and
+        # rebase-retry the push, because concurrent category runs share this
+        # branch. A single fire-and-forget push loses the stamp on exactly
+        # the deployment (ephemeral clones) where losing it means alerting
+        # every morning — the fatigue silence.json exists to prevent.
         try:
             subprocess.run(['git', '-C', ws, 'add', state_dir], check=True)
-            if subprocess.run(['git', '-C', ws, 'diff', '--cached', '--quiet']).returncode != 0:
+            staged = subprocess.run(['git', '-C', ws, 'diff', '--cached', '--name-only'],
+                                    capture_output=True, text=True).stdout.split(chr(10))
+            pfx = state_dir.rstrip('/') + '/'
+            outside = [x for x in staged if x.strip() and x != state_dir and not x.startswith(pfx)]
+            if outside:
+                # Log and skip rather than hard-fail: the alert is already
+                # posted, and refusing to stamp costs one duplicate warning
+                # where committing someone else's staged work costs trust.
+                print('feed-watch: not stamping silence.json -- staged path(s) outside ' +
+                      repr(state_dir) + ': ' + ', '.join(outside[:5]))
+            elif subprocess.run(['git', '-C', ws, 'diff', '--cached', '--quiet']).returncode != 0:
                 subprocess.run(['git', '-C', ws, 'commit', '-m',
                                 'chore(feed-watch): silence alert ' + category +
                                 ' (' + str(silence_days) + 'd)'], check=True)
-                subprocess.run(['git', '-C', ws, 'push', 'origin', 'HEAD'])
+                br = subprocess.run(['git', '-C', ws, 'rev-parse', '--abbrev-ref', 'HEAD'],
+                                    capture_output=True, text=True).stdout.strip() or 'HEAD'
+                for _ in range(5):
+                    if subprocess.run(['git', '-C', ws, 'push', 'origin', 'HEAD']).returncode == 0:
+                        break
+                    if subprocess.run(['git', '-C', ws, 'pull', '--rebase', '--autostash',
+                                       'origin', br]).returncode != 0:
+                        subprocess.run(['git', '-C', ws, 'rebase', '--abort'])
+                        print('feed-watch: could not push silence.json (rebase conflict)')
+                        break
+                else:
+                    print('feed-watch: could not push silence.json after 5 attempts')
         except Exception as e:
             # Best effort: an unstamped window costs one duplicate alert,
             # never the alert itself.
             print('feed-watch: could not persist silence.json: ' + str(e)[:200])
+    # A warning that reached NOBODY is the very silent-green outcome this
+    # node exists to end: the operator would see one more finished run and
+    # learn nothing, for another window. Stamp first (retrying an
+    # unreachable webhook every morning is noise), then fail loudly — the
+    # same rule the sibling `notify` applies to a total delivery failure.
+    if payloads and delivered == 0:
+        raise SystemExit('feed-watch: silence alert for ' + category + ' (' + str(silence_days) +
+                         'd) reached NOBODY -- all ' + str(len(payloads)) + ' post(s) failed: ' +
+                         '; '.join(failures))
     out({'posted': delivered > 0, 'dry_run': False, 'delivered': delivered, 'targets': targets,
          'summary': 'silence alert for ' + category + ' (' + str(silence_days) + 'd): delivered ' +
                     str(delivered) + '/' + str(len(payloads)) +
@@ -1335,7 +1390,7 @@ tool commit_state:
         with open(tmp, 'w', encoding='utf-8') as fh:
             fh.write(chr(10).join(kept) + (chr(10) if kept else ''))
         os.replace(tmp, ppath)
-    now = datetime.datetime.now()
+    now = datetime.datetime.now(datetime.timezone.utc)
     arch = os.path.join(cdir, 'digests.jsonl')
     digests = []
     if os.path.exists(arch):
@@ -1433,6 +1488,8 @@ workflow feed_watch:
     digest_title: "{{outputs.load_pending.digest_title}}",
     sinks: "{{outputs.load_pending.sinks}}",
     silence_days: "{{outputs.load_pending.silence_days}}",
+    silence_window: "{{vars.silence_alert_days}}",
+    silence_message: "{{outputs.plan.silence_message}}",
     dry_run: "{{vars.dry_run}}",
     workspace: "{{vars.workspace_dir}}",
     state_dir: "{{vars.state_dir}}",

--- a/bots/feed-watch/manifest.yaml
+++ b/bots/feed-watch/manifest.yaml
@@ -1,7 +1,7 @@
 name: feed-watch
 display_name: Vigie
 icon: 🔭
-version: 1.2.0
+version: 1.3.0
 description: |
   Universal feed-watch + digest bot (Huginn-style veille pipeline as a
   single bot). Two run modes over one file-backed state in the target

--- a/bots/issue-triage/skills/iterion-bot-catalog.md
+++ b/bots/issue-triage/skills/iterion-bot-catalog.md
@@ -573,7 +573,7 @@ schemes by default (opt into internal feeds with
   synthesize and deliver. Replaces a Huginn RSS → dedup → digest → LLM
   → webhook scenario one-for-one. Not for one-shot research questions
   (use a plain research bot) and it never edits code.
-- **Vars**: `allow_private_feeds` (bool), `category` (string), `config_path` (string), `dry_run` (bool), `fetch_timeout_secs` (int), `max_digest_items` (int), `max_items_per_feed` (int), `mode` (string), `scratch_dir` (string), `state_commit` (bool), `state_dir` (string), `workspace_dir` (string)
+- **Vars**: `allow_private_feeds` (bool), `category` (string), `config_path` (string), `dry_run` (bool), `fetch_timeout_secs` (int), `max_digest_items` (int), `max_items_per_feed` (int), `mode` (string), `scratch_dir` (string), `silence_alert_days` (int), `state_commit` (bool), `state_dir` (string), `workspace_dir` (string)
 - **Path**: `bots/feed-watch/main.bot`
 
 ### `golden-master` — Goldy

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -771,7 +771,7 @@ schemes by default (opt into internal feeds with
   synthesize and deliver. Replaces a Huginn RSS → dedup → digest → LLM
   → webhook scenario one-for-one. Not for one-shot research questions
   (use a plain research bot) and it never edits code.
-- **Vars**: `allow_private_feeds` (bool), `category` (string), `config_path` (string), `dry_run` (bool), `fetch_timeout_secs` (int), `max_digest_items` (int), `max_items_per_feed` (int), `mode` (string), `scratch_dir` (string), `state_commit` (bool), `state_dir` (string), `workspace_dir` (string)
+- **Vars**: `allow_private_feeds` (bool), `category` (string), `config_path` (string), `dry_run` (bool), `fetch_timeout_secs` (int), `max_digest_items` (int), `max_items_per_feed` (int), `mode` (string), `scratch_dir` (string), `silence_alert_days` (int), `state_commit` (bool), `state_dir` (string), `workspace_dir` (string)
 - **Path**: `bots/feed-watch/main.bot`
 
 ### `golden-master` — Goldy

--- a/docs/bot-runs/feed-watch.md
+++ b/docs/bot-runs/feed-watch.md
@@ -4,6 +4,70 @@
 
 Newest first. One section per dogfooded run.
 
+## 2026-08-19 — the veille came back, and the bot learned to report its own silence
+
+- Status: **resolved** (the 13→18 outage) + hardening shipped
+- Versions: bot 1.2.0 → 1.3.0 · iterion v3.47.0
+
+### The outage closed
+
+The re-seed was enough. The scheduled collect of 2026-08-18 17:00 UTC ran with
+no intervention (`new=4`, `committed=true`, pushed `a9f0610`), and this
+morning's chain ran end to end on its own:
+
+| step | evidence |
+|---|---|
+| collect 05:00 | finished |
+| digest cyber 06:00 | `items=108`, `span_days=6`, delivered **2/2** at 06:03:27Z |
+| the header | `🛡️ Veille Cyber — 13 au 19 août 2026 · Synthèse couvrant 6 jours` |
+
+So the state push had simply been frozen since 13/08; once it restarts,
+everything works. No hidden cluster cause — `kubectl exec` had already
+cleared the network, the feeds, the cache and the clock.
+
+### The gap that let it run five days
+
+**`finished` is not `delivered`.** A digest whose queue is empty exits at
+`plan → load_pending → done`: no LLM, no post, green status — indistinguishable
+from a healthy quiet week, every morning. The knowledge was already in the
+operator's memory since 10/08 and the outage still lasted five days, so the
+missing piece was never knowledge: it was an ALERT.
+
+### What ships (1.3.0)
+
+`silence_alert_days` (default 3, 0 disables). When the queue is empty AND no
+digest has been delivered for that many days, a deterministic `notify_silence`
+tool posts a short warning **on the same sinks as the digest** — a warning
+nobody reads is the failure it exists to prevent.
+
+- The oracle is `digests.jsonl`, not a counter of empty runs: it measures what
+  a READER would have seen, survives the collect/digest split, needs no new
+  state. A category that never delivered has no baseline and stays quiet.
+- `silence.json` stamps the window so a broken category warns once per window,
+  not every morning — the surest way to train a reader to ignore the one
+  signal that matters.
+- The stamp is written even when every post fails: retrying an unreachable
+  webhook daily adds noise, not information, and the failure is on the run.
+- Zero LLM on this path.
+
+Verified against a copy of the real production state, with the last digest
+back-dated to reproduce 13→18:
+
+```
+silence_days: 6   silence_alert: true    -> notify_silence -> #veille-vigie-secu, #vigie
+silence_days: 6   silence_alert: false   (silence.json fresh — no repeat)
+```
+
+The third case (a non-empty queue never alerts) is a literal guard,
+`if not items and alert_after > 0`, so it was read rather than run: exercising
+it would have spent an LLM call on the agent node for no added proof.
+
+### Still open
+
+`hnrss.org` has been 502 for 9 feeds since at least 17/08 — third-party
+outage, the whole HackerNews slice of the veille is mute. Replace the source
+if it persists.
+
 ## 2026-08-18 — Vigie silent since 13 Aug: the collect stopped finding anything new (runs 01a00e17, 01a00e4e)
 
 - Status: **partially diagnosed — re-seeded, root cause NOT closed**

--- a/e2e/feed_watch_test.go
+++ b/e2e/feed_watch_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
+	"time"
 )
 
 // feedWatchTool extracts a tool node from the compiled feed-watch fixture.
@@ -239,6 +240,7 @@ func TestFeedWatch_ScriptsStateMachine(t *testing.T) {
 	loadInputs := map[string]any{
 		"category": "demo", "editorial": plan["editorial"], "digest_title": plan["digest_title"],
 		"sinks": plan["sinks"], "workspace": ws, "state_dir": ".feed-watch", "max_items": 150,
+		"silence_alert_days": 3,
 	}
 	pending, stderr, err := runPy(t, ws, subScript(t, loadScript, loadInputs, ""))
 	if err != nil {
@@ -253,6 +255,11 @@ func TestFeedWatch_ScriptsStateMachine(t *testing.T) {
 	snapshot := pending["snapshot_ids"].([]any)
 	if len(snapshot) != 3 {
 		t.Fatalf("snapshot_ids = %v, want 3", snapshot)
+	}
+	// A queue with items is never silent, whatever the digest history —
+	// the guard that makes the silence alert impossible to misfire.
+	if pending["silence_alert"] != false {
+		t.Fatalf("a non-empty queue must never raise a silence alert: %v", pending["silence_alert"])
 	}
 
 	// notify — dry-run prepares payloads, delivers nothing.
@@ -330,6 +337,70 @@ func TestFeedWatch_ScriptsStateMachine(t *testing.T) {
 	}
 	if !strings.Contains(pending["recent_topics"].(string), "Demo headline") {
 		t.Fatalf("recent_topics should carry the archived digest, got %q", pending["recent_topics"])
+	}
+	// An empty queue right after a delivered digest is an ordinary quiet
+	// morning, not a silence worth announcing.
+	if pending["silence_alert"] != false {
+		t.Fatalf("a digest delivered moments ago must not raise a silence alert: %v", pending)
+	}
+
+	// The silence guard, end to end. A digest whose queue is empty exits
+	// green and posts nothing — which is exactly how a broken collector went
+	// unnoticed for five days (2026-08-13 → 18). Back-date the delivered
+	// digest and the same empty queue must now speak up.
+	digestsPath := filepath.Join(ws, ".feed-watch", "demo", "digests.jsonl")
+	raw, err := os.ReadFile(digestsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var archived map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(raw))), &archived); err != nil {
+		t.Fatalf("digests.jsonl is not one JSON object per line: %v", err)
+	}
+	archived["ts"] = time.Now().UTC().AddDate(0, 0, -6).Format("2006-01-02T15:04:05")
+	staleRow, _ := json.Marshal(archived)
+	if err := os.WriteFile(digestsPath, append(staleRow, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pending, stderr, err = runPy(t, ws, subScript(t, loadScript, loadInputs, ""))
+	if err != nil {
+		t.Fatalf("load_pending #3 failed: %v\nstderr: %s", err, stderr)
+	}
+	if pending["silence_alert"] != true {
+		t.Fatalf("6 days without a delivered digest must raise the alert: %v", pending)
+	}
+	if got := pending["silence_days"].(float64); got < 5 {
+		t.Fatalf("silence_days = %v, want ~6", got)
+	}
+
+	// …once per window, not once per run: a daily category would otherwise
+	// shout every morning, which trains the reader to ignore it.
+	stamp := filepath.Join(ws, ".feed-watch", "demo", "silence.json")
+	if err := os.WriteFile(stamp, []byte(`{"last_alert_ts": "`+
+		time.Now().UTC().Format("2006-01-02T15:04:05")+`"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pending, stderr, err = runPy(t, ws, subScript(t, loadScript, loadInputs, ""))
+	if err != nil {
+		t.Fatalf("load_pending #4 failed: %v\nstderr: %s", err, stderr)
+	}
+	if pending["silence_alert"] != false {
+		t.Fatalf("a fresh silence.json must suppress the repeat: %v", pending)
+	}
+
+	// Disabling it is a real off switch, not a smaller number.
+	offInputs := map[string]any{}
+	for k, v := range loadInputs {
+		offInputs[k] = v
+	}
+	offInputs["silence_alert_days"] = 0
+	os.Remove(stamp)
+	pending, stderr, err = runPy(t, ws, subScript(t, loadScript, offInputs, ""))
+	if err != nil {
+		t.Fatalf("load_pending #5 failed: %v\nstderr: %s", err, stderr)
+	}
+	if pending["silence_alert"] != false {
+		t.Fatalf("silence_alert_days=0 must disable the guard: %v", pending)
 	}
 }
 

--- a/e2e/feed_watch_test.go
+++ b/e2e/feed_watch_test.go
@@ -357,7 +357,7 @@ func TestFeedWatch_ScriptsStateMachine(t *testing.T) {
 	if err := json.Unmarshal([]byte(strings.TrimSpace(string(raw))), &archived); err != nil {
 		t.Fatalf("digests.jsonl is not one JSON object per line: %v", err)
 	}
-	archived["ts"] = time.Now().UTC().AddDate(0, 0, -6).Format("2006-01-02T15:04:05")
+	archived["ts"] = time.Now().UTC().AddDate(0, 0, -6).Format("2006-01-02T15:04:05-07:00")
 	staleRow, _ := json.Marshal(archived)
 	if err := os.WriteFile(digestsPath, append(staleRow, '\n'), 0o600); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## The gap

A digest whose queue is empty exits at `plan → load_pending → done`: no LLM, no post, status **`finished`**. Correct behaviour — and indistinguishable from a healthy quiet week, every morning, for as long as it lasts.

From 13 to 18 August, five daily `cyber` digests did exactly that while the collector fed nothing. Nobody learned anything until the operator asked why the veille was quiet.

**The missing piece was never knowledge.** "a `finished` run can be an empty queue" had been written down on 10 August, and the outage still ran five days. What was missing was an **alert**.

## What ships

`silence_alert_days` (default **3**, `0` disables). When the queue is empty **and** no digest has been delivered for that many days, a deterministic `notify_silence` tool posts a short warning **on the same sinks as the digest** — a warning nobody reads is the failure it exists to prevent.

Design decisions worth reviewing:

- **`digests.jsonl` is the oracle**, not a counter of empty runs. It measures what a *reader* would have seen, survives the collect/digest split (two separate runs, two clones), and needs no new state. A category that has **never** delivered has no baseline to be late against, so it stays quiet.
- **`silence.json` stamps the window**, so a broken category warns once per window instead of every morning — the surest way to train someone to ignore the one signal that matters.
- **The stamp is written even when every post fails.** Retrying an unreachable webhook daily adds noise, not information, and the failure is already visible on the run.
- **Zero LLM** on this path: the message is composed in Python, not by an agent.

## Verification

Against a **copy of the real production state**, with the last digest back-dated to reproduce 13→18:

```
silence_days: 6   silence_alert: true    -> notify_silence -> #veille-vigie-secu, #vigie
silence_days: 6   silence_alert: false   (fresh silence.json — no repeat)
```

The third case — a non-empty queue never alerting — is the literal guard `if not items and alert_after > 0`. I read it rather than ran it: exercising it means executing the agent node, i.e. spending an LLM call for no added proof.

`iterion validate` OK · `go test ./bots/...` green (catalog universality). The regenerated `iterion-bot-catalog.md` diff is exactly the new var.

## Context

The 13→18 outage itself is **closed** — the re-seed was enough, and this morning's chain ran end to end on its own: collect 05:00 → digest cyber 06:00 → `items=108`, `span_days=6`, delivered 2/2 at 06:03:27Z, under the header `🛡️ Veille Cyber — 13 au 19 août 2026 · Synthèse couvrant 6 jours`. Bilan updated in `docs/bot-runs/feed-watch.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
