### PR TITLE
fix(runtime): an unknown cost is not a free call

### DIFF
--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -541,8 +541,12 @@ The budget honours that difference rather than folding the absence into a
 and the first time it happens under a declared `max_cost_usd` the run emits
 one advisory `budget_warning` on dimension `cost_usd_unpriced`, whose
 `detail` names how many node executions and how many tokens the ceiling
-cannot see. The run continues — an operator may legitimately want it to —
-but the ceiling never again reads as enforced when it is only partial.
+could not see *at that point*. That figure is a floor, not a total: the
+warning is raised once per ceiling — the operator is told, not spammed —
+while the counters keep climbing behind it, so a run that goes on to burn
+forty unpriced nodes was told about the first. The run continues — an
+operator may legitimately want it to — but the ceiling never again reads as
+enforced when it is only partial.
 
 What reaches it is a model absent from both pricing sources — typically one
 newer than the static table. A backend that publishes no dollar figure of

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -528,6 +528,28 @@ workflow campaign:
   loop_budget_guard: off    # this loop must burn its cap, not stop short
 ```
 
+#### `max_cost_usd` only counts spend it can price
+
+A node's cost is known when the backend meters it (the `claude_code` and
+`pi` CLIs report their own figure) or when the model resolves in the price
+table — the live registry first, then `pkg/backend/cost`'s static table.
+When neither answers, `cost.Annotate` deliberately omits `_cost_usd`: an
+absent value means *no cost data*, never *this call was free*.
+
+The budget honours that difference rather than folding the absence into a
+`0.00` sample. Tokens burned at an unresolvable price are counted apart,
+and the first time it happens under a declared `max_cost_usd` the run emits
+one advisory `budget_warning` on dimension `cost_usd_unpriced`, whose
+`detail` names how many node executions and how many tokens the ceiling
+cannot see. The run continues — an operator may legitimately want it to —
+but the ceiling never again reads as enforced when it is only partial.
+
+Two situations reach it in practice: a backend that reports no cost of its
+own (`codex` parses its token counts but publishes no dollar figure), and a
+model absent from both pricing sources — typically one newer than the
+static table. If the warning fires, either add the model to the table or
+expect `max_cost_usd` to bind on the priced nodes only.
+
 ### The target repo's toolchain — `repo_devbox:`
 
 Two `devbox.json` files can supply a run's binaries, and both are

--- a/docs/dsl.md
+++ b/docs/dsl.md
@@ -544,11 +544,12 @@ one advisory `budget_warning` on dimension `cost_usd_unpriced`, whose
 cannot see. The run continues — an operator may legitimately want it to —
 but the ceiling never again reads as enforced when it is only partial.
 
-Two situations reach it in practice: a backend that reports no cost of its
-own (`codex` parses its token counts but publishes no dollar figure), and a
-model absent from both pricing sources — typically one newer than the
-static table. If the warning fires, either add the model to the table or
-expect `max_cost_usd` to bind on the priced nodes only.
+What reaches it is a model absent from both pricing sources — typically one
+newer than the static table. A backend that publishes no dollar figure of
+its own, like `codex`, is not a separate cause: it falls back to that same
+table, so it only goes unpriced when its model does. If the warning fires,
+either add the model to the table or expect `max_cost_usd` to bind on the
+priced nodes only.
 
 ### The target repo's toolchain — `repo_devbox:`
 

--- a/openapi.json
+++ b/openapi.json
@@ -105,6 +105,12 @@
           "budget_tokens_used": {
             "type": "integer"
           },
+          "budget_unpriced_nodes": {
+            "type": "integer"
+          },
+          "budget_unpriced_tokens": {
+            "type": "integer"
+          },
           "cost_usd_total": {
             "type": "number"
           },

--- a/pkg/alert/alert.go
+++ b/pkg/alert/alert.go
@@ -91,7 +91,14 @@ func (a Alert) WebhookText() string {
 	if a.Reason != "" {
 		fmt.Fprintf(&b, "\nReason: %s", a.Reason)
 	}
-	if a.Axis != "" {
+	// Only when there IS a ratio. A dimension whose budget_warning payload
+	// carries no used/limit pair (cost_usd_unpriced: tokens burned at an
+	// unknown price, against a dollar ceiling) arrives here with BudgetPct
+	// 0, and "Budget: cost_usd_unpriced at 0%" reads as "0% of the cost
+	// budget used" — the opposite of what the alert says. The axis name
+	// still travels on the event data and to errtrack; it is the percentage
+	// that is meaningless, so it is the percentage that is dropped.
+	if a.Axis != "" && a.BudgetPct > 0 {
 		fmt.Fprintf(&b, "\nBudget: %s at %.0f%%", a.Axis, a.BudgetPct)
 	}
 	if a.Link != "" {
@@ -121,7 +128,12 @@ func (a Alert) AsEventData() map[string]any {
 	}
 	if a.Axis != "" {
 		d["axis"] = a.Axis
-		d["budget_pct"] = a.BudgetPct
+		// Mirrors the `omitempty` on BudgetPct and WebhookText's guard: an
+		// axis-less dimension has no ratio, and publishing 0 would let the
+		// SPA render a percentage nothing measured.
+		if a.BudgetPct > 0 {
+			d["budget_pct"] = a.BudgetPct
+		}
 	}
 	if a.Link != "" {
 		d["link"] = a.Link

--- a/pkg/alert/manager.go
+++ b/pkg/alert/manager.go
@@ -319,6 +319,14 @@ func (m *Manager) budgetAlertLocked(kind Kind, rs *runState, evt store.Event, ax
 		pct = used / limit * 100
 	}
 	var reason string
+	// A warning that explains itself wins over the ratio phrasing: some
+	// dimensions carry no axis (no used/limit), and rendering them as
+	// "crossed the advisory threshold (0/0)" would announce a ceiling that
+	// nothing approached. This is the surface that reaches an operator who
+	// is not watching the console, so it must not speak nonsense.
+	if detail := strData(evt.Data, "detail"); detail != "" && kind != KindBudgetExceeded {
+		return m.alertLocked(kind, rs, evt.NodeID, detail, axis, pct, ts)
+	}
 	switch {
 	case kind == KindBudgetExceeded:
 		reason = fmt.Sprintf("%s budget exhausted (%.0f/%.0f)", axis, used, limit)

--- a/pkg/alert/manager_test.go
+++ b/pkg/alert/manager_test.go
@@ -2,6 +2,7 @@ package alert
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -273,4 +274,64 @@ func TestStartStopTicker(t *testing.T) {
 	m.Start(ctx)
 	m.Stop() // must not panic / double-close
 	m.Stop()
+}
+
+// A budget_warning on a dimension with no used/limit pair (cost_usd_unpriced:
+// tokens burned at a price nothing could resolve, against a dollar ceiling)
+// must reach the operator as its own explanation and NOTHING that looks like a
+// ratio. "Budget: cost_usd_unpriced at 0%" is readable as "0% of the cost
+// budget used" — the opposite of the alert's meaning, on the one surface that
+// exists to reach an operator who is not watching the console.
+func TestBudgetWarningWithoutRatioRendersNoPercentage(t *testing.T) {
+	sink := &captureSink{}
+	m := newTestManager(sink)
+
+	const detail = "max_cost_usd is only counting part of this run: 2 node execution(s) totalling 4000 tokens had no resolvable price."
+	m.Observe(store.Event{
+		RunID: "r1", Type: store.EventBudgetWarning, NodeID: "agent",
+		Timestamp: time.Now(),
+		Data: map[string]any{
+			"dimension": "cost_usd_unpriced",
+			"advisory":  true,
+			"detail":    detail,
+			// deliberately no "used" / "limit": this dimension has no axis
+		},
+	})
+
+	waitFor(t, func() bool { return len(sink.snapshot()) == 1 })
+	got := sink.snapshot()[0]
+
+	if got.Reason != detail {
+		t.Errorf("Reason = %q, want the warning's own detail", got.Reason)
+	}
+	if got.Axis != "cost_usd_unpriced" {
+		t.Errorf("Axis = %q — the dimension still travels for diagnostics", got.Axis)
+	}
+	if got.BudgetPct != 0 {
+		t.Errorf("BudgetPct = %v, want 0 (no ratio was reported)", got.BudgetPct)
+	}
+
+	txt := got.WebhookText()
+	if !strings.Contains(txt, detail) {
+		t.Errorf("WebhookText dropped the explanation: %q", txt)
+	}
+	if strings.Contains(txt, "at 0%") || strings.Contains(txt, "Budget: cost_usd_unpriced") {
+		t.Errorf("WebhookText rendered a percentage nothing measured: %q", txt)
+	}
+
+	if _, ok := got.AsEventData()["budget_pct"]; ok {
+		t.Error("AsEventData published budget_pct for a dimension with no ratio")
+	}
+	if got.AsEventData()["axis"] != "cost_usd_unpriced" {
+		t.Errorf("AsEventData dropped the axis: %+v", got.AsEventData())
+	}
+
+	// The guard must not touch a dimension that DOES have a ratio.
+	real := Alert{Kind: KindBudgetWarning, RunName: "r", Axis: "tokens", BudgetPct: 82}
+	if !strings.Contains(real.WebhookText(), "tokens at 82%") {
+		t.Errorf("a real axis lost its ratio line: %q", real.WebhookText())
+	}
+	if real.AsEventData()["budget_pct"] != 82.0 {
+		t.Errorf("a real axis lost budget_pct: %+v", real.AsEventData())
+	}
 }

--- a/pkg/backend/model/executor_human.go
+++ b/pkg/backend/model/executor_human.go
@@ -193,19 +193,38 @@ func (e *ClawExecutor) ExecuteHumanLLMForInteraction(
 		delete(output, "needs_human_input")
 	}
 
-	// Strip metadata keys. This map is returned as `answers` and copied
-	// verbatim into the re-invoked node's input, where a `_`-prefixed key
-	// both joins the reserved namespace the delegates read and — for a node
-	// with no user-prompt template — gets JSON-serialized into the user
-	// message as if it were an answer. Drop the whole namespace rather than
-	// a list, so the next metadata addition cannot reopen this.
-	for k := range output {
-		if strings.HasPrefix(k, "_") {
-			delete(output, k)
-		}
-	}
+	stripInteractionMetadata(output, input)
 
 	return output, needsHuman, nil
+}
+
+// stripInteractionMetadata drops the reserved `_`-prefixed namespace from an
+// interaction answer map, EXCEPT the keys that were actually asked.
+//
+// The map is returned as `answers` and copied verbatim into the re-invoked
+// node's input (runtime.reInvokeBackend), where a `_`-prefixed key both joins
+// the reserved namespace the delegates read and — for a node with no
+// user-prompt template — gets JSON-serialized into the user message as if it
+// were an answer. So the whole namespace goes, rather than a list of known
+// keys: the next metadata addition (`_cost_usd` was one) cannot reopen it.
+//
+// `asked` is the exemption, and it is not optional. sanitizeSchemaKey maps
+// every non-alphanumeric rune to `_`, so a delegate question keyed
+// "(a) which db?" arrives as the answer key `_a__which_db_`. Deleting that
+// discards an answer the LLM did produce: the agent is re-invoked with the
+// question still open, asks it again, and burns interaction depth until
+// maxInteractionDepth fails the run — with no event anywhere saying an answer
+// was dropped. `asked` holds exactly the sanitized question keys, so it is the
+// set the strip must leave alone.
+func stripInteractionMetadata(answers, asked map[string]any) {
+	for k := range answers {
+		if _, wasAsked := asked[k]; wasAsked {
+			continue
+		}
+		if strings.HasPrefix(k, "_") {
+			delete(answers, k)
+		}
+	}
 }
 
 // sanitizeSchemaKey replaces characters that are invalid in JSON Schema

--- a/pkg/backend/model/executor_human.go
+++ b/pkg/backend/model/executor_human.go
@@ -193,9 +193,17 @@ func (e *ClawExecutor) ExecuteHumanLLMForInteraction(
 		delete(output, "needs_human_input")
 	}
 
-	// Strip metadata keys.
-	delete(output, "_tokens")
-	delete(output, "_model")
+	// Strip metadata keys. This map is returned as `answers` and copied
+	// verbatim into the re-invoked node's input, where a `_`-prefixed key
+	// both joins the reserved namespace the delegates read and — for a node
+	// with no user-prompt template — gets JSON-serialized into the user
+	// message as if it were an answer. Drop the whole namespace rather than
+	// a list, so the next metadata addition cannot reopen this.
+	for k := range output {
+		if strings.HasPrefix(k, "_") {
+			delete(output, k)
+		}
+	}
 
 	return output, needsHuman, nil
 }

--- a/pkg/backend/model/executor_human.go
+++ b/pkg/backend/model/executor_human.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/SocialGouv/claw-code-go/pkg/api"
 
+	"github.com/SocialGouv/iterion/pkg/backend/cost"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 )
 
@@ -112,9 +113,11 @@ func (e *ClawExecutor) executeHumanLLM(ctx context.Context, node *ir.HumanNode, 
 		output = make(map[string]any)
 	}
 
-	// Attach usage metadata.
-	output["_tokens"] = result.TotalUsage.InputTokens + result.TotalUsage.OutputTokens
-	output["_model"] = modelSpec
+	// Attach usage metadata. Going through cost.Annotate rather than
+	// stamping the keys by hand is what puts `_cost_usd` on this path: an
+	// `interaction: llm` human node is a real LLM call, and hand-stamping
+	// left it invisible to max_cost_usd on every model, priced or not.
+	cost.Annotate(output, modelSpec, result.TotalUsage.InputTokens, result.TotalUsage.OutputTokens)
 
 	return output, nil
 }

--- a/pkg/backend/model/executor_human_strip_test.go
+++ b/pkg/backend/model/executor_human_strip_test.go
@@ -1,0 +1,68 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/cost"
+)
+
+// The metadata strip on the interaction path must remove everything the
+// generation layer stamps (`_tokens`, `_model`, `_cost_usd`) and nothing the
+// delegate actually asked — including questions whose sanitized key starts
+// with `_`, which sanitizeSchemaKey produces from any leading punctuation.
+func TestStripInteractionMetadata(t *testing.T) {
+	t.Run("drops the metadata namespace", func(t *testing.T) {
+		answers := map[string]any{"which_db": "postgres"}
+		// Exactly what the real path stamps, via the real annotator.
+		cost.Annotate(answers, "anthropic/claude-opus-5", 1000, 200)
+		if _, ok := answers["_cost_usd"]; !ok {
+			t.Fatal("precondition: cost.Annotate did not stamp _cost_usd")
+		}
+
+		stripInteractionMetadata(answers, map[string]any{"which_db": "which database?"})
+
+		if got, want := answers["which_db"], "postgres"; got != want {
+			t.Errorf("answer = %v, want %v", got, want)
+		}
+		for _, k := range []string{"_cost_usd", "_tokens", "_model"} {
+			if _, ok := answers[k]; ok {
+				t.Errorf("%s survived the strip — it would reach the re-invoked node's input", k)
+			}
+		}
+	})
+
+	t.Run("keeps an asked key that sanitizes to a _ prefix", func(t *testing.T) {
+		// A delegate question keyed with leading punctuation. This is the
+		// regression: a blanket prefix strip deletes the answer, the agent
+		// re-asks, and the run burns interaction depth to no purpose.
+		const question = "(a) which db?"
+		key := sanitizeSchemaKey(question)
+		if key[0] != '_' {
+			t.Fatalf("precondition: sanitizeSchemaKey(%q) = %q, expected a _ prefix", question, key)
+		}
+
+		asked := map[string]any{key: question}
+		answers := map[string]any{key: "postgres", "_tokens": 1200}
+
+		stripInteractionMetadata(answers, asked)
+
+		if got, ok := answers[key]; !ok || got != "postgres" {
+			t.Errorf("answer for %q was dropped (%v, present=%v)", key, got, ok)
+		}
+		if _, ok := answers["_tokens"]; ok {
+			t.Error("_tokens was not asked — it must still be stripped")
+		}
+	})
+
+	t.Run("a literal underscore key is an asked key like any other", func(t *testing.T) {
+		answers := map[string]any{"_notes": "keep me", "_model": "some/model"}
+		stripInteractionMetadata(answers, map[string]any{"_notes": "notes?"})
+
+		if answers["_notes"] != "keep me" {
+			t.Errorf("_notes = %v, want it kept: it was asked", answers["_notes"])
+		}
+		if _, ok := answers["_model"]; ok {
+			t.Error("_model was not asked — it must be stripped")
+		}
+	})
+}

--- a/pkg/cli/report.go
+++ b/pkg/cli/report.go
@@ -402,6 +402,13 @@ func (rb *reportBuilder) sumArtifactWritten(evt *store.Event, step *reportStep) 
 
 func (rb *reportBuilder) sumBudgetWarning(evt *store.Event, step *reportStep) bool {
 	if evt.Data != nil {
+		// Dimensions without an axis publish a detail instead of used/limit;
+		// printing "used: <nil> / limit: <nil>" would lose the only content
+		// the event carries.
+		if detail, ok := evt.Data["detail"].(string); ok && detail != "" {
+			step.Summary = fmt.Sprintf("Budget warning: %v — %s", evt.Data["dimension"], detail)
+			return true
+		}
 		step.Summary = fmt.Sprintf("Budget warning: %v (used: %v / limit: %v)", evt.Data["dimension"], evt.Data["used"], evt.Data["limit"])
 	}
 	return true

--- a/pkg/runtime/branch.go
+++ b/pkg/runtime/branch.go
@@ -304,7 +304,7 @@ func (e *Engine) executeNodeForBranch(ctx context.Context, rs *runState, runID, 
 // accumulate independently; the per-run budget pause decision stays on the
 // trunk's pre-exec path, branches only contribute spend.
 func (e *Engine) recordBranchUsage(ctx context.Context, rs *runState, runID, branchID, ledgerKey, currentNodeID string, output map[string]any, branchCostUSD *float64, result *branchResult) bool {
-	tokens, costUSD, costKnown := extractUsage(output)
+	tokens, costUSD := extractUsage(output)
 
 	if e.dailyCap != nil && costUSD > 0 {
 		*branchCostUSD += costUSD
@@ -316,7 +316,7 @@ func (e *Engine) recordBranchUsage(ctx context.Context, rs *runState, runID, bra
 	if rs.budget == nil {
 		return false
 	}
-	checks := rs.budget.RecordUsage(tokens, costUSD, costKnown)
+	checks := rs.budget.RecordUsage(tokens, costUSD)
 
 	for _, w := range findWarnings(checks) {
 		if err := e.emitBranch(ctx, runID, branchID, store.EventBudgetWarning, currentNodeID, budgetWarningData(w)); err != nil {

--- a/pkg/runtime/branch.go
+++ b/pkg/runtime/branch.go
@@ -304,7 +304,7 @@ func (e *Engine) executeNodeForBranch(ctx context.Context, rs *runState, runID, 
 // accumulate independently; the per-run budget pause decision stays on the
 // trunk's pre-exec path, branches only contribute spend.
 func (e *Engine) recordBranchUsage(ctx context.Context, rs *runState, runID, branchID, ledgerKey, currentNodeID string, output map[string]any, branchCostUSD *float64, result *branchResult) bool {
-	tokens, costUSD := extractUsage(output)
+	tokens, costUSD, costKnown := extractUsage(output)
 
 	if e.dailyCap != nil && costUSD > 0 {
 		*branchCostUSD += costUSD
@@ -316,15 +316,10 @@ func (e *Engine) recordBranchUsage(ctx context.Context, rs *runState, runID, bra
 	if rs.budget == nil {
 		return false
 	}
-	checks := rs.budget.RecordUsage(tokens, costUSD)
+	checks := rs.budget.RecordUsage(tokens, costUSD, costKnown)
 
 	for _, w := range findWarnings(checks) {
-		if err := e.emitBranch(ctx, runID, branchID, store.EventBudgetWarning, currentNodeID, map[string]any{
-			"dimension": w.dimension,
-			"advisory":  w.advisory,
-			"used":      w.used,
-			"limit":     w.limit,
-		}); err != nil {
+		if err := e.emitBranch(ctx, runID, branchID, store.EventBudgetWarning, currentNodeID, budgetWarningData(w)); err != nil {
 			e.logger.Warn("branch %s: failed to emit budget_warning: %v", branchID, err)
 			result.eventErrors++
 		}

--- a/pkg/runtime/budget.go
+++ b/pkg/runtime/budget.go
@@ -430,10 +430,19 @@ func (b *SharedBudget) unpricedWarningLocked() (budgetCheckResult, bool) {
 	// 0.8` of something about to bind). Omitting it is what makes them fall
 	// through to their no-ratio path instead of rendering "0/160" or
 	// replacing a genuine tokens pill.
+	// The figures are a FLOOR, and the wording has to say so. This fires on
+	// the first unpriced node and never again, so on a fresh run it always
+	// reports exactly one node — while the counters keep climbing behind it.
+	// Phrased as a total ("2 nodes totalling 90k tokens"), a run with 40
+	// unpriced nodes and 2M unpriced tokens would understate the invisible
+	// spend by orders of magnitude, on the very surface added to remove an
+	// understatement. Reporting the run's final total needs a surface that
+	// reads the counters back at run end; until then, an honest floor beats
+	// a precise-looking sample.
 	return budgetCheckResult{
 		warning: true, advisory: true, dimension: "cost_usd_unpriced",
 		detail: fmt.Sprintf(
-			"max_cost_usd is only counting part of this run: %d node execution(s) totalling %d tokens had no resolvable price, so their spend is unknown and cannot reach the ceiling.",
+			"max_cost_usd is only counting part of this run: as of this node, %d node execution(s) totalling %d tokens have had no resolvable price, so that spend is unknown and cannot reach the ceiling. Raised once per ceiling — the unpriced total keeps growing after this.",
 			b.unpricedNodes, b.unpricedTokens,
 		),
 	}, true

--- a/pkg/runtime/budget.go
+++ b/pkg/runtime/budget.go
@@ -120,6 +120,10 @@ func (b *SharedBudget) RaiseCaps(o ir.BudgetOverrides) (effective ir.BudgetOverr
 	if b.maxCostUSD > 0 && o.MaxCostUSD > b.maxCostUSD {
 		b.maxCostUSD = o.MaxCostUSD
 		delete(b.warningsEmitted, "cost_usd")
+		// A raised ceiling deserves a fresh reminder that part of the spend
+		// is still invisible to it — otherwise the operator re-budgets on a
+		// figure they were told once, long ago, was partial.
+		delete(b.warningsEmitted, "cost_usd_unpriced")
 		raised = true
 	}
 	if b.maxTokens > 0 && o.MaxTokens > b.maxTokens {
@@ -220,21 +224,22 @@ type budgetCheckResult struct {
 // check results. tokens and costUSD may be zero if the executor does not
 // report them.
 //
-// costKnown says whether costUSD is a measurement. When a node burned tokens
-// but no price could be resolved for its model, its spend is unknown — adding
-// the zero would let a run drift past max_cost_usd with the ceiling reporting
-// nothing. Those tokens are counted apart and surfaced once (see checkLocked).
+// A zero costUSD means the price could not be resolved, never that the call
+// was free — `cost.Annotate` omits `_cost_usd` rather than write a 0. Adding
+// that zero would let a run drift past max_cost_usd with the ceiling
+// reporting nothing, so tokens burned at an unknown price are counted apart
+// and surfaced once instead (see checkLocked).
 //
 // Because budget enforcement is soft (pre-check and post-record are not
 // atomic), concurrent branches may push usage past the limit. When overage
 // exceeds 20% of the limit, a warning is logged to aid debugging.
-func (b *SharedBudget) RecordUsage(tokens int, costUSD float64, costKnown bool) []budgetCheckResult {
+func (b *SharedBudget) RecordUsage(tokens int, costUSD float64) []budgetCheckResult {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	b.iterationsUsed++
 	b.tokensUsed += tokens
-	if costKnown {
+	if costUSD > 0 {
 		b.costUsed += costUSD
 	} else if tokens > 0 {
 		// Tokens with no resolvable price: real spend the cost axis cannot
@@ -399,12 +404,16 @@ func (b *SharedBudget) checkLocked() []budgetCheckResult {
 	// to know the ceiling is partial before the invoice tells them.
 	if b.maxCostUSD > 0 && b.unpricedNodes > 0 && !b.warningsEmitted["cost_usd_unpriced"] {
 		b.warningsEmitted["cost_usd_unpriced"] = true
+		// No used/limit: this dimension is not an axis with a ratio, and
+		// every other budget_warning consumer reads that pair as one
+		// (`used/limit >= 0.8` of something about to bind). Omitting it is
+		// what makes them fall through to their no-ratio path instead of
+		// rendering "0/160" or replacing a genuine tokens pill.
 		results = append(results, budgetCheckResult{
 			warning: true, advisory: true, dimension: "cost_usd_unpriced",
-			used: b.costUsed, limit: b.maxCostUSD,
 			detail: fmt.Sprintf(
-				"max_cost_usd is only counting part of this run: %d node execution(s) totalling %d tokens had no resolvable price, so their spend is unknown and absent from the %.2f recorded so far. Add the model to the price table or check that the backend reports a cost.",
-				b.unpricedNodes, b.unpricedTokens, b.costUsed,
+				"max_cost_usd is only counting part of this run: %d node execution(s) totalling %d tokens had no resolvable price, so their spend is unknown and cannot reach the ceiling.",
+				b.unpricedNodes, b.unpricedTokens,
 			),
 		})
 	}
@@ -438,8 +447,13 @@ func budgetWarningData(w budgetCheckResult) map[string]any {
 	data := map[string]any{
 		"dimension": w.dimension,
 		"advisory":  w.advisory,
-		"used":      w.used,
-		"limit":     w.limit,
+	}
+	// A real axis always has a positive limit (checkLocked returns early
+	// otherwise). Dimensions without one carry no ratio, so the pair is left
+	// out rather than published as a misleading 0/0.
+	if w.limit > 0 {
+		data["used"] = w.used
+		data["limit"] = w.limit
 	}
 	if w.detail != "" {
 		data["detail"] = w.detail
@@ -517,7 +531,7 @@ func (e *Engine) checkBudgetBeforeExec(rs *runState, nodeID string) error {
 // recordAndCheckBudget records usage from a node execution and emits
 // budget_warning / budget_exceeded events as needed.
 func (e *Engine) recordAndCheckBudget(rs *runState, nodeID string, output map[string]any) error {
-	tokens, costUSD, costKnown := extractUsage(output)
+	tokens, costUSD := extractUsage(output)
 
 	// Daily spend cap accounting (independent of the per-run budget so it
 	// works for workflows with no budget: block). We only record — the
@@ -534,7 +548,7 @@ func (e *Engine) recordAndCheckBudget(rs *runState, nodeID string, output map[st
 		return nil
 	}
 
-	checks := rs.budget.RecordUsage(tokens, costUSD, costKnown)
+	checks := rs.budget.RecordUsage(tokens, costUSD)
 
 	// Emit warnings.
 	for _, w := range findWarnings(checks) {

--- a/pkg/runtime/budget.go
+++ b/pkg/runtime/budget.go
@@ -47,6 +47,13 @@ type SharedBudget struct {
 	// everRaised records that at least one live raise_budget landed —
 	// the trigger for persisting the (absolute) caps on the run record.
 	everRaised bool
+
+	// Unpriced spend — nodes that burned tokens while no price could be
+	// resolved for their model. Their cost is unknown, NOT zero, so it can
+	// never reach costUsed; tracked here so a declared max_cost_usd can say
+	// out loud that it is only seeing part of the run.
+	unpricedTokens int
+	unpricedNodes  int
 }
 
 const (
@@ -203,22 +210,39 @@ type budgetCheckResult struct {
 	dimension   string // "tokens", "cost_usd", "iterations", "duration"
 	used        float64
 	limit       float64
+	// detail carries a human-readable explanation for dimensions whose
+	// used/limit pair does not speak for itself (cost_usd_unpriced counts
+	// tokens against a dollar ceiling). Empty on the numeric axes.
+	detail string
 }
 
 // RecordUsage records resource consumption from a node execution and returns
 // check results. tokens and costUSD may be zero if the executor does not
 // report them.
 //
+// costKnown says whether costUSD is a measurement. When a node burned tokens
+// but no price could be resolved for its model, its spend is unknown — adding
+// the zero would let a run drift past max_cost_usd with the ceiling reporting
+// nothing. Those tokens are counted apart and surfaced once (see checkLocked).
+//
 // Because budget enforcement is soft (pre-check and post-record are not
 // atomic), concurrent branches may push usage past the limit. When overage
 // exceeds 20% of the limit, a warning is logged to aid debugging.
-func (b *SharedBudget) RecordUsage(tokens int, costUSD float64) []budgetCheckResult {
+func (b *SharedBudget) RecordUsage(tokens int, costUSD float64, costKnown bool) []budgetCheckResult {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	b.iterationsUsed++
 	b.tokensUsed += tokens
-	b.costUsed += costUSD
+	if costKnown {
+		b.costUsed += costUSD
+	} else if tokens > 0 {
+		// Tokens with no resolvable price: real spend the cost axis cannot
+		// see. A node that consumed nothing (tool, compute) is not unpriced
+		// spend — it is no spend — so the token count is what separates them.
+		b.unpricedTokens += tokens
+		b.unpricedNodes++
+	}
 
 	checks := b.checkLocked()
 
@@ -367,6 +391,24 @@ func (b *SharedBudget) checkLocked() []budgetCheckResult {
 		})
 	}
 
+	// A declared cost ceiling that cannot see part of the spend is not
+	// enforcing anything on that part. Silence there is the worst outcome:
+	// the run finishes with no budget event and looks exactly like a run
+	// that stayed under its limit. Report it once, advisory — the operator
+	// may legitimately want to keep going (warn over reject), but they get
+	// to know the ceiling is partial before the invoice tells them.
+	if b.maxCostUSD > 0 && b.unpricedNodes > 0 && !b.warningsEmitted["cost_usd_unpriced"] {
+		b.warningsEmitted["cost_usd_unpriced"] = true
+		results = append(results, budgetCheckResult{
+			warning: true, advisory: true, dimension: "cost_usd_unpriced",
+			used: b.costUsed, limit: b.maxCostUSD,
+			detail: fmt.Sprintf(
+				"max_cost_usd is only counting part of this run: %d node execution(s) totalling %d tokens had no resolvable price, so their spend is unknown and absent from the %.2f recorded so far. Add the model to the price table or check that the backend reports a cost.",
+				b.unpricedNodes, b.unpricedTokens, b.costUsed,
+			),
+		})
+	}
+
 	return results
 }
 
@@ -388,6 +430,21 @@ func findExceeded(results []budgetCheckResult) *budgetCheckResult {
 // findHardLimited returns the first hard-limited result, or nil.
 func findHardLimited(results []budgetCheckResult) *budgetCheckResult {
 	return findBudgetCheck(results, func(r *budgetCheckResult) bool { return r.hardLimited })
+}
+
+// budgetWarningData renders a warning as a budget_warning event payload.
+// Shared by the trunk and branch emitters so a new field lands on both.
+func budgetWarningData(w budgetCheckResult) map[string]any {
+	data := map[string]any{
+		"dimension": w.dimension,
+		"advisory":  w.advisory,
+		"used":      w.used,
+		"limit":     w.limit,
+	}
+	if w.detail != "" {
+		data["detail"] = w.detail
+	}
+	return data
 }
 
 // findWarnings returns all warning results.
@@ -460,7 +517,7 @@ func (e *Engine) checkBudgetBeforeExec(rs *runState, nodeID string) error {
 // recordAndCheckBudget records usage from a node execution and emits
 // budget_warning / budget_exceeded events as needed.
 func (e *Engine) recordAndCheckBudget(rs *runState, nodeID string, output map[string]any) error {
-	tokens, costUSD := extractUsage(output)
+	tokens, costUSD, costKnown := extractUsage(output)
 
 	// Daily spend cap accounting (independent of the per-run budget so it
 	// works for workflows with no budget: block). We only record — the
@@ -477,16 +534,11 @@ func (e *Engine) recordAndCheckBudget(rs *runState, nodeID string, output map[st
 		return nil
 	}
 
-	checks := rs.budget.RecordUsage(tokens, costUSD)
+	checks := rs.budget.RecordUsage(tokens, costUSD, costKnown)
 
 	// Emit warnings.
 	for _, w := range findWarnings(checks) {
-		_ = e.emit(rs.ctx, rs.runID, store.EventBudgetWarning, nodeID, map[string]any{
-			"dimension": w.dimension,
-			"advisory":  w.advisory,
-			"used":      w.used,
-			"limit":     w.limit,
-		})
+		_ = e.emit(rs.ctx, rs.runID, store.EventBudgetWarning, nodeID, budgetWarningData(w))
 	}
 
 	// Fail on exceeded.

--- a/pkg/runtime/budget.go
+++ b/pkg/runtime/budget.go
@@ -177,13 +177,13 @@ func (b *SharedBudget) capsLocked() ir.BudgetOverrides {
 // Snapshot returns the budget's consumed amounts and elapsed active time so
 // they can be persisted in a checkpoint and restored on resume. Safe on a nil
 // budget (returns zeros). elapsed is time.Since(startedAt) at call time.
-func (b *SharedBudget) Snapshot() (tokens int, cost float64, iterations int, elapsed time.Duration) {
+func (b *SharedBudget) Snapshot() (tokens int, cost float64, iterations int, elapsed time.Duration, unpricedTokens, unpricedNodes int) {
 	if b == nil {
-		return 0, 0, 0, 0
+		return 0, 0, 0, 0, 0, 0
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	return b.tokensUsed, b.costUsed, b.iterationsUsed, time.Since(b.startedAt)
+	return b.tokensUsed, b.costUsed, b.iterationsUsed, time.Since(b.startedAt), b.unpricedTokens, b.unpricedNodes
 }
 
 // Restore seeds a freshly-built budget with consumption carried over from a
@@ -191,7 +191,7 @@ func (b *SharedBudget) Snapshot() (tokens int, cost float64, iterations int, ela
 // with a full allowance. elapsed shifts startedAt back so the duration budget
 // counts prior active time (the pause gap itself is excluded). Safe on a nil
 // budget (no-op). Called once, before the resumed run executes any node.
-func (b *SharedBudget) Restore(tokens int, cost float64, iterations int, elapsed time.Duration) {
+func (b *SharedBudget) Restore(tokens int, cost float64, iterations int, elapsed time.Duration, unpricedTokens, unpricedNodes int) {
 	if b == nil {
 		return
 	}
@@ -200,6 +200,11 @@ func (b *SharedBudget) Restore(tokens int, cost float64, iterations int, elapsed
 	b.tokensUsed = tokens
 	b.costUsed = cost
 	b.iterationsUsed = iterations
+	// Unpriced volume rides the checkpoint like the other counters: without
+	// it a resumed run re-warns while under-reporting, counting only the
+	// nodes that ran after the pause.
+	b.unpricedTokens = unpricedTokens
+	b.unpricedNodes = unpricedNodes
 	if elapsed > 0 {
 		b.startedAt = time.Now().Add(-elapsed)
 	}
@@ -250,6 +255,9 @@ func (b *SharedBudget) RecordUsage(tokens int, costUSD float64) []budgetCheckRes
 	}
 
 	checks := b.checkLocked()
+	if w, ok := b.unpricedWarningLocked(); ok {
+		checks = append(checks, w)
+	}
 
 	// Log a warning when soft enforcement allows significant overage.
 	for _, c := range checks {
@@ -396,29 +404,39 @@ func (b *SharedBudget) checkLocked() []budgetCheckResult {
 		})
 	}
 
-	// A declared cost ceiling that cannot see part of the spend is not
-	// enforcing anything on that part. Silence there is the worst outcome:
-	// the run finishes with no budget event and looks exactly like a run
-	// that stayed under its limit. Report it once, advisory — the operator
-	// may legitimately want to keep going (warn over reject), but they get
-	// to know the ceiling is partial before the invoice tells them.
-	if b.maxCostUSD > 0 && b.unpricedNodes > 0 && !b.warningsEmitted["cost_usd_unpriced"] {
-		b.warningsEmitted["cost_usd_unpriced"] = true
-		// No used/limit: this dimension is not an axis with a ratio, and
-		// every other budget_warning consumer reads that pair as one
-		// (`used/limit >= 0.8` of something about to bind). Omitting it is
-		// what makes them fall through to their no-ratio path instead of
-		// rendering "0/160" or replacing a genuine tokens pill.
-		results = append(results, budgetCheckResult{
-			warning: true, advisory: true, dimension: "cost_usd_unpriced",
-			detail: fmt.Sprintf(
-				"max_cost_usd is only counting part of this run: %d node execution(s) totalling %d tokens had no resolvable price, so their spend is unknown and cannot reach the ceiling.",
-				b.unpricedNodes, b.unpricedTokens,
-			),
-		})
-	}
-
 	return results
+}
+
+// unpricedWarningLocked reports, once, that a declared cost ceiling cannot
+// see part of the run's spend. Silence there is the worst outcome: the run
+// finishes with no budget event and looks exactly like one that stayed under
+// its limit. It is advisory — the operator may legitimately want to keep
+// going (warn over reject) — but they learn the ceiling is partial before
+// the invoice tells them.
+//
+// It lives here rather than in checkLocked because checkLocked is also
+// reached from the read-only Check() on the pre-exec path, which inspects
+// only exceeded/hard-limited and discards warnings. Since the condition
+// (`unpricedNodes > 0`) stays true once tripped, a Check() would consume the
+// one-shot flag and throw the warning away — and no caller would ever emit
+// it. Only RecordUsage, whose callers emit, may raise it.
+func (b *SharedBudget) unpricedWarningLocked() (budgetCheckResult, bool) {
+	if b.maxCostUSD <= 0 || b.unpricedNodes == 0 || b.warningsEmitted["cost_usd_unpriced"] {
+		return budgetCheckResult{}, false
+	}
+	b.warningsEmitted["cost_usd_unpriced"] = true
+	// No used/limit: this dimension is not an axis with a ratio, and every
+	// other budget_warning consumer reads that pair as one (`used/limit >=
+	// 0.8` of something about to bind). Omitting it is what makes them fall
+	// through to their no-ratio path instead of rendering "0/160" or
+	// replacing a genuine tokens pill.
+	return budgetCheckResult{
+		warning: true, advisory: true, dimension: "cost_usd_unpriced",
+		detail: fmt.Sprintf(
+			"max_cost_usd is only counting part of this run: %d node execution(s) totalling %d tokens had no resolvable price, so their spend is unknown and cannot reach the ceiling.",
+			b.unpricedNodes, b.unpricedTokens,
+		),
+	}, true
 }
 
 // findBudgetCheck returns the first result matching pick, or nil.

--- a/pkg/runtime/budget_test.go
+++ b/pkg/runtime/budget_test.go
@@ -542,7 +542,7 @@ func TestBudgetSnapshotRestoreRoundtrip(t *testing.T) {
 	b.RecordUsage(300, 4.0) // 1 iteration
 	b.RecordUsage(200, 1.5) // 2 iterations
 
-	tokens, cost, iters, elapsed := b.Snapshot()
+	tokens, cost, iters, elapsed, unpTok, unpNodes := b.Snapshot()
 	if tokens != 500 || cost != 5.5 || iters != 2 {
 		t.Fatalf("snapshot = (%d,%v,%d), want (500,5.5,2)", tokens, cost, iters)
 	}
@@ -552,12 +552,12 @@ func TestBudgetSnapshotRestoreRoundtrip(t *testing.T) {
 
 	// A fresh budget (as newRunState builds on resume) starts at zero...
 	resumed := newSharedBudget(&ir.Budget{MaxTokens: 1000, MaxCostUSD: 10, MaxIterations: 5, MaxDuration: "1h"}, nil)
-	if t0, _, _, _ := resumed.Snapshot(); t0 != 0 {
+	if t0, _, _, _, _, _ := resumed.Snapshot(); t0 != 0 {
 		t.Fatalf("fresh budget should start at 0 tokens, got %d", t0)
 	}
 	// ...until Restore seeds it from the checkpoint.
-	resumed.Restore(tokens, cost, iters, elapsed)
-	rt, rc, ri, _ := resumed.Snapshot()
+	resumed.Restore(tokens, cost, iters, elapsed, unpTok, unpNodes)
+	rt, rc, ri, _, _, _ := resumed.Snapshot()
 	if rt != 500 || rc != 5.5 || ri != 2 {
 		t.Fatalf("restored = (%d,%v,%d), want (500,5.5,2)", rt, rc, ri)
 	}
@@ -600,7 +600,7 @@ func TestCheckpointCarriesBudgetAccounting(t *testing.T) {
 	if resumed.costUSDTotal != 7.25 {
 		t.Fatalf("resumed costUSDTotal = %v, want 7.25", resumed.costUSDTotal)
 	}
-	tok, cost, _, _ := resumed.budget.Snapshot()
+	tok, cost, _, _, _, _ := resumed.budget.Snapshot()
 	if tok != 400 || cost != 3.0 {
 		t.Fatalf("resumed budget = (%d,%v), want (400,3)", tok, cost)
 	}
@@ -1400,7 +1400,7 @@ func TestSharedBudget_UnpricedSpend(t *testing.T) {
 		}
 	})
 
-	t.Run("re_arms_when_the_cost_ceiling_is_raised", func(t *testing.T) {
+	t.Run("re_arms_on_raise_and_survives_the_read_only_check", func(t *testing.T) {
 		b := newSharedBudget(&ir.Budget{MaxCostUSD: 160}, nil)
 		if unpriced(b.RecordUsage(50_000, 0)) == nil {
 			t.Fatal("expected the first warning")
@@ -1414,8 +1414,39 @@ func TestSharedBudget_UnpricedSpend(t *testing.T) {
 		if _, raised := b.RaiseCaps(ir.BudgetOverrides{MaxCostUSD: 400}); !raised {
 			t.Fatal("expected the raise to land")
 		}
+
+		// The engine drains overrides then calls Check() before the next node
+		// runs. Check() inspects only exceeded/hard-limited and discards
+		// warnings, so if it could produce this one it would silently eat the
+		// re-arm and no operator would ever see it. It must not appear here…
+		if unpriced(b.Check()) != nil {
+			t.Fatal("the read-only Check() path must never raise (and thus consume) the unpriced warning")
+		}
+		// …and must still be waiting for the next recorded node.
 		if unpriced(b.RecordUsage(50_000, 0)) == nil {
 			t.Error("a raised cost ceiling must re-arm the unpriced warning")
+		}
+	})
+
+	t.Run("counters_ride_the_checkpoint", func(t *testing.T) {
+		b := newSharedBudget(&ir.Budget{MaxCostUSD: 160}, nil)
+		b.RecordUsage(50_000, 0)
+		b.RecordUsage(30_000, 0)
+		_, _, _, _, unpTok, unpNodes := b.Snapshot()
+		if unpTok != 80_000 || unpNodes != 2 {
+			t.Fatalf("snapshot lost the unpriced volume: %d tokens over %d nodes", unpTok, unpNodes)
+		}
+
+		// Without this, a resumed run re-warns while counting only what ran
+		// after the pause — a partial number reported as if it were the total.
+		resumed := newSharedBudget(&ir.Budget{MaxCostUSD: 160}, nil)
+		resumed.Restore(0, 0, 2, 0, unpTok, unpNodes)
+		w := unpriced(resumed.RecordUsage(10_000, 0))
+		if w == nil {
+			t.Fatal("expected the warning on the resumed run")
+		}
+		if !strings.Contains(w.detail, "90000 tokens") || !strings.Contains(w.detail, "3 node") {
+			t.Errorf("resumed detail must count the whole run, got %q", w.detail)
 		}
 	})
 

--- a/pkg/runtime/budget_test.go
+++ b/pkg/runtime/budget_test.go
@@ -539,8 +539,8 @@ func TestBudgetSnapshotRestoreRoundtrip(t *testing.T) {
 	if b == nil {
 		t.Fatal("expected a budget")
 	}
-	b.RecordUsage(300, 4.0, true) // 1 iteration
-	b.RecordUsage(200, 1.5, true) // 2 iterations
+	b.RecordUsage(300, 4.0) // 1 iteration
+	b.RecordUsage(200, 1.5) // 2 iterations
 
 	tokens, cost, iters, elapsed := b.Snapshot()
 	if tokens != 500 || cost != 5.5 || iters != 2 {
@@ -563,9 +563,9 @@ func TestBudgetSnapshotRestoreRoundtrip(t *testing.T) {
 	}
 	// One more iteration on the resumed budget must exhaust max_iterations (5)
 	// counting from the restored 2, not from 0 — the runaway-loop guard.
-	resumed.RecordUsage(0, 0, false)           // 3
-	resumed.RecordUsage(0, 0, false)           // 4
-	checks := resumed.RecordUsage(0, 0, false) // 5 → exceeded
+	resumed.RecordUsage(0, 0)           // 3
+	resumed.RecordUsage(0, 0)           // 4
+	checks := resumed.RecordUsage(0, 0) // 5 → exceeded
 	if findExceeded(checks) == nil {
 		t.Fatal("expected iterations budget exceeded after restore+3 (2+3=5), got none")
 	}
@@ -581,7 +581,7 @@ func TestCheckpointCarriesBudgetAccounting(t *testing.T) {
 		budget:       newSharedBudget(&ir.Budget{MaxTokens: 1000, MaxCostUSD: 10}, nil),
 		costUSDTotal: 7.25,
 	}
-	rs.budget.RecordUsage(400, 3.0, true)
+	rs.budget.RecordUsage(400, 3.0)
 
 	cp := buildCheckpoint(rs, "n1")
 	if cp.BudgetTokensUsed != 400 || cp.BudgetCostUSD != 3.0 || cp.BudgetIterationsUsed != 1 {
@@ -1071,28 +1071,28 @@ func TestSharedBudgetWarningOnce(t *testing.T) {
 
 	// Record 8 iterations (80% threshold).
 	for i := 0; i < 7; i++ {
-		results := b.RecordUsage(0, 0, false)
+		results := b.RecordUsage(0, 0)
 		if len(findWarnings(results)) > 0 {
 			t.Errorf("unexpected warning at iteration %d", i+1)
 		}
 	}
 
 	// 8th iteration should trigger warning.
-	results := b.RecordUsage(0, 0, false)
+	results := b.RecordUsage(0, 0)
 	warnings := findWarnings(results)
 	if len(warnings) != 1 || warnings[0].dimension != "iterations" {
 		t.Errorf("expected iterations warning at 8/10, got %d warnings", len(warnings))
 	}
 
 	// 9th iteration should NOT trigger another warning.
-	results = b.RecordUsage(0, 0, false)
+	results = b.RecordUsage(0, 0)
 	warnings = findWarnings(results)
 	if len(warnings) != 0 {
 		t.Error("warning should only be emitted once per dimension")
 	}
 
 	// 10th iteration should trigger exceeded.
-	results = b.RecordUsage(0, 0, false)
+	results = b.RecordUsage(0, 0)
 	exc := findExceeded(results)
 	if exc == nil || exc.dimension != "iterations" {
 		t.Error("expected exceeded at 10/10")
@@ -1227,25 +1227,25 @@ func TestHardBudgetWarningStillFires(t *testing.T) {
 
 	// Record 7 iterations (70%) — no warning yet.
 	for i := 0; i < 7; i++ {
-		b.RecordUsage(0, 0, false)
+		b.RecordUsage(0, 0)
 	}
 
 	// 8th iteration (80%) — warning should fire.
-	results := b.RecordUsage(0, 0, false)
+	results := b.RecordUsage(0, 0)
 	warnings := findWarnings(results)
 	if len(warnings) != 1 || warnings[0].dimension != "iterations" {
 		t.Errorf("expected warning at 80%%, got %d warnings", len(warnings))
 	}
 
 	// 9th iteration (90%) — hard limit should fire.
-	results = b.RecordUsage(0, 0, false)
+	results = b.RecordUsage(0, 0)
 	hl := findHardLimited(results)
 	if hl == nil || hl.dimension != "iterations" {
 		t.Error("expected hard limit at 90%")
 	}
 
 	// 10th iteration (100%) — exceeded should fire.
-	results = b.RecordUsage(0, 0, false)
+	results = b.RecordUsage(0, 0)
 	exc := findExceeded(results)
 	if exc == nil || exc.dimension != "iterations" {
 		t.Error("expected exceeded at 100%")
@@ -1257,7 +1257,7 @@ func TestHardBudgetUnit(t *testing.T) {
 		b := newSharedBudget(&ir.Budget{MaxIterations: 10}, nil)
 		// Push to 9 iterations.
 		for i := 0; i < 9; i++ {
-			b.RecordUsage(0, 0, false)
+			b.RecordUsage(0, 0)
 		}
 		checks := b.Check()
 		hl := findHardLimited(checks)
@@ -1271,7 +1271,7 @@ func TestHardBudgetUnit(t *testing.T) {
 
 	t.Run("tokens_hard_limit", func(t *testing.T) {
 		b := newSharedBudget(&ir.Budget{MaxTokens: 1000}, nil)
-		b.RecordUsage(910, 0, false) // 91%
+		b.RecordUsage(910, 0) // 91%
 		checks := b.Check()
 		hl := findHardLimited(checks)
 		if hl == nil {
@@ -1284,7 +1284,7 @@ func TestHardBudgetUnit(t *testing.T) {
 
 	t.Run("cost_hard_limit", func(t *testing.T) {
 		b := newSharedBudget(&ir.Budget{MaxCostUSD: 10.0}, nil)
-		b.RecordUsage(0, 9.5, true) // 95%
+		b.RecordUsage(0, 9.5) // 95%
 		checks := b.Check()
 		hl := findHardLimited(checks)
 		if hl == nil {
@@ -1298,7 +1298,7 @@ func TestHardBudgetUnit(t *testing.T) {
 	t.Run("below_hard_threshold", func(t *testing.T) {
 		b := newSharedBudget(&ir.Budget{MaxIterations: 10}, nil)
 		for i := 0; i < 8; i++ {
-			b.RecordUsage(0, 0, false)
+			b.RecordUsage(0, 0)
 		}
 		checks := b.Check()
 		hl := findHardLimited(checks)
@@ -1322,7 +1322,7 @@ func TestSharedBudget_UnpricedSpend(t *testing.T) {
 	t.Run("warns_once_under_a_declared_cost_ceiling", func(t *testing.T) {
 		b := newSharedBudget(&ir.Budget{MaxCostUSD: 160}, nil)
 
-		w := unpriced(b.RecordUsage(50_000, 0, false))
+		w := unpriced(b.RecordUsage(50_000, 0))
 		if w == nil {
 			t.Fatal("expected a cost_usd_unpriced warning: the ceiling cannot see this node's spend")
 		}
@@ -1335,7 +1335,7 @@ func TestSharedBudget_UnpricedSpend(t *testing.T) {
 
 		// Same run, second unpriced node: still accounted, but one warning is
 		// the contract — the operator is told, not spammed.
-		if again := unpriced(b.RecordUsage(50_000, 0, false)); again != nil {
+		if again := unpriced(b.RecordUsage(50_000, 0)); again != nil {
 			t.Error("cost_usd_unpriced must warn at most once per run")
 		}
 
@@ -1350,7 +1350,7 @@ func TestSharedBudget_UnpricedSpend(t *testing.T) {
 
 	t.Run("silent_without_a_cost_ceiling", func(t *testing.T) {
 		b := newSharedBudget(&ir.Budget{MaxTokens: 1_000_000}, nil)
-		if w := unpriced(b.RecordUsage(50_000, 0, false)); w != nil {
+		if w := unpriced(b.RecordUsage(50_000, 0)); w != nil {
 			t.Error("no max_cost_usd declared: nothing is being under-enforced, so nothing to report")
 		}
 		if b.unpricedTokens != 50_000 {
@@ -1362,7 +1362,7 @@ func TestSharedBudget_UnpricedSpend(t *testing.T) {
 		b := newSharedBudget(&ir.Budget{MaxCostUSD: 160}, nil)
 		// Tool and compute nodes report no tokens and no cost. That is an
 		// absence of spend, not spend of unknown price.
-		if w := unpriced(b.RecordUsage(0, 0, false)); w != nil {
+		if w := unpriced(b.RecordUsage(0, 0)); w != nil {
 			t.Error("a zero-token node must not raise the unpriced warning")
 		}
 		if b.unpricedNodes != 0 {
@@ -1370,9 +1370,58 @@ func TestSharedBudget_UnpricedSpend(t *testing.T) {
 		}
 	})
 
+	t.Run("carries_no_used_limit_pair_so_ratio_consumers_skip_it", func(t *testing.T) {
+		b := newSharedBudget(&ir.Budget{MaxCostUSD: 160}, nil)
+		w := unpriced(b.RecordUsage(50_000, 0))
+		if w == nil {
+			t.Fatal("expected the unpriced warning")
+		}
+		// Every other budget_warning consumer reads used/limit as a ratio of
+		// an axis about to bind. This dimension has no axis, so the pair must
+		// not be published: the studio toast then prints no percentage and
+		// useRunMetrics keeps whatever genuine warning it already had.
+		data := budgetWarningData(*w)
+		if _, ok := data["used"]; ok {
+			t.Error("unpriced warning must not publish a `used` value")
+		}
+		if _, ok := data["limit"]; ok {
+			t.Error("unpriced warning must not publish a `limit` value")
+		}
+		if data["detail"] == nil || data["detail"] == "" {
+			t.Error("with no used/limit, `detail` is the only content the event carries")
+		}
+
+		// A real axis keeps its pair.
+		axis := budgetWarningData(budgetCheckResult{
+			warning: true, dimension: "tokens", used: 800, limit: 1000,
+		})
+		if axis["used"] != float64(800) || axis["limit"] != float64(1000) {
+			t.Errorf("a real axis must still publish used/limit, got %v", axis)
+		}
+	})
+
+	t.Run("re_arms_when_the_cost_ceiling_is_raised", func(t *testing.T) {
+		b := newSharedBudget(&ir.Budget{MaxCostUSD: 160}, nil)
+		if unpriced(b.RecordUsage(50_000, 0)) == nil {
+			t.Fatal("expected the first warning")
+		}
+		if unpriced(b.RecordUsage(50_000, 0)) != nil {
+			t.Fatal("expected the warning to be deduped within one ceiling")
+		}
+		// raise_budget re-arms the cost axis so the operator gets a fresh 80%
+		// tick; they must equally be re-told the ceiling they just raised is
+		// still only seeing part of the run.
+		if _, raised := b.RaiseCaps(ir.BudgetOverrides{MaxCostUSD: 400}); !raised {
+			t.Fatal("expected the raise to land")
+		}
+		if unpriced(b.RecordUsage(50_000, 0)) == nil {
+			t.Error("a raised cost ceiling must re-arm the unpriced warning")
+		}
+	})
+
 	t.Run("priced_spend_never_raises_it", func(t *testing.T) {
 		b := newSharedBudget(&ir.Budget{MaxCostUSD: 160}, nil)
-		if w := unpriced(b.RecordUsage(50_000, 2.5, true)); w != nil {
+		if w := unpriced(b.RecordUsage(50_000, 2.5)); w != nil {
 			t.Error("a measured cost is exactly what the ceiling is for")
 		}
 		if b.costUsed != 2.5 {

--- a/pkg/runtime/budget_test.go
+++ b/pkg/runtime/budget_test.go
@@ -539,8 +539,8 @@ func TestBudgetSnapshotRestoreRoundtrip(t *testing.T) {
 	if b == nil {
 		t.Fatal("expected a budget")
 	}
-	b.RecordUsage(300, 4.0) // 1 iteration
-	b.RecordUsage(200, 1.5) // 2 iterations
+	b.RecordUsage(300, 4.0, true) // 1 iteration
+	b.RecordUsage(200, 1.5, true) // 2 iterations
 
 	tokens, cost, iters, elapsed := b.Snapshot()
 	if tokens != 500 || cost != 5.5 || iters != 2 {
@@ -563,9 +563,9 @@ func TestBudgetSnapshotRestoreRoundtrip(t *testing.T) {
 	}
 	// One more iteration on the resumed budget must exhaust max_iterations (5)
 	// counting from the restored 2, not from 0 — the runaway-loop guard.
-	resumed.RecordUsage(0, 0)           // 3
-	resumed.RecordUsage(0, 0)           // 4
-	checks := resumed.RecordUsage(0, 0) // 5 → exceeded
+	resumed.RecordUsage(0, 0, false)           // 3
+	resumed.RecordUsage(0, 0, false)           // 4
+	checks := resumed.RecordUsage(0, 0, false) // 5 → exceeded
 	if findExceeded(checks) == nil {
 		t.Fatal("expected iterations budget exceeded after restore+3 (2+3=5), got none")
 	}
@@ -581,7 +581,7 @@ func TestCheckpointCarriesBudgetAccounting(t *testing.T) {
 		budget:       newSharedBudget(&ir.Budget{MaxTokens: 1000, MaxCostUSD: 10}, nil),
 		costUSDTotal: 7.25,
 	}
-	rs.budget.RecordUsage(400, 3.0)
+	rs.budget.RecordUsage(400, 3.0, true)
 
 	cp := buildCheckpoint(rs, "n1")
 	if cp.BudgetTokensUsed != 400 || cp.BudgetCostUSD != 3.0 || cp.BudgetIterationsUsed != 1 {
@@ -1071,28 +1071,28 @@ func TestSharedBudgetWarningOnce(t *testing.T) {
 
 	// Record 8 iterations (80% threshold).
 	for i := 0; i < 7; i++ {
-		results := b.RecordUsage(0, 0)
+		results := b.RecordUsage(0, 0, false)
 		if len(findWarnings(results)) > 0 {
 			t.Errorf("unexpected warning at iteration %d", i+1)
 		}
 	}
 
 	// 8th iteration should trigger warning.
-	results := b.RecordUsage(0, 0)
+	results := b.RecordUsage(0, 0, false)
 	warnings := findWarnings(results)
 	if len(warnings) != 1 || warnings[0].dimension != "iterations" {
 		t.Errorf("expected iterations warning at 8/10, got %d warnings", len(warnings))
 	}
 
 	// 9th iteration should NOT trigger another warning.
-	results = b.RecordUsage(0, 0)
+	results = b.RecordUsage(0, 0, false)
 	warnings = findWarnings(results)
 	if len(warnings) != 0 {
 		t.Error("warning should only be emitted once per dimension")
 	}
 
 	// 10th iteration should trigger exceeded.
-	results = b.RecordUsage(0, 0)
+	results = b.RecordUsage(0, 0, false)
 	exc := findExceeded(results)
 	if exc == nil || exc.dimension != "iterations" {
 		t.Error("expected exceeded at 10/10")
@@ -1227,25 +1227,25 @@ func TestHardBudgetWarningStillFires(t *testing.T) {
 
 	// Record 7 iterations (70%) — no warning yet.
 	for i := 0; i < 7; i++ {
-		b.RecordUsage(0, 0)
+		b.RecordUsage(0, 0, false)
 	}
 
 	// 8th iteration (80%) — warning should fire.
-	results := b.RecordUsage(0, 0)
+	results := b.RecordUsage(0, 0, false)
 	warnings := findWarnings(results)
 	if len(warnings) != 1 || warnings[0].dimension != "iterations" {
 		t.Errorf("expected warning at 80%%, got %d warnings", len(warnings))
 	}
 
 	// 9th iteration (90%) — hard limit should fire.
-	results = b.RecordUsage(0, 0)
+	results = b.RecordUsage(0, 0, false)
 	hl := findHardLimited(results)
 	if hl == nil || hl.dimension != "iterations" {
 		t.Error("expected hard limit at 90%")
 	}
 
 	// 10th iteration (100%) — exceeded should fire.
-	results = b.RecordUsage(0, 0)
+	results = b.RecordUsage(0, 0, false)
 	exc := findExceeded(results)
 	if exc == nil || exc.dimension != "iterations" {
 		t.Error("expected exceeded at 100%")
@@ -1257,7 +1257,7 @@ func TestHardBudgetUnit(t *testing.T) {
 		b := newSharedBudget(&ir.Budget{MaxIterations: 10}, nil)
 		// Push to 9 iterations.
 		for i := 0; i < 9; i++ {
-			b.RecordUsage(0, 0)
+			b.RecordUsage(0, 0, false)
 		}
 		checks := b.Check()
 		hl := findHardLimited(checks)
@@ -1271,7 +1271,7 @@ func TestHardBudgetUnit(t *testing.T) {
 
 	t.Run("tokens_hard_limit", func(t *testing.T) {
 		b := newSharedBudget(&ir.Budget{MaxTokens: 1000}, nil)
-		b.RecordUsage(910, 0) // 91%
+		b.RecordUsage(910, 0, false) // 91%
 		checks := b.Check()
 		hl := findHardLimited(checks)
 		if hl == nil {
@@ -1284,7 +1284,7 @@ func TestHardBudgetUnit(t *testing.T) {
 
 	t.Run("cost_hard_limit", func(t *testing.T) {
 		b := newSharedBudget(&ir.Budget{MaxCostUSD: 10.0}, nil)
-		b.RecordUsage(0, 9.5) // 95%
+		b.RecordUsage(0, 9.5, true) // 95%
 		checks := b.Check()
 		hl := findHardLimited(checks)
 		if hl == nil {
@@ -1298,12 +1298,85 @@ func TestHardBudgetUnit(t *testing.T) {
 	t.Run("below_hard_threshold", func(t *testing.T) {
 		b := newSharedBudget(&ir.Budget{MaxIterations: 10}, nil)
 		for i := 0; i < 8; i++ {
-			b.RecordUsage(0, 0)
+			b.RecordUsage(0, 0, false)
 		}
 		checks := b.Check()
 		hl := findHardLimited(checks)
 		if hl != nil {
 			t.Error("should not trigger hard limit at 8/10 (80%)")
+		}
+	})
+}
+
+// An unknown cost is not a free call. When a node burns tokens whose model
+// carries no resolvable price, `cost.Annotate` omits `_cost_usd` on purpose —
+// and a budget that folded that absence into a 0.00 sample would let a run
+// sail past max_cost_usd reporting nothing at all. These cover the seam.
+func TestSharedBudget_UnpricedSpend(t *testing.T) {
+	unpriced := func(checks []budgetCheckResult) *budgetCheckResult {
+		return findBudgetCheck(checks, func(r *budgetCheckResult) bool {
+			return r.dimension == "cost_usd_unpriced"
+		})
+	}
+
+	t.Run("warns_once_under_a_declared_cost_ceiling", func(t *testing.T) {
+		b := newSharedBudget(&ir.Budget{MaxCostUSD: 160}, nil)
+
+		w := unpriced(b.RecordUsage(50_000, 0, false))
+		if w == nil {
+			t.Fatal("expected a cost_usd_unpriced warning: the ceiling cannot see this node's spend")
+		}
+		if !w.warning || !w.advisory {
+			t.Errorf("unpriced spend must warn advisorily, got warning=%v advisory=%v", w.warning, w.advisory)
+		}
+		if w.detail == "" {
+			t.Error("the warning must say what is unmeasured; used/limit alone mixes tokens and dollars")
+		}
+
+		// Same run, second unpriced node: still accounted, but one warning is
+		// the contract — the operator is told, not spammed.
+		if again := unpriced(b.RecordUsage(50_000, 0, false)); again != nil {
+			t.Error("cost_usd_unpriced must warn at most once per run")
+		}
+
+		if b.costUsed != 0 {
+			t.Errorf("unknown cost must never reach the enforced axis, costUsed=%v", b.costUsed)
+		}
+		if b.unpricedTokens != 100_000 || b.unpricedNodes != 2 {
+			t.Errorf("expected 100000 unpriced tokens over 2 nodes, got %d over %d",
+				b.unpricedTokens, b.unpricedNodes)
+		}
+	})
+
+	t.Run("silent_without_a_cost_ceiling", func(t *testing.T) {
+		b := newSharedBudget(&ir.Budget{MaxTokens: 1_000_000}, nil)
+		if w := unpriced(b.RecordUsage(50_000, 0, false)); w != nil {
+			t.Error("no max_cost_usd declared: nothing is being under-enforced, so nothing to report")
+		}
+		if b.unpricedTokens != 50_000 {
+			t.Errorf("unpriced tokens are tracked regardless, got %d", b.unpricedTokens)
+		}
+	})
+
+	t.Run("a_node_that_spent_nothing_is_not_unpriced_spend", func(t *testing.T) {
+		b := newSharedBudget(&ir.Budget{MaxCostUSD: 160}, nil)
+		// Tool and compute nodes report no tokens and no cost. That is an
+		// absence of spend, not spend of unknown price.
+		if w := unpriced(b.RecordUsage(0, 0, false)); w != nil {
+			t.Error("a zero-token node must not raise the unpriced warning")
+		}
+		if b.unpricedNodes != 0 {
+			t.Errorf("expected no unpriced node, got %d", b.unpricedNodes)
+		}
+	})
+
+	t.Run("priced_spend_never_raises_it", func(t *testing.T) {
+		b := newSharedBudget(&ir.Budget{MaxCostUSD: 160}, nil)
+		if w := unpriced(b.RecordUsage(50_000, 2.5, true)); w != nil {
+			t.Error("a measured cost is exactly what the ceiling is for")
+		}
+		if b.costUsed != 2.5 {
+			t.Errorf("expected costUsed 2.5, got %v", b.costUsed)
 		}
 	})
 }

--- a/pkg/runtime/budget_test.go
+++ b/pkg/runtime/budget_test.go
@@ -1348,6 +1348,41 @@ func TestSharedBudget_UnpricedSpend(t *testing.T) {
 		}
 	})
 
+	// The warning fires on the FIRST unpriced node and never again, so its
+	// figures are a floor, not a run total — and the message must not read
+	// like one. A run with 40 unpriced nodes would otherwise be told "1".
+	t.Run("detail_reports_a_floor_not_a_total", func(t *testing.T) {
+		b := newSharedBudget(&ir.Budget{MaxCostUSD: 160}, nil)
+
+		w := unpriced(b.RecordUsage(50_000, 0))
+		if w == nil {
+			t.Fatal("expected the first unpriced node to warn")
+		}
+		// What it could possibly know at emission time: one node.
+		if !strings.Contains(w.detail, "1 node execution(s)") ||
+			!strings.Contains(w.detail, "50000 tokens") {
+			t.Errorf("detail should carry the counters as of this node: %q", w.detail)
+		}
+		// And it must announce that this is a running figure, since nothing
+		// re-emits and no surface reads the final counters back.
+		if !strings.Contains(w.detail, "as of this node") ||
+			!strings.Contains(w.detail, "keeps growing") {
+			t.Errorf("detail presents a first-node sample as a run total: %q", w.detail)
+		}
+
+		// Drive the run on: the counters climb well past what the operator
+		// was told, which is exactly why the wording is a floor.
+		for i := 0; i < 39; i++ {
+			if again := unpriced(b.RecordUsage(50_000, 0)); again != nil {
+				t.Fatal("cost_usd_unpriced must warn at most once per run")
+			}
+		}
+		if b.unpricedNodes != 40 || b.unpricedTokens != 2_000_000 {
+			t.Fatalf("counters = %d nodes / %d tokens, want 40 / 2000000",
+				b.unpricedNodes, b.unpricedTokens)
+		}
+	})
+
 	t.Run("silent_without_a_cost_ceiling", func(t *testing.T) {
 		b := newSharedBudget(&ir.Budget{MaxTokens: 1_000_000}, nil)
 		if w := unpriced(b.RecordUsage(50_000, 0)); w != nil {

--- a/pkg/runtime/checkpoint.go
+++ b/pkg/runtime/checkpoint.go
@@ -8,7 +8,7 @@ import (
 
 // buildCheckpoint creates a Checkpoint from the current runState.
 func buildCheckpoint(rs *runState, nodeID string) *store.Checkpoint {
-	tokens, cost, iterations, elapsed := rs.budget.Snapshot()
+	tokens, cost, iterations, elapsed, unpricedTokens, unpricedNodes := rs.budget.Snapshot()
 	return &store.Checkpoint{
 		NodeID:             nodeID,
 		Outputs:            rs.outputs,
@@ -26,6 +26,8 @@ func buildCheckpoint(rs *runState, nodeID string) *store.Checkpoint {
 		BudgetCostUSD:          cost,
 		BudgetIterationsUsed:   iterations,
 		BudgetElapsedNS:        elapsed.Nanoseconds(),
+		BudgetUnpricedTokens:   unpricedTokens,
+		BudgetUnpricedNodes:    unpricedNodes,
 		CostUSDTotal:           rs.costUSDTotal,
 		NodeSessions:           cloneNodeSessions(rs.nodeSessions),
 		BackendSessionStateRef: rs.pauseSessionRef,
@@ -52,7 +54,7 @@ func restoreBudgetAccounting(rs *runState, cp *store.Checkpoint) {
 	if cp == nil {
 		return
 	}
-	rs.budget.Restore(cp.BudgetTokensUsed, cp.BudgetCostUSD, cp.BudgetIterationsUsed, time.Duration(cp.BudgetElapsedNS))
+	rs.budget.Restore(cp.BudgetTokensUsed, cp.BudgetCostUSD, cp.BudgetIterationsUsed, time.Duration(cp.BudgetElapsedNS), cp.BudgetUnpricedTokens, cp.BudgetUnpricedNodes)
 	rs.costUSDTotal = cp.CostUSDTotal
 	// Consumption is continuous across the pause, so the persisted loop
 	// prices stay comparable to it and the first crossing after a resume

--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -172,7 +172,7 @@ func (e *Engine) ActiveElapsed() time.Duration {
 	if b == nil {
 		return 0
 	}
-	_, _, _, elapsed := b.Snapshot()
+	_, _, _, elapsed, _, _ := b.Snapshot()
 	return elapsed
 }
 

--- a/pkg/runtime/engine_events.go
+++ b/pkg/runtime/engine_events.go
@@ -129,7 +129,18 @@ func (e *Engine) logEvent(typ store.EventType, nodeID, branchID string, data map
 	case store.EventHumanAnswersRecorded:
 		l.Logf(iterlog.LevelInfo, "📝", "Human answers recorded: %s", nodeID)
 	case store.EventBudgetWarning:
-		l.Warn("Budget warning: %s", nodeID)
+		// Name the axis and, when the payload explains itself, say why. A
+		// bare "Budget warning: <node>" is the one line an operator scrolls
+		// past — and cost_usd_unpriced exists precisely to be noticed.
+		if dim, ok := data["dimension"].(string); ok && dim != "" {
+			if detail, ok := data["detail"].(string); ok && detail != "" {
+				l.Warn("Budget warning [%s] at %s: %s", dim, nodeID, detail)
+			} else {
+				l.Warn("Budget warning [%s]: %s", dim, nodeID)
+			}
+		} else {
+			l.Warn("Budget warning: %s", nodeID)
+		}
 	case store.EventBudgetExceeded:
 		l.Warn("Budget exceeded: %s", nodeID)
 	}

--- a/pkg/runtime/loop_budget_test.go
+++ b/pkg/runtime/loop_budget_test.go
@@ -242,11 +242,11 @@ func TestLoopBudgetGuard_ReEnteredLoopReBasesItsPrice(t *testing.T) {
 
 	// An outer iteration runs and the inner loop is entered: the entry
 	// re-bases its price on what has been consumed by then.
-	rs.budget.RecordUsage(9_000, 0)
+	rs.budget.RecordUsage(9_000, 0, false)
 	markLoopBudget(rs, "phase2")
 
 	// One cheap inner iteration, then its first crossing of this instance.
-	rs.budget.RecordUsage(1_000, 0)
+	rs.budget.RecordUsage(1_000, 0, false)
 	if v := eng.loopBudgetShortfall("phase2", rs); v != nil {
 		t.Fatalf("re-entered loop declined its first crossing: %s priced at %.0f with %.0f left — the mark was not re-based at entry",
 			v.dimension, v.spent, v.remaining)
@@ -317,9 +317,9 @@ func TestLoopBudgetGuard_MarksSurviveResume(t *testing.T) {
 	// (so one iteration costs 3k).
 	origin := eng.newRunState("r", nil)
 	origin.budget = newSharedBudget(wf.Budget, eng.logger)
-	origin.budget.RecordUsage(5_000, 0)
+	origin.budget.RecordUsage(5_000, 0, false)
 	markLoopBudget(origin, "continuation")
-	origin.budget.RecordUsage(3_000, 0)
+	origin.budget.RecordUsage(3_000, 0, false)
 
 	cp := buildCheckpoint(origin, "gate")
 	if len(cp.LoopBudgetMarks) == 0 {
@@ -350,7 +350,7 @@ func TestLoopBudgetGuard_UnpricedLoopIsNotDeclined(t *testing.T) {
 	rs := eng.newRunState("r", nil)
 	rs.budget = newSharedBudget(wf.Budget, eng.logger)
 
-	rs.budget.RecordUsage(9_500, 0)
+	rs.budget.RecordUsage(9_500, 0, false)
 	if v := eng.loopBudgetShortfall("continuation", rs); v != nil {
 		t.Fatalf("declined an unmeasured loop on a %s guess", v.dimension)
 	}
@@ -367,7 +367,7 @@ func TestLoopBudgetGuard_IgnoresUnenforcedAxes(t *testing.T) {
 	eng.baselineUnpricedLoops(rs)
 
 	// A pass burning real dollars against an unlimited cost axis.
-	rs.budget.RecordUsage(1_000, 500.0)
+	rs.budget.RecordUsage(1_000, 500.0, true)
 	if v := eng.loopBudgetShortfall("continuation", rs); v != nil {
 		t.Fatalf("reported a %q shortfall on an axis the workflow does not cap", v.dimension)
 	}

--- a/pkg/runtime/loop_budget_test.go
+++ b/pkg/runtime/loop_budget_test.go
@@ -242,11 +242,11 @@ func TestLoopBudgetGuard_ReEnteredLoopReBasesItsPrice(t *testing.T) {
 
 	// An outer iteration runs and the inner loop is entered: the entry
 	// re-bases its price on what has been consumed by then.
-	rs.budget.RecordUsage(9_000, 0, false)
+	rs.budget.RecordUsage(9_000, 0)
 	markLoopBudget(rs, "phase2")
 
 	// One cheap inner iteration, then its first crossing of this instance.
-	rs.budget.RecordUsage(1_000, 0, false)
+	rs.budget.RecordUsage(1_000, 0)
 	if v := eng.loopBudgetShortfall("phase2", rs); v != nil {
 		t.Fatalf("re-entered loop declined its first crossing: %s priced at %.0f with %.0f left — the mark was not re-based at entry",
 			v.dimension, v.spent, v.remaining)
@@ -317,9 +317,9 @@ func TestLoopBudgetGuard_MarksSurviveResume(t *testing.T) {
 	// (so one iteration costs 3k).
 	origin := eng.newRunState("r", nil)
 	origin.budget = newSharedBudget(wf.Budget, eng.logger)
-	origin.budget.RecordUsage(5_000, 0, false)
+	origin.budget.RecordUsage(5_000, 0)
 	markLoopBudget(origin, "continuation")
-	origin.budget.RecordUsage(3_000, 0, false)
+	origin.budget.RecordUsage(3_000, 0)
 
 	cp := buildCheckpoint(origin, "gate")
 	if len(cp.LoopBudgetMarks) == 0 {
@@ -350,7 +350,7 @@ func TestLoopBudgetGuard_UnpricedLoopIsNotDeclined(t *testing.T) {
 	rs := eng.newRunState("r", nil)
 	rs.budget = newSharedBudget(wf.Budget, eng.logger)
 
-	rs.budget.RecordUsage(9_500, 0, false)
+	rs.budget.RecordUsage(9_500, 0)
 	if v := eng.loopBudgetShortfall("continuation", rs); v != nil {
 		t.Fatalf("declined an unmeasured loop on a %s guess", v.dimension)
 	}
@@ -367,7 +367,7 @@ func TestLoopBudgetGuard_IgnoresUnenforcedAxes(t *testing.T) {
 	eng.baselineUnpricedLoops(rs)
 
 	// A pass burning real dollars against an unlimited cost axis.
-	rs.budget.RecordUsage(1_000, 500.0, true)
+	rs.budget.RecordUsage(1_000, 500.0)
 	if v := eng.loopBudgetShortfall("continuation", rs); v != nil {
 		t.Fatalf("reported a %q shortfall on an axis the workflow does not cap", v.dimension)
 	}

--- a/pkg/runtime/node_output.go
+++ b/pkg/runtime/node_output.go
@@ -47,7 +47,7 @@ func (e *Engine) validateNodeOutput(nodeID string, node ir.Node, output map[stri
 
 // extractUsage reads conventional _tokens and _cost_usd keys from a node
 // output. Returns zeros if absent.
-func extractUsage(output map[string]any) (tokens int, costUSD float64) {
+func extractUsage(output map[string]any) (tokens int, costUSD float64, costKnown bool) {
 	if v, ok := output["_tokens"]; ok {
 		switch t := v.(type) {
 		case int:
@@ -66,6 +66,12 @@ func extractUsage(output map[string]any) (tokens int, costUSD float64) {
 			costUSD = float64(t)
 		}
 	}
+	// `cost.Annotate` writes `_cost_usd` only when a price was resolved, so
+	// an absent (or zero) key means "no cost data", never "this call was
+	// free" — the cost package says so in as many words and tells callers
+	// not to record a $0 sample. costKnown is what lets the budget keep the
+	// two apart instead of adding a silent zero.
+	costKnown = costUSD > 0
 	return
 }
 

--- a/pkg/runtime/node_output.go
+++ b/pkg/runtime/node_output.go
@@ -47,7 +47,7 @@ func (e *Engine) validateNodeOutput(nodeID string, node ir.Node, output map[stri
 
 // extractUsage reads conventional _tokens and _cost_usd keys from a node
 // output. Returns zeros if absent.
-func extractUsage(output map[string]any) (tokens int, costUSD float64, costKnown bool) {
+func extractUsage(output map[string]any) (tokens int, costUSD float64) {
 	if v, ok := output["_tokens"]; ok {
 		switch t := v.(type) {
 		case int:
@@ -69,9 +69,8 @@ func extractUsage(output map[string]any) (tokens int, costUSD float64, costKnown
 	// `cost.Annotate` writes `_cost_usd` only when a price was resolved, so
 	// an absent (or zero) key means "no cost data", never "this call was
 	// free" — the cost package says so in as many words and tells callers
-	// not to record a $0 sample. costKnown is what lets the budget keep the
-	// two apart instead of adding a silent zero.
-	costKnown = costUSD > 0
+	// not to record a $0 sample. A zero returned here is therefore "unknown";
+	// SharedBudget.RecordUsage is what keeps it out of the enforced axis.
 	return
 }
 

--- a/pkg/runtime/node_output_test.go
+++ b/pkg/runtime/node_output_test.go
@@ -3,49 +3,46 @@ package runtime
 import "testing"
 
 // `cost.Annotate` writes `_cost_usd` only when a price was resolved, and its
-// doc is explicit that a zero there means "no cost data", never "free". The
-// budget can only honour that contract if extraction preserves the difference.
-func TestExtractUsage_DistinguishesUnknownCostFromFree(t *testing.T) {
+// doc is explicit that a zero there means "no cost data", never "free" — so a
+// zero out of extractUsage is "unknown", and SharedBudget.RecordUsage is what
+// keeps it out of the enforced axis.
+func TestExtractUsage_ZeroCostMeansUnknown(t *testing.T) {
 	tests := []struct {
 		name       string
 		output     map[string]any
 		wantTokens int
 		wantCost   float64
-		wantKnown  bool
 	}{
 		{
 			name:       "priced call",
 			output:     map[string]any{"_tokens": 1200, "_model": "claude-opus-5", "_cost_usd": 0.42},
-			wantTokens: 1200, wantCost: 0.42, wantKnown: true,
+			wantTokens: 1200, wantCost: 0.42,
 		},
 		{
 			name:       "tokens but no price for the model",
 			output:     map[string]any{"_tokens": 1200, "_model": "gpt-5.6-sol"},
-			wantTokens: 1200, wantCost: 0, wantKnown: false,
+			wantTokens: 1200, wantCost: 0,
 		},
 		{
 			name:       "explicit zero is still unknown, not free",
 			output:     map[string]any{"_tokens": 1200, "_cost_usd": 0.0},
-			wantTokens: 1200, wantCost: 0, wantKnown: false,
+			wantTokens: 1200, wantCost: 0,
 		},
 		{
 			name:       "node that made no LLM call",
 			output:     map[string]any{"status": "ok"},
-			wantTokens: 0, wantCost: 0, wantKnown: false,
+			wantTokens: 0, wantCost: 0,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tokens, cost, known := extractUsage(tt.output)
+			tokens, cost := extractUsage(tt.output)
 			if tokens != tt.wantTokens {
 				t.Errorf("tokens = %d, want %d", tokens, tt.wantTokens)
 			}
 			if cost != tt.wantCost {
 				t.Errorf("cost = %v, want %v", cost, tt.wantCost)
-			}
-			if known != tt.wantKnown {
-				t.Errorf("costKnown = %v, want %v", known, tt.wantKnown)
 			}
 		})
 	}

--- a/pkg/runtime/node_output_test.go
+++ b/pkg/runtime/node_output_test.go
@@ -1,0 +1,52 @@
+package runtime
+
+import "testing"
+
+// `cost.Annotate` writes `_cost_usd` only when a price was resolved, and its
+// doc is explicit that a zero there means "no cost data", never "free". The
+// budget can only honour that contract if extraction preserves the difference.
+func TestExtractUsage_DistinguishesUnknownCostFromFree(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     map[string]any
+		wantTokens int
+		wantCost   float64
+		wantKnown  bool
+	}{
+		{
+			name:       "priced call",
+			output:     map[string]any{"_tokens": 1200, "_model": "claude-opus-5", "_cost_usd": 0.42},
+			wantTokens: 1200, wantCost: 0.42, wantKnown: true,
+		},
+		{
+			name:       "tokens but no price for the model",
+			output:     map[string]any{"_tokens": 1200, "_model": "gpt-5.6-sol"},
+			wantTokens: 1200, wantCost: 0, wantKnown: false,
+		},
+		{
+			name:       "explicit zero is still unknown, not free",
+			output:     map[string]any{"_tokens": 1200, "_cost_usd": 0.0},
+			wantTokens: 1200, wantCost: 0, wantKnown: false,
+		},
+		{
+			name:       "node that made no LLM call",
+			output:     map[string]any{"status": "ok"},
+			wantTokens: 0, wantCost: 0, wantKnown: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokens, cost, known := extractUsage(tt.output)
+			if tokens != tt.wantTokens {
+				t.Errorf("tokens = %d, want %d", tokens, tt.wantTokens)
+			}
+			if cost != tt.wantCost {
+				t.Errorf("cost = %v, want %v", cost, tt.wantCost)
+			}
+			if known != tt.wantKnown {
+				t.Errorf("costKnown = %v, want %v", known, tt.wantKnown)
+			}
+		})
+	}
+}

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -759,10 +759,15 @@ type Checkpoint struct {
 	// failure) could spend an unbounded multiple of its declared budget, and
 	// the max_iterations runaway-loop guard would reset on every resume.
 	// Zero/omitted on legacy checkpoints (a fresh budget — the prior behaviour).
-	BudgetTokensUsed     int     `json:"budget_tokens_used,omitempty" bson:"budget_tokens_used,omitempty"`
-	BudgetCostUSD        float64 `json:"budget_cost_usd,omitempty" bson:"budget_cost_usd,omitempty"`
-	BudgetIterationsUsed int     `json:"budget_iterations_used,omitempty" bson:"budget_iterations_used,omitempty"`
-	BudgetElapsedNS      int64   `json:"budget_elapsed_ns,omitempty" bson:"budget_elapsed_ns,omitempty"`
+	BudgetTokensUsed int     `json:"budget_tokens_used,omitempty" bson:"budget_tokens_used,omitempty"`
+	BudgetCostUSD    float64 `json:"budget_cost_usd,omitempty" bson:"budget_cost_usd,omitempty"`
+	// BudgetUnpricedTokens / BudgetUnpricedNodes carry the volume the cost
+	// axis could not price. Absent from checkpoints written before they
+	// existed, which restores as zero — the prior behaviour.
+	BudgetUnpricedTokens int   `json:"budget_unpriced_tokens,omitempty" bson:"budget_unpriced_tokens,omitempty"`
+	BudgetUnpricedNodes  int   `json:"budget_unpriced_nodes,omitempty" bson:"budget_unpriced_nodes,omitempty"`
+	BudgetIterationsUsed int   `json:"budget_iterations_used,omitempty" bson:"budget_iterations_used,omitempty"`
+	BudgetElapsedNS      int64 `json:"budget_elapsed_ns,omitempty" bson:"budget_elapsed_ns,omitempty"`
 	// CostUSDTotal is the run's cumulative LLM spend across ALL execution
 	// segments. Persisted so the daily-spend-cap ledger (a monotonic max of
 	// the per-run cumulative) keeps climbing after a resume instead of

--- a/studio/src/api/runs/events.ts
+++ b/studio/src/api/runs/events.ts
@@ -348,6 +348,9 @@ export interface BudgetEventData {
   dimension?: string;
   used?: number;
   limit?: number;
+  // Set on dimensions that carry no used/limit ratio (cost_usd_unpriced),
+  // where it is the whole message rather than a supplement to one.
+  detail?: string;
   [key: string]: unknown;
 }
 

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -4801,6 +4801,8 @@ export interface components {
             budget_elapsed_ns?: number;
             budget_iterations_used?: number;
             budget_tokens_used?: number;
+            budget_unpriced_nodes?: number;
+            budget_unpriced_tokens?: number;
             cost_usd_total?: number;
             interaction_id: string;
             interaction_questions?: {

--- a/studio/src/hooks/useRunToasts.ts
+++ b/studio/src/hooks/useRunToasts.ts
@@ -66,6 +66,13 @@ export function toastForEvent(
       return { message: "Run cancelled", type: "info" };
     case "budget_warning": {
       const dim = e.data?.dimension ?? "budget";
+      // Dimensions without an axis carry no used/limit ratio; their `detail`
+      // is the whole message. Without this the toast reads "Budget warning:
+      // cost_usd_unpriced." and tells the operator nothing.
+      const detail = e.data?.detail;
+      if (typeof detail === "string" && detail !== "") {
+        return { message: `Budget warning: ${detail}`, type: "warning" };
+      }
       const used = e.data?.used;
       const limit = e.data?.limit;
       const pct =


### PR DESCRIPTION
Fixes #473.

`cost.Annotate` omits `_cost_usd` when no price can be resolved, and says so in as many words — an absent value means *no cost data*, never *this call was free*. `USDFromOutput`'s doc goes further: "callers must treat a zero as unknown and not as a measured free call."

The budget was the caller that did not, adding that zero to `costUsed`. So a run whose models are unpriced accumulated `0.00` per node, `max_cost_usd` never fired, and the run finished with no budget event — indistinguishable from one that stayed under its ceiling.

## What changes

**The accounting.** `SharedBudget.RecordUsage` keeps its signature; a zero cost with a non-zero token count is now counted apart (`unpricedTokens` / `unpricedNodes`) instead of folding a silent zero into the enforced axis. The discriminator is `tokens > 0`: a tool or compute node reports neither, and an absence of spend must not be confused with spend of unknown price.

**The signal.** Under a declared `max_cost_usd`, the first unpriced node raises one advisory `budget_warning` on a new dimension `cost_usd_unpriced`, whose `detail` says how many node executions and how many tokens the ceiling cannot see. It is raised from `RecordUsage` only — never from the read-only `Check()` on the pre-exec path, which discards warnings and would otherwise consume the one-shot flag before any caller could emit it.

**The rendering.** The payload deliberately carries no `used`/`limit`: every other `budget_warning` consumer reads that pair as a ratio of an axis about to bind, and this dimension has no axis. Consumers that print a message now prefer `detail` — `pkg/alert/manager.go` (the surface that reaches an operator not watching the console), `pkg/cli/report.go`, and the studio toast. `useRunMetrics` keeps ignoring ratio-less entries on purpose, so this can never evict a genuine "tokens 80%" pill.

**A gap it uncovered.** `interaction: llm` human *nodes* hand-stamped `_tokens`/`_model` and never annotated a cost, so they contributed nothing to `max_cost_usd` on any model, priced or not. They now go through `cost.Annotate`, and their output is the node output, so it reaches `recordAndCheckBudget`.

The *delegate-interaction* half is a different path and stays unmetered: `ExecuteHumanLLMForInteraction` returns only `answers`, which are merged into the re-invoked node's input and never recorded — that LLM call reaches neither `RecordUsage` nor the daily cap, before this PR or after. Pre-existing, called out here so the paragraph above is not read as covering it.

The interaction path's metadata strip drops the whole `_`-prefixed namespace rather than a list of keys, so the new `_cost_usd` cannot leak into the re-invoked node's input — and neither can the next metadata addition. It exempts the keys that were actually asked: `sanitizeSchemaKey` maps punctuation to `_`, so a question keyed `"(a) which db?"` answers into `_a__which_db_`, and a blanket strip would delete an answer the LLM did produce.

**Resume.** The unpriced counters ride the checkpoint alongside tokens/cost/iterations. Without that a resumed run re-warns while counting only the nodes that ran after the pause — a partial number reported as a total. Checkpoints written before these fields restore as zero, the prior behaviour.

**Raise.** `RaiseCaps` re-arms `cost_usd_unpriced` with the cost axis: re-budgeting on a figure known to be partial should say so again.

## Warn, not reject

Per the philosophy's "prefer to warn over reject, whenever an operator could legitimately want the thing": the run continues. Failing closed would abort every existing workflow that pairs a cost ceiling with a model the table does not know — a large behaviour change to smuggle into a bug fix. What the issue reports is the *silence*, and the silence is what this removes. A fail-closed mode, if wanted, belongs behind the usual precedence chain as its own change.

`budget_warning` is reused rather than adding an event type: the payload already carries `dimension`/`advisory`, consumers already render it, and this is exactly an advisory warning — the same shape as the existing `warn_tokens` advisory, dedupe key included.

## Not in scope

- **The pricing gap itself.** The models that triggered #473 (`gpt-5.6-sol`, `claude-fable-5`, `gpt-5.6-terra`) are in neither pricing source. Adding rows to `modelPriceTable` would make one workflow measurable and leave the next unlisted model to reproduce the defect silently — and the table's own comment says a price is a budget decision, not a drive-by edit. Worth its own PR.
- **The claw/OpenAI input-token gap** (`UsageDelta` has no `InputTokens`; the OpenAI Responses adapter parses `input_tokens` and drops it). Vendored `claw-code-go`, belongs upstream. It is one way to reach an unknown cost; this PR handles the consequence wherever it comes from.
- **A backend that reports neither tokens nor cost.** `CLIAgentBackend.parseStdout` yields zeros when the CLI's output carries no usage block, so `_tokens: 0` and no `_cost_usd` — indistinguishable from a tool node under the `tokens > 0` discriminator. It is this same defect by a third route, and closing it needs a positive "an LLM call happened" marker the output convention does not have — the same missing primitive as the next item, and better landed as one change covering both.
- **Partially-priced fallback chains.** `executor_retry.go` sums a chain into one `_cost_usd`, so a chain whose primary leg was priced and whose fallback was not reads as fully priced. Pre-existing, and this PR neither improves nor worsens it; propagating a per-attempt unknown needs a marker the output convention does not have today.

## Tests

- `TestSharedBudget_UnpricedSpend` — warns once under a ceiling; silent without one; a zero-token node is not unpriced spend; the payload carries no `used`/`limit` while a real axis still does; re-arms on raise **and survives a `Check()`** (this subtest fails against the pre-fix code, which is the point); counters ride a Snapshot/Restore round trip; priced spend never raises it.
- `TestExtractUsage_ZeroCostMeansUnknown` — priced, unpriced, explicit zero, and a node that made no LLM call.

## Docs

`docs/dsl.md` gains a subsection under the budget section: `max_cost_usd` only counts spend it can price, what raises the warning, and what actually reaches it — a model absent from both pricing sources, with `codex` described as falling back to that same table rather than as an independent cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

