### PR TITLE
feat(fallback): run-level fallback becomes an ordered chain (v11)

### DIFF
--- a/pkg/backend/model/executor_fallback_test.go
+++ b/pkg/backend/model/executor_fallback_test.go
@@ -107,6 +107,36 @@ func TestProviderFallback_FallsThroughThenSucceeds(t *testing.T) {
 	}
 }
 
+func TestRunFallbackEventsCarryStageIndexes(t *testing.T) {
+	rec := &fallbackRecorder{}
+	fake := &providerScriptedBackend{fail: map[string]error{
+		"primary": &delegate.ErrTransient{Reason: "primary unavailable"},
+		"stage-0": &delegate.ErrTransient{Reason: "first fallback unavailable"},
+	}}
+	reg := delegate.NewRegistry()
+	reg.Register(delegate.BackendClaudeCode, fake)
+	e := newFallbackExecutor(reg, rec.hook())
+	stage0, stage1 := 0, 1
+	chain := []chainElement{
+		{Provider: "primary"},
+		{Provider: "stage-0", FallbackIndex: &stage0},
+		{Provider: "stage-1", FallbackIndex: &stage1},
+	}
+	task := &delegate.Task{NodeID: "review", Model: "claude-opus-5"}
+
+	if _, err := e.dispatchWithProviderFallback(context.Background(), "review", delegate.BackendClaudeCode, chain, fake, task); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if len(rec.events) != 2 {
+		t.Fatalf("fallback events = %+v, want two stage transitions", rec.events)
+	}
+	for i, event := range rec.events {
+		if event.FallbackIndex == nil || *event.FallbackIndex != i {
+			t.Fatalf("event %d fallback index = %v, want %d", i, event.FallbackIndex, i)
+		}
+	}
+}
+
 // TestProviderFallback_PerElementModelSwap is the headline case for the
 // per-element model feature: a claude_code node declares
 // `provider: "zai:glm-5.2,anthropic:claude-opus-4-8"`, z.ai (running the

--- a/pkg/backend/model/executor_hooks.go
+++ b/pkg/backend/model/executor_hooks.go
@@ -118,6 +118,9 @@ type ProviderFallbackInfo struct {
 	Reason   string
 	Attempts int   // retry attempts spent on the failed provider; 0 for a cooldown skip
 	Err      error // the hard failure that triggered the fall-through
+	// FallbackIndex is the zero-based destination stage for a launch-time
+	// run fallback. Nil for authored and legacy provider chains.
+	FallbackIndex *int
 	// Cooldown is true when dispatch skipped an attempt using a refusal a
 	// previous node already observed. CooldownUntil is that refusal's reset.
 	Cooldown      bool

--- a/pkg/backend/model/executor_resolve.go
+++ b/pkg/backend/model/executor_resolve.go
@@ -97,6 +97,9 @@ type chainElement struct {
 	// `_skipped` instead of executing anything. Always last in the chain
 	// (compile-time C173).
 	Skip bool
+	// FallbackIndex is set only for a launch-time run fallback stage. It
+	// preserves the launch array index even when an earlier stage was refused.
+	FallbackIndex *int
 }
 
 // defaultFallbackTriggers is the `on:` set a `fallbacks:` route gets
@@ -144,6 +147,10 @@ func (e *ClawExecutor) resolveChain(node ir.Node) []chainElement {
 			Provider: strings.TrimSpace(ir.ExpandEnvWithDefault(fb.Provider)),
 			Model:    strings.TrimSpace(ir.ExpandEnvWithDefault(fb.Model)),
 			Skip:     fb.Action == ir.FallbackActionSkip,
+		}
+		if fb.RunStageSet {
+			stage := fb.RunStage
+			el.FallbackIndex = &stage
 		}
 		if el.Provider == "auto" {
 			el.Provider = "" // explicit auto → process-env precedence

--- a/pkg/backend/model/executor_retry.go
+++ b/pkg/backend/model/executor_retry.go
@@ -1090,6 +1090,7 @@ func (e *ClawExecutor) noteCooldownFallback(
 		ToBackend:     toBackend,
 		Reason:        string(cd.Category),
 		Attempts:      0,
+		FallbackIndex: to.FallbackIndex,
 		Cooldown:      true,
 		CooldownUntil: cd.Until,
 		ToSkip:        to.Skip,
@@ -1116,17 +1117,18 @@ func (e *ClawExecutor) noteFallback(
 		return
 	}
 	e.hooks.OnProviderFallback(nodeID, ProviderFallbackInfo{
-		BackendName: backendName,
-		From:        from.Provider,
-		To:          to.Provider,
-		FromModel:   fromModel,
-		ToModel:     toModel,
-		FromBackend: fromBackend,
-		ToBackend:   toBackend,
-		Reason:      string(delegate.ClassifyFallback(err, isDelegateRetryable(err))),
-		Attempts:    e.retry.maxAttempts(),
-		Err:         err,
-		ToSkip:      to.Skip,
+		BackendName:   backendName,
+		From:          from.Provider,
+		To:            to.Provider,
+		FromModel:     fromModel,
+		ToModel:       toModel,
+		FromBackend:   fromBackend,
+		ToBackend:     toBackend,
+		Reason:        string(delegate.ClassifyFallback(err, isDelegateRetryable(err))),
+		Attempts:      e.retry.maxAttempts(),
+		FallbackIndex: to.FallbackIndex,
+		Err:           err,
+		ToSkip:        to.Skip,
 	})
 }
 

--- a/pkg/backend/model/fallback_prereq_test.go
+++ b/pkg/backend/model/fallback_prereq_test.go
@@ -136,17 +136,19 @@ func TestModelFallbackEventReachesStore(t *testing.T) {
 	if hooks.OnProviderFallback == nil {
 		t.Fatal("OnProviderFallback is not wired into the store hooks")
 	}
+	firstStage, secondStage := 0, 1
 	hooks.OnProviderFallback("implement", ProviderFallbackInfo{
-		BackendName: delegate.BackendClaudeCode,
-		FromBackend: delegate.BackendClaudeCode,
-		ToBackend:   delegate.BackendClaw,
-		FromModel:   "claude-opus-5",
-		ToModel:     "openai/gpt-5.5",
-		From:        "anthropic",
-		To:          "openai",
-		Reason:      string(delegate.FallbackUsageWindow),
-		Attempts:    1,
-		Err:         usageWindowErr(),
+		BackendName:   delegate.BackendClaudeCode,
+		FromBackend:   delegate.BackendClaudeCode,
+		ToBackend:     delegate.BackendClaw,
+		FromModel:     "claude-opus-5",
+		ToModel:       "openai/gpt-5.5",
+		From:          "anthropic",
+		To:            "openai",
+		Reason:        string(delegate.FallbackUsageWindow),
+		Attempts:      1,
+		FallbackIndex: &firstStage,
+		Err:           usageWindowErr(),
 	})
 	reset := time.Date(2026, 8, 24, 11, 0, 0, 0, time.UTC)
 	hooks.OnProviderFallback("implement-next", ProviderFallbackInfo{
@@ -159,6 +161,7 @@ func TestModelFallbackEventReachesStore(t *testing.T) {
 		To:            "openai",
 		Reason:        string(delegate.FallbackUsageWindow),
 		Attempts:      0,
+		FallbackIndex: &secondStage,
 		Cooldown:      true,
 		CooldownUntil: reset,
 	})
@@ -179,6 +182,9 @@ func TestModelFallbackEventReachesStore(t *testing.T) {
 	}
 	if found.NodeID != "implement" {
 		t.Errorf("node_id = %q, want implement", found.NodeID)
+	}
+	if got := found.Data["fallback_index"]; got != float64(0) && got != 0 {
+		t.Errorf("fallback_index = %v, want 0", got)
 	}
 	for key, want := range map[string]any{
 		"from_backend": delegate.BackendClaudeCode,
@@ -215,5 +221,8 @@ func TestModelFallbackEventReachesStore(t *testing.T) {
 	}
 	if got := cooldown.Data["attempts"]; got != float64(0) && got != 0 {
 		t.Errorf("attempts = %v, want 0", got)
+	}
+	if got := cooldown.Data["fallback_index"]; got != float64(1) && got != 1 {
+		t.Errorf("fallback_index = %v, want 1", got)
 	}
 }

--- a/pkg/backend/model/hooks.go
+++ b/pkg/backend/model/hooks.go
@@ -993,6 +993,9 @@ func (h *storeHooks) onProviderFallback(nodeID string, info ProviderFallbackInfo
 		"reason":        info.Reason,
 		"attempts":      info.Attempts,
 	}
+	if info.FallbackIndex != nil {
+		data["fallback_index"] = *info.FallbackIndex
+	}
 	if info.Cooldown {
 		data["cooldown"] = true
 	}

--- a/pkg/backend/model/resolve_chain_test.go
+++ b/pkg/backend/model/resolve_chain_test.go
@@ -37,6 +37,24 @@ func TestResolveChain_AppendsFallbacksAfterProviderChain(t *testing.T) {
 	}
 }
 
+func TestResolveChain_PreservesRunFallbackStageIndex(t *testing.T) {
+	e := &ClawExecutor{}
+	node := chainAgentNode("x", delegate.BackendClaudeCode, "zai,anthropic", []ir.Fallback{
+		{
+			Name:        ir.RunFallbackName,
+			Backend:     delegate.BackendClaw,
+			Model:       "openai/gpt-5.5",
+			RunStage:    1,
+			RunStageSet: true,
+		},
+	})
+	chain := e.resolveChain(node)
+	stage := chain[len(chain)-1].FallbackIndex
+	if stage == nil || *stage != 1 {
+		t.Fatalf("run fallback index = %v, want original launch stage 1", stage)
+	}
+}
+
 // TestResolveChain_DefaultTriggers: a route that declares no `on:` gets
 // the closed positive default. `any` is excluded because a budget cap or
 // a schema-shape failure re-fails identically on every route; `auth` is

--- a/pkg/cli/resume_helpers.go
+++ b/pkg/cli/resume_helpers.go
@@ -142,7 +142,7 @@ func buildResumeExecutor(
 		PermissionAllow: opts.PermissionAllow,
 		PermissionAsk:   opts.PermissionAsk,
 		PermissionDeny:  opts.PermissionDeny,
-		RunFallback:     runFallback,
+		RunFallback:     []ir.Fallback{runFallback},
 		AutoMemory:      opts.AutoMemory,
 		// Same resolution the studio resume path uses, so the two surfaces
 		// key a bot's memory identically.

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -512,7 +512,7 @@ func buildRunExecutor(
 		PermissionAsk:   opts.PermissionAsk,
 		PermissionDeny:  opts.PermissionDeny,
 		ModelOverrides:  modelOverrides,
-		RunFallback:     runFallback,
+		RunFallback:     []ir.Fallback{runFallback},
 		// Wire the operator-message inbox so queued messages (a CLI
 		// `iterion supervise` attach, a DSL-declared supervisor, or a
 		// future CLI chatbox) are drained at the agent's turn boundaries.

--- a/pkg/dsl/ir/fallback_apply.go
+++ b/pkg/dsl/ir/fallback_apply.go
@@ -12,8 +12,9 @@ import (
 const RunFallbackName = "run-fallback"
 
 // ApplyRunFallback materialises the operator's launch-time fallback
-// route (studio Launch row / CLI `--fallback`) onto the compiled
-// workflow, and returns one message per node where it was REFUSED.
+// chain (studio Launch row / CLI `--fallback`) onto the compiled
+// workflow, and returns one message per node and stage where it was
+// REFUSED.
 //
 // It writes into the IR rather than being resolved privately inside the
 // executor, and that is the whole point. Three analyses read a node's
@@ -34,16 +35,14 @@ const RunFallbackName = "run-fallback"
 //     judge takes a route from its own block or not at all;
 //   - only a node that declares NO routes of its own. An author who
 //     wrote a chain vetted where it may go;
-//   - only a crossing that passes the same safety predicates as C176 —
+//   - every stage independently passes the same safety predicates as C176 —
 //     plus C135's, since a claw route that cannot resolve the node's
 //     declared tools would fail exactly when it is needed. A refused
-//     node keeps its primary and the caller warns; the route is never
-//     silently taken.
-func ApplyRunFallback(w *Workflow, route Fallback) []string {
-	if w == nil || (route.Backend == "" && route.Model == "" && route.Provider == "") {
+//     stage is skipped and the caller warns; later stages remain eligible.
+func ApplyRunFallback(w *Workflow, routes []Fallback) []string {
+	if w == nil || len(routes) == 0 {
 		return nil
 	}
-	route.Name = RunFallbackName
 
 	var refusals []string
 	for _, n := range w.Nodes {
@@ -60,39 +59,51 @@ func ApplyRunFallback(w *Workflow, route Fallback) []string {
 		}
 		nodeBackend := effectiveNodeBackend(nn.GetLLMFields().Backend, w.DefaultBackend)
 		perm := EffectivePermission(nn.GetPermission(), w.Permission)
-		if reason := ungatedCrossingReason(route.Backend, perm, len(w.PermissionAsk) > 0); reason != "" {
-			refusals = append(refusals, fmt.Sprintf("agent %q: run-level fallback %s", nn.NodeID(), reason))
-			continue
+		for stage, route := range routes {
+			if route.Backend == "" && route.Model == "" && route.Provider == "" {
+				continue
+			}
+			route.Name = RunFallbackName
+			route.RunStage = stage
+			route.RunStageSet = true
+			refuse := func(reason string) {
+				refusals = append(refusals, fmt.Sprintf(
+					"agent %q: run-level fallback stage %d %s", nn.NodeID(), stage+1, reason))
+			}
+			if reason := ungatedCrossingReason(route.Backend, perm, len(w.PermissionAsk) > 0); reason != "" {
+				refuse(reason)
+				continue
+			}
+			if reason := toolsInversionReason(nodeBackend, route.Backend, nn.GetTools()); reason != "" {
+				refuse(reason)
+				continue
+			}
+			if reason := sessionContinuityCrossingReason(nn.GetSession(), nodeBackend, route.Backend); reason != "" {
+				refuse(reason)
+				continue
+			}
+			// Refused only on what C135 would BLOCK — a name the compiler can
+			// positively identify as wrong, with no MCP wiring in sight. A bare
+			// name it merely does not recognise may still resolve onto an MCP
+			// tool whose catalog is merged after compilation, and dropping an
+			// operator's explicit route on that guess is worse than taking it.
+			// Same tiering as the diagnostic — see toolDiagReporter.
+			if reason := unresolvableToolsReason(route.Backend, nn.GetTools(), mcpWiringVisible(w, n)); reason != "" {
+				refuse(reason)
+				continue
+			}
+			// A route that changes backend with no model of its own cannot
+			// work — model specs are not portable — and a route naming the
+			// node's own backend with no model would re-issue the identical
+			// call. Both are dropped rather than left to fail at dispatch.
+			if route.Backend != "" && route.Model == "" {
+				refuse(fmt.Sprintf(
+					"names backend %q with no model — model specs are not portable across backends",
+					route.Backend))
+				continue
+			}
+			agent.Fallbacks = append(agent.Fallbacks, route)
 		}
-		if reason := toolsInversionReason(nodeBackend, route.Backend, nn.GetTools()); reason != "" {
-			refusals = append(refusals, fmt.Sprintf("agent %q: run-level fallback %s", nn.NodeID(), reason))
-			continue
-		}
-		if reason := sessionContinuityCrossingReason(nn.GetSession(), nodeBackend, route.Backend); reason != "" {
-			refusals = append(refusals, fmt.Sprintf("agent %q: run-level fallback %s", nn.NodeID(), reason))
-			continue
-		}
-		// Refused only on what C135 would BLOCK — a name the compiler can
-		// positively identify as wrong, with no MCP wiring in sight. A bare
-		// name it merely does not recognise may still resolve onto an MCP
-		// tool whose catalog is merged after compilation, and dropping an
-		// operator's explicit route on that guess is worse than taking it.
-		// Same tiering as the diagnostic — see toolDiagReporter.
-		if reason := unresolvableToolsReason(route.Backend, nn.GetTools(), mcpWiringVisible(w, n)); reason != "" {
-			refusals = append(refusals, fmt.Sprintf("agent %q: run-level fallback %s", nn.NodeID(), reason))
-			continue
-		}
-		// A route that changes backend with no model of its own cannot
-		// work — model specs are not portable — and a route naming the
-		// node's own backend with no model would re-issue the identical
-		// call. Both are dropped rather than left to fail at dispatch.
-		if route.Backend != "" && route.Model == "" {
-			refusals = append(refusals, fmt.Sprintf(
-				"agent %q: run-level fallback names backend %q with no model — model specs are not portable across backends",
-				nn.NodeID(), route.Backend))
-			continue
-		}
-		agent.Fallbacks = append(agent.Fallbacks, route)
 	}
 	return refusals
 }

--- a/pkg/dsl/ir/fallback_apply_test.go
+++ b/pkg/dsl/ir/fallback_apply_test.go
@@ -33,7 +33,7 @@ func TestApplyRunFallback_ReachesEligibleAgent(t *testing.T) {
 	agent := applyAgent("work", "claude_code", "", []string{"read_file"}, nil)
 	w := &Workflow{Nodes: map[string]Node{"work": agent}}
 
-	if refusals := ApplyRunFallback(w, runRoute()); len(refusals) != 0 {
+	if refusals := ApplyRunFallback(w, []Fallback{runRoute()}); len(refusals) != 0 {
 		t.Fatalf("unexpected refusals: %v", refusals)
 	}
 	if len(agent.Fallbacks) != 1 || agent.Fallbacks[0].Name != RunFallbackName {
@@ -52,7 +52,7 @@ func TestApplyRunFallback_NeverReachesJudges(t *testing.T) {
 	judge := applyJudge("gate", "claude_code")
 	w := &Workflow{Nodes: map[string]Node{"gate": judge}}
 
-	ApplyRunFallback(w, runRoute())
+	ApplyRunFallback(w, []Fallback{runRoute()})
 	if len(judge.Fallbacks) != 0 {
 		t.Errorf("the run-level route reached a judge: %+v", judge.Fallbacks)
 	}
@@ -67,7 +67,7 @@ func TestApplyRunFallback_AuthoredRoutesWin(t *testing.T) {
 	})
 	w := &Workflow{Nodes: map[string]Node{"work": agent}}
 
-	ApplyRunFallback(w, runRoute())
+	ApplyRunFallback(w, []Fallback{runRoute()})
 	if len(agent.Fallbacks) != 1 {
 		t.Errorf("run-level route appended past an authored chain: %+v", agent.Fallbacks)
 	}
@@ -82,7 +82,7 @@ func TestApplyRunFallback_RefusesUngatedRoute(t *testing.T) {
 	agent := applyAgent("work", "claude_code", "deny", []string{"read_file"}, nil)
 	w := &Workflow{Nodes: map[string]Node{"work": agent}}
 
-	refusals := ApplyRunFallback(w, Fallback{Backend: "codex", Model: "gpt-5.4"})
+	refusals := ApplyRunFallback(w, []Fallback{{Backend: "codex", Model: "gpt-5.4"}})
 	if len(refusals) != 1 || !strings.Contains(refusals[0], "UNGATED") {
 		t.Fatalf("expected an ungated-crossing refusal, got %v", refusals)
 	}
@@ -102,7 +102,7 @@ func TestApplyRunFallback_RefusesUngatedRouteFromWorkflowGate(t *testing.T) {
 		Nodes:      map[string]Node{"work": agent},
 	}
 
-	refusals := ApplyRunFallback(w, Fallback{Backend: "codex", Model: "gpt-5.4"})
+	refusals := ApplyRunFallback(w, []Fallback{{Backend: "codex", Model: "gpt-5.4"}})
 	if len(refusals) != 1 {
 		t.Fatalf("a workflow-level gate must refuse the same crossing, got %v", refusals)
 	}
@@ -116,7 +116,7 @@ func TestApplyRunFallback_RefusesToolsInversion(t *testing.T) {
 	agent := applyAgent("work", "claw", "", nil, nil)
 	w := &Workflow{Nodes: map[string]Node{"work": agent}}
 
-	refusals := ApplyRunFallback(w, Fallback{Backend: "claude_code", Model: "claude-opus-5"})
+	refusals := ApplyRunFallback(w, []Fallback{{Backend: "claude_code", Model: "claude-opus-5"}})
 	if len(refusals) != 1 || !strings.Contains(refusals[0], "un-restricts") {
 		t.Fatalf("expected a tools-inversion refusal, got %v", refusals)
 	}
@@ -131,7 +131,7 @@ func TestApplyRunFallback_RefusesBackendWithoutModel(t *testing.T) {
 	agent := applyAgent("work", "claude_code", "", []string{"read_file"}, nil)
 	w := &Workflow{Nodes: map[string]Node{"work": agent}}
 
-	refusals := ApplyRunFallback(w, Fallback{Backend: "claw"})
+	refusals := ApplyRunFallback(w, []Fallback{{Backend: "claw"}})
 	if len(refusals) != 1 || !strings.Contains(refusals[0], "no model") {
 		t.Fatalf("expected a missing-model refusal, got %v", refusals)
 	}
@@ -144,7 +144,7 @@ func TestApplyRunFallback_RefusesBackendWithoutModel(t *testing.T) {
 func TestApplyRunFallback_VisibleToPreRunAnalyses(t *testing.T) {
 	agent := applyAgent("work", "claude_code", "", []string{"read_file"}, nil)
 	w := &Workflow{Nodes: map[string]Node{"work": agent}}
-	ApplyRunFallback(w, runRoute())
+	ApplyRunFallback(w, []Fallback{runRoute()})
 
 	llm, ok := w.Nodes["work"].(LLMNode)
 	if !ok {
@@ -159,11 +159,53 @@ func TestApplyRunFallback_VisibleToPreRunAnalyses(t *testing.T) {
 func TestApplyRunFallback_NoRouteIsANoOp(t *testing.T) {
 	agent := applyAgent("work", "claude_code", "", nil, nil)
 	w := &Workflow{Nodes: map[string]Node{"work": agent}}
-	if refusals := ApplyRunFallback(w, Fallback{}); refusals != nil {
+	if refusals := ApplyRunFallback(w, nil); refusals != nil {
 		t.Errorf("an empty route must do nothing, got %v", refusals)
 	}
 	if len(agent.Fallbacks) != 0 {
 		t.Error("an empty route attached something")
+	}
+}
+
+func TestApplyRunFallback_PreservesStageOrder(t *testing.T) {
+	agent := applyAgent("work", "claude_code", "", []string{"read_file"}, nil)
+	w := &Workflow{Nodes: map[string]Node{"work": agent}}
+	routes := []Fallback{
+		{Backend: "claw", Model: "openai/gpt-5.5"},
+		{Backend: "claw", Model: "anthropic/claude-opus-5"},
+	}
+
+	if refusals := ApplyRunFallback(w, routes); len(refusals) != 0 {
+		t.Fatalf("unexpected refusals: %v", refusals)
+	}
+	if len(agent.Fallbacks) != 2 {
+		t.Fatalf("fallbacks = %+v, want two stages", agent.Fallbacks)
+	}
+	if agent.Fallbacks[0].Model != routes[0].Model || agent.Fallbacks[1].Model != routes[1].Model {
+		t.Fatalf("fallback order = %+v, want %+v", agent.Fallbacks, routes)
+	}
+	if !agent.Fallbacks[0].RunStageSet || agent.Fallbacks[0].RunStage != 0 || agent.Fallbacks[1].RunStage != 1 {
+		t.Fatalf("fallback stage indexes = %+v, want 0 then 1", agent.Fallbacks)
+	}
+}
+
+func TestApplyRunFallback_RefusedStageDoesNotStopChain(t *testing.T) {
+	agent := applyAgent("work", "claude_code", "deny", []string{"read_file"}, nil)
+	w := &Workflow{Nodes: map[string]Node{"work": agent}}
+	routes := []Fallback{
+		{Backend: "codex", Model: "gpt-5.4"},
+		{Backend: "claw", Model: "openai/gpt-5.5"},
+	}
+
+	refusals := ApplyRunFallback(w, routes)
+	if len(refusals) != 1 || !strings.Contains(refusals[0], "stage 1") || !strings.Contains(refusals[0], "UNGATED") {
+		t.Fatalf("refusals = %v, want the first stage refused explicitly", refusals)
+	}
+	if len(agent.Fallbacks) != 1 || agent.Fallbacks[0].Model != routes[1].Model {
+		t.Fatalf("fallbacks = %+v, want the accepted second stage", agent.Fallbacks)
+	}
+	if !agent.Fallbacks[0].RunStageSet || agent.Fallbacks[0].RunStage != 1 {
+		t.Fatalf("accepted stage index = %+v, want original index 1", agent.Fallbacks[0])
 	}
 }
 

--- a/pkg/dsl/ir/ir.go
+++ b/pkg/dsl/ir/ir.go
@@ -1439,6 +1439,11 @@ type Fallback struct {
 	Metered  bool     // the author's acknowledgement that this route spends a metered credential
 	Action   string   // "" = route; FallbackActionSkip = terminal degrade (zero-value output, loudly marked)
 	When     string   // optional expr over vars gating the route ("" = always active), evaluated at dispatch
+	// RunStage identifies this route's zero-based position in a launch-time
+	// fallback chain. RunStageSet distinguishes stage zero from authored
+	// routes; the compiler never sets either field.
+	RunStage    int
+	RunStageSet bool
 }
 
 // FallbackActionSkip is the `action: skip` terminal route: instead of

--- a/pkg/dsl/ir/validate_tools_test.go
+++ b/pkg/dsl/ir/validate_tools_test.go
@@ -176,7 +176,7 @@ func TestRunFallbackRefusedWhenToolsCannotResolve(t *testing.T) {
 	if cr.HasErrors() {
 		t.Fatalf("fixture must compile clean: %+v", cr.Diagnostics)
 	}
-	refusals := ApplyRunFallback(cr.Workflow, Fallback{Backend: "claw", Model: "anthropic/claude-opus-5"})
+	refusals := ApplyRunFallback(cr.Workflow, []Fallback{{Backend: "claw", Model: "anthropic/claude-opus-5"}})
 	if len(refusals) != 1 {
 		t.Fatalf("want the route refused, got %v", refusals)
 	}
@@ -197,7 +197,7 @@ func TestRunFallbackRefusedWhenToolsCannotResolve(t *testing.T) {
 func TestRunFallbackAcceptedWhenToolsResolve(t *testing.T) {
 	cr := compileToolsSrc(t, toolsWorkflow(
 		"  backend: \"claude_code\"\n  model: \"claude-opus-5\"\n  tools: [read_file, bash]\n"))
-	if refusals := ApplyRunFallback(cr.Workflow, Fallback{Backend: "claw", Model: "anthropic/claude-opus-5"}); len(refusals) != 0 {
+	if refusals := ApplyRunFallback(cr.Workflow, []Fallback{{Backend: "claw", Model: "anthropic/claude-opus-5"}}); len(refusals) != 0 {
 		t.Fatalf("a resolvable list must be accepted, got %v", refusals)
 	}
 	agent := cr.Workflow.Nodes["x"].(*AgentNode)
@@ -380,7 +380,7 @@ func TestMCPActivationBlockSoftensEvenLegacyNames(t *testing.T) {
 func TestRunFallbackNotRefusedOnUnrecognisedName(t *testing.T) {
 	cr := compileToolsSrc(t, toolsWorkflow(
 		"  backend: \"claude_code\"\n  model: \"claude-opus-5\"\n  tools: [read_file, firecrawl_search]\n"))
-	if refusals := ApplyRunFallback(cr.Workflow, Fallback{Backend: "claw", Model: "anthropic/claude-opus-5"}); len(refusals) != 0 {
+	if refusals := ApplyRunFallback(cr.Workflow, []Fallback{{Backend: "claw", Model: "anthropic/claude-opus-5"}}); len(refusals) != 0 {
 		t.Fatalf("an unrecognised name must not drop the operator's route, got %v", refusals)
 	}
 }

--- a/pkg/queue/types.go
+++ b/pkg/queue/types.go
@@ -11,6 +11,7 @@
 package queue
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -81,17 +82,21 @@ import (
 // local executor honoured it, but the cloud path dropped it at publish —
 // so the one route meant to rescue a run from a provider's exhausted
 // usage window never fired precisely where runs park unattended.
+// v=11 (2026-08-30): Fallback became an ordered chain. New consumers accept
+// both the v10 object and the v11 array, while producers always emit the
+// array. A v10 runner must reject the new payload rather than run with a
+// partially decoded rescue policy.
 //
 // KNOWN DEBT: ModelOverrides shipped earlier inside v7 (427a9f44e) without a
 // version bump. A v7 runner built before that commit can silently ignore the
 // operator's model/backend pins. That historical gap cannot be repaired by a
 // later bump; the additive-intent rule above prevents repeating it.
-const SchemaVersion = 10
+const SchemaVersion = 11
 
 // MinSchemaVersion is the oldest wire version a consumer still accepts.
-// v9 → v10 is additive (an absent Fallback simply means "no run-level
-// route"), so a v9 payload decodes into exactly the pre-v10 behaviour.
-const MinSchemaVersion = 9
+// v10 → v11 is additive from the new consumer's perspective: its custom
+// decoder promotes the v10 fallback object to a one-stage chain.
+const MinSchemaVersion = 10
 
 // RunMessage is the JSON envelope published on
 // `iterion.queue.runs`. The runner deserialises it, takes the
@@ -135,7 +140,7 @@ type RunMessage struct {
 	// display-only: the studio showed an override the delegates never
 	// honoured.
 	ModelOverrides []ModelOverride `json:"model_overrides,omitempty"`
-	// Fallback carries the operator's single run-level fallback route so
+	// Fallback carries the operator's ordered run-level fallback chain so
 	// the claiming runner APPLIES it to its executor (ir.ApplyRunFallback,
 	// same screen as a local launch) — the wire mirror of
 	// store.RunFallback, same doctrine as ModelOverrides above. Without
@@ -143,7 +148,7 @@ type RunMessage struct {
 	// dropped it at publish: the one route meant to rescue a run from an
 	// exhausted usage window never fired on the path where runs park
 	// unattended.
-	Fallback *RunFallback `json:"fallback,omitempty"`
+	Fallback RunFallback `json:"fallback,omitempty"`
 	// AutoMemory is the launch-time auto-memory (MEMORY.md) override — the
 	// wire half of the knob's strongest precedence level. Empty means the
 	// caller expressed nothing and the workflow/env decide.
@@ -275,15 +280,48 @@ type ModelOverride struct {
 	Provider string `json:"provider,omitempty"`
 }
 
-// RunFallback is the operator's single run-level fallback route on the
-// wire — the queue twin of runview.FallbackEntry. Node targeting is not
-// carried: eligibility (agent nodes without their own `fallbacks:`,
-// never judges) is decided by ir.ApplyRunFallback on the consuming side,
-// identically for a local launch and a runner pod.
-type RunFallback struct {
+// RunFallbackEntry is one stage of the operator's run-level fallback
+// chain on the wire — the queue twin of runview.FallbackEntry.
+type RunFallbackEntry struct {
 	Backend  string `json:"backend,omitempty"`
 	Model    string `json:"model,omitempty"`
 	Provider string `json:"provider,omitempty"`
+}
+
+// RunFallback is the ordered wire chain. Producers marshal it as an array;
+// UnmarshalJSON also accepts the v10 single-object form and promotes it to a
+// one-stage chain. Eligibility is decided by ir.ApplyRunFallback after decode.
+type RunFallback []RunFallbackEntry
+
+func (f *RunFallback) UnmarshalJSON(data []byte) error {
+	raw := bytes.TrimSpace(data)
+	if len(raw) == 0 {
+		return fmt.Errorf("queue: empty fallback JSON")
+	}
+	switch raw[0] {
+	case 'n':
+		if !bytes.Equal(raw, []byte("null")) {
+			return fmt.Errorf("queue: invalid fallback JSON %q", raw)
+		}
+		*f = nil
+		return nil
+	case '[':
+		var entries []RunFallbackEntry
+		if err := json.Unmarshal(raw, &entries); err != nil {
+			return fmt.Errorf("queue: decode fallback chain: %w", err)
+		}
+		*f = entries
+		return nil
+	case '{':
+		var entry RunFallbackEntry
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			return fmt.Errorf("queue: decode legacy fallback: %w", err)
+		}
+		*f = []RunFallbackEntry{entry}
+		return nil
+	default:
+		return fmt.Errorf("queue: fallback must be an object or array")
+	}
 }
 
 // IRBackend is the storage backend an IRRef points at.

--- a/pkg/queue/types_test.go
+++ b/pkg/queue/types_test.go
@@ -43,6 +43,51 @@ func TestRunMessage_RoundTripJSON(t *testing.T) {
 	}
 }
 
+func TestRunMessage_FallbackAcceptsObjectAndArray(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []RunFallbackEntry
+	}{
+		{
+			name: "legacy object",
+			raw:  `{"fallback":{"backend":"codex","model":"gpt-5.5"}}`,
+			want: []RunFallbackEntry{{Backend: "codex", Model: "gpt-5.5"}},
+		},
+		{
+			name: "ordered array",
+			raw:  `{"fallback":[{"backend":"codex","model":"gpt-5.5"},{"backend":"claw","model":"openai/gpt-5.5"}]}`,
+			want: []RunFallbackEntry{
+				{Backend: "codex", Model: "gpt-5.5"},
+				{Backend: "claw", Model: "openai/gpt-5.5"},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var msg RunMessage
+			if err := json.Unmarshal([]byte(tc.raw), &msg); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if len(msg.Fallback) != len(tc.want) {
+				t.Fatalf("fallback = %+v, want %+v", msg.Fallback, tc.want)
+			}
+			for i := range tc.want {
+				if msg.Fallback[i] != tc.want[i] {
+					t.Fatalf("fallback[%d] = %+v, want %+v", i, msg.Fallback[i], tc.want[i])
+				}
+			}
+			blob, err := json.Marshal(msg)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if !bytes.Contains(blob, []byte(`"fallback":[`)) {
+				t.Fatalf("canonical fallback is not an array: %s", blob)
+			}
+		})
+	}
+}
+
 func TestRunMessage_ValidateIRRefBackend(t *testing.T) {
 	good := &RunMessage{
 		V:            SchemaVersion,
@@ -185,17 +230,20 @@ func TestSchemaVersionConstant(t *testing.T) {
 	// route the launch declared never reaches the pod, and the run parks
 	// on the very provider wall the route exists to escape. Additive,
 	// same dual-accept window as v9 (MinSchemaVersion=9).
-	if SchemaVersion != 10 {
-		t.Errorf("SchemaVersion = %d, want 10 (bump intentionally)", SchemaVersion)
+	// v=11 (2026-08-30) expands Fallback to an ordered chain. Producers emit
+	// an array; the new decoder still promotes a v10 object to one stage, so
+	// the dual-accept window advances to MinSchemaVersion=10.
+	if SchemaVersion != 11 {
+		t.Errorf("SchemaVersion = %d, want 11 (bump intentionally)", SchemaVersion)
 	}
-	if MinSchemaVersion != 9 {
-		t.Errorf("MinSchemaVersion = %d, want 9", MinSchemaVersion)
+	if MinSchemaVersion != 10 {
+		t.Errorf("MinSchemaVersion = %d, want 10", MinSchemaVersion)
 	}
 }
 
-// TestValidate_DualAcceptWindow pins the rollout guarantee the v9 bump
-// relies on: a v8 payload (published by a not-yet-upgraded server, or
-// queued before the deploy) still validates on a v9 consumer, while
+// TestValidate_DualAcceptWindow pins the rollout guarantee the latest bump
+// relies on: a v10 payload (published by a not-yet-upgraded server, or
+// queued before the deploy) still validates on a v11 consumer, while
 // anything outside [MinSchemaVersion, SchemaVersion] is rejected as the
 // TRANSIENT ErrSchemaVersion.
 func TestValidate_DualAcceptWindow(t *testing.T) {

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -1884,7 +1884,7 @@ func (r *Runner) executorSpec(ctx context.Context, msg *queue.RunMessage, wf *ir
 		// wire. Before this, the cloud path persisted them display-only:
 		// the studio showed an override the delegates never honoured.
 		ModelOverrides: modelOverridesFromMsg(msg.ModelOverrides),
-		// The operator's run-level fallback route, carried on the wire for
+		// The operator's run-level fallback chain, carried on the wire for
 		// the same reason as the pins above — and applied through the SAME
 		// ir.ApplyRunFallback screen a local launch passes, so a pod can
 		// never take a crossing the compiler would refuse.
@@ -1943,19 +1943,23 @@ func stringifyVars(in map[string]any) (map[string]string, error) {
 // set — the runner-side twin of runview's launch-entry fold, so a cloud
 // run resolves per-node models exactly like a local launch with the same
 // flags.
-// runFallbackFromMsg folds the wire route into the IR form the executor
-// applies. Name is stamped here (not on the wire) so every consumer
-// reports the route under the one recognisable launch-route label.
-func runFallbackFromMsg(f *queue.RunFallback) ir.Fallback {
-	if f == nil {
-		return ir.Fallback{}
+// runFallbackFromMsg folds the wire chain into the IR form the executor
+// applies. Names are stamped here (not on the wire) so every consumer
+// reports the stages under the recognisable launch-route label.
+func runFallbackFromMsg(entries queue.RunFallback) []ir.Fallback {
+	if len(entries) == 0 {
+		return nil
 	}
-	return ir.Fallback{
-		Name:     ir.RunFallbackName,
-		Backend:  f.Backend,
-		Model:    f.Model,
-		Provider: f.Provider,
+	out := make([]ir.Fallback, 0, len(entries))
+	for _, f := range entries {
+		out = append(out, ir.Fallback{
+			Name:     ir.RunFallbackName,
+			Backend:  f.Backend,
+			Model:    f.Model,
+			Provider: f.Provider,
+		})
 	}
+	return out
 }
 
 func modelOverridesFromMsg(entries []queue.ModelOverride) model.ModelOverrides {

--- a/pkg/runner/model_overrides_test.go
+++ b/pkg/runner/model_overrides_test.go
@@ -39,11 +39,20 @@ func TestModelOverridesFromMsg(t *testing.T) {
 // modelOverridesFromMsg. The Name is stamped here so every consumer
 // reports the route under the recognisable launch-route label.
 func TestRunFallbackFromMsg(t *testing.T) {
-	f := runFallbackFromMsg(&queue.RunFallback{Backend: "codex", Model: "gpt-5.5", Provider: "openai"})
-	if f.Name != ir.RunFallbackName || f.Backend != "codex" || f.Model != "gpt-5.5" || f.Provider != "openai" {
-		t.Fatalf("folded route = %+v, want the wire fields under the run-fallback label", f)
+	chain := runFallbackFromMsg(queue.RunFallback{
+		{Backend: "codex", Model: "gpt-5.5", Provider: "openai"},
+		{Backend: "claw", Model: "anthropic/claude-opus-5", Provider: "anthropic"},
+	})
+	if len(chain) != 2 {
+		t.Fatalf("folded chain = %+v, want two stages", chain)
 	}
-	if z := runFallbackFromMsg(nil); z.Name != "" || z.Backend != "" || z.Model != "" || z.Provider != "" {
-		t.Fatalf("nil wire route folded to %+v, want the zero route ApplyRunFallback ignores", z)
+	if f := chain[0]; f.Name != ir.RunFallbackName || f.Backend != "codex" || f.Model != "gpt-5.5" || f.Provider != "openai" {
+		t.Fatalf("first folded stage = %+v, want the first wire entry under the run-fallback label", f)
+	}
+	if f := chain[1]; f.Name != ir.RunFallbackName || f.Backend != "claw" || f.Model != "anthropic/claude-opus-5" || f.Provider != "anthropic" {
+		t.Fatalf("second folded stage = %+v, want order preserved", f)
+	}
+	if z := runFallbackFromMsg(nil); z != nil {
+		t.Fatalf("nil wire chain folded to %+v, want nil", z)
 	}
 }

--- a/pkg/runview/executor.go
+++ b/pkg/runview/executor.go
@@ -102,14 +102,14 @@ type ExecutorSpec struct {
 	// explicitly and win over the node's DSL backend:/model:, so a run can
 	// re-target the bot per node-group without editing the .bot. Empty = no-op.
 	ModelOverrides model.ModelOverrides
-	// RunFallback is the operator's single run-level fallback route
-	// (studio Launch row / CLI --fallback). Zero value = none.
+	// RunFallback is the operator's ordered run-level fallback chain
+	// (studio Launch row / CLI --fallback). Empty = none.
 	//
 	// BuildExecutor materialises it onto the compiled workflow's eligible
 	// agent nodes rather than handing it to the executor privately, so it
 	// passes the same safety screen as an authored route and is visible
 	// to the pre-run analyses the engine runs on the SAME *ir.Workflow.
-	RunFallback ir.Fallback
+	RunFallback []ir.Fallback
 	// BotID is the stable bundle/bot identifier used to qualify
 	// structured visibility=bot memory. Empty falls back to Workflow.Name.
 	BotID string
@@ -265,22 +265,20 @@ func BuildExecutor(spec ExecutorSpec) (*model.ClawExecutor, error) {
 	if spec.RunID == "" {
 		return nil, fmt.Errorf("runview: run ID is required")
 	}
-	// Materialise the operator's launch-time fallback route onto the
+	if spec.Logger == nil {
+		spec.Logger = iterlog.NewFromEnv(os.Stderr)
+	}
+	// Materialise the operator's launch-time fallback chain onto the
 	// compiled workflow BEFORE anything reads it. The engine is
 	// constructed from the same *ir.Workflow, so writing it here is what
 	// lets the sandbox bind-mount, the parallel-branch admission and the
 	// fan_out_each guard all see the route — and what subjects it to the
 	// same refusals the compiler applies to an authored one.
 	//
-	// A refused node keeps its primary and the operator is told; the
-	// route is never silently taken.
+	// A refused stage is skipped and the operator is told; later stages
+	// continue through the same screen and are never silently taken.
 	for _, refusal := range ir.ApplyRunFallback(spec.Workflow, spec.RunFallback) {
-		if spec.Logger != nil {
-			spec.Logger.Warn("run-level fallback not applied — %s", refusal)
-		}
-	}
-	if spec.Logger == nil {
-		spec.Logger = iterlog.NewFromEnv(os.Stderr)
+		spec.Logger.Warn("run-level fallback not applied — %s", refusal)
 	}
 
 	reg := model.NewRegistry()

--- a/pkg/runview/service.go
+++ b/pkg/runview/service.go
@@ -120,12 +120,13 @@ type LaunchSpec struct {
 	// backend:/model:. Empty applies nothing. Composes with ReviewMode. See
 	// model_override.go.
 	ModelOverrides []ModelOverrideEntry
-	// Fallback is the operator's single run-level fallback route (the
-	// studio Launch row / CLI --fallback). It applies to agent nodes
-	// that declare no `fallbacks:` of their own, and never to judges —
+	// Fallback is the operator's ordered run-level fallback chain (the
+	// studio Launch row; a single CLI --fallback becomes a one-stage chain).
+	// It applies to agent nodes that declare no `fallbacks:` of their own,
+	// and never to judges —
 	// a weaker judge still emits a well-formed verdict, so a blanket
-	// launch setting must not reach one. Nil = none. See ADR-087.
-	Fallback *FallbackEntry
+	// launch setting must not reach one. Empty = none. See ADR-087.
+	Fallback []FallbackEntry
 	// Budget carries launch-time budget-cap overrides for the workflow's
 	// `budget:` block — the HTTP equivalent of the CLI --max-cost-usd /
 	// --max-tokens / --max-duration / --max-iterations /
@@ -261,29 +262,31 @@ type ModelOverrideEntry struct {
 	Provider string `json:"provider,omitempty"`
 }
 
-// FallbackEntry is the wire form of the operator's run-level fallback
-// route. A single route rather than a per-node chain: the value is
-// "don't lose a long run to a forfait wall", which one alternative
-// delivers, and a per-node ordered list is unusable on a real bot.
+// FallbackEntry is one stage of the operator's ordered run-level
+// fallback chain.
 type FallbackEntry struct {
 	Backend  string `json:"backend,omitempty"`
 	Model    string `json:"model,omitempty"`
 	Provider string `json:"provider,omitempty"`
 }
 
-// toRunFallback folds the launch entry into an IR route. A nil or
-// targetless entry yields the zero value, which ApplyRunFallback treats
-// as "no run-level route".
-func toRunFallback(e *FallbackEntry) ir.Fallback {
-	if e == nil {
-		return ir.Fallback{}
+// toRunFallback folds launch entries into the IR chain. Targetless
+// entries stay in place so ApplyRunFallback can preserve stage indexes
+// while screening every stage independently.
+func toRunFallback(entries []FallbackEntry) []ir.Fallback {
+	if len(entries) == 0 {
+		return nil
 	}
-	return ir.Fallback{
-		Name:     ir.RunFallbackName,
-		Backend:  e.Backend,
-		Model:    e.Model,
-		Provider: e.Provider,
+	out := make([]ir.Fallback, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, ir.Fallback{
+			Name:     ir.RunFallbackName,
+			Backend:  e.Backend,
+			Model:    e.Model,
+			Provider: e.Provider,
+		})
 	}
+	return out
 }
 
 // toModelOverrides folds the launch entries into the engine's ModelOverrides.

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -870,7 +870,7 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 		// studio Overview reads the pins from the run doc, and the resume
 		// path replays them onto its RunMessage from here.
 		ModelOverrides: runModelOverrides(spec.ModelOverrides),
-		// The run-level fallback route, same doctrine: stamped raw so the
+		// The run-level fallback chain, same doctrine: stamped raw so the
 		// resume path replays it, and mirrored onto the RunMessage below
 		// so the claiming runner applies it.
 		Fallback: runFallbackOf(spec.Fallback),
@@ -1014,8 +1014,8 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 		// doc is display-only — the studio would show an override the
 		// delegates never honoured.
 		ModelOverrides: queueModelOverrides(spec.ModelOverrides),
-		// The run-level fallback route rides the wire for the same reason:
-		// a route only persisted on the doc is display-only, and this one
+		// The run-level fallback chain rides the wire for the same reason:
+		// a chain only persisted on the doc is display-only, and this one
 		// exists precisely for unattended cloud runs hitting a provider's
 		// usage window.
 		Fallback: queueFallbackOf(spec.Fallback),
@@ -1262,9 +1262,9 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 		// A resumed attempt must honour the SAME pins the launch declared —
 		// replayed from the run doc, the single source the launch stamped.
 		ModelOverrides: queueOverridesFromRun(prior.ModelOverrides),
-		// The fallback route is replayed from the doc for the same reason:
+		// The fallback chain is replayed from the doc for the same reason:
 		// the auto-retry that follows a usage-window park is exactly the
-		// publication that must still carry the rescue route.
+		// publication that must still carry the rescue chain.
 		Fallback: queueFallbackFromRun(prior.Fallback),
 		// Carry the prior run's tenant onto the resume publication so
 		// the runner re-acquires the lease in the right scope. We trust
@@ -1653,31 +1653,49 @@ func budgetOverridesFromRun(o *store.RunBudgetOverrides) *ir.BudgetOverrides {
 	}
 }
 
-// runFallbackOf converts the launch's run-level fallback route into the
+// runFallbackOf converts the launch's run-level fallback chain into the
 // persisted run-doc form (the resume path's replay source). Targetless
-// entries persist as nil so override-less launches stay byte-identical.
-func runFallbackOf(e *runview.FallbackEntry) *store.RunFallback {
-	if e == nil || (e.Backend == "" && e.Model == "" && e.Provider == "") {
-		return nil
+// stages are omitted so override-less launches stay byte-identical.
+func runFallbackOf(entries []runview.FallbackEntry) store.RunFallback {
+	var out store.RunFallback
+	for _, e := range entries {
+		if e.Backend == "" && e.Model == "" && e.Provider == "" {
+			continue
+		}
+		out = append(out, store.RunFallbackEntry{
+			Backend: e.Backend, Model: e.Model, Provider: e.Provider,
+		})
 	}
-	return &store.RunFallback{Backend: e.Backend, Model: e.Model, Provider: e.Provider}
+	return out
 }
 
-// queueFallbackOf puts the launch's run-level fallback route on the wire.
-func queueFallbackOf(e *runview.FallbackEntry) *queue.RunFallback {
-	if e == nil || (e.Backend == "" && e.Model == "" && e.Provider == "") {
-		return nil
+// queueFallbackOf puts the launch's run-level fallback chain on the wire.
+func queueFallbackOf(entries []runview.FallbackEntry) queue.RunFallback {
+	var out queue.RunFallback
+	for _, e := range entries {
+		if e.Backend == "" && e.Model == "" && e.Provider == "" {
+			continue
+		}
+		out = append(out, queue.RunFallbackEntry{
+			Backend: e.Backend, Model: e.Model, Provider: e.Provider,
+		})
 	}
-	return &queue.RunFallback{Backend: e.Backend, Model: e.Model, Provider: e.Provider}
+	return out
 }
 
-// queueFallbackFromRun replays a run doc's persisted fallback route onto
+// queueFallbackFromRun replays a run doc's persisted fallback chain onto
 // a resume publication.
-func queueFallbackFromRun(f *store.RunFallback) *queue.RunFallback {
-	if f == nil {
+func queueFallbackFromRun(entries store.RunFallback) queue.RunFallback {
+	if len(entries) == 0 {
 		return nil
 	}
-	return &queue.RunFallback{Backend: f.Backend, Model: f.Model, Provider: f.Provider}
+	out := make(queue.RunFallback, 0, len(entries))
+	for _, f := range entries {
+		out = append(out, queue.RunFallbackEntry{
+			Backend: f.Backend, Model: f.Model, Provider: f.Provider,
+		})
+	}
+	return out
 }
 
 // queueOverridesFromRun replays a run doc's persisted pins onto a resume

--- a/pkg/server/cloudpublisher/publisher_fallback_test.go
+++ b/pkg/server/cloudpublisher/publisher_fallback_test.go
@@ -2,6 +2,7 @@ package cloudpublisher
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
@@ -37,7 +38,10 @@ func TestSubmitLaunchCarriesRunFallback(t *testing.T) {
 	spec := runview.LaunchSpec{
 		FilePath: "wf.bot",
 		Source:   "workflow wf:\n  start -> done\n",
-		Fallback: &runview.FallbackEntry{Backend: "codex", Model: "gpt-5.5"},
+		Fallback: []runview.FallbackEntry{
+			{Backend: "codex", Model: "gpt-5.5"},
+			{Backend: "claw", Model: "openai/gpt-5.5"},
+		},
 	}
 	if _, err := p.SubmitLaunch(ctx, "run-fb-1", spec, wf, "hash"); err != nil {
 		t.Fatalf("SubmitLaunch: %v", err)
@@ -45,15 +49,23 @@ func TestSubmitLaunchCarriesRunFallback(t *testing.T) {
 	if published == nil {
 		t.Fatal("nothing published")
 	}
-	if published.Fallback == nil || *published.Fallback != (queue.RunFallback{Backend: "codex", Model: "gpt-5.5"}) {
-		t.Fatalf("message fallback = %+v, want the launch route verbatim", published.Fallback)
+	wantQueue := queue.RunFallback{
+		{Backend: "codex", Model: "gpt-5.5"},
+		{Backend: "claw", Model: "openai/gpt-5.5"},
+	}
+	if !reflect.DeepEqual(published.Fallback, wantQueue) {
+		t.Fatalf("message fallback = %+v, want the launch chain verbatim", published.Fallback)
 	}
 	r, err := st.LoadRun(ctx, "run-fb-1")
 	if err != nil {
 		t.Fatalf("LoadRun: %v", err)
 	}
-	if r.Fallback == nil || r.Fallback.Backend != "codex" || r.Fallback.Model != "gpt-5.5" {
-		t.Fatalf("run doc fallback = %+v, want the route persisted for the resume replay", r.Fallback)
+	wantStore := store.RunFallback{
+		{Backend: "codex", Model: "gpt-5.5"},
+		{Backend: "claw", Model: "openai/gpt-5.5"},
+	}
+	if !reflect.DeepEqual(r.Fallback, wantStore) {
+		t.Fatalf("run doc fallback = %+v, want the chain persisted for the resume replay", r.Fallback)
 	}
 }
 
@@ -96,7 +108,10 @@ func TestSubmitResumeReplaysRunDocFallback(t *testing.T) {
 		TenantID: "team-a",
 		OwnerID:  "u1",
 		Status:   store.RunStatusFailedResumable,
-		Fallback: &store.RunFallback{Backend: "codex", Model: "gpt-5.5"},
+		Fallback: store.RunFallback{
+			{Backend: "codex", Model: "gpt-5.5"},
+			{Backend: "claw", Model: "openai/gpt-5.5"},
+		},
 	}); err != nil {
 		t.Fatalf("seed run: %v", err)
 	}
@@ -116,7 +131,11 @@ func TestSubmitResumeReplaysRunDocFallback(t *testing.T) {
 	if published == nil {
 		t.Fatal("nothing published")
 	}
-	if published.Fallback == nil || *published.Fallback != (queue.RunFallback{Backend: "codex", Model: "gpt-5.5"}) {
-		t.Fatalf("resume fallback = %+v, want the launch route replayed from the run doc — the auto-retry after a usage-window park is exactly the publication that must still carry the rescue", published.Fallback)
+	want := queue.RunFallback{
+		{Backend: "codex", Model: "gpt-5.5"},
+		{Backend: "claw", Model: "openai/gpt-5.5"},
+	}
+	if !reflect.DeepEqual(published.Fallback, want) {
+		t.Fatalf("resume fallback = %+v, want the launch chain replayed from the run doc — the auto-retry after a usage-window park is exactly the publication that must still carry the rescue", published.Fallback)
 	}
 }

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -107,11 +109,12 @@ type launchRunRequest struct {
 	// See runview.ModelOverrideEntry. The current queue contract carries them
 	// to cloud runners as well, where the executor applies them (issue #513).
 	ModelOverrides []runview.ModelOverrideEntry `json:"model_overrides,omitempty"`
-	// Fallback is the operator's single run-level fallback route, taken
-	// when an agent node's primary fails. It applies only to agent nodes
-	// that declare no `fallbacks:` of their own and never to judges.
+	// Fallback is the operator's ordered run-level fallback chain, taken
+	// when an agent node's primary or preceding stage fails. It applies only
+	// to agent nodes that declare no `fallbacks:` of their own and never to judges.
+	// A single object is promoted to a one-stage chain for compatibility.
 	// Omitted = none. See ADR-087.
-	Fallback *runview.FallbackEntry `json:"fallback,omitempty"`
+	Fallback launchFallback `json:"fallback,omitempty"`
 	// Budget carries run-level budget-cap overrides for the workflow's
 	// `budget:` block — the HTTP twin of the CLI --max-* flags. Non-zero
 	// fields win over the DSL/recipe budget; zero fields inherit. A bad
@@ -156,6 +159,41 @@ type launchRunRequest struct {
 	// holds the run's user-facing answer (the "final_answer" field).
 	// Empty → the notifier scans all artifact nodes for "final_answer".
 	CallbackAnswerNode string `json:"callback_answer_node,omitempty"`
+}
+
+// launchFallback accepts the original single-object request and the ordered
+// array form. Its default JSON marshaler always emits the canonical array.
+type launchFallback []runview.FallbackEntry
+
+func (f *launchFallback) UnmarshalJSON(data []byte) error {
+	raw := bytes.TrimSpace(data)
+	if len(raw) == 0 {
+		return fmt.Errorf("empty fallback JSON")
+	}
+	switch raw[0] {
+	case 'n':
+		if !bytes.Equal(raw, []byte("null")) {
+			return fmt.Errorf("invalid fallback JSON %q", raw)
+		}
+		*f = nil
+		return nil
+	case '[':
+		var entries []runview.FallbackEntry
+		if err := json.Unmarshal(raw, &entries); err != nil {
+			return fmt.Errorf("decode fallback chain: %w", err)
+		}
+		*f = entries
+		return nil
+	case '{':
+		var entry runview.FallbackEntry
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			return fmt.Errorf("decode legacy fallback: %w", err)
+		}
+		*f = []runview.FallbackEntry{entry}
+		return nil
+	default:
+		return fmt.Errorf("fallback must be an object or array")
+	}
 }
 
 // launchBudgetSpec is the wire shape of launchRunRequest.Budget. Field

--- a/pkg/server/runs_launch_fallback_test.go
+++ b/pkg/server/runs_launch_fallback_test.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestLaunchRunRequestFallbackAcceptsObjectAndArray(t *testing.T) {
+	tests := []struct {
+		name       string
+		raw        string
+		wantModels []string
+	}{
+		{
+			name:       "legacy object",
+			raw:        `{"fallback":{"backend":"codex","model":"gpt-5.5"}}`,
+			wantModels: []string{"gpt-5.5"},
+		},
+		{
+			name: "ordered array",
+			raw: `{"fallback":[` +
+				`{"backend":"codex","model":"gpt-5.5"},` +
+				`{"backend":"claw","model":"openai/gpt-5.5"}]}`,
+			wantModels: []string{"gpt-5.5", "openai/gpt-5.5"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var req launchRunRequest
+			if err := json.Unmarshal([]byte(tc.raw), &req); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if len(req.Fallback) != len(tc.wantModels) {
+				t.Fatalf("fallback = %+v, want %d stages", req.Fallback, len(tc.wantModels))
+			}
+			for i, want := range tc.wantModels {
+				if req.Fallback[i].Model != want {
+					t.Fatalf("fallback[%d].model = %q, want %q", i, req.Fallback[i].Model, want)
+				}
+			}
+			blob, err := json.Marshal(req)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if !bytes.Contains(blob, []byte(`"fallback":[`)) {
+				t.Fatalf("canonical launch fallback is not an array: %s", blob)
+			}
+		})
+	}
+}
+
+func TestLaunchRunRequestFallbackRejectsScalar(t *testing.T) {
+	var req launchRunRequest
+	if err := json.Unmarshal([]byte(`{"fallback":"codex:gpt-5.5"}`), &req); err == nil {
+		t.Fatal("scalar fallback must be rejected explicitly")
+	}
+}

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -274,8 +274,10 @@ const (
 	// Data keys: from_backend, to_backend, from_model, to_model,
 	// from_provider, to_provider (the credential hints, "" = auto),
 	// reason (delegate.FallbackCategory), attempts (budget spent on the
-	// failed element), error. A reactive skip additionally carries cooldown
-	// (true) and cooldown_until, with attempts=0 and no error.
+	// failed element), error. A launch-time run fallback also carries
+	// fallback_index (its zero-based destination stage). A reactive skip
+	// additionally carries cooldown (true) and cooldown_until,
+	// with attempts=0 and no error.
 	//
 	// This is the record that a fallback *chain* fired. Proxy / env
 	// overrides that rewrite the model without changing backend are

--- a/pkg/store/mongo/decode_shape_test.go
+++ b/pkg/store/mongo/decode_shape_test.go
@@ -29,6 +29,41 @@ func decodeLikeCursor(t *testing.T, in, out any) {
 	}
 }
 
+func TestRunFallbackBSONAcceptsObjectAndArray(t *testing.T) {
+	legacy := bson.D{
+		{Key: "_id", Value: "legacy-fallback"},
+		{Key: "fallback", Value: bson.D{
+			{Key: "backend", Value: "codex"},
+			{Key: "model", Value: "gpt-5.5"},
+		}},
+	}
+	var fromObject store.Run
+	decodeLikeCursor(t, legacy, &fromObject)
+	if len(fromObject.Fallback) != 1 || fromObject.Fallback[0].Backend != "codex" || fromObject.Fallback[0].Model != "gpt-5.5" {
+		t.Fatalf("legacy BSON fallback = %+v, want one promoted stage", fromObject.Fallback)
+	}
+
+	canonical := store.Run{
+		ID: "array-fallback",
+		Fallback: store.RunFallback{
+			{Backend: "codex", Model: "gpt-5.5"},
+			{Backend: "claw", Model: "openai/gpt-5.5"},
+		},
+	}
+	var fromArray store.Run
+	decodeLikeCursor(t, canonical, &fromArray)
+	if len(fromArray.Fallback) != 2 || fromArray.Fallback[1].Backend != "claw" {
+		t.Fatalf("array BSON fallback = %+v, want two ordered stages", fromArray.Fallback)
+	}
+	raw, err := bson.Marshal(canonical)
+	if err != nil {
+		t.Fatalf("marshal canonical run: %v", err)
+	}
+	if got := bson.Raw(raw).Lookup("fallback").Type; got != bson.TypeArray {
+		t.Fatalf("canonical BSON fallback type = %s, want array", got)
+	}
+}
+
 // TestEventDataDecodeShape pins the store's decode contract for the
 // open-shaped Event.Data payload: nested documents surface as plain
 // map[string]any, nested arrays as plain []any, and int32-width wire

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -1,10 +1,14 @@
 package store
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"slices"
 	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
 // ErrRunNotFound is the sentinel every RunStore.LoadRun implementation
@@ -105,12 +109,74 @@ type RunModelOverride struct {
 	Provider string `json:"provider,omitempty" bson:"provider,omitempty"`
 }
 
-// RunFallback is the persisted form of the launch's run-level fallback
-// route — the doc twin of queue.RunFallback.
-type RunFallback struct {
+// RunFallbackEntry is one persisted stage of the launch's run-level
+// fallback chain — the doc twin of queue.RunFallbackEntry.
+type RunFallbackEntry struct {
 	Backend  string `json:"backend,omitempty" bson:"backend,omitempty"`
 	Model    string `json:"model,omitempty" bson:"model,omitempty"`
 	Provider string `json:"provider,omitempty" bson:"provider,omitempty"`
+}
+
+// RunFallback is the ordered persisted chain. New JSON and BSON documents
+// encode it as an array; both decoders also promote the legacy single-object
+// representation to a one-stage chain.
+type RunFallback []RunFallbackEntry
+
+func (f *RunFallback) UnmarshalJSON(data []byte) error {
+	raw := bytes.TrimSpace(data)
+	if len(raw) == 0 {
+		return fmt.Errorf("store: empty fallback JSON")
+	}
+	switch raw[0] {
+	case 'n':
+		if !bytes.Equal(raw, []byte("null")) {
+			return fmt.Errorf("store: invalid fallback JSON %q", raw)
+		}
+		*f = nil
+		return nil
+	case '[':
+		var entries []RunFallbackEntry
+		if err := json.Unmarshal(raw, &entries); err != nil {
+			return fmt.Errorf("store: decode fallback chain: %w", err)
+		}
+		*f = entries
+		return nil
+	case '{':
+		var entry RunFallbackEntry
+		if err := json.Unmarshal(raw, &entry); err != nil {
+			return fmt.Errorf("store: decode legacy fallback: %w", err)
+		}
+		*f = []RunFallbackEntry{entry}
+		return nil
+	default:
+		return fmt.Errorf("store: fallback must be an object or array")
+	}
+}
+
+// UnmarshalBSONValue keeps legacy single-route run documents readable while
+// the canonical representation is an array.
+func (f *RunFallback) UnmarshalBSONValue(typ byte, data []byte) error {
+	switch bson.Type(typ) {
+	case bson.TypeNull:
+		*f = nil
+		return nil
+	case bson.TypeArray:
+		var entries []RunFallbackEntry
+		if err := bson.UnmarshalValue(bson.Type(typ), data, &entries); err != nil {
+			return fmt.Errorf("store: decode BSON fallback chain: %w", err)
+		}
+		*f = entries
+		return nil
+	case bson.TypeEmbeddedDocument:
+		var entry RunFallbackEntry
+		if err := bson.UnmarshalValue(bson.Type(typ), data, &entry); err != nil {
+			return fmt.Errorf("store: decode legacy BSON fallback: %w", err)
+		}
+		*f = []RunFallbackEntry{entry}
+		return nil
+	default:
+		return fmt.Errorf("store: BSON fallback must be an object or array, got %s", bson.Type(typ))
+	}
 }
 
 // NodeServed is the (backend, model) that actually served one LLM node.
@@ -292,13 +358,13 @@ type Run struct {
 	// executor at launch, never re-read from here. Empty when none, and
 	// left untouched on resume (resume doesn't re-supply them).
 	ModelOverrides []RunModelOverride `json:"model_overrides,omitempty" bson:"model_overrides,omitempty"`
-	// Fallback captures the launch-time run-level fallback route (CLI
+	// Fallback captures the launch-time run-level fallback chain (CLI
 	// `--fallback` / HTTP `fallback`) — the resume path's replay source,
 	// same doctrine as the budget ask: cloud resumes are often unattended
 	// auto-retries, so nothing else can re-state the route, and a dropped
 	// route silently strands the run on exactly the provider wall it was
 	// meant to escape.
-	Fallback *RunFallback `json:"fallback,omitempty" bson:"fallback,omitempty"`
+	Fallback RunFallback `json:"fallback,omitempty" bson:"fallback,omitempty"`
 	// NodesServed maps IR node id → last (backend, model) that served
 	// it. Display-only / post-hoc: makes a finished run self-describing
 	// without replaying events.jsonl. Empty for legacy runs and for

--- a/pkg/store/run_test.go
+++ b/pkg/store/run_test.go
@@ -1,9 +1,51 @@
 package store
 
 import (
+	"bytes"
+	"encoding/json"
 	"reflect"
 	"testing"
 )
+
+func TestRunFallbackJSONAcceptsObjectAndArray(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want RunFallback
+	}{
+		{
+			name: "legacy object",
+			raw:  `{"fallback":{"backend":"codex","model":"gpt-5.5"}}`,
+			want: RunFallback{{Backend: "codex", Model: "gpt-5.5"}},
+		},
+		{
+			name: "ordered array",
+			raw:  `{"fallback":[{"backend":"codex","model":"gpt-5.5"},{"backend":"claw","model":"openai/gpt-5.5"}]}`,
+			want: RunFallback{
+				{Backend: "codex", Model: "gpt-5.5"},
+				{Backend: "claw", Model: "openai/gpt-5.5"},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var run Run
+			if err := json.Unmarshal([]byte(tc.raw), &run); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(run.Fallback, tc.want) {
+				t.Fatalf("fallback = %+v, want %+v", run.Fallback, tc.want)
+			}
+			blob, err := json.Marshal(run)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if !bytes.Contains(blob, []byte(`"fallback":[`)) {
+				t.Fatalf("canonical fallback is not an array: %s", blob)
+			}
+		})
+	}
+}
 
 // sliceEq compares two string slices under the watched-issue helpers'
 // contract: a nil want means "must be exactly nil" (so the persisted


### PR DESCRIPTION
Extends #574: the run-level `fallback` accepts a single object (promoted, wire-compatible) **or an ordered array of stages**. Stages apply in order; a refused stage logs its typed refusal and the chain continues; the existing fallback event now carries `fallback_index`. Per-stage retry budgets — no cartesian blow-up. SchemaVersion 11 / MinSchemaVersion 10 (additive, same dual-accept pattern as v10/v9).

Motivation: one stage cannot express subscription → facade → cross-family routing, and a dead provider shared by primary+fallback still kills the run.

Drafted by codex (gpt-5.6-sol) under supervision; reviewed and tested locally: build OK, 4068 tests green across touched packages, leak-grep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)