### PR TITLE
fix(studio): make backend override picker permission-aware

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2974,6 +2974,166 @@
         ],
         "type": "object"
       },
+      "previewBackendOption": {
+        "properties": {
+          "unavailable_reason": {
+            "type": "string"
+          },
+          "warning": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "previewCostNode": {
+        "properties": {
+          "cost_max_usd": {
+            "type": "number"
+          },
+          "cost_min_usd": {
+            "type": "number"
+          },
+          "effort": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "node_id": {
+            "type": "string"
+          },
+          "tokens_in": {
+            "type": "integer"
+          },
+          "tokens_out": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "node_id",
+          "kind",
+          "tokens_in",
+          "tokens_out",
+          "cost_min_usd",
+          "cost_max_usd"
+        ],
+        "type": "object"
+      },
+      "previewCostRequest": {
+        "properties": {
+          "backend": {
+            "type": "string"
+          },
+          "backend_names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "file_path": {
+            "type": "string"
+          },
+          "permission": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "previewCostResponse": {
+        "properties": {
+          "backend_options": {
+            "additionalProperties": {
+              "additionalProperties": {
+                "$ref": "#/components/schemas/previewBackendOption"
+              },
+              "type": "object"
+            },
+            "type": "object"
+          },
+          "cost_max_usd": {
+            "type": "number"
+          },
+          "cost_min_usd": {
+            "type": "number"
+          },
+          "effective": {
+            "$ref": "#/components/schemas/previewEffectiveSettings"
+          },
+          "nodes": {
+            "items": {
+              "$ref": "#/components/schemas/previewCostNode"
+            },
+            "type": "array"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "tokens_max": {
+            "type": "integer"
+          },
+          "tokens_min": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "tokens_min",
+          "tokens_max",
+          "cost_min_usd",
+          "cost_max_usd",
+          "nodes"
+        ],
+        "type": "object"
+      },
+      "previewEffectiveKnob": {
+        "properties": {
+          "effective": {
+            "type": "string"
+          },
+          "node_pinned": {
+            "type": "boolean"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "effective",
+          "source"
+        ],
+        "type": "object"
+      },
+      "previewEffectiveSettings": {
+        "properties": {
+          "auto_memory": {
+            "$ref": "#/components/schemas/previewEffectiveKnob"
+          },
+          "backend": {
+            "$ref": "#/components/schemas/previewEffectiveKnob"
+          },
+          "compress": {
+            "$ref": "#/components/schemas/previewEffectiveKnob"
+          },
+          "permission": {
+            "$ref": "#/components/schemas/previewEffectiveKnob"
+          }
+        },
+        "required": [
+          "compress",
+          "auto_memory",
+          "permission",
+          "backend"
+        ],
+        "type": "object"
+      },
       "setOrgStatusReq": {
         "properties": {
           "reason": {
@@ -5812,9 +5972,26 @@
     "/api/runs/preview-cost": {
       "post": {
         "operationId": "postRunsPreviewCost",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/previewCostRequest"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
-          "default": {
-            "description": "Response"
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/previewCostResponse"
+                }
+              }
+            },
+            "description": "OK"
           }
         },
         "summary": "POST /api/runs/preview-cost",

--- a/pkg/dsl/ir/validate_fallbacks.go
+++ b/pkg/dsl/ir/validate_fallbacks.go
@@ -402,6 +402,22 @@ func toolsInversionReason(nodeBackend, routeBackend string, tools []string) stri
 	return "crosses the claw⇄CLI boundary on a node with no tools: list — an empty list means NO tools on claw but the full unrestricted toolset on a CLI backend, so the route silently changes what this node can do; declare an explicit tools: list"
 }
 
+// ToolRestrictionLossReason reports the non-security capability drift the
+// Studio must disclose when an explicit launch override moves a claw node to
+// a CLI backend. Claw enforces the lowercase tools: list; CLI backends running
+// under their native permission mode do not, so the shared permission gate
+// may remain intact while this independent restriction layer disappears.
+//
+// Fallback validation uses the stricter toolsInversionReason because a
+// fallback is automatic. A launch picker may still offer this deliberate
+// crossing, but must never present it as capability-neutral.
+func ToolRestrictionLossReason(nodeBackend, routeBackend string, tools []string) string {
+	if nodeBackend != clawBackendName || routeBackend == clawBackendName || len(tools) == 0 {
+		return ""
+	}
+	return "this claw node's tools: restriction is not enforced by the selected CLI backend; the permission gate remains active, but the backend's full native toolset becomes available"
+}
+
 // sessionContinuityCrossingReason refuses inherit / inherit_if_available /
 // fork / persist when a fallback changes backend (ADR-087 + ADR-089).
 func sessionContinuityCrossingReason(session SessionMode, nodeBackend, routeBackend string) string {

--- a/pkg/dsl/ir/validate_fallbacks_test.go
+++ b/pkg/dsl/ir/validate_fallbacks_test.go
@@ -144,6 +144,26 @@ func TestFallbackUngatedRouteIsRefused(t *testing.T) {
 	}
 }
 
+func TestToolRestrictionLossReason(t *testing.T) {
+	if got := ToolRestrictionLossReason("claw", "claude_code", []string{"read_file"}); !strings.Contains(got, "tools:") {
+		t.Fatalf("claw → CLI warning = %q, want tools: restriction loss", got)
+	}
+	for _, tc := range []struct {
+		name, from, to string
+		tools          []string
+	}{
+		{name: "same backend", from: "claw", to: "claw", tools: []string{"read_file"}},
+		{name: "CLI source", from: "claude_code", to: "codex", tools: []string{"read_file"}},
+		{name: "no restriction", from: "claw", to: "claude_code"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ToolRestrictionLossReason(tc.from, tc.to, tc.tools); got != "" {
+				t.Fatalf("unexpected warning: %s", got)
+			}
+		})
+	}
+}
+
 // externalHookBackends are the CLI backends whose PreToolUse hook is an
 // EXTERNAL process. Both earned their entry with a live denial (a real model,
 // a real tool call, a filesystem sentinel), and both are deny-only for the

--- a/pkg/server/cost_preview.go
+++ b/pkg/server/cost_preview.go
@@ -10,8 +10,11 @@ import (
 )
 
 type previewCostRequest struct {
-	FilePath string `json:"file_path,omitempty"`
-	Source   string `json:"source,omitempty"`
+	FilePath     string   `json:"file_path,omitempty"`
+	Source       string   `json:"source,omitempty"`
+	Permission   string   `json:"permission,omitempty"`
+	Backend      string   `json:"backend,omitempty"`
+	BackendNames []string `json:"backend_names,omitempty"`
 }
 
 // CostMin == 0 with CostMax == 0 signals "no pricing data" so the
@@ -43,6 +46,16 @@ type previewCostResponse struct {
 	// The client layers its own override on top (it owns the selects,
 	// so "run_override" never appears here).
 	Effective *previewEffectiveSettings `json:"effective,omitempty"`
+	// BackendOptions is keyed by node id, then by the backend names the
+	// Studio is actually offering. The server computes the exact launch-time
+	// permission precedence and capability crossing so the picker cannot
+	// drift from runtime admission.
+	BackendOptions map[string]map[string]previewBackendOption `json:"backend_options,omitempty"`
+}
+
+type previewBackendOption struct {
+	UnavailableReason string `json:"unavailable_reason,omitempty"`
+	Warning           string `json:"warning,omitempty"`
 }
 
 // previewEffectiveKnob is one knob's provenance below run-override.
@@ -51,8 +64,9 @@ type previewEffectiveKnob struct {
 	Effective string `json:"effective"`
 	// Source: "workflow" | "env" | "default".
 	Source string `json:"source"`
-	// NodePinned is true when at least one node sets its OWN value —
-	// a run override will not affect those nodes.
+	// NodePinned is true when at least one node sets its own value. Whether a
+	// run setting wins that pin is knob-specific (permission/compress/memory
+	// do; the default-backend setting does not).
 	NodePinned bool `json:"node_pinned,omitempty"`
 }
 
@@ -138,7 +152,15 @@ func (s *Server) handlePreviewCost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := previewCostResponse{Effective: buildEffectiveSettings(cr.Workflow)}
+	resp := previewCostResponse{
+		Effective: buildEffectiveSettings(cr.Workflow),
+		BackendOptions: buildBackendOverrideOptions(
+			cr.Workflow,
+			req.Permission,
+			req.Backend,
+			req.BackendNames,
+		),
+	}
 	hasPricing := false
 	for _, node := range cr.Workflow.Nodes {
 		var model, effort string

--- a/pkg/server/openapi_schema.go
+++ b/pkg/server/openapi_schema.go
@@ -116,6 +116,10 @@ func routeSchemas() map[string]routeOp {
 			}{},
 		},
 		"GET /api/runs/{id}/workflow": {response: runview.WireWorkflow{}},
+		"POST /api/runs/preview-cost": {
+			request:  previewCostRequest{},
+			response: previewCostResponse{},
+		},
 
 		// Model registry — known x usable x capabilities x pricing. Typed so
 		// the studio's picker (and every LaunchView node row) reads the same

--- a/pkg/server/settings_preview.go
+++ b/pkg/server/settings_preview.go
@@ -1,19 +1,120 @@
 package server
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
 	"github.com/SocialGouv/iterion/pkg/backend/automemory"
+	"github.com/SocialGouv/iterion/pkg/backend/permission"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 )
 
+// buildBackendOverrideOptions screens the backend names currently offered by
+// the Studio for every LLM node. The request carries those names rather than
+// duplicating a backend catalog here: a newly detected backend is therefore
+// fail-closed by the same IR predicate without requiring a UI capability
+// table update.
+func buildBackendOverrideOptions(
+	wf *ir.Workflow,
+	runPermission string,
+	runBackend string,
+	backendNames []string,
+) map[string]map[string]previewBackendOption {
+	if wf == nil || len(backendNames) == 0 {
+		return nil
+	}
+
+	result := make(map[string]map[string]previewBackendOption)
+	for _, node := range wf.Nodes {
+		llm, ok := node.(ir.LLMNode)
+		if !ok {
+			continue
+		}
+		mode, _, err := permission.ResolveModeSourced(
+			runPermission,
+			llm.GetPermission(),
+			wf.Permission,
+			os.Getenv("ITERION_PERMISSION"),
+		)
+		if err != nil {
+			// Validation remains authoritative for malformed modes, but the
+			// picker still fails closed instead of advertising every backend
+			// while the workflow itself is unlaunchable.
+			choices := make(map[string]previewBackendOption, len(backendNames))
+			for _, backend := range backendNames {
+				backend = strings.TrimSpace(backend)
+				if backend != "" {
+					choices[backend] = previewBackendOption{UnavailableReason: fmt.Sprintf(
+						"cannot assess permission safety until the invalid permission mode is fixed: %v",
+						err,
+					)}
+				}
+			}
+			if len(choices) > 0 {
+				result[llm.NodeID()] = choices
+			}
+			continue
+		}
+		currentBackend := effectivePreviewBackend(
+			llm.GetLLMFields().Backend,
+			runBackend,
+			wf.DefaultBackend,
+			os.Getenv("ITERION_DEFAULT_BACKEND"),
+		)
+		choices := make(map[string]previewBackendOption, len(backendNames))
+		for _, backend := range backendNames {
+			backend = strings.TrimSpace(backend)
+			if backend == "" {
+				continue
+			}
+			choice := previewBackendOption{}
+			choice.UnavailableReason = ir.UngatedCrossingReason(
+				backend,
+				mode.String(),
+				len(wf.PermissionAsk) > 0,
+			)
+			if choice.UnavailableReason == "" {
+				choice.Warning = ir.ToolRestrictionLossReason(
+					currentBackend,
+					backend,
+					llm.GetTools(),
+				)
+			}
+			choices[backend] = choice
+		}
+		if len(choices) > 0 {
+			result[llm.NodeID()] = choices
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+// effectivePreviewBackend mirrors the backend tail that is knowable before
+// launch. A node pin wins over the run's default-backend override; "auto" is
+// treated as unset at either layer. Credential auto-detection stays unknown,
+// which only suppresses a best-effort tools-drift warning — never a gate
+// refusal.
+func effectivePreviewBackend(node, run, workflow, env string) string {
+	for _, value := range []string{node, run, workflow, env} {
+		value = strings.TrimSpace(value)
+		if value != "" && value != "auto" {
+			return value
+		}
+	}
+	return ""
+}
+
 // buildEffectiveSettings resolves the launch-relevant knobs
 // (compress / auto_memory / permission / backend) BELOW the run-override level —
-// workflow DSL, then env, then default — and flags whether any node
-// pins its own value (a run override won't reach those nodes). The
-// Launch dialog layers the operator's own override on top client-side,
-// so this stays a pure function of (workflow, env).
+// workflow DSL, then env, then default — and flags whether any node pins its
+// own value. The Launch dialog layers the operator's override on top using
+// each knob's precedence (permission/compress/memory run overrides win node
+// pins; the default-backend setting does not), so this stays a pure function
+// of (workflow, env).
 func buildEffectiveSettings(wf *ir.Workflow) *previewEffectiveSettings {
 	if wf == nil {
 		return nil

--- a/pkg/server/settings_preview_test.go
+++ b/pkg/server/settings_preview_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
@@ -111,6 +112,73 @@ workflow main:
 	})
 }
 
+func TestBuildBackendOverrideOptionsMixedPermissions(t *testing.T) {
+	t.Setenv("ITERION_PERMISSION", "")
+	t.Setenv("ITERION_DEFAULT_BACKEND", "")
+	wf := compileSource(t, `agent gated:
+  model: "anthropic/claude-sonnet-4-6"
+  backend: "claw"
+  tools: [read_file]
+
+agent open:
+  model: "anthropic/claude-sonnet-4-6"
+  backend: "claw"
+  permission: off
+
+workflow main:
+  permission: deny
+  gated -> open
+  open -> done
+`)
+
+	choices := buildBackendOverrideOptions(
+		wf,
+		"",
+		"",
+		[]string{"claw", "claude_code", "codex"},
+	)
+	if got := choices["gated"]["codex"].UnavailableReason; got == "" {
+		t.Fatal("gated node presents codex as selectable")
+	}
+	if got := choices["open"]["codex"].UnavailableReason; got != "" {
+		t.Fatalf("permission: off node rejected codex: %s", got)
+	}
+	if got := choices["gated"]["claude_code"].Warning; !strings.Contains(got, "tools:") {
+		t.Fatalf("claw → claude_code warning = %q, want tools: restriction loss", got)
+	}
+
+	// Run-level off wins over BOTH the node and workflow declarations.
+	choices = buildBackendOverrideOptions(wf, "off", "", []string{"codex"})
+	for _, nodeID := range []string{"gated", "open"} {
+		if got := choices[nodeID]["codex"].UnavailableReason; got != "" {
+			t.Errorf("run permission: off did not win for %s: %s", nodeID, got)
+		}
+	}
+
+	// Conversely, a run-level gate wins over the node's explicit off.
+	choices = buildBackendOverrideOptions(wf, "ask", "", []string{"codex"})
+	for _, nodeID := range []string{"gated", "open"} {
+		if got := choices[nodeID]["codex"].UnavailableReason; got == "" {
+			t.Errorf("run permission: ask did not gate %s", nodeID)
+		}
+	}
+}
+
+func TestBuildBackendOverrideOptionsRequiresPauseForAskRules(t *testing.T) {
+	t.Setenv("ITERION_PERMISSION", "")
+	agent := &ir.AgentNode{}
+	agent.ID = "work"
+	wf := &ir.Workflow{
+		Permission: "deny",
+		Nodes:      map[string]ir.Node{"work": agent},
+	}
+	wf.PermissionAsk = []string{"Bash(git push:*)"}
+	choices := buildBackendOverrideOptions(wf, "", "", []string{"grok"})
+	if got := choices["work"]["grok"].UnavailableReason; !strings.Contains(got, "cannot pause") {
+		t.Fatalf("grok assessment = %q, want explicit ask-rule refusal", got)
+	}
+}
+
 func TestPreviewCost_EffectiveBlock(t *testing.T) {
 	t.Setenv("ITERION_COMPRESS", "")
 	t.Setenv("ITERION_PERMISSION", "")
@@ -132,5 +200,30 @@ workflow main:
 	}
 	if got.Effective.Backend.Source != "default" {
 		t.Fatalf("backend = %+v, want default source", got.Effective.Backend)
+	}
+}
+
+func TestPreviewCost_BackendOptionsExposeMixedNodeSafety(t *testing.T) {
+	t.Setenv("ITERION_PERMISSION", "")
+	_, hs := newTestServer(t)
+	src := `agent gated:
+  model: "anthropic/claude-sonnet-4-6"
+
+agent open:
+  model: "anthropic/claude-sonnet-4-6"
+  permission: off
+
+workflow main:
+  permission: deny
+  gated -> open
+  open -> done
+`
+	body := `{"source":` + jsonString(src) + `,"backend_names":["codex"]}`
+	got := postPreviewCost(t, hs.URL, body)
+	if got.BackendOptions["gated"]["codex"].UnavailableReason == "" {
+		t.Fatal("wire response presents codex as safe for the gated node")
+	}
+	if reason := got.BackendOptions["open"]["codex"].UnavailableReason; reason != "" {
+		t.Fatalf("wire response rejects codex for permission: off node: %s", reason)
 	}
 }

--- a/studio/src/api/runs/lifecycle.ts
+++ b/studio/src/api/runs/lifecycle.ts
@@ -48,6 +48,9 @@ export async function createRun(req: CreateRunRequest): Promise<CreateRunRespons
 export async function previewRunCost(req: {
   file_path?: string;
   source?: string;
+  permission?: string;
+  backend?: string;
+  backend_names?: string[];
 }): Promise<PreviewCostResponse> {
   return request("/runs/preview-cost", {
     method: "POST",

--- a/studio/src/api/runs/types.ts
+++ b/studio/src/api/runs/types.ts
@@ -801,12 +801,22 @@ export interface PreviewCostResponse {
   nodes: PreviewCostNode[];
   notes?: string[];
   effective?: PreviewEffectiveSettings;
+  // Per-node assessment of the backend names the client sent with the
+  // preview request. Blocking reasons share the runtime admission predicate;
+  // warnings describe non-security capability drift such as a claw tools:
+  // list becoming inert on a CLI backend.
+  backend_options?: Record<string, Record<string, PreviewBackendOption>>;
+}
+
+export interface PreviewBackendOption {
+  unavailable_reason?: string;
+  warning?: string;
 }
 
 // PreviewEffectiveSettings reports each launch knob's resolution BELOW
-// the run-override level (workflow/env/default + node-pinned flag) so
-// the Launch dialog can caption its selects with why a knob is what it
-// is. The client layers its own override on top.
+// the run-override level (workflow/env/default + node-pinned flag) so the
+// Launch dialog can caption its selects with why a knob is what it is. The
+// client layers its own override on top using the knob-specific precedence.
 export interface PreviewEffectiveKnob {
   effective: string;
   source: "workflow" | "env" | "default";

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5913,6 +5913,52 @@ export interface components {
                 [key: string]: string;
             };
         };
+        previewBackendOption: {
+            unavailable_reason?: string;
+            warning?: string;
+        };
+        previewCostNode: {
+            cost_max_usd: number;
+            cost_min_usd: number;
+            effort?: string;
+            kind: string;
+            model?: string;
+            node_id: string;
+            tokens_in: number;
+            tokens_out: number;
+        };
+        previewCostRequest: {
+            backend?: string;
+            backend_names?: string[];
+            file_path?: string;
+            permission?: string;
+            source?: string;
+        };
+        previewCostResponse: {
+            backend_options?: {
+                [key: string]: {
+                    [key: string]: components["schemas"]["previewBackendOption"];
+                };
+            };
+            cost_max_usd: number;
+            cost_min_usd: number;
+            effective?: components["schemas"]["previewEffectiveSettings"];
+            nodes: components["schemas"]["previewCostNode"][];
+            notes?: string[];
+            tokens_max: number;
+            tokens_min: number;
+        };
+        previewEffectiveKnob: {
+            effective: string;
+            node_pinned?: boolean;
+            source: string;
+        };
+        previewEffectiveSettings: {
+            auto_memory: components["schemas"]["previewEffectiveKnob"];
+            backend: components["schemas"]["previewEffectiveKnob"];
+            compress: components["schemas"]["previewEffectiveKnob"];
+            permission: components["schemas"]["previewEffectiveKnob"];
+        };
         setOrgStatusReq: {
             reason?: string;
             status: string;
@@ -8721,14 +8767,20 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        requestBody?: never;
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["previewCostRequest"];
+            };
+        };
         responses: {
-            /** @description Response */
-            default: {
+            /** @description OK */
+            200: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content?: never;
+                content: {
+                    "application/json": components["schemas"]["previewCostResponse"];
+                };
             };
         };
     };

--- a/studio/src/components/Runs/LaunchView.tsx
+++ b/studio/src/components/Runs/LaunchView.tsx
@@ -90,7 +90,7 @@ export default function LaunchView() {
   } = applyLaunchHints(fields, bot?.launch);
   const { attachments, handleAttachmentChange } = useAttachmentUploads();
   const repoTarget = useRepoTarget(bot, serverInfo);
-  const overrides = useRunOverrides(filePath, worktreeOn);
+  const overrides = useRunOverrides(filePath, currentSource, worktreeOn);
   const cloud = useServerInfoStore((s) => s.info?.mode === "cloud");
 
   const {

--- a/studio/src/components/Runs/launchView/EngineOptionsSection.tsx
+++ b/studio/src/components/Runs/launchView/EngineOptionsSection.tsx
@@ -70,6 +70,9 @@ export default function EngineOptionsSection({
         nodes={llmNodes}
         overrides={overrides.modelOverrides}
         backendReport={backendReport}
+        backendOptions={overrides.nodeBackendOptions}
+        backendOptionsReady={overrides.nodeBackendOptionsReady}
+        backendOptionsError={overrides.nodeBackendOptionsError}
         onChange={(name, patch) =>
           overrides.setModelOverrides((prev) => ({
             ...prev,

--- a/studio/src/components/Runs/launchView/ModelOverridesSection.test.tsx
+++ b/studio/src/components/Runs/launchView/ModelOverridesSection.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+
+import type { BackendDetectReport } from "@/api/backends";
+
+import ModelOverridesSection from "./ModelOverridesSection";
+
+afterEach(cleanup);
+
+vi.mock("@/hooks/useModelCatalog", () => ({
+  useModelCatalog: () => ({
+    models: [],
+    recommended: null,
+    invalidSpecs: [],
+    error: null,
+  }),
+}));
+
+vi.mock("@/components/models/ModelPicker", () => ({
+  default: () => <input aria-label="model override" />,
+}));
+
+const report: BackendDetectReport = {
+  preference_order: ["claude_code", "claw"],
+  resolved_default: "claw",
+  providers: [],
+  backends: [
+    { name: "claw", available: true, auth: "api_key" },
+    { name: "claude_code", available: true, auth: "oauth" },
+    { name: "codex", available: true, auth: "oauth" },
+  ],
+};
+
+const gatedNode = {
+  name: "gated",
+  kind: "agent" as const,
+  model: "a/model",
+  backend: "claw",
+};
+
+const nodes = [
+  gatedNode,
+  { name: "open", kind: "agent" as const, model: "a/model", backend: "claw" },
+];
+
+function openPicker() {
+  fireEvent.click(screen.getByRole("button", { name: /Model & backend per node/i }));
+}
+
+test("disables an unsafe backend only for the gated node and explains why", () => {
+  render(
+    <ModelOverridesSection
+      nodes={nodes}
+      overrides={{}}
+      backendReport={report}
+      backendOptions={{
+        gated: {
+          codex: {
+            unavailable_reason:
+              'runs on backend "codex", which cannot enforce the effective permission: deny gate — the run would be UNGATED',
+          },
+        },
+        open: { codex: {} },
+      }}
+      backendOptionsReady
+      backendOptionsError={false}
+      onChange={vi.fn()}
+    />,
+  );
+  openPicker();
+
+  const gated = screen.getByLabelText("Backend override for gated");
+  const open = screen.getByLabelText("Backend override for open");
+  const gatedCodex = within(gated).getByRole("option", { name: /codex/ });
+  const openCodex = within(open).getByRole("option", { name: /codex/ });
+
+  expect((gatedCodex as HTMLOptionElement).disabled).toBe(true);
+  expect(gatedCodex.textContent).toContain("cannot enforce permission: deny");
+  expect((openCodex as HTMLOptionElement).disabled).toBe(false);
+  expect(
+    screen.getByText(/cannot preserve this node's effective permission gate/i),
+  ).toBeTruthy();
+});
+
+test("warns when a claw tools restriction becomes inert on a CLI backend", () => {
+  render(
+    <ModelOverridesSection
+      nodes={[gatedNode]}
+      overrides={{ gated: { backend: "claude_code" } }}
+      backendReport={report}
+      backendOptions={{
+        gated: {
+          claude_code: {
+            warning:
+              "this claw node's tools: restriction is not enforced by the selected CLI backend; the permission gate remains active",
+          },
+        },
+      }}
+      backendOptionsReady
+      backendOptionsError={false}
+      onChange={vi.fn()}
+    />,
+  );
+  openPicker();
+
+  expect(screen.getByRole("status").textContent).toContain(
+    "tools: restriction is not enforced",
+  );
+  expect(screen.getByRole("status").textContent).toContain(
+    "permission gate remains active",
+  );
+});
+
+test("clears a stale selection that becomes unsafe after a run gate change", () => {
+  const onChange = vi.fn();
+  render(
+    <ModelOverridesSection
+      nodes={[gatedNode]}
+      overrides={{ gated: { backend: "codex" } }}
+      backendReport={report}
+      backendOptions={{
+        gated: {
+          codex: { unavailable_reason: "cannot preserve the permission gate" },
+        },
+      }}
+      backendOptionsReady
+      backendOptionsError={false}
+      onChange={onChange}
+    />,
+  );
+
+  expect(onChange).toHaveBeenCalledWith("gated", { backend: "" });
+});

--- a/studio/src/components/Runs/launchView/ModelOverridesSection.tsx
+++ b/studio/src/components/Runs/launchView/ModelOverridesSection.tsx
@@ -16,10 +16,11 @@
 // registry as extra specs so a bot pinned outside the curated set still
 // resolves — and so re-selecting the default stays one click.
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import type { BackendDetectReport } from "@/api/backends";
 import type { ModelEntry } from "@/api/models";
+import type { PreviewBackendOption } from "@/api/runs";
 
 import ModelPicker from "@/components/models/ModelPicker";
 import { Select } from "@/components/ui/Select";
@@ -44,13 +45,24 @@ export interface ModelOverridesSectionProps {
   nodes: LLMNode[];
   overrides: Record<string, NodeOverride>;
   backendReport: BackendDetectReport | null;
+  backendOptions: Record<string, Record<string, PreviewBackendOption>>;
+  backendOptionsReady: boolean;
+  backendOptionsError: boolean;
   onChange: (nodeName: string, patch: NodeOverride) => void;
+}
+
+function unavailableLabel(reason: string): string {
+  if (reason.includes("cannot pause")) return "cannot preserve ask rules";
+  const mode = reason.match(/permission: (ask|deny)/)?.[1];
+  return mode ? `cannot enforce permission: ${mode}` : "cannot preserve gate";
 }
 
 function NodeRow({
   node,
   override,
   backendReport,
+  backendOptions,
+  backendOptionsReady,
   models,
   recommended,
   onChange,
@@ -58,12 +70,21 @@ function NodeRow({
   node: LLMNode;
   override: NodeOverride;
   backendReport: BackendDetectReport | null;
+  backendOptions: Record<string, PreviewBackendOption>;
+  backendOptionsReady: boolean;
   models: ModelEntry[];
   recommended: ModelEntry | null;
   onChange: (patch: NodeOverride) => void;
 }) {
   const inheritModel = node.model && !node.model.includes("${") ? node.model : "";
   const backends = backendReport?.backends ?? [];
+  const selectedAssessment = override.backend
+    ? backendOptions[override.backend]
+    : undefined;
+  const unavailable = backends.filter(
+    (backend) =>
+      backend.available && backendOptions[backend.name]?.unavailable_reason,
+  );
   return (
     <div className="grid grid-cols-[160px_1fr_140px] gap-3 items-start">
       <div className="min-w-0">
@@ -86,19 +107,52 @@ function NodeRow({
       </div>
       <div>
         <Select
+          aria-label={`Backend override for ${node.name}`}
           value={override.backend ?? ""}
           onChange={(e) => onChange({ backend: e.currentTarget.value })}
         >
           <option value="">
             inherit{node.backend ? ` — ${node.backend}` : ""}
           </option>
-          {backends.map((b) => (
-            <option key={b.name} value={b.name} disabled={!b.available}>
-              {b.name}
-              {b.available ? "" : " — no credential"}
-            </option>
-          ))}
+          {backends.map((b) => {
+            const unavailableReason = backendOptions[b.name]?.unavailable_reason;
+            return (
+              <option
+                key={b.name}
+                value={b.name}
+                disabled={
+                  !b.available || !backendOptionsReady || !!unavailableReason
+                }
+              >
+                {b.name}
+                {!b.available
+                  ? " — no credential"
+                  : !backendOptionsReady
+                    ? " — checking permission safety"
+                  : unavailableReason
+                    ? ` — ${unavailableLabel(unavailableReason)}`
+                    : ""}
+              </option>
+            );
+          })}
         </Select>
+        {!backendOptionsReady && backends.some((backend) => backend.available) && (
+          <p className="mt-1 text-caption text-fg-subtle">
+            Backend overrides stay disabled until the permission capability
+            check succeeds.
+          </p>
+        )}
+        {unavailable.length > 0 && (
+          <p className="mt-1 text-caption text-fg-subtle">
+            Unavailable choices are disabled because they cannot preserve this
+            node&apos;s effective permission gate.
+          </p>
+        )}
+        {selectedAssessment?.warning && (
+          <p className="mt-1 text-caption text-warning" role="status">
+            {selectedAssessment.warning}
+          </p>
+        )}
       </div>
     </div>
   );
@@ -108,6 +162,9 @@ export default function ModelOverridesSection({
   nodes,
   overrides,
   backendReport,
+  backendOptions,
+  backendOptionsReady,
+  backendOptionsError,
   onChange,
 }: ModelOverridesSectionProps) {
   const [open, setOpen] = useState(false);
@@ -118,6 +175,22 @@ export default function ModelOverridesSection({
     extraSpecs: specs,
     enabled: open && nodes.length > 0,
   });
+
+  // A backend may have been selected while permission was off and become
+  // unsafe after the operator switches the run-level gate to ask/deny. Drop
+  // that now-invalid directive as soon as the server assessment arrives so
+  // the form cannot visually inherit while still submitting a stale unsafe
+  // override. Runtime admission remains the final boundary.
+  useEffect(() => {
+    for (const [nodeName, override] of Object.entries(overrides)) {
+      if (
+        override.backend &&
+        backendOptions[nodeName]?.[override.backend]?.unavailable_reason
+      ) {
+        onChange(nodeName, { backend: "" });
+      }
+    }
+  }, [backendOptions, onChange, overrides]);
 
   if (nodes.length === 0) return null;
 
@@ -159,6 +232,12 @@ export default function ModelOverridesSection({
               typing its <code>provider/model-id</code>.
             </p>
           )}
+          {backendOptionsError && (
+            <p className="text-caption text-warning">
+              Could not verify backend permission capabilities. Backend
+              overrides remain disabled; runtime admission is unchanged.
+            </p>
+          )}
           {invalidSpecs.length > 0 && (
             // A node's own `model:` that the registry cannot resolve is
             // skipped so it cannot blank the list — but skipping it in
@@ -184,6 +263,8 @@ export default function ModelOverridesSection({
                   node={n}
                   override={overrides[n.name] ?? {}}
                   backendReport={backendReport}
+                  backendOptions={backendOptions[n.name] ?? {}}
+                  backendOptionsReady={backendOptionsReady}
                   models={models}
                   recommended={recommended}
                   onChange={(patch) => onChange(n.name, patch)}
@@ -203,6 +284,8 @@ export default function ModelOverridesSection({
                   node={n}
                   override={overrides[n.name] ?? {}}
                   backendReport={backendReport}
+                  backendOptions={backendOptions[n.name] ?? {}}
+                  backendOptionsReady={backendOptionsReady}
                   models={models}
                   recommended={recommended}
                   onChange={(patch) => onChange(n.name, patch)}

--- a/studio/src/components/Runs/launchView/RunSettingsSection.test.tsx
+++ b/studio/src/components/Runs/launchView/RunSettingsSection.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+
+import RunSettingsSection from "./RunSettingsSection";
+
+afterEach(cleanup);
+
+test("shows that a run permission override wins a node permission pin", () => {
+  const { container } = render(
+    <RunSettingsSection
+      backendOverride=""
+      compressOverride=""
+      autoMemoryOverride=""
+      permissionOverride="deny"
+      reviewModeOverride=""
+      backendReport={null}
+      effective={{
+        backend: { effective: "auto", source: "default" },
+        compress: { effective: "auto", source: "default" },
+        auto_memory: { effective: "off", source: "default" },
+        permission: {
+          effective: "ask",
+          source: "workflow",
+          node_pinned: true,
+        },
+      }}
+      onBackendChange={vi.fn()}
+      onCompressChange={vi.fn()}
+      onAutoMemoryChange={vi.fn()}
+      onPermissionChange={vi.fn()}
+      onReviewModeChange={vi.fn()}
+      showReviewMode={false}
+    />,
+  );
+
+  expect(container.textContent).toContain(
+    "effective: deny · from run override · run override wins over node settings",
+  );
+  expect(container.textContent).not.toContain("override won’t affect them");
+});

--- a/studio/src/components/Runs/launchView/RunSettingsSection.tsx
+++ b/studio/src/components/Runs/launchView/RunSettingsSection.tsx
@@ -37,9 +37,12 @@ export interface RunSettingsSectionProps {
 
 // knobCaption renders "effective: X · from Y" — the override wins when
 // the operator set the select; else the server's workflow/env/default
-// resolution, plus a node-pinned warning when a run override wouldn't
-// reach every node.
-function knobCaption(override: string, knob: PreviewEffectiveKnob | undefined) {
+// resolution, plus the knob-specific relation to node pins.
+function knobCaption(
+  override: string,
+  knob: PreviewEffectiveKnob | undefined,
+  nodePinWins: boolean = false,
+) {
   if (!override && !knob) return null;
   const effective = override || knob?.effective || "";
   const source = override ? "run override" : (knob?.source ?? "");
@@ -47,9 +50,13 @@ function knobCaption(override: string, knob: PreviewEffectiveKnob | undefined) {
     <div className="mt-1 text-caption text-fg-subtle">
       effective: <code>{effective}</code>
       {source ? <> · from {source}</> : null}
-      {knob?.node_pinned ? (
-        <> · some nodes pin their own (override won’t affect them)</>
-      ) : null}
+      {knob?.node_pinned
+        ? override
+          ? nodePinWins
+            ? <> · some nodes pin their own (this setting won’t affect them)</>
+            : <> · run override wins over node settings</>
+          : <> · some nodes set their own value</>
+        : null}
     </div>
   );
 }
@@ -103,7 +110,7 @@ export default function RunSettingsSection({
                 </option>
               ))}
             </Select>
-            {knobCaption(backendOverride, effective?.backend)}
+            {knobCaption(backendOverride, effective?.backend, true)}
             <div className="mt-1 text-caption text-fg-subtle">
               Overrides the workflow&apos;s default. Nodes that pin a specific{" "}
               <code>backend:</code> keep their pin.

--- a/studio/src/components/Runs/launchView/useRunOverrides.ts
+++ b/studio/src/components/Runs/launchView/useRunOverrides.ts
@@ -10,6 +10,7 @@ import { useQuery } from "@tanstack/react-query";
 import { previewRunCost } from "@/api/runs";
 import type { MergeStrategy } from "@/api/runs";
 import { readBooleanFlag, writeBooleanFlag } from "@/lib/localStorageFlag";
+import { useBackendDetectStore } from "@/store/backendDetect";
 
 import {
   emptyBudgetFieldValues,
@@ -22,7 +23,11 @@ const ENGINE_OPTIONS_OPEN_KEY = "iterion.launch.engine-options-open";
 
 export type UseRunOverridesResult = ReturnType<typeof useRunOverrides>;
 
-export function useRunOverrides(filePath: string, worktreeOn: boolean) {
+export function useRunOverrides(
+  filePath: string,
+  currentSource: string | null,
+  worktreeOn: boolean,
+) {
   // Worktree finalization overrides — only meaningful when the
   // workflow declares `worktree: auto`. We always render the controls
   // (collapsed) even for non-worktree runs so the UI is predictable;
@@ -76,18 +81,41 @@ export function useRunOverrides(filePath: string, worktreeOn: boolean) {
   // tool-permission gate mode override ("" inherits the workflow/node
   // `permission:` DSL then ITERION_PERMISSION).
   const [permissionOverride, setPermissionOverride] = useState<string>("");
+  const backendReport = useBackendDetectStore((s) => s.report);
+  const backendNames = (backendReport?.backends ?? []).map((b) => b.name);
   // Server-resolved knob provenance below run-override (workflow/env/
   // default), captioning the Run-settings selects. Best-effort — any
   // failure just leaves the captions hidden.
   const effectiveQuery = useQuery({
-    queryKey: ["preview-effective-settings", filePath],
+    queryKey: [
+      "preview-effective-settings",
+      filePath,
+      filePath ? "" : currentSource,
+      permissionOverride,
+      backendOverride,
+      backendNames,
+    ],
     queryFn: async () =>
-      (await previewRunCost({ file_path: filePath })).effective ?? null,
-    enabled: !!filePath,
+      await previewRunCost({
+        file_path: filePath || undefined,
+        source: filePath ? undefined : currentSource || undefined,
+        permission: permissionOverride || undefined,
+        backend: backendOverride || undefined,
+        backend_names: backendNames,
+      }),
+    enabled: !!(filePath || currentSource),
   });
   const effectiveSettings = effectiveQuery.isError
     ? null
-    : effectiveQuery.data ?? null;
+    : effectiveQuery.data?.effective ?? null;
+  const nodeBackendOptions = effectiveQuery.isError
+    ? {}
+    : effectiveQuery.data?.backend_options ?? {};
+  // Fail closed in the picker while the server-side capability assessment is
+  // loading or unavailable. Runtime admission still repeats the check, but a
+  // transient preview failure must not briefly advertise an unsafe choice.
+  const nodeBackendOptionsReady = effectiveQuery.isSuccess;
+  const nodeBackendOptionsError = effectiveQuery.isError;
   // Mono/dual review-topology override ("" = auto: resolve from the
   // providers detected at launch). Only sent when explicitly mono/dual;
   // ignored by bots that don't declare a `review_mode` var.
@@ -146,6 +174,9 @@ export function useRunOverrides(filePath: string, worktreeOn: boolean) {
     permissionOverride,
     setPermissionOverride,
     effectiveSettings,
+    nodeBackendOptions,
+    nodeBackendOptionsReady,
+    nodeBackendOptionsError,
     reviewModeOverride,
     setReviewModeOverride,
     budgetFields,


### PR DESCRIPTION
## Outcome

Makes the Studio per-node backend override picker permission-gate aware before launch, while keeping the existing runtime admission check authoritative.

This is intentionally stacked on #480 / `feat/assistant-epic`: that branch contains the model picker and the runtime override rejection this ticket completes in the UI.

## Changes

- extends the cost-preview contract with server-computed backend assessments for every LLM node and every backend currently offered by the client;
- resolves permission precedence as run override > node > workflow > environment > off;
- disables choices that cannot enforce the effective gate, including deny-only backends when explicit ask rules require pausing;
- fails closed while the capability assessment is loading or unavailable, and clears a selection that becomes unsafe after the run permission changes;
- warns separately when a claw → CLI override makes the node's lowercase `tools:` restriction inert while the permission gate remains active;
- corrects the run-settings provenance caption so permission overrides are shown as winning node pins;
- types and regenerates the OpenAPI contract for `/api/runs/preview-cost`.

## Verification

- `go test ./pkg/...`
- `go vet ./pkg/server ./pkg/dsl/ir ./pkg/runview`
- Studio Vitest: 180 files / 1,606 tests
- Studio TypeScript: `tsc --noEmit`
- targeted Studio ESLint
- OpenAPI and generated Studio schema regeneration: clean/reproducible

Closes #489
