### PR TITLE
fix(fleet): fold Revi's advisory findings into the follow-ups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,8 +146,12 @@ e2e/.workspaces/
 
 # claude_code sub-invocations mirror skills into THEIR cwd too
 # (pkg/*/.claude/, e2e/.claude/), and a worktree finalize would
-# wip-bank that junk. .claude/ is runtime state at any depth.
+# wip-bank that junk. .claude/ is runtime state at any depth — except
+# the vendored codex fork, whose committed .claude/rules/ are its own
+# project content (re-included below; tracked files are unaffected by
+# ignore rules either way, the exception keeps future adds friction-free).
 **/.claude/
+!third_party/codex-agent-sdk-go/.claude/
 
 # docs-refresh bot cache (neutral repo-root dotfile it writes by design)
 .docs-refresh-cache.json

--- a/.gitignore
+++ b/.gitignore
@@ -147,13 +147,13 @@ e2e/.workspaces/
 # claude_code sub-invocations mirror skills into THEIR cwd too
 # (pkg/*/.claude/, e2e/.claude/), and a worktree finalize would
 # wip-bank that junk. .claude/ is runtime state at any depth — except
-# the vendored codex fork, whose committed .claude/rules/ are its own
-# project content (re-included below; tracked files are unaffected by
-# ignore rules either way, the exception keeps future adds friction-free).
-# The exception is narrowed to rules/ ONLY: the fork is an active work
-# target, so a bare `!…/.claude/` would re-open the wip-bank hole there
-# for the very runtime junk (skills/, *.local.json) this rule exists to
-# stop — git must descend into the dir, then re-ignore its other children.
+# the vendored codex fork's committed .claude/rules/, which is its own
+# project content. The exception is deliberately narrow: the fork is an
+# active work target, so a bare `!…/.claude/` would re-open the wip-bank
+# hole there for the very junk (skills/, *.local.json) this rule stops.
+# Hence three lines — descend into the dir, re-ignore its other children,
+# re-include rules/. (Tracked files are unaffected by ignore rules either
+# way; the exception keeps future adds under rules/ friction-free.)
 **/.claude/
 !third_party/codex-agent-sdk-go/.claude/
 third_party/codex-agent-sdk-go/.claude/*

--- a/.gitignore
+++ b/.gitignore
@@ -150,8 +150,14 @@ e2e/.workspaces/
 # the vendored codex fork, whose committed .claude/rules/ are its own
 # project content (re-included below; tracked files are unaffected by
 # ignore rules either way, the exception keeps future adds friction-free).
+# The exception is narrowed to rules/ ONLY: the fork is an active work
+# target, so a bare `!…/.claude/` would re-open the wip-bank hole there
+# for the very runtime junk (skills/, *.local.json) this rule exists to
+# stop — git must descend into the dir, then re-ignore its other children.
 **/.claude/
 !third_party/codex-agent-sdk-go/.claude/
+third_party/codex-agent-sdk-go/.claude/*
+!third_party/codex-agent-sdk-go/.claude/rules/
 
 # docs-refresh bot cache (neutral repo-root dotfile it writes by design)
 .docs-refresh-cache.json

--- a/bots/adr-cartograph/skills/verify-build.md
+++ b/bots/adr-cartograph/skills/verify-build.md
@@ -55,7 +55,8 @@ and the correct toolchain:
   workspace is a git *worktree* whose gitdir lives outside the sandbox
   mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
   status: exit status 128` even though git itself works. Put
-  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  `export GOFLAGS="${GOFLAGS:+$GOFLAGS }-buildvcs=false"` at the top
+  of verify.sh (append — never clobber an inherited GOFLAGS) — the
   binary's stamped identity is irrelevant to a build+test gate.
   (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**

--- a/bots/app-dev/main.bot
+++ b/bots/app-dev/main.bot
@@ -289,7 +289,9 @@ prompt campaign_system:
      cursor files.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-slice,
      either finish it to committable or discard the in-progress edits
-     — the deterministic gate verifies the WORKING TREE, and a half-
+     — `git restore -- <the paths you touched>`, never a blanket
+     `git clean` (the workspace may be the operator's own checkout).
+     The deterministic gate verifies the WORKING TREE, and a half-
      done slice (an un-vendored dependency, a dangling import) reds
      the gate as noise.
 

--- a/bots/app-dev/main.bot
+++ b/bots/app-dev/main.bot
@@ -288,10 +288,10 @@ prompt campaign_system:
      and a fresh pass reads `git log` and continues. No worklist /
      cursor files.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-slice,
-     either finish it to committable or revert/stash the in-progress
-     edits — the deterministic gate verifies the WORKING TREE, and a
-     half-done slice (an un-vendored dependency, a dangling import)
-     reds the gate as noise.
+     either finish it to committable or discard the in-progress edits
+     — the deterministic gate verifies the WORKING TREE, and a half-
+     done slice (an un-vendored dependency, a dangling import) reds
+     the gate as noise.
 
   4. BASELINE — don't chase failures you didn't cause. Pre-existing
      failures are in your user prompt (`baseline`) — greenfield runs

--- a/bots/app-dev/skills/verify-build.md
+++ b/bots/app-dev/skills/verify-build.md
@@ -55,7 +55,8 @@ and the correct toolchain:
   workspace is a git *worktree* whose gitdir lives outside the sandbox
   mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
   status: exit status 128` even though git itself works. Put
-  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  `export GOFLAGS="${GOFLAGS:+$GOFLAGS }-buildvcs=false"` at the top
+  of verify.sh (append — never clobber an inherited GOFLAGS) — the
   binary's stamped identity is irrelevant to a build+test gate.
   (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**

--- a/bots/branch-improve-loop/main.bot
+++ b/bots/branch-improve-loop/main.bot
@@ -277,10 +277,12 @@ prompt campaign_system:
      Do NOT keep a separate worklist / cursor file — the todo list lives in
      your working memory, the commits are the record.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-fix, either
-     finish it to committable or discard the in-progress edits — the
-     deterministic gate verifies the WORKING TREE, and a half-done fix
-     (an un-vendored dependency, a dangling import) reds the gate as
-     noise.
+     finish it to committable or discard the in-progress edits —
+     `git restore -- <the paths you touched>`, never a blanket
+     `git clean` (the workspace may be the operator's own checkout).
+     The deterministic gate verifies the WORKING TREE, and a half-done
+     fix (an un-vendored dependency, a dangling import) reds the gate
+     as noise.
 
   4. BASELINE — don't chase failures the branch didn't cause. Pre-existing
      test failures / known-flaky tests are in your user prompt (`baseline`).

--- a/bots/branch-improve-loop/main.bot
+++ b/bots/branch-improve-loop/main.bot
@@ -277,10 +277,10 @@ prompt campaign_system:
      Do NOT keep a separate worklist / cursor file — the todo list lives in
      your working memory, the commits are the record.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-fix, either
-     finish it to committable or revert/stash the in-progress edits —
-     the deterministic gate verifies the WORKING TREE, and a half-done
-     fix (an un-vendored dependency, a dangling import) reds the gate
-     as noise.
+     finish it to committable or discard the in-progress edits — the
+     deterministic gate verifies the WORKING TREE, and a half-done fix
+     (an un-vendored dependency, a dangling import) reds the gate as
+     noise.
 
   4. BASELINE — don't chase failures the branch didn't cause. Pre-existing
      test failures / known-flaky tests are in your user prompt (`baseline`).

--- a/bots/branch-improve-loop/skills/verify-build.md
+++ b/bots/branch-improve-loop/skills/verify-build.md
@@ -55,7 +55,8 @@ and the correct toolchain:
   workspace is a git *worktree* whose gitdir lives outside the sandbox
   mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
   status: exit status 128` even though git itself works. Put
-  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  `export GOFLAGS="${GOFLAGS:+$GOFLAGS }-buildvcs=false"` at the top
+  of verify.sh (append — never clobber an inherited GOFLAGS) — the
   binary's stamped identity is irrelevant to a build+test gate.
   (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**

--- a/bots/clean_tree_clause_test.go
+++ b/bots/clean_tree_clause_test.go
@@ -1,0 +1,102 @@
+package bots
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Every campaign contract ends its commit-in-stride rule with a clean-tree
+// clause: the deterministic gate verifies the WORKING TREE, so a pass that
+// stops mid-unit must not leave half-done edits behind to red it as noise.
+//
+// The clause tells the agent to DISCARD those edits, and that instruction is
+// only as safe as the verb it names. Two ways to get it wrong, both already
+// observed in this file's history:
+//
+//   - Name no verb at all ("discard the in-progress edits"). `git stash` then
+//     reads as a perfectly reasonable choice — and a run worktree shares
+//     `refs/stash` with the operator's repo, so a run that dies between the
+//     stash and its pop strands their tree with a ref they never made.
+//   - Leave `git clean` un-negated. Several campaign bots run in the
+//     operator's live checkout, where a blanket clean deletes THEIR untracked
+//     files, not the run's.
+//
+// This is an ANTI-REGRESSION guard in the shape of ratchet_clause_test.go's,
+// with the same known limit: a grep cannot tell a rule from a quotation of
+// one. It catches the likely regression — a reflow or a tightening that drops
+// the verb — not a semantic inversion. Reword on purpose and update the
+// expectation in the same change.
+var cleanTreeCarriers = []string{
+	"app-dev/main.bot",
+	"branch-improve-loop/main.bot",
+	"e2e-coverage/main.bot",
+	"feature-dev/main.bot",
+	"feature-gap-fill/main.bot",
+	"instrument/main.bot",
+	"secured-renovacy/main.bot",
+	"test-coverage/main.bot",
+	"whole-improve-loop/main.bot",
+}
+
+const cleanTreeMarker = "END EVERY PASS ON A CLEAN TREE:"
+
+// numberedBullet ends the clause at the contract's next rule, for the
+// carriers whose clean-tree paragraph is not followed by a blank line.
+var numberedBullet = regexp.MustCompile(`^\d+\. `)
+
+// cleanTreeClause returns the clause, lower-cased, stripped of backticks and
+// whitespace-collapsed, so an assertion matches regardless of where the
+// prompt's line wrapping falls. Truncating early can only make an assertion
+// FAIL, never silently pass — every one below asserts presence.
+func cleanTreeClause(t *testing.T, botPath string) string {
+	t.Helper()
+	src, err := os.ReadFile(botPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", botPath, err)
+	}
+	_, after, found := strings.Cut(string(src), cleanTreeMarker)
+	if !found {
+		t.Fatalf("%s: no %q clause — the campaign no longer tells the agent "+
+			"to end a pass on a tree the deterministic gate can read",
+			botPath, cleanTreeMarker)
+	}
+	body := []string{strings.TrimSpace(strings.Split(after, "\n")[0])}
+	for _, line := range strings.Split(after, "\n")[1:] {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || numberedBullet.MatchString(trimmed) {
+			break
+		}
+		body = append(body, trimmed)
+	}
+	clause := strings.Join(body, " ")
+	ornament := strings.NewReplacer("`", "", "*", "", "’", "'")
+	return strings.Join(strings.Fields(ornament.Replace(strings.ToLower(clause))), " ")
+}
+
+func TestCleanTreeClauseNamesASafeDiscardVerb(t *testing.T) {
+	for _, bot := range cleanTreeCarriers {
+		t.Run(bot, func(t *testing.T) {
+			clause := cleanTreeClause(t, bot)
+
+			// A named verb. Without one the agent picks its own, and the
+			// obvious pick writes to a ref shared with the operator's repo.
+			if !strings.Contains(clause, "git restore") {
+				t.Errorf("clean-tree clause names no restore command.\n"+
+					"  Why it is there: an unnamed \"discard\" leaves `git stash` "+
+					"as a reasonable reading, and a run worktree shares refs/stash "+
+					"with the operator's repo.\n  Clause as parsed: %q", clause)
+			}
+
+			// A blanket clean, un-negated, is worse than the stash it replaced:
+			// on an in-place run it deletes the operator's own untracked files.
+			if offenders := unNegatedMentions(clause, "git clean"); len(offenders) > 0 {
+				t.Errorf("clean-tree clause mentions `git clean` un-negated %d time(s).\n"+
+					"  Why it is guarded: the workspace may be the operator's own "+
+					"checkout, where a blanket clean deletes THEIR untracked files.\n"+
+					"  Context before each mention: %q", len(offenders), offenders)
+			}
+		})
+	}
+}

--- a/bots/dep-update-guard/skills/verify-build.md
+++ b/bots/dep-update-guard/skills/verify-build.md
@@ -55,7 +55,8 @@ and the correct toolchain:
   workspace is a git *worktree* whose gitdir lives outside the sandbox
   mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
   status: exit status 128` even though git itself works. Put
-  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  `export GOFLAGS="${GOFLAGS:+$GOFLAGS }-buildvcs=false"` at the top
+  of verify.sh (append — never clobber an inherited GOFLAGS) — the
   binary's stamped identity is irrelevant to a build+test gate.
   (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**

--- a/bots/docs-refresh/skills/forge-mr-create.md
+++ b/bots/docs-refresh/skills/forge-mr-create.md
@@ -3,14 +3,13 @@ name: forge-mr-create
 description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
 ---
 
-<!-- DUPLICATE — one of five byte-identical copies (iterion has no
-     skill-sharing primitive; see CLAUDE.md "If a skill ends up duplicated
-     across multiple bundles"). Edit one, edit all five:
-       bots/app-dev/skills/forge-mr-create.md
-       bots/branch-improve-loop/skills/forge-mr-create.md
-       bots/docs-refresh/skills/forge-mr-create.md
-       bots/feature-dev/skills/forge-mr-create.md
-       bots/whole-improve-loop/skills/forge-mr-create.md -->
+<!-- DIVERGED copy — this file carries docs-refresh's own amend-mode
+     delta on top of the skill the other bundles byte-share (iterion has
+     no skill-sharing primitive; see CLAUDE.md "If a skill ends up
+     duplicated across multiple bundles"). Do NOT blind-sync it from the
+     shared copies (app-dev / branch-improve-loop / feature-dev /
+     instrument / whole-improve-loop) — port shared fixes by hand and
+     keep the delta. -->
 
 # Opening a pull request from a finished run
 

--- a/bots/e2e-coverage/main.bot
+++ b/bots/e2e-coverage/main.bot
@@ -219,10 +219,10 @@ prompt campaign_system:
      committed test, and a fresh pass reads the matrix + `git log` and
      continues where you left off.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-gap, either
-     finish it to committable or revert/stash the in-progress edits —
-     the deterministic gate verifies the WORKING TREE, and a half-done
-     gap (an un-vendored dependency, a dangling import) reds the gate
-     as noise.
+     finish it to committable or discard the in-progress edits — the
+     deterministic gate verifies the WORKING TREE, and a half-done gap
+     (an un-vendored dependency, a dangling import) reds the gate as
+     noise.
 
   5. DO NOT CHANGE PRODUCT CODE to make a test pass — that inverts the
      dependency. The ONLY exception is a genuine, separately-flagged

--- a/bots/e2e-coverage/main.bot
+++ b/bots/e2e-coverage/main.bot
@@ -219,10 +219,12 @@ prompt campaign_system:
      committed test, and a fresh pass reads the matrix + `git log` and
      continues where you left off.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-gap, either
-     finish it to committable or discard the in-progress edits — the
-     deterministic gate verifies the WORKING TREE, and a half-done gap
-     (an un-vendored dependency, a dangling import) reds the gate as
-     noise.
+     finish it to committable or discard the in-progress edits —
+     `git restore -- <the paths you touched>`, never a blanket
+     `git clean` (the workspace may be the operator's own checkout).
+     The deterministic gate verifies the WORKING TREE, and a half-done
+     gap (an un-vendored dependency, a dangling import) reds the gate
+     as noise.
 
   5. DO NOT CHANGE PRODUCT CODE to make a test pass — that inverts the
      dependency. The ONLY exception is a genuine, separately-flagged

--- a/bots/e2e-coverage/skills/verify-build.md
+++ b/bots/e2e-coverage/skills/verify-build.md
@@ -56,7 +56,8 @@ and the correct toolchain:
   workspace is a git *worktree* whose gitdir lives outside the sandbox
   mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
   status: exit status 128` even though git itself works. Put
-  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  `export GOFLAGS="${GOFLAGS:+$GOFLAGS }-buildvcs=false"` at the top
+  of verify.sh (append — never clobber an inherited GOFLAGS) — the
   binary's stamped identity is irrelevant to a build+test gate.
   (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**

--- a/bots/feature-dev/main.bot
+++ b/bots/feature-dev/main.bot
@@ -192,7 +192,9 @@ prompt campaign_system:
      record.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-slice,
      either finish it to committable or discard the in-progress edits
-     — the deterministic gate verifies the WORKING TREE, and a half-
+     — `git restore -- <the paths you touched>`, never a blanket
+     `git clean` (the workspace may be the operator's own checkout).
+     The deterministic gate verifies the WORKING TREE, and a half-
      done slice (an un-vendored dependency, a dangling import) reds
      the gate as noise.
 

--- a/bots/feature-dev/main.bot
+++ b/bots/feature-dev/main.bot
@@ -191,10 +191,10 @@ prompt campaign_system:
      the todo list lives in your working memory, the commits are the
      record.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-slice,
-     either finish it to committable or revert/stash the in-progress
-     edits — the deterministic gate verifies the WORKING TREE, and a
-     half-done slice (an un-vendored dependency, a dangling import)
-     reds the gate as noise.
+     either finish it to committable or discard the in-progress edits
+     — the deterministic gate verifies the WORKING TREE, and a half-
+     done slice (an un-vendored dependency, a dangling import) reds
+     the gate as noise.
 
   4. BASELINE — don't chase failures you didn't cause. Pre-existing test
      failures / known-flaky tests are in your user prompt (`baseline`).

--- a/bots/feature-dev/skills/verify-build.md
+++ b/bots/feature-dev/skills/verify-build.md
@@ -55,7 +55,8 @@ and the correct toolchain:
   workspace is a git *worktree* whose gitdir lives outside the sandbox
   mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
   status: exit status 128` even though git itself works. Put
-  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  `export GOFLAGS="${GOFLAGS:+$GOFLAGS }-buildvcs=false"` at the top
+  of verify.sh (append — never clobber an inherited GOFLAGS) — the
   binary's stamped identity is irrelevant to a build+test gate.
   (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**

--- a/bots/feature-gap-fill/main.bot
+++ b/bots/feature-gap-fill/main.bot
@@ -181,8 +181,8 @@ prompt campaign_system:
      NOT keep a separate worklist / cursor file — the todo list lives in
      your working memory, the commits are the record.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-item, either
-     finish it to committable or revert/stash the in-progress edits —
-     the deterministic gate verifies the WORKING TREE, and a half-done
+     finish it to committable or discard the in-progress edits — the
+     deterministic gate verifies the WORKING TREE, and a half-done
      item (an un-vendored dependency, a dangling import) reds the gate
      as noise.
 

--- a/bots/feature-gap-fill/main.bot
+++ b/bots/feature-gap-fill/main.bot
@@ -181,8 +181,10 @@ prompt campaign_system:
      NOT keep a separate worklist / cursor file — the todo list lives in
      your working memory, the commits are the record.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-item, either
-     finish it to committable or discard the in-progress edits — the
-     deterministic gate verifies the WORKING TREE, and a half-done
+     finish it to committable or discard the in-progress edits —
+     `git restore -- <the paths you touched>`, never a blanket
+     `git clean` (the workspace may be the operator's own checkout).
+     The deterministic gate verifies the WORKING TREE, and a half-done
      item (an un-vendored dependency, a dangling import) reds the gate
      as noise.
 

--- a/bots/feature-gap-fill/skills/verify-build.md
+++ b/bots/feature-gap-fill/skills/verify-build.md
@@ -55,7 +55,8 @@ and the correct toolchain:
   workspace is a git *worktree* whose gitdir lives outside the sandbox
   mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
   status: exit status 128` even though git itself works. Put
-  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  `export GOFLAGS="${GOFLAGS:+$GOFLAGS }-buildvcs=false"` at the top
+  of verify.sh (append — never clobber an inherited GOFLAGS) — the
   binary's stamped identity is irrelevant to a build+test gate.
   (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**

--- a/bots/gitignore_claude_runtime_test.go
+++ b/bots/gitignore_claude_runtime_test.go
@@ -1,0 +1,58 @@
+package bots
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The repo-root `**/.claude/` rule exists because claude_code
+// sub-invocations mirror skills into THEIR cwd, and the campaign bots
+// commit with `git add -A` — so any un-ignored `.claude/` subtree gets
+// wip-banked into a bot's commit.
+//
+// third_party/codex-agent-sdk-go/ carries a committed `.claude/rules/`
+// of its own (real project content), so `.gitignore` re-includes it.
+// That exception is easy to write too broadly: a bare
+// `!third_party/codex-agent-sdk-go/.claude/` re-includes the WHOLE
+// subtree, reopening the wip-bank hole for exactly the runtime junk the
+// rule stops — and the fork is an active work target, so bots do run
+// there. The negation must descend into the dir, re-ignore its other
+// children, then re-include `rules/`.
+//
+// Nothing else checks this: an over-broad negation is invisible until a
+// run's mirrored skills land in a commit. This test asks git itself.
+func TestGitignoreKeepsClaudeRuntimeJunkIgnored(t *testing.T) {
+	git, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git not on PATH")
+	}
+	root := filepath.Join("..") // bots/ -> repo root
+	if out, err := exec.Command(git, "-C", root, "rev-parse", "--is-inside-work-tree").Output(); err != nil || strings.TrimSpace(string(out)) != "true" {
+		t.Skip("not a git work tree (vendored/exported checkout)")
+	}
+
+	fork := "third_party/codex-agent-sdk-go/.claude/"
+	cases := []struct {
+		path        string
+		wantIgnored bool
+		why         string
+	}{
+		{fork + "skills/MIRRORED.md", true, "the runtime skill mirror inside the vendored fork"},
+		{fork + "settings.local.json", true, "per-machine claude_code settings inside the vendored fork"},
+		{fork + "agents/SOME.md", true, "any other runtime artifact inside the vendored fork"},
+		{fork + "rules/architecture.md", false, "the fork's committed rules (tracked project content)"},
+		{fork + "rules/NEW.md", false, "a new rule added to the fork — must stay addable without -f"},
+		{"pkg/runtime/.claude/skills/MIRRORED.md", true, "the baseline **/.claude/ rule elsewhere in the tree"},
+	}
+
+	for _, tc := range cases {
+		// `git check-ignore` matches patterns only — the path need not exist.
+		err := exec.Command(git, "-C", root, "check-ignore", "-q", "--", tc.path).Run()
+		ignored := err == nil
+		if ignored != tc.wantIgnored {
+			t.Errorf("%s: ignored=%v want %v — %s", tc.path, ignored, tc.wantIgnored, tc.why)
+		}
+	}
+}

--- a/bots/instrument/main.bot
+++ b/bots/instrument/main.bot
@@ -230,7 +230,9 @@ prompt campaign_system:
      slice you committed, and a fresh pass just reads `git log` and
      continues where you left off. END EVERY PASS ON A CLEAN TREE: if
      you must stop mid-slice, either finish it to committable or
-     discard the in-progress edits — the deterministic gate
+     discard the in-progress edits — `git restore -- <the paths you
+     touched>`, never a blanket `git clean` (the workspace may be the
+     operator's own checkout). The deterministic gate
      verifies the WORKING TREE, and a half-slice (an un-vendored
      `go get`, a dangling import) reds the gate as noise.
 

--- a/bots/instrument/main.bot
+++ b/bots/instrument/main.bot
@@ -230,7 +230,7 @@ prompt campaign_system:
      slice you committed, and a fresh pass just reads `git log` and
      continues where you left off. END EVERY PASS ON A CLEAN TREE: if
      you must stop mid-slice, either finish it to committable or
-     revert/stash the in-progress edits — the deterministic gate
+     discard the in-progress edits — the deterministic gate
      verifies the WORKING TREE, and a half-slice (an un-vendored
      `go get`, a dangling import) reds the gate as noise.
 

--- a/bots/instrument/skills/verify-build.md
+++ b/bots/instrument/skills/verify-build.md
@@ -55,7 +55,8 @@ and the correct toolchain:
   workspace is a git *worktree* whose gitdir lives outside the sandbox
   mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
   status: exit status 128` even though git itself works. Put
-  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  `export GOFLAGS="${GOFLAGS:+$GOFLAGS }-buildvcs=false"` at the top
+  of verify.sh (append — never clobber an inherited GOFLAGS) — the
   binary's stamped identity is irrelevant to a build+test gate.
   (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**

--- a/bots/secured-renovacy/main.bot
+++ b/bots/secured-renovacy/main.bot
@@ -1457,10 +1457,12 @@ prompt p2_campaign_system:
      land) — git is the durable state; a later pass reads `git log`
      and continues.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-fix, either
-     finish it to committable or discard the in-progress edits — the
-     deterministic gate verifies the WORKING TREE, and a half-done fix
-     (an un-vendored dependency, a dangling import) reds the gate as
-     noise.
+     finish it to committable or discard the in-progress edits —
+     `git restore -- <the paths you touched>`, never a blanket
+     `git clean` (the workspace may be the operator's own checkout).
+     The deterministic gate verifies the WORKING TREE, and a half-done
+     fix (an un-vendored dependency, a dangling import) reds the gate
+     as noise.
   4. BASELINE — a failure that also occurs at `base_sha` (attribute
      cheaply once, then move on) predates this run: note it, never
      chase it. Fix only what the RUN's changes broke or left.

--- a/bots/secured-renovacy/main.bot
+++ b/bots/secured-renovacy/main.bot
@@ -1457,10 +1457,10 @@ prompt p2_campaign_system:
      land) — git is the durable state; a later pass reads `git log`
      and continues.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-fix, either
-     finish it to committable or revert/stash the in-progress edits —
-     the deterministic gate verifies the WORKING TREE, and a half-done
-     fix (an un-vendored dependency, a dangling import) reds the gate
-     as noise.
+     finish it to committable or discard the in-progress edits — the
+     deterministic gate verifies the WORKING TREE, and a half-done fix
+     (an un-vendored dependency, a dangling import) reds the gate as
+     noise.
   4. BASELINE — a failure that also occurs at `base_sha` (attribute
      cheaply once, then move on) predates this run: note it, never
      chase it. Fix only what the RUN's changes broke or left.

--- a/bots/secured-renovacy/skills/verify-build.md
+++ b/bots/secured-renovacy/skills/verify-build.md
@@ -55,7 +55,8 @@ and the correct toolchain:
   workspace is a git *worktree* whose gitdir lives outside the sandbox
   mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
   status: exit status 128` even though git itself works. Put
-  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  `export GOFLAGS="${GOFLAGS:+$GOFLAGS }-buildvcs=false"` at the top
+  of verify.sh (append — never clobber an inherited GOFLAGS) — the
   binary's stamped identity is irrelevant to a build+test gate.
   (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**

--- a/bots/test-coverage/main.bot
+++ b/bots/test-coverage/main.bot
@@ -194,10 +194,12 @@ prompt campaign_system:
      just reads `git log` and continues where you left off. Do NOT keep a
      separate worklist / cursor file.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-gap, either
-     finish it to committable or discard the in-progress edits — the
-     deterministic gate verifies the WORKING TREE, and a half-done gap
-     (an un-vendored dependency, a dangling import) reds the gate as
-     noise.
+     finish it to committable or discard the in-progress edits —
+     `git restore -- <the paths you touched>`, never a blanket
+     `git clean` (the workspace may be the operator's own checkout).
+     The deterministic gate verifies the WORKING TREE, and a half-done
+     gap (an un-vendored dependency, a dangling import) reds the gate
+     as noise.
 
   4. DO NOT CHANGE THE CODE UNDER TEST to make a test pass — that inverts
      the dependency. The ONLY exception is a genuine, separately-flagged

--- a/bots/test-coverage/main.bot
+++ b/bots/test-coverage/main.bot
@@ -194,10 +194,10 @@ prompt campaign_system:
      just reads `git log` and continues where you left off. Do NOT keep a
      separate worklist / cursor file.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-gap, either
-     finish it to committable or revert/stash the in-progress edits —
-     the deterministic gate verifies the WORKING TREE, and a half-done
-     gap (an un-vendored dependency, a dangling import) reds the gate
-     as noise.
+     finish it to committable or discard the in-progress edits — the
+     deterministic gate verifies the WORKING TREE, and a half-done gap
+     (an un-vendored dependency, a dangling import) reds the gate as
+     noise.
 
   4. DO NOT CHANGE THE CODE UNDER TEST to make a test pass — that inverts
      the dependency. The ONLY exception is a genuine, separately-flagged

--- a/bots/test-coverage/skills/verify-build.md
+++ b/bots/test-coverage/skills/verify-build.md
@@ -60,7 +60,8 @@ and the correct toolchain:
   workspace is a git *worktree* whose gitdir lives outside the sandbox
   mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
   status: exit status 128` even though git itself works. Put
-  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  `export GOFLAGS="${GOFLAGS:+$GOFLAGS }-buildvcs=false"` at the top
+  of verify.sh (append — never clobber an inherited GOFLAGS) — the
   binary's stamped identity is irrelevant to a build+test gate.
   (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**

--- a/bots/whole-improve-loop/main.bot
+++ b/bots/whole-improve-loop/main.bot
@@ -189,8 +189,10 @@ prompt campaign_system:
      worklist / cursor file — the todo list lives in your working memory, the
      commits are the record.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-site, either
-     finish it to committable or discard the in-progress edits — the
-     deterministic gate verifies the WORKING TREE, and a half-done
+     finish it to committable or discard the in-progress edits —
+     `git restore -- <the paths you touched>`, never a blanket
+     `git clean` (the workspace may be the operator's own checkout).
+     The deterministic gate verifies the WORKING TREE, and a half-done
      site (an un-vendored dependency, a dangling import) reds the gate
      as noise.
 

--- a/bots/whole-improve-loop/main.bot
+++ b/bots/whole-improve-loop/main.bot
@@ -189,8 +189,8 @@ prompt campaign_system:
      worklist / cursor file — the todo list lives in your working memory, the
      commits are the record.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-site, either
-     finish it to committable or revert/stash the in-progress edits —
-     the deterministic gate verifies the WORKING TREE, and a half-done
+     finish it to committable or discard the in-progress edits — the
+     deterministic gate verifies the WORKING TREE, and a half-done
      site (an un-vendored dependency, a dangling import) reds the gate
      as noise.
 

--- a/bots/whole-improve-loop/skills/verify-build.md
+++ b/bots/whole-improve-loop/skills/verify-build.md
@@ -55,7 +55,8 @@ and the correct toolchain:
   workspace is a git *worktree* whose gitdir lives outside the sandbox
   mounts, so `go build`'s VCS probe can fail with `error obtaining VCS
   status: exit status 128` even though git itself works. Put
-  `export GOFLAGS="-buildvcs=false"` at the top of verify.sh — the
+  `export GOFLAGS="${GOFLAGS:+$GOFLAGS }-buildvcs=false"` at the top
+  of verify.sh (append — never clobber an inherited GOFLAGS) — the
   binary's stamped identity is irrelevant to a build+test gate.
   (Observed live 2026-08-19, run 01a01a51: the gate burned a pass on it.)
 - **Language defaults (only when there is no wrapper):**


### PR DESCRIPTION
The merge queue landed #460 seconds before this commit reached the branch — this is that orphaned tail, cherry-picked onto main. Revi's four advisory findings on #460, applied:

- **GOFLAGS**: append form (`${GOFLAGS:+$GOFLAGS }-buildvcs=false`), never clobber an inherited value — all 11 verify-build copies.
- **clean-tree clause**: "discard the in-progress edits" — `git stash` from a run worktree pollutes the repo-shared `refs/stash`, and revert is a commit verb; all 9 carriers.
- **.gitignore**: re-include `third_party/codex-agent-sdk-go/.claude/` — the vendored fork's committed rules are project content, not runtime-mirror junk.
- **docs-refresh forge-mr-create header**: honest DIVERGED-copy note replacing the stale "edit all five" contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)