### PR TITLE
chore(golden-master): neutral placeholder paths in selftest and run notes

### DIFF
--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2458,12 +2458,12 @@ tool oracle_run:
             saved_env = {k: os.environ.get(k) for k in ("GM_SEALED_DIR", "GM_SCRATCH")}
             os.environ.pop("GM_SEALED_DIR", None)
             os.environ.pop("GM_SCRATCH", None)
-            a, b = sealed_dir_for("/w/replay/poss"), sealed_dir_for("/w/replay2/poss")
+            a, b = sealed_dir_for("/w/replay/app"), sealed_dir_for("/w/replay2/app")
             check("meme basename, deux worktrees -> deux piles", a != b, True)
             check("la pile ne vit pas dans le parent du worktree",
                   a.startswith("/w/"), False)
             check("deux processus, meme workspace -> meme pile",
-                  sealed_dir_for("/w/replay/poss") == a, True)
+                  sealed_dir_for("/w/replay/app") == a, True)
             os.environ["GM_SEALED_DIR"] = "/elsewhere/pile"
             check("GM_SEALED_DIR impose sa pile", sealed_dir_for("/w/x"), "/elsewhere/pile")
             for k, v in saved_env.items():

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2239,12 +2239,12 @@ def _selftest():
         saved_env = {k: os.environ.get(k) for k in ("GM_SEALED_DIR", "GM_SCRATCH")}
         os.environ.pop("GM_SEALED_DIR", None)
         os.environ.pop("GM_SCRATCH", None)
-        a, b = sealed_dir_for("/w/replay/poss"), sealed_dir_for("/w/replay2/poss")
+        a, b = sealed_dir_for("/w/replay/app"), sealed_dir_for("/w/replay2/app")
         check("meme basename, deux worktrees -> deux piles", a != b, True)
         check("la pile ne vit pas dans le parent du worktree",
               a.startswith("/w/"), False)
         check("deux processus, meme workspace -> meme pile",
-              sealed_dir_for("/w/replay/poss") == a, True)
+              sealed_dir_for("/w/replay/app") == a, True)
         os.environ["GM_SEALED_DIR"] = "/elsewhere/pile"
         check("GM_SEALED_DIR impose sa pile", sealed_dir_for("/w/x"), "/elsewhere/pile")
         for k, v in saved_env.items():

--- a/docs/bot-runs/golden-master.md
+++ b/docs/bot-runs/golden-master.md
@@ -450,7 +450,7 @@ capture implementations converge — a risk that did not materialise.
 ### Environment defects found (in the target's baseline harness, not the bot)
 
 5. **MySQL socket truncated at 107 characters.** `struct sockaddr_un.sun_path` is capped;
-   `~/.iterion/projects/<bot>/worktrees/<uuid>/.state/poss/mysql/mysqld.sock` is 109. The kernel
+   `~/.iterion/projects/<bot>/worktrees/<uuid>/.state/<repo>/mysql/mysqld.sock` is 109. The kernel
    truncates silently, mysqld listens somewhere the client never looks, the baseline never boots.
    Invisible on a dev checkout (71 characters). → socket moved to a short `/tmp` path keyed by a
    hash of the repo path, plus an explicit length guard.
@@ -458,7 +458,7 @@ capture implementations converge — a risk that did not materialise.
    start; at worst it captures the first one's application and produces a net that looks valid
    and describes a different tree. This happened — a dev instance was left running during a run.
    → ports derived from the repo path like the socket, effective URL published to
-   `../.state/poss/baseline-url.txt`.
+   `../.state/<repo>/baseline-url.txt`.
 
 None of these six was findable by review. All required a real run.
 


### PR DESCRIPTION
Selftest fixtures and run-note examples used a real target repo's directory name as a path literal. Replaced with neutral placeholders (`app`, `<repo>`).

No behavior change: harness selftest green, `TestGoldenMasterHarnessCopiesStayInSync` green.

Note for the maintainer: the name remains in git history; purging history is a separate decision (force-push/BFG + support), this PR just stops the bleeding at HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)