### PR TITLE
fix(bots): the clean-tree ratchet reads the whole clause, and the verb reaches the goal

### DIFF
--- a/bots/app-dev/main.bot
+++ b/bots/app-dev/main.bot
@@ -289,11 +289,12 @@ prompt campaign_system:
      cursor files.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-slice,
      either finish it to committable or discard the in-progress edits
-     — `git restore -- <the paths you touched>`, never a blanket
-     `git clean` (the workspace may be the operator's own checkout).
-     The deterministic gate verifies the WORKING TREE, and a half-
-     done slice (an un-vendored dependency, a dangling import) reds
-     the gate as noise.
+     — `git restore --staged --worktree -- <the paths you touched>`
+     and delete any new files you created; never a blanket `git clean`
+     (the workspace may be the operator's own checkout). The
+     deterministic gate verifies the WORKING TREE, and a half-done
+     slice (an un-vendored dependency, a dangling import) reds the
+     gate as noise.
 
   4. BASELINE — don't chase failures you didn't cause. Pre-existing
      failures are in your user prompt (`baseline`) — greenfield runs

--- a/bots/branch-improve-loop/main.bot
+++ b/bots/branch-improve-loop/main.bot
@@ -277,12 +277,13 @@ prompt campaign_system:
      Do NOT keep a separate worklist / cursor file — the todo list lives in
      your working memory, the commits are the record.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-fix, either
-     finish it to committable or discard the in-progress edits —
-     `git restore -- <the paths you touched>`, never a blanket
-     `git clean` (the workspace may be the operator's own checkout).
-     The deterministic gate verifies the WORKING TREE, and a half-done
-     fix (an un-vendored dependency, a dangling import) reds the gate
-     as noise.
+     finish it to committable or discard the in-progress edits — `git
+     restore --staged --worktree -- <the paths you touched>` and
+     delete any new files you created; never a blanket `git clean`
+     (the workspace may be the operator's own checkout). The
+     deterministic gate verifies the WORKING TREE, and a half-done fix
+     (an un-vendored dependency, a dangling import) reds the gate as
+     noise.
 
   4. BASELINE — don't chase failures the branch didn't cause. Pre-existing
      test failures / known-flaky tests are in your user prompt (`baseline`).

--- a/bots/clean_tree_clause_test.go
+++ b/bots/clean_tree_clause_test.go
@@ -48,8 +48,11 @@ var numberedBullet = regexp.MustCompile(`^\d+\. `)
 
 // cleanTreeClause returns the clause, lower-cased, stripped of backticks and
 // whitespace-collapsed, so an assertion matches regardless of where the
-// prompt's line wrapping falls. Truncating early can only make an assertion
-// FAIL, never silently pass — every one below asserts presence.
+// prompt's line wrapping falls. The scan runs to the contract's next
+// numbered rule (or the prompt block's own end, at column 0) and THROUGH
+// blank lines: the `git clean` check below asserts ABSENCE, so an early
+// stop would let an offending mention hide in text the assertion never
+// inspected — under-capture is only safe for the presence assertions.
 func cleanTreeClause(t *testing.T, botPath string) string {
 	t.Helper()
 	src, err := os.ReadFile(botPath)
@@ -64,9 +67,15 @@ func cleanTreeClause(t *testing.T, botPath string) string {
 	}
 	body := []string{strings.TrimSpace(strings.Split(after, "\n")[0])}
 	for _, line := range strings.Split(after, "\n")[1:] {
+		if line != "" && !strings.HasPrefix(line, " ") {
+			break // column 0: the prompt block itself ended
+		}
 		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || numberedBullet.MatchString(trimmed) {
+		if numberedBullet.MatchString(trimmed) {
 			break
+		}
+		if trimmed == "" {
+			continue
 		}
 		body = append(body, trimmed)
 	}
@@ -80,13 +89,19 @@ func TestCleanTreeClauseNamesASafeDiscardVerb(t *testing.T) {
 		t.Run(bot, func(t *testing.T) {
 			clause := cleanTreeClause(t, bot)
 
-			// A named verb. Without one the agent picks its own, and the
-			// obvious pick writes to a ref shared with the operator's repo.
-			if !strings.Contains(clause, "git restore") {
-				t.Errorf("clean-tree clause names no restore command.\n"+
+			// A named verb, in its FULL form. Without one the agent picks its
+			// own, and the obvious pick writes to a ref shared with the
+			// operator's repo. The bare `git restore -- <paths>` is not
+			// enough either: it restores the worktree FROM the index, which
+			// the contract's own pre-commit `git add -A` habit turns into a
+			// no-op, and it never removes newly created files.
+			if !strings.Contains(clause, "git restore --staged --worktree") {
+				t.Errorf("clean-tree clause does not name the full restore form "+
+					"(git restore --staged --worktree).\n"+
 					"  Why it is there: an unnamed \"discard\" leaves `git stash` "+
-					"as a reasonable reading, and a run worktree shares refs/stash "+
-					"with the operator's repo.\n  Clause as parsed: %q", clause)
+					"as a reasonable reading (a run worktree shares refs/stash "+
+					"with the operator's repo), and a bare `git restore` no-ops "+
+					"on staged edits.\n  Clause as parsed: %q", clause)
 			}
 
 			// A blanket clean, un-negated, is worse than the stash it replaced:

--- a/bots/e2e-coverage/main.bot
+++ b/bots/e2e-coverage/main.bot
@@ -219,12 +219,13 @@ prompt campaign_system:
      committed test, and a fresh pass reads the matrix + `git log` and
      continues where you left off.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-gap, either
-     finish it to committable or discard the in-progress edits —
-     `git restore -- <the paths you touched>`, never a blanket
-     `git clean` (the workspace may be the operator's own checkout).
-     The deterministic gate verifies the WORKING TREE, and a half-done
-     gap (an un-vendored dependency, a dangling import) reds the gate
-     as noise.
+     finish it to committable or discard the in-progress edits — `git
+     restore --staged --worktree -- <the paths you touched>` and
+     delete any new files you created; never a blanket `git clean`
+     (the workspace may be the operator's own checkout). The
+     deterministic gate verifies the WORKING TREE, and a half-done gap
+     (an un-vendored dependency, a dangling import) reds the gate as
+     noise.
 
   5. DO NOT CHANGE PRODUCT CODE to make a test pass — that inverts the
      dependency. The ONLY exception is a genuine, separately-flagged

--- a/bots/feature-dev/main.bot
+++ b/bots/feature-dev/main.bot
@@ -192,11 +192,12 @@ prompt campaign_system:
      record.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-slice,
      either finish it to committable or discard the in-progress edits
-     — `git restore -- <the paths you touched>`, never a blanket
-     `git clean` (the workspace may be the operator's own checkout).
-     The deterministic gate verifies the WORKING TREE, and a half-
-     done slice (an un-vendored dependency, a dangling import) reds
-     the gate as noise.
+     — `git restore --staged --worktree -- <the paths you touched>`
+     and delete any new files you created; never a blanket `git clean`
+     (the workspace may be the operator's own checkout). The
+     deterministic gate verifies the WORKING TREE, and a half-done
+     slice (an un-vendored dependency, a dangling import) reds the
+     gate as noise.
 
   4. BASELINE — don't chase failures you didn't cause. Pre-existing test
      failures / known-flaky tests are in your user prompt (`baseline`).

--- a/bots/feature-gap-fill/main.bot
+++ b/bots/feature-gap-fill/main.bot
@@ -181,10 +181,11 @@ prompt campaign_system:
      NOT keep a separate worklist / cursor file — the todo list lives in
      your working memory, the commits are the record.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-item, either
-     finish it to committable or discard the in-progress edits —
-     `git restore -- <the paths you touched>`, never a blanket
-     `git clean` (the workspace may be the operator's own checkout).
-     The deterministic gate verifies the WORKING TREE, and a half-done
+     finish it to committable or discard the in-progress edits — `git
+     restore --staged --worktree -- <the paths you touched>` and
+     delete any new files you created; never a blanket `git clean`
+     (the workspace may be the operator's own checkout). The
+     deterministic gate verifies the WORKING TREE, and a half-done
      item (an un-vendored dependency, a dangling import) reds the gate
      as noise.
 

--- a/bots/instrument/main.bot
+++ b/bots/instrument/main.bot
@@ -228,13 +228,14 @@ prompt campaign_system:
      the common case here — actually lands) and commit before moving
      on. git IS your durable state: an interrupted run keeps every
      slice you committed, and a fresh pass just reads `git log` and
-     continues where you left off. END EVERY PASS ON A CLEAN TREE: if you must stop mid-slice, either finish
- it to committable or discard the in-progress edits — `git restore
- --staged --worktree -- <the paths you touched>` and delete any new files
- you created; never a blanket `git clean` (the workspace may be the
- operator's own checkout). The deterministic gate verifies the WORKING
- TREE, and a half-done slice (an un-vendored dependency, a dangling
- import) reds the gate as noise.
+     continues where you left off.
+     END EVERY PASS ON A CLEAN TREE: if you must stop mid-slice, either
+     finish it to committable or discard the in-progress edits — `git
+     restore --staged --worktree -- <the paths you touched>` and delete
+     any new files you created; never a blanket `git clean` (the
+     workspace may be the operator's own checkout). The deterministic
+     gate verifies the WORKING TREE, and a half-done slice (an
+     un-vendored dependency, a dangling import) reds the gate as noise.
 
   4. BASELINE — don't chase failures you didn't cause. Pre-existing test
      failures / known-flaky tests are in your user prompt (`baseline`).

--- a/bots/instrument/main.bot
+++ b/bots/instrument/main.bot
@@ -228,13 +228,13 @@ prompt campaign_system:
      the common case here — actually lands) and commit before moving
      on. git IS your durable state: an interrupted run keeps every
      slice you committed, and a fresh pass just reads `git log` and
-     continues where you left off. END EVERY PASS ON A CLEAN TREE: if
-     you must stop mid-slice, either finish it to committable or
-     discard the in-progress edits — `git restore -- <the paths you
-     touched>`, never a blanket `git clean` (the workspace may be the
-     operator's own checkout). The deterministic gate
-     verifies the WORKING TREE, and a half-slice (an un-vendored
-     `go get`, a dangling import) reds the gate as noise.
+     continues where you left off. END EVERY PASS ON A CLEAN TREE: if you must stop mid-slice, either finish
+ it to committable or discard the in-progress edits — `git restore
+ --staged --worktree -- <the paths you touched>` and delete any new files
+ you created; never a blanket `git clean` (the workspace may be the
+ operator's own checkout). The deterministic gate verifies the WORKING
+ TREE, and a half-done slice (an un-vendored dependency, a dangling
+ import) reds the gate as noise.
 
   4. BASELINE — don't chase failures you didn't cause. Pre-existing test
      failures / known-flaky tests are in your user prompt (`baseline`).

--- a/bots/secured-renovacy/main.bot
+++ b/bots/secured-renovacy/main.bot
@@ -1457,12 +1457,13 @@ prompt p2_campaign_system:
      land) — git is the durable state; a later pass reads `git log`
      and continues.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-fix, either
-     finish it to committable or discard the in-progress edits —
-     `git restore -- <the paths you touched>`, never a blanket
-     `git clean` (the workspace may be the operator's own checkout).
-     The deterministic gate verifies the WORKING TREE, and a half-done
-     fix (an un-vendored dependency, a dangling import) reds the gate
-     as noise.
+     finish it to committable or discard the in-progress edits — `git
+     restore --staged --worktree -- <the paths you touched>` and
+     delete any new files you created; never a blanket `git clean`
+     (the workspace may be the operator's own checkout). The
+     deterministic gate verifies the WORKING TREE, and a half-done fix
+     (an un-vendored dependency, a dangling import) reds the gate as
+     noise.
   4. BASELINE — a failure that also occurs at `base_sha` (attribute
      cheaply once, then move on) predates this run: note it, never
      chase it. Fix only what the RUN's changes broke or left.

--- a/bots/test-coverage/main.bot
+++ b/bots/test-coverage/main.bot
@@ -194,12 +194,13 @@ prompt campaign_system:
      just reads `git log` and continues where you left off. Do NOT keep a
      separate worklist / cursor file.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-gap, either
-     finish it to committable or discard the in-progress edits —
-     `git restore -- <the paths you touched>`, never a blanket
-     `git clean` (the workspace may be the operator's own checkout).
-     The deterministic gate verifies the WORKING TREE, and a half-done
-     gap (an un-vendored dependency, a dangling import) reds the gate
-     as noise.
+     finish it to committable or discard the in-progress edits — `git
+     restore --staged --worktree -- <the paths you touched>` and
+     delete any new files you created; never a blanket `git clean`
+     (the workspace may be the operator's own checkout). The
+     deterministic gate verifies the WORKING TREE, and a half-done gap
+     (an un-vendored dependency, a dangling import) reds the gate as
+     noise.
 
   4. DO NOT CHANGE THE CODE UNDER TEST to make a test pass — that inverts
      the dependency. The ONLY exception is a genuine, separately-flagged

--- a/bots/whole-improve-loop/main.bot
+++ b/bots/whole-improve-loop/main.bot
@@ -189,10 +189,11 @@ prompt campaign_system:
      worklist / cursor file — the todo list lives in your working memory, the
      commits are the record.
      END EVERY PASS ON A CLEAN TREE: if you must stop mid-site, either
-     finish it to committable or discard the in-progress edits —
-     `git restore -- <the paths you touched>`, never a blanket
-     `git clean` (the workspace may be the operator's own checkout).
-     The deterministic gate verifies the WORKING TREE, and a half-done
+     finish it to committable or discard the in-progress edits — `git
+     restore --staged --worktree -- <the paths you touched>` and
+     delete any new files you created; never a blanket `git clean`
+     (the workspace may be the operator's own checkout). The
+     deterministic gate verifies the WORKING TREE, and a half-done
      site (an un-vendored dependency, a dangling import) reds the gate
      as noise.
 


### PR DESCRIPTION
Closes the two advisory findings Revi left on #461's zero-touch commits:

- **[medium]** `cleanTreeClause` truncated at the first blank line while its doc comment claimed truncation could only make assertions fail — false for the `git clean` ABSENCE assertion, which an early stop lets pass on text it never inspected. The scan now runs to the next numbered rule or the prompt block's end (column 0), through blank lines.
- **[low]** `git restore -- <paths>` restores the worktree FROM the index (a no-op after the contract's own pre-commit `git add -A`) and leaves new files behind. All 9 carriers now name the full form — `git restore --staged --worktree -- <paths>` plus deleting any new files created — and the ratchet pins the full form.

`go test ./bots/` green (incl. the updated ratchet against all 9 regenerated clauses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)