### PR TITLE
docs: forge_token binding for repo-bound schedules + auto-fix lane enabled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1781,8 +1781,12 @@ the findings in a session. The command seeds Billy with Revi's review
 (kind-matched hand-off), he pushes fixes onto the PR branch, posts his ledger +
 gate count, and the push re-triggers Revi. Every such run is a dogfood run:
 monitor it, fix the frictions it surfaces, write the bilan. Full habit +
-gotchas: [docs/revi-billy-loop.md](docs/revi-billy-loop.md). (The zero-touch
-`auto_fix_on_gate_failure` lane is deliberately not enabled here yet.)
+gotchas: [docs/revi-billy-loop.md](docs/revi-billy-loop.md). The zero-touch
+`auto_fix_on_gate_failure` lane is **enabled here** since 2026-08-28: a red
+`revi/review` launches Billy by itself, with no comment. So **check no fixer
+run is already in flight** (`iterion remote runs list`, or the gate's `pending`
+link) before hand-fixing a red PR — a manual push while he works recreates the
+mid-run collision.
 
 ## Conventions
 

--- a/bots/vuln-watch/skills/senti-config.md
+++ b/bots/vuln-watch/skills/senti-config.md
@@ -219,8 +219,32 @@ iterion remote schedules create --data '{"bot_id":"vuln-watch",
   "repo_ref":"main","vars":{"mode":"watch","state_commit":"true"}}'
 ```
 
+**A scheduled launch resolves NO connection for its `repo_url`** —
+unlike a studio/API launch (which pins a `connection_id` and mints a
+fresh managed token), the tick's clone token comes from the bot's
+`forge_token` secret resolution: per-bot binding first, else any team
+secret *named* `forge_token`. Bind the bot to the forge connection's
+MANAGED secret (auto-refreshed hourly; a hand-set `forge_token` team
+secret rots and every tick then dies on the clone):
+
+```sh
+# secret_id = the connection's forge_github_<conn-prefix> managed secret
+# (GET /api/teams/<team>/secrets to find it)
+iterion remote api POST /api/teams/<team>/bots/vuln-watch/bindings \
+  --data '{"secret_id":"<managed-secret-id>",
+           "secret_name_for_workflow":"forge_token",
+           "allowed_hosts":["github.com"]}'
+```
+
 ## Troubleshooting
 
+- **Every scheduled tick fails the CLONE: "Invalid username or token.
+  Password authentication is not supported for Git operations"** — the
+  bot has no `forge_token` binding, so the tick fell back to a stale
+  team secret named `forge_token` (manual launches still work: they
+  mint through their pinned connection, which masks the gap). Create
+  the binding to the connection's managed secret (see the cloud
+  scheduling recipe above), then resume one parked run to prove it.
 - **Run failed: "no Dependabot token for configured org(s)"** — the
   `dependabot_tokens` secret is missing/incomplete. App path: check the
   connection's health (`missing_security_permissions`) and its

--- a/bots/vuln-watch/skills/senti-config.md
+++ b/bots/vuln-watch/skills/senti-config.md
@@ -229,8 +229,8 @@ secret rots and every tick then dies on the clone):
 
 ```sh
 # secret_id = the connection's forge_github_<conn-prefix> managed secret
-# (GET /api/teams/<team>/secrets to find it)
-iterion remote api POST /api/teams/<team>/bots/vuln-watch/bindings \
+# (`iterion remote secrets list` to find its id)
+iterion remote bindings vuln-watch create \
   --data '{"secret_id":"<managed-secret-id>",
            "secret_name_for_workflow":"forge_token",
            "allowed_hosts":["github.com"]}'

--- a/docs/revi-billy-loop.md
+++ b/docs/revi-billy-loop.md
@@ -26,11 +26,21 @@ repo (`min_replier_role` on the command — verified live via the forge
 permission API, not from the payload).
 
 There is deliberately **no PR-open auto-launch for Billy**: opening a PR only
-ever auto-REVIEWS it (Revi). Billy runs on a deliberate command. The zero-touch
-lane (`auto_fix_on_gate_failure` — a red gate launches the fixer by itself,
-[merge-gate.md#autofix](merge-gate.md#autofix)) is intentionally **not enabled
-on this repo yet**; enabling it is one PATCH on the integration once the manual
-habit has proven smooth here.
+ever auto-REVIEWS it (Revi). Billy runs on a deliberate command — and, since
+2026-08-28, on a **red gate**: the zero-touch lane (`auto_fix_on_gate_failure`
+— a red gate launches the fixer by itself,
+[merge-gate.md#autofix](merge-gate.md#autofix)) is **enabled on this repo**,
+the manual habit having proven smooth. A red `revi/review` relaunches the
+fixer without a comment, bounded by the lane's own brakes (one attempt per
+head sha, five unattended passes per PR, the hold label). `/billy` remains
+the way to start a pass when the gate is green or the lane's passes are
+spent. One gotcha when flipping the flag: the `repo-bots` PATCH requires the
+FULL `bot_ids` list in the payload (omitting it is a 400, not "keep as is").
+
+**Corollary of the lane**: before hand-fixing a red PR, check no fixer run is
+already in flight on it (`iterion remote runs list` or the gate's `pending`
+link) — a manual push while the fixer works recreates the mid-run-push
+collision the session discipline below warns about.
 
 ## What the command seeds — you type nothing else
 


### PR DESCRIPTION
Two operational-knowledge captures from the 2026-08-27/28 sessions:

## 1. A cloud repo-bound schedule needs the forge_token binding

A cloudsched tick resolves no forge connection for its `repo_url` — the clone token comes from the bot's `forge_token` secret resolution (per-bot binding, else any team secret *named* `forge_token`). Without the binding every tick dies on `Invalid username or token` at clone while manual launches keep working, which masks the gap. Senti's schedule failed 13 consecutive ticks until the binding to the connection's managed secret was created (proved by resuming run `01a04515` → finished, state pushed).

- `docs/scheduling.md` — the general gotcha in Notes & limits
- `bots/vuln-watch/skills/senti-config.md` — the binding step in the cloud recipe + a troubleshooting entry on the exact error

## 2. The Revi→Billy auto-fix lane is now enabled on this repo

`auto_fix_on_gate_failure` was flipped on 2026-08-28 per the runbook's own criterion (manual habit proven smooth). `docs/revi-billy-loop.md` now documents the enabled state, the lane's brakes, the `repo-bots` PATCH `bot_ids` gotcha, and the check-before-hand-fix corollary (a manual push while the fixer runs recreates the mid-run collision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)