### PR TITLE
fix(feed-watch): size the marker reserve from the marker, and refuse the queue on a truncated digest

### DIFF
--- a/bots/feed-watch/main.bot
+++ b/bots/feed-watch/main.bot
@@ -1324,6 +1324,9 @@ tool notify:
             # LAST part now carries. Re-trim that one part rather than
             # reserving 64 chars on EVERY part, which would shrink the whole
             # digest to pay for a marker only one message ever gets.
+            room = limit - len(mark_for(len(parts), len(parts), True)) - 2
+            if room > 0 and len(parts[-1]) > room:
+                parts[-1] = parts[-1][:room].rstrip()
         if len(parts) == 1 and not cut:
             return parts
         n = len(parts)
@@ -1420,7 +1423,7 @@ tool notify:
     # queue would be consumed for items whose text never left. The channel
     # only sees a notice pointing at run artifacts its readers cannot open.
     # Same rule as a partial delivery: content dropped => do not consume.
-    if delivered < len(plans):
+    if delivered < len(plans) or truncated_limits:
         print(json.dumps({'posted': False, 'dry_run': False, 'delivered': delivered,
                           'targets': targets, 'parts': parts_max, 'posts': posts_ok,
                           'truncated': bool(truncated_limits)},

--- a/bots/feed-watch/main.bot
+++ b/bots/feed-watch/main.bot
@@ -425,7 +425,9 @@ schema notify_output:
   dry_run: bool
   targets: string[]
   summary: string
-  ## Messages the digest occupies on the widest sink (1 = it fit).
+  ## The most messages the digest occupies on any sink (1 = it fit
+  ## everywhere). That is the sink with the NARROWEST budget: a smaller
+  ## max_chars means more parts.
   parts: int
   ## Individual POSTs that succeeded, all sinks and parts counted. The
   ## delivery evidence `delivered` cannot carry: a sink that took 2 of 3
@@ -1197,10 +1199,17 @@ tool verify_message:
 
 ## Deterministic delivery (no LLM at the last step — a provider
 ## rate-limit cannot sink a finished digest). Posts to every configured
-## sink; a PARTIAL failure is surfaced in the output but does not fail
-## the run (a retry would double-post what already landed); a TOTAL
-## failure — not one POST accepted anywhere — fails the run loudly (safe
-## to resume, nothing was delivered).
+## sink.
+##
+## `posted` is NOT "something went out": it is the QUEUE-CONSUMPTION signal
+## (`notify -> commit_state when posted`), and commit_state clears the
+## delivered snapshots from pending.jsonl. So it is true only when every
+## sink received the digest WHOLE. Anything less — a sink that failed, a
+## sink that got parts 1..k of n, or a digest the max_messages ceiling
+## truncated — fails the run loudly with the queue INTACT. The successful
+## posts are reported on stderr; the replay may duplicate what already
+## landed, and that is the deliberate trade: a duplicate is recoverable, a
+## dropped digest is not.
 ##
 ## A digest longer than the sink's per-message budget is SPLIT into
 ## consecutive messages, never cut: the channel is the digest's only
@@ -1223,9 +1232,18 @@ tool notify:
     max_messages = int({{input.max_messages}} or 0)
     webhooks_file = {{secrets.webhooks.path}}
 
-    # Room for the blank line + '_(i/n)_' marker appended to every part of
-    # a split digest, so a part plus its marker still fits the budget.
-    MARK_RESERVE = 32
+    # The notice the LAST part carries when max_messages cut the tail off.
+    TRUNC_NOTE = ' -- digest truncated, full version in the run artifacts'
+
+    def mark_for(i, n, cut):
+        return '_(' + str(i) + '/' + str(n) + (TRUNC_NOTE if cut else '') + ')_'
+
+    # Room for the blank line + the marker appended to every part of a split
+    # digest. DERIVED from the longest marker a part can carry (the truncation
+    # notice, three-digit counts) rather than guessed: a reserve smaller than
+    # the marker it reserves for puts the last message OVER the budget the
+    # budget exists to respect.
+    MARK_RESERVE = len(chr(10) + chr(10) + mark_for(999, 999, True))
 
     def out(o):
         print(json.dumps(o, ensure_ascii=False))
@@ -1287,6 +1305,11 @@ tool notify:
             parts[i + 1] = moved + sep + parts[i + 1]
         return parts
 
+    # Budgets whose rendering DROPPED content (the max_messages ceiling).
+    # Visible outside messages_for because truncation, like a partial
+    # delivery, must forbid consuming the queue.
+    truncated_limits = set()
+
     def messages_for(limit):
         """The digest as it will be posted to a sink of budget `limit`:
         one entry when it fits, else numbered parts, the last one carrying
@@ -1294,16 +1317,19 @@ tool notify:
         parts = split_text(message or '', max(limit - MARK_RESERVE, 1))
         cut = max_messages > 0 and len(parts) > max_messages
         if cut:
+            truncated_limits.add(limit)
             parts = parts[:max_messages]
+            # Every part was sized against MARK_RESERVE, which covers the
+            # plain `_(i/n)_` marker — not the 62-char truncation notice the
+            # LAST part now carries. Re-trim that one part rather than
+            # reserving 64 chars on EVERY part, which would shrink the whole
+            # digest to pay for a marker only one message ever gets.
         if len(parts) == 1 and not cut:
             return parts
         n = len(parts)
         msgs = []
         for i, part in enumerate(parts, 1):
-            mark = '_(' + str(i) + '/' + str(n) + ')_'
-            if cut and i == n:
-                mark = '_(' + str(i) + '/' + str(n) + ' -- digest truncated, full version in the run artifacts)_'
-            msgs.append(part + chr(10) + chr(10) + mark)
+            msgs.append(part + chr(10) + chr(10) + mark_for(i, n, cut and i == n))
         return msgs
 
     if not sinks:
@@ -1388,12 +1414,22 @@ tool notify:
     # NOT consume, and fail LOUDLY so the stuck half is visible. The replay
     # may duplicate what already landed; a duplicate is recoverable, a lost
     # digest is not.
+    # Truncation is the THIRD way this node can drop content, and it is the
+    # quietest: the ceiling removes the tail parts BEFORE any POST, so every
+    # sink reports a complete send, `delivered` reaches len(plans), and the
+    # queue would be consumed for items whose text never left. The channel
+    # only sees a notice pointing at run artifacts its readers cannot open.
+    # Same rule as a partial delivery: content dropped => do not consume.
     if delivered < len(plans):
         print(json.dumps({'posted': False, 'dry_run': False, 'delivered': delivered,
-                          'targets': targets, 'parts': parts_max, 'posts': posts_ok},
+                          'targets': targets, 'parts': parts_max, 'posts': posts_ok,
+                          'truncated': bool(truncated_limits)},
                          ensure_ascii=False), file=sys.stderr)
-        raise SystemExit('feed-watch: only ' + str(delivered) + '/' + str(len(plans)) +
-                         ' sink(s) received the COMPLETE digest (' + str(posts_ok) +
+        why = ('the digest was TRUNCATED by the max_messages ceiling (' + str(max_messages) +
+               '), so part of it never left' if truncated_limits
+               else 'only ' + str(delivered) + '/' + str(len(plans)) +
+                    ' sink(s) received the COMPLETE digest')
+        raise SystemExit('feed-watch: ' + why + ' (' + str(posts_ok) +
                          ' post(s) ok) -- the queue is NOT consumed, so this digest replays in '
                          'full on the next run and may duplicate what already landed. ' +
                          '; '.join(failures))

--- a/bots/feed-watch/skills/notify-webhooks.md
+++ b/bots/feed-watch/skills/notify-webhooks.md
@@ -55,24 +55,25 @@ never appear in the repo, in prompts, or in logs.
   every item.
 - **no sinks configured** — not an error; the digest stays in the run
   artifacts (report-only mode). Queue kept, same rule.
-- **partial failure** (some sinks 2xx, some not) — the run SUCCEEDS
-  and the failures are listed in the notify output summary. Rationale:
-  failing the run would re-post to the sinks that already delivered on
-  resume (duplicates are worse than a visible partial). The queue is
-  consumed all the same, so a sink that is broken rather than flaky
-  loses one digest per run, quietly, until someone reads a summary.
-  Re-post from `<state_dir>/<category>/digests/*.md` once it is fixed.
 - **partial failure WITHIN a sink** (parts 1–2 of 3 delivered) — that
   sink stops there: posting part 3 over a missing part 2 leaves a hole
-  no reader can detect. It does not count in `delivered` (which means
-  *sinks that got the whole digest*) and the failed part is named in
-  the summary (`w1 part 2/3: …`).
-- **total failure** (not one POST accepted, anywhere) — the run FAILS
-  (failed_resumable). Nothing was delivered, so `iterion resume` is
-  safe and will re-attempt delivery. The guard is the `posts` count,
-  **not** `delivered`: once a digest can span several messages, "no
-  sink got all of it" no longer means "nothing was posted", and
-  resuming there would re-post what already landed.
+  no reader can detect. It does not count in `delivered`, which means
+  *sinks that got the whole digest*.
+- **partial failure** (a sink did not get the digest whole — some parts
+  refused, or one sink of several down) — the run **FAILS**
+  (failed_resumable) and the queue is **not** consumed, so the digest
+  replays in full next run. The replay may duplicate what already
+  landed on a healthy sink; that is the deliberate trade — a duplicate
+  is recoverable, a digest dropped from the queue is not.
+- **total failure** (not one POST accepted, anywhere) — same: the run
+  FAILS, nothing is consumed, `iterion resume` re-attempts delivery.
+
+`posted` is the **queue-consumption signal**, not "something went out":
+it takes the `notify -> commit_state when posted` edge, and commit_state
+clears the digested snapshots from `pending.jsonl`. So it is true only
+when EVERY sink received the whole digest. Anything less raises, loudly,
+naming the sinks and parts that failed — the alternative is a run that
+ends green having permanently dropped what it never delivered.
 
 ## Troubleshooting a missing digest
 

--- a/e2e/feed_watch_test.go
+++ b/e2e/feed_watch_test.go
@@ -880,13 +880,19 @@ func TestFeedWatch_NotifySplitsLongDigest(t *testing.T) {
 		}
 	})
 
-	t.Run("max_messages ceiling truncates the tail, and says so", func(t *testing.T) {
+	// Truncation is the quietest way this node can drop content: the ceiling
+	// removes the tail parts BEFORE any POST, so every sink reports a
+	// complete send and the queue would be consumed for items whose text
+	// never left. The channel only sees a notice pointing at run artifacts
+	// its readers cannot open. What fits is still posted — but the run must
+	// FAIL so the queue survives and the items are re-digested.
+	t.Run("max_messages ceiling posts what fits, says so, and keeps the queue", func(t *testing.T) {
 		msg := longDigest(20)
 		sinks := []any{map[string]any{"webhook": "w1", "channel": "#demo"}}
 		sink := newNotifySink()
-		out, err := run(t, msg, sinks, 1200, 2, sink)
-		if err != nil {
-			t.Fatalf("notify failed: %v", err)
+		_, err := run(t, msg, sinks, 1200, 2, sink)
+		if err == nil {
+			t.Fatal("a truncated digest must not report success — the queue would be consumed for items that never left")
 		}
 		got := sink.texts("#demo")
 		if len(got) != 2 {
@@ -898,8 +904,36 @@ func TestFeedWatch_NotifySplitsLongDigest(t *testing.T) {
 		if strings.Contains(got[0], "digest truncated") {
 			t.Fatal("only the LAST message announces the truncation")
 		}
-		if int(out["parts"].(float64)) != 2 {
-			t.Fatalf("parts must reflect what was posted: %v", out["parts"])
+	})
+
+	// The capped last message carries the LONGEST marker there is (the
+	// truncation notice). A reserve sized for the ordinary "_(i/n)_" puts it
+	// over the budget — and the budget exists to stay under the platform's
+	// hard post limit, so that POST is the one the platform rejects.
+	// The input is a single unbroken line on purpose: only the hard-cut path
+	// packs a part to exactly `limit - reserve`, where the shortfall shows.
+	// Block-separated text leaves slack that hides it.
+	t.Run("no message exceeds the budget, marker included", func(t *testing.T) {
+		msg := strings.Repeat("x", 9000)
+		sinks := []any{map[string]any{"webhook": "w1", "channel": "#demo"}}
+		sink := newNotifySink()
+		// Truncation keeps the queue, so this run fails by design; what is
+		// under test is what reached the channel before it did.
+		if _, err := run(t, msg, sinks, 1200, 3, sink); err == nil {
+			t.Fatal("a truncated digest must not report success")
+		}
+		got := sink.texts("#demo")
+		if len(got) != 3 {
+			t.Fatalf("expected 3 capped messages, got %d", len(got))
+		}
+		if !strings.Contains(got[2], "digest truncated") {
+			t.Fatalf("the capped tail must be announced: %q", tail(got[2]))
+		}
+		for i, m := range got {
+			if len(m) > 1200 {
+				t.Fatalf("message %d/%d is %d chars, over the 1200 budget: %q",
+					i+1, len(got), len(m), tail(m))
+			}
 		}
 	})
 


### PR DESCRIPTION
Follow-up to #570, which merged before these two fixes landed.

## R79a75e [medium] — the reserve was smaller than the marker it reserves for

`MARK_RESERVE` was `32` while the truncation notice the last capped part
carries is 64 chars, so a ceiling-truncated digest overshot the very budget
the reserve exists to respect: at `limit=1200` the last message measured
**1232**. An operator who sets a sink's `max_chars` to the platform's own
limit gets that POST rejected — losing precisely the notice saying the digest
was cut.

The reserve is now **derived** from the longest marker (`mark_for(999, 999,
True)`), so it cannot drift again when the notice is reworded, and the marker
is built in one place instead of two.

The regression test uses a single unbroken line on purpose: only the hard-cut
path packs a part to exactly `limit - reserve`, where the shortfall shows.
Block-separated text leaves slack that hides it — the first version of this
assertion passed against the bug for that reason, which is why it is written
this way.

## Truncation is the third way to drop content

`posted` is the queue-consumption signal (`notify -> commit_state when
posted`). #570 closed two ways of dropping content while reporting success (a
sink that failed, a sink that got parts 1..k of n); a digest the
`max_messages` ceiling truncated is the third, and it consumed the queue for
items that never left. Same predicate, same loud failure, queue intact.

## Doc alignment

`skills/notify-webhooks.md` still described the pre-#570 semantics ("partial
failure — the run SUCCEEDS", "the queue is consumed all the same") — the exact
opposite of what `notify` now does. A skill an agent reads that contradicts
the code is worse than no skill. Also: `notify_output.parts` documented "the
widest sink", but `parts_max` is a max over sinks, so it is the *narrowest*
budget that produces it (one of Revi's open questions on #570).

Verified: `iterion validate`, `go test ./e2e -run TestFeedWatch`, `task lint`,
each fix falsified by reintroducing the bug first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)