### PR TITLE
fix(supervise): unpinned evaluator prefers the supervised run's own provider family

### DIFF
--- a/docs/supervisors.md
+++ b/docs/supervisors.md
@@ -59,7 +59,7 @@ allowed (each watching a different node set).
 ```
 supervisor watchdog:
   watches: [implement, fix]            # agent node(s) to steer (omit = whole run)
-  model: "anthropic/claude-opus-5"  # default: auto-detect / ITERION_DEFAULT_SUPERVISOR_MODEL
+  model: "anthropic/claude-opus-5"  # optional pin; resolution below
   system: watchdog_policy              # a prompt: ref — the supervision policy
   cooldown: "45s"                      # min between turn-boundary evals (default 30s)
   max_evals: 12                        # hard eval cap (default 20)
@@ -69,6 +69,18 @@ prompt watchdog_policy:
   Intervene only if the implementer edits files outside src/, or a Bash
   test fails twice in a row. Keep messages short and actionable.
 ```
+
+**Model resolution** (unpinned supervisors): `model:` pin →
+`ITERION_DEFAULT_SUPERVISOR_MODEL` → **the provider family the watched
+nodes themselves run on** (their `provider:` routing, a `provider/`
+model prefix, or the backend's family — claude_code → anthropic,
+codex → openai), taken only when that provider's credential is actually
+detected → the detector's first available provider. The family
+preference is what keeps the coach on the credential the run already
+proved working: without it, a dead key sitting first in the host
+environment (a platform OPENAI key with no credits, on the prod runner
+pods) 429-ed every eval while the supervised campaign ran fine on
+Anthropic.
 
 `monitors:` pre-seeds event patterns at coordinator construction, armed
 as soon as a watched node becomes active (immediately, for a supervisor

--- a/docs/supervisors.md
+++ b/docs/supervisors.md
@@ -74,8 +74,11 @@ prompt watchdog_policy:
 `ITERION_DEFAULT_SUPERVISOR_MODEL` → **the provider family the watched
 nodes themselves run on** (their `provider:` routing, a `provider/`
 model prefix, or the backend's family — claude_code → anthropic,
-codex → openai), taken only when that provider's credential is actually
-detected → the detector's first available provider. The family
+codex → openai), honoured when that provider is detected in the env OR
+funded by the run's own ctx credentials (a per-provider API key, or the
+codex ChatGPT forfait for openai; the anthropic OAuth forfait does NOT
+count — it is usable only by the claude_code CLI, never by claw) → the
+detector's first available provider. The family
 preference is what keeps the coach on the credential the run already
 proved working: without it, a dead key sitting first in the host
 environment (a platform OPENAI key with no credits, on the prod runner

--- a/pkg/supervise/bot.go
+++ b/pkg/supervise/bot.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/backend/detect"
 	"github.com/SocialGouv/iterion/pkg/backend/model"
+	"github.com/SocialGouv/iterion/pkg/secrets"
 )
 
 // Decision is the supervisor bot's structured verdict for one wake. The
@@ -120,32 +121,43 @@ func NewLLMEvaluator() *LLMEvaluator {
 
 // resolveModel picks the model spec: the spec's pin wins, then the
 // ITERION_DEFAULT_SUPERVISOR_MODEL env override, then the provider
-// family the supervised nodes run on (Spec.ProviderHint — only when
-// that provider is detected available), then the detector's first
-// suggestion. Returns ErrNoSupervisorModel when none resolve.
-func resolveModel(specModel, providerHint string) (string, error) {
+// family the supervised nodes run on (Spec.ProviderHint — when the env
+// detector sees it OR the run's ctx credentials fund it), then the
+// detector's first suggestion. Returns ErrNoSupervisorModel when none
+// resolve.
+func resolveModel(ctx context.Context, specModel, providerHint string) (string, error) {
 	if specModel != "" {
 		return specModel, nil
 	}
 	if env := os.Getenv("ITERION_DEFAULT_SUPERVISOR_MODEL"); env != "" {
 		return env, nil
 	}
-	report := detect.Detect(context.Background())
-	return resolveModelWith("", providerHint, report.Providers)
+	report := detect.Detect(ctx)
+	ctxFunded := func(string) bool { return false }
+	if creds, ok := secrets.CredentialsFromContext(ctx); ok {
+		ctxFunded = ctxFundsProvider(creds)
+	}
+	return resolveModelWith("", providerHint, report.Providers, ctxFunded)
 }
 
 // resolveModelWith is resolveModel's pure tail (pin/env already
 // consulted by the caller when empty is passed): hinted provider first —
 // the credential the supervised run itself uses beats whatever key sits
 // first in the host environment, which on the prod pods was a dead
-// OPENAI key 429-ing every eval — then the detector's order.
-func resolveModelWith(specModel, providerHint string, providers []detect.ProviderStatus) (string, error) {
+// OPENAI key 429-ing every eval — then the detector's order. The env
+// detector alone cannot gate the hint: on a runner pod the run's
+// credentials are ctx-sealed (or OAuth-forfait files), invisible to an
+// os.Getenv probe, while the claw registry resolves them from ctx at
+// call time — so ctx funding honours the hint too. detect populates
+// SuggestedModel regardless of availability, which is what makes the
+// ctx-funded branch resolvable.
+func resolveModelWith(specModel, providerHint string, providers []detect.ProviderStatus, ctxFunded func(provider string) bool) (string, error) {
 	if specModel != "" {
 		return specModel, nil
 	}
 	if providerHint != "" {
 		for _, p := range providers {
-			if p.Name == providerHint && p.Available && p.SuggestedModel != "" {
+			if p.Name == providerHint && p.SuggestedModel != "" && (p.Available || ctxFunded(p.Name)) {
 				return p.SuggestedModel, nil
 			}
 		}
@@ -156,10 +168,30 @@ func resolveModelWith(specModel, providerHint string, providers []detect.Provide
 	return "", ErrNoSupervisorModel
 }
 
+// ctxFundsProvider maps the run's ctx credentials onto claw providers: a
+// per-provider API key funds its provider, and an OAuth-forfait
+// credential dir funds the provider its CLI belongs to (claude_code →
+// anthropic, codex → openai) — the registry builds clients from both at
+// call time (credentialsLookup / oauthDirLookup).
+func ctxFundsProvider(creds secrets.Credentials) func(provider string) bool {
+	return func(provider string) bool {
+		if creds.APIKeys[secrets.Provider(provider)] != "" {
+			return true
+		}
+		switch provider {
+		case "anthropic":
+			return creds.OAuthCredentialFiles["claude_code"] != ""
+		case "openai":
+			return creds.OAuthCredentialFiles["codex"] != ""
+		}
+		return false
+	}
+}
+
 // Evaluate implements Evaluator.
 func (e *LLMEvaluator) Evaluate(ctx context.Context, in EvalInput) (*Decision, EvalUsage, error) {
 	if e.client == nil {
-		spec, err := resolveModel(in.Spec.Model, in.Spec.ProviderHint)
+		spec, err := resolveModel(ctx, in.Spec.Model, in.Spec.ProviderHint)
 		if err != nil {
 			return nil, EvalUsage{}, err
 		}

--- a/pkg/supervise/bot.go
+++ b/pkg/supervise/bot.go
@@ -169,19 +169,22 @@ func resolveModelWith(specModel, providerHint string, providers []detect.Provide
 }
 
 // ctxFundsProvider maps the run's ctx credentials onto claw providers: a
-// per-provider API key funds its provider, and an OAuth-forfait
-// credential dir funds the provider its CLI belongs to (claude_code →
-// anthropic, codex → openai) — the registry builds clients from both at
-// call time (credentialsLookup / oauthDirLookup).
+// per-provider API key funds its provider (ResolveWithContext →
+// providersWithKey), and the codex ChatGPT forfait funds openai
+// (Registry.openAIFromCtxForfait reads OAuthDir("codex")), mirroring
+// that path's env kill-switches. Anthropic's OAuth forfait is
+// deliberately NOT mapped: it is usable only by the claude_code CLI —
+// claw's anthropic factory reads env vars alone and ResolveWithContext
+// has no anthropic OAuth-dir branch — so claiming it funds the
+// anthropic provider would resolve an unauthenticated client.
 func ctxFundsProvider(creds secrets.Credentials) func(provider string) bool {
 	return func(provider string) bool {
 		if creds.APIKeys[secrets.Provider(provider)] != "" {
 			return true
 		}
-		switch provider {
-		case "anthropic":
-			return creds.OAuthCredentialFiles["claude_code"] != ""
-		case "openai":
+		if provider == "openai" &&
+			os.Getenv("ITERION_OPENAI_USE_OAUTH") != "0" &&
+			os.Getenv("OPENAI_BASE_URL") == "" {
 			return creds.OAuthCredentialFiles["codex"] != ""
 		}
 		return false
@@ -195,7 +198,12 @@ func (e *LLMEvaluator) Evaluate(ctx context.Context, in EvalInput) (*Decision, E
 		if err != nil {
 			return nil, EvalUsage{}, err
 		}
-		client, err := e.registry.Resolve(spec)
+		// ResolveWithContext, not Resolve: on a runner pod the run's
+		// credentials are ctx-sealed and never in this process's env, and
+		// only the ctx-aware path builds a client from them — which is
+		// exactly what the ctx-funded ProviderHint branch above assumes.
+		// It falls back to Resolve when ctx carries no credentials.
+		client, err := e.registry.ResolveWithContext(ctx, spec)
 		if err != nil {
 			return nil, EvalUsage{}, fmt.Errorf("supervise: resolve model %q: %w", spec, err)
 		}

--- a/pkg/supervise/bot.go
+++ b/pkg/supervise/bot.go
@@ -119,9 +119,11 @@ func NewLLMEvaluator() *LLMEvaluator {
 }
 
 // resolveModel picks the model spec: the spec's pin wins, then the
-// ITERION_DEFAULT_SUPERVISOR_MODEL env override, then the detector's
-// suggested claw model. Returns ErrNoSupervisorModel when none resolve.
-func resolveModel(specModel string) (string, error) {
+// ITERION_DEFAULT_SUPERVISOR_MODEL env override, then the provider
+// family the supervised nodes run on (Spec.ProviderHint — only when
+// that provider is detected available), then the detector's first
+// suggestion. Returns ErrNoSupervisorModel when none resolve.
+func resolveModel(specModel, providerHint string) (string, error) {
 	if specModel != "" {
 		return specModel, nil
 	}
@@ -129,7 +131,26 @@ func resolveModel(specModel string) (string, error) {
 		return env, nil
 	}
 	report := detect.Detect(context.Background())
-	if spec := detect.SuggestedModel(detect.BackendClaw, report.Providers); spec != "" {
+	return resolveModelWith("", providerHint, report.Providers)
+}
+
+// resolveModelWith is resolveModel's pure tail (pin/env already
+// consulted by the caller when empty is passed): hinted provider first —
+// the credential the supervised run itself uses beats whatever key sits
+// first in the host environment, which on the prod pods was a dead
+// OPENAI key 429-ing every eval — then the detector's order.
+func resolveModelWith(specModel, providerHint string, providers []detect.ProviderStatus) (string, error) {
+	if specModel != "" {
+		return specModel, nil
+	}
+	if providerHint != "" {
+		for _, p := range providers {
+			if p.Name == providerHint && p.Available && p.SuggestedModel != "" {
+				return p.SuggestedModel, nil
+			}
+		}
+	}
+	if spec := detect.SuggestedModel(detect.BackendClaw, providers); spec != "" {
 		return spec, nil
 	}
 	return "", ErrNoSupervisorModel
@@ -138,7 +159,7 @@ func resolveModel(specModel string) (string, error) {
 // Evaluate implements Evaluator.
 func (e *LLMEvaluator) Evaluate(ctx context.Context, in EvalInput) (*Decision, EvalUsage, error) {
 	if e.client == nil {
-		spec, err := resolveModel(in.Spec.Model)
+		spec, err := resolveModel(in.Spec.Model, in.Spec.ProviderHint)
 		if err != nil {
 			return nil, EvalUsage{}, err
 		}

--- a/pkg/supervise/bot_test.go
+++ b/pkg/supervise/bot_test.go
@@ -1,6 +1,7 @@
 package supervise
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -92,14 +93,14 @@ func TestBuildUserPrompt(t *testing.T) {
 func TestResolveModel(t *testing.T) {
 	t.Run("spec pin wins over env", func(t *testing.T) {
 		t.Setenv("ITERION_DEFAULT_SUPERVISOR_MODEL", "openai/gpt-5.4-mini")
-		got, err := resolveModel("anthropic/claude-sonnet-4-6", "")
+		got, err := resolveModel(context.Background(), "anthropic/claude-sonnet-4-6", "")
 		if err != nil || got != "anthropic/claude-sonnet-4-6" {
 			t.Fatalf("resolveModel = (%q, %v); want spec pin", got, err)
 		}
 	})
 	t.Run("env override when no pin", func(t *testing.T) {
 		t.Setenv("ITERION_DEFAULT_SUPERVISOR_MODEL", "openai/gpt-5.4-mini")
-		got, err := resolveModel("", "openai")
+		got, err := resolveModel(context.Background(), "", "openai")
 		if err != nil || got != "openai/gpt-5.4-mini" {
 			t.Fatalf("resolveModel = (%q, %v); want env override", got, err)
 		}

--- a/pkg/supervise/bot_test.go
+++ b/pkg/supervise/bot_test.go
@@ -92,14 +92,14 @@ func TestBuildUserPrompt(t *testing.T) {
 func TestResolveModel(t *testing.T) {
 	t.Run("spec pin wins over env", func(t *testing.T) {
 		t.Setenv("ITERION_DEFAULT_SUPERVISOR_MODEL", "openai/gpt-5.4-mini")
-		got, err := resolveModel("anthropic/claude-sonnet-4-6")
+		got, err := resolveModel("anthropic/claude-sonnet-4-6", "")
 		if err != nil || got != "anthropic/claude-sonnet-4-6" {
 			t.Fatalf("resolveModel = (%q, %v); want spec pin", got, err)
 		}
 	})
 	t.Run("env override when no pin", func(t *testing.T) {
 		t.Setenv("ITERION_DEFAULT_SUPERVISOR_MODEL", "openai/gpt-5.4-mini")
-		got, err := resolveModel("")
+		got, err := resolveModel("", "openai")
 		if err != nil || got != "openai/gpt-5.4-mini" {
 			t.Fatalf("resolveModel = (%q, %v); want env override", got, err)
 		}

--- a/pkg/supervise/declared.go
+++ b/pkg/supervise/declared.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -141,12 +142,22 @@ func SpecsFromWorkflow(wf *ir.Workflow, logger *iterlog.Logger) []Spec {
 // providerHintFromWatched derives the provider family the watched nodes
 // run on, so an unpinned evaluator can prefer the credential the run
 // itself uses (see Spec.ProviderHint). Sources, per node, strongest
-// first: the node's explicit provider: routing (first of the chain), a
-// "provider/" prefix on its model, then the backend's own family
-// (claude_code → anthropic, codex → openai). CLI backends whose
-// credential claw cannot reuse (pi, kimi, grok) yield no hint.
+// first: the node's explicit provider: routing (walked to the first
+// claw-routable entry), a "provider/" prefix on its model, then the
+// backend's own family (claude_code → anthropic, codex → openai). CLI
+// backends whose credential claw cannot reuse (pi, kimi, grok) yield no
+// hint. A supervisor with no watches supervises the whole run, so its
+// hint derives from ALL the workflow's agent/judge nodes (sorted for
+// determinism — Nodes is a map).
 func providerHintFromWatched(wf *ir.Workflow, watches []string) string {
-	for _, id := range watches {
+	ids := watches
+	if len(ids) == 0 {
+		for id := range wf.Nodes {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+	}
+	for _, id := range ids {
 		node, ok := wf.Nodes[id]
 		if !ok {
 			continue
@@ -161,8 +172,10 @@ func providerHintFromWatched(wf *ir.Workflow, watches []string) string {
 			continue
 		}
 		if p := ir.ExpandEnvWithDefault(llm.Provider); p != "" {
-			if first, _, _ := strings.Cut(p, ","); strings.TrimSpace(first) != "" {
-				return strings.TrimSpace(first)
+			for _, entry := range strings.Split(p, ",") {
+				if entry = strings.TrimSpace(entry); clawProviders[entry] {
+					return entry
+				}
 			}
 		}
 		// A slash in a model string is only a provider prefix for claw

--- a/pkg/supervise/declared.go
+++ b/pkg/supervise/declared.go
@@ -120,17 +120,63 @@ func SpecsFromWorkflow(wf *ir.Workflow, logger *iterlog.Logger) []Spec {
 			}
 			monitors = append(monitors, parsed...)
 		}
+		hint := ""
+		if sup.Model == "" {
+			hint = providerHintFromWatched(wf, sup.Watches)
+		}
 		specs = append(specs, Spec{
-			Name:     sup.Name,
-			Model:    sup.Model,
-			System:   system,
-			Watches:  sup.Watches,
-			Monitors: monitors,
-			Cooldown: sup.Cooldown,
-			MaxEvals: sup.MaxEvals,
+			Name:         sup.Name,
+			Model:        sup.Model,
+			ProviderHint: hint,
+			System:       system,
+			Watches:      sup.Watches,
+			Monitors:     monitors,
+			Cooldown:     sup.Cooldown,
+			MaxEvals:     sup.MaxEvals,
 		})
 	}
 	return specs
+}
+
+// providerHintFromWatched derives the provider family the watched nodes
+// run on, so an unpinned evaluator can prefer the credential the run
+// itself uses (see Spec.ProviderHint). Sources, per node, strongest
+// first: the node's explicit provider: routing (first of the chain), a
+// "provider/" prefix on its model, then the backend's own family
+// (claude_code → anthropic, codex → openai). CLI backends whose
+// credential claw cannot reuse (pi, kimi, grok) yield no hint.
+func providerHintFromWatched(wf *ir.Workflow, watches []string) string {
+	for _, id := range watches {
+		node, ok := wf.Nodes[id]
+		if !ok {
+			continue
+		}
+		var llm *ir.LLMFields
+		switch n := node.(type) {
+		case *ir.AgentNode:
+			llm = &n.LLMFields
+		case *ir.JudgeNode:
+			llm = &n.LLMFields
+		default:
+			continue
+		}
+		if p := ir.ExpandEnvWithDefault(llm.Provider); p != "" {
+			if first, _, _ := strings.Cut(p, ","); strings.TrimSpace(first) != "" {
+				return strings.TrimSpace(first)
+			}
+		}
+		model := ir.ExpandEnvWithDefault(llm.Model)
+		if provider, _, found := strings.Cut(model, "/"); found && provider != "" && !strings.ContainsAny(provider, "${") {
+			return provider
+		}
+		switch ir.ExpandEnvWithDefault(llm.Backend) {
+		case "claude_code":
+			return "anthropic"
+		case "codex":
+			return "openai"
+		}
+	}
+	return ""
 }
 
 // StartDeclared spawns one Coordinator per spec, each observing runID

--- a/pkg/supervise/declared.go
+++ b/pkg/supervise/declared.go
@@ -165,8 +165,14 @@ func providerHintFromWatched(wf *ir.Workflow, watches []string) string {
 				return strings.TrimSpace(first)
 			}
 		}
+		// A slash in a model string is only a provider prefix for claw
+		// providers — kimi's canonical aliases (kimi-code/kimi-for-coding)
+		// carry a slash that is an alias namespace, not a provider. An
+		// unrecognized prefix yields nothing and the NEXT source (backend
+		// family, then the next watched node) is consulted instead of
+		// short-circuiting with garbage.
 		model := ir.ExpandEnvWithDefault(llm.Model)
-		if provider, _, found := strings.Cut(model, "/"); found && provider != "" && !strings.ContainsAny(provider, "${") {
+		if provider, _, found := strings.Cut(model, "/"); found && clawProviders[provider] {
 			return provider
 		}
 		switch ir.ExpandEnvWithDefault(llm.Backend) {
@@ -177,6 +183,20 @@ func providerHintFromWatched(wf *ir.Workflow, watches []string) string {
 		}
 	}
 	return ""
+}
+
+// clawProviders is the set of provider names claw can route (the same
+// families pkg/backend/detect reports on). Kept as a literal because the
+// hint is advisory: an out-of-date entry costs a fallback to detector
+// order, never a failure.
+var clawProviders = map[string]bool{
+	"anthropic": true,
+	"openai":    true,
+	"zai":       true,
+	"xai":       true,
+	"bedrock":   true,
+	"vertex":    true,
+	"foundry":   true,
 }
 
 // StartDeclared spawns one Coordinator per spec, each observing runID

--- a/pkg/supervise/model_hint_test.go
+++ b/pkg/supervise/model_hint_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/backend/detect"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/secrets"
 )
 
 // A supervisor with no model pin should evaluate with the SAME provider
@@ -65,6 +66,13 @@ func TestSpecsFromWorkflowDeriveProviderHint(t *testing.T) {
 			node: &ir.AgentNode{LLMFields: ir.LLMFields{Backend: "kimi", Model: "kimi-for-coding"}},
 			want: "",
 		},
+		{
+			// kimi's canonical model alias carries a slash that is NOT a
+			// provider prefix (kimiMapModel); it must not become a hint.
+			name: "non-provider alias prefix yields no hint",
+			node: &ir.AgentNode{LLMFields: ir.LLMFields{Backend: "kimi", Model: "kimi-code/kimi-for-coding"}},
+			want: "",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -95,28 +103,90 @@ func TestSpecsFromWorkflowPinnedModelSkipsHint(t *testing.T) {
 	}
 }
 
-// resolveModelWith precedence: pin → env → hinted provider (only when that
-// provider is detected available) → first available provider.
+// resolveModelWith precedence: pin → env → hinted provider (when the
+// detector sees it OR the run's ctx credentials fund it) → first
+// available provider.
 func TestResolveModelWithHintPrecedence(t *testing.T) {
 	providers := []detect.ProviderStatus{
 		{Name: "openai", Available: true, SuggestedModel: "openai/gpt-5.4-mini"},
 		{Name: "anthropic", Available: true, SuggestedModel: "anthropic/claude-opus-5"},
 	}
+	noCtx := func(string) bool { return false }
 
-	if got, _ := resolveModelWith("anthropic/claude-opus-5", "openai", providers); got != "anthropic/claude-opus-5" {
+	if got, _ := resolveModelWith("anthropic/claude-opus-5", "openai", providers, noCtx); got != "anthropic/claude-opus-5" {
 		t.Fatalf("pin must win, got %q", got)
 	}
-	if got, _ := resolveModelWith("", "anthropic", providers); got != "anthropic/claude-opus-5" {
+	if got, _ := resolveModelWith("", "anthropic", providers, noCtx); got != "anthropic/claude-opus-5" {
 		t.Fatalf("hinted provider must win over detector order, got %q", got)
 	}
-	// A hint for a provider with no credential must fall back, not fail.
-	if got, _ := resolveModelWith("", "zai", providers); got != "openai/gpt-5.4-mini" {
-		t.Fatalf("unavailable hint must fall back to the first available provider, got %q", got)
+	// A hint for a provider with no credential anywhere must fall back, not fail.
+	if got, _ := resolveModelWith("", "zai", providers, noCtx); got != "openai/gpt-5.4-mini" {
+		t.Fatalf("unfunded hint must fall back to the first available provider, got %q", got)
 	}
-	if got, _ := resolveModelWith("", "", providers); got != "openai/gpt-5.4-mini" {
+	if got, _ := resolveModelWith("", "", providers, noCtx); got != "openai/gpt-5.4-mini" {
 		t.Fatalf("no hint keeps the detector order, got %q", got)
 	}
-	if _, err := resolveModelWith("", "anthropic", nil); err == nil {
+	if _, err := resolveModelWith("", "anthropic", nil, noCtx); err == nil {
 		t.Fatal("no providers at all must return ErrNoSupervisorModel")
+	}
+}
+
+// The pod scenario the hint exists for: the run's credentials live in ctx
+// (sealed bundle / OAuth-forfait files), NOT in the process env — so the
+// detector reports the hinted provider unavailable while the claw
+// registry can perfectly authenticate it from ctx at call time. The hint
+// must be honoured on ctx funding, using the provider's suggested model
+// (populated by detect regardless of availability).
+func TestResolveModelWithHonoursCtxFundedHint(t *testing.T) {
+	providers := []detect.ProviderStatus{
+		{Name: "openai", Available: true, SuggestedModel: "openai/gpt-5.4-mini"},
+		{Name: "anthropic", Available: false, SuggestedModel: "anthropic/claude-opus-5"},
+	}
+	ctxFunded := func(p string) bool { return p == "anthropic" }
+
+	got, err := resolveModelWith("", "anthropic", providers, ctxFunded)
+	if err != nil || got != "anthropic/claude-opus-5" {
+		t.Fatalf("ctx-funded hint must be honoured over the env detector, got (%q, %v)", got, err)
+	}
+	// Without ctx funding the same hint falls back — no auth-error swap.
+	if got, _ := resolveModelWith("", "anthropic", providers, func(string) bool { return false }); got != "openai/gpt-5.4-mini" {
+		t.Fatalf("unfunded unavailable hint must fall back, got %q", got)
+	}
+}
+
+// ctxFundsProvider maps the run's ctx credentials onto claw providers:
+// a per-provider API key funds its provider; an OAuth-forfait file funds
+// the provider its CLI belongs to (claude_code → anthropic,
+// codex → openai).
+func TestCtxFundsProvider(t *testing.T) {
+	f := ctxFundsProvider(secrets.Credentials{
+		APIKeys:              map[secrets.Provider]string{"zai": "zk"},
+		OAuthCredentialFiles: map[string]string{"claude_code": "/tmp/cc"},
+	})
+	for provider, want := range map[string]bool{
+		"zai":       true,
+		"anthropic": true,
+		"openai":    false,
+		"xai":       false,
+	} {
+		if got := f(provider); got != want {
+			t.Errorf("ctxFundsProvider(%q) = %v, want %v", provider, got, want)
+		}
+	}
+}
+
+// A bogus hint from an alias prefix must not stop a LATER watched node
+// from supplying the real hint.
+func TestProviderHintSkipsBogusPrefixAndContinues(t *testing.T) {
+	wf := &ir.Workflow{
+		Nodes: map[string]ir.Node{
+			"scout":    &ir.AgentNode{LLMFields: ir.LLMFields{Backend: "kimi", Model: "kimi-code/kimi-for-coding"}},
+			"campaign": &ir.AgentNode{LLMFields: ir.LLMFields{Backend: "claude_code", Model: "claude-opus-5"}},
+		},
+		Supervisors: []*ir.Supervisor{{Name: "persy", Watches: []string{"scout", "campaign"}}},
+	}
+	specs := SpecsFromWorkflow(wf, iterlog.Nop())
+	if len(specs) != 1 || specs[0].ProviderHint != "anthropic" {
+		t.Fatalf("bogus alias prefix must be skipped and the next watched node consulted, got %+v", specs)
 	}
 }

--- a/pkg/supervise/model_hint_test.go
+++ b/pkg/supervise/model_hint_test.go
@@ -1,9 +1,11 @@
 package supervise
 
 import (
+	"context"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/backend/detect"
+	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/secrets"
@@ -154,24 +156,78 @@ func TestResolveModelWithHonoursCtxFundedHint(t *testing.T) {
 	}
 }
 
-// ctxFundsProvider maps the run's ctx credentials onto claw providers:
-// a per-provider API key funds its provider; an OAuth-forfait file funds
-// the provider its CLI belongs to (claude_code → anthropic,
-// codex → openai).
+// ctxFundsProvider: a per-provider API key funds its provider; the codex
+// ChatGPT forfait funds openai (the only OAuth path ResolveWithContext
+// actually has). The claude_code OAuth forfait does NOT fund anthropic —
+// claw's anthropic factory is env-only, so claiming it would resolve an
+// unauthenticated client.
 func TestCtxFundsProvider(t *testing.T) {
 	f := ctxFundsProvider(secrets.Credentials{
 		APIKeys:              map[secrets.Provider]string{"zai": "zk"},
-		OAuthCredentialFiles: map[string]string{"claude_code": "/tmp/cc"},
+		OAuthCredentialFiles: map[string]string{"claude_code": "/tmp/cc", "codex": "/tmp/cx"},
 	})
 	for provider, want := range map[string]bool{
 		"zai":       true,
-		"anthropic": true,
-		"openai":    false,
+		"anthropic": false,
+		"openai":    true,
 		"xai":       false,
 	} {
 		if got := f(provider); got != want {
 			t.Errorf("ctxFundsProvider(%q) = %v, want %v", provider, got, want)
 		}
+	}
+}
+
+// The composition the pod runs: a ctx-sealed BYOK key with an empty env
+// must yield a working evaluator client for that provider (Resolve alone
+// — the env-only path — cannot build it). The runner wires the
+// credentials lookup at boot; the test wires the same canonical closure.
+func TestEvaluatorClientResolvesFromCtxCredentials(t *testing.T) {
+	model.SetCredentialsLookup(func(ctx context.Context) (func(provider string) string, bool) {
+		creds, ok := secrets.CredentialsFromContext(ctx)
+		if !ok {
+			return nil, false
+		}
+		return func(provider string) string { return creds.APIKeys[secrets.Provider(provider)] }, true
+	})
+	e := NewLLMEvaluator()
+	ctx := secrets.WithCredentials(context.Background(),
+		secrets.Credentials{APIKeys: map[secrets.Provider]string{"anthropic": "sk-test"}})
+	client, err := e.registry.ResolveWithContext(ctx, "anthropic/claude-opus-5")
+	if err != nil || client == nil {
+		t.Fatalf("ResolveWithContext with a ctx BYOK key = (%v, %v); want a client", client, err)
+	}
+}
+
+// A whole-run supervisor (no watches:) supervises every node — its hint
+// derives from the workflow's agent/judge nodes generally, in
+// deterministic (sorted) order.
+func TestProviderHintWholeRunDerivesFromAllNodes(t *testing.T) {
+	wf := &ir.Workflow{
+		Nodes: map[string]ir.Node{
+			"a-tool":     &ir.ToolNode{},
+			"b-campaign": &ir.AgentNode{LLMFields: ir.LLMFields{Backend: "claude_code", Model: "claude-opus-5"}},
+		},
+		Supervisors: []*ir.Supervisor{{Name: "persy"}},
+	}
+	specs := SpecsFromWorkflow(wf, iterlog.Nop())
+	if len(specs) != 1 || specs[0].ProviderHint != "anthropic" {
+		t.Fatalf("whole-run supervisor must derive its hint from the workflow's LLM nodes, got %+v", specs)
+	}
+}
+
+// A provider: chain is walked until an entry claw can route — the first
+// element is not returned verbatim when it is not a claw provider.
+func TestProviderHintWalksProviderChain(t *testing.T) {
+	wf := &ir.Workflow{
+		Nodes: map[string]ir.Node{
+			"campaign": &ir.AgentNode{LLMFields: ir.LLMFields{Provider: "not-a-provider,anthropic", Backend: "claude_code"}},
+		},
+		Supervisors: []*ir.Supervisor{{Name: "persy", Watches: []string{"campaign"}}},
+	}
+	specs := SpecsFromWorkflow(wf, iterlog.Nop())
+	if len(specs) != 1 || specs[0].ProviderHint != "anthropic" {
+		t.Fatalf("provider chain must be walked to the first claw-routable entry, got %+v", specs)
 	}
 }
 

--- a/pkg/supervise/model_hint_test.go
+++ b/pkg/supervise/model_hint_test.go
@@ -1,0 +1,122 @@
+package supervise
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/detect"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+// A supervisor with no model pin should evaluate with the SAME provider
+// family as the run it supervises, not with whatever provider the host
+// detector lists first: on the prod pods a dead platform OPENAI key made
+// every Persy eval 429 while the supervised campaign was happily running
+// on the Anthropic credential (run 01a042c2).
+func TestSpecsFromWorkflowDeriveProviderHint(t *testing.T) {
+	wf := func(node ir.Node) *ir.Workflow {
+		return &ir.Workflow{
+			Nodes: map[string]ir.Node{"campaign": node},
+			Supervisors: []*ir.Supervisor{{
+				Name:    "persy",
+				Watches: []string{"campaign"},
+			}},
+			Prompts: map[string]*ir.Prompt{},
+		}
+	}
+
+	cases := []struct {
+		name string
+		node ir.Node
+		want string
+	}{
+		{
+			name: "claude_code backend maps to anthropic",
+			node: &ir.AgentNode{LLMFields: ir.LLMFields{Backend: "claude_code", Model: "claude-opus-5"}},
+			want: "anthropic",
+		},
+		{
+			name: "claw model provider prefix wins",
+			node: &ir.AgentNode{LLMFields: ir.LLMFields{Backend: "claw", Model: "openai/gpt-5.4-mini"}},
+			want: "openai",
+		},
+		{
+			name: "explicit provider field wins over everything",
+			node: &ir.AgentNode{LLMFields: ir.LLMFields{Provider: "zai,anthropic", Backend: "claude_code", Model: "claude-opus-5"}},
+			want: "zai",
+		},
+		{
+			name: "env-ref model still resolves the family from the backend",
+			node: &ir.AgentNode{LLMFields: ir.LLMFields{Backend: "claude_code", Model: "${ITERION_VIBE_MODEL_CLAUDE:-claude-opus-5}"}},
+			want: "anthropic",
+		},
+		{
+			name: "codex backend maps to openai",
+			node: &ir.AgentNode{LLMFields: ir.LLMFields{Backend: "codex", Model: "gpt-5.5"}},
+			want: "openai",
+		},
+		{
+			name: "judge nodes count too",
+			node: &ir.JudgeNode{LLMFields: ir.LLMFields{Backend: "claude_code"}},
+			want: "anthropic",
+		},
+		{
+			name: "unknown backend yields no hint",
+			node: &ir.AgentNode{LLMFields: ir.LLMFields{Backend: "kimi", Model: "kimi-for-coding"}},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			specs := SpecsFromWorkflow(wf(tc.node), iterlog.Nop())
+			if len(specs) != 1 {
+				t.Fatalf("specs = %d, want 1", len(specs))
+			}
+			if got := specs[0].ProviderHint; got != tc.want {
+				t.Fatalf("ProviderHint = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A pinned supervisor model must not grow a hint: the pin already decides.
+func TestSpecsFromWorkflowPinnedModelSkipsHint(t *testing.T) {
+	wf := &ir.Workflow{
+		Nodes: map[string]ir.Node{"campaign": &ir.AgentNode{LLMFields: ir.LLMFields{Backend: "claude_code"}}},
+		Supervisors: []*ir.Supervisor{{
+			Name:    "persy",
+			Model:   "openai/gpt-5.4-mini",
+			Watches: []string{"campaign"},
+		}},
+	}
+	specs := SpecsFromWorkflow(wf, iterlog.Nop())
+	if len(specs) != 1 || specs[0].ProviderHint != "" {
+		t.Fatalf("pinned model must not derive a hint, got %+v", specs)
+	}
+}
+
+// resolveModelWith precedence: pin → env → hinted provider (only when that
+// provider is detected available) → first available provider.
+func TestResolveModelWithHintPrecedence(t *testing.T) {
+	providers := []detect.ProviderStatus{
+		{Name: "openai", Available: true, SuggestedModel: "openai/gpt-5.4-mini"},
+		{Name: "anthropic", Available: true, SuggestedModel: "anthropic/claude-opus-5"},
+	}
+
+	if got, _ := resolveModelWith("anthropic/claude-opus-5", "openai", providers); got != "anthropic/claude-opus-5" {
+		t.Fatalf("pin must win, got %q", got)
+	}
+	if got, _ := resolveModelWith("", "anthropic", providers); got != "anthropic/claude-opus-5" {
+		t.Fatalf("hinted provider must win over detector order, got %q", got)
+	}
+	// A hint for a provider with no credential must fall back, not fail.
+	if got, _ := resolveModelWith("", "zai", providers); got != "openai/gpt-5.4-mini" {
+		t.Fatalf("unavailable hint must fall back to the first available provider, got %q", got)
+	}
+	if got, _ := resolveModelWith("", "", providers); got != "openai/gpt-5.4-mini" {
+		t.Fatalf("no hint keeps the detector order, got %q", got)
+	}
+	if _, err := resolveModelWith("", "anthropic", nil); err == nil {
+		t.Fatal("no providers at all must return ErrNoSupervisorModel")
+	}
+}

--- a/pkg/supervise/supervise.go
+++ b/pkg/supervise/supervise.go
@@ -43,6 +43,15 @@ type Spec struct {
 	// "anthropic/claude-opus-4-8"). Empty => auto-detect a reachable
 	// provider (see resolveModel).
 	Model string
+	// ProviderHint names the provider family the SUPERVISED nodes run
+	// on (derived from their provider:/model:/backend: by
+	// SpecsFromWorkflow). With no Model pin and no env override, the
+	// evaluator prefers this family over the detector's first pick —
+	// so the coach speaks through the credential the run itself proved
+	// working, instead of whatever key happens to sit first in the host
+	// environment. Consulted only when that provider is detected
+	// available; never a hard requirement.
+	ProviderHint string
 	// System is the resolved system-prompt text: the supervision policy
 	// (what to watch for, when to intervene, how forcefully).
 	System string

--- a/pkg/supervise/supervise.go
+++ b/pkg/supervise/supervise.go
@@ -49,8 +49,9 @@ type Spec struct {
 	// evaluator prefers this family over the detector's first pick —
 	// so the coach speaks through the credential the run itself proved
 	// working, instead of whatever key happens to sit first in the host
-	// environment. Consulted only when that provider is detected
-	// available; never a hard requirement.
+	// environment. Honoured when the env detector sees the provider OR
+	// the run's ctx credentials fund it (ctxFundsProvider); never a
+	// hard requirement — an unfunded hint falls back to detector order.
 	ProviderHint string
 	// System is the resolved system-prompt text: the supervision policy
 	// (what to watch for, when to intervene, how forcefully).


### PR DESCRIPTION
Found by the Persy cloud dogfood (run 01a042c2 on the prod runner): an unpinned supervisor resolves its evaluator model by host auto-detect, so whatever key sits first in the pod environment decides. On prod that was a dead platform OPENAI key — every eval 429-ed while the supervised campaign ran fine on the Anthropic credential.

`SpecsFromWorkflow` now derives a **provider hint** from the watched nodes (their `provider:` routing → a `provider/` model prefix → the backend's family: claude_code → anthropic, codex → openai), and the resolver prefers that family **only when its credential is detected available**. Precedence unchanged above it: `model:` pin → `ITERION_DEFAULT_SUPERVISOR_MODEL` → hint → detector order. Red-first tests for the hint derivation (incl. `${…}` env-ref models) and the resolver precedence; docs updated.

Companion ops note: the same dead key also flips `plan_review: auto` (ADR-091) to "on" on prod, which then fails + pauses every cloud feature-dev run — funding or removing the key fixes that half; this PR makes supervisors robust to it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)