### PR TITLE
fix(runtime): a budget overrun must not strand the node that earned it

### DIFF
--- a/pkg/runtime/budget.go
+++ b/pkg/runtime/budget.go
@@ -592,7 +592,26 @@ func (e *Engine) checkBudgetBeforeExec(rs *runState, nodeID string) error {
 
 // recordAndCheckBudget records usage from a node execution and emits
 // budget_warning / budget_exceeded events as needed.
+// recordAndCheckBudget keeps the IMMEDIATE contract: an overrun fails the
+// run at this node. Used by every caller that does not return through
+// execLoopAfterExec (the LLM router, the resume paths) — those never
+// reach the node boundary that consumes a deferred overrun, and the
+// remaining path may be special-dispatch nodes that run no pre-exec
+// check at all, so deferring there would let a run finish with the cap
+// blown.
 func (e *Engine) recordAndCheckBudget(rs *runState, nodeID string, output map[string]any) error {
+	return e.recordBudget(rs, nodeID, output, false)
+}
+
+// recordAndDeferBudget records usage and DEFERS a hard overrun to the
+// next node boundary — see the deferral rationale below. Only the
+// standard node path may use it: it is the one that computes a
+// successor to anchor the checkpoint on.
+func (e *Engine) recordAndDeferBudget(rs *runState, nodeID string, output map[string]any) error {
+	return e.recordBudget(rs, nodeID, output, true)
+}
+
+func (e *Engine) recordBudget(rs *runState, nodeID string, output map[string]any, deferExceeded bool) error {
 	tokens, costUSD := extractUsage(output)
 
 	// Daily spend cap accounting (independent of the per-run budget so it
@@ -628,6 +647,9 @@ func (e *Engine) recordAndCheckBudget(rs *runState, nodeID string, output map[st
 	// event, but anchored on a NOT-YET-EXECUTED node — the doctrine the
 	// daily spend cap already follows two blocks above.
 	if exc := findExceeded(checks); exc != nil {
+		if !deferExceeded {
+			return e.failBudgetExceeded(rs, nodeID, exc)
+		}
 		rs.budget.noteExceeded(exc)
 	}
 

--- a/pkg/runtime/budget.go
+++ b/pkg/runtime/budget.go
@@ -48,6 +48,10 @@ type SharedBudget struct {
 	// the trigger for persisting the (absolute) caps on the run record.
 	everRaised bool
 
+	// exceeded holds an overrun measured AFTER a node completed, pending
+	// the next node boundary where the run stops on it. See noteExceeded.
+	exceeded *budgetCheckResult
+
 	// Unpriced spend — nodes that burned tokens while no price could be
 	// resolved for their model. Their cost is unknown, NOT zero, so it can
 	// never reach costUsed; tracked here so a declared max_cost_usd can say
@@ -243,6 +247,32 @@ type budgetCheckResult struct {
 // Because budget enforcement is soft (pre-check and post-record are not
 // atomic), concurrent branches may push usage past the limit. When overage
 // exceeds 20% of the limit, a warning is logged to aid debugging.
+// noteExceeded records that a completed node took the run past a hard
+// limit. The first overrun wins: it is the one that ends the run, and a
+// later dimension tripping in a parallel branch does not overwrite the
+// reason the operator is shown.
+func (b *SharedBudget) noteExceeded(exc *budgetCheckResult) {
+	if exc == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.exceeded == nil {
+		v := *exc
+		b.exceeded = &v
+	}
+}
+
+// takeExceeded returns and clears a pending overrun, so exactly one node
+// boundary acts on it.
+func (b *SharedBudget) takeExceeded() *budgetCheckResult {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	exc := b.exceeded
+	b.exceeded = nil
+	return exc
+}
+
 func (b *SharedBudget) RecordUsage(tokens int, costUSD float64) []budgetCheckResult {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -587,9 +617,18 @@ func (e *Engine) recordAndCheckBudget(rs *runState, nodeID string, output map[st
 		_ = e.emit(rs.ctx, rs.runID, store.EventBudgetWarning, nodeID, budgetWarningData(w))
 	}
 
-	// Fail on exceeded.
+	// Exceeded by a node that ALREADY SUCCEEDED: note it and let the
+	// caller stop the run at the next node boundary. Failing right here
+	// anchors the checkpoint on the node that just produced a valid,
+	// stored output, so a resume re-executes it — for an agent node that
+	// means paying its entire cost again to reach a result the store
+	// already holds (observed: a campaign node overran 442/400, and its
+	// resume would have re-run the whole pass). Stopping one edge later
+	// keeps the run failing exactly as before, on the same error and
+	// event, but anchored on a NOT-YET-EXECUTED node — the doctrine the
+	// daily spend cap already follows two blocks above.
 	if exc := findExceeded(checks); exc != nil {
-		return e.failBudgetExceeded(rs, nodeID, exc)
+		rs.budget.noteExceeded(exc)
 	}
 
 	return nil

--- a/pkg/runtime/budget_test.go
+++ b/pkg/runtime/budget_test.go
@@ -1495,3 +1495,64 @@ func TestSharedBudget_UnpricedSpend(t *testing.T) {
 		}
 	})
 }
+
+// TestBudgetOverrunCheckpointsTheNextNode pins where a run stops when a
+// node that SUCCEEDED took it past the cap. The node's output is already
+// stored, so anchoring the checkpoint on it would make a resume pay for
+// that node twice — for an agent pass, the entire cost again. The run
+// still fails (the cap was exceeded), but on the node that has NOT run.
+func TestBudgetOverrunCheckpointsTheNextNode(t *testing.T) {
+	wf := &ir.Workflow{
+		Name:  "budget_overrun_checkpoint",
+		Entry: "expensive",
+		Nodes: map[string]ir.Node{
+			"expensive": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "expensive"}},
+			"tail":      &ir.AgentNode{BaseNode: ir.BaseNode{ID: "tail"}},
+			"done":      &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+			"fail":      &ir.FailNode{BaseNode: ir.BaseNode{ID: "fail"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "expensive", To: "tail"},
+			{From: "tail", To: "done"},
+		},
+		Schemas: map[string]*ir.Schema{},
+		Prompts: map[string]*ir.Prompt{},
+		Vars:    map[string]*ir.Var{},
+		Loops:   map[string]*ir.Loop{},
+		Budget:  &ir.Budget{MaxCostUSD: 1.0},
+	}
+
+	exec := newStubExecutor()
+	tailRan := false
+	exec.on("expensive", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"ok": true, "_cost_usd": 1.4}, nil
+	})
+	exec.on("tail", func(_ map[string]any) (map[string]any, error) {
+		tailRan = true
+		return map[string]any{"ok": true, "_cost_usd": 0.1}, nil
+	})
+
+	s := tmpStore(t)
+	eng := New(wf, s, exec)
+	err := eng.Run(context.Background(), "run-budget-overrun", nil)
+	if err == nil || !strings.Contains(err.Error(), "budget exceeded") {
+		t.Fatalf("an overrun must still fail the run, got: %v", err)
+	}
+	if tailRan {
+		t.Fatal("a node started after the budget was spent")
+	}
+
+	run, gerr := s.LoadRun(context.Background(), "run-budget-overrun")
+	if gerr != nil {
+		t.Fatal(gerr)
+	}
+	if run.Checkpoint == nil {
+		t.Fatal("no checkpoint saved: the run is not resumable")
+	}
+	if run.Checkpoint.NodeID != "tail" {
+		t.Fatalf("checkpoint anchored on %q, want \"tail\" — resuming would re-execute the node whose output is already stored", run.Checkpoint.NodeID)
+	}
+	if _, ok := run.Checkpoint.Outputs["expensive"]; !ok {
+		t.Fatal("the completed node's output is missing from the checkpoint: the resume would have to recompute it")
+	}
+}

--- a/pkg/runtime/budget_test.go
+++ b/pkg/runtime/budget_test.go
@@ -1556,3 +1556,80 @@ func TestBudgetOverrunCheckpointsTheNextNode(t *testing.T) {
 		t.Fatal("the completed node's output is missing from the checkpoint: the resume would have to recompute it")
 	}
 }
+
+// TestBudgetOverrunOnRouterStillFails pins the guarantee against the
+// deferral: recordAndCheckBudget has callers that never return through
+// execLoopAfterExec (the LLM router, the resume paths). Deferring THEIR
+// overrun would leave it uncollected whenever the rest of the path is
+// special-dispatch nodes — none of which run the pre-exec check — and the
+// run would reach done and be persisted `finished` with the cap blown.
+// A budget is a load-bearing limit: a path that exceeds it and reports
+// success is a broken guarantee, not a degradation.
+func TestBudgetOverrunOnRouterStillFails(t *testing.T) {
+	wf := &ir.Workflow{
+		Name:  "budget_overrun_router",
+		Entry: "route",
+		Nodes: map[string]ir.Node{
+			"route": &ir.RouterNode{BaseNode: ir.BaseNode{ID: "route"}, RouterMode: ir.RouterLLM},
+			"done":  &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+			"fail":  &ir.FailNode{BaseNode: ir.BaseNode{ID: "fail"}},
+		},
+		Edges:   []*ir.Edge{{From: "route", To: "done"}},
+		Schemas: map[string]*ir.Schema{},
+		Prompts: map[string]*ir.Prompt{},
+		Vars:    map[string]*ir.Var{},
+		Loops:   map[string]*ir.Loop{},
+		Budget:  &ir.Budget{MaxCostUSD: 1.0},
+	}
+
+	exec := newStubExecutor()
+	exec.on("route", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"next": "done", "_cost_usd": 5.0}, nil
+	})
+
+	s := tmpStore(t)
+	eng := New(wf, s, exec)
+	err := eng.Run(context.Background(), "run-budget-router", nil)
+	if err == nil || !strings.Contains(err.Error(), "budget exceeded") {
+		t.Fatalf("a router that blew the cap let the run finish: %v", err)
+	}
+}
+
+// TestBudgetOverrunSurvivesAnEdgeError pins WHICH error a run dies on when
+// the overrunning node also has no matching outgoing edge. BUDGET_EXCEEDED
+// carries the sentinel the cloud runner's terminal-ack matches; a naked
+// NO_OUTGOING_EDGE is nak'd back to the queue and redelivered onto the same
+// spent budget — the redelivery loop that carve-out exists to prevent.
+func TestBudgetOverrunSurvivesAnEdgeError(t *testing.T) {
+	wf := &ir.Workflow{
+		Name:  "budget_overrun_edge_error",
+		Entry: "a",
+		Nodes: map[string]ir.Node{
+			"a":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}},
+			"b":    &ir.AgentNode{BaseNode: ir.BaseNode{ID: "b"}},
+			"done": &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+			"fail": &ir.FailNode{BaseNode: ir.BaseNode{ID: "fail"}},
+		},
+		Edges:   []*ir.Edge{{From: "a", To: "b", Condition: "go_on"}, {From: "b", To: "done"}},
+		Schemas: map[string]*ir.Schema{},
+		Prompts: map[string]*ir.Prompt{},
+		Vars:    map[string]*ir.Var{},
+		Loops:   map[string]*ir.Loop{},
+		Budget:  &ir.Budget{MaxCostUSD: 1.0},
+	}
+
+	exec := newStubExecutor()
+	exec.on("a", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"go_on": false, "_cost_usd": 5.0}, nil
+	})
+
+	s := tmpStore(t)
+	eng := New(wf, s, exec)
+	err := eng.Run(context.Background(), "run-budget-edge-error", nil)
+	if err == nil {
+		t.Fatal("expected the run to fail")
+	}
+	if !errors.Is(err, ErrBudgetExceeded) {
+		t.Fatalf("run died on %v — the budget sentinel is gone, so the cloud runner would nak and redeliver onto the same spent budget", err)
+	}
+}

--- a/pkg/runtime/engine_exec.go
+++ b/pkg/runtime/engine_exec.go
@@ -597,6 +597,21 @@ func (e *Engine) execLoopAfterExec(ctx context.Context, rs *runState, currentNod
 	if err != nil {
 		return "", e.failRunErrWithCheckpoint(rs, currentNodeID, err)
 	}
+
+	// A hard overrun measured after THIS node ends the run here, one edge
+	// later than the measurement — anchored on the node that has not run,
+	// so a resume with a raised cap continues from there instead of
+	// re-executing the node whose output is already stored. With no next
+	// node the run has nowhere left to go, so it stops where it stands.
+	if rs.budget != nil {
+		if exc := rs.budget.takeExceeded(); exc != nil {
+			anchor := nextNodeID
+			if anchor == "" {
+				anchor = currentNodeID
+			}
+			return "", e.failBudgetExceeded(rs, anchor, exc)
+		}
+	}
 	return nextNodeID, nil
 }
 

--- a/pkg/runtime/engine_exec.go
+++ b/pkg/runtime/engine_exec.go
@@ -563,7 +563,7 @@ func (e *Engine) execLoopAfterExec(ctx context.Context, rs *runState, currentNod
 	}
 
 	// Record budget usage and check limits.
-	if err := e.recordAndCheckBudget(rs, currentNodeID, output); err != nil {
+	if err := e.recordAndDeferBudget(rs, currentNodeID, output); err != nil {
 		return "", err
 	}
 
@@ -593,24 +593,30 @@ func (e *Engine) execLoopAfterExec(ctx context.Context, rs *runState, currentNod
 	// fork-rewind capability for THIS node).
 	e.snapshotAtNodeBoundary(rs, currentNodeID)
 
-	nextNodeID, err := e.selectEdgeRS(rs, currentNodeID, output)
-	if err != nil {
-		return "", e.failRunErrWithCheckpoint(rs, currentNodeID, err)
-	}
+	nextNodeID, edgeErr := e.selectEdgeRS(rs, currentNodeID, output)
 
 	// A hard overrun measured after THIS node ends the run here, one edge
-	// later than the measurement — anchored on the node that has not run,
+	// later than the measurement — anchored on the node that has NOT run,
 	// so a resume with a raised cap continues from there instead of
-	// re-executing the node whose output is already stored. With no next
-	// node the run has nowhere left to go, so it stops where it stands.
+	// re-executing the node whose output is already stored.
+	//
+	// Taken BEFORE any edge error is surfaced: a node that blew the cap
+	// and then found no matching edge must still die as BUDGET_EXCEEDED.
+	// That error is what the cloud runner's terminal-ack carve-out
+	// matches; a naked NO_OUTGOING_EDGE goes back to JetStream and is
+	// redelivered onto the same spent budget. With no successor the run
+	// has nowhere to go, so it stops where it stands.
 	if rs.budget != nil {
 		if exc := rs.budget.takeExceeded(); exc != nil {
 			anchor := nextNodeID
-			if anchor == "" {
+			if edgeErr != nil || anchor == "" {
 				anchor = currentNodeID
 			}
 			return "", e.failBudgetExceeded(rs, anchor, exc)
 		}
+	}
+	if edgeErr != nil {
+		return "", e.failRunErrWithCheckpoint(rs, currentNodeID, edgeErr)
 	}
 	return nextNodeID, nil
 }


### PR DESCRIPTION
## The failure

A node whose usage takes the run past a hard cap has already **succeeded**: its output is validated, persisted, and in the store. The post-exec check then failed the run with the checkpoint anchored on *that* node — so `iterion resume --max-cost-usd <higher>` re-executed it.

For an agent node that means paying its entire cost a second time to reach a result already on disk. Observed live on a documentation campaign that overran **442/400 USD**: the run ended `failed_resumable`, and the only way forward was to pay for the whole pass again. Its committed work was banked in git, but the run could not reach its own exit path (a PR tail) to ship it.

## The fix

The overrun is noted on the shared budget and acted on **one edge later**, once the next node is known. The run still fails — same error, same `budget_exceeded` event, same resumable status — but anchored on a node that has **not** run, so the resume continues from there.

This is the doctrine the daily spend cap already follows, in a comment two blocks above the changed code:

> the pause decision happens on the pre-exec path so we anchor the checkpoint at a not-yet-executed node

The per-run budget's post-exec path was the one place that broke it.

**Nothing new starts on a spent budget.** `checkBudgetBeforeExec` still refuses every node at 100% (and blocks new executions at 90%); the new test asserts the successor never ran.

## Verification

- `go test ./pkg/...` → 9356 pass, 132 packages
- The new test was seen RED against the previous behaviour (checkpoint anchored on the completed node).

## Follow-up, not in this PR

Even with the checkpoint fixed, a run that overruns cannot reach its own exit path in the *same* run: the tail's nodes are refused like any other. The loop guard keeps a 10% margin precisely so the tail fits, but that only holds when the overrun comes from iteration count — not when a single node overshoots the cap on its own. Whether the exit path deserves a bounded grace allowance is a doctrine call for a maintainer, not something to slip into a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)