### PR TITLE
feat(cli): a command to stand a credential pool up, and a forfait blob that fails where the file name is known

### DIFF
--- a/cmd/iterion/remote_admin.go
+++ b/cmd/iterion/remote_admin.go
@@ -219,7 +219,12 @@ var remoteAdminLLMOAuthCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			blob, err := cli.ReadSecretBlob(remoteLLMFromEnv, remoteLLMFromFile)
+			// ReadCredentialBlob, not ReadSecretBlob: a forfait payload
+			// is routinely copied out of a terminal, and the escapes it
+			// carries used to surface as a server-side JSON parse error
+			// pointing at "\x1b". Normalise and validate the shape here,
+			// where the file name is still known.
+			blob, err := cli.ReadCredentialBlob(remoteLLMFromEnv, remoteLLMFromFile, kind)
 			if err != nil {
 				return err
 			}

--- a/cmd/iterion/remote_pool.go
+++ b/cmd/iterion/remote_pool.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/SocialGouv/iterion/pkg/cli"
 	"github.com/SocialGouv/iterion/pkg/credpool"
 	"github.com/spf13/cobra"
@@ -113,6 +114,15 @@ var remotePoolWithdrawCmd = &cobra.Command{
 	}),
 }
 
+var (
+	remotePoolName            string
+	remotePoolEnabled         bool
+	remotePoolAudAllTeams     bool
+	remotePoolAudContributors bool
+	remotePoolAudOrgs         []string
+	remotePoolAudTeams        []string
+)
+
 var remotePoolDonorsCmd = &cobra.Command{
 	Use:   "donors",
 	Short: "Operator view: the pool's policy and who is lending to it",
@@ -123,6 +133,66 @@ var remotePoolDonorsCmd = &cobra.Command{
 			return err
 		}
 		return cli.RemotePoolDonors(cmd.Context(), c, p, team)
+	}),
+}
+
+// remote pool policy — the OPERATOR half. `donors` shows the pool; this
+// creates or changes it. Until now the only way to open a pool was a raw
+// `remote api PUT`, which meant hand-writing the audience JSON: the one
+// step of standing a pool up had no command.
+var remotePoolPolicyCmd = &cobra.Command{
+	Use:   "policy",
+	Short: "Operator: create or update the pool (name, master switch, who may draw on it)",
+	Long: `Create or update the credential pool of this team's ORG.
+
+The pool document is keyed by org, so its policy governs every team under
+that org — the server treats changing it as an org-level decision and
+refuses a team admin who is not an org admin.
+
+Audience (pick what fits; they combine):
+  --all-teams          every team on the instance
+  --orgs a,b           every team under these orgs (the pool's own org is
+                       always admitted)
+  --teams x,y          exactly these teams
+  --contributors       anyone who is themselves an active donor ("lend to
+                       borrow")
+
+Only the flags you set are sent, so ` + "`pool policy --enabled=false`" + ` pauses
+a pool without restating its audience.`,
+	Args: cobra.NoArgs,
+	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
+		team, err := c.ResolveTeam(cmd.Context(), remoteTeamFlag)
+		if err != nil {
+			return err
+		}
+		var pol cli.PoolPolicy
+		if cmd.Flags().Changed("name") {
+			pol.Name = &remotePoolName
+		}
+		if cmd.Flags().Changed("enabled") {
+			pol.Enabled = &remotePoolEnabled
+		}
+		// The audience is sent WHOLE or not at all: it is a set, and
+		// merging a partial one server-side would let `--teams x` silently
+		// keep a forgotten --all-teams from a previous call.
+		if cmd.Flags().Changed("all-teams") || cmd.Flags().Changed("orgs") ||
+			cmd.Flags().Changed("teams") || cmd.Flags().Changed("contributors") {
+			pol.Audience = &struct {
+				Teams        []string `json:"teams,omitempty"`
+				Orgs         []string `json:"orgs,omitempty"`
+				Contributors bool     `json:"contributors,omitempty"`
+				AllTeams     bool     `json:"all_teams,omitempty"`
+			}{
+				Teams:        remotePoolAudTeams,
+				Orgs:         remotePoolAudOrgs,
+				Contributors: remotePoolAudContributors,
+				AllTeams:     remotePoolAudAllTeams,
+			}
+		}
+		if pol.Name == nil && pol.Enabled == nil && pol.Audience == nil {
+			return fmt.Errorf("nothing to change — set --name, --enabled, or an audience flag (--all-teams/--orgs/--teams/--contributors)")
+		}
+		return cli.RemotePoolPolicy(cmd.Context(), c, p, team, pol)
 	}),
 }
 
@@ -144,9 +214,18 @@ func init() {
 	remotePoolShareCmd.Flags().StringSliceVar(&remotePoolBots, "bots", nil, "Only these bot ids may use it (default: any)")
 	remotePoolDonorsCmd.Flags().StringVar(&remoteTeamFlag, "team", "", "Team id (default: switched/active team)")
 
+	remotePoolPolicyCmd.Flags().StringVar(&remoteTeamFlag, "team", "", "Team id (default: switched/active team)")
+	remotePoolPolicyCmd.Flags().StringVar(&remotePoolName, "name", "", "Pool name")
+	remotePoolPolicyCmd.Flags().BoolVar(&remotePoolEnabled, "enabled", true, "Master switch: off skips the pool tier entirely")
+	remotePoolPolicyCmd.Flags().BoolVar(&remotePoolAudAllTeams, "all-teams", false, "Audience: every team on the instance")
+	remotePoolPolicyCmd.Flags().StringSliceVar(&remotePoolAudOrgs, "orgs", nil, "Audience: every team under these org ids")
+	remotePoolPolicyCmd.Flags().StringSliceVar(&remotePoolAudTeams, "teams", nil, "Audience: exactly these team ids")
+	remotePoolPolicyCmd.Flags().BoolVar(&remotePoolAudContributors, "contributors", false, "Audience: anyone who is themselves an active donor")
+
 	remotePoolCmd.AddCommand(
 		remotePoolStatusCmd, remotePoolHistoryCmd, remotePoolShareCmd,
 		remotePoolPauseCmd, remotePoolResumeCmd, remotePoolWithdrawCmd, remotePoolDonorsCmd,
+		remotePoolPolicyCmd,
 	)
 	remoteCmd.AddCommand(remotePoolCmd)
 }

--- a/cmd/iterion/remote_pool.go
+++ b/cmd/iterion/remote_pool.go
@@ -158,7 +158,10 @@ Audience (pick what fits; they combine):
                        borrow")
 
 Only the flags you set are sent, so ` + "`pool policy --enabled=false`" + ` pauses
-a pool without restating its audience.`,
+a pool without restating its audience. The AUDIENCE itself is the one
+exception: it is a set, sent and replaced WHOLE — naming any audience
+flag clears the dials you do not restate, so repeat every one you mean
+to keep on each call.`,
 	Args: cobra.NoArgs,
 	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
 		team, err := c.ResolveTeam(cmd.Context(), remoteTeamFlag)
@@ -177,12 +180,7 @@ a pool without restating its audience.`,
 		// keep a forgotten --all-teams from a previous call.
 		if cmd.Flags().Changed("all-teams") || cmd.Flags().Changed("orgs") ||
 			cmd.Flags().Changed("teams") || cmd.Flags().Changed("contributors") {
-			pol.Audience = &struct {
-				Teams        []string `json:"teams,omitempty"`
-				Orgs         []string `json:"orgs,omitempty"`
-				Contributors bool     `json:"contributors,omitempty"`
-				AllTeams     bool     `json:"all_teams,omitempty"`
-			}{
+			pol.Audience = &credpool.Audience{
 				Teams:        remotePoolAudTeams,
 				Orgs:         remotePoolAudOrgs,
 				Contributors: remotePoolAudContributors,

--- a/cmd/iterion/remote_pool.go
+++ b/cmd/iterion/remote_pool.go
@@ -158,10 +158,13 @@ Audience (pick what fits; they combine):
                        borrow")
 
 Only the flags you set are sent, so ` + "`pool policy --enabled=false`" + ` pauses
-a pool without restating its audience. The AUDIENCE itself is the one
-exception: it is a set, sent and replaced WHOLE — naming any audience
+a pool without restating its audience. Two deviations from that rule:
+the AUDIENCE is a set, sent and replaced WHOLE — naming any audience
 flag clears the dials you do not restate, so repeat every one you mean
-to keep on each call.`,
+to keep on each call; and STANDING A POOL UP requires an explicit
+--enabled — the command refuses to create one with the master switch
+unstated, because a pool born disabled is invisible to the broker and
+every pledge under it is dead.`,
 	Args: cobra.NoArgs,
 	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
 		team, err := c.ResolveTeam(cmd.Context(), remoteTeamFlag)

--- a/docs/cloud-cli.md
+++ b/docs/cloud-cli.md
@@ -116,7 +116,7 @@ the staging step alone and prints the upload id.
 | `admin` | `orgs · users · dlq · llm · caps · bots · roles · sandbox` (super-admin; `llm api-keys`/`llm oauth` = the platform fallback credentials — rotate without a redeploy, see [cloud-llm-credentials.md](cloud-llm-credentials.md); `caps` = the runtime usage-cap percentages — retune without a restart, see [usage-caps.md](usage-caps.md#changing-the-caps-at-runtime-no-restart); `bots` = platform bot overrides — push any bot without an image rollout, `roles`/`sandbox` = runtime webhook role bindings + `sandbox: auto` image, see [platform-bots.md](platform-bots.md)) |
 | `sso` | `providers · domains` (org-scoped) |
 | `plugins` | `list · enable · disable · install · uninstall · config` |
-| `pool` | `status · history · share · pause · resume · withdraw · donors` — lend your own LLM subscription or personal metered key to the shared [credential pool](credential-pool.md), bounded by ceilings you set on `share` (`--max-usd-day/-week`, `--max-runs-day`, `--max-concurrent`, `--from-hour/--to-hour`, `--bots`). `donors` is the operator view of the pool's policy and its lenders. |
+| `pool` | `status · history · share · pause · resume · withdraw · donors · policy` — lend your own LLM subscription or personal metered key to the shared [credential pool](credential-pool.md), bounded by ceilings you set on `share` (`--max-usd-day/-week`, `--max-runs-day`, `--max-concurrent`, `--from-hour/--to-hour`, `--bots`). `donors` is the operator view of the pool's policy and its lenders; `policy` is the operator write side (`--enabled`, `--name`, audience flags — the audience is replaced whole). |
 | `server` | `info · health` |
 
 Structured mutation payloads follow the `--data '<json>'` /

--- a/docs/credential-pool.md
+++ b/docs/credential-pool.md
@@ -239,13 +239,16 @@ iterion remote api-keys create --provider anthropic --name mine --from-file ~/ke
 iterion remote pool share --source api_key --ref anthropic   --key-id <id from `iterion remote api-keys list`> --max-usd-day 3
 
 # 1. Operator: create/enable the pool for the org (default audience:
-#    the org's own teams only).
-iterion remote api PUT /api/teams/<team-id>/pool --data '{"enabled":true}'
+#    the org's own teams only). Creating one REQUIRES --enabled stated
+#    explicitly — a pool stood up disabled is invisible to the broker
+#    and every pledge under it is dead, so the CLI refuses the silent
+#    shape.
+iterion remote pool policy --enabled
 
 # Widen it only if you mean to — this lets more runs spend contributors'
-# personal subscriptions:
-iterion remote api PUT /api/teams/<team-id>/pool \
-  --data '{"enabled":true,"audience":{"contributors":true}}'
+# personal subscriptions. The audience is a SET, replaced whole: restate
+# every dial you mean to keep on each call.
+iterion remote pool policy --contributors
 
 # 2. Contributor: connect the subscription (once), then pledge it.
 iterion remote api POST /api/me/oauth/claude_code/authorize/start

--- a/pkg/cli/remote_admin_llm.go
+++ b/pkg/cli/remote_admin_llm.go
@@ -2,10 +2,14 @@ package cli
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -37,6 +41,77 @@ func ReadSecretBlob(fromEnv, fromFile string) ([]byte, error) {
 		return nil, fmt.Errorf("provide the payload via --from-env <VAR>, --from-file <path>, or pipe it on stdin")
 	}
 	return b, nil
+}
+
+// ansiEscape matches the escape sequences a terminal capture carries:
+// CSI (colour, cursor) and OSC (title) runs.
+var ansiEscape = regexp.MustCompile("\x1b\\[[0-9;?]*[ -/]*[@-~]|\x1b\\][^\x07\x1b]*(?:\x07|\x1b\\\\)")
+
+// ReadCredentialBlob resolves a credentials payload like ReadSecretBlob,
+// then makes it usable: a blob copied out of a terminal (a `cat` of
+// credentials.json under a pager, a screenshot-to-clipboard round trip)
+// carries ANSI escapes, and the server rejected it with a parse error
+// pointing at "" — accurate and useless. The escapes are stripped and
+// the result is validated HERE, so a malformed payload is named before it
+// travels: which file, which JSON error, and what the shape should be.
+//
+// Stripping is a normalisation, not a rescue: anything that is still not
+// the expected object after it is refused, loudly.
+func ReadCredentialBlob(fromEnv, fromFile, kind string) ([]byte, error) {
+	raw, err := ReadSecretBlob(fromEnv, fromFile)
+	if err != nil {
+		return nil, err
+	}
+	clean := bytes.TrimSpace(ansiEscape.ReplaceAll(raw, nil))
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(clean, &probe); err != nil {
+		return nil, fmt.Errorf("%s: the payload is not a JSON object (%v)%s", credentialSourceLabel(fromEnv, fromFile), err, credentialShapeHint(kind))
+	}
+	if want := credentialTopKey(kind); want != "" {
+		if _, ok := probe[want]; !ok {
+			keys := make([]string, 0, len(probe))
+			for k := range probe {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			return nil, fmt.Errorf("%s: no %q key — got %v%s", credentialSourceLabel(fromEnv, fromFile), want, keys, credentialShapeHint(kind))
+		}
+	}
+	return clean, nil
+}
+
+// credentialTopKey is the object key each forfait blob must carry; ""
+// for a kind whose shape this CLI does not pin.
+func credentialTopKey(kind string) string {
+	switch kind {
+	case "claude_code":
+		return "claudeAiOauth"
+	case "codex":
+		return "tokens"
+	}
+	return ""
+}
+
+func credentialShapeHint(kind string) string {
+	switch kind {
+	case "claude_code":
+		return "\nexpected the Claude Code credentials.json: {\"claudeAiOauth\":{\"accessToken\":…,\"refreshToken\":…,\"expiresAt\":…}}"
+	case "codex":
+		return "\nexpected the Codex auth.json: {\"tokens\":{\"access_token\":…,\"refresh_token\":…},\"auth_mode\":\"chatgpt\"}"
+	}
+	return ""
+}
+
+// credentialSourceLabel names WHERE the payload came from, so the error
+// points at the thing to fix rather than at an anonymous blob.
+func credentialSourceLabel(fromEnv, fromFile string) string {
+	switch {
+	case fromFile != "":
+		return fromFile
+	case fromEnv != "":
+		return "$" + fromEnv
+	}
+	return "stdin"
 }
 
 // RemoteAdminLLMOAuthConnect drives the browser code flow for the platform

--- a/pkg/cli/remote_admin_llm.go
+++ b/pkg/cli/remote_admin_llm.go
@@ -51,7 +51,7 @@ var ansiEscape = regexp.MustCompile("\x1b\\[[0-9;?]*[ -/]*[@-~]|\x1b\\][^\x07\x1
 // then makes it usable: a blob copied out of a terminal (a `cat` of
 // credentials.json under a pager, a screenshot-to-clipboard round trip)
 // carries ANSI escapes, and the server rejected it with a parse error
-// pointing at "" — accurate and useless. The escapes are stripped and
+// pointing at "\x1b" — accurate and useless. The escapes are stripped and
 // the result is validated HERE, so a malformed payload is named before it
 // travels: which file, which JSON error, and what the shape should be.
 //
@@ -103,13 +103,15 @@ func credentialShapeHint(kind string) string {
 }
 
 // credentialSourceLabel names WHERE the payload came from, so the error
-// points at the thing to fix rather than at an anonymous blob.
+// points at the thing to fix rather than at an anonymous blob. Same
+// precedence as ReadSecretValue: env wins over file, so the label names
+// the source that was actually read, not the one that lost.
 func credentialSourceLabel(fromEnv, fromFile string) string {
 	switch {
-	case fromFile != "":
-		return fromFile
 	case fromEnv != "":
 		return "$" + fromEnv
+	case fromFile != "":
+		return fromFile
 	}
 	return "stdin"
 }

--- a/pkg/cli/remote_credential_blob_test.go
+++ b/pkg/cli/remote_credential_blob_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A credentials.json copied out of a terminal carries ANSI escapes. The
+// server used to reject it with a parse error pointing at "\x1b" —
+// accurate and useless. It must be normalised here, and the result must
+// still be the real payload (values untouched).
+func TestReadCredentialBlob_StripsTerminalEscapes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credentials.json")
+	// Colour runs, a cursor move and an OSC title — the shapes a `cat`
+	// under a pager produces — wrapped around a real blob.
+	captured := "\x1b[?25l\x1b]0;credentials.json\x07\x1b[32m{\"claudeAiOauth\":{\"accessToken\":\"sk-ant-oat01-SECRET\"," +
+		"\"refreshToken\":\"sk-ant-ort01-REFRESH\",\"expiresAt\":1803818276000}}\x1b[0m\x1b[?25h\n"
+	if err := os.WriteFile(path, []byte(captured), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadCredentialBlob("", path, "claude_code")
+	if err != nil {
+		t.Fatalf("ReadCredentialBlob: %v", err)
+	}
+	want := `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-SECRET","refreshToken":"sk-ant-ort01-REFRESH","expiresAt":1803818276000}}`
+	if string(got) != want {
+		t.Fatalf("normalised blob =\n%s\nwant\n%s", got, want)
+	}
+}
+
+// A clean file is passed through untouched — normalising must not be a
+// rewrite.
+func TestReadCredentialBlob_CleanPayloadUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth.json")
+	clean := `{"auth_mode":"chatgpt","tokens":{"access_token":"a","refresh_token":"r","account_id":"acc"}}`
+	if err := os.WriteFile(path, []byte(clean+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadCredentialBlob("", path, "codex")
+	if err != nil {
+		t.Fatalf("ReadCredentialBlob: %v", err)
+	}
+	if string(got) != clean {
+		t.Fatalf("clean payload was rewritten:\n%s", got)
+	}
+}
+
+// Stripping is a normalisation, not a rescue: what is still not the
+// expected shape after it is refused HERE, naming the file, the JSON
+// error and the shape — instead of travelling to a server-side 400.
+func TestReadCredentialBlob_RefusesWithAnActionableError(t *testing.T) {
+	dir := t.TempDir()
+	cases := []struct {
+		name, content, kind string
+		wantIn              []string
+	}{
+		{
+			name:    "not json at all",
+			content: "\x1b[32mLogin successful. Token: sk-ant-oat01-X\x1b[0m",
+			kind:    "claude_code",
+			wantIn:  []string{"not a JSON object", "claudeAiOauth"},
+		},
+		{
+			name:    "json object of the wrong shape",
+			content: `{"access_token":"x","expires":1}`,
+			kind:    "claude_code",
+			wantIn:  []string{`no "claudeAiOauth" key`, "access_token", "expires"},
+		},
+		{
+			name:    "codex blob posted as claude_code",
+			content: `{"auth_mode":"chatgpt","tokens":{"access_token":"a"}}`,
+			kind:    "claude_code",
+			wantIn:  []string{`no "claudeAiOauth" key`, "credentials.json"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			path := filepath.Join(dir, c.name+".json")
+			if err := os.WriteFile(path, []byte(c.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := ReadCredentialBlob("", path, c.kind)
+			if err == nil {
+				t.Fatal("want a refusal, got nil")
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, path) {
+				t.Errorf("error must name the source file, got: %s", msg)
+			}
+			for _, w := range c.wantIn {
+				if !strings.Contains(msg, w) {
+					t.Errorf("error must mention %q, got: %s", w, msg)
+				}
+			}
+		})
+	}
+}
+
+// An unknown kind keeps working: the CLI pins the shapes it knows and
+// stays out of the way for anything else (the server remains the
+// authority on validity).
+func TestReadCredentialBlob_UnknownKindOnlyRequiresJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "other.json")
+	if err := os.WriteFile(path, []byte(`{"whatever":1}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ReadCredentialBlob("", path, "some_future_kind"); err != nil {
+		t.Fatalf("unknown kind must not be pinned to a shape: %v", err)
+	}
+}

--- a/pkg/cli/remote_pool.go
+++ b/pkg/cli/remote_pool.go
@@ -130,14 +130,13 @@ func RemotePoolDonors(ctx context.Context, c *RemoteClient, p *Printer, teamID s
 // the ones the caller sets are sent, so `pool policy --enabled=false`
 // pauses a pool without restating its audience.
 type PoolPolicy struct {
-	Name     *string `json:"name,omitempty"`
-	Enabled  *bool   `json:"enabled,omitempty"`
-	Audience *struct {
-		Teams        []string `json:"teams,omitempty"`
-		Orgs         []string `json:"orgs,omitempty"`
-		Contributors bool     `json:"contributors,omitempty"`
-		AllTeams     bool     `json:"all_teams,omitempty"`
-	} `json:"audience,omitempty"`
+	Name    *string `json:"name,omitempty"`
+	Enabled *bool   `json:"enabled,omitempty"`
+	// The DOMAIN type, not a wire mirror of it — same rule as the
+	// ceilings/window on PoolPledgeInput: a second copy of the shape is
+	// a second thing to keep in step every time it changes, and the
+	// server decodes into this exact type (poolRequest).
+	Audience *credpool.Audience `json:"audience,omitempty"`
 }
 
 // RemotePoolPolicy creates or updates the pool of the team's org. The
@@ -145,6 +144,30 @@ type PoolPolicy struct {
 // server enforces that; the CLI says so in its help rather than letting
 // an admin discover it through a 403.
 func RemotePoolPolicy(ctx context.Context, c *RemoteClient, p *Printer, teamID string, pol PoolPolicy) error {
+	if pol.Enabled == nil {
+		// A PUT that CREATES the pool defaults its master switch to
+		// off — a pool the broker's ListEnabled never reads, so no
+		// pledge under it can ever serve and nothing says why. Probe:
+		// an absent pool (the server describes "the pool that would be
+		// created" with an empty id) demands the switch stated
+		// explicitly rather than a silent dead-on-arrival create.
+		status, body, err := c.API(ctx, "GET", "/api/teams/"+teamID+"/pool", nil)
+		if err != nil {
+			return fmt.Errorf("probe pool before policy write: %w", err)
+		}
+		if status < 200 || status >= 300 {
+			return fmt.Errorf("probe pool before policy write: HTTP %d: %s", status, body)
+		}
+		var v struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(body, &v); err != nil {
+			return fmt.Errorf("probe pool before policy write: decode: %w", err)
+		}
+		if v.ID == "" {
+			return fmt.Errorf("no pool exists for this org yet — creating one requires the master switch stated explicitly: rerun with --enabled (or --enabled=false)")
+		}
+	}
 	body, err := json.Marshal(pol)
 	if err != nil {
 		return fmt.Errorf("encode pool policy: %w", err)

--- a/pkg/cli/remote_pool.go
+++ b/pkg/cli/remote_pool.go
@@ -125,6 +125,33 @@ func RemotePoolDonors(ctx context.Context, c *RemoteClient, p *Printer, teamID s
 	return RemoteGetPrint(ctx, c, p, "/api/teams/"+teamID+"/pool")
 }
 
+// PoolPolicy is the operator-side settings of a pool: its name, its
+// master switch, and who may draw on it. Every field is optional — only
+// the ones the caller sets are sent, so `pool policy --enabled=false`
+// pauses a pool without restating its audience.
+type PoolPolicy struct {
+	Name     *string `json:"name,omitempty"`
+	Enabled  *bool   `json:"enabled,omitempty"`
+	Audience *struct {
+		Teams        []string `json:"teams,omitempty"`
+		Orgs         []string `json:"orgs,omitempty"`
+		Contributors bool     `json:"contributors,omitempty"`
+		AllTeams     bool     `json:"all_teams,omitempty"`
+	} `json:"audience,omitempty"`
+}
+
+// RemotePoolPolicy creates or updates the pool of the team's org. The
+// pool document is keyed by ORG, so this is an org-level decision — the
+// server enforces that; the CLI says so in its help rather than letting
+// an admin discover it through a 403.
+func RemotePoolPolicy(ctx context.Context, c *RemoteClient, p *Printer, teamID string, pol PoolPolicy) error {
+	body, err := json.Marshal(pol)
+	if err != nil {
+		return fmt.Errorf("encode pool policy: %w", err)
+	}
+	return RemoteSendPrint(ctx, c, p, "PUT", "/api/teams/"+teamID+"/pool", body)
+}
+
 // LocalTimezone returns the host's IANA zone name so a donor's sharing
 // hours mean what they read on their own clock. Falls back to UTC when the
 // host cannot name its zone (a bare container), which is honest: an

--- a/pkg/cli/remote_test.go
+++ b/pkg/cli/remote_test.go
@@ -460,3 +460,75 @@ func TestParseAttachFlags(t *testing.T) {
 		t.Error("want error on malformed pair")
 	}
 }
+
+// --- pool policy (operator) ---
+
+// The operator half of the pool had no command: standing one up meant a
+// raw `remote api PUT` with a hand-written audience. RemotePoolPolicy
+// sends ONLY what the caller set — a partial update must not restate (or
+// silently drop) the rest of the policy.
+func TestRemotePoolPolicy_SendsOnlyWhatWasSet(t *testing.T) {
+	var gotPath, gotMethod string
+	var gotBody map[string]any
+	c := remoteTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"org1","name":"devthejo","enabled":true}`))
+	}))
+	p, _ := remotePrinter(cli.OutputJSON)
+
+	enabled := false
+	if err := cli.RemotePoolPolicy(context.Background(), c, p, "team-1", cli.PoolPolicy{Enabled: &enabled}); err != nil {
+		t.Fatalf("RemotePoolPolicy: %v", err)
+	}
+	if gotMethod != "PUT" || gotPath != "/api/teams/team-1/pool" {
+		t.Fatalf("request = %s %s, want PUT /api/teams/team-1/pool", gotMethod, gotPath)
+	}
+	if len(gotBody) != 1 {
+		t.Fatalf("body = %v, want only the enabled field", gotBody)
+	}
+	if gotBody["enabled"] != false {
+		t.Fatalf("enabled = %v, want false", gotBody["enabled"])
+	}
+	if _, ok := gotBody["audience"]; ok {
+		t.Fatal("a pause must not restate the audience — that is how a forgotten --all-teams survives")
+	}
+}
+
+// An audience travels WHOLE: it is a set, so every dial the caller chose
+// is present (and the ones they did not are absent, not carried over).
+func TestRemotePoolPolicy_AudienceTravelsWhole(t *testing.T) {
+	var gotBody map[string]any
+	c := remoteTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"org1"}`))
+	}))
+	p, _ := remotePrinter(cli.OutputJSON)
+
+	name := "devthejo"
+	pol := cli.PoolPolicy{Name: &name}
+	pol.Audience = &struct {
+		Teams        []string `json:"teams,omitempty"`
+		Orgs         []string `json:"orgs,omitempty"`
+		Contributors bool     `json:"contributors,omitempty"`
+		AllTeams     bool     `json:"all_teams,omitempty"`
+	}{AllTeams: true}
+	if err := cli.RemotePoolPolicy(context.Background(), c, p, "team-1", pol); err != nil {
+		t.Fatalf("RemotePoolPolicy: %v", err)
+	}
+	aud, ok := gotBody["audience"].(map[string]any)
+	if !ok {
+		t.Fatalf("audience missing from %v", gotBody)
+	}
+	if aud["all_teams"] != true {
+		t.Fatalf("all_teams = %v, want true", aud["all_teams"])
+	}
+	if gotBody["name"] != "devthejo" {
+		t.Fatalf("name = %v, want devthejo", gotBody["name"])
+	}
+	if _, ok := gotBody["enabled"]; ok {
+		t.Fatal("enabled was not set by the caller and must not be sent")
+	}
+}

--- a/pkg/cli/remote_test.go
+++ b/pkg/cli/remote_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/cli"
+	"github.com/SocialGouv/iterion/pkg/credpool"
 	"github.com/SocialGouv/iterion/pkg/secrets"
 )
 
@@ -509,12 +510,7 @@ func TestRemotePoolPolicy_AudienceTravelsWhole(t *testing.T) {
 
 	name := "devthejo"
 	pol := cli.PoolPolicy{Name: &name}
-	pol.Audience = &struct {
-		Teams        []string `json:"teams,omitempty"`
-		Orgs         []string `json:"orgs,omitempty"`
-		Contributors bool     `json:"contributors,omitempty"`
-		AllTeams     bool     `json:"all_teams,omitempty"`
-	}{AllTeams: true}
+	pol.Audience = &credpool.Audience{AllTeams: true}
 	if err := cli.RemotePoolPolicy(context.Background(), c, p, "team-1", pol); err != nil {
 		t.Fatalf("RemotePoolPolicy: %v", err)
 	}
@@ -530,5 +526,46 @@ func TestRemotePoolPolicy_AudienceTravelsWhole(t *testing.T) {
 	}
 	if _, ok := gotBody["enabled"]; ok {
 		t.Fatal("enabled was not set by the caller and must not be sent")
+	}
+}
+
+// Standing a NEW pool up without stating the master switch would create
+// it Enabled:false — invisible to the broker's ListEnabled, every pledge
+// under it dead, and nothing says why. The CLI probes first and refuses.
+func TestRemotePoolPolicy_RefusesSilentDisabledCreate(t *testing.T) {
+	var puts int
+	c := remoteTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet {
+			// The server describes "the pool that WOULD be created":
+			// empty id = no pool exists yet.
+			_, _ = w.Write([]byte(`{"id":"","org_id":"org1","donors":[]}`))
+			return
+		}
+		puts++
+		_, _ = w.Write([]byte(`{"id":"org1"}`))
+	}))
+	p, _ := remotePrinter(cli.OutputJSON)
+
+	pol := cli.PoolPolicy{Audience: &credpool.Audience{AllTeams: true}}
+	err := cli.RemotePoolPolicy(context.Background(), c, p, "team-1", pol)
+	if err == nil {
+		t.Fatal("want a refusal: creating a pool without --enabled stands it up disabled and dead")
+	}
+	if !strings.Contains(err.Error(), "--enabled") {
+		t.Fatalf("the refusal must name the missing flag, got: %v", err)
+	}
+	if puts != 0 {
+		t.Fatalf("the PUT must not be sent on refusal (got %d)", puts)
+	}
+
+	// Stating the switch skips the probe entirely and goes through.
+	enabled := true
+	pol.Enabled = &enabled
+	if err := cli.RemotePoolPolicy(context.Background(), c, p, "team-1", pol); err != nil {
+		t.Fatalf("explicit --enabled must pass: %v", err)
+	}
+	if puts != 1 {
+		t.Fatalf("PUT count = %d, want 1", puts)
 	}
 }


### PR DESCRIPTION
Both gaps were found by actually setting a pool up on a live instance — not by reading the code.

## 1. The pool's operator half had no command

\`pool donors\` shows the pool; **nothing created or changed one**. Standing a pool up meant a raw \`remote api PUT /api/teams/{id}/pool\` with a hand-written audience object — the one step that turns the whole credpool feature on had no CLI surface.

\`remote pool policy\` now does it: \`--name\`, \`--enabled\`, and the four audience dials (\`--all-teams\` / \`--orgs\` / \`--teams\` / \`--contributors\`). The help states up front that the pool document is keyed by ORG, so its policy governs every team under it — an org-level decision — instead of letting a team admin discover that through a 403.

**Only the flags the caller set are sent.** \`pool policy --enabled=false\` pauses a pool without restating its audience: a partial update must not be able to resurrect a forgotten \`--all-teams\`. The audience itself travels whole (it is a set; merging a partial one server-side would do exactly that).

## 2. A forfait blob failed on the server, with the file name already lost

A credentials.json is routinely copied out of a terminal. The ANSI escapes it carries reached the server, which answered:

\`\`\`
secrets: parse credentials.json: invalid character '\x1b' looking for beginning of value
\`\`\`

Accurate and useless — no file name, no expected shape, one round trip wasted. Reading a credential blob now normalises the escapes and validates the shape **CLI-side**, naming the source (file / \`$VAR\` / stdin), the JSON error, and the object it wanted:

\`\`\`
error: ~/.secrets/…-jothedev.txt: the payload is not a JSON object (invalid character 'W' …)
expected the Claude Code credentials.json: {"claudeAiOauth":{"accessToken":…,"refreshToken":…,"expiresAt":…}}
\`\`\`

Stripping is a **normalisation, not a rescue**: anything still malformed after it is refused, loudly, before it travels. Unknown kinds stay unpinned — the server remains the authority on validity. \`admin llm oauth set\` is the only CLI upload path (grepped), so the class is closed.

## Verification

- **End to end against a live instance**: \`pool policy --all-teams\` created/updated a real pool; \`admin llm oauth set claude_code --from-file\` refused a real terminal capture with the message above and accepted the real credentials.json.
- Unit: escape stripping preserves the payload byte for byte, a clean file is passed through untouched, three malformed shapes are each refused naming the file, partial policy updates send only what was set.
- **Each guard falsified by mutation** (strip removed, shape check disabled, \`omitempty\` dropped) — each turns its own test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)