### PR TITLE
feat(bots): product-docs (Prody) — functional documentation from a multi-repo product catalog

### DIFF
--- a/bots/issue-triage/iterion-bot-catalog-static.md
+++ b/bots/issue-triage/iterion-bot-catalog-static.md
@@ -39,7 +39,8 @@ Walk top-to-bottom; first match wins.
 | "review this branch / PR AND fix AND commit" | `branch-improve-loop` |
 | "review this PR / branch and just REPORT the issues" — read-only, findings only | `review-pr` |
 | "upgrade dependencies", "patch CVEs", "bump versions" — MUTATING manifests/lockfiles | `secured-renovacy` |
-| "audit the docs", "code↔doc drift", "outdated README" | `docs-refresh` |
+| "document what the product does for its users", "doc produit", "the user guide is out of date" — NON-TECHNICAL audience, dedicated docs repo, sources named by a product catalog | `product-docs` |
+| "audit the docs", "code↔doc drift", "outdated README" — TECHNICAL docs living next to the code | `docs-refresh` |
 | "audit the source for vulns" — DETECTION (findings, not fixes) | `sec-audit-source` |
 | "audit dependencies for malware / typosquats / supply-chain" — DETECTION | `sec-audit-deps` |
 | architectural choice, prioritisation, alignment, meetings | no fit |

--- a/bots/issue-triage/skills/iterion-bot-catalog.md
+++ b/bots/issue-triage/skills/iterion-bot-catalog.md
@@ -108,6 +108,7 @@ dispatcher routes on it), never the persona.
 | Morphy | `modernize` |
 | Nested Subbots Demo | `nested-subbots-demo` |
 | Pipeline Board Demo | `pipeline-board-demo` |
+| Prody | `product-docs` |
 | Revi (converse) | `revi-converse` |
 | Envy | `review-env` |
 | Revi | `review-pr` |
@@ -768,6 +769,68 @@ human / subbot only — no API keys, runs in seconds.
   produced-elements aggregation (image/audio preview) across the whole run
   tree. Not a production workflow.
 - **Path**: `examples/pipeline-board-demo/main.bot`
+
+### `product-docs` — Prody
+
+Functional documentation bot — one capable agent writes and maintains
+the BUSINESS-AUDIENCE documentation of a product ("what it does for
+its users") inside a DEDICATED documentation repository, grounded in
+the source code of the N repositories a product catalog names.
+
+It resolves the product from a catalog YAML (`catalog_path` +
+`product_id`), shallow-clones every source repo out of the docs
+worktree, redacts secret-bearing files from those clones, then reads
+what the sources actually implement — user-facing templates, i18n
+catalogs, form and validation rules, routes, API contracts, any
+framework — and writes the product's pages: a hub per user role or
+journey, one sub-page per step. Every page lands as its own
+`docs(...)` commit carrying a `Bot: product-docs` trailer and a
+`Product-Docs-Sources: <repo>@<sha>` trailer recording exactly which
+source commits it was written against.
+
+Sourced facts or `[à confirmer]` — never an invented business rule.
+Human-validated prose is preserved and touched only where the code
+contradicts it. A repository it could not clone is declared as a hole
+in the report, never documented from inference.
+
+The determinism is TRUTH-only: a scope gate fails the run if anything
+outside `<product_dir>/**/*.md` changed, an EDITORIAL LINT gate fails
+it if a published page still carries working notes, and convergence
+is those two gates ∧ the campaign's honest `docs_aligned` contract —
+nothing else. A deterministic scan runs each pass as an ADVISORY
+hints producer (dead links, orphan pages, catalog surfaces no page
+covers): help the agent is free to contradict, never an obligation.
+
+EDITORIAL SOVEREIGNTY: the bundle ships generic default editorial
+skills in French (documentary model, GitBook blocks, glossary, tone),
+but when the docs repo publishes its own `.product-docs/*.md` those
+are authoritative and override the defaults. The product team owns
+its editorial line; the bot brings a default, not a house style.
+
+Opt-in delivery: open_mr=true pushes the page series and opens ONE
+pull request at the end of the run — as a DRAFT by default, because
+functional documentation is validated by the product owners on the
+forge and marking it ready is their act, not the bot's.
+
+- **Use when**:
+  Use to generate or maintain the FUNCTIONAL, non-technical
+  documentation of a product — what it does for its users, role by
+  role and journey by journey — when that documentation lives in its
+  OWN repository and the code lives in one or more OTHER repositories
+  named by a product catalog. Run it in the docs repo with
+  `catalog_path` + `product_id`. It writes `.md` under the product's
+  directory only, and never touches the source repositories.
+  
+  NOT for technical documentation living next to the code (that is
+  docs-refresh / Doki, which aligns a repo's own README / docs/ in
+  place), and NOT for a technical knowledge wiki (that is wiki-gen /
+  Wikky, which owns a `wiki/` tree in the code repo). The
+  distinguisher is the AUDIENCE first — a product's users, not its
+  developers — and the topology second: docs repo here, N source
+  repos there.
+- **Triggers**: product-docs, functional-docs, doc-produit
+- **Vars**: `catalog_path` (string), `clone_depth` (int), `diff_since` (string), `dismissed_path` (string), `editorial_dir` (string), `extra_forbidden_headings` (string), `lint_rules` (string), `max_hints` (int), `max_passes` (int), `mode` (string), `mr_base` (string), `mr_branch` (string), `mr_draft` (bool), `open_mr` (bool), `product_id` (string), `scope_notes` (string), `scratch_dir` (string), `secret_globs` (string), `source_issue_ref` (string), `workspace_dir` (string)
+- **Path**: `bots/product-docs/main.bot`
 
 ### `revi-converse` — Revi (converse)
 

--- a/bots/issue-triage/skills/iterion-bot-catalog.md
+++ b/bots/issue-triage/skills/iterion-bot-catalog.md
@@ -39,7 +39,8 @@ Walk top-to-bottom; first match wins.
 | "review this branch / PR AND fix AND commit" | `branch-improve-loop` |
 | "review this PR / branch and just REPORT the issues" — read-only, findings only | `review-pr` |
 | "upgrade dependencies", "patch CVEs", "bump versions" — MUTATING manifests/lockfiles | `secured-renovacy` |
-| "audit the docs", "code↔doc drift", "outdated README" | `docs-refresh` |
+| "document what the product does for its users", "doc produit", "the user guide is out of date" — NON-TECHNICAL audience, dedicated docs repo, sources named by a product catalog | `product-docs` |
+| "audit the docs", "code↔doc drift", "outdated README" — TECHNICAL docs living next to the code | `docs-refresh` |
 | "audit the source for vulns" — DETECTION (findings, not fixes) | `sec-audit-source` |
 | "audit dependencies for malware / typosquats / supply-chain" — DETECTION | `sec-audit-deps` |
 | architectural choice, prioritisation, alignment, meetings | no fit |

--- a/bots/product-docs/README.md
+++ b/bots/product-docs/README.md
@@ -1,0 +1,212 @@
+# product-docs (Prody)
+
+Functional documentation bot — one capable agent + a mission + **truth
+gates only**. It writes and maintains the **business-audience**
+documentation of a product ("what it does for its users") inside a
+**dedicated documentation repository**, grounded in the source code of
+the **N other repositories** a product catalog names.
+
+- **Audience first**: the pages are read by the people who USE the
+  product — agents, managers, citizens, partners — not by the people who
+  build it. Code, schemas, endpoints, environment variables, deployment
+  and architecture are all out of scope, by construction.
+- **Cross-repo by construction**: the docs live here, the code lives
+  there. `catalog_ingest` shallow-clones every source repo into an
+  out-of-tree scratch dir and redacts credential-bearing files from the
+  clones before the agent may read them.
+- **Sourced or `[à confirmer]` — never invented.** Every factual claim
+  is grounded in something read in a source clone, or in human-validated
+  prose already on the page. There is no third option.
+- **Human-validated prose is preserved**, and touched only where the
+  code contradicts it or a documented journey is incomplete.
+- **A repository it could not read is a hole it declares**, in the
+  report and in the PR body — never an area documented from inference.
+
+Each aligned page lands in stride (`docs(<page>): …` plus a `Bot:
+product-docs` trailer **and** a `Product-Docs-Sources: <repo>@<sha>`
+trailer). Claims the product is meant to honour but the code does not
+implement yet are neither deleted nor aligned down: they go to a
+cross-pass promises ledger and are reported under "Points à confirmer
+avec l'équipe produit".
+
+## The three documentation bots
+
+All three write `.md` and commit. Settle the **audience** first; the
+topology follows.
+
+| Bot | Audience | Where the pages live | What it does |
+|---|---|---|---|
+| `docs-refresh` (Doki) | developers | the code repo, in place | aligns the repo's **existing** technical docs against the code |
+| `wiki-gen` (Wikky) | developers | the code repo, `wiki/` | **generates** a navigable OKF wiki it owns |
+| `product-docs` (Prody) | the product's **users** | a **dedicated docs repo** | writes the **functional** documentation from N **other** repos |
+
+Prody is the only one that clones sources, and the only one whose output
+a non-developer is expected to act on.
+
+## Editorial sovereignty
+
+The editorial line does **not** live in this bundle.
+
+1. **`<workspace>/.product-docs/*.md`** — the docs repository's own
+   editorial skills (documentary model, allowed blocks, glossary, tone).
+   **Authoritative**: where they disagree with the bundle, they win.
+   `scan_hints` reports the overrides in force on every pass, and the
+   scope gate **excludes** that directory so the bot can never rewrite
+   the charter that governs it.
+2. **The bundle's `skills/`** — a generic default, in French (the
+   published pages are French and end-user facing), used for whatever
+   the docs repo did not specify.
+
+What stays non-overridable is integrity, not taste: sourced facts or
+`[à confirmer]`, preserved human prose, declared holes, and the four
+`page_lint` rules. A docs repo may restyle every page; it may not
+authorise the bot to invent. See
+[ADR-091](../../docs/adr/091-product-docs-editorial-sovereignty-and-git-native-source-deltas.md).
+
+## Shape
+
+```
+catalog_ingest ─▶ scan_hints ─▶ campaign ─▶ scope_check ─▶ page_lint ─▶ gate
+gate ──(converged)──▶ mr_gate ─▶ forge_auth_probe ─▶ finalize_mr ─▶ done
+gate ─────────────────▶ scan_hints          (continuation_loop, max_passes)
+```
+
+- **`catalog_ingest`** (deterministic, once, outside the loop) — resolves
+  the product from the catalog, clones its source repos out of tree,
+  redacts secret-bearing files, and emits a per-repo inventory. A repo it
+  could not clone is present as a `degraded` entry **with a reason**,
+  never absent. A missing catalog, an unknown product or an entry without
+  `docs.product_dir` fails the run **loudly**: documenting the wrong
+  directory is worse than not running.
+- **`scan_hints`** (deterministic, advisory) — dead intra-doc links and
+  anchors, orphan pages (in a hub-and-step model an unlinked page is
+  invisible), catalog surfaces no page covers, empty pages, the editorial
+  overrides in force, and the incremental base. Help the campaign is free
+  to contradict — never a gate, never an obligation.
+- **`campaign`** — one adaptive `claude_code` agent, `session: fresh`.
+  Reads the source clones (i18n catalogs, templates, forms, routes, API
+  contracts — any framework, no per-framework parser anywhere in the
+  DSL), writes/repairs pages, commits each one in stride.
+- **`scope_check`** (deterministic truth gate) — the writeable set is
+  `<product_dir>/**/*.md` and nothing else: not the source clones, not
+  the docs repo's editorial skills, not another product's directory.
+- **`page_lint`** (deterministic truth gate) — a published page carries
+  no working notes: no HTML comments, no "Sources" box or section, no
+  "Points à clarifier" section, no "Correspondance technique" annex. A
+  violation is **not converged** and the located failures feed the next
+  pass.
+- **`gate`** — `converged = scope_ok ∧ lint_ok ∧ docs_aligned`. Nothing
+  else; the hint counts are telemetry, never conditions.
+
+A documentation-only change cannot break a build, so there is no build
+gate — `page_lint` is this bot's equivalent truth oracle on the artifact
+it actually ships.
+
+## The product catalog
+
+`catalog_path` is either a YAML/JSON **file** (one product, or a
+top-level `products:` map) or a **directory** holding one
+`<product_id>.yml` per product. Relative paths resolve inside the
+workspace.
+
+```yaml
+id: demo
+docs:
+  product_dir: documentation_produits/demo   # the writeable set
+  surfaces:                                   # optional, advisory
+    - name: Espace gestionnaire
+    - name: Espace citoyen
+gitlab:
+  host: gitlab.example.org                    # host for gitlab_path entries
+repos:
+  - id: demo-api
+    github_repo: org/demo-api                 # → https://github.com/org/demo-api.git
+  - id: demo-front
+    gitlab_path: group/demo/front             # → https://<gitlab.host>/group/demo/front.git
+  - id: demo-batch
+    url: https://forge.example.org/x/y.git    # explicit url wins over both
+    ref: main                                 # optional branch/tag
+```
+
+A `.json` catalog needs no dependency at all. A YAML catalog is parsed
+with PyYAML when the interpreter has it, otherwise with `yq` (declared
+in this bundle's `devbox.json`); with neither, the run fails with a
+precise message rather than guessing.
+
+## Incremental mode is git-native
+
+Every commit records which source commits it was written against:
+
+```
+Bot: product-docs
+Product-Docs-Sources: demo-api@a1b2c3d4e5f6,demo-front@0f1e2d3c4b5a
+```
+
+`catalog_ingest` reads the newest such trailer from the **docs repo's own
+history** and diffs each fresh clone from it. There is no side-car state
+file, so a crashed run, a wiped scratch dir or a fresh cloud pod loses
+nothing. When a shallow clone cannot reach a recorded commit the entry is
+marked `delta unavailable` with the reason — a delta that could not be
+computed is **never** reported as an empty one.
+
+## Inputs (main vars)
+
+| Var | Default | Description |
+|---|---|---|
+| `catalog_path` | **required** | Product catalog: a YAML/JSON file, or a directory holding `<product_id>.yml` |
+| `product_id` | **required** | Which product to document (selects the entry and its `product_dir`) |
+| `scope_notes` | `""` | Operator attention pin |
+| `mode` | `full` | `full` = whole-product sweep against the whole source corpus; `incremental` = scoped to the source delta (from the `Product-Docs-Sources:` trailer) and the docs delta (from the `Bot: product-docs` trailer) |
+| `diff_since` | `""` | Explicit incremental base on the docs side. Usually empty — `incremental` auto-detects it |
+| `editorial_dir` | `.product-docs` | Where the docs repo publishes its own AUTHORITATIVE editorial skills. Empty disables the override |
+| `clone_depth` | `1` | Shallow-clone depth for the source repos; `0` = full clone (raise it when a deep incremental base is needed) |
+| `secret_globs` | credential-carrier globs | Files deleted from every source clone before the agent may read them |
+| `lint_rules` | all four | Editorial rules `page_lint` enforces — drop a name to disable that rule |
+| `extra_forbidden_headings` | `""` | Extra heading titles a published page must never carry |
+| `max_hints` | `120` | Cap on the advisory hints list (context bound) |
+| `dismissed_path` | `${PROJECT_SCRATCH_DIR}/product-docs/dismissed.json` | Dismissals ledger (cross-pass memory) |
+| `scratch_dir` | `${PROJECT_SCRATCH_DIR}/product-docs` | Out-of-tree scratch: the source clones + the promises ledger |
+| `max_passes` | `4` | Continuation-loop cap |
+| `open_mr` | `false` | Push the page series + open ONE PR at the end |
+| `mr_draft` | `true` | Open that PR as a **draft** — human validation happens on the forge |
+| `mr_branch` / `mr_base` | `""` | PR branch (default `iterion/product-docs/<run-id>`) / base |
+| `source_issue_ref` | `""` | Issue to back-link the PR URL onto (forge URL or `native:<id>`) |
+
+## PR finalization (opt-in)
+
+`open_mr=true` appends the PR tail: a deterministic `forge_auth_probe`
+checks for a push credential (mounted `forge_token` secret, `*_TOKEN`
+env, or host `gh` auth) and only then the `finalize_mr` agent pushes the
+page series and opens one PR (GitHub `gh` / GitLab `glab` / Forgejo REST,
+per the bundle's `forge-mr-create` skill), reporting `drift_remaining`
+and `unread_sources` honestly in the body plus a "Points à confirmer avec
+l'équipe produit" section when the promises ledger has entries. Without a
+credential the tail skips cleanly and the commits stay on the run's
+storage branch. This is the delivery path for **cloud** runs, whose
+runner clone is ephemeral.
+
+**The PR is a draft by default.** Functional documentation is validated
+by the product owners on the forge, and marking it ready is their act,
+not the bot's. If a provider or CLI cannot open a draft, the PR is opened
+anyway and the reason is reported in `skipped_reason` — the `draft`
+output says whether the PR **is** a draft, not whether one was asked for.
+Set `--var mr_draft=false` for a repo whose review flow does not use
+drafts.
+
+## Run
+
+```bash
+iterion run bots/product-docs/main.bot \
+  --var catalog_path=catalog \
+  --var product_id=demo \
+  --var scope_notes='Le nouvel espace gestionnaire n'"'"'est pas documenté'
+```
+
+Add `--var open_mr=true` to open the (draft) pull request at the end, and
+`--var mode=incremental` for the scheduled weekly run.
+
+Skills shipped: `product-docs` (the operating playbook, English) plus the
+French editorial defaults `modele-documentaire`, `blocs-gitbook`,
+`glossaire-produit` and `ton-et-style`, and `forge-mr-create` for the
+opt-in PR tail — 6 skills total. See [main.bot](main.bot) for the full
+DSL.

--- a/bots/product-docs/README.md
+++ b/bots/product-docs/README.md
@@ -67,7 +67,8 @@ authorise the bot to invent. See
 
 ```
 catalog_ingest ─▶ scan_hints ─▶ campaign ─▶ scope_check ─▶ page_lint ─▶ gate
-gate ──(converged)──▶ mr_gate ─▶ forge_auth_probe ─▶ finalize_mr ─▶ done
+gate ──(converged)──▶ mr_gate ─▶ forge_auth_probe ─▶ finalize_mr
+                                          ─▶ surface_pr_link ─▶ done
 gate ─────────────────▶ scan_hints          (continuation_loop, max_passes)
 ```
 
@@ -106,8 +107,8 @@ it actually ships.
 
 `catalog_path` is either a YAML/JSON **file** (one product, or a
 top-level `products:` map) or a **directory** holding one
-`<product_id>.yml` per product. Relative paths resolve inside the
-workspace.
+`<product_id>.yml` / `.yaml` / `.json` per product. Relative paths
+resolve inside the workspace.
 
 ```yaml
 id: demo
@@ -166,7 +167,7 @@ computed is **never** reported as an empty one.
 | `max_hints` | `120` | Cap on the advisory hints list (context bound) |
 | `dismissed_path` | `${PROJECT_SCRATCH_DIR}/product-docs/dismissed.json` | Dismissals ledger (cross-pass memory) |
 | `scratch_dir` | `${PROJECT_SCRATCH_DIR}/product-docs` | Out-of-tree scratch: the source clones + the promises ledger |
-| `max_passes` | `4` | Continuation-loop cap |
+| `max_passes` | `4` | Continuation-loop cap: the loop back to `scan_hints` is taken at most this many times, so a run makes up to `max_passes + 1` campaign passes |
 | `open_mr` | `false` | Push the page series + open ONE PR at the end |
 | `mr_draft` | `true` | Open that PR as a **draft** — human validation happens on the forge |
 | `mr_branch` / `mr_base` | `""` | PR branch (default `iterion/product-docs/<run-id>`) / base |
@@ -202,8 +203,10 @@ iterion run bots/product-docs/main.bot \
   --var scope_notes='Le nouvel espace gestionnaire n'"'"'est pas documenté'
 ```
 
-Add `--var open_mr=true` to open the (draft) pull request at the end, and
-`--var mode=incremental` for the scheduled weekly run.
+Add `--var open_mr=true` to open the (draft) pull request at the end.
+The weekly scheduled invocation already carries `mode: incremental`
+(`manifest.yaml`); pass `--var mode=incremental` by hand for an
+out-of-band incremental pass.
 
 Skills shipped: `product-docs` (the operating playbook, English) plus the
 French editorial defaults `modele-documentaire`, `blocs-gitbook`,

--- a/bots/product-docs/README.md
+++ b/bots/product-docs/README.md
@@ -61,7 +61,7 @@ What stays non-overridable is integrity, not taste: sourced facts or
 `[à confirmer]`, preserved human prose, declared holes, and the four
 `page_lint` rules. A docs repo may restyle every page; it may not
 authorise the bot to invent. See
-[ADR-091](../../docs/adr/091-product-docs-editorial-sovereignty-and-git-native-source-deltas.md).
+[ADR-092](../../docs/adr/092-product-docs-editorial-sovereignty-and-git-native-source-deltas.md).
 
 ## Shape
 

--- a/bots/product-docs/devbox.json
+++ b/bots/product-docs/devbox.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.17.2/.schema/devbox.schema.json",
+  "packages": [
+    "gh@2.96.0",
+    "glab@1.108.0",
+    "yq-go@4.53.3"
+  ],
+  "env": {
+    "DEVBOX_NO_PROMPT": "true"
+  }
+}

--- a/bots/product-docs/devbox.lock
+++ b/bots/product-docs/devbox.lock
@@ -1,0 +1,143 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "gh@2.96.0": {
+      "last_modified": "2026-07-29T04:59:45Z",
+      "resolved": "github:NixOS/nixpkgs/9bc02893134c733dd85de46ee4fb2fac696b5529#gh",
+      "source": "devbox-search",
+      "version": "2.96.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/fc59sg6h20yvm9hh589zawj0n4xvjkyv-gh-2.96.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/fc59sg6h20yvm9hh589zawj0n4xvjkyv-gh-2.96.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hhli6yr6kkcqb24v5rjw4wdi3dabbp2s-gh-2.96.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/hhli6yr6kkcqb24v5rjw4wdi3dabbp2s-gh-2.96.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/waa7fl1d466lkihg89p60iisjwynyfb7-gh-2.96.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/waa7fl1d466lkihg89p60iisjwynyfb7-gh-2.96.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/9jyx6hrsjdcjx1gxmipj45bij5vzvq19-gh-2.96.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/9jyx6hrsjdcjx1gxmipj45bij5vzvq19-gh-2.96.0"
+        }
+      }
+    },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "last_modified": "2026-08-22T18:41:35Z",
+      "resolved": "github:NixOS/nixpkgs/174eb786fb68e3a13e4e535a3deea479a0c07a6a?lastModified=1787424095&narHash=sha256-dWLO5AHhKaw6rdWCtTes8hnntT1r0%2FJ5yhQGm0f0ZgU%3D"
+    },
+    "glab@1.108.0": {
+      "last_modified": "2026-08-01T16:34:20Z",
+      "resolved": "github:NixOS/nixpkgs/a5cbcfe954791221bfffe2307f7d1a1bf61a871e#glab",
+      "source": "devbox-search",
+      "version": "1.108.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ajfkpkbqqb33xv8yrk14sg9vv071q5qb-glab-1.108.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/ajfkpkbqqb33xv8yrk14sg9vv071q5qb-glab-1.108.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/s336hl6jq26m9jnhmfxw40sj3x7mm4jh-glab-1.108.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/s336hl6jq26m9jnhmfxw40sj3x7mm4jh-glab-1.108.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/rxfjy7iw808sa8gi6l36p8932y73h7q5-glab-1.108.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/rxfjy7iw808sa8gi6l36p8932y73h7q5-glab-1.108.0"
+        }
+      }
+    },
+    "yq-go@4.53.3": {
+      "last_modified": "2026-08-12T11:28:58Z",
+      "resolved": "github:NixOS/nixpkgs/044bfe75bfe4c7bbe043dc17b5e42ea823b84a09#yq-go",
+      "source": "devbox-search",
+      "version": "4.53.3",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/36qwbqaqq83bna6dxl8gq00893yf2pzw-yq-go-4.53.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/36qwbqaqq83bna6dxl8gq00893yf2pzw-yq-go-4.53.3"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/dq63h1d8cnz0536jyp2v12d2a3ksrycz-yq-go-4.53.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/dq63h1d8cnz0536jyp2v12d2a3ksrycz-yq-go-4.53.3"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/agf9fyr053m3092vsmh6vih3apz0kw05-yq-go-4.53.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/agf9fyr053m3092vsmh6vih3apz0kw05-yq-go-4.53.3"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/dmcm5z66qrywifn6aymsdhfx6rdiazpy-yq-go-4.53.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/dmcm5z66qrywifn6aymsdhfx6rdiazpy-yq-go-4.53.3"
+        }
+      }
+    }
+  }
+}

--- a/bots/product-docs/main.bot
+++ b/bots/product-docs/main.bot
@@ -65,7 +65,7 @@
 ## (default `.product-docs/`), those files are AUTHORITATIVE and
 ## override the bundle defaults wherever the two disagree. The product
 ## team owns its own editorial line; the bot brings a default, not a
-## house style. See ADR-091.
+## house style. See ADR-092.
 ##
 ## SOURCE DELTAS ARE GIT-NATIVE. Each in-stride commit carries a
 ## `Product-Docs-Sources: <repo-id>@<sha>,…` trailer naming exactly
@@ -75,7 +75,7 @@
 ## documented them" survives a crashed run, a fresh pod and a wiped
 ## scratch dir, with no side-car state file to lose. When a shallow
 ## clone cannot reach the recorded commit the delta is reported
-## UNAVAILABLE, never silently empty. See ADR-091.
+## UNAVAILABLE, never silently empty. See ADR-092.
 ##
 ## STACK/REPO-AGNOSTIC (CLAUDE.md "Catalog bots are repo-agnostic" +
 ## "Universal code bots"): no language, ecosystem, framework or repo
@@ -923,7 +923,23 @@ if not token:
             break
 git_env = dict(os.environ)
 git_env['GIT_TERMINAL_PROMPT'] = '0'
-if token:
+## The token belongs to ONE forge: the docs repo's own origin. The
+## helper answers only prompts naming that host -- the catalog is repo
+## content (hostile-grade), and an entry whose url points anywhere else
+## must get NO credential and fail its clone loudly, not hand the team
+## token to whichever host answered 401.
+forge_host = ''
+try:
+    _p = subprocess.run(['git', '-C', ws, 'remote', 'get-url', 'origin'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, timeout=30)
+    if _p.returncode == 0:
+        _u = _p.stdout.strip()
+        _m = re.search(r'^[a-z+]+://(?:[^/@]*@)?([^/:]+)', _u) or re.search(r'^(?:[^@]+@)([^:]+):', _u)
+        if _m:
+            forge_host = _m.group(1).strip().lower()
+except (OSError, subprocess.SubprocessError):
+    forge_host = ''
+forge_host = re.sub(r'[^a-z0-9.-]', '', forge_host)
+if token and forge_host:
     helper = os.path.join(scratch, 'git-askpass.sh')
     with open(helper, 'w', encoding='utf-8') as fh:
         ## chr(36) is the dollar sign: written literally, the SHELL
@@ -931,14 +947,26 @@ if token:
         ## helper reaches disk with its two arguments erased -- a shell
         ## syntax error, so every credentialed clone fails.
         D = chr(36)
-        fh.write('#!/bin/sh' + chr(10) + 'case ' + D + '1 in' + chr(10) + 'Username*) echo x-access-token ;;' + chr(10) + '*) printf %s ' + D + 'PRODUCT_DOCS_GIT_TOKEN ;;' + chr(10) + 'esac' + chr(10))
+        Q = chr(39)
+        ## Host guard: the prompt quotes the url (Username for
+        ## <quote>https://host<quote>: ), so the anchored patterns
+        ## ://host<quote> and @host<quote> cannot be satisfied by a
+        ## lookalike suffix domain. chr(34) is the double quote: a
+        ## literal one would terminate the sh -c string this python
+        ## body lives in.
+        DQ = chr(34)
+        guard = 'printf %s ' + DQ + D + '1' + DQ + ' | grep -qF -e ' + DQ + '://' + forge_host + Q + DQ + ' -e ' + DQ + '@' + forge_host + Q + DQ + ' || exit 1'
+        fh.write('#!/bin/sh' + chr(10) + guard + chr(10) + 'case ' + D + '1 in' + chr(10) + 'Username*) echo x-access-token ;;' + chr(10) + '*) printf %s ' + D + 'PRODUCT_DOCS_GIT_TOKEN ;;' + chr(10) + 'esac' + chr(10))
     os.chmod(helper, 0o700)
     git_env['GIT_ASKPASS'] = helper
     git_env['PRODUCT_DOCS_GIT_TOKEN'] = token
 
 def run_git(args, cwd=None, timeout=900):
     try:
-        p = subprocess.run(['git'] + args, cwd=cwd, env=git_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=timeout)
+        ## quotePath=false at the ONE choke point every call crosses:
+        ## the per-repo changed_files lists carry source paths, and the
+        ## sources of a French product name files with accents.
+        p = subprocess.run(['git', '-c', 'core.quotePath=false'] + args, cwd=cwd, env=git_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=timeout)
         return p.returncode, (p.stdout or ''), (p.stderr or '')
     except (OSError, subprocess.SubprocessError) as exc:
         return 1, '', str(exc)
@@ -951,8 +979,12 @@ def strip_creds(u):
 
 def redact(reason):
     ## Strip the token out of any git message before it reaches the
-    ## inventory, the events or the report.
+    ## inventory, the events or the report -- AND any inline url
+    ## credential the CATALOG itself carried (https://user:pass@host):
+    ## git echoes the full url in its clone errors, and this note
+    ## reaches the prompt, the events and the PR body.
     msg = ' '.join((reason or '').split())
+    msg = re.sub(r'://[^/@]*@', '://', msg)
     if token:
         msg = msg.replace(token, '<redacted>')
     return msg[:400]
@@ -1287,7 +1319,11 @@ mode = (os.environ.get('MODE') or 'full').strip().lower()
 diff_since = (os.environ.get('DIFF_SINCE') or '').strip()
 if mode == 'incremental' and not diff_since:
     try:
-        p = subprocess.run(['git', 'log', '-E', '--grep', '^Bot: product-docs', '-n', '1', '--format=%H'], capture_output=True, text=True, check=True)
+        ## Path-limited to THIS product, like catalog_ingest's own
+        ## stamp lookup: in a multi-product docs repo an unscoped grep
+        ## reads a SIBLING product's alignment commit and narrows this
+        ## product's delta window to nothing.
+        p = subprocess.run(['git', 'log', '-E', '--grep', '^Bot: product-docs', '-n', '1', '--format=%H', '--', product_dir], capture_output=True, text=True, check=True)
         diff_since = p.stdout.strip()
     except (OSError, subprocess.SubprocessError):
         diff_since = ''
@@ -1296,12 +1332,21 @@ recent = []
 if diff_since:
     for ref in (diff_since, 'origin/' + diff_since):
         try:
-            proc = subprocess.run(['git', 'diff', '--name-only', ref + '...HEAD'], capture_output=True, text=True, check=True)
+            ## quotePath=false so accented (French) page names come
+            ## back verbatim, not C-quoted into never-matching strings.
+            proc = subprocess.run(['git', '-c', 'core.quotePath=false', 'diff', '--name-only', ref + '...HEAD'], capture_output=True, text=True, check=True)
             recent = sorted(l for l in proc.stdout.splitlines() if l.strip())
             incremental_base = ref
             break
         except (OSError, subprocess.SubprocessError):
             recent = []
+if mode == 'incremental' and not incremental_base:
+    ## First run (or unreadable history): there is no alignment commit
+    ## to diff since, so an incremental pass would report an empty
+    ## delta the campaign is told to read as 'nothing changed'. The
+    ## honest degradation is a FULL sweep, said out loud.
+    mode = 'full'
+    hints_note = hints_note + '; BOOTSTRAP: no prior alignment commit for this product -- incremental mode degraded to a full sweep'
 print(json.dumps({'pages': pages, 'page_count': len(pages), 'hints': hints, 'hint_count': len(hints), 'dead_link_count': dead_link_count, 'orphan_count': orphan_count, 'unmapped_surface_count': unmapped_surface_count, 'checked_links': checked_links, 'ledger_excluded': ledger_excluded, 'truncated': truncated, 'hints_note': hints_note, 'editorial_files': editorial_files, 'mode': mode, 'incremental_base': incremental_base, 'recently_changed_pages': recent}, ensure_ascii=False))
 "`
   output: hints_output
@@ -1347,11 +1392,18 @@ editorial_dir = (os.environ.get('EDITORIAL_DIR') or '').strip().strip('/')
 base = (os.environ.get('BASE_SHA') or '').strip()
 
 def git(args):
-    try:
-        p = subprocess.run(['git', '-C', ws] + args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=120)
-        return p.stdout or ''
-    except (OSError, subprocess.SubprocessError):
-        return ''
+    ## core.quotePath=false: git C-quotes non-ASCII paths by default
+    ## (literal quotes + octal escapes), and this bot writes FRENCH
+    ## pages -- an accented filename must compare equal, not become a
+    ## permanent scope violation. A git failure RAISES: this gate is
+    ## the truth oracle, and an empty answer must fail it closed (the
+    ## same stance the empty-base guard below takes), never certify a
+    ## tree it did not diff. stderr stays separate so a git message can
+    ## never be mistaken for a changed path.
+    p = subprocess.run(['git', '-C', ws, '-c', 'core.quotePath=false'] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=120)
+    if p.returncode != 0:
+        raise RuntimeError('git ' + ' '.join(args[:2]) + ' rc=' + str(p.returncode) + ': ' + ' '.join((p.stderr or '').split())[:300])
+    return p.stdout or ''
 
 ## The base is RECORDED by catalog_ingest before the campaign writes
 ## anything. Re-deriving it from commit messages would hand the
@@ -1364,53 +1416,59 @@ if not base:
 ## --no-renames: with rename detection ON git reports only a rename's
 ## DESTINATION, so renaming a protected file onto an allowed .md path
 ## would delete it behind a green gate.
-changed = set(l for l in git(['diff', '--no-renames', base, '--name-only']).splitlines() if l.strip())
-## Mode 120000 is a symlink: writing THROUGH one escapes the repo
-## entirely, and committing one publishes a host path in the docs.
-symlinks = set()
-for row in git(['diff', '--no-renames', '--raw', base]).splitlines():
-    if not row.startswith(':'):
-        continue
-    meta, _, path = row.partition(chr(9))
-    fields = meta.split()
-    if len(fields) >= 2 and '120000' in (fields[0].lstrip(':'), fields[1]):
-        p = path.split(chr(9))[-1].strip()
-        if p:
-            symlinks.add(p)
-## -uall: without it git collapses an untracked directory into one
-## entry that never ends in .md, so a brand-new journey folder -- the
-## bootstrap case -- reds the gate on the very path it must write.
-for line in git(['status', '--porcelain', '-uall']).splitlines():
-    if line[:2].strip() == '??':
-        changed.add(line[3:].strip())
+try:
+    changed = set(l for l in git(['diff', '--no-renames', base, '--name-only']).splitlines() if l.strip())
+    ## Mode 120000 is a symlink: writing THROUGH one escapes the repo
+    ## entirely, and committing one publishes a host path in the docs.
+    symlinks = set()
+    for row in git(['diff', '--no-renames', '--raw', base]).splitlines():
+        if not row.startswith(':'):
+            continue
+        meta, _, path = row.partition(chr(9))
+        fields = meta.split()
+        if len(fields) >= 2 and '120000' in (fields[0].lstrip(':'), fields[1]):
+            p = path.split(chr(9))[-1].strip()
+            if p:
+                symlinks.add(p)
+    ## -uall: without it git collapses an untracked directory into one
+    ## entry that never ends in .md, so a brand-new journey folder -- the
+    ## bootstrap case -- reds the gate on the very path it must write.
+    for line in git(['status', '--porcelain', '-uall']).splitlines():
+        if line[:2].strip() == '??':
+            changed.add(line[3:].strip())
 
-# iterion materialises the bundle's skills into <workspace>/.claude/ at run
-# start and again on every resume. That tree is the ENGINE's own artifact
-# while it stays UNTRACKED: attributing it to the run would fail the gate on
-# every pass, and the campaign could not fix it — the next pass re-creates
-# it. A TRACKED path under it is a different thing: the run committed the
-# agent's own notes into the docs repo, so it stays in scope.
-tracked_claude = set(l.strip() for l in git(['ls-files', '--', '.claude']).splitlines() if l.strip())
-changed = set(p for p in changed if p in tracked_claude or (p != '.claude' and not p.startswith('.claude/')))
+    # iterion materialises the bundle's skills into <workspace>/.claude/ at run
+    # start and again on every resume. That tree is the ENGINE's own artifact
+    # while it stays UNTRACKED: attributing it to the run would fail the gate on
+    # every pass, and the campaign could not fix it — the next pass re-creates
+    # it. A TRACKED path under it is a different thing: the run committed the
+    # agent's own notes into the docs repo, so it stays in scope.
+    tracked_claude = set(l.strip() for l in git(['ls-files', '--', '.claude']).splitlines() if l.strip())
+    changed = set(p for p in changed if p in tracked_claude or (p != '.claude' and not p.startswith('.claude/')))
 
-def allowed(p):
-    if p in symlinks or os.path.islink(os.path.join(ws, p)):
-        return False
-    ## The editorial charter is the product team's own: the bot reads
-    ## it, is governed by it, and never rewrites it.
-    if editorial_dir and (p == editorial_dir or p.startswith(editorial_dir + '/')):
-        return False
-    if not p.endswith('.md'):
-        return False
-    if not product_dir:
-        return False
-    return p == product_dir or p.startswith(product_dir + '/')
+    def allowed(p):
+        if p in symlinks or os.path.islink(os.path.join(ws, p)):
+            return False
+        ## The editorial charter is the product team's own: the bot reads
+        ## it, is governed by it, and never rewrites it.
+        if editorial_dir and (p == editorial_dir or p.startswith(editorial_dir + '/')):
+            return False
+        if not p.endswith('.md'):
+            return False
+        if not product_dir:
+            return False
+        return p == product_dir or p.startswith(product_dir + '/')
 
-out_of_scope = sorted(p for p in changed if not allowed(p))
-log = ''
-if out_of_scope:
-    log = 'SCOPE VIOLATION: this run changed files outside the product writeable-set (.md under ' + (product_dir or '<product_dir>') + ' only, never a symlink, never the editorial charter ' + (editorial_dir or '<editorial_dir>') + '). Revert these before continuing (git revert the offending commits, or git checkout ' + base[:12] + ' -- <path>): ' + ', '.join(out_of_scope[:40])
-print(json.dumps({'scope_ok': not out_of_scope, 'out_of_scope': out_of_scope[:100], 'log': log}, ensure_ascii=False))
+    out_of_scope = sorted(p for p in changed if not allowed(p))
+    log = ''
+    if out_of_scope:
+        log = 'SCOPE VIOLATION: this run changed files outside the product writeable-set (.md under ' + (product_dir or '<product_dir>') + ' only, never a symlink, never the editorial charter ' + (editorial_dir or '<editorial_dir>') + '). Revert these before continuing (git revert the offending commits, or git checkout ' + base[:12] + ' -- <path>): ' + ', '.join(out_of_scope[:40])
+    print(json.dumps({'scope_ok': not out_of_scope, 'out_of_scope': out_of_scope[:100], 'log': log}, ensure_ascii=False))
+except Exception as exc:
+    ## Fail CLOSED: a gate that cannot compute the writeable set must
+    ## say so and refuse to certify -- git absent, a bad base, a
+    ## timeout. The campaign gets the reason verbatim.
+    print(json.dumps({'scope_ok': False, 'out_of_scope': [], 'log': 'SCOPE GATE UNAVAILABLE: ' + ' '.join(str(exc).split())[:400] + ' -- refusing to certify the writeable set.'}, ensure_ascii=False))
 "`
   output: scope_check_output
 

--- a/bots/product-docs/main.bot
+++ b/bots/product-docs/main.bot
@@ -1,0 +1,1589 @@
+## ─────────────────────────────────────────────────────────────────
+## product-docs (Prody) — FUNCTIONAL product documentation, generated
+## and maintained in a DEDICATED docs repository from a MULTI-REPO
+## product catalog.
+##
+## THE MISSION: make `<product_dir>/**/*.md` in this workspace (the
+## DOCS repo) a faithful, business-readable account of what the
+## product's source repositories actually implement — written for the
+## people who USE the product, not for the people who build it.
+##
+## THE THREE-BOT DISTINCTION (do not confuse them):
+##   - docs-refresh (Doki)  — aligns TECHNICAL docs that live NEXT TO
+##                            the code, in the same repo, in place.
+##   - wiki-gen (Wikky)     — generates a TECHNICAL OKF wiki it owns.
+##   - product-docs (Prody) — generates FUNCTIONAL, business-audience
+##                            documentation in a SEPARATE docs repo,
+##                            from N source repos named by a catalog.
+##
+## SHAPE — docs-refresh v3 topology (one capable agent + a mission +
+## TRUTH gates only; the scan is advisory, never an obligation):
+##
+##   catalog_ingest -> scan_hints -> campaign -> scope_check
+##     -> page_lint -> gate
+##   gate --(converged)--> mr_gate -> forge_auth_probe -> finalize_mr
+##   gate --> scan_hints            (continuation_loop, max_passes)
+##
+##   catalog_ingest — DETERMINISTIC. Parses the product catalog YAML,
+##                    resolves the product entry, shallow-clones every
+##                    source repo into an OUT-OF-TREE scratch dir
+##                    (never into the docs workspace), redacts
+##                    secret-bearing files from the clones, and emits a
+##                    per-repo inventory. A repo it cannot clone
+##                    becomes an explicit `degraded` entry with a
+##                    reason — never a silent skip, so the campaign
+##                    knows which part of the product it could NOT
+##                    read and says so instead of inventing.
+##   scan_hints     — DETERMINISTIC, ADVISORY. Dead intra-doc links and
+##                    anchors, orphan pages (a hub-and-step model makes
+##                    an unlinked page invisible), catalog surfaces no
+##                    page covers, the editorial overrides in force,
+##                    and the incremental base. Help, never a gate.
+##   campaign       — ONE adaptive claude_code agent. Reads the actual
+##                    source code in the clones (templates, i18n
+##                    catalogs, routes, OpenAPI — ANY framework, no
+##                    per-framework parser anywhere in this file),
+##                    writes/repairs pages, commits each aligned page
+##                    in stride with the `Bot: product-docs` trailer.
+##   scope_check    — DETERMINISTIC writeable set: `<product_dir>/**/
+##                    *.md` ONLY. The bot never edits source, never
+##                    edits the docs repo's own editorial skills.
+##   page_lint      — DETERMINISTIC editorial gate: a PUBLISHED page
+##                    carries no working notes. No "Sources" hint
+##                    boxes, no HTML comments, no "Points à clarifier"
+##                    section, no "Correspondance technique" annex.
+##                    A lint failure is NOT converged and feeds the
+##                    next pass.
+##   gate           — converged = scope_ok ∧ lint_ok ∧
+##                    campaign.docs_aligned. NOTHING ELSE.
+##
+## EDITORIAL SOVEREIGNTY — the core design constraint. The editorial
+## line does NOT live in this bundle. The bundle's `skills/` ship
+## GENERIC defaults (documentary model, GitBook blocks, glossary, tone)
+## in French, because the published pages are French and end-user
+## facing. When the DOCS REPO ships its own `<editorial_dir>/*.md`
+## (default `.product-docs/`), those files are AUTHORITATIVE and
+## override the bundle defaults wherever the two disagree. The product
+## team owns its own editorial line; the bot brings a default, not a
+## house style. See ADR-091.
+##
+## SOURCE DELTAS ARE GIT-NATIVE. Each in-stride commit carries a
+## `Product-Docs-Sources: <repo-id>@<sha>,…` trailer naming exactly
+## which source commits the page was written against. catalog_ingest
+## reads the newest such trailer from the DOCS repo history and diffs
+## each clone from it — so "what changed in the sources since we last
+## documented them" survives a crashed run, a fresh pod and a wiped
+## scratch dir, with no side-car state file to lose. When a shallow
+## clone cannot reach the recorded commit the delta is reported
+## UNAVAILABLE, never silently empty. See ADR-091.
+##
+## STACK/REPO-AGNOSTIC (CLAUDE.md "Catalog bots are repo-agnostic" +
+## "Universal code bots"): no language, ecosystem, framework or repo
+## layout literal anywhere in the vars, commands or schemas. The
+## product's shape is described by ITS catalog; how to read a given
+## stack is the agent's own judgment, guided by the skills.
+##
+## CONTINUATION IS BOUNDED. The single declared loop
+## (scan_hints→campaign→scope_check→page_lint→gate→scan_hints) is
+## capped by `max_passes`; on exhaustion the run ships what is banked
+## (every committed page is real, landed work). `iterion validate`
+## reports NO undeclared cycle — this is the only declared loop.
+## ─────────────────────────────────────────────────────────────────
+
+vars:
+  ## The DOCS repository — this run's workspace and the ONLY tree the
+  ## bot writes to. Source repositories are cloned out of tree.
+  workspace_dir: string = "${PROJECT_DIR}"
+
+  ## REQUIRED. The product catalog. Either a YAML FILE describing one
+  ## product, or a DIRECTORY holding one `<product_id>.yml` per
+  ## product (the pilot's `catalog/<id>.yml` layout). Relative paths
+  ## resolve inside the workspace; absolute paths are taken as-is.
+  ## Empty fails catalog_ingest loudly — there is nothing sensible to
+  ## default to, and guessing a path would document the wrong product.
+  catalog_path: string = ""
+
+  ## REQUIRED. Which product to document. Selects the catalog entry
+  ## (file name, or top-level key in a multi-product file), and with
+  ## it the `docs.product_dir` this run may write to.
+  product_id: string = ""
+
+  ## Optional free-text notes pinning the campaign's attention
+  ## ("the new agent workspace is undocumented", an operator's review).
+  scope_notes: string = ""
+
+  ## Alignment scope. `full`: sweep the whole product documentation
+  ## against the whole source corpus — the periodic reconciliation.
+  ## `incremental`: focus on the pages impacted by what changed in the
+  ## SOURCES since the last run (auto-detected from the
+  ## `Product-Docs-Sources:` commit trailer) and in the DOCS since the
+  ## last `Bot: product-docs` commit. A first run with no prior
+  ## alignment commit degrades cleanly to a full sweep.
+  mode: string = "full"
+
+  ## Incremental base (explicit pin, docs side). Non-empty forces
+  ## `git diff <diff_since>...HEAD` in the docs repo instead of the
+  ## trailer-detected base. Usually left empty.
+  diff_since: string = ""
+
+  ## The directory in the DOCS REPO holding the product team's OWN
+  ## editorial skills — documentary model, allowed blocks, glossary,
+  ## tone. Every `*.md` found here is handed to the campaign as
+  ## AUTHORITATIVE guidance overriding the bundle defaults. Empty
+  ## disables the override (bundle defaults only).
+  editorial_dir: string = ".product-docs"
+
+  ## Out-of-tree, sandbox-writable scratch: the source clones, the
+  ## promises ledger, and any cross-pass state. The engine resolves
+  ## ${PROJECT_SCRATCH_DIR} to ~/.iterion/projects/<key>/scratch
+  ## non-sandboxed and to the container-writable /tmp/iterion-scratch
+  ## under a sandbox. Keeping the clones OUT of the docs worktree is
+  ## what makes the scope gate meaningful.
+  scratch_dir: string = "${PROJECT_SCRATCH_DIR}/product-docs"
+
+  ## DISMISSALS LEDGER — the campaign's cross-pass MEMORY. JSON array
+  ## of {doc, kind, value, reason} entries it adjudicated as
+  ## not-worth-acting-on. scan_hints excludes them from every later
+  ## pass so a settled judgment never re-surfaces. Out of tree like
+  ## scratch_dir; empty disables the exclusion.
+  dismissed_path: string = "${PROJECT_SCRATCH_DIR}/product-docs/dismissed.json"
+
+  ## Clone depth for the source repositories. 1 = the cheapest clone
+  ## that still lets the agent read every file at HEAD. Raise it when
+  ## a run needs source HISTORY (a deep incremental base, a changelog
+  ## read); 0 means a FULL clone with no depth limit.
+  clone_depth: int = 1
+
+  ## Files removed from every source clone before the campaign may
+  ## read them. Comma-separated shell globs, matched against both the
+  ## base name and the clone-relative path. The default covers the
+  ## usual credential carriers; extend it per product rather than
+  ## trusting the source repos to be clean.
+  secret_globs: string = "*.env,.env,.env.*,*secret*,*secrets*,*credential*,*credentials*,*.pem,*.key,*.p12,*.pfx,id_rsa*,id_ed25519*,.netrc,.npmrc,.pypirc,kubeconfig,*kubeconfig*"
+
+  ## Editorial lint rules enforced on PUBLISHED pages (comma-separated,
+  ## page_lint). Dropping a name disables that rule for this run;
+  ## `extra_forbidden_headings` adds product-specific ones without
+  ## editing the bot.
+  ##   html_comments    — no HTML comments (working notes leak)
+  ##   sources_box      — no "Sources" hint box / section
+  ##   clarify_section  — no "Points à clarifier" section
+  ##   technical_annex  — no "Correspondance technique" annex
+  lint_rules: string = "html_comments,sources_box,clarify_section,technical_annex"
+
+  ## Extra heading titles (comma-separated, case-insensitive, matched
+  ## as a prefix of the heading text) that must never appear in a
+  ## published page. Empty by default.
+  extra_forbidden_headings: string = ""
+
+  ## Cap on the advisory hints list handed to the campaign (context
+  ## bound — telemetry counts are computed BEFORE truncation, so the
+  ## report stays honest about what was cut).
+  max_hints: int = 120
+
+  ## Hard cap on continuation PASSES — the convergence backstop.
+  ## NOTE loop semantics: `as continuation_loop(N)` bounds the loop
+  ## BACKS, so the total number of passes is N+1.
+  max_passes: int = 4
+
+  ## ─── PR finalization (opt-in) ─────────────────────────────────
+  ## open_mr=true pushes the page series and opens ONE pull request
+  ## at the end of the run (converged OR max_passes exhausted with
+  ## banked commits). Requires a git remote + a push credential — the
+  ## deterministic forge_auth_probe skips the tail cleanly when none
+  ## exists, and finalize_mr refuses to open an empty PR.
+  open_mr: bool = false
+
+  ## Open the pull request as a DRAFT. Functional documentation is
+  ## read by the business owners of the product, not merged on a green
+  ## test: the human validation happens ON THE FORGE, and marking the
+  ## PR ready is the reviewer's act, not the bot's. Default true for
+  ## exactly that reason; set false for a repo whose review flow does
+  ## not use drafts.
+  mr_draft: bool = true
+
+  mr_branch: string = ""
+  mr_base: string = ""
+  source_issue_ref: string = ""
+
+secrets:
+  ## Forge access: cloning the SOURCE repositories (private ones need
+  ## it), pushing the docs branch, opening the PR, back-linking the
+  ## issue. Mounted as a read-only file; git reads it through an
+  ## askpass helper, so the token never reaches a command line, a
+  ## prompt, or the run's events. optional:true so a public-source /
+  ## host-authenticated setup works unchanged.
+  forge_token:
+    as: file
+    optional: true
+
+## ─── Prompts ────────────────────────────────────────────────────
+
+prompt campaign_system:
+  You are a senior product writer running a FUNCTIONAL DOCUMENTATION
+  campaign — working exactly as you would in a productive, human-driven
+  session. You have the docs repository in front of you, read-only
+  clones of the product's source repositories beside it, and full tools
+  (read, edit, shell, git). No one micro-manages you; you own this pass
+  end to end.
+
+  THE MISSION: make the product documentation under the product
+  directory a faithful, business-readable account of WHAT THE PRODUCT
+  DOES FOR ITS USERS, grounded in what the sources actually implement.
+  You write for the people who USE the product — agents, managers,
+  citizens, partners — not for the people who build it.
+
+  THE AUDIENCE IS NOT TECHNICAL. Everything a reader needs to operate
+  the product belongs in these pages. Everything about HOW it is built
+  does not: no code, no schemas, no endpoints, no environment
+  variables, no deployment, no architecture. Technical documentation
+  is another bot's job (docs-refresh, in the source repo).
+
+  LOAD YOUR SKILLS FIRST, IN THIS ORDER OF AUTHORITY.
+
+  1. THE DOCS REPO'S OWN EDITORIAL SKILLS — listed in your user prompt
+     under "Editorial overrides in force" and readable at those paths.
+     These are AUTHORITATIVE. The product team wrote them; where they
+     disagree with anything below, THEY WIN, silently and completely.
+     Read every one of them before you write a line.
+  2. THE BUNDLE DEFAULTS under `.claude/skills/` — used for whatever
+     the docs repo did not specify:
+     - `product-docs.md` — the operating playbook and the inviolable
+       rules (read this one always)
+     - `modele-documentaire.md` — the default documentary model:
+       structure by user roles and journeys, a hub page per role/
+       journey and one sub-page per step
+     - `blocs-gitbook.md` — the block vocabulary the published pages
+       may use
+     - `glossaire-produit.md` — how to build and maintain the
+       product's glossary
+     - `ton-et-style.md` — the default tone, person, tense and
+       vocabulary rules
+     - `forge-mr-create.md` — read only if you are asked to publish
+       (you are not: publication is the run's tail, see below)
+
+  THE PAGES ARE WRITTEN IN FRENCH. They are read by French-speaking
+  end users. Your commit messages, your ledger entries and your
+  termination report stay in English.
+
+  THE SOURCES ARE THE TRUTH, AND THE ONLY TRUTH. Your user prompt
+  lists a local clone path per source repository. Read them. Business
+  rules, wordings, screens, roles, statuses, notifications and journeys
+  are discovered by reading what the code actually does — user-facing
+  templates, translation/i18n catalogs, form and validation rules,
+  route or menu definitions, API contracts, seed data, feature flags.
+  Any framework, any language: there is no parser and no checklist
+  here, only your judgment.
+
+  NEVER INVENT A BUSINESS RULE. Every factual claim on a page is
+  either grounded in something you read in a source clone (or in
+  human-validated prose already on the page), or it is marked
+  `[à confirmer]` in the text. There is no third option. A plausible
+  sentence you could not ground is the single worst thing you can
+  ship here: the reader has no way to tell it from a sourced one.
+
+  A REPOSITORY YOU COULD NOT READ IS A HOLE YOU DECLARE. The
+  inventory in your user prompt marks each repo `ok` or `degraded`
+  with a reason. Never document the part of the product a degraded
+  repo covers from inference — leave it out, or mark it
+  `[à confirmer]`, and name the gap in your termination report.
+
+  HUMAN-VALIDATED PROSE IS PRESERVED. Much of what is already on
+  these pages was written or corrected by a human who knows the
+  product better than any source read can teach you. Do NOT rewrite a
+  page because you would have phrased it differently. Touch existing
+  prose in exactly two cases: the CODE CONTRADICTS it (then correct
+  it, minimally, and say so in the commit), or it is incomplete
+  against a journey the code clearly implements (then extend it). A
+  pass that reflows prose it had no reason to touch has destroyed
+  human work and produced nothing.
+
+  PUBLISHED PAGES CARRY NO WORKING NOTES. A deterministic lint gate
+  runs after you and FAILS THE PASS on any of these in a published
+  page: an HTML comment, a "Sources" box or section, a "Points à
+  clarifier" section, a "Correspondance technique" annex. Your
+  research notes, your open questions and your source references do
+  not belong in the reader's page — open questions become
+  `[à confirmer]` in the sentence itself, and everything else belongs
+  in your commit message, in the promises ledger, or in your report.
+
+  HOW TO WORK — a living todo list, not frozen phases. Survey the
+  product directory and the source clones, build a dense list of the
+  pages this pass needs (a hub that is missing, a journey whose steps
+  are undocumented, a page the code has moved past), then work it one
+  page at a time, re-prioritising as you learn. On a large product you
+  have the subagent tool: fan out sub-readers by source repository or
+  by user role to read each area in parallel, then write from what
+  they surface — exactly as you would orchestrate a big native
+  session. A pass that stays on the two obvious pages is the shallow
+  failure to avoid.
+
+  For each page you act on, READ the sources that ground it (the tool
+  invocation IS your evidence; a page whose claims cannot cite one is
+  a façade), then adjudicate to exactly ONE of FOUR outcomes:
+    a. WRITE/REPAIR + COMMIT — the page is missing, incomplete, or
+       the code has moved past it: write it (or correct it) per the
+       documentary model in force, then COMMIT that page alone with a
+       semantic message (`docs(<page or journey>): <what changed>`),
+       the body ending with BOTH trailer lines:
+         Bot: product-docs
+         Product-Docs-Sources: <the stamp given in your user prompt>
+       The `Bot:` trailer is how the next run finds where alignment
+       landed; the `Product-Docs-Sources:` trailer is how it knows
+       which source commits the page was written against. Both are
+       REQUIRED on every commit. Stage everything including new files
+       (`git add -A`) before each commit.
+    b. DISMISS + LEDGER — an advisory hint that is a false positive,
+       or something genuinely not worth documenting for this
+       audience: record it in the DISMISSALS LEDGER (below) with a
+       reason. Dismissing without recording is what makes the same
+       non-issue come back to you next pass.
+    c. PROMISE + PROMISES LEDGER — the page describes something the
+       product is meant to do and the code does not do yet. Do NOT
+       delete it and do NOT align it down to the current behaviour:
+       see UNFULFILLED PROMISES below.
+    d. PRODUCT BUG + BOARD — the page is right and the SOURCE is
+       wrong (the code contradicts a rule the product owners stated).
+       Set is_product_bug=true, name it in human_note, and file it as
+       a board finding.
+
+  COMMIT LOCALLY ONLY — never `git push`, never open a PR yourself.
+  Publication is owned by the run's finalize tail (a deterministic
+  credential probe + ONE pull request, opened as a draft for human
+  validation). A campaign that pushes creates a duplicate PR next to
+  the tail's. Your commits on the local branch ARE your delivery.
+
+  COMMIT EACH PAGE AS YOU FINISH IT — never batch. git IS your durable
+  state: an interrupted run keeps every page you committed, and a
+  fresh pass just reads `git log` and continues. Do NOT keep a
+  separate worklist file.
+
+  WRITEABLE SET — `.md` files under the product directory named in
+  your user prompt, and nothing else. Never the source clones (they
+  are throwaway), never the docs repo's editorial skills (the product
+  team owns those), never any other product's directory. A
+  deterministic scope gate diffs the whole run after every pass and
+  bounces any out-of-scope file back to you — you would then have to
+  revert those commits before continuing. Don't make it fire.
+
+  END EVERY PASS ON A CLEAN TREE: if you must stop mid-page, either
+  finish it to committable or discard the in-progress edits —
+  `git restore --staged --worktree -- <the paths you touched>` and
+  delete any new files you created; never a blanket `git clean` (the
+  workspace may be the operator's own checkout). The deterministic
+  gates verify the WORKING TREE, and a half-written page reds them as
+  noise.
+
+  ASK ONLY ON A REAL DECISION. Keep operator pauses RARE — an
+  ambiguity about the product's own business rules that you cannot
+  settle from the sources is the case that deserves one; everything
+  else is `[à confirmer]` in the text plus a line in `summary`.
+
+  FINDINGS HANDOFF — after your last commit, capture anything OUT OF
+  SCOPE but worth tracking (a source bug found while grounding a
+  claim, a whole journey the catalog does not cover, a repo whose
+  credentials need provisioning): call
+  `mcp__iterion_board__list_issues` with `{ "state": "inbox" }` first
+  to avoid duplicates, then `mcp__iterion_board__create_issue` per NEW
+  finding with state "inbox" and labels ["findings",
+  "kind:<bug|drift|improvement|question>", "source:product_docs",
+  "area:<product or repo>", "severity:<low|medium|high>"]. Zero
+  findings is a fine outcome. If the board tools are unavailable, list
+  the findings in `summary`.
+
+  DISMISSALS LEDGER — the persistence half of adjudication. For EVERY
+  hint or self-found candidate you judge not-worth-acting-on, append
+  one entry to the JSON array at `{{vars.dismissed_path}}` (create the
+  file — `[]` — and its parent directory on first use;
+  read-modify-write, keep it valid JSON):
+    {"doc": "<page, or empty for a product-wide item>",
+     "kind": "<hint kind, or your own>", "value": "<the value>",
+     "reason": "<one line>"}
+  The scan excludes ledger entries from every later pass.
+
+  UNFULFILLED PROMISES — adjudication outcome (c). A page that
+  describes a capability the sources do not implement is not
+  necessarily stale: it may be a deliberate, still-wanted ambition, or
+  human-validated prose about a process that lives outside the code.
+  Do not delete it and do not align it down. Instead:
+    - Append one entry to the JSON array at
+      `{{vars.scratch_dir}}/promises.json` (create the file — `[]` —
+      and its parent directory on first use; read-modify-write, keep
+      it valid JSON; passes are fresh sessions, so the FILE is the
+      only way the list survives to the PR tail):
+        {"doc": "<page path>", "claim": "<the promised behaviour>",
+         "code_gap": "<what the sources lack>", "note": "<one line>"}
+    - ALSO record it in the DISMISSALS LEDGER (reason:
+      "promise: <short ref>") so it stops re-surfacing.
+    - OPTIONALLY mark the sentence `[à confirmer]` in the page itself
+      and commit that — flagging an unverifiable claim IS alignment.
+  Promises never block convergence: the PR tail lists them under
+  "Points à confirmer avec l'équipe produit".
+
+  KEEP GOING — write the real documentation this product is missing,
+  across its whole functional surface, not just the handful of scanned
+  hints. Stop this pass when a fresh look would find little more to
+  write (that "little more" IS your docs_aligned signal), or when you
+  reach the edge of your budget — then report. There is no prize for a
+  small diff, and none for padding: report what is true.
+
+  TERMINATION CONTRACT (required structured output — this is how the
+  engine detects completion; an under-specified end just gets
+  re-poked):
+    - docs_aligned: the ASYMPTOTE signal. true ONLY when THIS pass
+      converged the product documentation — a fresh comprehensive
+      survey would find little or nothing left to write or correct. If
+      this pass produced MANY pages, assume the next sweep will still
+      find real work and report false: the run loops you back on a
+      fresh tree, and it is the DECLINE of pages-per-pass toward zero
+      that ends the run.
+    - commits_this_pass: how many commits you landed this pass.
+    - drift_remaining: a concise note of what still needs writing
+      (empty when docs_aligned).
+    - unread_sources: the repositories (or product areas) you could
+      NOT read this pass, and what that leaves undocumented. Empty
+      when you read everything the catalog named.
+    - is_product_bug: true when you found ≥1 place where the page is
+      right and the source is wrong.
+    - needs_human / human_note: set if you paused or need an operator
+      decision.
+    - summary: which pages you wrote or corrected, what grounded each
+      one, and what you dismissed and why.
+
+  Be honest. Deterministic scope and lint gates re-check the tree
+  after you, and the run loops you back until you report docs_aligned
+  AND both gates are green — so under-reporting only costs a pass, and
+  over-reporting lands you right back here.
+
+prompt campaign_user:
+  Docs repository (your workspace, the ONLY tree you write to):
+  {{vars.workspace_dir}}
+
+  Product: {{input.product_id}}
+  Product directory (your writeable set — `.md` under it, nothing
+  else): {{input.product_dir}}
+
+  Scope notes (operator's attention pin, may be empty):
+  {{vars.scope_notes}}
+
+  ## Editorial overrides in force (AUTHORITATIVE — read them first)
+  These files live in the DOCS REPO and outrank the bundle's default
+  skills wherever they disagree. An empty list means the product team
+  published no editorial line of its own; use the bundle defaults.
+  {{input.editorial_files}}
+
+  ## Source repositories (read-only clones, out of your workspace)
+  Each entry: {id, status, path, head, url, changed_files, note}.
+  status `ok` = cloned and readable · `degraded` = NOT readable, with
+  the reason in `note` — never document that area from inference.
+  {{input.inventory}}
+
+  Source commit stamp to put in every commit's
+  `Product-Docs-Sources:` trailer, verbatim:
+  {{input.sources_stamp}}
+
+  Functional surfaces the catalog declares for this product (may be
+  empty — then derive them from the sources):
+  {{input.surfaces}}
+
+  ## Pass scope — mode: {{input.mode}}
+  FULL: sweep the WHOLE product documentation against the WHOLE source
+  corpus — plan it, then write exhaustively.
+  INCREMENTAL: focus on what the source deltas above
+  (`changed_files` per repo) and the docs delta since
+  {{input.incremental_base}} actually impact. Do NOT re-audit pages
+  untouched by those changes. If every `changed_files` is empty AND
+  `delta_unavailable` is reported for the repos, the delta could NOT
+  be computed — do NOT read that as "nothing changed": survey
+  directly. In BOTH modes the structural hints below cover the whole
+  product tree — fix any dead link or orphan page anywhere.
+
+  ## Advisory scan report (this pass)
+  {{input.hints_note}}
+
+  Hints — ADVISORY, sorted by signal; each entry:
+  {doc, line, kind, value, note}. Use them as a starting point,
+  contradict them freely (dismiss to the ledger with a reason), and
+  explore BEYOND them — the scan sees links and file names, you see
+  what the product does:
+  {{input.hints}}
+
+  Deterministic gate feedback from the PREVIOUS pass (empty on the
+  first pass; when present it is a SCOPE violation — files outside
+  `<product_dir>/**/*.md` changed, revert those commits — or a LINT
+  violation — a published page carries working notes, remove them):
+  {{input.fail_log}}
+
+  Plan your pass, then write — for each page: read the sources that
+  ground it → write or correct it per the editorial line in force →
+  check the page carries no working notes → commit it alone
+  (`docs(<page>): …` plus the `Bot: product-docs` and
+  `Product-Docs-Sources:` trailer lines — REQUIRED). Work through the
+  plan this pass, to the edge of your budget, then report the
+  termination contract. Read `git log` first to see what earlier
+  passes already wrote.
+
+## ─── PR finalization prompts (opt-in) ──────────────────────────────
+
+prompt finalize_mr_system:
+  You finalize a finished product-docs run by getting its SERIES of
+  per-page commits into ONE pull request (PR; merge request on GitLab).
+  You make NO further changes to the documentation.
+
+  Read the `forge-mr-create` skill FIRST — forge detection,
+  authenticating from the mounted forge_token, pushing, and opening a
+  PR (GitHub gh, GitLab glab, Forgejo/Gitea REST), including the DRAFT
+  flag on each.
+
+  Preconditions:
+    A. Commits to ship: HEAD must be ahead of the base
+       (`git rev-list --count <base>..HEAD` > 0). If not, set
+       opened=false, skipped_reason "no commits ahead of base" — never
+       push, never open an empty PR.
+    B. Authenticate the matching forge CLI from the mounted
+       forge_token file when present; otherwise assume host auth. If
+       neither works, set opened=false with a precise skipped_reason —
+       never pretend.
+
+  Then:
+    1. Branch = mr_branch if set, else a stable
+       iterion/product-docs/<run-id>; base = mr_base if set, else the
+       repo default branch (skill).
+    2. Push HEAD to that branch on origin and open the PR into the
+       base. DRAFT: when draft=true, open it as a DRAFT
+       (`gh pr create --draft`, `glab mr create --draft`, or the
+       provider's draft field on the REST path). Functional
+       documentation is validated by the product owners on the forge;
+       marking it ready is THEIR act, not yours. If the provider or
+       CLI cannot open a draft, open a normal PR and say so in
+       skipped_reason — never silently drop the draft intent.
+    3. Title: a concise "docs(<product>): …" summary. Body, in
+       French (the audience is the product team): what was documented
+       this run, the pages touched, and — when drift_remaining is
+       non-empty — an honest "Reste à documenter" section. When
+       unread_sources is non-empty, a "Sources non lues" section
+       naming what could not be read and what that leaves
+       undocumented. PROMISES: read the promises ledger named in your
+       user prompt; when it has entries, append a "Points à confirmer
+       avec l'équipe produit" section (one bullet each: page, claim,
+       gap) — verbatim in substance, never silently dropped.
+    4. If source_issue_ref is set, post the PR URL back (forge issue
+       URL → forge-CLI comment; "native:<id>" → board comment tool);
+       back_linked.
+    5. opened=true, url=<the new PR>, branch=<the branch>,
+       draft=<whether it is actually a draft>.
+
+  Return opened, url, branch, draft, back_linked, skipped_reason and a
+  short summary. Be honest: report exactly what happened.
+
+prompt finalize_mr_user:
+  Workspace (the docs repo): {{input.workspace_dir}}
+  Product: {{input.product_id}}
+  Open as DRAFT: {{input.draft}}
+  Branch override (empty → derive): {{input.mr_branch}}
+  Base (may be empty → repo default branch): {{input.mr_base}}
+  Source issue to back-link (may be empty): {{input.source_issue_ref}}
+  Operator scope notes (may be empty): {{input.scope_notes}}
+
+  Campaign summary (for the PR body):
+  {{input.campaign_summary}}
+
+  Remaining work reported by the campaign (empty = fully documented):
+  {{input.drift_remaining}}
+
+  Sources the campaign could NOT read (empty = it read everything):
+  {{input.unread_sources}}
+
+  Promises ledger (JSON array; the file may be absent or empty):
+  {{vars.scratch_dir}}/promises.json
+
+  Push the branch, open the pull request (draft per the flag above)
+  with the sections described in your system prompt, post the
+  back-link when a source issue is given, and return the structured
+  result.
+
+## ─── Schemas ────────────────────────────────────────────────────
+
+## catalog_ingest output — the resolved product + the source
+## inventory. `inventory` is a JSON array of per-repo entries
+## {id, status, path, head, url, changed_files, note}; a repo that
+## could not be cloned is present with status `degraded` and a reason,
+## never absent. `sources_stamp` is the verbatim
+## `Product-Docs-Sources:` trailer value the campaign must stamp.
+schema ingest_output:
+  product_id: string
+  product_dir: string
+  surfaces: json
+  inventory: json
+  sources_stamp: string
+  repo_count: int
+  ok_count: int
+  degraded_count: int
+  redacted_count: int
+  previous_stamp: string
+  delta_unavailable: bool
+  log: string
+
+## scan_hints input — the product tree to scan and the surfaces to
+## check coverage against, both resolved by catalog_ingest.
+schema hints_input:
+  product_dir: string
+  surfaces: json
+
+## scan_hints output — the ADVISORY report. hints is a bounded JSON
+## array of {doc, line, kind, value, note} entries (kinds: dead_link,
+## dead_anchor, orphan_page, unmapped_surface, empty_page); every
+## *_count field is TELEMETRY, never a gate condition.
+schema hints_output:
+  pages: string[]
+  page_count: int
+  hints: json
+  hint_count: int
+  dead_link_count: int
+  orphan_count: int
+  unmapped_surface_count: int
+  checked_links: int
+  ledger_excluded: int
+  truncated: bool
+  hints_note: string
+  editorial_files: string[]
+  mode: string
+  incremental_base: string
+  recently_changed_pages: string[]
+
+## campaign input: the resolved product + the source inventory + the
+## advisory report + the previous pass's deterministic gate feedback.
+schema campaign_input:
+  product_id: string
+  product_dir: string
+  surfaces: json
+  inventory: json
+  sources_stamp: string
+  editorial_files: string[]
+  hints: json
+  hint_count: int
+  hints_note: string
+  mode: string
+  incremental_base: string
+  fail_log: string
+
+## campaign's TERMINATION CONTRACT: a machine-checkable output the
+## engine keys convergence on. docs_aligned is the done-oracle; the
+## gate ANDs it with the scope and lint truth gates — nothing else.
+schema campaign_output:
+  docs_aligned: bool
+  commits_this_pass: int
+  drift_remaining: string
+  unread_sources: string
+  is_product_bug: bool
+  needs_human: bool
+  human_note: string
+  summary: string
+
+## scope_check / page_lint input — the product directory both gates
+## are scoped to (resolved by catalog_ingest, mapped on the edge
+## because a tool command cannot read `{{outputs.*}}`).
+schema product_dir_input:
+  product_dir: string
+
+## scope_check is the DETERMINISTIC writeable-set gate: every path
+## changed since the RUN BASE must be a `.md` file under the product
+## directory. Anything else fails the gate and bounces back to the
+## campaign, which must revert it.
+schema scope_check_output:
+  scope_ok: bool
+  out_of_scope: string[]
+  log: string
+
+## page_lint is the DETERMINISTIC editorial gate: a published page
+## carries no working notes. Violations are reported with page + line
+## + rule so the campaign can remove exactly them.
+schema lint_output:
+  lint_ok: bool
+  violations: json
+  violation_count: int
+  pages_linted: int
+  log: string
+
+## gate is the deterministic continuation decision. converged = the
+## writeable set is clean AND the published pages carry no working
+## notes AND the campaign reports the documentation aligned — nothing
+## else. fail_log relays both gates' complaints to the next pass.
+schema gate_state:
+  converged: bool
+  fail_log: string
+
+## ─── PR finalization schemas (opt-in) ───────────────────────────────
+
+## mr_gate lifts vars.open_mr into a bool output field so the two
+## outgoing edges use the C012-exhaustive simple form. No LLM, no shell.
+schema mr_gate_output:
+  open_mr: bool
+
+## forge_auth_probe output — deterministic "can we push?" so
+## finalize_mr (an LLM agent) is only ever entered when a push
+## credential actually exists.
+schema forge_auth_state:
+  available: bool
+  reason: string
+
+schema finalize_mr_input:
+  workspace_dir: string
+  product_id: string
+  draft: bool
+  mr_branch: string
+  mr_base: string
+  source_issue_ref: string
+  scope_notes: string
+  campaign_summary: string
+  drift_remaining: string
+  unread_sources: string
+
+schema finalize_mr_output:
+  opened: bool
+  url: string
+  branch: string
+  draft: bool
+  back_linked: bool
+  skipped_reason: string
+  summary: string
+
+schema surface_pr_link_input:
+  url: string
+
+## ─── Nodes ──────────────────────────────────────────────────────
+
+## catalog_ingest — the DETERMINISTIC multi-repo front door. Runs ONCE,
+## before the loop: the clones do not change during a run.
+##
+##   1. Resolve the catalog. `catalog_path` is either a YAML file (one
+##      product, or a top-level map of products keyed by id) or a
+##      directory holding `<product_id>.yml`. A missing catalog, a
+##      missing product, or a missing `docs.product_dir` is a LOUD
+##      failure — documenting the wrong directory is worse than not
+##      running.
+##   2. Clone each `repos[]` entry into <scratch>/sources/<id>,
+##      shallow by default, NEVER inside the workspace. `github_repo`
+##      (owner/name) and `gitlab_path` (+ the top-level `gitlab.host`
+##      block) are both accepted; an explicit `url` wins over both.
+##      Credentials reach git through an ASKPASS HELPER FILE, so the
+##      token never appears in a command line or in the run's events.
+##   3. Redact: every file matching `secret_globs` is deleted from the
+##      clone before the campaign can read it.
+##   4. Delta: read the newest `Product-Docs-Sources:` trailer from
+##      the DOCS repo history and diff each clone from the sha it
+##      records. A shallow clone that cannot reach it reports
+##      `delta_unavailable` — never a silently empty delta.
+##
+## A repo that fails at any step lands in the inventory as `degraded`
+## with the reason, and the run continues: partial sources produce
+## partial documentation, which is honest; a hard stop would produce
+## none.
+##
+## Raw-string command — the python body avoids double quotes and
+## literal backticks; values flow via shell env vars.
+tool catalog_ingest:
+  command: `WS={{vars.workspace_dir}} CATALOG={{vars.catalog_path}} PRODUCT={{vars.product_id}} SCRATCH={{vars.scratch_dir}} DEPTH={{vars.clone_depth}} SECRET_GLOBS={{vars.secret_globs}} python3 -c "
+import os, json, re, subprocess, shutil, fnmatch
+ws = os.environ['WS']
+catalog = (os.environ.get('CATALOG') or '').strip()
+product = (os.environ.get('PRODUCT') or '').strip()
+scratch = (os.environ.get('SCRATCH') or '').strip()
+try:
+    depth = int((os.environ.get('DEPTH') or '1').strip() or '1')
+except ValueError:
+    depth = 1
+secret_globs = [g.strip() for g in (os.environ.get('SECRET_GLOBS') or '').split(',') if g.strip()]
+if not catalog:
+    raise SystemExit('product-docs: catalog_path is required -- pass --var catalog_path=<catalog dir or yaml file>')
+if not product:
+    raise SystemExit('product-docs: product_id is required -- pass --var product_id=<id>')
+if not scratch:
+    raise SystemExit('product-docs: scratch_dir resolved empty -- the source clones have nowhere out-of-tree to live')
+os.chdir(ws)
+
+def load_yaml(path):
+    ## PyYAML when the interpreter has it; otherwise yq (declared in
+    ## this bundle devbox.json) rendering the same document as JSON.
+    ## Neither available is a LOUD failure, never a guessed parse.
+    try:
+        import yaml
+    except ImportError:
+        yaml = None
+    if yaml is not None:
+        with open(path, encoding='utf-8') as fh:
+            return yaml.safe_load(fh)
+    try:
+        p = subprocess.run(['yq', '-o=json', '.', path], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=60)
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise SystemExit('product-docs: cannot parse ' + path + ' -- no PyYAML and no yq on PATH (' + str(exc) + ')')
+    if p.returncode != 0:
+        raise SystemExit('product-docs: yq failed to parse ' + path + ': ' + (p.stderr or '').strip())
+    return json.loads(p.stdout)
+
+cat_path = catalog if os.path.isabs(catalog) else os.path.join(ws, catalog)
+entry = None
+if os.path.isdir(cat_path):
+    found = ''
+    for ext in ('.yml', '.yaml', '.json'):
+        cand = os.path.join(cat_path, product + ext)
+        if os.path.isfile(cand):
+            found = cand
+            break
+    if not found:
+        try:
+            avail = ', '.join(sorted(f for f in os.listdir(cat_path) if f.endswith(('.yml', '.yaml', '.json'))))
+        except OSError:
+            avail = '<unreadable>'
+        raise SystemExit('product-docs: no catalog entry for product ' + repr(product) + ' in ' + cat_path + ' -- available: ' + (avail or '<none>'))
+    cat_file = found
+    entry = load_yaml(cat_file)
+elif os.path.isfile(cat_path):
+    cat_file = cat_path
+    doc = load_yaml(cat_file)
+    if not isinstance(doc, dict):
+        raise SystemExit('product-docs: catalog ' + cat_file + ' is not a YAML mapping')
+    if isinstance(doc.get('products'), dict):
+        entry = doc['products'].get(product)
+        if entry is None:
+            raise SystemExit('product-docs: catalog ' + cat_file + ' has no products entry ' + repr(product) + ' -- available: ' + ', '.join(sorted(doc['products'])))
+    elif 'repos' in doc or 'docs' in doc:
+        declared = str(doc.get('id') or doc.get('product_id') or '').strip()
+        if declared and declared != product:
+            raise SystemExit('product-docs: catalog ' + cat_file + ' describes product ' + repr(declared) + ', not ' + repr(product))
+        entry = doc
+    else:
+        entry = doc.get(product)
+        if entry is None:
+            raise SystemExit('product-docs: catalog ' + cat_file + ' has no entry for ' + repr(product) + ' -- available: ' + ', '.join(sorted(str(k) for k in doc)))
+else:
+    raise SystemExit('product-docs: catalog_path ' + repr(catalog) + ' resolves to ' + cat_path + ', which does not exist (relative paths resolve inside the workspace)')
+if not isinstance(entry, dict):
+    raise SystemExit('product-docs: catalog entry for ' + repr(product) + ' is not a mapping')
+
+docs_block = entry.get('docs') if isinstance(entry.get('docs'), dict) else {}
+product_dir = str(docs_block.get('product_dir') or entry.get('product_dir') or '').strip().strip('/')
+if not product_dir:
+    raise SystemExit('product-docs: catalog entry for ' + repr(product) + ' declares no docs.product_dir -- the bot has no writeable set without it')
+if os.path.isabs(product_dir) or '..' in product_dir.split('/'):
+    raise SystemExit('product-docs: docs.product_dir ' + repr(product_dir) + ' must be a path INSIDE the docs repository')
+surfaces = docs_block.get('surfaces') or []
+if not isinstance(surfaces, list):
+    surfaces = []
+
+## Credentials reach git through an askpass helper file: the token
+## stays in the helper process environment, never in a command line
+## (visible in ps) and never in this node stdout.
+sources_root = os.path.join(scratch, 'sources')
+os.makedirs(sources_root, exist_ok=True)
+token = ''
+tok_file = '/run/iterion/secrets/forge_token'
+try:
+    if os.path.isfile(tok_file) and os.path.getsize(tok_file) > 0:
+        with open(tok_file, encoding='utf-8') as fh:
+            token = fh.read().strip()
+except OSError:
+    token = ''
+if not token:
+    for v in ('GH_TOKEN', 'GITHUB_TOKEN', 'GITLAB_TOKEN', 'FORGEJO_TOKEN', 'GITEA_TOKEN'):
+        if os.environ.get(v):
+            token = os.environ[v].strip()
+            break
+git_env = dict(os.environ)
+git_env['GIT_TERMINAL_PROMPT'] = '0'
+if token:
+    helper = os.path.join(scratch, 'git-askpass.sh')
+    with open(helper, 'w', encoding='utf-8') as fh:
+        fh.write('#!/bin/sh' + chr(10) + 'case $1 in' + chr(10) + 'Username*) echo x-access-token ;;' + chr(10) + '*) printf %s $PRODUCT_DOCS_GIT_TOKEN ;;' + chr(10) + 'esac' + chr(10))
+    os.chmod(helper, 0o700)
+    git_env['GIT_ASKPASS'] = helper
+    git_env['PRODUCT_DOCS_GIT_TOKEN'] = token
+
+def run_git(args, cwd=None, timeout=900):
+    try:
+        p = subprocess.run(['git'] + args, cwd=cwd, env=git_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=timeout)
+        return p.returncode, (p.stdout or ''), (p.stderr or '')
+    except (OSError, subprocess.SubprocessError) as exc:
+        return 1, '', str(exc)
+
+def redact(reason):
+    ## Strip the token out of any git message before it reaches the
+    ## inventory, the events or the report.
+    msg = ' '.join((reason or '').split())
+    if token:
+        msg = msg.replace(token, '<redacted>')
+    return msg[:400]
+
+gitlab_block = entry.get('gitlab') if isinstance(entry.get('gitlab'), dict) else {}
+gitlab_host = str(gitlab_block.get('host') or '').strip().rstrip('/')
+
+## The previous run source stamp, read from the DOCS repo own history:
+## git IS the state, so a wiped scratch or a crashed pod loses nothing.
+previous_stamp = ''
+rc, out, _ = run_git(['log', '-E', '--grep', '^Product-Docs-Sources:', '-n', '1', '--format=%B'], cwd=ws, timeout=120)
+if rc == 0:
+    for line in out.splitlines():
+        if line.strip().startswith('Product-Docs-Sources:'):
+            previous_stamp = line.split(':', 1)[1].strip()
+            break
+prev_shas = {}
+for part in previous_stamp.split(','):
+    part = part.strip()
+    if '@' in part:
+        k, v = part.rsplit('@', 1)
+        if k.strip() and v.strip():
+            prev_shas[k.strip()] = v.strip()
+
+repos = entry.get('repos') or []
+if not isinstance(repos, list):
+    repos = []
+inventory = []
+redacted_total = 0
+delta_unavailable = False
+for raw in repos:
+    if isinstance(raw, str):
+        raw = {'github_repo': raw}
+    if not isinstance(raw, dict):
+        continue
+    github_repo = str(raw.get('github_repo') or '').strip().strip('/')
+    gitlab_path = str(raw.get('gitlab_path') or '').strip().strip('/')
+    explicit = str(raw.get('url') or '').strip()
+    rid = str(raw.get('id') or '').strip()
+    if not rid:
+        base = explicit or github_repo or gitlab_path
+        rid = re.sub(r'[^A-Za-z0-9_.-]', '-', base.rstrip('/').split('/')[-1].replace('.git', '')) or 'repo'
+    ref = str(raw.get('ref') or raw.get('branch') or '').strip()
+    if explicit:
+        url = explicit
+    elif github_repo:
+        url = 'https://github.com/' + github_repo + '.git'
+    elif gitlab_path:
+        if not gitlab_host:
+            inventory.append({'id': rid, 'status': 'degraded', 'path': '', 'head': '', 'url': '', 'changed_files': [], 'note': 'gitlab_path ' + gitlab_path + ' declared but the catalog has no top-level gitlab.host block'})
+            continue
+        url = 'https://' + gitlab_host + '/' + gitlab_path + '.git'
+    else:
+        inventory.append({'id': rid, 'status': 'degraded', 'path': '', 'head': '', 'url': '', 'changed_files': [], 'note': 'catalog entry names no github_repo, gitlab_path or url'})
+        continue
+    dest = os.path.join(sources_root, rid)
+    note = ''
+    if os.path.isdir(os.path.join(dest, '.git')):
+        rc, _, err = run_git(['fetch', '--prune', 'origin'], cwd=dest)
+        if rc != 0:
+            shutil.rmtree(dest, ignore_errors=True)
+        else:
+            rc2, _, err2 = run_git(['reset', '--hard', 'FETCH_HEAD'], cwd=dest)
+            if rc2 != 0:
+                shutil.rmtree(dest, ignore_errors=True)
+            else:
+                note = 'updated existing clone'
+    if not os.path.isdir(os.path.join(dest, '.git')):
+        shutil.rmtree(dest, ignore_errors=True)
+        args = ['clone']
+        if depth > 0:
+            args += ['--depth', str(depth)]
+        if ref:
+            args += ['--branch', ref]
+        args += [url, dest]
+        rc, _, err = run_git(args)
+        if rc != 0:
+            shutil.rmtree(dest, ignore_errors=True)
+            inventory.append({'id': rid, 'status': 'degraded', 'path': '', 'head': '', 'url': url, 'changed_files': [], 'note': 'clone failed: ' + (redact(err) or 'unknown error') + (' (no push/read credential was available)' if not token else '')})
+            continue
+        note = 'cloned'
+    ## Redaction: a source repo may carry credential files the docs
+    ## agent has no business reading. Remove them from the CLONE.
+    removed = 0
+    for root, dirs, files in os.walk(dest):
+        if '.git' in dirs:
+            dirs.remove('.git')
+        for fname in files:
+            full = os.path.join(root, fname)
+            rel = os.path.relpath(full, dest)
+            if any(fnmatch.fnmatch(fname, g) or fnmatch.fnmatch(rel, g) for g in secret_globs):
+                try:
+                    os.remove(full)
+                    removed += 1
+                except OSError:
+                    pass
+    redacted_total += removed
+    rc, out, _ = run_git(['rev-parse', 'HEAD'], cwd=dest, timeout=60)
+    head = out.strip() if rc == 0 else ''
+    changed = []
+    prev = prev_shas.get(rid, '')
+    if prev and head and prev != head:
+        rc, _, _ = run_git(['cat-file', '-e', prev + '^{commit}'], cwd=dest, timeout=60)
+        if rc != 0:
+            run_git(['fetch', '--depth', '1', 'origin', prev], cwd=dest, timeout=300)
+            rc, _, _ = run_git(['cat-file', '-e', prev + '^{commit}'], cwd=dest, timeout=60)
+        if rc == 0:
+            rc, out, _ = run_git(['diff', '--name-only', prev, head], cwd=dest, timeout=300)
+            if rc == 0:
+                changed = [l for l in out.splitlines() if l.strip()]
+            else:
+                delta_unavailable = True
+                note = (note + '; ' if note else '') + 'delta unavailable: git diff from the recorded commit failed'
+        else:
+            delta_unavailable = True
+            note = (note + '; ' if note else '') + 'delta unavailable: commit ' + prev[:12] + ' recorded by the previous run is not reachable in this shallow clone (raise clone_depth to compute it)'
+    elif prev and head and prev == head:
+        note = (note + '; ' if note else '') + 'unchanged since the previous run'
+    if removed:
+        note = (note + '; ' if note else '') + str(removed) + ' secret-bearing file(s) redacted from the clone'
+    inventory.append({'id': rid, 'status': 'ok', 'path': dest, 'head': head, 'url': url, 'changed_files': changed[:500], 'note': note})
+
+ok = [e for e in inventory if e['status'] == 'ok']
+degraded = [e for e in inventory if e['status'] != 'ok']
+stamp = ','.join(e['id'] + '@' + (e['head'][:12] or 'unknown') for e in ok)
+parts = [str(len(ok)) + ' source repo(s) cloned', str(len(degraded)) + ' degraded']
+if redacted_total:
+    parts.append(str(redacted_total) + ' secret-bearing file(s) redacted')
+if delta_unavailable:
+    parts.append('source delta UNAVAILABLE for at least one repo -- treat the pass as a full survey')
+if degraded:
+    parts.append('unreadable: ' + ', '.join(e['id'] for e in degraded))
+if not repos:
+    parts.append('the catalog entry declares no repos[] -- nothing to ground the documentation in')
+print(json.dumps({'product_id': product, 'product_dir': product_dir, 'surfaces': surfaces, 'inventory': inventory, 'sources_stamp': stamp, 'repo_count': len(inventory), 'ok_count': len(ok), 'degraded_count': len(degraded), 'redacted_count': redacted_total, 'previous_stamp': previous_stamp, 'delta_unavailable': delta_unavailable, 'log': '; '.join(parts)}, ensure_ascii=False))
+"`
+  output: ingest_output
+
+## scan_hints — the ONE deterministic producer of ADVISORY hints over
+## the PUBLISHED product tree. Runs as the continuation-loop head, so
+## the report always reflects the live tree and hints the campaign
+## resolved retire between passes.
+##
+## What it checks (high-precision, product-model aware):
+##   - dead_link / dead_anchor — an intra-repo markdown link whose
+##     target file or GitHub-slug heading anchor does not resolve. In a
+##     hub-and-step model the navigation IS the product, so a dead link
+##     is a real defect, not cosmetics.
+##   - orphan_page — a page under the product directory that no other
+##     page links to. Unreachable from the hub = invisible to the
+##     reader. Index/README/SUMMARY pages are never orphans.
+##   - unmapped_surface — a functional surface the catalog declares
+##     that no page mentions. Advisory ZONE, not an obligation.
+##   - empty_page — a page with no prose beyond its title.
+## Ledger entries (vars.dismissed_path) are excluded. An empty product
+## tree is NOT special-cased: the report degrades to an explicit
+## bootstrap note and the campaign authors the initial set itself.
+tool scan_hints:
+  input: hints_input
+  command: `WS={{vars.workspace_dir}} PRODUCT_DIR={{input.product_dir}} SURFACES={{input.surfaces}} EDITORIAL_DIR={{vars.editorial_dir}} DISMISSED_PATH={{vars.dismissed_path}} MAX_HINTS={{vars.max_hints}} MODE={{vars.mode}} DIFF_SINCE={{vars.diff_since}} python3 -c "
+import os, json, glob, re, subprocess
+ws = os.environ['WS']
+os.chdir(ws)
+product_dir = (os.environ.get('PRODUCT_DIR') or '').strip().strip('/')
+editorial_dir = (os.environ.get('EDITORIAL_DIR') or '').strip().strip('/')
+try:
+    max_hints = int((os.environ.get('MAX_HINTS') or '120').strip() or '120')
+except ValueError:
+    max_hints = 120
+try:
+    surfaces = json.loads(os.environ.get('SURFACES') or '[]')
+except ValueError:
+    surfaces = []
+if not isinstance(surfaces, list):
+    surfaces = []
+pages = sorted(p for p in glob.glob(os.path.join(product_dir, '**', '*.md'), recursive=True) if os.path.isfile(p))
+dismissed = set()
+dismissed_path = (os.environ.get('DISMISSED_PATH') or '').strip()
+if dismissed_path and os.path.exists(dismissed_path):
+    try:
+        with open(dismissed_path, encoding='utf-8') as df:
+            for e in json.load(df):
+                if isinstance(e, dict):
+                    dismissed.add((e.get('doc', ''), e.get('kind', ''), str(e.get('value', ''))))
+    except (OSError, ValueError, TypeError):
+        pass
+hints = []
+ledger_excluded = 0
+def add_hint(doc, line, kind, value, note):
+    global ledger_excluded
+    if (doc, kind, str(value)) in dismissed:
+        ledger_excluded += 1
+        return
+    hints.append({'doc': doc, 'line': line, 'kind': kind, 'value': value, 'note': note})
+BT = chr(96)
+MD_LINK_RE = re.compile(r'\[(?:[^\]]*)\]\(([^)\s]+)')
+def slugify(text):
+    s = text.strip().lower().replace(BT, '')
+    s = re.sub(r'[^\w\s-]', '', s, flags=re.UNICODE)
+    s = re.sub(r'\s', '-', s)
+    return s.strip('-')
+_heading_cache = {}
+def headings_of(path):
+    if path in _heading_cache:
+        return _heading_cache[path]
+    slugs = set()
+    try:
+        with open(path, encoding='utf-8', errors='replace') as fh:
+            for ln in fh:
+                hm = re.match(r'\s{0,3}(#{1,6})\s+(.+)', ln)
+                if hm:
+                    slugs.add(slugify(hm.group(2)))
+    except (OSError, IsADirectoryError):
+        pass
+    _heading_cache[path] = slugs
+    return slugs
+INDEX_NAMES = {'readme.md', 'index.md', 'summary.md'}
+checked_links = 0
+linked_targets = set()
+corpus_parts = []
+empty_pages = []
+for doc in pages:
+    try:
+        with open(doc, encoding='utf-8', errors='replace') as fh:
+            lines = fh.readlines()
+    except (OSError, IsADirectoryError):
+        continue
+    corpus_parts.append(''.join(lines))
+    body = [l for l in lines if l.strip() and not l.lstrip().startswith('#')]
+    if not body:
+        empty_pages.append(doc)
+    seen = set()
+    for lineno, line in enumerate(lines, start=1):
+        for m in MD_LINK_RE.finditer(line):
+            target = m.group(1)
+            if target.startswith('#'):
+                continue
+            if re.match(r'^[a-z][a-z0-9+.-]*://', target) or target.startswith(('mailto:', 'tel:', '//', 'www.')):
+                continue
+            if '#' in target:
+                path_part, frag = target.split('#', 1)
+            else:
+                path_part, frag = target, ''
+            if ('link', target) in seen:
+                continue
+            seen.add(('link', target))
+            checked_links += 1
+            tgt = doc if not path_part else os.path.normpath(os.path.join(os.path.dirname(doc), path_part))
+            if path_part and not os.path.exists(tgt):
+                add_hint(doc, lineno, 'dead_link', target, 'link target not found: ' + tgt)
+                continue
+            if path_part:
+                linked_targets.add(tgt)
+            if frag and tgt.endswith('.md') and slugify(frag.replace('-', ' ')) and frag.lower() not in headings_of(tgt):
+                add_hint(doc, lineno, 'dead_anchor', target, 'no heading matching #' + frag + ' in ' + tgt)
+corpus = chr(10).join(corpus_parts)
+for doc in pages:
+    if os.path.basename(doc).lower() in INDEX_NAMES:
+        continue
+    if os.path.normpath(doc) in linked_targets:
+        continue
+    add_hint(doc, 0, 'orphan_page', doc, 'no other page links to this one -- unreachable from the hub, so invisible to the reader')
+for doc in empty_pages:
+    add_hint(doc, 0, 'empty_page', doc, 'page has a title and no prose')
+def surface_label(s):
+    if isinstance(s, dict):
+        return str(s.get('name') or s.get('title') or s.get('id') or '').strip()
+    return str(s).strip()
+for s in surfaces:
+    label = surface_label(s)
+    if not label:
+        continue
+    if label.lower() not in corpus.lower():
+        add_hint('', 0, 'unmapped_surface', label, 'the catalog declares this functional surface and no page mentions it (advisory zone)')
+prio = {'dead_link': 0, 'dead_anchor': 0, 'empty_page': 1, 'orphan_page': 2, 'unmapped_surface': 3}
+hints.sort(key=lambda h: (prio.get(h['kind'], 4), h['doc'], h['line']))
+dead_link_count = sum(1 for h in hints if h['kind'] in ('dead_link', 'dead_anchor'))
+orphan_count = sum(1 for h in hints if h['kind'] == 'orphan_page')
+unmapped_surface_count = sum(1 for h in hints if h['kind'] == 'unmapped_surface')
+truncated = max_hints > 0 and len(hints) > max_hints
+if max_hints > 0:
+    hints = hints[:max_hints]
+editorial_files = []
+if editorial_dir:
+    editorial_files = sorted(p for p in glob.glob(os.path.join(editorial_dir, '**', '*.md'), recursive=True) if os.path.isfile(p))
+if not pages:
+    hints_note = 'no page under ' + (product_dir or '<product_dir>') + ' yet -- this is a BOOTSTRAP pass: author the initial documentation set from the sources, per the documentary model in force'
+else:
+    hints_note = str(dead_link_count) + ' dead link(s)/anchor(s), ' + str(orphan_count) + ' orphan page(s), ' + str(unmapped_surface_count) + ' unmapped surface(s) -- from ' + str(checked_links) + ' internal link(s) across ' + str(len(pages)) + ' page(s); ' + str(ledger_excluded) + ' ledger-dismissed excluded' + (' [list truncated to ' + str(max_hints) + ']' if truncated else '')
+if editorial_files:
+    hints_note = hints_note + '; ' + str(len(editorial_files)) + ' editorial override(s) published by the docs repo (AUTHORITATIVE)'
+else:
+    hints_note = hints_note + '; no editorial override in the docs repo -- the bundle default skills apply'
+mode = (os.environ.get('MODE') or 'full').strip().lower()
+diff_since = (os.environ.get('DIFF_SINCE') or '').strip()
+if mode == 'incremental' and not diff_since:
+    try:
+        p = subprocess.run(['git', 'log', '-E', '--grep', '^Bot: product-docs', '-n', '1', '--format=%H'], capture_output=True, text=True, check=True)
+        diff_since = p.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        diff_since = ''
+incremental_base = ''
+recent = []
+if diff_since:
+    for ref in (diff_since, 'origin/' + diff_since):
+        try:
+            proc = subprocess.run(['git', 'diff', '--name-only', ref + '...HEAD'], capture_output=True, text=True, check=True)
+            recent = sorted(l for l in proc.stdout.splitlines() if l.strip())
+            incremental_base = ref
+            break
+        except (OSError, subprocess.SubprocessError):
+            recent = []
+print(json.dumps({'pages': pages, 'page_count': len(pages), 'hints': hints, 'hint_count': len(hints), 'dead_link_count': dead_link_count, 'orphan_count': orphan_count, 'unmapped_surface_count': unmapped_surface_count, 'checked_links': checked_links, 'ledger_excluded': ledger_excluded, 'truncated': truncated, 'hints_note': hints_note, 'editorial_files': editorial_files, 'mode': mode, 'incremental_base': incremental_base, 'recently_changed_pages': recent}, ensure_ascii=False))
+"`
+  output: hints_output
+
+## campaign — the one adaptive agent. claude_code with the full native
+## toolset so it works exactly like a native session: read the source
+## clones, read the editorial line in force, write the page, commit it
+## in stride. session: fresh — a fresh pass re-derives its todo from a
+## fresh advisory report + `git log` (git is the durable state). Board
+## capabilities power the findings handoff.
+agent campaign:
+  backend: "claude_code"
+  model: "${ITERION_PRODUCT_DOCS_MODEL_CLAUDE:-claude-opus-5}"
+  ## ultracode (on opus-4-8) hands the campaign the `agent` subagent
+  ## tool + the orchestration prerogative, so it can fan out its own
+  ## sub-readers per source repository or per user role. A product
+  ## spread over N repositories is exactly the shape a single
+  ## self-scoping agent under-serves.
+  reasoning_effort: "${ITERION_PRODUCT_DOCS_EFFORT_CLAUDE:-ultracode}"
+  input: campaign_input
+  output: campaign_output
+  system: campaign_system
+  user: campaign_user
+  session: fresh
+  interaction: human
+  capabilities: [board.read, board.create]
+
+## scope_check — the DETERMINISTIC writeable-set gate. Diffs the RUN
+## BASE (the newest reflog entry that is not one of this run's own
+## commits) against the working tree and flags any changed path that is
+## not a `.md` file under the product directory — so the source clones
+## (out of tree), the docs repo's editorial skills, and every other
+## product's directory are all structurally protected. Untracked files
+## are held to the same rule. No LLM; the campaign must revert whatever
+## this flags.
+tool scope_check:
+  input: product_dir_input
+  command: `WS={{vars.workspace_dir}} PRODUCT_DIR={{input.product_dir}} python3 -c "
+import os, json, subprocess
+ws = os.environ.get('WS', '.')
+product_dir = (os.environ.get('PRODUCT_DIR') or '').strip().strip('/')
+
+def git(args):
+    try:
+        p = subprocess.run(['git', '-C', ws] + args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, timeout=120)
+        return p.stdout or ''
+    except (OSError, subprocess.SubprocessError):
+        return ''
+
+reflog = [l for l in git(['reflog', '--format=%H']).splitlines() if l.strip()]
+def is_own_commit(h):
+    body = git(['log', '-1', '--format=%B', h])
+    return any(l.strip() == 'Bot: product-docs' for l in body.splitlines())
+base = 'HEAD'
+for h in reflog:
+    if not is_own_commit(h):
+        base = h
+        break
+changed = set(l for l in git(['diff', base, '--name-only']).splitlines() if l.strip())
+for line in git(['status', '--porcelain']).splitlines():
+    if line[:2].strip() == '??':
+        changed.add(line[3:].strip())
+
+def allowed(p):
+    if not p.endswith('.md'):
+        return False
+    if not product_dir:
+        return False
+    return p == product_dir or p.startswith(product_dir + '/')
+
+out_of_scope = sorted(p for p in changed if not allowed(p))
+log = ''
+if out_of_scope:
+    log = 'SCOPE VIOLATION: this run changed files outside the product writeable-set (.md under ' + (product_dir or '<product_dir>') + ' only). Revert these before continuing (git revert the offending commits, or git checkout ' + base[:12] + ' -- <path>): ' + ', '.join(out_of_scope[:40])
+print(json.dumps({'scope_ok': not out_of_scope, 'out_of_scope': out_of_scope[:100], 'log': log}, ensure_ascii=False))
+"`
+  output: scope_check_output
+
+## page_lint — the DETERMINISTIC EDITORIAL gate. A published page is
+## read by the product's users; it carries no trace of how it was
+## produced. Four rules, each independently disableable through
+## `lint_rules`, plus operator-supplied extra headings:
+##   html_comments   — an HTML comment is a working note that survived
+##   sources_box     — a "Sources" heading or a hint block whose body
+##                     is a source reference
+##   clarify_section — a "Points à clarifier" section (open questions
+##                     belong inline as [à confirmer], or in the run
+##                     report)
+##   technical_annex — a "Correspondance technique" annex (technical
+##                     content is out of scope for these pages)
+## A violation is NOT converged: the log feeds the next pass and the
+## campaign removes exactly the reported lines.
+tool page_lint:
+  input: product_dir_input
+  command: `WS={{vars.workspace_dir}} PRODUCT_DIR={{input.product_dir}} LINT_RULES={{vars.lint_rules}} EXTRA_HEADINGS={{vars.extra_forbidden_headings}} python3 -c "
+import os, json, glob, re
+ws = os.environ['WS']
+os.chdir(ws)
+product_dir = (os.environ.get('PRODUCT_DIR') or '').strip().strip('/')
+rules = {r.strip() for r in (os.environ.get('LINT_RULES') or '').split(',') if r.strip()}
+extra = [h.strip() for h in (os.environ.get('EXTRA_HEADINGS') or '').split(',') if h.strip()]
+pages = sorted(p for p in glob.glob(os.path.join(product_dir, '**', '*.md'), recursive=True) if os.path.isfile(p)) if product_dir else []
+HEADING_RE = re.compile(r'^\s{0,3}#{1,6}\s+(.+?)\s*$')
+BOLD_LABEL_RE = re.compile(r'^\s{0,3}\*\*([^*]+?)\s*:?\s*\*\*')
+SOURCES_RE = re.compile(r'^sources?\b', re.IGNORECASE)
+CLARIFY_RE = re.compile(r'^points?\s+.{0,4}\s*clarifier\b', re.IGNORECASE)
+ANNEX_RE = re.compile(r'^(annexe\s*:?\s*)?correspondance\s+technique\b', re.IGNORECASE)
+HINT_OPEN_RE = re.compile(r'^\s*\{%\s*hint\b')
+HINT_CLOSE_RE = re.compile(r'^\s*\{%\s*endhint\s*%\}')
+violations = []
+def add(page, line, rule, excerpt):
+    violations.append({'page': page, 'line': line, 'rule': rule, 'excerpt': ' '.join((excerpt or '').split())[:160]})
+for page in pages:
+    try:
+        with open(page, encoding='utf-8', errors='replace') as fh:
+            lines = fh.readlines()
+    except (OSError, IsADirectoryError):
+        continue
+    in_comment = False
+    in_hint = 0
+    hint_start = 0
+    hint_body = []
+    for lineno, line in enumerate(lines, start=1):
+        if 'html_comments' in rules:
+            if in_comment:
+                if '-->' in line:
+                    in_comment = False
+            elif '<!--' in line:
+                add(page, lineno, 'html_comments', line)
+                if '-->' not in line.split('<!--', 1)[1]:
+                    in_comment = True
+        if HINT_OPEN_RE.match(line):
+            in_hint = 1
+            hint_start = lineno
+            hint_body = []
+            continue
+        if in_hint:
+            if HINT_CLOSE_RE.match(line):
+                if 'sources_box' in rules:
+                    joined = ' '.join(hint_body)
+                    if re.search(r'\bsources?\s*:', joined, re.IGNORECASE) or re.search(r'^\s*\*?\*?sources?\b', joined, re.IGNORECASE):
+                        add(page, hint_start, 'sources_box', joined)
+                in_hint = 0
+                hint_body = []
+                continue
+            hint_body.append(line.strip())
+            continue
+        title = ''
+        hm = HEADING_RE.match(line)
+        if hm:
+            title = hm.group(1).strip()
+        else:
+            bm = BOLD_LABEL_RE.match(line)
+            if bm:
+                title = bm.group(1).strip()
+        if not title:
+            continue
+        plain = re.sub(r'[*_' + chr(96) + r']', '', title).strip()
+        if 'sources_box' in rules and SOURCES_RE.match(plain):
+            add(page, lineno, 'sources_box', line)
+        if 'clarify_section' in rules and CLARIFY_RE.match(plain):
+            add(page, lineno, 'clarify_section', line)
+        if 'technical_annex' in rules and ANNEX_RE.match(plain):
+            add(page, lineno, 'technical_annex', line)
+        for h in extra:
+            if plain.lower().startswith(h.lower()):
+                add(page, lineno, 'extra_forbidden_heading', line)
+log = ''
+if violations:
+    shown = ['- ' + v['page'] + ':' + str(v['line']) + ' [' + v['rule'] + '] ' + v['excerpt'] for v in violations[:40]]
+    log = 'EDITORIAL LINT VIOLATION: published pages must carry no working notes (no HTML comments, no Sources box/section, no Points a clarifier section, no Correspondance technique annex). Remove exactly these, then re-check:' + chr(10) + chr(10).join(shown)
+    if len(violations) > 40:
+        log = log + chr(10) + '- ... and ' + str(len(violations) - 40) + ' more'
+print(json.dumps({'lint_ok': not violations, 'violations': violations[:200], 'violation_count': len(violations), 'pages_linted': len(pages), 'log': log}, ensure_ascii=False))
+"`
+  output: lint_output
+
+## gate — the deterministic continuation decision. converged = the
+## writeable set is clean AND the published pages carry no working
+## notes AND the campaign reports the documentation aligned. NOTHING
+## ELSE: the advisory hint counts are telemetry in the run events,
+## never conditions. fail_log relays both gates' complaints to the next
+## pass; a green-but-more-work pass rides an empty log. No LLM, no
+## shell.
+compute gate:
+  output: gate_state
+  expr:
+    converged: "outputs.scope_check.scope_ok && outputs.page_lint.lint_ok && outputs.campaign.docs_aligned"
+    fail_log: "if(!outputs.scope_check.scope_ok, outputs.scope_check.log + ' | ', '') + if(!outputs.page_lint.lint_ok, outputs.page_lint.log, '')"
+
+## ─── Nodes : PR finalization tail (opt-in) ─────────────────────────
+
+## mr_gate decides whether the PR tail runs. No LLM, no shell.
+compute mr_gate:
+  output: mr_gate_output
+  expr:
+    open_mr: "vars.open_mr"
+
+## forge_auth_probe — DETERMINISTIC pre-flight for the push.
+## finalize_mr is an LLM agent; entering it with NO push credential
+## mounted burns a whole turn just to rediscover, in shell, that it
+## cannot push. Read-only, idempotent.
+tool forge_auth_probe:
+  command: `python3 -c "
+import os, subprocess, json
+tok = '/run/iterion/secrets/forge_token'
+try:
+    if os.path.isfile(tok) and os.path.getsize(tok) > 0:
+        print(json.dumps({'available': True, 'reason': 'file:' + tok})); raise SystemExit(0)
+except OSError:
+    pass
+for v in ('GH_TOKEN', 'GITHUB_TOKEN', 'GITLAB_TOKEN', 'FORGEJO_TOKEN', 'GITEA_TOKEN'):
+    if os.environ.get(v):
+        print(json.dumps({'available': True, 'reason': 'env:' + v})); raise SystemExit(0)
+try:
+    r = subprocess.run(['gh', 'auth', 'status'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=10)
+    if r.returncode == 0:
+        print(json.dumps({'available': True, 'reason': 'gh host auth'})); raise SystemExit(0)
+except (OSError, subprocess.SubprocessError):
+    pass
+print(json.dumps({'available': False, 'reason': 'no forge_token secret, no *_TOKEN env, no gh host auth'}))
+"`
+  output: forge_auth_state
+
+agent finalize_mr:
+  backend: "claude_code"
+  model: "${ITERION_PRODUCT_DOCS_MODEL_CLAUDE:-claude-opus-5}"
+  reasoning_effort: "${ITERION_PRODUCT_DOCS_MR_EFFORT:-medium}"
+  input: finalize_mr_input
+  output: finalize_mr_output
+  system: finalize_mr_system
+  user: finalize_mr_user
+  tools: [bash, read_file, glob, grep]
+  capabilities: [board.read, board.comment]
+  tool_max_steps: 20
+
+## surface_pr_link — DETERMINISTIC result-link emitter for the studio
+## run summary. The studio surfaces a run's headline PR link from the
+## `[iterion] preview_url=… kind=pr` directive a tool node prints on
+## stdout — never from agent prose. Read-only, idempotent.
+tool surface_pr_link:
+  input: surface_pr_link_input
+  command: `URL={{input.url}} python3 -c "
+import os
+u = (os.environ.get('URL') or '').strip()
+if u:
+    print('[iterion] preview_url=' + u + ' kind=pr scope=external')
+"`
+
+## ─── Workflow ───────────────────────────────────────────────────
+
+workflow product_docs:
+  entry: catalog_ingest
+
+  ## Run in an isolated git worktree of the DOCS repo — the campaign
+  ## commits pages in stride; the worktree + finalize keeps the
+  ## operator's checkout untouched during the run and lands the series
+  ## on a persistent branch.
+  worktree: auto
+
+  ## The docs repository is a documentation repository: it has no
+  ## build, and its devbox.json (if any) would install a toolchain
+  ## this run never uses. The BOT's own devbox.json still applies.
+  repo_devbox: off
+
+  budget:
+    max_parallel_branches: 1
+    ## A comprehensive pass reads N source repositories and writes a
+    ## journey-shaped page set — long by construction. The ceiling
+    ## holds max_passes of those, so the asymptote converges on its own
+    ## terms rather than stopping wherever the cap happens to fall. A
+    ## run on an OAuth forfait spends no money at all here — the figure
+    ## prices tokens against a plan already paid for.
+    ##
+    ## The engine declines a back-edge it cannot fund (priced by the
+    ## previous pass), so exhausting this ceiling routes the run
+    ## through mr_gate → the PR tail with the pages it committed in
+    ## stride, instead of dying mid-pass and stranding them.
+    max_duration: "6h"
+    max_cost_usd: 300
+
+  compaction:
+    threshold: 0.9
+    preserve_recent: 8
+
+  ## The clones happen ONCE, before the loop: source repositories do
+  ## not change during a run.
+  catalog_ingest -> scan_hints with {
+    product_dir: "{{outputs.catalog_ingest.product_dir}}",
+    surfaces: "{{outputs.catalog_ingest.surfaces}}"
+  }
+
+  ## Each pass: the fresh advisory report + the source inventory are
+  ## handed to the campaign as HELP (+ the previous gate's feedback —
+  ## empty on pass 1; outputs.gate resolves nil-safe before the gate
+  ## has run).
+  scan_hints -> campaign with {
+    product_id: "{{outputs.catalog_ingest.product_id}}",
+    product_dir: "{{outputs.catalog_ingest.product_dir}}",
+    surfaces: "{{outputs.catalog_ingest.surfaces}}",
+    inventory: "{{outputs.catalog_ingest.inventory}}",
+    sources_stamp: "{{outputs.catalog_ingest.sources_stamp}}",
+    editorial_files: "{{outputs.scan_hints.editorial_files}}",
+    hints: "{{outputs.scan_hints.hints}}",
+    hint_count: "{{outputs.scan_hints.hint_count}}",
+    hints_note: "{{outputs.scan_hints.hints_note}}",
+    mode: "{{outputs.scan_hints.mode}}",
+    incremental_base: "{{outputs.scan_hints.incremental_base}}",
+    fail_log: "{{outputs.gate.fail_log}}"
+  }
+
+  ## Deterministic TRUTH gates after every campaign pass: writeable-set
+  ## containment, then the editorial lint, then the continuation
+  ## decision. A documentation-only change cannot break a build, so
+  ## there is no build gate — the lint is this bot's equivalent truth
+  ## oracle on the artifact it actually ships.
+  campaign -> scope_check with {
+    product_dir: "{{outputs.catalog_ingest.product_dir}}"
+  }
+  scope_check -> page_lint with {
+    product_dir: "{{outputs.catalog_ingest.product_dir}}"
+  }
+  page_lint -> gate
+
+  ## Converged → straight to the PR tail.
+  gate -> mr_gate when converged
+  ## Not converged → another pass through the loop head: a fresh
+  ## advisory report (resolved hints + ledger entries retire) →
+  ## campaign. The scope/lint complaints ride outputs.gate.fail_log on
+  ## the scan_hints→campaign edge.
+  gate -> scan_hints as continuation_loop("{{vars.max_passes}}") with {
+    product_dir: "{{outputs.catalog_ingest.product_dir}}",
+    surfaces: "{{outputs.catalog_ingest.surfaces}}"
+  }
+  ## continuation_loop exhausted (max_passes hit while work remains) →
+  ## finish anyway, shipping what is banked (every committed page is
+  ## real, landed work; drift_remaining tells the operator what is
+  ## left).
+  gate -> mr_gate
+
+  ## ── PR tail (opt-in) ────────────────────────────────────────────
+  ## Reached on BOTH finishes (converged and max_passes-exhausted).
+  ## finalize_mr refuses an empty PR and reports drift_remaining +
+  ## unread_sources honestly in the body.
+  mr_gate -> forge_auth_probe when open_mr
+  mr_gate -> done when not open_mr
+
+  forge_auth_probe -> finalize_mr when available with {
+    workspace_dir:    "{{vars.workspace_dir}}",
+    product_id:       "{{outputs.catalog_ingest.product_id}}",
+    draft:            "{{vars.mr_draft}}",
+    mr_branch:        "{{vars.mr_branch}}",
+    mr_base:          "{{vars.mr_base}}",
+    source_issue_ref: "{{vars.source_issue_ref}}",
+    scope_notes:      "{{vars.scope_notes}}",
+    campaign_summary: "{{outputs.campaign.summary}}",
+    drift_remaining:  "{{outputs.campaign.drift_remaining}}",
+    unread_sources:   "{{outputs.campaign.unread_sources}}"
+  }
+  forge_auth_probe -> done when not available
+  ## PR opened → surface its URL as a headline result-link in the run
+  ## summary, then finish. Nothing opened → straight to done.
+  finalize_mr -> surface_pr_link when opened with { url: "{{outputs.finalize_mr.url}}" }
+  finalize_mr -> done when not opened
+  surface_pr_link -> done

--- a/bots/product-docs/main.bot
+++ b/bots/product-docs/main.bot
@@ -1290,6 +1290,13 @@ for line in git(['status', '--porcelain']).splitlines():
     if line[:2].strip() == '??':
         changed.add(line[3:].strip())
 
+# iterion materialises the bundle's skills into <workspace>/.claude/ at run
+# start and again on every resume. That tree is the ENGINE's own artifact,
+# not the campaign's work: attributing it to the run would fail the gate on
+# every pass, and the campaign could not fix it — the next pass re-creates
+# it. Untracked directories arrive from git status as '.claude/'.
+changed = set(p for p in changed if p != '.claude' and not p.startswith('.claude/'))
+
 def allowed(p):
     if not p.endswith('.md'):
         return False

--- a/bots/product-docs/main.bot
+++ b/bots/product-docs/main.bot
@@ -821,7 +821,7 @@ def load_catalog(path):
     try:
         p = subprocess.run(['yq', '-o=json', '.', path], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=60)
     except (OSError, subprocess.SubprocessError) as exc:
-        raise SystemExit('product-docs: cannot parse ' + path + ' -- no PyYAML and no yq on PATH (' + str(exc) + ')')
+        raise SystemExit('product-docs: cannot parse the YAML catalog ' + path + ' -- this interpreter has no PyYAML and yq is not on PATH (' + str(exc) + '). yq IS declared in the bot devbox.json, so its absence means the provisioning did not land: the run sandbox_devbox_provisioned event names why in its errors field. Otherwise write the catalog as .json, which needs no parser at all.')
     if p.returncode != 0:
         raise SystemExit('product-docs: yq failed to parse ' + path + ': ' + (p.stderr or '').strip())
     return json.loads(p.stdout)

--- a/bots/product-docs/main.bot
+++ b/bots/product-docs/main.bot
@@ -501,8 +501,9 @@ prompt campaign_user:
   corpus — plan it, then write exhaustively.
   INCREMENTAL: focus on what the source deltas above
   (`changed_files` per repo) and the docs delta since
-  {{input.incremental_base}} actually impact. Do NOT re-audit pages
-  untouched by those changes. If every `changed_files` is empty AND
+  {{input.incremental_base}} actually impact — the pages already
+  touched in that window: {{input.recently_changed_pages}}. Do NOT
+  re-audit pages untouched by those changes. If every `changed_files` is empty AND
   `delta_unavailable` is reported for the repos, the delta could NOT
   be computed — do NOT read that as "nothing changed": survey
   directly. In BOTH modes the structural hints below cover the whole
@@ -678,6 +679,7 @@ schema campaign_input:
   hints_note: string
   mode: string
   incremental_base: string
+  recently_changed_pages: string[]
   fail_log: string
 
 ## campaign's TERMINATION CONTRACT: a machine-checkable output the
@@ -1024,6 +1026,7 @@ if not isinstance(repos, list):
 inventory = []
 redacted_total = 0
 delta_unavailable = False
+seen_rids = {}
 for raw in repos:
     if isinstance(raw, str):
         raw = {'github_repo': raw}
@@ -1042,6 +1045,13 @@ for raw in repos:
     rid = re.sub(r'[^A-Za-z0-9_.-]', '-', rid).strip('.-') or 'repo'
     if rid in ('.', '..'):
         rid = 'repo'
+    ## Two ids colliding AFTER sanitisation would share one clone dir:
+    ## the second rmtree-and-reclones over the first, and the campaign
+    ## reads the wrong repository under the first id. A collision is a
+    ## catalog bug -- refuse it loudly instead of silently swapping code.
+    if rid in seen_rids:
+        raise SystemExit('product-docs: catalog ids ' + str(seen_rids[rid]) + ' and ' + str(raw.get('id') or '') + ' collide after sanitisation (both become ' + rid + ') -- rename one in the catalog')
+    seen_rids[rid] = str(raw.get('id') or rid)
     ref = str(raw.get('ref') or raw.get('branch') or '').strip()
     ## A catalog value handed to git must not be able to become an
     ## OPTION (leading dash) instead of a repository or a branch.
@@ -1140,7 +1150,11 @@ for raw in repos:
 
 ok = [e for e in inventory if e['status'] == 'ok']
 degraded = [e for e in inventory if e['status'] != 'ok']
-stamp = ','.join(e['id'] + '@' + (e['head'][:12] or 'unknown') for e in ok)
+## FULL sha: the next run's shallow-clone delta repair does
+## run_git(['fetch', '--depth', '1', 'origin', prev]) -- git can only
+## fetch a full object name, so an abbreviated stamp made the repair
+## permanently impossible and every incremental delta unavailable.
+stamp = ','.join(e['id'] + '@' + (e['head'] or 'unknown') for e in ok)
 parts = [str(len(ok)) + ' source repo(s) cloned', str(len(degraded)) + ' degraded']
 if redacted_total:
     parts.append(str(redacted_total) + ' secret-bearing file(s) redacted')
@@ -1764,6 +1778,7 @@ workflow product_docs:
     hints_note: "{{outputs.scan_hints.hints_note}}",
     mode: "{{outputs.scan_hints.mode}}",
     incremental_base: "{{outputs.scan_hints.incremental_base}}",
+    recently_changed_pages: "{{outputs.scan_hints.recently_changed_pages}}",
     fail_log: "{{outputs.gate.fail_log}}"
   }
 

--- a/bots/product-docs/main.bot
+++ b/bots/product-docs/main.bot
@@ -802,10 +802,15 @@ if not scratch:
     raise SystemExit('product-docs: scratch_dir resolved empty -- the source clones have nowhere out-of-tree to live')
 os.chdir(ws)
 
-def load_yaml(path):
-    ## PyYAML when the interpreter has it; otherwise yq (declared in
-    ## this bundle devbox.json) rendering the same document as JSON.
-    ## Neither available is a LOUD failure, never a guessed parse.
+def load_catalog(path):
+    ## A .json catalog needs no dependency at all (a generated catalog
+    ## is a legitimate shape). For YAML: PyYAML when the interpreter
+    ## has it; otherwise yq (declared in this bundle devbox.json)
+    ## rendering the same document as JSON. Neither available is a LOUD
+    ## failure -- never a hand-rolled, silently-wrong parse.
+    if path.endswith('.json'):
+        with open(path, encoding='utf-8') as fh:
+            return json.load(fh)
     try:
         import yaml
     except ImportError:
@@ -837,10 +842,10 @@ if os.path.isdir(cat_path):
             avail = '<unreadable>'
         raise SystemExit('product-docs: no catalog entry for product ' + repr(product) + ' in ' + cat_path + ' -- available: ' + (avail or '<none>'))
     cat_file = found
-    entry = load_yaml(cat_file)
+    entry = load_catalog(cat_file)
 elif os.path.isfile(cat_path):
     cat_file = cat_path
-    doc = load_yaml(cat_file)
+    doc = load_catalog(cat_file)
     if not isinstance(doc, dict):
         raise SystemExit('product-docs: catalog ' + cat_file + ' is not a YAML mapping')
     if isinstance(doc.get('products'), dict):

--- a/bots/product-docs/main.bot
+++ b/bots/product-docs/main.bot
@@ -158,8 +158,11 @@ vars:
   ## read them. Comma-separated shell globs, matched against both the
   ## base name and the clone-relative path. The default covers the
   ## usual credential carriers; extend it per product rather than
-  ## trusting the source repos to be clean.
-  secret_globs: string = "*.env,.env,.env.*,*secret*,*secrets*,*credential*,*credentials*,*.pem,*.key,*.p12,*.pfx,id_rsa*,id_ed25519*,.netrc,.npmrc,.pypirc,kubeconfig,*kubeconfig*"
+  ## trusting the source repos to be clean. Deleting a matched file
+  ## clears the clone's WORKTREE only — the same blob stays readable in
+  ## that clone's `.git`, which is why the history is dropped once the
+  ## source delta has been computed.
+  secret_globs: string = "*.env,.env,.env.*,*secret*,*secrets*,*credential*,*credentials*,*.pem,*.key,*.p12,*.pfx,id_rsa*,id_ed25519*,.netrc,.npmrc,.pypirc,kubeconfig,*kubeconfig*,values*.yaml,values*.yml,*.tfvars,*.tfstate,*.tfstate.backup,*.jks,*.keystore,.htpasswd"
 
   ## Editorial lint rules enforced on PUBLISHED pages (comma-separated,
   ## page_lint). Dropping a name disables that rule for this run;
@@ -169,7 +172,11 @@ vars:
   ##   sources_box      — no "Sources" hint box / section
   ##   clarify_section  — no "Points à clarifier" section
   ##   technical_annex  — no "Correspondance technique" annex
-  lint_rules: string = "html_comments,sources_box,clarify_section,technical_annex"
+  ##   secret_material  — no credential material (private-key block,
+  ##                      recognised token prefix, assigned opaque
+  ##                      password): the last deterministic gate
+  ##                      between a source clone and a published page
+  lint_rules: string = "html_comments,sources_box,clarify_section,technical_annex,secret_material"
 
   ## Extra heading titles (comma-separated, case-insensitive, matched
   ## as a prefix of the heading text) that must never appear in a
@@ -331,8 +338,11 @@ prompt campaign_system:
        The `Bot:` trailer is how the next run finds where alignment
        landed; the `Product-Docs-Sources:` trailer is how it knows
        which source commits the page was written against. Both are
-       REQUIRED on every commit. Stage everything including new files
-       (`git add -A`) before each commit.
+       REQUIRED on every commit. Stage BY PATH, never `git add -A`:
+       `git add -- <the page(s) you just wrote>` picks up new files
+       just as well, without sweeping in the engine's own `.claude/`
+       mirror or an operator's unrelated work — both of which the
+       writeable-set gate then charges to you.
     b. DISMISS + LEDGER — an advisory hint that is a false positive,
        or something genuinely not worth documenting for this
        audience: record it in the DISMISSALS LEDGER (below) with a
@@ -613,6 +623,9 @@ prompt finalize_mr_user:
 schema ingest_output:
   product_id: string
   product_dir: string
+  ## The docs repo HEAD as it stood before the campaign ran: the run
+  ## base scope_check diffs against.
+  base_sha: string
   surfaces: json
   inventory: json
   sources_stamp: string
@@ -685,6 +698,9 @@ schema campaign_output:
 ## because a tool command cannot read `{{outputs.*}}`).
 schema product_dir_input:
   product_dir: string
+  ## The run base recorded by catalog_ingest, before the campaign has
+  ## written anything. scope_check refuses to certify without it.
+  base_sha: string
 
 ## scope_check is the DETERMINISTIC writeable-set gate: every path
 ## changed since the RUN BASE must be a `.md` file under the product
@@ -867,11 +883,22 @@ if not isinstance(entry, dict):
     raise SystemExit('product-docs: catalog entry for ' + repr(product) + ' is not a mapping')
 
 docs_block = entry.get('docs') if isinstance(entry.get('docs'), dict) else {}
-product_dir = str(docs_block.get('product_dir') or entry.get('product_dir') or '').strip().strip('/')
+product_dir = str(docs_block.get('product_dir') or entry.get('product_dir') or '').strip()
 if not product_dir:
     raise SystemExit('product-docs: catalog entry for ' + repr(product) + ' declares no docs.product_dir -- the bot has no writeable set without it')
-if os.path.isabs(product_dir) or '..' in product_dir.split('/'):
-    raise SystemExit('product-docs: docs.product_dir ' + repr(product_dir) + ' must be a path INSIDE the docs repository')
+## Order matters: test absoluteness BEFORE stripping the leading
+## slash, or an absolute path is silently rewritten into a relative
+## one and the guard can never fire.
+if os.path.isabs(product_dir):
+    raise SystemExit('product-docs: docs.product_dir ' + repr(product_dir) + ' must be a path INSIDE the docs repository, not an absolute path')
+## normpath first: scope_check compares by literal prefix, so a
+## non-canonical form (./docs/x, docs//x) would pass this node and
+## then fail that gate on every pass, unfixably.
+product_dir = os.path.normpath(product_dir).strip('/')
+if '..' in product_dir.split('/') or product_dir in ('.', ''):
+    raise SystemExit('product-docs: docs.product_dir must be a path INSIDE the docs repository')
+if any(c in product_dir for c in '*?['):
+    raise SystemExit('product-docs: docs.product_dir ' + repr(product_dir) + ' must be a literal path, not a glob -- the writeable-set gate matches it as a prefix')
 surfaces = docs_block.get('surfaces') or []
 if not isinstance(surfaces, list):
     surfaces = []
@@ -911,6 +938,12 @@ def run_git(args, cwd=None, timeout=900):
     except (OSError, subprocess.SubprocessError) as exc:
         return 1, '', str(exc)
 
+def strip_creds(u):
+    ## A url may carry inline credentials (https://user:token@host/...).
+    ## The inventory reaches the campaign prompt, the run events and the
+    ## PR body, so ONE helper covers every path that reports a url.
+    return re.sub(r'://[^/@]*@', '://', u or '')
+
 def redact(reason):
     ## Strip the token out of any git message before it reaches the
     ## inventory, the events or the report.
@@ -931,12 +964,17 @@ if rc == 0:
         if line.strip().startswith('Product-Docs-Sources:'):
             previous_stamp = line.split(':', 1)[1].strip()
             break
+## A stamp value is a commit sha and nothing else. It is read from a
+## commit MESSAGE -- anyone who can land a commit in the docs repo
+## writes it -- and it is handed to git as a REF, where a flag-shaped
+## value (--upload-pack=...) is an execution primitive.
+SHA_RE = re.compile(r'^[0-9a-fA-F]{7,40}$')
 prev_shas = {}
 for part in previous_stamp.split(','):
     part = part.strip()
     if '@' in part:
         k, v = part.rsplit('@', 1)
-        if k.strip() and v.strip():
+        if k.strip() and SHA_RE.match(v.strip()):
             prev_shas[k.strip()] = v.strip()
 
 repos = entry.get('repos') or []
@@ -955,10 +993,27 @@ for raw in repos:
     explicit = str(raw.get('url') or '').strip()
     rid = str(raw.get('id') or '').strip()
     if not rid:
-        base = explicit or github_repo or gitlab_path
-        rid = re.sub(r'[^A-Za-z0-9_.-]', '-', base.rstrip('/').split('/')[-1].replace('.git', '')) or 'repo'
+        rid = (explicit or github_repo or gitlab_path).rstrip('/').split('/')[-1].replace('.git', '')
+    ## The id becomes a filesystem destination that is rmtree'd and
+    ## cloned into. The catalog is operator input, so it is sanitised
+    ## on EVERY path -- an explicit id is not more trustworthy than a
+    ## derived one, and os.path.join('<root>', '/etc') is '/etc'.
+    rid = re.sub(r'[^A-Za-z0-9_.-]', '-', rid).strip('.-') or 'repo'
+    if rid in ('.', '..'):
+        rid = 'repo'
     ref = str(raw.get('ref') or raw.get('branch') or '').strip()
+    ## A catalog value handed to git must not be able to become an
+    ## OPTION (leading dash) instead of a repository or a branch.
+    if ref.startswith('-'):
+        inventory.append({'id': rid, 'status': 'degraded', 'path': '', 'head': '', 'url': '', 'changed_files': [], 'note': 'ref refused: an option-shaped ref is a git argument, not a branch'})
+        continue
     if explicit:
+        ## Same for the url, plus the remote-HELPER form (ext::<cmd>),
+        ## which git executes outright. Ordinary local paths stay
+        ## legal: an on-disk mirror is a legitimate source.
+        if explicit.startswith('-') or '::' in explicit:
+            inventory.append({'id': rid, 'status': 'degraded', 'path': '', 'head': '', 'url': '', 'changed_files': [], 'note': 'url refused: an option-shaped or remote-helper (ext::) url is an execution primitive, not a repository'})
+            continue
         url = explicit
     elif github_repo:
         url = 'https://github.com/' + github_repo + '.git'
@@ -993,7 +1048,7 @@ for raw in repos:
         rc, _, err = run_git(args)
         if rc != 0:
             shutil.rmtree(dest, ignore_errors=True)
-            inventory.append({'id': rid, 'status': 'degraded', 'path': '', 'head': '', 'url': url, 'changed_files': [], 'note': 'clone failed: ' + (redact(err) or 'unknown error') + (' (no push/read credential was available)' if not token else '')})
+            inventory.append({'id': rid, 'status': 'degraded', 'path': '', 'head': '', 'url': strip_creds(url), 'changed_files': [], 'note': 'clone failed: ' + (redact(err) or 'unknown error') + (' (no push/read credential was available)' if not token else '')})
             continue
         note = 'cloned'
     ## Redaction: a source repo may carry credential files the docs
@@ -1035,7 +1090,12 @@ for raw in repos:
         note = (note + '; ' if note else '') + 'unchanged since the previous run'
     if removed:
         note = (note + '; ' if note else '') + str(removed) + ' secret-bearing file(s) redacted from the clone'
-    inventory.append({'id': rid, 'status': 'ok', 'path': dest, 'head': head, 'url': url, 'changed_files': changed[:500], 'note': note})
+    ## The delta is computed; the clone's history has no further use --
+    ## and it still holds every blob the redaction removed from the
+    ## worktree, readable with one git show. Dropping it is what makes
+    ## the redaction true rather than cosmetic.
+    shutil.rmtree(os.path.join(dest, '.git'), ignore_errors=True)
+    inventory.append({'id': rid, 'status': 'ok', 'path': dest, 'head': head, 'url': strip_creds(url), 'changed_files': changed[:500], 'note': note})
 
 ok = [e for e in inventory if e['status'] == 'ok']
 degraded = [e for e in inventory if e['status'] != 'ok']
@@ -1049,7 +1109,13 @@ if degraded:
     parts.append('unreadable: ' + ', '.join(e['id'] for e in degraded))
 if not repos:
     parts.append('the catalog entry declares no repos[] -- nothing to ground the documentation in')
-print(json.dumps({'product_id': product, 'product_dir': product_dir, 'surfaces': surfaces, 'inventory': inventory, 'sources_stamp': stamp, 'repo_count': len(inventory), 'ok_count': len(ok), 'degraded_count': len(degraded), 'redacted_count': redacted_total, 'previous_stamp': previous_stamp, 'delta_unavailable': delta_unavailable, 'log': '; '.join(parts)}, ensure_ascii=False))
+## The RUN BASE, recorded before the campaign has written anything.
+## scope_check diffs against THIS -- never against a base re-derived
+## from the campaign's own commit messages, which would let an
+## un-trailered commit choose the window it is audited on.
+rc, out, _ = run_git(['rev-parse', 'HEAD'], cwd=ws, timeout=60)
+base_sha = out.strip() if rc == 0 else ''
+print(json.dumps({'product_id': product, 'product_dir': product_dir, 'base_sha': base_sha, 'surfaces': surfaces, 'inventory': inventory, 'sources_stamp': stamp, 'repo_count': len(inventory), 'ok_count': len(ok), 'degraded_count': len(degraded), 'redacted_count': redacted_total, 'previous_stamp': previous_stamp, 'delta_unavailable': delta_unavailable, 'log': '; '.join(parts)}, ensure_ascii=False))
 "`
   output: ingest_output
 
@@ -1264,10 +1330,12 @@ agent campaign:
 ## this flags.
 tool scope_check:
   input: product_dir_input
-  command: `WS={{vars.workspace_dir}} PRODUCT_DIR={{input.product_dir}} python3 -c "
+  command: `WS={{vars.workspace_dir}} PRODUCT_DIR={{input.product_dir}} EDITORIAL_DIR={{vars.editorial_dir}} BASE_SHA={{input.base_sha}} python3 -c "
 import os, json, subprocess
 ws = os.environ.get('WS', '.')
 product_dir = (os.environ.get('PRODUCT_DIR') or '').strip().strip('/')
+editorial_dir = (os.environ.get('EDITORIAL_DIR') or '').strip().strip('/')
+base = (os.environ.get('BASE_SHA') or '').strip()
 
 def git(args):
     try:
@@ -1276,28 +1344,50 @@ def git(args):
     except (OSError, subprocess.SubprocessError):
         return ''
 
-reflog = [l for l in git(['reflog', '--format=%H']).splitlines() if l.strip()]
-def is_own_commit(h):
-    body = git(['log', '-1', '--format=%B', h])
-    return any(l.strip() == 'Bot: product-docs' for l in body.splitlines())
-base = 'HEAD'
-for h in reflog:
-    if not is_own_commit(h):
-        base = h
-        break
-changed = set(l for l in git(['diff', base, '--name-only']).splitlines() if l.strip())
+## The base is RECORDED by catalog_ingest before the campaign writes
+## anything. Re-deriving it from commit messages would hand the
+## audited party the choice of its own audit window: one commit
+## missing the trailer becomes the base and empties its own diff.
+if not base:
+    print(json.dumps({'scope_ok': False, 'out_of_scope': [], 'log': 'SCOPE GATE UNAVAILABLE: catalog_ingest recorded no run base (base_sha empty), so the writeable set cannot be computed. Refusing to certify it.'}, ensure_ascii=False))
+    raise SystemExit(0)
+
+## --no-renames: with rename detection ON git reports only a rename's
+## DESTINATION, so renaming a protected file onto an allowed .md path
+## would delete it behind a green gate.
+changed = set(l for l in git(['diff', '--no-renames', base, '--name-only']).splitlines() if l.strip())
+## Mode 120000 is a symlink: writing THROUGH one escapes the repo
+## entirely, and committing one publishes a host path in the docs.
+symlinks = set()
+for row in git(['diff', '--no-renames', '--raw', base]).splitlines():
+    if not row.startswith(':'):
+        continue
+    meta, _, path = row.partition(chr(9))
+    fields = meta.split()
+    if len(fields) >= 2 and '120000' in (fields[0].lstrip(':'), fields[1]):
+        p = path.split(chr(9))[-1].strip()
+        if p:
+            symlinks.add(p)
 for line in git(['status', '--porcelain']).splitlines():
     if line[:2].strip() == '??':
         changed.add(line[3:].strip())
 
 # iterion materialises the bundle's skills into <workspace>/.claude/ at run
-# start and again on every resume. That tree is the ENGINE's own artifact,
-# not the campaign's work: attributing it to the run would fail the gate on
+# start and again on every resume. That tree is the ENGINE's own artifact
+# while it stays UNTRACKED: attributing it to the run would fail the gate on
 # every pass, and the campaign could not fix it — the next pass re-creates
-# it. Untracked directories arrive from git status as '.claude/'.
-changed = set(p for p in changed if p != '.claude' and not p.startswith('.claude/'))
+# it. A TRACKED path under it is a different thing: the run committed the
+# agent's own notes into the docs repo, so it stays in scope.
+tracked_claude = set(l.strip() for l in git(['ls-files', '--', '.claude']).splitlines() if l.strip())
+changed = set(p for p in changed if p in tracked_claude or (p != '.claude' and not p.startswith('.claude/')))
 
 def allowed(p):
+    if p in symlinks or os.path.islink(os.path.join(ws, p)):
+        return False
+    ## The editorial charter is the product team's own: the bot reads
+    ## it, is governed by it, and never rewrites it.
+    if editorial_dir and (p == editorial_dir or p.startswith(editorial_dir + '/')):
+        return False
     if not p.endswith('.md'):
         return False
     if not product_dir:
@@ -1307,7 +1397,7 @@ def allowed(p):
 out_of_scope = sorted(p for p in changed if not allowed(p))
 log = ''
 if out_of_scope:
-    log = 'SCOPE VIOLATION: this run changed files outside the product writeable-set (.md under ' + (product_dir or '<product_dir>') + ' only). Revert these before continuing (git revert the offending commits, or git checkout ' + base[:12] + ' -- <path>): ' + ', '.join(out_of_scope[:40])
+    log = 'SCOPE VIOLATION: this run changed files outside the product writeable-set (.md under ' + (product_dir or '<product_dir>') + ' only, never a symlink, never the editorial charter ' + (editorial_dir or '<editorial_dir>') + '). Revert these before continuing (git revert the offending commits, or git checkout ' + base[:12] + ' -- <path>): ' + ', '.join(out_of_scope[:40])
 print(json.dumps({'scope_ok': not out_of_scope, 'out_of_scope': out_of_scope[:100], 'log': log}, ensure_ascii=False))
 "`
   output: scope_check_output
@@ -1335,17 +1425,45 @@ os.chdir(ws)
 product_dir = (os.environ.get('PRODUCT_DIR') or '').strip().strip('/')
 rules = {r.strip() for r in (os.environ.get('LINT_RULES') or '').split(',') if r.strip()}
 extra = [h.strip() for h in (os.environ.get('EXTRA_HEADINGS') or '').split(',') if h.strip()]
-pages = sorted(p for p in glob.glob(os.path.join(product_dir, '**', '*.md'), recursive=True) if os.path.isfile(p)) if product_dir else []
+if not product_dir:
+    ## Fail CLOSED, like scope_check: an empty product directory lints
+    ## zero pages, and reporting that as clean would certify an
+    ## artifact nobody looked at.
+    print(json.dumps({'lint_ok': False, 'violations': [], 'violation_count': 0, 'pages_linted': 0, 'log': 'EDITORIAL LINT UNAVAILABLE: no product_dir was resolved, so no published page could be read. Refusing to certify the pages as clean.'}, ensure_ascii=False))
+    raise SystemExit(0)
+pages = sorted(p for p in glob.glob(os.path.join(product_dir, '**', '*.md'), recursive=True) if os.path.isfile(p))
 HEADING_RE = re.compile(r'^\s{0,3}#{1,6}\s+(.+?)\s*$')
 BOLD_LABEL_RE = re.compile(r'^\s{0,3}\*\*([^*]+?)\s*:?\s*\*\*')
-SOURCES_RE = re.compile(r'^sources?\b', re.IGNORECASE)
-CLARIFY_RE = re.compile(r'^points?\s+.{0,4}\s*clarifier\b', re.IGNORECASE)
+## Anchored on the WHOLE heading: a blocking gate that fires on
+## 'Sources de financement' or 'Points a clarifier avec votre
+## conseiller' orders the campaign to delete reader-facing content,
+## and the run never converges. Chrome is the bare title.
+SOURCES_RE = re.compile(r'^sources?\s*:?\s*$', re.IGNORECASE)
+## A BOLD label is prose furniture, not a section title: only the
+## plural box title is chrome. '**Source :** arrete du 3 mars' is a
+## citation the reader wants.
+SOURCES_BOLD_RE = re.compile(r'^sources\s*:?\s*$', re.IGNORECASE)
+CLARIFY_RE = re.compile(r'^points?\s+.{0,4}\s*clarifier\s*:?\s*$', re.IGNORECASE)
 ANNEX_RE = re.compile(r'^(annexe\s*:?\s*)?correspondance\s+technique\b', re.IGNORECASE)
-HINT_OPEN_RE = re.compile(r'^\s*\{%\s*hint\b')
-HINT_CLOSE_RE = re.compile(r'^\s*\{%\s*endhint\s*%\}')
+HINT_OPEN_RE = re.compile(r'\{%\s*hint\b')
+HINT_CLOSE_RE = re.compile(r'\{%\s*endhint\s*%\}')
+FENCE_RE = re.compile(r'^\s{0,3}(' + chr(96) * 3 + '+|~{3,})')
+KEY_BLOCK_RE = re.compile(r'-----BEGIN [A-Z ]*PRIVATE KEY-----')
+TOKEN_RE = re.compile(r'\b(ghp_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{30,}|glpat-[A-Za-z0-9_-]{15,}|xox[abprs]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16}|sk-[A-Za-z0-9]{20,})')
+ASSIGN_RE = re.compile(r'(?:password|passwd|pwd|mot[_ ]de[_ ]passe|secret|token|api[_-]?key|access[_-]?key)\s*[:=]\s*(\S+)\s*$', re.IGNORECASE)
+## chr(36) is the dollar sign: written literally it would sit next to
+## an opening brace inside this double-quoted command and the SHELL
+## would expand it before python ever sees the pattern.
+PLACEHOLDER_RE = re.compile(r'^[<{(\[' + chr(36) + r']|[*x.]{3,}|^(votre|vos|your|mon|my|xxx|todo|redacted|confirmer)', re.IGNORECASE)
 violations = []
 def add(page, line, rule, excerpt):
     violations.append({'page': page, 'line': line, 'rule': rule, 'excerpt': ' '.join((excerpt or '').split())[:160]})
+def credential_value(v):
+    ## A credential is one opaque token. French prose ('8 caracteres
+    ## minimum', 'votre mot de passe personnel') never is.
+    if len(v) < 8 or PLACEHOLDER_RE.search(v):
+        return False
+    return bool(re.search(r'[0-9]', v)) or len(v) >= 16
 for page in pages:
     try:
         with open(page, encoding='utf-8', errors='replace') as fh:
@@ -1353,10 +1471,29 @@ for page in pages:
     except (OSError, IsADirectoryError):
         continue
     in_comment = False
+    in_fence = False
     in_hint = 0
     hint_start = 0
     hint_body = []
     for lineno, line in enumerate(lines, start=1):
+        ## Credential material is scanned EVERYWHERE, fenced code
+        ## included: a pasted secret is worse inside a block, not
+        ## exempt from the gate.
+        if 'secret_material' in rules:
+            if KEY_BLOCK_RE.search(line) or TOKEN_RE.search(line):
+                add(page, lineno, 'secret_material', line)
+            else:
+                am = ASSIGN_RE.search(line)
+                if am and credential_value(am.group(1)):
+                    add(page, lineno, 'secret_material', line)
+        ## Every other rule is about editorial chrome, which a fenced
+        ## sample legitimately contains: a page teaching users to paste
+        ## an HTML snippet must not be permanently red.
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
         if 'html_comments' in rules:
             if in_comment:
                 if '-->' in line:
@@ -1365,23 +1502,31 @@ for page in pages:
                 add(page, lineno, 'html_comments', line)
                 if '-->' not in line.split('<!--', 1)[1]:
                     in_comment = True
-        if HINT_OPEN_RE.match(line):
-            in_hint = 1
-            hint_start = lineno
+        ## A hint block is scanned for a Sources body, but it NEVER
+        ## suppresses the heading rules below: no document state may
+        ## disable a gate rule for the rest of a page (an unclosed or
+        ## single-line hint used to do exactly that).
+        if in_hint and HINT_CLOSE_RE.search(line):
+            if 'sources_box' in rules:
+                joined = ' '.join(hint_body)
+                if re.search(r'\bsources?\s*:', joined, re.IGNORECASE) or re.search(r'^\s*\*?\*?sources?\b', joined, re.IGNORECASE):
+                    add(page, hint_start, 'sources_box', joined)
+            in_hint = 0
             hint_body = []
-            continue
-        if in_hint:
-            if HINT_CLOSE_RE.match(line):
-                if 'sources_box' in rules:
-                    joined = ' '.join(hint_body)
-                    if re.search(r'\bsources?\s*:', joined, re.IGNORECASE) or re.search(r'^\s*\*?\*?sources?\b', joined, re.IGNORECASE):
-                        add(page, hint_start, 'sources_box', joined)
-                in_hint = 0
-                hint_body = []
-                continue
+        elif in_hint:
             hint_body.append(line.strip())
-            continue
+        elif HINT_OPEN_RE.search(line):
+            if HINT_CLOSE_RE.search(line):
+                if 'sources_box' in rules:
+                    body = HINT_OPEN_RE.split(line)[-1]
+                    if re.search(r'\bsources?\s*:', body, re.IGNORECASE):
+                        add(page, lineno, 'sources_box', line)
+            else:
+                in_hint = 1
+                hint_start = lineno
+                hint_body = []
         title = ''
+        from_bold = False
         hm = HEADING_RE.match(line)
         if hm:
             title = hm.group(1).strip()
@@ -1389,10 +1534,11 @@ for page in pages:
             bm = BOLD_LABEL_RE.match(line)
             if bm:
                 title = bm.group(1).strip()
+                from_bold = True
         if not title:
             continue
         plain = re.sub(r'[*_' + chr(96) + r']', '', title).strip()
-        if 'sources_box' in rules and SOURCES_RE.match(plain):
+        if 'sources_box' in rules and (SOURCES_BOLD_RE if from_bold else SOURCES_RE).match(plain):
             add(page, lineno, 'sources_box', line)
         if 'clarify_section' in rules and CLARIFY_RE.match(plain):
             add(page, lineno, 'clarify_section', line)
@@ -1401,6 +1547,12 @@ for page in pages:
         for h in extra:
             if plain.lower().startswith(h.lower()):
                 add(page, lineno, 'extra_forbidden_heading', line)
+    ## An unclosed hint still has a body: flush it at EOF rather than
+    ## letting a missing endhint drop the sources check.
+    if in_hint and 'sources_box' in rules:
+        joined = ' '.join(hint_body)
+        if re.search(r'\bsources?\s*:', joined, re.IGNORECASE) or re.search(r'^\s*\*?\*?sources?\b', joined, re.IGNORECASE):
+            add(page, hint_start, 'sources_box', joined)
 log = ''
 if violations:
     shown = ['- ' + v['page'] + ':' + str(v['line']) + ' [' + v['rule'] + '] ' + v['excerpt'] for v in violations[:40]]
@@ -1551,10 +1703,12 @@ workflow product_docs:
   ## there is no build gate — the lint is this bot's equivalent truth
   ## oracle on the artifact it actually ships.
   campaign -> scope_check with {
-    product_dir: "{{outputs.catalog_ingest.product_dir}}"
+    product_dir: "{{outputs.catalog_ingest.product_dir}}",
+    base_sha: "{{outputs.catalog_ingest.base_sha}}"
   }
   scope_check -> page_lint with {
-    product_dir: "{{outputs.catalog_ingest.product_dir}}"
+    product_dir: "{{outputs.catalog_ingest.product_dir}}",
+    base_sha: "{{outputs.catalog_ingest.base_sha}}"
   }
   page_lint -> gate
 

--- a/bots/product-docs/main.bot
+++ b/bots/product-docs/main.bot
@@ -547,7 +547,7 @@ prompt finalize_mr_system:
 
   Preconditions:
     A. Commits to ship: HEAD must be ahead of the base
-       (`git rev-list --count <base>..HEAD` > 0). If not, set
+       (`git rev-list --count origin/<base>..HEAD` > 0). If not, set
        opened=false, skipped_reason "no commits ahead of base" — never
        push, never open an empty PR.
     B. Authenticate the matching forge CLI from the mounted
@@ -926,7 +926,12 @@ git_env['GIT_TERMINAL_PROMPT'] = '0'
 if token:
     helper = os.path.join(scratch, 'git-askpass.sh')
     with open(helper, 'w', encoding='utf-8') as fh:
-        fh.write('#!/bin/sh' + chr(10) + 'case $1 in' + chr(10) + 'Username*) echo x-access-token ;;' + chr(10) + '*) printf %s $PRODUCT_DOCS_GIT_TOKEN ;;' + chr(10) + 'esac' + chr(10))
+        ## chr(36) is the dollar sign: written literally, the SHELL
+        ## expands it while parsing this double-quoted command, and the
+        ## helper reaches disk with its two arguments erased -- a shell
+        ## syntax error, so every credentialed clone fails.
+        D = chr(36)
+        fh.write('#!/bin/sh' + chr(10) + 'case ' + D + '1 in' + chr(10) + 'Username*) echo x-access-token ;;' + chr(10) + '*) printf %s ' + D + 'PRODUCT_DOCS_GIT_TOKEN ;;' + chr(10) + 'esac' + chr(10))
     os.chmod(helper, 0o700)
     git_env['GIT_ASKPASS'] = helper
     git_env['PRODUCT_DOCS_GIT_TOKEN'] = token
@@ -958,7 +963,11 @@ gitlab_host = str(gitlab_block.get('host') or '').strip().rstrip('/')
 ## The previous run source stamp, read from the DOCS repo own history:
 ## git IS the state, so a wiped scratch or a crashed pod loses nothing.
 previous_stamp = ''
-rc, out, _ = run_git(['log', '-E', '--grep', '^Product-Docs-Sources:', '-n', '1', '--format=%B'], cwd=ws, timeout=120)
+## Path-limited to THIS product: the trailer carries no product
+## identity, and a docs repo holding several products is the design's
+## own shape -- an unscoped lookup reads a sibling product's stamp and
+## reports a confident 'nothing changed'.
+rc, out, _ = run_git(['log', '-E', '--grep', '^Product-Docs-Sources:', '-n', '1', '--format=%B', '--', product_dir], cwd=ws, timeout=120)
 if rc == 0:
     for line in out.splitlines():
         if line.strip().startswith('Product-Docs-Sources:'):
@@ -1368,7 +1377,10 @@ for row in git(['diff', '--no-renames', '--raw', base]).splitlines():
         p = path.split(chr(9))[-1].strip()
         if p:
             symlinks.add(p)
-for line in git(['status', '--porcelain']).splitlines():
+## -uall: without it git collapses an untracked directory into one
+## entry that never ends in .md, so a brand-new journey folder -- the
+## bootstrap case -- reds the gate on the very path it must write.
+for line in git(['status', '--porcelain', '-uall']).splitlines():
     if line[:2].strip() == '??':
         changed.add(line[3:].strip())
 

--- a/bots/product-docs/manifest.yaml
+++ b/bots/product-docs/manifest.yaml
@@ -17,7 +17,7 @@ version: 1.0.0
 ##     "Points à clarifier", no "Correspondance technique" annex);
 ##   - EDITORIAL SOVEREIGNTY: the docs repo's own `.product-docs/*.md`
 ##     override the bundle's default editorial skills wherever the two
-##     disagree (ADR-091).
+##     disagree (ADR-092).
 ## Source deltas are git-native: every commit carries a
 ## `Product-Docs-Sources: <repo>@<sha>,…` trailer, so "what changed in
 ## the sources since we last documented them" survives a crashed run

--- a/bots/product-docs/manifest.yaml
+++ b/bots/product-docs/manifest.yaml
@@ -102,7 +102,11 @@ invocations:
     command: { name: prody, aliases: [product-docs, doc-produit], scope: any, min_replier_role: developer }
   - kind: schedule
     mode: board
-    schedule: { suggested_cron: "0 5 * * 1" }
+    ## A weekly reconciliation is INCREMENTAL by construction: it aligns
+    ## the pages against the source commits landed since the last run,
+    ## not the whole corpus. Declared here so the scheduled run actually
+    ## carries it — a var only a human can pass is not a schedule.
+    schedule: { suggested_cron: "0 5 * * 1", default_vars: { mode: incremental } }
   - kind: board
 
 ## Studio launch-form hierarchy: `primary` inputs render top-level in

--- a/bots/product-docs/manifest.yaml
+++ b/bots/product-docs/manifest.yaml
@@ -1,0 +1,113 @@
+name: product-docs
+display_name: Prody
+icon: 🧭
+version: 1.0.0
+## 1.0.0 — Functional (business-audience) product documentation,
+## generated and maintained in a DEDICATED docs repository from a
+## MULTI-REPO product catalog. Mirrors docs-refresh v3's topology (one
+## capable claude_code agent + a mission + TRUTH gates only) with three
+## deltas that make the cross-repo, non-technical case work:
+##   - catalog_ingest, a deterministic front door that resolves the
+##     product from a catalog YAML, shallow-clones its N source repos
+##     OUT of the docs worktree, redacts secret-bearing files from the
+##     clones, and reports a repo it could not read as an explicit
+##     `degraded` inventory entry (never a silent skip);
+##   - page_lint, a deterministic EDITORIAL gate — a published page
+##     carries no working notes (no HTML comments, no "Sources" box, no
+##     "Points à clarifier", no "Correspondance technique" annex);
+##   - EDITORIAL SOVEREIGNTY: the docs repo's own `.product-docs/*.md`
+##     override the bundle's default editorial skills wherever the two
+##     disagree (ADR-091).
+## Source deltas are git-native: every commit carries a
+## `Product-Docs-Sources: <repo>@<sha>,…` trailer, so "what changed in
+## the sources since we last documented them" survives a crashed run
+## and a wiped scratch dir with no side-car state file.
+description: |
+  Functional documentation bot — one capable agent writes and maintains
+  the BUSINESS-AUDIENCE documentation of a product ("what it does for
+  its users") inside a DEDICATED documentation repository, grounded in
+  the source code of the N repositories a product catalog names.
+
+  It resolves the product from a catalog YAML (`catalog_path` +
+  `product_id`), shallow-clones every source repo out of the docs
+  worktree, redacts secret-bearing files from those clones, then reads
+  what the sources actually implement — user-facing templates, i18n
+  catalogs, form and validation rules, routes, API contracts, any
+  framework — and writes the product's pages: a hub per user role or
+  journey, one sub-page per step. Every page lands as its own
+  `docs(...)` commit carrying a `Bot: product-docs` trailer and a
+  `Product-Docs-Sources: <repo>@<sha>` trailer recording exactly which
+  source commits it was written against.
+
+  Sourced facts or `[à confirmer]` — never an invented business rule.
+  Human-validated prose is preserved and touched only where the code
+  contradicts it. A repository it could not clone is declared as a hole
+  in the report, never documented from inference.
+
+  The determinism is TRUTH-only: a scope gate fails the run if anything
+  outside `<product_dir>/**/*.md` changed, an EDITORIAL LINT gate fails
+  it if a published page still carries working notes, and convergence
+  is those two gates ∧ the campaign's honest `docs_aligned` contract —
+  nothing else. A deterministic scan runs each pass as an ADVISORY
+  hints producer (dead links, orphan pages, catalog surfaces no page
+  covers): help the agent is free to contradict, never an obligation.
+
+  EDITORIAL SOVEREIGNTY: the bundle ships generic default editorial
+  skills in French (documentary model, GitBook blocks, glossary, tone),
+  but when the docs repo publishes its own `.product-docs/*.md` those
+  are authoritative and override the defaults. The product team owns
+  its editorial line; the bot brings a default, not a house style.
+
+  Opt-in delivery: open_mr=true pushes the page series and opens ONE
+  pull request at the end of the run — as a DRAFT by default, because
+  functional documentation is validated by the product owners on the
+  forge and marking it ready is their act, not the bot's.
+when_to_use: |
+  Use to generate or maintain the FUNCTIONAL, non-technical
+  documentation of a product — what it does for its users, role by
+  role and journey by journey — when that documentation lives in its
+  OWN repository and the code lives in one or more OTHER repositories
+  named by a product catalog. Run it in the docs repo with
+  `catalog_path` + `product_id`. It writes `.md` under the product's
+  directory only, and never touches the source repositories.
+
+  NOT for technical documentation living next to the code (that is
+  docs-refresh / Doki, which aligns a repo's own README / docs/ in
+  place), and NOT for a technical knowledge wiki (that is wiki-gen /
+  Wikky, which owns a `wiki/` tree in the code repo). The
+  distinguisher is the AUDIENCE first — a product's users, not its
+  developers — and the topology second: docs repo here, N source
+  repos there.
+author: SocialGouv (devthejo) — product-docs/main.bot
+schema_version: 1
+
+triggers:
+  - product-docs
+  - functional-docs
+  - doc-produit
+
+## The catalog vars have no sensible default (see main.bot): a board
+## dispatch that omits them fails LOUDLY in catalog_ingest rather than
+## documenting the wrong product. Per-ticket `bot_args` supply them.
+dispatch_vars:
+  scope_notes: |-
+    {{issue.title}}
+
+    {{issue.body}}
+
+invocations:
+  - kind: command
+    mode: direct
+    args_var: scope_notes
+    command: { name: prody, aliases: [product-docs, doc-produit], scope: any, min_replier_role: developer }
+  - kind: schedule
+    mode: board
+    schedule: { suggested_cron: "0 5 * * 1" }
+  - kind: board
+
+## Studio launch-form hierarchy: `primary` inputs render top-level in
+## the declared order; `hidden` vars are internal plumbing kept out of
+## the form (still settable via --var / bot_args).
+launch:
+  primary: [catalog_path, product_id, scope_notes, open_mr]
+  hidden: [workspace_dir, dismissed_path, scratch_dir, max_hints]

--- a/bots/product-docs/skills/blocs-gitbook.md
+++ b/bots/product-docs/skills/blocs-gitbook.md
@@ -43,8 +43,8 @@ Une précision utile mais non bloquante.
   Presque jamais nécessaire.
 
 **Un encadré ne contient jamais de référence de source.** Un encadré
-« Sources : … » est une note de travail : la sonde éditoriale le refuse et
-fait échouer la passe.
+« Sources : … » est une note de travail : la relecture automatique la refuse
+et la page revient en correction.
 
 Deux encadrés qui se suivent sont un signe qu'il fallait un paragraphe.
 
@@ -97,9 +97,19 @@ dossier, adresse) ne doit jamais être publiée.
 - **Une annexe « Correspondance technique »** : le contenu technique n'a pas
   sa place dans ces pages.
 - Du HTML brut pour la mise en page, des styles inline, des balises `<br>`.
-- Un bloc de code, sauf s'il montre quelque chose que l'utilisateur final
-  saisit ou reçoit littéralement (un identifiant de dossier, un message
-  d'erreur affiché à l'écran).
+- Un bloc de code, sauf dans deux cas : il montre quelque chose que
+  l'utilisateur final saisit ou reçoit littéralement (un identifiant de
+  dossier, un message d'erreur affiché à l'écran), ou c'est un schéma
+  `mermaid` qui rend le parcours lisible d'un coup d'œil (GitBook le rend
+  comme un diagramme, pas comme du code) :
 
-Les quatre premiers points sont vérifiés par une sonde déterministe après
-chaque passe : une seule occurrence fait échouer la passe et vous revient.
+  ```mermaid
+  flowchart TD
+   A[Accueil] --> D[Dossier] --> T[Transmission]
+  ```
+
+  Un schéma remplace un paragraphe d'énumération ; il ne remplace jamais
+  l'explication des règles.
+
+Les quatre premiers points sont vérifiés automatiquement après chaque
+rédaction : une seule occurrence renvoie la page en correction.

--- a/bots/product-docs/skills/blocs-gitbook.md
+++ b/bots/product-docs/skills/blocs-gitbook.md
@@ -1,0 +1,105 @@
+---
+name: blocs-gitbook
+description: Default GitBook block vocabulary for published functional pages — which blocks are allowed, what each one means to the reader, and which markup is forbidden. Overridden by the docs repository's own .product-docs/ framing when it publishes one.
+---
+
+# Blocs autorisés dans une page publiée
+
+> Ce vocabulaire est le **défaut du bundle**. Si le dépôt de documentation
+> publie sa propre liste de blocs (`.product-docs/*.md`), c'est celle-là qui
+> fait foi.
+
+Les pages sont du Markdown, publiées par GitBook. Le jeu de blocs ci-dessous
+est volontairement petit : chaque bloc a un sens pour le lecteur, et un bloc
+utilisé pour faire joli lui apprend à ignorer les suivants.
+
+## Markdown standard — la base
+
+Titres (`##`, `###`), paragraphes, listes à puces et numérotées, gras pour un
+libellé d'interface, liens relatifs, tableaux. C'est ce qui doit porter 90 %
+du contenu.
+
+- **Gras** : un libellé exact de l'interface (« cliquez sur **Envoyer** »).
+- *Italique* : un terme du glossaire à sa première occurrence dans la page.
+- Tableau : un ensemble fini de cas comparables (statuts, rôles, délais).
+  Jamais pour mettre en page du texte.
+
+## Les encadrés (`hint`)
+
+Quatre types, quatre sens distincts. Un encadré signale ce qu'un lecteur
+pressé ne doit pas rater — il ne répète pas le paragraphe qui précède.
+
+```
+{% hint style="info" %}
+Une précision utile mais non bloquante.
+{% endhint %}
+```
+
+- `info` — une précision, une exception bénigne, un délai à connaître.
+- `success` — la confirmation qu'une étape est bien terminée.
+- `warning` — une action irréversible, une condition qui bloque, une erreur
+  fréquente. C'est celui qui a le plus de valeur : réservez-le.
+- `danger` — une conséquence grave (perte de données, refus définitif).
+  Presque jamais nécessaire.
+
+**Un encadré ne contient jamais de référence de source.** Un encadré
+« Sources : … » est une note de travail : la sonde éditoriale le refuse et
+fait échouer la passe.
+
+Deux encadrés qui se suivent sont un signe qu'il fallait un paragraphe.
+
+## Les étapes numérotées (`stepper`)
+
+Pour un parcours strictement ordonné à l'intérieur d'une page.
+
+```
+{% stepper %}
+{% step %}
+### Déposer la demande
+Ce que fait l'utilisateur à cette étape.
+{% endstep %}
+{% endstepper %}
+```
+
+À réserver aux vraies séquences imposées. Une liste numérotée ordinaire suffit
+dans la plupart des cas, et se lit mieux.
+
+## Les onglets (`tabs`)
+
+Pour une même étape vécue différemment selon le profil ou le canal (par
+exemple « depuis un ordinateur » / « depuis un mobile »).
+
+```
+{% tabs %}
+{% tab title="Depuis un ordinateur" %}
+…
+{% endtab %}
+{% endtabs %}
+```
+
+Si les onglets décrivent deux parcours différents, ce sont deux pages.
+
+## Les images
+
+Une capture d'écran n'est utile que si elle montre quelque chose que le texte
+ne peut pas dire. Elle vieillit vite : elle doit rester compréhensible même
+légèrement décalée par rapport à l'interface. Texte alternatif toujours
+renseigné. Une capture qui contient des données réelles (nom, numéro de
+dossier, adresse) ne doit jamais être publiée.
+
+## Ce qui est interdit
+
+- **Tout commentaire HTML** (`<!-- … -->`). Aucune exception : c'est une note
+  de travail qui a survécu à la relecture.
+- **Un encadré ou une section « Sources »**, sous quelque forme que ce soit.
+- **Une section « Points à clarifier »** : une question ouverte s'écrit
+  `[à confirmer]` dans la phrase concernée.
+- **Une annexe « Correspondance technique »** : le contenu technique n'a pas
+  sa place dans ces pages.
+- Du HTML brut pour la mise en page, des styles inline, des balises `<br>`.
+- Un bloc de code, sauf s'il montre quelque chose que l'utilisateur final
+  saisit ou reçoit littéralement (un identifiant de dossier, un message
+  d'erreur affiché à l'écran).
+
+Les quatre premiers points sont vérifiés par une sonde déterministe après
+chaque passe : une seule occurrence fait échouer la passe et vous revient.

--- a/bots/product-docs/skills/forge-mr-create.md
+++ b/bots/product-docs/skills/forge-mr-create.md
@@ -108,11 +108,11 @@ token file nor host auth is available, push/open nothing: return
 ## 3. Choose the branch and push
 
 Pick the branch name: use the `mr_branch` input if non-empty, else derive
-a stable one — `iterion/improve/<run-id-or-short-sha>`. Push the run's
+a stable one — `iterion/product-docs/<run-id-or-short-sha>`. Push the run's
 HEAD to it on origin:
 
 ```
-BRANCH="${mr_branch:-iterion/improve/$(git rev-parse --short HEAD)}"
+BRANCH="${mr_branch:-iterion/product-docs/$(git rev-parse --short HEAD)}"
 git push origin "HEAD:refs/heads/$BRANCH"
 ```
 

--- a/bots/product-docs/skills/forge-mr-create.md
+++ b/bots/product-docs/skills/forge-mr-create.md
@@ -1,0 +1,195 @@
+---
+name: forge-mr-create
+description: How to push the current run's branch and open ONE pull request (merge request on GitLab) on GitHub (gh), GitLab (glab) or Forgejo/Gitea (REST), authenticating from the mounted forge_token, then post the PR URL back to the source issue. Read this before the finalize_mr node pushes or opens anything.
+---
+
+<!-- DIVERGED copy — this file carries product-docs' own DRAFT delta on
+     top of the skill the other bundles byte-share (iterion has no
+     skill-sharing primitive; see CLAUDE.md "If a skill ends up
+     duplicated across multiple bundles"). Do NOT blind-sync it from the
+     shared copies (app-dev / branch-improve-loop / feature-dev /
+     instrument / whole-improve-loop) — port shared fixes by hand and
+     keep the delta. bots/docs-refresh/skills/forge-mr-create.md carries
+     a different divergence (amend mode). -->
+
+# Opening a pull request from a finished run
+
+You are turning the commits this run produced into ONE pull request
+(PR; merge request on GitLab), then optionally posting its URL back onto
+the source issue. You push and open a PR — you do NOT edit, fix, or
+re-commit the workspace.
+
+## Fresh repository (created for this run — no remote branches yet)
+
+When the run targeted a repository CREATED at launch, `origin` exists
+but has no branches (`git ls-remote --heads origin` is empty). There is
+no base to open a PR against — the FIRST push IS the publication:
+
+1. `git push -u origin HEAD` — publishes the current branch; on an
+   empty repo it becomes the default branch.
+2. Skip the PR entirely (a PR needs base ≠ head). Report the repo's
+   web URL as the deliverable instead of a PR URL.
+3. Only from the SECOND run onward (remote default branch exists) does
+   the normal branch → PR flow below apply.
+
+## 0. Resolve the base, then check there are commits to ship
+
+The CWD is the run's git worktree (or clone). First resolve the BASE the
+PR will target. Use the `mr_base` input when it is non-empty; otherwise
+resolve the repository's DEFAULT branch from the origin remote — never
+hardcode `main`:
+
+```
+BASE="$mr_base"                                  # from input; may be empty
+if [ -z "$BASE" ]; then
+  # Default branch as the remote advertises it (origin/HEAD).
+  BASE="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')"
+fi
+if [ -z "$BASE" ]; then
+  # origin/HEAD not set (fresh clone / no remote HEAD ref). Ask the remote.
+  BASE="$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p')"
+  # Cache it so the symbolic-ref lookup works next time.
+  [ -n "$BASE" ] && git remote set-head origin "$BASE" >/dev/null 2>&1 || true
+fi
+BASE="${BASE:-main}"                             # last-resort floor only
+```
+
+Then confirm HEAD is ahead of that base before doing anything. Compare
+against the REMOTE ref, never the local branch: in a cloud/runner clone
+the campaign commits directly on the checked-out base branch, so the
+local `$BASE` ref IS HEAD and `"$BASE"..HEAD` is vacuously 0 — that
+exact mistake silently discarded a run's real commits.
+
+```
+git fetch origin "$BASE" --quiet 2>/dev/null || true
+git rev-list --count "origin/$BASE"..HEAD        # > 0 means there is work to ship
+```
+
+If the count is 0 (or `origin/$BASE` is missing), STOP: return
+`opened=false` with `skipped_reason="no commits ahead of base"`. Never
+open an empty PR.
+
+## 1. Detect the forge from the origin remote
+
+```
+git remote get-url origin
+```
+
+- host `github.com` (or GitHub Enterprise) → **GitHub**, use `gh`.
+- host contains `gitlab` → **GitLab**, use `glab`.
+- otherwise assume **Forgejo / Gitea** (self-hosted) → REST API via `curl`.
+
+If there is no `origin` remote (a local-only run), return `opened=false`
+with `skipped_reason="no origin remote to push to"`.
+
+## 2. Authenticate from the mounted forge_token
+
+This run may be unattended (a comment-triggered launch) with no
+pre-authenticated forge CLI, and a reused runner pod can carry a PREVIOUS
+run's login. The most robust path is **environment auth**: gh/glab read a
+token straight from the env, which overrides any stale login and avoids the
+`auth login` / `set-token` sub-commands whose flags drift between CLI
+versions (glab's `--host` → `--hostname` rename has bitten real runs). If
+the mounted secret file `/run/iterion/secrets/forge_token` EXISTS, export it
+for the matching CLI FIRST; never read the token into a prompt or echo it:
+
+- GitHub: `export GH_TOKEN="$(cat /run/iterion/secrets/forge_token)"`
+- GitLab: `export GITLAB_TOKEN="$(cat /run/iterion/secrets/forge_token)"` plus
+  `export GITLAB_HOST="<host>"` (host parsed from the origin URL); glab reads
+  both — do NOT run `glab auth login` / `set-token`.
+- Forgejo/Gitea: `export FORGEJO_TOKEN="$(cat /run/iterion/secrets/forge_token)"`
+
+When the file is absent (manual/local runs), assume host auth and verify
+the CLI is ready (`gh auth status` / `glab auth status`). If neither a
+token file nor host auth is available, push/open nothing: return
+`opened=false` with a precise `skipped_reason` (e.g.
+`"gh not authenticated; run gh auth login"`). Do not pretend.
+
+## 3. Choose the branch and push
+
+Pick the branch name: use the `mr_branch` input if non-empty, else derive
+a stable one — `iterion/improve/<run-id-or-short-sha>`. Push the run's
+HEAD to it on origin:
+
+```
+BRANCH="${mr_branch:-iterion/improve/$(git rev-parse --short HEAD)}"
+git push origin "HEAD:refs/heads/$BRANCH"
+```
+
+If the push is rejected (protected branch, no permission), return
+`opened=false` with the precise `skipped_reason` from the push error.
+
+## 4. Open the pull request
+
+Title: a short semantic summary of the improvements (reuse the run's
+commit subjects / scope_notes). Body: what changed and why, plus a line
+noting it was generated by an iterion improvement run.
+
+- **GitHub:**
+  `gh pr create --base "$BASE" --head "$BRANCH" --title "<title>" --body "<body>"`
+  (prints the PR URL on success). If a PR already exists for the branch,
+  `gh pr view "$BRANCH" --json url -q .url` — treat as `opened=true`.
+- **GitLab:**
+  `glab mr create --source-branch "$BRANCH" --target-branch "$BASE" --title "<title>" --description "<body>" --yes`
+  (prints the MR URL). Idempotent: if an MR already exists, fetch its URL
+  with `glab mr view "$BRANCH" -F json` and reuse it.
+- **Forgejo / Gitea (REST):** parse `<owner>/<repo>` from the origin URL,
+  then `POST https://<host>/api/v1/repos/<owner>/<repo>/pulls` with body
+  `{"head":"<BRANCH>","base":"<BASE>","title":"<title>","body":"<body>"}`
+  and header `Authorization: token $FORGEJO_TOKEN`. The response JSON's
+  `html_url` is the PR URL.
+
+Capture the resulting URL into `url` and set `opened=true`, `branch=$BRANCH`.
+
+## 4b. DRAFT — the product-docs delta
+
+Functional documentation is validated by the people who own the product,
+on the forge, before it is merged. So when the `draft` input is true
+(the default), the pull request is opened as a **draft** and left that
+way: marking it ready is the reviewer's act, never the bot's.
+
+- **GitHub:** add `--draft` to `gh pr create`.
+- **GitLab:** add `--draft` to `glab mr create` (older `glab` builds
+  instead want the title prefixed with `Draft: `; if `--draft` is
+  rejected, retry with the prefix).
+- **Forgejo / Gitea (REST):** there is no draft field on the create
+  endpoint — prefix the title with `WIP: `, which is Forgejo's own
+  work-in-progress marker and blocks the merge button the same way.
+
+An existing PR found on the branch is reused as-is: do **not** flip a PR
+a human already marked ready back to draft.
+
+If the draft could not be honoured (an old CLI, a provider with no draft
+concept and no WIP convention), open the PR anyway and say so in
+`skipped_reason` — `"opened, but not as a draft: <reason>"`. Report the
+truth in the `draft` output field: it says whether the PR **is** a
+draft, not whether one was asked for. Silently dropping the draft intent
+is the one outcome that is not acceptable — a reviewer who expects a
+draft may otherwise merge unvalidated prose.
+
+## 5. Back-link the source issue (optional)
+
+If the `source_issue_ref` input is non-empty, post the PR URL back to it
+so the requester sees the result where they asked:
+
+- ref looks like a **forge issue URL** (`https://…/issues/<n>` or
+  `…/-/issues/<n>`): comment via the same CLI —
+  `gh issue comment <n> --body "Opened: <url>"` /
+  `glab issue note <n> --message "Opened: <url>"` / Forgejo
+  `POST /repos/<owner>/<repo>/issues/<n>/comments`.
+- ref looks like **`native:<id>`** (the local kanban board): call the
+  board comment tool — `mcp__iterion_board__comment_issue` with
+  `{ id: "<id>", body: "Opened PR: <url>" }` (the finalize_mr node holds
+  the `board.comment` capability for exactly this).
+
+Set `back_linked=true` only when the comment actually posted. A failed
+back-link is not fatal — keep `opened=true` and note the failure in
+`summary`.
+
+## Honesty contract
+
+Report exactly what happened: `opened`, `url`, `branch`, `draft`,
+`back_linked`, and a precise `skipped_reason` whenever `opened=false` (or
+whenever the draft could not be honoured). Never fabricate a URL, never
+claim a PR you did not open, never claim a draft that is not one, never
+echo the token.

--- a/bots/product-docs/skills/glossaire-produit.md
+++ b/bots/product-docs/skills/glossaire-produit.md
@@ -65,7 +65,7 @@ Comme toute affirmation de ces pages, une définition est **sourcée ou
 
 Quand deux sources se contredisent (un ancien libellé subsiste dans un
 gabarit), retenez celui que l'utilisateur voit aujourd'hui et signalez la
-contradiction dans le rapport de la campagne — pas dans la page.
+contradiction dans le compte rendu de rédaction — pas dans la page.
 
 Quand aucune source ne permet de trancher le sens d'un terme, écrivez la
 définition avec `[à confirmer]` dans la phrase concernée. N'inventez jamais

--- a/bots/product-docs/skills/glossaire-produit.md
+++ b/bots/product-docs/skills/glossaire-produit.md
@@ -1,0 +1,96 @@
+---
+name: glossaire-produit
+description: How to build and maintain the per-product glossary page — which terms earn an entry, how each entry is written and grounded in the sources, and how pages link to it. Overridden by the docs repository's own .product-docs/ glossary when it publishes one.
+---
+
+# Glossaire du produit
+
+> Ce cadre est le **défaut du bundle**. Si le dépôt de documentation publie
+> son propre glossaire ou ses propres règles de vocabulaire
+> (`.product-docs/*.md`), c'est cela qui fait foi : le vocabulaire d'un
+> produit appartient à l'équipe produit, pas au générateur.
+
+Le glossaire est une page du produit (`<produit>/glossaire.md`). Il existe
+pour une seule raison : **un même objet métier doit porter le même nom sur
+toutes les pages, et ce nom doit être celui de l'interface**. Sans lui, chaque
+page réinvente un synonyme et le lecteur croit lire deux choses différentes.
+
+## Quels termes méritent une entrée
+
+Un terme entre au glossaire s'il remplit **au moins deux** de ces conditions :
+
+- il apparaît dans l'interface du produit (libellé, statut, intitulé de
+  bouton, en-tête de colonne) ;
+- il désigne un objet ou un état propre au produit, pas un mot courant ;
+- il est utilisé sur plus d'une page ;
+- son sens diffère du sens ordinaire du mot, ou d'un usage voisin dans un
+  autre produit de la même organisation.
+
+N'entrent pas : les termes techniques (ils n'ont pas leur place dans ces
+pages), les mots du langage courant, les acronymes internes que l'utilisateur
+final ne rencontre jamais.
+
+## Comment s'écrit une entrée
+
+```markdown
+### Nom du terme
+
+Définition en une à trois phrases, du point de vue de celui qui l'utilise.
+Ce que c'est, à quoi ça sert, à quel moment on le rencontre.
+
+Voir aussi : [terme lié](#terme-lie), [l'étape où il apparaît](parcours/etape.md)
+```
+
+- Le terme est écrit **exactement** comme l'interface l'écrit — même
+  singulier/pluriel, mêmes majuscules, même accentuation.
+- La définition ne contient pas le terme lui-même (« un dossier est un
+  dossier qui… »).
+- La définition ne décrit pas l'implémentation. « Statut que prend la demande
+  une fois l'instruction terminée » ; jamais « valeur de l'énumération ».
+- Les entrées sont classées par ordre alphabétique.
+- Un synonyme réellement utilisé par les utilisateurs mérite sa propre entrée
+  courte renvoyant à l'entrée principale.
+
+## Ancrer une définition dans les sources
+
+Comme toute affirmation de ces pages, une définition est **sourcée ou
+`[à confirmer]`**. Le vocabulaire réel se lit surtout dans :
+
+- les catalogues de traduction / fichiers i18n — la source la plus fiable,
+  c'est littéralement ce que l'utilisateur voit ;
+- les gabarits d'écran, d'e-mail et de notification ;
+- les libellés des états et des transitions (machines à états, énumérations
+  exposées à l'écran) ;
+- les messages de validation et d'erreur affichés.
+
+Quand deux sources se contredisent (un ancien libellé subsiste dans un
+gabarit), retenez celui que l'utilisateur voit aujourd'hui et signalez la
+contradiction dans le rapport de la campagne — pas dans la page.
+
+Quand aucune source ne permet de trancher le sens d'un terme, écrivez la
+définition avec `[à confirmer]` dans la phrase concernée. N'inventez jamais
+une définition plausible : une définition fausse contamine toutes les pages
+qui l'emploient.
+
+## Lier depuis les pages
+
+À sa **première occurrence dans une page**, un terme du glossaire est écrit en
+italique et lié à son entrée :
+
+```markdown
+La demande passe alors au statut *[en instruction](../glossaire.md#en-instruction)*.
+```
+
+Les occurrences suivantes de la même page ne sont pas liées : un texte truffé
+de liens ne se lit plus.
+
+## Entretien
+
+Le glossaire suit le produit comme les autres pages : quand une source montre
+qu'un libellé a changé, l'entrée est corrigée **et** les pages qui l'emploient
+sont mises à jour dans la même passe. Un glossaire à jour et des pages qui
+utilisent l'ancien mot valent moins que pas de glossaire du tout.
+
+Un terme qui a disparu de l'interface n'est pas supprimé sans vérification :
+il peut encore être connu des utilisateurs. Conservez l'entrée en indiquant
+par quoi il a été remplacé.

--- a/bots/product-docs/skills/modele-documentaire.md
+++ b/bots/product-docs/skills/modele-documentaire.md
@@ -1,0 +1,96 @@
+---
+name: modele-documentaire
+description: Default documentary model for functional product pages — structure by user roles and journeys, one hub page per role/journey and one sub-page per step. Overridden by the docs repository's own .product-docs/ model when it publishes one.
+---
+
+# Modèle documentaire par défaut
+
+> Ce modèle est le **défaut du bundle**. Si le dépôt de documentation publie
+> son propre modèle (`.product-docs/*.md`), c'est celui-là qui fait foi :
+> lisez-le d'abord et appliquez-le intégralement.
+
+La documentation fonctionnelle d'un produit se structure par **rôles** et par
+**parcours**, jamais par modules techniques. Le lecteur arrive avec une
+question de la forme « je suis X, je veux faire Y » — l'arborescence doit y
+répondre en deux clics.
+
+## L'arborescence
+
+```
+<produit>/
+  README.md                     ← page d'accueil du produit
+  <role-ou-parcours>/
+    README.md                   ← page HUB du rôle / parcours
+    <etape-1>.md                ← une sous-page par étape
+    <etape-2>.md
+  glossaire.md                  ← vocabulaire du produit
+```
+
+Trois niveaux suffisent presque toujours. Un quatrième niveau est le signe
+qu'une étape est en réalité un parcours : promouvez-la.
+
+## La page d'accueil du produit (`README.md`)
+
+Trois choses, dans cet ordre :
+
+1. **À quoi sert le produit**, en trois à cinq phrases, du point de vue de
+   celui qui l'utilise. Pas d'historique, pas d'architecture, pas de liste de
+   fonctionnalités.
+2. **Qui l'utilise** — un tableau des rôles, avec pour chacun un lien vers son
+   hub. C'est la table de routage du lecteur.
+3. **Par où commencer** — le parcours le plus courant, en un lien.
+
+## La page hub (`<role-ou-parcours>/README.md`)
+
+Le hub répond à « qu'est-ce que je peux faire ici, et dans quel ordre ». Il
+raconte le parcours ; il ne le détaille pas.
+
+1. **En une phrase** : ce que ce rôle (ou ce parcours) permet de faire.
+2. **Le parcours de bout en bout** : la suite des étapes, chacune en une
+   phrase, chacune liée à sa sous-page. Une liste numérotée quand l'ordre est
+   imposé, une liste à puces quand il ne l'est pas.
+3. **Ce qu'il faut avoir avant de commencer** : accès, pièces, informations —
+   uniquement si le produit l'exige réellement.
+4. **Les cas particuliers** connus, en une ligne chacun, liés à leur page.
+
+Un hub qui dépasse une page-écran est un hub qui documente au lieu de router.
+
+## La sous-page d'étape (`<etape>.md`)
+
+Une étape = une page. Une page = une chose qu'on fait, du début à la fin.
+
+1. **Titre** : l'action, à l'infinitif, avec les mots de l'interface
+   (« Déposer une demande », pas « Dépôt de dossier »).
+2. **Quand faire cette étape**, et par qui — une ou deux phrases.
+3. **Comment faire** : les actions dans l'ordre, telles qu'on les vit dans
+   l'interface. Les libellés cités entre guillemets sont les libellés réels.
+4. **Ce qui est demandé** : champs obligatoires, pièces, formats, limites —
+   uniquement ce que le produit contrôle vraiment.
+5. **Ce qui se passe ensuite** : le nouvel état, qui est notifié, quel est le
+   délai s'il en existe un, quelle est l'étape suivante (avec son lien).
+6. **Ce qui peut bloquer** : les refus possibles et la manière d'y remédier.
+   C'est la section que les lecteurs cherchent le plus, et celle qu'on oublie
+   le plus souvent.
+
+## Règles de rédaction structurelle
+
+- **Une page = une intention.** Si vous écrivez « par ailleurs » ou « à
+  noter », vérifiez que la suite ne mérite pas sa propre page.
+- **Chaque page est atteignable.** Toute page est liée depuis son hub, et tout
+  hub depuis l'accueil. Une page orpheline est une page invisible — la sonde
+  `orphan_page` la signale.
+- **Les liens sont relatifs** entre pages du produit, jamais absolus.
+- **Un titre décrit ce que le lecteur va faire**, pas la structure du produit.
+- **Pas de sommaire écrit à la main** dans une page : la navigation vit dans
+  les hubs.
+- **Une information n'est écrite qu'à un seul endroit.** Ailleurs, on lie.
+  Deux copies d'une règle métier divergent au premier changement.
+
+## Ce qui n'apparaît jamais dans une page publiée
+
+Ni commentaire HTML, ni encadré « Sources », ni section « Points à
+clarifier », ni annexe « Correspondance technique ». Ces éléments sont des
+notes de travail : une porte d'entrée fonctionnelle ne montre pas les
+coulisses de sa fabrication. Une question ouverte s'écrit `[à confirmer]`
+dans la phrase concernée ; le reste va dans le message de commit ou dans le
+rapport de la campagne.

--- a/bots/product-docs/skills/modele-documentaire.md
+++ b/bots/product-docs/skills/modele-documentaire.md
@@ -77,8 +77,8 @@ Une étape = une page. Une page = une chose qu'on fait, du début à la fin.
 - **Une page = une intention.** Si vous écrivez « par ailleurs » ou « à
   noter », vérifiez que la suite ne mérite pas sa propre page.
 - **Chaque page est atteignable.** Toute page est liée depuis son hub, et tout
-  hub depuis l'accueil. Une page orpheline est une page invisible — la sonde
-  `orphan_page` la signale.
+  hub depuis l'accueil. Une page orpheline est une page invisible : la
+  relecture automatique la signale.
 - **Les liens sont relatifs** entre pages du produit, jamais absolus.
 - **Un titre décrit ce que le lecteur va faire**, pas la structure du produit.
 - **Pas de sommaire écrit à la main** dans une page : la navigation vit dans
@@ -93,4 +93,4 @@ clarifier », ni annexe « Correspondance technique ». Ces éléments sont des
 notes de travail : une porte d'entrée fonctionnelle ne montre pas les
 coulisses de sa fabrication. Une question ouverte s'écrit `[à confirmer]`
 dans la phrase concernée ; le reste va dans le message de commit ou dans le
-rapport de la campagne.
+compte rendu de rédaction.

--- a/bots/product-docs/skills/product-docs.md
+++ b/bots/product-docs/skills/product-docs.md
@@ -1,0 +1,155 @@
+---
+name: product-docs
+description: Operating playbook for Prody — writing functional, business-audience product documentation in a dedicated docs repository from the source code of the repositories a product catalog names. Read it before writing any page.
+---
+
+# product-docs — operating playbook
+
+Prody writes the **functional documentation of a product**: what it does for
+the people who use it, role by role and journey by journey. The pages live in
+a **dedicated documentation repository** (this run's workspace); the code that
+grounds them lives in the **other repositories** a product catalog names,
+cloned read-only outside the workspace.
+
+One adaptive `campaign` agent does the writing. The deterministic nodes around
+it are **truth oracles and helpers**, never obligation generators:
+
+- `catalog_ingest` resolves the product from the catalog, clones its source
+  repositories out of tree, redacts secret-bearing files from the clones, and
+  reports every repository it could **not** read as a `degraded` inventory
+  entry with a reason.
+- `scan_hints` produces an ADVISORY report each pass: dead intra-doc links and
+  anchors, orphan pages, catalog surfaces no page covers, empty pages, and the
+  incremental base. Help, never a checklist you owe anyone.
+- `scope_check` rejects any change outside `<product_dir>/**/*.md`.
+- `page_lint` rejects a published page that still carries working notes.
+- `gate` converges on `scope_ok ∧ lint_ok ∧ docs_aligned` — nothing else.
+
+## The audience decides everything
+
+These pages are read by the product's **users** — agents, managers, citizens,
+partners — not by its developers. That single fact settles most authoring
+questions:
+
+- **In scope:** what the product lets someone do, in what order, under what
+  conditions; the vocabulary the interface actually uses; the statuses a file
+  or a request goes through; who is notified and when; what blocks a step and
+  how to unblock it.
+- **Out of scope:** code, schemas, endpoints, environment variables,
+  deployment, architecture, repository layout, anything a reader could not act
+  on from the interface. Technical documentation is another bot's job
+  (docs-refresh, in the source repo).
+
+If a sentence would only make sense to someone who has read the code, it does
+not belong on the page.
+
+## Authority order — the docs repo wins
+
+1. **The docs repository's own editorial skills** (`.product-docs/*.md`, or
+   whatever `editorial_dir` names). Listed in your user prompt. The product
+   team wrote them; where they disagree with anything else, they win.
+2. **This bundle's default skills** — `modele-documentaire`, `blocs-gitbook`,
+   `glossaire-produit`, `ton-et-style` — for whatever the docs repo did not
+   specify.
+
+The bundle brings a default editorial line, not a house style. A product team
+that published its own model has already made these decisions; re-litigating
+them in the pages is a defect.
+
+## Inviolable rules
+
+1. **The sources are the truth.** Every factual claim is grounded in something
+   read in a source clone, or in human-validated prose already on the page.
+2. **Sourced or `[à confirmer]` — never invented.** A plausible business rule
+   you could not ground is the worst thing shippable here: the reader has no
+   way to tell it apart from a sourced one. When you cannot ground it, either
+   leave it out or write it with `[à confirmer]` in the sentence itself.
+3. **A repository you could not read is a hole you declare.** Never document
+   the area a `degraded` inventory entry covers from inference. Name it in
+   `unread_sources`.
+4. **Human-validated prose is preserved.** Touch existing prose in exactly two
+   cases: the code contradicts it, or it is incomplete against a journey the
+   code clearly implements. A pass that reflows prose it had no reason to
+   touch has destroyed human work and produced nothing.
+5. **Stay inside the writeable set.** `.md` under the product directory, and
+   nothing else — never the source clones, never the docs repo's editorial
+   skills, never another product's directory.
+6. **Published pages carry no working notes.** No HTML comments, no "Sources"
+   box, no "Points à clarifier" section, no "Correspondance technique" annex.
+   The lint gate enforces it; see below for where those things go instead.
+7. **Commit each page as you finish it**, with both trailers. Never batch,
+   never push.
+
+## Where research notes actually go
+
+The lint gate is not arbitrary: each of the four forbidden artefacts has a
+correct destination.
+
+| What you want to record | Where it goes |
+|---|---|
+| Which file/commit grounded a claim | the commit message body |
+| An open question about a business rule | `[à confirmer]` inline, plus `summary` |
+| Something the product promises and the code does not do | the promises ledger (`promises.json`) |
+| A source bug found while grounding a claim | a board finding + `is_product_bug` |
+| A page-by-page account of the pass | the termination `summary` |
+
+Nothing on that list belongs in the reader's page.
+
+## Reading a source repository you have never seen
+
+There is no parser and no per-framework checklist here — any language, any
+stack. The signals that carry **functional** meaning, in rough order of value:
+
+- **User-facing text**: i18n / translation catalogs, templates, view files,
+  email and notification bodies. This is where the product's own vocabulary
+  lives, and the page must use that vocabulary, not a synonym.
+- **Forms and validation**: which fields exist, which are required, what is
+  refused and with what message. Most business rules are here.
+- **Routes, menus, navigation**: the shape of the journeys, and which role
+  reaches which screen.
+- **Roles, permissions, statuses**: state machines and enums name the steps a
+  file goes through — the backbone of a journey page.
+- **API contracts** (OpenAPI and the like): useful for the *what*, dangerous
+  for the *how*. Take the business meaning, leave the technical surface.
+- **Seed / fixture data**: often the clearest statement of the product's
+  reference data (categories, motives, thresholds).
+
+Prefer a signal the user can see over one they cannot. A validation message
+shown on screen beats a constant named after it.
+
+## How to work
+
+A living todo list, not frozen phases. Survey the product directory and the
+source clones, build a dense list of the pages this pass needs, then work it
+one page at a time, re-prioritising as you learn. On a product spread over
+several repositories, fan out sub-readers by repository or by user role and
+write from what they surface — a pass that stays on the two obvious pages is
+the shallow failure to avoid.
+
+Per page: read the sources that ground it → write or correct it per the
+editorial line in force → check it carries no working notes → commit it alone.
+
+## The two commit trailers
+
+Every commit body ends with both:
+
+```
+Bot: product-docs
+Product-Docs-Sources: <the stamp given in your user prompt>
+```
+
+`Bot:` is how the next run finds where documentation last landed.
+`Product-Docs-Sources:` records exactly which source commits the page was
+written against — it is what lets the next run compute "what changed in the
+sources since we last documented them" without any side-car state file.
+Dropping either one costs the next run its incremental base.
+
+## Convergence
+
+`docs_aligned` is an **asymptote signal**, not a finish line. If this pass
+produced many pages, assume the next sweep will still find real work and
+report `false`: the run loops you back on a fresh tree, and it is the decline
+of pages-per-pass toward zero that ends it. Report `true` only when a fresh
+comprehensive survey would find little or nothing left to write.
+
+Under-reporting costs one pass. Over-reporting lands you right back here.

--- a/bots/product-docs/skills/ton-et-style.md
+++ b/bots/product-docs/skills/ton-et-style.md
@@ -78,7 +78,7 @@ toucher détruit du travail humain et ne produit rien.
 
 Quand la prose validée et le code se contredisent et que **c'est le code qui
 semble fautif**, ne réalignez pas la page sur le comportement du code :
-signalez-le (`is_product_bug`) et laissez la page en l'état.
+signalez-le au compte rendu de rédaction et laissez la page en l'état.
 
 ## Titres
 
@@ -92,5 +92,5 @@ signalez-le (`is_product_bug`) et laissez la page en l'état.
 Ni commentaire HTML, ni encadré « Sources », ni section « Points à
 clarifier », ni annexe « Correspondance technique ». Les notes de travail, les
 références de fichiers et les questions ouvertes appartiennent au message de
-commit, au registre des promesses ou au rapport de la campagne — jamais à la
+commit, au registre des promesses ou au compte rendu de rédaction — jamais à la
 page que lit l'utilisateur.

--- a/bots/product-docs/skills/ton-et-style.md
+++ b/bots/product-docs/skills/ton-et-style.md
@@ -1,0 +1,96 @@
+---
+name: ton-et-style
+description: Default tone and style rules for published functional pages — person, tense, sentence shape, the sourced-or-[à confirmer] discipline, and how to touch human-validated prose. Overridden by the docs repository's own .product-docs/ style guide when it publishes one.
+---
+
+# Ton et style
+
+> Ces règles sont le **défaut du bundle**. Si le dépôt de documentation publie
+> sa propre charte (`.product-docs/*.md`), c'est elle qui fait foi.
+
+## Le ton
+
+Vous écrivez pour quelqu'un qui a une tâche à accomplir et peu de temps. Le
+ton est **factuel, direct et neutre** : ni promotionnel, ni scolaire, ni
+familier. On explique ce que le produit fait ; on ne le vend pas, on ne
+s'excuse pas de ses limites, on ne se félicite pas de ses fonctionnalités.
+
+## Les règles de forme
+
+- **Vouvoiement**, quand on s'adresse au lecteur. Pas de « nous ».
+- **Présent de l'indicatif.** « La demande passe au statut *en instruction* »,
+  jamais « la demande passera » ni « la demande va passer ».
+- **Voix active.** « Le gestionnaire valide le dossier », pas « le dossier est
+  validé par le gestionnaire ».
+- **Une idée par phrase.** Au-delà de deux lignes, coupez.
+- **Les mots de l'interface, entre guillemets ou en gras**, tels qu'ils sont
+  écrits à l'écran. N'inventez jamais un synonyme « plus clair » : le lecteur
+  cherche le libellé qu'il a sous les yeux.
+- **Pas de jargon technique** : ni API, ni base de données, ni déploiement, ni
+  nom de fichier ou de service. Si le mot n'apparaît pas dans l'interface et
+  n'est pas au glossaire, il n'a probablement pas sa place.
+- **Pas d'acronyme non explicité** à sa première occurrence.
+- **Les nombres et les délais s'écrivent tels que le produit les applique**
+  (« 30 jours », pas « environ un mois »), et seulement s'ils sont sourcés.
+- **Pas de méta-discours** : « cette page décrit… », « comme vu plus haut… »,
+  « nous allons voir… ». Entrez dans le sujet.
+- **Pas de références temporelles instables** : « récemment », « la nouvelle
+  version », « prochainement ». Une page se lit deux ans plus tard.
+
+## Sourcé, ou `[à confirmer]`
+
+C'est la règle qui prime sur toutes les autres.
+
+Chaque affirmation factuelle d'une page — une règle métier, un délai, un
+statut, un droit d'accès, une condition de refus — est **ancrée dans une
+source lue** (le code du produit) ou **dans une prose déjà validée par un
+humain**. Quand ni l'un ni l'autre, deux options seulement :
+
+1. ne pas l'écrire ;
+2. l'écrire en marquant l'incertitude **dans la phrase** :
+
+```markdown
+Le dossier est archivé au bout de 30 jours [à confirmer].
+```
+
+Il n'y a pas de troisième option. Une phrase plausible mais non vérifiée est
+indiscernable d'une phrase vérifiée pour le lecteur — c'est la faute la plus
+grave possible ici, plus grave qu'une lacune.
+
+Le marqueur `[à confirmer]` se place au plus près de l'élément incertain, pas
+en tête de section. Une page entière marquée `[à confirmer]` est une page
+qu'il ne fallait pas écrire.
+
+## La prose déjà validée par un humain
+
+Une grande partie de ces pages a été écrite ou corrigée par quelqu'un qui
+connaît le produit mieux que ne l'enseigne une lecture du code. On n'y touche
+que dans **deux cas** :
+
+1. **le code la contredit** — on corrige, au plus près, et on l'explique dans
+   le message de commit ;
+2. **elle est incomplète** au regard d'un parcours que le code implémente
+   clairement — on complète.
+
+Ne reformulez jamais une phrase correcte parce que vous l'auriez tournée
+autrement. Une passe qui réécrit de la prose qu'elle n'avait aucune raison de
+toucher détruit du travail humain et ne produit rien.
+
+Quand la prose validée et le code se contredisent et que **c'est le code qui
+semble fautif**, ne réalignez pas la page sur le comportement du code :
+signalez-le (`is_product_bug`) et laissez la page en l'état.
+
+## Titres
+
+- Un titre d'action est à l'infinitif : « Déposer une demande ».
+- Un titre de page hub nomme le rôle ou le parcours : « Espace gestionnaire ».
+- Pas de ponctuation finale, pas de numérotation manuelle.
+- Un seul titre de niveau 1 par page, qui est le titre de la page.
+
+## Ce qu'on ne met jamais dans une page
+
+Ni commentaire HTML, ni encadré « Sources », ni section « Points à
+clarifier », ni annexe « Correspondance technique ». Les notes de travail, les
+références de fichiers et les questions ouvertes appartiennent au message de
+commit, au registre des promesses ou au rapport de la campagne — jamais à la
+page que lit l'utilisateur.

--- a/bots/product_docs_gates_test.go
+++ b/bots/product_docs_gates_test.go
@@ -583,6 +583,115 @@ func TestProductDocsPageLint(t *testing.T) {
 	})
 }
 
+// TestProductDocsDeterministicPassConverges walks the whole deterministic
+// chain on a fixture — catalog_ingest → scan_hints → (a simulated campaign
+// pass) → scope_check → page_lint — and asserts every input the `gate`
+// compute node ANDs is green.
+//
+// The gate is `scope_ok ∧ lint_ok ∧ campaign.docs_aligned`. Only the third
+// term needs an LLM, so this test pins the other two end to end: a pass that
+// writes a hub plus step sub-pages per the documentary model, links them, and
+// commits each with BOTH trailers, converges. Without it, "the deterministic
+// half converges" would be an assertion nobody had run.
+func TestProductDocsDeterministicPassConverges(t *testing.T) {
+	requireGitPython(t)
+
+	source := newSourceRepo(t)
+	ws := t.TempDir()
+	scratch := t.TempDir()
+	gitIn(t, ws, "init", "-q", "-b", "main")
+	catalogFixture(t, ws, "catalog/demo",
+		"id: demo\n"+
+			"docs:\n"+
+			"  product_dir: documentation_produits/demo\n"+
+			"  surfaces:\n    - name: Espace gestionnaire\n"+
+			"repos:\n  - id: demo-src\n    url: "+source+"\n",
+		`{"id":"demo","docs":{"product_dir":"documentation_produits/demo",`+
+			`"surfaces":[{"name":"Espace gestionnaire"}]},`+
+			`"repos":[{"id":"demo-src","url":"`+source+`"}]}`+"\n")
+	// The docs repo publishes its own editorial line — the gate must leave it
+	// alone, and scan_hints must report it as in force.
+	writeFile(t, ws, ".product-docs/modele.md", "# Modèle local\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "chore: seed the docs repo")
+
+	// 1. catalog_ingest resolves the product and clones the source.
+	var ingest ingestOut
+	runJSON(t, ingestCommand(t, ws, "catalog", "demo", scratch), &ingest)
+	if ingest.OKCount != 1 || ingest.Degraded != 0 {
+		t.Fatalf("ingest = %d ok / %d degraded, want 1/0: %s", ingest.OKCount, ingest.Degraded, ingest.Log)
+	}
+	productDir := ingest.ProductDir
+
+	// 2. The first scan is a BOOTSTRAP: no page exists yet.
+	var before hintsOut
+	runJSON(t, hintsCommand(t, ws, productDir, `[{"name":"Espace gestionnaire"}]`), &before)
+	if !strings.Contains(before.HintsNote, "BOOTSTRAP") {
+		t.Fatalf("first pass on an empty product tree must announce the bootstrap: %q", before.HintsNote)
+	}
+	if !strings.Contains(before.HintsNote, "AUTHORITATIVE") {
+		t.Fatalf("the docs repo's own editorial override was not reported as in force: %q", before.HintsNote)
+	}
+
+	// 3. Simulate the campaign pass: an accueil linking the hub, a hub
+	//    linking its steps, one page per step — the documentary model — each
+	//    committed alone with both trailers.
+	stamp := ingest.Stamp
+	page := func(rel, body string) {
+		writeFile(t, ws, filepath.Join(productDir, rel), body)
+		gitIn(t, ws, "add", "-A")
+		gitIn(t, ws, "commit", "-q", "-m", "docs("+rel+"): rédigé\n\nBot: product-docs\nProduct-Docs-Sources: "+stamp)
+	}
+	page("README.md", "# Demo\n\nDemo permet de suivre une demande.\n\n"+
+		"- [Espace gestionnaire](gestionnaire/README.md)\n")
+	page("gestionnaire/README.md", "# Espace gestionnaire\n\nCe rôle instruit les demandes.\n\n"+
+		"1. [Déposer une demande](deposer.md)\n2. [Instruire la demande](instruire.md)\n")
+	page("gestionnaire/deposer.md", "# Déposer une demande\n\nCliquez sur **Envoyer**.\n\n"+
+		"{% hint style=\"warning\" %}\nCette action est irréversible.\n{% endhint %}\n")
+	page("gestionnaire/instruire.md", "# Instruire la demande\n\n"+
+		"La demande passe au statut **En instruction**. Le délai est de 30 jours [à confirmer].\n")
+
+	// 4. Both deterministic gates must be green.
+	var scope scopeOutPD
+	runJSON(t, resolveCommand(t, toolCommand(t, "product-docs/main.bot", "scope_check"), map[string]string{
+		"vars.workspace_dir": ws,
+		"input.product_dir":  productDir,
+	}), &scope)
+	if !scope.ScopeOK {
+		t.Fatalf("scope_check red after a well-behaved pass: %v — %s", scope.OutOfScope, scope.Log)
+	}
+
+	var lint lintOut
+	runJSON(t, lintCommand(t, ws, productDir, allLintRules, ""), &lint)
+	if !lint.LintOK {
+		t.Fatalf("page_lint red on pages carrying no working notes: %+v", lint.Violations)
+	}
+	if lint.PagesLinted != 4 {
+		t.Fatalf("pages_linted = %d, want the 4 pages the pass wrote", lint.PagesLinted)
+	}
+
+	// 5. The advisory scan must now be quiet: every page reachable, every
+	//    link resolving, the declared surface covered.
+	var after hintsOut
+	runJSON(t, hintsCommand(t, ws, productDir, `[{"name":"Espace gestionnaire"}]`), &after)
+	if after.PageCount != 4 {
+		t.Fatalf("page_count = %d, want 4", after.PageCount)
+	}
+	if after.DeadLinkCount != 0 || after.OrphanCount != 0 || after.UnmappedCount != 0 {
+		t.Fatalf("hints not quiet after a converging pass: %d dead / %d orphan / %d unmapped — %v",
+			after.DeadLinkCount, after.OrphanCount, after.UnmappedCount, after.Hints)
+	}
+
+	// 6. The trailers are what make the NEXT run incremental: a fresh
+	//    scratch dir must still recover the recorded source stamp.
+	var reingest ingestOut
+	runJSON(t, ingestCommand(t, ws, "catalog", "demo", t.TempDir()), &reingest)
+	if reingest.PrevStamp != stamp {
+		t.Fatalf("previous_stamp = %q, want the stamp the pass committed (%q) — the next run lost its incremental base",
+			reingest.PrevStamp, stamp)
+	}
+}
+
 type scopeOutPD struct {
 	ScopeOK    bool     `json:"scope_ok"`
 	OutOfScope []string `json:"out_of_scope"`

--- a/bots/product_docs_gates_test.go
+++ b/bots/product_docs_gates_test.go
@@ -146,6 +146,7 @@ type ingestOut struct {
 	OKCount     int              `json:"ok_count"`
 	Degraded    int              `json:"degraded_count"`
 	Redacted    int              `json:"redacted_count"`
+	BaseSHA     string           `json:"base_sha"`
 	PrevStamp   string           `json:"previous_stamp"`
 	DeltaUnavai bool             `json:"delta_unavailable"`
 	Log         string           `json:"log"`
@@ -271,6 +272,179 @@ func TestProductDocsCatalogIngest(t *testing.T) {
 	if got.PrevStamp != "" {
 		t.Fatalf("previous_stamp = %q on a repo with no prior product-docs commit, want empty", got.PrevStamp)
 	}
+	// Deleting a secret from the clone's WORKTREE leaves the same blob one
+	// `git show` away in its history. The campaign has a shell.
+	if _, err := os.Stat(filepath.Join(clonePath, ".git")); err == nil {
+		t.Fatal("the clone kept its .git: every redacted secret is still readable from the pack")
+	}
+}
+
+// TestProductDocsCatalogIngestRefusesHostilecatalog pins the front door
+// against the catalog itself. The catalog is operator input that reaches a
+// filesystem destination (rmtree + clone) and git argument lists — the two
+// places where a benign-looking value stops being data.
+func TestProductDocsCatalogIngestRefusesHostileCatalog(t *testing.T) {
+	requireGitPython(t)
+
+	source := newSourceRepo(t)
+
+	newWS := func(t *testing.T) (string, string) {
+		t.Helper()
+		ws := t.TempDir()
+		scratch := t.TempDir()
+		gitIn(t, ws, "init", "-q", "-b", "main")
+		writeFile(t, ws, "documentation_produits/demo/README.md", "# Demo\n")
+		gitIn(t, ws, "add", "-A")
+		gitIn(t, ws, "commit", "-q", "-m", "seed")
+		return ws, scratch
+	}
+
+	// An id is a directory NAME. Left raw it is a path: os.path.join with an
+	// absolute id discards the scratch root, and the node rmtree's whatever it
+	// lands on before cloning over it.
+	t.Run("a path-shaped repo id cannot escape the scratch root", func(t *testing.T) {
+		ws, scratch := newWS(t)
+		victim := t.TempDir()
+		writeFile(t, victim, "important/data.txt", "des données de l'hôte\n")
+		catalogFixture(t, ws, "catalog/demo",
+			"id: demo\ndocs:\n  product_dir: documentation_produits/demo\n"+
+				"repos:\n  - id: "+victim+"\n    url: "+source+"\n",
+			`{"id":"demo","docs":{"product_dir":"documentation_produits/demo"},`+
+				`"repos":[{"id":"`+victim+`","url":"`+source+`"}]}`+"\n")
+		var got ingestOut
+		runJSON(t, ingestCommand(t, ws, "catalog", "demo", scratch), &got)
+		if _, err := os.Stat(filepath.Join(victim, "important/data.txt")); err != nil {
+			t.Fatalf("a catalog id deleted a directory outside the scratch root: %v", err)
+		}
+		for _, e := range got.Inventory {
+			p, _ := e["path"].(string)
+			if p != "" && !strings.HasPrefix(p, scratch) {
+				t.Fatalf("clone destination %q escaped the scratch root %q", p, scratch)
+			}
+		}
+	})
+
+	// `..` as an id would rmtree the scratch root itself — every other clone
+	// and the ledgers with it.
+	t.Run("a dot-dot repo id cannot wipe the scratch root", func(t *testing.T) {
+		ws, scratch := newWS(t)
+		sibling := filepath.Join(scratch, "sources", "autre-clone")
+		if err := os.MkdirAll(sibling, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		catalogFixture(t, ws, "catalog/demo",
+			"id: demo\ndocs:\n  product_dir: documentation_produits/demo\n"+
+				"repos:\n  - id: '..'\n    url: "+source+"\n",
+			`{"id":"demo","docs":{"product_dir":"documentation_produits/demo"},`+
+				`"repos":[{"id":"..","url":"`+source+`"}]}`+"\n")
+		var got ingestOut
+		runJSON(t, ingestCommand(t, ws, "catalog", "demo", scratch), &got)
+		if _, err := os.Stat(sibling); err != nil {
+			t.Fatalf("a '..' id wiped the scratch root, taking the other clones with it: %v", err)
+		}
+		_ = got
+	})
+
+	// A url or ref that starts with a dash is read by git as an OPTION;
+	// ext::<command> is executed outright.
+	t.Run("option-shaped and remote-helper sources are refused", func(t *testing.T) {
+		for _, hostile := range []string{"--upload-pack=touch /tmp/product-docs-pwned", "ext::sh -c touch% /tmp/product-docs-pwned"} {
+			ws, scratch := newWS(t)
+			catalogFixture(t, ws, "catalog/demo",
+				"id: demo\ndocs:\n  product_dir: documentation_produits/demo\n"+
+					"repos:\n  - id: hostile\n    url: '"+hostile+"'\n",
+				`{"id":"demo","docs":{"product_dir":"documentation_produits/demo"},`+
+					`"repos":[{"id":"hostile","url":"`+hostile+`"}]}`+"\n")
+			var got ingestOut
+			runJSON(t, ingestCommand(t, ws, "catalog", "demo", scratch), &got)
+			if got.OKCount != 0 {
+				t.Fatalf("a git-option / remote-helper url was treated as a repository: %s", got.Log)
+			}
+			if _, err := os.Stat("/tmp/product-docs-pwned"); err == nil {
+				os.Remove("/tmp/product-docs-pwned")
+				t.Fatalf("the catalog url executed a command")
+			}
+		}
+	})
+
+	// The stamp is read from a commit MESSAGE in the docs repo — anyone who
+	// lands a commit writes it — and is handed to git as a REF.
+	t.Run("a stamp that is not a sha is never handed to git", func(t *testing.T) {
+		ws, scratch := newWS(t)
+		catalogFixture(t, ws, "catalog/demo",
+			"id: demo\ndocs:\n  product_dir: documentation_produits/demo\n"+
+				"repos:\n  - id: demo-src\n    url: "+source+"\n",
+			`{"id":"demo","docs":{"product_dir":"documentation_produits/demo"},`+
+				`"repos":[{"id":"demo-src","url":"`+source+`"}]}`+"\n")
+		writeFile(t, ws, "documentation_produits/demo/page.md", "# Page\n")
+		gitIn(t, ws, "add", "-A")
+		gitIn(t, ws, "commit", "-q", "-m",
+			"docs(demo): page\n\nBot: product-docs\nProduct-Docs-Sources: demo-src@--upload-pack=touch /tmp/product-docs-stamp-pwned")
+		var got ingestOut
+		runJSON(t, ingestCommand(t, ws, "catalog", "demo", scratch), &got)
+		if _, err := os.Stat("/tmp/product-docs-stamp-pwned"); err == nil {
+			os.Remove("/tmp/product-docs-stamp-pwned")
+			t.Fatal("a commit trailer executed a command through git")
+		}
+		if got.OKCount != 1 {
+			t.Fatalf("the run degraded on a hostile stamp instead of ignoring it: %s", got.Log)
+		}
+	})
+
+	// A url may carry inline credentials; the inventory reaches the campaign
+	// prompt, the run events and the PR body.
+	t.Run("inline credentials are stripped from the reported url", func(t *testing.T) {
+		ws, scratch := newWS(t)
+		hostile := "https://x-access-token:ghp_INLINECREDENTIAL987654321@github.invalid/org/repo.git"
+		catalogFixture(t, ws, "catalog/demo",
+			"id: demo\ndocs:\n  product_dir: documentation_produits/demo\n"+
+				"repos:\n  - id: privee\n    url: "+hostile+"\n",
+			`{"id":"demo","docs":{"product_dir":"documentation_produits/demo"},`+
+				`"repos":[{"id":"privee","url":"`+hostile+`"}]}`+"\n")
+		var got ingestOut
+		runJSON(t, ingestCommand(t, ws, "catalog", "demo", scratch), &got)
+		if strings.Contains(got.Log, "ghp_INLINECREDENTIAL") {
+			t.Fatalf("the log echoed an inline credential: %s", got.Log)
+		}
+		for _, e := range got.Inventory {
+			for k, v := range e {
+				if s, ok := v.(string); ok && strings.Contains(s, "ghp_INLINECREDENTIAL") {
+					t.Fatalf("inventory[%q] echoed the inline credential verbatim: %s", k, s)
+				}
+			}
+		}
+	})
+
+	// docs.product_dir is compared as a literal prefix by scope_check: a
+	// non-canonical or glob-shaped value passes here and then makes every pass
+	// unfixably red.
+	t.Run("a product_dir that the scope gate cannot match is refused", func(t *testing.T) {
+		for _, bad := range []string{"/etc/passwd-docs", "*", "docs/../../etc"} {
+			ws, scratch := newWS(t)
+			catalogFixture(t, ws, "catalog/demo",
+				"id: demo\ndocs:\n  product_dir: '"+bad+"'\n"+
+					"repos:\n  - id: demo-src\n    url: "+source+"\n",
+				`{"id":"demo","docs":{"product_dir":"`+bad+`"},`+
+					`"repos":[{"id":"demo-src","url":"`+source+`"}]}`+"\n")
+			runExpectingFailure(t, ingestCommand(t, ws, "catalog", "demo", scratch), "product-docs:")
+		}
+	})
+
+	// ...but a merely non-canonical form is CANONICALISED, not refused: an
+	// operator writing ./docs/produit means the same directory.
+	t.Run("a non-canonical product_dir is canonicalised", func(t *testing.T) {
+		ws, scratch := newWS(t)
+		catalogFixture(t, ws, "catalog/demo",
+			"id: demo\ndocs:\n  product_dir: ./documentation_produits/demo/\n"+
+				"repos:\n  - id: demo-src\n    url: "+source+"\n",
+			`{"id":"demo","docs":{"product_dir":"./documentation_produits/demo/"},`+
+				`"repos":[{"id":"demo-src","url":"`+source+`"}]}`+"\n")
+		var got ingestOut
+		runJSON(t, ingestCommand(t, ws, "catalog", "demo", scratch), &got)
+		if got.ProductDir != "documentation_produits/demo" {
+			t.Fatalf("product_dir = %q, want the canonical form the scope gate matches", got.ProductDir)
+		}
+	})
 }
 
 // TestProductDocsCatalogIngestSourceDelta pins the git-native incremental
@@ -483,7 +657,7 @@ func lintCommand(t *testing.T, ws, productDir, rules, extra string) string {
 	})
 }
 
-const allLintRules = "html_comments,sources_box,clarify_section,technical_annex"
+const allLintRules = "html_comments,sources_box,clarify_section,technical_annex,secret_material"
 
 // TestProductDocsPageLint pins the EDITORIAL gate — the one truth oracle on
 // the artifact this bot actually ships. A published page is read by the
@@ -569,6 +743,75 @@ func TestProductDocsPageLint(t *testing.T) {
 		}
 	})
 
+	// This gate BLOCKS: a rule that fires on reader-facing prose orders the
+	// campaign to delete legitimate content, and the run never converges. Every
+	// line below is ordinary French product documentation.
+	t.Run("reader-facing prose is not chrome", func(t *testing.T) {
+		ws := t.TempDir()
+		writeFile(t, ws, "docs/demo/aides.md", ""+
+			"# Aides\n\n"+
+			"## Sources de financement\n\nLe barème est publié chaque année.\n\n"+
+			"**Source :** arrêté du 3 mars.\n\n"+
+			"## Points à clarifier avec votre conseiller\n\nPrenez rendez-vous.\n\n"+
+			"Exemple de gabarit :\n\n"+
+			"```html\n<!-- remplacez le nom du bénéficiaire -->\n```\n\n"+
+			"Mot de passe : 8 caractères minimum, dont un chiffre.\n")
+		var got lintOut
+		runJSON(t, lintCommand(t, ws, "docs/demo", allLintRules, ""), &got)
+		if !got.LintOK {
+			t.Fatalf("the editorial gate fired on reader-facing prose — the campaign would be told to delete it: %+v", got.Violations)
+		}
+	})
+
+	// No document state may switch a rule off for the rest of a page: a hint
+	// closed on its own line, or never closed, used to swallow every heading
+	// rule to EOF.
+	t.Run("a hint block cannot disarm the gate", func(t *testing.T) {
+		for _, hint := range []string{
+			"{% hint style=\"info\" %}Vérifiez vos pièces.{% endhint %}\n",
+			"{% hint style=\"info\" %}\nVérifiez vos pièces.\n",
+		} {
+			ws := t.TempDir()
+			writeFile(t, ws, "docs/demo/p.md", "# Déposer\n\n"+hint+"\n## Sources\n\n- app.ts\n\n## Points à clarifier\n\n- qui valide ?\n")
+			var got lintOut
+			runJSON(t, lintCommand(t, ws, "docs/demo", allLintRules, ""), &got)
+			if got.LintOK {
+				t.Fatalf("a hint block disarmed the editorial gate for the rest of the page (hint %q)", hint)
+			}
+			if got.Count < 2 {
+				t.Fatalf("violations = %d, want both forbidden sections after the hint: %+v", got.Count, got.Violations)
+			}
+		}
+	})
+
+	// The last deterministic gate between a source clone and a published page.
+	t.Run("credential material never reaches a published page", func(t *testing.T) {
+		for _, body := range []string{
+			"# Config\n\nDB_PASSWORD=SUPERSECRET_TOKEN_42\n",
+			"# Config\n\n```yaml\npostgres:\n  password: PLAINTEXT_PG_PW_99\n```\n",
+			"# Config\n\nJeton : ghp_" + strings.Repeat("a", 36) + "\n",
+			"# Clé\n\n-----BEGIN RSA PRIVATE KEY-----\nMIIEow==\n-----END RSA PRIVATE KEY-----\n",
+		} {
+			ws := t.TempDir()
+			writeFile(t, ws, "docs/demo/p.md", body)
+			var got lintOut
+			runJSON(t, lintCommand(t, ws, "docs/demo", allLintRules, ""), &got)
+			if got.LintOK {
+				t.Fatalf("credential material passed the publication gate: %q", body)
+			}
+		}
+	})
+
+	// A gate that read zero pages has certified nothing.
+	t.Run("no product dir fails closed", func(t *testing.T) {
+		ws := t.TempDir()
+		var got lintOut
+		runJSON(t, lintCommand(t, ws, "", allLintRules, ""), &got)
+		if got.LintOK {
+			t.Fatalf("the lint certified an artifact it never read")
+		}
+	})
+
 	t.Run("extra_forbidden_headings extends the gate", func(t *testing.T) {
 		ws := t.TempDir()
 		writeFile(t, ws, "docs/demo/p.md", "# Déposer\n\n## Notes internes\n\n- x\n")
@@ -622,6 +865,10 @@ func TestProductDocsDeterministicPassConverges(t *testing.T) {
 		t.Fatalf("ingest = %d ok / %d degraded, want 1/0: %s", ingest.OKCount, ingest.Degraded, ingest.Log)
 	}
 	productDir := ingest.ProductDir
+	// The run base catalog_ingest recorded, before the campaign wrote a line.
+	if ingest.BaseSHA == "" {
+		t.Fatal("catalog_ingest recorded no run base: scope_check would refuse to certify the pass")
+	}
 
 	// 2. The first scan is a BOOTSTRAP: no page exists yet.
 	var before hintsOut
@@ -655,7 +902,9 @@ func TestProductDocsDeterministicPassConverges(t *testing.T) {
 	var scope scopeOutPD
 	runJSON(t, resolveCommand(t, toolCommand(t, "product-docs/main.bot", "scope_check"), map[string]string{
 		"vars.workspace_dir": ws,
+		"vars.editorial_dir": ".product-docs",
 		"input.product_dir":  productDir,
+		"input.base_sha":     ingest.BaseSHA,
 	}), &scope)
 	if !scope.ScopeOK {
 		t.Fatalf("scope_check red after a well-behaved pass: %v — %s", scope.OutOfScope, scope.Log)
@@ -705,12 +954,18 @@ func TestProductDocsScopeCheck(t *testing.T) {
 	requireGitPython(t)
 
 	command := toolCommand(t, "product-docs/main.bot", "scope_check")
-	run := func(t *testing.T, ws, productDir string) scopeOutPD {
+	// The run base is what catalog_ingest recorded BEFORE the campaign wrote
+	// anything — never a base re-derived from the campaign's own commit
+	// messages, which would let an un-trailered commit pick the window it is
+	// audited on.
+	run := func(t *testing.T, ws, productDir, base string) scopeOutPD {
 		t.Helper()
 		var got scopeOutPD
 		runJSON(t, resolveCommand(t, command, map[string]string{
 			"vars.workspace_dir": ws,
+			"vars.editorial_dir": ".product-docs",
 			"input.product_dir":  productDir,
+			"input.base_sha":     base,
 		}), &got)
 		return got
 	}
@@ -725,6 +980,16 @@ func TestProductDocsScopeCheck(t *testing.T) {
 		gitIn(t, ws, "commit", "-q", "-m", "seed")
 		return ws
 	}
+	// headOf is the run base as catalog_ingest records it: the docs repo HEAD
+	// at the moment the run starts.
+	headOf := func(t *testing.T, ws string) string {
+		t.Helper()
+		out, err := exec.Command("git", "-C", ws, "rev-parse", "HEAD").Output()
+		if err != nil {
+			t.Fatalf("git rev-parse HEAD: %v", err)
+		}
+		return strings.TrimSpace(string(out))
+	}
 	prodyCommit := func(t *testing.T, ws, msg string) {
 		gitIn(t, ws, "add", "-A")
 		gitIn(t, ws, "commit", "-q", "-m", msg+"\n\nBot: product-docs\nProduct-Docs-Sources: demo-src@deadbeef")
@@ -732,9 +997,10 @@ func TestProductDocsScopeCheck(t *testing.T) {
 
 	t.Run("pages under the product dir are in scope", func(t *testing.T) {
 		ws := newDocsRepo(t)
+		base := headOf(t, ws)
 		writeFile(t, ws, "documentation_produits/demo/gestionnaire/deposer.md", "# Déposer\n")
 		prodyCommit(t, ws, "docs(demo): déposer")
-		got := run(t, ws, "documentation_produits/demo")
+		got := run(t, ws, "documentation_produits/demo", base)
 		if !got.ScopeOK {
 			t.Fatalf("a page under the product dir was flagged out of scope: %v", got.OutOfScope)
 		}
@@ -742,9 +1008,10 @@ func TestProductDocsScopeCheck(t *testing.T) {
 
 	t.Run("another product's pages are out of scope", func(t *testing.T) {
 		ws := newDocsRepo(t)
+		base := headOf(t, ws)
 		writeFile(t, ws, "documentation_produits/autre/README.md", "# Autre (touché à tort)\n")
 		prodyCommit(t, ws, "docs(autre): oops")
-		got := run(t, ws, "documentation_produits/demo")
+		got := run(t, ws, "documentation_produits/demo", base)
 		if got.ScopeOK {
 			t.Fatalf("a page belonging to ANOTHER product passed the writeable-set gate")
 		}
@@ -755,19 +1022,47 @@ func TestProductDocsScopeCheck(t *testing.T) {
 
 	t.Run("the docs repo's own editorial skills are out of scope", func(t *testing.T) {
 		ws := newDocsRepo(t)
+		base := headOf(t, ws)
 		writeFile(t, ws, ".product-docs/modele.md", "# Modèle (réécrit par le bot)\n")
 		prodyCommit(t, ws, "docs: oops")
-		got := run(t, ws, "documentation_produits/demo")
+		got := run(t, ws, "documentation_produits/demo", base)
 		if got.ScopeOK {
 			t.Fatalf("the bot rewrote the product team's own editorial line and the gate approved it")
 		}
 	})
 
+	// A charter at the repo root is protected by the product-dir prefix rule
+	// alone. The guard that MATTERS is the one for a charter the operator
+	// puts INSIDE the product directory: a `.md` there passes every other
+	// rule, and only the editorial exclusion keeps the bot from rewriting the
+	// line it is governed by.
+	t.Run("an editorial charter inside the product dir is still out of scope", func(t *testing.T) {
+		ws := newDocsRepo(t)
+		editorial := "documentation_produits/demo/.product-docs"
+		writeFile(t, ws, editorial+"/ton-et-style.md", "# Ton\n")
+		gitIn(t, ws, "add", "-A")
+		gitIn(t, ws, "commit", "-q", "-m", "chore: charte du produit")
+		base := headOf(t, ws)
+		writeFile(t, ws, editorial+"/ton-et-style.md", "# Ton (réécrit par le bot)\n")
+		prodyCommit(t, ws, "docs(demo): ton")
+		var got scopeOutPD
+		runJSON(t, resolveCommand(t, command, map[string]string{
+			"vars.workspace_dir": ws,
+			"vars.editorial_dir": editorial,
+			"input.product_dir":  "documentation_produits/demo",
+			"input.base_sha":     base,
+		}), &got)
+		if got.ScopeOK {
+			t.Fatalf("the bot rewrote the charter that governs it and the gate approved it")
+		}
+	})
+
 	t.Run("a non-markdown file under the product dir is out of scope", func(t *testing.T) {
 		ws := newDocsRepo(t)
+		base := headOf(t, ws)
 		writeFile(t, ws, "documentation_produits/demo/script.sh", "#!/bin/sh\n")
 		prodyCommit(t, ws, "docs(demo): oops")
-		got := run(t, ws, "documentation_produits/demo")
+		got := run(t, ws, "documentation_produits/demo", base)
 		if got.ScopeOK {
 			t.Fatalf("a non-markdown file passed the writeable-set gate")
 		}
@@ -775,14 +1070,16 @@ func TestProductDocsScopeCheck(t *testing.T) {
 
 	t.Run("changes present before the run are not attributed to it", func(t *testing.T) {
 		ws := newDocsRepo(t)
-		// Someone else's code commit, landed BEFORE the run started.
+		// Someone else's code commit, landed BEFORE the run started — so it
+		// sits below the base catalog_ingest records at run start.
 		writeFile(t, ws, "tooling/build.sh", "#!/bin/sh\n")
 		gitIn(t, ws, "add", "-A")
 		gitIn(t, ws, "commit", "-q", "-m", "chore: not the bot's work")
+		base := headOf(t, ws)
 		// Then the run's own page commit.
 		writeFile(t, ws, "documentation_produits/demo/gestionnaire/deposer.md", "# Déposer\n")
 		prodyCommit(t, ws, "docs(demo): déposer")
-		got := run(t, ws, "documentation_produits/demo")
+		got := run(t, ws, "documentation_produits/demo", base)
 		if !got.ScopeOK {
 			t.Fatalf("pre-existing changes were attributed to the run: %v", got.OutOfScope)
 		}
@@ -795,10 +1092,14 @@ func TestProductDocsScopeCheck(t *testing.T) {
 	// 16-commit pass was reported as a scope violation on `.claude/`.
 	t.Run("the engine's own skill mirror is not the campaign's work", func(t *testing.T) {
 		ws := newDocsRepo(t)
+		base := headOf(t, ws)
+		// The mirror is UNTRACKED — the engine materialises it, the campaign
+		// never commits it (it stages by path, not `git add -A`).
 		writeFile(t, ws, ".claude/skills/product-docs.md", "# skill mirrored by the engine\n")
 		writeFile(t, ws, "documentation_produits/demo/gestionnaire/deposer.md", "# Déposer\n")
-		prodyCommit(t, ws, "docs(demo): déposer")
-		got := run(t, ws, "documentation_produits/demo")
+		gitIn(t, ws, "add", "--", "documentation_produits/demo/gestionnaire/deposer.md")
+		gitIn(t, ws, "commit", "-q", "-m", "docs(demo): déposer\n\nBot: product-docs\nProduct-Docs-Sources: demo-src@deadbeef")
+		got := run(t, ws, "documentation_produits/demo", base)
 		if !got.ScopeOK {
 			t.Fatalf("the engine's skill mirror was attributed to the campaign: %v — every pass would fail a gate the agent cannot satisfy", got.OutOfScope)
 		}
@@ -808,10 +1109,86 @@ func TestProductDocsScopeCheck(t *testing.T) {
 	// NOT the engine's mirror is still a violation.
 	t.Run("an untracked directory outside the product tree still fails", func(t *testing.T) {
 		ws := newDocsRepo(t)
+		base := headOf(t, ws)
 		writeFile(t, ws, ".claude-notes/scratch.md", "# not the engine's tree\n")
-		got := run(t, ws, "documentation_produits/demo")
+		got := run(t, ws, "documentation_produits/demo", base)
 		if got.ScopeOK {
 			t.Fatalf("an untracked tree outside the product dir passed the writeable-set gate")
+		}
+	})
+
+	// ...and once a path under .claude/ is TRACKED, the run committed the
+	// agent's own notes into the docs repo: they ship in the PR, so they are
+	// the campaign's work and in scope.
+	t.Run("a committed .claude path is the campaign's work", func(t *testing.T) {
+		ws := newDocsRepo(t)
+		base := headOf(t, ws)
+		writeFile(t, ws, ".claude/notes-du-bot.md", "# raisonnement brut\n")
+		gitIn(t, ws, "add", "-f", ".claude/notes-du-bot.md")
+		prodyCommit(t, ws, "docs(demo): oops")
+		got := run(t, ws, "documentation_produits/demo", base)
+		if got.ScopeOK {
+			t.Fatalf("the run committed .claude/ into the docs repo and the gate approved it: the agent's raw notes would ship in the PR")
+		}
+	})
+
+	// The base is RECORDED before the campaign writes. Deriving it from commit
+	// messages let one un-trailered commit become the base and empty its own
+	// diff — the audited party choosing its audit window.
+	t.Run("an untrailered commit cannot redefine the run base", func(t *testing.T) {
+		ws := newDocsRepo(t)
+		base := headOf(t, ws)
+		writeFile(t, ws, "src/app.py", "print('code touched by the bot')\n")
+		gitIn(t, ws, "add", "-A")
+		gitIn(t, ws, "commit", "-q", "-m", "docs(demo): page (no trailer)")
+		got := run(t, ws, "documentation_produits/demo", base)
+		if got.ScopeOK {
+			t.Fatalf("a commit that simply omitted the trailer disabled the writeable-set gate: %v", got.OutOfScope)
+		}
+	})
+
+	// Rename detection reports only a rename's DESTINATION, so moving a
+	// protected file onto an allowed .md path would delete it behind a green
+	// gate.
+	t.Run("renaming a protected file onto an allowed path is a violation", func(t *testing.T) {
+		ws := newDocsRepo(t)
+		base := headOf(t, ws)
+		gitIn(t, ws, "mv", ".product-docs/modele.md", "documentation_produits/demo/modele.md")
+		prodyCommit(t, ws, "docs(demo): déplacement")
+		got := run(t, ws, "documentation_produits/demo", base)
+		if got.ScopeOK {
+			t.Fatalf("the editorial charter was deleted by a rename and the gate approved it: %v", got.OutOfScope)
+		}
+	})
+
+	// Writing THROUGH a symlink escapes the repository entirely, and
+	// committing one publishes a host path in the docs.
+	t.Run("a symlink under the product dir is out of scope", func(t *testing.T) {
+		ws := newDocsRepo(t)
+		base := headOf(t, ws)
+		outside := filepath.Join(t.TempDir(), "cible-hors-depot.txt")
+		if err := os.WriteFile(outside, []byte("contenu privé\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(outside, filepath.Join(ws, "documentation_produits/demo/note.md")); err != nil {
+			t.Skipf("symlinks unavailable here: %v", err)
+		}
+		prodyCommit(t, ws, "docs(demo): note")
+		got := run(t, ws, "documentation_produits/demo", base)
+		if got.ScopeOK {
+			t.Fatalf("a symlink passed the writeable-set gate: the campaign can write outside the repository")
+		}
+	})
+
+	// A gate that cannot compute its own window must say so, not certify.
+	t.Run("no recorded base fails closed", func(t *testing.T) {
+		ws := newDocsRepo(t)
+		got := run(t, ws, "documentation_produits/demo", "")
+		if got.ScopeOK {
+			t.Fatalf("the gate certified a writeable set it could not compute")
+		}
+		if !strings.Contains(got.Log, "SCOPE GATE UNAVAILABLE") {
+			t.Fatalf("the log does not name the missing base: %q", got.Log)
 		}
 	})
 }

--- a/bots/product_docs_gates_test.go
+++ b/bots/product_docs_gates_test.go
@@ -1529,3 +1529,56 @@ func TestProductDocsInventoryStripsInlineURLCredentials(t *testing.T) {
 		t.Fatalf("an inline url credential survived into the inventory: %s", blob)
 	}
 }
+
+// TestProductDocsCatalogIngestRefusesCollidingIDs pins the clone-dir
+// identity: two catalog ids that collide AFTER sanitisation (a/b and
+// a-b both become a-b) would share one destination — the second
+// rmtree-and-reclones over the first and the campaign reads the wrong
+// repository under the first id. A collision is a catalog bug: refuse
+// it loudly, never swap code silently.
+func TestProductDocsCatalogIngestRefusesCollidingIDs(t *testing.T) {
+	requireGitPython(t)
+
+	source := newSourceRepo(t)
+	ws := t.TempDir()
+	gitIn(t, ws, "init", "-q", "-b", "main")
+	scratch := t.TempDir()
+	catalogFixture(t, ws, "catalog/demo",
+		"id: demo\nname: Demo\nproduct_dir: docs/demo\nrepos:\n"+
+			"  - id: a/b\n    url: "+source+"\n"+
+			"  - id: a-b\n    url: "+source+"\n",
+		`{"id":"demo","name":"Demo","product_dir":"docs/demo","repos":[{"id":"a/b","url":"`+source+`"},{"id":"a-b","url":"`+source+`"}]}`)
+	writeFile(t, ws, "docs/demo/README.md", "# Demo\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "seed")
+
+	runExpectingFailure(t, ingestCommand(t, ws, "catalog", "demo", scratch), "collide after sanitisation")
+}
+
+// TestProductDocsSourceStampRecordsFullSHA pins the stamp's fetchability:
+// the next incremental run repairs a shallow clone by fetching the
+// stamped sha (`git fetch --depth 1 origin <prev>`), and git can only
+// fetch a FULL object name. An abbreviated stamp made that repair
+// permanently impossible — every incremental delta came back
+// unavailable.
+func TestProductDocsSourceStampRecordsFullSHA(t *testing.T) {
+	requireGitPython(t)
+
+	source := newSourceRepo(t)
+	ws := t.TempDir()
+	gitIn(t, ws, "init", "-q", "-b", "main")
+	scratch := t.TempDir()
+	catalogFixture(t, ws, "catalog/demo",
+		"id: demo\nname: Demo\nproduct_dir: docs/demo\nrepos:\n  - id: demo-src\n    url: "+source+"\n",
+		`{"id":"demo","name":"Demo","product_dir":"docs/demo","repos":[{"id":"demo-src","url":"`+source+`"}]}`)
+	writeFile(t, ws, "docs/demo/README.md", "# Demo\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "seed")
+
+	var got ingestOut
+	runJSON(t, ingestCommand(t, ws, "catalog", "demo", scratch), &got)
+	parts := strings.SplitN(got.Stamp, "@", 2)
+	if len(parts) != 2 || len(parts[1]) != 40 {
+		t.Fatalf("sources_stamp %q does not record a full 40-char sha — the shallow-delta repair cannot fetch it", got.Stamp)
+	}
+}

--- a/bots/product_docs_gates_test.go
+++ b/bots/product_docs_gates_test.go
@@ -787,4 +787,31 @@ func TestProductDocsScopeCheck(t *testing.T) {
 			t.Fatalf("pre-existing changes were attributed to the run: %v", got.OutOfScope)
 		}
 	})
+
+	// The engine mirrors the bundle's skills into <workspace>/.claude/ at run
+	// start and again on every resume. Reading that as the campaign's work
+	// fails the gate on EVERY pass, and the campaign cannot fix it: the next
+	// pass re-creates the tree. Observed live on run 01a03a6a, where a clean
+	// 16-commit pass was reported as a scope violation on `.claude/`.
+	t.Run("the engine's own skill mirror is not the campaign's work", func(t *testing.T) {
+		ws := newDocsRepo(t)
+		writeFile(t, ws, ".claude/skills/product-docs.md", "# skill mirrored by the engine\n")
+		writeFile(t, ws, "documentation_produits/demo/gestionnaire/deposer.md", "# Déposer\n")
+		prodyCommit(t, ws, "docs(demo): déposer")
+		got := run(t, ws, "documentation_produits/demo")
+		if !got.ScopeOK {
+			t.Fatalf("the engine's skill mirror was attributed to the campaign: %v — every pass would fail a gate the agent cannot satisfy", got.OutOfScope)
+		}
+	})
+
+	// The exclusion above must stay surgical: an untracked directory that is
+	// NOT the engine's mirror is still a violation.
+	t.Run("an untracked directory outside the product tree still fails", func(t *testing.T) {
+		ws := newDocsRepo(t)
+		writeFile(t, ws, ".claude-notes/scratch.md", "# not the engine's tree\n")
+		got := run(t, ws, "documentation_produits/demo")
+		if got.ScopeOK {
+			t.Fatalf("an untracked tree outside the product dir passed the writeable-set gate")
+		}
+	})
 }

--- a/bots/product_docs_gates_test.go
+++ b/bots/product_docs_gates_test.go
@@ -415,6 +415,56 @@ func TestProductDocsCatalogIngestRefusesHostileCatalog(t *testing.T) {
 		}
 	})
 
+	// The whole python body lives inside a double-quoted `python3 -c "..."`
+	// string that sh parses FIRST: a literal dollar is expanded by the shell
+	// before python ever sees it. Here that erased both arguments of the
+	// askpass helper, leaving a shell syntax error on disk — so every
+	// credentialed clone failed and every private repo landed as `degraded`,
+	// silently.
+	t.Run("the credential helper survives the shell", func(t *testing.T) {
+		ws, scratch := newWS(t)
+		catalogFixture(t, ws, "catalog/demo",
+			"id: demo\ndocs:\n  product_dir: documentation_produits/demo\n"+
+				"repos:\n  - id: demo-src\n    url: "+source+"\n",
+			`{"id":"demo","docs":{"product_dir":"documentation_produits/demo"},`+
+				`"repos":[{"id":"demo-src","url":"`+source+`"}]}`+"\n")
+		cmd := exec.Command("sh", "-c", ingestCommand(t, ws, "catalog", "demo", scratch))
+		cmd.Env = append(os.Environ(),
+			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+			"GH_TOKEN=jeton-de-test-42",
+		)
+		if out, err := cmd.Output(); err != nil {
+			t.Fatalf("ingest failed with a token present: %v (%s)", err, out)
+		}
+		helper := filepath.Join(scratch, "git-askpass.sh")
+		body, err := os.ReadFile(helper)
+		if err != nil {
+			t.Fatalf("no askpass helper was written: %v", err)
+		}
+		if !strings.Contains(string(body), "case $1 in") || !strings.Contains(string(body), "$PRODUCT_DOCS_GIT_TOKEN") {
+			t.Fatalf("the shell ate the helper's arguments before python wrote it:\n%s", body)
+		}
+		// ...and it actually answers git's two prompts.
+		ask := exec.Command("sh", helper, "Username for 'https://forge':")
+		ask.Env = append(os.Environ(), "PRODUCT_DOCS_GIT_TOKEN=jeton-de-test-42")
+		userOut, err := ask.Output()
+		if err != nil {
+			t.Fatalf("the helper is not a runnable script: %v", err)
+		}
+		if strings.TrimSpace(string(userOut)) != "x-access-token" {
+			t.Fatalf("helper answered %q to a Username prompt", userOut)
+		}
+		ask = exec.Command("sh", helper, "Password for 'https://forge':")
+		ask.Env = append(os.Environ(), "PRODUCT_DOCS_GIT_TOKEN=jeton-de-test-42")
+		pwOut, err := ask.Output()
+		if err != nil {
+			t.Fatalf("the helper failed on a Password prompt: %v", err)
+		}
+		if strings.TrimSpace(string(pwOut)) != "jeton-de-test-42" {
+			t.Fatalf("helper answered %q to a Password prompt, want the token", pwOut)
+		}
+	})
+
 	// docs.product_dir is compared as a literal prefix by scope_check: a
 	// non-canonical or glob-shaped value passes here and then makes every pass
 	// unfixably red.
@@ -451,6 +501,67 @@ func TestProductDocsCatalogIngestRefusesHostileCatalog(t *testing.T) {
 // contract: the delta since the last run is recovered from the
 // `Product-Docs-Sources:` commit trailer in the DOCS repo, with no side-car
 // state file — so a crashed run or a wiped scratch dir loses nothing.
+// TestProductDocsSourceStampIsScopedToTheProduct pins the incremental base in
+// the shape the design actually has: ONE docs repo, SEVERAL products. The
+// `Product-Docs-Sources:` trailer carries no product identity, so an unscoped
+// history lookup reads whichever product ran last — and a stamp that matches
+// nothing yields an empty delta the campaign reads as "nothing changed", with
+// delta_unavailable false. The weekly incremental run then silently does
+// nothing and reports success.
+func TestProductDocsSourceStampIsScopedToTheProduct(t *testing.T) {
+	requireGitPython(t)
+
+	source := newSourceRepo(t)
+	ws := t.TempDir()
+	scratch := t.TempDir()
+	gitIn(t, ws, "init", "-q", "-b", "main")
+	for _, id := range []string{"alpha", "beta"} {
+		catalogFixture(t, ws, "catalog/"+id,
+			"id: "+id+"\ndocs:\n  product_dir: documentation_produits/"+id+"\n"+
+				"repos:\n  - id: plateforme\n    url: "+source+"\n",
+			`{"id":"`+id+`","docs":{"product_dir":"documentation_produits/`+id+`"},`+
+				`"repos":[{"id":"plateforme","url":"`+source+`"}]}`+"\n")
+		writeFile(t, ws, "documentation_produits/"+id+"/README.md", "# "+id+"\n")
+	}
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "seed")
+
+	// alpha is documented against the source as it stands now.
+	var first ingestOut
+	runJSON(t, ingestCommand(t, ws, "catalog", "alpha", scratch), &first)
+	alphaStamp := first.Stamp
+	writeFile(t, ws, "documentation_produits/alpha/page.md", "# Page alpha\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "docs(alpha): page\n\nBot: product-docs\nProduct-Docs-Sources: "+alphaStamp)
+
+	// The source then moves on, and BETA runs last — recording ITS stamp.
+	writeFile(t, source, "locales/fr.json", `{"submit":"Transmettre"}`+"\n")
+	gitIn(t, source, "add", "-A")
+	gitIn(t, source, "commit", "-q", "-m", "feat: renommer le bouton")
+	var betaIngest ingestOut
+	runJSON(t, ingestCommand(t, ws, "catalog", "beta", scratch), &betaIngest)
+	writeFile(t, ws, "documentation_produits/beta/page.md", "# Page beta\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "docs(beta): page\n\nBot: product-docs\nProduct-Docs-Sources: "+betaIngest.Stamp)
+
+	// Re-running ALPHA must recover ALPHA's own base, not beta's.
+	var again ingestOut
+	runJSON(t, ingestCommand(t, ws, "catalog", "alpha", scratch), &again)
+	if again.PrevStamp != alphaStamp {
+		t.Fatalf("previous_stamp = %q, want alpha's own %q — a sibling product's stamp was read as this product's incremental base",
+			again.PrevStamp, alphaStamp)
+	}
+	var changed []any
+	for _, e := range again.Inventory {
+		if e["id"] == "plateforme" {
+			changed, _ = e["changed_files"].([]any)
+		}
+	}
+	if len(changed) == 0 && !again.DeltaUnavai {
+		t.Fatal("the source moved but the delta is empty AND not reported unavailable: the campaign reads that as 'nothing changed' and the incremental pass becomes a silent no-op")
+	}
+}
+
 func TestProductDocsCatalogIngestSourceDelta(t *testing.T) {
 	requireGitPython(t)
 
@@ -1177,6 +1288,20 @@ func TestProductDocsScopeCheck(t *testing.T) {
 		got := run(t, ws, "documentation_produits/demo", base)
 		if got.ScopeOK {
 			t.Fatalf("a symlink passed the writeable-set gate: the campaign can write outside the repository")
+		}
+	})
+
+	// git collapses an untracked DIRECTORY into a single entry that never
+	// ends in .md — so a brand-new journey folder (the bootstrap case, and
+	// every mid-page stop) used to red the gate on the very path the campaign
+	// must write.
+	t.Run("a new page in a new directory is in scope", func(t *testing.T) {
+		ws := newDocsRepo(t)
+		base := headOf(t, ws)
+		writeFile(t, ws, "documentation_produits/demo/gestionnaire/deposer.md", "# Déposer\n")
+		got := run(t, ws, "documentation_produits/demo", base)
+		if !got.ScopeOK {
+			t.Fatalf("an untracked page inside the product dir was flagged out of scope: %v", got.OutOfScope)
 		}
 	})
 

--- a/bots/product_docs_gates_test.go
+++ b/bots/product_docs_gates_test.go
@@ -1,0 +1,681 @@
+package bots
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// product-docs (Prody) ships four deterministic nodes that decide the run:
+// catalog_ingest (what the campaign is allowed to read), scan_hints (what it
+// is advised to look at), scope_check (what it is allowed to write) and
+// page_lint (what it is allowed to publish). Each is an embedded python body
+// inside main.bot, so nothing but executing it proves it works — a change
+// that silently truncates one would otherwise surface as a bot that quietly
+// documents nothing, or a gate that approves anything.
+//
+// These tests extract each command from the COMPILED IR (the same string the
+// engine runs), resolve its template refs the way the engine does, and run it
+// against real git fixtures. No LLM, no network: the fixture "source repo" is
+// a local git directory cloned over a filesystem path.
+
+// shQuote wraps a value the way the engine's tool-command resolver does, so a
+// value carrying spaces or JSON punctuation reaches python intact.
+func shQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// resolveCommand substitutes {{vars.X}} / {{input.X}} refs in a tool command,
+// then fails the test if any ref was left behind — an unresolved ref would
+// otherwise reach the shell as literal braces and silently change behaviour.
+func resolveCommand(t *testing.T, command string, refs map[string]string) string {
+	t.Helper()
+	out := command
+	for k, v := range refs {
+		out = strings.ReplaceAll(out, "{{"+k+"}}", shQuote(v))
+	}
+	if i := strings.Index(out, "{{"); i >= 0 {
+		end := i + 40
+		if end > len(out) {
+			end = len(out)
+		}
+		t.Fatalf("unresolved template ref near %q", out[i:end])
+	}
+	return out
+}
+
+func runJSON(t *testing.T, command string, target any) {
+	t.Helper()
+	cmd := exec.Command("sh", "-c", command)
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		stderr := ""
+		if ee, ok := err.(*exec.ExitError); ok {
+			stderr = string(ee.Stderr)
+		}
+		t.Fatalf("command failed: %v\nstdout: %s\nstderr: %s", err, out, stderr)
+	}
+	if uerr := json.Unmarshal(out, target); uerr != nil {
+		t.Fatalf("output is not JSON: %v (out %q)", uerr, out)
+	}
+}
+
+// runExpectingFailure asserts the command exits non-zero and that its stderr
+// names the cause. A deterministic front door that swallows a bad catalog is
+// worse than one that has none: it documents the wrong product.
+func runExpectingFailure(t *testing.T, command, wantSubstr string) {
+	t.Helper()
+	cmd := exec.Command("sh", "-c", command)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected a loud failure, got success: %s", out)
+	}
+	if !strings.Contains(string(out), wantSubstr) {
+		t.Fatalf("failure message does not name the cause %q:\n%s", wantSubstr, out)
+	}
+}
+
+func gitIn(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s (in %s): %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+	return string(out)
+}
+
+func writeFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	p := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func requireGitPython(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+}
+
+// newSourceRepo builds a throwaway git repository standing in for one of the
+// product's source repos, carrying a user-facing i18n catalog (functional
+// signal) and a credential file (which must never survive into the clone).
+func newSourceRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	gitIn(t, dir, "init", "-q", "-b", "main")
+	writeFile(t, dir, "locales/fr.json", `{"submit":"Envoyer","status":"En instruction"}`+"\n")
+	writeFile(t, dir, ".env", "SECRET_KEY=never-read-me\n")
+	writeFile(t, dir, "config/app-secrets.yaml", "token: never-read-me\n")
+	gitIn(t, dir, "add", "-A")
+	gitIn(t, dir, "commit", "-q", "-m", "seed")
+	return dir
+}
+
+type ingestOut struct {
+	ProductID   string           `json:"product_id"`
+	ProductDir  string           `json:"product_dir"`
+	Surfaces    []any            `json:"surfaces"`
+	Inventory   []map[string]any `json:"inventory"`
+	Stamp       string           `json:"sources_stamp"`
+	RepoCount   int              `json:"repo_count"`
+	OKCount     int              `json:"ok_count"`
+	Degraded    int              `json:"degraded_count"`
+	Redacted    int              `json:"redacted_count"`
+	PrevStamp   string           `json:"previous_stamp"`
+	DeltaUnavai bool             `json:"delta_unavailable"`
+	Log         string           `json:"log"`
+}
+
+// hasYAMLParser reports whether this host can parse a YAML catalog at all.
+// catalog_ingest delegates YAML to PyYAML or to yq (declared in the bundle's
+// devbox.json) and fails loudly when it has neither — so on a bare host the
+// tests exercise the same logic through the dependency-free `.json` catalog
+// form, and the YAML surface is covered wherever a parser exists.
+func hasYAMLParser() bool {
+	if err := exec.Command("python3", "-c", "import yaml").Run(); err == nil {
+		return true
+	}
+	_, err := exec.LookPath("yq")
+	return err == nil
+}
+
+// catalogFixture writes a product-catalog entry in the richest form this host
+// can read back, and returns the file's extension so a test can assert on it.
+func catalogFixture(t *testing.T, ws, rel string, yamlBody string, jsonBody string) string {
+	t.Helper()
+	if hasYAMLParser() {
+		writeFile(t, ws, rel+".yml", yamlBody)
+		return "yaml"
+	}
+	writeFile(t, ws, rel+".json", jsonBody)
+	return "json"
+}
+
+func ingestCommand(t *testing.T, ws, catalog, product, scratch string) string {
+	t.Helper()
+	return resolveCommand(t, toolCommand(t, "product-docs/main.bot", "catalog_ingest"), map[string]string{
+		"vars.workspace_dir": ws,
+		"vars.catalog_path":  catalog,
+		"vars.product_id":    product,
+		"vars.scratch_dir":   scratch,
+		"vars.clone_depth":   "1",
+		"vars.secret_globs":  "*.env,.env,.env.*,*secret*,*secrets*,*credential*,*.pem,*.key",
+	})
+}
+
+// TestProductDocsCatalogIngest pins the front door's four promises: it
+// resolves the product from the catalog, it clones the sources OUT of the
+// docs worktree, it strips credential files from those clones, and a repo it
+// cannot read becomes a visible `degraded` entry instead of a silent absence.
+func TestProductDocsCatalogIngest(t *testing.T) {
+	requireGitPython(t)
+
+	source := newSourceRepo(t)
+	ws := t.TempDir()
+	scratch := t.TempDir()
+	gitIn(t, ws, "init", "-q", "-b", "main")
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	catalogFixture(t, ws, "catalog/demo",
+		"id: demo\n"+
+			"docs:\n"+
+			"  product_dir: documentation_produits/demo\n"+
+			"  surfaces:\n"+
+			"    - name: Espace gestionnaire\n"+
+			"repos:\n"+
+			"  - id: demo-src\n"+
+			"    url: "+source+"\n"+
+			"  - id: unreachable\n"+
+			"    url: "+missing+"\n",
+		`{"id":"demo","docs":{"product_dir":"documentation_produits/demo",`+
+			`"surfaces":[{"name":"Espace gestionnaire"}]},`+
+			`"repos":[{"id":"demo-src","url":"`+source+`"},`+
+			`{"id":"unreachable","url":"`+missing+`"}]}`+"\n")
+	writeFile(t, ws, "documentation_produits/demo/README.md", "# Demo\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "seed")
+
+	var got ingestOut
+	runJSON(t, ingestCommand(t, ws, "catalog", "demo", scratch), &got)
+
+	if got.ProductDir != "documentation_produits/demo" {
+		t.Fatalf("product_dir = %q, want the catalog's docs.product_dir", got.ProductDir)
+	}
+	if got.RepoCount != 2 || got.OKCount != 1 || got.Degraded != 1 {
+		t.Fatalf("inventory = %d repos / %d ok / %d degraded, want 2/1/1 (a repo that cannot be cloned must be REPORTED, not dropped): %s",
+			got.RepoCount, got.OKCount, got.Degraded, got.Log)
+	}
+	var okEntry, badEntry map[string]any
+	for _, e := range got.Inventory {
+		if e["status"] == "ok" {
+			okEntry = e
+		} else {
+			badEntry = e
+		}
+	}
+	if okEntry == nil || badEntry == nil {
+		t.Fatalf("inventory does not carry one ok + one degraded entry: %+v", got.Inventory)
+	}
+	if note, _ := badEntry["note"].(string); !strings.Contains(note, "clone failed") {
+		t.Fatalf("degraded entry does not say WHY it is degraded: %q", note)
+	}
+
+	// The clone lives out of the docs worktree: the scope gate would be
+	// meaningless if the sources landed inside it.
+	clonePath, _ := okEntry["path"].(string)
+	if !strings.HasPrefix(clonePath, scratch) {
+		t.Fatalf("source clone at %q is not under the scratch dir %q — sources must never land in the docs worktree", clonePath, scratch)
+	}
+	if _, err := os.Stat(filepath.Join(clonePath, "locales/fr.json")); err != nil {
+		t.Fatalf("the clone is missing the source file the campaign needs to read: %v", err)
+	}
+	// Redaction: credential-bearing files are gone from the clone.
+	for _, secret := range []string{".env", "config/app-secrets.yaml"} {
+		if _, err := os.Stat(filepath.Join(clonePath, secret)); err == nil {
+			t.Fatalf("%s survived into the clone — secret_globs redaction did not run", secret)
+		}
+	}
+	if got.Redacted != 2 {
+		t.Fatalf("redacted_count = %d, want 2", got.Redacted)
+	}
+
+	// The stamp names only readable repos, and is shaped for the commit
+	// trailer the next run reads back.
+	if !strings.HasPrefix(got.Stamp, "demo-src@") || strings.Contains(got.Stamp, "unreachable") {
+		t.Fatalf("sources_stamp = %q, want <ok-repo>@<sha> and no degraded repo", got.Stamp)
+	}
+	if got.PrevStamp != "" {
+		t.Fatalf("previous_stamp = %q on a repo with no prior product-docs commit, want empty", got.PrevStamp)
+	}
+}
+
+// TestProductDocsCatalogIngestSourceDelta pins the git-native incremental
+// contract: the delta since the last run is recovered from the
+// `Product-Docs-Sources:` commit trailer in the DOCS repo, with no side-car
+// state file — so a crashed run or a wiped scratch dir loses nothing.
+func TestProductDocsCatalogIngestSourceDelta(t *testing.T) {
+	requireGitPython(t)
+
+	source := newSourceRepo(t)
+	firstSHA := strings.TrimSpace(gitIn(t, source, "rev-parse", "HEAD"))
+
+	ws := t.TempDir()
+	gitIn(t, ws, "init", "-q", "-b", "main")
+	catalogFixture(t, ws, "catalog/demo",
+		"id: demo\n"+
+			"docs:\n  product_dir: docs/demo\n"+
+			"repos:\n  - id: demo-src\n    url: "+source+"\n",
+		`{"id":"demo","docs":{"product_dir":"docs/demo"},`+
+			`"repos":[{"id":"demo-src","url":"`+source+`"}]}`+"\n")
+	writeFile(t, ws, "docs/demo/README.md", "# Demo\n")
+	gitIn(t, ws, "add", "-A")
+	// The docs commit records exactly which source commit it was written
+	// against — the trailer IS the state.
+	gitIn(t, ws, "commit", "-q", "-m", "docs(demo): first pass\n\nBot: product-docs\nProduct-Docs-Sources: demo-src@"+firstSHA[:12])
+
+	// The source moves on.
+	writeFile(t, source, "locales/fr.json", `{"submit":"Transmettre"}`+"\n")
+	writeFile(t, source, "locales/en.json", `{"submit":"Send"}`+"\n")
+	gitIn(t, source, "add", "-A")
+	gitIn(t, source, "commit", "-q", "-m", "feat: reword the submit action")
+
+	// A FRESH scratch dir: nothing carried over except what git holds.
+	var got ingestOut
+	runJSON(t, ingestCommand(t, ws, "catalog", "demo", t.TempDir()), &got)
+
+	if got.PrevStamp == "" {
+		t.Fatalf("previous_stamp is empty — the Product-Docs-Sources trailer was not read back from the docs history")
+	}
+	if got.OKCount != 1 {
+		t.Fatalf("ok_count = %d, want 1: %s", got.OKCount, got.Log)
+	}
+	changed, _ := got.Inventory[0]["changed_files"].([]any)
+	// git ignores --depth on a local-path clone, so the recorded commit is
+	// always reachable here: the delta MUST be computed. (When it genuinely
+	// is not — a truly shallow remote clone — the contract is to set
+	// delta_unavailable and say so in the note, never to report an empty
+	// delta the campaign would read as "nothing changed".)
+	if got.DeltaUnavai {
+		note, _ := got.Inventory[0]["note"].(string)
+		t.Fatalf("delta_unavailable on a full local clone — the recorded commit was reachable: %q", note)
+	}
+	if len(changed) == 0 {
+		t.Fatalf("the source moved but changed_files is empty and delta_unavailable is false — a silently empty delta reads as 'nothing changed'")
+	}
+	found := map[string]bool{}
+	for _, c := range changed {
+		found[c.(string)] = true
+	}
+	if !found["locales/fr.json"] || !found["locales/en.json"] {
+		t.Fatalf("changed_files = %v, want both edited source files", changed)
+	}
+}
+
+// TestProductDocsCatalogIngestFailsLoudly pins the one behaviour a front door
+// must never have: guessing. A missing catalog, an unknown product or an
+// entry with no product_dir has to stop the run, because the alternative is
+// documenting the wrong directory.
+func TestProductDocsCatalogIngestFailsLoudly(t *testing.T) {
+	requireGitPython(t)
+
+	ws := t.TempDir()
+	gitIn(t, ws, "init", "-q", "-b", "main")
+	catalogFixture(t, ws, "catalog/demo", "id: demo\nrepos: []\n", `{"id":"demo","repos":[]}`+"\n")
+	writeFile(t, ws, "seed.md", "x\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "seed")
+
+	for _, tc := range []struct {
+		name           string
+		catalog        string
+		product        string
+		wantErrContain string
+	}{
+		{"missing catalog_path", "", "demo", "catalog_path is required"},
+		{"missing product_id", "catalog", "", "product_id is required"},
+		{"catalog does not exist", "nope", "demo", "does not exist"},
+		{"unknown product", "catalog", "ghost", "no catalog entry for product"},
+		{"entry without product_dir", "catalog", "demo", "declares no docs.product_dir"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runExpectingFailure(t, ingestCommand(t, ws, tc.catalog, tc.product, t.TempDir()), tc.wantErrContain)
+		})
+	}
+}
+
+type hintsOut struct {
+	Pages          []string         `json:"pages"`
+	PageCount      int              `json:"page_count"`
+	Hints          []map[string]any `json:"hints"`
+	DeadLinkCount  int              `json:"dead_link_count"`
+	OrphanCount    int              `json:"orphan_count"`
+	UnmappedCount  int              `json:"unmapped_surface_count"`
+	HintsNote      string           `json:"hints_note"`
+	EditorialFiles []string         `json:"editorial_files"`
+	Mode           string           `json:"mode"`
+}
+
+func hintsCommand(t *testing.T, ws, productDir, surfaces string) string {
+	t.Helper()
+	return resolveCommand(t, toolCommand(t, "product-docs/main.bot", "scan_hints"), map[string]string{
+		"vars.workspace_dir":  ws,
+		"input.product_dir":   productDir,
+		"input.surfaces":      surfaces,
+		"vars.editorial_dir":  ".product-docs",
+		"vars.dismissed_path": "",
+		"vars.max_hints":      "120",
+		"vars.mode":           "full",
+		"vars.diff_since":     "",
+	})
+}
+
+// TestProductDocsScanHints pins the advisory producer's signals. In a
+// hub-and-step model the navigation IS the product, so an unreachable page
+// and a dead link are real defects — and a surface the catalog declares that
+// no page covers is the gap the bot exists to close.
+func TestProductDocsScanHints(t *testing.T) {
+	requireGitPython(t)
+
+	ws := t.TempDir()
+	gitIn(t, ws, "init", "-q", "-b", "main")
+	writeFile(t, ws, "docs/demo/README.md", "# Demo\n\n- [Espace gestionnaire](gestionnaire/README.md)\n")
+	writeFile(t, ws, "docs/demo/gestionnaire/README.md",
+		"# Espace gestionnaire\n\n- [Déposer](deposer.md)\n- [Disparue](disparue.md)\n")
+	writeFile(t, ws, "docs/demo/gestionnaire/deposer.md", "# Déposer\n\nCliquez sur **Envoyer**.\n")
+	writeFile(t, ws, "docs/demo/gestionnaire/orpheline.md", "# Orpheline\n\nAucune page ne me lie.\n")
+	writeFile(t, ws, ".product-docs/modele.md", "# Modèle local\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "seed")
+
+	var got hintsOut
+	runJSON(t, hintsCommand(t, ws, "docs/demo", `[{"name":"Espace gestionnaire"},{"name":"Espace citoyen"}]`), &got)
+
+	if got.PageCount != 4 {
+		t.Fatalf("page_count = %d, want 4: %v", got.PageCount, got.Pages)
+	}
+	kinds := map[string][]string{}
+	for _, h := range got.Hints {
+		kinds[h["kind"].(string)] = append(kinds[h["kind"].(string)], h["value"].(string))
+	}
+	if got.DeadLinkCount != 1 || len(kinds["dead_link"]) != 1 || kinds["dead_link"][0] != "disparue.md" {
+		t.Fatalf("dead_link hints = %v (count %d), want exactly disparue.md", kinds["dead_link"], got.DeadLinkCount)
+	}
+	if got.OrphanCount != 1 || !strings.HasSuffix(kinds["orphan_page"][0], "orpheline.md") {
+		t.Fatalf("orphan_page hints = %v, want exactly orpheline.md (README/index pages are never orphans)", kinds["orphan_page"])
+	}
+	if got.UnmappedCount != 1 || kinds["unmapped_surface"][0] != "Espace citoyen" {
+		t.Fatalf("unmapped_surface hints = %v, want exactly the surface no page mentions", kinds["unmapped_surface"])
+	}
+	if len(got.EditorialFiles) != 1 || !strings.HasSuffix(got.EditorialFiles[0], "modele.md") {
+		t.Fatalf("editorial_files = %v, want the docs repo's own .product-docs/ override", got.EditorialFiles)
+	}
+	if !strings.Contains(got.HintsNote, "AUTHORITATIVE") {
+		t.Fatalf("hints_note does not tell the campaign the docs repo's editorial line outranks the bundle defaults: %q", got.HintsNote)
+	}
+}
+
+// TestProductDocsScanHintsBootstraps pins the empty-tree behaviour: a product
+// with no page yet is not an error and not a silent no-op — it is the
+// bootstrap pass, and the note has to say so or the campaign reads an empty
+// hint list as "nothing to do".
+func TestProductDocsScanHintsBootstraps(t *testing.T) {
+	requireGitPython(t)
+
+	ws := t.TempDir()
+	gitIn(t, ws, "init", "-q", "-b", "main")
+	writeFile(t, ws, "seed.md", "x\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "seed")
+
+	var got hintsOut
+	runJSON(t, hintsCommand(t, ws, "docs/demo", "[]"), &got)
+
+	if got.PageCount != 0 {
+		t.Fatalf("page_count = %d on an empty product tree, want 0", got.PageCount)
+	}
+	if !strings.Contains(got.HintsNote, "BOOTSTRAP") {
+		t.Fatalf("hints_note on an empty product tree = %q, want it to name the bootstrap pass", got.HintsNote)
+	}
+	if !strings.Contains(got.HintsNote, "no editorial override") {
+		t.Fatalf("hints_note does not report that the bundle defaults apply: %q", got.HintsNote)
+	}
+}
+
+type lintOut struct {
+	LintOK      bool             `json:"lint_ok"`
+	Violations  []map[string]any `json:"violations"`
+	Count       int              `json:"violation_count"`
+	PagesLinted int              `json:"pages_linted"`
+	Log         string           `json:"log"`
+}
+
+func lintCommand(t *testing.T, ws, productDir, rules, extra string) string {
+	t.Helper()
+	return resolveCommand(t, toolCommand(t, "product-docs/main.bot", "page_lint"), map[string]string{
+		"vars.workspace_dir":            ws,
+		"input.product_dir":             productDir,
+		"vars.lint_rules":               rules,
+		"vars.extra_forbidden_headings": extra,
+	})
+}
+
+const allLintRules = "html_comments,sources_box,clarify_section,technical_annex"
+
+// TestProductDocsPageLint pins the EDITORIAL gate — the one truth oracle on
+// the artifact this bot actually ships. A published page is read by the
+// product's users; it carries no trace of how it was produced.
+func TestProductDocsPageLint(t *testing.T) {
+	requireGitPython(t)
+
+	t.Run("clean page passes", func(t *testing.T) {
+		ws := t.TempDir()
+		writeFile(t, ws, "docs/demo/README.md",
+			"# Demo\n\nLe gestionnaire dépose une demande.\n\n"+
+				"{% hint style=\"warning\" %}\nCette action est irréversible.\n{% endhint %}\n\n"+
+				"Le délai est de 30 jours [à confirmer].\n")
+		var got lintOut
+		runJSON(t, lintCommand(t, ws, "docs/demo", allLintRules, ""), &got)
+		if !got.LintOK {
+			t.Fatalf("a clean page was rejected: %+v", got.Violations)
+		}
+		if got.PagesLinted != 1 {
+			t.Fatalf("pages_linted = %d, want 1", got.PagesLinted)
+		}
+		if got.Log != "" {
+			t.Fatalf("a green lint must produce no log, got %q", got.Log)
+		}
+	})
+
+	t.Run("each forbidden artefact is caught", func(t *testing.T) {
+		ws := t.TempDir()
+		writeFile(t, ws, "docs/demo/notes.md", ""+
+			"# Déposer\n\n"+
+			"<!-- TODO: vérifier le délai -->\n\n"+
+			"## Sources\n\n- locales/fr.json\n\n"+
+			"## Points à clarifier\n\n- Qui valide ?\n\n"+
+			"## Annexe : Correspondance technique\n\n- statut → enum Status\n")
+		var got lintOut
+		runJSON(t, lintCommand(t, ws, "docs/demo", allLintRules, ""), &got)
+
+		if got.LintOK {
+			t.Fatalf("a page carrying every forbidden artefact passed the lint")
+		}
+		byRule := map[string]int{}
+		for _, v := range got.Violations {
+			byRule[v["rule"].(string)]++
+		}
+		for _, rule := range []string{"html_comments", "sources_box", "clarify_section", "technical_annex"} {
+			if byRule[rule] == 0 {
+				t.Errorf("rule %s did not fire: %+v", rule, got.Violations)
+			}
+		}
+		// The log is what reaches the next pass: it must name the page, the
+		// line and the rule, or the campaign cannot remove exactly them.
+		if !strings.Contains(got.Log, "notes.md:3") || !strings.Contains(got.Log, "html_comments") {
+			t.Fatalf("the fail_log does not locate the violations precisely: %q", got.Log)
+		}
+	})
+
+	t.Run("a Sources hint box is caught", func(t *testing.T) {
+		ws := t.TempDir()
+		writeFile(t, ws, "docs/demo/box.md",
+			"# Déposer\n\n{% hint style=\"info\" %}\nSources : locales/fr.json, routes.rb\n{% endhint %}\n")
+		var got lintOut
+		runJSON(t, lintCommand(t, ws, "docs/demo", allLintRules, ""), &got)
+		if got.LintOK {
+			t.Fatalf("a hint box carrying a source reference passed the lint")
+		}
+		if got.Violations[0]["rule"] != "sources_box" {
+			t.Fatalf("violation rule = %v, want sources_box", got.Violations[0]["rule"])
+		}
+	})
+
+	t.Run("a rule dropped from lint_rules stops firing", func(t *testing.T) {
+		ws := t.TempDir()
+		writeFile(t, ws, "docs/demo/notes.md", "# Déposer\n\n<!-- note -->\n\n## Sources\n\n- x\n")
+		var got lintOut
+		runJSON(t, lintCommand(t, ws, "docs/demo", "sources_box", ""), &got)
+		if got.LintOK {
+			t.Fatalf("the still-enabled sources_box rule did not fire")
+		}
+		for _, v := range got.Violations {
+			if v["rule"] == "html_comments" {
+				t.Fatalf("html_comments fired although it was dropped from lint_rules: %+v", got.Violations)
+			}
+		}
+	})
+
+	t.Run("extra_forbidden_headings extends the gate", func(t *testing.T) {
+		ws := t.TempDir()
+		writeFile(t, ws, "docs/demo/p.md", "# Déposer\n\n## Notes internes\n\n- x\n")
+		var got lintOut
+		runJSON(t, lintCommand(t, ws, "docs/demo", allLintRules, "Notes internes"), &got)
+		if got.LintOK {
+			t.Fatalf("an operator-declared forbidden heading did not fire")
+		}
+		if got.Violations[0]["rule"] != "extra_forbidden_heading" {
+			t.Fatalf("violation rule = %v, want extra_forbidden_heading", got.Violations[0]["rule"])
+		}
+	})
+}
+
+type scopeOutPD struct {
+	ScopeOK    bool     `json:"scope_ok"`
+	OutOfScope []string `json:"out_of_scope"`
+	Log        string   `json:"log"`
+}
+
+// TestProductDocsScopeCheck pins the writeable set. Prody runs in a docs repo
+// that may hold OTHER products and the team's own editorial skills: the gate
+// has to be scoped to this product's directory, not merely to `.md`.
+func TestProductDocsScopeCheck(t *testing.T) {
+	requireGitPython(t)
+
+	command := toolCommand(t, "product-docs/main.bot", "scope_check")
+	run := func(t *testing.T, ws, productDir string) scopeOutPD {
+		t.Helper()
+		var got scopeOutPD
+		runJSON(t, resolveCommand(t, command, map[string]string{
+			"vars.workspace_dir": ws,
+			"input.product_dir":  productDir,
+		}), &got)
+		return got
+	}
+
+	newDocsRepo := func(t *testing.T) string {
+		ws := t.TempDir()
+		gitIn(t, ws, "init", "-q", "-b", "main")
+		writeFile(t, ws, "documentation_produits/demo/README.md", "# Demo\n")
+		writeFile(t, ws, "documentation_produits/autre/README.md", "# Autre\n")
+		writeFile(t, ws, ".product-docs/modele.md", "# Modèle\n")
+		gitIn(t, ws, "add", "-A")
+		gitIn(t, ws, "commit", "-q", "-m", "seed")
+		return ws
+	}
+	prodyCommit := func(t *testing.T, ws, msg string) {
+		gitIn(t, ws, "add", "-A")
+		gitIn(t, ws, "commit", "-q", "-m", msg+"\n\nBot: product-docs\nProduct-Docs-Sources: demo-src@deadbeef")
+	}
+
+	t.Run("pages under the product dir are in scope", func(t *testing.T) {
+		ws := newDocsRepo(t)
+		writeFile(t, ws, "documentation_produits/demo/gestionnaire/deposer.md", "# Déposer\n")
+		prodyCommit(t, ws, "docs(demo): déposer")
+		got := run(t, ws, "documentation_produits/demo")
+		if !got.ScopeOK {
+			t.Fatalf("a page under the product dir was flagged out of scope: %v", got.OutOfScope)
+		}
+	})
+
+	t.Run("another product's pages are out of scope", func(t *testing.T) {
+		ws := newDocsRepo(t)
+		writeFile(t, ws, "documentation_produits/autre/README.md", "# Autre (touché à tort)\n")
+		prodyCommit(t, ws, "docs(autre): oops")
+		got := run(t, ws, "documentation_produits/demo")
+		if got.ScopeOK {
+			t.Fatalf("a page belonging to ANOTHER product passed the writeable-set gate")
+		}
+		if !strings.Contains(got.Log, "documentation_produits/autre/README.md") {
+			t.Fatalf("the fail_log does not name the offending path: %q", got.Log)
+		}
+	})
+
+	t.Run("the docs repo's own editorial skills are out of scope", func(t *testing.T) {
+		ws := newDocsRepo(t)
+		writeFile(t, ws, ".product-docs/modele.md", "# Modèle (réécrit par le bot)\n")
+		prodyCommit(t, ws, "docs: oops")
+		got := run(t, ws, "documentation_produits/demo")
+		if got.ScopeOK {
+			t.Fatalf("the bot rewrote the product team's own editorial line and the gate approved it")
+		}
+	})
+
+	t.Run("a non-markdown file under the product dir is out of scope", func(t *testing.T) {
+		ws := newDocsRepo(t)
+		writeFile(t, ws, "documentation_produits/demo/script.sh", "#!/bin/sh\n")
+		prodyCommit(t, ws, "docs(demo): oops")
+		got := run(t, ws, "documentation_produits/demo")
+		if got.ScopeOK {
+			t.Fatalf("a non-markdown file passed the writeable-set gate")
+		}
+	})
+
+	t.Run("changes present before the run are not attributed to it", func(t *testing.T) {
+		ws := newDocsRepo(t)
+		// Someone else's code commit, landed BEFORE the run started.
+		writeFile(t, ws, "tooling/build.sh", "#!/bin/sh\n")
+		gitIn(t, ws, "add", "-A")
+		gitIn(t, ws, "commit", "-q", "-m", "chore: not the bot's work")
+		// Then the run's own page commit.
+		writeFile(t, ws, "documentation_produits/demo/gestionnaire/deposer.md", "# Déposer\n")
+		prodyCommit(t, ws, "docs(demo): déposer")
+		got := run(t, ws, "documentation_produits/demo")
+		if !got.ScopeOK {
+			t.Fatalf("pre-existing changes were attributed to the run: %v", got.OutOfScope)
+		}
+	})
+}

--- a/bots/product_docs_gates_test.go
+++ b/bots/product_docs_gates_test.go
@@ -423,6 +423,9 @@ func TestProductDocsCatalogIngestRefusesHostileCatalog(t *testing.T) {
 	// silently.
 	t.Run("the credential helper survives the shell", func(t *testing.T) {
 		ws, scratch := newWS(t)
+		// The helper is host-scoped to the docs repo's own origin: declare
+		// one so it exists, and probe it with that same host below.
+		gitIn(t, ws, "remote", "add", "origin", "https://forge/team/docs.git")
 		catalogFixture(t, ws, "catalog/demo",
 			"id: demo\ndocs:\n  product_dir: documentation_produits/demo\n"+
 				"repos:\n  - id: demo-src\n    url: "+source+"\n",
@@ -653,15 +656,16 @@ func TestProductDocsCatalogIngestFailsLoudly(t *testing.T) {
 }
 
 type hintsOut struct {
-	Pages          []string         `json:"pages"`
-	PageCount      int              `json:"page_count"`
-	Hints          []map[string]any `json:"hints"`
-	DeadLinkCount  int              `json:"dead_link_count"`
-	OrphanCount    int              `json:"orphan_count"`
-	UnmappedCount  int              `json:"unmapped_surface_count"`
-	HintsNote      string           `json:"hints_note"`
-	EditorialFiles []string         `json:"editorial_files"`
-	Mode           string           `json:"mode"`
+	Pages           []string         `json:"pages"`
+	PageCount       int              `json:"page_count"`
+	Hints           []map[string]any `json:"hints"`
+	DeadLinkCount   int              `json:"dead_link_count"`
+	OrphanCount     int              `json:"orphan_count"`
+	UnmappedCount   int              `json:"unmapped_surface_count"`
+	HintsNote       string           `json:"hints_note"`
+	EditorialFiles  []string         `json:"editorial_files"`
+	Mode            string           `json:"mode"`
+	IncrementalBase string           `json:"incremental_base"`
 }
 
 func hintsCommand(t *testing.T, ws, productDir, surfaces string) string {
@@ -1316,4 +1320,212 @@ func TestProductDocsScopeCheck(t *testing.T) {
 			t.Fatalf("the log does not name the missing base: %q", got.Log)
 		}
 	})
+}
+
+// TestProductDocsScopeCheckAcceptsAccentedPages pins core.quotePath: this
+// bot's pages are FRENCH and their filenames come from UI wording. With
+// git's default C-quoting, a committed "créer-un-dossier.md" comes back as
+// a quoted octal-escaped string that never ends in .md — a permanent,
+// unfixable scope violation on exactly the pages the bot exists to write.
+func TestProductDocsScopeCheckAcceptsAccentedPages(t *testing.T) {
+	requireGitPython(t)
+	command := toolCommand(t, "product-docs/main.bot", "scope_check")
+
+	ws := t.TempDir()
+	gitIn(t, ws, "init", "-q", "-b", "main")
+	writeFile(t, ws, "documentation_produits/demo/README.md", "# Demo\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "seed")
+	baseOut, err := exec.Command("git", "-C", ws, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse: %v", err)
+	}
+	base := strings.TrimSpace(string(baseOut))
+
+	// One accented page committed (the diff path), one still untracked
+	// (the status -uall path) — both must stay in scope.
+	writeFile(t, ws, "documentation_produits/demo/créer-un-dossier.md", "# Créer\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "docs(demo): créer\n\nBot: product-docs")
+	writeFile(t, ws, "documentation_produits/demo/évolution.md", "# Évolution\n")
+
+	var got scopeOutPD
+	runJSON(t, resolveCommand(t, command, map[string]string{
+		"vars.workspace_dir": ws,
+		"vars.editorial_dir": ".product-docs",
+		"input.product_dir":  "documentation_produits/demo",
+		"input.base_sha":     base,
+	}), &got)
+	if !got.ScopeOK {
+		t.Fatalf("accented page names were flagged out of scope: %v", got.OutOfScope)
+	}
+}
+
+// TestProductDocsScopeCheckFailsClosedWhenGitFails pins the truth oracle's
+// failure mode: a workspace git cannot answer for (not a repository, git
+// missing, a timeout) must FAIL the gate with a reason — never certify
+// scope_ok:true over a tree it did not diff.
+func TestProductDocsScopeCheckFailsClosedWhenGitFails(t *testing.T) {
+	requireGitPython(t)
+	command := toolCommand(t, "product-docs/main.bot", "scope_check")
+
+	ws := t.TempDir() // NOT a git repository
+	var got scopeOutPD
+	runJSON(t, resolveCommand(t, command, map[string]string{
+		"vars.workspace_dir": ws,
+		"vars.editorial_dir": ".product-docs",
+		"input.product_dir":  "documentation_produits/demo",
+		"input.base_sha":     "deadbeefdeadbeef",
+	}), &got)
+	if got.ScopeOK {
+		t.Fatal("the gate certified a workspace whose git calls all failed")
+	}
+	if !strings.Contains(got.Log, "SCOPE GATE UNAVAILABLE") {
+		t.Fatalf("the failure carries no reason: %q", got.Log)
+	}
+}
+
+// TestProductDocsScanHintsIncrementalBootstrapsToFull pins the promised
+// degradation: a FIRST incremental run has no alignment commit to diff
+// since, and relaying mode=incremental with an empty delta tells the
+// campaign "nothing changed" — the opposite of a bootstrap. The honest
+// answer is a full sweep, said out loud in the note.
+func TestProductDocsScanHintsIncrementalBootstrapsToFull(t *testing.T) {
+	requireGitPython(t)
+
+	ws := t.TempDir()
+	gitIn(t, ws, "init", "-q", "-b", "main")
+	writeFile(t, ws, "docs/demo/README.md", "# Demo\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "seed") // no Bot: product-docs trailer anywhere
+
+	var got hintsOut
+	runJSON(t, resolveCommand(t, toolCommand(t, "product-docs/main.bot", "scan_hints"), map[string]string{
+		"vars.workspace_dir":  ws,
+		"input.product_dir":   "docs/demo",
+		"input.surfaces":      `[]`,
+		"vars.editorial_dir":  ".product-docs",
+		"vars.dismissed_path": "",
+		"vars.max_hints":      "120",
+		"vars.mode":           "incremental",
+		"vars.diff_since":     "",
+	}), &got)
+	if got.Mode != "full" {
+		t.Fatalf("a first incremental run relayed mode=%q with base %q — the campaign will read the empty delta as 'nothing changed'", got.Mode, got.IncrementalBase)
+	}
+	if !strings.Contains(got.HintsNote, "BOOTSTRAP") {
+		t.Fatalf("the degradation is silent: %q", got.HintsNote)
+	}
+}
+
+// TestProductDocsScanHintsIncrementalScopedToProduct pins the delta
+// window's product identity: in a multi-product docs repo, a SIBLING
+// product's newer alignment commit must not become this product's base —
+// that narrows the window and hides real drift.
+func TestProductDocsScanHintsIncrementalScopedToProduct(t *testing.T) {
+	requireGitPython(t)
+
+	ws := t.TempDir()
+	gitIn(t, ws, "init", "-q", "-b", "main")
+	writeFile(t, ws, "docs/demo/README.md", "# Demo\n")
+	writeFile(t, ws, "docs/autre/README.md", "# Autre\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "seed")
+	// This product's alignment commit…
+	writeFile(t, ws, "docs/demo/page.md", "# Page\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "docs(demo): align\n\nBot: product-docs")
+	demoOut, _ := exec.Command("git", "-C", ws, "rev-parse", "HEAD").Output()
+	demoSHA := strings.TrimSpace(string(demoOut))
+	// …then a SIBLING product's newer one, then drift on this product.
+	writeFile(t, ws, "docs/autre/page.md", "# Autre page\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "docs(autre): align\n\nBot: product-docs")
+	writeFile(t, ws, "docs/demo/drift.md", "# Drift\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "docs(demo): drift (human)")
+
+	var got hintsOut
+	runJSON(t, resolveCommand(t, toolCommand(t, "product-docs/main.bot", "scan_hints"), map[string]string{
+		"vars.workspace_dir":  ws,
+		"input.product_dir":   "docs/demo",
+		"input.surfaces":      `[]`,
+		"vars.editorial_dir":  ".product-docs",
+		"vars.dismissed_path": "",
+		"vars.max_hints":      "120",
+		"vars.mode":           "incremental",
+		"vars.diff_since":     "",
+	}), &got)
+	if got.IncrementalBase != demoSHA {
+		t.Fatalf("the delta base is %q, not this product's own alignment %q — a sibling's commit narrowed the window", got.IncrementalBase, demoSHA)
+	}
+}
+
+// TestProductDocsAskpassIsHostScoped pins the credential boundary: the
+// forge token belongs to the docs repo's own origin, and the catalog is
+// repo content — hostile-grade. The generated askpass helper must answer
+// ONLY prompts naming the origin host; any other host (including a
+// lookalike suffix domain) gets nothing and the clone fails loudly.
+func TestProductDocsAskpassIsHostScoped(t *testing.T) {
+	requireGitPython(t)
+
+	ws := t.TempDir()
+	gitIn(t, ws, "init", "-q", "-b", "main")
+	gitIn(t, ws, "remote", "add", "origin", "https://forge.example/team/docs.git")
+	scratch := t.TempDir()
+	catalogFixture(t, ws, "catalog/demo",
+		"id: demo\nname: Demo\nproduct_dir: docs/demo\nrepos:\n  - id: src\n    url: https://evil.invalid/src.git\n",
+		`{"id":"demo","name":"Demo","product_dir":"docs/demo","repos":[{"id":"src","url":"https://evil.invalid/src.git"}]}`)
+	writeFile(t, ws, "docs/demo/README.md", "# Demo\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "seed")
+
+	cmd := exec.Command("sh", "-c", ingestCommand(t, ws, "catalog", "demo", scratch))
+	cmd.Env = append(os.Environ(), "GH_TOKEN=sekret-token-value",
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	_, _ = cmd.Output() // the evil clone fails; the helper file is what we assert on
+
+	helper := filepath.Join(scratch, "git-askpass.sh")
+	if _, err := os.Stat(helper); err != nil {
+		t.Fatalf("askpass helper was not written: %v", err)
+	}
+	run := func(prompt string) (string, error) {
+		out, err := exec.Command("sh", helper, prompt).Output()
+		return string(out), err
+	}
+	if out, err := run("Username for 'https://forge.example': "); err != nil || strings.TrimSpace(out) != "x-access-token" {
+		t.Fatalf("the helper refused its own forge (out %q err %v)", out, err)
+	}
+	if out, err := run("Username for 'https://evil.invalid': "); err == nil {
+		t.Fatalf("the helper answered a foreign host: %q", out)
+	}
+	if out, err := run("Password for 'https://x-access-token@evilforge.example': "); err == nil {
+		t.Fatalf("the helper answered a lookalike suffix domain: %q", out)
+	}
+}
+
+// TestProductDocsInventoryStripsInlineURLCredentials pins the one leak
+// path strip_creds did not cover: git echoes the CATALOG's own inline
+// credential (https://user:pass@host/…) verbatim in its clone errors, and
+// that note reaches the campaign prompt, the events and the PR body.
+func TestProductDocsInventoryStripsInlineURLCredentials(t *testing.T) {
+	requireGitPython(t)
+
+	ws := t.TempDir()
+	gitIn(t, ws, "init", "-q", "-b", "main")
+	gitIn(t, ws, "remote", "add", "origin", "https://forge.example/team/docs.git")
+	scratch := t.TempDir()
+	catalogFixture(t, ws, "catalog/demo",
+		"id: demo\nname: Demo\nproduct_dir: docs/demo\nrepos:\n  - id: src\n    url: https://leaky:hunter2@evil.invalid/src.git\n",
+		`{"id":"demo","name":"Demo","product_dir":"docs/demo","repos":[{"id":"src","url":"https://leaky:hunter2@evil.invalid/src.git"}]}`)
+	writeFile(t, ws, "docs/demo/README.md", "# Demo\n")
+	gitIn(t, ws, "add", "-A")
+	gitIn(t, ws, "commit", "-q", "-m", "seed")
+
+	var got ingestOut
+	runJSON(t, ingestCommand(t, ws, "catalog", "demo", scratch), &got)
+	blob, _ := json.Marshal(got.Inventory)
+	if strings.Contains(string(blob), "hunter2") || strings.Contains(string(blob), "leaky:") {
+		t.Fatalf("an inline url credential survived into the inventory: %s", blob)
+	}
 }

--- a/bots/whats-next/iterion-bot-catalog-static.md
+++ b/bots/whats-next/iterion-bot-catalog-static.md
@@ -80,6 +80,7 @@ Walk top-to-bottom; first match wins.
 | "review this PR / branch and just REPORT the issues" — read-only review, posts findings to the board, does NOT fix or commit | `review-pr` |
 | "upgrade dependencies", "patch CVEs", "bump versions", "renovate" — MUTATING (writes package.json / go.mod / lockfiles) | `secured-renovacy` |
 | "audit the docs", "find code↔doc drift", "doc/code alignment", "fix outdated README/CLAUDE.md" | `docs-refresh` |
+| "document what the product does for its users", "functional / business documentation", "doc produit", "the user guide is out of date" — for a NON-TECHNICAL audience, in a DEDICATED docs repo, from one or more source repos named by a product catalog | `product-docs` |
 | "audit the source for vulns", "find injection / SSRF / IDOR / secrets", "OWASP source scan" — DETECTION (writes findings, not fixes) | `sec-audit-source` |
 | "audit dependencies for malware / typosquats / install hooks", "supply-chain check", "post-`npm install` triage" — DETECTION across installed deps | `sec-audit-deps` |
 | architectural choice, hiring, prioritisation meeting, alignment | `""` |
@@ -195,6 +196,36 @@ before you walk the table on a new roadmap item.
   whole-improve-loop / etc. When an operator asks you for a long-horizon
   vision on a mature repo, the right move is often to route to `evolve`
   rather than answer at your own altitude.
+
+### `docs-refresh` (Doki) vs `wiki-gen` (Wikky) vs `product-docs` (Prody) — the three documentation bots
+
+All three write `.md` and commit. They differ on **who reads the
+result**, and secondarily on **where the pages live relative to the
+code**. Settle the audience first; the topology follows.
+
+- `docs-refresh` / Doki: a **developer** audience. It aligns the repo's
+  OWN existing technical docs (README, CLAUDE.md, `docs/**`) against
+  the code, IN PLACE, in the same repo. Repairs stale prose and writes
+  what is missing.
+- `wiki-gen` / Wikky: a **developer** audience too, but it OWNS a
+  parallel artifact — a navigable OKF `wiki/` tree it generates and
+  maintains in the code repo. Reach for it when the repo needs a
+  navigable knowledge base it does not have, not when existing docs
+  need fixing.
+- `product-docs` / Prody: a **business / end-user** audience. It writes
+  what the product does for the people who USE it — role by role,
+  journey by journey, in French — in a **dedicated documentation
+  repository**, grounded in the source code of the N **other**
+  repositories a product catalog names. It never touches those source
+  repos, and it publishes no technical content at all.
+- Tie-break — **audience**: "could a non-developer act on this page?"
+  Yes → Prody. No → Doki or Wikky.
+- Tie-break — **topology**: docs and code in the SAME repo → Doki or
+  Wikky. Docs in their own repo, code in one or more others, with a
+  catalog naming them → Prody (it is the only one that clones sources).
+- Prody needs two inputs with no default: `catalog_path` and
+  `product_id`. If the operator cannot name a product catalog, the work
+  is probably not Prody's — ask before routing.
 
 ### `ultra11y` (Ally) vs `rgaa-audit` (Acci) — who FINDS the non-conformity
 

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -306,6 +306,7 @@ dispatcher routes on it), never the persona.
 | Morphy | `modernize` |
 | Nested Subbots Demo | `nested-subbots-demo` |
 | Pipeline Board Demo | `pipeline-board-demo` |
+| Prody | `product-docs` |
 | Revi (converse) | `revi-converse` |
 | Envy | `review-env` |
 | Revi | `review-pr` |
@@ -966,6 +967,68 @@ human / subbot only — no API keys, runs in seconds.
   produced-elements aggregation (image/audio preview) across the whole run
   tree. Not a production workflow.
 - **Path**: `examples/pipeline-board-demo/main.bot`
+
+### `product-docs` — Prody
+
+Functional documentation bot — one capable agent writes and maintains
+the BUSINESS-AUDIENCE documentation of a product ("what it does for
+its users") inside a DEDICATED documentation repository, grounded in
+the source code of the N repositories a product catalog names.
+
+It resolves the product from a catalog YAML (`catalog_path` +
+`product_id`), shallow-clones every source repo out of the docs
+worktree, redacts secret-bearing files from those clones, then reads
+what the sources actually implement — user-facing templates, i18n
+catalogs, form and validation rules, routes, API contracts, any
+framework — and writes the product's pages: a hub per user role or
+journey, one sub-page per step. Every page lands as its own
+`docs(...)` commit carrying a `Bot: product-docs` trailer and a
+`Product-Docs-Sources: <repo>@<sha>` trailer recording exactly which
+source commits it was written against.
+
+Sourced facts or `[à confirmer]` — never an invented business rule.
+Human-validated prose is preserved and touched only where the code
+contradicts it. A repository it could not clone is declared as a hole
+in the report, never documented from inference.
+
+The determinism is TRUTH-only: a scope gate fails the run if anything
+outside `<product_dir>/**/*.md` changed, an EDITORIAL LINT gate fails
+it if a published page still carries working notes, and convergence
+is those two gates ∧ the campaign's honest `docs_aligned` contract —
+nothing else. A deterministic scan runs each pass as an ADVISORY
+hints producer (dead links, orphan pages, catalog surfaces no page
+covers): help the agent is free to contradict, never an obligation.
+
+EDITORIAL SOVEREIGNTY: the bundle ships generic default editorial
+skills in French (documentary model, GitBook blocks, glossary, tone),
+but when the docs repo publishes its own `.product-docs/*.md` those
+are authoritative and override the defaults. The product team owns
+its editorial line; the bot brings a default, not a house style.
+
+Opt-in delivery: open_mr=true pushes the page series and opens ONE
+pull request at the end of the run — as a DRAFT by default, because
+functional documentation is validated by the product owners on the
+forge and marking it ready is their act, not the bot's.
+
+- **Use when**:
+  Use to generate or maintain the FUNCTIONAL, non-technical
+  documentation of a product — what it does for its users, role by
+  role and journey by journey — when that documentation lives in its
+  OWN repository and the code lives in one or more OTHER repositories
+  named by a product catalog. Run it in the docs repo with
+  `catalog_path` + `product_id`. It writes `.md` under the product's
+  directory only, and never touches the source repositories.
+  
+  NOT for technical documentation living next to the code (that is
+  docs-refresh / Doki, which aligns a repo's own README / docs/ in
+  place), and NOT for a technical knowledge wiki (that is wiki-gen /
+  Wikky, which owns a `wiki/` tree in the code repo). The
+  distinguisher is the AUDIENCE first — a product's users, not its
+  developers — and the topology second: docs repo here, N source
+  repos there.
+- **Triggers**: product-docs, functional-docs, doc-produit
+- **Vars**: `catalog_path` (string), `clone_depth` (int), `diff_since` (string), `dismissed_path` (string), `editorial_dir` (string), `extra_forbidden_headings` (string), `lint_rules` (string), `max_hints` (int), `max_passes` (int), `mode` (string), `mr_base` (string), `mr_branch` (string), `mr_draft` (bool), `open_mr` (bool), `product_id` (string), `scope_notes` (string), `scratch_dir` (string), `secret_globs` (string), `source_issue_ref` (string), `workspace_dir` (string)
+- **Path**: `bots/product-docs/main.bot`
 
 ### `revi-converse` — Revi (converse)
 

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -80,6 +80,7 @@ Walk top-to-bottom; first match wins.
 | "review this PR / branch and just REPORT the issues" — read-only review, posts findings to the board, does NOT fix or commit | `review-pr` |
 | "upgrade dependencies", "patch CVEs", "bump versions", "renovate" — MUTATING (writes package.json / go.mod / lockfiles) | `secured-renovacy` |
 | "audit the docs", "find code↔doc drift", "doc/code alignment", "fix outdated README/CLAUDE.md" | `docs-refresh` |
+| "document what the product does for its users", "functional / business documentation", "doc produit", "the user guide is out of date" — for a NON-TECHNICAL audience, in a DEDICATED docs repo, from one or more source repos named by a product catalog | `product-docs` |
 | "audit the source for vulns", "find injection / SSRF / IDOR / secrets", "OWASP source scan" — DETECTION (writes findings, not fixes) | `sec-audit-source` |
 | "audit dependencies for malware / typosquats / install hooks", "supply-chain check", "post-`npm install` triage" — DETECTION across installed deps | `sec-audit-deps` |
 | architectural choice, hiring, prioritisation meeting, alignment | `""` |
@@ -195,6 +196,36 @@ before you walk the table on a new roadmap item.
   whole-improve-loop / etc. When an operator asks you for a long-horizon
   vision on a mature repo, the right move is often to route to `evolve`
   rather than answer at your own altitude.
+
+### `docs-refresh` (Doki) vs `wiki-gen` (Wikky) vs `product-docs` (Prody) — the three documentation bots
+
+All three write `.md` and commit. They differ on **who reads the
+result**, and secondarily on **where the pages live relative to the
+code**. Settle the audience first; the topology follows.
+
+- `docs-refresh` / Doki: a **developer** audience. It aligns the repo's
+  OWN existing technical docs (README, CLAUDE.md, `docs/**`) against
+  the code, IN PLACE, in the same repo. Repairs stale prose and writes
+  what is missing.
+- `wiki-gen` / Wikky: a **developer** audience too, but it OWNS a
+  parallel artifact — a navigable OKF `wiki/` tree it generates and
+  maintains in the code repo. Reach for it when the repo needs a
+  navigable knowledge base it does not have, not when existing docs
+  need fixing.
+- `product-docs` / Prody: a **business / end-user** audience. It writes
+  what the product does for the people who USE it — role by role,
+  journey by journey, in French — in a **dedicated documentation
+  repository**, grounded in the source code of the N **other**
+  repositories a product catalog names. It never touches those source
+  repos, and it publishes no technical content at all.
+- Tie-break — **audience**: "could a non-developer act on this page?"
+  Yes → Prody. No → Doki or Wikky.
+- Tie-break — **topology**: docs and code in the SAME repo → Doki or
+  Wikky. Docs in their own repo, code in one or more others, with a
+  catalog naming them → Prody (it is the only one that clones sources).
+- Prody needs two inputs with no default: `catalog_path` and
+  `product_id`. If the operator cannot name a product catalog, the work
+  is probably not Prody's — ask before routing.
 
 ### `ultra11y` (Ally) vs `rgaa-audit` (Acci) — who FINDS the non-conformity
 

--- a/docs/adr/091-product-docs-editorial-sovereignty-and-git-native-source-deltas.md
+++ b/docs/adr/091-product-docs-editorial-sovereignty-and-git-native-source-deltas.md
@@ -1,0 +1,164 @@
+# ADR-091 — Editorial sovereignty in the target repo, and git-native cross-repo source deltas
+
+- **Status**: Accepted
+- **Date**: 2026-08-25
+- **Applies to**: `bots/product-docs` (Prody)
+- **Extends**: CLAUDE.md "Catalog bots are repo-agnostic" + "Universal code bots — stack knowledge lives in skills"; the git-native philosophy (§4)
+- **Neighbours**: ADR-058 (one campaign agent + a deterministic gate), ADR-044 (deterministic gates never an LLM judgment)
+
+## Context
+
+`product-docs` is the first catalog bot whose **workspace and subject
+matter are in different repositories**: it runs inside a dedicated
+documentation repository and writes about code that lives in N *other*
+repositories, named by a product catalog. It is also the first whose
+output is read by **non-developers** — the product's own users — which
+makes the editorial line (structure, allowed blocks, vocabulary, tone) a
+load-bearing part of the deliverable rather than a matter of taste.
+
+Two decisions follow from that shape, and neither is obvious from the
+code alone.
+
+### 1. Where does the editorial line live?
+
+Every other catalog bot ships its discipline in its own `skills/`: the
+bundle is the authority, and a target repo that wants something else has
+no say. Applied here that would mean iterion dictating the house style of
+someone else's user-facing documentation — the structure of their pages,
+the words their product uses, the tone their users read. Different
+products, run by different teams, legitimately disagree about all three,
+and the team that owns the product is the one that knows.
+
+The alternatives considered:
+
+- **Bundle-only skills** (the convention). Uniform output, zero
+  configuration — and wrong for any team with an existing editorial
+  charter. Their first run would rewrite their pages into iterion's
+  shape, which is precisely the "destroyed human work" failure the
+  campaign contract otherwise forbids.
+- **Vars carrying the editorial line.** `--var tone=…`,
+  `--var model=hub-and-step`. Editorial guidance is prose, not a flag;
+  a var big enough to hold it is a file with worse ergonomics, invisible
+  to review, and re-typed on every launch.
+- **A closed set of named editorial presets.** The Nth-variant smell:
+  the second product that fits none of them costs a bundle PR.
+
+### 2. Where does "what changed in the sources" live?
+
+Incremental mode needs to know which source commits the documentation
+was last written against. `docs-refresh` answers the same question with
+a commit trailer (`Bot: docs-refresh`) because the docs and the code
+share one history — one `git log` sees both. Here they do not: the docs
+repo's history says nothing about the source repos' shas, and the source
+clones are throwaway (a fresh scratch dir on every cloud pod).
+
+The obvious answer is a side-car state file in the scratch dir mapping
+repo → last-documented sha. It is also the answer that loses the state
+exactly when it matters: a run that dies mid-pass, a wiped scratch, a
+different machine, a cloud pod that never sees the previous run's disk.
+Worse, it decouples the record from the work — the file can claim a sha
+whose pages were never committed, and nothing reconciles the two.
+
+## Decision
+
+### 1. The docs repository owns its editorial line; the bundle ships a default
+
+The campaign loads, in this authority order:
+
+1. **`<workspace>/<editorial_dir>/*.md`** (default `.product-docs/`) —
+   the docs repo's own editorial skills. **Authoritative.** Where they
+   disagree with anything the bundle says, they win, silently and
+   completely.
+2. **The bundle's `skills/`** — `modele-documentaire`, `blocs-gitbook`,
+   `glossaire-produit`, `ton-et-style`: a generic default, in French,
+   used for whatever the docs repo did not specify. Each one opens by
+   declaring itself a default the docs repo may override.
+
+`scan_hints` enumerates the overrides in force and reports them on every
+pass, so the campaign is told which authority it is under rather than
+having to discover it; the writeable-set gate **excludes**
+`<editorial_dir>` so the bot can never rewrite the charter it is
+governed by.
+
+What stays in the bundle, non-overridable, is the part that is not
+editorial taste but product-documentation *integrity*: sourced facts or
+`[à confirmer]` and never an invented business rule; human-validated
+prose preserved; a repository that could not be read declared as a hole;
+and the four working-note artefacts the deterministic `page_lint` gate
+refuses. A docs repo may restyle every page; it may not authorise the
+bot to invent.
+
+### 2. Source deltas are anchored on a commit trailer, in the docs repo
+
+Every in-stride commit carries **two** trailers:
+
+```
+Bot: product-docs
+Product-Docs-Sources: <repo-id>@<sha>,<repo-id>@<sha>,…
+```
+
+`catalog_ingest` reads the newest `Product-Docs-Sources:` line out of the
+**docs repo's own history** and diffs each fresh clone from the shas it
+records. The consequences are the point:
+
+- **The record and the work are the same object.** A stamp exists only
+  because a page was committed against those exact source commits. There
+  is no way for the two to disagree.
+- **Nothing to lose.** A crashed run, a wiped scratch dir, a fresh cloud
+  pod, another machine, a different operator: `git log` in the docs repo
+  is the whole state.
+- **It is reviewable.** A human reading the PR can see which source
+  commits each page was written against.
+
+When a shallow clone cannot reach a recorded commit, the ingest attempts
+a targeted `git fetch --depth 1 <sha>` and, failing that, reports
+`delta_unavailable` with the reason on the inventory entry — the campaign
+is told to treat the pass as a full survey. **A delta that could not be
+computed is never reported as an empty delta**, which the campaign would
+read as "nothing changed" and act on by writing nothing.
+
+## Consequences
+
+**Gained**
+
+- A product team adopts the bot without adopting iterion's house style,
+  and their charter is versioned and reviewed in their own repo.
+- Adding an editorial dimension the bundle never anticipated costs a
+  markdown file in the docs repo — no bundle PR, no engine PR, no enum.
+- Incremental mode works on the first cloud run, on a machine that has
+  never seen the product before, with no durable state outside git
+  (which also keeps the bot clear of the "filesystem-only durable seam"
+  hole ADR-073 had to close retroactively).
+
+**Paid**
+
+- **Two authorities to reason about.** A page that looks wrong may be
+  the docs repo's charter being honoured. The run report names the
+  overrides in force so the answer is one line away, but the ambiguity
+  is real and inherent.
+- **An override can be bad advice.** A poorly-written `.product-docs/`
+  file degrades the output, and iterion cannot lint prose it deliberately
+  does not own. The integrity rules above are the floor that keeps a bad
+  charter from producing *false* documentation rather than merely ugly
+  documentation.
+- **A dropped trailer costs the next run its base.** If the campaign
+  omits `Product-Docs-Sources:`, the next incremental run finds an older
+  stamp (or none) and degrades to a wider survey — expensive, never
+  wrong. The contract states both trailers as required in three places
+  (system prompt, user prompt, playbook skill); the failure mode is
+  deliberately the safe one.
+- **The stamp names only readable repos.** A repo that was `degraded`
+  this run contributes no sha, so the next run re-reads it from scratch.
+  That is the intended behaviour: there is no documented baseline for a
+  repository nobody could read.
+
+## Alternatives rejected
+
+| Alternative | Why not |
+|---|---|
+| Editorial line in the bundle only | Dictates a house style to teams who own their product's voice; first run rewrites their pages |
+| Editorial line as launch vars | Prose does not fit a flag; invisible to review; re-typed every launch |
+| A closed set of editorial presets | Nth-variant smell — the second unfitting product costs a bundle PR |
+| Side-car scratch file for source shas | Lost on a crash, a wiped scratch, or any other machine; can disagree with what was actually committed |
+| A state file committed into the docs repo | A second source of truth next to the commits, and a file the writeable-set gate would have to special-case |
+| Full clones so the delta is always computable | Pays a full history for every source repo on every run to avoid an honest, reported degradation |

--- a/docs/adr/092-product-docs-editorial-sovereignty-and-git-native-source-deltas.md
+++ b/docs/adr/092-product-docs-editorial-sovereignty-and-git-native-source-deltas.md
@@ -1,4 +1,4 @@
-# ADR-091 — Editorial sovereignty in the target repo, and git-native cross-repo source deltas
+# ADR-092 — Editorial sovereignty in the target repo, and git-native cross-repo source deltas
 
 - **Status**: Accepted
 - **Date**: 2026-08-25

--- a/docs/bot-runs/README.md
+++ b/docs/bot-runs/README.md
@@ -64,6 +64,7 @@ first bilan for a bot lands.
 | Endy | `e2e-coverage` | matrix-anchored e2e coverage completion (claims-verified gate) | [e2e-coverage.md](e2e-coverage.md) |
 | Doki | `docs-refresh` | docs↔code convergence loop | [docs-refresh.md](docs-refresh.md) |
 | Wikky | `wiki-gen` | navigable OKF wiki generator/maintainer | [wiki-gen.md](wiki-gen.md) |
+| Prody | `product-docs` | functional (business-audience) product docs, docs repo ← N source repos | [product-docs.md](product-docs.md) |
 | Revi | `review-pr` | read-only reviewer (mono default; cross-family dual opt-in) | [review-pr.md](review-pr.md) |
 | Revi (converse) | `revi-converse` | conversational PR follow-up | _not yet_ |
 | Seki | `sec-audit-source` | source SAST audit | [sec-audit-source.md](sec-audit-source.md) |

--- a/docs/bot-runs/product-docs.md
+++ b/docs/bot-runs/product-docs.md
@@ -1,0 +1,86 @@
+[← Bot runs](README.md)
+
+# product-docs (Prody) — run bilans
+
+Functional, business-audience product documentation generated and maintained
+in a dedicated docs repository from a multi-repo product catalog. Newest run
+first.
+
+## 2026-08-25 — first dogfood, fixture product (run 01a03a6a)
+
+- **Status:** validated (converged), with one real bot bug found and fixed.
+- **Versions:** bot 1.0.0 · iterion `fd9c5e611` (worktree build).
+- **Method:** `claude_code` / `claude-opus-5`, two campaign passes.
+  Fixture: a docs repo (`/tmp/prody-dogfood/docs`, empty product tree, one
+  local editorial override) and one source repo (`subvention-app`: a grant
+  request service — FR i18n catalog, two role-scoped route files, one form
+  template, a `.env`). Catalog `catalog/demo.yml` naming a single repo by
+  local `url:`. Vars: `catalog_path=catalog/demo.yml product_id=demo
+  max_passes=2 scratch_dir=/tmp/prody-dogfood/scratch`. Flags:
+  `--merge-into none`, `--sandbox none` (no container runtime on the host),
+  `open_mr` left false.
+- **Result:** converged on pass 2. 21 commits, one page per commit, all
+  carrying both `Bot: product-docs` and
+  `Product-Docs-Sources: subvention-app@e7bb04f1`. 8 pages: product home,
+  glossary, two role hubs (`espace-demandeur`, `espace-instructeur`), two
+  step pages each. `page_lint` green over all 8 (0 violations); `scope_check`
+  green; `gate.converged = true`. ≈$20.6 (13.6 + 7.0), ≈50 min wall clock.
+  Commits landed on `iterion/run/01a03a6a…` (merge deliberately skipped).
+- **Value:** high, and specifically the value the bot was built for. From an
+  EMPTY product directory the campaign produced a role-then-journey page set
+  a business reader can follow, in French, grounded file by file: statuses
+  from `fr.json`, the SIRET/50 000 €/10 Mo constraints from the route
+  validators, the "réponse sous 30 jours" promise from the mail body, the
+  mandatory refusal motive from the refuse handler. Unprovable facts were
+  marked `[à confirmer]` in-sentence rather than invented or dropped — pass 2
+  spent all 5 of its commits doing exactly that re-grounding.
+  - The **docs repo's own editorial rule was obeyed over the bundle default**:
+    `.product-docs/modele.md` demanded that hub pages open with
+    `## À qui s'adresse cette page`, and both hubs do — while the product home
+    (not a hub, per the bundle's own taxonomy) correctly does not. Editorial
+    sovereignty (ADR-091) works end to end.
+  - It found a genuine **source** defect and said so instead of documenting a
+    promise the code does not keep: `instruction.js` comments that accepting
+    "notifies the applicant", no mailer call exists, and `fr.json` has no
+    acceptance/refusal message body. Reported as `is_product_bug: true` and
+    filed on the board rather than papered over.
+  - It refused to resolve an ambiguity it could not prove (the worklist reads
+    `deposee`, both decision handlers call `transition(id, 'instruction', …)`,
+    and `transition` is defined in none of the cloned files): it documented
+    both ends and marked the passage between them.
+- **Findings / misses:**
+  - The redaction is honest but blind by construction: the inventory reported
+    "1 secret-bearing file redacted" and the campaign flagged, unprompted,
+    that it therefore could not know what functional area that file covered.
+    Right behaviour; worth remembering that a product whose config carries
+    functional truth will be under-documented by design.
+  - `catalog_ingest` failed LOUDLY and usefully three times before the run
+    started (missing YAML parser path, unwritable scratch root) — each message
+    named the cause and the remedy. No silent degradation observed.
+- **Engine / bot hardening:** one real bug, found only because this was a live
+  run. iterion mirrors the bundle's skills into `<workspace>/.claude/` at run
+  start and again on every resume; `scope_check` collected untracked paths
+  from `git status` and judged that engine-owned tree against the writeable
+  set, so a pass that wrote 8 pages and 16 clean commits was failed on
+  `.claude/`. Worse than a false positive: the agent then **deleted the
+  engine's own skill mirror** to satisfy the gate. Fixed by excluding
+  `.claude/` in `scope_check` (surgically — an untracked tree that is not the
+  mirror still fails), with both halves pinned in
+  `bots/product_docs_gates_test.go`. docs-refresh escapes the same class only
+  by accident: its writeable set is "any `.md`", which happens to admit the
+  mirrored skills.
+- **Lessons for next run:**
+  - Budget the campaign properly: `--max-cost-usd 15` killed pass 1 at
+    `scope_check` after the agent had already spent $13.57 and committed
+    everything (the 90% hard limit blocks the next node). A single Prody pass
+    on a one-repo product costs $7–14; budget `max_passes × ~15` or leave the
+    bot's own 300 ceiling alone. Resuming with `--max-cost-usd 45` picked up
+    exactly at `scope_check` and lost nothing.
+  - `iterion resume` has no `--sandbox` flag (only `iterion run` does) — use
+    `ITERION_SANDBOX_DEFAULT=none` on a host with no container runtime.
+  - Two passes is the natural shape on a bootstrap: pass 1 authors the page
+    set, pass 2 re-grounds it. `max_passes=2` was enough here; a multi-repo
+    product will want the default 4.
+  - The fixture is worth keeping: an empty product tree + one small
+    role-shaped source repo exercises hub/step authoring, glossary,
+    `[à confirmer]` discipline and the editorial override in under an hour.

--- a/docs/bot-runs/product-docs.md
+++ b/docs/bot-runs/product-docs.md
@@ -38,7 +38,7 @@ first.
     `.product-docs/modele.md` demanded that hub pages open with
     `## À qui s'adresse cette page`, and both hubs do — while the product home
     (not a hub, per the bundle's own taxonomy) correctly does not. Editorial
-    sovereignty (ADR-091) works end to end.
+    sovereignty (ADR-092) works end to end.
   - It found a genuine **source** defect and said so instead of documenting a
     promise the code does not keep: `instruction.js` comments that accepting
     "notifies the applicant", no mailer call exists, and `fr.json` has no

--- a/e2e/product_docs_test.go
+++ b/e2e/product_docs_test.go
@@ -1,0 +1,446 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// product-docs (Prody) mirrors docs-refresh's v3 shape — one capable agent +
+// a mission + TRUTH gates only — with three deltas this file pins:
+//
+//   - catalog_ingest runs ONCE, before the loop (the source clones do not
+//     change during a run), and a repo it could not read reaches the campaign
+//     as an explicit `degraded` inventory entry rather than as an absence;
+//   - page_lint is a THIRD gate term: a published page carrying working notes
+//     blocks convergence exactly like an out-of-scope write does;
+//   - the PR tail opens a DRAFT by default, because functional documentation
+//     is validated by the product owners on the forge.
+//
+// The bots/ suite executes the four deterministic node bodies against real git
+// fixtures; this file executes the GRAPH — edges, loop, gate expression and
+// tail — with every node stubbed, so a rewiring that no longer converges (or
+// that converges while a gate is red) fails here.
+
+// render flattens an edge-relayed value of any shape (a bool, a JSON array
+// decoded to []any, a substituted string) so an assertion can look for what it
+// carries. toStr, which the other bot suites share, is string-only by design —
+// the mapped fields pinned here are typed.
+func render(v any) string { return fmt.Sprintf("%v", v) }
+
+// productDocsState drives the stubs across passes.
+type productDocsState struct {
+	alignedBy    int // campaign reports docs_aligned=true on/after this pass
+	hintCount    int // advisory hint count reported every pass (never a gate)
+	inventory    []any
+	pass         int
+	failLogsSeen []string
+	campaignIn   map[string]any // the last campaign input map
+	gateInputs   map[string]map[string]any
+}
+
+// stubProductDocs registers the baseline green-path stubs. Individual tests
+// override nodes afterward (later .on wins).
+func stubProductDocs(exec *scenarioExecutor, st *productDocsState) {
+	if st.inventory == nil {
+		st.inventory = []any{map[string]any{
+			"id": "demo-src", "status": "ok", "path": "/scratch/sources/demo-src",
+			"sha": "deadbeef", "redacted": 2,
+		}}
+	}
+	st.gateInputs = map[string]map[string]any{}
+
+	exec.on("catalog_ingest", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{
+			"product_id": "demo", "product_dir": "documentation_produits/demo",
+			"surfaces":  []any{map[string]any{"name": "Espace gestionnaire"}},
+			"inventory": st.inventory, "sources_stamp": "demo-src@deadbeef",
+			"repo_count": 1, "ok_count": 1, "degraded_count": 0, "redacted_count": 2,
+			"previous_stamp": "", "delta_unavailable": false,
+			"log": "cloned 1 repo", "_tokens": 1,
+		}, nil
+	})
+	exec.on("scan_hints", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{
+			"pages": []any{"README.md"}, "page_count": 1,
+			"hints": []any{map[string]any{
+				"doc": "README.md", "line": 12, "kind": "dead_link",
+				"value": "gestionnaire/deposer.md", "note": "link target not found",
+			}},
+			"hint_count": st.hintCount, "dead_link_count": 1, "orphan_count": 0,
+			"unmapped_surface_count": 0, "checked_links": 3, "ledger_excluded": 0,
+			"truncated": false, "hints_note": "1 dead link(s)",
+			"editorial_files": []any{".product-docs/modele.md"},
+			"mode":            "full", "incremental_base": "",
+			"recently_changed_pages": []any{}, "_tokens": 1,
+		}, nil
+	})
+	exec.on("campaign", func(in map[string]any) (map[string]any, error) {
+		st.pass++
+		st.campaignIn = in
+		fl := ""
+		if raw, ok := in["fail_log"]; ok {
+			fl = strings.TrimSpace(toStr(raw))
+		}
+		st.failLogsSeen = append(st.failLogsSeen, fl)
+		aligned := st.pass >= st.alignedBy
+		remaining := "le parcours gestionnaire n'a pas encore de page d'étape"
+		if aligned {
+			remaining = ""
+		}
+		return map[string]any{
+			"docs_aligned": aligned, "commits_this_pass": 3, "drift_remaining": remaining,
+			"unread_sources": "", "is_product_bug": false, "needs_human": false,
+			"human_note": "", "summary": "hub + étapes rédigés", "_tokens": 10,
+		}, nil
+	})
+	exec.on("scope_check", func(in map[string]any) (map[string]any, error) {
+		st.gateInputs["scope_check"] = in
+		return map[string]any{"scope_ok": true, "out_of_scope": []any{}, "log": "", "_tokens": 1}, nil
+	})
+	exec.on("page_lint", func(in map[string]any) (map[string]any, error) {
+		st.gateInputs["page_lint"] = in
+		return map[string]any{
+			"lint_ok": true, "violations": []any{}, "violation_count": 0,
+			"pages_linted": 4, "log": "", "_tokens": 1,
+		}, nil
+	})
+	// available=true keeps the opt-in PR path reachable; the probe only runs
+	// behind the open_mr gate.
+	exec.on("forge_auth_probe", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"available": true, "reason": "env:GH_TOKEN", "_tokens": 1}, nil
+	})
+	exec.on("finalize_mr", func(in map[string]any) (map[string]any, error) {
+		st.gateInputs["finalize_mr"] = in
+		return map[string]any{
+			"opened": true, "url": "https://forge/pr/7", "branch": "iterion/product-docs/demo",
+			"draft": true, "back_linked": false, "skipped_reason": "",
+			"summary": "draft PR opened", "_tokens": 5,
+		}, nil
+	})
+}
+
+func runProductDocs(t *testing.T, exec *scenarioExecutor, runID string, inputs map[string]any) *store.Run {
+	t.Helper()
+	wf := compileFixtureStubSafe(t, "product-docs/main.bot")
+	s := tmpStore(t)
+	eng := runtime.New(wf, s, exec)
+	if err := eng.Run(context.Background(), runID, inputs); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	run, err := s.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if run.Status != store.RunStatusFinished {
+		t.Fatalf("status = %s, want %s", run.Status, store.RunStatusFinished)
+	}
+	return run
+}
+
+// TestProductDocs_ConvergesFirstPass: aligned campaign + two green gates on
+// pass 1 → one pass, and with open_mr defaulting false the run finishes
+// without touching the forge.
+func TestProductDocs_ConvergesFirstPass(t *testing.T) {
+	exec := newScenarioExecutor()
+	st := &productDocsState{alignedBy: 1, hintCount: 1}
+	stubProductDocs(exec, st)
+
+	runProductDocs(t, exec, "run-pd-first", nil)
+
+	if got := exec.callCount("campaign"); got != 1 {
+		t.Errorf("campaign called %d times, want 1", got)
+	}
+	if exec.wasCalled("forge_auth_probe") || exec.wasCalled("finalize_mr") {
+		t.Errorf("the PR tail fired with open_mr=false — it must be opt-in")
+	}
+	if st.failLogsSeen[0] != "" {
+		t.Errorf("pass 1 fail_log = %q, want empty (no gate has run yet)", st.failLogsSeen[0])
+	}
+}
+
+// TestProductDocs_ClonesOnceAcrossPasses is the delta docs-refresh has no
+// equivalent of: catalog_ingest sits BEFORE the loop head, so a second
+// continuation pass re-scans and re-campaigns but must NOT re-clone the source
+// repositories (they cannot change mid-run, and re-cloning N repos per pass
+// would dominate the run).
+func TestProductDocs_ClonesOnceAcrossPasses(t *testing.T) {
+	exec := newScenarioExecutor()
+	st := &productDocsState{alignedBy: 2, hintCount: 1}
+	stubProductDocs(exec, st)
+
+	runProductDocs(t, exec, "run-pd-clone-once", nil)
+
+	if got := exec.callCount("campaign"); got != 2 {
+		t.Errorf("campaign called %d times, want 2", got)
+	}
+	if got := exec.callCount("scan_hints"); got != 2 {
+		t.Errorf("scan_hints called %d times, want 2 (the loop head re-scans each pass)", got)
+	}
+	if got := exec.callCount("catalog_ingest"); got != 1 {
+		t.Errorf("catalog_ingest called %d times, want 1 — the clones happen once, before the loop", got)
+	}
+}
+
+// TestProductDocs_LintViolationBlocksConvergence pins Prody's third gate term.
+// The campaign claims the documentation aligned and the writeable set is
+// clean, but a published page still carries working notes: the run must NOT
+// converge, and the next pass must receive the lint complaint so the agent
+// removes exactly those lines.
+func TestProductDocs_LintViolationBlocksConvergence(t *testing.T) {
+	exec := newScenarioExecutor()
+	st := &productDocsState{alignedBy: 1, hintCount: 0} // claims aligned every pass
+	stubProductDocs(exec, st)
+	lintCalls := 0
+	exec.on("page_lint", func(_ map[string]any) (map[string]any, error) {
+		lintCalls++
+		if lintCalls == 1 {
+			return map[string]any{
+				"lint_ok": false,
+				"violations": []any{map[string]any{
+					"page": "documentation_produits/demo/gestionnaire/deposer.md",
+					"line": 42, "rule": "sources_box",
+				}},
+				"violation_count": 1, "pages_linted": 4,
+				"log":     "EDITORIAL LINT: documentation_produits/demo/gestionnaire/deposer.md:42 sources_box",
+				"_tokens": 1,
+			}, nil
+		}
+		return map[string]any{
+			"lint_ok": true, "violations": []any{}, "violation_count": 0,
+			"pages_linted": 4, "log": "", "_tokens": 1,
+		}, nil
+	})
+
+	runProductDocs(t, exec, "run-pd-lint", nil)
+
+	if got := exec.callCount("campaign"); got != 2 {
+		t.Errorf("campaign called %d times, want 2 — a red editorial lint must block convergence even when the agent reports docs_aligned", got)
+	}
+	if len(st.failLogsSeen) < 2 || !strings.Contains(st.failLogsSeen[1], "EDITORIAL LINT") {
+		t.Errorf("second campaign pass fail_log = %v, want the lint violation so the agent strips the working notes", st.failLogsSeen)
+	}
+}
+
+// TestProductDocs_ScopeViolationRoutesBack: the campaign wrote outside
+// `<product_dir>/**/*.md` — another product's tree, or the docs repo's own
+// editorial skills. The writeable-set gate fails the pass and the violation
+// reaches the next one.
+func TestProductDocs_ScopeViolationRoutesBack(t *testing.T) {
+	exec := newScenarioExecutor()
+	st := &productDocsState{alignedBy: 1, hintCount: 0}
+	stubProductDocs(exec, st)
+	scopeCalls := 0
+	exec.on("scope_check", func(_ map[string]any) (map[string]any, error) {
+		scopeCalls++
+		if scopeCalls == 1 {
+			return map[string]any{
+				"scope_ok": false, "out_of_scope": []any{".product-docs/modele.md"},
+				"log":     "SCOPE VIOLATION: this run changed files outside the product writeable-set: .product-docs/modele.md",
+				"_tokens": 1,
+			}, nil
+		}
+		return map[string]any{"scope_ok": true, "out_of_scope": []any{}, "log": "", "_tokens": 1}, nil
+	})
+
+	runProductDocs(t, exec, "run-pd-scope", nil)
+
+	if got := exec.callCount("campaign"); got != 2 {
+		t.Errorf("campaign called %d times, want 2 (a scope violation forces a revert pass)", got)
+	}
+	if len(st.failLogsSeen) < 2 || !strings.Contains(st.failLogsSeen[1], "SCOPE VIOLATION") {
+		t.Errorf("second campaign pass fail_log = %v, want the scope violation so the agent reverts it", st.failLogsSeen)
+	}
+}
+
+// TestProductDocs_HintsAreAdvisoryNeverGate (the v3 paradigm pin): the
+// deterministic scan is HELP, not an obligation. A large residual hint count —
+// dead links the agent judged not worth chasing, surfaces it deliberately did
+// not cover this pass — must not block convergence. If a scanner count ever
+// re-enters the gate expression, this test fails.
+func TestProductDocs_HintsAreAdvisoryNeverGate(t *testing.T) {
+	exec := newScenarioExecutor()
+	st := &productDocsState{alignedBy: 1, hintCount: 97}
+	stubProductDocs(exec, st)
+
+	runProductDocs(t, exec, "run-pd-advisory", nil)
+
+	if got := exec.callCount("campaign"); got != 1 {
+		t.Errorf("campaign called %d times, want 1 — 97 residual advisory hints must not block convergence", got)
+	}
+}
+
+// TestProductDocs_DegradedSourceReachesTheCampaign: a repository the front
+// door could not clone becomes an explicit `degraded` inventory entry, and
+// that entry must reach the campaign — which then documents the hole instead
+// of inferring the missing product surface. A silent skip would read, from
+// inside the agent, exactly like a product with fewer features.
+func TestProductDocs_DegradedSourceReachesTheCampaign(t *testing.T) {
+	exec := newScenarioExecutor()
+	st := &productDocsState{alignedBy: 1, hintCount: 0, inventory: []any{
+		map[string]any{"id": "demo-src", "status": "ok", "sha": "deadbeef"},
+		map[string]any{"id": "demo-api", "status": "degraded", "reason": "authentication failed: no credential for gitlab.example.org"},
+	}}
+	stubProductDocs(exec, st)
+
+	runProductDocs(t, exec, "run-pd-degraded", nil)
+
+	if got := exec.callCount("campaign"); got != 1 {
+		t.Errorf("campaign called %d times, want 1 — a degraded source is a documented hole, not a failed run", got)
+	}
+	inv := render(st.campaignIn["inventory"])
+	if !strings.Contains(inv, "degraded") || !strings.Contains(inv, "demo-api") {
+		t.Errorf("campaign inventory = %q, want the degraded entry naming the repo it could not read", inv)
+	}
+}
+
+// TestProductDocs_CatalogResolutionReachesEveryConsumer pins the wiring the
+// whole bot hangs on: `product_dir` is resolved ONCE by catalog_ingest and
+// must reach the campaign AND both deterministic gates (a tool command cannot
+// read `{{outputs.*}}`, so it rides the edge mapping — a mapping that silently
+// drops it would scope the gates to an empty path and approve anything).
+func TestProductDocs_CatalogResolutionReachesEveryConsumer(t *testing.T) {
+	exec := newScenarioExecutor()
+	st := &productDocsState{alignedBy: 1, hintCount: 0}
+	stubProductDocs(exec, st)
+
+	runProductDocs(t, exec, "run-pd-wiring", nil)
+
+	const wantDir = "documentation_produits/demo"
+	for _, field := range []string{"product_id", "product_dir", "surfaces", "inventory", "sources_stamp", "editorial_files", "hints", "hints_note", "mode", "incremental_base"} {
+		if _, ok := st.campaignIn[field]; !ok {
+			t.Errorf("campaign input missing %q — the scan_hints→campaign edge must carry it", field)
+		}
+	}
+	if got := render(st.campaignIn["product_dir"]); got != wantDir {
+		t.Errorf("campaign product_dir = %q, want %q", got, wantDir)
+	}
+	for _, gate := range []string{"scope_check", "page_lint"} {
+		if got := render(st.gateInputs[gate]["product_dir"]); got != wantDir {
+			t.Errorf("%s product_dir = %q, want %q — the gate would otherwise be scoped to nothing", gate, got, wantDir)
+		}
+	}
+}
+
+// TestProductDocs_MRPathOpensADraft pins the opt-in delivery tail AND its
+// default: with open_mr=true the converged series reaches finalize_mr with
+// draft=true (vars.mr_draft), and the opened URL is surfaced as the run's
+// headline result link. Functional documentation is validated by the product
+// owners on the forge — marking the PR ready is their act, not the bot's.
+func TestProductDocs_MRPathOpensADraft(t *testing.T) {
+	exec := newScenarioExecutor()
+	st := &productDocsState{alignedBy: 1, hintCount: 0}
+	stubProductDocs(exec, st)
+
+	runProductDocs(t, exec, "run-pd-mr", map[string]any{"open_mr": true})
+
+	if !exec.wasCalled("finalize_mr") {
+		t.Fatalf("finalize_mr did not fire with open_mr=true — the converged series must open a PR")
+	}
+	if got := render(st.gateInputs["finalize_mr"]["draft"]); got != "true" {
+		t.Errorf("finalize_mr draft = %q, want \"true\" — mr_draft defaults to a DRAFT PR", got)
+	}
+	if !exec.wasCalled("surface_pr_link") {
+		t.Errorf("surface_pr_link never ran — the opened PR must surface as the run's headline link")
+	}
+}
+
+// TestProductDocs_MRPathSkippedWithoutForgeAuth: no push credential → the
+// deterministic probe short-circuits to done. finalize_mr is an LLM agent;
+// entering it with nothing to push burns a turn to rediscover that in shell.
+func TestProductDocs_MRPathSkippedWithoutForgeAuth(t *testing.T) {
+	exec := newScenarioExecutor()
+	st := &productDocsState{alignedBy: 1, hintCount: 0}
+	stubProductDocs(exec, st)
+	exec.on("forge_auth_probe", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{
+			"available": false, "reason": "no forge_token secret, no *_TOKEN env, no gh host auth", "_tokens": 1,
+		}, nil
+	})
+
+	runProductDocs(t, exec, "run-pd-noauth", map[string]any{"open_mr": true})
+
+	if exec.wasCalled("finalize_mr") {
+		t.Errorf("finalize_mr fired with no push credential — the deterministic probe must skip the tail")
+	}
+}
+
+// TestProductDocs_Structural pins the IR shape: the deterministic front door
+// as entry, ONE adaptive campaign, four deterministic gates/probes, the two
+// computes — and the ABSENCE of both the retired reviewer/fixer relay (which
+// re-litigates instead of converging) and any per-framework parser node (the
+// campaign reads whatever stack the sources use; a `parse_openapi` node would
+// be the closed enum this bot must not have).
+func TestProductDocs_Structural(t *testing.T) {
+	wf := compileFixtureStubSafe(t, "product-docs/main.bot")
+
+	if wf.Entry != "catalog_ingest" {
+		t.Errorf("workflow entry = %q, want %q (the deterministic multi-repo front door leads)", wf.Entry, "catalog_ingest")
+	}
+	for _, id := range []string{"campaign", "finalize_mr"} {
+		node, ok := wf.Nodes[id]
+		if !ok {
+			t.Fatalf("workflow missing expected agent node %q", id)
+		}
+		if _, ok := node.(*ir.AgentNode); !ok {
+			t.Errorf("node %q is %T, want *ir.AgentNode (adaptive)", id, node)
+		}
+	}
+	for _, id := range []string{"catalog_ingest", "scan_hints", "scope_check", "page_lint", "forge_auth_probe", "surface_pr_link"} {
+		node, ok := wf.Nodes[id]
+		if !ok {
+			t.Fatalf("workflow missing expected tool node %q", id)
+		}
+		if _, ok := node.(*ir.ToolNode); !ok {
+			t.Errorf("node %q is %T, want *ir.ToolNode (deterministic)", id, node)
+		}
+	}
+	for _, id := range []string{"gate", "mr_gate"} {
+		node, ok := wf.Nodes[id]
+		if !ok {
+			t.Fatalf("workflow missing expected compute node %q", id)
+		}
+		if _, ok := node.(*ir.ComputeNode); !ok {
+			t.Errorf("node %q is %T, want *ir.ComputeNode", id, node)
+		}
+	}
+	for _, id := range []string{
+		// the reviewer/fixer relay the v3 shape retired
+		"reviewer_claude", "reviewer_gpt", "streak_check", "fix_claude", "fix_gpt",
+		// a docs-only bot cannot break a build: no verify apparatus
+		"verify_build", "verify_run", "verify_precheck",
+		// per-framework parsing belongs to the agent, never to the graph
+		"parse_openapi", "parse_i18n", "detect_framework",
+	} {
+		if _, ok := wf.Nodes[id]; ok {
+			t.Errorf("node %q is present — the bot is one campaign guided by an advisory scan + truth gates + PR tail, with no per-framework parser in the graph", id)
+		}
+	}
+
+	// The two catalog vars are REQUIRED: they default to empty so
+	// catalog_ingest fails loudly rather than documenting the wrong product.
+	for _, name := range []string{"catalog_path", "product_id"} {
+		v, ok := wf.Vars[name]
+		if !ok {
+			t.Fatalf("workflow missing var %q", name)
+		}
+		if v.Default != "" {
+			t.Errorf("var %q defaults to %v, want empty — a guessed catalog documents the wrong product", name, v.Default)
+		}
+	}
+	if v, ok := wf.Vars["mr_draft"]; !ok {
+		t.Errorf("workflow missing var mr_draft")
+	} else if v.Default != true {
+		t.Errorf("mr_draft defaults to %v, want true — the product owners mark the PR ready, not the bot", v.Default)
+	}
+	if v, ok := wf.Vars["open_mr"]; !ok {
+		t.Errorf("workflow missing var open_mr")
+	} else if v.Default != false {
+		t.Errorf("open_mr defaults to %v, want false — delivery is opt-in", v.Default)
+	}
+}


### PR DESCRIPTION
## What

A new bot bundle, `bots/product-docs/` (persona **Prody**), that generates and maintains **functional documentation** — business audience, non-technical — for a product whose docs live in a *dedicated* repository and whose sources live in *N other* repositories described by a catalog.

The catalog gap it fills: Doki (`docs-refresh`) aligns technical docs living next to the code; Wikky (`wiki-gen`) generates a technical OKF wiki. Neither produces "what the product does for its users", and neither handles the cross-repo shape. A real pilot exists — DNUM-SocialGouv maintains a 6 000-line Python generator (`documentation_generation`) publishing to a GitBook-synced docs repo — and its conventions are the acceptance bar here.

## Shape — docs-refresh v3, one capable agent + truth gates

```
catalog_ingest ─▶ scan_hints ─▶ campaign ─▶ scope_check ─▶ page_lint ─▶ gate
gate ──(converged)──▶ mr_gate ─▶ forge_auth_probe ─▶ finalize_mr ─▶ surface_pr_link ─▶ done
gate ─────────────────▶ scan_hints           (continuation_loop, max_passes)
```

- **`catalog_ingest`** — deterministic: parses the product catalog (YAML/JSON, the pilot's format), shallow-clones the sources into gitignored scratch, redacts credential carriers, computes the source delta from the `Product-Docs-Sources:` commit trailer (git *is* the state — no side-car file), and records the run base.
- **`campaign`** — one adaptive agent that reads the actual sources (templates, i18n, routes, OpenAPI — no per-framework parsers) and commits each page in stride.
- **`scope_check` / `page_lint`** — the deterministic truth gates: writeable set is `.md` under the product directory, and a published page carries no working notes (no Sources box, no HTML comments, no "Points à clarifier", no "Correspondance technique") and no credential material.

## Editorial sovereignty

The editorial line does **not** live in the bundle. When the docs repo ships `<editorial_dir>/*.md` (default `.product-docs/`), those files are authoritative and override the bundle defaults — and the scope gate excludes that directory, so the bot can never rewrite the charter that governs it. The bundle's own French defaults (documentary model, GitBook blocks, glossary, tone) are a starting point the product team owns and edits by pull request.

## Provenance

Authored by a `feature-dev` dogfood run, then hardened by a three-agent adversarial review. That review found **2 critical + 6 high** issues, all fixed in `cd15f9f0`, each with a regression test seen RED against the old behaviour:

- an explicit `repos[].id` was never sanitised, so a path-shaped id made `os.path.join` discard the scratch root and the node `rmtree`'d an arbitrary directory before cloning over it;
- `scope_check` derived its base from commit *messages*, so one commit missing the trailer became the base and emptied its own diff;
- the clone's `.git` kept every "redacted" secret readable; a source stamp read from a commit trailer reached `git fetch` as a ref (option injection); renames and symlinks escaped the writeable set; an unclosed `{% hint %}` disarmed three lint rules to EOF; and the lint fired on legitimate French prose — in a blocking gate, that false positive costs as much as a miss.

Worth noting for the engine: the run's own in-loop reviewer **skipped** its pass because the build gate read a pre-existing `pkg/dispatcher/native` flake as red. A false negative there silently removes the review.

## Verification

- `go test ./bots ./e2e` → 505 pass (bots 266, was 248 before the review)
- `iterion validate bots/product-docs/main.bot` → OK (12 nodes, 15 edges)
- `iterion bots regen-catalog` committed; `TestCommittedCatalogIsFresh` green
- e2e walks the whole graph offline (no network): clone-once, both gates, draft PR tail

🤖 Generated with [Claude Code](https://claude.com/claude-code)