### PR TITLE
fix(dispatcher): a paused human-review run survives a restart

### DIFF
--- a/docs/adr/014-dispatcher-paused-run-parking.md
+++ b/docs/adr/014-dispatcher-paused-run-parking.md
@@ -113,14 +113,15 @@ asymmetry between the two execution paths.
 The non-obvious trade-off: a parked issue **stays claimed**, and the
 dispatcher stops tracking it. Two accepted costs follow. (a) Across a daemon
 restart the claim is swept (`isStaleLocalMarker` fires once the owning pid
-dies), so the issue is re-dispatched **fresh once** and re-parks at the same
-point — benign, and consistent with the existing crash-recovery model. (b)
-If the operator resumes the run to completion out-of-band, the claim lingers
-until the next restart or a manual release (the dispatcher is no longer
-watching that run). We chose **claim-as-parking** over a new state machine
-because it is correct in-process with no schema/UI churn, and degrades
-gracefully; full out-of-band-resume reconciliation and a distinct
-"waiting for input" surface are the deferred follow-up.
+dies). `in_progress` stays eligible (crash-recovery), but the dispatcher
+**re-parks** a paused `last_run` instead of minting a sibling from entry —
+a planner restarted from `init_film` is not "the same pause". (b)
+If the operator resumes the run to completion out-of-band, the parked
+sweep (`reconcileParked`) files the card; a resume that re-pauses is
+re-parked by `reconcileStrandedPaused`. We chose **claim-as-parking**
+over a new state machine because it is correct in-process with no
+schema/UI churn; the awaiting-input column and the stranded-pause
+sweep closed the original follow-ups.
 
 ## Consequences
 

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -162,6 +162,28 @@ lifecycle: run `finished` → `agent.completed_state`, hard `failed` →
 genuinely still awaits the operator. The cloud board coordinator runs
 the same sweep for cloud-launched cards.
 
+A reboot (new PID) drops the park-claim. `in_progress` stays eligible
+for crash-recovery, but a live `last_run` is **never** replaced by a
+sibling planner from the workflow entry:
+
+| `last_run` status | On the next tick / boot |
+|---|---|
+| `paused_waiting_human` / `paused_operator` | Re-park: `awaiting_input`, same `last_run`, no auto-resume (no answers). |
+| `running` / `queued` | Hold. Do not mint. After orphan promotion the run becomes resumable. |
+| `failed_resumable` / `cancelled` | Resume the **same** run id. |
+| `finished` | Do not relaunch. File the ticket (`completed_state`). |
+| none, or hard `failed`, and the ticket is explicitly eligible | The only legitimate fresh run. |
+
+The stranded-pause sweep (`reconcileStrandedPaused`) also runs while
+the dispatcher is **paused**, so a studio restart with `desired: paused`
+re-parks without dispatching. An out-of-band `iterion resume --force`
+that re-pauses on a later human node is picked up by the same sweep —
+the dispatcher worker already returned when the run first parked, so
+`finishRun` is not in the loop.
+
+To really start over: cancel or finish the old run, or drag a
+hard-failed ticket back to `ready`. A reboot is not a from-scratch.
+
 ### In-progress transition (`agent.running_state`)
 
 After `tracker.Claim` succeeds, the dispatcher transitions the issue
@@ -285,12 +307,13 @@ without requiring an observed retirement transition.
 Directories created by older versions directly under
 `<workspace.root>/<sanitized-issue-id>/` are deliberately not adopted or
 deleted: the old sanitizer was many-to-one, so ownership cannot be proven from
-the name. A resumable run with only such a legacy/unowned workspace is restarted
-fresh in v2 while the old directory is left untouched for operator recovery.
-This loss of resume continuity is an accepted one-time migration cost. To
-reclaim legacy directories, first confirm that no active/resumable run still
-references them, then inspect and move or delete them manually; automatic
-cleanup would risk deleting a different issue's colliding legacy workspace.
+the name. A resumable run with only such a legacy/unowned workspace is **not**
+restarted fresh — that would mint a sibling planner and replay the prefix.
+Dispatch is deferred (visible as a skip) and the old directory is left
+untouched for operator recovery. To reclaim legacy directories, first confirm
+that no active/resumable run still references them, then inspect and move or
+delete them manually; automatic cleanup would risk deleting a different
+issue's colliding legacy workspace.
 The resolver also refuses workspaces whose symlink resolution lands outside the
 configured root.
 

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -169,7 +169,8 @@ sibling planner from the workflow entry:
 | `last_run` status | On the next tick / boot |
 |---|---|
 | `paused_waiting_human` / `paused_operator` | Re-park: `awaiting_input`, same `last_run`, no auto-resume (no answers). Only dispatcher-owned runs move the card — a pipelines-launched paused run keeps its card in place for the admission sweep, and still blocks any fresh mint. |
-| `running` / `queued` | Hold while the owner process lives (run lock held). A dead owner (SIGKILL, host crash — lock free, past the 2-minute grace window) is promoted by the dispatcher itself: checkpoint → `failed_resumable` (then resumed), none → `failed` (a fresh run becomes legitimate). This works in `--no-server` deployments too, which have no runview orphan reaper. |
+| `running` | Hold while the owner process lives (run lock held). A dead owner (SIGKILL, host crash — lock free, past the 2-minute grace window) is promoted by the dispatcher itself: checkpoint → `failed_resumable` (then resumed), none → `failed` (a fresh run becomes legitimate). This works in `--no-server` deployments too, which have no runview orphan reaper. |
+| `queued` | Hold without probing the run lock. Pipeline-queued runs deliberately have no lock owner until a concurrency slot opens; their queue owner advances their state machine. |
 | `failed_resumable` / `cancelled` | Resume the **same** run id. |
 | `finished` | No hold: a fresh run is allowed — dragging the card back to an eligible column **is** the re-queue gesture. |
 | none, or hard `failed`, and the ticket is explicitly eligible | The only other legitimate fresh run. |

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -315,6 +315,10 @@ untouched for operator recovery. To reclaim legacy directories, first confirm
 that no active/resumable run still references them, then inspect and move or
 delete them manually; automatic cleanup would risk deleting a different
 issue's colliding legacy workspace.
+If neither a run-scoped nor stable workspace shape exists at all (for example,
+an ephemeral workspace root disappeared while the run store survived), there
+is no unowned path to protect and the run cannot be resumed: the dispatcher
+starts a fresh isolated generation instead.
 The resolver also refuses workspaces whose symlink resolution lands outside the
 configured root.
 

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -168,11 +168,11 @@ sibling planner from the workflow entry:
 
 | `last_run` status | On the next tick / boot |
 |---|---|
-| `paused_waiting_human` / `paused_operator` | Re-park: `awaiting_input`, same `last_run`, no auto-resume (no answers). |
-| `running` / `queued` | Hold. Do not mint. After orphan promotion the run becomes resumable. |
+| `paused_waiting_human` / `paused_operator` | Re-park: `awaiting_input`, same `last_run`, no auto-resume (no answers). Only dispatcher-owned runs move the card — a pipelines-launched paused run keeps its card in place for the admission sweep, and still blocks any fresh mint. |
+| `running` / `queued` | Hold while the owner process lives (run lock held). A dead owner (SIGKILL, host crash — lock free, past the 2-minute grace window) is promoted by the dispatcher itself: checkpoint → `failed_resumable` (then resumed), none → `failed` (a fresh run becomes legitimate). This works in `--no-server` deployments too, which have no runview orphan reaper. |
 | `failed_resumable` / `cancelled` | Resume the **same** run id. |
-| `finished` | Do not relaunch. File the ticket (`completed_state`). |
-| none, or hard `failed`, and the ticket is explicitly eligible | The only legitimate fresh run. |
+| `finished` | No hold: a fresh run is allowed — dragging the card back to an eligible column **is** the re-queue gesture. |
+| none, or hard `failed`, and the ticket is explicitly eligible | The only other legitimate fresh run. |
 
 The stranded-pause sweep (`reconcileStrandedPaused`) also runs while
 the dispatcher is **paused**, so a studio restart with `desired: paused`
@@ -181,8 +181,9 @@ that re-pauses on a later human node is picked up by the same sweep —
 the dispatcher worker already returned when the run first parked, so
 `finishRun` is not in the loop.
 
-To really start over: cancel or finish the old run, or drag a
-hard-failed ticket back to `ready`. A reboot is not a from-scratch.
+To really start over: drag a `finished` or hard-`failed` ticket back to
+`ready`. A `cancelled` `last_run` is **resumed from its checkpoint**, not
+replaced — a reboot is not a from-scratch, and neither is cancel.
 
 ### In-progress transition (`agent.running_state`)
 

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -432,16 +432,17 @@ waiting, the dispatcher **does not mint a new run id**.
 
 | `last_run` | Dispatcher action |
 |---|---|
-| `paused_waiting_human` / `paused_operator` | Re-park the card in `awaiting_input`. No auto-resume (no answers). |
-| `running` / `queued` | Hold. Never start a sibling from the workflow entry. |
+| `paused_waiting_human` / `paused_operator` | Re-park the card in `awaiting_input` (dispatcher-owned runs). No auto-resume (no answers). |
+| `running` / `queued` | Hold while the owner lives. An orphaned run (no live lock, past the grace window) is promoted to `failed_resumable` / `failed` first — never a sibling from the workflow entry. |
 | `failed_resumable` / `cancelled` | `Engine.Resume` on the **same** id. |
-| `finished` | Do not relaunch; file the ticket. |
+| `finished` | Fresh run allowed — dragging the card back to `ready` is the re-queue gesture. |
 | none, or hard `failed` + ticket explicitly back in `ready` | Fresh run. |
 
 `iterion resume --force` (or the studio force-resume) continues **this**
 run after a bot edit. If that resume parks again on a later human node,
 the next dispatcher tick re-parks the same card — it does not start the
-workflow over. To throw the work away, cancel or finish the old run first.
+workflow over. To throw the work away, finish the run or let it fail
+hard: a `cancelled` run is resumed from its checkpoint, not replaced.
 
 See [dispatcher](dispatcher.md#paused-runs--the-awaiting_input-column--parked-sweep).
 

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -424,6 +424,27 @@ re-invoked after the answer:
 This keeps multi-turn interaction attached to the same node rather than
 mistaking the pause for a completed human node.
 
+## Dispatcher and last_run
+
+A run is durable across a studio or dispatcher restart. If the board card
+still points at that run (`issue.last_run`) and the status is live or
+waiting, the dispatcher **does not mint a new run id**.
+
+| `last_run` | Dispatcher action |
+|---|---|
+| `paused_waiting_human` / `paused_operator` | Re-park the card in `awaiting_input`. No auto-resume (no answers). |
+| `running` / `queued` | Hold. Never start a sibling from the workflow entry. |
+| `failed_resumable` / `cancelled` | `Engine.Resume` on the **same** id. |
+| `finished` | Do not relaunch; file the ticket. |
+| none, or hard `failed` + ticket explicitly back in `ready` | Fresh run. |
+
+`iterion resume --force` (or the studio force-resume) continues **this**
+run after a bot edit. If that resume parks again on a later human node,
+the next dispatcher tick re-parks the same card — it does not start the
+workflow over. To throw the work away, cancel or finish the old run first.
+
+See [dispatcher](dispatcher.md#paused-runs--the-awaiting_input-column--parked-sweep).
+
 ## Failure behavior
 
 Most runtime errors use the checkpoint-aware failure path: LLM/delegate errors,

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -433,7 +433,8 @@ waiting, the dispatcher **does not mint a new run id**.
 | `last_run` | Dispatcher action |
 |---|---|
 | `paused_waiting_human` / `paused_operator` | Re-park the card in `awaiting_input` (dispatcher-owned runs). No auto-resume (no answers). |
-| `running` / `queued` | Hold while the owner lives. An orphaned run (no live lock, past the grace window) is promoted to `failed_resumable` / `failed` first — never a sibling from the workflow entry. |
+| `running` | Hold while the owner lives. An orphaned run (no live lock, past the grace window) is promoted to `failed_resumable` / `failed` first — never a sibling from the workflow entry. |
+| `queued` | Hold without a lock probe: pipeline-queued runs have no lock owner until their concurrency slot opens. |
 | `failed_resumable` / `cancelled` | `Engine.Resume` on the **same** id. |
 | `finished` | Fresh run allowed — dragging the card back to `ready` is the re-queue gesture. |
 | none, or hard `failed` + ticket explicitly back in `ready` | Fresh run. |

--- a/pkg/dispatcher/claimjournal.go
+++ b/pkg/dispatcher/claimjournal.go
@@ -118,6 +118,19 @@ func (j *claimJournal) Load() []claimEntry {
 	return out
 }
 
+// Contains reports whether this dispatcher still owns an unreleased tracker
+// claim for issueID. It lets candidate-based UI pruning retain diagnostics for
+// deliberately parked, claimed cards that ListCandidates correctly omits.
+func (j *claimJournal) Contains(issueID string) bool {
+	if j == nil {
+		return false
+	}
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	_, ok := j.entries[issueID]
+	return ok
+}
+
 // persistLocked rewrites the journal atomically (tmp + rename). Called
 // under j.mu. A write failure is logged, not fatal: the in-memory view
 // stays correct for this process; only crash recovery degrades.

--- a/pkg/dispatcher/claimjournal_test.go
+++ b/pkg/dispatcher/claimjournal_test.go
@@ -19,7 +19,13 @@ func TestClaimJournalRoundTrip(t *testing.T) {
 	j := newClaimJournal(dir, quietLogger())
 	j.Record(claimEntry{IssueID: "gh:1", Identifier: "gh#1", Marker: "rog-42", ClaimedAt: time.Now().UTC()})
 	j.Record(claimEntry{IssueID: "gh:2", Identifier: "gh#2", Marker: "rog-42", ClaimedAt: time.Now().UTC()})
+	if !j.Contains("gh:1") || !j.Contains("gh:2") || j.Contains("gh:missing") {
+		t.Fatal("Contains did not reflect journalled claims")
+	}
 	j.Remove("gh:1")
+	if j.Contains("gh:1") {
+		t.Fatal("Contains retained a removed claim")
+	}
 
 	// A fresh journal (successor daemon) sees exactly the un-released claim.
 	j2 := newClaimJournal(dir, quietLogger())
@@ -34,6 +40,9 @@ func TestClaimJournalNilAndCorrupt(t *testing.T) {
 	var j *claimJournal
 	j.Record(claimEntry{IssueID: "x"})
 	j.Remove("x")
+	if j.Contains("x") {
+		t.Fatal("nil journal Contains must be false")
+	}
 	if got := j.Load(); got != nil {
 		t.Fatalf("nil journal Load = %v, want nil", got)
 	}

--- a/pkg/dispatcher/commands.go
+++ b/pkg/dispatcher/commands.go
@@ -405,8 +405,16 @@ func (c *Dispatcher) finishRun(ctx context.Context, issueID string, err error) {
 		// sibling from entry would replay the prefix (agents, tools,
 		// already-paid artefacts). Park: keep the claim, keep last_run,
 		// do not retry. The operator resumes THIS run with --force or
-		// cancels it before asking for a new one.
+		// cancels it before asking for a new one. Same operator
+		// visibility as the pause arm below — badge, awaiting-input
+		// column, and a dashboard skip entry — otherwise the ticket
+		// strands invisibly: claimed, no live worker, no badge, and
+		// absent from the snapshot's running and retry tables.
 		c.stampLastRun(issueID, r)
+		c.setAwaitingInput(issueID, true)
+		c.moveToAwaitingInput(issueID, r.Identifier)
+		c.recordDispatchSkip(tracker.Issue{ID: issueID, Identifier: r.Identifier},
+			"bot source changed since the last run started — resume with --force or cancel this run before a new dispatch")
 		c.logger.Warn("dispatcher: %s bot source changed (run=%s) — refusing a fresh sibling. Resume with --force from the run console, or cancel this run before a new dispatch.", r.Identifier, r.RunID)
 		c.fireSnapshot()
 		return

--- a/pkg/dispatcher/commands.go
+++ b/pkg/dispatcher/commands.go
@@ -167,18 +167,29 @@ func (m cmdCandidates) apply(c *Dispatcher, ctx context.Context) {
 	sortCandidates(candidates)
 
 	// Prune dispatch-skip entries whose issue is no longer an eligible,
-	// unclaimed candidate — it was claimed, closed, or dragged out of the
-	// ready lane, so the stale "won't dispatch" reason should disappear
-	// from the UI. Issues that re-skip below re-populate the map; ones
-	// that became dispatchable are cleared by dispatch() when they claim.
-	if len(c.state.dispatchSkips) > 0 {
+	// unclaimed candidate — it was closed or dragged out of the ready lane,
+	// so the stale "won't dispatch" reason should disappear from the UI.
+	// A journalled claim is the exception: deliberately parked cards are absent
+	// from ListCandidates but their operator-facing reason must remain visible.
+	// Issues that re-skip below re-populate the map; ones that became
+	// dispatchable are cleared by dispatch() when they claim.
+	if len(c.state.dispatchSkips) > 0 || len(c.state.lastRunHoldWarned) > 0 {
 		live := make(map[string]struct{}, len(candidates))
 		for _, iss := range candidates {
 			live[iss.ID] = struct{}{}
 		}
-		for id := range c.state.dispatchSkips {
-			if _, ok := live[id]; !ok {
-				delete(c.state.dispatchSkips, id)
+		if len(c.state.dispatchSkips) > 0 {
+			for id := range c.state.dispatchSkips {
+				if _, ok := live[id]; !ok && !c.claims.Contains(id) {
+					delete(c.state.dispatchSkips, id)
+				}
+			}
+		}
+		if len(c.state.lastRunHoldWarned) > 0 {
+			for id := range c.state.lastRunHoldWarned {
+				if _, ok := live[id]; !ok {
+					delete(c.state.lastRunHoldWarned, id)
+				}
 			}
 		}
 	}
@@ -727,10 +738,12 @@ func (c *Dispatcher) setAwaitingInput(issueID string, v bool) {
 // external tracker that rejects the transition leaves the card in place — the
 // retained claim already blocks re-dispatch, so this is a display-only
 // refinement, never load-bearing.
-func (c *Dispatcher) moveToAwaitingInput(issueID, identifier string) {
+func (c *Dispatcher) moveToAwaitingInput(issueID, identifier string) bool {
 	if err := c.tracker.UpdateState(context.Background(), issueID, native.StateAwaitingInput); err != nil {
 		c.logger.Info("dispatcher: %s stays in place (no awaiting-input column): %v", identifier, err)
+		return false
 	}
+	return true
 }
 
 // maybeTransitionToCompleted moves a cleanly-finished issue from

--- a/pkg/dispatcher/commands.go
+++ b/pkg/dispatcher/commands.go
@@ -395,8 +395,23 @@ func (c *Dispatcher) finishRun(ctx context.Context, issueID string, err error) {
 	// ErrRunPaused / ErrRunPausedOperator instead of naking for retry
 	// (pkg/runner/loop.go). The retained claim is reclaimed only by the
 	// stale-claim sweep once THIS daemon's pid dies (isStaleLocalMarker), so
-	// a live dispatcher never re-dispatches a parked issue; after a restart
-	// it degrades to a single fresh re-run that re-parks at the same point.
+	// a live dispatcher never re-dispatches a parked issue. After a
+	// restart the stale-claim sweep drops the claim; dispatch then
+	// re-parks (awaiting-input, same last_run) instead of minting a
+	// fresh run from entry — a planner restarted from init_film is
+	// not "the same pause".
+	if isResumeSourceChanged(err) {
+		// The bot source changed since this run started. Minting a
+		// sibling from entry would replay the prefix (agents, tools,
+		// already-paid artefacts). Park: keep the claim, keep last_run,
+		// do not retry. The operator resumes THIS run with --force or
+		// cancels it before asking for a new one.
+		c.stampLastRun(issueID, r)
+		c.logger.Warn("dispatcher: %s bot source changed (run=%s) — refusing a fresh sibling. Resume with --force from the run console, or cancel this run before a new dispatch.", r.Identifier, r.RunID)
+		c.fireSnapshot()
+		return
+	}
+
 	if errors.Is(err, runtime.ErrRunPaused) || errors.Is(err, runtime.ErrRunPausedOperator) {
 		c.stampLastRun(issueID, r)
 		c.setAwaitingInput(issueID, true)

--- a/pkg/dispatcher/commands.go
+++ b/pkg/dispatcher/commands.go
@@ -415,8 +415,9 @@ func (c *Dispatcher) finishRun(ctx context.Context, issueID string, err error) {
 		// The bot source changed since this run started. Minting a
 		// sibling from entry would replay the prefix (agents, tools,
 		// already-paid artefacts). Park: keep the claim, keep last_run,
-		// do not retry. The operator resumes THIS run with --force or
-		// cancels it before asking for a new one. Same operator
+		// do not retry. The operator resumes THIS run with --force; cancel
+		// is not an escape because cancelled last_runs remain resumable and
+		// still forbid a fresh sibling. Same operator
 		// visibility as the pause arm below — badge, awaiting-input
 		// column, and a dashboard skip entry — otherwise the ticket
 		// strands invisibly: claimed, no live worker, no badge, and
@@ -425,8 +426,8 @@ func (c *Dispatcher) finishRun(ctx context.Context, issueID string, err error) {
 		c.setAwaitingInput(issueID, true)
 		c.moveToAwaitingInput(issueID, r.Identifier)
 		c.recordDispatchSkip(tracker.Issue{ID: issueID, Identifier: r.Identifier},
-			"bot source changed since the last run started — resume with --force or cancel this run before a new dispatch")
-		c.logger.Warn("dispatcher: %s bot source changed (run=%s) — refusing a fresh sibling. Resume with --force from the run console, or cancel this run before a new dispatch.", r.Identifier, r.RunID)
+			"bot source changed since the last run started — resume with --force; cancelling does not free the ticket because a cancelled last_run is resumed from its checkpoint")
+		c.logger.Warn("dispatcher: %s bot source changed (run=%s) — refusing a fresh sibling. Resume with --force from the run console; cancelling does not unblock a fresh dispatch because a cancelled last_run is resumed from its checkpoint.", r.Identifier, r.RunID)
 		c.fireSnapshot()
 		return
 	}

--- a/pkg/dispatcher/commands_paused_test.go
+++ b/pkg/dispatcher/commands_paused_test.go
@@ -201,4 +201,23 @@ func TestFinishRun_SourceChangedParksNoSibling(t *testing.T) {
 	if _, stillRunning := c.state.running[issueID]; stillRunning {
 		t.Error("issue still tracked as running")
 	}
+
+	// Operator visibility, same as the pause arm: the card moves to the
+	// awaiting-input column and the refusal is surfaced as a dispatch
+	// skip — otherwise the ticket strands invisibly (claimed, no worker,
+	// no badge, absent from the running/retry tables).
+	states, err := ft.RefreshStates(context.Background(), []string{issueID})
+	if err != nil {
+		t.Fatalf("RefreshStates: %v", err)
+	}
+	if got := states[issueID]; got != native.StateAwaitingInput {
+		t.Errorf("issue state = %q, want %q", got, native.StateAwaitingInput)
+	}
+	skip, visible := c.state.dispatchSkips[issueID]
+	if !visible {
+		t.Fatal("source-changed park must surface as a dispatch skip")
+	}
+	if skip.Reason == "" {
+		t.Error("dispatch skip must carry the resume --force / cancel reason")
+	}
 }

--- a/pkg/dispatcher/commands_paused_test.go
+++ b/pkg/dispatcher/commands_paused_test.go
@@ -139,3 +139,66 @@ func TestFinishRun_PausedForInputIsParkedNotRetried(t *testing.T) {
 		})
 	}
 }
+
+// TestFinishRun_SourceChangedParksNoSibling: a doomed resume (bot
+// source changed) must not mint a sibling from entry. The ticket stays
+// claimed on the same last_run so the operator can resume --force.
+func TestFinishRun_SourceChangedParksNoSibling(t *testing.T) {
+	const issueID = "fake:source-changed-1"
+	ft := newFakeTracker()
+	ft.add(tracker.Issue{
+		ID: issueID, Identifier: "fake#src",
+		Title: "bot edited", WorkflowState: "in_progress",
+	})
+	if err := ft.Claim(context.Background(), issueID, "test"); err != nil {
+		t.Fatalf("seed claim: %v", err)
+	}
+
+	dir := t.TempDir()
+	wsDir := filepath.Join(dir, "ws")
+	cfg := &Config{
+		Name:     "test",
+		Workflow: filepath.Join(t.TempDir(), "fake.bot"),
+		Tracker:  TrackerConfig{Kind: "fake"},
+		Polling:  PollingConfig{IntervalMS: 50},
+		Agent: AgentConfig{
+			MaxConcurrent: 4, MaxRetryBackoffMS: 1000,
+			RunningState: "in_progress", FailedState: "blocked",
+		},
+		Workspace: WorkspaceConfig{Root: wsDir},
+	}
+	cfg.applyDefaults()
+	ws, err := NewWorkspaces(wsDir)
+	if err != nil {
+		t.Fatalf("NewWorkspaces: %v", err)
+	}
+	c, err := New(Options{
+		Config: cfg, Tracker: ft, Runner: &StubRunner{},
+		Workspaces: ws, Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{}),
+		HostMarker: "test",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c.state.running[issueID] = &runningEntry{
+		IssueID: issueID, Identifier: "fake#src", RunID: "run-src-1",
+		WorkflowState: "in_progress", WorkspacePath: filepath.Join(wsDir, "x"),
+		StartedAt: time.Now(), Attempt: 0, TransitionedFromState: "ready",
+	}
+	c.state.slotsByState["in_progress"] = 1
+
+	c.finishRun(context.Background(), issueID, runtime.ErrWorkflowSourceChanged)
+
+	ft.mu.Lock()
+	_, claimed := ft.claims[issueID]
+	ft.mu.Unlock()
+	if !claimed {
+		t.Error("claim was released — a source-changed ticket would be re-dispatched")
+	}
+	if _, queued := c.state.retries[issueID]; queued {
+		t.Error("a retry was scheduled — next attempt would mint a sibling")
+	}
+	if _, stillRunning := c.state.running[issueID]; stillRunning {
+		t.Error("issue still tracked as running")
+	}
+}

--- a/pkg/dispatcher/commands_paused_test.go
+++ b/pkg/dispatcher/commands_paused_test.go
@@ -175,11 +175,14 @@ func TestFinishRun_SourceChangedParksNoSibling(t *testing.T) {
 	c, err := New(Options{
 		Config: cfg, Tracker: ft, Runner: &StubRunner{},
 		Workspaces: ws, Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{}),
-		HostMarker: "test",
+		HostMarker: "test", StoreDir: dir,
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
+	c.claims.Record(claimEntry{
+		IssueID: issueID, Identifier: "fake#src", Marker: "test", ClaimedAt: time.Now().UTC(),
+	})
 	c.state.running[issueID] = &runningEntry{
 		IssueID: issueID, Identifier: "fake#src", RunID: "run-src-1",
 		WorkflowState: "in_progress", WorkspacePath: filepath.Join(wsDir, "x"),
@@ -219,5 +222,11 @@ func TestFinishRun_SourceChangedParksNoSibling(t *testing.T) {
 	}
 	if skip.Reason == "" {
 		t.Error("dispatch skip must carry the resume --force / cancel reason")
+	}
+	// A claimed parked ticket is absent from ListCandidates, but its sticky
+	// explanation must survive candidate pruning while our claim is journalled.
+	cmdCandidates{issues: nil}.apply(c, context.Background())
+	if _, visible := c.state.dispatchSkips[issueID]; !visible {
+		t.Error("source-changed dispatch skip was pruned while the parked claim is still held")
 	}
 }

--- a/pkg/dispatcher/commands_paused_test.go
+++ b/pkg/dispatcher/commands_paused_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -220,8 +221,11 @@ func TestFinishRun_SourceChangedParksNoSibling(t *testing.T) {
 	if !visible {
 		t.Fatal("source-changed park must surface as a dispatch skip")
 	}
-	if skip.Reason == "" {
-		t.Error("dispatch skip must carry the resume --force / cancel reason")
+	if !strings.Contains(skip.Reason, "resume with --force") {
+		t.Errorf("dispatch skip must carry the force-resume remedy, got %q", skip.Reason)
+	}
+	if strings.Contains(skip.Reason, "before a new dispatch") {
+		t.Errorf("dispatch skip must not claim that cancellation frees a fresh dispatch, got %q", skip.Reason)
 	}
 	// A claimed parked ticket is absent from ListCandidates, but its sticky
 	// explanation must survive candidate pruning while our claim is journalled.

--- a/pkg/dispatcher/commands_test.go
+++ b/pkg/dispatcher/commands_test.go
@@ -557,6 +557,14 @@ func TestDispatch_SkipsUnresolvableExplicitBot(t *testing.T) {
 	if snap := c.buildSnapshot(); len(snap.DispatchSkips) != 1 || snap.DispatchSkips[0].IssueID != "fake:ghost" {
 		t.Fatalf("snapshot DispatchSkips = %+v, want one fake:ghost entry", c.buildSnapshot().DispatchSkips)
 	}
+
+	// Warn-dedup state is candidate-scoped too: a deleted or terminal ticket
+	// must not retain an entry for the daemon lifetime.
+	c.state.lastRunHoldWarned["fake:gone"] = "held"
+	cmdCandidates{issues: nil}.apply(c, context.Background())
+	if _, ok := c.state.lastRunHoldWarned["fake:gone"]; ok {
+		t.Fatal("lastRunHoldWarned entry survived after issue left candidates")
+	}
 }
 
 // pumpCandidates drains the cmdCandidates that tick()'s off-actor discovery

--- a/pkg/dispatcher/loop.go
+++ b/pkg/dispatcher/loop.go
@@ -360,6 +360,14 @@ func (c *Dispatcher) dispatch(ctx context.Context, iss tracker.Issue) {
 	if !c.resolveExplicitBot(cfg, iss) {
 		return
 	}
+	// Durable last_run holds are read-only decisions. Resolve the indefinite
+	// ones before Claim so a live/foreign-paused run or an unowned resume
+	// workspace does not generate a Claim+Release board event pair every poll.
+	// Dispatcher-owned pauses deliberately fall through: the claim is what
+	// makes their re-park atomic with respect to other dispatchers.
+	if c.lastRunHoldBeforeClaim(iss) {
+		return
+	}
 	// Past the bot guards: this issue is dispatchable, so drop any skip
 	// entry a prior tick recorded (the operator fixed the bot name or
 	// added the route). Cleared here rather than on claim so a downstream
@@ -451,6 +459,75 @@ func (c *Dispatcher) dispatch(ctx context.Context, iss tracker.Issue) {
 		entry:               entry,
 		spec:                spec,
 	})
+}
+
+// lastRunHoldBeforeClaim handles persisted states that cannot make progress
+// through dispatch and would otherwise cause an unbounded Claim+Release loop.
+// It may promote a dead running/queued run; promoted resumable/hard-failed
+// states fall through so normal resume/fresh resolution can proceed.
+func (c *Dispatcher) lastRunHoldBeforeClaim(iss tracker.Issue) bool {
+	prev := c.lastRunID(iss.ID)
+	if prev == "" {
+		return false
+	}
+	rs, err := c.openRunStore()
+	if err != nil {
+		return false
+	}
+	r, err := rs.LoadRun(context.Background(), prev)
+	if err != nil {
+		return false
+	}
+	status := r.Status
+	if status == store.RunStatusRunning || status == store.RunStatusQueued {
+		status = c.promoteIfOrphaned(context.Background(), rs, r)
+	}
+	switch status {
+	case store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator:
+		if isDispatcherPausedRun(r) {
+			return false
+		}
+		reason := fmt.Sprintf("last run %s is %s — refusing a fresh sibling", prev, status)
+		c.recordLastRunHold(iss, reason)
+		return true
+	case store.RunStatusRunning, store.RunStatusQueued:
+		reason := fmt.Sprintf("last run %s is %s — refusing a fresh sibling", prev, status)
+		c.recordLastRunHold(iss, reason)
+		return true
+	}
+
+	resumeID := ""
+	if retry, ok := c.state.retries[iss.ID]; ok && retry.PrevRunID != "" {
+		resumeID = retry.PrevRunID
+	} else if status == store.RunStatusFailedResumable || status == store.RunStatusCancelled {
+		resumeID = prev
+	}
+	if resumeID == "" {
+		return false
+	}
+	_, exists, managed, err := c.workspaces.resumeGenerationState(iss.ID, resumeID)
+	if err != nil {
+		reason := fmt.Sprintf("workspace ownership probe failed for run %s: %v", resumeID, err)
+		c.recordLastRunHold(iss, reason)
+		return true
+	}
+	if exists && !managed {
+		reason := fmt.Sprintf("run %s has no managed v2 workspace ownership — refusing a fresh sibling", resumeID)
+		c.recordLastRunHold(iss, reason)
+		return true
+	}
+	return false
+}
+
+func (c *Dispatcher) recordLastRunHold(iss tracker.Issue, reason string) {
+	if c.state.lastRunHoldWarned == nil {
+		c.state.lastRunHoldWarned = map[string]string{}
+	}
+	if c.state.lastRunHoldWarned[iss.ID] != reason {
+		c.state.lastRunHoldWarned[iss.ID] = reason
+		c.logger.Warn("dispatcher: %s: %s", iss.Identifier, reason)
+	}
+	c.recordDispatchSkip(iss, reason)
 }
 
 func (c *Dispatcher) dispatchWorkspaceLifecycle(
@@ -657,8 +734,9 @@ func (c *Dispatcher) resolveRunID(ctx context.Context, iss tracker.Issue) (runID
 			}
 		}
 	}
+	missingResumeWorkspace := false
 	if resumeFromRunID != "" {
-		_, managed, err := c.workspaces.resumeGeneration(iss.ID, resumeFromRunID)
+		_, exists, managed, err := c.workspaces.resumeGenerationState(iss.ID, resumeFromRunID)
 		if err != nil {
 			reason := fmt.Sprintf("workspace ownership probe failed for run %s: %v", resumeFromRunID, err)
 			c.logger.Warn("dispatcher: %s: %s — dispatch deferred", iss.Identifier, reason)
@@ -666,7 +744,13 @@ func (c *Dispatcher) resolveRunID(ctx context.Context, iss tracker.Issue) (runID
 			c.releaseClaim(ctx, iss.ID, iss.Identifier)
 			return "", "", attempt, false
 		}
-		if !managed {
+		if !exists {
+			// The persisted run survived but its ephemeral workspace did not.
+			// There is no unowned path to protect and Engine.Resume cannot use
+			// the vanished workspace, so restart in a fresh isolated generation.
+			resumeFromRunID = ""
+			missingResumeWorkspace = true
+		} else if !managed {
 			// Pre-v2 paths were derived through a many-to-one sanitizer, so
 			// ownership cannot be proven from the directory name. Never run
 			// hooks in a new v2 workspace while Engine.Resume silently restores
@@ -674,13 +758,13 @@ func (c *Dispatcher) resolveRunID(ctx context.Context, iss tracker.Issue) (runID
 			// from entry either: a live last_run is durable. Defer; leave
 			// the old directory untouched for operator recovery.
 			reason := fmt.Sprintf("run %s has no managed v2 workspace ownership — refusing a fresh sibling", resumeFromRunID)
-			c.logger.Warn("dispatcher: %s: %s; legacy/unowned workspace left untouched", iss.Identifier, reason)
-			c.recordDispatchSkip(iss, reason)
+			c.recordLastRunHold(iss, reason)
 			c.releaseClaim(ctx, iss.ID, iss.Identifier)
 			return "", "", attempt, false
 		}
 	}
 	if resumeFromRunID != "" {
+		delete(c.state.lastRunHoldWarned, iss.ID)
 		return resumeFromRunID, resumeFromRunID, attempt, true
 	}
 	// About to mint. A live / waiting / still-resumable last_run must
@@ -689,18 +773,10 @@ func (c *Dispatcher) resolveRunID(ctx context.Context, iss tracker.Issue) (runID
 	// workspace probe failed open. A finished last_run does NOT hold
 	// the card: dragging it back to an eligible column is the
 	// operator's re-queue gesture (see lastRunForbidsFresh).
-	if prev := c.lastRunID(iss.ID); prev != "" {
+	if prev := c.lastRunID(iss.ID); prev != "" && !missingResumeWorkspace {
 		if status := c.runStatusOnDisk(prev); lastRunForbidsFresh(status) {
 			reason := fmt.Sprintf("last run %s is %s — refusing a fresh sibling", prev, status)
-			// Dedup via lastRunHoldWarned, NOT dispatchSkips: dispatch()
-			// deletes the skip entry before resolveRunID runs, so the
-			// entry never survives into the next tick and a held card
-			// would re-warn every poll otherwise.
-			if c.state.lastRunHoldWarned[iss.ID] != reason {
-				c.state.lastRunHoldWarned[iss.ID] = reason
-				c.logger.Warn("dispatcher: %s: %s", iss.Identifier, reason)
-			}
-			c.recordDispatchSkip(iss, reason)
+			c.recordLastRunHold(iss, reason)
 			c.releaseClaim(ctx, iss.ID, iss.Identifier)
 			return "", "", attempt, false
 		}

--- a/pkg/dispatcher/loop.go
+++ b/pkg/dispatcher/loop.go
@@ -22,7 +22,8 @@ import (
 //
 // When the dispatcher is paused, the dispatch step is skipped — runs
 // already in flight continue, stall detection still fires, retries
-// still queue. Paused means "no new work", not "stop everything".
+// still queue, and stranded paused last_runs are re-parked. Paused
+// means "no new work", not "stop everything".
 func (c *Dispatcher) tick(ctx context.Context) {
 	cfg := c.cfg.Load()
 	c.state.lastTickAt = time.Now().UTC()
@@ -30,6 +31,9 @@ func (c *Dispatcher) tick(ctx context.Context) {
 	c.reconcileStalled(ctx, cfg)
 	c.refreshRunningStates(ctx)
 	c.reconcileParked(ctx)
+	// Reclaim paused last_runs even while dispatch is suspended: a
+	// reboot with desired=paused must re-park, never mint a sibling.
+	c.reconcileStrandedPaused(ctx)
 
 	if c.paused.Load() {
 		c.fireSnapshot()
@@ -382,6 +386,14 @@ func (c *Dispatcher) dispatch(ctx context.Context, iss tracker.Issue) {
 		return
 	}
 
+	// A studio restart drops the claim that parked a human/operator
+	// pause. in_progress stays eligible, and paused_waiting_human is
+	// not resumable — without this guard we minted a NEW run from
+	// entry and rewrote the planner. Re-park; do not start fresh.
+	if c.reparkClaimedIfLastRunWaiting(iss) {
+		return
+	}
+
 	runID, resumeFromRunID, attempt, ok := c.resolveRunID(ctx, iss)
 	if !ok {
 		return
@@ -662,18 +674,42 @@ func (c *Dispatcher) resolveRunID(ctx context.Context, iss tracker.Issue) (runID
 			// Pre-v2 paths were derived through a many-to-one sanitizer, so
 			// ownership cannot be proven from the directory name. Never run
 			// hooks in a new v2 workspace while Engine.Resume silently restores
-			// a different legacy/missing WorkDir; restart safely instead and
-			// leave the old directory untouched for operator recovery.
-			c.logger.Warn(
-				"dispatcher: %s run %s has no managed v2 workspace ownership — starting fresh; legacy/unowned workspace left untouched",
-				iss.Identifier,
-				resumeFromRunID,
-			)
-			resumeFromRunID = ""
+			// a different legacy/missing WorkDir — and never mint a sibling
+			// from entry either: a live last_run is durable. Defer; leave
+			// the old directory untouched for operator recovery.
+			reason := fmt.Sprintf("run %s has no managed v2 workspace ownership — refusing a fresh sibling", resumeFromRunID)
+			c.logger.Warn("dispatcher: %s: %s; legacy/unowned workspace left untouched", iss.Identifier, reason)
+			c.recordDispatchSkip(iss, reason)
+			c.releaseClaim(ctx, iss.ID, iss.Identifier)
+			return "", "", attempt, false
 		}
 	}
 	if resumeFromRunID != "" {
 		return resumeFromRunID, resumeFromRunID, attempt, true
+	}
+	// About to mint. A live / waiting / still-resumable last_run must
+	// never become a sibling planner from entry — not on reboot, not
+	// because a retry entry dropped PrevRunID, not because the
+	// workspace probe failed open.
+	if prev := c.lastRunID(iss.ID); prev != "" {
+		if status := c.runStatusOnDisk(prev); lastRunForbidsFresh(status) {
+			reason := fmt.Sprintf("last run %s is %s — refusing a fresh sibling", prev, status)
+			if _, already := c.state.dispatchSkips[iss.ID]; !already {
+				c.logger.Warn("dispatcher: %s: %s", iss.Identifier, reason)
+			}
+			c.recordDispatchSkip(iss, reason)
+			if status == store.RunStatusFinished {
+				if target := c.cfg.Load().Agent.CompletedState; target != "" && target != iss.WorkflowState {
+					if err := c.tracker.UpdateState(ctx, iss.ID, target); err != nil {
+						c.logger.Warn("dispatcher: %s last run finished, move to %q: %v", iss.Identifier, target, err)
+					} else {
+						c.logger.Info("dispatcher: %s last run %s already finished — filed as %q, refusing a fresh sibling", iss.Identifier, prev, target)
+					}
+				}
+			}
+			c.releaseClaim(ctx, iss.ID, iss.Identifier)
+			return "", "", attempt, false
+		}
 	}
 	freshID, err := store.GenerateRunID()
 	if err != nil {

--- a/pkg/dispatcher/loop.go
+++ b/pkg/dispatcher/loop.go
@@ -479,7 +479,7 @@ func (c *Dispatcher) lastRunHoldBeforeClaim(iss tracker.Issue) bool {
 		return false
 	}
 	status := r.Status
-	if status == store.RunStatusRunning || status == store.RunStatusQueued {
+	if status == store.RunStatusRunning {
 		status = c.promoteIfOrphaned(context.Background(), rs, r)
 		if status != r.Status {
 			// promoteIfOrphaned re-reads under the run lock. Keep the record

--- a/pkg/dispatcher/loop.go
+++ b/pkg/dispatcher/loop.go
@@ -481,6 +481,15 @@ func (c *Dispatcher) lastRunHoldBeforeClaim(iss tracker.Issue) bool {
 	status := r.Status
 	if status == store.RunStatusRunning || status == store.RunStatusQueued {
 		status = c.promoteIfOrphaned(context.Background(), rs, r)
+		if status != r.Status {
+			// promoteIfOrphaned re-reads under the run lock. Keep the record
+			// aligned with the returned status so ownership checks below do
+			// not judge a newly-paused dispatcher run from the stale
+			// running/queued snapshot loaded above.
+			if cur, loadErr := rs.LoadRun(context.Background(), prev); loadErr == nil {
+				r = cur
+			}
+		}
 	}
 	switch status {
 	case store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator:
@@ -775,6 +784,18 @@ func (c *Dispatcher) resolveRunID(ctx context.Context, iss tracker.Issue) (runID
 	// operator's re-queue gesture (see lastRunForbidsFresh).
 	if prev := c.lastRunID(iss.ID); prev != "" && !missingResumeWorkspace {
 		if status := c.runStatusOnDisk(prev); lastRunForbidsFresh(status) {
+			// An empty retry target was authoritative when the retry was
+			// scheduled, but the durable run can become resumable later (for
+			// example after orphan promotion). Adopt that now-current target
+			// so the next tick resumes with the same attempt count instead of
+			// repeating Claim -> Release forever.
+			if hadRetryEntry && (status == store.RunStatusFailedResumable ||
+				status == store.RunStatusCancelled ||
+				status == store.RunStatusPausedOperator) {
+				if retry := c.state.retries[iss.ID]; retry != nil && retry.PrevRunID == "" {
+					retry.PrevRunID = prev
+				}
+			}
 			reason := fmt.Sprintf("last run %s is %s — refusing a fresh sibling", prev, status)
 			c.recordLastRunHold(iss, reason)
 			c.releaseClaim(ctx, iss.ID, iss.Identifier)

--- a/pkg/dispatcher/loop.go
+++ b/pkg/dispatcher/loop.go
@@ -413,9 +413,9 @@ func (c *Dispatcher) dispatch(ctx context.Context, iss tracker.Issue) {
 	}
 	// A fired retry remains authoritative until every synchronous dispatch
 	// decision has succeeded. In particular, an empty PrevRunID may encode a
-	// deliberate fresh restart after a source-change failure; consuming it in
-	// resolveRunID would let a lifecycle-probe failure make the next tick fall
-	// back to the stale persisted last_run pointer.
+	// deliberate fresh retry after a failure with no resumable run; consuming
+	// it in resolveRunID would let a lifecycle-probe failure make the next tick
+	// fall back to the stale persisted last_run pointer.
 	delete(c.state.retries, iss.ID)
 
 	runCtx, cancel := context.WithCancel(ctx)
@@ -614,9 +614,8 @@ func (c *Dispatcher) resolveRunID(ctx context.Context, iss tracker.Issue) (runID
 	// scheduled retry (an in-memory retryEntry existed). It gates the
 	// cross-restart fallback below: a retry entry carries a DELIBERATE
 	// resume-vs-fresh decision, and an empty PrevRunID on it means "run
-	// fresh" — e.g. scheduleRetry dropped a doomed resume because the bot
-	// source changed. The persisted last_run pointer must not override
-	// that decision.
+	// fresh" — e.g. the prior attempt failed before it produced a resumable
+	// run. The persisted last_run pointer must not override that decision.
 	hadRetryEntry := false
 	if cur, present := c.state.retries[iss.ID]; present {
 		hadRetryEntry = true
@@ -643,14 +642,11 @@ func (c *Dispatcher) resolveRunID(ctx context.Context, iss tracker.Issue) (runID
 	// other adapters silently fall through to a fresh runID.
 	//
 	// Gated on !hadRetryEntry: when a retry entry WAS present its
-	// PrevRunID is authoritative — including an empty value meaning
-	// "scheduleRetry deliberately dropped a doomed resume (bot source
-	// changed since the prior run) — run fresh". Without this guard the
-	// fallback re-reads the persisted last_run_id (still failed_resumable
-	// on disk) and re-resumes the same source-changed run on the very
-	// next poll, an infinite resume→fail→revert loop that strands the
-	// ticket. scheduleRetry's in-memory drop alone can't survive this
-	// re-resolution. See pkg/dispatcher/retry.go isResumeSourceChanged.
+	// PrevRunID is authoritative — including an empty value meaning "the
+	// previous failure had no resumable run — retry fresh". Without this
+	// guard the fallback could re-read an older persisted last_run_id and
+	// override the retry decision after a synchronous dispatch probe deferred
+	// the first attempt.
 	if resumeFromRunID == "" && !hadRetryEntry {
 		type lastRunLookup interface {
 			LastRunForIssue(id string) (string, error)
@@ -690,27 +686,26 @@ func (c *Dispatcher) resolveRunID(ctx context.Context, iss tracker.Issue) (runID
 	// About to mint. A live / waiting / still-resumable last_run must
 	// never become a sibling planner from entry — not on reboot, not
 	// because a retry entry dropped PrevRunID, not because the
-	// workspace probe failed open.
+	// workspace probe failed open. A finished last_run does NOT hold
+	// the card: dragging it back to an eligible column is the
+	// operator's re-queue gesture (see lastRunForbidsFresh).
 	if prev := c.lastRunID(iss.ID); prev != "" {
 		if status := c.runStatusOnDisk(prev); lastRunForbidsFresh(status) {
 			reason := fmt.Sprintf("last run %s is %s — refusing a fresh sibling", prev, status)
-			if _, already := c.state.dispatchSkips[iss.ID]; !already {
+			// Dedup via lastRunHoldWarned, NOT dispatchSkips: dispatch()
+			// deletes the skip entry before resolveRunID runs, so the
+			// entry never survives into the next tick and a held card
+			// would re-warn every poll otherwise.
+			if c.state.lastRunHoldWarned[iss.ID] != reason {
+				c.state.lastRunHoldWarned[iss.ID] = reason
 				c.logger.Warn("dispatcher: %s: %s", iss.Identifier, reason)
 			}
 			c.recordDispatchSkip(iss, reason)
-			if status == store.RunStatusFinished {
-				if target := c.cfg.Load().Agent.CompletedState; target != "" && target != iss.WorkflowState {
-					if err := c.tracker.UpdateState(ctx, iss.ID, target); err != nil {
-						c.logger.Warn("dispatcher: %s last run finished, move to %q: %v", iss.Identifier, target, err)
-					} else {
-						c.logger.Info("dispatcher: %s last run %s already finished — filed as %q, refusing a fresh sibling", iss.Identifier, prev, target)
-					}
-				}
-			}
 			c.releaseClaim(ctx, iss.ID, iss.Identifier)
 			return "", "", attempt, false
 		}
 	}
+	delete(c.state.lastRunHoldWarned, iss.ID)
 	freshID, err := store.GenerateRunID()
 	if err != nil {
 		c.logger.Warn("dispatcher: mint run id for %s: %v", iss.Identifier, err)

--- a/pkg/dispatcher/manager.go
+++ b/pkg/dispatcher/manager.go
@@ -134,14 +134,12 @@ func NewManager(opts ManagerOptions) (*Manager, error) {
 	intent := resolveBootIntent(persisted, m.cfg != nil)
 	switch intent {
 	case DesiredRunning, DesiredPaused:
-		if startErr := m.Start(); startErr != nil {
+		// Pause BEFORE the actor's first tick when restoring a paused
+		// session. Start-then-Pause raced the immediate boot tick and
+		// minted sibling runs for in_progress tickets whose last_run
+		// was still paused_waiting_human.
+		if startErr := m.start(intent == DesiredPaused); startErr != nil {
 			opts.Logger.Warn("manager: auto-start declined: %v", startErr)
-			break
-		}
-		if intent == DesiredPaused {
-			if pauseErr := m.Pause(); pauseErr != nil {
-				opts.Logger.Warn("manager: restore pause after auto-start: %v", pauseErr)
-			}
 		}
 	}
 	return m, nil
@@ -251,6 +249,13 @@ var ErrAlreadyRunning = errors.New("manager: already running")
 // an error and stays in StateError when the start sequence fails (bad
 // workflow, missing tracker creds, port conflict, …).
 func (m *Manager) Start() error {
+	return m.start(false)
+}
+
+// start is Start with an optional already-paused actor. paused=true
+// sets the flag BEFORE the actor loop so the immediate first tick
+// cannot dispatch (or mint a sibling) before Pause() would have run.
+func (m *Manager) start(paused bool) error {
 	m.mu.Lock()
 	if m.cur != nil {
 		m.mu.Unlock()
@@ -302,18 +307,30 @@ func (m *Manager) Start() error {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	if paused {
+		c.paused.Store(true)
+	}
 	c.Start(ctx)
 
 	m.mu.Lock()
 	m.cur = c
 	m.runner = runner
 	m.cancel = cancel
-	m.state = ManagerStateRunning
+	if paused {
+		m.state = ManagerStatePaused
+	} else {
+		m.state = ManagerStateRunning
+	}
 	m.lastErr = nil
 	m.startedAt = time.Now().UTC()
 	m.mu.Unlock()
-	m.persistDesired(DesiredRunning)
-	m.logger.Info("manager: dispatcher started (workflow=%s, tracker=%s)", cfg.Workflow, trk.Name())
+	if paused {
+		m.persistDesired(DesiredPaused)
+		m.logger.Info("manager: dispatcher started paused (workflow=%s, tracker=%s)", cfg.Workflow, trk.Name())
+	} else {
+		m.persistDesired(DesiredRunning)
+		m.logger.Info("manager: dispatcher started (workflow=%s, tracker=%s)", cfg.Workflow, trk.Name())
+	}
 	return nil
 }
 

--- a/pkg/dispatcher/manager_autostart_test.go
+++ b/pkg/dispatcher/manager_autostart_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 )
 
 // seedManagerFixture writes the minimum on-disk state for NewManager to
@@ -129,6 +132,51 @@ func TestNewManager_RestoresPersistedPausedState(t *testing.T) {
 	defer m.Stop()
 	if got := m.Status().State; got != ManagerStatePaused {
 		t.Errorf("state = %q, want paused (persisted paused)", got)
+	}
+	if cur := m.Current(); cur == nil || !cur.IsPaused() {
+		t.Error("actor must be started already-paused so the first tick cannot dispatch")
+	}
+}
+
+// TestNewManager_RestoresPausedWithoutDispatching is the boot race
+// behind issue 426: Start-then-Pause let the immediate first tick
+// mint a sibling for an eligible ticket. Restoring desired=paused
+// must set the flag before that tick.
+func TestNewManager_RestoresPausedWithoutDispatching(t *testing.T) {
+	t.Setenv("ITERION_DISPATCHER_AUTOSTART", "")
+	dir := seedManagerFixture(t)
+	ns := newTestNativeStore(t, dir)
+	iss, err := ns.Create(native.Issue{Title: "do not launch", State: native.StateReady})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := saveDesiredState(runtimeStatePath(dir), DesiredPaused); err != nil {
+		t.Fatalf("seed runtime state: %v", err)
+	}
+	m, err := NewManager(ManagerOptions{
+		StoreDir:    dir,
+		NativeStore: ns,
+		Logger:      newTestLogger(),
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	defer m.Stop()
+	if got := m.Status().State; got != ManagerStatePaused {
+		t.Fatalf("state = %q, want paused", got)
+	}
+	// The actor's first tick is immediate and asynchronous. Give it
+	// time to run; a raced Start-then-Pause would have claimed this.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		got, gerr := ns.Get(iss.ID)
+		if gerr != nil {
+			t.Fatalf("Get: %v", gerr)
+		}
+		if got.State != native.StateReady || got.Claim != "" {
+			t.Fatalf("paused boot dispatched: state=%q claim=%q", got.State, got.Claim)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }
 

--- a/pkg/dispatcher/native/adapter.go
+++ b/pkg/dispatcher/native/adapter.go
@@ -118,10 +118,13 @@ func (a *Adapter) Release(ctx context.Context, id, marker string) error {
 // ListForRepark returns cards this dispatcher may re-park after a
 // reboot or an out-of-band resume: any eligible state (plus
 // in_progress, the crash-recovery lane) that already has a last_run
-// and is unclaimed or claimed by marker. Cards already in
+// and is unclaimed. Cards already claimed by this daemon were handled when
+// the claim was acquired; excluding them makes a missing awaiting_input
+// column a one-shot best-effort move instead of an every-tick retry. Cards
+// already in
 // awaiting_input stay with ListAwaitingInput / reconcileParked.
 // Consumed by reconcileStrandedPaused via optional-interface assertion.
-func (a *Adapter) ListForRepark(marker string) ([]tracker.Issue, error) {
+func (a *Adapter) ListForRepark(_ string) ([]tracker.Issue, error) {
 	b := a.store.Board()
 	seen := make(map[string]bool, len(b.States))
 	states := make([]string, 0, len(b.States))
@@ -147,7 +150,7 @@ func (a *Adapter) ListForRepark(marker string) ([]tracker.Issue, error) {
 		if iss.LastRunID == "" {
 			continue
 		}
-		if iss.Claim != "" && iss.Claim != marker {
+		if iss.Claim != "" {
 			continue
 		}
 		out = append(out, toTrackerIssue(iss))

--- a/pkg/dispatcher/native/adapter.go
+++ b/pkg/dispatcher/native/adapter.go
@@ -115,6 +115,46 @@ func (a *Adapter) Release(ctx context.Context, id, marker string) error {
 	return a.store.Release(id, marker)
 }
 
+// ListForRepark returns cards this dispatcher may re-park after a
+// reboot or an out-of-band resume: any eligible state (plus
+// in_progress, the crash-recovery lane) that already has a last_run
+// and is unclaimed or claimed by marker. Cards already in
+// awaiting_input stay with ListAwaitingInput / reconcileParked.
+// Consumed by reconcileStrandedPaused via optional-interface assertion.
+func (a *Adapter) ListForRepark(marker string) ([]tracker.Issue, error) {
+	b := a.store.Board()
+	seen := make(map[string]bool, len(b.States))
+	states := make([]string, 0, len(b.States))
+	for _, s := range b.States {
+		if !s.Eligible && s.Name != StateInProgress {
+			continue
+		}
+		if s.Name == StateAwaitingInput || seen[s.Name] {
+			continue
+		}
+		seen[s.Name] = true
+		states = append(states, s.Name)
+	}
+	if len(states) == 0 {
+		return nil, nil
+	}
+	issues, err := a.store.List(ListFilter{States: states})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]tracker.Issue, 0, len(issues))
+	for _, iss := range issues {
+		if iss.LastRunID == "" {
+			continue
+		}
+		if iss.Claim != "" && iss.Claim != marker {
+			continue
+		}
+		out = append(out, toTrackerIssue(iss))
+	}
+	return out, nil
+}
+
 // ListAwaitingInput returns the cards parked in the awaiting-input
 // column that this dispatcher may reconcile: unclaimed (post-restart,
 // after the stale-claim sweep) or claimed by the given marker. Cards

--- a/pkg/dispatcher/native/adapter_test.go
+++ b/pkg/dispatcher/native/adapter_test.go
@@ -174,6 +174,13 @@ func TestListForRepark(t *testing.T) {
 	if err := s.Claim(theirs.ID, "other-host"); err != nil {
 		t.Fatalf("Claim: %v", err)
 	}
+	ours, _ := s.Create(native.Issue{Title: "ours", State: native.StateInProgress})
+	if err := s.SetLastRun(ours.ID, "run-ours", ""); err != nil {
+		t.Fatalf("SetLastRun ours: %v", err)
+	}
+	if err := s.Claim(ours.ID, "me"); err != nil {
+		t.Fatalf("Claim ours: %v", err)
+	}
 	fresh, _ := s.Create(native.Issue{Title: "fresh", State: native.StateReady})
 	_, _ = s.Create(native.Issue{Title: "inbox", State: native.StateInbox})
 
@@ -193,6 +200,9 @@ func TestListForRepark(t *testing.T) {
 	}
 	if ids[theirs.ID] {
 		t.Error("another daemon's claim must be excluded")
+	}
+	if ids[ours.ID] {
+		t.Error("an already-handled claim from this daemon must not be re-parked every tick")
 	}
 	if ids[fresh.ID] {
 		t.Error("a card with no last_run cannot be re-parked")

--- a/pkg/dispatcher/native/adapter_test.go
+++ b/pkg/dispatcher/native/adapter_test.go
@@ -153,6 +153,52 @@ func TestAdapterComment(t *testing.T) {
 	}
 }
 
+func TestListForRepark(t *testing.T) {
+	a, s := newAdapter(t)
+	ready, _ := s.Create(native.Issue{Title: "ready", State: native.StateReady})
+	if err := s.SetLastRun(ready.ID, "run-ready", ""); err != nil {
+		t.Fatalf("SetLastRun ready: %v", err)
+	}
+	progress, _ := s.Create(native.Issue{Title: "wip", State: native.StateInProgress})
+	if err := s.SetLastRun(progress.ID, "run-wip", ""); err != nil {
+		t.Fatalf("SetLastRun progress: %v", err)
+	}
+	parked, _ := s.Create(native.Issue{Title: "parked", State: native.StateAwaitingInput})
+	if err := s.SetLastRun(parked.ID, "run-parked", ""); err != nil {
+		t.Fatalf("SetLastRun parked: %v", err)
+	}
+	theirs, _ := s.Create(native.Issue{Title: "theirs", State: native.StateInProgress})
+	if err := s.SetLastRun(theirs.ID, "run-theirs", ""); err != nil {
+		t.Fatalf("SetLastRun theirs: %v", err)
+	}
+	if err := s.Claim(theirs.ID, "other-host"); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	fresh, _ := s.Create(native.Issue{Title: "fresh", State: native.StateReady})
+	_, _ = s.Create(native.Issue{Title: "inbox", State: native.StateInbox})
+
+	got, err := a.ListForRepark("me")
+	if err != nil {
+		t.Fatalf("ListForRepark: %v", err)
+	}
+	ids := map[string]bool{}
+	for _, iss := range got {
+		ids[iss.ID] = true
+	}
+	if !ids[ready.ID] || !ids[progress.ID] {
+		t.Fatalf("want ready + in_progress with last_run, got %+v", ids)
+	}
+	if ids[parked.ID] {
+		t.Error("awaiting_input belongs to ListAwaitingInput, not ListForRepark")
+	}
+	if ids[theirs.ID] {
+		t.Error("another daemon's claim must be excluded")
+	}
+	if ids[fresh.ID] {
+		t.Error("a card with no last_run cannot be re-parked")
+	}
+}
+
 func TestAdapterUpdateState(t *testing.T) {
 	a, s := newAdapter(t)
 	iss, _ := s.Create(native.Issue{Title: "x", State: "ready"})

--- a/pkg/dispatcher/parked.go
+++ b/pkg/dispatcher/parked.go
@@ -2,6 +2,8 @@ package dispatcher
 
 import (
 	"context"
+	"errors"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
@@ -78,6 +80,114 @@ func (c *Dispatcher) reconcileParked(ctx context.Context) {
 			c.logger.Warn("dispatcher: parked sweep release %s: %v", iss.Identifier, err)
 		}
 		c.claims.Remove(iss.ID)
+		moved = true
+	}
+	if moved {
+		c.fireSnapshot()
+	}
+}
+
+// lastRunID is the tracker's persisted last_run pointer, or "" when
+// the adapter has no lookup (github/forgejo) or the card has never
+// been dispatched. Native-only today, same seam as stampLastRun.
+func (c *Dispatcher) lastRunID(issueID string) string {
+	look, ok := c.tracker.(interface {
+		LastRunForIssue(id string) (string, error)
+	})
+	if !ok {
+		return ""
+	}
+	runID, err := look.LastRunForIssue(issueID)
+	if err != nil || runID == "" {
+		return ""
+	}
+	return runID
+}
+
+// reparkToAwaitingInput moves a card whose last_run is still paused
+// back to the awaiting-input column, same run id. Caller owns the
+// claim (so ListCandidates stays away even if the column is missing).
+func (c *Dispatcher) reparkToAwaitingInput(iss tracker.Issue, runID string) {
+	c.stampLastRun(iss.ID, &runningEntry{
+		IssueID: iss.ID, Identifier: iss.Identifier, RunID: runID,
+	})
+	c.setAwaitingInput(iss.ID, true)
+	c.moveToAwaitingInput(iss.ID, iss.Identifier)
+	c.logger.Info(
+		"dispatcher: %s last run %s is still paused — re-parked in awaiting-input, refusing a fresh run",
+		iss.Identifier, runID,
+	)
+}
+
+// reparkClaimedIfLastRunWaiting stops a fresh dispatch when last_run is
+// already paused for a human or the operator. The ticket must already
+// be claimed by this tick (so ListCandidates stays away). Returns true
+// when the caller must abort — the card is parked again, same run.
+func (c *Dispatcher) reparkClaimedIfLastRunWaiting(iss tracker.Issue) bool {
+	runID := c.lastRunID(iss.ID)
+	if runID == "" {
+		return false
+	}
+	switch c.runStatusOnDisk(runID) {
+	case store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator:
+	default:
+		return false
+	}
+	c.reparkToAwaitingInput(iss, runID)
+	c.fireSnapshot()
+	return true
+}
+
+// reconcileStrandedPaused re-parks eligible cards whose last_run is
+// still paused for a human or the operator. The usual case is a
+// studio reboot: SweepStaleClaims dropped the park-claim, in_progress
+// is eligible, and without this sweep the next dispatch would mint a
+// sibling from entry. Also catches an out-of-band `iterion resume`
+// that re-paused on a later human node — the dispatcher worker had
+// already returned, so finishRun never moved the card.
+//
+// Runs on every tick, including while paused: reclaim is re-park,
+// never a fresh run.
+func (c *Dispatcher) reconcileStrandedPaused(ctx context.Context) {
+	lister, ok := c.tracker.(interface {
+		ListForRepark(marker string) ([]tracker.Issue, error)
+	})
+	if !ok {
+		return
+	}
+	cards, err := lister.ListForRepark(c.hostMarker)
+	if err != nil {
+		c.logger.Warn("dispatcher: stranded-pause sweep list: %v", err)
+		return
+	}
+	moved := false
+	for _, iss := range cards {
+		if _, running := c.state.running[iss.ID]; running {
+			continue
+		}
+		runID := c.lastRunID(iss.ID)
+		if runID == "" {
+			continue
+		}
+		switch c.runStatusOnDisk(runID) {
+		case store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator:
+		default:
+			continue
+		}
+		// Claim before the column move so a concurrent tick cannot
+		// dispatch if awaiting_input is missing on a custom board.
+		c.claims.Record(claimEntry{
+			IssueID: iss.ID, Identifier: iss.Identifier,
+			Marker: c.hostMarker, ClaimedAt: time.Now().UTC(),
+		})
+		if err := c.tracker.Claim(ctx, iss.ID, c.hostMarker); err != nil {
+			c.claims.Remove(iss.ID)
+			if !errors.Is(err, tracker.ErrClaimConflict) {
+				c.logger.Warn("dispatcher: stranded-pause claim %s: %v", iss.Identifier, err)
+			}
+			continue
+		}
+		c.reparkToAwaitingInput(iss, runID)
 		moved = true
 	}
 	if moved {

--- a/pkg/dispatcher/parked.go
+++ b/pkg/dispatcher/parked.go
@@ -112,7 +112,7 @@ func (c *Dispatcher) lastRunID(issueID string) string {
 // reparkToAwaitingInput moves a card whose last_run is still paused
 // back to the awaiting-input column, same run id. Caller owns the
 // claim (so ListCandidates stays away even if the column is missing).
-func (c *Dispatcher) reparkToAwaitingInput(iss tracker.Issue, runID string) {
+func (c *Dispatcher) reparkToAwaitingInput(iss tracker.Issue, runID string) bool {
 	// A retry can coexist with the persisted pause when the run was
 	// resumed out-of-band while its dispatcher retry timer was pending.
 	// Re-parking supersedes that stale retry: leaving it behind would keep
@@ -123,15 +123,16 @@ func (c *Dispatcher) reparkToAwaitingInput(iss tracker.Issue, runID string) {
 		}
 		delete(c.state.retries, iss.ID)
 	}
-	c.stampLastRun(iss.ID, &runningEntry{
-		IssueID: iss.ID, Identifier: iss.Identifier, RunID: runID,
-	})
 	c.setAwaitingInput(iss.ID, true)
-	c.moveToAwaitingInput(iss.ID, iss.Identifier)
+	moved := c.moveToAwaitingInput(iss.ID, iss.Identifier)
+	if !moved {
+		return false
+	}
 	c.logger.Info(
 		"dispatcher: %s last run %s is still paused — re-parked in awaiting-input, refusing a fresh run",
 		iss.Identifier, runID,
 	)
+	return true
 }
 
 // reparkClaimedIfLastRunWaiting stops a fresh dispatch when last_run is
@@ -225,8 +226,7 @@ func (c *Dispatcher) reconcileStrandedPaused(ctx context.Context) {
 			}
 			continue
 		}
-		c.reparkToAwaitingInput(iss, runID)
-		moved = true
+		moved = c.reparkToAwaitingInput(iss, runID) || moved
 	}
 	if moved {
 		c.fireSnapshot()

--- a/pkg/dispatcher/parked.go
+++ b/pkg/dispatcher/parked.go
@@ -226,7 +226,15 @@ func (c *Dispatcher) reconcileStrandedPaused(ctx context.Context) {
 			}
 			continue
 		}
-		moved = c.reparkToAwaitingInput(iss, runID) || moved
+		if c.reparkToAwaitingInput(iss, runID) {
+			moved = true
+			continue
+		}
+		// The claim is load-bearing when the board cannot represent the
+		// awaiting-input column: releasing it would make the paused card a
+		// dispatch candidate again. Keep it, but surface the in-place park
+		// in the dashboard instead of leaving an invisible claimed card.
+		c.recordDispatchSkip(iss, "last run "+runID+" is still paused — held in place because the awaiting-input move failed")
 	}
 	if moved {
 		c.fireSnapshot()

--- a/pkg/dispatcher/parked.go
+++ b/pkg/dispatcher/parked.go
@@ -160,7 +160,11 @@ func (c *Dispatcher) reparkClaimedIfLastRunWaiting(iss tracker.Issue) bool {
 	if !isDispatcherPausedRun(r) {
 		return false
 	}
-	c.reparkToAwaitingInput(iss, runID)
+	if !c.reparkToAwaitingInput(iss, runID) {
+		// No awaiting-input column: the retained claim keeps the paused card
+		// safe, while the skip explains why it is held in its current lane.
+		c.recordDispatchSkip(iss, "last run "+runID+" is still paused — held in place because the awaiting-input move failed")
+	}
 	c.fireSnapshot()
 	return true
 }

--- a/pkg/dispatcher/parked.go
+++ b/pkg/dispatcher/parked.go
@@ -45,6 +45,11 @@ func (c *Dispatcher) reconcileParked(ctx context.Context) {
 		return
 	}
 	cfg := c.cfg.Load()
+	rs, err := c.openRunStore()
+	if err != nil {
+		c.logger.Debug("dispatcher: open store for parked sweep: %v", err)
+		return
+	}
 	moved := false
 	for _, iss := range parked {
 		if _, running := c.state.running[iss.ID]; running {
@@ -55,7 +60,7 @@ func (c *Dispatcher) reconcileParked(ctx context.Context) {
 			continue
 		}
 		var target string
-		switch c.runStatusOnDisk(runID) {
+		switch runStatusFrom(rs, runID) {
 		case store.RunStatusFinished:
 			target = cfg.Agent.CompletedState
 			c.logger.Info("dispatcher: %s resumed out-of-band and finished (run=%s) — moving awaiting-input card to %q", iss.Identifier, runID, target)
@@ -108,6 +113,16 @@ func (c *Dispatcher) lastRunID(issueID string) string {
 // back to the awaiting-input column, same run id. Caller owns the
 // claim (so ListCandidates stays away even if the column is missing).
 func (c *Dispatcher) reparkToAwaitingInput(iss tracker.Issue, runID string) {
+	// A retry can coexist with the persisted pause when the run was
+	// resumed out-of-band while its dispatcher retry timer was pending.
+	// Re-parking supersedes that stale retry: leaving it behind would keep
+	// a phantom row in the dashboard and reuse its attempt on a later run.
+	if retry, ok := c.state.retries[iss.ID]; ok {
+		if retry.Timer != nil {
+			retry.Timer.Stop()
+		}
+		delete(c.state.retries, iss.ID)
+	}
 	c.stampLastRun(iss.ID, &runningEntry{
 		IssueID: iss.ID, Identifier: iss.Identifier, RunID: runID,
 	})
@@ -123,14 +138,25 @@ func (c *Dispatcher) reparkToAwaitingInput(iss tracker.Issue, runID string) {
 // already paused for a human or the operator. The ticket must already
 // be claimed by this tick (so ListCandidates stays away). Returns true
 // when the caller must abort — the card is parked again, same run.
+// Only dispatcher-owned runs are re-parked (see isDispatcherPausedRun);
+// other paused runs still block the mint via lastRunForbidsFresh in
+// resolveRunID, just without touching the card.
 func (c *Dispatcher) reparkClaimedIfLastRunWaiting(iss tracker.Issue) bool {
 	runID := c.lastRunID(iss.ID)
 	if runID == "" {
 		return false
 	}
-	switch c.runStatusOnDisk(runID) {
-	case store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator:
-	default:
+	rs, err := c.openRunStore()
+	if err != nil {
+		c.logger.Debug("dispatcher: open store for re-park check: %v", err)
+		return false
+	}
+	r, err := rs.LoadRun(context.Background(), runID)
+	if err != nil {
+		c.logger.Debug("dispatcher: cannot read run %s for re-park check: %v", runID, err)
+		return false
+	}
+	if !isDispatcherPausedRun(r) {
 		return false
 	}
 	c.reparkToAwaitingInput(iss, runID)
@@ -146,6 +172,11 @@ func (c *Dispatcher) reparkClaimedIfLastRunWaiting(iss tracker.Issue) bool {
 // that re-paused on a later human node — the dispatcher worker had
 // already returned, so finishRun never moved the card.
 //
+// Only dispatcher-owned runs are re-parked (see isDispatcherPausedRun):
+// a pipelines-launched run belongs to the admission sweep's state
+// machine, which only reconciles in_progress tickets — exiling its
+// card to awaiting_input would strand it there after the answer.
+//
 // Runs on every tick, including while paused: reclaim is re-park,
 // never a fresh run.
 func (c *Dispatcher) reconcileStrandedPaused(ctx context.Context) {
@@ -160,6 +191,14 @@ func (c *Dispatcher) reconcileStrandedPaused(ctx context.Context) {
 		c.logger.Warn("dispatcher: stranded-pause sweep list: %v", err)
 		return
 	}
+	if len(cards) == 0 {
+		return
+	}
+	rs, err := c.openRunStore()
+	if err != nil {
+		c.logger.Debug("dispatcher: open store for stranded-pause sweep: %v", err)
+		return
+	}
 	moved := false
 	for _, iss := range cards {
 		if _, running := c.state.running[iss.ID]; running {
@@ -169,9 +208,8 @@ func (c *Dispatcher) reconcileStrandedPaused(ctx context.Context) {
 		if runID == "" {
 			continue
 		}
-		switch c.runStatusOnDisk(runID) {
-		case store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator:
-		default:
+		r, err := rs.LoadRun(ctx, runID)
+		if err != nil || !isDispatcherPausedRun(r) {
 			continue
 		}
 		// Claim before the column move so a concurrent tick cannot
@@ -195,22 +233,54 @@ func (c *Dispatcher) reconcileStrandedPaused(ctx context.Context) {
 	}
 }
 
+// isDispatcherPausedRun reports whether the run sits on a human/operator
+// pause AND belongs to the dispatcher (RunSource stamps every dispatch).
+// A run launched from the pipelines control center or the studio console
+// (Source nil or another kind) is left to its owner's state machine —
+// re-parking its card would only move the problem.
+func isDispatcherPausedRun(r *store.Run) bool {
+	if r == nil {
+		return false
+	}
+	if r.Status != store.RunStatusPausedWaitingHuman && r.Status != store.RunStatusPausedOperator {
+		return false
+	}
+	return r.Source != nil && r.Source.Kind == store.RunSourceKindDispatcher
+}
+
+// openRunStore builds the filesystem run store once for a sweep —
+// store.New does MkdirAll + gitignore housekeeping, too expensive to
+// repeat per card on the actor goroutine every tick.
+func (c *Dispatcher) openRunStore() (*store.FilesystemRunStore, error) {
+	if c.storeDir == "" {
+		return nil, errors.New("no store dir")
+	}
+	return store.New(c.storeDir, store.WithLogger(c.logger))
+}
+
+// runStatusFrom reads a run's persisted status from an already-open
+// store. Best-effort — any read error returns the empty status, which
+// the sweeps treat as "leave the card alone".
+func runStatusFrom(s *store.FilesystemRunStore, runID string) store.RunStatus {
+	r, err := s.LoadRun(context.Background(), runID)
+	if err != nil {
+		return ""
+	}
+	return r.Status
+}
+
 // runStatusOnDisk reads a run's persisted status straight from the store.
-// Best-effort — any read error returns the empty status, which the parked
-// sweep treats as "leave the card alone" (mirrors resumableRunID).
+// Best-effort — any read error returns the empty status, which the guard
+// treats as "leave the card alone". One-shot callers only; sweeps open
+// the store once and use runStatusFrom.
 func (c *Dispatcher) runStatusOnDisk(runID string) store.RunStatus {
 	if runID == "" || c.storeDir == "" {
 		return ""
 	}
-	s, err := store.New(c.storeDir, store.WithLogger(c.logger))
+	s, err := c.openRunStore()
 	if err != nil {
-		c.logger.Debug("dispatcher: open store for parked sweep: %v", err)
+		c.logger.Debug("dispatcher: open store for status check: %v", err)
 		return ""
 	}
-	r, err := s.LoadRun(context.Background(), runID)
-	if err != nil {
-		c.logger.Debug("dispatcher: cannot read run %s for parked sweep: %v", runID, err)
-		return ""
-	}
-	return r.Status
+	return runStatusFrom(s, runID)
 }

--- a/pkg/dispatcher/parked_test.go
+++ b/pkg/dispatcher/parked_test.go
@@ -371,6 +371,30 @@ func TestReconcileStrandedPaused_FailedMoveStaysClaimedAndVisible(t *testing.T) 
 	}
 }
 
+func TestDispatch_PausedRunFailedMoveStaysClaimedAndVisible(t *testing.T) {
+	fx := newLastRunFixture(t, store.RunStatusPausedWaitingHuman, native.StateInProgress)
+	fx.disp.tracker = &rejectAwaitingInputTracker{Adapter: native.NewAdapter(fx.board)}
+
+	fx.disp.dispatch(context.Background(), tracker.Issue{
+		ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
+		WorkflowState: native.StateInProgress,
+	})
+
+	got, err := fx.board.Get(fx.issue.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != native.StateInProgress {
+		t.Errorf("card state = %q, want unchanged %q", got.State, native.StateInProgress)
+	}
+	if got.Claim == "" {
+		t.Error("dispatch-path failed move must retain the protective claim")
+	}
+	if _, visible := fx.disp.state.dispatchSkips[fx.issue.ID]; !visible {
+		t.Error("dispatch-path failed move must surface an operator-visible dispatch skip")
+	}
+}
+
 func TestDispatch_RefusesFreshRunWhenLastRunIsStillLive(t *testing.T) {
 	for _, status := range []store.RunStatus{
 		store.RunStatusRunning,
@@ -528,11 +552,11 @@ func TestDispatch_ResumesOrphanedRunningLastRunWithCheckpoint(t *testing.T) {
 	}
 }
 
-// TestDispatch_HoldsLiveLockedRun: a running/queued last_run whose lock
-// is held by a live owner must be held — the dead-owner probe must
+// TestDispatch_HoldsLiveLockedRun: a running last_run whose lock is held by
+// a live owner must be held — the dead-owner probe must
 // never clobber in-flight work, even past the grace window.
 func TestDispatch_HoldsLiveLockedRun(t *testing.T) {
-	for _, status := range []store.RunStatus{store.RunStatusRunning, store.RunStatusQueued} {
+	for _, status := range []store.RunStatus{store.RunStatusRunning} {
 		t.Run(string(status), func(t *testing.T) {
 			fx := newLastRunFixture(t, status, native.StateInProgress)
 			run, err := fx.runStore.LoadRun(context.Background(), fx.runID)
@@ -571,6 +595,42 @@ func TestDispatch_HoldsLiveLockedRun(t *testing.T) {
 				t.Errorf("live-run hold must happen before Claim, got %q", card.Claim)
 			}
 		})
+	}
+}
+
+func TestDispatch_HoldsOldQueuedRunWithoutLock(t *testing.T) {
+	fx := newLastRunFixture(t, store.RunStatusQueued, native.StateInProgress)
+	run, err := fx.runStore.LoadRun(context.Background(), fx.runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	run.CreatedAt = time.Now().Add(-3 * time.Minute)
+	if err := fx.runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+
+	// Pipeline-queued runs have no lock owner by design. Even after the
+	// running-run grace window, the dispatcher must leave one to its queue.
+	fx.disp.dispatch(context.Background(), tracker.Issue{
+		ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
+		WorkflowState: native.StateInProgress,
+	})
+	if fx.launched != 0 {
+		t.Fatalf("queued last_run launched %d fresh run(s), want 0", fx.launched)
+	}
+	got, err := fx.runStore.LoadRun(context.Background(), fx.runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.Status != store.RunStatusQueued {
+		t.Errorf("queued run status = %q, want %q (never orphan-reaped)", got.Status, store.RunStatusQueued)
+	}
+	card, err := fx.board.Get(fx.issue.ID)
+	if err != nil {
+		t.Fatalf("Get card: %v", err)
+	}
+	if card.Claim != "" {
+		t.Errorf("queued-run hold must happen before Claim, got %q", card.Claim)
 	}
 }
 

--- a/pkg/dispatcher/parked_test.go
+++ b/pkg/dispatcher/parked_test.go
@@ -418,6 +418,9 @@ func TestDispatch_PausedLastRunNotDispatcherOwnedStaysPut(t *testing.T) {
 	if got.AwaitingInput {
 		t.Error("awaiting-input badge must not be set on a foreign card")
 	}
+	if got.Claim != "" {
+		t.Errorf("foreign paused hold must happen before Claim, got %q", got.Claim)
+	}
 	if _, skipped := fx.disp.state.dispatchSkips[fx.issue.ID]; !skipped {
 		t.Error("the refused mint must surface as a dispatch skip")
 	}
@@ -522,6 +525,13 @@ func TestDispatch_HoldsLiveLockedRun(t *testing.T) {
 			if got.Status != status {
 				t.Errorf("live run status = %q, want %q (untouched by the probe)", got.Status, status)
 			}
+			card, err := fx.board.Get(fx.issue.ID)
+			if err != nil {
+				t.Fatalf("Get card: %v", err)
+			}
+			if card.Claim != "" {
+				t.Errorf("live-run hold must happen before Claim, got %q", card.Claim)
+			}
 		})
 	}
 }
@@ -544,11 +554,32 @@ func TestDispatch_ResumesFailedResumableSameID(t *testing.T) {
 	}
 }
 
+func TestDispatch_MintsFreshWhenResumableWorkspaceIsMissing(t *testing.T) {
+	fx := newLastRunFixture(t, store.RunStatusFailedResumable, native.StateInProgress)
+	// No workspace shape exists: the store survived but the workspace root
+	// was ephemeral or removed. There is no foreign path to protect, and the
+	// old run cannot be resumed, so dispatch must start an isolated fresh run.
+	fx.disp.dispatch(context.Background(), tracker.Issue{
+		ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
+		WorkflowState: native.StateInProgress,
+	})
+	fx.disp.workersWG.Wait()
+	if fx.launched != 1 {
+		t.Fatalf("missing resume workspace launched %d time(s), want 1 fresh run", fx.launched)
+	}
+	if fx.lastSpec.RunID == "" || fx.lastSpec.RunID == fx.runID {
+		t.Errorf("spec run = %q, want a fresh id distinct from %q", fx.lastSpec.RunID, fx.runID)
+	}
+	if fx.lastSpec.ResumeFromRunID != "" {
+		t.Errorf("spec resumeFrom = %q, want empty for missing workspace", fx.lastSpec.ResumeFromRunID)
+	}
+}
+
 func TestDispatch_RefusesFreshSiblingWhenWorkspaceUnmanaged(t *testing.T) {
 	fx := newLastRunFixture(t, store.RunStatusFailedResumable, native.StateInProgress)
 	// A directory exists but no v2 ownership marker — the historic
 	// "starting fresh" path. Must defer, not mint.
-	legacy := filepath.Join(fx.disp.workspaces.root, "not-a-v2-workspace")
+	legacy := fx.disp.workspaces.PathForRun(fx.issue.ID, fx.runID)
 	if err := os.MkdirAll(legacy, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -568,6 +599,9 @@ func TestDispatch_RefusesFreshSiblingWhenWorkspaceUnmanaged(t *testing.T) {
 	}
 	if got.LastRunID != fx.runID {
 		t.Errorf("last_run = %q, want the existing run", got.LastRunID)
+	}
+	if got.Claim != "" {
+		t.Errorf("unmanaged workspace hold must happen before Claim, got claim %q", got.Claim)
 	}
 }
 

--- a/pkg/dispatcher/parked_test.go
+++ b/pkg/dispatcher/parked_test.go
@@ -3,10 +3,12 @@ package dispatcher
 import (
 	"bytes"
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -191,4 +193,296 @@ func TestReconcileParked_SkipsOtherDaemonsClaims(t *testing.T) {
 	if got.State != native.StateAwaitingInput || got.Claim != "other-host-9" {
 		t.Errorf("another daemon's parked card must be untouched, got state=%q claim=%q", got.State, got.Claim)
 	}
+}
+
+// TestDispatch_RefusesFreshRunWhenLastRunIsPaused is the reboot
+// regression: a human/operator pause survived on disk, the ticket is
+// still in_progress (claim died with the old PID), and dispatch must
+// re-park instead of minting a planner from init_film.
+func TestDispatch_RefusesFreshRunWhenLastRunIsPaused(t *testing.T) {
+	for _, status := range []store.RunStatus{
+		store.RunStatusPausedWaitingHuman,
+		store.RunStatusPausedOperator,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			dir := t.TempDir()
+			runStore, err := store.New(dir)
+			if err != nil {
+				t.Fatalf("store.New: %v", err)
+			}
+			run, err := runStore.CreateRun(context.Background(), "run-paused-keep", "wf", nil)
+			if err != nil {
+				t.Fatalf("CreateRun: %v", err)
+			}
+			run.Status = status
+			if err := runStore.SaveRun(context.Background(), run); err != nil {
+				t.Fatalf("SaveRun: %v", err)
+			}
+
+			ns, err := native.NewStore(filepath.Join(dir, "dispatcher"))
+			if err != nil {
+				t.Fatalf("native.NewStore: %v", err)
+			}
+			iss, err := ns.Create(native.Issue{Title: "ulysse", State: native.StateInProgress})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			if err := ns.SetLastRun(iss.ID, "run-paused-keep", ""); err != nil {
+				t.Fatalf("SetLastRun: %v", err)
+			}
+
+			launched := 0
+			runner := &StubRunner{Handler: func(context.Context, DispatchSpec) error {
+				launched++
+				return nil
+			}}
+			cfg := &Config{
+				Name:     "test",
+				Workflow: filepath.Join(t.TempDir(), "fake.bot"),
+				Tracker:  TrackerConfig{Kind: "native"},
+				Polling:  PollingConfig{IntervalMS: 50},
+				Agent: AgentConfig{
+					MaxConcurrent:  4,
+					RunningState:   "in_progress",
+					CompletedState: "review",
+					FailedState:    "blocked",
+				},
+				Workspace: WorkspaceConfig{Root: filepath.Join(dir, "ws")},
+			}
+			cfg.applyDefaults()
+			ws, err := NewWorkspaces(cfg.Workspace.Root)
+			if err != nil {
+				t.Fatalf("NewWorkspaces: %v", err)
+			}
+			c, err := New(Options{
+				Config: cfg, Tracker: native.NewAdapter(ns), Runner: runner,
+				Workspaces: ws, Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{}),
+				HostMarker: "test-host-1", StoreDir: dir,
+			})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+
+			c.dispatch(context.Background(), tracker.Issue{
+				ID: iss.ID, Identifier: iss.ID, Title: iss.Title,
+				WorkflowState: native.StateInProgress,
+			})
+
+			if launched != 0 {
+				t.Fatalf("dispatcher launched %d fresh run(s), want 0", launched)
+			}
+			got, err := ns.Get(iss.ID)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if got.State != native.StateAwaitingInput {
+				t.Errorf("card state = %q, want %q", got.State, native.StateAwaitingInput)
+			}
+			if got.LastRunID != "run-paused-keep" {
+				t.Errorf("last_run = %q, want the paused run", got.LastRunID)
+			}
+			if got.Claim == "" {
+				t.Errorf("re-parked card must keep the new claim so it is not a candidate")
+			}
+			if !got.AwaitingInput {
+				t.Errorf("awaiting-input badge must be set")
+			}
+			if _, running := c.state.running[iss.ID]; running {
+				t.Errorf("issue must not be tracked as a live worker")
+			}
+		})
+	}
+}
+
+func TestReconcileStrandedPaused_ReparksInProgressEvenWhenPaused(t *testing.T) {
+	fx := newLastRunFixture(t, store.RunStatusPausedWaitingHuman, native.StateInProgress)
+
+	fx.disp.paused.Store(true)
+	fx.disp.tick(context.Background())
+
+	if fx.launched != 0 {
+		t.Fatalf("paused tick launched %d run(s), want 0", fx.launched)
+	}
+	got, err := fx.board.Get(fx.issue.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != native.StateAwaitingInput {
+		t.Errorf("card state = %q, want %q", got.State, native.StateAwaitingInput)
+	}
+	if got.LastRunID != fx.runID {
+		t.Errorf("last_run = %q, want %q", got.LastRunID, fx.runID)
+	}
+	if got.Claim == "" {
+		t.Error("re-parked card must be claimed")
+	}
+	if !got.AwaitingInput {
+		t.Error("awaiting-input badge must be set")
+	}
+}
+
+func TestDispatch_RefusesFreshRunWhenLastRunIsStillLive(t *testing.T) {
+	for _, status := range []store.RunStatus{
+		store.RunStatusRunning,
+		store.RunStatusQueued,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			fx := newLastRunFixture(t, status, native.StateInProgress)
+			fx.disp.dispatch(context.Background(), tracker.Issue{
+				ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
+				WorkflowState: native.StateInProgress,
+			})
+			if fx.launched != 0 {
+				t.Fatalf("status %s launched %d fresh run(s), want 0", status, fx.launched)
+			}
+			got, err := fx.board.Get(fx.issue.ID)
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if got.LastRunID != fx.runID {
+				t.Errorf("last_run = %q, want the existing run", got.LastRunID)
+			}
+			if _, running := fx.disp.state.running[fx.issue.ID]; running {
+				t.Error("issue must not be tracked as a live worker")
+			}
+		})
+	}
+}
+
+func TestDispatch_FilesFinishedLastRunInsteadOfMinting(t *testing.T) {
+	fx := newLastRunFixture(t, store.RunStatusFinished, native.StateInProgress)
+	fx.disp.dispatch(context.Background(), tracker.Issue{
+		ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
+		WorkflowState: native.StateInProgress,
+	})
+	if fx.launched != 0 {
+		t.Fatalf("finished last_run launched %d fresh run(s), want 0", fx.launched)
+	}
+	got, err := fx.board.Get(fx.issue.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != "review" {
+		t.Errorf("card state = %q, want review (completed_state)", got.State)
+	}
+	if got.LastRunID != fx.runID {
+		t.Errorf("last_run = %q, want the finished run", got.LastRunID)
+	}
+}
+
+func TestDispatch_ResumesFailedResumableSameID(t *testing.T) {
+	fx := newLastRunFixture(t, store.RunStatusFailedResumable, native.StateInProgress)
+	if _, _, err := fx.disp.workspaces.CreateForRun(fx.issue.ID, fx.runID); err != nil {
+		t.Fatalf("CreateForRun: %v", err)
+	}
+	fx.disp.dispatch(context.Background(), tracker.Issue{
+		ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
+		WorkflowState: native.StateInProgress,
+	})
+	fx.disp.workersWG.Wait()
+	if fx.launched != 1 {
+		t.Fatalf("resumable last_run launched %d time(s), want 1 resume", fx.launched)
+	}
+	if fx.lastSpec.RunID != fx.runID || fx.lastSpec.ResumeFromRunID != fx.runID {
+		t.Errorf("spec run=%q resumeFrom=%q, want both %q", fx.lastSpec.RunID, fx.lastSpec.ResumeFromRunID, fx.runID)
+	}
+}
+
+func TestDispatch_RefusesFreshSiblingWhenWorkspaceUnmanaged(t *testing.T) {
+	fx := newLastRunFixture(t, store.RunStatusFailedResumable, native.StateInProgress)
+	// A directory exists but no v2 ownership marker — the historic
+	// "starting fresh" path. Must defer, not mint.
+	legacy := filepath.Join(fx.disp.workspaces.root, "not-a-v2-workspace")
+	if err := os.MkdirAll(legacy, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	fx.disp.dispatch(context.Background(), tracker.Issue{
+		ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
+		WorkflowState: native.StateInProgress,
+	})
+	if fx.launched != 0 {
+		t.Fatalf("unmanaged workspace launched %d fresh run(s), want 0", fx.launched)
+	}
+	if _, skipped := fx.disp.state.dispatchSkips[fx.issue.ID]; !skipped {
+		t.Error("unmanaged resume must surface as a dispatch skip")
+	}
+	got, err := fx.board.Get(fx.issue.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.LastRunID != fx.runID {
+		t.Errorf("last_run = %q, want the existing run", got.LastRunID)
+	}
+}
+
+type lastRunFixture struct {
+	disp     *Dispatcher
+	board    *native.Store
+	issue    *native.Issue
+	runID    string
+	launched int
+	lastSpec DispatchSpec
+}
+
+func newLastRunFixture(t *testing.T, status store.RunStatus, cardState string) *lastRunFixture {
+	t.Helper()
+	dir := t.TempDir()
+	runStore, err := store.New(dir)
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	const runID = "run-keep-me"
+	run, err := runStore.CreateRun(context.Background(), runID, "wf", nil)
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	run.Status = status
+	if err := runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+	ns, err := native.NewStore(filepath.Join(dir, "dispatcher"))
+	if err != nil {
+		t.Fatalf("native.NewStore: %v", err)
+	}
+	iss, err := ns.Create(native.Issue{Title: "ulysse", State: cardState})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := ns.SetLastRun(iss.ID, runID, ""); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+	fx := &lastRunFixture{board: ns, issue: iss, runID: runID}
+	runner := &StubRunner{Handler: func(_ context.Context, spec DispatchSpec) error {
+		fx.lastSpec = spec
+		fx.launched++
+		return nil
+	}}
+	cfg := &Config{
+		Name:     "test",
+		Workflow: filepath.Join(t.TempDir(), "fake.bot"),
+		Tracker:  TrackerConfig{Kind: "native"},
+		Polling:  PollingConfig{IntervalMS: 50},
+		Agent: AgentConfig{
+			MaxConcurrent:  4,
+			RunningState:   "in_progress",
+			CompletedState: "review",
+			FailedState:    "blocked",
+		},
+		Workspace: WorkspaceConfig{Root: filepath.Join(dir, "ws")},
+	}
+	cfg.applyDefaults()
+	ws, err := NewWorkspaces(cfg.Workspace.Root)
+	if err != nil {
+		t.Fatalf("NewWorkspaces: %v", err)
+	}
+	c, err := New(Options{
+		Config: cfg, Tracker: native.NewAdapter(ns), Runner: runner,
+		Workspaces: ws, Logger: iterlog.New(iterlog.LevelError, &bytes.Buffer{}),
+		HostMarker: "test-host-1", StoreDir: dir,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	fx.disp = c
+	return fx
 }

--- a/pkg/dispatcher/parked_test.go
+++ b/pkg/dispatcher/parked_test.go
@@ -333,6 +333,44 @@ func TestReconcileStrandedPaused_ReparksInProgressEvenWhenPaused(t *testing.T) {
 	}
 }
 
+type rejectAwaitingInputTracker struct {
+	*native.Adapter
+}
+
+func (t *rejectAwaitingInputTracker) UpdateState(ctx context.Context, id, state string) error {
+	if state == native.StateAwaitingInput {
+		return tracker.ErrTransitionRejected
+	}
+	return t.Adapter.UpdateState(ctx, id, state)
+}
+
+func TestReconcileStrandedPaused_FailedMoveStaysClaimedAndVisible(t *testing.T) {
+	fx := newLastRunFixture(t, store.RunStatusPausedWaitingHuman, native.StateInProgress)
+	fx.disp.tracker = &rejectAwaitingInputTracker{Adapter: native.NewAdapter(fx.board)}
+
+	fx.disp.reconcileStrandedPaused(context.Background())
+
+	got, err := fx.board.Get(fx.issue.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != native.StateInProgress {
+		t.Errorf("card state = %q, want unchanged %q", got.State, native.StateInProgress)
+	}
+	if got.Claim == "" {
+		t.Error("failed awaiting-input move must retain the protective claim")
+	}
+	if !got.AwaitingInput {
+		t.Error("failed column move must still retain the awaiting-input badge")
+	}
+	if !fx.disp.claims.Contains(fx.issue.ID) {
+		t.Error("failed column move must retain its claim journal entry")
+	}
+	if _, visible := fx.disp.state.dispatchSkips[fx.issue.ID]; !visible {
+		t.Error("failed column move must surface an operator-visible dispatch skip")
+	}
+}
+
 func TestDispatch_RefusesFreshRunWhenLastRunIsStillLive(t *testing.T) {
 	for _, status := range []store.RunStatus{
 		store.RunStatusRunning,
@@ -548,6 +586,54 @@ func TestDispatch_ResumesFailedResumableSameID(t *testing.T) {
 	fx.disp.workersWG.Wait()
 	if fx.launched != 1 {
 		t.Fatalf("resumable last_run launched %d time(s), want 1 resume", fx.launched)
+	}
+	if fx.lastSpec.RunID != fx.runID || fx.lastSpec.ResumeFromRunID != fx.runID {
+		t.Errorf("spec run=%q resumeFrom=%q, want both %q", fx.lastSpec.RunID, fx.lastSpec.ResumeFromRunID, fx.runID)
+	}
+}
+
+func TestDispatch_EmptyRetryAdoptsNewlyResumableLastRun(t *testing.T) {
+	fx := newLastRunFixture(t, store.RunStatusFailedResumable, native.StateInProgress)
+	if _, _, err := fx.disp.workspaces.CreateForRun(fx.issue.ID, fx.runID); err != nil {
+		t.Fatalf("CreateForRun: %v", err)
+	}
+	fx.disp.state.retries[fx.issue.ID] = &retryEntry{
+		IssueID: fx.issue.ID, Identifier: fx.issue.ID,
+		Attempt: 2, Fired: true, PrevRunID: "",
+	}
+	issue := tracker.Issue{
+		ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
+		WorkflowState: native.StateInProgress,
+	}
+
+	// The first pass discovers that the formerly-fresh retry target is now
+	// resumable. It releases the claim after rewriting the in-memory retry
+	// target, rather than churning forever with an authoritative empty id.
+	fx.disp.dispatch(context.Background(), issue)
+	retry := fx.disp.state.retries[fx.issue.ID]
+	if retry == nil || retry.PrevRunID != fx.runID {
+		t.Fatalf("retry target = %+v, want PrevRunID %q", retry, fx.runID)
+	}
+	if fx.launched != 0 {
+		t.Fatalf("first reconciliation pass launched %d run(s), want 0", fx.launched)
+	}
+	got, err := fx.board.Get(fx.issue.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Claim != "" {
+		t.Errorf("reconciliation pass retained claim %q", got.Claim)
+	}
+
+	// The next poll resumes the same run and preserves the retry attempt.
+	fx.disp.dispatch(context.Background(), issue)
+	running := fx.disp.state.running[fx.issue.ID]
+	if running == nil || running.Attempt != 2 {
+		t.Fatalf("running entry = %+v, want preserved retry attempt 2", running)
+	}
+	fx.disp.workersWG.Wait()
+	if fx.launched != 1 {
+		t.Fatalf("second pass launched %d run(s), want 1 resume", fx.launched)
 	}
 	if fx.lastSpec.RunID != fx.runID || fx.lastSpec.ResumeFromRunID != fx.runID {
 		t.Errorf("spec run=%q resumeFrom=%q, want both %q", fx.lastSpec.RunID, fx.lastSpec.ResumeFromRunID, fx.runID)

--- a/pkg/dispatcher/parked_test.go
+++ b/pkg/dispatcher/parked_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
@@ -215,6 +216,7 @@ func TestDispatch_RefusesFreshRunWhenLastRunIsPaused(t *testing.T) {
 				t.Fatalf("CreateRun: %v", err)
 			}
 			run.Status = status
+			run.Source = &store.RunSource{Kind: store.RunSourceKindDispatcher, IssueID: "native:fixture"}
 			if err := runStore.SaveRun(context.Background(), run); err != nil {
 				t.Fatalf("SaveRun: %v", err)
 			}
@@ -262,6 +264,13 @@ func TestDispatch_RefusesFreshRunWhenLastRunIsPaused(t *testing.T) {
 			if err != nil {
 				t.Fatalf("New: %v", err)
 			}
+			// An out-of-band resume can pause while an earlier dispatcher
+			// retry is still pending. The persisted pause supersedes it.
+			retryTimer := time.AfterFunc(time.Hour, func() {})
+			c.state.retries[iss.ID] = &retryEntry{
+				IssueID: iss.ID, Identifier: iss.ID, Attempt: 3, Timer: retryTimer,
+			}
+			t.Cleanup(func() { retryTimer.Stop() })
 
 			c.dispatch(context.Background(), tracker.Issue{
 				ID: iss.ID, Identifier: iss.ID, Title: iss.Title,
@@ -289,6 +298,9 @@ func TestDispatch_RefusesFreshRunWhenLastRunIsPaused(t *testing.T) {
 			}
 			if _, running := c.state.running[iss.ID]; running {
 				t.Errorf("issue must not be tracked as a live worker")
+			}
+			if _, retrying := c.state.retries[iss.ID]; retrying {
+				t.Errorf("re-park must consume a stale pending retry")
 			}
 		})
 	}
@@ -349,24 +361,168 @@ func TestDispatch_RefusesFreshRunWhenLastRunIsStillLive(t *testing.T) {
 	}
 }
 
-func TestDispatch_FilesFinishedLastRunInsteadOfMinting(t *testing.T) {
+// TestDispatch_MintsFreshWhenLastRunFinished: a finished last_run does
+// NOT hold the card. Dragging it back to an eligible column is the
+// operator's deliberate re-queue gesture — and since no surface ever
+// clears last_run_id, forbidding fresh here would make a new run for
+// that card unobtainable forever (review R16dca9).
+func TestDispatch_MintsFreshWhenLastRunFinished(t *testing.T) {
 	fx := newLastRunFixture(t, store.RunStatusFinished, native.StateInProgress)
 	fx.disp.dispatch(context.Background(), tracker.Issue{
 		ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
 		WorkflowState: native.StateInProgress,
 	})
+	fx.disp.workersWG.Wait()
+	if fx.launched != 1 {
+		t.Fatalf("finished last_run: launched %d time(s), want 1 fresh run", fx.launched)
+	}
+	if fx.lastSpec.RunID == "" || fx.lastSpec.RunID == fx.runID {
+		t.Errorf("spec run = %q, want a freshly minted id (not %q)", fx.lastSpec.RunID, fx.runID)
+	}
+	if fx.lastSpec.ResumeFromRunID != "" {
+		t.Errorf("spec resumeFrom = %q, want empty (fresh run, not a resume)", fx.lastSpec.ResumeFromRunID)
+	}
+}
+
+// TestDispatch_PausedLastRunNotDispatcherOwnedStaysPut: a paused run
+// launched from the pipelines control center or the studio console
+// (no dispatcher RunSource) must NOT have its card yanked into
+// awaiting_input — the admission sweep only reconciles in_progress
+// tickets, so the move would strand it. The card stays put; the guard
+// still refuses the fresh sibling.
+func TestDispatch_PausedLastRunNotDispatcherOwnedStaysPut(t *testing.T) {
+	fx := newLastRunFixture(t, store.RunStatusPausedWaitingHuman, native.StateInProgress)
+	run, err := fx.runStore.LoadRun(context.Background(), fx.runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	run.Source = nil // pipelines / studio launch
+	if err := fx.runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+
+	fx.disp.dispatch(context.Background(), tracker.Issue{
+		ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
+		WorkflowState: native.StateInProgress,
+	})
 	if fx.launched != 0 {
-		t.Fatalf("finished last_run launched %d fresh run(s), want 0", fx.launched)
+		t.Fatalf("paused last_run launched %d fresh run(s), want 0", fx.launched)
 	}
 	got, err := fx.board.Get(fx.issue.ID)
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if got.State != "review" {
-		t.Errorf("card state = %q, want review (completed_state)", got.State)
+	if got.State != native.StateInProgress {
+		t.Errorf("card state = %q, want %q (foreign paused run must not be re-parked)", got.State, native.StateInProgress)
 	}
-	if got.LastRunID != fx.runID {
-		t.Errorf("last_run = %q, want the finished run", got.LastRunID)
+	if got.AwaitingInput {
+		t.Error("awaiting-input badge must not be set on a foreign card")
+	}
+	if _, skipped := fx.disp.state.dispatchSkips[fx.issue.ID]; !skipped {
+		t.Error("the refused mint must surface as a dispatch skip")
+	}
+}
+
+// TestDispatch_PromotesOrphanedRunningLastRun covers the --no-server
+// deployment: no runview orphan reaper is in-process, so the dispatcher
+// itself must promote a run left "running" by a SIGKILL/host crash
+// (lock free, past the grace window) instead of holding the ticket
+// forever. No checkpoint → failed → a fresh run is legitimate.
+func TestDispatch_PromotesOrphanedRunningLastRun(t *testing.T) {
+	fx := newLastRunFixture(t, store.RunStatusRunning, native.StateInProgress)
+	run, err := fx.runStore.LoadRun(context.Background(), fx.runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	run.CreatedAt = time.Now().Add(-3 * time.Minute) // past the grace window
+	if err := fx.runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+
+	fx.disp.dispatch(context.Background(), tracker.Issue{
+		ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
+		WorkflowState: native.StateInProgress,
+	})
+	fx.disp.workersWG.Wait()
+	if fx.launched != 1 {
+		t.Fatalf("orphaned running last_run (no checkpoint): launched %d, want 1 fresh run", fx.launched)
+	}
+	got, err := fx.runStore.LoadRun(context.Background(), fx.runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.Status != store.RunStatusFailed {
+		t.Errorf("orphan status = %q, want %q (no checkpoint)", got.Status, store.RunStatusFailed)
+	}
+}
+
+// TestDispatch_ResumesOrphanedRunningLastRunWithCheckpoint: same dead
+// owner, but the run has a checkpoint — promotion lands on
+// failed_resumable and the dispatcher resumes the SAME run id.
+func TestDispatch_ResumesOrphanedRunningLastRunWithCheckpoint(t *testing.T) {
+	fx := newLastRunFixture(t, store.RunStatusRunning, native.StateInProgress)
+	run, err := fx.runStore.LoadRun(context.Background(), fx.runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	run.CreatedAt = time.Now().Add(-3 * time.Minute)
+	run.Checkpoint = &store.Checkpoint{}
+	if err := fx.runStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+	if _, _, err := fx.disp.workspaces.CreateForRun(fx.issue.ID, fx.runID); err != nil {
+		t.Fatalf("CreateForRun: %v", err)
+	}
+
+	fx.disp.dispatch(context.Background(), tracker.Issue{
+		ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
+		WorkflowState: native.StateInProgress,
+	})
+	fx.disp.workersWG.Wait()
+	if fx.launched != 1 {
+		t.Fatalf("orphaned running last_run (checkpoint): launched %d, want 1 resume", fx.launched)
+	}
+	if fx.lastSpec.RunID != fx.runID || fx.lastSpec.ResumeFromRunID != fx.runID {
+		t.Errorf("spec run=%q resumeFrom=%q, want both %q", fx.lastSpec.RunID, fx.lastSpec.ResumeFromRunID, fx.runID)
+	}
+}
+
+// TestDispatch_HoldsLiveLockedRun: a running/queued last_run whose lock
+// is held by a live owner must be held — the dead-owner probe must
+// never clobber in-flight work, even past the grace window.
+func TestDispatch_HoldsLiveLockedRun(t *testing.T) {
+	for _, status := range []store.RunStatus{store.RunStatusRunning, store.RunStatusQueued} {
+		t.Run(string(status), func(t *testing.T) {
+			fx := newLastRunFixture(t, status, native.StateInProgress)
+			run, err := fx.runStore.LoadRun(context.Background(), fx.runID)
+			if err != nil {
+				t.Fatalf("LoadRun: %v", err)
+			}
+			run.CreatedAt = time.Now().Add(-3 * time.Minute)
+			if err := fx.runStore.SaveRun(context.Background(), run); err != nil {
+				t.Fatalf("SaveRun: %v", err)
+			}
+			lock, err := fx.runStore.LockRun(context.Background(), fx.runID)
+			if err != nil {
+				t.Fatalf("LockRun: %v", err)
+			}
+			defer func() { _ = lock.Unlock() }()
+
+			fx.disp.dispatch(context.Background(), tracker.Issue{
+				ID: fx.issue.ID, Identifier: fx.issue.ID, Title: fx.issue.Title,
+				WorkflowState: native.StateInProgress,
+			})
+			if fx.launched != 0 {
+				t.Fatalf("live %s last_run launched %d fresh run(s), want 0", status, fx.launched)
+			}
+			got, err := fx.runStore.LoadRun(context.Background(), fx.runID)
+			if err != nil {
+				t.Fatalf("LoadRun: %v", err)
+			}
+			if got.Status != status {
+				t.Errorf("live run status = %q, want %q (untouched by the probe)", got.Status, status)
+			}
+		})
 	}
 }
 
@@ -418,6 +574,7 @@ func TestDispatch_RefusesFreshSiblingWhenWorkspaceUnmanaged(t *testing.T) {
 type lastRunFixture struct {
 	disp     *Dispatcher
 	board    *native.Store
+	runStore *store.FilesystemRunStore
 	issue    *native.Issue
 	runID    string
 	launched int
@@ -437,6 +594,9 @@ func newLastRunFixture(t *testing.T, status store.RunStatus, cardState string) *
 		t.Fatalf("CreateRun: %v", err)
 	}
 	run.Status = status
+	// Dispatcher-spawned runs carry a RunSource stamp — the re-park paths
+	// key off it to leave pipelines/studio-launched cards to their owner.
+	run.Source = &store.RunSource{Kind: store.RunSourceKindDispatcher, IssueID: "native:fixture"}
 	if err := runStore.SaveRun(context.Background(), run); err != nil {
 		t.Fatalf("SaveRun: %v", err)
 	}
@@ -451,7 +611,7 @@ func newLastRunFixture(t *testing.T, status store.RunStatus, cardState string) *
 	if err := ns.SetLastRun(iss.ID, runID, ""); err != nil {
 		t.Fatalf("SetLastRun: %v", err)
 	}
-	fx := &lastRunFixture{board: ns, issue: iss, runID: runID}
+	fx := &lastRunFixture{board: ns, issue: iss, runID: runID, runStore: runStore}
 	runner := &StubRunner{Handler: func(_ context.Context, spec DispatchSpec) error {
 		fx.lastSpec = spec
 		fx.launched++

--- a/pkg/dispatcher/retry.go
+++ b/pkg/dispatcher/retry.go
@@ -39,12 +39,13 @@ const sandboxParkDelay = 1 * time.Hour
 // When the prior run terminated in a resumable status (failed_resumable,
 // cancelled, paused_operator), prev.RunID is captured on the retry
 // entry so the next dispatch resumes the same run via
-// runtime.Engine.Resume instead of minting a fresh one. The engine's
-// resume machinery picks up at the failing node, reuses the worktree
-// the prior run created, and avoids re-executing upstream nodes
-// (which can be expensive — a feature_dev plan node can spend $5 and
-// 10 minutes on workspace exploration before producing its first
-// artifact).
+// runtime.Engine.Resume instead of minting a fresh one. A live last_run
+// is never discarded to mint a sibling planner from entry — see
+// lastRunForbidsFresh. The engine's resume machinery picks up at the
+// failing node, reuses the worktree the prior run created, and avoids
+// re-executing upstream nodes (which can be expensive — a feature_dev
+// plan node can spend $5 and 10 minutes on workspace exploration
+// before producing its first artifact).
 func (c *Dispatcher) scheduleRetry(issueID string, prev *runningEntry, runErr error) {
 	cfg := c.cfg.Load()
 	// prevAttempt is the attempt index of the run that just failed. It
@@ -86,21 +87,10 @@ func (c *Dispatcher) scheduleRetry(issueID string, prev *runningEntry, runErr er
 		errStr = runErr.Error()
 	}
 	prevRunID := c.resumableRunID(prev.RunID)
-	// The prior run may be resumable by status (failed_resumable /
-	// cancelled / paused_operator), but if resume already FAILED because
-	// the bot's workflow source changed since that run started, resuming
-	// again is futile — the runtime rejects it identically every attempt
-	// ("workflow source has changed ... re-run from scratch or use
-	// --force", pkg/runtime/resume.go). Drop the resume pointer so the
-	// next attempt mints a fresh runID instead of looping on the same
-	// doomed resume. Bot edits are routine in a dev/dogfood loop, so this
-	// otherwise strands every issue whose last run is failed_resumable.
-	if isResumeSourceChanged(runErr) {
-		if prevRunID != "" {
-			c.logger.Info("dispatcher: %s prior run %s not resumable (bot source changed) — retrying from scratch", prev.Identifier, prevRunID)
-		}
-		prevRunID = ""
-	}
+	// Source-changed is parked in finishRun (keep last_run, no sibling).
+	// If it still reaches here, keep the resume pointer: minting a
+	// planner from entry is worse than retrying a doomed resume.
+	// lastRunForbidsFresh still refuses GenerateRunID.
 	c.state.retries[issueID] = &retryEntry{
 		IssueID:    issueID,
 		Identifier: prev.Identifier,
@@ -123,20 +113,44 @@ func (c *Dispatcher) scheduleRetry(issueID string, prev *runningEntry, runErr er
 // isResumeSourceChanged reports whether runErr is the runtime's refusal
 // to resume because the bot's workflow source changed since the prior
 // run started (pkg/runtime/resume.go: "workflow source has changed ...
-// re-run from scratch or use --force"). Such a run cannot be resumed as-
-// is; the dispatcher must retry FRESH rather than reschedule the same
-// doomed resume. The runtime exposes a typed sentinel in-process and retains a
-// compatibility fallback for detached/mixed-version boundaries that flatten
-// errors to text.
+// re-run from scratch or use --force"). finishRun parks the ticket
+// instead of minting a sibling: the operator resumes THIS run with
+// --force, or cancels it before asking for a new one. The runtime
+// exposes a typed sentinel in-process and retains a compatibility
+// fallback for detached/mixed-version boundaries that flatten errors
+// to text.
 func isResumeSourceChanged(err error) bool {
 	return runtime.IsWorkflowSourceChanged(err)
 }
 
+// lastRunForbidsFresh reports statuses that still own the ticket: the
+// dispatcher must re-park, resume, or hold — never mint a sibling
+// planner from the workflow entry. The only legitimate fresh run is
+// no last_run, or a hard-failed / vanished last_run plus an
+// explicitly eligible ticket.
+func lastRunForbidsFresh(status store.RunStatus) bool {
+	switch status {
+	case store.RunStatusPausedWaitingHuman,
+		store.RunStatusPausedOperator,
+		store.RunStatusRunning,
+		store.RunStatusQueued,
+		store.RunStatusFinished,
+		store.RunStatusFailedResumable,
+		store.RunStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
 // resumableRunID returns the runID iff the corresponding run record
-// can be resumed by the runtime — i.e. its on-disk status is
-// failed_resumable, cancelled, or paused_operator. Returns "" if the
-// run is missing, terminal-without-checkpoint (failed), or any error
-// reading the store; the dispatcher then falls back to a fresh run.
+// can be auto-resumed by the dispatcher — i.e. its on-disk status is
+// failed_resumable, cancelled, or paused_operator. paused_waiting_human
+// is deliberately excluded (no answers → immediate re-pause); that
+// status is re-parked, not resumed. Returns "" if the run is missing,
+// hard-failed, or any error reading the store. An empty result is NOT
+// a licence to mint a sibling: resolveRunID still consults
+// lastRunForbidsFresh before GenerateRunID.
 // Best-effort: store IO errors are debug-logged, never fatal.
 func (c *Dispatcher) resumableRunID(runID string) string {
 	if runID == "" || c.storeDir == "" {

--- a/pkg/dispatcher/retry.go
+++ b/pkg/dispatcher/retry.go
@@ -125,8 +125,12 @@ func isResumeSourceChanged(err error) bool {
 
 // lastRunForbidsFresh reports statuses that still own the ticket: the
 // dispatcher must re-park, resume, or hold — never mint a sibling
-// planner from the workflow entry. The only legitimate fresh run is
-// no last_run, or a hard-failed / vanished last_run plus an
+// planner from the workflow entry. finished is deliberately NOT in the
+// set: the work completed, and dragging the card back to an eligible
+// column is the operator's deliberate re-queue gesture — with last_run
+// never cleared by any surface, forbidding finished would make a fresh
+// run for that card unobtainable forever. The other legitimate fresh
+// starts are no last_run, or a hard-failed / vanished last_run plus an
 // explicitly eligible ticket.
 func lastRunForbidsFresh(status store.RunStatus) bool {
 	switch status {
@@ -134,7 +138,6 @@ func lastRunForbidsFresh(status store.RunStatus) bool {
 		store.RunStatusPausedOperator,
 		store.RunStatusRunning,
 		store.RunStatusQueued,
-		store.RunStatusFinished,
 		store.RunStatusFailedResumable,
 		store.RunStatusCancelled:
 		return true
@@ -143,14 +146,28 @@ func lastRunForbidsFresh(status store.RunStatus) bool {
 	}
 }
 
+// orphanRunGraceWindow shields a just-created run from the dead-owner
+// probe: its launcher may sit between the run-record write and the lock
+// acquisition, so a young running/queued run is never judged. Mirrors
+// runview's orphanGraceWindow (pkg/runview/service_lifecycle.go).
+const orphanRunGraceWindow = 2 * time.Minute
+
 // resumableRunID returns the runID iff the corresponding run record
 // can be auto-resumed by the dispatcher — i.e. its on-disk status is
 // failed_resumable, cancelled, or paused_operator. paused_waiting_human
 // is deliberately excluded (no answers → immediate re-pause); that
 // status is re-parked, not resumed. Returns "" if the run is missing,
-// hard-failed, or any error reading the store. An empty result is NOT
-// a licence to mint a sibling: resolveRunID still consults
-// lastRunForbidsFresh before GenerateRunID.
+// hard-failed, finished, or any error reading the store. An empty
+// result is NOT a licence to mint a sibling: resolveRunID still
+// consults lastRunForbidsFresh before GenerateRunID.
+//
+// A running/queued status first goes through the dead-owner probe
+// (promoteIfOrphaned): the only orphan reaper lives in
+// runview.Service.reconcileOrphans, which `iterion dispatch
+// --no-server` never runs — without a dispatcher-side probe a run left
+// "running" on disk by a SIGKILL/host crash would hold its ticket
+// forever. Local disk I/O only; context.Background is fine on the
+// actor per the ADR-028 Step 3 boundary (same as runStatusOnDisk).
 // Best-effort: store IO errors are debug-logged, never fatal.
 func (c *Dispatcher) resumableRunID(runID string) string {
 	if runID == "" || c.storeDir == "" {
@@ -161,18 +178,69 @@ func (c *Dispatcher) resumableRunID(runID string) string {
 		c.logger.Debug("dispatcher: open store for resume check: %v", err)
 		return ""
 	}
-	r, err := s.LoadRun(context.Background(), runID)
+	ctx := context.Background()
+	r, err := s.LoadRun(ctx, runID)
 	if err != nil {
 		c.logger.Debug("dispatcher: cannot read run %s for resume check: %v", runID, err)
 		return ""
 	}
-	switch r.Status {
+	status := r.Status
+	if status == store.RunStatusRunning || status == store.RunStatusQueued {
+		status = c.promoteIfOrphaned(ctx, s, r)
+	}
+	switch status {
 	case store.RunStatusFailedResumable,
 		store.RunStatusCancelled,
 		store.RunStatusPausedOperator:
 		return runID
 	}
 	return ""
+}
+
+// promoteIfOrphaned re-examines a running/queued run whose owner may be
+// dead, mirroring runview.Service.reconcileOrphans: a just-created run
+// is shielded by the grace window, then a non-blocking LockRun is the
+// liveness probe — grabbing it proves no live process owns the run
+// (both the dispatcher's engine_runner and runview launches lock their
+// run for its whole lifetime, and flock is auto-released on crash). A
+// run nobody holds is promoted to failed_resumable (checkpoint present
+// → the caller resumes it) or failed (no recovery point → a fresh run
+// becomes legitimate), and the new status is returned. A held lock
+// (live owner), a store without cross-process lock authority, or any
+// error leaves the status untouched — the ticket is held, never
+// clobbered.
+func (c *Dispatcher) promoteIfOrphaned(ctx context.Context, s *store.FilesystemRunStore, r *store.Run) store.RunStatus {
+	status := r.Status
+	if !s.Capabilities().CrossProcessLock {
+		return status
+	}
+	if time.Since(r.CreatedAt) < orphanRunGraceWindow {
+		return status
+	}
+	lock, err := s.LockRun(ctx, r.ID)
+	if err != nil {
+		return status // a live owner holds the lock
+	}
+	defer func() { _ = lock.Unlock() }()
+	// Re-load under the lock — the owner may have released between the
+	// first read and now after persisting a terminal status.
+	cur, err := s.LoadRun(ctx, r.ID)
+	if err != nil {
+		return status
+	}
+	if cur.Status != store.RunStatusRunning && cur.Status != store.RunStatusQueued {
+		return cur.Status
+	}
+	newStatus := store.RunStatusFailed
+	if cur.Checkpoint != nil {
+		newStatus = store.RunStatusFailedResumable
+	}
+	if err := s.UpdateRunStatus(ctx, cur.ID, newStatus, "process orphaned: dispatcher found run '"+string(cur.Status)+"' with no live owner"); err != nil {
+		c.logger.Debug("dispatcher: orphan promotion %s: %v", cur.ID, err)
+		return status
+	}
+	c.logger.Info("dispatcher: last run %s was %s with no live owner — promoted to %s", cur.ID, cur.Status, newStatus)
+	return newStatus
 }
 
 // isSandboxSetupError reports whether the run failed before the

--- a/pkg/dispatcher/retry.go
+++ b/pkg/dispatcher/retry.go
@@ -153,10 +153,13 @@ func lastRunForbidsFresh(status store.RunStatus) bool {
 const orphanRunGraceWindow = 2 * time.Minute
 
 // resumableRunID returns the runID iff the corresponding run record
-// can be auto-resumed by the dispatcher — i.e. its on-disk status is
-// failed_resumable, cancelled, or paused_operator. paused_waiting_human
-// is deliberately excluded (no answers → immediate re-pause); that
-// status is re-parked, not resumed. Returns "" if the run is missing,
+// can be resumed by an already-authorized dispatcher retry — i.e. its
+// on-disk status is failed_resumable, cancelled, or paused_operator.
+// On restart, reparkClaimedIfLastRunWaiting intercepts dispatcher-owned
+// paused_operator before this helper is reached; the status remains here for
+// an in-memory retry decision in the same process. paused_waiting_human is
+// deliberately excluded (no answers → immediate re-pause); that status is
+// re-parked, not resumed. Returns "" if the run is missing,
 // hard-failed, finished, or any error reading the store. An empty
 // result is NOT a licence to mint a sibling: resolveRunID still
 // consults lastRunForbidsFresh before GenerateRunID.

--- a/pkg/dispatcher/retry.go
+++ b/pkg/dispatcher/retry.go
@@ -146,9 +146,9 @@ func lastRunForbidsFresh(status store.RunStatus) bool {
 	}
 }
 
-// orphanRunGraceWindow shields a just-created run from the dead-owner
+// orphanRunGraceWindow shields a just-created running run from the dead-owner
 // probe: its launcher may sit between the run-record write and the lock
-// acquisition, so a young running/queued run is never judged. Mirrors
+// acquisition, so a young run is never judged. Mirrors
 // runview's orphanGraceWindow (pkg/runview/service_lifecycle.go).
 const orphanRunGraceWindow = 2 * time.Minute
 
@@ -164,7 +164,7 @@ const orphanRunGraceWindow = 2 * time.Minute
 // result is NOT a licence to mint a sibling: resolveRunID still
 // consults lastRunForbidsFresh before GenerateRunID.
 //
-// A running/queued status first goes through the dead-owner probe
+// A running status first goes through the dead-owner probe
 // (promoteIfOrphaned): the only orphan reaper lives in
 // runview.Service.reconcileOrphans, which `iterion dispatch
 // --no-server` never runs — without a dispatcher-side probe a run left
@@ -188,7 +188,7 @@ func (c *Dispatcher) resumableRunID(runID string) string {
 		return ""
 	}
 	status := r.Status
-	if status == store.RunStatusRunning || status == store.RunStatusQueued {
+	if status == store.RunStatusRunning {
 		status = c.promoteIfOrphaned(ctx, s, r)
 	}
 	switch status {
@@ -200,7 +200,7 @@ func (c *Dispatcher) resumableRunID(runID string) string {
 	return ""
 }
 
-// promoteIfOrphaned re-examines a running/queued run whose owner may be
+// promoteIfOrphaned re-examines a running run whose owner may be
 // dead, mirroring runview.Service.reconcileOrphans: a just-created run
 // is shielded by the grace window, then a non-blocking LockRun is the
 // liveness probe — grabbing it proves no live process owns the run
@@ -231,7 +231,10 @@ func (c *Dispatcher) promoteIfOrphaned(ctx context.Context, s *store.FilesystemR
 	if err != nil {
 		return status
 	}
-	if cur.Status != store.RunStatusRunning && cur.Status != store.RunStatusQueued {
+	// Queued runs intentionally have no lock owner while they wait for a
+	// pipelines concurrency slot. A free lock is therefore evidence of an
+	// orphan only for running, matching runview.Service.reconcileOrphans.
+	if cur.Status != store.RunStatusRunning {
 		return cur.Status
 	}
 	newStatus := store.RunStatusFailed

--- a/pkg/dispatcher/retry.go
+++ b/pkg/dispatcher/retry.go
@@ -115,7 +115,8 @@ func (c *Dispatcher) scheduleRetry(issueID string, prev *runningEntry, runErr er
 // run started (pkg/runtime/resume.go: "workflow source has changed ...
 // re-run from scratch or use --force"). finishRun parks the ticket
 // instead of minting a sibling: the operator resumes THIS run with
-// --force, or cancels it before asking for a new one. The runtime
+// --force. Cancelling is not an escape: cancelled last_runs are resumed
+// from their checkpoint and still forbid a fresh sibling. The runtime
 // exposes a typed sentinel in-process and retains a compatibility
 // fallback for detached/mixed-version boundaries that flatten errors
 // to text.

--- a/pkg/dispatcher/retry_resume_test.go
+++ b/pkg/dispatcher/retry_resume_test.go
@@ -4,7 +4,31 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/store"
 )
+
+func TestLastRunForbidsFresh(t *testing.T) {
+	for _, status := range []store.RunStatus{
+		store.RunStatusPausedWaitingHuman,
+		store.RunStatusPausedOperator,
+		store.RunStatusRunning,
+		store.RunStatusQueued,
+		store.RunStatusFinished,
+		store.RunStatusFailedResumable,
+		store.RunStatusCancelled,
+	} {
+		if !lastRunForbidsFresh(status) {
+			t.Errorf("lastRunForbidsFresh(%s) = false, want true", status)
+		}
+	}
+	if lastRunForbidsFresh(store.RunStatusFailed) {
+		t.Error("hard-failed last_run may start fresh when the ticket is explicitly eligible")
+	}
+	if lastRunForbidsFresh("") {
+		t.Error("unknown/unreadable status must not block a fresh run")
+	}
+}
 
 func TestIsResumeSourceChanged(t *testing.T) {
 	cases := []struct {

--- a/pkg/dispatcher/retry_resume_test.go
+++ b/pkg/dispatcher/retry_resume_test.go
@@ -14,13 +14,15 @@ func TestLastRunForbidsFresh(t *testing.T) {
 		store.RunStatusPausedOperator,
 		store.RunStatusRunning,
 		store.RunStatusQueued,
-		store.RunStatusFinished,
 		store.RunStatusFailedResumable,
 		store.RunStatusCancelled,
 	} {
 		if !lastRunForbidsFresh(status) {
 			t.Errorf("lastRunForbidsFresh(%s) = false, want true", status)
 		}
+	}
+	if lastRunForbidsFresh(store.RunStatusFinished) {
+		t.Error("finished last_run must not hold the card — dragging it back to an eligible column is the re-queue gesture")
 	}
 	if lastRunForbidsFresh(store.RunStatusFailed) {
 		t.Error("hard-failed last_run may start fresh when the ticket is explicitly eligible")

--- a/pkg/dispatcher/state.go
+++ b/pkg/dispatcher/state.go
@@ -60,15 +60,23 @@ type state struct {
 	// candidates in tick); an entry is cleared the moment its issue
 	// successfully claims. Actor-goroutine-owned; no mutex needed.
 	dispatchSkips map[string]DispatchSkipView
+	// lastRunHoldWarned records the "refusing a fresh sibling" warn
+	// already emitted for an issue (value = the reason). The dispatchSkips
+	// entry can't carry this dedup: dispatch() deletes it before
+	// resolveRunID runs, so a held card (live running/queued last_run)
+	// would re-warn every poll. Cleared when the hold resolves and the
+	// dispatch proceeds. Actor-goroutine-owned; no mutex needed.
+	lastRunHoldWarned map[string]string
 }
 
 func newState() *state {
 	return &state{
-		running:       map[string]*runningEntry{},
-		retries:       map[string]*retryEntry{},
-		slotsByState:  map[string]int{},
-		tombstones:    map[string]struct{}{},
-		dispatchSkips: map[string]DispatchSkipView{},
+		running:           map[string]*runningEntry{},
+		retries:           map[string]*retryEntry{},
+		slotsByState:      map[string]int{},
+		tombstones:        map[string]struct{}{},
+		dispatchSkips:     map[string]DispatchSkipView{},
+		lastRunHoldWarned: map[string]string{},
 	}
 }
 

--- a/pkg/dispatcher/state.go
+++ b/pkg/dispatcher/state.go
@@ -65,7 +65,8 @@ type state struct {
 	// entry can't carry this dedup: dispatch() deletes it before
 	// resolveRunID runs, so a held card (live running/queued last_run)
 	// would re-warn every poll. Cleared when the hold resolves and the
-	// dispatch proceeds. Actor-goroutine-owned; no mutex needed.
+	// dispatch proceeds, or pruned when the issue leaves the candidate set.
+	// Actor-goroutine-owned; no mutex needed.
 	lastRunHoldWarned map[string]string
 }
 

--- a/pkg/dispatcher/workspace.go
+++ b/pkg/dispatcher/workspace.go
@@ -355,31 +355,38 @@ func (w *Workspaces) ownerPathForRun(issueID, runID string) string {
 }
 
 // resumeGeneration returns the active, verified workspace shape that owns a
-// resumable run. A unique run shape wins over a stable workspace retained from
-// an older keep-mode dispatch; if that unique shape exists but is invalid, we
-// fail closed instead of falling through to an unrelated stable workspace.
-// The probes are deliberately lock-free: they run on the dispatcher actor and
-// must never wait behind a worker's recursive delete. Invalid ownership shapes
-// return managed=false so a fresh generation can be isolated; operational
-// filesystem failures are returned so dispatch is deferred visibly.
+// resumable run. It preserves the historical compact result for lifecycle
+// callers; resumeGenerationState exposes the separate exists bit needed by
+// resolveRunID to distinguish a missing workspace (safe fresh restart) from an
+// existing but unowned/corrupt shape (fail closed).
 func (w *Workspaces) resumeGeneration(issueID, runID string) (string, bool, error) {
-	exists, err := w.generationShapeExists(issueID, runID)
+	generation, _, managed, err := w.resumeGenerationState(issueID, runID)
+	return generation, managed, err
+}
+
+// resumeGenerationState probes the run-scoped shape first, then the stable
+// workspace retained from an older keep-mode dispatch. If the unique run shape
+// exists but is invalid, it wins and we do not fall through to an unrelated
+// stable workspace. The probes are deliberately lock-free: they run on the
+// dispatcher actor and must never wait behind a worker's recursive delete.
+func (w *Workspaces) resumeGenerationState(issueID, runID string) (generation string, exists, managed bool, err error) {
+	exists, err = w.generationShapeExists(issueID, runID)
 	if err != nil {
-		return runID, false, err
+		return runID, false, false, err
 	}
 	if exists {
-		managed, err := w.generationIsManaged(issueID, runID)
-		return runID, managed, err
+		managed, err = w.generationIsManaged(issueID, runID)
+		return runID, true, managed, err
 	}
 	exists, err = w.generationShapeExists(issueID, "")
 	if err != nil {
-		return "", false, err
+		return "", false, false, err
 	}
 	if exists {
-		managed, err := w.generationIsManaged(issueID, "")
-		return "", managed, err
+		managed, err = w.generationIsManaged(issueID, "")
+		return "", true, managed, err
 	}
-	return "", false, nil
+	return "", false, false, nil
 }
 
 func (w *Workspaces) generationShapeExists(issueID, runID string) (bool, error) {

--- a/pkg/dispatcher/workspace_test.go
+++ b/pkg/dispatcher/workspace_test.go
@@ -224,6 +224,23 @@ func TestWorkspaceResumeGenerationDoesNotAdoptLegacyPath(t *testing.T) {
 	}
 }
 
+func TestWorkspaceResumeGenerationStateDistinguishesMissingFromUnmanaged(t *testing.T) {
+	w, err := NewWorkspaces(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewWorkspaces: %v", err)
+	}
+	const issueID, runID = "native:resume-state", "run-resume-state"
+	if generation, exists, managed, err := w.resumeGenerationState(issueID, runID); err != nil || exists || managed || generation != "" {
+		t.Fatalf("missing shape = (%q, %t, %t, %v), want empty, false, false, nil", generation, exists, managed, err)
+	}
+	if err := os.MkdirAll(w.PathForRun(issueID, runID), 0o755); err != nil {
+		t.Fatalf("mkdir unmanaged run shape: %v", err)
+	}
+	if generation, exists, managed, err := w.resumeGenerationState(issueID, runID); err != nil || !exists || managed || generation != runID {
+		t.Fatalf("unmanaged shape = (%q, %t, %t, %v), want %q, true, false, nil", generation, exists, managed, err, runID)
+	}
+}
+
 func TestWorkspaceResumeGenerationRejectsInvalidRunShapeBeforeStableFallback(t *testing.T) {
 	w, err := NewWorkspaces(t.TempDir())
 	if err != nil {


### PR DESCRIPTION
## Problem

After a host reboot, the dispatcher silently superseded runs paused on a human-review node instead of keeping them parked:

1. `sweepStaleLocalClaimsAtBoot` frees every claim whose PID is dead — including the claim that **parked** a card whose last run sits on a human node (ADR-014 parking).
2. The card falls back to an eligible state; the next tick re-claims it.
3. `resumableRunID` excludes `paused_waiting_human` **by design** (an auto-resume without answers would re-pause instantly), so `dispatch` minted a **fresh run from the workflow entry**, overwriting the card's `last_run_id`.

Observed live: a run paused at `approve_outline` in the evening was replaced by a brand-new run at the morning boot, re-doing the work from scratch.

## Fix

- **`reparkClaimedIfLastRunWaiting`** (`parked.go`): `dispatch` re-parks the card instead of minting when its `last_run` is still paused.
- **`reconcileStrandedPaused`** (`parked.go`): every tick re-parks eligible cards stranded with a paused `last_run` (e.g. after the boot claim sweep) — they show up as `awaiting_input` again, waiting for the operator.
- **`lastRunForbidsFresh`** (`retry.go`): refuse `GenerateRunID` while any live `last_run` (paused, running, finished, resumable) still owns the card.
- Start paused before the first tick (`manager.go`) to close the boot race between auto-start and the first dispatch.

Resume stays an explicit operator action (`POST /api/runs/{id}/resume`, console, `iterion resume`) — unchanged from ADR-014.

## Tests

- `parked_test.go`, `retry_resume_test.go`, `manager_autostart_test.go`, `commands_paused_test.go`, `native/adapter_test.go`
- `go test ./pkg/dispatcher/...` green; `go build ./...` + `go vet` clean.

Docs updated: ADR-014, `docs/dispatcher.md`, `docs/resume.md`.