### PR TITLE
fix(runview): merge is an owned, claimed state machine — no more double-squash between replicas

### DIFF
--- a/pkg/git/repohost.go
+++ b/pkg/git/repohost.go
@@ -1,0 +1,39 @@
+package git
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// RepoHost extracts the host from a git remote URL in either of the
+// two forms git accepts: a scheme URL (https://host/path,
+// ssh://user@host/path) or the scp-like shorthand ([user@]host:path).
+// Case-insensitive callers should compare the result with EqualFold.
+func RepoHost(repoURL string) (string, error) {
+	s := strings.TrimSpace(repoURL)
+	if i := strings.Index(s, "://"); i >= 0 {
+		u, err := url.Parse(s)
+		if err != nil {
+			return "", fmt.Errorf("parse: %w", err)
+		}
+		host := u.Hostname()
+		if host == "" {
+			return "", fmt.Errorf("missing host in %q", repoURL)
+		}
+		return host, nil
+	}
+	// scp-like: `[user@]host:path`.
+	colon := strings.Index(s, ":")
+	if colon <= 0 {
+		return "", fmt.Errorf("missing host in %q", repoURL)
+	}
+	host := s[:colon]
+	if at := strings.LastIndex(host, "@"); at >= 0 {
+		host = host[at+1:]
+	}
+	if host == "" {
+		return "", fmt.Errorf("missing host in %q", repoURL)
+	}
+	return host, nil
+}

--- a/pkg/runner/loop_gitws.go
+++ b/pkg/runner/loop_gitws.go
@@ -384,32 +384,10 @@ func validateRepoTarget(ctx context.Context, repoURL, repoSHA string) (net.IP, e
 // determined (defence in depth — ValidateCloneSource has already rejected
 // hostless and unsupported-transport forms above).
 func extractRepoHost(repoURL string) (string, error) {
-	s := strings.TrimSpace(repoURL)
-	if i := strings.Index(s, "://"); i >= 0 {
-		u, err := url.Parse(s)
-		if err != nil {
-			return "", fmt.Errorf("parse: %w", err)
-		}
-		host := u.Hostname()
-		if host == "" {
-			return "", fmt.Errorf("missing host in %q", repoURL)
-		}
-		return host, nil
-	}
-	// scp-like: `[user@]host:path`. ValidateCloneSource already requires
-	// the colon to come before any slash and the host to be non-empty.
-	colon := strings.Index(s, ":")
-	if colon <= 0 {
-		return "", fmt.Errorf("missing host in %q", repoURL)
-	}
-	host := s[:colon]
-	if at := strings.LastIndex(host, "@"); at >= 0 {
-		host = host[at+1:]
-	}
-	if host == "" {
-		return "", fmt.Errorf("missing host in %q", repoURL)
-	}
-	return host, nil
+	// ValidateCloneSource already requires the scp-like colon to come
+	// before any slash and the host to be non-empty; the shared helper
+	// enforces the same shape.
+	return gitlib.RepoHost(repoURL)
 }
 
 // gitOpTimeout bounds a single runner-side git subprocess. Without it a

--- a/pkg/runview/merge_claim_test.go
+++ b/pkg/runview/merge_claim_test.go
@@ -152,7 +152,7 @@ func TestPerformMerge_HeldClaimRejects(t *testing.T) {
 	st, svc, runID := seedMergeableRun(t)
 	ctx := context.Background()
 
-	claimed, prior, err := st.ClaimMerge(ctx, runID, time.Now().Add(-mergeClaimStaleAfter))
+	claimed, prior, _, err := st.ClaimMerge(ctx, runID, time.Now().Add(-mergeClaimStaleAfter))
 	if err != nil || !claimed {
 		t.Fatalf("seed claim: claimed=%v err=%v", claimed, err)
 	}
@@ -176,7 +176,7 @@ func TestPerformMerge_StaleClaimIsStolen(t *testing.T) {
 	st, svc, runID := seedMergeableRun(t)
 	ctx := context.Background()
 
-	if claimed, _, err := st.ClaimMerge(ctx, runID, time.Now().Add(-mergeClaimStaleAfter)); err != nil || !claimed {
+	if claimed, _, _, err := st.ClaimMerge(ctx, runID, time.Now().Add(-mergeClaimStaleAfter)); err != nil || !claimed {
 		t.Fatalf("seed claim: claimed=%v err=%v", claimed, err)
 	}
 	// Age the claim past the staleness bound.
@@ -248,5 +248,66 @@ func TestUpdateRunMergeIf_CannotClobberMerged(t *testing.T) {
 	r, _ := st.LoadRun(ctx, runID)
 	if r.MergeStatus != store.MergeStatusMerged || r.MergedCommit == "" {
 		t.Fatalf("merged record damaged: status=%q commit=%q", r.MergeStatus, r.MergedCommit)
+	}
+}
+
+// A run RecoverFinalize left as "skipped" stays mergeable — on main it
+// was, and refusing it would strand every recovered run.
+func TestPerformMerge_SkippedIsMergeable(t *testing.T) {
+	st, svc, runID := seedMergeableRun(t)
+	ctx := context.Background()
+
+	r, err := st.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	r.MergeStatus = store.MergeStatusSkipped
+	if err := st.SaveRun(ctx, r); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+	if _, err := svc.PerformMergeCtx(ctx, runID, MergeRequest{}); err != nil {
+		t.Fatalf("a skipped run must stay mergeable, got: %v", err)
+	}
+	r, _ = st.LoadRun(ctx, runID)
+	if r.MergeStatus != store.MergeStatusMerged {
+		t.Fatalf("MergeStatus=%q, want merged", r.MergeStatus)
+	}
+}
+
+// cancelSensitiveStore refuses merge-state writes on a dead context —
+// the behaviour of a real remote store (Mongo), which the filesystem
+// store cannot exhibit because it ignores ctx.
+type cancelSensitiveStore struct {
+	store.RunStore
+}
+
+func (c cancelSensitiveStore) UpdateRunMergeIf(ctx context.Context, id string, upd store.RunMergeUpdate, expectedFrom []store.MergeStatus) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	return c.RunStore.UpdateRunMergeIf(ctx, id, upd, expectedFrom)
+}
+
+// The merge outcome must not ride the request context: once the claim
+// is held, a client disconnect (cancelled request ctx) must neither
+// lose the outcome nor leak the claim. Against a ctx-honouring store,
+// a merge driven by an already-cancelled request still lands and
+// persists — proof the state writes are detached.
+func TestPerformMerge_OutcomeSurvivesRequestCancel(t *testing.T) {
+	st, _, runID := seedMergeableRun(t)
+
+	svc, err := NewService("", WithLogger(iterlog.Nop()), WithStore(cancelSensitiveStore{st}))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := svc.PerformMergeCtx(cancelled, runID, MergeRequest{}); err != nil {
+		t.Fatalf("merge under a cancelled request ctx must still persist, got: %v", err)
+	}
+	r, _ := st.LoadRun(context.Background(), runID)
+	if r.MergeStatus != store.MergeStatusMerged {
+		t.Fatalf("MergeStatus=%q, want merged (outcome lost to the request ctx)", r.MergeStatus)
 	}
 }

--- a/pkg/runview/merge_claim_test.go
+++ b/pkg/runview/merge_claim_test.go
@@ -1,0 +1,252 @@
+package runview
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// seedMergeableRun builds a real repo whose storage branch squashes
+// cleanly onto main, plus a run record pointing at it. Returns the
+// store, the service and the run id.
+func seedMergeableRun(t *testing.T) (*store.FilesystemRunStore, *Service, string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	dir := t.TempDir()
+	storeDir := filepath.Join(dir, "store")
+	repoDir := filepath.Join(dir, "repo")
+
+	logger := iterlog.Nop()
+	st, err := store.New(storeDir, store.WithLogger(logger))
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t.t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t.t",
+			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+			"LC_ALL=C",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\noutput: %s", args, err, string(out))
+		}
+	}
+	write := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(repoDir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	runGit("init", "-q", "-b", "main")
+	runGit("config", "user.email", "t@t.t")
+	runGit("config", "user.name", "t")
+	runGit("config", "commit.gpgsign", "false")
+	write("file.txt", "alpha\n")
+	runGit("add", "file.txt")
+	runGit("commit", "-qm", "base")
+	baseSHA := strings.TrimSpace(captureGitOutput(t, repoDir, "rev-parse", "HEAD"))
+
+	runGit("checkout", "-qb", "iterion/run/claim-test")
+	write("file.txt", "alpha\nbravo\n")
+	runGit("commit", "-qam", "feat")
+	storageSHA := strings.TrimSpace(captureGitOutput(t, repoDir, "rev-parse", "HEAD"))
+	runGit("checkout", "-q", "main")
+
+	ctx := context.Background()
+	runID := "run-claim-test"
+	if _, err := st.CreateRun(ctx, runID, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	r, err := st.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	r.Worktree = true
+	r.RepoRoot = repoDir
+	r.WorkDir = repoDir
+	r.BaseCommit = baseSHA
+	r.FinalCommit = storageSHA
+	r.FinalBranch = "iterion/run/claim-test"
+	r.Status = store.RunStatusFinished
+	r.MergeStrategy = store.MergeStrategySquash
+	if err := st.SaveRun(ctx, r); err != nil {
+		t.Fatalf("SaveRun seed: %v", err)
+	}
+
+	svc, err := NewService(storeDir, WithLogger(logger))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return st, svc, runID
+}
+
+// Two concurrent PerformMergeCtx calls on the same run: exactly one
+// wins; the loser is rejected AT THE CLAIM (or sees "already merged"),
+// and the persisted record carries the winner's outcome. Before the
+// claim existed this was the measured double-squash TOCTOU: both
+// callers passed the merged-check, both built a squash, and the loser
+// overwrote the winner's "merged" with "failed".
+func TestPerformMerge_ConcurrentClaims(t *testing.T) {
+	st, svc, runID := seedMergeableRun(t)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = svc.PerformMergeCtx(ctx, runID, MergeRequest{})
+		}(i)
+	}
+	wg.Wait()
+
+	okCount := 0
+	for _, e := range errs {
+		if e == nil {
+			okCount++
+			continue
+		}
+		msg := e.Error()
+		if !strings.Contains(msg, "merge in progress") && !strings.Contains(msg, "already merged") {
+			t.Errorf("loser error should be a claim rejection, got: %v", e)
+		}
+	}
+	if okCount != 1 {
+		t.Fatalf("exactly one merge must win, got %d (errs: %v)", okCount, errs)
+	}
+
+	r, err := st.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.MergeStatus != store.MergeStatusMerged {
+		t.Fatalf("MergeStatus=%q, want merged — the loser overwrote the winner", r.MergeStatus)
+	}
+	if r.MergedCommit == "" || r.MergedInto != "main" {
+		t.Fatalf("merged bookkeeping incomplete: commit=%q into=%q", r.MergedCommit, r.MergedInto)
+	}
+}
+
+// A fresh "merging" claim held by someone else rejects the caller
+// without touching git or the record.
+func TestPerformMerge_HeldClaimRejects(t *testing.T) {
+	st, svc, runID := seedMergeableRun(t)
+	ctx := context.Background()
+
+	claimed, prior, err := st.ClaimMerge(ctx, runID, time.Now().Add(-mergeClaimStaleAfter))
+	if err != nil || !claimed {
+		t.Fatalf("seed claim: claimed=%v err=%v", claimed, err)
+	}
+	if prior != "" {
+		t.Fatalf("prior=%q, want empty (never merged)", prior)
+	}
+
+	_, mergeErr := svc.PerformMergeCtx(ctx, runID, MergeRequest{})
+	if mergeErr == nil || !strings.Contains(mergeErr.Error(), "merge in progress") {
+		t.Fatalf("want claim rejection, got: %v", mergeErr)
+	}
+	r, _ := st.LoadRun(ctx, runID)
+	if r.MergeStatus != store.MergeStatusMerging {
+		t.Fatalf("MergeStatus=%q, want merging untouched", r.MergeStatus)
+	}
+}
+
+// A stale "merging" (the previous claimant crashed mid-merge) does not
+// wedge the run: the next caller steals the claim and completes.
+func TestPerformMerge_StaleClaimIsStolen(t *testing.T) {
+	st, svc, runID := seedMergeableRun(t)
+	ctx := context.Background()
+
+	if claimed, _, err := st.ClaimMerge(ctx, runID, time.Now().Add(-mergeClaimStaleAfter)); err != nil || !claimed {
+		t.Fatalf("seed claim: claimed=%v err=%v", claimed, err)
+	}
+	// Age the claim past the staleness bound.
+	r, err := st.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	r.MergeClaimedAt = time.Now().Add(-mergeClaimStaleAfter - time.Minute)
+	if err := st.SaveRun(ctx, r); err != nil {
+		t.Fatalf("SaveRun age claim: %v", err)
+	}
+
+	if _, err := svc.PerformMergeCtx(ctx, runID, MergeRequest{}); err != nil {
+		t.Fatalf("stale claim must be stealable, got: %v", err)
+	}
+	r, _ = st.LoadRun(ctx, runID)
+	if r.MergeStatus != store.MergeStatusMerged {
+		t.Fatalf("MergeStatus=%q, want merged", r.MergeStatus)
+	}
+}
+
+// An attempt that dies before any outcome (unresolvable repo root)
+// releases the claim and restores the pre-claim state — the run does
+// not stay wedged in "merging".
+func TestPerformMerge_EarlyErrorReleasesClaim(t *testing.T) {
+	st, svc, runID := seedMergeableRun(t)
+	ctx := context.Background()
+
+	r, err := st.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	r.RepoRoot = ""
+	r.WorkDir = filepath.Join(t.TempDir(), "gone")
+	r.MergeStatus = store.MergeStatusPending
+	if err := st.SaveRun(ctx, r); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+
+	_, mergeErr := svc.PerformMergeCtx(ctx, runID, MergeRequest{})
+	if mergeErr == nil || !strings.Contains(mergeErr.Error(), "no resolvable repo root") {
+		t.Fatalf("want repo-root error, got: %v", mergeErr)
+	}
+	r, _ = st.LoadRun(ctx, runID)
+	if r.MergeStatus != store.MergeStatusPending {
+		t.Fatalf("MergeStatus=%q, want pending restored (claim released)", r.MergeStatus)
+	}
+}
+
+// Once "merged" is persisted, no conditional writer expecting an
+// in-flight state can clobber it — the exact overwrite the TOCTOU
+// allowed (loser persisting "failed" over the winner's "merged").
+func TestUpdateRunMergeIf_CannotClobberMerged(t *testing.T) {
+	st, svc, runID := seedMergeableRun(t)
+	ctx := context.Background()
+
+	if _, err := svc.PerformMergeCtx(ctx, runID, MergeRequest{}); err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	changed, err := st.UpdateRunMergeIf(ctx, runID,
+		store.RunMergeUpdate{Status: store.MergeStatusFailed},
+		[]store.MergeStatus{store.MergeStatusMerging})
+	if err != nil {
+		t.Fatalf("UpdateRunMergeIf: %v", err)
+	}
+	if changed {
+		t.Fatal("a writer expecting 'merging' must not overwrite 'merged'")
+	}
+	r, _ := st.LoadRun(ctx, runID)
+	if r.MergeStatus != store.MergeStatusMerged || r.MergedCommit == "" {
+		t.Fatalf("merged record damaged: status=%q commit=%q", r.MergeStatus, r.MergedCommit)
+	}
+}

--- a/pkg/runview/service_control.go
+++ b/pkg/runview/service_control.go
@@ -364,7 +364,7 @@ func (s *Service) PerformMergeCtx(ctx context.Context, runID string, req MergeRe
 	// build a squash for the same run — the loser stops HERE, before
 	// any clone or push. The claim is released on every early exit and
 	// consumed by exactly one conditional persist below.
-	claimed, prior, err := s.store.ClaimMerge(ctx, runID, time.Now().Add(-mergeClaimStaleAfter))
+	claimed, prior, claimToken, err := s.store.ClaimMerge(ctx, runID, time.Now().Add(-mergeClaimStaleAfter))
 	if err != nil {
 		return nil, err
 	}
@@ -378,6 +378,12 @@ func (s *Service) PerformMergeCtx(ctx context.Context, runID string, req MergeRe
 			return nil, fmt.Errorf("run %q is not mergeable from merge_status=%q", runID, prior)
 		}
 	}
+	// Merge-state writes ride a context detached from the request: once
+	// the claim is held (and a fortiori once git has run), a client
+	// disconnect or ingress timeout must not be able to leak the claim
+	// or lose the outcome — a cancelled release would wedge the run in
+	// "merging" for the whole staleness window.
+	wctx := context.WithoutCancel(ctx)
 	r.MergeStatus = store.MergeStatusMerging
 	// Until an outcome is persisted, every exit restores the pre-claim
 	// state so an aborted attempt (bad token, unreachable repo) leaves
@@ -395,7 +401,8 @@ func (s *Service) PerformMergeCtx(ctx context.Context, runID string, req MergeRe
 		}
 		upd := mergeUpdateFromRun(r)
 		upd.Status = restoreTo
-		if changed, rerr := s.store.UpdateRunMergeIf(ctx, runID, upd, []store.MergeStatus{store.MergeStatusMerging}); rerr != nil || !changed {
+		upd.ExpectClaimedAt = claimToken
+		if changed, rerr := s.store.UpdateRunMergeIf(wctx, runID, upd, []store.MergeStatus{store.MergeStatusMerging}); rerr != nil || !changed {
 			if s.logger != nil {
 				s.logger.Warn("runview: release merge claim for %s (restore to %q): changed=%v err=%v", runID, restoreTo, changed, rerr)
 			}
@@ -427,7 +434,7 @@ func (s *Service) PerformMergeCtx(ctx context.Context, runID string, req MergeRe
 	// outside the studio), there's nothing to squash — a redundant squash
 	// would just build a confusing empty commit. Reconcile to "merged" and
 	// return a no-op success instead.
-	if ok, rcErr := s.reconcileOutOfBandMerge(ctx, r, repoRoot, resolveMergeTargetForPersistence(req.MergeInto, repoRoot), []store.MergeStatus{store.MergeStatusMerging}); rcErr != nil {
+	if ok, rcErr := s.reconcileOutOfBandMergeClaimed(wctx, r, repoRoot, resolveMergeTargetForPersistence(req.MergeInto, repoRoot), claimToken); rcErr != nil {
 		return nil, rcErr
 	} else if ok {
 		persisted = true
@@ -473,18 +480,30 @@ func (s *Service) PerformMergeCtx(ctx context.Context, runID string, req MergeRe
 			r.MergeStrategy = store.MergeStrategySquash
 			r.PendingMergeMessage = message
 			r.PendingMergeInto = resolveMergeTargetForPersistence(req.MergeInto, repoRoot)
-			if changed, saveErr := s.store.UpdateRunMergeIf(ctx, runID, mergeUpdateFromRun(r), []store.MergeStatus{store.MergeStatusMerging}); (saveErr != nil || !changed) && s.logger != nil {
-				s.logger.Warn("runview: persist merge conflict for %s: changed=%v err=%v", runID, changed, saveErr)
+			upd := mergeUpdateFromRun(r)
+			upd.ExpectClaimedAt = claimToken
+			changed, saveErr := s.store.UpdateRunMergeIf(wctx, runID, upd, []store.MergeStatus{store.MergeStatusMerging})
+			if saveErr != nil || !changed {
+				if s.logger != nil {
+					s.logger.Warn("runview: persist merge conflict for %s: changed=%v err=%v", runID, changed, saveErr)
+				}
+			} else {
+				persisted = true
 			}
-			persisted = true
 			return nil, mergeErr
 		}
 		// Persist the failure so the studio can show "Retry merge".
 		r.MergeStatus = store.MergeStatusFailed
-		if changed, saveErr := s.store.UpdateRunMergeIf(ctx, runID, mergeUpdateFromRun(r), []store.MergeStatus{store.MergeStatusMerging}); (saveErr != nil || !changed) && s.logger != nil {
-			s.logger.Warn("runview: persist merge failure for %s: changed=%v err=%v", runID, changed, saveErr)
+		upd := mergeUpdateFromRun(r)
+		upd.ExpectClaimedAt = claimToken
+		changed, saveErr := s.store.UpdateRunMergeIf(wctx, runID, upd, []store.MergeStatus{store.MergeStatusMerging})
+		if saveErr != nil || !changed {
+			if s.logger != nil {
+				s.logger.Warn("runview: persist merge failure for %s: changed=%v err=%v", runID, changed, saveErr)
+			}
+		} else {
+			persisted = true
 		}
-		persisted = true
 		return nil, mergeErr
 	}
 
@@ -493,15 +512,21 @@ func (s *Service) PerformMergeCtx(ctx context.Context, runID string, req MergeRe
 	if remote {
 		if pushErr := s.pushRepoTargetedMerge(ctx, repoRoot, token, res.MergedInto); pushErr != nil {
 			r.MergeStatus = store.MergeStatusFailed
-			if changed, saveErr := s.store.UpdateRunMergeIf(ctx, runID, mergeUpdateFromRun(r), []store.MergeStatus{store.MergeStatusMerging}); (saveErr != nil || !changed) && s.logger != nil {
-				s.logger.Warn("runview: persist merge failure for %s: changed=%v err=%v", runID, changed, saveErr)
+			upd := mergeUpdateFromRun(r)
+			upd.ExpectClaimedAt = claimToken
+			changed, saveErr := s.store.UpdateRunMergeIf(wctx, runID, upd, []store.MergeStatus{store.MergeStatusMerging})
+			if saveErr != nil || !changed {
+				if s.logger != nil {
+					s.logger.Warn("runview: persist merge failure for %s: changed=%v err=%v", runID, changed, saveErr)
+				}
+			} else {
+				persisted = true
 			}
-			persisted = true
 			return nil, fmt.Errorf("merged in the server-side clone but the push failed — %s does NOT carry the merge: %w", res.MergedInto, pushErr)
 		}
 	}
 	persisted = true
-	resp, err := s.persistMergeSuccess(ctx, r, res.MergedCommit, res.MergedInto, store.MergeStrategy(res.Strategy), []store.MergeStatus{store.MergeStatusMerging})
+	resp, err := s.persistMergeSuccess(wctx, r, res.MergedCommit, res.MergedInto, store.MergeStrategy(res.Strategy), []store.MergeStatus{store.MergeStatusMerging}, claimToken)
 	if err == nil && remote {
 		s.removeRepoTargetedMergeRoot(r.ID)
 	}
@@ -517,7 +542,17 @@ func (s *Service) PerformMergeCtx(ctx context.Context, runID string, req MergeRe
 // it reconciled, (false, nil) when there's nothing to do, and
 // (false, err) when the persist failed — the caller decides whether
 // that is fatal (PerformMerge) or best-effort (snapshot read).
+// reconcileOutOfBandMergeClaimed is the under-claim variant: the exit
+// is scoped to the caller's claim token.
+func (s *Service) reconcileOutOfBandMergeClaimed(ctx context.Context, r *store.Run, repoRoot, target string, claimToken time.Time) (bool, error) {
+	return s.reconcileOutOfBand(ctx, r, repoRoot, target, []store.MergeStatus{store.MergeStatusMerging}, claimToken)
+}
+
 func (s *Service) reconcileOutOfBandMerge(ctx context.Context, r *store.Run, repoRoot, target string, expectedFrom []store.MergeStatus) (bool, error) {
+	return s.reconcileOutOfBand(ctx, r, repoRoot, target, expectedFrom, time.Time{})
+}
+
+func (s *Service) reconcileOutOfBand(ctx context.Context, r *store.Run, repoRoot, target string, expectedFrom []store.MergeStatus, claimToken time.Time) (bool, error) {
 	if r == nil || r.FinalCommit == "" {
 		return false, nil
 	}
@@ -535,7 +570,9 @@ func (s *Service) reconcileOutOfBandMerge(ctx context.Context, r *store.Run, rep
 	r.MergeStatus = store.MergeStatusMerged
 	r.PendingMergeMessage = ""
 	r.PendingMergeInto = ""
-	changed, err := s.store.UpdateRunMergeIf(ctx, r.ID, mergeUpdateFromRun(r), expectedFrom)
+	upd := mergeUpdateFromRun(r)
+	upd.ExpectClaimedAt = claimToken
+	changed, err := s.store.UpdateRunMergeIf(ctx, r.ID, upd, expectedFrom)
 	if err != nil {
 		return false, fmt.Errorf("runview: persist out-of-band merge reconcile for %s: %w", r.ID, err)
 	}
@@ -779,13 +816,13 @@ func (s *Service) FinalizeMergeAfterConflict(ctx context.Context, runID, message
 		if pushErr := s.pushRepoTargetedMerge(ctx, repoRoot, token, target); pushErr != nil {
 			return nil, fmt.Errorf("conflict resolved and committed in the server-side clone but the push failed — %s does NOT carry the merge: %w", target, pushErr)
 		}
-		resp, perr := s.persistMergeSuccess(ctx, r, sha, target, store.MergeStrategySquash, []store.MergeStatus{store.MergeStatusConflicted})
+		resp, perr := s.persistMergeSuccess(ctx, r, sha, target, store.MergeStrategySquash, []store.MergeStatus{store.MergeStatusConflicted}, time.Time{})
 		if perr == nil {
 			s.removeRepoTargetedMergeRoot(r.ID)
 		}
 		return resp, perr
 	}
-	return s.persistMergeSuccess(ctx, r, sha, target, store.MergeStrategySquash, []store.MergeStatus{store.MergeStatusConflicted})
+	return s.persistMergeSuccess(ctx, r, sha, target, store.MergeStrategySquash, []store.MergeStatus{store.MergeStatusConflicted}, time.Time{})
 }
 
 // AbortMergeConflict discards the in-progress squash merge: runs
@@ -805,15 +842,19 @@ func (s *Service) AbortMergeConflict(ctx context.Context, runID string) error {
 	r.MergeStatus = store.MergeStatusFailed
 	r.PendingMergeMessage = ""
 	r.PendingMergeInto = ""
-	if changed, err := s.store.UpdateRunMergeIf(ctx, r.ID, mergeUpdateFromRun(r), []store.MergeStatus{store.MergeStatusConflicted}); err != nil {
-		return fmt.Errorf("runview: persist abort: %w", err)
-	} else if !changed {
-		return fmt.Errorf("runview: abort merge for %s: merge state changed concurrently — nothing aborted", r.ID)
-	}
+	changed, err := s.store.UpdateRunMergeIf(ctx, r.ID, mergeUpdateFromRun(r), []store.MergeStatus{store.MergeStatusConflicted})
 	if mergeRepoRoot(r) == "" && r.RepoURL != "" {
 		// Repo-targeted run: the server-side clone is disposable — drop
-		// it so a retried merge starts from a fresh checkout.
+		// it so a retried merge starts from a fresh checkout. Done even
+		// when the CAS below lost: `git reset --merge` already ran, the
+		// clone no longer matches any persisted state.
 		s.removeRepoTargetedMergeRoot(r.ID)
+	}
+	if err != nil {
+		return fmt.Errorf("runview: persist abort: %w", err)
+	}
+	if !changed {
+		return fmt.Errorf("runview: abort merge for %s: merge state changed concurrently — nothing aborted", r.ID)
 	}
 	return nil
 }
@@ -873,14 +914,16 @@ func requireConflict(r *store.Run, runID string) error {
 // uses res.MergedInto from the runtime call; Finalize defaults
 // PendingMergeInto / current-branch). Strategy is supplied as a
 // pre-typed MergeStatus so this helper does no coercion.
-func (s *Service) persistMergeSuccess(ctx context.Context, r *store.Run, sha, target string, strategy store.MergeStrategy, expectedFrom []store.MergeStatus) (*MergeResponse, error) {
+func (s *Service) persistMergeSuccess(ctx context.Context, r *store.Run, sha, target string, strategy store.MergeStrategy, expectedFrom []store.MergeStatus, claimToken time.Time) (*MergeResponse, error) {
 	r.MergedCommit = sha
 	r.MergedInto = target
 	r.MergeStrategy = strategy
 	r.MergeStatus = store.MergeStatusMerged
 	r.PendingMergeMessage = ""
 	r.PendingMergeInto = ""
-	changed, err := s.store.UpdateRunMergeIf(ctx, r.ID, mergeUpdateFromRun(r), expectedFrom)
+	upd := mergeUpdateFromRun(r)
+	upd.ExpectClaimedAt = claimToken
+	changed, err := s.store.UpdateRunMergeIf(ctx, r.ID, upd, expectedFrom)
 	if err != nil {
 		return nil, fmt.Errorf("runview: persist merge result: %w", err)
 	}
@@ -890,7 +933,7 @@ func (s *Service) persistMergeSuccess(ctx context.Context, r *store.Run, sha, ta
 		// Do NOT overwrite: the next merge attempt reconciles via the
 		// out-of-band ancestry check. Surface the split-brain instead
 		// of hiding it.
-		return nil, fmt.Errorf("runview: merge of %s landed on %s at %s but the run record changed concurrently — record NOT updated (a later attempt reconciles via ancestry)", r.ID, target, sha)
+		return nil, fmt.Errorf("runview: merge of %s landed on %s at %s but the run record changed concurrently — record NOT updated (a retried merge heals the record — re-squashing an already-squashed branch is a no-op)", r.ID, target, sha)
 	}
 	return &MergeResponse{
 		MergedCommit:  r.MergedCommit,

--- a/pkg/runview/service_control.go
+++ b/pkg/runview/service_control.go
@@ -308,6 +308,28 @@ type MergeResponse struct {
 	SourceIssueID string `json:"-"`
 }
 
+// mergeClaimStaleAfter bounds how long a merge claim protects its
+// holder: a "merging" older than this is up for grabs (the claimant
+// crashed mid-merge — a wedged claim must not block the run forever).
+// Generous vs the per-command git timeouts (120s) plus a server-side
+// clone of a large repo.
+const mergeClaimStaleAfter = 15 * time.Minute
+
+// mergeUpdateFromRun snapshots r's current merge bookkeeping into a
+// RunMergeUpdate, so a transition writes the fields it changes and
+// carries the rest unchanged (the same shape a full SaveRun of the
+// mutated r would have produced).
+func mergeUpdateFromRun(r *store.Run) store.RunMergeUpdate {
+	return store.RunMergeUpdate{
+		Status:              r.MergeStatus,
+		MergedCommit:        r.MergedCommit,
+		MergedInto:          r.MergedInto,
+		MergeStrategy:       r.MergeStrategy,
+		PendingMergeMessage: r.PendingMergeMessage,
+		PendingMergeInto:    r.PendingMergeInto,
+	}
+}
+
 // PerformMerge runs the deferred merge for runID. Preconditions:
 //   - run.FinalCommit and run.FinalBranch must be set (the engine must
 //     have created the storage branch — runs without commits cannot be
@@ -336,6 +358,50 @@ func (s *Service) PerformMergeCtx(ctx context.Context, runID string, req MergeRe
 	if r.MergeStatus == store.MergeStatusMerged {
 		return nil, fmt.Errorf("run %q is already merged into %q at %s", runID, r.MergedInto, r.MergedCommit)
 	}
+
+	// Claim the merge before touching git: a compare-and-set to
+	// "merging", so two replicas (or two operator clicks) cannot both
+	// build a squash for the same run — the loser stops HERE, before
+	// any clone or push. The claim is released on every early exit and
+	// consumed by exactly one conditional persist below.
+	claimed, prior, err := s.store.ClaimMerge(ctx, runID, time.Now().Add(-mergeClaimStaleAfter))
+	if err != nil {
+		return nil, err
+	}
+	if !claimed {
+		switch prior {
+		case store.MergeStatusMerged:
+			return nil, fmt.Errorf("run %q is already merged", runID)
+		case store.MergeStatusMerging:
+			return nil, fmt.Errorf("run %q has a merge in progress (claimed by another worker) — retry after it finishes", runID)
+		default:
+			return nil, fmt.Errorf("run %q is not mergeable from merge_status=%q", runID, prior)
+		}
+	}
+	r.MergeStatus = store.MergeStatusMerging
+	// Until an outcome is persisted, every exit restores the pre-claim
+	// state so an aborted attempt (bad token, unreachable repo) leaves
+	// the run exactly as found. A stale claim we stole restores to
+	// "failed", not back to "merging" — re-wedging it would hide the
+	// crash for another staleness window.
+	restoreTo := prior
+	if restoreTo == store.MergeStatusMerging {
+		restoreTo = store.MergeStatusFailed
+	}
+	persisted := false
+	defer func() {
+		if persisted {
+			return
+		}
+		upd := mergeUpdateFromRun(r)
+		upd.Status = restoreTo
+		if changed, rerr := s.store.UpdateRunMergeIf(ctx, runID, upd, []store.MergeStatus{store.MergeStatusMerging}); rerr != nil || !changed {
+			if s.logger != nil {
+				s.logger.Warn("runview: release merge claim for %s (restore to %q): changed=%v err=%v", runID, restoreTo, changed, rerr)
+			}
+		}
+	}()
+
 	repoRoot := mergeRepoRoot(r)
 	remote := repoRoot == "" && r.RepoURL != ""
 	token := ""
@@ -361,9 +427,10 @@ func (s *Service) PerformMergeCtx(ctx context.Context, runID string, req MergeRe
 	// outside the studio), there's nothing to squash — a redundant squash
 	// would just build a confusing empty commit. Reconcile to "merged" and
 	// return a no-op success instead.
-	if ok, rcErr := s.reconcileOutOfBandMerge(ctx, r, repoRoot, resolveMergeTargetForPersistence(req.MergeInto, repoRoot)); rcErr != nil {
+	if ok, rcErr := s.reconcileOutOfBandMerge(ctx, r, repoRoot, resolveMergeTargetForPersistence(req.MergeInto, repoRoot), []store.MergeStatus{store.MergeStatusMerging}); rcErr != nil {
 		return nil, rcErr
 	} else if ok {
+		persisted = true
 		return &MergeResponse{
 			MergedCommit:  r.MergedCommit,
 			MergedInto:    r.MergedInto,
@@ -406,16 +473,18 @@ func (s *Service) PerformMergeCtx(ctx context.Context, runID string, req MergeRe
 			r.MergeStrategy = store.MergeStrategySquash
 			r.PendingMergeMessage = message
 			r.PendingMergeInto = resolveMergeTargetForPersistence(req.MergeInto, repoRoot)
-			if saveErr := s.store.SaveRun(ctx, r); saveErr != nil && s.logger != nil {
-				s.logger.Warn("runview: persist merge conflict for %s: %v", runID, saveErr)
+			if changed, saveErr := s.store.UpdateRunMergeIf(ctx, runID, mergeUpdateFromRun(r), []store.MergeStatus{store.MergeStatusMerging}); (saveErr != nil || !changed) && s.logger != nil {
+				s.logger.Warn("runview: persist merge conflict for %s: changed=%v err=%v", runID, changed, saveErr)
 			}
+			persisted = true
 			return nil, mergeErr
 		}
 		// Persist the failure so the studio can show "Retry merge".
 		r.MergeStatus = store.MergeStatusFailed
-		if saveErr := s.store.SaveRun(ctx, r); saveErr != nil && s.logger != nil {
-			s.logger.Warn("runview: persist merge failure for %s: %v", runID, saveErr)
+		if changed, saveErr := s.store.UpdateRunMergeIf(ctx, runID, mergeUpdateFromRun(r), []store.MergeStatus{store.MergeStatusMerging}); (saveErr != nil || !changed) && s.logger != nil {
+			s.logger.Warn("runview: persist merge failure for %s: changed=%v err=%v", runID, changed, saveErr)
 		}
+		persisted = true
 		return nil, mergeErr
 	}
 
@@ -424,13 +493,15 @@ func (s *Service) PerformMergeCtx(ctx context.Context, runID string, req MergeRe
 	if remote {
 		if pushErr := s.pushRepoTargetedMerge(ctx, repoRoot, token, res.MergedInto); pushErr != nil {
 			r.MergeStatus = store.MergeStatusFailed
-			if saveErr := s.store.SaveRun(ctx, r); saveErr != nil && s.logger != nil {
-				s.logger.Warn("runview: persist merge failure for %s: %v", runID, saveErr)
+			if changed, saveErr := s.store.UpdateRunMergeIf(ctx, runID, mergeUpdateFromRun(r), []store.MergeStatus{store.MergeStatusMerging}); (saveErr != nil || !changed) && s.logger != nil {
+				s.logger.Warn("runview: persist merge failure for %s: changed=%v err=%v", runID, changed, saveErr)
 			}
+			persisted = true
 			return nil, fmt.Errorf("merged in the server-side clone but the push failed — %s does NOT carry the merge: %w", res.MergedInto, pushErr)
 		}
 	}
-	resp, err := s.persistMergeSuccess(ctx, r, res.MergedCommit, res.MergedInto, store.MergeStrategy(res.Strategy))
+	persisted = true
+	resp, err := s.persistMergeSuccess(ctx, r, res.MergedCommit, res.MergedInto, store.MergeStrategy(res.Strategy), []store.MergeStatus{store.MergeStatusMerging})
 	if err == nil && remote {
 		s.removeRepoTargetedMergeRoot(r.ID)
 	}
@@ -446,7 +517,7 @@ func (s *Service) PerformMergeCtx(ctx context.Context, runID string, req MergeRe
 // it reconciled, (false, nil) when there's nothing to do, and
 // (false, err) when the persist failed — the caller decides whether
 // that is fatal (PerformMerge) or best-effort (snapshot read).
-func (s *Service) reconcileOutOfBandMerge(ctx context.Context, r *store.Run, repoRoot, target string) (bool, error) {
+func (s *Service) reconcileOutOfBandMerge(ctx context.Context, r *store.Run, repoRoot, target string, expectedFrom []store.MergeStatus) (bool, error) {
 	if r == nil || r.FinalCommit == "" {
 		return false, nil
 	}
@@ -464,8 +535,14 @@ func (s *Service) reconcileOutOfBandMerge(ctx context.Context, r *store.Run, rep
 	r.MergeStatus = store.MergeStatusMerged
 	r.PendingMergeMessage = ""
 	r.PendingMergeInto = ""
-	if err := s.store.SaveRun(ctx, r); err != nil {
+	changed, err := s.store.UpdateRunMergeIf(ctx, r.ID, mergeUpdateFromRun(r), expectedFrom)
+	if err != nil {
 		return false, fmt.Errorf("runview: persist out-of-band merge reconcile for %s: %w", r.ID, err)
+	}
+	if !changed {
+		// Someone else moved the merge state while we were looking —
+		// their transition wins; report "nothing reconciled".
+		return false, nil
 	}
 	if s.logger != nil {
 		s.logger.Info("runview: run %s already merged out-of-band into %s (FinalCommit %s is an ancestor) — reconciled merge_status=merged", r.ID, target, r.FinalCommit)
@@ -535,8 +612,10 @@ func (s *Service) CommitAndFinalizeCtx(ctx context.Context, runID, message strin
 	// auto-FF path having landed it.)
 	if r.MergeStatus == store.MergeStatusSkipped && r.MergedInto == "" {
 		r.MergeStatus = store.MergeStatusPending
-		if err := s.store.SaveRun(ctx, r); err != nil {
+		if changed, err := s.store.UpdateRunMergeIf(ctx, r.ID, mergeUpdateFromRun(r), []store.MergeStatus{store.MergeStatusSkipped}); err != nil {
 			return nil, fmt.Errorf("runview: persist pending merge status: %w", err)
+		} else if !changed && s.logger != nil {
+			s.logger.Warn("runview: skipped→pending flip for %s lost a race — leaving the concurrent state", r.ID)
 		}
 	}
 	return &CommitAndFinalizeResponse{
@@ -700,13 +779,13 @@ func (s *Service) FinalizeMergeAfterConflict(ctx context.Context, runID, message
 		if pushErr := s.pushRepoTargetedMerge(ctx, repoRoot, token, target); pushErr != nil {
 			return nil, fmt.Errorf("conflict resolved and committed in the server-side clone but the push failed — %s does NOT carry the merge: %w", target, pushErr)
 		}
-		resp, perr := s.persistMergeSuccess(ctx, r, sha, target, store.MergeStrategySquash)
+		resp, perr := s.persistMergeSuccess(ctx, r, sha, target, store.MergeStrategySquash, []store.MergeStatus{store.MergeStatusConflicted})
 		if perr == nil {
 			s.removeRepoTargetedMergeRoot(r.ID)
 		}
 		return resp, perr
 	}
-	return s.persistMergeSuccess(ctx, r, sha, target, store.MergeStrategySquash)
+	return s.persistMergeSuccess(ctx, r, sha, target, store.MergeStrategySquash, []store.MergeStatus{store.MergeStatusConflicted})
 }
 
 // AbortMergeConflict discards the in-progress squash merge: runs
@@ -726,8 +805,10 @@ func (s *Service) AbortMergeConflict(ctx context.Context, runID string) error {
 	r.MergeStatus = store.MergeStatusFailed
 	r.PendingMergeMessage = ""
 	r.PendingMergeInto = ""
-	if err := s.store.SaveRun(ctx, r); err != nil {
+	if changed, err := s.store.UpdateRunMergeIf(ctx, r.ID, mergeUpdateFromRun(r), []store.MergeStatus{store.MergeStatusConflicted}); err != nil {
 		return fmt.Errorf("runview: persist abort: %w", err)
+	} else if !changed {
+		return fmt.Errorf("runview: abort merge for %s: merge state changed concurrently — nothing aborted", r.ID)
 	}
 	if mergeRepoRoot(r) == "" && r.RepoURL != "" {
 		// Repo-targeted run: the server-side clone is disposable — drop
@@ -792,15 +873,24 @@ func requireConflict(r *store.Run, runID string) error {
 // uses res.MergedInto from the runtime call; Finalize defaults
 // PendingMergeInto / current-branch). Strategy is supplied as a
 // pre-typed MergeStatus so this helper does no coercion.
-func (s *Service) persistMergeSuccess(ctx context.Context, r *store.Run, sha, target string, strategy store.MergeStrategy) (*MergeResponse, error) {
+func (s *Service) persistMergeSuccess(ctx context.Context, r *store.Run, sha, target string, strategy store.MergeStrategy, expectedFrom []store.MergeStatus) (*MergeResponse, error) {
 	r.MergedCommit = sha
 	r.MergedInto = target
 	r.MergeStrategy = strategy
 	r.MergeStatus = store.MergeStatusMerged
 	r.PendingMergeMessage = ""
 	r.PendingMergeInto = ""
-	if err := s.store.SaveRun(ctx, r); err != nil {
+	changed, err := s.store.UpdateRunMergeIf(ctx, r.ID, mergeUpdateFromRun(r), expectedFrom)
+	if err != nil {
 		return nil, fmt.Errorf("runview: persist merge result: %w", err)
+	}
+	if !changed {
+		// The git side of the merge landed but the run record moved
+		// concurrently (our claim was stolen, or another writer raced).
+		// Do NOT overwrite: the next merge attempt reconciles via the
+		// out-of-band ancestry check. Surface the split-brain instead
+		// of hiding it.
+		return nil, fmt.Errorf("runview: merge of %s landed on %s at %s but the run record changed concurrently — record NOT updated (a later attempt reconciles via ancestry)", r.ID, target, sha)
 	}
 	return &MergeResponse{
 		MergedCommit:  r.MergedCommit,

--- a/pkg/runview/service_control.go
+++ b/pkg/runview/service_control.go
@@ -311,9 +311,13 @@ type MergeResponse struct {
 // mergeClaimStaleAfter bounds how long a merge claim protects its
 // holder: a "merging" older than this is up for grabs (the claimant
 // crashed mid-merge — a wedged claim must not block the run forever).
-// Generous vs the per-command git timeouts (120s) plus a server-side
-// clone of a large repo.
-const mergeClaimStaleAfter = 15 * time.Minute
+// Sized with margin above the worst-case LIVE claimant: the summed
+// per-command git ceilings on the repo-targeted path (clone 120s +
+// fetch 120s + symbolic-ref 60s + squash attempts 4×60s + push 120s
+// ≈ 14 min) — a steal below that races a claimant that is merely slow,
+// and the token only protects the record, not two concurrent git
+// pushes.
+const mergeClaimStaleAfter = 30 * time.Minute
 
 // mergeUpdateFromRun snapshots r's current merge bookkeeping into a
 // RunMergeUpdate, so a transition writes the fields it changes and
@@ -565,12 +569,16 @@ func (s *Service) reconcileOutOfBand(ctx context.Context, r *store.Run, repoRoot
 	if target == "" || !gitlib.IsAncestor(repoRoot, r.FinalCommit, target) {
 		return false, nil
 	}
-	r.MergedCommit = r.FinalCommit
-	r.MergedInto = target
-	r.MergeStatus = store.MergeStatusMerged
-	r.PendingMergeMessage = ""
-	r.PendingMergeInto = ""
-	upd := mergeUpdateFromRun(r)
+	// Mutate a COPY: on a lost CAS the caller keeps using r, and phantom
+	// merged_commit/merged_into riding into its next transition would
+	// persist a failed record claiming a merge that never landed.
+	rr := *r
+	rr.MergedCommit = rr.FinalCommit
+	rr.MergedInto = target
+	rr.MergeStatus = store.MergeStatusMerged
+	rr.PendingMergeMessage = ""
+	rr.PendingMergeInto = ""
+	upd := mergeUpdateFromRun(&rr)
 	upd.ExpectClaimedAt = claimToken
 	changed, err := s.store.UpdateRunMergeIf(ctx, r.ID, upd, expectedFrom)
 	if err != nil {
@@ -581,6 +589,7 @@ func (s *Service) reconcileOutOfBand(ctx context.Context, r *store.Run, repoRoot
 		// their transition wins; report "nothing reconciled".
 		return false, nil
 	}
+	*r = rr
 	if s.logger != nil {
 		s.logger.Info("runview: run %s already merged out-of-band into %s (FinalCommit %s is an ancestor) — reconciled merge_status=merged", r.ID, target, r.FinalCommit)
 	}

--- a/pkg/runview/service_runs.go
+++ b/pkg/runview/service_runs.go
@@ -382,8 +382,10 @@ func (s *Service) SnapshotCtx(ctx context.Context, runID string) (*RunSnapshot, 
 	// is a deliberate branch-only outcome, and failed/conflicted have their
 	// own UX.
 	if r, err := s.store.LoadRun(ctx, runID); err == nil && r.MergeStatus == store.MergeStatusPending {
+		// The guard above admits only merge_status=pending, so that is
+		// the only state this CAS can exit from.
 		_, _ = s.reconcileOutOfBandMerge(ctx, r, mergeRepoRoot(r), "",
-			[]store.MergeStatus{"", store.MergeStatusPending, store.MergeStatusFailed})
+			[]store.MergeStatus{store.MergeStatusPending})
 	}
 	return BuildSnapshot(ctx, s.store, runID)
 }

--- a/pkg/runview/service_runs.go
+++ b/pkg/runview/service_runs.go
@@ -382,7 +382,8 @@ func (s *Service) SnapshotCtx(ctx context.Context, runID string) (*RunSnapshot, 
 	// is a deliberate branch-only outcome, and failed/conflicted have their
 	// own UX.
 	if r, err := s.store.LoadRun(ctx, runID); err == nil && r.MergeStatus == store.MergeStatusPending {
-		_, _ = s.reconcileOutOfBandMerge(ctx, r, mergeRepoRoot(r), "")
+		_, _ = s.reconcileOutOfBandMerge(ctx, r, mergeRepoRoot(r), "",
+			[]store.MergeStatus{"", store.MergeStatusPending, store.MergeStatusFailed})
 	}
 	return BuildSnapshot(ctx, s.store, runID)
 }

--- a/pkg/server/runs_merge.go
+++ b/pkg/server/runs_merge.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
+	"github.com/SocialGouv/iterion/pkg/forge"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/secrets"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -144,15 +147,38 @@ func (s *Server) forgeTokenForRun(ctx context.Context, r *store.Run) (string, er
 		return "", fmt.Errorf("forge integrations are not wired on this server — cannot open the run's forge token")
 	}
 	tctx := store.WithTenant(ctx, r.TenantID)
-	if conns, err := o.Connections.ListByTenant(tctx, r.TenantID); err == nil {
-		for i := range conns {
-			if conns[i].ManagedSecretID == secID {
-				// Best-effort: a mint failure keeps the stored token,
-				// which may still be live within its hour.
-				_, _ = o.EnsureManagedSecret(tctx, &conns[i], "merge")
-				break
-			}
+	conns, err := o.Connections.ListByTenant(tctx, r.TenantID)
+	if err != nil {
+		// A listing failure would silently skip the re-mint and surface
+		// later as an opaque push-auth error — fail here, with the cause.
+		return "", fmt.Errorf("list forge connections for the merge of %s: %w", r.ID, err)
+	}
+	var conn *forge.Connection
+	for i := range conns {
+		if conns[i].ManagedSecretID == secID {
+			conn = &conns[i]
+			break
 		}
+	}
+	if conn == nil {
+		// The pinned secret can outlive its connection (forge re-linked
+		// since launch) and the stored token may still be live, so this
+		// is a visible degradation, not a refusal.
+		s.logWarn("merge: no connection backs forge token secret %s (run %s) — using the stored token without re-mint", secID, r.ID)
+	} else {
+		// The token authenticates to the connection's forge host; refuse
+		// to open it for a run whose RepoURL points elsewhere (a
+		// mismatch means the run doc drifted from what launch resolved).
+		base := conn.ForgeBaseURL
+		if base == "" {
+			base = forge.DefaultBaseURL(conn.Provider)
+		}
+		if !sameForgeHost(base, r.RepoURL) {
+			return "", fmt.Errorf("run %s targets %s but its pinned forge connection authenticates to %s — refusing to open the token", r.ID, r.RepoURL, base)
+		}
+		// Best-effort: a mint failure keeps the stored token,
+		// which may still be live within its hour.
+		_, _ = o.EnsureManagedSecret(tctx, conn, "merge")
 	}
 	gs, err := o.Secrets.Get(tctx, secID)
 	if err != nil {
@@ -355,4 +381,20 @@ func (s *Server) handleAbortMergeConflict(w http.ResponseWriter, r *http.Request
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// sameForgeHost reports whether two URLs point at the same forge host
+// (case-insensitive hostname comparison; ports and paths ignored — a
+// connection's base URL is canonicalised to scheme+host at connect
+// time).
+func sameForgeHost(baseURL, repoURL string) bool {
+	b, err := url.Parse(baseURL)
+	if err != nil || b.Hostname() == "" {
+		return false
+	}
+	r, err := url.Parse(repoURL)
+	if err != nil || r.Hostname() == "" {
+		return false
+	}
+	return strings.EqualFold(b.Hostname(), r.Hostname())
 }

--- a/pkg/server/runs_merge.go
+++ b/pkg/server/runs_merge.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
+
+	gitlib "github.com/SocialGouv/iterion/pkg/git"
 
 	"github.com/SocialGouv/iterion/pkg/forge"
 	"github.com/SocialGouv/iterion/pkg/runview"
@@ -383,18 +384,19 @@ func (s *Server) handleAbortMergeConflict(w http.ResponseWriter, r *http.Request
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// sameForgeHost reports whether two URLs point at the same forge host
-// (case-insensitive hostname comparison; ports and paths ignored — a
-// connection's base URL is canonicalised to scheme+host at connect
-// time).
+// sameForgeHost reports whether two git URLs point at the same forge
+// host (case-insensitive; ports and paths ignored — a connection's
+// base URL is canonicalised to scheme+host at connect time). Uses the
+// shared extractor so the scp-like form a schedule can carry
+// ([user@]host:path) matches instead of being refused as hostless.
 func sameForgeHost(baseURL, repoURL string) bool {
-	b, err := url.Parse(baseURL)
-	if err != nil || b.Hostname() == "" {
+	b, err := gitlib.RepoHost(baseURL)
+	if err != nil {
 		return false
 	}
-	r, err := url.Parse(repoURL)
-	if err != nil || r.Hostname() == "" {
+	r, err := gitlib.RepoHost(repoURL)
+	if err != nil {
 		return false
 	}
-	return strings.EqualFold(b.Hostname(), r.Hostname())
+	return strings.EqualFold(b, r)
 }

--- a/pkg/server/runs_merge_test.go
+++ b/pkg/server/runs_merge_test.go
@@ -11,6 +11,12 @@ func TestSameForgeHost(t *testing.T) {
 		{"https://gitlab.example.com", "https://GitLab.Example.COM/group/repo.git", true},
 		{"https://gitlab.example.com", "https://gitlab.other.com/group/repo", false},
 		{"https://github.com", "https://github.com/org/repo", true},
+		// scp-like shorthand — the form schedules can carry — must
+		// match, not be refused as hostless.
+		{"https://gitlab.example.com", "git@gitlab.example.com:group/repo.git", true},
+		{"https://gitlab.example.com", "gitlab.example.com:group/repo.git", true},
+		{"https://gitlab.example.com", "git@other.example.com:group/repo.git", false},
+		{"https://gitlab.example.com", "ssh://git@gitlab.example.com/group/repo.git", true},
 		// Port differences are ignored: the connection base is
 		// canonicalised to scheme+host at connect time.
 		{"https://gitlab.example.com", "https://gitlab.example.com:443/group/repo", true},

--- a/pkg/server/runs_merge_test.go
+++ b/pkg/server/runs_merge_test.go
@@ -1,0 +1,28 @@
+package server
+
+import "testing"
+
+func TestSameForgeHost(t *testing.T) {
+	cases := []struct {
+		base, repo string
+		want       bool
+	}{
+		{"https://gitlab.example.com", "https://gitlab.example.com/group/repo", true},
+		{"https://gitlab.example.com", "https://GitLab.Example.COM/group/repo.git", true},
+		{"https://gitlab.example.com", "https://gitlab.other.com/group/repo", false},
+		{"https://github.com", "https://github.com/org/repo", true},
+		// Port differences are ignored: the connection base is
+		// canonicalised to scheme+host at connect time.
+		{"https://gitlab.example.com", "https://gitlab.example.com:443/group/repo", true},
+		// Unparseable or hostless inputs never match — the caller
+		// refuses rather than guessing.
+		{"", "https://gitlab.example.com/group/repo", false},
+		{"https://gitlab.example.com", "", false},
+		{"://bad", "https://gitlab.example.com/x", false},
+	}
+	for _, c := range cases {
+		if got := sameForgeHost(c.base, c.repo); got != c.want {
+			t.Errorf("sameForgeHost(%q, %q) = %t, want %t", c.base, c.repo, got, c.want)
+		}
+	}
+}

--- a/pkg/store/conformance_test.go
+++ b/pkg/store/conformance_test.go
@@ -323,8 +323,8 @@ func TestConformance_Filesystem(t *testing.T) {
 
 // testMergeClaimCAS drives the merge state machine at the store level:
 // the claim CAS (entry), the conditional persist (exit), the stale
-// steal, and the no-clobber-merged invariant that closes the
-// double-squash TOCTOU.
+// steal with claim-token isolation, and the no-clobber-merged
+// invariant that closes the double-squash TOCTOU.
 func testMergeClaimCAS(t *testing.T, s RunStore) {
 	t.Helper()
 	ctx := context.Background()
@@ -335,22 +335,27 @@ func testMergeClaimCAS(t *testing.T, s RunStore) {
 	notStale := time.Now().Add(-15 * time.Minute)
 
 	// Entry: an unset merge_status is claimable, prior comes back "".
-	claimed, prior, err := s.ClaimMerge(ctx, runID, notStale)
+	claimed, prior, tokenA, err := s.ClaimMerge(ctx, runID, notStale)
 	if err != nil || !claimed || prior != "" {
 		t.Fatalf("first claim = (%t, %q, %v), want (true, \"\", nil)", claimed, prior, err)
 	}
+	if tokenA.IsZero() {
+		t.Fatal("claim must return its token")
+	}
 	// A held (fresh) claim refuses the second claimant.
-	claimed, prior, err = s.ClaimMerge(ctx, runID, notStale)
+	claimed, prior, _, err = s.ClaimMerge(ctx, runID, notStale)
 	if err != nil || claimed || prior != MergeStatusMerging {
 		t.Fatalf("second claim = (%t, %q, %v), want (false, merging, nil)", claimed, prior, err)
 	}
 
-	// Exit: the holder persists the outcome conditioned on "merging".
+	// Exit: the holder persists the outcome conditioned on "merging"
+	// AND its own token.
 	changed, err := s.UpdateRunMergeIf(ctx, runID, RunMergeUpdate{
-		Status:        MergeStatusMerged,
-		MergedCommit:  "abc123",
-		MergedInto:    "main",
-		MergeStrategy: MergeStrategySquash,
+		Status:          MergeStatusMerged,
+		MergedCommit:    "abc123",
+		MergedInto:      "main",
+		MergeStrategy:   MergeStrategySquash,
+		ExpectClaimedAt: tokenA,
 	}, []MergeStatus{MergeStatusMerging})
 	if err != nil || !changed {
 		t.Fatalf("persist merged = (%t, %v), want (true, nil)", changed, err)
@@ -374,37 +379,93 @@ func testMergeClaimCAS(t *testing.T, s RunStore) {
 		t.Fatalf("merged record damaged: %+v", got)
 	}
 	// And "merged" is terminal for the claim too.
-	claimed, prior, err = s.ClaimMerge(ctx, runID, notStale)
+	claimed, prior, _, err = s.ClaimMerge(ctx, runID, notStale)
 	if err != nil || claimed || prior != MergeStatusMerged {
 		t.Fatalf("claim on merged = (%t, %q, %v), want (false, merged, nil)", claimed, prior, err)
 	}
 
 	// Stale steal: a claim whose stamp predates staleBefore is up for
-	// grabs — the previous claimant crashed mid-merge.
+	// grabs — AND the stolen-from claimant's token consumes nothing
+	// afterwards (the claim names an owner, not just a state; without
+	// the token check the crashed claimant's late failure write would
+	// overwrite the live claimant's outcome).
 	const runID2 = "run-merge-claim-stale"
 	if _, err := s.CreateRun(ctx, runID2, "wf", nil); err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
-	if claimed, _, err := s.ClaimMerge(ctx, runID2, notStale); err != nil || !claimed {
-		t.Fatalf("seed claim = (%t, %v)", claimed, err)
+	_, _, tokenOld, err := s.ClaimMerge(ctx, runID2, notStale)
+	if err != nil {
+		t.Fatalf("seed claim: %v", err)
 	}
-	if claimed, _, err := s.ClaimMerge(ctx, runID2, notStale); err != nil || claimed {
+	if claimed, _, _, err := s.ClaimMerge(ctx, runID2, notStale); err != nil || claimed {
 		t.Fatalf("fresh claim must hold, got steal (%t, %v)", claimed, err)
 	}
-	claimed, prior, err = s.ClaimMerge(ctx, runID2, time.Now().Add(time.Second))
+	claimed, prior, tokenNew, err := s.ClaimMerge(ctx, runID2, time.Now().Add(time.Second))
 	if err != nil || !claimed || prior != MergeStatusMerging {
 		t.Fatalf("stale steal = (%t, %q, %v), want (true, merging, nil)", claimed, prior, err)
+	}
+	if tokenNew.Equal(tokenOld) {
+		t.Fatal("steal must issue a fresh token")
+	}
+	changed, err = s.UpdateRunMergeIf(ctx, runID2, RunMergeUpdate{Status: MergeStatusFailed, ExpectClaimedAt: tokenOld},
+		[]MergeStatus{MergeStatusMerging})
+	if err != nil || changed {
+		t.Fatalf("stolen-from claimant's write = (%t, %v), want (false, nil)", changed, err)
+	}
+	changed, err = s.UpdateRunMergeIf(ctx, runID2, RunMergeUpdate{Status: MergeStatusMerged, MergedCommit: "def456", MergedInto: "main", ExpectClaimedAt: tokenNew},
+		[]MergeStatus{MergeStatusMerging})
+	if err != nil || !changed {
+		t.Fatalf("live claimant's write = (%t, %v), want (true, nil)", changed, err)
+	}
+
+	// A "merging" whose stamp is missing entirely (a full-document
+	// writer dropped it) is claimable — it must not wedge the run.
+	const runID3 = "run-merge-claim-nostamp"
+	if _, err := s.CreateRun(ctx, runID3, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if changed, err := s.UpdateRunMergeIf(ctx, runID3, RunMergeUpdate{Status: MergeStatusMerging},
+		[]MergeStatus{""}); err != nil || !changed {
+		t.Fatalf("seed stampless merging = (%t, %v)", changed, err)
+	}
+	claimed, _, _, err = s.ClaimMerge(ctx, runID3, notStale)
+	if err != nil || !claimed {
+		t.Fatalf("stampless merging must be claimable = (%t, %v)", claimed, err)
+	}
+
+	// skipped and conflicted stay claimable (/merge is the only path
+	// that re-materialises a lost merge clone; a recovered run lands
+	// "skipped" and must stay mergeable).
+	for _, st := range []MergeStatus{MergeStatusSkipped, MergeStatusConflicted} {
+		id := "run-merge-claim-" + string(st)
+		if _, err := s.CreateRun(ctx, id, "wf", nil); err != nil {
+			t.Fatalf("CreateRun: %v", err)
+		}
+		if changed, err := s.UpdateRunMergeIf(ctx, id, RunMergeUpdate{Status: st}, []MergeStatus{""}); err != nil || !changed {
+			t.Fatalf("seed %s = (%t, %v)", st, changed, err)
+		}
+		claimed, prior, _, err := s.ClaimMerge(ctx, id, notStale)
+		if err != nil || !claimed || prior != st {
+			t.Fatalf("claim on %s = (%t, %q, %v), want (true, %s, nil)", st, claimed, prior, err, st)
+		}
 	}
 
 	// Exit CAS with the empty status in expectedFrom matches an unset
 	// field (a run that never entered the machine).
-	const runID3 = "run-merge-claim-virgin"
-	if _, err := s.CreateRun(ctx, runID3, "wf", nil); err != nil {
+	const runID4 = "run-merge-claim-virgin"
+	if _, err := s.CreateRun(ctx, runID4, "wf", nil); err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
-	changed, err = s.UpdateRunMergeIf(ctx, runID3, RunMergeUpdate{Status: MergeStatusPending},
+	changed, err = s.UpdateRunMergeIf(ctx, runID4, RunMergeUpdate{Status: MergeStatusPending},
 		[]MergeStatus{""})
 	if err != nil || !changed {
 		t.Fatalf("empty-status CAS = (%t, %v), want (true, nil)", changed, err)
+	}
+
+	// A missing run is an ERROR, not a silent (false, nil) — a caller
+	// must be able to tell a lost race from a deleted run.
+	if _, err := s.UpdateRunMergeIf(ctx, "run-merge-claim-ghost", RunMergeUpdate{Status: MergeStatusPending},
+		[]MergeStatus{""}); err == nil {
+		t.Fatal("UpdateRunMergeIf on a missing run must error")
 	}
 }

--- a/pkg/store/conformance_test.go
+++ b/pkg/store/conformance_test.go
@@ -40,6 +40,7 @@ type conformanceOpts struct {
 func conformanceSuiteWithOpts(t *testing.T, factory runStoreFactory, opts conformanceOpts) {
 	t.Run("CreateLoadRoundTrip", func(t *testing.T) { testCreateLoad(t, factory(t), opts) })
 	t.Run("StatusTransitions", func(t *testing.T) { testStatusTransitions(t, factory(t)) })
+	t.Run("MergeClaimCAS", func(t *testing.T) { testMergeClaimCAS(t, factory(t)) })
 	t.Run("EventSeqMonotone", func(t *testing.T) { testEventSeqMonotone(t, factory(t)) })
 	t.Run("EventSeqUnderConcurrency", func(t *testing.T) { testEventSeqConcurrent(t, factory(t)) })
 	t.Run("ArtifactVersionsMonotone", func(t *testing.T) { testArtifactVersions(t, factory(t)) })
@@ -318,4 +319,92 @@ func TestConformance_Filesystem(t *testing.T) {
 		}
 		return s
 	})
+}
+
+// testMergeClaimCAS drives the merge state machine at the store level:
+// the claim CAS (entry), the conditional persist (exit), the stale
+// steal, and the no-clobber-merged invariant that closes the
+// double-squash TOCTOU.
+func testMergeClaimCAS(t *testing.T, s RunStore) {
+	t.Helper()
+	ctx := context.Background()
+	const runID = "run-merge-claim"
+	if _, err := s.CreateRun(ctx, runID, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	notStale := time.Now().Add(-15 * time.Minute)
+
+	// Entry: an unset merge_status is claimable, prior comes back "".
+	claimed, prior, err := s.ClaimMerge(ctx, runID, notStale)
+	if err != nil || !claimed || prior != "" {
+		t.Fatalf("first claim = (%t, %q, %v), want (true, \"\", nil)", claimed, prior, err)
+	}
+	// A held (fresh) claim refuses the second claimant.
+	claimed, prior, err = s.ClaimMerge(ctx, runID, notStale)
+	if err != nil || claimed || prior != MergeStatusMerging {
+		t.Fatalf("second claim = (%t, %q, %v), want (false, merging, nil)", claimed, prior, err)
+	}
+
+	// Exit: the holder persists the outcome conditioned on "merging".
+	changed, err := s.UpdateRunMergeIf(ctx, runID, RunMergeUpdate{
+		Status:        MergeStatusMerged,
+		MergedCommit:  "abc123",
+		MergedInto:    "main",
+		MergeStrategy: MergeStrategySquash,
+	}, []MergeStatus{MergeStatusMerging})
+	if err != nil || !changed {
+		t.Fatalf("persist merged = (%t, %v), want (true, nil)", changed, err)
+	}
+	r, err := s.LoadRun(ctx, runID)
+	if err != nil || r.MergeStatus != MergeStatusMerged || r.MergedCommit != "abc123" || r.MergedInto != "main" {
+		t.Fatalf("merged bookkeeping = %+v (%v)", r, err)
+	}
+	if !r.MergeClaimedAt.IsZero() {
+		t.Errorf("MergeClaimedAt should be cleared by the exit write, got %v", r.MergeClaimedAt)
+	}
+
+	// No-clobber: a late writer still expecting "merging" (the loser of
+	// a race, or a stolen-claim holder) cannot overwrite "merged".
+	changed, err = s.UpdateRunMergeIf(ctx, runID, RunMergeUpdate{Status: MergeStatusFailed},
+		[]MergeStatus{MergeStatusMerging})
+	if err != nil || changed {
+		t.Fatalf("clobber attempt = (%t, %v), want (false, nil)", changed, err)
+	}
+	if got, _ := s.LoadRun(ctx, runID); got.MergeStatus != MergeStatusMerged || got.MergedCommit != "abc123" {
+		t.Fatalf("merged record damaged: %+v", got)
+	}
+	// And "merged" is terminal for the claim too.
+	claimed, prior, err = s.ClaimMerge(ctx, runID, notStale)
+	if err != nil || claimed || prior != MergeStatusMerged {
+		t.Fatalf("claim on merged = (%t, %q, %v), want (false, merged, nil)", claimed, prior, err)
+	}
+
+	// Stale steal: a claim whose stamp predates staleBefore is up for
+	// grabs — the previous claimant crashed mid-merge.
+	const runID2 = "run-merge-claim-stale"
+	if _, err := s.CreateRun(ctx, runID2, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if claimed, _, err := s.ClaimMerge(ctx, runID2, notStale); err != nil || !claimed {
+		t.Fatalf("seed claim = (%t, %v)", claimed, err)
+	}
+	if claimed, _, err := s.ClaimMerge(ctx, runID2, notStale); err != nil || claimed {
+		t.Fatalf("fresh claim must hold, got steal (%t, %v)", claimed, err)
+	}
+	claimed, prior, err = s.ClaimMerge(ctx, runID2, time.Now().Add(time.Second))
+	if err != nil || !claimed || prior != MergeStatusMerging {
+		t.Fatalf("stale steal = (%t, %q, %v), want (true, merging, nil)", claimed, prior, err)
+	}
+
+	// Exit CAS with the empty status in expectedFrom matches an unset
+	// field (a run that never entered the machine).
+	const runID3 = "run-merge-claim-virgin"
+	if _, err := s.CreateRun(ctx, runID3, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	changed, err = s.UpdateRunMergeIf(ctx, runID3, RunMergeUpdate{Status: MergeStatusPending},
+		[]MergeStatus{""})
+	if err != nil || !changed {
+		t.Fatalf("empty-status CAS = (%t, %v), want (true, nil)", changed, err)
+	}
 }

--- a/pkg/store/iface.go
+++ b/pkg/store/iface.go
@@ -134,13 +134,16 @@ type RunStore interface {
 	// ClaimMerge is the compare-and-set entry to the merge state
 	// machine: it flips MergeStatus to "merging" and stamps
 	// MergeClaimedAt, iff the current status is claimable — "",
-	// "pending" or "failed", or a "merging" whose MergeClaimedAt is
-	// before staleBefore (the previous claimant crashed; a wedged claim
-	// must not block the run forever). Returns the status the run held
-	// before the claim so an aborted attempt can restore it, and
-	// claimed=false (with the current status) when someone else holds
-	// the claim or the run is already merged/skipped/conflicted.
-	ClaimMerge(ctx context.Context, id string, staleBefore time.Time) (claimed bool, prior MergeStatus, err error)
+	// "pending", "failed", "skipped" or "conflicted", or a "merging"
+	// whose MergeClaimedAt is before staleBefore or unset (the previous
+	// claimant crashed; a wedged claim must not block the run forever).
+	// Returns the status the run held before the claim so an aborted
+	// attempt can restore it, plus the claim token (the exact
+	// MergeClaimedAt stamp written — pass it as ExpectClaimedAt on
+	// every exit so a stolen claim cannot consume its successor's), and
+	// claimed=false (with the current status) when someone else holds a
+	// fresh claim or the run is already merged.
+	ClaimMerge(ctx context.Context, id string, staleBefore time.Time) (claimed bool, prior MergeStatus, claimToken time.Time, err error)
 	// UpdateRunMergeIf is the compare-and-set exit from the merge state
 	// machine: it persists upd's merge fields iff the current
 	// MergeStatus is in expectedFrom (empty string matches an unset

--- a/pkg/store/iface.go
+++ b/pkg/store/iface.go
@@ -131,6 +131,23 @@ type RunStore interface {
 	// cloud publisher to avoid stomping on raced state transitions.
 	UpdateRunStatusIf(ctx context.Context, id string, status RunStatus, runErr string, expectedFrom []RunStatus) (changed bool, err error)
 	UpdateRunStatusIfCoded(ctx context.Context, id string, status RunStatus, runErr string, code FailureCode, expectedFrom []RunStatus) (changed bool, err error)
+	// ClaimMerge is the compare-and-set entry to the merge state
+	// machine: it flips MergeStatus to "merging" and stamps
+	// MergeClaimedAt, iff the current status is claimable — "",
+	// "pending" or "failed", or a "merging" whose MergeClaimedAt is
+	// before staleBefore (the previous claimant crashed; a wedged claim
+	// must not block the run forever). Returns the status the run held
+	// before the claim so an aborted attempt can restore it, and
+	// claimed=false (with the current status) when someone else holds
+	// the claim or the run is already merged/skipped/conflicted.
+	ClaimMerge(ctx context.Context, id string, staleBefore time.Time) (claimed bool, prior MergeStatus, err error)
+	// UpdateRunMergeIf is the compare-and-set exit from the merge state
+	// machine: it persists upd's merge fields iff the current
+	// MergeStatus is in expectedFrom (empty string matches an unset
+	// field). Returns changed=false when the state drifted — the caller
+	// lost its claim or raced another writer — in which case nothing
+	// was written.
+	UpdateRunMergeIf(ctx context.Context, id string, upd RunMergeUpdate, expectedFrom []MergeStatus) (changed bool, err error)
 	SaveCheckpoint(ctx context.Context, id string, cp *Checkpoint) error
 	PauseRun(ctx context.Context, id string, cp *Checkpoint) error
 	FailRunResumable(ctx context.Context, id string, cp *Checkpoint, runErr string, code FailureCode) error

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -745,6 +745,99 @@ func (s *Store) UpdateRunStatusIfCoded(ctx context.Context, id string, status st
 	return res.MatchedCount > 0, nil
 }
 
+// mergeStatusFilter builds the merge_status clause for a CAS filter:
+// the empty status matches both an unset field and an explicit "".
+func mergeStatusFilter(expectedFrom []store.MergeStatus) bson.M {
+	hasEmpty := false
+	vals := make([]store.MergeStatus, 0, len(expectedFrom))
+	for _, st := range expectedFrom {
+		if st == "" {
+			hasEmpty = true
+		}
+		vals = append(vals, st)
+	}
+	in := bson.M{"merge_status": bson.M{"$in": vals}}
+	if !hasEmpty {
+		return in
+	}
+	return bson.M{"$or": bson.A{in, bson.M{"merge_status": bson.M{"$exists": false}}}}
+}
+
+// ClaimMerge is the compare-and-set entry to the merge state machine
+// (see store.RunStore), implemented as a conditional FindOneAndUpdate:
+// the flip to "merging" only lands when the persisted status is
+// claimable — unset/pending/failed, or a "merging" whose claim stamp
+// predates staleBefore (the previous claimant crashed mid-merge).
+func (s *Store) ClaimMerge(ctx context.Context, id string, staleBefore time.Time) (bool, store.MergeStatus, error) {
+	now := time.Now().UTC()
+	claimable := bson.M{"$or": bson.A{
+		bson.M{"merge_status": bson.M{"$in": bson.A{"", store.MergeStatusPending, store.MergeStatusFailed}}},
+		bson.M{"merge_status": bson.M{"$exists": false}},
+		bson.M{"merge_status": store.MergeStatusMerging, "merge_claimed_at": bson.M{"$lt": staleBefore}},
+	}}
+	filter := notDeleted(withTenantFilter(ctx, bson.M{"_id": id, "$and": bson.A{claimable}}))
+	update := bson.M{
+		"$set": bson.M{"merge_status": store.MergeStatusMerging, "merge_claimed_at": now, "updated_at": now},
+		"$inc": bson.M{"version": 1},
+	}
+	opts := options.FindOneAndUpdate().
+		SetReturnDocument(options.Before).
+		SetProjection(bson.M{"merge_status": 1})
+	var before struct {
+		MergeStatus store.MergeStatus `bson:"merge_status"`
+	}
+	err := s.runs.FindOneAndUpdate(ctx, filter, update, opts).Decode(&before)
+	if err == nil {
+		return true, before.MergeStatus, nil
+	}
+	if !errors.Is(err, mongo.ErrNoDocuments) {
+		return false, "", fmt.Errorf("store/mongo: claim merge %s: %w", id, err)
+	}
+	// Not claimable (or missing): read the current status so the caller
+	// can say WHY the claim was refused.
+	var cur struct {
+		MergeStatus store.MergeStatus `bson:"merge_status"`
+	}
+	err = s.runs.FindOne(ctx, notDeleted(withTenantFilter(ctx, bson.M{"_id": id})),
+		options.FindOne().SetProjection(bson.M{"merge_status": 1})).Decode(&cur)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return false, "", fmt.Errorf("store/mongo: claim merge: run %s not found", id)
+		}
+		return false, "", fmt.Errorf("store/mongo: claim merge %s: %w", id, err)
+	}
+	return false, cur.MergeStatus, nil
+}
+
+// UpdateRunMergeIf is the compare-and-set exit from the merge state
+// machine (see store.RunStore): a conditional UpdateOne on the full
+// merge bookkeeping. Empty fields are $unset, mirroring the omitempty
+// shape a full SaveRun would produce.
+func (s *Store) UpdateRunMergeIf(ctx context.Context, id string, upd store.RunMergeUpdate, expectedFrom []store.MergeStatus) (bool, error) {
+	set := bson.M{"updated_at": time.Now().UTC()}
+	unset := bson.M{"merge_claimed_at": ""}
+	stringField := func(key, val string) {
+		if val == "" {
+			unset[key] = ""
+		} else {
+			set[key] = val
+		}
+	}
+	stringField("merge_status", string(upd.Status))
+	stringField("merged_commit", upd.MergedCommit)
+	stringField("merged_into", upd.MergedInto)
+	stringField("merge_strategy", string(upd.MergeStrategy))
+	stringField("pending_merge_message", upd.PendingMergeMessage)
+	stringField("pending_merge_into", upd.PendingMergeInto)
+	update := bson.M{"$set": set, "$unset": unset, "$inc": bson.M{"version": 1}}
+	filter := notDeleted(withTenantFilter(ctx, bson.M{"_id": id, "$and": bson.A{mergeStatusFilter(expectedFrom)}}))
+	res, err := s.runs.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return false, fmt.Errorf("store/mongo: update merge if %s: %w", id, err)
+	}
+	return res.MatchedCount > 0, nil
+}
+
 // FailQueuedRunIfAttempt is the queue-attempt-aware counterpart to the
 // status-only CAS above. queued_at and status are matched in the SAME Mongo
 // update so a concurrent resume cannot slip a newer queued attempt between a

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -768,12 +768,17 @@ func mergeStatusFilter(expectedFrom []store.MergeStatus) bson.M {
 // the flip to "merging" only lands when the persisted status is
 // claimable — unset/pending/failed, or a "merging" whose claim stamp
 // predates staleBefore (the previous claimant crashed mid-merge).
-func (s *Store) ClaimMerge(ctx context.Context, id string, staleBefore time.Time) (bool, store.MergeStatus, error) {
-	now := time.Now().UTC()
+func (s *Store) ClaimMerge(ctx context.Context, id string, staleBefore time.Time) (bool, store.MergeStatus, time.Time, error) {
+	// Millisecond precision: BSON stores times in ms, and the token
+	// must compare equal after a round-trip.
+	now := time.Now().UTC().Truncate(time.Millisecond)
 	claimable := bson.M{"$or": bson.A{
-		bson.M{"merge_status": bson.M{"$in": bson.A{"", store.MergeStatusPending, store.MergeStatusFailed}}},
+		bson.M{"merge_status": bson.M{"$in": bson.A{"", store.MergeStatusPending, store.MergeStatusFailed, store.MergeStatusSkipped, store.MergeStatusConflicted}}},
 		bson.M{"merge_status": bson.M{"$exists": false}},
 		bson.M{"merge_status": store.MergeStatusMerging, "merge_claimed_at": bson.M{"$lt": staleBefore}},
+		// A "merging" without a stamp (a full-document writer dropped
+		// it) counts as infinitely stale — it must not wedge the run.
+		bson.M{"merge_status": store.MergeStatusMerging, "merge_claimed_at": bson.M{"$exists": false}},
 	}}
 	filter := notDeleted(withTenantFilter(ctx, bson.M{"_id": id, "$and": bson.A{claimable}}))
 	update := bson.M{
@@ -788,10 +793,10 @@ func (s *Store) ClaimMerge(ctx context.Context, id string, staleBefore time.Time
 	}
 	err := s.runs.FindOneAndUpdate(ctx, filter, update, opts).Decode(&before)
 	if err == nil {
-		return true, before.MergeStatus, nil
+		return true, before.MergeStatus, now, nil
 	}
 	if !errors.Is(err, mongo.ErrNoDocuments) {
-		return false, "", fmt.Errorf("store/mongo: claim merge %s: %w", id, err)
+		return false, "", time.Time{}, fmt.Errorf("store/mongo: claim merge %s: %w", id, err)
 	}
 	// Not claimable (or missing): read the current status so the caller
 	// can say WHY the claim was refused.
@@ -802,11 +807,11 @@ func (s *Store) ClaimMerge(ctx context.Context, id string, staleBefore time.Time
 		options.FindOne().SetProjection(bson.M{"merge_status": 1})).Decode(&cur)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
-			return false, "", fmt.Errorf("store/mongo: claim merge: run %s not found", id)
+			return false, "", time.Time{}, fmt.Errorf("store/mongo: claim merge: run %s not found", id)
 		}
-		return false, "", fmt.Errorf("store/mongo: claim merge %s: %w", id, err)
+		return false, "", time.Time{}, fmt.Errorf("store/mongo: claim merge %s: %w", id, err)
 	}
-	return false, cur.MergeStatus, nil
+	return false, cur.MergeStatus, time.Time{}, nil
 }
 
 // UpdateRunMergeIf is the compare-and-set exit from the merge state
@@ -830,12 +835,32 @@ func (s *Store) UpdateRunMergeIf(ctx context.Context, id string, upd store.RunMe
 	stringField("pending_merge_message", upd.PendingMergeMessage)
 	stringField("pending_merge_into", upd.PendingMergeInto)
 	update := bson.M{"$set": set, "$unset": unset, "$inc": bson.M{"version": 1}}
-	filter := notDeleted(withTenantFilter(ctx, bson.M{"_id": id, "$and": bson.A{mergeStatusFilter(expectedFrom)}}))
+	cas := bson.A{mergeStatusFilter(expectedFrom)}
+	if !upd.ExpectClaimedAt.IsZero() {
+		// Scope the exit to ONE claim: a claimant whose claim was
+		// stolen must not consume its successor's (see RunMergeUpdate).
+		cas = append(cas, bson.M{"merge_claimed_at": upd.ExpectClaimedAt})
+	}
+	filter := notDeleted(withTenantFilter(ctx, bson.M{"_id": id, "$and": cas}))
 	res, err := s.runs.UpdateOne(ctx, filter, update)
 	if err != nil {
 		return false, fmt.Errorf("store/mongo: update merge if %s: %w", id, err)
 	}
-	return res.MatchedCount > 0, nil
+	if res.MatchedCount > 0 {
+		return true, nil
+	}
+	// Distinguish "state drifted" (a CAS outcome the caller handles)
+	// from "run missing" (an error — a silently absorbed write would
+	// masquerade as a lost race).
+	exists := s.runs.FindOne(ctx, notDeleted(withTenantFilter(ctx, bson.M{"_id": id})),
+		options.FindOne().SetProjection(bson.M{"_id": 1}))
+	if err := exists.Err(); err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return false, fmt.Errorf("store/mongo: update merge if: run %s not found", id)
+		}
+		return false, fmt.Errorf("store/mongo: update merge if %s: %w", id, err)
+	}
+	return false, nil
 }
 
 // FailQueuedRunIfAttempt is the queue-attempt-aware counterpart to the

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -800,19 +800,39 @@ func (s *Store) ClaimMerge(ctx context.Context, id string, staleBefore time.Time
 		bson.M{"merge_status": store.MergeStatusMerging, "merge_claimed_at": bson.M{"$exists": false}},
 	}}
 	filter := notDeleted(withTenantFilter(ctx, bson.M{"_id": id, "$and": bson.A{claimable}}))
-	update := bson.M{
-		"$set": bson.M{"merge_status": store.MergeStatusMerging, "merge_claimed_at": now, "updated_at": now},
-		"$inc": bson.M{"version": 1},
-	}
+	// Strictly monotonic vs the stamp being stolen (mirrors the FS
+	// twin): a steal landing in the SAME millisecond would mint an
+	// equal token and the loser's token-scoped exits would pass as the
+	// winner's. The pipeline computes max(now, old+1ms); the Go side
+	// derives the identical token from the pre-image below.
+	tokenExpr := bson.M{"$cond": bson.A{
+		bson.M{"$and": bson.A{
+			bson.M{"$ne": bson.A{bson.M{"$type": "$merge_claimed_at"}, "missing"}},
+			bson.M{"$gte": bson.A{"$merge_claimed_at", now}},
+		}},
+		bson.M{"$add": bson.A{"$merge_claimed_at", 1}},
+		now,
+	}}
+	update := mongo.Pipeline{{{Key: "$set", Value: bson.M{
+		"merge_status":     bson.M{"$literal": string(store.MergeStatusMerging)},
+		"merge_claimed_at": tokenExpr,
+		"updated_at":       now,
+		"version":          bson.M{"$add": bson.A{bson.M{"$ifNull": bson.A{"$version", 0}}, 1}},
+	}}}}
 	opts := options.FindOneAndUpdate().
 		SetReturnDocument(options.Before).
-		SetProjection(bson.M{"merge_status": 1})
+		SetProjection(bson.M{"merge_status": 1, "merge_claimed_at": 1})
 	var before struct {
-		MergeStatus store.MergeStatus `bson:"merge_status"`
+		MergeStatus    store.MergeStatus `bson:"merge_status"`
+		MergeClaimedAt time.Time         `bson:"merge_claimed_at"`
 	}
 	err := s.runs.FindOneAndUpdate(ctx, filter, update, opts).Decode(&before)
 	if err == nil {
-		return true, before.MergeStatus, now, nil
+		token := now
+		if !before.MergeClaimedAt.IsZero() && !now.After(before.MergeClaimedAt) {
+			token = before.MergeClaimedAt.Add(time.Millisecond)
+		}
+		return true, before.MergeStatus, token, nil
 	}
 	if !errors.Is(err, mongo.ErrNoDocuments) {
 		return false, "", time.Time{}, fmt.Errorf("store/mongo: claim merge %s: %w", id, err)

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -222,6 +222,25 @@ func (s *Store) SaveRun(ctx context.Context, r *store.Run) error {
 	r.UpdatedAt = time.Now().UTC()
 	r.SchemaVersion = SchemaVersion
 	stampTenant(ctx, r)
+	// The merge claim is owned by ClaimMerge/UpdateRunMergeIf. A caller
+	// whose copy predates a live claim (rename, rewind bookkeeping)
+	// must not disavow it through this full-document replace. Best-
+	// effort read-then-replace (a claim landing inside this window can
+	// still be clobbered — the FS twin is atomic under its mutex; a
+	// version CAS on SaveRun is the real fix, follow-up), which closes
+	// the measured window: a stale copy loaded BEFORE the claim.
+	if r.MergeStatus != store.MergeStatusMerging {
+		var cur struct {
+			MergeStatus    store.MergeStatus `bson:"merge_status"`
+			MergeClaimedAt time.Time         `bson:"merge_claimed_at"`
+		}
+		if ferr := s.runs.FindOne(ctx, notDeleted(withTenantFilter(ctx, bson.M{"_id": r.ID})),
+			options.FindOne().SetProjection(bson.M{"merge_status": 1, "merge_claimed_at": 1})).Decode(&cur); ferr == nil &&
+			cur.MergeStatus == store.MergeStatusMerging {
+			r.MergeStatus = cur.MergeStatus
+			r.MergeClaimedAt = cur.MergeClaimedAt
+		}
+	}
 	// The notDeleted predicate closes the guard's TOCTOU window: a
 	// DeleteRun racing between the check above and this write leaves a
 	// tombstoned doc the filter no longer matches, and the upsert then

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -860,6 +860,15 @@ type RunMergeUpdate struct {
 	MergeStrategy       MergeStrategy
 	PendingMergeMessage string
 	PendingMergeInto    string
+	// ExpectClaimedAt scopes an exit from "merging" to ONE claim: when
+	// non-zero, the CAS additionally requires the persisted
+	// MergeClaimedAt to equal it (the token ClaimMerge returned). A
+	// claimant whose claim was stolen for staleness then matches
+	// nothing — it cannot consume the live claimant's claim, so a late
+	// failure write can never overwrite the state of the worker that
+	// took over. Zero skips the check (exits from non-merging states,
+	// which carry no claim).
+	ExpectClaimedAt time.Time
 }
 
 // NodeSessionSlot is the durable persist slot for one LLM node (ADR-089).

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -523,10 +523,16 @@ type Run struct {
 	AutoMerge bool `json:"auto_merge,omitempty" bson:"auto_merge,omitempty"`
 	// MergeStatus tracks whether the merge has happened yet:
 	//   "pending"  — storage branch created, merge awaiting user action
+	//   "merging"  — a merge claim is held (one worker is performing it)
 	//   "merged"   — merge succeeded; MergedInto + MergedCommit are set
 	//   "skipped"  — explicit opt-out (merge_into="none") or no commits
 	//   "failed"   — auto-merge attempted but failed; user can retry
 	MergeStatus MergeStatus `json:"merge_status,omitempty" bson:"merge_status,omitempty"`
+	// MergeClaimedAt is stamped when a worker claims the merge
+	// (MergeStatus="merging"). A claim older than the staleness bound a
+	// caller passes to ClaimMerge is up for grabs again — the previous
+	// claimant crashed mid-merge and must not wedge the run forever.
+	MergeClaimedAt time.Time `json:"merge_claimed_at,omitempty" bson:"merge_claimed_at,omitempty"`
 	// MergedCommit is the SHA on the target branch after the merge.
 	// Equal to FinalCommit for "merge" (FF) strategy; a fresh squash
 	// commit SHA for "squash". Empty when not yet merged.
@@ -824,6 +830,13 @@ const (
 	MergeStatusMerged  MergeStatus = "merged"
 	MergeStatusSkipped MergeStatus = "skipped"
 	MergeStatusFailed  MergeStatus = "failed"
+	// MergeStatusMerging is the claim state: exactly one worker holds
+	// the right to perform the merge (ClaimMerge is a compare-and-set,
+	// so two server replicas cannot both build a squash for the same
+	// run). Every persisted exit from this state goes through
+	// UpdateRunMergeIf, so a claimant that lost its claim (staleness
+	// steal) cannot overwrite the outcome of the worker that took over.
+	MergeStatusMerging MergeStatus = "merging"
 	// MergeStatusConflicted means `git merge --squash` produced
 	// content conflicts and the worktree is currently in the
 	// conflicted state (UU paths, markers on disk). The operator
@@ -832,6 +845,22 @@ const (
 	// status flips to "merged".
 	MergeStatusConflicted MergeStatus = "conflicted"
 )
+
+// RunMergeUpdate is the full merge bookkeeping written by one merge
+// transition. UpdateRunMergeIf persists it atomically, conditioned on
+// the current MergeStatus — the single choke point every merge-side
+// writer goes through, so a racing writer cannot clobber a state
+// another worker already landed (in particular: nobody can overwrite
+// "merged"). Empty string fields are cleared on the run, mirroring the
+// omitempty semantics a full SaveRun would have.
+type RunMergeUpdate struct {
+	Status              MergeStatus
+	MergedCommit        string
+	MergedInto          string
+	MergeStrategy       MergeStrategy
+	PendingMergeMessage string
+	PendingMergeInto    string
+}
 
 // NodeSessionSlot is the durable persist slot for one LLM node (ADR-089).
 // StateRef names a blob in BackendSessionStore. Empty StateRef means the

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -414,10 +414,16 @@ func (s *FilesystemRunStore) UpdateRunStatusIfCoded(ctx context.Context, id stri
 // once stale (the previous claimant crashed mid-merge).
 func mergeClaimable(cur MergeStatus, claimedAt, staleBefore time.Time) bool {
 	switch cur {
-	case "", MergeStatusPending, MergeStatusFailed:
+	case "", MergeStatusPending, MergeStatusFailed, MergeStatusSkipped, MergeStatusConflicted:
+		// skipped and conflicted stay claimable: /merge is the only
+		// path that re-materialises a lost server-side merge clone, and
+		// a recovered run (RecoverFinalize lands "skipped") must stay
+		// mergeable. The exit CAS still serialises the outcome.
 		return true
 	case MergeStatusMerging:
-		return claimedAt.Before(staleBefore)
+		// A zero claimedAt (a full-document writer dropped the stamp)
+		// counts as infinitely stale — it must not wedge the run.
+		return claimedAt.IsZero() || claimedAt.Before(staleBefore)
 	default:
 		return false
 	}
@@ -426,25 +432,28 @@ func mergeClaimable(cur MergeStatus, claimedAt, staleBefore time.Time) bool {
 // ClaimMerge is the compare-and-set entry to the merge state machine
 // (see store.RunStore). Guarded by the store mutex, so concurrent
 // claimants in one process serialize here.
-func (s *FilesystemRunStore) ClaimMerge(_ context.Context, id string, staleBefore time.Time) (bool, MergeStatus, error) {
+func (s *FilesystemRunStore) ClaimMerge(_ context.Context, id string, staleBefore time.Time) (bool, MergeStatus, time.Time, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	r, err := s.loadRunRaw(id)
 	if err != nil {
-		return false, "", err
+		return false, "", time.Time{}, err
 	}
 	prior := r.MergeStatus
 	if !mergeClaimable(prior, r.MergeClaimedAt, staleBefore) {
-		return false, prior, nil
+		return false, prior, time.Time{}, nil
 	}
+	// Millisecond precision: the token must survive a Mongo round-trip
+	// identically on both backends, and BSON stores times in ms.
+	now := time.Now().UTC().Truncate(time.Millisecond)
 	r.MergeStatus = MergeStatusMerging
-	r.MergeClaimedAt = time.Now().UTC()
-	r.UpdatedAt = time.Now().UTC()
+	r.MergeClaimedAt = now
+	r.UpdatedAt = now
 	if err := s.writeRun(r); err != nil {
-		return false, prior, err
+		return false, prior, time.Time{}, err
 	}
-	return true, prior, nil
+	return true, prior, now, nil
 }
 
 // UpdateRunMergeIf is the compare-and-set exit from the merge state
@@ -466,6 +475,11 @@ func (s *FilesystemRunStore) UpdateRunMergeIf(_ context.Context, id string, upd 
 		}
 	}
 	if !matched {
+		return false, nil
+	}
+	if !upd.ExpectClaimedAt.IsZero() && !r.MergeClaimedAt.Equal(upd.ExpectClaimedAt) {
+		// The claim this writer holds was stolen — its exit consumes
+		// nothing.
 		return false, nil
 	}
 	r.MergeStatus = upd.Status

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -458,6 +458,14 @@ func (s *FilesystemRunStore) ClaimMerge(_ context.Context, id string, staleBefor
 	// Millisecond precision: the token must survive a Mongo round-trip
 	// identically on both backends, and BSON stores times in ms.
 	now := time.Now().UTC().Truncate(time.Millisecond)
+	// Strictly monotonic vs the stamp being stolen: a steal landing in
+	// the SAME millisecond as the claim it replaces would mint an equal
+	// token, and the loser's token-scoped exits would pass as the
+	// winner's — the fencing collapses exactly when two claimants are
+	// closest.
+	if !now.After(r.MergeClaimedAt) {
+		now = r.MergeClaimedAt.Add(time.Millisecond)
+	}
 	r.MergeStatus = MergeStatusMerging
 	r.MergeClaimedAt = now
 	r.UpdatedAt = now

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -408,6 +408,80 @@ func (s *FilesystemRunStore) UpdateRunStatusIfCoded(ctx context.Context, id stri
 	return true, nil
 }
 
+// mergeClaimable reports whether a run in status cur (with claim time
+// claimedAt) can be claimed for merging at staleBefore: unset, pending
+// and failed are always claimable; a "merging" claim is claimable only
+// once stale (the previous claimant crashed mid-merge).
+func mergeClaimable(cur MergeStatus, claimedAt, staleBefore time.Time) bool {
+	switch cur {
+	case "", MergeStatusPending, MergeStatusFailed:
+		return true
+	case MergeStatusMerging:
+		return claimedAt.Before(staleBefore)
+	default:
+		return false
+	}
+}
+
+// ClaimMerge is the compare-and-set entry to the merge state machine
+// (see store.RunStore). Guarded by the store mutex, so concurrent
+// claimants in one process serialize here.
+func (s *FilesystemRunStore) ClaimMerge(_ context.Context, id string, staleBefore time.Time) (bool, MergeStatus, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	r, err := s.loadRunRaw(id)
+	if err != nil {
+		return false, "", err
+	}
+	prior := r.MergeStatus
+	if !mergeClaimable(prior, r.MergeClaimedAt, staleBefore) {
+		return false, prior, nil
+	}
+	r.MergeStatus = MergeStatusMerging
+	r.MergeClaimedAt = time.Now().UTC()
+	r.UpdatedAt = time.Now().UTC()
+	if err := s.writeRun(r); err != nil {
+		return false, prior, err
+	}
+	return true, prior, nil
+}
+
+// UpdateRunMergeIf is the compare-and-set exit from the merge state
+// machine (see store.RunStore): the write only lands when the current
+// MergeStatus is in expectedFrom.
+func (s *FilesystemRunStore) UpdateRunMergeIf(_ context.Context, id string, upd RunMergeUpdate, expectedFrom []MergeStatus) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	r, err := s.loadRunRaw(id)
+	if err != nil {
+		return false, err
+	}
+	matched := false
+	for _, want := range expectedFrom {
+		if r.MergeStatus == want {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return false, nil
+	}
+	r.MergeStatus = upd.Status
+	r.MergedCommit = upd.MergedCommit
+	r.MergedInto = upd.MergedInto
+	r.MergeStrategy = upd.MergeStrategy
+	r.PendingMergeMessage = upd.PendingMergeMessage
+	r.PendingMergeInto = upd.PendingMergeInto
+	r.MergeClaimedAt = time.Time{}
+	r.UpdatedAt = time.Now().UTC()
+	if err := s.writeRun(r); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // FailQueuedRunIfAttempt atomically fails only the queue attempt represented
 // by publishedAt. A later resume refreshes QueuedAt before publishing, so an
 // older delivery cannot clobber that new attempt during its queued→running

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -161,6 +161,17 @@ func (s *FilesystemRunStore) SaveRun(_ context.Context, r *Run) error {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// The merge claim is owned by ClaimMerge/UpdateRunMergeIf. A caller
+	// whose copy predates a live claim (rename, rewind bookkeeping)
+	// must not disavow it through this full-document write: clobbering
+	// merge_status+merge_claimed_at lets the next claimant through
+	// while the first is mid-merge — the double-squash the claim
+	// exists to prevent. Atomic here (under s.mu, same as writeRun).
+	if cur, err := s.loadRunRaw(r.ID); err == nil &&
+		cur.MergeStatus == MergeStatusMerging && r.MergeStatus != MergeStatusMerging {
+		r.MergeStatus = cur.MergeStatus
+		r.MergeClaimedAt = cur.MergeClaimedAt
+	}
 	return s.writeRun(r)
 }
 

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -1758,8 +1758,8 @@ func testPausePointerLifecycle(t *testing.T, s store.RunStore) {
 
 // testMergeClaimCAS drives the merge state machine at the store level:
 // the claim CAS (entry), the conditional persist (exit), the stale
-// steal, and the no-clobber-merged invariant that closes the
-// double-squash TOCTOU.
+// steal with claim-token isolation, and the no-clobber-merged
+// invariant that closes the double-squash TOCTOU.
 func testMergeClaimCAS(t *testing.T, s store.RunStore) {
 	t.Helper()
 	ctx := testCtx()
@@ -1770,22 +1770,27 @@ func testMergeClaimCAS(t *testing.T, s store.RunStore) {
 	notStale := time.Now().Add(-15 * time.Minute)
 
 	// Entry: an unset merge_status is claimable, prior comes back "".
-	claimed, prior, err := s.ClaimMerge(ctx, runID, notStale)
+	claimed, prior, tokenA, err := s.ClaimMerge(ctx, runID, notStale)
 	if err != nil || !claimed || prior != "" {
 		t.Fatalf("first claim = (%t, %q, %v), want (true, \"\", nil)", claimed, prior, err)
 	}
+	if tokenA.IsZero() {
+		t.Fatal("claim must return its token")
+	}
 	// A held (fresh) claim refuses the second claimant.
-	claimed, prior, err = s.ClaimMerge(ctx, runID, notStale)
+	claimed, prior, _, err = s.ClaimMerge(ctx, runID, notStale)
 	if err != nil || claimed || prior != store.MergeStatusMerging {
 		t.Fatalf("second claim = (%t, %q, %v), want (false, merging, nil)", claimed, prior, err)
 	}
 
-	// Exit: the holder persists the outcome conditioned on "merging".
+	// Exit: the holder persists the outcome conditioned on "merging"
+	// AND its own token.
 	changed, err := s.UpdateRunMergeIf(ctx, runID, store.RunMergeUpdate{
-		Status:        store.MergeStatusMerged,
-		MergedCommit:  "abc123",
-		MergedInto:    "main",
-		MergeStrategy: store.MergeStrategySquash,
+		Status:          store.MergeStatusMerged,
+		MergedCommit:    "abc123",
+		MergedInto:      "main",
+		MergeStrategy:   store.MergeStrategySquash,
+		ExpectClaimedAt: tokenA,
 	}, []store.MergeStatus{store.MergeStatusMerging})
 	if err != nil || !changed {
 		t.Fatalf("persist merged = (%t, %v), want (true, nil)", changed, err)
@@ -1809,37 +1814,93 @@ func testMergeClaimCAS(t *testing.T, s store.RunStore) {
 		t.Fatalf("merged record damaged: %+v", got)
 	}
 	// And "merged" is terminal for the claim too.
-	claimed, prior, err = s.ClaimMerge(ctx, runID, notStale)
+	claimed, prior, _, err = s.ClaimMerge(ctx, runID, notStale)
 	if err != nil || claimed || prior != store.MergeStatusMerged {
 		t.Fatalf("claim on merged = (%t, %q, %v), want (false, merged, nil)", claimed, prior, err)
 	}
 
 	// Stale steal: a claim whose stamp predates staleBefore is up for
-	// grabs — the previous claimant crashed mid-merge.
+	// grabs — AND the stolen-from claimant's token consumes nothing
+	// afterwards (the claim names an owner, not just a state; without
+	// the token check the crashed claimant's late failure write would
+	// overwrite the live claimant's outcome).
 	const runID2 = "run-merge-claim-stale"
 	if _, err := s.CreateRun(ctx, runID2, "wf", nil); err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
-	if claimed, _, err := s.ClaimMerge(ctx, runID2, notStale); err != nil || !claimed {
-		t.Fatalf("seed claim = (%t, %v)", claimed, err)
+	_, _, tokenOld, err := s.ClaimMerge(ctx, runID2, notStale)
+	if err != nil {
+		t.Fatalf("seed claim: %v", err)
 	}
-	if claimed, _, err := s.ClaimMerge(ctx, runID2, notStale); err != nil || claimed {
+	if claimed, _, _, err := s.ClaimMerge(ctx, runID2, notStale); err != nil || claimed {
 		t.Fatalf("fresh claim must hold, got steal (%t, %v)", claimed, err)
 	}
-	claimed, prior, err = s.ClaimMerge(ctx, runID2, time.Now().Add(time.Second))
+	claimed, prior, tokenNew, err := s.ClaimMerge(ctx, runID2, time.Now().Add(time.Second))
 	if err != nil || !claimed || prior != store.MergeStatusMerging {
 		t.Fatalf("stale steal = (%t, %q, %v), want (true, merging, nil)", claimed, prior, err)
+	}
+	if tokenNew.Equal(tokenOld) {
+		t.Fatal("steal must issue a fresh token")
+	}
+	changed, err = s.UpdateRunMergeIf(ctx, runID2, store.RunMergeUpdate{Status: store.MergeStatusFailed, ExpectClaimedAt: tokenOld},
+		[]store.MergeStatus{store.MergeStatusMerging})
+	if err != nil || changed {
+		t.Fatalf("stolen-from claimant's write = (%t, %v), want (false, nil)", changed, err)
+	}
+	changed, err = s.UpdateRunMergeIf(ctx, runID2, store.RunMergeUpdate{Status: store.MergeStatusMerged, MergedCommit: "def456", MergedInto: "main", ExpectClaimedAt: tokenNew},
+		[]store.MergeStatus{store.MergeStatusMerging})
+	if err != nil || !changed {
+		t.Fatalf("live claimant's write = (%t, %v), want (true, nil)", changed, err)
+	}
+
+	// A "merging" whose stamp is missing entirely (a full-document
+	// writer dropped it) is claimable — it must not wedge the run.
+	const runID3 = "run-merge-claim-nostamp"
+	if _, err := s.CreateRun(ctx, runID3, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if changed, err := s.UpdateRunMergeIf(ctx, runID3, store.RunMergeUpdate{Status: store.MergeStatusMerging},
+		[]store.MergeStatus{""}); err != nil || !changed {
+		t.Fatalf("seed stampless merging = (%t, %v)", changed, err)
+	}
+	claimed, _, _, err = s.ClaimMerge(ctx, runID3, notStale)
+	if err != nil || !claimed {
+		t.Fatalf("stampless merging must be claimable = (%t, %v)", claimed, err)
+	}
+
+	// skipped and conflicted stay claimable (/merge is the only path
+	// that re-materialises a lost merge clone; a recovered run lands
+	// "skipped" and must stay mergeable).
+	for _, st := range []store.MergeStatus{store.MergeStatusSkipped, store.MergeStatusConflicted} {
+		id := "run-merge-claim-" + string(st)
+		if _, err := s.CreateRun(ctx, id, "wf", nil); err != nil {
+			t.Fatalf("CreateRun: %v", err)
+		}
+		if changed, err := s.UpdateRunMergeIf(ctx, id, store.RunMergeUpdate{Status: st}, []store.MergeStatus{""}); err != nil || !changed {
+			t.Fatalf("seed %s = (%t, %v)", st, changed, err)
+		}
+		claimed, prior, _, err := s.ClaimMerge(ctx, id, notStale)
+		if err != nil || !claimed || prior != st {
+			t.Fatalf("claim on %s = (%t, %q, %v), want (true, %s, nil)", st, claimed, prior, err, st)
+		}
 	}
 
 	// Exit CAS with the empty status in expectedFrom matches an unset
 	// field (a run that never entered the machine).
-	const runID3 = "run-merge-claim-virgin"
-	if _, err := s.CreateRun(ctx, runID3, "wf", nil); err != nil {
+	const runID4 = "run-merge-claim-virgin"
+	if _, err := s.CreateRun(ctx, runID4, "wf", nil); err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
-	changed, err = s.UpdateRunMergeIf(ctx, runID3, store.RunMergeUpdate{Status: store.MergeStatusPending},
+	changed, err = s.UpdateRunMergeIf(ctx, runID4, store.RunMergeUpdate{Status: store.MergeStatusPending},
 		[]store.MergeStatus{""})
 	if err != nil || !changed {
 		t.Fatalf("empty-status CAS = (%t, %v), want (true, nil)", changed, err)
+	}
+
+	// A missing run is an ERROR, not a silent (false, nil) — a caller
+	// must be able to tell a lost race from a deleted run.
+	if _, err := s.UpdateRunMergeIf(ctx, "run-merge-claim-ghost", store.RunMergeUpdate{Status: store.MergeStatusPending},
+		[]store.MergeStatus{""}); err == nil {
+		t.Fatal("UpdateRunMergeIf on a missing run must error")
 	}
 }

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -55,6 +55,7 @@ func RunWithOpts(t *testing.T, factory Factory, opts Opts) {
 	t.Run("CreateLoadRoundTrip", func(t *testing.T) { testCreateLoad(t, factory(t), opts) })
 	t.Run("StatusTransitions", func(t *testing.T) { testStatusTransitions(t, factory(t)) })
 	t.Run("QueuedAttemptCAS", func(t *testing.T) { testQueuedAttemptCAS(t, factory(t)) })
+	t.Run("MergeClaimCAS", func(t *testing.T) { testMergeClaimCAS(t, factory(t)) })
 	t.Run("FailRunTerminal", func(t *testing.T) { testFailRunTerminal(t, factory(t)) })
 	t.Run("FailureCodeLifecycle", func(t *testing.T) { testFailureCodeLifecycle(t, factory(t)) })
 	t.Run("TransitionSideEffects", func(t *testing.T) { testTransitionSideEffects(t, factory(t)) })
@@ -1754,5 +1755,91 @@ func testPausePointerLifecycle(t *testing.T, s store.RunStore) {
 	}
 	if r.Checkpoint.InteractionID != "I1" {
 		t.Errorf("SaveCheckpoint on a PAUSED run stripped the live pointer (%q) — the next resume cannot load its interaction", r.Checkpoint.InteractionID)
+
+// testMergeClaimCAS drives the merge state machine at the store level:
+// the claim CAS (entry), the conditional persist (exit), the stale
+// steal, and the no-clobber-merged invariant that closes the
+// double-squash TOCTOU.
+func testMergeClaimCAS(t *testing.T, s store.RunStore) {
+	t.Helper()
+	ctx := testCtx()
+	const runID = "run-merge-claim"
+	if _, err := s.CreateRun(ctx, runID, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	notStale := time.Now().Add(-15 * time.Minute)
+
+	// Entry: an unset merge_status is claimable, prior comes back "".
+	claimed, prior, err := s.ClaimMerge(ctx, runID, notStale)
+	if err != nil || !claimed || prior != "" {
+		t.Fatalf("first claim = (%t, %q, %v), want (true, \"\", nil)", claimed, prior, err)
+	}
+	// A held (fresh) claim refuses the second claimant.
+	claimed, prior, err = s.ClaimMerge(ctx, runID, notStale)
+	if err != nil || claimed || prior != store.MergeStatusMerging {
+		t.Fatalf("second claim = (%t, %q, %v), want (false, merging, nil)", claimed, prior, err)
+	}
+
+	// Exit: the holder persists the outcome conditioned on "merging".
+	changed, err := s.UpdateRunMergeIf(ctx, runID, store.RunMergeUpdate{
+		Status:        store.MergeStatusMerged,
+		MergedCommit:  "abc123",
+		MergedInto:    "main",
+		MergeStrategy: store.MergeStrategySquash,
+	}, []store.MergeStatus{store.MergeStatusMerging})
+	if err != nil || !changed {
+		t.Fatalf("persist merged = (%t, %v), want (true, nil)", changed, err)
+	}
+	r, err := s.LoadRun(ctx, runID)
+	if err != nil || r.MergeStatus != store.MergeStatusMerged || r.MergedCommit != "abc123" || r.MergedInto != "main" {
+		t.Fatalf("merged bookkeeping = %+v (%v)", r, err)
+	}
+	if !r.MergeClaimedAt.IsZero() {
+		t.Errorf("MergeClaimedAt should be cleared by the exit write, got %v", r.MergeClaimedAt)
+	}
+
+	// No-clobber: a late writer still expecting "merging" (the loser of
+	// a race, or a stolen-claim holder) cannot overwrite "merged".
+	changed, err = s.UpdateRunMergeIf(ctx, runID, store.RunMergeUpdate{Status: store.MergeStatusFailed},
+		[]store.MergeStatus{store.MergeStatusMerging})
+	if err != nil || changed {
+		t.Fatalf("clobber attempt = (%t, %v), want (false, nil)", changed, err)
+	}
+	if got, _ := s.LoadRun(ctx, runID); got.MergeStatus != store.MergeStatusMerged || got.MergedCommit != "abc123" {
+		t.Fatalf("merged record damaged: %+v", got)
+	}
+	// And "merged" is terminal for the claim too.
+	claimed, prior, err = s.ClaimMerge(ctx, runID, notStale)
+	if err != nil || claimed || prior != store.MergeStatusMerged {
+		t.Fatalf("claim on merged = (%t, %q, %v), want (false, merged, nil)", claimed, prior, err)
+	}
+
+	// Stale steal: a claim whose stamp predates staleBefore is up for
+	// grabs — the previous claimant crashed mid-merge.
+	const runID2 = "run-merge-claim-stale"
+	if _, err := s.CreateRun(ctx, runID2, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if claimed, _, err := s.ClaimMerge(ctx, runID2, notStale); err != nil || !claimed {
+		t.Fatalf("seed claim = (%t, %v)", claimed, err)
+	}
+	if claimed, _, err := s.ClaimMerge(ctx, runID2, notStale); err != nil || claimed {
+		t.Fatalf("fresh claim must hold, got steal (%t, %v)", claimed, err)
+	}
+	claimed, prior, err = s.ClaimMerge(ctx, runID2, time.Now().Add(time.Second))
+	if err != nil || !claimed || prior != store.MergeStatusMerging {
+		t.Fatalf("stale steal = (%t, %q, %v), want (true, merging, nil)", claimed, prior, err)
+	}
+
+	// Exit CAS with the empty status in expectedFrom matches an unset
+	// field (a run that never entered the machine).
+	const runID3 = "run-merge-claim-virgin"
+	if _, err := s.CreateRun(ctx, runID3, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	changed, err = s.UpdateRunMergeIf(ctx, runID3, store.RunMergeUpdate{Status: store.MergeStatusPending},
+		[]store.MergeStatus{""})
+	if err != nil || !changed {
+		t.Fatalf("empty-status CAS = (%t, %v), want (true, nil)", changed, err)
 	}
 }

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -56,6 +56,7 @@ func RunWithOpts(t *testing.T, factory Factory, opts Opts) {
 	t.Run("StatusTransitions", func(t *testing.T) { testStatusTransitions(t, factory(t)) })
 	t.Run("QueuedAttemptCAS", func(t *testing.T) { testQueuedAttemptCAS(t, factory(t)) })
 	t.Run("MergeClaimCAS", func(t *testing.T) { testMergeClaimCAS(t, factory(t)) })
+	t.Run("SaveRunPreservesLiveMergeClaim", func(t *testing.T) { testSaveRunPreservesLiveMergeClaim(t, factory(t)) })
 	t.Run("FailRunTerminal", func(t *testing.T) { testFailRunTerminal(t, factory(t)) })
 	t.Run("FailureCodeLifecycle", func(t *testing.T) { testFailureCodeLifecycle(t, factory(t)) })
 	t.Run("TransitionSideEffects", func(t *testing.T) { testTransitionSideEffects(t, factory(t)) })
@@ -1755,6 +1756,8 @@ func testPausePointerLifecycle(t *testing.T, s store.RunStore) {
 	}
 	if r.Checkpoint.InteractionID != "I1" {
 		t.Errorf("SaveCheckpoint on a PAUSED run stripped the live pointer (%q) — the next resume cannot load its interaction", r.Checkpoint.InteractionID)
+	}
+}
 
 // testMergeClaimCAS drives the merge state machine at the store level:
 // the claim CAS (entry), the conditional persist (exit), the stale
@@ -1902,5 +1905,46 @@ func testMergeClaimCAS(t *testing.T, s store.RunStore) {
 	if _, err := s.UpdateRunMergeIf(ctx, "run-merge-claim-ghost", store.RunMergeUpdate{Status: store.MergeStatusPending},
 		[]store.MergeStatus{""}); err == nil {
 		t.Fatal("UpdateRunMergeIf on a missing run must error")
+	}
+}
+
+// testSaveRunPreservesLiveMergeClaim: the merge claim is owned by the
+// merge choke points (ClaimMerge / UpdateRunMergeIf); a full-document
+// SaveRun from a writer that loaded the run BEFORE the claim (operator
+// rename, rewind bookkeeping, cloud publisher stamps) must not disavow
+// a live claim — clobbering merge_status+merge_claimed_at re-opens the
+// double-squash the claim exists to prevent (the next claimant passes
+// immediately while the first is mid-merge).
+func testSaveRunPreservesLiveMergeClaim(t *testing.T, s store.RunStore) {
+	ctx := testCtx()
+	if _, err := s.CreateRun(ctx, "mc-save", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	// The stale copy, loaded before the claim.
+	stale, err := s.LoadRun(ctx, "mc-save")
+	if err != nil {
+		t.Fatal(err)
+	}
+	claimed, _, token, err := s.ClaimMerge(ctx, "mc-save", time.Now().UTC())
+	if err != nil || !claimed {
+		t.Fatalf("claim: claimed=%v err=%v", claimed, err)
+	}
+	// The stale writer saves (e.g. a rename): the claim must survive.
+	stale.Name = "renamed"
+	if err := s.SaveRun(ctx, stale); err != nil {
+		t.Fatal(err)
+	}
+	r, err := s.LoadRun(ctx, "mc-save")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Name != "renamed" {
+		t.Errorf("the save's own payload was lost: name=%q", r.Name)
+	}
+	if r.MergeStatus != store.MergeStatusMerging {
+		t.Errorf("SaveRun disavowed a live merge claim: merge_status=%q, want %q — the next claimant would double-squash", r.MergeStatus, store.MergeStatusMerging)
+	}
+	if !r.MergeClaimedAt.Equal(token) {
+		t.Errorf("SaveRun dropped the claim stamp: %v, want %v", r.MergeClaimedAt, token)
 	}
 }

--- a/studio/src/api/runs/types.ts
+++ b/studio/src/api/runs/types.ts
@@ -135,7 +135,11 @@ export type MergeStatus =
   // currently in the conflicted state (markers on disk, UU paths in
   // the index). The studio renders MergeConflictView until the
   // operator resolves every file + finalizes or aborts.
-  | "conflicted";
+  | "conflicted"
+  // A worker holds the merge claim (ClaimMerge CAS) and is squashing/
+  // pushing right now; a second merge request is refused server-side
+  // until the claim resolves or goes stale.
+  | "merging";
 
 // Mirror of sessionboard.Widget / sessionboard.Spec (Go). The LLM
 // curation layer (Phase 2) emits these; the studio renders one card per

--- a/studio/src/components/Runs/CommitsPanel.tsx
+++ b/studio/src/components/Runs/CommitsPanel.tsx
@@ -215,6 +215,10 @@ function MergeFooter({
     run.merge_status === "merged" || (!run.merge_status && Boolean(run.merged_into));
   const conflicted = run.merge_status === "conflicted";
   const failed = run.merge_status === "failed";
+  // A live claim: another worker is mid-merge — showing the form would
+  // offer a button that 409s ("merge in progress, claimed by another
+  // worker") until the claim resolves.
+  const merging = run.merge_status === "merging";
   // `skipped` is set when finalizeWorktree found no FF target: an explicit
   // merge_into=none at launch, OR a detached-HEAD worktree start — which is
   // EVERY dispatcher run (the dispatcher seeds workspaces via `git worktree
@@ -292,6 +296,18 @@ function MergeFooter({
           <div className="font-mono text-caption mt-0.5">{shortMerged}</div>
         )}
       </div>
+    );
+  }
+
+  // A worker holds the merge claim right now: no form, no button — a
+  // request would be refused server-side until the claim resolves. The
+  // record flips to merged/failed/conflicted when it does.
+  if (merging) {
+    return (
+      <NoticeFooter tone="muted">
+        Merge in progress — another worker holds the claim. This updates
+        when it completes.
+      </NoticeFooter>
     );
   }
 

--- a/studio/src/components/Runs/leftPanel/overview/OutcomeSection.tsx
+++ b/studio/src/components/Runs/leftPanel/overview/OutcomeSection.tsx
@@ -112,6 +112,8 @@ function mergeStatusLabel(s: RunHeader["merge_status"] | undefined): string {
       return "Skipped";
     case "conflicted":
       return "Merge conflict — resolve in Commits tab";
+    case "merging":
+      return "Merge in progress…";
     default:
       return s || "—";
   }

--- a/studio/src/components/Runs/runHeader/MergeStatusBadge.tsx
+++ b/studio/src/components/Runs/runHeader/MergeStatusBadge.tsx
@@ -48,6 +48,16 @@ export default function MergeStatusBadge({
       </span>
     );
   }
+  if (status === "merging") {
+    return (
+      <span
+        className="ml-2 px-1.5 py-0.5 rounded bg-info-soft text-info-fg"
+        title="A worker holds the merge claim; the record updates when it completes."
+      >
+        merge in progress…
+      </span>
+    );
+  }
   if (status === "conflicted") {
     return (
       <span


### PR DESCRIPTION
## The defect

\`PerformMergeCtx\` checked \`merge_status == merged\` and went to work. On a multi-replica server (prod runs 3), two concurrent calls both passed the check, both built a squash (two different commits under the default squash strategy), and the loser — its non-FF push refused by the forge — persisted \`merge_status=failed\` over the winner's \`merged\` via a full-document \`ReplaceOne\`. The record then said *failed* while the target branch carried the merge: the exact class of silent state corruption an instance-side auto-router would amplify.

Found by adversarial plan review (code-anchored, statically); the concurrency window is live on every repo-targeted landing.

## The fix: one choke point

- **\`ClaimMerge\`** (store CAS): unset/pending/failed/skipped/conflicted → \`merging\`, stamping \`merge_claimed_at\`. The second caller stops **before any clone or git work**. A claim older than 15 min (or stampless) is stealable — a claimant that crashed mid-merge must not wedge the run.
- **The claim names an owner, not a state**: \`ClaimMerge\` returns its stamp as a token (ms-truncated so it BSON-round-trips identically); every exit from \`merging\` is scoped to it. A stolen-from claimant's late write consumes nothing.
- **\`UpdateRunMergeIf\`** (store CAS): every merge-side writer — success, failure, conflict, abort, out-of-band reconcile, skipped→pending — exits conditionally. Nobody can overwrite \`merged\`. A missing run is an explicit error on both backends.
- **Outcome writes ride \`context.WithoutCancel\`**: a client disconnect after the claim can neither lose the outcome nor leak the claim (proven against a ctx-honouring store; the FS store ignores ctx and cannot see this class).
- **Split-brain is surfaced, not hidden**: if git landed but the record moved concurrently, the caller gets an explicit error; a retried merge heals the record (re-squashing an already-squashed branch is a git no-op).
- The merge token resolver now validates its connection: listing failures fail up front, a connection host ≠ RepoURL host refuses before unsealing, host comparison uses the shared \`git.RepoHost\` extractor (scp-like forms match instead of being refused).

Both stores implement the pair (FS under the store mutex, Mongo as conditional \`UpdateOne\`/\`FindOneAndUpdate\`); the storetest conformance suite gains \`MergeClaimCAS\` so the backends cannot drift.

## Adversarial review disposition

One full adversarial round on the diff, proofs executed against a **real mongod** and **real git repos**: 3 high + 2 medium + 3 low — **8/8 addressed** in the third commit (owner token; detached context; conflicted/skipped claimable again — the claim initially refused states \`main\` used to merge; shared host extractor; stampless-merging arm on Mongo; explicit missing-run error; clone cleanup on lost abort CAS; dead expectedFrom). What the review attacked without breaking is listed in its report: composed Mongo filter validity, BSON round-trip of the stamp, benign TOCTOU of the refusal-path read, squash-retry self-healing, RecoverFinalize non-collision, cross-replica finalize bound.

## Verification

- 2380 tests pass across the touched packages; new coverage: concurrent \`PerformMergeCtx\` race (exactly one winner), held claim, stale steal with token isolation, early-error release, no-clobber-merged, outcome-survives-request-cancel, skipped-stays-mergeable, scp-like host matching.
- **Every guard falsified by mutation** (CAS ignored, token ignored, context not detached, claimable set shrunk, extractor weakened) — each flips its own test red.

Known residual (out of scope, named): a full-document \`SaveRun\` from an **active** run's runner can still clobber merge fields — the generic lost-update class; merges happen post-terminal where the runner is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)