### PR TITLE
fix(feed-watch): a push refused for credentials is not a rebase conflict

### DIFF
--- a/bots/feed-watch/main.bot
+++ b/bots/feed-watch/main.bot
@@ -748,11 +748,30 @@ tool dedup_queue:
         br = subprocess.run(['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
                             capture_output=True, text=True).stdout.strip() or 'HEAD'
         for _ in range(5):
-            if subprocess.run(['git', 'push', 'origin', 'HEAD']).returncode == 0:
+            pushed = subprocess.run(['git', 'push', 'origin', 'HEAD'],
+                                    capture_output=True, text=True)
+            if pushed.returncode == 0:
                 return True
-            if subprocess.run(['git', 'pull', '--rebase', '--autostash', 'origin', br]).returncode != 0:
+            # Name the cause, don't guess it. A push that fails for want of
+            # credentials is not a rebase conflict, and reporting it as one
+            # sends the reader looking for a merge problem that does not
+            # exist — measured on the 2026-08-19 ux-metier digest, which
+            # died on "git rebase failed (conflict)" while the real message
+            # underneath was "could not read Username for github.com".
+            err = (pushed.stderr or '')[-400:]
+            if 'could not read Username' in err or 'Authentication failed' in err \
+                    or 'terminal prompts disabled' in err or 'Permission denied' in err:
+                raise SystemExit('feed-watch: git push was refused for lack of credentials -- '
+                                 'the state was committed locally and is NOT pushed, so this '
+                                 "category's queue will replay next run. Bind the forge_token "
+                                 'secret (or run with state_commit=false). git said: ' + err.strip())
+            rebased = subprocess.run(['git', 'pull', '--rebase', '--autostash', 'origin', br],
+                                     capture_output=True, text=True)
+            if rebased.returncode != 0:
                 subprocess.run(['git', 'rebase', '--abort'])
-                raise SystemExit('feed-watch: git rebase failed pushing state (conflict) -- aborting')
+                raise SystemExit('feed-watch: could not rebase onto origin/' + br +
+                                 ' to retry the push -- aborting. git said: ' +
+                                 (rebased.stderr or '')[-400:].strip())
         raise SystemExit('feed-watch: git push failed after 5 retries (non-fast-forward or network)')
 
     entries = []
@@ -1383,11 +1402,30 @@ tool commit_state:
         br = subprocess.run(['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
                             capture_output=True, text=True).stdout.strip() or 'HEAD'
         for _ in range(5):
-            if subprocess.run(['git', 'push', 'origin', 'HEAD']).returncode == 0:
+            pushed = subprocess.run(['git', 'push', 'origin', 'HEAD'],
+                                    capture_output=True, text=True)
+            if pushed.returncode == 0:
                 return True
-            if subprocess.run(['git', 'pull', '--rebase', '--autostash', 'origin', br]).returncode != 0:
+            # Name the cause, don't guess it. A push that fails for want of
+            # credentials is not a rebase conflict, and reporting it as one
+            # sends the reader looking for a merge problem that does not
+            # exist — measured on the 2026-08-19 ux-metier digest, which
+            # died on "git rebase failed (conflict)" while the real message
+            # underneath was "could not read Username for github.com".
+            err = (pushed.stderr or '')[-400:]
+            if 'could not read Username' in err or 'Authentication failed' in err \
+                    or 'terminal prompts disabled' in err or 'Permission denied' in err:
+                raise SystemExit('feed-watch: git push was refused for lack of credentials -- '
+                                 'the state was committed locally and is NOT pushed, so this '
+                                 "category's queue will replay next run. Bind the forge_token "
+                                 'secret (or run with state_commit=false). git said: ' + err.strip())
+            rebased = subprocess.run(['git', 'pull', '--rebase', '--autostash', 'origin', br],
+                                     capture_output=True, text=True)
+            if rebased.returncode != 0:
                 subprocess.run(['git', 'rebase', '--abort'])
-                raise SystemExit('feed-watch: git rebase failed pushing state (conflict) -- aborting')
+                raise SystemExit('feed-watch: could not rebase onto origin/' + br +
+                                 ' to retry the push -- aborting. git said: ' +
+                                 (rebased.stderr or '')[-400:].strip())
         raise SystemExit('feed-watch: git push failed after 5 retries (non-fast-forward or network)')
 
     cdir = os.path.join(state_dir, category)


### PR DESCRIPTION
## What happened

This morning's `ux-metier` digest delivered normally (22 items, 2/2 to `#veille-design-accessibilite` and `#veille-vigie-design`) and then died with:

```
feed-watch: git rebase failed pushing state (conflict) -- aborting
```

There was no conflict. Underneath, twice:

```
fatal: could not read Username for 'https://github.com': No such device or address
fatal: no rebase in progress
```

The push had no credentials; the rebase retry had none either; the abort found no rebase to abort. The message names the one thing that did **not** happen, sends the reader hunting a merge problem that does not exist, and hides the consequence that actually matters: **the state was committed locally and never pushed**, so the category's queue replays its whole digest next run. Which is precisely what would have happened — 22 already-published items were still queued in the state repo (repaired by hand in `iterion-veille@a5f14df`).

## What changes

The push captures stderr and recognises the credential family — `could not read Username`, `Authentication failed`, `terminal prompts disabled`, `Permission denied` — reporting what git said **and what it costs**:

> git push was refused for lack of credentials — the state was committed locally and is NOT pushed, so this category's queue will replay next run. Bind the forge_token secret (or run with state_commit=false). git said: …

The rebase branch now reports git's own stderr instead of asserting a conflict it never verified.

Both copies of `_commit_push_state` carry the fix. They are duplicated by the bot's structure (one per tool node); leaving one honest and one lying would be worse than either state.

## Not fixed here

**Why that run had no git credentials** when the three other digests the same morning — same repo, same connection, same schedule family — had them. That needs the per-run secret provisioning inspected; this PR only makes the failure say what it is.

## Validation

`iterion validate` OK · `go test ./e2e/ -run TestFeedWatch` green · `task lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
