### PR TITLE
feat(observability): opt-in Sentry tracing — API transactions + LLM-call spans (Obsy dogfood)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,12 +182,14 @@ the hours this one spent.
   guarantee a dead review still answers (outcome event + 1-min sweep).
   Read it when a gate looks stuck — "absent", "pending forever", a synthetic
   `review died`, or a repair that posts nothing and says why in the logs.
-- [docs/observability.md](docs/observability.md) — process logs and error
-  tracking: the env vars (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`,
-  `ITERION_LOG_FORMAT`, `ITERION_LOG_LEVEL`), which surfaces default to JSON,
-  what a Sentry/GlitchTip project receives (panics, fatal exits, error logs,
-  run alerts), the scrubbing, and the smoke test. Read it when a deployment
-  needs to answer "what crashed, how often, since which release".
+- [docs/observability.md](docs/observability.md) — process logs, error
+  tracking and tracing: the env vars (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`,
+  `SENTRY_TRACES_SAMPLE_RATE`, `ITERION_LOG_FORMAT`, `ITERION_LOG_LEVEL`),
+  which surfaces default to JSON, what a Sentry/GlitchTip project receives
+  (panics, fatal exits, error logs, run alerts — plus, when the sample rate
+  is set, one transaction per API request and per in-process LLM call), the
+  scrubbing, and the smoke tests. Read it when a deployment needs to answer
+  "what crashed, how often, since which release" or "where did the time go".
 
 ## Development setup
 
@@ -1652,5 +1654,10 @@ head sha, off by default so the developer keeps the choice.
   in-house structured logger `pkg/log` (JSON by default on server / runner /
   dispatcher); optional error tracking through `pkg/errtrack` (sentry-go, the
   Sentry DSN protocol — Sentry or GlitchTip), enabled only when `SENTRY_DSN`
-  is set. See [docs/observability.md](docs/observability.md)
+  is set. **Tracing rides the same client** as a SECOND opt-in
+  (`SENTRY_TRACES_SAMPLE_RATE` in `[0,1]`, off otherwise): one transaction per
+  API request (route-named) and one per in-process LLM call — never per run,
+  which is `events.jsonl`'s job. Independent of the OTLP exporter in
+  `pkg/cloud/tracing`. Extend `pkg/errtrack`, never add a second tracker.
+  See [docs/observability.md](docs/observability.md) + ADR-088
 - Output abstraction: `Printer` (`pkg/cli/output.go`) with human and JSON modes

--- a/docs/adr/088-error-tracking-via-sentry-dsn-protocol.md
+++ b/docs/adr/088-error-tracking-via-sentry-dsn-protocol.md
@@ -8,6 +8,10 @@
   `Redact`),
   [pkg/errtrack/hook.go](../../pkg/errtrack/hook.go)
   (`LogHook`, `AttachLogHook`),
+  [pkg/errtrack/tracing.go](../../pkg/errtrack/tracing.go) +
+  [http.go](../../pkg/errtrack/http.go) +
+  [span.go](../../pkg/errtrack/span.go) (`TracingEnabled`,
+  `HTTPMiddleware`, `StartSpan` — see the 2026-08-20 addendum),
   [pkg/log/log.go](../../pkg/log/log.go) (`Hook`, `SetHook`),
   [pkg/alert/errtrack.go](../../pkg/alert/errtrack.go) (`TrackerSink`)
 - **Runbook**: [docs/observability.md](../observability.md)
@@ -111,3 +115,60 @@ the tracker (`alert.TrackerSink`), which is the right relationship.
 - `pkg/log` now has a hook slot. It is single-consumer by design — if a
   second consumer ever appears, the slot becomes a slice, not a second
   logging abstraction.
+
+## Addendum — 2026-08-20: tracing, opt-in on the same client
+
+The decision above closed with *"Tracing stays OTel's job; incidents
+are Sentry-protocol's"*. That still holds for the OTLP path
+([pkg/cloud/tracing](../../pkg/cloud/tracing/tracing.go)), which is
+untouched — but it read as "iterion will never emit a Sentry
+transaction", and a deployment already paying for a Sentry/GlitchTip
+project should not need a collector to answer *"which route is slow"*.
+Tracing is therefore wired **on the same client**, and stays off unless
+asked for. The two paths are independent and complementary: point one,
+the other, or both.
+
+- **A second opt-in, not a consequence of the first.**
+  `SENTRY_TRACES_SAMPLE_RATE` in `[0, 1]` enables it; unset, `0`,
+  unparsable or out of range ⇒ off even with a DSN set. The SDK does
+  not read that variable natively, so `Init` resolves it and sets
+  `EnableTracing` / `TracesSampleRate`. A value that is set but unusable
+  is reported loudly and never costs error tracking — same rule as a
+  malformed DSN. Off is the safe default even though the family was
+  requested at build time: a transaction per request is quota an
+  operator turns on deliberately.
+- **Auto-instrumentation for HTTP, exactly one hand-made span.** The
+  server's root handler is wrapped with the SDK's own `sentryhttp`
+  (behind `errtrack.HTTPMiddleware`, so `pkg/server` does not import
+  the SDK); the one hand seam is the in-process provider call in
+  `pkg/backend/model.callAndAggregate`. The engine's node loop, the
+  store and the dispatcher are deliberately NOT instrumented — one
+  seam done well beats a span tree nobody reads.
+- **A run is not a transaction.** Runs last minutes to hours.
+  Transactions are request-scoped or call-scoped; a run's story is
+  already `events.jsonl`, which is the layer built for it. This is the
+  non-goal most likely to be "fixed" by a later pass, hence recorded.
+- **Zero overhead when off, provably.** `HTTPMiddleware` returns the
+  identity function and `StartSpan` returns a nil handle plus the
+  caller's own context, so an un-traced deployment runs the same
+  handler chain and allocates nothing. Both are asserted, not asserted
+  *about*.
+- **Transaction naming is a design constraint, not a detail.** The SDK
+  names a transaction from `http.Request.Pattern`, which the mux stamps
+  during routing — but the auth layer forwards a `WithContext` copy, so
+  the outermost middleware always sees it empty and every run id would
+  become its own transaction. The server resolves the registered
+  pattern up front and hands it to the middleware.
+- **Transactions need their own scrubbing hook.** `BeforeSend` never
+  sees them; `BeforeSendTransaction` gets the same scrubber, extended
+  to walk spans. Wiring one without the other would have shipped an
+  unscrubbed wire path.
+- **Consequence — the key filter gained a numeric exemption.** Span
+  measurements exposed that `token` in `sensitiveKeys` was redacting
+  `input_tokens` as readily as `access_token`. A credential is text, so
+  a numeric value is now exempt: over-redaction destroys an event as
+  surely as a leak.
+- **GlitchTip renders transactions but not Sentry's performance
+  product** (no span metrics, no profiling, no replay). The
+  instrumentation is identical; the caveat is about what the operator
+  sees, and lives in the runbook.

--- a/docs/bot-runs/instrument.md
+++ b/docs/bot-runs/instrument.md
@@ -4,6 +4,42 @@ Newest first. Bot: [bots/instrument/](../../bots/instrument/) — observability
 instrumentation campaign (Sentry/GlitchTip error tracking + standardized
 logs; opt-in tracing).
 
+## 2026-08-20 — second dogfood: the opt-in tracing family (run 01a01db3)
+
+- Status: **validated**
+- Versions: bot 0.1.0 (+ the #460/#462 contract fixes) · iterion `fb4a453d5` (v3.50.2)
+- Method: same chassis, `scope=errors,logs,tracing` (the tracing opt-in
+  exercised for the first time), `--max-cost-usd 45 --merge-into none`,
+  mission_notes = tracing arbitrations (dial via SENTRY_TRACES_SAMPLE_RATE
+  read in errtrack.Init — sentry-go does not read it natively; sentryhttp
+  on the API server behind an identity-when-off errtrack.HTTPMiddleware;
+  exactly ONE hand seam: the in-process LLM call; no run-length
+  transactions).
+- Result: **converged in ONE pass** (vs 3 on the first dogfood — the
+  clean-tree clause and the verify-build GOFLAGS gotcha landed between
+  the two runs and no friction recurred). $29.10, 41.6 min, 6 commits on
+  `iterion/run/blastoff-wail-pyrebloom-b28b` (`c5a2424`).
+- Value: `pkg/errtrack` tracing dial (off unless the env parses > 0, loud
+  on unparsable, Config.TracesSampleRate test seam), one Sentry
+  transaction per API request named by route, one span per provider call
+  in pkg/backend/model/generation.go, tracing_test.go + server
+  tracing_test.go on the in-memory transport, docs/observability.md
+  Tracing section + ADR-088 dated addendum. Host verification: full
+  `task check` exit=0 (128 pkgs). Live smoke: ephemeral server with
+  rate=1 → the two `http.server` transactions visible in the project's
+  Performance page, named by route.
+- Findings / misses: the campaign verified errors+logs already complete
+  and spent the whole pass on tracing — the "expect zero work there"
+  mission note prevented re-litigating. It also self-documented the
+  one-surface scope choice (final commit). Nothing over-claimed; review
+  clean on the first pass.
+- Engine/bot hardening: none needed — the run surfaced no new engine or
+  bot friction (first frictionless run of the fleet's chassis on this
+  repo).
+- Lessons for next run: the fleet-propagated lessons demonstrably
+  compound (3 passes → 1); a scope var carrying an already-done family
+  costs one cheap verification, not a wasted pass.
+
 ## 2026-08-19 — first dogfood: instrument iterion itself (run 01a01a51)
 
 - Status: **validated**

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,32 +1,33 @@
-# Observability — logs and error tracking
+# Observability — logs, error tracking and tracing
 
-iterion has two observability layers, and they answer different
-questions:
+iterion's observability layers answer different questions:
 
 | Layer | Question it answers | Where it lives |
 |---|---|---|
 | Run events (`events.jsonl`) | *What did this run do?* | the run store, the studio, `iterion report` |
 | **Process logs** | *What is this process doing right now?* | stdout/stderr of the server / runner / dispatcher |
 | **Error tracking** | *Is the deployment healthy — what crashed, how often, since which release?* | a Sentry or GlitchTip project |
+| **Tracing** | *Where did the time go — which API routes are slow, which provider calls are expensive?* | the same Sentry/GlitchTip project (Performance) |
 
 Run events are documented in
 [persisted-formats.md](persisted-formats.md). This page covers the
-other two: how to configure them, and what an operator gets.
+other three: how to configure them, and what an operator gets.
 
 ## Environment variables
 
 | Variable | Default | Effect |
 |---|---|---|
-| `SENTRY_DSN` | *unset* | **The master switch for error tracking.** Unset ⇒ nothing is initialised and iterion behaves exactly as it did. Set ⇒ panics, fatal errors, error logs and run alerts are reported. |
+| `SENTRY_DSN` | *unset* | **The master switch for error tracking AND tracing.** Unset ⇒ nothing is initialised and iterion behaves exactly as it did. Set ⇒ panics, fatal errors, error logs and run alerts are reported. |
 | `SENTRY_ENVIRONMENT` | *unset* | Tags every event with the deployment (`production`, `staging`, …). Set it — untagged events from several deployments land in one undifferentiated stream. |
+| `SENTRY_TRACES_SAMPLE_RATE` | *unset* (= **tracing off**) | A fraction in `[0, 1]`: how many units of work become a transaction. A **second** opt-in on top of the DSN. |
 | `ITERION_LOG_FORMAT` | `human` on the CLI, **`json`** on server / runner / dispatcher | `human` (emoji console lines) or `json` (one object per line). |
 | `ITERION_LOG_LEVEL` | `info` | `error`, `warn`, `info`, `debug`, `trace`. |
 
-`SENTRY_DSN` and `SENTRY_ENVIRONMENT` are the SDK's standard names, not
-`ITERION_*` ones, so the DSN you copy from the project page drops into
-the deployment recipe unchanged. They are read from the process
-environment, and — like every other iterion env var — from a `.env`
-next to the project (see `loadDotEnvFromCwd`).
+The `SENTRY_*` names are the SDK's standards, not `ITERION_*` ones, so
+the DSN you copy from the project page drops into the deployment recipe
+unchanged. They are read from the process environment, and — like every
+other iterion env var — from a `.env` next to the project (see
+`loadDotEnvFromCwd`).
 
 ## Logs
 
@@ -149,9 +150,13 @@ Everything passes the SDK's `BeforeSend` hook before it leaves the
 process ([pkg/errtrack/scrub.go](../pkg/errtrack/scrub.go)):
 
 - fields, tags and headers whose **name** looks sensitive
-  (`authorization`, `cookie`, `token`, `secret`, `password`, `api_key`,
-  `credential`, `private_key`, `dsn`, `session`, `bearer`, `auth`) are
-  replaced with `[redacted]` whatever their value;
+  (`authorization`, `cookie`, `token`, `secret`, `password`, `passwd`,
+  `api_key`, `apikey`, `credential`, `private_key`, `dsn`, `session`,
+  `bearer`) are replaced with `[redacted]` whatever their value —
+  **unless the value is a number**, since a credential is text and the
+  exemption is what keeps `input_tokens: 1200` a measurement instead of
+  `[redacted]`. Bare `auth` is deliberately *not* in the list:
+  substring matching would eat `author` / `pr_author`;
 - credential-shaped **substrings** are redacted inside otherwise-useful
   text: URL userinfo (`https://key:secret@host` — the shape of a DSN),
   the `sk-` / `xai-` / `ghp_` / `glpat-` / `iap_` / `iwh_` token
@@ -159,8 +164,11 @@ process ([pkg/errtrack/scrub.go](../pkg/errtrack/scrub.go)):
   `__ITERION_SECRET_*__` placeholders, and email addresses;
 - the **user record** (id, email, ip) is cleared unconditionally.
 
-Scrubbing is on the SDK's own send hook rather than at the call sites,
+Scrubbing is on the SDK's own send hooks rather than at the call sites,
 so nothing can bypass it — including events the SDK generates itself.
+Transaction envelopes take a *different* hook (`BeforeSendTransaction`),
+which gets the same scrubber, walking every span's name/op/description/
+tags/data.
 
 ### Smoke test
 
@@ -184,3 +192,92 @@ and the exit code and terminal output are byte-for-byte what they were.
 Note that `iterion run /nonexistent.bot` is *not* a useful smoke test:
 a missing file is a user-input error (exit 2) and those are
 deliberately never reported.
+
+## Tracing
+
+### Turning it on
+
+Tracing rides the **same DSN and the same client** as error tracking —
+there is no second SDK and no second init. It needs a **second**
+opt-in:
+
+```sh
+export SENTRY_DSN='https://<key>@<host>/<project>'
+export SENTRY_TRACES_SAMPLE_RATE=0.05      # 5% of units of work
+```
+
+`SENTRY_TRACES_SAMPLE_RATE` unset, `0`, unparsable, or outside `[0, 1]`
+⇒ **tracing is off even with the DSN set**. The refusal of a value that
+is set but unusable is loud (one error-level line naming the variable)
+and never costs you error tracking. The SDK does not read this variable
+on its own; `errtrack.Init` resolves it and configures the client.
+
+**Sampling guidance.** Keep production between **0.05 and 0.1**. Every
+sampled unit of work is an envelope on the wire and a row in your
+project's quota, and iterion's expensive surfaces (the studio SPA
+polling, run-console requests) are chatty. `1.0` is for a smoke test or
+a local session, not for a deployment.
+
+### What gets traced
+
+| Seam | Shape |
+|---|---|
+| **Every API request** ([pkg/server/server.go](../pkg/server/server.go), the root handler) | one transaction named after the **route pattern** — `GET /api/runs/{id}`, not `GET /api/runs/019f83…`, so a thousand run ids stay one entry in the performance view. Status, method and the request context ride along |
+| **Every in-process LLM call** ([pkg/backend/model/generation_request.go](../pkg/backend/model/generation_request.go), `callAndAggregate`) | one `llm.generate` span tagged `llm.provider` / `llm.model` and carrying the call's input/output/cache-read token counts. Under an in-flight request it nests inside that request's transaction; off a request — the normal shape for a run — it is a standalone transaction |
+
+That is the **whole** list, and deliberately so:
+
+- **A run gets no transaction.** Runs last minutes to hours; a span
+  tree spanning a whole campaign is unreadable and its envelope is
+  enormous. Use the run's own `events.jsonl` (and the studio timeline)
+  for "what did this run do" — that is what it is for.
+- **404s are not traced.** The SDK ignores them by default, which suits
+  a server that also serves an SPA.
+- The engine's node loop, the store and the dispatcher are **not**
+  instrumented. One hand-made seam, done well, beats a tree of spans
+  nobody reads.
+
+Only the CLI-agent backends' *in-process* path is covered: a
+`claude_code` / `codex` / `pi` / `kimi` / `grok` node shells out to its
+own CLI, which iterion does not trace.
+
+### Relationship to the OpenTelemetry wiring
+
+iterion also has an **independent** OTel exporter
+([pkg/cloud/tracing](../pkg/cloud/tracing/tracing.go)) driven by
+`OTEL_EXPORTER_OTLP_ENDPOINT`, feeding the `otel.Tracer` spans in
+`pkg/runtime`, `pkg/runner` and a couple of server handlers. The two
+are complementary and share nothing: point one, the other, or both.
+Sentry tracing needs no collector; OTLP needs one but reaches a
+vendor-neutral backend.
+
+### GlitchTip caveat
+
+GlitchTip accepts transaction envelopes and renders basic performance
+data, but does **not** implement Sentry's full performance product —
+no span metrics or dashboards, no profiling, no session replay. The
+instrumentation is identical either way; what differs is what you will
+see. On GlitchTip, keep the sample rate at the low end: you are paying
+the wire cost for a thinner view.
+
+### Smoke test
+
+```sh
+export SENTRY_DSN='https://<key>@<host>/<project>'
+export SENTRY_ENVIRONMENT=smoke-test
+export SENTRY_TRACES_SAMPLE_RATE=1.0        # smoke only — never a deployment
+
+iterion studio --no-browser-pane --port 4891 &
+curl -s localhost:4891/api/v1/bots > /dev/null
+```
+
+Within a few seconds, **Performance** should show a transaction named
+`GET /api/v1/bots`, tagged with the same `release` and `environment` as
+your error events. Launch any bot on the `claw` backend and an
+`llm.generate` transaction appears alongside it, tagged with the
+provider and model that served it.
+
+Then unset `SENTRY_TRACES_SAMPLE_RATE` and repeat: **no transaction is
+produced**, the handler chain is the one that shipped before tracing
+existed (the middleware is the identity function), and error tracking
+keeps working exactly as above.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -235,7 +235,9 @@ That is the **whole** list, and deliberately so:
   a server that also serves an SPA.
 - The engine's node loop, the store and the dispatcher are **not**
   instrumented. One hand-made seam, done well, beats a tree of spans
-  nobody reads.
+  nobody reads. That includes `iterion dispatch`'s own little
+  loopback mux (healthz + `/api/server/info` + the SPA): it is not the
+  API server, and tracing a static-file host buys nothing.
 
 Only the CLI-agent backends' *in-process* path is covered: a
 `claude_code` / `codex` / `pi` / `kimi` / `grok` node shells out to its

--- a/pkg/backend/model/generation_request.go
+++ b/pkg/backend/model/generation_request.go
@@ -10,6 +10,7 @@ import (
 	"github.com/SocialGouv/claw-code-go/pkg/api"
 
 	"github.com/SocialGouv/iterion/pkg/backend/thinktokens"
+	"github.com/SocialGouv/iterion/pkg/errtrack"
 )
 
 // ---------------------------------------------------------------------------
@@ -32,6 +33,20 @@ func wireModelID(spec string) string {
 		return spec[i+1:]
 	}
 	return spec
+}
+
+// llmSpanOp is the operation name every in-process provider call is
+// traced under, so one query in Sentry covers them all.
+const llmSpanOp = "llm.generate"
+
+// modelProvider is wireModelID's other half: the routing prefix of a
+// model spec ("anthropic/claude-opus-5" → "anthropic"), or "default"
+// when the spec is bare and the registry picks the provider.
+func modelProvider(spec string) string {
+	if i := strings.Index(spec, "/"); i >= 0 {
+		return spec[:i]
+	}
+	return "default"
 }
 
 func buildRequest(opts GenerationOptions, messages []api.Message, extraTools []api.Tool, toolChoice *api.ToolChoice) (api.CreateMessageRequest, error) {
@@ -169,15 +184,25 @@ func fireOnRequest(opts GenerationOptions, messageCount int) {
 // callAndAggregate calls StreamResponse, aggregates the stream, fires the
 // OnResponse hook, and returns the aggregated result. On StreamResponse
 // failure it fires OnResponse with the error and returns nil, err.
+//
+// This is iterion's ONE hand-instrumented tracing seam: every in-process
+// provider call funnels through here, and one call is a unit of work
+// worth timing. A run is not — it lasts minutes to hours, so it gets no
+// transaction of its own.
 func callAndAggregate(
 	ctx context.Context,
 	client api.APIClient,
 	req api.CreateMessageRequest,
 	opts GenerationOptions,
 ) (*aggregatedResponse, error) {
+	ctx, span := errtrack.StartSpan(ctx, llmSpanOp, opts.Model)
+	span.SetTag("llm.provider", modelProvider(opts.Model))
+	span.SetTag("llm.model", wireModelID(opts.Model))
+
 	start := time.Now()
 	ch, err := client.StreamResponse(ctx, req)
 	if err != nil {
+		span.Finish(err)
 		if opts.OnResponse != nil {
 			opts.OnResponse(ResponseInfo{
 				Latency: time.Since(start),
@@ -189,6 +214,10 @@ func callAndAggregate(
 
 	agg := aggregateStream(ctx, ch)
 	latency := time.Since(start)
+	span.SetData("llm.input_tokens", agg.usage.InputTokens)
+	span.SetData("llm.output_tokens", agg.usage.OutputTokens)
+	span.SetData("llm.cache_read_tokens", agg.usage.CacheReadTokens)
+	span.Finish(agg.err)
 
 	// Thinking metrics. Preferred source is the provider's exact billed
 	// count (usage.output_tokens_details, captured from message_delta);

--- a/pkg/backend/model/generation_request.go
+++ b/pkg/backend/model/generation_request.go
@@ -195,7 +195,10 @@ func callAndAggregate(
 	req api.CreateMessageRequest,
 	opts GenerationOptions,
 ) (*aggregatedResponse, error) {
-	ctx, span := errtrack.StartSpan(ctx, llmSpanOp, opts.Model)
+	// Independent transaction, never a child: this runs on a context
+	// derived from the LAUNCH request, whose transaction finished long
+	// ago — a child of it would be silently dropped by the SDK.
+	span := errtrack.StartIndependent(llmSpanOp, opts.Model)
 	span.SetTag("llm.provider", modelProvider(opts.Model))
 	span.SetTag("llm.model", wireModelID(opts.Model))
 

--- a/pkg/backend/model/generation_tracing_test.go
+++ b/pkg/backend/model/generation_tracing_test.go
@@ -1,0 +1,161 @@
+package model
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/claw-code-go/pkg/api"
+	sentry "github.com/getsentry/sentry-go"
+
+	"github.com/SocialGouv/iterion/pkg/errtrack"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+// spanTransport records events in-process; nothing reaches a network.
+type spanTransport struct {
+	mu     sync.Mutex
+	events []*sentry.Event
+}
+
+func (t *spanTransport) Configure(sentry.ClientOptions) {}
+func (t *spanTransport) SendEvent(e *sentry.Event) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, e)
+}
+func (t *spanTransport) Flush(time.Duration) bool              { return true }
+func (t *spanTransport) FlushWithContext(context.Context) bool { return true }
+func (t *spanTransport) Close()                                {}
+
+func (t *spanTransport) transactions() []*sentry.Event {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var out []*sentry.Event
+	for _, e := range t.events {
+		if e.Type == "transaction" {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// errtrack installs its client once per PROCESS, so this is the single
+// transport of the binary and the single Init.
+var (
+	genTransport   = &spanTransport{}
+	genTransportOn sync.Once
+)
+
+func enableGenerationTracing(t *testing.T) *spanTransport {
+	t.Helper()
+	genTransportOn.Do(func() {
+		full := 1.0
+		errtrack.Init(errtrack.Config{
+			DSN:              "https://publickey@localhost/1",
+			Transport:        genTransport,
+			Logger:           iterlog.New(iterlog.LevelError, io.Discard),
+			TracesSampleRate: &full,
+		})
+	})
+	if !errtrack.TracingEnabled() {
+		t.Fatal("errtrack.Init did not enable tracing")
+	}
+	return genTransport
+}
+
+// DECLARATION ORDER MATTERS: this must run before the test below turns
+// tracing on, because errtrack's Init is once-per-process. It is the
+// off-state proof for the generation seam — the shape every deployment
+// that has not set SENTRY_TRACES_SAMPLE_RATE runs in.
+func TestGenerationEmitsNoTransactionWhenTracingIsOff(t *testing.T) {
+	if errtrack.TracingEnabled() {
+		t.Fatal("tracing is already on — a test declared earlier enabled it")
+	}
+	client := &execMockClient{streams: []<-chan api.StreamEvent{mockStreamEvents("hi", "end_turn")}}
+
+	agg, err := callAndAggregate(context.Background(), client, api.CreateMessageRequest{},
+		GenerationOptions{Model: "anthropic/claude-opus-5"})
+	if err != nil {
+		t.Fatalf("callAndAggregate: %v", err)
+	}
+	if agg.text != "hi" {
+		t.Fatalf("text = %q — instrumentation changed the result", agg.text)
+	}
+	if got := len(genTransport.transactions()); got != 0 {
+		t.Fatalf("tracing off produced %d transaction(s)", got)
+	}
+}
+
+func TestGenerationIsTracedAsOneTaggedTransaction(t *testing.T) {
+	tr := enableGenerationTracing(t)
+	before := len(tr.transactions())
+
+	client := &execMockClient{streams: []<-chan api.StreamEvent{mockStreamEvents("hello", "end_turn")}}
+	if _, err := callAndAggregate(context.Background(), client, api.CreateMessageRequest{},
+		GenerationOptions{Model: "anthropic/claude-opus-5"}); err != nil {
+		t.Fatalf("callAndAggregate: %v", err)
+	}
+	errtrack.Flush()
+
+	txns := tr.transactions()[before:]
+	if len(txns) != 1 {
+		t.Fatalf("want 1 transaction for 1 provider call, got %d", len(txns))
+	}
+	txn := txns[0]
+	if txn.Transaction != "llm.generate anthropic/claude-opus-5" {
+		t.Errorf("transaction name = %q", txn.Transaction)
+	}
+	if txn.Tags["llm.provider"] != "anthropic" {
+		t.Errorf("llm.provider tag = %q", txn.Tags["llm.provider"])
+	}
+	if txn.Tags["llm.model"] != "claude-opus-5" {
+		t.Errorf("llm.model tag = %q", txn.Tags["llm.model"])
+	}
+	// The stream fixture bills 100 in / 50 out.
+	if txn.Contexts["trace"]["data"] == nil {
+		t.Fatalf("the transaction carries no span data: %+v", txn.Contexts["trace"])
+	}
+	data, _ := txn.Contexts["trace"]["data"].(map[string]any)
+	if data["llm.input_tokens"] != 100 || data["llm.output_tokens"] != 50 {
+		t.Errorf("token measurements = %v", data)
+	}
+}
+
+// A provider that never opens the stream must still close its span, and
+// say it failed.
+func TestAFailedProviderCallIsTracedAsAnError(t *testing.T) {
+	tr := enableGenerationTracing(t)
+	before := len(tr.transactions())
+
+	client := &execMockClient{err: errors.New("provider unreachable")}
+	if _, err := callAndAggregate(context.Background(), client, api.CreateMessageRequest{},
+		GenerationOptions{Model: "openai/gpt-5.4-mini"}); err == nil {
+		t.Fatal("want the provider error to propagate")
+	}
+	errtrack.Flush()
+
+	txns := tr.transactions()[before:]
+	if len(txns) != 1 {
+		t.Fatalf("want 1 transaction, got %d", len(txns))
+	}
+	if got, _ := txns[0].Contexts["trace"]["status"].(string); got != "internal_error" {
+		t.Errorf("trace status = %q, want internal_error", got)
+	}
+}
+
+func TestModelProviderSplitsTheRoutingPrefix(t *testing.T) {
+	for spec, want := range map[string]string{
+		"anthropic/claude-opus-5": "anthropic",
+		"openai/gpt-5.4-mini":     "openai",
+		"claude-opus-4-8":         "default",
+		"":                        "default",
+	} {
+		if got := modelProvider(spec); got != want {
+			t.Errorf("modelProvider(%q) = %q, want %q", spec, got, want)
+		}
+	}
+}

--- a/pkg/backend/model/generation_tracing_test.go
+++ b/pkg/backend/model/generation_tracing_test.go
@@ -67,13 +67,16 @@ func enableGenerationTracing(t *testing.T) *spanTransport {
 	return genTransport
 }
 
-// DECLARATION ORDER MATTERS: this must run before the test below turns
-// tracing on, because errtrack's Init is once-per-process. It is the
-// off-state proof for the generation seam — the shape every deployment
-// that has not set SENTRY_TRACES_SAMPLE_RATE runs in.
+// The off-state proof for the generation seam — the shape every
+// deployment that has not set SENTRY_TRACES_SAMPLE_RATE runs in.
+// errtrack's Init is once-per-process, so when another test in the
+// package (in whatever order -shuffle picked) has already enabled
+// tracing, the off state is simply not observable here any more: SKIP
+// rather than fail — pkg/errtrack's own tests (which have a test-only
+// reset) keep the off-state covered regardless of order.
 func TestGenerationEmitsNoTransactionWhenTracingIsOff(t *testing.T) {
 	if errtrack.TracingEnabled() {
-		t.Fatal("tracing is already on — a test declared earlier enabled it")
+		t.Skip("tracing already enabled by another test in this process; off-state covered by pkg/errtrack's own tests")
 	}
 	client := &execMockClient{streams: []<-chan api.StreamEvent{mockStreamEvents("hi", "end_turn")}}
 

--- a/pkg/errtrack/errtrack.go
+++ b/pkg/errtrack/errtrack.go
@@ -75,6 +75,11 @@ type Config struct {
 	// ServerName tags events with the process identity (a CLI command
 	// name, a runner pod). Empty ⇒ the SDK's default (the hostname).
 	ServerName string
+	// TracesSampleRate overrides SENTRY_TRACES_SAMPLE_RATE, the tracing
+	// dial. A pointer because 0 is meaningful: nil ⇒ read the env,
+	// &0 ⇒ tracing explicitly off. Mainly a test seam — a deployment
+	// turns the dial with the env var.
+	TracesSampleRate *float64
 }
 
 // Init installs the Sentry client when a DSN is configured and reports
@@ -110,6 +115,8 @@ func doInit(cfg Config) bool {
 		release = defaultRelease()
 	}
 
+	rate := resolveTracesSampleRate(cfg, cfg.Logger)
+
 	err := sentry.Init(sentry.ClientOptions{
 		Dsn:              dsn,
 		Environment:      env,
@@ -119,6 +126,11 @@ func doInit(cfg Config) bool {
 		AttachStacktrace: true,
 		BeforeSend:       scrubEvent,
 		BeforeBreadcrumb: scrubBreadcrumb,
+		// Transaction events bypass BeforeSend entirely; without this
+		// hook every span would reach the wire unscrubbed.
+		BeforeSendTransaction: scrubEvent,
+		EnableTracing:         rate > 0,
+		TracesSampleRate:      rate,
 	})
 	if err != nil {
 		// Loud, never fatal: a broken DSN costs error tracking, not the
@@ -128,7 +140,8 @@ func doInit(cfg Config) bool {
 		cfg.Logger.Error("errtrack: error tracking disabled — %s", Redact(err.Error()))
 		return false
 	}
-	cfg.Logger.Debug("errtrack: error tracking enabled (release=%s environment=%s)", release, env)
+	tracing.Store(rate > 0)
+	cfg.Logger.Debug("errtrack: error tracking enabled (release=%s environment=%s traces_sample_rate=%v)", release, env, rate)
 	return true
 }
 
@@ -241,5 +254,6 @@ func applyFields(scope *sentry.Scope, fields map[string]any) {
 // code initialises once and never tears down.
 func reset() {
 	enabled.Store(false)
+	tracing.Store(false)
 	initOnce = sync.Once{}
 }

--- a/pkg/errtrack/http.go
+++ b/pkg/errtrack/http.go
@@ -1,0 +1,61 @@
+package errtrack
+
+import (
+	"net/http"
+
+	sentryhttp "github.com/getsentry/sentry-go/http"
+)
+
+// HTTPOptions parameterises HTTPMiddleware.
+type HTTPOptions struct {
+	// RouteName maps a request to the LOW-CARDINALITY name its
+	// transaction should carry — the route pattern
+	// ("GET /api/runs/{id}"), not the URL ("GET /api/runs/019f83…").
+	//
+	// It exists because the SDK reads http.Request.Pattern, which
+	// net/http's mux stamps on the request only once routing has
+	// happened — and any middleware in between that forwards a
+	// r.WithContext() copy (an auth layer injecting an identity, say)
+	// leaves the outer request's Pattern empty, so every distinct URL
+	// would become its own transaction.
+	//
+	// Return "" to fall back to the SDK's own naming. nil is fine: the
+	// middleware then never looks a route up.
+	RouteName func(*http.Request) string
+}
+
+// HTTPMiddleware returns the middleware that turns each HTTP request
+// into a Sentry transaction.
+//
+// **When tracing is off it returns the identity function**, so a
+// deployment without SENTRY_TRACES_SAMPLE_RATE keeps byte-for-byte the
+// handler chain it had — no wrapper, no per-request allocation, no
+// route lookup. Call it after Init, which is what settles that.
+//
+// The wrapped chain keeps the caller's panic semantics: the SDK
+// captures a panic escaping a handler and RE-PANICS, so net/http's own
+// per-connection recovery still ends the request exactly as before.
+func HTTPMiddleware(opts HTTPOptions) func(http.Handler) http.Handler {
+	if !tracing.Load() {
+		return func(next http.Handler) http.Handler { return next }
+	}
+	handler := sentryhttp.New(sentryhttp.Options{Repanic: true})
+	return func(next http.Handler) http.Handler {
+		traced := handler.Handle(next)
+		if opts.RouteName == nil {
+			return traced
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if name := opts.RouteName(r); name != "" {
+				// A copy: the request belongs to the server, and the
+				// mux downstream stamps the real pattern on its own
+				// copy anyway. Pattern is informational — PathValue
+				// reads the mux's match, not this field.
+				clone := r.Clone(r.Context())
+				clone.Pattern = name
+				r = clone
+			}
+			traced.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/errtrack/http_test.go
+++ b/pkg/errtrack/http_test.go
@@ -1,0 +1,184 @@
+package errtrack
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// hijackableRecorder mimics the shape of net/http's own response
+// writer — Flusher + Hijacker + io.ReaderFrom — so a test can prove the
+// middleware does not cost the server its WebSocket upgrades.
+//
+// All three matter: the SDK's response-writer proxy only forwards
+// Hijack when the writer it wraps implements the whole trio, and
+// degrades to a flush-only proxy otherwise. Being the OUTERMOST
+// middleware is what guarantees it sees the real writer.
+type hijackableRecorder struct {
+	*httptest.ResponseRecorder
+	hijacked bool
+}
+
+func (h *hijackableRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h.hijacked = true
+	return nil, nil, nil
+}
+
+func (h *hijackableRecorder) ReadFrom(r io.Reader) (int64, error) {
+	return io.Copy(h.ResponseRecorder.Body, r)
+}
+
+func TestHTTPMiddlewareIsTheIdentityWhenTracingIsOff(t *testing.T) {
+	t.Setenv(EnvTracesSampleRate, "")
+	tr := enable(t, Config{})
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	wrapped := HTTPMiddleware(HTTPOptions{RouteName: func(*http.Request) string { return "GET /never" }})(next)
+
+	// Not "behaves the same" — the SAME handler value: with tracing off
+	// there is no wrapper at all on the server's hot path.
+	if reflect.ValueOf(wrapped).Pointer() != reflect.ValueOf(next).Pointer() {
+		t.Fatal("HTTPMiddleware wrapped the handler while tracing is off")
+	}
+
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/things/42", nil))
+	if rec.Code != http.StatusTeapot {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	Flush()
+	if got := len(transactions(tr.all())); got != 0 {
+		t.Fatalf("tracing off produced %d transaction(s)", got)
+	}
+}
+
+func TestHTTPMiddlewareRecordsOneTransactionPerRequest(t *testing.T) {
+	tr := enable(t, Config{TracesSampleRate: rate(1)})
+
+	wrapped := HTTPMiddleware(HTTPOptions{})(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) },
+	))
+
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/things/42", nil))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d — the middleware changed the response", rec.Code)
+	}
+	Flush()
+
+	txns := transactions(tr.all())
+	if len(txns) != 1 {
+		t.Fatalf("want 1 transaction, got %d", len(txns))
+	}
+	if txns[0].Transaction != "GET /api/things/42" {
+		t.Errorf("transaction name = %q", txns[0].Transaction)
+	}
+}
+
+func TestRouteNameKeepsTransactionCardinalityLow(t *testing.T) {
+	tr := enable(t, Config{TracesSampleRate: rate(1)})
+
+	wrapped := HTTPMiddleware(HTTPOptions{
+		RouteName: func(*http.Request) string { return "GET /api/things/{id}" },
+	})(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	for _, path := range []string{"/api/things/42", "/api/things/1337"} {
+		wrapped.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, path, nil))
+	}
+	Flush()
+
+	txns := transactions(tr.all())
+	if len(txns) != 2 {
+		t.Fatalf("want 2 transactions, got %d", len(txns))
+	}
+	for _, txn := range txns {
+		if txn.Transaction != "GET /api/things/{id}" {
+			t.Errorf("transaction name = %q — two URLs must share one route name", txn.Transaction)
+		}
+	}
+}
+
+func TestWrappedHandlerKeepsItsRequestAndCanStillHijack(t *testing.T) {
+	enable(t, Config{TracesSampleRate: rate(1)})
+
+	var gotPath, gotHeader, gotValue string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotHeader = r.Header.Get("X-Iterion-Run")
+		gotValue = r.PathValue("id")
+		// The run console upgrades to WebSocket here; a wrapper that
+		// hides http.Hijacker would break every live run view.
+		if _, _, err := w.(http.Hijacker).Hijack(); err != nil {
+			t.Errorf("Hijack: %v", err)
+		}
+	})
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /api/things/{id}", next)
+	wrapped := HTTPMiddleware(HTTPOptions{
+		RouteName: func(*http.Request) string { return "GET /api/things/{id}" },
+	})(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/things/42", nil)
+	req.Header.Set("X-Iterion-Run", "run-token")
+	rec := &hijackableRecorder{ResponseRecorder: httptest.NewRecorder()}
+	wrapped.ServeHTTP(rec, req)
+
+	if !rec.hijacked {
+		t.Fatal("the handler could not hijack the connection")
+	}
+	if gotPath != "/api/things/42" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotHeader != "run-token" {
+		t.Errorf("header = %q — the request copy lost its headers", gotHeader)
+	}
+	// The clone sets Pattern; the mux must still resolve wildcards.
+	if gotValue != "42" {
+		t.Errorf("PathValue(id) = %q — route matching broke", gotValue)
+	}
+}
+
+func TestAPanicInAHandlerIsCapturedAndRepanicked(t *testing.T) {
+	tr := enable(t, Config{TracesSampleRate: rate(1)})
+
+	wrapped := HTTPMiddleware(HTTPOptions{})(http.HandlerFunc(
+		func(http.ResponseWriter, *http.Request) { panic("handler exploded") },
+	))
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("the panic was swallowed — the server's panic semantics changed")
+			}
+		}()
+		wrapped.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/boom", nil))
+	}()
+	Flush()
+
+	// A string panic value is reported as a message event by the SDK.
+	var found bool
+	for _, ev := range tr.all() {
+		if ev.Type == "transaction" {
+			continue
+		}
+		if strings.Contains(ev.Message, "handler exploded") {
+			found = true
+		}
+		for _, ex := range ev.Exception {
+			if strings.Contains(ex.Value, "handler exploded") {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatal("the handler panic was not reported")
+	}
+}

--- a/pkg/errtrack/http_test.go
+++ b/pkg/errtrack/http_test.go
@@ -30,7 +30,7 @@ func (h *hijackableRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 }
 
 func (h *hijackableRecorder) ReadFrom(r io.Reader) (int64, error) {
-	return io.Copy(h.ResponseRecorder.Body, r)
+	return io.Copy(h.Body, r)
 }
 
 func TestHTTPMiddlewareIsTheIdentityWhenTracingIsOff(t *testing.T) {

--- a/pkg/errtrack/scrub.go
+++ b/pkg/errtrack/scrub.go
@@ -2,6 +2,7 @@ package errtrack
 
 import (
 	"fmt"
+	"net/url"
 	"reflect"
 	"regexp"
 	"strings"
@@ -23,6 +24,20 @@ var sensitiveKeys = []string{
 	"authorization", "cookie", "secret", "token", "password", "passwd",
 	"api_key", "apikey", "credential", "private_key", "dsn", "session",
 	"bearer",
+	// iterion's own request-borne credential: the ephemeral run bearer
+	// authorizing the board-MCP / ask_user HTTP transports. Bare hex, so
+	// no value pattern can catch it — the header NAME is the signal.
+	"x-iterion-run",
+}
+
+// sensitiveQueryParams are query-string parameter names whose VALUE is
+// a credential without matching any sensitiveKeys fragment — the OAuth
+// authorization `code` and CSRF `state` on the SSO / forge callbacks.
+// Kept separate from sensitiveKeys: as prose, "code" and "state" are
+// everywhere ("exit code=1"), but as QUERY PARAMETERS they are precise.
+var sensitiveQueryParams = map[string]bool{
+	"code":  true,
+	"state": true,
 }
 
 // secretPatterns redact a secret embedded in an otherwise-useful
@@ -259,14 +274,57 @@ func scrubEvent(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 			}
 			event.Request.Headers[k] = Redact(event.Request.Headers[k])
 		}
-		event.Request.QueryString = Redact(event.Request.QueryString)
+		event.Request.QueryString = scrubQueryString(event.Request.QueryString)
 		event.Request.Cookies = redacted
-		event.Request.URL = Redact(event.Request.URL)
+		event.Request.URL = scrubURL(event.Request.URL)
 		event.Request.Data = Redact(event.Request.Data)
 	}
 	// The user record is identity data we never need for triage.
 	event.User = sentry.User{}
 	return event
+}
+
+// scrubQueryString redacts the values of credential-bearing query
+// parameters — the sensitiveKeys fragments plus the OAuth callback
+// params (`code`, `state`) — and leaves the rest intact, then applies
+// the pattern pass on the survivors. A string that does not parse as a
+// query falls back to the plain pattern pass.
+func scrubQueryString(q string) string {
+	if q == "" {
+		return q
+	}
+	values, err := url.ParseQuery(q)
+	if err != nil {
+		return Redact(q)
+	}
+	for key, vals := range values {
+		lk := strings.ToLower(key)
+		if isSensitiveKey(key) || sensitiveQueryParams[lk] {
+			for i := range vals {
+				vals[i] = redacted
+			}
+			continue
+		}
+		for i := range vals {
+			vals[i] = Redact(vals[i])
+		}
+	}
+	return values.Encode()
+}
+
+// scrubURL applies the pattern pass to the URL and the query-parameter
+// pass to its query part, so a credential riding a full URL (the OAuth
+// callback with ?code=…) is caught in both renderings.
+func scrubURL(raw string) string {
+	if raw == "" {
+		return raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return Redact(raw)
+	}
+	u.RawQuery = scrubQueryString(u.RawQuery)
+	return Redact(u.String())
 }
 
 // scrubBreadcrumb is the SDK's BeforeBreadcrumb hook.

--- a/pkg/errtrack/scrub.go
+++ b/pkg/errtrack/scrub.go
@@ -24,20 +24,28 @@ var sensitiveKeys = []string{
 	"authorization", "cookie", "secret", "token", "password", "passwd",
 	"api_key", "apikey", "credential", "private_key", "dsn", "session",
 	"bearer",
-	// iterion's own request-borne credential: the ephemeral run bearer
-	// authorizing the board-MCP / ask_user HTTP transports. Bare hex, so
-	// no value pattern can catch it — the header NAME is the signal.
-	"x-iterion-run",
+	// iterion's own request-borne credentials as a FAMILY: X-Iterion-Run
+	// (the ephemeral run bearer on the board-MCP / ask_user transports)
+	// and X-Iterion-Refresh (the session refresh fallback for SDK
+	// clients) are bare tokens no value pattern can catch — the header
+	// NAME is the signal, and matching the prefix closes the class
+	// instead of chasing each header. An X-Iterion-* header carries
+	// protocol state, never diagnostic value worth shipping.
+	"x-iterion-",
 }
 
 // sensitiveQueryParams are query-string parameter names whose VALUE is
 // a credential without matching any sensitiveKeys fragment — the OAuth
-// authorization `code` and CSRF `state` on the SSO / forge callbacks.
-// Kept separate from sensitiveKeys: as prose, "code" and "state" are
-// everywhere ("exit code=1"), but as QUERY PARAMETERS they are precise.
+// authorization `code` and CSRF `state` on the SSO / forge callbacks,
+// and `sig`, the presigned-attachment HMAC that authenticates a
+// download for its whole TTL (a traced URL carrying it would be a
+// replayable grant to a run artifact). Kept separate from
+// sensitiveKeys: as prose, "code" and "state" are everywhere
+// ("exit code=1"), but as QUERY PARAMETERS they are precise.
 var sensitiveQueryParams = map[string]bool{
 	"code":  true,
 	"state": true,
+	"sig":   true,
 }
 
 // secretPatterns redact a secret embedded in an otherwise-useful

--- a/pkg/errtrack/scrub.go
+++ b/pkg/errtrack/scrub.go
@@ -84,6 +84,24 @@ func isSensitiveKey(k string) bool {
 	return false
 }
 
+// isMeasurement reports whether a value is a plain number.
+//
+// A credential is text: never an int, never a float. So a numeric value
+// is safe to send even under a name the key filter distrusts — and that
+// exemption is what keeps `input_tokens: 1200` a usable measurement
+// instead of `[redacted]`, since "token" has to stay in sensitiveKeys
+// for `access_token` and friends. Over-redaction destroys an event as
+// surely as a leak: the same reasoning already anchors the key=value
+// regex so `tokens=48657` survives.
+func isMeasurement(v any) bool {
+	switch v.(type) {
+	case bool, int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64, float32, float64:
+		return true
+	}
+	return false
+}
+
 // maxScrubDepth bounds the recursive field walk. Past the cap the value
 // is dropped to the redaction marker rather than rendered: fmt's %v does
 // not detect cycles, so stringifying an arbitrarily deep (or cyclic)
@@ -103,7 +121,7 @@ func scrubFields(fields map[string]any) map[string]any {
 	}
 	out := make(map[string]any, len(fields))
 	for k, v := range fields {
-		if isSensitiveKey(k) {
+		if isSensitiveKey(k) && !isMeasurement(v) {
 			out[k] = redacted
 			continue
 		}
@@ -151,11 +169,12 @@ func scrubValue(v any, depth int) any {
 		iter := rv.MapRange()
 		for iter.Next() {
 			key := fmt.Sprint(iter.Key().Interface())
-			if isSensitiveKey(key) {
+			val := iter.Value().Interface()
+			if isSensitiveKey(key) && !isMeasurement(val) {
 				out[key] = redacted
 				continue
 			}
-			out[key] = scrubValue(iter.Value().Interface(), depth+1)
+			out[key] = scrubValue(val, depth+1)
 		}
 		return out
 	case reflect.Slice, reflect.Array:
@@ -172,11 +191,12 @@ func scrubValue(v any, depth int) any {
 			if !f.IsExported() {
 				continue
 			}
-			if isSensitiveKey(f.Name) {
+			fv := rv.Field(i).Interface()
+			if isSensitiveKey(f.Name) && !isMeasurement(fv) {
 				out[f.Name] = redacted
 				continue
 			}
-			out[f.Name] = scrubValue(rv.Field(i).Interface(), depth+1)
+			out[f.Name] = scrubValue(fv, depth+1)
 		}
 		return out
 	default:

--- a/pkg/errtrack/scrub.go
+++ b/pkg/errtrack/scrub.go
@@ -185,10 +185,11 @@ func scrubValue(v any, depth int) any {
 	}
 }
 
-// scrubEvent is the SDK's BeforeSend hook: the last checkpoint before
-// anything leaves the process. It walks the payload surfaces that can
-// carry operator data — message, exception values, tags, contexts,
-// request headers/query — and redacts each in place.
+// scrubEvent is the SDK's BeforeSend AND BeforeSendTransaction hook:
+// the last checkpoint before anything leaves the process. It walks the
+// payload surfaces that can carry operator data — message, exception
+// values, tags, contexts, request headers/query, spans — and redacts
+// each in place.
 func scrubEvent(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 	if event == nil {
 		return nil
@@ -223,6 +224,12 @@ func scrubEvent(event *sentry.Event, _ *sentry.EventHint) *sentry.Event {
 	}
 	for _, b := range event.Breadcrumbs {
 		scrubBreadcrumbInPlace(b)
+	}
+	// Transaction events carry their timing tree here. Mutating the
+	// spans is safe: the SDK pre-serialises them only after the
+	// BeforeSend* hooks have run.
+	for _, s := range event.Spans {
+		scrubSpanInPlace(s)
 	}
 	if event.Request != nil {
 		for k := range event.Request.Headers {

--- a/pkg/errtrack/scrub_test.go
+++ b/pkg/errtrack/scrub_test.go
@@ -148,3 +148,47 @@ func TestRedactCommonSecretShapes(t *testing.T) {
 		t.Errorf("over-redaction of benign prose: %q -> %q", benign, got)
 	}
 }
+
+// A credential is text; a count is a number. The key filter has to keep
+// "token" (for access_token and friends), so the numeric exemption is
+// what stops it from destroying every token count iterion measures.
+func TestNumericValuesSurviveASensitiveKeyName(t *testing.T) {
+	got := scrubFields(map[string]any{
+		"input_tokens":  1200,
+		"total_tokens":  int64(1250),
+		"cost_usd":      0.42,
+		"session_count": 3,
+		"access_token":  "ghp_0123456789abcdefghij",
+		"api_key":       "sk-live-0123456789abcdef",
+		"nested": map[string]any{
+			"output_tokens": 50,
+			"auth_token":    "hunter2hunter2",
+		},
+	})
+
+	for k, want := range map[string]any{
+		"input_tokens":  1200,
+		"total_tokens":  int64(1250),
+		"cost_usd":      0.42,
+		"session_count": 3,
+	} {
+		if got[k] != want {
+			t.Errorf("%s = %v, want the measurement %v", k, got[k], want)
+		}
+	}
+	for _, k := range []string{"access_token", "api_key"} {
+		if got[k] != redacted {
+			t.Errorf("%s = %v — a credential must never survive", k, got[k])
+		}
+	}
+	nested, ok := got["nested"].(map[string]any)
+	if !ok {
+		t.Fatalf("nested = %T", got["nested"])
+	}
+	if nested["output_tokens"] != 50 {
+		t.Errorf("nested count = %v", nested["output_tokens"])
+	}
+	if nested["auth_token"] != redacted {
+		t.Errorf("nested credential = %v", nested["auth_token"])
+	}
+}

--- a/pkg/errtrack/scrub_test.go
+++ b/pkg/errtrack/scrub_test.go
@@ -192,3 +192,36 @@ func TestNumericValuesSurviveASensitiveKeyName(t *testing.T) {
 		t.Errorf("nested credential = %v", nested["auth_token"])
 	}
 }
+
+// Transactions carry the full request envelope (sentryhttp SetRequest),
+// so iterion's own request-borne credentials must be scrubbed: the
+// X-Iterion-Run bearer (bare hex — only the header NAME identifies it)
+// and the OAuth callback's code/state query parameters.
+func TestRequestCredentialsAreScrubbedFromTransactions(t *testing.T) {
+	ev := &sentry.Event{
+		Type: "transaction",
+		Request: &sentry.Request{
+			Headers: map[string]string{
+				"X-Iterion-Run": "3f9a1c0d2b4e5f60718293a4b5c6d7e8",
+				"Accept":        "application/json",
+			},
+			QueryString: "code=authcode1234567&state=csrf9876543&redirect_uri=https%3A%2F%2Fapp%2Fcb",
+			URL:         "https://host/api/auth/oidc/callback?code=authcode1234567",
+		},
+	}
+	got := scrubEvent(ev, nil)
+	if v := got.Request.Headers["X-Iterion-Run"]; strings.Contains(v, "3f9a1c0d") {
+		t.Errorf("X-Iterion-Run bearer leaked: %q", v)
+	}
+	if got.Request.Headers["Accept"] != "application/json" {
+		t.Errorf("benign header over-redacted: %q", got.Request.Headers["Accept"])
+	}
+	for _, s := range []string{got.Request.QueryString, got.Request.URL} {
+		if strings.Contains(s, "authcode1234567") || strings.Contains(s, "csrf9876543") {
+			t.Errorf("OAuth code/state leaked: %q", s)
+		}
+	}
+	if !strings.Contains(got.Request.QueryString, "redirect_uri") {
+		t.Errorf("benign query param destroyed: %q", got.Request.QueryString)
+	}
+}

--- a/pkg/errtrack/scrub_test.go
+++ b/pkg/errtrack/scrub_test.go
@@ -202,16 +202,20 @@ func TestRequestCredentialsAreScrubbedFromTransactions(t *testing.T) {
 		Type: "transaction",
 		Request: &sentry.Request{
 			Headers: map[string]string{
-				"X-Iterion-Run": "3f9a1c0d2b4e5f60718293a4b5c6d7e8",
-				"Accept":        "application/json",
+				"X-Iterion-Run":     "3f9a1c0d2b4e5f60718293a4b5c6d7e8",
+				"X-Iterion-Refresh": "9d8c7b6a5f4e3d2c1b0a998877665544",
+				"Accept":            "application/json",
 			},
-			QueryString: "code=authcode1234567&state=csrf9876543&redirect_uri=https%3A%2F%2Fapp%2Fcb",
+			QueryString: "code=authcode1234567&state=csrf9876543&sig=a1b2c3d4e5f60718&exp=1755640000&redirect_uri=https%3A%2F%2Fapp%2Fcb",
 			URL:         "https://host/api/auth/oidc/callback?code=authcode1234567",
 		},
 	}
 	got := scrubEvent(ev, nil)
 	if v := got.Request.Headers["X-Iterion-Run"]; strings.Contains(v, "3f9a1c0d") {
 		t.Errorf("X-Iterion-Run bearer leaked: %q", v)
+	}
+	if v := got.Request.Headers["X-Iterion-Refresh"]; strings.Contains(v, "9d8c7b6a") {
+		t.Errorf("X-Iterion-Refresh session token leaked: %q", v)
 	}
 	if got.Request.Headers["Accept"] != "application/json" {
 		t.Errorf("benign header over-redacted: %q", got.Request.Headers["Accept"])
@@ -220,6 +224,12 @@ func TestRequestCredentialsAreScrubbedFromTransactions(t *testing.T) {
 		if strings.Contains(s, "authcode1234567") || strings.Contains(s, "csrf9876543") {
 			t.Errorf("OAuth code/state leaked: %q", s)
 		}
+	}
+	if strings.Contains(got.Request.QueryString, "a1b2c3d4e5f60718") {
+		t.Errorf("presigned-attachment sig leaked: %q", got.Request.QueryString)
+	}
+	if !strings.Contains(got.Request.QueryString, "exp=1755640000") {
+		t.Errorf("benign exp param destroyed: %q", got.Request.QueryString)
 	}
 	if !strings.Contains(got.Request.QueryString, "redirect_uri") {
 		t.Errorf("benign query param destroyed: %q", got.Request.QueryString)

--- a/pkg/errtrack/span.go
+++ b/pkg/errtrack/span.go
@@ -20,10 +20,13 @@ type Span struct{ span *sentry.Span }
 //
 // op is the machine-facing operation ("llm.generate"); name is the
 // low-cardinality label ("anthropic/claude-opus-5"). When ctx carries a
-// parent (an in-flight HTTP request) the result is a child span;
-// otherwise it is a standalone transaction — which is the shape of
-// everything iterion does off a request, and the reason name must stay
-// a bounded set rather than, say, a run id.
+// parent span the result is a child span; otherwise it is a standalone
+// transaction. ONLY use it for work that lives and dies INSIDE the
+// parent's lifetime (a step of the HTTP request being traced): a child
+// finished after its transaction was sent is silently dropped by the
+// SDK, and a run launched from an API request keeps that request's
+// (long-finished) transaction in its context — use StartIndependent for
+// any background lifetime.
 func StartSpan(ctx context.Context, op, name string) (context.Context, *Span) {
 	if !tracing.Load() {
 		return ctx, nil
@@ -31,6 +34,23 @@ func StartSpan(ctx context.Context, op, name string) (context.Context, *Span) {
 	s := sentry.StartSpan(ctx, op, sentry.WithTransactionName(op+" "+name))
 	s.Description = name
 	return s.Context(), &Span{span: s}
+}
+
+// StartIndependent times one unit of work as its OWN transaction,
+// deliberately ignoring any span the caller's context may carry. This
+// is the right shape for background lifetimes — a run's LLM call, a
+// worker step — whose context is derived from a launch request: the
+// request's transaction finished long ago, so parenting under it would
+// orphan the span (never exported), and inspecting the finished span
+// cross-goroutine would race. name must stay a bounded set (a
+// provider/model), never a run id.
+func StartIndependent(op, name string) *Span {
+	if !tracing.Load() {
+		return nil
+	}
+	s := sentry.StartSpan(context.Background(), op, sentry.WithTransactionName(op+" "+name))
+	s.Description = name
+	return &Span{span: s}
 }
 
 // SetData attaches a measurement to the span — token counts, sizes.

--- a/pkg/errtrack/span.go
+++ b/pkg/errtrack/span.go
@@ -1,0 +1,67 @@
+package errtrack
+
+import (
+	"context"
+
+	sentry "github.com/getsentry/sentry-go"
+)
+
+// Span is the handle StartSpan hands back. A nil *Span is the disabled
+// case and every method tolerates it, so a call site is three lines
+// with no `if` around them.
+type Span struct{ span *sentry.Span }
+
+// StartSpan times one unit of work and returns the context its children
+// should use.
+//
+// **A nil Span and the caller's own ctx when tracing is off** — nothing
+// is allocated, so a hot seam pays a single atomic load for carrying
+// the instrumentation.
+//
+// op is the machine-facing operation ("llm.generate"); name is the
+// low-cardinality label ("anthropic/claude-opus-5"). When ctx carries a
+// parent (an in-flight HTTP request) the result is a child span;
+// otherwise it is a standalone transaction — which is the shape of
+// everything iterion does off a request, and the reason name must stay
+// a bounded set rather than, say, a run id.
+func StartSpan(ctx context.Context, op, name string) (context.Context, *Span) {
+	if !tracing.Load() {
+		return ctx, nil
+	}
+	s := sentry.StartSpan(ctx, op, sentry.WithTransactionName(op+" "+name))
+	s.Description = name
+	return s.Context(), &Span{span: s}
+}
+
+// SetData attaches a measurement to the span — token counts, sizes.
+// Values pass the scrubber before they leave the process, like every
+// other payload.
+func (s *Span) SetData(key string, value any) {
+	if s == nil {
+		return
+	}
+	s.span.SetData(key, value)
+}
+
+// SetTag attaches an indexed, low-cardinality label (a provider name, a
+// backend id). Never a run id or a prompt.
+func (s *Span) SetTag(key, value string) {
+	if s == nil {
+		return
+	}
+	s.span.SetTag(key, value)
+}
+
+// Finish closes the span, recording err as its status. Safe on a nil
+// Span, and safe to call twice.
+func (s *Span) Finish(err error) {
+	if s == nil {
+		return
+	}
+	if err != nil {
+		s.span.Status = sentry.SpanStatusInternalError
+	} else {
+		s.span.Status = sentry.SpanStatusOK
+	}
+	s.span.Finish()
+}

--- a/pkg/errtrack/span_test.go
+++ b/pkg/errtrack/span_test.go
@@ -1,0 +1,88 @@
+package errtrack
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	sentry "github.com/getsentry/sentry-go"
+)
+
+func TestStartSpanIsFreeWhenTracingIsOff(t *testing.T) {
+	t.Setenv(EnvTracesSampleRate, "")
+	tr := enable(t, Config{})
+
+	base := context.Background()
+	ctx, span := StartSpan(base, "llm.generate", "anthropic/claude-opus-5")
+	if span != nil {
+		t.Fatal("a span was allocated while tracing is off")
+	}
+	//nolint:staticcheck // the point IS that the caller's own ctx comes back.
+	if ctx != base {
+		t.Fatal("StartSpan replaced the caller's context while tracing is off")
+	}
+	// Every method has to tolerate the nil handle, or the call site
+	// needs an `if` around it and the seam stops being free.
+	span.SetTag("llm.provider", "anthropic")
+	span.SetData("llm.input_tokens", 42)
+	span.Finish(errors.New("boom"))
+	span.Finish(nil)
+
+	Flush()
+	if got := len(transactions(tr.all())); got != 0 {
+		t.Fatalf("tracing off produced %d transaction(s)", got)
+	}
+}
+
+func TestStartSpanWithNoParentIsAStandaloneTransaction(t *testing.T) {
+	tr := enable(t, Config{TracesSampleRate: rate(1)})
+
+	_, span := StartSpan(context.Background(), "llm.generate", "anthropic/claude-opus-5")
+	span.SetTag("llm.provider", "anthropic")
+	span.SetData("llm.input_tokens", 1200)
+	span.Finish(nil)
+	Flush()
+
+	txns := transactions(tr.all())
+	if len(txns) != 1 {
+		t.Fatalf("want 1 transaction, got %d", len(txns))
+	}
+	if txns[0].Transaction != "llm.generate anthropic/claude-opus-5" {
+		t.Errorf("transaction name = %q", txns[0].Transaction)
+	}
+	if txns[0].Tags["llm.provider"] != "anthropic" {
+		t.Errorf("tags = %v", txns[0].Tags)
+	}
+}
+
+func TestStartSpanUnderARequestIsAChildSpan(t *testing.T) {
+	tr := enable(t, Config{TracesSampleRate: rate(1)})
+
+	txn := sentry.StartTransaction(context.Background(), "GET /api/runs/{id}")
+	ctx, span := StartSpan(txn.Context(), "llm.generate", "openai/gpt-5.4-mini")
+	span.SetData("llm.output_tokens", 7)
+	span.Finish(errors.New("stream died"))
+	txn.Finish()
+	Flush()
+
+	txns := transactions(tr.all())
+	if len(txns) != 1 {
+		t.Fatalf("want 1 transaction (the request), got %d", len(txns))
+	}
+	if len(txns[0].Spans) != 1 {
+		t.Fatalf("the generation did not attach to the request: %d span(s)", len(txns[0].Spans))
+	}
+	child := txns[0].Spans[0]
+	if child.Op != "llm.generate" {
+		t.Errorf("span op = %q", child.Op)
+	}
+	if child.Description != "openai/gpt-5.4-mini" {
+		t.Errorf("span description = %q", child.Description)
+	}
+	if child.Status != sentry.SpanStatusInternalError {
+		t.Errorf("a failed call reported status %v", child.Status)
+	}
+	if sentry.SpanFromContext(ctx) == nil {
+		t.Error("StartSpan returned a context carrying no span")
+	}
+}

--- a/pkg/errtrack/tracing.go
+++ b/pkg/errtrack/tracing.go
@@ -1,0 +1,92 @@
+package errtrack
+
+import (
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"sync/atomic"
+
+	sentry "github.com/getsentry/sentry-go"
+
+	"github.com/SocialGouv/iterion/pkg/log"
+)
+
+// EnvTracesSampleRate is the tracing dial: the fraction of units of
+// work (an API request, one LLM generation) recorded as a Sentry
+// transaction, in [0, 1].
+//
+// It is a SECOND opt-in on top of SENTRY_DSN, and the SDK does not read
+// it on its own — Init does, below. Unset, 0, or unparsable ⇒ tracing is
+// strictly off even with a DSN configured, because a transaction per
+// request is a cost an operator opts into deliberately.
+const EnvTracesSampleRate = "SENTRY_TRACES_SAMPLE_RATE"
+
+// tracing mirrors "the installed client has tracing enabled". Separate
+// from enabled so a hot seam can skip building a span with one atomic
+// load, without asking the SDK.
+var tracing atomic.Bool
+
+// TracingEnabled reports whether transactions/spans are being recorded.
+// Guard every hand-made span with it: with tracing off a span costs
+// nothing because it is never created.
+//
+// It implies Enabled() — tracing rides the same client and DSN.
+func TracingEnabled() bool { return tracing.Load() }
+
+// resolveTracesSampleRate reads the sampling dial, in Config-then-env
+// precedence, and returns 0 (off) for anything it refuses.
+//
+// Only called once a DSN is configured, so an operator with tracking
+// off never sees a line about a var they did not set.
+func resolveTracesSampleRate(cfg Config, logger *log.Logger) float64 {
+	if cfg.TracesSampleRate != nil {
+		return validSampleRate(*cfg.TracesSampleRate, "Config.TracesSampleRate", logger)
+	}
+	raw := strings.TrimSpace(os.Getenv(EnvTracesSampleRate))
+	if raw == "" {
+		return 0
+	}
+	rate, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		logger.Error("errtrack: %s=%q is not a number — tracing disabled", EnvTracesSampleRate, Redact(raw))
+		return 0
+	}
+	return validSampleRate(rate, EnvTracesSampleRate, logger)
+}
+
+// validSampleRate returns rate when it is a usable fraction and 0
+// otherwise, reporting the refusal loudly. The comparison is written as
+// a negated conjunction on purpose: NaN fails every ordered comparison,
+// so `rate < 0 || rate > 1` would let it through and hand the SDK a
+// sampler that decides nothing.
+func validSampleRate(rate float64, source string, logger *log.Logger) float64 {
+	if math.IsNaN(rate) || !(rate >= 0 && rate <= 1) {
+		logger.Error("errtrack: %s=%v is outside [0,1] — tracing disabled", source, rate)
+		return 0
+	}
+	return rate
+}
+
+// scrubSpanInPlace redacts the operator-supplied surfaces of one span.
+// Called from scrubEvent for every span of a transaction event, which
+// reaches the wire through BeforeSendTransaction — a hook BeforeSend
+// never sees.
+func scrubSpanInPlace(s *sentry.Span) {
+	if s == nil {
+		return
+	}
+	s.Name = Redact(s.Name)
+	s.Op = Redact(s.Op)
+	s.Description = Redact(s.Description)
+	for k, v := range s.Tags {
+		if isSensitiveKey(k) {
+			s.Tags[k] = redacted
+			continue
+		}
+		s.Tags[k] = Redact(v)
+	}
+	if len(s.Data) > 0 {
+		s.Data = scrubFields(s.Data)
+	}
+}

--- a/pkg/errtrack/tracing_test.go
+++ b/pkg/errtrack/tracing_test.go
@@ -163,3 +163,39 @@ func TestSpansAreScrubbedBeforeSend(t *testing.T) {
 		t.Errorf("scrubbing destroyed a harmless span field: %v", got.Data["model"])
 	}
 }
+
+// A context that still carries a FINISHED transaction — exactly what a
+// run launched from an API request holds by the time it makes its first
+// LLM call — silently orphans any child started on it: the SDK drops a
+// child finished after its transaction was sent. This test pins that
+// SDK behaviour (the reason StartIndependent exists) and proves the
+// independent form survives the same context.
+func TestIndependentSpanSurvivesAFinishedParentTransaction(t *testing.T) {
+	tr := enable(t, Config{TracesSampleRate: rate(1)})
+
+	parent := sentry.StartSpan(context.Background(), "http.server",
+		sentry.WithTransactionName("GET /api/runs"))
+	deadCtx := parent.Context()
+	parent.Finish()
+	Flush()
+	if got := len(transactions(tr.all())); got != 1 {
+		t.Fatalf("expected the request transaction alone, got %d", got)
+	}
+
+	// The orphan: a child of the finished transaction is never exported.
+	_, orphan := StartSpan(deadCtx, "llm.generate", "anthropic/claude-opus-5")
+	orphan.Finish(nil)
+	Flush()
+	if got := len(transactions(tr.all())); got != 1 {
+		t.Fatalf("a child of a finished transaction should be dropped by the SDK; transport now has %d", got)
+	}
+
+	// The fix: the independent form exports regardless of the context.
+	span := StartIndependent("llm.generate", "anthropic/claude-opus-5")
+	span.SetTag("llm.provider", "anthropic")
+	span.Finish(nil)
+	Flush()
+	if got := len(transactions(tr.all())); got != 2 {
+		t.Fatalf("StartIndependent should export its own transaction; transport has %d", got)
+	}
+}

--- a/pkg/errtrack/tracing_test.go
+++ b/pkg/errtrack/tracing_test.go
@@ -1,0 +1,165 @@
+package errtrack
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	sentry "github.com/getsentry/sentry-go"
+
+	"github.com/SocialGouv/iterion/pkg/log"
+)
+
+func rate(v float64) *float64 { return &v }
+
+// transactions filters the recorded envelopes down to transaction
+// events — the only ones tracing produces.
+func transactions(evs []*sentry.Event) []*sentry.Event {
+	var out []*sentry.Event
+	for _, e := range evs {
+		if e.Type == "transaction" {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func TestTracingIsOffWhenTheSampleRateEnvIsUnset(t *testing.T) {
+	t.Setenv(EnvTracesSampleRate, "")
+
+	var buf bytes.Buffer
+	tr := enable(t, Config{Logger: log.New(log.LevelTrace, &buf)})
+
+	if !Enabled() {
+		t.Fatal("error tracking should be on with a DSN")
+	}
+	if TracingEnabled() {
+		t.Fatal("tracing must stay off when the sample rate is unset")
+	}
+
+	// The whole point: a transaction started anyway is never recorded.
+	sentry.StartTransaction(context.Background(), "unsampled").Finish()
+	Flush()
+	if got := len(transactions(tr.all())); got != 0 {
+		t.Fatalf("tracing off produced %d transaction(s)", got)
+	}
+}
+
+func TestTracingOnRecordsOneTransactionPerUnitOfWork(t *testing.T) {
+	tr := enable(t, Config{TracesSampleRate: rate(1)})
+
+	if !TracingEnabled() {
+		t.Fatal("TracingEnabled() false with rate 1")
+	}
+	sentry.StartTransaction(context.Background(), "iterion.test.unit").Finish()
+	Flush()
+
+	txns := transactions(tr.all())
+	if len(txns) != 1 {
+		t.Fatalf("want 1 transaction, got %d", len(txns))
+	}
+	if txns[0].Transaction != "iterion.test.unit" {
+		t.Errorf("transaction name = %q", txns[0].Transaction)
+	}
+}
+
+func TestExplicitZeroSampleRateIsOff(t *testing.T) {
+	// The env says "trace everything"; the caller's explicit 0 wins.
+	t.Setenv(EnvTracesSampleRate, "1.0")
+	tr := enable(t, Config{TracesSampleRate: rate(0)})
+
+	if TracingEnabled() {
+		t.Fatal("an explicit rate of 0 must disable tracing")
+	}
+	sentry.StartTransaction(context.Background(), "unsampled").Finish()
+	Flush()
+	if got := len(transactions(tr.all())); got != 0 {
+		t.Fatalf("rate 0 produced %d transaction(s)", got)
+	}
+}
+
+func TestSampleRateFromTheEnvEnablesTracing(t *testing.T) {
+	t.Setenv(EnvTracesSampleRate, "1")
+	tr := enable(t, Config{})
+
+	if !TracingEnabled() {
+		t.Fatal("SENTRY_TRACES_SAMPLE_RATE=1 did not enable tracing")
+	}
+	sentry.StartTransaction(context.Background(), "from.env").Finish()
+	Flush()
+	if got := len(transactions(tr.all())); got != 1 {
+		t.Fatalf("want 1 transaction, got %d", got)
+	}
+}
+
+func TestUnusableSampleRateIsLoudAndOff(t *testing.T) {
+	for _, raw := range []string{"banana", "1.5", "-0.1", "NaN", "Inf"} {
+		t.Run(raw, func(t *testing.T) {
+			t.Setenv(EnvTracesSampleRate, raw)
+			var buf bytes.Buffer
+			enable(t, Config{Logger: log.New(log.LevelError, &buf)})
+
+			if TracingEnabled() {
+				t.Fatalf("%q enabled tracing", raw)
+			}
+			if !Enabled() {
+				t.Fatal("a bad sample rate must not disable ERROR tracking")
+			}
+			out := buf.String()
+			if !strings.Contains(out, EnvTracesSampleRate) {
+				t.Fatalf("the refusal was not reported: %q", out)
+			}
+		})
+	}
+}
+
+func TestABadSampleRateIsSilentWhenTrackingIsOff(t *testing.T) {
+	t.Setenv(EnvDSN, "")
+	t.Setenv(EnvTracesSampleRate, "banana")
+	reset()
+	t.Cleanup(reset)
+
+	var buf bytes.Buffer
+	if Init(Config{Logger: log.New(log.LevelTrace, &buf)}) {
+		t.Fatal("Init reported enabled with no DSN")
+	}
+	if got := buf.String(); got != "" {
+		t.Fatalf("no DSN must mean no output at all, got %q", got)
+	}
+}
+
+func TestSpansAreScrubbedBeforeSend(t *testing.T) {
+	tr := enable(t, Config{TracesSampleRate: rate(1)})
+
+	txn := sentry.StartTransaction(context.Background(), "iterion.test.scrub")
+	span := txn.StartChild("llm.generate")
+	span.Description = "call to https://user:hunter2@api.example.com/v1"
+	span.SetTag("api_key", "sk-live-0123456789abcdef")
+	span.SetData("operator", "someone@example.com")
+	span.SetData("model", "anthropic/claude-opus-5")
+	span.Finish()
+	txn.Finish()
+	Flush()
+
+	txns := transactions(tr.all())
+	if len(txns) != 1 {
+		t.Fatalf("want 1 transaction, got %d", len(txns))
+	}
+	if len(txns[0].Spans) != 1 {
+		t.Fatalf("want 1 child span, got %d", len(txns[0].Spans))
+	}
+	got := txns[0].Spans[0]
+	if strings.Contains(got.Description, "hunter2") {
+		t.Errorf("span description leaked userinfo: %q", got.Description)
+	}
+	if got.Tags["api_key"] != redacted {
+		t.Errorf("span tag api_key = %q", got.Tags["api_key"])
+	}
+	if s, _ := got.Data["operator"].(string); strings.Contains(s, "someone@example.com") {
+		t.Errorf("span data leaked an email: %q", s)
+	}
+	if got.Data["model"] != "anthropic/claude-opus-5" {
+		t.Errorf("scrubbing destroyed a harmless span field: %v", got.Data["model"])
+	}
+}

--- a/pkg/server/gosafe_errtrack_test.go
+++ b/pkg/server/gosafe_errtrack_test.go
@@ -51,10 +51,16 @@ var (
 func enableTracker(t *testing.T) *memTransport {
 	t.Helper()
 	trackerTransportOn.Do(func() {
+		fullSampling := 1.0
 		errtrack.Init(errtrack.Config{
 			DSN:       "https://publickey@localhost/1",
 			Transport: trackerTransport,
 			Logger:    iterlog.New(iterlog.LevelError, io.Discard),
+			// Tracing on, so the same single Init also covers the
+			// request-transaction wiring (see tracing_test.go). Only a
+			// test that drives srv.handler produces transactions; the
+			// rest of the suite substitutes srv.mux.
+			TracesSampleRate: &fullSampling,
 		})
 	})
 	if !errtrack.Enabled() {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -567,7 +567,13 @@ func New(cfg Config, logger *iterlog.Logger) *Server {
 	// every /api/* call requires a valid bearer / cookie. DEV
 	// override: cfg.DisableAuth synthesizes a super-admin Identity
 	// instead of rejecting unauthenticated requests.
-	s.handler = s.authMiddleware(s.mux)
+	// Outermost: one Sentry transaction per request, named after the
+	// route pattern rather than the URL. Identity middleware unless
+	// SENTRY_TRACES_SAMPLE_RATE turned tracing on, so the chain below
+	// is untouched on a deployment that did not ask for it.
+	s.handler = errtrack.HTTPMiddleware(errtrack.HTTPOptions{RouteName: s.routePattern})(
+		s.authMiddleware(s.mux),
+	)
 	s.server = &http.Server{
 		Addr:              net.JoinHostPort(cfg.Bind, fmt.Sprintf("%d", cfg.Port)),
 		Handler:           s.handler,

--- a/pkg/server/tracing.go
+++ b/pkg/server/tracing.go
@@ -1,0 +1,21 @@
+package server
+
+import "net/http"
+
+// routePattern resolves a request to the route pattern the mux would
+// match ("GET /api/runs/{id}"), which is the name a request-scoped
+// Sentry transaction should carry: one per ROUTE, not one per URL.
+//
+// The lookup is needed because the auth layer forwards a
+// r.WithContext() copy to the mux, so the pattern net/http stamps
+// during routing never reaches the outermost middleware.
+//
+// Returns "" when nothing matches (the tracer then names the
+// transaction itself) — and is only ever called when tracing is on.
+func (s *Server) routePattern(r *http.Request) string {
+	if s == nil || s.mux == nil {
+		return ""
+	}
+	_, pattern := s.mux.Handler(r)
+	return pattern
+}

--- a/pkg/server/tracing_test.go
+++ b/pkg/server/tracing_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	sentry "github.com/getsentry/sentry-go"
+
+	"github.com/SocialGouv/iterion/pkg/errtrack"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// tracedServer builds a Server whose full handler chain (the one
+// http.Server is given) is exercised — not srv.mux, which every other
+// test substitutes to bypass auth.
+func tracedServer(t *testing.T) *Server {
+	t.Helper()
+	workDir := t.TempDir()
+	return New(Config{
+		DisableAuth:             true,
+		WorkDir:                 workDir,
+		StoreDir:                filepath.Join(workDir, ".iterion"),
+		SkipProjectRegistration: true,
+	}, iterlog.New(iterlog.LevelError, os.Stderr))
+}
+
+func newTransactions(before, after []*sentry.Event) []*sentry.Event {
+	var out []*sentry.Event
+	for _, e := range after[len(before):] {
+		if e.Type == "transaction" {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// The wiring proof: an API request served by the REAL handler chain
+// (tracing middleware → auth → mux) becomes one transaction, named
+// after the route pattern rather than the URL — so a thousand run ids
+// stay one entry in the performance view instead of a thousand.
+func TestAPIRequestBecomesOneRouteNamedTransaction(t *testing.T) {
+	tr := enableTracker(t)
+	if !errtrack.TracingEnabled() {
+		t.Fatal("tracing is off — the test binary's Init did not set a sample rate")
+	}
+	srv := tracedServer(t)
+	seedRun(t, srv, "run-traced-1", "demo", store.RunStatusFinished)
+	before := tr.all()
+
+	rec := httptest.NewRecorder()
+	srv.handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/runs/run-traced-1", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d — the middleware changed the response", rec.Code)
+	}
+	errtrack.Flush()
+
+	txns := newTransactions(before, tr.all())
+	if len(txns) != 1 {
+		t.Fatalf("want 1 transaction for 1 request, got %d", len(txns))
+	}
+	if txns[0].Transaction != "GET /api/runs/{id}" {
+		t.Errorf("transaction name = %q, want the route pattern", txns[0].Transaction)
+	}
+}
+
+// routePattern is what keeps transaction cardinality bounded; it must
+// resolve the mux's registered pattern for a request the auth layer may
+// never forward, and stay quiet on a path nothing serves.
+func TestRoutePatternResolvesTheRegisteredPattern(t *testing.T) {
+	srv := tracedServer(t)
+
+	if got := srv.routePattern(httptest.NewRequest(http.MethodGet, "/api/runs/abc123", nil)); got != "GET /api/runs/{id}" {
+		t.Errorf("routePattern = %q", got)
+	}
+	// Anything the API does not claim falls to the SPA catch-all —
+	// still one name, which is the whole point.
+	if got := srv.routePattern(httptest.NewRequest(http.MethodGet, "/some/spa/deep/link", nil)); got != "GET /" {
+		t.Errorf("routePattern on an SPA path = %q, want the catch-all", got)
+	}
+	var nilSrv *Server
+	if got := nilSrv.routePattern(httptest.NewRequest(http.MethodGet, "/api/runs/abc", nil)); got != "" {
+		t.Errorf("routePattern on a nil server = %q", got)
+	}
+}

--- a/vendor/github.com/getsentry/sentry-go/http/README.md
+++ b/vendor/github.com/getsentry/sentry-go/http/README.md
@@ -1,0 +1,135 @@
+<p align="center">
+  <a href="https://sentry.io" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <br />
+</p>
+
+# Official Sentry net/http Handler for Sentry-go SDK
+
+**go.dev:** https://pkg.go.dev/github.com/getsentry/sentry-go/http
+
+**Example:** https://github.com/getsentry/sentry-go/tree/master/_examples/http
+
+## Installation
+
+```sh
+go get github.com/getsentry/sentry-go/http
+```
+
+```go
+import (
+    "fmt"
+    "net/http"
+
+    "github.com/getsentry/sentry-go"
+    sentryhttp "github.com/getsentry/sentry-go/http"
+)
+
+// To initialize Sentry's handler, you need to initialize Sentry itself beforehand
+if err := sentry.Init(sentry.ClientOptions{
+    Dsn: "your-public-dsn",
+}); err != nil {
+    fmt.Printf("Sentry initialization failed: %v\n", err)
+}
+
+// Create an instance of sentryhttp
+sentryHandler := sentryhttp.New(sentryhttp.Options{})
+
+// Once it's done, you can setup routes and attach the handler as one of your middleware
+http.Handle("/", sentryHandler.Handle(&handler{}))
+http.HandleFunc("/foo", sentryHandler.HandleFunc(func(rw http.ResponseWriter, r *http.Request) {
+    panic("y tho")
+}))
+
+fmt.Println("Listening and serving HTTP on :3000")
+
+// And run it
+if err := http.ListenAndServe(":3000", nil); err != nil {
+    panic(err)
+}
+```
+
+## Configuration
+
+`sentryhttp` accepts a struct of `Options` that allows you to configure how the handler will behave.
+
+Currently it respects 3 options:
+
+```go
+// Whether Sentry should repanic after recovery, in most cases it should be set to true,
+// and you should gracefully handle http responses.
+Repanic         bool
+// Whether you want to block the request before moving forward with the response.
+// Useful, when you want to restart the process after it panics.
+WaitForDelivery bool
+// Timeout for the event delivery requests.
+Timeout         time.Duration
+```
+
+## Usage
+
+`sentryhttp` attaches an instance of `*sentry.Hub` (https://pkg.go.dev/github.com/getsentry/sentry-go#Hub) to the request's context, which makes it available throughout the rest of the request's lifetime.
+You can access it by using the `sentry.GetHubFromContext()` method on the request itself in any of your proceeding middleware and routes.
+And it should be used instead of the global `sentry.CaptureMessage`, `sentry.CaptureException`, or any other calls, as it keeps the separation of data between the requests.
+
+**Keep in mind that `*sentry.Hub` won't be available in middleware attached before to `sentryhttp`!**
+
+```go
+type handler struct{}
+
+func (h *handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	if hub := sentry.GetHubFromContext(r.Context()); hub != nil {
+		hub.WithScope(func(scope *sentry.Scope) {
+			scope.SetTag("unwantedQuery", "someQueryDataMaybe")
+			hub.CaptureMessage("User provided unwanted query string, but we recovered just fine")
+		})
+	}
+	rw.WriteHeader(http.StatusOK)
+}
+
+func enhanceSentryEvent(handler http.HandlerFunc) http.HandlerFunc {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		if hub := sentry.GetHubFromContext(r.Context()); hub != nil {
+			hub.Scope().SetTag("someRandomTag", "maybeYouNeedIt")
+		}
+		handler(rw, r)
+	}
+}
+
+// Later in the code
+
+sentryHandler := sentryhttp.New(sentryhttp.Options{
+    Repanic: true,
+})
+
+http.Handle("/", sentryHandler.Handle(&handler{}))
+http.HandleFunc("/foo", sentryHandler.HandleFunc(
+    enhanceSentryEvent(func(rw http.ResponseWriter, r *http.Request) {
+        panic("y tho")
+    }),
+))
+
+fmt.Println("Listening and serving HTTP on :3000")
+
+if err := http.ListenAndServe(":3000", nil); err != nil {
+    panic(err)
+}
+```
+
+### Accessing Request in `BeforeSend` callback
+
+```go
+sentry.Init(sentry.ClientOptions{
+    Dsn: "your-public-dsn",
+    BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+        if hint.Context != nil {
+            if req, ok := hint.Context.Value(sentry.RequestContextKey).(*http.Request); ok {
+                // You have access to the original Request here
+            }
+        }
+
+        return event
+    },
+})
+```

--- a/vendor/github.com/getsentry/sentry-go/http/sentryhttp.go
+++ b/vendor/github.com/getsentry/sentry-go/http/sentryhttp.go
@@ -1,0 +1,147 @@
+// Package sentryhttp provides Sentry integration for servers based on the
+// net/http package.
+package sentryhttp
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go/internal/httputils"
+	"github.com/getsentry/sentry-go/internal/traceutils"
+)
+
+// The identifier of the HTTP SDK.
+const sdkIdentifier = "sentry.go.http"
+
+// A Handler is an HTTP middleware factory that provides integration with
+// Sentry.
+type Handler struct {
+	repanic         bool
+	waitForDelivery bool
+	timeout         time.Duration
+}
+
+// Options configure a Handler.
+type Options struct {
+	// Repanic configures whether to panic again after recovering from a panic.
+	// Use this option if you have other panic handlers or want the default
+	// behavior from Go's http package, as documented in
+	// https://golang.org/pkg/net/http/#Handler.
+	Repanic bool
+	// WaitForDelivery indicates, in case of a panic, whether to block the
+	// current goroutine and wait until the panic event has been reported to
+	// Sentry before repanicking or resuming normal execution.
+	//
+	// This option is normally not needed. Unless you need different behaviors
+	// for different HTTP handlers, configure the SDK to use the
+	// HTTPSyncTransport instead.
+	//
+	// Waiting (or using HTTPSyncTransport) is useful when the web server runs
+	// in an environment that interrupts execution at the end of a request flow,
+	// like modern serverless platforms.
+	WaitForDelivery bool
+	// Timeout for the delivery of panic events. Defaults to 2s. Only relevant
+	// when WaitForDelivery is true.
+	//
+	// If the timeout is reached, the current goroutine is no longer blocked
+	// waiting, but the delivery is not canceled.
+	Timeout time.Duration
+}
+
+// New returns a new Handler. Use the Handle and HandleFunc methods to wrap
+// existing HTTP handlers.
+func New(options Options) *Handler {
+	if options.Timeout == 0 {
+		options.Timeout = sentry.DefaultFlushTimeout
+	}
+
+	return &Handler{
+		repanic:         options.Repanic,
+		timeout:         options.Timeout,
+		waitForDelivery: options.WaitForDelivery,
+	}
+}
+
+// Handle works as a middleware that wraps an existing http.Handler. A wrapped
+// handler will recover from and report panics to Sentry, and provide access to
+// a request-specific hub to report messages and errors.
+func (h *Handler) Handle(handler http.Handler) http.Handler {
+	return h.handle(handler)
+}
+
+// HandleFunc is like Handle, but with a handler function parameter for cases
+// where that is convenient. In particular, use it to wrap a handler function
+// literal.
+//
+//	http.Handle(pattern, h.HandleFunc(func (w http.ResponseWriter, r *http.Request) {
+//	    // handler code here
+//	}))
+func (h *Handler) HandleFunc(handler http.HandlerFunc) http.HandlerFunc {
+	return h.handle(handler)
+}
+
+func (h *Handler) handle(handler http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		hub := sentry.GetHubFromContext(r.Context())
+		if hub == nil {
+			hub = sentry.CurrentHub().Clone()
+			ctx = sentry.SetHubOnContext(ctx, hub)
+		}
+
+		if client := hub.Client(); client != nil {
+			client.SetSDKIdentifier(sdkIdentifier)
+		}
+
+		options := []sentry.SpanOption{
+			sentry.ContinueTrace(hub, r.Header.Get(sentry.SentryTraceHeader), r.Header.Get(sentry.SentryBaggageHeader)),
+			sentry.WithOpName("http.server"),
+			sentry.WithTransactionSource(sentry.SourceURL),
+			sentry.WithSpanOrigin(sentry.SpanOriginStdLib),
+		}
+
+		transaction := sentry.StartTransaction(ctx,
+			traceutils.GetHTTPSpanName(r),
+			options...,
+		)
+		transaction.SetData("http.request.method", r.Method)
+
+		rw := httputils.NewWrapResponseWriter(w, r.ProtoMajor)
+
+		defer func() {
+			// r.Pattern is populated by ServeMux after routing, so we
+			// read it here in the defer after the handler has run.
+			if r.Pattern != "" {
+				transaction.Name = traceutils.GetHTTPSpanName(r)
+				transaction.Source = sentry.SourceRoute
+			}
+			status := rw.Status()
+			transaction.Status = sentry.HTTPtoSpanStatus(status)
+			transaction.SetData("http.response.status_code", status)
+			transaction.Finish()
+		}()
+
+		hub.Scope().SetRequest(r)
+		r = r.WithContext(transaction.Context())
+		defer h.recoverWithSentry(hub, r)
+
+		handler.ServeHTTP(rw, r)
+	}
+}
+
+func (h *Handler) recoverWithSentry(hub *sentry.Hub, r *http.Request) {
+	if err := recover(); err != nil {
+		eventID := hub.RecoverWithContext(
+			context.WithValue(r.Context(), sentry.RequestContextKey, r),
+			err,
+		)
+		if eventID != nil && h.waitForDelivery {
+			hub.Flush(h.timeout)
+		}
+		if h.repanic {
+			panic(err)
+		}
+	}
+}

--- a/vendor/github.com/getsentry/sentry-go/internal/traceutils/route_name.go
+++ b/vendor/github.com/getsentry/sentry-go/internal/traceutils/route_name.go
@@ -1,0 +1,21 @@
+package traceutils
+
+import (
+	"net/http"
+	"strings"
+)
+
+// GetHTTPSpanName grab needed fields from *http.Request to generate a span name for `http.server` span op.
+func GetHTTPSpanName(r *http.Request) string {
+	if r.Pattern != "" {
+		// If value does not start with HTTP methods, add them.
+		// The method and the path should be separated by a space.
+		if parts := strings.SplitN(r.Pattern, " ", 2); len(parts) == 1 {
+			return r.Method + " " + r.Pattern
+		}
+
+		return r.Pattern
+	}
+
+	return r.Method + " " + r.URL.Path
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -353,6 +353,7 @@ github.com/fsnotify/fsnotify/internal
 ## explicit; go 1.25.0
 github.com/getsentry/sentry-go
 github.com/getsentry/sentry-go/attribute
+github.com/getsentry/sentry-go/http
 github.com/getsentry/sentry-go/internal/debug
 github.com/getsentry/sentry-go/internal/debuglog
 github.com/getsentry/sentry-go/internal/http
@@ -362,6 +363,7 @@ github.com/getsentry/sentry-go/internal/otel/baggage/internal/baggage
 github.com/getsentry/sentry-go/internal/protocol
 github.com/getsentry/sentry-go/internal/ratelimit
 github.com/getsentry/sentry-go/internal/telemetry
+github.com/getsentry/sentry-go/internal/traceutils
 github.com/getsentry/sentry-go/internal/util
 github.com/getsentry/sentry-go/report
 # github.com/glebarez/go-sqlite v1.22.0


### PR DESCRIPTION
Second Obsy dogfood (run `01a01db3`, bilan in `docs/bot-runs/instrument.md`) — the bot's opt-in **tracing** family exercised for the first time, `scope=errors,logs,tracing`. **Converged in one pass** (vs 3 on the first dogfood — the fleet lessons landed in between compounded).

- **`pkg/errtrack` tracing dial**: enabled iff `SENTRY_TRACES_SAMPLE_RATE` parses > 0 (sentry-go does not read that env natively — read in `Init`); absent/0 ⇒ strictly off even with a DSN; unparsable ⇒ loud error + off; `Config.TracesSampleRate` test seam.
- **One transaction per API request** via the official `sentryhttp` middleware behind `errtrack.HTTPMiddleware()` — identity function when tracing is off (zero overhead, `pkg/server` never imports sentry directly), panic semantics unchanged.
- **Exactly one hand seam**: a span per in-process LLM provider call (`pkg/backend/model/generation.go`), tagged provider/model. Deliberate non-goals documented: no run-length transactions, no engine node-loop instrumentation.
- Docs: `docs/observability.md` Tracing section (sampling guidance: keep prod low, 1.0 only for a smoke) + ADR-088 dated addendum.
- Tests on the in-memory transport (rate=1 ⇒ transactions; rate=0/DSN-unset ⇒ none, middleware is identity). Verified: full `task check` exit=0 (128 pkgs); live smoke — ephemeral server, two `http.server` transactions named by route visible in the Sentry project's Performance page.

Prod note: prod stays tracing-OFF by default (env not set); dialing it on is a one-line values change when wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)