### PR TITLE
fix(gate): the sweep's last pass over a stuck run must be visible at info

### DIFF
--- a/pkg/server/forge_gate_lastpass_test.go
+++ b/pkg/server/forge_gate_lastpass_test.go
@@ -1,0 +1,130 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// abstainingSweepFixture builds a run that owes a gate verdict but whose
+// publish grant cannot be resolved — the reconciler's first abstain branch,
+// and the shape of a run stuck in a PERMANENT abstain: every sweep pass walks
+// the same branch and declines, for the whole lookback, then never again.
+//
+// The logger is pinned at warn, which is the level deployments run at (prod
+// carries ITERION_LOG_LEVEL=info). Anything the code emits below that is not
+// "quiet", it is ABSENT — which is the property under test.
+func abstainingSweepFixture(t *testing.T) (*Server, string, *bytes.Buffer) {
+	t.Helper()
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	s := newForgeGateTestServer(t, st)
+	logs := &bytes.Buffer{}
+	s.logger = iterlog.New(iterlog.LevelWarn, logs)
+
+	inputs := gatingInputs()
+	inputs[forgePublishVarToken] = "tok-never-registered"
+	const runID = "run-stuck"
+	if _, err := st.CreateRun(context.Background(), runID, "review_pr", inputs); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	return s, runID, logs
+}
+
+// runUpdatedAt is the instant the sweep's lookback is measured from.
+func runUpdatedAt(t *testing.T, s *Server, runID string) time.Time {
+	t.Helper()
+	run, err := s.cfg.Store.LoadRun(context.Background(), runID)
+	if err != nil || run == nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if run.UpdatedAt.IsZero() {
+		t.Fatal("run carries no UpdatedAt — the sweep window cannot be measured from it")
+	}
+	return run.UpdatedAt
+}
+
+// While the net is still trying, a stuck check is not news: the sweep re-offers
+// the same run every minute and would otherwise emit ~60 identical lines an
+// hour, per replica, burying the branches that carry new information.
+func TestGateSweepAbstain_StaysQuietWhileTheNetIsStillTrying(t *testing.T) {
+	s, runID, logs := abstainingSweepFixture(t)
+	at := runUpdatedAt(t, s, runID)
+	s.gateClock = func() time.Time { return at.Add(2 * gateSweepInterval) }
+
+	if err := s.reconcileGateForRunID(context.Background(), runID, gateTriggerSweep); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if logs.Len() != 0 {
+		t.Fatalf("an early sweep pass must not log above debug, got: %s", logs)
+	}
+}
+
+// The last pass is the one that matters: past the lookback the run leaves the
+// candidate window and NOTHING revisits it, so whatever the reconciler
+// abstained on becomes permanent. Before this, the whole sweep history was
+// Debug — suppressed at info — so a pull request blocked for 22 hours behind an
+// unanswered required check left no line anywhere naming the reason.
+func TestGateSweepAbstain_LastPassNamesTheReasonAndThePermanence(t *testing.T) {
+	s, runID, logs := abstainingSweepFixture(t)
+	at := runUpdatedAt(t, s, runID)
+	s.gateClock = func() time.Time { return at.Add(gateSweepLookback - gateSweepInterval) }
+
+	if err := s.reconcileGateForRunID(context.Background(), runID, gateTriggerSweep); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	out := logs.String()
+	if out == "" {
+		t.Fatal("the last sweep pass over a stuck run must be visible at warn — it is the only chance to name why the check stays unanswered")
+	}
+	for _, want := range []string{
+		runID,                            // WHICH run owes the verdict
+		"https://github.com/o/r/pull/42", // WHICH pull request is waiting
+		"publish grant is expired",       // WHY it posts nothing
+		"last sweep pass",                // that the miss is now permanent
+		"stays unanswered",               //
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("last-pass warning does not carry %q, got: %s", want, out)
+		}
+	}
+}
+
+// The event path fires once per run and has always warned; the last-pass rule
+// must not silence it. A run offered by the event before the window is old is
+// exactly the ordinary case, and it is the FIRST notice an operator gets.
+func TestGateAbstain_EventPathWarnsRegardlessOfWindowAge(t *testing.T) {
+	s, runID, logs := abstainingSweepFixture(t)
+	at := runUpdatedAt(t, s, runID)
+	s.gateClock = func() time.Time { return at.Add(time.Second) }
+
+	if err := s.reconcileGateForRunID(context.Background(), runID, gateTriggerEvent); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if !strings.Contains(logs.String(), "publish grant is expired") {
+		t.Fatalf("the event path must warn on the first abstain, got: %s", logs)
+	}
+	if strings.Contains(logs.String(), "last sweep pass") {
+		t.Fatalf("the event path is not a sweep pass and must not claim to be the last one, got: %s", logs)
+	}
+}
+
+// A run with no UpdatedAt cannot be placed in the window at all. Treating that
+// as "the last pass" would warn on EVERY pass for such a run — the volume this
+// whole rule exists to avoid.
+func TestGateSweepIsLastPass_UndatableRunIsNeverTheLastPass(t *testing.T) {
+	s := &Server{}
+	if s.gateSweepIsLastPass(nil) {
+		t.Error("a nil run must not be reported as the last pass")
+	}
+	if s.gateSweepIsLastPass(&store.Run{}) {
+		t.Error("a run with no UpdatedAt must not be reported as the last pass")
+	}
+}

--- a/pkg/server/forge_gate_reconcile.go
+++ b/pkg/server/forge_gate_reconcile.go
@@ -206,21 +206,30 @@ func (s *Server) reconcileGateForRunID(ctx context.Context, runID, via string) e
 	// that never gated anything. Naming the reason is what makes the next
 	// occurrence a grep instead of an investigation.
 	//
-	// Warn on the EVENT path only. The sweep re-offers the same run every
-	// minute for the whole lookback, so a run sitting in a permanent abstain
-	// branch — a lost grant, an unreachable forge — would log the identical
-	// line ~60 times an hour per replica and bury the branches that carry new
-	// information, defeating the point of naming the reason at all. The event
-	// fires once per run, which is exactly one line per occurrence.
+	// Warn on the EVENT path, and on the sweep's LAST pass over this run.
+	// The sweep re-offers the same run every minute for the whole lookback, so
+	// a run sitting in a permanent abstain branch — a lost grant, an
+	// unreachable forge — would log the identical line ~60 times an hour per
+	// replica and bury the branches that carry new information. But Debug is
+	// suppressed at the info level deployments run at, so those passes said
+	// NOTHING at all: the one Warn the event path emits dies with the pod, and
+	// a check stuck for a day leaves nothing to diagnose it with. The last
+	// pass is the one that matters anyway — past the lookback nothing revisits
+	// the run and the miss becomes permanent — so it speaks, once.
 	abstain := func(format string, args ...any) error {
-		if s.logger != nil {
-			msg := "forge gate: run %s (via %s) held a grant on %s but posts nothing: " + format
-			args = append([]any{runID, via, prURL}, args...)
-			if via == gateTriggerSweep {
-				s.logger.Debug(msg, args...)
-			} else {
-				s.logger.Warn(msg, args...)
-			}
+		if s.logger == nil {
+			return nil
+		}
+		msg := "forge gate: run %s (via %s) held a grant on %s but posts nothing: " + format
+		args = append([]any{runID, via, prURL}, args...)
+		switch {
+		case via != gateTriggerSweep:
+			s.logger.Warn(msg, args...)
+		case s.gateSweepIsLastPass(run):
+			s.logger.Warn(msg+" — this was the last sweep pass inside the "+
+				gateSweepLookback.String()+" window: nothing will offer this run again, so the check it owes stays unanswered until a human acts", args...)
+		default:
+			s.logger.Debug(msg, args...)
 		}
 		return nil
 	}

--- a/pkg/server/forge_gate_sweeper.go
+++ b/pkg/server/forge_gate_sweeper.go
@@ -140,3 +140,31 @@ func (s *Server) sweepGates(ctx context.Context, lister gateSweepLister, now tim
 	s.warnf("merge-gate sweeper: stopped after %d pages of %d — the oldest candidates in the %s window were not examined this pass",
 		gateSweepMaxPages, gateSweepBatch, gateSweepLookback)
 }
+
+// gateSweepIsLastPass reports whether this pass is among the final ones that
+// will ever offer the run to the reconciler. Candidacy is bounded by
+// gateSweepLookback on the run's own updated_at, so once that much time has
+// passed the run leaves the window and NOTHING revisits it — whatever the
+// reconciler abstained on becomes permanent.
+//
+// That instant is the only one worth a Warn out of ~60 identical passes: a
+// stuck check is not news while the net is still trying, and is news the
+// moment the net gives up. The margin is two intervals so a late or skipped
+// pass does not swallow the only line that names the reason (2026-08-29: a
+// pull request sat behind an unanswered required check for 22h and the whole
+// sweep history had been Debug, which deployments suppress at info level).
+func (s *Server) gateSweepIsLastPass(run *store.Run) bool {
+	if run == nil || run.UpdatedAt.IsZero() {
+		return false
+	}
+	return s.gateNow().Sub(run.UpdatedAt) >= gateSweepLookback-2*gateSweepInterval
+}
+
+// gateNow reads the wall clock the gate sweeper judges its window by,
+// overridable in tests (mirrors scheduleClock).
+func (s *Server) gateNow() time.Time {
+	if s != nil && s.gateClock != nil {
+		return s.gateClock()
+	}
+	return time.Now().UTC()
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -209,6 +209,10 @@ type Server struct {
 	// deterministic instant to assert NextFire jumps to the expected slot).
 	// nil → time.Now().UTC().
 	scheduleClock func() time.Time
+	// gateClock overrides the wall clock the merge-gate sweeper measures its
+	// lookback window by (test seam — a test cannot wait an hour to reach the
+	// last pass over a run). nil → time.Now().UTC().
+	gateClock func() time.Time
 	// webhookNoteGate overrides the conversational replier gate (forge
 	// token + loop-guard + reply-in-thread detection + allowlist/role authz
 	// — test seam, the real gate calls the GitLab API). nil →


### PR DESCRIPTION
## The defect

A run that owes a merge-gate verdict and declines to post one logs its reason at `Debug` on the sweep path — deliberately, so the ~60 identical passes an hour per replica don't bury the branches that carry new information.

Deployments run at **info** (`ITERION_LOG_LEVEL=info` on prod). So those passes emit *nothing at all*. The single `Warn` the event path fires dies with the pod. A required check left unanswered has no trace anywhere naming why.

## Measured

PR #564 sat behind an unanswered `revi/review` for **22 hours**. The owing run (`01a049db`) was `failed_resumable` with `retry_state: null` — precisely the class the reconciler documents as *"those runs ARE dead; reconcile them"*. Every verifiable precondition held: publish grant, `pr_url`, `gate_context: revi/review`, a `head_sha` still matching the PR head, an in-flight claim whose target URL named that very run, valkey-backed grant store, sweeper attached (its startup line is in the logs).

It abstained ~57 times and **which branch is unknowable after the fact** — the whole sweep history was suppressed, and by the time anyone looked the server pods were 35 minutes old.

This does not identify the abstaining branch. It makes the next occurrence identifiable.

## The change

Candidacy is bounded by `gateSweepLookback` on the run's `updated_at`, so the **last pass inside that window is the moment the miss becomes permanent** — nothing revisits the run afterwards. That pass now warns once, naming the run, the pull request, the reason, and the permanence. Earlier passes stay at `Debug`, so the volume argument that chose `Debug` is preserved intact.

No decision changes — only which of them is audible.

## Verification

- 4 tests, both mutations **verified RED** on their own assertion: always-`Debug` breaks the last-pass test, always-`Warn` breaks the stays-quiet test.
- The logger is pinned at `warn` in the fixture, matching the level deployments actually run at — so the test asserts *absence*, not "quiet".
- **Class grep**: 6 `Debug` declines in the gate family, **1 defective**. The other 5 (`head moved`, `another run holds the claim`, and the three relaunch dedups) stay silent while a live owner or an already-filed board card carries the signal — correct, untouched.
- `task lint` 0 issues; `./pkg/server` and `./e2e` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)