### PR TITLE
feat(forge): watch-only GitHub App for org-wide Dependabot alerts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,7 +217,14 @@ the hours this one spent.
   `security_read_enabled` PATCH, refresh worker keeps it minted) vs the
   hand-set fine-grained-PAT path, and the health/422 diagnostics. Read it
   when wiring vuln-watch (Senti) or when its run fails on "no Dependabot
-  token".
+  token". Covers the **coverage trap** — the org-wide endpoint returns only
+  what the installation can see, so a `selected`-scope install is silently
+  near-blind — and the **watch-only App** (`security_read_only`, manifest
+  permissions REPLACED by `metadata`+`vulnerability_alerts` read) that makes
+  an All-repositories install safe. Its connection carries
+  `purpose: security_read`, which is what keeps the refresh worker from
+  minting it a runtime token (that mint would 422 → degrade → withdraw the
+  token it exists to supply) and keeps the publish resolver from picking it.
 - [docs/observability.md](docs/observability.md) — process logs, error
   tracking and tracing: the env vars (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`,
   `SENTRY_TRACES_SAMPLE_RATE`, `ITERION_LOG_FORMAT`, `ITERION_LOG_LEVEL`),

--- a/docs/forge-security-read.md
+++ b/docs/forge-security-read.md
@@ -73,6 +73,57 @@ deletes the secret when the map empties).
 Multiple orgs = one connection per org (a GitHub App is installed per
 org), each opted in; the worker merges them all into the one secret.
 
+### The coverage trap, and the watch-only App
+
+The org-wide alerts endpoint returns **only what the installation can
+see**. An App installed on *selected* repositories therefore yields
+alerts for those repositories alone — silently, with no error and no
+partial-coverage warning. Org-wide coverage means installing on **All
+repositories**.
+
+That is a problem for the ordinary forge App, which holds
+`contents:write` (and, when opted in, `administration:write`): widening
+it to every repository of an org to gain read access to alerts grants
+write on every repository as a side effect.
+
+The **watch-only App** exists for exactly this. It is built from a
+manifest that *replaces* the runtime baseline instead of adding to it —
+`metadata:read` + `vulnerability_alerts:read`, nothing else — so it is
+safe to install on All repositories:
+
+- Studio: Integrations → connect → *Create your GitHub App* → check
+  **"Watch-only App (Dependabot alerts, read)"**. The write-grant
+  checkboxes disappear; the App is named `iterion-watch-<id>` so its
+  shape is legible on the org's Apps list.
+- API: `POST /api/teams/{id}/forge/oauth-apps/github-manifest` with
+  `{"security_read_only": true}`.
+
+Its connection is stamped `purpose: "security_read"`
+([pkg/forge/types.go](../pkg/forge/types.go)), which is what keeps it
+out of every runtime path. Three consequences worth knowing, because
+each one would otherwise be a silent failure:
+
+- **The refresh worker never mints a runtime token for it.** That mint
+  would request permissions the App was deliberately never granted →
+  `422` → the connection is marked degraded → its security-read entry is
+  *withdrawn*. A watch-only connection would destroy the token it exists
+  to supply, about an hour after being wired. Its whole refresh is the
+  security mint, and it is re-armed from **that token's own expiry** —
+  there is no runtime token to date the sweep from.
+- **The publish resolver skips it.** `forgeConnectionForPR` otherwise
+  falls back to "the first team connection on this forge host", and a
+  review posted through a watch-only connection would `403`.
+- **Its health view does not report the absent delivery grants.** They
+  are the point, not a defect.
+
+The role is inherited from the App record, never inferred from the
+granted permissions: a runtime App an owner narrowed by mistake must
+read as broken (degraded, with a reason), not quietly re-label itself
+watch-only and stop doing its job.
+
+The per-connection opt-in still applies — creating a watch-only App does
+not by itself mint anything; PATCH `security_read_enabled` as above.
+
 ## Health and diagnostics
 
 - `GET /api/teams/{id}/forge/connections/{conn_id}/health` reports

--- a/openapi.json
+++ b/openapi.json
@@ -314,6 +314,9 @@
           "provider": {
             "type": "string"
           },
+          "purpose": {
+            "type": "string"
+          },
           "scopes": {
             "items": {
               "type": "string"
@@ -647,6 +650,9 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "security_read_only": {
+            "type": "boolean"
           },
           "tenant_id": {
             "type": "string"
@@ -2184,6 +2190,9 @@
           },
           "provider": {
             "type": "string"
+          },
+          "security_read_only": {
+            "type": "boolean"
           }
         },
         "required": [

--- a/pkg/forge/github/app_manifest.go
+++ b/pkg/forge/github/app_manifest.go
@@ -159,6 +159,28 @@ type ManifestConversion struct {
 		Login string `json:"login"`
 		Type  string `json:"type"` // "Organization" | "User"
 	} `json:"owner"`
+	// Permissions is what the App GitHub actually created carries. iterion
+	// POSTs the manifest through the operator's BROWSER, so what came back is
+	// the only evidence of what was registered — the request iterion built is
+	// not. A watch-only App is the one shape whose whole value rests on its
+	// permissions, and an org owner is asked to install it on every repository:
+	// the claim has to be confronted with this before it is recorded.
+	Permissions map[string]string `json:"permissions"`
+}
+
+// IsSecurityReadOnly reports whether the created App carries exactly the
+// watch-only permission profile and nothing else.
+func (c ManifestConversion) IsSecurityReadOnly() bool {
+	want := SecurityReadInstallationPermissions()
+	if len(c.Permissions) != len(want) {
+		return false
+	}
+	for name, level := range want {
+		if c.Permissions[name] != level {
+			return false
+		}
+	}
+	return true
 }
 
 // AppManageURL is the GitHub settings page (Advanced tab, with the Delete

--- a/pkg/forge/github/app_manifest.go
+++ b/pkg/forge/github/app_manifest.go
@@ -60,6 +60,16 @@ type AppManifestOptions struct {
 	// the dedicated security-read token (SecurityReadInstallationPermissions),
 	// never into the runtime forge token.
 	AllowSecurityRead bool
+	// SecurityReadOnly builds a WATCH-ONLY App: metadata:read plus
+	// vulnerability_alerts:read, and nothing else. It REPLACES the runtime
+	// baseline rather than adding to it, so the App can be installed org-wide
+	// (which the org-wide alerts endpoint requires — it returns only what the
+	// installation can see) without granting write on every repository.
+	//
+	// Its connection carries forge.PurposeSecurityRead and is excluded from
+	// all runtime paths. When set, the other options are ignored: they only
+	// add write grants, which is exactly what this shape exists to avoid.
+	SecurityReadOnly bool
 }
 
 // BuildAppManifest assembles the manifest for an iterion forge GitHub App. The
@@ -72,6 +82,14 @@ type AppManifestOptions struct {
 // require `repository_hooks:write`, not `administration` — and only joins the
 // grant when opts.AllowRepoCreation asks for the create-repo capability.
 func BuildAppManifest(name, homeURL, redirectURL string, opts ...AppManifestOptions) AppManifest {
+	for _, o := range opts {
+		if o.SecurityReadOnly {
+			// Whole-set replacement, evaluated before anything can widen it:
+			// a watch-only App that also carried the runtime baseline would
+			// defeat its own purpose.
+			return newAppManifest(name, homeURL, redirectURL, SecurityReadInstallationPermissions())
+		}
+	}
 	perms := RuntimeInstallationPermissions()
 	// statuses:write lets Revi post its revi/review merge-gate commit status.
 	// Optional at runtime (the mint falls back without it — see AppClient.rest),
@@ -90,6 +108,14 @@ func BuildAppManifest(name, homeURL, redirectURL string, opts ...AppManifestOpti
 			perms["vulnerability_alerts"] = "read"
 		}
 	}
+	return newAppManifest(name, homeURL, redirectURL, perms)
+}
+
+// newAppManifest assembles the manifest envelope around an already-decided
+// permission set. Every App iterion creates shares the same callback/setup
+// wiring; only DefaultPermissions differ between the runtime and the
+// watch-only shapes.
+func newAppManifest(name, homeURL, redirectURL string, perms map[string]string) AppManifest {
 	return AppManifest{
 		Name:        name,
 		URL:         homeURL,
@@ -108,7 +134,8 @@ func BuildAppManifest(name, homeURL, redirectURL string, opts ...AppManifestOpti
 		// open + comment; metadata: baseline; repository_hooks: per-repo
 		// inbound webhook), plus administration:write ONLY when the
 		// create-repo capability was opted in — minted tokens always
-		// narrow to the subset a call needs.
+		// narrow to the subset a call needs. A SecurityReadOnly App instead
+		// carries metadata:read + vulnerability_alerts:read and nothing else.
 		DefaultPermissions: perms,
 		HookAttributes:     map[string]any{"url": homeURL, "active": false},
 	}

--- a/pkg/forge/github/app_manifest_test.go
+++ b/pkg/forge/github/app_manifest_test.go
@@ -114,3 +114,41 @@ func TestSecurityReadPermissions(t *testing.T) {
 		t.Fatalf("MissingSecurityPermissions(nil) = %v, want nil", got)
 	}
 }
+
+// A watch-only App is the one shape that may be installed on ALL repositories
+// of an org without handing out write, so its permission set must be exactly
+// the security-read profile — never the runtime baseline plus an extra grant.
+func TestBuildAppManifest_SecurityReadOnly(t *testing.T) {
+	m := BuildAppManifest("iterion-watch-x", "https://it", "https://it/cb",
+		AppManifestOptions{SecurityReadOnly: true})
+	want := SecurityReadInstallationPermissions()
+	if len(m.DefaultPermissions) != len(want) {
+		t.Fatalf("watch-only permissions = %v, want exactly %v", m.DefaultPermissions, want)
+	}
+	for name, level := range want {
+		if m.DefaultPermissions[name] != level {
+			t.Fatalf("watch-only %q = %q, want %q (%v)", name, m.DefaultPermissions[name], level, m.DefaultPermissions)
+		}
+	}
+	// The callback wiring is shared with the runtime shape: a watch-only App
+	// still has to complete the same install → connection round-trip.
+	if m.SetupURL != "https://it/api/forge/github/app/callback" {
+		t.Fatalf("SetupURL = %q", m.SetupURL)
+	}
+}
+
+// The write-granting options must not be able to widen a watch-only App —
+// that combination is exactly what the shape exists to make impossible.
+func TestBuildAppManifest_SecurityReadOnlyOverridesWriteOptions(t *testing.T) {
+	m := BuildAppManifest("iterion-watch-x", "https://it", "https://it/cb",
+		AppManifestOptions{
+			SecurityReadOnly:  true,
+			AllowRepoCreation: true,
+			AllowAppDelivery:  true,
+		})
+	for _, forbidden := range []string{"administration", "contents", "pull_requests", "repository_hooks", "workflows", "packages", "statuses", "issues"} {
+		if lvl, ok := m.DefaultPermissions[forbidden]; ok {
+			t.Fatalf("watch-only App carries %q=%q — write options widened it: %v", forbidden, lvl, m.DefaultPermissions)
+		}
+	}
+}

--- a/pkg/forge/github/app_manifest_test.go
+++ b/pkg/forge/github/app_manifest_test.go
@@ -152,3 +152,30 @@ func TestBuildAppManifest_SecurityReadOnlyOverridesWriteOptions(t *testing.T) {
 		}
 	}
 }
+
+// iterion POSTs the manifest through the operator's BROWSER, so the App GitHub
+// actually created is the only evidence of what was registered — the request
+// iterion built is not. A watch-only App is the one shape whose entire value
+// rests on its permissions, and an org owner is asked to install it on every
+// repository, so the claim has to be confronted with the response.
+func TestManifestConversion_IsSecurityReadOnly(t *testing.T) {
+	cases := []struct {
+		name  string
+		perms map[string]string
+		want  bool
+	}{
+		{"exact profile", map[string]string{"metadata": "read", "vulnerability_alerts": "read"}, true},
+		{"carries write too", map[string]string{"metadata": "read", "vulnerability_alerts": "read", "contents": "write"}, false},
+		{"missing the alerts grant", map[string]string{"metadata": "read"}, false},
+		{"right names, wrong level", map[string]string{"metadata": "read", "vulnerability_alerts": "write"}, false},
+		{"empty (GitHub said nothing)", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := ManifestConversion{Permissions: tc.perms}
+			if got := c.IsSecurityReadOnly(); got != tc.want {
+				t.Fatalf("IsSecurityReadOnly(%v) = %v, want %v", tc.perms, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/forge/oauth_app_store.go
+++ b/pkg/forge/oauth_app_store.go
@@ -114,10 +114,20 @@ func firstAppOnInstance(apps []ForgeOAuthApp, err error) (ForgeOAuthApp, error) 
 	if err != nil {
 		return ForgeOAuthApp{}, err
 	}
-	if len(apps) == 0 {
-		return ForgeOAuthApp{}, ErrOAuthAppNotFound
+	for _, a := range apps {
+		// A watch-only App is never the IMPLICIT answer to "which app for this
+		// host". It is reachable only by explicit id (the install flow passes
+		// one). Otherwise a team that registered it first — the natural order
+		// for a security-first onboarding, since this listing is oldest-first —
+		// would have every default install AND every OAuth connect resolve to
+		// an App that holds no rights, producing a connection labelled runtime
+		// that can do nothing.
+		if a.SecurityReadOnly {
+			continue
+		}
+		return a, nil
 	}
-	return apps[0], nil
+	return ForgeOAuthApp{}, ErrOAuthAppNotFound
 }
 
 // ownerOrInstance labels an app in operator-facing errors by the account that
@@ -148,7 +158,13 @@ func (m *MemoryOAuthAppStore) Create(_ context.Context, a ForgeOAuthApp) error {
 	defer m.mu.Unlock()
 	for _, ex := range m.apps {
 		if ex.TenantID == a.TenantID && ex.Provider == a.Provider &&
-			ex.ForgeBaseURL == a.ForgeBaseURL && ex.OwnerLogin == a.OwnerLogin {
+			ex.ForgeBaseURL == a.ForgeBaseURL && ex.OwnerLogin == a.OwnerLogin &&
+			// The ROLE is part of the identity: one org legitimately hosts a
+			// runtime App and a watch-only App. Without this the second one
+			// collides, and the collision is only discovered at the manifest
+			// CALLBACK — after GitHub created the App and handed back the
+			// private key it never reissues, which iterion then drops.
+			ex.SecurityReadOnly == a.SecurityReadOnly {
 			return fmt.Errorf("%w for %s on %s", ErrOAuthAppExists, a.Provider, ownerOrInstance(a))
 		}
 	}
@@ -237,22 +253,33 @@ func NewMongoOAuthAppStore(db *mongo.Database) *MongoOAuthAppStore {
 // changes behaviour instead of silently keeping the old rule.
 const legacyOAuthAppInstanceIndex = "tenant_provider_baseurl_unique"
 
+// legacyOAuthAppOwnerIndex is the previous generation, superseded once the
+// ROLE joined the identity: one org may hold a runtime App and a watch-only
+// App at the same time.
+const legacyOAuthAppOwnerIndex = "tenant_provider_baseurl_owner_unique"
+
 func (s *MongoOAuthAppStore) EnsureSchema(ctx context.Context) error {
-	if err := s.coll.Indexes().DropOne(ctx, legacyOAuthAppInstanceIndex); err != nil {
-		// IndexNotFound (fresh install, or already migrated) is the expected
-		// steady state — anything else is a real failure worth surfacing.
-		if !mongoutil.IsIndexNotFound(err) {
-			return fmt.Errorf("forge: drop legacy oauth app index: %w", err)
+	for _, stale := range []string{legacyOAuthAppInstanceIndex, legacyOAuthAppOwnerIndex} {
+		if err := s.coll.Indexes().DropOne(ctx, stale); err != nil {
+			// IndexNotFound (fresh install, or already migrated) is the expected
+			// steady state — anything else is a real failure worth surfacing.
+			if !mongoutil.IsIndexNotFound(err) {
+				return fmt.Errorf("forge: drop legacy oauth app index %s: %w", stale, err)
+			}
 		}
 	}
 	_, err := s.coll.Indexes().CreateMany(ctx, []mongo.IndexModel{
-		// Uniqueness is per OWNING ACCOUNT, not per host: a tenant legitimately
-		// holds one app per GitHub org (a private App is only installable on its
-		// owner), so keying on the host alone made the second org impossible.
-		// Legacy rows carry no owner_login; they all collapse to owner_login:""
-		// and therefore remain bound by exactly the old one-per-host rule, which
-		// is what keeps this index creatable over existing data.
-		{Keys: bson.D{{Key: "tenant_id", Value: 1}, {Key: "provider", Value: 1}, {Key: "forge_base_url", Value: 1}, {Key: "owner_login", Value: 1}}, Options: options.Index().SetUnique(true).SetName("tenant_provider_baseurl_owner_unique")},
+		// Uniqueness is per OWNING ACCOUNT **and per role**, not per host: a
+		// tenant legitimately holds one app per GitHub org (a private App is
+		// only installable on its owner), and one org legitimately hosts both a
+		// runtime App and a watch-only App — the second of which would
+		// otherwise collide only at the manifest callback, after GitHub minted
+		// the private key it never reissues.
+		// Legacy rows carry neither owner_login nor security_read_only; both
+		// collapse to the missing-field value, so those rows remain bound by
+		// exactly the old rule, which is what keeps this index creatable over
+		// existing data.
+		{Keys: bson.D{{Key: "tenant_id", Value: 1}, {Key: "provider", Value: 1}, {Key: "forge_base_url", Value: 1}, {Key: "owner_login", Value: 1}, {Key: "security_read_only", Value: 1}}, Options: options.Index().SetUnique(true).SetName("tenant_provider_baseurl_owner_role_unique")},
 	})
 	if err != nil && !mongoutil.IsIndexConflict(err) {
 		return fmt.Errorf("forge: ensure forge_oauth_apps indexes: %w", err)

--- a/pkg/forge/oauth_app_store.go
+++ b/pkg/forge/oauth_app_store.go
@@ -69,6 +69,13 @@ type ForgeOAuthApp struct {
 	// "which org". Surfaced so the UI can label the picker by org rather than by
 	// opaque slug.
 	OwnerLogin string `bson:"owner_login,omitempty" json:"owner_login,omitempty"`
+	// SecurityReadOnly marks a WATCH-ONLY App: created from the manifest
+	// shape that requests metadata:read + vulnerability_alerts:read and
+	// nothing else. It travels here rather than in the connect flow's state
+	// because it is a property of the APP, not of one install: every
+	// connection born from this App is a PurposeSecurityRead connection, on
+	// the first org and on the tenth.
+	SecurityReadOnly bool `bson:"security_read_only,omitempty" json:"security_read_only,omitempty"`
 	// Installable is a computed view flag (never persisted): true when the App
 	// holds a private key, so the UI can offer the "Install" (github_app) action.
 	Installable bool `bson:"-" json:"installable,omitempty"`

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -746,6 +746,19 @@ func (o *Orchestrator) EnsureManagedSecret(ctx context.Context, conn *Connection
 // token, stamping its id onto the connection. Reused across every repo/bot
 // of the connection; the refresh worker rewrites its plaintext on rotation.
 func (o *Orchestrator) ensureManagedSecret(ctx context.Context, conn *Connection, actor string) (string, error) {
+	// A watch-only connection has no runtime token to hand a bot: its App
+	// holds neither contents nor hooks. Refusing HERE is what makes the guard
+	// exhaustive — this is the single chokepoint every runtime path funnels
+	// through (Provision, and the repo-targeted launch via
+	// EnsureManagedSecret), and it fires BEFORE Provision writes the bot
+	// bindings. That ordering matters more than the message: a binding is
+	// keyed (tenant, bot, secret_name) and therefore TEAM-GLOBAL, it is
+	// written before the first forge call, and nothing rolls it back — so a
+	// provision that fails later would leave every repo of that bot pointing
+	// at a token that cannot push.
+	if conn.IsSecurityReadOnly() {
+		return "", fmt.Errorf("forge: connection %s is watch-only (Dependabot alerts): it holds no contents/hooks grant and has no runtime token to hand a bot — use the team's runtime connection", conn.ID)
+	}
 	if conn.ManagedSecretID != "" {
 		return conn.ManagedSecretID, nil
 	}

--- a/pkg/forge/refresh.go
+++ b/pkg/forge/refresh.go
@@ -249,12 +249,19 @@ func (w *RefreshWorker) refreshOne(ctx context.Context, conn Connection) error {
 // so the next sweep picks it up. There is no runtime token, no managed secret
 // and no refresh-token grant involved.
 func (w *RefreshWorker) refreshSecurityOnly(ctx context.Context, conn Connection) error {
-	if !conn.SecurityReadEnabled || w.SecurityMinter == nil {
-		// Opt-in switched off (or the feature is unwired): the connection has
-		// no other job, so there is nothing to renew. Withdraw any entry it
-		// still owns — withdrawSecurityReadEntry, NOT dropSecurityReadEntry,
-		// whose `!SecurityReadEnabled` guard is the very condition that got us
-		// here and would make the withdrawal a no-op.
+	if w.SecurityMinter == nil {
+		// The feature is UNWIRED, which says nothing about whether the token in
+		// the map is still wanted. Withdrawing here would let a partially-wired
+		// replica strip live tokens from the tenant map — so skip, exactly as
+		// the runtime lane skips a connection it cannot refresh.
+		return nil
+	}
+	if !conn.SecurityReadEnabled {
+		// Opt-in switched off: the connection has no other job, so there is
+		// nothing to renew. Withdraw any entry it still owns —
+		// withdrawSecurityReadEntry, NOT dropSecurityReadEntry, whose
+		// `!SecurityReadEnabled` guard is the very condition that got us here
+		// and would make the withdrawal a no-op.
 		if err := w.withdrawSecurityReadEntry(ctx, conn); err != nil {
 			return err
 		}
@@ -275,6 +282,13 @@ func (w *RefreshWorker) refreshSecurityOnly(ctx context.Context, conn Connection
 		// runtime lane calls markRevoked here; without the same treatment the
 		// connection keeps reading "active" while the map holds a token that
 		// dies within the hour — a 401 in the bot with nothing to explain it.
+		//
+		// Clear the expiry FIRST. markRevoked does not touch it, and this lane
+		// deliberately bypasses the StatusDegraded early-exit that stops the
+		// runtime lane from re-entering — so a revoked connection that stays
+		// dated is re-minted against the forge on every tick, forever, with no
+		// self-heal path.
+		conn.AccessTokenExpiresAt = nil
 		return w.markRevoked(ctx, conn)
 	case err != nil:
 		// Transient (or at least unclassified): keep retrying, but do not let
@@ -288,11 +302,10 @@ func (w *RefreshWorker) refreshSecurityOnly(ctx context.Context, conn Connection
 		}
 		return fmt.Errorf("forge: security-read mint for connection %s: %w", conn.ID, err)
 	}
-	// Date the connection from the token BEFORE the upsert, and persist it
-	// even when the upsert fails: an upsert that fails permanently (a
-	// malformed operator-written map, an unkeyable connection) would otherwise
-	// leave the connection perpetually due and re-mint against GitHub on every
-	// tick, forever.
+	// Date the connection from the token before the upsert. The new expiry is
+	// persisted on success, and on a PERMANENT upsert failure (which leaves the
+	// sweep by being degraded) — but NOT on a transient one, which must stay
+	// due so the next tick retries.
 	now := w.now()
 	conn.Status = StatusActive
 	conn.StatusReason = "" // the security lane IS this connection: a good mint clears it
@@ -306,12 +319,20 @@ func (w *RefreshWorker) refreshSecurityOnly(ctx context.Context, conn Connection
 	conn.AccessTokenExpiresAt = &exp
 	conn.UpdatedAt = now
 
-	upsertErr := UpsertSecurityReadToken(ctx, w.Secrets, w.Sealer, &conn, secTok, now)
-	if upsertErr != nil && isPermanentSecurityReadErr(upsertErr) {
-		// Permanent by nature: retrying cannot fix a malformed map or a
-		// connection with no org to key on. Record it once instead of
-		// re-minting every ten minutes.
-		return w.markSecurityReadDegraded(ctx, conn, upsertErr)
+	if upsertErr := UpsertSecurityReadToken(ctx, w.Secrets, w.Sealer, &conn, secTok, now); upsertErr != nil {
+		if isPermanentSecurityReadErr(upsertErr) {
+			// Permanent by nature: retrying cannot fix a malformed map or a
+			// connection with no org to key on. Record it once instead of
+			// re-minting every ten minutes.
+			return w.markSecurityReadDegraded(ctx, conn, upsertErr)
+		}
+		// Transient (store blip, seal error, CAS retries exhausted): the token
+		// just minted never reached the map, so do NOT persist the fresh
+		// expiry. Persisting it would take the connection out of the sweep for
+		// ~55 minutes while the map still advertises the PREVIOUS token, which
+		// is expiring right now — the very thing the transient-mint branch
+		// above refuses to allow.
+		return fmt.Errorf("forge: security-read upsert for connection %s: %w", conn.ID, upsertErr)
 	}
 	// An operator may have switched the opt-in off while the mint was in
 	// flight (a few hundred ms, six times an hour). Blindly writing back the
@@ -320,10 +341,7 @@ func (w *RefreshWorker) refreshSecurityOnly(ctx context.Context, conn Connection
 	if fresh, ferr := w.Connections.Get(ctx, conn.ID); ferr == nil && !fresh.SecurityReadEnabled {
 		return w.withdrawSecurityReadEntry(ctx, fresh)
 	}
-	if err := w.Connections.Update(ctx, conn); err != nil {
-		return err
-	}
-	return upsertErr
+	return w.Connections.Update(ctx, conn)
 }
 
 // isPermanentSecurityReadErr classifies an upsert failure that no retry can

--- a/pkg/forge/refresh.go
+++ b/pkg/forge/refresh.go
@@ -252,31 +252,96 @@ func (w *RefreshWorker) refreshSecurityOnly(ctx context.Context, conn Connection
 	if !conn.SecurityReadEnabled || w.SecurityMinter == nil {
 		// Opt-in switched off (or the feature is unwired): the connection has
 		// no other job, so there is nothing to renew. Withdraw any entry it
-		// still owns rather than letting a token the map promises to keep
-		// fresh quietly expire.
-		return w.dropSecurityReadEntry(ctx, conn)
+		// still owns — withdrawSecurityReadEntry, NOT dropSecurityReadEntry,
+		// whose `!SecurityReadEnabled` guard is the very condition that got us
+		// here and would make the withdrawal a no-op.
+		if err := w.withdrawSecurityReadEntry(ctx, conn); err != nil {
+			return err
+		}
+		// And stop being due. A connection that has nothing to renew but keeps
+		// a past expiry is swept on EVERY tick, forever — which is the state
+		// every watch-only connection is born in, since the opt-in starts off.
+		return w.parkSecurityOnly(ctx, conn)
 	}
 	secTok, expiresAt, err := w.SecurityMinter(ctx, conn)
-	if errors.Is(err, ErrPermissionsNotGranted) {
-		if derr := w.dropSecurityReadEntry(ctx, conn); derr != nil {
+	switch {
+	case errors.Is(err, ErrPermissionsNotGranted):
+		if derr := w.withdrawSecurityReadEntry(ctx, conn); derr != nil {
 			return derr
 		}
 		return w.markSecurityReadDegraded(ctx, conn, err)
-	}
-	if err != nil {
+	case errors.Is(err, ErrUnauthorized):
+		// The App's key was rotated, or the installation suspended. The
+		// runtime lane calls markRevoked here; without the same treatment the
+		// connection keeps reading "active" while the map holds a token that
+		// dies within the hour — a 401 in the bot with nothing to explain it.
+		return w.markRevoked(ctx, conn)
+	case err != nil:
+		// Transient (or at least unclassified): keep retrying, but do not let
+		// the map keep promising freshness it no longer has. The map carries
+		// no expiry of its own, so once the expiry we recorded has passed the
+		// token in it is dead by definition.
+		if conn.AccessTokenExpiresAt != nil && !conn.AccessTokenExpiresAt.After(w.now()) {
+			if derr := w.withdrawSecurityReadEntry(ctx, conn); derr != nil {
+				return derr
+			}
+		}
 		return fmt.Errorf("forge: security-read mint for connection %s: %w", conn.ID, err)
 	}
-	if err := UpsertSecurityReadToken(ctx, w.Secrets, w.Sealer, &conn, secTok, w.now()); err != nil {
-		return err
-	}
+	// Date the connection from the token BEFORE the upsert, and persist it
+	// even when the upsert fails: an upsert that fails permanently (a
+	// malformed operator-written map, an unkeyable connection) would otherwise
+	// leave the connection perpetually due and re-mint against GitHub on every
+	// tick, forever.
 	now := w.now()
 	conn.Status = StatusActive
 	conn.StatusReason = "" // the security lane IS this connection: a good mint clears it
 	conn.LastRefreshedAt = &now
-	if !expiresAt.IsZero() {
-		exp := expiresAt
-		conn.AccessTokenExpiresAt = &exp
+	exp := expiresAt
+	if exp.IsZero() {
+		// Mirror the GitHub client's own default rather than leaving the
+		// connection undated (which reads as "never expires" to the sweep).
+		exp = now.Add(time.Hour)
 	}
+	conn.AccessTokenExpiresAt = &exp
+	conn.UpdatedAt = now
+
+	upsertErr := UpsertSecurityReadToken(ctx, w.Secrets, w.Sealer, &conn, secTok, now)
+	if upsertErr != nil && isPermanentSecurityReadErr(upsertErr) {
+		// Permanent by nature: retrying cannot fix a malformed map or a
+		// connection with no org to key on. Record it once instead of
+		// re-minting every ten minutes.
+		return w.markSecurityReadDegraded(ctx, conn, upsertErr)
+	}
+	// An operator may have switched the opt-in off while the mint was in
+	// flight (a few hundred ms, six times an hour). Blindly writing back the
+	// record we read at the top of the sweep would resurrect their choice —
+	// and we would have just re-uploaded the token they asked us to withdraw.
+	if fresh, ferr := w.Connections.Get(ctx, conn.ID); ferr == nil && !fresh.SecurityReadEnabled {
+		return w.withdrawSecurityReadEntry(ctx, fresh)
+	}
+	if err := w.Connections.Update(ctx, conn); err != nil {
+		return err
+	}
+	return upsertErr
+}
+
+// isPermanentSecurityReadErr classifies an upsert failure that no retry can
+// fix: the map an operator hand-wrote is not a map, or the connection has no
+// org name to file its token under.
+func isPermanentSecurityReadErr(err error) bool {
+	return errors.Is(err, ErrSecurityReadMalformed) || errors.Is(err, ErrSecurityReadNoOrgKey)
+}
+
+// parkSecurityOnly takes an idle watch-only connection out of the refresh
+// sweep by clearing the expiry that keeps it due. It has no token to renew;
+// the enable endpoint re-dates it when the opt-in comes back on.
+func (w *RefreshWorker) parkSecurityOnly(ctx context.Context, conn Connection) error {
+	if conn.AccessTokenExpiresAt == nil {
+		return nil // already parked — do not rewrite the record on every tick
+	}
+	now := w.now()
+	conn.AccessTokenExpiresAt = nil
 	conn.UpdatedAt = now
 	return w.Connections.Update(ctx, conn)
 }
@@ -305,7 +370,18 @@ func (w *RefreshWorker) markSecurityReadDegraded(ctx context.Context, conn Conne
 // revoked): a token in that map is a promise of freshness, and a connection
 // that stopped refreshing must not leave a silently-dying one behind.
 func (w *RefreshWorker) dropSecurityReadEntry(ctx context.Context, conn Connection) error {
-	if !conn.SecurityReadEnabled || conn.Kind != KindGitHubApp {
+	if !conn.SecurityReadEnabled {
+		return nil
+	}
+	return w.withdrawSecurityReadEntry(ctx, conn)
+}
+
+// withdrawSecurityReadEntry removes the connection's org entry unconditionally
+// — the opt-in flag is NOT consulted. It is what the opt-out path needs:
+// "the flag is off" is precisely why an entry left behind must go, so a guard
+// on that same flag would turn the withdrawal into a no-op.
+func (w *RefreshWorker) withdrawSecurityReadEntry(ctx context.Context, conn Connection) error {
+	if conn.Kind != KindGitHubApp {
 		return nil
 	}
 	// RunOnce's ctx carries NO tenant (it sweeps every tenant), and the

--- a/pkg/forge/refresh.go
+++ b/pkg/forge/refresh.go
@@ -49,7 +49,13 @@ type RefreshWorker struct {
 	// SecurityReadEnabled. The worker re-mints it alongside each connection
 	// refresh (both tokens live ~1h, so they rotate together) and merges it
 	// into the tenant's dependabot_tokens secret. Nil = feature unwired.
-	SecurityMinter func(ctx context.Context, conn Connection) (string, error)
+	//
+	// It returns the token's own expiry because a PurposeSecurityRead
+	// connection has no runtime token to date the sweep from: that expiry is
+	// the ONLY thing that puts the connection back on ExpiringBefore's list,
+	// and without it a watch-only connection would mint once and then go
+	// quiet forever.
+	SecurityMinter func(ctx context.Context, conn Connection) (string, time.Time, error)
 	// Lead is how far before expiry a token is refreshed (default 5m).
 	Lead time.Duration
 	Now  func() time.Time
@@ -97,6 +103,21 @@ func (w *RefreshWorker) RunOnce(ctx context.Context) (int, error) {
 // generic secret SECOND, so a crash between them leaves a working-but-old
 // secret rather than a zero value.
 func (w *RefreshWorker) refreshOne(ctx context.Context, conn Connection) error {
+	// A watch-only connection holds an App with metadata:read +
+	// vulnerability_alerts:read and NOTHING else. Asking the ordinary
+	// refresher for a runtime token would request permissions it was
+	// deliberately never granted: GitHub answers 422, markDegraded fires, and
+	// dropSecurityReadEntry withdraws the very token this connection exists to
+	// supply. Its whole refresh IS the security mint.
+	//
+	// This is decided BEFORE RefresherFor is consulted, and that order is
+	// load-bearing: a resolver that returns nil for a connection with no
+	// runtime credential would otherwise take the "not refreshable" exit and
+	// the security token would never be re-minted — alerts stopping about an
+	// hour after wiring, with nothing in the logs.
+	if conn.IsSecurityReadOnly() {
+		return w.refreshSecurityOnly(store.WithTenant(ctx, conn.TenantID), conn)
+	}
 	if w.RefresherFor == nil {
 		return nil
 	}
@@ -199,7 +220,7 @@ func (w *RefreshWorker) refreshOne(ctx context.Context, conn Connection) error {
 	// vuln-watch reading a dead token would otherwise fail with no trail
 	// on the server side.
 	if conn.SecurityReadEnabled && conn.Kind == KindGitHubApp && w.SecurityMinter != nil {
-		secTok, err := w.SecurityMinter(ctx, conn)
+		secTok, _, err := w.SecurityMinter(ctx, conn)
 		if errors.Is(err, ErrPermissionsNotGranted) {
 			// PERMANENT (the org revoked, or never approved, the alerts
 			// grant): retrying can never self-heal, and the entry already in
@@ -220,6 +241,44 @@ func (w *RefreshWorker) refreshOne(ctx context.Context, conn Connection) error {
 		}
 	}
 	return nil
+}
+
+// refreshSecurityOnly is the whole refresh cycle of a PurposeSecurityRead
+// connection: mint the org-wide alerts token, merge it into the tenant's
+// dependabot_tokens map, and date the connection from the token's own expiry
+// so the next sweep picks it up. There is no runtime token, no managed secret
+// and no refresh-token grant involved.
+func (w *RefreshWorker) refreshSecurityOnly(ctx context.Context, conn Connection) error {
+	if !conn.SecurityReadEnabled || w.SecurityMinter == nil {
+		// Opt-in switched off (or the feature is unwired): the connection has
+		// no other job, so there is nothing to renew. Withdraw any entry it
+		// still owns rather than letting a token the map promises to keep
+		// fresh quietly expire.
+		return w.dropSecurityReadEntry(ctx, conn)
+	}
+	secTok, expiresAt, err := w.SecurityMinter(ctx, conn)
+	if errors.Is(err, ErrPermissionsNotGranted) {
+		if derr := w.dropSecurityReadEntry(ctx, conn); derr != nil {
+			return derr
+		}
+		return w.markSecurityReadDegraded(ctx, conn, err)
+	}
+	if err != nil {
+		return fmt.Errorf("forge: security-read mint for connection %s: %w", conn.ID, err)
+	}
+	if err := UpsertSecurityReadToken(ctx, w.Secrets, w.Sealer, &conn, secTok, w.now()); err != nil {
+		return err
+	}
+	now := w.now()
+	conn.Status = StatusActive
+	conn.StatusReason = "" // the security lane IS this connection: a good mint clears it
+	conn.LastRefreshedAt = &now
+	if !expiresAt.IsZero() {
+		exp := expiresAt
+		conn.AccessTokenExpiresAt = &exp
+	}
+	conn.UpdatedAt = now
+	return w.Connections.Update(ctx, conn)
 }
 
 // securityReadDegradePrefix marks a StatusReason that belongs to the

--- a/pkg/forge/security_read.go
+++ b/pkg/forge/security_read.go
@@ -165,6 +165,16 @@ func UpsertSecurityReadToken(ctx context.Context, st secrets.GenericSecretStore,
 				return err
 			}
 		}
+		// An org rename moves the derived key, and the health probe rewrites
+		// InstallationAccount from live truth — so the very NEXT refresh files
+		// under the new key. Drop the entry this connection filed last time
+		// before the recorded key is overwritten: otherwise both of
+		// RemoveSecurityReadToken's candidate keys become the new one and the
+		// pre-rename entry is unreachable by every withdrawal path, leaving a
+		// live token advertised under a stale org name until it dies.
+		if prev := strings.ToLower(strings.TrimSpace(conn.SecurityReadOrgKey)); prev != "" && prev != org {
+			delete(tokens, prev)
+		}
 		tokens[org] = token
 		// Remember where it landed, so withdrawal never has to guess (see
 		// Connection.SecurityReadOrgKey).

--- a/pkg/forge/security_read.go
+++ b/pkg/forge/security_read.go
@@ -35,6 +35,12 @@ const securityReadCreatedBy = "forge-security-read"
 // from a store/seal failure matters: those leave a LIVE token behind.
 var ErrSecurityReadMalformed = errors.New("forge: malformed security-read secret")
 
+// ErrSecurityReadNoOrgKey marks a connection that cannot be filed in the map
+// because nothing names the org it operates on. Like a missing grant this is
+// permanent — retrying re-derives the same nothing — so the refresh worker
+// records it once instead of re-minting against the forge on every tick.
+var ErrSecurityReadNoOrgKey = errors.New("forge: connection has no org to key its security-read token by")
+
 // fingerprintGuardedStore is the optional CAS capability a GenericSecretStore
 // may implement. The dependabot_tokens map is the first generic secret SHARED
 // across connections and rewritten by every replica's refresh worker;
@@ -112,13 +118,13 @@ func securityReadOrgKey(conn *Connection) (string, error) {
 	if conn.Kind == KindGitHubApp {
 		org := strings.ToLower(strings.TrimSpace(conn.InstallationAccount))
 		if org == "" {
-			return "", fmt.Errorf("forge: connection %s has no installation account recorded — cannot key its security-read token by org (reconnect, or open the connection's health view to refresh it)", conn.ID)
+			return "", fmt.Errorf("%w: connection %s has no installation account recorded (reconnect, or open the connection's health view to refresh it)", ErrSecurityReadNoOrgKey, conn.ID)
 		}
 		return org, nil
 	}
 	org := strings.ToLower(strings.TrimSpace(conn.AccountLogin))
 	if org == "" {
-		return "", fmt.Errorf("forge: connection %s has no account login — cannot key its security-read token", conn.ID)
+		return "", fmt.Errorf("%w: connection %s has no account login", ErrSecurityReadNoOrgKey, conn.ID)
 	}
 	return org, nil
 }
@@ -160,6 +166,9 @@ func UpsertSecurityReadToken(ctx context.Context, st secrets.GenericSecretStore,
 			}
 		}
 		tokens[org] = token
+		// Remember where it landed, so withdrawal never has to guess (see
+		// Connection.SecurityReadOrgKey).
+		conn.SecurityReadOrgKey = org
 		encoded, err := encodeSecurityReadTokens(tokens)
 		if err != nil {
 			return err
@@ -248,9 +257,22 @@ func unionHosts(a, b []string) []string {
 // No-op when the secret or the entry is absent. Same CAS discipline as the
 // upsert: a plain overwrite could resurrect a concurrent writer's entry.
 func RemoveSecurityReadToken(ctx context.Context, st secrets.GenericSecretStore, sealer secrets.Sealer, conn *Connection) error {
+	// Both the key the token was FILED under and the one derivable now: an org
+	// rename makes them differ, and taking only the derived one strands a live
+	// token nothing can ever reach. A missing derived key is not fatal when a
+	// recorded one exists — withdrawal must work on exactly the connections
+	// whose key can no longer be computed.
+	keys := map[string]bool{}
+	if recorded := strings.ToLower(strings.TrimSpace(conn.SecurityReadOrgKey)); recorded != "" {
+		keys[recorded] = true
+	}
 	org, err := securityReadOrgKey(conn)
 	if err != nil {
-		return err
+		if len(keys) == 0 {
+			return err
+		}
+	} else {
+		keys[org] = true
 	}
 	for attempt := 0; ; attempt++ {
 		gs, ok, err := findSecurityReadSecret(ctx, st, conn.TenantID)
@@ -265,10 +287,16 @@ func RemoveSecurityReadToken(ctx context.Context, st secrets.GenericSecretStore,
 		if err != nil {
 			return err
 		}
-		if _, present := tokens[org]; !present {
+		removed := false
+		for k := range keys {
+			if _, present := tokens[k]; present {
+				delete(tokens, k)
+				removed = true
+			}
+		}
+		if !removed {
 			return nil
 		}
-		delete(tokens, org)
 		if len(tokens) == 0 && gs.CreatedBy == securityReadCreatedBy {
 			if err := st.Delete(ctx, gs.ID); err != nil {
 				return fmt.Errorf("forge: delete emptied %s secret: %w", SecurityReadSecretName, err)

--- a/pkg/forge/security_read_test.go
+++ b/pkg/forge/security_read_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -168,12 +169,12 @@ func TestRefreshWorker_MintsSecurityReadTokenAlongsideRefresh(t *testing.T) {
 		RefresherFor: func(Connection) TokenRefresher {
 			return fakeRefresher{newAccess: "fresh-install-token", expiresAt: now.Add(time.Hour)}
 		},
-		SecurityMinter: func(_ context.Context, conn Connection) (string, error) {
+		SecurityMinter: func(_ context.Context, conn Connection) (string, time.Time, error) {
 			minted++
 			if conn.ID != "conn-gh" {
 				t.Fatalf("minter called for %s", conn.ID)
 			}
-			return "sec-read-token", nil
+			return "sec-read-token", time.Time{}, nil
 		},
 	}
 	if _, err := w.RunOnce(context.Background()); err != nil {
@@ -203,9 +204,9 @@ func TestRefreshWorker_SecurityMinterSkippedWhenNotOptedIn(t *testing.T) {
 		RefresherFor: func(Connection) TokenRefresher {
 			return fakeRefresher{newAccess: "fresh", expiresAt: now.Add(time.Hour)}
 		},
-		SecurityMinter: func(context.Context, Connection) (string, error) {
+		SecurityMinter: func(context.Context, Connection) (string, time.Time, error) {
 			t.Fatal("security minter must not run for a connection that did not opt in")
-			return "", nil
+			return "", time.Time{}, nil
 		},
 	}
 	if _, err := w.RunOnce(context.Background()); err != nil {
@@ -231,12 +232,12 @@ func TestRefreshWorker_SecurityMintFailureSurfacesButKeepsRefresh(t *testing.T) 
 		RefresherFor: func(Connection) TokenRefresher {
 			return fakeRefresher{newAccess: "fresh-install-token", expiresAt: now.Add(time.Hour)}
 		},
-		SecurityMinter: func(context.Context, Connection) (string, error) {
+		SecurityMinter: func(context.Context, Connection) (string, time.Time, error) {
 			// TRANSIENT (a forge blip). The permanent class
 			// (ErrPermissionsNotGranted) has its own contract — recorded
 			// once and withdrawn, see
 			// TestRefreshWorker_PermanentMintFailureDisablesAndWithdraws.
-			return "", errors.New("github: 502 bad gateway")
+			return "", time.Time{}, errors.New("github: 502 bad gateway")
 		},
 	}
 	_, err := w.RunOnce(context.Background())
@@ -399,9 +400,9 @@ func TestRefreshWorker_WithdrawsEntryWhenConnectionCannotRefresh(t *testing.T) {
 		Connections: connStore, Secrets: tenantScoped, Sealer: sealer,
 		Now:          func() time.Time { return now },
 		RefresherFor: func(Connection) TokenRefresher { return fakeRefresher{newAccess: "x", expiresAt: now.Add(time.Hour)} },
-		SecurityMinter: func(context.Context, Connection) (string, error) {
+		SecurityMinter: func(context.Context, Connection) (string, time.Time, error) {
 			t.Fatal("a degraded connection must not be re-minted")
-			return "", nil
+			return "", time.Time{}, nil
 		},
 	}
 	if _, err := w.RunOnce(context.Background()); err != nil {
@@ -429,10 +430,10 @@ func TestRefreshWorker_PermanentMintFailureDisablesAndWithdraws(t *testing.T) {
 		RefresherFor: func(Connection) TokenRefresher {
 			return fakeRefresher{newAccess: "fresh", expiresAt: now.Add(time.Hour)}
 		},
-		SecurityMinter: func(context.Context, Connection) (string, error) {
+		SecurityMinter: func(context.Context, Connection) (string, time.Time, error) {
 			calls++
 			// The org revoked (or never approved) the alerts grant.
-			return "", ErrPermissionsNotGranted
+			return "", time.Time{}, ErrPermissionsNotGranted
 		},
 	}
 	if _, err := w.RunOnce(context.Background()); err != nil {
@@ -509,8 +510,8 @@ func TestRefreshWorker_KeepsTheSecurityReadReasonAcrossRefreshes(t *testing.T) {
 		RefresherFor: func(Connection) TokenRefresher {
 			return fakeRefresher{newAccess: "fresh", expiresAt: clock.Add(time.Hour)}
 		},
-		SecurityMinter: func(context.Context, Connection) (string, error) {
-			return "", ErrPermissionsNotGranted
+		SecurityMinter: func(context.Context, Connection) (string, time.Time, error) {
+			return "", time.Time{}, ErrPermissionsNotGranted
 		},
 	}
 	if _, err := w.RunOnce(context.Background()); err != nil {
@@ -536,5 +537,155 @@ func TestRefreshWorker_KeepsTheSecurityReadReasonAcrossRefreshes(t *testing.T) {
 	}
 	if !strings.Contains(got.StatusReason, "Dependabot alerts") {
 		t.Fatalf("the security-read reason was erased by an ordinary refresh: %q", got.StatusReason)
+	}
+}
+
+// seedWatchOnlyConn is a PurposeSecurityRead connection: an App holding
+// metadata + vulnerability_alerts and nothing else.
+func seedWatchOnlyConn(t *testing.T, sealer secrets.Sealer, connStore ConnectionStore, expiresAt time.Time, optedIn bool) Connection {
+	t.Helper()
+	c := seedGitHubAppConn(t, sealer, connStore, expiresAt, optedIn)
+	c.Purpose = PurposeSecurityRead
+	if err := connStore.Update(context.Background(), c); err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// The whole point of the role: a watch-only connection must never ask for a
+// RUNTIME token. Its App was never granted contents/pull_requests, so the
+// mint would 422 → markDegraded → dropSecurityReadEntry, i.e. the connection
+// would destroy the one token it exists to provide, roughly an hour after
+// being wired. The runtime refresher here fails the test if it is consulted.
+func TestRefreshWorker_WatchOnlyNeverMintsRuntimeToken(t *testing.T) {
+	sealer, _ := secrets.NewAESGCMSealer(make([]byte, 32))
+	connStore := NewMemoryConnectionStore()
+	secStore := secrets.NewMemoryGenericSecretStore()
+	now := time.Unix(1700000000, 0).UTC()
+	seedWatchOnlyConn(t, sealer, connStore, now.Add(2*time.Minute), true)
+
+	w := &RefreshWorker{
+		Connections: connStore,
+		Secrets:     secStore,
+		Sealer:      sealer,
+		Now:         func() time.Time { return now },
+		RefresherFor: func(Connection) TokenRefresher {
+			t.Fatal("the runtime refresher must not run for a watch-only connection")
+			return nil
+		},
+		SecurityMinter: func(context.Context, Connection) (string, time.Time, error) {
+			return "sec-read-token", now.Add(time.Hour), nil
+		},
+	}
+	if _, err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if m := securityReadMap(t, sealer, secStore, "t1"); m["socialgouv"] != "sec-read-token" {
+		t.Fatalf("map = %v, want socialgouv → sec-read-token", m)
+	}
+	got, err := connStore.Get(context.Background(), "conn-gh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != StatusActive {
+		t.Fatalf("status = %q (reason %q), want active", got.Status, got.StatusReason)
+	}
+}
+
+// A watch-only connection has no runtime token to date the sweep from, so the
+// SECURITY token's expiry is what puts it back on ExpiringBefore's list.
+// Without it the connection mints once and then goes quiet forever — the
+// failure mode is invisible until alerts silently stop an hour later.
+func TestRefreshWorker_WatchOnlyRearmsFromSecurityTokenExpiry(t *testing.T) {
+	sealer, _ := secrets.NewAESGCMSealer(make([]byte, 32))
+	connStore := NewMemoryConnectionStore()
+	secStore := secrets.NewMemoryGenericSecretStore()
+	now := time.Unix(1700000000, 0).UTC()
+	seedWatchOnlyConn(t, sealer, connStore, now.Add(2*time.Minute), true)
+
+	mintExpiry := now.Add(time.Hour)
+	w := &RefreshWorker{
+		Connections:  connStore,
+		Secrets:      secStore,
+		Sealer:       sealer,
+		Now:          func() time.Time { return now },
+		RefresherFor: func(Connection) TokenRefresher { return fakeRefresher{} },
+		SecurityMinter: func(context.Context, Connection) (string, time.Time, error) {
+			return "sec-read-token", mintExpiry, nil
+		},
+	}
+	if _, err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	got, err := connStore.Get(context.Background(), "conn-gh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessTokenExpiresAt == nil || !got.AccessTokenExpiresAt.Equal(mintExpiry) {
+		t.Fatalf("AccessTokenExpiresAt = %v, want the mint's own expiry %v", got.AccessTokenExpiresAt, mintExpiry)
+	}
+	// The real proof: a later sweep, positioned just before that expiry, finds
+	// the connection again and re-mints.
+	later := mintExpiry.Add(-2 * time.Minute)
+	minted := 0
+	w.Now = func() time.Time { return later }
+	w.SecurityMinter = func(context.Context, Connection) (string, time.Time, error) {
+		minted++
+		return "sec-read-token-2", later.Add(time.Hour), nil
+	}
+	if _, err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("second RunOnce: %v", err)
+	}
+	if minted != 1 {
+		t.Fatalf("re-mints on the next sweep = %d, want 1 — the connection fell out of the rotation", minted)
+	}
+}
+
+// A permanent grant failure on a watch-only connection follows the same
+// contract as on a runtime one: withdraw the entry (a token in the map is a
+// promise of freshness) and record the reason once.
+func TestRefreshWorker_WatchOnlyPermanentFailureWithdrawsAndRecords(t *testing.T) {
+	sealer, _ := secrets.NewAESGCMSealer(make([]byte, 32))
+	connStore := NewMemoryConnectionStore()
+	secStore := secrets.NewMemoryGenericSecretStore()
+	now := time.Unix(1700000000, 0).UTC()
+	conn := seedWatchOnlyConn(t, sealer, connStore, now.Add(2*time.Minute), true)
+	if err := UpsertSecurityReadToken(context.Background(), secStore, sealer, &conn, "stale-token", now); err != nil {
+		t.Fatal(err)
+	}
+
+	w := &RefreshWorker{
+		Connections:  connStore,
+		Secrets:      secStore,
+		Sealer:       sealer,
+		Now:          func() time.Time { return now },
+		RefresherFor: func(Connection) TokenRefresher { return fakeRefresher{} },
+		SecurityMinter: func(context.Context, Connection) (string, time.Time, error) {
+			return "", time.Time{}, fmt.Errorf("%w: the installation lacks 'Dependabot alerts: read'", ErrPermissionsNotGranted)
+		},
+	}
+	if _, err := w.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	// Withdrawing the only entry empties the map, which deletes the secret
+	// outright — so "gone" and "present without this org" are both correct
+	// withdrawals, and only a surviving entry is a failure.
+	if gs, ok, err := findSecurityReadSecret(context.Background(), secStore, "t1"); err != nil {
+		t.Fatal(err)
+	} else if ok {
+		m := securityReadMap(t, sealer, secStore, "t1")
+		if m["socialgouv"] != "" {
+			t.Fatalf("stale entry survived a permanent failure: %v (secret %s)", m, gs.ID)
+		}
+	}
+	got, err := connStore.Get(context.Background(), "conn-gh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SecurityReadEnabled {
+		t.Fatal("opt-in should be switched off after a permanent grant failure")
+	}
+	if !strings.HasPrefix(got.StatusReason, securityReadDegradePrefix) {
+		t.Fatalf("StatusReason = %q, want the security-read explanation", got.StatusReason)
 	}
 }

--- a/pkg/forge/types.go
+++ b/pkg/forge/types.go
@@ -177,6 +177,15 @@ type Connection struct {
 	//     defect — they are the point.
 	Purpose Purpose `bson:"purpose,omitempty" json:"purpose,omitempty"`
 
+	// SecurityReadOrgKey records the key this connection's token was actually
+	// FILED UNDER in the dependabot_tokens map. Withdrawal reads it instead of
+	// re-deriving the key from InstallationAccount, which the health probe
+	// rewrites from live truth: after a GitHub org rename the derived key no
+	// longer matches the deposited one, and the old entry becomes a dead token
+	// no withdrawal path can reach — the map never empties, so the secret is
+	// never deleted, and a disconnect leaves it readable by every bot.
+	SecurityReadOrgKey string `bson:"security_read_org_key,omitempty" json:"-"`
+
 	Status ConnectionStatus `bson:"status" json:"status"`
 
 	// StatusReason is a human-readable explanation for a non-active Status

--- a/pkg/forge/types.go
+++ b/pkg/forge/types.go
@@ -79,6 +79,24 @@ const (
 	StatusDegraded ConnectionStatus = "degraded"
 )
 
+// Purpose is the role a connection plays. It is deliberately NOT derived
+// from the granted permissions: a runtime App that an owner narrowed by
+// mistake must read as broken (degraded, with a reason), not silently
+// re-label itself a security-read connection and stop doing its job.
+type Purpose string
+
+const (
+	// PurposeRuntime is the zero value, so every connection that existed
+	// before this field keeps its behaviour with no migration.
+	PurposeRuntime Purpose = ""
+	// PurposeSecurityRead is a read-only alerts source. See Connection.Purpose.
+	PurposeSecurityRead Purpose = "security_read"
+)
+
+// IsSecurityReadOnly reports whether this connection exists only to mint the
+// org-wide Dependabot-alerts token and must never be used for runtime work.
+func (c Connection) IsSecurityReadOnly() bool { return c.Purpose == PurposeSecurityRead }
+
 // Connection is a team's authenticated link to one forge account. The
 // admin token material lives sealed on SealedPayload (AAD bound to ID);
 // the JSON encoder drops it so it never reaches the studio.
@@ -141,6 +159,23 @@ type Connection struct {
 	// secret the vuln-watch bot reads. Off by default: alert data is
 	// sensitive, so a team turns it on per connection, deliberately.
 	SecurityReadEnabled bool `bson:"security_read_enabled,omitempty" json:"security_read_enabled,omitempty"`
+
+	// Purpose is what this connection is FOR. Empty (PurposeRuntime) is the
+	// ordinary forge connection: it clones, pushes, opens PRs, carries
+	// webhooks. PurposeSecurityRead marks a connection whose App holds only
+	// metadata:read + vulnerability_alerts:read — it exists solely to mint the
+	// org-wide Dependabot-alerts token, and CANNOT do runtime work.
+	//
+	// The distinction is load-bearing in three places, and skipping any one of
+	// them breaks the connection rather than merely limiting it:
+	//   - the refresh worker must not mint a RUNTIME token for it (the mint
+	//     would 422 on permissions it deliberately lacks, marking it degraded
+	//     and withdrawing the very token it exists to supply);
+	//   - the auto-resolvers that pick "a connection on this host" must skip
+	//     it, or a review lands on a connection that cannot post;
+	//   - the health view must not report its absent delivery grants as a
+	//     defect — they are the point.
+	Purpose Purpose `bson:"purpose,omitempty" json:"purpose,omitempty"`
 
 	Status ConnectionStatus `bson:"status" json:"status"`
 

--- a/pkg/forge/watch_only_exclusion_test.go
+++ b/pkg/forge/watch_only_exclusion_test.go
@@ -1,0 +1,140 @@
+package forge
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+// seedWatchOnlyRuntimeConn is a watch-only connection on the orchestrator's
+// store, shaped like the ones Provision is normally handed.
+func seedWatchOnlyRuntimeConn(t *testing.T, o *Orchestrator, sealer secrets.Sealer) Connection {
+	t.Helper()
+	c := seedConn(t, o, sealer)
+	c.Purpose = PurposeSecurityRead
+	if err := o.Connections.Update(context.Background(), c); err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// Provision writes the bot bindings BEFORE its first forge call, the binding
+// key is (tenant, bot, secret_name) and therefore TEAM-GLOBAL, and nothing
+// rolls it back. So a watch-only connection accepted here does not merely fail
+// — it repoints every repo of that bot at a token that cannot push, and the
+// operator only sees "provision failed". Refusing at ensureManagedSecret is
+// what makes that impossible: it runs before any binding is written.
+func TestProvision_RefusesWatchOnlyBeforeWritingAnyBinding(t *testing.T) {
+	o, _, sealer := newTestOrch(t)
+	conn := seedWatchOnlyRuntimeConn(t, o, sealer)
+
+	_, err := o.Provision(context.Background(), ProvisionRequest{
+		TenantID:     "t1",
+		ConnectionID: conn.ID,
+		RepoFullName: "grp/app",
+		BotIDs:       []string{"review-pr"},
+		ActorID:      "u1",
+	})
+	if err == nil {
+		t.Fatal("Provision accepted a watch-only connection")
+	}
+	// The message has to name the cause: the operator picked this connection.
+	if got := err.Error(); !strings.Contains(got, "watch-only") {
+		t.Fatalf("error = %q, want it to name the watch-only role", got)
+	}
+	// Nothing was written — no managed secret, no binding, no integration.
+	fresh, gerr := o.Connections.Get(context.Background(), conn.ID)
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	if fresh.ManagedSecretID != "" {
+		t.Fatalf("a managed secret was created for a watch-only connection: %s", fresh.ManagedSecretID)
+	}
+	if b, berr := o.Bindings.ListByTenant(context.Background(), "t1"); berr == nil && len(b) > 0 {
+		t.Fatalf("bindings were written before the refusal: %+v", b)
+	}
+}
+
+// EnsureManagedSecret is the same chokepoint reached by the repo-targeted
+// launch path, which asks for a run's forge token.
+func TestEnsureManagedSecret_RefusesWatchOnly(t *testing.T) {
+	o, _, sealer := newTestOrch(t)
+	conn := seedWatchOnlyRuntimeConn(t, o, sealer)
+	if _, err := o.EnsureManagedSecret(context.Background(), &conn, "launch"); err == nil {
+		t.Fatal("EnsureManagedSecret handed a runtime token to a watch-only connection")
+	}
+}
+
+// A watch-only App must never be the IMPLICIT answer to "which app for this
+// host". This listing is oldest-first, so a team that registered its watch-only
+// App first — the natural order for a security-first onboarding — would have
+// every default install and every OAuth connect resolve to an App with no
+// rights, producing a connection labelled runtime that can do nothing.
+func TestGetByInstance_SkipsWatchOnlyApps(t *testing.T) {
+	st := NewMemoryOAuthAppStore()
+	ctx := context.Background()
+	base := CanonicalBaseURL(ProviderGitHub, "")
+	mk := func(id, owner string, watch bool, at time.Time) ForgeOAuthApp {
+		return ForgeOAuthApp{
+			ID: id, TenantID: "t1", Provider: ProviderGitHub, ForgeBaseURL: base,
+			ClientID: id, OwnerLogin: owner, SecurityReadOnly: watch, CreatedAt: at,
+		}
+	}
+	// Watch-only registered FIRST (it is the oldest).
+	if err := st.Create(ctx, mk("watch", "OrgA", true, time.Unix(1, 0))); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Create(ctx, mk("runtime", "OrgB", false, time.Unix(2, 0))); err != nil {
+		t.Fatal(err)
+	}
+	got, err := st.GetByInstance(ctx, "t1", ProviderGitHub, base)
+	if err != nil {
+		t.Fatalf("GetByInstance: %v", err)
+	}
+	if got.ID != "runtime" {
+		t.Fatalf("default app = %q, want the runtime one", got.ID)
+	}
+
+	// With ONLY a watch-only App, the answer is "none" — a clean error beats
+	// silently authorizing against an App that holds nothing.
+	only := NewMemoryOAuthAppStore()
+	if err := only.Create(ctx, mk("watch", "OrgA", true, time.Unix(1, 0))); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := only.GetByInstance(ctx, "t1", ProviderGitHub, base); !errors.Is(err, ErrOAuthAppNotFound) {
+		t.Fatalf("GetByInstance err = %v, want ErrOAuthAppNotFound", err)
+	}
+}
+
+// One org legitimately hosts a runtime App AND a watch-only App. Without the
+// role in the uniqueness key the second collides — and the collision is only
+// discovered at the manifest callback, after GitHub created the App and handed
+// back the private key it never reissues, which iterion then drops on the floor.
+func TestOAuthAppUniqueness_AllowsRuntimeAndWatchOnlyOnTheSameOrg(t *testing.T) {
+	st := NewMemoryOAuthAppStore()
+	ctx := context.Background()
+	base := CanonicalBaseURL(ProviderGitHub, "")
+	mk := func(id string, watch bool) ForgeOAuthApp {
+		return ForgeOAuthApp{
+			ID: id, TenantID: "t1", Provider: ProviderGitHub, ForgeBaseURL: base,
+			ClientID: id, OwnerLogin: "SocialGouv", SecurityReadOnly: watch,
+		}
+	}
+	if err := st.Create(ctx, mk("runtime", false)); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Create(ctx, mk("watch", true)); err != nil {
+		t.Fatalf("the watch-only App collided with the runtime one: %v", err)
+	}
+	// Two apps of the SAME role on one org still collide.
+	if err := st.Create(ctx, mk("runtime-2", false)); !errors.Is(err, ErrOAuthAppExists) {
+		t.Fatalf("second runtime app err = %v, want ErrOAuthAppExists", err)
+	}
+	if err := st.Create(ctx, mk("watch-2", true)); !errors.Is(err, ErrOAuthAppExists) {
+		t.Fatalf("second watch-only app err = %v, want ErrOAuthAppExists", err)
+	}
+}

--- a/pkg/forge/watch_only_lifecycle_test.go
+++ b/pkg/forge/watch_only_lifecycle_test.go
@@ -245,3 +245,122 @@ func TestWatchOnly_ZeroMintExpiryStillDatesTheConnection(t *testing.T) {
 		t.Fatalf("AccessTokenExpiresAt = %v, want the one-hour default %v", exp, want)
 	}
 }
+
+// markRevoked does not clear the expiry, and this lane deliberately bypasses
+// the StatusDegraded early-exit that stops the runtime lane re-entering. So a
+// revoked watch-only connection that stays dated is re-minted against the forge
+// on every tick, forever, with no self-heal path. A single RunOnce cannot see
+// it — the sweep has to run more than once.
+func TestWatchOnly_RevokedConnectionLeavesTheSweepInsteadOfLooping(t *testing.T) {
+	mints := 0
+	h := newLifecycleHarness(t, true, nil)
+	h.worker.SecurityMinter = func(context.Context, Connection) (string, time.Time, error) {
+		mints++
+		return "", time.Time{}, fmt.Errorf("mint: %w", ErrUnauthorized)
+	}
+	for i := 0; i < 8; i++ {
+		_, _ = h.worker.RunOnce(context.Background())
+		h.now = h.now.Add(10 * time.Minute)
+	}
+	if mints > 1 {
+		t.Fatalf("mints = %d over eight ticks — a revoked connection is hammering the forge forever", mints)
+	}
+	if exp := h.conn(t).AccessTokenExpiresAt; exp != nil {
+		t.Fatalf("AccessTokenExpiresAt = %v, want nil — a revoked credential must leave the sweep", exp)
+	}
+}
+
+// The new expiry is written before the upsert. On a TRANSIENT upsert failure
+// the token never reached the map, so persisting that expiry would take the
+// connection out of the sweep for ~55 minutes while the map still advertises
+// the PREVIOUS token, which is expiring right now.
+func TestWatchOnly_TransientUpsertFailureKeepsTheConnectionDue(t *testing.T) {
+	h := newLifecycleHarness(t, true, func(context.Context, Connection) (string, time.Time, error) {
+		return "tok", time.Time{}, nil
+	})
+	before := h.conn(t).AccessTokenExpiresAt
+	h.worker.Secrets = failingSecretStore{GenericSecretStore: h.secrets, err: errors.New("mongo: connection reset")}
+
+	if _, err := h.worker.RunOnce(context.Background()); err == nil {
+		t.Fatal("a transient upsert failure must surface as an error")
+	}
+	got := h.conn(t).AccessTokenExpiresAt
+	if got == nil || !got.Equal(*before) {
+		t.Fatalf("expiry moved to %v (was %v) — the connection left the sweep with nothing in the map", got, before)
+	}
+	// Still due, so the next tick retries.
+	due, err := h.conns.ExpiringBefore(context.Background(), h.now.Add(5*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(due) != 1 {
+		t.Fatalf("due connections = %d, want 1 — nothing will retry", len(due))
+	}
+}
+
+// An UNWIRED feature says nothing about whether the token in the map is still
+// wanted. Treating a nil minter like "switched off" would let a partially-wired
+// replica strip live tokens from the tenant map.
+func TestWatchOnly_NilMinterSkipsInsteadOfWithdrawing(t *testing.T) {
+	h := newLifecycleHarness(t, true, nil) // minter left nil
+	conn := h.conn(t)
+	if err := UpsertSecurityReadToken(context.Background(), h.secrets, h.sealer, &conn, "live-token", h.now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.worker.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if !h.mapHas(t, "socialgouv") {
+		t.Fatal("an unwired minter stripped a live token from the map")
+	}
+}
+
+// The realistic ordering is rename → refresh → remove, not rename → remove:
+// the health probe rewrites InstallationAccount from live truth, so the very
+// next refresh files under the new key. Without dropping the previously
+// recorded entry at that moment, both of RemoveSecurityReadToken's candidate
+// keys become the new one and the pre-rename entry is unreachable forever.
+func TestWatchOnly_RenameThenRefreshThenRemoveLeavesNothingStranded(t *testing.T) {
+	h := newLifecycleHarness(t, true, func(context.Context, Connection) (string, time.Time, error) {
+		return "tok-2", time.Time{}, nil
+	})
+	conn := h.conn(t)
+	if err := UpsertSecurityReadToken(context.Background(), h.secrets, h.sealer, &conn, "tok-1", h.now); err != nil {
+		t.Fatal(err)
+	}
+	// GitHub org renamed; the health probe syncs the new account onto the
+	// connection, and the worker refreshes before anyone disconnects.
+	conn.InstallationAccount = "SocialGouv-Renamed"
+	if err := h.conns.Update(context.Background(), conn); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.worker.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if h.mapHas(t, "socialgouv") {
+		t.Fatal("the pre-rename entry survived the refresh — nothing can ever withdraw it")
+	}
+	if !h.mapHas(t, "socialgouv-renamed") {
+		t.Fatal("the refresh did not file the token under the new org")
+	}
+	// And the disconnect empties the map for real.
+	fresh := h.conn(t)
+	if err := RemoveSecurityReadToken(context.Background(), h.secrets, h.sealer, &fresh); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, ok, err := findSecurityReadSecret(context.Background(), h.secrets, "t1"); err != nil {
+		t.Fatal(err)
+	} else if ok {
+		t.Fatal("the secret survived a disconnect — the map never emptied")
+	}
+}
+
+// failingSecretStore makes the UPSERT fail transiently while every read still
+// works, so the test exercises the upsert branch and nothing else.
+type failingSecretStore struct {
+	secrets.GenericSecretStore
+	err error
+}
+
+func (f failingSecretStore) Create(context.Context, secrets.GenericSecret) error { return f.err }
+func (f failingSecretStore) Update(context.Context, secrets.GenericSecret) error { return f.err }

--- a/pkg/forge/watch_only_lifecycle_test.go
+++ b/pkg/forge/watch_only_lifecycle_test.go
@@ -1,0 +1,247 @@
+package forge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+type lifecycleHarness struct {
+	sealer  secrets.Sealer
+	conns   *MemoryConnectionStore
+	secrets secrets.GenericSecretStore
+	now     time.Time
+	worker  *RefreshWorker
+}
+
+func newLifecycleHarness(t *testing.T, optedIn bool, minter func(context.Context, Connection) (string, time.Time, error)) *lifecycleHarness {
+	t.Helper()
+	sealer, _ := secrets.NewAESGCMSealer(make([]byte, 32))
+	h := &lifecycleHarness{
+		sealer:  sealer,
+		conns:   NewMemoryConnectionStore(),
+		secrets: secrets.NewMemoryGenericSecretStore(),
+		now:     time.Unix(1700000000, 0).UTC(),
+	}
+	seedWatchOnlyConn(t, sealer, h.conns, h.now.Add(2*time.Minute), optedIn)
+	h.worker = &RefreshWorker{
+		Connections:    h.conns,
+		Secrets:        h.secrets,
+		Sealer:         sealer,
+		Now:            func() time.Time { return h.now },
+		RefresherFor:   func(Connection) TokenRefresher { return fakeRefresher{} },
+		SecurityMinter: minter,
+	}
+	return h
+}
+
+func (h *lifecycleHarness) conn(t *testing.T) Connection {
+	t.Helper()
+	c, err := h.conns.Get(context.Background(), "conn-gh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func (h *lifecycleHarness) mapHas(t *testing.T, org string) bool {
+	t.Helper()
+	gs, ok, err := findSecurityReadSecret(context.Background(), h.secrets, "t1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		return false
+	}
+	plain, err := secrets.OpenGenericSecret(h.sealer, gs.ID, gs.SealedSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := securityReadTokens(plain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m[org] != ""
+}
+
+// The runtime lane calls markRevoked on a 401 (rotated App key, suspended
+// installation) and withdraws the entry. Without the same classification the
+// watch-only connection keeps reading "active" while the map holds a token
+// that dies within the hour — a 401 in the bot with nothing to explain it.
+func TestWatchOnly_UnauthorizedMintRevokesAndWithdraws(t *testing.T) {
+	h := newLifecycleHarness(t, true, func(context.Context, Connection) (string, time.Time, error) {
+		return "", time.Time{}, fmt.Errorf("mint: %w", ErrUnauthorized)
+	})
+	conn := h.conn(t)
+	if err := UpsertSecurityReadToken(context.Background(), h.secrets, h.sealer, &conn, "live-token", h.now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.worker.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if got := h.conn(t).Status; got != StatusNeedsReauth {
+		t.Fatalf("status = %q, want needs_reauth", got)
+	}
+	if h.mapHas(t, "socialgouv") {
+		t.Fatal("a revoked connection left its dead token in the map")
+	}
+}
+
+// A malformed operator-written map can never be fixed by retrying. Left
+// unclassified it re-mints against GitHub on every tick, forever, and the
+// connection never leaves the sweep because it is dated only on success.
+func TestWatchOnly_PermanentUpsertFailureDegradesInsteadOfLooping(t *testing.T) {
+	mints := 0
+	h := newLifecycleHarness(t, true, nil)
+	h.worker.SecurityMinter = func(context.Context, Connection) (string, time.Time, error) {
+		mints++
+		return "tok", h.now.Add(time.Hour), nil
+	}
+	// A hand-set bare PAT where the contract wants a JSON map.
+	id := secrets.NewGenericSecretID()
+	sealed, _ := secrets.SealGenericSecret(h.sealer, id, []byte("ghp_not_a_map"))
+	if err := h.secrets.Create(context.Background(), secrets.GenericSecret{
+		ID: id, TenantID: "t1", ScopeTeamID: "t1", Name: SecurityReadSecretName,
+		SealedSecret: sealed, CreatedAt: h.now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 6; i++ {
+		_, _ = h.worker.RunOnce(context.Background())
+		h.now = h.now.Add(10 * time.Minute)
+	}
+	if mints > 1 {
+		t.Fatalf("mints = %d over six ticks — a permanent upsert failure is re-minting forever", mints)
+	}
+	if got := h.conn(t); got.SecurityReadEnabled {
+		t.Fatalf("opt-in still on after a permanent upsert failure (reason %q)", got.StatusReason)
+	}
+}
+
+// The opt-out branch documents withdrawing the entry it still owns. Guarding
+// that withdrawal on the very flag whose absence got us here made the whole
+// branch a no-op.
+func TestWatchOnly_OptedOutWithdrawsAndLeavesTheSweep(t *testing.T) {
+	h := newLifecycleHarness(t, false, func(context.Context, Connection) (string, time.Time, error) {
+		t.Fatal("the minter must not run for an opted-out connection")
+		return "", time.Time{}, nil
+	})
+	// An entry survives from when the opt-in was on.
+	conn := h.conn(t)
+	conn.SecurityReadEnabled = true
+	if err := UpsertSecurityReadToken(context.Background(), h.secrets, h.sealer, &conn, "stale-token", h.now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.worker.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if h.mapHas(t, "socialgouv") {
+		t.Fatal("the opt-out path did NOT withdraw the entry it documents withdrawing")
+	}
+	if exp := h.conn(t).AccessTokenExpiresAt; exp != nil {
+		t.Fatalf("AccessTokenExpiresAt = %v, want nil — an idle connection must leave the sweep", exp)
+	}
+	due, err := h.conns.ExpiringBefore(context.Background(), h.now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(due) != 0 {
+		t.Fatalf("still due after parking: %d connection(s)", len(due))
+	}
+}
+
+// A transient mint failure keeps retrying, but the map carries no expiry of
+// its own: once the expiry we recorded has passed, the token in it is dead and
+// must stop being advertised as fresh.
+func TestWatchOnly_TransientFailureWithdrawsAnExpiredEntry(t *testing.T) {
+	h := newLifecycleHarness(t, true, func(context.Context, Connection) (string, time.Time, error) {
+		return "", time.Time{}, errors.New("github: 502 bad gateway")
+	})
+	conn := h.conn(t)
+	if err := UpsertSecurityReadToken(context.Background(), h.secrets, h.sealer, &conn, "live-token", h.now); err != nil {
+		t.Fatal(err)
+	}
+	h.now = h.now.Add(10 * time.Minute) // past the recorded expiry
+	if _, err := h.worker.RunOnce(context.Background()); err == nil {
+		t.Fatal("a transient mint failure must surface as an error")
+	}
+	if h.mapHas(t, "socialgouv") {
+		t.Fatal("an expired token is still advertised in the map")
+	}
+}
+
+// The worker reads the connection at the top of the sweep and writes it back
+// after the mint. An operator disabling the opt-in in that window would see
+// their choice resurrected — and the token they asked to withdraw re-uploaded.
+func TestWatchOnly_ConcurrentDisableIsNotResurrected(t *testing.T) {
+	h := newLifecycleHarness(t, true, nil)
+	h.worker.SecurityMinter = func(context.Context, Connection) (string, time.Time, error) {
+		// The operator's PATCH lands while the mint is in flight.
+		c := h.conn(t)
+		c.SecurityReadEnabled = false
+		if err := h.conns.Update(context.Background(), c); err != nil {
+			t.Fatal(err)
+		}
+		return "tok", h.now.Add(time.Hour), nil
+	}
+	if _, err := h.worker.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if h.conn(t).SecurityReadEnabled {
+		t.Fatal("the worker resurrected an operator's disable (lost update)")
+	}
+	if h.mapHas(t, "socialgouv") {
+		t.Fatal("the worker re-uploaded a token the operator had just withdrawn")
+	}
+}
+
+// The health probe rewrites InstallationAccount from live truth, so a GitHub
+// org rename moves the derived key. Withdrawal must reach the key the token
+// was actually FILED under, or the entry is stranded forever: the map never
+// empties, the secret is never deleted, and a disconnect leaves a live token
+// readable by every bot of the team.
+func TestWatchOnly_WithdrawalReachesTheRecordedKeyAfterAnOrgRename(t *testing.T) {
+	h := newLifecycleHarness(t, true, func(context.Context, Connection) (string, time.Time, error) {
+		return "tok", time.Time{}, nil
+	})
+	conn := h.conn(t)
+	if err := UpsertSecurityReadToken(context.Background(), h.secrets, h.sealer, &conn, "tok", h.now); err != nil {
+		t.Fatal(err)
+	}
+	if conn.SecurityReadOrgKey != "socialgouv" {
+		t.Fatalf("SecurityReadOrgKey = %q, want the key it filed under", conn.SecurityReadOrgKey)
+	}
+	conn.InstallationAccount = "SocialGouv-Renamed" // renamed on GitHub
+	if err := RemoveSecurityReadToken(context.Background(), h.secrets, h.sealer, &conn); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if h.mapHas(t, "socialgouv") {
+		t.Fatal("the pre-rename entry was stranded — no withdrawal path can reach it")
+	}
+}
+
+// A minter that reports no expiry must not leave the connection undated: an
+// undated connection reads as "never expires" to the sweep on one side, or is
+// re-minted every tick on the other.
+func TestWatchOnly_ZeroMintExpiryStillDatesTheConnection(t *testing.T) {
+	h := newLifecycleHarness(t, true, func(context.Context, Connection) (string, time.Time, error) {
+		return "tok", time.Time{}, nil
+	})
+	if _, err := h.worker.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	// Asserting merely "in the future" would be satisfied by the expiry the
+	// connection was SEEDED with (now+2m) — the test would pass against its
+	// own defect. Assert the default was actually applied.
+	exp := h.conn(t).AccessTokenExpiresAt
+	if exp == nil {
+		t.Fatal("AccessTokenExpiresAt = nil — an undated connection reads as never-expiring")
+	}
+	if want := h.now.Add(time.Hour); !exp.Equal(want) {
+		t.Fatalf("AccessTokenExpiresAt = %v, want the one-hour default %v", exp, want)
+	}
+}

--- a/pkg/server/forge_clients.go
+++ b/pkg/server/forge_clients.go
@@ -396,13 +396,13 @@ func (s *Server) forgeLogWarn(format string, args ...any) {
 // org-level Dependabot alerts endpoint needs the whole installation, and the
 // permission subset is the least-privilege dimension here. Fails with an
 // explicit, actionable error when the installation never approved the grant.
-func (s *Server) forgeSecurityTokenMinter(ctx context.Context, conn forge.Connection) (string, error) {
+func (s *Server) forgeSecurityTokenMinter(ctx context.Context, conn forge.Connection) (string, time.Time, error) {
 	if conn.Kind != forge.KindGitHubApp {
-		return "", fmt.Errorf("forge: security-read tokens require a github_app connection")
+		return "", time.Time{}, fmt.Errorf("forge: security-read tokens require a github_app connection")
 	}
 	cfg, _, ok := s.githubAppConfigForConnection(ctx, conn)
 	if !ok {
-		return "", fmt.Errorf("forge: no github app available for this connection")
+		return "", time.Time{}, fmt.Errorf("forge: no github app available for this connection")
 	}
 	// A known-narrow grant fails BEFORE the mint with the remediation named,
 	// instead of surfacing GitHub's generic 422. An unknown grant set
@@ -416,14 +416,14 @@ func (s *Server) forgeSecurityTokenMinter(ctx context.Context, conn forge.Connec
 			if org == "" {
 				org = conn.AccountLogin
 			}
-			return "", fmt.Errorf("%w: the installation for %q lacks 'Dependabot alerts: read' — add the permission on the GitHub App, have an org admin approve the pending request, then retry",
+			return "", time.Time{}, fmt.Errorf("%w: the installation for %q lacks 'Dependabot alerts: read' — add the permission on the GitHub App, have an org admin approve the pending request, then retry",
 				forge.ErrPermissionsNotGranted, org)
 		}
 	}
-	tok, _, err := forgegithub.MintInstallationToken(ctx, s.forgeHTTPClient(),
+	tok, expiresAt, err := forgegithub.MintInstallationToken(ctx, s.forgeHTTPClient(),
 		forgegithub.APIBaseFor(conn.BaseURL()), cfg, conn.InstallationID, time.Now().UTC(),
 		&forgegithub.InstallationTokenOptions{Permissions: forgegithub.SecurityReadInstallationPermissions()})
-	return tok, err
+	return tok, expiresAt, err
 }
 
 // forgeMintRepoNames is the repo-scope oracle for a github_app connection's

--- a/pkg/server/forge_connect_routes.go
+++ b/pkg/server/forge_connect_routes.go
@@ -371,9 +371,25 @@ func (s *Server) handleForgeGitHubAppCallback(w http.ResponseWriter, r *http.Req
 	} else if s.logger != nil {
 		s.logger.Warn("forge: read installation %d permissions at connect: %v", installationID, ierr)
 	}
+	// A watch-only App (metadata + vulnerability_alerts, nothing else) has no
+	// runtime work to do, so its FIRST token is minted on the security-read
+	// set rather than the runtime one. Without this the connect seals a
+	// metadata-only token — RuntimePermissionsFor narrows to the intersection
+	// — which reads as a working connection while being able to do nothing.
+	watchOnly := false
+	if appRecordID != "" && s.forgeOAuthApps != nil {
+		if rec, aerr := s.forgeOAuthApps.Get(store.WithTenant(r.Context(), pending.TenantID), appRecordID); aerr == nil {
+			watchOnly = rec.SecurityReadOnly
+		} else if s.logger != nil {
+			s.logger.Warn("forge: read app record %s at install: %v", appRecordID, aerr)
+		}
+	}
 	// No repositories scope yet — none provisioned; the refresh worker
 	// re-scopes to the provisioned repo set thereafter.
 	runtimePerms := forgegithub.RuntimePermissionsFor(granted)
+	if watchOnly {
+		runtimePerms = forgegithub.SecurityReadInstallationPermissions()
+	}
 	tok, exp, err := forgegithub.MintInstallationToken(r.Context(), s.forgeHTTPClient(), forgegithub.APIBaseFor(base), cfg, installationID, now,
 		&forgegithub.InstallationTokenOptions{Permissions: runtimePerms})
 	if err != nil {
@@ -396,7 +412,11 @@ func (s *Server) handleForgeGitHubAppCallback(w http.ResponseWriter, r *http.Req
 		InstallationID: installationID, AppSlug: cfg.AppSlug, OAuthAppID: appRecordID,
 		InstallationAccount: installAccount,
 		GrantedPermissions:  granted,
-		Status:              forge.StatusActive, SealedPayload: sealed, AccessTokenExpiresAt: &exp,
+		// The role is inherited from the App, not inferred from the grant: a
+		// runtime App an owner narrowed by mistake must read as broken, never
+		// re-label itself watch-only and quietly stop doing its job.
+		Purpose: purposeForApp(watchOnly),
+		Status:  forge.StatusActive, SealedPayload: sealed, AccessTokenExpiresAt: &exp,
 		CreatedBy: pending.UserID, CreatedAt: now, UpdatedAt: now,
 	}
 	if err := s.forgeConnections.Create(store.WithTenant(r.Context(), pending.TenantID), conn); err != nil {
@@ -409,4 +429,13 @@ func (s *Server) handleForgeGitHubAppCallback(w http.ResponseWriter, r *http.Req
 		target = "/teams/" + pending.TenantID
 	}
 	http.Redirect(w, r, appendQueryParam(target, "connected", connID), http.StatusFound)
+}
+
+// purposeForApp maps a watch-only App to the connection role that keeps it out
+// of every runtime path.
+func purposeForApp(watchOnly bool) forge.Purpose {
+	if watchOnly {
+		return forge.PurposeSecurityRead
+	}
+	return forge.PurposeRuntime
 }

--- a/pkg/server/forge_connect_routes.go
+++ b/pkg/server/forge_connect_routes.go
@@ -376,13 +376,21 @@ func (s *Server) handleForgeGitHubAppCallback(w http.ResponseWriter, r *http.Req
 	// set rather than the runtime one. Without this the connect seals a
 	// metadata-only token — RuntimePermissionsFor narrows to the intersection
 	// — which reads as a working connection while being able to do nothing.
+	// FAIL CLOSED. The role is stamped once, here, and never recomputed: a
+	// connection born mislabelled `runtime` from a watch-only App neutralises
+	// every Purpose-based guard at once — it would be handed to bots as a
+	// runtime connection, and the refresh worker would ask GitHub for a
+	// runtime token it can never have. Refusing costs one click (the App
+	// still exists, the operator retries the install); guessing costs a
+	// connection that looks healthy and can do nothing.
 	watchOnly := false
 	if appRecordID != "" && s.forgeOAuthApps != nil {
-		if rec, aerr := s.forgeOAuthApps.Get(store.WithTenant(r.Context(), pending.TenantID), appRecordID); aerr == nil {
-			watchOnly = rec.SecurityReadOnly
-		} else if s.logger != nil {
-			s.logger.Warn("forge: read app record %s at install: %v", appRecordID, aerr)
+		rec, aerr := s.forgeOAuthApps.Get(store.WithTenant(r.Context(), pending.TenantID), appRecordID)
+		if aerr != nil {
+			httpError(w, http.StatusBadGateway, "could not read the app record %s: %v — retry the install", appRecordID, aerr)
+			return
 		}
+		watchOnly = rec.SecurityReadOnly
 	}
 	// No repositories scope yet — none provisioned; the refresh worker
 	// re-scopes to the provisioned repo set thereafter.

--- a/pkg/server/forge_connections_routes.go
+++ b/pkg/server/forge_connections_routes.go
@@ -462,11 +462,16 @@ func (s *Server) handlePatchForgeConnection(w http.ResponseWriter, r *http.Reque
 			httpError(w, http.StatusBadGateway, "security-read token mint: %v", err)
 			return
 		}
-		// Date the connection from the token we just minted. On a watch-only
-		// connection this IS the refresh clock — nothing else writes it — so
-		// dropping it here would leave the connection's next sweep resting on
-		// whatever stale expiry happened to be lying around.
-		if !mintedUntil.IsZero() {
+		// Date the connection from the token we just minted — but ONLY on a
+		// watch-only connection, where this field is the refresh clock and
+		// nothing else writes it. This endpoint serves ANY github_app
+		// connection, and on a runtime one the field is the clock of the
+		// RUNTIME token sealed in SealedPayload: a security token always
+		// expires an hour out, so writing it here would push the connection out
+		// of ExpiringBefore's window for ~55 minutes and let a runtime token
+		// that was near expiry die unrenewed — every bot on it 401ing, with
+		// nothing to explain it.
+		if !mintedUntil.IsZero() && conn.IsSecurityReadOnly() {
 			exp := mintedUntil
 			conn.AccessTokenExpiresAt = &exp
 		}

--- a/pkg/server/forge_connections_routes.go
+++ b/pkg/server/forge_connections_routes.go
@@ -230,7 +230,12 @@ func (s *Server) handleForgeConnectionHealth(w http.ResponseWriter, r *http.Requ
 				h.InstallationAccount = inst.Login
 				h.ManageInstallURL = inst.HTMLURL
 				h.GrantedPermissions = inst.Permissions
-				h.MissingPermissions = forgegithub.MissingDeliveryPermissions(inst.Permissions)
+				// A watch-only connection has NO delivery grants on purpose —
+				// reporting them as missing would tell an operator to "fix" the
+				// one property that makes this App safe to install org-wide.
+				if !conn.IsSecurityReadOnly() {
+					h.MissingPermissions = forgegithub.MissingDeliveryPermissions(inst.Permissions)
+				}
 				h.MissingSecurityPermissions = forgegithub.MissingSecurityPermissions(inst.Permissions)
 				// Keep the stored grant in step with the live one: the mint
 				// reads it, and an owner may approve (or revoke) a permission
@@ -438,7 +443,7 @@ func (s *Server) handlePatchForgeConnection(w http.ResponseWriter, r *http.Reque
 		if mint == nil {
 			mint = s.forgeSecurityTokenMinter
 		}
-		tok, err := mint(ctx, conn)
+		tok, _, err := mint(ctx, conn)
 		if err != nil {
 			if errors.Is(err, forge.ErrPermissionsNotGranted) {
 				httpError(w, http.StatusUnprocessableEntity, "%v", err)

--- a/pkg/server/forge_connections_routes.go
+++ b/pkg/server/forge_connections_routes.go
@@ -180,6 +180,21 @@ func (s *Server) syncGrantedPermissions(ctx context.Context, conn forge.Connecti
 	}
 }
 
+// missingDeliveryFor is the ONE place that decides whether a connection's
+// absent delivery grants are a defect worth reporting. A watch-only connection
+// has none on purpose — naming them would tell an operator to "fix" the very
+// property that makes its App safe to install on every repository of an org.
+//
+// It exists as a helper because the health DTO is assembled at more than one
+// endpoint (the health view and the refresh route), and guarding only the site
+// in front of you leaves the other one contradicting it.
+func missingDeliveryFor(conn forge.Connection, granted map[string]string) []string {
+	if conn.IsSecurityReadOnly() {
+		return nil
+	}
+	return forgegithub.MissingDeliveryPermissions(granted)
+}
+
 func samePermissions(a, b map[string]string) bool {
 	if len(a) != len(b) {
 		return false
@@ -230,12 +245,7 @@ func (s *Server) handleForgeConnectionHealth(w http.ResponseWriter, r *http.Requ
 				h.InstallationAccount = inst.Login
 				h.ManageInstallURL = inst.HTMLURL
 				h.GrantedPermissions = inst.Permissions
-				// A watch-only connection has NO delivery grants on purpose —
-				// reporting them as missing would tell an operator to "fix" the
-				// one property that makes this App safe to install org-wide.
-				if !conn.IsSecurityReadOnly() {
-					h.MissingPermissions = forgegithub.MissingDeliveryPermissions(inst.Permissions)
-				}
+				h.MissingPermissions = missingDeliveryFor(conn, inst.Permissions)
 				h.MissingSecurityPermissions = forgegithub.MissingSecurityPermissions(inst.Permissions)
 				// Keep the stored grant in step with the live one: the mint
 				// reads it, and an owner may approve (or revoke) a permission
@@ -250,7 +260,7 @@ func (s *Server) handleForgeConnectionHealth(w http.ResponseWriter, r *http.Requ
 			// permissions so the pre-flight looks at the thing that acts.
 			if tokenPerms, ok := forgegithub.LastMintedPermissions(conn.InstallationID); ok {
 				h.TokenPermissions = tokenPerms
-				h.TokenMissingPermissions = forgegithub.MissingDeliveryPermissions(tokenPerms)
+				h.TokenMissingPermissions = missingDeliveryFor(conn, tokenPerms)
 			}
 		}
 		if admin, err := s.forgeAdminFor(r.Context(), conn); err == nil {
@@ -443,7 +453,7 @@ func (s *Server) handlePatchForgeConnection(w http.ResponseWriter, r *http.Reque
 		if mint == nil {
 			mint = s.forgeSecurityTokenMinter
 		}
-		tok, _, err := mint(ctx, conn)
+		tok, mintedUntil, err := mint(ctx, conn)
 		if err != nil {
 			if errors.Is(err, forge.ErrPermissionsNotGranted) {
 				httpError(w, http.StatusUnprocessableEntity, "%v", err)
@@ -451,6 +461,14 @@ func (s *Server) handlePatchForgeConnection(w http.ResponseWriter, r *http.Reque
 			}
 			httpError(w, http.StatusBadGateway, "security-read token mint: %v", err)
 			return
+		}
+		// Date the connection from the token we just minted. On a watch-only
+		// connection this IS the refresh clock — nothing else writes it — so
+		// dropping it here would leave the connection's next sweep resting on
+		// whatever stale expiry happened to be lying around.
+		if !mintedUntil.IsZero() {
+			exp := mintedUntil
+			conn.AccessTokenExpiresAt = &exp
 		}
 		if err := forge.UpsertSecurityReadToken(ctx, s.genericSecrets, s.sealer, &conn, tok, time.Now().UTC()); err != nil {
 			httpError(w, http.StatusInternalServerError, "%v", err)

--- a/pkg/server/forge_github_manifest_routes.go
+++ b/pkg/server/forge_github_manifest_routes.go
@@ -124,13 +124,29 @@ func (s *Server) handleGitHubManifestCallback(w http.ResponseWriter, r *http.Req
 	// Deep link to the App's settings/advanced page so the operator can delete
 	// it on GitHub when they remove the OAuth app here (GitHub has no app-delete API).
 	manageURL := forgegithub.AppManageURL(pending.ForgeBaseURL, conv.Owner.Login, conv.Owner.Type, conv.Slug)
+	// The manifest travels through the operator's browser, so the App that got
+	// created is not necessarily the one iterion asked for. Refuse to record a
+	// watch-only label the created App does not actually carry: that label is
+	// what suppresses its missing-permission warnings and what convinces an org
+	// owner to install it on every repository.
+	if pending.SecurityReadOnly && !conv.IsSecurityReadOnly() {
+		httpError(w, http.StatusBadGateway,
+			"the GitHub App that was created carries %v, not the watch-only profile %v — it was NOT recorded; delete it at %s and retry",
+			conv.Permissions, forgegithub.SecurityReadInstallationPermissions(), manageURL)
+		return
+	}
 	// Capture the App slug + private key (conv.PEM) so the App can be INSTALLED
 	// (least-privilege github_app), not only OAuth-authorized.
 	app, err := s.createForgeOAuthApp(r, pending.TenantID, pending.UserID, forge.ProviderGitHub, pending.ForgeBaseURL, conv.ClientID, conv.ClientSecret, strconv.FormatInt(conv.ID, 10), true, "github_manifest",
 		githubAppFacts{ManageURL: manageURL, Slug: conv.Slug, PrivateKeyPEM: conv.PEM, OwnerLogin: conv.Owner.Login,
 			SecurityReadOnly: pending.SecurityReadOnly})
 	if err != nil {
-		s.writeForgeOAuthAppError(w, err)
+		// The App EXISTS on GitHub by now, and its private key was returned
+		// once and is gone with this request. Name where to delete it, or the
+		// operator retries and leaves one more orphan behind each time.
+		httpError(w, http.StatusConflict,
+			"the GitHub App %q was created but could not be recorded: %v — delete it at %s, then retry",
+			conv.Slug, err, manageURL)
 		return
 	}
 	target := pending.NextURL

--- a/pkg/server/forge_github_manifest_routes.go
+++ b/pkg/server/forge_github_manifest_routes.go
@@ -129,7 +129,14 @@ func (s *Server) handleGitHubManifestCallback(w http.ResponseWriter, r *http.Req
 	// watch-only label the created App does not actually carry: that label is
 	// what suppresses its missing-permission warnings and what convinces an org
 	// owner to install it on every repository.
-	if pending.SecurityReadOnly && !conv.IsSecurityReadOnly() {
+	// Only when GitHub actually TOLD us what it created. The App and its
+	// non-reissuable private key already exist by now, so refusing on an absent
+	// `permissions` field would destroy a credential over a response-shape
+	// surprise — and this flow has never run against the real endpoint. An
+	// absent field means "cannot verify", which falls back to trusting the
+	// manifest we sent, exactly as every other field does; a PRESENT and
+	// mismatched one is evidence of tampering and still refuses.
+	if pending.SecurityReadOnly && len(conv.Permissions) > 0 && !conv.IsSecurityReadOnly() {
 		httpError(w, http.StatusBadGateway,
 			"the GitHub App that was created carries %v, not the watch-only profile %v — it was NOT recorded; delete it at %s and retry",
 			conv.Permissions, forgegithub.SecurityReadInstallationPermissions(), manageURL)

--- a/pkg/server/forge_github_manifest_routes.go
+++ b/pkg/server/forge_github_manifest_routes.go
@@ -53,7 +53,8 @@ func (s *Server) handleStartGitHubManifest(w http.ResponseWriter, r *http.Reques
 	if err := s.forgeStates.put(forgePending{
 		State: state, Provider: forge.ProviderGitHub, ForgeBaseURL: baseURL,
 		TenantID: teamID, UserID: id.UserID, AgentBinding: binding,
-		NextURL: safeNext(req.Next), IssuedAt: time.Now().UTC(),
+		NextURL: safeNext(req.Next), SecurityReadOnly: req.SecurityReadOnly,
+		IssuedAt: time.Now().UTC(),
 	}); err != nil {
 		if s.logger != nil {
 			s.logger.Error("forge connect: %v", err)
@@ -65,9 +66,17 @@ func (s *Server) handleStartGitHubManifest(w http.ResponseWriter, r *http.Reques
 
 	home := strings.TrimRight(s.cfg.PublicURL, "/")
 	redirectURL := home + "/api/forge/github/app-manifest/callback"
-	name := "iterion-forge-" + uuid.NewString()[:8] // GitHub App names are globally unique
+	// GitHub App names are globally unique. The prefix also makes the shape
+	// readable on the org's Apps list, where a watch-only App sits next to
+	// write-capable ones and only its name distinguishes them at a glance.
+	prefix := "iterion-forge-"
+	if req.SecurityReadOnly {
+		prefix = "iterion-watch-"
+	}
+	name := prefix + uuid.NewString()[:8]
 	manifest := forgegithub.BuildAppManifest(name, home, redirectURL,
 		forgegithub.AppManifestOptions{
+			SecurityReadOnly:  req.SecurityReadOnly,
 			AllowRepoCreation: req.AllowRepoCreation,
 			AllowAppDelivery:  req.AllowAppDelivery,
 			AllowSecurityRead: req.AllowSecurityRead,
@@ -118,7 +127,8 @@ func (s *Server) handleGitHubManifestCallback(w http.ResponseWriter, r *http.Req
 	// Capture the App slug + private key (conv.PEM) so the App can be INSTALLED
 	// (least-privilege github_app), not only OAuth-authorized.
 	app, err := s.createForgeOAuthApp(r, pending.TenantID, pending.UserID, forge.ProviderGitHub, pending.ForgeBaseURL, conv.ClientID, conv.ClientSecret, strconv.FormatInt(conv.ID, 10), true, "github_manifest",
-		githubAppFacts{ManageURL: manageURL, Slug: conv.Slug, PrivateKeyPEM: conv.PEM, OwnerLogin: conv.Owner.Login})
+		githubAppFacts{ManageURL: manageURL, Slug: conv.Slug, PrivateKeyPEM: conv.PEM, OwnerLogin: conv.Owner.Login,
+			SecurityReadOnly: pending.SecurityReadOnly})
 	if err != nil {
 		s.writeForgeOAuthAppError(w, err)
 		return

--- a/pkg/server/forge_oauth_app_routes.go
+++ b/pkg/server/forge_oauth_app_routes.go
@@ -44,6 +44,12 @@ type forgeOAuthAppReq struct {
 	// installed org-wide. Empty = the user's personal account (a private App is
 	// then installable only there — the cause of "only your personal account").
 	GitHubOrg string `json:"github_org,omitempty"`
+	// SecurityReadOnly (github-manifest): build a WATCH-ONLY App —
+	// metadata:read + vulnerability_alerts:read and nothing else — meant to be
+	// installed org-wide as the Dependabot-alerts source without granting
+	// write on every repository. Mutually exclusive with the Allow* options,
+	// which only add write grants.
+	SecurityReadOnly bool `json:"security_read_only,omitempty"`
 	// AllowRepoCreation (github-manifest): request administration:write on
 	// the App so iterion can CREATE repositories in the installed org
 	// (opt-in — the connect wizard surfaces it as a visible checkbox;
@@ -263,6 +269,10 @@ type githubAppFacts struct {
 	// OwnerLogin is the account the App belongs to — the discriminator once a
 	// tenant holds one App per org.
 	OwnerLogin string
+	// SecurityReadOnly marks the App as watch-only (see
+	// ForgeOAuthApp.SecurityReadOnly); every connection installed from it is
+	// stamped forge.PurposeSecurityRead.
+	SecurityReadOnly bool
 }
 
 // the latter pass the client_id/client_secret they got back from the forge.
@@ -291,7 +301,8 @@ func (s *Server) createForgeOAuthApp(r *http.Request, teamID, userID string, pro
 		ClientID: clientID, SealedSecret: sealed, RedirectURI: s.forgeOAuthRedirectURI(),
 		ProviderAppID: providerAppID, AutoCreated: autoCreated, AppManageURL: appManageURL,
 		AppSlug: appSlug, SealedPrivateKey: sealedKey, OwnerLogin: gh.OwnerLogin,
-		CreatedBy: userID, CreatedAt: now, UpdatedAt: now,
+		SecurityReadOnly: gh.SecurityReadOnly,
+		CreatedBy:        userID, CreatedAt: now, UpdatedAt: now,
 	}
 	if err := s.forgeOAuthApps.Create(store.WithTenant(r.Context(), teamID), app); err != nil {
 		return forge.ForgeOAuthApp{}, err

--- a/pkg/server/forge_provisioning_routes.go
+++ b/pkg/server/forge_provisioning_routes.go
@@ -88,7 +88,16 @@ func (s *Server) handleEnableForgeRepoBots(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	// Assert the connection belongs to this team before we provision.
-	if _, ok := s.forgeConnForTenant(w, r, teamID, req.ConnectionID); !ok {
+	conn, ok := s.forgeConnForTenant(w, r, teamID, req.ConnectionID)
+	if !ok {
+		return
+	}
+	// A watch-only connection cannot carry a webhook or a bot's forge token.
+	// The orchestrator refuses it as well; naming it here keeps the operator's
+	// mistake attached to the choice they just made.
+	if conn.IsSecurityReadOnly() {
+		httpError(w, http.StatusUnprocessableEntity,
+			"connection %s is watch-only (Dependabot alerts only) — it cannot host webhooks or hand a bot a forge token; pick the team's runtime connection", conn.ID)
 		return
 	}
 	ctx := store.WithTenant(r.Context(), teamID)

--- a/pkg/server/forge_publish.go
+++ b/pkg/server/forge_publish.go
@@ -706,7 +706,12 @@ func (s *Server) repoIntegrationFor(ctx context.Context, teamID, host, repo stri
 // PR's forge host.
 func (s *Server) forgeConnectionForPR(ctx context.Context, teamID, preferredConnID, host, repo string) (forge.Connection, bool) {
 	matches := func(c forge.Connection) bool {
-		return c.TenantID == teamID && strings.EqualFold(hostOfURL(c.BaseURL()), host)
+		// A watch-only connection sits on the same host and would be picked by
+		// the "first connection on this host" fallback below — then every
+		// review comment and commit status posted through it would 403: its
+		// App holds no pull_requests/statuses grant, by design.
+		return c.TenantID == teamID && !c.IsSecurityReadOnly() &&
+			strings.EqualFold(hostOfURL(c.BaseURL()), host)
 	}
 	if preferredConnID != "" {
 		if c, err := s.forgeConnections.Get(ctx, preferredConnID); err == nil && matches(c) {

--- a/pkg/server/forge_publish.go
+++ b/pkg/server/forge_publish.go
@@ -716,6 +716,12 @@ func (s *Server) forgeConnectionForPR(ctx context.Context, teamID, preferredConn
 	if preferredConnID != "" {
 		if c, err := s.forgeConnections.Get(ctx, preferredConnID); err == nil && matches(c) {
 			return c, true
+		} else if s.logger != nil {
+			// Falling through to another connection is the historical
+			// behaviour and stays — but an operator's explicit pin being
+			// replaced must never be silent, or the verdict is published under
+			// an identity nobody chose and nothing says so.
+			s.logger.Warn("forge: pinned connection %s is not usable for %s on %s — resolving another", preferredConnID, repo, host)
 		}
 	}
 	if s.forgeIntegrations != nil {

--- a/pkg/server/forge_refresh_route.go
+++ b/pkg/server/forge_refresh_route.go
@@ -63,7 +63,7 @@ func (s *Server) handleForgeConnectionRefresh(w http.ResponseWriter, r *http.Req
 		InstallationAccount: inst.Login,
 		ManageInstallURL:    inst.HTMLURL,
 		GrantedPermissions:  inst.Permissions,
-		MissingPermissions:  forgegithub.MissingDeliveryPermissions(inst.Permissions),
+		MissingPermissions:  missingDeliveryFor(conn, inst.Permissions),
 	}
 	// Force a fresh token mint so the observability reflects the new grants
 	// (forgeAdminFor builds a fresh client → rest() mints on first use).
@@ -74,7 +74,7 @@ func (s *Server) handleForgeConnectionRefresh(w http.ResponseWriter, r *http.Req
 	}
 	if tokenPerms, ok := forgegithub.LastMintedPermissions(conn.InstallationID); ok {
 		out.TokenPermissions = tokenPerms
-		out.TokenMissingPermissions = forgegithub.MissingDeliveryPermissions(tokenPerms)
+		out.TokenMissingPermissions = missingDeliveryFor(conn, tokenPerms)
 	}
 	writeJSON(w, out)
 }

--- a/pkg/server/forge_security_read_routes_test.go
+++ b/pkg/server/forge_security_read_routes_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/forge"
 	"github.com/SocialGouv/iterion/pkg/secrets"
@@ -69,9 +70,9 @@ func TestSecurityReadPatch_EnableThenDisable(t *testing.T) {
 	s := newForgeTestServer(t)
 	seedAppConn(t, s, "c1", "SocialGouv", "", false)
 	minted := 0
-	s.forgeSecurityMint = func(context.Context, forge.Connection) (string, error) {
+	s.forgeSecurityMint = func(context.Context, forge.Connection) (string, time.Time, error) {
 		minted++
-		return "ghs_minted", nil
+		return "ghs_minted", time.Time{}, nil
 	}
 
 	if w := patchSecurityRead(t, s, "c1", true); w.Code != http.StatusOK {
@@ -111,9 +112,9 @@ func TestSecurityReadPatch_EnableThenDisable(t *testing.T) {
 func TestSecurityReadPatch_RefusesAShadowingPersonalSecret(t *testing.T) {
 	s := newForgeTestServer(t)
 	seedAppConn(t, s, "c1", "SocialGouv", "", false)
-	s.forgeSecurityMint = func(context.Context, forge.Connection) (string, error) {
+	s.forgeSecurityMint = func(context.Context, forge.Connection) (string, time.Time, error) {
 		t.Fatal("the mint must not run when the name is shadowed")
-		return "", nil
+		return "", time.Time{}, nil
 	}
 	id := secrets.NewGenericSecretID()
 	sealed, _ := secrets.SealGenericSecret(s.sealer, id, []byte(`{"socialgouv":"ghp_member"}`))
@@ -139,9 +140,9 @@ func TestSecurityReadPatch_RefusesACrossHostOrgCollision(t *testing.T) {
 	s := newForgeTestServer(t)
 	seedAppConn(t, s, "c1", "acme", "", true)                          // github.com, already enabled
 	seedAppConn(t, s, "c2", "acme", "https://ghe.corp.example", false) // same org, other host
-	s.forgeSecurityMint = func(context.Context, forge.Connection) (string, error) {
+	s.forgeSecurityMint = func(context.Context, forge.Connection) (string, time.Time, error) {
 		t.Fatal("the mint must not run on a colliding org")
-		return "", nil
+		return "", time.Time{}, nil
 	}
 	w := patchSecurityRead(t, s, "c2", true)
 	if w.Code != http.StatusConflict {
@@ -158,8 +159,8 @@ func TestSecurityReadPatch_RefusesACrossHostOrgCollision(t *testing.T) {
 func TestSecurityReadPatch_RollsBackWhenThePersistFails(t *testing.T) {
 	s := newForgeTestServer(t)
 	seedAppConn(t, s, "c1", "SocialGouv", "", false)
-	s.forgeSecurityMint = func(context.Context, forge.Connection) (string, error) {
-		return "ghs_minted", nil
+	s.forgeSecurityMint = func(context.Context, forge.Connection) (string, time.Time, error) {
+		return "ghs_minted", time.Time{}, nil
 	}
 	s.forgeConnections = failingUpdateConnStore{s.forgeConnections}
 
@@ -199,9 +200,9 @@ func TestSecurityReadPatch_CollisionReadsTheOrgNotTheBotHandle(t *testing.T) {
 	seedAppConn(t, s, "c1", "orgA", "", true)
 	seedAppConn(t, s, "c2", "orgB", "https://ghe.corp.example", false)
 	minted := 0
-	s.forgeSecurityMint = func(context.Context, forge.Connection) (string, error) {
+	s.forgeSecurityMint = func(context.Context, forge.Connection) (string, time.Time, error) {
 		minted++
-		return "ghs_b", nil
+		return "ghs_b", time.Time{}, nil
 	}
 	if w := patchSecurityRead(t, s, "c2", true); w.Code != http.StatusOK {
 		t.Fatalf("distinct orgs must not collide: code=%d body=%s", w.Code, w.Body.String())
@@ -215,9 +216,9 @@ func TestSecurityReadPatch_CollisionReadsTheOrgNotTheBotHandle(t *testing.T) {
 	s2 := newForgeTestServer(t)
 	seedAppConn(t, s2, "d1", "acme", "", true)
 	seedAppConn(t, s2, "d2", "acme", "https://ghe.corp.example", false)
-	s2.forgeSecurityMint = func(context.Context, forge.Connection) (string, error) {
+	s2.forgeSecurityMint = func(context.Context, forge.Connection) (string, time.Time, error) {
 		t.Fatal("a colliding org must not be minted")
-		return "", nil
+		return "", time.Time{}, nil
 	}
 	if w := patchSecurityRead(t, s2, "d2", true); w.Code != http.StatusConflict {
 		t.Fatalf("same org on two hosts must be refused: code=%d body=%s", w.Code, w.Body.String())

--- a/pkg/server/forge_state.go
+++ b/pkg/server/forge_state.go
@@ -33,7 +33,13 @@ type forgePending struct {
 	// holds one app per owning org. Empty for non-app flows and for installs
 	// started before the picker existed.
 	OAuthAppID string
-	IssuedAt   time.Time
+	// SecurityReadOnly carries the watch-only choice from the manifest /start
+	// to its /callback, which is the only place that can stamp it on the
+	// created App record. It must survive the hop across replicas — the
+	// Valkey backend marshals this struct wholesale, so an exported field is
+	// enough.
+	SecurityReadOnly bool
+	IssuedAt         time.Time
 }
 
 // forgeStateBackend stores forgePending CSRF state keyed by State, with a

--- a/pkg/server/forge_watch_only_test.go
+++ b/pkg/server/forge_watch_only_test.go
@@ -52,3 +52,22 @@ func TestForgeConnectionForPR_PreferredWatchOnlyIsRefused(t *testing.T) {
 		t.Fatalf("pinned watch-only connection %q was accepted", got.ID)
 	}
 }
+
+// The health DTO is assembled at TWO endpoints (the health view and the
+// refresh route) and rendered by the same card. Guarding only the site in
+// front of you leaves the other one telling the operator to "fix" the very
+// property that makes a watch-only App safe to install org-wide — which is
+// how this guard was shipped the first time.
+func TestMissingDeliveryFor_SilentOnWatchOnlyLoudOnRuntime(t *testing.T) {
+	watchOnlyGrant := map[string]string{"metadata": "read", "vulnerability_alerts": "read"}
+
+	watch := forge.Connection{Purpose: forge.PurposeSecurityRead}
+	if got := missingDeliveryFor(watch, watchOnlyGrant); len(got) != 0 {
+		t.Fatalf("watch-only reported missing delivery grants %v — they are the point, not a defect", got)
+	}
+	// The same grant on a RUNTIME connection is a genuine gap and must show.
+	runtime := forge.Connection{Purpose: forge.PurposeRuntime}
+	if got := missingDeliveryFor(runtime, watchOnlyGrant); len(got) == 0 {
+		t.Fatal("a runtime connection missing its delivery grants reported nothing")
+	}
+}

--- a/pkg/server/forge_watch_only_test.go
+++ b/pkg/server/forge_watch_only_test.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+)
+
+// seedConnForPublish creates a github connection on github.com with a chosen
+// role, so the publish resolver can be asked which one it picks.
+func seedConnForPublish(t *testing.T, s *Server, id string, purpose forge.Purpose) {
+	t.Helper()
+	conn := forge.Connection{
+		ID: id, TenantID: "t1", Provider: forge.ProviderGitHub, Kind: forge.KindGitHubApp,
+		Status: forge.StatusActive, AccountLogin: "iterion-forge-x[bot]",
+		InstallationAccount: "SocialGouv", InstallationID: 42,
+		ForgeBaseURL: "https://github.com", Purpose: purpose,
+	}
+	if err := s.forgeConnections.Create(context.Background(), conn); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// forgeConnectionForPR falls back to "the first team connection on this forge
+// host". A watch-only connection sits on that same host and would be picked —
+// then every review comment and commit status posted through it 403s, because
+// its App holds no pull_requests/statuses grant by design. The failure would
+// look like a broken reviewer, not like a mis-picked connection.
+func TestForgeConnectionForPR_SkipsWatchOnlyConnection(t *testing.T) {
+	s := newForgeTestServer(t)
+	seedConnForPublish(t, s, "watch-only", forge.PurposeSecurityRead)
+
+	if got, ok := s.forgeConnectionForPR(context.Background(), "t1", "", "github.com", "SocialGouv/x"); ok {
+		t.Fatalf("resolver picked the watch-only connection %q — it cannot post anything", got.ID)
+	}
+
+	// With a runtime connection present it must resolve to that one.
+	seedConnForPublish(t, s, "runtime", forge.PurposeRuntime)
+	got, ok := s.forgeConnectionForPR(context.Background(), "t1", "", "github.com", "SocialGouv/x")
+	if !ok || got.ID != "runtime" {
+		t.Fatalf("resolver = (%q, %v), want the runtime connection", got.ID, ok)
+	}
+}
+
+// Explicitly naming a watch-only connection must not bypass the guard either:
+// the preferred-id path runs through the same predicate.
+func TestForgeConnectionForPR_PreferredWatchOnlyIsRefused(t *testing.T) {
+	s := newForgeTestServer(t)
+	seedConnForPublish(t, s, "watch-only", forge.PurposeSecurityRead)
+	if got, ok := s.forgeConnectionForPR(context.Background(), "t1", "watch-only", "github.com", "SocialGouv/x"); ok {
+		t.Fatalf("pinned watch-only connection %q was accepted", got.ID)
+	}
+}

--- a/pkg/server/forge_watch_only_test.go
+++ b/pkg/server/forge_watch_only_test.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/forge"
 )
@@ -69,5 +71,73 @@ func TestMissingDeliveryFor_SilentOnWatchOnlyLoudOnRuntime(t *testing.T) {
 	runtime := forge.Connection{Purpose: forge.PurposeRuntime}
 	if got := missingDeliveryFor(runtime, watchOnlyGrant); len(got) == 0 {
 		t.Fatal("a runtime connection missing its delivery grants reported nothing")
+	}
+}
+
+// The opt-in endpoint serves ANY github_app connection — the ordinary-App path
+// is the documented one. On a RUNTIME connection AccessTokenExpiresAt is the
+// clock of the runtime token sealed in the payload, and a security token always
+// expires an hour out: writing it there pushes the connection out of the
+// refresh sweep for ~55 minutes, letting a runtime token that was near expiry
+// die unrenewed while every bot on it 401s.
+func TestPatchSecurityRead_DoesNotMoveARuntimeConnectionsRefreshClock(t *testing.T) {
+	s := newForgeTestServer(t)
+	seedAppConn(t, s, "runtime-conn", "SocialGouv", "", false)
+
+	// A runtime token about to expire — the case that breaks.
+	conn, err := s.forgeConnections.Get(context.Background(), "runtime-conn")
+	if err != nil {
+		t.Fatal(err)
+	}
+	nearly := time.Now().UTC().Add(2 * time.Minute)
+	conn.AccessTokenExpiresAt = &nearly
+	if err := s.forgeConnections.Update(context.Background(), conn); err != nil {
+		t.Fatal(err)
+	}
+
+	s.forgeSecurityMint = func(context.Context, forge.Connection) (string, time.Time, error) {
+		return "ghs_minted", time.Now().UTC().Add(time.Hour), nil
+	}
+	if w := patchSecurityRead(t, s, "runtime-conn", true); w.Code != http.StatusOK {
+		t.Fatalf("enable: code=%d body=%s", w.Code, w.Body.String())
+	}
+
+	got, err := s.forgeConnections.Get(context.Background(), "runtime-conn")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessTokenExpiresAt == nil || !got.AccessTokenExpiresAt.Equal(nearly) {
+		t.Fatalf("runtime refresh clock moved to %v (was %v) — the runtime token will die unrenewed",
+			got.AccessTokenExpiresAt, nearly)
+	}
+}
+
+// On a watch-only connection the same field IS the refresh clock and nothing
+// else writes it, so the mint's expiry must land.
+func TestPatchSecurityRead_DatesAWatchOnlyConnectionFromTheMint(t *testing.T) {
+	s := newForgeTestServer(t)
+	seedAppConn(t, s, "watch-conn", "SocialGouv", "", false)
+	conn, err := s.forgeConnections.Get(context.Background(), "watch-conn")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn.Purpose = forge.PurposeSecurityRead
+	if err := s.forgeConnections.Update(context.Background(), conn); err != nil {
+		t.Fatal(err)
+	}
+
+	until := time.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	s.forgeSecurityMint = func(context.Context, forge.Connection) (string, time.Time, error) {
+		return "ghs_minted", until, nil
+	}
+	if w := patchSecurityRead(t, s, "watch-conn", true); w.Code != http.StatusOK {
+		t.Fatalf("enable: code=%d body=%s", w.Code, w.Body.String())
+	}
+	got, err := s.forgeConnections.Get(context.Background(), "watch-conn")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessTokenExpiresAt == nil || !got.AccessTokenExpiresAt.Equal(until) {
+		t.Fatalf("watch-only clock = %v, want the mint's expiry %v", got.AccessTokenExpiresAt, until)
 	}
 }

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -324,6 +324,15 @@ func (s *Server) handleLaunchRun(w http.ResponseWriter, r *http.Request) {
 			span.SetStatus(codes.Error, "connection not found")
 			return
 		}
+		// A watch-only connection cannot clone or push. The orchestrator
+		// refuses it too, but only once the launch is under way — say it here,
+		// where the operator picked it, instead of failing in the pod.
+		if conn.IsSecurityReadOnly() {
+			s.httpErrorFor(w, r, http.StatusUnprocessableEntity,
+				"connection %s is watch-only (Dependabot alerts only) — it cannot clone or push; pick the team's runtime connection", conn.ID)
+			span.SetStatus(codes.Error, "watch-only connection")
+			return
+		}
 		// The repo must live on the connection's forge host: the managed
 		// token is only ever aimed at the host it belongs to.
 		base := strings.TrimSuffix(conn.BaseURL(), "/")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -178,7 +178,7 @@ type Server struct {
 	// A field rather than a direct method call so the enable endpoint can be
 	// driven without a live GitHub App (the mint is the one step that needs
 	// one, and the endpoint's guards/rollback are what matter).
-	forgeSecurityMint func(context.Context, forge.Connection) (string, error)
+	forgeSecurityMint func(context.Context, forge.Connection) (string, time.Time, error)
 	forgeOAuthApps    forge.OAuthAppStore
 	forgeGitHubApp    ForgeGitHubAppConfig
 	orgSSO            orgsso.Store

--- a/studio/src/api/forgeConnections.ts
+++ b/studio/src/api/forgeConnections.ts
@@ -387,6 +387,11 @@ export async function startGitHubManifest(
   // allow_security_read requests vulnerability_alerts:read so a bot can read
   // the org's Dependabot alerts (docs/forge-security-read.md); off by default
   // and only ever minted into a dedicated token.
+  // security_read_only builds a WATCH-ONLY App instead: metadata + Dependabot
+  // alerts, both read, and nothing else — the shape meant to be installed on
+  // ALL repositories without granting write anywhere. It replaces the runtime
+  // permissions rather than adding to them, so it cannot be combined with the
+  // allow_* options above.
   input: {
     forge_base_url?: string;
     next?: string;
@@ -394,6 +399,7 @@ export async function startGitHubManifest(
     allow_repo_creation?: boolean;
     allow_app_delivery?: boolean;
     allow_security_read?: boolean;
+    security_read_only?: boolean;
   },
 ): Promise<GitHubManifestStart> {
   // Body type-checked against the spec's forgeOAuthAppReq (provider is

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -4906,6 +4906,7 @@ export interface components {
             namespace?: string;
             oauth_app_id?: string;
             provider: string;
+            purpose?: string;
             scopes?: string[];
             security_read_enabled?: boolean;
             status: string;
@@ -5000,6 +5001,7 @@ export interface components {
             provider_app_id?: string;
             redirect_uri?: string;
             scopes?: string[];
+            security_read_only?: boolean;
             tenant_id: string;
             /** Format: date-time */
             updated_at: string;
@@ -5460,6 +5462,7 @@ export interface components {
             mode?: string;
             next?: string;
             provider: string;
+            security_read_only?: boolean;
         };
         forgeTeamRepo: {
             bot_ids: string[];

--- a/studio/src/components/Runs/launchView/RepoTargetSection.tsx
+++ b/studio/src/components/Runs/launchView/RepoTargetSection.tsx
@@ -164,7 +164,12 @@ export default function RepoTargetSection({
     enabled: state.mode === "create" && !!teamID,
     staleTime: 30_000,
   });
-  const connections: ForgeConnection[] = connectionsQuery.data ?? EMPTY_CONNECTIONS;
+  // A watch-only connection (Dependabot alerts, read) cannot clone or push, so
+  // it is never a launch target. The server refuses it with a 422; not
+  // offering it is what keeps the operator from meeting that refusal at all.
+  const connections: ForgeConnection[] =
+    connectionsQuery.data?.filter((c) => c.purpose !== "security_read") ??
+    EMPTY_CONNECTIONS;
   const connectionsLoading = connectionsQuery.isLoading && repos.length === 0;
 
   const createConnOptions = useMemo(() => {

--- a/studio/src/views/Board/PushToForge.tsx
+++ b/studio/src/views/Board/PushToForge.tsx
@@ -107,7 +107,12 @@ function PushToForgeDialog({
     queryKey: ["forge-connections", teamID],
     queryFn: () => listForgeConnections(teamID),
   });
-  const connections = connectionsQuery.data ?? null;
+  // Watch-only connections (Dependabot alerts, read) cannot push: their App
+  // holds no contents/issues grant. They must not appear here at all — the
+  // picker below defaults to the FIRST connection, so a team that connected
+  // its watch-only App first would push through it by default and take a 403.
+  const connections =
+    connectionsQuery.data?.filter((c) => c.purpose !== "security_read") ?? null;
   const loadError = connectionsQuery.error
     ? errorMessage(connectionsQuery.error)
     : null;

--- a/studio/src/views/integrations/wizard/connect/CreateGitHubAppCard.tsx
+++ b/studio/src/views/integrations/wizard/connect/CreateGitHubAppCard.tsx
@@ -37,6 +37,11 @@ export default function CreateGitHubAppCard({
   // Off by default: alert data names every vulnerable dependency of every
   // repo, so the team opts in deliberately.
   const [allowSecurityRead, setAllowSecurityRead] = useState(false);
+  // Watch-only builds an App that can ONLY read alerts. It is the shape to
+  // install on every repository of an org: the org-wide alerts endpoint
+  // returns just what the installation can see, and widening a write-capable
+  // App to all repositories to get that coverage is the trade this avoids.
+  const [watchOnly, setWatchOnly] = useState(false);
 
   // Fetch failures stay silent (no error surfaced) — the "Pick from
   // GitHub" link below covers the empty case.
@@ -61,9 +66,12 @@ export default function CreateGitHubAppCard({
       const { post_url, manifest } = await startGitHubManifest(teamID, {
         forge_base_url: baseURL.trim() || undefined,
         github_org: githubOrg.trim() || undefined,
-        allow_repo_creation: allowRepoCreation,
-        allow_app_delivery: allowAppDelivery,
-        allow_security_read: allowSecurityRead,
+        // The write grants are dropped rather than merely hidden: a stale
+        // checkbox value must not travel and quietly widen a watch-only App.
+        allow_repo_creation: watchOnly ? false : allowRepoCreation,
+        allow_app_delivery: watchOnly ? false : allowAppDelivery,
+        allow_security_read: watchOnly ? false : allowSecurityRead,
+        security_read_only: watchOnly,
         next: RETURN_PATH,
       });
       // Auto-submit the hidden form: GitHub swallows the manifest, creates
@@ -146,6 +154,28 @@ export default function CreateGitHubAppCard({
       </div>
 
       <Checkbox
+        id="wizard-watch-only"
+        checked={watchOnly}
+        onChange={(e) => setWatchOnly(e.target.checked)}
+        label={
+          <span className="text-fg-default text-xs">
+            <span className="font-medium">
+              Watch-only App (Dependabot alerts, read)
+            </span>
+            <span className="block text-caption text-fg-muted mt-0.5">
+              Creates an App that can do nothing but read alerts — Metadata and
+              Dependabot alerts, both read-only. This is the one to install on
+              all repositories of an org: the org-wide alerts endpoint only
+              returns what the installation can see, and this shape buys that
+              coverage without granting write anywhere.
+            </span>
+          </span>
+        }
+      />
+
+      {watchOnly ? null : (
+        <>
+      <Checkbox
         id="wizard-allow-repo-creation"
         checked={allowRepoCreation}
         onChange={(e) => setAllowRepoCreation(e.target.checked)}
@@ -199,6 +229,8 @@ export default function CreateGitHubAppCard({
           </span>
         }
       />
+        </>
+      )}
 
       <Button
         variant="primary"
@@ -206,7 +238,11 @@ export default function CreateGitHubAppCard({
         disabled={busy}
         loading={busy}
       >
-        {busy ? "Opening GitHub…" : "Create a GitHub App"}
+        {busy
+          ? "Opening GitHub…"
+          : watchOnly
+            ? "Create a watch-only App"
+            : "Create a GitHub App"}
       </Button>
     </div>
   );

--- a/studio/src/views/teams/tabs/integrations/ConnectionCard.tsx
+++ b/studio/src/views/teams/tabs/integrations/ConnectionCard.tsx
@@ -98,6 +98,14 @@ export function ConnectionCard({
           <div className="text-xs text-fg-muted">
             {conn.forge_base_url ?? conn.provider} · {connectionKindLabel(conn.kind)}
           </div>
+          {conn.purpose === "security_read" && (
+            // The one place the role must be VISIBLE rather than filtered out:
+            // this connection is absent from every target picker, and without
+            // saying why, that absence reads as a bug.
+            <Badge variant="neutral" size="sm" className="mt-1">
+              Watch-only · Dependabot alerts
+            </Badge>
+          )}
         </div>
         {canManage && (
           <Button


### PR DESCRIPTION
## Why

The org-wide Dependabot alerts endpoint returns **only what the installation can see**. Covering an org therefore means installing on *All repositories* — and doing that with the ordinary forge App would grant `contents:write` (and, when opted in, `administration:write`) on every repository of that org, as a side effect of wanting to **read** alerts. On SocialGouv that is 388 repositories.

This adds an App shape that can be installed org-wide safely, and a connection role that keeps it out of everything else.

## What

- **`AppManifestOptions.SecurityReadOnly`** — a manifest whose permissions *replace* the runtime baseline instead of adding to it: `metadata:read` + `vulnerability_alerts:read`, nothing else. The write-granting options cannot widen it.
- **`forge.Purpose` / `PurposeSecurityRead`** — the role, inherited from the App record and **never inferred from the granted permissions**: a runtime App an owner narrowed by mistake must read as broken, not silently re-label itself and stop doing its job.
- Studio: a "Watch-only App" checkbox in the connect wizard, the role filtered out of push/launch target pickers, and shown as a badge on the connection card — where its absence from every picker would otherwise read as a bug.

## The three silent failures the role closes

1. **The refresh worker must not mint a runtime token for it.** That mint asks for permissions the App was deliberately never granted → `422` → degraded → the security-read entry *withdrawn*. The connection would destroy the token it exists to supply, about an hour after wiring. Its whole refresh is the security mint, re-armed from **that token's own expiry** — there is no runtime token to date the sweep from.
2. **`forgeConnectionForPR` must skip it**, or its "first connection on this host" fallback publishes reviews through an App that cannot post.
3. **The health view must not report its absent delivery grants** — they are the point.

## Review

Three adversarial reviewers ran against the first commit and produced **17 confirmed findings, no false positives**. The second commit closes them; the message lists each. Highlights:

- `Orchestrator.Provision` accepted a watch-only connection, and since it writes bot bindings *before* its first forge call — keyed `(tenant, bot, secret_name)`, i.e. **team-global**, never rolled back — a *failed* provision repointed every repo of that bot at a token that cannot push, while the operator read "provision failed".
- The health signal is assembled at **two** endpoints; only one was guarded, so the refresh route still told operators to "fix" the very property that makes the App safe org-wide.
- The watch-only lane had dropped terminal-failure handling on the way out of the runtime lane (`ErrUnauthorized`, permanent upsert failures), and its opt-out branch called a withdrawal guarded on the very flag whose absence got it there — dead code, documented as working.
- The uniqueness key ignored the role, so creating the watch-only App under an org that already holds the runtime App collided **at the manifest callback** — after GitHub created the App and returned the private key it never reissues.

Every regression test here was seen **RED** by re-introducing its defect.

## Not covered

The full flow (manifest creation → All-repositories install → first mint) has never run for real; it is exercised by tests at every link, and will be validated on the prod instance after deploy.

**Adjacent pre-existing debt, deliberately out of scope:** `ensureBotBinding` repoints the binding before any forge call without rollback, which breaks the same way between two ordinary runtime connections. The guard added here only rules out the nastiest variant.

Docs: `docs/forge-security-read.md` gains the coverage trap and the watch-only section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
