### PR TITLE
docs: Billy bilan for the CHANGELOG run + two operational findings it surfaced

### DIFF
--- a/docs/bot-runs/branch-improve-loop.md
+++ b/docs/bot-runs/branch-improve-loop.md
@@ -1,5 +1,48 @@
 # Billy — branch-improvement validation
 
+## 2026-08-30 — three launches, zero delivery: the duration cap and the weekly cap (runs 01a0517a, 01a051dd, 01a05216)
+
+- Status: **failed.** `/billy` on SocialGouv/iterion#579 (the CHANGELOG
+  feature) produced no commit and no push across three launches. Nothing was
+  wrong with the hand-off — `prior_review` seeded, campaign working, tool
+  calls flowing — the run simply ran out of wall-clock, and the retries hit a
+  wall that was not Billy's.
+- Versions: iterion cloud prod (edge ~v3.74/3.77) · bot `branch-improve-loop`
+- Method: documented habit — Revi left 1 medium + 1 low on #579, `/billy`
+  comment as maintainer, no `skip`.
+- Result:
+
+  | run | wall-clock | outcome |
+  |---|---|---|
+  | `01a0517a` 07:02 | **2h31** | `budget exceeded: duration (9001s/9000s)` |
+  | `01a051dd` 08:51 | — | `failed_resumable` |
+  | `01a05216` 09:53 | 3 min | `usage cap: seven_day window at 75% ≥ 70% (week, hard)` |
+
+- Value: none delivered. The findings were fixed by hand instead, after the
+  weekly cap made a fourth attempt impossible before its 2026-09-01 reset.
+
+### Lessons
+
+- **The 2h30 duration cap is not sized for this repo's verify gate.** Each
+  campaign pass re-runs the repo's real build+test, measured at ~10 min a pass
+  (one tool call spanned 07:59:04 → 08:09:05). A handful of passes and the cap
+  is spent before the delivery tail. The loop budget guard declines a further
+  iteration when the budget cannot fund one, but nothing here shortened the
+  *first* pass, and the run died mid-pass with nothing committed — the exact
+  shape "commit in stride" exists to avoid. Either raise `max_duration` for
+  targets whose gate is expensive, or make the gate cheaper (scope the test
+  command to the touched packages).
+- **A run burning its whole cap with zero commits should be cancellable on
+  sight.** Nothing in the run view said "2h in, nothing banked"; the operator
+  reads `running` and waits. `commits_this_pass` exists in the contract —
+  surfacing it (or a zero-commit warning past N minutes) would have turned
+  2h31 of spend into a 20-minute decision.
+- **The habit has a precondition worth stating: Billy must be able to run.**
+  `docs/revi-billy-loop.md` says "don't hand-fix, comment /billy". When the
+  weekly cap is hard-blocking until a reset two days out, that instruction has
+  no path, and waiting is worse than fixing. The runbook should name the
+  fallback rather than leave the operator to infer it.
+
 ## 2026-08-27 — first `/billy` of the Revi→Billy habit on iterion itself (runs 01a0428a, 01a042b9, 01a042d7)
 
 - Status: **partial.** The habit's whole chain worked — `/billy` comment →

--- a/docs/ci-pipeline-topology.md
+++ b/docs/ci-pipeline-topology.md
@@ -70,3 +70,30 @@ release-images.yml   runner + sandbox @ :vX.Y.Z   push tags v*  (await image.yml
   sandbox `:edge`; tags go through `release-images.yml`, PRs publish nothing.
 - No cycles: nothing re-triggers `image.yml`, so the `image.yml → {runner,
   sandbox}` fan-out terminates.
+
+### The docs site can freeze silently — check for a stuck `pages` run
+
+`docs.yml` serialises on `concurrency: group: pages` with
+`cancel-in-progress: false`, so one run that never starts blocks the group
+forever: every later run waits behind it as `pending`, and each new push
+collapses the previous pending one to `cancelled`. The run list then shows an
+unbroken column of `cancelled` and **no failure anywhere** — nothing is red,
+the site simply stops updating.
+
+Measured 2026-08-30: a `docs` run queued since 2026-08-12 held the group for
+18 days. Every docs change in between — including a dead link that fails the
+build — never reached the site. Cancelling the zombie freed the queue
+immediately and the next run deployed.
+
+The list view hides it, because a run queued weeks ago is far down the page.
+Ask the API for what is actually stuck, not what ran recently:
+
+```sh
+gh api "repos/SocialGouv/iterion/actions/runs?status=queued&per_page=20" \
+  --jq '.workflow_runs[] | "\(.id) \(.name) \(.created_at)"'
+gh run cancel <id>   # its Pages deploy already happened; the leftover job is a zombie
+```
+
+A quicker tell, when you only want to know whether the site is current:
+`gh api repos/SocialGouv/iterion/deployments --jq '[.[]|select(.environment=="github-pages")][0].created_at'`
+— if that date is not recent, the group is stuck.

--- a/docs/revi-billy-loop.md
+++ b/docs/revi-billy-loop.md
@@ -96,6 +96,15 @@ The webhook tail resolves everything from the PR and the repo integration:
   `usage cap: … window` is `failed_resumable` with the usage-window retry
   armed — it resumes at the provider reset by itself
   ([usage-caps.md](usage-caps.md)). Don't relaunch it by hand.
+- **"Don't hand-fix" assumes Billy can run.** When the *weekly* cap is
+  hard-blocking, the reset can be days out and the habit has no path: fix the
+  findings yourself, say so on the PR against their finding ids, and write the
+  bilan for the launches that failed. Same when he burns his duration cap
+  without banking a commit — on a repo whose verify gate re-runs the whole
+  build+test (~10 min a pass here), 2h30 buys few passes, so a run sitting at
+  `running` with nothing pushed is worth cancelling rather than waiting out
+  (measured 2026-08-30: 2h31 for zero commits, see
+  [bot-runs/branch-improve-loop.md](bot-runs/branch-improve-loop.md)).
 
 ## Dogfood duty
 


### PR DESCRIPTION
Three `/billy` launches on #579 delivered nothing. The hand-off was fine — `prior_review` seeded, campaign working, tool calls flowing — but the first run spent **2h31** and died on the duration cap mid-pass with no commit banked, and the retries hit the hard **weekly usage cap** whose reset was two days out. The findings were fixed by hand instead.

| run | wall-clock | outcome |
|---|---|---|
| `01a0517a` 07:02 | **2h31** | `budget exceeded: duration (9001s/9000s)` |
| `01a051dd` 08:51 | — | `failed_resumable` |
| `01a05216` 09:53 | 3 min | `usage cap: seven_day window at 75% ≥ 70% (week, hard)` |

Two findings land where they will be looked for:

**`revi-billy-loop.md`** — "don't hand-fix, comment `/billy`" has an unstated precondition: Billy must be able to run. Names the fallback for a hard weekly cap, and for a run burning its duration without banking a commit (this repo's verify gate re-runs the whole build+test, ~10 min a pass, so 2h30 buys few passes).

**`ci-pipeline-topology.md`** — the docs site can freeze **with nothing red**. `docs.yml` serialises on `concurrency: group: pages` with `cancel-in-progress: false`, so one run that never starts blocks the group and every later run collapses to `cancelled`. A run queued since **2026-08-12 held it for 18 days** — no docs change in that window reached the site, a dead link included. Cancelling the zombie freed it at once and the next run deployed. Records the two API queries that find it, since the run list hides a run queued weeks ago.

Docs build green, 927 files link-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)