### PR TITLE
fix(cli): local file secrets never reached the sandbox

### DIFF
--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -314,6 +314,17 @@ func RunRun(ctx context.Context, opts RunOptions, p *Printer) error {
 	if err != nil {
 		return err
 	}
+	// The ENGINE's context needs the credentials too, not only the
+	// executor's: declared file secrets are mounted into the sandbox at
+	// run start, from the ctx handed to Run. Without this the mount is
+	// skipped and an optional secret silently never reaches the bot.
+	if localStore, localSealer, lsErr := localSecretsForRun(len(wf.Secrets) > 0, storeDir, logger); lsErr != nil {
+		return lsErr
+	} else if stamped, sErr := runview.StampLocalCredentials(ctx, wf, localStore, localSealer, logger); sErr != nil {
+		return sErr
+	} else {
+		ctx = stamped
+	}
 	if c, ok := executor.(io.Closer); ok {
 		defer func() {
 			if cerr := c.Close(); cerr != nil {

--- a/pkg/runview/executor.go
+++ b/pkg/runview/executor.go
@@ -178,6 +178,52 @@ type ExecutorSpec struct {
 // declaredSecretNames returns the names of the workflow's declared
 // `secrets:` block — the only names a `{{secrets.X}}` reference can legally
 // use (compile-checked). Nil-safe.
+// StampLocalCredentials resolves the workflow's declared `secrets:` names
+// from the local sealed store and returns a context carrying them — the
+// in-process equivalent of the cloud runner's injectCredentials. Returns
+// ctx unchanged when there is no local store, or when credentials are
+// already present (the cloud path's are never overwritten).
+//
+// It is EXPORTED because the context it returns has to reach further than
+// the executor: the engine mounts declared file secrets into the sandbox
+// at run start, reading them from the ctx passed to Run. A caller that
+// stamps only the executor's own context ships a sandbox with no secret
+// files at all — an optional one is skipped silently, and the bot simply
+// never finds its token (observed: a docs bot's PR tail reporting "no
+// forge_token secret" on a host whose store held exactly that secret).
+func StampLocalCredentials(
+	ctx context.Context,
+	wf *ir.Workflow,
+	localSecrets secrets.GenericSecretStore,
+	sealer secrets.Sealer,
+	logger *iterlog.Logger,
+) (context.Context, error) {
+	if localSecrets == nil || sealer == nil {
+		return ctx, nil
+	}
+	if _, already := secrets.CredentialsFromContext(ctx); already {
+		return ctx, nil
+	}
+	creds, err := secrets.ResolveLocalCredentials(ctx, localSecrets, sealer, declaredSecretNames(wf), logger)
+	if err != nil {
+		return nil, fmt.Errorf("runview: resolve local secrets: %w", err)
+	}
+	// Required-secret launch gate (parity with the cloud publisher): a
+	// non-`optional` declared secret with no inline value MUST resolve to
+	// a non-empty value. If it resolves to nothing, fail the launch here
+	// rather than running the bot with the credential unset.
+	haveValue := make(map[string]bool, len(creds.Generic))
+	for name, v := range creds.Generic {
+		if v != "" {
+			haveValue[name] = true
+		}
+	}
+	if missing := secrets.UnresolvedRequired(requiredSecretNames(wf), haveValue); len(missing) > 0 {
+		return nil, secrets.RequiredSecretsError(missing, "this workspace")
+	}
+	return secrets.WithCredentials(ctx, creds), nil
+}
+
 func declaredSecretNames(wf *ir.Workflow) []string {
 	if wf == nil || len(wf.Secrets) == 0 {
 		return nil
@@ -249,29 +295,11 @@ func BuildExecutor(spec ExecutorSpec) (*model.ClawExecutor, error) {
 	// stamp them into ctx — the in-process equivalent of the cloud runner's
 	// injectCredentials. Skipped when the cloud path already put Credentials
 	// in ctx (never overwrite pre-resolved cloud credentials).
-	if spec.LocalSecrets != nil && spec.LocalSealer != nil {
-		if _, already := secrets.CredentialsFromContext(ctx); !already {
-			names := declaredSecretNames(spec.Workflow)
-			creds, err := secrets.ResolveLocalCredentials(ctx, spec.LocalSecrets, spec.LocalSealer, names, spec.Logger)
-			if err != nil {
-				return nil, fmt.Errorf("runview: resolve local secrets: %w", err)
-			}
-			// Required-secret launch gate (parity with the cloud publisher): a
-			// non-`optional` declared secret with no inline value MUST resolve to
-			// a non-empty value. If it resolves to nothing, fail the launch here
-			// rather than running the bot with the credential unset.
-			haveValue := make(map[string]bool, len(creds.Generic))
-			for name, v := range creds.Generic {
-				if v != "" {
-					haveValue[name] = true
-				}
-			}
-			if missing := secrets.UnresolvedRequired(requiredSecretNames(spec.Workflow), haveValue); len(missing) > 0 {
-				return nil, secrets.RequiredSecretsError(missing, "this workspace")
-			}
-			ctx = secrets.WithCredentials(ctx, creds)
-		}
+	stamped, err := StampLocalCredentials(ctx, spec.Workflow, spec.LocalSecrets, spec.LocalSealer, spec.Logger)
+	if err != nil {
+		return nil, err
 	}
+	ctx = stamped
 	// Build the per-run secret guard (Layer 0/1/2) from the resolved
 	// credentials in ctx + sensitive host env + declared workflow
 	// secrets, then thread it through the event hooks so every sink is

--- a/pkg/runview/executor_secrets_test.go
+++ b/pkg/runview/executor_secrets_test.go
@@ -76,3 +76,57 @@ func TestBuildExecutor_OptionalSecretUnresolvedOK(t *testing.T) {
 		t.Fatalf("optional unresolved secret must not fail BuildExecutor: %v", err)
 	}
 }
+
+// TestStampLocalCredentials_ReachesTheEngineContext pins WHERE the resolved
+// credentials have to land. The engine mounts declared file secrets into the
+// sandbox at run start, reading them from the context handed to Run — so a
+// caller that stamps only the executor's own context ships a container with
+// no secret files, and an optional secret is skipped in silence. That is how
+// a docs bot's PR tail reported "no forge_token secret" on a host whose
+// store held exactly that secret.
+func TestStampLocalCredentials_ReachesTheEngineContext(t *testing.T) {
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	memStore := secrets.NewMemoryGenericSecretStore()
+	const secretID = "sec-forge-token"
+	sealed, err := secrets.SealGenericSecret(sealer, secretID, []byte("jeton-de-test"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if err := memStore.Create(context.Background(), secrets.GenericSecret{
+		ID:           secretID,
+		ScopeTeamID:  secrets.LocalScopeTeam,
+		Name:         "forge_token",
+		SealedSecret: sealed,
+	}); err != nil {
+		t.Fatalf("store the secret: %v", err)
+	}
+
+	wf := &ir.Workflow{Name: "canary", Secrets: map[string]*ir.Secret{
+		"forge_token": {As: "file", Optional: true},
+	}}
+
+	ctx, err := StampLocalCredentials(context.Background(), wf, memStore, sealer, nil)
+	if err != nil {
+		t.Fatalf("StampLocalCredentials: %v", err)
+	}
+	creds, ok := secrets.CredentialsFromContext(ctx)
+	if !ok {
+		t.Fatal("the returned context carries no credentials: the sandbox would mount nothing")
+	}
+	if got := creds.GenericSecret("forge_token"); got == "" {
+		t.Fatal("forge_token resolved empty from a store that holds it — the file secret would be skipped as unresolved")
+	}
+
+	// No local store: the caller's context must come back untouched rather
+	// than carrying an empty credential set that masks the cloud path's own.
+	same, err := StampLocalCredentials(context.Background(), wf, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("no-store stamp: %v", err)
+	}
+	if _, ok := secrets.CredentialsFromContext(same); ok {
+		t.Fatal("stamped credentials with no local store configured")
+	}
+}


### PR DESCRIPTION
## The failure

A bot declaring a file secret got it mounted **nowhere** on a local run.

The credentials are resolved from the sealed store and stamped into the *executor's* context (`BuildExecutor`). But the engine mounts declared file secrets into the sandbox **at run start**, from the context handed to `Run` — and that context never carried them. `addSecretFileMounts` therefore read an empty `Credentials` and:

- an **optional** secret was skipped in silence ("the agent simply won't find the file"),
- a **required** one failed the launch with `file secret "X" has no resolved value … or configure a stored secret named "X"` — on a host whose store held exactly that secret.

What it cost in practice: a documentation bot's PR tail probed for its forge token, found none, and **two full runs ended without opening the pull request they had done all the work for**, while `iterion secret list` showed the token sitting right there. The error message sends you to fix the store, which is already correct.

## The fix

The resolution block becomes an exported `runview.StampLocalCredentials` — one implementation, still a no-op when the cloud path pre-resolved credentials — and the CLI stamps the context it actually hands to the engine.

## Verification

A probe bot reading `/run/iterion/secrets/<name>` from a **tool** node, against a host store holding the secret:

```
before: available=false  mount_exists=False  hint_exists=False
after:  available=true   mount_exists=True   hint_exists=True
```

- `go test ./pkg/runview ./pkg/cli ./pkg/runtime ./pkg/secrets` → 1541 pass
- The unit test asserts the returned context carries the resolved value, and that a caller with no local store gets its context back untouched (never masking cloud credentials with an empty set).
- The mutation that drops the stamp (`_ = stamped`) turns the end-to-end probe red again.

## Note for review

Other entry points (`resume`, studio launch, the cloud runner) build their executor the same way. Cloud is unaffected — its credentials are already in the context before `BuildExecutor` runs — but `iterion resume` on a local sandboxed run likely needs the same stamping; I did not touch it here because I could not exercise it the way I exercised `run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)