### PR TITLE
feat(store): numbered episodes with continuation ownership — the run document stops saying nothing

### DIFF
--- a/docs/persisted-formats.md
+++ b/docs/persisted-formats.md
@@ -75,6 +75,25 @@ status. Absent/empty means UNKNOWN (legacy rows, unclassified writers) —
 never "no failure". The vocabulary is open-world: readers must accept codes
 they do not know (see [`store.FailureCode`](../pkg/store/lifecycle.go)).
 
+`outcome_seq` counts the run's terminal EPISODES: it increments on every
+TRANSITION into `finished` / `failed` / `failed_resumable` / `cancelled`
+(never on a same-status rewrite — a drain's re-flip or the publisher's
+resume rollback must not invent an episode). `(run_id, outcome_seq)` is the
+stable per-episode key an outcome consumer claims on; the event-derived id
+cannot serve (second-truncated timestamps collide, and every save refreshes
+`updated_at`). `continuation_state` says who owns the run's future after a
+park: `redelivery_pending` (the RUNNER promoted it at an actual queue Nak),
+`retry_armed` (a quota-window retry exists — promotion happens when
+`ScheduleRunRetry` arms, demotion to `final` when it abandons), or `final`
+(nobody — acting is the consumer's decision). Empty = UNKNOWN, which a
+consumer must never read as final. Engine writers state only the CAUSE
+(`failure_code`); continuation is runner/server-side knowledge. Both fields
+are store-owned bookkeeping: full-document saves can neither rewind the
+counter nor resurrect a stale continuation. **Deploy-order constraint**: an
+old binary's `SaveRun` drops the fields entirely (rewinding the episode key
+for its consumers), so a release adding an `outcome_seq` CONSUMER must ship
+only after the fleet fully carries the writer.
+
 `nodes_served` maps each LLM node's id to the last `(backend, model)` that
 served it (`model` is the provider-reported effective model; `declared_model`
 is what the node asked for). It is the run-record half of making a finished

--- a/openapi.json
+++ b/openapi.json
@@ -1376,6 +1376,9 @@
           "checkpoint": {
             "$ref": "#/components/schemas/Checkpoint"
           },
+          "continuation_state": {
+            "type": "string"
+          },
           "created_at": {
             "format": "date-time",
             "type": "string"
@@ -1461,6 +1464,9 @@
             },
             "type": "object"
           },
+          "outcome_seq": {
+            "type": "integer"
+          },
           "parent_node_id": {
             "type": "string"
           },
@@ -1489,6 +1495,9 @@
             "$ref": "#/components/schemas/RunSource"
           },
           "status": {
+            "type": "string"
+          },
+          "terminal_code": {
             "type": "string"
           },
           "updated_at": {

--- a/openapi.json
+++ b/openapi.json
@@ -1497,9 +1497,6 @@
           "status": {
             "type": "string"
           },
-          "terminal_code": {
-            "type": "string"
-          },
           "updated_at": {
             "format": "date-time",
             "type": "string"

--- a/pkg/alert/opsdispatch_test.go
+++ b/pkg/alert/opsdispatch_test.go
@@ -314,13 +314,18 @@ func TestOpsDispatcher_NewFailureCodeIsANewEpisode(t *testing.T) {
 	}
 
 	// Resume, then re-park on an UNRETRYABLE cause: attempts unchanged,
-	// no retry armed, different code.
+	// no retry armed, different code. Driven through the REAL
+	// transitions (the store owns the cause on a same-status write —
+	// a SaveRun shortcut can no longer re-code a parked run).
+	if err := rs.UpdateRunStatus(context.Background(), run.ID, store.RunStatusRunning, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := rs.UpdateRunStatusCoded(context.Background(), run.ID, store.RunStatusFailedResumable,
+		"anthropic: invalid api key", store.FailureAuthFailed); err != nil {
+		t.Fatal(err)
+	}
 	run2, _ := rs.LoadRun(context.Background(), run.ID)
-	run2.Status = store.RunStatusFailedResumable
-	run2.Error = "anthropic: invalid api key"
-	run2.FailureCode = store.FailureAuthFailed
 	run2.RetryState = &store.RunRetryState{Attempts: 1}
-	run2.UpdatedAt = run2.UpdatedAt.Add(10 * time.Minute)
 	if err := rs.SaveRun(context.Background(), run2); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/internal/mongoutil/find.go
+++ b/pkg/internal/mongoutil/find.go
@@ -115,7 +115,9 @@ func ReplaceOneChecked(ctx context.Context, coll *mongo.Collection, filter bson.
 // notFoundErr. It is the shared shape behind the many "update field(s)
 // of X" methods that reject an update to a missing document, as
 // opposed to ReplaceOneChecked's whole-document replace.
-func UpdateOneChecked(ctx context.Context, coll *mongo.Collection, filter, update bson.M, notFoundErr error, errMsg string) error {
+// update accepts a bson.M operator document or a mongo.Pipeline
+// (aggregation-pipeline update) — UpdateOne takes either.
+func UpdateOneChecked(ctx context.Context, coll *mongo.Collection, filter bson.M, update any, notFoundErr error, errMsg string) error {
 	res, err := coll.UpdateOne(ctx, filter, update)
 	if err != nil {
 		return fmt.Errorf("%s: %w", errMsg, err)

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -1202,6 +1202,24 @@ func (r *Runner) processOne(parent context.Context, delivery *natsq.Delivery) {
 	if outcomeSideEffectsFire(err, outcome.action) {
 		fireOutcome()
 	}
+	// The continuation promote: only the RUNNER knows whether a Nak
+	// really means a redelivery (the engine has no queue topology, so
+	// its park writers leave continuation unknown). Promote to
+	// redelivery_pending at the actual Nak — a same-status write that
+	// states ownership without touching the engine's cause or message,
+	// and without inventing an episode. A Nak into nothing (last
+	// permitted delivery of an ErrRunInterrupted, exempt from DLQ)
+	// stays unknown, which is honest: nobody owns that run's future.
+	if outcome.action == actionNak && redeliverable && r.cfg.Store != nil {
+		bg, cancel := context.WithTimeout(context.WithoutCancel(runCtx), 10*time.Second)
+		sctx := store.WithIdentity(bg, msg.TenantID, msg.OwnerID)
+		if _, serr := r.cfg.Store.UpdateRunOutcome(sctx, msg.RunID, store.RunStatusFailedResumable, "",
+			store.RunOutcomeMeta{Continuation: store.ContinuationRedeliveryPending},
+			[]store.RunStatus{store.RunStatusFailedResumable}); serr != nil {
+			logger.Warn("runner: continuation promote for %s: %v", msg.RunID, serr)
+		}
+		cancel()
+	}
 	logAt(logger, outcome.level, outcome.logFmt, outcome.logArgs...)
 	finalStatus = outcome.finalStatus
 	dispatchTerminal(logger, delivery, outcome.action, outcome.op, msg.RunID)

--- a/pkg/runner/loop_nats.go
+++ b/pkg/runner/loop_nats.go
@@ -208,11 +208,19 @@ func (r *Runner) parkOnDLQOnFinalDelivery(err error, delivery *natsq.Delivery, m
 		return true, "dlq"
 	}
 	sctx := store.WithIdentity(bg, msg.TenantID, msg.OwnerID)
-	if _, serr := r.cfg.Store.UpdateRunOutcome(sctx, msg.RunID, store.RunStatusFailedResumable,
+	// failed_resumable is in the expected set because on the NOMINAL
+	// path the engine has already written it before this park runs —
+	// a CAS from [running, queued] alone could never land, and the
+	// DLQ_PARKED cause died silently (adversarial gate F4). The
+	// abstention is logged: a filter miss here means the document's
+	// story and the queue's diverged.
+	if changed, serr := r.cfg.Store.UpdateRunOutcome(sctx, msg.RunID, store.RunStatusFailedResumable,
 		fmt.Sprintf("max deliveries exhausted: %v (parked on DLQ — replay via /api/admin/dlq)", err),
 		store.RunOutcomeMeta{Code: store.FailureDLQParked, Continuation: store.ContinuationFinal},
-		[]store.RunStatus{store.RunStatusRunning, store.RunStatusQueued}); serr != nil {
+		[]store.RunStatus{store.RunStatusRunning, store.RunStatusQueued, store.RunStatusFailedResumable}); serr != nil {
 		logger.Warn("runner: DLQ status flip for %s: %v", msg.RunID, serr)
+	} else if !changed {
+		logger.Warn("runner: DLQ status flip for %s declined (status drifted) — the document does not carry DLQ_PARKED", msg.RunID)
 	}
 	termTerminal(logger, delivery, "term-dlq-parked", msg.RunID)
 	return true, "dlq"

--- a/pkg/runner/loop_nats.go
+++ b/pkg/runner/loop_nats.go
@@ -208,8 +208,9 @@ func (r *Runner) parkOnDLQOnFinalDelivery(err error, delivery *natsq.Delivery, m
 		return true, "dlq"
 	}
 	sctx := store.WithIdentity(bg, msg.TenantID, msg.OwnerID)
-	if _, serr := r.cfg.Store.UpdateRunStatusIf(sctx, msg.RunID, store.RunStatusFailedResumable,
+	if _, serr := r.cfg.Store.UpdateRunOutcome(sctx, msg.RunID, store.RunStatusFailedResumable,
 		fmt.Sprintf("max deliveries exhausted: %v (parked on DLQ — replay via /api/admin/dlq)", err),
+		store.RunOutcomeMeta{Code: store.FailureDLQParked, Continuation: store.ContinuationFinal},
 		[]store.RunStatus{store.RunStatusRunning, store.RunStatusQueued}); serr != nil {
 		logger.Warn("runner: DLQ status flip for %s: %v", msg.RunID, serr)
 	}

--- a/pkg/runner/usage_cap.go
+++ b/pkg/runner/usage_cap.go
@@ -160,8 +160,15 @@ func (r *Runner) usageCapPreflight(ctx context.Context, wf *ir.Workflow, msg *qu
 		sctx, scancel := context.WithTimeout(context.WithoutCancel(ctx), usageCapStoreTimeout)
 		defer scancel()
 		sctx = store.WithIdentity(sctx, msg.TenantID, msg.OwnerID)
-		if _, serr := r.cfg.Store.UpdateRunStatusIfCoded(sctx, msg.RunID, store.RunStatusFailedResumable,
-			d.Reason, store.FailureUsageLimitBlocked,
+		if _, serr := r.cfg.Store.UpdateRunOutcome(sctx, msg.RunID, store.RunStatusFailedResumable,
+			d.Reason,
+			// Continuation deliberately unknown here: the arming
+			// decision happens later (armUsageWindowRetry), and three
+			// of its branches arm nothing — the document must not say
+			// retry_armed before a retry actually exists. Promotion to
+			// retry_armed lives with ScheduleRunRetry; demotion to
+			// final with AbandonRunRetry.
+			store.RunOutcomeMeta{Code: store.FailureUsageLimitBlocked},
 			[]store.RunStatus{store.RunStatusRunning, store.RunStatusQueued}); serr != nil && logger != nil {
 			logger.Warn("runner: usage-cap status flip for %s: %v", msg.RunID, serr)
 		}

--- a/pkg/runner/usage_cap_test.go
+++ b/pkg/runner/usage_cap_test.go
@@ -22,16 +22,18 @@ type capStatusStore struct {
 	store.RunStore
 	gotStatus store.RunStatus
 	gotErr    string
-	gotCode   store.FailureCode
+	gotMeta   store.RunOutcomeMeta
 	gotFrom   []store.RunStatus
 	calls     int
 }
 
-func (s *capStatusStore) UpdateRunStatusIfCoded(_ context.Context, _ string, status store.RunStatus, runErr string, code store.FailureCode, from []store.RunStatus) (bool, error) {
+// The fake records the FULL meta — a fake that throws the metadata away
+// certifies a writer that could stop passing it (adversarial gate F5).
+func (s *capStatusStore) UpdateRunOutcome(_ context.Context, _ string, status store.RunStatus, runErr string, meta store.RunOutcomeMeta, from []store.RunStatus) (bool, error) {
 	s.calls++
 	s.gotStatus = status
 	s.gotErr = runErr
-	s.gotCode = code
+	s.gotMeta = meta
 	s.gotFrom = from
 	return true, nil
 }
@@ -109,8 +111,8 @@ func TestUsageCapPreflight_BlocksBeforeSpendingAnything(t *testing.T) {
 	if rs.calls != 1 || rs.gotStatus != store.RunStatusFailedResumable {
 		t.Fatalf("status flip: calls=%d status=%q — without failed_resumable the retry cannot arm", rs.calls, rs.gotStatus)
 	}
-	if rs.gotCode != store.FailureUsageLimitBlocked {
-		t.Errorf("failure code = %q, want USAGE_LIMIT_BLOCKED persisted with the flip", rs.gotCode)
+	if rs.gotMeta.Code != store.FailureUsageLimitBlocked {
+		t.Errorf("failure code = %q, want USAGE_LIMIT_BLOCKED persisted with the flip", rs.gotMeta.Code)
 	}
 	if rs.gotErr == "" {
 		t.Error("the run must say why it did not start")

--- a/pkg/runview/service_control.go
+++ b/pkg/runview/service_control.go
@@ -128,7 +128,10 @@ func (s *Service) CancelInactiveCtx(ctx context.Context, runID string) (bool, er
 	if r.Error != "" {
 		reason += ": " + r.Error
 	}
-	if err := s.store.UpdateRunStatusCoded(ctx, runID, store.RunStatusCancelled, reason, store.FailureCancelled); err != nil {
+	// An operator cancel is the one server-side writer that KNOWS the
+	// continuation: nobody owns this run's future any more (final).
+	if _, err := s.store.UpdateRunOutcome(ctx, runID, store.RunStatusCancelled, reason,
+		store.RunOutcomeMeta{Code: store.FailureCancelled, Continuation: store.ContinuationFinal}, nil); err != nil {
 		return false, fmt.Errorf("update status: %w", err)
 	}
 	// Re-load post-flip so RecoverFinalize sees the new status.

--- a/pkg/runview/snapshot.go
+++ b/pkg/runview/snapshot.go
@@ -129,14 +129,20 @@ type RunHeader struct {
 	// Worktree finalization summary (only populated for `worktree:
 	// auto` runs that reached a clean exit). The studio uses these to
 	// surface the persistent branch and FF status in the run header.
-	FinalCommit      string              `json:"final_commit,omitempty"`
-	FinalBranch      string              `json:"final_branch,omitempty"`
-	FinalBranchError string              `json:"final_branch_error,omitempty"`
-	MergedInto       string              `json:"merged_into,omitempty"`
-	MergedCommit     string              `json:"merged_commit,omitempty"`
-	MergeStrategy    store.MergeStrategy `json:"merge_strategy,omitempty"`
-	MergeStatus      store.MergeStatus   `json:"merge_status,omitempty"`
-	AutoMerge        bool                `json:"auto_merge,omitempty"`
+	FinalCommit      string `json:"final_commit,omitempty"`
+	FinalBranch      string `json:"final_branch,omitempty"`
+	FinalBranchError string `json:"final_branch_error,omitempty"`
+	// Outcome bookkeeping (see store.Run): the episode counter, the
+	// typed cause of the last terminal transition, and who owns the
+	// continuation. This is what lets an outcome consumer act on the
+	// DOCUMENT instead of parsing error prose or replaying events.
+	OutcomeSeq        int64                   `json:"outcome_seq,omitempty"`
+	ContinuationState store.ContinuationState `json:"continuation_state,omitempty"`
+	MergedInto        string                  `json:"merged_into,omitempty"`
+	MergedCommit      string                  `json:"merged_commit,omitempty"`
+	MergeStrategy     store.MergeStrategy     `json:"merge_strategy,omitempty"`
+	MergeStatus       store.MergeStatus       `json:"merge_status,omitempty"`
+	AutoMerge         bool                    `json:"auto_merge,omitempty"`
 	// LocAdded / LocDeleted aggregate the three-dot numstat of the
 	// run's commits against its fork point (merge-base of the merge
 	// target and FinalCommit), computed server-side with a cache.
@@ -1430,6 +1436,8 @@ func headerFromRun(r *store.Run) RunHeader {
 		FinalCommit:       r.FinalCommit,
 		FinalBranch:       r.FinalBranch,
 		FinalBranchError:  r.FinalBranchError,
+		OutcomeSeq:        r.OutcomeSeq,
+		ContinuationState: r.ContinuationState,
 		MergedInto:        r.MergedInto,
 		MergedCommit:      r.MergedCommit,
 		MergeStrategy:     r.MergeStrategy,

--- a/pkg/server/queue_sweeper.go
+++ b/pkg/server/queue_sweeper.go
@@ -164,8 +164,9 @@ func (s *Server) sweepOrphanRuns(ctx context.Context, lister staleRunLister, lea
 				continue // in flight
 			}
 			runCtx := store.WithIdentity(ctx, ref.TenantID, "sweeper")
-			changed, err := s.cfg.Store.UpdateRunStatusIf(runCtx, ref.ID, store.RunStatusFailedResumable,
+			changed, err := s.cfg.Store.UpdateRunOutcome(runCtx, ref.ID, store.RunStatusFailedResumable,
 				"orphaned by a runner crash or exhausted redelivery — resume to retry",
+				store.RunOutcomeMeta{Code: store.FailureProcessOrphaned, Continuation: store.ContinuationFinal},
 				p.statuses)
 			if err != nil {
 				countErr("flip", err)

--- a/pkg/server/queue_sweeper_test.go
+++ b/pkg/server/queue_sweeper_test.go
@@ -51,6 +51,10 @@ type fakeSweepStore struct {
 	flipped map[string]store.RunStatus
 }
 
+func (f *fakeSweepStore) UpdateRunOutcome(ctx context.Context, id string, status store.RunStatus, runErr string, _ store.RunOutcomeMeta, expectedFrom []store.RunStatus) (bool, error) {
+	return f.UpdateRunStatusIf(ctx, id, status, runErr, expectedFrom)
+}
+
 func (f *fakeSweepStore) UpdateRunStatusIf(ctx context.Context, id string, status store.RunStatus, _ string, _ []store.RunStatus) (bool, error) {
 	// The sweeper must stamp the run's tenant before the CAS — assert
 	// the ctx carries one (the mongo store would panic otherwise).

--- a/pkg/store/conformance_test.go
+++ b/pkg/store/conformance_test.go
@@ -319,3 +319,4 @@ func TestConformance_Filesystem(t *testing.T) {
 		return s
 	})
 }
+

--- a/pkg/store/conformance_test.go
+++ b/pkg/store/conformance_test.go
@@ -40,6 +40,7 @@ type conformanceOpts struct {
 func conformanceSuiteWithOpts(t *testing.T, factory runStoreFactory, opts conformanceOpts) {
 	t.Run("CreateLoadRoundTrip", func(t *testing.T) { testCreateLoad(t, factory(t), opts) })
 	t.Run("StatusTransitions", func(t *testing.T) { testStatusTransitions(t, factory(t)) })
+	t.Run("SaveRunHostileValues", func(t *testing.T) { testSaveRunHostileValues(t, factory(t)) })
 	t.Run("EventSeqMonotone", func(t *testing.T) { testEventSeqMonotone(t, factory(t)) })
 	t.Run("EventSeqUnderConcurrency", func(t *testing.T) { testEventSeqConcurrent(t, factory(t)) })
 	t.Run("ArtifactVersionsMonotone", func(t *testing.T) { testArtifactVersions(t, factory(t)) })
@@ -320,3 +321,50 @@ func TestConformance_Filesystem(t *testing.T) {
 	})
 }
 
+// testSaveRunHostileValues guards the Mongo pipeline against
+// aggregation-expression evaluation of DATA: a $-prefixed string value
+// must round-trip verbatim (not be parsed as a field path and dropped
+// or substituted), and a dotted map key must not reject the write —
+// agent outputs ("$ ./gradlew build") and user inputs ("config.path")
+// produce both shapes routinely.
+func testSaveRunHostileValues(t *testing.T, s RunStore) {
+	t.Helper()
+	ctx := context.Background()
+	const runID = "run-hostile-values"
+	if _, err := s.CreateRun(ctx, runID, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	r, err := s.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	r.Error = "$workflow_name is not a field path"
+	r.Inputs = map[string]any{"config.path": "/etc/app.yml", "cmd": "$JAVA_HOME/bin/java"}
+	if err := s.SaveRun(ctx, r); err != nil {
+		t.Fatalf("SaveRun with hostile values: %v", err)
+	}
+	got, err := s.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.Error != r.Error {
+		t.Fatalf("Error = %q, want %q (a $-value was evaluated, not stored)", got.Error, r.Error)
+	}
+	if got.Inputs["config.path"] != "/etc/app.yml" || got.Inputs["cmd"] != "$JAVA_HOME/bin/java" {
+		t.Fatalf("Inputs = %v, want the hostile keys/values verbatim", got.Inputs)
+	}
+
+	// An upsert-create directly in a terminal status is NOT an episode:
+	// nothing transitioned, the document was born that way (fork seeds
+	// cancelled children through SaveRun on a run that does not exist).
+	born := *got
+	born.ID = "run-born-terminal"
+	born.Status = RunStatusCancelled
+	born.OutcomeSeq = 0
+	if err := s.SaveRun(ctx, &born); err != nil {
+		t.Fatalf("SaveRun upsert-create: %v", err)
+	}
+	if b, err := s.LoadRun(ctx, "run-born-terminal"); err != nil || b.OutcomeSeq != 0 {
+		t.Fatalf("born-terminal = (seq %d, %v), want (0, nil)", b.OutcomeSeq, err)
+	}
+}

--- a/pkg/store/iface.go
+++ b/pkg/store/iface.go
@@ -131,6 +131,17 @@ type RunStore interface {
 	// cloud publisher to avoid stomping on raced state transitions.
 	UpdateRunStatusIf(ctx context.Context, id string, status RunStatus, runErr string, expectedFrom []RunStatus) (changed bool, err error)
 	UpdateRunStatusIfCoded(ctx context.Context, id string, status RunStatus, runErr string, code FailureCode, expectedFrom []RunStatus) (changed bool, err error)
+	// UpdateRunOutcome is the typed status transition: UpdateRunStatusIf
+	// plus the outcome metadata (failure classification + continuation
+	// ownership) persisted atomically with it. nil expectedFrom makes
+	// the write unconditional. This is the RUNNER-side choke point that
+	// stops the class of "the run document says failed_resumable and
+	// nothing else" — a consumer reads WHY and WHO owns the continuation
+	// from the document, not from event-prose archaeology. Engine paths
+	// keep the code-only writers below (the engine cannot know the queue
+	// topology, so it never states a continuation — F3 of the
+	// adversarial gate).
+	UpdateRunOutcome(ctx context.Context, id string, status RunStatus, runErr string, meta RunOutcomeMeta, expectedFrom []RunStatus) (changed bool, err error)
 	SaveCheckpoint(ctx context.Context, id string, cp *Checkpoint) error
 	PauseRun(ctx context.Context, id string, cp *Checkpoint) error
 	FailRunResumable(ctx context.Context, id string, cp *Checkpoint, runErr string, code FailureCode) error

--- a/pkg/store/lifecycle.go
+++ b/pkg/store/lifecycle.go
@@ -91,6 +91,9 @@ const (
 	// because its message schema version is outside the runner's
 	// accepted range. Declared for the schema-park writer (follow-up).
 	FailureQueueSchemaMismatch FailureCode = "QUEUE_SCHEMA_MISMATCH"
+	// FailureDLQParked: the queue exhausted its deliveries for this run
+	// and parked it on the DLQ — replay via /api/admin/dlq.
+	FailureDLQParked FailureCode = "DLQ_PARKED"
 )
 
 // AllRunStatuses is the exhaustive status vocabulary, for callers that

--- a/pkg/store/lifecycle_negative_space_test.go
+++ b/pkg/store/lifecycle_negative_space_test.go
@@ -293,11 +293,11 @@ var negativeSpaceAllowlist = map[string]allowEntry{
 	"pkg/cli/remote_runs.go :: Cancelled+Failed+FailedResumable+Finished":  {[]string{"followRemoteRun"}, "--follow stop set over the WIRE statuses (strings): IsTerminal's set; the paused non-exit is the known bug #3 follow-up card"},
 
 	// -- pkg/runner.
-	"pkg/runner/loop.go :: Failed+Finished":                    {[]string{"bankableStatus"}, "forge-banking outcomes (finalStatus strings; budget_exceeded rides along outside the run-status vocabulary)"},
-	"pkg/runner/loop.go :: Failed+Finished+PausedWaitingHuman": {[]string{"resolveDeliveryPreconditions"}, "stale-delivery drop set: shapes a redelivery can never legitimately target"},
-	"pkg/runner/loop.go :: FailedResumable+PausedOperator":     {[]string{"resolveDeliveryPreconditions"}, "redelivery auto-convert-to-Resume pair (dispatcher-parked shapes)"},
-	"pkg/runner/loop_nats.go :: Queued+Running":                {[]string{"parkOnDLQOnFinalDelivery"}, "DLQ park CAS: only a claimed-or-queued attempt may be parked"},
-	"pkg/runner/usage_cap.go :: Queued+Running":                {[]string{"usageCapPreflight"}, "usage-cap park CAS: only a claimed-or-queued attempt may be parked"},
+	"pkg/runner/loop.go :: Failed+Finished":                     {[]string{"bankableStatus"}, "forge-banking outcomes (finalStatus strings; budget_exceeded rides along outside the run-status vocabulary)"},
+	"pkg/runner/loop.go :: Failed+Finished+PausedWaitingHuman":  {[]string{"resolveDeliveryPreconditions"}, "stale-delivery drop set: shapes a redelivery can never legitimately target"},
+	"pkg/runner/loop.go :: FailedResumable+PausedOperator":      {[]string{"resolveDeliveryPreconditions"}, "redelivery auto-convert-to-Resume pair (dispatcher-parked shapes)"},
+	"pkg/runner/loop_nats.go :: FailedResumable+Queued+Running": {[]string{"parkOnDLQOnFinalDelivery"}, "DLQ park CAS: claimed/queued attempts AND the engine's own failed_resumable write — on the nominal path the engine parks first, and a CAS that excluded it dropped the DLQ_PARKED cause silently (gate F4)"},
+	"pkg/runner/usage_cap.go :: Queued+Running":                 {[]string{"usageCapPreflight"}, "usage-cap park CAS: only a claimed-or-queued attempt may be parked"},
 
 	// -- pkg/worktreepool.
 	"pkg/worktreepool/classify.go :: PausedOperator+PausedWaitingHuman": {[]string{"isPausedResumable"}, "the paused pair guarding checkout sparing (GC policy nuance documented at the site)"},

--- a/pkg/store/lifecycle_negative_space_test.go
+++ b/pkg/store/lifecycle_negative_space_test.go
@@ -254,9 +254,9 @@ func markLogicalDescendants(n ast.Node, marked map[ast.Node]bool) {
 // reason here.
 var negativeSpaceAllowlist = map[string]allowEntry{
 	// -- pkg/store: transition machinery + harnesses.
-	"pkg/store/store_run.go :: Cancelled+Failed+FailedResumable+Finished":                                                              {[]string{"applyStatusTransition"}, "FinishedAt-stamping side-effect switch"},
-	"pkg/store/store_run.go :: PausedWaitingHuman+Running":                                                                             {[]string{"applyStatusTransition"}, "FinishedAt-clear pair (resume paths un-freeze the duration ticker)"},
-	"pkg/store/mongo/runs.go :: Cancelled+Failed+FailedResumable+Finished":                                                             {[]string{"ListNotifiableRuns", "runStatusUpdate"}, "the mongo transition switch + the notifiable-sweep terminal $in (a bson filter cannot call a predicate; both are IsTerminal's set)"},
+	"pkg/store/store_run.go :: Cancelled+Failed+FailedResumable+Finished":                                                              {[]string{"applyStatusTransitionOutcome"}, "FinishedAt-stamping side-effect switch (renamed by the outcome-bookkeeping merge)"},
+	"pkg/store/store_run.go :: PausedWaitingHuman+Running":                                                                             {[]string{"applyStatusTransitionOutcome"}, "FinishedAt-clear pair (resume paths un-freeze the duration ticker)"},
+	"pkg/store/mongo/runs.go :: Cancelled+Failed+FailedResumable+Finished":                                                             {[]string{"ListNotifiableRuns", "SaveRun"}, "the notifiable-sweep terminal $in + SaveRun's terminal-arrival episode increment (a bson filter/pipeline cannot call a predicate; both are IsTerminal's set — the transition choke point itself now derives via predicates in statusTransitionSet)"},
 	"pkg/store/mongo/runs.go :: Queued+Running":                                                                                        {[]string{"CountActiveRunsByTenant"}, "CountsAgainstLaunchLimit twin inside a $in filter"},
 	"pkg/store/storetest/conformance.go :: Cancelled+Failed+FailedResumable+Finished+PausedOperator+PausedWaitingHuman+Queued+Running": {[]string{"testTombstoneRefusesWriters"}, "tombstone canary passes every status to prove no CAS writes on a deleted run"},
 

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -712,6 +712,7 @@ func (s *Store) RecordNodeServed(ctx context.Context, id, nodeID string, served 
 //     the writer states one (an untyped rewrite of an already-parked
 //     run must not erase a live retry_armed), and cleared on a genuine
 //     state change without a statement.
+//
 // Free-text values ride under $literal — in a pipeline stage a string
 // value is an EXPRESSION, and an operator-supplied error message
 // containing "$status" must be stored as data, not evaluated.
@@ -721,16 +722,31 @@ func statusTransitionSet(status store.RunStatus, runErr string, meta store.RunOu
 	set := bson.M{
 		"status":     bson.M{"$literal": string(status)},
 		"updated_at": now,
-		"error":      bson.M{"$literal": runErr},
 		"version":    bson.M{"$add": bson.A{bson.M{"$ifNull": bson.A{"$version", 0}}, 1}},
+	}
+	// The error message: a transition always states its own (empty
+	// included); a same-status rewrite that states nothing keeps the
+	// transition's message — the runner's continuation promote must not
+	// blank the engine's failure text.
+	if runErr != "" {
+		set["error"] = bson.M{"$literal": runErr}
+	} else {
+		set["error"] = bson.M{"$cond": bson.A{statusChanged, "", bson.M{"$ifNull": bson.A{"$error", ""}}}}
 	}
 	// The FailureCode discipline: set on a failure status, removed by
 	// every transition to a non-failure one — $$REMOVE, not "", keeps
 	// the persisted shape identical to the FS twin's omitempty JSON
-	// (including an UNKNOWN empty code on a failure status).
-	if status.CarriesFailureCode() && meta.Code != "" {
+	// (including an UNKNOWN empty code on a failure status). An untyped
+	// SAME-STATUS rewrite preserves the cause the transition wrote
+	// (adversarial gate F1's second half: a drain-style rewrite must
+	// not erase the typed cause).
+	switch {
+	case status.CarriesFailureCode() && meta.Code != "":
 		set["failure_code"] = bson.M{"$literal": string(meta.Code)}
-	} else {
+	case status.CarriesFailureCode():
+		set["failure_code"] = bson.M{"$cond": bson.A{statusChanged, "$$REMOVE",
+			bson.M{"$ifNull": bson.A{"$failure_code", "$$REMOVE"}}}}
+	default:
 		set["failure_code"] = "$$REMOVE"
 	}
 	// The pause pointer is a consumable (store.CarriesPausePointer):
@@ -870,7 +886,6 @@ func (s *Store) FailQueuedRunIfAttempt(ctx context.Context, id, runErr string, p
 	}
 	return res.MatchedCount > 0, nil
 }
-
 
 var _ store.QueuedAttemptStore = (*Store)(nil)
 

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -269,7 +269,10 @@ func (s *Store) SaveRun(ctx context.Context, r *store.Run) error {
 	case store.RunStatusFinished, store.RunStatusFailed, store.RunStatusFailedResumable, store.RunStatusCancelled:
 		terminalInc = 1
 	}
-	statusChanged := bson.M{"$ne": bson.A{"$status", r.Status}}
+	// $ifNull: an upsert-create has no $status; without the default a
+	// brand-new document written directly in a terminal status would
+	// count an episode on Mongo and none on FS.
+	statusChanged := bson.M{"$ne": bson.A{bson.M{"$ifNull": bson.A{"$status", r.Status}}, r.Status}}
 	seqBase := bson.M{"$ifNull": bson.A{"$outcome_seq", 0}}
 	// The document's own (normalized) failure code lands on a status
 	// CHANGE — a transition through SaveRun owns its cause (the
@@ -285,8 +288,16 @@ func (s *Store) SaveRun(ctx context.Context, r *store.Run) error {
 		"continuation_state": bson.M{"$cond": bson.A{statusChanged, "$$REMOVE", bson.M{"$ifNull": bson.A{"$continuation_state", "$$REMOVE"}}}},
 		"failure_code":       bson.M{"$cond": bson.A{statusChanged, docCode, bson.M{"$ifNull": bson.A{"$failure_code", "$$REMOVE"}}}},
 	}
+	// $literal shields the document from aggregation-expression
+	// evaluation: without it, any string VALUE starting with "$" is
+	// parsed as a field path (silently dropped or substituted by
+	// another field's value) and any map key containing "." rejects
+	// the write — an agent output like "$ ./gradlew build" or an input
+	// keyed "config.path" is enough. The computed fields stay outside
+	// the literal: they must resolve $status/$outcome_seq against the
+	// stored pre-image.
 	pipeline := mongo.Pipeline{
-		{{Key: "$replaceWith", Value: bson.M{"$mergeObjects": bson.A{computed, doc}}}},
+		{{Key: "$replaceWith", Value: bson.M{"$mergeObjects": bson.A{computed, bson.M{"$literal": doc}}}}},
 	}
 	_, err = s.runs.UpdateOne(ctx, notDeleted(withTenantFilter(ctx, bson.M{"_id": r.ID})), pipeline, options.UpdateOne().SetUpsert(true))
 	if err != nil {

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -245,7 +245,50 @@ func (s *Store) SaveRun(ctx context.Context, r *store.Run) error {
 		cp.InteractionQuestions = nil
 		r.Checkpoint = &cp
 	}
-	_, err := s.runs.ReplaceOne(ctx, notDeleted(withTenantFilter(ctx, bson.M{"_id": r.ID})), r, options.Replace().SetUpsert(true))
+	// Pipeline update instead of a plain ReplaceOne: the outcome
+	// bookkeeping (outcome_seq / continuation_state) does not belong to
+	// full-document savers — a caller replaying a stale in-memory Run
+	// must not rewind the episode counter or resurrect a continuation a
+	// status transition wrote meanwhile. Same persisted status ⇒ keep
+	// the persisted values; a status change through SaveRun IS a
+	// transition ⇒ new episode on terminal arrival, continuation
+	// cleared (untyped). Mirrors FilesystemRunStore.
+	raw, err := bson.Marshal(r)
+	if err != nil {
+		return fmt.Errorf("store/mongo: marshal run %s: %w", r.ID, err)
+	}
+	var doc bson.M
+	if err := bson.Unmarshal(raw, &doc); err != nil {
+		return fmt.Errorf("store/mongo: remarshal run %s: %w", r.ID, err)
+	}
+	delete(doc, "outcome_seq")
+	delete(doc, "continuation_state")
+	delete(doc, "failure_code")
+	terminalInc := 0
+	switch r.Status {
+	case store.RunStatusFinished, store.RunStatusFailed, store.RunStatusFailedResumable, store.RunStatusCancelled:
+		terminalInc = 1
+	}
+	statusChanged := bson.M{"$ne": bson.A{"$status", r.Status}}
+	seqBase := bson.M{"$ifNull": bson.A{"$outcome_seq", 0}}
+	// The document's own (normalized) failure code lands on a status
+	// CHANGE — a transition through SaveRun owns its cause (the
+	// publisher rollback re-stamps the prior one this way). On a
+	// same-status save the persisted value wins: a stale copy must not
+	// erase what a park wrote meanwhile.
+	var docCode any = "$$REMOVE"
+	if r.FailureCode != "" {
+		docCode = bson.M{"$literal": string(r.FailureCode)}
+	}
+	computed := bson.M{
+		"outcome_seq":        bson.M{"$cond": bson.A{statusChanged, bson.M{"$add": bson.A{seqBase, terminalInc}}, seqBase}},
+		"continuation_state": bson.M{"$cond": bson.A{statusChanged, "$$REMOVE", bson.M{"$ifNull": bson.A{"$continuation_state", "$$REMOVE"}}}},
+		"failure_code":       bson.M{"$cond": bson.A{statusChanged, docCode, bson.M{"$ifNull": bson.A{"$failure_code", "$$REMOVE"}}}},
+	}
+	pipeline := mongo.Pipeline{
+		{{Key: "$replaceWith", Value: bson.M{"$mergeObjects": bson.A{computed, doc}}}},
+	}
+	_, err = s.runs.UpdateOne(ctx, notDeleted(withTenantFilter(ctx, bson.M{"_id": r.ID})), pipeline, options.UpdateOne().SetUpsert(true))
 	if err != nil {
 		if mongo.IsDuplicateKeyError(err) {
 			return fmt.Errorf("store/mongo: run %s: %w", r.ID, store.ErrRunDeleted)
@@ -644,56 +687,89 @@ func (s *Store) RecordNodeServed(ctx context.Context, id, nodeID string, served 
 	return nil
 }
 
-// runStatusUpdate builds the shared $set/$unset pair for a status
-// transition — the Mongo twin of the FS store's applyStatusTransition,
-// including the FailureCode discipline: set on a failure status,
-// cleared by every transition to a non-failure one.
-func runStatusUpdate(status store.RunStatus, runErr string, code store.FailureCode, now time.Time) (bson.M, bson.M) {
+// statusTransitionSet builds the single $set-stage document of a
+// status-transition PIPELINE update — the Mongo twin of the FS store's
+// applyStatusTransitionOutcome, and the one choke point every status
+// writer goes through (a writer that hand-rolls its update WILL
+// drift). A pipeline, not a plain $set/$unset pair, because two of the
+// disciplines are conditional on the CURRENT document:
+//   - outcome_seq increments only on a TRANSITION into a terminal
+//     status ($cond on "$status"): a same-status rewrite (a drain's
+//     markInterrupted, a repeated flip, the publisher's rollback) must
+//     not invent an episode;
+//   - continuation_state is preserved on a same-status rewrite unless
+//     the writer states one (an untyped rewrite of an already-parked
+//     run must not erase a live retry_armed), and cleared on a genuine
+//     state change without a statement.
+// Free-text values ride under $literal — in a pipeline stage a string
+// value is an EXPRESSION, and an operator-supplied error message
+// containing "$status" must be stored as data, not evaluated.
+func statusTransitionSet(status store.RunStatus, runErr string, meta store.RunOutcomeMeta, now time.Time) bson.M {
+	terminal := status.IsFinalSuccess() || status.IsFinalFailure() || status.IsTerminalResumable()
+	statusChanged := bson.M{"$ne": bson.A{"$status", string(status)}}
 	set := bson.M{
-		"status":     status,
+		"status":     bson.M{"$literal": string(status)},
 		"updated_at": now,
-		"error":      runErr,
+		"error":      bson.M{"$literal": runErr},
+		"version":    bson.M{"$add": bson.A{bson.M{"$ifNull": bson.A{"$version", 0}}, 1}},
 	}
-	unset := bson.M{}
-	// The pause pointer is a consumable (see store.CarriesPausePointer):
-	// a transition into a status that cannot truthfully carry it clears
-	// the interaction evidence off the surviving checkpoint. Dotted
-	// $unset is a no-op when the checkpoint (or field) is absent.
-	// Callers that $set the whole checkpoint document in the same
-	// update (failRunCheckpointed) must DROP these two keys and strip
-	// the value instead — Mongo rejects conflicting paths.
-	if !status.CarriesPausePointer() {
-		unset["checkpoint.interaction_id"] = ""
-		unset["checkpoint.interaction_questions"] = ""
-	}
-	if status.CarriesFailureCode() && code != "" {
-		set["failure_code"] = code
+	// The FailureCode discipline: set on a failure status, removed by
+	// every transition to a non-failure one — $$REMOVE, not "", keeps
+	// the persisted shape identical to the FS twin's omitempty JSON
+	// (including an UNKNOWN empty code on a failure status).
+	if status.CarriesFailureCode() && meta.Code != "" {
+		set["failure_code"] = bson.M{"$literal": string(meta.Code)}
 	} else {
-		// $unset, not $set "": keeps the persisted shape identical to
-		// the FS twin's omitempty JSON — including an UNKNOWN (empty)
-		// code on a failure status, so {$exists: false} means exactly
-		// "unclassified" on both twins.
-		unset["failure_code"] = ""
+		set["failure_code"] = "$$REMOVE"
 	}
-	switch status {
-	case store.RunStatusFinished, store.RunStatusFailed, store.RunStatusFailedResumable, store.RunStatusCancelled:
+	// The pause pointer is a consumable (store.CarriesPausePointer):
+	// strip it off the SURVIVING checkpoint via $unsetField, guarded on
+	// the checkpoint being a document (a dotted write on a null parent
+	// would materialize an empty object; an absent field evaluates to
+	// missing and stays absent).
+	if !status.CarriesPausePointer() {
+		set["checkpoint"] = bson.M{"$cond": bson.A{
+			bson.M{"$eq": bson.A{bson.M{"$type": "$checkpoint"}, "object"}},
+			bson.M{"$unsetField": bson.M{"field": "interaction_questions",
+				"input": bson.M{"$unsetField": bson.M{"field": "interaction_id", "input": "$checkpoint"}}}},
+			"$checkpoint",
+		}}
+	}
+	switch {
+	case terminal:
 		set["finished_at"] = now
-	case store.RunStatusQueued:
+	case status == store.RunStatusQueued:
+		// Every queue publication is a distinct attempt (rejected by
+		// identity, not merely by the shared `queued` status).
 		set["queued_at"] = now
-		unset["finished_at"] = ""
-	case store.RunStatusRunning:
+		set["finished_at"] = "$$REMOVE"
+	case status == store.RunStatusRunning:
 		// Resume must clear FinishedAt or the elapsed-time ticker
-		// freezes mid-run (mirrors FilesystemRunStore).
-		set["error"] = ""
-		unset["finished_at"] = ""
-	case store.RunStatusPausedWaitingHuman:
-		// Mirror the FS store: a generic UpdateRunStatus that crosses
-		// from a previously-terminal (failed_resumable) state into
-		// paused-waiting-human must also clear finished_at so the
-		// elapsed-time UI doesn't stay frozen.
-		unset["finished_at"] = ""
+		// freezes mid-run; a running run carries no failure message.
+		set["error"] = bson.M{"$literal": ""}
+		set["finished_at"] = "$$REMOVE"
+	case status == store.RunStatusPausedWaitingHuman:
+		// A generic UpdateRunStatus crossing from a previously-terminal
+		// state into paused must clear finished_at too.
+		set["finished_at"] = "$$REMOVE"
 	}
-	return set, unset
+	if terminal {
+		seqBase := bson.M{"$ifNull": bson.A{"$outcome_seq", 0}}
+		set["outcome_seq"] = bson.M{"$cond": bson.A{statusChanged,
+			bson.M{"$add": bson.A{seqBase, 1}}, seqBase}}
+	}
+	if meta.Continuation != "" {
+		set["continuation_state"] = bson.M{"$literal": string(meta.Continuation)}
+	} else {
+		set["continuation_state"] = bson.M{"$cond": bson.A{statusChanged, "$$REMOVE",
+			bson.M{"$ifNull": bson.A{"$continuation_state", "$$REMOVE"}}}}
+	}
+	return set
+}
+
+// statusTransitionPipeline wraps the $set stage as the update pipeline.
+func statusTransitionPipeline(set bson.M) mongo.Pipeline {
+	return mongo.Pipeline{{{Key: "$set", Value: set}}}
 }
 
 func (s *Store) UpdateRunStatus(ctx context.Context, id string, status store.RunStatus, runErr string) error {
@@ -701,15 +777,27 @@ func (s *Store) UpdateRunStatus(ctx context.Context, id string, status store.Run
 }
 
 // UpdateRunStatusCoded is UpdateRunStatus carrying the typed failure
-// classification in the same $set.
+// classification in the same atomic write.
 func (s *Store) UpdateRunStatusCoded(ctx context.Context, id string, status store.RunStatus, runErr string, code store.FailureCode) error {
-	set, unset := runStatusUpdate(status, runErr, code, time.Now().UTC())
-	update := bson.M{"$set": set, "$inc": bson.M{"version": 1}}
-	if len(unset) > 0 {
-		update["$unset"] = unset
-	}
-	return mongoutil.UpdateOneChecked(ctx, s.runs, notDeleted(withTenantFilter(ctx, bson.M{"_id": id})), update,
+	pipeline := statusTransitionPipeline(statusTransitionSet(status, runErr, store.RunOutcomeMeta{Code: code}, time.Now().UTC()))
+	return mongoutil.UpdateOneChecked(ctx, s.runs, notDeleted(withTenantFilter(ctx, bson.M{"_id": id})), pipeline,
 		fmt.Errorf("store/mongo: run %s not found", id), fmt.Sprintf("store/mongo: update status %s", id))
+}
+
+// UpdateRunOutcome is the typed status transition (see store.RunStore):
+// UpdateRunStatusIf plus the outcome metadata persisted atomically.
+// The RUNNER-side writer — the engine's code-only writers stay above.
+func (s *Store) UpdateRunOutcome(ctx context.Context, id string, status store.RunStatus, runErr string, meta store.RunOutcomeMeta, expectedFrom []store.RunStatus) (bool, error) {
+	pipeline := statusTransitionPipeline(statusTransitionSet(status, runErr, meta, time.Now().UTC()))
+	filter := notDeleted(withTenantFilter(ctx, bson.M{"_id": id}))
+	if len(expectedFrom) > 0 {
+		filter["status"] = bson.M{"$in": expectedFrom}
+	}
+	res, err := s.runs.UpdateOne(ctx, filter, pipeline)
+	if err != nil {
+		return false, fmt.Errorf("store/mongo: update outcome %s: %w", id, err)
+	}
+	return res.MatchedCount > 0, nil
 }
 
 // UpdateRunStatusIf is a compare-and-set on the status field
@@ -725,20 +813,16 @@ func (s *Store) UpdateRunStatusIf(ctx context.Context, id string, status store.R
 // UpdateRunStatusIfCoded is the CAS variant carrying the typed failure
 // classification — code and status land in one atomic UpdateOne.
 func (s *Store) UpdateRunStatusIfCoded(ctx context.Context, id string, status store.RunStatus, runErr string, code store.FailureCode, expectedFrom []store.RunStatus) (bool, error) {
-	set, unset := runStatusUpdate(status, runErr, code, time.Now().UTC())
-	update := bson.M{"$set": set, "$inc": bson.M{"version": 1}}
-	if len(unset) > 0 {
-		update["$unset"] = unset
-	}
 	if len(expectedFrom) == 0 {
 		// A CAS with no expected set is an unconditional write in
 		// disguise (and the FS twin would silently no-op instead) —
 		// refuse loudly rather than diverge.
 		return false, fmt.Errorf("store/mongo: update status if %s: empty expectedFrom", id)
 	}
+	pipeline := statusTransitionPipeline(statusTransitionSet(status, runErr, store.RunOutcomeMeta{Code: code}, time.Now().UTC()))
 	filter := notDeleted(withTenantFilter(ctx, bson.M{"_id": id}))
 	filter["status"] = bson.M{"$in": expectedFrom}
-	res, err := s.runs.UpdateOne(ctx, filter, update)
+	res, err := s.runs.UpdateOne(ctx, filter, pipeline)
 	if err != nil {
 		return false, fmt.Errorf("store/mongo: update status if %s: %w", id, err)
 	}
@@ -766,18 +850,16 @@ func (s *Store) FailQueuedRunIfAttempt(ctx context.Context, id, runErr string, p
 		},
 	}))
 	// Queue-park classification is follow-up; the empty code reads as
-	// unknown, which is honest here.
-	set, unset := runStatusUpdate(store.RunStatusFailedResumable, runErr, "", now)
-	update := bson.M{"$set": set, "$inc": bson.M{"version": 1}}
-	if len(unset) > 0 {
-		update["$unset"] = unset
-	}
-	res, err := s.runs.UpdateOne(ctx, filter, update)
+	// unknown, which is honest here. The filter pins status=queued, so
+	// the transition-gated episode increment always fires.
+	pipeline := statusTransitionPipeline(statusTransitionSet(store.RunStatusFailedResumable, runErr, store.RunOutcomeMeta{}, now))
+	res, err := s.runs.UpdateOne(ctx, filter, pipeline)
 	if err != nil {
 		return false, fmt.Errorf("store/mongo: fail queued attempt %s: %w", id, err)
 	}
 	return res.MatchedCount > 0, nil
 }
+
 
 var _ store.QueuedAttemptStore = (*Store)(nil)
 
@@ -785,7 +867,7 @@ var _ store.QueuedAttemptStore = (*Store)(nil)
 // §F T-33 layers an explicit version-conditional update on top; this
 // method is the simple "no contention" form used by the engine itself.
 func (s *Store) SaveCheckpoint(ctx context.Context, id string, cp *store.Checkpoint) error {
-	// Same pointer discipline as runStatusUpdate (mirrors the FS
+	// Same pointer discipline as statusTransitionSet (mirrors the FS
 	// twin): a checkpoint carrying interaction evidence may only land
 	// while the run's status carries it — otherwise a stale in-memory
 	// copy is being replayed. The status read costs one projection and
@@ -826,29 +908,32 @@ func (s *Store) PauseRun(ctx context.Context, id string, cp *store.Checkpoint) e
 			"updated_at": now,
 		},
 		"$inc": bson.M{"version": 1},
-		// A paused run carries no failure classification — same
-		// discipline as runStatusUpdate, which this checkpoint-coupled
-		// write bypasses.
-		"$unset": bson.M{"finished_at": "", "failure_code": ""},
+		// A paused run carries no failure classification and no
+		// platform continuation statement — same discipline as
+		// statusTransitionSet, which this checkpoint-coupled write
+		// bypasses.
+		"$unset": bson.M{"finished_at": "", "failure_code": "", "continuation_state": ""},
 	}
 	return mongoutil.UpdateOneChecked(ctx, s.runs, notDeleted(withTenantFilter(ctx, bson.M{"_id": id})), update,
 		fmt.Errorf("store/mongo: run %s not found", id), fmt.Sprintf("store/mongo: pause %s", id))
 }
 
 // failRunCheckpointed is the shared body of FailRunResumable and
-// FailRunTerminal: the shared transition $set (which owns the
-// failure-code discipline) plus the checkpoint, guarded by the atomic
-// cancelled-wins filter — an operator cancel is terminal and outranks a
-// failure racing in behind it, and the failure would win simply by
-// writing last, auto-resuming a run somebody deliberately stopped.
+// FailRunTerminal: the shared transition pipeline (which owns the
+// failure-code and outcome-bookkeeping discipline) plus the
+// checkpoint, guarded by the atomic cancelled-wins filter — an
+// operator cancel is terminal and outranks a failure racing in behind
+// it, and the failure would win simply by writing last, auto-resuming
+// a run somebody deliberately stopped.
 func (s *Store) failRunCheckpointed(ctx context.Context, id string, status store.RunStatus, cp *store.Checkpoint, runErr string, code store.FailureCode, opName string) error {
-	set, unset := runStatusUpdate(status, runErr, code, time.Now().UTC())
-	// The whole-checkpoint $set below conflicts with the dotted pointer
-	// $unset — apply the same consumption to the VALUE instead. (Engine
-	// failure boundaries never set a pointer; this guards the preserved-
-	// checkpoint callers.)
-	delete(unset, "checkpoint.interaction_id")
-	delete(unset, "checkpoint.interaction_questions")
+	set := statusTransitionSet(status, runErr, store.RunOutcomeMeta{Code: code}, time.Now().UTC())
+	// The whole-checkpoint $set replaces statusTransitionSet's
+	// surviving-checkpoint expression — apply the pointer consumption
+	// to the VALUE instead. (Engine failure boundaries never set a
+	// pointer; this guards the preserved-checkpoint callers.) $literal
+	// because in a pipeline stage the checkpoint's own content —
+	// arbitrary node outputs — would otherwise be evaluated as
+	// expressions.
 	if cp != nil && !status.CarriesPausePointer() &&
 		(cp.InteractionID != "" || len(cp.InteractionQuestions) > 0) {
 		consumed := *cp
@@ -856,13 +941,13 @@ func (s *Store) failRunCheckpointed(ctx context.Context, id string, status store
 		consumed.InteractionQuestions = nil
 		cp = &consumed
 	}
-	set["checkpoint"] = cp
-	update := bson.M{"$set": set, "$inc": bson.M{"version": 1}}
-	if len(unset) > 0 {
-		update["$unset"] = unset
+	if cp != nil {
+		set["checkpoint"] = bson.M{"$literal": cp}
+	} else {
+		set["checkpoint"] = nil
 	}
 	filter := notDeleted(withTenantFilter(ctx, bson.M{"_id": id, "status": bson.M{"$ne": store.RunStatusCancelled}}))
-	res, err := s.runs.UpdateOne(ctx, filter, update)
+	res, err := s.runs.UpdateOne(ctx, filter, statusTransitionPipeline(set))
 	if err != nil {
 		return fmt.Errorf("store/mongo: %s %s: %w", opName, id, err)
 	}

--- a/pkg/store/mongo/runs_retry.go
+++ b/pkg/store/mongo/runs_retry.go
@@ -65,7 +65,11 @@ func (s *Store) ScheduleRunRetry(ctx context.Context, runID string, at time.Time
 			retryPath("retry_after"): at.UTC(),
 			retryPath("reason"):      reason,
 			retryPath("code"):        code,
-			"updated_at":             now,
+			// Arming IS the promotion: continuation_state must only say
+			// retry_armed once a retry actually exists (the block point
+			// stamps unknown), and this write is the one that creates it.
+			"continuation_state": store.ContinuationRetryArmed,
+			"updated_at":         now,
 		},
 		"$unset": bson.M{
 			// A fresh arming supersedes the previous failure note and claim.
@@ -155,7 +159,12 @@ func (s *Store) AbandonRunRetry(ctx context.Context, runID, reason string) error
 	update := bson.M{
 		"$set": bson.M{
 			retryPath("last_error"): reason,
-			"updated_at":            now,
+			// Nothing is armed any more — the run's future belongs to a
+			// human/consumer decision. Leaving retry_armed here would
+			// make an outcome consumer wait forever on a retry that
+			// will never fire.
+			"continuation_state": store.ContinuationFinal,
+			"updated_at":         now,
 		},
 		"$unset": bson.M{retryPath("retry_after"): ""},
 		"$inc":   bson.M{"version": 1},

--- a/pkg/store/mongo/runs_retry_test.go
+++ b/pkg/store/mongo/runs_retry_test.go
@@ -400,3 +400,53 @@ func TestRunRetry_StoreCapabilityIsDetectable(t *testing.T) {
 		t.Error("the Mongo store must satisfy store.RunRetryStore")
 	}
 }
+
+// TestRunRetry_ContinuationFollowsTheRetryLifecycle pins the promote/
+// demote pair: arming a retry IS the promotion to retry_armed (the
+// document must not claim it earlier — three branches of the runner's
+// arming decision arm nothing), and abandoning it demotes to final.
+// Without this canary both writes were mutant-survivable: nothing in
+// the repo asserted the continuation ever reaches a run document
+// through the retry lanes (adversarial gate F5).
+func TestRunRetry_ContinuationFollowsTheRetryLifecycle(t *testing.T) {
+	s := retryTestStore(t)
+	ctx := retryCtx()
+	const runID = "run-retry-continuation"
+	seedFailedResumable(t, s, runID)
+
+	load := func() *store.Run {
+		t.Helper()
+		r, err := s.LoadRun(ctx, runID)
+		if err != nil {
+			t.Fatalf("LoadRun: %v", err)
+		}
+		return r
+	}
+	if r := load(); r.ContinuationState != "" {
+		t.Fatalf("pre-arm continuation = %q, want unknown", r.ContinuationState)
+	}
+
+	armed, _, err := s.ScheduleRunRetry(ctx, runID, time.Now().Add(time.Hour), "usage_window", "USAGE_LIMIT_BLOCKED", 3)
+	if err != nil || !armed {
+		t.Fatalf("ScheduleRunRetry = (%t, %v), want (true, nil)", armed, err)
+	}
+	if r := load(); r.ContinuationState != store.ContinuationRetryArmed {
+		t.Fatalf("post-arm continuation = %q, want retry_armed", r.ContinuationState)
+	}
+	// The arm must not have erased the transition's cause or invented an
+	// episode: it is a same-status bookkeeping write.
+	if r := load(); r.OutcomeSeq != 1 {
+		t.Fatalf("post-arm seq = %d, want 1", r.OutcomeSeq)
+	}
+
+	if err := s.AbandonRunRetry(ctx, runID, "attempts exhausted"); err != nil {
+		t.Fatalf("AbandonRunRetry: %v", err)
+	}
+	r := load()
+	if r.ContinuationState != store.ContinuationFinal {
+		t.Fatalf("post-abandon continuation = %q, want final — a consumer must know nobody owns this run's future", r.ContinuationState)
+	}
+	if r.OutcomeSeq != 1 {
+		t.Fatalf("post-abandon seq = %d, want 1", r.OutcomeSeq)
+	}
+}

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -508,6 +508,23 @@ type Run struct {
 	// missing. The studio surfaces this so the operator can run
 	// `git branch <name> <FinalCommit>` before the reflog expires.
 	FinalBranchError string `json:"final_branch_error,omitempty" bson:"final_branch_error,omitempty"`
+	// OutcomeSeq counts this run's terminal arrivals: every transition
+	// INTO finished / failed / failed_resumable / cancelled increments
+	// it (a redelivered run that dies again is a NEW episode). It is
+	// the stable per-episode key an outcome consumer needs — the
+	// event-derived RunOutcomeEventID cannot serve: it truncates
+	// UpdatedAt to the second (two episodes in one second collide) and
+	// every SaveRun refreshes UpdatedAt (the same episode re-read
+	// yields a new key).
+	OutcomeSeq int64 `json:"outcome_seq,omitempty" bson:"outcome_seq,omitempty"`
+	// The typed cause of the last terminal transition lives in
+	// FailureCode (ADR-095) — one taxonomy, not two.
+	// ContinuationState says who still owns this run's future after a
+	// terminal transition: a platform continuation (queue redelivery in
+	// flight, quota retry armed) or nobody (final). An outcome consumer
+	// must not act — resume, relaunch, route — while a continuation is
+	// pending; until now it had to GUESS from the error prose.
+	ContinuationState ContinuationState `json:"continuation_state,omitempty" bson:"continuation_state,omitempty"`
 	// MergedInto is the branch the engine fast-forwarded to FinalCommit
 	// after the run, or empty when the FF was skipped (dirty main,
 	// non-FF, branch divergence, opt-out, or detached HEAD at start).
@@ -813,6 +830,38 @@ const (
 	MergeStrategySquash MergeStrategy = "squash"
 	MergeStrategyMerge  MergeStrategy = "merge"
 )
+
+// ContinuationState enumerates who owns a run's future after a
+// terminal transition. Empty means the transition predates the typed
+// bookkeeping (or the writer did not know) — consumers must treat it
+// as unknown, never as final.
+type ContinuationState string
+
+const (
+	// ContinuationRedeliveryPending: the queue still holds the message
+	// (NAK'd); a runner will pick the run back up without anyone asking.
+	ContinuationRedeliveryPending ContinuationState = "redelivery_pending"
+	// ContinuationRetryArmed: a scheduled retry (quota window parking)
+	// will resume the run at RetryState.RetryAfter.
+	ContinuationRetryArmed ContinuationState = "retry_armed"
+	// ContinuationFinal: no platform continuation exists — acting on
+	// this run is now the consumer's decision.
+	ContinuationFinal ContinuationState = "final"
+)
+
+// RunOutcomeMeta is the typed WHY of a status transition, persisted
+// with it: the failure classification (ADR-095's Run.FailureCode — one
+// taxonomy, not a parallel terminal_code) and the continuation
+// ownership. Writers that know pass it; the store clears both fields
+// on transitions that cannot carry them, so stale metadata can never
+// describe a newer outcome. Continuation is a RUNNER-side statement —
+// the engine does not know the queue topology, so engine failure paths
+// persist code only (continuation stays unknown until the runner
+// promotes it at the actual NAK / retry-arm / park).
+type RunOutcomeMeta struct {
+	Code         FailureCode
+	Continuation ContinuationState
+}
 
 // MergeStatus enumerates the lifecycle of the merge step independently
 // from the overall RunStatus — a finished run may still have a pending

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -167,20 +167,24 @@ func (s *FilesystemRunStore) SaveRun(_ context.Context, r *Run) error {
 	// meanwhile. Same status ⇒ keep the persisted values; a status
 	// change through SaveRun IS a transition ⇒ stamp it (untyped).
 	if persisted, err := s.loadRunRaw(r.ID); err == nil {
+		// Work on a copy: the caller's struct must not observe the
+		// bookkeeping (the Mongo implementation doesn't mutate either).
+		rr := *r
 		if persisted.Status == r.Status {
-			r.OutcomeSeq = persisted.OutcomeSeq
-			r.ContinuationState = persisted.ContinuationState
+			rr.OutcomeSeq = persisted.OutcomeSeq
+			rr.ContinuationState = persisted.ContinuationState
 			// The typed cause too: transitions own it, and a stale
 			// same-status copy clearing it would erase what a park
 			// wrote meanwhile.
-			r.FailureCode = persisted.FailureCode
+			rr.FailureCode = persisted.FailureCode
 		} else {
-			r.OutcomeSeq = persisted.OutcomeSeq
-			if r.Status.IsFinalSuccess() || r.Status.IsFinalFailure() || r.Status.IsTerminalResumable() {
-				r.OutcomeSeq++
+			rr.OutcomeSeq = persisted.OutcomeSeq
+			if rr.Status.IsFinalSuccess() || rr.Status.IsFinalFailure() || rr.Status.IsTerminalResumable() {
+				rr.OutcomeSeq++
 			}
-			r.ContinuationState = ""
+			rr.ContinuationState = ""
 		}
+		return s.writeRun(&rr)
 	}
 	return s.writeRun(r)
 }

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -161,6 +161,27 @@ func (s *FilesystemRunStore) SaveRun(_ context.Context, r *Run) error {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Outcome bookkeeping does not belong to full-document savers: a
+	// caller replaying a stale in-memory Run must not rewind the
+	// episode counter or resurrect metadata a status transition wrote
+	// meanwhile. Same status ⇒ keep the persisted values; a status
+	// change through SaveRun IS a transition ⇒ stamp it (untyped).
+	if persisted, err := s.loadRunRaw(r.ID); err == nil {
+		if persisted.Status == r.Status {
+			r.OutcomeSeq = persisted.OutcomeSeq
+			r.ContinuationState = persisted.ContinuationState
+			// The typed cause too: transitions own it, and a stale
+			// same-status copy clearing it would erase what a park
+			// wrote meanwhile.
+			r.FailureCode = persisted.FailureCode
+		} else {
+			r.OutcomeSeq = persisted.OutcomeSeq
+			if r.Status.IsFinalSuccess() || r.Status.IsFinalFailure() || r.Status.IsTerminalResumable() {
+				r.OutcomeSeq++
+			}
+			r.ContinuationState = ""
+		}
+	}
 	return s.writeRun(r)
 }
 
@@ -408,6 +429,34 @@ func (s *FilesystemRunStore) UpdateRunStatusIfCoded(ctx context.Context, id stri
 	return true, nil
 }
 
+// UpdateRunOutcome is the typed status transition (see store.RunStore):
+// UpdateRunStatusIf plus the outcome metadata persisted atomically.
+func (s *FilesystemRunStore) UpdateRunOutcome(_ context.Context, id string, status RunStatus, runErr string, meta RunOutcomeMeta, expectedFrom []RunStatus) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	r, err := s.loadRunRaw(id)
+	if err != nil {
+		return false, err
+	}
+	if len(expectedFrom) > 0 {
+		matched := false
+		for _, want := range expectedFrom {
+			if r.Status == want {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false, nil
+		}
+	}
+	if err := s.applyStatusTransitionOutcome(r, status, runErr, meta); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // FailQueuedRunIfAttempt atomically fails only the queue attempt represented
 // by publishedAt. A later resume refreshes QueuedAt before publishing, so an
 // older delivery cannot clobber that new attempt during its queued→running
@@ -442,6 +491,36 @@ func (s *FilesystemRunStore) FailQueuedRunIfAttempt(_ context.Context, id, runEr
 // failure status, cleared by every transition to a non-failure one —
 // which is what makes a stale code after a resume impossible.
 func (s *FilesystemRunStore) applyStatusTransition(r *Run, status RunStatus, runErr string, code FailureCode) error {
+	return s.applyStatusTransitionOutcome(r, status, runErr, RunOutcomeMeta{Code: code})
+}
+
+// applyStatusTransitionOutcome adds the outcome bookkeeping to the
+// shared transition tail:
+//   - OutcomeSeq increments on a TRANSITION into a terminal status,
+//     never on a same-status rewrite (a drain's markInterrupted or a
+//     repeated flip must not invent an episode — adversarial gate F1);
+//   - ContinuationState is a RUNNER-side statement: it is written when
+//     the meta states one, cleared when the run genuinely changes
+//     state without a statement (unknown, honest), and PRESERVED on a
+//     same-status rewrite (an untyped rewrite of an already-parked run
+//     must not erase a live retry_armed).
+//
+// The publisher's resume rollback (queued back to the prior resumable
+// status) is the one caller for which a transition is NOT a new
+// episode — it restores OutcomeSeq/ContinuationState by hand, the same
+// way it restores FailureCode.
+func (s *FilesystemRunStore) applyStatusTransitionOutcome(r *Run, status RunStatus, runErr string, meta RunOutcomeMeta) error {
+	terminal := status.IsFinalSuccess() || status.IsFinalFailure() || status.IsTerminalResumable()
+	transition := r.Status != status
+	if terminal && transition {
+		r.OutcomeSeq++
+	}
+	if meta.Continuation != "" {
+		r.ContinuationState = meta.Continuation
+	} else if transition {
+		r.ContinuationState = ""
+	}
+	code := meta.Code
 	r.Status = status
 	r.UpdatedAt = time.Now().UTC()
 	r.Error = runErr
@@ -544,6 +623,9 @@ func (s *FilesystemRunStore) PauseRun(ctx context.Context, id string, cp *Checkp
 	}
 	r.Checkpoint = cp
 	r.Status = RunStatusPausedWaitingHuman
+	// A paused run has no platform continuation statement — same
+	// discipline as FailureCode below.
+	r.ContinuationState = ""
 	// A paused run carries no failure classification — same discipline
 	// as the transition choke point, which this checkpoint-coupled
 	// write bypasses. FinishedAt likewise: a paused run is not over,
@@ -557,11 +639,12 @@ func (s *FilesystemRunStore) PauseRun(ctx context.Context, id string, cp *Checkp
 
 // failRunCheckpointed is the shared body of FailRunResumable and
 // FailRunTerminal: the atomic cancelled-wins guard, the checkpoint, and
-// the ordinary transition tail (which owns the failure-code
-// discipline). An operator cancel is terminal and outranks a failure
-// racing in behind it — the two race whenever an interruption and a
-// cancel arrive together, and the failure would win simply by writing
-// last, auto-resuming a run somebody deliberately stopped.
+// the ordinary transition tail (which owns the failure-code and
+// outcome-bookkeeping discipline). An operator cancel is terminal and
+// outranks a failure racing in behind it — the two race whenever an
+// interruption and a cancel arrive together, and the failure would win
+// simply by writing last, auto-resuming a run somebody deliberately
+// stopped.
 func (s *FilesystemRunStore) failRunCheckpointed(id string, status RunStatus, cp *Checkpoint, runErr string, code FailureCode) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -186,7 +186,17 @@ func (s *FilesystemRunStore) SaveRun(_ context.Context, r *Run) error {
 		}
 		return s.writeRun(&rr)
 	}
-	return s.writeRun(r)
+	// Create branch (no persisted document): mirror the Mongo upsert —
+	// the store owns the outcome bookkeeping even on first write, so a
+	// caller cannot seed a fabricated episode counter or continuation
+	// (adversarial gate F7: the FS branch used to trust the caller's
+	// bookkeeping verbatim). A run BORN terminal has episode 0: a
+	// creation is not a transition, and a reactor must not treat an
+	// imported/fixture document as a fresh outcome.
+	rr := *r
+	rr.OutcomeSeq = 0
+	rr.ContinuationState = ""
+	return s.writeRun(&rr)
 }
 
 // loadRunRaw is the pure-read variant of LoadRun: it parses run.json
@@ -524,13 +534,23 @@ func (s *FilesystemRunStore) applyStatusTransitionOutcome(r *Run, status RunStat
 	} else if transition {
 		r.ContinuationState = ""
 	}
-	code := meta.Code
 	r.Status = status
 	r.UpdatedAt = time.Now().UTC()
-	r.Error = runErr
-	if status.CarriesFailureCode() {
-		r.FailureCode = code
-	} else {
+	// A transition always states its own message (empty included); a
+	// same-status rewrite that states nothing keeps the transition's —
+	// the runner's continuation promote must not blank the engine's
+	// failure text. Same rule for the typed cause below.
+	if runErr != "" || transition {
+		r.Error = runErr
+	}
+	switch {
+	case status.CarriesFailureCode() && meta.Code != "":
+		r.FailureCode = meta.Code
+	case status.CarriesFailureCode():
+		if transition {
+			r.FailureCode = ""
+		}
+	default:
 		r.FailureCode = ""
 	}
 	switch status {

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -54,6 +54,7 @@ type Opts struct {
 func RunWithOpts(t *testing.T, factory Factory, opts Opts) {
 	t.Run("CreateLoadRoundTrip", func(t *testing.T) { testCreateLoad(t, factory(t), opts) })
 	t.Run("StatusTransitions", func(t *testing.T) { testStatusTransitions(t, factory(t)) })
+	t.Run("OutcomeSeqAndTypedCauses", func(t *testing.T) { testOutcomeSeqAndTypedCauses(t, factory(t)) })
 	t.Run("QueuedAttemptCAS", func(t *testing.T) { testQueuedAttemptCAS(t, factory(t)) })
 	t.Run("FailRunTerminal", func(t *testing.T) { testFailRunTerminal(t, factory(t)) })
 	t.Run("FailureCodeLifecycle", func(t *testing.T) { testFailureCodeLifecycle(t, factory(t)) })
@@ -1754,5 +1755,131 @@ func testPausePointerLifecycle(t *testing.T, s store.RunStore) {
 	}
 	if r.Checkpoint.InteractionID != "I1" {
 		t.Errorf("SaveCheckpoint on a PAUSED run stripped the live pointer (%q) — the next resume cannot load its interaction", r.Checkpoint.InteractionID)
+	}
+}
+
+// testOutcomeSeqAndTypedCauses drives the outcome bookkeeping: every
+// terminal arrival is a new episode, typed metadata travels with the
+// transition that carries it (and ONLY that one), and full-document
+// savers can neither rewind the counter nor resurrect stale metadata.
+func testOutcomeSeqAndTypedCauses(t *testing.T, s store.RunStore) {
+	t.Helper()
+	ctx := testCtx()
+	const runID = "run-outcome-seq"
+	if _, err := s.CreateRun(ctx, runID, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	load := func() *store.Run {
+		t.Helper()
+		r, err := s.LoadRun(ctx, runID)
+		if err != nil {
+			t.Fatalf("LoadRun: %v", err)
+		}
+		return r
+	}
+
+	// Non-terminal transitions don't count episodes.
+	if err := s.UpdateRunStatus(ctx, runID, store.RunStatusRunning, ""); err != nil {
+		t.Fatalf("running: %v", err)
+	}
+	if r := load(); r.OutcomeSeq != 0 {
+		t.Fatalf("seq after running = %d, want 0", r.OutcomeSeq)
+	}
+
+	// First terminal arrival: episode 1, untyped ⇒ empty metadata.
+	if err := s.UpdateRunStatus(ctx, runID, store.RunStatusFailedResumable, "boom"); err != nil {
+		t.Fatalf("failed_resumable: %v", err)
+	}
+	r := load()
+	if r.OutcomeSeq != 1 || r.FailureCode != "" || r.ContinuationState != "" {
+		t.Fatalf("episode 1 = (seq %d, code %q, cont %q), want (1, \"\", \"\")", r.OutcomeSeq, r.FailureCode, r.ContinuationState)
+	}
+
+	// Typed transition: episode 2 carries its cause (ADR-095's
+	// failure_code — ONE taxonomy) and continuation.
+	changed, err := s.UpdateRunOutcome(ctx, runID, store.RunStatusCancelled, "stopped",
+		store.RunOutcomeMeta{Code: store.FailureCancelled, Continuation: store.ContinuationFinal},
+		[]store.RunStatus{store.RunStatusFailedResumable})
+	if err != nil || !changed {
+		t.Fatalf("typed cancel = (%t, %v), want (true, nil)", changed, err)
+	}
+	r = load()
+	if r.OutcomeSeq != 2 || r.FailureCode != store.FailureCancelled || r.ContinuationState != store.ContinuationFinal {
+		t.Fatalf("episode 2 = (seq %d, code %q, cont %q)", r.OutcomeSeq, r.FailureCode, r.ContinuationState)
+	}
+	// The CAS arm still works.
+	if changed, err := s.UpdateRunOutcome(ctx, runID, store.RunStatusFailed, "no",
+		store.RunOutcomeMeta{Code: store.FailureExecutionFailed}, []store.RunStatus{store.RunStatusRunning}); err != nil || changed {
+		t.Fatalf("outcome CAS mismatch = (%t, %v), want (false, nil)", changed, err)
+	}
+
+	// Leaving the terminal state clears the metadata: stale metadata
+	// must never describe a newer outcome.
+	if err := s.UpdateRunStatus(ctx, runID, store.RunStatusRunning, ""); err != nil {
+		t.Fatalf("resume: %v", err)
+	}
+	r = load()
+	if r.OutcomeSeq != 2 || r.FailureCode != "" || r.ContinuationState != "" {
+		t.Fatalf("post-resume = (seq %d, code %q, cont %q), want (2, \"\", \"\")", r.OutcomeSeq, r.FailureCode, r.ContinuationState)
+	}
+
+	// The checkpoint-aware ENGINE writer types its episode — code only:
+	// the engine does not know the queue topology, so it never states a
+	// continuation (the runner promotes it below).
+	if err := s.FailRunResumable(ctx, runID, &store.Checkpoint{NodeID: "n"}, "drained",
+		store.FailureInterrupted); err != nil {
+		t.Fatalf("FailRunResumable: %v", err)
+	}
+	r = load()
+	if r.OutcomeSeq != 3 || r.FailureCode != store.FailureInterrupted || r.ContinuationState != "" {
+		t.Fatalf("episode 3 = (seq %d, code %q, cont %q), want (3, INTERRUPTED, \"\")", r.OutcomeSeq, r.FailureCode, r.ContinuationState)
+	}
+
+	// The RUNNER promotes the continuation at the actual NAK — a
+	// same-status write that states ownership WITHOUT inventing an
+	// episode (the transition-gated increment).
+	if changed, err := s.UpdateRunOutcome(ctx, runID, store.RunStatusFailedResumable, "drained",
+		store.RunOutcomeMeta{Code: store.FailureInterrupted, Continuation: store.ContinuationRedeliveryPending},
+		[]store.RunStatus{store.RunStatusFailedResumable}); err != nil || !changed {
+		t.Fatalf("continuation promote = (%t, %v), want (true, nil)", changed, err)
+	}
+	r = load()
+	if r.OutcomeSeq != 3 || r.ContinuationState != store.ContinuationRedeliveryPending {
+		t.Fatalf("promoted = (seq %d, cont %q), want (3, redelivery_pending) — a same-status promote must not invent an episode", r.OutcomeSeq, r.ContinuationState)
+	}
+
+	// A full-document save with a STALE in-memory run (same status)
+	// keeps the persisted bookkeeping — it can neither rewind the
+	// counter nor clear the cause/continuation a transition wrote
+	// meanwhile.
+	stale := *r
+	stale.OutcomeSeq = 0
+	stale.FailureCode = ""
+	stale.ContinuationState = ""
+	if err := s.SaveRun(ctx, &stale); err != nil {
+		t.Fatalf("stale SaveRun: %v", err)
+	}
+	r = load()
+	if r.OutcomeSeq != 3 || r.FailureCode != store.FailureInterrupted || r.ContinuationState != store.ContinuationRedeliveryPending {
+		t.Fatalf("after stale save = (seq %d, code %q, cont %q), want preserved (3, INTERRUPTED, redelivery_pending)", r.OutcomeSeq, r.FailureCode, r.ContinuationState)
+	}
+
+	// A status CHANGE through SaveRun is a transition: metadata clears,
+	// and a terminal arrival counts an episode.
+	moved := *r
+	moved.Status = store.RunStatusRunning
+	if err := s.SaveRun(ctx, &moved); err != nil {
+		t.Fatalf("SaveRun to running: %v", err)
+	}
+	if r = load(); r.OutcomeSeq != 3 || r.FailureCode != "" {
+		t.Fatalf("save-to-running = (seq %d, code %q), want (3, \"\")", r.OutcomeSeq, r.FailureCode)
+	}
+	moved = *r
+	moved.Status = store.RunStatusFinished
+	if err := s.SaveRun(ctx, &moved); err != nil {
+		t.Fatalf("SaveRun to finished: %v", err)
+	}
+	if r = load(); r.OutcomeSeq != 4 {
+		t.Fatalf("save-to-finished seq = %d, want 4", r.OutcomeSeq)
 	}
 }

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -55,6 +55,7 @@ func RunWithOpts(t *testing.T, factory Factory, opts Opts) {
 	t.Run("CreateLoadRoundTrip", func(t *testing.T) { testCreateLoad(t, factory(t), opts) })
 	t.Run("StatusTransitions", func(t *testing.T) { testStatusTransitions(t, factory(t)) })
 	t.Run("OutcomeSeqAndTypedCauses", func(t *testing.T) { testOutcomeSeqAndTypedCauses(t, factory(t)) })
+	t.Run("SaveRunHostileValues", func(t *testing.T) { testSaveRunHostileValues(t, factory(t)) })
 	t.Run("QueuedAttemptCAS", func(t *testing.T) { testQueuedAttemptCAS(t, factory(t)) })
 	t.Run("FailRunTerminal", func(t *testing.T) { testFailRunTerminal(t, factory(t)) })
 	t.Run("FailureCodeLifecycle", func(t *testing.T) { testFailureCodeLifecycle(t, factory(t)) })
@@ -1881,5 +1882,53 @@ func testOutcomeSeqAndTypedCauses(t *testing.T, s store.RunStore) {
 	}
 	if r = load(); r.OutcomeSeq != 4 {
 		t.Fatalf("save-to-finished seq = %d, want 4", r.OutcomeSeq)
+	}
+}
+
+// testSaveRunHostileValues guards the Mongo pipeline against
+// aggregation-expression evaluation of DATA: a $-prefixed string value
+// must round-trip verbatim (not be parsed as a field path and dropped
+// or substituted), and a dotted map key must not reject the write —
+// agent outputs ("$ ./gradlew build") and user inputs ("config.path")
+// produce both shapes routinely.
+func testSaveRunHostileValues(t *testing.T, s store.RunStore) {
+	t.Helper()
+	ctx := testCtx()
+	const runID = "run-hostile-values"
+	if _, err := s.CreateRun(ctx, runID, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	r, err := s.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	r.Error = "$workflow_name is not a field path"
+	r.Inputs = map[string]any{"config.path": "/etc/app.yml", "cmd": "$JAVA_HOME/bin/java"}
+	if err := s.SaveRun(ctx, r); err != nil {
+		t.Fatalf("SaveRun with hostile values: %v", err)
+	}
+	got, err := s.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.Error != r.Error {
+		t.Fatalf("Error = %q, want %q (a $-value was evaluated, not stored)", got.Error, r.Error)
+	}
+	if got.Inputs["config.path"] != "/etc/app.yml" || got.Inputs["cmd"] != "$JAVA_HOME/bin/java" {
+		t.Fatalf("Inputs = %v, want the hostile keys/values verbatim", got.Inputs)
+	}
+
+	// An upsert-create directly in a terminal status is NOT an episode:
+	// nothing transitioned, the document was born that way (fork seeds
+	// cancelled children through SaveRun on a run that does not exist).
+	born := *got
+	born.ID = "run-born-terminal"
+	born.Status = store.RunStatusCancelled
+	born.OutcomeSeq = 0
+	if err := s.SaveRun(ctx, &born); err != nil {
+		t.Fatalf("SaveRun upsert-create: %v", err)
+	}
+	if b, err := s.LoadRun(ctx, "run-born-terminal"); err != nil || b.OutcomeSeq != 0 {
+		t.Fatalf("born-terminal = (seq %d, %v), want (0, nil)", b.OutcomeSeq, err)
 	}
 }

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5446,6 +5446,7 @@ export interface components {
             bundle_display_name?: string;
             bundle_name?: string;
             checkpoint?: components["schemas"]["Checkpoint"];
+            continuation_state?: string;
             /** Format: date-time */
             created_at: string;
             /** Format: date-time */
@@ -5478,6 +5479,7 @@ export interface components {
             nodes_served?: {
                 [key: string]: components["schemas"]["NodeServed"];
             };
+            outcome_seq?: number;
             parent_node_id?: string;
             parent_run_id?: string;
             permission_mode?: string;
@@ -5488,6 +5490,7 @@ export interface components {
             shard_label?: string;
             source?: components["schemas"]["RunSource"];
             status: string;
+            terminal_code?: string;
             /** Format: date-time */
             updated_at: string;
             watched_issue_ids?: string[];

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5490,7 +5490,6 @@ export interface components {
             shard_label?: string;
             source?: components["schemas"]["RunSource"];
             status: string;
-            terminal_code?: string;
             /** Format: date-time */
             updated_at: string;
             watched_issue_ids?: string[];


### PR DESCRIPTION
Rebuilt on ADR-095 (#603), which landed the CAUSE half of the original design: `failure_code` is persisted by the same writers as the status, one vocabulary, open-world. This PR adds what the contract still lacks — WHICH terminal arrival this is, and WHO owns the run's future:

- **`outcome_seq`** — increments on every transition INTO a terminal status, at the stores' existing transition funnels. A redelivered run that dies again is a NEW episode; a same-status rewrite must NOT mint one (forces the Mongo funnel from a plain `$inc` onto a pipeline update with a `$cond` on the persisted status).
- **`continuation_state`** — `redelivery_pending` / `retry_armed` / `final`. Typed only by the sites that KNOW, via the new `UpdateRunOutcome` writer: the usage-cap park (retry_armed), the DLQ park (new `DLQ_PARKED` code, final), the orphan sweep (wires the `PROCESS_ORPHANED` code ADR-095 declared follow-up, final), the operator cancels (final). Engine failure paths keep their ADR-095 signatures — their continuation reads as UNKNOWN, which consumers must treat conservatively, never as final.
- **SaveRun on both stores** preserves the bookkeeping (no rewind, no resurrection; a status change through SaveRun IS a transition; a document BORN terminal counts zero). Mongo SaveRun moves from `ReplaceOne` to a `$mergeObjects` pipeline riding under `$literal` — conformance pins hostile values (`$JAVA_HOME`, dotted keys).

Verification: conformance against FS **and a real mongod**; falsified by mutation red four ways (FS increment removed, FS preservation removed, Mongo `$literal` removed, Mongo `$cond` → unconditional `$inc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)