### PR TITLE
docs: Revi → Billy habit on this repo — /billy after findings, dogfood duty

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,12 @@ the hours this one spent.
   guarantee a dead review still answers (outcome event + 1-min sweep).
   Read it when a gate looks stuck — "absent", "pending forever", a synthetic
   `review died`, or a repair that posts nothing and says why in the logs.
+- [docs/revi-billy-loop.md](docs/revi-billy-loop.md) — the Revi → Billy habit
+  on THIS repo: findings on a PR here → comment `/billy` (don't hand-fix),
+  what the command seeds (prior-review hand-off, push-back, ledger, gate),
+  the session gotchas (don't touch the branch while he runs, pull after his
+  push), and the dogfood duty (bilan per run). Read it before acting on a
+  Revi review of an iterion PR.
 - [docs/probes-and-graceful-shutdown.md](docs/probes-and-graceful-shutdown.md) —
   what `/healthz` and `/readyz` promise on the server AND the runner, the
   lame-duck window (`ITERION_SHUTDOWN_DELAY`) that keeps a deploy or an HPA
@@ -1722,6 +1728,15 @@ review ([pkg/server/forge_publish.go](pkg/server/forge_publish.go)). See
 sharing one context on the same PR, and the per-repo **opt-in** zero-touch lane
 (`auto_fix_on_gate_failure`) where a red gate launches the repo's fixer once per
 head sha, off by default so the developer keeps the choice.
+
+**Revi → Billy is the habit on this repo.** When Revi leaves findings on a PR
+here, comment **`/billy`** on the PR and let the fixer work — don't hand-fix
+the findings in a session. The command seeds Billy with Revi's review
+(kind-matched hand-off), he pushes fixes onto the PR branch, posts his ledger +
+gate count, and the push re-triggers Revi. Every such run is a dogfood run:
+monitor it, fix the frictions it surfaces, write the bilan. Full habit +
+gotchas: [docs/revi-billy-loop.md](docs/revi-billy-loop.md). (The zero-touch
+`auto_fix_on_gate_failure` lane is deliberately not enabled here yet.)
 
 ## Conventions
 

--- a/bots/branch-improve-loop/README.md
+++ b/bots/branch-improve-loop/README.md
@@ -195,6 +195,8 @@ read-only), critiqued by a cross-family peer (`claw` +
 `openai/gpt-5.6-sol` by default), and revised by the SAME author session
 before the campaign fixes; otherwise the phase is bypassed whole (the v2
 shape, unchanged). `plan_review_policy` picks the mid-run
-peer-unavailability behaviour: `wait` (default — the run parks
-failed_resumable, the usage-window retry resumes it) or `skip` (the
-reviewer's `action: skip` route — continue unreviewed, loudly stamped).
+peer-unavailability behaviour: `skip` (default — the reviewer's
+`action: skip` route: continue unreviewed, loudly stamped; the peer is
+an optional enrichment and must never block the campaign — Anthropic
+alone always suffices) or `wait` (the run parks failed_resumable, the
+usage-window retry resumes it — the deliberate-spend posture).

--- a/bots/branch-improve-loop/main.bot
+++ b/bots/branch-improve-loop/main.bot
@@ -219,12 +219,16 @@ vars:
   ## (the peer reviewer then fails loudly on a missing credential).
   plan_review: string = "auto"
   ## What a MID-RUN peer failure (forfait window shut, provider down,
-  ## credential revoked) does: "wait" (default) parks the run
-  ## failed_resumable until the peer window reopens (run-level
-  ## usage-window retry; cloud durable, local --auto-resume); "skip"
-  ## arms the reviewer's `action: skip` fallback route — the plan
-  ## proceeds unreviewed, LOUDLY (_skipped stamped, plan_gate reads it).
-  plan_review_policy: string [enum: "wait", "skip"] = "wait"
+  ## credential revoked) does: "skip" (default) arms the reviewer's
+  ## `action: skip` fallback route — the plan proceeds unreviewed,
+  ## LOUDLY (_skipped stamped, plan_gate reads it). The peer is an
+  ## optional enrichment: the Anthropic family alone must always
+  ## suffice to fix a branch, so a dead peer never blocks the campaign
+  ## (a fixer invoked on a PR that parks on an OPTIONAL reviewer holds
+  ## the PR hostage). "wait" parks the run failed_resumable until the
+  ## peer window reopens (run-level usage-window retry; cloud durable,
+  ## local --auto-resume) — the deliberate-spend posture.
+  plan_review_policy: string [enum: "wait", "skip"] = "skip"
 
 secrets:
   ## Forge access for push + PR creation + the issue back-link. Mounted as a

--- a/bots/branch-improve-loop/manifest.yaml
+++ b/bots/branch-improve-loop/manifest.yaml
@@ -1,7 +1,14 @@
 name: branch-improve-loop
 display_name: Billy
 icon: 🌿
-version: 1.2.0
+version: 1.2.1
+## 1.2.1 — plan_review_policy defaults to "skip": the cross-model plan peer
+## is an optional enrichment, and the Anthropic family alone must always
+## suffice to fix a branch. A dead/parked peer (401 credential, shut forfait
+## window, provider outage) completes plan_review with the `_skipped` stamp
+## and the campaign proceeds, instead of parking the run — a fixer invoked
+## on a PR that waits on an OPTIONAL reviewer holds the PR hostage. `wait`
+## remains the per-run opt-in for the deliberate-spend posture.
 ## 1.1.1 — an advisory block before the report (`Fit` / `Rot` / `Ratchet`,
 ## the shape whole-improve-loop already carries): the last of the three asks
 ## for the cheap deterministic check that would have caught the issue just

--- a/bots/plan_phase_test.go
+++ b/bots/plan_phase_test.go
@@ -44,9 +44,19 @@ func TestPlanPhaseWiring(t *testing.T) {
 			}
 			wf := cr.Workflow
 
+			// branch-improve-loop defaults the peer policy to "skip": a
+			// fixer invoked ON a pull request must never park on its
+			// OPTIONAL cross-model plan reviewer — the Anthropic family
+			// alone always suffices to fix a branch, and a parked fixer
+			// holds the PR hostage. The other campaign bots keep "wait"
+			// (a parked campaign blocks nobody external).
+			wantPolicy := "wait"
+			if bot == "branch-improve-loop" {
+				wantPolicy = "skip"
+			}
 			for varName, wantDefault := range map[string]string{
 				"plan_review":        "auto",
-				"plan_review_policy": "wait",
+				"plan_review_policy": wantPolicy,
 			} {
 				v, ok := wf.Vars[varName]
 				if !ok {

--- a/docs/adr/091-fallback-skip-route-and-plan-peer-review.md
+++ b/docs/adr/091-fallback-skip-route-and-plan-peer-review.md
@@ -159,7 +159,8 @@ execution) hardened the design; all folded in before first release:
   pre-existing repo-wide posture, review-pr included); and a
   `session: inherit_if_available` node resumed cross-pod can hold a
   dead `_session_id` — the engine seam wanted is "resume failure under
-  inherit_if_available ⇒ fresh".
+  inherit_if_available ⇒ fresh". *(The second is CLOSED — see the third
+  amendment.)*
 
 ## Second amendment (2026-08-26, from Revi's pre-merge gate review)
 
@@ -179,6 +180,46 @@ execution) hardened the design; all folded in before first release:
   now fails at launch instead of silently selecting wait), and
   `fillZeroValues` emits `float64` for int fields (the JSON-shaped
   contract ValidateOutput and a store round-trip expect).
+
+## Third amendment (2026-08-27, from the first `/billy` dogfood on this repo)
+
+Two of the decisions above met a real run and moved
+([docs/bot-runs/branch-improve-loop.md](../bot-runs/branch-improve-loop.md),
+[docs/revi-billy-loop.md](../revi-billy-loop.md)):
+
+- **The `inherit_if_available ⇒ fresh` seam shipped**, closing the
+  known-and-accepted item above — and with a WIDER scope than asked.
+  `delegate.Task.SessionOptional` is set for `inherit_if_available` AND
+  for `persist`: both say the session is best-effort, and a cloud resume
+  that replaces the sandbox container kills the CLI's session files for
+  either. On an UNCLASSIFIED failure the executor drops the session
+  (evicting the claw node-session store too, so "fresh" is fresh on
+  every backend) and retries once. Unclassified ONLY: auth /
+  usage_window / unavailable are credential- or model-level, and
+  transient_exhausted is a provider-side cause the session had no part
+  in — degrading there would buy a second full retry budget under an
+  outage and discard continuity for nothing.
+  Widening to `persist` is deliberate: a wedged node returns
+  `error_during_execution` in ~2.6s on EVERY resume, so "fail loudly and
+  let the run-level retry handle it" is not a live option — the retry
+  re-hits the same dead file. Losing one loop iteration's memory is the
+  cheaper failure.
+- **The degrade is loud**, on the same terms this ADR set for the skip
+  route: a `session_degraded` store event (the restore-side twin of
+  `persist_session_degraded`) and a `_session_degraded: true` stamp on
+  the node's own output, so a deterministic gate can fail closed on an
+  amnesiac input. It is deliberately NOT a `model_fallback` — the same
+  backend, model and credential served; what degraded is the node's
+  INPUT.
+- **`plan_review_policy` now defaults to `skip` for
+  `branch-improve-loop` only.** The discriminator is not the bot's
+  identity but the property that it is invoked ON an external artifact:
+  a fixer that parks on an OPTIONAL cross-model reviewer holds someone's
+  pull request hostage, while a parked campaign on a workspace blocks
+  nobody. The other three campaign bots keep `wait`. Residual risk,
+  filed rather than fixed: a permanently dead peer credential now
+  degrades every run silently, and the only operator signal is the run
+  console — the fixer's PR comment does not yet say "plan peer skipped".
 
 ## Consequences
 

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -431,6 +431,39 @@ A fall-through also **drops the failed route's conversation** — the
 session store carries no provider fingerprint, so replaying it would
 send one provider's signed turns to another.
 
+### A best-effort session that no longer loads
+
+`session: inherit_if_available` and `session: persist` say the session
+is *best effort*. Sometimes the id resolves but its backing state is
+gone — a cloud resume replaces the sandbox container, and the CLI's
+session files die with it, after which every resume of that node fails
+identically and forever. "If available" covers that too: the executor
+retries **once** with the session dropped.
+
+Deliberately narrow, on three axes:
+
+- **Unclassified failures only.** That is where a refused session lands
+  (the backend declined to load it and said nothing typed about why),
+  and being non-retryable it makes the fresh attempt a single extra
+  call. `auth` / `usage_window` / `unavailable` are credential- or
+  model-level — a fresh session hits the same wall — and
+  `transient_exhausted` is a provider-side cause (throttle, 5xx, TCP
+  blip) the session had no part in.
+- **Backends that actually resume with the id** — `claude_code`,
+  `codex`, `pi`. `claw` never reads `SessionID` (its conversation is
+  replayed from the run's own store), and `kimi` / `grok` only report
+  one, so there the "fresh" call would be byte-identical.
+- **`inherit` and `fork` never degrade.** They asked for continuity
+  unconditionally, and keep failing loudly.
+
+Like a fall-through, it is not silent: a `session_degraded` event
+(backend, session id, reason, error) and **`_session_degraded: true` on
+the node's own output**, so a deterministic gate can fail closed on an
+amnesiac input. It is *not* a `model_fallback` and does not set
+`_fallback_used`: the same backend, model and credential served — what
+degraded is the node's input. The node's accumulated `claw` conversation
+is evicted alongside, so "fresh" means fresh on every backend.
+
 ### Refusals
 
 Two crossings are compile-time **errors** (`C176`), because the degraded

--- a/docs/bot-runs/branch-improve-loop.md
+++ b/docs/bot-runs/branch-improve-loop.md
@@ -1,5 +1,69 @@
 # Billy — branch-improvement validation
 
+## 2026-08-27 — first `/billy` of the Revi→Billy habit on iterion itself (runs 01a0428a, 01a042b9, 01a042d7)
+
+- Status: **partial.** The habit's whole chain worked — `/billy` comment →
+  launch with `prior_review` seeded (3.6–6 KB, the kind-matched hand-off),
+  campaign converged in ONE pass (7 commits, verify green, in-loop review
+  clean), honest verdict posted — but the **push died on an expired forge
+  token** after 1h11, so the fixes never reached the PR. Three engine/bot
+  defects found, two fixed in this change, one filed
+  (native:54412d84). This bilan inaugurates [docs/revi-billy-loop.md](../revi-billy-loop.md).
+- Versions: iterion cloud prod (edge ~v3.65) · bot `branch-improve-loop` 1.2.0
+- Method: the documented habit — Revi reviewed SocialGouv/iterion#541
+  (1 high: "OAuth meter key follows the access token"), then `/billy`
+  comments (maintainer). Weekly usage cap was at 95% → rotated the team +
+  platform claude_code OAuth credential (fresh token), temporarily raised
+  the runtime week cap 95→99 to get past the pre-#541 shared-meter stale
+  reading, resumed the parked review. Three Billy attempts:
+  - **Run 1 (01a0428a):** paused on `plan_review` — the team's codex OAuth
+    record was DEAD (401), and `plan_review: auto` had resolved `on` from
+    its mere existence. Uploaded a fresh codex auth.json → peer served on
+    retry — then `plan_revise` wedged forever (~2.6s
+    `error_during_execution` × 9): the mid-plan-phase resume had replaced
+    the sandbox container, the author session's files died with it, and
+    `inherit_if_available` only tolerated a MISSING session id, not an
+    unloadable one. Cancelled.
+  - **Run 2 (01a042b9):** `plan_review` 400 — `gpt-5.6-sol requires a newer
+    codex-cli` (the ChatGPT-wire version gate; runner lacks a recent
+    `ITERION_CODEX_VERSION`). Cancelled; pinned `plan_review: "off"` in the
+    iterion repo integration's launch_vars (operator directive: **the fixer
+    must never depend on a second family — Anthropic alone suffices**).
+  - **Run 3 (01a042d7):** clean campaign, pure Anthropic. Converged in one
+    pass: `branch_clean`, 7 commits, verify_run green, in-loop review clean,
+    $9.13 / 90 K tokens / 1h11. Fixed Revi's finding the right way
+    (refresh-invariant identity: fingerprint stamped at connect/seal,
+    `PledgeID` for pool grants) — notable because the PR author had
+    hand-fixed the finding mid-dogfood and Revi's re-review had STILL found
+    1 high; Billy's ledger disposed of every id with arguments. Then
+    `push_back_tool`: `Invalid username or token` — the sealed GitHub App
+    installation token (minted at launch, ~1h validity) had expired. The 7
+    commits died with the pod; the verdict honestly posted
+    `failure — 3 fix(es) never reached this head`.
+- Value: the habit is real — the hand-off, the one-pass convergence, the
+  honest gate all worked; and the dogfood surfaced defects no test had.
+- Findings / misses: (1) a DEAD second-family credential blocks the whole
+  fixer via `plan_review: auto` + `policy: wait`; (2) `inherit_if_available`
+  wedges forever when the session's backing state died with the container;
+  (3) `push_auth_probe` validates token PRESENCE, not validity (answered
+  `available` with a 10-min-dead token); (4) the launch-minted forge push
+  token cannot outlive the App-token validity, so any >1h fixer run loses
+  its push.
+- Engine/bot hardening (this change): `plan_review_policy` defaults to
+  `skip` for Billy (bot 1.2.1 — the peer is optional enrichment, never a
+  blocker); `Task.SessionOptional` — the executor retries ONCE with a fresh
+  session when an optional session fails to serve (red-first tests). Filed:
+  mint-at-use forge push token + a real auth probe (native:54412d84).
+- Follow-up: a fourth `/billy` was launched right after to re-deliver the
+  lost fixes (its prior_review is the re-review of the current head);
+  outcome to be appended by the session that watches it land.
+- Lessons for next run: keep fixer runs under the App-token validity until
+  mint-at-use lands (tighter `scope_notes`, or `max_duration` < 1h so the
+  budget guard ships what is banked while the token is alive); the usage-cap
+  runbook rotation is CLI-only now (`iterion remote admin llm oauth set` +
+  team `/oauth/{kind}/credentials` — no k8s secret edit, no runner restart);
+  after any `/billy`, `git pull` before touching the branch.
+
 ## 2026-08-13 — the write path on a self-hosted GitLab, end to end (run 019ffb9e)
 
 - Status: **validated.** Every link a fixer needs on a forge that had never

--- a/docs/bot-runs/branch-improve-loop.md
+++ b/docs/bot-runs/branch-improve-loop.md
@@ -54,9 +54,26 @@
   blocker); `Task.SessionOptional` — the executor retries ONCE with a fresh
   session when an optional session fails to serve (red-first tests). Filed:
   mint-at-use forge push token + a real auth probe (native:54412d84).
-- Follow-up: a fourth `/billy` was launched right after to re-deliver the
-  lost fixes (its prior_review is the re-review of the current head);
-  outcome to be appended by the session that watches it land.
+- Follow-up — **both delivery runs landed the same day**:
+  - **Run 4 on #541 (01a0431d, 53 min):** re-derived the lost fixes from the
+    fresh prior_review, converged, **pushed 6 commits** (refresh-invariant
+    OAuth meter identity + tests actually executing the refresh path +
+    operator docs), verdict `success — 3 finding(s) fixed, re-review by the
+    fixer clean, build green` on `556d6f4e`.
+  - **Run 5 on #544 (01a0431e, 1h53):** `/billy` on the habit PR itself for
+    Revi's 3 findings on OUR fixes — **pushed 11 commits** that materially
+    hardened the session-degrade change: loud degrade (event + output
+    stamp, R051957), narrowed to `unclassified` failures (R1486ff),
+    claw node-session eviction, backend gate (only backends that resume by
+    SessionID), the SessionOptional mapping pinned across all six session
+    modes (R552e44), plus docs/ADR alignment — and it improved the habit
+    runbook itself (the `review_on_sync` dependency of step 3).
+  - The 1h53 push succeeding **contradicts** the "App token dies at 1h"
+    hypothesis for run 3's failure; the board card (native:54412d84) was
+    corrected — the standing defect is `push_auth_probe` validating
+    presence, not validity; run 3's root cause is unreproduced (plausible:
+    the integration PATCH 2 min before launch re-provisioned the managed
+    forge_token).
 - Lessons for next run: keep fixer runs under the App-token validity until
   mint-at-use lands (tighter `scope_notes`, or `max_duration` < 1h so the
   budget guard ships what is banked while the token is alive); the usage-cap

--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -200,7 +200,9 @@ run riding the runner's env-fallback credentials gets no injection at
 all — the bots' `auto` default then reads as off, fail-safe.) Mid-run peer-forfait exhaustion follows
 `--var plan_review_policy=wait|skip` (wait = the run parks
 failed_resumable and the usage-window retry resumes it when the window
-reopens; skip = continue without the review, loudly stamped). Gotcha:
+reopens; skip = continue without the review, loudly stamped).
+branch-improve-loop defaults to `skip` — a fixer invoked on a PR must
+never park on its optional peer; the other campaign bots default `wait`. Gotcha:
 the ChatGPT-forfait wire gates models by the codex-cli `version:` header
 — if gpt-5.6 is refused with a model-availability error, set
 `ITERION_CODEX_VERSION` to a recent codex-cli version (gpt-5.5 needed

--- a/docs/revi-billy-loop.md
+++ b/docs/revi-billy-loop.md
@@ -61,6 +61,15 @@ The webhook tail resolves everything from the PR and the repo integration:
    and to you: a contested finding keeps the gate red until a human decides
    (`/revi approve [reason]`, maintainer-gated).
 
+   That third step is **not free** — it needs `review_on_sync` on the repo's
+   webhook config, which is **off by default** (a push is otherwise an
+   on-demand re-review, deliberately budget-frugal). It is the same switch the
+   merge gate needs, so a repo whose `revi/review` is a required check has it
+   on; a repo that only ever auto-reviews on open does not, and Billy's push
+   there ends the loop until someone comments `/revi`. Check it before
+   concluding the loop is broken:
+   `iterion remote api GET /api/teams/<team-id>/webhooks` → `review_on_sync`.
+
 ## Session discipline (the gotchas)
 
 - **Don't work on the PR branch while Billy runs** — he pushes onto it. After

--- a/docs/revi-billy-loop.md
+++ b/docs/revi-billy-loop.md
@@ -1,0 +1,88 @@
+# Revi → Billy on this repo — the operating habit
+
+When Revi (`bots/review-pr`) reviews a pull request of **this repository** and
+leaves findings, the habit is to **comment `/billy` on the PR** and let the
+fixer work — not to hand-fix the findings in an interactive session. iterion is
+a code factory; its own PRs are the first place its review→fix loop must earn
+its keep. Every `/billy` run here is a dogfood run: monitor it, fix the
+frictions it surfaces (bot or engine), and write the bilan.
+
+This runbook is the *habit*; the mechanics live in
+[merge-gate.md](merge-gate.md) (gate, reconciler, two-bots-one-context) and
+[bots/branch-improve-loop/README.md](../bots/branch-improve-loop/README.md)
+(the campaign shape).
+
+## The command
+
+On the PR, comment:
+
+```
+/billy
+```
+
+(aliases: `/improve`, `/branch-improve-loop`; optional free text after the
+command lands in `scope_notes`). The commenter must hold **maintainer+** on the
+repo (`min_replier_role` on the command — verified live via the forge
+permission API, not from the payload).
+
+There is deliberately **no PR-open auto-launch for Billy**: opening a PR only
+ever auto-REVIEWS it (Revi). Billy runs on a deliberate command. The zero-touch
+lane (`auto_fix_on_gate_failure` — a red gate launches the fixer by itself,
+[merge-gate.md#autofix](merge-gate.md#autofix)) is intentionally **not enabled
+on this repo yet**; enabling it is one PATCH on the integration once the manual
+habit has proven smooth here.
+
+## What the command seeds — you type nothing else
+
+The webhook tail resolves everything from the PR and the repo integration:
+
+- **`prior_review`** — the latest review of this PR, findings + ready-made
+  replacements, seeded through the kind-matched hand-off
+  (`consumes: kind: review` in Billy's manifest ←
+  `produces:` in Revi's; [pkg/server/webhooks_handoff.go](../pkg/server/webhooks_handoff.go)).
+  Billy **re-checks every finding against the current diff** rather than
+  trusting a stale verdict, and still runs fine when no review exists.
+- **`push_branch` / `pr_url`** — his commits are pushed onto the PR's source
+  branch, and his finding **ledger** (per finding id: fixed /
+  refused-with-argument / deferred) is posted as a comment ON the PR.
+- **`gate_context` + publish grant** — from the integration's `launch_vars`
+  (`revi/review` here), so he can post his own gate count on the head he
+  pushed.
+
+## What to expect on the PR
+
+1. Billy verifies each prior finding, fixes the real ones **one commit per
+   fix** (build+test before each commit), and pushes onto the PR branch.
+2. He posts the ledger comment and a gate status **on the head he pushed** —
+   a count, never a judgement; a green from Billy says so in its description.
+3. His push is a `synchronize`, so Revi **re-reviews the new head** and its
+   independent verdict supersedes minutes later. A finding Billy contested
+   (with an argument, in the ledger) is handed to the next review as pushback —
+   and to you: a contested finding keeps the gate red until a human decides
+   (`/revi approve [reason]`, maintainer-gated).
+
+## Session discipline (the gotchas)
+
+- **Don't work on the PR branch while Billy runs** — he pushes onto it. After
+  his push, `git pull` before resuming any local work on that branch.
+- **Only invoke him on PRs you own** (or with the author's accord): he rewrites
+  their branch.
+- **Monitor, don't fire-and-forget**: the run console link is on the `pending`
+  gate status; or `iterion remote runs` / the `remote_run_log` MCP tool.
+  Proof of a good run = ledger comment + commits on the branch + gate status
+  on the new head + Revi's re-review landing after it.
+- **He posts nothing?** Check the run's inputs for `forge_publish_url` and
+  `gate_context` before blaming the bot ([merge-gate.md](merge-gate.md)).
+- **Usage caps park runs**: a review or fix run that dies on
+  `usage cap: … window` is `failed_resumable` with the usage-window retry
+  armed — it resumes at the provider reset by itself
+  ([usage-caps.md](usage-caps.md)). Don't relaunch it by hand.
+
+## Dogfood duty
+
+Every `/billy` run on this repo gets a dated bilan in
+[docs/bot-runs/branch-improve-loop.md](bot-runs/branch-improve-loop.md)
+(newest-first — status, method, result, value, frictions, lessons). A friction
+found here is a defect to fix in stride — in the bot
+(`bots/branch-improve-loop/`) or the engine — that is the point of running the
+loop on ourselves.

--- a/pkg/backend/delegate/delegate.go
+++ b/pkg/backend/delegate/delegate.go
@@ -659,6 +659,16 @@ type Task struct {
 	// a new ID and does not mutate the original session.
 	ForkSession bool
 
+	// SessionOptional marks SessionID as best-effort continuity
+	// (session: inherit_if_available / persist): the id resolved on the
+	// upstream output map, but its backing state may no longer load —
+	// a cloud resume replaces the sandbox container, and a CLI backend's
+	// session files die with it. When set, the executor retries a failed
+	// call ONCE with the session dropped (loudly) before walking the
+	// fallback chain; plain `inherit`/`fork` leave it false and keep
+	// failing loudly, since they asked for continuity unconditionally.
+	SessionOptional bool
+
 	// SessionFingerprint carries the provider fingerprint that the
 	// parent SessionID was created against (e.g. "anthropic-direct",
 	// "facade:api.z.ai"). The backend uses it to detect a cross-provider

--- a/pkg/backend/delegate/delegate.go
+++ b/pkg/backend/delegate/delegate.go
@@ -663,10 +663,17 @@ type Task struct {
 	// (session: inherit_if_available / persist): the id resolved on the
 	// upstream output map, but its backing state may no longer load —
 	// a cloud resume replaces the sandbox container, and a CLI backend's
-	// session files die with it. When set, the executor retries a failed
-	// call ONCE with the session dropped (loudly) before walking the
-	// fallback chain; plain `inherit`/`fork` leave it false and keep
-	// failing loudly, since they asked for continuity unconditionally.
+	// session files die with it. Plain `inherit`/`fork` leave it false
+	// and keep failing loudly, since they asked for continuity
+	// unconditionally.
+	//
+	// It is a PERMISSION, not an instruction: the executor MAY retry a
+	// failed call once with the session dropped — loudly (a
+	// `session_degraded` event plus a `_session_degraded` output stamp) —
+	// before walking the fallback chain, but only when the failure is
+	// UNCLASSIFIED and only on a backend that actually resumes with the
+	// id. Both narrowings are argued at model.sessionResumeEligible and
+	// at the dispatch site.
 	SessionOptional bool
 
 	// SessionFingerprint carries the provider fingerprint that the

--- a/pkg/backend/model/executor_build_task.go
+++ b/pkg/backend/model/executor_build_task.go
@@ -202,7 +202,21 @@ func stampDelegateOutputMeta(output map[string]any, result delegate.Result, back
 // Nothing is written on the happy path, so an output that carries these
 // keys always means something actually happened.
 func stampFallbackMeta(output map[string]any, out chainOutcome) {
-	if output == nil || !out.FellThrough {
+	if output == nil {
+		return
+	}
+	// A dropped best-effort session is a degraded INPUT, not a route
+	// change: the node's first-choice backend/model/credential served it
+	// — it just served it amnesiac. So it gets its own key rather than
+	// `_fallback_used`, which a gate reads as "something other than what
+	// I asked for produced this". Both are the same posture though: an
+	// output that carries either key means the node ran degraded, and a
+	// deterministic gate can fail closed on it (see the session_degraded
+	// event for the human-readable half).
+	if out.SessionDegraded {
+		output["_session_degraded"] = true
+	}
+	if !out.FellThrough {
 		return
 	}
 	output["_fallback_used"] = true

--- a/pkg/backend/model/executor_build_task.go
+++ b/pkg/backend/model/executor_build_task.go
@@ -1295,6 +1295,13 @@ func (e *ClawExecutor) applySessionContinuity(task *delegate.Task, f backendFiel
 		if f.session == ir.SessionFork {
 			task.ForkSession = true
 		}
+		// Best-effort modes: the id resolved, but its backing state may be
+		// gone (a cloud resume replaced the sandbox container and the CLI's
+		// session files with it). Mark the session droppable so the
+		// executor can degrade to fresh instead of failing the node forever.
+		if f.session == ir.SessionInheritIfAvailable || f.session == ir.SessionPersist {
+			task.SessionOptional = true
+		}
 		// Forward the provider fingerprint that produced the parent
 		// session so the backend can detect cross-provider forks
 		// (which fail with 400 "Invalid signature in thinking block"

--- a/pkg/backend/model/executor_build_task.go
+++ b/pkg/backend/model/executor_build_task.go
@@ -189,8 +189,10 @@ func stampDelegateOutputMeta(output map[string]any, result delegate.Result, back
 	}
 }
 
-// stampFallbackMeta records, on the node's own output, that the run was
-// served by something other than its first choice.
+// stampFallbackMeta records, on the node's own output, that the node ran
+// DEGRADED — served by something other than its first choice
+// (`_fallback_used` / `_served_by`), or served by its first choice
+// without the session it asked for (`_session_degraded`).
 //
 // This is the half of ADR-087's judge guardrail that a bot can act on.
 // A reviewer served by a weaker model still emits a well-formed verdict

--- a/pkg/backend/model/executor_hooks.go
+++ b/pkg/backend/model/executor_hooks.go
@@ -129,6 +129,19 @@ type ProviderFallbackInfo struct {
 	ToSkip bool
 }
 
+// SessionDegradedInfo describes a best-effort session that could not be
+// resumed, passed to the OnSessionDegraded hook.
+type SessionDegradedInfo struct {
+	BackendName string // backend whose session failed to load
+	SessionID   string // the id that failed to serve
+	// Reason is the delegate.FallbackCategory the failure classified as.
+	// Always "unclassified" today — the degrade fires on nothing else,
+	// deliberately (a typed auth/usage-window/transient failure names a
+	// cause the session had no part in).
+	Reason string
+	Err    error // the failure the dropped session is being blamed for
+}
+
 // EventHooks allows the executor to emit observability events back to the caller.
 type EventHooks struct {
 	OnLLMRequest    func(nodeID string, info LLMRequestInfo)
@@ -179,6 +192,14 @@ type EventHooks struct {
 	// provider — and lets the studio / Prometheus exporter surface that
 	// a credential route was exhausted without the run itself failing.
 	OnProviderFallback func(nodeID string, info ProviderFallbackInfo)
+
+	// OnSessionDegraded fires when a best-effort session
+	// (`session: inherit_if_available` / `persist`) failed to serve and
+	// the call was re-run with the session dropped. Purely observational
+	// — the node goes on to succeed — but it is the ONLY thing that puts
+	// "this node ran without the conversation it asked for" in the run
+	// record; the process log alone leaves a downstream gate blind.
+	OnSessionDegraded func(nodeID string, info SessionDegradedInfo)
 
 	// OnNodeFinished fires after a node's executor returns successfully.
 	// The output map carries iterion's conventional usage keys (`_tokens`,
@@ -246,6 +267,7 @@ func ChainHooks(a, b EventHooks) EventHooks {
 		OnDelegateError:    chainCb2(a.OnDelegateError, b.OnDelegateError),
 		OnDelegateRetry:    chainCb2(a.OnDelegateRetry, b.OnDelegateRetry),
 		OnProviderFallback: chainCb2(a.OnProviderFallback, b.OnProviderFallback),
+		OnSessionDegraded:  chainCb2(a.OnSessionDegraded, b.OnSessionDegraded),
 		OnNodeFinished:     chainCb2(a.OnNodeFinished, b.OnNodeFinished),
 	}
 }

--- a/pkg/backend/model/executor_retry.go
+++ b/pkg/backend/model/executor_retry.go
@@ -906,7 +906,15 @@ func (e *ClawExecutor) dispatchChain(
 		causes = append(causes, err)
 
 		if ctx.Err() != nil {
-			return chainOutcome{Result: result, BackendName: backendName}, err
+			// Cancellation is terminal for the node, but it does not
+			// un-spend what the abandoned attempts already burned: fold
+			// `spent` in here exactly as the exhausted-chain tail does.
+			// Dropping it under-reported an abandoned route's tokens and
+			// cost to max_cost_usd, the org monthly cap and a lending
+			// donor's ledger — and the optional-session degrade made that
+			// reachable on a SINGLE-route node, where `spent` used to be
+			// provably empty at this point.
+			return chainOutcome{Result: spent.applyTo(result), BackendName: backendName}, err
 		}
 		cat := delegate.ClassifyFallback(err, isDelegateRetryable(err))
 		lastCat = cat

--- a/pkg/backend/model/executor_retry.go
+++ b/pkg/backend/model/executor_retry.go
@@ -661,6 +661,14 @@ type chainOutcome struct {
 	// zero-value output (only the caller knows the schema). Result carries
 	// the failed routes' accumulated spend, never content.
 	Skipped bool
+	// SessionDegraded reports that the element that served did so only
+	// after its best-effort session (`session: inherit_if_available` /
+	// `persist`) failed to load and was dropped — the node completed
+	// WITHOUT the conversation it asked for. It exists for the same
+	// reason as FellThrough: a deterministic gate must be able to fail
+	// closed on a degraded input, and an amnesiac node's output is
+	// well-formed in every other respect.
+	SessionDegraded bool
 }
 
 // dispatchChain walks a node's fallback chain, building each element
@@ -856,13 +864,12 @@ func (e *ClawExecutor) dispatchChain(
 		// would buy a SECOND full retry budget (backoff included) under
 		// a provider outage and silently discard continuity for an
 		// unrelated cause (R1486ff).
+		sessionDegraded := false
 		if err != nil && ctx.Err() == nil && task.SessionOptional && task.SessionID != "" {
-			switch delegate.ClassifyFallback(err, isDelegateRetryable(err)) {
+			switch cat := delegate.ClassifyFallback(err, isDelegateRetryable(err)); cat {
 			case delegate.FallbackUnclassified:
-				if e.logger != nil {
-					e.logger.Warn("[%s#%d/%s] optional session %s failed to serve (%v) — retrying once with a FRESH session; the node will not see the upstream conversation",
-						nodeID, LoopIterationFromContext(ctx), backendName, task.SessionID, err)
-				}
+				e.noteSessionDegrade(ctx, nodeID, backendName, task.SessionID, cat, err)
+				sessionDegraded = true
 				spent.add(result)
 				// Dropping task.SessionID is not enough to make the retry
 				// fresh: a claw node's conversation lives in the
@@ -887,12 +894,13 @@ func (e *ClawExecutor) dispatchChain(
 		}
 		if err == nil {
 			return chainOutcome{
-				Result:      spent.applyTo(result),
-				BackendName: backendName,
-				Backend:     backend,
-				Task:        task,
-				ServedBy:    stepLabel(el),
-				FellThrough: i > 0,
+				Result:          spent.applyTo(result),
+				BackendName:     backendName,
+				Backend:         backend,
+				Task:            task,
+				ServedBy:        stepLabel(el),
+				FellThrough:     i > 0,
+				SessionDegraded: sessionDegraded,
 			}, nil
 		}
 		causes = append(causes, err)
@@ -1067,6 +1075,36 @@ func (e *ClawExecutor) noteFallback(
 		Attempts:    e.retry.maxAttempts(),
 		Err:         err,
 		ToSkip:      to.Skip,
+	})
+}
+
+// noteSessionDegrade emits the one log line and the one hook that make a
+// dropped best-effort session visible.
+//
+// A degrade is not a route change — the same backend, model and
+// credential serve the retry — so it is deliberately NOT a
+// model_fallback: what changed is the node's INPUT, which now lacks the
+// conversation its `session:` field asked for. That is the whole reason
+// it needs a record of its own; the node goes on to complete
+// successfully and would otherwise read as a clean pass.
+func (e *ClawExecutor) noteSessionDegrade(
+	ctx context.Context,
+	nodeID, backendName, sessionID string,
+	cat delegate.FallbackCategory,
+	err error,
+) {
+	if e.logger != nil {
+		e.logger.Warn("[%s#%d/%s] optional session %s failed to serve (%v) — retrying once with a FRESH session; the node will not see the upstream conversation",
+			nodeID, LoopIterationFromContext(ctx), backendName, sessionID, err)
+	}
+	if e.hooks.OnSessionDegraded == nil {
+		return
+	}
+	e.hooks.OnSessionDegraded(nodeID, SessionDegradedInfo{
+		BackendName: backendName,
+		SessionID:   sessionID,
+		Reason:      string(cat),
+		Err:         err,
 	})
 }
 

--- a/pkg/backend/model/executor_retry.go
+++ b/pkg/backend/model/executor_retry.go
@@ -308,6 +308,45 @@ func providerFallbackEligible(backendName string) bool {
 	return backendName == delegate.BackendClaudeCode
 }
 
+// sessionResumeBackends are the backends that actually CONSUME
+// Task.SessionID to resume a conversation. Membership is a property of
+// the code, verified per backend, not a guess:
+//
+//	claude_code — claudesdk.WithResume(task.SessionID)
+//	codex       — codexsdk.WithResume(task.SessionID)
+//	pi          — `--session-id` / `--fork <id>`
+//
+// Everyone else only ever REPORTS a session id and never resumes one:
+// claw never mentions Task.SessionID at all (its conversation lives in
+// the host's (runID, nodeID) store and is replayed independently), and
+// the generic CLI-agent path behind kimi/grok parses an id out of the
+// CLI's output without ever passing one back in.
+//
+// Deliberately its own set rather than a reuse of
+// providerFallbackEligible: that one answers "does this backend honour
+// the provider HINT", a different question with a different answer.
+var sessionResumeBackends = map[string]bool{
+	delegate.BackendClaudeCode: true,
+	delegate.BackendCodex:      true,
+	delegate.BackendPi:         true,
+}
+
+// sessionResumeEligible reports whether dropping Task.SessionID can
+// plausibly change the outcome of a retry on this backend.
+//
+// It gates the optional-session degrade for the same reason
+// collapseHintOnlyChain trims a hint-only chain: on a backend that
+// ignores the id, the "fresh" retry is a byte-identical call that will
+// fail identically, so the degrade would be a whole wasted agentic turn
+// — and it would evict the node's accumulated conversation on the way,
+// destroying real state for a failure the session had no part in. Under
+// the shipped `sandbox: auto` that is not a corner case: a sandboxed
+// claw failure flattens to a string at the __claw-runner IPC boundary
+// and classifies UNCLASSIFIED, so EVERY such failure would qualify.
+func sessionResumeEligible(backendName string) bool {
+	return sessionResumeBackends[backendName]
+}
+
 // chainIsHintOnly reports whether every element defers to the node's
 // resolved backend — i.e. the chain can only swap a credential, never
 // re-shape the task. That is exactly the legacy `provider:` chain
@@ -865,7 +904,8 @@ func (e *ClawExecutor) dispatchChain(
 		// a provider outage and silently discard continuity for an
 		// unrelated cause (R1486ff).
 		sessionDegraded := false
-		if err != nil && ctx.Err() == nil && task.SessionOptional && task.SessionID != "" {
+		if err != nil && ctx.Err() == nil && task.SessionOptional && task.SessionID != "" &&
+			sessionResumeEligible(backendName) {
 			switch cat := delegate.ClassifyFallback(err, isDelegateRetryable(err)); cat {
 			case delegate.FallbackUnclassified:
 				e.noteSessionDegrade(ctx, nodeID, backendName, task.SessionID, cat, err)

--- a/pkg/backend/model/executor_retry.go
+++ b/pkg/backend/model/executor_retry.go
@@ -842,13 +842,23 @@ func (e *ClawExecutor) dispatchChain(
 		// session files die with it, after which every resume of this node
 		// fails identically (lived on branch-improve-loop's plan_revise:
 		// error_during_execution in ~2.6s, forever). "If available" covers
-		// that too: retry ONCE with the session dropped, loudly. Only for
-		// execution-shaped failures — an auth/usage-window/unavailable
-		// failure is credential- or model-level and a fresh session would
-		// hit the same wall.
+		// that too: retry ONCE with the session dropped, loudly.
+		//
+		// UNCLASSIFIED only. That is where a dead session lands — the
+		// backend refused to load it and said nothing typed about why —
+		// and, being non-retryable, it makes the fresh attempt a single
+		// extra call. Every other category names a cause the session is
+		// not: auth / usage_window / unavailable are credential- or
+		// model-level (a fresh session hits the same wall), and
+		// transient_exhausted is by construction "isDelegateRetryable
+		// said yes and the budget ran out" — a throttle, a 5xx, a TCP
+		// blip, none of which the session id caused. Degrading there
+		// would buy a SECOND full retry budget (backoff included) under
+		// a provider outage and silently discard continuity for an
+		// unrelated cause (R1486ff).
 		if err != nil && ctx.Err() == nil && task.SessionOptional && task.SessionID != "" {
 			switch delegate.ClassifyFallback(err, isDelegateRetryable(err)) {
-			case delegate.FallbackUnclassified, delegate.FallbackTransientExhausted:
+			case delegate.FallbackUnclassified:
 				if e.logger != nil {
 					e.logger.Warn("[%s#%d/%s] optional session %s failed to serve (%v) — retrying once with a FRESH session; the node will not see the upstream conversation",
 						nodeID, LoopIterationFromContext(ctx), backendName, task.SessionID, err)

--- a/pkg/backend/model/executor_retry.go
+++ b/pkg/backend/model/executor_retry.go
@@ -854,6 +854,14 @@ func (e *ClawExecutor) dispatchChain(
 						nodeID, LoopIterationFromContext(ctx), backendName, task.SessionID, err)
 				}
 				spent.add(result)
+				// Dropping task.SessionID is not enough to make the retry
+				// fresh: a claw node's conversation lives in the
+				// (runID, nodeID) session store and is replayed regardless
+				// of the id (claw_backend's session_replay envelope). Left
+				// in place it would re-send the FAILED attempt's messages
+				// into the "fresh" call — the exact hazard the route-change
+				// path evicts for — and make the log line above a lie.
+				e.evictNodeSessionForFallback(ctx, nodeID)
 				fresh := *task
 				fresh.SessionID = ""
 				fresh.ForkSession = false

--- a/pkg/backend/model/executor_retry.go
+++ b/pkg/backend/model/executor_retry.go
@@ -836,6 +836,37 @@ func (e *ClawExecutor) dispatchChain(
 		result, err = e.retryDelegateLoopChain(ctx, nodeID, backendName, accepts, func() (delegate.Result, error) {
 			return backend.Execute(ctx, *task)
 		})
+		// Best-effort session degrade (inherit_if_available / persist): the
+		// upstream session id resolved, but its backing state can be gone —
+		// a cloud resume replaces the sandbox container and a CLI backend's
+		// session files die with it, after which every resume of this node
+		// fails identically (lived on branch-improve-loop's plan_revise:
+		// error_during_execution in ~2.6s, forever). "If available" covers
+		// that too: retry ONCE with the session dropped, loudly. Only for
+		// execution-shaped failures — an auth/usage-window/unavailable
+		// failure is credential- or model-level and a fresh session would
+		// hit the same wall.
+		if err != nil && ctx.Err() == nil && task.SessionOptional && task.SessionID != "" {
+			switch delegate.ClassifyFallback(err, isDelegateRetryable(err)) {
+			case delegate.FallbackUnclassified, delegate.FallbackTransientExhausted:
+				if e.logger != nil {
+					e.logger.Warn("[%s#%d/%s] optional session %s failed to serve (%v) — retrying once with a FRESH session; the node will not see the upstream conversation",
+						nodeID, LoopIterationFromContext(ctx), backendName, task.SessionID, err)
+				}
+				spent.add(result)
+				fresh := *task
+				fresh.SessionID = ""
+				fresh.ForkSession = false
+				fresh.SessionFingerprint = ""
+				freshResult, freshErr := e.retryDelegateLoopChain(ctx, nodeID, backendName, accepts, func() (delegate.Result, error) {
+					return backend.Execute(ctx, fresh)
+				})
+				if freshErr == nil {
+					task = &fresh
+				}
+				result, err = freshResult, freshErr
+			}
+		}
 		if err == nil {
 			return chainOutcome{
 				Result:      spent.applyTo(result),

--- a/pkg/backend/model/executor_retry.go
+++ b/pkg/backend/model/executor_retry.go
@@ -911,13 +911,17 @@ func (e *ClawExecutor) dispatchChain(
 				e.noteSessionDegrade(ctx, nodeID, backendName, task.SessionID, cat, err)
 				sessionDegraded = true
 				spent.add(result)
-				// Dropping task.SessionID is not enough to make the retry
-				// fresh: a claw node's conversation lives in the
-				// (runID, nodeID) session store and is replayed regardless
-				// of the id (claw_backend's session_replay envelope). Left
-				// in place it would re-send the FAILED attempt's messages
-				// into the "fresh" call — the exact hazard the route-change
-				// path evicts for — and make the log line above a lie.
+				// Dropping task.SessionID is not, by itself, enough to
+				// make the retry fresh. The (runID, nodeID) claw store is
+				// replayed independently of the id (claw_backend's
+				// session_replay envelope), and it is keyed by NODE, not
+				// by element or iteration — so a node that ran on claw
+				// earlier in its chain, or in an earlier loop pass, can
+				// still hold messages that would be replayed into the call
+				// this event just announced as FRESH. sessionResumeEligible
+				// keeps the degrade off claw itself, so this is the guard
+				// for that residue, on the same terms the route-change path
+				// evicts for.
 				e.evictNodeSessionForFallback(ctx, nodeID)
 				fresh := *task
 				fresh.SessionID = ""

--- a/pkg/backend/model/hooks.go
+++ b/pkg/backend/model/hooks.go
@@ -950,6 +950,32 @@ func (h *storeHooks) onDelegateRetry(nodeID string, info DelegateInfo) {
 		nodeID, info.BackendName, info.Attempt, info.Delay.Milliseconds(), errMsg)
 }
 
+// onSessionDegraded implements the OnSessionDegraded hook: it turns a
+// dropped best-effort session into a first-class store event.
+//
+// Warn-level: the node is about to succeed, but it succeeds AMNESIAC —
+// it lost the conversation its `session:` field asked for. That is a
+// fact about the node's input quality, and the only other trace is a
+// process log line nobody reads after the fact.
+func (h *storeHooks) onSessionDegraded(nodeID string, info SessionDegradedInfo) {
+	data := map[string]any{
+		"backend":    info.BackendName,
+		"session_id": info.SessionID,
+		"reason":     info.Reason,
+	}
+	if info.Err != nil {
+		data["error"] = info.Err.Error()
+	}
+	h.emit(nodeID, store.EventSessionDegraded, data)
+
+	errMsg := ""
+	if info.Err != nil {
+		errMsg = info.Err.Error()
+	}
+	h.logger.Warn("Session degraded [%s]: %s could not resume session %s (%s) — the node runs FRESH, without the conversation it asked for: %s",
+		nodeID, info.BackendName, info.SessionID, info.Reason, errMsg)
+}
+
 // onProviderFallback implements the OnProviderFallback hook: it turns a
 // chain fall-through into a first-class store event.
 //
@@ -1141,6 +1167,7 @@ func NewStoreEventHooks(ctx context.Context, emitter EventEmitter, runID string,
 		OnDelegateError:    h.onDelegateError,
 		OnDelegateRetry:    h.onDelegateRetry,
 		OnProviderFallback: h.onProviderFallback,
+		OnSessionDegraded:  h.onSessionDegraded,
 		// OnToolNodeResult handles direct tool nodes with full I/O content.
 		OnToolNodeResult: h.onToolNodeResult,
 	}

--- a/pkg/backend/model/session_continuity_modes_test.go
+++ b/pkg/backend/model/session_continuity_modes_test.go
@@ -1,0 +1,68 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+)
+
+// TestApplySessionContinuityMarksOptionalModes pins the three lines that
+// decide whether a node's session is droppable at all. Without them the
+// executor's degrade is unreachable and branch-improve-loop's plan_revise
+// returns to wedging on a dead session across a cloud resume — every
+// other test in the tree hand-builds delegate.Task{SessionOptional: …},
+// so a refactor that dropped or narrowed the mapping stayed green
+// (R552e44).
+func TestApplySessionContinuityMarksOptionalModes(t *testing.T) {
+	cases := []struct {
+		mode         ir.SessionMode
+		wantID       bool // does the mode inherit the upstream id at all?
+		wantOptional bool
+		wantFork     bool
+	}{
+		// Best-effort: the id resolved, but its backing state may be gone.
+		{ir.SessionInheritIfAvailable, true, true, false},
+		{ir.SessionPersist, true, true, false},
+		// Unconditional continuity: a failure keeps failing loudly.
+		{ir.SessionInherit, true, false, false},
+		{ir.SessionFork, true, false, true},
+		// Modes that carry no upstream session at all.
+		{ir.SessionFresh, false, false, false},
+		{ir.SessionArtifactsOnly, false, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.mode.String(), func(t *testing.T) {
+			e := &ClawExecutor{}
+			task := &delegate.Task{}
+			e.applySessionContinuity(task, backendFields{id: "plan_revise", session: c.mode}, map[string]any{
+				"_session_id":          "upstream-session",
+				"_session_fingerprint": "anthropic-direct",
+			})
+			if got := task.SessionID != ""; got != c.wantID {
+				t.Fatalf("SessionID set = %v, want %v", got, c.wantID)
+			}
+			if task.SessionOptional != c.wantOptional {
+				t.Errorf("SessionOptional = %v, want %v", task.SessionOptional, c.wantOptional)
+			}
+			if task.ForkSession != c.wantFork {
+				t.Errorf("ForkSession = %v, want %v", task.ForkSession, c.wantFork)
+			}
+		})
+	}
+}
+
+// A best-effort mode with NO upstream id must not claim a droppable
+// session: there is nothing to drop, and the stamp would make a plain
+// fresh node look degraded.
+func TestApplySessionContinuityNoIDLeavesOptionalClear(t *testing.T) {
+	for _, mode := range []ir.SessionMode{ir.SessionInheritIfAvailable, ir.SessionPersist} {
+		e := &ClawExecutor{}
+		task := &delegate.Task{}
+		e.applySessionContinuity(task, backendFields{id: "plan_revise", session: mode}, map[string]any{})
+		if task.SessionOptional || task.SessionID != "" {
+			t.Errorf("%s with no upstream id: SessionOptional=%v SessionID=%q, want clear",
+				mode, task.SessionOptional, task.SessionID)
+		}
+	}
+}

--- a/pkg/backend/model/session_optional_degrade_test.go
+++ b/pkg/backend/model/session_optional_degrade_test.go
@@ -116,3 +116,31 @@ func TestOptionalSessionAuthFailureDoesNotDegrade(t *testing.T) {
 		}
 	}
 }
+
+// TestOptionalSessionDegradeEvictsNodeSession: dropping task.SessionID
+// only makes the retry fresh for a backend that keys continuity on the
+// id. A claw node's conversation lives in the (runID, nodeID) session
+// store and is replayed regardless — including the FAILED attempt's
+// messages — so the degrade must evict it, exactly as the route-change
+// path does, or the "FRESH session" it logs is not fresh at all.
+func TestOptionalSessionDegradeEvictsNodeSession(t *testing.T) {
+	const runID, nodeID = "run-1", "plan_revise"
+	sessions := newNodeSessionStore()
+	if err := sessions.SaveSnapshot(runID, nodeID, []byte(`[{"role":"assistant"}]`)); err != nil {
+		t.Fatalf("seed snapshot: %v", err)
+	}
+	if sessions.LoadSnapshot(runID, nodeID) == nil {
+		t.Fatal("precondition: snapshot not stored")
+	}
+	ctx := withRuntimeContext(context.Background(), runID, sessions)
+
+	e, _, chain := sessionDegradeExecutor(errors.New("delegate: claude-code error: subtype=error_during_execution"))
+	build := e.newElementBuilder(nodeID, delegate.BackendClaudeCode, nil, sessionDegradeBuilder(e, true))
+
+	if _, err := e.dispatchChain(ctx, nodeID, chain, "claude-opus-5", build); err != nil {
+		t.Fatalf("optional session should degrade to fresh, got: %v", err)
+	}
+	if snap := sessions.LoadSnapshot(runID, nodeID); snap != nil {
+		t.Errorf("the dead session's conversation survived the degrade: %s", snap)
+	}
+}

--- a/pkg/backend/model/session_optional_degrade_test.go
+++ b/pkg/backend/model/session_optional_degrade_test.go
@@ -233,3 +233,55 @@ func TestCleanPassStampsNoSessionDegrade(t *testing.T) {
 		t.Errorf("clean pass stamped _session_degraded: %v", stamped)
 	}
 }
+
+// cancellingDegradeBackend fails the session-carrying attempt after
+// spending real tokens, then cancels the run during the fresh retry.
+type cancellingDegradeBackend struct {
+	cancel context.CancelFunc
+	fail   error
+	calls  int
+}
+
+func (b *cancellingDegradeBackend) Execute(ctx context.Context, task delegate.Task) (delegate.Result, error) {
+	b.calls++
+	if task.SessionID != "" {
+		return delegate.Result{
+			BackendName: delegate.BackendClaudeCode,
+			Tokens:      500,
+			Output:      map[string]any{"_tokens": 500, "_cost_usd": 1.25},
+		}, b.fail
+	}
+	b.cancel()
+	return delegate.Result{BackendName: delegate.BackendClaudeCode}, ctx.Err()
+}
+
+// TestOptionalSessionDegradeKeepsSpendOnCancel: cancellation is terminal
+// for the node but does not un-spend what the abandoned attempt burned.
+// The degrade made this reachable on a SINGLE-route node — where the
+// accumulator used to be provably empty at the cancel return — so a
+// cancel during the fresh retry silently dropped the first attempt's
+// tokens and cost from max_cost_usd, the org monthly cap and a lending
+// donor's ledger.
+func TestOptionalSessionDegradeKeepsSpendOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	be := &cancellingDegradeBackend{
+		cancel: cancel,
+		fail:   errors.New("delegate: claude-code error: subtype=error_during_execution"),
+	}
+	reg := delegate.NewRegistry()
+	reg.Register(delegate.BackendClaudeCode, be)
+	e := newFallbackExecutor(reg, EventHooks{})
+	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(e, true))
+
+	out, err := e.dispatchChain(ctx, "plan_revise", []chainElement{{Label: "primary"}}, "claude-opus-5", build)
+	if err == nil {
+		t.Fatal("a cancelled fresh retry must surface the cancellation")
+	}
+	if be.calls != 2 {
+		t.Fatalf("want 2 attempts (dead session, then fresh), got %d", be.calls)
+	}
+	if out.Result.Tokens != 500 {
+		t.Errorf("the abandoned attempt's tokens were dropped on cancel: %d", out.Result.Tokens)
+	}
+}

--- a/pkg/backend/model/session_optional_degrade_test.go
+++ b/pkg/backend/model/session_optional_degrade_test.go
@@ -1,0 +1,118 @@
+package model
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+)
+
+// sessionPickyBackend fails any task that carries a SessionID and
+// succeeds on a fresh one — the shape of a CLI backend whose session
+// files died with the sandbox container (a cloud resume replaces the
+// container, `claude --resume <id>` then errors on every attempt).
+type sessionPickyBackend struct {
+	name  string
+	fail  error
+	tasks []delegate.Task
+}
+
+func (b *sessionPickyBackend) Execute(_ context.Context, task delegate.Task) (delegate.Result, error) {
+	b.tasks = append(b.tasks, task)
+	res := delegate.Result{
+		BackendName: b.name,
+		Duration:    time.Millisecond,
+		Output:      map[string]any{"ok": true},
+	}
+	if task.SessionID != "" {
+		return delegate.Result{BackendName: b.name, Duration: time.Millisecond}, b.fail
+	}
+	return res, nil
+}
+
+func sessionDegradeExecutor(fail error) (*ClawExecutor, *sessionPickyBackend, []chainElement) {
+	be := &sessionPickyBackend{name: delegate.BackendClaudeCode, fail: fail}
+	reg := delegate.NewRegistry()
+	reg.Register(delegate.BackendClaudeCode, be)
+	e := newFallbackExecutor(reg, EventHooks{})
+	return e, be, []chainElement{{Label: "primary"}}
+}
+
+func sessionDegradeBuilder(e *ClawExecutor, optional bool) func(context.Context, string) (*delegate.Task, error) {
+	return func(_ context.Context, _ string) (*delegate.Task, error) {
+		return &delegate.Task{
+			NodeID:          "plan_revise",
+			Model:           "claude-opus-5",
+			SessionID:       "dead-session",
+			SessionOptional: optional,
+		}, nil
+	}
+}
+
+// TestOptionalSessionDegradesToFresh pins the inherit_if_available
+// contract past the resume boundary: when the upstream session id
+// resolves but its backing state no longer loads, the executor retries
+// ONCE with the session dropped instead of failing the node forever
+// (lived on branch-improve-loop's plan_revise: error_during_execution
+// in ~2.6s on every resume, run wedged).
+func TestOptionalSessionDegradesToFresh(t *testing.T) {
+	e, be, chain := sessionDegradeExecutor(errors.New("delegate: claude-code error: subtype=error_during_execution"))
+	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(e, true))
+
+	out, err := e.dispatchChain(context.Background(), "plan_revise", chain, "claude-opus-5", build)
+	if err != nil {
+		t.Fatalf("optional session should degrade to fresh, got: %v", err)
+	}
+	if len(be.tasks) != 2 {
+		t.Fatalf("want 2 attempts (resume, then fresh), got %d", len(be.tasks))
+	}
+	if be.tasks[0].SessionID != "dead-session" {
+		t.Errorf("first attempt should carry the session id, got %q", be.tasks[0].SessionID)
+	}
+	if be.tasks[1].SessionID != "" || be.tasks[1].ForkSession || be.tasks[1].SessionFingerprint != "" {
+		t.Errorf("fresh retry must drop every session field, got %+v", be.tasks[1])
+	}
+	if got := out.Result.Output["ok"]; got != true {
+		t.Errorf("fresh attempt's output lost: %v", out.Result.Output)
+	}
+}
+
+// TestRequiredSessionDoesNotDegrade: plain `inherit`/`fork` asked for
+// continuity unconditionally — a failure keeps failing loudly.
+func TestRequiredSessionDoesNotDegrade(t *testing.T) {
+	e, be, chain := sessionDegradeExecutor(errors.New("delegate: claude-code error: subtype=error_during_execution"))
+	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(e, false))
+
+	if _, err := e.dispatchChain(context.Background(), "plan_revise", chain, "claude-opus-5", build); err == nil {
+		t.Fatal("required session must not degrade to fresh")
+	}
+	for _, task := range be.tasks {
+		if task.SessionID == "" {
+			t.Fatal("required session was retried fresh")
+		}
+	}
+}
+
+// TestOptionalSessionAuthFailureDoesNotDegrade: an auth/usage-window
+// failure is credential-level — a fresh session hits the same wall, so
+// the typed error must surface promptly instead of paying a blind retry.
+func TestOptionalSessionAuthFailureDoesNotDegrade(t *testing.T) {
+	e, be, chain := sessionDegradeExecutor(&delegate.ErrAuthFailed{Provider: delegate.BackendClaudeCode, Detail: "401"})
+	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(e, true))
+
+	_, err := e.dispatchChain(context.Background(), "plan_revise", chain, "claude-opus-5", build)
+	if err == nil {
+		t.Fatal("auth failure must surface, not degrade")
+	}
+	var authErr *delegate.ErrAuthFailed
+	if !errors.As(err, &authErr) {
+		t.Fatalf("typed auth error lost: %v", err)
+	}
+	for _, task := range be.tasks {
+		if task.SessionID == "" {
+			t.Fatal("auth failure must not trigger the fresh-session retry")
+		}
+	}
+}

--- a/pkg/backend/model/session_optional_degrade_test.go
+++ b/pkg/backend/model/session_optional_degrade_test.go
@@ -40,7 +40,7 @@ func sessionDegradeExecutor(fail error) (*ClawExecutor, *sessionPickyBackend, []
 	return e, be, []chainElement{{Label: "primary"}}
 }
 
-func sessionDegradeBuilder(e *ClawExecutor, optional bool) func(context.Context, string) (*delegate.Task, error) {
+func sessionDegradeBuilder(optional bool) func(context.Context, string) (*delegate.Task, error) {
 	return func(_ context.Context, _ string) (*delegate.Task, error) {
 		return &delegate.Task{
 			NodeID:          "plan_revise",
@@ -59,7 +59,7 @@ func sessionDegradeBuilder(e *ClawExecutor, optional bool) func(context.Context,
 // in ~2.6s on every resume, run wedged).
 func TestOptionalSessionDegradesToFresh(t *testing.T) {
 	e, be, chain := sessionDegradeExecutor(errors.New("delegate: claude-code error: subtype=error_during_execution"))
-	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(e, true))
+	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(true))
 
 	out, err := e.dispatchChain(context.Background(), "plan_revise", chain, "claude-opus-5", build)
 	if err != nil {
@@ -83,7 +83,7 @@ func TestOptionalSessionDegradesToFresh(t *testing.T) {
 // continuity unconditionally — a failure keeps failing loudly.
 func TestRequiredSessionDoesNotDegrade(t *testing.T) {
 	e, be, chain := sessionDegradeExecutor(errors.New("delegate: claude-code error: subtype=error_during_execution"))
-	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(e, false))
+	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(false))
 
 	if _, err := e.dispatchChain(context.Background(), "plan_revise", chain, "claude-opus-5", build); err == nil {
 		t.Fatal("required session must not degrade to fresh")
@@ -100,7 +100,7 @@ func TestRequiredSessionDoesNotDegrade(t *testing.T) {
 // the typed error must surface promptly instead of paying a blind retry.
 func TestOptionalSessionAuthFailureDoesNotDegrade(t *testing.T) {
 	e, be, chain := sessionDegradeExecutor(&delegate.ErrAuthFailed{Provider: delegate.BackendClaudeCode, Detail: "401"})
-	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(e, true))
+	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(true))
 
 	_, err := e.dispatchChain(context.Background(), "plan_revise", chain, "claude-opus-5", build)
 	if err == nil {
@@ -135,7 +135,7 @@ func TestOptionalSessionDegradeEvictsNodeSession(t *testing.T) {
 	ctx := withRuntimeContext(context.Background(), runID, sessions)
 
 	e, _, chain := sessionDegradeExecutor(errors.New("delegate: claude-code error: subtype=error_during_execution"))
-	build := e.newElementBuilder(nodeID, delegate.BackendClaudeCode, nil, sessionDegradeBuilder(e, true))
+	build := e.newElementBuilder(nodeID, delegate.BackendClaudeCode, nil, sessionDegradeBuilder(true))
 
 	if _, err := e.dispatchChain(ctx, nodeID, chain, "claude-opus-5", build); err != nil {
 		t.Fatalf("optional session should degrade to fresh, got: %v", err)
@@ -154,7 +154,7 @@ func TestOptionalSessionDegradeEvictsNodeSession(t *testing.T) {
 func TestOptionalSessionTransientFailureDoesNotDegrade(t *testing.T) {
 	e, be, chain := sessionDegradeExecutor(&delegate.ErrTransient{Reason: "upstream 503"})
 	e.retry.MaxAttempts = 1 // exhaust the budget on the first call
-	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(e, true))
+	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(true))
 
 	if _, err := e.dispatchChain(context.Background(), "plan_revise", chain, "claude-opus-5", build); err == nil {
 		t.Fatal("a transient provider failure must surface, not degrade the session")
@@ -184,7 +184,7 @@ func TestOptionalSessionDegradeIsRunVisible(t *testing.T) {
 		OnSessionDegraded: func(_ string, info SessionDegradedInfo) { seen = append(seen, info) },
 	})
 	chain := []chainElement{{Label: "primary"}}
-	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(e, true))
+	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(true))
 
 	out, err := e.dispatchChain(context.Background(), "plan_revise", chain, "claude-opus-5", build)
 	if err != nil {
@@ -272,7 +272,7 @@ func TestOptionalSessionDegradeKeepsSpendOnCancel(t *testing.T) {
 	reg := delegate.NewRegistry()
 	reg.Register(delegate.BackendClaudeCode, be)
 	e := newFallbackExecutor(reg, EventHooks{})
-	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(e, true))
+	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(true))
 
 	out, err := e.dispatchChain(ctx, "plan_revise", []chainElement{{Label: "primary"}}, "claude-opus-5", build)
 	if err == nil {
@@ -313,7 +313,7 @@ func TestOptionalSessionDegradeSkipsBackendsThatIgnoreTheID(t *testing.T) {
 			reg := delegate.NewRegistry()
 			reg.Register(backendName, be)
 			e := newFallbackExecutor(reg, EventHooks{})
-			build := e.newElementBuilder(nodeID, backendName, nil, sessionDegradeBuilder(e, true))
+			build := e.newElementBuilder(nodeID, backendName, nil, sessionDegradeBuilder(true))
 
 			if _, err := e.dispatchChain(ctx, nodeID, []chainElement{{Label: "primary"}}, "some-model", build); err == nil {
 				t.Fatal("a backend that ignores the session id cannot be rescued by dropping it")

--- a/pkg/backend/model/session_optional_degrade_test.go
+++ b/pkg/backend/model/session_optional_degrade_test.go
@@ -165,3 +165,71 @@ func TestOptionalSessionTransientFailureDoesNotDegrade(t *testing.T) {
 		}
 	}
 }
+
+// TestOptionalSessionDegradeIsRunVisible: the node SUCCEEDS having lost
+// the conversation its `session:` field asked for. A process log line is
+// not a run record — without a stamp on the output a downstream
+// deterministic gate cannot fail closed on the amnesiac input, and
+// without an event nothing in the timeline says the node started blank
+// (R051957).
+func TestOptionalSessionDegradeIsRunVisible(t *testing.T) {
+	var seen []SessionDegradedInfo
+	be := &sessionPickyBackend{
+		name: delegate.BackendClaudeCode,
+		fail: errors.New("delegate: claude-code error: subtype=error_during_execution"),
+	}
+	reg := delegate.NewRegistry()
+	reg.Register(delegate.BackendClaudeCode, be)
+	e := newFallbackExecutor(reg, EventHooks{
+		OnSessionDegraded: func(_ string, info SessionDegradedInfo) { seen = append(seen, info) },
+	})
+	chain := []chainElement{{Label: "primary"}}
+	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(e, true))
+
+	out, err := e.dispatchChain(context.Background(), "plan_revise", chain, "claude-opus-5", build)
+	if err != nil {
+		t.Fatalf("optional session should degrade to fresh, got: %v", err)
+	}
+	if len(seen) != 1 {
+		t.Fatalf("want exactly 1 session-degrade event, got %d", len(seen))
+	}
+	if seen[0].SessionID != "dead-session" || seen[0].BackendName != delegate.BackendClaudeCode {
+		t.Errorf("event does not name the session that failed: %+v", seen[0])
+	}
+	if seen[0].Reason != string(delegate.FallbackUnclassified) || seen[0].Err == nil {
+		t.Errorf("event lost the reason/cause: %+v", seen[0])
+	}
+	if !out.SessionDegraded {
+		t.Fatal("chainOutcome does not report the degrade — the output stamp is derived from it")
+	}
+	stamped := map[string]any{"ok": true}
+	stampFallbackMeta(stamped, out)
+	if stamped["_session_degraded"] != true {
+		t.Errorf("output not stamped _session_degraded: %v", stamped)
+	}
+	if _, ok := stamped["_fallback_used"]; ok {
+		t.Errorf("a session degrade is not a route change — _fallback_used must stay clear: %v", stamped)
+	}
+}
+
+// A clean pass must carry neither key: an output that stamps
+// _session_degraded always means something actually happened.
+func TestCleanPassStampsNoSessionDegrade(t *testing.T) {
+	e, be, chain := sessionDegradeExecutor(errors.New("unused"))
+	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil,
+		func(_ context.Context, _ string) (*delegate.Task, error) {
+			return &delegate.Task{NodeID: "plan_revise", Model: "claude-opus-5"}, nil
+		})
+	out, err := e.dispatchChain(context.Background(), "plan_revise", chain, "claude-opus-5", build)
+	if err != nil {
+		t.Fatalf("clean pass failed: %v", err)
+	}
+	if len(be.tasks) != 1 || out.SessionDegraded {
+		t.Fatalf("clean pass reported a degrade: attempts=%d degraded=%v", len(be.tasks), out.SessionDegraded)
+	}
+	stamped := map[string]any{"ok": true}
+	stampFallbackMeta(stamped, out)
+	if _, ok := stamped["_session_degraded"]; ok {
+		t.Errorf("clean pass stamped _session_degraded: %v", stamped)
+	}
+}

--- a/pkg/backend/model/session_optional_degrade_test.go
+++ b/pkg/backend/model/session_optional_degrade_test.go
@@ -285,3 +285,65 @@ func TestOptionalSessionDegradeKeepsSpendOnCancel(t *testing.T) {
 		t.Errorf("the abandoned attempt's tokens were dropped on cancel: %d", out.Result.Tokens)
 	}
 }
+
+// TestOptionalSessionDegradeSkipsBackendsThatIgnoreTheID: claw never
+// mentions Task.SessionID (its conversation lives in the host's
+// (runID, nodeID) store and is replayed independently), and the generic
+// CLI-agent path behind kimi/grok only ever REPORTS an id. On those,
+// dropping the id produces a byte-identical call — so the degrade would
+// be a whole wasted agentic turn AND would evict the node's accumulated
+// conversation for a failure the session had no part in. Under the
+// shipped `sandbox: auto` that is not a corner case: a sandboxed claw
+// failure flattens to a string at the IPC boundary and classifies
+// UNCLASSIFIED, so every one of them would qualify.
+func TestOptionalSessionDegradeSkipsBackendsThatIgnoreTheID(t *testing.T) {
+	for _, backendName := range []string{delegate.BackendClaw, delegate.BackendKimi, delegate.BackendGrok} {
+		t.Run(backendName, func(t *testing.T) {
+			const runID, nodeID = "run-1", "plan_revise"
+			sessions := newNodeSessionStore()
+			if err := sessions.SaveSnapshot(runID, nodeID, []byte(`[{"role":"assistant"}]`)); err != nil {
+				t.Fatalf("seed snapshot: %v", err)
+			}
+			ctx := withRuntimeContext(context.Background(), runID, sessions)
+
+			be := &sessionPickyBackend{
+				name: backendName,
+				fail: errors.New("claw runner: flattened failure"),
+			}
+			reg := delegate.NewRegistry()
+			reg.Register(backendName, be)
+			e := newFallbackExecutor(reg, EventHooks{})
+			build := e.newElementBuilder(nodeID, backendName, nil, sessionDegradeBuilder(e, true))
+
+			if _, err := e.dispatchChain(ctx, nodeID, []chainElement{{Label: "primary"}}, "some-model", build); err == nil {
+				t.Fatal("a backend that ignores the session id cannot be rescued by dropping it")
+			}
+			if len(be.tasks) != 1 {
+				t.Errorf("want 1 attempt (no pointless fresh retry), got %d", len(be.tasks))
+			}
+			if sessions.LoadSnapshot(runID, nodeID) == nil {
+				t.Error("the node's accumulated conversation was evicted for a failure the session had no part in")
+			}
+		})
+	}
+}
+
+// The eligible backends are exactly the three that call resume with it.
+func TestSessionResumeEligible(t *testing.T) {
+	want := map[string]bool{
+		delegate.BackendClaudeCode: true, // claudesdk.WithResume(task.SessionID)
+		delegate.BackendCodex:      true, // codexsdk.WithResume(task.SessionID)
+		delegate.BackendPi:         true, // --session-id / --fork <id>
+		delegate.BackendClaw:       false,
+		delegate.BackendKimi:       false,
+		delegate.BackendGrok:       false,
+	}
+	for name, eligible := range want {
+		if got := sessionResumeEligible(name); got != eligible {
+			t.Errorf("sessionResumeEligible(%q) = %v, want %v", name, got, eligible)
+		}
+	}
+	if sessionResumeEligible("some-future-backend") {
+		t.Error("an unknown backend must default to ineligible — opting in is a per-backend decision")
+	}
+}

--- a/pkg/backend/model/session_optional_degrade_test.go
+++ b/pkg/backend/model/session_optional_degrade_test.go
@@ -144,3 +144,24 @@ func TestOptionalSessionDegradeEvictsNodeSession(t *testing.T) {
 		t.Errorf("the dead session's conversation survived the degrade: %s", snap)
 	}
 }
+
+// TestOptionalSessionTransientFailureDoesNotDegrade: a throttle, a 5xx
+// or a TCP blip that outlived the retry budget classifies as
+// transient_exhausted — a provider-side cause the session id had no
+// part in. Degrading there would buy a SECOND full retry budget under a
+// provider outage AND discard the node's continuity for nothing
+// (R1486ff), so the failure must surface with the session intact.
+func TestOptionalSessionTransientFailureDoesNotDegrade(t *testing.T) {
+	e, be, chain := sessionDegradeExecutor(&delegate.ErrTransient{Reason: "upstream 503"})
+	e.retry.MaxAttempts = 1 // exhaust the budget on the first call
+	build := e.newElementBuilder("plan_revise", delegate.BackendClaudeCode, nil, sessionDegradeBuilder(e, true))
+
+	if _, err := e.dispatchChain(context.Background(), "plan_revise", chain, "claude-opus-5", build); err == nil {
+		t.Fatal("a transient provider failure must surface, not degrade the session")
+	}
+	for i, task := range be.tasks {
+		if task.SessionID == "" {
+			t.Fatalf("attempt %d ran fresh: a provider-side transient must not drop the session", i)
+		}
+	}
+}

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -353,6 +353,22 @@ const (
 	// dir, Put failure). The node succeeded; the next visit runs fresh.
 	// Data: reason (short).
 	EventPersistDegraded EventType = "persist_session_degraded"
+	// EventSessionDegraded is the RESTORE-side twin of
+	// EventPersistDegraded: a node whose session is best-effort
+	// (`session: inherit_if_available` / `persist`) resolved an id whose
+	// backing state no longer loads — a cloud resume replaced the sandbox
+	// container and the CLI's session files died with it — so the
+	// executor re-ran the call with the session dropped. The node
+	// SUCCEEDS having lost its upstream (or accumulated) conversation,
+	// which is precisely why it must be loud: without this event the only
+	// trace is a process log line, and nothing in the run record would say
+	// the node started amnesiac. The node's own output carries the
+	// machine-readable half (`_session_degraded`), so a deterministic gate
+	// can fail closed on it.
+	//
+	// Data keys: backend, session_id (the id that failed to serve),
+	// reason (delegate.FallbackCategory), error.
+	EventSessionDegraded EventType = "session_degraded"
 	// EventSandboxBuildStarted fires when the engine calls
 	// [sandbox.Builder.Build] between Prepare and Start (V2-6, docker
 	// driver via `docker buildx build --load`). Data:

--- a/studio/src/api/runs/events.ts
+++ b/studio/src/api/runs/events.ts
@@ -418,6 +418,7 @@ export type PassthroughEventType =
   | "delegate_retry"
   | "model_fallback"
   | "model_drift"
+  | "session_degraded"
   | "sandbox_skipped"
   | "sandbox_started"
   | "sandbox_claw_routed_via_runner"

--- a/studio/src/components/Runs/eventLog/eventModel.ts
+++ b/studio/src/components/Runs/eventLog/eventModel.ts
@@ -28,6 +28,10 @@ export const EVENT_BADGE: Record<string, string> = {
   // override, fallback route). Same colour as fallback: the record
   // is honest, the run is degraded.
   model_drift: "bg-warning-soft text-warning-fg",
+  // A best-effort session that could not be resumed: the node ran, but
+  // without the conversation it asked for. Same colour as fallback —
+  // the run continues on a degraded input.
+  session_degraded: "bg-warning-soft text-warning-fg",
   llm_request: "bg-surface-2 text-fg-muted",
   llm_step_finished: "bg-surface-2 text-fg-muted",
   tool_called: "bg-surface-2 text-fg-muted",
@@ -100,6 +104,8 @@ export function previewData(data: Record<string, unknown> | undefined): string {
     "cooldown_until",
     "attempts",
     "from_backend",
+    // session_degraded: which session failed to load, and why.
+    "session_id",
     "to_action",
     "to_backend",
     "to_model",


### PR DESCRIPTION
## What

Documents the operating habit we're adopting on this repository: when Revi leaves findings on a PR here, comment `/billy` and let the fixer work — don't hand-fix the findings in an interactive session.

- New runbook [docs/revi-billy-loop.md](https://github.com/SocialGouv/iterion/blob/docs/revi-billy-habit/docs/revi-billy-loop.md): the command, what it seeds (prior-review hand-off, push-back, ledger, gate), the session gotchas (don't touch the branch while Billy runs, pull after his push), when not to, and the dogfood duty (bilan per run).
- CLAUDE.md: reflex paragraph next to the Revi merge-gate section + an operational-runbook-index entry.

The zero-touch `auto_fix_on_gate_failure` lane stays deliberately OFF on this repo until the manual habit has proven smooth.

## Why

iterion is a code factory; its own PRs are the first place the review→fix loop must earn its keep. The wiring already exists (proven 2026-08-01 on the e2e repo, 2026-08-13 on GitLab) — what was missing is the documented habit, so sessions stopped hand-fixing Revi findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)