### PR TITLE
fix(cloud): a resume must keep the budget the launch declared

### DIFF
--- a/pkg/runview/service.go
+++ b/pkg/runview/service.go
@@ -132,8 +132,10 @@ type LaunchSpec struct {
 	// --max-parallel-branches flags. Applied to the compiled workflow after
 	// recipe/preset resolution and before the executor snapshots Budget
 	// (non-zero field wins, zero inherits — see ir.ApplyBudgetOverrides).
-	// The detached path forwards it as the CLI flags; the queued cloud path
-	// does not support it yet and rejects a non-zero Budget explicitly.
+	// The detached path forwards it as the CLI flags; the queued cloud
+	// path publishes it on the RunMessage (clamped to the pool grant),
+	// persists the raw ask on the run doc, and replays it on resume so
+	// unattended auto-retries keep the cap the launch declared.
 	Budget *ir.BudgetOverrides
 	// ParentRunID, ShardIndex, ShardCount, ShardLabel are set when a
 	// parent run dispatches this as a shard child (see Cap. 3 in

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -870,6 +870,11 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 		// studio Overview reads the pins from the run doc, and the resume
 		// path replays them onto its RunMessage from here.
 		ModelOverrides: runModelOverrides(spec.ModelOverrides),
+		// The raw budget ask, same doctrine as the model pins above: the
+		// run doc is the single source the resume path replays from. The
+		// clamped/effective figure is NOT what is stamped — the resume
+		// re-clamps against its own grant.
+		BudgetOverrides: runBudgetOverrides(spec.Budget),
 	}
 	// Typed provenance (schedule / dispatcher / trigger spine). The queued
 	// doc is the ONLY carrier: the RunMessage has no source field, and the
@@ -1231,7 +1236,11 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 		// paused for a day must not come back holding yesterday's budget.
 		// Offset by what the run already banked: the engine restores that
 		// figure into the very tracker this ceiling is checked against.
-		Budget:         clampBudgetToGrant(nil, wf, creds.grant, checkpointCostUSD(prior), p.logger, spec.RunID),
+		// The launch's own budget ask is replayed from the run doc (same
+		// doctrine as ModelOverrides below): cloud resumes are often
+		// unattended auto-retries, so nothing else can re-state it, and a
+		// dropped override silently reverts the run to the workflow's cap.
+		Budget:         clampBudgetToGrant(budgetOverridesFromRun(prior.BudgetOverrides), wf, creds.grant, checkpointCostUSD(prior), p.logger, spec.RunID),
 		BackendConfig:  queue.BackendConfig{Default: queue.BackendClaw},
 		PublishedAtRFC: time.Now().UTC().Format(time.RFC3339Nano),
 		// A resumed attempt must honour the SAME pins the launch declared —
@@ -1587,6 +1596,41 @@ func runModelOverrides(entries []runview.ModelOverrideEntry) []store.RunModelOve
 		out = append(out, store.RunModelOverride{Selector: e.Selector, Backend: e.Backend, Model: e.Model, Provider: e.Provider})
 	}
 	return out
+}
+
+// runBudgetOverrides converts the launch's raw budget ask into the
+// persisted run-doc form (the resume path's replay source, the budget
+// twin of runModelOverrides). An absent or all-zero ask persists as nil
+// so legacy docs and override-less launches stay byte-identical.
+// CapImposed is deliberately not persisted: it is a product of the grant
+// clamp, recomputed against the CURRENT grant on every publication.
+func runBudgetOverrides(o *ir.BudgetOverrides) *store.RunBudgetOverrides {
+	if o == nil || o.IsZero() {
+		return nil
+	}
+	return &store.RunBudgetOverrides{
+		MaxCostUSD:          o.MaxCostUSD,
+		MaxTokens:           o.MaxTokens,
+		MaxDuration:         o.MaxDuration,
+		MaxIterations:       o.MaxIterations,
+		MaxParallelBranches: o.MaxParallelBranches,
+	}
+}
+
+// budgetOverridesFromRun replays a run doc's persisted budget ask onto a
+// resume publication, where clampBudgetToGrant re-clamps it against the
+// resume's own grant exactly like a fresh launch.
+func budgetOverridesFromRun(o *store.RunBudgetOverrides) *ir.BudgetOverrides {
+	if o == nil {
+		return nil
+	}
+	return &ir.BudgetOverrides{
+		MaxCostUSD:          o.MaxCostUSD,
+		MaxTokens:           o.MaxTokens,
+		MaxDuration:         o.MaxDuration,
+		MaxIterations:       o.MaxIterations,
+		MaxParallelBranches: o.MaxParallelBranches,
+	}
 }
 
 // queueOverridesFromRun replays a run doc's persisted pins onto a resume

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -1123,6 +1123,13 @@ func (p *Publisher) CancelRunWithReason(ctx context.Context, runID, reason strin
 // runner picks it up and dispatches to engine.Resume which threads
 // the answers in.
 //
+// A JetStream redelivery of the ORIGINAL launch message is a different
+// resume path (the runner converts it in place, keeping the message's
+// launch-time budget — the figure clamped against the launch grant):
+// only this explicit republication re-clamps the persisted budget ask
+// against the CURRENT grant. Two resumes of the same run can therefore
+// carry different caps, each honest about its own grant.
+//
 // On publish failure the run is reverted to its prior resumable status
 // so the studio surfaces an actionable error instead of leaving a
 // "queued" row that no runner will ever pick up. Mirrors the rollback

--- a/pkg/server/cloudpublisher/publisher_budget_overrides_test.go
+++ b/pkg/server/cloudpublisher/publisher_budget_overrides_test.go
@@ -1,0 +1,124 @@
+package cloudpublisher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// The operator's launch-time budget ask must survive a resume: cloud
+// resumes are often unattended (usage-window auto-retries), so nothing
+// can re-state the override, and a dropped one silently reverts the run
+// to the workflow's own cap. Mesure : un run posé avec max_duration 8h,
+// parqué par le cap puis repris, est mort à 14407s/14400s pendant que
+// son doc affichait 8h. Falsified both ways: the ask rides the launch
+// wire AND lands on the run doc; an ask-less launch stays byte-identical
+// (nil on both carriers); a resume replays the doc's ask onto its wire.
+
+func TestSubmitLaunchPersistsTheBudgetAsk(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	var published *queue.RunMessage
+	p := &Publisher{
+		store: st,
+		publishRun: func(_ context.Context, m *queue.RunMessage) error {
+			published = m
+			return nil
+		},
+	}
+	ctx := store.WithIdentity(context.Background(), "team-a", "u1")
+	wf := &ir.Workflow{Name: "wf", Budget: &ir.Budget{MaxDuration: "4h"}}
+	spec := runview.LaunchSpec{
+		FilePath: "wf.bot",
+		Source:   "workflow wf:\n  start -> done\n",
+		Budget:   &ir.BudgetOverrides{MaxDuration: "8h", MaxCostUSD: 120},
+	}
+	if _, err := p.SubmitLaunch(ctx, "run-bo-1", spec, wf, "hash"); err != nil {
+		t.Fatalf("SubmitLaunch: %v", err)
+	}
+	if published == nil {
+		t.Fatal("nothing published")
+	}
+	if published.Budget == nil || published.Budget.MaxDuration != "8h" || published.Budget.MaxCostUSD != 120 {
+		t.Fatalf("launch wire budget = %+v, want the operator's ask verbatim", published.Budget)
+	}
+	r, err := st.LoadRun(ctx, "run-bo-1")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.BudgetOverrides == nil || r.BudgetOverrides.MaxDuration != "8h" || r.BudgetOverrides.MaxCostUSD != 120 {
+		t.Fatalf("run doc budget ask = %+v, want the raw ask persisted as the resume's replay source", r.BudgetOverrides)
+	}
+}
+
+func TestSubmitLaunchWithoutBudgetAskPersistsNone(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	var published *queue.RunMessage
+	p := &Publisher{
+		store: st,
+		publishRun: func(_ context.Context, m *queue.RunMessage) error {
+			published = m
+			return nil
+		},
+	}
+	ctx := store.WithIdentity(context.Background(), "team-a", "u1")
+	wf := &ir.Workflow{Name: "wf", Budget: &ir.Budget{MaxDuration: "4h"}}
+	spec := runview.LaunchSpec{FilePath: "wf.bot", Source: "workflow wf:\n  start -> done\n"}
+	if _, err := p.SubmitLaunch(ctx, "run-bo-2", spec, wf, "hash"); err != nil {
+		t.Fatalf("SubmitLaunch: %v", err)
+	}
+	if published == nil || published.Budget != nil {
+		t.Fatalf("ask-less launch published budget %+v, want nil (older consumers stay byte-identical)", published.Budget)
+	}
+	if r, _ := st.LoadRun(ctx, "run-bo-2"); r != nil && r.BudgetOverrides != nil {
+		t.Fatalf("ask-less launch persisted %+v, want none", r.BudgetOverrides)
+	}
+}
+
+func TestSubmitResumeReplaysTheLaunchBudgetAsk(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	ctx := store.WithIdentity(context.Background(), "team-a", "u1")
+	const runID = "run-bo-resume"
+	if err := st.SaveRun(ctx, &store.Run{
+		ID:              runID,
+		TenantID:        "team-a",
+		OwnerID:         "u1",
+		Status:          store.RunStatusFailedResumable,
+		BudgetOverrides: &store.RunBudgetOverrides{MaxDuration: "8h", MaxCostUSD: 120},
+	}); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	var published *queue.RunMessage
+	p := &Publisher{
+		store: st,
+		publishRun: func(_ context.Context, m *queue.RunMessage) error {
+			published = m
+			return nil
+		},
+	}
+	// The workflow's own budget is the 4h that killed the lived run: the
+	// replay must beat it, not inherit it.
+	wf := &ir.Workflow{Name: "wf", Budget: &ir.Budget{MaxDuration: "4h"}}
+	spec := runview.ResumeSpec{RunID: runID, FilePath: "wf.bot", Source: "workflow wf:\n  entry: done\n"}
+	if err := p.SubmitResume(ctx, spec, wf, "hash"); err != nil {
+		t.Fatalf("SubmitResume: %v", err)
+	}
+	if published == nil {
+		t.Fatal("nothing published")
+	}
+	if published.Budget == nil || published.Budget.MaxDuration != "8h" || published.Budget.MaxCostUSD != 120 {
+		t.Fatalf("resume wire budget = %+v, want the launch ask replayed from the run doc (a nil here is the measured death at 14407s/14400s under a doc showing 8h)", published.Budget)
+	}
+}

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -144,6 +144,28 @@ type RunBudget struct {
 	MaxParallelBranches int     `json:"max_parallel_branches,omitempty" bson:"max_parallel_branches,omitempty"`
 }
 
+// RunBudgetOverrides is the operator's launch-time budget ask, persisted
+// verbatim so the resume path can replay it — the budget counterpart of
+// ModelOverrides ("replayed from the run doc, the single source the
+// launch stamped"). Distinct from RunBudget, which is the EFFECTIVE
+// resolved cap set the runtime snapshots for display: that one is
+// display-only by contract, this one is the replay source. It matters
+// because cloud resumes are often unattended (usage-window auto-retries),
+// so no operator is present to re-state the override — a resume that
+// dropped it silently fell back to the workflow's own cap. Mesure : un
+// run posé avec max_duration 8h, parqué par le cap puis repris, est mort
+// à 14407s/14400s pendant que son doc affichait 8h. Nil = the launch
+// declared no override. No CapImposed field: that marker is a product of
+// the grant clamp, recomputed against the CURRENT grant on every
+// publication, never a declaration.
+type RunBudgetOverrides struct {
+	MaxCostUSD          float64 `json:"max_cost_usd,omitempty" bson:"max_cost_usd,omitempty"`
+	MaxTokens           int     `json:"max_tokens,omitempty" bson:"max_tokens,omitempty"`
+	MaxDuration         string  `json:"max_duration,omitempty" bson:"max_duration,omitempty"`
+	MaxIterations       int     `json:"max_iterations,omitempty" bson:"max_iterations,omitempty"`
+	MaxParallelBranches int     `json:"max_parallel_branches,omitempty" bson:"max_parallel_branches,omitempty"`
+}
+
 // RunBudgetRaises is the live-steering (raise_budget) counterpart of
 // RunBudget: the ABSOLUTE caps granted mid-run, persisted so resume
 // re-applies them (raise-only) over the workflow's declared budget.
@@ -274,6 +296,10 @@ type Run struct {
 	// budget meters with a denominator. Nil when the workflow declares
 	// no budget: block and no overrides applied. See RunBudget.
 	Budget *RunBudget `json:"budget,omitempty" bson:"budget,omitempty"`
+	// BudgetOverrides is the launch-time budget ask persisted verbatim —
+	// the resume path's replay source (see RunBudgetOverrides). Nil for
+	// launches that declared none and for legacy runs.
+	BudgetOverrides *RunBudgetOverrides `json:"budget_overrides,omitempty" bson:"budget_overrides,omitempty"`
 	// LoopOverrides is the accumulated per-loop iteration grant applied
 	// by live steering (bump_loop): loop name → extra iterations on top
 	// of the loop's declared/expr-resolved max. AUTHORITATIVE for


### PR DESCRIPTION
## The failure

`SubmitLaunch` publishes the operator's launch-time budget override on the RunMessage — but `SubmitResume` rebuilt its message with a **nil** override. The first resume (and cloud resumes are mostly **unattended usage-window auto-retries**, so no operator is there to re-state anything) silently reverted the run to the workflow's own `budget:` block.

Observed live: a run launched with `budget: {max_duration: "8h"}`, parked by a usage cap and auto-resumed, died `budget_exceeded` at **14407s/14400s** — the workflow's 4h — while its run doc still displayed 8h. The display was honest about the launch; the enforcement had forgotten it.

## The fix

Same doctrine as the model pins, one comment above the changed line (*"replayed from the run doc, the single source the launch stamped"*):

- **launch** persists the raw ask on the run doc (`Run.BudgetOverrides`, new field — distinct from `Run.Budget`, which is the runtime's display-only snapshot of the *effective* set);
- **resume** replays it into `clampBudgetToGrant`, which re-clamps against the resume's own grant exactly like a fresh launch (the "yesterday's budget" comment there already described this composition — it was only ever handed a nil).

`CapImposed` is deliberately **not** persisted: it is a product of the grant clamp, recomputed against the CURRENT grant on every publication, never a declaration. Ask-less launches persist and publish nil on both carriers — legacy docs and older payloads stay byte-identical.

Also fixes the `LaunchSpec.Budget` comment, which still claimed the queued cloud path "rejects a non-zero Budget explicitly" — it has published one since schema v=4.

## Falsified both ways

- `TestSubmitResumeReplaysTheLaunchBudgetAsk` seeds the lived scenario (doc ask 8h, workflow cap 4h) and asserts the resume wire carries 8h — **red before the fix** (`resume wire budget = <nil>`), green after.
- `TestSubmitLaunchPersistsTheBudgetAsk` / `...WithoutBudgetAskPersistsNone` pin both carriers in both directions.

`go test ./pkg/...`: 9567 passed, 133 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)