### PR TITLE
fix(model): forward ITERION_CODEX_VERSION into the sandboxed claw runner

### DIFF
--- a/pkg/backend/model/claw_backend.go
+++ b/pkg/backend/model/claw_backend.go
@@ -1063,6 +1063,13 @@ var providerCredentialEnvVars = []string{
 	"ITERION_LLM_USER_AGENT",
 	"CLAW_USER_AGENT",
 	"ANTHROPIC_CUSTOM_HEADERS",
+	// The ChatGPT-forfait wire gates model availability on the codex-cli
+	// `version:` header. The sandbox image ships no codex binary, so the
+	// in-container runner's `codex --version` probe finds nothing and
+	// falls back to claw's baked-in version — which the backend then
+	// refuses for newer models ("gpt-5.6-sol requires a newer codex-cli").
+	// The operator override must therefore cross the boundary.
+	"ITERION_CODEX_VERSION",
 }
 
 // byokEnvVar names the environment variable claw's registry reads for a

--- a/pkg/backend/model/claw_sandbox_env_test.go
+++ b/pkg/backend/model/claw_sandbox_env_test.go
@@ -69,3 +69,15 @@ func TestForwardableProviderEnv_runCredentialsBeatTheAmbientOnes(t *testing.T) {
 		}
 	})
 }
+
+// The ChatGPT-forfait wire gates model access on the codex-cli version
+// header, and the sandbox image ships no codex binary — so the operator's
+// ITERION_CODEX_VERSION override must cross into the in-container runner
+// or newer models 400 only when sandboxed.
+func TestForwardableProviderEnv_forwardsCodexVersionOverride(t *testing.T) {
+	t.Setenv("ITERION_CODEX_VERSION", "0.144.6")
+	env := forwardableProviderEnv(context.Background())
+	if env["ITERION_CODEX_VERSION"] != "0.144.6" {
+		t.Errorf("ITERION_CODEX_VERSION = %q, want the ambient override forwarded", env["ITERION_CODEX_VERSION"])
+	}
+}


### PR DESCRIPTION
The ChatGPT-forfait wire gates model availability on the codex-cli `version:` header. The sandbox image ships no codex binary, so the in-container `__claw-runner`'s `codex --version` probe finds nothing and falls back to claw's baked-in version — which the backend then refuses for newer models.

Lived on iterion#541's `/billy` dogfood: `plan_review` (claw + `openai/gpt-5.6-sol`) 400'd with *"gpt-5.6-sol requires a newer codex-cli"* on every cloud attempt, and setting `ITERION_CODEX_VERSION` on the runner deployment would have cured nothing, since the override never crossed into the container. One list entry in `providerCredentialEnvVars` (the same client-identity family as `ITERION_LLM_USER_AGENT`), pinned by a red-first test.

Unblocks re-enabling the cross-model plan peer on cloud (currently pinned `plan_review=off` on the iterion integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)