### PR TITLE
fix(studio): default inline subbot frame to live/latest child

### DIFF
--- a/studio/src/hooks/useInlineSubbotData.ts
+++ b/studio/src/hooks/useInlineSubbotData.ts
@@ -10,7 +10,11 @@ import {
   type RunSummary,
   type WireWorkflow,
 } from "@/api/runs";
-import { groupChildrenByNode, isSettledRunStatus } from "@/lib/subRuns";
+import {
+  groupChildrenByNode,
+  isSettledRunStatus,
+  resolveSelectedSubbotChild,
+} from "@/lib/subRuns";
 import { makeSubbotChildId } from "@/lib/subbotGraph";
 
 // Data feeds for the run canvas's INLINE subbot expansion
@@ -38,8 +42,8 @@ export interface InlineSubbotData {
   childWorkflowsByNode: Map<string, WireWorkflow>;
   // child run id -> its live executions (selected children only).
   childExecutionsByRun: Map<string, ExecutionState[]>;
-  // frameId -> the child run the frame displays (user pick, defaulted
-  // to the first child).
+  // frameId -> the child run the frame displays (user pick, else the
+  // live/latest child — see resolveSelectedSubbotChild).
   selectedChildByFrame: Map<string, string>;
 }
 
@@ -70,18 +74,15 @@ function useSubbotLevel(
   pickedByFrame: Map<string, string>,
 ): LevelData {
   // Effective selection: the user's pick while that child still exists,
-  // else the first child (created_at asc — stable).
+  // else the live/latest child (not children[0] — that is the oldest).
   const selected = useMemo(() => {
     const m = new Map<string, string>();
     for (const f of frames) {
-      if (f.children.length === 0) continue;
-      const picked = pickedByFrame.get(f.frameId);
-      m.set(
-        f.frameId,
-        picked && f.children.some((c) => c.id === picked)
-          ? picked
-          : f.children[0]!.id,
+      const id = resolveSelectedSubbotChild(
+        f.children,
+        pickedByFrame.get(f.frameId),
       );
+      if (id) m.set(f.frameId, id);
     }
     return m;
   }, [frames, pickedByFrame]);

--- a/studio/src/hooks/useInlineSubbotData.ts
+++ b/studio/src/hooks/useInlineSubbotData.ts
@@ -75,8 +75,8 @@ function useSubbotLevel(
   pickedByFrame: Map<string, string>,
 ): LevelData {
   // Effective selection: the user's pick while that child still exists,
-  // else the last auto-shown child while the list has not grown, else
-  // the live/latest child (not children[0] — that is the oldest).
+  // else the last auto-shown child while the list has not grown and no
+  // sibling outranks it, else the live/latest child (not children[0]).
   const stickyByFrame = useRef(new Map<string, SubbotSelectionSticky>());
   const selected = useMemo(() => {
     const m = new Map<string, string>();
@@ -119,6 +119,10 @@ function useSubbotLevel(
         queryKey: ["run-workflow", id],
         queryFn: () => getRunWorkflow(id),
         staleTime: 5 * 60_000,
+        // Keep the last IR on screen while a new child key fetches —
+        // otherwise auto-reselect blanks expandWireSubbots until the
+        // request returns. Siblings share a source in normal execution.
+        placeholderData: (prev: WireWorkflow | undefined) => prev,
       };
     }),
     combine: combineWf,

--- a/studio/src/hooks/useInlineSubbotData.ts
+++ b/studio/src/hooks/useInlineSubbotData.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { useQueries, type UseQueryResult } from "@tanstack/react-query";
 
 import {
@@ -14,6 +14,7 @@ import {
   groupChildrenByNode,
   isSettledRunStatus,
   resolveSelectedSubbotChild,
+  type SubbotSelectionSticky,
 } from "@/lib/subRuns";
 import { makeSubbotChildId } from "@/lib/subbotGraph";
 
@@ -25,11 +26,11 @@ import { makeSubbotChildId } from "@/lib/subbotGraph";
 // (matching lib/subbotGraph.MAX_SUBBOT_EXPANSION_DEPTH) keep the hook
 // order static; deeper subbots stay compact.
 //
-// Per level and frame: the child workflow shape (from the first child —
-// all children of one node share the source), the SELECTED child's
-// children (nested grouping + tab dots), and the SELECTED child's live
-// executions (REST-polled at 3s while unsettled; siblings poll nothing
-// until their tab is picked).
+// Per level and frame: the child workflow shape (from the displayed
+// child — siblings share a source in normal execution), the SELECTED
+// child's children (nested grouping + tab dots), and the SELECTED
+// child's live executions (REST-polled at 3s while unsettled; siblings
+// poll nothing until their tab is picked).
 const CHILD_POLL_MS = 3000;
 // Safety cap on frames tracked per level — beyond this the inline
 // frames still render for the first N, later ones stay compact.
@@ -74,16 +75,24 @@ function useSubbotLevel(
   pickedByFrame: Map<string, string>,
 ): LevelData {
   // Effective selection: the user's pick while that child still exists,
-  // else the live/latest child (not children[0] — that is the oldest).
+  // else the last auto-shown child while the list has not grown, else
+  // the live/latest child (not children[0] — that is the oldest).
+  const stickyByFrame = useRef(new Map<string, SubbotSelectionSticky>());
   const selected = useMemo(() => {
     const m = new Map<string, string>();
+    const next = new Map<string, SubbotSelectionSticky>();
     for (const f of frames) {
       const id = resolveSelectedSubbotChild(
         f.children,
         pickedByFrame.get(f.frameId),
+        stickyByFrame.current.get(f.frameId),
       );
-      if (id) m.set(f.frameId, id);
+      if (id) {
+        m.set(f.frameId, id);
+        next.set(f.frameId, { id, count: f.children.length });
+      }
     }
+    stickyByFrame.current = next;
     return m;
   }, [frames, pickedByFrame]);
 
@@ -104,11 +113,14 @@ function useSubbotLevel(
     [frames],
   );
   const wfByFrame = useQueries({
-    queries: frames.map((f) => ({
-      queryKey: ["run-workflow", f.children[0]!.id],
-      queryFn: () => getRunWorkflow(f.children[0]!.id),
-      staleTime: 5 * 60_000,
-    })),
+    queries: frames.map((f) => {
+      const id = selected.get(f.frameId) ?? f.children[0]!.id;
+      return {
+        queryKey: ["run-workflow", id],
+        queryFn: () => getRunWorkflow(id),
+        staleTime: 5 * 60_000,
+      };
+    }),
     combine: combineWf,
   });
 

--- a/studio/src/lib/subRuns.test.ts
+++ b/studio/src/lib/subRuns.test.ts
@@ -332,4 +332,43 @@ describe("resolveSelectedSubbotChild", () => {
       resolveSelectedSubbotChild(children, "a", { id: "b", count: 2 }),
     ).toBe("a");
   });
+
+  it("hops off a sticky child that failed while a sibling is still running", () => {
+    const children = [
+      child({ id: "sticky-fail", status: "failed" }),
+      child({ id: "live", status: "running" }),
+    ];
+    expect(
+      resolveSelectedSubbotChild(children, undefined, {
+        id: "sticky-fail",
+        count: 2,
+      }),
+    ).toBe("live");
+  });
+
+  it("hops from a sticky settled child to a sibling that later hits paused_waiting_human", () => {
+    const children = [
+      child({ id: "done", status: "finished" }),
+      child({ id: "gate", status: "paused_waiting_human" }),
+    ];
+    expect(
+      resolveSelectedSubbotChild(children, undefined, {
+        id: "done",
+        count: 2,
+      }),
+    ).toBe("gate");
+  });
+
+  it("keeps sticky among equal-rank running siblings (no hop)", () => {
+    const children = [
+      child({ id: "a", status: "running" }),
+      child({ id: "b", status: "running" }),
+    ];
+    expect(
+      resolveSelectedSubbotChild(children, undefined, {
+        id: "a",
+        count: 2,
+      }),
+    ).toBe("a");
+  });
 });

--- a/studio/src/lib/subRuns.test.ts
+++ b/studio/src/lib/subRuns.test.ts
@@ -178,68 +178,82 @@ describe("isSettledRunStatus", () => {
 });
 
 describe("resolveSelectedSubbotChild", () => {
-  const older = "2026-08-01T10:00:00Z";
-  const newer = "2026-08-01T11:00:00Z";
-  const newest = "2026-08-01T12:00:00Z";
-
   it("returns undefined for an empty list", () => {
     expect(resolveSelectedSubbotChild([])).toBeUndefined();
   });
 
-  it("defaults to the newer finished child over an older failed one", () => {
+  it("defaults to the later finished child over an earlier failed one (list order)", () => {
     const children = [
-      child({ id: "old-fail", status: "failed", created_at: older }),
-      child({ id: "new-pass", status: "finished", created_at: newer }),
+      child({ id: "old-fail", status: "failed" }),
+      child({ id: "new-pass", status: "finished" }),
     ];
     expect(resolveSelectedSubbotChild(children)).toBe("new-pass");
   });
 
+  it("tie-breaks equal rank by later array position, not ISO string order", () => {
+    // Go encoding/json RFC3339Nano trims fractional zeros, so ".12Z" >
+    // ".125Z" lexicographically even though 120ms is older than 125ms.
+    const children = [
+      child({
+        id: "older",
+        status: "finished",
+        created_at: "2026-08-01T10:00:00.12Z",
+      }),
+      child({
+        id: "newer",
+        status: "finished",
+        created_at: "2026-08-01T10:00:00.125Z",
+      }),
+    ];
+    expect(resolveSelectedSubbotChild(children)).toBe("newer");
+  });
+
   it("prefers a running child over settled historical children", () => {
     const children = [
-      child({ id: "old-fail", status: "failed", created_at: older }),
-      child({ id: "live", status: "running", created_at: newer }),
-      child({ id: "new-pass", status: "finished", created_at: newest }),
+      child({ id: "old-fail", status: "failed" }),
+      child({ id: "live", status: "running" }),
+      child({ id: "new-pass", status: "finished" }),
     ];
     expect(resolveSelectedSubbotChild(children)).toBe("live");
   });
 
   it("prefers paused_waiting_human over settled children, but not over running", () => {
     const waiting = [
-      child({ id: "old-fail", status: "failed", created_at: older }),
-      child({ id: "gate", status: "paused_waiting_human", created_at: newer }),
-      child({ id: "new-pass", status: "finished", created_at: newest }),
+      child({ id: "old-fail", status: "failed" }),
+      child({ id: "gate", status: "paused_waiting_human" }),
+      child({ id: "new-pass", status: "finished" }),
     ];
     expect(resolveSelectedSubbotChild(waiting)).toBe("gate");
 
     const runningWins = [
-      child({ id: "gate", status: "paused_waiting_human", created_at: older }),
-      child({ id: "live", status: "running", created_at: newer }),
+      child({ id: "gate", status: "paused_waiting_human" }),
+      child({ id: "live", status: "running" }),
     ];
     expect(resolveSelectedSubbotChild(runningWins)).toBe("live");
   });
 
   it("prefers another unsettled child (queued / operator pause) over settled history", () => {
     const children = [
-      child({ id: "old-fail", status: "failed", created_at: older }),
-      child({ id: "queued", status: "queued", created_at: newer }),
-      child({ id: "new-pass", status: "finished", created_at: newest }),
+      child({ id: "old-fail", status: "failed" }),
+      child({ id: "queued", status: "queued" }),
+      child({ id: "new-pass", status: "finished" }),
     ];
     expect(resolveSelectedSubbotChild(children)).toBe("queued");
   });
 
   it("keeps a valid explicit user selection", () => {
     const children = [
-      child({ id: "old-fail", status: "failed", created_at: older }),
-      child({ id: "live", status: "running", created_at: newer }),
-      child({ id: "new-pass", status: "finished", created_at: newest }),
+      child({ id: "old-fail", status: "failed" }),
+      child({ id: "live", status: "running" }),
+      child({ id: "new-pass", status: "finished" }),
     ];
     expect(resolveSelectedSubbotChild(children, "old-fail")).toBe("old-fail");
   });
 
   it("drops a stale explicit selection and falls back to the live/latest child", () => {
     const children = [
-      child({ id: "old-fail", status: "failed", created_at: older }),
-      child({ id: "new-pass", status: "finished", created_at: newer }),
+      child({ id: "old-fail", status: "failed" }),
+      child({ id: "new-pass", status: "finished" }),
     ];
     expect(resolveSelectedSubbotChild(children, "gone")).toBe("new-pass");
   });
@@ -250,22 +264,72 @@ describe("resolveSelectedSubbotChild", () => {
       child({
         id: "batch-0-fail",
         status: "failed",
-        created_at: older,
         parent_node_id: "review_epic_acceptance",
       }),
       child({
         id: "batch-1-pass",
         status: "finished",
-        created_at: newer,
         parent_node_id: "review_epic_acceptance",
       }),
       child({
         id: "batch-2-pass",
         status: "finished",
-        created_at: newest,
         parent_node_id: "review_epic_acceptance",
       }),
     ];
     expect(resolveSelectedSubbotChild(children)).toBe("batch-2-pass");
+  });
+
+  it("keeps sticky when statuses change and length is unchanged", () => {
+    const first = [
+      child({ id: "a", status: "running" }),
+      child({ id: "b", status: "running" }),
+      child({ id: "c", status: "queued" }),
+    ];
+    expect(resolveSelectedSubbotChild(first)).toBe("b");
+    const after = [
+      child({ id: "a", status: "finished" }),
+      child({ id: "b", status: "finished" }),
+      child({ id: "c", status: "finished" }),
+    ];
+    expect(
+      resolveSelectedSubbotChild(after, undefined, { id: "b", count: 3 }),
+    ).toBe("b");
+  });
+
+  it("drops sticky when the list grows (new spawn, #525)", () => {
+    const children = [
+      child({ id: "old-fail", status: "failed" }),
+      child({ id: "new-pass", status: "finished" }),
+    ];
+    expect(
+      resolveSelectedSubbotChild(children, undefined, {
+        id: "old-fail",
+        count: 1,
+      }),
+    ).toBe("new-pass");
+  });
+
+  it("drops sticky when that child disappears", () => {
+    const children = [
+      child({ id: "a", status: "failed" }),
+      child({ id: "b", status: "finished" }),
+    ];
+    expect(
+      resolveSelectedSubbotChild(children, undefined, {
+        id: "gone",
+        count: 2,
+      }),
+    ).toBe("b");
+  });
+
+  it("lets an explicit pick win over sticky", () => {
+    const children = [
+      child({ id: "a", status: "failed" }),
+      child({ id: "b", status: "running" }),
+    ];
+    expect(
+      resolveSelectedSubbotChild(children, "a", { id: "b", count: 2 }),
+    ).toBe("a");
   });
 });

--- a/studio/src/lib/subRuns.test.ts
+++ b/studio/src/lib/subRuns.test.ts
@@ -5,6 +5,7 @@ import {
   childTabLabel,
   groupChildrenByNode,
   isSettledRunStatus,
+  resolveSelectedSubbotChild,
   statusDotClass,
 } from "./subRuns";
 
@@ -173,5 +174,98 @@ describe("isSettledRunStatus", () => {
     ];
     for (const s of settled) expect(isSettledRunStatus(s)).toBe(true);
     for (const s of open) expect(isSettledRunStatus(s)).toBe(false);
+  });
+});
+
+describe("resolveSelectedSubbotChild", () => {
+  const older = "2026-08-01T10:00:00Z";
+  const newer = "2026-08-01T11:00:00Z";
+  const newest = "2026-08-01T12:00:00Z";
+
+  it("returns undefined for an empty list", () => {
+    expect(resolveSelectedSubbotChild([])).toBeUndefined();
+  });
+
+  it("defaults to the newer finished child over an older failed one", () => {
+    const children = [
+      child({ id: "old-fail", status: "failed", created_at: older }),
+      child({ id: "new-pass", status: "finished", created_at: newer }),
+    ];
+    expect(resolveSelectedSubbotChild(children)).toBe("new-pass");
+  });
+
+  it("prefers a running child over settled historical children", () => {
+    const children = [
+      child({ id: "old-fail", status: "failed", created_at: older }),
+      child({ id: "live", status: "running", created_at: newer }),
+      child({ id: "new-pass", status: "finished", created_at: newest }),
+    ];
+    expect(resolveSelectedSubbotChild(children)).toBe("live");
+  });
+
+  it("prefers paused_waiting_human over settled children, but not over running", () => {
+    const waiting = [
+      child({ id: "old-fail", status: "failed", created_at: older }),
+      child({ id: "gate", status: "paused_waiting_human", created_at: newer }),
+      child({ id: "new-pass", status: "finished", created_at: newest }),
+    ];
+    expect(resolveSelectedSubbotChild(waiting)).toBe("gate");
+
+    const runningWins = [
+      child({ id: "gate", status: "paused_waiting_human", created_at: older }),
+      child({ id: "live", status: "running", created_at: newer }),
+    ];
+    expect(resolveSelectedSubbotChild(runningWins)).toBe("live");
+  });
+
+  it("prefers another unsettled child (queued / operator pause) over settled history", () => {
+    const children = [
+      child({ id: "old-fail", status: "failed", created_at: older }),
+      child({ id: "queued", status: "queued", created_at: newer }),
+      child({ id: "new-pass", status: "finished", created_at: newest }),
+    ];
+    expect(resolveSelectedSubbotChild(children)).toBe("queued");
+  });
+
+  it("keeps a valid explicit user selection", () => {
+    const children = [
+      child({ id: "old-fail", status: "failed", created_at: older }),
+      child({ id: "live", status: "running", created_at: newer }),
+      child({ id: "new-pass", status: "finished", created_at: newest }),
+    ];
+    expect(resolveSelectedSubbotChild(children, "old-fail")).toBe("old-fail");
+  });
+
+  it("drops a stale explicit selection and falls back to the live/latest child", () => {
+    const children = [
+      child({ id: "old-fail", status: "failed", created_at: older }),
+      child({ id: "new-pass", status: "finished", created_at: newer }),
+    ];
+    expect(resolveSelectedSubbotChild(children, "gone")).toBe("new-pass");
+  });
+
+  it("does not let a historical fan-out failure paint the current pipeline", () => {
+    // fan_out_each × subbot: children arrive created_at asc, one per batch.
+    const children = [
+      child({
+        id: "batch-0-fail",
+        status: "failed",
+        created_at: older,
+        parent_node_id: "review_epic_acceptance",
+      }),
+      child({
+        id: "batch-1-pass",
+        status: "finished",
+        created_at: newer,
+        parent_node_id: "review_epic_acceptance",
+      }),
+      child({
+        id: "batch-2-pass",
+        status: "finished",
+        created_at: newest,
+        parent_node_id: "review_epic_acceptance",
+      }),
+    ];
+    expect(resolveSelectedSubbotChild(children)).toBe("batch-2-pass");
   });
 });

--- a/studio/src/lib/subRuns.ts
+++ b/studio/src/lib/subRuns.ts
@@ -118,8 +118,11 @@ export function isSettledRunStatus(status: RunStatus): boolean {
 
 // Rank for the inline-frame default tab: live work first, then a
 // human gate, then any other unsettled child, then settled history.
-// Lower wins. Within a rank, created_at (ISO) descending is the
-// tie-break — children arrive created_at asc, so "latest" is last.
+// Lower wins. Within a rank, later array position is the tie-break —
+// both stores return children created_at asc, and groupChildrenByNode
+// preserves that order. Do not compare created_at strings: Go's
+// encoding/json RFC3339Nano trims fractional zeros, so ".12Z" > ".125Z"
+// lexicographically and would pick the older child (issue #525).
 function subbotDefaultRank(status: RunStatus): number {
   switch (status) {
     case "running":
@@ -134,28 +137,41 @@ function subbotDefaultRank(status: RunStatus): number {
   }
 }
 
+// Last auto-shown child for a frame, plus the children.length observed
+// when it was shown. useSubbotLevel keeps one of these per frame so a
+// 3s poll does not hop between already-visible siblings as their
+// statuses flip. A new spawn (length grew) or a missing sticky id
+// re-resolves — that is the #525 path.
+export interface SubbotSelectionSticky {
+  id: string;
+  count: number;
+}
+
 // resolveSelectedSubbotChild picks which child run an inline subbot
 // frame displays. An explicit user pick is kept while that child still
-// exists; otherwise prefer running, then paused_waiting_human, then
-// another unsettled child, then the most recently created child. Never
-// defaults to children[0] (oldest) — a historical failure would paint
-// the current pipeline red (issue #525).
+// exists. Else a still-present sticky id is kept while the list has not
+// grown (no later child spawned). Else prefer running, then
+// paused_waiting_human, then another unsettled child, then the latest
+// child by array position. Never defaults to children[0] (oldest) — a
+// historical failure would paint the current pipeline red (issue #525).
 export function resolveSelectedSubbotChild(
   children: RunSummary[],
   picked?: string | null,
+  sticky?: SubbotSelectionSticky | null,
 ): string | undefined {
   if (children.length === 0) return undefined;
   if (picked && children.some((c) => c.id === picked)) return picked;
+  if (
+    sticky &&
+    children.some((c) => c.id === sticky.id) &&
+    children.length <= sticky.count
+  ) {
+    return sticky.id;
+  }
   let best = children[0]!;
   for (let i = 1; i < children.length; i++) {
     const c = children[i]!;
-    const rankDiff = subbotDefaultRank(c.status) - subbotDefaultRank(best.status);
-    if (rankDiff < 0) {
-      best = c;
-      continue;
-    }
-    if (rankDiff > 0) continue;
-    if (c.created_at >= best.created_at) best = c;
+    if (subbotDefaultRank(c.status) <= subbotDefaultRank(best.status)) best = c;
   }
   return best.id;
 }

--- a/studio/src/lib/subRuns.ts
+++ b/studio/src/lib/subRuns.ts
@@ -139,9 +139,10 @@ function subbotDefaultRank(status: RunStatus): number {
 
 // Last auto-shown child for a frame, plus the children.length observed
 // when it was shown. useSubbotLevel keeps one of these per frame so a
-// 3s poll does not hop between already-visible siblings as their
-// statuses flip. A new spawn (length grew) or a missing sticky id
-// re-resolves — that is the #525 path.
+// 3s poll does not hop between already-visible siblings of equal rank
+// as their statuses flip. A new spawn (length grew), a missing sticky
+// id, or a sibling with a strictly better rank (live over a sticky
+// failure) re-resolves — that is the #525 path.
 export interface SubbotSelectionSticky {
   id: string;
   count: number;
@@ -149,10 +150,11 @@ export interface SubbotSelectionSticky {
 
 // resolveSelectedSubbotChild picks which child run an inline subbot
 // frame displays. An explicit user pick is kept while that child still
-// exists. Else a still-present sticky id is kept while the list has not
-// grown (no later child spawned). Else prefer running, then
-// paused_waiting_human, then another unsettled child, then the latest
-// child by array position. Never defaults to children[0] (oldest) — a
+// exists. Else the rank+position default is computed, and a still-
+// present sticky id is kept only while the list has not grown AND its
+// rank is no worse than that default — so equal-rank siblings stay put,
+// but a sticky failure yields to a sibling that is still running (or a
+// later human gate). Never defaults to children[0] (oldest) — a
 // historical failure would paint the current pipeline red (issue #525).
 export function resolveSelectedSubbotChild(
   children: RunSummary[],
@@ -161,17 +163,19 @@ export function resolveSelectedSubbotChild(
 ): string | undefined {
   if (children.length === 0) return undefined;
   if (picked && children.some((c) => c.id === picked)) return picked;
-  if (
-    sticky &&
-    children.some((c) => c.id === sticky.id) &&
-    children.length <= sticky.count
-  ) {
-    return sticky.id;
-  }
   let best = children[0]!;
   for (let i = 1; i < children.length; i++) {
     const c = children[i]!;
     if (subbotDefaultRank(c.status) <= subbotDefaultRank(best.status)) best = c;
+  }
+  if (sticky && children.length <= sticky.count) {
+    const stuck = children.find((c) => c.id === sticky.id);
+    if (
+      stuck &&
+      subbotDefaultRank(stuck.status) <= subbotDefaultRank(best.status)
+    ) {
+      return stuck.id;
+    }
   }
   return best.id;
 }

--- a/studio/src/lib/subRuns.ts
+++ b/studio/src/lib/subRuns.ts
@@ -115,3 +115,47 @@ export function isSettledRunStatus(status: RunStatus): boolean {
     status === "cancelled"
   );
 }
+
+// Rank for the inline-frame default tab: live work first, then a
+// human gate, then any other unsettled child, then settled history.
+// Lower wins. Within a rank, created_at (ISO) descending is the
+// tie-break — children arrive created_at asc, so "latest" is last.
+function subbotDefaultRank(status: RunStatus): number {
+  switch (status) {
+    case "running":
+      return 0;
+    case "paused_waiting_human":
+      return 1;
+    case "queued":
+    case "paused_operator":
+      return 2;
+    default:
+      return 3;
+  }
+}
+
+// resolveSelectedSubbotChild picks which child run an inline subbot
+// frame displays. An explicit user pick is kept while that child still
+// exists; otherwise prefer running, then paused_waiting_human, then
+// another unsettled child, then the most recently created child. Never
+// defaults to children[0] (oldest) — a historical failure would paint
+// the current pipeline red (issue #525).
+export function resolveSelectedSubbotChild(
+  children: RunSummary[],
+  picked?: string | null,
+): string | undefined {
+  if (children.length === 0) return undefined;
+  if (picked && children.some((c) => c.id === picked)) return picked;
+  let best = children[0]!;
+  for (let i = 1; i < children.length; i++) {
+    const c = children[i]!;
+    const rankDiff = subbotDefaultRank(c.status) - subbotDefaultRank(best.status);
+    if (rankDiff < 0) {
+      best = c;
+      continue;
+    }
+    if (rankDiff > 0) continue;
+    if (c.created_at >= best.created_at) best = c;
+  }
+  return best.id;
+}


### PR DESCRIPTION
## Summary

Fixes #525: the Run canvas inline subbot frame defaulted to `children[0]`, which is the **oldest** child (API order is `created_at` asc). After a `fan_out_each × subbot` retry, an old failed child stayed selected and painted the expanded graph red even when the current child had finished successfully.

Without an explicit tab pick the frame now:

1. Prefers a currently `running` child
2. Else prefers `paused_waiting_human`, then another unsettled child (`queued` / `paused_operator`)
3. Else selects the most recently created child
4. Keeps a valid explicit user selection

## Test plan

- [x] `corepack pnpm exec vitest run src/lib/subRuns.test.ts` (16 tests, including the #525 cases)
- [ ] On a parent run with an old failed child + a newer finished child, expand the subbot frame: the pipeline shows the newer child (green), not the historical failure
- [ ] While a later child is `running` or `paused_waiting_human`, that tab is selected over settled history
- [ ] Clicking an older tab keeps that child selected