### PR TITLE
fix(server): a queued run waiting for a free runner is not an orphan

### DIFF
--- a/pkg/queue/nats/nats.go
+++ b/pkg/queue/nats/nats.go
@@ -141,6 +141,25 @@ type Conn struct {
 // Nak, which an operator may configure above AckWait. The server's orphan
 // sweeper derives its queued-staleness cutoff from the larger interval so it
 // never flips a message that is still legitimately waiting for redelivery.
+// QueueBacklog reports how many messages wait on the durable consumer —
+// work that exists and nobody has fetched. The server's orphan sweeper
+// reads it to tell "the message is gone" (a real orphan) from "every
+// runner is busy" (a run waiting its turn, which must not be flipped).
+func (c *Conn) QueueBacklog(ctx context.Context) (uint64, error) {
+	// Read the durable consumer's info directly: CreateOrUpdateConsumer
+	// would work too (it is idempotent) but a read must not carry the
+	// power to rewrite the consumer's config on a sweeper tick.
+	cons, err := c.js.Consumer(ctx, c.cfg.StreamName, c.cfg.ConsumerName)
+	if err != nil {
+		return 0, fmt.Errorf("queue/nats: consumer info: %w", err)
+	}
+	info, err := cons.Info(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("queue/nats: consumer info: %w", err)
+	}
+	return info.NumPending, nil
+}
+
 func (c *Conn) RedeliveryWindow() time.Duration {
 	interval := c.cfg.AckWait
 	if c.cfg.SchemaMismatchDelay > interval {

--- a/pkg/server/queue_sweeper.go
+++ b/pkg/server/queue_sweeper.go
@@ -63,6 +63,25 @@ const (
 	sweepRunningAfter = 10 * time.Minute
 )
 
+// queueBacklogReader is the optional capability that tells the sweeper
+// whether the QUEUE still holds work nobody has fetched (implemented by
+// natsq.Conn over the durable consumer's NumPending).
+//
+// It separates two causes a "queued row with no lease" cannot tell apart
+// on its own: a message that is GONE (crash mid-decode, purge after
+// MaxDeliver — a genuine orphan, the run must be flipped so resume
+// lights up) and a run that has simply not been fetched YET because
+// every runner is busy. The second is not a fault: with one run per pod
+// and a frozen pool, a long campaign fills the fleet and short runs
+// queue behind it — flipping those killed the instance's own PR reviews
+// (measured 2026-09-01: reviews orphaned while queued, relaunched by the
+// merge gate, orphaned again).
+type queueBacklogReader interface {
+	// QueueBacklog reports how many messages wait on the durable
+	// consumer, i.e. work that exists and nobody has taken.
+	QueueBacklog(ctx context.Context) (uint64, error)
+}
+
 // redeliveryWindower is the optional lease-checker capability the
 // sweeper derives its queued-staleness cutoff from (implemented by
 // natsq.Conn), so the cutoff tracks operator overrides of
@@ -81,6 +100,23 @@ func queuedSweepCutoff(leases runLeaseChecker) time.Duration {
 		}
 	}
 	return sweepQueuedFallback
+}
+
+// queueBacklog asks the queue how much unfetched work it holds. The
+// second return is false when the capability is absent or the read
+// failed — in which case the sweeper behaves exactly as before rather
+// than assuming either answer.
+func (s *Server) queueBacklog(ctx context.Context, leases runLeaseChecker) (uint64, bool) {
+	r, ok := leases.(queueBacklogReader)
+	if !ok {
+		return 0, false
+	}
+	n, err := r.QueueBacklog(ctx)
+	if err != nil {
+		s.logWarn("sweeper: queue backlog unreadable (%v) — the queued pass runs on the lease signal alone", err)
+		return 0, false
+	}
+	return n, true
 }
 
 // runQueueSweeper loops until ctx is cancelled. Started by
@@ -116,6 +152,18 @@ func (s *Server) sweepOrphanRuns(ctx context.Context, lister staleRunLister, lea
 	passes := []pass{
 		{[]store.RunStatus{store.RunStatusQueued}, now.Add(-queuedSweepCutoff(leases))},
 		{[]store.RunStatus{store.RunStatusRunning}, now.Add(-sweepRunningAfter)},
+	}
+	// A backlog means the queue still holds work nobody has fetched: the
+	// stale queued rows are runs WAITING for a free runner, not orphans.
+	// Skip the queued pass entirely rather than flip them — a run killed
+	// while legitimately waiting is worse than one recovered a tick late,
+	// and the running pass (whose lease check is a real signal) is
+	// unaffected.
+	if backlog, ok := s.queueBacklog(ctx, leases); ok && backlog > 0 {
+		if s.logger != nil {
+			s.logger.Debug("sweeper: %d message(s) still waiting on the consumer — skipping the queued pass (those rows are unclaimed for want of a free runner, not orphaned)", backlog)
+		}
+		passes = passes[1:]
 	}
 	// Per-pass error accounting: any failed step means orphan recovery is
 	// DEGRADED for the runs it skipped — a state a success-only counter

--- a/pkg/server/queue_sweeper_test.go
+++ b/pkg/server/queue_sweeper_test.go
@@ -248,3 +248,94 @@ func TestSweepOrphanRuns_MixedCauseNeedsBothRecoveries(t *testing.T) {
 		t.Fatal("episode still open after both stages recovered with evidence")
 	}
 }
+
+// fakeBacklogLeases reports a queue backlog, like the real natsq.Conn.
+type fakeBacklogLeases struct {
+	fakeLeases
+	backlog uint64
+	err     error
+}
+
+func (f *fakeBacklogLeases) QueueBacklog(context.Context) (uint64, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	return f.backlog, nil
+}
+
+// A queued run with no lease is NOT an orphan while the queue still
+// holds unfetched work: it is waiting for a free runner. One run per
+// pod plus a frozen pool means a long campaign fills the fleet, and
+// flipping the short runs queued behind it killed the instance's own PR
+// reviews (measured 2026-09-01). The running pass, whose lease check is
+// a real signal, must keep working.
+func TestSweepOrphanRuns_queuedWaitingForCapacityIsNotOrphaned(t *testing.T) {
+	s := newOrgTestServer(t)
+	fs := &fakeSweepStore{}
+	s.cfg.Store = fs
+	lister := &fakeStaleLister{refs: map[string][]mongostore.StaleRunRef{
+		"queued":  {{ID: "r-waiting", TenantID: "t1", Status: "queued"}},
+		"running": {{ID: "r-crashed", TenantID: "t2", Status: "running"}},
+	}}
+	leases := &fakeBacklogLeases{backlog: 3}
+
+	s.sweepOrphanRuns(context.Background(), lister, leases, time.Now().UTC())
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if _, flipped := fs.flipped["r-waiting"]; flipped {
+		t.Fatal("a queued run waiting for a free runner must not be flipped — the queue still holds its message")
+	}
+	if fs.flipped["r-crashed"] != store.RunStatusFailedResumable {
+		t.Fatalf("the running pass must still recover crashed runs: %+v", fs.flipped)
+	}
+}
+
+// An empty queue means the message is GONE: the queued row is a real
+// orphan and must be recovered, exactly as before.
+func TestSweepOrphanRuns_queuedWithEmptyQueueIsStillOrphaned(t *testing.T) {
+	s := newOrgTestServer(t)
+	fs := &fakeSweepStore{}
+	s.cfg.Store = fs
+	lister := &fakeStaleLister{refs: map[string][]mongostore.StaleRunRef{
+		"queued": {{ID: "r-gone", TenantID: "t1", Status: "queued"}},
+	}}
+
+	s.sweepOrphanRuns(context.Background(), lister, &fakeBacklogLeases{backlog: 0}, time.Now().UTC())
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if fs.flipped["r-gone"] != store.RunStatusFailedResumable {
+		t.Fatalf("a queued row whose message is gone is a real orphan: %+v", fs.flipped)
+	}
+}
+
+// The backlog is an optional capability and an optional answer: a queue
+// that cannot report one leaves the sweeper exactly as it was, rather
+// than assuming either direction.
+func TestSweepOrphanRuns_backlogUnknownKeepsPreviousBehaviour(t *testing.T) {
+	for _, c := range []struct {
+		name   string
+		leases runLeaseChecker
+	}{
+		{"capability absent", &fakeLeases{}},
+		{"backlog read fails", &fakeBacklogLeases{err: context.DeadlineExceeded}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			s := newOrgTestServer(t)
+			fs := &fakeSweepStore{}
+			s.cfg.Store = fs
+			lister := &fakeStaleLister{refs: map[string][]mongostore.StaleRunRef{
+				"queued": {{ID: "r-unknown", TenantID: "t1", Status: "queued"}},
+			}}
+
+			s.sweepOrphanRuns(context.Background(), lister, c.leases, time.Now().UTC())
+
+			fs.mu.Lock()
+			defer fs.mu.Unlock()
+			if fs.flipped["r-unknown"] != store.RunStatusFailedResumable {
+				t.Fatalf("without a backlog answer the sweeper must behave as before: %+v", fs.flipped)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The defect, measured in production today

The orphan sweeper reads *"queued row, stale, no lease"* as *"the message is gone"* and flips the run to `failed_resumable`. That shape has **two causes**, and the second one is normal operation.

A runner pod takes **one run at a time**, so a frozen pool (`min == max`, no scale-in, so long runs are never killed) is a hard parallelism ceiling. A campaign of multi-hour runs fills every pod; short runs then sit in the queue — unfetched, lease-less, and stale — waiting their turn.

**2026-09-01 on this instance:** five campaign runs held the five pods. The PR reviews the merge gate waits on stayed queued, the sweeper declared them orphaned, the gate relaunched them, and they died the same way. Six pull requests went red on *"review died without a verdict"* — **none for a reason in its own diff**. The engine was killing the work it was waiting for.

## The fix

The queue can already tell the two causes apart: a consumer still reporting pending messages is holding work nobody fetched. The sweeper now asks — `QueueBacklog` over the durable consumer's `NumPending` — and **skips the QUEUED pass while a backlog exists**. The running pass, whose lease check is a real signal, is untouched.

Read-only by construction: it reads the consumer instead of `CreateOrUpdateConsumer`, so a sweeper tick can never rewrite the consumer's configuration.

**Conservative on every unknown.** No capability, or a failed read, leaves the sweeper behaving exactly as before rather than assuming either direction. An empty queue still means the message is gone — that row is still recovered.

## Verification

Three tests, plus the five existing sweeper tests still green:

- a queued run waiting for capacity is spared **while a crashed running run is still recovered** in the same pass;
- an empty queue still orphans the queued row;
- an absent capability and a failing read both keep the previous behaviour.

Falsified by mutation (skip disabled → the waiting run is flipped again).

Operationally the symptom was also lifted by sizing the frozen pool at 8 (infra side), but that is a ceiling, not a fix: at any pool size a long enough campaign refills it, and this class would come straight back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
