### PR TITLE
fix(queue): survive a queue-backend outage — bounded republish retry, typed 503, budget guard before the sandbox

### DIFF
--- a/pkg/queue/nats/errors.go
+++ b/pkg/queue/nats/errors.go
@@ -13,7 +13,7 @@ import (
 // Payload/schema errors are intentionally excluded: retrying those cannot
 // make them valid and must preserve their original semantic error.
 func IsTransientPublishError(err error) bool {
-	return errors.Is(err, context.DeadlineExceeded) ||
+	if errors.Is(err, context.DeadlineExceeded) ||
 		errors.Is(err, natsgo.ErrNoResponders) ||
 		errors.Is(err, natsgo.ErrTimeout) ||
 		errors.Is(err, natsgo.ErrDisconnected) ||
@@ -21,5 +21,23 @@ func IsTransientPublishError(err error) bool {
 		errors.Is(err, natsgo.ErrInvalidConnection) ||
 		errors.Is(err, natsgo.ErrNoStreamResponse) ||
 		errors.Is(err, jetstream.ErrNoStreamResponse) ||
-		errors.Is(err, jetstream.ErrConnectionClosed)
+		errors.Is(err, jetstream.ErrConnectionClosed) {
+		return true
+	}
+
+	// JetStream can answer a publish with a server-side APIError while the
+	// cluster is degraded. Retry only the explicitly temporary conditions;
+	// schema, subject, and stream errors remain permanent by default.
+	var apiErr *jetstream.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	switch apiErr.ErrorCode {
+	case jetstream.ErrorCode(10008), // cluster temporarily unavailable
+		jetstream.ErrorCode(10023), // insufficient resources
+		jetstream.ErrorCode(10040): // cluster peer not a member
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/queue/nats/errors.go
+++ b/pkg/queue/nats/errors.go
@@ -1,0 +1,25 @@
+package nats
+
+import (
+	"context"
+	"errors"
+
+	natsgo "github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// IsTransientPublishError reports whether a failed JetStream publish is
+// expected to recover after the broker reconnects or responders return.
+// Payload/schema errors are intentionally excluded: retrying those cannot
+// make them valid and must preserve their original semantic error.
+func IsTransientPublishError(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded) ||
+		errors.Is(err, natsgo.ErrNoResponders) ||
+		errors.Is(err, natsgo.ErrTimeout) ||
+		errors.Is(err, natsgo.ErrDisconnected) ||
+		errors.Is(err, natsgo.ErrConnectionClosed) ||
+		errors.Is(err, natsgo.ErrInvalidConnection) ||
+		errors.Is(err, natsgo.ErrNoStreamResponse) ||
+		errors.Is(err, jetstream.ErrNoStreamResponse) ||
+		errors.Is(err, jetstream.ErrConnectionClosed)
+}

--- a/pkg/queue/nats/errors_test.go
+++ b/pkg/queue/nats/errors_test.go
@@ -1,0 +1,37 @@
+package nats
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	natsgo "github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestIsTransientPublishError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "no responders", err: natsgo.ErrNoResponders, want: true},
+		{name: "request timeout", err: natsgo.ErrTimeout, want: true},
+		{name: "publish deadline", err: context.DeadlineExceeded, want: true},
+		{name: "disconnected", err: natsgo.ErrDisconnected, want: true},
+		{name: "connection closed", err: natsgo.ErrConnectionClosed, want: true},
+		{name: "invalid connection", err: natsgo.ErrInvalidConnection, want: true},
+		{name: "legacy stream unavailable", err: natsgo.ErrNoStreamResponse, want: true},
+		{name: "stream unavailable", err: jetstream.ErrNoStreamResponse, want: true},
+		{name: "wrapped transient", err: errors.Join(errors.New("publish failed"), jetstream.ErrConnectionClosed), want: true},
+		{name: "payload refusal", err: errors.New("maximum payload exceeded"), want: false},
+		{name: "caller cancellation", err: context.Canceled, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTransientPublishError(tt.err); got != tt.want {
+				t.Errorf("IsTransientPublishError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/queue/nats/errors_test.go
+++ b/pkg/queue/nats/errors_test.go
@@ -3,6 +3,7 @@ package nats
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	natsgo "github.com/nats-io/nats.go"
@@ -24,6 +25,11 @@ func TestIsTransientPublishError(t *testing.T) {
 		{name: "legacy stream unavailable", err: natsgo.ErrNoStreamResponse, want: true},
 		{name: "stream unavailable", err: jetstream.ErrNoStreamResponse, want: true},
 		{name: "wrapped transient", err: errors.Join(errors.New("publish failed"), jetstream.ErrConnectionClosed), want: true},
+		{name: "api cluster temporarily unavailable", err: fmt.Errorf("publish failed: %w", &jetstream.APIError{Code: 503, ErrorCode: jetstream.ErrorCode(10008)}), want: true},
+		{name: "api insufficient resources", err: fmt.Errorf("publish failed: %w", &jetstream.APIError{Code: 503, ErrorCode: jetstream.ErrorCode(10023)}), want: true},
+		{name: "api cluster peer not member", err: fmt.Errorf("publish failed: %w", &jetstream.APIError{Code: 503, ErrorCode: jetstream.ErrorCode(10040)}), want: true},
+		{name: "api stream not found", err: fmt.Errorf("publish failed: %w", &jetstream.APIError{Code: 404, ErrorCode: jetstream.ErrorCode(10059)}), want: false},
+		{name: "api bad request", err: fmt.Errorf("publish failed: %w", &jetstream.APIError{Code: 400, ErrorCode: jetstream.ErrorCode(10003)}), want: false},
 		{name: "payload refusal", err: errors.New("maximum payload exceeded"), want: false},
 		{name: "caller cancellation", err: context.Canceled, want: false},
 	}

--- a/pkg/runtime/budget_exit_grace.go
+++ b/pkg/runtime/budget_exit_grace.go
@@ -80,6 +80,18 @@ func (e *Engine) withinBudgetGrace(rs *runState) (dimension string, ok bool) {
 	if rs == nil || rs.budget == nil {
 		return "", false
 	}
+	return e.withinSharedBudgetGrace(rs.budget)
+}
+
+// withinSharedBudgetGrace is the policy predicate shared by the normal
+// pre-exec gate and the failed-resume preflight. The latter deliberately
+// returns without finalizing when this is true so the rebuilt run reaches
+// checkBudgetBeforeExec, which emits the ordinary grace events and keeps the
+// same bounded forward-only behavior as an uninterrupted run.
+func (e *Engine) withinSharedBudgetGrace(b *SharedBudget) (dimension string, ok bool) {
+	if e == nil || b == nil {
+		return "", false
+	}
 	// The "no further ITERATION can start" half of the safety argument
 	// is the loop guard's, not the grace's — and that guard is an
 	// operator escape hatch (`loop_budget_guard: off`,
@@ -92,14 +104,14 @@ func (e *Engine) withinBudgetGrace(rs *runState) (dimension string, ok bool) {
 	// An externally-imposed cap (platform ceiling, pool donor allowance —
 	// ir.Budget.CapImposed) is an absolute promise to a third party: no
 	// grace, the declared figure IS the wall.
-	if rs.budget.capIsImposed() {
+	if b.capIsImposed() {
 		return "", false
 	}
 	ratio := budgetExitGraceRatio()
 	if ratio <= 0 {
 		return "", false
 	}
-	return rs.budget.exitGraceRoom(ratio)
+	return b.exitGraceRoom(ratio)
 }
 
 // GracedRemainingDuration is the wall-clock room left before the GRACED

--- a/pkg/runtime/budget_resume_preflight.go
+++ b/pkg/runtime/budget_resume_preflight.go
@@ -36,6 +36,13 @@ func (e *Engine) failSpentBudgetBeforeResume(ctx context.Context, r *store.Run) 
 
 	checks := b.Check()
 	if exc := findExceeded(checks); exc != nil {
+		// A run already inside its bounded exit allowance must take the same
+		// path as an uninterrupted run. Let resume rebuild its state and reach
+		// checkBudgetBeforeExec, which grants and audits the grace while the
+		// loop guard prevents another iteration from starting.
+		if _, ok := e.withinSharedBudgetGrace(b); ok {
+			return nil
+		}
 		return e.finalizeSpentBudgetBeforeResume(ctx, r, exc, false)
 	}
 	// The in-run pre-exec gate refuses a new node at 90% to reserve room for

--- a/pkg/runtime/budget_resume_preflight.go
+++ b/pkg/runtime/budget_resume_preflight.go
@@ -1,0 +1,98 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// failSpentBudgetBeforeResume applies the same persisted accounting and cap
+// raises as a rebuilt runState, but does so immediately after the resume CAS
+// and before restoreRunEnv/startSandbox. A redelivery that cannot start its
+// next node therefore reaches the normal budget_exceeded + run_failed
+// disposition without provisioning a sandbox merely to rediscover the cap.
+func (e *Engine) failSpentBudgetBeforeResume(ctx context.Context, r *store.Run) error {
+	if e == nil || e.workflow == nil || r == nil || r.Checkpoint == nil {
+		return nil
+	}
+	b := newSharedBudget(e.workflow.Budget, e.logger)
+	if b == nil {
+		return nil
+	}
+	cp := r.Checkpoint
+	b.Restore(cp.BudgetTokensUsed, cp.BudgetCostUSD, cp.BudgetIterationsUsed,
+		time.Duration(cp.BudgetElapsedNS), cp.BudgetUnpricedTokens, cp.BudgetUnpricedNodes)
+	if raises := r.BudgetRaises; raises != nil {
+		b.RaiseCaps(ir.BudgetOverrides{
+			MaxCostUSD:    raises.MaxCostUSD,
+			MaxTokens:     raises.MaxTokens,
+			MaxIterations: raises.MaxIterations,
+			MaxDuration:   raises.MaxDuration,
+		})
+	}
+
+	checks := b.Check()
+	if exc := findExceeded(checks); exc != nil {
+		return e.finalizeSpentBudgetBeforeResume(ctx, r, exc, false)
+	}
+	// The in-run pre-exec gate refuses a new node at 90% to reserve room for
+	// concurrent overage. Reproduce that decision here too: provisioning a
+	// sandbox cannot change the accounting and would immediately hit the same
+	// hard-limit branch.
+	if hard := findHardLimited(checks); hard != nil {
+		return e.finalizeSpentBudgetBeforeResume(ctx, r, hard, true)
+	}
+	return nil
+}
+
+func (e *Engine) finalizeSpentBudgetBeforeResume(ctx context.Context, r *store.Run, check *budgetCheckResult, hardLimit bool) error {
+	nodeID := r.Checkpoint.NodeID
+	data := map[string]any{
+		"dimension": check.dimension,
+		"used":      check.used,
+		"limit":     check.limit,
+	}
+	var rtErr *RuntimeError
+	if hardLimit {
+		data["hard_limit"] = true
+		rtErr = &RuntimeError{
+			Code:    ErrCodeBudgetExceeded,
+			Message: fmt.Sprintf("budget hard limit reached: %s at %.0f%% (%.0f/%.0f)", check.dimension, (check.used/check.limit)*100, check.used, check.limit),
+			NodeID:  nodeID,
+			Hint:    fmt.Sprintf("increase the %s budget or optimize the workflow; new executions are blocked at 90%% to prevent concurrent overage", check.dimension),
+			Cause:   ErrBudgetExceeded,
+		}
+	} else {
+		rtErr = &RuntimeError{
+			Code:    ErrCodeBudgetExceeded,
+			Message: fmt.Sprintf("budget exceeded: %s (%.0f/%.0f)", check.dimension, check.used, check.limit),
+			NodeID:  nodeID,
+			Hint:    fmt.Sprintf("raise budget.%s and resume — local: `iterion resume --max-%s`; cloud: `runs resume --file <workflow with the raised budget>`", check.dimension, check.dimension),
+			Cause:   ErrBudgetExceeded,
+		}
+	}
+
+	if err := e.emit(ctx, r.ID, store.EventBudgetExceeded, nodeID, data); err != nil && e.logger != nil {
+		e.logger.Warn("failed to emit budget_exceeded event: %v", err)
+	}
+	// The run was claimed to running immediately before this guard. Restore
+	// its existing rich checkpoint while moving it back to failed_resumable,
+	// exactly like failRunErrWithCheckpoint does after an in-loop budget death.
+	if err := e.store.FailRunResumable(ctx, r.ID, r.Checkpoint, rtErr.Message); err != nil {
+		if e.logger != nil {
+			e.logger.Error("failed to persist pre-resume budget failure: %v", err)
+		}
+		return e.failRunErr(ctx, r.ID, nodeID, rtErr)
+	}
+	if err := e.emit(ctx, r.ID, store.EventRunFailed, nodeID, map[string]any{
+		"error":     rtErr.Message,
+		"code":      string(rtErr.Code),
+		"resumable": true,
+	}); err != nil && e.logger != nil {
+		e.logger.Warn("failed to emit run_failed event: %v", err)
+	}
+	return rtErr
+}

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -474,9 +474,6 @@ func (e *Engine) seedRepoRootForResume(r *store.Run) {
 func (e *Engine) resumeRebuildState(ctx context.Context, r *store.Run, cp *store.Checkpoint, outputs map[string]map[string]any, artifactVersions map[string]int) (*runState, func(), error) {
 	runID := r.ID
 	humanNodeID := cp.NodeID
-	if err := e.failSpentBudgetBeforeResume(ctx, r); err != nil {
-		return nil, nil, err
-	}
 
 	// Clone (not alias) the counter maps: the engine mutates them in place
 	// during the resumed run, so aliasing r.Checkpoint's maps would race a

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -474,6 +474,9 @@ func (e *Engine) seedRepoRootForResume(r *store.Run) {
 func (e *Engine) resumeRebuildState(ctx context.Context, r *store.Run, cp *store.Checkpoint, outputs map[string]map[string]any, artifactVersions map[string]int) (*runState, func(), error) {
 	runID := r.ID
 	humanNodeID := cp.NodeID
+	if err := e.failSpentBudgetBeforeResume(ctx, r); err != nil {
+		return nil, nil, err
+	}
 
 	// Clone (not alias) the counter maps: the engine mutates them in place
 	// during the resumed run, so aliasing r.Checkpoint's maps would race a
@@ -629,6 +632,9 @@ func (e *Engine) resumeFromFailure(ctx context.Context, r *store.Run) error {
 	}
 
 	if err := e.claimForFailureResume(ctx, runID, cp, restartNodeID); err != nil {
+		return err
+	}
+	if err := e.failSpentBudgetBeforeResume(ctx, r); err != nil {
 		return err
 	}
 

--- a/pkg/runtime/resume_failure_char_test.go
+++ b/pkg/runtime/resume_failure_char_test.go
@@ -605,6 +605,115 @@ func TestResumeFromFailure_BudgetSpendRestored(t *testing.T) {
 	}
 }
 
+// TestResumeFromFailure_BudgetExitGraceFinishesAt105Percent pins the outage
+// redelivery case: a checkpoint already inside the bounded 10% exit grace
+// must reach the ordinary pre-exec gate, execute its delivery node once, and
+// finish instead of being killed by the sandbox preflight.
+func TestResumeFromFailure_BudgetExitGraceFinishesAt105Percent(t *testing.T) {
+	t.Setenv("ITERION_BUDGET_EXIT_GRACE", "0.1")
+	t.Setenv("ITERION_LOOP_BUDGET_GUARD", "on")
+	wf := charResumeWF()
+	wf.Budget = &ir.Budget{MaxCostUSD: 1.0}
+
+	s := tmpStore(t)
+	ctx := context.Background()
+	const runID = "run-char-budget-exit-grace"
+	if _, err := s.CreateRun(ctx, runID, "resume_char", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	cp := &store.Checkpoint{
+		NodeID:        "step_b",
+		Outputs:       map[string]map[string]any{"step_a": {"result": "ok"}},
+		BudgetCostUSD: 1.05,
+	}
+	if err := s.FailRunResumable(ctx, runID, cp, "queue backend interrupted the prior attempt"); err != nil {
+		t.Fatalf("FailRunResumable: %v", err)
+	}
+
+	var exitCalls int
+	exec := newStubExecutor()
+	exec.on("step_b", func(_ map[string]any) (map[string]any, error) {
+		exitCalls++
+		return map[string]any{"result": "delivered"}, nil
+	})
+
+	if err := New(wf, s, exec).Resume(ctx, runID, nil); err != nil {
+		t.Fatalf("Resume at 105%% of cap: %v", err)
+	}
+	if exitCalls != 1 {
+		t.Errorf("exit node executions = %d, want 1", exitCalls)
+	}
+	r, err := s.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.Status != store.RunStatusFinished {
+		t.Errorf("status = %s, want finished", r.Status)
+	}
+	events, err := s.LoadEvents(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	var graceEvents int
+	for _, evt := range events {
+		if evt.Type == store.EventBudgetExitGrace {
+			graceEvents++
+		}
+	}
+	if graceEvents != 2 {
+		t.Errorf("budget_exit_grace events = %d, want 2", graceEvents)
+	}
+}
+
+// TestResumeFromPause_HardLimitCheckpointKeepsHumanAnswers pins the narrow
+// pause path: answers are recorded before the next-node budget gate fails,
+// and the resulting failed_resumable checkpoint must contain those answers
+// and restart at the downstream node rather than asking the human again.
+func TestResumeFromPause_HardLimitCheckpointKeepsHumanAnswers(t *testing.T) {
+	wf := humanWorkflow()
+	wf.Budget = &ir.Budget{MaxCostUSD: 1.0}
+
+	s := tmpStore(t)
+	ctx := context.Background()
+	const runID = "run-human-budget-preflight"
+	exec := newStubExecutor()
+	exec.on("analyze", func(_ map[string]any) (map[string]any, error) {
+		return map[string]any{"summary": "needs review"}, nil
+	})
+	if err := New(wf, s, exec).Run(ctx, runID, nil); !errors.Is(err, ErrRunPaused) {
+		t.Fatalf("Run: got %v, want ErrRunPaused", err)
+	}
+	r, err := s.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun paused run: %v", err)
+	}
+	r.Checkpoint.BudgetCostUSD = 0.95
+	if err := s.SaveCheckpoint(ctx, runID, r.Checkpoint); err != nil {
+		t.Fatalf("SaveCheckpoint at hard limit: %v", err)
+	}
+
+	answers := map[string]any{"approved": true, "reason": "operator approved"}
+	err = New(wf, s, exec).Resume(ctx, runID, answers)
+	var rtErr *RuntimeError
+	if !errors.As(err, &rtErr) || rtErr.Code != ErrCodeBudgetExceeded {
+		t.Fatalf("Resume error = %v, want RuntimeError BUDGET_EXCEEDED", err)
+	}
+	r, err = s.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun after resume: %v", err)
+	}
+	if r.Status != store.RunStatusFailedResumable {
+		t.Errorf("status = %s, want failed_resumable", r.Status)
+	}
+	if r.Checkpoint == nil || r.Checkpoint.NodeID != "integrate" {
+		t.Fatalf("checkpoint = %+v, want downstream node integrate", r.Checkpoint)
+	}
+	gotAnswers := r.Checkpoint.Outputs["review"]
+	if gotAnswers["approved"] != true || gotAnswers["reason"] != "operator approved" {
+		t.Errorf("checkpoint outputs[review] = %#v, want recorded operator answers", gotAnswers)
+	}
+}
+
 // TestResumeFromFailure_ExhaustedDurationFinalizesBeforeSandbox pins the
 // redelivery guard: persisted active time that already exhausted the run's
 // duration budget must produce the ordinary resumable budget death before

--- a/pkg/runtime/resume_failure_char_test.go
+++ b/pkg/runtime/resume_failure_char_test.go
@@ -16,9 +16,11 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -600,5 +602,84 @@ func TestResumeFromFailure_BudgetSpendRestored(t *testing.T) {
 	r, _ := s.LoadRun(ctx, runID)
 	if r.Status != store.RunStatusFailedResumable {
 		t.Errorf("status = %s, want failed_resumable (raise the cap + resume)", r.Status)
+	}
+}
+
+// TestResumeFromFailure_ExhaustedDurationFinalizesBeforeSandbox pins the
+// redelivery guard: persisted active time that already exhausted the run's
+// duration budget must produce the ordinary resumable budget death before
+// the sandbox lifecycle is invoked.
+func TestResumeFromFailure_ExhaustedDurationFinalizesBeforeSandbox(t *testing.T) {
+	wf := charResumeWF()
+	wf.Budget = &ir.Budget{MaxDuration: "10m"}
+	// Make sandbox provisioning observable if the guard ever moves too late.
+	wf.Sandbox = &ir.SandboxSpec{Mode: "inline", Image: "must-not-be-provisioned.invalid/test:latest"}
+
+	s := tmpStore(t)
+	ctx := context.Background()
+	const runID = "run-char-duration-preflight"
+	if _, err := s.CreateRun(ctx, runID, "resume_char", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	cp := &store.Checkpoint{
+		NodeID:          "step_b",
+		Outputs:         map[string]map[string]any{"step_a": {"result": "ok"}},
+		BudgetElapsedNS: (11 * time.Minute).Nanoseconds(),
+	}
+	if err := s.FailRunResumable(ctx, runID, cp, "queue backend interrupted the prior attempt"); err != nil {
+		t.Fatalf("FailRunResumable: %v", err)
+	}
+
+	var nodeCalls, sandboxStarts int
+	exec := newStubExecutor()
+	exec.on("step_b", func(_ map[string]any) (map[string]any, error) {
+		nodeCalls++
+		return map[string]any{"result": "unexpected"}, nil
+	})
+	err := New(wf, s, exec, WithSandboxRunObserver(func(sandbox.Run) {
+		sandboxStarts++
+	})).Resume(ctx, runID, nil)
+	var rtErr *RuntimeError
+	if !errors.As(err, &rtErr) || rtErr.Code != ErrCodeBudgetExceeded {
+		t.Fatalf("error = %v, want RuntimeError BUDGET_EXCEEDED", err)
+	}
+	if nodeCalls != 0 {
+		t.Errorf("restart node executed %d times, want 0", nodeCalls)
+	}
+	if sandboxStarts != 0 {
+		t.Errorf("sandbox provisioning invoked %d times, want 0", sandboxStarts)
+	}
+
+	r, loadErr := s.LoadRun(ctx, runID)
+	if loadErr != nil {
+		t.Fatalf("LoadRun: %v", loadErr)
+	}
+	if r.Status != store.RunStatusFailedResumable {
+		t.Errorf("status = %s, want failed_resumable", r.Status)
+	}
+	if r.Checkpoint == nil || r.Checkpoint.NodeID != "step_b" {
+		t.Fatalf("checkpoint = %+v, want preserved at step_b", r.Checkpoint)
+	}
+
+	events, eventsErr := s.LoadEvents(ctx, runID)
+	if eventsErr != nil {
+		t.Fatalf("LoadEvents: %v", eventsErr)
+	}
+	var sawBudgetExceeded, sawBudgetRunFailed bool
+	for _, evt := range events {
+		switch evt.Type {
+		case store.EventBudgetExceeded:
+			sawBudgetExceeded = evt.Data["dimension"] == "duration"
+		case store.EventRunFailed:
+			if evt.Data["code"] == string(ErrCodeBudgetExceeded) {
+				sawBudgetRunFailed = true
+			}
+		case store.EventSandboxHostStateMounted, store.EventSandboxDevboxProvisioned,
+			store.EventSandboxStarted, store.EventNodeStarted:
+			t.Errorf("preflight emitted post-provision event %s: %+v", evt.Type, evt.Data)
+		}
+	}
+	if !sawBudgetExceeded || !sawBudgetRunFailed {
+		t.Errorf("events missing normal budget death: budget_exceeded=%v run_failed=%v", sawBudgetExceeded, sawBudgetRunFailed)
 	}
 }

--- a/pkg/runview/queue_error.go
+++ b/pkg/runview/queue_error.go
@@ -1,0 +1,33 @@
+package runview
+
+import "fmt"
+
+// QueueUnavailableErrorCode is the stable API code returned when the cloud
+// queue cannot accept a launch or resume after bounded retries.
+const QueueUnavailableErrorCode = "QUEUE_UNAVAILABLE"
+
+// QueueUnavailableError marks a transient queue-backend outage. Callers may
+// retry the same operation; semantic resume refusals use their existing error
+// types and are deliberately not wrapped in this type.
+type QueueUnavailableError struct {
+	Cause error
+}
+
+func (e *QueueUnavailableError) Error() string {
+	if e == nil || e.Cause == nil {
+		return "queue temporarily unavailable"
+	}
+	return fmt.Sprintf("queue temporarily unavailable: %v", e.Cause)
+}
+
+func (e *QueueUnavailableError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Cause
+}
+
+// Code and Retryable let transport layers expose stable machine-readable
+// semantics without matching the human-readable NATS cause.
+func (e *QueueUnavailableError) Code() string    { return QueueUnavailableErrorCode }
+func (e *QueueUnavailableError) Retryable() bool { return true }

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -1302,10 +1302,7 @@ func (p *Publisher) publish(ctx context.Context, msg *queue.RunMessage) error {
 	return p.publishWithRetry(ctx, msg)
 }
 
-const (
-	publishRetryWindow  = 10 * time.Second
-	publishAttemptLimit = 2 * time.Second
-)
+const publishRetryWindow = 10 * time.Second
 
 var defaultPublishRetryDelays = []time.Duration{
 	250 * time.Millisecond,
@@ -1327,9 +1324,11 @@ func (p *Publisher) publishWithRetry(ctx context.Context, msg *queue.RunMessage)
 	attempts := len(delays) + 1
 	var lastErr error
 	for attempt := 1; attempt <= attempts; attempt++ {
-		attemptCtx, attemptCancel := context.WithTimeout(retryCtx, publishAttemptLimit)
-		lastErr = p.publishOnce(attemptCtx, msg)
-		attemptCancel()
+		// PublishRun owns its 5s acknowledgement deadline. Do not impose a
+		// shorter outer attempt timeout: cancelling only the ack wait after the
+		// broker accepted the message can turn a successful publish into retries
+		// and finally a false QUEUE_UNAVAILABLE response.
+		lastErr = p.publishOnce(retryCtx, msg)
 		if lastErr == nil {
 			return nil
 		}

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -119,7 +119,10 @@ type TeamResolver interface {
 type Publisher struct {
 	nats       *natsq.Conn
 	publishRun func(context.Context, *queue.RunMessage) error
-	cancelRun  func(string) error
+	// publishRetryDelays is nil in production (the bounded default below).
+	// Tests replace it with zero delays while exercising the same choke point.
+	publishRetryDelays []time.Duration
+	cancelRun          func(string) error
 	// maxPayload reports the NATS server-negotiated max message size so
 	// the offload path can size a RunMessage against it. Nil (the default
 	// in unit tests) disables IR offload — the message is published as-is.
@@ -1296,6 +1299,76 @@ func (p *Publisher) publish(ctx context.Context, msg *queue.RunMessage) error {
 	if err := p.offloadOversizedIR(ctx, msg); err != nil {
 		return err
 	}
+	return p.publishWithRetry(ctx, msg)
+}
+
+const (
+	publishRetryWindow  = 10 * time.Second
+	publishAttemptLimit = 2 * time.Second
+)
+
+var defaultPublishRetryDelays = []time.Duration{
+	250 * time.Millisecond,
+	500 * time.Millisecond,
+	750 * time.Millisecond,
+}
+
+// publishWithRetry is the single retry choke point for cloud launches and
+// resumes. RunMessage's Nats-Msg-Id stays stable across attempts, so a publish
+// whose acknowledgement was lost is absorbed by JetStream deduplication.
+func (p *Publisher) publishWithRetry(ctx context.Context, msg *queue.RunMessage) error {
+	retryCtx, cancel := context.WithTimeout(ctx, publishRetryWindow)
+	defer cancel()
+
+	delays := p.publishRetryDelays
+	if delays == nil {
+		delays = defaultPublishRetryDelays
+	}
+	attempts := len(delays) + 1
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		attemptCtx, attemptCancel := context.WithTimeout(retryCtx, publishAttemptLimit)
+		lastErr = p.publishOnce(attemptCtx, msg)
+		attemptCancel()
+		if lastErr == nil {
+			return nil
+		}
+		// A caller cancellation is not a queue outage and must retain its
+		// cancellation semantics. PublishRun's own deadline, on the other
+		// hand, is a transient NATS timeout and is retried below.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if !natsq.IsTransientPublishError(lastErr) {
+			return lastErr
+		}
+		if attempt == attempts || retryCtx.Err() != nil {
+			break
+		}
+		delay := delays[attempt-1]
+		if p.logger != nil {
+			p.logger.Warn("cloudpublisher: queue publish attempt %d/%d failed transiently: %v — retrying in %s", attempt, attempts, lastErr, delay)
+		}
+		if delay <= 0 {
+			continue
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-timer.C:
+		case <-retryCtx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return &runview.QueueUnavailableError{Cause: lastErr}
+		}
+	}
+	return &runview.QueueUnavailableError{Cause: lastErr}
+}
+
+func (p *Publisher) publishOnce(ctx context.Context, msg *queue.RunMessage) error {
 	if p.publishRun != nil {
 		return p.publishRun(ctx, msg)
 	}

--- a/pkg/server/cloudpublisher/publisher_retry_test.go
+++ b/pkg/server/cloudpublisher/publisher_retry_test.go
@@ -62,3 +62,34 @@ func TestPublishWithRetryPersistentFailureReturnsQueueUnavailable(t *testing.T) 
 		t.Fatalf("publish calls = %d, want 4", calls)
 	}
 }
+
+func TestPublishWithRetrySlowSuccessfulAck(t *testing.T) {
+	var calls int
+	p := &Publisher{
+		logger:             iterlog.Nop(),
+		publishRetryDelays: []time.Duration{},
+		publishRun: func(ctx context.Context, _ *queue.RunMessage) error {
+			calls++
+			timer := time.NewTimer(3 * time.Second)
+			defer timer.Stop()
+			select {
+			case <-timer.C:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	}
+
+	started := time.Now()
+	err := p.publish(context.Background(), &queue.RunMessage{RunID: "run-slow-ack"})
+	if err != nil {
+		t.Fatalf("publish with a 3s successful acknowledgement: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("publish calls = %d, want 1", calls)
+	}
+	if elapsed := time.Since(started); elapsed < 3*time.Second {
+		t.Errorf("publish returned after %s, want it to wait for the successful acknowledgement", elapsed)
+	}
+}

--- a/pkg/server/cloudpublisher/publisher_retry_test.go
+++ b/pkg/server/cloudpublisher/publisher_retry_test.go
@@ -1,0 +1,64 @@
+package cloudpublisher
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	natsgo "github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/runview"
+)
+
+func TestPublishWithRetryTransientFailureThenSuccess(t *testing.T) {
+	var calls int
+	p := &Publisher{
+		logger:             iterlog.Nop(),
+		publishRetryDelays: []time.Duration{0, 0, 0},
+		publishRun: func(context.Context, *queue.RunMessage) error {
+			calls++
+			if calls == 1 {
+				return natsgo.ErrNoResponders
+			}
+			return nil
+		},
+	}
+
+	if err := p.publish(context.Background(), &queue.RunMessage{RunID: "run-retry"}); err != nil {
+		t.Fatalf("publish after transient failure: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("publish calls = %d, want 2", calls)
+	}
+}
+
+func TestPublishWithRetryPersistentFailureReturnsQueueUnavailable(t *testing.T) {
+	var calls int
+	p := &Publisher{
+		logger:             iterlog.Nop(),
+		publishRetryDelays: []time.Duration{0, 0, 0},
+		publishRun: func(context.Context, *queue.RunMessage) error {
+			calls++
+			return jetstream.ErrNoStreamResponse
+		},
+	}
+
+	err := p.publish(context.Background(), &queue.RunMessage{RunID: "run-down"})
+	var unavailable *runview.QueueUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("error type = %T (%v), want *runview.QueueUnavailableError", err, err)
+	}
+	if unavailable.Code() != runview.QueueUnavailableErrorCode || !unavailable.Retryable() {
+		t.Fatalf("typed retry metadata = (%q, %v), want (%q, true)", unavailable.Code(), unavailable.Retryable(), runview.QueueUnavailableErrorCode)
+	}
+	if !errors.Is(err, jetstream.ErrNoStreamResponse) {
+		t.Fatalf("typed error does not retain NATS cause: %v", err)
+	}
+	if calls != 4 {
+		t.Fatalf("publish calls = %d, want 4", calls)
+	}
+}

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -489,6 +489,11 @@ func (s *Server) handleLaunchRun(w http.ResponseWriter, r *http.Request) {
 			span.SetStatus(codes.Error, "usage cap reached")
 			return
 		}
+		if s.writeQueueOutageError(w, r, "launch", err) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "queue unavailable")
+			return
+		}
 		s.httpErrorFor(w, r, http.StatusBadRequest, "launch: %v", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "launch failed")
@@ -664,13 +669,7 @@ func (s *Server) handleResumeRun(w http.ResponseWriter, r *http.Request) {
 // writeResumeError preserves the normal human-readable error response and
 // adds a stable code for the one resume failure the studio must act on.
 func (s *Server) writeResumeError(w http.ResponseWriter, r *http.Request, err error) {
-	var queueErr *runview.QueueUnavailableError
-	if errors.As(err, &queueErr) {
-		s.writeJSONError(w, r, http.StatusServiceUnavailable, map[string]any{
-			"error":      fmt.Sprintf("resume: %v", queueErr),
-			"error_code": queueErr.Code(),
-			"retryable":  queueErr.Retryable(),
-		})
+	if s.writeQueueOutageError(w, r, "resume", err) {
 		return
 	}
 	if runtime.IsWorkflowSourceChanged(err) {
@@ -681,6 +680,23 @@ func (s *Server) writeResumeError(w http.ResponseWriter, r *http.Request, err er
 		return
 	}
 	s.httpErrorFor(w, r, http.StatusBadRequest, "resume: %v", err)
+}
+
+// writeQueueOutageError is shared by launch and both resume error sites
+// (upload preflight and publication). errors.As deliberately handles the
+// wrapping and errors.Join shapes produced when queue publication and the
+// compensating run-status update both fail.
+func (s *Server) writeQueueOutageError(w http.ResponseWriter, r *http.Request, operation string, err error) bool {
+	var queueErr *runview.QueueUnavailableError
+	if !errors.As(err, &queueErr) {
+		return false
+	}
+	s.writeJSONError(w, r, http.StatusServiceUnavailable, map[string]any{
+		"error":      fmt.Sprintf("%s: %v", operation, queueErr),
+		"error_code": queueErr.Code(),
+		"retryable":  queueErr.Retryable(),
+	})
+	return true
 }
 
 // parseTimeout accepts an empty string (no timeout) or a Go duration

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -664,6 +664,15 @@ func (s *Server) handleResumeRun(w http.ResponseWriter, r *http.Request) {
 // writeResumeError preserves the normal human-readable error response and
 // adds a stable code for the one resume failure the studio must act on.
 func (s *Server) writeResumeError(w http.ResponseWriter, r *http.Request, err error) {
+	var queueErr *runview.QueueUnavailableError
+	if errors.As(err, &queueErr) {
+		s.writeJSONError(w, r, http.StatusServiceUnavailable, map[string]any{
+			"error":      fmt.Sprintf("resume: %v", queueErr),
+			"error_code": queueErr.Code(),
+			"retryable":  queueErr.Retryable(),
+		})
+		return
+	}
 	if runtime.IsWorkflowSourceChanged(err) {
 		s.writeJSONError(w, r, http.StatusBadRequest, map[string]any{
 			"error":      fmt.Sprintf("resume: %v", err),

--- a/pkg/server/runs_resume_error_test.go
+++ b/pkg/server/runs_resume_error_test.go
@@ -74,6 +74,31 @@ func TestWriteResumeError_UnrelatedFailureHasNoSourceChangedCode(t *testing.T) {
 	}
 }
 
+func TestWriteResumeError_QueueUnavailableIsRetryableServiceUnavailable(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/runs/r1/resume", nil)
+
+	(&Server{}).writeResumeError(rec, req, &runview.QueueUnavailableError{Cause: errors.New("broker unavailable")})
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	var body struct {
+		Error     string `json:"error"`
+		ErrorCode string `json:"error_code"`
+		Retryable bool   `json:"retryable"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response %q: %v", rec.Body.String(), err)
+	}
+	if body.ErrorCode != runview.QueueUnavailableErrorCode {
+		t.Errorf("error_code = %q, want %q", body.ErrorCode, runview.QueueUnavailableErrorCode)
+	}
+	if !body.Retryable {
+		t.Error("retryable = false, want true")
+	}
+}
+
 func TestResumeRun_SourceChangedReturnsStableCodeBeforeAsyncLaunch(t *testing.T) {
 	t.Setenv("ITERION_RUNS_DETACHED", "0")
 	srv, httpServer := newTestServer(t)

--- a/pkg/server/runs_resume_error_test.go
+++ b/pkg/server/runs_resume_error_test.go
@@ -11,11 +11,82 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
+
+type queueOutageTestPublisher struct {
+	err error
+}
+
+func (p *queueOutageTestPublisher) SubmitLaunch(context.Context, string, runview.LaunchSpec, *ir.Workflow, string) (int, error) {
+	return 0, p.err
+}
+
+func (*queueOutageTestPublisher) CancelRun(context.Context, string) error { return nil }
+
+func (*queueOutageTestPublisher) CancelRunWithReason(context.Context, string, string) error {
+	return nil
+}
+
+func (p *queueOutageTestPublisher) SubmitResume(context.Context, runview.ResumeSpec, *ir.Workflow, string) error {
+	return p.err
+}
+
+func installQueueOutageTestPublisher(t *testing.T, srv *Server, publishErr error) {
+	t.Helper()
+	svc, err := runview.NewService(srv.cfg.StoreDir,
+		runview.WithLogger(iterlog.Nop()),
+		runview.WithLaunchPublisher(&queueOutageTestPublisher{err: publishErr}),
+	)
+	if err != nil {
+		t.Fatalf("NewService with queue outage publisher: %v", err)
+	}
+	srv.runs = svc
+}
+
+func newQueueOutageHTTPTestServer(t *testing.T) *Server {
+	t.Helper()
+	workDir := t.TempDir()
+	srv := New(Config{
+		WorkDir:                 workDir,
+		StoreDir:                filepath.Join(workDir, ".iterion"),
+		SkipProjectRegistration: true,
+	}, iterlog.Nop())
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+	return srv
+}
+
+func assertQueueUnavailableResponse(t *testing.T, resp *http.Response) {
+	t.Helper()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+	var body struct {
+		Error     string `json:"error"`
+		ErrorCode string `json:"error_code"`
+		Retryable bool   `json:"retryable"`
+	}
+	decodeJSONResp(t, resp, &body)
+	if body.ErrorCode != runview.QueueUnavailableErrorCode {
+		t.Errorf("error_code = %q, want %q", body.ErrorCode, runview.QueueUnavailableErrorCode)
+	}
+	if !body.Retryable {
+		t.Error("retryable = false, want true")
+	}
+	if body.Error == "" {
+		t.Error("human-readable error should remain populated")
+	}
+}
 
 func TestWriteResumeError_SourceChangedCarriesStableCode(t *testing.T) {
 	tests := []struct {
@@ -97,6 +168,82 @@ func TestWriteResumeError_QueueUnavailableIsRetryableServiceUnavailable(t *testi
 	if !body.Retryable {
 		t.Error("retryable = false, want true")
 	}
+}
+
+func TestQueueUnavailableLaunchAndResumeReturnRetryableServiceUnavailable(t *testing.T) {
+	const source = "workflow queue_outage:\n  entry: done\n"
+
+	t.Run("launch", func(t *testing.T) {
+		srv := newQueueOutageHTTPTestServer(t)
+		queueErr := &runview.QueueUnavailableError{Cause: errors.New("broker recovering")}
+		// SubmitLaunch wraps the queue error in production, and may join it
+		// with a failed status rollback. Keep that outer shape in the proof.
+		installQueueOutageTestPublisher(t, srv, errors.Join(
+			fmt.Errorf("cloudpublisher: publish: %w", queueErr),
+			errors.New("status rollback also failed"),
+		))
+		body, err := json.Marshal(map[string]any{
+			"file_path": "queue_outage.bot",
+			"source":    source,
+			"run_id":    "run-queue-outage-launch",
+		})
+		if err != nil {
+			t.Fatalf("marshal launch request: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/api/runs", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		srv.handleLaunchRun(rec, req)
+		assertQueueUnavailableResponse(t, rec.Result())
+	})
+
+	t.Run("resume", func(t *testing.T) {
+		srv := newQueueOutageHTTPTestServer(t)
+		queueErr := &runview.QueueUnavailableError{Cause: errors.New("broker recovering")}
+		installQueueOutageTestPublisher(t, srv, fmt.Errorf("cloudpublisher: republish: %w", queueErr))
+
+		logicalPath := filepath.Join(srv.cfg.WorkDir, "queue_outage.bot")
+		_, workflowHash, err := runview.CompileWorkflowFromSource(logicalPath, source)
+		if err != nil {
+			t.Fatalf("compile workflow: %v", err)
+		}
+		st, err := store.New(srv.cfg.StoreDir)
+		if err != nil {
+			t.Fatalf("open run store: %v", err)
+		}
+		const runID = "run-queue-outage-resume"
+		if _, err := st.CreateRun(context.Background(), runID, "queue_outage", nil); err != nil {
+			t.Fatalf("CreateRun: %v", err)
+		}
+		r, err := st.LoadRun(context.Background(), runID)
+		if err != nil {
+			t.Fatalf("LoadRun: %v", err)
+		}
+		r.FilePath = logicalPath
+		r.WorkflowSource = source
+		r.WorkflowHash = workflowHash
+		r.Status = store.RunStatusPausedOperator
+		if err := st.SaveRun(context.Background(), r); err != nil {
+			t.Fatalf("SaveRun: %v", err)
+		}
+		if err := st.SaveCheckpoint(context.Background(), runID, &store.Checkpoint{NodeID: "done"}); err != nil {
+			t.Fatalf("SaveCheckpoint: %v", err)
+		}
+
+		body, err := json.Marshal(map[string]any{
+			"file_path": logicalPath,
+			"source":    source,
+		})
+		if err != nil {
+			t.Fatalf("marshal resume request: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/api/runs/"+runID+"/resume", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.SetPathValue("id", runID)
+		rec := httptest.NewRecorder()
+		srv.handleResumeRun(rec, req)
+		assertQueueUnavailableResponse(t, rec.Result())
+	})
 }
 
 func TestResumeRun_SourceChangedReturnsStableCodeBeforeAsyncLaunch(t *testing.T) {


### PR DESCRIPTION
## The measured incident

A ~27-minute blackout of the node hosting the JetStream assets (2026-08-31) produced three distinct harms:

1. every in-flight run was interrupted (`EXECUTION_FAILED … interrupted at node X (resumable)`);
2. `POST /api/runs/{id}/resume` hard-failed with `nats: no response from stream` — a transient blip presented to automation exactly like a permanent refusal;
3. after recovery, the server redelivered a run ALREADY past its duration budget: full sandbox provision, then `budget_exceeded` in under a minute.

## The change

- **Bounded republish retry** at the shared Launch/Resume choke point, with transient NATS errors classified explicitly — including server-side JetStream `APIError`s (10008 cluster temporarily unavailable, 10023 insufficient resources, 10040 peer not member); every other code stays permanent.
- **Typed retryable failure**: persistent outage returns `QUEUE_UNAVAILABLE` as HTTP **503** with `retryable: true`, on **both** launch and resume through one shared writer (launch previously answered 400 — "malformed, do not retry" — on the more common operation).
- **Budget guard at redelivery**, before any sandbox is provisioned: an exhausted run is finalized with the ordinary `budget_exceeded` / `run_failed` events and its checkpoint preserved.

## What adversarial review changed in it

The first version of this branch was reviewed against `main` with executed proofs, and four defects were fixed before this PR opened:

- the preflight **ignored the budget exit grace**, killing resumes `main` completes (a run at 105 % of cap: `main` → `finished`, branch → `failed_resumable`). The grace predicate is now shared by the in-run gate and the preflight — one point of truth, not a copy;
- on the human-pause path the preflight **discarded the operator's answers** (stale checkpoint persisted); the preflight now runs on the failure path only, which is the redelivery loop it targets;
- a 2 s per-attempt limit **truncated `PublishRun`'s own 5 s ack budget**, making the publisher less tolerant of a slow-but-alive broker — the exact regime of a cluster recovering from this outage;
- `QUEUE_UNAVAILABLE` was honoured on resume only.

Each fix was verified red (defect restored) then green. `go build ./...`, `go test ./pkg/...` green (2110 in the touched packages).

## Known limit, stated

The runner's interruption comes from the KV lease heartbeat: a single failed `Lock.Refresh` cancels immediately, though the lease TTL leaves ~40 s of margin. A bounded retry inside that window is safe against split-brain (the key is create-only until TTL purge) but buys ~25 s — enough for an election blip, not for a 27-minute outage. Reaching that horizon means raising the lease TTL, which symmetrically raises crash-recovery latency. Deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)