### PR TITLE
fix(models): discard runRefresh's return at the goroutine launch (errcheck)

### DIFF
--- a/pkg/backend/model/modelspecs.go
+++ b/pkg/backend/model/modelspecs.go
@@ -232,7 +232,10 @@ func (r *specRegistry) ensureFresh() {
 	r.mu.Unlock()
 
 	if trigger {
-		go r.runRefresh(context.Background())
+		// The outcome lands in r.refreshErr (runRefresh's deferred publish)
+		// and is read by whoever joins on refreshDone; the return value is
+		// only for that defer, so the goroutine launch discards it.
+		go func() { _ = r.runRefresh(context.Background()) }()
 	}
 }
 
@@ -270,7 +273,10 @@ func (r *specRegistry) refresh(ctx context.Context) error {
 	r.mu.Unlock()
 
 	if start {
-		go r.runRefresh(context.Background())
+		// The outcome lands in r.refreshErr (runRefresh's deferred publish)
+		// and is read by whoever joins on refreshDone; the return value is
+		// only for that defer, so the goroutine launch discards it.
+		go func() { _ = r.runRefresh(context.Background()) }()
 	}
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
## Why

`golangci` has been red on `feat/assistant-epic` since `a431e9b8` (coalesce forced catalog refreshes): the last green run on the epic is `60527187`, and both #565 and #566 inherit the failure —

```
pkg/backend/model/modelspecs.go:235:18: Error return value of `r.runRefresh` is not checked (errcheck)
pkg/backend/model/modelspecs.go:273:18: Error return value of `r.runRefresh` is not checked (errcheck)
```

`main` never had this code (the singleflight refresh only exists on the epic), so nothing to sync from there.

## What

Both `go r.runRefresh(context.Background())` launches become `go func() { _ = r.runRefresh(context.Background()) }()`, with a comment on why the value is discarded: `runRefresh`'s named return exists for its deferred block, which publishes the outcome to `r.refreshErr` and closes `refreshDone`; the joiners read it from there. No behaviour change.

## Verified

- `go vet ./pkg/backend/model/` + `go test ./pkg/backend/model/` — ok
- `golangci-lint run ./pkg/backend/model/...` (v2.12.2, the CI pin, under `GOTOOLCHAIN=go1.26.0`) — 0 issues

Associated PR: unblocks the `golangci` check on #566 (`fix/copi-offers-after-pause`), which touches only TSX and cannot fix it on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUGCrmAn8EsWmF6LvptFWK
