### PR TITLE
fix(test): deflake the launch tests at their cost, not their timeout

### DIFF
--- a/pkg/dispatcher/engine_runner_subbot_test.go
+++ b/pkg/dispatcher/engine_runner_subbot_test.go
@@ -227,8 +227,24 @@ func TestEngineRunner_SubbotChildHoldsRunLock(t *testing.T) {
 	t.Cleanup(func() { _ = os.WriteFile(release, []byte("go"), 0o644) })
 	childID := ""
 	held := false
+	// Watch the dispatch goroutine while polling. The child blocks until the
+	// release file exists, so Dispatch returning here means it never reached
+	// the subbot node — and its error is the diagnosis. Without this the loop
+	// runs the deadline out and reports "no child appeared", which names the
+	// symptom while the cause sits unread in the channel (observed in CI:
+	// 60s burned, nothing actionable in the log).
+	var dispatchErr error
+	dispatched := false
 	deadline := time.Now().Add(60 * time.Second)
 	for time.Now().Before(deadline) && !held {
+		select {
+		case dispatchErr = <-done:
+			dispatched = true
+		default:
+		}
+		if dispatched {
+			break
+		}
 		ids, lerr := probe.ListRuns(context.Background())
 		if lerr != nil {
 			t.Fatalf("ListRuns: %v", lerr)
@@ -272,6 +288,9 @@ func TestEngineRunner_SubbotChildHoldsRunLock(t *testing.T) {
 	if err := os.WriteFile(release, []byte("go"), 0o644); err != nil {
 		t.Fatalf("write release file: %v", err)
 	}
+	if dispatched && childID == "" {
+		t.Fatalf("Dispatch returned before any child run appeared — the subbot node was never reached: %v", dispatchErr)
+	}
 	if childID == "" {
 		t.Fatal("never observed a child run — the subbot node did not spawn one")
 	}
@@ -279,8 +298,11 @@ func TestEngineRunner_SubbotChildHoldsRunLock(t *testing.T) {
 		t.Fatal("never caught the child mid-pass — its lock was never observed held while it was blocked on the release file")
 	}
 
-	if derr := <-done; derr != nil {
-		t.Fatalf("Dispatch: %v", derr)
+	if !dispatched {
+		dispatchErr = <-done
+	}
+	if dispatchErr != nil {
+		t.Fatalf("Dispatch: %v", dispatchErr)
 	}
 	lock, err := probe.LockRun(context.Background(), childID)
 	if err != nil {

--- a/pkg/runview/service_launch_budget_test.go
+++ b/pkg/runview/service_launch_budget_test.go
@@ -29,6 +29,14 @@ human gate:
   interaction: human
 
 workflow budget_demo:
+  ## This test runs from inside iterion, so the run's workspace root is the
+  ## repo itself and both defaults bite: worktree defaults to auto (a full
+  ## git checkout of iterion per run) and repo_devbox to on (realising
+  ## iterion's own devbox.json, which a cold Nix cache turns into minutes).
+  ## The test only reads the persisted budget snapshot, so it wants neither
+  ## — together they made its wait for the human pause a coin flip.
+  worktree: none
+  repo_devbox: off
   budget:
     max_cost_usd: 60
     max_tokens: 5000

--- a/pkg/runview/service_launch_loop_budget_test.go
+++ b/pkg/runview/service_launch_loop_budget_test.go
@@ -39,6 +39,12 @@ tool deliver:
   output: deliver_out
 
 workflow loop_budget_demo:
+  ## The nodes run printf; the run needs neither a git checkout of the repo
+  ## this test lives in (worktree defaults to auto) nor its toolchain
+  ## (repo_devbox defaults to on). Both are pure latency here, and latency
+  ## is what turns a bounded wait into a flake.
+  worktree: none
+  repo_devbox: off
   budget:
     max_tokens: 10000
   entry: work


### PR DESCRIPTION
Two tests failed on wall-clock this week — `TestLaunch_AppliesBudgetOverrides` (30s, *"run goroutine did not exit"*) and `TestEngineRunner_SubbotChildHoldsRunLock` (60s, *"never observed a child run"*). Neither was slow by nature, and neither timeout is raised here.

## The launch tests paid for a repo checkout they never used

They run from inside this repo, so the run's workspace root **is** iterion, and two engine defaults bite at once: `worktree:` defaults to `auto` (a full git checkout of iterion, per run) and `repo_devbox:` to `on` (realising iterion's own `devbox.json`). That second one is the case CLAUDE.md already documents — *"the cold realise outlasted the sandbox start window often enough to kill runs"*.

Neither buys these tests anything: one reads a persisted budget snapshot, the other runs `printf` in tool nodes.

| test | before | after |
|---|---|---|
| `TestLaunch_AppliesBudgetOverrides` | 2.4s | **0.04s** |
| `TestLaunch_LoopBudgetGuardOverrideReachesTheEngine` | 5.7s | **0.15s** |

A 30s bound stops being a coin flip under load when the work costs 40ms.

## The subbot test reported the symptom and swallowed the cause

It is not slow — **0.09s under `-race` in isolation**. It burned its full 60s deadline because it polls for a child while the dispatch goroutine's error sits unread in a channel, then reports *"no child appeared"* and never why. It now watches that channel while polling.

**Canary** (subbot pointed at a missing source): 60s of nothing becomes **0.08s** naming the unreadable file —

```
Dispatch returned before any child run appeared — the subbot node was never
reached: [EXECUTION_FAILED] subbot "run_child" (source "child.bot"): compile
child "child.bot": cannot read file: … no such file or directory
```

## Deliberately left alone

The runview subbot and rewind/merge tests are slow for the same reason but assert worktree behaviour — one is literally `TestEngineRunner_SubbotChildNeverAdoptsParentWorktree`. Declaring `worktree: none` there would weaken what they prove.

Verified: `pkg/runview` + `pkg/dispatcher` green under `-race`, `task lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)