### PR TITLE
feat(golden-master): net extension by pure addition — request ledger + the net's own acting subbot

### DIFF
--- a/bots/golden-master/extend.bot
+++ b/bots/golden-master/extend.bot
@@ -67,9 +67,17 @@ prompt extend_system:
      rewritten one.
 
   A new corpus entry needs its reference captured the way the net captures
-  everything: through the harness's own record path for exactly the entries
-  you added, never by hand-writing what you believe the response is — an
-  invented reference asserts nothing.
+  everything: through the harness's own record path, scoped to exactly the
+  entries you added —
+
+      GM_MODE=record GM_RECORD_IDS=<id,...> \
+        python3 {{vars.oracle_dir}}/harness.py
+
+  — never a full re-record (inside a lot, behaviour may have legitimately
+  moved: re-recording everything rewrites every reference and is refused
+  wholesale), and never by hand-writing what you believe the response is —
+  an invented reference asserts nothing. Record the captured reference path
+  in the act: a claimed entry claims its derived refs/<id>.txt.
 
   Commit your work. The verdict is read from git; uncommitted work is
   invisible to it.

--- a/bots/golden-master/extend.bot
+++ b/bots/golden-master/extend.bot
@@ -1,0 +1,384 @@
+## ═══════════════════════════════════════════════════════════════════
+## extend — act an EXTENSION request: give the net an observation point its
+## owner was asked for, by pure addition.
+##
+## Run as a subbot from inside a modernisation lot's run. A lot whose intent
+## requires observing a surface the net does not cover yet (a new route, a
+## state only the modernised code reaches) must not write under the net to
+## get it — that is the separation of powers. It writes a REQUEST in the
+## extension ledger instead, and this bot — the net's own — acts it.
+##
+## Why an addition may be acted by a bot when a re-baseline may not: an
+## addition is CHECKABLE. It cannot mask an existing divergence; it can only
+## add a constraint. Everything that merely wears an addition's name is the
+## masking vector and is refused mechanically, by the harness's own code
+## (`GM_MODE=extend-verify`), never by this prompt:
+##
+##   ADD a reference file    → new path under refs/, absent at base.
+##   ADD a corpus entry      → every base entry survives equal, the entry is
+##                             claimed by the request, its observation tuple
+##                             collides with nothing.
+##   REWRITE / DELETE / RENAME → NEVER. The delete side of a rename is judged
+##                             separately and loses. Those go to the
+##                             re-baseline ledger and a human act.
+##
+## The line is held in git by `extend_verify` below, not by the prompt: this
+## bot runs inside the lot's own workspace, so anything it can write, the lot
+## can write through it — the check is the boundary.
+## ═══════════════════════════════════════════════════════════════════
+
+vars:
+  workspace_dir: string = "${PROJECT_DIR}"
+  oracle_dir:    string = ".golden-master"
+  ## Which lot requested the extensions — context for the work, never
+  ## authority: the requests themselves are read from the ledger.
+  lot_id: string = ""
+  ## One acting pass, then a second only if the first was refused. A third
+  ## pass on the same refusal is an agent arguing with a deterministic check.
+  max_passes: int = 2
+
+## ─── Prompts ───────────────────────────────────────────────────────
+
+prompt extend_system:
+  You extend a behavioural non-regression net by PURE ADDITION, acting
+  requests its owner's ledger carries.
+
+  Read the bundled skills first: `golden-master` for the method the net rests
+  on and what a reference is; `surface-discovery` for how an observation
+  point is written so it actually observes.
+
+  Four rules override any instinct to make the check pass:
+
+  1. Additions ONLY, on the extension surface ONLY: new files under `refs/`,
+     new entries in `corpus.json`. A deterministic check reads the git diff
+     against the run's base and refuses anything else — a rewritten file, a
+     deleted file, a touched entry, a path under canon/ or mutants/ or the
+     harness. It names what you touched.
+  2. Act EXACTLY what each request declares — its paths, its entries. An
+     addition beside the request is smuggling and is refused as such; do not
+     improve, complete, or tidy while you are here.
+  3. Never write a request. You act them. A request you cannot satisfy by
+     pure addition (it needs a rewrite, a rename, a removal) is REFUSED in
+     your report with the reason — its requester takes it to the re-baseline
+     ledger and a human. Do not close it, do not work around it.
+  4. Record every path you touched in the act block
+     (`iterion:extension-act`, one JSON object, `recorded_paths`), APPENDED
+     to the ledger — the ledger is an audit trail and the check refuses a
+     rewritten one.
+
+  A new corpus entry needs its reference captured the way the net captures
+  everything: through the harness's own record path for exactly the entries
+  you added, never by hand-writing what you believe the response is — an
+  invented reference asserts nothing.
+
+  Commit your work. The verdict is read from git; uncommitted work is
+  invisible to it.
+
+prompt extend_user:
+  Repository: `{{vars.workspace_dir}}`. Net: `{{vars.oracle_dir}}`.
+  Ledger: `{{vars.oracle_dir}}/EXTENSIONS.md`.
+
+  Lot `{{vars.lot_id}}` left these extension requests pending:
+
+  {{input.pending}}
+
+  For each: read its request block in the ledger, apply it by pure addition,
+  capture the reference through the harness's record path, append the act
+  block with every path you touched, and commit. Check your work the way the
+  gate will:
+
+      GM_MODE=extend-verify GM_BASE=<base sha> \
+        python3 {{vars.oracle_dir}}/harness.py
+
+  That is the harness deciding whether each acted extension is a pure
+  addition. It says NOTHING about whether the net now OBSERVES the new
+  surface — only the full gate captures and compares, and it runs after you.
+
+  {{input.fail_log}}
+
+  Report ONE short line in `summary` — including which requests you REFUSED
+  and why, if any. Anything longer belongs in the commit message.
+
+## ─── Schemas ───────────────────────────────────────────────────────
+
+schema campaign_input:
+  pending: string
+  fail_log: string
+
+## One field, and it is not believed. The deterministic check below is the
+## sole authority on whether the extension holds.
+schema campaign_output:
+  summary: string
+
+schema base_state:
+  head: string
+  dirty: string
+  pending: json
+  notice: string
+
+## Not one field here is an opinion.
+schema verify_report:
+  committed: bool
+  scope_clean: bool
+  out_of_scope: string[]
+  additions_ok: bool
+  refused: json
+  no_new_requests: bool
+  still_pending: json
+  extended: int
+  log_tail: string
+
+schema gate_state:
+  converged: bool
+  fail_log: string
+
+## What the parent reads back.
+schema extend_result:
+  converged: bool
+  extended: int
+  notice: string
+
+## ─── Nodes ─────────────────────────────────────────────────────────
+
+## extend_base — the commit this run starts from, and the requests to act.
+##
+## Captured BEFORE the agent, because every check below compares against it.
+## Reading it afterwards would compare the work with itself and pass by
+## construction. The pending list is read by the harness's own code — the
+## party that decides what is pending is the harness, and asking twice
+## invites two answers.
+tool extend_base:
+  output: base_state
+  language: py
+  script: |
+    import json
+    import os
+    import subprocess
+
+    ws = {{vars.workspace_dir}}
+    gm = {{vars.oracle_dir}}
+
+    head = subprocess.run(["git", "-C", ws, "rev-parse", "HEAD"],
+                          capture_output=True, text=True)
+    dirty = subprocess.run(["git", "-C", ws, "status", "--porcelain"],
+                           capture_output=True, text=True)
+
+    pending, notice = [], ""
+    if head.returncode != 0:
+        notice = "git cannot answer on %s: %s" % (ws, (head.stderr or "").strip())
+    else:
+        env = dict(os.environ, GM_MODE="extensions", GM_WORKSPACE=ws, GM_DIR=gm)
+        p = subprocess.run(["python3", os.path.join(ws, gm, "harness.py")],
+                           cwd=ws, env=env, capture_output=True, text=True,
+                           timeout=300)
+        try:
+            pending = json.loads((p.stdout or "").strip().splitlines()[-1]).get("pending") or []
+        except (ValueError, IndexError):
+            notice = ("the harness did not answer GM_MODE=extensions (exit %d): %s"
+                      % (p.returncode, (p.stdout + p.stderr)[-400:]))
+    if dirty.returncode == 0 and dirty.stdout.strip() and not notice:
+        # Said, not refused: the parent commits its lot before verifying, so a
+        # dirty tree here means something else is in flight — and this run's
+        # additions would be indistinguishable from it in the diff.
+        notice = ("the workspace was already dirty when this extension started "
+                  "(%d path(s)); the checks below compare against HEAD, so those "
+                  "changes will be read as this run's."
+                  % len([l for l in dirty.stdout.splitlines() if l.strip()]))
+
+    print(json.dumps({"head": head.stdout.strip(), "dirty": dirty.stdout.strip(),
+                      "pending": pending, "notice": notice}))
+
+agent extend_campaign:
+  backend: "claude_code"
+  model: "${ITERION_GOLDEN_MASTER_MODEL_CLAUDE:-claude-opus-5}"
+  reasoning_effort: "${ITERION_GOLDEN_MASTER_EFFORT:-high}"
+  input: campaign_input
+  output: campaign_output
+  system: extend_system
+  user: extend_user
+  session: fresh
+  skills: ["golden-master", "surface-discovery"]
+
+## extend_verify — the whole verdict, deterministic, in one node.
+##
+## Scope first, for the same reason as everywhere in this bundle: a run that
+## touched the judge's territory has already done the damage, and nothing it
+## did afterwards matters. Then the additions-only verdict, decided by the
+## HARNESS's code — the same code that will refuse at the gate.
+tool extend_verify:
+  input: verify_input
+  output: verify_report
+  language: py
+  script: |
+    import json
+    import os
+    import subprocess
+
+    ws = {{vars.workspace_dir}}
+    gm = {{vars.oracle_dir}}
+    base = {{input.head}}
+    before = {p.get("id") for p in ({{input.pending}} or []) if p.get("id")}
+
+    report = {"committed": False, "scope_clean": False, "out_of_scope": [],
+              "additions_ok": False, "refused": [], "no_new_requests": False,
+              "still_pending": [], "extended": 0, "log_tail": ""}
+    problems = []
+
+    def git(*args):
+        p = subprocess.run(["git", "-C", ws] + list(args),
+                           capture_output=True, text=True, timeout=120)
+        return p.returncode, p.stdout, p.stderr
+
+    # 1. Committed. The verdict below reads git; uncommitted work is a tree
+    #    the verdict never sees.
+    code, out, err = git("status", "--porcelain")
+    if code != 0:
+        problems.append("git cannot answer on %s: %s" % (ws, err.strip()))
+    else:
+        report["committed"] = not out.strip()
+        if out.strip():
+            paths = sorted(l[3:] for l in out.splitlines() if l.strip())
+            problems.append("the extension is NOT COMMITTED (%d path(s): %s). "
+                            "Commit, then verify."
+                            % (len(paths), ", ".join(paths[:12])))
+
+    # 2. Scope — THE line. Every path this run touched must be on the
+    #    extension surface: refs/, corpus.json, the ledger. Canon, mutants,
+    #    configuration, coverage, the harness and all product code are the
+    #    judge's territory, and naming them is the failure.
+    gmp = gm.rstrip("/")
+    allowed_exact = {gmp + "/corpus.json", gmp + "/EXTENSIONS.md"}
+    allowed_prefix = gmp + "/refs/"
+    code, out, err = git("diff", "--name-only", base, "HEAD")
+    if code != 0:
+        problems.append("cannot diff against %s: %s" % (base, err.strip()))
+    else:
+        touched = sorted(l.strip() for l in out.splitlines() if l.strip())
+        outside = [p for p in touched
+                   if p not in allowed_exact and not p.startswith(allowed_prefix)]
+        report["out_of_scope"] = outside
+        report["scope_clean"] = not outside
+        if outside:
+            problems.append(
+                "%d path(s) OUTSIDE the extension surface were changed: %s. "
+                "This bot runs inside the lot's own workspace — anything it "
+                "may write, the lot may write through it. The check is the "
+                "boundary." % (len(outside), ", ".join(outside[:20])))
+
+    def harness(mode, **extra):
+        env = dict(os.environ, GM_MODE=mode, GM_WORKSPACE=ws, GM_DIR=gm, **extra)
+        p = subprocess.run(["python3", os.path.join(ws, gm, "harness.py")],
+                           cwd=ws, env=env, capture_output=True, text=True,
+                           timeout=300)
+        try:
+            return json.loads((p.stdout or "").strip().splitlines()[-1])
+        except (ValueError, IndexError):
+            problems.append("the harness did not answer GM_MODE=%s (exit %d): %s"
+                            % (mode, p.returncode, (p.stdout + p.stderr)[-400:]))
+            return None
+
+    # 3. Additions-only, decided by the harness's own code — the same code
+    #    that refuses at the gate, so passing here and failing there is not a
+    #    state that exists.
+    verdict = harness("extend-verify", GM_BASE=base)
+    if verdict is not None:
+        if verdict.get("error"):
+            problems.append(str(verdict["error"]))
+        bad = [r for r in (verdict.get("acted") or []) if not r.get("ok")]
+        report["additions_ok"] = (not bad and not verdict.get("problems")
+                                  and bool(verdict.get("acted")))
+        report["extended"] = len([r for r in (verdict.get("acted") or [])
+                                  if r.get("ok")])
+        for r in bad:
+            problems.append("extension %s refused: %s"
+                            % (r.get("id"), "; ".join(r.get("problems") or [])))
+        for p_ in (verdict.get("problems") or []):
+            problems.append(p_)
+        if not verdict.get("acted"):
+            problems.append("no act block was appended — a run that acted "
+                            "nothing extended nothing (refusals are reported, "
+                            "not silently skipped)")
+
+    # 4. No new requests. This bot ACTS requests; writing one would let it
+    #    hand itself work the lot never asked for.
+    if verdict is not None:
+        report["no_new_requests"] = int(verdict.get("requests_added") or 0) == 0
+        if not report["no_new_requests"]:
+            problems.append("%d request(s) were ADDED during this run — this "
+                            "bot acts requests, it never writes them"
+                            % verdict.get("requests_added"))
+
+    # What is STILL pending is reported, not judged: a request refused with a
+    # written reason legitimately remains pending — it goes back to its
+    # requester, and the parent's gate keeps refusing until someone with the
+    # authority closes it. This bot failing to act everything must never be
+    # quieter than the requests not existing.
+    listing = harness("extensions")
+    if listing is not None:
+        report["still_pending"] = listing.get("pending") or []
+        report["refused"] = [p_ for p_ in report["still_pending"]
+                             if p_.get("id") in before]
+
+    report["log_tail"] = "\n".join(problems)[-6000:]
+    print(json.dumps(report))
+
+schema verify_input:
+  head: string
+  pending: json
+
+## A pure CONJUNCTION, never an aggregate. An extension that is additions-ok
+## but out of scope is not "mostly fine" — it is a lot writing in the judge's
+## territory through the net's own bot.
+compute extend_gate:
+  output: gate_state
+  expr:
+    converged: "outputs.extend_verify.committed && outputs.extend_verify.scope_clean && outputs.extend_verify.additions_ok && outputs.extend_verify.no_new_requests"
+    fail_log: "outputs.extend_verify.log_tail"
+
+## What the parent reads back. `extended` is the harness's count, never the
+## agent's claim.
+compute extend_result:
+  output: extend_result
+  publish: notice
+  expr:
+    converged: "outputs.extend_gate.converged"
+    extended: "outputs.extend_verify.extended"
+    notice: "if(outputs.extend_gate.converged, 'extensions acted by pure addition; whether the net now OBSERVES them is the gate to say', 'the extension was REFUSED: ' + outputs.extend_gate.fail_log)"
+
+workflow extend:
+  entry: extend_base
+
+  ## No `sandbox:` block (ADR-082): this runs inside the parent lot's
+  ## workspace, on the toolchain the target repository declares for itself.
+
+  budget:
+    max_parallel_branches: 1
+    max_duration: "1h"
+    max_cost_usd: 20
+
+  extend_base -> extend_campaign with {
+    pending:  "{{outputs.extend_base.pending}}",
+    fail_log: ""
+  }
+
+  extend_campaign -> extend_verify with {
+    head:    "{{outputs.extend_base.head}}",
+    pending: "{{outputs.extend_base.pending}}"
+  }
+
+  extend_verify -> extend_gate
+  extend_gate -> extend_result when converged
+
+  ## Refused → one more pass, carrying the deterministic refusal so the agent
+  ## fixes the cause instead of re-deriving it.
+  extend_gate -> extend_campaign as repair_loop("{{vars.max_passes}}") with {
+    pending:  "{{outputs.extend_base.pending}}",
+    fail_log: "{{outputs.extend_gate.fail_log}}"
+  }
+
+  ## Loop exhausted → report the refusal rather than swallow it. The parent's
+  ## gate keeps refusing on the pending requests, so this bot failing must
+  ## never be quieter than this bot not existing.
+  extend_gate -> extend_result
+
+  extend_result -> done

--- a/bots/golden-master/extend.bot
+++ b/bots/golden-master/extend.bot
@@ -249,7 +249,12 @@ tool extend_verify:
     gmp = gm.rstrip("/")
     allowed_exact = {gmp + "/corpus.json", gmp + "/EXTENSIONS.md"}
     allowed_prefix = gmp + "/refs/"
-    code, out, err = git("diff", "--name-only", base, "HEAD")
+    # quotePath=false: a non-ASCII reference path comes back quoted and no
+    # longer matches the allowed prefix — the subbot would refuse its own
+    # correct work (adversarial finding, executed).
+    code, out, err = git("-c", "core.quotePath=false",
+                         "diff", "--name-only", base, "HEAD")
+    touched = []
     if code != 0:
         problems.append("cannot diff against %s: %s" % (base, err.strip()))
     else:
@@ -285,7 +290,18 @@ tool extend_verify:
         if verdict.get("error"):
             problems.append(str(verdict["error"]))
         bad = [r for r in (verdict.get("acted") or []) if not r.get("ok")]
+        # Every surface path this run touched must be CERTIFIED, not merely
+        # in scope: a refs file added beside the acted ones is smuggling,
+        # and it must be refused here, not discovered at the parent's gate.
+        certified = set(verdict.get("ok_paths") or [])
+        certified.add(gmp + "/EXTENSIONS.md")
+        uncertified = [p for p in touched if p not in certified]
+        if uncertified:
+            problems.append("%d touched path(s) no certified act covers: %s "
+                            "— acting more than was asked is smuggling"
+                            % (len(uncertified), ", ".join(uncertified[:12])))
         report["additions_ok"] = (not bad and not verdict.get("problems")
+                                  and not uncertified
                                   and bool(verdict.get("acted")))
         report["extended"] = len([r for r in (verdict.get("acted") or [])
                                   if r.get("ok")])

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1334,14 +1334,15 @@ tool oracle_run:
     ## never a masked duplicate.
     OBSERVATION_FIELDS = ("method", "path", "persona", "surface", "fields",
                           "steps", "params", "query", "body", "readback",
-                          "no_redirect")
+                          "no_redirect", "csrf_field")
 
 
     def _entry_observation_key(entry):
         """What an entry OBSERVES: two entries equal under this key are two
-        references for one observation — a collision, not an addition."""
-        return json.dumps({k: entry.get(k) for k in OBSERVATION_FIELDS
-                           if k in entry},
+        references for one observation — a collision, not an addition. Absent
+        and empty collapse together — a twin carrying `"query": ""` must not
+        split the key on mere PRESENCE (consolidation finding, executed)."""
+        return json.dumps({k: (entry.get(k) or None) for k in OBSERVATION_FIELDS},
                           sort_keys=True, ensure_ascii=False)
 
 
@@ -1469,6 +1470,20 @@ tool oracle_run:
                             "entry %r was MODIFIED — a rewrite is the masking "
                             "vector, not an extension" % bid)
                 added_ids = set(head_by_id) - set(base_by_id)
+                # An entry id DERIVES a reference path (refs/<id>.txt) in the
+                # record and gate paths, unvalidated there — so an added id
+                # carrying a separator is a write to an EXISTING reference
+                # wearing an addition's name, the corpus-surface twin of the
+                # refs/ symlink (consolidation finding, executed with
+                # id "../refs/1").
+                for aid in sorted(added_ids):
+                    if not isinstance(aid, str) or not aid or aid in (".", "..") \
+                            or any(c in aid for c in "/\\") \
+                            or aid != os.path.basename(aid):
+                        corpus_problems.append(
+                            "added entry id %r derives a reference path outside "
+                            "refs/ — a write to an existing reference wearing an "
+                            "addition's name" % (aid,))
                 claimed = set()
                 for act in acts:
                     req = requests.get(act.get("id"))
@@ -1536,13 +1551,22 @@ tool oracle_run:
                             "%s is not a regular file (mode %s) — a link is a "
                             "write to somewhere else wearing an addition's name"
                             % (p, blob_mode("HEAD", p) or "?"))
-                    elif req is not None and p not in (req.get("paths") or []):
-                        # Added refs are claimed against the request the way
-                        # entries are claimed against corpus_entries — acting
-                        # more than was asked is smuggling, whichever surface.
+                    elif req is not None and p not in (req.get("paths") or []) \
+                            and p not in {refs_prefix + e["id"] + ".txt"
+                                          for e in (req.get("corpus_entries") or [])
+                                          if isinstance(e, dict)
+                                          and isinstance(e.get("id"), str)
+                                          and e["id"] == os.path.basename(e["id"])}:
+                        # Added refs are claimed against the request — explicitly
+                        # in `paths` (add-file), or implicitly as the reference an
+                        # add-entry's claimed entry DERIVES (the gate demands
+                        # refs/<id>.txt for every entry, so a claimed entry claims
+                        # its reference; ids carrying separators derive nothing —
+                        # they are refused above). Anything else is smuggling.
                         row["problems"].append(
-                            "%s is not declared in the request's `paths` — "
-                            "acting more than was asked is smuggling" % p)
+                            "%s is neither declared in the request's `paths` nor "
+                            "derived from a claimed corpus entry — acting more "
+                            "than was asked is smuggling" % p)
                 else:
                     row["problems"].append(
                         "%s is outside the extension surface (refs/ and "
@@ -2989,6 +3013,53 @@ tool oracle_run:
             check("corpus malforme -> refuse, pas une traceback",
                   extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
 
+            # 8g. Les refus du tour de CONSOLIDATION — la classe id-derive-un-
+            #     chemin et la cle sensible a la presence, plus le flux add-entry
+            #     legitime que le durcissement du tour 1 avait ferme.
+
+            # Un id ajoute portant un separateur derive refs/<id>.txt HORS de
+            # refs/ — le jumeau corpus du symlink.
+            xreset()
+            traversal = {"id": "../refs/1", "method": "GET", "path": "/t", "persona": "p"}
+            xledger(("request", '{"id": "E-5", "lot": "L", "corpus_entries": [{"id": "../refs/1"}]}'),
+                    ("act", '{"id": "E-5", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, traversal]}, f)
+            xcommit()
+            check("id en traversee (../refs/1) -> refuse",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+            # La PRESENCE d'un champ allowliste vide ne scinde pas la cle.
+            xreset()
+            present_twin = dict(base_entry, id="9", query="")
+            xledger(("request", '{"id": "E-3", "lot": "L", "corpus_entries": [{"id": "9"}]}'),
+                    ("act", '{"id": "E-3", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, present_twin]}, f)
+            xcommit()
+            check("collision masquee par un champ allowliste VIDE -> refusee",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+            # Le flux add-entry LEGITIME : l'entree revendiquee revendique sa
+            # reference derivee — corpus.json ET refs/2.txt exemptes, sans
+            # `paths` dans la demande (la forme que la doctrine prescrit).
+            xreset()
+            xledger(("request", '{"id": "E-2", "lot": "L", "type": "add-entry",'
+                                ' "corpus_entries": [{"id": "2"}]}'),
+                    ("act", '{"id": "E-2", "lot": "L", "recorded_paths":'
+                            ' [".golden-master/corpus.json", ".golden-master/refs/2.txt"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, new_entry]}, f)
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("ref-2\n")
+            xcommit()
+            v = extension_verdict(xroot, ".golden-master", xbase)
+            check("add-entry avec sa ref derivee, sans `paths` -> ok, les deux exemptes",
+                  [v["acted"][0]["ok"], v["ok_paths"]],
+                  [True, [".golden-master/corpus.json", ".golden-master/refs/2.txt"]])
+
             # 9. Scellement : derivable partout, jamais dans le parent du worktree
             #    (lecture seule en sandbox), et sans collision entre worktrees
             #    freres qui partagent le meme basename.
@@ -3370,7 +3441,22 @@ tool oracle_run:
 
         try:
             if mode == "record":
-                snap = capture(config, corpus, canon)
+                # GM_RECORD_IDS scopes the record to named entries — the extension
+                # subbot needs to capture EXACTLY the entries it added: a full
+                # re-record inside a lot where behaviour legitimately moved would
+                # rewrite every reference and be refused wholesale as smuggling.
+                only = [i for i in os.environ.get("GM_RECORD_IDS", "").split(",")
+                        if i.strip()]
+                if only:
+                    known = {e["id"] for e in corpus["entries"]}
+                    missing = [i for i in only if i not in known]
+                    if missing:
+                        bail("GM_RECORD_IDS names %d entr%s absent from the "
+                             "corpus: %s — recording an unknown id writes a "
+                             "reference nothing will ever compare"
+                             % (len(missing), "y" if len(missing) == 1 else "ies",
+                                ", ".join(missing)))
+                snap = capture(config, corpus, canon, ids=only or None)
                 for k, v in snap.items():
                     with open(os.path.join(refs_dir, k + ".txt"), "w", encoding="utf-8", newline="") as f:
                         f.write(v)

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1578,6 +1578,14 @@ tool oracle_run:
                 verdict["ok_paths"].extend(row["paths"])
             verdict["acted"].append(row)
 
+        # Corpus damage must surface even when NO act recorded corpus.json —
+        # otherwise a hand-run of this mode shows every row ok and an empty
+        # problems list while the corpus sits amputated, and the reader walks
+        # away reassured by the very command meant to warn them (review note).
+        if corpus_changed and corpus_problems and \
+                not any(corpus_rel in (a.get("recorded_paths") or []) for a in acts):
+            verdict["problems"].extend(corpus_problems)
+
         verdict["ok_paths"] = sorted(set(verdict["ok_paths"]))
         return verdict
 

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1310,18 +1310,38 @@ tool oracle_run:
         if not text:
             return []
         requests = _extension_blocks(text, "request")
-        acted = {b.get("id") for b in _extension_blocks(text, "act")}
-        if any(r.get("id") == "UNPARSEABLE" for r in requests) or "UNPARSEABLE" in acted:
+        acts = _extension_blocks(text, "act")
+        if any(b.get("id") == "UNPARSEABLE" for b in requests + acts):
             return [{"id": "UNPARSEABLE",
                      "why": "a ledger block does not parse as JSON — escalate, do not guess"}]
+        # Only a WELL-FORMED act closes a request: an act with no recorded path
+        # acted nothing, and letting it close the term would let the constrained
+        # party silence the conjunction with four lines of JSON — the
+        # additions-only verdict never runs at gate time, so this shape check is
+        # the whole defence here (adversarial finding, executed).
+        acted = {b["id"] for b in acts
+                 if isinstance(b.get("recorded_paths"), list) and b["recorded_paths"]}
         return [{"id": r["id"], "lot": r.get("lot", "?")}
                 for r in requests if r["id"] not in acted]
 
 
+    ## The fields that DECIDE what an entry observes. An allowlist, not
+    ## "everything but id": a stripped-everything key is defeated by one cosmetic
+    ## key (`note`, `comment`) that makes two identical observations compare
+    ## different (adversarial finding, executed). Fields outside this list do not
+    ## discriminate; if the harness later grows a discriminating field, the
+    ## failure mode is a FALSE collision — refused, escalated to the requester —
+    ## never a masked duplicate.
+    OBSERVATION_FIELDS = ("method", "path", "persona", "surface", "fields",
+                          "steps", "params", "query", "body", "readback",
+                          "no_redirect")
+
+
     def _entry_observation_key(entry):
-        """What an entry OBSERVES, id stripped: two entries equal under this key
-        are two references for one observation — a collision, not an addition."""
-        return json.dumps({k: v for k, v in entry.items() if k != "id"},
+        """What an entry OBSERVES: two entries equal under this key are two
+        references for one observation — a collision, not an addition."""
+        return json.dumps({k: entry.get(k) for k in OBSERVATION_FIELDS
+                           if k in entry},
                           sort_keys=True, ensure_ascii=False)
 
 
@@ -1352,9 +1372,23 @@ tool oracle_run:
             code, out, _ = git("show", "%s:%s" % (ref, path))
             return out if code == 0 else None
 
+        def blob_mode(ref, path):
+            code, out, _ = git("ls-tree", ref, "--", path)
+            return out.split()[0] if code == 0 and out.strip() else ""
+
         ledger_rel = gm_rel.rstrip("/") + "/EXTENSIONS.md"
         corpus_rel = gm_rel.rstrip("/") + "/corpus.json"
         refs_prefix = gm_rel.rstrip("/") + "/refs/"
+
+        # An unresolvable base and an honest "absent at base" both read as None
+        # below, so a bad sha would certify everything as an addition — a guard
+        # whose failure mode is a full pass (adversarial finding, executed).
+        # Refuse it the way an empty base is refused.
+        code, _, err = git("rev-parse", "--verify", "--quiet", base + "^{commit}")
+        if code != 0:
+            return {"error": "GM_BASE %r does not resolve to a commit (%s) — "
+                             "judging additions against nothing would pass by "
+                             "construction" % (base, err.strip() or "unknown ref")}
 
         verdict = {"acted": [], "ok_paths": [], "ledger_append_only": True,
                    "requests_added": 0, "problems": []}
@@ -1392,13 +1426,38 @@ tool oracle_run:
                 base_c = json.loads(base_corpus_txt or "{}")
             except ValueError as e:
                 corpus_problems.append("corpus.json does not parse: %s" % e)
+            if head_c is not None and base_c is not None and \
+                    not isinstance(head_c, dict):
+                corpus_problems.append("corpus.json is not an object")
+                head_c = base_c = None
+            if head_c is not None and base_c is not None and (
+                    not isinstance(head_c.get("entries", []), list)
+                    or not all(isinstance(e, dict)
+                               for e in head_c.get("entries", []))):
+                corpus_problems.append(
+                    "corpus.json `entries` is not a list of objects — refused, "
+                    "not crashed")
+                head_c = base_c = None
             if head_c is not None and base_c is not None:
                 if {k: v for k, v in head_c.items() if k != "entries"} != \
                         {k: v for k, v in base_c.items() if k != "entries"}:
                     corpus_problems.append(
                         "corpus.json keys outside `entries` changed — an "
                         "extension adds entries and touches nothing else")
-                base_by_id = {e.get("id"): e for e in base_c.get("entries", [])}
+                # An id names ONE observation. Duplicated ids collapse in every
+                # by-id index (this one, the capture map, the refs map), so the
+                # equality check would read the surviving twin while the capture
+                # hands the reference to the other — an existing observation
+                # hijacked through the channel (adversarial finding, executed).
+                head_ids = [e.get("id") for e in head_c.get("entries", [])]
+                dupes = sorted({i for i in head_ids if head_ids.count(i) > 1})
+                if dupes:
+                    corpus_problems.append(
+                        "duplicate entry id(s) %s — an id is one observation, "
+                        "and a twin id hands the capture to whichever entry "
+                        "wins an ordering nobody audits" % ", ".join(map(repr, dupes)))
+                base_by_id = {e.get("id"): e for e in base_c.get("entries", [])
+                              if isinstance(e, dict)}
                 head_by_id = {e.get("id"): e for e in head_c.get("entries", [])}
                 for bid, be in base_by_id.items():
                     if bid not in head_by_id:
@@ -1468,6 +1527,22 @@ tool oracle_run:
                         row["problems"].append(
                             "%s is recorded but absent at HEAD — a recorded "
                             "delete, and a delete is the masking vector" % p)
+                    elif blob_mode("HEAD", p) not in ("100644", "100755"):
+                        # A symlink's content is its target string, so it passes
+                        # every text check while the next record pass writes
+                        # THROUGH it onto an existing reference — an addition
+                        # that masks (adversarial finding, executed).
+                        row["problems"].append(
+                            "%s is not a regular file (mode %s) — a link is a "
+                            "write to somewhere else wearing an addition's name"
+                            % (p, blob_mode("HEAD", p) or "?"))
+                    elif req is not None and p not in (req.get("paths") or []):
+                        # Added refs are claimed against the request the way
+                        # entries are claimed against corpus_entries — acting
+                        # more than was asked is smuggling, whichever surface.
+                        row["problems"].append(
+                            "%s is not declared in the request's `paths` — "
+                            "acting more than was asked is smuggling" % p)
                 else:
                     row["problems"].append(
                         "%s is outside the extension surface (refs/ and "
@@ -2840,6 +2915,78 @@ tool oracle_run:
                 f.write("ref-2\n")
             xcommit()
             check("acte sans demande -> refuse",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+            # 8f. Les refus arraches par la revue adversariale — chaque
+            #     deguisement executee contre le verdict doit rester rouge.
+
+            # Un acte VIDE ne ferme pas le terme de conjonction : quatre lignes
+            # de JSON suffiraient a la partie contrainte pour eteindre la porte.
+            xledger(("request", req2), ("act", '{"id": "E-1", "lot": "L"}'))
+            check("acte sans recorded_paths -> la demande RESTE pendante",
+                  [p["id"] for p in pending_extensions(xgm)], ["E-1"])
+            xledger(("request", req2),
+                    ("act", '{"id": "E-1", "lot": "L", "recorded_paths": []}'))
+            check("acte a recorded_paths vide -> la demande RESTE pendante",
+                  [p["id"] for p in pending_extensions(xgm)], ["E-1"])
+
+            # Un symlink sous refs/ : son contenu est sa cible, la prochaine
+            # passe record ecrit A TRAVERS lui sur une reference existante.
+            xreset()
+            xledger(("request", req2), ("act", act2))
+            os.symlink("1.txt", os.path.join(xgm, "refs", "2.txt"))
+            xcommit()
+            check("symlink sous refs/ -> refuse",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+            # Un chemin refs/ enregistre mais non declare par la demande.
+            xreset()
+            xledger(("request", req2),
+                    ("act", '{"id": "E-1", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/refs/3.txt"]}'))
+            with open(os.path.join(xgm, "refs", "3.txt"), "w", encoding="utf-8") as f:
+                f.write("ref-3\n")
+            xcommit()
+            check("ref ajoutee non declaree par la demande -> refusee",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+            # Un id duplique : l'egalite lit un jumeau, la capture sert l'autre.
+            xreset()
+            xledger(("request", '{"id": "E-2", "lot": "L", "corpus_entries": [{"id": "1"}]}'),
+                    ("act", '{"id": "E-2", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            twin = dict(base_entry, path="/detournee")
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [twin, base_entry]}, f)
+            xcommit()
+            check("id duplique dans le corpus -> refuse",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+            # Une cle cosmetique ne neutralise pas la collision d'observation.
+            xreset()
+            cosmetic = dict(base_entry, id="9", note="differente en apparence")
+            xledger(("request", '{"id": "E-3", "lot": "L", "corpus_entries": [{"id": "9"}]}'),
+                    ("act", '{"id": "E-3", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, cosmetic]}, f)
+            xcommit()
+            check("collision masquee par une cle cosmetique -> refusee",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+            # Une base irresoluble ne tamponne rien : elle refuse.
+            check("GM_BASE irresoluble -> erreur, pas un laissez-passer",
+                  "error" in extension_verdict(xroot, ".golden-master", "d" * 40), True)
+
+            # Un corpus malforme refuse, il ne crashe pas.
+            xreset()
+            xledger(("request", '{"id": "E-2", "lot": "L", "corpus_entries": [{"id": "2"}]}'),
+                    ("act", '{"id": "E-2", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                f.write('{"entries": {"E1": {}}}')
+            xcommit()
+            check("corpus malforme -> refuse, pas une traceback",
                   extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
 
             # 9. Scellement : derivable partout, jamais dans le parent du worktree

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -2458,12 +2458,12 @@ tool oracle_run:
             saved_env = {k: os.environ.get(k) for k in ("GM_SEALED_DIR", "GM_SCRATCH")}
             os.environ.pop("GM_SEALED_DIR", None)
             os.environ.pop("GM_SCRATCH", None)
-            a, b = sealed_dir_for("/w/replay/poss"), sealed_dir_for("/w/replay2/poss")
+            a, b = sealed_dir_for("/w/replay/app"), sealed_dir_for("/w/replay2/app")
             check("meme basename, deux worktrees -> deux piles", a != b, True)
             check("la pile ne vit pas dans le parent du worktree",
                   a.startswith("/w/"), False)
             check("deux processus, meme workspace -> meme pile",
-                  sealed_dir_for("/w/replay/poss") == a, True)
+                  sealed_dir_for("/w/replay/app") == a, True)
             os.environ["GM_SEALED_DIR"] = "/elsewhere/pile"
             check("GM_SEALED_DIR impose sa pile", sealed_dir_for("/w/x"), "/elsewhere/pile")
             for k, v in saved_env.items():

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1259,6 +1259,230 @@ tool oracle_run:
                 for r in requests if not closed(r["id"])]
 
 
+    # ─── Net extension — additions applied by the net's own subbot ──────────────
+    #
+    # The additive counterpart of the re-baseline ledger, with the opposite
+    # authority: a re-baseline MOVES a reference and only a human act closes it;
+    # an extension ADDS an observation point and the net's own subbot may act it,
+    # because an addition is checkable — it cannot mask an existing divergence,
+    # it can only add a constraint. The line that keeps that true is drawn here,
+    # mechanically: a delete or a rewrite wearing an addition's name is refused
+    # (removing the inconvenient reference and re-adding a "fresh" one that
+    # matches the broken behaviour IS the masking vector), and so is an addition
+    # whose observation tuple collides with an existing entry (two references for
+    # one observation resolve later by a "cleanup" that picks the masking
+    # direction).
+
+    def _extension_ledger_text(gm_dir):
+        path = os.path.join(gm_dir, "EXTENSIONS.md")
+        if not os.path.isfile(path):
+            return ""
+        with open(path, encoding="utf-8") as f:
+            return f.read()
+
+
+    def _extension_blocks(text, kind):
+        """Same block idiom as the re-baseline ledger: HTML comment, one JSON
+        object. An unreadable block is an escalation, never a guess."""
+        out = []
+        for body in re.findall(r"<!-- iterion:extension-%s\n(.*?)\n-->" % kind,
+                               text, re.S):
+            try:
+                obj = json.loads(body)
+            except ValueError:
+                obj = None
+            if not isinstance(obj, dict) or \
+                    not (isinstance(obj.get("id"), str) and obj.get("id")):
+                obj = {"id": "UNPARSEABLE", "raw": body[:120]}
+            out.append(obj)
+        return out
+
+
+    def pending_extensions(gm_dir, text=None):
+        """Extension requests no act has answered — a conjunction term, like
+        pending re-baselines, for the mirrored reason: a pending request names an
+        observation the net was ASKED to gain and does not have, so a green built
+        while it waits reports coverage its own intent knows is missing. There is
+        no `replaces` chain here: an extension that no longer applies is acted or
+        withdrawn by its requester, not superseded."""
+        if text is None:
+            text = _extension_ledger_text(gm_dir)
+        if not text:
+            return []
+        requests = _extension_blocks(text, "request")
+        acted = {b.get("id") for b in _extension_blocks(text, "act")}
+        if any(r.get("id") == "UNPARSEABLE" for r in requests) or "UNPARSEABLE" in acted:
+            return [{"id": "UNPARSEABLE",
+                     "why": "a ledger block does not parse as JSON — escalate, do not guess"}]
+        return [{"id": r["id"], "lot": r.get("lot", "?")}
+                for r in requests if r["id"] not in acted]
+
+
+    def _entry_observation_key(entry):
+        """What an entry OBSERVES, id stripped: two entries equal under this key
+        are two references for one observation — a collision, not an addition."""
+        return json.dumps({k: v for k, v in entry.items() if k != "id"},
+                          sort_keys=True, ensure_ascii=False)
+
+
+    def extension_verdict(ws, gm_rel, base):
+        """Judge every ACTED extension against `base`, in git — never against the
+        acting party's word.
+
+        Per acted request, every recorded path must be a pure addition:
+          - under refs/: absent at base, present at HEAD. A path that existed at
+            base is a rewrite wearing an addition's name; one absent at HEAD is a
+            delete — both are the masking vector and both refuse. A rename is a
+            delete plus a fresh file, judged separately, and the delete side
+            loses.
+          - corpus.json: every base entry survives equal, non-entry keys
+            untouched, every added entry is claimed by an acted request's
+            `corpus_entries`, and no addition collides — with the base corpus or
+            with a sibling addition — on its observation tuple.
+        The ledger itself must be append-only (base text is a prefix of HEAD
+        text): history in the ledger is the audit trail, and an edited trail
+        audits nothing.
+        """
+        def git(*args):
+            p = subprocess.run(["git", "-C", ws] + list(args),
+                               capture_output=True, text=True, timeout=120)
+            return p.returncode, p.stdout, p.stderr
+
+        def at(ref, path):
+            code, out, _ = git("show", "%s:%s" % (ref, path))
+            return out if code == 0 else None
+
+        ledger_rel = gm_rel.rstrip("/") + "/EXTENSIONS.md"
+        corpus_rel = gm_rel.rstrip("/") + "/corpus.json"
+        refs_prefix = gm_rel.rstrip("/") + "/refs/"
+
+        verdict = {"acted": [], "ok_paths": [], "ledger_append_only": True,
+                   "requests_added": 0, "problems": []}
+
+        head_txt = at("HEAD", ledger_rel) or ""
+        base_txt = at(base, ledger_rel) or ""
+        if base_txt and not head_txt.startswith(base_txt):
+            verdict["ledger_append_only"] = False
+            verdict["problems"].append(
+                "EXTENSIONS.md was REWRITTEN, not appended — history in the "
+                "ledger is the audit trail, and an edited trail audits nothing")
+
+        all_blocks = (_extension_blocks(head_txt, "request") +
+                      _extension_blocks(head_txt, "act"))
+        if any(b.get("id") == "UNPARSEABLE" for b in all_blocks):
+            verdict["problems"].append(
+                "a ledger block does not parse as JSON — escalate, do not guess")
+        requests = {b["id"]: b for b in _extension_blocks(head_txt, "request")
+                    if b.get("id") != "UNPARSEABLE"}
+        acts = [b for b in _extension_blocks(head_txt, "act")
+                if b.get("id") != "UNPARSEABLE"]
+        base_req_ids = {b.get("id") for b in _extension_blocks(base_txt, "request")}
+        verdict["requests_added"] = len(set(requests) - base_req_ids)
+
+        # The corpus is judged ONCE, globally: additions-only, every base entry
+        # intact, every addition claimed by an acted request, no collision.
+        corpus_ok, corpus_problems, added_ids = True, [], set()
+        head_corpus_txt = at("HEAD", corpus_rel)
+        base_corpus_txt = at(base, corpus_rel)
+        corpus_changed = head_corpus_txt != base_corpus_txt
+        if corpus_changed:
+            head_c = base_c = None
+            try:
+                head_c = json.loads(head_corpus_txt or "{}")
+                base_c = json.loads(base_corpus_txt or "{}")
+            except ValueError as e:
+                corpus_problems.append("corpus.json does not parse: %s" % e)
+            if head_c is not None and base_c is not None:
+                if {k: v for k, v in head_c.items() if k != "entries"} != \
+                        {k: v for k, v in base_c.items() if k != "entries"}:
+                    corpus_problems.append(
+                        "corpus.json keys outside `entries` changed — an "
+                        "extension adds entries and touches nothing else")
+                base_by_id = {e.get("id"): e for e in base_c.get("entries", [])}
+                head_by_id = {e.get("id"): e for e in head_c.get("entries", [])}
+                for bid, be in base_by_id.items():
+                    if bid not in head_by_id:
+                        corpus_problems.append(
+                            "entry %r was REMOVED — a delete is the masking "
+                            "vector, not an extension" % bid)
+                    elif head_by_id[bid] != be:
+                        corpus_problems.append(
+                            "entry %r was MODIFIED — a rewrite is the masking "
+                            "vector, not an extension" % bid)
+                added_ids = set(head_by_id) - set(base_by_id)
+                claimed = set()
+                for act in acts:
+                    req = requests.get(act.get("id"))
+                    for e in (req or {}).get("corpus_entries") or []:
+                        if isinstance(e, dict) and e.get("id"):
+                            claimed.add(e["id"])
+                unclaimed = added_ids - claimed
+                if unclaimed:
+                    corpus_problems.append(
+                        "%d added entr%s no acted request claims: %s — an "
+                        "addition smuggled beside an acted one is still smuggled"
+                        % (len(unclaimed), "y" if len(unclaimed) == 1 else "ies",
+                           ", ".join(sorted(unclaimed))))
+                base_keys = {_entry_observation_key(e)
+                             for e in base_by_id.values()}
+                seen_new = {}
+                for aid in sorted(added_ids):
+                    key = _entry_observation_key(head_by_id[aid])
+                    if key in base_keys or key in seen_new:
+                        other = seen_new.get(key, "an existing entry")
+                        corpus_problems.append(
+                            "added entry %r observes the same tuple as %s — two "
+                            "references for one observation resolve later by a "
+                            "cleanup that picks the masking direction"
+                            % (aid, other))
+                    seen_new[key] = "added entry %r" % aid
+            corpus_ok = not corpus_problems
+
+        for act in acts:
+            row = {"id": act.get("id"), "paths": [], "ok": False, "problems": []}
+            req = requests.get(act.get("id"))
+            if req is None:
+                row["problems"].append("an act without a request acts nothing")
+            paths = [p for p in (act.get("recorded_paths") or [])
+                     if isinstance(p, str) and p]
+            row["paths"] = paths
+            if req is not None and not paths:
+                row["problems"].append(
+                    "the act records no path — an extension that touched "
+                    "nothing extended nothing")
+            for p in paths:
+                if p == ledger_rel:
+                    continue
+                if p == corpus_rel:
+                    if not corpus_changed:
+                        row["problems"].append(
+                            "corpus.json is recorded but did not change")
+                    elif not corpus_ok:
+                        row["problems"].extend(corpus_problems)
+                elif p.startswith(refs_prefix):
+                    if at(base, p) is not None:
+                        row["problems"].append(
+                            "%s existed at base — a rewrite wearing an "
+                            "addition's name" % p)
+                    elif at("HEAD", p) is None:
+                        row["problems"].append(
+                            "%s is recorded but absent at HEAD — a recorded "
+                            "delete, and a delete is the masking vector" % p)
+                else:
+                    row["problems"].append(
+                        "%s is outside the extension surface (refs/ and "
+                        "corpus.json) — the canon, the mutants, the harness and "
+                        "the configuration are the judge's territory" % p)
+            row["ok"] = (req is not None and not row["problems"]
+                         and verdict["ledger_append_only"])
+            if row["ok"]:
+                verdict["ok_paths"].extend(row["paths"])
+            verdict["acted"].append(row)
+
+        verdict["ok_paths"] = sorted(set(verdict["ok_paths"]))
+        return verdict
+
+
     # ─── Route coverage — the corpus states its own perimeter ───────────────────
 
     def route_regex(pattern):
@@ -2452,6 +2676,172 @@ tool oracle_run:
             check("bloc objet SANS id -> escalade nommee, pas un KeyError",
                   pending_rebaselines(ldir)[0]["id"], "UNPARSEABLE")
 
+            # 8e. Extensions : le verdict additions-only, falsifie dans les deux
+            #     sens — une extension legitime DOIT passer, et chaque deguisement
+            #     du vecteur de masquage (reecriture, suppression, retouche,
+            #     collision, entree passee en fraude, registre reecrit) DOIT
+            #     rougir. Un fixture git reel, parce que le verdict se lit en git.
+            xroot = tempfile.mkdtemp(prefix="gm-selftest-ext-")
+            xgm = os.path.join(xroot, ".golden-master")
+            os.makedirs(os.path.join(xgm, "refs"))
+            base_entry = {"id": "1", "method": "GET", "path": "/a", "persona": "p"}
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry]}, f)
+            with open(os.path.join(xgm, "refs", "1.txt"), "w", encoding="utf-8") as f:
+                f.write("ref-1\n")
+            for cmd in ("git init -q", "git add -A",
+                        "git -c user.email=t@t -c user.name=t commit -qm seed"):
+                run(cmd, xroot, timeout=60)
+            xbase = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+
+            def xledger(*blks):
+                with open(os.path.join(xgm, "EXTENSIONS.md"), "w", encoding="utf-8") as f:
+                    f.write("\n".join("<!-- iterion:extension-%s\n%s\n-->" % b
+                                      for b in blks))
+
+            def xcommit():
+                run("git add -A", xroot, timeout=60)
+                run("git -c user.email=t@t -c user.name=t commit -qm x",
+                    xroot, timeout=60)
+
+            def xreset():
+                run("git reset -q --hard %s" % xbase, xroot, timeout=60)
+                run("git clean -qfd", xroot, timeout=60)
+
+            req2 = ('{"id": "E-1", "lot": "L", "type": "add-file",'
+                    ' "paths": [".golden-master/refs/2.txt"]}')
+            act2 = ('{"id": "E-1", "lot": "L",'
+                    ' "recorded_paths": [".golden-master/refs/2.txt"]}')
+
+            check("pas de registre -> aucune extension pendante",
+                  pending_extensions(xgm), [])
+            xledger(("request", req2))
+            check("demande sans acte -> pendante",
+                  [p["id"] for p in pending_extensions(xgm)], ["E-1"])
+            xledger(("request", req2), ("act", act2))
+            check("demande actee -> rien", pending_extensions(xgm), [])
+            xledger(("request", 'pas du json'))
+            check("bloc extension illisible -> escalade nommee",
+                  pending_extensions(xgm)[0]["id"], "UNPARSEABLE")
+
+            # Extension legitime : un fichier de ref NEUF, acte, registre commite.
+            xreset()
+            xledger(("request", req2), ("act", act2))
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("ref-2\n")
+            xcommit()
+            v = extension_verdict(xroot, ".golden-master", xbase)
+            check("add-file legitime -> ok, chemin exempte",
+                  [v["acted"][0]["ok"], v["ok_paths"]],
+                  [True, [".golden-master/refs/2.txt"]])
+
+            # Reecriture deguisee : la ref existait a la base.
+            xreset()
+            xledger(("request", '{"id": "E-1", "lot": "L", "paths": [".golden-master/refs/1.txt"]}'),
+                    ("act", '{"id": "E-1", "lot": "L", "recorded_paths": [".golden-master/refs/1.txt"]}'))
+            with open(os.path.join(xgm, "refs", "1.txt"), "w", encoding="utf-8") as f:
+                f.write("ref-1-reecrite\n")
+            xcommit()
+            check("reecriture deguisee en ajout -> refusee",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+            # Suppression enregistree : le chemin manque a HEAD (le cote delete
+            # d'un renommage perd exactement ici).
+            xreset()
+            xledger(("request", req2), ("act", act2))
+            xcommit()
+            check("chemin enregistre absent a HEAD (delete/rename) -> refuse",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+            # Entree de corpus legitime, revendiquee par la demande.
+            xreset()
+            new_entry = {"id": "2", "method": "GET", "path": "/b", "persona": "p"}
+            xledger(("request", '{"id": "E-2", "lot": "L", "type": "add-entry",'
+                                ' "corpus_entries": [{"id": "2"}]}'),
+                    ("act", '{"id": "E-2", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, new_entry]}, f)
+            xcommit()
+            check("add-entry legitime et revendiquee -> ok",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], True)
+
+            # Retouche d'une entree existante sous couvert d'ajout.
+            xreset()
+            xledger(("request", '{"id": "E-2", "lot": "L", "corpus_entries": [{"id": "2"}]}'),
+                    ("act", '{"id": "E-2", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            touched = dict(base_entry, path="/a-bougee")
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [touched, new_entry]}, f)
+            xcommit()
+            check("entree existante retouchee -> refusee",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+            # Collision : la « nouvelle » entree observe le meme tuple qu'une
+            # existante — deux references pour une observation.
+            xreset()
+            collider = dict(base_entry, id="9")
+            xledger(("request", '{"id": "E-3", "lot": "L", "corpus_entries": [{"id": "9"}]}'),
+                    ("act", '{"id": "E-3", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, collider]}, f)
+            xcommit()
+            check("collision de tuple d'observation -> refusee",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+            # Entree passee en fraude : ajoutee au corpus, revendiquee par
+            # personne.
+            xreset()
+            smuggled = {"id": "8", "method": "GET", "path": "/c", "persona": "p"}
+            xledger(("request", '{"id": "E-2", "lot": "L", "corpus_entries": [{"id": "2"}]}'),
+                    ("act", '{"id": "E-2", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/corpus.json"]}'))
+            with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+                json.dump({"entries": [base_entry, new_entry, smuggled]}, f)
+            xcommit()
+            check("entree non revendiquee a cote d'une actee -> refusee",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+            # Chemin hors surface : le canon est le territoire du juge.
+            xreset()
+            xledger(("request", '{"id": "E-4", "lot": "L", "paths": [".golden-master/canon/x.py"]}'),
+                    ("act", '{"id": "E-4", "lot": "L",'
+                            ' "recorded_paths": [".golden-master/canon/x.py"]}'))
+            os.makedirs(os.path.join(xgm, "canon"), exist_ok=True)
+            with open(os.path.join(xgm, "canon", "x.py"), "w", encoding="utf-8") as f:
+                f.write("# neuf\n")
+            xcommit()
+            check("chemin hors refs/+corpus (canon) -> refuse",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+            # Registre reecrit : un registre COMMITTE a la base n'est plus un
+            # prefixe de HEAD. (Un registre ne EXISTANT PAS a la base rend ce
+            # check vacueux par construction — la, c'est « acte sans demande »
+            # qui tient la ligne, teste plus bas.)
+            xreset()
+            xledger(("request", req2))
+            xcommit()
+            xbase2 = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+            xledger(("act", act2))  # la demande a disparu : trail edite
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("ref-2\n")
+            xcommit()
+            v = extension_verdict(xroot, ".golden-master", xbase2)
+            check("registre committe puis reecrit -> append_only faux et acte refuse",
+                  [v["ledger_append_only"], v["acted"][0]["ok"]],
+                  [False, False])
+
+            # Acte sans demande : il n'acte rien.
+            xreset()
+            xledger(("act", act2))
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("ref-2\n")
+            xcommit()
+            check("acte sans demande -> refuse",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
             # 9. Scellement : derivable partout, jamais dans le parent du worktree
             #    (lecture seule en sandbox), et sans collision entre worktrees
             #    freres qui partagent le meme basename.
@@ -2495,12 +2885,30 @@ tool oracle_run:
         # set somewhere the gate will not look, and two runs cannot share a pile.
         sealed_dir = sealed_dir_for(ws)
         floor = int(os.environ.get("GM_MUTATION_FLOOR", "90"))
-        mode = os.environ.get("GM_MODE", "gate")   # gate | record | selfcheck | validate | selftest
+        mode = os.environ.get("GM_MODE", "gate")   # gate | record | selfcheck | validate | selftest | extensions | extend-verify
 
         # Les tests du harnais d'abord, et hors de tout le reste : ils ne touchent
         # ni au depot, ni a l'application, ni a la configuration.
         if mode == "selftest":
             raise SystemExit(_selftest())
+
+        # Ledger listings and the additions-only verdict are pure git/file reads:
+        # no boot, no capture, callable from a verifier that must not pay for
+        # either — and BY the party whose own work they judge, because the code
+        # deciding is this file's, not theirs.
+        if mode == "extensions":
+            print(json.dumps({"pending": pending_extensions(gm_dir)}))
+            raise SystemExit(0)
+        if mode == "extend-verify":
+            base = os.environ.get("GM_BASE", "")
+            if not base:
+                print(json.dumps({"error": "GM_BASE is required — judging "
+                                  "additions against nothing would pass by "
+                                  "construction"}))
+                raise SystemExit(1)
+            print(json.dumps(extension_verdict(
+                ws, os.environ.get("GM_DIR", ".golden-master"), base)))
+            raise SystemExit(0)
 
         report = {"mode": mode, "total": 0, "valid": 0, "detected": 0, "score_pct": 0,
                   "noop_silent": False, "revert_clean": True, "collateral": 0,
@@ -2512,6 +2920,7 @@ tool oracle_run:
                   "features_total": 0, "features_excluded": 0,
                   "holdout_awaiting_gate": False,
                   "pending_rebaselines": [],
+                  "pending_extensions": [],
                   "holdout_detected": 0, "holdout_total": 0, "stable": False,
                   "holdout_detected_on_surface": 0, "score_on_surface_pct": 0,
                   "corpus_total": 0, "corpus_distinct": 0, "duplicate_refs": [],
@@ -2761,6 +3170,17 @@ tool oracle_run:
                      "them (record, diff == announced, act block, then the verdict after "
                      "a green counter-test), or refuse them in writing."
                      % (len(pending), json.dumps(pending, ensure_ascii=False)))
+
+            pending_ext = pending_extensions(gm_dir)
+            if pending_ext:
+                report["pending_extensions"] = pending_ext
+                bail("the ledger carries %d pending extension request(s): %s. Each one "
+                     "names an observation the net was asked to gain and does not "
+                     "have — a green built while they wait reports coverage the "
+                     "intent already knows is missing. The net's extension subbot "
+                     "acts them; what it cannot apply additively goes back to its "
+                     "requester in writing."
+                     % (len(pending_ext), json.dumps(pending_ext, ensure_ascii=False)))
 
         try:
             app_up(config, ws)

--- a/bots/golden-master/main.bot
+++ b/bots/golden-master/main.bot
@@ -1294,8 +1294,34 @@ tool oracle_run:
             if not isinstance(obj, dict) or \
                     not (isinstance(obj.get("id"), str) and obj.get("id")):
                 obj = {"id": "UNPARSEABLE", "raw": body[:120]}
+            else:
+                # The list-shaped fields are iterated by every judgement below. A
+                # scalar here raised TypeError inside the verdict, and a verdict
+                # that cannot answer was read as "nothing to refuse" by the lot
+                # gate — the ledger disabling its own guard (adversarial finding,
+                # executed). Normalising at the single parse point makes such a
+                # block refusable instead of fatal.
+                for field in ("recorded_paths", "paths", "corpus_entries"):
+                    if field in obj and not isinstance(obj[field], list):
+                        obj[field] = []
             out.append(obj)
         return out
+
+
+    def _records_extension_surface(paths):
+        """An act closes a request only by recording the SURFACE an extension can
+        reach: a reference, or the corpus. An act naming only the ledger records
+        the paperwork of its own filing — it closed the conjunction term while the
+        reference it declared did not exist (adversarial finding, executed)."""
+        if not isinstance(paths, list):
+            return False
+        for p in paths:
+            if not isinstance(p, str) or not p:
+                continue
+            rel = p.split("/", 1)[1] if p.startswith(".golden-master/") else p
+            if rel.startswith("refs/") or rel == "corpus.json":
+                return True
+        return False
 
 
     def pending_extensions(gm_dir, text=None):
@@ -1320,7 +1346,7 @@ tool oracle_run:
         # additions-only verdict never runs at gate time, so this shape check is
         # the whole defence here (adversarial finding, executed).
         acted = {b["id"] for b in acts
-                 if isinstance(b.get("recorded_paths"), list) and b["recorded_paths"]}
+                 if _records_extension_surface(b.get("recorded_paths"))}
         return [{"id": r["id"], "lot": r.get("lot", "?")}
                 for r in requests if r["id"] not in acted]
 
@@ -1333,8 +1359,8 @@ tool oracle_run:
     ## failure mode is a FALSE collision — refused, escalated to the requester —
     ## never a masked duplicate.
     OBSERVATION_FIELDS = ("method", "path", "persona", "surface", "fields",
-                          "steps", "params", "query", "body", "readback",
-                          "no_redirect", "csrf_field")
+                          "steps", "readback", "no_redirect", "csrf_field",
+                          "static_prefix", "template_prefix", "probes")
 
 
     def _entry_observation_key(entry):
@@ -1380,6 +1406,31 @@ tool oracle_run:
         ledger_rel = gm_rel.rstrip("/") + "/EXTENSIONS.md"
         corpus_rel = gm_rel.rstrip("/") + "/corpus.json"
         refs_prefix = gm_rel.rstrip("/") + "/refs/"
+
+        def introducing_commits():
+            """First commit in which each ledger block id appears, oldest first.
+
+            Separation of powers is a claim about WHO wrote what, and the
+            ledger's own history is the only record of it neither party writes
+            twice. A request and its act sharing an introducing commit means the
+            constrained party filed and answered in one gesture, so the net's
+            subbot never ran — production cannot produce that shape, because the
+            parent commits its lot before the subbot starts (adversarial finding,
+            executed)."""
+            code, out, _ = git("log", "--format=%H", "--reverse", "--", ledger_rel)
+            if code != 0:
+                return None
+            first = {}
+            for sha in out.split():
+                text = at(sha, ledger_rel)
+                if text is None:
+                    continue
+                for kind in ("request", "act"):
+                    for b in _extension_blocks(text, kind):
+                        bid = b.get("id")
+                        if isinstance(bid, str) and bid:
+                            first.setdefault((kind, bid), sha)
+            return first
 
         # An unresolvable base and an honest "absent at base" both read as None
         # below, so a bad sha would certify everything as an addition — a guard
@@ -1512,11 +1563,23 @@ tool oracle_run:
                     seen_new[key] = "added entry %r" % aid
             corpus_ok = not corpus_problems
 
+        intro = introducing_commits()
         for act in acts:
             row = {"id": act.get("id"), "paths": [], "ok": False, "problems": []}
             req = requests.get(act.get("id"))
             if req is None:
                 row["problems"].append("an act without a request acts nothing")
+            elif intro is None:
+                row["problems"].append(
+                    "cannot read the ledger's history — provenance unproven, and "
+                    "an unprovable act is refused, not assumed")
+            elif intro.get(("act", act.get("id"))) is not None \
+                    and intro.get(("act", act.get("id"))) == intro.get(("request", act.get("id"))):
+                row["problems"].append(
+                    "the requester acted its own request: %s introduced both the "
+                    "request and the act, so the net's subbot never judged it — "
+                    "filing and answering are different powers"
+                    % intro[("act", act.get("id"))][:12])
             paths = [p for p in (act.get("recorded_paths") or [])
                      if isinstance(p, str) and p]
             row["paths"] = paths
@@ -1572,6 +1635,13 @@ tool oracle_run:
                         "%s is outside the extension surface (refs/ and "
                         "corpus.json) — the canon, the mutants, the harness and "
                         "the configuration are the judge's territory" % p)
+            if req is not None and not _records_extension_surface(paths):
+                # The ledger is the paperwork of the filing, not the extension:
+                # an act recording only it certified paths the net never gained
+                # (adversarial finding, executed).
+                row["problems"].append(
+                    "the act records no path on the extension surface (refs/ or "
+                    "corpus.json) — filing paperwork is not an extension")
             row["ok"] = (req is not None and not row["problems"]
                          and verdict["ledger_append_only"])
             if row["ok"]:
@@ -2811,6 +2881,14 @@ tool oracle_run:
                 run("git -c user.email=t@t -c user.name=t commit -qm x",
                     xroot, timeout=60)
 
+            def xrequest(req):
+                """The lot files its request and commits. A fixture that stages a
+                request and its act in ONE commit models a sequence production
+                cannot produce (the parent commits its lot before the subbot
+                starts) — and hides the provenance the verdict checks."""
+                xledger(("request", req))
+                xcommit()
+
             def xreset():
                 run("git reset -q --hard %s" % xbase, xroot, timeout=60)
                 run("git clean -qfd", xroot, timeout=60)
@@ -2833,6 +2911,7 @@ tool oracle_run:
 
             # Extension legitime : un fichier de ref NEUF, acte, registre commite.
             xreset()
+            xrequest(req2)
             xledger(("request", req2), ("act", act2))
             with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
                 f.write("ref-2\n")
@@ -2863,6 +2942,8 @@ tool oracle_run:
             # Entree de corpus legitime, revendiquee par la demande.
             xreset()
             new_entry = {"id": "2", "method": "GET", "path": "/b", "persona": "p"}
+            xrequest('{"id": "E-2", "lot": "L", "type": "add-entry",'
+                     ' "corpus_entries": [{"id": "2"}]}')
             xledger(("request", '{"id": "E-2", "lot": "L", "type": "add-entry",'
                                 ' "corpus_entries": [{"id": "2"}]}'),
                     ("act", '{"id": "E-2", "lot": "L",'
@@ -2946,6 +3027,53 @@ tool oracle_run:
             with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
                 f.write("ref-2\n")
             xcommit()
+            # Un acte introduit par le commit qui depose sa propre demande : le
+            # lot a filed and answered, le subbot du filet n'a jamais juge.
+            xreset()
+            xledger(("request", req2), ("act", act2))
+            with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+                f.write("ref-2\n")
+            xcommit()
+            v_self = extension_verdict(xroot, ".golden-master", xbase)
+            check("demande et acte dans UN commit (le lot s'auto-sert) -> refuse",
+                  [v_self["acted"][0]["ok"], v_self["ok_paths"]], [False, []])
+
+            # Un acte qui n'enregistre que le registre : il ne laisse pas la
+            # demande pendante, et il n'est pas certifie.
+            xreset()
+            ledger_only = ('{"id": "E-1", "lot": "L", "recorded_paths":'
+                           ' [".golden-master/EXTENSIONS.md"]}')
+            xrequest(req2)
+            xledger(("request", req2), ("act", ledger_only))
+            xcommit()
+            check("acte n'enregistrant QUE le registre -> la demande RESTE pendante",
+                  [p["id"] for p in pending_extensions(xgm)], ["E-1"])
+            check("acte n'enregistrant QUE le registre -> refuse",
+                  extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"],
+                  False)
+
+            # Un scalaire la ou le juge itere : le bloc devient refusable, il ne
+            # fait plus tomber le verdict (qui etait lu comme "rien a refuser").
+            xreset()
+            scalar_act = '{"id": "E-1", "lot": "L", "recorded_paths": 1}'
+            xrequest(req2)
+            xledger(("request", req2), ("act", scalar_act))
+            xcommit()
+            check("recorded_paths scalaire -> la demande RESTE pendante, pas de crash",
+                  [p["id"] for p in pending_extensions(xgm)], ["E-1"])
+            v_scalar = extension_verdict(xroot, ".golden-master", xbase)
+            check("recorded_paths scalaire -> verdict rendu et acte refuse",
+                  ["error" not in v_scalar, v_scalar["acted"][0]["ok"]], [True, False])
+
+            # Deux entrees d'assets aux prefixes DISTINCTS observent deux choses
+            # differentes : refuser l'ajout serait un faux positif bloquant.
+            a1 = {"id": "a1", "surface": "asset", "persona": "p",
+                  "static_prefix": "s/", "template_prefix": "t/"}
+            a2 = {"id": "a2", "surface": "asset", "persona": "p",
+                  "static_prefix": "admin-s/", "template_prefix": "admin-t/"}
+            check("deux entrees asset a prefixes distincts -> pas de collision",
+                  _entry_observation_key(a1) == _entry_observation_key(a2), False)
+
             check("acte sans demande -> refuse",
                   extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
 
@@ -3054,6 +3182,8 @@ tool oracle_run:
             # reference derivee — corpus.json ET refs/2.txt exemptes, sans
             # `paths` dans la demande (la forme que la doctrine prescrit).
             xreset()
+            xrequest('{"id": "E-2", "lot": "L", "type": "add-entry",'
+                     ' "corpus_entries": [{"id": "2"}]}')
             xledger(("request", '{"id": "E-2", "lot": "L", "type": "add-entry",'
                                 ' "corpus_entries": [{"id": "2"}]}'),
                     ("act", '{"id": "E-2", "lot": "L", "recorded_paths":'

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1359,6 +1359,14 @@ def extension_verdict(ws, gm_rel, base):
             verdict["ok_paths"].extend(row["paths"])
         verdict["acted"].append(row)
 
+    # Corpus damage must surface even when NO act recorded corpus.json —
+    # otherwise a hand-run of this mode shows every row ok and an empty
+    # problems list while the corpus sits amputated, and the reader walks
+    # away reassured by the very command meant to warn them (review note).
+    if corpus_changed and corpus_problems and \
+            not any(corpus_rel in (a.get("recorded_paths") or []) for a in acts):
+        verdict["problems"].extend(corpus_problems)
+
     verdict["ok_paths"] = sorted(set(verdict["ok_paths"]))
     return verdict
 

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1075,8 +1075,34 @@ def _extension_blocks(text, kind):
         if not isinstance(obj, dict) or \
                 not (isinstance(obj.get("id"), str) and obj.get("id")):
             obj = {"id": "UNPARSEABLE", "raw": body[:120]}
+        else:
+            # The list-shaped fields are iterated by every judgement below. A
+            # scalar here raised TypeError inside the verdict, and a verdict
+            # that cannot answer was read as "nothing to refuse" by the lot
+            # gate — the ledger disabling its own guard (adversarial finding,
+            # executed). Normalising at the single parse point makes such a
+            # block refusable instead of fatal.
+            for field in ("recorded_paths", "paths", "corpus_entries"):
+                if field in obj and not isinstance(obj[field], list):
+                    obj[field] = []
         out.append(obj)
     return out
+
+
+def _records_extension_surface(paths):
+    """An act closes a request only by recording the SURFACE an extension can
+    reach: a reference, or the corpus. An act naming only the ledger records
+    the paperwork of its own filing — it closed the conjunction term while the
+    reference it declared did not exist (adversarial finding, executed)."""
+    if not isinstance(paths, list):
+        return False
+    for p in paths:
+        if not isinstance(p, str) or not p:
+            continue
+        rel = p.split("/", 1)[1] if p.startswith(".golden-master/") else p
+        if rel.startswith("refs/") or rel == "corpus.json":
+            return True
+    return False
 
 
 def pending_extensions(gm_dir, text=None):
@@ -1101,7 +1127,7 @@ def pending_extensions(gm_dir, text=None):
     # additions-only verdict never runs at gate time, so this shape check is
     # the whole defence here (adversarial finding, executed).
     acted = {b["id"] for b in acts
-             if isinstance(b.get("recorded_paths"), list) and b["recorded_paths"]}
+             if _records_extension_surface(b.get("recorded_paths"))}
     return [{"id": r["id"], "lot": r.get("lot", "?")}
             for r in requests if r["id"] not in acted]
 
@@ -1114,8 +1140,8 @@ def pending_extensions(gm_dir, text=None):
 ## failure mode is a FALSE collision — refused, escalated to the requester —
 ## never a masked duplicate.
 OBSERVATION_FIELDS = ("method", "path", "persona", "surface", "fields",
-                      "steps", "params", "query", "body", "readback",
-                      "no_redirect", "csrf_field")
+                      "steps", "readback", "no_redirect", "csrf_field",
+                      "static_prefix", "template_prefix", "probes")
 
 
 def _entry_observation_key(entry):
@@ -1161,6 +1187,31 @@ def extension_verdict(ws, gm_rel, base):
     ledger_rel = gm_rel.rstrip("/") + "/EXTENSIONS.md"
     corpus_rel = gm_rel.rstrip("/") + "/corpus.json"
     refs_prefix = gm_rel.rstrip("/") + "/refs/"
+
+    def introducing_commits():
+        """First commit in which each ledger block id appears, oldest first.
+
+        Separation of powers is a claim about WHO wrote what, and the
+        ledger's own history is the only record of it neither party writes
+        twice. A request and its act sharing an introducing commit means the
+        constrained party filed and answered in one gesture, so the net's
+        subbot never ran — production cannot produce that shape, because the
+        parent commits its lot before the subbot starts (adversarial finding,
+        executed)."""
+        code, out, _ = git("log", "--format=%H", "--reverse", "--", ledger_rel)
+        if code != 0:
+            return None
+        first = {}
+        for sha in out.split():
+            text = at(sha, ledger_rel)
+            if text is None:
+                continue
+            for kind in ("request", "act"):
+                for b in _extension_blocks(text, kind):
+                    bid = b.get("id")
+                    if isinstance(bid, str) and bid:
+                        first.setdefault((kind, bid), sha)
+        return first
 
     # An unresolvable base and an honest "absent at base" both read as None
     # below, so a bad sha would certify everything as an addition — a guard
@@ -1293,11 +1344,23 @@ def extension_verdict(ws, gm_rel, base):
                 seen_new[key] = "added entry %r" % aid
         corpus_ok = not corpus_problems
 
+    intro = introducing_commits()
     for act in acts:
         row = {"id": act.get("id"), "paths": [], "ok": False, "problems": []}
         req = requests.get(act.get("id"))
         if req is None:
             row["problems"].append("an act without a request acts nothing")
+        elif intro is None:
+            row["problems"].append(
+                "cannot read the ledger's history — provenance unproven, and "
+                "an unprovable act is refused, not assumed")
+        elif intro.get(("act", act.get("id"))) is not None \
+                and intro.get(("act", act.get("id"))) == intro.get(("request", act.get("id"))):
+            row["problems"].append(
+                "the requester acted its own request: %s introduced both the "
+                "request and the act, so the net's subbot never judged it — "
+                "filing and answering are different powers"
+                % intro[("act", act.get("id"))][:12])
         paths = [p for p in (act.get("recorded_paths") or [])
                  if isinstance(p, str) and p]
         row["paths"] = paths
@@ -1353,6 +1416,13 @@ def extension_verdict(ws, gm_rel, base):
                     "%s is outside the extension surface (refs/ and "
                     "corpus.json) — the canon, the mutants, the harness and "
                     "the configuration are the judge's territory" % p)
+        if req is not None and not _records_extension_surface(paths):
+            # The ledger is the paperwork of the filing, not the extension:
+            # an act recording only it certified paths the net never gained
+            # (adversarial finding, executed).
+            row["problems"].append(
+                "the act records no path on the extension surface (refs/ or "
+                "corpus.json) — filing paperwork is not an extension")
         row["ok"] = (req is not None and not row["problems"]
                      and verdict["ledger_append_only"])
         if row["ok"]:
@@ -2592,6 +2662,14 @@ def _selftest():
             run("git -c user.email=t@t -c user.name=t commit -qm x",
                 xroot, timeout=60)
 
+        def xrequest(req):
+            """The lot files its request and commits. A fixture that stages a
+            request and its act in ONE commit models a sequence production
+            cannot produce (the parent commits its lot before the subbot
+            starts) — and hides the provenance the verdict checks."""
+            xledger(("request", req))
+            xcommit()
+
         def xreset():
             run("git reset -q --hard %s" % xbase, xroot, timeout=60)
             run("git clean -qfd", xroot, timeout=60)
@@ -2614,6 +2692,7 @@ def _selftest():
 
         # Extension legitime : un fichier de ref NEUF, acte, registre commite.
         xreset()
+        xrequest(req2)
         xledger(("request", req2), ("act", act2))
         with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
             f.write("ref-2\n")
@@ -2644,6 +2723,8 @@ def _selftest():
         # Entree de corpus legitime, revendiquee par la demande.
         xreset()
         new_entry = {"id": "2", "method": "GET", "path": "/b", "persona": "p"}
+        xrequest('{"id": "E-2", "lot": "L", "type": "add-entry",'
+                 ' "corpus_entries": [{"id": "2"}]}')
         xledger(("request", '{"id": "E-2", "lot": "L", "type": "add-entry",'
                             ' "corpus_entries": [{"id": "2"}]}'),
                 ("act", '{"id": "E-2", "lot": "L",'
@@ -2727,6 +2808,53 @@ def _selftest():
         with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
             f.write("ref-2\n")
         xcommit()
+        # Un acte introduit par le commit qui depose sa propre demande : le
+        # lot a filed and answered, le subbot du filet n'a jamais juge.
+        xreset()
+        xledger(("request", req2), ("act", act2))
+        with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+            f.write("ref-2\n")
+        xcommit()
+        v_self = extension_verdict(xroot, ".golden-master", xbase)
+        check("demande et acte dans UN commit (le lot s'auto-sert) -> refuse",
+              [v_self["acted"][0]["ok"], v_self["ok_paths"]], [False, []])
+
+        # Un acte qui n'enregistre que le registre : il ne laisse pas la
+        # demande pendante, et il n'est pas certifie.
+        xreset()
+        ledger_only = ('{"id": "E-1", "lot": "L", "recorded_paths":'
+                       ' [".golden-master/EXTENSIONS.md"]}')
+        xrequest(req2)
+        xledger(("request", req2), ("act", ledger_only))
+        xcommit()
+        check("acte n'enregistrant QUE le registre -> la demande RESTE pendante",
+              [p["id"] for p in pending_extensions(xgm)], ["E-1"])
+        check("acte n'enregistrant QUE le registre -> refuse",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"],
+              False)
+
+        # Un scalaire la ou le juge itere : le bloc devient refusable, il ne
+        # fait plus tomber le verdict (qui etait lu comme "rien a refuser").
+        xreset()
+        scalar_act = '{"id": "E-1", "lot": "L", "recorded_paths": 1}'
+        xrequest(req2)
+        xledger(("request", req2), ("act", scalar_act))
+        xcommit()
+        check("recorded_paths scalaire -> la demande RESTE pendante, pas de crash",
+              [p["id"] for p in pending_extensions(xgm)], ["E-1"])
+        v_scalar = extension_verdict(xroot, ".golden-master", xbase)
+        check("recorded_paths scalaire -> verdict rendu et acte refuse",
+              ["error" not in v_scalar, v_scalar["acted"][0]["ok"]], [True, False])
+
+        # Deux entrees d'assets aux prefixes DISTINCTS observent deux choses
+        # differentes : refuser l'ajout serait un faux positif bloquant.
+        a1 = {"id": "a1", "surface": "asset", "persona": "p",
+              "static_prefix": "s/", "template_prefix": "t/"}
+        a2 = {"id": "a2", "surface": "asset", "persona": "p",
+              "static_prefix": "admin-s/", "template_prefix": "admin-t/"}
+        check("deux entrees asset a prefixes distincts -> pas de collision",
+              _entry_observation_key(a1) == _entry_observation_key(a2), False)
+
         check("acte sans demande -> refuse",
               extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
 
@@ -2835,6 +2963,8 @@ def _selftest():
         # reference derivee — corpus.json ET refs/2.txt exemptes, sans
         # `paths` dans la demande (la forme que la doctrine prescrit).
         xreset()
+        xrequest('{"id": "E-2", "lot": "L", "type": "add-entry",'
+                 ' "corpus_entries": [{"id": "2"}]}')
         xledger(("request", '{"id": "E-2", "lot": "L", "type": "add-entry",'
                             ' "corpus_entries": [{"id": "2"}]}'),
                 ("act", '{"id": "E-2", "lot": "L", "recorded_paths":'

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1040,6 +1040,230 @@ def pending_rebaselines(gm_dir):
             for r in requests if not closed(r["id"])]
 
 
+# ─── Net extension — additions applied by the net's own subbot ──────────────
+#
+# The additive counterpart of the re-baseline ledger, with the opposite
+# authority: a re-baseline MOVES a reference and only a human act closes it;
+# an extension ADDS an observation point and the net's own subbot may act it,
+# because an addition is checkable — it cannot mask an existing divergence,
+# it can only add a constraint. The line that keeps that true is drawn here,
+# mechanically: a delete or a rewrite wearing an addition's name is refused
+# (removing the inconvenient reference and re-adding a "fresh" one that
+# matches the broken behaviour IS the masking vector), and so is an addition
+# whose observation tuple collides with an existing entry (two references for
+# one observation resolve later by a "cleanup" that picks the masking
+# direction).
+
+def _extension_ledger_text(gm_dir):
+    path = os.path.join(gm_dir, "EXTENSIONS.md")
+    if not os.path.isfile(path):
+        return ""
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def _extension_blocks(text, kind):
+    """Same block idiom as the re-baseline ledger: HTML comment, one JSON
+    object. An unreadable block is an escalation, never a guess."""
+    out = []
+    for body in re.findall(r"<!-- iterion:extension-%s\n(.*?)\n-->" % kind,
+                           text, re.S):
+        try:
+            obj = json.loads(body)
+        except ValueError:
+            obj = None
+        if not isinstance(obj, dict) or \
+                not (isinstance(obj.get("id"), str) and obj.get("id")):
+            obj = {"id": "UNPARSEABLE", "raw": body[:120]}
+        out.append(obj)
+    return out
+
+
+def pending_extensions(gm_dir, text=None):
+    """Extension requests no act has answered — a conjunction term, like
+    pending re-baselines, for the mirrored reason: a pending request names an
+    observation the net was ASKED to gain and does not have, so a green built
+    while it waits reports coverage its own intent knows is missing. There is
+    no `replaces` chain here: an extension that no longer applies is acted or
+    withdrawn by its requester, not superseded."""
+    if text is None:
+        text = _extension_ledger_text(gm_dir)
+    if not text:
+        return []
+    requests = _extension_blocks(text, "request")
+    acted = {b.get("id") for b in _extension_blocks(text, "act")}
+    if any(r.get("id") == "UNPARSEABLE" for r in requests) or "UNPARSEABLE" in acted:
+        return [{"id": "UNPARSEABLE",
+                 "why": "a ledger block does not parse as JSON — escalate, do not guess"}]
+    return [{"id": r["id"], "lot": r.get("lot", "?")}
+            for r in requests if r["id"] not in acted]
+
+
+def _entry_observation_key(entry):
+    """What an entry OBSERVES, id stripped: two entries equal under this key
+    are two references for one observation — a collision, not an addition."""
+    return json.dumps({k: v for k, v in entry.items() if k != "id"},
+                      sort_keys=True, ensure_ascii=False)
+
+
+def extension_verdict(ws, gm_rel, base):
+    """Judge every ACTED extension against `base`, in git — never against the
+    acting party's word.
+
+    Per acted request, every recorded path must be a pure addition:
+      - under refs/: absent at base, present at HEAD. A path that existed at
+        base is a rewrite wearing an addition's name; one absent at HEAD is a
+        delete — both are the masking vector and both refuse. A rename is a
+        delete plus a fresh file, judged separately, and the delete side
+        loses.
+      - corpus.json: every base entry survives equal, non-entry keys
+        untouched, every added entry is claimed by an acted request's
+        `corpus_entries`, and no addition collides — with the base corpus or
+        with a sibling addition — on its observation tuple.
+    The ledger itself must be append-only (base text is a prefix of HEAD
+    text): history in the ledger is the audit trail, and an edited trail
+    audits nothing.
+    """
+    def git(*args):
+        p = subprocess.run(["git", "-C", ws] + list(args),
+                           capture_output=True, text=True, timeout=120)
+        return p.returncode, p.stdout, p.stderr
+
+    def at(ref, path):
+        code, out, _ = git("show", "%s:%s" % (ref, path))
+        return out if code == 0 else None
+
+    ledger_rel = gm_rel.rstrip("/") + "/EXTENSIONS.md"
+    corpus_rel = gm_rel.rstrip("/") + "/corpus.json"
+    refs_prefix = gm_rel.rstrip("/") + "/refs/"
+
+    verdict = {"acted": [], "ok_paths": [], "ledger_append_only": True,
+               "requests_added": 0, "problems": []}
+
+    head_txt = at("HEAD", ledger_rel) or ""
+    base_txt = at(base, ledger_rel) or ""
+    if base_txt and not head_txt.startswith(base_txt):
+        verdict["ledger_append_only"] = False
+        verdict["problems"].append(
+            "EXTENSIONS.md was REWRITTEN, not appended — history in the "
+            "ledger is the audit trail, and an edited trail audits nothing")
+
+    all_blocks = (_extension_blocks(head_txt, "request") +
+                  _extension_blocks(head_txt, "act"))
+    if any(b.get("id") == "UNPARSEABLE" for b in all_blocks):
+        verdict["problems"].append(
+            "a ledger block does not parse as JSON — escalate, do not guess")
+    requests = {b["id"]: b for b in _extension_blocks(head_txt, "request")
+                if b.get("id") != "UNPARSEABLE"}
+    acts = [b for b in _extension_blocks(head_txt, "act")
+            if b.get("id") != "UNPARSEABLE"]
+    base_req_ids = {b.get("id") for b in _extension_blocks(base_txt, "request")}
+    verdict["requests_added"] = len(set(requests) - base_req_ids)
+
+    # The corpus is judged ONCE, globally: additions-only, every base entry
+    # intact, every addition claimed by an acted request, no collision.
+    corpus_ok, corpus_problems, added_ids = True, [], set()
+    head_corpus_txt = at("HEAD", corpus_rel)
+    base_corpus_txt = at(base, corpus_rel)
+    corpus_changed = head_corpus_txt != base_corpus_txt
+    if corpus_changed:
+        head_c = base_c = None
+        try:
+            head_c = json.loads(head_corpus_txt or "{}")
+            base_c = json.loads(base_corpus_txt or "{}")
+        except ValueError as e:
+            corpus_problems.append("corpus.json does not parse: %s" % e)
+        if head_c is not None and base_c is not None:
+            if {k: v for k, v in head_c.items() if k != "entries"} != \
+                    {k: v for k, v in base_c.items() if k != "entries"}:
+                corpus_problems.append(
+                    "corpus.json keys outside `entries` changed — an "
+                    "extension adds entries and touches nothing else")
+            base_by_id = {e.get("id"): e for e in base_c.get("entries", [])}
+            head_by_id = {e.get("id"): e for e in head_c.get("entries", [])}
+            for bid, be in base_by_id.items():
+                if bid not in head_by_id:
+                    corpus_problems.append(
+                        "entry %r was REMOVED — a delete is the masking "
+                        "vector, not an extension" % bid)
+                elif head_by_id[bid] != be:
+                    corpus_problems.append(
+                        "entry %r was MODIFIED — a rewrite is the masking "
+                        "vector, not an extension" % bid)
+            added_ids = set(head_by_id) - set(base_by_id)
+            claimed = set()
+            for act in acts:
+                req = requests.get(act.get("id"))
+                for e in (req or {}).get("corpus_entries") or []:
+                    if isinstance(e, dict) and e.get("id"):
+                        claimed.add(e["id"])
+            unclaimed = added_ids - claimed
+            if unclaimed:
+                corpus_problems.append(
+                    "%d added entr%s no acted request claims: %s — an "
+                    "addition smuggled beside an acted one is still smuggled"
+                    % (len(unclaimed), "y" if len(unclaimed) == 1 else "ies",
+                       ", ".join(sorted(unclaimed))))
+            base_keys = {_entry_observation_key(e)
+                         for e in base_by_id.values()}
+            seen_new = {}
+            for aid in sorted(added_ids):
+                key = _entry_observation_key(head_by_id[aid])
+                if key in base_keys or key in seen_new:
+                    other = seen_new.get(key, "an existing entry")
+                    corpus_problems.append(
+                        "added entry %r observes the same tuple as %s — two "
+                        "references for one observation resolve later by a "
+                        "cleanup that picks the masking direction"
+                        % (aid, other))
+                seen_new[key] = "added entry %r" % aid
+        corpus_ok = not corpus_problems
+
+    for act in acts:
+        row = {"id": act.get("id"), "paths": [], "ok": False, "problems": []}
+        req = requests.get(act.get("id"))
+        if req is None:
+            row["problems"].append("an act without a request acts nothing")
+        paths = [p for p in (act.get("recorded_paths") or [])
+                 if isinstance(p, str) and p]
+        row["paths"] = paths
+        if req is not None and not paths:
+            row["problems"].append(
+                "the act records no path — an extension that touched "
+                "nothing extended nothing")
+        for p in paths:
+            if p == ledger_rel:
+                continue
+            if p == corpus_rel:
+                if not corpus_changed:
+                    row["problems"].append(
+                        "corpus.json is recorded but did not change")
+                elif not corpus_ok:
+                    row["problems"].extend(corpus_problems)
+            elif p.startswith(refs_prefix):
+                if at(base, p) is not None:
+                    row["problems"].append(
+                        "%s existed at base — a rewrite wearing an "
+                        "addition's name" % p)
+                elif at("HEAD", p) is None:
+                    row["problems"].append(
+                        "%s is recorded but absent at HEAD — a recorded "
+                        "delete, and a delete is the masking vector" % p)
+            else:
+                row["problems"].append(
+                    "%s is outside the extension surface (refs/ and "
+                    "corpus.json) — the canon, the mutants, the harness and "
+                    "the configuration are the judge's territory" % p)
+        row["ok"] = (req is not None and not row["problems"]
+                     and verdict["ledger_append_only"])
+        if row["ok"]:
+            verdict["ok_paths"].extend(row["paths"])
+        verdict["acted"].append(row)
+
+    verdict["ok_paths"] = sorted(set(verdict["ok_paths"]))
+    return verdict
+
+
 # ─── Route coverage — the corpus states its own perimeter ───────────────────
 
 def route_regex(pattern):
@@ -2233,6 +2457,172 @@ def _selftest():
         check("bloc objet SANS id -> escalade nommee, pas un KeyError",
               pending_rebaselines(ldir)[0]["id"], "UNPARSEABLE")
 
+        # 8e. Extensions : le verdict additions-only, falsifie dans les deux
+        #     sens — une extension legitime DOIT passer, et chaque deguisement
+        #     du vecteur de masquage (reecriture, suppression, retouche,
+        #     collision, entree passee en fraude, registre reecrit) DOIT
+        #     rougir. Un fixture git reel, parce que le verdict se lit en git.
+        xroot = tempfile.mkdtemp(prefix="gm-selftest-ext-")
+        xgm = os.path.join(xroot, ".golden-master")
+        os.makedirs(os.path.join(xgm, "refs"))
+        base_entry = {"id": "1", "method": "GET", "path": "/a", "persona": "p"}
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            json.dump({"entries": [base_entry]}, f)
+        with open(os.path.join(xgm, "refs", "1.txt"), "w", encoding="utf-8") as f:
+            f.write("ref-1\n")
+        for cmd in ("git init -q", "git add -A",
+                    "git -c user.email=t@t -c user.name=t commit -qm seed"):
+            run(cmd, xroot, timeout=60)
+        xbase = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+
+        def xledger(*blks):
+            with open(os.path.join(xgm, "EXTENSIONS.md"), "w", encoding="utf-8") as f:
+                f.write("\n".join("<!-- iterion:extension-%s\n%s\n-->" % b
+                                  for b in blks))
+
+        def xcommit():
+            run("git add -A", xroot, timeout=60)
+            run("git -c user.email=t@t -c user.name=t commit -qm x",
+                xroot, timeout=60)
+
+        def xreset():
+            run("git reset -q --hard %s" % xbase, xroot, timeout=60)
+            run("git clean -qfd", xroot, timeout=60)
+
+        req2 = ('{"id": "E-1", "lot": "L", "type": "add-file",'
+                ' "paths": [".golden-master/refs/2.txt"]}')
+        act2 = ('{"id": "E-1", "lot": "L",'
+                ' "recorded_paths": [".golden-master/refs/2.txt"]}')
+
+        check("pas de registre -> aucune extension pendante",
+              pending_extensions(xgm), [])
+        xledger(("request", req2))
+        check("demande sans acte -> pendante",
+              [p["id"] for p in pending_extensions(xgm)], ["E-1"])
+        xledger(("request", req2), ("act", act2))
+        check("demande actee -> rien", pending_extensions(xgm), [])
+        xledger(("request", 'pas du json'))
+        check("bloc extension illisible -> escalade nommee",
+              pending_extensions(xgm)[0]["id"], "UNPARSEABLE")
+
+        # Extension legitime : un fichier de ref NEUF, acte, registre commite.
+        xreset()
+        xledger(("request", req2), ("act", act2))
+        with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+            f.write("ref-2\n")
+        xcommit()
+        v = extension_verdict(xroot, ".golden-master", xbase)
+        check("add-file legitime -> ok, chemin exempte",
+              [v["acted"][0]["ok"], v["ok_paths"]],
+              [True, [".golden-master/refs/2.txt"]])
+
+        # Reecriture deguisee : la ref existait a la base.
+        xreset()
+        xledger(("request", '{"id": "E-1", "lot": "L", "paths": [".golden-master/refs/1.txt"]}'),
+                ("act", '{"id": "E-1", "lot": "L", "recorded_paths": [".golden-master/refs/1.txt"]}'))
+        with open(os.path.join(xgm, "refs", "1.txt"), "w", encoding="utf-8") as f:
+            f.write("ref-1-reecrite\n")
+        xcommit()
+        check("reecriture deguisee en ajout -> refusee",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+        # Suppression enregistree : le chemin manque a HEAD (le cote delete
+        # d'un renommage perd exactement ici).
+        xreset()
+        xledger(("request", req2), ("act", act2))
+        xcommit()
+        check("chemin enregistre absent a HEAD (delete/rename) -> refuse",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+        # Entree de corpus legitime, revendiquee par la demande.
+        xreset()
+        new_entry = {"id": "2", "method": "GET", "path": "/b", "persona": "p"}
+        xledger(("request", '{"id": "E-2", "lot": "L", "type": "add-entry",'
+                            ' "corpus_entries": [{"id": "2"}]}'),
+                ("act", '{"id": "E-2", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/corpus.json"]}'))
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            json.dump({"entries": [base_entry, new_entry]}, f)
+        xcommit()
+        check("add-entry legitime et revendiquee -> ok",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], True)
+
+        # Retouche d'une entree existante sous couvert d'ajout.
+        xreset()
+        xledger(("request", '{"id": "E-2", "lot": "L", "corpus_entries": [{"id": "2"}]}'),
+                ("act", '{"id": "E-2", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/corpus.json"]}'))
+        touched = dict(base_entry, path="/a-bougee")
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            json.dump({"entries": [touched, new_entry]}, f)
+        xcommit()
+        check("entree existante retouchee -> refusee",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+        # Collision : la « nouvelle » entree observe le meme tuple qu'une
+        # existante — deux references pour une observation.
+        xreset()
+        collider = dict(base_entry, id="9")
+        xledger(("request", '{"id": "E-3", "lot": "L", "corpus_entries": [{"id": "9"}]}'),
+                ("act", '{"id": "E-3", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/corpus.json"]}'))
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            json.dump({"entries": [base_entry, collider]}, f)
+        xcommit()
+        check("collision de tuple d'observation -> refusee",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+        # Entree passee en fraude : ajoutee au corpus, revendiquee par
+        # personne.
+        xreset()
+        smuggled = {"id": "8", "method": "GET", "path": "/c", "persona": "p"}
+        xledger(("request", '{"id": "E-2", "lot": "L", "corpus_entries": [{"id": "2"}]}'),
+                ("act", '{"id": "E-2", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/corpus.json"]}'))
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            json.dump({"entries": [base_entry, new_entry, smuggled]}, f)
+        xcommit()
+        check("entree non revendiquee a cote d'une actee -> refusee",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+        # Chemin hors surface : le canon est le territoire du juge.
+        xreset()
+        xledger(("request", '{"id": "E-4", "lot": "L", "paths": [".golden-master/canon/x.py"]}'),
+                ("act", '{"id": "E-4", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/canon/x.py"]}'))
+        os.makedirs(os.path.join(xgm, "canon"), exist_ok=True)
+        with open(os.path.join(xgm, "canon", "x.py"), "w", encoding="utf-8") as f:
+            f.write("# neuf\n")
+        xcommit()
+        check("chemin hors refs/+corpus (canon) -> refuse",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+        # Registre reecrit : un registre COMMITTE a la base n'est plus un
+        # prefixe de HEAD. (Un registre ne EXISTANT PAS a la base rend ce
+        # check vacueux par construction — la, c'est « acte sans demande »
+        # qui tient la ligne, teste plus bas.)
+        xreset()
+        xledger(("request", req2))
+        xcommit()
+        xbase2 = run("git rev-parse HEAD", xroot, timeout=60)[1].strip()
+        xledger(("act", act2))  # la demande a disparu : trail edite
+        with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+            f.write("ref-2\n")
+        xcommit()
+        v = extension_verdict(xroot, ".golden-master", xbase2)
+        check("registre committe puis reecrit -> append_only faux et acte refuse",
+              [v["ledger_append_only"], v["acted"][0]["ok"]],
+              [False, False])
+
+        # Acte sans demande : il n'acte rien.
+        xreset()
+        xledger(("act", act2))
+        with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+            f.write("ref-2\n")
+        xcommit()
+        check("acte sans demande -> refuse",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
         # 9. Scellement : derivable partout, jamais dans le parent du worktree
         #    (lecture seule en sandbox), et sans collision entre worktrees
         #    freres qui partagent le meme basename.
@@ -2276,12 +2666,30 @@ def main():
     # set somewhere the gate will not look, and two runs cannot share a pile.
     sealed_dir = sealed_dir_for(ws)
     floor = int(os.environ.get("GM_MUTATION_FLOOR", "90"))
-    mode = os.environ.get("GM_MODE", "gate")   # gate | record | selfcheck | validate | selftest
+    mode = os.environ.get("GM_MODE", "gate")   # gate | record | selfcheck | validate | selftest | extensions | extend-verify
 
     # Les tests du harnais d'abord, et hors de tout le reste : ils ne touchent
     # ni au depot, ni a l'application, ni a la configuration.
     if mode == "selftest":
         raise SystemExit(_selftest())
+
+    # Ledger listings and the additions-only verdict are pure git/file reads:
+    # no boot, no capture, callable from a verifier that must not pay for
+    # either — and BY the party whose own work they judge, because the code
+    # deciding is this file's, not theirs.
+    if mode == "extensions":
+        print(json.dumps({"pending": pending_extensions(gm_dir)}))
+        raise SystemExit(0)
+    if mode == "extend-verify":
+        base = os.environ.get("GM_BASE", "")
+        if not base:
+            print(json.dumps({"error": "GM_BASE is required — judging "
+                              "additions against nothing would pass by "
+                              "construction"}))
+            raise SystemExit(1)
+        print(json.dumps(extension_verdict(
+            ws, os.environ.get("GM_DIR", ".golden-master"), base)))
+        raise SystemExit(0)
 
     report = {"mode": mode, "total": 0, "valid": 0, "detected": 0, "score_pct": 0,
               "noop_silent": False, "revert_clean": True, "collateral": 0,
@@ -2293,6 +2701,7 @@ def main():
               "features_total": 0, "features_excluded": 0,
               "holdout_awaiting_gate": False,
               "pending_rebaselines": [],
+              "pending_extensions": [],
               "holdout_detected": 0, "holdout_total": 0, "stable": False,
               "holdout_detected_on_surface": 0, "score_on_surface_pct": 0,
               "corpus_total": 0, "corpus_distinct": 0, "duplicate_refs": [],
@@ -2542,6 +2951,17 @@ def main():
                  "them (record, diff == announced, act block, then the verdict after "
                  "a green counter-test), or refuse them in writing."
                  % (len(pending), json.dumps(pending, ensure_ascii=False)))
+
+        pending_ext = pending_extensions(gm_dir)
+        if pending_ext:
+            report["pending_extensions"] = pending_ext
+            bail("the ledger carries %d pending extension request(s): %s. Each one "
+                 "names an observation the net was asked to gain and does not "
+                 "have — a green built while they wait reports coverage the "
+                 "intent already knows is missing. The net's extension subbot "
+                 "acts them; what it cannot apply additively goes back to its "
+                 "requester in writing."
+                 % (len(pending_ext), json.dumps(pending_ext, ensure_ascii=False)))
 
     try:
         app_up(config, ws)

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1115,14 +1115,15 @@ def pending_extensions(gm_dir, text=None):
 ## never a masked duplicate.
 OBSERVATION_FIELDS = ("method", "path", "persona", "surface", "fields",
                       "steps", "params", "query", "body", "readback",
-                      "no_redirect")
+                      "no_redirect", "csrf_field")
 
 
 def _entry_observation_key(entry):
     """What an entry OBSERVES: two entries equal under this key are two
-    references for one observation — a collision, not an addition."""
-    return json.dumps({k: entry.get(k) for k in OBSERVATION_FIELDS
-                       if k in entry},
+    references for one observation — a collision, not an addition. Absent
+    and empty collapse together — a twin carrying `"query": ""` must not
+    split the key on mere PRESENCE (consolidation finding, executed)."""
+    return json.dumps({k: (entry.get(k) or None) for k in OBSERVATION_FIELDS},
                       sort_keys=True, ensure_ascii=False)
 
 
@@ -1250,6 +1251,20 @@ def extension_verdict(ws, gm_rel, base):
                         "entry %r was MODIFIED — a rewrite is the masking "
                         "vector, not an extension" % bid)
             added_ids = set(head_by_id) - set(base_by_id)
+            # An entry id DERIVES a reference path (refs/<id>.txt) in the
+            # record and gate paths, unvalidated there — so an added id
+            # carrying a separator is a write to an EXISTING reference
+            # wearing an addition's name, the corpus-surface twin of the
+            # refs/ symlink (consolidation finding, executed with
+            # id "../refs/1").
+            for aid in sorted(added_ids):
+                if not isinstance(aid, str) or not aid or aid in (".", "..") \
+                        or any(c in aid for c in "/\\") \
+                        or aid != os.path.basename(aid):
+                    corpus_problems.append(
+                        "added entry id %r derives a reference path outside "
+                        "refs/ — a write to an existing reference wearing an "
+                        "addition's name" % (aid,))
             claimed = set()
             for act in acts:
                 req = requests.get(act.get("id"))
@@ -1317,13 +1332,22 @@ def extension_verdict(ws, gm_rel, base):
                         "%s is not a regular file (mode %s) — a link is a "
                         "write to somewhere else wearing an addition's name"
                         % (p, blob_mode("HEAD", p) or "?"))
-                elif req is not None and p not in (req.get("paths") or []):
-                    # Added refs are claimed against the request the way
-                    # entries are claimed against corpus_entries — acting
-                    # more than was asked is smuggling, whichever surface.
+                elif req is not None and p not in (req.get("paths") or []) \
+                        and p not in {refs_prefix + e["id"] + ".txt"
+                                      for e in (req.get("corpus_entries") or [])
+                                      if isinstance(e, dict)
+                                      and isinstance(e.get("id"), str)
+                                      and e["id"] == os.path.basename(e["id"])}:
+                    # Added refs are claimed against the request — explicitly
+                    # in `paths` (add-file), or implicitly as the reference an
+                    # add-entry's claimed entry DERIVES (the gate demands
+                    # refs/<id>.txt for every entry, so a claimed entry claims
+                    # its reference; ids carrying separators derive nothing —
+                    # they are refused above). Anything else is smuggling.
                     row["problems"].append(
-                        "%s is not declared in the request's `paths` — "
-                        "acting more than was asked is smuggling" % p)
+                        "%s is neither declared in the request's `paths` nor "
+                        "derived from a claimed corpus entry — acting more "
+                        "than was asked is smuggling" % p)
             else:
                 row["problems"].append(
                     "%s is outside the extension surface (refs/ and "
@@ -2770,6 +2794,53 @@ def _selftest():
         check("corpus malforme -> refuse, pas une traceback",
               extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
 
+        # 8g. Les refus du tour de CONSOLIDATION — la classe id-derive-un-
+        #     chemin et la cle sensible a la presence, plus le flux add-entry
+        #     legitime que le durcissement du tour 1 avait ferme.
+
+        # Un id ajoute portant un separateur derive refs/<id>.txt HORS de
+        # refs/ — le jumeau corpus du symlink.
+        xreset()
+        traversal = {"id": "../refs/1", "method": "GET", "path": "/t", "persona": "p"}
+        xledger(("request", '{"id": "E-5", "lot": "L", "corpus_entries": [{"id": "../refs/1"}]}'),
+                ("act", '{"id": "E-5", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/corpus.json"]}'))
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            json.dump({"entries": [base_entry, traversal]}, f)
+        xcommit()
+        check("id en traversee (../refs/1) -> refuse",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+        # La PRESENCE d'un champ allowliste vide ne scinde pas la cle.
+        xreset()
+        present_twin = dict(base_entry, id="9", query="")
+        xledger(("request", '{"id": "E-3", "lot": "L", "corpus_entries": [{"id": "9"}]}'),
+                ("act", '{"id": "E-3", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/corpus.json"]}'))
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            json.dump({"entries": [base_entry, present_twin]}, f)
+        xcommit()
+        check("collision masquee par un champ allowliste VIDE -> refusee",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+        # Le flux add-entry LEGITIME : l'entree revendiquee revendique sa
+        # reference derivee — corpus.json ET refs/2.txt exemptes, sans
+        # `paths` dans la demande (la forme que la doctrine prescrit).
+        xreset()
+        xledger(("request", '{"id": "E-2", "lot": "L", "type": "add-entry",'
+                            ' "corpus_entries": [{"id": "2"}]}'),
+                ("act", '{"id": "E-2", "lot": "L", "recorded_paths":'
+                        ' [".golden-master/corpus.json", ".golden-master/refs/2.txt"]}'))
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            json.dump({"entries": [base_entry, new_entry]}, f)
+        with open(os.path.join(xgm, "refs", "2.txt"), "w", encoding="utf-8") as f:
+            f.write("ref-2\n")
+        xcommit()
+        v = extension_verdict(xroot, ".golden-master", xbase)
+        check("add-entry avec sa ref derivee, sans `paths` -> ok, les deux exemptes",
+              [v["acted"][0]["ok"], v["ok_paths"]],
+              [True, [".golden-master/corpus.json", ".golden-master/refs/2.txt"]])
+
         # 9. Scellement : derivable partout, jamais dans le parent du worktree
         #    (lecture seule en sandbox), et sans collision entre worktrees
         #    freres qui partagent le meme basename.
@@ -3151,7 +3222,22 @@ def main():
 
     try:
         if mode == "record":
-            snap = capture(config, corpus, canon)
+            # GM_RECORD_IDS scopes the record to named entries — the extension
+            # subbot needs to capture EXACTLY the entries it added: a full
+            # re-record inside a lot where behaviour legitimately moved would
+            # rewrite every reference and be refused wholesale as smuggling.
+            only = [i for i in os.environ.get("GM_RECORD_IDS", "").split(",")
+                    if i.strip()]
+            if only:
+                known = {e["id"] for e in corpus["entries"]}
+                missing = [i for i in only if i not in known]
+                if missing:
+                    bail("GM_RECORD_IDS names %d entr%s absent from the "
+                         "corpus: %s — recording an unknown id writes a "
+                         "reference nothing will ever compare"
+                         % (len(missing), "y" if len(missing) == 1 else "ies",
+                            ", ".join(missing)))
+            snap = capture(config, corpus, canon, ids=only or None)
             for k, v in snap.items():
                 with open(os.path.join(refs_dir, k + ".txt"), "w", encoding="utf-8", newline="") as f:
                     f.write(v)

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -1091,18 +1091,38 @@ def pending_extensions(gm_dir, text=None):
     if not text:
         return []
     requests = _extension_blocks(text, "request")
-    acted = {b.get("id") for b in _extension_blocks(text, "act")}
-    if any(r.get("id") == "UNPARSEABLE" for r in requests) or "UNPARSEABLE" in acted:
+    acts = _extension_blocks(text, "act")
+    if any(b.get("id") == "UNPARSEABLE" for b in requests + acts):
         return [{"id": "UNPARSEABLE",
                  "why": "a ledger block does not parse as JSON — escalate, do not guess"}]
+    # Only a WELL-FORMED act closes a request: an act with no recorded path
+    # acted nothing, and letting it close the term would let the constrained
+    # party silence the conjunction with four lines of JSON — the
+    # additions-only verdict never runs at gate time, so this shape check is
+    # the whole defence here (adversarial finding, executed).
+    acted = {b["id"] for b in acts
+             if isinstance(b.get("recorded_paths"), list) and b["recorded_paths"]}
     return [{"id": r["id"], "lot": r.get("lot", "?")}
             for r in requests if r["id"] not in acted]
 
 
+## The fields that DECIDE what an entry observes. An allowlist, not
+## "everything but id": a stripped-everything key is defeated by one cosmetic
+## key (`note`, `comment`) that makes two identical observations compare
+## different (adversarial finding, executed). Fields outside this list do not
+## discriminate; if the harness later grows a discriminating field, the
+## failure mode is a FALSE collision — refused, escalated to the requester —
+## never a masked duplicate.
+OBSERVATION_FIELDS = ("method", "path", "persona", "surface", "fields",
+                      "steps", "params", "query", "body", "readback",
+                      "no_redirect")
+
+
 def _entry_observation_key(entry):
-    """What an entry OBSERVES, id stripped: two entries equal under this key
-    are two references for one observation — a collision, not an addition."""
-    return json.dumps({k: v for k, v in entry.items() if k != "id"},
+    """What an entry OBSERVES: two entries equal under this key are two
+    references for one observation — a collision, not an addition."""
+    return json.dumps({k: entry.get(k) for k in OBSERVATION_FIELDS
+                       if k in entry},
                       sort_keys=True, ensure_ascii=False)
 
 
@@ -1133,9 +1153,23 @@ def extension_verdict(ws, gm_rel, base):
         code, out, _ = git("show", "%s:%s" % (ref, path))
         return out if code == 0 else None
 
+    def blob_mode(ref, path):
+        code, out, _ = git("ls-tree", ref, "--", path)
+        return out.split()[0] if code == 0 and out.strip() else ""
+
     ledger_rel = gm_rel.rstrip("/") + "/EXTENSIONS.md"
     corpus_rel = gm_rel.rstrip("/") + "/corpus.json"
     refs_prefix = gm_rel.rstrip("/") + "/refs/"
+
+    # An unresolvable base and an honest "absent at base" both read as None
+    # below, so a bad sha would certify everything as an addition — a guard
+    # whose failure mode is a full pass (adversarial finding, executed).
+    # Refuse it the way an empty base is refused.
+    code, _, err = git("rev-parse", "--verify", "--quiet", base + "^{commit}")
+    if code != 0:
+        return {"error": "GM_BASE %r does not resolve to a commit (%s) — "
+                         "judging additions against nothing would pass by "
+                         "construction" % (base, err.strip() or "unknown ref")}
 
     verdict = {"acted": [], "ok_paths": [], "ledger_append_only": True,
                "requests_added": 0, "problems": []}
@@ -1173,13 +1207,38 @@ def extension_verdict(ws, gm_rel, base):
             base_c = json.loads(base_corpus_txt or "{}")
         except ValueError as e:
             corpus_problems.append("corpus.json does not parse: %s" % e)
+        if head_c is not None and base_c is not None and \
+                not isinstance(head_c, dict):
+            corpus_problems.append("corpus.json is not an object")
+            head_c = base_c = None
+        if head_c is not None and base_c is not None and (
+                not isinstance(head_c.get("entries", []), list)
+                or not all(isinstance(e, dict)
+                           for e in head_c.get("entries", []))):
+            corpus_problems.append(
+                "corpus.json `entries` is not a list of objects — refused, "
+                "not crashed")
+            head_c = base_c = None
         if head_c is not None and base_c is not None:
             if {k: v for k, v in head_c.items() if k != "entries"} != \
                     {k: v for k, v in base_c.items() if k != "entries"}:
                 corpus_problems.append(
                     "corpus.json keys outside `entries` changed — an "
                     "extension adds entries and touches nothing else")
-            base_by_id = {e.get("id"): e for e in base_c.get("entries", [])}
+            # An id names ONE observation. Duplicated ids collapse in every
+            # by-id index (this one, the capture map, the refs map), so the
+            # equality check would read the surviving twin while the capture
+            # hands the reference to the other — an existing observation
+            # hijacked through the channel (adversarial finding, executed).
+            head_ids = [e.get("id") for e in head_c.get("entries", [])]
+            dupes = sorted({i for i in head_ids if head_ids.count(i) > 1})
+            if dupes:
+                corpus_problems.append(
+                    "duplicate entry id(s) %s — an id is one observation, "
+                    "and a twin id hands the capture to whichever entry "
+                    "wins an ordering nobody audits" % ", ".join(map(repr, dupes)))
+            base_by_id = {e.get("id"): e for e in base_c.get("entries", [])
+                          if isinstance(e, dict)}
             head_by_id = {e.get("id"): e for e in head_c.get("entries", [])}
             for bid, be in base_by_id.items():
                 if bid not in head_by_id:
@@ -1249,6 +1308,22 @@ def extension_verdict(ws, gm_rel, base):
                     row["problems"].append(
                         "%s is recorded but absent at HEAD — a recorded "
                         "delete, and a delete is the masking vector" % p)
+                elif blob_mode("HEAD", p) not in ("100644", "100755"):
+                    # A symlink's content is its target string, so it passes
+                    # every text check while the next record pass writes
+                    # THROUGH it onto an existing reference — an addition
+                    # that masks (adversarial finding, executed).
+                    row["problems"].append(
+                        "%s is not a regular file (mode %s) — a link is a "
+                        "write to somewhere else wearing an addition's name"
+                        % (p, blob_mode("HEAD", p) or "?"))
+                elif req is not None and p not in (req.get("paths") or []):
+                    # Added refs are claimed against the request the way
+                    # entries are claimed against corpus_entries — acting
+                    # more than was asked is smuggling, whichever surface.
+                    row["problems"].append(
+                        "%s is not declared in the request's `paths` — "
+                        "acting more than was asked is smuggling" % p)
             else:
                 row["problems"].append(
                     "%s is outside the extension surface (refs/ and "
@@ -2621,6 +2696,78 @@ def _selftest():
             f.write("ref-2\n")
         xcommit()
         check("acte sans demande -> refuse",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+        # 8f. Les refus arraches par la revue adversariale — chaque
+        #     deguisement executee contre le verdict doit rester rouge.
+
+        # Un acte VIDE ne ferme pas le terme de conjonction : quatre lignes
+        # de JSON suffiraient a la partie contrainte pour eteindre la porte.
+        xledger(("request", req2), ("act", '{"id": "E-1", "lot": "L"}'))
+        check("acte sans recorded_paths -> la demande RESTE pendante",
+              [p["id"] for p in pending_extensions(xgm)], ["E-1"])
+        xledger(("request", req2),
+                ("act", '{"id": "E-1", "lot": "L", "recorded_paths": []}'))
+        check("acte a recorded_paths vide -> la demande RESTE pendante",
+              [p["id"] for p in pending_extensions(xgm)], ["E-1"])
+
+        # Un symlink sous refs/ : son contenu est sa cible, la prochaine
+        # passe record ecrit A TRAVERS lui sur une reference existante.
+        xreset()
+        xledger(("request", req2), ("act", act2))
+        os.symlink("1.txt", os.path.join(xgm, "refs", "2.txt"))
+        xcommit()
+        check("symlink sous refs/ -> refuse",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+        # Un chemin refs/ enregistre mais non declare par la demande.
+        xreset()
+        xledger(("request", req2),
+                ("act", '{"id": "E-1", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/refs/3.txt"]}'))
+        with open(os.path.join(xgm, "refs", "3.txt"), "w", encoding="utf-8") as f:
+            f.write("ref-3\n")
+        xcommit()
+        check("ref ajoutee non declaree par la demande -> refusee",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+        # Un id duplique : l'egalite lit un jumeau, la capture sert l'autre.
+        xreset()
+        xledger(("request", '{"id": "E-2", "lot": "L", "corpus_entries": [{"id": "1"}]}'),
+                ("act", '{"id": "E-2", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/corpus.json"]}'))
+        twin = dict(base_entry, path="/detournee")
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            json.dump({"entries": [twin, base_entry]}, f)
+        xcommit()
+        check("id duplique dans le corpus -> refuse",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+        # Une cle cosmetique ne neutralise pas la collision d'observation.
+        xreset()
+        cosmetic = dict(base_entry, id="9", note="differente en apparence")
+        xledger(("request", '{"id": "E-3", "lot": "L", "corpus_entries": [{"id": "9"}]}'),
+                ("act", '{"id": "E-3", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/corpus.json"]}'))
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            json.dump({"entries": [base_entry, cosmetic]}, f)
+        xcommit()
+        check("collision masquee par une cle cosmetique -> refusee",
+              extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
+
+        # Une base irresoluble ne tamponne rien : elle refuse.
+        check("GM_BASE irresoluble -> erreur, pas un laissez-passer",
+              "error" in extension_verdict(xroot, ".golden-master", "d" * 40), True)
+
+        # Un corpus malforme refuse, il ne crashe pas.
+        xreset()
+        xledger(("request", '{"id": "E-2", "lot": "L", "corpus_entries": [{"id": "2"}]}'),
+                ("act", '{"id": "E-2", "lot": "L",'
+                        ' "recorded_paths": [".golden-master/corpus.json"]}'))
+        with open(os.path.join(xgm, "corpus.json"), "w", encoding="utf-8") as f:
+            f.write('{"entries": {"E1": {}}}')
+        xcommit()
+        check("corpus malforme -> refuse, pas une traceback",
               extension_verdict(xroot, ".golden-master", xbase)["acted"][0]["ok"], False)
 
         # 9. Scellement : derivable partout, jamais dans le parent du worktree

--- a/bots/golden-master/oracle-harness.py
+++ b/bots/golden-master/oracle-harness.py
@@ -2239,12 +2239,12 @@ def _selftest():
         saved_env = {k: os.environ.get(k) for k in ("GM_SEALED_DIR", "GM_SCRATCH")}
         os.environ.pop("GM_SEALED_DIR", None)
         os.environ.pop("GM_SCRATCH", None)
-        a, b = sealed_dir_for("/w/replay/poss"), sealed_dir_for("/w/replay2/poss")
+        a, b = sealed_dir_for("/w/replay/app"), sealed_dir_for("/w/replay2/app")
         check("meme basename, deux worktrees -> deux piles", a != b, True)
         check("la pile ne vit pas dans le parent du worktree",
               a.startswith("/w/"), False)
         check("deux processus, meme workspace -> meme pile",
-              sealed_dir_for("/w/replay/poss") == a, True)
+              sealed_dir_for("/w/replay/app") == a, True)
         os.environ["GM_SEALED_DIR"] = "/elsewhere/pile"
         check("GM_SEALED_DIR impose sa pile", sealed_dir_for("/w/x"), "/elsewhere/pile")
         for k, v in saved_env.items():

--- a/bots/golden-master/reanchor.bot
+++ b/bots/golden-master/reanchor.bot
@@ -244,7 +244,10 @@ tool reanchor_verify:
     #    configuration, the harness or any product file appearing here means the
     #    lot has just moved what judges it, through this bot.
     mutants_prefix = os.path.join(gm, "mutants") + "/"
-    code, out, err = git("diff", "--name-only", base, "HEAD")
+    # quotePath=false: a non-ASCII path comes back quoted and stops matching
+    # the prefix — the scope check would accuse a correct repair.
+    code, out, err = git("-c", "core.quotePath=false",
+                         "diff", "--name-only", base, "HEAD")
     if code != 0:
         problems.append("cannot diff against %s: %s" % (base, err.strip()))
     else:

--- a/bots/golden-master/skills/golden-master.md
+++ b/bots/golden-master/skills/golden-master.md
@@ -231,6 +231,13 @@ divergence, it can only add a constraint. Same block idiom:
 -->
 ```
 
+An `add-entry` implies its reference: the gate demands `refs/<id>.txt` for
+every corpus entry, so the acting bot captures it (`GM_MODE=record` scoped
+with `GM_RECORD_IDS=<id,…>` — never a full re-record) and records it in the
+act; a claimed entry claims its derived reference, no `paths` line needed.
+Entry ids are file-name-safe by construction — an id carrying a path
+separator would derive a reference OUTSIDE refs/ and is refused.
+
 **A pending extension request is a conjunction term too** (`pending_extensions` in the verdict),
 for the mirrored reason: it names coverage the intent already knows is missing, and a green built
 while it waits reports that coverage anyway. No `replaces` chain here — a request that no longer

--- a/bots/golden-master/skills/golden-master.md
+++ b/bots/golden-master/skills/golden-master.md
@@ -248,9 +248,12 @@ run's base): every recorded path is a PURE addition — a refs/ file absent at b
 entries where every base entry survives equal. A rewrite, a delete, or a rename (its delete side
 loses) is the masking vector wearing an addition's name → refused, re-baseline ledger, human. An
 added entry no acted request claims is smuggling → refused. An added entry whose observation
-tuple (the entry minus its `id`) equals an existing one is a COLLISION — two references for one
-observation resolve later by a cleanup that picks the masking direction → refused. The ledger is
-append-only: an edited trail audits nothing.
+tuple equals an existing one is a COLLISION — the tuple is the `OBSERVATION_FIELDS` allowlist
+(`method`, `path`, `persona`, `surface`, `fields`, `steps`, `params`, `query`, `body`,
+`readback`, `no_redirect`, `csrf_field`), NOT "the entry minus its id": a distinguishing field
+outside the allowlist does not disambiguate, and absent and empty compare equal. Two references
+for one observation resolve later by a cleanup that picks the masking direction → refused. The
+ledger is append-only: an edited trail audits nothing.
 
 ## The `write` surface — the only one a read-only capture cannot reach
 

--- a/bots/golden-master/skills/golden-master.md
+++ b/bots/golden-master/skills/golden-master.md
@@ -211,6 +211,40 @@ under pressure learns a file's convention from the file, and a ledger whose visi
 all prose teaches prose — measured: a model announcement, complete in every way except the block,
 that nothing could act on until an operator transcribed it by hand.
 
+### The extension ledger — additions, the one change a bot may grant
+
+`EXTENSIONS.md`, beside `REBASELINE.md`, carries the ADDITIVE counterpart with the opposite
+authority. A re-baseline MOVES a reference, so only a human act closes it. An extension ADDS an
+observation point — a new route, a state only modernised code reaches — and the net's own subbot
+(`extend.bot`) may act it, because an addition is checkable: it cannot mask an existing
+divergence, it can only add a constraint. Same block idiom:
+
+```
+<!-- iterion:extension-request
+{"id": "E-<lot>-<n>", "lot": "<lot-id>", "type": "add-file|add-entry",
+ "paths": ["new reference paths under refs/, if add-file"],
+ "corpus_entries": [{"id": "<new-entry-id>", "...": "the full entry, tuple included"}],
+ "justification": "one line: the observation the intent requires and the net lacks"}
+-->
+<!-- iterion:extension-act
+{"id": "E-<lot>-<n>", "lot": "<lot-id>", "recorded_paths": ["…"], "ts": "…"}
+-->
+```
+
+**A pending extension request is a conjunction term too** (`pending_extensions` in the verdict),
+for the mirrored reason: it names coverage the intent already knows is missing, and a green built
+while it waits reports that coverage anyway. No `replaces` chain here — a request that no longer
+applies is acted or withdrawn by its requester, never superseded.
+
+What the acting side is held to, mechanically (`GM_MODE=extend-verify`, judged in git against the
+run's base): every recorded path is a PURE addition — a refs/ file absent at base, or corpus
+entries where every base entry survives equal. A rewrite, a delete, or a rename (its delete side
+loses) is the masking vector wearing an addition's name → refused, re-baseline ledger, human. An
+added entry no acted request claims is smuggling → refused. An added entry whose observation
+tuple (the entry minus its `id`) equals an existing one is a COLLISION — two references for one
+observation resolve later by a cleanup that picks the masking direction → refused. The ledger is
+append-only: an edited trail audits nothing.
+
 ## The `write` surface — the only one a read-only capture cannot reach
 
 Every other surface watches a response **served**. A corruption that happens

--- a/bots/issue-triage/skills/iterion-bot-catalog.md
+++ b/bots/issue-triage/skills/iterion-bot-catalog.md
@@ -738,7 +738,7 @@ redefine what judges it, because a golden master dies by re-baselining. The
   there. Do NOT use it to decide WHAT to modernise: the programme is a human
   decision recorded in the contract, and the lot DAG in particular encodes
   compatibility knowledge that cannot be re-derived from the tree.
-- **Vars**: `max_passes` (int), `only_lot` (string), `plan_path` (string), `reanchor` (bool), `source_issue_ref` (string), `workspace_dir` (string)
+- **Vars**: `extend` (bool), `max_passes` (int), `only_lot` (string), `plan_path` (string), `reanchor` (bool), `source_issue_ref` (string), `workspace_dir` (string)
 - **Path**: `bots/modernize/main.bot`
 
 ### `nested-subbots-demo` — Nested Subbots Demo

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -33,6 +33,11 @@ vars:
   ## report and the surface they probed uncovered — which is the status quo, and
   ## which nothing goes red about.
   reanchor: bool = true
+  ## Act the lot's EXTENSION requests (new observation points, by pure
+  ## addition) by running the net's own bot as a subbot. Off leaves the
+  ## requests pending in the ledger, where the oracle gate refuses until a
+  ## human acts them — pending is loud by design, never a silent skip.
+  extend: bool = true
   source_issue_ref: string = ""
 
 secrets:
@@ -140,6 +145,10 @@ schema lot_report:
   ## read it and nothing ever did — a signal that exists in a log and not in the
   ## contract is not a signal.
   oracle_invalid: json
+  ## Extension requests the lot left pending in the net's ledger — read by the
+  ## harness's own code, and routed to the net's extension subbot. A lot may
+  ## ASK for a new observation point; it may never write one.
+  extension_pending: json
   log_tail: string
 
 schema gate_state:
@@ -148,6 +157,7 @@ schema gate_state:
   stop: bool
   fail_log: string
   needs_reanchor: bool
+  needs_extend: bool
 
 schema verify_input:
   lot_id: string
@@ -407,7 +417,7 @@ tool lot_verify:
 
     report = {"gate_passed": False, "oracle_passed": False, "refs_untouched": False,
               "refs_changed": [], "lot_blocked": False, "block_reason": "", "log_tail": "",
-              "oracle_invalid": []}
+              "oracle_invalid": [], "extension_pending": []}
     problems = []
 
     # Did the campaign declare this lot blocked? Read from the contract, which
@@ -502,12 +512,45 @@ tool lot_verify:
                   os.path.join(gm_dir, "corpus.json"),
                   os.path.join(gm_dir, "route-coverage.json"),
                   os.path.join(gm_dir, "feature-coverage.json")]
+
+        # The extension ledger, read and judged by the HARNESS's own code —
+        # never by this bot's. Pending requests route to the net's extension
+        # subbot; ACTED extensions that the harness certifies as pure
+        # additions are exempted from the immutability verdict below, and
+        # ONLY those: an addition cannot mask an existing divergence, which
+        # is the one property that makes the exemption safe to grant.
+        def harness_json(mode, **extra):
+            hp = os.path.join(ws, gm_dir, "harness.py")
+            if not os.path.isfile(hp):
+                return None
+            env = dict(os.environ, GM_MODE=mode, GM_WORKSPACE=ws,
+                       GM_DIR=gm_dir, **extra)
+            p = subprocess.run(["python3", hp], cwd=ws, env=env,
+                               capture_output=True, text=True, timeout=300)
+            try:
+                return json.loads((p.stdout or "").strip().splitlines()[-1])
+            except (ValueError, IndexError):
+                problems.append("the harness did not answer GM_MODE=%s "
+                                "(exit %d): %s"
+                                % (mode, p.returncode,
+                                   (p.stdout + p.stderr)[-400:]))
+                return None
+
+        listing = harness_json("extensions")
+        if listing is not None:
+            report["extension_pending"] = listing.get("pending") or []
+        exempt = set()
+        verdict = harness_json("extend-verify", GM_BASE=base)
+        if verdict is not None and not verdict.get("error"):
+            exempt = set(verdict.get("ok_paths") or [])
+
         code, log = run("git diff --name-only %s -- %s"
                         % (base, " ".join(shlex.quote(p) for p in judged)))
         if code != 0:
             problems.append("cannot diff the references against %s: %s" % (base, log))
         else:
-            changed = [l.strip() for l in log.splitlines() if l.strip()]
+            changed = [l.strip() for l in log.splitlines()
+                       if l.strip() and l.strip() not in exempt]
             report["refs_changed"] = changed
             report["refs_untouched"] = not changed
             if changed:
@@ -535,6 +578,10 @@ compute lot_gate:
     ## stops being covered in silence. A lot can therefore go green while the
     ## net gets narrower — which is the one failure mode a green cannot report.
     needs_reanchor: "vars.reanchor && length(outputs.lot_verify.oracle_invalid) > 0"
+    ## Unlike needs_reanchor, a pending extension CANNOT ride a green: the
+    ## oracle gate refuses on it, so this only routes the repair — it never
+    ## decides the verdict.
+    needs_extend: "vars.extend && length(outputs.lot_verify.extension_pending) > 0"
 
 ## reanchor — the net's OWN bot, run as a subbot, to repair a mutant this lot
 ## invalidated.
@@ -561,6 +608,27 @@ subbot reanchor:
 schema reanchor_result:
   converged: bool
   repaired: int
+  notice: string
+
+## extend — the net's OWN bot, run as a subbot, to act the extension requests
+## this lot wrote in the ledger.
+##
+## Same placement logic as reanchor, and the same missing `isolated:`: the
+## child works on THIS lot's checkout, and what keeps it honest is its own
+## deterministic check — every path it touches must be a pure ADDITION on the
+## extension surface, judged by the harness's code. The lot may ASK for an
+## observation point; only the net's bot may grant one, and only additively —
+## a rewrite, a delete or a rename goes to the re-baseline ledger and a human.
+subbot extend:
+  source: "../golden-master/extend.bot"
+  with {
+    lot_id: "{{outputs.work_gate.lot_id}}"
+  }
+  output: extend_result
+
+schema extend_result:
+  converged: bool
+  extended: int
   notice: string
 
 workflow modernize:
@@ -618,6 +686,25 @@ workflow modernize:
   ## is part of that verdict, so reading it again is what stops a failed repair
   ## from looking like a successful one.
   reanchor -> lot_verify with {
+    lot_id:    "{{outputs.work_gate.lot_id}}",
+    plan_path: "{{vars.plan_path}}",
+    base_sha:  "{{outputs.work_gate.base_sha}}",
+    refs_dir:  "{{outputs.work_gate.refs_dir}}",
+    exit_gate: "{{outputs.work_gate.exit_gate}}"
+  }
+
+  ## Act the lot's extension requests, after any reanchor and before the lot
+  ## is decided: the oracle gate refuses on a pending request, so a lot that
+  ## asked for an observation point cannot converge until the net's bot has
+  ## granted it — or refused it in writing, which stays pending and loud.
+  ## Bounded to a single attempt for the same reason as reanchor: the child
+  ## has its own repair loop.
+  lot_gate -> extend when needs_extend as extend_loop("1")
+
+  ## The verdict is re-taken on the extended net. The harness re-certifies
+  ## the additions inside lot_verify — exemption is re-derived every pass,
+  ## never remembered.
+  extend -> lot_verify with {
     lot_id:    "{{outputs.work_gate.lot_id}}",
     plan_path: "{{vars.plan_path}}",
     base_sha:  "{{outputs.work_gate.base_sha}}",

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -544,13 +544,33 @@ tool lot_verify:
         if verdict is not None and not verdict.get("error"):
             exempt = set(verdict.get("ok_paths") or [])
 
-        code, log = run("git diff --name-only %s -- %s"
+        # The certifier is the TARGET's harness copy — a file the lot could
+        # write. Two mechanical bounds keep its word from mattering when it
+        # shouldn't (adversarial finding, executed: a 12-line harness.py
+        # exempted itself and every reference):
+        #   1. only the extension surface is ever exemptible, whatever the
+        #      harness claims;
+        #   2. if ANY judged path outside that surface moved — the harness,
+        #      the canon, the runner, the config — the certifier itself is
+        #      suspect and its certificate is worth nothing: exempt nothing.
+        # quotePath=false, or a non-ASCII reference path comes back quoted
+        # and the exemption misses it — a legitimate extension accused of
+        # rewriting the net (same finding, same class in the two subbots).
+        surface_prefix = refs_dir.rstrip("/") + "/"
+        corpus_path = os.path.join(gm_dir, "corpus.json")
+        exempt = {p for p in exempt
+                  if p == corpus_path or p.startswith(surface_prefix)}
+
+        code, log = run("git -c core.quotePath=false diff --name-only %s -- %s"
                         % (base, " ".join(shlex.quote(p) for p in judged)))
         if code != 0:
             problems.append("cannot diff the references against %s: %s" % (base, log))
         else:
-            changed = [l.strip() for l in log.splitlines()
-                       if l.strip() and l.strip() not in exempt]
+            raw = [l.strip() for l in log.splitlines() if l.strip()]
+            if any(p != corpus_path and not p.startswith(surface_prefix)
+                   for p in raw):
+                exempt = set()
+            changed = [p for p in raw if p not in exempt]
             report["refs_changed"] = changed
             report["refs_untouched"] = not changed
             if changed:

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -581,6 +581,24 @@ tool lot_verify:
                                 "edited to hide that it did. Both are stop conditions."
                                 % (len(changed), ", ".join(changed[:20])))
 
+        # The certifier's REFUSALS are as binding as its certificates. The
+        # ledger is not in the judged diff (a lot legitimately writes its
+        # requests there), so without this term a lot could rewrite the
+        # ledger or append a sham act, extinguish the pending term, and ride
+        # a green — extension_verdict SEES both frauds and its verdict was
+        # read for ok_paths only (consolidation finding, executed: emptied
+        # ledger and act recording "peu-importe-quoi" both came out green).
+        if verdict is not None and not verdict.get("error"):
+            bad = [r for r in (verdict.get("acted") or []) if not r.get("ok")]
+            if verdict.get("problems") or bad \
+                    or not verdict.get("ledger_append_only", True):
+                problems.extend(verdict.get("problems") or [])
+                problems.extend("extension %s refused: %s"
+                                % (r.get("id"),
+                                   "; ".join(r.get("problems") or []))
+                                for r in bad)
+                report["refs_untouched"] = False
+
     report["log_tail"] = "\n".join(problems)[-6000:]
     print(json.dumps(report))
 

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -504,14 +504,19 @@ tool lot_verify:
         # et un vert ne peut pas rapporter ce retrecissement (mesure au tour
         # 6). Un changement legitime de ces fichiers est une EXTENSION du
         # filet : elle appartient a son proprietaire, par le registre.
-        judged = [refs_dir,
-                  os.path.join(gm_dir, "verify-oracle.sh"),
-                  os.path.join(gm_dir, "harness.py"),
-                  os.path.join(gm_dir, "canon"),
-                  os.path.join(gm_dir, "config.json"),
-                  os.path.join(gm_dir, "corpus.json"),
-                  os.path.join(gm_dir, "route-coverage.json"),
-                  os.path.join(gm_dir, "feature-coverage.json")]
+        # The WHOLE net directory is judged, not a fixed file list: a fixed
+        # list leaves a NEW file invisible, and `python3 <net>/harness.py`
+        # puts that directory at sys.path[0] — a dropped <net>/json.py
+        # executes before any verdict is read, so an unjudged new file is a
+        # certifier hijack, not clutter (review finding). Three exclusions,
+        # each owned by another deterministic check: the two ledgers (the
+        # lot legitimately writes its requests there; the harness judges
+        # append-only and act shape), and mutants/ (reanchor's own scope
+        # check owns every path under it).
+        judged = [gm_dir]
+        unjudged_prefixes = (os.path.join(gm_dir, "mutants") + "/",)
+        unjudged_exact = {os.path.join(gm_dir, "EXTENSIONS.md"),
+                          os.path.join(gm_dir, "REBASELINE.md")}
 
         # The extension ledger, read and judged by the HARNESS's own code —
         # never by this bot's. Pending requests route to the net's extension
@@ -523,10 +528,30 @@ tool lot_verify:
             hp = os.path.join(ws, gm_dir, "harness.py")
             if not os.path.isfile(hp):
                 return None
+            # A net materialised BEFORE this feature has no extension modes:
+            # its main() would fall through to the FULL gate path — boot the
+            # app, run the campaign — and die on this call's timeout (review
+            # finding, executed against the merge-base harness). Capability
+            # is read from the file, and its absence is the legal state of
+            # an older net: no extension machinery, no exemption, exactly
+            # the pre-feature behaviour until the net's owner re-materialises.
+            try:
+                with open(hp, encoding="utf-8") as f:
+                    if 'mode == "extend-verify"' not in f.read():
+                        return None
+            except OSError as e:
+                problems.append("cannot read %s to probe its capabilities: %s"
+                                % (hp, e))
+                return None
             env = dict(os.environ, GM_MODE=mode, GM_WORKSPACE=ws,
                        GM_DIR=gm_dir, **extra)
-            p = subprocess.run(["python3", hp], cwd=ws, env=env,
-                               capture_output=True, text=True, timeout=300)
+            try:
+                p = subprocess.run(["python3", hp], cwd=ws, env=env,
+                                   capture_output=True, text=True, timeout=300)
+            except subprocess.TimeoutExpired:
+                problems.append("the harness did not answer GM_MODE=%s "
+                                "within 300s — refusing, not exempting" % mode)
+                return None
             try:
                 return json.loads((p.stdout or "").strip().splitlines()[-1])
             except (ValueError, IndexError):
@@ -561,12 +586,33 @@ tool lot_verify:
         exempt = {p for p in exempt
                   if p == corpus_path or p.startswith(surface_prefix)}
 
+        # The certificate is judged on COMMITTED content (git show), while
+        # the diff below reads the WORKING TREE — so an exempted path with
+        # uncommitted worktree damage would escape the verdict wearing its
+        # certificate (review finding, executed: additions-only committed,
+        # entry deleted in the worktree, green). A dirty net voids the
+        # certificate: commit, then verify.
+        code, log = run("git -c core.quotePath=false status --porcelain -- %s"
+                        % shlex.quote(gm_dir))
+        if code != 0:
+            problems.append("cannot read the net's worktree state: %s" % log)
+            exempt = set()
+        elif log.strip():
+            dirty = sorted(l[3:] for l in log.splitlines() if l.strip())
+            problems.append("%d uncommitted path(s) under the net (%s) — the "
+                            "extension certificate reads commits, the verdict "
+                            "reads the tree; a dirty net voids the certificate."
+                            % (len(dirty), ", ".join(dirty[:12])))
+            exempt = set()
+
         code, log = run("git -c core.quotePath=false diff --name-only %s -- %s"
                         % (base, " ".join(shlex.quote(p) for p in judged)))
         if code != 0:
             problems.append("cannot diff the references against %s: %s" % (base, log))
         else:
-            raw = [l.strip() for l in log.splitlines() if l.strip()]
+            raw = [l.strip() for l in log.splitlines()
+                   if l.strip() and l.strip() not in unjudged_exact
+                   and not any(l.strip().startswith(u) for u in unjudged_prefixes)]
             if any(p != corpus_path and not p.startswith(surface_prefix)
                    for p in raw):
                 exempt = set()

--- a/bots/modernize/main.bot
+++ b/bots/modernize/main.bot
@@ -604,6 +604,12 @@ tool lot_verify:
                             "reads the tree; a dirty net voids the certificate."
                             % (len(dirty), ", ".join(dirty[:12])))
             exempt = set()
+            # A voided certificate is a REFUSAL, not a remark: the pending
+            # term reads the worktree while every ledger judgement reads
+            # HEAD, so an uncommitted ledger edit could retire a committed
+            # request from the term with nothing to refuse it (adversarial
+            # finding, executed).
+            report["refs_untouched"] = False
 
         code, log = run("git -c core.quotePath=false diff --name-only %s -- %s"
                         % (base, " ".join(shlex.quote(p) for p in judged)))
@@ -644,6 +650,19 @@ tool lot_verify:
                                    "; ".join(r.get("problems") or []))
                                 for r in bad)
                 report["refs_untouched"] = False
+        else:
+            # No verdict is not "nothing to refuse". The certifier runs on
+            # ledger content the constrained party writes, so a crash there
+            # is reachable from the ledger itself — reading its silence as
+            # absolution let a rewritten ledger ride a green (adversarial
+            # finding, executed).
+            problems.append(
+                "the extension certifier returned no usable verdict (%s) — "
+                "a certifier that cannot answer is a refusal, not an absence"
+                % ((verdict or {}).get("error")
+                   or (verdict or {}).get("__unparsed__")
+                   or "no output")[:300])
+            report["refs_untouched"] = False
 
     report["log_tail"] = "\n".join(problems)[-6000:]
     print(json.dumps(report))

--- a/bots/modernize/skills/modernize-lots.md
+++ b/bots/modernize/skills/modernize-lots.md
@@ -158,6 +158,18 @@ A red the ledger never heard about is a dead end: the supervising process can
 only execute what was announced. Every re-baseline need, however obvious it
 feels in the moment, goes to the ledger.
 
+The same channel exists for the opposite need. When the intent requires the
+net to OBSERVE something it does not cover yet — a new route, a state only
+the modernised code reaches — you do not write under the net to get it. You
+write an extension request in `EXTENSIONS.md` (same block discipline, blocks
+`iterion:extension-request`; canonical format in the golden-master doctrine
+skill) and the net's own bot acts it by pure addition, mechanically checked.
+The distinction that decides which ledger: MOVING a reference is a
+re-baseline and needs a human; ADDING an observation point is an extension
+and the net's bot may grant it. A rename is a move. If your request cannot be
+satisfied without touching an existing reference or entry, it is a
+re-baseline request wearing the wrong block.
+
 ## The third place a fix can cheat: the environment the judge looks through
 
 Two forms of cheating are obvious enough that any net guards against them:

--- a/bots/whats-next/skills/iterion-bot-catalog.md
+++ b/bots/whats-next/skills/iterion-bot-catalog.md
@@ -981,7 +981,7 @@ redefine what judges it, because a golden master dies by re-baselining. The
   there. Do NOT use it to decide WHAT to modernise: the programme is a human
   decision recorded in the contract, and the lot DAG in particular encodes
   compatibility knowledge that cannot be re-derived from the tree.
-- **Vars**: `max_passes` (int), `only_lot` (string), `plan_path` (string), `reanchor` (bool), `source_issue_ref` (string), `workspace_dir` (string)
+- **Vars**: `extend` (bool), `max_passes` (int), `only_lot` (string), `plan_path` (string), `reanchor` (bool), `source_issue_ref` (string), `workspace_dir` (string)
 - **Path**: `bots/modernize/main.bot`
 
 ### `nested-subbots-demo` — Nested Subbots Demo

--- a/docs/bot-runs/golden-master.md
+++ b/docs/bot-runs/golden-master.md
@@ -450,7 +450,7 @@ capture implementations converge — a risk that did not materialise.
 ### Environment defects found (in the target's baseline harness, not the bot)
 
 5. **MySQL socket truncated at 107 characters.** `struct sockaddr_un.sun_path` is capped;
-   `~/.iterion/projects/<bot>/worktrees/<uuid>/.state/poss/mysql/mysqld.sock` is 109. The kernel
+   `~/.iterion/projects/<bot>/worktrees/<uuid>/.state/<repo>/mysql/mysqld.sock` is 109. The kernel
    truncates silently, mysqld listens somewhere the client never looks, the baseline never boots.
    Invisible on a dev checkout (71 characters). → socket moved to a short `/tmp` path keyed by a
    hash of the repo path, plus an explicit length guard.
@@ -458,7 +458,7 @@ capture implementations converge — a risk that did not materialise.
    start; at worst it captures the first one's application and produces a net that looks valid
    and describes a different tree. This happened — a dev instance was left running during a run.
    → ports derived from the repo path like the socket, effective URL published to
-   `../.state/poss/baseline-url.txt`.
+   `../.state/<repo>/baseline-url.txt`.
 
 None of these six was findable by review. All required a real run.
 


### PR DESCRIPTION
## The gap, measured

A modernisation lot whose intent requires the net to OBSERVE a new surface (a route, a state only the modernised code reaches) has no legal move today: the refs-immutability check in `lot_verify` refuses every write under the net, so extension-shaped lots cannot converge without a human act. Measured on a live campaign: three immutability refusals in 48h, one of them a legitimate extension need that had filed its request AND written directly anyway — the prompt rule alone does not hold the line.

## The design

Additions get a legal path because an addition is *checkable* — it cannot mask an existing divergence, only add a constraint. Everything that merely wears an addition's name is refused mechanically, by harness code, never by prompt. On the `reanchor` precedent:

- **`EXTENSIONS.md`** beside `REBASELINE.md`, same block idiom (`iterion:extension-request` / `-act`), opposite authority: a re-baseline MOVES a reference → human act; an extension ADDS an observation point → the net's own subbot (**`extend.bot`**, new) may act it.
- **`GM_MODE=extend-verify`** (harness): judges every acted extension in git against the run's base — refs paths must be new regular blobs declared by the request; corpus entries must leave every base entry intact, be claimed by an acted request, and collide with nothing on their observation tuple; the ledger is append-only.
- **A pending request is a conjunction term** in the gate (`pending_extensions`), like a pending re-baseline: coverage the intent knows is missing must not ride a green.
- **modernize wiring**: `extend` var (default true), pending requests route `lot_gate -> extend` (single attempt, child owns its repair loop), verdict re-taken on the extended net; only harness-certified paths are exempted from immutability, re-derived every pass.

## Falsified both ways

Harness selftest: **92 checks** (22 new). The legitimate add-file and claimed add-entry MUST pass; each of these MUST refuse: disguised rewrite, recorded delete (a rename's delete side loses), touched entry, tuple collision (including one hidden behind a cosmetic key), smuggled entry, undeclared refs path, symlink, out-of-surface path, rewritten ledger, request-less act, empty act, unresolvable base, malformed corpus.

One adversarial review round (execute-to-prove posture) ran against the first cut and returned 1 critical + 4 high findings, all demonstrated with fixtures and all now refused — see the second commit's message for the list; the harness-rewrite fixture (a 12-line `harness.py` exempting itself and every reference) now goes red on all three paths.

`iterion validate` OK on `extend.bot`, `reanchor.bot`, `modernize/main.bot`; harness copies re-synced (`sync-harness.py`, Go sync test green); catalogs regenerated; 296 bot tests green.

## Known limits (deliberate)

- The subbot runs in the lot's workspace (no isolation) — the deterministic check is the boundary, exactly as for `reanchor`.
- Eligible surface is `refs/` + `corpus.json` only; canon/mutants/config/coverage stay the judge's territory.
- Renames and deletes always go to the re-baseline ledger and a human.
- Follow-up candidates (not this PR): duplicate-id refusal in the main gate path (same class as the extension-side check, needs falsification against existing nets first); record-mode following symlinks generally.

Based on #587 (branch includes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)