### PR TITLE
feat(queue): the run-level fallback route rides the wire to the pod

### DIFF
--- a/pkg/queue/types.go
+++ b/pkg/queue/types.go
@@ -75,17 +75,23 @@ import (
 // same-release roll of both — remains required; dual-accept removes only
 // the stranded-v8-message half of the window.)
 //
+// v=10 (2026-08-29): added Fallback so the operator's single run-level
+// fallback route (`--fallback` / launch `fallback`) reaches the runner.
+// Same failure direction as v=7: the server accepted the field and the
+// local executor honoured it, but the cloud path dropped it at publish —
+// so the one route meant to rescue a run from a provider's exhausted
+// usage window never fired precisely where runs park unattended.
+//
 // KNOWN DEBT: ModelOverrides shipped earlier inside v7 (427a9f44e) without a
 // version bump. A v7 runner built before that commit can silently ignore the
 // operator's model/backend pins. That historical gap cannot be repaired by a
 // later bump; the additive-intent rule above prevents repeating it.
-const SchemaVersion = 9
+const SchemaVersion = 10
 
 // MinSchemaVersion is the oldest wire version a consumer still accepts.
-// v8 → v9 is additive (absent BotBundle/SandboxImage simply mean "no stored
-// bundle, env-default image"), so a v8 payload decodes into exactly the
-// pre-v9 behaviour.
-const MinSchemaVersion = 8
+// v9 → v10 is additive (an absent Fallback simply means "no run-level
+// route"), so a v9 payload decodes into exactly the pre-v10 behaviour.
+const MinSchemaVersion = 9
 
 // RunMessage is the JSON envelope published on
 // `iterion.queue.runs`. The runner deserialises it, takes the
@@ -129,6 +135,15 @@ type RunMessage struct {
 	// display-only: the studio showed an override the delegates never
 	// honoured.
 	ModelOverrides []ModelOverride `json:"model_overrides,omitempty"`
+	// Fallback carries the operator's single run-level fallback route so
+	// the claiming runner APPLIES it to its executor (ir.ApplyRunFallback,
+	// same screen as a local launch) — the wire mirror of
+	// store.RunFallback, same doctrine as ModelOverrides above. Without
+	// this field the cloud path accepted the launch's `fallback` and
+	// dropped it at publish: the one route meant to rescue a run from an
+	// exhausted usage window never fired on the path where runs park
+	// unattended.
+	Fallback *RunFallback `json:"fallback,omitempty"`
 	// AutoMemory is the launch-time auto-memory (MEMORY.md) override — the
 	// wire half of the knob's strongest precedence level. Empty means the
 	// caller expressed nothing and the workflow/env decide.
@@ -255,6 +270,17 @@ type BudgetOverrides struct {
 // node id, id glob, kind keyword ("agent"|"judge"|…) or "*".
 type ModelOverride struct {
 	Selector string `json:"selector"`
+	Backend  string `json:"backend,omitempty"`
+	Model    string `json:"model,omitempty"`
+	Provider string `json:"provider,omitempty"`
+}
+
+// RunFallback is the operator's single run-level fallback route on the
+// wire — the queue twin of runview.FallbackEntry. Node targeting is not
+// carried: eligibility (agent nodes without their own `fallbacks:`,
+// never judges) is decided by ir.ApplyRunFallback on the consuming side,
+// identically for a local launch and a runner pod.
+type RunFallback struct {
 	Backend  string `json:"backend,omitempty"`
 	Model    string `json:"model,omitempty"`
 	Provider string `json:"provider,omitempty"`

--- a/pkg/queue/types_test.go
+++ b/pkg/queue/types_test.go
@@ -181,11 +181,15 @@ func TestSchemaVersionConstant(t *testing.T) {
 	// bump with a dual-accept window (MinSchemaVersion=8): the change is
 	// purely additive, so consumers take both and a rolling deploy has no
 	// rollout-ordering hazard.
-	if SchemaVersion != 9 {
-		t.Errorf("SchemaVersion = %d, want 9 (bump intentionally)", SchemaVersion)
+	// v=10 (2026-08-29) added Fallback — dropped, the run-level rescue
+	// route the launch declared never reaches the pod, and the run parks
+	// on the very provider wall the route exists to escape. Additive,
+	// same dual-accept window as v9 (MinSchemaVersion=9).
+	if SchemaVersion != 10 {
+		t.Errorf("SchemaVersion = %d, want 10 (bump intentionally)", SchemaVersion)
 	}
-	if MinSchemaVersion != 8 {
-		t.Errorf("MinSchemaVersion = %d, want 8", MinSchemaVersion)
+	if MinSchemaVersion != 9 {
+		t.Errorf("MinSchemaVersion = %d, want 9", MinSchemaVersion)
 	}
 }
 

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -1771,6 +1771,11 @@ func (r *Runner) executorSpec(ctx context.Context, msg *queue.RunMessage, wf *ir
 		// wire. Before this, the cloud path persisted them display-only:
 		// the studio showed an override the delegates never honoured.
 		ModelOverrides: modelOverridesFromMsg(msg.ModelOverrides),
+		// The operator's run-level fallback route, carried on the wire for
+		// the same reason as the pins above — and applied through the SAME
+		// ir.ApplyRunFallback screen a local launch passes, so a pod can
+		// never take a crossing the compiler would refuse.
+		RunFallback: runFallbackFromMsg(msg.Fallback),
 		// Inbox/AsyncAsk drain the run's queued messages into the agent's
 		// live turn — supervisor steering and operator chat both ride
 		// them. Every other launch surface binds these; without them the
@@ -1825,6 +1830,21 @@ func stringifyVars(in map[string]any) (map[string]string, error) {
 // set — the runner-side twin of runview's launch-entry fold, so a cloud
 // run resolves per-node models exactly like a local launch with the same
 // flags.
+// runFallbackFromMsg folds the wire route into the IR form the executor
+// applies. Name is stamped here (not on the wire) so every consumer
+// reports the route under the one recognisable launch-route label.
+func runFallbackFromMsg(f *queue.RunFallback) ir.Fallback {
+	if f == nil {
+		return ir.Fallback{}
+	}
+	return ir.Fallback{
+		Name:     ir.RunFallbackName,
+		Backend:  f.Backend,
+		Model:    f.Model,
+		Provider: f.Provider,
+	}
+}
+
 func modelOverridesFromMsg(entries []queue.ModelOverride) model.ModelOverrides {
 	var o model.ModelOverrides
 	for _, e := range entries {

--- a/pkg/runner/model_overrides_test.go
+++ b/pkg/runner/model_overrides_test.go
@@ -33,3 +33,17 @@ func TestModelOverridesFromMsg(t *testing.T) {
 		t.Fatal("an empty wire must fold into the zero override set")
 	}
 }
+
+// runFallbackFromMsg is the runner-side fold of the wire route into the
+// IR form ir.ApplyRunFallback screens — the run-level fallback twin of
+// modelOverridesFromMsg. The Name is stamped here so every consumer
+// reports the route under the recognisable launch-route label.
+func TestRunFallbackFromMsg(t *testing.T) {
+	f := runFallbackFromMsg(&queue.RunFallback{Backend: "codex", Model: "gpt-5.5", Provider: "openai"})
+	if f.Name != ir.RunFallbackName || f.Backend != "codex" || f.Model != "gpt-5.5" || f.Provider != "openai" {
+		t.Fatalf("folded route = %+v, want the wire fields under the run-fallback label", f)
+	}
+	if z := runFallbackFromMsg(nil); z.Name != "" || z.Backend != "" || z.Model != "" || z.Provider != "" {
+		t.Fatalf("nil wire route folded to %+v, want the zero route ApplyRunFallback ignores", z)
+	}
+}

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -870,6 +870,10 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 		// studio Overview reads the pins from the run doc, and the resume
 		// path replays them onto its RunMessage from here.
 		ModelOverrides: runModelOverrides(spec.ModelOverrides),
+		// The run-level fallback route, same doctrine: stamped raw so the
+		// resume path replays it, and mirrored onto the RunMessage below
+		// so the claiming runner applies it.
+		Fallback: runFallbackOf(spec.Fallback),
 		// The raw budget ask, same doctrine as the model pins above: the
 		// run doc is the single source the resume path replays from. The
 		// clamped/effective figure is NOT what is stamped — the resume
@@ -1010,6 +1014,11 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 		// doc is display-only — the studio would show an override the
 		// delegates never honoured.
 		ModelOverrides: queueModelOverrides(spec.ModelOverrides),
+		// The run-level fallback route rides the wire for the same reason:
+		// a route only persisted on the doc is display-only, and this one
+		// exists precisely for unattended cloud runs hitting a provider's
+		// usage window.
+		Fallback: queueFallbackOf(spec.Fallback),
 	}
 	if err := p.publish(ctx, msg); err != nil {
 		pubErr := fmt.Errorf("cloudpublisher: publish: %w", err)
@@ -1253,6 +1262,10 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 		// A resumed attempt must honour the SAME pins the launch declared —
 		// replayed from the run doc, the single source the launch stamped.
 		ModelOverrides: queueOverridesFromRun(prior.ModelOverrides),
+		// The fallback route is replayed from the doc for the same reason:
+		// the auto-retry that follows a usage-window park is exactly the
+		// publication that must still carry the rescue route.
+		Fallback: queueFallbackFromRun(prior.Fallback),
 		// Carry the prior run's tenant onto the resume publication so
 		// the runner re-acquires the lease in the right scope. We trust
 		// the loaded prior doc rather than ctx: a super-admin resuming
@@ -1638,6 +1651,33 @@ func budgetOverridesFromRun(o *store.RunBudgetOverrides) *ir.BudgetOverrides {
 		MaxIterations:       o.MaxIterations,
 		MaxParallelBranches: o.MaxParallelBranches,
 	}
+}
+
+// runFallbackOf converts the launch's run-level fallback route into the
+// persisted run-doc form (the resume path's replay source). Targetless
+// entries persist as nil so override-less launches stay byte-identical.
+func runFallbackOf(e *runview.FallbackEntry) *store.RunFallback {
+	if e == nil || (e.Backend == "" && e.Model == "" && e.Provider == "") {
+		return nil
+	}
+	return &store.RunFallback{Backend: e.Backend, Model: e.Model, Provider: e.Provider}
+}
+
+// queueFallbackOf puts the launch's run-level fallback route on the wire.
+func queueFallbackOf(e *runview.FallbackEntry) *queue.RunFallback {
+	if e == nil || (e.Backend == "" && e.Model == "" && e.Provider == "") {
+		return nil
+	}
+	return &queue.RunFallback{Backend: e.Backend, Model: e.Model, Provider: e.Provider}
+}
+
+// queueFallbackFromRun replays a run doc's persisted fallback route onto
+// a resume publication.
+func queueFallbackFromRun(f *store.RunFallback) *queue.RunFallback {
+	if f == nil {
+		return nil
+	}
+	return &queue.RunFallback{Backend: f.Backend, Model: f.Model, Provider: f.Provider}
 }
 
 // queueOverridesFromRun replays a run doc's persisted pins onto a resume

--- a/pkg/server/cloudpublisher/publisher_fallback_test.go
+++ b/pkg/server/cloudpublisher/publisher_fallback_test.go
@@ -1,0 +1,122 @@
+package cloudpublisher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// The operator's run-level fallback route must ride the cloud wire AND
+// land on the run doc: the runner builds its own executor, so a route
+// the server accepted but never published is a rescue the studio implies
+// and the pod never takes — on exactly the path (unattended cloud runs
+// hitting a provider's usage window) the route exists for. Falsified
+// both ways: the route travels to both carriers; a routeless launch
+// publishes byte-identical messages (nil field); a resume replays the
+// run doc's route.
+
+func TestSubmitLaunchCarriesRunFallback(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	var published *queue.RunMessage
+	p := &Publisher{
+		store: st,
+		publishRun: func(_ context.Context, m *queue.RunMessage) error {
+			published = m
+			return nil
+		},
+	}
+	ctx := store.WithIdentity(context.Background(), "team-a", "u1")
+	wf := &ir.Workflow{Name: "wf"}
+	spec := runview.LaunchSpec{
+		FilePath: "wf.bot",
+		Source:   "workflow wf:\n  start -> done\n",
+		Fallback: &runview.FallbackEntry{Backend: "codex", Model: "gpt-5.5"},
+	}
+	if _, err := p.SubmitLaunch(ctx, "run-fb-1", spec, wf, "hash"); err != nil {
+		t.Fatalf("SubmitLaunch: %v", err)
+	}
+	if published == nil {
+		t.Fatal("nothing published")
+	}
+	if published.Fallback == nil || *published.Fallback != (queue.RunFallback{Backend: "codex", Model: "gpt-5.5"}) {
+		t.Fatalf("message fallback = %+v, want the launch route verbatim", published.Fallback)
+	}
+	r, err := st.LoadRun(ctx, "run-fb-1")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.Fallback == nil || r.Fallback.Backend != "codex" || r.Fallback.Model != "gpt-5.5" {
+		t.Fatalf("run doc fallback = %+v, want the route persisted for the resume replay", r.Fallback)
+	}
+}
+
+func TestSubmitLaunchWithoutFallbackPublishesNone(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	var published *queue.RunMessage
+	p := &Publisher{
+		store: st,
+		publishRun: func(_ context.Context, m *queue.RunMessage) error {
+			published = m
+			return nil
+		},
+	}
+	ctx := store.WithIdentity(context.Background(), "team-a", "u1")
+	wf := &ir.Workflow{Name: "wf"}
+	spec := runview.LaunchSpec{FilePath: "wf.bot", Source: "workflow wf:\n  start -> done\n"}
+	if _, err := p.SubmitLaunch(ctx, "run-fb-2", spec, wf, "hash"); err != nil {
+		t.Fatalf("SubmitLaunch: %v", err)
+	}
+	if published == nil || published.Fallback != nil {
+		t.Fatalf("routeless launch published %+v, want nil (older consumers stay byte-identical)", published.Fallback)
+	}
+	if r, _ := st.LoadRun(ctx, "run-fb-2"); r != nil && r.Fallback != nil {
+		t.Fatalf("routeless launch persisted %+v, want none", r.Fallback)
+	}
+}
+
+func TestSubmitResumeReplaysRunDocFallback(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	ctx := store.WithIdentity(context.Background(), "team-a", "u1")
+	const runID = "run-fb-resume"
+	if err := st.SaveRun(ctx, &store.Run{
+		ID:       runID,
+		TenantID: "team-a",
+		OwnerID:  "u1",
+		Status:   store.RunStatusFailedResumable,
+		Fallback: &store.RunFallback{Backend: "codex", Model: "gpt-5.5"},
+	}); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	var published *queue.RunMessage
+	p := &Publisher{
+		store: st,
+		publishRun: func(_ context.Context, m *queue.RunMessage) error {
+			published = m
+			return nil
+		},
+	}
+	wf := &ir.Workflow{Name: "wf"}
+	spec := runview.ResumeSpec{RunID: runID, FilePath: "wf.bot", Source: "workflow wf:\n  entry: done\n"}
+	if err := p.SubmitResume(ctx, spec, wf, "hash"); err != nil {
+		t.Fatalf("SubmitResume: %v", err)
+	}
+	if published == nil {
+		t.Fatal("nothing published")
+	}
+	if published.Fallback == nil || *published.Fallback != (queue.RunFallback{Backend: "codex", Model: "gpt-5.5"}) {
+		t.Fatalf("resume fallback = %+v, want the launch route replayed from the run doc — the auto-retry after a usage-window park is exactly the publication that must still carry the rescue", published.Fallback)
+	}
+}

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -105,6 +105,14 @@ type RunModelOverride struct {
 	Provider string `json:"provider,omitempty" bson:"provider,omitempty"`
 }
 
+// RunFallback is the persisted form of the launch's run-level fallback
+// route — the doc twin of queue.RunFallback.
+type RunFallback struct {
+	Backend  string `json:"backend,omitempty" bson:"backend,omitempty"`
+	Model    string `json:"model,omitempty" bson:"model,omitempty"`
+	Provider string `json:"provider,omitempty" bson:"provider,omitempty"`
+}
+
 // NodeServed is the (backend, model) that actually served one LLM node.
 // Last write wins per node_id — a loop's last pass is what a finished
 // run.json reports; the event stream is the full history.
@@ -284,6 +292,13 @@ type Run struct {
 	// executor at launch, never re-read from here. Empty when none, and
 	// left untouched on resume (resume doesn't re-supply them).
 	ModelOverrides []RunModelOverride `json:"model_overrides,omitempty" bson:"model_overrides,omitempty"`
+	// Fallback captures the launch-time run-level fallback route (CLI
+	// `--fallback` / HTTP `fallback`) — the resume path's replay source,
+	// same doctrine as the budget ask: cloud resumes are often unattended
+	// auto-retries, so nothing else can re-state the route, and a dropped
+	// route silently strands the run on exactly the provider wall it was
+	// meant to escape.
+	Fallback *RunFallback `json:"fallback,omitempty" bson:"fallback,omitempty"`
 	// NodesServed maps IR node id → last (backend, model) that served
 	// it. Display-only / post-hoc: makes a finished run self-describing
 	// without replaying events.jsonl. Empty for legacy runs and for


### PR DESCRIPTION
## What

The launch API accepts `fallback` (the operator's single run-level rescue route, ADR-087) and the local executor honours it — but the cloud publisher dropped it at publish: no RunMessage field, no run-doc stamp, no resume replay. The route meant to rescue a run from a provider's exhausted usage window never fired precisely on the path where runs park unattended.

**Measured**: on one campaign, two runs lost 72–85% of their wall-clock to usage-window parking that a declared `fallback: codex` route would have bypassed (the default trigger set is exactly `usage_window` + `unavailable`).

## How

Same doctrine and same three carriers as the model pins (#513) and the budget ask (#554):

- **run doc** at launch (`store.RunFallback`) — the resume path's replay source;
- **RunMessage** (`queue.RunFallback`, schema **v9 → v10**, additive, dual-accept `MinSchemaVersion=9`);
- **resume replay** from the doc — the auto-retry that follows a usage-window park is exactly the publication that must still carry the rescue.

The runner folds the wire route into `ir.ApplyRunFallback`'s screen (agent nodes without their own `fallbacks:`, never judges, same safety predicates), so a pod can never take a crossing the compiler would refuse locally.

## Falsified

- `TestSubmitLaunchCarriesRunFallback` / `WithoutFallbackPublishesNone` / `TestSubmitResumeReplaysRunDocFallback` (mirror of the #513 suite); mutant `Fallback: nil` at the wire stamp → red, restored → green.
- `TestRunFallbackFromMsg` (runner fold, label stamped).
- Schema sentinel updated intentionally (`TestSchemaVersionConstant` want 10/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)