### PR TITLE
chore(fleet): propagate the Obsy dogfood lessons across the campaign bots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,11 @@ e2e/.workspaces/
 # swept into a code bot's commit. (Surfaced by a docs-refresh dogfood run.)
 .claude/skills/
 
+# claude_code sub-invocations mirror skills into THEIR cwd too
+# (pkg/*/.claude/, e2e/.claude/), and a worktree finalize would
+# wip-bank that junk. .claude/ is runtime state at any depth.
+**/.claude/
+
 # docs-refresh bot cache (neutral repo-root dotfile it writes by design)
 .docs-refresh-cache.json
 

--- a/bots/adr-cartograph/skills/verify-build.md
+++ b/bots/adr-cartograph/skills/verify-build.md
@@ -51,6 +51,13 @@ and the correct toolchain:
     the real toolchain (`go`, `node`, `cargo`, `python`) directly on `PATH`, so
     you may fall back ONCE to the bare tool — `command -v go && go build ./...
     && go test ./...` — rather than retrying the wrapper.
+- **Go in a sandboxed git worktree: disable VCS stamping.** The run's
+  workspace is a git *worktree* whose gitdir lives outside the sandbox
+  mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
+  status: exit status 128` even though git itself works. Put
+  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  binary's stamped identity is irrelevant to a build+test gate.
+  (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**
   - Go (`go.mod`): `go build ./... && go test ./...`
   - Node (`package.json`): pick the package manager from the lockfile

--- a/bots/app-dev/main.bot
+++ b/bots/app-dev/main.bot
@@ -287,6 +287,11 @@ prompt campaign_system:
      durable state: an interrupted run keeps every committed slice,
      and a fresh pass reads `git log` and continues. No worklist /
      cursor files.
+     END EVERY PASS ON A CLEAN TREE: if you must stop mid-slice,
+     either finish it to committable or revert/stash the in-progress
+     edits — the deterministic gate verifies the WORKING TREE, and a
+     half-done slice (an un-vendored dependency, a dangling import)
+     reds the gate as noise.
 
   4. BASELINE — don't chase failures you didn't cause. Pre-existing
      failures are in your user prompt (`baseline`) — greenfield runs

--- a/bots/app-dev/skills/forge-mr-create.md
+++ b/bots/app-dev/skills/forge-mr-create.md
@@ -3,14 +3,16 @@ name: forge-mr-create
 description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
 ---
 
-<!-- DUPLICATE — one of five byte-identical copies (iterion has no
+<!-- DUPLICATE — byte-identical copies across bundles (iterion has no
      skill-sharing primitive; see CLAUDE.md "If a skill ends up duplicated
-     across multiple bundles"). Edit one, edit all five:
+     across multiple bundles"). Edit one, edit the others:
        bots/app-dev/skills/forge-mr-create.md
        bots/branch-improve-loop/skills/forge-mr-create.md
-       bots/docs-refresh/skills/forge-mr-create.md
        bots/feature-dev/skills/forge-mr-create.md
-       bots/whole-improve-loop/skills/forge-mr-create.md -->
+       bots/instrument/skills/forge-mr-create.md
+       bots/whole-improve-loop/skills/forge-mr-create.md
+     bots/docs-refresh/skills/forge-mr-create.md has DIVERGED (its own
+     amend-mode delta) — do not blind-sync that one. -->
 
 # Opening a pull request from a finished run
 

--- a/bots/app-dev/skills/verify-build.md
+++ b/bots/app-dev/skills/verify-build.md
@@ -51,6 +51,13 @@ and the correct toolchain:
     the real toolchain (`go`, `node`, `cargo`, `python`) directly on `PATH`, so
     you may fall back ONCE to the bare tool — `command -v go && go build ./...
     && go test ./...` — rather than retrying the wrapper.
+- **Go in a sandboxed git worktree: disable VCS stamping.** The run's
+  workspace is a git *worktree* whose gitdir lives outside the sandbox
+  mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
+  status: exit status 128` even though git itself works. Put
+  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  binary's stamped identity is irrelevant to a build+test gate.
+  (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**
   - Go (`go.mod`): `go build ./... && go test ./...`
   - Node (`package.json`): pick the package manager from the lockfile

--- a/bots/branch-improve-loop/main.bot
+++ b/bots/branch-improve-loop/main.bot
@@ -276,6 +276,11 @@ prompt campaign_system:
      reads `git log`, re-diffs the branch, and continues where you left off.
      Do NOT keep a separate worklist / cursor file — the todo list lives in
      your working memory, the commits are the record.
+     END EVERY PASS ON A CLEAN TREE: if you must stop mid-fix, either
+     finish it to committable or revert/stash the in-progress edits —
+     the deterministic gate verifies the WORKING TREE, and a half-done
+     fix (an un-vendored dependency, a dangling import) reds the gate
+     as noise.
 
   4. BASELINE — don't chase failures the branch didn't cause. Pre-existing
      test failures / known-flaky tests are in your user prompt (`baseline`).

--- a/bots/branch-improve-loop/skills/forge-mr-create.md
+++ b/bots/branch-improve-loop/skills/forge-mr-create.md
@@ -3,14 +3,16 @@ name: forge-mr-create
 description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
 ---
 
-<!-- DUPLICATE — one of five byte-identical copies (iterion has no
+<!-- DUPLICATE — byte-identical copies across bundles (iterion has no
      skill-sharing primitive; see CLAUDE.md "If a skill ends up duplicated
-     across multiple bundles"). Edit one, edit all five:
+     across multiple bundles"). Edit one, edit the others:
        bots/app-dev/skills/forge-mr-create.md
        bots/branch-improve-loop/skills/forge-mr-create.md
-       bots/docs-refresh/skills/forge-mr-create.md
        bots/feature-dev/skills/forge-mr-create.md
-       bots/whole-improve-loop/skills/forge-mr-create.md -->
+       bots/instrument/skills/forge-mr-create.md
+       bots/whole-improve-loop/skills/forge-mr-create.md
+     bots/docs-refresh/skills/forge-mr-create.md has DIVERGED (its own
+     amend-mode delta) — do not blind-sync that one. -->
 
 # Opening a pull request from a finished run
 

--- a/bots/branch-improve-loop/skills/verify-build.md
+++ b/bots/branch-improve-loop/skills/verify-build.md
@@ -51,6 +51,13 @@ and the correct toolchain:
     the real toolchain (`go`, `node`, `cargo`, `python`) directly on `PATH`, so
     you may fall back ONCE to the bare tool — `command -v go && go build ./...
     && go test ./...` — rather than retrying the wrapper.
+- **Go in a sandboxed git worktree: disable VCS stamping.** The run's
+  workspace is a git *worktree* whose gitdir lives outside the sandbox
+  mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
+  status: exit status 128` even though git itself works. Put
+  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  binary's stamped identity is irrelevant to a build+test gate.
+  (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**
   - Go (`go.mod`): `go build ./... && go test ./...`
   - Node (`package.json`): pick the package manager from the lockfile

--- a/bots/dep-update-guard/skills/verify-build.md
+++ b/bots/dep-update-guard/skills/verify-build.md
@@ -51,6 +51,13 @@ and the correct toolchain:
     the real toolchain (`go`, `node`, `cargo`, `python`) directly on `PATH`, so
     you may fall back ONCE to the bare tool — `command -v go && go build ./...
     && go test ./...` — rather than retrying the wrapper.
+- **Go in a sandboxed git worktree: disable VCS stamping.** The run's
+  workspace is a git *worktree* whose gitdir lives outside the sandbox
+  mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
+  status: exit status 128` even though git itself works. Put
+  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  binary's stamped identity is irrelevant to a build+test gate.
+  (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**
   - Go (`go.mod`): `go build ./... && go test ./...`
   - Node (`package.json`): pick the package manager from the lockfile

--- a/bots/e2e-coverage/main.bot
+++ b/bots/e2e-coverage/main.bot
@@ -218,6 +218,11 @@ prompt campaign_system:
      git IS your durable state: an interrupted run keeps every
      committed test, and a fresh pass reads the matrix + `git log` and
      continues where you left off.
+     END EVERY PASS ON A CLEAN TREE: if you must stop mid-gap, either
+     finish it to committable or revert/stash the in-progress edits —
+     the deterministic gate verifies the WORKING TREE, and a half-done
+     gap (an un-vendored dependency, a dangling import) reds the gate
+     as noise.
 
   5. DO NOT CHANGE PRODUCT CODE to make a test pass — that inverts the
      dependency. The ONLY exception is a genuine, separately-flagged

--- a/bots/e2e-coverage/skills/verify-build.md
+++ b/bots/e2e-coverage/skills/verify-build.md
@@ -52,6 +52,13 @@ and the correct toolchain:
     the real toolchain (`go`, `node`, `cargo`, `python`) directly on `PATH`, so
     you may fall back ONCE to the bare tool — `command -v go && go build ./...
     && go test ./...` — rather than retrying the wrapper.
+- **Go in a sandboxed git worktree: disable VCS stamping.** The run's
+  workspace is a git *worktree* whose gitdir lives outside the sandbox
+  mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
+  status: exit status 128` even though git itself works. Put
+  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  binary's stamped identity is irrelevant to a build+test gate.
+  (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**
   - Go (`go.mod`): `go build ./... && go test ./...`
   - Node (`package.json`): pick the package manager from the lockfile

--- a/bots/feature-dev/main.bot
+++ b/bots/feature-dev/main.bot
@@ -190,6 +190,11 @@ prompt campaign_system:
      where you left off. Do NOT keep a separate worklist / cursor file —
      the todo list lives in your working memory, the commits are the
      record.
+     END EVERY PASS ON A CLEAN TREE: if you must stop mid-slice,
+     either finish it to committable or revert/stash the in-progress
+     edits — the deterministic gate verifies the WORKING TREE, and a
+     half-done slice (an un-vendored dependency, a dangling import)
+     reds the gate as noise.
 
   4. BASELINE — don't chase failures you didn't cause. Pre-existing test
      failures / known-flaky tests are in your user prompt (`baseline`).

--- a/bots/feature-dev/skills/forge-mr-create.md
+++ b/bots/feature-dev/skills/forge-mr-create.md
@@ -3,14 +3,16 @@ name: forge-mr-create
 description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
 ---
 
-<!-- DUPLICATE — one of five byte-identical copies (iterion has no
+<!-- DUPLICATE — byte-identical copies across bundles (iterion has no
      skill-sharing primitive; see CLAUDE.md "If a skill ends up duplicated
-     across multiple bundles"). Edit one, edit all five:
+     across multiple bundles"). Edit one, edit the others:
        bots/app-dev/skills/forge-mr-create.md
        bots/branch-improve-loop/skills/forge-mr-create.md
-       bots/docs-refresh/skills/forge-mr-create.md
        bots/feature-dev/skills/forge-mr-create.md
-       bots/whole-improve-loop/skills/forge-mr-create.md -->
+       bots/instrument/skills/forge-mr-create.md
+       bots/whole-improve-loop/skills/forge-mr-create.md
+     bots/docs-refresh/skills/forge-mr-create.md has DIVERGED (its own
+     amend-mode delta) — do not blind-sync that one. -->
 
 # Opening a pull request from a finished run
 

--- a/bots/feature-dev/skills/verify-build.md
+++ b/bots/feature-dev/skills/verify-build.md
@@ -51,6 +51,13 @@ and the correct toolchain:
     the real toolchain (`go`, `node`, `cargo`, `python`) directly on `PATH`, so
     you may fall back ONCE to the bare tool — `command -v go && go build ./...
     && go test ./...` — rather than retrying the wrapper.
+- **Go in a sandboxed git worktree: disable VCS stamping.** The run's
+  workspace is a git *worktree* whose gitdir lives outside the sandbox
+  mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
+  status: exit status 128` even though git itself works. Put
+  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  binary's stamped identity is irrelevant to a build+test gate.
+  (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**
   - Go (`go.mod`): `go build ./... && go test ./...`
   - Node (`package.json`): pick the package manager from the lockfile

--- a/bots/feature-gap-fill/main.bot
+++ b/bots/feature-gap-fill/main.bot
@@ -180,6 +180,11 @@ prompt campaign_system:
      `git log`, re-checks the spec, and continues where you left off. Do
      NOT keep a separate worklist / cursor file — the todo list lives in
      your working memory, the commits are the record.
+     END EVERY PASS ON A CLEAN TREE: if you must stop mid-item, either
+     finish it to committable or revert/stash the in-progress edits —
+     the deterministic gate verifies the WORKING TREE, and a half-done
+     item (an un-vendored dependency, a dangling import) reds the gate
+     as noise.
 
   4. PRESERVATION DISCIPLINE — the gap spec's `implemented` items are
      load-bearing. Do NOT touch them unless directly required to wire up

--- a/bots/feature-gap-fill/skills/verify-build.md
+++ b/bots/feature-gap-fill/skills/verify-build.md
@@ -51,6 +51,13 @@ and the correct toolchain:
     the real toolchain (`go`, `node`, `cargo`, `python`) directly on `PATH`, so
     you may fall back ONCE to the bare tool — `command -v go && go build ./...
     && go test ./...` — rather than retrying the wrapper.
+- **Go in a sandboxed git worktree: disable VCS stamping.** The run's
+  workspace is a git *worktree* whose gitdir lives outside the sandbox
+  mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
+  status: exit status 128` even though git itself works. Put
+  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  binary's stamped identity is irrelevant to a build+test gate.
+  (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**
   - Go (`go.mod`): `go build ./... && go test ./...`
   - Node (`package.json`): pick the package manager from the lockfile

--- a/bots/instrument/skills/verify-build.md
+++ b/bots/instrument/skills/verify-build.md
@@ -39,13 +39,6 @@ and the correct toolchain:
   `go.mod`'s `go` directive is newer than the installed `go version`, use the
   project's wrapper (e.g. `devbox run -- go …`) or `GOTOOLCHAIN=auto go …` so
   the pinned toolchain is fetched, rather than failing on "requires go >= X".
-- **Go in a sandboxed git worktree: disable VCS stamping.** The run's
-  workspace is a git *worktree* whose gitdir lives outside the sandbox
-  mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
-  status: exit status 128` even though git itself works. Put
-  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
-  binary's stamped identity is irrelevant to a build+test gate.
-  (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
   - **devbox is first-class inside the iterion sandbox** — when the repo
     pins its toolchain via `devbox.json`, prefer `devbox run -- …`; the engine
     lays the whole `$HOME` subtree user-writable so the wrapper's cache/home
@@ -58,6 +51,13 @@ and the correct toolchain:
     the real toolchain (`go`, `node`, `cargo`, `python`) directly on `PATH`, so
     you may fall back ONCE to the bare tool — `command -v go && go build ./...
     && go test ./...` — rather than retrying the wrapper.
+- **Go in a sandboxed git worktree: disable VCS stamping.** The run's
+  workspace is a git *worktree* whose gitdir lives outside the sandbox
+  mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
+  status: exit status 128` even though git itself works. Put
+  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  binary's stamped identity is irrelevant to a build+test gate.
+  (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**
   - Go (`go.mod`): `go build ./... && go test ./...`
   - Node (`package.json`): pick the package manager from the lockfile

--- a/bots/secured-renovacy/main.bot
+++ b/bots/secured-renovacy/main.bot
@@ -1456,6 +1456,11 @@ prompt p2_campaign_system:
   3. COMMIT EACH FIX AS YOU FINISH IT (`git add -A` so new files
      land) — git is the durable state; a later pass reads `git log`
      and continues.
+     END EVERY PASS ON A CLEAN TREE: if you must stop mid-fix, either
+     finish it to committable or revert/stash the in-progress edits —
+     the deterministic gate verifies the WORKING TREE, and a half-done
+     fix (an un-vendored dependency, a dangling import) reds the gate
+     as noise.
   4. BASELINE — a failure that also occurs at `base_sha` (attribute
      cheaply once, then move on) predates this run: note it, never
      chase it. Fix only what the RUN's changes broke or left.

--- a/bots/secured-renovacy/skills/verify-build.md
+++ b/bots/secured-renovacy/skills/verify-build.md
@@ -51,6 +51,13 @@ and the correct toolchain:
     the real toolchain (`go`, `node`, `cargo`, `python`) directly on `PATH`, so
     you may fall back ONCE to the bare tool — `command -v go && go build ./...
     && go test ./...` — rather than retrying the wrapper.
+- **Go in a sandboxed git worktree: disable VCS stamping.** The run's
+  workspace is a git *worktree* whose gitdir lives outside the sandbox
+  mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
+  status: exit status 128` even though git itself works. Put
+  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  binary's stamped identity is irrelevant to a build+test gate.
+  (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**
   - Go (`go.mod`): `go build ./... && go test ./...`
   - Node (`package.json`): pick the package manager from the lockfile

--- a/bots/test-coverage/main.bot
+++ b/bots/test-coverage/main.bot
@@ -193,6 +193,11 @@ prompt campaign_system:
      interrupted run keeps every test you committed, and a fresh pass
      just reads `git log` and continues where you left off. Do NOT keep a
      separate worklist / cursor file.
+     END EVERY PASS ON A CLEAN TREE: if you must stop mid-gap, either
+     finish it to committable or revert/stash the in-progress edits —
+     the deterministic gate verifies the WORKING TREE, and a half-done
+     gap (an un-vendored dependency, a dangling import) reds the gate
+     as noise.
 
   4. DO NOT CHANGE THE CODE UNDER TEST to make a test pass — that inverts
      the dependency. The ONLY exception is a genuine, separately-flagged

--- a/bots/test-coverage/skills/verify-build.md
+++ b/bots/test-coverage/skills/verify-build.md
@@ -56,6 +56,13 @@ and the correct toolchain:
     the real toolchain (`go`, `node`, `cargo`, `python`) directly on `PATH`, so
     you may fall back ONCE to the bare tool — `command -v go && go build ./...
     && go test ./...` — rather than retrying the wrapper.
+- **Go in a sandboxed git worktree: disable VCS stamping.** The run's
+  workspace is a git *worktree* whose gitdir lives outside the sandbox
+  mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
+  status: exit status 128` even though git itself works. Put
+  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  binary's stamped identity is irrelevant to a build+test gate.
+  (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**
   - Go (`go.mod`): `go build ./... && go test ./...`
   - Node (`package.json`): pick the package manager from the lockfile

--- a/bots/whole-improve-loop/main.bot
+++ b/bots/whole-improve-loop/main.bot
@@ -188,6 +188,11 @@ prompt campaign_system:
      reads `git log` and continues where you left off. Do NOT keep a separate
      worklist / cursor file — the todo list lives in your working memory, the
      commits are the record.
+     END EVERY PASS ON A CLEAN TREE: if you must stop mid-site, either
+     finish it to committable or revert/stash the in-progress edits —
+     the deterministic gate verifies the WORKING TREE, and a half-done
+     site (an un-vendored dependency, a dangling import) reds the gate
+     as noise.
 
   4. BASELINE — don't chase failures you didn't cause. Pre-existing test
      failures / known-flaky tests are in your user prompt (`baseline`). Do NOT

--- a/bots/whole-improve-loop/skills/forge-mr-create.md
+++ b/bots/whole-improve-loop/skills/forge-mr-create.md
@@ -3,14 +3,16 @@ name: forge-mr-create
 description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
 ---
 
-<!-- DUPLICATE — one of five byte-identical copies (iterion has no
+<!-- DUPLICATE — byte-identical copies across bundles (iterion has no
      skill-sharing primitive; see CLAUDE.md "If a skill ends up duplicated
-     across multiple bundles"). Edit one, edit all five:
+     across multiple bundles"). Edit one, edit the others:
        bots/app-dev/skills/forge-mr-create.md
        bots/branch-improve-loop/skills/forge-mr-create.md
-       bots/docs-refresh/skills/forge-mr-create.md
        bots/feature-dev/skills/forge-mr-create.md
-       bots/whole-improve-loop/skills/forge-mr-create.md -->
+       bots/instrument/skills/forge-mr-create.md
+       bots/whole-improve-loop/skills/forge-mr-create.md
+     bots/docs-refresh/skills/forge-mr-create.md has DIVERGED (its own
+     amend-mode delta) — do not blind-sync that one. -->
 
 # Opening a pull request from a finished run
 

--- a/bots/whole-improve-loop/skills/verify-build.md
+++ b/bots/whole-improve-loop/skills/verify-build.md
@@ -51,6 +51,13 @@ and the correct toolchain:
     the real toolchain (`go`, `node`, `cargo`, `python`) directly on `PATH`, so
     you may fall back ONCE to the bare tool — `command -v go && go build ./...
     && go test ./...` — rather than retrying the wrapper.
+- **Go in a sandboxed git worktree: disable VCS stamping.** The run's
+  workspace is a git *worktree* whose gitdir lives outside the sandbox
+  mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
+  status: exit status 128` even though git itself works. Put
+  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  binary's stamped identity is irrelevant to a build+test gate.
+  (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**
   - Go (`go.mod`): `go build ./... && go test ./...`
   - Node (`package.json`): pick the package manager from the lockfile


### PR DESCRIPTION
Spreads the three lessons paid for by the instrument bot's first dogfood (run `01a01a51`, bilan in `docs/bot-runs/instrument.md`) from `bots/instrument` to the whole fleet:

- **verify-build skill, all 11 copies**: `export GOFLAGS="-buildvcs=false"` in verify.sh — go's VCS probe fails (exit 128) in a sandboxed git worktree; the dogfood gate burned a pass rediscovering it. instrument's copy re-anchored so every copy carries the block at the same spot.
- **8 build-gated campaign contracts** (feature-dev, whole/branch-improve-loop, feature-gap-fill, test-coverage, e2e-coverage, app-dev, secured-renovacy): *end every pass on a clean tree* — a half-done unit left uncommitted reds the deterministic gate as noise (observed: pass 1's un-vendored `go get`).
- **forge-mr-create duplicate header**: resynced byte-identical across the 5 shared copies (md5-verified), naming all six and flagging docs-refresh's deliberate divergence.
- **.gitignore `**/.claude/`**: claude_code sub-invocations mirror skills into their own cwd (`pkg/*/.claude/`, `e2e/.claude/`) and a worktree finalize wip-banked that junk into a run's storage branch.

Full `go test ./bots/` green (ratchet-clause guards, drift tails, universality, bundle consistency); no engine code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)