### PR TITLE
fix(pipelines): a dispatcher give-up reaches Needs attention, not Closed

### DIFF
--- a/cmd/iterion/issue.go
+++ b/cmd/iterion/issue.go
@@ -126,14 +126,15 @@ var issueMoveCmd = &cobra.Command{
 // ---------------------------------------------------------------------------
 
 var (
-	issueUpdateTitle      string
-	issueUpdateBody       string
-	issueUpdateLabels     []string
-	issueUpdatePriority   int
-	issueUpdateAssignee   string
-	issueUpdateBlockers   []string
-	issueUpdateFields     []string
-	issueUpdateClearField []string
+	issueUpdateTitle        string
+	issueUpdateBody         string
+	issueUpdateLabels       []string
+	issueUpdatePriority     int
+	issueUpdateAssignee     string
+	issueUpdateBlockers     []string
+	issueUpdateFields       []string
+	issueUpdateClearField   []string
+	issueUpdateClearLastRun bool
 )
 
 var issueUpdateCmd = &cobra.Command{
@@ -146,6 +147,7 @@ var issueUpdateCmd = &cobra.Command{
 			IDOrPrefix:         args[0],
 			Fields:             issueUpdateFields,
 			ClearField:         issueUpdateClearField,
+			ClearLastRun:       issueUpdateClearLastRun,
 		}
 		if cmd.Flags().Changed("title") {
 			opts.Title = &issueUpdateTitle
@@ -255,6 +257,8 @@ func init() {
 	issueUpdateCmd.Flags().StringSliceVar(&issueUpdateBlockers, "blockers", nil, "Replace blockers (comma-separated)")
 	issueUpdateCmd.Flags().StringSliceVar(&issueUpdateFields, "field", nil, "Set custom field as key=value (repeatable)")
 	issueUpdateCmd.Flags().StringSliceVar(&issueUpdateClearField, "clear-field", nil, "Clear a custom field (repeatable)")
+	issueUpdateCmd.Flags().BoolVar(&issueUpdateClearLastRun, "clear-last-run", false,
+		"Forget the last run: the next dispatch starts fresh instead of resuming it (run history is kept)")
 
 	// board
 	issueBoardInitCmd.Flags().StringVar(&issueBoardInitFrom, "from", "", "Load board.json from this file (default: built-in starter board)")

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -278,6 +278,28 @@ and the next tick reconsiders the candidate (which may by then have
 moved out of the eligible set — fine, the dispatcher releases without
 re-dispatching).
 
+### Giving up (`agent.max_attempts`)
+
+Once `agent.max_attempts` is reached the dispatcher **gives up**: it moves the
+issue to `agent.failed_state` (default `blocked`) and drops the retry, so a
+doomed ticket stops burning model spend. If the board cannot represent that
+state the move is refused and the unbounded retry is kept instead — a ticket is
+never frozen in place.
+
+A successful give-up also **stamps** the issue (`Issue.gave_up` — the run, the
+state written, the attempt count — plus an `issue_gave_up` event). The stamp
+exists because the give-up's target and the board's own Close target are the
+same terminal state: without it, readers cannot tell a dispatcher that ran out
+of attempts from an operator who filed the ticket, and the /pipelines board
+buries the failure in Closed instead of raising it in **Needs attention**
+([native tracker](native-tracker.md#pipeline-board)). It is not stamped when
+the terminal move was refused — a give-up that fell back to retrying has not
+given up.
+
+The stamp expires on its own (it names a run and a state, so a newer run or any
+move of the ticket makes it stale); the board's **Close** clears it explicitly,
+since that files the ticket into the state the give-up already wrote.
+
 ## Workspace lifecycle
 
 Workspaces live below

--- a/docs/dispatcher.md
+++ b/docs/dispatcher.md
@@ -296,9 +296,13 @@ buries the failure in Closed instead of raising it in **Needs attention**
 the terminal move was refused — a give-up that fell back to retrying has not
 given up.
 
-The stamp expires on its own (it names a run and a state, so a newer run or any
-move of the ticket makes it stale); the board's **Close** clears it explicitly,
-since that files the ticket into the state the give-up already wrote.
+The stamp expires on its own and for good: it names a run and a state, and each
+store drops it on any write in a different state. Since a retry resumes the
+*same* run id, a merely-stale stamp would otherwise revive when a human filed
+the ticket back into that state. Closing a ticket that is already sitting in
+the give-up's state changes nothing, so the three close surfaces — the pipeline
+board's Close, `iterion issue close`, and the board tool `close_issue` — clear
+the stamp explicitly.
 
 ## Workspace lifecycle
 

--- a/docs/native-tracker.md
+++ b/docs/native-tracker.md
@@ -320,14 +320,26 @@ burns the whole retry budget on every run.
 The dispatcher therefore **stamps** the give-up on the ticket
 (`Issue.gave_up`: the run, the state it wrote, the attempt count, an
 `issue_gave_up` event), and the projection routes a terminal ticket carrying a
-*current* stamp to `needs_attention`, badged **Gave up**. The stamp expires by
-itself — it names the run and the state, so a newer run or any move of the
-ticket makes it stale — so nothing has to remember to clear it. The one
-exception is filing a ticket into the state it is already in: **Close** clears
-the stamp explicitly, which is what makes it the acknowledgement the give-up
-never got. A given-up card renders in the lane but **reserves no slot**: it is
-terminal, nothing will relaunch it until the operator acts, and holding
-capacity for it would leak a slot with no bound.
+*current* stamp to `needs_attention`, badged **Gave up**.
+
+The stamp expires by itself, and permanently: it names the run and the state,
+the store **drops it on any write in a different state** (one hook on each
+store's write path, so no future state writer has to remember), and a stamp
+naming another run never describes the card. That permanence is load-bearing —
+a dispatcher retry resumes the *same* run id, so a stamp that merely looked
+stale would come back to life the moment a human filed the ticket back into
+that state, and the board would re-file an operator's own decision as an
+unattended give-up.
+
+The one case no write hook can catch is filing a ticket into the state it is
+**already** in — the give-up's target and every close target are the same
+state. So the three closes clear the stamp explicitly: the pipeline board's
+**Close**, `iterion issue close`, and the board tool `close_issue`. That is
+what makes closing the acknowledgement the give-up never got.
+
+A given-up card renders in the lane but **reserves no slot**: it is terminal,
+nothing will relaunch it until the operator acts, and holding capacity for it
+would leak a slot with no bound.
 
 **Getting back to a fresh run.** A ticket's `last_run_id` pointer is what the
 dispatcher resumes on the next dispatch (`resolveRunID` → `resumableRunID`),

--- a/docs/native-tracker.md
+++ b/docs/native-tracker.md
@@ -175,6 +175,14 @@ names a resumable run the dispatcher **resumes** it on the next dispatch
 instead of starting one; clearing it is how an operator gets back to a fresh
 run after a failure resuming cannot fix. The run history (`runs`) is kept.
 
+Two limits are deliberate. It **refuses** while the run is still alive
+(`running` / `queued` / `paused_*`): that pointer is also the dispatcher's
+sibling guard, and clearing it there would let the next dispatch start a
+*second* run on the same ticket. And a live dispatcher with a retry already
+scheduled for the ticket holds its own in-memory pointer, which wins over the
+persisted one for that attempt — for a ticket the dispatcher has **given up**
+on, the retry was dropped at give-up, so the flag takes effect immediately.
+
 `iterion issue list` accepts `--json` (the global flag) to emit
 machine-readable output:
 

--- a/docs/native-tracker.md
+++ b/docs/native-tracker.md
@@ -155,6 +155,7 @@ iterion issue move     <id-or-prefix>  --to <state>
 iterion issue update   <id-or-prefix>  [--title T] [--body B] [--labels L1,L2]
                                        [--priority N] [--assignee A] [--blockers B1,B2]
                                        [--field k=v]+ [--clear-field K]+
+                                       [--clear-last-run]
 iterion issue close    <id-or-prefix>          # → first terminal state
 
 iterion issue board show
@@ -168,6 +169,11 @@ shown in `list`).
 `--field key=value` infers the type from the value: `true`/`false` →
 bool, integers / floats → number, everything else → string. Use
 `--clear-field key` to unset a value.
+
+`--clear-last-run` drops the card's `last_run` pointer. While that pointer
+names a resumable run the dispatcher **resumes** it on the next dispatch
+instead of starting one; clearing it is how an operator gets back to a fresh
+run after a failure resuming cannot fix. The run history (`runs`) is kept.
 
 `iterion issue list` accepts `--json` (the global flag) to emit
 machine-readable output:
@@ -291,13 +297,45 @@ Lane semantics — the board is **task-centric**:
   without reserving — otherwise Stop would punish the operator who pressed
   it, and Close would retain the very slot it exists to release. Failures
   iterion caused *itself* (a drain at shutdown, the boot orphan sweep) show
-  here but do not reserve, or every restart would hold every slot;
+  here but do not reserve, or every restart would hold every slot. A
+  **dispatcher give-up** also lands here even though its ticket reads
+  terminal — see below;
 - `Closed` = every pipeline that reached an end: finished, or stopped by the
   operator. A per-card **Success** / **Stopped** badge distinguishes the
   outcome; a successful card's output shows in the details sidebar, a stopped
   one shows the **reason** and (ticket-backed) offers **Retry** (restages to
   Ready) + Edit. A header control filters the lane by **All / Success /
   Stopped**.
+
+**A dispatcher give-up is not a filing.** When `iterion dispatch` exhausts
+`agent.max_attempts` on a ticket it files it into `agent.failed_state`
+(default `blocked`) by itself — the *same* terminal state the board's Close
+writes. A terminal ticket otherwise means "a human already filed this", so
+before the give-up stamp the projection could not tell the two apart and put
+the card in **Closed**: the one class of failure the Needs-attention lane
+exists for — a pipeline that died and wants a human — was the one it never
+showed, because a deterministic failure (a fail-closed bot demanding a rewind)
+burns the whole retry budget on every run.
+
+The dispatcher therefore **stamps** the give-up on the ticket
+(`Issue.gave_up`: the run, the state it wrote, the attempt count, an
+`issue_gave_up` event), and the projection routes a terminal ticket carrying a
+*current* stamp to `needs_attention`, badged **Gave up**. The stamp expires by
+itself — it names the run and the state, so a newer run or any move of the
+ticket makes it stale — so nothing has to remember to clear it. The one
+exception is filing a ticket into the state it is already in: **Close** clears
+the stamp explicitly, which is what makes it the acknowledgement the give-up
+never got. A given-up card renders in the lane but **reserves no slot**: it is
+terminal, nothing will relaunch it until the operator acts, and holding
+capacity for it would leak a slot with no bound.
+
+**Getting back to a fresh run.** A ticket's `last_run_id` pointer is what the
+dispatcher resumes on the next dispatch (`resolveRunID` → `resumableRunID`),
+so a run that died in a way resuming cannot fix keeps being resumed. Drop the
+pointer with `iterion issue update <id> --clear-last-run` — the next dispatch
+mints a new run from the workflow entry instead. The run *history*
+(`Issue.runs`) is kept: those runs happened, and their consoles are the
+evidence.
 
 **Closing a pipeline.** `Close` (⋯ menu, every non-terminal lane) cancels
 everything still alive under the card and files the ticket as **abandoned**
@@ -398,6 +436,7 @@ perform an N+1 traversal over issues, checkpoints and child runs:
 | `/api/v1/pipeline-board/tasks/{id}` | PATCH | Edit a not-yet-run ticket (title, body, labels, priority, bot, bot_args, blockers) |
 | `/api/v1/pipeline-board/tasks/{id}` | DELETE | Delete a ticket (issue only, never a run); 409 while any run in its tree is active |
 | `/api/v1/pipeline-board/tasks/{id}/reset` | POST | Cancel every active run in the ticket's tree, then restage it to Ready |
+| `/api/v1/pipeline-board/tasks/{id}/close` | POST | Cancel the ticket's tree and file it terminal (`blocked`, never `done`); also clears a dispatcher give-up stamp — Close is the acknowledgement |
 | `/api/v1/pipeline-board/tasks/{id}/dependency-graph` | GET | Limited-depth hard-dep graph (also `GET /api/v1/native/issues/{id}/dependency-graph`) |
 | `/api/v1/pipeline-board/bulk/ready` | POST | `{ids?\|family_id?\|pipeline_kind?}` stage many tickets Ready (skip open blockers by default) |
 | `/api/v1/pipeline-board/bulk/recompute-deps` | POST | Re-promote `waiting_deps` tickets whose blockers are now satisfied |

--- a/docs/native-tracker.md
+++ b/docs/native-tracker.md
@@ -175,6 +175,11 @@ names a resumable run the dispatcher **resumes** it on the next dispatch
 instead of starting one; clearing it is how an operator gets back to a fresh
 run after a failure resuming cannot fix. The run history (`runs`) is kept.
 
+It clears the pointer, not the ticket: a card the dispatcher gave up on is
+still in a terminal state, so the fresh run materialises once the ticket is
+**restaged** too (Retry on the board, or `iterion issue move … --to ready`).
+Clear first, then restage — the other order re-pins the pointer.
+
 Two limits are deliberate. It **refuses** while the run is still alive
 (`running` / `queued` / `paused_*`): that pointer is also the dispatcher's
 sibling guard, and clearing it there would let the next dispatch start a

--- a/e2e/cli_issue_test.go
+++ b/e2e/cli_issue_test.go
@@ -387,3 +387,57 @@ func TestIssueCloseRefusesABoardWithNoTerminalState(t *testing.T) {
 		t.Errorf("a refused close moved the card to %q; it must stay put", got.State)
 	}
 }
+
+// `--clear-last-run` is the operator's way back to a FRESH launch. While the
+// pointer names a resumable run the dispatcher resumes THAT run rather than
+// minting a new one, so a ticket whose run died in a way resuming cannot fix
+// had no exit but editing the issue JSON by hand (issue #494). The pointer
+// clears; the run HISTORY does not — those runs still happened, and the
+// operator still needs their consoles.
+//
+// Mutation check: keep the pointer and the "cleared" assertion fails; wipe
+// Runs along with it and the history assertion fails.
+func TestIssueCLIUpdateClearsLastRunPointerKeepingHistory(t *testing.T) {
+	storeDir := t.TempDir()
+	common := cli.IssueCommonOptions{StoreDir: storeDir}
+
+	card := createIssueViaCLI(t, cli.IssueCreateOptions{
+		IssueCommonOptions: common,
+		Title:              "resumed forever",
+		State:              native.StateBlocked,
+	})
+
+	s := reopenBoard(t, storeDir)
+	if err := s.SetLastRun(card.ID, "run-dead", "/tmp/ws"); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+
+	var buf bytes.Buffer
+	p := &cli.Printer{W: &buf, Format: cli.OutputJSON}
+	if err := cli.RunIssueUpdate(p, cli.IssueUpdateOptions{
+		IssueCommonOptions: common,
+		IDOrPrefix:         card.ID,
+		ClearLastRun:       true,
+	}); err != nil {
+		t.Fatalf("issue update --clear-last-run: %v", err)
+	}
+
+	got, err := reopenBoard(t, storeDir).Get(card.ID)
+	if err != nil {
+		t.Fatalf("reload issue: %v", err)
+	}
+	if got.LastRunID != "" || got.LastWorkdir != "" {
+		t.Errorf("last-run pointer survived: run=%q workdir=%q", got.LastRunID, got.LastWorkdir)
+	}
+	if len(got.Runs) != 1 || got.Runs[0].RunID != "run-dead" {
+		t.Errorf("run history = %+v, want the dead run kept (its console is still the evidence)", got.Runs)
+	}
+	// The command reports the cleared card, not the pre-clear snapshot.
+	var reported native.Issue
+	if err := json.Unmarshal(buf.Bytes(), &reported); err != nil {
+		t.Fatalf("decode reported issue from %q: %v", buf.String(), err)
+	}
+	if reported.LastRunID != "" {
+		t.Errorf("reported last_run_id = %q, want empty — the output contradicted the write", reported.LastRunID)
+	}
+}

--- a/e2e/cli_issue_test.go
+++ b/e2e/cli_issue_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/cli"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/store"
 )
 
 // `iterion issue` is the operator's hands-on surface onto the native
@@ -385,6 +387,89 @@ func TestIssueCloseRefusesABoardWithNoTerminalState(t *testing.T) {
 	}
 	if got.State != native.StateReady {
 		t.Errorf("a refused close moved the card to %q; it must stay put", got.State)
+	}
+}
+
+// `--clear-last-run` must NOT forget a run that is still alive. The pointer is
+// the dispatcher's sibling guard (lastRunForbidsFresh): clearing it while the
+// run is running or parked on a question lets the next dispatch mint a second
+// run on the same ticket — two agents, and on a `worktree: auto` bot two
+// branches and two PRs for one issue.
+//
+// Mutation check: drop the guard and the live case clears the pointer.
+func TestIssueCLIClearLastRunRefusesWhileTheRunIsAlive(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     store.RunStatus
+		wantRefuse bool
+	}{
+		{"running", store.RunStatusRunning, true},
+		{"parked on a question", store.RunStatusPausedWaitingHuman, true},
+		{"queued for a slot", store.RunStatusQueued, true},
+		// The documented case: dead, but resumable — which is exactly why the
+		// flag exists, since a resumable pointer is what keeps being resumed.
+		{"failed_resumable", store.RunStatusFailedResumable, false},
+		{"cancelled", store.RunStatusCancelled, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			storeDir := t.TempDir()
+			common := cli.IssueCommonOptions{StoreDir: storeDir}
+			card := createIssueViaCLI(t, cli.IssueCreateOptions{
+				IssueCommonOptions: common,
+				Title:              "owns a run",
+				State:              native.StateInProgress,
+			})
+			rs, err := store.New(storeDir)
+			if err != nil {
+				t.Fatalf("store.New: %v", err)
+			}
+			ctx := context.Background()
+			if _, err := rs.CreateRun(ctx, "run-live", "bot", nil); err != nil {
+				t.Fatalf("CreateRun: %v", err)
+			}
+			run, err := rs.LoadRun(ctx, "run-live")
+			if err != nil {
+				t.Fatalf("LoadRun: %v", err)
+			}
+			run.Status = c.status
+			if err := rs.SaveRun(ctx, run); err != nil {
+				t.Fatalf("SaveRun: %v", err)
+			}
+			if err := reopenBoard(t, storeDir).SetLastRun(card.ID, "run-live", ""); err != nil {
+				t.Fatalf("SetLastRun: %v", err)
+			}
+
+			var buf bytes.Buffer
+			p := &cli.Printer{W: &buf, Format: cli.OutputHuman}
+			err = cli.RunIssueUpdate(p, cli.IssueUpdateOptions{
+				IssueCommonOptions: common,
+				IDOrPrefix:         card.ID,
+				ClearLastRun:       true,
+			})
+			got, getErr := reopenBoard(t, storeDir).Get(card.ID)
+			if getErr != nil {
+				t.Fatalf("reload issue: %v", getErr)
+			}
+			if c.wantRefuse {
+				if err == nil {
+					t.Fatalf("clearing a %s run was allowed — the next dispatch could start a sibling", c.status)
+				}
+				if !strings.Contains(err.Error(), "SECOND run") {
+					t.Errorf("error = %v, want it to name the consequence", err)
+				}
+				if got.LastRunID != "run-live" {
+					t.Errorf("a refused clear still dropped the pointer: %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("clearing a %s run was refused: %v", c.status, err)
+			}
+			if got.LastRunID != "" {
+				t.Errorf("pointer survived on a %s run: %+v", c.status, got)
+			}
+		})
 	}
 }
 

--- a/e2e/cli_issue_test.go
+++ b/e2e/cli_issue_test.go
@@ -388,6 +388,53 @@ func TestIssueCloseRefusesABoardWithNoTerminalState(t *testing.T) {
 	}
 }
 
+// `iterion issue close` is an acknowledgement, so it must also drop a
+// dispatcher give-up stamp — and it is the surface where that matters most:
+// the board's first terminal state is usually the very state the give-up
+// filed the ticket into, so the SetState is a no-op and nothing else expires
+// the stamp. Without this the card stays in the pipeline board's
+// needs-attention lane after the operator closed it.
+//
+// Mutation check: drop the clear and the stamp survives the close.
+func TestIssueCLICloseAcknowledgesADispatcherGiveUp(t *testing.T) {
+	storeDir := t.TempDir()
+	common := cli.IssueCommonOptions{StoreDir: storeDir}
+
+	card := createIssueViaCLI(t, cli.IssueCreateOptions{
+		IssueCommonOptions: common,
+		Title:              "given up on",
+		State:              native.StateBlocked,
+	})
+	s := reopenBoard(t, storeDir)
+	if err := s.SetGaveUp(card.ID, &native.GiveUp{RunID: "run-dead", State: native.StateBlocked, Attempts: 3}); err != nil {
+		t.Fatalf("SetGaveUp: %v", err)
+	}
+
+	var buf bytes.Buffer
+	p := &cli.Printer{W: &buf, Format: cli.OutputJSON}
+	if err := cli.RunIssueClose(p, cli.IssueRefOptions{
+		IssueCommonOptions: common,
+		IDOrPrefix:         card.ID,
+	}); err != nil {
+		t.Fatalf("issue close: %v", err)
+	}
+
+	got, err := reopenBoard(t, storeDir).Get(card.ID)
+	if err != nil {
+		t.Fatalf("reload issue: %v", err)
+	}
+	if got.GaveUp != nil {
+		t.Errorf("give-up stamp survived close: %+v — the card never leaves the lane", got.GaveUp)
+	}
+	var reported native.Issue
+	if err := json.Unmarshal(buf.Bytes(), &reported); err != nil {
+		t.Fatalf("decode reported issue from %q: %v", buf.String(), err)
+	}
+	if reported.GaveUp != nil {
+		t.Errorf("close reported a stamp it just cleared: %+v", reported.GaveUp)
+	}
+}
+
 // `--clear-last-run` is the operator's way back to a FRESH launch. While the
 // pointer names a resumable run the dispatcher resumes THAT run rather than
 // minting a new one, so a ticket whose run died in a way resuming cannot fix

--- a/openapi.json
+++ b/openapi.json
@@ -623,6 +623,27 @@
         ],
         "type": "object"
       },
+      "GiveUp": {
+        "properties": {
+          "at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "attempts": {
+            "type": "integer"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "at"
+        ],
+        "type": "object"
+      },
       "Issue": {
         "properties": {
           "assignee": {
@@ -668,6 +689,9 @@
           "fields": {
             "additionalProperties": {},
             "type": "object"
+          },
+          "gave_up": {
+            "$ref": "#/components/schemas/GiveUp"
           },
           "id": {
             "type": "string"
@@ -817,6 +841,9 @@
           },
           "failed": {
             "type": "boolean"
+          },
+          "gave_up": {
+            "$ref": "#/components/schemas/GiveUp"
           },
           "id": {
             "type": "string"

--- a/pkg/cli/issue.go
+++ b/pkg/cli/issue.go
@@ -329,7 +329,8 @@ func RunIssueClose(p *Printer, opts IssueRefOptions) error {
 	if terminal == "" {
 		return errors.New("issue close: board has no terminal state — declare one or use `issue move`")
 	}
-	if _, err := s.SetState(id, terminal); err != nil {
+	filed, err := s.SetState(id, terminal)
+	if err != nil {
 		return err
 	}
 	// Closing is the operator ACKNOWLEDGING the ticket, so drop any
@@ -344,9 +345,11 @@ func RunIssueClose(p *Printer, opts IssueRefOptions) error {
 	if err := s.SetGaveUp(id, nil); err != nil {
 		p.Line("warning: could not clear the dispatcher give-up stamp on %s: %v", shortID(id), err)
 	}
-	iss, err := s.Get(id)
-	if err != nil {
-		return err
+	// Same for the re-read: the close has landed, so fall back to SetState's
+	// snapshot rather than report a committed close as a failure.
+	iss := filed
+	if refreshed, getErr := s.Get(id); getErr == nil {
+		iss = refreshed
 	}
 	if p.Format == OutputJSON {
 		p.JSON(iss)

--- a/pkg/cli/issue.go
+++ b/pkg/cli/issue.go
@@ -333,6 +333,17 @@ func RunIssueClose(p *Printer, opts IssueRefOptions) error {
 	if err != nil {
 		return err
 	}
+	// Closing is the operator ACKNOWLEDGING the ticket, so drop any
+	// dispatcher give-up stamp on it. Moving a ticket expires the stamp on
+	// its own, but closing one the dispatcher already filed into this very
+	// state changes nothing — and would leave the card sitting in the
+	// pipeline board's needs-attention lane after the operator closed it.
+	if err := s.SetGaveUp(id, nil); err != nil {
+		return err
+	}
+	if iss, err = s.Get(id); err != nil {
+		return err
+	}
 	if p.Format == OutputJSON {
 		p.JSON(iss)
 		return nil

--- a/pkg/cli/issue.go
+++ b/pkg/cli/issue.go
@@ -276,6 +276,17 @@ func RunIssueUpdate(p *Printer, opts IssueUpdateOptions) error {
 		}
 		fields[k] = nil
 	}
+	// Before the patch: refusing after it would apply --title and then error,
+	// leaving the operator with a half-done command they did not ask for.
+	if opts.ClearLastRun {
+		current, err := s.Get(id)
+		if err != nil {
+			return err
+		}
+		if err := refuseClearWhileRunAlive(opts.IssueCommonOptions, current.LastRunID); err != nil {
+			return err
+		}
+	}
 	patch := native.Patch{
 		Title:    opts.Title,
 		Body:     opts.Body,
@@ -290,9 +301,6 @@ func RunIssueUpdate(p *Printer, opts IssueUpdateOptions) error {
 		return err
 	}
 	if opts.ClearLastRun {
-		if err := refuseClearWhileRunAlive(opts.IssueCommonOptions, iss.LastRunID); err != nil {
-			return err
-		}
 		if err := s.SetLastRun(id, "", ""); err != nil {
 			return err
 		}
@@ -386,7 +394,10 @@ func RunIssueClose(p *Printer, opts IssueRefOptions) error {
 	// failure. A surviving stamp costs a card in the wrong lane, not
 	// correctness — say so and carry on.
 	if err := s.SetGaveUp(id, nil); err != nil {
-		p.Line("warning: could not clear the dispatcher give-up stamp on %s: %v", shortID(id), err)
+		// stderr, not the Printer: `--json` writes a single document to
+		// stdout, and a warning spliced in front of it turns a scripted
+		// close into a parse error on a path that otherwise succeeded.
+		fmt.Fprintf(os.Stderr, "warning: could not clear the dispatcher give-up stamp on %s: %v\n", shortID(id), err)
 	}
 	// Same for the re-read: the close has landed, so fall back to SetState's
 	// snapshot rather than report a committed close as a failure.

--- a/pkg/cli/issue.go
+++ b/pkg/cli/issue.go
@@ -246,6 +246,14 @@ type IssueUpdateOptions struct {
 	Blockers   *[]string
 	Fields     []string // key=value (set or replace)
 	ClearField []string
+	// ClearLastRun drops the issue's last_run pointer (Store.SetLastRun with
+	// empty strings — the clear its own contract documents). It is the
+	// operator's way back to a FRESH launch: while the pointer names a
+	// resumable run, the dispatcher resumes that run instead of minting a new
+	// one (resolveRunID → resumableRunID), so a ticket whose run died in a way
+	// resuming cannot fix had no exit but hand-editing the issue JSON.
+	// The run history (Issue.Runs) is kept — the runs still happened.
+	ClearLastRun bool
 }
 
 // RunIssueUpdate applies the patch.
@@ -281,11 +289,22 @@ func RunIssueUpdate(p *Printer, opts IssueUpdateOptions) error {
 	if err != nil {
 		return err
 	}
+	if opts.ClearLastRun {
+		if err := s.SetLastRun(id, "", ""); err != nil {
+			return err
+		}
+		if iss, err = s.Get(id); err != nil {
+			return err
+		}
+	}
 	if p.Format == OutputJSON {
 		p.JSON(iss)
 		return nil
 	}
 	p.Line("Updated %s", shortID(iss.ID))
+	if opts.ClearLastRun {
+		p.Line("Cleared the last-run pointer — the next dispatch starts a fresh run instead of resuming.")
+	}
 	return nil
 }
 

--- a/pkg/cli/issue.go
+++ b/pkg/cli/issue.go
@@ -337,8 +337,12 @@ func RunIssueClose(p *Printer, opts IssueRefOptions) error {
 	// its own, but closing one the dispatcher already filed into this very
 	// state changes nothing — and would leave the card sitting in the
 	// pipeline board's needs-attention lane after the operator closed it.
+	// Best-effort, like the pipeline board's Close: SetState has already
+	// committed, so failing here would report a close that DID happen as a
+	// failure. A surviving stamp costs a card in the wrong lane, not
+	// correctness — say so and carry on.
 	if err := s.SetGaveUp(id, nil); err != nil {
-		return err
+		p.Line("warning: could not clear the dispatcher give-up stamp on %s: %v", shortID(id), err)
 	}
 	iss, err := s.Get(id)
 	if err != nil {

--- a/pkg/cli/issue.go
+++ b/pkg/cli/issue.go
@@ -329,8 +329,7 @@ func RunIssueClose(p *Printer, opts IssueRefOptions) error {
 	if terminal == "" {
 		return errors.New("issue close: board has no terminal state — declare one or use `issue move`")
 	}
-	iss, err := s.SetState(id, terminal)
-	if err != nil {
+	if _, err := s.SetState(id, terminal); err != nil {
 		return err
 	}
 	// Closing is the operator ACKNOWLEDGING the ticket, so drop any
@@ -341,7 +340,8 @@ func RunIssueClose(p *Printer, opts IssueRefOptions) error {
 	if err := s.SetGaveUp(id, nil); err != nil {
 		return err
 	}
-	if iss, err = s.Get(id); err != nil {
+	iss, err := s.Get(id)
+	if err != nil {
 		return err
 	}
 	if p.Format == OutputJSON {

--- a/pkg/cli/issue.go
+++ b/pkg/cli/issue.go
@@ -290,6 +290,9 @@ func RunIssueUpdate(p *Printer, opts IssueUpdateOptions) error {
 		return err
 	}
 	if opts.ClearLastRun {
+		if err := refuseClearWhileRunAlive(opts.IssueCommonOptions, iss.LastRunID); err != nil {
+			return err
+		}
 		if err := s.SetLastRun(id, "", ""); err != nil {
 			return err
 		}
@@ -304,6 +307,46 @@ func RunIssueUpdate(p *Printer, opts IssueUpdateOptions) error {
 	p.Line("Updated %s", shortID(iss.ID))
 	if opts.ClearLastRun {
 		p.Line("Cleared the last-run pointer — the next dispatch starts a fresh run instead of resuming.")
+	}
+	return nil
+}
+
+// refuseClearWhileRunAlive stops `--clear-last-run` from forgetting a run that
+// is still ALIVE. The pointer is the sole persisted input to the dispatcher's
+// sibling guard (lastRunForbidsFresh, pkg/dispatcher/retry.go): with it gone,
+// the next dispatch mints a fresh run from the workflow entry — and if the
+// original is still running or parked on a question, that is two agents on one
+// ticket, two branches and two PRs for one issue.
+//
+// The flag's whole purpose is to defeat that guard for a run that is dead but
+// RESUMABLE (`failed_resumable` / `cancelled` — the documented case, and both
+// forbidden statuses), so the discrimination that matters is dead-vs-live, not
+// terminal-vs-not. A run that cannot be read is not protected: it is already
+// gone as far as the dispatcher is concerned.
+func refuseClearWhileRunAlive(opts IssueCommonOptions, runID string) error {
+	if strings.TrimSpace(runID) == "" {
+		return nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	rs, err := store.New(store.ResolveStoreDir(cwd, opts.StoreDir))
+	if err != nil {
+		// No readable store — nothing to protect, and refusing here would
+		// block the escape hatch over a condition we cannot establish.
+		return nil
+	}
+	run, err := rs.LoadRun(context.Background(), runID)
+	if err != nil || run == nil {
+		return nil
+	}
+	switch run.Status {
+	case store.RunStatusRunning, store.RunStatusQueued,
+		store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator:
+		return fmt.Errorf(
+			"issue update: run %s is still %s — clearing the pointer now would let the next dispatch start a SECOND run on this ticket; stop or answer it first (`iterion inspect --run-id %s`)",
+			shortID(runID), run.Status, runID)
 	}
 	return nil
 }

--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -141,6 +141,32 @@ func runBoardStoreSuite(t *testing.T, store native.BoardStore) {
 		t.Errorf("SetAwaitingInput(false) not cleared: %+v", got)
 	}
 
+	// SetGaveUp records / clears the dispatcher's give-up stamp — the record
+	// that distinguishes an automatic give-up from an operator filing the
+	// same terminal state by hand. Both stores must round-trip the nested
+	// value, or the pipeline board's needs-attention lane is cloud-blind.
+	current, err := store.Get(created.ID)
+	if err != nil {
+		t.Fatalf("Get before SetGaveUp: %v", err)
+	}
+	if err := store.SetGaveUp(created.ID, &native.GiveUp{RunID: "run-1", State: current.State, Attempts: 3}); err != nil {
+		t.Errorf("SetGaveUp: %v", err)
+	}
+	got, err := store.Get(created.ID)
+	if err != nil {
+		t.Errorf("Get after SetGaveUp: %v", err)
+	} else if got.GaveUp == nil || got.GaveUp.RunID != "run-1" || got.GaveUp.Attempts != 3 || got.GaveUp.At.IsZero() {
+		t.Errorf("give-up stamp not persisted: %+v", got.GaveUp)
+	} else if !got.GaveUp.Current(got.State, "run-1") {
+		t.Errorf("stamp does not describe the issue it was written on: state=%q stamp=%+v", got.State, got.GaveUp)
+	}
+	if err := store.SetGaveUp(created.ID, nil); err != nil {
+		t.Errorf("SetGaveUp(nil): %v", err)
+	}
+	if got, _ := store.Get(created.ID); got.GaveUp != nil {
+		t.Errorf("SetGaveUp(nil) did not clear: %+v", got.GaveUp)
+	}
+
 	// List: filter by state + assignee; sort by priority.
 	_, _ = store.Create(native.Issue{Title: "second", State: native.StateReady, Priority: 9})
 	ready, err := store.List(native.ListFilter{States: []string{native.StateReady}})

--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -160,6 +160,21 @@ func runBoardStoreSuite(t *testing.T, store native.BoardStore) {
 	} else if !got.GaveUp.Current(got.State, "run-1") {
 		t.Errorf("stamp does not describe the issue it was written on: state=%q stamp=%+v", got.State, got.GaveUp)
 	}
+	// Moving the ticket expires the stamp for good — both stores enforce it
+	// on their write path, or a returning ticket would resurrect a give-up.
+	if _, err := store.SetState(created.ID, native.StateBlocked); err != nil {
+		t.Errorf("SetState(blocked): %v", err)
+	}
+	if got, _ := store.Get(created.ID); got.GaveUp != nil {
+		t.Errorf("stamp survived the ticket moving: %+v", got.GaveUp)
+	}
+	if _, err := store.SetState(created.ID, current.State); err != nil {
+		t.Errorf("SetState(back): %v", err)
+	}
+	if got, _ := store.Get(created.ID); got.GaveUp != nil {
+		t.Errorf("stamp came back when the ticket returned to its state: %+v", got.GaveUp)
+	}
+	// And an explicit clear is a no-op on an unstamped issue.
 	if err := store.SetGaveUp(created.ID, nil); err != nil {
 		t.Errorf("SetGaveUp(nil): %v", err)
 	}

--- a/pkg/dispatcher/boardmongo/store.go
+++ b/pkg/dispatcher/boardmongo/store.go
@@ -258,6 +258,7 @@ func (s *Store) List(filter native.ListFilter) ([]*native.Issue, error) {
 
 // replace persists the issue and stamps UpdatedAt.
 func (s *Store) replace(ctx context.Context, iss *native.Issue) error {
+	expireGiveUp(iss)
 	_, err := s.issues.ReplaceOne(ctx, bson.M{"_id": iss.ID, "tenant_id": s.tenant}, issueDoc{ID: iss.ID, Tenant: s.tenant, Issue: *iss})
 	if err != nil {
 		return fmt.Errorf("boardmongo: replace issue: %w", err)
@@ -450,7 +451,7 @@ func (s *Store) SetGaveUp(id string, g *native.GiveUp) error {
 	if err != nil {
 		return err
 	}
-	if sameGiveUp(iss.GaveUp, g) {
+	if sameGiveUp(iss.GaveUp, g) && (g == nil || g.State == iss.State) {
 		return nil
 	}
 	if g == nil {
@@ -460,6 +461,10 @@ func (s *Store) SetGaveUp(id string, g *native.GiveUp) error {
 		if stamp.At.IsZero() {
 			stamp.At = time.Now().UTC()
 		}
+		// Recorded against the state the ticket is actually in — see the
+		// filesystem store's SetGaveUp for why a stamp that disagrees with
+		// its issue would be dropped by the write that persists it.
+		stamp.State = iss.State
 		iss.GaveUp = &stamp
 	}
 	iss.UpdatedAt = time.Now().UTC()
@@ -473,6 +478,16 @@ func (s *Store) SetGaveUp(id string, g *native.GiveUp) error {
 		payload["attempts"] = g.Attempts
 	}
 	return s.emit(native.Event{Type: native.EvtIssueGaveUp, IssueID: id, Payload: payload})
+}
+
+// expireGiveUp drops a stamp that no longer describes the state the issue is
+// being written in, on the ONE write path — the Mongo twin of the filesystem
+// store's rule, which is what makes give-up staleness permanent instead of
+// reversible. See native.Store.expireGiveUp for the full argument.
+func expireGiveUp(iss *native.Issue) {
+	if iss.GaveUp != nil && iss.GaveUp.State != iss.State {
+		iss.GaveUp = nil
+	}
 }
 
 // sameGiveUp compares two stamps on the fields that decide behaviour (the

--- a/pkg/dispatcher/boardmongo/store.go
+++ b/pkg/dispatcher/boardmongo/store.go
@@ -454,6 +454,10 @@ func (s *Store) SetGaveUp(id string, g *native.GiveUp) error {
 	if sameGiveUp(iss.GaveUp, g) && (g == nil || g.State == iss.State) {
 		return nil
 	}
+	// stamped is what actually landed on the issue (nil for a clear); the
+	// event reports IT, never the caller's g, which may name a state the
+	// store overrode.
+	var stamped *native.GiveUp
 	if g == nil {
 		iss.GaveUp = nil
 	} else {
@@ -466,16 +470,20 @@ func (s *Store) SetGaveUp(id string, g *native.GiveUp) error {
 		// its issue would be dropped by the write that persists it.
 		stamp.State = iss.State
 		iss.GaveUp = &stamp
+		stamped = &stamp
 	}
 	iss.UpdatedAt = time.Now().UTC()
 	if err := s.replace(ctx, iss); err != nil {
 		return err
 	}
-	payload := map[string]any{"gave_up": g != nil}
-	if g != nil {
-		payload["run_id"] = g.RunID
-		payload["state"] = g.State
-		payload["attempts"] = g.Attempts
+	payload := map[string]any{"gave_up": stamped != nil}
+	if stamped != nil {
+		payload["run_id"] = stamped.RunID
+		// The state that was STAMPED, not the one the caller believed — the
+		// two differ when a give-up raced an operator move, and the audit
+		// record exists to reconstruct what actually happened.
+		payload["state"] = stamped.State
+		payload["attempts"] = stamped.Attempts
 	}
 	return s.emit(native.Event{Type: native.EvtIssueGaveUp, IssueID: id, Payload: payload})
 }

--- a/pkg/dispatcher/boardmongo/store.go
+++ b/pkg/dispatcher/boardmongo/store.go
@@ -451,7 +451,11 @@ func (s *Store) SetGaveUp(id string, g *native.GiveUp) error {
 	if err != nil {
 		return err
 	}
-	if sameGiveUp(iss.GaveUp, g) && (g == nil || g.State == iss.State) {
+	// Compare against what would ACTUALLY be written — the store overrides a
+	// caller's state with the ticket's own (below), so comparing the caller's
+	// value would re-write and re-emit on every repeat call whenever the two
+	// disagree.
+	if sameGiveUp(iss.GaveUp, giveUpFor(iss, g)) {
 		return nil
 	}
 	// stamped is what actually landed on the issue (nil for a clear); the
@@ -461,14 +465,10 @@ func (s *Store) SetGaveUp(id string, g *native.GiveUp) error {
 	if g == nil {
 		iss.GaveUp = nil
 	} else {
-		stamp := *g
+		stamp := *giveUpFor(iss, g)
 		if stamp.At.IsZero() {
 			stamp.At = time.Now().UTC()
 		}
-		// Recorded against the state the ticket is actually in — see the
-		// filesystem store's SetGaveUp for why a stamp that disagrees with
-		// its issue would be dropped by the write that persists it.
-		stamp.State = iss.State
 		iss.GaveUp = &stamp
 		stamped = &stamp
 	}
@@ -496,6 +496,23 @@ func expireGiveUp(iss *native.Issue) {
 	if iss.GaveUp != nil && iss.GaveUp.State != iss.State {
 		iss.GaveUp = nil
 	}
+}
+
+// giveUpFor returns the stamp that would land on iss for a caller's g: the
+// same values, but described against the state the ticket is ACTUALLY in.
+//
+// The store overrides the caller's state on purpose. A stamp born disagreeing
+// with its issue would be expired by the very write that persists it
+// (expireGiveUp) and vanish silently; recording what is true keeps the
+// caller's intent ("filed as X") and the record in agreement, and lets the
+// idempotence check compare like with like.
+func giveUpFor(iss *native.Issue, g *native.GiveUp) *native.GiveUp {
+	if g == nil {
+		return nil
+	}
+	out := *g
+	out.State = iss.State
+	return &out
 }
 
 // sameGiveUp compares two stamps on the fields that decide behaviour (the

--- a/pkg/dispatcher/boardmongo/store.go
+++ b/pkg/dispatcher/boardmongo/store.go
@@ -451,21 +451,23 @@ func (s *Store) SetGaveUp(id string, g *native.GiveUp) error {
 	if err != nil {
 		return err
 	}
-	// Compare against what would ACTUALLY be written — the store overrides a
-	// caller's state with the ticket's own (below), so comparing the caller's
-	// value would re-write and re-emit on every repeat call whenever the two
-	// disagree.
-	if sameGiveUp(iss.GaveUp, giveUpFor(iss, g)) {
+	want, ok := giveUpToRecord(iss, g)
+	if !ok {
+		return nil
+	}
+	// Compared against what would ACTUALLY be written, so a repeat call is a
+	// real no-op rather than a re-write that churns UpdatedAt.
+	if sameGiveUp(iss.GaveUp, want) {
 		return nil
 	}
 	// stamped is what actually landed on the issue (nil for a clear); the
 	// event reports IT, never the caller's g, which may name a state the
 	// store overrode.
 	var stamped *native.GiveUp
-	if g == nil {
+	if want == nil {
 		iss.GaveUp = nil
 	} else {
-		stamp := *giveUpFor(iss, g)
+		stamp := *want
 		if stamp.At.IsZero() {
 			stamp.At = time.Now().UTC()
 		}
@@ -498,21 +500,30 @@ func expireGiveUp(iss *native.Issue) {
 	}
 }
 
-// giveUpFor returns the stamp that would land on iss for a caller's g: the
-// same values, but described against the state the ticket is ACTUALLY in.
+// giveUpToRecord resolves a caller's stamp against the issue as it stands,
+// returning the value to write and whether to write at all.
 //
-// The store overrides the caller's state on purpose. A stamp born disagreeing
-// with its issue would be expired by the very write that persists it
-// (expireGiveUp) and vanish silently; recording what is true keeps the
-// caller's intent ("filed as X") and the record in agreement, and lets the
-// idempotence check compare like with like.
-func giveUpFor(iss *native.Issue, g *native.GiveUp) *native.GiveUp {
+// A give-up describes a ticket that is still where the give-up PUT it. When
+// the ticket has already moved — an operator got there between the terminal
+// move and the stamp — the give-up is superseded, and recording it would put
+// the operator's own choice under a "the dispatcher gave up and filed this
+// ticket as …" banner. Nothing is written; the state change already stands in
+// the audit log.
+//
+// A stamp arriving without a state is filled in from the issue, so the value
+// compared for idempotence and the value written are always the same thing.
+func giveUpToRecord(iss *native.Issue, g *native.GiveUp) (*native.GiveUp, bool) {
 	if g == nil {
-		return nil
+		return nil, true
 	}
 	out := *g
-	out.State = iss.State
-	return &out
+	if out.State == "" {
+		out.State = iss.State
+	}
+	if out.State != iss.State {
+		return nil, false
+	}
+	return &out, true
 }
 
 // sameGiveUp compares two stamps on the fields that decide behaviour (the

--- a/pkg/dispatcher/boardmongo/store.go
+++ b/pkg/dispatcher/boardmongo/store.go
@@ -438,6 +438,53 @@ func (s *Store) SetAwaitingInput(id string, v bool) error {
 	return s.emit(native.Event{Type: native.EvtIssueUpdated, IssueID: id, Payload: map[string]any{"awaiting_input": v}})
 }
 
+// SetGaveUp stamps (nil clears) the dispatcher's give-up on an issue — the
+// record that its current state was written by an exhausted retry budget and
+// not by a human (see native.Issue.GaveUp). Idempotent on the fields that
+// decide behaviour; mirrors SetAwaitingInput: read → set → replace → bump
+// UpdatedAt → emit, here EvtIssueGaveUp.
+func (s *Store) SetGaveUp(id string, g *native.GiveUp) error {
+	ctx, cancel := ctxWithTimeout()
+	defer cancel()
+	iss, err := s.get(ctx, id)
+	if err != nil {
+		return err
+	}
+	if sameGiveUp(iss.GaveUp, g) {
+		return nil
+	}
+	if g == nil {
+		iss.GaveUp = nil
+	} else {
+		stamp := *g
+		if stamp.At.IsZero() {
+			stamp.At = time.Now().UTC()
+		}
+		iss.GaveUp = &stamp
+	}
+	iss.UpdatedAt = time.Now().UTC()
+	if err := s.replace(ctx, iss); err != nil {
+		return err
+	}
+	payload := map[string]any{"gave_up": g != nil}
+	if g != nil {
+		payload["run_id"] = g.RunID
+		payload["state"] = g.State
+		payload["attempts"] = g.Attempts
+	}
+	return s.emit(native.Event{Type: native.EvtIssueGaveUp, IssueID: id, Payload: payload})
+}
+
+// sameGiveUp compares two stamps on the fields that decide behaviour (the
+// timestamp is provenance, not identity), so a re-stamp of the same give-up
+// writes nothing. Mirrors the filesystem store's predicate.
+func sameGiveUp(a, b *native.GiveUp) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.RunID == b.RunID && a.State == b.State && a.Attempts == b.Attempts
+}
+
 // AddComment appends a note to the issue's discussion thread and returns
 // the updated issue plus the created comment.
 func (s *Store) AddComment(id, author, body string) (*native.Issue, *native.Comment, error) {

--- a/pkg/dispatcher/commands.go
+++ b/pkg/dispatcher/commands.go
@@ -739,6 +739,15 @@ func (c *Dispatcher) setAwaitingInput(issueID string, v bool) {
 	}
 }
 
+// giveUpStamper is the optional seam a board-backed tracker implements to
+// record a give-up. Named rather than inlined at the assertion so a test can
+// hold the shipped adapters to it: an assertion on an anonymous interface
+// fails SILENTLY, which is how the SetLastRun pass-through went missing and no
+// issue got its pointer for a release.
+type giveUpStamper interface {
+	SetGaveUp(id string, g *native.GiveUp) error
+}
+
 // stampGiveUp records on the tracker issue that THIS dispatcher filed it
 // after exhausting its retry budget — the fact a bare terminal state cannot
 // carry. Without it the pipeline board reads the give-up's own FailedState
@@ -754,9 +763,7 @@ func (c *Dispatcher) setAwaitingInput(issueID string, v bool) {
 // Called ONLY once that move succeeded: a give-up that fell back to retrying
 // (the board cannot represent the failed state) has not given up.
 func (c *Dispatcher) stampGiveUp(plan finishPlan) {
-	setter, ok := c.tracker.(interface {
-		SetGaveUp(id string, g *native.GiveUp) error
-	})
+	setter, ok := c.tracker.(giveUpStamper)
 	if !ok {
 		return
 	}

--- a/pkg/dispatcher/commands.go
+++ b/pkg/dispatcher/commands.go
@@ -659,6 +659,11 @@ func (c *Dispatcher) runFinishWorker(plan finishPlan) {
 			// Terminal move succeeded — the give-up is final, so drop the
 			// optimistic retry guard the actor scheduled.
 			c.logger.Warn("dispatcher: %s gave up after %d attempts (run=%s): %s — moved to %q; clear the blocker or re-open the issue to retry", plan.identifier, plan.attemptCount, plan.runID, plan.runErrText, plan.failedState)
+			// Stamp the ticket so downstream readers can tell this move
+			// apart from an operator filing the same state by hand — the
+			// pipeline board needs it to surface the failure instead of
+			// filing it as acknowledged history.
+			c.stampGiveUp(plan)
 			c.postCmd(cmdDropRetry{issueID: plan.issueID})
 		}
 	}
@@ -731,6 +736,38 @@ func (c *Dispatcher) setAwaitingInput(issueID string, v bool) {
 	}
 	if err := setter.SetAwaitingInput(issueID, v); err != nil {
 		c.logger.Warn("dispatcher: set awaiting-input=%v on %s: %v", v, issueID, err)
+	}
+}
+
+// stampGiveUp records on the tracker issue that THIS dispatcher filed it
+// after exhausting its retry budget — the fact a bare terminal state cannot
+// carry. Without it the pipeline board reads the give-up's own FailedState
+// move as "a human already filed this ticket" and buries the failure in
+// Closed, which is exactly the failure its Needs-attention lane exists for
+// (issue #494).
+//
+// Same optional-interface seam as setAwaitingInput/stampLastRun: only board
+// trackers implement it, external ones skip silently. Best-effort — a write
+// failure is logged at warn and never derails the give-up, whose authority is
+// the FailedState move that already landed.
+//
+// Called ONLY once that move succeeded: a give-up that fell back to retrying
+// (the board cannot represent the failed state) has not given up.
+func (c *Dispatcher) stampGiveUp(plan finishPlan) {
+	setter, ok := c.tracker.(interface {
+		SetGaveUp(id string, g *native.GiveUp) error
+	})
+	if !ok {
+		return
+	}
+	stamp := &native.GiveUp{
+		RunID:    plan.runID,
+		State:    plan.failedState,
+		Attempts: plan.attemptCount,
+		At:       time.Now().UTC(),
+	}
+	if err := setter.SetGaveUp(plan.issueID, stamp); err != nil {
+		c.logger.Warn("dispatcher: stamp give-up on %s: %v", plan.identifier, err)
 	}
 }
 

--- a/pkg/dispatcher/commands_test.go
+++ b/pkg/dispatcher/commands_test.go
@@ -374,6 +374,21 @@ func TestFinishRun_GiveUpMovesToFailedState(t *testing.T) {
 	if _, ok := c.state.retries[issueID]; ok {
 		t.Fatal("retry guard not dropped after a successful give-up move")
 	}
+	// The move alone is ambiguous: an operator filing the ticket by hand
+	// writes the very same state. The give-up must also STAMP the ticket, or
+	// the pipeline board files an unattended failure as acknowledged history
+	// and it never reaches the needs-attention lane (issue #494).
+	stamps := ft.giveUpStamps()
+	if len(stamps) != 1 || stamps[0] == nil {
+		t.Fatalf("give-up stamps = %+v, want exactly one", stamps)
+	}
+	got := stamps[0]
+	if got.RunID != "run-gv" || got.State != "blocked" || got.Attempts != 1 {
+		t.Errorf("give-up stamp = %+v, want run-gv/blocked/1 attempt", got)
+	}
+	if got.At.IsZero() {
+		t.Error("give-up stamp carries no timestamp")
+	}
 }
 
 // TestFinishRun_GiveUpFallsBackToRetryWhenMoveRejected proves the deliberate
@@ -411,6 +426,12 @@ func TestFinishRun_GiveUpFallsBackToRetryWhenMoveRejected(t *testing.T) {
 	}
 	if _, ok := c.state.retries[issueID]; !ok {
 		t.Fatal("retry must be preserved when the give-up move is rejected (board can't represent failed)")
+	}
+	// A give-up that fell back to retrying has not given up. Stamping here
+	// would put a still-retrying ticket in the needs-attention lane and tell
+	// the operator a decision was made that was not.
+	if stamps := ft.giveUpStamps(); len(stamps) != 0 {
+		t.Errorf("give-up stamps = %+v, want none — the terminal move was rejected", stamps)
 	}
 }
 

--- a/pkg/dispatcher/commands_test.go
+++ b/pkg/dispatcher/commands_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/runtime"
@@ -849,4 +850,92 @@ func TestFinishRun_WarnsOnZeroCommit(t *testing.T) {
 			t.Fatalf("issue state = %q, want %q", state, "review")
 		}
 	})
+}
+
+// The whole give-up chain against a REAL board: the dispatcher's optional
+// interface assertion, the native Adapter's pass-through, the store write.
+// Each half is covered on its own, and each half is exactly where a silent
+// break lives — an anonymous type assertion that stops matching returns no
+// error, it just stops stamping, and the pipeline board quietly goes back to
+// filing unattended failures as acknowledged history (issue #494).
+func TestGiveUpStampsThroughTheNativeAdapter(t *testing.T) {
+	dir := t.TempDir()
+	ns, err := native.NewStore(filepath.Join(dir, "board"))
+	if err != nil {
+		t.Fatalf("native.NewStore: %v", err)
+	}
+	t.Cleanup(func() { _ = ns.Close() })
+
+	// The adapter must satisfy the seam the dispatcher asserts on, or every
+	// stamp is dropped without a word.
+	var _ giveUpStamper = native.NewAdapter(ns)
+
+	iss, err := ns.Create(native.Issue{Title: "doomed", State: native.StateInProgress, Bot: "review"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := ns.Claim(iss.ID, "test-host-1"); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+
+	cfg := &Config{
+		Name:     "test",
+		Workflow: filepath.Join(t.TempDir(), "fake.bot"),
+		Tracker:  TrackerConfig{Kind: "native"},
+		Polling:  PollingConfig{IntervalMS: 50},
+		Agent: AgentConfig{
+			MaxConcurrent: 4,
+			MaxAttempts:   1, // Attempt+1 reaches the cap → exhausted
+			RunningState:  "in_progress",
+			FailedState:   native.StateBlocked,
+		},
+		Workspace: WorkspaceConfig{Root: filepath.Join(dir, "ws")},
+	}
+	cfg.applyDefaults()
+	ws, err := NewWorkspaces(cfg.Workspace.Root)
+	if err != nil {
+		t.Fatalf("NewWorkspaces: %v", err)
+	}
+	c, err := New(Options{
+		Config:     cfg,
+		Tracker:    native.NewAdapter(ns),
+		Runner:     &StubRunner{},
+		Workspaces: ws,
+		Logger:     iterlog.New(iterlog.LevelError, &bytes.Buffer{}),
+		HostMarker: "test-host-1",
+		StoreDir:   dir,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c.state.running[iss.ID] = &runningEntry{
+		IssueID:               iss.ID,
+		Identifier:            iss.ID,
+		RunID:                 "run-doomed",
+		WorkflowState:         "in_progress",
+		WorkspacePath:         filepath.Join(dir, "ws", "doomed"),
+		StartedAt:             time.Now(),
+		TransitionedFromState: native.StateReady,
+	}
+
+	c.finishRun(context.Background(), iss.ID, errPermanentFailure{})
+	c.workersWG.Wait()
+
+	got, err := ns.Get(iss.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != native.StateBlocked {
+		t.Fatalf("ticket state = %q, want blocked", got.State)
+	}
+	if got.GaveUp == nil {
+		t.Fatal("the give-up left no stamp — the board cannot tell it from an operator filing the ticket")
+	}
+	if got.GaveUp.RunID != "run-doomed" || got.GaveUp.Attempts != 1 {
+		t.Errorf("stamp = %+v, want run-doomed / 1 attempt", got.GaveUp)
+	}
+	// And it describes the ticket as filed, which is what the projection reads.
+	if !got.GaveUp.Current(got.State, "run-doomed") {
+		t.Errorf("stamp does not describe the filed ticket: state=%q stamp=%+v", got.State, got.GaveUp)
+	}
 }

--- a/pkg/dispatcher/loop_state_test.go
+++ b/pkg/dispatcher/loop_state_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/tracker"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 )
@@ -25,6 +26,10 @@ type stateAwareTracker struct {
 	updateCallsMu     atomic.Value // []stateUpdate, swapped under updateMu
 	updateMu          chanMu       // serialises append; matches fakeTracker.mu style
 	updateRejectState string       // when non-empty, UpdateState rejects moves into this state
+
+	// giveUps records the give-up stamps the dispatcher writes through the
+	// optional SetGaveUp seam (native.BoardStore), newest-last.
+	giveUps atomic.Value // []*native.GiveUp, swapped under updateMu
 }
 
 // chanMu is a single-slot channel used as a mutex. The dispatcher tests
@@ -69,6 +74,21 @@ func (t *stateAwareTracker) UpdateState(ctx context.Context, id, newState string
 		return tracker.ErrTransitionRejected
 	}
 	return t.fakeTracker.UpdateState(ctx, id, newState)
+}
+
+// SetGaveUp implements the optional seam the dispatcher type-asserts to when
+// it files a ticket after exhausting its retry budget (stampGiveUp).
+func (t *stateAwareTracker) SetGaveUp(id string, g *native.GiveUp) error {
+	t.updateMu.Lock()
+	defer t.updateMu.Unlock()
+	cur, _ := t.giveUps.Load().([]*native.GiveUp)
+	t.giveUps.Store(append(append([]*native.GiveUp(nil), cur...), g))
+	return nil
+}
+
+func (t *stateAwareTracker) giveUpStamps() []*native.GiveUp {
+	cur, _ := t.giveUps.Load().([]*native.GiveUp)
+	return append([]*native.GiveUp(nil), cur...)
 }
 
 func (t *stateAwareTracker) calls() []stateUpdate {

--- a/pkg/dispatcher/native/adapter.go
+++ b/pkg/dispatcher/native/adapter.go
@@ -201,6 +201,13 @@ func (a *Adapter) SetAwaitingInput(id string, v bool) error {
 	return a.store.SetAwaitingInput(id, v)
 }
 
+// SetGaveUp passes through to the underlying store so the dispatcher's
+// optional-interface type assertion (setGaveUp in commands.go) resolves —
+// same seam, and same silent-fall-through trap, as SetAwaitingInput above.
+func (a *Adapter) SetGaveUp(id string, g *GiveUp) error {
+	return a.store.SetGaveUp(id, g)
+}
+
 // LastRunForIssue returns the runID of the most recent dispatch on
 // this issue. Empty when the issue has never been dispatched (or the
 // issue does not exist). Used by the dispatcher's resume path as a

--- a/pkg/dispatcher/native/boardops/ops.go
+++ b/pkg/dispatcher/native/boardops/ops.go
@@ -525,7 +525,8 @@ func doClose(store native.BoardStore, raw json.RawMessage) (json.RawMessage, err
 			return nil, fmt.Errorf("state %q is not terminal", target)
 		}
 	}
-	if _, err := store.SetState(resolved, target); err != nil {
+	filed, err := store.SetState(resolved, target)
+	if err != nil {
 		return nil, err
 	}
 	// Closing acknowledges the ticket, so any dispatcher give-up stamp on it
@@ -538,9 +539,13 @@ func doClose(store native.BoardStore, raw json.RawMessage) (json.RawMessage, err
 	// card in the wrong lane, not correctness — the same call the pipeline
 	// board's Close makes.
 	_ = store.SetGaveUp(resolved, nil)
-	iss, err := store.Get(resolved)
-	if err != nil {
-		return nil, err
+	// Same reasoning for the re-read. On a cloud board this Get is a network
+	// round-trip that can fail transiently, and the close has already landed:
+	// degrade to the pre-clear snapshot rather than tell the agent a close
+	// that DID happen failed (it would retry, or report the ticket open).
+	iss := filed
+	if refreshed, getErr := store.Get(resolved); getErr == nil {
+		iss = refreshed
 	}
 	return json.Marshal(iss)
 }

--- a/pkg/dispatcher/native/boardops/ops.go
+++ b/pkg/dispatcher/native/boardops/ops.go
@@ -533,9 +533,11 @@ func doClose(store native.BoardStore, raw json.RawMessage) (json.RawMessage, err
 	// dispatcher already filed into this same state does not move it, and
 	// would leave the card in the pipeline board's needs-attention lane after
 	// it was closed.
-	if err := store.SetGaveUp(resolved, nil); err != nil {
-		return nil, err
-	}
+	// Best-effort: SetState has already committed, so raising here would tell
+	// the agent a close that DID happen failed. A surviving stamp costs a
+	// card in the wrong lane, not correctness — the same call the pipeline
+	// board's Close makes.
+	_ = store.SetGaveUp(resolved, nil)
 	iss, err := store.Get(resolved)
 	if err != nil {
 		return nil, err

--- a/pkg/dispatcher/native/boardops/ops.go
+++ b/pkg/dispatcher/native/boardops/ops.go
@@ -525,8 +525,7 @@ func doClose(store native.BoardStore, raw json.RawMessage) (json.RawMessage, err
 			return nil, fmt.Errorf("state %q is not terminal", target)
 		}
 	}
-	iss, err := store.SetState(resolved, target)
-	if err != nil {
+	if _, err := store.SetState(resolved, target); err != nil {
 		return nil, err
 	}
 	// Closing acknowledges the ticket, so any dispatcher give-up stamp on it
@@ -537,7 +536,8 @@ func doClose(store native.BoardStore, raw json.RawMessage) (json.RawMessage, err
 	if err := store.SetGaveUp(resolved, nil); err != nil {
 		return nil, err
 	}
-	if iss, err = store.Get(resolved); err != nil {
+	iss, err := store.Get(resolved)
+	if err != nil {
 		return nil, err
 	}
 	return json.Marshal(iss)

--- a/pkg/dispatcher/native/boardops/ops.go
+++ b/pkg/dispatcher/native/boardops/ops.go
@@ -529,6 +529,17 @@ func doClose(store native.BoardStore, raw json.RawMessage) (json.RawMessage, err
 	if err != nil {
 		return nil, err
 	}
+	// Closing acknowledges the ticket, so any dispatcher give-up stamp on it
+	// goes. A move expires the stamp by itself; closing a ticket the
+	// dispatcher already filed into this same state does not move it, and
+	// would leave the card in the pipeline board's needs-attention lane after
+	// it was closed.
+	if err := store.SetGaveUp(resolved, nil); err != nil {
+		return nil, err
+	}
+	if iss, err = store.Get(resolved); err != nil {
+		return nil, err
+	}
 	return json.Marshal(iss)
 }
 

--- a/pkg/dispatcher/native/boardops/ops_test.go
+++ b/pkg/dispatcher/native/boardops/ops_test.go
@@ -320,3 +320,48 @@ func TestCreateIssue_ParentIDAndAutoSpawn(t *testing.T) {
 		t.Fatalf("auto ParentID = %q", child2.ParentID)
 	}
 }
+
+// Closing a ticket the DISPATCHER filed (retry budget exhausted) is the
+// operator's acknowledgement of that give-up, so it must drop the stamp —
+// including when the close target is the state the give-up already wrote,
+// where the state change is a no-op and nothing else can expire the stamp.
+// Otherwise the card stays in the pipeline board's needs-attention lane after
+// being closed.
+func TestClose_AcknowledgesADispatcherGiveUp(t *testing.T) {
+	s := newStore(t)
+	caps := NewCapabilities("board.create,board.close,board.read")
+	res, err := Call(s, caps, "create_issue", json.RawMessage(`{"title":"doomed"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var iss native.Issue
+	_ = json.Unmarshal(res, &iss)
+
+	if _, err := s.SetState(iss.ID, native.StateBlocked); err != nil {
+		t.Fatalf("SetState: %v", err)
+	}
+	if err := s.SetGaveUp(iss.ID, &native.GiveUp{RunID: "run-x", State: native.StateBlocked, Attempts: 3}); err != nil {
+		t.Fatalf("SetGaveUp: %v", err)
+	}
+
+	args, _ := json.Marshal(map[string]string{"id": iss.ID, "to": native.StateBlocked})
+	closed, err := Call(s, caps, "close_issue", args)
+	if err != nil {
+		t.Fatalf("close_issue: %v", err)
+	}
+	got, err := s.Get(iss.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.GaveUp != nil {
+		t.Errorf("give-up stamp survived close_issue: %+v", got.GaveUp)
+	}
+	// The tool's own result must agree with what was persisted.
+	var reported native.Issue
+	if err := json.Unmarshal(closed, &reported); err != nil {
+		t.Fatalf("decode close_issue result: %v", err)
+	}
+	if reported.GaveUp != nil {
+		t.Errorf("close_issue reported a stamp it just cleared: %+v", reported.GaveUp)
+	}
+}

--- a/pkg/dispatcher/native/boardstore.go
+++ b/pkg/dispatcher/native/boardstore.go
@@ -31,6 +31,10 @@ type BoardStore interface {
 	// run parked awaiting human/operator input, so the board grid can badge
 	// the card without a per-run fetch. A best-effort HINT (see Issue.AwaitingInput).
 	SetAwaitingInput(id string, v bool) error
+	// SetGaveUp records (nil clears) that the dispatcher filed this ticket
+	// itself after exhausting its retry budget, so a reader can tell an
+	// automatic give-up from an operator's own filing (see Issue.GaveUp).
+	SetGaveUp(id string, g *GiveUp) error
 
 	// AddComment appends a note to the issue's discussion thread and
 	// returns the updated issue plus the created comment.

--- a/pkg/dispatcher/native/event.go
+++ b/pkg/dispatcher/native/event.go
@@ -14,6 +14,12 @@ const (
 	EvtIssueReleased EventType = "issue_released"
 	EvtIssueLastRun  EventType = "issue_last_run_updated"
 	EvtIssueComment  EventType = "issue_comment_added"
+	// EvtIssueGaveUp is emitted when the dispatcher's give-up stamp is
+	// written or cleared on an issue (see Issue.GaveUp). Payload:
+	// {gave_up: bool, run_id, state, attempts} — a give-up is the one
+	// state change on a ticket that no human asked for, so it gets its own
+	// audit record rather than an anonymous issue_updated.
+	EvtIssueGaveUp EventType = "issue_gave_up"
 	// EvtIssueBlockersUpdated is emitted when an issue's blockers list changes
 	// (create-with-blockers, Update patch). Payload: {blockers: []string}.
 	EvtIssueBlockersUpdated EventType = "issue_blockers_updated"

--- a/pkg/dispatcher/native/issue.go
+++ b/pkg/dispatcher/native/issue.go
@@ -49,6 +49,20 @@ type Issue struct {
 	// (e.g. after a console-only resume the dispatcher never observed) is
 	// corrected at the next card touch.
 	AwaitingInput bool `json:"awaiting_input,omitempty"`
+	// GaveUp records that the ticket's CURRENT state was written by the
+	// dispatcher GIVING UP — its retry budget ran out and it filed the ticket
+	// in Agent.FailedState (default "blocked") on its own. That state is
+	// usually terminal, and a terminal ticket otherwise reads as "a human
+	// already filed this"; without this stamp the two are indistinguishable
+	// and the pipeline board buries an automatic give-up in Closed instead of
+	// surfacing it in Needs attention (issue #494).
+	//
+	// The stamp is SELF-INVALIDATING rather than something every writer must
+	// remember to clear: it records the run it happened on and the state it
+	// wrote, so a later run or any move of the ticket makes it stale by
+	// construction (see GiveUp.Current). The one case that needs an explicit
+	// clear is an operator filing the ticket into the state it is already in.
+	GaveUp *GiveUp `json:"gave_up,omitempty"`
 	// LastWorkdir is the absolute filesystem path the last run
 	// executed in — either the per-issue dispatcher workspace or,
 	// when `worktree: auto` was used, the run's git worktree path.
@@ -91,6 +105,12 @@ type RunRef struct {
 // boardmongo SetLastRun implementations so the append semantics stay
 // identical across stores. Growth is uncapped by design.
 func AppendRunRef(runs []RunRef, runID, workdir string, at time.Time) []RunRef {
+	// SetLastRun(id, "", "") is the documented way to CLEAR the pointer, and
+	// a cleared pointer is not a run that happened — appending it would put a
+	// blank entry in the card's run history.
+	if runID == "" {
+		return runs
+	}
 	for i := range runs {
 		if runs[i].RunID == runID {
 			runs[i].Workdir = workdir
@@ -99,6 +119,37 @@ func AppendRunRef(runs []RunRef, runID, workdir string, at time.Time) []RunRef {
 		}
 	}
 	return append(runs, RunRef{RunID: runID, Workdir: workdir, At: at})
+}
+
+// GiveUp is the give-up stamp on an Issue: the dispatcher exhausted
+// Agent.MaxAttempts on RunID and moved the ticket to State by itself. It is
+// the "who filed this ticket" answer a bare terminal state cannot give.
+type GiveUp struct {
+	// RunID is the run whose failure exhausted the budget.
+	RunID string `json:"run_id,omitempty"`
+	// State is the state the give-up wrote. Kept so the stamp expires on its
+	// own: once the ticket sits anywhere else, someone decided something
+	// after the give-up and the stamp no longer describes the card.
+	State string `json:"state,omitempty"`
+	// Attempts is how many attempts were made before giving up.
+	Attempts int `json:"attempts,omitempty"`
+	// At is when the give-up was stamped (UTC).
+	At time.Time `json:"at"`
+}
+
+// Current reports whether the stamp still describes the issue as it stands:
+// the ticket has not moved since the give-up, and the run being examined is
+// the one that was given up on. Anything else — a retry, an operator move, a
+// newer run — makes the stamp history rather than a live signal, with no
+// writer having to remember to clear it.
+//
+// A stamp with no run id never matches: it cannot be attributed to the card
+// being rendered, and guessing is how the lane got confusing in the first place.
+func (g *GiveUp) Current(issueState, runID string) bool {
+	if g == nil || g.RunID == "" {
+		return false
+	}
+	return g.State == issueState && g.RunID == runID
 }
 
 // ExternalRef links a board card to an issue on an external forge. Set by

--- a/pkg/dispatcher/native/store_issues.go
+++ b/pkg/dispatcher/native/store_issues.go
@@ -595,6 +595,7 @@ func (s *Store) writeIssueLocked(iss *Issue) error {
 	if err := validateIssueID(iss.ID); err != nil {
 		return err
 	}
+	expireGiveUp(iss)
 	if err := os.MkdirAll(filepath.Join(s.root, issuesDir), dirPerm); err != nil {
 		return err
 	}
@@ -607,6 +608,29 @@ func (s *Store) writeIssueLocked(iss *Issue) error {
 		return fmt.Errorf("native store: write issue: %w", err)
 	}
 	return nil
+}
+
+// expireGiveUp drops a give-up stamp that no longer describes the state the
+// issue is being written in. It runs on the ONE write path rather than at each
+// of the several state writers (SetState, ClaimForLaunch, the unblock promote,
+// a schema migration) so no future state writer has to remember it — the
+// property the stamp's contract claims (Issue.GaveUp) is enforced here rather
+// than trusted.
+//
+// It is what makes staleness PERMANENT. Comparing state at read time alone is
+// reversible: a ticket that leaves the stamped state and comes back — with the
+// same run, which is the norm since a dispatcher retry resumes the same run id
+// — would make the stamp live again and re-file an operator's own decision as
+// an unattended give-up, the exact mirror of the bug the stamp exists to fix.
+// Once the ticket moves, the stamp is gone for good.
+//
+// The one thing it cannot catch is a filing that does NOT change the state
+// (Close on a ticket already sitting in the give-up's state); those surfaces
+// clear the stamp explicitly.
+func expireGiveUp(iss *Issue) {
+	if iss.GaveUp != nil && iss.GaveUp.State != iss.State {
+		iss.GaveUp = nil
+	}
 }
 
 // readIssueLocked returns a defensive copy of the indexed issue.

--- a/pkg/dispatcher/native/store_issues.go
+++ b/pkg/dispatcher/native/store_issues.go
@@ -189,6 +189,10 @@ func cloneIssue(in *Issue) *Issue {
 		ext := *in.External
 		c.External = &ext
 	}
+	if in.GaveUp != nil {
+		g := *in.GaveUp
+		c.GaveUp = &g
+	}
 	if in.Labels != nil {
 		c.Labels = append([]string(nil), in.Labels...)
 	}

--- a/pkg/dispatcher/native/store_lifecycle.go
+++ b/pkg/dispatcher/native/store_lifecycle.go
@@ -123,7 +123,11 @@ func (s *Store) SetGaveUp(id string, g *GiveUp) (err error) {
 	if err != nil {
 		return err
 	}
-	if sameGiveUp(iss.GaveUp, g) && (g == nil || g.State == iss.State) {
+	// Compare against what would ACTUALLY be written — the store overrides a
+	// caller's state with the ticket's own (below), so comparing the caller's
+	// value would re-write and re-emit on every repeat call whenever the two
+	// disagree.
+	if sameGiveUp(iss.GaveUp, giveUpFor(iss, g)) {
 		return nil
 	}
 	// stamped is what actually landed on the issue (nil for a clear); the
@@ -133,17 +137,10 @@ func (s *Store) SetGaveUp(id string, g *GiveUp) (err error) {
 	if g == nil {
 		iss.GaveUp = nil
 	} else {
-		stamp := *g
+		stamp := *giveUpFor(iss, g)
 		if stamp.At.IsZero() {
 			stamp.At = time.Now().UTC()
 		}
-		// The stamp describes the ticket AS IT STANDS, so its state is the
-		// one the issue is actually in — not the one the caller believed it
-		// had moved to. A stamp born disagreeing with the ticket would be
-		// expired by the very write that persists it (expireGiveUp), which
-		// would drop it silently; recording what is true instead keeps the
-		// caller's intent (`filed as X`) and the record in agreement.
-		stamp.State = iss.State
 		iss.GaveUp = &stamp
 		stamped = &stamp
 	}
@@ -166,6 +163,23 @@ func (s *Store) SetGaveUp(id string, g *GiveUp) (err error) {
 		IssueID: id,
 		Payload: payload,
 	})
+}
+
+// giveUpFor returns the stamp that would land on iss for a caller's g: the
+// same values, but described against the state the ticket is ACTUALLY in.
+//
+// The store overrides the caller's state on purpose. A stamp born disagreeing
+// with its issue would be expired by the very write that persists it
+// (expireGiveUp) and vanish silently; recording what is true keeps the
+// caller's intent ("filed as X") and the record in agreement, and lets the
+// idempotence check compare like with like.
+func giveUpFor(iss *Issue, g *GiveUp) *GiveUp {
+	if g == nil {
+		return nil
+	}
+	out := *g
+	out.State = iss.State
+	return &out
 }
 
 // sameGiveUp compares two stamps on the fields that decide behaviour — the

--- a/pkg/dispatcher/native/store_lifecycle.go
+++ b/pkg/dispatcher/native/store_lifecycle.go
@@ -105,6 +105,64 @@ func (s *Store) SetAwaitingInput(id string, v bool) (err error) {
 	})
 }
 
+// SetGaveUp stamps (or, with a nil g, clears) the dispatcher's give-up on an
+// issue — the record that the ticket's current state was written by the
+// dispatcher exhausting its retry budget rather than by a human filing it
+// (see Issue.GaveUp). Idempotent: re-stamping the same run/state/attempts is
+// a no-op, as is clearing an issue that carries no stamp.
+//
+// Follows the SetAwaitingInput shape (read → set → write → bump UpdatedAt),
+// but emits its own EvtIssueGaveUp: a give-up is the one ticket transition
+// nobody asked for, and events.jsonl is where an operator reconstructs why a
+// ticket ended where it did.
+func (s *Store) SetGaveUp(id string, g *GiveUp) (err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	defer s.recoverMutator("SetGaveUp", &err)
+	iss, err := s.readIssueLocked(id)
+	if err != nil {
+		return err
+	}
+	if sameGiveUp(iss.GaveUp, g) {
+		return nil
+	}
+	if g == nil {
+		iss.GaveUp = nil
+	} else {
+		stamp := *g
+		if stamp.At.IsZero() {
+			stamp.At = time.Now().UTC()
+		}
+		iss.GaveUp = &stamp
+	}
+	iss.UpdatedAt = time.Now().UTC()
+	if err := s.writeIssueLocked(iss); err != nil {
+		return err
+	}
+	s.index[iss.ID] = cloneIssue(iss)
+	payload := map[string]any{"gave_up": g != nil}
+	if g != nil {
+		payload["run_id"] = g.RunID
+		payload["state"] = g.State
+		payload["attempts"] = g.Attempts
+	}
+	return s.emitPostCommitEvent(Event{
+		Type:    EvtIssueGaveUp,
+		IssueID: id,
+		Payload: payload,
+	})
+}
+
+// sameGiveUp compares two stamps on the fields that decide behaviour — the
+// timestamp is provenance, not identity, so a re-stamp of the same give-up
+// stays a no-op instead of churning the card's UpdatedAt on every poll.
+func sameGiveUp(a, b *GiveUp) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return a.RunID == b.RunID && a.State == b.State && a.Attempts == b.Attempts
+}
+
 // AddComment appends a note to the issue's discussion thread and returns
 // the updated issue plus the created comment. Author is a free-form
 // display name; body must be non-empty. The append is persisted to

--- a/pkg/dispatcher/native/store_lifecycle.go
+++ b/pkg/dispatcher/native/store_lifecycle.go
@@ -126,6 +126,10 @@ func (s *Store) SetGaveUp(id string, g *GiveUp) (err error) {
 	if sameGiveUp(iss.GaveUp, g) && (g == nil || g.State == iss.State) {
 		return nil
 	}
+	// stamped is what actually landed on the issue (nil for a clear); the
+	// event reports IT, never the caller's g, which may name a state the
+	// store overrode.
+	var stamped *GiveUp
 	if g == nil {
 		iss.GaveUp = nil
 	} else {
@@ -141,17 +145,21 @@ func (s *Store) SetGaveUp(id string, g *GiveUp) (err error) {
 		// caller's intent (`filed as X`) and the record in agreement.
 		stamp.State = iss.State
 		iss.GaveUp = &stamp
+		stamped = &stamp
 	}
 	iss.UpdatedAt = time.Now().UTC()
 	if err := s.writeIssueLocked(iss); err != nil {
 		return err
 	}
 	s.index[iss.ID] = cloneIssue(iss)
-	payload := map[string]any{"gave_up": g != nil}
-	if g != nil {
-		payload["run_id"] = g.RunID
-		payload["state"] = g.State
-		payload["attempts"] = g.Attempts
+	payload := map[string]any{"gave_up": stamped != nil}
+	if stamped != nil {
+		payload["run_id"] = stamped.RunID
+		// The state that was STAMPED, not the one the caller believed — the
+		// two differ when a give-up raced an operator move, and the audit
+		// record exists to reconstruct what actually happened.
+		payload["state"] = stamped.State
+		payload["attempts"] = stamped.Attempts
 	}
 	return s.emitPostCommitEvent(Event{
 		Type:    EvtIssueGaveUp,

--- a/pkg/dispatcher/native/store_lifecycle.go
+++ b/pkg/dispatcher/native/store_lifecycle.go
@@ -123,21 +123,23 @@ func (s *Store) SetGaveUp(id string, g *GiveUp) (err error) {
 	if err != nil {
 		return err
 	}
-	// Compare against what would ACTUALLY be written — the store overrides a
-	// caller's state with the ticket's own (below), so comparing the caller's
-	// value would re-write and re-emit on every repeat call whenever the two
-	// disagree.
-	if sameGiveUp(iss.GaveUp, giveUpFor(iss, g)) {
+	want, ok := giveUpToRecord(iss, g)
+	if !ok {
+		return nil
+	}
+	// Compared against what would ACTUALLY be written, so a repeat call is a
+	// real no-op rather than a re-write that churns UpdatedAt.
+	if sameGiveUp(iss.GaveUp, want) {
 		return nil
 	}
 	// stamped is what actually landed on the issue (nil for a clear); the
 	// event reports IT, never the caller's g, which may name a state the
 	// store overrode.
 	var stamped *GiveUp
-	if g == nil {
+	if want == nil {
 		iss.GaveUp = nil
 	} else {
-		stamp := *giveUpFor(iss, g)
+		stamp := *want
 		if stamp.At.IsZero() {
 			stamp.At = time.Now().UTC()
 		}
@@ -165,21 +167,30 @@ func (s *Store) SetGaveUp(id string, g *GiveUp) (err error) {
 	})
 }
 
-// giveUpFor returns the stamp that would land on iss for a caller's g: the
-// same values, but described against the state the ticket is ACTUALLY in.
+// giveUpToRecord resolves a caller's stamp against the issue as it stands,
+// returning the value to write and whether to write at all.
 //
-// The store overrides the caller's state on purpose. A stamp born disagreeing
-// with its issue would be expired by the very write that persists it
-// (expireGiveUp) and vanish silently; recording what is true keeps the
-// caller's intent ("filed as X") and the record in agreement, and lets the
-// idempotence check compare like with like.
-func giveUpFor(iss *Issue, g *GiveUp) *GiveUp {
+// A give-up describes a ticket that is still where the give-up PUT it. When
+// the ticket has already moved — an operator got there between the terminal
+// move and the stamp — the give-up is superseded, and recording it would put
+// the operator's own choice under a "the dispatcher gave up and filed this
+// ticket as …" banner. Nothing is written; the state change already stands in
+// the audit log.
+//
+// A stamp arriving without a state is filled in from the issue, so the value
+// compared for idempotence and the value written are always the same thing.
+func giveUpToRecord(iss *Issue, g *GiveUp) (*GiveUp, bool) {
 	if g == nil {
-		return nil
+		return nil, true
 	}
 	out := *g
-	out.State = iss.State
-	return &out
+	if out.State == "" {
+		out.State = iss.State
+	}
+	if out.State != iss.State {
+		return nil, false
+	}
+	return &out, true
 }
 
 // sameGiveUp compares two stamps on the fields that decide behaviour — the

--- a/pkg/dispatcher/native/store_lifecycle.go
+++ b/pkg/dispatcher/native/store_lifecycle.go
@@ -123,7 +123,7 @@ func (s *Store) SetGaveUp(id string, g *GiveUp) (err error) {
 	if err != nil {
 		return err
 	}
-	if sameGiveUp(iss.GaveUp, g) {
+	if sameGiveUp(iss.GaveUp, g) && (g == nil || g.State == iss.State) {
 		return nil
 	}
 	if g == nil {
@@ -133,6 +133,13 @@ func (s *Store) SetGaveUp(id string, g *GiveUp) (err error) {
 		if stamp.At.IsZero() {
 			stamp.At = time.Now().UTC()
 		}
+		// The stamp describes the ticket AS IT STANDS, so its state is the
+		// one the issue is actually in — not the one the caller believed it
+		// had moved to. A stamp born disagreeing with the ticket would be
+		// expired by the very write that persists it (expireGiveUp), which
+		// would drop it silently; recording what is true instead keeps the
+		// caller's intent (`filed as X`) and the record in agreement.
+		stamp.State = iss.State
 		iss.GaveUp = &stamp
 	}
 	iss.UpdatedAt = time.Now().UTC()

--- a/pkg/dispatcher/native/store_test.go
+++ b/pkg/dispatcher/native/store_test.go
@@ -896,3 +896,108 @@ func TestAggregateLabels(t *testing.T) {
 		}
 	}
 }
+
+// The give-up stamp is what lets a reader tell the dispatcher filing a ticket
+// (retry budget exhausted) from an operator filing the same terminal state by
+// hand. It must persist, expire on its own, and not churn the card on
+// re-stamps — a stamp rewritten on every poll would bump UpdatedAt and defeat
+// the board's `?since=` pruning.
+func TestSetGaveUpStampsExpiresAndIsIdempotent(t *testing.T) {
+	s := newTestStore(t)
+	iss, _ := s.Create(Issue{Title: "doomed", State: StateInProgress})
+
+	countEvents := func() int {
+		n := 0
+		_ = s.ScanEvents(func(e *Event) bool {
+			if e.Type == EvtIssueGaveUp && e.IssueID == iss.ID {
+				n++
+			}
+			return true
+		})
+		return n
+	}
+
+	stamp := &GiveUp{RunID: "run-7", State: StateBlocked, Attempts: 3}
+	if err := s.SetGaveUp(iss.ID, stamp); err != nil {
+		t.Fatalf("SetGaveUp: %v", err)
+	}
+	if _, err := s.SetState(iss.ID, StateBlocked); err != nil {
+		t.Fatalf("SetState: %v", err)
+	}
+	got, err := s.Get(iss.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.GaveUp == nil || got.GaveUp.RunID != "run-7" || got.GaveUp.Attempts != 3 {
+		t.Fatalf("stamp not persisted: %+v", got.GaveUp)
+	}
+	if got.GaveUp.At.IsZero() {
+		t.Error("SetGaveUp must timestamp a stamp that arrives without one")
+	}
+	if !got.GaveUp.Current(got.State, "run-7") {
+		t.Error("the stamp must describe the ticket it was just written on")
+	}
+	// Expiry, with nobody having to clear anything: another run's card is not
+	// this give-up, and a ticket someone has moved since is no longer it.
+	if got.GaveUp.Current(got.State, "run-8") {
+		t.Error("a stamp claimed a run it was not written for")
+	}
+	if got.GaveUp.Current(StateDone, "run-7") {
+		t.Error("a stamp survived the ticket being moved elsewhere")
+	}
+
+	if got := countEvents(); got != 1 {
+		t.Fatalf("first SetGaveUp emitted %d events, want 1", got)
+	}
+	// Idempotent on the fields that decide behaviour — the timestamp is
+	// provenance, not identity.
+	if err := s.SetGaveUp(iss.ID, &GiveUp{RunID: "run-7", State: StateBlocked, Attempts: 3}); err != nil {
+		t.Fatalf("re-stamp: %v", err)
+	}
+	if got := countEvents(); got != 1 {
+		t.Fatalf("re-stamping the same give-up emitted %d events, want 1", got)
+	}
+
+	// Clearing is the explicit acknowledgement path (board Close).
+	if err := s.SetGaveUp(iss.ID, nil); err != nil {
+		t.Fatalf("SetGaveUp(nil): %v", err)
+	}
+	if got, _ := s.Get(iss.ID); got.GaveUp != nil {
+		t.Fatalf("stamp survived the clear: %+v", got.GaveUp)
+	}
+	if got := countEvents(); got != 2 {
+		t.Fatalf("clearing emitted no event (%d total), want 2", got)
+	}
+	// Clearing an unstamped issue is a no-op, not a third event.
+	if err := s.SetGaveUp(iss.ID, nil); err != nil {
+		t.Fatalf("SetGaveUp(nil) twice: %v", err)
+	}
+	if got := countEvents(); got != 2 {
+		t.Fatalf("clearing twice emitted %d events, want 2", got)
+	}
+}
+
+// SetLastRun's own contract says empty strings clear the pointer — the
+// operator's escape hatch from a dead run that keeps being resumed. A cleared
+// pointer is not a run that happened, so it must not land in the card's run
+// history as a blank row.
+func TestSetLastRunClearDoesNotAppendABlankRun(t *testing.T) {
+	s := newTestStore(t)
+	iss, _ := s.Create(Issue{Title: "x", State: StateReady})
+	if err := s.SetLastRun(iss.ID, "run-1", "/tmp/wd"); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+	if err := s.SetLastRun(iss.ID, "", ""); err != nil {
+		t.Fatalf("SetLastRun clear: %v", err)
+	}
+	got, err := s.Get(iss.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.LastRunID != "" || got.LastWorkdir != "" {
+		t.Fatalf("pointer not cleared: %+v", got)
+	}
+	if len(got.Runs) != 1 || got.Runs[0].RunID != "run-1" {
+		t.Fatalf("run history = %+v, want the one real run and no blank row", got.Runs)
+	}
+}

--- a/pkg/dispatcher/native/store_test.go
+++ b/pkg/dispatcher/native/store_test.go
@@ -1092,3 +1092,36 @@ func TestSetGaveUpEventReportsTheStateItStamped(t *testing.T) {
 		t.Errorf("event run_id = %v, want run-9", got)
 	}
 }
+
+// Re-stamping the same give-up must stay a no-op even when the caller's state
+// disagrees with the ticket's — the store overrides it, so comparing the
+// caller's value would re-write and re-emit on every call, churning the card's
+// UpdatedAt (and with it the board's `?since=` pruning) on every dispatcher tick.
+func TestSetGaveUpIsIdempotentAgainstWhatItWouldWrite(t *testing.T) {
+	s := newTestStore(t)
+	iss, _ := s.Create(Issue{Title: "raced", State: StateInProgress})
+	stamp := func() *GiveUp {
+		return &GiveUp{RunID: "run-9", State: StateBlocked, Attempts: 2}
+	}
+	if err := s.SetGaveUp(iss.ID, stamp()); err != nil {
+		t.Fatalf("SetGaveUp: %v", err)
+	}
+	first, _ := s.Get(iss.ID)
+	if err := s.SetGaveUp(iss.ID, stamp()); err != nil {
+		t.Fatalf("SetGaveUp again: %v", err)
+	}
+	again, _ := s.Get(iss.ID)
+	if !again.UpdatedAt.Equal(first.UpdatedAt) {
+		t.Errorf("a repeat stamp rewrote the issue: %s → %s", first.UpdatedAt, again.UpdatedAt)
+	}
+	n := 0
+	_ = s.ScanEvents(func(e *Event) bool {
+		if e.Type == EvtIssueGaveUp && e.IssueID == iss.ID {
+			n++
+		}
+		return true
+	})
+	if n != 1 {
+		t.Errorf("give-up events = %d, want 1 — the repeat call re-emitted", n)
+	}
+}

--- a/pkg/dispatcher/native/store_test.go
+++ b/pkg/dispatcher/native/store_test.go
@@ -1040,12 +1040,18 @@ func TestGiveUpStampDoesNotComeBackWhenTheTicketReturns(t *testing.T) {
 	}
 }
 
-// A stamp records the state the ticket is ACTUALLY in. A caller that believes
-// it moved the ticket elsewhere would otherwise write a stamp the very same
-// write expires, losing it silently.
-func TestSetGaveUpRecordsTheStateTheTicketIsIn(t *testing.T) {
+// A give-up whose ticket has already MOVED is superseded: an operator got
+// there between the terminal move and the stamp, so recording it would put
+// their own choice under a "the dispatcher gave up and filed this ticket
+// as …" banner — and, on a non-terminal target, badge a live card with it.
+func TestSetGaveUpSkipsAGiveUpTheTicketHasMovedPast(t *testing.T) {
 	s := newTestStore(t)
 	iss, _ := s.Create(Issue{Title: "raced", State: StateInProgress})
+	// The dispatcher believes it filed the ticket as blocked; the operator
+	// dragged it back to ready first.
+	if _, err := s.SetState(iss.ID, StateReady); err != nil {
+		t.Fatalf("SetState: %v", err)
+	}
 	if err := s.SetGaveUp(iss.ID, &GiveUp{RunID: "run-9", State: StateBlocked, Attempts: 2}); err != nil {
 		t.Fatalf("SetGaveUp: %v", err)
 	}
@@ -1053,11 +1059,35 @@ func TestSetGaveUpRecordsTheStateTheTicketIsIn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if got.GaveUp == nil {
-		t.Fatal("stamp dropped instead of being recorded against the real state")
+	if got.GaveUp != nil {
+		t.Errorf("a superseded give-up was recorded: %+v", got.GaveUp)
 	}
-	if got.GaveUp.State != StateInProgress {
-		t.Errorf("stamp state = %q, want the ticket's own %q", got.GaveUp.State, StateInProgress)
+	n := 0
+	_ = s.ScanEvents(func(e *Event) bool {
+		if e.Type == EvtIssueGaveUp && e.IssueID == iss.ID {
+			n++
+		}
+		return true
+	})
+	if n != 0 {
+		t.Errorf("give-up events = %d, want 0 — nothing was recorded", n)
+	}
+}
+
+// A stamp that arrives without a state is filled in from the issue, so the
+// value compared for idempotence and the value written are the same thing.
+func TestSetGaveUpFillsAMissingStateFromTheTicket(t *testing.T) {
+	s := newTestStore(t)
+	iss, _ := s.Create(Issue{Title: "doomed", State: StateBlocked})
+	if err := s.SetGaveUp(iss.ID, &GiveUp{RunID: "run-9", Attempts: 2}); err != nil {
+		t.Fatalf("SetGaveUp: %v", err)
+	}
+	got, err := s.Get(iss.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.GaveUp == nil || got.GaveUp.State != StateBlocked {
+		t.Fatalf("stamp = %+v, want it filled in with %q", got.GaveUp, StateBlocked)
 	}
 	if !got.GaveUp.Current(got.State, "run-9") {
 		t.Error("a freshly written stamp must describe the ticket it was written on")
@@ -1072,7 +1102,9 @@ func TestSetGaveUpRecordsTheStateTheTicketIsIn(t *testing.T) {
 func TestSetGaveUpEventReportsTheStateItStamped(t *testing.T) {
 	s := newTestStore(t)
 	iss, _ := s.Create(Issue{Title: "raced", State: StateInProgress})
-	if err := s.SetGaveUp(iss.ID, &GiveUp{RunID: "run-9", State: StateBlocked, Attempts: 2}); err != nil {
+	// No state from the caller: the store fills it in, and the event must
+	// report what it filled rather than the empty value it was handed.
+	if err := s.SetGaveUp(iss.ID, &GiveUp{RunID: "run-9", Attempts: 2}); err != nil {
 		t.Fatalf("SetGaveUp: %v", err)
 	}
 	var payload map[string]any
@@ -1093,15 +1125,17 @@ func TestSetGaveUpEventReportsTheStateItStamped(t *testing.T) {
 	}
 }
 
-// Re-stamping the same give-up must stay a no-op even when the caller's state
-// disagrees with the ticket's — the store overrides it, so comparing the
-// caller's value would re-write and re-emit on every call, churning the card's
-// UpdatedAt (and with it the board's `?since=` pruning) on every dispatcher tick.
+// Re-stamping the same give-up must stay a no-op even when the caller left the
+// state out — the store fills it in, so comparing the caller's value would
+// re-write and re-emit on every call, churning the card's UpdatedAt (and with
+// it the board's `?since=` pruning) on every dispatcher tick.
 func TestSetGaveUpIsIdempotentAgainstWhatItWouldWrite(t *testing.T) {
 	s := newTestStore(t)
 	iss, _ := s.Create(Issue{Title: "raced", State: StateInProgress})
+	// No state from the caller — the case where comparing the caller's value
+	// instead of the written one would re-write on every call.
 	stamp := func() *GiveUp {
-		return &GiveUp{RunID: "run-9", State: StateBlocked, Attempts: 2}
+		return &GiveUp{RunID: "run-9", Attempts: 2}
 	}
 	if err := s.SetGaveUp(iss.ID, stamp()); err != nil {
 		t.Fatalf("SetGaveUp: %v", err)

--- a/pkg/dispatcher/native/store_test.go
+++ b/pkg/dispatcher/native/store_test.go
@@ -1063,3 +1063,32 @@ func TestSetGaveUpRecordsTheStateTheTicketIsIn(t *testing.T) {
 		t.Error("a freshly written stamp must describe the ticket it was written on")
 	}
 }
+
+// The audit record must name the state that was STAMPED. SetGaveUp overrides
+// a caller's state with the ticket's real one (so the stamp is not born
+// stale), and events.jsonl exists precisely so an operator can reconstruct why
+// a ticket ended where it did — reporting the discarded value would make the
+// one durable record of a give-up disagree with the issue it describes.
+func TestSetGaveUpEventReportsTheStateItStamped(t *testing.T) {
+	s := newTestStore(t)
+	iss, _ := s.Create(Issue{Title: "raced", State: StateInProgress})
+	if err := s.SetGaveUp(iss.ID, &GiveUp{RunID: "run-9", State: StateBlocked, Attempts: 2}); err != nil {
+		t.Fatalf("SetGaveUp: %v", err)
+	}
+	var payload map[string]any
+	_ = s.ScanEvents(func(e *Event) bool {
+		if e.Type == EvtIssueGaveUp && e.IssueID == iss.ID {
+			payload = e.Payload
+		}
+		return true
+	})
+	if payload == nil {
+		t.Fatal("no issue_gave_up event recorded")
+	}
+	if got := payload["state"]; got != StateInProgress {
+		t.Errorf("event state = %v, want the stamped %q", got, StateInProgress)
+	}
+	if got := payload["run_id"]; got != "run-9" {
+		t.Errorf("event run_id = %v, want run-9", got)
+	}
+}

--- a/pkg/dispatcher/native/store_test.go
+++ b/pkg/dispatcher/native/store_test.go
@@ -917,12 +917,13 @@ func TestSetGaveUpStampsExpiresAndIsIdempotent(t *testing.T) {
 		return n
 	}
 
+	// The dispatcher's order: file the ticket, THEN stamp what filed it.
+	if _, err := s.SetState(iss.ID, StateBlocked); err != nil {
+		t.Fatalf("SetState: %v", err)
+	}
 	stamp := &GiveUp{RunID: "run-7", State: StateBlocked, Attempts: 3}
 	if err := s.SetGaveUp(iss.ID, stamp); err != nil {
 		t.Fatalf("SetGaveUp: %v", err)
-	}
-	if _, err := s.SetState(iss.ID, StateBlocked); err != nil {
-		t.Fatalf("SetState: %v", err)
 	}
 	got, err := s.Get(iss.ID)
 	if err != nil {
@@ -999,5 +1000,66 @@ func TestSetLastRunClearDoesNotAppendABlankRun(t *testing.T) {
 	}
 	if len(got.Runs) != 1 || got.Runs[0].RunID != "run-1" {
 		t.Fatalf("run history = %+v, want the one real run and no blank row", got.Runs)
+	}
+}
+
+// Once the ticket moves, the give-up stamp is gone for GOOD. Read-time state
+// comparison alone would be reversible: a dispatcher retry resumes the SAME
+// run id, so a ticket that leaves the stamped state and later returns to it
+// would make the stamp live again — and the board would re-file an
+// operator's own decision as an unattended give-up, the mirror image of the
+// bug the stamp exists to fix.
+func TestGiveUpStampDoesNotComeBackWhenTheTicketReturns(t *testing.T) {
+	s := newTestStore(t)
+	iss, _ := s.Create(Issue{Title: "doomed", State: StateInProgress})
+	if _, err := s.SetState(iss.ID, StateBlocked); err != nil {
+		t.Fatalf("SetState(blocked): %v", err)
+	}
+	if err := s.SetGaveUp(iss.ID, &GiveUp{RunID: "run-7", State: StateBlocked, Attempts: 3}); err != nil {
+		t.Fatalf("SetGaveUp: %v", err)
+	}
+
+	// The operator retries: the ticket is restaged, which supersedes the
+	// give-up. Any write in the new state expires the stamp.
+	if _, err := s.SetState(iss.ID, StateReady); err != nil {
+		t.Fatalf("SetState(ready): %v", err)
+	}
+	if got, _ := s.Get(iss.ID); got.GaveUp != nil {
+		t.Fatalf("stamp survived the ticket leaving its state: %+v", got.GaveUp)
+	}
+	// …and the operator files it by hand later, same run still current.
+	if _, err := s.SetState(iss.ID, StateBlocked); err != nil {
+		t.Fatalf("SetState(blocked) again: %v", err)
+	}
+	got, err := s.Get(iss.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.GaveUp != nil {
+		t.Fatalf("stamp came back to life on a filing a human made: %+v", got.GaveUp)
+	}
+}
+
+// A stamp records the state the ticket is ACTUALLY in. A caller that believes
+// it moved the ticket elsewhere would otherwise write a stamp the very same
+// write expires, losing it silently.
+func TestSetGaveUpRecordsTheStateTheTicketIsIn(t *testing.T) {
+	s := newTestStore(t)
+	iss, _ := s.Create(Issue{Title: "raced", State: StateInProgress})
+	if err := s.SetGaveUp(iss.ID, &GiveUp{RunID: "run-9", State: StateBlocked, Attempts: 2}); err != nil {
+		t.Fatalf("SetGaveUp: %v", err)
+	}
+	got, err := s.Get(iss.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.GaveUp == nil {
+		t.Fatal("stamp dropped instead of being recorded against the real state")
+	}
+	if got.GaveUp.State != StateInProgress {
+		t.Errorf("stamp state = %q, want the ticket's own %q", got.GaveUp.State, StateInProgress)
+	}
+	if !got.GaveUp.Current(got.State, "run-9") {
+		t.Error("a freshly written stamp must describe the ticket it was written on")
 	}
 }

--- a/pkg/dispatcher/retry.go
+++ b/pkg/dispatcher/retry.go
@@ -128,11 +128,17 @@ func isResumeSourceChanged(err error) bool {
 // dispatcher must re-park, resume, or hold — never mint a sibling
 // planner from the workflow entry. finished is deliberately NOT in the
 // set: the work completed, and dragging the card back to an eligible
-// column is the operator's deliberate re-queue gesture — with last_run
-// never cleared by any surface, forbidding finished would make a fresh
-// run for that card unobtainable forever. The other legitimate fresh
-// starts are no last_run, or a hard-failed / vanished last_run plus an
-// explicitly eligible ticket.
+// column is the operator's deliberate re-queue gesture, and forbidding
+// finished would make a fresh run for that card unobtainable for as
+// long as the pointer stands. The other legitimate fresh starts are no
+// last_run, or a hard-failed / vanished last_run plus an explicitly
+// eligible ticket.
+//
+// ONE surface clears the pointer deliberately — `iterion issue update
+// --clear-last-run`, the operator's way out of a run that resuming cannot
+// fix. It refuses while that run is still alive (running / queued /
+// paused_*), precisely so it cannot hand this guard an empty pointer for a
+// ticket somebody is still working on.
 func lastRunForbidsFresh(status store.RunStatus) bool {
 	switch status {
 	case store.RunStatusPausedWaitingHuman,

--- a/pkg/server/pipeline_board_actions.go
+++ b/pkg/server/pipeline_board_actions.go
@@ -350,6 +350,16 @@ func (s *Server) handlePipelineBoardTaskClose(w http.ResponseWriter, r *http.Req
 		s.httpErrorFor(w, r, http.StatusInternalServerError, "pipeline board close: file ticket: %v", err)
 		return
 	}
+	// Close IS the acknowledgement a dispatcher give-up was missing, so drop
+	// the stamp that put the card in Needs attention. Every other exit
+	// invalidates it for free — a retry moves the ticket, a relaunch changes
+	// the run — but Close files a ticket into the state the give-up already
+	// wrote, so SetState above is a no-op there and only an explicit clear
+	// ends it. Best-effort: the ticket is filed either way, and a surviving
+	// stamp costs a card in the wrong lane, not correctness.
+	if err := boardStore.SetGaveUp(id, nil); err != nil && s.logger != nil {
+		s.logger.Warn("pipeline board: close ticket %s: clear give-up stamp: %v", id, err)
+	}
 	// Re-sweep once against a FRESH view. launchTicketNow flips the ticket to
 	// in_progress seconds before the run it started becomes discoverable, so
 	// the admission loop can have started a run for this very ticket during

--- a/pkg/server/pipeline_board_actions.go
+++ b/pkg/server/pipeline_board_actions.go
@@ -357,8 +357,15 @@ func (s *Server) handlePipelineBoardTaskClose(w http.ResponseWriter, r *http.Req
 	// wrote, so SetState above is a no-op there and only an explicit clear
 	// ends it. Best-effort: the ticket is filed either way, and a surviving
 	// stamp costs a card in the wrong lane, not correctness.
-	if err := boardStore.SetGaveUp(id, nil); err != nil && s.logger != nil {
-		s.logger.Warn("pipeline board: close ticket %s: clear give-up stamp: %v", id, err)
+	if err := boardStore.SetGaveUp(id, nil); err != nil {
+		if s.logger != nil {
+			s.logger.Warn("pipeline board: close ticket %s: clear give-up stamp: %v", id, err)
+		}
+	} else if refreshed, getErr := boardStore.Get(id); getErr == nil {
+		// `updated` is SetState's pre-clear snapshot; encoding it would hand
+		// an API consumer a ticket that still carries the stamp this call
+		// just dropped — a response contradicting its own write.
+		updated = refreshed
 	}
 	// Re-sweep once against a FRESH view. launchTicketNow flips the ticket to
 	// in_progress seconds before the run it started becomes discoverable, so

--- a/pkg/server/pipeline_board_actions_test.go
+++ b/pkg/server/pipeline_board_actions_test.go
@@ -628,3 +628,144 @@ func TestPipelineBoardRestagedTicketKeepsItsSlot(t *testing.T) {
 		t.Error("a ticket parked on deps held a slot it cannot use")
 	}
 }
+
+// A dispatcher GIVE-UP is not an operator's filing. The dispatcher's own
+// failed_state (default "blocked") and the board's Close target are the same
+// terminal state, so before the give-up stamp the projection could not tell
+// them apart and filed an unattended failure as acknowledged history — the
+// one class of failure the lane exists for was the one it never showed
+// (issue #494). Each sub-case pins one half of the discrimination.
+func TestPipelineBoardDispatcherGiveUpEntersLane(t *testing.T) {
+	cases := []struct {
+		name       string
+		stamp      func(runID string) *native.GiveUp
+		state      string
+		wantColumn string
+		wantStamp  bool
+	}{
+		{
+			name: "give-up on this run in this state surfaces",
+			stamp: func(runID string) *native.GiveUp {
+				return &native.GiveUp{RunID: runID, State: native.StateBlocked, Attempts: 3}
+			},
+			state:      native.StateBlocked,
+			wantColumn: pipelineColumnNeedsAttention,
+			wantStamp:  true,
+		},
+		{
+			name:       "no stamp: the operator filed it, so it stays history",
+			stamp:      func(string) *native.GiveUp { return nil },
+			state:      native.StateBlocked,
+			wantColumn: pipelineColumnClosed,
+		},
+		{
+			// The ticket was given up on, then MOVED to another terminal
+			// state by a human. Someone decided something after the give-up;
+			// the stamp is history and must not pin the card to the lane.
+			name: "stamp for a state the ticket has since left is stale",
+			stamp: func(runID string) *native.GiveUp {
+				return &native.GiveUp{RunID: runID, State: native.StateBlocked, Attempts: 3}
+			},
+			state:      native.StateDone,
+			wantColumn: pipelineColumnClosed,
+		},
+		{
+			// An older attempt was given up on; the card shows a NEWER run.
+			// Attributing the old give-up to it would explain the wrong run.
+			name: "stamp for another run does not travel to this card",
+			stamp: func(string) *native.GiveUp {
+				return &native.GiveUp{RunID: "some-older-run", State: native.StateBlocked, Attempts: 3}
+			},
+			state:      native.StateBlocked,
+			wantColumn: pipelineColumnClosed,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			env := newPipelineBoardTestEnv(t)
+			issue, err := env.board.Create(native.Issue{Title: "Deterministic failure", State: native.StateInProgress, Bot: "review"})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			env.seedRun(t, "gaveup-run", "review", store.RunStatusFailedResumable, func(run *store.Run) {
+				run.FilePath = env.botPath
+				run.Error = `[EXECUTION_FAILED] node "record_contracts_incomplete"`
+			})
+			if err := env.board.SetLastRun(issue.ID, "gaveup-run", ""); err != nil {
+				t.Fatalf("SetLastRun: %v", err)
+			}
+			if stamp := c.stamp("gaveup-run"); stamp != nil {
+				if err := env.board.SetGaveUp(issue.ID, stamp); err != nil {
+					t.Fatalf("SetGaveUp: %v", err)
+				}
+			}
+			// Filed terminal LAST, exactly as the give-up does it.
+			if _, err := env.board.SetState(issue.ID, c.state); err != nil {
+				t.Fatalf("SetState(%s): %v", c.state, err)
+			}
+
+			card := findPipelineCard(t, env.projection(t).Cards, "run:gaveup-run")
+			if card.ColumnID != c.wantColumn {
+				t.Errorf("column = %q, want %q (ticket %s)", card.ColumnID, c.wantColumn, c.state)
+			}
+			// Whatever the lane, a TERMINAL ticket reserves nothing: nothing
+			// will relaunch it until the operator acts, so holding capacity
+			// for it would leak a slot with no bound.
+			if card.ReservesSlot {
+				t.Error("a terminal ticket reserved a concurrency slot — an unreleasable hold")
+			}
+			if (card.GaveUp != nil) != c.wantStamp {
+				t.Fatalf("card.GaveUp = %+v, want present=%v", card.GaveUp, c.wantStamp)
+			}
+			if c.wantStamp && card.GaveUp.Attempts != 3 {
+				t.Errorf("card.GaveUp.Attempts = %d, want the 3 attempts that were burned", card.GaveUp.Attempts)
+			}
+		})
+	}
+}
+
+// Close is the acknowledgement a give-up never got. It files the ticket into
+// the state the give-up ALREADY wrote, so the state change is a no-op there
+// and only an explicit clear of the stamp can move the card out of the lane.
+func TestPipelineBoardCloseAcknowledgesAGiveUp(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	issue, err := env.board.Create(native.Issue{Title: "Given up on", State: native.StateInProgress, Bot: "review"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// `failed` (NOT failed_resumable): the close sweep leaves an already-hard-
+	// failed run alone, so nothing but the cleared stamp can change the lane.
+	env.seedRun(t, "ack-run", "review", store.RunStatusFailed, func(run *store.Run) {
+		run.FilePath = env.botPath
+		run.Error = "kaboom"
+	})
+	if err := env.board.SetLastRun(issue.ID, "ack-run", ""); err != nil {
+		t.Fatalf("SetLastRun: %v", err)
+	}
+	if err := env.board.SetGaveUp(issue.ID, &native.GiveUp{RunID: "ack-run", State: native.StateBlocked, Attempts: 3}); err != nil {
+		t.Fatalf("SetGaveUp: %v", err)
+	}
+	if _, err := env.board.SetState(issue.ID, native.StateBlocked); err != nil {
+		t.Fatalf("SetState: %v", err)
+	}
+	if card := findPipelineCard(t, env.projection(t).Cards, "run:ack-run"); card.ColumnID != pipelineColumnNeedsAttention {
+		t.Fatalf("column before close = %q, want needs_attention", card.ColumnID)
+	}
+
+	resp := closeTask(t, env, issue.ID)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("close status = %d, want 200", resp.StatusCode)
+	}
+
+	filed, err := env.board.Get(issue.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if filed.GaveUp != nil {
+		t.Errorf("give-up stamp survived Close: %+v — the card would never leave the lane", filed.GaveUp)
+	}
+	if card := findPipelineCard(t, env.projection(t).Cards, "run:ack-run"); card.ColumnID != pipelineColumnClosed {
+		t.Errorf("column after close = %q, want closed", card.ColumnID)
+	}
+}

--- a/pkg/server/pipeline_board_actions_test.go
+++ b/pkg/server/pipeline_board_actions_test.go
@@ -659,17 +659,6 @@ func TestPipelineBoardDispatcherGiveUpEntersLane(t *testing.T) {
 			wantColumn: pipelineColumnClosed,
 		},
 		{
-			// The ticket was given up on, then MOVED to another terminal
-			// state by a human. Someone decided something after the give-up;
-			// the stamp is history and must not pin the card to the lane.
-			name: "stamp for a state the ticket has since left is stale",
-			stamp: func(runID string) *native.GiveUp {
-				return &native.GiveUp{RunID: runID, State: native.StateBlocked, Attempts: 3}
-			},
-			state:      native.StateDone,
-			wantColumn: pipelineColumnClosed,
-		},
-		{
 			// An older attempt was given up on; the card shows a NEWER run.
 			// Attributing the old give-up to it would explain the wrong run.
 			name: "stamp for another run does not travel to this card",
@@ -694,14 +683,16 @@ func TestPipelineBoardDispatcherGiveUpEntersLane(t *testing.T) {
 			if err := env.board.SetLastRun(issue.ID, "gaveup-run", ""); err != nil {
 				t.Fatalf("SetLastRun: %v", err)
 			}
+			// File the ticket FIRST, then stamp — the dispatcher's own order,
+			// and the only one that survives: moving a ticket expires any
+			// stamp on it.
+			if _, err := env.board.SetState(issue.ID, c.state); err != nil {
+				t.Fatalf("SetState(%s): %v", c.state, err)
+			}
 			if stamp := c.stamp("gaveup-run"); stamp != nil {
 				if err := env.board.SetGaveUp(issue.ID, stamp); err != nil {
 					t.Fatalf("SetGaveUp: %v", err)
 				}
-			}
-			// Filed terminal LAST, exactly as the give-up does it.
-			if _, err := env.board.SetState(issue.ID, c.state); err != nil {
-				t.Fatalf("SetState(%s): %v", c.state, err)
 			}
 
 			card := findPipelineCard(t, env.projection(t).Cards, "run:gaveup-run")
@@ -742,11 +733,11 @@ func TestPipelineBoardCloseAcknowledgesAGiveUp(t *testing.T) {
 	if err := env.board.SetLastRun(issue.ID, "ack-run", ""); err != nil {
 		t.Fatalf("SetLastRun: %v", err)
 	}
-	if err := env.board.SetGaveUp(issue.ID, &native.GiveUp{RunID: "ack-run", State: native.StateBlocked, Attempts: 3}); err != nil {
-		t.Fatalf("SetGaveUp: %v", err)
-	}
 	if _, err := env.board.SetState(issue.ID, native.StateBlocked); err != nil {
 		t.Fatalf("SetState: %v", err)
+	}
+	if err := env.board.SetGaveUp(issue.ID, &native.GiveUp{RunID: "ack-run", State: native.StateBlocked, Attempts: 3}); err != nil {
+		t.Fatalf("SetGaveUp: %v", err)
 	}
 	if card := findPipelineCard(t, env.projection(t).Cards, "run:ack-run"); card.ColumnID != pipelineColumnNeedsAttention {
 		t.Fatalf("column before close = %q, want needs_attention", card.ColumnID)
@@ -765,7 +756,80 @@ func TestPipelineBoardCloseAcknowledgesAGiveUp(t *testing.T) {
 	if filed.GaveUp != nil {
 		t.Errorf("give-up stamp survived Close: %+v — the card would never leave the lane", filed.GaveUp)
 	}
+	// The response must not contradict the write it just made: an API client
+	// reading `task` would otherwise still see the stamp this call dropped.
+	var body struct {
+		Task *native.Issue `json:"task"`
+	}
+	decodeJSONResp(t, resp, &body)
+	if body.Task == nil || body.Task.GaveUp != nil {
+		t.Errorf("close response task = %+v, want the cleared ticket", body.Task)
+	}
 	if card := findPipelineCard(t, env.projection(t).Cards, "run:ack-run"); card.ColumnID != pipelineColumnClosed {
 		t.Errorf("column after close = %q, want closed", card.ColumnID)
+	}
+}
+
+// The projection's own staleness guard, exercised directly.
+//
+// It cannot be reached through the store — SetGaveUp records the state the
+// ticket is actually in, and any move expires the stamp — which is exactly
+// why it is worth pinning here: the lane must not depend on the store having
+// remembered. A stamp naming a state the ticket is not in describes nothing,
+// and a card it pinned to the lane would be unexplainable.
+func TestPipelineLaneStaleGiveUpStampDoesNotPinTheLane(t *testing.T) {
+	terminal := map[string]struct{}{
+		native.StateBlocked: {},
+		native.StateDone:    {},
+	}
+	root := &store.Run{ID: "run-a", Status: store.RunStatusFailedResumable}
+	cases := []struct {
+		name  string
+		issue *native.Issue
+		want  string
+	}{
+		{
+			name: "stamp describes this ticket and this run",
+			issue: &native.Issue{
+				ID: "i", Bot: "review", State: native.StateBlocked,
+				GaveUp: &native.GiveUp{RunID: "run-a", State: native.StateBlocked, Attempts: 3},
+			},
+			want: pipelineColumnNeedsAttention,
+		},
+		{
+			name: "stamp names a state the ticket is not in",
+			issue: &native.Issue{
+				ID: "i", Bot: "review", State: native.StateDone,
+				GaveUp: &native.GiveUp{RunID: "run-a", State: native.StateBlocked, Attempts: 3},
+			},
+			want: pipelineColumnClosed,
+		},
+		{
+			name: "stamp names another run",
+			issue: &native.Issue{
+				ID: "i", Bot: "review", State: native.StateBlocked,
+				GaveUp: &native.GiveUp{RunID: "run-older", State: native.StateBlocked, Attempts: 3},
+			},
+			want: pipelineColumnClosed,
+		},
+		{
+			name: "stamp names no run at all",
+			issue: &native.Issue{
+				ID: "i", Bot: "review", State: native.StateBlocked,
+				GaveUp: &native.GiveUp{State: native.StateBlocked, Attempts: 3},
+			},
+			want: pipelineColumnClosed,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			column, reserves := pipelineLaneForRoot(root, c.issue, terminal, nil)
+			if column != c.want {
+				t.Errorf("column = %q, want %q", column, c.want)
+			}
+			if reserves {
+				t.Error("a terminal ticket reserved a slot nothing can release")
+			}
+		})
 	}
 }

--- a/pkg/server/pipeline_boards.go
+++ b/pkg/server/pipeline_boards.go
@@ -22,15 +22,22 @@ const (
 	// "needs_attention" holds runs that DIED mid-flight and want a human. A
 	// root card is in that lane iff its run status is failed or
 	// failed_resumable, its tree has no pending human review, and — when the
-	// card is ticket-backed — its ticket is in a non-terminal state. It is
-	// deliberately narrower than the old failed bucket: a run the operator
-	// CANCELLED is a decision, not an anomaly, and stays in Closed.
+	// card is ticket-backed — its ticket is in a non-terminal state OR is
+	// terminal because the dispatcher GAVE UP on it (pipelineTicketGaveUp).
+	// It is deliberately narrower than the old failed bucket: a run the
+	// operator CANCELLED is a decision, not an anomaly, and stays in Closed.
+	// An exhausted retry budget is not a decision — nobody chose it — which
+	// is why it belongs here even though the ticket reads terminal.
 	//
-	// The lane is load-bearing, not cosmetic: a card sitting in it RESERVES a
-	// concurrency slot (see pipeline_reservations.go) so nothing else takes
-	// the place it needs to restart into. That is why membership and
-	// reservation are decided by one function, pipelineLaneForRoot — a card
-	// that reserves without rendering here would be an invisible held slot.
+	// The lane is load-bearing, not cosmetic: a card sitting in it usually
+	// RESERVES a concurrency slot (see pipeline_reservations.go) so nothing
+	// else takes the place it needs to restart into. That is why membership
+	// and reservation are decided by one function, pipelineLaneForRoot — a
+	// card that reserves without rendering here would be an invisible held
+	// slot. The converse is allowed and deliberate: a card can render here
+	// and hold nothing, which is what a given-up (terminal) ticket does —
+	// nothing will relaunch it until the operator acts, so reserving for it
+	// would leak capacity with no bound.
 	pipelineColumnOpened         = "opened"
 	pipelineColumnInProgress     = "in_progress"
 	pipelineColumnNeedsAttention = "needs_attention"

--- a/pkg/server/pipeline_boards_progress.go
+++ b/pkg/server/pipeline_boards_progress.go
@@ -291,6 +291,22 @@ func pipelineLaneForRoot(root *store.Run, issue *native.Issue, terminalStates ma
 			return pipelineColumnClosed, false
 		}
 		if _, terminal := terminalStates[issue.State]; terminal {
+			if pipelineTicketGaveUp(issue, root) {
+				// NOT the operator's filing: the dispatcher wrote this
+				// terminal state itself when its retry budget ran out, and
+				// an exhausted budget is an anomaly, not a decision. A
+				// deterministic failure — a fail-closed pipeline demanding a
+				// human — burns every attempt on every run, so treating a
+				// give-up as acknowledged history hid exactly the class of
+				// failure this lane exists for (issue #494).
+				//
+				// It renders WITHOUT reserving. A terminal ticket will not
+				// relaunch on its own, so holding capacity for it would be a
+				// leak with no bound — the same reason a waiting_deps ticket
+				// releases (see pipelineTicketHoldsSlot). Retry restages the
+				// ticket, and the reservation starts there.
+				return pipelineColumnNeedsAttention, false
+			}
 			// The operator already filed this ticket (typically via Close).
 			// The failure is acknowledged history, not open work.
 			return pipelineColumnClosed, false
@@ -299,6 +315,25 @@ func pipelineLaneForRoot(root *store.Run, issue *native.Issue, terminalStates ma
 	default:
 		return pipelineColumnInProgress, false
 	}
+}
+
+// pipelineTicketGaveUp reports that the ticket in front of us is terminal
+// because the DISPATCHER gave up on this very run, with nobody having acted
+// on it since — the one case where a terminal ticket state is an unattended
+// failure rather than an operator's decision.
+//
+// The question cannot be answered from the state alone: the dispatcher's
+// give-up target (Agent.FailedState, default "blocked") and the board's Close
+// target are the same state by construction, so the projection reads the
+// stamp the dispatcher leaves instead of guessing. The stamp expires on its
+// own — a newer run or any move of the ticket makes it stale (native.GiveUp.
+// Current) — so no writer has to remember to clear it, and a stale stamp can
+// never pin a card to the lane.
+func pipelineTicketGaveUp(issue *native.Issue, root *store.Run) bool {
+	if issue == nil || root == nil {
+		return false
+	}
+	return issue.GaveUp.Current(issue.State, root.ID)
 }
 
 // pipelineTicketHoldsSlot is the ONE definition of "this ticket is holding a

--- a/pkg/server/pipeline_boards_projection.go
+++ b/pkg/server/pipeline_boards_projection.go
@@ -670,10 +670,13 @@ func (b *pipelineProjectionBuilder) addRootCard(root *store.Run, issue *native.I
 		card.Priority = issue.Priority
 		card.External = issue.External
 		card.Attempts = b.attemptsForIssue(issue, root)
-		// Only a stamp that still describes THIS card travels — a stale one
-		// (older run, ticket moved since) is history, and shipping it would
-		// invite the UI to explain a lane the card is no longer in.
-		if pipelineTicketGaveUp(issue, root) {
+		// The stamp travels only on the lane it explains. Gating on the
+		// column the lane function already decided — rather than re-deriving
+		// the predicate — is what keeps that true: a give-up whose run the
+		// operator later RESUMED to a clean finish leaves the ticket filed
+		// and the stamp current, but that card is Closed and successful, and
+		// a "gave up" claim on it would be a lie waiting for a UI change.
+		if column == pipelineColumnNeedsAttention && pipelineTicketGaveUp(issue, root) {
 			card.GaveUp = issue.GaveUp
 		}
 		if card.EntryInput == nil {

--- a/pkg/server/pipeline_boards_projection.go
+++ b/pkg/server/pipeline_boards_projection.go
@@ -670,6 +670,12 @@ func (b *pipelineProjectionBuilder) addRootCard(root *store.Run, issue *native.I
 		card.Priority = issue.Priority
 		card.External = issue.External
 		card.Attempts = b.attemptsForIssue(issue, root)
+		// Only a stamp that still describes THIS card travels — a stale one
+		// (older run, ticket moved since) is history, and shipping it would
+		// invite the UI to explain a lane the card is no longer in.
+		if pipelineTicketGaveUp(issue, root) {
+			card.GaveUp = issue.GaveUp
+		}
 		if card.EntryInput == nil {
 			card.EntryInput = stringMapToAny(issue.BotArgs)
 		}

--- a/pkg/server/pipeline_boards_types.go
+++ b/pkg/server/pipeline_boards_types.go
@@ -142,6 +142,12 @@ type PipelineBoardCard struct {
 	// mid-flight) and closed (cancelled by the operator). The UI shows the
 	// Error as the reason and offers a Retry on ticket-backed cards.
 	Failed bool `json:"failed,omitempty"`
+	// GaveUp is set when the ticket's terminal state was written by the
+	// dispatcher exhausting its retry budget rather than by an operator
+	// filing it — the reason such a card is in Needs attention despite a
+	// terminal ticket state. Carries the run, the state written and the
+	// attempt count so the UI can say so instead of looking inconsistent.
+	GaveUp *native.GiveUp `json:"gave_up,omitempty"`
 	// ReservesSlot is true when this card is holding one of the local
 	// pipeline concurrency slots open for its own restart — no process is
 	// running, but nothing else may take its place until the operator

--- a/pkg/server/pipeline_reservations.go
+++ b/pkg/server/pipeline_reservations.go
@@ -52,7 +52,12 @@ func (m *pipelineReservedMemo) invalidate() {
 //
 //   - it names a bot (otherwise it is a plain backlog item, not a pipeline);
 //   - its ticket state is NOT terminal (Close files the ticket, which is how
-//     the reservation is released);
+//     the reservation is released) — including a ticket the dispatcher filed
+//     itself by giving up: that card DOES render in the lane (it is an
+//     unattended failure, not a decision) but reserves nothing, because
+//     nothing will relaunch a terminal ticket and the hold would have no
+//     bound. Rendering without reserving is the safe direction; the reverse
+//     is the invisible held slot;
 //   - its current run's status is failed or failed_resumable, OR its
 //     current run is a NON-TERMINAL recovery fork: a fork starts via
 //     Resume, which never enters pipelineQueue, so nothing else accounts

--- a/studio/src/api/pipelineBoards.test.ts
+++ b/studio/src/api/pipelineBoards.test.ts
@@ -223,6 +223,40 @@ describe("normalizePipelineBoard", () => {
     expect(child?.role).toBe("producer");
   });
 
+  it("keeps a give-up stamp, and drops one that names no run", () => {
+    const board = normalizePipelineBoard({
+      cards: [
+        {
+          id: "run:a",
+          column_id: "needs_attention",
+          title: "Given up on",
+          gave_up: {
+            run_id: "run-dead",
+            state: "blocked",
+            attempts: 3,
+            at: "2026-08-23T09:00:00Z",
+          },
+        },
+        {
+          // A stamp with no run cannot be attributed to the card showing it,
+          // so rendering a claim about an unknown run would be worse than
+          // rendering nothing.
+          id: "run:b",
+          column_id: "needs_attention",
+          title: "Unattributable",
+          gave_up: { state: "blocked", attempts: 2 },
+        },
+      ],
+    });
+    expect(board.cards[0]?.gave_up).toEqual({
+      run_id: "run-dead",
+      state: "blocked",
+      attempts: 3,
+      at: "2026-08-23T09:00:00Z",
+    });
+    expect(board.cards[1]?.gave_up).toBeUndefined();
+  });
+
   it("omits planner provenance when the server sends none", () => {
     const board = normalizePipelineBoard({
       cards: [{ id: "task:x", column_id: "opened", title: "Loose" }],

--- a/studio/src/api/pipelineBoards.ts
+++ b/studio/src/api/pipelineBoards.ts
@@ -63,6 +63,22 @@ export interface PipelineBoardBlocking {
   title?: string;
 }
 
+/**
+ * The dispatcher's give-up stamp: this ticket's terminal state was written by
+ * an exhausted retry budget, not by a human filing it. The two are the same
+ * state on the board, so this is the only thing that tells them apart.
+ */
+export interface PipelineBoardGiveUp {
+  /** The run whose failure exhausted the budget. */
+  run_id: string;
+  /** The state the give-up wrote (usually the board's `blocked`). */
+  state?: string;
+  /** How many attempts were burned before giving up. */
+  attempts?: number;
+  /** When the give-up happened (RFC 3339). */
+  at?: string;
+}
+
 /** Spawned child ticket under a planner parent. */
 export interface PipelineBoardChildRef {
   issue_id: string;
@@ -128,6 +144,10 @@ export interface PipelineBoardCard {
   // for its own restart. Nothing is running against it — retrying, resuming
   // or closing the card releases the slot.
   reserves_slot?: boolean;
+  // Set when the ticket's TERMINAL state was written by the dispatcher giving
+  // up (its retry budget ran out), not by an operator filing it. It is why
+  // such a card sits in Needs attention while its ticket reads "blocked".
+  gave_up?: PipelineBoardGiveUp;
   // Ready lane (wire ID "opened") — a task-backed ticket staged (waiting for a
   // concurrency slot; the studio auto-launches it when one frees).
   ready?: boolean;
@@ -247,6 +267,24 @@ function normalizeAttempts(value: unknown): PipelineBoardAttempt[] | undefined {
 // card's full `{provider, connection_id, repo, ...}` link, and a run-only
 // fallback that carries only `repo` (project_path; provider/connection_id
 // empty strings on the wire). Anything missing `repo` is treated as absent.
+function normalizeGiveUp(value: unknown): PipelineBoardGiveUp | undefined {
+  const source = record(value);
+  if (!source) return undefined;
+  const run_id = text(source.run_id);
+  // A stamp with no run cannot be attributed to the card showing it, and the
+  // server never emits one — treat it as absent rather than render a claim
+  // about an unknown run.
+  if (!run_id) return undefined;
+  const out: PipelineBoardGiveUp = { run_id };
+  const state = text(source.state);
+  if (state) out.state = state;
+  const attempts = numberValue(source.attempts);
+  if (attempts !== undefined) out.attempts = attempts;
+  const at = text(source.at);
+  if (at) out.at = at;
+  return out;
+}
+
 function normalizeExternal(value: unknown): ExternalLinkInput | undefined {
   const source = record(value);
   if (!source) return undefined;
@@ -392,6 +430,7 @@ export function normalizePipelineBoardCard(
   const attempts = normalizeAttempts(source.attempts);
   const reviews = normalizePendingReviews(source.pending_reviews);
   const external = normalizeExternal(source.external);
+  const giveUp = normalizeGiveUp(source.gave_up);
   return {
     id,
     kind: text(source.kind) ?? (runID ? "run" : "task"),
@@ -447,6 +486,7 @@ export function normalizePipelineBoardCard(
     ...(typeof source.reserves_slot === "boolean"
       ? { reserves_slot: source.reserves_slot }
       : {}),
+    ...(giveUp ? { gave_up: giveUp } : {}),
     ...(typeof source.ready === "boolean" ? { ready: source.ready } : {}),
     ...(entryInput ? { entry_input: entryInput } : {}),
     ...(numberValue(source.queue_position) !== undefined

--- a/studio/src/api/pipelineBoards.ts
+++ b/studio/src/api/pipelineBoards.ts
@@ -263,10 +263,6 @@ function normalizeAttempts(value: unknown): PipelineBoardAttempt[] | undefined {
   });
 }
 
-// normalizeExternal tolerates the two shapes the server emits: a task-backed
-// card's full `{provider, connection_id, repo, ...}` link, and a run-only
-// fallback that carries only `repo` (project_path; provider/connection_id
-// empty strings on the wire). Anything missing `repo` is treated as absent.
 function normalizeGiveUp(value: unknown): PipelineBoardGiveUp | undefined {
   const source = record(value);
   if (!source) return undefined;
@@ -285,6 +281,10 @@ function normalizeGiveUp(value: unknown): PipelineBoardGiveUp | undefined {
   return out;
 }
 
+// normalizeExternal tolerates the two shapes the server emits: a task-backed
+// card's full `{provider, connection_id, repo, ...}` link, and a run-only
+// fallback that carries only `repo` (project_path; provider/connection_id
+// empty strings on the wire). Anything missing `repo` is treated as absent.
 function normalizeExternal(value: unknown): ExternalLinkInput | undefined {
   const source = record(value);
   if (!source) return undefined;

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -4972,6 +4972,13 @@ export interface components {
             /** Format: date-time */
             updated_at: string;
         };
+        GiveUp: {
+            /** Format: date-time */
+            at: string;
+            attempts?: number;
+            run_id?: string;
+            state?: string;
+        };
         Issue: {
             assignee?: string;
             awaiting_input?: boolean;
@@ -4989,6 +4996,7 @@ export interface components {
             fields?: {
                 [key: string]: unknown;
             };
+            gave_up?: components["schemas"]["GiveUp"];
             id: string;
             labels?: string[];
             last_run_id?: string;
@@ -5033,6 +5041,7 @@ export interface components {
             executed_nodes: number;
             external?: components["schemas"]["ExternalRef"];
             failed?: boolean;
+            gave_up?: components["schemas"]["GiveUp"];
             id: string;
             issue_id?: string;
             issue_state?: string;

--- a/studio/src/views/PipelineBoard/PipelineCardDetails.test.tsx
+++ b/studio/src/views/PipelineBoard/PipelineCardDetails.test.tsx
@@ -197,6 +197,26 @@ describe("PipelineCardDetailsBody", () => {
     expect(html).toContain('data-run-ids="run-ko"');
   });
 
+  it("a given-up card names the dispatcher as the one who filed the ticket", () => {
+    // The ticket reads terminal ("blocked") while the card sits in Needs
+    // attention. Without naming who filed it, the operator reads that state
+    // as somebody's decision and stops looking.
+    const html = render(
+      makeCard({
+        column_id: "needs_attention",
+        run_id: "run-dead",
+        issue_id: "iss-9",
+        issue_state: "blocked",
+        status: "failed_resumable",
+        failed: true,
+        error: "kaboom",
+        gave_up: { run_id: "run-dead", state: "blocked", attempts: 3 },
+      }),
+    );
+    expect(html).toContain("The dispatcher gave up after 3 attempts");
+    expect(html).toContain("kaboom"); // the underlying reason stays
+  });
+
   it("successful Closed card shows inputs + result + produced elements", () => {
     const html = render(
       makeCard({

--- a/studio/src/views/PipelineBoard/PipelineCardDetails.test.tsx
+++ b/studio/src/views/PipelineBoard/PipelineCardDetails.test.tsx
@@ -215,6 +215,10 @@ describe("PipelineCardDetailsBody", () => {
     );
     expect(html).toContain("The dispatcher gave up after 3 attempts");
     expect(html).toContain("kaboom"); // the underlying reason stays
+    // Retry must not be sold as "starts it over": a live dispatcher resumes
+    // the same dead run unless the last-run pointer is cleared first.
+    expect(html).toContain("--clear-last-run");
+    expect(html).not.toContain("Retry starts it over");
   });
 
   it("successful Closed card shows inputs + result + produced elements", () => {

--- a/studio/src/views/PipelineBoard/PipelineCardDetails.tsx
+++ b/studio/src/views/PipelineBoard/PipelineCardDetails.tsx
@@ -575,8 +575,10 @@ export function PipelineCardDetailsBody({
             // filed it — the dispatcher, out of attempts — so the operator
             // does not read a terminal ticket as somebody's decision.
             <InlineBanner tone="warning" layout="inline">
-              {giveUpSentence(card.gave_up)} Retry starts it over; Close
-              acknowledges it.
+              {giveUpSentence(card.gave_up)} Retry restages the ticket — a
+              running dispatcher resumes this run from its checkpoint, so use{" "}
+              <code>iterion issue update {card.issue_id} --clear-last-run</code>{" "}
+              first to force a fresh one. Close acknowledges the give-up.
             </InlineBanner>
           )}
           {card.error && (

--- a/studio/src/views/PipelineBoard/PipelineCardDetails.tsx
+++ b/studio/src/views/PipelineBoard/PipelineCardDetails.tsx
@@ -381,6 +381,22 @@ function SpawnTreeSection({ card }: { card: PipelineBoardCard }) {
   );
 }
 
+// giveUpSentence states who filed a terminal ticket that is nonetheless
+// waiting on a human: the dispatcher, out of attempts. Built as ONE string so
+// the punctuation cannot drift on JSX's whitespace joining.
+function giveUpSentence(
+  giveUp: NonNullable<PipelineBoardCard["gave_up"]>,
+): string {
+  const attempts =
+    giveUp.attempts && giveUp.attempts > 0
+      ? `after ${giveUp.attempts} attempt${giveUp.attempts === 1 ? "" : "s"}`
+      : "after exhausting its attempts";
+  const filed = giveUp.state
+    ? ` and filed this ticket as "${giveUp.state}"`
+    : "";
+  return `The dispatcher gave up ${attempts}${filed}.`;
+}
+
 // DependenciesSection surfaces hard deps (blockers) and reverse deps
 // (blocking). Distinct from human-review "Blocked" — these are ticket-to-
 // ticket gates the launch loop honours.
@@ -551,12 +567,23 @@ export function PipelineCardDetailsBody({
         </section>
       )}
 
-      {closedFailed && card.error && (
+      {closedFailed && (card.error || card.gave_up) && (
         <section aria-label="Failure" className="space-y-2">
           <SectionHeading>Failure</SectionHeading>
-          <InlineBanner tone="danger" layout="inline">
-            {card.error}
-          </InlineBanner>
+          {card.gave_up && (
+            // The ticket reads as filed while the card needs a human. Say who
+            // filed it — the dispatcher, out of attempts — so the operator
+            // does not read a terminal ticket as somebody's decision.
+            <InlineBanner tone="warning" layout="inline">
+              {giveUpSentence(card.gave_up)} Retry starts it over; Close
+              acknowledges it.
+            </InlineBanner>
+          )}
+          {card.error && (
+            <InlineBanner tone="danger" layout="inline">
+              {card.error}
+            </InlineBanner>
+          )}
         </section>
       )}
 

--- a/studio/src/views/PipelineBoard/PipelineColumns.test.tsx
+++ b/studio/src/views/PipelineBoard/PipelineColumns.test.tsx
@@ -310,6 +310,34 @@ describe("PipelineColumns", () => {
     expect(html).toContain("Retry"); // ticket-backed → retryable to Todo
   });
 
+  it("says the dispatcher gave up on a card whose ticket reads terminal", () => {
+    // Such a card is in Needs attention while its ticket is filed `blocked`,
+    // which reads as a contradiction until the badge names WHO filed it.
+    // It holds no slot: nothing will relaunch a terminal ticket on its own.
+    const html = render(
+      makeBoard([
+        makeCard({
+          id: "gave-up",
+          column_id: "needs_attention",
+          kind: "run",
+          title: "Deterministic failure",
+          issue_id: "iss-3",
+          issue_state: "blocked",
+          run_id: "run-dead",
+          status: "failed_resumable",
+          failed: true,
+          error: "kaboom",
+          gave_up: { run_id: "run-dead", state: "blocked", attempts: 3 },
+        }),
+      ]),
+    );
+
+    expect(html).toContain("Gave up");
+    expect(html).toContain("3 attempts"); // the tooltip says how many were burned
+    expect(html).not.toContain("Holds a slot");
+    expect(html).toContain("Retry"); // still the way out
+  });
+
   it("hides the Needs attention lane entirely when nothing is broken", () => {
     // An always-visible empty lane reads as a permanent accusation.
     const html = render(

--- a/studio/src/views/PipelineBoard/PipelineColumns.tsx
+++ b/studio/src/views/PipelineBoard/PipelineColumns.tsx
@@ -527,7 +527,7 @@ export function PipelineColumns({
               <CardSection
                 id="needs-attention"
                 title="Needs attention"
-                subtitle="Failed mid-flight — each holds a slot until you retry, resume or close it"
+                subtitle="Failed mid-flight — most hold a slot until you retry, resume or close it"
                 accent="bg-danger"
                 count={needsAttention.length}
                 empty="Nothing to fix."

--- a/studio/src/views/PipelineBoard/PipelineColumns.tsx
+++ b/studio/src/views/PipelineBoard/PipelineColumns.tsx
@@ -1289,6 +1289,20 @@ function ClosedStatus({ card }: { card: PipelineBoardCardDTO }) {
   );
 }
 
+// giveUpTitle spells out what the badge stands for: the dispatcher stopped
+// retrying by itself, so this card is waiting on a human even though its
+// ticket is filed. Retrying is what starts it over.
+function giveUpTitle(
+  giveUp: NonNullable<PipelineBoardCardDTO["gave_up"]>,
+): string {
+  const attempts =
+    giveUp.attempts && giveUp.attempts > 0
+      ? `after ${giveUp.attempts} attempt${giveUp.attempts === 1 ? "" : "s"}`
+      : "after exhausting its attempts";
+  const filed = giveUp.state ? ` and filed the ticket as "${giveUp.state}"` : "";
+  return `The dispatcher gave up ${attempts}${filed}. Nobody decided this — retry, or close the card to acknowledge it.`;
+}
+
 function NeedsAttentionStatus({ card }: { card: PipelineBoardCardDTO }) {
   return (
     <div className="min-w-0 space-y-1.5">
@@ -1305,6 +1319,15 @@ function NeedsAttentionStatus({ card }: { card: PipelineBoardCardDTO }) {
             title="A concurrency slot is held open so this pipeline can restart into it. Nothing is running against it. Retry, resume or close the card to release it."
           >
             Holds a slot
+          </Badge>
+        )}
+        {card.gave_up && (
+          // Without this the card looks inconsistent: its ticket reads
+          // "blocked" (a filed, terminal state) while the card sits in Needs
+          // attention. Naming the give-up is what makes the lane make sense —
+          // nobody filed it, the dispatcher ran out of attempts.
+          <Badge variant="warning" title={giveUpTitle(card.gave_up)}>
+            Gave up
           </Badge>
         )}
       </div>

--- a/studio/src/views/PipelineBoard/PipelineColumns.tsx
+++ b/studio/src/views/PipelineBoard/PipelineColumns.tsx
@@ -1291,7 +1291,13 @@ function ClosedStatus({ card }: { card: PipelineBoardCardDTO }) {
 
 // giveUpTitle spells out what the badge stands for: the dispatcher stopped
 // retrying by itself, so this card is waiting on a human even though its
-// ticket is filed. Retrying is what starts it over.
+// ticket is filed.
+//
+// It does NOT promise that Retry starts the pipeline over. Retry restages the
+// ticket, and whoever picks it up decides: the studio's admission loop mints a
+// fresh run, a live dispatcher resumes this one from its checkpoint. Saying
+// "starts it over" would send the operator to re-burn the budget on the same
+// checkpoint; the details panel names the tool that forces a fresh run.
 function giveUpTitle(
   giveUp: NonNullable<PipelineBoardCardDTO["gave_up"]>,
 ): string {
@@ -1300,7 +1306,7 @@ function giveUpTitle(
       ? `after ${giveUp.attempts} attempt${giveUp.attempts === 1 ? "" : "s"}`
       : "after exhausting its attempts";
   const filed = giveUp.state ? ` and filed the ticket as "${giveUp.state}"` : "";
-  return `The dispatcher gave up ${attempts}${filed}. Nobody decided this — retry, or close the card to acknowledge it.`;
+  return `The dispatcher gave up ${attempts}${filed}. Nobody decided this — retry it, or close the card to acknowledge it.`;
 }
 
 function NeedsAttentionStatus({ card }: { card: PipelineBoardCardDTO }) {


### PR DESCRIPTION
Closes #494.

## The bug

`iterion dispatch` exhausting `agent.max_attempts` files the ticket into
`agent.failed_state` (default `blocked`) **itself** — the very same terminal
state the board's Close writes. `pipelineLaneForRoot` read any terminal ticket
as *"the operator already filed this"* and put the card in **Closed**, so the
one class of failure the Needs-attention lane exists for — a pipeline that died
mid-flight and wants a human — was precisely the one it never showed. Worse for
fail-closed pipelines: a deterministic failure burns the whole retry budget on
*every* run, so it was misfiled every time.

## The fix (option 1 from the issue)

The state alone cannot answer "who filed this", so the dispatcher **stamps** the
give-up on the ticket and the projection reads the stamp instead of guessing.

- `native.Issue.GaveUp` (`gave_up`) — the run, the state written, the attempt
  count, a timestamp — plus a dedicated `issue_gave_up` event. Set through
  `BoardStore.SetGaveUp`, the same optional-interface seam as `SetAwaitingInput`
  (native store, adapter pass-through, **and boardmongo** — no local-only seam).
- Written **only when the terminal move landed**: a give-up that fell back to
  retrying (board can't represent `failed_state`) has not given up.
- `pipelineLaneForRoot`: a terminal ticket carrying a *current* stamp →
  `needs_attention`, badged **Gave up** with the attempt count.

**The stamp expires by itself.** It names a run and a state, so a newer run or
any move of the ticket makes it stale (`GiveUp.Current`) — nothing has to
remember to clear it, and a stale stamp can never pin a card to the lane. The
one case that needs an explicit clear is filing a ticket into the state the
give-up already wrote: **Close clears it**, which is exactly what makes Close
the acknowledgement the give-up never got.

**It renders without reserving.** A terminal ticket will not relaunch on its
own, so holding a concurrency slot for it would leak capacity with no bound
(the same reasoning that releases a `waiting_deps` ticket). `pipelineLaneForRoot`
and `pipelineReservedSet` stay in agreement; only the safe direction — render
without reserving — is new.

## Secondary gap: back to a *fresh* run

`iterion issue update <id> --clear-last-run` drops the pointer the dispatcher
resumes from (`resolveRunID` → `resumableRunID`), so a run that died in a way
resuming cannot fix stops being resumed forever. The run **history** is kept —
those runs happened. A cleared pointer also no longer appends a blank `RunRef`.

## Tests

Each of these fails without the corresponding half of the fix:

- `TestPipelineBoardDispatcherGiveUpEntersLane` — the missing case from the
  issue (terminal ticket + `failed_resumable` run), plus the three negatives
  that keep it honest: no stamp → Closed, stamp for a state the ticket has left
  → Closed, stamp for another run → Closed. All assert the card reserves nothing.
- `TestPipelineBoardCloseAcknowledgesAGiveUp` — Close on a hard-`failed` card
  (whose run the sweep deliberately leaves alone), so only the cleared stamp can
  move the lane.
- `TestFinishRun_GiveUpMovesToFailedState` now asserts the stamp's content;
  `…FallsBackToRetryWhenMoveRejected` asserts **no** stamp.
- `TestSetGaveUpStampsExpiresAndIsIdempotent`, the shared BoardStore conformance
  suite (native + Mongo), `TestSetLastRunClearDoesNotAppendABlankRun`,
  `TestIssueCLIUpdateClearsLastRunPointerKeepingHistory`, and studio specs for
  the badge, the details banner and the DTO normalizer.

`go test ./...`, `tsc -b`, and the full studio vitest suite are green; the
OpenAPI spec + generated `schema.ts` are regenerated.

## Docs

`docs/native-tracker.md` (lane contract, the give-up section, the fresh-run
recipe, the `close` endpoint row) and `docs/dispatcher.md` (a new *Giving up*
section under the retry queue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)