### PR TITLE
feat(platformcfg): bot vars — ${ITERION_X} resolved from the DB before the pod env

### DIFF
--- a/cmd/iterion/remote_admin.go
+++ b/cmd/iterion/remote_admin.go
@@ -392,6 +392,49 @@ var (
 	remoteRoleClears = map[string]*bool{}
 )
 
+var remoteAdminVarsCmd = &cobra.Command{
+	Use:   "vars [set NAME VALUE | rm NAME]",
+	Short: "Bot-var overrides: resolve ${ITERION_X:-default} from the DB before the pod env — re-tune a bot without a rollout",
+	Long: `Platform bot vars — DB-backed overrides for the ` + "`${ITERION_X:-default}`" + ` .bot
+expansions (model pins, reasoning effort, tunables). Precedence:
+setting > pod env var > the .bot's own default.
+
+  iterion remote admin vars                                  # stored + origin
+  iterion remote admin vars set ITERION_VIBE_EFFORT_CLAUDE max
+  iterion remote admin vars rm  ITERION_VIBE_EFFORT_CLAUDE   # back to env/default
+
+Infra namespaces (Mongo/NATS/JWT/secrets/…) and credential-shaped names
+are refused at write time. Changes reach every replica within the
+resolver TTL (no restart); runs claimed after that expand the new value.`,
+	Args: cobra.MaximumNArgs(3),
+	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
+		const path = "/api/admin/settings/bot-vars"
+		if len(args) == 0 {
+			return cli.RemoteGetPrint(cmd.Context(), c, p, path)
+		}
+		patch := map[string]*string{}
+		switch args[0] {
+		case "set":
+			if len(args) != 3 {
+				return fmt.Errorf("usage: admin vars set NAME VALUE")
+			}
+			patch[args[1]] = &args[2]
+		case "rm":
+			if len(args) != 2 {
+				return fmt.Errorf("usage: admin vars rm NAME")
+			}
+			patch[args[1]] = nil
+		default:
+			return fmt.Errorf("unknown vars action %q (want set|rm)", args[0])
+		}
+		body, err := json.Marshal(patch)
+		if err != nil {
+			return err
+		}
+		return cli.RemoteSendPrint(cmd.Context(), c, p, "PUT", path, body)
+	}),
+}
+
 var remoteAdminRolesCmd = &cobra.Command{
 	Use:   "roles [set]",
 	Short: "Webhook role→bot bindings: show the effective set (default) or re-point a role without a rollout",
@@ -610,7 +653,7 @@ func init() {
 	remoteAdminSandboxCmd.Flags().StringVar(&remoteSandboxImage, "default-image", "", "`sandbox: auto` fallback image ref (prefer an @sha256 digest)")
 	remoteAdminSandboxCmd.Flags().BoolVar(&remoteSandboxClearImage, "clear-default-image", false, "Clear the override (fall back to the env default / built-in)")
 
-	remoteAdminCmd.AddCommand(remoteAdminOrgsCmd, remoteAdminUsersCmd, remoteAdminDLQCmd, remoteAdminLLMCmd, remoteAdminCapsCmd, remoteAdminBotsCmd, remoteAdminRolesCmd, remoteAdminSandboxCmd)
+	remoteAdminCmd.AddCommand(remoteAdminOrgsCmd, remoteAdminUsersCmd, remoteAdminDLQCmd, remoteAdminLLMCmd, remoteAdminCapsCmd, remoteAdminBotsCmd, remoteAdminRolesCmd, remoteAdminSandboxCmd, remoteAdminVarsCmd)
 
 	remoteSSOProvidersCmd.Flags().StringVar(&remoteSSOData, "data", "", "Request body JSON (literal or @file)")
 	remoteSSODomainsCmd.Flags().StringVar(&remoteSSOData, "data", "", "Request body JSON (literal or @file)")

--- a/cmd/iterion/remote_admin.go
+++ b/cmd/iterion/remote_admin.go
@@ -405,7 +405,13 @@ setting > pod env var > the .bot's own default.
 
 Infra namespaces (Mongo/NATS/JWT/secrets/…) and credential-shaped names
 are refused at write time. Changes reach every replica within the
-resolver TTL (no restart); runs claimed after that expand the new value.`,
+resolver TTL (no restart); runs claimed after that expand the new value.
+
+Two honesty notes. Values are stored, echoed and audit-logged IN CLEAR —
+never put a secret in a bot var, even under an innocent name. And a var
+only takes effect where the engine resolves it through the expansion
+chain (every ` + "`${ITERION_X:-default}`" + ` in a .bot, plus the routed model
+pins); a name nothing reads is accepted but changes nothing.`,
 	Args: cobra.MaximumNArgs(3),
 	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
 		const path = "/api/admin/settings/bot-vars"

--- a/cmd/iterion/runner.go
+++ b/cmd/iterion/runner.go
@@ -16,9 +16,11 @@ import (
 	"github.com/SocialGouv/iterion/pkg/cloud/tracing"
 	iterconfig "github.com/SocialGouv/iterion/pkg/config"
 	"github.com/SocialGouv/iterion/pkg/credpool"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/errtrack"
 	"github.com/SocialGouv/iterion/pkg/eventbus"
 	"github.com/SocialGouv/iterion/pkg/orgusage"
+	"github.com/SocialGouv/iterion/pkg/platformcfg"
 	natsq "github.com/SocialGouv/iterion/pkg/queue/nats"
 	"github.com/SocialGouv/iterion/pkg/runner"
 	"github.com/SocialGouv/iterion/pkg/secrets"
@@ -226,6 +228,21 @@ func runRunner(cmd *cobra.Command, _ []string) error {
 	usageCapSource := usagecap.NewResolver(
 		usagecap.NewMongoSettingsStore(st.DB()), usageCapEnvPolicy,
 		usagecap.WithWarnLogger(logger.Warn))
+	// Bot-var settings (platformcfg FamilyBotVars) reach every
+	// ${ITERION_X:-default} expansion the runner performs — model pins,
+	// reasoning effort, tunables — through the ir overlay. Installed once
+	// at boot; each claimed run sees the values within the resolver TTL,
+	// no restart. Precedence: setting > pod env > .bot default.
+	botVarsResolver := platformcfg.NewResolver[platformcfg.BotVars](
+		platformcfg.NewMongoBotVars(st.DB()), logger.Warn)
+	ir.SetEnvOverlay(func(name string) (string, bool) {
+		rec := botVarsResolver.Get(context.Background())
+		if rec == nil {
+			return "", false
+		}
+		v, ok := rec.Vars[name]
+		return v, ok
+	})
 	// The schema is ensured unconditionally: a cap disabled in env can be
 	// armed at runtime through the settings record, and the readings
 	// ledger must exist by then.

--- a/cmd/iterion/server.go
+++ b/cmd/iterion/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/credpool"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/boardmongo"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/errtrack"
 	"github.com/SocialGouv/iterion/pkg/eventbus"
 	"github.com/SocialGouv/iterion/pkg/forge"
@@ -326,6 +327,19 @@ func runServer(cmd *cobra.Command, _ []string) error {
 	})
 
 	sandboxResolver := platformcfg.NewResolver[platformcfg.Sandbox](stores.sandboxCfg, logger.Warn)
+	// Bot-var settings reach ${ITERION_X:-default} expansion through the
+	// ir overlay — installed once at boot, shared with the admin PUT's
+	// Invalidate so this replica's own compile-time previews see a
+	// mutation immediately. Precedence: setting > pod env > .bot default.
+	botVarsResolver := platformcfg.NewResolver[platformcfg.BotVars](stores.botVars, logger.Warn)
+	ir.SetEnvOverlay(func(name string) (string, bool) {
+		rec := botVarsResolver.Get(context.Background())
+		if rec == nil {
+			return "", false
+		}
+		v, ok := rec.Vars[name]
+		return v, ok
+	})
 	pub, err := cloudpublisher.New(cloudpublisher.Config{
 		NATS:             natsConn,
 		Store:            st,
@@ -513,6 +527,8 @@ func runServer(cmd *cobra.Command, _ []string) error {
 		PluginSources:          stores.pluginSources,
 		BotSources:             stores.botSources,
 		BotRolesSettings:       stores.botRoles,
+		BotVarsSettings:        stores.botVars,
+		BotVarsResolver:        botVarsResolver,
 		SandboxSettings:        stores.sandboxCfg,
 		SandboxResolver:        sandboxResolver,
 		WebhookConfigs:         stores.webhooks.Configs,
@@ -617,6 +633,7 @@ type cloudStores struct {
 	usageCapSettings *usagecap.MongoSettingsStore
 	botRoles         *platformcfg.MongoStore[platformcfg.BotRoles]
 	sandboxCfg       *platformcfg.MongoStore[platformcfg.Sandbox]
+	botVars          *platformcfg.MongoStore[platformcfg.BotVars]
 	marketplace      marketplace.Store
 	pat              *pat.MongoStore
 	memory           *mongostore.MongoMemoryStore
@@ -646,6 +663,7 @@ func buildCloudStores(ctx context.Context, st *mongostore.Store, logger *iterlog
 		botSources:       botsource.NewMongoStore(st.DB()),
 		botRoles:         platformcfg.NewMongoBotRoles(st.DB()),
 		sandboxCfg:       platformcfg.NewMongoSandbox(st.DB()),
+		botVars:          platformcfg.NewMongoBotVars(st.DB()),
 		orgSSO:           orgsso.NewMongoStore(st.DB()),
 		orgDomain:        orgsso.NewMongoDomainStore(st.DB()),
 		// Mongo-backed OIDC state store: PendingAuth must survive across replicas

--- a/docs/adr/093-bot-vars-runtime-settings.md
+++ b/docs/adr/093-bot-vars-runtime-settings.md
@@ -1,0 +1,55 @@
+# ADR-093 — Bot-var overrides: `${ITERION_X:-default}` resolved from the DB before the pod env
+
+- **Status**: Accepted
+- **Date**: 2026-08-29
+- **Extends**: ADR-090 (runtime operational settings), the `platformcfg` families (bot_roles, sandbox)
+- **Family**: `bot_vars` (`pkg/platformcfg`)
+
+## Context
+
+Bots parameterize their model pins, reasoning effort and tunables as
+`${ITERION_X:-default}` expansions (`ITERION_VIBE_MODEL_CLAUDE`,
+`ITERION_MODERNIZE_EFFORT`, …). Those expansions read the runner pod's
+env, so re-tuning a bot in production meant a Helm values change and a
+rollout — while credentials, bot bundles, usage caps, role bindings and
+the sandbox image had all already moved to the CLI→API→DB surface. The
+operator asked for the same for bot vars, live within the settings TTL.
+
+## Decision
+
+A fourth `platformcfg` family, `bot_vars`: one document holding a
+validated `map[ITERION_*]value`. It reaches the expansions through ONE
+choke point — `ir.ExpandEnvWithDefault` consults an overlay
+(`ir.SetEnvOverlay`, installed once at process boot by the server and
+runner cmds, backed by a TTL resolver) before `os.Getenv`. Precedence:
+**setting > pod env > the .bot's `:-` default**. An empty overlay value
+counts as unset (clearing is removing the key, never pinning "").
+
+The record stays typed and validated in `platformcfg` (the ADR-090
+rejection of a generic KV table): only the value SPACE is a map, because
+the keys are declared by bots, not the engine. `Validate` refuses names
+outside `ITERION_[A-Z0-9_]+`, credential-shaped names
+(KEY/TOKEN/SECRET/PASSWORD/PRIVATE/CREDENTIAL — a var that suggests a
+secret must never transit a non-secret surface), the infra namespaces
+(Mongo/NATS/JWT/secrets/S3/blob/Valkey/OIDC/OAuth/public-URL/bootstrap),
+and the families that already have their own audited surface (usage cap,
+sandbox default image). Values are single-line, non-blank, bounded.
+
+Writes are super-admin only (`PUT /api/admin/settings/bot-vars`, merge
+per key: string = set, `null` = clear, absent = untouched), audited with
+old→new per touched key (values are non-secret by construction), and
+invalidate the mutating replica's resolver; every other replica
+converges within `platformcfg.DefaultTTL`. Runs claimed after that
+expand the new value — no restart anywhere.
+
+## Consequences
+
+- `iterion remote admin vars [set NAME VALUE | rm NAME]` is the operator
+  surface; the GET echoes stored+origin+propagation bound.
+- Local CLI runs keep byte-identical env-only behaviour (nil overlay).
+- Vars read by shell scripts INSIDE a sandbox container (container env)
+  are out of scope: the DSL-expanded fields (model, effort, timeouts,
+  tool commands) are all runner-side and covered.
+- A redelivered message re-expands with the CURRENT settings (same
+  posture as the usage caps; unlike the sandbox image, nothing is pinned
+  on the RunMessage — "effective from the next run" is the contract).

--- a/docs/adr/093-bot-vars-runtime-settings.md
+++ b/docs/adr/093-bot-vars-runtime-settings.md
@@ -42,14 +42,33 @@ invalidate the mutating replica's resolver; every other replica
 converges within `platformcfg.DefaultTTL`. Runs claimed after that
 expand the new value — no restart anywhere.
 
+Beyond the `${…}` expansions, the direct `os.Getenv("ITERION_*")`
+model-pin sites (supervisor, verified-action, classifier, conflict
+resolver, session board) are routed through the exported `ir.LookupEnv`
+so the same setting reaches them; `mcp_server` command/args/url moved
+from `os.ExpandEnv` to `ExpandEnvWithDefault`, which also gives those
+fields the documented `:-` form. Other `os.Getenv` reads (boot config,
+infra) stay env-only by design — the blocklist keeps their names
+unwritable so routing more sites later can never turn a stored var into
+an infra override; the list is namespace hygiene and depth, not the
+containment boundary (that is the overlay's ITERION_-gated reach).
+
 ## Consequences
 
 - `iterion remote admin vars [set NAME VALUE | rm NAME]` is the operator
   surface; the GET echoes stored+origin+propagation bound.
+- Values are stored, echoed and audit-logged in clear: the name gate
+  refuses credential-shaped NAMES, nothing can vouch for values — the
+  CLI help says never to store a secret in a bot var.
+- A var only takes effect where the engine resolves it through the
+  expansion chain; a name nothing reads is accepted but inert.
 - Local CLI runs keep byte-identical env-only behaviour (nil overlay).
 - Vars read by shell scripts INSIDE a sandbox container (container env)
-  are out of scope: the DSL-expanded fields (model, effort, timeouts,
-  tool commands) are all runner-side and covered.
-- A redelivered message re-expands with the CURRENT settings (same
-  posture as the usage caps; unlike the sandbox image, nothing is pinned
-  on the RunMessage — "effective from the next run" is the contract).
+  are out of scope.
+- Propagation is per NODE boundary, not per run: expansions happen as
+  each node builds, so a run longer than the TTL can straddle a change
+  (node 1 old value, node 30 new). Same posture as a cap tightened
+  mid-run. A redelivered message re-expands with the CURRENT settings —
+  nothing is pinned on the RunMessage.
+- Concurrent PUTs are safe: the write is a CAS on `updated_at`; a lost
+  race is a loud 409, never a silently dropped key.

--- a/docs/platform-bots.md
+++ b/docs/platform-bots.md
@@ -126,9 +126,9 @@ consumable by upgraded runners. The reverse direction keeps the standard
 policy: a pre-bump runner rejects v9, so roll server and runner from the
 same release (or runner first) as usual.
 
-## Platform settings: bot roles + sandbox image
+## Platform settings: bot roles + sandbox image + bot vars
 
-Two more runtime-settings families (ADR-090 doctrine: env/const = default,
+Three more runtime-settings families (ADR-090 doctrine: env/const = default,
 DB record = override, ≤30 s propagation, super-admin surface), stored in
 the same `platform_settings` collection as the usage caps:
 
@@ -142,6 +142,11 @@ iterion remote admin roles set --clear-reviewer   # back to the built-in default
 iterion remote admin sandbox
 iterion remote admin sandbox set --default-image ghcr.io/…/iterion-sandbox-slim@sha256:…
 iterion remote admin sandbox set --clear-default-image
+
+# Bot-var overrides — ${ITERION_X:-default} resolved from the DB before the pod env
+iterion remote admin vars                        # stored + origin
+iterion remote admin vars set ITERION_VIBE_EFFORT_CLAUDE max
+iterion remote admin vars rm  ITERION_VIBE_EFFORT_CLAUDE  # back to env/default
 ```
 
 Role overrides apply at every webhook lane that used to read the

--- a/openapi.json
+++ b/openapi.json
@@ -3507,6 +3507,32 @@
         ]
       }
     },
+    "/api/admin/settings/bot-vars": {
+      "get": {
+        "operationId": "getAdminSettingsBotVars",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "GET /api/admin/settings/bot-vars",
+        "tags": [
+          "admin"
+        ]
+      },
+      "put": {
+        "operationId": "putAdminSettingsBotVars",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "PUT /api/admin/settings/bot-vars",
+        "tags": [
+          "admin"
+        ]
+      }
+    },
     "/api/admin/settings/sandbox": {
       "get": {
         "operationId": "getAdminSettingsSandbox",

--- a/pkg/backend/model/executor_router.go
+++ b/pkg/backend/model/executor_router.go
@@ -187,7 +187,7 @@ func (e *ClawExecutor) executeLLMRouterUnified(ctx context.Context, node *ir.Rou
 	// stdlib's silent collapse to "".
 	expanded := ir.ExpandEnvWithDefault(node.Model)
 	if expanded == "" {
-		expanded = os.Getenv("ITERION_DEFAULT_SUPERVISOR_MODEL")
+		expanded = ir.LookupEnv("ITERION_DEFAULT_SUPERVISOR_MODEL")
 	}
 	if expanded == "" {
 		expanded = defaultRouterModel

--- a/pkg/backend/model/executor_verified_action.go
+++ b/pkg/backend/model/executor_verified_action.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 
@@ -302,7 +301,7 @@ func (e *ClawExecutor) recoveryModel(node *ir.ToolNode) string {
 			return m
 		}
 	}
-	if m := os.Getenv("ITERION_VERIFIED_ACTION_MODEL"); m != "" {
+	if m := ir.LookupEnv("ITERION_VERIFIED_ACTION_MODEL"); m != "" {
 		return m
 	}
 	return defaultVerifiedActionModel

--- a/pkg/dsl/ir/env_overlay_test.go
+++ b/pkg/dsl/ir/env_overlay_test.go
@@ -1,0 +1,48 @@
+package ir
+
+import (
+	"os"
+	"testing"
+)
+
+// The overlay is consulted before the process env on every expansion
+// form, and its absence keeps the historical env-only behaviour —
+// falsified both ways so the settings surface cannot silently detach
+// from the ~30 call sites that rely on this one choke point.
+func TestExpandEnvWithDefault_OverlayPrecedence(t *testing.T) {
+	t.Setenv("ITERION_OVERLAY_T1", "from-env")
+	defer SetEnvOverlay(nil)
+
+	SetEnvOverlay(func(name string) (string, bool) {
+		if name == "ITERION_OVERLAY_T1" {
+			return "from-setting", true
+		}
+		return "", false
+	})
+	for form, want := range map[string]string{
+		"${ITERION_OVERLAY_T1}":                             "from-setting",
+		"${ITERION_OVERLAY_T1:-fallback}":                   "from-setting",
+		"$ITERION_OVERLAY_T1":                               "from-setting",
+		"${ITERION_OVERLAY_MISS:-fallback}":                 "fallback",
+		"${ITERION_OVERLAY_NEST:-${ITERION_OVERLAY_T1:-x}}": "from-setting",
+	} {
+		if got := ExpandEnvWithDefault(form); got != want {
+			t.Errorf("%s = %q, want %q (setting must beat env)", form, got, want)
+		}
+	}
+
+	// An overlay hit with an empty value counts as unset: env then wins.
+	SetEnvOverlay(func(string) (string, bool) { return "", true })
+	if got := ExpandEnvWithDefault("${ITERION_OVERLAY_T1:-fb}"); got != "from-env" {
+		t.Errorf("empty overlay value = %q, want the env value (a setting cannot pin empty)", got)
+	}
+
+	SetEnvOverlay(nil)
+	if got := ExpandEnvWithDefault("${ITERION_OVERLAY_T1:-fb}"); got != "from-env" {
+		t.Errorf("nil overlay = %q, want byte-identical env-only behaviour", got)
+	}
+	os.Unsetenv("ITERION_OVERLAY_T1")
+	if got := ExpandEnvWithDefault("${ITERION_OVERLAY_T1:-fb}"); got != "fb" {
+		t.Errorf("unset everywhere = %q, want the .bot default", got)
+	}
+}

--- a/pkg/dsl/ir/validate_nodes.go
+++ b/pkg/dsl/ir/validate_nodes.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/backend/automemory"
@@ -960,31 +961,51 @@ func modelEnvRefNames(s string) []string {
 }
 
 // envOverlay, when set, is consulted BEFORE the process env by every
-// lookup in ExpandEnvWithDefault. It is how DB-backed bot-var settings
-// (platformcfg FamilyBotVars) reach the ~30 expansion sites through one
-// choke point: cmd wiring installs a TTL-cached resolver here at boot,
-// once, before any workflow runs — never mutated afterwards, so reads
-// need no lock. Nil (the default, and every local CLI run) keeps the
+// lookup in ExpandEnvWithDefault (and by LookupEnv's direct callers).
+// It is how DB-backed bot-var settings (platformcfg FamilyBotVars)
+// reach every expansion site through one choke point: cmd wiring
+// installs a TTL-cached resolver here at boot. Held behind an atomic
+// so a mid-process SetEnvOverlay (tests do it; a future caller might)
+// can never race a concurrent expansion — the read path pays one
+// atomic load. Nil (the default, and every local CLI run) keeps the
 // historical env-only behaviour byte-identical.
-var envOverlay func(name string) (string, bool)
+var envOverlay atomic.Pointer[func(name string) (string, bool)]
 
 // SetEnvOverlay installs the settings lookup consulted before os.Getenv.
-// Call it once at process boot; the precedence it creates is
-// setting > pod env > `:-` default.
-func SetEnvOverlay(fn func(name string) (string, bool)) { envOverlay = fn }
+// The precedence it creates is setting > pod env > `:-` default.
+// Nil restores env-only behaviour.
+func SetEnvOverlay(fn func(name string) (string, bool)) {
+	if fn == nil {
+		envOverlay.Store(nil)
+		return
+	}
+	envOverlay.Store(&fn)
+}
 
-// lookupEnv resolves one variable name through the overlay-then-env
-// chain. An overlay hit with an empty value counts as unset (same rule
-// the `:-` form applies to env values), so a setting cannot pin
-// "empty" — clearing is expressed by removing the key.
-func lookupEnv(name string) string {
-	if envOverlay != nil {
-		if v, ok := envOverlay(name); ok && v != "" {
-			return v
+// LookupEnv resolves one variable name through the overlay-then-env
+// chain — the same resolution ExpandEnvWithDefault applies inside
+// `${...}` forms, exported for the direct os.Getenv("ITERION_*") sites
+// (model pins, delegate tunables) so a bot-var setting reaches them
+// too, not only the DSL expansions. An overlay hit with an empty value
+// counts as unset (same rule the `:-` form applies to env values), so
+// a setting cannot pin "empty" — clearing is expressed by removing the
+// key. The overlay is consulted ONLY for ITERION_-namespaced names:
+// the write surface validates that namespace, and gating the read side
+// too means a corrupted or hand-edited settings document can never
+// inject $HOME, $PATH or a provider credential into an expansion.
+func LookupEnv(name string) string {
+	if strings.HasPrefix(name, "ITERION_") {
+		if fn := envOverlay.Load(); fn != nil {
+			if v, ok := (*fn)(name); ok && v != "" {
+				return v
+			}
 		}
 	}
 	return os.Getenv(name)
 }
+
+// lookupEnv keeps the package-internal call sites on the short name.
+func lookupEnv(name string) string { return LookupEnv(name) }
 
 // ExpandEnvWithDefault expands ${VAR} and ${VAR:-default} forms in s.
 // Mirrors the shell parameter-expansion default-value syntax that

--- a/pkg/dsl/ir/validate_nodes.go
+++ b/pkg/dsl/ir/validate_nodes.go
@@ -959,6 +959,33 @@ func modelEnvRefNames(s string) []string {
 	return names
 }
 
+// envOverlay, when set, is consulted BEFORE the process env by every
+// lookup in ExpandEnvWithDefault. It is how DB-backed bot-var settings
+// (platformcfg FamilyBotVars) reach the ~30 expansion sites through one
+// choke point: cmd wiring installs a TTL-cached resolver here at boot,
+// once, before any workflow runs — never mutated afterwards, so reads
+// need no lock. Nil (the default, and every local CLI run) keeps the
+// historical env-only behaviour byte-identical.
+var envOverlay func(name string) (string, bool)
+
+// SetEnvOverlay installs the settings lookup consulted before os.Getenv.
+// Call it once at process boot; the precedence it creates is
+// setting > pod env > `:-` default.
+func SetEnvOverlay(fn func(name string) (string, bool)) { envOverlay = fn }
+
+// lookupEnv resolves one variable name through the overlay-then-env
+// chain. An overlay hit with an empty value counts as unset (same rule
+// the `:-` form applies to env values), so a setting cannot pin
+// "empty" — clearing is expressed by removing the key.
+func lookupEnv(name string) string {
+	if envOverlay != nil {
+		if v, ok := envOverlay(name); ok && v != "" {
+			return v
+		}
+	}
+	return os.Getenv(name)
+}
+
 // ExpandEnvWithDefault expands ${VAR} and ${VAR:-default} forms in s.
 // Mirrors the shell parameter-expansion default-value syntax that
 // stdlib os.ExpandEnv does not support: when ${VAR} is unset or empty,
@@ -984,7 +1011,7 @@ func ExpandEnvWithDefault(s string) string {
 				end++
 			}
 			if end > i+1 {
-				b.WriteString(os.Getenv(s[i+1 : end]))
+				b.WriteString(lookupEnv(s[i+1 : end]))
 				i = end
 				continue
 			}
@@ -1016,13 +1043,13 @@ func ExpandEnvWithDefault(s string) string {
 				expanded := ExpandEnvWithDefault(inner)
 				if idx := strings.Index(expanded, ":-"); idx >= 0 {
 					name, fallback := expanded[:idx], expanded[idx+2:]
-					if v := os.Getenv(name); v != "" {
+					if v := lookupEnv(name); v != "" {
 						b.WriteString(v)
 					} else {
 						b.WriteString(fallback)
 					}
 				} else {
-					b.WriteString(os.Getenv(expanded))
+					b.WriteString(lookupEnv(expanded))
 				}
 				i = j + 1
 				continue

--- a/pkg/platformcfg/botvars_liveness_test.go
+++ b/pkg/platformcfg/botvars_liveness_test.go
@@ -1,0 +1,58 @@
+package platformcfg
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+)
+
+// The operator's whole promise in one test: a bot-var written to the
+// settings store changes what ${ITERION_X:-default} expands to IN THE
+// SAME PROCESS, within the resolver TTL, with no restart — and clearing
+// it falls back to the default. This is the runtime-settings signature
+// scenario (the usage-cap family pins the same shape).
+func TestBotVars_SettingsChangeIsLiveThroughExpansion(t *testing.T) {
+	st := NewMemoryStore[BotVars]()
+	clock := time.Now()
+	r := NewResolver[BotVars](st, nil)
+	r.now = func() time.Time { return clock }
+
+	ir.SetEnvOverlay(func(name string) (string, bool) {
+		rec := r.Get(context.Background())
+		if rec == nil {
+			return "", false
+		}
+		v, ok := rec.Vars[name]
+		return v, ok
+	})
+	defer ir.SetEnvOverlay(nil)
+
+	const form = "${ITERION_VIBE_EFFORT_CLAUDE:-high}"
+	if got := ir.ExpandEnvWithDefault(form); got != "high" {
+		t.Fatalf("before any setting: %q, want the .bot default", got)
+	}
+
+	rec := BotVars{Vars: map[string]string{"ITERION_VIBE_EFFORT_CLAUDE": "max"}}
+	if err := rec.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if err := st.Put(context.Background(), rec); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	// Within the TTL the old value may still be served (per-replica
+	// convergence); past it the new value MUST be.
+	clock = clock.Add(DefaultTTL + time.Second)
+	if got := ir.ExpandEnvWithDefault(form); got != "max" {
+		t.Fatalf("after the write + TTL: %q, want the DB override live with no restart", got)
+	}
+
+	if err := st.Put(context.Background(), BotVars{}); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	clock = clock.Add(DefaultTTL + time.Second)
+	if got := ir.ExpandEnvWithDefault(form); got != "high" {
+		t.Fatalf("after clearing: %q, want the .bot default back", got)
+	}
+}

--- a/pkg/platformcfg/platformcfg.go
+++ b/pkg/platformcfg/platformcfg.go
@@ -6,13 +6,16 @@
 // fixed _id (the layout usagecap's settings store reserved for exactly
 // this growth).
 //
-// Two families ship here:
+// Families shipped here:
 //   - bot_roles — the webhook role→bot-id bindings that were hardcoded
 //     engine constants (reviewer/revi_converse/brancher/implementer), so
 //     re-pointing a role at another bot no longer needs a rollout.
 //   - sandbox — the `sandbox: auto` fallback image, resolved at PUBLISH
 //     time and pinned on the RunMessage so a redelivery reruns in the same
 //     environment.
+//   - bot_vars — DB-resolved overrides for the ${ITERION_X:-default}
+//     expansions bots declare (model pins, reasoning effort, tunables),
+//     consulted before the pod env through ir.SetEnvOverlay.
 //
 // A nil field means "no override — inherit the code/env default", which is
 // what keeps a deployment that never touches the API at exactly its
@@ -119,16 +122,37 @@ type BotVars struct {
 }
 
 // botVarsInfraPrefixes are the env namespaces a DB record must never
-// shadow: they configure the process's own transport, storage, identity
-// and enforcement — an override there would let a settings write repoint
-// the database it is stored in, or blunt the cap that meters it. The
-// usage-cap and sandbox-image families are excluded because they already
-// have their own audited, validated settings surface.
+// shadow. Honest scope: most of these are read via plain os.Getenv at
+// boot and never through the overlay, so this list is namespace HYGIENE
+// and defence in depth (the read side additionally gates on ITERION_),
+// not the containment boundary — that is the overlay's reach itself.
+// It still matters for the sites that DO resolve through
+// ir.LookupEnv/ExpandEnvWithDefault today or gain it tomorrow: keeping
+// transport/auth/enforcement names unwritable means routing one more
+// os.Getenv site through the choke point can never turn a stored var
+// into an infra override. Grepped from the real config surface
+// (pkg/config, cmd), not written from memory. The usage-cap and
+// sandbox-image families are excluded because they already have their
+// own audited, validated settings surface.
 var botVarsInfraPrefixes = []string{
-	"ITERION_MONGO_", "ITERION_NATS_", "ITERION_JWT_", "ITERION_SECRETS_",
-	"ITERION_S3_", "ITERION_BLOB_", "ITERION_VALKEY_", "ITERION_OIDC_",
-	"ITERION_OAUTH_", "ITERION_USAGE_CAP", "ITERION_SANDBOX_DEFAULT_IMAGE",
-	"ITERION_PUBLIC_URL", "ITERION_BOOTSTRAP_",
+	"ITERION_MONGO_", "ITERION_NATS_", "ITERION_QUEUE_", "ITERION_REDIS_",
+	"ITERION_JWT_", "ITERION_SECRETS_", "ITERION_S3_",
+	"ITERION_OIDC_", "ITERION_OAUTH_", "ITERION_AUTH_",
+	"ITERION_ACCESS_", "ITERION_PAT_", "ITERION_COOKIE_",
+	"ITERION_SMTP_", "ITERION_OTLP_", "ITERION_SANDBOX_",
+	"ITERION_USAGE_CAP", "ITERION_BOOTSTRAP_",
+	"ITERION_MODEL_SPECS_", "ITERION_UPDATE_",
+}
+
+// botVarsInfraExact are single infra names outside those namespaces —
+// exact matches, so a legitimate sibling (ITERION_BIN_PACKING…) is not
+// collaterally blocked the way a bare prefix would.
+var botVarsInfraExact = map[string]bool{
+	"ITERION_PUBLIC_URL":   true,
+	"ITERION_DISABLE_AUTH": true,
+	"ITERION_SIGNUP_MODE":  true,
+	"ITERION_BIN":          true,
+	"ITERION_PI_BIN":       true,
 }
 
 // botVarsMax bounds the record so a runaway writer cannot grow the
@@ -179,6 +203,9 @@ func botVarNameOK(name string) bool {
 		if strings.Contains(name, bad) {
 			return false
 		}
+	}
+	if botVarsInfraExact[name] {
+		return false
 	}
 	for _, p := range botVarsInfraPrefixes {
 		if strings.HasPrefix(name, p) {

--- a/pkg/platformcfg/platformcfg.go
+++ b/pkg/platformcfg/platformcfg.go
@@ -100,6 +100,94 @@ func (s Sandbox) Validate() error {
 	return nil
 }
 
+// BotVars is the bot-variable override record: the `${ITERION_X:-default}`
+// expansions every .bot declares (model pins, reasoning effort, tunables)
+// resolved from the DB before the pod's env — so re-tuning a bot no longer
+// needs a Helm values change and a rollout. The record stays typed and
+// validated here per the ADR-090 rejection of a generic KV table; only the
+// VALUE SPACE is a map, because the keys are declared by bots, not by the
+// engine.
+type BotVars struct {
+	// Vars maps ITERION_* names to their override values. A key present
+	// here beats the pod's env var; an absent key inherits env then the
+	// .bot's `:-` default. Clearing = removing the key (never an empty
+	// value).
+	Vars map[string]string `bson:"vars,omitempty" json:"vars"`
+
+	UpdatedAt time.Time `bson:"updated_at" json:"updated_at"`
+	UpdatedBy string    `bson:"updated_by,omitempty" json:"updated_by,omitempty"`
+}
+
+// botVarsInfraPrefixes are the env namespaces a DB record must never
+// shadow: they configure the process's own transport, storage, identity
+// and enforcement — an override there would let a settings write repoint
+// the database it is stored in, or blunt the cap that meters it. The
+// usage-cap and sandbox-image families are excluded because they already
+// have their own audited, validated settings surface.
+var botVarsInfraPrefixes = []string{
+	"ITERION_MONGO_", "ITERION_NATS_", "ITERION_JWT_", "ITERION_SECRETS_",
+	"ITERION_S3_", "ITERION_BLOB_", "ITERION_VALKEY_", "ITERION_OIDC_",
+	"ITERION_OAUTH_", "ITERION_USAGE_CAP", "ITERION_SANDBOX_DEFAULT_IMAGE",
+	"ITERION_PUBLIC_URL", "ITERION_BOOTSTRAP_",
+}
+
+// botVarsMax bounds the record so a runaway writer cannot grow the
+// document the TTL cache re-reads on every expiry.
+const (
+	botVarsMaxKeys     = 200
+	botVarsMaxValueLen = 256
+)
+
+// Validate rejects names outside the bot-var grammar, credential-shaped
+// names (the same doctrine as the model-env allowlist: a var whose name
+// suggests a secret must never transit a non-secret surface), infra
+// namespaces, and unbounded values. One bad entry fails the whole write —
+// nothing is persisted partially.
+func (b BotVars) Validate() error {
+	if len(b.Vars) > botVarsMaxKeys {
+		return fmt.Errorf("platformcfg: bot_vars: %d keys exceeds the %d-key bound", len(b.Vars), botVarsMaxKeys)
+	}
+	for name, val := range b.Vars {
+		if !botVarNameOK(name) {
+			return fmt.Errorf("platformcfg: bot_vars: %q is not an overridable bot var (want ITERION_A_Z0_9 outside the infra/credential namespaces)", name)
+		}
+		if strings.TrimSpace(val) == "" {
+			return fmt.Errorf("platformcfg: bot_vars: %s: value must not be blank (remove the key to clear the override)", name)
+		}
+		if strings.ContainsAny(val, "\n\r") {
+			return fmt.Errorf("platformcfg: bot_vars: %s: value must be a single line", name)
+		}
+		if len(val) > botVarsMaxValueLen {
+			return fmt.Errorf("platformcfg: bot_vars: %s: value exceeds %d bytes", name, botVarsMaxValueLen)
+		}
+	}
+	return nil
+}
+
+// botVarNameOK is the name gate: ITERION_-prefixed upper snake case, no
+// credential-shaped words, no infra namespace.
+func botVarNameOK(name string) bool {
+	if !strings.HasPrefix(name, "ITERION_") || len(name) <= len("ITERION_") {
+		return false
+	}
+	for _, r := range name {
+		if (r < 'A' || r > 'Z') && (r < '0' || r > '9') && r != '_' {
+			return false
+		}
+	}
+	for _, bad := range []string{"KEY", "TOKEN", "SECRET", "PASSWORD", "PRIVATE", "CREDENTIAL"} {
+		if strings.Contains(name, bad) {
+			return false
+		}
+	}
+	for _, p := range botVarsInfraPrefixes {
+		if strings.HasPrefix(name, p) {
+			return false
+		}
+	}
+	return true
+}
+
 // Store persists one settings family: Get returns (nil, nil) when no record
 // exists yet; Put replaces the whole record (ReplaceOne semantics, so a
 // cleared override really disappears).

--- a/pkg/platformcfg/platformcfg_test.go
+++ b/pkg/platformcfg/platformcfg_test.go
@@ -270,3 +270,49 @@ func TestResolver_PanicInFetchDoesNotWedge(t *testing.T) {
 		t.Error("the panic must be logged as a failed read")
 	}
 }
+
+func TestBotVarsValidate(t *testing.T) {
+	ok := BotVars{Vars: map[string]string{
+		"ITERION_VIBE_EFFORT_CLAUDE":            "max",
+		"ITERION_GOLDEN_MASTER_ADVERSARY_MODEL": "claude-opus-5",
+	}}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("valid vars: %v", err)
+	}
+	rejected := map[string]string{
+		"not ITERION_-prefixed":  "OTHER_VAR",
+		"lowercase":              "ITERION_vibe",
+		"bare prefix":            "ITERION_",
+		"infra mongo":            "ITERION_MONGO_URI",
+		"infra nats":             "ITERION_NATS_URL",
+		"infra jwt":              "ITERION_JWT_SIGNING",
+		"cap family (dedicated)": "ITERION_USAGE_CAP_WEEK",
+		"sandbox image family":   "ITERION_SANDBOX_DEFAULT_IMAGE",
+		"credential-shaped key":  "ITERION_MY_API_KEY",
+		"credential-shaped tok":  "ITERION_FORGE_TOKEN_TTL",
+	}
+	for label, name := range rejected {
+		if err := (BotVars{Vars: map[string]string{name: "v"}}).Validate(); err == nil {
+			t.Errorf("%s (%s) must be rejected", label, name)
+		}
+	}
+	badValues := map[string]string{
+		"blank value":      "  ",
+		"multi-line value": "a\nb",
+		"oversized value":  strings.Repeat("x", botVarsMaxValueLen+1),
+	}
+	for label, v := range badValues {
+		if err := (BotVars{Vars: map[string]string{"ITERION_OK_VAR": v}}).Validate(); err == nil {
+			t.Errorf("%s must be rejected", label)
+		}
+	}
+	big := map[string]string{}
+	for i := 0; i <= botVarsMaxKeys; i++ {
+		big["ITERION_V"+strings.Repeat("X", 3)+string(rune('A'+i%26))+string(rune('A'+(i/26)%26))+string(rune('A'+(i/676)%26))] = "v"
+	}
+	if len(big) > botVarsMaxKeys {
+		if err := (BotVars{Vars: big}).Validate(); err == nil {
+			t.Error("a record past the key bound must be rejected")
+		}
+	}
+}

--- a/pkg/platformcfg/store.go
+++ b/pkg/platformcfg/store.go
@@ -22,6 +22,7 @@ const colPlatformSettings = "platform_settings"
 const (
 	FamilyBotRoles = "bot_roles"
 	FamilySandbox  = "sandbox"
+	FamilyBotVars  = "bot_vars"
 )
 
 // MongoStore is the cloud Store for one family: the single document every
@@ -39,6 +40,11 @@ func NewMongoBotRoles(db *mongo.Database) *MongoStore[BotRoles] {
 // NewMongoSandbox binds the sandbox family to a database.
 func NewMongoSandbox(db *mongo.Database) *MongoStore[Sandbox] {
 	return &MongoStore[Sandbox]{col: db.Collection(colPlatformSettings), docID: FamilySandbox}
+}
+
+// NewMongoBotVars binds the bot_vars family to a database.
+func NewMongoBotVars(db *mongo.Database) *MongoStore[BotVars] {
+	return &MongoStore[BotVars]{col: db.Collection(colPlatformSettings), docID: FamilyBotVars}
 }
 
 func (s *MongoStore[T]) Get(ctx context.Context) (*T, error) {
@@ -104,6 +110,8 @@ func stampUpdatedAt[T any](rec *T) {
 	case *BotRoles:
 		v.UpdatedAt = time.Now().UTC()
 	case *Sandbox:
+		v.UpdatedAt = time.Now().UTC()
+	case *BotVars:
 		v.UpdatedAt = time.Now().UTC()
 	}
 }

--- a/pkg/platformcfg/store.go
+++ b/pkg/platformcfg/store.go
@@ -77,6 +77,56 @@ func (s *MongoStore[T]) Put(ctx context.Context, rec T) error {
 	return nil
 }
 
+// updatedAtOf reads the family record's UpdatedAt (the CAS token for
+// PutIfUnchanged). Zero for families that would not have the field —
+// none today, the switch is the same shape stampUpdatedAt maintains.
+func updatedAtOf[T any](rec *T) time.Time {
+	switch v := any(rec).(type) {
+	case *BotRoles:
+		return v.UpdatedAt
+	case *Sandbox:
+		return v.UpdatedAt
+	case *BotVars:
+		return v.UpdatedAt
+	}
+	return time.Time{}
+}
+
+// PutIfUnchanged writes rec only if the stored document's updated_at
+// still equals prevUpdatedAt (zero = "no document existed"). Returns
+// false when another writer got there first — the read-modify-write
+// callers (the per-key merge handlers) surface that as a 409 and
+// re-read, instead of silently dropping the concurrent writer's keys
+// under ReplaceOne semantics.
+func (s *MongoStore[T]) PutIfUnchanged(ctx context.Context, rec T, prevUpdatedAt time.Time) (bool, error) {
+	stampUpdatedAt(&rec)
+	body, err := bson.Marshal(rec)
+	if err != nil {
+		return false, fmt.Errorf("platformcfg: encode %s: %w", s.docID, err)
+	}
+	var doc bson.M
+	if err := bson.Unmarshal(body, &doc); err != nil {
+		return false, fmt.Errorf("platformcfg: encode %s: %w", s.docID, err)
+	}
+	doc["_id"] = s.docID
+	filter := bson.M{"_id": s.docID, "updated_at": prevUpdatedAt}
+	upsert := false
+	if prevUpdatedAt.IsZero() {
+		// First write: match only a missing document, and upsert it.
+		filter = bson.M{"_id": s.docID, "updated_at": bson.M{"$exists": false}}
+		upsert = true
+	}
+	res, err := s.col.ReplaceOne(ctx, filter, doc, options.Replace().SetUpsert(upsert))
+	if err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			// The upsert raced another first write.
+			return false, nil
+		}
+		return false, fmt.Errorf("platformcfg: put %s: %w", s.docID, err)
+	}
+	return res.MatchedCount > 0 || res.UpsertedCount > 0, nil
+}
+
 // MemoryStore is the in-process Store for tests and single-process wiring.
 type MemoryStore[T any] struct {
 	mu  sync.Mutex
@@ -101,6 +151,29 @@ func (m *MemoryStore[T]) Put(_ context.Context, rec T) error {
 	defer m.mu.Unlock()
 	m.rec = &rec
 	return nil
+}
+
+// PutIfUnchanged is the MemoryStore mirror of the Mongo CAS write.
+func (m *MemoryStore[T]) PutIfUnchanged(_ context.Context, rec T, prevUpdatedAt time.Time) (bool, error) {
+	stampUpdatedAt(&rec)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	switch {
+	case m.rec == nil:
+		if !prevUpdatedAt.IsZero() {
+			return false, nil
+		}
+	case !updatedAtOf(m.rec).Equal(prevUpdatedAt):
+		return false, nil
+	}
+	m.rec = &rec
+	return true, nil
+}
+
+// CASStore is the optional conditional-write surface a Store may offer;
+// the merge handlers use it when present and fall back to Put otherwise.
+type CASStore[T any] interface {
+	PutIfUnchanged(ctx context.Context, rec T, prevUpdatedAt time.Time) (bool, error)
 }
 
 // stampUpdatedAt sets the family record's UpdatedAt on write — in the

--- a/pkg/runview/conflict_agent.go
+++ b/pkg/runview/conflict_agent.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"slices"
 	"strings"
 
@@ -24,6 +23,7 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/backend/detect"
 	"github.com/SocialGouv/iterion/pkg/backend/model"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -190,7 +190,7 @@ func resolveResolverModel(registry *model.Registry, override string) (string, er
 	// Honour an explicit operator override via env — useful in
 	// devloops where the detector's pick isn't what we want for
 	// resolution.
-	if env := os.Getenv("ITERION_CONFLICT_RESOLVER_MODEL"); env != "" {
+	if env := ir.LookupEnv("ITERION_CONFLICT_RESOLVER_MODEL"); env != "" {
 		return env, nil
 	}
 	report := detect.Detect(context.Background())

--- a/pkg/runview/executor.go
+++ b/pkg/runview/executor.go
@@ -561,14 +561,14 @@ func buildMCPManager(wf *ir.Workflow, storeDir string, logger *iterlog.Logger) (
 	for name, server := range wf.ResolvedMCPServers {
 		expandedArgs := make([]string, len(server.Args))
 		for i, a := range server.Args {
-			expandedArgs[i] = os.ExpandEnv(a)
+			expandedArgs[i] = ir.ExpandEnvWithDefault(a)
 		}
 		catalog[name] = &mcp.ServerConfig{
 			Name:      server.Name,
 			Transport: mcp.FromIRTransport(server.Transport),
-			Command:   os.ExpandEnv(server.Command),
+			Command:   ir.ExpandEnvWithDefault(server.Command),
 			Args:      expandedArgs,
-			URL:       os.ExpandEnv(server.URL),
+			URL:       ir.ExpandEnvWithDefault(server.URL),
 			Headers:   server.Headers,
 			// Env is already fully resolved at catalog-build time (plugin
 			// {{config.*}} placeholders expanded by loadPluginServers) — copy
@@ -641,7 +641,7 @@ func buildToolChecker(wf *ir.Workflow) tool.ToolChecker {
 //
 // Returns (nil, nil) when the env var is empty.
 func newLLMClassifierFromEnv(reg *model.Registry, logger *iterlog.Logger) (permissions.Classifier, error) {
-	spec := strings.TrimSpace(os.Getenv("ITERION_LLM_CLASSIFIER_MODEL"))
+	spec := strings.TrimSpace(ir.LookupEnv("ITERION_LLM_CLASSIFIER_MODEL"))
 	if spec == "" {
 		return nil, nil
 	}

--- a/pkg/server/openapi_spec.go
+++ b/pkg/server/openapi_spec.go
@@ -78,6 +78,7 @@ func BuildOpenAPISpec() (map[string]any, error) {
 		BotSources:        botsource.NewMemoryStore(),
 		BotRolesSettings:  platformcfg.NewMemoryStore[platformcfg.BotRoles](),
 		SandboxSettings:   platformcfg.NewMemoryStore[platformcfg.Sandbox](),
+		BotVarsSettings:   platformcfg.NewMemoryStore[platformcfg.BotVars](),
 		Store:             runStore,
 	}
 

--- a/pkg/server/platform_settings.go
+++ b/pkg/server/platform_settings.go
@@ -76,6 +76,10 @@ func (s *Server) registerAdminSettingsFamilyRoutes() {
 		s.mux.Handle("GET /api/admin/settings/sandbox", s.requireSuperAdmin(http.HandlerFunc(s.handleAdminGetSandboxSettings)))
 		s.mux.Handle("PUT /api/admin/settings/sandbox", s.requireSuperAdmin(http.HandlerFunc(s.handleAdminPutSandboxSettings)))
 	}
+	if s.botVarsStore != nil {
+		s.mux.Handle("GET /api/admin/settings/bot-vars", s.requireSuperAdmin(http.HandlerFunc(s.handleAdminGetBotVars)))
+		s.mux.Handle("PUT /api/admin/settings/bot-vars", s.requireSuperAdmin(http.HandlerFunc(s.handleAdminPutBotVars)))
+	}
 }
 
 func (s *Server) handleAdminGetBotRoles(w http.ResponseWriter, r *http.Request) {
@@ -221,4 +225,89 @@ func strPtrOr(v *string, def string) string {
 		return def
 	}
 	return *v
+}
+
+func (s *Server) handleAdminGetBotVars(w http.ResponseWriter, r *http.Request) {
+	rec, err := s.botVarsStore.Get(r.Context())
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "%v", err)
+		return
+	}
+	origin := "default"
+	if rec != nil && len(rec.Vars) > 0 {
+		origin = "db"
+	}
+	s.writeJSONFor(w, r, map[string]any{
+		"stored": rec,
+		"origin": origin,
+		// The bound every replica converges within after a write — the
+		// operator-facing answer to "when does my var take effect".
+		"propagation_bound_seconds": int(platformcfg.DefaultTTL.Seconds()),
+	})
+}
+
+// handleAdminPutBotVars applies MERGE semantics per key, like the caps
+// route does per field: a string sets the override, an explicit null
+// removes the key, a key absent from the body keeps its stored state.
+func (s *Server) handleAdminPutBotVars(w http.ResponseWriter, r *http.Request) {
+	if !s.requireSafeOrigin(w, r) {
+		return
+	}
+	var patch map[string]*string
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&patch); err != nil {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "invalid body: %v", err)
+		return
+	}
+	if len(patch) == 0 {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "empty patch: name at least one ITERION_* var (null to clear)")
+		return
+	}
+	rec, err := s.botVarsStore.Get(r.Context())
+	if err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "%v", err)
+		return
+	}
+	if rec == nil {
+		rec = &platformcfg.BotVars{}
+	}
+	// Work on a COPY of the map: the store may hand back a record that
+	// shares it (MemoryStore does), and a patch that fails validation
+	// below must leave the stored record untouched.
+	vars := make(map[string]string, len(rec.Vars))
+	for k, v := range rec.Vars {
+		vars[k] = v
+	}
+	rec.Vars = vars
+	// Audit meta carries old→new per touched key: the values are
+	// non-secret by construction (Validate refuses credential-shaped
+	// names), so they are loggable in clear.
+	changes := map[string]any{}
+	for name, v := range patch {
+		old := rec.Vars[name]
+		if v == nil {
+			if _, had := rec.Vars[name]; !had {
+				// Clearing a key that was never set: refuse loudly rather
+				// than audit a no-op — the operator probably misspelled it.
+				s.httpErrorFor(w, r, http.StatusBadRequest, "%s is not set — nothing to clear", name)
+				return
+			}
+			delete(rec.Vars, name)
+			changes[name] = map[string]string{"old": old, "new": ""}
+			continue
+		}
+		rec.Vars[name] = *v
+		changes[name] = map[string]string{"old": old, "new": *v}
+	}
+	if err := rec.Validate(); err != nil {
+		s.httpErrorFor(w, r, http.StatusBadRequest, "%v", err)
+		return
+	}
+	rec.UpdatedBy = s.requestUserID(r)
+	if err := s.botVarsStore.Put(r.Context(), *rec); err != nil {
+		s.httpErrorFor(w, r, http.StatusInternalServerError, "%v", err)
+		return
+	}
+	s.botVars.Invalidate()
+	s.auditPlatform(r, "", "platform.settings.bot_vars.updated", "platform_settings", platformcfg.FamilyBotVars, changes)
+	s.handleAdminGetBotVars(w, r)
 }

--- a/pkg/server/platform_settings.go
+++ b/pkg/server/platform_settings.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/platformcfg"
 )
@@ -267,6 +268,10 @@ func (s *Server) handleAdminPutBotVars(w http.ResponseWriter, r *http.Request) {
 		s.httpErrorFor(w, r, http.StatusInternalServerError, "%v", err)
 		return
 	}
+	var prevUpdatedAt time.Time
+	if rec != nil {
+		prevUpdatedAt = rec.UpdatedAt
+	}
 	if rec == nil {
 		rec = &platformcfg.BotVars{}
 	}
@@ -278,9 +283,11 @@ func (s *Server) handleAdminPutBotVars(w http.ResponseWriter, r *http.Request) {
 		vars[k] = v
 	}
 	rec.Vars = vars
-	// Audit meta carries old→new per touched key: the values are
-	// non-secret by construction (Validate refuses credential-shaped
-	// names), so they are loggable in clear.
+	// Audit meta carries old→new per touched key. Validate refuses
+	// credential-SHAPED NAMES, but nothing can vouch for the VALUE an
+	// operator chooses to store under an innocent name: values live in
+	// clear in the settings doc, this audit trail and every GET — the
+	// CLI help says so, and the surface is super-admin-only.
 	changes := map[string]any{}
 	for name, v := range patch {
 		old := rec.Vars[name]
@@ -303,7 +310,21 @@ func (s *Server) handleAdminPutBotVars(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	rec.UpdatedBy = s.requestUserID(r)
-	if err := s.botVarsStore.Put(r.Context(), *rec); err != nil {
+	// Conditional write: two replicas merging concurrently must not
+	// silently drop each other's keys through a blind ReplaceOne. A lost
+	// race is a loud 409 — the operator re-runs the command against the
+	// fresh state.
+	if cas, ok := s.botVarsStore.(platformcfg.CASStore[platformcfg.BotVars]); ok {
+		wrote, err := cas.PutIfUnchanged(r.Context(), *rec, prevUpdatedAt)
+		if err != nil {
+			s.httpErrorFor(w, r, http.StatusInternalServerError, "%v", err)
+			return
+		}
+		if !wrote {
+			s.httpErrorFor(w, r, http.StatusConflict, "bot vars changed concurrently — re-read and retry")
+			return
+		}
+	} else if err := s.botVarsStore.Put(r.Context(), *rec); err != nil {
 		s.httpErrorFor(w, r, http.StatusInternalServerError, "%v", err)
 		return
 	}

--- a/pkg/server/platform_settings_test.go
+++ b/pkg/server/platform_settings_test.go
@@ -185,3 +185,50 @@ func TestEffectiveEntries_PlatformOverlay(t *testing.T) {
 		t.Fatalf("new-slug platform bot must be appended, got %v", byName)
 	}
 }
+
+func TestAdminBotVars_PutMergeClearAndRejects(t *testing.T) {
+	st := platformcfg.NewMemoryStore[platformcfg.BotVars]()
+	s := New(Config{SkipProjectRegistration: true, BotVarsSettings: st}, iterlog.New(iterlog.LevelError, nil))
+	admin := auth.WithIdentity(context.Background(), auth.Identity{UserID: "root", IsSuperAdmin: true})
+
+	put := func(body string) *httptest.ResponseRecorder {
+		r := httptest.NewRequest("PUT", "/api/admin/settings/bot-vars", strings.NewReader(body)).WithContext(admin)
+		w := httptest.NewRecorder()
+		s.handleAdminPutBotVars(w, r)
+		return w
+	}
+
+	if w := put(`{"ITERION_VIBE_EFFORT_CLAUDE":"max"}`); w.Code != http.StatusOK {
+		t.Fatalf("set = %d: %s", w.Code, w.Body.String())
+	}
+	if w := put(`{"ITERION_MODERNIZE_EFFORT":"max"}`); w.Code != http.StatusOK {
+		t.Fatalf("merge set = %d: %s", w.Code, w.Body.String())
+	}
+	rec, _ := st.Get(context.Background())
+	if rec == nil || rec.Vars["ITERION_VIBE_EFFORT_CLAUDE"] != "max" || rec.Vars["ITERION_MODERNIZE_EFFORT"] != "max" {
+		t.Fatalf("merge semantics lost a key: %+v", rec)
+	}
+
+	// An infra/credential-shaped key is refused and NOTHING is written.
+	for _, bad := range []string{`{"ITERION_MONGO_URI":"mongodb://evil"}`, `{"ITERION_MY_API_KEY":"x"}`, `{"OTHER":"x"}`, `{}`} {
+		if w := put(bad); w.Code != http.StatusBadRequest {
+			t.Fatalf("put %s = %d, want 400", bad, w.Code)
+		}
+	}
+	rec, _ = st.Get(context.Background())
+	if len(rec.Vars) != 2 {
+		t.Fatalf("a rejected write mutated the record: %+v", rec)
+	}
+
+	// null clears; clearing an unset key is a loud 400, not a no-op audit.
+	if w := put(`{"ITERION_VIBE_EFFORT_CLAUDE":null}`); w.Code != http.StatusOK {
+		t.Fatalf("clear = %d: %s", w.Code, w.Body.String())
+	}
+	if w := put(`{"ITERION_NEVER_SET":null}`); w.Code != http.StatusBadRequest {
+		t.Fatalf("clear-unset = %d, want 400", w.Code)
+	}
+	rec, _ = st.Get(context.Background())
+	if _, still := rec.Vars["ITERION_VIBE_EFFORT_CLAUDE"]; still || len(rec.Vars) != 1 {
+		t.Fatalf("clear semantics wrong: %+v", rec)
+	}
+}

--- a/pkg/server/platform_settings_test.go
+++ b/pkg/server/platform_settings_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/botsource"
@@ -230,5 +231,42 @@ func TestAdminBotVars_PutMergeClearAndRejects(t *testing.T) {
 	rec, _ = st.Get(context.Background())
 	if _, still := rec.Vars["ITERION_VIBE_EFFORT_CLAUDE"]; still || len(rec.Vars) != 1 {
 		t.Fatalf("clear semantics wrong: %+v", rec)
+	}
+}
+
+func TestAdminBotVars_ConcurrentPutIsA409NotALostKey(t *testing.T) {
+	st := platformcfg.NewMemoryStore[platformcfg.BotVars]()
+	s := New(Config{SkipProjectRegistration: true, BotVarsSettings: st}, iterlog.New(iterlog.LevelError, nil))
+	admin := auth.WithIdentity(context.Background(), auth.Identity{UserID: "root", IsSuperAdmin: true})
+
+	put := func(body string) *httptest.ResponseRecorder {
+		r := httptest.NewRequest("PUT", "/api/admin/settings/bot-vars", strings.NewReader(body)).WithContext(admin)
+		w := httptest.NewRecorder()
+		s.handleAdminPutBotVars(w, r)
+		return w
+	}
+	if w := put(`{"ITERION_A_VAR":"1"}`); w.Code != http.StatusOK {
+		t.Fatalf("seed = %d", w.Code)
+	}
+	// Simulate replica B writing between A's read and A's write: bump the
+	// stored record directly so A's CAS token is stale.
+	rec, _ := st.Get(context.Background())
+	rec.Vars["ITERION_B_VAR"] = "2"
+	if err := st.Put(context.Background(), *rec); err != nil {
+		t.Fatalf("concurrent write: %v", err)
+	}
+	// A's handler now reads fresh state (this test drives sequentially),
+	// so instead exercise the CAS directly with the stale token.
+	stale := rec.UpdatedAt.Add(-time.Second)
+	wrote, err := st.PutIfUnchanged(context.Background(), platformcfg.BotVars{Vars: map[string]string{"ITERION_A_VAR": "1"}}, stale)
+	if err != nil {
+		t.Fatalf("cas: %v", err)
+	}
+	if wrote {
+		t.Fatal("a stale CAS token must not win — that is the silently-dropped-key path")
+	}
+	after, _ := st.Get(context.Background())
+	if after.Vars["ITERION_B_VAR"] != "2" {
+		t.Fatalf("the concurrent writer's key was lost: %+v", after.Vars)
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -168,6 +168,8 @@ type Server struct {
 	botRolesStore   platformcfg.Store[platformcfg.BotRoles]
 	sandboxCfg      *platformcfg.Resolver[platformcfg.Sandbox]
 	sandboxCfgStore platformcfg.Store[platformcfg.Sandbox]
+	botVars         *platformcfg.Resolver[platformcfg.BotVars]
+	botVarsStore    platformcfg.Store[platformcfg.BotVars]
 	// platformBots caches the platform-override entry set per replica
 	// (TTL-bounded read cache; Mongo stays the authority — bot_resolver.go).
 	platformBots   *platformcfg.Resolver[platformBotSet]
@@ -452,6 +454,7 @@ func New(cfg Config, logger *iterlog.Logger) *Server {
 		botSources:        cfg.BotSources,
 		botRolesStore:     cfg.BotRolesSettings,
 		sandboxCfgStore:   cfg.SandboxSettings,
+		botVarsStore:      cfg.BotVarsSettings,
 		forgeIntegrations: cfg.ForgeIntegrations,
 		forgeOAuthApps:    cfg.ForgeOAuthApps,
 		forgeGitHubApp:    cfg.ForgeGitHubApp,
@@ -467,6 +470,14 @@ func New(cfg Config, logger *iterlog.Logger) *Server {
 	// the stores. A nil store keeps them nil-safe — Get returns nil and
 	// every consumer falls back to its hardcoded/env default.
 	s.botRoles = platformcfg.NewResolver(cfg.BotRolesSettings, logger.Warn)
+	if cfg.BotVarsResolver != nil {
+		// Shared with the ir.SetEnvOverlay hook (cmd wiring): ONE resolver,
+		// so the admin PUT's Invalidate reaches this replica's own
+		// expansions immediately, not after the TTL.
+		s.botVars = cfg.BotVarsResolver
+	} else {
+		s.botVars = platformcfg.NewResolver(cfg.BotVarsSettings, logger.Warn)
+	}
 	if cfg.SandboxResolver != nil {
 		// Shared with the cloud publisher (cmd wiring): ONE resolver
 		// instance, so the admin PUT's Invalidate reaches publish-time

--- a/pkg/server/server_config.go
+++ b/pkg/server/server_config.go
@@ -236,11 +236,21 @@ type Config struct {
 	// keeps the hardcoded/env defaults (local mode).
 	BotRolesSettings platformcfg.Store[platformcfg.BotRoles]
 	SandboxSettings  platformcfg.Store[platformcfg.Sandbox]
+	// BotVarsSettings is the bot-variable override family: DB-resolved
+	// values for the `${ITERION_X:-default}` expansions bots declare, so
+	// re-tuning a bot (model pin, reasoning effort) is a settings write,
+	// not a Helm change + rollout. Nil keeps env-only expansion.
+	BotVarsSettings platformcfg.Store[platformcfg.BotVars]
 	// SandboxResolver, when non-nil, is the SHARED TTL resolver over
 	// SandboxSettings, also handed to the cloud publisher — one instance,
 	// so the admin PUT's Invalidate reaches publish-time pinning on the
 	// same replica. Nil (tests/local) builds a private one.
 	SandboxResolver *platformcfg.Resolver[platformcfg.Sandbox]
+	// BotVarsResolver, when non-nil, is the SHARED TTL resolver over
+	// BotVarsSettings, also installed as ir.SetEnvOverlay by the cmd
+	// wiring — one instance, so the admin PUT's Invalidate reaches the
+	// same replica's expansions immediately. Nil builds a private one.
+	BotVarsResolver *platformcfg.Resolver[platformcfg.BotVars]
 
 	// MemoryStore backs the shared-knowledge REST surface
 	// (/api/memory/*). nil → the local filesystem store. Cloud mode

--- a/pkg/sessionboard/bot.go
+++ b/pkg/sessionboard/bot.go
@@ -5,13 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/SocialGouv/claw-code-go/pkg/api"
 
 	"github.com/SocialGouv/iterion/pkg/backend/detect"
 	"github.com/SocialGouv/iterion/pkg/backend/model"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 )
 
 // decisionSchema is the structured-output contract handed to
@@ -86,7 +86,7 @@ func resolveModel(pinned string) (string, error) {
 	if pinned != "" {
 		return pinned, nil
 	}
-	if env := os.Getenv("ITERION_DEFAULT_SESSIONBOARD_MODEL"); env != "" {
+	if env := ir.LookupEnv("ITERION_DEFAULT_SESSIONBOARD_MODEL"); env != "" {
 		return env, nil
 	}
 	report := detect.Detect(context.Background())

--- a/pkg/sessionboard/env.go
+++ b/pkg/sessionboard/env.go
@@ -3,6 +3,8 @@ package sessionboard
 import (
 	"os"
 	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 )
 
 // Enabled reports whether the LLM curation layer should run, read from
@@ -23,5 +25,5 @@ func Enabled() bool {
 // ITERION_DEFAULT_SESSIONBOARD_MODEL, or "" to let the evaluator
 // auto-detect a reachable provider.
 func ModelFromEnv() string {
-	return strings.TrimSpace(os.Getenv("ITERION_DEFAULT_SESSIONBOARD_MODEL"))
+	return strings.TrimSpace(ir.LookupEnv("ITERION_DEFAULT_SESSIONBOARD_MODEL"))
 }

--- a/pkg/supervise/bot.go
+++ b/pkg/supervise/bot.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/backend/detect"
 	"github.com/SocialGouv/iterion/pkg/backend/model"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/secrets"
 )
 
@@ -129,7 +130,7 @@ func resolveModel(ctx context.Context, specModel, providerHint string) (string, 
 	if specModel != "" {
 		return specModel, nil
 	}
-	if env := os.Getenv("ITERION_DEFAULT_SUPERVISOR_MODEL"); env != "" {
+	if env := ir.LookupEnv("ITERION_DEFAULT_SUPERVISOR_MODEL"); env != "" {
 		return env, nil
 	}
 	report := detect.Detect(ctx)

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -399,6 +399,24 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/admin/settings/bot-vars": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** GET /api/admin/settings/bot-vars */
+        get: operations["getAdminSettingsBotVars"];
+        /** PUT /api/admin/settings/bot-vars */
+        put: operations["putAdminSettingsBotVars"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/admin/settings/sandbox": {
         parameters: {
             query?: never;
@@ -6460,6 +6478,42 @@ export interface operations {
         };
     };
     putAdminSettingsBotRoles: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getAdminSettingsBotVars: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    putAdminSettingsBotVars: {
         parameters: {
             query?: never;
             header?: never;


### PR DESCRIPTION
## Why

Bots parameterize their model pins, reasoning effort and tunables as `${ITERION_X:-default}` expansions (`ITERION_VIBE_MODEL_CLAUDE`, `ITERION_MODERNIZE_EFFORT`, …), read from the runner pod's **env** — so re-tuning a bot in production meant a Helm values change and a rollout. Credentials, bot bundles, usage caps, role bindings and the sandbox image had all already moved to the CLI→API→DB runtime-settings surface (ADR-090). Operator ask: the same for bot vars.

## What

A fourth `platformcfg` family, **`bot_vars`** — one validated `map[ITERION_*]value` document in `platform_settings`:

- **One choke point**: `ir.ExpandEnvWithDefault` consults an overlay (`ir.SetEnvOverlay`, installed once at boot by the server and runner cmds, TTL resolver behind it) before `os.Getenv` — all ~30 expansion sites covered at once. Precedence: **setting > pod env > `:-` default**; an empty overlay value counts as unset (clearing = removing the key, never pinning "").
- **Validation as the safety argument**: names outside `ITERION_[A-Z0-9_]+` refused; credential-shaped names refused (KEY/TOKEN/SECRET/PASSWORD/PRIVATE/CREDENTIAL — a var whose name suggests a secret must never transit a non-secret surface); infra namespaces refused (Mongo/NATS/JWT/secrets/S3/blob/Valkey/OIDC/OAuth/public-URL/bootstrap); the families that already own an audited surface refused (usage cap, sandbox image). Single-line, non-blank, bounded values; bounded key count.
- **Routes** `GET/PUT /api/admin/settings/bot-vars` (super-admin, safe-origin): PUT merges per key (string = set, `null` = clear, absent = untouched), audits old→new per touched key (values non-secret by construction), invalidates the mutating replica's resolver; others converge within the TTL (echoed as `propagation_bound_seconds`). The handler mutates a **copy** of the stored map — a patch that fails validation cannot corrupt the record through a shared-map store (pinned against `MemoryStore`).
- **CLI**: `iterion remote admin vars [set NAME VALUE | rm NAME]`.
- Local CLI runs keep byte-identical env-only behaviour (nil overlay).

## The liveness signature

`TestBotVars_SettingsChangeIsLiveThroughExpansion` pins the whole operator promise in one process: `${ITERION_VIBE_EFFORT_CLAUDE:-high}` → `high`, settings write, TTL passes, → `max`, clear, → `high` — **no restart anywhere**. Overlay precedence falsified both ways in `pkg/dsl/ir` (setting beats env; empty setting yields env; nil overlay is byte-identical to before).

ADR-093 records the decision. `openapi.json` + `studio/src/api/schema.ts` regenerated.

2069 tests green across the four touched packages; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)