### PR TITLE
feat(runner): park an unbankable attempt's work on its own ref

### DIFF
--- a/pkg/runner/bank_test.go
+++ b/pkg/runner/bank_test.go
@@ -1238,9 +1238,11 @@ func TestBankFailureRecordingIsBounded(t *testing.T) {
 
 // A slow-but-HEALTHY store must not defeat the doc-cancel guard: the
 // round-3 probe answered the cancelled doc in 7s and the 5s-bounded
-// read failed open, pushing refused work. The read now rides the doc
-// pair's more generous bound; fail-open remains only for a store that
-// cannot answer within it (the documented preservation-wins residue).
+// read failed open, pushing refused work. The read rides its own
+// parkDocReadTimeout — wide enough for this case, tight enough that a
+// wedged store cannot spend the doc pair's window in pre-Nak latency
+// (TestParkDocReadBoundIsTight asserts that ceiling); past it,
+// fail-open is the documented preservation-wins residue.
 func TestParkDocCancelGuardSurvivesASlowStore(t *testing.T) {
 	r, msg, work, origin, base := bankFixture(t)
 	run := loadRun(t, r, msg.RunID)
@@ -1249,7 +1251,7 @@ func TestParkDocCancelGuardSurvivesASlowStore(t *testing.T) {
 		t.Fatalf("flip to cancelled: %v", err)
 	}
 	probe := &parkIOProbeStore{RunStore: r.cfg.Store,
-		loadWindow: make(chan time.Duration, 1), loadDelay: parkStoreOpTimeout + 2*time.Second}
+		loadWindow: make(chan time.Duration, 1), loadDelay: parkDocReadTimeout - 3*time.Second}
 	r.cfg.Store = probe
 	gitOut(t, work, "commit", "--allow-empty", "-m", "refused work")
 	head := gitOut(t, work, "rev-parse", "HEAD")
@@ -1309,7 +1311,7 @@ func TestStorageBankSaveGetsItsOwnWindow(t *testing.T) {
 	r, msg, work, origin, base := bankFixture(t)
 	probe := &parkIOProbeStore{RunStore: r.cfg.Store,
 		loadWindow: make(chan time.Duration, 1), saveWindow: make(chan time.Duration, 1),
-		loadDelay: 6 * time.Second}
+		loadDelay: 3 * time.Second}
 	r.cfg.Store = probe
 	gitOut(t, work, "commit", "--allow-empty", "-m", "the run's work")
 	head := gitOut(t, work, "rev-parse", "HEAD")
@@ -1319,14 +1321,16 @@ func TestStorageBankSaveGetsItsOwnWindow(t *testing.T) {
 	if got, ok := bankedBranch(t, origin, msg.RunID); !ok || got != head {
 		t.Fatalf("nominal bank broken: %q (present=%v)", got, ok)
 	}
-	if run := loadRun(t, r, msg.RunID); run.FinalBranch == "" {
-		t.Fatal("the doc pair was not recorded")
+	// Read through the UNDECORATED store: the delayed probe would charge
+	// the test a second loadDelay for its own assertion.
+	if run, err := probe.RunStore.LoadRun(store.WithIdentity(context.Background(), msg.TenantID, ""), msg.RunID); err != nil || run.FinalBranch == "" {
+		t.Fatalf("the doc pair was not recorded (err=%v)", err)
 	}
 	<-probe.loadWindow
 	select {
 	case w := <-probe.saveWindow:
-		if w < bankDocOpTimeout-3*time.Second {
-			t.Errorf("save window = %s after a 6s load — the save inherited only what the load left; each doc op must ride its own bound", w)
+		if w < bankDocOpTimeout-1500*time.Millisecond {
+			t.Errorf("save window = %s after a 3s load — the save inherited only what the load left; each doc op must ride its own bound", w)
 		}
 	default:
 		t.Fatal("the bank never saved the doc")
@@ -1433,4 +1437,52 @@ func TestParkDocReadBoundIsTight(t *testing.T) {
 	default:
 		t.Fatal("the park never re-read the doc")
 	}
+}
+
+// A dead push must be NAMED on every post-push doc-I/O exit: without
+// push_error the event is key-for-key identical to the push-succeeded
+// shape, and once the doc write meant to carry FinalBranchError has
+// died too, push_error is the cause's only durable carrier.
+func TestStorageBankDeadPushExitsNameThePushError(t *testing.T) {
+	deadRemote := func(t *testing.T, work string) {
+		t.Helper()
+		gitOut(t, work, "remote", "set-url", "origin", filepath.Join(t.TempDir(), "no-such-remote.git"))
+	}
+	t.Run("dead push x dead save", func(t *testing.T) {
+		r, msg, work, _, base := bankFixture(t)
+		probe := &parkIOProbeStore{RunStore: r.cfg.Store, saveErr: errors.New("store down")}
+		r.cfg.Store = probe
+		gitOut(t, work, "commit", "--allow-empty", "-m", "work")
+		deadRemote(t, work)
+
+		r.bankRepoWorkspace(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, "finished")
+
+		ev := findEvent(t, r, msg.RunID, store.EventRunBankRefused)
+		if ev == nil {
+			t.Fatal("no event at all")
+		}
+		if pe, _ := ev.Data["push_error"].(string); pe == "" {
+			t.Fatalf("event %v claims {branch, head} with no push_error — indistinguishable from a pushed branch, and the push failure has no durable carrier left", ev.Data)
+		}
+	})
+	t.Run("dead push x cancelled doc", func(t *testing.T) {
+		r, msg, work, _, base := bankFixture(t)
+		run := loadRun(t, r, msg.RunID)
+		run.Status = store.RunStatusCancelled
+		if err := r.cfg.Store.SaveRun(store.WithIdentity(context.Background(), msg.TenantID, ""), run); err != nil {
+			t.Fatal(err)
+		}
+		gitOut(t, work, "commit", "--allow-empty", "-m", "work")
+		deadRemote(t, work)
+
+		r.bankRepoWorkspace(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, "failed")
+
+		ev := findEvent(t, r, msg.RunID, store.EventRunBankRefused)
+		if ev == nil {
+			t.Fatal("no event at all")
+		}
+		if pe, _ := ev.Data["push_error"].(string); pe == "" {
+			t.Fatalf("event %v hides the dead push behind cancelled_while_banking", ev.Data)
+		}
+	})
 }

--- a/pkg/runner/bank_test.go
+++ b/pkg/runner/bank_test.go
@@ -938,6 +938,19 @@ func TestBankAttemptRefOperatorCancelParksNothing(t *testing.T) {
 		if _, ok := attemptRefAt(t, origin, msg.RunID, head); ok {
 			t.Fatal("a doc-cancelled run must not park")
 		}
+		// But never in silence: cancelled is a status the product RESUMES
+		// (rewind parks live runs there), so discarding forge-side work
+		// must leave its trace on the timeline.
+		ev := findEvent(t, r, msg.RunID, store.EventRunBankAttempt)
+		if ev == nil {
+			t.Fatal("the doc-cancelled skip left no run_bank_attempt — work discarded with zero durable trace on a resumable status")
+		}
+		if errStr, _ := ev.Data["error"].(string); !strings.Contains(errStr, "cancelled") {
+			t.Errorf("event error = %v, want the cancelled-doc skip named", ev.Data["error"])
+		}
+		if ev.Data["head"] != head {
+			t.Errorf("event head = %v, want %s so the work stays findable in the snapshot", ev.Data["head"], head)
+		}
 	})
 	t.Run("bankable death on an operator-cancelled ctx", func(t *testing.T) {
 		r, msg, work, origin, base := bankFixture(t)
@@ -1052,5 +1065,73 @@ func TestBankAttemptRefUnreadableHeadIsLoud(t *testing.T) {
 	}
 	if run := loadRun(t, r, msg.RunID); run.FinalBranchError != "" {
 		t.Fatalf("FinalBranchError = %q, want the park refusal kept off the run doc", run.FinalBranchError)
+	}
+}
+
+// parkIOProbeStore wraps a real store and records the deadline state of
+// the park's store I/O — the round-2 probe made permanent. A wedged
+// store must never pin the pod: the forge got its deadline in round 1,
+// and the store is the same class of external resource, sitting on the
+// same pre-Nak path.
+type parkIOProbeStore struct {
+	store.RunStore
+	loadWindow  chan time.Duration // -1 when no deadline
+	eventWindow chan time.Duration
+}
+
+func window(ctx context.Context) time.Duration {
+	d, ok := ctx.Deadline()
+	if !ok {
+		return -1
+	}
+	return time.Until(d)
+}
+
+func (s *parkIOProbeStore) LoadRun(ctx context.Context, id string) (*store.Run, error) {
+	select {
+	case s.loadWindow <- window(ctx):
+	default:
+	}
+	return s.RunStore.LoadRun(ctx, id)
+}
+
+func (s *parkIOProbeStore) AppendEvent(ctx context.Context, runID string, ev store.Event) (*store.Event, error) {
+	select {
+	case s.eventWindow <- window(ctx):
+	default:
+	}
+	return s.RunStore.AppendEvent(ctx, runID, ev)
+}
+
+func TestParkStoreIOIsBounded(t *testing.T) {
+	r, msg, work, origin, base := bankFixture(t)
+	probe := &parkIOProbeStore{RunStore: r.cfg.Store,
+		loadWindow: make(chan time.Duration, 1), eventWindow: make(chan time.Duration, 1)}
+	r.cfg.Store = probe
+	gitOut(t, work, "commit", "--allow-empty", "-m", "work in flight")
+	head := gitOut(t, work, "rev-parse", "HEAD")
+
+	r.bankIfBankable(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, runtime.ErrRunPaused)
+
+	if got, ok := attemptRefAt(t, origin, msg.RunID, head); !ok || got != head {
+		t.Fatalf("nominal park broken by the probe: ref %q (present=%v)", got, ok)
+	}
+	select {
+	case w := <-probe.loadWindow:
+		if w < 0 {
+			t.Error("the park's doc re-read ran with NO deadline — a wedged store pins the pod forever (round 1's forge class, by another resource)")
+		}
+	default:
+		t.Error("the park never re-read the doc")
+	}
+	select {
+	case w := <-probe.eventWindow:
+		if w < 0 {
+			t.Error("the park's event write ran with NO deadline")
+		} else if w > 30*time.Second {
+			t.Errorf("the event write's window is %s — it must ride its OWN short bound, not the park budget, so the event still lands when the push just died on that budget", w)
+		}
+	default:
+		t.Error("the park never wrote its event")
 	}
 }

--- a/pkg/runner/bank_test.go
+++ b/pkg/runner/bank_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -812,7 +813,7 @@ func TestBankFinishedContainedChainLeavesNoArchive(t *testing.T) {
 
 func attemptRefAt(t *testing.T, origin, runID, head string) (string, bool) {
 	t.Helper()
-	return refAt(t, origin, "refs/heads/iterion/run-"+runID+"-attempt-"+head[:12])
+	return refAt(t, origin, "refs/heads/iterion/run-"+runID+"-parked-"+head[:12])
 }
 
 func TestBankAttemptRefParksInterruptedAndPaused(t *testing.T) {
@@ -898,6 +899,46 @@ func TestBankAttemptRefOperatorCancelParksNothing(t *testing.T) {
 			t.Fatalf("cancelled left a run_bank_attempt event: %v", ev.Data)
 		}
 	})
+	t.Run("paused on an operator-cancelled ctx", func(t *testing.T) {
+		// The proven minutes-wide window: the pause persisted, then the
+		// operator cancelled while the sandbox export/teardown ran. The
+		// non-bankable road must honour the refusal exactly like the
+		// bankable one.
+		r, msg, work, origin, base := bankFixture(t)
+		gitOut(t, work, "commit", "--allow-empty", "-m", "refused work")
+		head := gitOut(t, work, "rev-parse", "HEAD")
+		ctx, cancel := context.WithCancelCause(context.Background())
+		cancel(runtime.ErrRunCancelled)
+		t.Cleanup(func() { cancel(nil) })
+
+		r.bankIfBankable(ctx, msg, work, base, runtime.WorkspaceIntegrity{}, runtime.ErrRunPaused)
+
+		if _, ok := attemptRefAt(t, origin, msg.RunID, head); ok {
+			t.Fatal("a pause on an operator-cancelled ctx must not park")
+		}
+		if ev := findEvent(t, r, msg.RunID, store.EventRunBankAttempt); ev != nil {
+			t.Fatalf("refused work left a run_bank_attempt event: %v", ev.Data)
+		}
+	})
+	t.Run("doc already cancelled parks nothing even on a live ctx", func(t *testing.T) {
+		// The cancel can land without ever cancelling THIS pod's ctx (the
+		// cancel subscription is best-effort). The park re-reads the doc
+		// before pushing, exactly like pushBank does before recording.
+		r, msg, work, origin, base := bankFixture(t)
+		gitOut(t, work, "commit", "--allow-empty", "-m", "refused work")
+		head := gitOut(t, work, "rev-parse", "HEAD")
+		run := loadRun(t, r, msg.RunID)
+		run.Status = store.RunStatusCancelled
+		if err := r.cfg.Store.SaveRun(store.WithIdentity(context.Background(), msg.TenantID, ""), run); err != nil {
+			t.Fatalf("flip to cancelled: %v", err)
+		}
+
+		r.bankIfBankable(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, runtime.ErrRunPaused)
+
+		if _, ok := attemptRefAt(t, origin, msg.RunID, head); ok {
+			t.Fatal("a doc-cancelled run must not park")
+		}
+	})
 	t.Run("bankable death on an operator-cancelled ctx", func(t *testing.T) {
 		r, msg, work, origin, base := bankFixture(t)
 		gitOut(t, work, "commit", "--allow-empty", "-m", "refused work")
@@ -965,5 +1006,51 @@ func TestBankAttemptRefIntegrityRefusalIsLoudOnTheTimeline(t *testing.T) {
 	}
 	if _, hasRef := ev.Data["ref"]; hasRef {
 		t.Errorf("refusal event carries a ref: %v — exactly one of ref/error may be present", ev.Data)
+	}
+}
+
+// The park's detached ctx must ALWAYS carry a deadline — including when
+// the operator disabled per-op git bounds. That choice bounds one git
+// op; it is not a licence to make a best-effort parking uninterruptible
+// on a pod that already lost its lease (proven: an accept-and-never-
+// answer forge pinned the push forever, and the Nak that triggers
+// redelivery only fires after the park returns).
+func TestAttemptBankContextIsAlwaysBounded(t *testing.T) {
+	old := gitOpTimeout
+	gitOpTimeout = 0 // the operator disabled per-op bounds
+	t.Cleanup(func() { gitOpTimeout = old })
+
+	ctx, cancel := attemptBankContext()
+	defer cancel()
+	if _, ok := ctx.Deadline(); !ok {
+		t.Fatal("the park ctx has no deadline with gitOpTimeout<=0 — an unanswering forge pins the pod forever and delays the redelivery Nak")
+	}
+}
+
+// "Never silence" must hold on the one shape resolveBankHead cannot
+// classify: HEAD unreadable with no integrity signal. The storage bank
+// keeps its historical warn-only behaviour; the PARK path's event is
+// the only durable record, so it must say the work was not parked.
+func TestBankAttemptRefUnreadableHeadIsLoud(t *testing.T) {
+	r, msg, work, origin, base := bankFixture(t)
+	gitOut(t, work, "commit", "--allow-empty", "-m", "the run's work")
+	if err := os.WriteFile(filepath.Join(work, ".git", "HEAD"), []byte("ref: refs/heads/vanished\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r.bankIfBankable(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, runtime.ErrRunInterrupted)
+
+	if out, err := exec.Command("git", "-C", origin, "for-each-ref", "refs/heads/iterion/").CombinedOutput(); err != nil || strings.TrimSpace(string(out)) != "" {
+		t.Fatalf("an unreadable HEAD parked something: %q (%v)", out, err)
+	}
+	ev := findEvent(t, r, msg.RunID, store.EventRunBankAttempt)
+	if ev == nil {
+		t.Fatal("an unreadable HEAD left no run_bank_attempt — total silence on the path whose event is the only record")
+	}
+	if errStr, _ := ev.Data["error"].(string); !strings.Contains(errStr, "HEAD") {
+		t.Errorf("event error = %v, want the unreadable HEAD named", ev.Data["error"])
+	}
+	if run := loadRun(t, r, msg.RunID); run.FinalBranchError != "" {
+		t.Fatalf("FinalBranchError = %q, want the park refusal kept off the run doc", run.FinalBranchError)
 	}
 }

--- a/pkg/runner/bank_test.go
+++ b/pkg/runner/bank_test.go
@@ -479,6 +479,15 @@ func TestBankLeavesCancelledRunUnrecorded(t *testing.T) {
 	if after.FinalBranch != "" || after.FinalCommit != "" {
 		t.Fatalf("cancelled run recorded FinalBranch=%q FinalCommit=%q, want both empty (not merge-eligible)", after.FinalBranch, after.FinalCommit)
 	}
+	// The branch exists on the forge with nothing on the doc pointing at
+	// it — that state must be on the timeline, not only in a pod log.
+	ev := findEvent(t, r, msg.RunID, store.EventRunBankRefused)
+	if ev == nil {
+		t.Fatal("a pushed-but-unrecorded branch left no run_bank_refused — invisible outside the pod log")
+	}
+	if got := ev.Data["reason"]; got != "cancelled_while_banking" {
+		t.Errorf("reason = %v, want cancelled_while_banking", got)
+	}
 }
 
 // The wall-clock death is the class the death bank most exists for, and
@@ -1079,6 +1088,8 @@ type parkIOProbeStore struct {
 	saveWindow  chan time.Duration
 	eventWindow chan time.Duration
 	loadDelay   time.Duration // simulates a slow-but-healthy store
+	loadErr     error         // injected LoadRun failure
+	saveErr     error         // injected SaveRun failure
 }
 
 func window(ctx context.Context) time.Duration {
@@ -1101,6 +1112,9 @@ func (s *parkIOProbeStore) LoadRun(ctx context.Context, id string) (*store.Run, 
 			return nil, ctx.Err()
 		}
 	}
+	if s.loadErr != nil {
+		return nil, s.loadErr
+	}
 	return s.RunStore.LoadRun(ctx, id)
 }
 
@@ -1110,6 +1124,9 @@ func (s *parkIOProbeStore) SaveRun(ctx context.Context, run *store.Run) error {
 		case s.saveWindow <- window(ctx):
 		default:
 		}
+	}
+	if s.saveErr != nil {
+		return s.saveErr
 	}
 	return s.RunStore.SaveRun(ctx, run)
 }
@@ -1279,5 +1296,141 @@ func TestParkEventLandsWhenTheBudgetIsSpent(t *testing.T) {
 	}
 	if _, hasErr := ev.Data["error"]; !hasErr {
 		t.Errorf("event data = %v, want the budget-death error named", ev.Data)
+	}
+}
+
+// ── Round 4: the storage bank's doc I/O exits must be loud and per-op ──
+
+// One shared 30s ctx for load->save meant the save only got what the
+// load left (proven: a 28s load starved a 3s save — branch pushed, doc
+// empty, merge truth lost in silence). Per-op contexts: the save's
+// window must not depend on the load's spend.
+func TestStorageBankSaveGetsItsOwnWindow(t *testing.T) {
+	r, msg, work, origin, base := bankFixture(t)
+	probe := &parkIOProbeStore{RunStore: r.cfg.Store,
+		loadWindow: make(chan time.Duration, 1), saveWindow: make(chan time.Duration, 1),
+		loadDelay: 6 * time.Second}
+	r.cfg.Store = probe
+	gitOut(t, work, "commit", "--allow-empty", "-m", "the run's work")
+	head := gitOut(t, work, "rev-parse", "HEAD")
+
+	r.bankRepoWorkspace(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, "finished")
+
+	if got, ok := bankedBranch(t, origin, msg.RunID); !ok || got != head {
+		t.Fatalf("nominal bank broken: %q (present=%v)", got, ok)
+	}
+	if run := loadRun(t, r, msg.RunID); run.FinalBranch == "" {
+		t.Fatal("the doc pair was not recorded")
+	}
+	<-probe.loadWindow
+	select {
+	case w := <-probe.saveWindow:
+		if w < bankDocOpTimeout-3*time.Second {
+			t.Errorf("save window = %s after a 6s load — the save inherited only what the load left; each doc op must ride its own bound", w)
+		}
+	default:
+		t.Fatal("the bank never saved the doc")
+	}
+}
+
+// Every doc-I/O exit of the storage bank that leaves an accomplished
+// side effect (branch pushed, refusal computed) must land on the
+// timeline — the park already honours this on every exit; these were
+// the five log-only ones.
+func TestStorageBankDocIOFailuresAreLoud(t *testing.T) {
+	t.Run("load failure after the push", func(t *testing.T) {
+		r, msg, work, origin, base := bankFixture(t)
+		probe := &parkIOProbeStore{RunStore: r.cfg.Store, loadErr: errors.New("store down")}
+		r.cfg.Store = probe
+		gitOut(t, work, "commit", "--allow-empty", "-m", "work")
+		head := gitOut(t, work, "rev-parse", "HEAD")
+
+		r.bankRepoWorkspace(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, "finished")
+
+		if got, ok := bankedBranch(t, origin, msg.RunID); !ok || got != head {
+			t.Fatalf("push should precede the doc read: %q (present=%v)", got, ok)
+		}
+		ev := findEvent(t, r, msg.RunID, store.EventRunBankRefused)
+		if ev == nil {
+			t.Fatal("branch on the forge, doc read dead, timeline EMPTY — the silent merge-truth loss")
+		}
+		if got := ev.Data["reason"]; got != "doc_load_failed" {
+			t.Errorf("reason = %v, want doc_load_failed", got)
+		}
+		if ev.Data["head"] != head {
+			t.Errorf("event head = %v, want the pushed head %s", ev.Data["head"], head)
+		}
+	})
+	t.Run("save failure after the push", func(t *testing.T) {
+		r, msg, work, _, base := bankFixture(t)
+		probe := &parkIOProbeStore{RunStore: r.cfg.Store, saveErr: errors.New("store down")}
+		r.cfg.Store = probe
+		gitOut(t, work, "commit", "--allow-empty", "-m", "work")
+
+		r.bankRepoWorkspace(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, "finished")
+
+		ev := findEvent(t, r, msg.RunID, store.EventRunBankRefused)
+		if ev == nil {
+			t.Fatal("SaveRun died and the timeline is empty — the doc pair is lost in silence")
+		}
+		if got := ev.Data["reason"]; got != "doc_save_failed" {
+			t.Errorf("reason = %v, want doc_save_failed", got)
+		}
+	})
+	t.Run("refusal recording load failure keeps the cause", func(t *testing.T) {
+		r, msg, _, _, _ := bankFixture(t)
+		probe := &parkIOProbeStore{RunStore: r.cfg.Store, loadErr: errors.New("store down")}
+		r.cfg.Store = probe
+
+		r.recordBankFailure(msg, "bank refused: the exported workspace lost the run's final tree")
+
+		ev := findEvent(t, r, msg.RunID, store.EventRunBankRefused)
+		if ev == nil {
+			t.Fatal("the integrity refusal vanished entirely — neither FinalBranchError nor the timeline carries it")
+		}
+		if cause, _ := ev.Data["cause"].(string); !strings.Contains(cause, "bank refused") {
+			t.Errorf("cause = %v, want the original refusal preserved", ev.Data["cause"])
+		}
+	})
+	t.Run("refusal recording save failure keeps the cause", func(t *testing.T) {
+		r, msg, _, _, _ := bankFixture(t)
+		probe := &parkIOProbeStore{RunStore: r.cfg.Store, saveErr: errors.New("store down")}
+		r.cfg.Store = probe
+
+		r.recordBankFailure(msg, "bank refused: probe cause")
+
+		ev := findEvent(t, r, msg.RunID, store.EventRunBankRefused)
+		if ev == nil {
+			t.Fatal("the refusal's save failure is invisible outside the pod log")
+		}
+		if cause, _ := ev.Data["cause"].(string); !strings.Contains(cause, "probe cause") {
+			t.Errorf("cause = %v, want the original refusal preserved", ev.Data["cause"])
+		}
+	})
+}
+
+// The park's doc-cancel courtesy read rides its own tight bound — NOT
+// the doc pair's 30s: on the interrupted path a wedged store was
+// measured costing 30s of pre-Nak latency, 6x the round-2 figure the
+// budget comment argues against.
+func TestParkDocReadBoundIsTight(t *testing.T) {
+	r, msg, work, origin, base := bankFixture(t)
+	probe := &parkIOProbeStore{RunStore: r.cfg.Store, loadWindow: make(chan time.Duration, 1)}
+	r.cfg.Store = probe
+	gitOut(t, work, "commit", "--allow-empty", "-m", "work")
+	head := gitOut(t, work, "rev-parse", "HEAD")
+
+	r.bankIfBankable(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, runtime.ErrRunPaused)
+
+	if got, ok := attemptRefAt(t, origin, msg.RunID, head); !ok || got != head {
+		t.Fatalf("nominal park broken: %q (present=%v)", got, ok)
+	}
+	select {
+	case w := <-probe.loadWindow:
+		if w > parkDocReadTimeout+time.Second {
+			t.Errorf("doc-cancel read window = %s — it must ride its own tight bound (%s), not the doc pair's %s: a wedged store buys that much pre-Nak latency", w, parkDocReadTimeout, bankDocOpTimeout)
+		}
+	default:
+		t.Fatal("the park never re-read the doc")
 	}
 }

--- a/pkg/runner/bank_test.go
+++ b/pkg/runner/bank_test.go
@@ -1076,7 +1076,9 @@ func TestBankAttemptRefUnreadableHeadIsLoud(t *testing.T) {
 type parkIOProbeStore struct {
 	store.RunStore
 	loadWindow  chan time.Duration // -1 when no deadline
+	saveWindow  chan time.Duration
 	eventWindow chan time.Duration
+	loadDelay   time.Duration // simulates a slow-but-healthy store
 }
 
 func window(ctx context.Context) time.Duration {
@@ -1092,7 +1094,24 @@ func (s *parkIOProbeStore) LoadRun(ctx context.Context, id string) (*store.Run, 
 	case s.loadWindow <- window(ctx):
 	default:
 	}
+	if s.loadDelay > 0 {
+		select {
+		case <-time.After(s.loadDelay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 	return s.RunStore.LoadRun(ctx, id)
+}
+
+func (s *parkIOProbeStore) SaveRun(ctx context.Context, run *store.Run) error {
+	if s.saveWindow != nil {
+		select {
+		case s.saveWindow <- window(ctx):
+		default:
+		}
+	}
+	return s.RunStore.SaveRun(ctx, run)
 }
 
 func (s *parkIOProbeStore) AppendEvent(ctx context.Context, runID string, ev store.Event) (*store.Event, error) {
@@ -1133,5 +1152,132 @@ func TestParkStoreIOIsBounded(t *testing.T) {
 		}
 	default:
 		t.Error("the park never wrote its event")
+	}
+}
+
+// The storage bank's doc pair is PRE-Nak too: a generic `failed` is
+// bankable and naks only after bankIfBankable returns, with the
+// heartbeat still refreshing the lease — so its load->save must be
+// deadlined like every other store op on the teardown traversal. A
+// write that never returns does not serve merge truth; it replaces it
+// with a pod nothing can redeliver.
+func TestStorageBankDocIOIsBounded(t *testing.T) {
+	r, msg, work, origin, base := bankFixture(t)
+	probe := &parkIOProbeStore{RunStore: r.cfg.Store,
+		loadWindow: make(chan time.Duration, 1), saveWindow: make(chan time.Duration, 1)}
+	r.cfg.Store = probe
+	gitOut(t, work, "commit", "--allow-empty", "-m", "the run's work")
+	head := gitOut(t, work, "rev-parse", "HEAD")
+
+	r.bankRepoWorkspace(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, "finished")
+
+	if got, ok := bankedBranch(t, origin, msg.RunID); !ok || got != head {
+		t.Fatalf("nominal bank broken by the probe: %q (present=%v)", got, ok)
+	}
+	select {
+	case w := <-probe.loadWindow:
+		if w < 0 {
+			t.Error("pushBank's doc load ran with NO deadline — a wedged store pins the pod pre-Nak, lease still refreshing")
+		}
+	default:
+		t.Error("the bank never loaded the doc")
+	}
+	select {
+	case w := <-probe.saveWindow:
+		if w < 0 {
+			t.Error("pushBank's doc save ran with NO deadline")
+		}
+	default:
+		t.Error("the bank never saved the doc")
+	}
+}
+
+// recordBankFailure carries the same doc pair on the same pre-Nak path.
+func TestBankFailureRecordingIsBounded(t *testing.T) {
+	r, msg, _, _, _ := bankFixture(t)
+	probe := &parkIOProbeStore{RunStore: r.cfg.Store,
+		loadWindow: make(chan time.Duration, 1), saveWindow: make(chan time.Duration, 1)}
+	r.cfg.Store = probe
+
+	r.recordBankFailure(msg, "bank refused: probe")
+
+	select {
+	case w := <-probe.loadWindow:
+		if w < 0 {
+			t.Error("recordBankFailure's doc load ran with NO deadline")
+		}
+	default:
+		t.Error("recordBankFailure never loaded the doc")
+	}
+	select {
+	case w := <-probe.saveWindow:
+		if w < 0 {
+			t.Error("recordBankFailure's doc save ran with NO deadline")
+		}
+	default:
+		t.Error("recordBankFailure never saved the doc")
+	}
+}
+
+// A slow-but-HEALTHY store must not defeat the doc-cancel guard: the
+// round-3 probe answered the cancelled doc in 7s and the 5s-bounded
+// read failed open, pushing refused work. The read now rides the doc
+// pair's more generous bound; fail-open remains only for a store that
+// cannot answer within it (the documented preservation-wins residue).
+func TestParkDocCancelGuardSurvivesASlowStore(t *testing.T) {
+	r, msg, work, origin, base := bankFixture(t)
+	run := loadRun(t, r, msg.RunID)
+	run.Status = store.RunStatusCancelled
+	if err := r.cfg.Store.SaveRun(store.WithIdentity(context.Background(), msg.TenantID, ""), run); err != nil {
+		t.Fatalf("flip to cancelled: %v", err)
+	}
+	probe := &parkIOProbeStore{RunStore: r.cfg.Store,
+		loadWindow: make(chan time.Duration, 1), loadDelay: parkStoreOpTimeout + 2*time.Second}
+	r.cfg.Store = probe
+	gitOut(t, work, "commit", "--allow-empty", "-m", "refused work")
+	head := gitOut(t, work, "rev-parse", "HEAD")
+
+	r.bankIfBankable(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, runtime.ErrRunPaused)
+
+	if _, ok := attemptRefAt(t, origin, msg.RunID, head); ok {
+		t.Fatal("a slow store defeated the doc-cancel guard: the refused work was pushed anyway")
+	}
+}
+
+// The event write's detachment, exercised at the ONLY moment where the
+// detached and the park-derived shapes diverge: the park budget spent.
+// The push dies on the exhausted budget; the failure event must still
+// land, on a window of its own.
+func TestParkEventLandsWhenTheBudgetIsSpent(t *testing.T) {
+	old := attemptBankBudget
+	attemptBankBudget = time.Millisecond
+	t.Cleanup(func() { attemptBankBudget = old })
+
+	r, msg, work, origin, base := bankFixture(t)
+	probe := &parkIOProbeStore{RunStore: r.cfg.Store, eventWindow: make(chan time.Duration, 1),
+		loadWindow: make(chan time.Duration, 1)}
+	r.cfg.Store = probe
+	gitOut(t, work, "commit", "--allow-empty", "-m", "work in flight")
+	head := gitOut(t, work, "rev-parse", "HEAD")
+
+	r.bankIfBankable(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, runtime.ErrRunPaused)
+
+	if _, ok := attemptRefAt(t, origin, msg.RunID, head); ok {
+		t.Fatal("a spent budget still pushed — the probe premise is broken")
+	}
+	select {
+	case w := <-probe.eventWindow:
+		if w < 0 {
+			t.Errorf("the failure event rode the spent park budget (window %s) — it must ride its own bound precisely when the push just died on that budget", w)
+		}
+	default:
+		t.Fatal("the spent-budget park emitted NO event — the exact silence the detached write exists to prevent")
+	}
+	ev := findEvent(t, r, msg.RunID, store.EventRunBankAttempt)
+	if ev == nil {
+		t.Fatal("no run_bank_attempt persisted")
+	}
+	if _, hasErr := ev.Data["error"]; !hasErr {
+		t.Errorf("event data = %v, want the budget-death error named", ev.Data)
 	}
 }

--- a/pkg/runner/bank_test.go
+++ b/pkg/runner/bank_test.go
@@ -1251,7 +1251,7 @@ func TestParkDocCancelGuardSurvivesASlowStore(t *testing.T) {
 		t.Fatalf("flip to cancelled: %v", err)
 	}
 	probe := &parkIOProbeStore{RunStore: r.cfg.Store,
-		loadWindow: make(chan time.Duration, 1), loadDelay: parkDocReadTimeout - 3*time.Second}
+		loadWindow: make(chan time.Duration, 1), loadDelay: parkDocReadTimeout * 7 / 10}
 	r.cfg.Store = probe
 	gitOut(t, work, "commit", "--allow-empty", "-m", "refused work")
 	head := gitOut(t, work, "rev-parse", "HEAD")
@@ -1481,8 +1481,56 @@ func TestStorageBankDeadPushExitsNameThePushError(t *testing.T) {
 		if ev == nil {
 			t.Fatal("no event at all")
 		}
+		if got := ev.Data["reason"]; got != "cancelled_while_banking" {
+			t.Errorf("reason = %v, want cancelled_while_banking", got)
+		}
 		if pe, _ := ev.Data["push_error"].(string); pe == "" {
 			t.Fatalf("event %v hides the dead push behind cancelled_while_banking", ev.Data)
+		}
+	})
+	// M1 — the hysterical-judge face: a LIVE push must never be declared
+	// dead. push_error present on a succeeded push would be the exact
+	// inverse of the bug this family fixes.
+	t.Run("live push x dead save carries NO push_error", func(t *testing.T) {
+		r, msg, work, origin, base := bankFixture(t)
+		probe := &parkIOProbeStore{RunStore: r.cfg.Store, saveErr: errors.New("store down")}
+		r.cfg.Store = probe
+		gitOut(t, work, "commit", "--allow-empty", "-m", "work")
+		head := gitOut(t, work, "rev-parse", "HEAD")
+
+		r.bankRepoWorkspace(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, "finished")
+
+		if got, ok := bankedBranch(t, origin, msg.RunID); !ok || got != head {
+			t.Fatalf("push should have landed: %q (present=%v)", got, ok)
+		}
+		ev := findEvent(t, r, msg.RunID, store.EventRunBankRefused)
+		if ev == nil {
+			t.Fatal("no event at all")
+		}
+		if _, has := ev.Data["push_error"]; has {
+			t.Fatalf("event %v declares dead a branch that IS on the forge", ev.Data)
+		}
+	})
+	// M2 — the third post-push exit, uncovered until a mutant proved it
+	// could be nil'ed in silence.
+	t.Run("dead push x dead load", func(t *testing.T) {
+		r, msg, work, _, base := bankFixture(t)
+		probe := &parkIOProbeStore{RunStore: r.cfg.Store, loadErr: errors.New("store down")}
+		r.cfg.Store = probe
+		gitOut(t, work, "commit", "--allow-empty", "-m", "work")
+		deadRemote(t, work)
+
+		r.bankRepoWorkspace(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, "finished")
+
+		ev := findEvent(t, r, msg.RunID, store.EventRunBankRefused)
+		if ev == nil {
+			t.Fatal("no event at all")
+		}
+		if got := ev.Data["reason"]; got != "doc_load_failed" {
+			t.Errorf("reason = %v, want doc_load_failed", got)
+		}
+		if pe, _ := ev.Data["push_error"].(string); pe == "" {
+			t.Fatalf("event %v — both push and doc read died and the push failure has no carrier", ev.Data)
 		}
 	})
 }

--- a/pkg/runner/bank_test.go
+++ b/pkg/runner/bank_test.go
@@ -799,3 +799,171 @@ func TestBankFinishedContainedChainLeavesNoArchive(t *testing.T) {
 		t.Fatalf("a contained supersede must stay silent, got run_bank_superseded with data=%v", ev.Data)
 	}
 }
+
+// ── Attempt-ref parking (interrupted / paused / lease-loss deaths) ──
+//
+// Those outcomes must not touch the STORAGE branch (another pod may own
+// the lease; FinalBranch on a half-done run would be merge-eligible) —
+// but their work is as stranded as a death's, so it parks on a
+// uniquely-named ref with the run doc left untouched. Falsified both
+// ways: the parking outcomes leave the ref + the timeline event and
+// nothing on the doc; an operator cancel and a verified no-op leave
+// NOTHING; an unverifiable export refuses loudly on the timeline.
+
+func attemptRefAt(t *testing.T, origin, runID, head string) (string, bool) {
+	t.Helper()
+	return refAt(t, origin, "refs/heads/iterion/run-"+runID+"-attempt-"+head[:12])
+}
+
+func TestBankAttemptRefParksInterruptedAndPaused(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		err   error
+		cause string
+	}{
+		{"interrupted delivery parks", runtime.ErrRunInterrupted, "interrupted"},
+		{"paused run parks", runtime.ErrRunPaused, "paused"},
+		{"operator pause parks", runtime.ErrRunPausedOperator, "paused_operator"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			r, msg, work, origin, base := bankFixture(t)
+			gitOut(t, work, "commit", "--allow-empty", "-m", "work in flight")
+			head := gitOut(t, work, "rev-parse", "HEAD")
+
+			r.bankIfBankable(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, c.err)
+
+			if got, present := bankedBranch(t, origin, msg.RunID); present {
+				t.Fatalf("the storage branch must stay untouched, found it at %q", got)
+			}
+			if got, ok := attemptRefAt(t, origin, msg.RunID, head); !ok || got != head {
+				t.Fatalf("attempt ref = %q (present=%v), want the in-flight head %s parked", got, ok, head)
+			}
+			run := loadRun(t, r, msg.RunID)
+			if run.FinalBranch != "" || run.FinalCommit != "" || run.FinalBranchError != "" {
+				t.Fatalf("run doc = %q/%q/%q, want it untouched (an attempt ref must not be merge-eligible)", run.FinalBranch, run.FinalCommit, run.FinalBranchError)
+			}
+			ev := findEvent(t, r, msg.RunID, store.EventRunBankAttempt)
+			if ev == nil {
+				t.Fatal("no run_bank_attempt on the timeline — the parked ref is invisible outside the pod log")
+			}
+			if ev.Data["head"] != head || ev.Data["cause"] != c.cause {
+				t.Errorf("event data = %v, want head %s and cause %q", ev.Data, head, c.cause)
+			}
+		})
+	}
+}
+
+// A bankable death on a ctx cancelled for LEASE LOSS: the storage branch
+// stays with whoever owns the lease, but the work parks on the attempt
+// ref — the case that used to strand it in the snapshot outright.
+func TestBankAttemptRefParksLeaseLossDeath(t *testing.T) {
+	r, msg, work, origin, base := bankFixture(t)
+	gitOut(t, work, "commit", "--allow-empty", "-m", "work the dying pod holds")
+	head := gitOut(t, work, "rev-parse", "HEAD")
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(runtime.ErrRunInterrupted)
+	t.Cleanup(func() { cancel(nil) })
+
+	r.bankIfBankable(ctx, msg, work, base, runtime.WorkspaceIntegrity{}, errors.New("boom"))
+
+	if got, present := bankedBranch(t, origin, msg.RunID); present {
+		t.Fatalf("a lease-loss death must not touch the storage branch, found %q", got)
+	}
+	if got, ok := attemptRefAt(t, origin, msg.RunID, head); !ok || got != head {
+		t.Fatalf("attempt ref = %q (present=%v), want %s parked", got, ok, head)
+	}
+	if run := loadRun(t, r, msg.RunID); run.FinalBranch != "" || run.FinalBranchError != "" {
+		t.Fatalf("run doc = %q/%q, want it untouched", run.FinalBranch, run.FinalBranchError)
+	}
+}
+
+// The operator refusing the work is the one outcome that parks NOTHING —
+// on both roads a cancel can arrive by (classified status, and a
+// bankable death whose ctx cause is the cancel sentinel).
+func TestBankAttemptRefOperatorCancelParksNothing(t *testing.T) {
+	t.Run("classified cancelled", func(t *testing.T) {
+		r, msg, work, origin, base := bankFixture(t)
+		gitOut(t, work, "commit", "--allow-empty", "-m", "refused work")
+		head := gitOut(t, work, "rev-parse", "HEAD")
+
+		r.bankIfBankable(context.Background(), msg, work, base, runtime.WorkspaceIntegrity{}, runtime.ErrRunCancelled)
+
+		if _, present := bankedBranch(t, origin, msg.RunID); present {
+			t.Fatal("cancelled must not bank the storage branch")
+		}
+		if _, ok := attemptRefAt(t, origin, msg.RunID, head); ok {
+			t.Fatal("cancelled must not park an attempt ref either")
+		}
+		if ev := findEvent(t, r, msg.RunID, store.EventRunBankAttempt); ev != nil {
+			t.Fatalf("cancelled left a run_bank_attempt event: %v", ev.Data)
+		}
+	})
+	t.Run("bankable death on an operator-cancelled ctx", func(t *testing.T) {
+		r, msg, work, origin, base := bankFixture(t)
+		gitOut(t, work, "commit", "--allow-empty", "-m", "refused work")
+		head := gitOut(t, work, "rev-parse", "HEAD")
+		ctx, cancel := context.WithCancelCause(context.Background())
+		cancel(runtime.ErrRunCancelled)
+		t.Cleanup(func() { cancel(nil) })
+
+		r.bankIfBankable(ctx, msg, work, base, runtime.WorkspaceIntegrity{}, errors.New("boom"))
+
+		if _, present := bankedBranch(t, origin, msg.RunID); present {
+			t.Fatal("an operator-cancelled ctx must not bank the storage branch")
+		}
+		if _, ok := attemptRefAt(t, origin, msg.RunID, head); ok {
+			t.Fatal("an operator-cancelled ctx must not park an attempt ref")
+		}
+		if ev := findEvent(t, r, msg.RunID, store.EventRunBankAttempt); ev != nil {
+			t.Fatalf("operator cancel left a run_bank_attempt event: %v", ev.Data)
+		}
+	})
+}
+
+// A verified no-op (pod-side HEAD confirms the baseline) parks nothing
+// and stays silent — the attempt ref must not manufacture refs for runs
+// that produced no commits.
+func TestBankAttemptRefVerifiedNoopStaysSilent(t *testing.T) {
+	r, msg, work, origin, base := bankFixture(t)
+
+	r.bankIfBankable(context.Background(), msg, work, base,
+		runtime.WorkspaceIntegrity{Applicable: true, PodHead: base}, runtime.ErrRunPaused)
+
+	if out, err := exec.Command("git", "-C", origin, "for-each-ref", "refs/heads/iterion/").CombinedOutput(); err != nil || strings.TrimSpace(string(out)) != "" {
+		t.Fatalf("a workless pause parked something anyway: %q (%v)", out, err)
+	}
+	if ev := findEvent(t, r, msg.RunID, store.EventRunBankAttempt); ev != nil {
+		t.Fatalf("a verified no-op left a run_bank_attempt event: %v", ev.Data)
+	}
+}
+
+// The attempt ref rides the SAME integrity oracle as the storage bank: an
+// export that did not deliver the pod's final tree is refused — but the
+// refusal lands on the TIMELINE, never on FinalBranchError (the run is
+// not terminally unbanked; it may resume, and the field would raise a
+// terminal alarm over a non-terminal outcome).
+func TestBankAttemptRefIntegrityRefusalIsLoudOnTheTimeline(t *testing.T) {
+	r, msg, work, origin, base := bankFixture(t)
+	podHead := "feedfacefeedfacefeedfacefeedfacefeedface"
+
+	r.bankIfBankable(context.Background(), msg, work, base,
+		runtime.WorkspaceIntegrity{Applicable: true, PodHead: podHead}, runtime.ErrRunInterrupted)
+
+	if out, err := exec.Command("git", "-C", origin, "for-each-ref", "refs/heads/iterion/").CombinedOutput(); err != nil || strings.TrimSpace(string(out)) != "" {
+		t.Fatalf("an unverifiable export parked a ref anyway: %q (%v)", out, err)
+	}
+	run := loadRun(t, r, msg.RunID)
+	if run.FinalBranchError != "" {
+		t.Fatalf("FinalBranchError = %q, want the attempt-path refusal kept OFF the run doc", run.FinalBranchError)
+	}
+	ev := findEvent(t, r, msg.RunID, store.EventRunBankAttempt)
+	if ev == nil {
+		t.Fatal("the integrity refusal left no run_bank_attempt — a silent loss of the parked-work promise")
+	}
+	if errStr, _ := ev.Data["error"].(string); !strings.Contains(errStr, "export") {
+		t.Errorf("event error = %v, want the export refusal named", ev.Data["error"])
+	}
+	if _, hasRef := ev.Data["ref"]; hasRef {
+		t.Errorf("refusal event carries a ref: %v — exactly one of ref/error may be present", ev.Data)
+	}
+}

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -400,16 +400,38 @@ func bankableStatus(finalStatus string) bool {
 // which every direct bankRepoWorkspace test is blind to.
 func (r *Runner) bankIfBankable(ctx context.Context, msg *queue.RunMessage, workDir, base string, integ runtime.WorkspaceIntegrity, runErr error) {
 	finalStatus := classifyExecResult(runErr, msg.RunID).finalStatus
-	if !bankableStatus(finalStatus) {
+	if bankableStatus(finalStatus) {
+		bankCtx, cancel, ok := bankContext(ctx)
+		if ok {
+			defer cancel()
+			r.bankRepoWorkspace(bankCtx, msg, workDir, base, integ, finalStatus)
+			return
+		}
+		cause := context.Cause(ctx)
+		if errors.Is(cause, runtime.ErrRunCancelled) {
+			// The operator refused the work — it is not parked anywhere.
+			r.cfg.Logger.Warn("runner: run %s: NOT banking — the run ctx was cancelled by the operator (%v). This attempt's work stays in the git-meta snapshot.", msg.RunID, cause)
+			return
+		}
+		// The refusal protects the STORAGE branch from a lease that may
+		// already belong to another pod; a ref named after this chain's
+		// own head cannot contest anything, so the work parks there
+		// instead of stranding in the snapshot.
+		r.cfg.Logger.Warn("runner: run %s: NOT banking the storage branch — the run ctx was cancelled (%v), not merely deadlined: this pod's lease may already have moved. Parking this attempt's work on its own attempt ref instead.", msg.RunID, cause)
+		r.bankAttemptRef(msg, workDir, base, integ, "lease-loss death ("+finalStatus+")")
 		return
 	}
-	bankCtx, cancel, ok := bankContext(ctx)
-	if !ok {
-		r.cfg.Logger.Warn("runner: run %s: NOT banking — the run ctx was cancelled (%v), not merely deadlined: this pod's lease on the run may already have moved, and banking from here could race the new owner's push. This attempt's work stays in the git-meta snapshot.", msg.RunID, context.Cause(ctx))
-		return
+	switch finalStatus {
+	case "interrupted", "paused", "paused_operator":
+		// Not the storage branch — an interrupted delivery redelivers and
+		// its successor banks that branch; recording FinalBranch on a
+		// paused run would make it merge-eligible mid-flight — but the
+		// work itself is as stranded as a death's (the successor
+		// re-clones at base), so it parks on a uniquely-named attempt
+		// ref, run doc untouched.
+		r.bankAttemptRef(msg, workDir, base, integ, finalStatus)
 	}
-	defer cancel()
-	r.bankRepoWorkspace(bankCtx, msg, workDir, base, integ, finalStatus)
+	// cancelled stays unbanked entirely: the operator refused the work.
 }
 
 // bankContext decides whether the bank may outlive the run ctx.
@@ -1641,18 +1663,16 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 		// in the git-meta snapshot above, and turning that snapshot back
 		// into a branch takes a manual replay every time (measured: nine
 		// manual recoveries in three days of one campaign). An interrupted
-		// delivery does NOT bank — not because its work survives (the
-		// redelivery re-clones at RepoSHA and banks only its OWN later
-		// commits; this attempt's work strands in the snapshot exactly
-		// like a death's) but because interruption means the lease may
+		// delivery must NOT touch the storage branch — the lease may
 		// already belong to another pod, and a bank from here could race
-		// the new owner's push (bankContext refuses on the same oracle).
-		// A cancel is the operator saying the work is not wanted. Paused runs do
-		// not bank either — NOT because the work is safe (a cloud resume
-		// re-clones at the base, so a paused run's committed work is as
-		// stranded as a death's until it ends) but because FinalBranch on
-		// a half-done run would make it merge-eligible mid-flight; that
-		// trade-off is a product decision deferred, not an oversight.
+		// the new owner's push (bankContext refuses on the same oracle) —
+		// and a paused run must not either: FinalBranch on a half-done
+		// run would make it merge-eligible mid-flight. But their work is
+		// as stranded as a death's (the successor re-clones at RepoSHA
+		// and banks only its OWN later commits), so both park it on a
+		// uniquely-named attempt ref instead — doc untouched, no name
+		// contested (bankAttemptRef). A cancel is the operator saying
+		// the work is not wanted; it parks nowhere.
 		r.bankIfBankable(ctx, msg, workDir, gitBase, integ, runErr)
 	}
 

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -400,6 +400,12 @@ func bankableStatus(finalStatus string) bool {
 // which every direct bankRepoWorkspace test is blind to.
 func (r *Runner) bankIfBankable(ctx context.Context, msg *queue.RunMessage, workDir, base string, integ runtime.WorkspaceIntegrity, runErr error) {
 	finalStatus := classifyExecResult(runErr, msg.RunID).finalStatus
+	// The operator refusing the work is honoured on EVERY road out of
+	// here — including a cancel that lands while the run was pausing or
+	// tearing down (the cancel subscription cancels the run ctx from a
+	// NATS goroutine, and the sandbox export gives it a minutes-wide
+	// window to race the engine's own paused/interrupted return).
+	operatorRefused := errors.Is(context.Cause(ctx), runtime.ErrRunCancelled)
 	if bankableStatus(finalStatus) {
 		bankCtx, cancel, ok := bankContext(ctx)
 		if ok {
@@ -407,18 +413,21 @@ func (r *Runner) bankIfBankable(ctx context.Context, msg *queue.RunMessage, work
 			r.bankRepoWorkspace(bankCtx, msg, workDir, base, integ, finalStatus)
 			return
 		}
-		cause := context.Cause(ctx)
-		if errors.Is(cause, runtime.ErrRunCancelled) {
+		if operatorRefused {
 			// The operator refused the work — it is not parked anywhere.
-			r.cfg.Logger.Warn("runner: run %s: NOT banking — the run ctx was cancelled by the operator (%v). This attempt's work stays in the git-meta snapshot.", msg.RunID, cause)
+			r.cfg.Logger.Warn("runner: run %s: NOT banking — the run ctx was cancelled by the operator. This attempt's work stays in the git-meta snapshot.", msg.RunID)
 			return
 		}
 		// The refusal protects the STORAGE branch from a lease that may
 		// already belong to another pod; a ref named after this chain's
 		// own head cannot contest anything, so the work parks there
 		// instead of stranding in the snapshot.
-		r.cfg.Logger.Warn("runner: run %s: NOT banking the storage branch — the run ctx was cancelled (%v), not merely deadlined: this pod's lease may already have moved. Parking this attempt's work on its own attempt ref instead.", msg.RunID, cause)
+		r.cfg.Logger.Warn("runner: run %s: NOT banking the storage branch — the run ctx was cancelled (%v), not merely deadlined: this pod's lease may already have moved. Parking this attempt's work on its own ref instead.", msg.RunID, context.Cause(ctx))
 		r.bankAttemptRef(msg, workDir, base, integ, "lease-loss death ("+finalStatus+")")
+		return
+	}
+	if operatorRefused {
+		r.cfg.Logger.Warn("runner: run %s: NOT parking (%s) — the operator cancelled the run; refused work parks nowhere.", msg.RunID, finalStatus)
 		return
 	}
 	switch finalStatus {
@@ -427,8 +436,8 @@ func (r *Runner) bankIfBankable(ctx context.Context, msg *queue.RunMessage, work
 		// its successor banks that branch; recording FinalBranch on a
 		// paused run would make it merge-eligible mid-flight — but the
 		// work itself is as stranded as a death's (the successor
-		// re-clones at base), so it parks on a uniquely-named attempt
-		// ref, run doc untouched.
+		// re-clones at base), so it parks on a uniquely-named ref, run
+		// doc untouched.
 		r.bankAttemptRef(msg, workDir, base, integ, finalStatus)
 	}
 	// cancelled stays unbanked entirely: the operator refused the work.

--- a/pkg/runner/loop_gitws.go
+++ b/pkg/runner/loop_gitws.go
@@ -728,11 +728,13 @@ func (r *Runner) bankAttemptRef(msg *queue.RunMessage, workDir, base string, int
 	// parks live runs there), so the skip is recorded on the timeline,
 	// never silent. Bounded read, fail-open on error: the read is a
 	// courtesy to the operator, not a gate on preserving work — and not
-	// a licence for a wedged store to pin the pod. It rides the doc
-	// pair's generous bound (a merely SLOW store must not fail the guard
-	// open — proven at 7s); a store that cannot answer within it is the
-	// documented preservation-wins residue.
-	rctx, rcancel := context.WithTimeout(ctx, bankDocOpTimeout)
+	// a licence for a wedged store to pin the pod. Its own tight bound:
+	// wide enough that a merely SLOW store does not fail the guard open
+	// (proven at 7s), tight enough that a wedged store cannot buy its
+	// whole window in pre-Nak recovery latency (measured at 30s when
+	// this rode the doc pair's bound). Past it, the documented
+	// preservation-wins residue applies.
+	rctx, rcancel := context.WithTimeout(ctx, parkDocReadTimeout)
 	run, lerr := r.cfg.Store.LoadRun(store.WithIdentity(rctx, msg.TenantID, msg.OwnerID), msg.RunID)
 	rcancel()
 	if lerr == nil && run != nil && run.Status == store.RunStatusCancelled {
@@ -779,9 +781,20 @@ const parkStoreOpTimeout = 5 * time.Second
 // redeliver. A deadline here fails LOUDLY on the existing error paths.
 const bankDocOpTimeout = 30 * time.Second
 
-// bankStoreCtx is the one choke point building the bank's doc-pair
-// store context: detached (the run ctx may already be cancelled),
-// identity-carrying, always deadlined.
+// parkDocReadTimeout bounds the park's doc-cancel courtesy read alone —
+// tighter than the doc pair's bound on purpose: this read sits on the
+// interrupted pre-Nak path, where a wedged store buys its whole window
+// in added recovery latency (measured at 30s when it rode
+// bankDocOpTimeout). 10s covers the slow-but-healthy store the guard
+// exists for (proven at 7s) with margin.
+const parkDocReadTimeout = 10 * time.Second
+
+// bankStoreCtx builds one bounded store context PER DOC OP: detached
+// (the run ctx may already be cancelled), identity-carrying, always
+// deadlined. Per op, not per pair — a load that eats the shared window
+// starves the save, and a save that dies after the push loses the
+// merge truth the pair exists to record (proven: 28s load, 3s save
+// that would have fit its own bound, branch orphaned on the forge).
 func bankStoreCtx(msg *queue.RunMessage) (context.Context, context.CancelFunc) {
 	wctx, cancel := context.WithTimeout(context.Background(), bankDocOpTimeout)
 	return store.WithIdentity(wctx, msg.TenantID, msg.OwnerID), cancel
@@ -875,24 +888,42 @@ func (r *Runner) pushBank(ctx context.Context, msg *queue.RunMessage, workDir, h
 	// claim-time token stays only as the redaction key for error output.
 	pushErr := r.runGit(ctx, workDir, tok, bankPushArgs(branch, head, oldHead)...)
 
-	// Persist on a detached, deadlined ctx carrying the run's tenant
-	// identity (the run ctx may already be cancelled) — and bounded,
-	// because this runs pre-Nak with the lease still refreshing.
-	idCtx, idCancel := bankStoreCtx(msg)
-	defer idCancel()
-	run, lerr := r.cfg.Store.LoadRun(idCtx, msg.RunID)
+	// Persist on detached, deadlined ctxs carrying the run's tenant
+	// identity (the run ctx may already be cancelled) — bounded PER OP,
+	// because this runs pre-Nak with the lease still refreshing, and a
+	// load that eats a shared window starves the save. Every exit past
+	// this point that leaves the pushed branch unrecorded goes on the
+	// timeline: the doc is what `runs merge` trusts, and a branch the
+	// doc does not name is invisible everywhere but the pod log.
+	lctx, lcancel := bankStoreCtx(msg)
+	run, lerr := r.cfg.Store.LoadRun(lctx, msg.RunID)
+	lcancel()
 	if lerr != nil || run == nil {
 		r.cfg.Logger.Error("runner: run %s: bank: load run to record branch: %v", msg.RunID, lerr)
+		data := map[string]any{
+			"branch": branch, "head": head,
+			"reason": "doc_load_failed",
+			"error":  fmt.Sprintf("the doc read died, nothing recorded: %v", lerr),
+		}
+		if pushErr != nil {
+			// Both died: the push failure would otherwise vanish with the
+			// doc write that was meant to carry it.
+			data["push_error"] = pushErr.Error()
+		}
+		r.recordBankRefused(msg, data)
 		return
 	}
 	// Re-read just before the write: an operator cancel that landed while
 	// the push was in flight must not become merge-eligible through this
 	// SaveRun — the branch may exist on the forge, but the doc is what
 	// `runs merge` trusts, and a cancel is the operator refusing the
-	// work. (The remaining load→save window is the same one the success
-	// path has always had.)
+	// work.
 	if run.Status == store.RunStatusCancelled {
 		r.cfg.Logger.Warn("runner: run %s: bank: run was cancelled while banking — leaving FinalBranch unset (branch %s pushed but not recorded)", msg.RunID, branch)
+		r.recordBankRefused(msg, map[string]any{
+			"branch": branch, "head": head,
+			"reason": "cancelled_while_banking",
+		})
 		return
 	}
 	// The three fields must stay mutually consistent ACROSS ATTEMPTS. A
@@ -932,8 +963,15 @@ func (r *Runner) pushBank(ctx context.Context, msg *queue.RunMessage, workDir, h
 		run.FinalBranchError = ""
 		r.cfg.Logger.Info("runner: run %s banked: %s @ %.12s", msg.RunID, branch, head)
 	}
-	if serr := r.cfg.Store.SaveRun(idCtx, run); serr != nil {
+	sctx, scancel := bankStoreCtx(msg)
+	defer scancel()
+	if serr := r.cfg.Store.SaveRun(sctx, run); serr != nil {
 		r.cfg.Logger.Error("runner: run %s: bank: persist FinalBranch: %v", msg.RunID, serr)
+		r.recordBankRefused(msg, map[string]any{
+			"branch": branch, "head": head,
+			"reason": "doc_save_failed",
+			"error":  serr.Error(),
+		})
 	}
 }
 
@@ -1160,11 +1198,19 @@ func (r *Runner) recordBankRefused(msg *queue.RunMessage, data map[string]any) {
 // recorded, on the timeline, exactly like a refused chain comparison.
 func (r *Runner) recordBankFailure(msg *queue.RunMessage, cause string) {
 	r.cfg.Logger.Error("runner: run %s: %s", msg.RunID, cause)
-	idCtx, idCancel := bankStoreCtx(msg)
-	defer idCancel()
-	run, lerr := r.cfg.Store.LoadRun(idCtx, msg.RunID)
+	lctx, lcancel := bankStoreCtx(msg)
+	run, lerr := r.cfg.Store.LoadRun(lctx, msg.RunID)
+	lcancel()
 	if lerr != nil || run == nil {
+		// The refusal is often the ONLY information the run leaves (an
+		// export mismatch has no branch) — a dead doc read must not
+		// erase it; the timeline carries it instead.
 		r.cfg.Logger.Error("runner: run %s: bank: load run to record refusal: %v", msg.RunID, lerr)
+		r.recordBankRefused(msg, map[string]any{
+			"cause":  cause,
+			"reason": "doc_load_failed",
+			"error":  fmt.Sprintf("%v", lerr),
+		})
 		return
 	}
 	if run.FinalBranch != "" {
@@ -1178,7 +1224,14 @@ func (r *Runner) recordBankFailure(msg *queue.RunMessage, cause string) {
 		return
 	}
 	run.FinalBranchError = cause
-	if serr := r.cfg.Store.SaveRun(idCtx, run); serr != nil {
+	sctx, scancel := bankStoreCtx(msg)
+	defer scancel()
+	if serr := r.cfg.Store.SaveRun(sctx, run); serr != nil {
 		r.cfg.Logger.Error("runner: run %s: bank: persist FinalBranchError: %v", msg.RunID, serr)
+		r.recordBankRefused(msg, map[string]any{
+			"cause":  cause,
+			"reason": "doc_save_failed",
+			"error":  serr.Error(),
+		})
 	}
 }

--- a/pkg/runner/loop_gitws.go
+++ b/pkg/runner/loop_gitws.go
@@ -719,14 +719,23 @@ func (r *Runner) bankAttemptRef(msg *queue.RunMessage, workDir, base string, int
 		}
 		return
 	}
-	// Same re-read pushBank does before recording: an operator cancel can
-	// land without ever cancelling THIS pod's ctx (the cancel
-	// subscription is best-effort — "continuing without"), and refused
-	// work parks nowhere. Fail-open on a read error: the read is a
-	// courtesy to the operator, not a gate on preserving work.
-	idCtx := store.WithIdentity(context.Background(), msg.TenantID, msg.OwnerID)
-	if run, lerr := r.cfg.Store.LoadRun(idCtx, msg.RunID); lerr == nil && run != nil && run.Status == store.RunStatusCancelled {
+	// Doc re-read before the push: an operator cancel can land without
+	// ever cancelling THIS pod's ctx (the cancel subscription is
+	// best-effort — "continuing without"), and refused work parks
+	// nowhere. Unlike pushBank's re-read — which runs AFTER its push and
+	// only withholds merge eligibility — this one withholds the push
+	// itself, and `cancelled` is a status the product RESUMES (rewind
+	// parks live runs there), so the skip is recorded on the timeline,
+	// never silent. Bounded read, fail-open on error: the read is a
+	// courtesy to the operator, not a gate on preserving work — and not
+	// a licence for a wedged store to pin the pod.
+	rctx, rcancel := context.WithTimeout(ctx, parkStoreOpTimeout)
+	run, lerr := r.cfg.Store.LoadRun(store.WithIdentity(rctx, msg.TenantID, msg.OwnerID), msg.RunID)
+	rcancel()
+	if lerr == nil && run != nil && run.Status == store.RunStatusCancelled {
 		r.cfg.Logger.Warn("runner: run %s: NOT parking (%s) — the run doc reads cancelled; the operator refused the work.", msg.RunID, cause)
+		r.recordBankAttempt(msg, map[string]any{"cause": cause, "head": head,
+			"error": "not parked — the run doc reads cancelled (the work stays in the git-meta snapshot)"})
 		return
 	}
 	ref := "iterion/run-" + msg.RunID + "-parked-" + shortSHA(head)
@@ -746,6 +755,13 @@ func (r *Runner) bankAttemptRef(msg *queue.RunMessage, workDir, base string, int
 // a run another pod should already be picking up.
 const attemptBankBudget = 2 * time.Minute
 
+// parkStoreOpTimeout bounds each of the park's individual STORE ops (the
+// doc courtesy read, the timeline event write) — the store is the same
+// class of external resource as the forge, on the same pre-Nak path,
+// and the mongo client carries no timeout of its own. Same 5s
+// teardown-write convention as runtime's run_failure/pause paths.
+const parkStoreOpTimeout = 5 * time.Second
+
 // attemptBankContext builds the park's detached context — ALWAYS
 // deadlined, including when the operator disabled per-op git bounds
 // (ITERION_RUNNER_GIT_TIMEOUT<=0). That choice bounds one git op; it is
@@ -759,11 +775,16 @@ func attemptBankContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), attemptBankBudget)
 }
 
-// recordBankAttempt puts an attempt-ref outcome on the run's timeline —
-// the only durable record of the parked ref, since the run doc is
-// deliberately left untouched on every bankAttemptRef path.
+// recordBankAttempt puts a park outcome on the run's timeline — the
+// only durable record of the parked ref, since the run doc is
+// deliberately left untouched on every bankAttemptRef path. The write
+// rides its OWN detached short bound, not the park budget: the event
+// must land precisely when the push just died on that budget, and a
+// wedged store must not pin the pod either way.
 func (r *Runner) recordBankAttempt(msg *queue.RunMessage, data map[string]any) {
-	idCtx := store.WithIdentity(context.Background(), msg.TenantID, msg.OwnerID)
+	wctx, cancel := context.WithTimeout(context.Background(), parkStoreOpTimeout)
+	defer cancel()
+	idCtx := store.WithIdentity(wctx, msg.TenantID, msg.OwnerID)
 	if _, err := r.cfg.Store.AppendEvent(idCtx, msg.RunID, store.Event{
 		Type: store.EventRunBankAttempt,
 		Data: data,
@@ -1008,7 +1029,11 @@ func (r *Runner) recordBankSuperseded(msg *queue.RunMessage, branch, oldHead, ne
 	if archiveErr != "" {
 		data["archive_error"] = archiveErr
 	}
-	idCtx := store.WithIdentity(context.Background(), msg.TenantID, msg.OwnerID)
+	// Bounded like every best-effort timeline write on a teardown path
+	// (parkStoreOpTimeout): a wedged store must not pin the pod.
+	wctx, cancel := context.WithTimeout(context.Background(), parkStoreOpTimeout)
+	defer cancel()
+	idCtx := store.WithIdentity(wctx, msg.TenantID, msg.OwnerID)
 	if _, err := r.cfg.Store.AppendEvent(idCtx, msg.RunID, store.Event{
 		Type: store.EventRunBankSuperseded,
 		Data: data,
@@ -1078,7 +1103,11 @@ func (r *Runner) bankSupersedes(ctx context.Context, msg *queue.RunMessage, work
 // already be dead): a store that refuses the append must never change
 // the run's outcome.
 func (r *Runner) recordBankRefused(msg *queue.RunMessage, data map[string]any) {
-	idCtx := store.WithIdentity(context.Background(), msg.TenantID, msg.OwnerID)
+	// Bounded like every best-effort timeline write on a teardown path
+	// (parkStoreOpTimeout): a wedged store must not pin the pod.
+	wctx, cancel := context.WithTimeout(context.Background(), parkStoreOpTimeout)
+	defer cancel()
+	idCtx := store.WithIdentity(wctx, msg.TenantID, msg.OwnerID)
 	if _, err := r.cfg.Store.AppendEvent(idCtx, msg.RunID, store.Event{
 		Type: store.EventRunBankRefused,
 		Data: data,

--- a/pkg/runner/loop_gitws.go
+++ b/pkg/runner/loop_gitws.go
@@ -756,7 +756,7 @@ func (r *Runner) bankAttemptRef(msg *queue.RunMessage, workDir, base string, int
 // attemptBankBudget bounds the park's GIT work end to end; each store
 // op rides its own short bound on top (parkStoreOpTimeout for the
 // event write — detached on purpose, so the event still lands when the
-// push just died on this budget; bankDocOpTimeout for the doc read).
+// push just died on this budget; parkDocReadTimeout for the doc read).
 // Deliberately far below bankBudget: the park is ONE push, not the
 // bank's four network ops — and on the interrupted path it runs BEFORE
 // the Nak that triggers redelivery, so every second spent here is
@@ -764,8 +764,8 @@ func (r *Runner) bankAttemptRef(msg *queue.RunMessage, workDir, base string, int
 // picking up. A var so tests can exercise the spent-budget divergence.
 var attemptBankBudget = 2 * time.Minute
 
-// parkStoreOpTimeout bounds each of the park's individual STORE ops (the
-// doc courtesy read, the timeline event write) — the store is the same
+// parkStoreOpTimeout bounds the park's timeline event write (the doc
+// courtesy read rides parkDocReadTimeout) — the store is the same
 // class of external resource as the forge, on the same pre-Nak path,
 // and the mongo client carries no timeout of its own. Same 5s
 // teardown-write convention as runtime's run_failure/pause paths.
@@ -900,16 +900,8 @@ func (r *Runner) pushBank(ctx context.Context, msg *queue.RunMessage, workDir, h
 	lcancel()
 	if lerr != nil || run == nil {
 		r.cfg.Logger.Error("runner: run %s: bank: load run to record branch: %v", msg.RunID, lerr)
-		data := map[string]any{
-			"branch": branch, "head": head,
-			"reason": "doc_load_failed",
-			"error":  fmt.Sprintf("the doc read died, nothing recorded: %v", lerr),
-		}
-		if pushErr != nil {
-			// Both died: the push failure would otherwise vanish with the
-			// doc write that was meant to carry it.
-			data["push_error"] = pushErr.Error()
-		}
+		data := bankExitData(branch, head, "doc_load_failed", pushErr)
+		data["error"] = fmt.Sprintf("the doc read died, nothing recorded: %v", lerr)
 		r.recordBankRefused(msg, data)
 		return
 	}
@@ -920,10 +912,7 @@ func (r *Runner) pushBank(ctx context.Context, msg *queue.RunMessage, workDir, h
 	// work.
 	if run.Status == store.RunStatusCancelled {
 		r.cfg.Logger.Warn("runner: run %s: bank: run was cancelled while banking — leaving FinalBranch unset (branch %s pushed but not recorded)", msg.RunID, branch)
-		r.recordBankRefused(msg, map[string]any{
-			"branch": branch, "head": head,
-			"reason": "cancelled_while_banking",
-		})
+		r.recordBankRefused(msg, bankExitData(branch, head, "cancelled_while_banking", pushErr))
 		return
 	}
 	// The three fields must stay mutually consistent ACROSS ATTEMPTS. A
@@ -967,12 +956,24 @@ func (r *Runner) pushBank(ctx context.Context, msg *queue.RunMessage, workDir, h
 	defer scancel()
 	if serr := r.cfg.Store.SaveRun(sctx, run); serr != nil {
 		r.cfg.Logger.Error("runner: run %s: bank: persist FinalBranch: %v", msg.RunID, serr)
-		r.recordBankRefused(msg, map[string]any{
-			"branch": branch, "head": head,
-			"reason": "doc_save_failed",
-			"error":  serr.Error(),
-		})
+		data := bankExitData(branch, head, "doc_save_failed", pushErr)
+		data["error"] = serr.Error()
+		r.recordBankRefused(msg, data)
 	}
+}
+
+// bankExitData shapes a post-push doc-I/O exit for the timeline. head
+// sits on the forge only when the push SUCCEEDED, so a dead push is
+// named on every such exit: without it the event is key-for-key
+// identical to the push-succeeded shape, and once the doc write meant
+// to carry FinalBranchError has died too, push_error is the cause's
+// only durable carrier.
+func bankExitData(branch, head, reason string, pushErr error) map[string]any {
+	data := map[string]any{"branch": branch, "head": head, "reason": reason}
+	if pushErr != nil {
+		data["push_error"] = pushErr.Error()
+	}
+	return data
 }
 
 // bankPushArgs builds the bank's push, binding it to the ref state the

--- a/pkg/runner/loop_gitws.go
+++ b/pkg/runner/loop_gitws.go
@@ -665,8 +665,13 @@ func (r *Runner) resolveBankHead(ctx context.Context, runID, workDir, base strin
 }
 
 // bankAttemptRef parks an attempt's work on a uniquely-named ref —
-// iterion/run-<id>-attempt-<head12>, the naming preserveSupersededChain
-// established — when the STORAGE branch must not be touched: an
+// iterion/run-<id>-parked-<head12>. Same head-derived shape as
+// preserveSupersededChain's archives, but a DISTINCT infix on purpose:
+// an archive names the complete chain of a dead attempt (a once-valid
+// FinalBranch), a parked ref names the half-done work of a run that may
+// still be alive, and a future pruning policy must be able to tell the
+// two apart by name alone. Parked when the STORAGE branch must not be
+// touched: an
 // interrupted delivery (the lease may already belong to another pod,
 // and two pods force-pushing one branch is the split-brain the bank
 // refusal exists to prevent — but a ref carrying this chain's own head
@@ -689,16 +694,13 @@ func (r *Runner) resolveBankHead(ctx context.Context, runID, workDir, base strin
 // precisely because the ref is uncontested: the anti-clobber machinery
 // (ls-remote, lease, supersede) exists for a SHARED name and would be
 // dead weight on a name derived from the pushed head itself. The push
-// is plain (no force): a ref that already exists at this head is a
-// no-op, and anything else — a 12-hex prefix collision — is refused by
-// git and reported, never overwritten.
+// is plain (no force): a ref already at this head is a no-op, an
+// existing ANCESTOR is fast-forwarded (contained in the new chain —
+// nothing lost), and a divergent squatter — a 12-hex prefix collision —
+// is refused by git and reported, never overwritten.
 func (r *Runner) bankAttemptRef(msg *queue.RunMessage, workDir, base string, integ runtime.WorkspaceIntegrity, cause string) {
-	ctx := context.Background()
-	if gitOpTimeout > 0 {
-		bounded, cancel := context.WithTimeout(ctx, bankBudget)
-		defer cancel()
-		ctx = bounded
-	}
+	ctx, cancel := attemptBankContext()
+	defer cancel()
 	head, refusal := r.resolveBankHead(ctx, msg.RunID, workDir, base, integ)
 	if refusal != "" {
 		r.cfg.Logger.Error("runner: run %s: attempt ref not parked (%s): %s", msg.RunID, cause, refusal)
@@ -706,9 +708,28 @@ func (r *Runner) bankAttemptRef(msg *queue.RunMessage, workDir, base string, int
 		return
 	}
 	if head == "" {
+		// A verified no-op stays silent — but an unreadable HEAD is not a
+		// no-op, and on THIS path the event is the only durable record.
+		// (The storage bank keeps its historical warn-only behaviour: its
+		// refusals land on FinalBranchError, a field this path never
+		// touches.)
+		if _, err := gitlib.RevParseHead(workDir); err != nil {
+			r.recordBankAttempt(msg, map[string]any{"cause": cause,
+				"error": "workspace HEAD unreadable — nothing parked, the work stays in the git-meta snapshot: " + err.Error()})
+		}
 		return
 	}
-	ref := "iterion/run-" + msg.RunID + "-attempt-" + shortSHA(head)
+	// Same re-read pushBank does before recording: an operator cancel can
+	// land without ever cancelling THIS pod's ctx (the cancel
+	// subscription is best-effort — "continuing without"), and refused
+	// work parks nowhere. Fail-open on a read error: the read is a
+	// courtesy to the operator, not a gate on preserving work.
+	idCtx := store.WithIdentity(context.Background(), msg.TenantID, msg.OwnerID)
+	if run, lerr := r.cfg.Store.LoadRun(idCtx, msg.RunID); lerr == nil && run != nil && run.Status == store.RunStatusCancelled {
+		r.cfg.Logger.Warn("runner: run %s: NOT parking (%s) — the run doc reads cancelled; the operator refused the work.", msg.RunID, cause)
+		return
+	}
+	ref := "iterion/run-" + msg.RunID + "-parked-" + shortSHA(head)
 	if err := r.runGit(ctx, workDir, "", "push", "origin", head+":refs/heads/"+ref); err != nil {
 		r.cfg.Logger.Error("runner: run %s: attempt ref push %s FAILED — the work exists only in this pod's clone and the git-meta snapshot: %v", msg.RunID, ref, err)
 		r.recordBankAttempt(msg, map[string]any{"cause": cause, "error": fmt.Sprintf("push %s: %v", ref, err)})
@@ -716,6 +737,26 @@ func (r *Runner) bankAttemptRef(msg *queue.RunMessage, workDir, base string, int
 	}
 	r.cfg.Logger.Info("runner: run %s: attempt work parked at %s @ %.12s (%s)", msg.RunID, ref, head, cause)
 	r.recordBankAttempt(msg, map[string]any{"cause": cause, "ref": ref, "head": head})
+}
+
+// attemptBankBudget bounds the park end to end. Deliberately far below
+// bankBudget: the park is ONE push, not the bank's four network ops —
+// and on the interrupted path it runs BEFORE the Nak that triggers
+// redelivery, so every second spent here is added recovery latency for
+// a run another pod should already be picking up.
+const attemptBankBudget = 2 * time.Minute
+
+// attemptBankContext builds the park's detached context — ALWAYS
+// deadlined, including when the operator disabled per-op git bounds
+// (ITERION_RUNNER_GIT_TIMEOUT<=0). That choice bounds one git op; it is
+// not a licence to make a best-effort parking uninterruptible: the
+// caller's ctx is already cancelled on these paths, so nothing else can
+// ever stop the push, and a forge that accepts the connection and never
+// answers would pin the pod forever (proven by probe). Unlike
+// bankContext's unbounded arm, this pod has already lost the run — a
+// park it cannot finish in the budget is a park it forfeits, loudly.
+func attemptBankContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), attemptBankBudget)
 }
 
 // recordBankAttempt puts an attempt-ref outcome on the run's timeline —

--- a/pkg/runner/loop_gitws.go
+++ b/pkg/runner/loop_gitws.go
@@ -728,8 +728,11 @@ func (r *Runner) bankAttemptRef(msg *queue.RunMessage, workDir, base string, int
 	// parks live runs there), so the skip is recorded on the timeline,
 	// never silent. Bounded read, fail-open on error: the read is a
 	// courtesy to the operator, not a gate on preserving work — and not
-	// a licence for a wedged store to pin the pod.
-	rctx, rcancel := context.WithTimeout(ctx, parkStoreOpTimeout)
+	// a licence for a wedged store to pin the pod. It rides the doc
+	// pair's generous bound (a merely SLOW store must not fail the guard
+	// open — proven at 7s); a store that cannot answer within it is the
+	// documented preservation-wins residue.
+	rctx, rcancel := context.WithTimeout(ctx, bankDocOpTimeout)
 	run, lerr := r.cfg.Store.LoadRun(store.WithIdentity(rctx, msg.TenantID, msg.OwnerID), msg.RunID)
 	rcancel()
 	if lerr == nil && run != nil && run.Status == store.RunStatusCancelled {
@@ -748,12 +751,16 @@ func (r *Runner) bankAttemptRef(msg *queue.RunMessage, workDir, base string, int
 	r.recordBankAttempt(msg, map[string]any{"cause": cause, "ref": ref, "head": head})
 }
 
-// attemptBankBudget bounds the park end to end. Deliberately far below
-// bankBudget: the park is ONE push, not the bank's four network ops —
-// and on the interrupted path it runs BEFORE the Nak that triggers
-// redelivery, so every second spent here is added recovery latency for
-// a run another pod should already be picking up.
-const attemptBankBudget = 2 * time.Minute
+// attemptBankBudget bounds the park's GIT work end to end; each store
+// op rides its own short bound on top (parkStoreOpTimeout for the
+// event write — detached on purpose, so the event still lands when the
+// push just died on this budget; bankDocOpTimeout for the doc read).
+// Deliberately far below bankBudget: the park is ONE push, not the
+// bank's four network ops — and on the interrupted path it runs BEFORE
+// the Nak that triggers redelivery, so every second spent here is
+// added recovery latency for a run another pod should already be
+// picking up. A var so tests can exercise the spent-budget divergence.
+var attemptBankBudget = 2 * time.Minute
 
 // parkStoreOpTimeout bounds each of the park's individual STORE ops (the
 // doc courtesy read, the timeline event write) — the store is the same
@@ -761,6 +768,24 @@ const attemptBankBudget = 2 * time.Minute
 // and the mongo client carries no timeout of its own. Same 5s
 // teardown-write convention as runtime's run_failure/pause paths.
 const parkStoreOpTimeout = 5 * time.Second
+
+// bankDocOpTimeout bounds the storage bank's run-doc pair I/O
+// (pushBank's load→save, recordBankFailure's) — load-bearing for merge
+// truth, hence far more generous than parkStoreOpTimeout, but bounded
+// all the same: the storage bank is PRE-Nak too (a generic `failed` is
+// bankable and naks only after banking returns, with the heartbeat
+// still refreshing the lease), and a doc write that never returns does
+// not serve merge truth — it replaces it with a pod nothing can
+// redeliver. A deadline here fails LOUDLY on the existing error paths.
+const bankDocOpTimeout = 30 * time.Second
+
+// bankStoreCtx is the one choke point building the bank's doc-pair
+// store context: detached (the run ctx may already be cancelled),
+// identity-carrying, always deadlined.
+func bankStoreCtx(msg *queue.RunMessage) (context.Context, context.CancelFunc) {
+	wctx, cancel := context.WithTimeout(context.Background(), bankDocOpTimeout)
+	return store.WithIdentity(wctx, msg.TenantID, msg.OwnerID), cancel
+}
 
 // attemptBankContext builds the park's detached context — ALWAYS
 // deadlined, including when the operator disabled per-op git bounds
@@ -850,9 +875,11 @@ func (r *Runner) pushBank(ctx context.Context, msg *queue.RunMessage, workDir, h
 	// claim-time token stays only as the redaction key for error output.
 	pushErr := r.runGit(ctx, workDir, tok, bankPushArgs(branch, head, oldHead)...)
 
-	// Persist on a background ctx carrying the run's tenant identity (the
-	// run ctx may already be cancelled) — recordRunGitMeta's rationale.
-	idCtx := store.WithIdentity(context.Background(), msg.TenantID, msg.OwnerID)
+	// Persist on a detached, deadlined ctx carrying the run's tenant
+	// identity (the run ctx may already be cancelled) — and bounded,
+	// because this runs pre-Nak with the lease still refreshing.
+	idCtx, idCancel := bankStoreCtx(msg)
+	defer idCancel()
 	run, lerr := r.cfg.Store.LoadRun(idCtx, msg.RunID)
 	if lerr != nil || run == nil {
 		r.cfg.Logger.Error("runner: run %s: bank: load run to record branch: %v", msg.RunID, lerr)
@@ -1133,7 +1160,8 @@ func (r *Runner) recordBankRefused(msg *queue.RunMessage, data map[string]any) {
 // recorded, on the timeline, exactly like a refused chain comparison.
 func (r *Runner) recordBankFailure(msg *queue.RunMessage, cause string) {
 	r.cfg.Logger.Error("runner: run %s: %s", msg.RunID, cause)
-	idCtx := store.WithIdentity(context.Background(), msg.TenantID, msg.OwnerID)
+	idCtx, idCancel := bankStoreCtx(msg)
+	defer idCancel()
 	run, lerr := r.cfg.Store.LoadRun(idCtx, msg.RunID)
 	if lerr != nil || run == nil {
 		r.cfg.Logger.Error("runner: run %s: bank: load run to record refusal: %v", msg.RunID, lerr)

--- a/pkg/runner/loop_gitws.go
+++ b/pkg/runner/loop_gitws.go
@@ -590,6 +590,28 @@ func injectGitToken(rawURL, token string) string {
 // by overwriting the pair or the field whose meaning is "this commit has
 // no branch guarding it".
 func (r *Runner) bankRepoWorkspace(ctx context.Context, msg *queue.RunMessage, workDir, base string, integ runtime.WorkspaceIntegrity, finalStatus string) {
+	head, refusal := r.resolveBankHead(ctx, msg.RunID, workDir, base, integ)
+	if refusal != "" {
+		r.recordBankFailure(msg, refusal)
+		return
+	}
+	if head == "" {
+		return
+	}
+	r.pushBank(ctx, msg, workDir, head, finalStatus)
+}
+
+// resolveBankHead applies the export-integrity oracle to the host clone
+// and answers which commit a bank may push. The one head-resolution
+// authority for BOTH bank shapes (storage branch and attempt ref), so
+// the two cannot drift on what "the run's final tree" means. Outcomes:
+//   - head != "": bankable (a caveat, when any, is already logged);
+//   - head == "" && refusal == "": nothing to bank — a verified no-op,
+//     or an unreadable HEAD with no integrity signal (warned, as before);
+//   - head == "" && refusal != "": refuse loudly — the CALLER records it
+//     (FinalBranchError for a terminal bank, the timeline for an
+//     attempt ref), because where the refusal must land differs.
+func (r *Runner) resolveBankHead(ctx context.Context, runID, workDir, base string, integ runtime.WorkspaceIntegrity) (string, string) {
 	head, headErr := gitlib.RevParseHead(workDir)
 	if integ.Applicable {
 		// The workspace is a pod-side COPY streamed back at sandbox
@@ -602,14 +624,13 @@ func (r *Runner) bankRepoWorkspace(ctx context.Context, msg *queue.RunMessage, w
 		switch {
 		case integ.CaptureErr != "":
 			if headErr != nil || (base != "" && head == base) {
-				r.recordBankFailure(msg, fmt.Sprintf(
+				return "", fmt.Sprintf(
 					"bank refused: pod-side HEAD unknown (%s) and the exported workspace shows no new work (HEAD %s, baseline %s) — cannot tell 'no commits' from 'the export lost the work'",
-					integ.CaptureErr, strutil.FirstNonBlank(head, "unreadable"), strutil.FirstNonBlank(base, "unknown")))
-				return
+					integ.CaptureErr, strutil.FirstNonBlank(head, "unreadable"), strutil.FirstNonBlank(base, "unknown"))
 			}
 			// The host tree does carry new commits; completeness is
 			// unverifiable but preserving the visible work wins.
-			r.cfg.Logger.Warn("runner: run %s: banking WITHOUT pod-side verification (capture failed: %s) — the branch may be missing commits that never left the pod", msg.RunID, integ.CaptureErr)
+			r.cfg.Logger.Warn("runner: run %s: banking WITHOUT pod-side verification (capture failed: %s) — the branch may be missing commits that never left the pod", runID, integ.CaptureErr)
 		case headErr != nil || head != integ.PodHead:
 			// The export can deliver every OBJECT yet leave the clone's
 			// ref system stale: tar cannot delete, so when a pod-side
@@ -620,29 +641,94 @@ func (r *Runner) bankRepoWorkspace(ctx context.Context, msg *queue.RunMessage, w
 			// THAT exact commit by SHA — it is the tree the run
 			// finished on. Otherwise refuse loudly.
 			if headErr == nil && r.hostHasCommit(ctx, workDir, integ.PodHead) {
-				r.cfg.Logger.Warn("runner: run %s: exported workspace reads %s but the pod-side HEAD %s IS present host-side (stale ref shadowing) — banking the pod's final commit by SHA", msg.RunID, head, integ.PodHead)
-				r.pushBank(ctx, msg, workDir, integ.PodHead, finalStatus)
-				return
+				r.cfg.Logger.Warn("runner: run %s: exported workspace reads %s but the pod-side HEAD %s IS present host-side (stale ref shadowing) — banking the pod's final commit by SHA", runID, head, integ.PodHead)
+				return integ.PodHead, ""
 			}
-			r.recordBankFailure(msg, fmt.Sprintf(
+			return "", fmt.Sprintf(
 				"bank refused: the run finished at pod-side HEAD %s but the exported workspace reads %s — the export did not deliver the run's final tree",
-				integ.PodHead, strutil.FirstNonBlank(head, "unreadable")))
-			return
+				integ.PodHead, strutil.FirstNonBlank(head, "unreadable"))
 		}
 	}
 	if headErr != nil {
-		r.cfg.Logger.Warn("runner: run %s: bank: read HEAD: %v", msg.RunID, headErr)
-		return
+		r.cfg.Logger.Warn("runner: run %s: bank: read HEAD: %v", runID, headErr)
+		return "", ""
 	}
 	if base != "" && head == base {
 		confirmed := ""
 		if integ.Applicable {
 			confirmed = " (pod-side HEAD confirms it)"
 		}
-		r.cfg.Logger.Info("runner: run %s: nothing to bank — HEAD is still the clone baseline%s", msg.RunID, confirmed)
+		r.cfg.Logger.Info("runner: run %s: nothing to bank — HEAD is still the clone baseline%s", runID, confirmed)
+		return "", ""
+	}
+	return head, ""
+}
+
+// bankAttemptRef parks an attempt's work on a uniquely-named ref —
+// iterion/run-<id>-attempt-<head12>, the naming preserveSupersededChain
+// established — when the STORAGE branch must not be touched: an
+// interrupted delivery (the lease may already belong to another pod,
+// and two pods force-pushing one branch is the split-brain the bank
+// refusal exists to prevent — but a ref carrying this chain's own head
+// in its NAME cannot contest anything), a paused run (recording
+// FinalBranch would make a half-done run merge-eligible mid-flight),
+// and a bankable death whose run ctx was cancelled for lease loss.
+//
+// Without it, those attempts' commits exist only in the git-meta
+// snapshot, and turning that snapshot back into a branch takes a manual
+// replay every time — the same measured cost the death bank closed for
+// budget/failure outcomes, still being paid for these.
+//
+// Deliberately DOC-LESS: no FinalBranch (merge eligibility), no
+// FinalCommit, no FinalBranchError (the run is not terminally
+// unbanked — it may resume or redeliver). The ref lands on the run's
+// timeline as run_bank_attempt, success or failure — never silence.
+//
+// The run ctx on these paths is typically already cancelled, so the
+// push runs on its own detached, bounded context. That is safe here
+// precisely because the ref is uncontested: the anti-clobber machinery
+// (ls-remote, lease, supersede) exists for a SHARED name and would be
+// dead weight on a name derived from the pushed head itself. The push
+// is plain (no force): a ref that already exists at this head is a
+// no-op, and anything else — a 12-hex prefix collision — is refused by
+// git and reported, never overwritten.
+func (r *Runner) bankAttemptRef(msg *queue.RunMessage, workDir, base string, integ runtime.WorkspaceIntegrity, cause string) {
+	ctx := context.Background()
+	if gitOpTimeout > 0 {
+		bounded, cancel := context.WithTimeout(ctx, bankBudget)
+		defer cancel()
+		ctx = bounded
+	}
+	head, refusal := r.resolveBankHead(ctx, msg.RunID, workDir, base, integ)
+	if refusal != "" {
+		r.cfg.Logger.Error("runner: run %s: attempt ref not parked (%s): %s", msg.RunID, cause, refusal)
+		r.recordBankAttempt(msg, map[string]any{"cause": cause, "error": refusal})
 		return
 	}
-	r.pushBank(ctx, msg, workDir, head, finalStatus)
+	if head == "" {
+		return
+	}
+	ref := "iterion/run-" + msg.RunID + "-attempt-" + shortSHA(head)
+	if err := r.runGit(ctx, workDir, "", "push", "origin", head+":refs/heads/"+ref); err != nil {
+		r.cfg.Logger.Error("runner: run %s: attempt ref push %s FAILED — the work exists only in this pod's clone and the git-meta snapshot: %v", msg.RunID, ref, err)
+		r.recordBankAttempt(msg, map[string]any{"cause": cause, "error": fmt.Sprintf("push %s: %v", ref, err)})
+		return
+	}
+	r.cfg.Logger.Info("runner: run %s: attempt work parked at %s @ %.12s (%s)", msg.RunID, ref, head, cause)
+	r.recordBankAttempt(msg, map[string]any{"cause": cause, "ref": ref, "head": head})
+}
+
+// recordBankAttempt puts an attempt-ref outcome on the run's timeline —
+// the only durable record of the parked ref, since the run doc is
+// deliberately left untouched on every bankAttemptRef path.
+func (r *Runner) recordBankAttempt(msg *queue.RunMessage, data map[string]any) {
+	idCtx := store.WithIdentity(context.Background(), msg.TenantID, msg.OwnerID)
+	if _, err := r.cfg.Store.AppendEvent(idCtx, msg.RunID, store.Event{
+		Type: store.EventRunBankAttempt,
+		Data: data,
+	}); err != nil {
+		r.cfg.Logger.Warn("runner: run %s: could not emit run_bank_attempt: %v", msg.RunID, err)
+	}
 }
 
 // hostHasCommit reports whether sha resolves to a commit object present

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -167,7 +167,10 @@ const (
 	//     bank's doc I/O died or was refused AFTER the side effect — the
 	//     branch may sit on the forge with the doc naming nothing, or an
 	//     integrity refusal may have lost its FinalBranchError write; the
-	//     event is then the only durable carrier of what happened
+	//     event is then the only durable carrier of what happened. On
+	//     these shapes head sits on the forge ONLY when push_error is
+	//     absent — a present push_error is the explicit marker that the
+	//     head never reached it
 	EventRunBankRefused EventType = "run_bank_refused"
 	// EventRunBankSuperseded marks a finished outcome force-taking the
 	// storage branch from an earlier dead attempt whose banked chain the
@@ -199,7 +202,8 @@ const (
 	// FinalBranchError — so this event is the ONLY durable record that
 	// the ref exists (or why it could not be pushed). Data:
 	//   - ref / head: the parked ref and the commit it holds — the
-	//     success shape
+	//     success shape (head also rides the doc-cancelled skip, naming
+	//     the commit that was NOT parked)
 	//   - cause: which outcome parked it (interrupted, paused,
 	//     paused_operator, or the lease-loss death)
 	//   - error: why the head could not be resolved or pushed (the work

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -162,6 +162,12 @@ const (
 	//     integrity-check refusal only
 	//   - reason ("push_failed") / error: the forge refused this
 	//     attempt's push — the push-failure refusal only
+	//   - reason ("doc_load_failed" / "doc_save_failed" /
+	//     "cancelled_while_banking") + head/branch/error/push_error: the
+	//     bank's doc I/O died or was refused AFTER the side effect — the
+	//     branch may sit on the forge with the doc naming nothing, or an
+	//     integrity refusal may have lost its FinalBranchError write; the
+	//     event is then the only durable carrier of what happened
 	EventRunBankRefused EventType = "run_bank_refused"
 	// EventRunBankSuperseded marks a finished outcome force-taking the
 	// storage branch from an earlier dead attempt whose banked chain the

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -179,6 +179,24 @@ const (
 	//     recoverable from the run's git-meta snapshot) — the failure
 	//     shape; exactly one of the two is present
 	EventRunBankSuperseded EventType = "run_bank_superseded"
+	// EventRunBankAttempt marks an attempt's work being parked on its own
+	// uniquely-named ref (iterion/run-<id>-attempt-<sha12>) because the
+	// STORAGE branch must not be touched: an interrupted delivery (the
+	// lease may already belong to another pod — a ref named after this
+	// chain's own head cannot contest anything), a paused run (recording
+	// FinalBranch would make a half-done run merge-eligible), or a
+	// bankable death whose run ctx was cancelled for lease loss. The run
+	// doc is deliberately left alone — no FinalBranch/FinalCommit/
+	// FinalBranchError — so this event is the ONLY durable record that
+	// the ref exists (or why it could not be pushed). Data:
+	//   - ref / head: the parked ref and the commit it holds — the
+	//     success shape
+	//   - cause: which outcome parked it (interrupted, paused,
+	//     paused_operator, or the lease-loss death)
+	//   - error: why the head could not be resolved or pushed (the work
+	//     stays recoverable from the git-meta snapshot) — the failure
+	//     shape; exactly one of ref/error is present
+	EventRunBankAttempt EventType = "run_bank_attempt"
 	// EventRunRewound marks an in-place rewind: the operator re-anchored
 	// THIS run's checkpoint on an already-executed node and invalidated
 	// the outputs downstream of it, so the next resume re-executes from

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -170,7 +170,13 @@ const (
 	//     event is then the only durable carrier of what happened. On
 	//     these shapes head sits on the forge ONLY when push_error is
 	//     absent — a present push_error is the explicit marker that the
-	//     head never reached it
+	//     push was not confirmed (a deadline can kill the client after
+	//     the server applied the update, so "unconfirmed", not "never
+	//     arrived"). Two producers share the doc_*_failed reasons:
+	//     pushBank's post-push exits carry head/branch (a possibly
+	//     orphaned branch), recordBankFailure's pre-push ones carry
+	//     cause and no head (an integrity refusal that lost its
+	//     FinalBranchError write) — head-vs-cause is the discriminant
 	EventRunBankRefused EventType = "run_bank_refused"
 	// EventRunBankSuperseded marks a finished outcome force-taking the
 	// storage branch from an earlier dead attempt whose banked chain the

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -180,7 +180,10 @@ const (
 	//     shape; exactly one of the two is present
 	EventRunBankSuperseded EventType = "run_bank_superseded"
 	// EventRunBankAttempt marks an attempt's work being parked on its own
-	// uniquely-named ref (iterion/run-<id>-attempt-<sha12>) because the
+	// uniquely-named ref (iterion/run-<id>-parked-<sha12> — a distinct
+	// infix from the supersede archives' -attempt-, so a pruning policy
+	// can tell a dead attempt's archive from a live run's parked work by
+	// name alone) because the
 	// STORAGE branch must not be touched: an interrupted delivery (the
 	// lease may already belong to another pod — a ref named after this
 	// chain's own head cannot contest anything), a paused run (recording

--- a/studio/src/api/runs/events.ts
+++ b/studio/src/api/runs/events.ts
@@ -408,6 +408,7 @@ export type PassthroughEventType =
   | "run_workspace_reset"
   | "run_bank_refused"
   | "run_bank_superseded"
+  | "run_bank_attempt"
   | "review_turn"
   | "review_verdict"
   | "review_merged"


### PR DESCRIPTION
## What

An interrupted delivery, a paused run, and a bankable death on a lease-lost ctx all leave their commits stranded in the git-meta snapshot. The storage branch must not be touched on those paths — another pod may own the lease, and `FinalBranch` on a half-done run would be merge-eligible mid-flight — but **both objections are about the name, not the push**. So the work now parks on a ref that contests nothing: `iterion/run-<id>-parked-<head12>` (head-derived like `preserveSupersededChain`'s archives, but a distinct infix so a future pruning policy can tell a dead attempt's archive from a live run's parked work by name alone), run doc deliberately untouched, outcome on the timeline as `run_bank_attempt` — success or failure, never silence.

An operator cancel still parks nothing: the operator refused the work.

## Why

Turning the snapshot back into a branch takes a manual replay every time — the same measured cost the death bank (#556) closed for budget/failure outcomes (nine manual recoveries in three days of one campaign), still being paid for interrupted/paused/lease-loss outcomes.

## How

- `resolveBankHead` extracts the head resolution + export-integrity oracle into ONE shared authority, so the storage bank and the attempt ref cannot drift on what "the run's final tree" means (incl. the unverifiable-export refusals and the stale-ref-shadowing recovery — behavior preserved, existing tests untouched and green).
- `bankAttemptRef` runs on its own detached, bounded ctx (the run ctx on these paths is typically already cancelled); plain push, no force — a colliding name is refused and reported, never overwritten. No ls-remote/lease/supersede machinery: it exists for a SHARED name, and this name derives from the pushed head itself.
- New `run_bank_attempt` event (store + studio type union) is the only durable record of the parked ref, by design.

## Verification

- `go test ./pkg/runner/ ./pkg/store/` green; `gofmt`/`go vet`/`golangci-lint` clean.
- Falsified both ways in tests: parking outcomes leave the ref + event + an untouched doc; cancel and verified no-op leave NOTHING; an unverifiable export refuses loudly on the timeline (not on `FinalBranchError`).
- Falsified by mutation: neutralizing the gate arm → red; parking on the storage-branch name → red (2 failures).

## Adversarial round (2 reviewers, executed probes)

One round, two parallel adversarial reviews (mechanics + integration). Adopted and fixed in the second commit — each finding proven by an executed probe, each fix seen red on its own assertion first: always-deadlined park ctx (uncancellable/unbounded push proven with an accept-and-never-answer forge), operator-cancel guard on the non-bankable road + doc re-read before the push (cancel racing a pause through the minutes-wide export window), `-parked-` infix (namespace split from supersede archives), loud unreadable-HEAD refusal, comment truths. Refuted with proof and kept as-is: zero drift in the extracted head oracle (mechanical diff vs `main`), attempt refs cannot fool `bankedBranchHead`, `runs merge` reads only the doc pair, push failures already loud. Deferred: an operator surface for parked refs (the doc-less design is deliberate; the timeline event is durable and queryable) and redaction-token plumbing on the park push (probe showed git elides userinfo and the origin URL is credential-free).

## Follow-on (out of scope)

Anchoring a resume/redelivery on the banked head instead of re-cloning at base (already noted in `TestBankOnBudgetDeathLandsTheBranch`); pruning stale parked refs at the terminal bank; bounding the four remaining `context.Background()` store/upload ops on the teardown traversal OUTSIDE the bank seam (`recordRunGitMeta`, `uploadRunFiles`, the two outcome notifiers — same pre-Nak pin-the-pod class the loop closed inside the seam, engine-wide sweep); and git-meta snapshot capture robustness — measured the same day this PR was written: a run died at its budget wall with an EMPTY commit store despite having passed its work gate, so the snapshot (this PR's documented fallback) can itself be the missing net. Parking and snapshotting must fail independently, and a whole-run capture miss deserves its own loud signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


