### PR TITLE
fix(models): report cloud run reachability, not control-plane env

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -2,7 +2,7 @@
 
 Two questions this answers, both of which used to have no answer at all:
 
-1. **Which models can I actually use on this host?** — `iterion models`,
+1. **Which models can I actually use for a run from here?** — `iterion models`,
    `GET /api/models`, and the studio's model pickers, all off one code path.
 2. **Which model does the studio assistant run on, and how do I change it?**
    — the model picker on the session launcher / header, persisted per user.
@@ -19,7 +19,8 @@ A model entry crosses four sources that already existed separately:
 |---|---|
 | `model.KnownModelSpecs` | which specs the catalog ENUMERATES (curated list) |
 | the models.dev aggregator | fresher capabilities/prices for those specs |
-| [`pkg/backend/detect`](../pkg/backend/detect/detect.go) | what THIS host holds credentials for |
+| [`pkg/backend/detect`](../pkg/backend/detect/detect.go) | local: what THIS host holds credentials for |
+| tenant launch tiers (BYOK, OAuth-forfait, platform) | cloud: what a *run for this tenant* will receive |
 | `llmtypes.ModelCapabilities` | context window, tool-calling, reasoning, temperature |
 | [`pkg/backend/cost`](../pkg/backend/cost/cost.go) `EffectiveRate` | what a run is actually charged |
 
@@ -36,7 +37,10 @@ unreachable.
 
 [`pkg/modelcatalog`](../pkg/modelcatalog/catalog.go) is the crossing, and is
 the single code path behind both the CLI and the HTTP endpoint — the two
-cannot disagree about whether a model is reachable.
+cannot disagree about whether a model is reachable. In cloud the HTTP
+endpoint no longer feeds it the control-plane `detect.Report`: that is the
+host the *server* process sees, not the bundle `cloudpublisher` seals for
+the runner.
 
 ### From the CLI
 
@@ -70,6 +74,22 @@ launch form asks about a bot whose nodes pin models outside the curated set.
 
 Only capability values and credential **source names** (`ANTHROPIC_API_KEY`)
 cross the wire — never a credential value.
+
+Each row carries `reachability`:
+
+| value | meaning | picker |
+|---|---|---|
+| `local` | proven from the host process (CLI / local studio) | blocking if `usable=false` |
+| `cloud` | proven from the authenticated tenant's launch tiers (BYOK, user/org OAuth-forfait, platform) | listed as available for this team's runs |
+| `unknown` | cloud, but no launch-tier proof — a pool grant or runner-env fallback *may* still serve | warning, **not** a blocking "unreachable" |
+
+Cloud **never** treats a control-plane env key as tenant reachability, and
+**never** treats a tenant BYOK/OAuth that the server process lacks as
+unreachable. The pool is not probed (proving it would acquire a grant), so
+those models stay `unknown` rather than a false yes or a false no.
+
+The catalog envelope also stamps `reachability: "local"|"cloud"` for the
+surface that was evaluated.
 
 ### Two mappings that are easy to get wrong
 
@@ -119,7 +139,8 @@ letting it be discovered mid-run:
 
 | condition | level | why |
 |---|---|---|
-| no credential can reach the model | blocking | the run fails at its first node |
+| no credential can reach the model (`reachability` local or cloud) | blocking | the run fails at its first node |
+| cloud reachability is `unknown` | warning | launch-tier proof is missing; a pool grant or runner fallback may still serve |
 | the model has no tool-calling | blocking | the agent loses the board, skills and run introspection — broken, not degraded |
 | `ultracode` on anything but `claude-opus-4-8` | warning | it degrades silently to plain `xhigh` (diagnostic C089, [docs/ultracode.md](ultracode.md)) |
 

--- a/openapi.json
+++ b/openapi.json
@@ -121,6 +121,9 @@
             },
             "type": "array"
           },
+          "reachability": {
+            "type": "string"
+          },
           "recommended_spec": {
             "type": "string"
           },
@@ -549,6 +552,9 @@
           "provider": {
             "type": "string"
           },
+          "reachability": {
+            "type": "string"
+          },
           "reasoning": {
             "type": "boolean"
           },
@@ -589,7 +595,8 @@
           "temperature",
           "ultracode_capable",
           "price_known",
-          "usable"
+          "usable",
+          "reachability"
         ],
         "type": "object"
       },

--- a/pkg/cli/models.go
+++ b/pkg/cli/models.go
@@ -95,6 +95,9 @@ func RunModels(ctx context.Context, opts ModelsOptions, p *Printer) error {
 // formatUsable renders reachability compactly: the backends that can drive the
 // model, or "no" when none can.
 func formatUsable(m modelcatalog.Entry) string {
+	if m.Reachability == modelcatalog.ReachabilityUnknown {
+		return "unknown"
+	}
 	if !m.Usable {
 		return "no"
 	}

--- a/pkg/modelcatalog/catalog.go
+++ b/pkg/modelcatalog/catalog.go
@@ -68,11 +68,19 @@ type Entry struct {
 	// a bare zero cannot.
 	PriceKnown bool `json:"price_known"`
 
-	// Usable is true when at least one detected backend can drive this spec
-	// with the credentials present on this host right now.
+	// Usable is true when at least one backend can drive this spec with the
+	// credentials the *run* would receive. Local studio evaluates the host
+	// process; cloud evaluates the tenant launch tiers. Unknown reachability
+	// stays false — the picker must not treat that as a hard "unreachable".
 	Usable bool `json:"usable"`
 	// UnusableReason explains a false Usable in operator language.
 	UnusableReason string `json:"unusable_reason,omitempty"`
+	// Reachability is how Usable was decided:
+	//   "local"   — host-process detect.Report (CLI / local studio)
+	//   "cloud"   — tenant launch tiers proved a credential the run will get
+	//   "unknown" — cloud, but no launch-tier proof (pool / runner env may
+	//               still serve). Never a blocking "unreachable".
+	Reachability string `json:"reachability"`
 	// Backends lists the detected backends that can drive this spec, in
 	// preference order. Empty when Usable is false.
 	Backends []string `json:"backends,omitempty"`
@@ -106,6 +114,10 @@ type Catalog struct {
 	// node's DSL default at once, and one bot pinning a malformed `model:`
 	// must not blank out the whole catalog for every other model on the host.
 	InvalidSpecs []InvalidSpec `json:"invalid_specs,omitempty"`
+	// Reachability is the credential surface this catalog evaluated:
+	// "local" (host process) or "cloud" (tenant launch tiers). Per-entry
+	// Reachability may be "unknown" when a cloud row could not be proven.
+	Reachability string `json:"reachability,omitempty"`
 }
 
 // InvalidSpec is one caller-supplied hint the catalog could not resolve.
@@ -128,16 +140,40 @@ type Options struct {
 	ExtraSpecs []string
 	// Refresh force-refetches the model-spec aggregator cache first.
 	Refresh bool
-	// Report is the host credential snapshot. When nil, Build calls
+	// Report is the credential snapshot. When nil, Build calls
 	// detect.Detect itself — pass a cached report on hot paths.
+	// Cloud callers must pass a report derived from the tenant launch
+	// surface (ReportFromCloudPresence), never the control-plane host.
 	Report *detect.Report
+	// Reachability stamped on the catalog and on proven entries. Empty
+	// defaults to ReachabilityLocal.
+	Reachability string
+	// UnprovenIsUnknown, when true, stamps a model the Report cannot
+	// drive as reachability "unknown" instead of a proven-unusable host
+	// gap. Cloud uses this: a missing launch-tier credential is not the
+	// same as "this host has no key" — the pool or runner env may still
+	// serve, and a control-plane env key must never fill the gap.
+	UnprovenIsUnknown bool
 }
+
+// Reachability values on Catalog / Entry. Keep these strings stable: the
+// studio picker and OpenAPI client key off them.
+const (
+	ReachabilityLocal   = "local"
+	ReachabilityCloud   = "cloud"
+	ReachabilityUnknown = "unknown"
+)
 
 // Build resolves the catalog. It returns an error only when a caller-supplied
 // spec is malformed; every other degradation (offline aggregator, no
 // credentials) is reported in the result rather than raised.
 func Build(ctx context.Context, opts Options) (Catalog, error) {
 	var cat Catalog
+	scope := opts.Reachability
+	if scope == "" {
+		scope = ReachabilityLocal
+	}
+	cat.Reachability = scope
 
 	if opts.Refresh {
 		cat.Refreshed = true
@@ -229,6 +265,14 @@ func Build(ctx context.Context, opts Options) (Catalog, error) {
 		}
 		e.Backends, e.CredentialSource, e.UnusableReason = availability(*report, e.Provider, e.Model, e.CredentialProvider)
 		e.Usable = len(e.Backends) > 0
+		e.Reachability = scope
+		if opts.UnprovenIsUnknown && !e.Usable {
+			e.Reachability = ReachabilityUnknown
+			// Drop the host-probe phrasing ("no credential detected for
+			// provider X on this host") — that sentence is the defect:
+			// cloud absence is unproven, not a local gap.
+			e.UnusableReason = unknownCloudReason
+		}
 		cat.Models = append(cat.Models, e)
 	}
 

--- a/pkg/modelcatalog/cloud.go
+++ b/pkg/modelcatalog/cloud.go
@@ -1,0 +1,170 @@
+package modelcatalog
+
+import (
+	"github.com/SocialGouv/iterion/pkg/backend/detect"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+// unknownCloudReason is the operator-facing explanation for a model the
+// cloud launch tiers did not prove. It must never read as "this host has
+// no credential" — that sentence is what made the picker lie when the
+// control-plane env and the run bundle disagreed.
+const unknownCloudReason = "cloud run credentials are not proven for this model — a pool grant or runner fallback may still serve it"
+
+// CloudPresence is the launch-tier credential surface for one tenant:
+// which providers and OAuth kinds a cloud run would receive. Names and
+// kinds only — never a credential value.
+//
+// Tiers match cloudpublisher.resolveAndSealCredentials (BYOK, user/org
+// OAuth, platform). The mutualised pool is deliberately absent: a grant
+// is opportunistic and cannot be proven without acquiring one.
+type CloudPresence struct {
+	// ProviderSources maps a detect provider name ("anthropic", "openai",
+	// "foundry", …) to the credential *source label* the catalog may
+	// echo (an env-var name, never a secret).
+	ProviderSources map[string]string
+	// ClaudeCodeOAuth is true when a claude_code forfait blob would be
+	// injected (user, org, or platform). That unlocks the claude_code
+	// backend even with no Anthropic API key.
+	ClaudeCodeOAuth bool
+	// CodexOAuth is true when a ChatGPT-forfait blob would be injected.
+	// That unlocks the OpenAI provider the same way a host Codex login does.
+	CodexOAuth bool
+}
+
+// DetectProviderName maps a secrets.Provider onto the detect.Report
+// provider name availability() looks up. Azure BYOK is the one rename:
+// detect calls that probe "foundry".
+func DetectProviderName(p secrets.Provider) string {
+	if p == secrets.ProviderAzure {
+		return "foundry"
+	}
+	return string(p)
+}
+
+// ProviderSourceLabel is the env-var name a run would see for this
+// provider — the same strings detect.Report.Source uses locally. Never a
+// value, never a last4.
+func ProviderSourceLabel(p secrets.Provider) string {
+	switch p {
+	case secrets.ProviderAnthropic:
+		return "ANTHROPIC_API_KEY"
+	case secrets.ProviderOpenAI:
+		return "OPENAI_API_KEY"
+	case secrets.ProviderZAI:
+		return "ZAI_API_KEY"
+	case secrets.ProviderXAI:
+		return "XAI_API_KEY"
+	case secrets.ProviderAzure:
+		return "AZURE_OPENAI_API_KEY"
+	case secrets.ProviderOpenRouter:
+		return "OPENROUTER_API_KEY"
+	case secrets.ProviderBedrock:
+		return "AWS_REGION"
+	case secrets.ProviderVertex:
+		return "GOOGLE_CLOUD_PROJECT"
+	default:
+		return string(p)
+	}
+}
+
+// ReportFromCloudPresence builds the detect.Report modelcatalog.Build
+// consumes, from launch-tier *presence* instead of the server process
+// environment. Backends are those a cloud runner can drive given that
+// presence — never whether the control-plane host has a `claude` binary.
+func ReportFromCloudPresence(p CloudPresence) detect.Report {
+	providers := cloudProviderSkeleton()
+	for i := range providers {
+		if src, ok := p.ProviderSources[providers[i].Name]; ok && src != "" {
+			providers[i].Available = true
+			providers[i].Source = src
+		}
+	}
+	if p.CodexOAuth {
+		for i := range providers {
+			if providers[i].Name != "openai" || providers[i].Available {
+				continue
+			}
+			providers[i].Available = true
+			providers[i].Source = "ChatGPT-OAuth"
+		}
+	}
+	if p.ClaudeCodeOAuth {
+		for i := range providers {
+			if providers[i].Name != "anthropic" || providers[i].Available {
+				continue
+			}
+			providers[i].Available = true
+			providers[i].Source = "claude_code oauth"
+		}
+	}
+
+	anthropicKey := false
+	anyProvider := false
+	for _, prov := range providers {
+		if !prov.Available {
+			continue
+		}
+		anyProvider = true
+		if prov.Name == "anthropic" {
+			anthropicKey = true
+		}
+	}
+
+	claudeCode := detect.BackendStatus{
+		Name: detect.BackendClaudeCode,
+		Auth: detect.AuthNone,
+	}
+	if p.ClaudeCodeOAuth || anthropicKey {
+		claudeCode.Available = true
+		if p.ClaudeCodeOAuth {
+			claudeCode.Auth = detect.AuthOAuth
+			claudeCode.Sources = []string{"claude_code oauth"}
+		} else {
+			claudeCode.Auth = detect.AuthAPIKey
+			claudeCode.Sources = []string{"ANTHROPIC_API_KEY"}
+		}
+	}
+
+	claw := detect.BackendStatus{
+		Name: detect.BackendClaw,
+		Auth: detect.AuthNone,
+	}
+	pi := detect.BackendStatus{
+		Name: detect.BackendPi,
+		Auth: detect.AuthNone,
+	}
+	if anyProvider || p.ClaudeCodeOAuth {
+		claw.Available = true
+		pi.Available = true
+		if anyProvider {
+			claw.Auth = detect.AuthAPIKey
+			pi.Auth = detect.AuthAPIKey
+		} else {
+			claw.Auth = detect.AuthOAuth
+			pi.Auth = detect.AuthOAuth
+		}
+	}
+
+	backends := []detect.BackendStatus{claudeCode, claw, pi}
+	pref := detect.DefaultPreferenceOrder
+	return detect.Report{
+		PreferenceOrder: pref,
+		ResolvedDefault: detect.Resolve(pref, backends),
+		Backends:        backends,
+		Providers:       providers,
+	}
+}
+
+func cloudProviderSkeleton() []detect.ProviderStatus {
+	return []detect.ProviderStatus{
+		{Name: "anthropic", Source: "ANTHROPIC_API_KEY", SuggestedModel: "anthropic/claude-opus-5"},
+		{Name: "zai", Source: "ZAI_API_KEY", SuggestedModel: "anthropic/glm-5.2"},
+		{Name: "openai", Source: "OPENAI_API_KEY", SuggestedModel: "openai/gpt-5.4-mini"},
+		{Name: "xai", Source: "XAI_API_KEY", SuggestedModel: "xai/grok-3"},
+		{Name: "foundry", Source: "AZURE_OPENAI_API_KEY"},
+		{Name: "bedrock", Source: "AWS_REGION"},
+		{Name: "vertex", Source: "GOOGLE_CLOUD_PROJECT"},
+		{Name: "openrouter", Source: "OPENROUTER_API_KEY"},
+	}
+}

--- a/pkg/modelcatalog/cloud_test.go
+++ b/pkg/modelcatalog/cloud_test.go
@@ -1,0 +1,126 @@
+package modelcatalog
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/detect"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+)
+
+func TestReportFromCloudPresence_EmptyIsNotTheHost(t *testing.T) {
+	report := ReportFromCloudPresence(CloudPresence{})
+	for _, p := range report.Providers {
+		if p.Available {
+			t.Errorf("empty presence marked provider %s available", p.Name)
+		}
+	}
+	for _, b := range report.Backends {
+		if b.Available {
+			t.Errorf("empty presence marked backend %s available", b.Name)
+		}
+	}
+	if report.ResolvedDefault != "" {
+		t.Errorf("ResolvedDefault = %q, want empty", report.ResolvedDefault)
+	}
+}
+
+func TestReportFromCloudPresence_BYOKUnlocksClawNotTheControlPlane(t *testing.T) {
+	report := ReportFromCloudPresence(CloudPresence{
+		ProviderSources: map[string]string{"openai": "OPENAI_API_KEY"},
+	})
+	openai, ok := providerStatus(report, "openai")
+	if !ok || !openai.Available {
+		t.Fatal("openai BYOK must mark the openai provider available")
+	}
+	if openai.Source != "OPENAI_API_KEY" {
+		t.Errorf("Source = %q, want OPENAI_API_KEY (a name, not a value)", openai.Source)
+	}
+	anthropic, _ := providerStatus(report, "anthropic")
+	if anthropic.Available {
+		t.Error("an OpenAI key must not mark anthropic available")
+	}
+	claw, _ := backendStatus(report, detect.BackendClaw)
+	if !claw.Available {
+		t.Error("claw must be available when any provider key is present")
+	}
+	cc, _ := backendStatus(report, detect.BackendClaudeCode)
+	if cc.Available {
+		t.Error("claude_code must not be available on an OpenAI-only presence")
+	}
+}
+
+func TestReportFromCloudPresence_ClaudeCodeOAuthUnlocksClaudeWithoutAnAPIKey(t *testing.T) {
+	report := ReportFromCloudPresence(CloudPresence{ClaudeCodeOAuth: true})
+	cat := build(t, Options{
+		Specs:             []string{"anthropic/claude-opus-5", "openai/gpt-5.5", "anthropic/glm-5.2"},
+		Report:            &report,
+		Reachability:      ReachabilityCloud,
+		UnprovenIsUnknown: true,
+	})
+	claude, _ := cat.Find("anthropic/claude-opus-5")
+	if !claude.Usable || claude.Reachability != ReachabilityCloud {
+		t.Errorf("claude-opus-5 must be cloud-proven from a forfait: %+v", claude)
+	}
+	if gpt, _ := cat.Find("openai/gpt-5.5"); gpt.Usable {
+		t.Errorf("claude_code oauth must not make openai usable: %+v", gpt)
+	}
+	if glm, _ := cat.Find("anthropic/glm-5.2"); glm.Usable {
+		t.Errorf("claude_code oauth must not make glm usable: %+v", glm)
+	}
+}
+
+func TestUnprovenCloudModelsAreUnknownNotHostUnreachable(t *testing.T) {
+	report := ReportFromCloudPresence(CloudPresence{
+		ProviderSources: map[string]string{"openai": "OPENAI_API_KEY"},
+	})
+	cat := build(t, Options{
+		Specs:             []string{"openai/gpt-5.5", "anthropic/claude-opus-5"},
+		Report:            &report,
+		Reachability:      ReachabilityCloud,
+		UnprovenIsUnknown: true,
+	})
+	if cat.Reachability != ReachabilityCloud {
+		t.Errorf("catalog reachability = %q, want cloud", cat.Reachability)
+	}
+	gpt, _ := cat.Find("openai/gpt-5.5")
+	if !gpt.Usable || gpt.Reachability != ReachabilityCloud {
+		t.Errorf("gpt must be cloud-proven: %+v", gpt)
+	}
+	claude, _ := cat.Find("anthropic/claude-opus-5")
+	if claude.Usable {
+		t.Errorf("claude must not be usable without a tenant anthropic credential: %+v", claude)
+	}
+	if claude.Reachability != ReachabilityUnknown {
+		t.Errorf("claude reachability = %q, want unknown (not a host-unreachable)", claude.Reachability)
+	}
+	if !strings.Contains(claude.UnusableReason, "cloud") {
+		t.Errorf("reason %q should describe the cloud surface, not this host", claude.UnusableReason)
+	}
+}
+
+func TestDetectProviderNameAndSourceLabelNeverHoldAValue(t *testing.T) {
+	if got := DetectProviderName(secrets.ProviderAzure); got != "foundry" {
+		t.Errorf("azure → %q, want foundry", got)
+	}
+	if got := DetectProviderName(secrets.ProviderAnthropic); got != "anthropic" {
+		t.Errorf("anthropic → %q", got)
+	}
+	if got := ProviderSourceLabel(secrets.ProviderAnthropic); got != "ANTHROPIC_API_KEY" {
+		t.Errorf("source = %q", got)
+	}
+	if strings.Contains(ProviderSourceLabel(secrets.ProviderOpenAI), "sk-") {
+		t.Fatal("source label leaked a key-shaped string")
+	}
+}
+
+func TestLocalBuildStampsLocalReachability(t *testing.T) {
+	cat := build(t, Options{Specs: []string{"anthropic/claude-opus-5"}, Report: bareHost()})
+	if cat.Reachability != ReachabilityLocal {
+		t.Errorf("catalog reachability = %q, want local", cat.Reachability)
+	}
+	e, _ := cat.Find("anthropic/claude-opus-5")
+	if e.Reachability != ReachabilityLocal {
+		t.Errorf("entry reachability = %q, want local", e.Reachability)
+	}
+}

--- a/pkg/server/model_reachability.go
+++ b/pkg/server/model_reachability.go
@@ -1,0 +1,142 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/modelcatalog"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// probeCloudRunPresence lists the launch-tier credentials a cloud run for
+// this identity would receive: tenant BYOK, user/org OAuth-forfait, then
+// platform. Presence only — it never opens a sealed blob, never returns a
+// value, and never consults the server process environment.
+//
+// The mutualised pool is not probed: a grant is opportunistic and proving
+// it would mean acquiring one. Unproven providers stay reachability
+// "unknown" rather than a false unreachable.
+func (s *Server) probeCloudRunPresence(ctx context.Context, id auth.Identity) modelcatalog.CloudPresence {
+	out := modelcatalog.CloudPresence{
+		ProviderSources: map[string]string{},
+	}
+	if id.TeamID == "" {
+		return out
+	}
+	now := time.Now().UTC()
+	s.collectBYOKPresence(ctx, id.TeamID, id.UserID, now, out.ProviderSources)
+	s.collectOAuthPresence(ctx, id.TeamID, id.UserID, &out)
+	s.collectPlatformPresence(ctx, now, &out)
+	return out
+}
+
+func (s *Server) collectBYOKPresence(ctx context.Context, teamID, userID string, now time.Time, into map[string]string) {
+	if s.apiKeys == nil {
+		return
+	}
+	tctx := store.WithTenant(ctx, teamID)
+	keys, err := s.apiKeys.ListByTeam(tctx, teamID, userID)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("models: list tenant BYOK: %v", err)
+		}
+		return
+	}
+	for _, k := range keys {
+		noteProviderPresence(into, k, now)
+	}
+}
+
+func (s *Server) collectOAuthPresence(ctx context.Context, teamID, userID string, out *modelcatalog.CloudPresence) {
+	if s.oauthStore == nil {
+		return
+	}
+	noteOAuth := func(ownerKey string) {
+		if ownerKey == "" {
+			return
+		}
+		recs, err := s.oauthStore.ListByUser(ctx, ownerKey)
+		if err != nil {
+			if s.logger != nil {
+				s.logger.Warn("models: list oauth %s: %v", ownerKey, err)
+			}
+			return
+		}
+		for _, rec := range recs {
+			if len(rec.SealedPayload) == 0 {
+				continue
+			}
+			switch rec.Kind {
+			case secrets.OAuthKindClaudeCode:
+				out.ClaudeCodeOAuth = true
+			case secrets.OAuthKindCodex:
+				out.CodexOAuth = true
+			}
+		}
+	}
+	noteOAuth(userID)
+	noteOAuth(secrets.OrgOwnerKey(teamID))
+}
+
+func (s *Server) collectPlatformPresence(ctx context.Context, now time.Time, out *modelcatalog.CloudPresence) {
+	if s.apiKeys != nil {
+		pctx := store.WithTenant(ctx, secrets.PlatformTenantID)
+		keys, err := s.apiKeys.ListByTeam(pctx, secrets.PlatformTenantID, "")
+		if err != nil {
+			if s.logger != nil {
+				s.logger.Warn("models: list platform BYOK: %v", err)
+			}
+		} else {
+			for _, k := range keys {
+				name := modelcatalog.DetectProviderName(k.Provider)
+				if _, already := out.ProviderSources[name]; already {
+					continue
+				}
+				noteProviderPresence(out.ProviderSources, k, now)
+			}
+		}
+	}
+	if s.oauthStore == nil {
+		return
+	}
+	recs, err := s.oauthStore.ListByUser(ctx, secrets.PlatformOwnerKey)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("models: list platform oauth: %v", err)
+		}
+		return
+	}
+	for _, rec := range recs {
+		if len(rec.SealedPayload) == 0 {
+			continue
+		}
+		switch rec.Kind {
+		case secrets.OAuthKindClaudeCode:
+			out.ClaudeCodeOAuth = true
+		case secrets.OAuthKindCodex:
+			out.CodexOAuth = true
+		}
+	}
+}
+
+func noteProviderPresence(into map[string]string, k secrets.ApiKey, now time.Time) {
+	if len(k.SealedSecret) == 0 {
+		return
+	}
+	if k.ExpiresAt != nil && !k.ExpiresAt.After(now) {
+		return
+	}
+	if !k.Provider.Valid() {
+		return
+	}
+	name := modelcatalog.DetectProviderName(k.Provider)
+	if name == "" {
+		return
+	}
+	if _, exists := into[name]; exists {
+		return
+	}
+	into[name] = modelcatalog.ProviderSourceLabel(k.Provider)
+}

--- a/pkg/server/models_routes.go
+++ b/pkg/server/models_routes.go
@@ -4,19 +4,21 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/backend/detect"
 	"github.com/SocialGouv/iterion/pkg/modelcatalog"
 )
 
 // handleModels serves the model registry: every model iterion knows about,
-// crossed with the credentials THIS host holds, the capabilities each model
-// has, and what it costs.
+// crossed with the credentials a *run from this request* would receive, the
+// capabilities each model has, and what it costs.
 //
-// It exists because the studio's model field was free text with a datalist of
-// hints — an operator could not see what they had access to, what it cost, or
-// whether it could even call tools. The answer is host state, not a hardcoded
-// list, so it is computed per request off the same cached detect.Report that
-// backs /api/backends/detect.
+// Local studio evaluates the host process (the same cached detect.Report
+// that backs /api/backends/detect). Cloud evaluates the authenticated
+// tenant's launch tiers — BYOK, user/org OAuth-forfait, platform — never
+// the control-plane env. A control-plane key the run will not get must
+// not make a model look reachable; a tenant key absent from that env
+// must not make it look unreachable.
 //
 // Query params:
 //
@@ -26,31 +28,45 @@ import (
 //	                     models already in use, which is the one list from
 //	                     which no new choice can be made)
 //	refresh=1            re-probe host credentials AND re-fetch the model-spec
-//	                     aggregator before answering
+//	                     aggregator before answering (local only: cloud
+//	                     presence is read from the stores each request)
 //
 // Read-only, and reveals only capability + credential SOURCE names
 // (e.g. "ANTHROPIC_API_KEY") — never a credential value.
 func (s *Server) handleModels(w http.ResponseWriter, r *http.Request) {
-	s.detectorOnce.Do(func() {
-		s.detector = detect.NewCachedDetector(backendDetectTTL)
-	})
-
 	refresh := r.URL.Query().Get("refresh") == "1"
-	if refresh {
-		// Same ordering as handleBackendsDetect: the hook may (un)set env
-		// vars, so it has to fire before the cache is dropped.
-		if s.OnForceRefresh != nil {
-			s.OnForceRefresh()
-		}
-		s.detector.Invalidate()
-	}
-	report := s.detector.Get(r.Context())
-
-	cat, err := modelcatalog.Build(r.Context(), modelcatalog.Options{
+	opts := modelcatalog.Options{
 		ExtraSpecs: dedupeSpecs(r.URL.Query()["spec"]),
 		Refresh:    refresh,
-		Report:     &report,
-	})
+	}
+
+	if s.cfg.Mode == "cloud" {
+		opts.Reachability = modelcatalog.ReachabilityCloud
+		opts.UnprovenIsUnknown = true
+		var presence modelcatalog.CloudPresence
+		if id, ok := auth.FromContext(r.Context()); ok {
+			presence = s.probeCloudRunPresence(r.Context(), id)
+		}
+		report := modelcatalog.ReportFromCloudPresence(presence)
+		opts.Report = &report
+	} else {
+		s.detectorOnce.Do(func() {
+			s.detector = detect.NewCachedDetector(backendDetectTTL)
+		})
+		if refresh {
+			// Same ordering as handleBackendsDetect: the hook may (un)set env
+			// vars, so it has to fire before the cache is dropped.
+			if s.OnForceRefresh != nil {
+				s.OnForceRefresh()
+			}
+			s.detector.Invalidate()
+		}
+		report := s.detector.Get(r.Context())
+		opts.Reachability = modelcatalog.ReachabilityLocal
+		opts.Report = &report
+	}
+
+	cat, err := modelcatalog.Build(r.Context(), opts)
 	if err != nil {
 		// Defensive: the handler only ever passes ExtraSpecs, which Build
 		// degrades into cat.InvalidSpecs rather than raising. A malformed

--- a/pkg/server/models_routes_test.go
+++ b/pkg/server/models_routes_test.go
@@ -1,18 +1,28 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
+	"time"
 
+	"github.com/SocialGouv/iterion/pkg/auth"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/modelcatalog"
+	"github.com/SocialGouv/iterion/pkg/secrets"
 )
 
-func getModels(t *testing.T, srv *Server, query string) (*httptest.ResponseRecorder, modelcatalog.Catalog) {
+func getModels(t *testing.T, srv *Server, query string, ctxs ...context.Context) (*httptest.ResponseRecorder, modelcatalog.Catalog) {
 	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/models"+query, nil)
+	if len(ctxs) > 0 && ctxs[0] != nil {
+		req = req.WithContext(ctxs[0])
+	}
 	rec := httptest.NewRecorder()
-	srv.mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/models"+query, nil))
+	srv.mux.ServeHTTP(rec, req)
 	var cat modelcatalog.Catalog
 	if rec.Code == http.StatusOK {
 		if err := json.Unmarshal(rec.Body.Bytes(), &cat); err != nil {
@@ -155,5 +165,183 @@ func TestDedupeSpecs(t *testing.T) {
 				break
 			}
 		}
+	}
+}
+
+func newCloudModelsServer(t *testing.T) (*Server, *secrets.MemoryApiKeyStore, *secrets.MemoryOAuthStore) {
+	t.Helper()
+	keys := secrets.NewMemoryApiKeyStore()
+	oauth := secrets.NewMemoryOAuthStore()
+	srv := New(Config{
+		WorkDir:                 t.TempDir(),
+		SkipProjectRegistration: true,
+		DisableAuth:             true,
+		Mode:                    "cloud",
+		ApiKeys:                 keys,
+		OAuthForfait:            oauth,
+	}, iterlog.New(iterlog.LevelError, os.Stderr))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	return srv, keys, oauth
+}
+
+func cloudIdentity(team, user string) context.Context {
+	return auth.WithIdentity(context.Background(), auth.Identity{
+		UserID: user,
+		TeamID: team,
+	})
+}
+
+func seedTeamKey(t *testing.T, store *secrets.MemoryApiKeyStore, team, user string, p secrets.Provider, secret string) {
+	t.Helper()
+	id := secrets.NewApiKeyID()
+	if err := store.Create(context.Background(), secrets.ApiKey{
+		ID:           id,
+		TenantID:     team,
+		ScopeTeamID:  team,
+		ScopeUserID:  user,
+		Provider:     p,
+		Name:         "test",
+		SealedSecret: []byte("sealed:" + secret),
+		CreatedAt:    time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create key: %v", err)
+	}
+}
+
+func seedOAuthKind(t *testing.T, st *secrets.MemoryOAuthStore, owner string, kind secrets.OAuthKind, token string) {
+	t.Helper()
+	if err := st.Upsert(context.Background(), secrets.OAuthRecord{
+		UserID:        owner,
+		Kind:          kind,
+		SealedPayload: []byte("sealed:" + token),
+	}); err != nil {
+		t.Fatalf("upsert oauth: %v", err)
+	}
+}
+
+// A tenant BYOK that the control-plane process does not hold must still
+// show as reachable. The picker used to read the server env and emit a
+// blocking "unreachable" that a cloud run would not hit.
+func TestGetModels_CloudTenantBYOKIsNotAFalseUnreachable(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-control-plane-only")
+	t.Setenv("OPENAI_API_KEY", "")
+
+	srv, keys, _ := newCloudModelsServer(t)
+	const tenantSecret = "sk-tenant-openai-never-on-the-server"
+	seedTeamKey(t, keys, "team-a", "", secrets.ProviderOpenAI, tenantSecret)
+
+	rec, cat := getModels(t, srv, "?spec=openai/gpt-5.5&spec=anthropic/claude-opus-5", cloudIdentity("team-a", "alice"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	if cat.Reachability != modelcatalog.ReachabilityCloud {
+		t.Errorf("catalog reachability = %q, want cloud", cat.Reachability)
+	}
+	gpt, ok := cat.Find("openai/gpt-5.5")
+	if !ok {
+		t.Fatal("missing openai/gpt-5.5")
+	}
+	if !gpt.Usable || gpt.Reachability != modelcatalog.ReachabilityCloud {
+		t.Errorf("tenant OpenAI BYOK must be cloud-proven usable: %+v", gpt)
+	}
+	if gpt.CredentialSource != "OPENAI_API_KEY" {
+		t.Errorf("credential_source = %q, want the env-var name", gpt.CredentialSource)
+	}
+	claude, _ := cat.Find("anthropic/claude-opus-5")
+	if claude.Usable {
+		t.Errorf("control-plane ANTHROPIC_API_KEY must not make claude usable for this tenant: %+v", claude)
+	}
+	if claude.Reachability != modelcatalog.ReachabilityUnknown {
+		t.Errorf("claude reachability = %q, want unknown (not host-unreachable)", claude.Reachability)
+	}
+	body := rec.Body.String()
+	if contains(body, tenantSecret) || contains(body, "sk-ant-control-plane-only") {
+		t.Fatalf("response leaked a credential value:\n%s", body)
+	}
+}
+
+// A user/org OAuth forfait absent from the server env must not produce a
+// false unreachable on Claude models — the publisher injects that blob.
+func TestGetModels_CloudTenantOAuthIsNotAFalseUnreachable(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	srv, _, oauth := newCloudModelsServer(t)
+	const oat = "sk-ant-oat-user-forfait"
+	seedOAuthKind(t, oauth, "alice", secrets.OAuthKindClaudeCode, oat)
+
+	rec, cat := getModels(t, srv, "?spec=anthropic/claude-opus-5", cloudIdentity("team-a", "alice"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	claude, _ := cat.Find("anthropic/claude-opus-5")
+	if !claude.Usable || claude.Reachability != modelcatalog.ReachabilityCloud {
+		t.Errorf("user claude_code forfait must be cloud-proven: %+v", claude)
+	}
+	if contains(rec.Body.String(), oat) {
+		t.Fatalf("response leaked the forfait token:\n%s", rec.Body.String())
+	}
+}
+
+// A server-process credential that the publisher will not inject must not
+// make the model look reachable to that tenant.
+func TestGetModels_CloudIgnoresControlPlaneEnv(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-control-plane-only")
+	t.Setenv("OPENAI_API_KEY", "sk-openai-control-plane-only")
+	srv, _, _ := newCloudModelsServer(t)
+
+	rec, cat := getModels(t, srv, "", cloudIdentity("team-empty", "bob"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rec.Code, rec.Body.String())
+	}
+	for _, m := range cat.Models {
+		if m.Usable {
+			t.Errorf("%s is usable from control-plane env for a tenant with no keys: %+v", m.Spec, m)
+		}
+		if m.Reachability != modelcatalog.ReachabilityUnknown {
+			t.Errorf("%s reachability = %q, want unknown", m.Spec, m.Reachability)
+		}
+	}
+	body := rec.Body.String()
+	if contains(body, "sk-ant-control-plane-only") || contains(body, "sk-openai-control-plane-only") {
+		t.Fatalf("response leaked a control-plane credential:\n%s", body)
+	}
+}
+
+func TestGetModels_CloudWithoutIdentityStaysUnknown(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-control-plane-only")
+	srv, keys, _ := newCloudModelsServer(t)
+	seedTeamKey(t, keys, "team-a", "", secrets.ProviderAnthropic, "sk-tenant")
+
+	_, cat := getModels(t, srv, "?spec=anthropic/claude-opus-5")
+	claude, _ := cat.Find("anthropic/claude-opus-5")
+	if claude.Usable {
+		t.Errorf("unauthenticated cloud catalog must not use tenant or host creds: %+v", claude)
+	}
+	if claude.Reachability != modelcatalog.ReachabilityUnknown {
+		t.Errorf("reachability = %q, want unknown", claude.Reachability)
+	}
+}
+
+func TestGetModels_CloudPlatformKeyIsProven(t *testing.T) {
+	srv, keys, _ := newCloudModelsServer(t)
+	if err := keys.Create(context.Background(), secrets.ApiKey{
+		ID:           secrets.NewApiKeyID(),
+		TenantID:     secrets.PlatformTenantID,
+		ScopeTeamID:  secrets.PlatformTenantID,
+		Provider:     secrets.ProviderXAI,
+		Name:         "platform",
+		SealedSecret: []byte("sealed:platform-xai"),
+		CreatedAt:    time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("platform key: %v", err)
+	}
+
+	_, cat := getModels(t, srv, "?spec=xai/grok-3", cloudIdentity("team-a", "alice"))
+	grok, _ := cat.Find("xai/grok-3")
+	if !grok.Usable || grok.Reachability != modelcatalog.ReachabilityCloud {
+		t.Errorf("platform xAI key is injected into the run, so grok must be cloud-proven: %+v", grok)
 	}
 }

--- a/studio/src/api/models.test.ts
+++ b/studio/src/api/models.test.ts
@@ -71,10 +71,26 @@ describe("modelCapabilityWarning", () => {
 
   it("blocks on a model this host cannot reach, and repeats the server's reason", () => {
     const w = modelCapabilityWarning(
-      entry({ usable: false, unusable_reason: "no credential detected for provider openai" }),
+      entry({
+        usable: false,
+        reachability: "local",
+        unusable_reason: "no credential detected for provider openai",
+      }),
     );
     expect(w?.level).toBe("blocking");
     expect(w?.message).toContain("openai");
+  });
+
+  it("does not block when cloud reachability is unproven", () => {
+    const w = modelCapabilityWarning(
+      entry({
+        usable: false,
+        reachability: "unknown",
+        unusable_reason: "cloud run credentials are not proven for this model",
+      }),
+    );
+    expect(w?.level).toBe("warning");
+    expect(w?.message).toContain("cloud");
   });
 
   // Tool-calling is the capability whose absence breaks the assistant

--- a/studio/src/api/models.ts
+++ b/studio/src/api/models.ts
@@ -43,6 +43,9 @@ export interface ModelEntry {
 
   usable: boolean;
   unusable_reason?: string;
+  // How usable was decided. "unknown" is cloud-unproven (pool / runner
+  // env may still serve) and must not be treated as a blocking unreachable.
+  reachability?: "local" | "cloud" | "unknown" | string;
   // Backends that can drive this spec right now, in host preference order.
   backends?: string[] | null;
   // The credential that would be used, by NAME (e.g. "ANTHROPIC_API_KEY").
@@ -53,6 +56,8 @@ export interface ModelEntry {
 export interface ModelCatalog {
   models: ModelEntry[];
   recommended_spec?: string;
+  // Credential surface this catalog evaluated: host process vs tenant launch.
+  reachability?: "local" | "cloud" | string;
   resolved_default_backend?: string;
   backends?:
     | {
@@ -161,7 +166,7 @@ export function modelCapabilityWarning(
   opts: { wantsUltracode?: boolean } = {},
 ): { level: "blocking" | "warning"; message: string } | null {
   if (!m) return null;
-  if (!m.usable) {
+  if (!m.usable && m.reachability !== "unknown") {
     return {
       level: "blocking",
       message:
@@ -174,6 +179,14 @@ export function modelCapabilityWarning(
       level: "blocking",
       message:
         "this model cannot call tools — the agent loses the board, skills and run introspection",
+    };
+  }
+  if (m.reachability === "unknown") {
+    return {
+      level: "warning",
+      message:
+        m.unusable_reason ||
+        "cloud run credentials are not proven for this model — a pool grant or runner fallback may still serve it",
     };
   }
   if (opts.wantsUltracode && !m.ultracode_capable) {

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -4834,6 +4834,7 @@ export interface components {
             backends?: components["schemas"]["BackendStatus"][];
             invalid_specs?: components["schemas"]["InvalidSpec"][];
             models: components["schemas"]["Entry"][];
+            reachability?: string;
             recommended_spec?: string;
             refresh_error?: string;
             refreshed?: boolean;
@@ -4982,6 +4983,7 @@ export interface components {
             output_cost_per_m?: number;
             price_known: boolean;
             provider: string;
+            reachability: string;
             reasoning: boolean;
             recommended?: boolean;
             source: string;

--- a/studio/src/components/models/ModelPicker.tsx
+++ b/studio/src/components/models/ModelPicker.tsx
@@ -50,7 +50,8 @@ function optionLabel(m: ModelEntry): string {
   if (m.context_window > 0) bits.push(formatContextWindow(m.context_window));
   if (m.price_known) bits.push(formatModelPrice(m).replace(" per Mtok", "/Mtok"));
   if (!m.tool_call) bits.push("no tools");
-  if (!m.usable) bits.push("no credential");
+  if (m.reachability === "unknown") bits.push("unproven");
+  else if (!m.usable) bits.push("no credential");
   return bits.length > 0 ? `${m.spec} — ${bits.join(" · ")}` : m.spec;
 }
 
@@ -70,7 +71,13 @@ export default function ModelPicker({
   const selected = models.find((m) => m.spec === value);
   const warning = modelCapabilityWarning(selected, { wantsUltracode });
   const usable = models.filter((m) => m.usable);
-  const unreachable = models.filter((m) => !m.usable);
+  const unproven = models.filter((m) => !m.usable && m.reachability === "unknown");
+  const unreachable = models.filter(
+    (m) => !m.usable && m.reachability !== "unknown",
+  );
+  const cloud = models.some(
+    (m) => m.reachability === "cloud" || m.reachability === "unknown",
+  );
   // A value the list does not carry still needs an option of its own, or the
   // <select> silently falls back to its first entry and the operator reads
   // "bot default" while a model IS set. Two ways to get here, both real: a
@@ -120,7 +127,13 @@ export default function ModelPicker({
           <option value="">{inheritLabel}</option>
           {orphan && <option value={value}>{value}</option>}
           {usable.length > 0 && (
-            <optgroup label="Available on this host">
+            <optgroup
+              label={
+                cloud
+                  ? "Available for this team's runs"
+                  : "Available on this host"
+              }
+            >
               {usable.map((m) => (
                 <option key={m.spec} value={m.spec}>
                   {optionLabel(m)}
@@ -129,11 +142,26 @@ export default function ModelPicker({
               ))}
             </optgroup>
           )}
+          {unproven.length > 0 && (
+            <optgroup label="Not proven for this team's runs">
+              {unproven.map((m) => (
+                <option key={m.spec} value={m.spec}>
+                  {optionLabel(m)}
+                </option>
+              ))}
+            </optgroup>
+          )}
           {unreachable.length > 0 && (
             // Listed, not hidden: seeing that a model exists but needs a
             // credential is what tells an operator which key to set. Selecting
             // one is allowed and warned about, never silently swallowed.
-            <optgroup label="Needs a credential this host does not have">
+            <optgroup
+              label={
+                cloud
+                  ? "Needs a credential this team does not have"
+                  : "Needs a credential this host does not have"
+              }
+            >
               {unreachable.map((m) => (
                 <option key={m.spec} value={m.spec}>
                   {optionLabel(m)}


### PR DESCRIPTION
Closes #482

## The defect

`GET /api/models` crossed the catalog with `detect.Report` from the **server process**. In cloud, the credential a run actually receives is assembled later by `cloudpublisher` from tenant BYOK, user/org OAuth-forfait, the mutualised pool, and platform credentials.

The picker could therefore:

- label a model **unreachable** (blocking launch warning) even though the cloud run can reach it
- advertise a **control-plane** env key that this tenant's run will never get

## The change

- **Local** studio/CLI still evaluate host `detect.Report` (`reachability: local`).
- **Cloud** evaluates launch-tier **presence** for the authenticated tenant — BYOK, user/org OAuth, platform — names only, never a value. Proven rows are `reachability: cloud` and `usable: true`.
- A provider with no launch-tier proof is `reachability: unknown` (pool / runner env may still serve). The studio treats that as a **warning**, not a blocking unreachable.
- Control-plane env is never consulted in cloud.
- OpenAPI + picker grouping + `docs/models.md` follow the same contract.

The pool is deliberately not probed: proving it would acquire a grant.

## Tests

- `pkg/modelcatalog` — presence → report; tenant OpenAI BYOK does not unlock Anthropic; Claude forfait unlocks Claude without an API key; unproven rows are unknown.
- `pkg/server` — tenant BYOK absent from server env is not a false unreachable; tenant OAuth ditto; server env key is not tenant-reachable; no credential value on the wire; platform key is proven.