### PR TITLE
fix(bots): plan_review_policy defaults to skip fleet-wide

### DIFF
--- a/bots/app-dev/main.bot
+++ b/bots/app-dev/main.bot
@@ -125,12 +125,15 @@ vars:
   ## (the peer reviewer then fails loudly on a missing credential).
   plan_review: string = "auto"
   ## What a MID-RUN peer failure (forfait window shut, provider down,
-  ## credential revoked) does: "wait" (default) parks the run
-  ## failed_resumable until the peer window reopens (run-level
-  ## usage-window retry; cloud durable, local --auto-resume); "skip"
-  ## arms the reviewer's `action: skip` fallback route — the plan
-  ## proceeds unreviewed, LOUDLY (_skipped stamped, plan_gate reads it).
-  plan_review_policy: string [enum: "wait", "skip"] = "wait"
+  ## credential revoked) does: "skip" (default) arms the reviewer's
+  ## `action: skip` fallback route — the plan proceeds unreviewed,
+  ## LOUDLY (_skipped stamped, plan_gate reads it). The peer is an
+  ## optional enrichment: the primary family alone must always suffice,
+  ## so a dead peer credential never parks the whole campaign. "wait"
+  ## parks the run failed_resumable until the peer window reopens
+  ## (run-level usage-window retry; cloud durable, local --auto-resume)
+  ## — the deliberate-spend posture, per run.
+  plan_review_policy: string [enum: "wait", "skip"] = "skip"
 
   ## ─── Deployment (opt-in, platform-agnostic) ───────────────────
   ## deploy_enabled=true adds a deploy phase AFTER the app converges

--- a/bots/app-dev/manifest.yaml
+++ b/bots/app-dev/manifest.yaml
@@ -1,7 +1,13 @@
 name: app-dev
 display_name: Appy
 icon: 🏗️
-version: 0.2.0
+version: 0.2.1
+## 0.2.1 — plan_review_policy defaults to "skip": the cross-model plan peer
+## is an optional enrichment, and the primary family alone must always
+## suffice. A dead/parked peer credential (401, shut forfait window,
+## provider outage) completes plan_review with the `_skipped` stamp and
+## the campaign proceeds, instead of parking the run. "wait" remains the
+## per-run opt-in for the deliberate-spend posture.
 ## 0.1.1 — ADR-082 Phase 2 (sandbox-by-default): removed the `sandbox:`
 ## block (image pin, ~/.claude mount, claude post_create gate) — isolation
 ## is the platform's job; gh/glab join crane in the pinned devbox.json.

--- a/bots/feature-dev/main.bot
+++ b/bots/feature-dev/main.bot
@@ -142,15 +142,18 @@ vars:
   plan_review: string = "auto"
   ## What a MID-RUN peer failure (forfait window shut, provider down,
   ## credential revoked) does:
-  ##   wait (default) — the failure stays a failure: the run parks
+  ##   skip (default) — the reviewer's `action: skip` fallback route
+  ##     completes it with a zero-value critique stamped _skipped; the
+  ##     plan proceeds unreviewed, LOUDLY (plan_gate reads the stamp).
+  ##     The peer is an optional enrichment: the primary family alone
+  ##     must always suffice, so a dead peer credential never parks the
+  ##     whole campaign (lived: a stale second-family key paused every
+  ##     cloud run of this bot through plan_review auto + wait).
+  ##   wait — the failure stays a failure: the run parks
   ##     failed_resumable and the run-level usage-window retry resumes
   ##     it when the window reopens (cloud: durable; local:
-  ##     --auto-resume). The pair review is the point of the phase, so
-  ##     degrading it is a per-run choice, never a silent default.
-  ##   skip — the reviewer's `action: skip` fallback route completes it
-  ##     with a zero-value critique stamped _skipped; the plan proceeds
-  ##     unreviewed, LOUDLY (plan_gate reads the stamp).
-  plan_review_policy: string [enum: "wait", "skip"] = "wait"
+  ##     --auto-resume) — the deliberate-spend posture, per run.
+  plan_review_policy: string [enum: "wait", "skip"] = "skip"
 
 secrets:
   ## Forge access for push + PR creation + the issue back-link. Mounted

--- a/bots/feature-dev/manifest.yaml
+++ b/bots/feature-dev/manifest.yaml
@@ -1,7 +1,13 @@
 name: feature-dev
 display_name: Featurly
 icon: 🛠️
-version: 2.3.0
+version: 2.3.1
+## 2.3.1 — plan_review_policy defaults to "skip": the cross-model plan peer
+## is an optional enrichment, and the primary family alone must always
+## suffice. A dead/parked peer credential (401, shut forfait window,
+## provider outage) completes plan_review with the `_skipped` stamp and
+## the campaign proceeds, instead of parking the run. "wait" remains the
+## per-run opt-in for the deliberate-spend posture.
 ## 2.3.0 — cross-model peer-reviewed plan phase (ADR-091): when a second
 ## model family is credentialed (plan_review auto→on, resolved at launch
 ## by pkg/reviewtopology), the plan is authored (claude, read-only),

--- a/bots/plan_phase_test.go
+++ b/bots/plan_phase_test.go
@@ -44,19 +44,16 @@ func TestPlanPhaseWiring(t *testing.T) {
 			}
 			wf := cr.Workflow
 
-			// branch-improve-loop defaults the peer policy to "skip": a
-			// fixer invoked ON a pull request must never park on its
-			// OPTIONAL cross-model plan reviewer — the Anthropic family
-			// alone always suffices to fix a branch, and a parked fixer
-			// holds the PR hostage. The other campaign bots keep "wait"
-			// (a parked campaign blocks nobody external).
-			wantPolicy := "wait"
-			if bot == "branch-improve-loop" {
-				wantPolicy = "skip"
-			}
+			// The peer policy defaults to "skip" fleet-wide: the
+			// cross-model plan reviewer is an OPTIONAL enrichment, and
+			// the primary family alone must always suffice — a dead
+			// second-family credential parked a fixer holding a PR
+			// hostage, and a stale pod key paused every cloud campaign
+			// through plan_review auto + wait. "wait" stays the per-run
+			// deliberate-spend opt-in.
 			for varName, wantDefault := range map[string]string{
 				"plan_review":        "auto",
-				"plan_review_policy": wantPolicy,
+				"plan_review_policy": "skip",
 			} {
 				v, ok := wf.Vars[varName]
 				if !ok {

--- a/bots/whole-improve-loop/main.bot
+++ b/bots/whole-improve-loop/main.bot
@@ -147,12 +147,15 @@ vars:
   ## (the peer reviewer then fails loudly on a missing credential).
   plan_review: string = "auto"
   ## What a MID-RUN peer failure (forfait window shut, provider down,
-  ## credential revoked) does: "wait" (default) parks the run
-  ## failed_resumable until the peer window reopens (run-level
-  ## usage-window retry; cloud durable, local --auto-resume); "skip"
-  ## arms the reviewer's `action: skip` fallback route — the plan
-  ## proceeds unreviewed, LOUDLY (_skipped stamped, plan_gate reads it).
-  plan_review_policy: string [enum: "wait", "skip"] = "wait"
+  ## credential revoked) does: "skip" (default) arms the reviewer's
+  ## `action: skip` fallback route — the plan proceeds unreviewed,
+  ## LOUDLY (_skipped stamped, plan_gate reads it). The peer is an
+  ## optional enrichment: the primary family alone must always suffice,
+  ## so a dead peer credential never parks the whole campaign. "wait"
+  ## parks the run failed_resumable until the peer window reopens
+  ## (run-level usage-window retry; cloud durable, local --auto-resume)
+  ## — the deliberate-spend posture, per run.
+  plan_review_policy: string [enum: "wait", "skip"] = "skip"
 
 secrets:
   ## Forge access for push + PR creation + the issue back-link. Mounted as a

--- a/bots/whole-improve-loop/manifest.yaml
+++ b/bots/whole-improve-loop/manifest.yaml
@@ -1,7 +1,13 @@
 name: whole-improve-loop
 display_name: Willy
 icon: 🌍
-version: 2.2.0
+version: 2.2.1
+## 2.2.1 — plan_review_policy defaults to "skip": the cross-model plan peer
+## is an optional enrichment, and the primary family alone must always
+## suffice. A dead/parked peer credential (401, shut forfait window,
+## provider outage) completes plan_review with the `_skipped` stamp and
+## the campaign proceeds, instead of parking the run. "wait" remains the
+## per-run opt-in for the deliberate-spend posture.
 ## 2.0.2 — third advisory question before the report: `Ratchet` — the cheap
 ## deterministic check that would have caught the site it just fixed, landed
 ## in the same commit or a follow-up one, NEVER by amending a commit already

--- a/docs/adr/091-fallback-skip-route-and-plan-peer-review.md
+++ b/docs/adr/091-fallback-skip-route-and-plan-peer-review.md
@@ -211,15 +211,18 @@ Two of the decisions above met a real run and moved
   amnesiac input. It is deliberately NOT a `model_fallback` — the same
   backend, model and credential served; what degraded is the node's
   INPUT.
-- **`plan_review_policy` now defaults to `skip` for
-  `branch-improve-loop` only.** The discriminator is not the bot's
-  identity but the property that it is invoked ON an external artifact:
-  a fixer that parks on an OPTIONAL cross-model reviewer holds someone's
-  pull request hostage, while a parked campaign on a workspace blocks
-  nobody. The other three campaign bots keep `wait`. Residual risk,
-  filed rather than fixed: a permanently dead peer credential now
-  degrades every run silently, and the only operator signal is the run
-  console — the fixer's PR comment does not yet say "plan peer skipped".
+- **`plan_review_policy` now defaults to `skip` — fleet-wide** (all
+  four plan-phase campaign bots). It started as a branch-improve-loop
+  exception (a fixer that parks on an OPTIONAL cross-model reviewer
+  holds someone's pull request hostage), then two lived incidents the
+  same day generalised it: a dead second-family credential blocked a
+  fixer through `plan_review: auto` + `wait`, and a stale pod OpenAI
+  key paused every cloud campaign the same way. The peer is an optional
+  enrichment; the primary family alone must always suffice. `wait`
+  stays the per-run deliberate-spend opt-in. Residual risk, filed
+  rather than fixed: a permanently dead peer credential now degrades
+  every run silently, and the only operator signal is the run console —
+  the fixer's PR comment does not yet say "plan peer skipped".
 
 ## Consequences
 

--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -201,8 +201,9 @@ all — the bots' `auto` default then reads as off, fail-safe.) Mid-run peer-for
 `--var plan_review_policy=wait|skip` (wait = the run parks
 failed_resumable and the usage-window retry resumes it when the window
 reopens; skip = continue without the review, loudly stamped).
-branch-improve-loop defaults to `skip` — a fixer invoked on a PR must
-never park on its optional peer; the other campaign bots default `wait`. Gotcha:
+All four campaign bots default to `skip` — the peer is an optional
+enrichment, and a dead second-family credential must never park a
+campaign (`wait` is the per-run deliberate-spend opt-in). Gotcha:
 the ChatGPT-forfait wire gates models by the codex-cli `version:` header
 — if gpt-5.6 is refused with a model-availability error, set
 `ITERION_CODEX_VERSION` to a recent codex-cli version (gpt-5.5 needed


### PR DESCRIPTION
Extends #544's branch-improve-loop default to the three sibling plan-phase campaign bots (app-dev, feature-dev, whole-improve-loop): the cross-model plan peer is an **optional enrichment** — the primary family alone must always suffice, so a dead/parked second-family credential completes `plan_review` with the `_skipped` stamp instead of parking the campaign. `wait` stays the per-run deliberate-spend opt-in.

Two lived incidents the same day made the case:
- a dead codex credential blocked a `/billy` fixer through `plan_review: auto` + `wait` (see the 2026-08-27 bilan in docs/bot-runs/branch-improve-loop.md);
- a stale pod OpenAI key paused every cloud feature-dev the same way.

**Stacked on #544** — the shared `plan_phase_test.go` change builds on it; the diff collapses to 9 files once #544 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)