### PR TITLE
fix(modernize): read a scalar exit_gate as one whole command

### DIFF
--- a/bots/campaign/main.bot
+++ b/bots/campaign/main.bot
@@ -835,9 +835,13 @@ tool finalize:
             gates = [gates]
         if not isinstance(gates, list) or not all(isinstance(g, str) for g in gates):
             return None
-        # A command containing a newline is refused by modernize's reader
-        # (its transport is newline-joined); accepting it here would let this
-        # supervisor requalify a lot the executing bot cannot even read.
+        # A command containing an INTERIOR newline is refused by modernize's
+        # reader (its transport is newline-joined); accepting it here would
+        # let this supervisor requalify a lot the executing bot cannot even
+        # read. Strip first — yq hands every block/folded scalar with a
+        # trailing newline, and a single-command block is legitimate.
+        gates = [g.strip() for g in gates]
+        gates = [g for g in gates if g]
         if any("\n" in g for g in gates):
             return None
         return gates

--- a/bots/campaign/main.bot
+++ b/bots/campaign/main.bot
@@ -835,6 +835,11 @@ tool finalize:
             gates = [gates]
         if not isinstance(gates, list) or not all(isinstance(g, str) for g in gates):
             return None
+        # A command containing a newline is refused by modernize's reader
+        # (its transport is newline-joined); accepting it here would let this
+        # supervisor requalify a lot the executing bot cannot even read.
+        if any("\n" in g for g in gates):
+            return None
         return gates
 
     requal = {"head": head[:12], "commands": {}, "lots": {}}
@@ -853,6 +858,12 @@ tool finalize:
                 requal["lots"][l.get("id")] = {"verdict": "unreadable exit_gate "
                                                "(%s) — not requalifiable"
                                                % type(l.get("exit_gate")).__name__}
+                continue
+            if not gates:
+                # Zero commands ran; "every gate command green" over an empty
+                # set is the vacuous claim this report exists to refuse.
+                requal["lots"][l.get("id")] = {"verdict": "no exit_gate "
+                                               "declared — not requalifiable"}
                 continue
             reds = [g for g in gates if requal["commands"][g]["rc"] != 0]
             if reds:

--- a/bots/campaign/main.bot
+++ b/bots/campaign/main.bot
@@ -830,11 +830,14 @@ tool finalize:
     # out one command per character (or per mapping key) and manufacture a
     # verdict nobody's gate ever rendered.
     def gate_commands(l):
+        """(commands, defect): commands is None when the gate is not
+        requalifiable, and defect names WHICH refusal, verbatim for the
+        committed verdict — the two causes are distinct diagnoses."""
         gates = l.get("exit_gate") or []
         if isinstance(gates, str):
             gates = [gates]
         if not isinstance(gates, list) or not all(isinstance(g, str) for g in gates):
-            return None
+            return None, "unreadable exit_gate (%s)" % type(l.get("exit_gate")).__name__
         # A command containing an INTERIOR newline is refused by modernize's
         # reader (its transport is newline-joined); accepting it here would
         # let this supervisor requalify a lot the executing bot cannot even
@@ -843,25 +846,24 @@ tool finalize:
         gates = [g.strip() for g in gates]
         gates = [g for g in gates if g]
         if any("\n" in g for g in gates):
-            return None
-        return gates
+            return None, "multi-line exit_gate command"
+        return gates, ""
 
     requal = {"head": head[:12], "commands": {}, "lots": {}}
     if not dirty and blocked:
         cmds = []
         for l in blocked:
-            for g in (gate_commands(l) or []):
+            for g in (gate_commands(l)[0] or []):
                 if g not in cmds:
                     cmds.append(g)
         for c in cmds:
             code, log = sh(c)
             requal["commands"][c] = {"rc": code, "tail": log[-400:]}
         for l in blocked:
-            gates = gate_commands(l)
+            gates, defect = gate_commands(l)
             if gates is None:
-                requal["lots"][l.get("id")] = {"verdict": "unreadable exit_gate "
-                                               "(%s) — not requalifiable"
-                                               % type(l.get("exit_gate")).__name__}
+                requal["lots"][l.get("id")] = {"verdict": "%s — not "
+                                               "requalifiable" % defect}
                 continue
             if not gates:
                 # Zero commands ran; "every gate command green" over an empty

--- a/bots/campaign/main.bot
+++ b/bots/campaign/main.bot
@@ -837,7 +837,10 @@ tool finalize:
         if isinstance(gates, str):
             gates = [gates]
         if not isinstance(gates, list) or not all(isinstance(g, str) for g in gates):
-            return None, "unreadable exit_gate (%s)" % type(l.get("exit_gate")).__name__
+            shape = (type(l.get("exit_gate")).__name__ if not isinstance(gates, list)
+                     else "list holding %s" % type(next(
+                         g for g in gates if not isinstance(g, str))).__name__)
+            return None, "unreadable exit_gate (%s)" % shape
         # A command containing an INTERIOR newline is refused by modernize's
         # reader (its transport is newline-joined); accepting it here would
         # let this supervisor requalify a lot the executing bot cannot even

--- a/bots/campaign/main.bot
+++ b/bots/campaign/main.bot
@@ -824,18 +824,36 @@ tool finalize:
                           else "RED (exit %d) — tail:\n\n```\n%s\n```" % (code, log[-1500:]))
 
     # Requalification: distinct commands once each, verdicts projected.
+    # Same contract surface as modernize's plan_read: a scalar exit_gate is
+    # one command, a sequence several; any other shape is unreadable and the
+    # lot carrying it is NOT requalifiable — iterating it raw would shell
+    # out one command per character (or per mapping key) and manufacture a
+    # verdict nobody's gate ever rendered.
+    def gate_commands(l):
+        gates = l.get("exit_gate") or []
+        if isinstance(gates, str):
+            gates = [gates]
+        if not isinstance(gates, list) or not all(isinstance(g, str) for g in gates):
+            return None
+        return gates
+
     requal = {"head": head[:12], "commands": {}, "lots": {}}
     if not dirty and blocked:
         cmds = []
         for l in blocked:
-            for g in (l.get("exit_gate") or []):
+            for g in (gate_commands(l) or []):
                 if g not in cmds:
                     cmds.append(g)
         for c in cmds:
             code, log = sh(c)
             requal["commands"][c] = {"rc": code, "tail": log[-400:]}
         for l in blocked:
-            gates = l.get("exit_gate") or []
+            gates = gate_commands(l)
+            if gates is None:
+                requal["lots"][l.get("id")] = {"verdict": "unreadable exit_gate "
+                                               "(%s) — not requalifiable"
+                                               % type(l.get("exit_gate")).__name__}
+                continue
             reds = [g for g in gates if requal["commands"][g]["rc"] != 0]
             if reds:
                 requal["lots"][l.get("id")] = {"verdict": "still blocked",

--- a/bots/campaign_gate_commands_test.go
+++ b/bots/campaign_gate_commands_test.go
@@ -1,0 +1,125 @@
+package bots
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCampaignGateCommandsNormalises executes the REAL gate_commands from
+// campaign's finalize node — the requalification half of the exit_gate
+// contract, and the half that actually shelled out one command per character
+// in the measured incident (modernize's reader was fixed first; this twin
+// re-reads the same field on the final tree).
+//
+// The two readers cannot share text (a function inside one node's script vs
+// an inline block in another bot's), so what keeps them aligned is executing
+// both against the same contract forms: modernize_plan_read_test pins the
+// reader, this pins the requalifier.
+func TestCampaignGateCommandsNormalises(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+
+	fn := extractPyFunc(t, toolScript(t, "campaign/main.bot", "finalize"), "gate_commands")
+
+	driver := fn + `
+import json, sys
+cases = {
+    "scalar": {"exit_gate": "test -f a && b.sh"},
+    "list": {"exit_gate": ["./gradlew build", "./verify.sh"]},
+    "block_single": {"exit_gate": "test -f a\n"},
+    "block_multi": {"exit_gate": "for f in a b; do\n  test -f \"$f\"\ndone\n"},
+    "mapping": {"exit_gate": {"build": "./gradlew build"}},
+    "list_with_none": {"exit_gate": ["./ok.sh", None]},
+    "empty": {"exit_gate": []},
+    "absent": {},
+}
+out = {}
+for name, lot in cases.items():
+    gates, defect = gate_commands(lot)
+    out[name] = {"gates": gates, "defect": defect}
+print(json.dumps(out))
+`
+	tmp := filepath.Join(t.TempDir(), "gate_commands.py")
+	if err := os.WriteFile(tmp, []byte(driver), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := exec.Command("python3", tmp).Output()
+	if err != nil {
+		t.Fatalf("gate_commands driver failed: %v (out %q)", err, raw)
+	}
+
+	type verdict struct {
+		Gates  []string `json:"gates"`
+		Defect string   `json:"defect"`
+	}
+	var got map[string]verdict
+	if uerr := json.Unmarshal(raw, &got); uerr != nil {
+		t.Fatalf("driver output is not JSON: %v (out %q)", uerr, raw)
+	}
+
+	want := map[string]verdict{
+		"scalar":       {Gates: []string{"test -f a && b.sh"}},
+		"list":         {Gates: []string{"./gradlew build", "./verify.sh"}},
+		"block_single": {Gates: []string{"test -f a"}},
+		"block_multi":  {Gates: nil, Defect: "multi-line exit_gate command"},
+		"mapping":      {Gates: nil, Defect: "unreadable exit_gate (dict)"},
+		"list_with_none": {Gates: nil,
+			Defect: "unreadable exit_gate (list holding NoneType)"},
+		"empty":  {Gates: []string{}},
+		"absent": {Gates: []string{}},
+	}
+	for name, w := range want {
+		g, ok := got[name]
+		if !ok {
+			t.Errorf("%s: missing from driver output", name)
+			continue
+		}
+		if strings.Join(g.Gates, "\x00") != strings.Join(w.Gates, "\x00") ||
+			(g.Gates == nil) != (w.Gates == nil) {
+			t.Errorf("%s: gates = %q, want %q", name, g.Gates, w.Gates)
+		}
+		if g.Defect != w.Defect {
+			t.Errorf("%s: defect = %q, want %q", name, g.Defect, w.Defect)
+		}
+	}
+}
+
+// extractPyFunc lifts one top-level-of-its-indent `def` (and its whole body)
+// out of a node script, dedented so it can run standalone.
+func extractPyFunc(t *testing.T, script, name string) string {
+	t.Helper()
+	lines := strings.Split(script, "\n")
+	start := -1
+	indent := 0
+	for i, l := range lines {
+		trimmed := strings.TrimLeft(l, " ")
+		if strings.HasPrefix(trimmed, "def "+name+"(") {
+			start = i
+			indent = len(l) - len(trimmed)
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatalf("def %s not found in node script", name)
+	}
+	var body []string
+	for _, l := range lines[start:] {
+		if len(body) > 0 {
+			trimmed := strings.TrimLeft(l, " ")
+			if trimmed != "" && len(l)-len(trimmed) <= indent {
+				break
+			}
+		}
+		if len(l) >= indent {
+			body = append(body, l[indent:])
+		} else {
+			body = append(body, "")
+		}
+	}
+	return strings.Join(body, "\n") + "\n"
+}

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -333,6 +333,15 @@ tool plan_read:
         refuse("lot %s declares exit_gate in an unreadable shape (%s): write "
                "one command as a string, or a list of command strings."
                % (chosen.get("id"), type(chosen.get("exit_gate")).__name__))
+    # One command, one line: the field travels to the verifier newline-joined
+    # and is split back on newlines there, so a command CONTAINING a newline
+    # (a `|` block scalar, a multi-line list item) would be torn apart into
+    # fragments nobody declared. Multi-line logic belongs in a script file
+    # the gate invokes.
+    if any("\n" in c for c in gate):
+        refuse("lot %s declares a multi-line exit_gate command. Each command "
+               "must be a single line; put multi-line logic in a script file "
+               "and invoke it." % chosen.get("id"))
     if not gate:
         emit("lot %s declares no exit_gate. A lot with no gate cannot be "
              "verified, and an unverifiable lot is indistinguishable from one "

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -330,9 +330,12 @@ tool plan_read:
     # a gate nobody wrote. An unreadable gate is a contract that cannot be
     # read, not a lot with nothing to do.
     if not isinstance(gate, list) or not all(isinstance(c, str) for c in gate):
+        shape = (type(chosen.get("exit_gate")).__name__ if not isinstance(gate, list)
+                 else "list holding %s" % type(next(
+                     c for c in gate if not isinstance(c, str))).__name__)
         refuse("lot %s declares exit_gate in an unreadable shape (%s): write "
                "one command as a string, or a list of command strings."
-               % (chosen.get("id"), type(chosen.get("exit_gate")).__name__))
+               % (chosen.get("id"), shape))
     # One command, one line: the field travels to the verifier newline-joined
     # and is split back on newlines there, so a command CONTAINING a newline
     # (a `|` block scalar, a multi-line list item) would be torn apart into

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -325,6 +325,14 @@ tool plan_read:
     # lettre `t`.
     if isinstance(gate, str):
         gate = [gate]
+    # Any other shape (a mapping, a list holding non-strings) would ALSO
+    # survive the join — a dict contributes its keys — and hand the verifier
+    # a gate nobody wrote. An unreadable gate is a contract that cannot be
+    # read, not a lot with nothing to do.
+    if not isinstance(gate, list) or not all(isinstance(c, str) for c in gate):
+        refuse("lot %s declares exit_gate in an unreadable shape (%s): write "
+               "one command as a string, or a list of command strings."
+               % (chosen.get("id"), type(chosen.get("exit_gate")).__name__))
     if not gate:
         emit("lot %s declares no exit_gate. A lot with no gate cannot be "
              "verified, and an unverifiable lot is indistinguishable from one "

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -317,6 +317,14 @@ tool plan_read:
             emit("every lot in the contract is done.")
 
     gate = chosen.get("exit_gate") or []
+    # A YAML scalar declares one command, a sequence several — both are
+    # legitimate contract forms. Joining a bare string would iterate its
+    # CHARACTERS: the verifier then runs `t` (exit 127) instead of `test …`,
+    # and the lot can never converge. Mesure : premier lot d'une campagne de
+    # rejeu, gate `test -f …` declare en scalaire, verdict rouge sur la
+    # lettre `t`.
+    if isinstance(gate, str):
+        gate = [gate]
     if not gate:
         emit("lot %s declares no exit_gate. A lot with no gate cannot be "
              "verified, and an unverifiable lot is indistinguishable from one "

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -336,8 +336,12 @@ tool plan_read:
     # One command, one line: the field travels to the verifier newline-joined
     # and is split back on newlines there, so a command CONTAINING a newline
     # (a `|` block scalar, a multi-line list item) would be torn apart into
-    # fragments nobody declared. Multi-line logic belongs in a script file
-    # the gate invokes.
+    # fragments nobody declared. Strip before judging — yq hands every block
+    # and folded scalar with a TRAILING newline, and a single-command block
+    # is legitimate; only an interior newline is the multi-line thing being
+    # refused. Multi-line logic belongs in a script file the gate invokes.
+    gate = [c.strip() for c in gate]
+    gate = [c for c in gate if c]
     if any("\n" in c for c in gate):
         refuse("lot %s declares a multi-line exit_gate command. Each command "
                "must be a single line; put multi-line logic in a script file "

--- a/bots/modernize/skills/plan-contract.md
+++ b/bots/modernize/skills/plan-contract.md
@@ -65,7 +65,9 @@ is a bookmark, not evidence.
 ## `exit_gate`
 
 A list of shell commands, run in order, in the repository root. **Every one must
-exit 0.** They are the definition of the lot, so write them to be:
+exit 0.** Write the list form; a bare string (one command) is accepted on read,
+anything else is refused as unreadable. They are the definition of the lot, so
+write them to be:
 
 - **Deterministic** — the same command on the same tree gives the same verdict.
   A gate that depends on the network or on wall-clock time will eventually fail

--- a/bots/modernize/skills/plan-contract.md
+++ b/bots/modernize/skills/plan-contract.md
@@ -66,9 +66,9 @@ is a bookmark, not evidence.
 
 A list of shell commands, run in order, in the repository root. **Every one must
 exit 0.** Write the list form; a bare string (one command) is accepted on read,
-anything else is refused as unreadable. One command, one line — a command
-containing a newline (a `|` block scalar) is refused; put multi-line logic in
-a script file and invoke it. They are the definition of the lot, so
+anything else is refused as unreadable. One command, one line — commands are
+stripped (a single-command `|` block is fine), and a command with an interior
+newline is refused; put multi-line logic in a script file and invoke it. They are the definition of the lot, so
 write them to be:
 
 - **Deterministic** — the same command on the same tree gives the same verdict.

--- a/bots/modernize/skills/plan-contract.md
+++ b/bots/modernize/skills/plan-contract.md
@@ -66,7 +66,9 @@ is a bookmark, not evidence.
 
 A list of shell commands, run in order, in the repository root. **Every one must
 exit 0.** Write the list form; a bare string (one command) is accepted on read,
-anything else is refused as unreadable. They are the definition of the lot, so
+anything else is refused as unreadable. One command, one line — a command
+containing a newline (a `|` block scalar) is refused; put multi-line logic in
+a script file and invoke it. They are the definition of the lot, so
 write them to be:
 
 - **Deterministic** — the same command on the same tree gives the same verdict.

--- a/bots/modernize_plan_read_test.go
+++ b/bots/modernize_plan_read_test.go
@@ -35,13 +35,21 @@ func TestModernizePlanReadExitGateForms(t *testing.T) {
 		Notice      string `json:"notice"`
 	}
 
-	run := func(t *testing.T, planYAML string) planReadOut {
+	run := func(t *testing.T, planYAML string, wantExit int) planReadOut {
 		t.Helper()
 		ws := t.TempDir()
 		git := func(args ...string) {
 			t.Helper()
 			full := append([]string{"-C", ws}, args...)
-			if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			cmd := exec.Command("git", full...)
+			// The throwaway repo must not inherit the operator's global or
+			// system config: a core.hooksPath or commit.gpgsign there fails
+			// `git commit` for reasons unrelated to what this test pins.
+			cmd.Env = append(os.Environ(),
+				"GIT_CONFIG_GLOBAL=/dev/null",
+				"GIT_CONFIG_SYSTEM=/dev/null",
+			)
+			if out, err := cmd.CombinedOutput(); err != nil {
 				t.Fatalf("git %v: %v (%s)", args, err, out)
 			}
 		}
@@ -68,8 +76,16 @@ func TestModernizePlanReadExitGateForms(t *testing.T) {
 			t.Fatal(err)
 		}
 		out, err := exec.Command("python3", scriptPath).Output()
+		exit := 0
 		if err != nil {
-			t.Fatalf("plan_read failed to execute: %v (out %q)", err, out)
+			ee, ok := err.(*exec.ExitError)
+			if !ok {
+				t.Fatalf("plan_read failed to execute: %v (out %q)", err, out)
+			}
+			exit = ee.ExitCode()
+		}
+		if exit != wantExit {
+			t.Fatalf("plan_read exited %d, want %d (out %q)", exit, wantExit, out)
 		}
 		var res planReadOut
 		if uerr := json.Unmarshal(out, &res); uerr != nil {
@@ -86,7 +102,7 @@ lots:
     rebaseline_allowed: false
     exit_gate: test -f .tool-versions && bash scripts/env/probe.sh
     status: todo
-`)
+`, 0)
 		if res.NothingToDo {
 			t.Fatalf("nothing_to_do on a contract with a todo lot (notice %q)", res.Notice)
 		}
@@ -105,10 +121,24 @@ lots:
       - ./gradlew --no-daemon build -x test
       - ./gradlew --no-daemon bootJar
     status: todo
-`)
+`, 0)
 		want := "./gradlew --no-daemon build -x test\n./gradlew --no-daemon bootJar"
 		if res.ExitGate != want {
 			t.Fatalf("exit_gate = %q, want %q", res.ExitGate, want)
+		}
+	})
+
+	t.Run("mapping gate is refused as unreadable", func(t *testing.T) {
+		res := run(t, `version: 1
+lots:
+  - id: T2
+    title: slip
+    exit_gate:
+      build: ./gradlew build
+    status: todo
+`, 1)
+		if !strings.Contains(res.Notice, "unreadable shape") {
+			t.Fatalf("notice = %q, want an unreadable-shape refusal", res.Notice)
 		}
 	})
 }

--- a/bots/modernize_plan_read_test.go
+++ b/bots/modernize_plan_read_test.go
@@ -1,0 +1,114 @@
+package bots
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestModernizePlanReadExitGateForms pins the contract surface of the
+// `exit_gate` field. A YAML scalar and a YAML sequence are both legitimate
+// ways to declare a lot's gate, and the reader must hand the verifier whole
+// commands either way.
+//
+// The failure this guards: `"\n".join(gate)` over a bare string iterates its
+// CHARACTERS, so the verifier's first command is the single letter `t`
+// (exit 127: `t: not found`) and the lot can never converge — a red verdict
+// manufactured by the reader, not earned by the tree.
+func TestModernizePlanReadExitGateForms(t *testing.T) {
+	for _, tool := range []string{"python3", "git", "yq"} {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not on PATH", tool)
+		}
+	}
+
+	script := toolScript(t, "modernize/main.bot", "plan_read")
+
+	type planReadOut struct {
+		NothingToDo bool   `json:"nothing_to_do"`
+		LotID       string `json:"lot_id"`
+		ExitGate    string `json:"exit_gate"`
+		Notice      string `json:"notice"`
+	}
+
+	run := func(t *testing.T, planYAML string) planReadOut {
+		t.Helper()
+		ws := t.TempDir()
+		git := func(args ...string) {
+			t.Helper()
+			full := append([]string{"-C", ws}, args...)
+			if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+				t.Fatalf("git %v: %v (%s)", args, err, out)
+			}
+		}
+		git("init", "-q", "-b", "main")
+		git("config", "user.email", "t@example.com")
+		git("config", "user.name", "t")
+		if err := os.MkdirAll(filepath.Join(ws, ".modernize"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(ws, ".modernize", "plan.yaml"), []byte(planYAML), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		git("add", ".modernize/plan.yaml")
+		git("commit", "-qm", "contract")
+
+		body := strings.ReplaceAll(script, "{{vars.workspace_dir}}", strconv.Quote(ws))
+		body = strings.ReplaceAll(body, "{{vars.plan_path}}", strconv.Quote(".modernize/plan.yaml"))
+		body = strings.ReplaceAll(body, "{{vars.only_lot}}", strconv.Quote(""))
+		if i := strings.Index(body, "{{"); i >= 0 {
+			t.Fatalf("unresolved template ref in plan_read near %q", body[i:min(i+40, len(body))])
+		}
+		scriptPath := filepath.Join(t.TempDir(), "plan_read.py")
+		if err := os.WriteFile(scriptPath, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		out, err := exec.Command("python3", scriptPath).Output()
+		if err != nil {
+			t.Fatalf("plan_read failed to execute: %v (out %q)", err, out)
+		}
+		var res planReadOut
+		if uerr := json.Unmarshal(out, &res); uerr != nil {
+			t.Fatalf("plan_read output is not JSON: %v (out %q)", uerr, out)
+		}
+		return res
+	}
+
+	t.Run("scalar gate reaches the verifier whole", func(t *testing.T) {
+		res := run(t, `version: 1
+lots:
+  - id: T1
+    title: toolchain
+    rebaseline_allowed: false
+    exit_gate: test -f .tool-versions && bash scripts/env/probe.sh
+    status: todo
+`)
+		if res.NothingToDo {
+			t.Fatalf("nothing_to_do on a contract with a todo lot (notice %q)", res.Notice)
+		}
+		want := "test -f .tool-versions && bash scripts/env/probe.sh"
+		if res.ExitGate != want {
+			t.Fatalf("exit_gate = %q, want the whole command %q", res.ExitGate, want)
+		}
+	})
+
+	t.Run("sequence gate joins one command per line", func(t *testing.T) {
+		res := run(t, `version: 1
+lots:
+  - id: L1
+    title: build
+    exit_gate:
+      - ./gradlew --no-daemon build -x test
+      - ./gradlew --no-daemon bootJar
+    status: todo
+`)
+		want := "./gradlew --no-daemon build -x test\n./gradlew --no-daemon bootJar"
+		if res.ExitGate != want {
+			t.Fatalf("exit_gate = %q, want %q", res.ExitGate, want)
+		}
+	})
+}

--- a/bots/modernize_plan_read_test.go
+++ b/bots/modernize_plan_read_test.go
@@ -128,6 +128,22 @@ lots:
 		}
 	})
 
+	t.Run("block-scalar gate is refused as multi-line", func(t *testing.T) {
+		res := run(t, `version: 1
+lots:
+  - id: T3
+    title: loop
+    exit_gate: |
+      for f in a b; do
+        test -f "$f"
+      done
+    status: todo
+`, 1)
+		if !strings.Contains(res.Notice, "multi-line") {
+			t.Fatalf("notice = %q, want a multi-line refusal", res.Notice)
+		}
+	})
+
 	t.Run("mapping gate is refused as unreadable", func(t *testing.T) {
 		res := run(t, `version: 1
 lots:

--- a/bots/modernize_plan_read_test.go
+++ b/bots/modernize_plan_read_test.go
@@ -128,6 +128,20 @@ lots:
 		}
 	})
 
+	t.Run("single-command block scalar is one command, trailing newline stripped", func(t *testing.T) {
+		res := run(t, `version: 1
+lots:
+  - id: T4
+    title: block
+    exit_gate: |
+      test -f .tool-versions
+    status: todo
+`, 0)
+		if res.ExitGate != "test -f .tool-versions" {
+			t.Fatalf("exit_gate = %q, want the stripped single command", res.ExitGate)
+		}
+	})
+
 	t.Run("block-scalar gate is refused as multi-line", func(t *testing.T) {
 		res := run(t, `version: 1
 lots:

--- a/docs/bot-runs/modernize.md
+++ b/docs/bot-runs/modernize.md
@@ -4,6 +4,22 @@ Carries a repository through a programme of modernisation lots — steps whose
 entry and exit are both deterministic gates — against a behavioural oracle it
 is forbidden to rewrite. See [bots/modernize/](../../bots/modernize/).
 
+## 2026-08-25 — the reader manufactures a red: a scalar exit_gate runs one letter at a time (run 01a033f9)
+
+- Status: **ENGINE DEFECT, fixed.** First lot of a cloud campaign whose
+  contract declared its gates as YAML scalars.
+- `plan_read` joined the field with `"\n".join(gate)` unconditionally: a bare
+  string was iterated character by character, the verifier's first command was
+  the single letter `t` (exit 127: `t: not found`), and the fail_log opened
+  with a failure no declared gate ever rendered. The lot itself had landed its
+  work and reported `blocked` for its own, correct reason — the manufactured
+  red was stacked on top of a real one, which is how it was noticed at all.
+- Fix: scalar → one-command list at read time; any other shape is refused as
+  an unreadable contract (a mapping would survive the join too — as its KEYS).
+  Campaign's blocked-lot requalification reads the same field and got the same
+  normalisation. Pinned by a bot-level test that executes the real `plan_read`
+  against both legitimate contract forms plus the mapping refusal.
+
 ## 2026-07-28 — the modernisation converges: green gate, green net, verified twice (runs 019fa8e7, 019fa8fd)
 
 - Status: **VALIDATED.** Two major build-tool versions and four framework lines


### PR DESCRIPTION
## What

`plan_read` joined a lot's `exit_gate` with `"\n".join(gate)` unconditionally. A YAML **scalar** (one command as a bare string) was therefore iterated character by character: the verifier's first command became a single letter, failed with `exit 127: not found`, and the lot could never converge — a red verdict manufactured by the reader, not earned by the tree.

Measured on a live campaign: first lot of a programme declared `exit_gate: test -f …` in scalar form; the gate ran `t`.

## Fix

Normalise a string to a one-command list before joining. Both YAML forms are legitimate contract surface:

```yaml
exit_gate: test -f .tool-versions        # one command
exit_gate:                                # several
  - ./gradlew build
  - ./verify.sh
```

## Test

`bots/modernize_plan_read_test.go` runs the real `plan_read` script (extracted from the compiled bundle) against real git workspaces carrying each contract form, and pins that the verifier receives whole commands. Full `./bots/` suite: 216 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)