### PR TITLE
fix(forge): Senti security-read — Revi's last three findings

### DIFF
--- a/pkg/forge/refresh.go
+++ b/pkg/forge/refresh.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/secrets"
@@ -160,7 +161,13 @@ func (w *RefreshWorker) refreshOne(ctx context.Context, conn Connection) error {
 	now := w.now()
 	conn.SealedPayload = sealed
 	conn.Status = StatusActive
-	conn.StatusReason = "" // a successful mint clears any prior degrade/reauth reason
+	// A successful mint clears a prior degrade/reauth reason — but NOT the
+	// security-read one: that lane is independent (the forge token is fine,
+	// the alerts grant is not), so wiping it here would leave the opt-in
+	// switched off with nothing left to say why, ~55 minutes later.
+	if conn.SecurityReadEnabled || !strings.HasPrefix(conn.StatusReason, securityReadDegradePrefix) {
+		conn.StatusReason = ""
+	}
 	conn.LastRefreshedAt = &now
 	if !out.ExpiresAt.IsZero() {
 		exp := out.ExpiresAt
@@ -215,6 +222,11 @@ func (w *RefreshWorker) refreshOne(ctx context.Context, conn Connection) error {
 	return nil
 }
 
+// securityReadDegradePrefix marks a StatusReason that belongs to the
+// security-read lane, so an ordinary (successful) token refresh does not
+// erase the one explanation an operator has for a silently-off opt-in.
+const securityReadDegradePrefix = "security-read disabled: "
+
 // markSecurityReadDegraded turns the security-read opt-in back off on a
 // PERMANENT mint failure, stamping the actionable reason. The connection
 // itself stays usable (its forge token is unaffected) — only the alerts
@@ -223,8 +235,8 @@ func (w *RefreshWorker) refreshOne(ctx context.Context, conn Connection) error {
 func (w *RefreshWorker) markSecurityReadDegraded(ctx context.Context, conn Connection, cause error) error {
 	conn.SecurityReadEnabled = false
 	conn.StatusReason = fmt.Sprintf(
-		"security-read disabled: %v — approve 'Dependabot alerts: read' on the installation, then re-enable it",
-		cause)
+		"%s%v — approve 'Dependabot alerts: read' on the installation, then re-enable it",
+		securityReadDegradePrefix, cause)
 	conn.UpdatedAt = w.now()
 	return w.Connections.Update(ctx, conn)
 }

--- a/pkg/forge/refresh_test.go
+++ b/pkg/forge/refresh_test.go
@@ -46,6 +46,17 @@ func (s tenantScopedSecretStore) ListByTeam(ctx context.Context, teamID, userID 
 	return s.MemoryGenericSecretStore.ListByTeam(ctx, teamID, userID)
 }
 
+// UpdateIfFingerprint is the method guardedUpdate PREFERS whenever the store
+// implements it — which the embedded memory store now does. Without this
+// override the promoted method bypasses the very tenant assertion this
+// double exists to make.
+func (s tenantScopedSecretStore) UpdateIfFingerprint(ctx context.Context, rec secrets.GenericSecret, expected string) error {
+	if t, ok := store.TenantFromContext(ctx); !ok || t == "" {
+		return errNoTenant
+	}
+	return s.MemoryGenericSecretStore.UpdateIfFingerprint(ctx, rec, expected)
+}
+
 func (s tenantScopedSecretStore) Delete(ctx context.Context, id string) error {
 	if t, ok := store.TenantFromContext(ctx); !ok || t == "" {
 		return errNoTenant

--- a/pkg/forge/security_read_test.go
+++ b/pkg/forge/security_read_test.go
@@ -489,3 +489,52 @@ func TestSecurityReadOrgKey_RefusesTheAppBotHandle(t *testing.T) {
 		t.Fatalf("pat key = %q (err %v)", key, err)
 	}
 }
+
+func TestRefreshWorker_KeepsTheSecurityReadReasonAcrossRefreshes(t *testing.T) {
+	sealer, _ := secrets.NewAESGCMSealer(make([]byte, 32))
+	connStore := NewMemoryConnectionStore()
+	secStore := secrets.NewMemoryGenericSecretStore()
+	now := time.Unix(1700000000, 0).UTC()
+	conn := seedGitHubAppConn(t, sealer, connStore, now.Add(2*time.Minute), true)
+	if err := UpsertSecurityReadToken(context.Background(), secStore, sealer, &conn, "ghs_live", now); err != nil {
+		t.Fatal(err)
+	}
+	// A moving clock: the connection only becomes due again once its freshly
+	// bumped expiry re-enters the lead window — the "~55 minutes later" that
+	// makes this bug invisible within a single tick.
+	clock := now
+	w := &RefreshWorker{
+		Connections: connStore, Secrets: tenantScopedSecretStore{secStore}, Sealer: sealer,
+		Now: func() time.Time { return clock },
+		RefresherFor: func(Connection) TokenRefresher {
+			return fakeRefresher{newAccess: "fresh", expiresAt: clock.Add(time.Hour)}
+		},
+		SecurityMinter: func(context.Context, Connection) (string, error) {
+			return "", ErrPermissionsNotGranted
+		},
+	}
+	if _, err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	got, _ := connStore.Get(context.Background(), "conn-gh")
+	if got.SecurityReadEnabled || !strings.Contains(got.StatusReason, "Dependabot alerts") {
+		t.Fatalf("degrade not recorded: enabled=%v reason=%q", got.SecurityReadEnabled, got.StatusReason)
+	}
+
+	// The forge token keeps refreshing fine (the two lanes are independent).
+	// That success must NOT erase the one explanation an operator has for an
+	// opt-in that is now silently off.
+	clock = clock.Add(58 * time.Minute)
+	if _, err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("second RunOnce: %v", err)
+	}
+	got, _ = connStore.Get(context.Background(), "conn-gh")
+	// Guard the guard: without an actual second refresh this test proves
+	// nothing (the connection would simply not be due).
+	if got.LastRefreshedAt == nil || !got.LastRefreshedAt.Equal(clock) {
+		t.Fatalf("the second tick must have refreshed the connection (last=%v, clock=%v)", got.LastRefreshedAt, clock)
+	}
+	if !strings.Contains(got.StatusReason, "Dependabot alerts") {
+		t.Fatalf("the security-read reason was erased by an ordinary refresh: %q", got.StatusReason)
+	}
+}

--- a/pkg/server/forge_connections_routes.go
+++ b/pkg/server/forge_connections_routes.go
@@ -451,11 +451,17 @@ func (s *Server) handlePatchForgeConnection(w http.ResponseWriter, r *http.Reque
 			httpError(w, http.StatusInternalServerError, "%v", err)
 			return
 		}
-	} else {
-		// Unconditional: the stored flag and the secret map can disagree (a
-		// failed persist after a successful mint), and gating the withdrawal
-		// on the flag would answer 200 while leaving the org token in place.
-		// RemoveSecurityReadToken is idempotent on absence.
+	} else if conn.Kind == forge.KindGitHubApp {
+		// Unconditional for an App connection (the only kind that can hold a
+		// minted entry): the stored flag and the secret map can disagree —
+		// a failed persist after a successful mint — and gating the
+		// withdrawal on the flag would answer 200 while leaving the org
+		// token in place. RemoveSecurityReadToken is idempotent on absence.
+		//
+		// Scoped to that kind, though: a pat/oauth connection can never have
+		// minted anything, and its AccountLogin IS an org name — withdrawing
+		// on it would delete that org's entry from the operator's own
+		// hand-set map, which is the documented non-App path.
 		if err := forge.RemoveSecurityReadToken(ctx, s.genericSecrets, s.sealer, &conn); err != nil {
 			httpError(w, http.StatusInternalServerError, "%v", err)
 			return

--- a/pkg/server/forge_security_read_routes_test.go
+++ b/pkg/server/forge_security_read_routes_test.go
@@ -223,3 +223,36 @@ func TestSecurityReadPatch_CollisionReadsTheOrgNotTheBotHandle(t *testing.T) {
 		t.Fatalf("same org on two hosts must be refused: code=%d body=%s", w.Code, w.Body.String())
 	}
 }
+
+// TestSecurityReadPatch_DisableLeavesAnUnrelatedPATConnectionAlone pins the
+// asymmetry the enable branch already had: a pat/oauth connection can never
+// have minted anything, and its AccountLogin IS an org name — so withdrawing
+// on it would delete that org's entry from the operator's own hand-set map.
+func TestSecurityReadPatch_DisableLeavesAnUnrelatedPATConnectionAlone(t *testing.T) {
+	s := newForgeTestServer(t)
+	// An operator's hand-set map, exactly as the runbook describes it.
+	id := secrets.NewGenericSecretID()
+	body := `{"acme":"ghp_hand_set"}`
+	sealed, _ := secrets.SealGenericSecret(s.sealer, id, []byte(body))
+	if err := s.genericSecrets.Create(context.Background(), secrets.GenericSecret{
+		ID: id, TenantID: "t1", ScopeTeamID: "t1", Name: forge.SecurityReadSecretName,
+		SealedSecret: sealed, Fingerprint: secrets.FingerprintSHA256(body), CreatedBy: "u-operator",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// An unrelated PAT connection whose account happens to be that org.
+	if err := s.forgeConnections.Create(context.Background(), forge.Connection{
+		ID: "p1", TenantID: "t1", Provider: forge.ProviderGitHub, Kind: forge.KindPAT,
+		Status: forge.StatusActive, AccountLogin: "acme",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if w := patchSecurityRead(t, s, "p1", false); w.Code != http.StatusOK {
+		t.Fatalf("code=%d body=%s", w.Code, w.Body.String())
+	}
+	m, ok := securityReadMapFor(t, s)
+	if !ok || m["acme"] != "ghp_hand_set" {
+		t.Fatalf("the operator's hand-set entry must survive, got %v (present=%v)", m, ok)
+	}
+}


### PR DESCRIPTION
Suite de #515, mergée pendant que ces correctifs finissaient d'être validés (la merge queue verrouille la branche, donc ils arrivent séparément).

Ce sont les 3 derniers findings de Revi sur cette PR — sa gate était déjà **verte** (aucun haut ni critique), ces trois-là sont medium/low et cohérents entre eux : chacun concerne un chemin où une action légitime en abîme une autre.

- **R6592f7** [medium/data] — la branche *disable* du PATCH tournait pour **n'importe quel type** de connexion alors que la branche *enable* refuse les non-App. Or l'`AccountLogin` d'une connexion PAT/OAuth **est** un nom d'org : un `PATCH {"security_read_enabled": false}` sur une connexion PAT sans rapport supprimait l'entrée de cet org dans la map — y compris celle que l'opérateur a posée à la main, qui est justement le chemin documenté hors App. Scopée à `github_app`, comme l'enable.
- **R6a58bf** [medium] — la raison de désactivation de security-read était effacée par le refresh **réussi** suivant du token forge (~55 min plus tard), laissant l'opt-in éteint sans plus rien pour expliquer pourquoi. Les deux voies sont indépendantes : la raison est préfixée et survit désormais.
- **R2044a6** [low/tests] — le double de test tenant-scopé gardait `Update` mais pas `UpdateIfFingerprint`, que `guardedUpdate` **préfère** dès que le store l'implémente. L'upsert security-read échappait donc à l'assertion que ce double existe pour poser.

Sur le troisième, une note qui vaut plus que le correctif : la non-régression de **R6a58bf** exigeait une **horloge qui avance** pour discriminer. Avec une horloge figée, la connexion n'est pas due au second tick, donc le test passait contre son propre défaut. Il assertit maintenant que le refresh a bien eu lieu avant d'asserter ce qui y a survécu.

`task check` complet vert sur `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)