### PR TITLE
fix(errtrack): the independent transaction rides a cloned hub

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -223,7 +223,7 @@ a local session, not for a deployment.
 | Seam | Shape |
 |---|---|
 | **Every API request** ([pkg/server/server.go](../pkg/server/server.go), the root handler) | one transaction named after the **route pattern** — `GET /api/runs/{id}`, not `GET /api/runs/019f83…`, so a thousand run ids stay one entry in the performance view. Status, method and the request context ride along |
-| **Every in-process LLM call** ([pkg/backend/model/generation_request.go](../pkg/backend/model/generation_request.go), `callAndAggregate`) | one `llm.generate` span tagged `llm.provider` / `llm.model` and carrying the call's input/output/cache-read token counts. Under an in-flight request it nests inside that request's transaction; off a request — the normal shape for a run — it is a standalone transaction |
+| **Every in-process LLM call** ([pkg/backend/model/generation_request.go](../pkg/backend/model/generation_request.go), `callAndAggregate`) | one `llm.generate` transaction tagged `llm.provider` / `llm.model` and carrying the call's input/output/cache-read token counts. Always **standalone, on an isolated hub** — a run's context still carries its launch request's long-finished transaction, so nesting under it would orphan the span (never exported) and pollute the global error trace context |
 
 That is the **whole** list, and deliberately so:
 

--- a/pkg/errtrack/span.go
+++ b/pkg/errtrack/span.go
@@ -48,7 +48,14 @@ func StartIndependent(op, name string) *Span {
 	if !tracing.Load() {
 		return nil
 	}
-	s := sentry.StartSpan(context.Background(), op, sentry.WithTransactionName(op+" "+name))
+	// An isolated hub: sentry.StartSpan installs the new span on the
+	// hub's scope and, for a transaction, never restores what was there
+	// — so the process-global hub would leave every later error event
+	// linked to a stale (or, under parallel generations, arbitrary)
+	// llm.generate trace. The clone shares the client, so the
+	// transaction still ships.
+	ctx := sentry.SetHubOnContext(context.Background(), sentry.CurrentHub().Clone())
+	s := sentry.StartSpan(ctx, op, sentry.WithTransactionName(op+" "+name))
 	s.Description = name
 	return &Span{span: s}
 }

--- a/pkg/errtrack/tracing_test.go
+++ b/pkg/errtrack/tracing_test.go
@@ -3,6 +3,7 @@ package errtrack
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -197,5 +198,41 @@ func TestIndependentSpanSurvivesAFinishedParentTransaction(t *testing.T) {
 	Flush()
 	if got := len(transactions(tr.all())); got != 2 {
 		t.Fatalf("StartIndependent should export its own transaction; transport has %d", got)
+	}
+}
+
+// StartIndependent must not leak its transaction onto the process-global
+// hub scope: sentry.StartSpan installs the span on the hub's scope and,
+// for a transaction, doFinish never restores what was there — so on the
+// global hub every LATER error event would inherit the trace context of
+// a stale (or, under parallel generations, arbitrary) llm.generate
+// transaction. The independent span therefore rides a CLONED hub.
+func TestIndependentSpanDoesNotContaminateGlobalErrorTraceContext(t *testing.T) {
+	tr := enable(t, Config{TracesSampleRate: rate(1)})
+
+	span := StartIndependent("llm.generate", "anthropic/claude-opus-5")
+	span.Finish(nil)
+	Flush()
+	txs := transactions(tr.all())
+	if len(txs) != 1 {
+		t.Fatalf("expected the llm transaction, got %d", len(txs))
+	}
+	llmTrace := txs[0].Contexts["trace"]["trace_id"]
+
+	CaptureError(errors.New("boom after generation"), nil)
+	Flush()
+	var errEvent *sentry.Event
+	for _, e := range tr.all() {
+		if e.Type != "transaction" {
+			errEvent = e
+		}
+	}
+	if errEvent == nil {
+		t.Fatal("no error event captured")
+	}
+	if tc, ok := errEvent.Contexts["trace"]; ok {
+		if tc["trace_id"] == llmTrace {
+			t.Fatalf("error event inherited the finished llm transaction's trace context (%v) — StartIndependent leaked its span onto the global hub scope", llmTrace)
+		}
 	}
 }


### PR DESCRIPTION
Closes Revi's post-merge advisory on #463 (R2683ce), verified red-first: `sentry.StartSpan` installs the span on the hub's scope and `doFinish` never restores it for transactions — so `StartIndependent` on the global hub left its finished `llm.generate` transaction on the global scope, and every later error/panic event inherited that unrelated trace context (regression test reproduced the exact trace_id match before the fix). The independent transaction now starts on `CurrentHub().Clone()` — private scope, shared client, still ships. Also fixes the runbook's stale LLM-span row (R5f6696).

🤖 Generated with [Claude Code](https://claude.com/claude-code)