### PR TITLE
fix(pipelines): adopt finished recovery forks on the cloud board (#379)

### DIFF
--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -599,8 +599,13 @@ func TestMongoStore_Conformance(t *testing.T) {
 	// fairness); the stranded-card sweep lists NEWEST first, so a capped
 	// window always contains the freshest strandings on a saturated board
 	// (R0544a9). ready-a was created before ready-b, so their UpdatedAt
-	// order is creation order.
-	if len(elig) == 2 && (elig[0].Issue.Title != "ready-a" || elig[1].Issue.Title != "ready-b") {
+	// order is creation order. The count is FATAL: a stray ready+unclaimed
+	// card leaked by an earlier suite would otherwise silently void the
+	// ordering assertions below.
+	if len(elig) != 2 {
+		t.Fatalf("cross-tenant eligible count = %d (%v), want exactly ready-a + ready-b", len(elig), gotTitles)
+	}
+	if elig[0].Issue.Title != "ready-a" || elig[1].Issue.Title != "ready-b" {
 		t.Errorf("oldest-first order = [%s, %s], want [ready-a, ready-b]", elig[0].Issue.Title, elig[1].Issue.Title)
 	}
 	desc, derr := coord.ListEligible(ctx, []string{native.StateReady}, 1, true)

--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -577,7 +577,7 @@ func TestMongoStore_Conformance(t *testing.T) {
 			}
 		}
 	}
-	elig, eerr := coord.ListEligible(ctx, []string{native.StateReady}, 50)
+	elig, eerr := coord.ListEligible(ctx, []string{native.StateReady}, 50, false)
 	if eerr != nil {
 		t.Fatalf("ListEligible: %v", eerr)
 	}
@@ -593,6 +593,22 @@ func TestMongoStore_Conformance(t *testing.T) {
 	}
 	if _, ok := gotTitles["claimed"]; ok {
 		t.Error("claimed card must not be eligible")
+	}
+
+	// Ordering contract: the dispatch tick lists oldest-updated first (FIFO
+	// fairness); the stranded-card sweep lists NEWEST first, so a capped
+	// window always contains the freshest strandings on a saturated board
+	// (R0544a9). ready-a was created before ready-b, so their UpdatedAt
+	// order is creation order.
+	if len(elig) == 2 && !(elig[0].Issue.Title == "ready-a" && elig[1].Issue.Title == "ready-b") {
+		t.Errorf("oldest-first order = [%s, %s], want [ready-a, ready-b]", elig[0].Issue.Title, elig[1].Issue.Title)
+	}
+	desc, derr := coord.ListEligible(ctx, []string{native.StateReady}, 1, true)
+	if derr != nil {
+		t.Fatalf("ListEligible newest-first: %v", derr)
+	}
+	if len(desc) != 1 || desc[0].Issue.Title != "ready-b" {
+		t.Errorf("newest-first capped window = %v, want the freshest card ready-b", desc)
 	}
 }
 

--- a/pkg/dispatcher/boardmongo/conformance_test.go
+++ b/pkg/dispatcher/boardmongo/conformance_test.go
@@ -600,7 +600,7 @@ func TestMongoStore_Conformance(t *testing.T) {
 	// window always contains the freshest strandings on a saturated board
 	// (R0544a9). ready-a was created before ready-b, so their UpdatedAt
 	// order is creation order.
-	if len(elig) == 2 && !(elig[0].Issue.Title == "ready-a" && elig[1].Issue.Title == "ready-b") {
+	if len(elig) == 2 && (elig[0].Issue.Title != "ready-a" || elig[1].Issue.Title != "ready-b") {
 		t.Errorf("oldest-first order = [%s, %s], want [ready-a, ready-b]", elig[0].Issue.Title, elig[1].Issue.Title)
 	}
 	desc, derr := coord.ListEligible(ctx, []string{native.StateReady}, 1, true)

--- a/pkg/dispatcher/boardmongo/coordinator.go
+++ b/pkg/dispatcher/boardmongo/coordinator.go
@@ -35,15 +35,25 @@ func NewCoordinator(db *mongo.Database) *Coordinator {
 func (c *Coordinator) StoreFor(tenant string) *Store { return New(c.db, tenant) }
 
 // ListEligible returns up to `limit` UNCLAIMED issues whose state is in
-// `eligible`, across every tenant, oldest-updated first. (v1 assumes the
-// default-board eligibility passed by the caller; a per-tenant custom board
-// schema is a future refinement. Blocker gating is left to the per-issue
-// processor.)
-func (c *Coordinator) ListEligible(ctx context.Context, eligible []string, limit int) ([]Candidate, error) {
+// `eligible`, across every tenant, in the requested update order:
+// oldest-updated first (newestFirst=false) for the dispatch tick — FIFO
+// fairness — or newest-updated first for the stranded-card sweeps, whose
+// capped window must always contain the freshest strandings (a stranding
+// bumps UpdatedAt, and a sweep that leaves a card in place does not, so
+// under oldest-first a saturated board's forgotten pile occupies the window
+// permanently and starves exactly the cards the sweep exists to rescue).
+// (v1 assumes the default-board eligibility passed by the caller; a
+// per-tenant custom board schema is a future refinement. Blocker gating is
+// left to the per-issue processor.)
+func (c *Coordinator) ListEligible(ctx context.Context, eligible []string, limit int, newestFirst bool) ([]Candidate, error) {
 	if len(eligible) == 0 {
 		return nil, nil
 	}
-	opt := options.Find().SetSort(bson.D{{Key: "issue.updatedat", Value: 1}})
+	order := 1
+	if newestFirst {
+		order = -1
+	}
+	opt := options.Find().SetSort(bson.D{{Key: "issue.updatedat", Value: order}})
 	if limit > 0 {
 		opt.SetLimit(int64(limit))
 	}

--- a/pkg/dispatcher/boardmongo/store.go
+++ b/pkg/dispatcher/boardmongo/store.go
@@ -90,6 +90,17 @@ func EnsureSchema(ctx context.Context, db *mongo.Database) error {
 	issues := db.Collection(IssuesCollection)
 	_, err := issues.Indexes().CreateMany(ctx, []mongo.IndexModel{
 		{Keys: bson.D{{Key: "tenant_id", Value: 1}}, Options: options.Index().SetName("tenant")},
+		// Serves Coordinator.ListEligible — three cross-tenant queries per
+		// 5s tick per replica, one of them over in_progress+blocked (the
+		// states that only accumulate). Without it each is a COLLSCAN plus
+		// a blocking in-memory sort that trips Mongo's non-indexed-sort
+		// limit at scale. The trailing updatedat key serves BOTH sort
+		// directions (an index walks backwards for free).
+		{Keys: bson.D{
+			{Key: "issue.state", Value: 1},
+			{Key: "issue.claim", Value: 1},
+			{Key: "issue.updatedat", Value: 1},
+		}, Options: options.Index().SetName("eligible_by_updated")},
 	})
 	if err != nil && !mongoutil.IsIndexConflict(err) {
 		return fmt.Errorf("boardmongo: ensure issues index: %w", err)

--- a/pkg/server/boarddispatch.go
+++ b/pkg/server/boarddispatch.go
@@ -358,7 +358,17 @@ func (d *boardDispatcher) reconcileDeadPointer(ctx context.Context, c boardmongo
 	}
 	d.log("card %s/%s adopted finished fork %s over dead run %s — moving to %s", c.Tenant, c.Issue.ID, fork.ID, runID, d.doneState)
 	if err := d.coord.SetState(ctx, c.Tenant, c.Issue.ID, d.doneState); err != nil {
-		d.warn("fork-adoption move %s/%s → %s: %v", c.Tenant, c.Issue.ID, d.doneState, err)
+		d.warn("fork-adoption move %s/%s → %s: %v — reverting the pointer so the adoption retries whole", c.Tenant, c.Issue.ID, d.doneState, err)
+		// Half-adopted is the one shape nothing revisits (R716c91): a
+		// blocked card whose pointer now reads finished is skipped by the
+		// operator-placement guard above, so the filing would never
+		// complete. Put the dead parent back (best-effort) so the next TTL
+		// retries the adoption as a UNIT — including the deterministic
+		// SetState failure of a custom board with no done column, which
+		// stays a per-TTL warn instead of a silent permanent stranding.
+		if rerr := d.adoptRun(c.Tenant, c.Issue.ID, runID, c.Issue.LastWorkdir); rerr != nil {
+			d.warn("fork-adoption revert %s/%s to %s: %v — card left half-adopted; an operator state move re-arms the sweep", c.Tenant, c.Issue.ID, runID, rerr)
+		}
 	}
 }
 
@@ -494,15 +504,21 @@ func (s *Server) stampCardLastRun(tenant, cardID, runID string) {
 // included) via the CloudBoardFor seam. The fork-adoption sweep uses it to
 // converge a stranded card's pointer with the finished fork the projection
 // already shows — and the returned error is what lets the sweep SKIP the done
-// filing when the stamp did not land (Re9efb2). A missing seam or empty run
-// id stays a silent no-op: there is no board to converge with.
+// filing when the stamp did not land (Re9efb2). A missing seam is therefore
+// an ERROR, not a silent no-op: a wiring that runs the sweep without the
+// board seam must not file cards it cannot stamp (production wires
+// CloudBoardCoordinator and CloudBoardFor together; this guards any future
+// wiring that doesn't). Only an empty run id is a no-op — nothing to stamp.
 func (s *Server) adoptCardRun(tenant, cardID, runID, workdir string) error {
-	if s.cfg.CloudBoardFor == nil || runID == "" {
+	if runID == "" {
 		return nil
+	}
+	if s.cfg.CloudBoardFor == nil {
+		return errors.New("cloud board seam unwired (CloudBoardFor)")
 	}
 	store := s.cfg.CloudBoardFor(tenant)
 	if store == nil {
-		return nil
+		return fmt.Errorf("no board store for tenant %s", tenant)
 	}
 	return store.SetLastRun(cardID, runID, workdir)
 }

--- a/pkg/server/boarddispatch.go
+++ b/pkg/server/boarddispatch.go
@@ -19,7 +19,7 @@ import (
 // boardCoordinator is the cross-tenant board view the cloud dispatcher needs.
 // *boardmongo.Coordinator satisfies it; tests pass a fake.
 type boardCoordinator interface {
-	ListEligible(ctx context.Context, eligible []string, limit int) ([]boardmongo.Candidate, error)
+	ListEligible(ctx context.Context, eligible []string, limit int, newestFirst bool) ([]boardmongo.Candidate, error)
 	Claim(ctx context.Context, tenant, id, marker string) error
 	SetState(ctx context.Context, tenant, id, state string) error
 	Release(ctx context.Context, tenant, id, marker string) error
@@ -76,6 +76,11 @@ type boardDispatcher struct {
 	reconcileMemoMu sync.Mutex
 	reconcileMemo   map[string]time.Time
 
+	// saturationWarned dedups the fork-adoption sweep's listing-cap warning
+	// to one line per condition edge (only touched from the run-loop
+	// goroutine, which calls the sweeps sequentially).
+	saturationWarned bool
+
 	interval time.Duration
 	sem      chan struct{}
 	logger   *iterlog.Logger
@@ -105,7 +110,7 @@ func newBoardDispatcher(coord boardCoordinator, process func(context.Context, st
 // tick claims as many eligible cards as there are free slots and dispatches
 // each in a detached goroutine. Returns the number it claimed this tick.
 func (d *boardDispatcher) tick(ctx context.Context) int {
-	cands, err := d.coord.ListEligible(ctx, d.eligible, cap(d.sem)*2)
+	cands, err := d.coord.ListEligible(ctx, d.eligible, cap(d.sem)*2, false)
 	if err != nil {
 		d.warn("list eligible: %v", err)
 		return 0
@@ -170,7 +175,7 @@ func (d *boardDispatcher) sweepParked(ctx context.Context) {
 	if d.statusFor == nil {
 		return
 	}
-	cands, err := d.coord.ListEligible(ctx, []string{d.awaitingState}, sweepCardLimit)
+	cands, err := d.coord.ListEligible(ctx, []string{d.awaitingState}, sweepCardLimit, false)
 	if err != nil {
 		d.warn("parked sweep list: %v", err)
 		return
@@ -250,16 +255,27 @@ func (d *boardDispatcher) sweepForkAdoptions(ctx context.Context) {
 	if d.statusFor == nil || d.runFor == nil || d.issueRuns == nil || d.adoptRun == nil {
 		return
 	}
-	cands, err := d.coord.ListEligible(ctx, []string{d.inProgressState, d.blockedState}, sweepCardLimit)
+	// Newest-updated FIRST: a stranding bumps the card's UpdatedAt, so the
+	// freshest strandings always enter the window even on a board saturated
+	// past the cap — under oldest-first the forgotten blocked pile (which the
+	// sweep leaves in place, so its timestamps never move) would occupy the
+	// window permanently and starve exactly the cards this sweep exists to
+	// rescue (R0544a9).
+	cands, err := d.coord.ListEligible(ctx, []string{d.inProgressState, d.blockedState}, sweepCardLimit, true)
 	if err != nil {
 		d.warn("fork-adoption sweep list: %v", err)
 		return
 	}
-	// blocked accumulates board-wide and the listing is oldest-updated
-	// first: once a deployment sits at the cap, the window starves every
-	// newly-stranded card. Say so — the saturation is otherwise silent.
-	if len(cands) == sweepCardLimit {
-		d.warn("fork-adoption sweep at the %d-card listing cap — newly stranded cards may be starved", sweepCardLimit)
+	// At the cap, cards older than the window's tail are out of reach until
+	// operators drain the pile. Say so — once per condition edge, not per
+	// 5s tick (the sweeps run on the single run-loop goroutine).
+	if saturated := len(cands) == sweepCardLimit; saturated != d.saturationWarned {
+		d.saturationWarned = saturated
+		if saturated {
+			d.warn("fork-adoption sweep at the %d-card listing cap — cards stranded longer than the newest %d are out of reach until the blocked pile drains", sweepCardLimit, sweepCardLimit)
+		} else {
+			d.log("fork-adoption sweep back under the %d-card listing cap", sweepCardLimit)
+		}
 	}
 	for _, c := range cands {
 		d.reconcileDeadPointer(ctx, c)
@@ -278,14 +294,17 @@ func (d *boardDispatcher) reconcileDeadPointer(ctx context.Context, c boardmongo
 	if !d.reconcileDue(c.Tenant, c.Issue.ID) {
 		return
 	}
+	// The card is being evaluated: memoize BEFORE the read, not after. A
+	// card whose LastRunID no longer resolves (the run was pruned or
+	// deleted) fails statusFor on EVERY tick — permanently, not
+	// transiently — so memoizing only on success would leave exactly the
+	// cards the memo exists for paying one run load per tick, forever
+	// (R08601b). A genuinely transient blip just waits out one TTL.
+	d.noteReconcile(c.Tenant, c.Issue.ID)
 	st, err := d.statusFor(ctx, c.Tenant, runID)
 	if err != nil {
-		return // transient read failure — retry next tick, unmemoized
+		return // unreadable pointer — re-evaluated after the TTL
 	}
-	// The card was evaluated: memoize so the next evaluation waits
-	// forkAdoptionScanTTL instead of running every tick. Filed cards leave
-	// the listing anyway; the memo is what bounds the cards that STAY.
-	defer d.noteReconcile(c.Tenant, c.Issue.ID)
 	if st == store.RunStatusFinished {
 		// Only in_progress is the dispatcher's own orphan window (the run
 		// finished, the state move never landed). A blocked card is an

--- a/pkg/server/boarddispatch.go
+++ b/pkg/server/boarddispatch.go
@@ -54,6 +54,24 @@ type boardDispatcher struct {
 	statusFor  func(ctx context.Context, tenant, runID string) (store.RunStatus, error)
 	clearBadge func(tenant, id string)
 
+	// runFor + issueRuns + adoptRun power the fork-adoption sweep
+	// (sweepForkAdoptions). runFor loads a full run record tenant-scoped
+	// (the sweep needs CreatedAt to order fork candidates, which statusFor
+	// alone can't provide); issueRuns lists the runs sourced from an issue
+	// via the indexed reverse edge; adoptRun stamps the adopted fork onto
+	// the card via the CloudBoardFor seam. All optional — a nil runFor
+	// disables the sweep.
+	runFor    func(ctx context.Context, tenant, runID string) (*store.Run, error)
+	issueRuns func(ctx context.Context, tenant, issueID string) ([]*store.Run, error)
+	adoptRun  func(tenant, cardID, runID, workdir string)
+
+	// forkScanMemo bounds the fork-adoption sweep's search cost: a stuck
+	// card whose issue turned up no finished fork is not re-searched until
+	// forkAdoptionScanTTL has elapsed, so an abandoned failure does not
+	// turn into a per-tick query forever (keyed tenant|issueID).
+	forkScanMemoMu sync.Mutex
+	forkScanMemo   map[string]time.Time
+
 	interval time.Duration
 	sem      chan struct{}
 	logger   *iterlog.Logger
@@ -182,6 +200,145 @@ func (d *boardDispatcher) sweepParked(ctx context.Context) {
 	}
 }
 
+// forkAdoptionScanTTL bounds how often the fork-adoption sweep re-searches
+// the runs of an issue that turned up no finished fork: one indexed query
+// per stuck card per TTL instead of one per tick, forever, for a failure
+// the operator never addresses.
+const forkAdoptionScanTTL = 30 * time.Second
+
+// sweepForkAdoptions reconciles cards stranded on a DEAD pointer: the card
+// sits in in_progress or blocked (the run's terminal resting states once its
+// poll loop is gone), the pointer run is terminal, and nothing will ever
+// touch the card again — a recovery fork never becomes LastRunID on its
+// own. When the operator forked the dead run and that fork ACTUALLY
+// finished (FinishedAt != nil — a parked shell has delivered nothing), the
+// projection already lets the fork replace its parent on the card; this
+// sweep converges the TICKET with what the card shows: it adopts the newest
+// finished fork as the card's pointer, then files the card done (the tenant
+// store's SetState cascades the waiting_deps promotion of satisfied
+// dependents). Mirrors the local reconcileFinishedTickets
+// (pkg/server/pipeline_admission.go), which is gated to local mode while
+// the projection also runs in cloud (#379).
+//
+// The sweep rides ListEligible, so it only sees UNCLAIMED cards: a card
+// being processed right now is claimed (invisible — its live pointer fails
+// the terminal check anyway), and a card still claimed by a hard-killed
+// replica stays out of reach until its claim is released.
+//
+// A card whose pointer finished cleanly is filed done outright — the
+// orphan window between a run's finish and processCard's state move is
+// small but real (a hard-killed replica never makes the move).
+//
+// Cost: the per-card pointer status read mirrors sweepParked's; the fork
+// search runs ONLY for stuck cards and rides the indexed
+// ListRunsBySourceIssue edge (never a full store scan), negative results
+// memoized per (tenant, issue) for forkAdoptionScanTTL. Multi-replica safe
+// without claims: the fork choice is deterministic, SetLastRun/SetState are
+// idempotent for the same values, and neither in_progress nor blocked is in
+// `eligible`, so no replica re-dispatches a filed card.
+func (d *boardDispatcher) sweepForkAdoptions(ctx context.Context) {
+	if d.statusFor == nil || d.runFor == nil || d.issueRuns == nil || d.adoptRun == nil {
+		return
+	}
+	cands, err := d.coord.ListEligible(ctx, []string{d.inProgressState, d.blockedState}, 200)
+	if err != nil {
+		d.warn("fork-adoption sweep list: %v", err)
+		return
+	}
+	for _, c := range cands {
+		d.reconcileDeadPointer(ctx, c)
+	}
+}
+
+// reconcileDeadPointer files one stranded card: directly when its pointer
+// run finished cleanly, or by adopting the issue's newest finished fork
+// when the pointer died. Best-effort per card — an unreadable record leaves
+// the card for the next tick.
+func (d *boardDispatcher) reconcileDeadPointer(ctx context.Context, c boardmongo.Candidate) {
+	runID := c.Issue.LastRunID
+	if runID == "" {
+		return
+	}
+	st, err := d.statusFor(ctx, c.Tenant, runID)
+	if err != nil {
+		return // best-effort: unreadable run → leave the card alone
+	}
+	if st == store.RunStatusFinished {
+		d.log("card %s/%s pointer run %s finished but the card was never filed — moving to %s", c.Tenant, c.Issue.ID, runID, d.doneState)
+		if err := d.coord.SetState(ctx, c.Tenant, c.Issue.ID, d.doneState); err != nil {
+			d.warn("fork-adoption move %s/%s → %s: %v", c.Tenant, c.Issue.ID, d.doneState, err)
+		}
+		return
+	}
+	if !st.IsTerminal() {
+		return // live pointer — processCard (or a resume) still owns the card
+	}
+	if !d.forkScanDue(c.Tenant, c.Issue.ID) {
+		return
+	}
+	d.noteForkScan(c.Tenant, c.Issue.ID)
+	pointer, err := d.runFor(ctx, c.Tenant, runID)
+	if err != nil || pointer == nil {
+		return
+	}
+	runs, err := d.issueRuns(ctx, c.Tenant, c.Issue.ID)
+	if err != nil {
+		d.warn("fork-adoption sweep: list runs of card %s/%s: %v", c.Tenant, c.Issue.ID, err)
+		return
+	}
+	forks := make([]*store.Run, 0, len(runs))
+	for _, r := range runs {
+		if r == nil || r.ForkedFrom == "" || r.Source == nil || r.Source.IssueID == "" {
+			continue
+		}
+		if r.Status != store.RunStatusFinished || r.FinishedAt == nil {
+			continue
+		}
+		forks = append(forks, r)
+	}
+	fork := newestFinishedIssueFork(forks, pointer)
+	if fork == nil {
+		return
+	}
+	// Adopt the fork as the current attempt so the pointer converges with
+	// what the card already shows — workdir included, unlike launch-time
+	// stamps: the fork has already executed, and LastWorkdir feeds the
+	// studio's inspect-the-diff link.
+	d.adoptRun(c.Tenant, c.Issue.ID, fork.ID, fork.WorkDir)
+	d.log("card %s/%s adopted finished fork %s over dead run %s — moving to %s", c.Tenant, c.Issue.ID, fork.ID, runID, d.doneState)
+	if err := d.coord.SetState(ctx, c.Tenant, c.Issue.ID, d.doneState); err != nil {
+		d.warn("fork-adoption move %s/%s → %s: %v", c.Tenant, c.Issue.ID, d.doneState, err)
+	}
+}
+
+// forkScanDue reports whether the fork search for a (tenant, issue) pair is
+// due again — false while a previous empty search is younger than
+// forkAdoptionScanTTL.
+func (d *boardDispatcher) forkScanDue(tenant, issueID string) bool {
+	d.forkScanMemoMu.Lock()
+	defer d.forkScanMemoMu.Unlock()
+	last, ok := d.forkScanMemo[tenant+"|"+issueID]
+	return !ok || time.Since(last) >= forkAdoptionScanTTL
+}
+
+// noteForkScan records that a (tenant, issue) fork search ran and found
+// nothing to adopt, and prunes expired entries so the memo can't grow past
+// the set of recently-stuck cards.
+func (d *boardDispatcher) noteForkScan(tenant, issueID string) {
+	d.forkScanMemoMu.Lock()
+	defer d.forkScanMemoMu.Unlock()
+	if d.forkScanMemo == nil {
+		d.forkScanMemo = map[string]time.Time{}
+	}
+	now := time.Now()
+	for k, at := range d.forkScanMemo {
+		if now.Sub(at) >= forkAdoptionScanTTL {
+			delete(d.forkScanMemo, k)
+		}
+	}
+	d.forkScanMemo[tenant+"|"+issueID] = now
+}
+
 // run loops tick every interval until ctx is cancelled, then drains in-flight
 // cards. Start one per replica.
 func (d *boardDispatcher) run(ctx context.Context) {
@@ -190,6 +347,7 @@ func (d *boardDispatcher) run(ctx context.Context) {
 	for {
 		d.tick(ctx)
 		d.sweepParked(ctx)
+		d.sweepForkAdoptions(ctx)
 		select {
 		case <-ctx.Done():
 			d.wg.Wait() // let in-flight cards finish their state transition
@@ -276,6 +434,14 @@ func liftBoardLaunchContext(botArgs map[string]string) (boardLaunchContext, erro
 // (the Mongo-backed store in cloud, a native store in tests). Best-effort: a
 // stamp failure never fails the run — the card simply lacks its live-run link.
 func (s *Server) stampCardLastRun(tenant, cardID, runID string) {
+	s.adoptCardRun(tenant, cardID, runID, "")
+}
+
+// adoptCardRun stamps a run onto the tenant's board card (SetLastRun, workdir
+// included) via the CloudBoardFor seam. The fork-adoption sweep uses it to
+// converge a stranded card's pointer with the finished fork the projection
+// already shows. Best-effort: a stamp failure never fails the sweep.
+func (s *Server) adoptCardRun(tenant, cardID, runID, workdir string) {
 	if s.cfg.CloudBoardFor == nil || runID == "" {
 		return
 	}
@@ -283,7 +449,7 @@ func (s *Server) stampCardLastRun(tenant, cardID, runID string) {
 	if store == nil {
 		return
 	}
-	if err := store.SetLastRun(cardID, runID, ""); err != nil && s.logger != nil {
+	if err := store.SetLastRun(cardID, runID, workdir); err != nil && s.logger != nil {
 		s.logger.Warn("board dispatcher: stamp run %s on card %s/%s: %v", runID, tenant, cardID, err)
 	}
 }
@@ -318,6 +484,44 @@ func (s *Server) boardRunStatus(ctx context.Context, tenant, runID string) (stor
 		return "", err
 	}
 	return run.Status, nil
+}
+
+// boardRun reads a run's full record for the fork-adoption sweep (the sweep
+// needs CreatedAt to order fork candidates, which boardRunStatus alone can't
+// provide), tenant-scoped exactly like boardRunStatus.
+func (s *Server) boardRun(ctx context.Context, tenant, runID string) (*store.Run, error) {
+	if s.runs == nil {
+		return nil, errors.New("run service unavailable")
+	}
+	ctx = store.WithIdentity(ctx, tenant, "board-dispatcher")
+	return s.runs.LoadRunCtx(ctx, runID)
+}
+
+// boardIssueRuns lists the runs sourced from an issue for the fork-adoption
+// sweep, tenant-scoped, via the indexed card←run reverse edge
+// (ListRunsBySourceIssue) — never a full run-store scan.
+func (s *Server) boardIssueRuns(ctx context.Context, tenant, issueID string) ([]*store.Run, error) {
+	if s.runs == nil {
+		return nil, errors.New("run service unavailable")
+	}
+	rs := s.runs.RunStore()
+	if rs == nil {
+		return nil, errors.New("run store unavailable")
+	}
+	ctx = store.WithIdentity(ctx, tenant, "board-dispatcher")
+	ids, err := rs.ListRunsBySourceIssue(ctx, issueID)
+	if err != nil {
+		return nil, err
+	}
+	runs := make([]*store.Run, 0, len(ids))
+	for _, id := range ids {
+		r, err := s.runs.LoadRunCtx(ctx, id)
+		if err != nil || r == nil {
+			continue // best-effort: an unreadable run simply can't be adopted
+		}
+		runs = append(runs, r)
+	}
+	return runs, nil
 }
 
 func (s *Server) processBoardCard(ctx context.Context, tenant string, iss native.Issue) error {

--- a/pkg/server/boarddispatch.go
+++ b/pkg/server/boarddispatch.go
@@ -59,18 +59,22 @@ type boardDispatcher struct {
 	// (the sweep needs CreatedAt to order fork candidates, which statusFor
 	// alone can't provide); issueRuns lists the runs sourced from an issue
 	// via the indexed reverse edge; adoptRun stamps the adopted fork onto
-	// the card via the CloudBoardFor seam. All optional — a nil runFor
-	// disables the sweep.
+	// the card via the CloudBoardFor seam — a stamp error must SKIP the
+	// filing (done is terminal for the sweep, so a card filed while still
+	// pointing at the dead parent would never self-heal). All optional — a
+	// nil runFor disables the sweep.
 	runFor    func(ctx context.Context, tenant, runID string) (*store.Run, error)
 	issueRuns func(ctx context.Context, tenant, issueID string) ([]*store.Run, error)
-	adoptRun  func(tenant, cardID, runID, workdir string)
+	adoptRun  func(tenant, cardID, runID, workdir string) error
 
-	// forkScanMemo bounds the fork-adoption sweep's search cost: a stuck
-	// card whose issue turned up no finished fork is not re-searched until
-	// forkAdoptionScanTTL has elapsed, so an abandoned failure does not
-	// turn into a per-tick query forever (keyed tenant|issueID).
-	forkScanMemoMu sync.Mutex
-	forkScanMemo   map[string]time.Time
+	// reconcileMemo bounds the fork-adoption sweep's per-card cost: a card
+	// the sweep evaluated and left in place is not re-evaluated until
+	// forkAdoptionScanTTL has elapsed — in_progress/blocked are resting
+	// states that never drain on their own, so an unmemoized per-tick read
+	// would cost one run load per abandoned card per tick forever
+	// (keyed tenant|issueID).
+	reconcileMemoMu sync.Mutex
+	reconcileMemo   map[string]time.Time
 
 	interval time.Duration
 	sem      chan struct{}
@@ -166,7 +170,7 @@ func (d *boardDispatcher) sweepParked(ctx context.Context) {
 	if d.statusFor == nil {
 		return
 	}
-	cands, err := d.coord.ListEligible(ctx, []string{d.awaitingState}, 200)
+	cands, err := d.coord.ListEligible(ctx, []string{d.awaitingState}, sweepCardLimit)
 	if err != nil {
 		d.warn("parked sweep list: %v", err)
 		return
@@ -200,11 +204,16 @@ func (d *boardDispatcher) sweepParked(ctx context.Context) {
 	}
 }
 
-// forkAdoptionScanTTL bounds how often the fork-adoption sweep re-searches
-// the runs of an issue that turned up no finished fork: one indexed query
-// per stuck card per TTL instead of one per tick, forever, for a failure
-// the operator never addresses.
+// forkAdoptionScanTTL bounds how often the fork-adoption sweep re-evaluates
+// a card it left in place: one evaluation per stranded card per TTL instead
+// of one per tick — in_progress/blocked are resting states that never drain
+// on their own, so an unmemoized per-tick read would cost one run load per
+// abandoned card per tick, forever (R642c4d).
 const forkAdoptionScanTTL = 30 * time.Second
+
+// sweepCardLimit caps the cross-tenant listing a sweep pass works through
+// (shared by sweepParked and sweepForkAdoptions).
+const sweepCardLimit = 200
 
 // sweepForkAdoptions reconciles cards stranded on a DEAD pointer: the card
 // sits in in_progress or blocked (the run's terminal resting states once its
@@ -223,16 +232,17 @@ const forkAdoptionScanTTL = 30 * time.Second
 // The sweep rides ListEligible, so it only sees UNCLAIMED cards: a card
 // being processed right now is claimed (invisible — its live pointer fails
 // the terminal check anyway), and a card still claimed by a hard-killed
-// replica stays out of reach until its claim is released.
+// replica stays out of reach — boardmongo claims carry no TTL and no
+// reaper exists yet, so the replica-death case needs that reaper first
+// (R5ceb26, follow-up). The reachable stranded states are the ones
+// processCard itself released (blocked after a failure) or an operator
+// moved by hand.
 //
-// A card whose pointer finished cleanly is filed done outright — the
-// orphan window between a run's finish and processCard's state move is
-// small but real (a hard-killed replica never makes the move).
-//
-// Cost: the per-card pointer status read mirrors sweepParked's; the fork
-// search runs ONLY for stuck cards and rides the indexed
-// ListRunsBySourceIssue edge (never a full store scan), negative results
-// memoized per (tenant, issue) for forkAdoptionScanTTL. Multi-replica safe
+// Cost: the fork search runs ONLY for stuck cards and rides the indexed
+// ListRunsBySourceIssue edge (never a full store scan); every evaluated
+// card is then memoized per (tenant, issue) for forkAdoptionScanTTL, so a
+// board of abandoned failures pays one status read + at most one indexed
+// query per card per TTL — not per tick (R642c4d). Multi-replica safe
 // without claims: the fork choice is deterministic, SetLastRun/SetState are
 // idempotent for the same values, and neither in_progress nor blocked is in
 // `eligible`, so no replica re-dispatches a filed card.
@@ -240,10 +250,16 @@ func (d *boardDispatcher) sweepForkAdoptions(ctx context.Context) {
 	if d.statusFor == nil || d.runFor == nil || d.issueRuns == nil || d.adoptRun == nil {
 		return
 	}
-	cands, err := d.coord.ListEligible(ctx, []string{d.inProgressState, d.blockedState}, 200)
+	cands, err := d.coord.ListEligible(ctx, []string{d.inProgressState, d.blockedState}, sweepCardLimit)
 	if err != nil {
 		d.warn("fork-adoption sweep list: %v", err)
 		return
+	}
+	// blocked accumulates board-wide and the listing is oldest-updated
+	// first: once a deployment sits at the cap, the window starves every
+	// newly-stranded card. Say so — the saturation is otherwise silent.
+	if len(cands) == sweepCardLimit {
+		d.warn("fork-adoption sweep at the %d-card listing cap — newly stranded cards may be starved", sweepCardLimit)
 	}
 	for _, c := range cands {
 		d.reconcileDeadPointer(ctx, c)
@@ -259,11 +275,25 @@ func (d *boardDispatcher) reconcileDeadPointer(ctx context.Context, c boardmongo
 	if runID == "" {
 		return
 	}
+	if !d.reconcileDue(c.Tenant, c.Issue.ID) {
+		return
+	}
 	st, err := d.statusFor(ctx, c.Tenant, runID)
 	if err != nil {
-		return // best-effort: unreadable run → leave the card alone
+		return // transient read failure — retry next tick, unmemoized
 	}
+	// The card was evaluated: memoize so the next evaluation waits
+	// forkAdoptionScanTTL instead of running every tick. Filed cards leave
+	// the listing anyway; the memo is what bounds the cards that STAY.
+	defer d.noteReconcile(c.Tenant, c.Issue.ID)
 	if st == store.RunStatusFinished {
+		// Only in_progress is the dispatcher's own orphan window (the run
+		// finished, the state move never landed). A blocked card is an
+		// operator-facing "bad outcome" flag — re-filing it done would
+		// override a deliberate placement within one tick (R751dc1).
+		if c.Issue.State != d.inProgressState {
+			return
+		}
 		d.log("card %s/%s pointer run %s finished but the card was never filed — moving to %s", c.Tenant, c.Issue.ID, runID, d.doneState)
 		if err := d.coord.SetState(ctx, c.Tenant, c.Issue.ID, d.doneState); err != nil {
 			d.warn("fork-adoption move %s/%s → %s: %v", c.Tenant, c.Issue.ID, d.doneState, err)
@@ -273,10 +303,6 @@ func (d *boardDispatcher) reconcileDeadPointer(ctx context.Context, c boardmongo
 	if !st.IsTerminal() {
 		return // live pointer — processCard (or a resume) still owns the card
 	}
-	if !d.forkScanDue(c.Tenant, c.Issue.ID) {
-		return
-	}
-	d.noteForkScan(c.Tenant, c.Issue.ID)
 	pointer, err := d.runFor(ctx, c.Tenant, runID)
 	if err != nil || pointer == nil {
 		return
@@ -303,40 +329,46 @@ func (d *boardDispatcher) reconcileDeadPointer(ctx context.Context, c boardmongo
 	// Adopt the fork as the current attempt so the pointer converges with
 	// what the card already shows — workdir included, unlike launch-time
 	// stamps: the fork has already executed, and LastWorkdir feeds the
-	// studio's inspect-the-diff link.
-	d.adoptRun(c.Tenant, c.Issue.ID, fork.ID, fork.WorkDir)
+	// studio's inspect-the-diff link. A stamp failure must SKIP the filing
+	// (mirror pipeline_admission.go's guard): done is terminal for this
+	// sweep, so a card filed while still pointing at the dead parent would
+	// never self-heal.
+	if err := d.adoptRun(c.Tenant, c.Issue.ID, fork.ID, fork.WorkDir); err != nil {
+		d.warn("fork-adoption stamp %s on card %s/%s: %v", fork.ID, c.Tenant, c.Issue.ID, err)
+		return
+	}
 	d.log("card %s/%s adopted finished fork %s over dead run %s — moving to %s", c.Tenant, c.Issue.ID, fork.ID, runID, d.doneState)
 	if err := d.coord.SetState(ctx, c.Tenant, c.Issue.ID, d.doneState); err != nil {
 		d.warn("fork-adoption move %s/%s → %s: %v", c.Tenant, c.Issue.ID, d.doneState, err)
 	}
 }
 
-// forkScanDue reports whether the fork search for a (tenant, issue) pair is
-// due again — false while a previous empty search is younger than
+// reconcileDue reports whether the sweep's evaluation of a (tenant, issue)
+// card is due again — false while a previous evaluation is younger than
 // forkAdoptionScanTTL.
-func (d *boardDispatcher) forkScanDue(tenant, issueID string) bool {
-	d.forkScanMemoMu.Lock()
-	defer d.forkScanMemoMu.Unlock()
-	last, ok := d.forkScanMemo[tenant+"|"+issueID]
+func (d *boardDispatcher) reconcileDue(tenant, issueID string) bool {
+	d.reconcileMemoMu.Lock()
+	defer d.reconcileMemoMu.Unlock()
+	last, ok := d.reconcileMemo[tenant+"|"+issueID]
 	return !ok || time.Since(last) >= forkAdoptionScanTTL
 }
 
-// noteForkScan records that a (tenant, issue) fork search ran and found
-// nothing to adopt, and prunes expired entries so the memo can't grow past
-// the set of recently-stuck cards.
-func (d *boardDispatcher) noteForkScan(tenant, issueID string) {
-	d.forkScanMemoMu.Lock()
-	defer d.forkScanMemoMu.Unlock()
-	if d.forkScanMemo == nil {
-		d.forkScanMemo = map[string]time.Time{}
+// noteReconcile records that a (tenant, issue) card was evaluated, and
+// prunes expired entries so the memo can't grow past the set of
+// recently-stuck cards.
+func (d *boardDispatcher) noteReconcile(tenant, issueID string) {
+	d.reconcileMemoMu.Lock()
+	defer d.reconcileMemoMu.Unlock()
+	if d.reconcileMemo == nil {
+		d.reconcileMemo = map[string]time.Time{}
 	}
 	now := time.Now()
-	for k, at := range d.forkScanMemo {
+	for k, at := range d.reconcileMemo {
 		if now.Sub(at) >= forkAdoptionScanTTL {
-			delete(d.forkScanMemo, k)
+			delete(d.reconcileMemo, k)
 		}
 	}
-	d.forkScanMemo[tenant+"|"+issueID] = now
+	d.reconcileMemo[tenant+"|"+issueID] = now
 }
 
 // run loops tick every interval until ctx is cancelled, then drains in-flight
@@ -434,24 +466,26 @@ func liftBoardLaunchContext(botArgs map[string]string) (boardLaunchContext, erro
 // (the Mongo-backed store in cloud, a native store in tests). Best-effort: a
 // stamp failure never fails the run — the card simply lacks its live-run link.
 func (s *Server) stampCardLastRun(tenant, cardID, runID string) {
-	s.adoptCardRun(tenant, cardID, runID, "")
+	if err := s.adoptCardRun(tenant, cardID, runID, ""); err != nil && s.logger != nil {
+		s.logger.Warn("board dispatcher: stamp run %s on card %s/%s: %v", runID, tenant, cardID, err)
+	}
 }
 
 // adoptCardRun stamps a run onto the tenant's board card (SetLastRun, workdir
 // included) via the CloudBoardFor seam. The fork-adoption sweep uses it to
 // converge a stranded card's pointer with the finished fork the projection
-// already shows. Best-effort: a stamp failure never fails the sweep.
-func (s *Server) adoptCardRun(tenant, cardID, runID, workdir string) {
+// already shows — and the returned error is what lets the sweep SKIP the done
+// filing when the stamp did not land (Re9efb2). A missing seam or empty run
+// id stays a silent no-op: there is no board to converge with.
+func (s *Server) adoptCardRun(tenant, cardID, runID, workdir string) error {
 	if s.cfg.CloudBoardFor == nil || runID == "" {
-		return
+		return nil
 	}
 	store := s.cfg.CloudBoardFor(tenant)
 	if store == nil {
-		return
+		return nil
 	}
-	if err := store.SetLastRun(cardID, runID, workdir); err != nil && s.logger != nil {
-		s.logger.Warn("board dispatcher: stamp run %s on card %s/%s: %v", runID, tenant, cardID, err)
-	}
+	return store.SetLastRun(cardID, runID, workdir)
 }
 
 // setCardAwaitingInput denormalizes the pause hint onto the tenant's board
@@ -557,6 +591,18 @@ func (s *Server) processBoardCard(ctx context.Context, tenant string, iss native
 		RepoRef:         lc.RepoRef,
 		KeyOverrides:    lc.KeyOverrides,
 		SecretOverrides: lc.SecretOverrides,
+		// Stamp the card onto the run record (ADR-046 SourceRef) — the
+		// card→run edge SetLastRun writes below is not enough: the
+		// fork-adoption sweep resolves an issue's runs through the indexed
+		// ListRunsBySourceIssue REVERSE edge, which only exists when every
+		// board-dispatched run persists Source.IssueID (Rf72821 — without
+		// it the sweep's fork search comes back empty forever in cloud).
+		// Kind mirrors the local dispatcher's engine_runner stamp.
+		SourceRef: &store.RunSource{
+			Kind:       store.RunSourceKindDispatcher,
+			IssueID:    iss.ID,
+			IssueTitle: iss.Title,
+		},
 	})
 	if err != nil {
 		return err

--- a/pkg/server/boarddispatch_test.go
+++ b/pkg/server/boarddispatch_test.go
@@ -34,8 +34,11 @@ func newFakeBoardCoord(cands ...boardmongo.Candidate) *fakeBoardCoord {
 
 // ListEligible honours the real coordinator's contract — unclaimed cards in
 // one of the requested states, capped — so a caller sweeping the wrong state
-// list (or ignoring the claim filter) fails here instead of passing vacuously.
-func (f *fakeBoardCoord) ListEligible(_ context.Context, states []string, limit int) ([]boardmongo.Candidate, error) {
+// list (or ignoring the claim filter) fails here instead of passing
+// vacuously. The UpdatedAt ordering (newestFirst) is exercised against the
+// real store in boardmongo's conformance suite, not here: the fake carries
+// no timestamps.
+func (f *fakeBoardCoord) ListEligible(_ context.Context, states []string, limit int, _ bool) ([]boardmongo.Candidate, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	var out []boardmongo.Candidate
@@ -677,6 +680,77 @@ func TestBoardDispatcher_SweepAdoptsFinishedFork(t *testing.T) {
 	// Nil wiring (sweep disabled) must be a hard no-op, not a panic.
 	d2 := newBoardDispatcher(f, func(context.Context, string, native.Issue) error { return nil }, "replica-A", 4, nil)
 	d2.sweepForkAdoptions(context.Background())
+}
+
+// TestBoardDispatcher_SweepMemoizesUnreadablePointer: a card whose LastRunID
+// no longer resolves (the run was pruned or deleted) fails statusFor on
+// every tick — permanently. The memo must be written BEFORE the read, or
+// exactly the cards it exists to bound pay one run load per 5s tick forever
+// (R08601b).
+func TestBoardDispatcher_SweepMemoizesUnreadablePointer(t *testing.T) {
+	f := newFakeBoardCoord(boardmongo.Candidate{
+		Tenant: "t1",
+		Issue:  native.Issue{ID: "native:pruned", State: native.StateBlocked, LastRunID: "run-gone"},
+	})
+	d := newBoardDispatcher(f, func(context.Context, string, native.Issue) error {
+		t.Fatal("the fork-adoption sweep must never dispatch a card")
+		return nil
+	}, "replica-A", 4, nil)
+	var reads int
+	d.statusFor = func(context.Context, string, string) (store.RunStatus, error) {
+		reads++
+		return "", errors.New("run run-gone not found (pruned)")
+	}
+	d.runFor = func(context.Context, string, string) (*store.Run, error) { return nil, errors.New("gone") }
+	d.issueRuns = func(context.Context, string, string) ([]*store.Run, error) { return nil, nil }
+	d.adoptRun = func(string, string, string, string) error { return nil }
+
+	d.sweepForkAdoptions(context.Background())
+	d.sweepForkAdoptions(context.Background())
+
+	if reads != 1 {
+		t.Errorf("statusFor reads across two sweeps = %d, want 1 (an unreadable pointer must be memoized for the TTL, not re-read per tick)", reads)
+	}
+	if got, moved := f.states["native:pruned"]; moved {
+		t.Errorf("unreadable pointer must leave the card in place, was moved to %q", got)
+	}
+}
+
+// TestBoardDispatcher_SweepSaturationWarnDedups: the listing-cap warning
+// fires once per condition EDGE, not per 5s tick (~17k identical lines/day
+// otherwise), and re-arms when the board drops back under the cap (R0544a9).
+func TestBoardDispatcher_SweepSaturationWarnDedups(t *testing.T) {
+	cands := make([]boardmongo.Candidate, sweepCardLimit)
+	for i := range cands {
+		cands[i] = boardmongo.Candidate{
+			Tenant: "t1",
+			Issue:  native.Issue{ID: fmt.Sprintf("native:%d", i), State: native.StateBlocked},
+		}
+	}
+	f := newFakeBoardCoord(cands...)
+	d := newBoardDispatcher(f, func(context.Context, string, native.Issue) error { return nil }, "replica-A", 4, nil)
+	d.statusFor = func(context.Context, string, string) (store.RunStatus, error) { return "", errors.New("x") }
+	d.runFor = func(context.Context, string, string) (*store.Run, error) { return nil, errors.New("x") }
+	d.issueRuns = func(context.Context, string, string) ([]*store.Run, error) { return nil, nil }
+	d.adoptRun = func(string, string, string, string) error { return nil }
+
+	d.sweepForkAdoptions(context.Background())
+	if !d.saturationWarned {
+		t.Fatal("a full listing window must flag saturation")
+	}
+	d.sweepForkAdoptions(context.Background())
+	if !d.saturationWarned {
+		t.Fatal("saturation must stay flagged while the condition holds")
+	}
+
+	// Drop under the cap: the flag resets so the next saturation warns again.
+	f.mu.Lock()
+	f.cands = f.cands[:sweepCardLimit-1]
+	f.mu.Unlock()
+	d.sweepForkAdoptions(context.Background())
+	if d.saturationWarned {
+		t.Fatal("dropping under the cap must reset the saturation flag")
+	}
 }
 
 // TestBoardDispatcher_SweepSkipsFilingOnStampFailure: done is terminal for

--- a/pkg/server/boarddispatch_test.go
+++ b/pkg/server/boarddispatch_test.go
@@ -26,10 +26,11 @@ type fakeBoardCoord struct {
 	claimed  map[string]string
 	states   map[string]string
 	claimErr map[string]error
+	stateErr map[string]error
 }
 
 func newFakeBoardCoord(cands ...boardmongo.Candidate) *fakeBoardCoord {
-	return &fakeBoardCoord{cands: cands, claimed: map[string]string{}, states: map[string]string{}, claimErr: map[string]error{}}
+	return &fakeBoardCoord{cands: cands, claimed: map[string]string{}, states: map[string]string{}, claimErr: map[string]error{}, stateErr: map[string]error{}}
 }
 
 // ListEligible honours the real coordinator's contract — unclaimed cards in
@@ -73,8 +74,11 @@ func (f *fakeBoardCoord) Claim(_ context.Context, _, id, marker string) error {
 
 func (f *fakeBoardCoord) SetState(_ context.Context, _, id, state string) error {
 	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.stateErr[id]; err != nil {
+		return err
+	}
 	f.states[id] = state
-	f.mu.Unlock()
 	return nil
 }
 
@@ -753,6 +757,57 @@ func TestBoardDispatcher_SweepSaturationWarnDedups(t *testing.T) {
 	}
 }
 
+// TestBoardDispatcher_SweepRevertsAdoptionOnFilingFailure: adoptRun then
+// SetState(done) are two writes; if the second fails the card would be
+// HALF-adopted — blocked, pointer reading finished — and the
+// operator-placement guard would skip it on every later pass, stranding it
+// forever with a mutated pointer (R716c91). The sweep must revert the
+// pointer to the dead parent so the next TTL retries the adoption as a
+// unit.
+func TestBoardDispatcher_SweepRevertsAdoptionOnFilingFailure(t *testing.T) {
+	older := time.Now().Add(-time.Hour)
+	ended := older.Add(30 * time.Minute)
+	f := newFakeBoardCoord(boardmongo.Candidate{
+		Tenant: "t1",
+		Issue:  native.Issue{ID: "native:stuck", State: native.StateBlocked, LastRunID: "run-dead", LastWorkdir: "/wt/dead"},
+	})
+	f.stateErr["native:stuck"] = errors.New("transition rejected: no done column")
+	d := newBoardDispatcher(f, func(context.Context, string, native.Issue) error {
+		t.Fatal("the fork-adoption sweep must never dispatch a card")
+		return nil
+	}, "replica-A", 4, nil)
+	d.statusFor = func(context.Context, string, string) (store.RunStatus, error) {
+		return store.RunStatusFailed, nil
+	}
+	d.runFor = func(context.Context, string, string) (*store.Run, error) {
+		return &store.Run{ID: "run-dead", Status: store.RunStatusFailed, CreatedAt: older}, nil
+	}
+	d.issueRuns = func(context.Context, string, string) ([]*store.Run, error) {
+		return []*store.Run{
+			{ID: "run-dead", Status: store.RunStatusFailed, CreatedAt: older,
+				Source: &store.RunSource{IssueID: "native:stuck"}},
+			{ID: "run-fork", Status: store.RunStatusFinished, CreatedAt: older.Add(10 * time.Minute),
+				FinishedAt: &ended, ForkedFrom: "run-dead", WorkDir: "/wt/fork",
+				Source: &store.RunSource{IssueID: "native:stuck"}},
+		}, nil
+	}
+	var stamps [][2]string
+	d.adoptRun = func(_, _, runID, workdir string) error {
+		stamps = append(stamps, [2]string{runID, workdir})
+		return nil
+	}
+
+	d.sweepForkAdoptions(context.Background())
+
+	want := [][2]string{{"run-fork", "/wt/fork"}, {"run-dead", "/wt/dead"}}
+	if len(stamps) != 2 || stamps[0] != want[0] || stamps[1] != want[1] {
+		t.Errorf("stamps = %v, want adopt-then-revert %v", stamps, want)
+	}
+	if got, moved := f.states["native:stuck"]; moved {
+		t.Errorf("filing failed — the card must not move, was set to %q", got)
+	}
+}
+
 // TestBoardDispatcher_SweepSkipsFilingOnStampFailure: done is terminal for
 // the sweep ({in_progress, blocked} is all it lists), so a card filed done
 // while SetLastRun failed would show a Done card pointing at the FAILED
@@ -878,12 +933,17 @@ func TestAdoptCardRun(t *testing.T) {
 	if got.LastRunID != "run-fork" || got.LastWorkdir != "/wt/fork" {
 		t.Fatalf("card pointer = (%q, %q), want (run-fork, /wt/fork)", got.LastRunID, got.LastWorkdir)
 	}
-	// A failed stamp must SURFACE (the sweep skips the done filing on it),
-	// while a missing seam stays a silent no-op (nothing to converge with).
+	// A failed stamp must SURFACE (the sweep skips the done filing on it) —
+	// and so must a missing seam: a wiring that sweeps without the board
+	// seam must not file cards it cannot stamp. Only an empty run id is a
+	// no-op (nothing to stamp).
 	if err := s.adoptCardRun("t1", "native:no-such-card", "run-y", ""); err == nil {
 		t.Error("stamping a missing card must return the store error, got nil")
 	}
-	if err := (&Server{}).adoptCardRun("t1", iss.ID, "run-x", ""); err != nil { // CloudBoardFor nil → no-op
-		t.Errorf("nil seam must be a silent no-op, got %v", err)
+	if err := (&Server{}).adoptCardRun("t1", iss.ID, "run-x", ""); err == nil {
+		t.Error("a missing CloudBoardFor seam must surface as an error, got nil")
+	}
+	if err := (&Server{}).adoptCardRun("t1", iss.ID, "", ""); err != nil {
+		t.Errorf("an empty run id is a no-op, got %v", err)
 	}
 }

--- a/pkg/server/boarddispatch_test.go
+++ b/pkg/server/boarddispatch_test.go
@@ -516,3 +516,211 @@ func TestApplyPRLaunchContextPrecedence(t *testing.T) {
 		t.Error("no pr_url: no repo policy to apply")
 	}
 }
+
+// TestBoardDispatcher_SweepAdoptsFinishedFork: a cloud card stranded on a
+// DEAD pointer — in_progress because its dispatcher replica died mid-run and
+// nothing ever moved it on, or blocked because the run failed — is never
+// touched again: tick only claims Ready cards, and a recovery fork never
+// becomes LastRunID on its own. The projection already lets the finished
+// fork replace its parent on the card (#377); the sweep must converge the
+// TICKET with that view: adopt the issue's newest fork that ACTUALLY
+// finished (FinishedAt != nil — a parked shell delivered nothing), then file
+// the card done. A card whose own pointer finished cleanly is filed
+// outright. Live pointers, pointer-less cards and forkless failures stay
+// put. Cloud parity with the local reconcileFinishedTickets (#379).
+func TestBoardDispatcher_SweepAdoptsFinishedFork(t *testing.T) {
+	older := time.Now().Add(-time.Hour)
+	ended := older.Add(50 * time.Minute)
+	card := func(id, state, runID string) boardmongo.Candidate {
+		return boardmongo.Candidate{Tenant: "t1", Issue: native.Issue{ID: id, State: state, LastRunID: runID}}
+	}
+	src := func(issueID string) *store.RunSource { return &store.RunSource{IssueID: issueID} }
+	f := newFakeBoardCoord(
+		card("native:stuck", native.StateInProgress, "run-dead"),
+		card("native:blocked", native.StateBlocked, "run-dead2"),
+		card("native:live", native.StateInProgress, "run-live"),
+		card("native:forkless", native.StateInProgress, "run-dead3"),
+		card("native:finished", native.StateInProgress, "run-fin"),
+		card("native:noptr", native.StateInProgress, ""),
+	)
+	statuses := map[string]store.RunStatus{
+		"run-dead":  store.RunStatusFailed,
+		"run-dead2": store.RunStatusFailed,
+		"run-dead3": store.RunStatusFailed,
+		"run-live":  store.RunStatusRunning,
+		"run-fin":   store.RunStatusFinished,
+	}
+	pointers := map[string]*store.Run{
+		"run-dead":  {ID: "run-dead", Status: store.RunStatusFailed, CreatedAt: older},
+		"run-dead2": {ID: "run-dead2", Status: store.RunStatusFailed, CreatedAt: older},
+		"run-dead3": {ID: "run-dead3", Status: store.RunStatusFailed, CreatedAt: older},
+	}
+	byIssue := map[string][]*store.Run{
+		"native:stuck": {
+			{ID: "run-dead", Status: store.RunStatusFailed, CreatedAt: older, Source: src("native:stuck")},
+			{ID: "run-fork", Status: store.RunStatusFinished, CreatedAt: older.Add(30 * time.Minute),
+				FinishedAt: &ended, ForkedFrom: "run-dead", WorkDir: "/wt/fork", Source: src("native:stuck")},
+			// Newer but parked: cancelled via Fork()'s initial SaveRun, no
+			// FinishedAt — must not win over the fork that really finished.
+			{ID: "run-fork-parked", Status: store.RunStatusCancelled, CreatedAt: older.Add(40 * time.Minute),
+				ForkedFrom: "run-fork", Source: src("native:stuck")},
+		},
+		"native:blocked": {
+			{ID: "run-dead2", Status: store.RunStatusFailed, CreatedAt: older, Source: src("native:blocked")},
+			{ID: "run-fork2", Status: store.RunStatusFinished, CreatedAt: older.Add(20 * time.Minute),
+				FinishedAt: &ended, ForkedFrom: "run-dead2", Source: src("native:blocked")},
+		},
+		"native:forkless": {
+			{ID: "run-dead3", Status: store.RunStatusFailed, CreatedAt: older, Source: src("native:forkless")},
+		},
+	}
+
+	d := newBoardDispatcher(f, func(context.Context, string, native.Issue) error {
+		t.Fatal("the fork-adoption sweep must never dispatch a card")
+		return nil
+	}, "replica-A", 4, nil)
+	d.statusFor = func(_ context.Context, _, runID string) (store.RunStatus, error) {
+		return statuses[runID], nil
+	}
+	d.runFor = func(_ context.Context, _, runID string) (*store.Run, error) {
+		r, ok := pointers[runID]
+		if !ok {
+			return nil, fmt.Errorf("run %s not found", runID)
+		}
+		return r, nil
+	}
+	var searches int
+	d.issueRuns = func(_ context.Context, _, issueID string) ([]*store.Run, error) {
+		searches++
+		return byIssue[issueID], nil
+	}
+	var amu sync.Mutex
+	adopted := map[string][2]string{}
+	d.adoptRun = func(_, cardID, runID, workdir string) {
+		amu.Lock()
+		adopted[cardID] = [2]string{runID, workdir}
+		amu.Unlock()
+	}
+
+	d.sweepForkAdoptions(context.Background())
+
+	for _, id := range []string{"native:stuck", "native:blocked", "native:finished"} {
+		if got := f.states[id]; got != native.StateDone {
+			t.Errorf("card %s state = %q, want %q", id, got, native.StateDone)
+		}
+	}
+	if got := adopted["native:stuck"]; got != [2]string{"run-fork", "/wt/fork"} {
+		t.Errorf("native:stuck adoption = %v, want the finished fork with its workdir", got)
+	}
+	if got := adopted["native:blocked"]; got != [2]string{"run-fork2", ""} {
+		t.Errorf("native:blocked adoption = %v, want run-fork2", got)
+	}
+	// A card whose own pointer finished is filed without an adoption.
+	if _, ok := adopted["native:finished"]; ok {
+		t.Errorf("native:finished must be filed outright, not adopted: %v", adopted["native:finished"])
+	}
+	// Live pointer, missing pointer and forkless failure stay put.
+	for _, id := range []string{"native:live", "native:noptr", "native:forkless"} {
+		if got, moved := f.states[id]; moved {
+			t.Errorf("card %s must stay put, was moved to %q", id, got)
+		}
+	}
+	if searches != 3 {
+		t.Errorf("fork searches = %d, want 3 (stuck, blocked, forkless — one per stuck card)", searches)
+	}
+
+	// A second sweep within the TTL must not re-search an issue that turned
+	// up nothing to adopt — an abandoned failure is the RESTING state of a
+	// board, not a reason to pay an indexed query per card per tick.
+	d.sweepForkAdoptions(context.Background())
+	if searches != 3 {
+		t.Errorf("fork searches after a 2nd sweep = %d, want 3 (negative results memoized for the TTL)", searches)
+	}
+
+	// Nil wiring (sweep disabled) must be a hard no-op, not a panic.
+	d2 := newBoardDispatcher(f, func(context.Context, string, native.Issue) error { return nil }, "replica-A", 4, nil)
+	d2.sweepForkAdoptions(context.Background())
+}
+
+// TestBoardIssueRuns: the fork-adoption sweep reads an issue's runs through
+// the indexed card←run reverse edge (ListRunsBySourceIssue), tenant-scoped
+// like every other cloud board read — never a full run-store scan.
+func TestBoardIssueRuns(t *testing.T) {
+	rs, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc, err := runview.NewService("", runview.WithStore(rs))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{}
+	s.runs = svc
+
+	ctx := context.Background()
+	ended := time.Now()
+	for _, r := range []*store.Run{
+		{ID: "run-a", WorkflowName: "wf", Status: store.RunStatusFailed, Source: &store.RunSource{IssueID: "native:1"}},
+		{ID: "run-b", WorkflowName: "wf", Status: store.RunStatusFinished, FinishedAt: &ended,
+			ForkedFrom: "run-a", Source: &store.RunSource{IssueID: "native:1"}},
+		{ID: "run-c", WorkflowName: "wf", Status: store.RunStatusFinished, FinishedAt: &ended,
+			Source: &store.RunSource{IssueID: "native:2"}},
+	} {
+		if err := rs.SaveRun(ctx, r); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	runs, err := s.boardIssueRuns(ctx, "t1", "native:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, r := range runs {
+		got[r.ID] = true
+	}
+	if !got["run-a"] || !got["run-b"] || got["run-c"] || len(runs) != 2 {
+		t.Errorf("boardIssueRuns(native:1) = %v, want exactly run-a and run-b", got)
+	}
+
+	// boardRun serves the full record (CreatedAt orders fork candidates).
+	full, err := s.boardRun(ctx, "t1", "run-b")
+	if err != nil || full == nil || full.ForkedFrom != "run-a" {
+		t.Errorf("boardRun(run-b) = %+v, %v", full, err)
+	}
+
+	// Unwired server: an error, not a panic.
+	if _, err := (&Server{}).boardIssueRuns(ctx, "t1", "native:1"); err == nil {
+		t.Error("boardIssueRuns without a run service should error")
+	}
+	if _, err := (&Server{}).boardRun(ctx, "t1", "run-b"); err == nil {
+		t.Error("boardRun without a run service should error")
+	}
+}
+
+// TestAdoptCardRun: the fork-adoption stamp goes through the same
+// CloudBoardFor seam as stampCardLastRun but keeps the fork's workdir (the
+// run has already executed; LastWorkdir feeds the studio's inspect-the-diff
+// link — cf. R26faf1 on the local twin).
+func TestAdoptCardRun(t *testing.T) {
+	boardStore, err := native.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	iss, err := boardStore.Create(native.Issue{Title: "x", State: native.StateInProgress})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{}
+	s.cfg.CloudBoardFor = func(string) native.BoardStore { return boardStore }
+
+	s.adoptCardRun("t1", iss.ID, "run-fork", "/wt/fork")
+	got, err := boardStore.Get(iss.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.LastRunID != "run-fork" || got.LastWorkdir != "/wt/fork" {
+		t.Fatalf("card pointer = (%q, %q), want (run-fork, /wt/fork)", got.LastRunID, got.LastWorkdir)
+	}
+	(&Server{}).adoptCardRun("t1", iss.ID, "run-x", "") // CloudBoardFor nil → no-op
+}

--- a/pkg/server/boarddispatch_test.go
+++ b/pkg/server/boarddispatch_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -31,14 +32,25 @@ func newFakeBoardCoord(cands ...boardmongo.Candidate) *fakeBoardCoord {
 	return &fakeBoardCoord{cands: cands, claimed: map[string]string{}, states: map[string]string{}, claimErr: map[string]error{}}
 }
 
-func (f *fakeBoardCoord) ListEligible(_ context.Context, _ []string, _ int) ([]boardmongo.Candidate, error) {
+// ListEligible honours the real coordinator's contract — unclaimed cards in
+// one of the requested states, capped — so a caller sweeping the wrong state
+// list (or ignoring the claim filter) fails here instead of passing vacuously.
+func (f *fakeBoardCoord) ListEligible(_ context.Context, states []string, limit int) ([]boardmongo.Candidate, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	var out []boardmongo.Candidate
 	for _, c := range f.cands {
-		if f.claimed[c.Issue.ID] == "" {
-			out = append(out, c)
+		state := c.Issue.State
+		if moved, ok := f.states[c.Issue.ID]; ok {
+			state = moved // a SetState since construction wins, like the real store
 		}
+		if f.claimed[c.Issue.ID] != "" || !slices.Contains(states, state) {
+			continue
+		}
+		if len(out) == limit {
+			break
+		}
+		out = append(out, c)
 	}
 	return out, nil
 }
@@ -393,18 +405,34 @@ func TestProcessBoardCardCarriesPRLaunchContext(t *testing.T) {
 	// Wait for the run to SETTLE, not merely to exist: reading run.json the
 	// moment it appears leaves the engine's goroutines writing into the temp
 	// store while cleanup removes it.
-	var inputs map[string]any
+	var settled *store.Run
 	for deadline := time.Now().Add(30 * time.Second); time.Now().Before(deadline); {
 		if ids, lerr := rs.ListRuns(ctx); lerr == nil && len(ids) > 0 {
 			if run, rerr := rs.LoadRun(ctx, ids[0]); rerr == nil && run.Status.IsTerminal() {
-				inputs = run.Inputs
+				settled = run
 				break
 			}
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	if inputs == nil {
+	if settled == nil {
 		t.Fatal("no run settled from the card")
+	}
+	inputs := settled.Inputs
+
+	// The run must persist its card as SourceRef (Rf72821): the fork-adoption
+	// sweep resolves an issue's runs through the indexed ListRunsBySourceIssue
+	// reverse edge, which exists only if the board launch stamps
+	// Source.IssueID — the card→run SetLastRun stamp alone leaves the sweep's
+	// search empty forever.
+	if settled.Source == nil || settled.Source.IssueID != "card1" {
+		t.Fatalf("run.Source = %+v, want the dispatched card stamped (IssueID=card1)", settled.Source)
+	}
+	if settled.Source.Kind != store.RunSourceKindDispatcher {
+		t.Errorf("run.Source.Kind = %q, want %q (the cloud board dispatcher IS a dispatcher launch)", settled.Source.Kind, store.RunSourceKindDispatcher)
+	}
+	if ids, err := rs.ListRunsBySourceIssue(ctx, "card1"); err != nil || len(ids) != 1 || ids[0] != settled.ID {
+		t.Errorf("ListRunsBySourceIssue(card1) = %v, %v — the sweep's reverse edge must resolve the board-dispatched run", ids, err)
 	}
 
 	if got, _ := inputs["gate_context"].(string); got != "iterion/review" {
@@ -541,6 +569,11 @@ func TestBoardDispatcher_SweepAdoptsFinishedFork(t *testing.T) {
 		card("native:live", native.StateInProgress, "run-live"),
 		card("native:forkless", native.StateInProgress, "run-dead3"),
 		card("native:finished", native.StateInProgress, "run-fin"),
+		// blocked + finished pointer: an operator dragged a done card to
+		// Blocked to flag a bad outcome — the direct-file branch must not
+		// override that placement (R751dc1); only in_progress is the
+		// dispatcher's own orphan window.
+		card("native:blockedfin", native.StateBlocked, "run-fin2"),
 		card("native:noptr", native.StateInProgress, ""),
 	)
 	statuses := map[string]store.RunStatus{
@@ -549,6 +582,7 @@ func TestBoardDispatcher_SweepAdoptsFinishedFork(t *testing.T) {
 		"run-dead3": store.RunStatusFailed,
 		"run-live":  store.RunStatusRunning,
 		"run-fin":   store.RunStatusFinished,
+		"run-fin2":  store.RunStatusFinished,
 	}
 	pointers := map[string]*store.Run{
 		"run-dead":  {ID: "run-dead", Status: store.RunStatusFailed, CreatedAt: older},
@@ -596,10 +630,11 @@ func TestBoardDispatcher_SweepAdoptsFinishedFork(t *testing.T) {
 	}
 	var amu sync.Mutex
 	adopted := map[string][2]string{}
-	d.adoptRun = func(_, cardID, runID, workdir string) {
+	d.adoptRun = func(_, cardID, runID, workdir string) error {
 		amu.Lock()
 		adopted[cardID] = [2]string{runID, workdir}
 		amu.Unlock()
+		return nil
 	}
 
 	d.sweepForkAdoptions(context.Background())
@@ -619,8 +654,10 @@ func TestBoardDispatcher_SweepAdoptsFinishedFork(t *testing.T) {
 	if _, ok := adopted["native:finished"]; ok {
 		t.Errorf("native:finished must be filed outright, not adopted: %v", adopted["native:finished"])
 	}
-	// Live pointer, missing pointer and forkless failure stay put.
-	for _, id := range []string{"native:live", "native:noptr", "native:forkless"} {
+	// Live pointer, missing pointer, forkless failure — and a BLOCKED card
+	// whose pointer finished (an operator placement, not a dispatcher
+	// orphan; R751dc1) — stay put.
+	for _, id := range []string{"native:live", "native:noptr", "native:forkless", "native:blockedfin"} {
 		if got, moved := f.states[id]; moved {
 			t.Errorf("card %s must stay put, was moved to %q", id, got)
 		}
@@ -640,6 +677,49 @@ func TestBoardDispatcher_SweepAdoptsFinishedFork(t *testing.T) {
 	// Nil wiring (sweep disabled) must be a hard no-op, not a panic.
 	d2 := newBoardDispatcher(f, func(context.Context, string, native.Issue) error { return nil }, "replica-A", 4, nil)
 	d2.sweepForkAdoptions(context.Background())
+}
+
+// TestBoardDispatcher_SweepSkipsFilingOnStampFailure: done is terminal for
+// the sweep ({in_progress, blocked} is all it lists), so a card filed done
+// while SetLastRun failed would show a Done card pointing at the FAILED
+// parent forever — no later tick revisits it. A stamp error must therefore
+// skip the SetState, mirroring the local twin's guard
+// (pipeline_admission.go). Re9efb2.
+func TestBoardDispatcher_SweepSkipsFilingOnStampFailure(t *testing.T) {
+	older := time.Now().Add(-time.Hour)
+	ended := older.Add(30 * time.Minute)
+	f := newFakeBoardCoord(boardmongo.Candidate{
+		Tenant: "t1",
+		Issue:  native.Issue{ID: "native:stuck", State: native.StateInProgress, LastRunID: "run-dead"},
+	})
+	d := newBoardDispatcher(f, func(context.Context, string, native.Issue) error {
+		t.Fatal("the fork-adoption sweep must never dispatch a card")
+		return nil
+	}, "replica-A", 4, nil)
+	d.statusFor = func(context.Context, string, string) (store.RunStatus, error) {
+		return store.RunStatusFailed, nil
+	}
+	d.runFor = func(context.Context, string, string) (*store.Run, error) {
+		return &store.Run{ID: "run-dead", Status: store.RunStatusFailed, CreatedAt: older}, nil
+	}
+	d.issueRuns = func(context.Context, string, string) ([]*store.Run, error) {
+		return []*store.Run{
+			{ID: "run-dead", Status: store.RunStatusFailed, CreatedAt: older,
+				Source: &store.RunSource{IssueID: "native:stuck"}},
+			{ID: "run-fork", Status: store.RunStatusFinished, CreatedAt: older.Add(10 * time.Minute),
+				FinishedAt: &ended, ForkedFrom: "run-dead",
+				Source: &store.RunSource{IssueID: "native:stuck"}},
+		}, nil
+	}
+	d.adoptRun = func(string, string, string, string) error {
+		return errors.New("mongo blip")
+	}
+
+	d.sweepForkAdoptions(context.Background())
+
+	if got, moved := f.states["native:stuck"]; moved {
+		t.Errorf("stamp failed but the card was filed to %q — it now points at the dead parent and can never self-heal", got)
+	}
 }
 
 // TestBoardIssueRuns: the fork-adoption sweep reads an issue's runs through
@@ -714,7 +794,9 @@ func TestAdoptCardRun(t *testing.T) {
 	s := &Server{}
 	s.cfg.CloudBoardFor = func(string) native.BoardStore { return boardStore }
 
-	s.adoptCardRun("t1", iss.ID, "run-fork", "/wt/fork")
+	if err := s.adoptCardRun("t1", iss.ID, "run-fork", "/wt/fork"); err != nil {
+		t.Fatalf("adoptCardRun: %v", err)
+	}
 	got, err := boardStore.Get(iss.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -722,5 +804,12 @@ func TestAdoptCardRun(t *testing.T) {
 	if got.LastRunID != "run-fork" || got.LastWorkdir != "/wt/fork" {
 		t.Fatalf("card pointer = (%q, %q), want (run-fork, /wt/fork)", got.LastRunID, got.LastWorkdir)
 	}
-	(&Server{}).adoptCardRun("t1", iss.ID, "run-x", "") // CloudBoardFor nil → no-op
+	// A failed stamp must SURFACE (the sweep skips the done filing on it),
+	// while a missing seam stays a silent no-op (nothing to converge with).
+	if err := s.adoptCardRun("t1", "native:no-such-card", "run-y", ""); err == nil {
+		t.Error("stamping a missing card must return the store error, got nil")
+	}
+	if err := (&Server{}).adoptCardRun("t1", iss.ID, "run-x", ""); err != nil { // CloudBoardFor nil → no-op
+		t.Errorf("nil seam must be a silent no-op, got %v", err)
+	}
 }

--- a/pkg/server/server_lifecycle.go
+++ b/pkg/server/server_lifecycle.go
@@ -331,6 +331,12 @@ func (s *Server) ListenAndServe() error {
 			// and clear the denormalized ⏸ badge when the sweep moves a card.
 			d.statusFor = s.boardRunStatus
 			d.clearBadge = func(tenant, id string) { s.setCardAwaitingInput(tenant, id, false) }
+			// Fork-adoption sweep wiring: full run record + the issue's runs
+			// (tenant-scoped) to resolve a finished fork, and the CloudBoardFor
+			// seam to adopt it onto the stranded card.
+			d.runFor = s.boardRun
+			d.issueRuns = s.boardIssueRuns
+			d.adoptRun = s.adoptCardRun
 			d.run(ctx)
 		}()
 	}


### PR DESCRIPTION
## Problème (#379)

`reconcileFinishedTickets` (pkg/server/pipeline_admission.go) — le sweep qui adopte un fork de récupération **terminé** comme `LastRunID` puis classe le ticket `done` (cascade vers les dépendants en `waiting_deps`) — est gated mode local (`pipelineAdmissionEnabled` retourne false en cloud), alors que la projection board qui laisse un fork remplacer son parent mort sur la carte (#377) tourne aussi en cloud.

Conséquence : en cloud, un fork terminé prenait la carte (Closed) mais aucun sweep ne l'adoptait jamais — le ticket restait `in_progress` indéfiniment et ses dépendants en `waiting_deps`.

## Correctif

Nouveau sweep `sweepForkAdoptions` sur le board dispatcher cloud (à côté de `sweepParked`) : pour les cartes non claimées échouées en `in_progress`/`blocked` sur un pointeur terminal-mais-pas-finished, il résout le fork le plus récent de l'issue **réellement terminé** (`FinishedAt != nil` — un shell parqué ne qualifie jamais), l'adopte via la seam `CloudBoardFor` (`SetLastRun` avec le workdir du fork, cf. R26faf1), puis classe la carte `done` — le `SetState` du store tenant cascade la promotion `waiting_deps`. Une carte dont le pointeur lui-même a fini proprement est classée directement (fenêtre orpheline entre la fin du run et le move de `processCard`).

## Coût (cf. Rc2c8ed)

- la recherche de fork passe par l'arête indexée `ListRunsBySourceIssue` (index Mongo `(tenant_id, source.issue_id, created_at)`) — **jamais** de scan complet du store ;
- elle ne tourne que pour les cartes réellement bloquées sur un pointeur mort ;
- les résultats négatifs sont mémoïsés par (tenant, issue) pour 30s — une failure abandonnée ne devient pas une requête par tick à vie.

Multi-replica sans leader election : le choix du fork est déterministe, `SetLastRun`/`SetState` sont idempotents pour les mêmes valeurs, et ni `in_progress` ni `blocked` ne sont dans `eligible` — aucune carte classée n'est re-dispatchée. Le sweep ne voit que les cartes **non claimées** (`ListEligible`) : pas de course avec un `processCard` vivant.

## Tests

- `TestBoardDispatcher_SweepAdoptsFinishedFork` : adoption du fork terminé (in_progress **et** blocked), fork parqué plus récent ignoré, carte au pointeur finished classée directement, pointeur live / sans pointeur / sans fork laissés en place, mémo négative (1 recherche par issue sur 2 sweeps), wiring nil = no-op
- `TestBoardIssueRuns` : la seam passe par `ListRunsBySourceIssue`, filtrée par issue
- `TestAdoptCardRun` : le stamp conserve le workdir du fork

Closes #379