### PR TITLE
fix(bots,docs): Revi follow-up on the plan-phase extension (#578)

### DIFF
--- a/bots/e2e-coverage/main.bot
+++ b/bots/e2e-coverage/main.bot
@@ -1136,8 +1136,8 @@ workflow e2e_coverage:
 
   budget:
     max_parallel_branches: 1
-    max_duration: "3h"
-    max_cost_usd: 60
+    max_duration: "3h30m"
+    max_cost_usd: 75
 
   compaction:
     threshold: 0.9
@@ -1201,10 +1201,11 @@ workflow e2e_coverage:
   ## outputs.gate.fail_log (a BODY node — never the loop-head
   ## campaign's own output on its back-edge, which would read a
   ## loop-entry-frozen value).
-  ## The back-edge BLANKS the plan-phase fields: node input is built
-  ## from the SELECTED incoming edges, so on re-entry this mapping is
-  ## the only source — and a stale pass-1 plan must not re-anchor later
-  ## passes (git log is the durable state there).
+  ## The back-edge BLANKS the plan-phase fields: at loop re-entry the
+  ## back-edge is an OVERLAY applied last — forward-edge mappings from
+  ## sources with output still contribute the unmapped keys — so a
+  ## stale pass-1 plan would re-anchor later passes that must read
+  ## `git log` instead.
   gate -> campaign as continuation_loop("{{vars.max_passes}}") with {
     fail_log: "{{outputs.gate.fail_log}}",
     plan: "", plan_critique: "", plan_responses: ""

--- a/bots/e2e-coverage/manifest.yaml
+++ b/bots/e2e-coverage/manifest.yaml
@@ -2,6 +2,7 @@ name: e2e-coverage
 display_name: Endy
 icon: 🕸️
 version: 0.2.0
+## 0.2.0 — cross-model plan phase (ADR-091) ahead of the campaign; budget +30m/+$15 to fund it
 ## 0.1.0 — initial release (ADR-058 v2 shape, sibling of test-coverage).
 ## ONE adaptive `campaign` agent drives an application's FEATURE-level
 ## e2e coverage to complete, anchored on a committed feature×coverage

--- a/bots/feature-gap-fill/main.bot
+++ b/bots/feature-gap-fill/main.bot
@@ -792,8 +792,8 @@ workflow feature_gap_fill:
 
   budget:
     max_parallel_branches: 1
-    max_duration: "2h"
-    max_cost_usd: 60
+    max_duration: "2h30m"
+    max_cost_usd: 75
 
   compaction:
     threshold: 0.9
@@ -852,10 +852,11 @@ workflow feature_gap_fill:
   ## (campaign→verify_build→verify_run→gate→campaign); the loop-back reads
   ## outputs.gate.fail_log (a BODY node — never the loop-head campaign's own
   ## output on its back-edge, which would read a loop-entry-frozen value).
-  ## The back-edge BLANKS the plan-phase fields: node input is built
-  ## from the SELECTED incoming edges, so on re-entry this mapping is
-  ## the only source — and a stale pass-1 plan must not re-anchor later
-  ## passes (git log is the durable state there).
+  ## The back-edge BLANKS the plan-phase fields: at loop re-entry the
+  ## back-edge is an OVERLAY applied last — forward-edge mappings from
+  ## sources with output still contribute the unmapped keys — so a
+  ## stale pass-1 plan would re-anchor later passes that must read
+  ## `git log` instead.
   gate -> campaign as continuation_loop("{{vars.max_passes}}") with {
     fail_log: "{{outputs.gate.fail_log}}",
     plan: "", plan_critique: "", plan_responses: ""

--- a/bots/feature-gap-fill/manifest.yaml
+++ b/bots/feature-gap-fill/manifest.yaml
@@ -2,6 +2,7 @@ name: feature-gap-fill
 display_name: Fini
 icon: 🧩
 version: 2.1.0
+## 2.1.0 — cross-model plan phase (ADR-091): plan_topology→plan→plan_review→plan_gate→plan_revise ahead of the campaign; budget +30m/+$15 to fund it
 ## 2.0.1 — ADR-082 Phase 2 (sandbox-by-default): removed the `sandbox:`
 ## block — isolation is the platform's job; the target repo's toolchain
 ## comes from its own devcontainer/devbox.json.

--- a/bots/test-coverage/main.bot
+++ b/bots/test-coverage/main.bot
@@ -478,6 +478,9 @@ prompt plan_review_user:
   THE COVERAGE TARGET the plan serves (empty = the whole repository):
   {{vars.target}}
 
+  Test kinds in scope — unit: {{vars.test_unit}} · integration:
+  {{vars.test_integration}} · e2e: {{vars.test_e2e}}
+
   THE PLAN under review:
   {{input.plan}}
 
@@ -831,8 +834,8 @@ workflow test_coverage:
 
   budget:
     max_parallel_branches: 1
-    max_duration: "2h"
-    max_cost_usd: 60
+    max_duration: "2h30m"
+    max_cost_usd: 75
 
   compaction:
     threshold: 0.9
@@ -893,10 +896,11 @@ workflow test_coverage:
   ## single declared loop; the loop-back reads outputs.gate.fail_log (a
   ## BODY node — never the loop-head campaign's own output on its
   ## back-edge, which would read a loop-entry-frozen value).
-  ## The back-edge BLANKS the plan-phase fields: node input is built
-  ## from the SELECTED incoming edges, so on re-entry this mapping is
-  ## the only source — and a stale pass-1 plan must not re-anchor later
-  ## passes (git log is the durable state there).
+  ## The back-edge BLANKS the plan-phase fields: at loop re-entry the
+  ## back-edge is an OVERLAY applied last — forward-edge mappings from
+  ## sources with output still contribute the unmapped keys — so a
+  ## stale pass-1 plan would re-anchor later passes that must read
+  ## `git log` instead.
   gate -> campaign as continuation_loop("{{vars.max_passes}}") with {
     fail_log: "{{outputs.gate.fail_log}}",
     plan: "", plan_critique: "", plan_responses: ""

--- a/bots/test-coverage/manifest.yaml
+++ b/bots/test-coverage/manifest.yaml
@@ -2,6 +2,7 @@ name: test-coverage
 display_name: Testy
 icon: 🧪
 version: 2.1.0
+## 2.1.0 — cross-model plan phase (ADR-091) ahead of the campaign; budget +30m/+$15 to fund it
 ## 2.0.1 — ADR-082 Phase 2 (sandbox-by-default): removed the `sandbox:`
 ## block — isolation is the platform's job; the target repo's toolchain
 ## comes from its own devcontainer/devbox.json.

--- a/docs/adr/091-fallback-skip-route-and-plan-peer-review.md
+++ b/docs/adr/091-fallback-skip-route-and-plan-peer-review.md
@@ -82,7 +82,10 @@ defaults regardless of tenant credentials.
    closing the standing `review_mode` queued-run gap. An empty bundle
    (runner env fallback, unknowable at publish) injects nothing.
 
-4. **The plan phase in the four campaign bots.** Opt-in by resolution:
+4. **The plan phase in the campaign bots** (the four originals;
+   extended 2026-08-30 to feature-gap-fill / test-coverage /
+   e2e-coverage — the authoritative list is `bots/plan_phase_test.go`).
+   Opt-in by resolution:
    `plan_topology` (compute) → `plan` (author, claude family, read-only)
    → `plan_review` (peer, `claw` + `openai/gpt-5.6-sol` by default,
    read-only tools, carrying the skip route) → `plan_gate` (compute

--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -166,8 +166,10 @@ iterion remote api GET /api/teams/<team-id>/oauth/connections
 
 ## Activating the cross-model plan review (one credential, nothing else)
 
-The campaign bots (feature-dev, app-dev, branch-improve-loop,
-whole-improve-loop) carry an opt-in **peer-reviewed plan phase**
+The plan-phase campaign bots (feature-dev, app-dev,
+branch-improve-loop, whole-improve-loop, feature-gap-fill,
+test-coverage, e2e-coverage — the authoritative list is
+`bots/plan_phase_test.go`) carry an opt-in **peer-reviewed plan phase**
 ([ADR-091](adr/091-fallback-skip-route-and-plan-peer-review.md)): a
 cross-family reviewer (default `claw` + `openai/gpt-5.6-sol`) critiques
 the plan before the campaign implements. `plan_review: auto` resolves at
@@ -201,7 +203,7 @@ all — the bots' `auto` default then reads as off, fail-safe.) Mid-run peer-for
 `--var plan_review_policy=wait|skip` (wait = the run parks
 failed_resumable and the usage-window retry resumes it when the window
 reopens; skip = continue without the review, loudly stamped).
-All four campaign bots default to `skip` — the peer is an optional
+All plan-phase campaign bots default to `skip` — the peer is an optional
 enrichment, and a dead second-family credential must never park a
 campaign (`wait` is the per-run deliberate-spend opt-in). Gotcha:
 the ChatGPT-forfait wire gates models by the codex-cli `version:` header


### PR DESCRIPTION
Addresses the 5 non-blocking finding classes Revi left on #578 (merged before the follow-up — the fixer lane needs an open PR, so this is the manual follow-up):

- **Back-edge comments inverted the engine's re-entry semantics** (R0c5ecf/R111a3c/R62b46b): verified against `pkg/runtime/engine_resolve.go` — at loop re-entry the back-edge is an OVERLAY applied last, forward mappings still contribute unmapped keys. The blanks work by applied-last, not by only-source; the comments now say so.
- **Budget headroom** (R9c35e4/R80915d/R15f1bc/R86427d): the three bots get the +30m/+$15 the phase's introducing commit established for branch/whole-improve-loop.
- **test-coverage peer mission** (R255dc8): the reviewer now receives the kind scope the author gets.
- **Manifest changelogs** (R2c671d): per-version comments added for the bumps.
- **Doc enumerations** (R1c4b91): cloud-llm-credentials + the ADR-091 decision name the 7-bot set, with `bots/plan_phase_test.go` as the authority.

Verify: `iterion validate` ×3 OK · `go test ./bots/` green · e2e coverage/plan-review suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)