### PR TITLE
fix(studio): offer assistant actions only once the turn is parked

### DIFF
--- a/docs/adr/091-ubiquitous-assistant-chat-dock.md
+++ b/docs/adr/091-ubiquitous-assistant-chat-dock.md
@@ -212,6 +212,14 @@ an explicit request, or always allow. Every new catalogue entry defaults to
 ask. Server-side identity, tenant permissions and domain validation remain in
 force after the Studio decision. Secrets are not an action argument type.
 
+When an offer appears is part of the boundary too: only once the turn is
+parked on its chat pause, i.e. after the optional cross-review has been
+composed into the reply the offer sits under. The artifact carrying the
+requests is published when the agent node finishes, earlier than that, and
+rendering from it directly put an executable card in front of the operator
+while the reviewer was still writing (run 01a04999, 2026-08-28). A turn that
+never reaches its pause offers nothing.
+
 This also closes an architectural inconsistency in Nexie: board reads remain
 capability-gated MCP calls, while board writes no longer happen inside the
 model's tool loop and therefore cannot bypass the global Assistant settings.

--- a/docs/assistant-dock.md
+++ b/docs/assistant-dock.md
@@ -164,6 +164,17 @@ invalid request, server permissions still apply, and a key derived from the
 run/node/artifact version prevents a remount or reload from repeating a write.
 Destructive actions stay visibly labelled and use a danger confirmation.
 
+An offer belongs to a reply. The turn artifact is published when the agent
+node finishes — before the optional cross-review and before the chat pause —
+so the Studio renders an offer, and fires an *Always allow* policy, only once
+the turn is parked on its chat pause, with the reviewed reply above it. Without
+that gate the action card was clickable (or self-executing) for the whole time
+the reviewer was still writing the critique it exists to put in front of you.
+Corollary: a turn that never reaches its pause — the run failed or was
+cancelled between the agent node and the chat node — offers nothing; an action
+nobody reviewed is not executable. Mid-turn `ask_user` pauses show no offers
+either: the artifact of that moment is the previous turn's.
+
 The catalogue covers the live editor, board issues, pipeline tasks, run
 lifecycle, dispatcher lifecycle, bot creation/install and plugin management.
 Secret values are deliberately absent: an assistant can reason about a missing

--- a/studio/src/components/ChatDock/ChatDock.test.tsx
+++ b/studio/src/components/ChatDock/ChatDock.test.tsx
@@ -66,6 +66,21 @@ vi.mock("@/components/shared/AgentChatboxInline", () => ({
   },
 }));
 
+// One standing action request, so the offer tests below can tell "hidden by
+// the pause gate" from "nothing to offer". Under the default `ask` policy the
+// card renders a confirmation button and executes nothing.
+const offered = vi.hoisted(() => ({
+  request: {
+    key: "run-1:copi:1:0",
+    id: "pipeline.task.reset" as const,
+    intent: "explicit" as const,
+    args: { task_id: "native:d5fc94b2-ca40-4cb5-9056-ea02fb8dfdaf" },
+  },
+}));
+vi.mock("@/hooks/useAssistantActions", () => ({
+  useAssistantActions: () => [offered.request],
+}));
+
 function makeSession(over: Partial<UseWhatsNextSession> = {}): UseWhatsNextSession {
   return {
     status: "idle",
@@ -148,5 +163,72 @@ describe("ChatDock conversation isolation", () => {
     expect(screen.getByTestId("composer").textContent).toBe("1");
     fireEvent.click(screen.getByRole("button", { name: /new conversation/i }));
     expect(screen.getByTestId("composer").textContent).toBe("2");
+  });
+});
+
+// An offer belongs to a reply. The offers are built from the latest run
+// artifact, which the agent node publishes BEFORE the optional cross-review
+// runs and before the chat node pauses — on run 01a04999 the action card was
+// clickable for the 23 s the reviewer was still writing. The dock must show
+// them only once the turn is parked on its chat pause.
+describe("ChatDock offers wait for the chat pause", () => {
+  // ChatTranscript scrolls its tail into view on mount; jsdom has no layout
+  // and no scrollIntoView, and the throw would trip the assistant's
+  // ErrorBoundary into "the app without a dock" — an empty render that would
+  // make the two "nothing offered" cases below pass vacuously.
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  const question = {
+    kind: "human-question" as const,
+    id: "chat:1:question",
+    nodeId: "chat",
+    prompt: "Je propose le reset de la tâche.",
+  };
+
+  it("offers nothing while the turn is still running (the reviewer's window)", () => {
+    session = makeSession({
+      status: "active",
+      runId: "run-1",
+      runStatus: "running",
+      messages: [{ ...question, status: "answered", userReply: "ok go" }],
+    });
+    renderDock();
+    // The transcript itself is on screen — the offer is gated, not the dock.
+    expect(screen.getByText(/Je propose le reset/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Confirm action" })).toBeNull();
+  });
+
+  it("offers the action once the turn is parked on its chat pause", () => {
+    session = makeSession({
+      status: "active",
+      runId: "run-1",
+      runStatus: "paused_waiting_human",
+      messages: [{ ...question, status: "pending" }],
+    });
+    renderDock();
+    expect(screen.getByRole("button", { name: "Confirm action" })).toBeTruthy();
+  });
+
+  it("offers nothing on a mid-turn ask_user pause (the artifact is last turn's)", () => {
+    session = makeSession({
+      status: "active",
+      runId: "run-1",
+      runStatus: "paused_waiting_human",
+      messages: [
+        {
+          ...question,
+          id: "ask-1",
+          nodeId: "copi",
+          status: "pending",
+          questions: { ask_user_response: "Which task?" },
+        },
+      ],
+    });
+    renderDock();
+    // The transcript itself is on screen — the offer is gated, not the dock.
+    expect(screen.getByText(/Je propose le reset/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Confirm action" })).toBeNull();
   });
 });

--- a/studio/src/components/ChatDock/ChatDock.tsx
+++ b/studio/src/components/ChatDock/ChatDock.tsx
@@ -254,10 +254,12 @@ function AssistantDock({
 
   // Tell an open editor tab when there is something new to read.
   //
-  // The draft is a node OUTPUT — written at `artifact_written`, when the turn
-  // ends — so this is the earliest instant anything could have changed, and
-  // the tab needs no clock of its own. The conversation drives the canvas
-  // instead of the canvas guessing.
+  // The draft is a node OUTPUT — written at `artifact_written` when the
+  // agent node finishes, which is BEFORE the optional cross-review and the
+  // chat pause — so this is the earliest instant anything could have
+  // changed, and the tab needs no clock of its own. The conversation drives
+  // the canvas instead of the canvas guessing. A refresh of an already-open
+  // tab is a read; the offers below, which can WRITE, wait for the pause.
   const queryClient = useQueryClient();
   const turnCount = session.messages.length;
   useEffect(() => {
@@ -279,6 +281,22 @@ function AssistantDock({
   }, []);
 
   const unread = useUnreadWhileClosed(dock, session.messages.length);
+  // An offer belongs to a reply. The offers are built from the latest run
+  // artifact carrying their field, and the agent node publishes that
+  // artifact BEFORE the optional cross-review runs and before the chat node
+  // pauses — on run 01a04999 the artifact landed at 18:20:03, the reviewer
+  // wrote until 18:20:26, and the action card was clickable (or, under an
+  // `auto` policy, self-executing) the whole time, i.e. before the critique
+  // the reviewer exists to put in front of the operator. So the offers
+  // render only once the turn is parked on its chat pause. Not on an
+  // `ask_user` pause mid-turn: the artifact of that moment is the previous
+  // turn's, and its offers would be stale. This assumes a chat bot parks its
+  // turn on a `human` node (Copi's and Nexie's `chat`), never on `ask_user`.
+  // Corollary, deliberate: a turn that never reaches its pause (the run
+  // failed or was cancelled between the agent node and `chat`) offers
+  // nothing — an action nobody reviewed must not be executable.
+  const turnParked =
+    !!composer.pendingHumanQuestion && !composer.pendingIsAskUser;
   const needsAttention =
     !!composer.pendingHumanQuestion ||
     session.runStatus === "paused_waiting_human" ||
@@ -367,22 +385,24 @@ function AssistantDock({
             // contract as the /whats-next route.
             composerHandlesId={composer.pendingHumanQuestion?.id}
             bubbleSlot={
-              <>
-                <DraftBotOffer
-                  runId={session.runId}
-                  revision={session.messages.length}
-                />
-                {bot.editor?.proposals === true && (
-                  <EditorChangeOffer
+              turnParked ? (
+                <>
+                  <DraftBotOffer
                     runId={session.runId}
                     revision={session.messages.length}
                   />
-                )}
-                <AssistantActionOffer
-                  runId={session.runId}
-                  revision={session.messages.length}
-                />
-              </>
+                  {bot.editor?.proposals === true && (
+                    <EditorChangeOffer
+                      runId={session.runId}
+                      revision={session.messages.length}
+                    />
+                  )}
+                  <AssistantActionOffer
+                    runId={session.runId}
+                    revision={session.messages.length}
+                  />
+                </>
+              ) : null
             }
             onHumanSubmit={(messageId, outcome) => {
               const m = session.messages.find((x) => x.id === messageId);

--- a/studio/src/components/WhatsNext/WhatsNextView.tsx
+++ b/studio/src/components/WhatsNext/WhatsNextView.tsx
@@ -116,11 +116,17 @@ function WhatsNextConversation({
                 // onHumanSubmit fallback only fires for a pending card
                 // the composer somehow doesn't own (defensive).
                 composerHandlesId={pendingHumanQuestion?.id}
+                // Same rule as the dock (see ChatDock's `turnParked`): an
+                // offer belongs to a reply, so it renders only once the turn
+                // is parked on its chat pause — never during the agent's
+                // turn, whose artifact already carries next turn's requests.
                 bubbleSlot={
-                  <AssistantActionOffer
-                    runId={session.runId}
-                    revision={session.messages.length}
-                  />
+                  pendingHumanQuestion && !pendingIsAskUser ? (
+                    <AssistantActionOffer
+                      runId={session.runId}
+                      revision={session.messages.length}
+                    />
+                  ) : null
                 }
                 onHumanSubmit={(messageId, outcome) => {
                   const m = session.messages.find((x) => x.id === messageId);


### PR DESCRIPTION
## Why

Operator report, confirmed on run `01a04999` (turn 1): the `copi` artifact was written at 18:20:03, the `review` judge ran until 18:20:26, the `chat` pause came at 18:20:27. For those 23 s the dock already showed Copi's action offer — clickable, or self-executing under an *Always allow* policy — before the critique the cross-review exists to put in front of the operator.

Mechanism: the offers (`DraftBotOffer`, `EditorChangeOffer`, `AssistantActionOffer`) are built from the **latest run artifact** carrying their field (`lookupAssistantActions` & co.), refetched on every `session.messages.length` change — which the "Cross-reviewing Copi's answer" banner increments. Nothing tied them to the pause (`useAssistantActions` only had `enabled: !!runId`), and `ChatTranscript` hosts the `bubbleSlot` on the last human-question row "answered or not", so during turn N+1 the slot sat on turn N's answered question showing turn N+1's fresh artifact.

## What

**Rule: an offer belongs to a reply.** `ChatDock` and `WhatsNextView` render the offers only while the turn is parked on its chat pause — `pendingHumanQuestion && !pendingIsAskUser`. Not during the agent's turn, not during the review, not on a mid-turn `ask_user` pause (that artifact is the previous turn's). `revision` stays `messages.length`; with the gate the query simply does not fire until the pause.

**Observable behaviour change, deliberate:** a turn that never reaches its pause (run failed or cancelled between the agent node and `chat`) offers nothing — an action nobody reviewed must not be executable. Stated in `docs/assistant-dock.md` and ADR-091 §E.

Assumption written in the code: a chat bot parks its turn on a `human` node (Copi's and Nexie's `chat`), never on `ask_user`.

- `ChatDock.tsx`: `turnParked` gate on the three offers; the stale "written when the turn ends" comment on the editor-tab invalidation corrected (the artifact lands when the agent node finishes; that refresh is a read and stays).
- `WhatsNextView.tsx`: same gate on its `AssistantActionOffer`.
- `ChatDock.test.tsx`: three cases — running (the reviewer's window) → no card while the transcript IS on screen; parked → card; `ask_user` pause → no card. (`scrollIntoView` stubbed: jsdom lacks it and the throw tripped the assistant's ErrorBoundary into an empty render.)

## Verified

Unit: `vitest run src/components/ChatDock src/components/WhatsNext` — 104 passed; `tsc -b` clean; eslint 0 errors on the touched files.

Live, on a patched static build serving a probe studio (`--bots-path` → this branch's Copi 0.1.2, cross-review on, leading-question scenario, run `01a04a27`):

| turn | artifact | review | pause | on screen during review | at the pause |
|---|---|---|---|---|---|
| 1 | 20:55:13 | → 20:55:28 | 20:55:28 | "Cross-reviewing…" banner, **no card** | reply + « Revue croisée » |
| 2 (« ok go ») | 20:56:14 | → 20:56:19 | 20:56:19 | — | `pipeline.task.reset` (DESTRUCTIVE) + `pipeline.task.launch` cards, **unexecuted**, under the reply |

## Follow-ups (not here)

- `EditorChangeOffer` keeps its auto-apply guard in a ref; hoisting it to `sessionStorage` (as `AssistantActionOffer` does) would make the doc's "a key … prevents a remount from repeating a write" true for it too.
- #563 adds `AssistantFileChangeOffer` in the same `bubbleSlot` block → expected conflict; resolution = the fourth offer inside the same gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwtNA2bEoncV1AcfmapqrH
