### PR TITLE
fix(pipelines): hide chat sessions (Copi/Nexie) from the pipeline board

### DIFF
--- a/pkg/server/pipeline_boards_projection.go
+++ b/pkg/server/pipeline_boards_projection.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/SocialGouv/iterion/pkg/bundle"
 	"github.com/SocialGouv/iterion/pkg/dispatcher/native"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -103,6 +105,13 @@ type pipelineProjectionBuilder struct {
 	since         time.Time
 	hiddenBySince int
 
+	// chatBot answers "is this bot conversational?" (a manifest chat:
+	// surface) for a (bot id, workflow path) pair — injected by the server,
+	// memoized per key in chatBots for the lifetime of one projection so a
+	// board of N Copi sessions reads the manifest once, not N times.
+	chatBot  func(botID, filePath string) bool
+	chatBots map[string]bool
+
 	cardLimitReached  bool
 	depthLimitReached bool
 	cycleDetected     bool
@@ -128,6 +137,8 @@ func (s *Server) buildPipelineBoard(ctx context.Context, boardStore native.Board
 		queuePositions:  map[string]int{},
 		since:           since,
 		finalOutputMemo: &s.finalOutputMemo,
+		chatBot:         s.botIsChat,
+		chatBots:        map[string]bool{},
 	}
 	if runs != nil {
 		builder.rs = runs.RunStore()
@@ -194,7 +205,12 @@ func (s *Server) buildPipelineBoard(ctx context.Context, boardStore native.Board
 	// Standalone roots: manual/API/scheduled/queued runs with no native
 	// issue. Only top-level runs (parent absent or dangling) become cards;
 	// a child belongs to the root that spawned it, even when the child runs
-	// a different bot.
+	// a different bot. A CHAT SESSION (a run of a bot whose manifest
+	// declares a chat: surface — the assistant dock's Copi / Nexie) is not a
+	// pipeline at all and never becomes a card: the dock is its surface, and
+	// a session parks on a budget-free human turn for days, so projecting it
+	// would pin one In-progress card per open conversation. Its children
+	// (a subbot it spawned) stay folded under it and disappear with it.
 	standalone := make([]*store.Run, 0)
 	for _, run := range builder.runs {
 		if _, owned := builder.issueOwnedRuns[run.ID]; owned {
@@ -202,6 +218,9 @@ func (s *Server) buildPipelineBoard(ctx context.Context, boardStore native.Board
 		}
 		parentID := pipelineParentRunID(run)
 		if parentID != "" && builder.runs[parentID] != nil {
+			continue
+		}
+		if builder.isChatSession(run) {
 			continue
 		}
 		standalone = append(standalone, run)
@@ -457,6 +476,56 @@ func pipelineCardEligible(run *store.Run) bool {
 // ended.
 func pipelineForkShell(run *store.Run) bool {
 	return run.ForkedFrom != "" && run.Status.IsTerminal() && run.FinishedAt == nil
+}
+
+// isChatSession reports whether run belongs to a conversational bot — see
+// the standalone-roots comment in buildPipelineBoard. Memoized per bot id
+// (or, for a legacy run stamped with no bot id, per workflow directory).
+func (b *pipelineProjectionBuilder) isChatSession(run *store.Run) bool {
+	if b.chatBot == nil || run == nil {
+		return false
+	}
+	botID := strings.TrimSpace(run.BotID)
+	filePath := strings.TrimSpace(run.FilePath)
+	key := "bot:" + botID
+	if botID == "" {
+		if filePath == "" {
+			return false
+		}
+		key = "dir:" + filepath.Dir(filePath)
+	}
+	if b.chatBots == nil {
+		b.chatBots = map[string]bool{}
+	}
+	if v, ok := b.chatBots[key]; ok {
+		return v
+	}
+	v := b.chatBot(botID, filePath)
+	b.chatBots[key] = v
+	return v
+}
+
+// botIsChat resolves whether the bot behind a run declares a chat: surface
+// in its manifest. The bot id goes through the same tiers as every other
+// manifest read (platform override, then the configured catalog —
+// botManifest); a run with no bot id (a legacy launch, or a loose .bot)
+// falls back to the manifest beside its workflow file, which is where a
+// bundle's manifest lives. Anything unresolvable is an ordinary run — the
+// board must never hide a card on a missing or malformed manifest.
+func (s *Server) botIsChat(botID, filePath string) bool {
+	if botID != "" {
+		if m := s.botManifest(botID); m != nil {
+			return m.Chat != nil
+		}
+	}
+	if filePath == "" {
+		return false
+	}
+	m, err := bundle.LoadManifest(filepath.Join(filepath.Dir(filePath), "manifest.yaml"))
+	if err != nil || m == nil {
+		return false
+	}
+	return m.Chat != nil
 }
 
 func (b *pipelineProjectionBuilder) attemptsForIssue(issue *native.Issue, current *store.Run) []PipelineBoardAttempt {

--- a/pkg/server/pipeline_boards_test.go
+++ b/pkg/server/pipeline_boards_test.go
@@ -1721,3 +1721,54 @@ func TestPipelineBoardParkedForkWithoutParentRecord(t *testing.T) {
 		t.Error("a parked fork shell must not become the card root even when the parent's record is gone")
 	}
 }
+
+// A CHAT SESSION — a run of a bot whose manifest declares a chat: surface
+// (the assistant dock's Copi / Nexie) — is not a pipeline: the dock is its
+// surface and it parks on a human turn for days. It never becomes a card,
+// whether resolved by bot id or (legacy run, no bot id) by the manifest
+// beside its workflow file; its own children stay folded under it; every
+// ordinary run keeps its card. The rule is the manifest block, never a bot
+// id — the engine stays bot-agnostic.
+func TestPipelineBoardHidesChatSessions(t *testing.T) {
+	env := newPipelineBoardTestEnv(t)
+	bundleDir := filepath.Join(env.workDir, "bots", "chatty")
+	if err := os.MkdirAll(bundleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	chatBotPath := filepath.Join(bundleDir, "main.bot")
+	if err := os.WriteFile(chatBotPath, []byte(pipelineBoardTestBot), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := "name: chatty\ndisplay_name: Chatty\nchat:\n  nodes:\n    approval: {kind: human, text_field: feedback}\n"
+	if err := os.WriteFile(filepath.Join(bundleDir, "manifest.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	env.seedRun(t, "chat-open", "review", store.RunStatusPausedWaitingHuman, func(run *store.Run) {
+		run.FilePath = chatBotPath
+		run.BotID = "chatty"
+	})
+	env.seedRun(t, "chat-legacy", "review", store.RunStatusFinished, func(run *store.Run) {
+		run.FilePath = chatBotPath // no BotID: resolved from the manifest beside the file
+	})
+	env.seedRun(t, "chat-child", "review", store.RunStatusRunning, func(run *store.Run) {
+		run.FilePath = env.botPath
+		run.ParentRunID = "chat-open"
+	})
+	env.seedRun(t, "run-manual", "review", store.RunStatusRunning, func(run *store.Run) {
+		run.FilePath = env.botPath
+	})
+
+	projection := env.projection(t)
+	for _, hidden := range []string{"run:chat-open", "run:chat-legacy", "run:chat-child"} {
+		if hasPipelineCard(projection.Cards, hidden) {
+			t.Errorf("chat session %s was projected as a pipeline card", hidden)
+		}
+	}
+	if findPipelineCard(t, projection.Cards, "run:run-manual").ColumnID != pipelineColumnInProgress {
+		t.Error("ordinary running run should keep its In-progress card")
+	}
+	if len(projection.Cards) != 1 {
+		t.Errorf("cards = %d, want exactly the ordinary run: %+v", len(projection.Cards), projection.Cards)
+	}
+}


### PR DESCRIPTION
## Summary

A run of a bot whose manifest declares a `chat:` surface (the assistant dock's Copi / Nexie) is a **conversation, not a pipeline**: the dock is its surface, and a session parks on a budget-free human turn for days — so every open Copi conversation was pinning an *In progress* card on `/pipelines`.

- The projection now skips such runs among the standalone roots; their children (a subbot a session spawned) stay folded under them and disappear with them.
- The rule is the **manifest block, never a bot id** (engine stays bot-agnostic): resolved through the same tiers as every other manifest read (platform override → catalog, `botManifest`), with a fallback on the manifest beside the run's workflow file for legacy runs stamped with no `bot_id`.
- Memoized per bot for the lifetime of one projection; anything unresolvable stays an ordinary card (the board never hides a run on a missing/malformed manifest).

## Test

`TestPipelineBoardHidesChatSessions` — a `chat:` bundle in the test catalog; a session resolved by `bot_id`, a legacy one resolved by file path, and a child of the session are all absent; the ordinary run keeps its card.

`go vet ./pkg/server/` + `go test ./pkg/server/` green.

## Not in this PR (observed)

A chat session is still a ROOT launch, so it takes one `--max-concurrent-pipelines` slot while it runs (`service_launch.go` `pipelineQueue.admitOrEnqueue` counts every parent-less launch). Worth a follow-up if open conversations start starving pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZMkgJjuS7CV79xhy4pREk
