### PR TITLE
docs: claw–claude_code parity doctrine (pre-arbitrated)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,9 +139,9 @@ specific bot (see 2).
 (claw-code-go, the sibling repo) is meant to be feature-paritary with
 `claude_code`, and the two backends are meant to be **interchangeable** on
 the same node: `claude_code` is the more stable and mature harness today;
-`claw` reaches every provider the registry knows. It is an **addendum** to
-the numbered five above, not a sixth principle — equally settled, equally
-not to re-litigate. Consequences, settled:
+`claw` reaches every provider the registry knows. This doctrine is an
+**addendum** to the numbered five above, not a sixth principle — equally
+settled, equally not to re-litigate. Consequences, settled:
 
 - A claw error, gap or limitation met in real use is a **claw-code-go
   backlog item, not a disqualification** — fix the harness, then re-judge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,25 @@ tool" — the audience is anyone who operates agent work. But don't make git
 optional in the core, and don't ship a view that needs the engine to know a
 specific bot (see 2).
 
+**Backend parity doctrine — claw ↔ claude_code (pre-arbitrated).** `claw`
+(claw-code-go, the sibling repo) is meant to be feature-paritary with
+`claude_code`, and the two backends are meant to be **interchangeable** on
+the same node: `claude_code` is the more stable and mature harness today;
+`claw` reaches every provider the registry knows. Consequences, settled:
+
+- A claw error, gap or limitation met in real use is a **claw-code-go
+  backlog item, not a disqualification** — fix the harness, then re-judge
+  the model. (Known v1 gaps to burn down: MCP servers and mid-tool-loop
+  `ask_user` under the sandboxed `__claw-runner`; session resume parity.)
+- Every engine-side capability wired for one of the two (credentials,
+  fingerprinting/meters, permission gate, session resume, events) must be
+  wired — or explicitly refused with a typed diagnostic — for the other.
+  A feature that silently works on one backend only is a defect (see 1).
+- Backend fallback/switching (run-level `fallback`, per-node overrides) is
+  the interchangeability mechanism: every production switch is also a
+  parity measurement. Keep switches observable (events name the backend
+  and the served model).
+
 ## Operational-knowledge reflex — capture what a session cost you to discover
 
 When a work session burns real time **discovering how to configure or operate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,9 @@ specific bot (see 2).
 (claw-code-go, the sibling repo) is meant to be feature-paritary with
 `claude_code`, and the two backends are meant to be **interchangeable** on
 the same node: `claude_code` is the more stable and mature harness today;
-`claw` reaches every provider the registry knows. Consequences, settled:
+`claw` reaches every provider the registry knows. It is an **addendum** to
+the numbered five above, not a sixth principle — equally settled, equally
+not to re-litigate. Consequences, settled:
 
 - A claw error, gap or limitation met in real use is a **claw-code-go
   backlog item, not a disqualification** — fix the harness, then re-judge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,8 +143,11 @@ the same node: `claude_code` is the more stable and mature harness today;
 
 - A claw error, gap or limitation met in real use is a **claw-code-go
   backlog item, not a disqualification** — fix the harness, then re-judge
-  the model. (Known v1 gaps to burn down: MCP servers and mid-tool-loop
-  `ask_user` under the sandboxed `__claw-runner`; session resume parity.)
+  the model. (Known gap to burn down: session resume parity — `claw`
+  never reads `SessionID`, replaying from the run's own store. MCP
+  servers and mid-tool-loop `ask_user` under the sandboxed
+  `__claw-runner` shipped in V2-2/V2-3 — see
+  [docs/sandbox.md](docs/sandbox.md).)
 - Every engine-side capability wired for one of the two (credentials,
   fingerprinting/meters, permission gate, session resume, events) must be
   wired — or explicitly refused with a typed diagnostic — for the other.

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -36,6 +36,24 @@ flowchart LR
 | `grok` | Same generic CLI-agent protocol, and the same **`deny`-only** gate, `sandbox: none` requirement and unwired session resume/fork. | Explicit only. |
 | `codex` | Supported Codex CLI backend. Uses Codex's native tool loop and sandbox; see its capability boundaries below. | Per-node/workflow opt-in, or explicit addition to `ITERION_BACKEND_PREFERENCE`. |
 
+### Parity doctrine: `claw` ↔ `claude_code`
+
+These two are not alternatives at different tiers — they are meant to be
+**feature-paritary and interchangeable on the same node**. `claude_code` is
+the more stable, mature harness today; `claw` is the in-process twin that
+reaches every provider the registry knows (including providers the CLI
+cannot speak to). The settled rules:
+
+- A claw gap, error or limitation found in real use is a **claw-code-go
+  backlog item, not a disqualification**: fix the harness first, then
+  re-judge the model that ran on it.
+- Engine capabilities (credentials, fingerprints/meters, permission gate,
+  session resume, events) must land on **both** backends — or refuse with
+  a typed diagnostic on the one that cannot honour them yet.
+- Run-level `fallback` and per-node overrides are the switching mechanism;
+  every production switch doubles as a parity measurement, so switches
+  stay observable (events carry the backend and the served model).
+
 ## TL;DR
 
 If you have **at least one** of:


### PR DESCRIPTION
Settles in writing what kept being re-explained: `claw` and `claude_code` are meant to be feature-paritary and interchangeable per node.

- A claw gap/error/limitation met in real use is a **claw-code-go backlog item, not a disqualification** — fix the harness, then re-judge the model.
- Engine capabilities (credentials, fingerprints/meters, permission gate, session resume, events) land on **both** backends, or refuse with a typed diagnostic.
- Run-level `fallback` / per-node overrides are the switching mechanism; every production switch doubles as a parity measurement.

Two blocks: CLAUDE.md philosophy (pre-arbitrated) + docs/backends.md next to the status table. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)