### PR TITLE
fix(model): forward host-probed codex version into the sandboxed claw runner

### DIFF
--- a/docs/bot-runs/feature-dev.md
+++ b/docs/bot-runs/feature-dev.md
@@ -1,5 +1,72 @@
 # Featurly — `feature-dev` run bilans
 
+## 2026-08-27 — Plan phase cross-model LIVE: gpt-5.6-sol peer-reviews the plan, claude challenges and integrates (runs 01a04514 skip-path, 01a04520 full-path)
+
+- Status: **validated** (both plan-phase paths of ADR-091 proven live —
+  the review-succeeded chain AND the `action: skip` degrade)
+- Versions: bot 2.3.0 · iterion 9b9ab7c32 (v3.69.0) · first run since the
+  codex OAuth forfait landed on this host (2 credentialed families →
+  `plan_review` auto-resolved **on**, log `plan review: on` at launch)
+- Method: real feature off the board (native:293b9720 — ADR-042: surface
+  model pricing/max-output in ModelCapabilities), local run visible in the
+  studio store, `--merge-into none`, `--max-cost-usd 30 --max-duration 2h`,
+  default `sandbox: auto` (docker, slim image), Persy armed on `campaign`.
+- Result: **converged** in 1 pass. Chain proven end-to-end:
+  `plan_topology → plan` (ON path, no bypass) → plan authored by
+  claude_code opus (4m40, 22k tok) → **`plan_review` served by
+  `claw + openai/gpt-5.6-sol`** (13m, 31.8k tok, zero fallback,
+  `blocking: true`) → `plan_gate → plan_revise` **in the SAME claude
+  session as `plan`** (`e01607fb` on both `system/init` lines — the author
+  revises with full context) → campaign on a fresh session. Delivery:
+  7 commits on `iterion/run/01a04520…` (`efb37307`), verify gate green
+  (vet + tests + studio tsc/vitest + the OpenAPI-drift check the bot
+  authored into its own verify.sh), internal review clean, ADR-093
+  written. Cost ≈ $43 / 248k tok / ~1h45 — the **gpt peer review itself
+  billed $0 metered** (ChatGPT forfait wire).
+- Value: the peer review was REAL, grounded review — e.g. it caught that
+  copying `useEffortCapabilities`'s infinite `staleTime` would cache the
+  curated (price-less) cold-start response forever and permanently hide
+  the dynamic pricing the feature exists to surface, with exact
+  `file:line` citations; `plan_revise` verified the claim in code and
+  answered "ACCEPTED — Verified … Plan now derives staleTime from the
+  response's own `source`". Exactly the challenge-and-integrate flow the
+  feature was built for.
+- Findings / misses:
+  - Run 01a04514 (first attempt) proved the **skip path** live for free:
+    the peer call 400'd, the `give_up` route fired
+    (`model_fallback … to_action: skip`, output `_skipped:true`,
+    `_served_by: give_up`), `plan_gate` routed AROUND `plan_revise`, the
+    campaign continued on the unreviewed plan. #548's fleet-wide `skip`
+    default behaves as designed.
+  - My dogfood `--max-cost-usd 30` was too tight for a 7-slice feature:
+    campaign alone spent $32.6, the run died `BUDGET_EXCEEDED (38/30)` on
+    `verify_probe` (beyond the 1.1 grace) — but `failed_resumable` +
+    "raise cap + resume" recovered it exactly as documented, with all 7
+    commits banked in the worktree. Realistic floor for a real feature:
+    ≥ $50.
+- Engine hardening:
+  1. **The 400 behind the skip was an engine gap**: `gpt-5.6-sol requires
+     a newer version of Codex` — the sandboxed `__claw-runner` cannot
+     probe `codex --version` (no codex binary in the image) and only the
+     `ITERION_CODEX_VERSION` env var crossed the boundary (#553); the
+     HOST-probed version never did. Fixed in this PR
+     (`forwardableProviderEnv` forwards the host-resolved version through
+     the single env choke point, docker + k8s; red-first test). Cloud
+     runner pods still want `ITERION_CODEX_VERSION` set at the deployment
+     (docs/cloud-llm-credentials.md).
+  2. **`--merge-into none` is lost across `iterion resume`**: the merge
+     prefs are not persisted on run.json and `resume` rejects the flag,
+     so the resumed run finalized offering a merge into whatever branch
+     the operator had checked out MEANWHILE (an unrelated fix branch)
+     with `merge_status: pending` instead of the `none` ⇒ skip semantics.
+     Nothing merged (auto-merge off), but the recorded intent was
+     silently replaced — board finding filed.
+- Lessons for next run: budget a real feature ≥ $50; the peer review adds
+  ~13 min + ~32k tokens at $0 metered cost — cheap for what it caught;
+  when the checkout is shared with the operator, expect the branch under
+  you to move (commit early on YOUR branch, verify HEAD right before
+  `git switch -c`).
+
 ## 2026-08-27 — Persy A/B on a weakened campaign: first REAL intervention, obeyed within 37 seconds (runs 01a0434a OFF, 01a0435c ON)
 
 - Status: **validated** (the intervention half of Persy, live, with the

--- a/pkg/backend/model/claw_backend.go
+++ b/pkg/backend/model/claw_backend.go
@@ -1072,6 +1072,11 @@ var providerCredentialEnvVars = []string{
 	"ITERION_CODEX_VERSION",
 }
 
+// hostCodexVersion resolves the codex-cli version on the HOST side of the
+// sandbox boundary (env override, then `codex --version`). A var so tests
+// can stub the probe.
+var hostCodexVersion = codexCLIVersion
+
 // byokEnvVar names the environment variable claw's registry reads for a
 // provider's key inside the container. A provider absent here has no
 // env-based BYOK path, so a tenant key for it cannot be forwarded.
@@ -1102,6 +1107,18 @@ func forwardableProviderEnv(ctx context.Context) map[string]string {
 	for _, name := range providerCredentialEnvVars {
 		if v := os.Getenv(name); v != "" {
 			env[name] = v
+		}
+	}
+	// No ITERION_CODEX_VERSION override set: forward the HOST-resolved
+	// codex-cli version instead. The in-container runner cannot probe
+	// `codex --version` itself (the sandbox image ships no codex binary),
+	// so without a value crossing the boundary it falls back to claw's
+	// baked-in version string — which the ChatGPT-forfait backend refuses
+	// for newer models ("gpt-5.6-sol requires a newer version of Codex")
+	// even though the host's codex install is current.
+	if env["ITERION_CODEX_VERSION"] == "" {
+		if v := hostCodexVersion(); v != "" {
+			env["ITERION_CODEX_VERSION"] = v
 		}
 	}
 	creds, ok := secrets.CredentialsFromContext(ctx)

--- a/pkg/backend/model/claw_sandbox_env_test.go
+++ b/pkg/backend/model/claw_sandbox_env_test.go
@@ -81,3 +81,27 @@ func TestForwardableProviderEnv_forwardsCodexVersionOverride(t *testing.T) {
 		t.Errorf("ITERION_CODEX_VERSION = %q, want the ambient override forwarded", env["ITERION_CODEX_VERSION"])
 	}
 }
+
+// With NO operator override, the HOST-probed `codex --version` value must
+// cross the boundary instead. Measured live (run 01a04514, 2026-08-27): host
+// codex-cli 0.144.6 present, env unset → the in-container runner fell back
+// to claw's baked-in version and OpenAI 400'd gpt-5.6-sol ("requires a newer
+// version of Codex"), failing the plan_review node the host could serve.
+func TestForwardableProviderEnv_forwardsHostProbedCodexVersion(t *testing.T) {
+	t.Setenv("ITERION_CODEX_VERSION", "")
+	orig := hostCodexVersion
+	t.Cleanup(func() { hostCodexVersion = orig })
+
+	hostCodexVersion = func() string { return "0.144.6" }
+	env := forwardableProviderEnv(context.Background())
+	if env["ITERION_CODEX_VERSION"] != "0.144.6" {
+		t.Errorf("ITERION_CODEX_VERSION = %q, want the host-probed version forwarded when no override is set", env["ITERION_CODEX_VERSION"])
+	}
+
+	// No codex on the host either: forward nothing, never an empty pair.
+	hostCodexVersion = func() string { return "" }
+	env = forwardableProviderEnv(context.Background())
+	if v, ok := env["ITERION_CODEX_VERSION"]; ok {
+		t.Errorf("ITERION_CODEX_VERSION = %q set with nothing to forward — an empty value must not cross", v)
+	}
+}


### PR DESCRIPTION
## What

The sandbox image ships no codex binary, so the in-container `__claw-runner` cannot probe `codex --version` itself. Only the `ITERION_CODEX_VERSION` env var crossed the boundary (#553); with it unset, the runner fell back to claw's baked-in version string and OpenAI 400'd newer models — measured live on run `01a04520`'s predecessor: `gpt-5.6-sol requires a newer version of Codex` while the host's codex-cli 0.144.6 could serve it, failing the plan_review node.

`forwardableProviderEnv` (the single env choke point for the sandboxed claw runner, docker + k8s) now forwards the HOST-resolved version (operator override, then `codex --version`) when no override is set. Red-first test + mutation-verified; empty probe forwards nothing (never an empty pair).

Cloud runner pods without a codex install still want `ITERION_CODEX_VERSION` set at the deployment (docs/cloud-llm-credentials.md).

## Also

`docs/bot-runs/feature-dev.md`: the bilan of the plan-review cross-model dogfood (2026-08-27) that surfaced this — both ADR-091 plan-phase paths proven live (gpt-5.6-sol peer review grounded+blocking, same-session challenge-and-integrate, and the `action: skip` degrade), feature ADR-042 delivered on the storage branch, second friction filed as board `native:1284f4ae` (merge prefs lost across resume).

🤖 Generated with [Claude Code](https://claude.com/claude-code)