### PR TITLE
fix(forge): unbreak the dep-update lane's dead-gate recovery

### DIFF
--- a/bots/dep-update-guard/manifest.yaml
+++ b/bots/dep-update-guard/manifest.yaml
@@ -1,7 +1,12 @@
 name: dep-update-guard
 display_name: Vetty
 icon: 💂
-version: 2.7.6
+version: 2.7.7
+## 2.7.7 -- verify-build skill §1c: timeouts are a strictness axis. The verify
+## sandbox runs 2-5x slower than CI, and go test's implicit 10m per-binary
+## timeout manufactured hold_unstable on four consecutive Actions-pin bumps
+## while CI was green on the identical shas. The skill now requires keeping
+## CI's explicit timeouts and RAISING the implicit ones (e.g. -timeout 30m).
 ## 2.7.6 -- a verify that overruns is a red build, not a crashed run. The
 ## TimeoutExpired handler concatenated e.output to a str, and on the timeout
 ## path that attribute is BYTES even though text=True was passed (the decode

--- a/bots/dep-update-guard/skills/verify-build.md
+++ b/bots/dep-update-guard/skills/verify-build.md
@@ -120,7 +120,20 @@ verdict in production:
   exact invocation — flags included — from the CI step or the task-runner
   target CI calls; when in doubt, run the repo's own umbrella target
   (`task check`, `make ci`) INSTEAD of hand-assembling steps.
-- **Call the target; never transcribe its body.** When a task runner defines
+- **Timeouts are a strictness axis — your sandbox is SLOWER than CI.** A
+  wall-clock limit is a threshold like any other, and the verify sandbox
+  (shared CPU, cold caches) routinely runs the same suite 2-5× slower than
+  the repo's CI runners. Go's default per-binary `go test` timeout is 10m:
+  a suite that takes 6m in CI dies at 10m in a throttled pod with
+  `panic: test timed out` — a red that says nothing about the bump
+  (observed live: four consecutive GitHub-Actions pin bumps held
+  `hold_unstable` because the repo's e2e package outran 10m in the sandbox
+  while the repo's CI was green on the identical shas). So: keep every
+  explicit timeout CI sets, and RAISE — never lower — the implicit ones:
+  pass a generous `-timeout` (e.g. 3× the CI duration, `-timeout 30m`) to
+  `go test`, and give `verify.sh` itself headroom over the suite's worst
+  observed wall-clock. A longer timeout is LESS strict and therefore always
+  legitimate; a tighter one manufactures reds CI would not show.
   the step, `verify.sh` invokes `task <target>` — it does not copy what that
   target runs. A Taskfile/Makefile command is frequently a multi-line shell
   block, and a block does not survive being passed as one `sh -c` argument:

--- a/docs/bot-runs/feed-watch.md
+++ b/docs/bot-runs/feed-watch.md
@@ -4,6 +4,32 @@
 
 Newest first. One section per dogfooded run.
 
+## 2026-08-24 — period headlines reversed to send-date titles (runs 01a03268 / 01a032d6)
+- Status: validated (probe) · tsjs delivery pending its 09:08 UTC usage-window resume
+- Versions: bot 1.4.0 · iterion 359668383
+- Method: operator arbitrage after PR #452's window-dating shipped — cyber titled
+  "21 → 24 août", gopyrust "30 juillet → 24 août" after two quota-dead Mondays.
+  New contract: the headline names digest_title + the SEND date only
+  (deterministic `digest_date` emitted by load_pending, checkpointed at
+  queue-drain time); #452's anti-breaking spirit stays as one body clause when
+  span_days > 1. Validated by a local dry-run probe (11-day span → title
+  "24 août 2026" alone, window in the body). Adversarial review (2 agents):
+  no high/critical; MEDIUM accepted+documented (digest_date frozen across a
+  cross-midnight resume — off by the resume lag, body note stays correct);
+  pre-existing digests.jsonl malformed-line crash now skips loudly.
+- Ops findings the same morning: tsjs 06:15 burned its full 30-min duration
+  budget in usage-cap-throttled delegate retries (soft 5h cap at 85%) before
+  dying on BUDGET_EXCEEDED (not auto-resumed, by design); the relaunched run
+  parked cleanly in 15s with a typed session-limit error and an armed 09:08
+  retry — the fail-fast vs budget-burn contrast is worth an engine look
+  (native board candidate: bound delegate usage-cap retries under a soft cap
+  so a capped node parks resumable instead of eating its duration budget).
+- Engine hardening (same session, separate commit): `iterion remote teams
+  switch` was broken for every account — the CLI decoded a removed flat
+  `teams` field from /api/auth/me (fix: RemoteMe aliases the server's own
+  response type; membership authority = the mint endpoint's canViewTeam; the
+  mint now states the pinned team's org).
+
 ## 2026-08-19 — the veille came back, and the bot learned to report its own silence
 
 - Status: **resolved** (the 13→18 outage) + hardening shipped

--- a/docs/bot-runs/feed-watch.md
+++ b/docs/bot-runs/feed-watch.md
@@ -4,32 +4,6 @@
 
 Newest first. One section per dogfooded run.
 
-## 2026-08-24 — period headlines reversed to send-date titles (runs 01a03268 / 01a032d6)
-- Status: validated (probe) · tsjs delivery pending its 09:08 UTC usage-window resume
-- Versions: bot 1.4.0 · iterion 359668383
-- Method: operator arbitrage after PR #452's window-dating shipped — cyber titled
-  "21 → 24 août", gopyrust "30 juillet → 24 août" after two quota-dead Mondays.
-  New contract: the headline names digest_title + the SEND date only
-  (deterministic `digest_date` emitted by load_pending, checkpointed at
-  queue-drain time); #452's anti-breaking spirit stays as one body clause when
-  span_days > 1. Validated by a local dry-run probe (11-day span → title
-  "24 août 2026" alone, window in the body). Adversarial review (2 agents):
-  no high/critical; MEDIUM accepted+documented (digest_date frozen across a
-  cross-midnight resume — off by the resume lag, body note stays correct);
-  pre-existing digests.jsonl malformed-line crash now skips loudly.
-- Ops findings the same morning: tsjs 06:15 burned its full 30-min duration
-  budget in usage-cap-throttled delegate retries (soft 5h cap at 85%) before
-  dying on BUDGET_EXCEEDED (not auto-resumed, by design); the relaunched run
-  parked cleanly in 15s with a typed session-limit error and an armed 09:08
-  retry — the fail-fast vs budget-burn contrast is worth an engine look
-  (native board candidate: bound delegate usage-cap retries under a soft cap
-  so a capped node parks resumable instead of eating its duration budget).
-- Engine hardening (same session, separate commit): `iterion remote teams
-  switch` was broken for every account — the CLI decoded a removed flat
-  `teams` field from /api/auth/me (fix: RemoteMe aliases the server's own
-  response type; membership authority = the mint endpoint's canViewTeam; the
-  mint now states the pinned team's org).
-
 ## 2026-08-19 — the veille came back, and the bot learned to report its own silence
 
 - Status: **resolved** (the 13→18 outage) + hardening shipped

--- a/e2e/async_interaction_test.go
+++ b/e2e/async_interaction_test.go
@@ -117,6 +117,68 @@ func TestAwaitAnswersReleasedByAnswer(t *testing.T) {
 	}
 }
 
+// TestAwaitAnswersDoorbellNeverMissed asserts the in-process doorbell
+// is a RELIABLE release mechanism (arm-before-check invariant) — not a
+// happy-path best-effort layered over the level-poll. The fixture pins
+// a large poll (via awaitAnswersPollInterval override) AND a large node
+// timeout so ONLY the doorbell can release the parked gate branch in
+// the test's 3s ceiling: if a ring landed in the [check … arm] gap and
+// were dropped, the test would deadline instead of converging. Repeat
+// the launch/answer cycle many times to stress every possible
+// interleaving of the ring with the branch scheduler.
+func TestAwaitAnswersDoorbellNeverMissed(t *testing.T) {
+	// Force the fallback poll well outside the test's convergence
+	// budget. If the doorbell is missed, nothing else releases the
+	// gate within 3s.
+	prev := runtime.SetAwaitAnswersPollInterval(60 * time.Second)
+	t.Cleanup(func() { runtime.SetAwaitAnswersPollInterval(prev) })
+
+	wf := compileFixture(t, "async_await_mini.bot")
+
+	// Many iterations: each one is a fresh engine + fresh store + fresh
+	// run, exercising the arm-check-select window against the ring in
+	// every scheduler interleaving. A missed ring on ANY iteration
+	// hangs that iteration and trips the ceiling.
+	const iters = 10
+	for i := 0; i < iters; i++ {
+		s := tmpStore(t)
+		runID := "e2e-async-doorbell"
+		iid := runID + "_asker_async_1"
+		seedAsyncInteraction(t, s, runID, "asker", iid, "ship it?")
+
+		eng := runtime.New(wf, s, newScenarioExecutor())
+		done := make(chan error, 1)
+		go func() { done <- eng.Run(context.Background(), runID, nil) }()
+
+		// Small sleep so the gate branch has a chance to reach the arm
+		// (best case exercises the doorbell wake). No sleep would still
+		// pass — the pre-arm answer is caught by the store check — but
+		// this is the interleaving the observed slow-pod failure hits.
+		time.Sleep(50 * time.Millisecond)
+		if _, err := store.AnswerInteraction(context.Background(), s, runID, iid, map[string]any{delegate.AskUserQuestionKey: "yes"}); err != nil {
+			t.Fatalf("iter %d: answer interaction: %v", i, err)
+		}
+		eng.NotifyInteractionAnswered()
+
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("iter %d: run: %v", i, err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Fatalf("iter %d: run did not converge in 3s — doorbell missed (poll=60s and node timeout=30s both well outside this window)", i)
+		}
+
+		r, err := s.LoadRun(context.Background(), runID)
+		if err != nil {
+			t.Fatalf("iter %d: load run: %v", i, err)
+		}
+		if r.Status != store.RunStatusFinished {
+			t.Fatalf("iter %d: status = %s, want finished", i, r.Status)
+		}
+	}
+}
+
 // TestAwaitAnswersTimeout: an unanswered question bounds the wait at
 // the node's mandatory timeout and fails the run with an explicit
 // timeout error naming the pending interaction.

--- a/e2e/async_interaction_test.go
+++ b/e2e/async_interaction_test.go
@@ -165,8 +165,14 @@ func TestAwaitAnswersDoorbellNeverMissed(t *testing.T) {
 			if err != nil {
 				t.Fatalf("iter %d: run: %v", i, err)
 			}
-		case <-time.After(3 * time.Second):
-			t.Fatalf("iter %d: run did not converge in 3s — doorbell missed (poll=60s and node timeout=30s both well outside this window)", i)
+		// The ceiling bounds a FULL engine lifecycle, not just the doorbell
+		// wake: under -race on a loaded CI runner one iteration takes
+		// several seconds before the gate node even parks (observed: 3s
+		// tripped on iter 0 in CI while 30 local -race runs stayed <2s).
+		// 15s keeps the discriminant intact — the poll is at 60s and the
+		// node timeout at 30s, so only the doorbell can release in time.
+		case <-time.After(15 * time.Second):
+			t.Fatalf("iter %d: run did not converge in 15s — doorbell missed (poll=60s and node timeout=30s both well outside this window)", i)
 		}
 
 		r, err := s.LoadRun(context.Background(), runID)

--- a/e2e/testdata/async_await_mini.bot
+++ b/e2e/testdata/async_await_mini.bot
@@ -23,8 +23,15 @@ compute side:
   expr:
     n: "outputs.prep.n"
 
+## Timeout is well ABOVE the 5s awaitAnswersPollInterval so the level-poll
+## fallback wins the select over the deadline even under timer starvation
+## on a loaded pod (a same-duration timeout races the poll ticker and, at
+## coincident firing times, `select` picks randomly — a 50/50 timeout on
+## an already-answered question). The in-process doorbell (rung by the
+## test's NotifyInteractionAnswered) still releases the branch within ms
+## on the happy path; this bound only matters as the belt-and-braces.
 await_answers gate:
-  timeout: "5s"
+  timeout: "30s"
 
 compute gather:
   await: wait_all

--- a/pkg/git/safety.go
+++ b/pkg/git/safety.go
@@ -199,3 +199,39 @@ func ValidateBranchName(name string) error {
 	}
 	return nil
 }
+
+// shellUnsafeRefBytes are the bytes that let a ref name break out of a shell
+// command it is interpolated into. Deliberately NOT parentheses: Renovate's
+// grouped branches (`renovate/npm-(non-major)`) are legitimate and must keep
+// flowing, and a paren in an unquoted assignment is a bash *syntax error* —
+// the tool node fails loudly, which is a bug to fix in the bot, not a way in.
+// These bytes are different in kind: each one ENDS the current word or
+// command and starts attacker-chosen text.
+const shellUnsafeRefBytes = ";|&$`'\"<>\n\r\\!"
+
+// ValidateShellSafeRef gates a ref name that travels further than git: as a
+// launch var a bot interpolates into a shell command, or as a value the
+// runner stamps into an environment assignment.
+//
+// This is a SEPARATE gate from ValidateBranchName on purpose. That one must
+// stay faithful to `git check-ref-format` so Renovate's grouped branches can
+// be fetched at all; git's own rules happily accept `;`, backticks and
+// quotes, which are harmless to git and fatal to `bash -c`. The old narrow
+// allowlist covered both jobs at once, so widening it for Renovate silently
+// removed a shell guard that was load-bearing: a fork PR from a branch named
+// `x;id;#` reaches `PUSH_BRANCH={{vars.push_branch}} python3 -c …`
+// (bots/branch-improve-loop) as a second command, inside a sandbox holding
+// the run's forge token.
+//
+// Applied where FORGE-CONTROLLED refs enter the system — the runner's clone
+// target, which every webhook-launched run passes through — never to an
+// operator's own `--branch-name`, which is not attacker-controlled.
+func ValidateShellSafeRef(name string) error {
+	if err := ValidateBranchName(name); err != nil {
+		return err
+	}
+	if i := strings.IndexAny(name, shellUnsafeRefBytes); i >= 0 {
+		return fmt.Errorf("git: ref %q contains %q, which is legal in git but would break out of a shell command the ref is interpolated into", name, string(name[i]))
+	}
+	return nil
+}

--- a/pkg/git/safety.go
+++ b/pkg/git/safety.go
@@ -148,6 +148,19 @@ func ValidateBranchName(name string) error {
 	if strings.HasPrefix(name, "-") {
 		return fmt.Errorf("git: branch name %q must not start with '-' (would be parsed as a flag)", name)
 	}
+	// git itself accepts a leading '+' in a branch NAME, but several callers
+	// place the validated value in a refspec position (`git fetch origin
+	// <ref>`), where '+' is the force sigil and silently changes what is
+	// fetched. No dependency bot generates such names; refusing is the safe
+	// uniform rule.
+	if strings.HasPrefix(name, "+") {
+		return fmt.Errorf("git: branch name %q must not start with '+' (a refspec force sigil)", name)
+	}
+	// `git check-ref-format --branch HEAD` refuses it too; accepting it here
+	// only defers to a noisier failure at `git checkout -B`.
+	if name == "HEAD" {
+		return fmt.Errorf("git: branch name must not be 'HEAD'")
+	}
 	// git check-ref-format: no spaces, no control bytes, and none of the
 	// ref-syntax metacharacters. Byte-wise walk is UTF-8 safe — multi-byte
 	// runes are all >= 0x80 and pass through untouched.

--- a/pkg/git/safety.go
+++ b/pkg/git/safety.go
@@ -3,7 +3,6 @@ package git
 import (
 	"fmt"
 	"path/filepath"
-	"regexp"
 	"strings"
 )
 
@@ -58,14 +57,6 @@ func ValidateRelPath(p string) error {
 	}
 	return nil
 }
-
-// branchNameAllowed accepts an alphanumeric, hyphen, underscore, dot
-// or slash sequence. The leading byte must be alphanumeric so a value
-// starting with `-` can never reach `git branch` as a positional that
-// might be re-parsed as a flag (defense in depth — callers should also
-// pass `--` to git, but this catches the bug earlier with a friendly
-// error).
-var branchNameAllowed = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._/-]*$`)
 
 // ValidateCloneSource gates the URL passed to `git clone`. The `--` sentinel
 // in ShallowClone already blocks command-line flag injection, but it does NOT
@@ -133,17 +124,20 @@ func ValidateCloneSource(src string) error {
 	return fmt.Errorf("git: clone source %q is not a supported git transport (only https:// and ssh git URLs are allowed; install a local bundle by its directory path instead)", src)
 }
 
-// ValidateBranchName accepts a branch name coming from a user-controlled
-// surface (`--branch-name` CLI flag, Launch API, studio modal) and
-// rejects forms that could either confuse `git branch` flag parsing or
-// be rejected by `git check-ref-format` downstream — failing early with
-// a clear error rather than surfacing a noisy git stderr to the caller.
+// ValidateBranchName accepts a branch/ref name coming from a user-controlled
+// surface (`--branch-name` CLI flag, Launch API, studio modal, webhook repo
+// refs) and rejects forms that could either confuse git flag parsing or be
+// rejected by `git check-ref-format` downstream — failing early with a clear
+// error rather than surfacing a noisy git stderr to the caller.
 //
-// The rules are intentionally tighter than git's own check-ref-format:
-// we want a small allowlist (letters, digits, `.`, `_`, `/`, `-`) so
-// every accepted value also passes git's checks. Combined with the
-// `--` sentinel used by callers, this prevents flag injection through
-// the storage-branch name.
+// The rules mirror git's own check-ref-format for a one-level ref, with ONE
+// deliberate extra: a leading `-` is refused so a value can never reach a git
+// invocation as something an argv parser might re-read as a flag (defense in
+// depth — callers also pass `--`). Everything else git accepts is accepted
+// here — parentheses, `+`, `@` inside a name, non-ASCII. An earlier allowlist
+// ([A-Za-z0-9][A-Za-z0-9._/-]*) rejected legal names: Renovate's grouped
+// branches (`renovate/npm-(non-major)`) could never be fetched, which made
+// their PRs permanently unreviewable on the webhook lane.
 func ValidateBranchName(name string) error {
 	if name == "" {
 		return fmt.Errorf("git: branch name must not be empty")
@@ -151,23 +145,44 @@ func ValidateBranchName(name string) error {
 	if len(name) > 255 {
 		return fmt.Errorf("git: branch name must be at most 255 bytes")
 	}
-	if strings.ContainsRune(name, 0) {
-		return fmt.Errorf("git: branch name contains null byte")
+	if strings.HasPrefix(name, "-") {
+		return fmt.Errorf("git: branch name %q must not start with '-' (would be parsed as a flag)", name)
 	}
-	if !branchNameAllowed.MatchString(name) {
-		return fmt.Errorf("git: branch name %q must match [A-Za-z0-9][A-Za-z0-9._/-]* (no leading -/./_, no spaces or special chars)", name)
+	// git check-ref-format: no spaces, no control bytes, and none of the
+	// ref-syntax metacharacters. Byte-wise walk is UTF-8 safe — multi-byte
+	// runes are all >= 0x80 and pass through untouched.
+	for i := 0; i < len(name); i++ {
+		b := name[i]
+		if b <= 0x20 || b == 0x7f {
+			return fmt.Errorf("git: branch name %q contains a space or control character", name)
+		}
+		switch b {
+		case '~', '^', ':', '?', '*', '[', '\\':
+			return fmt.Errorf("git: branch name %q contains %q, which git check-ref-format refuses", name, string(rune(b)))
+		}
+	}
+	if name == "@" {
+		return fmt.Errorf("git: branch name must not be the single character '@'")
+	}
+	if strings.Contains(name, "@{") {
+		return fmt.Errorf("git: branch name %q must not contain '@{'", name)
 	}
 	if strings.Contains(name, "..") {
 		return fmt.Errorf("git: branch name %q must not contain '..'", name)
 	}
-	if strings.Contains(name, "//") {
-		return fmt.Errorf("git: branch name %q must not contain '//'", name)
+	if strings.HasPrefix(name, "/") || strings.HasSuffix(name, "/") || strings.Contains(name, "//") {
+		return fmt.Errorf("git: branch name %q must not start or end with '/' or contain '//'", name)
 	}
-	if strings.HasSuffix(name, "/") || strings.HasSuffix(name, ".") {
-		return fmt.Errorf("git: branch name %q must not end with '/' or '.'", name)
+	if strings.HasSuffix(name, ".") {
+		return fmt.Errorf("git: branch name %q must not end with '.'", name)
 	}
-	if strings.HasSuffix(name, ".lock") {
-		return fmt.Errorf("git: branch name %q must not end with '.lock'", name)
+	for _, seg := range strings.Split(name, "/") {
+		if strings.HasPrefix(seg, ".") {
+			return fmt.Errorf("git: branch name %q has a path component starting with '.'", name)
+		}
+		if strings.HasSuffix(seg, ".lock") {
+			return fmt.Errorf("git: branch name %q has a path component ending with '.lock'", name)
+		}
 	}
 	return nil
 }

--- a/pkg/git/safety_test.go
+++ b/pkg/git/safety_test.go
@@ -13,6 +13,16 @@ func TestValidateBranchName(t *testing.T) {
 		"v1.2.3",
 		"hot-fix",
 		"a.b.c/d_e",
+		// git check-ref-format accepts all of these; the old allowlist
+		// refused them and made Renovate's grouped branches unreviewable.
+		"renovate/npm-(non-major)",
+		"renovate/major-(major)-updates",
+		"feat+plus",
+		"topic@2024",
+		"a=b",
+		"héllo-branche",
+		"_under",
+		"deps/bump#42",
 	}
 	for _, name := range valid {
 		if err := ValidateBranchName(name); err != nil {
@@ -29,7 +39,9 @@ func TestValidateBranchName(t *testing.T) {
 		{"--force", "looks like a long flag"},
 		{"/abs", "leading slash"},
 		{".hidden", "leading dot"},
-		{"_under", "leading underscore"},
+		{"x/.hidden", "component starting with dot"},
+		{"x.lock/y", "component ending with .lock"},
+		{"@", "the single character @"},
 		{"feat with space", "space"},
 		{"feat\ttab", "tab"},
 		{"feat:colon", "colon (git ref-format)"},

--- a/pkg/git/safety_test.go
+++ b/pkg/git/safety_test.go
@@ -75,3 +75,56 @@ func TestValidateBranchName(t *testing.T) {
 		t.Errorf("ValidateBranchName(256 bytes) = nil, want error")
 	}
 }
+
+// The widening of ValidateBranchName to git's own rules removed a guard that
+// was silently load-bearing: git happily accepts `;`, backticks and quotes,
+// and a forge-controlled branch name travels on as a launch var that bots
+// interpolate into `bash -c` (bots/branch-improve-loop's
+// `PUSH_BRANCH={{vars.push_branch}} python3 -c …`, unquoted). The shell gate
+// is separate so Renovate's grouped branches keep flowing.
+func TestValidateShellSafeRef(t *testing.T) {
+	t.Parallel()
+
+	mustPass := []string{
+		"main",
+		"renovate/npm-(non-major)", // the whole point of the widening
+		"renovate/major-(major)-x", // parens: bash syntax error at worst, never RCE
+		"dependabot/go_modules/x-1.2.3",
+		"iterion/improve/019f-abcd",
+		"feat+plus",
+		"héllo-branche",
+	}
+	for _, name := range mustPass {
+		if err := ValidateShellSafeRef(name); err != nil {
+			t.Errorf("ValidateShellSafeRef(%q) = %v, want nil — a legitimate bot branch must still flow", name, err)
+		}
+	}
+
+	// Each of these ENDS the current word or command and starts
+	// attacker-chosen text. git accepts every one of them.
+	mustFail := []struct{ name, why string }{
+		{"x;id;#", "command separator — the live RCE shape in an unquoted assignment"},
+		{"x|id", "pipe"},
+		{"x&id", "background + separator"},
+		{"x$(id)", "command substitution"},
+		{"x`id`", "backtick substitution"},
+		{"x'y", "single quote closes a bot's SCOPE_MODE='…' quoting"},
+		{"x\"y", "double quote"},
+		{"x<y", "redirect in"},
+		{"x>y", "redirect out"},
+		{"x!y", "history expansion"},
+		{"-x", "flag injection (inherited from ValidateBranchName)"},
+	}
+	for _, tc := range mustFail {
+		if err := ValidateShellSafeRef(tc.name); err == nil {
+			t.Errorf("ValidateShellSafeRef(%q) = nil, want error (%s)", tc.name, tc.why)
+		}
+	}
+
+	// The two gates are deliberately different: git-faithful for fetching,
+	// shell-safe for interpolating. A test that let them collapse into one
+	// would hide the next regression in either direction.
+	if err := ValidateBranchName("x;id;#"); err != nil {
+		t.Errorf("ValidateBranchName(%q) = %v, want nil — it must stay faithful to git check-ref-format", "x;id;#", err)
+	}
+}

--- a/pkg/git/safety_test.go
+++ b/pkg/git/safety_test.go
@@ -37,6 +37,8 @@ func TestValidateBranchName(t *testing.T) {
 		{"", "empty"},
 		{"-force", "leading dash (flag injection)"},
 		{"--force", "looks like a long flag"},
+		{"+force", "leading plus (refspec force sigil at fetch call sites)"},
+		{"HEAD", "git check-ref-format --branch refuses it"},
 		{"/abs", "leading slash"},
 		{".hidden", "leading dot"},
 		{"x/.hidden", "component starting with dot"},

--- a/pkg/runner/loop_gitws.go
+++ b/pkg/runner/loop_gitws.go
@@ -337,7 +337,7 @@ func seedRunScratchIgnore(dir string) {
 // validateRepoTarget gates the webhook-sourced clone URL and ref before
 // they reach git. It rejects remote-helper transports (`ext::`, `file://`)
 // via ValidateCloneSource and flag-shaped refs (leading `-`) via
-// ValidateBranchName — the two ways an attacker-controlled RepoURL/RepoSHA
+// ValidateShellSafeRef — the two ways an attacker-controlled RepoURL/RepoSHA
 // could turn `git clone`/`git fetch` into arbitrary command execution.
 // An empty ref is allowed (the caller only fetches when RepoSHA is non-blank).
 //
@@ -353,7 +353,12 @@ func validateRepoTarget(ctx context.Context, repoURL, repoSHA string) (net.IP, e
 		return nil, fmt.Errorf("runner: reject repo url: %w", err)
 	}
 	if ref := strings.TrimSpace(repoSHA); ref != "" {
-		if err := gitlib.ValidateBranchName(ref); err != nil {
+		// ValidateShellSafeRef, not ValidateBranchName: this ref is forge-
+		// controlled (a PR's source branch arrives here from the webhook) and
+		// the SAME value is stamped into launch vars that bots interpolate
+		// into `bash -c` commands. git's own rules accept `;`, backticks and
+		// quotes; a shell does not survive them.
+		if err := gitlib.ValidateShellSafeRef(ref); err != nil {
 			return nil, fmt.Errorf("runner: reject repo ref: %w", err)
 		}
 	}

--- a/pkg/runtime/await_answers_node.go
+++ b/pkg/runtime/await_answers_node.go
@@ -17,7 +17,22 @@ import (
 // await_answers node is parked. The in-process answersBell wakes it
 // immediately for same-process answers; the poll is the cross-process
 // net (CLI answering the store while the engine runs elsewhere).
-const awaitAnswersPollInterval = 5 * time.Second
+// A package var (not const) so tests can retune it via
+// SetAwaitAnswersPollInterval; production callers never touch it.
+var awaitAnswersPollInterval = 5 * time.Second
+
+// SetAwaitAnswersPollInterval overrides the await_answers store-recheck
+// cadence and returns the previous value so the caller can restore it.
+// TEST-ONLY: a stress test that must isolate the doorbell path from the
+// fallback poll pushes the interval far out; a stress test on the
+// fallback poll itself pushes it in. Nothing outside tests should call
+// this — the production value is deliberately conservative for the
+// cross-process CLI-answer path.
+func SetAwaitAnswersPollInterval(d time.Duration) time.Duration {
+	prev := awaitAnswersPollInterval
+	awaitAnswersPollInterval = d
+	return prev
+}
 
 // awaitAsyncAnswers is the body of an await_answers node (ADR-081): a
 // level-triggered wait until no pending Kind=async interaction remains
@@ -31,6 +46,19 @@ func (e *Engine) awaitAsyncAnswers(ctx context.Context, rs *runState, nodeID str
 	defer ticker.Stop()
 
 	for {
+		// Arm the doorbell BEFORE checking the store. A ring landing after
+		// this arm closes `bell` and wakes the select below; a ring landing
+		// before it is caught by the store check that follows (the answer
+		// is already persisted). The inverse order (check-then-arm) has a
+		// race window: a ring in the [check … arm] gap creates a fresh
+		// channel that the arm returns, and the select then blocks on that
+		// fresh channel until the poll ticker fires — up to a full poll
+		// interval of extra latency, and on a heavily-loaded pod where the
+		// deadline collides with the ticker (same duration for the fixture
+		// timeout AND the poll cadence) the deadline can win the select
+		// and time the branch out on an answered question.
+		bell := e.answersBell.wait()
+
 		pending, err := store.ListPendingAsyncInteractions(ctx, e.store, rs.runID, an.From)
 		if err != nil {
 			return nil, &RuntimeError{
@@ -44,10 +72,6 @@ func (e *Engine) awaitAsyncAnswers(ctx context.Context, rs *runState, nodeID str
 			return e.awaitAnswersOutput(ctx, rs.runID, nodeID, an.From)
 		}
 
-		// Arm the doorbell BEFORE re-checking via select so an answer
-		// landing between the list above and the select cannot be missed
-		// beyond one poll tick.
-		bell := e.answersBell.wait()
 		select {
 		case <-bell:
 		case <-ticker.C:

--- a/pkg/runtime/edge_input_ref_test.go
+++ b/pkg/runtime/edge_input_ref_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
@@ -230,14 +231,23 @@ func TestEdgeInputRef_RouterPassThrough(t *testing.T) {
 		t.Fatalf("router pass-through must not trip C034: %v", msgs)
 	}
 
+	// analyzer_a and analyzer_b run on CONCURRENT fan-out branches — the
+	// shared capture map needs the mutex or the race detector (rightly)
+	// flags the two handler writes. Reads happen after Run returns, past
+	// the engine's join, so they need no lock.
+	var gotMu sync.Mutex
 	got := map[string]any{}
 	exec := newStubExecutor()
 	exec.on("analyzer_a", func(in map[string]any) (map[string]any, error) {
+		gotMu.Lock()
 		got["a"] = in["data"]
+		gotMu.Unlock()
 		return map[string]any{"data": in["data"]}, nil
 	})
 	exec.on("analyzer_b", func(in map[string]any) (map[string]any, error) {
+		gotMu.Lock()
 		got["b"] = in["data"]
+		gotMu.Unlock()
 		return map[string]any{"data": in["data"]}, nil
 	})
 	exec.on("join", func(map[string]any) (map[string]any, error) {

--- a/pkg/runtime/run_failure.go
+++ b/pkg/runtime/run_failure.go
@@ -203,8 +203,23 @@ func (e *Engine) handleContextDoneWithCheckpoint(rs *runState, nodeID string, ct
 		if err := e.store.SaveCheckpoint(storeCtx, rs.runID, cp); err != nil {
 			e.logger.Error("failed to save checkpoint on cancellation: %v", err)
 		}
-		if err := e.store.UpdateRunStatus(storeCtx, rs.runID, store.RunStatusCancelled, "run cancelled"); err != nil {
+		// CAS, not a blind write: in cloud mode the publisher flips the doc to
+		// cancelled WITH a specific reason ("superseded by a newer delivery…",
+		// "cancelled by user") BEFORE the cancel subject reaches this engine.
+		// An unconditional write here would overwrite that reason with the
+		// generic "run cancelled" — which is then what the run list, board
+		// cards and merge-gate synthetic statuses display. Skip the write when
+		// the run is already terminal; the reason recorded first is the truth.
+		cancellable := []store.RunStatus{
+			store.RunStatusRunning,
+			store.RunStatusPausedWaitingHuman,
+			store.RunStatusPausedOperator,
+			store.RunStatusFailedResumable,
+		}
+		if changed, err := e.store.UpdateRunStatusIf(storeCtx, rs.runID, store.RunStatusCancelled, "run cancelled", cancellable); err != nil {
 			e.logger.Error("failed to persist cancellation status: %v", err)
+		} else if !changed {
+			e.logger.Debug("run %s already terminal — keeping the recorded cancellation reason", rs.runID)
 		}
 		if err := e.emit(storeCtx, rs.runID, store.EventRunCancelled, nodeID, map[string]any{
 			"reason": "context cancelled",

--- a/pkg/runview/service_control.go
+++ b/pkg/runview/service_control.go
@@ -33,6 +33,19 @@ func (s *Service) Cancel(runID string) error {
 	return s.manager.Cancel(runID)
 }
 
+// CancelWithReason mirrors Cancel but records WHY on the run (run.Error) —
+// what the run list, board cards and merge-gate synthetic statuses read. An
+// automated caller (the webhook supersede lane) must not sign its cancel
+// "cancelled by user". The in-process manager path has no reason plumbing —
+// the engine stamps its own cancellation semantics — so the reason applies
+// on the cloud path, where the bare status flip IS the record.
+func (s *Service) CancelWithReason(runID, reason string) error {
+	if s.publisher != nil {
+		return s.publisher.CancelRunWithReason(context.Background(), runID, reason)
+	}
+	return s.manager.Cancel(runID)
+}
+
 // CancelInactive flips a persisted-but-not-active run to cancelled status
 // when the operator clicked Cancel on a paused_waiting_human or
 // failed_resumable run. Returns (cancelled, error): cancelled=true means

--- a/pkg/runview/service_launch.go
+++ b/pkg/runview/service_launch.go
@@ -45,6 +45,11 @@ type LaunchPublisher interface {
 	// flips the Mongo doc to cancelled regardless of whether a runner
 	// is currently holding the lease.
 	CancelRun(ctx context.Context, runID string) error
+	// CancelRunWithReason is CancelRun with an explicit reason recorded
+	// on the run (run.Error). Automated cancellations — the webhook
+	// supersede lane — pass what actually happened; CancelRun stays the
+	// operator-click shape ("cancelled by user").
+	CancelRunWithReason(ctx context.Context, runID, reason string) error
 	// SubmitResume republishes a RunMessage with ResumeSpec set so
 	// the runner picks the run back up.
 	SubmitResume(ctx context.Context, spec ResumeSpec, wf *ir.Workflow, hash string) error

--- a/pkg/runview/service_launch_budget_test.go
+++ b/pkg/runview/service_launch_budget_test.go
@@ -126,6 +126,9 @@ func (p *stubLaunchPublisher) SubmitLaunch(_ context.Context, _ string, spec Lau
 	return 1, nil
 }
 func (p *stubLaunchPublisher) CancelRun(context.Context, string) error { return nil }
+func (p *stubLaunchPublisher) CancelRunWithReason(context.Context, string, string) error {
+	return nil
+}
 func (p *stubLaunchPublisher) SubmitResume(context.Context, ResumeSpec, *ir.Workflow, string) error {
 	return nil
 }

--- a/pkg/runview/service_launch_operator_resume_test.go
+++ b/pkg/runview/service_launch_operator_resume_test.go
@@ -21,6 +21,9 @@ func (*operatorResumePublisher) SubmitLaunch(context.Context, string, LaunchSpec
 }
 
 func (*operatorResumePublisher) CancelRun(context.Context, string) error { return nil }
+func (*operatorResumePublisher) CancelRunWithReason(context.Context, string, string) error {
+	return nil
+}
 
 func (p *operatorResumePublisher) SubmitResume(context.Context, ResumeSpec, *ir.Workflow, string) error {
 	p.resumeCalls++

--- a/pkg/runview/service_resume_hash_test.go
+++ b/pkg/runview/service_resume_hash_test.go
@@ -63,6 +63,10 @@ func (*resumeHashPublisher) CancelRun(context.Context, string) error {
 	return nil
 }
 
+func (*resumeHashPublisher) CancelRunWithReason(context.Context, string, string) error {
+	return nil
+}
+
 func (p *resumeHashPublisher) SubmitResume(context.Context, ResumeSpec, *ir.Workflow, string) error {
 	p.resumeCalls++
 	return nil

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -954,6 +954,20 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 //
 // Idempotent: running CancelRun on an already-terminal run is a no-op.
 func (p *Publisher) CancelRun(ctx context.Context, runID string) error {
+	return p.CancelRunWithReason(ctx, runID, "cancelled by user")
+}
+
+// CancelRunWithReason is CancelRun with an explicit reason. The reason lands
+// in run.Error — which the run list, the board cards and the merge-gate
+// synthetic status all read — so an AUTOMATED cancel must say what actually
+// happened instead of masquerading as an operator action: a webhook supersede
+// once overwrote a runner validation error with "cancelled by user", and the
+// PR's synthetic gate then blamed a human who had touched nothing.
+//
+// The prior error, when present, is carried forward (same rationale as
+// runview.CancelInactiveCtx): run.Error is the only record in run.json of WHY
+// the run was in its pre-cancel state, and cancelling must not erase it.
+func (p *Publisher) CancelRunWithReason(ctx context.Context, runID, reason string) error {
 	// Cancel descends here with a NON-request context (runview.Service.Cancel
 	// takes no ctx), so the mongo tenant filter has no tenant and its
 	// tenant-scoped queries panic. The caller (handleCancelRun / the WS
@@ -982,7 +996,13 @@ func (p *Publisher) CancelRun(ctx context.Context, runID string) error {
 		store.RunStatusPausedWaitingHuman,
 		store.RunStatusFailedResumable,
 	}
-	changed, err := p.store.UpdateRunStatusIf(ctx, runID, store.RunStatusCancelled, "cancelled by user", cancellable)
+	if strings.TrimSpace(reason) == "" {
+		reason = "cancelled"
+	}
+	if prior := strings.TrimSpace(r.Error); prior != "" {
+		reason += " (was " + string(r.Status) + ": " + prior + ")"
+	}
+	changed, err := p.store.UpdateRunStatusIf(ctx, runID, store.RunStatusCancelled, reason, cancellable)
 	if err != nil {
 		return fmt.Errorf("cloudpublisher: flip status: %w", err)
 	}

--- a/pkg/server/cloudpublisher/publisher_cancel_test.go
+++ b/pkg/server/cloudpublisher/publisher_cancel_test.go
@@ -1,0 +1,92 @@
+package cloudpublisher
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// A cancel's reason lands in run.Error — what the run list, board cards and
+// merge-gate synthetic statuses all read. Pinned here: an automated cancel
+// (the webhook supersede lane) records what actually happened instead of
+// "cancelled by user", and the prior error is carried forward rather than
+// erased (a supersede once overwrote a runner validation error, and the PR's
+// synthetic gate then blamed a human who had touched nothing).
+func TestCancelRunWithReason(t *testing.T) {
+	newPub := func(t *testing.T) (*Publisher, store.RunStore) {
+		t.Helper()
+		st, err := store.New(t.TempDir())
+		if err != nil {
+			t.Fatalf("store.New: %v", err)
+		}
+		return &Publisher{
+			store:     st,
+			cancelRun: func(string) error { return nil },
+		}, st
+	}
+	seed := func(t *testing.T, st store.RunStore, id string, status store.RunStatus, runErr string) {
+		t.Helper()
+		run, err := st.CreateRun(context.Background(), id, "wf", nil)
+		if err != nil {
+			t.Fatalf("CreateRun: %v", err)
+		}
+		run.Status = status
+		run.Error = runErr
+		if err := st.SaveRun(context.Background(), run); err != nil {
+			t.Fatalf("SaveRun: %v", err)
+		}
+	}
+
+	t.Run("an automated reason is recorded verbatim and keeps the prior error", func(t *testing.T) {
+		p, st := newPub(t)
+		seed(t, st, "run-1", store.RunStatusFailedResumable, `runner: reject repo ref: git: branch name "renovate/npm-(non-major)"`)
+		if err := p.CancelRunWithReason(context.Background(), "run-1", "superseded by a newer delivery for the same subject"); err != nil {
+			t.Fatalf("CancelRunWithReason: %v", err)
+		}
+		run, err := st.LoadRun(context.Background(), "run-1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if run.Status != store.RunStatusCancelled {
+			t.Fatalf("status = %s, want cancelled", run.Status)
+		}
+		if !strings.HasPrefix(run.Error, "superseded by a newer delivery") {
+			t.Errorf("error = %q, want the automated reason first", run.Error)
+		}
+		if !strings.Contains(run.Error, "was failed_resumable") || !strings.Contains(run.Error, "reject repo ref") {
+			t.Errorf("error = %q — the prior failure is the only record of WHY the run was dead and must survive the cancel", run.Error)
+		}
+	})
+
+	t.Run("the operator click stays 'cancelled by user'", func(t *testing.T) {
+		p, st := newPub(t)
+		seed(t, st, "run-2", store.RunStatusRunning, "")
+		if err := p.CancelRun(context.Background(), "run-2"); err != nil {
+			t.Fatalf("CancelRun: %v", err)
+		}
+		run, err := st.LoadRun(context.Background(), "run-2")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if run.Error != "cancelled by user" {
+			t.Errorf("error = %q, want the plain operator shape", run.Error)
+		}
+	})
+
+	t.Run("an empty reason still names the fact", func(t *testing.T) {
+		p, st := newPub(t)
+		seed(t, st, "run-3", store.RunStatusQueued, "")
+		if err := p.CancelRunWithReason(context.Background(), "run-3", "  "); err != nil {
+			t.Fatalf("CancelRunWithReason: %v", err)
+		}
+		run, err := st.LoadRun(context.Background(), "run-3")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if run.Error != "cancelled" {
+			t.Errorf("error = %q, want %q", run.Error, "cancelled")
+		}
+	})
+}

--- a/pkg/server/cloudpublisher/publisher_cancel_test.go
+++ b/pkg/server/cloudpublisher/publisher_cancel_test.go
@@ -75,6 +75,39 @@ func TestCancelRunWithReason(t *testing.T) {
 		}
 	})
 
+	// The composition that lost the reason in production: for a RUNNING run
+	// the publisher flips the doc first, then the runner (holding the lease)
+	// unwinds and writes its own generic "run cancelled". The engine's write
+	// is a CAS from non-terminal statuses (pkg/runtime/run_failure.go), so
+	// the publisher's specific reason must survive it.
+	t.Run("the runner's engine cancel does not overwrite a recorded reason", func(t *testing.T) {
+		p, st := newPub(t)
+		seed(t, st, "run-4", store.RunStatusRunning, "")
+		if err := p.CancelRunWithReason(context.Background(), "run-4", "superseded by a newer delivery for the same subject"); err != nil {
+			t.Fatalf("CancelRunWithReason: %v", err)
+		}
+		// The exact write the engine performs on ctx-cancel.
+		changed, err := st.UpdateRunStatusIf(context.Background(), "run-4", store.RunStatusCancelled, "run cancelled", []store.RunStatus{
+			store.RunStatusRunning,
+			store.RunStatusPausedWaitingHuman,
+			store.RunStatusPausedOperator,
+			store.RunStatusFailedResumable,
+		})
+		if err != nil {
+			t.Fatalf("engine CAS: %v", err)
+		}
+		if changed {
+			t.Fatal("the engine's write applied over an already-cancelled run — the recorded reason is lost")
+		}
+		run, err := st.LoadRun(context.Background(), "run-4")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.HasPrefix(run.Error, "superseded by a newer delivery") {
+			t.Errorf("error = %q — the supersede reason did not survive the runner's cancel", run.Error)
+		}
+	})
+
 	t.Run("an empty reason still names the fact", func(t *testing.T) {
 		p, st := newPub(t)
 		seed(t, st, "run-3", store.RunStatusQueued, "")

--- a/pkg/server/forge_gate_reconcile.go
+++ b/pkg/server/forge_gate_reconcile.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"regexp"
 	"strings"
 	"unicode/utf8"
 
@@ -18,10 +19,10 @@ import (
 // who knows to re-trigger the bot can unstick it.
 //
 // It is not a rare path. Observed in production twice in one day: a rolling
-// deploy drained a review mid-flight (the lame-duck drain is not deployed, so
-// a rollout cancels in-flight runs), and separately a bot bug made the publish
-// step skip on every run. Both left pull requests blocked for hours with every
-// other check green.
+// deploy drained a review mid-flight (whenever the lame-duck drain is not
+// active — or a run outlives its drain window — a rollout cancels in-flight
+// runs), and separately a bot bug made the publish step skip on every run.
+// Both left pull requests blocked for hours with every other check green.
 //
 // So the last thing a gating run does, whether it succeeded or not, is leave a
 // verdict the PR can display. When the run ends without one, this posts a
@@ -43,6 +44,19 @@ const (
 // to carry the remedy: whoever finds it has no other clue about what happened.
 const gateInterruptedDescription = "review ended without a verdict — push again or comment the bot's command to re-run"
 
+// gateReasonWrappers are mechanical prefixes the queue and the runner wrap
+// around the actual cause of death. The 60-rune budget below cannot survive
+// them: the wrapped form of a runner reject reads "max deliveries exhausted:
+// runner: prepare repo workspace for 01a0…: runner: reject repo ref: …" and
+// truncates before the only part an operator can act on. Stripping is
+// cosmetic — the full error stays on the run the status links to.
+var gateReasonWrappers = []*regexp.Regexp{
+	regexp.MustCompile(`^max deliveries exhausted: `),
+	regexp.MustCompile(`^runner: prepare repo workspace for [^:]*: `),
+	regexp.MustCompile(`^runner: `),
+	regexp.MustCompile(`^git: `),
+}
+
 // gateInterruptedDescriptionFor prefixes the remedy with WHY the run died when
 // the run doc can say (budget exceeded, provider error, …). GitHub truncates
 // commit-status descriptions at 140 characters, so the reason is bounded and
@@ -54,6 +68,14 @@ func gateInterruptedDescriptionFor(run *store.Run) string {
 	}
 	if i := strings.IndexByte(reason, '\n'); i >= 0 {
 		reason = strings.TrimSpace(reason[:i])
+	}
+	for stripped := true; stripped; {
+		stripped = false
+		for _, re := range gateReasonWrappers {
+			if next := re.ReplaceAllString(reason, ""); next != reason {
+				reason, stripped = next, true
+			}
+		}
 	}
 	if reason == "" {
 		return gateInterruptedDescription
@@ -338,12 +360,9 @@ func (s *Server) reconcileGateForRunID(ctx context.Context, runID, via string) e
 		}
 
 	default: // a synthetic interruption
-		// It deliberately does NOT stand this repair down in general: when a
-		// relaunched run dies too, the second death must still be answered and
-		// escalated rather than mistake the first death's marker for an
-		// answer. That argument is about a DIFFERENT run on the same head. The
-		// same run offered twice — the event and the sweep racing, or the sweep
-		// re-reading its window every minute for an hour — is already answered.
+		// The same run offered twice — the event and the sweep racing, or the
+		// sweep re-reading its window every minute for an hour — is already
+		// answered.
 		if gateStatusSpeaksFor(gate, runURL) {
 			return nil
 		}
@@ -357,6 +376,21 @@ func (s *Server) reconcileGateForRunID(ctx context.Context, runID, via string) e
 			return abstain("a synthetic failure is already on %s@%s and PublicURL is unset, so it cannot be told from this run's own — set PublicURL to enable second-death escalation",
 				repo, shortSHA(pr.HeadSHA))
 		}
+		// ANOTHER dead run's synthetic failure already marks this head. One
+		// marker is enough: re-posting would only re-point the status's target
+		// URL at THIS run, and the next sweep pass on the other run would
+		// point it back — observed in production as 116 status writes on one
+		// head in 15 minutes, two dead runs alternating every sweep tick
+		// (buildkit-operator#21, 2026-08-17). The relaunch tail still runs,
+		// because a second death on the head must escalate rather than
+		// mistake the first death's marker for an answer; its idempotency
+		// claim and the board card's (PR, head) dedup make repeat offers
+		// no-ops.
+		s.relaunchDeadGateRun(ctx, deadGateRun{
+			run: run, grant: grant, conn: conn, gc: gc,
+			repo: repo, number: number, pr: pr, gateCtx: gateCtx, prURL: prURL,
+		})
+		return nil
 	}
 
 	st := forge.CommitStatus{

--- a/pkg/server/forge_gate_reconcile_test.go
+++ b/pkg/server/forge_gate_reconcile_test.go
@@ -306,6 +306,24 @@ func TestGateReconcile_ReasonTruncationIsRuneSafe(t *testing.T) {
 	}
 }
 
+// The reason on the synthetic status must survive the queue/runner wrappers:
+// the raw error of a runner reject reads "max deliveries exhausted: runner:
+// prepare repo workspace for <id>: runner: reject repo ref: …" and the
+// 60-rune budget used to truncate before the only actionable part.
+func TestGateReconcile_ReasonStripsMechanicalWrappers(t *testing.T) {
+	run := &store.Run{Error: `max deliveries exhausted: runner: prepare repo workspace for 01a0321a-7945-7dfe-a886-0cb56054caa4: runner: reject repo ref: git: branch name "renovate/npm-(non-major)" must match [A-Za-z0-9][A-Za-z0-9._/-]* (parked on DLQ — replay via /api/admin/dlq)`}
+	got := gateInterruptedDescriptionFor(run)
+	if !strings.Contains(got, `reject repo ref`) || !strings.Contains(got, "renovate/npm-(non-major)") {
+		t.Errorf("description lost the actionable cause: %q", got)
+	}
+	if strings.Contains(got, "max deliveries exhausted") || strings.Contains(got, "prepare repo workspace") {
+		t.Errorf("description still carries mechanical wrappers: %q", got)
+	}
+	if !isSyntheticGateInterruption(got) {
+		t.Errorf("stripped description no longer recognized as synthetic: %q", got)
+	}
+}
+
 // The synthetic marker must be recognized in both its shapes and must never
 // swallow a real verdict.
 func TestGateReconcile_SyntheticMarker(t *testing.T) {

--- a/pkg/server/forge_gate_relaunch.go
+++ b/pkg/server/forge_gate_relaunch.go
@@ -34,6 +34,14 @@ const gateRelaunchEventKind = "gate_relaunch"
 // (or Nexie) can find every gate that died past recovery in one query.
 const gateRelaunchLabel = "source:gate-reconcile"
 
+// gateRelaunchOfVar rides the relaunch's launch vars and names the dead run it
+// replaces. The workflow itself drops undeclared vars, but run.Inputs keeps
+// them (same mechanism as the publish token), which is what lets the SECOND
+// death name the ORIGINAL run in its escalation: the escalating pass is the
+// relaunched run's own, and without this stamp the card cited one run twice
+// while the first death stayed unfindable.
+const gateRelaunchOfVar = "gate_relaunch_of"
+
 // deadGateRun carries what reconcileGateForRun already resolved about the dead
 // run, so the relaunch re-validates nothing it does not have to.
 type deadGateRun struct {
@@ -108,7 +116,7 @@ func (s *Server) relaunchDeadGateRun(ctx context.Context, d deadGateRun) {
 	// PR facts, the operator's pinned gate_context/arm_automerge, the bot's
 	// own vars. Only the per-run publish grant is dropped: the launch tail
 	// mints a fresh one (and would overwrite a stale copy anyway).
-	vars := make(map[string]string, len(d.run.Inputs))
+	vars := make(map[string]string, len(d.run.Inputs)+1)
 	for k, v := range d.run.Inputs {
 		if k == forgePublishVarToken || k == forgePublishVarURL {
 			continue
@@ -117,6 +125,7 @@ func (s *Server) relaunchDeadGateRun(ctx context.Context, d deadGateRun) {
 			vars[k] = sv
 		}
 	}
+	vars[gateRelaunchOfVar] = d.run.ID
 
 	actor := "gaterelaunch:" + cfg.ID
 	launchCtx := auth.WithIdentity(ctx, auth.Identity{
@@ -182,7 +191,7 @@ func (s *Server) relaunchDeadGateRun(ctx context.Context, d deadGateRun) {
 		}
 		s.logWarn("gate relaunch: %s on %s#%d@%s already got its one relaunch (run %s) and died again — escalating to the board",
 			d.gateCtx, d.repo, d.number, shortSHA(d.pr.HeadSHA), res.RunID)
-		s.escalateDeadGateToBoard(d, res.RunID, "the automatic relaunch died too")
+		s.escalateDeadGateToBoard(ctx, d, res.RunID, "the automatic relaunch died too")
 	default:
 		why := strings.TrimSpace(res.Error)
 		if why == "" {
@@ -190,7 +199,7 @@ func (s *Server) relaunchDeadGateRun(ctx context.Context, d deadGateRun) {
 		}
 		s.logWarn("gate relaunch: could not relaunch %s on %s#%d@%s (%s) — escalating to the board",
 			botID, d.repo, d.number, shortSHA(d.pr.HeadSHA), why)
-		s.escalateDeadGateToBoard(d, "", "the automatic relaunch could not start: "+why)
+		s.escalateDeadGateToBoard(ctx, d, "", "the automatic relaunch could not start: "+why)
 	}
 }
 
@@ -202,7 +211,10 @@ func (s *Server) relaunchDeadGateRun(ctx context.Context, d deadGateRun) {
 //
 // One card per (PR, head): a closed card means a human already dealt with this
 // revision, and a fresh death on the SAME head adds nothing they don't know.
-func (s *Server) escalateDeadGateToBoard(d deadGateRun, priorRelaunchRunID, why string) {
+// A freshly filed card is ALSO posted as a PR comment — the board is the
+// operator's queue, but the PR is where the people waiting on the merge look
+// (a card alone sat unseen for 7 days while a security PR stayed blocked).
+func (s *Server) escalateDeadGateToBoard(ctx context.Context, d deadGateRun, priorRelaunchRunID, why string) {
 	if s.cfg.CloudBoardFor == nil {
 		s.logWarn("gate relaunch: no board on this deployment — %s#%d stays red with no card; the failure status carries the remedy", d.repo, d.number)
 		return
@@ -217,22 +229,43 @@ func (s *Server) escalateDeadGateToBoard(d deadGateRun, priorRelaunchRunID, why 
 		return
 	}
 
-	reason := strings.TrimSpace(d.run.Error)
-	if reason == "" {
-		reason = "(no error recorded on the run)"
+	// Name the two runs that died — not one of them twice. The escalating
+	// pass is usually the RELAUNCHED run's own death: the idempotency claim
+	// then names d.run itself, and the card used to cite that one URL as both
+	// "dead run" and "relaunched run" while the original death stayed
+	// unfindable. The original's id travels on the relaunch's launch vars.
+	originalID, originalErr := d.run.ID, strings.TrimSpace(d.run.Error)
+	relaunchID, relaunchErr := strings.TrimSpace(priorRelaunchRunID), ""
+	if relaunchID != "" && strings.EqualFold(relaunchID, d.run.ID) {
+		relaunchID, relaunchErr = d.run.ID, originalErr
+		originalID, originalErr = runInputString(d.run, gateRelaunchOfVar), ""
 	}
+	if relaunchID != "" && relaunchErr == "" && s.cfg.Store != nil {
+		if r, err := s.cfg.Store.LoadRun(store.WithoutTenantFilter(ctx), relaunchID); err == nil && r != nil {
+			relaunchErr = strings.TrimSpace(r.Error)
+		}
+	}
+	if originalID != "" && originalErr == "" && s.cfg.Store != nil {
+		if r, err := s.cfg.Store.LoadRun(store.WithoutTenantFilter(ctx), originalID); err == nil && r != nil {
+			originalErr = strings.TrimSpace(r.Error)
+		}
+	}
+
 	base := strings.TrimRight(strings.TrimSpace(s.cfg.PublicURL), "/")
 	body := fmt.Sprintf(
 		"The merge gate `%s` on %s#%d died without posting a verdict, and the automatic recovery is exhausted: %s.\n\n"+
 			"- Pull request: %s\n"+
-			"- Head audited: `%s`\n"+
-			"- Dead run: %s — `%s`\n",
+			"- Head audited: `%s`\n",
 		d.gateCtx, d.repo, d.number, why,
 		d.prURL,
-		d.pr.HeadSHA,
-		gateRunURL(base, d.run.ID), reason)
-	if priorRelaunchRunID != "" {
-		body += fmt.Sprintf("- Relaunched run (also dead): %s\n", gateRunURL(base, priorRelaunchRunID))
+		d.pr.HeadSHA)
+	if originalID != "" {
+		body += fmt.Sprintf("- Dead run: %s — `%s`\n", gateRunURL(base, originalID), orNoError(originalErr))
+	} else {
+		body += "- Dead run: unknown (the relaunch was launched before its parent run was stamped)\n"
+	}
+	if relaunchID != "" && !strings.EqualFold(relaunchID, originalID) {
+		body += fmt.Sprintf("- Relaunched run (also dead): %s — `%s`\n", gateRunURL(base, relaunchID), orNoError(relaunchErr))
 	}
 	body += "\nA required check dying twice on one revision usually means a structural problem — " +
 		"a run budget too short for this workload, a recurring provider quota, or a bot defect. " +
@@ -249,6 +282,42 @@ func (s *Server) escalateDeadGateToBoard(d deadGateRun, priorRelaunchRunID, why 
 	}
 	if s.logger != nil {
 		s.logger.Info("gate relaunch: board card filed for %s on %s#%d@%s", d.gateCtx, d.repo, d.number, shortSHA(d.pr.HeadSHA))
+	}
+	s.commentDeadGateOnPR(ctx, d, body)
+}
+
+// orNoError renders an empty run error as an explicit placeholder so the
+// escalation never shows a bare empty code span.
+func orNoError(err string) string {
+	if err == "" {
+		return "no error recorded"
+	}
+	return err
+}
+
+// commentDeadGateOnPR posts the escalation on the pull request itself — the
+// one surface the PR's audience is guaranteed to see. The commit status only
+// offers 140 characters and the board card lives on the integration's team
+// board, which the people waiting on THIS merge may never open. Best-effort,
+// and deliberately gated on the board card having just been created: the card
+// dedup is what bounds this to one comment per (PR, head) — a deployment with
+// no board gets no comment rather than one per sweep pass.
+func (s *Server) commentDeadGateOnPR(ctx context.Context, d deadGateRun, body string) {
+	rc, err := s.reviewClientFor(ctx, d.conn)
+	if err != nil {
+		s.logWarn("gate relaunch: no review client for %s (%v) — escalation stays board+status only", d.repo, err)
+		return
+	}
+	if rc == nil {
+		s.logWarn("gate relaunch: provider %s cannot post PR comments — escalation stays board+status only", d.conn.Provider)
+		return
+	}
+	if _, err := rc.CreatePullReview(ctx, d.repo, d.number, forge.NewReview{Body: body}); err != nil {
+		s.logWarn("gate relaunch: escalation comment on %s#%d failed: %v", d.repo, d.number, err)
+		return
+	}
+	if s.logger != nil {
+		s.logger.Info("gate relaunch: escalation comment posted on %s#%d", d.repo, d.number)
 	}
 }
 

--- a/pkg/server/forge_gate_relaunch.go
+++ b/pkg/server/forge_gate_relaunch.go
@@ -6,6 +6,8 @@ import (
 
 	"context"
 
+	"github.com/google/uuid"
+
 	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/forge"
@@ -189,17 +191,28 @@ func (s *Server) relaunchDeadGateRun(ctx context.Context, d deadGateRun) {
 			}
 			return
 		}
-		s.logWarn("gate relaunch: %s on %s#%d@%s already got its one relaunch (run %s) and died again — escalating to the board",
-			d.gateCtx, d.repo, d.number, shortSHA(d.pr.HeadSHA), res.RunID)
-		s.escalateDeadGateToBoard(ctx, d, res.RunID, "the automatic relaunch died too")
+		// Log AFTER the dedup decision: the sweep re-offers a dead run every
+		// minute for its whole lookback, and a Warn claiming "escalating"
+		// on every already-escalated pass is 60 false lines an hour.
+		if s.escalateDeadGateToBoard(ctx, d, res.RunID, "the automatic relaunch died too") {
+			s.logWarn("gate relaunch: %s on %s#%d@%s already got its one relaunch (run %s) and died again — escalated to the board",
+				d.gateCtx, d.repo, d.number, shortSHA(d.pr.HeadSHA), res.RunID)
+		} else if s.logger != nil {
+			s.logger.Debug("gate relaunch: %s on %s#%d@%s is already escalated — nothing new to file",
+				d.gateCtx, d.repo, d.number, shortSHA(d.pr.HeadSHA))
+		}
 	default:
 		why := strings.TrimSpace(res.Error)
 		if why == "" {
 			why = res.Status
 		}
-		s.logWarn("gate relaunch: could not relaunch %s on %s#%d@%s (%s) — escalating to the board",
-			botID, d.repo, d.number, shortSHA(d.pr.HeadSHA), why)
-		s.escalateDeadGateToBoard(ctx, d, "", "the automatic relaunch could not start: "+why)
+		if s.escalateDeadGateToBoard(ctx, d, "", "the automatic relaunch could not start: "+why) {
+			s.logWarn("gate relaunch: could not relaunch %s on %s#%d@%s (%s) — escalated to the board",
+				botID, d.repo, d.number, shortSHA(d.pr.HeadSHA), why)
+		} else if s.logger != nil {
+			s.logger.Debug("gate relaunch: could not relaunch %s on %s#%d@%s (%s) — already escalated",
+				botID, d.repo, d.number, shortSHA(d.pr.HeadSHA), why)
+		}
 	}
 }
 
@@ -214,20 +227,28 @@ func (s *Server) relaunchDeadGateRun(ctx context.Context, d deadGateRun) {
 // A freshly filed card is ALSO posted as a PR comment — the board is the
 // operator's queue, but the PR is where the people waiting on the merge look
 // (a card alone sat unseen for 7 days while a security PR stayed blocked).
-func (s *Server) escalateDeadGateToBoard(ctx context.Context, d deadGateRun, priorRelaunchRunID, why string) {
+//
+// Returns whether THIS call filed the card. The dedup is a deterministic card
+// id (UUIDv5 of the (repo, PR, head) key), not just the List pre-check: the
+// gate sweep runs unelected on every replica, and two replicas racing past
+// the List would otherwise each create a card AND each post the PR comment —
+// the store's unique-id insert is the only primitive here that serialises
+// cross-replica. The label stays on the card for querying.
+func (s *Server) escalateDeadGateToBoard(ctx context.Context, d deadGateRun, priorRelaunchRunID, why string) bool {
 	if s.cfg.CloudBoardFor == nil {
 		s.logWarn("gate relaunch: no board on this deployment — %s#%d stays red with no card; the failure status carries the remedy", d.repo, d.number)
-		return
+		return false
 	}
 	board := s.cfg.CloudBoardFor(d.grant.TeamID)
 	if board == nil {
 		s.logWarn("gate relaunch: no board for team %s — %s#%d stays red with no card", d.grant.TeamID, d.repo, d.number)
-		return
+		return false
 	}
 	dedup := fmt.Sprintf("gate-dead:%s#%d@%s", d.repo, d.number, shortSHA(d.pr.HeadSHA))
 	if existing, err := board.List(native.ListFilter{Labels: []string{dedup}}); err == nil && len(existing) > 0 {
-		return
+		return false
 	}
+	cardID := "native:" + uuid.NewSHA1(uuid.NameSpaceURL, []byte("iterion://gate-dead/"+d.grant.TeamID+"/"+dedup)).String()
 
 	// Name the two runs that died — not one of them twice. The escalating
 	// pass is usually the RELAUNCHED run's own death: the idempotency claim
@@ -273,26 +294,38 @@ func (s *Server) escalateDeadGateToBoard(ctx context.Context, d deadGateRun, pri
 		"status on the PR is overwritten by the next real verdict."
 
 	if _, err := board.Create(native.Issue{
+		ID:     cardID,
 		Title:  truncate(fmt.Sprintf("Merge gate %s keeps dying on %s#%d", d.gateCtx, d.repo, d.number), 120),
 		Body:   body,
 		Labels: []string{gateRelaunchLabel, dedup},
 	}); err != nil {
+		// A create refused on the deterministic id means another replica won
+		// the race a moment ago — the escalation exists, nothing to add. Any
+		// other failure is a real board problem: say so, the PR keeps its
+		// synthetic status either way.
+		if existing, lerr := board.List(native.ListFilter{Labels: []string{dedup}}); lerr == nil && len(existing) > 0 {
+			return false
+		}
 		s.logWarn("gate relaunch: board card create failed for %s#%d: %v", d.repo, d.number, err)
-		return
+		return false
 	}
 	if s.logger != nil {
 		s.logger.Info("gate relaunch: board card filed for %s on %s#%d@%s", d.gateCtx, d.repo, d.number, shortSHA(d.pr.HeadSHA))
 	}
 	s.commentDeadGateOnPR(ctx, d, body)
+	return true
 }
 
-// orNoError renders an empty run error as an explicit placeholder so the
-// escalation never shows a bare empty code span.
+// orNoError renders a run error for embedding in a markdown `code span`: an
+// empty error becomes an explicit placeholder, and backticks are replaced so
+// forge-controlled error prose (which can quote a hostile ref name verbatim)
+// cannot close the span and smuggle active markdown (@mentions) into the
+// escalation comment.
 func orNoError(err string) string {
 	if err == "" {
 		return "no error recorded"
 	}
-	return err
+	return strings.ReplaceAll(err, "`", "'")
 }
 
 // commentDeadGateOnPR posts the escalation on the pull request itself — the

--- a/pkg/server/forge_gate_relaunch.go
+++ b/pkg/server/forge_gate_relaunch.go
@@ -261,14 +261,22 @@ func (s *Server) escalateDeadGateToBoard(ctx context.Context, d deadGateRun, pri
 		relaunchID, relaunchErr = d.run.ID, originalErr
 		originalID, originalErr = runInputString(d.run, gateRelaunchOfVar), ""
 	}
-	if relaunchID != "" && relaunchErr == "" && s.cfg.Store != nil {
-		if r, err := s.cfg.Store.LoadRun(store.WithoutTenantFilter(ctx), relaunchID); err == nil && r != nil {
-			relaunchErr = strings.TrimSpace(r.Error)
+	// The two ids do NOT have the same provenance, so they are not trusted
+	// the same way. relaunchID comes from iterion's own idempotency claim —
+	// the delivery record proves this team launched it — so an unreadable run
+	// only costs its error text. originalID comes from a LAUNCH VAR, which an
+	// operator can pin on a webhook: it is a claim, not proof, and one this
+	// lane is about to publish on a pull request.
+	if relaunchID != "" && relaunchErr == "" {
+		if e, ok := s.gateRunError(ctx, d.grant.TeamID, relaunchID); ok {
+			relaunchErr = e
 		}
 	}
-	if originalID != "" && originalErr == "" && s.cfg.Store != nil {
-		if r, err := s.cfg.Store.LoadRun(store.WithoutTenantFilter(ctx), originalID); err == nil && r != nil {
-			originalErr = strings.TrimSpace(r.Error)
+	if originalID != "" && originalErr == "" {
+		if e, ok := s.gateRunError(ctx, d.grant.TeamID, originalID); ok {
+			originalErr = e
+		} else {
+			originalID = "" // unreadable, or another team's — do not cite it
 		}
 	}
 
@@ -316,16 +324,50 @@ func (s *Server) escalateDeadGateToBoard(ctx context.Context, d deadGateRun, pri
 	return true
 }
 
+// gateRunError reads another run's failure reason for the escalation, and is
+// the TENANT BOUNDARY of this lane. `originalID` reaches it from a launch var
+// (`gate_relaunch_of`), which an operator can pin on a webhook — so the id can
+// name a run this team does not own, whose error and URL are about to be
+// published on a pull request and a board card. The untenanted load is
+// deliberate (the reconciler runs on a bus goroutine with no request tenant),
+// which is exactly why the ownership check has to be explicit here.
+//
+// Reports ok=false when the run is unreadable, missing, or another team's —
+// the caller then drops the id entirely rather than citing a run it cannot
+// vouch for.
+func (s *Server) gateRunError(ctx context.Context, teamID, runID string) (string, bool) {
+	if s.cfg.Store == nil {
+		return "", false
+	}
+	r, err := s.cfg.Store.LoadRun(store.WithoutTenantFilter(ctx), runID)
+	if err != nil || r == nil {
+		return "", false
+	}
+	if r.TenantID != "" && teamID != "" && !strings.EqualFold(r.TenantID, teamID) {
+		s.logWarn("gate relaunch: refusing to cite run %s (team %s) in team %s's escalation — the id came from a launch var",
+			runID, r.TenantID, teamID)
+		return "", false
+	}
+	return strings.TrimSpace(r.Error), true
+}
+
 // orNoError renders a run error for embedding in a markdown `code span`: an
-// empty error becomes an explicit placeholder, and backticks are replaced so
-// forge-controlled error prose (which can quote a hostile ref name verbatim)
-// cannot close the span and smuggle active markdown (@mentions) into the
-// escalation comment.
+// empty error becomes an explicit placeholder, and everything that can END
+// the span is neutralised, so forge-controlled error prose (which quotes a
+// hostile ref name and a remote's message verbatim) cannot smuggle active
+// markdown — @mentions, headings — into a comment posted by iterion's own
+// forge identity.
+//
+// A NEWLINE ends a code span just as surely as a backtick does, and run
+// errors are routinely multi-line: the runner builds them from git's full
+// CombinedOutput. Collapsing first is what makes the backtick escaping mean
+// anything.
 func orNoError(err string) string {
 	if err == "" {
 		return "no error recorded"
 	}
-	return strings.ReplaceAll(err, "`", "'")
+	flat := strings.Join(strings.Fields(err), " ")
+	return strings.ReplaceAll(flat, "`", "'")
 }
 
 // commentDeadGateOnPR posts the escalation on the pull request itself — the

--- a/pkg/server/forge_gate_relaunch_test.go
+++ b/pkg/server/forge_gate_relaunch_test.go
@@ -152,6 +152,9 @@ func TestGateRelaunch(t *testing.T) {
 		if vars["pr_url"] != prURL || vars["arm_automerge"] != "true" {
 			t.Errorf("relaunch dropped original launch vars: %v", vars)
 		}
+		if vars[gateRelaunchOfVar] != runID {
+			t.Errorf("%s = %q, want the dead run %s — the second death cannot name the original without it", gateRelaunchOfVar, vars[gateRelaunchOfVar], runID)
+		}
 		if tok := vars[forgePublishVarToken]; tok == "" || tok == "run-token" {
 			t.Errorf("publish token = %q — the tail must mint a FRESH grant, not reuse the dead run's", tok)
 		}
@@ -163,13 +166,20 @@ func TestGateRelaunch(t *testing.T) {
 	})
 
 	// The natural second-death sequence: the first death posted the synthetic
-	// failure and spent the head's one relaunch; now the RELAUNCHED run dies
-	// too. The gate carries the reconciler's own marker — which must not read
-	// as "already posted", or this exact case would go silent right where the
-	// recovery runs out (found adversarially: an earlier version stood down on
-	// its own synthetic status and the board escalation was unreachable).
+	// failure and spent the head's one relaunch; now another run of the same
+	// bot dies on the head. The marker must not read as "already posted" for
+	// the ESCALATION (found adversarially: an earlier version stood down on
+	// its own synthetic status and the board escalation was unreachable) —
+	// but it IS enough as a status: re-posting from a run the marker does not
+	// speak for is what produced the 116-write storm on one head (two dead
+	// runs re-pointing the target URL at themselves every sweep tick,
+	// buildkit-operator#21 2026-08-17).
 	t.Run("the second death on the same head escalates to the board instead", func(t *testing.T) {
 		w := build(t, nil)
+		rc := &fakeReviewClient{}
+		w.s.forgeReviewClientFor = func(context.Context, forge.Connection) (forge.ReviewClient, error) {
+			return rc, nil
+		}
 		// The head's one attempt is already spent…
 		if err := w.s.webhookDeliveries.Insert(context.Background(), webhooks.Delivery{
 			ID: "d-spent", TenantID: team, WebhookID: "w1", IdempotencyKey: relaunchIdem,
@@ -177,33 +187,108 @@ func TestGateRelaunch(t *testing.T) {
 		}); err != nil {
 			t.Fatal(err)
 		}
-		// …and the gate still shows the first death's synthetic failure.
+		// …and the gate still shows the first death's synthetic failure,
+		// pointing at the run that posted it.
 		w.gc.statuses = []forge.CommitStatus{{
 			Context: gateNm, State: forge.CommitStateFailure,
 			Description: gateInterruptedDescription,
+			TargetURL:   "https://iterion.test/runs/run-prior-relaunch",
 		}}
 		runID := seedDeadRun(t, w.s)
 		_ = w.s.reconcileGateForRun(context.Background(), terminalEvent(runID))
 		if *w.launched != 0 {
 			t.Fatalf("launched %d runs, want 0 — one relaunch per head, ever", *w.launched)
 		}
-		if w.gc.setCalls != 1 {
-			t.Fatalf("posted %d statuses, want 1 — the synthetic failure is refreshed with the newest death's reason", w.gc.setCalls)
+		if w.gc.setCalls != 0 {
+			t.Fatalf("posted %d statuses, want 0 — one synthetic marker per head is enough; re-posting is the status storm", w.gc.setCalls)
 		}
 		cards, err := w.board.List(native.ListFilter{Labels: []string{gateRelaunchLabel}})
 		if err != nil || len(cards) != 1 {
 			t.Fatalf("board cards = %d (%v), want exactly 1", len(cards), err)
 		}
-		if !strings.Contains(cards[0].Body, "run-prior-relaunch") || !strings.Contains(cards[0].Body, "budget exceeded") {
-			t.Errorf("the card must name the dead runs and the reason; got body:\n%s", cards[0].Body)
+		if !strings.Contains(cards[0].Body, "run-prior-relaunch") || !strings.Contains(cards[0].Body, runID) || !strings.Contains(cards[0].Body, "budget exceeded") {
+			t.Errorf("the card must name BOTH dead runs and the reason; got body:\n%s", cards[0].Body)
+		}
+		// The escalation is also posted on the PR — the board card alone sat
+		// unseen for 7 days while a security PR stayed blocked.
+		if rc.calls != 1 {
+			t.Fatalf("PR escalation comments = %d, want 1", rc.calls)
+		}
+		if rc.repo != repo || rc.number != 7 || !strings.Contains(rc.in.Body, "run-prior-relaunch") {
+			t.Errorf("comment landed on %s#%d with body:\n%s", rc.repo, rc.number, rc.in.Body)
 		}
 
-		// A third death on the same head adds no second card.
+		// A third death on the same head adds no second card — and no second
+		// comment (the card dedup is what bounds the comment).
 		runID2 := seedDeadRun(t, w.s)
 		_ = w.s.reconcileGateForRun(context.Background(), terminalEvent(runID2))
 		cards, err = w.board.List(native.ListFilter{Labels: []string{gateRelaunchLabel}})
 		if err != nil || len(cards) != 1 {
 			t.Fatalf("board cards after a third death = %d (%v), want still 1", len(cards), err)
+		}
+		if rc.calls != 1 {
+			t.Fatalf("PR escalation comments after a third death = %d, want still 1", rc.calls)
+		}
+	})
+
+	// The escalating pass is usually the RELAUNCHED run's own death: the
+	// idempotency claim then names that run itself. The card used to cite it
+	// as both "dead run" and "relaunched run" — one URL twice, the original
+	// death unfindable (observed on buildkit-operator#21). The original's id
+	// travels on the relaunch's launch vars and must resurface here, with its
+	// own error loaded from the store.
+	t.Run("the relaunched run's own death names the original run", func(t *testing.T) {
+		w := build(t, nil)
+		// The original dead run, with its own distinct error.
+		orig, err := w.s.cfg.Store.CreateRun(context.Background(), "run-original", "dep_update_guard", deadInputs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		orig.Status = store.RunStatusCancelled
+		orig.Error = "superseded by a rolling deploy drain"
+		if err := w.s.cfg.Store.SaveRun(context.Background(), orig); err != nil {
+			t.Fatal(err)
+		}
+		// The relaunched run, stamped with its parent, now dead too.
+		relInputs := map[string]any{}
+		for k, v := range deadInputs {
+			relInputs[k] = v
+		}
+		relInputs[gateRelaunchOfVar] = "run-original"
+		rel, err := w.s.cfg.Store.CreateRun(context.Background(), "run-relaunch", "dep_update_guard", relInputs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rel.BotID = botID
+		rel.Status = store.RunStatusFailedResumable
+		rel.Error = "budget exceeded: duration"
+		if err := w.s.cfg.Store.SaveRun(context.Background(), rel); err != nil {
+			t.Fatal(err)
+		}
+		// The head's claim names the relaunch ITSELF, and the gate carries its
+		// in-flight claim — the shape its own death event finds.
+		if err := w.s.webhookDeliveries.Insert(context.Background(), webhooks.Delivery{
+			ID: "d-self", TenantID: team, WebhookID: "w1", IdempotencyKey: relaunchIdem,
+			Status: webhooks.StatusLaunched, RunID: "run-relaunch",
+		}); err != nil {
+			t.Fatal(err)
+		}
+		w.gc.statuses = []forge.CommitStatus{{
+			Context: gateNm, State: forge.CommitStatePending,
+			Description: gateInFlightDescription,
+			TargetURL:   "https://iterion.test/runs/run-relaunch",
+		}}
+		_ = w.s.reconcileGateForRun(context.Background(), terminalEvent("run-relaunch"))
+		cards, err := w.board.List(native.ListFilter{Labels: []string{gateRelaunchLabel}})
+		if err != nil || len(cards) != 1 {
+			t.Fatalf("board cards = %d (%v), want 1", len(cards), err)
+		}
+		body := cards[0].Body
+		if !strings.Contains(body, "run-original") || !strings.Contains(body, "superseded by a rolling deploy drain") {
+			t.Errorf("the card must name the ORIGINAL dead run and its error; got:\n%s", body)
+		}
+		if got := strings.Count(body, "run-relaunch"); got != 1 {
+			t.Errorf("the relaunched run appears %d times, want exactly 1 (one URL twice is the defect being pinned):\n%s", got, body)
 		}
 	})
 

--- a/pkg/server/forge_gate_relaunch_test.go
+++ b/pkg/server/forge_gate_relaunch_test.go
@@ -410,3 +410,73 @@ func TestGateRelaunch(t *testing.T) {
 		}
 	})
 }
+
+// The escalation body is published on a PULL REQUEST by iterion's own forge
+// identity, and it quotes run errors that carry forge-controlled prose (a ref
+// name, a remote's message) verbatim. Both ways out of the code span are
+// pinned here: a backtick, and a NEWLINE — a code span cannot contain one, so
+// a multi-line run error (the runner builds them from git's CombinedOutput)
+// renders everything after the first line as live markdown.
+func TestEscalationQuotesForgeProseInertly(t *testing.T) {
+	hostile := "git fetch: exit 128: fatal: couldn't find remote ref x`y\n# Heading\n@octocat please run this"
+	got := orNoError(hostile)
+
+	if strings.ContainsAny(got, "\n\r") {
+		t.Errorf("orNoError left a newline in %q — it ends the code span and everything after renders as markdown", got)
+	}
+	if strings.Contains(got, "`") {
+		t.Errorf("orNoError left a backtick in %q — it closes the code span", got)
+	}
+	// The content itself must survive: a sanitiser that drops the reason
+	// leaves the human with nothing to act on.
+	for _, want := range []string{"exit 128", "remote ref", "octocat"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("orNoError dropped %q from the reason: %q", want, got)
+		}
+	}
+	if orNoError("") != "no error recorded" {
+		t.Errorf("empty error must render an explicit placeholder, got %q", orNoError(""))
+	}
+}
+
+// `gate_relaunch_of` arrives from run.Inputs — the union of webhook launch
+// vars, per-bot rule vars and operator overrides — so its value is NOT proof
+// of ownership. Citing it unchecked publishes another team's run error and
+// run URL onto this team's pull request and board card.
+func TestEscalationRefusesToCiteAnotherTeamsRun(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := newForgeGateTestServer(t, st)
+	foreign, err := st.CreateRun(context.Background(), "run-other-team", "dep_update_guard", map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreign.TenantID = "some-other-team"
+	foreign.Status = store.RunStatusFailedResumable
+	foreign.Error = "SECRET-TENANT-B-FAILURE"
+	if err := st.SaveRun(context.Background(), foreign); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := s.gateRunError(context.Background(), "t1", "run-other-team")
+	if ok || got != "" {
+		t.Fatalf("gateRunError returned (%q, %v) for another team's run — its error is about to be published on a PR", got, ok)
+	}
+
+	// The owning team still reads its own run: a boundary that refuses
+	// everything would silently empty every escalation.
+	mine, err := st.CreateRun(context.Background(), "run-mine", "dep_update_guard", map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mine.TenantID = "t1"
+	mine.Error = "budget exceeded"
+	if err := st.SaveRun(context.Background(), mine); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := s.gateRunError(context.Background(), "t1", "run-mine"); !ok || got != "budget exceeded" {
+		t.Fatalf("gateRunError on the team's OWN run = (%q, %v), want (\"budget exceeded\", true)", got, ok)
+	}
+}

--- a/pkg/server/forge_gate_relaunch_test.go
+++ b/pkg/server/forge_gate_relaunch_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/SocialGouv/iterion/pkg/webhooks"
 )
 
+// blindListBoard simulates the cross-replica race window: List never sees
+// what the other replica just created, so the dedup pre-check passes on both.
+type blindListBoard struct {
+	native.BoardStore
+}
+
+func (b blindListBoard) List(native.ListFilter) ([]*native.Issue, error) {
+	return nil, nil
+}
+
 // The relaunch lane is the recovery half of the reconciler: a gating run that
 // died without a verdict gets its bot re-run ONCE per head, through the same
 // admission tail as any webhook launch, and a head whose one attempt is spent
@@ -228,6 +238,47 @@ func TestGateRelaunch(t *testing.T) {
 		}
 		if rc.calls != 1 {
 			t.Fatalf("PR escalation comments after a third death = %d, want still 1", rc.calls)
+		}
+	})
+
+	// The gate sweep runs unelected on every replica, so two replicas can race
+	// past the List pre-check before either card commits. The deterministic
+	// card id is what serialises them: the loser's Create is refused by the
+	// store, and neither a second card NOR a second PR comment lands.
+	t.Run("two replicas racing the escalation file one card and one comment", func(t *testing.T) {
+		w := build(t, nil)
+		rc := &fakeReviewClient{}
+		w.s.forgeReviewClientFor = func(context.Context, forge.Connection) (forge.ReviewClient, error) {
+			return rc, nil
+		}
+		// A board whose List NEVER sees the other replica's card — the race
+		// window in which both replicas decide to file.
+		w.s.cfg.CloudBoardFor = func(string) native.BoardStore { return blindListBoard{w.board} }
+		runID := seedDeadRun(t, w.s)
+		run, err := w.s.cfg.Store.LoadRun(context.Background(), runID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		d := deadGateRun{
+			run:   run,
+			grant: ForgePublishGrant{TeamID: team, ConnectionID: "c1", Repo: repo},
+			conn:  forge.Connection{ID: "c1", TenantID: team, Provider: forge.ProviderGitHub},
+			repo:  repo, number: 7,
+			pr:      forge.PullRef{HeadSHA: head},
+			gateCtx: gateNm, prURL: prURL,
+		}
+		if filed := w.s.escalateDeadGateToBoard(context.Background(), d, "", "first replica"); !filed {
+			t.Fatal("the first replica must file the card")
+		}
+		if filed := w.s.escalateDeadGateToBoard(context.Background(), d, "", "second replica"); filed {
+			t.Fatal("the second replica raced past the List pre-check and must lose on the deterministic card id")
+		}
+		cards, err := w.board.List(native.ListFilter{Labels: []string{gateRelaunchLabel}})
+		if err != nil || len(cards) != 1 {
+			t.Fatalf("board cards = %d (%v), want exactly 1", len(cards), err)
+		}
+		if rc.calls != 1 {
+			t.Fatalf("PR escalation comments = %d, want 1 — the losing replica must not repeat it", rc.calls)
 		}
 	})
 

--- a/pkg/server/forge_gate_sweeper_test.go
+++ b/pkg/server/forge_gate_sweeper_test.go
@@ -103,12 +103,16 @@ func TestGateSweep_WindowIsBoundedOnBothSides(t *testing.T) {
 	}
 }
 
-// The discrimination the repeated offer forced, in both directions. A
-// synthetic failure is not a verdict, so it does not stand the repair down in
-// general — that is what lets a SECOND death on the same head (a relaunched
-// run dying too) escalate instead of mistaking the first death's marker for an
-// answer. But the same run offered again is already answered. The target URL
-// names the run the failure speaks for, which separates the two without
+// The discrimination the repeated offer forced. A synthetic failure is not a
+// verdict, so it does not stand the REPAIR down in general — a SECOND death on
+// the same head (a relaunched run dying too) still walks the relaunch tail and
+// escalates (pinned end-to-end in TestGateRelaunch) instead of mistaking the
+// first death's marker for an answer. But the STATUS WRITE stands down either
+// way: one marker per head is enough, and re-posting from a run the marker
+// does not speak for is the storm — two dead runs re-pointing the target URL
+// at themselves every sweep tick, 116 writes on one head in 15 minutes
+// (buildkit-operator#21, 2026-08-17). The target URL names the run the
+// failure speaks for, which separates "mine" from "another's" without
 // bookkeeping a second replica would not share.
 func TestGateReconcile_SyntheticFailureStandsDownOnlyForItsOwnRun(t *testing.T) {
 	interruption := func(targetURL string) forge.CommitStatus {
@@ -132,7 +136,7 @@ func TestGateReconcile_SyntheticFailureStandsDownOnlyForItsOwnRun(t *testing.T) 
 			t.Fatalf("posted %d statuses, want 0 — every sweep pass would re-post and re-enter the recovery", gc.setCalls)
 		}
 	})
-	t.Run("another run's — the second death must still escalate", func(t *testing.T) {
+	t.Run("another run's — no re-post, the storm lives there", func(t *testing.T) {
 		gc := &listingGateClient{
 			fakeGateClient: fakeGateClient{headSHA: "deadbeef"},
 			statuses:       []forge.CommitStatus{interruption("https://iterion.test/runs/some-earlier-run")},
@@ -141,8 +145,8 @@ func TestGateReconcile_SyntheticFailureStandsDownOnlyForItsOwnRun(t *testing.T) 
 		if err := s.reconcileGateForRun(context.Background(), terminalEvent(runID)); err != nil {
 			t.Fatalf("reconcile: %v", err)
 		}
-		if gc.setCalls != 1 {
-			t.Fatalf("posted %d statuses, want 1 — the repair goes silent exactly where the recovery runs out", gc.setCalls)
+		if gc.setCalls != 0 {
+			t.Fatalf("posted %d statuses, want 0 — re-posting over another run's marker is the status storm", gc.setCalls)
 		}
 	})
 }

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -623,7 +623,12 @@ type webhookLaunchResult struct {
 func (s *Server) supersedeLiveRuns(ctx context.Context, cfg webhooks.Config, meta webhookEventMeta, botID string) {
 	cancel := s.webhookCancelRun
 	if cancel == nil && s.runs != nil {
-		cancel = s.runs.Cancel
+		// Named reason: this cancel is nobody's click. It lands in run.Error,
+		// which the merge-gate synthetic status quotes — "cancelled by user"
+		// there sent operators hunting for a human who did nothing.
+		cancel = func(runID string) error {
+			return s.runs.CancelWithReason(runID, supersededRunReason)
+		}
 	}
 	if cfg.Overlap == "" || s.webhookDeliveries == nil || cancel == nil {
 		return
@@ -666,6 +671,11 @@ func (s *Server) supersedeLiveRuns(ctx context.Context, cfg webhooks.Config, met
 // live runs are necessarily among the most recent deliveries on its webhook,
 // and an unbounded scan would put the whole delivery history on the hot path.
 const supersedeLookback = 50
+
+// supersededRunReason is recorded as the run error of a run cancelled by the
+// overlap=supersede lane. Kept short: the merge-gate synthetic description
+// quotes it within a 60-rune budget.
+const supersededRunReason = "superseded by a newer delivery for the same subject"
 
 // scheduleForgeBoardProjection kicks the near-real-time forge→board refresh
 // for a repo. Once per DELIVERY, never once per bot: a fan-out would otherwise


### PR DESCRIPTION
Four production defects found auditing the Renovate auto-upgrade pipeline end-to-end (buildkit-operator#21 stuck 7 days on a dead security review; iterion#504 permanently unreviewable; a 116-write status storm; operators blamed for cancels nobody clicked):

- **`ValidateBranchName` now mirrors `git check-ref-format`** instead of a narrow allowlist. Renovate's grouped branches (`renovate/npm-(non-major)`) were rejected at the runner — both webhook launches DLQ'd, the PR could never be reviewed. Leading `-` stays refused (flag-injection defense).
- **No re-post over another dead run's synthetic gate failure.** Two dead runs on one head re-pointed the status target at themselves on every sweep tick — 116 GitHub status writes in 15 minutes on bko#21. One marker per head; the relaunch/escalation tail still walks (pinned by tests).
- **The board escalation names BOTH dead runs** (original + relaunch, via a `gate_relaunch_of` launch var — the card used to cite one URL twice) **and is now also posted as a PR comment**: the card alone sat unseen in a team inbox for 7 days while a security PR stayed blocked.
- **Truthful cancel reasons**: the webhook supersede lane records `superseded by a newer delivery` instead of `cancelled by user`, the prior error is preserved (it was being erased — the gate then displayed a lie), and the synthetic description strips queue/runner wrappers so the actionable cause fits the 140-char budget.

Plus Vetty 2.7.7: the verify-build skill pins timeouts as a strictness axis (sandbox 2-5× slower than CI; go test's implicit 10m held four green Actions-pin bumps `hold_unstable`).

Full audit + live-proof protocol in the session plan; a follow-up commit adds the e2e doorbell-race fix (`TestAwaitAnswersReleasedByAnswer`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)