### PR TITLE
feat(instrument): Obsy — Sentry/GlitchTip error tracking + log standardization bot

### DIFF
--- a/bots/instrument/README.md
+++ b/bots/instrument/README.md
@@ -1,0 +1,58 @@
+# instrument (Obsy)
+
+Observability instrumentation campaign — **ADR-058 minimal-framing**
+(the proven feature-dev / branch-improve-loop chassis). ONE adaptive
+`campaign` agent surveys the target repo's production entry points and
+wires the observability families requested in `scope`, one verified
+semantic commit at a time — tests included, ADRs authored for the
+SDK/library choices, docs updated where the repo documents
+configuration. A deterministic build/test gate + an in-loop adversarial
+review + a bounded continuation loop re-poke it until every family is
+fully wired and the tree is green; an opt-in tail opens the pull
+request. git is the durable state.
+
+## Families (`scope` — open comma list)
+
+| Family | Meaning (definition of done: `skills/instrumentation.md`) |
+|---|---|
+| `errors` | Error tracking via a **Sentry-DSN-protocol** SDK (Sentry AND GlitchTip). Enabled only when the DSN env var is set (default `SENTRY_DSN`); loud non-fatal init failure; release/environment tags; capture at process seams; flush on shutdown; secret/PII scrubbing. |
+| `logs` | ONE central logging seam — **extend the repo's existing logger, never replace it**. Leveled + structured fields; **JSON by default on production surfaces**, human on interactive CLI; stray-print sweep; error→event / warn→breadcrumb coupling into the tracker. |
+| `tracing` | **Opt-in** (add it explicitly). Sentry-first transactions/spans, env-tunable sampling, conservative prod default. See `skills/tracing.md`. |
+
+Stack knowledge lives in `skills/lang-go.md` / `lang-js.md` /
+`lang-python.md` — adding a stack or a family is a skill file, never a
+DSL edit.
+
+## Inputs
+
+| Var | Required | Description |
+|---|---|---|
+| `scope` | no | Families to wire (default `errors,logs`; `tracing` is opt-in) |
+| `dsn_env_var` | no | Runtime DSN env var name (default `SENTRY_DSN`; unset at runtime = tracking off) |
+| `mission_notes` | no | Repo-specific arbitrations for this run (which module to extend, seams, exclusions) |
+| `workspace_dir` | no | Defaults to `${PROJECT_DIR}` (the run's worktree — do not override) |
+| `baseline` | no | Known pre-existing failures to SKIP (empty = cheap stash-check once) |
+| `max_passes` | no | Continuation-loop cap (default 6) |
+| `open_mr` | no | Push the series + open a PR on convergence (default false) |
+| `mr_branch` / `mr_base` / `source_issue_ref` | no | PR wiring — see main.bot |
+
+## Shape (v2 — one agent, minimal framing)
+
+```
+campaign → verify_probe → verify_build → verify_run → review → gate
+gate → mr_gate           when converged (green AND instrumentation_complete AND review.clean)
+gate → campaign          as continuation_loop(max_passes), carrying the failure log
+mr_gate → forge_auth_probe → finalize_mr → surface_pr_link → done   (opt-in PR tail)
+```
+
+## Run it
+
+```sh
+iterion run bots/instrument \
+  --var mission_notes="extend pkg/log; SENTRY_DSN standard envs" \
+  --var scope=errors,logs
+```
+
+Wire the DSN afterwards by setting the env var (e.g. `SENTRY_DSN`,
+plus `SENTRY_ENVIRONMENT`) on the instrumented deployment — the run's
+docs slice records the exact envs it introduced.

--- a/bots/instrument/devbox.json
+++ b/bots/instrument/devbox.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.17.2/.schema/devbox.schema.json",
+  "packages": [
+    "gh@2.96.0",
+    "glab@1.108.0"
+  ],
+  "env": {
+    "DEVBOX_NO_PROMPT": "true"
+  }
+}

--- a/bots/instrument/devbox.lock
+++ b/bots/instrument/devbox.lock
@@ -1,0 +1,95 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "gh@2.96.0": {
+      "last_modified": "2026-07-08T21:13:06Z",
+      "resolved": "github:NixOS/nixpkgs/389ed85304b281ca7f306cf8a1eb4378651ca44e#gh",
+      "source": "devbox-search",
+      "version": "2.96.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/5m3slxi84h97r5hzmy4dhfksl9cc166a-gh-2.96.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/5m3slxi84h97r5hzmy4dhfksl9cc166a-gh-2.96.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/85s40vacs1ajn0x7b3vszvlqwnflh0dq-gh-2.96.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/85s40vacs1ajn0x7b3vszvlqwnflh0dq-gh-2.96.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/waa7fl1d466lkihg89p60iisjwynyfb7-gh-2.96.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/waa7fl1d466lkihg89p60iisjwynyfb7-gh-2.96.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/fz2h6h3cgw645ighi31zdjwbkdzmaav7-gh-2.96.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/fz2h6h3cgw645ighi31zdjwbkdzmaav7-gh-2.96.0"
+        }
+      }
+    },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2026-07-20T13:48:30Z",
+      "resolved": "github:NixOS/nixpkgs/421eebfd0ec7bccd4abe826ce62d7e6e83129493?lastModified=1784555310&narHash=sha256-%2FFCliTPgiuV1owejZFNx3Ch9irdvkOfOFl%2BHHZ%2BDrtM%3D"
+    },
+    "glab@1.108.0": {
+      "last_modified": "2026-07-16T04:38:10Z",
+      "resolved": "github:NixOS/nixpkgs/6368bc923cec55a5f78960ade0cb4dd99580e087#glab",
+      "source": "devbox-search",
+      "version": "1.108.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/g1pxpc8mc85b5njadwc7c4ji9z17gs6m-glab-1.108.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/g1pxpc8mc85b5njadwc7c4ji9z17gs6m-glab-1.108.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/qsh8x8h14cbrkkmgxzgh8kz2qpiqh16f-glab-1.108.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/qsh8x8h14cbrkkmgxzgh8kz2qpiqh16f-glab-1.108.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/3czfggb51vdif2fia979hcv3cl9cib4p-glab-1.108.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/3czfggb51vdif2fia979hcv3cl9cib4p-glab-1.108.0"
+        }
+      }
+    }
+  }
+}

--- a/bots/instrument/main.bot
+++ b/bots/instrument/main.bot
@@ -1,0 +1,954 @@
+## ─────────────────────────────────────────────────────────────────
+## instrument (Obsy) — observability instrumentation campaign:
+##                     error tracking + standardized logs (+ opt-in
+##                     tracing), one verified commit at a time.
+##
+## THE MISSION is an INSTRUMENTATION campaign: point it at a repo and
+## ONE adaptive agent wires the observability families requested in
+## `scope` — *errors* (an error-tracking SDK speaking the Sentry DSN
+## protocol, so Sentry AND GlitchTip both work, enabled only when the
+## DSN env var is set), *logs* (ONE central logging seam, leveled +
+## structured, JSON by default on production surfaces, error→event /
+## warn→breadcrumb coupling into the tracker), and opt-in *tracing*
+## (Sentry-first transactions/spans). Then a deterministic build/test
+## gate re-checks the tree and an opt-in PR tail ships the series.
+##
+## Sibling of `feature_dev` / `whole_improve_loop` / `branch_improve_loop`
+## v2: SAME proven shape (one adaptive `campaign` agent + a
+## deterministic build/test gate + an in-loop adversarial review + a
+## bounded continuation loop + git-as-state + the opt-in PR path),
+## DIFFERENT scope — the observability FAMILIES define the work, and
+## the stack-specific knowledge (which SDK, which log lib, which
+## seams) lives in the bundle's SKILLS, never in this DSL.
+##
+## WHY THIS SHAPE. ADR-058 (minimal framing): the deficit is framing,
+## not capability. A capable agent instruments a repo better as ONE
+## flow — survey the entry points, build a living todo of slices, land
+## one verified commit per slice — than as an assembly line of
+## detect/plan/wire/review nodes. Determinism stays where it earns its
+## keep (the build/test gate, the bounded loop); everything else is
+## the agent's own judgment guided by the skills.
+##
+## GRAPH (see the workflow block):
+##   campaign     — ONE adaptive agent (claude_code, full tools). Mission =
+##                  instrument the repo per `scope`, method from the
+##                  `instrumentation` skill + the matching `lang-*` skill(s)
+##                  (+ `tracing` when requested). Living todo, one verified
+##                  semantic commit per slice, in stride. git IS the durable
+##                  state — a re-dispatch re-runs `campaign`, which reads
+##                  `git log` and continues. Termination output:
+##                  {instrumentation_complete, commits_this_pass, …}.
+##   verify_build — adaptive, stack-agnostic: reads the `verify-build` skill
+##     + verify_run  and writes the repo's real build+test into an OUT-OF-TREE
+##                  <scratch_dir>/verify.sh; a DETERMINISTIC tool node
+##                  re-runs it and gates on the REAL exit code (no LLM
+##                  judgment). The anti-Goodhart truth oracle: the agent
+##                  can't self-certify — the tests it writes for the
+##                  instrumentation run under this gate.
+##   review       — adversarial in-loop self-review (readonly): the
+##                  code-review-invariants checklist against the run's own
+##                  diff, blocking only on high-confidence real defects.
+##   gate         — deterministic compute: green AND instrumentation_complete
+##                  AND review-clean → converged → ship; else loop back to
+##                  `campaign` (RED → with the failure log; green but work
+##                  remains → another pass). No LLM, no shell.
+##   mr_gate      — deterministic: open the optional PR (the series of
+##     + finalize_mr per-pass commits) when open_mr, else finish.
+##
+## CONTINUATION IS BOUNDED. The single declared loop
+## (campaign→verify→review→gate→campaign) is capped by `max_passes`; on
+## exhaustion it ships what is banked. LANDS CONTINUOUSLY: the agent
+## commits each slice in stride, so an interrupted / budget-capped run
+## has banked every committed slice (git is the state).
+##
+## STACK/REPO-AGNOSTIC (CLAUDE.md "Catalog bots are repo-agnostic" +
+## "Universal code bots"): `scope` is an OPEN comma list (adding a new
+## family = a skill file + a scope token, zero DSL edits), no language /
+## package-manager literal and no iterion-specific target path appears
+## in any var default, command body, or schema. Repo-specific
+## arbitrations (which package to create, which seams to wire) travel in
+## the per-run `mission_notes` var, never in this file.
+## ─────────────────────────────────────────────────────────────────
+
+vars:
+  workspace_dir: string = "${PROJECT_DIR}"
+
+  ## THE FAMILIES to instrument — an open, comma-separated list. Shipped
+  ## families (each with a matching skill): "errors" (Sentry-DSN-protocol
+  ## error tracking — Sentry AND GlitchTip), "logs" (one central logging
+  ## seam, JSON default in prod), "tracing" (OPT-IN, Sentry-first
+  ## transactions/spans — add it explicitly: scope=errors,logs,tracing).
+  scope: string = "errors,logs"
+
+  ## The environment variable the instrumented code reads its DSN from at
+  ## RUNTIME. SENTRY_DSN is the ecosystem convention every Sentry-protocol
+  ## SDK (and GlitchTip) understands; override when the target repo has
+  ## its own env naming scheme. The instrumentation must be OFF (zero
+  ## behaviour change) when this variable is unset.
+  dsn_env_var: string = "SENTRY_DSN"
+
+  ## Optional operator guidance for THIS run: repo-specific arbitrations
+  ## (which module to extend, which seams to wire, what to exclude),
+  ## constraints, or context. Empty = the campaign surveys and decides
+  ## per the skills.
+  mission_notes: string = ""
+
+  ## Out-of-tree, sandbox-writable scratch for the deterministic gate's
+  ## verify script/log ONLY. The engine resolves ${PROJECT_SCRATCH_DIR}
+  ## to ~/.iterion/projects/<key>/scratch non-sandboxed and to the
+  ## container-writable /tmp/iterion-scratch under a sandbox (never
+  ## hardcode ~/.iterion here — the -full image's pinned non-host User
+  ## cannot write a host-owned path → EACCES). Keeping it OUT of the
+  ## target worktree is the repo-agnostic rule: never pollute someone
+  ## else's tree.
+  scratch_dir: string = "${PROJECT_SCRATCH_DIR}/instrument"
+
+  ## BASELINE (G5 — docs/references/productive-session-patterns.md). Known
+  ## pre-existing test failures / flaky tests the campaign must SKIP rather
+  ## than burn budget proving they aren't its own. Empty (default) = the
+  ## campaign establishes it once cheaply (a `git stash`-based check) then
+  ## skips what predates its work. The dispatcher/operator can pre-fill it.
+  baseline: string = ""
+
+  ## Hard cap on continuation PASSES — the convergence backstop. Each pass
+  ## is one campaign→verify cycle; the run stops (shipping what is banked)
+  ## when the instrumentation is reported complete + the tree is green, or
+  ## when this cap is hit. Sizes the declared continuation loop.
+  ## NOTE loop semantics: the DSL `as continuation_loop(N)` bounds the
+  ## loop-BACKS (re-entries), so the TOTAL number of passes is N+1.
+  max_passes: int = 6
+
+  ## ─── PR finalization (opt-in) ─────────────────────────────────
+  ## When open_mr=true, after convergence finalize_mr pushes the run's HEAD
+  ## (the SERIES of per-slice commits) to the forge and opens a pull
+  ## request (PR; merge request on GitLab). Off by default so a plain
+  ## local run just leaves the commits on the storage branch (worktree
+  ## finalization). The issue-label / comment→PR triggers set this true.
+  ## Requires a forge_token secret (or host-authenticated gh/glab).
+  open_mr: bool = false
+  ## Branch name to push + open the PR from. Empty = derive a stable name
+  ## from the run (iterion/improve/<run-id>).
+  mr_branch: string = ""
+  ## Integration base the PR targets. Empty = the repo's default branch.
+  mr_base: string = ""
+  ## Optional back-link target: the source issue this run answers, as
+  ## "native:<id>" (local board) or a forge issue URL. When set,
+  ## finalize_mr posts the opened PR's URL back as a comment on it.
+  source_issue_ref: string = ""
+
+secrets:
+  ## Forge access for push + PR creation + the issue back-link. Mounted
+  ## as a read-only file the gh/glab CLI authenticates from; never read
+  ## into a prompt. optional:true so manual/local runs that rely on
+  ## host-authenticated gh/glab still work (finalize_mr falls back to
+  ## host auth when the file is absent). See skills/forge-mr-create.md.
+  forge_token:
+    as: file
+    optional: true
+
+## ─── Prompts ────────────────────────────────────────────────────
+
+prompt campaign_system:
+  You are a senior engineer INSTRUMENTING one repository for
+  observability, end to end — working EXACTLY as you would in a
+  productive, human-driven engineering session. You have the repo in
+  front of you and full tools (read, edit, shell, git). No one
+  micro-manages you; you own this pass end to end.
+
+  THE MISSION: wire the observability families listed in `scope` (in
+  your user prompt) into THIS repo, the way a maintainer of this repo
+  would have — reusing its conventions, extending its existing seams,
+  landing tests. The method lives in your skills; read them FIRST:
+
+  - `instrumentation` — the playbook: how to survey the repo, what
+    "done" means per family, the extend-don't-replace rule, the
+    verification discipline. Always read this one.
+  - `lang-<stack>` — the per-stack reference (SDK choice, log lib
+    choice, wiring seams) for each stack you detect in the repo. Read
+    the one(s) that match; if no lang skill matches the repo's stack,
+    derive the equivalents from the playbook's principles and say so
+    in your summary.
+  - `tracing` — ONLY when `scope` includes tracing (it is opt-in).
+
+  WHAT EACH FAMILY MEANS (the definition of done is in the
+  `instrumentation` skill; this is the shape):
+
+  - errors — error tracking through an SDK speaking the SENTRY DSN
+    PROTOCOL (works against Sentry and GlitchTip alike). Enabled ONLY
+    when the DSN env var (named in your user prompt) is set at runtime;
+    with it unset the application's behaviour is STRICTLY unchanged. An
+    init failure is reported loudly (an error log) but never crashes
+    the app. Tag release + environment. Capture at the process seams:
+    panics/uncaught exceptions at every real entry point, recovery
+    points of long-running workers, fatal exits. Flush pending events
+    on shutdown. Scrub secrets/PII before send.
+
+  - logs — ONE central logging seam for the whole codebase. If the repo
+    ALREADY has a central logger, EXTEND it — never replace it, never
+    add a parallel abstraction. Leveled + structured fields; JSON
+    output is the DEFAULT on production surfaces (servers, daemons,
+    workers), human-readable stays the default on interactive CLI/TTY
+    surfaces; both env-overridable. Sweep stray prints on production
+    code paths into the seam. When the errors family is also in scope,
+    couple the two: an error-level log becomes a tracker EVENT
+    (structured fields as context), warn-level becomes a BREADCRUMB.
+
+  - tracing (opt-in) — Sentry-first transactions/spans per the
+    `tracing` skill, with a conservative env-tunable sample rate.
+    Never wire it when scope does not ask for it.
+
+  HOW TO WORK — reproduce the shape of a productive session, agent-side:
+
+  1. LIVING TODO LIST, not frozen phases. Start with a BRIEF survey:
+     the real production entry points (servers, daemons, workers, CLI),
+     the existing logging (a central lib? strays?), the repo's env/config
+     conventions, the test layout. For BROAD exploration fan out
+     read-only sub-agents (the Task/agent tool) in parallel and keep
+     your own context for the design. Then build a todo of the concrete
+     SLICES the instrumentation needs (a slice = a coherent, buildable,
+     testable increment: the error-tracking wrapper + its unit tests,
+     one entry point wired + its test, the JSON-default flip on one
+     surface, the stray-log sweep of one package). Keep the list DENSE
+     and MOVING — re-prioritize, append, and defer as you learn.
+
+  2. THE REPEATED UNIT, one slice at a time: locate where the slice
+     attaches (reuse the repo's existing patterns and conventions — no
+     parallel abstractions when an existing seam fits) → implement the
+     SMALLEST coherent version, tests included where the behaviour
+     warrants them (the tracker coupling and the JSON format DESERVE
+     unit tests — use the SDK's in-memory/mock transport, NEVER a real
+     network call in tests) → build → run the affected tests → COMMIT
+     it with a semantic message (`feat(scope): <precise slice>`, or the
+     `type(scope):` that fits). A few edits per commit, validation
+     BEFORE the commit — never commit code you have not built and
+     tested green.
+
+  3. COMMIT EACH SLICE AS YOU FINISH IT — never batch. Stage everything
+     including new files (`git add -A`, so a slice that ADDS files —
+     the common case here — actually lands) and commit before moving
+     on. git IS your durable state: an interrupted run keeps every
+     slice you committed, and a fresh pass just reads `git log` and
+     continues where you left off.
+
+  4. BASELINE — don't chase failures you didn't cause. Pre-existing test
+     failures / known-flaky tests are in your user prompt (`baseline`).
+     Do NOT try to fix or investigate those; if a test was already red
+     before your change, SKIP it and note it. If the baseline is empty,
+     do ONE cheap `git stash`-based check to establish which failures
+     pre-date your work, then stop investigating them.
+
+  5. TEACH-BACK ON AMBIGUITY; BLOCK ONLY ON A REAL HARD STOP. If the
+     mission notes admit more than one materially different reading, or
+     your plan rests on a load-bearing assumption they do not settle,
+     post a teach-back ONCE (first pass only): call `ask_user_async`
+     with the goal RESTATED IN YOUR OWN WORDS, the assumptions you are
+     proceeding on, and what you would build differently under the
+     other reading — then KEEP WORKING under those stated assumptions.
+     Reserve the BLOCKING `ask_user` for a genuine hard stop — a
+     destructive/irreversible choice, a public contract that would have
+     to break. Keep both RARE: a clear mission gets zero questions.
+
+  ADR DOCUMENTATION — part of shipping, not an afterthought:
+  1. When you make a non-trivial technical decision while implementing —
+     choosing one SDK or log library over alternatives, adopting a new
+     pattern, accepting a deliberate trade-off, or diverging from an
+     existing convention — you MUST add or update an ADR markdown file
+     under the repo's ADR directory (usually `docs/adr/`), committed
+     with the slice that embodies it. Follow the format of existing
+     ADRs in the repo. The SDK/library choice for a repo that had none
+     is almost always ADR-worthy; capture the alternative you rejected.
+  2. Also update the repo's operator-facing docs where it documents
+     configuration: the DSN env var, the log format envs, and how to
+     wire a Sentry/GlitchTip project belong in the repo's runbook/docs
+     the way THIS repo documents such things.
+
+  FINDINGS HANDOFF — after your last commit, capture anything you
+  noticed that is OUT OF SCOPE for this instrumentation but worth
+  tracking (a pre-existing bug, a doc drift, a refactor opportunity):
+  call `mcp__iterion_board__list_issues` with `{ "state": "inbox" }`
+  first to avoid duplicates, then `mcp__iterion_board__create_issue`
+  per NEW finding with state "inbox" and labels ["findings",
+  "kind:<bug|drift|improvement|question>", "source:instrument",
+  "area:<subsystem>", "severity:<low|medium|high>"]. Be conservative —
+  zero findings is a fine outcome. If the board tools are unavailable
+  in this environment, list the findings in `summary` instead.
+
+  KEEP GOING, one slice at a time, until every family in scope is fully
+  wired within your budget. Then STOP and report.
+
+  TERMINATION CONTRACT (required structured output — this is how the
+  engine detects completion; an under-specified end just gets re-poked):
+    - instrumentation_complete: true ONLY when a fresh re-read of the
+      scope + the `instrumentation` skill's definition of done against
+      the tree finds EVERY requested family fully wired, tested and
+      documented — no TODOs, no placeholders, no half-wired seams.
+      false if work remains (a later pass continues from your commits).
+    - commits_this_pass: how many commits you landed this pass.
+    - work_remaining: a concise note of what still needs doing (empty
+      when instrumentation_complete).
+    - needs_human / human_note: set if you paused or need an operator
+      decision.
+    - summary: what you shipped, slice by slice, CITING the concrete
+      seams you instrumented (file:line), the env vars introduced, and
+      any ADRs you authored.
+
+  Be honest. A DETERMINISTIC build/test gate re-checks the tree after
+  you and the run loops you back for another pass until you report
+  instrumentation_complete AND the tree is green — so under-reporting
+  only costs a pass, and over-reporting lands you right back here.
+
+prompt campaign_user:
+  Repository: {{vars.workspace_dir}}
+
+  FAMILIES to instrument (open comma list — see the `instrumentation`
+  skill for each family's definition of done):
+  {{vars.scope}}
+
+  DSN env var the error-tracking code must read at runtime (unset =
+  tracking OFF, zero behaviour change):
+  {{vars.dsn_env_var}}
+
+  OPERATOR MISSION NOTES — repo-specific arbitrations and constraints
+  for this run (empty = survey and decide per the skills):
+  {{vars.mission_notes}}
+
+  BASELINE — pre-existing failures / known-flaky tests to SKIP (empty =
+  establish it once cheaply, then skip what predates your work):
+  {{vars.baseline}}
+
+  Deterministic gate feedback from the PREVIOUS pass (empty on the first
+  pass; when present, the build/test tree was RED after your last pass —
+  FIX exactly what this shows before continuing the instrumentation):
+  {{input.fail_log}}
+
+  Instrument the repo one slice at a time — locate → smallest coherent
+  slice with its tests → build → test → commit — until a fresh re-read
+  of the scope against the tree finds nothing left to do. Read `git log`
+  first to see what earlier passes already landed. Then report the
+  termination contract (instrumentation_complete, commits_this_pass,
+  work_remaining).
+
+## ─── verify (deterministic build/test gate, stack-agnostic) ─────────
+## An ADAPTIVE agent (verify_build) reads the verify-build skill and writes
+## the repo's real build+test into <scratch_dir>/verify.sh; a DETERMINISTIC
+## tool node (verify_run) re-runs it and gates on the REAL exit code. No
+## language / package manager is named here — the gate stays universal while
+## the verdict stays deterministic. verify_build does NOT fix code: a RED gate
+## routes back to `campaign` (the one capable agent) to fix what it broke.
+
+prompt verify_system:
+  You are a release engineer. An instrumentation pass just applied changes to
+  this repository and committed them. Your single job: capture how THIS repo
+  builds and tests itself into a re-runnable script the deterministic gate
+  will execute. You do NOT change code.
+
+  STEPS:
+  1. Detect how THIS repo builds and tests itself — read the `verify-build`
+     skill. Use the repo's OWN toolchain (a task runner / Makefile target, a
+     package-manager test script, or a language build+test command),
+     HONOURING any pinned toolchain (version managers, lockfiles, devbox,
+     GOTOOLCHAIN). Do NOT assume a language.
+  2. Write an executable POSIX-sh script to `{{vars.scratch_dir}}/verify.sh`
+     (an OUT-OF-TREE scratch path, NOT inside the repo — create it first with
+     `mkdir -p {{vars.scratch_dir}}`) that runs the repo's build AND its tests
+     (or the closest fast equivalent) and exits non-zero on any failure. Keep
+     it to the commands a developer of THIS repo would run; no network-heavy
+     or destructive steps.
+  3. PRE-EXISTING failures: some repos are already red on the base tree,
+     before this run touched anything. Scope `verify.sh` to the build plus the
+     test targets the campaign's changes actually affect (package/module
+     level), so the gate measures THIS run's work and a red base can't absorb
+     it — and list any excluded pre-existing failures in your summary.
+  4. Run it ONCE to confirm the script itself is valid (the commands resolve).
+     You do NOT fix code here: if the build is RED because the campaign broke
+     something, the deterministic gate reports it and the campaign fixes it on
+     the next pass. Just make `verify.sh` faithfully run the repo's real
+     build+test.
+  5. If the repo genuinely has no build/test system (pure docs/config), write
+     a script that echoes that and exits 0, and say so.
+
+  A deterministic tool node RE-RUNS your script and gates the run on its real
+  exit code. Output prepared=true once `{{vars.scratch_dir}}/verify.sh` exists
+  and reflects the repo's real build+test; summary = the command you settled
+  on and any pre-existing failures you scoped out.
+
+prompt verify_user:
+  Repository to verify: {{vars.workspace_dir}}
+
+  Capture the repo's real build + test into `{{vars.scratch_dir}}/verify.sh`
+  (an out-of-tree scratch path — see the system prompt + the `verify-build`
+  skill). Do NOT change code; the deterministic gate runs your script and the
+  campaign fixes any red on the next pass.
+
+  MANDATORY (skill section 1b): if the repo's own CI enforces a
+  codegen-drift gate (git diff --exit-code after a regen/vendor step, a
+  drift-check task, test -z on git status --porcelain), verify.sh MUST
+  mirror it — run the repo's regen command(s), then fail on drift. The
+  deterministic precheck rejects a gateless verify.sh in that case
+  (exit 3) and the loop burns a full pass re-learning this.
+
+## ─── Adversarial in-loop review prompts ─────────────────────────────
+
+prompt review_system:
+  You are an adversarial code reviewer running as a stage INSIDE the
+  build loop, BEFORE the work becomes a pull request. Your job is to catch
+  the defects that compile and pass tests but still ship a real bug — so
+  the human reviewer downstream finds nothing. You make NO code changes;
+  you report findings the campaign fixes on its next pass.
+
+  Read the `code-review-invariants` skill FIRST. It is the checklist: the
+  six recurring classes of cross-cutting defect (sibling-consistency,
+  lifecycle parity for new persistent state, isolation/scoping parity,
+  authority gates on background mutators, provable claims, loud failure).
+
+  Procedure:
+    1. If `build_passed` is false, the tree is mid-implementation — return
+       `clean: true` with empty findings immediately (the build failure is
+       handled by the deterministic gate; do not review a broken tree).
+    2. Determine the base: `git merge-base HEAD <base_ref or the repo
+       default branch>`. Review the run's own work: `git diff <base>..HEAD`
+       and `git diff --stat <base>..HEAD` for the whole footprint.
+    3. For each new/changed unit, walk the invariant checklist. For a
+       suspected violation, VERIFY it against the code (open the sibling,
+       confirm the boundary is really absent) before reporting — a false
+       finding wastes a whole pass.
+    4. `prior_findings` carries what you flagged on the previous pass. Do
+       NOT re-raise a prior finding unless the current diff still shows it
+       unaddressed. If the campaign fixed it, it is resolved.
+
+  Blocking bar — be disciplined, this loop must converge:
+    - Block (`clean: false`) ONLY on a HIGH-CONFIDENCE defect in the six
+      invariant classes: a real correctness, security/isolation, lifecycle,
+      authority, false-claim, or silent-failure bug you have verified in
+      the code.
+    - Do NOT block on style, naming, preference, test coverage, or
+      "could be nicer". A diff that introduces no new persistent state, no
+      new access path, no background mutator, no over-claim, and stays
+      consistent with its siblings is CLEAN — say so. Do not invent work
+      to look thorough. Under-flagging a nit is free; a false block costs a
+      whole campaign pass.
+
+  Output: `clean` (true when nothing blocking), and `findings` — when not
+  clean, a specific, actionable list (file:line, which invariant, why it is
+  a real bug, what the fix is), so the campaign fixes it directly. Empty
+  when clean.
+
+prompt review_user:
+  Review the working tree at {{vars.workspace_dir}}.
+  Base hint: {{input.base_ref}}   ·   build passed: {{input.build_passed}}
+
+  Findings you raised last pass (do not re-raise unless still unaddressed):
+  {{input.prior_findings}}
+
+  Adversarially review this run's diff against the `code-review-invariants`
+  checklist. Return clean=true if nothing high-confidence is wrong; else
+  return specific, actionable findings for the campaign to fix.
+
+## ─── PR finalization prompts (opt-in) ──────────────────────────────
+
+prompt finalize_mr_system:
+  You finalize a converged instrumentation run by opening ONE pull request
+  (PR; merge request on GitLab) for the SERIES of per-slice commits this run
+  produced, then (optionally) posting the PR link back to the source
+  issue. You make NO
+  further code changes.
+
+  Read the `forge-mr-create` skill FIRST — it tells you how to detect the
+  forge, authenticate from the mounted forge_token, push the branch, and
+  open the PR (GitHub via gh, GitLab via glab, Forgejo/Gitea via REST).
+
+  Procedure:
+    1. Confirm there are commits to ship: the run's HEAD must be ahead of
+       the base (`git rev-list --count origin/<base>..HEAD` > 0). If not, set
+       opened=false with skipped_reason "no commits ahead of base" — do
+       NOT open an empty PR.
+    2. Determine the branch name (mr_branch if set, else a stable
+       iterion/improve/<run-id> name) and the base (mr_base if set, else
+       the repo's default branch — see the skill).
+    3. Authenticate the matching forge CLI from the mounted forge_token
+       file when present; otherwise assume host auth. If neither is
+       available, set opened=false with a precise skipped_reason — never
+       pretend.
+    4. Push HEAD to the branch on the origin remote, then open the PR
+       from that branch into the base, with a clear title + body
+       summarising the instrumentation and the slices landed (use
+       scope_notes for context).
+    5. If source_issue_ref is set, post the opened PR URL back to it: a
+       forge issue URL → comment via the same forge CLI; a "native:<id>"
+       ref → use the board comment tool. Set back_linked accordingly.
+
+  Return opened, url, branch, back_linked, skipped_reason and a short
+  summary. Be honest: report exactly what happened.
+
+prompt finalize_mr_user:
+  Workspace: {{input.workspace_dir}}
+  Desired branch (may be empty → derive): {{input.mr_branch}}
+  Base (may be empty → repo default branch): {{input.mr_base}}
+  Source issue to back-link (may be empty): {{input.source_issue_ref}}
+  Context / scope: {{input.scope_notes}}
+
+  Push the branch, open the PR, post the back-link when a source issue
+  is given, and return the structured result.
+
+## ─── Schemas ────────────────────────────────────────────────────
+
+## campaign's input: the deterministic gate's failure log from the PREVIOUS
+## pass (empty on the first pass and on a green-but-more-work continuation).
+schema campaign_input:
+  fail_log: string
+
+## campaign's TERMINATION CONTRACT (G2): a machine-checkable output the engine
+## keys convergence on. instrumentation_complete is the done-oracle (a fresh
+## re-read of the scope against the tree finds every family fully wired); the
+## rest is observability.
+schema campaign_output:
+  instrumentation_complete: bool
+  commits_this_pass: int
+  work_remaining: string
+  needs_human: bool
+  human_note: string
+  summary: string
+
+## verify_plan is verify_build's contract: it has WRITTEN <scratch_dir>/verify.sh.
+schema verify_plan:
+  prepared: bool
+  summary: string
+
+## verify_result is the DETERMINISTIC gate's contract. `passed` is set from
+## the real process exit code of re-running <scratch_dir>/verify.sh — NOT an
+## LLM judgment. `skipped` is true only when no verify script was produced
+## (treated as pass but surfaced loudly, never a silent façade).
+schema verify_result:
+  passed: bool
+  skipped: bool
+  exit_code: int
+  log_tail: string
+
+## verify_probe output — deterministic "is a usable verify.sh already prepared?"
+## so verify_build (an LLM agent, ~$0.69/13k tok EVERY pass) is only paid when
+## the script is missing/invalid or on the first pass. fresh=true reuses it.
+## verify_probe input — the continuation-loop iteration, mapped on the
+## campaign→verify_probe edge. Loop refs ({{loop.*}}) do NOT resolve inside a
+## tool command (only input/vars/run do), so the iteration is passed in as node
+## input via the edge data-mapping. Pass 1 = iteration 0 (always regenerate).
+schema verify_probe_input:
+  iteration: int
+
+schema verify_probe_state:
+  fresh: bool
+  reason: string
+
+## gate is the deterministic continuation decision. converged = the tree is
+## green AND the campaign reported the instrumentation fully shipped AND the
+## adversarial review is clean. fail_log relays the real build failure OR the
+## review findings to the campaign (empty when green + clean).
+schema gate_state:
+  converged: bool
+  fail_log: string
+
+## review is the in-loop adversarial self-review (ADR: push the downstream
+## review INTO the loop so the PR ships pre-refined). clean=true when the
+## diff has no high-confidence invariant violation; findings carries the
+## specific, actionable defects the campaign must fix next pass.
+schema review_input:
+  base_ref: string
+  build_passed: bool
+  prior_findings: string
+
+schema review_output:
+  clean: bool
+  findings: string
+
+schema mr_gate_output:
+  open_mr: bool
+
+## forge_auth_probe output — deterministic "can we push?" so finalize_mr (an
+## LLM agent) is only ever entered when a push credential actually exists.
+schema forge_auth_state:
+  available: bool
+  reason: string
+
+schema finalize_mr_input:
+  workspace_dir: string
+  mr_branch: string
+  mr_base: string
+  source_issue_ref: string
+  scope_notes: string
+
+schema finalize_mr_output:
+  opened: bool
+  url: string
+  branch: string
+  back_linked: bool
+  skipped_reason: string
+  summary: string
+
+## ─── Nodes ──────────────────────────────────────────────────────
+
+## campaign — the one adaptive agent. claude_code with the full native
+## toolset (read/edit/shell/git) so it works exactly like a native Claude
+## Code session: brief survey, a living todo of slices, one verified
+## commit per slice, in stride. session: fresh — a fresh pass re-derives
+## its todo from the scope + `git log` (git is the durable state).
+## interaction: async — an ambiguous mission gets a non-blocking
+## teach-back (ask_user_async: restate + assumptions, keep working) while
+## the blocking ask_user stays for genuine hard stops (kept rare by the
+## contract). Board capabilities power the end-of-pass findings handoff.
+agent campaign:
+  description: "Campaign: instrument & commit slices"
+  backend: "claude_code"
+  model: "${ITERION_VIBE_MODEL_CLAUDE:-claude-opus-5}"
+  reasoning_effort: "${ITERION_VIBE_EFFORT_CLAUDE:-high}"
+  input: campaign_input
+  output: campaign_output
+  system: campaign_system
+  user: campaign_user
+  session: fresh
+  interaction: async
+  capabilities: [board.read, board.create]
+
+## verify_probe — DETERMINISTIC pre-check: is a usable verify.sh already in the
+## scratch dir from an earlier pass of THIS run? verify_build is an LLM agent
+## (~$0.69/13k tok EVERY pass); once pass 1 has authored verify.sh, re-authoring
+## it every pass is pure waste. This tool answers "reuse it?" in ~50ms of
+## subprocess: fresh=true when verify.sh exists, is non-empty, and passes
+## `sh -n` — AND this is not the first pass (iteration>0), so pass 1 of every run
+## always (re)generates verify.sh for the CURRENT tree, defeating a stale script
+## a prior run may have left in a persistent (non-sandbox) scratch dir. python3
+## for safe JSON + no quote clashes (mirrors verify_run); read-only, idempotent.
+tool verify_probe:
+  command: `SCRATCH={{vars.scratch_dir}} ITER={{input.iteration}} python3 -c "
+import os, subprocess, json
+scratch = os.environ.get('SCRATCH', '.')
+script = os.path.join(scratch, 'verify.sh')
+try:
+    iteration = int(os.environ.get('ITER', '0') or '0')
+except ValueError:
+    iteration = 0
+fresh = False
+if iteration <= 0:
+    reason = 'first pass of this run: (re)generate verify.sh for the current tree'
+elif not os.path.isfile(script):
+    reason = 'no verify.sh in the scratch dir yet'
+elif os.path.getsize(script) == 0:
+    reason = 'verify.sh is empty'
+else:
+    chk = subprocess.run(['sh', '-n', script], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    if chk.returncode != 0:
+        reason = 'verify.sh failed the sh -n syntax check: ' + (chk.stdout or '')[-300:]
+    else:
+        fresh = True
+        reason = 'verify.sh present and valid; reuse it (skip verify_build)'
+print(json.dumps({'fresh': fresh, 'reason': reason}))
+"`
+  input: verify_probe_input
+  output: verify_probe_state
+
+## verify_build — adaptive, stack-agnostic gate authoring (writes
+## <scratch_dir>/verify.sh). fresh: whole-tree buildability, not a
+## per-slice session. medium: mechanical capture of the repo's
+## build/test.
+agent verify_build:
+  backend: "claude_code"
+  model: "${ITERION_VIBE_MODEL_CLAUDE:-claude-opus-5}"
+  reasoning_effort: "${ITERION_VIBE_EFFORT_VERIFY_BUILD:-medium}"
+  output: verify_plan
+  system: verify_system
+  user: verify_user
+  session: fresh
+  interaction: human
+
+## verify_run — the DETERMINISTIC half: re-runs the agent-prepared
+## <scratch_dir>/verify.sh and reports the REAL exit code. No language /
+## package manager appears here — it executes whatever verify_build wrote, so
+## the gate stays universal while the verdict stays deterministic. python3 for
+## safe JSON + subprocess capture; double-quote-free body, no backticks (E012).
+tool verify_run:
+  description: "Verify gate: run build+tests (real exit code)"
+  command: `WS={{vars.workspace_dir}} SCRATCH={{vars.scratch_dir}} python3 -c "
+import os, subprocess, json
+ws = os.environ.get('WS', '.')
+scratch = os.environ.get('SCRATCH', '.')
+try:
+    os.makedirs(scratch, exist_ok=True)
+except OSError:
+    pass
+script = os.path.join(scratch, 'verify.sh')
+if not os.path.exists(script):
+    print(json.dumps({'passed': True, 'skipped': True, 'exit_code': 0, 'log_tail': 'verify_build produced no verify.sh in the scratch dir; build/test gate SKIPPED (counted as pass, but surfaced) -- verify_build should write the script'}))
+    raise SystemExit(0)
+def tree_state():
+    try:
+        p = subprocess.run(['git', '-C', ws, 'status', '--porcelain'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=60)
+        if p.returncode != 0:
+            return None
+        return set(l for l in p.stdout.splitlines() if l.strip())
+    except Exception:
+        return None
+pre = tree_state()
+rc = 0
+out = ''
+try:
+    p = subprocess.run(['sh', script], cwd=ws, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=1500)
+    out = p.stdout or ''
+    rc = p.returncode
+except subprocess.TimeoutExpired as e:
+    out = (e.output or '') + chr(10) + '[verify timed out after 1500s]'
+    rc = 124
+except Exception as e:
+    out = 'verify_run could not execute the script: ' + str(e)
+    rc = 1
+# Deterministic codegen-drift tail (stack-agnostic; the gate stays
+# deterministic per ADR-044). Only on a GREEN verify: (1) if the repo's own
+# CI enforces a drift gate, verify.sh must mirror it; (2) a green verify
+# must not leave new changes in the tree (regen output belongs in a commit).
+if rc == 0:
+    import glob
+    def has_drift_gate(text):
+        for l in text.splitlines():
+            # git diff --exit-code is the canonical build-failing gate.
+            if 'diff' in l and '--exit-code' in l:
+                return True
+            # --quiet / status --porcelain also appear as commit-if-changed
+            # control flow in updater workflows (e.g. a Homebrew tap bump) --
+            # only count them when the same line actually fails the build.
+            gated = ('exit 1' in l) or ('|| exit' in l) or ('test -z' in l) or ('[ -z' in l)
+            if gated and (('diff' in l and '--quiet' in l) or 'status --porcelain' in l):
+                return True
+        return False
+    ci_hit = ''
+    for pat in ('.github/workflows/*.yml', '.github/workflows/*.yaml', '.gitlab-ci.yml', '.circleci/config.yml'):
+        for f in sorted(glob.glob(os.path.join(ws, pat))):
+            try:
+                if has_drift_gate(open(f, encoding='utf-8', errors='replace').read()):
+                    ci_hit = os.path.relpath(f, ws)
+                    break
+            except OSError:
+                pass
+        if ci_hit:
+            break
+    if ci_hit:
+        try:
+            vs = open(script, encoding='utf-8', errors='replace').read()
+        except OSError:
+            vs = ''
+        if not has_drift_gate(vs):
+            rc = 3
+            out = out + chr(10) + 'DRIFT GATE MISSING: CI (' + ci_hit + ') enforces a codegen-drift gate but ' + script + ' has none -- edit the script per the verify-build skill section 1b (run the repo regen command, then: git diff --exit-code).'
+    if rc == 0 and pre is not None:
+        post = tree_state()
+        if post is not None:
+            fresh = sorted(post - pre)
+            if fresh:
+                rc = 4
+                out = out + chr(10) + 'UNCOMMITTED REGEN OUTPUT: a green verify left new changes in the tree; commit (or gitignore) them:' + chr(10) + chr(10).join(fresh[:50])
+try:
+    with open(os.path.join(scratch, 'verify.log'), 'w', encoding='utf-8') as lf:
+        lf.write(out)
+except OSError:
+    pass
+print(json.dumps({'passed': rc == 0, 'skipped': False, 'exit_code': rc, 'log_tail': out[-4000:]}))
+"`
+  output: verify_result
+
+## review — adversarial in-loop self-review (readonly). Runs after the
+## deterministic build gate; reads the code-review-invariants skill and the
+## run's own diff, and blocks convergence ONLY on a high-confidence defect
+## in the six invariant classes. This is the refinement the downstream
+## reviewer would otherwise do — moved INTO the loop so the PR ships clean.
+## claude_code (full read/git toolset), readonly so it cannot mutate;
+## session: fresh. Convergent by design: light no-op on a red build, strict
+## no-re-raise, blocks only verified real bugs (see review_system).
+agent review:
+  backend: "claude_code"
+  model: "${ITERION_VIBE_MODEL_REVIEW:-claude-opus-5}"
+  reasoning_effort: "${ITERION_VIBE_EFFORT_REVIEW:-high}"
+  input: review_input
+  output: review_output
+  system: review_system
+  user: review_user
+  session: fresh
+  readonly: true
+
+## gate — the deterministic continuation decision. Reads the build result
+## (outputs.verify_run.passed), the campaign's termination output
+## (outputs.campaign.instrumentation_complete), AND the adversarial review
+## verdict (outputs.review.clean), all fresh in the loop BODY (the same
+## discipline whole_improve_loop's gate uses to read the loop-head safely).
+## converged = green AND fully wired AND review-clean. fail_log carries the
+## real build failure (RED build) or the review findings (green but dirty) to
+## the campaign; empty when green + clean. No LLM, no shell.
+compute gate:
+  description: "Convergence check: instrumentation complete & gates green"
+  output: gate_state
+  expr:
+    converged: "outputs.verify_run.passed && outputs.campaign.instrumentation_complete && outputs.review.clean"
+    fail_log: "if(outputs.verify_run.passed, if(outputs.review.clean, '', outputs.review.findings), outputs.verify_run.log_tail)"
+
+## mr_gate lifts vars.open_mr into a bool output field so the two outgoing
+## edges use the C012-exhaustive simple form. No LLM, no shell.
+compute mr_gate:
+  output: mr_gate_output
+  expr:
+    open_mr: "vars.open_mr"
+
+## finalize_mr — opt-in PR creation shipping the SERIES of per-slice
+## commits. claude_code so the bundled forge-mr-create skill is mirrored and
+## the board comment tool (native back-link) is available.
+## forge_auth_probe — DETERMINISTIC pre-flight for the push. finalize_mr is an
+## LLM agent (claude_code, opus); entering it with NO push credential mounted
+## burns a whole turn just to REDISCOVER, in shell, that it can't push (~$0.26
+## observed on branch-improve-loop run 019f415c — this node is byte-shared).
+## This tool answers "is there a push credential?" in ~100ms of subprocess so
+## the graph only pays finalize_mr when a push can actually happen. python3 for
+## safe JSON + no quote clashes (mirrors verify_run); read-only, idempotent.
+tool forge_auth_probe:
+  command: `python3 -c "
+import os, subprocess, json
+tok = '/run/iterion/secrets/forge_token'
+try:
+    if os.path.isfile(tok) and os.path.getsize(tok) > 0:
+        print(json.dumps({'available': True, 'reason': 'file:' + tok})); raise SystemExit(0)
+except OSError:
+    pass
+for v in ('GH_TOKEN', 'GITHUB_TOKEN', 'GITLAB_TOKEN', 'FORGEJO_TOKEN', 'GITEA_TOKEN'):
+    if os.environ.get(v):
+        print(json.dumps({'available': True, 'reason': 'env:' + v})); raise SystemExit(0)
+try:
+    r = subprocess.run(['gh', 'auth', 'status'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10)
+    if r.returncode == 0:
+        print(json.dumps({'available': True, 'reason': 'gh host auth'})); raise SystemExit(0)
+except Exception:
+    pass
+print(json.dumps({'available': False, 'reason': 'no forge_token secret, no *_TOKEN env, no gh host auth'}))
+"`
+  output: forge_auth_state
+
+agent finalize_mr:
+  backend: "claude_code"
+  model: "${ITERION_INSTRUMENT_MR_MODEL:-claude-opus-5}"
+  reasoning_effort: "${ITERION_INSTRUMENT_MR_EFFORT:-medium}"
+  input: finalize_mr_input
+  output: finalize_mr_output
+  system: finalize_mr_system
+  user: finalize_mr_user
+  tools: [bash, read_file, glob, grep]
+  capabilities: [board.read, board.comment]
+  ## 20 is ample for push + open-PR + back-link (~5-8 commands nominal);
+  ## forge_auth_probe guarantees the node is only entered when a push
+  ## credential exists.
+  tool_max_steps: 20
+
+## surface_pr_link — DETERMINISTIC result-link emitter for the studio run
+## summary. finalize_mr is an LLM agent, but the studio surfaces a run's
+## headline PR link from the deterministic `[iterion] preview_url=… kind=pr`
+## directive a tool node prints on stdout — never from agent prose. Reached
+## only when finalize_mr actually opened a PR (opened=true ⇒ url set); the
+## python guard drops an empty url so the scanner never sees a malformed
+## directive. read-only, idempotent.
+schema surface_pr_link_input:
+  url: string
+
+tool surface_pr_link:
+  input: surface_pr_link_input
+  command: `URL={{input.url}} python3 -c "
+import os
+u = (os.environ.get('URL') or '').strip()
+if u:
+    print('[iterion] preview_url=' + u + ' kind=pr scope=external')
+"`
+
+## ─── Workflow ───────────────────────────────────────────────────
+
+workflow instrument:
+  ## Entry is the campaign itself — the mission starts working IMMEDIATELY
+  ## (the survey is the campaign's own first move, not a blocking upstream
+  ## plan node). A re-dispatch's campaign reads `git log` and continues
+  ## from the slices earlier passes banked.
+  entry: campaign
+
+  ## Run in an isolated git worktree at .iterion/worktrees/<run-id>/. The bot
+  ## mutates code AND commits; the worktree + finalize FF guarantees: (a) the
+  ## operator's main checkout is untouched during the run, (b) on convergence
+  ## the commits land on a persistent branch `iterion/run/<friendly-name>` AND
+  ## fast-forward the operator's currently-checked-out branch (best-effort,
+  ## skipped with a warning on conflict).
+  worktree: auto
+
+  ## No `sandbox:` block (ADR-082): isolation is the platform's job —
+  ## the engine sandboxes by default (`sandbox: auto` reads the target
+  ## repo's devcontainer, else the default image). The bot declares only
+  ## its own toolchain in the sibling devbox.json (gh/glab for the PR
+  ## tail); the target repo's toolchain comes from the target's own
+  ## devcontainer/devbox.json.
+
+  budget:
+    max_parallel_branches: 1
+    max_duration: "3h"
+    max_cost_usd: 100
+
+  compaction:
+    threshold: 0.9
+    preserve_recent: 8
+
+  ## Each pass: the campaign ships instrumentation slices (committing each
+  ## in stride), then the deterministic build/test gate re-checks the tree.
+  campaign -> verify_probe with {
+    iteration: "{{loop.continuation_loop.iteration}}"
+  }
+  ## verify_probe reuses an already-valid verify.sh (skipping the LLM
+  ## verify_build) on passes 2+; the first pass of every run regenerates it for
+  ## the current tree. Both outgoing edges test the bool `fresh` (C012-exhaustive).
+  verify_probe -> verify_run when fresh
+  verify_probe -> verify_build when not fresh
+  verify_build -> verify_run
+  ## After the deterministic build gate, the adversarial review inspects the
+  ## run's diff (the refinement pass moved in-loop), then the gate decides.
+  verify_run -> review with {
+    base_ref:       "{{vars.mr_base}}",
+    build_passed:   "{{outputs.verify_run.passed}}",
+    prior_findings: "{{outputs.gate.fail_log}}"
+  }
+  review -> gate
+
+  ## Converged (green AND the campaign reports every family fully wired) →
+  ## ship what is banked (optional PR, else finish).
+  gate -> mr_gate when converged
+  ## Not converged → another campaign pass. RED carries the failure log so the
+  ## agent fixes what it broke; green-but-more-work carries an empty log so the
+  ## agent simply continues the instrumentation. This closes the single declared
+  ## loop (campaign→verify_build→verify_run→gate→campaign); the loop-back reads
+  ## outputs.gate.fail_log (a BODY node — never the loop-head campaign's own
+  ## output on its back-edge, which would read a loop-entry-frozen value).
+  gate -> campaign as continuation_loop("{{vars.max_passes}}") with {
+    fail_log: "{{outputs.gate.fail_log}}"
+  }
+  ## continuation_loop exhausted (max_passes hit while work remains) → ship
+  ## what is banked anyway (every committed slice is real, landed work).
+  ## Unconditional fallthrough after the loop-back retries are spent.
+  gate -> mr_gate
+
+  ## Converged (or capped) → optional PR path, else finish. finalize_mr pushes
+  ## the run's HEAD (the series of per-slice commits) + opens the PR and
+  ## (when source_issue_ref is set) posts the URL back. The mission notes
+  ## ride along as the PR's scope context.
+  mr_gate -> forge_auth_probe when open_mr
+  mr_gate -> done when not open_mr
+
+  ## Push credential present → finalize_mr pushes + opens the PR; absent →
+  ## finish cleanly (commits are on the engine's iterion/run/<name> storage
+  ## branch for a manual push) instead of paying an agent turn to rediscover it.
+  forge_auth_probe -> finalize_mr when available with {
+    workspace_dir:    "{{vars.workspace_dir}}",
+    mr_branch:        "{{vars.mr_branch}}",
+    mr_base:          "{{vars.mr_base}}",
+    source_issue_ref: "{{vars.source_issue_ref}}",
+    scope_notes:      "{{vars.mission_notes}}"
+  }
+  forge_auth_probe -> done when not available
+  ## PR opened → surface its URL as a headline result-link in the run summary
+  ## (deterministic stdout directive → preview_url_available kind=pr), then
+  ## finish. Nothing opened (empty diff / refused PR) → straight to done.
+  finalize_mr -> surface_pr_link when opened with { url: "{{outputs.finalize_mr.url}}" }
+  finalize_mr -> done when not opened
+  surface_pr_link -> done

--- a/bots/instrument/main.bot
+++ b/bots/instrument/main.bot
@@ -301,12 +301,15 @@ prompt campaign_system:
   instrumentation_complete AND the tree is green — so under-reporting
   only costs a pass, and over-reporting lands you right back here.
 
-  The gate re-runs `{{vars.scratch_dir}}/verify.sh` (authored on the
-  first pass). If the failure log shows the SCRIPT itself is broken —
-  an environment flag it lacks, a stale package scope — fix the script
-  in place (it must still faithfully run this repo's real build+test);
-  do not burn passes re-reporting complete against a gate that cannot
-  go green.
+  The gate re-runs `{{vars.scratch_dir}}/verify.sh`, authored by a
+  SEPARATE release-engineer agent on the first pass. If the failure log
+  shows the SCRIPT itself is broken — an environment flag it lacks, a
+  stale package scope — DELETE it (`rm {{vars.scratch_dir}}/verify.sh`)
+  and say why in your summary: the release engineer re-authors it fresh
+  for the current tree on the same pass. You never write or edit
+  verify.sh yourself — a gate only stays a gate while the graded party
+  cannot hold the pen. Do not burn passes re-reporting complete against
+  a script nobody re-authors.
 
 prompt campaign_user:
   Repository: {{vars.workspace_dir}}

--- a/bots/instrument/main.bot
+++ b/bots/instrument/main.bot
@@ -228,7 +228,11 @@ prompt campaign_system:
      the common case here — actually lands) and commit before moving
      on. git IS your durable state: an interrupted run keeps every
      slice you committed, and a fresh pass just reads `git log` and
-     continues where you left off.
+     continues where you left off. END EVERY PASS ON A CLEAN TREE: if
+     you must stop mid-slice, either finish it to committable or
+     revert/stash the in-progress edits — the deterministic gate
+     verifies the WORKING TREE, and a half-slice (an un-vendored
+     `go get`, a dangling import) reds the gate as noise.
 
   4. BASELINE — don't chase failures you didn't cause. Pre-existing test
      failures / known-flaky tests are in your user prompt (`baseline`).
@@ -296,6 +300,13 @@ prompt campaign_system:
   you and the run loops you back for another pass until you report
   instrumentation_complete AND the tree is green — so under-reporting
   only costs a pass, and over-reporting lands you right back here.
+
+  The gate re-runs `{{vars.scratch_dir}}/verify.sh` (authored on the
+  first pass). If the failure log shows the SCRIPT itself is broken —
+  an environment flag it lacks, a stale package scope — fix the script
+  in place (it must still faithfully run this repo's real build+test);
+  do not burn passes re-reporting complete against a gate that cannot
+  go green.
 
 prompt campaign_user:
   Repository: {{vars.workspace_dir}}

--- a/bots/instrument/manifest.yaml
+++ b/bots/instrument/manifest.yaml
@@ -1,0 +1,75 @@
+name: instrument
+display_name: Obsy
+icon: 📡
+version: 0.1.0
+## 0.1.0 — initial release. ADR-058 minimal-framing shape (the proven
+## feature-dev/branch-improve-loop chassis): ONE adaptive `campaign`
+## agent + the deterministic build/test gate + the in-loop adversarial
+## review + a bounded continuation loop + the opt-in PR tail. Stack
+## knowledge lives in the bundle skills (instrumentation playbook,
+## lang-go/js/python, opt-in tracing); the DSL enumerates no language.
+description: |
+  Observability instrumentation campaign — one capable agent wires a
+  repo for error tracking and standardized logs, one verified semantic
+  commit at a time. `scope` is an open family list: *errors* (an SDK
+  speaking the Sentry DSN protocol — Sentry AND GlitchTip — enabled
+  only when the DSN env var is set, loud non-fatal init, release/
+  environment tags, capture at process seams, flush on shutdown,
+  scrubbing), *logs* (ONE central logging seam — extended, never
+  replaced — leveled + structured, JSON by default on production
+  surfaces, error→event / warn→breadcrumb coupling into the tracker),
+  and opt-in *tracing* (Sentry-first transactions/spans, env-tunable
+  sampling). A deterministic build/test gate + bounded continuation
+  loop re-poke the campaign until every requested family is fully
+  wired, tested and documented; an opt-in tail opens the pull request.
+when_to_use: |
+  Use to instrument a repository for observability: add Sentry/
+  GlitchTip-compatible error tracking, standardize logging onto one
+  structured lib with JSON output in production, or both (default
+  scope "errors,logs"; add "tracing" explicitly for performance
+  traces). Point repo-specific arbitrations (which module to extend,
+  which seams to wire) through `mission_notes`. Not the route for
+  general feature work (feature-dev) or for building dashboards —
+  this bot wires the emission side only.
+author: SocialGouv (devthejo) — instrument/main.bot
+schema_version: 1
+
+dispatch_vars:
+  mission_notes: |-
+    {{issue.title}}
+
+    {{issue.body}}
+  ## Board/comment-dispatched runs open a pull request at the end
+  ## and post the URL back onto the source issue. CLI runs keep the
+  ## defaults (open_mr=false) so a plain local run just commits.
+  open_mr: "true"
+  source_issue_ref: "{{issue.id}}"
+
+## Forge access for the PR push + creation + the issue back-link.
+## The auto-provisioner requests these scopes and binds the connection
+## token under `forge_token` (cross-ref main.bot `secrets: { forge_token }`).
+forge:
+  ## issue_labeled: labeling an issue (e.g. "instrument") launches Obsy
+  ## to wire the requested observability and open a PR back-linked to
+  ## the issue. pull_request_comment: the on-demand `/obsy <notes>`
+  ## slash command.
+  events: [issue_labeled, pull_request_comment]
+  token_scopes:
+    pull_requests: write     # open the PR
+    repository: write         # push the branch
+    issues: write             # post the PR URL back onto the source issue
+  secret: forge_token
+
+invocations:
+  - kind: command
+    mode: board
+    args_var: mission_notes
+    command: { name: obsy, aliases: [instrument], scope: any, min_replier_role: maintainer, opens_mr: true }
+  - kind: board
+
+## Studio launch-form hierarchy: `primary` inputs render top-level in
+## the declared order; `hidden` vars are dispatch/webhook plumbing kept
+## out of the form (still settable via --var / bot_args).
+launch:
+  primary: [mission_notes, scope, dsn_env_var]
+  hidden: [source_issue_ref]

--- a/bots/instrument/skills/code-review-invariants.md
+++ b/bots/instrument/skills/code-review-invariants.md
@@ -1,0 +1,135 @@
+---
+name: code-review-invariants
+description: The cross-cutting invariants an adversarial self-review must check on a code diff before it ships — the defect classes that compile, pass tests, and still ship a real bug. Stack- and repo-agnostic.
+---
+
+# Code-review invariants — the defects that pass CI and still ship a bug
+
+A green build + passing tests proves the code *runs*. It does NOT prove it
+is *correct, safe, or consistent*. The defects that survive CI and reach a
+human reviewer are almost always one of a small, recurring set of
+cross-cutting invariant violations. Before you declare work complete,
+adversarially review your own diff against this checklist — and **fix what
+you find in the same pass**. The goal: the independent reviewer downstream
+finds nothing.
+
+Review the **working-tree diff** (`git diff <base>`, and `git diff --stat`
+to see the whole footprint — including files you may have forgotten). For
+each new or changed function, ask the questions below.
+
+## 1. Sibling-consistency (the highest-yield check)
+
+For every new function, handler, method, or manifest you added, **find its
+nearest existing sibling** — the function that does the most similar job —
+and diff how each handles the cross-cutting concerns:
+
+- **Authorization / scoping**: does the sibling gate access (tenant, owner,
+  user, permission) *before* it reads/writes? If it does and yours doesn't,
+  that is a leak. (The classic: a new read endpoint that skips the
+  ownership check its sibling performs → cross-tenant/cross-user data
+  exposure.)
+- **Error handling**: does the sibling propagate/log errors where yours
+  swallows them?
+- **Cleanup / lifecycle**: does the sibling register teardown that yours
+  omits?
+
+If your function diverges from its sibling on any cross-cutting concern,
+either match the sibling or be able to state precisely why the difference
+is correct. Silent divergence is the #1 source of shipped defects.
+
+## 2. Lifecycle parity for new persistent state
+
+If you added a new persistent store — a table, collection, bucket/prefix,
+on-disk file, cache, index — you MUST also wire, in the same change:
+
+- **Deletion**: when the owning entity (run, user, record) is deleted, its
+  new state is deleted too. Find the existing "delete everything for X"
+  path and add your new state to it. A new collection absent from the
+  cleanup path leaks that data forever.
+- **Retention / TTL**: if the store isn't cleaned by an explicit delete, it
+  needs a bounded lifetime (TTL, lifecycle rule) — mirror what sibling
+  stores use. "Neither cleaned nor TTL'd" = an unbounded leak.
+- **Creation/schema**: index/schema setup wired into the same
+  initialization path as siblings.
+
+## 3. Isolation parity for new data access
+
+Every new read/write of shared data must enforce the **same isolation
+boundary** as its siblings — tenant, org, user, project. A store keyed only
+on an entity id (no tenant prefix) forces the boundary to live at the
+caller: load the entity under the caller's scope first, and 404 if it
+isn't theirs. Check that your new path does this exactly as the established
+one does. A "tenant-aware" comment is not a tenant check — verify the code.
+
+## 4. Authority gates on background mutators
+
+Any code that reaps, garbage-collects, reconciles, or force-mutates state
+it doesn't directly own (background loops, orphan cleaners, cross-process
+coordination) must gate on **real ownership authority**, never on a probe
+that can succeed vacuously. A lock/lease that returns success when no real
+locking backend is configured (a no-op) will make every live entity look
+"unowned" and get reaped. Confirm the guard checks the *capability*
+("do I actually have cross-process authority?"), not just the probe's
+return value.
+
+## 5. Claims must be provable against the real path
+
+Any comment, doc, ADR, or commit message that asserts a behavioral or
+security guarantee ("this closes the leak", "cascades on delete", "the
+reaper covers case X") must be **provable by tracing the actual deployed
+code path**. A guarantee that only holds in a topology you don't ship is a
+false claim — scope the wording to what the code actually delivers, or make
+the code deliver it. Over-claiming safety is worse than admitting a
+residual gap.
+
+## 6. Loud failure, never silent masking
+
+An error must surface, not be disguised. A `catch`/`if err != nil` that
+returns an empty result makes a genuine failure (store outage, decode
+error) indistinguishable from "no data" — the panel renders empty, the
+outage is invisible. Log (or propagate) the error before returning the
+empty/degraded state. No silent recovery that hides a root cause.
+
+## 7. Fit and rot — did we build the RIGHT thing, and only that
+
+Sections 1–6 catch code that is *wrong*. This one catches code that is
+*correct but hollow* — it compiles, passes, reviews clean, and still isn't
+what the task needed. Two failure modes, opposite directions:
+
+- **Fit (under-serving):** does the change serve the actual *need*,
+  end-to-end, not just the literal acceptance criteria? A change can satisfy
+  every stated check and still miss the point — it addresses a symptom, sits
+  at the wrong layer, or handles the happy path the ticket named while the
+  real workflow the user described stays broken. Re-read the original intent,
+  then trace the delivered path against it. Name any gap between what was
+  asked for and what the code actually does — a passing test over the wrong
+  behavior is a façade, not a fix.
+- **Rot (over-serving):** did the change make the codebase *worse to work
+  in*? Three tells: **duplication** (a third helper doing what two existing
+  ones already do — reuse the sibling instead), **over-engineering** (an
+  abstraction, config knob, or generality with exactly one caller and no
+  second on the horizon — inline it), and **incoherence** (now there are two
+  ways to do the same thing, and the next author won't know which). Leave the
+  tree more coherent than you found it, not more tangled.
+
+Conformance to the repo's declared conventions is already covered for
+cross-cutting concerns by §1; here, just confirm the change reads like the
+code around it. This section is judgment, not a checklist — apply it once,
+honestly, and fix what you find in the same pass. It is **advisory**: the
+deterministic build+test gate stays the only thing that blocks shipping — this
+lens sharpens the diff, it never gates it.
+
+## How to use this in a self-review pass
+
+1. `git diff <base>` and `git diff --stat` — see the *whole* change.
+2. For each new/changed unit, walk sections 1–7. Most changes only touch a
+   few; be honest about which apply.
+3. For anything you find, **fix it now** and note it. Do not defer.
+4. Only when a section genuinely doesn't apply (no new state, no new
+   handler, no claim) skip it — don't invent work. Small changes get a
+   small review.
+
+This is not style policing. It is the specific set of correctness,
+security, and consistency defects that otherwise ship green and get caught
+downstream. Catching them here is the difference between a PR that merges
+clean and one that comes back with findings.

--- a/bots/instrument/skills/forge-mr-create.md
+++ b/bots/instrument/skills/forge-mr-create.md
@@ -1,0 +1,167 @@
+---
+name: forge-mr-create
+description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
+---
+
+<!-- DUPLICATE — one of five byte-identical copies (iterion has no
+     skill-sharing primitive; see CLAUDE.md "If a skill ends up duplicated
+     across multiple bundles"). Edit one, edit all five:
+       bots/app-dev/skills/forge-mr-create.md
+       bots/branch-improve-loop/skills/forge-mr-create.md
+       bots/docs-refresh/skills/forge-mr-create.md
+       bots/feature-dev/skills/forge-mr-create.md
+       bots/whole-improve-loop/skills/forge-mr-create.md -->
+
+# Opening a pull request from a finished run
+
+You are turning the commits this run produced into ONE pull request
+(PR; merge request on GitLab), then optionally posting its URL back onto
+the source issue. You push and open a PR — you do NOT edit, fix, or
+re-commit the workspace.
+
+## Fresh repository (created for this run — no remote branches yet)
+
+When the run targeted a repository CREATED at launch, `origin` exists
+but has no branches (`git ls-remote --heads origin` is empty). There is
+no base to open a PR against — the FIRST push IS the publication:
+
+1. `git push -u origin HEAD` — publishes the current branch; on an
+   empty repo it becomes the default branch.
+2. Skip the PR entirely (a PR needs base ≠ head). Report the repo's
+   web URL as the deliverable instead of a PR URL.
+3. Only from the SECOND run onward (remote default branch exists) does
+   the normal branch → PR flow below apply.
+
+## 0. Resolve the base, then check there are commits to ship
+
+The CWD is the run's git worktree (or clone). First resolve the BASE the
+PR will target. Use the `mr_base` input when it is non-empty; otherwise
+resolve the repository's DEFAULT branch from the origin remote — never
+hardcode `main`:
+
+```
+BASE="$mr_base"                                  # from input; may be empty
+if [ -z "$BASE" ]; then
+  # Default branch as the remote advertises it (origin/HEAD).
+  BASE="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')"
+fi
+if [ -z "$BASE" ]; then
+  # origin/HEAD not set (fresh clone / no remote HEAD ref). Ask the remote.
+  BASE="$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')"
+  # Cache it so the symbolic-ref lookup works next time.
+  [ -n "$BASE" ] && git remote set-head origin "$BASE" >/dev/null 2>&1 || true
+fi
+BASE="${BASE:-main}"                             # last-resort floor only
+```
+
+Then confirm HEAD is ahead of that base before doing anything. Compare
+against the REMOTE ref, never the local branch: in a cloud/runner clone
+the campaign commits directly on the checked-out base branch, so the
+local `$BASE` ref IS HEAD and `"$BASE"..HEAD` is vacuously 0 — that
+exact mistake silently discarded a run's real commits.
+
+```
+git fetch origin "$BASE" --quiet 2>/dev/null || true
+git rev-list --count "origin/$BASE"..HEAD        # > 0 means there is work to ship
+```
+
+If the count is 0 (or `origin/$BASE` is missing), STOP: return
+`opened=false` with `skipped_reason="no commits ahead of base"`. Never
+open an empty PR.
+
+## 1. Detect the forge from the origin remote
+
+```
+git remote get-url origin
+```
+
+- host `github.com` (or GitHub Enterprise) → **GitHub**, use `gh`.
+- host contains `gitlab` → **GitLab**, use `glab`.
+- otherwise assume **Forgejo / Gitea** (self-hosted) → REST API via `curl`.
+
+If there is no `origin` remote (a local-only run), return `opened=false`
+with `skipped_reason="no origin remote to push to"`.
+
+## 2. Authenticate from the mounted forge_token
+
+This run may be unattended (a comment-triggered launch) with no
+pre-authenticated forge CLI, and a reused runner pod can carry a PREVIOUS
+run's login. The most robust path is **environment auth**: gh/glab read a
+token straight from the env, which overrides any stale login and avoids the
+`auth login` / `set-token` sub-commands whose flags drift between CLI
+versions (glab's `--host` → `--hostname` rename has bitten real runs). If
+the mounted secret file `/run/iterion/secrets/forge_token` EXISTS, export it
+for the matching CLI FIRST; never read the token into a prompt or echo it:
+
+- GitHub: `export GH_TOKEN="$(cat /run/iterion/secrets/forge_token)"`
+- GitLab: `export GITLAB_TOKEN="$(cat /run/iterion/secrets/forge_token)"` plus
+  `export GITLAB_HOST="<host>"` (host parsed from the origin URL); glab reads
+  both — do NOT run `glab auth login` / `set-token`.
+- Forgejo/Gitea: `export FORGEJO_TOKEN="$(cat /run/iterion/secrets/forge_token)"`
+
+When the file is absent (manual/local runs), assume host auth and verify
+the CLI is ready (`gh auth status` / `glab auth status`). If neither a
+token file nor host auth is available, push/open nothing: return
+`opened=false` with a precise `skipped_reason` (e.g.
+`"gh not authenticated; run gh auth login"`). Do not pretend.
+
+## 3. Choose the branch and push
+
+Pick the branch name: use the `mr_branch` input if non-empty, else derive
+a stable one — `iterion/improve/<run-id-or-short-sha>`. Push the run's
+HEAD to it on origin:
+
+```
+BRANCH="${mr_branch:-iterion/improve/$(git rev-parse --short HEAD)}"
+git push origin "HEAD:refs/heads/$BRANCH"
+```
+
+If the push is rejected (protected branch, no permission), return
+`opened=false` with the precise `skipped_reason` from the push error.
+
+## 4. Open the pull request
+
+Title: a short semantic summary of the improvements (reuse the run's
+commit subjects / scope_notes). Body: what changed and why, plus a line
+noting it was generated by an iterion improvement run.
+
+- **GitHub:**
+  `gh pr create --base "$BASE" --head "$BRANCH" --title "<title>" --body "<body>"`
+  (prints the PR URL on success). If a PR already exists for the branch,
+  `gh pr view "$BRANCH" --json url -q .url` — treat as `opened=true`.
+- **GitLab:**
+  `glab mr create --source-branch "$BRANCH" --target-branch "$BASE" --title "<title>" --description "<body>" --yes`
+  (prints the MR URL). Idempotent: if an MR already exists, fetch its URL
+  with `glab mr view "$BRANCH" -F json` and reuse it.
+- **Forgejo / Gitea (REST):** parse `<owner>/<repo>` from the origin URL,
+  then `POST https://<host>/api/v1/repos/<owner>/<repo>/pulls` with body
+  `{"head":"<BRANCH>","base":"<BASE>","title":"<title>","body":"<body>"}`
+  and header `Authorization: token $FORGEJO_TOKEN`. The response JSON's
+  `html_url` is the PR URL.
+
+Capture the resulting URL into `url` and set `opened=true`, `branch=$BRANCH`.
+
+## 5. Back-link the source issue (optional)
+
+If the `source_issue_ref` input is non-empty, post the PR URL back to it
+so the requester sees the result where they asked:
+
+- ref looks like a **forge issue URL** (`https://…/issues/<n>` or
+  `…/-/issues/<n>`): comment via the same CLI —
+  `gh issue comment <n> --body "Opened: <url>"` /
+  `glab issue note <n> --message "Opened: <url>"` / Forgejo
+  `POST /repos/<owner>/<repo>/issues/<n>/comments`.
+- ref looks like **`native:<id>`** (the local kanban board): call the
+  board comment tool — `mcp__iterion_board__comment_issue` with
+  `{ id: "<id>", body: "Opened PR: <url>" }` (the finalize_mr node holds
+  the `board.comment` capability for exactly this).
+
+Set `back_linked=true` only when the comment actually posted. A failed
+back-link is not fatal — keep `opened=true` and note the failure in
+`summary`.
+
+## Honesty contract
+
+Report exactly what happened: `opened`, `url`, `branch`, `back_linked`,
+and a precise `skipped_reason` whenever `opened=false`. Never fabricate a
+URL, never claim a PR you did not open, never echo the token.

--- a/bots/instrument/skills/forge-mr-create.md
+++ b/bots/instrument/skills/forge-mr-create.md
@@ -3,14 +3,16 @@ name: forge-mr-create
 description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
 ---
 
-<!-- DUPLICATE — one of five byte-identical copies (iterion has no
+<!-- DUPLICATE — byte-identical copies across bundles (iterion has no
      skill-sharing primitive; see CLAUDE.md "If a skill ends up duplicated
-     across multiple bundles"). Edit one, edit all five:
+     across multiple bundles"). Edit one, edit the others:
        bots/app-dev/skills/forge-mr-create.md
        bots/branch-improve-loop/skills/forge-mr-create.md
-       bots/docs-refresh/skills/forge-mr-create.md
        bots/feature-dev/skills/forge-mr-create.md
-       bots/whole-improve-loop/skills/forge-mr-create.md -->
+       bots/instrument/skills/forge-mr-create.md
+       bots/whole-improve-loop/skills/forge-mr-create.md
+     bots/docs-refresh/skills/forge-mr-create.md has DIVERGED (its own
+     amend-mode delta) — do not blind-sync that one. -->
 
 # Opening a pull request from a finished run
 

--- a/bots/instrument/skills/instrumentation.md
+++ b/bots/instrument/skills/instrumentation.md
@@ -1,0 +1,146 @@
+---
+name: instrumentation
+description: The observability-instrumentation playbook — how to survey a repo, what "done" means for the errors / logs / tracing families, the extend-don't-replace rule for logging seams, DSN opt-in semantics, and the verification discipline. Read this FIRST in every instrument campaign pass.
+---
+
+# instrumentation — the playbook
+
+You are instrumenting ONE repository for observability. The families
+requested for this run are in `scope`; this skill defines what each
+family means and the discipline that keeps the work honest. Stack
+specifics (which SDK, which log lib, which wiring seams) live in the
+`lang-<stack>` skills — read the one(s) matching the repo. Tracing has
+its own skill, read ONLY when scope asks for it.
+
+## 0. Survey first (cheap, before any edit)
+
+1. **Production entry points** — every place the code starts running
+   for real: HTTP servers, daemons/long-running workers, queue/job
+   consumers, schedulers, and the CLI `main`. These are where error
+   capture and log-format defaults attach. List them; the list drives
+   your todo.
+2. **Existing logging** — does the repo already have a central logging
+   module/wrapper? Grep for a `log`/`logger`/`logging` package of its
+   own, then for strays (`print`, `console.log`, `fmt.Print*`,
+   `System.out`, bare stdlib loggers) on production code paths.
+3. **Configuration conventions** — how this repo reads env/config
+   (prefix naming, a config loader, flag precedence). New env vars MUST
+   follow the house convention; the DSN env var name is given to you
+   and is the ecosystem standard unless the operator overrode it.
+4. **Test layout + toolchain** — where unit tests live, how they run.
+   Your instrumentation ships WITH tests; the deterministic gate will
+   run them.
+
+Mission notes from the operator override any default in this skill —
+they are the repo owner's arbitration.
+
+## 1. Family: errors (error tracking)
+
+Target: an SDK speaking the **Sentry DSN protocol** — the same DSN and
+SDK work against Sentry *and* GlitchTip (GlitchTip implements the
+Sentry ingestion API; no GlitchTip-specific client exists or is
+needed). Pick the stack's official Sentry SDK per the `lang-*` skill.
+
+Definition of done:
+
+- **Opt-in by env, off by default.** The SDK initialises ONLY when the
+  DSN env var is set at runtime. Unset ⇒ strictly zero behaviour
+  change: no goroutine/thread, no network, no init log noise beyond at
+  most a debug line. Never hardcode a DSN; never invent a second
+  activation path.
+- **Loud, non-fatal init failure.** A malformed DSN or failed init is
+  reported through the repo's own logger at error level — and the app
+  keeps running. Observability must never take the service down.
+- **Identity tags.** Set `release` (the repo's own version/commit
+  source — a build-info package, a VERSION file, git describe) and
+  `environment` (from the standard `SENTRY_ENVIRONMENT` env or the
+  repo's own env notion). Without a release, events are unusable for
+  regression triage.
+- **Capture at the process seams**, not scattered call sites:
+  - panic/uncaught-exception capture at every real entry point found
+    in the survey (server request recovery, worker/goroutine recovery
+    points, CLI top-level);
+  - the fatal-exit path (an error that terminates the process is
+    captured before exit);
+  - existing recover/rescue blocks: add capture INSIDE them, do not
+    restructure them.
+- **Flush on shutdown.** Pending events are flushed with a short
+  bounded timeout (~2s) on normal termination and on the fatal path.
+  A captured event that dies with the process is a façade.
+- **Scrubbing.** Configure the SDK's before-send hook to drop obvious
+  secrets/PII (auth headers, tokens, DSN-like strings, emails where
+  the repo treats them as personal data). Follow the repo's own
+  sensitivity conventions when it has them.
+- **Central wrapper, thin.** One small module owns init/flush/capture
+  helpers so call sites never import the SDK directly in more than a
+  handful of places. If the repo already HAS an error-tracking wrapper,
+  extend it instead.
+
+## 2. Family: logs (standardization)
+
+Target: **one central logging seam** for the whole codebase, structured
+and machine-shippable in production.
+
+**THE RULE: extend, don't replace.** If the repo already has a central
+logger — even a home-grown one — you extend IT (add the missing
+format/hook/fields) and sweep the rest of the code onto it. Replacing a
+working seam, or adding a parallel one, is the classic façade: two
+half-adopted loggers are worse than one imperfect one. Only when the
+repo has NO central seam do you introduce the stack's standard lib
+(per the `lang-*` skill), wrapped thinly so the repo owns its API.
+
+Definition of done:
+
+- **Leveled + structured.** error/warn/info/debug levels and key-value
+  fields (a `WithField`-style context or the lib's native equivalent).
+  Log lines never crash the producer: a serialization failure is
+  dropped or degraded, never thrown.
+- **JSON by default in production.** Every long-running production
+  surface (server, daemon, worker) emits one JSON object per line by
+  default — stable field names (timestamp, level, msg, fields) suitable
+  for Loki/ELK/CloudWatch. Interactive/TTY surfaces (the CLI a human
+  runs) keep the human-readable format by default. BOTH are switchable
+  by env/config following the repo's conventions — the default is a
+  default, never a cage.
+- **Stray sweep.** Production code paths log through the seam — sweep
+  `print`/`console.log`/ad-hoc stdlib loggers into it. Out of scope:
+  test files, throwaway scripts, developer tooling, and surfaces whose
+  stdout IS the product (a CLI's command output is not a log).
+- **Coupling to the tracker** (only when `errors` is also in scope):
+  wire the seam's hook/handler mechanism so an **error-level log
+  becomes a tracker event** (with its structured fields as context) and
+  a **warn-level log becomes a breadcrumb** attached to subsequent
+  events. The coupling lives in ONE place (the wrapper), is active only
+  when the tracker is enabled, and must never block or panic the
+  logging path.
+
+## 3. Family: tracing (opt-in)
+
+Only when `scope` includes `tracing`. Read the `tracing` skill — it
+covers the Sentry-first transaction/span model, sampling, and per-stack
+entry points. Never wire tracing "while you're at it".
+
+## 4. Verification discipline
+
+- **Unit tests, no network.** Every Sentry-protocol SDK has an
+  in-memory/mock transport (see the `lang-*` skill) — assert that an
+  error-level log or a captured panic produces an event with the
+  expected fields, and that warn produces a breadcrumb. A test that
+  needs a live DSN is wrong.
+- **Format proof.** A unit test asserts the JSON log format's field
+  names on a sample line (the shipper contract), and that the
+  prod-surface default is JSON while the interactive default is human.
+- **Off-state proof.** With the DSN env unset, init is a no-op — assert
+  it (no client, no transport, no error).
+- **Docs.** The DSN env var, the environment/release envs, the log
+  format envs, and "how to point this at Sentry or GlitchTip" land in
+  the repo's own docs, wherever it documents configuration. An
+  undocumented env var does not exist.
+
+## 5. Honesty
+
+Your summary CITES the seams you wired (file:line), the env vars you
+introduced, and the tests that prove each family. The deterministic
+gate runs the repo's real build+tests behind you, and the adversarial
+review reads your diff — claiming a family is wired when a seam is
+missing costs you the next pass.

--- a/bots/instrument/skills/lang-go.md
+++ b/bots/instrument/skills/lang-go.md
@@ -1,0 +1,97 @@
+---
+name: lang-go
+description: Go reference for the instrument campaign — sentry-go for error tracking (init, recover, flush, mock transport tests), log/slog as the default structured logger when the repo has none, hook patterns for a home-grown logger, and Go module/vendoring gotchas. Read when the target repo is Go.
+---
+
+# lang-go — instrumenting a Go repository
+
+## Error tracking: `github.com/getsentry/sentry-go`
+
+The official Go SDK for the Sentry DSN protocol (works unchanged
+against GlitchTip). Core wiring:
+
+```go
+err := sentry.Init(sentry.ClientOptions{
+    Dsn:         os.Getenv(dsnEnvVar),   // "" would disable, but prefer: skip Init entirely when unset
+    Release:     release,                 // from the repo's own version/commit source
+    Environment: os.Getenv("SENTRY_ENVIRONMENT"),
+    BeforeSend:  scrub,                   // drop secrets/PII before the wire
+})
+```
+
+- **Skip `Init` entirely when the DSN env is empty** — that is the
+  cleanest "zero behaviour change" off-state, and makes the enabled
+  check (`enabled bool` on your wrapper) trivial to test.
+- `sentry.Init` returns an error on a malformed DSN — log it at error
+  level through the repo's logger and continue (never `os.Exit`).
+- **Flush**: `sentry.Flush(2 * time.Second)` on the shutdown path AND
+  before a fatal exit. `CaptureException`/`CaptureMessage` are async;
+  without the flush the event dies with the process.
+- **Panic seams**: in each goroutine/worker recovery point the repo
+  already has, add capture inside the existing `recover()` block:
+  `sentry.CurrentHub().Recover(r); sentry.Flush(2 * time.Second)`.
+  For the process top level, a small
+  `defer func(){ if r := recover(); r != nil { capture(r); panic(r) } }()`
+  in `main` (re-panic so exit semantics don't change). HTTP servers
+  that already recover per-request: capture there, keep their recovery
+  semantics intact.
+- **Context/tags**: prefer `sentry.WithScope` + `scope.SetContext` /
+  `scope.SetTag` at capture time over global mutable state.
+
+### Testing without a network
+
+`sentry.ClientOptions.Transport` accepts a custom transport. In tests,
+install a fake that records events in memory:
+
+```go
+type memTransport struct{ events []*sentry.Event; mu sync.Mutex }
+func (t *memTransport) Configure(sentry.ClientOptions) {}
+func (t *memTransport) SendEvent(e *sentry.Event) { t.mu.Lock(); t.events = append(t.events, e); t.mu.Unlock() }
+func (t *memTransport) Flush(time.Duration) bool { return true }
+func (t *memTransport) FlushWithContext(context.Context) bool { return true }
+func (t *memTransport) Close() {}
+```
+
+(Match the `sentry.Transport` interface of the pinned SDK version —
+check `transport.go` in the vendored copy; older versions have no
+`FlushWithContext`/`Close`.) Then assert: an error-level log produces
+one event with the expected message/fields; warn produces a breadcrumb
+on the scope; DSN unset produces nothing.
+
+### Modules & vendoring
+
+- `go get github.com/getsentry/sentry-go@latest` then, **if the repo
+  vendors** (a `vendor/` dir + `-mod=vendor` builds), `go mod vendor`
+  — never hand-edit `vendor/`. Commit go.mod/go.sum/vendor in the same
+  slice as the first use.
+- sentry-go is pure Go (no cgo) — safe for `CGO_ENABLED=0` static
+  builds.
+
+## Logging
+
+- **Repo already has a central logger** (common in mature Go repos):
+  EXTEND it. The usual gaps to fill: a JSON output mode (one object
+  per line: ts/level/msg/fields), `WithField`-style context, and a
+  **hook seam** — a small interface or func the wrapper calls on every
+  line at/above a level. The tracker coupling then registers a hook:
+  error → `CaptureEvent` (message + fields as context), warn →
+  `AddBreadcrumb`. The hook must be non-blocking and panic-safe
+  (`defer recover()` inside the hook dispatch): log lines never crash
+  the producer.
+- **No central logger**: use stdlib **`log/slog`** (Go ≥1.21) — zero
+  new dependency. `slog.NewJSONHandler(os.Stderr, …)` for prod
+  surfaces, `slog.NewTextHandler` (or the repo's preferred pretty
+  handler) for TTY. Wrap it in a tiny package the repo owns so the
+  seam is yours to hook: implement a `slog.Handler` that delegates and
+  forwards error/warn records to the tracker.
+- **Prod default detection**: prefer an explicit per-surface default
+  (the server/daemon commands construct the logger with JSON; the CLI
+  constructs human) over global TTY sniffing — explicit beats magic,
+  and both stay overridable by the repo's log-format env.
+
+## Stray sweep targets (Go)
+
+`fmt.Print*`/`println` on server/daemon/worker paths, stdlib
+`log.Printf/Fatalf` imports outside `main` bootstrap, per-package
+ad-hoc loggers. Leave alone: test files, `//go:build`-tagged host
+tooling, generated code, and stdout that is the command's product.

--- a/bots/instrument/skills/lang-js.md
+++ b/bots/instrument/skills/lang-js.md
@@ -1,0 +1,83 @@
+---
+name: lang-js
+description: Node.js / TypeScript reference for the instrument campaign — @sentry/node for error tracking (init order, process handlers, express/fastify seams, testTransport), pino as the default structured logger when the repo has none, hook patterns for existing loggers. Read when the target repo is Node/JS/TS.
+---
+
+# lang-js — instrumenting a Node.js / TypeScript repository
+
+## Error tracking: `@sentry/node`
+
+The official Node SDK (v8+ line) speaks the Sentry DSN protocol —
+GlitchTip accepts it unchanged. Core wiring:
+
+```ts
+import * as Sentry from "@sentry/node";
+
+export function initErrTrack() {
+  const dsn = process.env[DSN_ENV_VAR];
+  if (!dsn) return false;                 // opt-in: unset ⇒ zero behaviour change
+  Sentry.init({
+    dsn,
+    release: RELEASE,                     // repo's own version/commit source
+    environment: process.env.SENTRY_ENVIRONMENT,
+    beforeSend: scrub,                    // drop secrets/PII
+  });
+  return true;
+}
+```
+
+- **Init order matters** (v8): `Sentry.init` must run BEFORE the
+  frameworks/handlers it auto-instruments are loaded — put the init in
+  a module imported first from the entry point (the SDK docs call this
+  the `instrument.js` pattern). For a plain error-tracking setup
+  without tracing this is less strict, but keep the convention anyway.
+- **Process seams**: `Sentry.init` installs `uncaughtException` /
+  `unhandledRejection` handlers via its default integrations — verify
+  they are active rather than re-adding your own. For servers:
+  `Sentry.setupExpressErrorHandler(app)` (v8) / the fastify
+  equivalent, AFTER the routes. Workers/queue consumers: capture in
+  their existing catch blocks (`Sentry.captureException(err)`).
+- **Flush on shutdown**: `await Sentry.flush(2000)` in the graceful
+  shutdown path and before `process.exit` on the fatal path.
+- Package manager: use the repo's own (respect its lockfile — npm /
+  yarn / pnpm), pin per house convention, commit the lockfile change
+  with the slice.
+
+### Testing without a network
+
+Two proven options; pick what fits the repo's test stack:
+- `Sentry.init({ dsn: "https://k@example.invalid/1", transport: makeTestTransport() })`
+  — a transport whose `send` pushes envelopes onto an array; assert on
+  the captured events.
+- Or spy on `Sentry.captureException`/`captureMessage` with the repo's
+  mocking tool (vitest/jest `vi.spyOn`). Prefer the transport form —
+  it exercises the real client pipeline (beforeSend, scrubbing).
+Assert the off-state too: DSN unset ⇒ `initErrTrack() === false`, no
+handlers installed by you, no client (`Sentry.getClient()` undefined).
+
+## Logging
+
+- **Repo already has a central logger** (winston, pino, a wrapper):
+  EXTEND it — add JSON-in-prod default, level/fields if missing, and
+  the tracker coupling at ITS seam (winston: a custom Transport;
+  pino: a second stream via `pino.multistream` or a lightweight
+  wrapper around the level methods).
+- **No central logger**: use **pino** — the Node standard for
+  structured JSON logs (JSON by default, one object per line,
+  `level`/`time`/`msg` + fields). Human-readable dev output via
+  `pino-pretty` ONLY on TTY/dev (a dev dependency or opt-in
+  transport), never in prod. Wrap pino in a tiny module the repo owns
+  (`lib/log.ts`), exposing leveled methods + child-logger fields, so
+  the tracker coupling lives in one place: error → `captureException`
+  / `captureMessage` (fields as context), warn → `addBreadcrumb`.
+  Non-blocking, try/catch'd: logging must never throw.
+- **Prod default**: JSON when not a TTY or when `NODE_ENV=production`
+  — follow the repo's own env conventions, keep an explicit log-format
+  env override.
+
+## Stray sweep targets (JS/TS)
+
+`console.log/warn/error` on server/worker paths (route handlers,
+services, jobs). Leave alone: tests, build scripts, CLIs whose stdout
+is the product, and browser bundles (frontend logging is a different
+scope — flag it as a finding instead of wiring it drive-by).

--- a/bots/instrument/skills/lang-python.md
+++ b/bots/instrument/skills/lang-python.md
@@ -1,0 +1,81 @@
+---
+name: lang-python
+description: Python reference for the instrument campaign — sentry-sdk for error tracking (init, LoggingIntegration for the error=event/warn=breadcrumb coupling, transport tests), structlog or logging+JSON formatter for standardized logs. Read when the target repo is Python.
+---
+
+# lang-python — instrumenting a Python repository
+
+## Error tracking: `sentry-sdk`
+
+The official Python SDK; GlitchTip accepts it unchanged. Core wiring:
+
+```python
+import os, sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
+
+def init_errtrack() -> bool:
+    dsn = os.environ.get(DSN_ENV_VAR, "")
+    if not dsn:
+        return False                      # opt-in: unset ⇒ zero behaviour change
+    sentry_sdk.init(
+        dsn=dsn,
+        release=RELEASE,                  # repo's own version/commit source
+        environment=os.environ.get("SENTRY_ENVIRONMENT"),
+        before_send=scrub,                # drop secrets/PII
+        integrations=[LoggingIntegration(level=logging.WARNING,      # breadcrumbs from warn+
+                                         event_level=logging.ERROR)], # events from error+
+    )
+    return True
+```
+
+- **`LoggingIntegration` IS the coupling.** The error→event /
+  warn→breadcrumb rule is native here: `event_level=ERROR` turns every
+  `logging.error(...)` into a tracker event, `level=WARNING` records
+  warn+ as breadcrumbs. If the repo logs through stdlib `logging` (or
+  structlog bound to it), you get the coupling without touching call
+  sites. Tune `level`/`event_level` to exactly warn/error.
+- **Process seams**: `sentry_sdk.init` hooks `sys.excepthook` by
+  default; framework integrations (django/flask/fastapi/celery) are
+  auto-enabled when the package is importable — verify which apply to
+  this repo's entry points rather than assuming. Long-running workers
+  with their own try/except loops: `sentry_sdk.capture_exception(e)`
+  inside the existing handler.
+- **Flush/atexit**: the SDK flushes on interpreter exit via its atexit
+  integration; for daemons with custom shutdown, call
+  `sentry_sdk.flush(timeout=2)` explicitly.
+- Dependency: add `sentry-sdk` via the repo's own dependency manager
+  (pyproject/poetry/uv/requirements) with the house pinning style.
+
+### Testing without a network
+
+`sentry_sdk.init(dsn="https://k@example.invalid/1", transport=RecordingTransport())`
+— a transport subclassing `sentry_sdk.transport.Transport` whose
+`capture_envelope` appends to a list; assert an error log produces one
+event with the expected message/extra, a warning only a breadcrumb.
+Assert the off-state: DSN unset ⇒ `init_errtrack() is False` and
+`sentry_sdk.get_client().is_active()` is false (or Hub client None on
+older SDK lines — match the pinned version).
+
+## Logging
+
+- **Repo already has a central setup** (a `logging` config module,
+  loguru, structlog): EXTEND it — add the JSON formatter/renderer and
+  keep its API. With stdlib `logging`, the JSON side is a formatter
+  (e.g. `python-json-logger`'s `JsonFormatter`, or a small hand-rolled
+  formatter if the repo avoids new deps) applied to the prod handler.
+- **No central setup**: prefer **structlog** for new structured
+  logging (bind fields, `structlog.processors.JSONRenderer()` in prod,
+  `ConsoleRenderer()` on TTY/dev), wired through stdlib `logging` so
+  `LoggingIntegration` still sees every record. A repo that wants zero
+  deps: stdlib `logging` + a JSON formatter module of its own.
+- **Prod default**: JSON on server/daemon/worker entry points,
+  human/console on interactive CLI; both switchable by the repo's
+  log-format env convention.
+
+## Stray sweep targets (Python)
+
+`print(...)` on server/worker/job paths, per-module ad-hoc
+`logging.basicConfig` calls (basicConfig belongs in ONE entry-point
+setup, not scattered), bare `except: pass` that swallows what should
+be captured (flag as finding if fixing is out of scope). Leave alone:
+tests, scripts/, notebooks, CLI stdout that is the product.

--- a/bots/instrument/skills/tracing.md
+++ b/bots/instrument/skills/tracing.md
@@ -1,0 +1,59 @@
+---
+name: tracing
+description: Opt-in tracing family for the instrument campaign — Sentry-first transactions/spans, env-tunable sampling with a conservative prod default, per-stack entry points, and what GlitchTip does/doesn't support. Read ONLY when the run's scope includes "tracing".
+---
+
+# tracing — opt-in family (Sentry-first)
+
+Only wire this when `scope` explicitly includes `tracing`. It rides the
+SAME SDK and DSN as the errors family (never a second init), so errors
+must be wired first or in the same slice.
+
+## The model
+
+Sentry-first: **transactions** (one per unit of work — an HTTP request,
+a job, a worker cycle) containing **spans** (the timed steps inside —
+DB call, outbound HTTP, subprocess). Most value comes from the SDK's
+auto-instrumentation of the repo's frameworks; hand-made spans are for
+the repo's own hot seams only.
+
+## Definition of done
+
+- **Sampling is env-tunable with a conservative prod default.** Expose
+  the standard `SENTRY_TRACES_SAMPLE_RATE` env (the SDKs read it
+  natively or via one option line); default it LOW (0 unless the env is
+  set — tracing off is the safe default even when the family is
+  requested at build time, the operator turns the dial at runtime).
+  Never hardcode 1.0 outside dev/docs examples.
+- **Auto-instrumentation first**: enable the SDK's integrations
+  matching the survey's entry points (HTTP server/client, DB) —
+  Go: `sentry-go`'s `sentryhttp`/`sentryecho`/… handler wrappers plus
+  `EnableTracing: true, TracesSampleRate: rate` in ClientOptions;
+  Node: `Sentry.init({ tracesSampleRate })` + the framework integration
+  already required by the errors family (v8 auto-instruments express/
+  fastify/pg/redis when init runs first — the `instrument.js` order
+  rule is HARD here);
+  Python: `traces_sample_rate=rate` in `sentry_sdk.init` (django/
+  flask/fastapi/celery integrations pick it up).
+- **Hand spans sparingly**: one or two of the repo's own hot seams
+  (the survey tells you which), via the SDK's span API, behind the
+  same "enabled" check as everything else.
+- **Zero overhead when off**: rate 0 / DSN unset ⇒ no transaction
+  objects on hot paths (guard hand-made spans with the enabled check).
+- **Docs**: the sample-rate env + what gets traced land next to the
+  DSN docs.
+
+## GlitchTip caveat (state it in the docs you write)
+
+GlitchTip accepts transaction envelopes and renders basic performance
+data, but does NOT implement Sentry's full performance product
+(no span metrics/dashboards, no profiling, no session replay). The
+instrumentation is identical either way — the caveat is about what the
+operator will SEE, so write it where you document the DSN wiring.
+
+## Verification
+
+Same discipline as errors: a unit test with the mock/recording
+transport asserts that (rate=1, DSN set) one transaction envelope is
+produced for a sample unit of work, and that rate=0/DSN-unset produces
+none. No live DSN in tests, ever.

--- a/bots/instrument/skills/verify-build.md
+++ b/bots/instrument/skills/verify-build.md
@@ -39,6 +39,13 @@ and the correct toolchain:
   `go.mod`'s `go` directive is newer than the installed `go version`, use the
   project's wrapper (e.g. `devbox run -- go …`) or `GOTOOLCHAIN=auto go …` so
   the pinned toolchain is fetched, rather than failing on "requires go >= X".
+- **Go in a sandboxed git worktree: disable VCS stamping.** The run's
+  workspace is a git *worktree* whose gitdir lives outside the sandbox
+  mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
+  status: exit status 128` even though git itself works. Put
+  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  binary's stamped identity is irrelevant to a build+test gate.
+  (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
   - **devbox is first-class inside the iterion sandbox** — when the repo
     pins its toolchain via `devbox.json`, prefer `devbox run -- …`; the engine
     lays the whole `$HOME` subtree user-writable so the wrapper's cache/home

--- a/bots/instrument/skills/verify-build.md
+++ b/bots/instrument/skills/verify-build.md
@@ -1,0 +1,171 @@
+---
+name: verify-build
+description: Detect and run a repository's OWN build + test so a deterministic gate can confirm the tree actually compiles and passes before the improve-loop commits. Stack-agnostic — read this when asked to verify a build.
+---
+
+# verify-build
+
+Your job: make the repository in front of you **build and test green using its
+own tooling**, and leave a re-runnable script for the deterministic gate.
+
+This is the backstop for the whole-improve-loop review. Reviewers read **one
+chunk of source at a time**, so a change that breaks compilation in *another*
+file (a renamed or retyped symbol with a caller the current pass never exercised)
+or a bug only a test catches is invisible to them. The build + tests are what
+catch it — that is the entire reason this step exists.
+
+## 1. Detect the repo's build + test commands
+
+Do **not** assume a language. Look at the markers actually present and prefer
+the project's own wrapper when it has one — a wrapper encodes the correct flags
+and the correct toolchain:
+
+- **Task runner / Makefile** — `Taskfile.yml` → `task build` / `task test` /
+  `task check`; `Makefile` → `make build` / `make test`; `Justfile` → `just …`.
+  This is almost always the right answer when present. List the targets that
+  actually exist (`task --list`, `make -qp`, `just --list`) instead of assuming
+  the conventional names: plenty of repos have `test` and `lint` but no `check`
+  umbrella, and a verify.sh calling a target that does not exist fails for a
+  reason that has nothing to do with the change under test.
+- **A gate CI runs inline is still a gate.** When CI invokes something the task
+  runner does not expose — a coverage threshold script, a schema check, a
+  shell assertion — copy that invocation into verify.sh verbatim. `task test`
+  passing while CI's `go test … && bash hack/coverage.sh cover.out 85` fails is
+  a green local verify on a red change, which is the exact failure the
+  deterministic gate exists to prevent.
+- **Pinned toolchain — honour it or the build fails on a version mismatch.**
+  `devbox.json` → prefix with `devbox run -- …`. `.tool-versions` (asdf/mise),
+  `.nvmrc`, `flake.nix`, `mise.toml` → activate accordingly. For Go: if
+  `go.mod`'s `go` directive is newer than the installed `go version`, use the
+  project's wrapper (e.g. `devbox run -- go …`) or `GOTOOLCHAIN=auto go …` so
+  the pinned toolchain is fetched, rather than failing on "requires go >= X".
+  - **devbox is first-class inside the iterion sandbox** — when the repo
+    pins its toolchain via `devbox.json`, prefer `devbox run -- …`; the engine
+    lays the whole `$HOME` subtree user-writable so the wrapper's cache/home
+    work normally. (This wasn't always true: until the `homeNestedBindParents`
+    fix, the Go-cache binds left `$HOME/.cache` root-owned and `devbox run`
+    died with `mkdir: cannot create directory '/home/.../.cache/devbox':
+    Permission denied` — observed 2026-06-23, run 019ef550. That root cause is
+    fixed in the engine.) Last-resort only: if the wrapper still fails for a
+    genuine environment reason (not a code error), the sandbox image also ships
+    the real toolchain (`go`, `node`, `cargo`, `python`) directly on `PATH`, so
+    you may fall back ONCE to the bare tool — `command -v go && go build ./...
+    && go test ./...` — rather than retrying the wrapper.
+- **Language defaults (only when there is no wrapper):**
+  - Go (`go.mod`): `go build ./... && go test ./...`
+  - Node (`package.json`): pick the package manager from the lockfile
+    (`pnpm-lock.yaml`→pnpm, `yarn.lock`→yarn, `package-lock.json`→npm) and run
+    its `build` + `test` scripts if defined.
+  - Rust (`Cargo.toml`): `cargo build && cargo test`.
+  - Python (`pyproject.toml`/`setup.py`): the configured test runner, e.g.
+    `python -m pytest`, plus a type/lint check if the project defines one.
+  - Anything else: build + unit-test the way the repo's CI does — read
+    `.github/workflows/*` (or other CI config) if present; CI is the source of
+    truth for "how this repo is built".
+
+Prefer the **fast** path: compile the whole module (a compile error is the
+common breakage) + run the unit tests. Skip slow integration / e2e / live
+suites unless they are the only tests the repo has.
+
+## 1b. Include the repo's codegen-freshness / drift checks
+
+Build + test green does NOT mean CI is green. Many repos commit **generated
+artifacts** — an OpenAPI/Swagger spec + generated client types, protobuf/gRPC
+stubs, generated mocks, a Helm chart version pinned to a package file — and
+enforce in CI that the committed copy matches a fresh regeneration
+(`regenerate && git diff --exit-code`). A change that adds an API route, a
+proto message, or a schema field but forgets to regenerate ships **green
+build + red CI** — exactly the drift the deterministic gate or CI catches that
+you should catch here instead.
+
+So your `verify.sh` **must** mirror CI's gates, not just build+test — a build+test-only
+`verify.sh` is the single most common way an autonomous change ships green-locally /
+red-in-CI. This is not optional whenever the repo commits generated artifacts:
+
+- **Read the CI config** (`.github/workflows/*.yml`, `.gitlab-ci.yml`,
+  `.circleci/`) and include every gate it enforces — especially steps named
+  *drift*, *generate*, *codegen*, *check*, *fmt*, *lint*, *tidy/verify*.
+- **Grep the task runner** for freshness targets: `Taskfile.yml`/`Makefile`
+  entries like `*:gen` / `*:generate` / `*:check` / `openapi:check` /
+  `proto:check`. When a `check`/`verify` umbrella target exists that bundles
+  lint + test + drift, prefer it — it is the repo's own definition of "CI
+  green".
+- The pattern to add for each committed-generated artifact:
+  `<the repo's regen command> && git diff --exit-code -- <the generated
+  paths>` — a non-empty diff means stale, which is a real red.
+
+If you changed code that feeds a generator (a new HTTP route, a new exported
+type in a schema-bearing package), regenerating and committing the output is
+part of the work — the gate is here to force it. (iterion specifically:
+`task openapi:check` + the helm chart drift check are CI gates; a new
+`/api/...` route needs `task openapi:gen` committed.)
+
+This section is **deterministically enforced** by the verify gate: when the
+repo's CI config contains a drift gate and your `verify.sh` has no
+`git diff --exit-code`/`--quiet` line, the gate fails with a DRIFT GATE
+MISSING error; and a green verify that leaves new changes in the tree fails
+with UNCOMMITTED REGEN OUTPUT. Writing the gate here is cheaper than being
+bounced by the enforcement.
+
+## 2. Write the verify script to the scratch dir
+
+Write an executable POSIX-sh script at the exact `verify.sh` path your task
+prompt gives you — an **out-of-tree scratch dir** (`scratch_dir`), NOT the
+target repo. Create that directory first if it does not exist (`mkdir -p` its
+parent). The script runs the build AND tests you settled on and **exits
+non-zero on any failure**. Example
+*shape* (adapt to the repo — illustration, not a fixed command):
+
+```sh
+#!/bin/sh
+set -e
+devbox run -- task build
+devbox run -- task test
+# Codegen-freshness gate (§1b) — regenerate the repo's committed derived
+# artifacts, then fail if the tree drifted. Adapt the regen command(s) to the
+# repo (grep the task runner for *:gen / *:generate); omit this block only when
+# the repo commits NO generated artifacts. `git diff --exit-code` (no paths)
+# catches drift in whatever the regen wrote.
+devbox run -- task openapi:gen      # ← the repo's own regen target(s)
+git diff --exit-code || { echo "codegen drift — regenerate + commit the output" >&2; exit 1; }
+```
+
+The deterministic gate re-runs **this** script and gates the commit on its real
+exit code — so it must genuinely pass, not merely look plausible. A `verify.sh`
+that omits the §1b regen step when the repo has generated artifacts is the
+canonical way a change lands green-locally / red-in-CI.
+
+## 3. Run it, and fix what the just-applied changes broke
+
+Run your script. If it fails, the failure is almost always introduced by the
+changes the preceding work just applied. Read the error and fix it **at the
+source** with the **smallest** change that restores build + tests: update the
+missed caller, correct the signature, fix the read/write mode, repair the test.
+Do **not** refactor or change behaviour beyond what is needed to compile and
+pass. Re-run until green.
+
+If the repository genuinely has no build/test system (pure docs/config), write
+a script that echoes that fact and exits 0, and say so plainly in your summary —
+do not invent a build.
+
+## Safety — never destroy or recreate version-control state
+
+The verify script and your fixes run against the operator's real working tree —
+often a **git worktree bind-mounted into a sandbox**. NEVER:
+
+- `rm`, move, truncate, or recreate `.git` (or `.hg`/`.svn`), and NEVER run
+  `git init` / `git clone` over an existing checkout. A worktree's `.git` is a
+  *file* pointing at the parent repo; deleting it or `git init`-ing over it
+  **disconnects the operator's worktree and strands their commits** (observed
+  2026-06-15, run 019eca0d — a bootstrap that ran `rm -f .git; git init` severed
+  the worktree's link to the repo).
+- Reset, force-checkout, `git clean`, or otherwise discard tracked files or
+  history.
+
+If a build/test step needs git and git is **unavailable in this environment**
+(e.g. `git rev-parse` fails because a worktree's `.git` target isn't mounted in
+the sandbox), do NOT manufacture a repo. Make the verify script **skip** the
+git-dependent tests — guard them behind `git rev-parse --is-inside-work-tree` —
+and note the skip in your summary. A gate that skips a few git-dependent tests
+with a loud note is correct; one that destroys the operator's repo to run them
+is not.

--- a/bots/issue-triage/skills/iterion-bot-catalog.md
+++ b/bots/issue-triage/skills/iterion-bot-catalog.md
@@ -102,6 +102,7 @@ dispatcher routes on it), never the persona.
 | Vigie | `feed-watch` |
 | Goldy | `golden-master` |
 | Heartbeat (always-on demo) | `heartbeat` |
+| Obsy | `instrument` |
 | Triagy | `issue-triage` (this bot) |
 | Morphy | `modernize` |
 | Nested Subbots Demo | `nested-subbots-demo` |
@@ -619,6 +620,34 @@ long-lived bot running as a stream of fresh, individually-budgeted runs
 rather than one immortal run. No LLM, no API keys.
 
 - **Path**: `examples/keepalive/main.bot`
+
+### `instrument` — Obsy
+
+Observability instrumentation campaign — one capable agent wires a
+repo for error tracking and standardized logs, one verified semantic
+commit at a time. `scope` is an open family list: *errors* (an SDK
+speaking the Sentry DSN protocol — Sentry AND GlitchTip — enabled
+only when the DSN env var is set, loud non-fatal init, release/
+environment tags, capture at process seams, flush on shutdown,
+scrubbing), *logs* (ONE central logging seam — extended, never
+replaced — leveled + structured, JSON by default on production
+surfaces, error→event / warn→breadcrumb coupling into the tracker),
+and opt-in *tracing* (Sentry-first transactions/spans, env-tunable
+sampling). A deterministic build/test gate + bounded continuation
+loop re-poke the campaign until every requested family is fully
+wired, tested and documented; an opt-in tail opens the pull request.
+
+- **Use when**:
+  Use to instrument a repository for observability: add Sentry/
+  GlitchTip-compatible error tracking, standardize logging onto one
+  structured lib with JSON output in production, or both (default
+  scope "errors,logs"; add "tracing" explicitly for performance
+  traces). Point repo-specific arbitrations (which module to extend,
+  which seams to wire) through `mission_notes`. Not the route for
+  general feature work (feature-dev) or for building dashboards —
+  this bot wires the emission side only.
+- **Vars**: `baseline` (string), `dsn_env_var` (string), `max_passes` (int), `mission_notes` (string), `mr_base` (string), `mr_branch` (string), `open_mr` (bool), `scope` (string), `scratch_dir` (string), `source_issue_ref` (string), `workspace_dir` (string)
+- **Path**: `bots/instrument/main.bot`
 
 ### `issue-triage` — Triagy
 

--- a/bots/verify_probe_wiring_test.go
+++ b/bots/verify_probe_wiring_test.go
@@ -31,6 +31,7 @@ func TestVerifyProbeLoopIterationWiring(t *testing.T) {
 		"branch-improve-loop/main.bot",
 		"whole-improve-loop/main.bot",
 		"feature-dev/main.bot",
+		"instrument/main.bot",
 	}
 	for _, rel := range bots {
 		rel := rel

--- a/bots/verify_run_drift_test.go
+++ b/bots/verify_run_drift_test.go
@@ -215,6 +215,7 @@ func TestVerifyRunDriftTailPresentInAllBots(t *testing.T) {
 		"e2e-coverage/main.bot":        "verify_run",
 		"dep-update-guard/main.bot":    "verify_run",
 		"adr-cartograph/main.bot":      "verify_run",
+		"instrument/main.bot":          "verify_run",
 		// docs-refresh dropped the build-verify apparatus (a docs-only
 		// campaign can't break the build) — commit 8aee22894, converges on
 		// scope_ok ∧ docs_aligned alone. No verify_run node to guard.

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -300,6 +300,7 @@ dispatcher routes on it), never the persona.
 | Vigie | `feed-watch` |
 | Goldy | `golden-master` |
 | Heartbeat (always-on demo) | `heartbeat` |
+| Obsy | `instrument` |
 | Triagy | `issue-triage` |
 | Morphy | `modernize` |
 | Nested Subbots Demo | `nested-subbots-demo` |
@@ -817,6 +818,34 @@ long-lived bot running as a stream of fresh, individually-budgeted runs
 rather than one immortal run. No LLM, no API keys.
 
 - **Path**: `examples/keepalive/main.bot`
+
+### `instrument` — Obsy
+
+Observability instrumentation campaign — one capable agent wires a
+repo for error tracking and standardized logs, one verified semantic
+commit at a time. `scope` is an open family list: *errors* (an SDK
+speaking the Sentry DSN protocol — Sentry AND GlitchTip — enabled
+only when the DSN env var is set, loud non-fatal init, release/
+environment tags, capture at process seams, flush on shutdown,
+scrubbing), *logs* (ONE central logging seam — extended, never
+replaced — leveled + structured, JSON by default on production
+surfaces, error→event / warn→breadcrumb coupling into the tracker),
+and opt-in *tracing* (Sentry-first transactions/spans, env-tunable
+sampling). A deterministic build/test gate + bounded continuation
+loop re-poke the campaign until every requested family is fully
+wired, tested and documented; an opt-in tail opens the pull request.
+
+- **Use when**:
+  Use to instrument a repository for observability: add Sentry/
+  GlitchTip-compatible error tracking, standardize logging onto one
+  structured lib with JSON output in production, or both (default
+  scope "errors,logs"; add "tracing" explicitly for performance
+  traces). Point repo-specific arbitrations (which module to extend,
+  which seams to wire) through `mission_notes`. Not the route for
+  general feature work (feature-dev) or for building dashboards —
+  this bot wires the emission side only.
+- **Vars**: `baseline` (string), `dsn_env_var` (string), `max_passes` (int), `mission_notes` (string), `mr_base` (string), `mr_branch` (string), `open_mr` (bool), `scope` (string), `scratch_dir` (string), `source_issue_ref` (string), `workspace_dir` (string)
+- **Path**: `bots/instrument/main.bot`
 
 ### `issue-triage` — Triagy
 

--- a/docs/bot-runs/README.md
+++ b/docs/bot-runs/README.md
@@ -73,6 +73,7 @@ first bilan for a bot lands.
 | Renovacy | `secured-renovacy` | dependency upgrade pipeline | [secured-renovacy.md](secured-renovacy.md) |
 | Bmady | `bmady` | BMAD multi-persona human-gated delivery | [bmady.md](bmady.md) |
 | Devy | `devbox-setup` | devbox.json bootstrap | [devbox-setup.md](devbox-setup.md) |
+| Obsy | `instrument` | observability instrumentation (Sentry/GlitchTip errors + JSON logs; opt-in tracing) | [instrument.md](instrument.md) |
 | Adry | `adr-cartograph` | ADR cartographer + completeness audit (idempotent) | [adr-cartograph.md](adr-cartograph.md) |
 | Vetty | `dep-update-guard` | Dependabot/Renovate PR guard (audit + align + deterministic verify) | [dep-update-guard.md](dep-update-guard.md) |
 | Acci | `rgaa-audit` | RGAA 4.1.2 accessibility audit (read-only) | [rgaa-audit.md](rgaa-audit.md) |

--- a/docs/bot-runs/instrument.md
+++ b/docs/bot-runs/instrument.md
@@ -82,3 +82,24 @@ logs; opt-in tracing).
   a repo this size; the docs' `iterion dispatch /nonexistent-config.yaml`
   smoke is the correct first live probe (a user-input error like a
   missing `.bot` is deliberately never reported).
+- Adversarial review (post-run, 3 parallel reviewers, executed proofs):
+  - *errtrack*: 2 high + 1 medium, all real — scrubFields was one level
+    deep (nested `password:` reached the transport, and a CYCLIC logged
+    value stack-overflowed the process via `%v`), event meta surfaces
+    (ServerName/Environment/Release/…) unscrubbed, common token shapes
+    (Slack/AIza/JWT/key=value) unmatched; plus bare `"auth"` in
+    sensitiveKeys over-redacted `pr_author`. All fixed with red-first
+    regression tests (commit on the instrumentation branch).
+  - *bundle*: 1 medium — the frictions-fix clause licensing the campaign
+    to EDIT verify.sh was a gate bypass (out-of-tree, invisible to the
+    in-loop review, probe-reused forever, vacuous on targets without a
+    CI drift gate; both halves executed). Reworded: the campaign may
+    only DELETE the script, verify_build re-authors it. + instrument
+    added to the verify_probe/verify_run guard-test lists; stale
+    byte-share header fixed in the bundle's forge-mr-create copy.
+  - *seams*: nothing high/critical — DSN-unset byte-parity, re-panic
+    semantics, 2s flush bound (measured 2.01s on a hanging ingest),
+    dispatch JSON default + human override all proven. Assumed as-is:
+    the documented Fatalf→degrade on the infallible embedded-SPA path,
+    the throwaway logger in claudesdk's defensive errorf, the discarded
+    per-surface ServerName on second Init (cosmetic).

--- a/docs/bot-runs/instrument.md
+++ b/docs/bot-runs/instrument.md
@@ -1,0 +1,84 @@
+# instrument (Obsy) — run bilans
+
+Newest first. Bot: [bots/instrument/](../../bots/instrument/) — observability
+instrumentation campaign (Sentry/GlitchTip error tracking + standardized
+logs; opt-in tracing).
+
+## 2026-08-19 — first dogfood: instrument iterion itself (run 01a01a51)
+
+- Status: **validated**
+- Versions: bot 0.1.0 (bundle commit `719f1af`) · iterion `ed7f6ecad` (v3.48.3)
+- Method: campaign/verify_build/review on claude_code · claude-opus-5
+  (effort high / medium / high), sandbox auto (repo devcontainer, devbox
+  toolchain), `--max-cost-usd 60 --merge-into none --var open_mr=false`,
+  `scope=errors,logs` (defaults), `mission_notes` = pre-arbitrated iterion
+  design (extend pkg/log; new pkg/errtrack on sentry-go; standard
+  SENTRY_* envs; seams: CLI main / gosafe / alert.Sink / server+runner+
+  dispatch; dispatch → JSON default; docs + ADR).
+- Result: **converged pass 3** (cap 6+1), $51.44, 95.4 min, 282k tokens.
+  18 instrumentation commits on `iterion/run/turbo-jolt-cryomantle-9c42`
+  (final `4e997cc`; PR tip `0929e8ee` — the last commit is a wip-banked
+  junk artifact, see friction 3). Host verification: full `task check`
+  green (vet, gofmt, golangci-lint, 128 test pkgs, goldens, studio
+  lint+tsc+vitest, pi-ext) at the PR tip.
+- Value: complete errors+logs instrumentation of iterion —
+  - `pkg/errtrack` (sentry-go v0.48.0 vendored): opt-in iff `SENTRY_DSN`,
+    loud non-fatal init, release `iterion@<version>+<commit>` from
+    appinfo, `SENTRY_ENVIRONMENT`, bounded `Flush(2s)`, key+value
+    secret/PII scrubbing (`BeforeSend`/`BeforeBreadcrumb`), test-only
+    `Transport` seam;
+  - `pkg/log` warn+ hook seam → error=event (fields as context),
+    warn=breadcrumb; "log lines never crash the producer" preserved
+    (panic-safe hook dispatch);
+  - capture seams: CLI top level (panic + fatal exit), `pkg/server`
+    gosafe + detached goroutines, cloudpublisher detached tasks, runner
+    background loops, `pkg/alert` errtrack sink (run_failed/stall/budget);
+  - logs: `iterion dispatch` now defaults to JSON like server/runner;
+    studio honours the log env vars; last stdlib `log` stragglers swept
+    onto the seam; a run's own log lines stay in process format;
+  - docs/observability.md runbook + ADR-088 + CLAUDE.md runbook-index
+    pointer + the Conventions line rewritten (no more "no structured
+    logging library");
+  - unit tests with an in-memory transport (no network, DSN-unset no-op
+    proof, scrubbing proof).
+  Live smoke (operator, post-run): fake local ingest ← `iterion dispatch
+  /nonexistent-config.yaml` with DSN ⇒ exactly one envelope
+  (`level:error`, `environment:smoke-test`, `release:iterion@…`); DSN
+  unset ⇒ byte-identical output + exit code, zero network.
+- Findings / misses: pass 1 under-reported honestly (1 slice + a precise
+  10-item plan — the contract's honesty clause working). Pass 3's fresh
+  re-read found seams the mission notes had NOT listed (runner bg loops,
+  server detached goroutines, run-log format interaction) — the
+  "fresh pass re-reads everything" design paying off. Nothing
+  over-claimed; review (in-loop, opus high) stayed clean and blocked
+  nothing.
+- Engine/bot hardening (frictions → fixes):
+  1. **verify.sh authored without `-buildvcs=false`** — go's VCS probe
+     fails (exit 128) in a sandboxed git worktree — and `verify_probe`
+     reuses any syntactically-valid script forever, so the gate could
+     never go green while the campaign kept (correctly) reporting
+     complete. Operator patched the script mid-run; bundle fix committed
+     (`22a9196`): the campaign contract now names the script path and
+     licenses fixing the SCRIPT when the failure is the gate's, and the
+     bundle's verify-build skill documents the GOFLAGS gotcha.
+     **Follow-up (fleet):** the other 10 `verify-build.md` copies
+     (4 variants) share the gap.
+  2. **Pass boundary on a dirty tree** — pass 1 ended mid-slice with an
+     un-vendored `go get` in the working tree; the deterministic gate
+     verifies the TREE, so the half-slice red it as noise (one wasted
+     verify cycle). Contract clause added (`22a9196`): end every pass on
+     a clean tree (finish or revert). **Follow-up (fleet):** feature-dev
+     and siblings share the exposure.
+  3. **finalizeWorktree wip-banked 8 junk files** —
+     `{e2e,pkg/*}/.claude/skills/deploy-target.md` mirrors (a skill from
+     another bundle, mirrored into sub-agents' working dirs; nested
+     `.claude/` is not gitignored, only the root one). Same junk sits
+     untracked in the operator's main workspace, so it predates this
+     run. The PR excludes the wip commit. **Follow-up (engine):**
+     gitignore `**/.claude/` (or stop mirroring into non-root cwds).
+- Lessons for next run: pre-arbitrated `mission_notes` are the quality
+  lever — the campaign executed a 10-point repo-specific design with
+  zero teach-back needed; `$60 / 3 passes` is the right budget shape for
+  a repo this size; the docs' `iterion dispatch /nonexistent-config.yaml`
+  smoke is the correct first live probe (a user-input error like a
+  missing `.bot` is deliberately never reported).


### PR DESCRIPTION
New catalog bot on the proven ADR-058 chassis (feature-dev/Billy shape): ONE adaptive `campaign` agent + deterministic build/test gate + in-loop adversarial review + bounded continuation loop + opt-in PR tail.

- **`scope` is an OPEN family list** (`errors,logs` default; `tracing` opt-in, Sentry-first) — adding a family or a stack is a skill file, zero DSL edits.
- **errors**: SDK speaking the Sentry DSN protocol (Sentry AND GlitchTip), enabled only when the DSN env var is set, loud non-fatal init, release/environment tags, process-seam capture, flush on shutdown, scrubbing.
- **logs**: one central logging seam (extend, never replace), JSON default on production surfaces, error→event / warn→breadcrumb coupling.
- Stack knowledge in skills (`lang-go/js/python`, `tracing`); verify/review/PR machinery byte-shared with feature-dev; instrument added to the verify_probe/verify_run guard-test lists.
- Catalog regenerated (whats-next + issue-triage copies).

**Validated by live dogfood on iterion itself** (run `01a01a51`: converged pass 3, $51.44 / 95 min, 18 commits — shipped as stacked PR on top of this one) — bilan in `docs/bot-runs/instrument.md`, including the post-run adversarial review whose gate-bypass finding is fixed here (the campaign may only DELETE verify.sh, never write it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)