### PR TITLE
feat(bots): product-docs publication tail — skill-driven Onyxia deploy behind deterministic gates

### DIFF
--- a/bots/issue-triage/skills/iterion-bot-catalog.md
+++ b/bots/issue-triage/skills/iterion-bot-catalog.md
@@ -830,7 +830,7 @@ forge and marking it ready is their act, not the bot's.
   developers — and the topology second: docs repo here, N source
   repos there.
 - **Triggers**: product-docs, functional-docs, doc-produit
-- **Vars**: `catalog_path` (string), `clone_depth` (int), `diff_since` (string), `dismissed_path` (string), `editorial_dir` (string), `extra_forbidden_headings` (string), `lint_rules` (string), `max_hints` (int), `max_passes` (int), `mode` (string), `mr_base` (string), `mr_branch` (string), `mr_draft` (bool), `open_mr` (bool), `product_id` (string), `scope_notes` (string), `scratch_dir` (string), `secret_globs` (string), `source_issue_ref` (string), `workspace_dir` (string)
+- **Vars**: `catalog_path` (string), `clone_depth` (int), `diff_since` (string), `dismissed_path` (string), `editorial_dir` (string), `extra_forbidden_headings` (string), `lint_rules` (string), `max_hints` (int), `max_passes` (int), `mode` (string), `mr_base` (string), `mr_branch` (string), `mr_draft` (bool), `open_mr` (bool), `product_id` (string), `publish` (bool), `publish_base_url` (string), `publish_s3_bucket` (string), `publish_s3_prefix` (string), `publish_site` (string), `publish_tools_ref` (string), `scope_notes` (string), `scratch_dir` (string), `secret_globs` (string), `source_issue_ref` (string), `workspace_dir` (string)
 - **Path**: `bots/product-docs/main.bot`
 
 ### `revi-converse` — Revi (converse)

--- a/bots/product-docs/deploy/gitbook_to_mkdocs.py
+++ b/bots/product-docs/deploy/gitbook_to_mkdocs.py
@@ -52,6 +52,7 @@ def convert_page(text, relpath):
     # Step numbering restarts at each {% stepper %}.
     step_no = 0
     pending_step_title = False  # swallow the first heading inside a step as its title
+    step_line_idx = -1  # index in out of the step's admonition line (title promotion target)
 
     def indent():
         return "    " * len(stack)
@@ -89,6 +90,7 @@ def convert_page(text, relpath):
             step_no += 1
             # Title is filled in when the step's first heading is seen.
             out.append(indent() + '!!! abstract "Étape %d"' % step_no)
+            step_line_idx = len(out) - 1
             stack.append(("step", indent()))
             pending_step_title = True
             continue
@@ -130,8 +132,12 @@ def convert_page(text, relpath):
         if pending_step_title:
             h = HEADING_RE.match(line)
             if h:
-                # Promote the step's own heading into the admonition title.
-                out[-1] = out[-1][: out[-1].rindex('"Étape')] + '"Étape %d — %s"' % (step_no, h.group(1).replace('"', "'"))
+                # Promote the step's own heading into the admonition title —
+                # at the REMEMBERED admonition line: a blank line between
+                # {% step %} and its heading has already pushed more lines
+                # onto out, so out[-1] is not the admonition anymore.
+                target = out[step_line_idx]
+                out[step_line_idx] = target[: target.rindex('"Étape')] + '"Étape %d — %s"' % (step_no, h.group(1).replace('"', "'"))
                 pending_step_title = False
                 continue
             if line.strip():

--- a/bots/product-docs/deploy/gitbook_to_mkdocs.py
+++ b/bots/product-docs/deploy/gitbook_to_mkdocs.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Convert a GitBook-flavoured markdown tree into an MkDocs (Material) source.
+
+Input : a GitBook space dir (README.md + SUMMARY.md + pages, {% hint %} /
+        {% stepper %} / {% tabs %} blocks).
+Output: <out>/mkdocs.yml + <out>/docs/** ready for `mkdocs build`.
+
+Fail-closed: any {% ... %} construct this script does not know how to render
+aborts the conversion with the offending file:line, rather than silently
+shipping a page with raw template noise in it.
+"""
+
+import argparse
+import os
+import re
+import shutil
+import sys
+
+HINT_OPEN_RE = re.compile(r'^\s*\{%\s*hint(?:\s+style="([a-z]+)")?\s*%\}\s*$')
+HINT_CLOSE_RE = re.compile(r'^\s*\{%\s*endhint\s*%\}\s*$')
+STEPPER_OPEN_RE = re.compile(r'^\s*\{%\s*stepper\s*%\}\s*$')
+STEPPER_CLOSE_RE = re.compile(r'^\s*\{%\s*endstepper\s*%\}\s*$')
+STEP_OPEN_RE = re.compile(r'^\s*\{%\s*step\s*%\}\s*$')
+STEP_CLOSE_RE = re.compile(r'^\s*\{%\s*endstep\s*%\}\s*$')
+TABS_OPEN_RE = re.compile(r'^\s*\{%\s*tabs\s*%\}\s*$')
+TABS_CLOSE_RE = re.compile(r'^\s*\{%\s*endtabs\s*%\}\s*$')
+TAB_OPEN_RE = re.compile(r'^\s*\{%\s*tab\s+title="([^"]*)"\s*%\}\s*$')
+TAB_CLOSE_RE = re.compile(r'^\s*\{%\s*endtab\s*%\}\s*$')
+EMBED_RE = re.compile(r'^\s*\{%\s*embed\s+url="([^"]+)"\s*%\}\s*$')
+CONTENT_REF_OPEN_RE = re.compile(r'^\s*\{%\s*content-ref\s+url="([^"]+)"\s*%\}\s*$')
+CONTENT_REF_CLOSE_RE = re.compile(r'^\s*\{%\s*endcontent-ref\s*%\}\s*$')
+ANY_TAG_RE = re.compile(r'\{%.*?%\}')
+FENCE_RE = re.compile(r'^\s{0,3}(```|~~~)')
+HEADING_RE = re.compile(r'^\s*#{1,6}\s+(.*\S)\s*$')
+
+# GitBook hint styles → Material admonition types (all four exist natively).
+HINT_STYLES = {"info": "info", "warning": "warning", "danger": "danger", "success": "success"}
+
+
+class ConvertError(Exception):
+    pass
+
+
+def convert_page(text, relpath):
+    out = []
+    in_fence = False
+    fence_marker = None
+    # Stack of ('hint'|'step'|'tab', indent) — content inside is re-indented.
+    stack = []
+    # Step numbering restarts at each {% stepper %}.
+    step_no = 0
+    pending_step_title = False  # swallow the first heading inside a step as its title
+
+    def indent():
+        return "    " * len(stack)
+
+    for lineno, line in enumerate(text.splitlines(), 1):
+        fence = FENCE_RE.match(line)
+        if fence:
+            if not in_fence:
+                in_fence, fence_marker = True, fence.group(1)
+            elif fence.group(1) == fence_marker:
+                in_fence, fence_marker = False, None
+            out.append(indent() + line if stack else line)
+            continue
+        if in_fence:
+            out.append(indent() + line if stack else line)
+            continue
+
+        m = HINT_OPEN_RE.match(line)
+        if m:
+            style = HINT_STYLES.get(m.group(1) or "info", "note")
+            out.append(indent() + "!!! " + style)
+            stack.append(("hint", indent()))
+            continue
+        if HINT_CLOSE_RE.match(line):
+            _pop(stack, "hint", relpath, lineno)
+            continue
+
+        if STEPPER_OPEN_RE.match(line):
+            step_no = 0
+            continue  # pure container — steps carry the structure
+        if STEPPER_CLOSE_RE.match(line):
+            continue
+        m = STEP_OPEN_RE.match(line)
+        if m:
+            step_no += 1
+            # Title is filled in when the step's first heading is seen.
+            out.append(indent() + '!!! abstract "Étape %d"' % step_no)
+            stack.append(("step", indent()))
+            pending_step_title = True
+            continue
+        if STEP_CLOSE_RE.match(line):
+            _pop(stack, "step", relpath, lineno)
+            pending_step_title = False
+            continue
+
+        if TABS_OPEN_RE.match(line):
+            continue  # container — tabs are siblings at the same indent
+        if TABS_CLOSE_RE.match(line):
+            continue
+        m = TAB_OPEN_RE.match(line)
+        if m:
+            out.append(indent() + '=== "%s"' % m.group(1).replace('"', "'"))
+            stack.append(("tab", indent()))
+            continue
+        if TAB_CLOSE_RE.match(line):
+            _pop(stack, "tab", relpath, lineno)
+            continue
+
+        m = EMBED_RE.match(line)
+        if m:
+            out.append(indent() + "<%s>" % m.group(1))
+            continue
+        m = CONTENT_REF_OPEN_RE.match(line)
+        if m:
+            # The inner line repeats the link; the closing tag ends the block.
+            out.append(indent() + "→ [%s](%s)" % (m.group(1), m.group(1)))
+            stack.append(("content-ref", indent()))
+            continue
+        if CONTENT_REF_CLOSE_RE.match(line):
+            _pop(stack, "content-ref", relpath, lineno)
+            continue
+
+        if ANY_TAG_RE.search(line):
+            raise ConvertError("%s:%d: unhandled GitBook construct: %s" % (relpath, lineno, line.strip()))
+
+        if pending_step_title:
+            h = HEADING_RE.match(line)
+            if h:
+                # Promote the step's own heading into the admonition title.
+                out[-1] = out[-1][: out[-1].rindex('"Étape')] + '"Étape %d — %s"' % (step_no, h.group(1).replace('"', "'"))
+                pending_step_title = False
+                continue
+            if line.strip():
+                pending_step_title = False
+
+        if stack and stack[-1][0] == "content-ref":
+            continue  # inner repetition of the link — already rendered
+
+        out.append(indent() + line if (stack and line.strip()) else (line if not stack else ""))
+
+    if stack:
+        raise ConvertError("%s: unclosed %s block at EOF" % (relpath, stack[-1][0]))
+    return "\n".join(out) + "\n"
+
+
+def _pop(stack, kind, relpath, lineno):
+    if not stack or stack[-1][0] != kind:
+        raise ConvertError("%s:%d: end%s without matching open" % (relpath, lineno, kind))
+    stack.pop()
+
+
+SUMMARY_SECTION_RE = re.compile(r'^##\s+(.*\S)\s*$')
+SUMMARY_ITEM_RE = re.compile(r'^(\s*)[*-]\s+\[([^\]]+)\]\(([^)]+)\)\s*$')
+
+
+def build_nav(summary_text, relpath="SUMMARY.md"):
+    """Parse a GitBook SUMMARY.md into an MkDocs nav structure (list of dicts)."""
+    nav = []
+    section_items = None  # items list of the current '## Section'
+    parents = []  # stack of (indent_len, children_list) for nested items
+
+    def target(items, indent_len):
+        while parents and parents[-1][0] >= indent_len:
+            parents.pop()
+        return parents[-1][1] if parents else items
+
+    for lineno, line in enumerate(summary_text.splitlines(), 1):
+        if not line.strip() or line.startswith("# "):
+            continue
+        m = SUMMARY_SECTION_RE.match(line)
+        if m:
+            section_items = []
+            nav.append({m.group(1): section_items})
+            parents = []
+            continue
+        m = SUMMARY_ITEM_RE.match(line)
+        if m:
+            indent_len, title, path = len(m.group(1)), m.group(2), m.group(3)
+            entry = {title: path}
+            items = section_items if section_items is not None else nav
+            dest = target(items, indent_len)
+            dest.append(entry)
+            children = []
+            parents.append((indent_len, children))
+            entry["_children"] = children
+            continue
+        raise ConvertError("%s:%d: unrecognised SUMMARY line: %s" % (relpath, lineno, line.strip()))
+
+    def finalize(entries):
+        result = []
+        for e in entries:
+            (title, path) = next((k, v) for k, v in e.items() if k != "_children")
+            kids = finalize(e.get("_children", []))
+            if kids:
+                result.append({title: [path] + kids})
+            else:
+                result.append({title: path})
+        return result
+
+    out = []
+    for e in nav:
+        if "_children" in e:
+            out.extend(finalize([e]))
+        else:
+            (title, items) = next(iter(e.items()))
+            out.append({title: finalize(items)})
+    return out
+
+
+def dump_yaml(value, level=0):
+    """Minimal YAML emitter for the nav/config structures this script builds."""
+    pad = "  " * level
+    lines = []
+    if isinstance(value, list):
+        for item in value:
+            if isinstance(item, (dict, list)):
+                first, rest = _dump_inline(item, level + 1)
+                lines.append(pad + "- " + first)
+                lines.extend(rest)
+            else:
+                lines.append(pad + "- " + _scalar(item))
+    elif isinstance(value, dict):
+        for k, v in value.items():
+            if isinstance(v, (dict, list)) and v:
+                lines.append(pad + _scalar(k) + ":")
+                lines.extend(dump_yaml(v, level + 1))
+            else:
+                lines.append(pad + _scalar(k) + ": " + _scalar(v))
+    return lines
+
+
+def _dump_inline(item, level):
+    if isinstance(item, dict) and len(item) == 1:
+        (k, v) = next(iter(item.items()))
+        if isinstance(v, (dict, list)):
+            rest = dump_yaml(v, level + 1)
+            return _scalar(k) + ":", rest
+        return _scalar(k) + ": " + _scalar(v), []
+    sub = dump_yaml(item, level)
+    return sub[0].strip(), sub[1:]
+
+
+class Raw(str):
+    """A scalar emitted verbatim (YAML tags like !!python/object/apply)."""
+
+
+def _scalar(v):
+    if isinstance(v, Raw):
+        return str(v)
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    s = str(v)
+    if re.search(r'[:#\[\]{}&*!|>%@`"\']', s) or s != s.strip():
+        return '"' + s.replace('"', '\\"') + '"'
+    return s
+
+
+MD_LINK_RE = re.compile(r'(\[[^\]]*\]\()([^)#\s]+\.md)((?:#[^)]*)?\))')
+
+
+def fix_root_relative_links(docs_dir):
+    """Rewrite page links that only resolve from the space ROOT (a GitBook
+    corpus habit; broken on GitBook too) into correct page-relative links.
+    Returns the number of rewritten links."""
+    fixed = 0
+    for root, _dirs, files in os.walk(docs_dir):
+        for name in files:
+            if not name.endswith(".md"):
+                continue
+            path = os.path.join(root, name)
+            with open(path, encoding="utf-8") as f:
+                text = f.read()
+
+            def repl(m):
+                nonlocal fixed
+                target = m.group(2)
+                if target.startswith(("http://", "https://", "mailto:")):
+                    return m.group(0)
+                if os.path.isfile(os.path.normpath(os.path.join(root, target))):
+                    return m.group(0)
+                from_root = os.path.normpath(os.path.join(docs_dir, target))
+                if os.path.isfile(from_root):
+                    fixed += 1
+                    return m.group(1) + os.path.relpath(from_root, root) + m.group(3)
+                return m.group(0)
+
+            new = MD_LINK_RE.sub(repl, text)
+            if new != text:
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(new)
+    return fixed
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--src", required=True, help="GitBook space dir (holds SUMMARY.md)")
+    ap.add_argument("--out", required=True, help="output dir (docs/ + mkdocs.yml)")
+    ap.add_argument("--site-name", required=True)
+    ap.add_argument("--site-url", default="", help="final public base URL (subpath-aware)")
+    args = ap.parse_args()
+
+    src, out = os.path.abspath(args.src), os.path.abspath(args.out)
+    docs = os.path.join(out, "docs")
+    if os.path.isdir(docs):
+        shutil.rmtree(docs)
+    os.makedirs(docs)
+
+    converted = 0
+    for root, dirs, files in os.walk(src):
+        dirs[:] = [d for d in dirs if not d.startswith(".") or d == ".gitbook"]
+        for name in files:
+            if name.startswith(".") or name == "SUMMARY.md":
+                continue
+            src_path = os.path.join(root, name)
+            rel = os.path.relpath(src_path, src)
+            dst_path = os.path.join(docs, rel)
+            os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+            if name.endswith(".md"):
+                with open(src_path, encoding="utf-8") as f:
+                    text = f.read()
+                with open(dst_path, "w", encoding="utf-8") as f:
+                    f.write(convert_page(text, rel))
+                converted += 1
+            else:
+                shutil.copy2(src_path, dst_path)
+
+    fixed = fix_root_relative_links(docs)
+    if fixed:
+        print("rewrote %d root-relative links" % fixed)
+
+    summary_path = os.path.join(src, "SUMMARY.md")
+    if not os.path.isfile(summary_path):
+        raise ConvertError("SUMMARY.md not found in " + src)
+    with open(summary_path, encoding="utf-8") as f:
+        nav = build_nav(f.read())
+
+    config = {
+        "site_name": args.site_name,
+        "docs_dir": "docs",
+        "theme": {
+            "name": "material",
+            "language": "fr",
+            "features": ["navigation.sections", "navigation.top", "toc.follow", "search.highlight"],
+        },
+        "markdown_extensions": [
+            "admonition",
+            "attr_list",
+            "md_in_html",
+            "tables",
+            {"pymdownx.superfences": {}},
+            {"pymdownx.tabbed": {"alternate_style": True}},
+            # Unicode-preserving slugs so accented anchors (#déclarant) resolve.
+            {"toc": {"permalink": True, "slugify": Raw("!!python/object/apply:pymdownx.slugs.slugify {kwds: {case: lower}}")}},
+        ],
+        "nav": nav,
+    }
+    if args.site_url:
+        config["site_url"] = args.site_url
+
+    with open(os.path.join(out, "mkdocs.yml"), "w", encoding="utf-8") as f:
+        f.write("\n".join(dump_yaml(config)) + "\n")
+
+    print("converted %d pages → %s" % (converted, out))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except ConvertError as e:
+        print("gitbook_to_mkdocs: " + str(e), file=sys.stderr)
+        sys.exit(1)

--- a/bots/product-docs/deploy/gitbook_to_mkdocs.py
+++ b/bots/product-docs/deploy/gitbook_to_mkdocs.py
@@ -33,8 +33,10 @@ ANY_TAG_RE = re.compile(r'\{%.*?%\}')
 FENCE_RE = re.compile(r'^\s{0,3}(```|~~~)')
 HEADING_RE = re.compile(r'^\s*#{1,6}\s+(.*\S)\s*$')
 
-# GitBook hint styles → Material admonition types (all four exist natively).
+# GitBook hint styles → Material admonition types (all four exist natively),
+# with French display titles (the corpus is end-user documentation in French).
 HINT_STYLES = {"info": "info", "warning": "warning", "danger": "danger", "success": "success"}
+HINT_TITLES = {"info": "Info", "warning": "Attention", "danger": "Danger", "success": "Bon à savoir", "note": "Note"}
 
 
 class ConvertError(Exception):
@@ -70,7 +72,7 @@ def convert_page(text, relpath):
         m = HINT_OPEN_RE.match(line)
         if m:
             style = HINT_STYLES.get(m.group(1) or "info", "note")
-            out.append(indent() + "!!! " + style)
+            out.append(indent() + '!!! %s "%s"' % (style, HINT_TITLES[style]))
             stack.append(("hint", indent()))
             continue
         if HINT_CLOSE_RE.match(line):

--- a/bots/product-docs/deploy/onyxia-serve-init.sh
+++ b/bots/product-docs/deploy/onyxia-serve-init.sh
@@ -17,7 +17,8 @@
 # relaunching the service re-injects fresh ones.
 set -u
 
-SITES_BUCKET="${SITES_BUCKET:-devthejo}"
+# The bucket names a deployment, never a person: fail loudly when unset.
+: "${SITES_BUCKET:?SITES_BUCKET is required (the datalab account bucket to mirror from)}"
 SITES_PREFIX="${SITES_PREFIX:-sites}"
 SERVE_PORT="${SERVE_PORT:-5000}"
 SYNC_INTERVAL="${SYNC_INTERVAL:-60}"
@@ -25,7 +26,15 @@ SITES_DIR="${SITES_DIR:-$HOME/sites}"
 
 ENDPOINT_HOST="${AWS_S3_ENDPOINT:-minio.lab.sspcloud.fr}"
 # MC_HOST_* carries the STS session token, which `mc alias set` cannot.
-export MC_HOST_sites="https://${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}:${AWS_SESSION_TOKEN}@${ENDPOINT_HOST}"
+# The value is parsed as a URL: STS secrets are base64-family and can
+# carry '/', '+', '=' or ':' — percent-encode each part or a '/' in the
+# secret silently truncates the authority.
+export MC_HOST_sites="$(python3 - <<'PYENC'
+import os, urllib.parse
+q = lambda v: urllib.parse.quote(os.environ.get(v, ''), safe='')
+print('https://' + q('AWS_ACCESS_KEY_ID') + ':' + q('AWS_SECRET_ACCESS_KEY') + ':' + q('AWS_SESSION_TOKEN') + '@' + os.environ.get('AWS_S3_ENDPOINT', 'minio.lab.sspcloud.fr'))
+PYENC
+)"
 
 # mc ships in the Onyxia images; install it only when absent (plain images).
 if ! command -v mc >/dev/null 2>&1; then

--- a/bots/product-docs/deploy/onyxia-serve-init.sh
+++ b/bots/product-docs/deploy/onyxia-serve-init.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Serve-side companion of the `deploy-onyxia-sspcloud` skill.
+#
+# Runs as the Onyxia personal init script of a long-lived datalab service
+# (any interactive chart works — vscode-python is the tested one). It keeps a
+# local mirror of s3://$SITES_BUCKET/$SITES_PREFIX/ and serves it over HTTP on
+# the chart's user port, so the service's ingress URL publishes every site
+# pushed under that prefix:
+#
+#   s3://<bucket>/<prefix>/<site>/index.html  →  https://<service-url>/<site>/
+#
+# The bot side (the skill) only ever pushes to S3 — it never talks to Onyxia.
+#
+# No secrets in this file: S3 credentials are the AWS_* env vars Onyxia
+# injects into every service. They are STS tokens that expire (~7 days), so
+# the sync loop logs — but keeps serving the last good mirror — once they do;
+# relaunching the service re-injects fresh ones.
+set -u
+
+SITES_BUCKET="${SITES_BUCKET:-devthejo}"
+SITES_PREFIX="${SITES_PREFIX:-sites}"
+SERVE_PORT="${SERVE_PORT:-5000}"
+SYNC_INTERVAL="${SYNC_INTERVAL:-60}"
+SITES_DIR="${SITES_DIR:-$HOME/sites}"
+
+ENDPOINT_HOST="${AWS_S3_ENDPOINT:-minio.lab.sspcloud.fr}"
+# MC_HOST_* carries the STS session token, which `mc alias set` cannot.
+export MC_HOST_sites="https://${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}:${AWS_SESSION_TOKEN}@${ENDPOINT_HOST}"
+
+# mc ships in the Onyxia images; install it only when absent (plain images).
+if ! command -v mc >/dev/null 2>&1; then
+  curl -fsSLo /tmp/mc https://dl.min.io/client/mc/release/linux-amd64/mc
+  chmod +x /tmp/mc
+  mkdir -p "$HOME/.local/bin" && mv /tmp/mc "$HOME/.local/bin/mc"
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+mkdir -p "$SITES_DIR"
+
+# Initial mirror is synchronous so the first HTTP response already has content.
+mc mirror --remove --overwrite --quiet "sites/${SITES_BUCKET}/${SITES_PREFIX}" "$SITES_DIR" \
+  || echo "onyxia-serve: initial mirror failed — serving empty dir" >&2
+
+nohup sh -c "while :; do
+  mc mirror --remove --overwrite --quiet 'sites/${SITES_BUCKET}/${SITES_PREFIX}' '$SITES_DIR' \
+    || echo \"onyxia-serve: sync failed at \$(date -u +%FT%TZ) — credentials expired?\"
+  sleep '${SYNC_INTERVAL}'
+done" >"$HOME/sites-sync.log" 2>&1 &
+
+nohup python3 -m http.server "$SERVE_PORT" --directory "$SITES_DIR" \
+  >"$HOME/sites-http.log" 2>&1 &
+
+echo "onyxia-serve: mirroring s3://${SITES_BUCKET}/${SITES_PREFIX} → ${SITES_DIR}, serving on :${SERVE_PORT}"

--- a/bots/product-docs/main.bot
+++ b/bots/product-docs/main.bot
@@ -23,6 +23,8 @@
 ##     -> page_lint -> gate
 ##   gate --(converged)--> mr_gate -> forge_auth_probe -> finalize_mr
 ##   gate --> scan_hints            (continuation_loop, max_passes)
+##   …every tail outcome -> publish_gate --(publish)--> publish
+##     -> verify_publish -> surface_site_link -> done
 ##
 ##   catalog_ingest — DETERMINISTIC. Parses the product catalog YAML,
 ##                    resolves the product entry, shallow-clones every
@@ -213,6 +215,32 @@ vars:
   mr_base: string = ""
   source_issue_ref: string = ""
 
+  ## ─── Publication (opt-in) ─────────────────────────────────────
+  ## publish=true converts the product docs into a static site
+  ## (GitBook blocks → MkDocs Material), pushes it to the SSP Cloud
+  ## datalab S3 bucket and verifies the public URL served by the
+  ## standing serve service. The platform HOW lives in the
+  ## org-private `deploy-onyxia-sspcloud` skill the publish agent
+  ## loads explicitly — swap deploy target by swapping that skill.
+  publish: bool = false
+
+  ## Base URL of the standing serve service (its user-port ingress),
+  ## e.g. https://user-devthejo-918000-user.user.lab.sspcloud.fr.
+  ## Required when publish=true: publish_gate refuses to enter the
+  ## tail without it.
+  publish_base_url: string = ""
+
+  ## URL path segment of the published site; empty = the product id.
+  publish_site: string = ""
+
+  publish_s3_bucket: string = "devthejo"
+  publish_s3_prefix: string = "sites"
+
+  ## Pinned ref of SocialGouv/iterion the publish agent fetches the
+  ## GitBook→MkDocs converter from (raw URL). Pin a tag/SHA once the
+  ## publish tail has landed on main.
+  publish_tools_ref: string = "feat/product-docs-publish"
+
 secrets:
   ## Forge access: cloning the SOURCE repositories (private ones need
   ## it), pushing the docs branch, opening the PR, back-linking the
@@ -221,6 +249,22 @@ secrets:
   ## prompt, or the run's events. optional:true so a public-source /
   ## host-authenticated setup works unchanged.
   forge_token:
+    as: file
+    optional: true
+
+  ## SSP Cloud datalab S3 (Onyxia STS) — the publish tail's push
+  ## credentials, one value per file (see the deploy-onyxia-sspcloud
+  ## skill). optional:true so every non-publishing run works
+  ## unchanged; publish_gate routes the tail out cleanly when they
+  ## are absent. They are STS tokens with a ~7-day expiry — the
+  ## publish agent reports expiry per the skill instead of retrying.
+  onyxia_s3_access_key:
+    as: file
+    optional: true
+  onyxia_s3_secret_key:
+    as: file
+    optional: true
+  onyxia_s3_session_token:
     as: file
     optional: true
 
@@ -613,6 +657,59 @@ prompt finalize_mr_user:
   back-link when a source issue is given, and return the structured
   result.
 
+## ─── Publication prompts (opt-in) ───────────────────────────────
+
+prompt publish_system:
+  You are the PUBLISH phase of a functional-documentation bot. The
+  docs corpus in this workspace has already been written, gated and
+  committed — your only job is to turn it into a static site and put
+  it live, then report the URL.
+
+  The PLATFORM playbook — where to push, with which credentials, how
+  to verify — is the `deploy-onyxia-sspcloud` skill in
+  .claude/skills/. Read it FIRST and follow it exactly: every
+  constraint in it was paid for.
+
+  Hard rules:
+  - Secrets are used BY REFERENCE only (command substitution from
+    their mounted files, per the skill). Never cat/echo/print a
+    secret value, never place one on a command line.
+  - Do NOT modify the documentation tree, the git state, or anything
+    outside your scratch build directory. You build and you push to
+    object storage; nothing else.
+  - Fail honestly: if a step cannot succeed (missing tool, expired
+    credentials, unreachable endpoint), stop, set deployed=false and
+    say exactly what failed and what the operator should do. Never
+    fabricate a URL and never report success you did not verify.
+
+prompt publish_user:
+  Product: {{input.product_id}}
+  Docs tree (GitBook-flavoured markdown): {{input.product_dir}}
+  Site slug: {{input.site}} (empty means: use the product id)
+  Serve-service base URL: {{input.base_url}}
+  S3 bucket/prefix: {{input.s3_bucket}}/{{input.s3_prefix}}
+
+  Step 1 — BUILD the static site in a scratch dir OUTSIDE the docs
+  tree (e.g. /tmp/iterion-scratch/publish):
+  - Fetch the converter (pinned ref {{input.tools_ref}}):
+    https://raw.githubusercontent.com/SocialGouv/iterion/{{input.tools_ref}}/bots/product-docs/deploy/gitbook_to_mkdocs.py
+  - python3 -m venv + pip install 'mkdocs-material' 'mkdocs>=1.6,<2'
+  - Run the converter: --src {{input.product_dir}} --out <scratch>
+    --site-name from the docs README title (fallback: the product
+    id), --site-url {{input.base_url}}/<site>/
+  - mkdocs build from <scratch> (config the converter generated).
+    A converter or build FAILURE is a stop-and-report, not something
+    to patch around: the converter fails closed on constructs it
+    does not know, and that is a finding to surface.
+
+  Step 2 — DEPLOY the built site and VERIFY the live URL, exactly as
+  the deploy-onyxia-sspcloud skill prescribes (tooling, bucket
+  guard, mirror, poll, content check).
+
+  Return JSON: {"deployed": bool, "url": "<live url or empty>",
+  "summary": "<what was built and pushed, page count, or the honest
+  failure and its remedy>"}
+
 ## ─── Schemas ────────────────────────────────────────────────────
 
 ## catalog_ingest output — the resolved product + the source
@@ -767,6 +864,40 @@ schema finalize_mr_output:
   summary: string
 
 schema surface_pr_link_input:
+  url: string
+
+## ─── Publication schemas (opt-in) ───────────────────────────────
+
+## publish_gate output — deterministic "can we publish?" so the
+## publish agent is only ever entered when the var opt-in, the serve
+## base URL and all three S3 secrets are actually present.
+schema publish_gate_output:
+  do_publish: bool
+  reason: string
+
+schema publish_input:
+  product_id: string
+  product_dir: string
+  site: string
+  base_url: string
+  s3_bucket: string
+  s3_prefix: string
+  tools_ref: string
+
+schema publish_output:
+  deployed: bool
+  url: string
+  summary: string
+
+schema verify_publish_input:
+  url: string
+
+schema verify_publish_output:
+  verified: bool
+  url: string
+  detail: string
+
+schema surface_site_link_input:
   url: string
 
 ## ─── Nodes ──────────────────────────────────────────────────────
@@ -1719,6 +1850,88 @@ if u:
     print('[iterion] preview_url=' + u + ' kind=pr scope=external')
 "`
 
+## ─── Nodes : publication tail (opt-in) ──────────────────────────
+
+## publish_gate — DETERMINISTIC pre-flight for the publish tail.
+## publish is an LLM agent; entering it with no opt-in, no serve URL
+## or no S3 credentials burns a turn to rediscover in shell what a
+## 10-line probe already knows. Read-only, idempotent.
+tool publish_gate:
+  command: `PUB={{vars.publish}} BASE={{vars.publish_base_url}} python3 -c "
+import os, json
+pub = (os.environ.get('PUB') or '').strip().lower() in ('1', 'true', 'yes')
+base = (os.environ.get('BASE') or '').strip()
+names = ['onyxia_s3_access_key', 'onyxia_s3_secret_key', 'onyxia_s3_session_token']
+missing = [n for n in names if not os.path.isfile('/run/iterion/secrets/' + n)]
+ok = pub and bool(base) and not missing
+if not pub:
+    reason = 'publish disabled (vars.publish=false)'
+elif not base:
+    reason = 'publish_base_url is empty'
+elif missing:
+    reason = 'missing S3 secrets: ' + ', '.join(missing)
+else:
+    reason = 'ready'
+print(json.dumps({'do_publish': ok, 'reason': reason}))
+"`
+  output: publish_gate_output
+
+agent publish:
+  backend: "claude_code"
+  model: "${ITERION_PRODUCT_DOCS_MODEL_CLAUDE:-claude-opus-5}"
+  reasoning_effort: "${ITERION_PRODUCT_DOCS_PUBLISH_EFFORT:-medium}"
+  skills: ["deploy-onyxia-sspcloud"]
+  input: publish_input
+  output: publish_output
+  system: publish_system
+  user: publish_user
+  tools: [bash, read_file, glob, grep]
+  tool_max_steps: 40
+
+## verify_publish — DETERMINISTIC truth gate on the live URL. The
+## agent's own verification is necessary but not sufficient: this
+## node re-checks from outside the agent's narrative and FAILS the
+## run when the site is not actually serving. Polls ≤ 2 min for the
+## serve loop (60 s sync) to pick the push up.
+tool verify_publish:
+  input: verify_publish_input
+  command: `URL={{input.url}} python3 -c "
+import json, os, time, urllib.request
+u = (os.environ.get('URL') or '').strip()
+if not u:
+    print(json.dumps({'verified': False, 'url': '', 'detail': 'publish agent returned no URL'}))
+    raise SystemExit(1)
+if not u.endswith('/'):
+    u = u + '/'
+code, body = 0, ''
+for i in range(12):
+    try:
+        r = urllib.request.urlopen(u, timeout=10)
+        code = r.getcode()
+        body = r.read(65536).decode('utf-8', 'replace')
+    except Exception:
+        code, body = 0, ''
+    if code == 200 and '<title>' in body:
+        break
+    time.sleep(10)
+if code != 200 or '<title>' not in body:
+    print(json.dumps({'verified': False, 'url': u, 'detail': 'http ' + str(code) + ' after 12 tries'}))
+    raise SystemExit(1)
+print(json.dumps({'verified': True, 'url': u, 'detail': 'http 200, title present'}))
+"`
+  output: verify_publish_output
+
+## surface_site_link — DETERMINISTIC result-link emitter, the
+## published site counterpart of surface_pr_link.
+tool surface_site_link:
+  input: surface_site_link_input
+  command: `URL={{input.url}} python3 -c "
+import os
+u = (os.environ.get('URL') or '').strip()
+if u:
+    print('[iterion] preview_url=' + u + ' kind=site scope=external')
+"`
+
 ## ─── Workflow ───────────────────────────────────────────────────
 
 workflow product_docs:
@@ -1818,7 +2031,7 @@ workflow product_docs:
   ## finalize_mr refuses an empty PR and reports drift_remaining +
   ## unread_sources honestly in the body.
   mr_gate -> forge_auth_probe when open_mr
-  mr_gate -> done when not open_mr
+  mr_gate -> publish_gate when not open_mr
 
   forge_auth_probe -> finalize_mr when available with {
     workspace_dir:    "{{vars.workspace_dir}}",
@@ -1832,9 +2045,29 @@ workflow product_docs:
     drift_remaining:  "{{outputs.campaign.drift_remaining}}",
     unread_sources:   "{{outputs.campaign.unread_sources}}"
   }
-  forge_auth_probe -> done when not available
+  forge_auth_probe -> publish_gate when not available
   ## PR opened → surface its URL as a headline result-link in the run
-  ## summary, then finish. Nothing opened → straight to done.
+  ## summary. Every PR-tail outcome then flows into the publication
+  ## tail, which decides for itself (publish_gate) whether to run.
   finalize_mr -> surface_pr_link when opened with { url: "{{outputs.finalize_mr.url}}" }
-  finalize_mr -> done when not opened
-  surface_pr_link -> done
+  finalize_mr -> publish_gate when not opened
+  surface_pr_link -> publish_gate
+
+  ## ── Publication tail (opt-in) ───────────────────────────────────
+  ## Deterministic gate → skill-driven publish agent → deterministic
+  ## URL truth gate. verify_publish FAILS the run when the site is
+  ## not serving: a publish that was asked for either goes live or
+  ## fails loudly — never a façade.
+  publish_gate -> publish when do_publish with {
+    product_id: "{{outputs.catalog_ingest.product_id}}",
+    product_dir: "{{outputs.catalog_ingest.product_dir}}",
+    site: "{{vars.publish_site}}",
+    base_url: "{{vars.publish_base_url}}",
+    s3_bucket: "{{vars.publish_s3_bucket}}",
+    s3_prefix: "{{vars.publish_s3_prefix}}",
+    tools_ref: "{{vars.publish_tools_ref}}"
+  }
+  publish_gate -> done when not do_publish
+  publish -> verify_publish with { url: "{{outputs.publish.url}}" }
+  verify_publish -> surface_site_link with { url: "{{outputs.verify_publish.url}}" }
+  surface_site_link -> done

--- a/bots/product-docs/main.bot
+++ b/bots/product-docs/main.bot
@@ -233,13 +233,16 @@ vars:
   ## URL path segment of the published site; empty = the product id.
   publish_site: string = ""
 
-  publish_s3_bucket: string = "devthejo"
+  ## The target bucket names a deployment, never a person: no default.
+  ## publish_gate refuses the tail when it is empty.
+  publish_s3_bucket: string = ""
   publish_s3_prefix: string = "sites"
 
-  ## Pinned ref of SocialGouv/iterion the publish agent fetches the
-  ## GitBook→MkDocs converter from (raw URL). Pin a tag/SHA once the
-  ## publish tail has landed on main.
-  publish_tools_ref: string = "feat/product-docs-publish"
+  ## Ref of SocialGouv/iterion the publish agent fetches the
+  ## GitBook→MkDocs converter from (raw URL). Defaults to main (where
+  ## the converter lives once this bundle is merged); pin a tag/SHA for
+  ## reproducible deployments.
+  publish_tools_ref: string = "main"
 
 secrets:
   ## Forge access: cloning the SOURCE repositories (private ones need
@@ -891,6 +894,7 @@ schema publish_output:
 
 schema verify_publish_input:
   url: string
+  base_url: string
 
 schema verify_publish_output:
   verified: bool
@@ -1857,17 +1861,24 @@ if u:
 ## or no S3 credentials burns a turn to rediscover in shell what a
 ## 10-line probe already knows. Read-only, idempotent.
 tool publish_gate:
-  command: `PUB={{vars.publish}} BASE={{vars.publish_base_url}} python3 -c "
+  ## Secret paths come from the TEMPLATE ({{secrets.X.path}}), which the
+  ## engine resolves for sandboxed AND host runs alike — a hardcoded
+  ## /run/iterion/secrets/ only exists under the sandbox bind-mount and
+  ## silently disabled publishing everywhere else.
+  command: `PUB={{vars.publish}} BASE={{vars.publish_base_url}} BUCKET={{vars.publish_s3_bucket}} SEC_A={{secrets.onyxia_s3_access_key.path}} SEC_B={{secrets.onyxia_s3_secret_key.path}} SEC_C={{secrets.onyxia_s3_session_token.path}} python3 -c "
 import os, json
 pub = (os.environ.get('PUB') or '').strip().lower() in ('1', 'true', 'yes')
 base = (os.environ.get('BASE') or '').strip()
-names = ['onyxia_s3_access_key', 'onyxia_s3_secret_key', 'onyxia_s3_session_token']
-missing = [n for n in names if not os.path.isfile('/run/iterion/secrets/' + n)]
-ok = pub and bool(base) and not missing
+bucket = (os.environ.get('BUCKET') or '').strip()
+paths = {'onyxia_s3_access_key': os.environ.get('SEC_A') or '', 'onyxia_s3_secret_key': os.environ.get('SEC_B') or '', 'onyxia_s3_session_token': os.environ.get('SEC_C') or ''}
+missing = [n for n, p in paths.items() if not (p and os.path.isfile(p))]
+ok = pub and bool(base) and bool(bucket) and not missing
 if not pub:
     reason = 'publish disabled (vars.publish=false)'
 elif not base:
     reason = 'publish_base_url is empty'
+elif not bucket:
+    reason = 'publish_s3_bucket is empty -- name the target bucket, there is no default'
 elif missing:
     reason = 'missing S3 secrets: ' + ', '.join(missing)
 else:
@@ -1895,14 +1906,20 @@ agent publish:
 ## serve loop (60 s sync) to pick the push up.
 tool verify_publish:
   input: verify_publish_input
-  command: `URL={{input.url}} python3 -c "
+  command: `URL={{input.url}} BASE={{input.base_url}} python3 -c "
 import json, os, time, urllib.request
 u = (os.environ.get('URL') or '').strip()
+base = (os.environ.get('BASE') or '').strip().rstrip('/')
 if not u:
     print(json.dumps({'verified': False, 'url': '', 'detail': 'publish agent returned no URL'}))
     raise SystemExit(1)
 if not u.endswith('/'):
     u = u + '/'
+## The truth gate verifies THE OPERATOR'S deployment, not whatever URL
+## the agent narrated: any live page would answer 200 with a title.
+if not base or not u.startswith(base + '/'):
+    print(json.dumps({'verified': False, 'url': u, 'detail': 'returned url is not under publish_base_url (' + (base or '<empty>') + ')'}))
+    raise SystemExit(1)
 code, body = 0, ''
 for i in range(12):
     try:
@@ -2068,6 +2085,12 @@ workflow product_docs:
     tools_ref: "{{vars.publish_tools_ref}}"
   }
   publish_gate -> done when not do_publish
-  publish -> verify_publish with { url: "{{outputs.publish.url}}" }
+  ## Unconditional fallback: edge selection SKIPS a conditional edge
+  ## whose field is absent from the output (an errored tool body yields
+  ## an output without do_publish), and a node with only conditional
+  ## edges then dead-ends the run with NO_OUTGOING_EDGE. The fallback
+  ## makes the safe route structural: no publish signal → done.
+  publish_gate -> done
+  publish -> verify_publish with { url: "{{outputs.publish.url}}", base_url: "{{vars.publish_base_url}}" }
   verify_publish -> surface_site_link with { url: "{{outputs.verify_publish.url}}" }
   surface_site_link -> done

--- a/bots/product_docs_gates_test.go
+++ b/bots/product_docs_gates_test.go
@@ -2,6 +2,8 @@ package bots
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1580,5 +1582,119 @@ func TestProductDocsSourceStampRecordsFullSHA(t *testing.T) {
 	parts := strings.SplitN(got.Stamp, "@", 2)
 	if len(parts) != 2 || len(parts[1]) != 40 {
 		t.Fatalf("sources_stamp %q does not record a full 40-char sha — the shallow-delta repair cannot fetch it", got.Stamp)
+	}
+}
+
+// TestProductDocsPublishGate pins the publish tail's deterministic
+// pre-flight, executing the real node body: the tail opens only on the
+// explicit opt-in + a serve base URL + a named bucket + all three S3
+// secrets present at their TEMPLATE-resolved paths (host and sandbox
+// runs resolve differently; a hardcoded mount path silently disabled
+// publishing on host runs).
+func TestProductDocsPublishGate(t *testing.T) {
+	requireGitPython(t)
+	command := toolCommand(t, "product-docs/main.bot", "publish_gate")
+
+	secretsDir := t.TempDir()
+	paths := map[string]string{}
+	for _, n := range []string{"onyxia_s3_access_key", "onyxia_s3_secret_key", "onyxia_s3_session_token"} {
+		p := filepath.Join(secretsDir, n)
+		if err := os.WriteFile(p, []byte("v"), 0o600); err != nil {
+			t.Fatalf("write secret fixture: %v", err)
+		}
+		paths[n] = p
+	}
+	run := func(t *testing.T, publish, base, bucket, missing string) publishGateOut {
+		t.Helper()
+		refs := map[string]string{
+			"vars.publish":                         publish,
+			"vars.publish_base_url":                base,
+			"vars.publish_s3_bucket":               bucket,
+			"secrets.onyxia_s3_access_key.path":    paths["onyxia_s3_access_key"],
+			"secrets.onyxia_s3_secret_key.path":    paths["onyxia_s3_secret_key"],
+			"secrets.onyxia_s3_session_token.path": paths["onyxia_s3_session_token"],
+		}
+		if missing != "" {
+			refs["secrets."+missing+".path"] = filepath.Join(secretsDir, "absent")
+		}
+		var got publishGateOut
+		runJSON(t, resolveCommand(t, command, refs), &got)
+		return got
+	}
+
+	if got := run(t, "true", "https://serve.example", "demo-bucket", ""); !got.DoPublish || got.Reason != "ready" {
+		t.Fatalf("all preconditions met yet the gate refused: %+v", got)
+	}
+	if got := run(t, "false", "https://serve.example", "demo-bucket", ""); got.DoPublish || !strings.Contains(got.Reason, "disabled") {
+		t.Fatalf("publish=false must route the tail out with its reason: %+v", got)
+	}
+	if got := run(t, "true", "https://serve.example", "", ""); got.DoPublish || !strings.Contains(got.Reason, "bucket") {
+		t.Fatalf("an empty bucket must refuse the tail (no personal default): %+v", got)
+	}
+	if got := run(t, "true", "https://serve.example", "demo-bucket", "onyxia_s3_secret_key"); got.DoPublish || !strings.Contains(got.Reason, "onyxia_s3_secret_key") {
+		t.Fatalf("a missing secret must be named in the refusal: %+v", got)
+	}
+}
+
+type publishGateOut struct {
+	DoPublish bool   `json:"do_publish"`
+	Reason    string `json:"reason"`
+}
+
+// TestProductDocsVerifyPublish pins the external truth gate: it verifies
+// THE OPERATOR'S deployment — a 200 with a title under publish_base_url —
+// never whatever live URL the agent happened to narrate.
+func TestProductDocsVerifyPublish(t *testing.T) {
+	requireGitPython(t)
+	command := toolCommand(t, "product-docs/main.bot", "verify_publish")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/site/" {
+			_, _ = w.Write([]byte("<html><head><title>Demo</title></head></html>"))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	var got verifyPublishOut
+	runJSON(t, resolveCommand(t, command, map[string]string{
+		"input.url":      srv.URL + "/site/",
+		"input.base_url": srv.URL,
+	}), &got)
+	if !got.Verified {
+		t.Fatalf("a live page under the base was not verified: %+v", got)
+	}
+
+	runExpectingFailure(t, resolveCommand(t, command, map[string]string{
+		"input.url":      srv.URL + "/site/",
+		"input.base_url": "https://elsewhere.example",
+	}), "not under publish_base_url")
+}
+
+type verifyPublishOut struct {
+	Verified bool   `json:"verified"`
+	URL      string `json:"url"`
+	Detail   string `json:"detail"`
+}
+
+// TestGitbookToMkdocsBlankLineStep pins the converter against the crash
+// Revi reproduced: a blank line between {% step %} and its heading made
+// the title promotion index into the wrong output line (ValueError).
+func TestGitbookToMkdocsBlankLineStep(t *testing.T) {
+	requireGitPython(t)
+	script := filepath.Join("product-docs", "deploy", "gitbook_to_mkdocs.py")
+	py := `
+import importlib.util
+spec = importlib.util.spec_from_file_location('g', '` + script + `')
+g = importlib.util.module_from_spec(spec); spec.loader.exec_module(g)
+out = g.convert_page('# P\n\n{% stepper %}\n{% step %}\n\n### Titre\ncontenu\n{% endstep %}\n{% endstepper %}\n', 't.md')
+assert 'Étape 1 — Titre' in out, out
+print('ok')
+`
+	cmd := exec.Command("python3", "-c", py)
+	out, err := cmd.CombinedOutput()
+	if err != nil || !strings.Contains(string(out), "ok") {
+		t.Fatalf("converter crashed on blank-line step: %v\n%s", err, out)
 	}
 }

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -1073,7 +1073,7 @@ forge and marking it ready is their act, not the bot's.
   developers — and the topology second: docs repo here, N source
   repos there.
 - **Triggers**: product-docs, functional-docs, doc-produit
-- **Vars**: `catalog_path` (string), `clone_depth` (int), `diff_since` (string), `dismissed_path` (string), `editorial_dir` (string), `extra_forbidden_headings` (string), `lint_rules` (string), `max_hints` (int), `max_passes` (int), `mode` (string), `mr_base` (string), `mr_branch` (string), `mr_draft` (bool), `open_mr` (bool), `product_id` (string), `scope_notes` (string), `scratch_dir` (string), `secret_globs` (string), `source_issue_ref` (string), `workspace_dir` (string)
+- **Vars**: `catalog_path` (string), `clone_depth` (int), `diff_since` (string), `dismissed_path` (string), `editorial_dir` (string), `extra_forbidden_headings` (string), `lint_rules` (string), `max_hints` (int), `max_passes` (int), `mode` (string), `mr_base` (string), `mr_branch` (string), `mr_draft` (bool), `open_mr` (bool), `product_id` (string), `publish` (bool), `publish_base_url` (string), `publish_s3_bucket` (string), `publish_s3_prefix` (string), `publish_site` (string), `publish_tools_ref` (string), `scope_notes` (string), `scratch_dir` (string), `secret_globs` (string), `source_issue_ref` (string), `workspace_dir` (string)
 - **Path**: `bots/product-docs/main.bot`
 
 ### `revi-converse` — Revi (converse)


### PR DESCRIPTION
Stacked on #524. Adds the opt-in publication tail to Prody:

```
…every PR-tail outcome → publish_gate → publish → verify_publish → surface_site_link → done
```

- **publish_gate** (deterministic pre-flight): opt-in var + serve base URL + the three Onyxia S3 file secrets present, else the tail routes out with a reason.
- **publish** (agent): loads the org-private `deploy-onyxia-sspcloud` skill **explicitly** (ADR-059 `skills:` ref; shipped to cloud runners via the ADR-079 team plugin-source). Builds the static site — `deploy/gitbook_to_mkdocs.py`, GitBook blocks → MkDocs Material (hints → admonitions with French titles, steppers → numbered steps, tabs → content tabs, SUMMARY → nav, unicode slugs, root-relative link remediation, fail-closed on unknown constructs) — then pushes to the datalab's **private** S3 per the skill.
- **verify_publish** (deterministic truth gate): re-checks the live URL from OUTSIDE the agent's narrative, polls ≤2 min for the serve loop, **fails the run** when the site is not serving.
- **serve side**: `deploy/onyxia-serve-init.sh`, the standing datalab service's personal-init companion (mirror s3://…/sites/ every 60 s + HTTP on the user port). No secrets in it — Onyxia injects the AWS_* env.

Exercised end to end on the Sirena corpus (run 01a03ed3, 2026-08-26): `publish_gate ready → deployed:true → verify_publish http 200` — live at https://user-devthejo-918000-user.user.lab.sspcloud.fr/sirena/

Draft until #524 lands (then retarget to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)