### PR TITLE
fix(usagecap): the meter follows the credential, not the slot

### DIFF
--- a/docs/usage-caps.md
+++ b/docs/usage-caps.md
@@ -209,6 +209,44 @@ subscription is never blocked by what another tenant spent, and runs falling
 back to the deployment's own credential share one meter, which is correct —
 they really are one subscription.
 
+### Rotating a credential resets its meter — on purpose
+
+The key names the CREDENTIAL, not the slot it sits in:
+
+```
+claude_code|tenant:<id>              # legacy, still valid, expires in place
+claude_code|tenant:<id>|fp:aaaa1111  # the meter of ONE credential
+```
+
+`fp:` is the audit fingerprint of the credential the run actually spends,
+stamped when a human connects it and preserved across the automatic token
+refreshes (which rewrite the tokens of the *same* subscription). Without
+it, posting a fresh token over an exhausted one inherited the old
+account's reading — legitimately fresh until its own reset instant, up to
+seven days out — and parked every run of a credential with a full week
+available. That happened.
+
+So: **connect a new credential and the pre-flight finds nothing, fails
+open, and republishes the new account's real readings at the first call.**
+The old readings expire in place under their orphaned key (the collection
+has a 14-day TTL), and nothing needs migrating. This applies to every tier
+— a tenant's forfait, a pool donor's lent subscription, and the
+deployment's own platform forfait, where the meter is fleet-wide.
+
+Two boundaries worth knowing:
+
+- **Re-connecting the SAME Anthropic subscription also opens a fresh
+  meter.** A `credentials.json` carries no account id, so iterion cannot
+  tell "the same subscription again" from "a different one" (Codex's
+  `auth.json` does carry `account_id`, and is metered per account). The
+  reflex of re-pasting credentials when a token *looks* broken therefore
+  forgets what was measured. It fails open — one run rediscovers the wall
+  and republishes it — and the mid-run guard is the backstop.
+- **A local CLI/studio run is metered per machine, not per credential.**
+  Rotating your own credential inside a long-lived `iterion studio`
+  process keeps reading the replaced account's window until it resets;
+  restart the process to clear it.
+
 The pre-flight **fails open** on every uncertainty (no ledger, an unreadable
 ledger, nothing measured yet, a rolled-over reading). A cap exists to protect
 a subscription from a fleet, not to strand the fleet on a bookkeeping outage;

--- a/pkg/credpool/broker.go
+++ b/pkg/credpool/broker.go
@@ -116,6 +116,14 @@ type Grant struct {
 	// must never be logged, persisted in the clear, or returned over an
 	// API.
 	Payload []byte
+	// Fingerprint is the donor credential's stable audit identity — not
+	// the payload's, which token refresh rewrites every few hours for the
+	// same subscription. It is what the borrower's usage-cap meter keys
+	// on, so a donor who reconnects a FRESH subscription opens a fresh
+	// meter instead of inheriting the exhausted readings of the one it
+	// replaced. Empty for a lent API key (the runner hashes the plaintext
+	// it holds) and for donor records that predate stamping.
+	Fingerprint string
 	// RemainingUSD is what was left of the donor's tightest spend cap.
 	// Zero means the donor set no spend cap, NOT "nothing left" — callers
 	// clamping a run budget must treat zero as "no ceiling from the pool".
@@ -385,7 +393,7 @@ func (b *Broker) tryPledge(ctx context.Context, pool Pool, p Pledge, req Request
 		}
 	}
 
-	payload, gone, err := b.openCredential(ctx, p, now)
+	payload, fingerprint, gone, err := b.openCredential(ctx, p, now)
 	if err != nil {
 		release()
 		return nil, err
@@ -431,6 +439,7 @@ func (b *Broker) tryPledge(ctx context.Context, pool Pool, p Pledge, req Request
 		DonorID:      p.UserID,
 		Credential:   p.Credential,
 		Payload:      payload,
+		Fingerprint:  fingerprint,
 		RemainingUSD: remaining,
 	}, nil
 }
@@ -448,30 +457,36 @@ func meteredNote(src CredentialSource) string {
 // `gone` reason — rather than an error — when the credential has vanished
 // or died in a way only the donor can fix, so the caller parks the pledge
 // instead of rediscovering it on every launch.
-func (b *Broker) openCredential(ctx context.Context, p Pledge, now time.Time) (payload []byte, gone string, err error) {
+//
+// fingerprint is the donor record's stable audit identity, which the
+// borrower's usage-cap meter keys on so a donor who reconnects a fresh
+// subscription is not metered against the one it replaced. Only the OAuth
+// case carries one: an API key IS its own identity, so the runner hashes
+// the plaintext it already holds rather than being told.
+func (b *Broker) openCredential(ctx context.Context, p Pledge, now time.Time) (payload []byte, fingerprint, gone string, err error) {
 	switch p.Source {
 	case SourceOAuth:
 		rec, gerr := b.oauth.Get(ctx, p.UserID, secrets.OAuthKind(p.Ref))
 		if gerr != nil {
 			if errors.Is(gerr, secrets.ErrOAuthNotFound) {
-				return nil, "the connected subscription was disconnected — reconnect it to resume sharing", nil
+				return nil, "", "the connected subscription was disconnected — reconnect it to resume sharing", nil
 			}
-			return nil, "", gerr
+			return nil, "", "", gerr
 		}
 		// An expired token with no way to renew is dead: the refresh worker
 		// skips it, so it will never come back on its own.
 		if rec.NotRefreshable && rec.AccessTokenExpiresAt != nil && !now.Before(*rec.AccessTokenExpiresAt) {
-			return nil, "the connected subscription expired and carries no refresh token — reconnect it to resume sharing", nil
+			return nil, "", "the connected subscription expired and carries no refresh token — reconnect it to resume sharing", nil
 		}
 		pt, oerr := secrets.OpenOAuthPayload(b.sealer, rec.UserID, rec.Kind, rec.SealedPayload)
 		if oerr != nil {
-			return nil, "", fmt.Errorf("credpool: unseal donated subscription: %w", oerr)
+			return nil, "", "", fmt.Errorf("credpool: unseal donated subscription: %w", oerr)
 		}
-		return pt, "", nil
+		return pt, rec.Fingerprint, "", nil
 
 	case SourceAPIKey:
 		if b.apiKeys == nil {
-			return nil, "", fmt.Errorf("credpool: no api-key store wired; cannot serve %s", p.Credential)
+			return nil, "", "", fmt.Errorf("credpool: no api-key store wired; cannot serve %s", p.Credential)
 		}
 		// GetOwned, not Get: this read runs on the BORROWER's context, in
 		// another tenant than the donor's, and the tenant-scoped Get would
@@ -481,29 +496,29 @@ func (b *Broker) openCredential(ctx context.Context, p Pledge, now time.Time) (p
 		k, gerr := b.apiKeys.GetOwned(ctx, p.KeyID, p.UserID)
 		if gerr != nil {
 			if errors.Is(gerr, secrets.ErrApiKeyNotFound) {
-				return nil, "the lent API key was deleted — pledge another to resume sharing", nil
+				return nil, "", "the lent API key was deleted — pledge another to resume sharing", nil
 			}
-			return nil, "", gerr
+			return nil, "", "", gerr
 		}
 		// A donor lends THEIR OWN key. A team-wide key is the team's to
 		// spend, not one member's to hand to the pool, and a pledge must
 		// never become a way to re-scope somebody else's credential.
 		if k.ScopeUserID == "" || k.ScopeUserID != p.UserID {
-			return nil, "that API key is not yours to lend — pledge a personal key instead", nil
+			return nil, "", "that API key is not yours to lend — pledge a personal key instead", nil
 		}
 		if k.Provider != secrets.Provider(p.Ref) {
-			return nil, "the lent API key no longer matches the pledged provider — pledge it again", nil
+			return nil, "", "the lent API key no longer matches the pledged provider — pledge it again", nil
 		}
 		if k.ExpiresAt != nil && !now.Before(*k.ExpiresAt) {
-			return nil, "the lent API key has expired — pledge a current one to resume sharing", nil
+			return nil, "", "the lent API key has expired — pledge a current one to resume sharing", nil
 		}
 		pt, oerr := secrets.OpenApiKey(b.sealer, k)
 		if oerr != nil {
-			return nil, "", fmt.Errorf("credpool: unseal donated api key: %w", oerr)
+			return nil, "", "", fmt.Errorf("credpool: unseal donated api key: %w", oerr)
 		}
-		return pt, "", nil
+		return pt, "", "", nil
 	}
-	return nil, "", fmt.Errorf("credpool: unknown credential source %q", p.Source)
+	return nil, "", "", fmt.Errorf("credpool: unknown credential source %q", p.Source)
 }
 
 // supersedeOpenLeases closes any lease still marked as serving this run.

--- a/pkg/runner/loop_credentials.go
+++ b/pkg/runner/loop_credentials.go
@@ -56,6 +56,22 @@ func (r *Runner) injectCredentials(ctx context.Context, msg *queue.RunMessage) (
 		return ctx, nil, fmt.Errorf("unseal run_secrets %s: %w", msg.SecretsRef, err)
 	}
 
+	// The audit identity of each credential, computed while the plaintext
+	// is in hand: cleanup zeroes the secrets, the fingerprints stay — they
+	// are what lets the usage-cap meter key tell a rotated credential from
+	// the account it replaced.
+	fingerprints := map[string]string{}
+	for prov, key := range bundle.APIKeys {
+		if key != "" {
+			fingerprints[string(prov)] = secrets.FingerprintHex(key)
+		}
+	}
+	for kind, payload := range bundle.OAuthCredentials {
+		if len(payload) > 0 {
+			fingerprints[kind] = secrets.FingerprintHex(string(payload))
+		}
+	}
+
 	creds := secrets.Credentials{
 		APIKeys: bundle.APIKeys,
 		Generic: bundle.GenericSecrets,
@@ -70,6 +86,7 @@ func (r *Runner) injectCredentials(ctx context.Context, msg *queue.RunMessage) (
 		// usage-cap scope check reads them to meter platform-tier
 		// credentials on the shared platform key.
 		PlatformSourced: bundle.PlatformSourced,
+		Fingerprints:    fingerprints,
 	}
 	tmpDirs := make([]string, 0, len(bundle.OAuthCredentials))
 	// cancelRefresh stops the per-run OAuth-forfait token refreshers (set

--- a/pkg/runner/loop_credentials.go
+++ b/pkg/runner/loop_credentials.go
@@ -67,7 +67,7 @@ func (r *Runner) injectCredentials(ctx context.Context, msg *queue.RunMessage) (
 	fingerprints := map[string]string{}
 	for prov, key := range bundle.APIKeys {
 		if key != "" {
-			fingerprints[string(prov)] = secrets.FingerprintHex(key)
+			fingerprints[string(prov)] = secrets.FingerprintSHA256(key)
 		}
 	}
 	for kind, fp := range bundle.OAuthFingerprints {

--- a/pkg/runner/loop_credentials.go
+++ b/pkg/runner/loop_credentials.go
@@ -56,19 +56,23 @@ func (r *Runner) injectCredentials(ctx context.Context, msg *queue.RunMessage) (
 		return ctx, nil, fmt.Errorf("unseal run_secrets %s: %w", msg.SecretsRef, err)
 	}
 
-	// The audit identity of each credential, computed while the plaintext
-	// is in hand: cleanup zeroes the secrets, the fingerprints stay — they
-	// are what lets the usage-cap meter key tell a rotated credential from
-	// the account it replaced.
+	// The audit identity of each credential: cleanup zeroes the secrets,
+	// the fingerprints stay — they are what lets the usage-cap meter key
+	// tell a rotated credential from the account it replaced. An API key
+	// is static, so its own hash identifies it; an OAuth payload is NOT
+	// (the refresh worker rewrites its tokens every few hours for the
+	// same subscription), so the record's connect-time fingerprint
+	// travels in the bundle instead. Absent for legacy records — those
+	// keep the fingerprint-less meter they always had.
 	fingerprints := map[string]string{}
 	for prov, key := range bundle.APIKeys {
 		if key != "" {
 			fingerprints[string(prov)] = secrets.FingerprintHex(key)
 		}
 	}
-	for kind, payload := range bundle.OAuthCredentials {
-		if len(payload) > 0 {
-			fingerprints[kind] = secrets.FingerprintHex(string(payload))
+	for kind, fp := range bundle.OAuthFingerprints {
+		if fp != "" {
+			fingerprints[kind] = fp
 		}
 	}
 

--- a/pkg/runner/usage_cap.go
+++ b/pkg/runner/usage_cap.go
@@ -41,6 +41,7 @@ import (
 // deployment's single meter — is the platform's.
 func usageCapKey(ctx context.Context, msg *queue.RunMessage) string {
 	scope := usagecap.ScopePlatform
+	credFP := ""
 	if creds, ok := secrets.CredentialsFromContext(ctx); ok {
 		tenantOwnKey := creds.APIKey(secrets.ProviderAnthropic) != "" &&
 			!creds.IsPlatformSourced(string(secrets.ProviderAnthropic))
@@ -49,8 +50,18 @@ func usageCapKey(ctx context.Context, msg *queue.RunMessage) string {
 		if tenantOwnKey || tenantOwnOAuth {
 			scope = usagecap.TenantScope(msg.TenantID)
 		}
+		// The meter follows the CREDENTIAL: same preference order as the
+		// delegate (a ctx API key outranks an OAuth dir), so the
+		// fingerprint names the credential the run will actually spend.
+		// A rotated token therefore opens a fresh meter instead of
+		// inheriting the readings of the account it replaced.
+		if fp := creds.Fingerprint(string(secrets.ProviderAnthropic)); fp != "" {
+			credFP = fp
+		} else if fp := creds.Fingerprint(delegate.BackendClaudeCode); fp != "" {
+			credFP = fp
+		}
 	}
-	return usagecap.Key(delegate.BackendClaudeCode, scope)
+	return usagecap.Key(delegate.BackendClaudeCode, scope, credFP)
 }
 
 // usageGuardFor builds the guard for one run: the machine-wide policy

--- a/pkg/runner/usage_cap_test.go
+++ b/pkg/runner/usage_cap_test.go
@@ -75,7 +75,7 @@ func TestUsageCapPreflight_BlocksBeforeSpendingAnything(t *testing.T) {
 	ctx := t.Context()
 	resets := time.Now().UTC().Add(30 * time.Hour)
 	caps := usagecap.NewMemStore()
-	key := usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform)
+	key := usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform, "")
 	if err := caps.Record(ctx, key, usagecap.Reading{
 		Window:      usagecap.WindowSevenDay,
 		Utilization: 0.92,
@@ -123,7 +123,7 @@ func TestUsageCapPreflight_BlocksBeforeSpendingAnything(t *testing.T) {
 func TestUsageCapPreflight_RuntimeSettingsChangeIsLive(t *testing.T) {
 	ctx := t.Context()
 	caps := usagecap.NewMemStore()
-	key := usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform)
+	key := usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform, "")
 	if err := caps.Record(ctx, key, usagecap.Reading{
 		Window:      usagecap.WindowSevenDay,
 		Utilization: 0.60,
@@ -200,7 +200,7 @@ func TestUsageCapPreflight_FailsOpen(t *testing.T) {
 			pol:  usagecap.Policy{},
 			caps: func(t *testing.T) usagecap.Store {
 				s := usagecap.NewMemStore()
-				_ = s.Record(t.Context(), usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform), fresh())
+				_ = s.Record(t.Context(), usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform, ""), fresh())
 				return s
 			},
 		},
@@ -224,7 +224,7 @@ func TestUsageCapPreflight_FailsOpen(t *testing.T) {
 			pol:  capTestPolicy(),
 			caps: func(t *testing.T) usagecap.Store {
 				s := usagecap.NewMemStore()
-				_ = s.Record(t.Context(), usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform), stale())
+				_ = s.Record(t.Context(), usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform, ""), stale())
 				return s
 			},
 		},
@@ -249,14 +249,14 @@ func TestUsageCapPreflight_FailsOpen(t *testing.T) {
 func TestUsageCapKey_SeparatesTenantCredentialsFromThePlatform(t *testing.T) {
 	msg := &queue.RunMessage{TenantID: "team-7"}
 
-	if got := usageCapKey(context.Background(), msg); got != usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform) {
+	if got := usageCapKey(context.Background(), msg); got != usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform, "") {
 		t.Errorf("no credentials in ctx = %q, want the platform meter", got)
 	}
 
 	own := secrets.WithCredentials(context.Background(), secrets.Credentials{
 		APIKeys: map[secrets.Provider]string{secrets.ProviderAnthropic: "sk-tenant"},
 	})
-	if got := usageCapKey(own, msg); got != usagecap.Key(delegate.BackendClaudeCode, usagecap.TenantScope("team-7")) {
+	if got := usageCapKey(own, msg); got != usagecap.Key(delegate.BackendClaudeCode, usagecap.TenantScope("team-7"), "") {
 		t.Errorf("tenant BYOK = %q, want the tenant's own meter", got)
 	}
 
@@ -265,7 +265,7 @@ func TestUsageCapKey_SeparatesTenantCredentialsFromThePlatform(t *testing.T) {
 	unrelated := secrets.WithCredentials(context.Background(), secrets.Credentials{
 		Generic: map[string]string{"forge_token": "x"},
 	})
-	if got := usageCapKey(unrelated, msg); got != usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform) {
+	if got := usageCapKey(unrelated, msg); got != usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform, "") {
 		t.Errorf("unrelated secrets = %q, want the platform meter", got)
 	}
 
@@ -281,7 +281,7 @@ func TestUsageCapKey_SeparatesTenantCredentialsFromThePlatform(t *testing.T) {
 			delegate.BackendClaudeCode:        true,
 		},
 	})
-	if got := usageCapKey(platformFilled, msg); got != usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform) {
+	if got := usageCapKey(platformFilled, msg); got != usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform, "") {
 		t.Errorf("platform-sourced bundle = %q, want the platform meter", got)
 	}
 
@@ -294,7 +294,7 @@ func TestUsageCapKey_SeparatesTenantCredentialsFromThePlatform(t *testing.T) {
 		},
 		PlatformSourced: map[string]bool{string(secrets.ProviderOpenAI): true},
 	})
-	if got := usageCapKey(mixed, msg); got != usagecap.Key(delegate.BackendClaudeCode, usagecap.TenantScope("team-7")) {
+	if got := usageCapKey(mixed, msg); got != usagecap.Key(delegate.BackendClaudeCode, usagecap.TenantScope("team-7"), "") {
 		t.Errorf("tenant anthropic + platform openai = %q, want the tenant meter", got)
 	}
 }
@@ -321,7 +321,7 @@ func TestUsageGuardFor_PublishesUnderTheRunsCredentialKey(t *testing.T) {
 	}
 	g.Observe(usagecap.Reading{Window: usagecap.WindowFiveHour, Utilization: 0.5, ObservedAt: time.Now().UTC()})
 
-	got, err := caps.Latest(ctx, usagecap.Key(delegate.BackendClaudeCode, usagecap.TenantScope("team-7")))
+	got, err := caps.Latest(ctx, usagecap.Key(delegate.BackendClaudeCode, usagecap.TenantScope("team-7"), ""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -361,7 +361,7 @@ func capToolOnlyWorkflow() *ir.Workflow {
 func TestUsageCapPreflight_SparesAWorkflowThatCannotCallAModel(t *testing.T) {
 	ctx := t.Context()
 	caps := usagecap.NewMemStore()
-	if err := caps.Record(ctx, usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform),
+	if err := caps.Record(ctx, usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform, ""),
 		usagecap.Reading{
 			Window:      usagecap.WindowSevenDay,
 			Utilization: 0.92,
@@ -388,5 +388,82 @@ func TestUsageCapPreflight_SparesAWorkflowThatCannotCallAModel(t *testing.T) {
 	if err := r.usageCapPreflight(ctx, capLLMWorkflow(),
 		&queue.RunMessage{RunID: "think-1"}, iterlog.Nop()); err == nil {
 		t.Error("the cap must still refuse a model-calling run")
+	}
+}
+
+// The failure this pins, lived on a real deployment: a fresh OAuth token was
+// posted over a team's exhausted one, and the seven-day reading recorded
+// against the OLD account — legitimately fresh until its own reset instant,
+// five days out — kept parking every run. The meter must follow the
+// CREDENTIAL, not the slot: a rotated credential opens a fresh key, finds
+// nothing recorded, and the preflight fails open.
+func TestUsageCapPreflight_RotatedCredentialIsNotParkedByTheOldAccounts(t *testing.T) {
+	ctx := t.Context()
+	caps := usagecap.NewMemStore()
+	msg := &queue.RunMessage{RunID: "run-1", TenantID: "team-7"}
+
+	oldCreds := secrets.Credentials{
+		OAuthCredentialFiles: map[string]string{delegate.BackendClaudeCode: t.TempDir()},
+		Fingerprints:         map[string]string{delegate.BackendClaudeCode: "aaaa1111bbbb2222"},
+	}
+	newCreds := secrets.Credentials{
+		OAuthCredentialFiles: map[string]string{delegate.BackendClaudeCode: t.TempDir()},
+		Fingerprints:         map[string]string{delegate.BackendClaudeCode: "cccc3333dddd4444"},
+	}
+	oldCtx := secrets.WithCredentials(ctx, oldCreds)
+	newCtx := secrets.WithCredentials(ctx, newCreds)
+
+	// The old account's week is spent — recorded under the OLD credential's
+	// meter, exactly where the guard published it.
+	if err := caps.Record(ctx, usageCapKey(oldCtx, msg), usagecap.Reading{
+		Window:      usagecap.WindowSevenDay,
+		Utilization: 0.95,
+		Status:      usagecap.StatusRejected,
+		ResetsAt:    time.Now().UTC().Add(5 * 24 * time.Hour),
+		ObservedAt:  time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rs := &capStatusStore{}
+	r := capRunner(capTestPolicy(), caps, rs)
+
+	// Same tenant, same slot, OLD token: parked.
+	if err := r.usageCapPreflight(oldCtx, capLLMWorkflow(), msg, iterlog.Nop()); err == nil {
+		t.Fatal("the old credential's meter is at 95%: the run must be parked")
+	}
+
+	// Same tenant, same slot, NEW token: the old reading must not apply.
+	if err := r.usageCapPreflight(newCtx, capLLMWorkflow(), msg, iterlog.Nop()); err != nil {
+		t.Fatalf("rotated credential parked by the replaced account's reading: %v", err)
+	}
+}
+
+// The meter key names the credential the run actually spends: the delegate
+// ranks a ctx API key above an OAuth dir, so the fingerprint must follow
+// the same preference, and legacy credentials without fingerprints keep the
+// fingerprint-less key they always had.
+func TestUsageCapKey_FingerprintFollowsTheSpendingCredential(t *testing.T) {
+	msg := &queue.RunMessage{TenantID: "team-7"}
+
+	both := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		APIKeys:              map[secrets.Provider]string{secrets.ProviderAnthropic: "sk-tenant"},
+		OAuthCredentialFiles: map[string]string{delegate.BackendClaudeCode: "/tmp/x"},
+		Fingerprints: map[string]string{
+			string(secrets.ProviderAnthropic): "aaaa000011112222",
+			delegate.BackendClaudeCode:        "bbbb000011112222",
+		},
+	})
+	want := usagecap.Key(delegate.BackendClaudeCode, usagecap.TenantScope("team-7"), "aaaa000011112222")
+	if got := usageCapKey(both, msg); got != want {
+		t.Errorf("both slots filled = %q, want the API key's fingerprint %q (delegate preference order)", got, want)
+	}
+
+	legacy := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		APIKeys: map[secrets.Provider]string{secrets.ProviderAnthropic: "sk-tenant"},
+	})
+	want = usagecap.Key(delegate.BackendClaudeCode, usagecap.TenantScope("team-7"), "")
+	if got := usageCapKey(legacy, msg); got != want {
+		t.Errorf("legacy fingerprint-less credentials = %q, want the historical key %q", got, want)
 	}
 }

--- a/pkg/runview/usagecap.go
+++ b/pkg/runview/usagecap.go
@@ -38,7 +38,7 @@ func resolveUsageGuard(spec ExecutorSpec) (*usagecap.Guard, error) {
 		return spec.UsageGuard, nil
 	}
 	store := processUsageStore()
-	key := usagecap.Key("", usagecap.ScopeLocal)
+	key := usagecap.Key("", usagecap.ScopeLocal, "")
 	sink := func(r usagecap.Reading) {
 		// Best effort: an unrecorded reading costs the NEXT run a
 		// pre-flight, never this one its correctness.
@@ -92,7 +92,7 @@ func usagePreflightFrom(src usagecap.PolicySource) (blocked bool, reason string)
 	if !pol.Enabled() {
 		return false, ""
 	}
-	readings, err := processUsageStore().Latest(context.Background(), usagecap.Key("", usagecap.ScopeLocal))
+	readings, err := processUsageStore().Latest(context.Background(), usagecap.Key("", usagecap.ScopeLocal, ""))
 	if err != nil {
 		return false, ""
 	}

--- a/pkg/runview/usagecap.go
+++ b/pkg/runview/usagecap.go
@@ -33,6 +33,19 @@ func processUsageStore() *usagecap.MemStore {
 // A malformed policy is an error rather than an absent cap: every wrong
 // answer here fails open, and a guard silently disabled by a typo is the
 // failure the whole package exists to prevent.
+//
+// The local key carries NO credential fingerprint, unlike the runner's
+// (usagecap.Key's third segment) — deliberately, and not merely because
+// ExecutorSpec has no credential handle here. Locally there is no connect
+// event to stamp a stable identity at: the credential is whatever
+// ~/.claude/.credentials.json holds, and the CLI REWRITES that file on
+// every token refresh. Hashing it would open a new meter every few hours,
+// so no reading would ever accumulate and the cap would go quietly inert —
+// strictly worse than the slot-shaped meter, whose only cost is that an
+// operator who rotates their own credential mid-process reads the replaced
+// account's window until it resets. Closing this properly needs a stable
+// account identity, the same one secrets.SubscriptionFingerprint documents
+// as missing from Anthropic's payload.
 func resolveUsageGuard(spec ExecutorSpec) (*usagecap.Guard, error) {
 	if spec.UsageGuard != nil {
 		return spec.UsageGuard, nil

--- a/pkg/runview/usagecap_test.go
+++ b/pkg/runview/usagecap_test.go
@@ -12,7 +12,7 @@ import (
 // set — which t.Setenv scopes to the test.
 func recordLocal(t *testing.T, util float64) {
 	t.Helper()
-	if err := processUsageStore().Record(t.Context(), usagecap.Key("", usagecap.ScopeLocal), usagecap.Reading{
+	if err := processUsageStore().Record(t.Context(), usagecap.Key("", usagecap.ScopeLocal, ""), usagecap.Reading{
 		Window:      usagecap.WindowSevenDay,
 		Utilization: util,
 		Status:      usagecap.StatusWarning,

--- a/pkg/secrets/credentials.go
+++ b/pkg/secrets/credentials.go
@@ -53,12 +53,22 @@ type Credentials struct {
 	// deployment's own credential, not the tenant's.
 	PlatformSourced map[string]bool
 	// Fingerprints maps a credential slot (a Provider name or an OAuth
-	// kind) to the short audit fingerprint of the plaintext that filled
-	// it. Not sensitive (8 hash bytes) and deliberately NOT zeroed by
-	// cleanup: it says WHICH credential a run drew on. The usage-cap
-	// meter key composes it, so a rotated credential opens a fresh
-	// ledger instead of inheriting the readings of the account it
-	// replaced.
+	// kind) to the audit identity of what filled it. Not sensitive (8
+	// hash bytes) and deliberately NOT zeroed by cleanup: it says WHICH
+	// credential a run drew on. The usage-cap meter key composes it, so
+	// a rotated credential opens a fresh ledger instead of inheriting
+	// the readings of the account it replaced.
+	//
+	// The two slot kinds derive it differently, and the difference IS
+	// the contract: an API key is static, so its own hash identifies it,
+	// while an OAuth payload is NOT — the refresh worker rewrites its
+	// tokens every few hours for the same subscription — so an OAuth
+	// slot carries the record's stamped identity
+	// (SubscriptionFingerprint, fixed at connect) rather than a hash of
+	// the blob sitting in the slot. Hashing an OAuth payload here would
+	// rotate the meter with every token and no reading would ever
+	// accumulate. Absent for credentials that predate stamping: those
+	// keep the fingerprint-less meter they always had.
 	Fingerprints map[string]string
 }
 

--- a/pkg/secrets/credentials.go
+++ b/pkg/secrets/credentials.go
@@ -52,6 +52,14 @@ type Credentials struct {
 	// scope metering or policy per tenant must treat these as the
 	// deployment's own credential, not the tenant's.
 	PlatformSourced map[string]bool
+	// Fingerprints maps a credential slot (a Provider name or an OAuth
+	// kind) to the short audit fingerprint of the plaintext that filled
+	// it. Not sensitive (8 hash bytes) and deliberately NOT zeroed by
+	// cleanup: it says WHICH credential a run drew on. The usage-cap
+	// meter key composes it, so a rotated credential opens a fresh
+	// ledger instead of inheriting the readings of the account it
+	// replaced.
+	Fingerprints map[string]string
 }
 
 // IsPlatformSourced reports whether the named credential slot (a provider
@@ -79,6 +87,16 @@ func WireFamily(slot string) string {
 	default:
 		return slot
 	}
+}
+
+// Fingerprint returns the short audit fingerprint of the credential that
+// filled slot (a Provider name or an OAuth kind), or "" when the slot is
+// empty or predates fingerprinting.
+func (c Credentials) Fingerprint(slot string) string {
+	if c.Fingerprints == nil {
+		return ""
+	}
+	return c.Fingerprints[slot]
 }
 
 // APIKey returns the plaintext API key for the requested provider

--- a/pkg/secrets/fingerprint.go
+++ b/pkg/secrets/fingerprint.go
@@ -5,17 +5,19 @@ import (
 	"encoding/hex"
 )
 
-// fingerprintHex returns the first 8 bytes of SHA-256 hex-encoded.
-// 64 bits is enough to distinguish keys in audit logs while keeping
-// the value short; collisions in this space are not a security
-// concern (we never use the fingerprint as a key).
+// fingerprintHex returns the first 8 bytes of SHA-256 hex-encoded. 64 bits
+// is enough to distinguish credentials while keeping the value short, and
+// it reveals nothing about the secret. FingerprintSHA256 is its exported
+// form — the one every caller outside this package uses.
+//
+// It IS a key: the usage-cap meter composes it (usagecap.Key), so two
+// distinct credentials colliding here would silently share one ledger.
+// They would have to collide on 64 bits AND land on the same backend and
+// tenant scope, which is far below the rate at which the readings they
+// hold expire on their own. What the value must never be is a key to the
+// SECRET: it is one-way, and nothing may treat holding it as proof of
+// holding the credential it names.
 func fingerprintHex(secret string) string {
 	sum := sha256.Sum256([]byte(secret))
 	return hex.EncodeToString(sum[:8])
 }
-
-// FingerprintHex is the public form of fingerprintHex: the short audit
-// identity of a credential. It says WHICH credential produced a
-// measurement (usage metering, audit trails) without revealing it — it is
-// never a lookup key for the secret itself.
-func FingerprintHex(secret string) string { return fingerprintHex(secret) }

--- a/pkg/secrets/fingerprint.go
+++ b/pkg/secrets/fingerprint.go
@@ -13,3 +13,9 @@ func fingerprintHex(secret string) string {
 	sum := sha256.Sum256([]byte(secret))
 	return hex.EncodeToString(sum[:8])
 }
+
+// FingerprintHex is the public form of fingerprintHex: the short audit
+// identity of a credential. It says WHICH credential produced a
+// measurement (usage metering, audit trails) without revealing it — it is
+// never a lookup key for the secret itself.
+func FingerprintHex(secret string) string { return fingerprintHex(secret) }

--- a/pkg/secrets/oauth.go
+++ b/pkg/secrets/oauth.go
@@ -196,6 +196,37 @@ func ParseCodexView(payload []byte) (CodexCredentialsView, error) {
 	return v, nil
 }
 
+// SubscriptionFingerprint returns the audit identity of the SUBSCRIPTION
+// behind an OAuth credentials payload — what the usage-cap meter keys on,
+// so runs that spend one account share one ledger.
+//
+// It prefers a stable account identifier the payload names, because the
+// blob itself is not one: the same subscription connected twice (org-level
+// and personally, or re-pasted after a token looked broken) serialises
+// differently every time, and hashing the blob would open a second meter
+// that starts empty and admits a run the first meter would have parked.
+// Codex's auth.json carries `tokens.account_id`, which is exactly that
+// identifier; the hash is namespaced so an account-derived identity can
+// never be confused with a blob-derived one.
+//
+// KNOWN GAP — Anthropic: a Claude Code credentials.json carries no account
+// or subscription id (see AnthropicCredentialsView, and the token exchange
+// in oauth_authcode.go, which returns only tokens/scopes/expiry), so it
+// falls back to the whole-blob hash and re-connecting the SAME Claude
+// subscription still opens a fresh meter. That fails OPEN — the next run
+// proceeds and republishes the provider's own reading at its first call —
+// and the mid-run guard remains the backstop. Closing it needs an identity
+// from outside the payload (an Anthropic profile lookup at connect time),
+// not a different hash of it.
+func SubscriptionFingerprint(kind OAuthKind, payload []byte) string {
+	if kind == OAuthKindCodex {
+		if v, err := ParseCodexView(payload); err == nil && v.Tokens.AccountID != "" {
+			return fingerprintHex("oauth-account:" + string(kind) + ":" + v.Tokens.AccountID)
+		}
+	}
+	return fingerprintHex(string(payload))
+}
+
 // CodexAuthJSONPath returns the on-disk location of Codex CLI's auth.json,
 // honouring the `CODEX_HOME` env var (Codex's documented override) and
 // falling back to `~/.codex/auth.json`. Returns an empty string when no

--- a/pkg/secrets/oauth.go
+++ b/pkg/secrets/oauth.go
@@ -89,9 +89,16 @@ type OAuthRecord struct {
 	// can renew it. Inverted polarity so legacy records (field absent =
 	// false) keep being attempted; the first ErrNotRefreshable outcome
 	// self-heals them by setting this flag.
-	NotRefreshable bool      `bson:"not_refreshable,omitempty" json:"not_refreshable,omitempty"`
-	CreatedAt      time.Time `bson:"created_at" json:"created_at"`
-	UpdatedAt      time.Time `bson:"updated_at" json:"updated_at"`
+	NotRefreshable bool `bson:"not_refreshable,omitempty" json:"not_refreshable,omitempty"`
+	// Fingerprint is the audit identity of the SUBSCRIPTION behind this
+	// record: stamped when a human connects/pastes credentials, PRESERVED
+	// by the automatic refresh worker (whose rewrites are the same
+	// account), self-healed on legacy records at their first refresh. It
+	// is what downstream metering keys on — re-posting credentials is the
+	// act that says "different subscription", so it re-stamps.
+	Fingerprint string    `bson:"fingerprint,omitempty" json:"fingerprint,omitempty"`
+	CreatedAt   time.Time `bson:"created_at" json:"created_at"`
+	UpdatedAt   time.Time `bson:"updated_at" json:"updated_at"`
 }
 
 // OAuthStore is the persistence interface for sealed OAuth records.

--- a/pkg/secrets/oauth_refresh.go
+++ b/pkg/secrets/oauth_refresh.go
@@ -153,6 +153,13 @@ func RefreshRecord(ctx context.Context, sealer Sealer, hc *http.Client, anthropi
 	if err != nil {
 		return fmt.Errorf("secrets: unseal: %w", err)
 	}
+	// Legacy records predate the subscription fingerprint: stamp it from
+	// the CURRENT payload once — every later refresh preserves it, so the
+	// identity is stable from here on. Records stamped at connect time
+	// are left untouched: a refresh is the same subscription.
+	if rec.Fingerprint == "" {
+		rec.Fingerprint = fingerprintHex(string(payload))
+	}
 	now := time.Now().UTC()
 	switch rec.Kind {
 	case OAuthKindClaudeCode:

--- a/pkg/secrets/oauth_refresh.go
+++ b/pkg/secrets/oauth_refresh.go
@@ -156,9 +156,12 @@ func RefreshRecord(ctx context.Context, sealer Sealer, hc *http.Client, anthropi
 	// Legacy records predate the subscription fingerprint: stamp it from
 	// the CURRENT payload once — every later refresh preserves it, so the
 	// identity is stable from here on. Records stamped at connect time
-	// are left untouched: a refresh is the same subscription.
+	// are left untouched: a refresh is the same subscription. Same
+	// derivation as the connect path, so a self-healed record and a
+	// re-connected one land on the SAME meter wherever the payload names
+	// an account.
 	if rec.Fingerprint == "" {
-		rec.Fingerprint = fingerprintHex(string(payload))
+		rec.Fingerprint = SubscriptionFingerprint(rec.Kind, payload)
 	}
 	now := time.Now().UTC()
 	switch rec.Kind {

--- a/pkg/secrets/oauth_refresh_worker_test.go
+++ b/pkg/secrets/oauth_refresh_worker_test.go
@@ -172,3 +172,34 @@ func TestOAuthRefreshWorker_SkipsKindWithoutClientID(t *testing.T) {
 		t.Fatalf("expected 0 refreshed, got %d", n)
 	}
 }
+
+// The subscription fingerprint's two invariants, pinned where they live:
+// a legacy record is stamped once from its current payload (self-heal),
+// and a record that already carries one KEEPS it through any refresh
+// outcome — the refresh rewrites tokens for the SAME subscription, so a
+// fingerprint that moved with the payload would rotate the meter every
+// few hours and no reading would ever accumulate against its cap.
+func TestRefreshRecord_SubscriptionFingerprintStampsOnceThenSticks(t *testing.T) {
+	sealer, _ := NewAESGCMSealer(make([]byte, 32))
+	blob := []byte(`{"claudeAiOauth":{"accessToken":"sk-ant-snapshot1234567890abcd"}}`)
+	sealed, err := SealOAuthPayload(sealer, "erin", OAuthKindClaudeCode, blob)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+
+	legacy := OAuthRecord{UserID: "erin", Kind: OAuthKindClaudeCode, SealedPayload: sealed}
+	_ = RefreshRecord(context.Background(), sealer, http.DefaultClient, "client-xyz", "", &legacy)
+	if legacy.Fingerprint == "" {
+		t.Fatal("legacy record not self-healed: fingerprint still empty after a refresh attempt")
+	}
+	if legacy.Fingerprint != fingerprintHex(string(blob)) {
+		t.Fatalf("self-heal stamped %q, want the current payload's fingerprint", legacy.Fingerprint)
+	}
+
+	stamped := OAuthRecord{UserID: "erin", Kind: OAuthKindClaudeCode,
+		SealedPayload: sealed, Fingerprint: "prior-identity"}
+	_ = RefreshRecord(context.Background(), sealer, http.DefaultClient, "client-xyz", "", &stamped)
+	if stamped.Fingerprint != "prior-identity" {
+		t.Fatalf("refresh replaced the fingerprint (%q): the meter identity must survive token rotation", stamped.Fingerprint)
+	}
+}

--- a/pkg/secrets/oauth_refresh_worker_test.go
+++ b/pkg/secrets/oauth_refresh_worker_test.go
@@ -203,3 +203,49 @@ func TestRefreshRecord_SubscriptionFingerprintStampsOnceThenSticks(t *testing.T)
 		t.Fatalf("refresh replaced the fingerprint (%q): the meter identity must survive token rotation", stamped.Fingerprint)
 	}
 }
+
+// The half above cannot reach: a payload with no refreshToken returns
+// ErrNotRefreshable before any token exchange, so "a SUCCESSFUL refresh
+// preserves the identity" was asserted but never executed — and that is
+// the invariant that actually protects the cap. A refresh REWRITES the
+// payload (new access + refresh token, same subscription); if the
+// fingerprint moved with it, the meter would rotate every few hours, no
+// reading would ever accumulate against a cap, and the failure would be
+// silent — a cap that measures nothing looks exactly like a cap with
+// headroom.
+func TestRefreshRecord_ASuccessfulRefreshKeepsTheSubscriptionIdentity(t *testing.T) {
+	freshRetrySchedule(t)
+	sealer, _ := NewAESGCMSealer(make([]byte, 32))
+	blob := []byte(`{"claudeAiOauth":{"accessToken":"sk-ant-old1234567890abcd","refreshToken":"rf-old"}}`)
+	sealed, err := SealOAuthPayload(sealer, "erin", OAuthKindClaudeCode, blob)
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	srv := newFakeOAuthServer(
+		`{"access_token":"sk-ant-rotated1234567890abcd","refresh_token":"rf-rotated","expires_in":3600}`,
+		http.StatusOK)
+	defer srv.Close()
+
+	rec := OAuthRecord{UserID: "erin", Kind: OAuthKindClaudeCode,
+		SealedPayload: sealed, Fingerprint: "connect-time-identity"}
+	if err := RefreshRecord(context.Background(), sealer, redirectingClient(srv.URL), "client-xyz", "", &rec); err != nil {
+		t.Fatalf("RefreshRecord: %v", err)
+	}
+
+	// The refresh really happened — otherwise the assertion below would
+	// hold vacuously, which is exactly the trap this test replaces.
+	rotated, err := OpenOAuthPayload(sealer, rec.UserID, rec.Kind, rec.SealedPayload)
+	if err != nil {
+		t.Fatalf("unseal refreshed payload: %v", err)
+	}
+	view, err := ParseAnthropicView(rotated)
+	if err != nil {
+		t.Fatalf("parse refreshed payload: %v", err)
+	}
+	if view.ClaudeAIOauth.AccessToken != "sk-ant-rotated1234567890abcd" {
+		t.Fatalf("payload not rotated (%q): the success path never ran", view.ClaudeAIOauth.AccessToken)
+	}
+	if rec.Fingerprint != "connect-time-identity" {
+		t.Errorf("fingerprint = %q after a successful refresh, want the connect-time identity: the meter would rotate with every token", rec.Fingerprint)
+	}
+}

--- a/pkg/secrets/oauth_test.go
+++ b/pkg/secrets/oauth_test.go
@@ -236,3 +236,57 @@ func TestParseCodexView_Malformed(t *testing.T) {
 		t.Fatalf("expected zero view on parse error, got %+v", v)
 	}
 }
+
+// The meter identity must be the SUBSCRIPTION, not the credentials blob.
+// The blob is not one: the same account connected twice — org-level and
+// personally, or re-pasted after a token looked broken — serialises
+// differently every time, and a blob hash would open a second meter that
+// starts empty and admits a run the first would have parked. Codex names
+// its account; Anthropic does not, and that gap is pinned here too so it
+// stays a documented limit rather than a silent one.
+func TestSubscriptionFingerprint_IdentifiesTheAccountNotTheBlob(t *testing.T) {
+	codex := func(token, account string) []byte {
+		return []byte(`{"auth_mode":"chatgpt","tokens":{"access_token":"` + token +
+			`","refresh_token":"r-` + token + `","account_id":"` + account + `"}}`)
+	}
+
+	// One account, two connections: different tokens, ONE meter.
+	first := SubscriptionFingerprint(OAuthKindCodex, codex("tok-1", "acct-A"))
+	second := SubscriptionFingerprint(OAuthKindCodex, codex("tok-2", "acct-A"))
+	if first != second {
+		t.Errorf("same codex account fingerprinted %q then %q — one subscription would get two meters and two ceilings", first, second)
+	}
+	if first == "" {
+		t.Fatal("empty fingerprint: every payload must yield an identity")
+	}
+
+	// Two accounts must never share a meter — that is the whole point of
+	// keying the ledger on the credential.
+	if other := SubscriptionFingerprint(OAuthKindCodex, codex("tok-1", "acct-B")); other == first {
+		t.Error("two distinct codex accounts share a fingerprint: one account's spend would park the other's runs")
+	}
+
+	// An account-derived identity must never collide with a blob-derived
+	// one, hence the namespace in the hashed input.
+	if raw := SubscriptionFingerprint(OAuthKindClaudeCode, codex("tok-1", "acct-A")); raw == first {
+		t.Error("account-derived and blob-derived identities collide — the namespace is not applied")
+	}
+
+	// Fallbacks: a codex payload with no account_id, and Anthropic, which
+	// carries no account identifier at all (see SubscriptionFingerprint's
+	// KNOWN GAP). Both must still yield a stable per-blob identity rather
+	// than an empty one, which would collapse every credential onto the
+	// historical slot-shaped key.
+	noAccount := []byte(`{"auth_mode":"apikey","tokens":{"access_token":"tok-9"}}`)
+	if got := SubscriptionFingerprint(OAuthKindCodex, noAccount); got != fingerprintHex(string(noAccount)) {
+		t.Errorf("codex without account_id = %q, want the blob fallback", got)
+	}
+	anth := []byte(`{"claudeAiOauth":{"accessToken":"sk-ant-1"}}`)
+	if got := SubscriptionFingerprint(OAuthKindClaudeCode, anth); got != fingerprintHex(string(anth)) {
+		t.Errorf("anthropic = %q, want the blob fallback", got)
+	}
+	if SubscriptionFingerprint(OAuthKindClaudeCode, anth) ==
+		SubscriptionFingerprint(OAuthKindClaudeCode, []byte(`{"claudeAiOauth":{"accessToken":"sk-ant-2"}}`)) {
+		t.Error("two distinct anthropic credentials share a fingerprint")
+	}
+}

--- a/pkg/secrets/run_secrets.go
+++ b/pkg/secrets/run_secrets.go
@@ -48,6 +48,11 @@ type RunBundle struct {
 	// that the runner materialises as a credentials.json /
 	// auth.json before spawning the CLI subprocess.
 	OAuthCredentials map[string][]byte `json:"oauth_credentials,omitempty"`
+	// OAuthFingerprints maps the same kinds to the SUBSCRIPTION's audit
+	// fingerprint (OAuthRecord.Fingerprint) — stable across automatic
+	// token refreshes, re-stamped when a human posts new credentials.
+	// Metering keys on it; empty for records that predate stamping.
+	OAuthFingerprints map[string]string `json:"oauth_fingerprints,omitempty"`
 	// ForgeAppBotLogin is the GitHub-App bot login (e.g.
 	// "iterion-forge-1234[bot]") when the run's forge_token was resolved
 	// from a github_app connection. An installation token can't `GET /user`

--- a/pkg/secrets/sealer.go
+++ b/pkg/secrets/sealer.go
@@ -167,8 +167,10 @@ func Last4(secret string) string {
 }
 
 // FingerprintSHA256 returns a stable 16-char hex fingerprint of a
-// secret value. Useful for logs that need to correlate two records
-// using the same key without ever revealing the secret.
+// secret value: the audit identity of WHICH credential a record or a
+// measurement belongs to, without ever revealing it. Correlating logs is
+// one use; the usage-cap meter key is another. See fingerprintHex for
+// what the value may and may not stand in for.
 func FingerprintSHA256(secret string) string {
 	return fingerprintHex(secret)
 }

--- a/pkg/server/cloudpublisher/credpool_tier_test.go
+++ b/pkg/server/cloudpublisher/credpool_tier_test.go
@@ -311,3 +311,24 @@ func TestWantsFor_unpinnedRunKeepsTheWholeOrder(t *testing.T) {
 		}
 	}
 }
+
+// A lent subscription is metered like any other: on the DONOR credential's
+// own identity. Without it the borrower's meter is slot-shaped, so a donor
+// who reconnects a fresh subscription is still parked by the readings of
+// the account it replaced — the lived failure, borrowed.
+func TestPoolTier_grantCarriesTheDonorCredentialsIdentity(t *testing.T) {
+	f := newPoolFixture(t, credpool.Limits{MaxUSDPerDay: 5})
+
+	bundle, creds := f.resolve(t, "run-1", nil)
+
+	if creds.grant == nil {
+		t.Fatal("no grant — the tier is not wired")
+	}
+	want := seededFP("donor")
+	if creds.grant.Fingerprint != want {
+		t.Errorf("grant.Fingerprint = %q, want the donor record's %q", creds.grant.Fingerprint, want)
+	}
+	if got := bundle.OAuthFingerprints["claude_code"]; got != want {
+		t.Errorf("OAuthFingerprints[claude_code] = %q, want %q — the borrower's meter would follow the slot, not the lent credential", got, want)
+	}
+}

--- a/pkg/server/cloudpublisher/oauth_fallback_test.go
+++ b/pkg/server/cloudpublisher/oauth_fallback_test.go
@@ -24,10 +24,18 @@ func seedOAuth(t *testing.T, st secrets.OAuthStore, sealer secrets.Sealer, owner
 		UserID:        ownerKey,
 		Kind:          secrets.OAuthKindClaudeCode,
 		SealedPayload: sealed,
+		// Production shape: sealOAuthRecord stamps the subscription's audit
+		// identity at connect time. A sentinel rather than a real hash —
+		// what a tier owes the bundle is THIS record's identity, whatever
+		// it was derived from.
+		Fingerprint: seededFP(ownerKey),
 	}); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 }
+
+// seededFP is the fingerprint seedOAuth stamps on the record it creates.
+func seededFP(ownerKey string) string { return "fp-" + ownerKey }
 
 func resolveBundle(t *testing.T, p *Publisher, runSecrets *secrets.MemoryRunSecretsStore, sealer secrets.Sealer, runID, tenant, owner string) secrets.RunBundle {
 	t.Helper()

--- a/pkg/server/cloudpublisher/platform_tier_test.go
+++ b/pkg/server/cloudpublisher/platform_tier_test.go
@@ -210,3 +210,32 @@ func TestPlatformTier_storeErrorDegradesToNoOp(t *testing.T) {
 		t.Fatalf("bundle = %+v, want empty on a degraded platform store", b)
 	}
 }
+
+// The platform forfait is ONE meter for the whole deployment
+// (usagecap.ScopePlatform), so a super-admin rotating it is exactly the
+// lived failure the credential-keyed meter exists to prevent — one tier
+// up, and fleet-wide. The record's identity must reach the bundle or the
+// runner falls back to the slot-shaped key and the fresh subscription
+// inherits the exhausted readings of the one it replaced.
+func TestPlatformTier_oauthFillCarriesTheCredentialsIdentity(t *testing.T) {
+	sealer, _ := secrets.NewAESGCMSealer(make([]byte, 32))
+	oauth := secrets.NewMemoryOAuthStore()
+	seedOAuth(t, oauth, sealer, secrets.PlatformOwnerKey, "sk-ant-platform")
+
+	p := &Publisher{
+		oauthForfait: oauth,
+		runSecrets:   secrets.NewMemoryRunSecretsStore(),
+		sealer:       sealer,
+		logger:       testLogger(),
+	}
+	rs := p.runSecrets.(*secrets.MemoryRunSecretsStore)
+
+	b := resolveBundle(t, p, rs, sealer, "run-1", "team1", "webhook:cfg-1")
+	if len(b.OAuthCredentials["claude_code"]) == 0 {
+		t.Fatal("no platform forfait in the bundle — the tier is not wired")
+	}
+	want := seededFP(secrets.PlatformOwnerKey)
+	if got := b.OAuthFingerprints["claude_code"]; got != want {
+		t.Errorf("OAuthFingerprints[claude_code] = %q, want %q — a rotated platform forfait would inherit the replaced account's meter", got, want)
+	}
+}

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -487,7 +487,13 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 					continue
 				}
 				bundle.OAuthCredentials[string(rec.Kind)] = payload
-				p.logger.Info("cloudpublisher: oauth-forfait(%s) used run=%s owner=%s kind=%s", label, runID, ownerKey, rec.Kind)
+				if rec.Fingerprint != "" {
+					if bundle.OAuthFingerprints == nil {
+						bundle.OAuthFingerprints = map[string]string{}
+					}
+					bundle.OAuthFingerprints[string(rec.Kind)] = rec.Fingerprint
+				}
+				p.logger.Info("cloudpublisher: oauth-forfait(%s) used run=%s owner=%s kind=%s fp=%s", label, runID, ownerKey, rec.Kind, rec.Fingerprint)
 			}
 		}
 		addOAuth(ownerID, "user")

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -487,12 +487,7 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 					continue
 				}
 				bundle.OAuthCredentials[string(rec.Kind)] = payload
-				if rec.Fingerprint != "" {
-					if bundle.OAuthFingerprints == nil {
-						bundle.OAuthFingerprints = map[string]string{}
-					}
-					bundle.OAuthFingerprints[string(rec.Kind)] = rec.Fingerprint
-				}
+				setOAuthFingerprint(&bundle, string(rec.Kind), rec.Fingerprint)
 				p.logger.Info("cloudpublisher: oauth-forfait(%s) used run=%s owner=%s kind=%s fp=%s", label, runID, ownerKey, rec.Kind, rec.Fingerprint)
 			}
 		}
@@ -513,6 +508,11 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 			switch grant.Source {
 			case credpool.SourceOAuth:
 				bundle.OAuthCredentials[grant.Ref] = grant.Payload
+				// The donor's own credential identity, so the borrower's
+				// meter follows the lent subscription rather than the slot
+				// it landed in: a donor who reconnects a fresh one is not
+				// parked by the readings of the account it replaced.
+				setOAuthFingerprint(&bundle, grant.Ref, grant.Fingerprint)
 			case credpool.SourceAPIKey:
 				bundle.APIKeys[secrets.Provider(grant.Ref)] = string(grant.Payload)
 			}
@@ -588,6 +588,23 @@ type credResolution struct {
 	// topology vars for a queued run. Empty = nothing resolved (env
 	// fallback), in which case no injection happens.
 	families reviewtopology.FamilySet
+}
+
+// setOAuthFingerprint stamps the audit identity of the credential that
+// filled an OAuth slot, whichever tier it came from. Every tier must do it:
+// the runner's usage-cap meter keys on this, and a slot filled without one
+// falls back to the historical slot-shaped meter — where a rotated
+// credential inherits the exhausted readings of the account it replaced.
+// An empty fingerprint (a record predating stamping) is left absent rather
+// than written blank, so the historical key stays reachable.
+func setOAuthFingerprint(bundle *secrets.RunBundle, kind, fp string) {
+	if fp == "" {
+		return
+	}
+	if bundle.OAuthFingerprints == nil {
+		bundle.OAuthFingerprints = map[string]string{}
+	}
+	bundle.OAuthFingerprints[kind] = fp
 }
 
 // fillFromPlatform fills the API-key and OAuth slots still empty after the
@@ -687,8 +704,14 @@ func (p *Publisher) fillFromPlatform(ctx context.Context, runID string, bundle *
 			}
 			bundle.OAuthCredentials[string(rec.Kind)] = payload
 			bundle.PlatformSourced[string(rec.Kind)] = true
+			// The platform forfait is ONE meter for the whole deployment
+			// (ScopePlatform), which makes rotating it exactly the lived
+			// failure one tier up: without the identity, a super-admin who
+			// swaps in a fresh subscription inherits the exhausted
+			// readings of the one it replaced, fleet-wide.
+			setOAuthFingerprint(bundle, string(rec.Kind), rec.Fingerprint)
 			taken[secrets.WireFamily(string(rec.Kind))] = true
-			p.logger.Info("cloudpublisher: platform credential used run=%s slot=%s", runID, rec.Kind)
+			p.logger.Info("cloudpublisher: platform credential used run=%s slot=%s fp=%s", runID, rec.Kind, rec.Fingerprint)
 		}
 	}
 }

--- a/pkg/server/oauth_routes.go
+++ b/pkg/server/oauth_routes.go
@@ -334,7 +334,7 @@ func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secr
 	// A human connecting/pasting credentials is the act that says "this
 	// subscription": stamp its audit identity here, once. The refresh
 	// worker rewrites tokens for the SAME subscription and preserves it.
-	rec.Fingerprint = secrets.FingerprintHex(string(blob))
+	rec.Fingerprint = secrets.FingerprintSHA256(string(blob))
 	if err := s.oauthStore.Upsert(ctx, rec); err != nil {
 		return secrets.OAuthRecord{}, err
 	}

--- a/pkg/server/oauth_routes.go
+++ b/pkg/server/oauth_routes.go
@@ -334,7 +334,9 @@ func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secr
 	// A human connecting/pasting credentials is the act that says "this
 	// subscription": stamp its audit identity here, once. The refresh
 	// worker rewrites tokens for the SAME subscription and preserves it.
-	rec.Fingerprint = secrets.FingerprintSHA256(string(blob))
+	// Derived from the account the payload names where it names one, so
+	// connecting ONE subscription twice does not open two meters.
+	rec.Fingerprint = secrets.SubscriptionFingerprint(kind, blob)
 	if err := s.oauthStore.Upsert(ctx, rec); err != nil {
 		return secrets.OAuthRecord{}, err
 	}

--- a/pkg/server/oauth_routes.go
+++ b/pkg/server/oauth_routes.go
@@ -331,6 +331,10 @@ func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secr
 		return secrets.OAuthRecord{}, fmt.Errorf("seal: %w", err)
 	}
 	rec.SealedPayload = sealed
+	// A human connecting/pasting credentials is the act that says "this
+	// subscription": stamp its audit identity here, once. The refresh
+	// worker rewrites tokens for the SAME subscription and preserves it.
+	rec.Fingerprint = secrets.FingerprintHex(string(blob))
 	if err := s.oauthStore.Upsert(ctx, rec); err != nil {
 		return secrets.OAuthRecord{}, err
 	}

--- a/pkg/usagecap/env_test.go
+++ b/pkg/usagecap/env_test.go
@@ -122,7 +122,7 @@ func TestParseMode(t *testing.T) {
 func TestMemStore(t *testing.T) {
 	ctx := t.Context()
 	s := NewMemStore()
-	key := Key("claude_code", ScopePlatform)
+	key := Key("claude_code", ScopePlatform, "")
 	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
 
 	if got, err := s.Latest(ctx, "unknown"); err != nil || len(got) != 0 {
@@ -156,10 +156,27 @@ func TestKeyScoping(t *testing.T) {
 	// A tenant's own subscription is a different meter from the
 	// deployment's: merging them would let one tenant's spend park
 	// another's runs.
-	if Key("claude_code", TenantScope("t1")) == Key("claude_code", ScopePlatform) {
+	if Key("claude_code", TenantScope("t1"), "") == Key("claude_code", ScopePlatform, "") {
 		t.Fatal("tenant and platform credentials must not share a key")
 	}
-	if Key("claude_code", TenantScope("")) != Key("claude_code", ScopePlatform) {
+	if Key("claude_code", TenantScope(""), "") != Key("claude_code", ScopePlatform, "") {
 		t.Fatal("a run with no tenant falls back to the platform meter")
+	}
+}
+
+// The key follows the credential: a fingerprint opens its own meter, an
+// empty fingerprint IS the historical two-segment key — readings recorded
+// before fingerprinting stay readable and expire in place.
+func TestKey_CredentialFingerprintSegment(t *testing.T) {
+	if got := Key("claude_code", ScopePlatform, ""); got != "claude_code|platform" {
+		t.Errorf("fingerprint-less key = %q, want the historical format", got)
+	}
+	a := Key("claude_code", TenantScope("t1"), "aaaa1111")
+	b := Key("claude_code", TenantScope("t1"), "bbbb2222")
+	if a == b {
+		t.Error("two credentials on one tenant must not share a meter")
+	}
+	if a != "claude_code|tenant:t1|fp:aaaa1111" {
+		t.Errorf("fingerprinted key = %q", a)
 	}
 }

--- a/pkg/usagecap/store.go
+++ b/pkg/usagecap/store.go
@@ -34,7 +34,16 @@ type Store interface {
 // meter. Runs that fall back to the deployment's own credential share
 // ScopePlatform, and merging THOSE is not a compromise but the point — they
 // really are one subscription.
-func Key(backend, scope string) string {
+//
+// credFP, when known, is the audit fingerprint of the credential itself
+// (secrets.FingerprintHex). It is what makes the meter follow the
+// CREDENTIAL and not the slot: a rotated token opens a fresh key, so a
+// seven-day reading recorded against the old account — legitimately fresh
+// until its own reset instant — cannot park runs that no longer draw on
+// it. Mesure : une clé neuve posée sur une team est restée bloquée des
+// jours par le reading à 95% de la clé qu'elle remplaçait. Readings
+// recorded under a fingerprint-less key simply expire in place.
+func Key(backend, scope, credFP string) string {
 	backend = strings.TrimSpace(backend)
 	scope = strings.TrimSpace(scope)
 	if backend == "" {
@@ -43,7 +52,11 @@ func Key(backend, scope string) string {
 	if scope == "" {
 		scope = ScopePlatform
 	}
-	return backend + "|" + scope
+	k := backend + "|" + scope
+	if fp := strings.TrimSpace(credFP); fp != "" {
+		k += "|fp:" + fp
+	}
+	return k
 }
 
 const (

--- a/pkg/usagecap/store.go
+++ b/pkg/usagecap/store.go
@@ -36,7 +36,7 @@ type Store interface {
 // really are one subscription.
 //
 // credFP, when known, is the audit fingerprint of the credential itself
-// (secrets.FingerprintHex). It is what makes the meter follow the
+// (secrets.FingerprintSHA256). It is what makes the meter follow the
 // CREDENTIAL and not the slot: a rotated token opens a fresh key, so a
 // seven-day reading recorded against the old account — legitimately fresh
 // until its own reset instant — cannot park runs that no longer draw on


### PR DESCRIPTION
## The lived failure

A fresh OAuth token was posted over a team's exhausted one. The seven-day reading recorded against the **old** account — legitimately fresh until its own reset instant, five days out — kept parking every run of the **new** credential: the meter key was `backend|scope`, so both tokens shared one meter.

## Fix

The meter key composes the credential's **audit fingerprint** (8-byte SHA-256, computed at bundle materialisation while the plaintext is in hand; identity, not secret — never zeroed by cleanup):

```
claude_code|tenant:<id>              # historical, still valid, expires in place
claude_code|tenant:<id>|fp:aaaa1111  # the meter of ONE credential
```

The fingerprint follows the delegate's own preference order (ctx API key outranks OAuth dir), so it names the credential the run actually spends. A rotated credential opens a fresh meter → preflight finds nothing → fails open → the run publishes the new account's real readings. Old readings die at their own `ResetsAt` under their orphaned key. Zero migration.

## Tests

- `TestUsageCapPreflight_RotatedCredentialIsNotParkedByTheOldAccounts` — the lived scenario end-to-end at the preflight seam (old token parked at 95%, new token proceeds).
- `TestUsageCapKey_FingerprintFollowsTheSpendingCredential` — preference order + legacy fingerprint-less credentials keep the historical key.
- `TestKey_CredentialFingerprintSegment` — key format, historical compatibility.
- All touched packages green (`usagecap`, `runner`, `secrets`, `runview`); `pkg/server`'s `TestLocalSkills_CRUD` fails on the pristine tree too on this machine (local skills environment pollution, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)