### PR TITLE
feat(bots): Senti names who is actually vulnerable, not who uses the tech

### DIFF
--- a/bots/issue-triage/skills/iterion-bot-catalog.md
+++ b/bots/issue-triage/skills/iterion-bot-catalog.md
@@ -1151,7 +1151,7 @@ the run, a source silent for too long is announced on the sinks.
   digest (use feed-watch), not a PR dependency gate (use
   supply-shield-cve), not a code audit (use sec-audit-*); it never
   edits code.
-- **Vars**: `allow_private_sources` (bool), `config_path` (string), `dry_run` (bool), `fetch_timeout_secs` (int), `inventory_path` (string), `kev_max_age_days` (int), `max_alerts_per_run` (int), `max_version_lookups` (int), `mode` (string), `observe_window_days` (int), `scratch_dir` (string), `source_stale_hours` (int), `state_commit` (bool), `state_dir` (string), `workspace_dir` (string)
+- **Vars**: `allow_private_sources` (bool), `config_path` (string), `dry_run` (bool), `fetch_timeout_secs` (int), `inventory_path` (string), `kev_max_age_days` (int), `max_alerts_per_run` (int), `max_version_lookups` (int), `max_version_seconds` (int), `mode` (string), `observe_window_days` (int), `scratch_dir` (string), `source_stale_hours` (int), `state_commit` (bool), `state_dir` (string), `workspace_dir` (string)
 - **Path**: `bots/vuln-watch/main.bot`
 
 ### `whats-next` — Nexie

--- a/bots/issue-triage/skills/iterion-bot-catalog.md
+++ b/bots/issue-triage/skills/iterion-bot-catalog.md
@@ -1151,7 +1151,7 @@ the run, a source silent for too long is announced on the sinks.
   digest (use feed-watch), not a PR dependency gate (use
   supply-shield-cve), not a code audit (use sec-audit-*); it never
   edits code.
-- **Vars**: `allow_private_sources` (bool), `config_path` (string), `dry_run` (bool), `fetch_timeout_secs` (int), `inventory_path` (string), `kev_max_age_days` (int), `max_alerts_per_run` (int), `mode` (string), `observe_window_days` (int), `scratch_dir` (string), `source_stale_hours` (int), `state_commit` (bool), `state_dir` (string), `workspace_dir` (string)
+- **Vars**: `allow_private_sources` (bool), `config_path` (string), `dry_run` (bool), `fetch_timeout_secs` (int), `inventory_path` (string), `kev_max_age_days` (int), `max_alerts_per_run` (int), `max_version_lookups` (int), `mode` (string), `observe_window_days` (int), `scratch_dir` (string), `source_stale_hours` (int), `state_commit` (bool), `state_dir` (string), `workspace_dir` (string)
 - **Path**: `bots/vuln-watch/main.bot`
 
 ### `whats-next` — Nexie

--- a/bots/vuln-watch/main.bot
+++ b/bots/vuln-watch/main.bot
@@ -412,7 +412,7 @@ tool plan:
         'confirmed_projects': 'Vulnerable — confirmed',
         'declared_projects': 'Declares this technology — to verify',
         'not_a_package': 'no dependency package to check against (deployed product): version not verifiable automatically',
-        'check_unavailable': 'version check unavailable this run (lookup budget or API error)',
+        'check_unavailable': 'version NOT verified this run (no advisory match, lookup budget or API error) — assume nothing',
         'none_found': 'no vulnerable dependency found in the watched orgs',
         'fixed_window': 'was vulnerable {since} → {until}',
         'open_since': 'since {since}',
@@ -1842,21 +1842,38 @@ tool confirm_versions:
 
     def packages_for(cve):
         ## The advisory database is the authority on WHICH packages a CVE
-        ## affects. A deployed product (Metabase, GitLab, WordPress) resolves
-        ## to no package at all — that is a real answer, not a failure.
+        ## affects — and it answers THREE different things, which the message
+        ## downstream must not collapse into one:
+        ##   * an advisory carrying package mappings -> those packages;
+        ##   * an advisory carrying NONE -> the technology genuinely has no
+        ##     package in any manifest: a deployed product. Measured shape of
+        ##     that answer (CVE-2023-38646, Metabase RCE) is ONE advisory whose
+        ##     `vulnerabilities` array is empty;
+        ##   * an EMPTY advisory list -> GitHub has no advisory indexed for
+        ##     this CVE at all. Establishes nothing; measured on an unknown id.
+        ## Returns (packages, status), status in indexed|not_indexed|failed.
         if cve in adv_cache:
             return adv_cache[cve]
         url = api_base + '/advisories?cve_id=' + quote(cve, safe='')
         data = budgeted(lambda: get(url, tokens.get('*') or next(iter(tokens.values()), '')), 'advisory ' + cve)
+        if not isinstance(data, list):
+            ## A read that failed, was never funded, or came back in a shape
+            ## the endpoint does not document. None of those is an answer —
+            ## and none may be CACHED, or one blip would mis-stamp every later
+            ## unit sharing this CVE for the rest of the run.
+            return (set(), 'failed')
         pkgs = set()
-        for a in (data or []):
+        for a in data:
+            if not isinstance(a, dict):
+                continue
             for v in (a.get('vulnerabilities') or []):
-                pk = (v.get('package') or {})
+                pk = ((v or {}).get('package') or {})
                 name, eco = pk.get('name') or '', (pk.get('ecosystem') or '').lower()
                 if name and eco:
                     pkgs.add((eco, name))
-        adv_cache[cve] = pkgs
-        return pkgs
+        res = (pkgs, 'indexed' if data else 'not_indexed')
+        adv_cache[cve] = res
+        return res
 
     def alerts_for(org, eco, names):
         token = tokens.get(org) or tokens.get('*')
@@ -1872,12 +1889,22 @@ tool confirm_versions:
     for a in alerts:
         cves = [c for c in (a.get('cves') or []) if c]
         pkgs = set()
+        adv_status = set()
         for c in cves[:6]:  # a CERT-FR avis can carry hundreds; the head is the subject
-            pkgs |= packages_for(c)
+            p, st = packages_for(c)
+            pkgs |= p
+            adv_status.add(st)
         if not pkgs:
-            ## Nothing to look up: either the advisory names no package, or the
-            ## lookup budget ran out. Say which, so the message can be honest.
-            a['version_check'] = 'unavailable' if lookups[0] >= max_lookups else 'not_a_package'
+            ## Nothing to look up — and WHY is three different facts, only one
+            ## of which is about the technology. "The advisory exists and names
+            ## no package" IS the deployed-product signal the label was written
+            ## for (Metabase, GitLab, a WordPress install). A read that failed,
+            ## was never funded, or matched no indexed advisory says nothing at
+            ## all — dressing that up as "deployed product" states a confident
+            ## fact about the technology derived from a transport error.
+            a['version_check'] = ('not_a_package'
+                                  if ('indexed' in adv_status and 'failed' not in adv_status)
+                                  else 'unavailable')
             continue
         confirmable += 1
         by_eco = {}

--- a/bots/vuln-watch/main.bot
+++ b/bots/vuln-watch/main.bot
@@ -2000,9 +2000,18 @@ tool confirm_versions:
         if a.get('repos'):
             continue
         cves = [c for c in (a.get('cves') or []) if c]
+        ## A CERT-FR avis can carry hundreds of CVEs, so only the head is
+        ## resolved. That head carries NO signal: poll_advisories stores the
+        ## set `sorted()`, so these are just the six lowest-numbered ids — the
+        ## oldest years, not the advisory's subject. Which is exactly why the
+        ## cut has to be REPORTED: if the CVE naming the affected package sits
+        ## at position 7, an unmarked result reads as "this technology has no
+        ## package to check" or as an all-clear, on evidence never gathered.
+        cve_cap = 6
+        truncated_cves = len(cves) > cve_cap
         pkgs = set()
         adv_status = set()
-        for c in cves[:6]:  # a CERT-FR avis can carry hundreds; the head is the subject
+        for c in cves[:cve_cap]:
             p, st = packages_for(c)
             pkgs |= p
             adv_status.add(st)
@@ -2011,11 +2020,13 @@ tool confirm_versions:
             ## of which is about the technology. "The advisory exists and names
             ## no package" IS the deployed-product signal the label was written
             ## for (Metabase, GitLab, a WordPress install). A read that failed,
-            ## was never funded, or matched no indexed advisory says nothing at
-            ## all — dressing that up as "deployed product" states a confident
-            ## fact about the technology derived from a transport error.
+            ## was never funded, matched no indexed advisory, or was never
+            ## reached because the CVE list was cut, says nothing at all —
+            ## dressing any of those up as "deployed product" states a
+            ## confident fact about the technology on no evidence.
             a['version_check'] = ('not_a_package'
-                                  if ('indexed' in adv_status and 'failed' not in adv_status)
+                                  if ('indexed' in adv_status and 'failed' not in adv_status
+                                      and not truncated_cves)
                                   else 'unavailable')
             continue
         confirmable += 1
@@ -2027,9 +2038,10 @@ tool confirm_versions:
         ## version and its dates, and the message showed ONE fix as though it
         ## covered the repository.
         matches = {}
-        ## An advisory read that failed leaves the package set incomplete, so
-        ## whatever the alert lane then finds cannot be a COMPLETE answer.
-        checked, complete = False, ('failed' not in adv_status)
+        ## An advisory read that failed — or a CVE list cut short — leaves the
+        ## package set incomplete, so whatever the alert lane then finds cannot
+        ## be a COMPLETE answer, and an empty one cannot be an all-clear.
+        checked, complete = False, ('failed' not in adv_status and not truncated_cves)
         for org in orgs:
             got, ok = alerts_for(org, names)
             checked = checked or ok

--- a/bots/vuln-watch/main.bot
+++ b/bots/vuln-watch/main.bot
@@ -1989,6 +1989,16 @@ tool confirm_versions:
     confirmable = 0
     confirmed = 0
     for a in alerts:
+        ## A unit carrying `repos` came off the DEPENDABOT lane, which is
+        ## already version-precise — it names the repositories running an
+        ## affected version, which is exactly what this node has to go and
+        ## establish for every OTHER lane. notify renders confirmed_repos only
+        ## on the branch where `repos` is empty, so confirming these would be
+        ## lookups nothing can ever display, drawn from the same budget the KEV
+        ## and feed units need. Not hypothetical: the first live tick had that
+        ## lane alone reporting ~200 new alerts against max_alerts_per_run=20.
+        if a.get('repos'):
+            continue
         cves = [c for c in (a.get('cves') or []) if c]
         pkgs = set()
         adv_status = set()

--- a/bots/vuln-watch/main.bot
+++ b/bots/vuln-watch/main.bot
@@ -1913,7 +1913,27 @@ tool confirm_versions:
         if cve in adv_cache:
             return adv_cache[cve]
         url = api_base + '/advisories?cve_id=' + quote(cve, safe='')
-        got = budgeted(lambda: get(url, tokens.get('*') or next(iter(tokens.values()), '')), 'advisory ' + cve)
+
+        def fetch_advisory():
+            ## /advisories is a PUBLIC endpoint — it answers unauthenticated
+            ## (verified against the live API). A token is sent only to buy the
+            ## authenticated rate limit, and the one available here is some
+            ## org's Dependabot credential: in production a watch-only GitHub
+            ## App installation token whose manifest permissions were REPLACED
+            ## by metadata + vulnerability_alerts read (docs/forge-security-read.md),
+            ## which this endpoint has no reason to accept. If it is rejected,
+            ## the advisory lane must not go dark — every unit would render as
+            ## unverified and the whole confirmation would quietly stop working
+            ## — so fall back to the unauthenticated read it does not need.
+            tok = tokens.get('*') or next(iter(tokens.values()), '')
+            if not tok:
+                return get(url, '')
+            try:
+                return get(url, tok)
+            except Exception:
+                return get(url, '')
+
+        got = budgeted(fetch_advisory, 'advisory ' + cve)
         ## A cve_id query returns at most one advisory, so there is no page to
         ## walk here — only the alerts lane needs that.
         data = got[0] if got else None

--- a/bots/vuln-watch/main.bot
+++ b/bots/vuln-watch/main.bot
@@ -1759,35 +1759,71 @@ tool confirm_versions:
         except ValueError:
             tokens = {}
 
-    base_host = (urlsplit(api_base).hostname or '')
+    _base_parts = urlsplit(api_base)
+    base_host = (_base_parts.hostname or '')
+    base_scheme = _base_parts.scheme
+
+    def _port_of(parts):
+        return parts.port or (443 if parts.scheme == 'https' else 80)
+
+    base_port = _port_of(_base_parts)
 
     def _addr_ok(ip):
         a = ipaddress.ip_address(ip)
         return allow_private or a.is_global
 
+    def _origin_ok(parts):
+        ## The token is a bearer credential: what may carry it is an ORIGIN,
+        ## not a hostname. Pinning the host alone would still allow an
+        ## https -> http hop on the same name (the token in clear on the
+        ## wire) or a hop to another service on a different port.
+        return (parts.scheme in ('http', 'https') and parts.scheme == base_scheme
+                and (parts.hostname or '') == base_host and _port_of(parts) == base_port)
+
+    def _addrs_ok(parts):
+        for fam, _, _, _, sa in socket.getaddrinfo(parts.hostname, _port_of(parts), proto=socket.IPPROTO_TCP):
+            if not _addr_ok(sa[0]):
+                raise OSError('refusing a non-public address for ' + str(parts.hostname))
+
+    class _SafeRedirect(urllib.request.HTTPRedirectHandler):
+        ## urllib's default opener copies EVERY header (bar content-*) onto a
+        ## redirected request and compares no hosts — so a 30x answered by the
+        ## API origin would hand the org's Dependabot token to whoever the
+        ## Location names, with the pre-flight address check never re-run.
+        ## The polling lanes carry the same guard; this one also pins the
+        ## scheme and port, so an https -> http downgrade cannot slip through.
+        def redirect_request(self, req, fp, code, msg, headers, newurl):
+            parts = urlsplit(newurl)
+            if not _origin_ok(parts):
+                raise OSError('refusing redirect off the configured API origin: ' + str(newurl)[:200])
+            _addrs_ok(parts)
+            return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+    _opener = urllib.request.build_opener(_SafeRedirect())
+
     def get(url, token):
-        ## Same egress discipline as the polling lanes: the host is pinned to
+        ## Same egress discipline as the polling lanes: the origin is pinned to
         ## the configured API base, and a resolved address must be public
         ## unless the operator opted into private ranges.
         parts = urlsplit(url)
+        if not _origin_ok(parts):
+            raise OSError('refusing an off-origin request: ' + url[:200])
         ## Same guard as the polling lanes: the token rides as a bearer, so
         ## plaintext is refused unless the operator opted into private
         ## sources (which is also what a test harness uses).
-        if parts.scheme not in ('http', 'https') or (parts.hostname or '') != base_host:
-            raise OSError('refusing an off-host request: ' + url[:200])
         if parts.scheme != 'https' and not allow_private:
             raise OSError('refusing a plaintext request carrying a token: ' + url[:200])
-        for fam, _, _, _, sa in socket.getaddrinfo(parts.hostname, parts.port or (443 if parts.scheme == 'https' else 80), proto=socket.IPPROTO_TCP):
-            if not _addr_ok(sa[0]):
-                raise OSError('refusing a non-public address for ' + str(parts.hostname))
+        _addrs_ok(parts)
         req = urllib.request.Request(url, headers={
             'Accept': 'application/vnd.github+json',
             'X-GitHub-Api-Version': '2022-11-28',
             'User-Agent': 'iterion-vuln-watch'})
         if token:
             req.add_header('Authorization', 'Bearer ' + token)
-        with urllib.request.urlopen(req, timeout=timeout) as r:
-            return json.loads(r.read().decode('utf-8') or '[]')
+        with _opener.open(req, timeout=timeout) as r:
+            ## Bounded like the sibling lane's read: a hostile or broken
+            ## endpoint must not be able to stream this node out of memory.
+            return json.loads(r.read(8 * 1024 * 1024).decode('utf-8') or '[]')
 
     lookups = [0]
     errors = []

--- a/bots/vuln-watch/main.bot
+++ b/bots/vuln-watch/main.bot
@@ -1932,7 +1932,12 @@ tool confirm_versions:
         confirmable += 1
         names = set(n for _, n in pkgs)
         cveset = set(cves)
-        hits = {}
+        ## Keyed by (repo, PACKAGE), not by repo: one advisory routinely names
+        ## several packages and a repo can run more than one of them. Keyed by
+        ## repo alone, every match after the first lost its package, its fix
+        ## version and its dates, and the message showed ONE fix as though it
+        ## covered the repository.
+        matches = {}
         ## An advisory read that failed leaves the package set incomplete, so
         ## whatever the alert lane then finds cannot be a COMPLETE answer.
         checked, complete = False, ('failed' not in adv_status)
@@ -1955,17 +1960,36 @@ tool confirm_versions:
                 repo = ((al.get('repository') or {}).get('full_name') or '')
                 if not repo:
                     continue
+                key = (repo, pk.get('name') or '')
+                st = (al.get('state') or '')
+                prev = matches.get(key)
+                ## An OPEN alert wins over a fixed one for the same repo+package
+                ## — still-vulnerable is the actionable truth — and it brings
+                ## its OWN fix version and dates with it. Promoting the state
+                ## alone would date an open exposure from the resolved alert
+                ## that happened to be seen first, and order here is not
+                ## controllable: it follows org iteration and GitHub's sort.
+                if prev is not None and not (st == 'open' and prev['state'] != 'open'):
+                    continue
                 sv = (al.get('security_vulnerability') or {})
-                rec = hits.setdefault(repo, {'repo': repo, 'state': al.get('state') or '',
-                                             'package': pk.get('name') or '',
-                                             'fix': ((sv.get('first_patched_version') or {}) or {}).get('identifier') or '',
-                                             'since': (al.get('created_at') or '')[:10],
-                                             'until': (al.get('fixed_at') or '')[:10]})
-                ## An open alert always wins over a fixed one for the same
-                ## repo: still-vulnerable is the actionable truth.
-                if (al.get('state') or '') == 'open':
-                    rec['state'] = 'open'
-                    rec['until'] = ''
+                matches[key] = {'repo': repo, 'package': key[1], 'state': st,
+                                'fix': ((sv.get('first_patched_version') or {}) or {}).get('identifier') or '',
+                                'since': (al.get('created_at') or '')[:10],
+                                'until': '' if st == 'open' else (al.get('fixed_at') or '')[:10]}
+        ## Group back to ONE record per repository: the operator-facing count is
+        ## repositories, and a repo running two affected packages must not
+        ## inflate it into two findings. A repo with anything still open is an
+        ## open repo, and only its open packages are the actionable part.
+        hits = {}
+        for key in sorted(matches):
+            m = matches[key]
+            g = hits.setdefault(m['repo'], {'repo': m['repo'], 'state': m['state'], 'packages': []})
+            if m['state'] == 'open' and g['state'] != 'open':
+                g['state'], g['packages'] = 'open', []
+            elif g['state'] == 'open' and m['state'] != 'open':
+                continue
+            g['packages'].append({'package': m['package'], 'fix': m['fix'],
+                                  'since': m['since'], 'until': m['until']})
         a['confirmed_repos'] = sorted(hits.values(), key=lambda r: (r['state'] != 'open', r['repo']))
         if hits:
             a['version_check'] = 'confirmed'
@@ -2104,16 +2128,27 @@ tool notify:
                 bits = []
                 for c in group[:12]:
                     who = flat(c.get('repo'), 100)
+                    pks = c.get('packages') or []
                     detail = []
-                    if c.get('fix'):
-                        detail.append('→ ' + flat(c['fix'], 30))
+                    ## Every affected package, not just the first: showing one
+                    ## fix version as though it covered the repository is how an
+                    ## operator patches half of an exposure and files it closed.
+                    for p in pks[:4]:
+                        nm = flat(p.get('package'), 40)
+                        detail.append((nm + ' → ' + flat(p.get('fix'), 30)) if p.get('fix') else nm)
+                    if len(pks) > 4:
+                        detail.append('+' + str(len(pks) - 4) + ' ' + labels['more'])
+                    ## Dates span the repo's matches, so a window can never be
+                    ## borrowed from a different package's alert.
+                    sinces = sorted(x for x in [p.get('since') or '' for p in pks] if x)
+                    untils = sorted(x for x in [p.get('until') or '' for p in pks] if x)
                     if c.get('state') == 'open':
-                        if c.get('since'):
-                            detail.append(labels['open_since'].replace('{since}', flat(c['since'], 10)))
-                    elif c.get('since') and c.get('until'):
+                        if sinces:
+                            detail.append(labels['open_since'].replace('{since}', flat(sinces[0], 10)))
+                    elif sinces and untils:
                         detail.append(labels['fixed_window']
-                                      .replace('{since}', flat(c['since'], 10))
-                                      .replace('{until}', flat(c['until'], 10)))
+                                      .replace('{since}', flat(sinces[0], 10))
+                                      .replace('{until}', flat(untils[-1], 10)))
                     bits.append('`' + who + '`' + ((' ' + ' · '.join(detail)) if detail else ''))
                 extra = len(group) - len(bits)
                 lines.append(heading + ' (' + str(len(group)) + '): ' + ', '.join(bits) +

--- a/bots/vuln-watch/main.bot
+++ b/bots/vuln-watch/main.bot
@@ -111,6 +111,11 @@ vars:
   ## state_dir NOT gitignored and push credentials on the workspace.
   state_commit: bool = false
 
+  ## Ceiling on advisory + Dependabot lookups the version confirmation may
+  ## spend in one run. The confirmation is a precision nicety: it must never
+  ## be the reason an hourly tick hangs or hammers the forge.
+  max_version_lookups: int = 40
+
   ## Per-request HTTP timeout (feeds, APIs).
   fetch_timeout_secs: int = 20
 
@@ -261,6 +266,29 @@ schema match_output:
   alertlog_file: string
   summary: string
 
+schema confirm_input:
+  ## The alerts match_policy decided to post, enriched in place.
+  alerts: json
+  github_orgs: string[]
+  github_api_base: string
+  timeout_secs: int
+  allow_private: bool
+  ## Hard ceiling on advisory+alert lookups for one run: the confirmation
+  ## is a nicety, never a reason for the tick to hang or to hammer the API.
+  max_lookups: int
+
+schema confirm_output:
+  alerts: json
+  ## Units whose affected packages could be resolved at all. A deployed
+  ## product (Metabase, GitLab, a WordPress install) has NO package in any
+  ## dependency manifest, so it can never be confirmed this way — that is
+  ## reported, not silently rendered as "nothing found".
+  confirmable: int
+  confirmed: int
+  lookups: int
+  errors: json
+  summary: string
+
 schema notify_input:
   alerts: json
   overflow_count: int
@@ -381,6 +409,13 @@ tool plan:
         'no_fix': 'none published yet',
         'fix_see_source': 'see the advisory',
         'projects': 'Affected projects',
+        'confirmed_projects': 'Vulnerable — confirmed',
+        'declared_projects': 'Declares this technology — to verify',
+        'not_a_package': 'no dependency package to check against (deployed product): version not verifiable automatically',
+        'check_unavailable': 'version check unavailable this run (lookup budget or API error)',
+        'none_found': 'no vulnerable dependency found in the watched orgs',
+        'fixed_window': 'was vulnerable {since} → {until}',
+        'open_since': 'since {since}',
         'repos': 'repo(s)',
         'via_dependabot': 'flagged by Dependabot in {n} repo(s)',
         'sources': 'Sources',
@@ -1679,6 +1714,174 @@ tool match_policy:
 ## message per alert + one overflow note + one staleness warning to the
 ## configured sinks. The techno→projects join arrives pre-resolved —
 ## this node is a renderer and a courier, nothing more.
+tool confirm_versions:
+  ## Turns "these 53 projects declare this technology" into "this repo runs
+  ## a version the advisory names, and here is the fix".
+  ##
+  ## The inventory match is deliberately keyword-based and therefore
+  ## VERSION-BLIND: it answers "who uses React", not "who is vulnerable".
+  ## Measured on the first live tick: a React Server Components advisory
+  ## named 53 projects; exactly ONE repository carried an affected package.
+  ## An alert that over-names by 53x is the kind operators stop reading,
+  ## which is the failure this whole bot exists to avoid.
+  ##
+  ## Two GitHub reads per alerted unit, both server-side filtered:
+  ##   1. /advisories?cve_id=...  -> the packages the advisory actually names
+  ##   2. /orgs/{org}/dependabot/alerts?package=...  -> who runs them
+  ##
+  ## GOTCHA, paid for: `state=all` is NOT a valid value for that endpoint,
+  ## and GitHub answers 200 with an EMPTY list instead of an error — the
+  ## confirmation would have been silently, permanently empty. OMIT the
+  ## parameter to get every state (open + fixed + dismissed); measured
+  ## `state=open&package=uuid` -> 73, `state=all&package=uuid` -> 0,
+  ## no state param -> 78.
+  input: confirm_input
+  output: confirm_output
+  language: py
+  script: |
+    import json, os, re, socket, ipaddress
+    import urllib.request, urllib.error
+    from urllib.parse import urlsplit, quote
+    null = None; true = True; false = False  # JSON-literal shim for missing refs
+    alerts = {{input.alerts}} or []
+    orgs = {{input.github_orgs}} or []
+    api_base = ({{input.github_api_base}} or 'https://api.github.com').rstrip('/')
+    timeout = int({{input.timeout_secs}} or 20)
+    allow_private = {{input.allow_private}}
+    max_lookups = int({{input.max_lookups}} or 40)
+    tokens_file = {{secrets.dependabot_tokens.path}}
+
+    tokens = {}
+    if tokens_file and os.path.exists(tokens_file):
+        try:
+            raw = open(tokens_file, encoding='utf-8').read().strip()
+            tokens = json.loads(raw) if raw else {}
+        except ValueError:
+            tokens = {}
+
+    base_host = (urlsplit(api_base).hostname or '')
+
+    def _addr_ok(ip):
+        a = ipaddress.ip_address(ip)
+        return allow_private or a.is_global
+
+    def get(url, token):
+        ## Same egress discipline as the polling lanes: the host is pinned to
+        ## the configured API base, and a resolved address must be public
+        ## unless the operator opted into private ranges.
+        parts = urlsplit(url)
+        ## Same guard as the polling lanes: the token rides as a bearer, so
+        ## plaintext is refused unless the operator opted into private
+        ## sources (which is also what a test harness uses).
+        if parts.scheme not in ('http', 'https') or (parts.hostname or '') != base_host:
+            raise OSError('refusing an off-host request: ' + url[:200])
+        if parts.scheme != 'https' and not allow_private:
+            raise OSError('refusing a plaintext request carrying a token: ' + url[:200])
+        for fam, _, _, _, sa in socket.getaddrinfo(parts.hostname, parts.port or (443 if parts.scheme == 'https' else 80), proto=socket.IPPROTO_TCP):
+            if not _addr_ok(sa[0]):
+                raise OSError('refusing a non-public address for ' + str(parts.hostname))
+        req = urllib.request.Request(url, headers={
+            'Accept': 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+            'User-Agent': 'iterion-vuln-watch'})
+        if token:
+            req.add_header('Authorization', 'Bearer ' + token)
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.loads(r.read().decode('utf-8') or '[]')
+
+    lookups = [0]
+    errors = []
+
+    def budgeted(fn, what):
+        if lookups[0] >= max_lookups:
+            return None
+        lookups[0] += 1
+        try:
+            return fn()
+        except Exception as e:
+            errors.append({'what': what, 'error': type(e).__name__ + ': ' + str(e)[:200]})
+            return None
+
+    adv_cache = {}
+
+    def packages_for(cve):
+        ## The advisory database is the authority on WHICH packages a CVE
+        ## affects. A deployed product (Metabase, GitLab, WordPress) resolves
+        ## to no package at all — that is a real answer, not a failure.
+        if cve in adv_cache:
+            return adv_cache[cve]
+        url = api_base + '/advisories?cve_id=' + quote(cve, safe='')
+        data = budgeted(lambda: get(url, tokens.get('*') or next(iter(tokens.values()), '')), 'advisory ' + cve)
+        pkgs = set()
+        for a in (data or []):
+            for v in (a.get('vulnerabilities') or []):
+                pk = (v.get('package') or {})
+                name, eco = pk.get('name') or '', (pk.get('ecosystem') or '').lower()
+                if name and eco:
+                    pkgs.add((eco, name))
+        adv_cache[cve] = pkgs
+        return pkgs
+
+    def alerts_for(org, eco, names):
+        token = tokens.get(org) or tokens.get('*')
+        if not token:
+            return []
+        ## NO state parameter — see the GOTCHA in this node's header.
+        url = (api_base + '/orgs/' + quote(org, safe='') + '/dependabot/alerts?per_page=100&ecosystem=' +
+               quote(eco, safe='') + '&package=' + quote(','.join(sorted(names)), safe=','))
+        return budgeted(lambda: get(url, token), 'alerts ' + org + '/' + eco) or []
+
+    confirmable = 0
+    confirmed = 0
+    for a in alerts:
+        cves = [c for c in (a.get('cves') or []) if c]
+        pkgs = set()
+        for c in cves[:6]:  # a CERT-FR avis can carry hundreds; the head is the subject
+            pkgs |= packages_for(c)
+        if not pkgs:
+            ## Nothing to look up: either the advisory names no package, or the
+            ## lookup budget ran out. Say which, so the message can be honest.
+            a['version_check'] = 'unavailable' if lookups[0] >= max_lookups else 'not_a_package'
+            continue
+        confirmable += 1
+        by_eco = {}
+        for eco, name in pkgs:
+            by_eco.setdefault(eco, set()).add(name)
+        cveset = set(cves)
+        hits = {}
+        for org in orgs:
+            for eco, names in by_eco.items():
+                for al in alerts_for(org, eco, names):
+                    adv = (al.get('security_advisory') or {})
+                    if cveset and (adv.get('cve_id') or '') not in cveset:
+                        continue
+                    repo = ((al.get('repository') or {}).get('full_name') or '')
+                    if not repo:
+                        continue
+                    sv = (al.get('security_vulnerability') or {})
+                    rec = hits.setdefault(repo, {'repo': repo, 'state': al.get('state') or '',
+                                                 'package': ((al.get('dependency') or {}).get('package') or {}).get('name') or '',
+                                                 'fix': ((sv.get('first_patched_version') or {}) or {}).get('identifier') or '',
+                                                 'since': (al.get('created_at') or '')[:10],
+                                                 'until': (al.get('fixed_at') or '')[:10]})
+                    ## An open alert always wins over a fixed one for the same
+                    ## repo: still-vulnerable is the actionable truth.
+                    if (al.get('state') or '') == 'open':
+                        rec['state'] = 'open'
+                        rec['until'] = ''
+        a['confirmed_repos'] = sorted(hits.values(), key=lambda r: (r['state'] != 'open', r['repo']))
+        a['version_check'] = 'confirmed' if hits else 'none_found'
+        if hits:
+            confirmed += 1
+
+    parts = [str(confirmed) + '/' + str(confirmable) + ' unit(s) version-confirmed',
+             str(lookups[0]) + ' lookup(s)']
+    if errors:
+        parts.append(str(len(errors)) + ' lookup error(s)')
+    print(json.dumps({'alerts': alerts, 'confirmable': confirmable, 'confirmed': confirmed,
+                      'lookups': lookups[0], 'errors': errors,
+                      'summary': ', '.join(parts)}))
+
 tool notify:
   input: notify_input
   output: notify_output
@@ -1776,11 +1979,49 @@ tool notify:
                          proj_part + ', '.join('`' + r + '`' for r in shown) +
                          ((' +' + str(extra) + ' ' + labels['more']) if extra > 0 else ''))
             lines.append('_' + labels['via_dependabot'].replace('{n}', str(len(a['repos']))) + '_')
-        elif pnames:
-            shown = [flat(n, 60) for n in pnames[:12]]
-            extra = len(pnames) - len(shown)
-            lines.append(labels['projects'] + ' (' + str(len(pnames)) + '): ' + ', '.join(shown) +
-                         ((' +' + str(extra) + ' ' + labels['more']) if extra > 0 else ''))
+        else:
+            ## Two lists, never one. The inventory match is keyword-based and
+            ## VERSION-BLIND — it answers "who declares this technology", not
+            ## "who is vulnerable". Printing it alone under a heading that reads
+            ## "affected" is what turns one real finding into a 53-project wall
+            ## nobody reads. What confirm_versions proved comes FIRST and stays
+            ## short; the rest is demoted to context, explicitly unverified.
+            conf = a.get('confirmed_repos') or []
+            if conf:
+                bits = []
+                for c in conf[:12]:
+                    who = flat(c.get('repo'), 100)
+                    detail = []
+                    if c.get('fix'):
+                        detail.append('→ ' + flat(c['fix'], 30))
+                    if c.get('state') == 'open':
+                        if c.get('since'):
+                            detail.append(labels['open_since'].replace('{since}', flat(c['since'], 10)))
+                    elif c.get('since') and c.get('until'):
+                        detail.append(labels['fixed_window']
+                                      .replace('{since}', flat(c['since'], 10))
+                                      .replace('{until}', flat(c['until'], 10)))
+                    bits.append('`' + who + '`' + ((' ' + ' · '.join(detail)) if detail else ''))
+                extra = len(conf) - len(bits)
+                lines.append(labels['confirmed_projects'] + ' (' + str(len(conf)) + '): ' + ', '.join(bits) +
+                             ((' +' + str(extra) + ' ' + labels['more']) if extra > 0 else ''))
+            else:
+                ## Say WHY nothing is confirmed. "none_found" and "this kind of
+                ## technology cannot be checked" are different facts, and
+                ## collapsing them would let a deployed product read as safe.
+                why = a.get('version_check') or ''
+                if why == 'not_a_package':
+                    lines.append('_' + labels['not_a_package'] + '_')
+                elif why == 'unavailable':
+                    lines.append('_' + labels['check_unavailable'] + '_')
+                elif why == 'none_found':
+                    lines.append('_' + labels['none_found'] + '_')
+            if pnames:
+                shown = [flat(n, 60) for n in pnames[:12]]
+                extra = len(pnames) - len(shown)
+                head = labels['declared_projects'] if conf or a.get('version_check') else labels['projects']
+                lines.append(head + ' (' + str(len(pnames)) + '): ' + ', '.join(shown) +
+                             ((' +' + str(extra) + ' ' + labels['more']) if extra > 0 else ''))
         src = []
         unit_url = safe_url(a.get('url'))
         if unit_url:
@@ -2087,8 +2328,17 @@ workflow vuln_watch:
     source_stale_hours: "{{vars.source_stale_hours}}"
   }
 
-  match_policy -> notify with {
+  match_policy -> confirm_versions with {
     alerts: "{{outputs.match_policy.alerts}}",
+    github_orgs: "{{outputs.plan.github_orgs}}",
+    github_api_base: "{{outputs.plan.github_api_base}}",
+    timeout_secs: "{{vars.fetch_timeout_secs}}",
+    allow_private: "{{vars.allow_private_sources}}",
+    max_lookups: "{{vars.max_version_lookups}}"
+  }
+
+  confirm_versions -> notify with {
+    alerts: "{{outputs.confirm_versions.alerts}}",
     overflow_count: "{{outputs.match_policy.overflow_count}}",
     stale_sources: "{{outputs.match_policy.stale_sources}}",
     sinks: "{{outputs.plan.sinks}}",

--- a/bots/vuln-watch/main.bot
+++ b/bots/vuln-watch/main.bot
@@ -116,6 +116,17 @@ vars:
   ## be the reason an hourly tick hangs or hammers the forge.
   max_version_lookups: int = 40
 
+  ## ...and a COUNT of lookups is not a wall-clock bound. At the defaults, 40
+  ## sequential requests x a 20s per-request timeout is 800s against a 900s
+  ## max_duration — before DNS, body reads, and the three polling lanes that
+  ## run first. confirm_versions sits upstream of BOTH notify and
+  ## commit_state, so overrunning the workflow budget means no message
+  ## delivered and no state consumed: the bot goes silent for exactly as long
+  ## as GitHub is slow, which is plausibly when it matters most. This deadline
+  ## is what makes the "never the reason a tick hangs" contract above true.
+  ## 0 disables it (the lookup ceiling then bounds the node on its own).
+  max_version_seconds: int = 120
+
   ## Per-request HTTP timeout (feeds, APIs).
   fetch_timeout_secs: int = 20
 
@@ -276,6 +287,9 @@ schema confirm_input:
   ## Hard ceiling on advisory+alert lookups for one run: the confirmation
   ## is a nicety, never a reason for the tick to hang or to hammer the API.
   max_lookups: int
+  ## ...and the wall-clock half of that promise, which the count alone
+  ## cannot make (a slow API turns 40 lookups into 800s). 0 disables.
+  max_seconds: int
 
 schema confirm_output:
   alerts: json
@@ -1744,8 +1758,8 @@ tool confirm_versions:
   output: confirm_output
   language: py
   script: |
-    import json, os, re, socket, ipaddress
-    import urllib.request, urllib.error
+    import json, os, socket, time, ipaddress
+    import urllib.request
     from urllib.parse import urlsplit, quote
     null = None; true = True; false = False  # JSON-literal shim for missing refs
     alerts = {{input.alerts}} or []
@@ -1754,6 +1768,10 @@ tool confirm_versions:
     timeout = int({{input.timeout_secs}} or 20)
     allow_private = {{input.allow_private}}
     max_lookups = int({{input.max_lookups}} or 40)
+    max_seconds = int({{input.max_seconds}} or 0)
+    ## MONOTONIC, not wall time: a clock step must not extend or collapse the
+    ## window this node is allowed to spend.
+    deadline = (time.monotonic() + max_seconds) if max_seconds > 0 else None
     tokens_file = {{secrets.dependabot_tokens.path}}
 
     tokens = {}
@@ -1825,7 +1843,10 @@ tool confirm_versions:
             'User-Agent': 'iterion-vuln-watch'})
         if token:
             req.add_header('Authorization', 'Bearer ' + token)
-        with _opener.open(req, timeout=timeout) as r:
+        ## Clamp the per-request timeout to what is left of the node's window,
+        ## so one hung read cannot overshoot the deadline by a whole timeout.
+        t = timeout if deadline is None else max(1, min(timeout, int(deadline - time.monotonic())))
+        with _opener.open(req, timeout=t) as r:
             ## Bounded like the sibling lane's read: a hostile or broken
             ## endpoint must not be able to stream this node out of memory.
             return json.loads(r.read(8 * 1024 * 1024).decode('utf-8') or '[]')
@@ -1833,8 +1854,21 @@ tool confirm_versions:
     lookups = [0]
     errors = []
 
+    expired = [False]
+
     def budgeted(fn, what):
         if lookups[0] >= max_lookups:
+            return None
+        ## The deadline is checked BEFORE every request, so a degraded API
+        ## costs this node its precision and never the run's delivery. What
+        ## is left unlooked-up degrades to "not verified", never to an
+        ## all-clear — see the version_check assignment below.
+        if deadline is not None and time.monotonic() >= deadline:
+            if not expired[0]:
+                expired[0] = True
+                errors.append({'what': 'deadline',
+                               'error': 'version confirmation stopped after ' + str(max_seconds) +
+                                        's; remaining units are reported unverified'})
             return None
         lookups[0] += 1
         try:
@@ -2005,6 +2039,10 @@ tool confirm_versions:
 
     parts = [str(confirmed) + '/' + str(confirmable) + ' unit(s) version-confirmed',
              str(lookups[0]) + ' lookup(s)']
+    if expired[0]:
+        parts.append('stopped on the ' + str(max_seconds) + 's deadline')
+    elif lookups[0] >= max_lookups:
+        parts.append('lookup budget spent')
     if errors:
         parts.append(str(len(errors)) + ' lookup error(s)')
     print(json.dumps({'alerts': alerts, 'confirmable': confirmable, 'confirmed': confirmed,
@@ -2485,7 +2523,8 @@ workflow vuln_watch:
     github_api_base: "{{outputs.plan.github_api_base}}",
     timeout_secs: "{{vars.fetch_timeout_secs}}",
     allow_private: "{{vars.allow_private_sources}}",
-    max_lookups: "{{vars.max_version_lookups}}"
+    max_lookups: "{{vars.max_version_lookups}}",
+    max_seconds: "{{vars.max_version_seconds}}"
   }
 
   confirm_versions -> notify with {

--- a/bots/vuln-watch/main.bot
+++ b/bots/vuln-watch/main.bot
@@ -1849,7 +1849,25 @@ tool confirm_versions:
         with _opener.open(req, timeout=t) as r:
             ## Bounded like the sibling lane's read: a hostile or broken
             ## endpoint must not be able to stream this node out of memory.
-            return json.loads(r.read(8 * 1024 * 1024).decode('utf-8') or '[]')
+            ## The Link header comes back with it — without that, pagination is
+            ## not even OBSERVABLE from here, let alone walked.
+            return (json.loads(r.read(8 * 1024 * 1024).decode('utf-8') or '[]'),
+                    (r.headers.get('Link') or ''))
+
+    def next_link(link_header):
+        ## The pagination URL is server-supplied and re-requested WITH the
+        ## Authorization header, so it is followed only while it stays on the
+        ## configured origin — a rewritten Link header would otherwise
+        ## exfiltrate the token in one hop, exactly as a 30x would.
+        for part in (link_header or '').split(','):
+            if 'rel="next"' in part:
+                s, e = part.find('<'), part.find('>')
+                if 0 <= s < e:
+                    url = part[s + 1:e]
+                    if not _origin_ok(urlsplit(url)):
+                        raise OSError('refusing an off-origin pagination Link: ' + url[:200])
+                    return url
+        return ''
 
     lookups = [0]
     errors = []
@@ -1878,6 +1896,7 @@ tool confirm_versions:
             return None
 
     adv_cache = {}
+    MAX_PAGES = 10  # bounded walk; truncation is REPORTED, never silent
 
     def packages_for(cve):
         ## The advisory database is the authority on WHICH packages a CVE
@@ -1894,7 +1913,10 @@ tool confirm_versions:
         if cve in adv_cache:
             return adv_cache[cve]
         url = api_base + '/advisories?cve_id=' + quote(cve, safe='')
-        data = budgeted(lambda: get(url, tokens.get('*') or next(iter(tokens.values()), '')), 'advisory ' + cve)
+        got = budgeted(lambda: get(url, tokens.get('*') or next(iter(tokens.values()), '')), 'advisory ' + cve)
+        ## A cve_id query returns at most one advisory, so there is no page to
+        ## walk here — only the alerts lane needs that.
+        data = got[0] if got else None
         if not isinstance(data, list):
             ## A read that failed, was never funded, or came back in a shape
             ## the endpoint does not document. None of those is an answer —
@@ -1936,10 +1958,33 @@ tool confirm_versions:
             return ([], False)
         url = (api_base + '/orgs/' + quote(org, safe='') + '/dependabot/alerts?per_page=100&state=' +
                quote('open,fixed', safe=',') + '&package=' + quote(','.join(sorted(names)), safe=','))
-        data = budgeted(lambda: get(url, token), 'alerts ' + org)
-        if not isinstance(data, list):
-            return ([], False)
-        return (data, True)
+        ## One page of 100 is NOT the answer. A single package already yielded
+        ## 78 alerts in one org on the first live tick, and an advisory naming
+        ## several packages across a 388-repo org exceeds 100 routinely — so
+        ## page 2 onwards would vanish precisely on the biggest, most urgent
+        ## advisories, which is the under-reporting this node exists to fix.
+        ## Bounded like the sibling lane, and truncation is REPORTED: a walk
+        ## that stopped early returns checked=False, so the unit reads
+        ## "not verified" rather than as a complete answer.
+        out, pages = [], 0
+        while url:
+            got = budgeted(lambda u=url: get(u, token), 'alerts ' + org)
+            if got is None or not isinstance(got[0], list):
+                return (out, False)
+            out.extend(got[0])
+            pages += 1
+            try:
+                url = next_link(got[1])
+            except Exception as e:
+                errors.append({'what': 'alerts ' + org + ' pagination',
+                               'error': type(e).__name__ + ': ' + str(e)[:200]})
+                return (out, False)
+            if url and pages >= MAX_PAGES:
+                errors.append({'what': 'alerts ' + org,
+                               'error': 'more than ' + str(MAX_PAGES) + ' pages of matching alerts;'
+                                        ' the remainder was not scanned'})
+                return (out, False)
+        return (out, True)
 
     confirmable = 0
     confirmed = 0

--- a/bots/vuln-watch/main.bot
+++ b/bots/vuln-watch/main.bot
@@ -410,6 +410,7 @@ tool plan:
         'fix_see_source': 'see the advisory',
         'projects': 'Affected projects',
         'confirmed_projects': 'Vulnerable — confirmed',
+        'fixed_projects': 'Was vulnerable — already fixed',
         'declared_projects': 'Declares this technology — to verify',
         'not_a_package': 'no dependency package to check against (deployed product): version not verifiable automatically',
         'check_unavailable': 'version NOT verified this run (no advisory match, lookup budget or API error) — assume nothing',
@@ -1731,10 +1732,14 @@ tool confirm_versions:
   ##
   ## GOTCHA, paid for: `state=all` is NOT a valid value for that endpoint,
   ## and GitHub answers 200 with an EMPTY list instead of an error — the
-  ## confirmation would have been silently, permanently empty. OMIT the
-  ## parameter to get every state (open + fixed + dismissed); measured
-  ## `state=open&package=uuid` -> 73, `state=all&package=uuid` -> 0,
-  ## no state param -> 78.
+  ## confirmation would have been silently, permanently empty. Measured
+  ## `state=open&package=uuid` -> 73, `state=all&package=uuid` -> 0, no state
+  ## param -> 78. The REASON, per GitHub's own OpenAPI description: `state` is
+  ## a comma-separated LIST over {auto_dismissed, dismissed, fixed, open}, and
+  ## `all` is simply not a member — so it matches nothing rather than
+  ## everything. `open,fixed` is the valid spelling of what this node wants
+  ## (an exposure, and the window of a closed one), and it drops both
+  ## dismissal states server-side: a dismissal is a decision, not an exposure.
   input: confirm_input
   output: confirm_output
   language: py
@@ -1890,12 +1895,13 @@ tool confirm_versions:
         ## instead of one per ecosystem, and the (ecosystem, name) pair is
         ## re-checked on the way back so nothing is lost by dropping it.
         ##
-        ## NO `state` parameter either — see the GOTCHA in this node's header.
+        ## `state=open,fixed` — NEVER `state=all`; see the GOTCHA in this
+        ## node's header for why the latter silently matches nothing.
         token = tokens.get(org) or tokens.get('*')
         if not token:
             return ([], False)
-        url = (api_base + '/orgs/' + quote(org, safe='') + '/dependabot/alerts?per_page=100&package=' +
-               quote(','.join(sorted(names)), safe=','))
+        url = (api_base + '/orgs/' + quote(org, safe='') + '/dependabot/alerts?per_page=100&state=' +
+               quote('open,fixed', safe=',') + '&package=' + quote(','.join(sorted(names)), safe=','))
         data = budgeted(lambda: get(url, token), 'alerts ' + org)
         if not isinstance(data, list):
             return ([], False)
@@ -2086,9 +2092,17 @@ tool notify:
             ## nobody reads. What confirm_versions proved comes FIRST and stays
             ## short; the rest is demoted to context, explicitly unverified.
             conf = a.get('confirmed_repos') or []
-            if conf:
+            def render_repos(group, heading):
+                ## A heading is what a skimmed security message is read by, so
+                ## an already-fixed match must NEVER sit under one that asserts
+                ## current exposure — its "was vulnerable" detail line does not
+                ## undo the word above it. Open exposures and closed history are
+                ## two sections; the window is kept, it is just not called a
+                ## vulnerability any more.
+                if not group:
+                    return
                 bits = []
-                for c in conf[:12]:
+                for c in group[:12]:
                     who = flat(c.get('repo'), 100)
                     detail = []
                     if c.get('fix'):
@@ -2101,9 +2115,12 @@ tool notify:
                                       .replace('{since}', flat(c['since'], 10))
                                       .replace('{until}', flat(c['until'], 10)))
                     bits.append('`' + who + '`' + ((' ' + ' · '.join(detail)) if detail else ''))
-                extra = len(conf) - len(bits)
-                lines.append(labels['confirmed_projects'] + ' (' + str(len(conf)) + '): ' + ', '.join(bits) +
+                extra = len(group) - len(bits)
+                lines.append(heading + ' (' + str(len(group)) + '): ' + ', '.join(bits) +
                              ((' +' + str(extra) + ' ' + labels['more']) if extra > 0 else ''))
+            if conf:
+                render_repos([c for c in conf if c.get('state') == 'open'], labels['confirmed_projects'])
+                render_repos([c for c in conf if c.get('state') != 'open'], labels['fixed_projects'])
             else:
                 ## Say WHY nothing is confirmed. "none_found" and "this kind of
                 ## technology cannot be checked" are different facts, and

--- a/bots/vuln-watch/main.bot
+++ b/bots/vuln-watch/main.bot
@@ -1875,14 +1875,31 @@ tool confirm_versions:
         adv_cache[cve] = res
         return res
 
-    def alerts_for(org, eco, names):
+    def alerts_for(org, names):
+        ## Returns (alerts, checked). `checked` is False whenever NO answer was
+        ## obtained — no token for the org, no budget left, an HTTP error. An
+        ## org that was never asked is not an org where nothing was found, and
+        ## only this flag can tell the two apart downstream.
+        ##
+        ## NO `ecosystem` parameter, deliberately: the advisory database's
+        ## vocabulary is WIDER than this endpoint's (it returns `actions`,
+        ## `erlang`, `other`, `swift`, none of which the alerts endpoint
+        ## accepts), so forwarding one verbatim 422s — and a swallowed 422
+        ## reads as an all-clear. The `package` filter narrows server-side on
+        ## its own (measured: `package=uuid` -> 78), one request per org
+        ## instead of one per ecosystem, and the (ecosystem, name) pair is
+        ## re-checked on the way back so nothing is lost by dropping it.
+        ##
+        ## NO `state` parameter either — see the GOTCHA in this node's header.
         token = tokens.get(org) or tokens.get('*')
         if not token:
-            return []
-        ## NO state parameter — see the GOTCHA in this node's header.
-        url = (api_base + '/orgs/' + quote(org, safe='') + '/dependabot/alerts?per_page=100&ecosystem=' +
-               quote(eco, safe='') + '&package=' + quote(','.join(sorted(names)), safe=','))
-        return budgeted(lambda: get(url, token), 'alerts ' + org + '/' + eco) or []
+            return ([], False)
+        url = (api_base + '/orgs/' + quote(org, safe='') + '/dependabot/alerts?per_page=100&package=' +
+               quote(','.join(sorted(names)), safe=','))
+        data = budgeted(lambda: get(url, token), 'alerts ' + org)
+        if not isinstance(data, list):
+            return ([], False)
+        return (data, True)
 
     confirmable = 0
     confirmed = 0
@@ -1907,35 +1924,54 @@ tool confirm_versions:
                                   else 'unavailable')
             continue
         confirmable += 1
-        by_eco = {}
-        for eco, name in pkgs:
-            by_eco.setdefault(eco, set()).add(name)
+        names = set(n for _, n in pkgs)
         cveset = set(cves)
         hits = {}
+        ## An advisory read that failed leaves the package set incomplete, so
+        ## whatever the alert lane then finds cannot be a COMPLETE answer.
+        checked, complete = False, ('failed' not in adv_status)
         for org in orgs:
-            for eco, names in by_eco.items():
-                for al in alerts_for(org, eco, names):
-                    adv = (al.get('security_advisory') or {})
-                    if cveset and (adv.get('cve_id') or '') not in cveset:
-                        continue
-                    repo = ((al.get('repository') or {}).get('full_name') or '')
-                    if not repo:
-                        continue
-                    sv = (al.get('security_vulnerability') or {})
-                    rec = hits.setdefault(repo, {'repo': repo, 'state': al.get('state') or '',
-                                                 'package': ((al.get('dependency') or {}).get('package') or {}).get('name') or '',
-                                                 'fix': ((sv.get('first_patched_version') or {}) or {}).get('identifier') or '',
-                                                 'since': (al.get('created_at') or '')[:10],
-                                                 'until': (al.get('fixed_at') or '')[:10]})
-                    ## An open alert always wins over a fixed one for the same
-                    ## repo: still-vulnerable is the actionable truth.
-                    if (al.get('state') or '') == 'open':
-                        rec['state'] = 'open'
-                        rec['until'] = ''
+            got, ok = alerts_for(org, names)
+            checked = checked or ok
+            complete = complete and ok
+            for al in got:
+                if not isinstance(al, dict):
+                    continue
+                adv = (al.get('security_advisory') or {})
+                if cveset and (adv.get('cve_id') or '') not in cveset:
+                    continue
+                pk = ((al.get('dependency') or {}).get('package') or {})
+                ## The ecosystem is no longer filtered server-side (see
+                ## alerts_for), so the pair is re-checked here: a package name
+                ## can collide across ecosystems.
+                if ((pk.get('ecosystem') or '').lower(), pk.get('name') or '') not in pkgs:
+                    continue
+                repo = ((al.get('repository') or {}).get('full_name') or '')
+                if not repo:
+                    continue
+                sv = (al.get('security_vulnerability') or {})
+                rec = hits.setdefault(repo, {'repo': repo, 'state': al.get('state') or '',
+                                             'package': pk.get('name') or '',
+                                             'fix': ((sv.get('first_patched_version') or {}) or {}).get('identifier') or '',
+                                             'since': (al.get('created_at') or '')[:10],
+                                             'until': (al.get('fixed_at') or '')[:10]})
+                ## An open alert always wins over a fixed one for the same
+                ## repo: still-vulnerable is the actionable truth.
+                if (al.get('state') or '') == 'open':
+                    rec['state'] = 'open'
+                    rec['until'] = ''
         a['confirmed_repos'] = sorted(hits.values(), key=lambda r: (r['state'] != 'open', r['repo']))
-        a['version_check'] = 'confirmed' if hits else 'none_found'
         if hits:
+            a['version_check'] = 'confirmed'
             confirmed += 1
+        else:
+            ## An empty result is an ALL-CLEAR only where a check actually ran
+            ## to completion. No org configured, no token for one, a spent
+            ## budget, an HTTP error, a partial advisory resolution — every one
+            ## of them yields the same empty set, and rendering that as "no
+            ## vulnerable dependency found in the watched orgs" is a false
+            ## all-clear on a security message.
+            a['version_check'] = 'none_found' if (checked and complete) else 'unavailable'
 
     parts = [str(confirmed) + '/' + str(confirmable) + ' unit(s) version-confirmed',
              str(lookups[0]) + ' lookup(s)']

--- a/bots/vuln-watch/main.bot
+++ b/bots/vuln-watch/main.bot
@@ -2044,9 +2044,14 @@ tool confirm_versions:
             ## reached because the CVE list was cut, says nothing at all —
             ## dressing any of those up as "deployed product" states a
             ## confident fact about the technology on no evidence.
+            ## Membership is NOT the test: adv_status is one state per CVE, so
+            ## `'indexed' in ...` is true as soon as ONE of them resolved. A
+            ## unit mixing an indexed CVE with an unindexed one would then be
+            ## called a deployed product on the strength of the CVE GitHub was
+            ## never asked to explain. Require the WHOLE head to be indexed —
+            ## an unindexed CVE is the same epistemic state as a failed read.
             a['version_check'] = ('not_a_package'
-                                  if ('indexed' in adv_status and 'failed' not in adv_status
-                                      and not truncated_cves)
+                                  if (adv_status == {'indexed'} and not truncated_cves)
                                   else 'unavailable')
             continue
         confirmable += 1
@@ -2058,10 +2063,15 @@ tool confirm_versions:
         ## version and its dates, and the message showed ONE fix as though it
         ## covered the repository.
         matches = {}
-        ## An advisory read that failed — or a CVE list cut short — leaves the
-        ## package set incomplete, so whatever the alert lane then finds cannot
-        ## be a COMPLETE answer, and an empty one cannot be an all-clear.
-        checked, complete = False, ('failed' not in adv_status and not truncated_cves)
+        ## An advisory read that failed, a CVE GitHub has no advisory indexed
+        ## for, or a CVE list cut short — each leaves the package set
+        ## incomplete, so whatever the alert lane then finds cannot be a
+        ## COMPLETE answer, and an empty one cannot be an all-clear. An
+        ## unindexed CVE is not a lesser doubt than a failed read: its affected
+        ## package was never named, so it was never looked for.
+        checked, complete = False, ('failed' not in adv_status
+                                    and 'not_indexed' not in adv_status
+                                    and not truncated_cves)
         for org in orgs:
             got, ok = alerts_for(org, names)
             checked = checked or ok

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -1364,7 +1364,7 @@ the run, a source silent for too long is announced on the sinks.
   digest (use feed-watch), not a PR dependency gate (use
   supply-shield-cve), not a code audit (use sec-audit-*); it never
   edits code.
-- **Vars**: `allow_private_sources` (bool), `config_path` (string), `dry_run` (bool), `fetch_timeout_secs` (int), `inventory_path` (string), `kev_max_age_days` (int), `max_alerts_per_run` (int), `max_version_lookups` (int), `mode` (string), `observe_window_days` (int), `scratch_dir` (string), `source_stale_hours` (int), `state_commit` (bool), `state_dir` (string), `workspace_dir` (string)
+- **Vars**: `allow_private_sources` (bool), `config_path` (string), `dry_run` (bool), `fetch_timeout_secs` (int), `inventory_path` (string), `kev_max_age_days` (int), `max_alerts_per_run` (int), `max_version_lookups` (int), `max_version_seconds` (int), `mode` (string), `observe_window_days` (int), `scratch_dir` (string), `source_stale_hours` (int), `state_commit` (bool), `state_dir` (string), `workspace_dir` (string)
 - **Path**: `bots/vuln-watch/main.bot`
 
 ### `whats-next` — Nexie

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -1364,7 +1364,7 @@ the run, a source silent for too long is announced on the sinks.
   digest (use feed-watch), not a PR dependency gate (use
   supply-shield-cve), not a code audit (use sec-audit-*); it never
   edits code.
-- **Vars**: `allow_private_sources` (bool), `config_path` (string), `dry_run` (bool), `fetch_timeout_secs` (int), `inventory_path` (string), `kev_max_age_days` (int), `max_alerts_per_run` (int), `mode` (string), `observe_window_days` (int), `scratch_dir` (string), `source_stale_hours` (int), `state_commit` (bool), `state_dir` (string), `workspace_dir` (string)
+- **Vars**: `allow_private_sources` (bool), `config_path` (string), `dry_run` (bool), `fetch_timeout_secs` (int), `inventory_path` (string), `kev_max_age_days` (int), `max_alerts_per_run` (int), `max_version_lookups` (int), `mode` (string), `observe_window_days` (int), `scratch_dir` (string), `source_stale_hours` (int), `state_commit` (bool), `state_dir` (string), `workspace_dir` (string)
 - **Path**: `bots/vuln-watch/main.bot`
 
 ### `whats-next` — Nexie

--- a/docs/bot-runs/vuln-watch.md
+++ b/docs/bot-runs/vuln-watch.md
@@ -1,5 +1,33 @@
 # vuln-watch (Senti) — run log
 
+## 2026-08-27 — prod wiring, first live alerts (runs 01a04222 / 01a04232 / 01a04234)
+
+- Status: **validated** — Senti is live on the cloud instance, hourly at `17 * * * *`.
+- Versions: bot 0.1.0 · iterion v3.64.1 (prod)
+- Method: cloud runs against `SocialGouv/iterion-veille@main`, `mode=watch`,
+  `state_commit=true`; credentials from the **watch-only GitHub App** path
+  (PR #527), not a PAT.
+- Result: the never-exercised App flow works end to end. `poll_dependabot`
+  reported `orgs_ok: 2, orgs_failed: 0, new_alerts: 200` — proving the
+  `dependabot_tokens` map is keyed by ORG (`socialgouv`, `dnum-socialgouv`)
+  and not by the App's bot handle. Run 1 (dry) and run 2 (real) were
+  BOOTSTRAP: 0 alerts, 77 observed, cursors armed and state pushed. Run 3
+  posted **5 alerts, delivered 5/5** to `#veille-vigie-secu`.
+- Value: the five are exactly the shape the design promises — exploitation-driven
+  and project-scoped. React Server Components (KEV 2025-12-05, EPSS 100%) named
+  **53 projects**; GitLab (KEV 2024-05-01) **17**; WordPress **1** (RITM); plus
+  Metabase and a Splunk/Kafka unit. Zero LLM tokens, zero project names sent to
+  a model.
+- Findings / misses: none new. The 5-alert figure matches the replayed
+  acceptance measurement exactly, across a completely different credential path.
+- Engine hardening: the watch-only App + `forge.Purpose` seam (PR #527) exists
+  *because* widening the runtime forge App to All-repositories would have granted
+  `contents:write` on 388 repos to obtain a read. Three adversarial reviewers plus
+  one Revi round found 21 real defects in it before merge.
+- Lessons for next run: a `dry_run` does NOT commit state, so the first real run
+  is always another BOOTSTRAP — budget two ticks before expecting alerts. The
+  per-run cap never engaged (0 overflow) on a 5-alert backlog.
+
 ## 2026-08-24 — retro-Metabase acceptance probe (runs 01a0352e-*, 01a03530-*)
 - Status: validated
 - Versions: bot 0.1.0 · iterion v3.58.3+7dd9767f6 (feat/vuln-watch-senti)

--- a/e2e/vuln_watch_test.go
+++ b/e2e/vuln_watch_test.go
@@ -89,6 +89,10 @@ type vulnWatchHarness struct {
 	// (`actions`, `erlang`, `other`, `swift` come back from /advisories and are
 	// all refused here).
 	rejectEcosystem atomic.Bool
+	// refuseAdvisoryToken makes /advisories 403 any authenticated request while
+	// still serving the anonymous one — the shape of an App installation token
+	// scoped to something this endpoint does not recognise.
+	refuseAdvisoryToken atomic.Bool
 	// depQueries records every query string the alerts endpoint received, so a
 	// test can assert HOW it was asked — the `state=all` trap is invisible in
 	// the response (GitHub answers 200 + empty list, never an error).
@@ -230,6 +234,10 @@ func newVulnWatchHarness(t *testing.T) *vulnWatchHarness {
 	mux.HandleFunc("/advisories", func(w http.ResponseWriter, r *http.Request) {
 		if to, _ := h.redirectAdvisoriesTo.Load().(string); to != "" {
 			http.Redirect(w, r, to, http.StatusFound)
+			return
+		}
+		if h.refuseAdvisoryToken.Load() && r.Header.Get("Authorization") != "" {
+			w.WriteHeader(http.StatusForbidden)
 			return
 		}
 		byCVE, _ := h.advisoryPkgs.Load().(map[string][]map[string]string)
@@ -2688,4 +2696,39 @@ func TestVulnWatch_ACutCVEListIsNeverAConfidentAnswer(t *testing.T) {
 			t.Fatalf("a cut CVE list must read as unverified, got %q", vc)
 		}
 	})
+}
+
+// /advisories is a PUBLIC endpoint — it answers unauthenticated (verified
+// against the live API). The token sent with it buys only the authenticated
+// rate limit, and the one available here is some org's Dependabot credential:
+// in production a watch-only GitHub App installation token whose manifest
+// permissions were REPLACED by metadata + vulnerability_alerts read, which
+// this endpoint has no reason to accept. If it 403s, every advisory lookup
+// fails, every unit renders "not verified", and the whole confirmation stops
+// working silently — the exact capability degradation this bot must not have.
+func TestVulnWatch_AdvisoryLookupSurvivesATokenTheEndpointRefuses(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	h := newVulnWatchHarness(t)
+	// Refuse the bearer, exactly as an App token scoped to something else
+	// would be refused — but serve the public read.
+	h.refuseAdvisoryToken.Store(true)
+	h.setAdvisoryPkgs(map[string][]map[string]string{
+		"CVE-2026-7090": {{"ecosystem": "npm", "name": "acme-lib"}},
+	})
+	h.depAlerts.Store([]map[string]any{vwAlert("acme/site", "acme-lib", "npm",
+		"CVE-2026-7090", "open", "2026-08-01T00:00:00Z", "", "2.0.1")})
+
+	alerts := []map[string]any{{"key": "kev:CVE-2026-7090", "cves": []string{"CVE-2026-7090"},
+		"title": "token probe", "severity": "critical", "project_names": []string{"proj"}}}
+	out, stderr, err := vwConfirm(t, wf, h, h.srv.URL, alerts)
+	if err != nil {
+		t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+	}
+	got, _ := out["alerts"].([]any)
+	if vc, _ := got[0].(map[string]any)["version_check"].(string); vc != "confirmed" {
+		t.Fatalf("a refused bearer on a PUBLIC endpoint took the whole confirmation down, got %q", vc)
+	}
 }

--- a/e2e/vuln_watch_test.go
+++ b/e2e/vuln_watch_test.go
@@ -79,6 +79,10 @@ type vulnWatchHarness struct {
 	epssScores               atomic.Value // map[string]string served by /epss
 	// advisoryPkgs feeds GET /advisories?cve_id=… : cve -> [{ecosystem,name}].
 	advisoryPkgs atomic.Value
+	// redirectAdvisoriesTo, when set, makes /advisories answer a 302 there —
+	// the shape that gives urllib's default opener its chance to carry the
+	// Authorization header off the API origin.
+	redirectAdvisoriesTo atomic.Value
 	// depQueries records every query string the alerts endpoint received, so a
 	// test can assert HOW it was asked — the `state=all` trap is invisible in
 	// the response (GitHub answers 200 + empty list, never an error).
@@ -163,6 +167,10 @@ func newVulnWatchHarness(t *testing.T) *vulnWatchHarness {
 		_ = json.NewEncoder(w).Encode(alerts)
 	})
 	mux.HandleFunc("/advisories", func(w http.ResponseWriter, r *http.Request) {
+		if to, _ := h.redirectAdvisoriesTo.Load().(string); to != "" {
+			http.Redirect(w, r, to, http.StatusFound)
+			return
+		}
 		byCVE, _ := h.advisoryPkgs.Load().(map[string][]map[string]string)
 		pkgs := byCVE[r.URL.Query().Get("cve_id")]
 		var vulns []map[string]any
@@ -1905,5 +1913,64 @@ func vwAlert(repo, pkg, eco, cve, state, created, fixedAt, patched string) map[s
 			"summary": cve + " summary", "severity": "critical"},
 		"security_vulnerability": map[string]any{
 			"first_patched_version": map[string]any{"identifier": patched}},
+	}
+}
+
+// vwConfirm drives confirm_versions alone against an arbitrary API base — the
+// node is where the org's Dependabot token is spent, so its egress guards are
+// worth exercising directly rather than only through a whole watch cycle.
+func vwConfirm(t *testing.T, wf *ir.Workflow, h *vulnWatchHarness, apiBase string, alerts []map[string]any) (map[string]any, string, error) {
+	t.Helper()
+	return runPy(t, h.ws, vwSub(t, vwTool(t, wf, "confirm_versions").Script, map[string]any{
+		"alerts": alerts, "github_orgs": []string{"testorg"},
+		"github_api_base": apiBase, "timeout_secs": 5,
+		"allow_private": true, "max_lookups": 40,
+	}, nil, map[string]string{"dependabot_tokens": h.tokensFile}))
+}
+
+// urllib's default opener copies the Authorization header onto a redirected
+// request and compares no hosts, so a 30x answered by the API origin hands the
+// org's Dependabot token to whoever the Location names. The pin has to be the
+// full ORIGIN, not the hostname: a same-name hop to another scheme or port is
+// exactly as much of a leak, and the "same host" spelling of the guard would
+// wave both through.
+func TestVulnWatch_VersionCheckNeverCarriesTheTokenOffOrigin(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	h := newVulnWatchHarness(t)
+
+	// The attacker end: a SECOND origin on the same hostname (127.0.0.1) and a
+	// different port — what a hostname-only guard would happily follow.
+	var leaked atomic.Bool
+	var reached atomic.Bool
+	thief := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached.Store(true)
+		if r.Header.Get("Authorization") != "" {
+			leaked.Store(true)
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer thief.Close()
+	h.redirectAdvisoriesTo.Store(thief.URL + "/stolen")
+
+	alerts := []map[string]any{{"key": "kev:CVE-2026-7010", "cves": []string{"CVE-2026-7010"},
+		"title": "redirect probe", "severity": "critical", "project_names": []string{"proj"}}}
+	out, stderr, err := vwConfirm(t, wf, h, h.srv.URL, alerts)
+	if err != nil {
+		t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+	}
+	if leaked.Load() {
+		t.Fatal("the Dependabot token was handed to another origin across a redirect")
+	}
+	if reached.Load() {
+		t.Fatal("the redirect off the API origin was followed at all — the hop must be refused before it is made")
+	}
+	// And the refusal must be REPORTED, not silently read as an answer: a
+	// swallowed hop that renders as an all-clear is the failure mode of its own.
+	errs, _ := out["errors"].([]any)
+	if len(errs) == 0 {
+		t.Fatalf("the refused redirect must surface as a lookup error, got: %v", out)
 	}
 }

--- a/e2e/vuln_watch_test.go
+++ b/e2e/vuln_watch_test.go
@@ -2279,3 +2279,86 @@ func TestVulnWatch_ConfirmedMeansOpen_DismissedAndFixedDoNot(t *testing.T) {
 		t.Fatalf("the open exposure must be the one named as confirmed:\n%s", msg)
 	}
 }
+
+// hits used to be keyed by REPOSITORY alone, with the "open wins over fixed"
+// promotion overwriting only the state. Two defects fell out of that, and
+// neither is controllable by ordering — it follows org iteration and GitHub's
+// own sort:
+//
+//   - a repo whose FIXED alert was seen first, then an open one, kept the
+//     fixed alert's package, fix version and created_at while being stamped
+//     open — an open exposure dated from a resolved one, pointed at the fix
+//     version of possibly another package;
+//   - a repo running TWO simultaneously-affected packages showed only one,
+//     as though that single fix covered the repository.
+//
+// The operator-facing count must nevertheless stay REPOSITORIES: keying by
+// (repo, package) without regrouping would inflate one finding into two.
+func TestVulnWatch_EveryAffectedPackageSurvivesAndTheCountStaysRepos(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	h := newVulnWatchHarness(t)
+	h.setAdvisoryPkgs(map[string][]map[string]string{
+		"CVE-2026-7050": {{"ecosystem": "npm", "name": "acme-lib"}, {"ecosystem": "npm", "name": "acme-core"}},
+	})
+	h.depAlerts.Store([]map[string]any{
+		// The FIXED alert first, deliberately: this is the order that used to
+		// date the open exposure from the resolved one.
+		vwAlert("acme/site", "acme-lib", "npm", "CVE-2026-7050", "fixed", "2026-01-01T00:00:00Z", "2026-02-01T00:00:00Z", "1.0.9"),
+		vwAlert("acme/site", "acme-lib", "npm", "CVE-2026-7050", "open", "2026-08-01T00:00:00Z", "", "2.0.1"),
+		// A second, simultaneously-open package in the SAME repo.
+		vwAlert("acme/site", "acme-core", "npm", "CVE-2026-7050", "open", "2026-08-02T00:00:00Z", "", "3.1.4"),
+	})
+
+	alerts := []map[string]any{{"key": "kev:CVE-2026-7050", "cves": []string{"CVE-2026-7050"},
+		"title": "multi-package", "severity": "critical", "project_names": []string{"proj"}}}
+	out, stderr, err := vwConfirm(t, wf, h, h.srv.URL, alerts)
+	if err != nil {
+		t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+	}
+	// What the operator READS is the oracle, so it is checked before the shape.
+	msg := vwRender(t, wf, h, out["alerts"])
+	if strings.Contains(msg, "1.0.9") {
+		t.Fatalf("the open exposure points at the fix version of the RESOLVED alert seen first:\n%s", msg)
+	}
+	if strings.Contains(msg, "2026-01-01") {
+		t.Fatalf("the open exposure is dated from the RESOLVED alert seen first:\n%s", msg)
+	}
+	for _, want := range []string{"acme-lib → 2.0.1", "acme-core → 3.1.4"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("missing %q — half an exposure reads as a whole one:\n%s", want, msg)
+		}
+	}
+	if !strings.Contains(msg, "Vulnerable — confirmed (1)") {
+		t.Fatalf("the count must read as repositories, not matches:\n%s", msg)
+	}
+
+	got, _ := out["alerts"].([]any)
+	repos, _ := got[0].(map[string]any)["confirmed_repos"].([]any)
+	if len(repos) != 1 {
+		t.Fatalf("one repository, one finding — got %d: %v", len(repos), repos)
+	}
+	rec, _ := repos[0].(map[string]any)
+	if st, _ := rec["state"].(string); st != "open" {
+		t.Fatalf("the repo is still vulnerable, got state %q", st)
+	}
+	pkgs, _ := rec["packages"].([]any)
+	fixes := map[string]string{}
+	for _, p := range pkgs {
+		m, _ := p.(map[string]any)
+		name, _ := m["package"].(string)
+		fix, _ := m["fix"].(string)
+		fixes[name] = fix
+		if since, _ := m["since"].(string); since == "2026-01-01" {
+			t.Fatalf("%s: the open exposure is dated from the RESOLVED alert seen first", name)
+		}
+	}
+	if fixes["acme-lib"] != "2.0.1" {
+		t.Fatalf("acme-lib must carry the OPEN alert's fix version, got %q", fixes["acme-lib"])
+	}
+	if fixes["acme-core"] != "3.1.4" {
+		t.Fatalf("the second open package was dropped — one fix shown as though it covered the repo: %v", fixes)
+	}
+}

--- a/e2e/vuln_watch_test.go
+++ b/e2e/vuln_watch_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -190,10 +191,41 @@ func newVulnWatchHarness(t *testing.T) *vulnWatchHarness {
 			if kept == nil {
 				kept = []map[string]any{}
 			}
-			_ = json.NewEncoder(w).Encode(kept)
-			return
+			alerts = kept
 		}
-		_ = json.NewEncoder(w).Encode(alerts)
+		// Paginate like the real endpoint — per_page + a Link: rel="next"
+		// header — or a test asserting the walk is vacuous, and the silent
+		// truncation this reproduces stays invisible.
+		perPage := 100
+		if v := r.URL.Query().Get("per_page"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				perPage = n
+			}
+		}
+		page := 1
+		if v := r.URL.Query().Get("page"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				page = n
+			}
+		}
+		start := (page - 1) * perPage
+		if start > len(alerts) {
+			start = len(alerts)
+		}
+		end := start + perPage
+		if end > len(alerts) {
+			end = len(alerts)
+		}
+		if end < len(alerts) {
+			nextQ := r.URL.Query()
+			nextQ.Set("page", strconv.Itoa(page+1))
+			w.Header().Set("Link", "<"+h.srv.URL+r.URL.Path+"?"+nextQ.Encode()+`>; rel="next"`)
+		}
+		out := alerts[start:end]
+		if out == nil {
+			out = []map[string]any{}
+		}
+		_ = json.NewEncoder(w).Encode(out)
 	})
 	mux.HandleFunc("/advisories", func(w http.ResponseWriter, r *http.Request) {
 		if to, _ := h.redirectAdvisoriesTo.Load().(string); to != "" {
@@ -2431,5 +2463,106 @@ func TestVulnWatch_ASlowAPICostsPrecisionNotDelivery(t *testing.T) {
 		if !strings.Contains(delivered, want) {
 			t.Fatalf("delivery must survive a degraded confirmation — %s never reached the sink:\n%s", want, delivered)
 		}
+	}
+}
+
+// alerts_for asked for per_page=100 and never followed Link: rel="next" —
+// indeed get() discarded r.headers entirely, so pagination was not even
+// OBSERVABLE from this node. The branch's own measurement shows a single
+// package yielding 78 alerts in one org; an advisory naming several packages
+// across a 388-repo org exceeds 100 routinely, and every repo past the first
+// page vanished with no marker. Under-reporting the confirmed set is the
+// failure this node exists to fix, and it degraded exactly on the biggest,
+// most urgent advisories. The sibling poll_dependabot lane takes this
+// seriously (MAX_PAGES with a truncated flag, "truncation is REPORTED, never
+// silent"); this lane had neither.
+func TestVulnWatch_ConfirmationWalksPastTheFirstPage(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	h := newVulnWatchHarness(t)
+	h.setAdvisoryPkgs(map[string][]map[string]string{
+		"CVE-2026-7070": {{"ecosystem": "npm", "name": "acme-lib"}},
+	})
+	// 150 affected repos: one full page plus a remainder.
+	var alerts []map[string]any
+	for i := 0; i < 150; i++ {
+		alerts = append(alerts, vwAlert(fmt.Sprintf("acme/repo-%03d", i), "acme-lib", "npm",
+			"CVE-2026-7070", "open", "2026-08-01T00:00:00Z", "", "2.0.1"))
+	}
+	h.depAlerts.Store(alerts)
+
+	unit := []map[string]any{{"key": "kev:CVE-2026-7070", "cves": []string{"CVE-2026-7070"},
+		"title": "big advisory", "severity": "critical", "project_names": []string{"proj"}}}
+	out, stderr, err := vwConfirm(t, wf, h, h.srv.URL, unit)
+	if err != nil {
+		t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+	}
+	got, _ := out["alerts"].([]any)
+	repos, _ := got[0].(map[string]any)["confirmed_repos"].([]any)
+	if len(repos) != 150 {
+		t.Fatalf("the walk stopped at one page: %d of 150 repos confirmed", len(repos))
+	}
+	// The last repo lives only on page 2.
+	last := false
+	for _, r := range repos {
+		if n, _ := r.(map[string]any)["repo"].(string); n == "acme/repo-149" {
+			last = true
+		}
+	}
+	if !last {
+		t.Fatal("acme/repo-149 is on page 2 and was dropped with no marker")
+	}
+}
+
+// And when the walk IS cut short, what it did not reach must not be presented
+// as an answer. This is the sharp case: page 1 holds only NON-matching alerts
+// and every real match lives on page 2. Unpaginated — or paginated but silent
+// about stopping — the node sees nothing, concludes nothing is there, and
+// renders the explicit all-clear "no vulnerable dependency found in the
+// watched orgs" over 50 genuinely vulnerable repositories.
+func TestVulnWatch_TruncatedWalkIsReportedNotPresentedAsComplete(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	h := newVulnWatchHarness(t)
+	h.setAdvisoryPkgs(map[string][]map[string]string{
+		"CVE-2026-7071": {{"ecosystem": "npm", "name": "acme-lib"}},
+	})
+	var alerts []map[string]any
+	// Page 1: 100 alerts on the same package but a DIFFERENT advisory, so the
+	// cve filter drops every one of them.
+	for i := 0; i < 100; i++ {
+		alerts = append(alerts, vwAlert(fmt.Sprintf("acme/other-%03d", i), "acme-lib", "npm",
+			"CVE-2026-9999", "open", "2026-08-01T00:00:00Z", "", "2.0.1"))
+	}
+	// Page 2: the 50 repos that are actually vulnerable.
+	for i := 0; i < 50; i++ {
+		alerts = append(alerts, vwAlert(fmt.Sprintf("acme/hit-%03d", i), "acme-lib", "npm",
+			"CVE-2026-7071", "open", "2026-08-01T00:00:00Z", "", "2.0.1"))
+	}
+	h.depAlerts.Store(alerts)
+
+	unit := []map[string]any{{"key": "kev:CVE-2026-7071", "cves": []string{"CVE-2026-7071"},
+		"title": "big advisory", "severity": "critical", "project_names": []string{"proj"}}}
+	// Budget: one advisory lookup + exactly one alerts page, then nothing left.
+	out, stderr, err := runPy(t, h.ws, vwSub(t, vwTool(t, wf, "confirm_versions").Script, map[string]any{
+		"alerts": unit, "github_orgs": []string{"testorg"}, "github_api_base": h.srv.URL,
+		"timeout_secs": 5, "allow_private": true, "max_lookups": 2, "max_seconds": 0,
+	}, nil, map[string]string{"dependabot_tokens": h.tokensFile}))
+	if err != nil {
+		t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+	}
+	got, _ := out["alerts"].([]any)
+	unitOut, _ := got[0].(map[string]any)
+	if vc, _ := unitOut["version_check"].(string); vc == "none_found" {
+		t.Fatal("the walk stopped before the page holding all 50 vulnerable repos, and the message reads \"no vulnerable dependency found in the watched orgs\"")
+	} else if vc != "unavailable" {
+		t.Fatalf("a walk cut short must read as unverified, got %q", vc)
+	}
+	if msg := vwRender(t, wf, h, out["alerts"]); strings.Contains(msg, "no vulnerable dependency found") {
+		t.Fatalf("a truncated walk rendered as an all-clear:\n%s", msg)
 	}
 }

--- a/e2e/vuln_watch_test.go
+++ b/e2e/vuln_watch_test.go
@@ -77,8 +77,15 @@ type vulnWatchHarness struct {
 	feedItems                atomic.Value // []vwFeedItem
 	enrichBroken             atomic.Bool  // when set, <link>/json/ answers 503
 	epssScores               atomic.Value // map[string]string served by /epss
-	srv                      *httptest.Server
-	sinkHits                 atomic.Int64
+	// advisoryPkgs feeds GET /advisories?cve_id=… : cve -> [{ecosystem,name}].
+	advisoryPkgs atomic.Value
+	// depQueries records every query string the alerts endpoint received, so a
+	// test can assert HOW it was asked — the `state=all` trap is invisible in
+	// the response (GitHub answers 200 + empty list, never an error).
+	depQueryMu sync.Mutex
+	depQueries []string
+	srv        *httptest.Server
+	sinkHits   atomic.Int64
 	// sinkBodies is appended from HTTP handler goroutines and read from the
 	// test goroutine — guard it, or the race detector is right to complain.
 	sinkMu     sync.Mutex
@@ -114,6 +121,7 @@ func newVulnWatchHarness(t *testing.T) *vulnWatchHarness {
 	h.depAlerts.Store([]map[string]any{})
 	h.feedItems.Store([]vwFeedItem{})
 	h.epssScores.Store(map[string]string{})
+	h.advisoryPkgs.Store(map[string][]map[string]string{})
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/orgs/testorg/dependabot/alerts", func(w http.ResponseWriter, r *http.Request) {
@@ -121,7 +129,54 @@ func newVulnWatchHarness(t *testing.T) *vulnWatchHarness {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-		_ = json.NewEncoder(w).Encode(h.depAlerts.Load())
+		h.depQueryMu.Lock()
+		h.depQueries = append(h.depQueries, r.URL.RawQuery)
+		h.depQueryMu.Unlock()
+		alerts, _ := h.depAlerts.Load().([]map[string]any)
+		// Mirror the REAL endpoint: `state=all` is not a valid value and
+		// GitHub answers an EMPTY list rather than erroring. A confirmation
+		// built on it would be silently, permanently empty — so the fake has
+		// to reproduce the trap, not paper over it.
+		if r.URL.Query().Get("state") == "all" {
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+			return
+		}
+		if want := r.URL.Query().Get("package"); want != "" {
+			names := map[string]bool{}
+			for _, n := range strings.Split(want, ",") {
+				names[strings.TrimSpace(n)] = true
+			}
+			var kept []map[string]any
+			for _, a := range alerts {
+				dep, _ := a["dependency"].(map[string]any)
+				pkg, _ := dep["package"].(map[string]any)
+				if name, _ := pkg["name"].(string); names[name] {
+					kept = append(kept, a)
+				}
+			}
+			if kept == nil {
+				kept = []map[string]any{}
+			}
+			_ = json.NewEncoder(w).Encode(kept)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(alerts)
+	})
+	mux.HandleFunc("/advisories", func(w http.ResponseWriter, r *http.Request) {
+		byCVE, _ := h.advisoryPkgs.Load().(map[string][]map[string]string)
+		pkgs := byCVE[r.URL.Query().Get("cve_id")]
+		var vulns []map[string]any
+		for _, pk := range pkgs {
+			vulns = append(vulns, map[string]any{"package": map[string]any{
+				"ecosystem": pk["ecosystem"], "name": pk["name"]}})
+		}
+		if vulns == nil {
+			// A deployed product (Metabase, GitLab, a WordPress install) has
+			// no package in any manifest — an empty answer is a real answer.
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]map[string]any{{"vulnerabilities": vulns}})
 	})
 	mux.HandleFunc("/alerte/feed/", func(w http.ResponseWriter, r *http.Request) {
 		items := h.feedItems.Load().([]vwFeedItem)
@@ -401,8 +456,21 @@ func (h *vulnWatchHarness) runWatchOpts(t *testing.T, wf *ir.Workflow, dryRun bo
 		t.Fatalf("match_policy failed: %v\nstderr: %s", err, stderr)
 	}
 
+	// The version confirmation sits between the policy and the message: it is
+	// what turns "these projects declare this technology" into "this repo runs
+	// an affected version". The harness drives nodes by hand, so a node added
+	// to the graph has to be added HERE too or it silently never runs.
+	confirm, stderr, err := runPy(t, h.ws, vwSub(t, vwTool(t, wf, "confirm_versions").Script, map[string]any{
+		"alerts": match["alerts"], "github_orgs": plan["github_orgs"],
+		"github_api_base": plan["github_api_base"], "timeout_secs": 5,
+		"allow_private": true, "max_lookups": 40,
+	}, nil, map[string]string{"dependabot_tokens": h.tokensFile}))
+	if err != nil {
+		t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+	}
+
 	notify, stderr, err = runPy(t, h.ws, vwSub(t, vwTool(t, wf, "notify").Script, map[string]any{
-		"alerts": match["alerts"], "overflow_count": match["overflow_count"],
+		"alerts": confirm["alerts"], "overflow_count": match["overflow_count"],
 		"stale_sources": match["stale_sources"], "sinks": plan["sinks"],
 		"labels": plan["labels"], "dry_run": dryRun,
 	}, nil, map[string]string{"webhooks": h.webhooksFile}))
@@ -1693,5 +1761,149 @@ func TestVulnWatch_EPSSLaneAndSeverityFloor(t *testing.T) {
 	}
 	if msg := h2.lastBody(t); !strings.Contains(msg, "severity floor") {
 		t.Fatalf("the message must say what qualified it:\n%s", msg)
+	}
+}
+
+// setAdvisoryPkgs declares which packages the advisory database attributes to
+// a CVE — the authority the version confirmation consults first.
+func (h *vulnWatchHarness) setAdvisoryPkgs(m map[string][]map[string]string) {
+	h.advisoryPkgs.Store(m)
+}
+
+// queries snapshots how the alerts endpoint was asked.
+func (h *vulnWatchHarness) queries() []string {
+	h.depQueryMu.Lock()
+	defer h.depQueryMu.Unlock()
+	return append([]string(nil), h.depQueries...)
+}
+
+// The inventory match is keyword-based and VERSION-BLIND: it answers "who
+// declares this technology", not "who is vulnerable". Measured on the first
+// live tick, a React Server Components advisory named 53 projects while
+// exactly ONE repository carried an affected package. An alert that over-names
+// by 53x is the kind operators stop reading — which is the failure this bot
+// exists to prevent. So a confirmed repo must be named FIRST, with its fix,
+// and the keyword list demoted to explicitly-unverified context.
+func TestVulnWatch_ConfirmedVersionsOutrankTheKeywordList(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	h := newVulnWatchHarness(t)
+	h.setAdvisoryPkgs(map[string][]map[string]string{
+		"CVE-2026-7001": {{"ecosystem": "npm", "name": "acme-lib"}},
+	})
+	h.depAlerts.Store([]map[string]any{vwAlert("acme/site", "acme-lib", "npm",
+		"CVE-2026-7001", "open", "2026-08-01T00:00:00Z", "", "2.0.1")})
+
+	h.setKEV([]map[string]any{{"cveID": "CVE-2000-0001", "vendorProject": "x",
+		"product": "x", "dateAdded": "2026-01-01"}})
+	h.runWatch(t, wf, false) // bootstrap arms the cursors
+
+	h.setKEV([]map[string]any{
+		{"cveID": "CVE-2000-0001", "vendorProject": "x", "product": "x", "dateAdded": "2026-01-01"},
+		{"cveID": "CVE-2026-7001", "vendorProject": "Metabase", "product": "Metabase",
+			"vulnerabilityName": "Metabase SQL injection", "dateAdded": "2026-08-25"},
+	})
+	if _, _ = h.runWatch(t, wf, false); true {
+		msg := h.lastBody(t)
+		if !strings.Contains(msg, "Vulnerable — confirmed") {
+			t.Fatalf("no confirmed section — the keyword list is standing in for verification:\n%s", msg)
+		}
+		if !strings.Contains(msg, "acme/site") || !strings.Contains(msg, "2.0.1") {
+			t.Fatalf("the confirmed repo and its fixed version must be named:\n%s", msg)
+		}
+		if !strings.Contains(msg, "Declares this technology — to verify") {
+			t.Fatalf("the keyword list must be demoted, not dropped or promoted:\n%s", msg)
+		}
+	}
+}
+
+// THE CANARY for a trap that costs nothing to fall into and everything to
+// miss: `state=all` is not a valid value for the Dependabot alerts endpoint,
+// and GitHub answers 200 with an EMPTY list instead of an error. Measured on
+// the real API: `state=open&package=uuid` -> 73, `state=all&package=uuid` -> 0,
+// no state parameter -> 78. A confirmation built on `state=all` is silently
+// and permanently empty — and every message would fall back to the keyword
+// list while claiming to have checked.
+func TestVulnWatch_VersionCheckNeverAsksForStateAll(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	h := newVulnWatchHarness(t)
+	h.setAdvisoryPkgs(map[string][]map[string]string{
+		"CVE-2026-7002": {{"ecosystem": "npm", "name": "acme-lib"}},
+	})
+	h.depAlerts.Store([]map[string]any{vwAlert("acme/site", "acme-lib", "npm",
+		"CVE-2026-7002", "open", "2026-08-01T00:00:00Z", "", "2.0.1")})
+	h.setKEV([]map[string]any{{"cveID": "CVE-2000-0002", "vendorProject": "x",
+		"product": "x", "dateAdded": "2026-01-01"}})
+	h.runWatch(t, wf, false)
+	h.setKEV([]map[string]any{
+		{"cveID": "CVE-2000-0002", "vendorProject": "x", "product": "x", "dateAdded": "2026-01-01"},
+		{"cveID": "CVE-2026-7002", "vendorProject": "Metabase", "product": "Metabase",
+			"vulnerabilityName": "Metabase SQL injection", "dateAdded": "2026-08-25"},
+	})
+	h.runWatch(t, wf, false)
+
+	saw := false
+	for _, q := range h.queries() {
+		if strings.Contains(q, "state=all") {
+			t.Fatalf("the version check asked for state=all — GitHub answers an empty list, so it would never confirm anything: %q", q)
+		}
+		if strings.Contains(q, "package=") {
+			saw = true
+		}
+	}
+	if !saw {
+		t.Fatal("no package-filtered query was made — the version check never ran")
+	}
+	if msg := h.lastBody(t); !strings.Contains(msg, "acme/site") {
+		t.Fatalf("the confirmation produced nothing:\n%s", msg)
+	}
+}
+
+// A deployed product — Metabase, GitLab, a WordPress install — has no package
+// in any dependency manifest, so it can NEVER be confirmed this way. Saying
+// "no vulnerable dependency found" there would read as "you are safe", which
+// is the opposite of the truth. The two facts must not collapse into one.
+func TestVulnWatch_UnverifiableTechnologySaysSoInsteadOfLookingClean(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	h := newVulnWatchHarness(t)
+	h.setAdvisoryPkgs(map[string][]map[string]string{}) // no package for any CVE
+	h.setKEV([]map[string]any{{"cveID": "CVE-2000-0003", "vendorProject": "x",
+		"product": "x", "dateAdded": "2026-01-01"}})
+	h.runWatch(t, wf, false)
+	h.setKEV([]map[string]any{
+		{"cveID": "CVE-2000-0003", "vendorProject": "x", "product": "x", "dateAdded": "2026-01-01"},
+		{"cveID": "CVE-2026-7003", "vendorProject": "Metabase", "product": "Metabase",
+			"vulnerabilityName": "Metabase SQL injection", "dateAdded": "2026-08-25"},
+	})
+	h.runWatch(t, wf, false)
+	msg := h.lastBody(t)
+	if !strings.Contains(msg, "not verifiable automatically") {
+		t.Fatalf("an unverifiable technology must say so:\n%s", msg)
+	}
+	if strings.Contains(msg, "no vulnerable dependency found") {
+		t.Fatalf("'nothing found' must not stand in for 'cannot be checked':\n%s", msg)
+	}
+}
+
+// vwAlert builds one Dependabot alert record in the shape the endpoint returns.
+func vwAlert(repo, pkg, eco, cve, state, created, fixedAt, patched string) map[string]any {
+	return map[string]any{
+		"state":      state,
+		"created_at": created,
+		"fixed_at":   fixedAt,
+		"repository": map[string]any{"full_name": repo},
+		"dependency": map[string]any{"package": map[string]any{"name": pkg, "ecosystem": eco}},
+		"security_advisory": map[string]any{"cve_id": cve, "ghsa_id": "GHSA-" + cve,
+			"summary": cve + " summary", "severity": "critical"},
+		"security_vulnerability": map[string]any{
+			"first_patched_version": map[string]any{"identifier": patched}},
 	}
 }

--- a/e2e/vuln_watch_test.go
+++ b/e2e/vuln_watch_test.go
@@ -2613,3 +2613,79 @@ func TestVulnWatch_DependabotLaneUnitsSpendNoConfirmationBudget(t *testing.T) {
 		t.Fatalf("expected exactly 2 lookups (advisory + alerts for the KEV unit), got %v", out["lookups"])
 	}
 }
+
+// Only the first 6 CVEs of a unit are resolved, and that head carries NO
+// signal: poll_advisories stores the set sorted(), so they are the six
+// lowest-numbered ids — the oldest years, not the advisory's subject. The
+// committed comment claimed otherwise. A CERT-FR avis routinely carries more,
+// so the CVE that actually names the affected package can sit past the cut.
+// Unlike the pagination cut there is not even a page-size signal to notice it
+// from: it has to be marked at the source, or an incomplete look renders as a
+// complete answer.
+func TestVulnWatch_ACutCVEListIsNeverAConfidentAnswer(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+
+	// Eight CVEs. Sorted, CVE-2026-7108 lands past the six-CVE head — and it
+	// is the only one naming a package. The head is a product advisory that
+	// legitimately names none, which is what makes the answer look confident.
+	var cves []string
+	for i := 1; i <= 8; i++ {
+		cves = append(cves, fmt.Sprintf("CVE-2026-71%02d", i))
+	}
+	adv := map[string][]map[string]string{
+		"CVE-2026-7101": {}, // indexed, names no package: the deployed-product shape
+		"CVE-2026-7108": {{"ecosystem": "npm", "name": "acme-lib"}},
+	}
+
+	t.Run("no deployed-product claim on evidence never gathered", func(t *testing.T) {
+		h := newVulnWatchHarness(t)
+		h.setAdvisoryPkgs(adv)
+		alerts := []map[string]any{{"key": "avis:CERTFR-2026-AVI-001", "cves": cves,
+			"title": "a CERT-FR avis", "severity": "critical", "project_names": []string{"proj"}}}
+		out, stderr, err := vwConfirm(t, wf, h, h.srv.URL, alerts)
+		if err != nil {
+			t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+		}
+		got, _ := out["alerts"].([]any)
+		vc, _ := got[0].(map[string]any)["version_check"].(string)
+		if vc == "not_a_package" {
+			t.Fatal("the CVE naming the package sits past the cut, yet the unit claims the technology has no package to check — a deployed-product claim on evidence never gathered")
+		}
+		if vc != "unavailable" {
+			t.Fatalf("a cut CVE list must read as unverified, got %q", vc)
+		}
+		if msg := vwRender(t, wf, h, out["alerts"]); strings.Contains(msg, "deployed product") {
+			t.Fatalf("a cut CVE list rendered as a deployed-product claim:\n%s", msg)
+		}
+	})
+
+	// And the same cut must not produce the other confident answer either:
+	// packages resolved from the head, nothing found for them, but a CVE past
+	// the cut could have named a package that IS running somewhere.
+	t.Run("no all-clear on evidence never gathered", func(t *testing.T) {
+		h := newVulnWatchHarness(t)
+		withHead := map[string][]map[string]string{
+			"CVE-2026-7101": {{"ecosystem": "npm", "name": "unused-lib"}},
+			"CVE-2026-7108": {{"ecosystem": "npm", "name": "acme-lib"}},
+		}
+		h.setAdvisoryPkgs(withHead)
+		h.depAlerts.Store([]map[string]any{}) // nothing matches what the head named
+		alerts := []map[string]any{{"key": "avis:CERTFR-2026-AVI-002", "cves": cves,
+			"title": "a CERT-FR avis", "severity": "critical", "project_names": []string{"proj"}}}
+		out, stderr, err := vwConfirm(t, wf, h, h.srv.URL, alerts)
+		if err != nil {
+			t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+		}
+		got, _ := out["alerts"].([]any)
+		vc, _ := got[0].(map[string]any)["version_check"].(string)
+		if vc == "none_found" {
+			t.Fatal("two of the unit's CVEs were never looked at, yet the message reads \"no vulnerable dependency found in the watched orgs\"")
+		}
+		if vc != "unavailable" {
+			t.Fatalf("a cut CVE list must read as unverified, got %q", vc)
+		}
+	})
+}

--- a/e2e/vuln_watch_test.go
+++ b/e2e/vuln_watch_test.go
@@ -511,7 +511,7 @@ func (h *vulnWatchHarness) runWatchOpts(t *testing.T, wf *ir.Workflow, dryRun bo
 	confirm, stderr, err := runPy(t, h.ws, vwSub(t, vwTool(t, wf, "confirm_versions").Script, map[string]any{
 		"alerts": match["alerts"], "github_orgs": plan["github_orgs"],
 		"github_api_base": plan["github_api_base"], "timeout_secs": 5,
-		"allow_private": true, "max_lookups": 40,
+		"allow_private": true, "max_lookups": 40, "max_seconds": 0,
 	}, nil, map[string]string{"dependabot_tokens": h.tokensFile}))
 	if err != nil {
 		t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
@@ -1986,7 +1986,7 @@ func vwConfirm(t *testing.T, wf *ir.Workflow, h *vulnWatchHarness, apiBase strin
 	return runPy(t, h.ws, vwSub(t, vwTool(t, wf, "confirm_versions").Script, map[string]any{
 		"alerts": alerts, "github_orgs": []string{"testorg"},
 		"github_api_base": apiBase, "timeout_secs": 5,
-		"allow_private": true, "max_lookups": 40,
+		"allow_private": true, "max_lookups": 40, "max_seconds": 0,
 	}, nil, map[string]string{"dependabot_tokens": h.tokensFile}))
 }
 
@@ -2153,6 +2153,7 @@ func TestVulnWatch_UncheckedIsNeverRenderedAsAnAllClear(t *testing.T) {
 			out, stderr, err := runPy(t, h.ws, vwSub(t, vwTool(t, wf, "confirm_versions").Script, map[string]any{
 				"alerts": unit(), "github_orgs": orgs, "github_api_base": h.srv.URL,
 				"timeout_secs": 5, "allow_private": true, "max_lookups": maxLookups,
+				"max_seconds": 0,
 			}, nil, map[string]string{"dependabot_tokens": h.tokensFile}))
 			if err != nil {
 				t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
@@ -2360,5 +2361,75 @@ func TestVulnWatch_EveryAffectedPackageSurvivesAndTheCountStaysRepos(t *testing.
 	}
 	if fixes["acme-core"] != "3.1.4" {
 		t.Fatalf("the second open package was dropped — one fix shown as though it covered the repo: %v", fixes)
+	}
+}
+
+// A COUNT of lookups is not a wall-clock bound. At the committed defaults, 40
+// sequential requests x a 20s per-request timeout is 800s against a 900s
+// max_duration — before DNS, body reads, and the three polling lanes that run
+// first. And confirm_versions sits upstream of BOTH notify and commit_state,
+// so overrunning the workflow budget means no message delivered and no state
+// consumed: the bot goes silent for exactly as long as GitHub is slow, which
+// directly contradicts this node's own contract ("it must never be the reason
+// an hourly tick hangs"). Delivery is at-least-once, so nothing is lost
+// permanently — but prolonged silence on a security watch IS the failure.
+func TestVulnWatch_ASlowAPICostsPrecisionNotDelivery(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	h := newVulnWatchHarness(t)
+
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(3 * time.Second)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer slow.Close()
+
+	// Ten units, each needing a lookup: without a deadline this is ten
+	// sequential stalls, and the node's cost grows with the alert backlog.
+	var alerts []map[string]any
+	for i := 0; i < 10; i++ {
+		cve := fmt.Sprintf("CVE-2026-70%02d", 60+i)
+		alerts = append(alerts, map[string]any{"key": "kev:" + cve, "cves": []string{cve},
+			"title": "slow " + cve, "severity": "critical", "project_names": []string{"proj"}})
+	}
+
+	start := time.Now()
+	out, stderr, err := runPy(t, h.ws, vwSub(t, vwTool(t, wf, "confirm_versions").Script, map[string]any{
+		"alerts": alerts, "github_orgs": []string{"testorg"}, "github_api_base": slow.URL,
+		"timeout_secs": 20, "allow_private": true, "max_lookups": 40, "max_seconds": 5,
+	}, nil, map[string]string{"dependabot_tokens": h.tokensFile}))
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+	}
+	// 10 units x 3s would be 30s unbounded. The deadline is 5s; allow the one
+	// in-flight request to finish plus interpreter start-up.
+	if elapsed > 20*time.Second {
+		t.Fatalf("the deadline did not bound the node: %s elapsed on a 5s window", elapsed)
+	}
+	if s, _ := out["summary"].(string); !strings.Contains(s, "deadline") {
+		t.Fatalf("a truncated confirmation must SAY so, got summary %q", s)
+	}
+	// And what it could not check must degrade to "not verified" — never to
+	// the all-clear, which is what makes prolonged silence into a wrong answer.
+	got, _ := out["alerts"].([]any)
+	if len(got) != len(alerts) {
+		t.Fatalf("every alert must survive the node, got %d of %d", len(got), len(alerts))
+	}
+	for i, g := range got {
+		if vc, _ := g.(map[string]any)["version_check"].(string); vc == "none_found" || vc == "confirmed" {
+			t.Fatalf("alert %d was never checked, yet reads as %q", i, vc)
+		}
+	}
+	// The whole point: every message still goes out.
+	vwRender(t, wf, h, out["alerts"])
+	delivered := strings.Join(h.bodies(), "\n")
+	for i := range alerts {
+		want := fmt.Sprintf("CVE-2026-70%02d", 60+i)
+		if !strings.Contains(delivered, want) {
+			t.Fatalf("delivery must survive a degraded confirmation — %s never reached the sink:\n%s", want, delivered)
+		}
 	}
 }

--- a/e2e/vuln_watch_test.go
+++ b/e2e/vuln_watch_test.go
@@ -2768,3 +2768,70 @@ func TestVulnWatch_HarnessDrivesEveryNodeInTheGraph(t *testing.T) {
 		}
 	}
 }
+
+// adv_status holds ONE state per CVE, so testing it by MEMBERSHIP answers a
+// different question than the one that matters. A CERT-FR avis routinely
+// carries several CVEs, and GitHub's advisory database only indexes those it
+// can map to a packaging ecosystem — so `{indexed, not_indexed}` is the common
+// case for exactly the multi-CVE units this node exists to disambiguate.
+// Claiming "deployed product" there states a confident fact about the
+// technology on the strength of the CVE GitHub was never asked to explain.
+func TestVulnWatch_MixedIndexedCVEsAreNotADeployedProductClaim(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	h := newVulnWatchHarness(t)
+	// CVE-A resolves to an advisory that names NO package (a deployed
+	// product); CVE-B is not indexed at all. Neither yields a package, but the
+	// two states are not the same epistemic thing.
+	h.setAdvisoryPkgs(map[string][]map[string]string{"CVE-2026-7040": {}})
+
+	alerts := []map[string]any{{"key": "adv:mixed", "cves": []string{"CVE-2026-7040", "CVE-2026-7041"},
+		"title": "mixed", "severity": "critical", "project_names": []string{"proj"}}}
+	out, stderr, err := vwConfirm(t, wf, h, h.srv.URL, alerts)
+	if err != nil {
+		t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+	}
+	got, _ := out["alerts"].([]any)
+	vc, _ := got[0].(map[string]any)["version_check"].(string)
+	if vc == "not_a_package" {
+		t.Fatal("a unit mixing an indexed and an unindexed CVE was called a deployed product — the unindexed one was never explained")
+	}
+	if vc != "unavailable" {
+		t.Fatalf("version_check = %q, want unavailable", vc)
+	}
+}
+
+// The same membership bug on the other side: with CVE-A indexed to a package
+// nobody runs and CVE-B unindexed, the lookup legitimately finds nothing — but
+// CVE-B's affected package was never named, so it was never looked for.
+// Printing the explicit all-clear there is a false all-clear on a security
+// message.
+func TestVulnWatch_MixedIndexedCVEsCannotProduceAnAllClear(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	h := newVulnWatchHarness(t)
+	h.setAdvisoryPkgs(map[string][]map[string]string{
+		"CVE-2026-7050": {{"ecosystem": "npm", "name": "nobody-runs-this"}},
+		// CVE-2026-7051 deliberately absent => not_indexed.
+	})
+	h.depAlerts.Store([]map[string]any{}) // the lane finds nothing for that package
+
+	alerts := []map[string]any{{"key": "adv:mixed2", "cves": []string{"CVE-2026-7050", "CVE-2026-7051"},
+		"title": "mixed", "severity": "critical", "project_names": []string{"proj"}}}
+	out, stderr, err := vwConfirm(t, wf, h, h.srv.URL, alerts)
+	if err != nil {
+		t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+	}
+	got, _ := out["alerts"].([]any)
+	vc, _ := got[0].(map[string]any)["version_check"].(string)
+	if vc == "none_found" {
+		t.Fatal("an all-clear was emitted while one CVE's affected package was never named, let alone searched for")
+	}
+	if vc != "unavailable" {
+		t.Fatalf("version_check = %q, want unavailable", vc)
+	}
+}

--- a/e2e/vuln_watch_test.go
+++ b/e2e/vuln_watch_test.go
@@ -2732,3 +2732,39 @@ func TestVulnWatch_AdvisoryLookupSurvivesATokenTheEndpointRefuses(t *testing.T) 
 		t.Fatalf("a refused bearer on a PUBLIC endpoint took the whole confirmation down, got %q", vc)
 	}
 }
+
+// The harness drives this bot's nodes BY HAND rather than running the engine,
+// which is what makes the suite fast and credential-free — and what lets the
+// graph and the harness drift apart in silence. confirm_versions came with a
+// comment saying exactly that ("a node added to the graph has to be added HERE
+// too or it silently never runs"), but a comment is not a check: a future node
+// wired into the workflow and forgotten here would be covered by nothing, and
+// every existing test would still pass.
+//
+// This is that check. It is deliberately scoped to this one bot's fixture, so
+// it can only ever fail on the bot the suite is about.
+func TestVulnWatch_HarnessDrivesEveryNodeInTheGraph(t *testing.T) {
+	wf := compileFixture(t, "vuln-watch/main.bot")
+
+	// Every tool node the harness is known to drive (see runWatchOpts and the
+	// per-node tests). Adding a node to main.bot without wiring it here — or
+	// into runWatchOpts — is the drift this test exists to catch.
+	driven := map[string]bool{
+		"plan": true, "poll_dependabot": true, "poll_advisories": true,
+		"poll_exploit": true, "match_policy": true, "confirm_versions": true,
+		"notify": true, "commit_state": true,
+	}
+	for id, node := range wf.Nodes {
+		if _, isTool := node.(*ir.ToolNode); !isTool {
+			continue
+		}
+		if !driven[id] {
+			t.Errorf("tool node %q is in the workflow but no test drives it — the harness executes nodes by hand, so it is covered by nothing", id)
+		}
+	}
+	for id := range driven {
+		if _, ok := wf.Nodes[id]; !ok {
+			t.Errorf("the harness claims to drive %q, which no longer exists in the workflow", id)
+		}
+	}
+}

--- a/e2e/vuln_watch_test.go
+++ b/e2e/vuln_watch_test.go
@@ -83,6 +83,11 @@ type vulnWatchHarness struct {
 	// the shape that gives urllib's default opener its chance to carry the
 	// Authorization header off the API origin.
 	redirectAdvisoriesTo atomic.Value
+	// rejectEcosystem makes the alerts endpoint 422 on any `ecosystem` filter,
+	// as the real one does for a value outside its own narrower vocabulary
+	// (`actions`, `erlang`, `other`, `swift` come back from /advisories and are
+	// all refused here).
+	rejectEcosystem atomic.Bool
 	// depQueries records every query string the alerts endpoint received, so a
 	// test can assert HOW it was asked — the `state=all` trap is invisible in
 	// the response (GitHub answers 200 + empty list, never an error).
@@ -136,6 +141,10 @@ func newVulnWatchHarness(t *testing.T) *vulnWatchHarness {
 		h.depQueryMu.Lock()
 		h.depQueries = append(h.depQueries, r.URL.RawQuery)
 		h.depQueryMu.Unlock()
+		if h.rejectEcosystem.Load() && r.URL.Query().Get("ecosystem") != "" {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			return
+		}
 		alerts, _ := h.depAlerts.Load().([]map[string]any)
 		// Mirror the REAL endpoint: `state=all` is not a valid value and
 		// GitHub answers an EMPTY list rather than erroring. A confirmation
@@ -2056,5 +2065,102 @@ func TestVulnWatch_FailedAdvisoryReadIsNotADeployedProductClaim(t *testing.T) {
 	}
 	if hits.Load() < 2 {
 		t.Fatalf("the failed read was cached (%d attempts): one blip would mis-stamp every later unit on that CVE", hits.Load())
+	}
+}
+
+// "no vulnerable dependency found in the watched orgs" is an ALL-CLEAR, and an
+// all-clear on a security message is only honest when a check actually ran.
+// The same empty result comes back when no org is configured, when no token
+// covers one, when the lookup budget is spent, and when the API errors — and
+// every one of those used to render as the all-clear.
+func TestVulnWatch_UncheckedIsNeverRenderedAsAnAllClear(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	unit := func() []map[string]any {
+		return []map[string]any{{"key": "kev:CVE-2026-7030", "cves": []string{"CVE-2026-7030"},
+			"title": "all-clear probe", "severity": "critical", "project_names": []string{"proj"}}}
+	}
+	adv := map[string][]map[string]string{"CVE-2026-7030": {{"ecosystem": "npm", "name": "acme-lib"}}}
+
+	for _, tc := range []struct {
+		name  string
+		apply func(t *testing.T, h *vulnWatchHarness) (orgs []string, maxLookups int)
+	}{
+		// No org to ask: a feed+KEV-only deployment is a valid configuration
+		// (plan only fails when orgs AND feeds AND kev_url are all empty).
+		{"no org configured", func(t *testing.T, h *vulnWatchHarness) ([]string, int) {
+			return []string{}, 40
+		}},
+		// A token map that covers no configured org: alerts_for used to return
+		// an empty list before making any request at all.
+		{"no token for the org", func(t *testing.T, h *vulnWatchHarness) ([]string, int) {
+			if err := os.WriteFile(h.tokensFile, []byte(`{"otherorg":"tok-other"}`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			return []string{"testorg"}, 40
+		}},
+		// Budget spent on the advisory read, nothing left for the alert read.
+		{"lookup budget spent", func(t *testing.T, h *vulnWatchHarness) ([]string, int) {
+			return []string{"testorg"}, 1
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newVulnWatchHarness(t)
+			h.setAdvisoryPkgs(adv)
+			orgs, maxLookups := tc.apply(t, h)
+			out, stderr, err := runPy(t, h.ws, vwSub(t, vwTool(t, wf, "confirm_versions").Script, map[string]any{
+				"alerts": unit(), "github_orgs": orgs, "github_api_base": h.srv.URL,
+				"timeout_secs": 5, "allow_private": true, "max_lookups": maxLookups,
+			}, nil, map[string]string{"dependabot_tokens": h.tokensFile}))
+			if err != nil {
+				t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+			}
+			got, _ := out["alerts"].([]any)
+			vc, _ := got[0].(map[string]any)["version_check"].(string)
+			if vc == "none_found" {
+				t.Fatal("nothing was checked, yet the unit is stamped none_found — the message would read \"no vulnerable dependency found in the watched orgs\"")
+			}
+			if vc != "unavailable" {
+				t.Fatalf("an unchecked unit must read as unverified, got %q", vc)
+			}
+		})
+	}
+}
+
+// The advisory database's ecosystem vocabulary is WIDER than the Dependabot
+// alerts endpoint's: /advisories returns `actions`, `erlang`, `other` and
+// `swift`, and the alerts endpoint accepts none of them. Forwarding one
+// verbatim 422s, budgeted() swallows it, and the unit renders as an all-clear.
+// GitHub Actions advisories are not exotic.
+func TestVulnWatch_EcosystemOutsideTheAlertsVocabularyStillConfirms(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	h := newVulnWatchHarness(t)
+	h.setAdvisoryPkgs(map[string][]map[string]string{
+		"CVE-2026-7031": {{"ecosystem": "actions", "name": "acme/checkout"}},
+	})
+	// The real endpoint 422s on an ecosystem it does not know; reproduce that
+	// rather than papering over it.
+	h.rejectEcosystem.Store(true)
+	h.depAlerts.Store([]map[string]any{vwAlert("acme/site", "acme/checkout", "actions",
+		"CVE-2026-7031", "open", "2026-08-01T00:00:00Z", "", "v4.2.0")})
+
+	alerts := []map[string]any{{"key": "kev:CVE-2026-7031", "cves": []string{"CVE-2026-7031"},
+		"title": "actions advisory", "severity": "critical", "project_names": []string{"proj"}}}
+	out, stderr, err := vwConfirm(t, wf, h, h.srv.URL, alerts)
+	if err != nil {
+		t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+	}
+	got, _ := out["alerts"].([]any)
+	vc, _ := got[0].(map[string]any)["version_check"].(string)
+	if vc == "none_found" {
+		t.Fatal("a 422 on the ecosystem filter rendered as an all-clear")
+	}
+	if vc != "confirmed" {
+		t.Fatalf("the actions advisory is confirmable without the ecosystem filter, got %q", vc)
 	}
 }

--- a/e2e/vuln_watch_test.go
+++ b/e2e/vuln_watch_test.go
@@ -2566,3 +2566,50 @@ func TestVulnWatch_TruncatedWalkIsReportedNotPresentedAsComplete(t *testing.T) {
 		t.Fatalf("a truncated walk rendered as an all-clear:\n%s", msg)
 	}
 }
+
+// The Dependabot lane is the one lane that is ALREADY version-precise: its
+// units carry `repos`, the repositories running an affected version. notify
+// renders confirmed_repos only on the branch where `repos` is empty, so a
+// lookup spent on one of those units can never be displayed — it is drawn
+// from the same bounded budget the KEV and feed units need, and those are the
+// units this node exists for. The first live tick had that lane alone
+// reporting ~200 new alerts against max_alerts_per_run=20.
+func TestVulnWatch_DependabotLaneUnitsSpendNoConfirmationBudget(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	h := newVulnWatchHarness(t)
+	h.setAdvisoryPkgs(map[string][]map[string]string{
+		"CVE-2026-7080": {{"ecosystem": "npm", "name": "acme-lib"}},
+		"CVE-2026-7081": {{"ecosystem": "npm", "name": "acme-lib"}},
+	})
+	h.depAlerts.Store([]map[string]any{vwAlert("acme/site", "acme-lib", "npm",
+		"CVE-2026-7081", "open", "2026-08-01T00:00:00Z", "", "2.0.1")})
+
+	alerts := []map[string]any{
+		// Already version-precise: nothing to confirm, nothing renderable.
+		{"key": "dep:CVE-2026-7080", "cves": []string{"CVE-2026-7080"}, "title": "dependabot unit",
+			"severity": "critical", "repos": []string{"acme/known"}, "project_names": []string{"proj"}},
+		// The unit the feature is FOR — it must still get its confirmation.
+		{"key": "kev:CVE-2026-7081", "cves": []string{"CVE-2026-7081"}, "title": "kev unit",
+			"severity": "critical", "project_names": []string{"proj"}},
+	}
+	out, stderr, err := vwConfirm(t, wf, h, h.srv.URL, alerts)
+	if err != nil {
+		t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+	}
+	got, _ := out["alerts"].([]any)
+	dep, _ := got[0].(map[string]any)
+	if _, spent := dep["version_check"]; spent {
+		t.Fatalf("the Dependabot-lane unit was looked up; nothing can render the result: %v", dep["version_check"])
+	}
+	kev, _ := got[1].(map[string]any)
+	if vc, _ := kev["version_check"].(string); vc != "confirmed" {
+		t.Fatalf("the KEV unit is what the budget is for, got %q", vc)
+	}
+	// One advisory + one alerts page for the KEV unit — and nothing else.
+	if n, _ := out["lookups"].(float64); n != 2 {
+		t.Fatalf("expected exactly 2 lookups (advisory + alerts for the KEV unit), got %v", out["lookups"])
+	}
+}

--- a/e2e/vuln_watch_test.go
+++ b/e2e/vuln_watch_test.go
@@ -146,13 +146,33 @@ func newVulnWatchHarness(t *testing.T) *vulnWatchHarness {
 			return
 		}
 		alerts, _ := h.depAlerts.Load().([]map[string]any)
-		// Mirror the REAL endpoint: `state=all` is not a valid value and
-		// GitHub answers an EMPTY list rather than erroring. A confirmation
-		// built on it would be silently, permanently empty — so the fake has
-		// to reproduce the trap, not paper over it.
-		if r.URL.Query().Get("state") == "all" {
-			_ = json.NewEncoder(w).Encode([]map[string]any{})
-			return
+		// Mirror the REAL endpoint: `state` is a comma-separated list over
+		// {auto_dismissed, dismissed, fixed, open} and `all` is not a member,
+		// so GitHub matches NOTHING and answers an empty list rather than
+		// erroring. A confirmation built on it would be silently, permanently
+		// empty — the fake reproduces the trap instead of papering over it,
+		// and honours the filter, or a test asserting one is vacuous.
+		if want := r.URL.Query().Get("state"); want != "" {
+			states := map[string]bool{}
+			for _, s := range strings.Split(want, ",") {
+				states[strings.TrimSpace(s)] = true
+			}
+			var kept []map[string]any
+			for _, a := range alerts {
+				// The real endpoint always carries a state; a fixture that
+				// omits one means the ordinary case, `open`.
+				st, _ := a["state"].(string)
+				if st == "" {
+					st = "open"
+				}
+				if states[st] {
+					kept = append(kept, a)
+				}
+			}
+			if kept == nil {
+				kept = []map[string]any{}
+			}
+			alerts = kept
 		}
 		if want := r.URL.Query().Get("package"); want != "" {
 			names := map[string]bool{}
@@ -1938,6 +1958,26 @@ func vwAlert(repo, pkg, eco, cve, state, created, fixedAt, patched string) map[s
 	}
 }
 
+// vwRender drives notify alone over an already-confirmed alert list, so a test
+// can assert what the operator actually READS without replaying a whole tick.
+func vwRender(t *testing.T, wf *ir.Workflow, h *vulnWatchHarness, alerts any) string {
+	t.Helper()
+	plan, stderr, err := runPy(t, h.ws, vwSub(t, vwTool(t, wf, "plan").Script, nil, map[string]any{
+		"workspace_dir": h.ws, "config_path": "vuln-watch.json",
+		"inventory_path": "inventory.json", "mode": "watch",
+	}, nil))
+	if err != nil {
+		t.Fatalf("plan failed: %v\nstderr: %s", err, stderr)
+	}
+	if _, stderr, err = runPy(t, h.ws, vwSub(t, vwTool(t, wf, "notify").Script, map[string]any{
+		"alerts": alerts, "overflow_count": 0, "stale_sources": []any{},
+		"sinks": plan["sinks"], "labels": plan["labels"], "dry_run": false,
+	}, nil, map[string]string{"webhooks": h.webhooksFile})); err != nil {
+		t.Fatalf("notify failed: %v\nstderr: %s", err, stderr)
+	}
+	return h.lastBody(t)
+}
+
 // vwConfirm drives confirm_versions alone against an arbitrary API base — the
 // node is where the org's Dependabot token is spent, so its egress guards are
 // worth exercising directly rather than only through a whole watch cycle.
@@ -2162,5 +2202,80 @@ func TestVulnWatch_EcosystemOutsideTheAlertsVocabularyStillConfirms(t *testing.T
 	}
 	if vc != "confirmed" {
 		t.Fatalf("the actions advisory is confirmable without the ecosystem filter, got %q", vc)
+	}
+}
+
+// The state parameter used to be omitted entirely, so the endpoint returned
+// `dismissed` and `auto_dismissed` alerts alongside the rest (the branch's own
+// measurement: 73 open vs 78 total for one package) and NOTHING filtered them
+// out. A dismissal is a decision, not an exposure — and it has no fixed_at, so
+// neither the open_since nor the fixed_window detail fired: it printed as a
+// bare repo name under "Vulnerable — confirmed", visually identical to a
+// genuinely-open hit. Over-naming the confirmed list is the exact noise class
+// this whole change exists to remove.
+//
+// A `fixed` alert is the milder half of the same defect: its detail says "was
+// vulnerable", but a skimmed security message is read by its HEADINGS, and the
+// heading above it asserted current exposure.
+func TestVulnWatch_ConfirmedMeansOpen_DismissedAndFixedDoNot(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	h := newVulnWatchHarness(t)
+	h.setAdvisoryPkgs(map[string][]map[string]string{
+		"CVE-2026-7040": {{"ecosystem": "npm", "name": "acme-lib"}},
+	})
+	h.depAlerts.Store([]map[string]any{
+		vwAlert("acme/open-one", "acme-lib", "npm", "CVE-2026-7040", "open", "2026-08-01T00:00:00Z", "", "2.0.1"),
+		vwAlert("acme/fixed-one", "acme-lib", "npm", "CVE-2026-7040", "fixed", "2026-06-01T00:00:00Z", "2026-07-01T00:00:00Z", "2.0.1"),
+		vwAlert("acme/dismissed-one", "acme-lib", "npm", "CVE-2026-7040", "dismissed", "2026-05-01T00:00:00Z", "", "2.0.1"),
+		vwAlert("acme/auto-dismissed-one", "acme-lib", "npm", "CVE-2026-7040", "auto_dismissed", "2026-05-01T00:00:00Z", "", "2.0.1"),
+	})
+
+	alerts := []map[string]any{{"key": "kev:CVE-2026-7040", "cves": []string{"CVE-2026-7040"},
+		"title": "state probe", "severity": "critical", "project_names": []string{"proj"}}}
+	out, stderr, err := vwConfirm(t, wf, h, h.srv.URL, alerts)
+	if err != nil {
+		t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+	}
+	for _, q := range h.queries() {
+		if strings.Contains(q, "state=all") {
+			t.Fatalf("state=all matches nothing — the confirmation would be permanently empty: %q", q)
+		}
+	}
+	got, _ := out["alerts"].([]any)
+	unit, _ := got[0].(map[string]any)
+	repos, _ := unit["confirmed_repos"].([]any)
+	byRepo := map[string]string{}
+	for _, r := range repos {
+		m, _ := r.(map[string]any)
+		name, _ := m["repo"].(string)
+		st, _ := m["state"].(string)
+		byRepo[name] = st
+	}
+	for _, gone := range []string{"acme/dismissed-one", "acme/auto-dismissed-one"} {
+		if _, ok := byRepo[gone]; ok {
+			t.Fatalf("%s was dismissed — a decision is not an exposure, and it would print bare under \"Vulnerable — confirmed\"", gone)
+		}
+	}
+	if byRepo["acme/open-one"] != "open" || byRepo["acme/fixed-one"] != "fixed" {
+		t.Fatalf("open and fixed must both survive, with their states intact: %v", byRepo)
+	}
+
+	// And the message must not file the fixed one under a heading that asserts
+	// current vulnerability.
+	msg := vwRender(t, wf, h, out["alerts"])
+	openIdx := strings.Index(msg, "Vulnerable — confirmed")
+	fixedIdx := strings.Index(msg, "Was vulnerable — already fixed")
+	if openIdx < 0 || fixedIdx < 0 {
+		t.Fatalf("both sections must appear:\n%s", msg)
+	}
+	openLine := msg[openIdx:fixedIdx]
+	if strings.Contains(openLine, "acme/fixed-one") {
+		t.Fatalf("an already-fixed repo sits under the heading asserting current exposure:\n%s", msg)
+	}
+	if !strings.Contains(openLine, "acme/open-one") {
+		t.Fatalf("the open exposure must be the one named as confirmed:\n%s", msg)
 	}
 }

--- a/e2e/vuln_watch_test.go
+++ b/e2e/vuln_watch_test.go
@@ -172,17 +172,28 @@ func newVulnWatchHarness(t *testing.T) *vulnWatchHarness {
 			return
 		}
 		byCVE, _ := h.advisoryPkgs.Load().(map[string][]map[string]string)
-		pkgs := byCVE[r.URL.Query().Get("cve_id")]
+		cve := r.URL.Query().Get("cve_id")
+		pkgs, indexed := byCVE[cve]
+		if !indexed {
+			// The real endpoint returns 200 + an EMPTY list for a CVE it has
+			// no advisory for (measured against an unknown CVE id). That is
+			// not the deployed-product answer — it establishes nothing.
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
+			return
+		}
 		var vulns []map[string]any
 		for _, pk := range pkgs {
 			vulns = append(vulns, map[string]any{"package": map[string]any{
 				"ecosystem": pk["ecosystem"], "name": pk["name"]}})
 		}
+		// A deployed product (Metabase, GitLab, a WordPress install) has no
+		// package in any manifest. Measured on CVE-2023-38646 (Metabase RCE),
+		// the real shape of that answer is ONE advisory whose `vulnerabilities`
+		// array is empty — NOT an empty advisory list. Conflating the two is
+		// what let a "GitHub has never heard of this CVE" read out as a
+		// confident claim about the nature of the technology.
 		if vulns == nil {
-			// A deployed product (Metabase, GitLab, a WordPress install) has
-			// no package in any manifest — an empty answer is a real answer.
-			_ = json.NewEncoder(w).Encode([]map[string]any{})
-			return
+			vulns = []map[string]any{}
 		}
 		_ = json.NewEncoder(w).Encode([]map[string]any{{"vulnerabilities": vulns}})
 	})
@@ -1882,7 +1893,9 @@ func TestVulnWatch_UnverifiableTechnologySaysSoInsteadOfLookingClean(t *testing.
 	}
 	wf := compileFixture(t, "vuln-watch/main.bot")
 	h := newVulnWatchHarness(t)
-	h.setAdvisoryPkgs(map[string][]map[string]string{}) // no package for any CVE
+	// INDEXED, but naming no package — the real shape of the Metabase answer,
+	// and the only one that establishes "deployed product".
+	h.setAdvisoryPkgs(map[string][]map[string]string{"CVE-2026-7003": {}})
 	h.setKEV([]map[string]any{{"cveID": "CVE-2000-0003", "vendorProject": "x",
 		"product": "x", "dateAdded": "2026-01-01"}})
 	h.runWatch(t, wf, false)
@@ -1972,5 +1985,76 @@ func TestVulnWatch_VersionCheckNeverCarriesTheTokenOffOrigin(t *testing.T) {
 	errs, _ := out["errors"].([]any)
 	if len(errs) == 0 {
 		t.Fatalf("the refused redirect must surface as a lookup error, got: %v", out)
+	}
+}
+
+// "GitHub has no advisory indexed for this CVE" and "the advisory exists and
+// names no package" are the same empty package set and COMPLETELY different
+// facts. Only the second says anything about the technology. Deriving the
+// deployed-product claim from the first states a confident fact about what a
+// thing IS out of what the database happens not to hold — and the operator
+// reads that as "checked, nothing to check".
+func TestVulnWatch_UnindexedCVEIsNotADeployedProductClaim(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	h := newVulnWatchHarness(t)
+	// No entry at all for the CVE => the endpoint answers 200 + [].
+	h.setAdvisoryPkgs(map[string][]map[string]string{})
+
+	alerts := []map[string]any{{"key": "kev:CVE-2026-7020", "cves": []string{"CVE-2026-7020"},
+		"title": "unindexed", "severity": "critical", "project_names": []string{"proj"}}}
+	out, stderr, err := vwConfirm(t, wf, h, h.srv.URL, alerts)
+	if err != nil {
+		t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+	}
+	got, _ := out["alerts"].([]any)
+	vc, _ := got[0].(map[string]any)["version_check"].(string)
+	if vc != "unavailable" {
+		t.Fatalf("an unindexed CVE must read as unverified, got %q", vc)
+	}
+}
+
+// A transport failure is not a fact about the technology either. Worse, the
+// answer used to be CACHED, so one blip mis-stamped every later unit sharing
+// that CVE for the rest of the run.
+func TestVulnWatch_FailedAdvisoryReadIsNotADeployedProductClaim(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+	wf := compileFixture(t, "vuln-watch/main.bot")
+	h := newVulnWatchHarness(t)
+
+	var hits atomic.Int64
+	broken := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/advisories") {
+			hits.Add(1)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer broken.Close()
+
+	// TWO units on the same CVE: the second proves the failure was not cached.
+	alerts := []map[string]any{
+		{"key": "kev:CVE-2026-7021", "cves": []string{"CVE-2026-7021"}, "title": "a",
+			"severity": "critical", "project_names": []string{"proj"}},
+		{"key": "feed:CVE-2026-7021", "cves": []string{"CVE-2026-7021"}, "title": "b",
+			"severity": "critical", "project_names": []string{"proj"}},
+	}
+	out, stderr, err := vwConfirm(t, wf, h, broken.URL, alerts)
+	if err != nil {
+		t.Fatalf("confirm_versions failed: %v\nstderr: %s", err, stderr)
+	}
+	got, _ := out["alerts"].([]any)
+	for i, g := range got {
+		if vc, _ := g.(map[string]any)["version_check"].(string); vc != "unavailable" {
+			t.Fatalf("alert %d: a failed advisory read must read as unverified, got %q", i, vc)
+		}
+	}
+	if hits.Load() < 2 {
+		t.Fatalf("the failed read was cached (%d attempts): one blip would mis-stamp every later unit on that CVE", hits.Load())
 	}
 }


### PR DESCRIPTION
## The measurement that motivated this

Senti's first live tick posted an alert for a React Server Components advisory naming **53 projects**. Querying GitHub for the packages that advisory actually names, and then for who runs them, returns **one repository**: `SocialGouv/1000jours`.

A 53× over-report is exactly the noise that makes security alerts get ignored — the failure this bot exists to prevent.

## Why it happened

The project list came from the inventory, which matches by keyword and is therefore **version-blind**: it answers *"who declares React"*, not *"who runs an affected version"*. Only the Dependabot lane was version-precise, and advisory/KEV-driven alerts never touched it.

## What this adds

A `confirm_versions` node between the policy and the message, doing two server-side-filtered reads per alerted unit:

```
/advisories?cve_id=…                    → the packages the advisory names
/orgs/{org}/dependabot/alerts?package=… → who runs an affected version
```

The message now carries **two** lists: what is *confirmed vulnerable* (repo, fixed version, and — from `created_at`/`fixed_at` — since when, or the window it was exposed) first and short; the keyword list demoted to explicitly-unverified context.

## The trap, and its canary

`state=all` is **not** a valid value for the Dependabot alerts endpoint, and GitHub answers `200` with an **empty list** rather than an error. Measured:

| query | alerts |
|---|---|
| `state=open&package=uuid` | 73 |
| `state=all&package=uuid` | **0** |
| `package=uuid` (no state) | 78 |

A confirmation built on it would have been silently and permanently empty while every message claimed to have checked. `TestVulnWatch_VersionCheckNeverAsksForStateAll` fails if the query ever regains it, and the harness's fake API **reproduces** the trap rather than papering over it.

## Three facts kept distinct

Collapsing them would let a deployed product read as safe:

- **confirmed vulnerable** — a repo runs an affected version;
- **nothing found** in the watched orgs;
- **not verifiable at all** — Metabase, GitLab, a WordPress install have no package in any dependency manifest. Their version lives in the infrastructure, and no amount of dependency scanning will find it.

Lookups are bounded by `max_version_lookups` (default 40): the confirmation is a precision nicety, never a reason for an hourly tick to hang.

## Not covered

Version verification still cannot see the **63 repositories with Dependabot alerts disabled** (listed in the veille repo's `coverage.md`) — enabling them org-wide is the cheap fix and widens this feature for free. Deployed-product versions remain out of reach without an infrastructure source of truth.

Every test was seen **RED** by re-introducing its defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
