### PR TITLE
feat(store): canonical terminal-state contract + persisted failure taxonomy (ADR-095)

### DIFF
--- a/docs/adr/095-terminal-state-contract-and-failure-taxonomy.md
+++ b/docs/adr/095-terminal-state-contract-and-failure-taxonomy.md
@@ -46,8 +46,9 @@ question, the internal claim-CAS sets (they gate a TRANSITION, not
 eligibility — e.g. the failure-resume claim accepts `queued` for the cloud
 pre-flip). The negative-space test
 ([lifecycle_negative_space_test.go](../../pkg/store/lifecycle_negative_space_test.go))
-forbids NEW hand-rolled sets in store/supervise/runview outside its
-per-file, reason-carrying allowlist.
+forbids NEW hand-rolled sets in store, supervise, runview, runtime and
+cloudpublisher (the two packages where the motivating drift bug lived)
+outside its per-set, reason-carrying allowlist.
 
 ### 3. `Run.FailureCode` — persisted, open-world, zero-means-unknown
 
@@ -59,10 +60,10 @@ failure status** — it annotates `Run.Error` and follows it exactly:
   CAS paths — never a separate read-modify-write).
 - **Cleared by every transition to a non-failure status** — `running`,
   `queued` (the cloud resume pre-flip), paused, finished. The SubmitResume
-  rollback restores the prior code with the prior text. `healRun` repairs a
-  stale code a whole-document writer resurrects.
-- **Open-world**: the registry (`KnownFailureCodes`) is documentation.
-  Readers never validate against it; an unknown non-empty code round-trips
+  rollback restores the prior code (see the mixed-fleet note for the
+  heal story).
+- **Open-world**: the const block is the registry, and it is
+  documentation only. Readers never validate against it; an unknown non-empty code round-trips
   unharmed (conformance + BSON decode-shape tests). Empty = UNKNOWN, never
   "no failure".
 - Writer-by-writer semantics: engine failures persist their
@@ -80,10 +81,14 @@ failure status** — it annotates `Run.Error` and follows it exactly:
 
 ### 4. Mixed-fleet note
 
-An older binary's whole-document `SaveRun` (Mongo `ReplaceOne`) drops the
-field it does not know. Accepted WITHOUT a two-release rollout: the field is
-advisory (unknown is a first-class reading), the loss window is the rolling
-deploy, and `healRun` cleans what it can. Deploy server and runner together
+An older binary's whole-document `SaveRun` (Mongo `ReplaceOne`) DROPS the
+field it does not know — a loss (back to unknown), never a stale lie, since
+a binary old enough to miss the field cannot have written one either.
+Accepted WITHOUT a two-release rollout: the field is advisory and unknown is
+a first-class reading. The FS store additionally heals on read (`healRun`
+clears a code on a non-failure status — covers hand-edited run.json); the
+Mongo twin needs no heal because every transition goes through the coded
+choke points. Deploy server and runner together
 (the runner image is digest-pinned; bump it in the same infra change).
 Rollback is safe: the field stops being written, stale values heal on read.
 

--- a/docs/adr/095-terminal-state-contract-and-failure-taxonomy.md
+++ b/docs/adr/095-terminal-state-contract-and-failure-taxonomy.md
@@ -74,10 +74,14 @@ failure status** — it annotates `Run.Error` and follows it exactly:
   **Synthetic parkings write an empty code** (fork shell, rewind/restore
   claims): they are not failures. A cancel of an already-parked run writes
   CANCELLED; the prior cause survives in the composed text, as before.
-- Declared-but-deferred writers: `PROCESS_ORPHANED` (orphan sweeps,
-  reconciles, force-stale, dead-pid), `QUEUE_SCHEMA_MISMATCH` (schema park),
-  the DLQ park — a follow-up card wires them; until then those paths
-  honestly persist unknown.
+- The resume-after-source-edit wall persists `NODE_NOT_FOUND` (the
+  auto-resume gate refuses to re-hit a deterministic wall only when the
+  code names it); `LOOP_EXHAUSTED`/`JOIN_FAILED`/`RESUME_INVALID` are
+  declared RESERVED with no persisting writer yet. The runview orphan
+  reconciles persist `PROCESS_ORPHANED`; the server orphan sweeper, the
+  dispatcher promote, force-stale and dead-pid writers, plus
+  `QUEUE_SCHEMA_MISMATCH` (schema park) and the DLQ park, are the
+  follow-up card — until then those paths honestly persist unknown.
 
 ### 4. Mixed-fleet note
 

--- a/docs/adr/095-terminal-state-contract-and-failure-taxonomy.md
+++ b/docs/adr/095-terminal-state-contract-and-failure-taxonomy.md
@@ -1,0 +1,102 @@
+# ADR-095 — Canonical terminal-state contract and persisted failure taxonomy
+
+- Status: accepted (2026-09-01)
+- Relations: ADR-014 (paused-run semantics — deliberately NOT a transition
+  state machine; this ADR adds classification only, zero new transitions),
+  ADR-028 (dispatcher lifecycle), ADR-015 (FailNode handling — the FAIL_NODE
+  code is the typed signal its deferral 5 waited for), PR #594 (the
+  operator-cancel / internal-interruption split the CANCELLED vs INTERRUPTED
+  codes persist).
+
+## Problem
+
+Terminal-ness was decided by four disagreeing predicates (store run-status,
+supervise event-level, runview ExecStatus, ir graph-shape), the resumable
+4-set {failed_resumable, cancelled, paused_operator, paused_waiting_human}
+was hand-copied at 7+ sites, and failure classification — a typed, 18-value
+`runtime.ErrorCode` — died at the persistence boundary: `Run.Error` is free
+text, so every downstream consumer (alerts, retry lanes, dispatchers) either
+string-matched or stayed blind. Audited in full (146 status-decision sites,
+110 policy-carrying, 8 concrete contradictions) before this contract.
+
+## Decision
+
+### 1. The contract lives in `pkg/store` ([lifecycle.go](../../pkg/store/lifecycle.go))
+
+`pkg/store` is the shared floor of the import DAG (store ← {runtime,
+supervise} ← runview ← dispatcher) and already owns the `RunStatus` enum.
+No new leaf package: `runtime.ErrorCode` becomes a **type alias** of
+`store.FailureCode` (constants re-exported), so one vocabulary exists.
+
+### 2. Policy-named predicates, not one IsTerminal
+
+Each predicate answers ONE question; callers stop re-deriving sets:
+`IsTerminal` (stop polling — unchanged), `IsPaused`, `IsFinalSuccess`,
+`IsFinalFailure`, `IsTerminalResumable`, `IsQueued`, `CanOperatorResume`
+(+`RequiresResumeAnswers`), `CanAutoResume` (never cancelled — automation
+must not override an operator's stop), `CountsAgainstLaunchLimit`.
+
+**Documented divergences that STAY** (each argued at its declaration and
+pinned by tests): supervise's event-level terminal set (failed_resumable
+collapses into run_failed; run_paused non-terminal), runview's ExecStatus
+monotonicity set (paused is settle-only-downgradable), `pipelineRunRetired`
+(narrower: failed_resumable still holds a slot), `sandboxContainerReapable`
+(wider: paused_operator containers reapable), worktreepool's ownership
+question, the internal claim-CAS sets (they gate a TRANSITION, not
+eligibility — e.g. the failure-resume claim accepts `queued` for the cloud
+pre-flip). The negative-space test
+([lifecycle_negative_space_test.go](../../pkg/store/lifecycle_negative_space_test.go))
+forbids NEW hand-rolled sets in store/supervise/runview outside its
+per-file, reason-carrying allowlist.
+
+### 3. `Run.FailureCode` — persisted, open-world, zero-means-unknown
+
+`failure_code` (json+bson, omitempty) classifies **the cause of the CURRENT
+failure status** — it annotates `Run.Error` and follows it exactly:
+
+- Written by the same store operation as the status (`FailRun*` carry the
+  code; `UpdateRunStatusCoded` / `UpdateRunStatusIfCoded` for the plain and
+  CAS paths — never a separate read-modify-write).
+- **Cleared by every transition to a non-failure status** — `running`,
+  `queued` (the cloud resume pre-flip), paused, finished. The SubmitResume
+  rollback restores the prior code with the prior text. `healRun` repairs a
+  stale code a whole-document writer resurrects.
+- **Open-world**: the registry (`KnownFailureCodes`) is documentation.
+  Readers never validate against it; an unknown non-empty code round-trips
+  unharmed (conformance + BSON decode-shape tests). Empty = UNKNOWN, never
+  "no failure".
+- Writer-by-writer semantics: engine failures persist their
+  `RuntimeError.Code`; FailNode → `FAIL_NODE` (deliberate termination,
+  distinct from a crash at last); internal stops → `INTERRUPTED`; operator
+  cancels (runtime CAS, publisher, runview, setup) → `CANCELLED`; node
+  timeout → `TIMEOUT`; the runner usage-cap park → `USAGE_LIMIT_BLOCKED`.
+  **Synthetic parkings write an empty code** (fork shell, rewind/restore
+  claims): they are not failures. A cancel of an already-parked run writes
+  CANCELLED; the prior cause survives in the composed text, as before.
+- Declared-but-deferred writers: `PROCESS_ORPHANED` (orphan sweeps,
+  reconciles, force-stale, dead-pid), `QUEUE_SCHEMA_MISMATCH` (schema park),
+  the DLQ park — a follow-up card wires them; until then those paths
+  honestly persist unknown.
+
+### 4. Mixed-fleet note
+
+An older binary's whole-document `SaveRun` (Mongo `ReplaceOne`) drops the
+field it does not know. Accepted WITHOUT a two-release rollout: the field is
+advisory (unknown is a first-class reading), the loss window is the rolling
+deploy, and `healRun` cleans what it can. Deploy server and runner together
+(the runner image is digest-pinned; bump it in the same infra change).
+Rollback is safe: the field stops being written, stale values heal on read.
+
+## Consequences
+
+- The cloud publisher's cancel CAS gained `paused_operator` (the one set
+  missing it — a cloud run parked there was un-cancellable, "cancel raced"
+  forever). Other contradictions from the audit are follow-up cards, not
+  silent drift: they are now enumerated with reasons.
+- Operator alerts and the run API name the failure class
+  (`failure_code` on RunSummary/RunHeader, `[CODE]` on the alert line);
+  consumers that string-match `Run.Error` (dispatcher sandbox-classify,
+  retry lanes) can migrate to typed-first reads as follow-up.
+- Cross-layer agreement is executable: predicate truth tables + relation
+  invariants in store, event-collapse documentation in supervise,
+  ExecStatus divergence in runview.

--- a/docs/adr/095-terminal-state-contract-and-failure-taxonomy.md
+++ b/docs/adr/095-terminal-state-contract-and-failure-taxonomy.md
@@ -46,9 +46,11 @@ question, the internal claim-CAS sets (they gate a TRANSITION, not
 eligibility — e.g. the failure-resume claim accepts `queued` for the cloud
 pre-flip). The negative-space test
 ([lifecycle_negative_space_test.go](../../pkg/store/lifecycle_negative_space_test.go))
-forbids NEW hand-rolled sets in store, supervise, runview, runtime and
-cloudpublisher (the two packages where the motivating drift bug lived)
-outside its per-set, reason-carrying allowlist.
+forbids NEW hand-rolled sets across eleven packages (store, supervise,
+runview, runtime, cloudpublisher, dispatcher, cli, notify, worktreepool,
+operatormcp, runner) outside its per-set allowlist, each entry anchored
+to the enclosing FUNCTION with its reason — a removed+added pair of
+same-combo sets cannot trade places behind a count.
 
 ### 3. `Run.FailureCode` — persisted, open-world, zero-means-unknown
 
@@ -74,9 +76,12 @@ failure status** — it annotates `Run.Error` and follows it exactly:
   **Synthetic parkings write an empty code** (fork shell, rewind/restore
   claims): they are not failures. A cancel of an already-parked run writes
   CANCELLED; the prior cause survives in the composed text, as before.
-- The resume-after-source-edit wall persists `NODE_NOT_FOUND` (the
-  auto-resume gate refuses to re-hit a deterministic wall only when the
-  code names it); `LOOP_EXHAUSTED`/`JOIN_FAILED`/`RESUME_INVALID` are
+- The resume-after-source-edit wall persists `NODE_NOT_FOUND` at every
+  lookup site (main loop, branch fan-out, both resume paths,
+  convergence — whose wait_all aggregate keeps a code ALL failed
+  branches share). The in-process --auto-resume gate already refuses it
+  through the typed error; readers of the PERSISTED code (dispatcher /
+  retry lanes across processes) are the follow-up card; `LOOP_EXHAUSTED`/`JOIN_FAILED`/`RESUME_INVALID` are
   declared RESERVED with no persisting writer yet. The runview orphan
   reconciles persist `PROCESS_ORPHANED`; the server orphan sweeper, the
   dispatcher promote, force-stale and dead-pid writers, plus
@@ -95,6 +100,23 @@ Mongo twin needs no heal because every transition goes through the coded
 choke points. Deploy server and runner together
 (the runner image is digest-pinned; bump it in the same infra change).
 Rollback is safe: the field stops being written, stale values heal on read.
+
+### 5. A status transition never destroys the checkpoint
+
+The FS store used to clear the checkpoint on the running and finished
+transitions (and the first loop round taught Mongo the same). That
+destroyed the CLOUD resume point: the park writers that follow a claim
+(drain, usage-cap, orphan sweeps, --force-stale) flip
+running→failed_resumable with no checkpoint of their own, and the next
+resume restarted from the workflow entry. The contract is now the
+reverse on BOTH twins — only `DeleteRun` and the rewind machinery
+remove a checkpoint; resumability is `Status`'s job; a finished run
+keeps its checkpoint (`iterion fork` reads it). Two consequences are
+handled explicitly: `resumeFromPause` CONSUMES the pause pointer
+(clears `InteractionID`/`InteractionQuestions` right after its claim,
+or a later park would hand a stale interaction to Resume's queued
+router and overwrite the operator's answers), and the run-outcome
+event only surfaces checkpoint interaction evidence on a PAUSED status.
 
 ## Consequences
 

--- a/docs/persisted-formats.md
+++ b/docs/persisted-formats.md
@@ -68,6 +68,13 @@ The complete shape is [`store.Run`](../pkg/store/run.go). `omitempty` fields
 from local/cloud, worktree, webhook, secret, attachment, budget, and Studio
 features can legitimately be absent.
 
+`failure_code` (ADR-095) is the machine-readable classification of `error`
+on a failure status (`failed` / `failed_resumable` / `cancelled`), written
+atomically with the status and cleared by every transition to a non-failure
+status. Absent/empty means UNKNOWN (legacy rows, unclassified writers) —
+never "no failure". The vocabulary is open-world: readers must accept codes
+they do not know (see [`store.FailureCode`](../pkg/store/lifecycle.go)).
+
 `nodes_served` maps each LLM node's id to the last `(backend, model)` that
 served it (`model` is the provider-reported effective model; `declared_model`
 is what the node asked for). It is the run-record half of making a finished

--- a/docs/persisted-formats.md
+++ b/docs/persisted-formats.md
@@ -106,9 +106,11 @@ though an explicit resume can transition them back to `running`.
 The checkpoint embedded in `run.json` is the source of truth for resume.
 `events.jsonl` is an audit/observation stream and is never replayed to rebuild
 execution state. A checkpoint may be present while a run is still `running`
-because it is saved best-effort after successful node boundaries; it is
-preserved for resumable/cancelled/paused states and cleared on ordinary
-finished/failed transitions.
+because it is saved best-effort after successful node boundaries. **A status
+transition never destroys it** (ADR-095): only `DeleteRun` and the rewind
+machinery remove one, and resumability is decided by `Status` alone — a
+terminal run keeps its checkpoint (`iterion fork` reads a finished
+parent's).
 
 ```jsonc
 {

--- a/e2e/rewind_resume_test.go
+++ b/e2e/rewind_resume_test.go
@@ -31,7 +31,7 @@ func TestRewindThenResume_SkipsUpstreamNodes(t *testing.T) {
 
 	// Pass 1: verify fails execution (a transient-style error, NOT the
 	// `fail` terminal node — reaching that is intentional termination and
-	// produces a non-resumable `failed` with the checkpoint cleared), so
+	// produces a non-resumable `failed` (the checkpoint is preserved — ADR-095)), so
 	// the run lands failed_resumable anchored on `verify`.
 	exec := newScenarioExecutor()
 	exec.on("verify", func(_ map[string]any) (map[string]any, error) {

--- a/openapi.json
+++ b/openapi.json
@@ -1390,6 +1390,9 @@
           "error": {
             "type": "string"
           },
+          "failure_code": {
+            "type": "string"
+          },
           "fallbacks_used": {
             "items": {
               "$ref": "#/components/schemas/FallbackUsage"
@@ -1642,6 +1645,9 @@
             "type": "string"
           },
           "error": {
+            "type": "string"
+          },
+          "failure_code": {
             "type": "string"
           },
           "file_path": {

--- a/pkg/alert/alert.go
+++ b/pkg/alert/alert.go
@@ -51,15 +51,19 @@ const (
 // human-readable reason, and the budget axis + percentage consumed when
 // the trigger is budget-related.
 type Alert struct {
-	Kind      Kind      `json:"kind"`
-	RunID     string    `json:"run_id"`
-	RunName   string    `json:"run_name,omitempty"`
-	NodeID    string    `json:"node_id,omitempty"`
-	Reason    string    `json:"reason,omitempty"`
-	Axis      string    `json:"axis,omitempty"`       // budget dimension (tokens/cost_usd/...)
-	BudgetPct float64   `json:"budget_pct,omitempty"` // 0..100, budget alerts only
-	Link      string    `json:"link,omitempty"`       // <baseURL>/runs/<id>
-	Timestamp time.Time `json:"timestamp"`
+	Kind    Kind   `json:"kind"`
+	RunID   string `json:"run_id"`
+	RunName string `json:"run_name,omitempty"`
+	NodeID  string `json:"node_id,omitempty"`
+	Reason  string `json:"reason,omitempty"`
+	// FailureCode is the run's persisted typed classification (ADR-095)
+	// when one exists — a machine consumer reads it here, never by
+	// parsing Reason.
+	FailureCode string    `json:"failure_code,omitempty"`
+	Axis        string    `json:"axis,omitempty"`       // budget dimension (tokens/cost_usd/...)
+	BudgetPct   float64   `json:"budget_pct,omitempty"` // 0..100, budget alerts only
+	Link        string    `json:"link,omitempty"`       // <baseURL>/runs/<id>
+	Timestamp   time.Time `json:"timestamp"`
 }
 
 // Title is a short one-line headline suitable for a toast or
@@ -99,6 +103,9 @@ func (a Alert) WebhookText() string {
 	if a.Reason != "" {
 		fmt.Fprintf(&b, "\nReason: %s", a.Reason)
 	}
+	if a.FailureCode != "" {
+		fmt.Fprintf(&b, " [%s]", a.FailureCode)
+	}
 	// Only when there IS a ratio. A dimension whose budget_warning payload
 	// carries no used/limit pair (cost_usd_unpriced: tokens burned at an
 	// unknown price, against a dollar ceiling) arrives here with BudgetPct
@@ -133,6 +140,9 @@ func (a Alert) AsEventData() map[string]any {
 	}
 	if a.Reason != "" {
 		d["reason"] = a.Reason
+	}
+	if a.FailureCode != "" {
+		d["failure_code"] = a.FailureCode
 	}
 	if a.Axis != "" {
 		d["axis"] = a.Axis

--- a/pkg/alert/alert.go
+++ b/pkg/alert/alert.go
@@ -102,9 +102,13 @@ func (a Alert) WebhookText() string {
 	}
 	if a.Reason != "" {
 		fmt.Fprintf(&b, "\nReason: %s", a.Reason)
-	}
-	if a.FailureCode != "" {
-		fmt.Fprintf(&b, " [%s]", a.FailureCode)
+		if a.FailureCode != "" {
+			fmt.Fprintf(&b, " [%s]", a.FailureCode)
+		}
+	} else if a.FailureCode != "" {
+		// No prose to annotate — the code gets its own line rather
+		// than visually qualifying the node or the run name above.
+		fmt.Fprintf(&b, "\nCode: %s", a.FailureCode)
 	}
 	// Only when there IS a ratio. A dimension whose budget_warning payload
 	// carries no used/limit pair (cost_usd_unpriced: tokens burned at an

--- a/pkg/alert/errtrack.go
+++ b/pkg/alert/errtrack.go
@@ -43,6 +43,9 @@ func (TrackerSink) Notify(_ context.Context, a Alert) {
 	if a.Reason != "" {
 		fields["reason"] = a.Reason
 	}
+	if a.FailureCode != "" {
+		fields["failure_code"] = a.FailureCode
+	}
 	if a.Axis != "" {
 		fields["axis"] = a.Axis
 		fields["budget_pct"] = a.BudgetPct

--- a/pkg/alert/failure_code_render_test.go
+++ b/pkg/alert/failure_code_render_test.go
@@ -1,0 +1,74 @@
+package alert
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/errtrack"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// The in-process Manager must not drop the typed code the run_failed
+// event has carried all along — the local studio's alerts would
+// otherwise stay unclassified while the cloud path names the class.
+func TestManagerPropagatesEventFailureCode(t *testing.T) {
+	sink := &captureSink{}
+	m := newTestManager(sink)
+	m.Observe(store.Event{RunID: "r1", Type: store.EventRunFailed, NodeID: "agent",
+		Timestamp: time.Now(), Data: map[string]any{"error": "anthropic 401", "code": "AUTH_FAILED"}})
+	waitFor(t, func() bool { return len(sink.snapshot()) >= 1 })
+	got := sink.snapshot()[0]
+	if got.FailureCode != "AUTH_FAILED" {
+		t.Fatalf("in-process alert dropped the typed code: %q", got.FailureCode)
+	}
+}
+
+// The tracker sink is the machine consumer par excellence — it must
+// carry failure_code like its two sibling renders (WebhookText,
+// AsEventData) instead of forcing Sentry queries to parse Reason.
+func TestTrackerSinkCarriesFailureCode(t *testing.T) {
+	tr := trackerTransport
+	trackerTransportOn.Do(func() {
+		errtrack.Init(errtrack.Config{
+			DSN:       "https://publickey@localhost/1",
+			Transport: tr,
+			Logger:    iterlog.New(iterlog.LevelError, io.Discard),
+		})
+	})
+	if !errtrack.Enabled() {
+		t.Skip("errtrack init raced another binary state")
+	}
+	before := len(tr.all())
+	TrackerSink{}.Notify(context.Background(), Alert{
+		Kind: KindRunFailed, RunID: "r1", Reason: "boom", FailureCode: "TIMEOUT",
+	})
+	evs := tr.all()
+	if len(evs) != before+1 {
+		t.Fatalf("events = %d, want %d", len(evs), before+1)
+	}
+	if got := evs[len(evs)-1].Contexts["iterion"]["failure_code"]; got != "TIMEOUT" {
+		t.Fatalf("tracker event failure_code = %v, want TIMEOUT", got)
+	}
+}
+
+// The webhook text annotates the Reason line when there is one, and
+// gives the code its own line otherwise — never gluing "[CODE]" onto
+// the node or the run name.
+func TestWebhookTextFailureCodePlacement(t *testing.T) {
+	withReason := Alert{Kind: KindRunFailed, RunName: "digest", Reason: "deadline", FailureCode: "TIMEOUT"}
+	if txt := withReason.WebhookText(); !strings.Contains(txt, "Reason: deadline [TIMEOUT]") {
+		t.Errorf("reason+code render: %q", txt)
+	}
+	noReason := Alert{Kind: KindRunFailed, RunName: "digest", NodeID: "synthesize", FailureCode: "TIMEOUT"}
+	txt := noReason.WebhookText()
+	if !strings.Contains(txt, "\nCode: TIMEOUT") {
+		t.Errorf("code without reason must get its own line: %q", txt)
+	}
+	if strings.Contains(txt, "synthesize [TIMEOUT]") {
+		t.Errorf("code glued onto the node line: %q", txt)
+	}
+}

--- a/pkg/alert/manager.go
+++ b/pkg/alert/manager.go
@@ -200,7 +200,12 @@ func (m *Manager) Observe(evt store.Event) {
 			if reason == "" {
 				reason = "see run logs"
 			}
-			fired = append(fired, m.alertLocked(KindRunFailed, rs, evt.NodeID, reason, "", 0, ts))
+			a := m.alertLocked(KindRunFailed, rs, evt.NodeID, reason, "", 0, ts)
+			// The run_failed event has carried the typed code all
+			// along — the in-process path must not drop what the cloud
+			// path (OpsDispatcher.classify) surfaces.
+			a.FailureCode = strData(evt.Data, "code")
+			fired = append(fired, a)
 		}
 	case store.EventRunFinished, store.EventRunCancelled:
 		rs.terminal = true

--- a/pkg/alert/opsdispatch.go
+++ b/pkg/alert/opsdispatch.go
@@ -230,10 +230,16 @@ func (d *OpsDispatcher) classify(ctx context.Context, ev trigger.Event) (Alert, 
 		if run.Error != "" {
 			a.Reason += " · " + truncate(run.Error, 200)
 		}
+		if run.FailureCode != "" {
+			a.Reason += " [" + string(run.FailureCode) + "]"
+		}
 		return a, run, true
 	case store.RunStatusFailed:
 		a.Kind = KindRunFailed
 		a.Reason = truncate(run.Error, 200)
+		if run.FailureCode != "" {
+			a.Reason += " [" + string(run.FailureCode) + "]"
+		}
 		return a, run, true
 	default:
 		// Already resumed/finished by the time we looked — nothing owed.

--- a/pkg/alert/opsdispatch.go
+++ b/pkg/alert/opsdispatch.go
@@ -172,7 +172,14 @@ func opsEpisodeKey(run *store.Run) string {
 		if run.RetryState != nil {
 			attempts = run.RetryState.Attempts
 		}
-		return fmt.Sprintf("%srun:%s:parked:%d", opsEpisodePrefix, run.ID, attempts)
+		// The failure code joins the key because attempts alone can
+		// stand still across two DIFFERENT parks: ScheduleRunRetry is
+		// the only writer that advances it, so a resumed run re-parking
+		// on an unretryable cause (no retry armed) reuses the old
+		// count — and the operator would never hear about the new,
+		// manual-intervention failure. Same code repeated = still one
+		// episode, so the retry-cycle anti-spam is intact.
+		return fmt.Sprintf("%srun:%s:parked:%d:%s", opsEpisodePrefix, run.ID, attempts, run.FailureCode)
 	}
 	return opsEpisodePrefix + trigger.RunOutcomeEventID(run.ID, string(run.Status), "", run.UpdatedAt)
 }

--- a/pkg/alert/opsdispatch.go
+++ b/pkg/alert/opsdispatch.go
@@ -230,16 +230,12 @@ func (d *OpsDispatcher) classify(ctx context.Context, ev trigger.Event) (Alert, 
 		if run.Error != "" {
 			a.Reason += " · " + truncate(run.Error, 200)
 		}
-		if run.FailureCode != "" {
-			a.Reason += " [" + string(run.FailureCode) + "]"
-		}
+		a.FailureCode = string(run.FailureCode)
 		return a, run, true
 	case store.RunStatusFailed:
 		a.Kind = KindRunFailed
 		a.Reason = truncate(run.Error, 200)
-		if run.FailureCode != "" {
-			a.Reason += " [" + string(run.FailureCode) + "]"
-		}
+		a.FailureCode = string(run.FailureCode)
 		return a, run, true
 	default:
 		// Already resumed/finished by the time we looked — nothing owed.

--- a/pkg/alert/opsdispatch.go
+++ b/pkg/alert/opsdispatch.go
@@ -2,6 +2,8 @@ package alert
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"sync"
@@ -172,14 +174,23 @@ func opsEpisodeKey(run *store.Run) string {
 		if run.RetryState != nil {
 			attempts = run.RetryState.Attempts
 		}
-		// The failure code joins the key because attempts alone can
+		// The failure CLASS joins the key because attempts alone can
 		// stand still across two DIFFERENT parks: ScheduleRunRetry is
 		// the only writer that advances it, so a resumed run re-parking
 		// on an unretryable cause (no retry armed) reuses the old
 		// count — and the operator would never hear about the new,
-		// manual-intervention failure. Same code repeated = still one
-		// episode, so the retry-cycle anti-spam is intact.
-		return fmt.Sprintf("%srun:%s:parked:%d:%s", opsEpisodePrefix, run.ID, attempts, run.FailureCode)
+		// manual-intervention failure. Same class repeated = still one
+		// episode, so the retry-cycle anti-spam is intact. When the
+		// writer left the code UNKNOWN (the declared-deferred parks:
+		// sandbox-fail, schema park, DLQ), a fingerprint of the error
+		// text stands in — two distinct unclassified parks are still
+		// two incidents.
+		class := string(run.FailureCode)
+		if class == "" {
+			sum := sha256.Sum256([]byte(run.Error))
+			class = "e:" + hex.EncodeToString(sum[:6])
+		}
+		return fmt.Sprintf("%srun:%s:parked:%d:%s", opsEpisodePrefix, run.ID, attempts, class)
 	}
 	return opsEpisodePrefix + trigger.RunOutcomeEventID(run.ID, string(run.Status), "", run.UpdatedAt)
 }

--- a/pkg/alert/opsdispatch_test.go
+++ b/pkg/alert/opsdispatch_test.go
@@ -341,3 +341,35 @@ func TestOpsDispatcher_NewFailureCodeIsANewEpisode(t *testing.T) {
 		t.Fatalf("repeat of the same code: %d alerts, want still 2", got)
 	}
 }
+
+// Unclassified parks (the declared-deferred writers persist an empty
+// code) still discriminate episodes: a fingerprint of the error text
+// stands in for the class, so two DIFFERENT unclassified parks are two
+// incidents while a bookkeeping bump of the same one stays deduped.
+func TestOpsDispatcher_EmptyCodeParksDiscriminateByError(t *testing.T) {
+	d, rs, sink := opsWorld(t)
+	run := seedOpsRun(t, rs, store.RunStatusFailedResumable, func(r *store.Run) {
+		r.Error = "sandbox start failed: image pull backoff"
+		r.RetryState = &store.RunRetryState{Attempts: 1}
+	})
+	_ = d.Handle(context.Background(), trigger.BuildRunOutcome(context.Background(), rs, run.ID, nil))
+	// Bookkeeping bump, same error: still one episode.
+	r2, _ := rs.LoadRun(context.Background(), run.ID)
+	r2.UpdatedAt = r2.UpdatedAt.Add(time.Minute)
+	_ = rs.SaveRun(context.Background(), r2)
+	_ = d.Handle(context.Background(), trigger.BuildRunOutcome(context.Background(), rs, run.ID, nil))
+	if got := len(sink.alerts()); got != 1 {
+		t.Fatalf("same unclassified park re-alerted: %d, want 1", got)
+	}
+	// A DIFFERENT unclassified failure, attempts unchanged: new incident.
+	r3, _ := rs.LoadRun(context.Background(), run.ID)
+	r3.Error = "queue schema mismatch: message v12 outside accepted range"
+	r3.UpdatedAt = r3.UpdatedAt.Add(time.Minute)
+	if err := rs.SaveRun(context.Background(), r3); err != nil {
+		t.Fatal(err)
+	}
+	_ = d.Handle(context.Background(), trigger.BuildRunOutcome(context.Background(), rs, run.ID, nil))
+	if got := len(sink.alerts()); got != 2 {
+		t.Fatalf("a NEW unclassified failure was silenced: %d alerts, want 2", got)
+	}
+}

--- a/pkg/alert/opsdispatch_test.go
+++ b/pkg/alert/opsdispatch_test.go
@@ -294,3 +294,50 @@ func TestOpsDispatcher_LoserNeverCertifiesAPendingClaim(t *testing.T) {
 		t.Fatalf("%d alerts after release + healthy sweep, want 1 — the loser's stamp silenced the episode forever", got)
 	}
 }
+
+// A SECOND park with a DIFFERENT failure code is a genuinely new
+// incident even when RetryState.Attempts stands still (ScheduleRunRetry
+// is its only writer, and an unretryable re-park never calls it). The
+// episode key must discriminate on the code, or the operator never
+// hears that the run now needs a manual resume.
+func TestOpsDispatcher_NewFailureCodeIsANewEpisode(t *testing.T) {
+	d, rs, sink := opsWorld(t)
+	reset := time.Now().Add(3 * time.Hour).UTC()
+	run := seedOpsRun(t, rs, store.RunStatusFailedResumable, func(r *store.Run) {
+		r.Error = "usage cap: weekly window"
+		r.FailureCode = store.FailureUsageLimitBlocked
+		r.RetryState = &store.RunRetryState{RetryAfter: &reset, Reason: "usage_window", Attempts: 1}
+	})
+	_ = d.Handle(context.Background(), trigger.BuildRunOutcome(context.Background(), rs, run.ID, nil))
+	if got := len(sink.alerts()); got != 1 {
+		t.Fatalf("first park: %d alerts, want 1", got)
+	}
+
+	// Resume, then re-park on an UNRETRYABLE cause: attempts unchanged,
+	// no retry armed, different code.
+	run2, _ := rs.LoadRun(context.Background(), run.ID)
+	run2.Status = store.RunStatusFailedResumable
+	run2.Error = "anthropic: invalid api key"
+	run2.FailureCode = store.FailureAuthFailed
+	run2.RetryState = &store.RunRetryState{Attempts: 1}
+	run2.UpdatedAt = run2.UpdatedAt.Add(10 * time.Minute)
+	if err := rs.SaveRun(context.Background(), run2); err != nil {
+		t.Fatal(err)
+	}
+	_ = d.Handle(context.Background(), trigger.BuildRunOutcome(context.Background(), rs, run.ID, nil))
+	alerts := sink.alerts()
+	if len(alerts) != 2 {
+		t.Fatalf("second park with a new failure code: %d alerts, want 2 — the manual-intervention incident was silenced", len(alerts))
+	}
+	if alerts[1].FailureCode != string(store.FailureAuthFailed) {
+		t.Errorf("second alert code = %q, want AUTH_FAILED", alerts[1].FailureCode)
+	}
+	// Same code repeated (a bookkeeping bump) stays ONE episode.
+	run3, _ := rs.LoadRun(context.Background(), run.ID)
+	run3.UpdatedAt = run3.UpdatedAt.Add(90 * time.Second)
+	_ = rs.SaveRun(context.Background(), run3)
+	_ = d.Handle(context.Background(), trigger.BuildRunOutcome(context.Background(), rs, run.ID, nil))
+	if got := len(sink.alerts()); got != 2 {
+		t.Fatalf("repeat of the same code: %d alerts, want still 2", got)
+	}
+}

--- a/pkg/cli/auto_resume.go
+++ b/pkg/cli/auto_resume.go
@@ -229,7 +229,7 @@ func autoResumeLoop(
 			logger.Warn("auto-resume: load run %s: %v — stopping", runID, loadErr)
 			return err
 		}
-		if r.Status != store.RunStatusFailedResumable {
+		if !r.Status.CanAutoResume() {
 			return err
 		}
 

--- a/pkg/cli/inspect.go
+++ b/pkg/cli/inspect.go
@@ -165,10 +165,12 @@ func RunInspect(opts InspectOptions, p *Printer) error {
 	}
 
 	// Checkpoint info. The checkpoint survives every status transition
-	// (ADR-095), so gate on the statuses where it is a live recovery
-	// point — on a running or terminal run it is history, and rendering
-	// "Paused at" there would misreport the run.
-	if r.Checkpoint != nil && r.Status.CanOperatorResume() {
+	// (ADR-095), so it is shown whenever it carries an anchor — on a
+	// queued run it is where a cloud resume will restart, on a failed
+	// run it is where the post-mortem starts, on a running run it is
+	// the last boundary. Only the WORDING is status-gated: "Paused at"
+	// would misreport a non-paused run.
+	if r.Checkpoint != nil && r.Checkpoint.NodeID != "" {
 		p.Blank()
 		p.Header("Checkpoint")
 		nodeLabel := "Node"

--- a/pkg/cli/inspect.go
+++ b/pkg/cli/inspect.go
@@ -164,20 +164,28 @@ func RunInspect(opts InspectOptions, p *Printer) error {
 		}
 	}
 
-	// Checkpoint info (for paused runs).
-	if r.Checkpoint != nil {
+	// Checkpoint info. The checkpoint survives every status transition
+	// (ADR-095), so gate on the statuses where it is a live recovery
+	// point — on a running or terminal run it is history, and rendering
+	// "Paused at" there would misreport the run.
+	if r.Checkpoint != nil && r.Status.CanOperatorResume() {
 		p.Blank()
 		p.Header("Checkpoint")
-		p.KV("Paused at", r.Checkpoint.NodeID)
-		p.KV("Interaction", r.Checkpoint.InteractionID)
-
-		// Show pending interaction questions.
-		inter, err := s.LoadInteraction(context.Background(), opts.RunID, r.Checkpoint.InteractionID)
-		if err == nil && len(inter.Questions) > 0 {
-			p.Blank()
-			p.Line("  Questions:")
-			for k, v := range inter.Questions {
-				p.Line("    %s: %v", k, v)
+		nodeLabel := "Node"
+		if r.Status.IsPaused() {
+			nodeLabel = "Paused at"
+		}
+		p.KV(nodeLabel, r.Checkpoint.NodeID)
+		// The interaction is a pause pointer: pending only while paused.
+		if r.Status.IsPaused() && r.Checkpoint.InteractionID != "" {
+			p.KV("Interaction", r.Checkpoint.InteractionID)
+			inter, err := s.LoadInteraction(context.Background(), opts.RunID, r.Checkpoint.InteractionID)
+			if err == nil && len(inter.Questions) > 0 {
+				p.Blank()
+				p.Line("  Questions:")
+				for k, v := range inter.Questions {
+					p.Line("    %s: %v", k, v)
+				}
 			}
 		}
 	}

--- a/pkg/cli/inspect.go
+++ b/pkg/cli/inspect.go
@@ -178,7 +178,9 @@ func RunInspect(opts InspectOptions, p *Printer) error {
 			nodeLabel = "Paused at"
 		}
 		p.KV(nodeLabel, r.Checkpoint.NodeID)
-		// The interaction is a pause pointer: pending only while paused.
+		// Stricter than CarriesPausePointer (paused ∨ queued) on
+		// purpose: on a queued run the form is not actionable — the
+		// answers already travel in the queue message.
 		if r.Status.IsPaused() && r.Checkpoint.InteractionID != "" {
 			p.KV("Interaction", r.Checkpoint.InteractionID)
 			inter, err := s.LoadInteraction(context.Background(), opts.RunID, r.Checkpoint.InteractionID)

--- a/pkg/cli/inspect_checkpoint_test.go
+++ b/pkg/cli/inspect_checkpoint_test.go
@@ -41,6 +41,41 @@ func TestInspectHidesStalePauseOnFinishedRun(t *testing.T) {
 	}
 }
 
+// The middle of the matrix: a failed_resumable run keeps its anchor
+// (where the post-mortem starts) but must not advertise a pause — this
+// is the line that distinguishes the NodeID gate from an IsPaused one.
+func TestInspectShowsAnchorWithoutPauseOnFailedResumable(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if _, err := s.CreateRun(ctx, "r-parked", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	cp := &store.Checkpoint{NodeID: "implement", InteractionID: "I1"}
+	if err := s.PauseRun(ctx, "r-parked", cp); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpdateRunStatus(ctx, "r-parked", store.RunStatusFailedResumable, "parked"); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	p := &Printer{Format: OutputHuman, W: &buf}
+	if err := RunInspect(InspectOptions{RunID: "r-parked", StoreDir: dir}, p); err != nil {
+		t.Fatalf("RunInspect: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "implement") {
+		t.Errorf("inspect of a parked run lost its checkpoint anchor:\n%s", out)
+	}
+	if strings.Contains(out, "Paused at") || strings.Contains(out, "I1") {
+		t.Errorf("inspect of a parked run advertises a pause:\n%s", out)
+	}
+}
+
 // On a genuinely paused run the block stays: the pointer is live.
 func TestInspectShowsPausePointerOnPausedRun(t *testing.T) {
 	dir := t.TempDir()

--- a/pkg/cli/inspect_checkpoint_test.go
+++ b/pkg/cli/inspect_checkpoint_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// The checkpoint survives every status transition (ADR-095), so a
+// FINISHED run keeps whatever interaction pointer it held. Inspect must
+// not report "Paused at" + a live "Interaction" id on a terminated run.
+func TestInspectHidesStalePauseOnFinishedRun(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if _, err := s.CreateRun(ctx, "r-stale", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	cp := &store.Checkpoint{NodeID: "gate", InteractionID: "I1"}
+	if err := s.PauseRun(ctx, "r-stale", cp); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpdateRunStatus(ctx, "r-stale", store.RunStatusFinished, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	p := &Printer{Format: OutputHuman, W: &buf}
+	if err := RunInspect(InspectOptions{RunID: "r-stale", StoreDir: dir}, p); err != nil {
+		t.Fatalf("RunInspect: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "Paused at") || strings.Contains(out, "I1") {
+		t.Errorf("inspect of a FINISHED run advertises a pause:\n%s", out)
+	}
+}
+
+// On a genuinely paused run the block stays: the pointer is live.
+func TestInspectShowsPausePointerOnPausedRun(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if _, err := s.CreateRun(ctx, "r-paused", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	cp := &store.Checkpoint{NodeID: "gate", InteractionID: "I1"}
+	if err := s.PauseRun(ctx, "r-paused", cp); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	p := &Printer{Format: OutputHuman, W: &buf}
+	if err := RunInspect(InspectOptions{RunID: "r-paused", StoreDir: dir}, p); err != nil {
+		t.Fatalf("RunInspect: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Paused at") || !strings.Contains(out, "I1") {
+		t.Errorf("inspect of a PAUSED run lost its pause pointer:\n%s", out)
+	}
+}

--- a/pkg/cli/resume.go
+++ b/pkg/cli/resume.go
@@ -331,10 +331,7 @@ func RunResumeWithFile(ctx context.Context, iterFile string, opts ResumeOptions,
 	if err != nil {
 		return fmt.Errorf("cannot reload run: %w", err)
 	}
-	if r.Status != store.RunStatusPausedWaitingHuman &&
-		r.Status != store.RunStatusFailedResumable &&
-		r.Status != store.RunStatusCancelled &&
-		r.Status != store.RunStatusPausedOperator {
+	if !r.Status.CanOperatorResume() {
 		return fmt.Errorf("run %q can no longer be resumed (status: %s)", opts.RunID, r.Status)
 	}
 

--- a/pkg/cli/resume.go
+++ b/pkg/cli/resume.go
@@ -165,12 +165,12 @@ func RunResumeWithFile(ctx context.Context, iterFile string, opts ResumeOptions,
 	}
 
 	resumingFromFailure := false
-	switch r.Status {
-	case store.RunStatusPausedWaitingHuman:
-		// OK — requires answers
-	case store.RunStatusFailedResumable, store.RunStatusCancelled, store.RunStatusPausedOperator:
+	switch {
+	case r.Status.RequiresResumeAnswers():
+		// OK — the pause path
+	case r.Status.CanOperatorResume():
 		resumingFromFailure = true
-	case store.RunStatusRunning:
+	case r.Status == store.RunStatusRunning:
 		// Status=running on a run whose engine actually died is the
 		// classic orphan case. The server-boot sweep handles most of
 		// these automatically; --force-stale lets the operator unstick

--- a/pkg/notify/completion.go
+++ b/pkg/notify/completion.go
@@ -141,19 +141,11 @@ func (n *Notifier) FireForRun(ctx context.Context, st store.RunStore, runID stri
 	n.deliver(ctx, run.CallbackURL, payload)
 }
 
-// shouldNotify reports whether a status warrants a completion callback.
-// Running and the two paused states are excluded — they are not
-// terminal-for-notification.
+// shouldNotify reports whether a status warrants a completion callback:
+// exactly the canonical terminal set (failed_resumable counts as final
+// for delivery; the paused states do not).
 func shouldNotify(s store.RunStatus) bool {
-	switch s {
-	case store.RunStatusFinished,
-		store.RunStatusFailed,
-		store.RunStatusFailedResumable,
-		store.RunStatusCancelled:
-		return true
-	default:
-		return false
-	}
+	return s.IsTerminal()
 }
 
 // resolveFinalAnswer extracts the run's user-facing answer string.

--- a/pkg/notify/completion.go
+++ b/pkg/notify/completion.go
@@ -141,9 +141,11 @@ func (n *Notifier) FireForRun(ctx context.Context, st store.RunStore, runID stri
 	n.deliver(ctx, run.CallbackURL, payload)
 }
 
-// shouldNotify reports whether a status warrants a completion callback:
-// exactly the canonical terminal set (failed_resumable counts as final
-// for delivery; the paused states do not).
+// shouldNotify reports whether a status warrants a completion callback.
+// It deliberately BORROWS IsTerminal (the stop-polling contract):
+// delivery-finality and polling share the same set today, and this
+// comment is the tripwire — if IsTerminal ever moves for a polling
+// reason, delivery needs its own predicate, not a silent ride-along.
 func shouldNotify(s store.RunStatus) bool {
 	return s.IsTerminal()
 }

--- a/pkg/operatormcp/tools_local.go
+++ b/pkg/operatormcp/tools_local.go
@@ -397,7 +397,7 @@ func handleLocalRunGet(ctx context.Context, s *Server, raw json.RawMessage) (str
 	if r.MergeStatus != "" {
 		view["merge_status"] = string(r.MergeStatus)
 	}
-	view["resumable"] = r.Status == store.RunStatusFailedResumable || r.Status == store.RunStatusCancelled || r.Status.IsPaused()
+	view["resumable"] = r.Status.CanOperatorResume()
 
 	// Liveness of a "running" doc: the run flock is the oracle (held ⇔
 	// some live process is executing the run; the OS drops it on any
@@ -718,7 +718,7 @@ func handleLocalResume(ctx context.Context, s *Server, raw json.RawMessage) (str
 	if err != nil {
 		return "", false, err
 	}
-	if !r.Status.IsPaused() && r.Status != store.RunStatusFailedResumable && r.Status != store.RunStatusCancelled {
+	if !r.Status.CanOperatorResume() {
 		return "", false, fmt.Errorf("run %s has status %s — only paused, failed_resumable or cancelled runs can be resumed", r.ID, r.Status)
 	}
 	filePath := s.resolvePath(args.FilePath)

--- a/pkg/runner/usage_cap.go
+++ b/pkg/runner/usage_cap.go
@@ -160,8 +160,8 @@ func (r *Runner) usageCapPreflight(ctx context.Context, wf *ir.Workflow, msg *qu
 		sctx, scancel := context.WithTimeout(context.WithoutCancel(ctx), usageCapStoreTimeout)
 		defer scancel()
 		sctx = store.WithIdentity(sctx, msg.TenantID, msg.OwnerID)
-		if _, serr := r.cfg.Store.UpdateRunStatusIf(sctx, msg.RunID, store.RunStatusFailedResumable,
-			d.Reason,
+		if _, serr := r.cfg.Store.UpdateRunStatusIfCoded(sctx, msg.RunID, store.RunStatusFailedResumable,
+			d.Reason, store.FailureUsageLimitBlocked,
 			[]store.RunStatus{store.RunStatusRunning, store.RunStatusQueued}); serr != nil && logger != nil {
 			logger.Warn("runner: usage-cap status flip for %s: %v", msg.RunID, serr)
 		}

--- a/pkg/runner/usage_cap_test.go
+++ b/pkg/runner/usage_cap_test.go
@@ -22,14 +22,16 @@ type capStatusStore struct {
 	store.RunStore
 	gotStatus store.RunStatus
 	gotErr    string
+	gotCode   store.FailureCode
 	gotFrom   []store.RunStatus
 	calls     int
 }
 
-func (s *capStatusStore) UpdateRunStatusIf(_ context.Context, _ string, status store.RunStatus, runErr string, from []store.RunStatus) (bool, error) {
+func (s *capStatusStore) UpdateRunStatusIfCoded(_ context.Context, _ string, status store.RunStatus, runErr string, code store.FailureCode, from []store.RunStatus) (bool, error) {
 	s.calls++
 	s.gotStatus = status
 	s.gotErr = runErr
+	s.gotCode = code
 	s.gotFrom = from
 	return true, nil
 }
@@ -106,6 +108,9 @@ func TestUsageCapPreflight_BlocksBeforeSpendingAnything(t *testing.T) {
 	}
 	if rs.calls != 1 || rs.gotStatus != store.RunStatusFailedResumable {
 		t.Fatalf("status flip: calls=%d status=%q — without failed_resumable the retry cannot arm", rs.calls, rs.gotStatus)
+	}
+	if rs.gotCode != store.FailureUsageLimitBlocked {
+		t.Errorf("failure code = %q, want USAGE_LIMIT_BLOCKED persisted with the flip", rs.gotCode)
 	}
 	if rs.gotErr == "" {
 		t.Error("the run must say why it did not start")

--- a/pkg/runtime/branch.go
+++ b/pkg/runtime/branch.go
@@ -79,7 +79,7 @@ func (e *Engine) execBranch(ctx context.Context, rs *runState, branchID string, 
 
 		node, ok := e.workflow.Nodes[currentNodeID]
 		if !ok {
-			result.err = fmt.Errorf("node %q not found in branch %s", currentNodeID, branchID)
+			result.err = &RuntimeError{Code: ErrCodeNodeNotFound, NodeID: currentNodeID, Message: fmt.Sprintf("node %q not found in branch %s", currentNodeID, branchID)}
 			return result
 		}
 

--- a/pkg/runtime/budget_resume_preflight.go
+++ b/pkg/runtime/budget_resume_preflight.go
@@ -88,7 +88,7 @@ func (e *Engine) finalizeSpentBudgetBeforeResume(ctx context.Context, r *store.R
 	// The run was claimed to running immediately before this guard. Restore
 	// its existing rich checkpoint while moving it back to failed_resumable,
 	// exactly like failRunErrWithCheckpoint does after an in-loop budget death.
-	if err := e.store.FailRunResumable(ctx, r.ID, r.Checkpoint, rtErr.Message); err != nil {
+	if err := e.store.FailRunResumable(ctx, r.ID, r.Checkpoint, rtErr.Message, rtErr.Code); err != nil {
 		if e.logger != nil {
 			e.logger.Error("failed to persist pre-resume budget failure: %v", err)
 		}

--- a/pkg/runtime/convergence.go
+++ b/pkg/runtime/convergence.go
@@ -45,8 +45,9 @@ func (e *Engine) processConvergence(rs *runState, convergenceNodeID string, resu
 			// When every failed branch carries the SAME typed code, the
 			// aggregate keeps it — a fan-out hitting one deterministic
 			// wall (a ghost node after a source edit) must not launder
-			// NODE_NOT_FOUND into the EXECUTION_FAILED catch-all, which
-			// the auto-resume gate would happily retry.
+			// NODE_NOT_FOUND into the EXECUTION_FAILED catch-all — the
+			// in-process auto-resume gate retries the latter and
+			// refuses the former.
 			if code := commonBranchFailureCode(results); code != "" {
 				return "", &RuntimeError{Code: code, NodeID: convergenceNodeID, Message: msg}
 			}

--- a/pkg/runtime/convergence.go
+++ b/pkg/runtime/convergence.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -15,7 +16,7 @@ import (
 func (e *Engine) processConvergence(rs *runState, convergenceNodeID string, results []*branchResult) (string, error) {
 	convNode, ok := e.workflow.Nodes[convergenceNodeID]
 	if !ok {
-		return "", fmt.Errorf("convergence node %q not found", convergenceNodeID)
+		return "", &RuntimeError{Code: ErrCodeNodeNotFound, NodeID: convergenceNodeID, Message: fmt.Sprintf("convergence node %q not found", convergenceNodeID)}
 	}
 
 	// Determine await strategy: use node's explicit setting, default to wait_all.
@@ -39,8 +40,17 @@ func (e *Engine) processConvergence(rs *runState, convergenceNodeID string, resu
 	switch strategy {
 	case ir.AwaitWaitAll:
 		if len(failedBranches) > 0 {
-			return "", fmt.Errorf("convergence at %s (wait_all): %d branch(es) failed: %v",
+			msg := fmt.Sprintf("convergence at %s (wait_all): %d branch(es) failed: %v",
 				convergenceNodeID, len(failedBranches), failedBranches[0]["error"])
+			// When every failed branch carries the SAME typed code, the
+			// aggregate keeps it — a fan-out hitting one deterministic
+			// wall (a ghost node after a source edit) must not launder
+			// NODE_NOT_FOUND into the EXECUTION_FAILED catch-all, which
+			// the auto-resume gate would happily retry.
+			if code := commonBranchFailureCode(results); code != "" {
+				return "", &RuntimeError{Code: code, NodeID: convergenceNodeID, Message: msg}
+			}
+			return "", fmt.Errorf("%s", msg)
 		}
 	case ir.AwaitBestEffort:
 		// Proceed even with failures — failed branch metadata is exposed.
@@ -256,4 +266,26 @@ func deepCopyValue(v any) any {
 	default:
 		return v
 	}
+}
+
+// commonBranchFailureCode returns the typed failure code shared by
+// EVERY failed branch result, or "" when they disagree (or none is
+// typed) — partial agreement stays the catch-all, never a guess.
+func commonBranchFailureCode(results []*branchResult) ErrorCode {
+	var code ErrorCode
+	for _, r := range results {
+		if r == nil || r.err == nil {
+			continue
+		}
+		var rtErr *RuntimeError
+		if !errors.As(r.err, &rtErr) || rtErr.Code == "" {
+			return ""
+		}
+		if code == "" {
+			code = rtErr.Code
+		} else if code != rtErr.Code {
+			return ""
+		}
+	}
+	return code
 }

--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -463,13 +463,13 @@ type resumeBackendState struct {
 // resume then restarts from the entry, which it is built to do.
 func (e *Engine) markFailedBestEffort(ctx context.Context, runID, phase string, cause error) {
 	writeCtx := context.WithoutCancel(ctx)
-	status, msg := setupFailureStatus(ctx, phase, cause)
+	status, msg, code := setupFailureStatus(ctx, phase, cause)
 	var err error
 	for attempt, delay := 0, 500*time.Millisecond; attempt < 3; attempt, delay = attempt+1, delay*4 {
 		if attempt > 0 {
 			time.Sleep(delay)
 		}
-		if err = e.store.UpdateRunStatus(writeCtx, runID, status, msg); err == nil {
+		if err = e.store.UpdateRunStatusCoded(writeCtx, runID, status, msg, code); err == nil {
 			return
 		}
 	}
@@ -491,17 +491,27 @@ func (e *Engine) markFailedBestEffort(ctx context.Context, runID, phase string, 
 // It reads the CTX, not just the error: a drain kills the work by
 // cancelling, so what surfaces is whatever the interrupted step returned
 // (a killed `kubectl exec`, a half-written worktree), never the cause.
-func setupFailureStatus(ctx context.Context, phase string, cause error) (store.RunStatus, string) {
+func setupFailureStatus(ctx context.Context, phase string, cause error) (store.RunStatus, string, store.FailureCode) {
 	if ctx == nil || ctx.Err() == nil {
-		return store.RunStatusFailed, fmt.Sprintf("%s: %v", phase, cause)
+		return store.RunStatusFailed, fmt.Sprintf("%s: %v", phase, cause), setupFailureCode(cause)
 	}
 	if errors.Is(context.Cause(ctx), ErrRunInterrupted) {
-		return store.RunStatusFailedResumable, fmt.Sprintf("%s interrupted before the first node (resumable): %v", phase, cause)
+		return store.RunStatusFailedResumable, fmt.Sprintf("%s interrupted before the first node (resumable): %v", phase, cause), store.FailureInterrupted
 	}
 	if errors.Is(ctx.Err(), context.Canceled) {
-		return store.RunStatusCancelled, fmt.Sprintf("%s cancelled before the first node: %v", phase, cause)
+		return store.RunStatusCancelled, fmt.Sprintf("%s cancelled before the first node: %v", phase, cause), store.FailureCancelled
 	}
-	return store.RunStatusFailed, fmt.Sprintf("%s: %v", phase, cause)
+	return store.RunStatusFailed, fmt.Sprintf("%s: %v", phase, cause), setupFailureCode(cause)
+}
+
+// setupFailureCode recovers a typed classification from a setup error
+// when one is present; a plain error stays unknown (empty).
+func setupFailureCode(cause error) store.FailureCode {
+	var rtErr *RuntimeError
+	if errors.As(cause, &rtErr) {
+		return rtErr.Code
+	}
+	return ""
 }
 
 // setupErr decorates the error a setup phase returns so an interruption

--- a/pkg/runtime/engine_exec.go
+++ b/pkg/runtime/engine_exec.go
@@ -63,9 +63,9 @@ func (e *Engine) execLoop(ctx context.Context, rs *runState, startNodeID string)
 		node, ok := e.workflow.Nodes[currentNodeID]
 		if !ok {
 			// Typed, not the EXECUTION_FAILED catch-all: this is the
-			// resume-after-source-edit wall, and the auto-resume gate
-			// refuses to re-hit a deterministic wall only when the code
-			// says which wall it is.
+			// resume-after-source-edit wall. The in-process auto-resume
+			// gate refuses it through the typed error; persisted-code
+			// readers are follow-up.
 			return e.failRunErrWithCheckpoint(rs, currentNodeID, &RuntimeError{
 				Code:    ErrCodeNodeNotFound,
 				Message: fmt.Sprintf("node %q not found", currentNodeID),

--- a/pkg/runtime/engine_exec.go
+++ b/pkg/runtime/engine_exec.go
@@ -62,8 +62,15 @@ func (e *Engine) execLoop(ctx context.Context, rs *runState, startNodeID string)
 
 		node, ok := e.workflow.Nodes[currentNodeID]
 		if !ok {
-			return e.failRunWithCheckpoint(rs, currentNodeID,
-				fmt.Sprintf("node %q not found", currentNodeID))
+			// Typed, not the EXECUTION_FAILED catch-all: this is the
+			// resume-after-source-edit wall, and the auto-resume gate
+			// refuses to re-hit a deterministic wall only when the code
+			// says which wall it is.
+			return e.failRunErrWithCheckpoint(rs, currentNodeID, &RuntimeError{
+				Code:    ErrCodeNodeNotFound,
+				Message: fmt.Sprintf("node %q not found", currentNodeID),
+				NodeID:  currentNodeID,
+			})
 		}
 
 		// A specially-dispatched node (fan-out, round-robin, LLM router,

--- a/pkg/runtime/engine_test.go
+++ b/pkg/runtime/engine_test.go
@@ -1019,9 +1019,11 @@ func TestHumanPauseAndResume(t *testing.T) {
 	if r.Status != store.RunStatusFinished {
 		t.Errorf("expected status finished, got %s", r.Status)
 	}
-	// Checkpoint should be cleared after resume.
-	if r.Checkpoint != nil {
-		t.Error("checkpoint should be nil after run finishes")
+	// The checkpoint SURVIVES the finish (a status transition never
+	// destroys it — `iterion fork` reads a terminal parent's
+	// checkpoint); resumability is gated on Status alone.
+	if r.Checkpoint == nil {
+		t.Error("finished run lost its checkpoint — fork of a finished run would start empty")
 	}
 
 	// Verify human answers were passed to the integrate node.

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -22,48 +22,24 @@ import (
 type ErrorCode = store.FailureCode
 
 const (
-	ErrCodeNodeNotFound     = store.FailureNodeNotFound
-	ErrCodeNoOutgoingEdge   = store.FailureNoOutgoingEdge
-	ErrCodeLoopExhausted    = store.FailureLoopExhausted
-	ErrCodeBudgetExceeded   = store.FailureBudgetExceeded
-	ErrCodeExecutionFailed  = store.FailureExecutionFailed
-	ErrCodeWorkspaceSafety  = store.FailureWorkspaceSafety
-	ErrCodeTimeout          = store.FailureTimeout
-	ErrCodeCancelled        = store.FailureCancelled
-	ErrCodeJoinFailed       = store.FailureJoinFailed
-	ErrCodeResumeInvalid    = store.FailureResumeInvalid
-	ErrCodeSchemaValidation = store.FailureSchemaValidation
-	ErrCodeRateLimited      = store.FailureRateLimited
-	// ErrCodeUsageLimitBlocked: the provider's subscription/quota WINDOW
-	// is exhausted (Anthropic forfait 5h / session / weekly cap) —
-	// distinct from ErrCodeRateLimited because retrying inside the
-	// window can never succeed: the only cure is waiting for the reset.
-	// In-node recovery fails terminal immediately; the run lands
-	// failed_resumable and the run-level auto-resume loop waits with a
-	// reset-aware delay (see pkg/cli/auto_resume.go).
+	ErrCodeNodeNotFound          = store.FailureNodeNotFound
+	ErrCodeNoOutgoingEdge        = store.FailureNoOutgoingEdge
+	ErrCodeLoopExhausted         = store.FailureLoopExhausted
+	ErrCodeBudgetExceeded        = store.FailureBudgetExceeded
+	ErrCodeExecutionFailed       = store.FailureExecutionFailed
+	ErrCodeWorkspaceSafety       = store.FailureWorkspaceSafety
+	ErrCodeTimeout               = store.FailureTimeout
+	ErrCodeCancelled             = store.FailureCancelled
+	ErrCodeJoinFailed            = store.FailureJoinFailed
+	ErrCodeResumeInvalid         = store.FailureResumeInvalid
+	ErrCodeSchemaValidation      = store.FailureSchemaValidation
+	ErrCodeRateLimited           = store.FailureRateLimited
 	ErrCodeUsageLimitBlocked     = store.FailureUsageLimitBlocked
 	ErrCodeContextLengthExceeded = store.FailureContextLengthExceeded
 	ErrCodeToolFailedTransient   = store.FailureToolFailedTransient
 	ErrCodeToolFailedPermanent   = store.FailureToolFailedPermanent
-	// ErrCodeNetworkTransient: occasional ISP / DNS / TCP / TLS hiccup
-	// reaching the upstream model API. Distinct from ErrCodeExecutionFailed
-	// so the recovery dispatcher can apply a longer exponential-backoff
-	// budget — a 2-second single retry is plenty for "stale token" or
-	// "race on the tool subprocess", but useless against a 30-second
-	// captive-portal handoff or a multi-minute datacenter routing blip.
-	// Surfaced via Classify when the error string matches a known
-	// network-failure phrase (FailedToOpenSocket, "Unable to connect to
-	// API", "no such host", "connection refused", "i/o timeout", etc.).
-	ErrCodeNetworkTransient = store.FailureNetworkTransient
-	// ErrCodeAuthFailed: the upstream model provider rejected the
-	// request for credential reasons (HTTP 401/403, "authentication
-	// token is expired", "invalid api key", …). NOT transient — retrying
-	// the same call can never succeed until a human re-authenticates
-	// (e.g. `codex login` for the ChatGPT-forfait OAuth token, or
-	// rotating an API key). The recovery dispatcher pauses for human
-	// instead of burning the retry budget; the run is resumable once the
-	// credential is refreshed.
-	ErrCodeAuthFailed = store.FailureAuthFailed
+	ErrCodeNetworkTransient      = store.FailureNetworkTransient
+	ErrCodeAuthFailed            = store.FailureAuthFailed
 )
 
 // RuntimeError is a structured error carrying a machine-readable code,

--- a/pkg/runtime/errors.go
+++ b/pkg/runtime/errors.go
@@ -6,24 +6,34 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/backend/model"
+	"github.com/SocialGouv/iterion/pkg/store"
 )
 
 // ErrorCode categorizes runtime errors for programmatic handling.
-type ErrorCode string
+//
+// It IS the persisted store.FailureCode vocabulary (a type alias, so
+// values are interchangeable across the package boundary) — the same
+// code the engine classifies with in-process is what lands on
+// Run.FailureCode at the store, instead of dying into free text
+// (ADR-095). The constants below re-export the store's values under
+// the historical runtime names; codes the engine does not emit itself
+// (INTERRUPTED, FAIL_NODE, PROCESS_ORPHANED, QUEUE_SCHEMA_MISMATCH)
+// live only under their store.Failure* names.
+type ErrorCode = store.FailureCode
 
 const (
-	ErrCodeNodeNotFound     ErrorCode = "NODE_NOT_FOUND"
-	ErrCodeNoOutgoingEdge   ErrorCode = "NO_OUTGOING_EDGE"
-	ErrCodeLoopExhausted    ErrorCode = "LOOP_EXHAUSTED"
-	ErrCodeBudgetExceeded   ErrorCode = "BUDGET_EXCEEDED"
-	ErrCodeExecutionFailed  ErrorCode = "EXECUTION_FAILED"
-	ErrCodeWorkspaceSafety  ErrorCode = "WORKSPACE_SAFETY"
-	ErrCodeTimeout          ErrorCode = "TIMEOUT"
-	ErrCodeCancelled        ErrorCode = "CANCELLED"
-	ErrCodeJoinFailed       ErrorCode = "JOIN_FAILED"
-	ErrCodeResumeInvalid    ErrorCode = "RESUME_INVALID"
-	ErrCodeSchemaValidation ErrorCode = "SCHEMA_VALIDATION"
-	ErrCodeRateLimited      ErrorCode = "RATE_LIMITED"
+	ErrCodeNodeNotFound     = store.FailureNodeNotFound
+	ErrCodeNoOutgoingEdge   = store.FailureNoOutgoingEdge
+	ErrCodeLoopExhausted    = store.FailureLoopExhausted
+	ErrCodeBudgetExceeded   = store.FailureBudgetExceeded
+	ErrCodeExecutionFailed  = store.FailureExecutionFailed
+	ErrCodeWorkspaceSafety  = store.FailureWorkspaceSafety
+	ErrCodeTimeout          = store.FailureTimeout
+	ErrCodeCancelled        = store.FailureCancelled
+	ErrCodeJoinFailed       = store.FailureJoinFailed
+	ErrCodeResumeInvalid    = store.FailureResumeInvalid
+	ErrCodeSchemaValidation = store.FailureSchemaValidation
+	ErrCodeRateLimited      = store.FailureRateLimited
 	// ErrCodeUsageLimitBlocked: the provider's subscription/quota WINDOW
 	// is exhausted (Anthropic forfait 5h / session / weekly cap) —
 	// distinct from ErrCodeRateLimited because retrying inside the
@@ -31,10 +41,10 @@ const (
 	// In-node recovery fails terminal immediately; the run lands
 	// failed_resumable and the run-level auto-resume loop waits with a
 	// reset-aware delay (see pkg/cli/auto_resume.go).
-	ErrCodeUsageLimitBlocked     ErrorCode = "USAGE_LIMIT_BLOCKED"
-	ErrCodeContextLengthExceeded ErrorCode = "CONTEXT_LENGTH_EXCEEDED"
-	ErrCodeToolFailedTransient   ErrorCode = "TOOL_FAILED_TRANSIENT"
-	ErrCodeToolFailedPermanent   ErrorCode = "TOOL_FAILED_PERMANENT"
+	ErrCodeUsageLimitBlocked     = store.FailureUsageLimitBlocked
+	ErrCodeContextLengthExceeded = store.FailureContextLengthExceeded
+	ErrCodeToolFailedTransient   = store.FailureToolFailedTransient
+	ErrCodeToolFailedPermanent   = store.FailureToolFailedPermanent
 	// ErrCodeNetworkTransient: occasional ISP / DNS / TCP / TLS hiccup
 	// reaching the upstream model API. Distinct from ErrCodeExecutionFailed
 	// so the recovery dispatcher can apply a longer exponential-backoff
@@ -44,7 +54,7 @@ const (
 	// Surfaced via Classify when the error string matches a known
 	// network-failure phrase (FailedToOpenSocket, "Unable to connect to
 	// API", "no such host", "connection refused", "i/o timeout", etc.).
-	ErrCodeNetworkTransient ErrorCode = "NETWORK_TRANSIENT"
+	ErrCodeNetworkTransient = store.FailureNetworkTransient
 	// ErrCodeAuthFailed: the upstream model provider rejected the
 	// request for credential reasons (HTTP 401/403, "authentication
 	// token is expired", "invalid api key", …). NOT transient — retrying
@@ -53,7 +63,7 @@ const (
 	// rotating an API key). The recovery dispatcher pauses for human
 	// instead of burning the retry budget; the run is resumable once the
 	// credential is refreshed.
-	ErrCodeAuthFailed ErrorCode = "AUTH_FAILED"
+	ErrCodeAuthFailed = store.FailureAuthFailed
 )
 
 // RuntimeError is a structured error carrying a machine-readable code,

--- a/pkg/runtime/fan_out_each.go
+++ b/pkg/runtime/fan_out_each.go
@@ -46,7 +46,7 @@ import (
 func (e *Engine) execFanOutEach(ctx context.Context, rs *runState, routerNodeID string) (string, error) {
 	node, ok := e.workflow.Nodes[routerNodeID]
 	if !ok {
-		return "", fmt.Errorf("fan_out_each router %q not found", routerNodeID)
+		return "", &RuntimeError{Code: ErrCodeNodeNotFound, NodeID: routerNodeID, Message: fmt.Sprintf("fan_out_each router %q not found", routerNodeID)}
 	}
 	rn, ok := node.(*ir.RouterNode)
 	if !ok || rn.RouterMode != ir.RouterFanOutEach {

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -253,25 +253,9 @@ func (e *Engine) resumeFromPause(ctx context.Context, r *store.Run, answers map[
 	// publisher flips the run to queued before the runner claims the
 	// resume message (Resume's queued case routed here on the pending
 	// interaction evidence). The CAS still serializes concurrent claims.
-	if err := e.claimForResume(ctx, runID, store.RunStatusPausedWaitingHuman, store.RunStatusQueued); err != nil {
+	// The claim also CONSUMES the pause pointer — see claimForResume.
+	if err := e.claimForResume(ctx, r, cp, store.RunStatusPausedWaitingHuman, store.RunStatusQueued); err != nil {
 		return err
-	}
-
-	// The pause pointer is CONSUMED by this resume. The checkpoint now
-	// survives the running claim (ADR-095: a status transition never
-	// destroys it), so leaving the interaction evidence in place would
-	// hand a STALE InteractionID to Resume's `queued` router after a
-	// later park (drain, orphan sweep): that re-entry would route back
-	// here and overwrite the operator's recorded answers with the
-	// retry's empty ones — silently crossing the human gate. With the
-	// pointer cleared, a park inside this window resumes through
-	// resumeFromFailure anchored on cp.NodeID: the gate re-pauses and
-	// re-asks, answers intact.
-	consumed := *cp // cp stays in use in-memory (the delegate-pause branch)
-	consumed.InteractionID = ""
-	consumed.InteractionQuestions = nil
-	if err := e.store.SaveCheckpoint(ctx, runID, &consumed); err != nil && e.logger != nil {
-		e.logger.Warn("resume %s: could not clear the consumed pause pointer: %v", runID, err)
 	}
 
 	// Build runState before edge selection so failures are resumable.
@@ -441,21 +425,59 @@ func (e *Engine) materializeHumanArtifact(ctx context.Context, runID, humanNodeI
 }
 
 // claimForResume atomically claims a run for resume via a compare-and-set
-// on the run status, then emits run_resumed (no data). Returns a clear
-// error when the CAS rejects the transition — typically a second concurrent
-// resume racing the first, which we refuse rather than spawn a duplicate
-// execution clobbering run.json. Used by the human-pause path; the
-// failed-resumable path claims via claimForFailureResume because it
-// carries resume-data on the emit.
-func (e *Engine) claimForResume(ctx context.Context, runID string, allowed ...store.RunStatus) error {
-	claimed, claimErr := e.store.UpdateRunStatusIf(ctx, runID, store.RunStatusRunning, "", allowed)
+// on the run status, consumes the pause pointer, then emits run_resumed
+// (no data). Returns a clear error when the CAS rejects the transition —
+// typically a second concurrent resume racing the first, which we refuse
+// rather than spawn a duplicate execution clobbering run.json. The single
+// choke point for BOTH human-pause resume paths (single-shot answers and
+// the review gate) — a claim without the consumption reopens the
+// stale-pointer window on that path alone. The failed-resumable path
+// claims via claimForFailureResume because it carries resume-data on the
+// emit (its checkpoint holds no pause pointer: failure boundaries never
+// set one, and a pause's pointer was consumed by the resume that used it).
+func (e *Engine) claimForResume(ctx context.Context, r *store.Run, cp *store.Checkpoint, allowed ...store.RunStatus) error {
+	claimed, claimErr := e.store.UpdateRunStatusIf(ctx, r.ID, store.RunStatusRunning, "", allowed)
 	if claimErr != nil {
 		return fmt.Errorf("runtime: claim run for resume: %w", claimErr)
 	}
 	if !claimed {
-		return fmt.Errorf("runtime: run %q is already being executed (status no longer paused); refusing duplicate resume", runID)
+		return fmt.Errorf("runtime: run %q is already being executed (status no longer paused); refusing duplicate resume", r.ID)
 	}
-	return e.emit(ctx, runID, store.EventRunResumed, "", nil)
+	e.consumePausePointer(ctx, r, cp)
+	return e.emit(ctx, r.ID, store.EventRunResumed, "", nil)
+}
+
+// consumePausePointer clears the interaction evidence off the persisted
+// checkpoint right after a resume claim. The checkpoint survives the
+// running claim (ADR-095: a status transition never destroys it), so
+// leaving the evidence in place would hand a STALE InteractionID to
+// Resume's `queued` router after a later park (drain, orphan sweep): that
+// re-entry would route back into the pause path and overwrite the
+// operator's recorded answers with the retry's empty ones — silently
+// crossing the human gate. With the pointer cleared, a park inside this
+// window resumes through resumeFromFailure anchored on cp.NodeID: the
+// gate re-pauses and re-asks, answers intact.
+func (e *Engine) consumePausePointer(ctx context.Context, r *store.Run, cp *store.Checkpoint) {
+	if cp == nil || (cp.InteractionID == "" && len(cp.InteractionQuestions) == 0) {
+		return
+	}
+	// The caller's cp stays whole: the delegate-pause and review-gate
+	// paths still read its InteractionID in memory.
+	consumed := *cp
+	consumed.InteractionID = ""
+	consumed.InteractionQuestions = nil
+	err := e.store.SaveCheckpoint(ctx, r.ID, &consumed)
+	if err != nil {
+		// One retry: a failed consumption reopens the human-gate window,
+		// while aborting here would wedge a run already claimed running.
+		err = e.store.SaveCheckpoint(ctx, r.ID, &consumed)
+	}
+	if err != nil && e.logger != nil {
+		e.logger.Error("resume %s: could not clear the consumed pause pointer — a later park may replay interaction %q over the operator's answers: %v", r.ID, cp.InteractionID, err)
+	}
+	// Align the in-memory run with what is persisted, so a future
+	// SaveRun(r) on this path cannot resurrect the pointer.
+	r.Checkpoint = &consumed
 }
 
 // seedRepoRootForResume fills e.repoRoot from the run record when it has
@@ -1997,10 +2019,12 @@ func (e *Engine) restampWorkflowSource(ctx context.Context, r *store.Run) {
 	// which therefore still carries the pre-claim status. SaveRun writes
 	// the whole document, so saving `r` verbatim would silently undo the
 	// claim: the run persists as cancelled/paused_* for its entire
-	// execution, the Checkpoint and FinishedAt that the `running`
-	// transition deliberately cleared come back, and — worst — the
+	// execution, the FinishedAt that the `running` transition
+	// deliberately cleared comes back, and — worst — the
 	// duplicate-resume guard falls, letting a second concurrent resume
-	// claim the same run id and spawn a second engine on it.
+	// claim the same run id and spawn a second engine on it. (The
+	// Checkpoint is NOT part of that argument: a status transition never
+	// destroys it — ADR-095 §5.)
 	fresh, lerr := e.store.LoadRun(ctx, r.ID)
 	if lerr != nil {
 		if e.logger != nil {

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -257,6 +257,23 @@ func (e *Engine) resumeFromPause(ctx context.Context, r *store.Run, answers map[
 		return err
 	}
 
+	// The pause pointer is CONSUMED by this resume. The checkpoint now
+	// survives the running claim (ADR-095: a status transition never
+	// destroys it), so leaving the interaction evidence in place would
+	// hand a STALE InteractionID to Resume's `queued` router after a
+	// later park (drain, orphan sweep): that re-entry would route back
+	// here and overwrite the operator's recorded answers with the
+	// retry's empty ones — silently crossing the human gate. With the
+	// pointer cleared, a park inside this window resumes through
+	// resumeFromFailure anchored on cp.NodeID: the gate re-pauses and
+	// re-asks, answers intact.
+	consumed := *cp // cp stays in use in-memory (the delegate-pause branch)
+	consumed.InteractionID = ""
+	consumed.InteractionQuestions = nil
+	if err := e.store.SaveCheckpoint(ctx, runID, &consumed); err != nil && e.logger != nil {
+		e.logger.Warn("resume %s: could not clear the consumed pause pointer: %v", runID, err)
+	}
+
 	// Build runState before edge selection so failures are resumable.
 	// Init maps when the checkpoint deserialised with omitted fields
 	// (Mongo bson omitempty, legacy stores) — a nil map here would

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -290,7 +290,7 @@ func (e *Engine) resumeFromPause(ctx context.Context, r *store.Run, answers map[
 	if cp.BackendName != "" {
 		node, ok := e.workflow.Nodes[humanNodeID]
 		if !ok {
-			return fmt.Errorf("runtime: paused node %q not found in workflow", humanNodeID)
+			return &RuntimeError{Code: ErrCodeNodeNotFound, NodeID: humanNodeID, Message: fmt.Sprintf("runtime: paused node %q not found in workflow", humanNodeID)}
 		}
 		ni := &model.ErrNeedsInteraction{
 			NodeID:           humanNodeID,
@@ -387,7 +387,7 @@ func (e *Engine) recordHumanAnswers(ctx context.Context, r *store.Run, cp *store
 func (e *Engine) materializeHumanArtifact(ctx context.Context, runID, humanNodeID string, answers map[string]any, artifactVersions map[string]int) (map[string]int, error) {
 	humanNode, ok := e.workflow.Nodes[humanNodeID]
 	if !ok {
-		return nil, fmt.Errorf("runtime: human node %q not found in workflow", humanNodeID)
+		return nil, &RuntimeError{Code: ErrCodeNodeNotFound, NodeID: humanNodeID, Message: fmt.Sprintf("runtime: human node %q not found in workflow", humanNodeID)}
 	}
 	if artifactVersions == nil {
 		artifactVersions = make(map[string]int)

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -550,7 +550,7 @@ func (e *Engine) resumeRebuildState(ctx context.Context, r *store.Run, cp *store
 		if preservedCp == nil {
 			preservedCp = &store.Checkpoint{NodeID: humanNodeID}
 		}
-		if err := e.store.FailRunResumable(ctx, runID, preservedCp, sbErr.Error()); err != nil {
+		if err := e.store.FailRunResumable(ctx, runID, preservedCp, sbErr.Error(), ""); err != nil {
 			// FailRunResumable failed too — fall back to a hard
 			// "failed" status flip so the run doesn't appear stuck.
 			// If even that fails, log loudly: the store is in a bad
@@ -673,7 +673,7 @@ func (e *Engine) resumeFromFailure(ctx context.Context, r *store.Run) error {
 		if preservedCp == nil {
 			preservedCp = &store.Checkpoint{NodeID: e.workflow.Entry}
 		}
-		if frErr := e.store.FailRunResumable(ctx, runID, preservedCp, sbErr.Error()); frErr != nil {
+		if frErr := e.store.FailRunResumable(ctx, runID, preservedCp, sbErr.Error(), ""); frErr != nil {
 			// FailRunResumable failed — fall back to a plain terminal status so
 			// the run doesn't linger as `running`. If THAT also fails the run is
 			// stuck non-terminal (an orphan the operator must hand-hack), so

--- a/pkg/runtime/resume_failure_char_test.go
+++ b/pkg/runtime/resume_failure_char_test.go
@@ -89,7 +89,7 @@ func TestResumeFromFailure_ResumableStatusTable(t *testing.T) {
 				Outputs: map[string]map[string]any{"step_a": {"result": "ok"}},
 			}
 			if tc.viaFailResumable {
-				if err := s.FailRunResumable(ctx, runID, cp, "boom"); err != nil {
+				if err := s.FailRunResumable(ctx, runID, cp, "boom", ""); err != nil {
 					t.Fatalf("FailRunResumable: %v", err)
 				}
 			} else {
@@ -158,7 +158,7 @@ func TestResumeFromFailure_NoCheckpointRestartsFromEntry(t *testing.T) {
 	if _, err := s.CreateRun(ctx, runID, "resume_char", nil); err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
-	if err := s.FailRunResumable(ctx, runID, nil, "pre-first-node boom"); err != nil {
+	if err := s.FailRunResumable(ctx, runID, nil, "pre-first-node boom", ""); err != nil {
 		t.Fatalf("FailRunResumable: %v", err)
 	}
 
@@ -292,7 +292,7 @@ func TestResumeFromFailure_RestoresLoopCounters(t *testing.T) {
 		Outputs:      map[string]map[string]any{"fix": {"attempt": 1}},
 		LoopCounters: map[string]int{"retry": 1},
 	}
-	if err := s.FailRunResumable(ctx, runID, cp, "boom"); err != nil {
+	if err := s.FailRunResumable(ctx, runID, cp, "boom", ""); err != nil {
 		t.Fatalf("FailRunResumable: %v", err)
 	}
 
@@ -344,7 +344,7 @@ func TestResumeFromFailure_CheckpointMapsNotMutated(t *testing.T) {
 		LoopCounters:     map[string]int{},
 		ArtifactVersions: map[string]int{},
 	}
-	if err := s.FailRunResumable(ctx, runID, cp, "boom"); err != nil {
+	if err := s.FailRunResumable(ctx, runID, cp, "boom", ""); err != nil {
 		t.Fatalf("FailRunResumable: %v", err)
 	}
 
@@ -421,7 +421,7 @@ func TestResumeFromFailure_BackendRehydrationInjectedOnce(t *testing.T) {
 		BackendConversation: conversation,
 		BackendSessionID:    "sess-42",
 	}
-	if err := s.FailRunResumable(ctx, runID, cp, "boom"); err != nil {
+	if err := s.FailRunResumable(ctx, runID, cp, "boom", ""); err != nil {
 		t.Fatalf("FailRunResumable: %v", err)
 	}
 
@@ -528,7 +528,7 @@ func TestResumeFromFailure_ExecutorEnvRestored(t *testing.T) {
 	if _, err := s.CreateRun(ctx, runID, "resume_char_env", nil); err != nil {
 		t.Fatalf("CreateRun: %v", err)
 	}
-	if err := s.FailRunResumable(ctx, runID, &store.Checkpoint{NodeID: "step_a"}, "boom"); err != nil {
+	if err := s.FailRunResumable(ctx, runID, &store.Checkpoint{NodeID: "step_a"}, "boom", ""); err != nil {
 		t.Fatalf("FailRunResumable: %v", err)
 	}
 
@@ -577,7 +577,7 @@ func TestResumeFromFailure_BudgetSpendRestored(t *testing.T) {
 		Outputs:       map[string]map[string]any{"step_a": {"result": "ok"}},
 		BudgetCostUSD: 5.0, // already over the 1.0 cap
 	}
-	if err := s.FailRunResumable(ctx, runID, cp, "boom"); err != nil {
+	if err := s.FailRunResumable(ctx, runID, cp, "boom", ""); err != nil {
 		t.Fatalf("FailRunResumable: %v", err)
 	}
 
@@ -626,7 +626,7 @@ func TestResumeFromFailure_BudgetExitGraceFinishesAt105Percent(t *testing.T) {
 		Outputs:       map[string]map[string]any{"step_a": {"result": "ok"}},
 		BudgetCostUSD: 1.05,
 	}
-	if err := s.FailRunResumable(ctx, runID, cp, "queue backend interrupted the prior attempt"); err != nil {
+	if err := s.FailRunResumable(ctx, runID, cp, "queue backend interrupted the prior attempt", ""); err != nil {
 		t.Fatalf("FailRunResumable: %v", err)
 	}
 
@@ -735,7 +735,7 @@ func TestResumeFromFailure_ExhaustedDurationFinalizesBeforeSandbox(t *testing.T)
 		Outputs:         map[string]map[string]any{"step_a": {"result": "ok"}},
 		BudgetElapsedNS: (11 * time.Minute).Nanoseconds(),
 	}
-	if err := s.FailRunResumable(ctx, runID, cp, "queue backend interrupted the prior attempt"); err != nil {
+	if err := s.FailRunResumable(ctx, runID, cp, "queue backend interrupted the prior attempt", ""); err != nil {
 		t.Fatalf("FailRunResumable: %v", err)
 	}
 

--- a/pkg/runtime/resume_internal_test.go
+++ b/pkg/runtime/resume_internal_test.go
@@ -430,12 +430,18 @@ func TestResumeFromPauseConsumesThePausePointer(t *testing.T) {
 	if rerr := e.resumeFromPause(ctx, run, map[string]any{"approve": "YES"}); rerr != nil {
 		t.Logf("resumeFromPause returned: %v", rerr)
 	}
+	if len(spy.ops) < 2 || spy.ops[0] != "claim:running" {
+		t.Fatalf("op sequence %v — the resume must CLAIM (CAS to running) before anything else, or a second concurrent resume spawns a duplicate engine", spy.ops)
+	}
 	if len(spy.writes) == 0 {
 		t.Fatal("no checkpoint write at all")
 	}
 	w := spy.writes[0]
 	if w.NodeID != "gate" || w.InteractionID != "" || len(w.InteractionQuestions) != 0 {
 		t.Fatalf("first checkpoint write after the claim is %+v; want the gate checkpoint with the pause pointer cleared — a park before the consumption would replay interaction I1 and overwrite the operator's answers", w)
+	}
+	if spy.ops[1] != "checkpoint:gate:interaction=" {
+		t.Fatalf("op sequence %v — the consumption must be the claim's immediate successor", spy.ops)
 	}
 }
 
@@ -471,6 +477,9 @@ func TestReviewGateConsumesThePausePointer(t *testing.T) {
 	}); rerr != nil {
 		t.Logf("resumeFromPause returned: %v", rerr)
 	}
+	if len(spy.ops) < 2 || spy.ops[0] != "claim:running" {
+		t.Fatalf("op sequence %v — the review-gate resume must CLAIM before anything else", spy.ops)
+	}
 	if len(spy.writes) == 0 {
 		t.Fatal("no checkpoint write at all")
 	}
@@ -480,15 +489,80 @@ func TestReviewGateConsumesThePausePointer(t *testing.T) {
 	}
 }
 
-// checkpointSpyStore records every SaveCheckpoint payload.
+// checkpointSpyStore records every SaveCheckpoint payload and every
+// running-claim CAS, in one ordered op log — the consumption canaries
+// assert the SEQUENCE (claim first, consumption second), guarding the
+// choke point on both its promises: no second engine on the run, and
+// no live pointer left behind it.
 type checkpointSpyStore struct {
 	store.RunStore
 	writes []store.Checkpoint
+	ops    []string
 }
 
 func (s *checkpointSpyStore) SaveCheckpoint(ctx context.Context, id string, cp *store.Checkpoint) error {
 	if cp != nil {
 		s.writes = append(s.writes, *cp)
+		s.ops = append(s.ops, "checkpoint:"+cp.NodeID+":interaction="+cp.InteractionID)
 	}
 	return s.RunStore.SaveCheckpoint(ctx, id, cp)
+}
+
+func (s *checkpointSpyStore) UpdateRunStatusIf(ctx context.Context, id string, status store.RunStatus, runErr string, expectedFrom []store.RunStatus) (bool, error) {
+	if status == store.RunStatusRunning {
+		s.ops = append(s.ops, "claim:running")
+	}
+	return s.RunStore.UpdateRunStatusIf(ctx, id, status, runErr, expectedFrom)
+}
+
+// The pause pointer that NO resume consumes: cancelling a run parked on
+// a human gate is a status-only flip, and since a transition preserves
+// the checkpoint (ADR-095 §5) the pointer used to survive onto the
+// cancelled run. On cloud, SubmitResume CASes cancelled → queued with no
+// answers (RequiresResumeAnswers is false for cancelled, so the UI shows
+// no form), and Resume's queued router — which arbitrates on pointer
+// presence alone — sent it into resumeFromPause: the gate was crossed
+// with an empty answer, silently. The store's transition normalization
+// (CarriesPausePointer) now consumes the pointer at the cancel, so the
+// queued router routes to resumeFromFailure and the gate re-asks.
+func TestCancelledPausePointerDoesNotCrossTheGateOnCloudResume(t *testing.T) {
+	base := tmpStore(t)
+	ctx := context.Background()
+	if _, err := base.CreateRun(ctx, "run-cloudgate", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	cp := &store.Checkpoint{NodeID: "gate", InteractionID: "I1",
+		InteractionQuestions: map[string]any{"approve": "yes?"}}
+	if err := base.PauseRun(ctx, "run-cloudgate", cp); err != nil {
+		t.Fatal(err)
+	}
+	// Operator cancel: exactly the status-only flip CancelInactive performs.
+	if err := base.UpdateRunStatus(ctx, "run-cloudgate", store.RunStatusCancelled, "cancelled by operator"); err != nil {
+		t.Fatal(err)
+	}
+	// Cloud resume: the publisher CASes cancelled → queued BEFORE a runner
+	// claims the message (SubmitResume), and the runner calls Resume with
+	// the message's answers — empty for a cancelled run.
+	if ok, err := base.UpdateRunStatusIf(ctx, "run-cloudgate", store.RunStatusQueued, "",
+		[]store.RunStatus{store.RunStatusCancelled}); err != nil || !ok {
+		t.Fatalf("queued CAS: ok=%v err=%v", ok, err)
+	}
+	e := &Engine{store: base, workflow: &ir.Workflow{Name: "wf", Entry: "gate", Nodes: map[string]ir.Node{
+		"gate": &ir.HumanNode{BaseNode: ir.BaseNode{ID: "gate"}},
+		"calc": &ir.ComputeNode{BaseNode: ir.BaseNode{ID: "calc"}},
+		"end":  &ir.DoneNode{BaseNode: ir.BaseNode{ID: "end"}},
+	}, Edges: []*ir.Edge{{From: "gate", To: "calc"}, {From: "calc", To: "end"}}}}
+	if rerr := e.Resume(ctx, "run-cloudgate", nil); rerr != nil {
+		t.Logf("Resume returned: %v", rerr)
+	}
+	after, err := base.LoadRun(ctx, "run-cloudgate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Status == store.RunStatusFinished {
+		t.Fatalf("the human gate was CROSSED with an empty answer: cancelled run resumed on cloud went straight to finished (outputs gate=%v)", after.Checkpoint.Outputs["gate"])
+	}
+	if after.Status != store.RunStatusPausedWaitingHuman {
+		t.Errorf("status = %q, want paused_waiting_human — the resumed gate must re-ask, not silently pass", after.Status)
+	}
 }

--- a/pkg/runtime/resume_internal_test.go
+++ b/pkg/runtime/resume_internal_test.go
@@ -390,3 +390,59 @@ func TestRestampWorkflowSource_PreservesTheResumeClaim(t *testing.T) {
 		t.Errorf("workflow_hash = %q, want %q", got.WorkflowHash, "hash-new")
 	}
 }
+
+// The pause pointer is consumed by the resume that uses it: right
+// after resumeFromPause's claim, a checkpoint write clearing the
+// interaction evidence must land — since the checkpoint survives the
+// running claim (ADR-095), leaving a stale InteractionID would route a
+// LATER park's resume back into the pause path and overwrite the
+// operator's answers with empty ones (silently crossing the human
+// gate). A spy store records the write sequence so the oracle holds
+// whatever the rest of the flow does afterwards.
+func TestResumeFromPauseConsumesThePausePointer(t *testing.T) {
+	base := tmpStore(t)
+	spy := &checkpointSpyStore{RunStore: base}
+	ctx := context.Background()
+	if _, err := base.CreateRun(ctx, "run-consume", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	cp := &store.Checkpoint{NodeID: "gate", InteractionID: "I1",
+		InteractionQuestions: map[string]any{"approve": "yes?"}}
+	if err := base.PauseRun(ctx, "run-consume", cp); err != nil {
+		t.Fatal(err)
+	}
+	e := &Engine{store: spy, workflow: &ir.Workflow{Name: "wf", Nodes: map[string]ir.Node{
+		"gate": &ir.HumanNode{BaseNode: ir.BaseNode{ID: "gate"}},
+	}}}
+	run, err := base.LoadRun(ctx, "run-consume")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = e.resumeFromPause(ctx, run, map[string]any{"approve": "YES"})
+	consumedSeen := false
+	for _, w := range spy.writes {
+		if w.InteractionID == "" && len(w.InteractionQuestions) == 0 {
+			consumedSeen = true
+			break
+		}
+		if w.InteractionID == "I1" {
+			continue // pre-claim bookkeeping may re-save the pointer
+		}
+	}
+	if !consumedSeen {
+		t.Fatalf("no checkpoint write ever cleared the pause pointer (writes: %d) — a park after the claim would replay interaction I1 and overwrite the operator's answers", len(spy.writes))
+	}
+}
+
+// checkpointSpyStore records every SaveCheckpoint payload.
+type checkpointSpyStore struct {
+	store.RunStore
+	writes []store.Checkpoint
+}
+
+func (s *checkpointSpyStore) SaveCheckpoint(ctx context.Context, id string, cp *store.Checkpoint) error {
+	if cp != nil {
+		s.writes = append(s.writes, *cp)
+	}
+	return s.RunStore.SaveCheckpoint(ctx, id, cp)
+}

--- a/pkg/runtime/resume_internal_test.go
+++ b/pkg/runtime/resume_internal_test.go
@@ -376,8 +376,8 @@ func TestRestampWorkflowSource_PreservesTheResumeClaim(t *testing.T) {
 			"letting a second concurrent resume claim the same run",
 			got.Status, store.RunStatusRunning)
 	}
-	if got.Checkpoint != nil {
-		t.Errorf("checkpoint resurrected (%+v) — the running transition clears it", got.Checkpoint)
+	if got.Checkpoint == nil || got.Checkpoint.NodeID != "implement" {
+		t.Errorf("checkpoint lost across the restamp (%+v) — the running claim PRESERVES the resume point, and the restamp must not drop it either", got.Checkpoint)
 	}
 	if got.FinishedAt != nil {
 		t.Errorf("finished_at resurrected (%v) — the studio duration ticker freezes on it", got.FinishedAt)

--- a/pkg/runtime/resume_internal_test.go
+++ b/pkg/runtime/resume_internal_test.go
@@ -336,10 +336,12 @@ func TestCurrentLoopIterationPath_FallbackToEdgeMembership(t *testing.T) {
 // to `running`, and the claim helpers mutate their OWN copy of the record
 // (UpdateRunStatusIf → loadRunRaw), never the caller's. Saving that stale
 // in-memory snapshot verbatim silently undid the claim: the run persisted
-// as cancelled/paused_* for its whole execution, the Checkpoint and
-// FinishedAt the `running` transition deliberately clears came back, and
-// the duplicate-resume guard fell — a second concurrent resume would find
-// a resumable status, win its CAS, and spawn a second engine on one run id.
+// as cancelled/paused_* for its whole execution, the FinishedAt the
+// `running` transition deliberately clears came back, and the
+// duplicate-resume guard fell — a second concurrent resume would find a
+// resumable status, win its CAS, and spawn a second engine on one run id.
+// (The Checkpoint survives every transition — ADR-095 §5 — so it is not
+// part of that argument; the test asserts the restamp preserves it too.)
 func TestRestampWorkflowSource_PreservesTheResumeClaim(t *testing.T) {
 	ctx := context.Background()
 	st := tmpStore(t)
@@ -397,8 +399,13 @@ func TestRestampWorkflowSource_PreservesTheResumeClaim(t *testing.T) {
 // running claim (ADR-095), leaving a stale InteractionID would route a
 // LATER park's resume back into the pause path and overwrite the
 // operator's answers with empty ones (silently crossing the human
-// gate). A spy store records the write sequence so the oracle holds
-// whatever the rest of the flow does afterwards.
+// gate). The oracle is POSITIONAL — the FIRST checkpoint write after
+// the claim must be the consumption itself: an "any write with an empty
+// pointer" oracle is satisfied by every ordinary boundary write
+// (buildCheckpoint never sets InteractionID), so it goes green the
+// moment the fixture grows a downstream node, fix present or not. The
+// fixture deliberately HAS one (gate → calc → end) to keep the oracle
+// honest against that failure mode.
 func TestResumeFromPauseConsumesThePausePointer(t *testing.T) {
 	base := tmpStore(t)
 	spy := &checkpointSpyStore{RunStore: base}
@@ -413,24 +420,63 @@ func TestResumeFromPauseConsumesThePausePointer(t *testing.T) {
 	}
 	e := &Engine{store: spy, workflow: &ir.Workflow{Name: "wf", Nodes: map[string]ir.Node{
 		"gate": &ir.HumanNode{BaseNode: ir.BaseNode{ID: "gate"}},
-	}}}
+		"calc": &ir.ComputeNode{BaseNode: ir.BaseNode{ID: "calc"}},
+		"end":  &ir.DoneNode{BaseNode: ir.BaseNode{ID: "end"}},
+	}, Edges: []*ir.Edge{{From: "gate", To: "calc"}, {From: "calc", To: "end"}}}}
 	run, err := base.LoadRun(ctx, "run-consume")
 	if err != nil {
 		t.Fatal(err)
 	}
-	_ = e.resumeFromPause(ctx, run, map[string]any{"approve": "YES"})
-	consumedSeen := false
-	for _, w := range spy.writes {
-		if w.InteractionID == "" && len(w.InteractionQuestions) == 0 {
-			consumedSeen = true
-			break
-		}
-		if w.InteractionID == "I1" {
-			continue // pre-claim bookkeeping may re-save the pointer
-		}
+	if rerr := e.resumeFromPause(ctx, run, map[string]any{"approve": "YES"}); rerr != nil {
+		t.Logf("resumeFromPause returned: %v", rerr)
 	}
-	if !consumedSeen {
-		t.Fatalf("no checkpoint write ever cleared the pause pointer (writes: %d) — a park after the claim would replay interaction I1 and overwrite the operator's answers", len(spy.writes))
+	if len(spy.writes) == 0 {
+		t.Fatal("no checkpoint write at all")
+	}
+	w := spy.writes[0]
+	if w.NodeID != "gate" || w.InteractionID != "" || len(w.InteractionQuestions) != 0 {
+		t.Fatalf("first checkpoint write after the claim is %+v; want the gate checkpoint with the pause pointer cleared — a park before the consumption would replay interaction I1 and overwrite the operator's answers", w)
+	}
+}
+
+// Same contract, applied to the OTHER resume path out of a human pause:
+// the review gate. resumeFromPause returns into resumeReviewGate before
+// the single-shot machinery, so its claim must consume the pointer too —
+// the shared claimForResume helper is what holds both paths to it.
+func TestReviewGateConsumesThePausePointer(t *testing.T) {
+	base := tmpStore(t)
+	spy := &checkpointSpyStore{RunStore: base}
+	ctx := context.Background()
+	if _, err := base.CreateRun(ctx, "run-review", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	cp := &store.Checkpoint{NodeID: "gate", InteractionID: "I1",
+		InteractionQuestions: map[string]any{"approve": "yes?"}}
+	if err := base.PauseRun(ctx, "run-review", cp); err != nil {
+		t.Fatal(err)
+	}
+	hn := &ir.HumanNode{BaseNode: ir.BaseNode{ID: "gate"}, MaxTurns: 3}
+	hn.Interaction = ir.InteractionReview
+	e := &Engine{store: spy, workflow: &ir.Workflow{Name: "wf", Nodes: map[string]ir.Node{
+		"gate": hn,
+		"calc": &ir.ComputeNode{BaseNode: ir.BaseNode{ID: "calc"}},
+		"end":  &ir.DoneNode{BaseNode: ir.BaseNode{ID: "end"}},
+	}, Edges: []*ir.Edge{{From: "gate", To: "calc"}, {From: "calc", To: "end"}}}}
+	run, err := base.LoadRun(ctx, "run-review")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rerr := e.resumeFromPause(ctx, run, map[string]any{
+		"__review_action": "request_changes",
+	}); rerr != nil {
+		t.Logf("resumeFromPause returned: %v", rerr)
+	}
+	if len(spy.writes) == 0 {
+		t.Fatal("no checkpoint write at all")
+	}
+	w := spy.writes[0]
+	if w.NodeID != "gate" || w.InteractionID != "" || len(w.InteractionQuestions) != 0 {
+		t.Fatalf("first checkpoint write after the review-gate claim is %+v; want the gate checkpoint with the pause pointer cleared — a status-only park in that window leaves interaction I1 live, and Resume's queued router sends the re-entry straight back into the review dialogue", w)
 	}
 }
 

--- a/pkg/runtime/resume_internal_test.go
+++ b/pkg/runtime/resume_internal_test.go
@@ -566,3 +566,47 @@ func TestCancelledPausePointerDoesNotCrossTheGateOnCloudResume(t *testing.T) {
 		t.Errorf("status = %q, want paused_waiting_human — the resumed gate must re-ask, not silently pass", after.Status)
 	}
 }
+
+// The POSITIVE half of CarriesPausePointer — queued is in the predicate
+// so a cloud resume of a HUMAN pause still routes into the answers path
+// (the operator's answers ride the queue message). If the hop stopped
+// preserving the pointer, this resume would silently re-ask instead of
+// recording them. Twin of the negative canary above; the oracle is the
+// RECORDED ANSWER, not just the status.
+func TestQueuedHopRecordsTheOperatorsAnswers(t *testing.T) {
+	base := tmpStore(t)
+	ctx := context.Background()
+	if _, err := base.CreateRun(ctx, "run-queuedgate", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	cp := &store.Checkpoint{NodeID: "gate", InteractionID: "I1",
+		InteractionQuestions: map[string]any{"approve": "yes?"}}
+	if err := base.PauseRun(ctx, "run-queuedgate", cp); err != nil {
+		t.Fatal(err)
+	}
+	// SubmitResume: paused → queued before a runner claims the message.
+	if ok, err := base.UpdateRunStatusIf(ctx, "run-queuedgate", store.RunStatusQueued, "",
+		[]store.RunStatus{store.RunStatusPausedWaitingHuman}); err != nil || !ok {
+		t.Fatalf("queued CAS: ok=%v err=%v", ok, err)
+	}
+	e := &Engine{store: base, workflow: &ir.Workflow{Name: "wf", Entry: "gate", Nodes: map[string]ir.Node{
+		"gate": &ir.HumanNode{BaseNode: ir.BaseNode{ID: "gate"}},
+		"calc": &ir.ComputeNode{BaseNode: ir.BaseNode{ID: "calc"}},
+		"end":  &ir.DoneNode{BaseNode: ir.BaseNode{ID: "end"}},
+	}, Edges: []*ir.Edge{{From: "gate", To: "calc"}, {From: "calc", To: "end"}}}}
+	// The runner's Resume with the message's answers.
+	if rerr := e.Resume(ctx, "run-queuedgate", map[string]any{"approve": "YES"}); rerr != nil {
+		t.Logf("Resume returned: %v", rerr)
+	}
+	after, err := base.LoadRun(ctx, "run-queuedgate")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("status=%s outputs[gate]=%v", after.Status, after.Checkpoint.Outputs["gate"])
+	if after.Status == store.RunStatusPausedWaitingHuman {
+		t.Fatalf("the cloud resume of a human pause RE-ASKED instead of recording the answers: status=%s", after.Status)
+	}
+	if got := after.Checkpoint.Outputs["gate"]; got == nil || got["approve"] != "YES" {
+		t.Fatalf("the operator's answer was not recorded on the gate output: %v", got)
+	}
+}

--- a/pkg/runtime/review.go
+++ b/pkg/runtime/review.go
@@ -107,16 +107,13 @@ func (e *Engine) resumeReviewGate(ctx context.Context, r *store.Run, cp *store.C
 	}
 
 	// Claim the run (paused → running) so a duplicate concurrent resume
-	// can't spawn a second execution.
-	claimed, claimErr := e.store.UpdateRunStatusIf(ctx, runID, store.RunStatusRunning, "",
-		[]store.RunStatus{store.RunStatusPausedWaitingHuman})
-	if claimErr != nil {
-		return fmt.Errorf("runtime: claim run for review resume: %w", claimErr)
-	}
-	if !claimed {
-		return fmt.Errorf("runtime: run %q is already being executed; refusing duplicate review resume", runID)
-	}
-	if err := e.emit(ctx, runID, store.EventRunResumed, "", nil); err != nil {
+	// can't spawn a second execution. The shared claim helper also
+	// consumes the pause pointer — without it, a status-only park between
+	// this claim and the next checkpoint boundary would leave the stale
+	// InteractionID live, and Resume's `queued` router would send the
+	// re-entry straight back into the review dialogue (an approved,
+	// already-merged gate re-pausing with an empty human turn).
+	if err := e.claimForResume(ctx, r, cp, store.RunStatusPausedWaitingHuman); err != nil {
 		return err
 	}
 

--- a/pkg/runtime/run_failure.go
+++ b/pkg/runtime/run_failure.go
@@ -24,7 +24,7 @@ func (e *Engine) failRun(ctx context.Context, runID, nodeID, reason string) erro
 func (e *Engine) failRunErr(ctx context.Context, runID, nodeID string, origErr error) error {
 	var rtErr *RuntimeError
 	if errors.As(origErr, &rtErr) {
-		if storeErr := e.store.UpdateRunStatus(ctx, runID, store.RunStatusFailed, rtErr.Message); storeErr != nil {
+		if storeErr := e.store.UpdateRunStatusCoded(ctx, runID, store.RunStatusFailed, rtErr.Message, rtErr.Code); storeErr != nil {
 			e.logger.Error("failed to persist run failure status: %v", storeErr)
 			return fmt.Errorf("runtime: node %q failed (%s) and could not persist failure: %w", nodeID, rtErr.Message, storeErr)
 		}
@@ -46,7 +46,7 @@ func (e *Engine) failRunErr(ctx context.Context, runID, nodeID string, origErr e
 // If the store update fails, the store error is returned instead of the runtime
 // error so callers know the failure state was not persisted.
 func (e *Engine) failRunWithCode(ctx context.Context, runID, nodeID, reason string, code ErrorCode, hint string) error {
-	if storeErr := e.store.UpdateRunStatus(ctx, runID, store.RunStatusFailed, reason); storeErr != nil {
+	if storeErr := e.store.UpdateRunStatusCoded(ctx, runID, store.RunStatusFailed, reason, code); storeErr != nil {
 		e.logger.Error("failed to persist run failure status: %v", storeErr)
 		return fmt.Errorf("runtime: node %q failed (%s) and could not persist failure: %w", nodeID, reason, storeErr)
 	}
@@ -93,19 +93,19 @@ func (e *Engine) emitRunFailedAndReturn(ctx context.Context, runID, nodeID, reas
 // plain checkpoint-less failure if the write fails.
 func (e *Engine) failRunDeliberate(rs *runState, nodeID, reason string) error {
 	cp := buildCheckpoint(rs, nodeID)
-	if storeErr := e.store.FailRunTerminal(rs.ctx, rs.runID, cp, reason); storeErr != nil {
+	if storeErr := e.store.FailRunTerminal(rs.ctx, rs.runID, cp, reason, store.FailureFailNode); storeErr != nil {
 		e.logger.Error("failed to persist terminal failure: %v", storeErr)
 		return e.failRun(rs.ctx, rs.runID, nodeID, reason)
 	}
 	if err := e.emit(rs.ctx, rs.runID, store.EventRunFailed, nodeID, map[string]any{
 		"error":      reason,
-		"code":       string(ErrCodeExecutionFailed),
+		"code":       string(store.FailureFailNode),
 		"rewindable": true,
 	}); err != nil {
 		e.logger.Warn("failed to emit run_failed event: %v", err)
 	}
 	return &RuntimeError{
-		Code:    ErrCodeExecutionFailed,
+		Code:    store.FailureFailNode,
 		Message: reason,
 		NodeID:  nodeID,
 	}
@@ -117,7 +117,7 @@ func (e *Engine) failRunDeliberate(rs *runState, nodeID, reason string) error {
 func (e *Engine) failRunWithCheckpoint(rs *runState, nodeID, reason string) error {
 	e.captureFailureBoundary(rs, nodeID)
 	cp := buildCheckpoint(rs, nodeID)
-	if storeErr := e.store.FailRunResumable(rs.ctx, rs.runID, cp, reason); storeErr != nil {
+	if storeErr := e.store.FailRunResumable(rs.ctx, rs.runID, cp, reason, ErrCodeExecutionFailed); storeErr != nil {
 		e.logger.Error("failed to persist resumable failure: %v", storeErr)
 		return e.failRun(rs.ctx, rs.runID, nodeID, reason)
 	}
@@ -132,7 +132,7 @@ func (e *Engine) failRunErrWithCheckpoint(rs *runState, nodeID string, origErr e
 		// failRunWithCheckpoint, which captures for itself.
 		e.captureFailureBoundary(rs, nodeID)
 		cp := buildCheckpoint(rs, nodeID)
-		if storeErr := e.store.FailRunResumable(rs.ctx, rs.runID, cp, rtErr.Message); storeErr != nil {
+		if storeErr := e.store.FailRunResumable(rs.ctx, rs.runID, cp, rtErr.Message, rtErr.Code); storeErr != nil {
 			e.logger.Error("failed to persist resumable failure: %v", storeErr)
 			return e.failRunErr(rs.ctx, rs.runID, nodeID, origErr)
 		}
@@ -185,13 +185,13 @@ func (e *Engine) handleContextDoneWithCheckpoint(rs *runState, nodeID string, ct
 		// CAS or event-suppression is needed.
 		if errors.Is(context.Cause(rs.ctx), ErrRunInterrupted) {
 			reason := fmt.Sprintf("interrupted at node %s (resumable)", nodeID)
-			if storeErr := e.store.FailRunResumable(storeCtx, rs.runID, cp, reason); storeErr != nil {
+			if storeErr := e.store.FailRunResumable(storeCtx, rs.runID, cp, reason, store.FailureInterrupted); storeErr != nil {
 				e.logger.Error("failed to persist resumable interruption: %v", storeErr)
 				return e.failRun(storeCtx, rs.runID, nodeID, reason)
 			}
 			if err := e.emit(storeCtx, rs.runID, store.EventRunFailed, nodeID, map[string]any{
 				"error":       reason,
-				"code":        string(ErrCodeExecutionFailed),
+				"code":        string(store.FailureInterrupted),
 				"resumable":   true,
 				"interrupted": true,
 			}); err != nil {
@@ -216,7 +216,7 @@ func (e *Engine) handleContextDoneWithCheckpoint(rs *runState, nodeID string, ct
 			store.RunStatusPausedOperator,
 			store.RunStatusFailedResumable,
 		}
-		if changed, err := e.store.UpdateRunStatusIf(storeCtx, rs.runID, store.RunStatusCancelled, "run cancelled", cancellable); err != nil {
+		if changed, err := e.store.UpdateRunStatusIfCoded(storeCtx, rs.runID, store.RunStatusCancelled, "run cancelled", store.FailureCancelled, cancellable); err != nil {
 			e.logger.Error("failed to persist cancellation status: %v", err)
 		} else if !changed {
 			e.logger.Debug("run %s already terminal — keeping the recorded cancellation reason", rs.runID)
@@ -233,11 +233,11 @@ func (e *Engine) handleContextDoneWithCheckpoint(rs *runState, nodeID string, ct
 	// the already-expired rs.ctx.
 	reason := fmt.Sprintf("timeout: %s", ctxErr.Error())
 	cp := buildCheckpoint(rs, nodeID)
-	if storeErr := e.store.FailRunResumable(storeCtx, rs.runID, cp, reason); storeErr != nil {
+	if storeErr := e.store.FailRunResumable(storeCtx, rs.runID, cp, reason, ErrCodeTimeout); storeErr != nil {
 		e.logger.Error("failed to persist resumable failure: %v", storeErr)
 		return e.failRun(storeCtx, rs.runID, nodeID, reason)
 	}
-	return e.emitRunFailedAndReturn(storeCtx, rs.runID, nodeID, reason, ErrCodeExecutionFailed)
+	return e.emitRunFailedAndReturn(storeCtx, rs.runID, nodeID, reason, ErrCodeTimeout)
 }
 
 // wrapContextErr wraps a context error for branch-level reporting.

--- a/pkg/runtime/setup_failure_status_test.go
+++ b/pkg/runtime/setup_failure_status_test.go
@@ -23,19 +23,22 @@ func TestSetupFailureStatus(t *testing.T) {
 	cancelOperator()
 
 	for _, tc := range []struct {
-		name   string
-		ctx    context.Context
-		want   store.RunStatus
-		reason string
+		name     string
+		ctx      context.Context
+		want     store.RunStatus
+		wantCode store.FailureCode
 	}{
-		{"a runner drain is resumable", interrupted, store.RunStatusFailedResumable, "interrupted"},
-		{"an operator cancel says so", operator, store.RunStatusCancelled, "cancelled"},
+		{"a runner drain is resumable", interrupted, store.RunStatusFailedResumable, store.FailureInterrupted},
+		{"an operator cancel says so", operator, store.RunStatusCancelled, store.FailureCancelled},
 		{"a real setup error still fails", context.Background(), store.RunStatusFailed, ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, msg := setupFailureStatus(tc.ctx, "sandbox start", boom)
+			got, msg, code := setupFailureStatus(tc.ctx, "sandbox start", boom)
 			if got != tc.want {
 				t.Fatalf("status = %q, want %q (msg %q)", got, tc.want, msg)
+			}
+			if code != tc.wantCode {
+				t.Errorf("code = %q, want %q", code, tc.wantCode)
 			}
 			if !strings.Contains(msg, "sandbox start") || !strings.Contains(msg, boom.Error()) {
 				t.Errorf("the message must keep the phase and the cause; got %q", msg)

--- a/pkg/runview/execstatus_agreement_test.go
+++ b/pkg/runview/execstatus_agreement_test.go
@@ -1,0 +1,32 @@
+package runview
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// TestExecStatusTerminalAgreement documents the node-row ExecStatus
+// vocabulary's relation to the canonical RunStatus contract (ADR-095):
+// isTerminalExecStatus answers MONOTONICITY ("may a stale node_started
+// downgrade this row?"), not liveness — which is why Paused counts as
+// terminal here while store.RunStatus.IsPaused is emphatically not
+// store-terminal, and why there is no cancelled exec status at all
+// (handleRunCancelled closes in-flight rows as failed with a
+// cancelled-by-user marker).
+func TestExecStatusTerminalAgreement(t *testing.T) {
+	terminal := []ExecStatus{ExecStatusFinished, ExecStatusFailed, ExecStatusSkipped, ExecStatusPaused}
+	for _, s := range terminal {
+		if !isTerminalExecStatus(s) {
+			t.Errorf("isTerminalExecStatus(%s) = false, want true", s)
+		}
+	}
+	if isTerminalExecStatus(ExecStatusRunning) {
+		t.Error("running must stay downgradeable")
+	}
+	// The documented divergence, asserted from both sides: paused is
+	// exec-terminal but not store-terminal.
+	if !isTerminalExecStatus(ExecStatusPaused) || store.RunStatusPausedWaitingHuman.IsTerminal() {
+		t.Error("paused divergence drifted: exec-terminal AND store-non-terminal is the contract")
+	}
+}

--- a/pkg/runview/rewind.go
+++ b/pkg/runview/rewind.go
@@ -422,9 +422,13 @@ func (s *Service) Rewind(ctx context.Context, spec RewindSpec) (*RewindResult, e
 	}
 
 	run.Status = store.RunStatusCancelled
-	// Clear the stale failure message: the run is no longer "failed at
-	// verify", it is parked at the pivot awaiting a fresh execution.
+	// Clear the stale failure message AND its typed code: the run is no
+	// longer "failed at verify", it is parked at the pivot awaiting a
+	// fresh execution — a synthetic parking carries no failure
+	// classification (ADR-095), and SaveRun below is a full-document
+	// overwrite that would otherwise resurrect the pre-claim code.
 	run.Error = ""
+	run.FailureCode = ""
 	run.Checkpoint = cp
 	run.UpdatedAt = time.Now().UTC()
 	// Re-apply the stamp the claim performed. `run` was loaded BEFORE the

--- a/pkg/runview/service.go
+++ b/pkg/runview/service.go
@@ -400,6 +400,9 @@ type RunSummary struct {
 	UpdatedAt  time.Time       `json:"updated_at"`
 	FinishedAt *time.Time      `json:"finished_at,omitempty"`
 	Error      string          `json:"error,omitempty"`
+	// FailureCode is Error's machine-readable classification (ADR-095);
+	// empty = unknown/legacy.
+	FailureCode store.FailureCode `json:"failure_code,omitempty"`
 	// Active reports whether the run is currently held by this
 	// process's manager. A run with status "running" but Active=false
 	// belongs to another process or to a previous boot — Cancel won't

--- a/pkg/runview/service_control.go
+++ b/pkg/runview/service_control.go
@@ -128,7 +128,7 @@ func (s *Service) CancelInactiveCtx(ctx context.Context, runID string) (bool, er
 	if r.Error != "" {
 		reason += ": " + r.Error
 	}
-	if err := s.store.UpdateRunStatus(ctx, runID, store.RunStatusCancelled, reason); err != nil {
+	if err := s.store.UpdateRunStatusCoded(ctx, runID, store.RunStatusCancelled, reason, store.FailureCancelled); err != nil {
 		return false, fmt.Errorf("update status: %w", err)
 	}
 	// Re-load post-flip so RecoverFinalize sees the new status.

--- a/pkg/runview/service_launch.go
+++ b/pkg/runview/service_launch.go
@@ -519,17 +519,13 @@ func (s *Service) Resume(parent context.Context, spec ResumeSpec) (*LaunchResult
 // validateResumable returns nil if r is in a state from which Resume
 // can proceed; otherwise it returns a descriptive error.
 func validateResumable(r *store.Run, answers map[string]any) error {
-	switch r.Status {
-	case store.RunStatusPausedWaitingHuman:
-		if len(answers) == 0 {
-			return fmt.Errorf("no answers provided; resume of paused run requires answers")
-		}
-		return nil
-	case store.RunStatusPausedOperator, store.RunStatusFailedResumable, store.RunStatusCancelled:
-		return nil
-	default:
+	if !r.Status.CanOperatorResume() {
 		return fmt.Errorf("run %q cannot be resumed (status: %s)", r.ID, r.Status)
 	}
+	if r.Status.RequiresResumeAnswers() && len(answers) == 0 {
+		return fmt.Errorf("no answers provided; resume of paused run requires answers")
+	}
+	return nil
 }
 
 // spawnRun owns the lock + register + goroutine + defer-cleanup

--- a/pkg/runview/service_lifecycle.go
+++ b/pkg/runview/service_lifecycle.go
@@ -563,7 +563,7 @@ func (s *Service) markInterrupted(runID string) {
 	}); err != nil {
 		s.logger.Warn("runview: drain: append run_interrupted for %s: %v", runID, err)
 	}
-	if err := s.store.UpdateRunStatus(ctx, runID, store.RunStatusFailedResumable, reason); err != nil {
+	if err := s.store.UpdateRunStatusCoded(ctx, runID, store.RunStatusFailedResumable, reason, store.FailureInterrupted); err != nil {
 		s.logger.Warn("runview: drain: update status for %s: %v", runID, err)
 	}
 }

--- a/pkg/runview/service_lifecycle.go
+++ b/pkg/runview/service_lifecycle.go
@@ -261,7 +261,7 @@ func (s *Service) reconcileOrphans() {
 		if r2.Checkpoint != nil {
 			newStatus = store.RunStatusFailedResumable
 		}
-		if err := s.store.UpdateRunStatus(ctx, id, newStatus, ReasonProcessOrphaned); err != nil {
+		if err := s.store.UpdateRunStatusCoded(ctx, id, newStatus, ReasonProcessOrphaned, store.FailureProcessOrphaned); err != nil {
 			s.logger.Warn("runview: reconcile %s: %v", id, err)
 		} else {
 			s.logger.Info("runview: reconciled orphan run %s → %s", id, newStatus)
@@ -612,7 +612,7 @@ func (s *Service) reconcileRun(runID string) (*store.Run, bool, error) {
 	// entry — either way the studio can offer the resume button.
 	newStatus := store.RunStatusFailedResumable
 	const reason = "orphan reconciled on resume request: server had no live goroutine for run"
-	if err := s.store.UpdateRunStatus(context.Background(), runID, newStatus, reason); err != nil {
+	if err := s.store.UpdateRunStatusCoded(context.Background(), runID, newStatus, reason, store.FailureProcessOrphaned); err != nil {
 		_ = lock.Unlock()
 		return r2, false, fmt.Errorf("reconcile %s: %w", runID, err)
 	}

--- a/pkg/runview/service_runs.go
+++ b/pkg/runview/service_runs.go
@@ -244,6 +244,7 @@ func summarizeRun(r *store.Run, active bool) RunSummary {
 		UpdatedAt:         r.UpdatedAt,
 		FinishedAt:        r.FinishedAt,
 		Error:             r.Error,
+		FailureCode:       r.FailureCode,
 		Active:            active,
 		FinalCommit:       r.FinalCommit,
 		FinalBranch:       r.FinalBranch,

--- a/pkg/runview/snapshot.go
+++ b/pkg/runview/snapshot.go
@@ -97,12 +97,15 @@ type RunHeader struct {
 	// overrides + cloud ceiling clamp), surfaced so the studio Overview
 	// draws budget meters with a denominator. Nil when the workflow
 	// declared no budget: block. See store.RunBudget.
-	Budget     *store.RunBudget  `json:"budget,omitempty"`
-	CreatedAt  time.Time         `json:"created_at"`
-	UpdatedAt  time.Time         `json:"updated_at"`
-	FinishedAt *time.Time        `json:"finished_at,omitempty"`
-	Error      string            `json:"error,omitempty"`
-	Checkpoint *store.Checkpoint `json:"checkpoint,omitempty"`
+	Budget     *store.RunBudget `json:"budget,omitempty"`
+	CreatedAt  time.Time        `json:"created_at"`
+	UpdatedAt  time.Time        `json:"updated_at"`
+	FinishedAt *time.Time       `json:"finished_at,omitempty"`
+	Error      string           `json:"error,omitempty"`
+	// FailureCode is Error's machine-readable classification (ADR-095);
+	// empty = unknown/legacy.
+	FailureCode store.FailureCode `json:"failure_code,omitempty"`
+	Checkpoint  *store.Checkpoint `json:"checkpoint,omitempty"`
 	// WorkDir is the absolute filesystem path the run executed in
 	// (per-run worktree when Worktree is true, otherwise inherited cwd).
 	// Empty for runs created before this field was persisted; the studio
@@ -1418,6 +1421,7 @@ func headerFromRun(r *store.Run) RunHeader {
 		UpdatedAt:         r.UpdatedAt,
 		FinishedAt:        r.FinishedAt,
 		Error:             r.Error,
+		FailureCode:       r.FailureCode,
 		Checkpoint:        r.Checkpoint,
 		WorkDir:           r.WorkDir,
 		ProjectPath:       r.ProjectPath,

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -1107,7 +1107,7 @@ func (p *Publisher) CancelRunWithReason(ctx context.Context, runID, reason strin
 	if prior := strings.TrimSpace(r.Error); prior != "" {
 		reason += " (was " + string(r.Status) + ": " + prior + ")"
 	}
-	changed, err := p.store.UpdateRunStatusIf(ctx, runID, store.RunStatusCancelled, reason, cancellable)
+	changed, err := p.store.UpdateRunStatusIfCoded(ctx, runID, store.RunStatusCancelled, reason, store.FailureCancelled, cancellable)
 	if err != nil {
 		return fmt.Errorf("cloudpublisher: flip status: %w", err)
 	}
@@ -1194,13 +1194,17 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 		if republished {
 			return
 		}
+		// Restore the prior failure classification alongside its text —
+		// the queued claim cleared both. A publish failure gets its own
+		// text but keeps the prior code: the run is back in the state
+		// whose cause that code classifies.
 		runErr := prior.Error
 		if retErr != nil {
 			runErr = fmt.Sprintf("queue resume: %v", retErr)
 		}
 		rollbackCtx, rollbackCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 		defer rollbackCancel()
-		if _, rbErr := p.store.UpdateRunStatusIf(rollbackCtx, spec.RunID, priorStatus, runErr,
+		if _, rbErr := p.store.UpdateRunStatusIfCoded(rollbackCtx, spec.RunID, priorStatus, runErr, prior.FailureCode,
 			[]store.RunStatus{store.RunStatusQueued}); rbErr != nil {
 			p.logger.Error("cloudpublisher: rollback %s after resume failure: %v", spec.RunID, rbErr)
 		}

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -1095,10 +1095,15 @@ func (p *Publisher) CancelRunWithReason(ctx context.Context, runID, reason strin
 	// silently overwrite the in-flight resume back to cancelled with
 	// no visible warning. The expectedFrom set lists every status we
 	// consider cancellable here.
+	// paused_operator included like its peers (the runtime cancel CAS in
+	// pkg/runtime/run_failure.go and runview's CancelInactiveCtx): an
+	// operator-paused run must stay cancellable, or it can only ever be
+	// resumed.
 	cancellable := []store.RunStatus{
 		store.RunStatusQueued,
 		store.RunStatusRunning,
 		store.RunStatusPausedWaitingHuman,
+		store.RunStatusPausedOperator,
 		store.RunStatusFailedResumable,
 	}
 	if strings.TrimSpace(reason) == "" {
@@ -1160,12 +1165,10 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 		return fmt.Errorf("cloudpublisher: load prior run %s: %w", spec.RunID, loadErr)
 	}
 	priorStatus := prior.Status
-	switch priorStatus {
-	case store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator, store.RunStatusFailedResumable, store.RunStatusCancelled:
-		// Valid resume source states. The runview layer validates first, but
-		// SubmitResume repeats the boundary check because another request may
-		// have changed the row since that read.
-	default:
+	// The runview layer validates first, but SubmitResume repeats the
+	// boundary check because another request may have changed the row
+	// since that read.
+	if !priorStatus.CanOperatorResume() {
 		return fmt.Errorf("cloudpublisher: run %s is not resumable from status %s", spec.RunID, priorStatus)
 	}
 

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -1085,9 +1085,8 @@ func (p *Publisher) CancelRunWithReason(ctx context.Context, runID, reason strin
 	if err != nil {
 		return fmt.Errorf("cloudpublisher: load run %s: %w", runID, err)
 	}
-	switch r.Status {
-	case store.RunStatusFinished, store.RunStatusFailed, store.RunStatusCancelled:
-		return nil // already terminal
+	if !r.Status.CanBeCancelled() {
+		return nil // already settled
 	}
 	// CAS on the cancellable statuses. A SubmitResume that races this
 	// call can flip queued → running between our LoadRun and the
@@ -1095,16 +1094,16 @@ func (p *Publisher) CancelRunWithReason(ctx context.Context, runID, reason strin
 	// silently overwrite the in-flight resume back to cancelled with
 	// no visible warning. The expectedFrom set lists every status we
 	// consider cancellable here.
-	// paused_operator included like its peers (the runtime cancel CAS in
-	// pkg/runtime/run_failure.go and runview's CancelInactiveCtx): an
-	// operator-paused run must stay cancellable, or it can only ever be
-	// resumed.
-	cancellable := []store.RunStatus{
-		store.RunStatusQueued,
-		store.RunStatusRunning,
-		store.RunStatusPausedWaitingHuman,
-		store.RunStatusPausedOperator,
-		store.RunStatusFailedResumable,
+	// The cloud publisher owns the queue AND the doc, so its reach is
+	// the full canonical set — including paused_operator (once missing
+	// here, which made an operator-paused cloud run un-cancellable) and
+	// queued (this surface can retract a queued attempt; the engine's
+	// narrower CAS cannot).
+	var cancellable []store.RunStatus
+	for _, st := range store.AllRunStatuses {
+		if st.CanBeCancelled() {
+			cancellable = append(cancellable, st)
+		}
 	}
 	if strings.TrimSpace(reason) == "" {
 		reason = "cancelled"
@@ -1122,8 +1121,7 @@ func (p *Publisher) CancelRunWithReason(ctx context.Context, runID, reason strin
 		// should surface for the operator to retry.
 		r2, _ := p.store.LoadRun(ctx, runID)
 		if r2 != nil {
-			switch r2.Status {
-			case store.RunStatusFinished, store.RunStatusFailed, store.RunStatusCancelled:
+			if !r2.Status.CanBeCancelled() {
 				return nil
 			}
 			return fmt.Errorf("cloudpublisher: cancel raced (status now %s) — retry", r2.Status)

--- a/pkg/server/cloudpublisher/publisher_cancel_test.go
+++ b/pkg/server/cloudpublisher/publisher_cancel_test.go
@@ -123,3 +123,38 @@ func TestCancelRunWithReason(t *testing.T) {
 		}
 	})
 }
+
+// A paused_operator run is cancellable everywhere else (the runtime CAS
+// and runview's CancelInactive both list it, explicitly "so an orphaned
+// operator-paused run can still be cancelled") — the cloud publisher's
+// CAS was the one set missing it, leaving a cloud run parked
+// paused_operator impossible to cancel: the terminal fast-path does not
+// return, the CAS misses, and every retry reports "cancel raced".
+func TestCancelRun_PausedOperatorIsCancellable(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := &Publisher{store: st, cancelRun: func(string) error { return nil }}
+	run, err := st.CreateRun(context.Background(), "run-po", "wf", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.Status = store.RunStatusPausedOperator
+	if err := st.SaveRun(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.CancelRun(context.Background(), "run-po"); err != nil {
+		t.Fatalf("cancelling a paused_operator run must succeed, got: %v", err)
+	}
+	got, err := st.LoadRun(context.Background(), "run-po")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != store.RunStatusCancelled {
+		t.Fatalf("status = %s, want cancelled", got.Status)
+	}
+	if got.FailureCode != store.FailureCancelled {
+		t.Errorf("failure code = %q, want CANCELLED", got.FailureCode)
+	}
+}

--- a/pkg/store/iface.go
+++ b/pkg/store/iface.go
@@ -115,8 +115,14 @@ type RunStore interface {
 	SetSubbotChild(ctx context.Context, parentRunID, key, childRunID string) error
 	ClearSubbotChild(ctx context.Context, parentRunID, key string) error
 
-	// Status & checkpoint
+	// Status & checkpoint. The Coded variants carry the typed
+	// FailureCode (ADR-095) in the SAME write as the status — never a
+	// separate read-modify-write; the plain forms delegate with an
+	// empty (unknown) code. Every transition to a non-failure status
+	// clears the code, which is the invariant that keeps a resumed run
+	// from lying about a past failure.
 	UpdateRunStatus(ctx context.Context, id string, status RunStatus, runErr string) error
+	UpdateRunStatusCoded(ctx context.Context, id string, status RunStatus, runErr string, code FailureCode) error
 	// UpdateRunStatusIf is a compare-and-set on the status field: the
 	// write only lands when the current status is in expectedFrom.
 	// Returns changed=true when the write applied, false when the
@@ -124,13 +130,14 @@ type RunStore interface {
 	// firing concurrently with a Resume republish). Used by the
 	// cloud publisher to avoid stomping on raced state transitions.
 	UpdateRunStatusIf(ctx context.Context, id string, status RunStatus, runErr string, expectedFrom []RunStatus) (changed bool, err error)
+	UpdateRunStatusIfCoded(ctx context.Context, id string, status RunStatus, runErr string, code FailureCode, expectedFrom []RunStatus) (changed bool, err error)
 	SaveCheckpoint(ctx context.Context, id string, cp *Checkpoint) error
 	PauseRun(ctx context.Context, id string, cp *Checkpoint) error
-	FailRunResumable(ctx context.Context, id string, cp *Checkpoint, runErr string) error
+	FailRunResumable(ctx context.Context, id string, cp *Checkpoint, runErr string, code FailureCode) error
 	// FailRunTerminal is FailRunResumable's terminal counterpart: status
 	// failed (no auto-resume) but the checkpoint is kept so the run stays
 	// rewindable on an explicit operator action.
-	FailRunTerminal(ctx context.Context, id string, cp *Checkpoint, runErr string) error
+	FailRunTerminal(ctx context.Context, id string, cp *Checkpoint, runErr string, code FailureCode) error
 
 	// Events (append-only, monotonic seq per run)
 	AppendEvent(ctx context.Context, runID string, evt Event) (*Event, error)

--- a/pkg/store/lifecycle.go
+++ b/pkg/store/lifecycle.go
@@ -82,11 +82,11 @@ var KnownFailureCodes = []FailureCode{
 	FailureQueueSchemaMismatch,
 }
 
-// failureStatuses is the only set of statuses on which a non-empty
+// CarriesFailureCode names the only statuses on which a non-empty
 // FailureCode may persist. Every status transition through the store
 // choke points clears the field when the target is outside this set,
 // which is what makes a stale code impossible after a resume.
-func (s RunStatus) carriesFailureCode() bool {
+func (s RunStatus) CarriesFailureCode() bool {
 	return s == RunStatusFailed || s == RunStatusFailedResumable || s == RunStatusCancelled
 }
 

--- a/pkg/store/lifecycle.go
+++ b/pkg/store/lifecycle.go
@@ -30,24 +30,44 @@ package store
 type FailureCode string
 
 const (
-	FailureNodeNotFound          FailureCode = "NODE_NOT_FOUND"
-	FailureNoOutgoingEdge        FailureCode = "NO_OUTGOING_EDGE"
-	FailureLoopExhausted         FailureCode = "LOOP_EXHAUSTED"
-	FailureBudgetExceeded        FailureCode = "BUDGET_EXCEEDED"
-	FailureExecutionFailed       FailureCode = "EXECUTION_FAILED"
-	FailureWorkspaceSafety       FailureCode = "WORKSPACE_SAFETY"
-	FailureTimeout               FailureCode = "TIMEOUT"
-	FailureCancelled             FailureCode = "CANCELLED"
-	FailureJoinFailed            FailureCode = "JOIN_FAILED"
-	FailureResumeInvalid         FailureCode = "RESUME_INVALID"
-	FailureSchemaValidation      FailureCode = "SCHEMA_VALIDATION"
-	FailureRateLimited           FailureCode = "RATE_LIMITED"
+	FailureNodeNotFound     FailureCode = "NODE_NOT_FOUND"
+	FailureNoOutgoingEdge   FailureCode = "NO_OUTGOING_EDGE"
+	FailureLoopExhausted    FailureCode = "LOOP_EXHAUSTED"
+	FailureBudgetExceeded   FailureCode = "BUDGET_EXCEEDED"
+	FailureExecutionFailed  FailureCode = "EXECUTION_FAILED"
+	FailureWorkspaceSafety  FailureCode = "WORKSPACE_SAFETY"
+	FailureTimeout          FailureCode = "TIMEOUT"
+	FailureCancelled        FailureCode = "CANCELLED"
+	FailureJoinFailed       FailureCode = "JOIN_FAILED"
+	FailureResumeInvalid    FailureCode = "RESUME_INVALID"
+	FailureSchemaValidation FailureCode = "SCHEMA_VALIDATION"
+	FailureRateLimited      FailureCode = "RATE_LIMITED"
+	// FailureUsageLimitBlocked: the provider's subscription/quota WINDOW
+	// is exhausted (Anthropic forfait 5h / session / weekly cap) —
+	// distinct from FailureRateLimited because retrying inside the
+	// window can never succeed: the only cure is waiting for the reset.
+	// In-node recovery fails terminal immediately; the run lands
+	// failed_resumable and the run-level auto-resume loop waits with a
+	// reset-aware delay (see pkg/cli/auto_resume.go).
 	FailureUsageLimitBlocked     FailureCode = "USAGE_LIMIT_BLOCKED"
 	FailureContextLengthExceeded FailureCode = "CONTEXT_LENGTH_EXCEEDED"
 	FailureToolFailedTransient   FailureCode = "TOOL_FAILED_TRANSIENT"
 	FailureToolFailedPermanent   FailureCode = "TOOL_FAILED_PERMANENT"
-	FailureNetworkTransient      FailureCode = "NETWORK_TRANSIENT"
-	FailureAuthFailed            FailureCode = "AUTH_FAILED"
+	// FailureNetworkTransient: occasional ISP / DNS / TCP / TLS hiccup
+	// reaching the upstream model API. Distinct from
+	// FailureExecutionFailed so the recovery dispatcher can apply a
+	// longer exponential-backoff budget — a 2-second single retry is
+	// plenty for "stale token" or "race on the tool subprocess", but
+	// useless against a 30-second captive-portal handoff or a
+	// multi-minute datacenter routing blip.
+	FailureNetworkTransient FailureCode = "NETWORK_TRANSIENT"
+	// FailureAuthFailed: the upstream model provider rejected the
+	// request for credential reasons (HTTP 401/403, expired token,
+	// invalid api key). NOT transient — retrying the same call can
+	// never succeed until a human re-authenticates. The recovery
+	// dispatcher pauses for human instead of burning the retry budget;
+	// the run is resumable once the credential is refreshed.
+	FailureAuthFailed FailureCode = "AUTH_FAILED"
 
 	// FailureInterrupted: an INTERNAL stop (runner drain, dispatcher
 	// stall reap, server shutdown) parked the run failed_resumable.
@@ -68,18 +88,13 @@ const (
 	FailureQueueSchemaMismatch FailureCode = "QUEUE_SCHEMA_MISMATCH"
 )
 
-// KnownFailureCodes documents the codes this binary emits. For humans
-// and docs generation only — never use it to validate a persisted
-// value (open-world contract above).
-var KnownFailureCodes = []FailureCode{
-	FailureNodeNotFound, FailureNoOutgoingEdge, FailureLoopExhausted,
-	FailureBudgetExceeded, FailureExecutionFailed, FailureWorkspaceSafety,
-	FailureTimeout, FailureCancelled, FailureJoinFailed, FailureResumeInvalid,
-	FailureSchemaValidation, FailureRateLimited, FailureUsageLimitBlocked,
-	FailureContextLengthExceeded, FailureToolFailedTransient,
-	FailureToolFailedPermanent, FailureNetworkTransient, FailureAuthFailed,
-	FailureInterrupted, FailureFailNode, FailureProcessOrphaned,
-	FailureQueueSchemaMismatch,
+// AllRunStatuses is the exhaustive status vocabulary, for callers that
+// derive a policy set from a predicate (and for the truth-table tests).
+// Order matches the declaration block above.
+var AllRunStatuses = []RunStatus{
+	RunStatusRunning, RunStatusPausedWaitingHuman, RunStatusPausedOperator,
+	RunStatusFinished, RunStatusFailed, RunStatusFailedResumable,
+	RunStatusCancelled, RunStatusQueued,
 }
 
 // CarriesFailureCode names the only statuses on which a non-empty
@@ -144,4 +159,15 @@ func (s RunStatus) CanAutoResume() bool { return s == RunStatusFailedResumable }
 // launch slot.
 func (s RunStatus) CountsAgainstLaunchLimit() bool {
 	return s == RunStatusQueued || s == RunStatusRunning
+}
+
+// CanBeCancelled is the MAXIMAL set a cancel write may stomp: anything
+// not already finally settled (finished, failed, cancelled). Surfaces
+// with a narrower reach keep their own subset and say why — the
+// engine's ctx-cancel CAS excludes queued because a queued doc is a
+// NEWER attempt that engine does not own (pkg/runtime/run_failure.go),
+// and runview's CancelInactive excludes running (a live run is
+// cancelled through its process, not a store write).
+func (s RunStatus) CanBeCancelled() bool {
+	return !s.IsFinalSuccess() && !s.IsFinalFailure() && s != RunStatusCancelled
 }

--- a/pkg/store/lifecycle.go
+++ b/pkg/store/lifecycle.go
@@ -110,6 +110,21 @@ func (s RunStatus) CarriesFailureCode() bool {
 	return s == RunStatusFailed || s == RunStatusFailedResumable || s == RunStatusCancelled
 }
 
+// CarriesPausePointer reports whether a run in this status may
+// truthfully carry a pending-interaction pointer on its checkpoint
+// (Checkpoint.InteractionID / InteractionQuestions). True for the
+// paused statuses (the pointer IS the pause) and for queued — the
+// in-flight cloud resume hop: SubmitResume flips paused → queued
+// before a runner claims the message, and the runner's queued router
+// reads the pointer to route a human-answers resume. Every other
+// transition consumes it: the checkpoint itself survives (ADR-095 §5),
+// but a pointer on a cancelled/terminal/running run is a replayable
+// lie — a later resume would route back into the pause path and cross
+// the human gate with empty answers.
+func (s RunStatus) CarriesPausePointer() bool {
+	return s.IsPaused() || s == RunStatusQueued
+}
+
 // ---------------------------------------------------------------------------
 // Policy predicates — one named question each
 // ---------------------------------------------------------------------------

--- a/pkg/store/lifecycle.go
+++ b/pkg/store/lifecycle.go
@@ -1,0 +1,147 @@
+package store
+
+// This file is the canonical terminal-state contract for runs (ADR-095).
+//
+// Two things live here and nowhere else:
+//
+//  1. The policy predicates on RunStatus. Each one answers ONE named
+//     question; callers pick the predicate whose question they are
+//     actually asking instead of re-deriving a status set. Predicates
+//     that other layers deliberately diverge from (supervise's
+//     event-level terminal set, runview's ExecStatus monotonicity set,
+//     the board/pipeline sets) document the divergence at their own
+//     declaration and are pinned by the cross-layer agreement tests.
+//
+//  2. FailureCode — the persisted, machine-readable classification of
+//     why a run is in a failure status. It is the same vocabulary the
+//     engine uses in-process (runtime.ErrorCode is a type alias of it),
+//     persisted on Run.FailureCode instead of dying at the store
+//     boundary as free text.
+
+// FailureCode classifies a run failure. The empty value means UNKNOWN
+// (legacy rows, writers not yet classified) — never "no failure": the
+// presence of a failure is Run.Status's job.
+//
+// The registry below is OPEN-WORLD: it documents the codes iterion
+// itself emits, but readers MUST NOT validate against it — a newer
+// binary (or an external writer) may persist a code this binary does
+// not know, and it must round-trip unharmed. Zero-means-unknown is the
+// only universal rule.
+type FailureCode string
+
+const (
+	FailureNodeNotFound          FailureCode = "NODE_NOT_FOUND"
+	FailureNoOutgoingEdge        FailureCode = "NO_OUTGOING_EDGE"
+	FailureLoopExhausted         FailureCode = "LOOP_EXHAUSTED"
+	FailureBudgetExceeded        FailureCode = "BUDGET_EXCEEDED"
+	FailureExecutionFailed       FailureCode = "EXECUTION_FAILED"
+	FailureWorkspaceSafety       FailureCode = "WORKSPACE_SAFETY"
+	FailureTimeout               FailureCode = "TIMEOUT"
+	FailureCancelled             FailureCode = "CANCELLED"
+	FailureJoinFailed            FailureCode = "JOIN_FAILED"
+	FailureResumeInvalid         FailureCode = "RESUME_INVALID"
+	FailureSchemaValidation      FailureCode = "SCHEMA_VALIDATION"
+	FailureRateLimited           FailureCode = "RATE_LIMITED"
+	FailureUsageLimitBlocked     FailureCode = "USAGE_LIMIT_BLOCKED"
+	FailureContextLengthExceeded FailureCode = "CONTEXT_LENGTH_EXCEEDED"
+	FailureToolFailedTransient   FailureCode = "TOOL_FAILED_TRANSIENT"
+	FailureToolFailedPermanent   FailureCode = "TOOL_FAILED_PERMANENT"
+	FailureNetworkTransient      FailureCode = "NETWORK_TRANSIENT"
+	FailureAuthFailed            FailureCode = "AUTH_FAILED"
+
+	// FailureInterrupted: an INTERNAL stop (runner drain, dispatcher
+	// stall reap, server shutdown) parked the run failed_resumable.
+	// Previously only visible as the run_failed event's
+	// `interrupted:true` flag.
+	FailureInterrupted FailureCode = "INTERRUPTED"
+	// FailureFailNode: the workflow's own `fail` node ended the run —
+	// a deliberate graph termination, not a crash (ADR-015).
+	FailureFailNode FailureCode = "FAIL_NODE"
+	// FailureProcessOrphaned: a liveness probe (flock, lease, pid)
+	// found the run's owner dead and flipped it failed_resumable.
+	// Declared here for the orphan sweep/reconcile writers; wiring
+	// them is follow-up work to the ADR-095 slice.
+	FailureProcessOrphaned FailureCode = "PROCESS_ORPHANED"
+	// FailureQueueSchemaMismatch: a cloud queue delivery was parked
+	// because its message schema version is outside the runner's
+	// accepted range. Declared for the schema-park writer (follow-up).
+	FailureQueueSchemaMismatch FailureCode = "QUEUE_SCHEMA_MISMATCH"
+)
+
+// KnownFailureCodes documents the codes this binary emits. For humans
+// and docs generation only — never use it to validate a persisted
+// value (open-world contract above).
+var KnownFailureCodes = []FailureCode{
+	FailureNodeNotFound, FailureNoOutgoingEdge, FailureLoopExhausted,
+	FailureBudgetExceeded, FailureExecutionFailed, FailureWorkspaceSafety,
+	FailureTimeout, FailureCancelled, FailureJoinFailed, FailureResumeInvalid,
+	FailureSchemaValidation, FailureRateLimited, FailureUsageLimitBlocked,
+	FailureContextLengthExceeded, FailureToolFailedTransient,
+	FailureToolFailedPermanent, FailureNetworkTransient, FailureAuthFailed,
+	FailureInterrupted, FailureFailNode, FailureProcessOrphaned,
+	FailureQueueSchemaMismatch,
+}
+
+// failureStatuses is the only set of statuses on which a non-empty
+// FailureCode may persist. Every status transition through the store
+// choke points clears the field when the target is outside this set,
+// which is what makes a stale code impossible after a resume.
+func (s RunStatus) carriesFailureCode() bool {
+	return s == RunStatusFailed || s == RunStatusFailedResumable || s == RunStatusCancelled
+}
+
+// ---------------------------------------------------------------------------
+// Policy predicates — one named question each
+// ---------------------------------------------------------------------------
+
+// IsFinalSuccess: the run completed its workflow (reached a done node).
+func (s RunStatus) IsFinalSuccess() bool { return s == RunStatusFinished }
+
+// IsFinalFailure: the run failed with no automatic path forward — only
+// an explicit operator action (rewind, fresh launch) touches it again.
+func (s RunStatus) IsFinalFailure() bool { return s == RunStatusFailed }
+
+// IsTerminalResumable: terminal for polling purposes (IsTerminal is
+// true) yet holding a checkpoint an operator may resume from. The
+// deliberate ambiguity of failed_resumable/cancelled being "terminal",
+// made explicit.
+func (s RunStatus) IsTerminalResumable() bool {
+	return s == RunStatusFailedResumable || s == RunStatusCancelled
+}
+
+// IsQueued: submitted to the cloud queue, not yet claimed by a runner.
+func (s RunStatus) IsQueued() bool { return s == RunStatusQueued }
+
+// CanOperatorResume answers the EXTERNAL eligibility question: may an
+// operator ask this run to continue (studio Resume, `iterion resume`,
+// SubmitResume, MCP local_resume)? It deliberately says nothing about
+// HOW the resume proceeds — paused_waiting_human routes through the
+// answers path (see RequiresResumeAnswers) while the other three
+// restart from the failure checkpoint — and internal claim CAS sets
+// keep their own, narrower or wider, sets (e.g. the failure-resume
+// claim also accepts `queued` for the cloud pre-flip, and the pause
+// claim accepts only paused_waiting_human).
+func (s RunStatus) CanOperatorResume() bool {
+	return s == RunStatusFailedResumable || s == RunStatusCancelled ||
+		s == RunStatusPausedOperator || s == RunStatusPausedWaitingHuman
+}
+
+// RequiresResumeAnswers: resuming this status needs the pending human
+// interaction answered first (`--answers-file`, the studio form).
+func (s RunStatus) RequiresResumeAnswers() bool { return s == RunStatusPausedWaitingHuman }
+
+// CanAutoResume answers the AUTOMATIC eligibility question: may
+// machinery (dispatcher retry, --auto-resume, usage-window retries)
+// resume this run with no human in the loop? Deliberately excludes
+// cancelled — an operator's cancel is a decision automation must never
+// override — and the paused statuses, which wait on a human by
+// definition.
+func (s RunStatus) CanAutoResume() bool { return s == RunStatusFailedResumable }
+
+// CountsAgainstLaunchLimit: the run occupies launch-admission capacity
+// (tenant concurrency caps, overlap policies). Named after the policy,
+// not "active": a paused run is alive too, it just doesn't hold a
+// launch slot.
+func (s RunStatus) CountsAgainstLaunchLimit() bool {
+	return s == RunStatusQueued || s == RunStatusRunning
+}

--- a/pkg/store/lifecycle.go
+++ b/pkg/store/lifecycle.go
@@ -30,8 +30,13 @@ package store
 type FailureCode string
 
 const (
-	FailureNodeNotFound     FailureCode = "NODE_NOT_FOUND"
-	FailureNoOutgoingEdge   FailureCode = "NO_OUTGOING_EDGE"
+	FailureNodeNotFound   FailureCode = "NODE_NOT_FOUND"
+	FailureNoOutgoingEdge FailureCode = "NO_OUTGOING_EDGE"
+	// FailureLoopExhausted, FailureJoinFailed and FailureResumeInvalid
+	// are RESERVED: declared for the event vocabulary but with no
+	// persisting writer today — a run record never carries them until
+	// their sites are classified. Kept so the wire vocabulary and the
+	// runtime aliases stay stable.
 	FailureLoopExhausted    FailureCode = "LOOP_EXHAUSTED"
 	FailureBudgetExceeded   FailureCode = "BUDGET_EXCEEDED"
 	FailureExecutionFailed  FailureCode = "EXECUTION_FAILED"
@@ -146,11 +151,14 @@ func (s RunStatus) CanOperatorResume() bool {
 func (s RunStatus) RequiresResumeAnswers() bool { return s == RunStatusPausedWaitingHuman }
 
 // CanAutoResume answers the AUTOMATIC eligibility question: may
-// machinery (dispatcher retry, --auto-resume, usage-window retries)
-// resume this run with no human in the loop? Deliberately excludes
-// cancelled — an operator's cancel is a decision automation must never
-// override — and the paused statuses, which wait on a human by
-// definition.
+// machinery (--auto-resume, usage-window retries) resume this run with
+// no human in the loop? Deliberately excludes cancelled — an operator's
+// cancel is a decision automation must never override — and the paused
+// statuses, which wait on a human by definition. One documented
+// divergence: the dispatcher's resumableRunID additionally re-dispatches
+// its OWN paused_operator tickets (pkg/dispatcher/retry.go) — a
+// dispatcher-owned pause is machinery state there, not an operator's;
+// do not "align" it onto this predicate.
 func (s RunStatus) CanAutoResume() bool { return s == RunStatusFailedResumable }
 
 // CountsAgainstLaunchLimit: the run occupies launch-admission capacity

--- a/pkg/store/lifecycle_negative_space_test.go
+++ b/pkg/store/lifecycle_negative_space_test.go
@@ -10,84 +10,73 @@ import (
 )
 
 // TestNoHandRolledTerminalSets is the negative-space guard of ADR-095:
-// in the three packages the contract card names (pkg/store,
-// pkg/supervise, pkg/runview), every multi-status RunStatus set —
-// a `case` clause or a []RunStatus literal combining two or more
-// terminal-ish statuses — must either live in lifecycle.go or be an
-// ALLOWLISTED, individually-justified divergence. A new hand-rolled set
-// fails here until it is either replaced by a predicate or argued onto
-// the allowlist.
+// in the packages it walks — the three the contract card names plus the
+// two where the motivating drift bug actually lived (pkg/runtime's
+// cancel CAS, pkg/server/cloudpublisher's cancellable set) — every line
+// combining two or more distinct RunStatus identifiers is a policy set
+// and must be either the contract itself or an ALLOWLISTED,
+// individually-justified divergence. The allowlist is keyed by
+// file + status-combo, so a NEW set slipping into an already-known file
+// still fails; an allowlist entry that stops matching fails too (stale
+// justifications are how drift hides).
 func TestNoHandRolledTerminalSets(t *testing.T) {
 	root := "../.." // pkg/store → repo root
-	pkgs := []string{"pkg/store", "pkg/supervise", "pkg/runview"}
+	pkgs := []string{"pkg/store", "pkg/supervise", "pkg/runview", "pkg/runtime", "pkg/server/cloudpublisher"}
 
-	// Statuses whose combination signals a policy set. running/queued
-	// pairs are launch-capacity sets and equally policy-bearing.
 	statusIdent := regexp.MustCompile(`RunStatus(Finished|Failed|FailedResumable|Cancelled|PausedWaitingHuman|PausedOperator|Running|Queued)\b`)
+	// Slice literals span lines (the motivating publisher set did), so
+	// they are matched as whole `[]RunStatus{...}` blocks; everything
+	// else (case clauses, boolean chains) is effectively single-line.
+	sliceLit := regexp.MustCompile(`(?s)\[\](?:store\.)?RunStatus\{[^}]*\}`)
 
-	// One detection = "<rel-path>: <sorted status combo>".
-	// The allowlist maps each accepted detection to its reason; the
-	// reason is printed when the corresponding line disappears so a
-	// stale entry is noticed too.
-	allow := map[string]string{
-		// -- pkg/store: the contract itself and its machinery.
-		"pkg/store/lifecycle.go":             "the canonical contract",
-		"pkg/store/lifecycle_test.go":        "the contract's truth table",
-		"pkg/store/store_run.go":             "transition machinery (applyStatusTransition side-effect switch + cancelled-wins guards), not a policy set",
-		"pkg/store/mongo/runs.go":            "mongo twin of the transition machinery ($set side-effect switches + notifiable filter, kept in lockstep by conformance)",
-		"pkg/store/storetest/conformance.go": "conformance harness exercising transitions",
-		"pkg/store/run.go":                   "IsTerminal/IsPaused: contract predicates declared beside the enum",
-		// -- pkg/runview: individually documented divergences.
-		"pkg/runview/rewind.go":               "rewindableStatuses: deliberately wider than CanOperatorResume (failed kept rewindable, queued claimable)",
-		"pkg/runview/rewind_files.go":         "restore path branches on finished/failed/rewindable — mirrors rewindableStatuses",
-		"pkg/runview/service_control.go":      "CancelInactive flippable set (failed deliberately excluded) + inbox refuse set (failed_resumable deliberately accepted)",
-		"pkg/runview/service_launch.go":       "validateResumable: delegates to CanOperatorResume; retains the answers-path split",
-		"pkg/runview/service_lifecycle.go":    "sandboxContainerReapable: documented wider-than-IsTerminal set (paused_operator reapable)",
-		"pkg/runview/subbot.go":               "subbot outcome routing: finished vs failure-trio vs in-flight, a three-way outcome switch",
-		"pkg/runview/pipeline_scheduler.go":   "queued-only launch guards",
-		"pkg/runview/service_runs.go":         "list filters",
-		"pkg/runview/snapshot.go":             "ExecStatus (node-row) vocabulary, not RunStatus policy",
-		"pkg/runview/service_interactions.go": "paused_waiting_human auto-resume trigger, single-status",
-		"pkg/runview/service_commands.go":     "AnswerHuman requires paused_waiting_human, single-status",
-		"pkg/runview/detached.go":             "IsPaused stream-keepalive, single-status checks",
-		"pkg/runview/fork.go":                 "fork shell parked as synthetic cancelled (empty reason and code)",
-		// -- pkg/supervise: event-level vocabulary, not RunStatus.
-		"pkg/supervise/inproc.go": "steering inbox refuse set: finished/failed/cancelled refuse, failed_resumable deliberately accepted (drained on resume)",
+	// One key = "<rel-path> :: <sorted status combo>", one value = the
+	// reason this exact set is allowed to exist outside lifecycle.go.
+	allow := map[string]string{}
+	for k, v := range negativeSpaceAllowlist {
+		allow[k] = v
 	}
 
-	found := map[string][]string{}
+	found := map[string]bool{}
 	for _, p := range pkgs {
 		dir := filepath.Join(root, p)
-		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-			if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") {
+		err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") {
 				return err
 			}
 			rel, _ := filepath.Rel(root, path)
-			if strings.HasSuffix(rel, "_test.go") && rel != "pkg/store/lifecycle_test.go" {
+			rel = filepath.ToSlash(rel)
+			if strings.HasSuffix(rel, "_test.go") {
 				return nil
 			}
 			data, rerr := os.ReadFile(path)
 			if rerr != nil {
 				return rerr
 			}
-			for _, line := range strings.Split(string(data), "\n") {
-				ms := statusIdent.FindAllString(line, -1)
+			record := func(chunk string) {
+				ms := statusIdent.FindAllString(chunk, -1)
 				if len(ms) < 2 {
-					continue
+					return
 				}
 				set := map[string]bool{}
 				for _, m := range ms {
-					set[m] = true
+					set[strings.TrimPrefix(m, "RunStatus")] = true
 				}
 				if len(set) < 2 {
-					continue
+					return
 				}
 				combo := make([]string, 0, len(set))
 				for k := range set {
 					combo = append(combo, k)
 				}
 				sort.Strings(combo)
-				found[filepath.ToSlash(rel)] = append(found[filepath.ToSlash(rel)], strings.Join(combo, "+"))
+				found[rel+" :: "+strings.Join(combo, "+")] = true
+			}
+			src := string(data)
+			for _, lit := range sliceLit.FindAllString(src, -1) {
+				record(lit)
+			}
+			for _, line := range strings.Split(sliceLit.ReplaceAllString(src, ""), "\n") {
+				record(line)
 			}
 			return nil
 		})
@@ -96,14 +85,47 @@ func TestNoHandRolledTerminalSets(t *testing.T) {
 		}
 	}
 
-	for file, combos := range found {
-		if _, ok := allow[file]; !ok {
-			t.Errorf("hand-rolled RunStatus set in %s (%v) — replace with a lifecycle.go predicate or allowlist it here with its reason", file, combos)
+	for key := range found {
+		if strings.HasPrefix(key, "pkg/store/lifecycle.go ::") || strings.HasPrefix(key, "pkg/store/run.go ::") {
+			continue // the contract and the predicates beside the enum
+		}
+		if _, ok := allow[key]; !ok {
+			t.Errorf("hand-rolled RunStatus set: %q — replace it with a lifecycle.go predicate or allowlist it with its reason", key)
 		}
 	}
-	for file, reason := range allow {
-		if _, ok := found[file]; !ok && !strings.Contains(reason, "contract") {
-			t.Logf("allowlist entry %s no longer matches any set (%s) — consider pruning", file, reason)
+	for key, reason := range allow {
+		if !found[key] {
+			t.Errorf("stale allowlist entry %q (%s) — the set is gone; prune the entry", key, reason)
 		}
 	}
+}
+
+// negativeSpaceAllowlist: every surviving multi-status set outside the
+// contract, each with the reason it is NOT a predicate call. Adding a
+// set means arguing its reason here.
+var negativeSpaceAllowlist = map[string]string{
+	// -- pkg/store: transition machinery, not policy sets.
+	"pkg/store/store_run.go :: Cancelled+Failed+FailedResumable+Finished":  "applyStatusTransition side-effect switch (FinishedAt stamping)",
+	"pkg/store/store_run.go :: Finished+Running":                           "applyStatusTransition checkpoint-clear pair (running/finished drop the recovery point)",
+	"pkg/store/store_run.go :: PausedWaitingHuman+Running":                 "applyStatusTransition FinishedAt-clear pair (resume paths un-freeze the duration ticker)",
+	"pkg/store/mongo/runs.go :: Cancelled+Failed+FailedResumable+Finished": "runStatusUpdate: mongo twin of the transition side-effect switch",
+	"pkg/store/mongo/runs.go :: Queued+Running":                            "CountsAgainstLaunchLimit twin inside a Mongo $in filter (CountActiveRunsByTenant); a bson filter cannot call a predicate",
+
+	// -- pkg/runview: individually documented divergences.
+	"pkg/runview/rewind.go :: Cancelled+Failed+FailedResumable+PausedOperator+PausedWaitingHuman+Queued": "rewindableStatuses: deliberately wider than CanOperatorResume (failed stays rewindable, queued claimable)",
+	"pkg/runview/service_control.go :: FailedResumable+PausedOperator+PausedWaitingHuman":                "CancelInactive flippable arm (queued has its own case; failed deliberately excluded; no running — a live run cancels through its process)",
+	"pkg/runview/service_control.go :: Cancelled+Failed+Finished":                                        "inbox refuse set: failed_resumable deliberately ACCEPTED (drained on resume)",
+	"pkg/runview/service_lifecycle.go :: PausedWaitingHuman+Running":                                     "sandboxContainerReapable keep-set: documented wider-than-IsTerminal reaping (paused_operator reapable)",
+	"pkg/runview/subbot.go :: Cancelled+Failed+FailedResumable":                                          "subbot outcome routing: failure-trio → clear + rerun fresh, a three-way outcome switch",
+
+	// -- pkg/supervise: steering admission.
+	"pkg/supervise/inproc.go :: Cancelled+Failed+Finished": "steering inbox refuse set: failed_resumable deliberately accepted (drained on resume)",
+
+	// -- pkg/runtime: claim-CAS / routing sets (they gate a TRANSITION,
+	// not external eligibility — see CanOperatorResume's doc).
+	"pkg/runtime/run_failure.go :: FailedResumable+PausedOperator+PausedWaitingHuman+Running": "engine ctx-cancel CAS: CanBeCancelled minus queued — a queued doc is a NEWER attempt this engine does not own",
+	"pkg/runtime/resume.go :: Cancelled+FailedResumable+PausedOperator":                       "Resume dispatch: routes the failure-shaped statuses to resumeFromFailure (the answers path is a separate case)",
+	"pkg/runtime/resume.go :: Cancelled+FailedResumable+PausedOperator+Queued":                "failure-resume claim: CanOperatorResume minus paused_waiting_human (answers path) plus queued (cloud pre-flip)",
+	"pkg/runtime/resume.go :: PausedWaitingHuman+Queued":                                      "pause-resume claim: queued accepted for the cloud pre-flip",
+	"pkg/runtime/worktree.go :: Cancelled+Failed+Finished":                                    "RecoverFinalize gate: only fully-stopped shapes finalize; failed_resumable deliberately waits for resume-or-cancel",
 }

--- a/pkg/store/lifecycle_negative_space_test.go
+++ b/pkg/store/lifecycle_negative_space_test.go
@@ -1,83 +1,152 @@
 package store
 
 import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"testing"
 )
 
 // TestNoHandRolledTerminalSets is the negative-space guard of ADR-095:
-// in the packages it walks — the three the contract card names plus the
-// two where the motivating drift bug actually lived (pkg/runtime's
-// cancel CAS, pkg/server/cloudpublisher's cancellable set) — every line
-// combining two or more distinct RunStatus identifiers is a policy set
-// and must be either the contract itself or an ALLOWLISTED,
-// individually-justified divergence. The allowlist is keyed by
-// file + status-combo, so a NEW set slipping into an already-known file
-// still fails; an allowlist entry that stops matching fails too (stale
-// justifications are how drift hides).
+// in the packages it walks — the three the contract card names, the two
+// where the motivating drift bug lived (pkg/runtime, cloudpublisher),
+// and every package part 4 migrated — any SYNTACTIC construct grouping
+// two or more distinct RunStatus identifiers (a case clause, any
+// composite literal — []RunStatus, []string, bson.A, a map — or a
+// maximal &&/|| chain) is a policy set. It must be either the contract
+// itself or an ALLOWLISTED, individually-justified divergence. The
+// allowlist is keyed by file + status-combo AND carries the expected
+// occurrence count, so a SECOND set with an already-justified combo in
+// a known file still fails; an entry whose count stops matching fails
+// too (stale justifications are how drift hides). Parsing the AST (not
+// the source text) means comments can never false-positive and gofmt
+// line-wrapping can never hide a set.
 func TestNoHandRolledTerminalSets(t *testing.T) {
 	root := "../.." // pkg/store → repo root
-	pkgs := []string{"pkg/store", "pkg/supervise", "pkg/runview", "pkg/runtime", "pkg/server/cloudpublisher"}
-
-	statusIdent := regexp.MustCompile(`RunStatus(Finished|Failed|FailedResumable|Cancelled|PausedWaitingHuman|PausedOperator|Running|Queued)\b`)
-	// Slice literals span lines (the motivating publisher set did), so
-	// they are matched as whole `[]RunStatus{...}` blocks; everything
-	// else (case clauses, boolean chains) is effectively single-line.
-	sliceLit := regexp.MustCompile(`(?s)\[\](?:store\.)?RunStatus\{[^}]*\}`)
-
-	// One key = "<rel-path> :: <sorted status combo>", one value = the
-	// reason this exact set is allowed to exist outside lifecycle.go.
-	allow := map[string]string{}
-	for k, v := range negativeSpaceAllowlist {
-		allow[k] = v
+	pkgs := []string{
+		"pkg/store", "pkg/supervise", "pkg/runview",
+		"pkg/runtime", "pkg/server/cloudpublisher",
+		"pkg/cli", "pkg/notify", "pkg/worktreepool", "pkg/operatormcp", "pkg/runner",
 	}
 
-	found := map[string]bool{}
+	statusNames := map[string]bool{
+		"RunStatusFinished": true, "RunStatusFailed": true, "RunStatusFailedResumable": true,
+		"RunStatusCancelled": true, "RunStatusPausedWaitingHuman": true, "RunStatusPausedOperator": true,
+		"RunStatusRunning": true, "RunStatusQueued": true,
+	}
+
+	// statusesIn collects the distinct RunStatusX identifiers anywhere
+	// under n (plain idents in pkg/store, selector idents elsewhere).
+	statusesIn := func(n ast.Node) []string {
+		set := map[string]bool{}
+		ast.Inspect(n, func(c ast.Node) bool {
+			if id, ok := c.(*ast.Ident); ok && statusNames[id.Name] {
+				set[strings.TrimPrefix(id.Name, "RunStatus")] = true
+			}
+			return true
+		})
+		out := make([]string, 0, len(set))
+		for k := range set {
+			out = append(out, k)
+		}
+		sort.Strings(out)
+		return out
+	}
+
+	isLogical := func(e ast.Expr) bool {
+		b, ok := e.(*ast.BinaryExpr)
+		return ok && (b.Op == token.LAND || b.Op == token.LOR)
+	}
+
+	found := map[string]int{}
 	for _, p := range pkgs {
 		dir := filepath.Join(root, p)
 		err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
-			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
 				return err
 			}
-			rel, _ := filepath.Rel(root, path)
+			rel, relErr := filepath.Rel(root, path)
+			if relErr != nil {
+				return relErr
+			}
 			rel = filepath.ToSlash(rel)
-			if strings.HasSuffix(rel, "_test.go") {
-				return nil
+			fset := token.NewFileSet()
+			file, perr := parser.ParseFile(fset, path, nil, 0)
+			if perr != nil {
+				return fmt.Errorf("parse %s: %w", rel, perr)
 			}
-			data, rerr := os.ReadFile(path)
-			if rerr != nil {
-				return rerr
-			}
-			record := func(chunk string) {
-				ms := statusIdent.FindAllString(chunk, -1)
-				if len(ms) < 2 {
-					return
+			record := func(n ast.Node) {
+				combo := statusesIn(n)
+				if len(combo) >= 2 {
+					found[rel+" :: "+strings.Join(combo, "+")]++
 				}
-				set := map[string]bool{}
-				for _, m := range ms {
-					set[strings.TrimPrefix(m, "RunStatus")] = true
-				}
-				if len(set) < 2 {
-					return
-				}
-				combo := make([]string, 0, len(set))
-				for k := range set {
-					combo = append(combo, k)
-				}
-				sort.Strings(combo)
-				found[rel+" :: "+strings.Join(combo, "+")] = true
 			}
-			src := string(data)
-			for _, lit := range sliceLit.FindAllString(src, -1) {
-				record(lit)
-			}
-			for _, line := range strings.Split(sliceLit.ReplaceAllString(src, ""), "\n") {
-				record(line)
-			}
+			// Operand children of a logical chain are marked so only
+			// the MAXIMAL &&/|| expression records (one set, not N).
+			logicalChild := map[ast.Node]bool{}
+			ast.Inspect(file, func(n ast.Node) bool {
+				switch v := n.(type) {
+				case *ast.CaseClause:
+					// The clause's exprs as ONE grouped set — a
+					// `case A, B, C:` is a single policy set however
+					// it wraps.
+					set := map[string]bool{}
+					for _, e := range v.List {
+						for _, s := range statusesIn(e) {
+							set[s] = true
+						}
+					}
+					if len(set) >= 2 {
+						combo := make([]string, 0, len(set))
+						for k := range set {
+							combo = append(combo, k)
+						}
+						sort.Strings(combo)
+						found[rel+" :: "+strings.Join(combo, "+")]++
+					}
+					return true // body still walked for nested sets
+				case *ast.CompositeLit:
+					record(v)
+					return false // counted once, as this literal
+				case *ast.CallExpr:
+					// append(base, RunStatusX, RunStatusY, …) builds a
+					// set without a composite literal.
+					if id, ok := v.Fun.(*ast.Ident); ok && id.Name == "append" {
+						set := map[string]bool{}
+						for _, a := range v.Args[1:] {
+							for _, st := range statusesIn(a) {
+								set[st] = true
+							}
+						}
+						if len(set) >= 2 {
+							combo := make([]string, 0, len(set))
+							for k := range set {
+								combo = append(combo, k)
+							}
+							sort.Strings(combo)
+							found[rel+" :: "+strings.Join(combo, "+")]++
+						}
+					}
+				case *ast.BinaryExpr:
+					if isLogical(v) {
+						if isLogical(v.X) {
+							logicalChild[v.X] = true
+						}
+						if isLogical(v.Y) {
+							logicalChild[v.Y] = true
+						}
+						if !logicalChild[n] {
+							record(v)
+						}
+					}
+				}
+				return true
+			})
 			return nil
 		})
 		if err != nil {
@@ -85,47 +154,72 @@ func TestNoHandRolledTerminalSets(t *testing.T) {
 		}
 	}
 
-	for key := range found {
+	for key, n := range found {
 		if strings.HasPrefix(key, "pkg/store/lifecycle.go ::") || strings.HasPrefix(key, "pkg/store/run.go ::") {
 			continue // the contract and the predicates beside the enum
 		}
-		if _, ok := allow[key]; !ok {
-			t.Errorf("hand-rolled RunStatus set: %q — replace it with a lifecycle.go predicate or allowlist it with its reason", key)
+		e, ok := negativeSpaceAllowlist[key]
+		if !ok {
+			t.Errorf("hand-rolled RunStatus set: %q (×%d) — replace it with a lifecycle.go predicate or allowlist it with its reason", key, n)
+			continue
+		}
+		if e.count != n {
+			t.Errorf("allowlist entry %q expects %d occurrence(s), found %d — a set was added or removed; re-justify", key, e.count, n)
 		}
 	}
-	for key, reason := range allow {
-		if !found[key] {
-			t.Errorf("stale allowlist entry %q (%s) — the set is gone; prune the entry", key, reason)
+	for key, e := range negativeSpaceAllowlist {
+		if _, ok := found[key]; !ok {
+			t.Errorf("stale allowlist entry %q (%s) — the set is gone; prune the entry", key, e.reason)
 		}
 	}
 }
 
+type allowEntry struct {
+	count  int
+	reason string
+}
+
 // negativeSpaceAllowlist: every surviving multi-status set outside the
-// contract, each with the reason it is NOT a predicate call. Adding a
-// set means arguing its reason here.
-var negativeSpaceAllowlist = map[string]string{
-	// -- pkg/store: transition machinery, not policy sets.
-	"pkg/store/store_run.go :: Cancelled+Failed+FailedResumable+Finished":  "applyStatusTransition side-effect switch (FinishedAt stamping)",
-	"pkg/store/store_run.go :: Finished+Running":                           "applyStatusTransition checkpoint-clear pair (running/finished drop the recovery point)",
-	"pkg/store/store_run.go :: PausedWaitingHuman+Running":                 "applyStatusTransition FinishedAt-clear pair (resume paths un-freeze the duration ticker)",
-	"pkg/store/mongo/runs.go :: Cancelled+Failed+FailedResumable+Finished": "runStatusUpdate: mongo twin of the transition side-effect switch",
-	"pkg/store/mongo/runs.go :: Queued+Running":                            "CountsAgainstLaunchLimit twin inside a Mongo $in filter (CountActiveRunsByTenant); a bson filter cannot call a predicate",
+// contract, keyed "file :: combo", each with its occurrence count and
+// the reason it is NOT a predicate call. Adding a set means arguing its
+// reason here.
+var negativeSpaceAllowlist = map[string]allowEntry{
+	// -- pkg/store: transition machinery + the conformance harness.
+	"pkg/store/store_run.go :: Cancelled+Failed+FailedResumable+Finished":                                                              {1, "applyStatusTransition side-effect switch (FinishedAt stamping)"},
+	"pkg/store/store_run.go :: Finished+Running":                                                                                       {1, "applyStatusTransition checkpoint-clear pair"},
+	"pkg/store/store_run.go :: PausedWaitingHuman+Running":                                                                             {1, "applyStatusTransition FinishedAt-clear pair"},
+	"pkg/store/mongo/runs.go :: Cancelled+Failed+FailedResumable+Finished":                                                             {2, "runStatusUpdate side-effect switch + ListNotifiableRuns terminal $in (a bson filter cannot call a predicate; kept in lockstep with IsTerminal by the sweep contract)"},
+	"pkg/store/mongo/runs.go :: Queued+Running":                                                                                        {1, "CountsAgainstLaunchLimit twin inside CountActiveRunsByTenant's $in filter"},
+	"pkg/store/storetest/conformance.go :: Cancelled+Failed+FailedResumable+Finished+PausedOperator+PausedWaitingHuman+Queued+Running": {1, "tombstone canary passes every status to prove no CAS writes on a deleted run"},
 
 	// -- pkg/runview: individually documented divergences.
-	"pkg/runview/rewind.go :: Cancelled+Failed+FailedResumable+PausedOperator+PausedWaitingHuman+Queued": "rewindableStatuses: deliberately wider than CanOperatorResume (failed stays rewindable, queued claimable)",
-	"pkg/runview/service_control.go :: FailedResumable+PausedOperator+PausedWaitingHuman":                "CancelInactive flippable arm (queued has its own case; failed deliberately excluded; no running — a live run cancels through its process)",
-	"pkg/runview/service_control.go :: Cancelled+Failed+Finished":                                        "inbox refuse set: failed_resumable deliberately ACCEPTED (drained on resume)",
-	"pkg/runview/service_lifecycle.go :: PausedWaitingHuman+Running":                                     "sandboxContainerReapable keep-set: documented wider-than-IsTerminal reaping (paused_operator reapable)",
-	"pkg/runview/subbot.go :: Cancelled+Failed+FailedResumable":                                          "subbot outcome routing: failure-trio → clear + rerun fresh, a three-way outcome switch",
+	"pkg/runview/rewind.go :: Cancelled+Failed+FailedResumable+PausedOperator+PausedWaitingHuman+Queued": {1, "rewindableStatuses: deliberately wider than CanOperatorResume (failed stays rewindable, queued claimable)"},
+	"pkg/runview/service_control.go :: FailedResumable+PausedOperator+PausedWaitingHuman":                {1, "CancelInactive flippable arm (queued has its own case; failed deliberately excluded; no running)"},
+	"pkg/runview/service_control.go :: Cancelled+Failed+Finished":                                        {1, "inbox refuse set: failed_resumable deliberately ACCEPTED (drained on resume)"},
+	"pkg/runview/service_lifecycle.go :: PausedWaitingHuman+Running":                                     {1, "sandboxContainerReapable keep-set: documented wider-than-IsTerminal reaping"},
+	"pkg/runview/subbot.go :: Cancelled+Failed+FailedResumable":                                          {2, "subbot outcome routing (reattach switch + park-wait poll): failure-trio → clear + rerun fresh"},
 
-	// -- pkg/supervise: steering admission.
-	"pkg/supervise/inproc.go :: Cancelled+Failed+Finished": "steering inbox refuse set: failed_resumable deliberately accepted (drained on resume)",
+	// -- pkg/supervise.
+	"pkg/supervise/inproc.go :: Cancelled+Failed+Finished": {1, "steering inbox refuse set: failed_resumable deliberately accepted (drained on resume)"},
 
 	// -- pkg/runtime: claim-CAS / routing sets (they gate a TRANSITION,
 	// not external eligibility — see CanOperatorResume's doc).
-	"pkg/runtime/run_failure.go :: FailedResumable+PausedOperator+PausedWaitingHuman+Running": "engine ctx-cancel CAS: CanBeCancelled minus queued — a queued doc is a NEWER attempt this engine does not own",
-	"pkg/runtime/resume.go :: Cancelled+FailedResumable+PausedOperator":                       "Resume dispatch: routes the failure-shaped statuses to resumeFromFailure (the answers path is a separate case)",
-	"pkg/runtime/resume.go :: Cancelled+FailedResumable+PausedOperator+Queued":                "failure-resume claim: CanOperatorResume minus paused_waiting_human (answers path) plus queued (cloud pre-flip)",
-	"pkg/runtime/resume.go :: PausedWaitingHuman+Queued":                                      "pause-resume claim: queued accepted for the cloud pre-flip",
-	"pkg/runtime/worktree.go :: Cancelled+Failed+Finished":                                    "RecoverFinalize gate: only fully-stopped shapes finalize; failed_resumable deliberately waits for resume-or-cancel",
+	"pkg/runtime/run_failure.go :: FailedResumable+PausedOperator+PausedWaitingHuman+Running": {1, "engine ctx-cancel CAS: CanBeCancelled minus queued — a queued doc is a NEWER attempt this engine does not own"},
+	"pkg/runtime/resume.go :: Cancelled+FailedResumable+PausedOperator":                       {1, "Resume dispatch: routes the failure-shaped statuses to resumeFromFailure (the answers path is a separate case)"},
+	"pkg/runtime/resume.go :: Cancelled+FailedResumable+PausedOperator+Queued":                {1, "failure-resume claim: CanOperatorResume minus paused_waiting_human (answers path) plus queued (cloud pre-flip)"},
+	"pkg/runtime/worktree.go :: Cancelled+Failed+Finished":                                    {1, "RecoverFinalize gate: only fully-stopped shapes finalize; failed_resumable waits for resume-or-cancel"},
+
+	// -- pkg/cli.
+	"pkg/cli/issue.go :: PausedOperator+PausedWaitingHuman+Queued+Running": {1, "--clear-last-run guard: refuse while any live-or-parked-on-human shape holds the pointer"},
+	"pkg/cli/runs_prune.go :: Cancelled+Failed+FailedResumable+Finished":   {1, "prune name map: the statuses --status accepts by name"},
+	"pkg/cli/runs_prune.go :: Cancelled+Failed+Finished":                   {1, "prune DEFAULT set: failed_resumable deliberately excluded (only explicit --status touches resumable work)"},
+
+	// -- pkg/runner.
+	"pkg/runner/loop.go :: Failed+Finished+PausedWaitingHuman": {1, "stale-delivery drop set: shapes a redelivery can never legitimately target"},
+	"pkg/runner/loop.go :: FailedResumable+PausedOperator":     {1, "redelivery auto-convert-to-Resume pair (dispatcher-parked shapes)"},
+	"pkg/runner/loop_nats.go :: Queued+Running":                {1, "DLQ park CAS: only a claimed-or-queued attempt may be parked"},
+	"pkg/runner/usage_cap.go :: Queued+Running":                {1, "usage-cap park CAS: only a claimed-or-queued attempt may be parked"},
+
+	// -- pkg/worktreepool.
+	"pkg/worktreepool/classify.go :: PausedOperator+PausedWaitingHuman": {1, "isPausedResumable: the paused pair guarding checkout sparing (delegating would hide the GC policy nuance its doc carries)"},
 }

--- a/pkg/store/lifecycle_negative_space_test.go
+++ b/pkg/store/lifecycle_negative_space_test.go
@@ -30,7 +30,7 @@ func TestNoHandRolledTerminalSets(t *testing.T) {
 	root := "../.." // pkg/store → repo root
 	pkgs := []string{
 		"pkg/store", "pkg/supervise", "pkg/runview",
-		"pkg/runtime", "pkg/server/cloudpublisher",
+		"pkg/runtime", "pkg/server/cloudpublisher", "pkg/dispatcher",
 		"pkg/cli", "pkg/notify", "pkg/worktreepool", "pkg/operatormcp", "pkg/runner",
 	}
 
@@ -39,14 +39,30 @@ func TestNoHandRolledTerminalSets(t *testing.T) {
 		"RunStatusCancelled": true, "RunStatusPausedWaitingHuman": true, "RunStatusPausedOperator": true,
 		"RunStatusRunning": true, "RunStatusQueued": true,
 	}
+	statusStrings := map[string]string{
+		`"finished"`: "Finished", `"failed"`: "Failed", `"failed_resumable"`: "FailedResumable",
+		`"cancelled"`: "Cancelled", `"paused_waiting_human"`: "PausedWaitingHuman",
+		`"paused_operator"`: "PausedOperator", `"running"`: "Running", `"queued"`: "Queued",
+	}
 
-	// statusesIn collects the distinct RunStatusX identifiers anywhere
-	// under n (plain idents in pkg/store, selector idents elsewhere).
+	// statusesIn collects the distinct statuses anywhere under n: the
+	// RunStatusX identifiers (plain in pkg/store, selector elsewhere)
+	// AND exact string literals of the status values — a []string /
+	// metric-label set spells the same policy.
 	statusesIn := func(n ast.Node) []string {
 		set := map[string]bool{}
 		ast.Inspect(n, func(c ast.Node) bool {
-			if id, ok := c.(*ast.Ident); ok && statusNames[id.Name] {
-				set[strings.TrimPrefix(id.Name, "RunStatus")] = true
+			switch v := c.(type) {
+			case *ast.Ident:
+				if statusNames[v.Name] {
+					set[strings.TrimPrefix(v.Name, "RunStatus")] = true
+				}
+			case *ast.BasicLit:
+				if v.Kind == token.STRING {
+					if name, ok := statusStrings[v.Value]; ok {
+						set[name] = true
+					}
+				}
 			}
 			return true
 		})
@@ -58,17 +74,35 @@ func TestNoHandRolledTerminalSets(t *testing.T) {
 		return out
 	}
 
+	unparen := func(e ast.Expr) ast.Expr {
+		for {
+			if p, ok := e.(*ast.ParenExpr); ok {
+				e = p.X
+				continue
+			}
+			return e
+		}
+	}
 	isLogical := func(e ast.Expr) bool {
-		b, ok := e.(*ast.BinaryExpr)
+		b, ok := unparen(e).(*ast.BinaryExpr)
 		return ok && (b.Op == token.LAND || b.Op == token.LOR)
 	}
 
-	found := map[string]int{}
+	found := map[string][]string{}
 	for _, p := range pkgs {
 		dir := filepath.Join(root, p)
 		err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
-			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			if err != nil {
 				return err
+			}
+			if d.IsDir() {
+				if d.Name() == "testdata" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
 			}
 			rel, relErr := filepath.Rel(root, path)
 			if relErr != nil {
@@ -80,10 +114,23 @@ func TestNoHandRolledTerminalSets(t *testing.T) {
 			if perr != nil {
 				return fmt.Errorf("parse %s: %w", rel, perr)
 			}
+			// funcAt names the enclosing function of a position — the
+			// allowlist anchor, so two same-combo sets in one file stay
+			// individually accountable (a swap cannot hide behind a
+			// count).
+			funcAt := func(pos token.Pos) string {
+				for _, d := range file.Decls {
+					if fd, ok := d.(*ast.FuncDecl); ok && fd.Pos() <= pos && pos <= fd.End() {
+						return fd.Name.Name
+					}
+				}
+				return "<pkg-level>"
+			}
 			record := func(n ast.Node) {
 				combo := statusesIn(n)
 				if len(combo) >= 2 {
-					found[rel+" :: "+strings.Join(combo, "+")]++
+					key := rel + " :: " + strings.Join(combo, "+")
+					found[key] = append(found[key], funcAt(n.Pos()))
 				}
 			}
 			// Operand children of a logical chain are marked so only
@@ -94,11 +141,17 @@ func TestNoHandRolledTerminalSets(t *testing.T) {
 				case *ast.CaseClause:
 					// The clause's exprs as ONE grouped set — a
 					// `case A, B, C:` is a single policy set however
-					// it wraps.
+					// it wraps — and any logical expr in the list is
+					// marked so the BinaryExpr pass does not count it
+					// a second time.
 					set := map[string]bool{}
 					for _, e := range v.List {
 						for _, s := range statusesIn(e) {
 							set[s] = true
+						}
+						if isLogical(e) {
+							markLogicalDescendants(unparen(e), logicalChild)
+							logicalChild[unparen(e)] = true
 						}
 					}
 					if len(set) >= 2 {
@@ -107,7 +160,8 @@ func TestNoHandRolledTerminalSets(t *testing.T) {
 							combo = append(combo, k)
 						}
 						sort.Strings(combo)
-						found[rel+" :: "+strings.Join(combo, "+")]++
+						key := rel + " :: " + strings.Join(combo, "+")
+						found[key] = append(found[key], funcAt(v.Pos()))
 					}
 					return true // body still walked for nested sets
 				case *ast.CompositeLit:
@@ -129,19 +183,19 @@ func TestNoHandRolledTerminalSets(t *testing.T) {
 								combo = append(combo, k)
 							}
 							sort.Strings(combo)
-							found[rel+" :: "+strings.Join(combo, "+")]++
+							key := rel + " :: " + strings.Join(combo, "+")
+							found[key] = append(found[key], funcAt(v.Pos()))
 						}
 					}
 				case *ast.BinaryExpr:
-					if isLogical(v) {
-						if isLogical(v.X) {
-							logicalChild[v.X] = true
-						}
-						if isLogical(v.Y) {
-							logicalChild[v.Y] = true
-						}
+					if v.Op == token.LAND || v.Op == token.LOR {
 						if !logicalChild[n] {
 							record(v)
+							// Every logical expr under this maximal
+							// chain — through parens AND call args
+							// (f(a||b) && c) — is part of it, never a
+							// second set.
+							markLogicalDescendants(v, logicalChild)
 						}
 					}
 				}
@@ -154,17 +208,20 @@ func TestNoHandRolledTerminalSets(t *testing.T) {
 		}
 	}
 
-	for key, n := range found {
+	for key, anchors := range found {
+		sort.Strings(anchors)
 		if strings.HasPrefix(key, "pkg/store/lifecycle.go ::") || strings.HasPrefix(key, "pkg/store/run.go ::") {
 			continue // the contract and the predicates beside the enum
 		}
 		e, ok := negativeSpaceAllowlist[key]
 		if !ok {
-			t.Errorf("hand-rolled RunStatus set: %q (×%d) — replace it with a lifecycle.go predicate or allowlist it with its reason", key, n)
+			t.Errorf("hand-rolled RunStatus set: %q (in %v) — replace it with a lifecycle.go predicate or allowlist it with its reason", key, anchors)
 			continue
 		}
-		if e.count != n {
-			t.Errorf("allowlist entry %q expects %d occurrence(s), found %d — a set was added or removed; re-justify", key, e.count, n)
+		want := append([]string(nil), e.anchors...)
+		sort.Strings(want)
+		if strings.Join(want, ",") != strings.Join(anchors, ",") {
+			t.Errorf("allowlist entry %q expects anchors %v, found %v — a set moved, was added or removed; re-justify per site", key, want, anchors)
 		}
 	}
 	for key, e := range negativeSpaceAllowlist {
@@ -175,8 +232,20 @@ func TestNoHandRolledTerminalSets(t *testing.T) {
 }
 
 type allowEntry struct {
-	count  int
-	reason string
+	// anchors: the enclosing function of each justified occurrence.
+	anchors []string
+	reason  string
+}
+
+// markLogicalDescendants flags every &&/|| expression under n as part
+// of an already-recorded chain.
+func markLogicalDescendants(n ast.Node, marked map[ast.Node]bool) {
+	ast.Inspect(n, func(c ast.Node) bool {
+		if b, ok := c.(*ast.BinaryExpr); ok && (b.Op == token.LAND || b.Op == token.LOR) && c != n {
+			marked[c] = true
+		}
+		return true
+	})
 }
 
 // negativeSpaceAllowlist: every surviving multi-status set outside the
@@ -184,42 +253,52 @@ type allowEntry struct {
 // the reason it is NOT a predicate call. Adding a set means arguing its
 // reason here.
 var negativeSpaceAllowlist = map[string]allowEntry{
-	// -- pkg/store: transition machinery + the conformance harness.
-	"pkg/store/store_run.go :: Cancelled+Failed+FailedResumable+Finished":                                                              {1, "applyStatusTransition side-effect switch (FinishedAt stamping)"},
-	"pkg/store/store_run.go :: Finished+Running":                                                                                       {1, "applyStatusTransition checkpoint-clear pair"},
-	"pkg/store/store_run.go :: PausedWaitingHuman+Running":                                                                             {1, "applyStatusTransition FinishedAt-clear pair"},
-	"pkg/store/mongo/runs.go :: Cancelled+Failed+FailedResumable+Finished":                                                             {2, "runStatusUpdate side-effect switch + ListNotifiableRuns terminal $in (a bson filter cannot call a predicate; kept in lockstep with IsTerminal by the sweep contract)"},
-	"pkg/store/mongo/runs.go :: Queued+Running":                                                                                        {1, "CountsAgainstLaunchLimit twin inside CountActiveRunsByTenant's $in filter"},
-	"pkg/store/storetest/conformance.go :: Cancelled+Failed+FailedResumable+Finished+PausedOperator+PausedWaitingHuman+Queued+Running": {1, "tombstone canary passes every status to prove no CAS writes on a deleted run"},
+	// -- pkg/store: transition machinery + harnesses.
+	"pkg/store/store_run.go :: Cancelled+Failed+FailedResumable+Finished":                                                              {[]string{"applyStatusTransition"}, "FinishedAt-stamping side-effect switch"},
+	"pkg/store/store_run.go :: PausedWaitingHuman+Running":                                                                             {[]string{"applyStatusTransition"}, "FinishedAt-clear pair (resume paths un-freeze the duration ticker)"},
+	"pkg/store/mongo/runs.go :: Cancelled+Failed+FailedResumable+Finished":                                                             {[]string{"ListNotifiableRuns", "runStatusUpdate"}, "the mongo transition switch + the notifiable-sweep terminal $in (a bson filter cannot call a predicate; both are IsTerminal's set)"},
+	"pkg/store/mongo/runs.go :: Queued+Running":                                                                                        {[]string{"CountActiveRunsByTenant"}, "CountsAgainstLaunchLimit twin inside a $in filter"},
+	"pkg/store/storetest/conformance.go :: Cancelled+Failed+FailedResumable+Finished+PausedOperator+PausedWaitingHuman+Queued+Running": {[]string{"testTombstoneRefusesWriters"}, "tombstone canary passes every status to prove no CAS writes on a deleted run"},
 
-	// -- pkg/runview: individually documented divergences.
-	"pkg/runview/rewind.go :: Cancelled+Failed+FailedResumable+PausedOperator+PausedWaitingHuman+Queued": {1, "rewindableStatuses: deliberately wider than CanOperatorResume (failed stays rewindable, queued claimable)"},
-	"pkg/runview/service_control.go :: FailedResumable+PausedOperator+PausedWaitingHuman":                {1, "CancelInactive flippable arm (queued has its own case; failed deliberately excluded; no running)"},
-	"pkg/runview/service_control.go :: Cancelled+Failed+Finished":                                        {1, "inbox refuse set: failed_resumable deliberately ACCEPTED (drained on resume)"},
-	"pkg/runview/service_lifecycle.go :: PausedWaitingHuman+Running":                                     {1, "sandboxContainerReapable keep-set: documented wider-than-IsTerminal reaping"},
-	"pkg/runview/subbot.go :: Cancelled+Failed+FailedResumable":                                          {2, "subbot outcome routing (reattach switch + park-wait poll): failure-trio → clear + rerun fresh"},
+	// -- pkg/runview.
+	"pkg/runview/rewind.go :: Cancelled+Failed+FailedResumable+PausedOperator+PausedWaitingHuman+Queued": {[]string{"<pkg-level>"}, "rewindableStatuses: deliberately wider than CanOperatorResume (failed stays rewindable, queued claimable)"},
+	"pkg/runview/service_control.go :: FailedResumable+PausedOperator+PausedWaitingHuman":                {[]string{"CancelInactiveCtx"}, "flippable arm: queued has its own case, failed deliberately excluded, no running"},
+	"pkg/runview/service_control.go :: Cancelled+Failed+Finished":                                        {[]string{"QueueMessage"}, "inbox refuse set: failed_resumable deliberately ACCEPTED (drained on resume)"},
+	"pkg/runview/service_lifecycle.go :: PausedWaitingHuman+Running":                                     {[]string{"sandboxContainerReapable"}, "keep-set: documented wider-than-IsTerminal reaping (paused_operator reapable)"},
+	"pkg/runview/subbot.go :: Cancelled+Failed+FailedResumable":                                          {[]string{"AwaitSubbotTerminal", "ReattachSubbotChild"}, "subbot outcome routing: failure-trio → clear + rerun fresh"},
 
 	// -- pkg/supervise.
-	"pkg/supervise/inproc.go :: Cancelled+Failed+Finished": {1, "steering inbox refuse set: failed_resumable deliberately accepted (drained on resume)"},
+	"pkg/supervise/inproc.go :: Cancelled+Failed+Finished": {[]string{"Inject"}, "steering inbox refuse set: failed_resumable deliberately accepted"},
 
-	// -- pkg/runtime: claim-CAS / routing sets (they gate a TRANSITION,
-	// not external eligibility — see CanOperatorResume's doc).
-	"pkg/runtime/run_failure.go :: FailedResumable+PausedOperator+PausedWaitingHuman+Running": {1, "engine ctx-cancel CAS: CanBeCancelled minus queued — a queued doc is a NEWER attempt this engine does not own"},
-	"pkg/runtime/resume.go :: Cancelled+FailedResumable+PausedOperator":                       {1, "Resume dispatch: routes the failure-shaped statuses to resumeFromFailure (the answers path is a separate case)"},
-	"pkg/runtime/resume.go :: Cancelled+FailedResumable+PausedOperator+Queued":                {1, "failure-resume claim: CanOperatorResume minus paused_waiting_human (answers path) plus queued (cloud pre-flip)"},
-	"pkg/runtime/worktree.go :: Cancelled+Failed+Finished":                                    {1, "RecoverFinalize gate: only fully-stopped shapes finalize; failed_resumable waits for resume-or-cancel"},
+	// -- pkg/runtime: claim-CAS / routing sets (transition gates, not
+	// external eligibility — see CanOperatorResume's doc).
+	"pkg/runtime/run_failure.go :: FailedResumable+PausedOperator+PausedWaitingHuman+Running": {[]string{"handleContextDoneWithCheckpoint"}, "engine ctx-cancel CAS: CanBeCancelled minus queued — a queued doc is a NEWER attempt this engine does not own"},
+	"pkg/runtime/resume.go :: Cancelled+FailedResumable+PausedOperator":                       {[]string{"Resume"}, "Resume dispatch: failure-shaped statuses route to resumeFromFailure"},
+	"pkg/runtime/resume.go :: Cancelled+FailedResumable+PausedOperator+Queued":                {[]string{"claimForFailureResume"}, "failure-resume claim: CanOperatorResume minus the answers path plus queued (cloud pre-flip)"},
+	"pkg/runtime/worktree.go :: Cancelled+Failed+Finished":                                    {[]string{"RecoverFinalize"}, "finalize gate: only fully-stopped shapes; failed_resumable waits for resume-or-cancel"},
+
+	// -- pkg/dispatcher: its own admission policies (the documented
+	// CanAutoResume divergence lives HERE — enforced, not just written).
+	"pkg/dispatcher/retry.go :: Cancelled+FailedResumable+PausedOperator+PausedWaitingHuman+Queued+Running": {[]string{"lastRunForbidsFresh"}, "everything but hard `failed` forbids a fresh sibling — the anti-double-launch hold"},
+	"pkg/dispatcher/retry.go :: FailedResumable+PausedOperator":                                             {[]string{"resumableRunID"}, "the CanAutoResume DIVERGENCE named in lifecycle.go: a dispatcher-owned paused_operator is machinery state, re-dispatched"},
+	"pkg/dispatcher/loop.go :: FailedResumable+PausedOperator":                                              {[]string{"resolveRunID"}, "retry-entry adoption pair (mirrors resumableRunID)"},
+	"pkg/dispatcher/loop.go :: PausedOperator+PausedWaitingHuman":                                           {[]string{"lastRunHoldBeforeClaim"}, "dispatcher-paused re-dispatch arm"},
+	"pkg/dispatcher/loop.go :: Queued+Running":                                                              {[]string{"lastRunHoldBeforeClaim"}, "live-run hold arm"},
+	"pkg/dispatcher/parked.go :: PausedOperator+PausedWaitingHuman":                                         {[]string{"isDispatcherPausedRun"}, "IsPaused twin + dispatcher-source check (kept literal beside its source predicate)"},
 
 	// -- pkg/cli.
-	"pkg/cli/issue.go :: PausedOperator+PausedWaitingHuman+Queued+Running": {1, "--clear-last-run guard: refuse while any live-or-parked-on-human shape holds the pointer"},
-	"pkg/cli/runs_prune.go :: Cancelled+Failed+FailedResumable+Finished":   {1, "prune name map: the statuses --status accepts by name"},
-	"pkg/cli/runs_prune.go :: Cancelled+Failed+Finished":                   {1, "prune DEFAULT set: failed_resumable deliberately excluded (only explicit --status touches resumable work)"},
+	"pkg/cli/issue.go :: PausedOperator+PausedWaitingHuman+Queued+Running": {[]string{"refuseClearWhileRunAlive"}, "--clear-last-run guard: refuse while any live-or-parked-on-human shape holds the pointer"},
+	"pkg/cli/runs_prune.go :: Cancelled+Failed+FailedResumable+Finished":   {[]string{"<pkg-level>"}, "prune name map: the statuses --status accepts"},
+	"pkg/cli/runs_prune.go :: Cancelled+Failed+Finished":                   {[]string{"validatePruneStatuses"}, "prune DEFAULT set: failed_resumable deliberately excluded"},
+	"pkg/cli/remote_runs.go :: Cancelled+Failed+FailedResumable+Finished":  {[]string{"followRemoteRun"}, "--follow stop set over the WIRE statuses (strings): IsTerminal's set; the paused non-exit is the known bug #3 follow-up card"},
 
 	// -- pkg/runner.
-	"pkg/runner/loop.go :: Failed+Finished+PausedWaitingHuman": {1, "stale-delivery drop set: shapes a redelivery can never legitimately target"},
-	"pkg/runner/loop.go :: FailedResumable+PausedOperator":     {1, "redelivery auto-convert-to-Resume pair (dispatcher-parked shapes)"},
-	"pkg/runner/loop_nats.go :: Queued+Running":                {1, "DLQ park CAS: only a claimed-or-queued attempt may be parked"},
-	"pkg/runner/usage_cap.go :: Queued+Running":                {1, "usage-cap park CAS: only a claimed-or-queued attempt may be parked"},
+	"pkg/runner/loop.go :: Failed+Finished":                    {[]string{"bankableStatus"}, "forge-banking outcomes (finalStatus strings; budget_exceeded rides along outside the run-status vocabulary)"},
+	"pkg/runner/loop.go :: Failed+Finished+PausedWaitingHuman": {[]string{"resolveDeliveryPreconditions"}, "stale-delivery drop set: shapes a redelivery can never legitimately target"},
+	"pkg/runner/loop.go :: FailedResumable+PausedOperator":     {[]string{"resolveDeliveryPreconditions"}, "redelivery auto-convert-to-Resume pair (dispatcher-parked shapes)"},
+	"pkg/runner/loop_nats.go :: Queued+Running":                {[]string{"parkOnDLQOnFinalDelivery"}, "DLQ park CAS: only a claimed-or-queued attempt may be parked"},
+	"pkg/runner/usage_cap.go :: Queued+Running":                {[]string{"usageCapPreflight"}, "usage-cap park CAS: only a claimed-or-queued attempt may be parked"},
 
 	// -- pkg/worktreepool.
-	"pkg/worktreepool/classify.go :: PausedOperator+PausedWaitingHuman": {1, "isPausedResumable: the paused pair guarding checkout sparing (delegating would hide the GC policy nuance its doc carries)"},
+	"pkg/worktreepool/classify.go :: PausedOperator+PausedWaitingHuman": {[]string{"isPausedResumable"}, "the paused pair guarding checkout sparing (GC policy nuance documented at the site)"},
 }

--- a/pkg/store/lifecycle_negative_space_test.go
+++ b/pkg/store/lifecycle_negative_space_test.go
@@ -1,0 +1,109 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestNoHandRolledTerminalSets is the negative-space guard of ADR-095:
+// in the three packages the contract card names (pkg/store,
+// pkg/supervise, pkg/runview), every multi-status RunStatus set —
+// a `case` clause or a []RunStatus literal combining two or more
+// terminal-ish statuses — must either live in lifecycle.go or be an
+// ALLOWLISTED, individually-justified divergence. A new hand-rolled set
+// fails here until it is either replaced by a predicate or argued onto
+// the allowlist.
+func TestNoHandRolledTerminalSets(t *testing.T) {
+	root := "../.." // pkg/store → repo root
+	pkgs := []string{"pkg/store", "pkg/supervise", "pkg/runview"}
+
+	// Statuses whose combination signals a policy set. running/queued
+	// pairs are launch-capacity sets and equally policy-bearing.
+	statusIdent := regexp.MustCompile(`RunStatus(Finished|Failed|FailedResumable|Cancelled|PausedWaitingHuman|PausedOperator|Running|Queued)\b`)
+
+	// One detection = "<rel-path>: <sorted status combo>".
+	// The allowlist maps each accepted detection to its reason; the
+	// reason is printed when the corresponding line disappears so a
+	// stale entry is noticed too.
+	allow := map[string]string{
+		// -- pkg/store: the contract itself and its machinery.
+		"pkg/store/lifecycle.go":             "the canonical contract",
+		"pkg/store/lifecycle_test.go":        "the contract's truth table",
+		"pkg/store/store_run.go":             "transition machinery (applyStatusTransition side-effect switch + cancelled-wins guards), not a policy set",
+		"pkg/store/mongo/runs.go":            "mongo twin of the transition machinery ($set side-effect switches + notifiable filter, kept in lockstep by conformance)",
+		"pkg/store/storetest/conformance.go": "conformance harness exercising transitions",
+		"pkg/store/run.go":                   "IsTerminal/IsPaused: contract predicates declared beside the enum",
+		// -- pkg/runview: individually documented divergences.
+		"pkg/runview/rewind.go":               "rewindableStatuses: deliberately wider than CanOperatorResume (failed kept rewindable, queued claimable)",
+		"pkg/runview/rewind_files.go":         "restore path branches on finished/failed/rewindable — mirrors rewindableStatuses",
+		"pkg/runview/service_control.go":      "CancelInactive flippable set (failed deliberately excluded) + inbox refuse set (failed_resumable deliberately accepted)",
+		"pkg/runview/service_launch.go":       "validateResumable: delegates to CanOperatorResume; retains the answers-path split",
+		"pkg/runview/service_lifecycle.go":    "sandboxContainerReapable: documented wider-than-IsTerminal set (paused_operator reapable)",
+		"pkg/runview/subbot.go":               "subbot outcome routing: finished vs failure-trio vs in-flight, a three-way outcome switch",
+		"pkg/runview/pipeline_scheduler.go":   "queued-only launch guards",
+		"pkg/runview/service_runs.go":         "list filters",
+		"pkg/runview/snapshot.go":             "ExecStatus (node-row) vocabulary, not RunStatus policy",
+		"pkg/runview/service_interactions.go": "paused_waiting_human auto-resume trigger, single-status",
+		"pkg/runview/service_commands.go":     "AnswerHuman requires paused_waiting_human, single-status",
+		"pkg/runview/detached.go":             "IsPaused stream-keepalive, single-status checks",
+		"pkg/runview/fork.go":                 "fork shell parked as synthetic cancelled (empty reason and code)",
+		// -- pkg/supervise: event-level vocabulary, not RunStatus.
+		"pkg/supervise/inproc.go": "steering inbox refuse set: finished/failed/cancelled refuse, failed_resumable deliberately accepted (drained on resume)",
+	}
+
+	found := map[string][]string{}
+	for _, p := range pkgs {
+		dir := filepath.Join(root, p)
+		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") {
+				return err
+			}
+			rel, _ := filepath.Rel(root, path)
+			if strings.HasSuffix(rel, "_test.go") && rel != "pkg/store/lifecycle_test.go" {
+				return nil
+			}
+			data, rerr := os.ReadFile(path)
+			if rerr != nil {
+				return rerr
+			}
+			for _, line := range strings.Split(string(data), "\n") {
+				ms := statusIdent.FindAllString(line, -1)
+				if len(ms) < 2 {
+					continue
+				}
+				set := map[string]bool{}
+				for _, m := range ms {
+					set[m] = true
+				}
+				if len(set) < 2 {
+					continue
+				}
+				combo := make([]string, 0, len(set))
+				for k := range set {
+					combo = append(combo, k)
+				}
+				sort.Strings(combo)
+				found[filepath.ToSlash(rel)] = append(found[filepath.ToSlash(rel)], strings.Join(combo, "+"))
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", p, err)
+		}
+	}
+
+	for file, combos := range found {
+		if _, ok := allow[file]; !ok {
+			t.Errorf("hand-rolled RunStatus set in %s (%v) — replace with a lifecycle.go predicate or allowlist it here with its reason", file, combos)
+		}
+	}
+	for file, reason := range allow {
+		if _, ok := found[file]; !ok && !strings.Contains(reason, "contract") {
+			t.Logf("allowlist entry %s no longer matches any set (%s) — consider pruning", file, reason)
+		}
+	}
+}

--- a/pkg/store/lifecycle_test.go
+++ b/pkg/store/lifecycle_test.go
@@ -56,7 +56,7 @@ func TestLifecyclePredicateMatrix(t *testing.T) {
 		{"CountsAgainstLaunchLimit", RunStatus.CountsAgainstLaunchLimit, map[RunStatus]bool{
 			RunStatusQueued: true, RunStatusRunning: true,
 		}},
-		{"carriesFailureCode", RunStatus.carriesFailureCode, map[RunStatus]bool{
+		{"CarriesFailureCode", RunStatus.CarriesFailureCode, map[RunStatus]bool{
 			RunStatusFailed: true, RunStatusFailedResumable: true,
 			RunStatusCancelled: true,
 		}},
@@ -91,8 +91,8 @@ func TestLifecyclePredicateRelations(t *testing.T) {
 			t.Errorf("CountsAgainstLaunchLimit(%s) overlaps terminal/paused", st)
 		}
 		// A failure code may only persist on terminal failure shapes.
-		if st.carriesFailureCode() && !(st.IsFinalFailure() || st.IsTerminalResumable()) {
-			t.Errorf("carriesFailureCode(%s) outside failure statuses", st)
+		if st.CarriesFailureCode() && !(st.IsFinalFailure() || st.IsTerminalResumable()) {
+			t.Errorf("CarriesFailureCode(%s) outside failure statuses", st)
 		}
 	}
 }

--- a/pkg/store/lifecycle_test.go
+++ b/pkg/store/lifecycle_test.go
@@ -5,14 +5,10 @@ import (
 	"testing"
 )
 
-// allStatuses is the exhaustive status vocabulary. If a status is ever
+// allStatuses aliases the canonical vocabulary. If a status is ever
 // added, every predicate row below must take a position on it — the
 // test fails on an unlisted status, which is the point.
-var allStatuses = []RunStatus{
-	RunStatusRunning, RunStatusPausedWaitingHuman, RunStatusPausedOperator,
-	RunStatusFinished, RunStatusFailed, RunStatusFailedResumable,
-	RunStatusCancelled, RunStatusQueued,
-}
+var allStatuses = AllRunStatuses
 
 // TestLifecyclePredicateMatrix pins every predicate's full truth table.
 // This is the single place the sets are spelled out; a drive-by edit to
@@ -55,6 +51,11 @@ func TestLifecyclePredicateMatrix(t *testing.T) {
 		}},
 		{"CountsAgainstLaunchLimit", RunStatus.CountsAgainstLaunchLimit, map[RunStatus]bool{
 			RunStatusQueued: true, RunStatusRunning: true,
+		}},
+		{"CanBeCancelled", RunStatus.CanBeCancelled, map[RunStatus]bool{
+			RunStatusRunning: true, RunStatusPausedWaitingHuman: true,
+			RunStatusPausedOperator: true, RunStatusFailedResumable: true,
+			RunStatusQueued: true,
 		}},
 		{"CarriesFailureCode", RunStatus.CarriesFailureCode, map[RunStatus]bool{
 			RunStatusFailed: true, RunStatusFailedResumable: true,

--- a/pkg/store/lifecycle_test.go
+++ b/pkg/store/lifecycle_test.go
@@ -1,0 +1,125 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// allStatuses is the exhaustive status vocabulary. If a status is ever
+// added, every predicate row below must take a position on it — the
+// test fails on an unlisted status, which is the point.
+var allStatuses = []RunStatus{
+	RunStatusRunning, RunStatusPausedWaitingHuman, RunStatusPausedOperator,
+	RunStatusFinished, RunStatusFailed, RunStatusFailedResumable,
+	RunStatusCancelled, RunStatusQueued,
+}
+
+// TestLifecyclePredicateMatrix pins every predicate's full truth table.
+// This is the single place the sets are spelled out; a drive-by edit to
+// one predicate that silently changes policy shows up as a diff here.
+func TestLifecyclePredicateMatrix(t *testing.T) {
+	type row struct {
+		name string
+		fn   func(RunStatus) bool
+		want map[RunStatus]bool
+	}
+	rows := []row{
+		{"IsTerminal", RunStatus.IsTerminal, map[RunStatus]bool{
+			RunStatusFinished: true, RunStatusFailed: true,
+			RunStatusFailedResumable: true, RunStatusCancelled: true,
+		}},
+		{"IsPaused", RunStatus.IsPaused, map[RunStatus]bool{
+			RunStatusPausedWaitingHuman: true, RunStatusPausedOperator: true,
+		}},
+		{"IsFinalSuccess", RunStatus.IsFinalSuccess, map[RunStatus]bool{
+			RunStatusFinished: true,
+		}},
+		{"IsFinalFailure", RunStatus.IsFinalFailure, map[RunStatus]bool{
+			RunStatusFailed: true,
+		}},
+		{"IsTerminalResumable", RunStatus.IsTerminalResumable, map[RunStatus]bool{
+			RunStatusFailedResumable: true, RunStatusCancelled: true,
+		}},
+		{"IsQueued", RunStatus.IsQueued, map[RunStatus]bool{
+			RunStatusQueued: true,
+		}},
+		{"CanOperatorResume", RunStatus.CanOperatorResume, map[RunStatus]bool{
+			RunStatusFailedResumable: true, RunStatusCancelled: true,
+			RunStatusPausedOperator: true, RunStatusPausedWaitingHuman: true,
+		}},
+		{"RequiresResumeAnswers", RunStatus.RequiresResumeAnswers, map[RunStatus]bool{
+			RunStatusPausedWaitingHuman: true,
+		}},
+		{"CanAutoResume", RunStatus.CanAutoResume, map[RunStatus]bool{
+			RunStatusFailedResumable: true,
+		}},
+		{"CountsAgainstLaunchLimit", RunStatus.CountsAgainstLaunchLimit, map[RunStatus]bool{
+			RunStatusQueued: true, RunStatusRunning: true,
+		}},
+		{"carriesFailureCode", RunStatus.carriesFailureCode, map[RunStatus]bool{
+			RunStatusFailed: true, RunStatusFailedResumable: true,
+			RunStatusCancelled: true,
+		}},
+	}
+	for _, r := range rows {
+		for _, st := range allStatuses {
+			if got, want := r.fn(st), r.want[st]; got != want {
+				t.Errorf("%s(%s) = %v, want %v", r.name, st, got, want)
+			}
+		}
+	}
+}
+
+// TestLifecyclePredicateRelations pins the structural relations between
+// predicates so they cannot drift apart independently.
+func TestLifecyclePredicateRelations(t *testing.T) {
+	for _, st := range allStatuses {
+		// IsTerminal = final-success ∪ final-failure ∪ terminal-resumable.
+		if st.IsTerminal() != (st.IsFinalSuccess() || st.IsFinalFailure() || st.IsTerminalResumable()) {
+			t.Errorf("IsTerminal(%s) is not the union of its parts", st)
+		}
+		// Auto-resume is strictly narrower than operator resume.
+		if st.CanAutoResume() && !st.CanOperatorResume() {
+			t.Errorf("CanAutoResume(%s) without CanOperatorResume", st)
+		}
+		// Answers are only required on a status an operator can resume.
+		if st.RequiresResumeAnswers() && !st.CanOperatorResume() {
+			t.Errorf("RequiresResumeAnswers(%s) without CanOperatorResume", st)
+		}
+		// A status never both holds a launch slot and is terminal/paused.
+		if st.CountsAgainstLaunchLimit() && (st.IsTerminal() || st.IsPaused()) {
+			t.Errorf("CountsAgainstLaunchLimit(%s) overlaps terminal/paused", st)
+		}
+		// A failure code may only persist on terminal failure shapes.
+		if st.carriesFailureCode() && !(st.IsFinalFailure() || st.IsTerminalResumable()) {
+			t.Errorf("carriesFailureCode(%s) outside failure statuses", st)
+		}
+	}
+}
+
+// TestFailureCodeUnknownRoundTrip proves the open-world contract: a
+// code this binary has never heard of survives a JSON round-trip of the
+// Run document unharmed (the BSON shape is covered by the mongo
+// decode-shape test).
+func TestFailureCodeUnknownRoundTrip(t *testing.T) {
+	r := Run{ID: "r1", Status: RunStatusFailedResumable, FailureCode: "SOME_FUTURE_CODE_V9"}
+	b, err := json.Marshal(&r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back Run
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.FailureCode != "SOME_FUTURE_CODE_V9" {
+		t.Fatalf("unknown code mangled: %q", back.FailureCode)
+	}
+	// And the legacy shape: absent field decodes to the zero value.
+	var legacy Run
+	if err := json.Unmarshal([]byte(`{"id":"old","status":"failed"}`), &legacy); err != nil {
+		t.Fatal(err)
+	}
+	if legacy.FailureCode != "" {
+		t.Fatalf("legacy row grew a code: %q", legacy.FailureCode)
+	}
+}

--- a/pkg/store/lifecycle_test.go
+++ b/pkg/store/lifecycle_test.go
@@ -91,7 +91,7 @@ func TestLifecyclePredicateRelations(t *testing.T) {
 			t.Errorf("CountsAgainstLaunchLimit(%s) overlaps terminal/paused", st)
 		}
 		// A failure code may only persist on terminal failure shapes.
-		if st.CarriesFailureCode() && !(st.IsFinalFailure() || st.IsTerminalResumable()) {
+		if st.CarriesFailureCode() && !st.IsFinalFailure() && !st.IsTerminalResumable() {
 			t.Errorf("CarriesFailureCode(%s) outside failure statuses", st)
 		}
 	}

--- a/pkg/store/lifecycle_test.go
+++ b/pkg/store/lifecycle_test.go
@@ -2,6 +2,10 @@ package store
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
 	"testing"
 )
 
@@ -123,4 +127,53 @@ func TestFailureCodeUnknownRoundTrip(t *testing.T) {
 	if legacy.FailureCode != "" {
 		t.Fatalf("legacy row grew a code: %q", legacy.FailureCode)
 	}
+}
+
+// TestAllRunStatusesIsExhaustive pins the derived-set safety net: the
+// cloud publisher (and any future caller) derives production CAS sets
+// from AllRunStatuses × a predicate, so a status declared in run.go but
+// missing from the list would silently shrink those sets. The const
+// block is read from source, the same way the negative-space guard
+// works.
+func TestAllRunStatusesIsExhaustive(t *testing.T) {
+	src, err := os.ReadFile("run.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	declared := regexp.MustCompile(`(?m)^\s*(RunStatus\w+)\s+RunStatus\s*=\s*"`).FindAllStringSubmatch(string(src), -1)
+	if len(declared) == 0 {
+		t.Fatal("no RunStatus constants found in run.go — the regex drifted")
+	}
+	listed := map[RunStatus]bool{}
+	for _, st := range AllRunStatuses {
+		listed[st] = true
+	}
+	if len(listed) != len(declared) {
+		t.Errorf("AllRunStatuses lists %d statuses, run.go declares %d", len(listed), len(declared))
+	}
+	for _, m := range declared {
+		name := m[1]
+		found := false
+		for _, st := range AllRunStatuses {
+			if fmt.Sprintf("RunStatus%s", exportedName(st)) == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("run.go declares %s but AllRunStatuses does not list it — derived CAS sets silently shrink", name)
+		}
+	}
+}
+
+// exportedName maps a status value back to its constant suffix.
+func exportedName(st RunStatus) string {
+	parts := strings.Split(string(st), "_")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, "")
 }

--- a/pkg/store/mongo/decode_shape_test.go
+++ b/pkg/store/mongo/decode_shape_test.go
@@ -165,3 +165,29 @@ func TestCheckpointOutputsDecodeShape(t *testing.T) {
 		t.Fatalf("detail.nested decoded as %T, want map[string]any", detail["nested"])
 	}
 }
+
+// TestFailureCodeBSONRoundTrip pins the ADR-095 field's wire shape:
+// a known code, an UNKNOWN future code (open-world contract), and the
+// legacy document with no field at all (zero value, never an error).
+func TestFailureCodeBSONRoundTrip(t *testing.T) {
+	coded := store.Run{ID: "fc", Status: store.RunStatusFailedResumable, FailureCode: store.FailureUsageLimitBlocked}
+	var back store.Run
+	decodeLikeCursor(t, coded, &back)
+	if back.FailureCode != store.FailureUsageLimitBlocked {
+		t.Fatalf("known code = %q", back.FailureCode)
+	}
+
+	future := store.Run{ID: "fc2", Status: store.RunStatusFailed, FailureCode: "SOME_FUTURE_CODE_V9"}
+	var back2 store.Run
+	decodeLikeCursor(t, future, &back2)
+	if back2.FailureCode != "SOME_FUTURE_CODE_V9" {
+		t.Fatalf("unknown code mangled: %q", back2.FailureCode)
+	}
+
+	legacy := bson.D{{Key: "_id", Value: "old"}, {Key: "status", Value: "failed"}}
+	var back3 store.Run
+	decodeLikeCursor(t, legacy, &back3)
+	if back3.FailureCode != "" {
+		t.Fatalf("legacy row grew a code: %q", back3.FailureCode)
+	}
+}

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -226,9 +226,12 @@ func (s *Store) SaveRun(ctx context.Context, r *store.Run) error {
 	// DeleteRun racing between the check above and this write leaves a
 	// tombstoned doc the filter no longer matches, and the upsert then
 	// trips the duplicate-_id error instead of resurrecting the run.
-	// A full-document write must not resurrect a failure code a copy
-	// loaded before a status change still carries (the rewind claim
-	// learned this the hard way) — normalize at the choke point.
+	// Best-effort guard: a copy whose STATUS is already non-failure
+	// must not resurrect its failure code through this full-document
+	// write. A copy stale on the status itself still rewrites
+	// status+code together (the inherent SaveRun read-modify-write
+	// hazard — a version CAS is the real fix, follow-up); callers on
+	// that path re-stamp the fields by hand (see rewind.go).
 	if !r.Status.CarriesFailureCode() {
 		r.FailureCode = ""
 	}
@@ -654,9 +657,6 @@ func runStatusUpdate(status store.RunStatus, runErr string, code store.FailureCo
 	switch status {
 	case store.RunStatusFinished, store.RunStatusFailed, store.RunStatusFailedResumable, store.RunStatusCancelled:
 		set["finished_at"] = now
-		if status == store.RunStatusFinished {
-			unset["checkpoint"] = ""
-		}
 	case store.RunStatusQueued:
 		set["queued_at"] = now
 		unset["finished_at"] = ""
@@ -665,11 +665,6 @@ func runStatusUpdate(status store.RunStatus, runErr string, code store.FailureCo
 		// freezes mid-run (mirrors FilesystemRunStore).
 		set["error"] = ""
 		unset["finished_at"] = ""
-		// And the checkpoint, like the FS twin's applyStatusTransition:
-		// a pod claiming queued→running must not keep a previous
-		// attempt's checkpoint, or a crash before its first own
-		// checkpoint resumes from a stale node.
-		unset["checkpoint"] = ""
 	case store.RunStatusPausedWaitingHuman:
 		// Mirror the FS store: a generic UpdateRunStatus that crosses
 		// from a previously-terminal (failed_resumable) state into
@@ -819,12 +814,14 @@ func (s *Store) failRunCheckpointed(ctx context.Context, id string, status store
 		return fmt.Errorf("store/mongo: %s %s: %w", opName, id, err)
 	}
 	if res.MatchedCount == 0 {
-		// Either the run is gone, or it is already cancelled and stays so.
-		// Distinguish, since a genuine miss must still surface.
+		// Either the run is gone (absent or tombstoned — LoadRun's
+		// typed error says which), or it is already cancelled and
+		// stays so.
 		if _, gerr := s.LoadRun(ctx, id); gerr == nil {
 			return nil
+		} else {
+			return fmt.Errorf("store/mongo: %s %s: %w", opName, id, gerr)
 		}
-		return fmt.Errorf("store/mongo: run %s not found", id)
 	}
 	return nil
 }

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -226,6 +226,12 @@ func (s *Store) SaveRun(ctx context.Context, r *store.Run) error {
 	// DeleteRun racing between the check above and this write leaves a
 	// tombstoned doc the filter no longer matches, and the upsert then
 	// trips the duplicate-_id error instead of resurrecting the run.
+	// A full-document write must not resurrect a failure code a copy
+	// loaded before a status change still carries (the rewind claim
+	// learned this the hard way) — normalize at the choke point.
+	if !r.Status.CarriesFailureCode() {
+		r.FailureCode = ""
+	}
 	_, err := s.runs.ReplaceOne(ctx, notDeleted(withTenantFilter(ctx, bson.M{"_id": r.ID})), r, options.Replace().SetUpsert(true))
 	if err != nil {
 		if mongo.IsDuplicateKeyError(err) {
@@ -636,16 +642,21 @@ func runStatusUpdate(status store.RunStatus, runErr string, code store.FailureCo
 		"error":      runErr,
 	}
 	unset := bson.M{}
-	if status.CarriesFailureCode() {
+	if status.CarriesFailureCode() && code != "" {
 		set["failure_code"] = code
 	} else {
 		// $unset, not $set "": keeps the persisted shape identical to
-		// the FS twin's omitempty JSON.
+		// the FS twin's omitempty JSON — including an UNKNOWN (empty)
+		// code on a failure status, so {$exists: false} means exactly
+		// "unclassified" on both twins.
 		unset["failure_code"] = ""
 	}
 	switch status {
 	case store.RunStatusFinished, store.RunStatusFailed, store.RunStatusFailedResumable, store.RunStatusCancelled:
 		set["finished_at"] = now
+		if status == store.RunStatusFinished {
+			unset["checkpoint"] = ""
+		}
 	case store.RunStatusQueued:
 		set["queued_at"] = now
 		unset["finished_at"] = ""
@@ -654,6 +665,11 @@ func runStatusUpdate(status store.RunStatus, runErr string, code store.FailureCo
 		// freezes mid-run (mirrors FilesystemRunStore).
 		set["error"] = ""
 		unset["finished_at"] = ""
+		// And the checkpoint, like the FS twin's applyStatusTransition:
+		// a pod claiming queued→running must not keep a previous
+		// attempt's checkpoint, or a crash before its first own
+		// checkpoint resumes from a stale node.
+		unset["checkpoint"] = ""
 	case store.RunStatusPausedWaitingHuman:
 		// Mirror the FS store: a generic UpdateRunStatus that crosses
 		// from a previously-terminal (failed_resumable) state into
@@ -698,10 +714,14 @@ func (s *Store) UpdateRunStatusIfCoded(ctx context.Context, id string, status st
 	if len(unset) > 0 {
 		update["$unset"] = unset
 	}
-	filter := withTenantFilter(ctx, bson.M{"_id": id})
-	if len(expectedFrom) > 0 {
-		filter["status"] = bson.M{"$in": expectedFrom}
+	if len(expectedFrom) == 0 {
+		// A CAS with no expected set is an unconditional write in
+		// disguise (and the FS twin would silently no-op instead) —
+		// refuse loudly rather than diverge.
+		return false, fmt.Errorf("store/mongo: update status if %s: empty expectedFrom", id)
 	}
+	filter := notDeleted(withTenantFilter(ctx, bson.M{"_id": id}))
+	filter["status"] = bson.M{"$in": expectedFrom}
 	res, err := s.runs.UpdateOne(ctx, filter, update)
 	if err != nil {
 		return false, fmt.Errorf("store/mongo: update status if %s: %w", id, err)
@@ -731,11 +751,12 @@ func (s *Store) FailQueuedRunIfAttempt(ctx context.Context, id, runErr string, p
 	}))
 	// Queue-park classification is follow-up; the empty code reads as
 	// unknown, which is honest here.
-	set, _ := runStatusUpdate(store.RunStatusFailedResumable, runErr, "", now)
-	res, err := s.runs.UpdateOne(ctx, filter, bson.M{
-		"$set": set,
-		"$inc": bson.M{"version": 1},
-	})
+	set, unset := runStatusUpdate(store.RunStatusFailedResumable, runErr, "", now)
+	update := bson.M{"$set": set, "$inc": bson.M{"version": 1}}
+	if len(unset) > 0 {
+		update["$unset"] = unset
+	}
+	res, err := s.runs.UpdateOne(ctx, filter, update)
 	if err != nil {
 		return false, fmt.Errorf("store/mongo: fail queued attempt %s: %w", id, err)
 	}
@@ -755,7 +776,7 @@ func (s *Store) SaveCheckpoint(ctx context.Context, id string, cp *store.Checkpo
 		},
 		"$inc": bson.M{"version": 1},
 	}
-	return mongoutil.UpdateOneChecked(ctx, s.runs, withTenantFilter(ctx, bson.M{"_id": id}), update,
+	return mongoutil.UpdateOneChecked(ctx, s.runs, notDeleted(withTenantFilter(ctx, bson.M{"_id": id})), update,
 		fmt.Errorf("store/mongo: run %s not found", id), fmt.Sprintf("store/mongo: save checkpoint %s", id))
 }
 
@@ -775,7 +796,7 @@ func (s *Store) PauseRun(ctx context.Context, id string, cp *store.Checkpoint) e
 		// write bypasses.
 		"$unset": bson.M{"finished_at": "", "failure_code": ""},
 	}
-	return mongoutil.UpdateOneChecked(ctx, s.runs, withTenantFilter(ctx, bson.M{"_id": id}), update,
+	return mongoutil.UpdateOneChecked(ctx, s.runs, notDeleted(withTenantFilter(ctx, bson.M{"_id": id})), update,
 		fmt.Errorf("store/mongo: run %s not found", id), fmt.Sprintf("store/mongo: pause %s", id))
 }
 
@@ -786,10 +807,13 @@ func (s *Store) PauseRun(ctx context.Context, id string, cp *store.Checkpoint) e
 // failure racing in behind it, and the failure would win simply by
 // writing last, auto-resuming a run somebody deliberately stopped.
 func (s *Store) failRunCheckpointed(ctx context.Context, id string, status store.RunStatus, cp *store.Checkpoint, runErr string, code store.FailureCode, opName string) error {
-	set, _ := runStatusUpdate(status, runErr, code, time.Now().UTC())
+	set, unset := runStatusUpdate(status, runErr, code, time.Now().UTC())
 	set["checkpoint"] = cp
 	update := bson.M{"$set": set, "$inc": bson.M{"version": 1}}
-	filter := withTenantFilter(ctx, bson.M{"_id": id, "status": bson.M{"$ne": store.RunStatusCancelled}})
+	if len(unset) > 0 {
+		update["$unset"] = unset
+	}
+	filter := notDeleted(withTenantFilter(ctx, bson.M{"_id": id, "status": bson.M{"$ne": store.RunStatusCancelled}}))
 	res, err := s.runs.UpdateOne(ctx, filter, update)
 	if err != nil {
 		return fmt.Errorf("store/mongo: %s %s: %w", opName, id, err)

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -625,12 +625,20 @@ func (s *Store) RecordNodeServed(ctx context.Context, id, nodeID string, served 
 	return nil
 }
 
-func (s *Store) UpdateRunStatus(ctx context.Context, id string, status store.RunStatus, runErr string) error {
-	now := time.Now().UTC()
+// runStatusUpdate builds the shared $set/$unset pair for a status
+// transition — the Mongo twin of the FS store's applyStatusTransition,
+// including the FailureCode discipline: set on a failure status,
+// cleared by every transition to a non-failure one.
+func runStatusUpdate(status store.RunStatus, runErr string, code store.FailureCode, now time.Time) (bson.M, bson.M) {
 	set := bson.M{
 		"status":     status,
 		"updated_at": now,
 		"error":      runErr,
+	}
+	if status.CarriesFailureCode() {
+		set["failure_code"] = code
+	} else {
+		set["failure_code"] = ""
 	}
 	unset := bson.M{}
 	switch status {
@@ -651,6 +659,17 @@ func (s *Store) UpdateRunStatus(ctx context.Context, id string, status store.Run
 		// elapsed-time UI doesn't stay frozen.
 		unset["finished_at"] = ""
 	}
+	return set, unset
+}
+
+func (s *Store) UpdateRunStatus(ctx context.Context, id string, status store.RunStatus, runErr string) error {
+	return s.UpdateRunStatusCoded(ctx, id, status, runErr, "")
+}
+
+// UpdateRunStatusCoded is UpdateRunStatus carrying the typed failure
+// classification in the same $set.
+func (s *Store) UpdateRunStatusCoded(ctx context.Context, id string, status store.RunStatus, runErr string, code store.FailureCode) error {
+	set, unset := runStatusUpdate(status, runErr, code, time.Now().UTC())
 	update := bson.M{"$set": set, "$inc": bson.M{"version": 1}}
 	if len(unset) > 0 {
 		update["$unset"] = unset
@@ -666,25 +685,13 @@ func (s *Store) UpdateRunStatus(ctx context.Context, id string, status store.Run
 // since the caller's last read (concurrent transition by another
 // publisher, runner, or operator).
 func (s *Store) UpdateRunStatusIf(ctx context.Context, id string, status store.RunStatus, runErr string, expectedFrom []store.RunStatus) (bool, error) {
-	now := time.Now().UTC()
-	set := bson.M{
-		"status":     status,
-		"updated_at": now,
-		"error":      runErr,
-	}
-	unset := bson.M{}
-	switch status {
-	case store.RunStatusFinished, store.RunStatusFailed, store.RunStatusFailedResumable, store.RunStatusCancelled:
-		set["finished_at"] = now
-	case store.RunStatusQueued:
-		set["queued_at"] = now
-		unset["finished_at"] = ""
-	case store.RunStatusRunning:
-		set["error"] = ""
-		unset["finished_at"] = ""
-	case store.RunStatusPausedWaitingHuman:
-		unset["finished_at"] = ""
-	}
+	return s.UpdateRunStatusIfCoded(ctx, id, status, runErr, "", expectedFrom)
+}
+
+// UpdateRunStatusIfCoded is the CAS variant carrying the typed failure
+// classification — code and status land in one atomic UpdateOne.
+func (s *Store) UpdateRunStatusIfCoded(ctx context.Context, id string, status store.RunStatus, runErr string, code store.FailureCode, expectedFrom []store.RunStatus) (bool, error) {
+	set, unset := runStatusUpdate(status, runErr, code, time.Now().UTC())
 	update := bson.M{"$set": set, "$inc": bson.M{"version": 1}}
 	if len(unset) > 0 {
 		update["$unset"] = unset
@@ -726,6 +733,9 @@ func (s *Store) FailQueuedRunIfAttempt(ctx context.Context, id, runErr string, p
 			"updated_at":  now,
 			"finished_at": now,
 			"error":       runErr,
+			// Queue-park classification is follow-up; empty = unknown,
+			// and the field always reflects the LAST transition.
+			"failure_code": "",
 		},
 		"$inc": bson.M{"version": 1},
 	})
@@ -772,15 +782,16 @@ func (s *Store) PauseRun(ctx context.Context, id string, cp *store.Checkpoint) e
 // FailRunResumable writes the checkpoint, flips status to
 // failed_resumable, and records the failure reason. Resume can then
 // re-pick up at NodeID without replaying upstream work.
-func (s *Store) FailRunResumable(ctx context.Context, id string, cp *store.Checkpoint, runErr string) error {
+func (s *Store) FailRunResumable(ctx context.Context, id string, cp *store.Checkpoint, runErr string, code store.FailureCode) error {
 	now := time.Now().UTC()
 	update := bson.M{
 		"$set": bson.M{
-			"status":      store.RunStatusFailedResumable,
-			"checkpoint":  cp,
-			"error":       runErr,
-			"updated_at":  now,
-			"finished_at": now,
+			"status":       store.RunStatusFailedResumable,
+			"checkpoint":   cp,
+			"error":        runErr,
+			"failure_code": code,
+			"updated_at":   now,
+			"finished_at":  now,
 		},
 		"$inc": bson.M{"version": 1},
 	}
@@ -808,15 +819,16 @@ func (s *Store) FailRunResumable(ctx context.Context, id string, cp *store.Check
 // records the failure reason. The run is terminal — no auto-resume — but
 // the checkpoint is preserved so the operator can still rewind it
 // explicitly. Same atomic cancelled-guard as FailRunResumable.
-func (s *Store) FailRunTerminal(ctx context.Context, id string, cp *store.Checkpoint, runErr string) error {
+func (s *Store) FailRunTerminal(ctx context.Context, id string, cp *store.Checkpoint, runErr string, code store.FailureCode) error {
 	now := time.Now().UTC()
 	update := bson.M{
 		"$set": bson.M{
-			"status":      store.RunStatusFailed,
-			"checkpoint":  cp,
-			"error":       runErr,
-			"updated_at":  now,
-			"finished_at": now,
+			"status":       store.RunStatusFailed,
+			"checkpoint":   cp,
+			"error":        runErr,
+			"failure_code": code,
+			"updated_at":   now,
+			"finished_at":  now,
 		},
 		"$inc": bson.M{"version": 1},
 	}

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -785,6 +785,25 @@ var _ store.QueuedAttemptStore = (*Store)(nil)
 // §F T-33 layers an explicit version-conditional update on top; this
 // method is the simple "no contention" form used by the engine itself.
 func (s *Store) SaveCheckpoint(ctx context.Context, id string, cp *store.Checkpoint) error {
+	// Same pointer discipline as runStatusUpdate (mirrors the FS
+	// twin): a checkpoint carrying interaction evidence may only land
+	// while the run's status carries it — otherwise a stale in-memory
+	// copy is being replayed. The status read costs one projection and
+	// only fires when the checkpoint actually carries a pointer (the
+	// rare pause-adjacent writes; ordinary boundary writes skip it).
+	if cp != nil && (cp.InteractionID != "" || len(cp.InteractionQuestions) > 0) {
+		var cur struct {
+			Status store.RunStatus `bson:"status"`
+		}
+		if ferr := s.runs.FindOne(ctx, notDeleted(withTenantFilter(ctx, bson.M{"_id": id})),
+			options.FindOne().SetProjection(bson.M{"status": 1})).Decode(&cur); ferr == nil &&
+			!cur.Status.CarriesPausePointer() {
+			c := *cp
+			c.InteractionID = ""
+			c.InteractionQuestions = nil
+			cp = &c
+		}
+	}
 	update := bson.M{
 		"$set": bson.M{
 			"checkpoint": cp,

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -235,6 +235,16 @@ func (s *Store) SaveRun(ctx context.Context, r *store.Run) error {
 	if !r.Status.CarriesFailureCode() {
 		r.FailureCode = ""
 	}
+	// Same discipline for the pause pointer: a full-document write on a
+	// non-carrying status must not resurrect consumed interaction
+	// evidence (mirrors the FS twin).
+	if !r.Status.CarriesPausePointer() && r.Checkpoint != nil &&
+		(r.Checkpoint.InteractionID != "" || len(r.Checkpoint.InteractionQuestions) > 0) {
+		cp := *r.Checkpoint
+		cp.InteractionID = ""
+		cp.InteractionQuestions = nil
+		r.Checkpoint = &cp
+	}
 	_, err := s.runs.ReplaceOne(ctx, notDeleted(withTenantFilter(ctx, bson.M{"_id": r.ID})), r, options.Replace().SetUpsert(true))
 	if err != nil {
 		if mongo.IsDuplicateKeyError(err) {
@@ -645,6 +655,17 @@ func runStatusUpdate(status store.RunStatus, runErr string, code store.FailureCo
 		"error":      runErr,
 	}
 	unset := bson.M{}
+	// The pause pointer is a consumable (see store.CarriesPausePointer):
+	// a transition into a status that cannot truthfully carry it clears
+	// the interaction evidence off the surviving checkpoint. Dotted
+	// $unset is a no-op when the checkpoint (or field) is absent.
+	// Callers that $set the whole checkpoint document in the same
+	// update (failRunCheckpointed) must DROP these two keys and strip
+	// the value instead — Mongo rejects conflicting paths.
+	if !status.CarriesPausePointer() {
+		unset["checkpoint.interaction_id"] = ""
+		unset["checkpoint.interaction_questions"] = ""
+	}
 	if status.CarriesFailureCode() && code != "" {
 		set["failure_code"] = code
 	} else {
@@ -803,6 +824,19 @@ func (s *Store) PauseRun(ctx context.Context, id string, cp *store.Checkpoint) e
 // writing last, auto-resuming a run somebody deliberately stopped.
 func (s *Store) failRunCheckpointed(ctx context.Context, id string, status store.RunStatus, cp *store.Checkpoint, runErr string, code store.FailureCode, opName string) error {
 	set, unset := runStatusUpdate(status, runErr, code, time.Now().UTC())
+	// The whole-checkpoint $set below conflicts with the dotted pointer
+	// $unset — apply the same consumption to the VALUE instead. (Engine
+	// failure boundaries never set a pointer; this guards the preserved-
+	// checkpoint callers.)
+	delete(unset, "checkpoint.interaction_id")
+	delete(unset, "checkpoint.interaction_questions")
+	if cp != nil && !status.CarriesPausePointer() &&
+		(cp.InteractionID != "" || len(cp.InteractionQuestions) > 0) {
+		consumed := *cp
+		consumed.InteractionID = ""
+		consumed.InteractionQuestions = nil
+		cp = &consumed
+	}
 	set["checkpoint"] = cp
 	update := bson.M{"$set": set, "$inc": bson.M{"version": 1}}
 	if len(unset) > 0 {

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -635,12 +635,14 @@ func runStatusUpdate(status store.RunStatus, runErr string, code store.FailureCo
 		"updated_at": now,
 		"error":      runErr,
 	}
+	unset := bson.M{}
 	if status.CarriesFailureCode() {
 		set["failure_code"] = code
 	} else {
-		set["failure_code"] = ""
+		// $unset, not $set "": keeps the persisted shape identical to
+		// the FS twin's omitempty JSON.
+		unset["failure_code"] = ""
 	}
-	unset := bson.M{}
 	switch status {
 	case store.RunStatusFinished, store.RunStatusFailed, store.RunStatusFailedResumable, store.RunStatusCancelled:
 		set["finished_at"] = now
@@ -727,16 +729,11 @@ func (s *Store) FailQueuedRunIfAttempt(ctx context.Context, id, runErr string, p
 			bson.M{"queued_at": nil},
 		},
 	}))
+	// Queue-park classification is follow-up; the empty code reads as
+	// unknown, which is honest here.
+	set, _ := runStatusUpdate(store.RunStatusFailedResumable, runErr, "", now)
 	res, err := s.runs.UpdateOne(ctx, filter, bson.M{
-		"$set": bson.M{
-			"status":      store.RunStatusFailedResumable,
-			"updated_at":  now,
-			"finished_at": now,
-			"error":       runErr,
-			// Queue-park classification is follow-up; empty = unknown,
-			// and the field always reflects the LAST transition.
-			"failure_code": "",
-		},
+		"$set": set,
 		"$inc": bson.M{"version": 1},
 	})
 	if err != nil {
@@ -772,37 +769,30 @@ func (s *Store) PauseRun(ctx context.Context, id string, cp *store.Checkpoint) e
 			"checkpoint": cp,
 			"updated_at": now,
 		},
-		"$inc":   bson.M{"version": 1},
-		"$unset": bson.M{"finished_at": ""},
+		"$inc": bson.M{"version": 1},
+		// A paused run carries no failure classification — same
+		// discipline as runStatusUpdate, which this checkpoint-coupled
+		// write bypasses.
+		"$unset": bson.M{"finished_at": "", "failure_code": ""},
 	}
 	return mongoutil.UpdateOneChecked(ctx, s.runs, withTenantFilter(ctx, bson.M{"_id": id}), update,
 		fmt.Errorf("store/mongo: run %s not found", id), fmt.Sprintf("store/mongo: pause %s", id))
 }
 
-// FailRunResumable writes the checkpoint, flips status to
-// failed_resumable, and records the failure reason. Resume can then
-// re-pick up at NodeID without replaying upstream work.
-func (s *Store) FailRunResumable(ctx context.Context, id string, cp *store.Checkpoint, runErr string, code store.FailureCode) error {
-	now := time.Now().UTC()
-	update := bson.M{
-		"$set": bson.M{
-			"status":       store.RunStatusFailedResumable,
-			"checkpoint":   cp,
-			"error":        runErr,
-			"failure_code": code,
-			"updated_at":   now,
-			"finished_at":  now,
-		},
-		"$inc": bson.M{"version": 1},
-	}
-	// An operator cancel is terminal and outranks a resumable failure. The two
-	// race whenever an interruption and a cancel arrive together, and resumable
-	// would win simply by writing last — auto-resuming a run somebody
-	// deliberately stopped. Excluded in the FILTER so the guard is atomic.
+// failRunCheckpointed is the shared body of FailRunResumable and
+// FailRunTerminal: the shared transition $set (which owns the
+// failure-code discipline) plus the checkpoint, guarded by the atomic
+// cancelled-wins filter — an operator cancel is terminal and outranks a
+// failure racing in behind it, and the failure would win simply by
+// writing last, auto-resuming a run somebody deliberately stopped.
+func (s *Store) failRunCheckpointed(ctx context.Context, id string, status store.RunStatus, cp *store.Checkpoint, runErr string, code store.FailureCode, opName string) error {
+	set, _ := runStatusUpdate(status, runErr, code, time.Now().UTC())
+	set["checkpoint"] = cp
+	update := bson.M{"$set": set, "$inc": bson.M{"version": 1}}
 	filter := withTenantFilter(ctx, bson.M{"_id": id, "status": bson.M{"$ne": store.RunStatusCancelled}})
 	res, err := s.runs.UpdateOne(ctx, filter, update)
 	if err != nil {
-		return fmt.Errorf("store/mongo: fail resumable %s: %w", id, err)
+		return fmt.Errorf("store/mongo: %s %s: %w", opName, id, err)
 	}
 	if res.MatchedCount == 0 {
 		// Either the run is gone, or it is already cancelled and stays so.
@@ -815,35 +805,17 @@ func (s *Store) FailRunResumable(ctx context.Context, id string, cp *store.Check
 	return nil
 }
 
+// FailRunResumable writes the checkpoint, flips status to
+// failed_resumable, and records the failure reason + code. Resume can
+// then re-pick up at NodeID without replaying upstream work.
+func (s *Store) FailRunResumable(ctx context.Context, id string, cp *store.Checkpoint, runErr string, code store.FailureCode) error {
+	return s.failRunCheckpointed(ctx, id, store.RunStatusFailedResumable, cp, runErr, code, "fail resumable")
+}
+
 // FailRunTerminal writes the checkpoint, flips status to failed, and
-// records the failure reason. The run is terminal — no auto-resume — but
-// the checkpoint is preserved so the operator can still rewind it
-// explicitly. Same atomic cancelled-guard as FailRunResumable.
+// records the failure reason + code. The run is terminal — no
+// auto-resume — but the checkpoint is preserved so the operator can
+// still rewind it explicitly.
 func (s *Store) FailRunTerminal(ctx context.Context, id string, cp *store.Checkpoint, runErr string, code store.FailureCode) error {
-	now := time.Now().UTC()
-	update := bson.M{
-		"$set": bson.M{
-			"status":       store.RunStatusFailed,
-			"checkpoint":   cp,
-			"error":        runErr,
-			"failure_code": code,
-			"updated_at":   now,
-			"finished_at":  now,
-		},
-		"$inc": bson.M{"version": 1},
-	}
-	filter := withTenantFilter(ctx, bson.M{"_id": id, "status": bson.M{"$ne": store.RunStatusCancelled}})
-	res, err := s.runs.UpdateOne(ctx, filter, update)
-	if err != nil {
-		return fmt.Errorf("store/mongo: fail terminal %s: %w", id, err)
-	}
-	if res.MatchedCount == 0 {
-		// Either the run is gone, or it is already cancelled and stays so.
-		// Distinguish, since a genuine miss must still surface.
-		if _, gerr := s.LoadRun(ctx, id); gerr == nil {
-			return nil
-		}
-		return fmt.Errorf("store/mongo: run %s not found", id)
-	}
-	return nil
+	return s.failRunCheckpointed(ctx, id, store.RunStatusFailed, cp, runErr, code, "fail terminal")
 }

--- a/pkg/store/mongo/runs_retry_test.go
+++ b/pkg/store/mongo/runs_retry_test.go
@@ -69,7 +69,7 @@ func seedFailedResumable(t *testing.T, s *Store, runID string) {
 	if err := s.SaveRun(ctx, r); err != nil {
 		t.Fatalf("SaveRun: %v", err)
 	}
-	if err := s.FailRunResumable(ctx, runID, &store.Checkpoint{NodeID: "synthesize"}, "usage window exhausted"); err != nil {
+	if err := s.FailRunResumable(ctx, runID, &store.Checkpoint{NodeID: "synthesize"}, "usage window exhausted", ""); err != nil {
 		t.Fatalf("FailRunResumable: %v", err)
 	}
 }

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -463,9 +463,12 @@ type Run struct {
 	// the cause of the CURRENT failure status (failed /
 	// failed_resumable / cancelled), cleared by every transition to a
 	// non-failure status. Empty for legacy runs and for writers not
-	// yet classified: empty means UNKNOWN, never "no failure". See
-	// lifecycle.go (ADR-095) for the vocabulary and the open-world
-	// contract.
+	// yet classified: empty means UNKNOWN, never "no failure". One
+	// documented exception to "follows Error exactly": the cloud
+	// resume-publish rollback restores the PRIOR code under its own
+	// rollback text — the code classifies the restored state, not the
+	// rollback message. See lifecycle.go (ADR-095) for the vocabulary
+	// and the open-world contract.
 	FailureCode   FailureCode    `json:"failure_code,omitempty" bson:"failure_code,omitempty"`
 	Checkpoint    *Checkpoint    `json:"checkpoint,omitempty" bson:"checkpoint,omitempty"`
 	ArtifactIndex map[string]int `json:"artifact_index,omitempty" bson:"artifact_index,omitempty"` // node_id → latest version written

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -459,8 +459,16 @@ type Run struct {
 	UpdatedAt         time.Time      `json:"updated_at" bson:"updated_at"`
 	FinishedAt        *time.Time     `json:"finished_at,omitempty" bson:"finished_at,omitempty"`
 	Error             string         `json:"error,omitempty" bson:"error,omitempty"`
-	Checkpoint        *Checkpoint    `json:"checkpoint,omitempty" bson:"checkpoint,omitempty"`
-	ArtifactIndex     map[string]int `json:"artifact_index,omitempty" bson:"artifact_index,omitempty"` // node_id → latest version written
+	// FailureCode is the machine-readable classification of Error —
+	// the cause of the CURRENT failure status (failed /
+	// failed_resumable / cancelled), cleared by every transition to a
+	// non-failure status. Empty for legacy runs and for writers not
+	// yet classified: empty means UNKNOWN, never "no failure". See
+	// lifecycle.go (ADR-095) for the vocabulary and the open-world
+	// contract.
+	FailureCode   FailureCode    `json:"failure_code,omitempty" bson:"failure_code,omitempty"`
+	Checkpoint    *Checkpoint    `json:"checkpoint,omitempty" bson:"checkpoint,omitempty"`
+	ArtifactIndex map[string]int `json:"artifact_index,omitempty" bson:"artifact_index,omitempty"` // node_id → latest version written
 	// WorkDir is the absolute filesystem path the run executes in
 	// (the per-run git worktree when Worktree is true, otherwise the
 	// engine's resolved cwd at start). Persisted so studio surfaces

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -194,6 +194,13 @@ func healRun(r *Run) bool {
 		r.FinishedAt = nil
 		changed = true
 	}
+	// A failure code may only persist on a failure status (the
+	// transition machinery clears it, but a whole-document writer on
+	// an older binary can resurrect a stale one — heal on read).
+	if r.FailureCode != "" && !r.Status.CarriesFailureCode() {
+		r.FailureCode = ""
+		changed = true
+	}
 	return changed
 }
 
@@ -259,6 +266,13 @@ func (s *FilesystemRunStore) LoadRun(_ context.Context, id string) (*Run, error)
 // UpdateRunStatus updates the status (and optional error) of a run.
 // Protected by mu to prevent concurrent read-modify-write races.
 func (s *FilesystemRunStore) UpdateRunStatus(ctx context.Context, id string, status RunStatus, runErr string) error {
+	return s.UpdateRunStatusCoded(ctx, id, status, runErr, "")
+}
+
+// UpdateRunStatusCoded is UpdateRunStatus carrying the typed failure
+// classification; the code lands (or is cleared) in the same write as
+// the status.
+func (s *FilesystemRunStore) UpdateRunStatusCoded(ctx context.Context, id string, status RunStatus, runErr string, code FailureCode) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -266,7 +280,7 @@ func (s *FilesystemRunStore) UpdateRunStatus(ctx context.Context, id string, sta
 	if err != nil {
 		return err
 	}
-	return s.applyStatusTransition(r, status, runErr)
+	return s.applyStatusTransition(r, status, runErr, code)
 }
 
 // PatchRunSteering persists the live-steering state on run.json.
@@ -337,6 +351,13 @@ func (s *FilesystemRunStore) RecordNodeServed(_ context.Context, id, nodeID stri
 // changed=true on a successful write, false if the status had
 // drifted since the caller's last read.
 func (s *FilesystemRunStore) UpdateRunStatusIf(ctx context.Context, id string, status RunStatus, runErr string, expectedFrom []RunStatus) (bool, error) {
+	return s.UpdateRunStatusIfCoded(ctx, id, status, runErr, "", expectedFrom)
+}
+
+// UpdateRunStatusIfCoded is the CAS variant carrying the typed failure
+// classification — code and status land in one atomic write, never a
+// separate read-modify-write.
+func (s *FilesystemRunStore) UpdateRunStatusIfCoded(ctx context.Context, id string, status RunStatus, runErr string, code FailureCode, expectedFrom []RunStatus) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -354,7 +375,7 @@ func (s *FilesystemRunStore) UpdateRunStatusIf(ctx context.Context, id string, s
 	if !matched {
 		return false, nil
 	}
-	if err := s.applyStatusTransition(r, status, runErr); err != nil {
+	if err := s.applyStatusTransition(r, status, runErr, code); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -378,7 +399,9 @@ func (s *FilesystemRunStore) FailQueuedRunIfAttempt(_ context.Context, id, runEr
 	if r.Status != RunStatusQueued || (r.QueuedAt != nil && r.QueuedAt.After(publishedAt)) {
 		return false, nil
 	}
-	if err := s.applyStatusTransition(r, RunStatusFailedResumable, runErr); err != nil {
+	// Classification of the queue-park writer is follow-up work; the
+	// empty code reads as unknown, which is honest here.
+	if err := s.applyStatusTransition(r, RunStatusFailedResumable, runErr, ""); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -388,10 +411,18 @@ func (s *FilesystemRunStore) FailQueuedRunIfAttempt(_ context.Context, id, runEr
 // UpdateRunStatusIf: mutate r in-place (status, timestamps, terminal
 // finished_at / resume FinishedAt clear, checkpoint clear when leaving
 // paused state), then persist via writeRun. Caller must hold s.mu.
-func (s *FilesystemRunStore) applyStatusTransition(r *Run, status RunStatus, runErr string) error {
+// The failure code follows the same discipline as Error: set on a
+// failure status, cleared by every transition to a non-failure one —
+// which is what makes a stale code after a resume impossible.
+func (s *FilesystemRunStore) applyStatusTransition(r *Run, status RunStatus, runErr string, code FailureCode) error {
 	r.Status = status
 	r.UpdatedAt = time.Now().UTC()
 	r.Error = runErr
+	if status.CarriesFailureCode() {
+		r.FailureCode = code
+	} else {
+		r.FailureCode = ""
+	}
 	switch status {
 	case RunStatusFinished, RunStatusFailed, RunStatusFailedResumable, RunStatusCancelled:
 		t := r.UpdatedAt
@@ -456,7 +487,7 @@ func (s *FilesystemRunStore) PauseRun(ctx context.Context, id string, cp *Checkp
 // FailRunResumable atomically sets the checkpoint, error message, and status
 // to failed_resumable in a single write, enabling resume from the last
 // successfully completed node.
-func (s *FilesystemRunStore) FailRunResumable(ctx context.Context, id string, cp *Checkpoint, runErr string) error {
+func (s *FilesystemRunStore) FailRunResumable(ctx context.Context, id string, cp *Checkpoint, runErr string, code FailureCode) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -474,6 +505,7 @@ func (s *FilesystemRunStore) FailRunResumable(ctx context.Context, id string, cp
 	r.Checkpoint = cp
 	r.Status = RunStatusFailedResumable
 	r.Error = runErr
+	r.FailureCode = code
 	t := time.Now().UTC()
 	r.UpdatedAt = t
 	r.FinishedAt = &t
@@ -485,7 +517,7 @@ func (s *FilesystemRunStore) FailRunResumable(ctx context.Context, id string, cp
 // no auto-resume — but the checkpoint is preserved so the operator can still
 // rewind it explicitly (a run that reached the DSL fail node has a coherent
 // on-disk state worth recovering from).
-func (s *FilesystemRunStore) FailRunTerminal(ctx context.Context, id string, cp *Checkpoint, runErr string) error {
+func (s *FilesystemRunStore) FailRunTerminal(ctx context.Context, id string, cp *Checkpoint, runErr string, code FailureCode) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -501,6 +533,7 @@ func (s *FilesystemRunStore) FailRunTerminal(ctx context.Context, id string, cp 
 	r.Checkpoint = cp
 	r.Status = RunStatusFailed
 	r.Error = runErr
+	r.FailureCode = code
 	t := time.Now().UTC()
 	r.UpdatedAt = t
 	r.FinishedAt = &t

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -149,6 +149,16 @@ func (s *FilesystemRunStore) SaveRun(_ context.Context, r *Run) error {
 	if !r.Status.CarriesFailureCode() {
 		r.FailureCode = ""
 	}
+	// Same discipline for the pause pointer: a full-document write on a
+	// non-carrying status must not resurrect consumed interaction
+	// evidence.
+	if !r.Status.CarriesPausePointer() && r.Checkpoint != nil &&
+		(r.Checkpoint.InteractionID != "" || len(r.Checkpoint.InteractionQuestions) > 0) {
+		cp := *r.Checkpoint
+		cp.InteractionID = ""
+		cp.InteractionQuestions = nil
+		r.Checkpoint = &cp
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.writeRun(r)
@@ -461,6 +471,21 @@ func (s *FilesystemRunStore) applyStatusTransition(r *Run, status RunStatus, run
 			// message, whatever the caller passed.
 			r.Error = ""
 		}
+	}
+	// The pause pointer is a consumable: a transition into a status
+	// that cannot truthfully carry it (CarriesPausePointer) clears the
+	// interaction evidence — the checkpoint itself survives (below).
+	// Without this, a status-only cancel of a paused run kept the
+	// pointer, and a cloud resume (cancelled → queued, no answers)
+	// routed back into the pause path and crossed the human gate with
+	// an empty answer. Copy-on-write: failRunCheckpointed aliases the
+	// caller's checkpoint into r just before this tail.
+	if !status.CarriesPausePointer() && r.Checkpoint != nil &&
+		(r.Checkpoint.InteractionID != "" || len(r.Checkpoint.InteractionQuestions) > 0) {
+		cp := *r.Checkpoint
+		cp.InteractionID = ""
+		cp.InteractionQuestions = nil
+		r.Checkpoint = &cp
 	}
 	// A status transition NEVER destroys the checkpoint. The running
 	// claim used to clear it here — which, on a cloud pod, destroyed

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -480,14 +480,22 @@ func (s *FilesystemRunStore) PauseRun(ctx context.Context, id string, cp *Checkp
 	}
 	r.Checkpoint = cp
 	r.Status = RunStatusPausedWaitingHuman
+	// A paused run carries no failure classification — same discipline
+	// as the transition choke point, which this checkpoint-coupled
+	// write bypasses.
+	r.FailureCode = ""
 	r.UpdatedAt = time.Now().UTC()
 	return s.writeRun(r)
 }
 
-// FailRunResumable atomically sets the checkpoint, error message, and status
-// to failed_resumable in a single write, enabling resume from the last
-// successfully completed node.
-func (s *FilesystemRunStore) FailRunResumable(ctx context.Context, id string, cp *Checkpoint, runErr string, code FailureCode) error {
+// failRunCheckpointed is the shared body of FailRunResumable and
+// FailRunTerminal: the atomic cancelled-wins guard, the checkpoint, and
+// the ordinary transition tail (which owns the failure-code
+// discipline). An operator cancel is terminal and outranks a failure
+// racing in behind it — the two race whenever an interruption and a
+// cancel arrive together, and the failure would win simply by writing
+// last, auto-resuming a run somebody deliberately stopped.
+func (s *FilesystemRunStore) failRunCheckpointed(id string, status RunStatus, cp *Checkpoint, runErr string, code FailureCode) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -495,21 +503,18 @@ func (s *FilesystemRunStore) FailRunResumable(ctx context.Context, id string, cp
 	if err != nil {
 		return err
 	}
-	// An operator cancel is terminal and outranks a resumable failure. The
-	// two race whenever an interruption and a cancel arrive together, and
-	// resumable would win simply by writing last — auto-resuming a run
-	// somebody deliberately stopped. Cancelled stands.
 	if r.Status == RunStatusCancelled {
 		return nil
 	}
 	r.Checkpoint = cp
-	r.Status = RunStatusFailedResumable
-	r.Error = runErr
-	r.FailureCode = code
-	t := time.Now().UTC()
-	r.UpdatedAt = t
-	r.FinishedAt = &t
-	return s.writeRun(r)
+	return s.applyStatusTransition(r, status, runErr, code)
+}
+
+// FailRunResumable atomically sets the checkpoint, error message, and status
+// to failed_resumable in a single write, enabling resume from the last
+// successfully completed node.
+func (s *FilesystemRunStore) FailRunResumable(ctx context.Context, id string, cp *Checkpoint, runErr string, code FailureCode) error {
+	return s.failRunCheckpointed(id, RunStatusFailedResumable, cp, runErr, code)
 }
 
 // FailRunTerminal atomically sets the checkpoint, error message, and status
@@ -518,26 +523,7 @@ func (s *FilesystemRunStore) FailRunResumable(ctx context.Context, id string, cp
 // rewind it explicitly (a run that reached the DSL fail node has a coherent
 // on-disk state worth recovering from).
 func (s *FilesystemRunStore) FailRunTerminal(ctx context.Context, id string, cp *Checkpoint, runErr string, code FailureCode) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	r, err := s.loadRunRaw(id)
-	if err != nil {
-		return err
-	}
-	// Same guard as FailRunResumable: an operator cancel is terminal and
-	// outranks a failure racing in behind it. Cancelled stands.
-	if r.Status == RunStatusCancelled {
-		return nil
-	}
-	r.Checkpoint = cp
-	r.Status = RunStatusFailed
-	r.Error = runErr
-	r.FailureCode = code
-	t := time.Now().UTC()
-	r.UpdatedAt = t
-	r.FinishedAt = &t
-	return s.writeRun(r)
+	return s.failRunCheckpointed(id, RunStatusFailed, cp, runErr, code)
 }
 
 // AddWatchedIssues merges issueIDs into the run's WatchedIssueIDs set

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -511,6 +511,21 @@ func (s *FilesystemRunStore) SaveCheckpoint(ctx context.Context, id string, cp *
 	if err != nil {
 		return err
 	}
+	// Same pointer discipline as the transition tail: a checkpoint
+	// carrying interaction evidence may only land while the run's
+	// status carries it (CarriesPausePointer) — otherwise a stale
+	// in-memory copy is being replayed (the rewind shape: SaveRun
+	// normalizes its own copy, then SaveCheckpoint re-persists the
+	// caller's original). On a paused run the write-through is
+	// legitimate (bookkeeping updates on a live pause keep the
+	// pointer). Strip on a copy — the caller's object stays whole.
+	if cp != nil && !r.Status.CarriesPausePointer() &&
+		(cp.InteractionID != "" || len(cp.InteractionQuestions) > 0) {
+		c := *cp
+		c.InteractionID = ""
+		c.InteractionQuestions = nil
+		cp = &c
+	}
 	r.Checkpoint = cp
 	r.UpdatedAt = time.Now().UTC()
 	return s.writeRun(r)

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -140,6 +140,12 @@ func (s *FilesystemRunStore) SaveRun(_ context.Context, r *Run) error {
 	if err := s.guardNotDeleted(r.ID); err != nil {
 		return err
 	}
+	// A full-document write must not resurrect a failure code a copy
+	// loaded before a status change still carries (the rewind claim
+	// learned this the hard way) — normalize at the choke point.
+	if !r.Status.CarriesFailureCode() {
+		r.FailureCode = ""
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.writeRun(r)
@@ -194,9 +200,10 @@ func healRun(r *Run) bool {
 		r.FinishedAt = nil
 		changed = true
 	}
-	// A failure code may only persist on a failure status (the
-	// transition machinery clears it, but a whole-document writer on
-	// an older binary can resurrect a stale one — heal on read).
+	// A failure code may only persist on a failure status. The
+	// transition machinery clears it and SaveRun normalizes, so the
+	// remaining sources are historical rows written before those
+	// guards and hand-edited run.json — heal on read.
 	if r.FailureCode != "" && !r.Status.CarriesFailureCode() {
 		r.FailureCode = ""
 		changed = true
@@ -358,6 +365,13 @@ func (s *FilesystemRunStore) UpdateRunStatusIf(ctx context.Context, id string, s
 // classification — code and status land in one atomic write, never a
 // separate read-modify-write.
 func (s *FilesystemRunStore) UpdateRunStatusIfCoded(ctx context.Context, id string, status RunStatus, runErr string, code FailureCode, expectedFrom []RunStatus) (bool, error) {
+	if len(expectedFrom) == 0 {
+		// A CAS with no expected set is a bug at the caller (a derived
+		// slice gone empty) — refuse loudly instead of silently
+		// matching nothing (while the Mongo twin would write
+		// unconditionally).
+		return false, fmt.Errorf("store: update status if %s: empty expectedFrom", id)
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -439,6 +453,11 @@ func (s *FilesystemRunStore) applyStatusTransition(r *Run, status RunStatus, run
 		// FinishedAt — otherwise the studio's duration ticker uses the
 		// stale terminal timestamp and freezes mid-run.
 		r.FinishedAt = nil
+		if status == RunStatusRunning {
+			// Mirror the Mongo twin: a running run carries no failure
+			// message, whatever the caller passed.
+			r.Error = ""
+		}
 	}
 	// Clear checkpoint when leaving paused state (preserved for
 	// failed_resumable, cancelled, and failed). `failed` keeps its
@@ -482,8 +501,11 @@ func (s *FilesystemRunStore) PauseRun(ctx context.Context, id string, cp *Checkp
 	r.Status = RunStatusPausedWaitingHuman
 	// A paused run carries no failure classification — same discipline
 	// as the transition choke point, which this checkpoint-coupled
-	// write bypasses.
+	// write bypasses. FinishedAt likewise: a paused run is not over,
+	// and a stale terminal timestamp freezes the studio duration
+	// ticker (mirrors the Mongo twin's $unset).
 	r.FailureCode = ""
+	r.FinishedAt = nil
 	r.UpdatedAt = time.Now().UTC()
 	return s.writeRun(r)
 }

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -140,9 +140,12 @@ func (s *FilesystemRunStore) SaveRun(_ context.Context, r *Run) error {
 	if err := s.guardNotDeleted(r.ID); err != nil {
 		return err
 	}
-	// A full-document write must not resurrect a failure code a copy
-	// loaded before a status change still carries (the rewind claim
-	// learned this the hard way) — normalize at the choke point.
+	// Best-effort guard: a copy whose STATUS is already non-failure
+	// must not resurrect its failure code through this full-document
+	// write. A copy stale on the status itself still rewrites
+	// status+code together (the inherent SaveRun read-modify-write
+	// hazard — a version CAS is the real fix, follow-up); callers on
+	// that path re-stamp the fields by hand (see rewind.go).
 	if !r.Status.CarriesFailureCode() {
 		r.FailureCode = ""
 	}
@@ -459,15 +462,17 @@ func (s *FilesystemRunStore) applyStatusTransition(r *Run, status RunStatus, run
 			r.Error = ""
 		}
 	}
-	// Clear checkpoint when leaving paused state (preserved for
-	// failed_resumable, cancelled, and failed). `failed` keeps its
-	// checkpoint on purpose: a run that reached the DSL fail node is
-	// terminal (no auto-resume) but stays rewindable on an explicit
-	// operator action — its on-disk state is coherent, there is no
-	// technical reason to destroy the recovery point.
-	if status == RunStatusRunning || status == RunStatusFinished {
-		r.Checkpoint = nil
-	}
+	// A status transition NEVER destroys the checkpoint. The running
+	// claim used to clear it here — which, on a cloud pod, destroyed
+	// the resume point the moment a resumed run was claimed: every
+	// park writer that follows (drain, usage-cap, orphan sweeps,
+	// --force-stale) flips running→failed_resumable WITHOUT a
+	// checkpoint of its own, and the next resume restarted from the
+	// workflow entry. A fresh launch has no checkpoint to keep, a
+	// resumed run has everything to lose, and the engine overwrites it
+	// at its first node boundary anyway. Finished likewise keeps it:
+	// `iterion fork` reads a terminal parent's checkpoint for its
+	// outputs. Only DeleteRun and the rewind machinery may remove one.
 	return s.writeRun(r)
 }
 

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -1469,7 +1469,7 @@ func TestFailRunResumable(t *testing.T) {
 	mustCreateRun(t, s, "run-fr")
 
 	cp := &Checkpoint{NodeID: "node-z"}
-	if err := s.FailRunResumable(ctx, "run-fr", cp, "rate limited"); err != nil {
+	if err := s.FailRunResumable(ctx, "run-fr", cp, "rate limited", ""); err != nil {
 		t.Fatalf("FailRunResumable: %v", err)
 	}
 
@@ -1501,7 +1501,7 @@ func TestFailRunTerminal(t *testing.T) {
 	mustCreateRun(t, s, "run-ft")
 
 	cp := &Checkpoint{NodeID: "node-f"}
-	if err := s.FailRunTerminal(ctx, "run-ft", cp, "workflow reached fail node"); err != nil {
+	if err := s.FailRunTerminal(ctx, "run-ft", cp, "workflow reached fail node", ""); err != nil {
 		t.Fatalf("FailRunTerminal: %v", err)
 	}
 
@@ -1533,7 +1533,7 @@ func TestFailRunTerminalCancelledWins(t *testing.T) {
 		t.Fatalf("UpdateRunStatus: %v", err)
 	}
 
-	if err := s.FailRunTerminal(ctx, "run-ft-cancel", &Checkpoint{NodeID: "node-f"}, "late failure"); err != nil {
+	if err := s.FailRunTerminal(ctx, "run-ft-cancel", &Checkpoint{NodeID: "node-f"}, "late failure", ""); err != nil {
 		t.Fatalf("FailRunTerminal: %v", err)
 	}
 	r, err := s.LoadRun(ctx, "run-ft-cancel")
@@ -1712,7 +1712,7 @@ func TestFailRunResumableNeverOverwritesAnOperatorCancel(t *testing.T) {
 	if err := s.UpdateRunStatus(context.Background(), id, RunStatusCancelled, "operator cancelled"); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.FailRunResumable(context.Background(), id, &Checkpoint{NodeID: "n1"}, "interrupted"); err != nil {
+	if err := s.FailRunResumable(context.Background(), id, &Checkpoint{NodeID: "n1"}, "interrupted", ""); err != nil {
 		t.Fatalf("FailRunResumable on a cancelled run should be a no-op, got %v", err)
 	}
 	run, err := s.LoadRun(context.Background(), id)

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -1545,9 +1545,12 @@ func TestFailRunTerminalCancelledWins(t *testing.T) {
 	}
 }
 
-// UpdateRunStatus(failed) preserves an existing checkpoint, while the
-// running/finished transitions keep clearing it.
-func TestUpdateRunStatusFailedKeepsCheckpoint(t *testing.T) {
+// UpdateRunStatus preserves an existing checkpoint on EVERY transition:
+// a status change never destroys the recovery point (ADR-095) —
+// `iterion fork` reads a terminal parent's checkpoint, and the park
+// writers that follow a running claim rely on the resume point
+// surviving it.
+func TestUpdateRunStatusPreservesCheckpoint(t *testing.T) {
 	s := tmpStore(t)
 	ctx := context.Background()
 	mustCreateRun(t, s, "run-keep-cp")
@@ -1573,8 +1576,8 @@ func TestUpdateRunStatusFailedKeepsCheckpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadRun: %v", err)
 	}
-	if r.Checkpoint != nil {
-		t.Errorf("Checkpoint = %+v after finished transition, want cleared", r.Checkpoint)
+	if r.Checkpoint == nil || r.Checkpoint.NodeID != "node-a" {
+		t.Errorf("Checkpoint = %+v after finished transition, want preserved (fork reads it)", r.Checkpoint)
 	}
 }
 

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -1719,4 +1719,44 @@ func testPausePointerLifecycle(t *testing.T, s store.RunStore) {
 	if r.Checkpoint.InteractionID != "" {
 		t.Errorf("SaveRun resurrected a consumed pause pointer on a cancelled run: %q", r.Checkpoint.InteractionID)
 	}
+
+	// SaveCheckpoint must not resurrect it either: SaveRun normalizes
+	// its own COPY, so a caller that then re-persists its original
+	// checkpoint (the rewind shape: SaveRun(run) then SaveCheckpoint(cp))
+	// would replay the live pointer. Only PauseRun writes one.
+	if err := s.SaveCheckpoint(ctx, "pp-cancel", cp()); err != nil {
+		t.Fatal(err)
+	}
+	r, err = s.LoadRun(ctx, "pp-cancel")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Checkpoint.InteractionID != "" || len(r.Checkpoint.InteractionQuestions) > 0 {
+		t.Errorf("SaveCheckpoint resurrected the pause pointer (%q) — the rewind write shape replays it", r.Checkpoint.InteractionID)
+	}
+
+	// …but on a PAUSED run the write-through is legitimate: budget/
+	// bookkeeping updates on a live pause must keep the pointer, or the
+	// next resume cannot load its interaction.
+	r, err = s.LoadRun(ctx, "pp-queued")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// pp-queued is queued (carries) — reuse it: bump a counter and re-save.
+	if ok, cerr := s.UpdateRunStatusIf(ctx, "pp-queued", store.RunStatusPausedWaitingHuman, "",
+		[]store.RunStatus{store.RunStatusQueued}); cerr != nil || !ok {
+		t.Fatalf("back to paused: ok=%v err=%v", ok, cerr)
+	}
+	pausedCp := cp()
+	pausedCp.BudgetCostUSD = 0.95
+	if err := s.SaveCheckpoint(ctx, "pp-queued", pausedCp); err != nil {
+		t.Fatal(err)
+	}
+	r, err = s.LoadRun(ctx, "pp-queued")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Checkpoint.InteractionID != "I1" {
+		t.Errorf("SaveCheckpoint on a PAUSED run stripped the live pointer (%q) — the next resume cannot load its interaction", r.Checkpoint.InteractionID)
+	}
 }

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -1738,10 +1738,6 @@ func testPausePointerLifecycle(t *testing.T, s store.RunStore) {
 	// …but on a PAUSED run the write-through is legitimate: budget/
 	// bookkeeping updates on a live pause must keep the pointer, or the
 	// next resume cannot load its interaction.
-	r, err = s.LoadRun(ctx, "pp-queued")
-	if err != nil {
-		t.Fatal(err)
-	}
 	// pp-queued is queued (carries) — reuse it: bump a counter and re-save.
 	if ok, cerr := s.UpdateRunStatusIf(ctx, "pp-queued", store.RunStatusPausedWaitingHuman, "",
 		[]store.RunStatus{store.RunStatusQueued}); cerr != nil || !ok {

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -57,6 +57,8 @@ func RunWithOpts(t *testing.T, factory Factory, opts Opts) {
 	t.Run("QueuedAttemptCAS", func(t *testing.T) { testQueuedAttemptCAS(t, factory(t)) })
 	t.Run("FailRunTerminal", func(t *testing.T) { testFailRunTerminal(t, factory(t)) })
 	t.Run("FailureCodeLifecycle", func(t *testing.T) { testFailureCodeLifecycle(t, factory(t)) })
+	t.Run("TransitionSideEffects", func(t *testing.T) { testTransitionSideEffects(t, factory(t)) })
+	t.Run("TombstoneRefusesWriters", func(t *testing.T) { testTombstoneRefusesWriters(t, factory(t)) })
 	t.Run("EventSeqMonotone", func(t *testing.T) { testEventSeqMonotone(t, factory(t)) })
 	t.Run("EventSeqUnderConcurrency", func(t *testing.T) { testEventSeqConcurrent(t, factory(t)) })
 	t.Run("EventDataDecodeShape", func(t *testing.T) { testEventDataDecodeShape(t, factory(t)) })
@@ -1183,6 +1185,108 @@ func testFailureCodeLifecycle(t *testing.T, s store.RunStore) {
 	r, _ = s.LoadRun(ctx, "run_fc")
 	if r.FailureCode != "SOME_FUTURE_CODE_V9" {
 		t.Fatalf("unknown code mangled: %q", r.FailureCode)
+	}
+}
+
+// testTransitionSideEffects pins the transition side effects BOTH twins
+// must share (each was a live FS↔Mongo divergence): the running claim
+// clears checkpoint AND error, PauseRun clears FinishedAt and the code,
+// SaveRun normalizes a stale code, and an empty-expectedFrom CAS is a
+// loud error — never a silent no-op on one twin and an unconditional
+// write on the other.
+func testTransitionSideEffects(t *testing.T, s store.RunStore) {
+	t.Helper()
+	ctx := testCtx()
+	if _, err := s.CreateRun(ctx, "run_tse", "demo", nil); err != nil {
+		t.Fatal(err)
+	}
+	cp := &store.Checkpoint{NodeID: "n1"}
+	if err := s.FailRunResumable(ctx, "run_tse", cp, "boom", store.FailureInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	// The running claim drops the previous attempt's checkpoint on both
+	// twins — a pod crashing before its first own checkpoint must not
+	// resume from a stale node on one backend and the entry on the other.
+	if err := s.UpdateRunStatus(ctx, "run_tse", store.RunStatusRunning, "should not persist"); err != nil {
+		t.Fatal(err)
+	}
+	r, err := s.LoadRun(ctx, "run_tse")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Checkpoint != nil {
+		t.Errorf("running claim must clear the checkpoint, got node %q", r.Checkpoint.NodeID)
+	}
+	if r.Error != "" {
+		t.Errorf("running run must carry no failure message, got %q", r.Error)
+	}
+	// PauseRun: not over, so no terminal timestamp and no failure code.
+	if err := s.FailRunResumable(ctx, "run_tse", cp, "boom", store.FailureInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PauseRun(ctx, "run_tse", &store.Checkpoint{NodeID: "n2"}); err != nil {
+		t.Fatal(err)
+	}
+	r, _ = s.LoadRun(ctx, "run_tse")
+	if r.FinishedAt != nil {
+		t.Error("paused run kept a stale FinishedAt")
+	}
+	if r.FailureCode != "" {
+		t.Errorf("paused run kept a stale code %q", r.FailureCode)
+	}
+	// SaveRun normalizes: a copy loaded before a status change must not
+	// resurrect its failure code through the full-document write.
+	r.Status = store.RunStatusRunning
+	r.FailureCode = store.FailureUsageLimitBlocked
+	if err := s.SaveRun(ctx, r); err != nil {
+		t.Fatal(err)
+	}
+	r, _ = s.LoadRun(ctx, "run_tse")
+	if r.FailureCode != "" {
+		t.Errorf("SaveRun resurrected a stale code %q on a running run", r.FailureCode)
+	}
+	// Empty expectedFrom: a loud error on both twins (FS used to no-op
+	// silently while Mongo wrote unconditionally).
+	if _, err := s.UpdateRunStatusIf(ctx, "run_tse", store.RunStatusCancelled, "x", nil); err == nil {
+		t.Error("empty-expectedFrom CAS must be refused")
+	}
+	r, _ = s.LoadRun(ctx, "run_tse")
+	if r.Status == store.RunStatusCancelled {
+		t.Error("empty-expectedFrom CAS wrote anyway")
+	}
+}
+
+// testTombstoneRefusesWriters pins that a deleted run stays dead on both
+// twins: no status/checkpoint/pause/failure writer may mutate the
+// tombstone (Mongo used to write status, code and checkpoint onto the
+// skeleton and report success).
+func testTombstoneRefusesWriters(t *testing.T, s store.RunStore) {
+	t.Helper()
+	ctx := testCtx()
+	if _, err := s.CreateRun(ctx, "run_tomb", "demo", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DeleteRun(ctx, "run_tomb"); err != nil {
+		t.Fatal(err)
+	}
+	cp := &store.Checkpoint{NodeID: "n1"}
+	if err := s.FailRunResumable(ctx, "run_tomb", cp, "post-delete", store.FailureFailNode); err == nil {
+		t.Error("FailRunResumable succeeded on a tombstone")
+	}
+	if err := s.FailRunTerminal(ctx, "run_tomb", cp, "post-delete", ""); err == nil {
+		t.Error("FailRunTerminal succeeded on a tombstone")
+	}
+	if err := s.PauseRun(ctx, "run_tomb", cp); err == nil {
+		t.Error("PauseRun succeeded on a tombstone")
+	}
+	if err := s.SaveCheckpoint(ctx, "run_tomb", cp); err == nil {
+		t.Error("SaveCheckpoint succeeded on a tombstone")
+	}
+	if changed, _ := s.UpdateRunStatusIf(ctx, "run_tomb", store.RunStatusCancelled, "x", []store.RunStatus{store.RunStatusRunning, store.RunStatusFailed, store.RunStatusFailedResumable, store.RunStatusQueued, store.RunStatusFinished, store.RunStatusCancelled, store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator, "deleted"}); changed {
+		t.Error("status CAS wrote onto a tombstone")
+	}
+	if _, err := s.LoadRun(ctx, "run_tomb"); !errors.Is(err, store.ErrRunDeleted) {
+		t.Errorf("tombstone must read as ErrRunDeleted, got %v", err)
 	}
 }
 

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -56,6 +56,7 @@ func RunWithOpts(t *testing.T, factory Factory, opts Opts) {
 	t.Run("StatusTransitions", func(t *testing.T) { testStatusTransitions(t, factory(t)) })
 	t.Run("QueuedAttemptCAS", func(t *testing.T) { testQueuedAttemptCAS(t, factory(t)) })
 	t.Run("FailRunTerminal", func(t *testing.T) { testFailRunTerminal(t, factory(t)) })
+	t.Run("FailureCodeLifecycle", func(t *testing.T) { testFailureCodeLifecycle(t, factory(t)) })
 	t.Run("EventSeqMonotone", func(t *testing.T) { testEventSeqMonotone(t, factory(t)) })
 	t.Run("EventSeqUnderConcurrency", func(t *testing.T) { testEventSeqConcurrent(t, factory(t)) })
 	t.Run("EventDataDecodeShape", func(t *testing.T) { testEventDataDecodeShape(t, factory(t)) })
@@ -1112,6 +1113,66 @@ func testStatusTransitions(t *testing.T, s store.RunStore) {
 	}
 }
 
+// testFailureCodeLifecycle pins the ADR-095 persistence discipline on
+// BOTH store twins: the typed code lands in the same write as the
+// failure status (plain, coded-CAS and FailRun* forms), an UNKNOWN
+// code round-trips unharmed (open-world contract), and EVERY
+// transition to a non-failure status clears it — the invariant that
+// keeps a resumed run from lying about a past failure.
+func testFailureCodeLifecycle(t *testing.T, s store.RunStore) {
+	t.Helper()
+	ctx := testCtx()
+	if _, err := s.CreateRun(ctx, "run_fc", "demo", nil); err != nil {
+		t.Fatal(err)
+	}
+	// FailRunResumable carries the code atomically.
+	cp := &store.Checkpoint{NodeID: "n1"}
+	if err := s.FailRunResumable(ctx, "run_fc", cp, "quota window shut", store.FailureUsageLimitBlocked); err != nil {
+		t.Fatal(err)
+	}
+	r, err := s.LoadRun(ctx, "run_fc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.FailureCode != store.FailureUsageLimitBlocked {
+		t.Fatalf("FailureCode after FailRunResumable: got %q", r.FailureCode)
+	}
+	// Resume (any transition to running) clears code AND error together.
+	if err := s.UpdateRunStatus(ctx, "run_fc", store.RunStatusRunning, ""); err != nil {
+		t.Fatal(err)
+	}
+	r, _ = s.LoadRun(ctx, "run_fc")
+	if r.FailureCode != "" || r.Error != "" {
+		t.Fatalf("resume must clear code+error, got code=%q error=%q", r.FailureCode, r.Error)
+	}
+	// Coded CAS: code and status land in one write.
+	changed, err := s.UpdateRunStatusIfCoded(ctx, "run_fc", store.RunStatusCancelled, "run cancelled", store.FailureCancelled, []store.RunStatus{store.RunStatusRunning})
+	if err != nil || !changed {
+		t.Fatalf("coded CAS: changed=%v err=%v", changed, err)
+	}
+	r, _ = s.LoadRun(ctx, "run_fc")
+	if r.FailureCode != store.FailureCancelled {
+		t.Fatalf("FailureCode after coded CAS: got %q", r.FailureCode)
+	}
+	// Transition to queued (the cloud resume pre-flip) clears it too —
+	// the invariant covers queued, not only running.
+	if _, err := s.UpdateRunStatusIf(ctx, "run_fc", store.RunStatusQueued, "", []store.RunStatus{store.RunStatusCancelled}); err != nil {
+		t.Fatal(err)
+	}
+	r, _ = s.LoadRun(ctx, "run_fc")
+	if r.FailureCode != "" {
+		t.Fatalf("queued must clear the code, got %q", r.FailureCode)
+	}
+	// Open-world: an unknown, non-empty code survives persistence.
+	if err := s.UpdateRunStatusCoded(ctx, "run_fc", store.RunStatusFailed, "boom", store.FailureCode("SOME_FUTURE_CODE_V9")); err != nil {
+		t.Fatal(err)
+	}
+	r, _ = s.LoadRun(ctx, "run_fc")
+	if r.FailureCode != "SOME_FUTURE_CODE_V9" {
+		t.Fatalf("unknown code mangled: %q", r.FailureCode)
+	}
+}
+
 // testFailRunTerminal pins the checkpoint-preserving terminal failure on
 // BOTH store twins: status failed + checkpoint retained + FinishedAt set,
 // and the atomic cancelled-outranks guard. The DSL fail-node path depends
@@ -1122,7 +1183,7 @@ func testFailRunTerminal(t *testing.T, s store.RunStore) {
 		t.Fatal(err)
 	}
 	cp := &store.Checkpoint{NodeID: "node-f"}
-	if err := s.FailRunTerminal(testCtx(), "run_ft", cp, "workflow reached fail node"); err != nil {
+	if err := s.FailRunTerminal(testCtx(), "run_ft", cp, "workflow reached fail node", store.FailureFailNode); err != nil {
 		t.Fatalf("FailRunTerminal: %v", err)
 	}
 	r, err := s.LoadRun(testCtx(), "run_ft")
@@ -1149,7 +1210,7 @@ func testFailRunTerminal(t *testing.T, s store.RunStore) {
 	if err := s.UpdateRunStatus(testCtx(), "run_ft_cancel", store.RunStatusCancelled, "operator stop"); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.FailRunTerminal(testCtx(), "run_ft_cancel", cp, "late failure"); err != nil {
+	if err := s.FailRunTerminal(testCtx(), "run_ft_cancel", cp, "late failure", ""); err != nil {
 		t.Fatalf("FailRunTerminal on a cancelled run: %v", err)
 	}
 	r, err = s.LoadRun(testCtx(), "run_ft_cancel")

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -1204,9 +1204,13 @@ func testTransitionSideEffects(t *testing.T, s store.RunStore) {
 	if err := s.FailRunResumable(ctx, "run_tse", cp, "boom", store.FailureInterrupted); err != nil {
 		t.Fatal(err)
 	}
-	// The running claim drops the previous attempt's checkpoint on both
-	// twins — a pod crashing before its first own checkpoint must not
-	// resume from a stale node on one backend and the entry on the other.
+	// The running claim PRESERVES the previous attempt's checkpoint on
+	// both twins: the park writers that follow (drain, usage-cap,
+	// orphan sweeps) flip running→failed_resumable without a
+	// checkpoint of their own, and the resume point must survive that
+	// round trip — a pod dying between its claim and its first own
+	// checkpoint resumes from the previous attempt's node, never from
+	// the workflow entry.
 	if err := s.UpdateRunStatus(ctx, "run_tse", store.RunStatusRunning, "should not persist"); err != nil {
 		t.Fatal(err)
 	}
@@ -1214,8 +1218,8 @@ func testTransitionSideEffects(t *testing.T, s store.RunStore) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r.Checkpoint != nil {
-		t.Errorf("running claim must clear the checkpoint, got node %q", r.Checkpoint.NodeID)
+	if r.Checkpoint == nil || r.Checkpoint.NodeID != "n1" {
+		t.Errorf("running claim destroyed the resume point (checkpoint %v)", r.Checkpoint)
 	}
 	if r.Error != "" {
 		t.Errorf("running run must carry no failure message, got %q", r.Error)
@@ -1245,6 +1249,19 @@ func testTransitionSideEffects(t *testing.T, s store.RunStore) {
 	if r.FailureCode != "" {
 		t.Errorf("SaveRun resurrected a stale code %q on a running run", r.FailureCode)
 	}
+	// Finished keeps the checkpoint too: `iterion fork` reads a
+	// terminal parent's checkpoint for its upstream outputs.
+	if err := s.UpdateRunStatus(ctx, "run_tse", store.RunStatusFinished, ""); err != nil {
+		t.Fatal(err)
+	}
+	r, _ = s.LoadRun(ctx, "run_tse")
+	if r.Checkpoint == nil {
+		t.Error("finished transition destroyed the checkpoint a fork would read")
+	}
+	if err := s.UpdateRunStatus(ctx, "run_tse", store.RunStatusRunning, ""); err != nil {
+		t.Fatal(err)
+	}
+
 	// Empty expectedFrom: a loud error on both twins (FS used to no-op
 	// silently while Mongo wrote unconditionally).
 	if _, err := s.UpdateRunStatusIf(ctx, "run_tse", store.RunStatusCancelled, "x", nil); err == nil {

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -59,6 +59,7 @@ func RunWithOpts(t *testing.T, factory Factory, opts Opts) {
 	t.Run("FailureCodeLifecycle", func(t *testing.T) { testFailureCodeLifecycle(t, factory(t)) })
 	t.Run("TransitionSideEffects", func(t *testing.T) { testTransitionSideEffects(t, factory(t)) })
 	t.Run("TombstoneRefusesWriters", func(t *testing.T) { testTombstoneRefusesWriters(t, factory(t)) })
+	t.Run("PausePointerLifecycle", func(t *testing.T) { testPausePointerLifecycle(t, factory(t)) })
 	t.Run("EventSeqMonotone", func(t *testing.T) { testEventSeqMonotone(t, factory(t)) })
 	t.Run("EventSeqUnderConcurrency", func(t *testing.T) { testEventSeqConcurrent(t, factory(t)) })
 	t.Run("EventDataDecodeShape", func(t *testing.T) { testEventDataDecodeShape(t, factory(t)) })
@@ -1639,5 +1640,83 @@ func testUserMessagesInbox(t *testing.T, s store.RunStore) {
 	// Updating an unknown ID returns ErrQueuedMessageNotFound.
 	if err := s.UpdateQueuedMessageStatus(ctx, "run_um", "nonexistent", store.QueuedMessageStatusDelivered); err == nil {
 		t.Fatalf("Update nonexistent: expected error")
+	}
+}
+
+// testPausePointerLifecycle holds both backends to the pause-pointer
+// consumption contract (store.CarriesPausePointer): the checkpoint
+// survives every transition (ADR-095 §5), but its interaction evidence
+// is a consumable — cleared by any transition into a status that
+// cannot truthfully carry it, and PRESERVED on the paused → queued
+// cloud-resume hop, which the runner's queued router reads to route a
+// human-answers resume. Without the consumption, a status-only cancel
+// of a paused run left the pointer live and a cloud resume crossed the
+// human gate with an empty answer.
+func testPausePointerLifecycle(t *testing.T, s store.RunStore) {
+	ctx := testCtx()
+	cp := func() *store.Checkpoint {
+		return &store.Checkpoint{NodeID: "gate", InteractionID: "I1",
+			InteractionQuestions: map[string]any{"approve": "yes?"}}
+	}
+
+	// Cancel consumes: pause → cancelled clears the pointer, keeps the node.
+	if _, err := s.CreateRun(ctx, "pp-cancel", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PauseRun(ctx, "pp-cancel", cp()); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpdateRunStatus(ctx, "pp-cancel", store.RunStatusCancelled, "operator cancel"); err != nil {
+		t.Fatal(err)
+	}
+	r, err := s.LoadRun(ctx, "pp-cancel")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Checkpoint == nil || r.Checkpoint.NodeID != "gate" {
+		t.Fatalf("cancel must preserve the checkpoint anchor, got %+v", r.Checkpoint)
+	}
+	if r.Checkpoint.InteractionID != "" || len(r.Checkpoint.InteractionQuestions) > 0 {
+		t.Errorf("cancel left the pause pointer live (%q, %d questions) — a cloud resume would cross the human gate with an empty answer",
+			r.Checkpoint.InteractionID, len(r.Checkpoint.InteractionQuestions))
+	}
+
+	// The queued hop preserves: pause → queued (SubmitResume with answers)
+	// must keep the pointer — it is what routes the runner's Resume into
+	// the pause path where the answers are recorded.
+	if _, err := s.CreateRun(ctx, "pp-queued", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PauseRun(ctx, "pp-queued", cp()); err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := s.UpdateRunStatusIf(ctx, "pp-queued", store.RunStatusQueued, "",
+		[]store.RunStatus{store.RunStatusPausedWaitingHuman}); err != nil || !ok {
+		t.Fatalf("queued CAS: ok=%v err=%v", ok, err)
+	}
+	r, err = s.LoadRun(ctx, "pp-queued")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Checkpoint == nil || r.Checkpoint.InteractionID != "I1" {
+		t.Errorf("the paused → queued hop must PRESERVE the pause pointer (the runner routes the answers resume on it), got %+v", r.Checkpoint)
+	}
+
+	// SaveRun on a non-carrying status must not resurrect a consumed
+	// pointer through a full-document write.
+	r, err = s.LoadRun(ctx, "pp-cancel")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Checkpoint.InteractionID = "I-resurrected"
+	if err := s.SaveRun(ctx, r); err != nil {
+		t.Fatal(err)
+	}
+	r, err = s.LoadRun(ctx, "pp-cancel")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Checkpoint.InteractionID != "" {
+		t.Errorf("SaveRun resurrected a consumed pause pointer on a cancelled run: %q", r.Checkpoint.InteractionID)
 	}
 }

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -1163,6 +1163,19 @@ func testFailureCodeLifecycle(t *testing.T, s store.RunStore) {
 	if r.FailureCode != "" {
 		t.Fatalf("queued must clear the code, got %q", r.FailureCode)
 	}
+	// A checkpoint-coupled pause (which bypasses the transition choke
+	// point) still clears the classification: paused is not a failure.
+	if err := s.UpdateRunStatusCoded(ctx, "run_fc", store.RunStatusFailedResumable, "parked", store.FailureInterrupted); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PauseRun(ctx, "run_fc", &store.Checkpoint{NodeID: "n2"}); err != nil {
+		t.Fatal(err)
+	}
+	r, _ = s.LoadRun(ctx, "run_fc")
+	if r.FailureCode != "" {
+		t.Fatalf("pause must clear the code, got %q", r.FailureCode)
+	}
+
 	// Open-world: an unknown, non-empty code survives persistence.
 	if err := s.UpdateRunStatusCoded(ctx, "run_fc", store.RunStatusFailed, "boom", store.FailureCode("SOME_FUTURE_CODE_V9")); err != nil {
 		t.Fatal(err)

--- a/pkg/supervise/terminal_agreement_test.go
+++ b/pkg/supervise/terminal_agreement_test.go
@@ -1,0 +1,50 @@
+package supervise
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// TestTerminalAgreementWithRunStatus pins how the event-level terminal
+// vocabulary maps onto the canonical RunStatus contract (ADR-095), and
+// documents its two DELIBERATE divergences:
+//
+//   - a run parking `failed_resumable` emits run_failed — the event
+//     collapses final-failure and terminal-resumable, so a coordinator
+//     self-closes on both (correct: the supervised execution ended;
+//     a resume spawns a fresh coordinator).
+//   - run_paused is NOT terminal here (the run will continue) even
+//     though runview's node-row ExecStatus treats paused as settled for
+//     monotonicity — different question, different answer.
+func TestTerminalAgreementWithRunStatus(t *testing.T) {
+	// The event the engine emits when a run ENTERS each status.
+	// (finished/failed/cancelled/paused emitters live in
+	// pkg/runtime/run_failure.go + engine_exec.go; failed_resumable
+	// emits run_failed with resumable:true.)
+	statusEvent := map[store.RunStatus]store.EventType{
+		store.RunStatusFinished:           store.EventRunFinished,
+		store.RunStatusFailed:             store.EventRunFailed,
+		store.RunStatusFailedResumable:    store.EventRunFailed,
+		store.RunStatusCancelled:          store.EventRunCancelled,
+		store.RunStatusPausedWaitingHuman: store.EventRunPaused,
+		store.RunStatusPausedOperator:     store.EventRunPaused,
+	}
+	for st, evtType := range statusEvent {
+		evt := &store.Event{Type: evtType}
+		got := IsTerminal(evt)
+		want := st.IsTerminal() // the canonical verdict
+		if st == store.RunStatusFailedResumable && got != true {
+			t.Errorf("failed_resumable's run_failed must read terminal (coordinator self-close)")
+		}
+		if st.IsPaused() {
+			if got {
+				t.Errorf("run_paused must NOT be terminal for a coordinator (%s)", st)
+			}
+			continue
+		}
+		if got != want {
+			t.Errorf("supervise.IsTerminal(%s → %s) = %v, canonical IsTerminal = %v — undocumented divergence", st, evtType, got, want)
+		}
+	}
+}

--- a/pkg/trigger/runoutcome.go
+++ b/pkg/trigger/runoutcome.go
@@ -90,10 +90,13 @@ func BuildRunOutcome(ctx context.Context, rs store.RunStore, runID string, bodyE
 		case r.Status.IsPaused():
 			kind = KindRunPaused
 		}
-		// A paused run carries the node + pending interaction on its
+		// A PAUSED run carries the node + pending interaction on its
 		// checkpoint; surface both so a consumer can pinpoint the paused
-		// node and render the answer affordance.
-		if r.Checkpoint != nil {
+		// node and render the answer affordance. Status-gated: the
+		// checkpoint survives every transition now (ADR-095), so a
+		// finished run still carries a consumed pause pointer — a
+		// terminal outcome must not deep-link to an answered form.
+		if r.Checkpoint != nil && r.Status.IsPaused() {
 			nodeID = r.Checkpoint.NodeID
 			interactionID = r.Checkpoint.InteractionID
 		}

--- a/pkg/trigger/runoutcome.go
+++ b/pkg/trigger/runoutcome.go
@@ -93,10 +93,12 @@ func BuildRunOutcome(ctx context.Context, rs store.RunStore, runID string, bodyE
 		// The checkpoint's NodeID is the outcome's anchor — the paused
 		// node on a pause, the failing node on a failure ("The run
 		// failed at node X" in usernotify) — valid on every status. The
-		// interaction id is different: a consumable pause pointer,
-		// status-gated because the checkpoint survives every transition
-		// now (ADR-095) — a terminal outcome must not deep-link to an
-		// answered form.
+		// interaction id is different: a consumable pause pointer.
+		// Stricter than CarriesPausePointer (paused ∨ queued) on
+		// purpose — an outcome event for a queued run must not
+		// deep-link an answer form that is already in flight; the
+		// store's transition normalization is the enforcing layer,
+		// this gate is belt-and-braces.
 		if r.Checkpoint != nil {
 			nodeID = r.Checkpoint.NodeID
 			if r.Status.IsPaused() {

--- a/pkg/trigger/runoutcome.go
+++ b/pkg/trigger/runoutcome.go
@@ -90,15 +90,18 @@ func BuildRunOutcome(ctx context.Context, rs store.RunStore, runID string, bodyE
 		case r.Status.IsPaused():
 			kind = KindRunPaused
 		}
-		// A PAUSED run carries the node + pending interaction on its
-		// checkpoint; surface both so a consumer can pinpoint the paused
-		// node and render the answer affordance. Status-gated: the
-		// checkpoint survives every transition now (ADR-095), so a
-		// finished run still carries a consumed pause pointer — a
-		// terminal outcome must not deep-link to an answered form.
-		if r.Checkpoint != nil && r.Status.IsPaused() {
+		// The checkpoint's NodeID is the outcome's anchor — the paused
+		// node on a pause, the failing node on a failure ("The run
+		// failed at node X" in usernotify) — valid on every status. The
+		// interaction id is different: a consumable pause pointer,
+		// status-gated because the checkpoint survives every transition
+		// now (ADR-095) — a terminal outcome must not deep-link to an
+		// answered form.
+		if r.Checkpoint != nil {
 			nodeID = r.Checkpoint.NodeID
-			interactionID = r.Checkpoint.InteractionID
+			if r.Status.IsPaused() {
+				interactionID = r.Checkpoint.InteractionID
+			}
 		}
 	}
 

--- a/pkg/trigger/runoutcome_node_test.go
+++ b/pkg/trigger/runoutcome_node_test.go
@@ -22,8 +22,17 @@ func TestRunOutcomeKeepsFailureNodeAndDropsInteraction(t *testing.T) {
 	if _, err := s.CreateRun(ctx, "r-fail", "wf", nil); err != nil {
 		t.Fatal(err)
 	}
-	cp := &store.Checkpoint{NodeID: "implement", InteractionID: "I-stale"}
-	if err := s.FailRunResumable(ctx, "r-fail", cp, "boom at implement", store.FailureExecutionFailed); err != nil {
+	// Real genealogy for a failed run that once held a pointer: a pause,
+	// then a status-only park — the transition normalization
+	// (store.CarriesPausePointer) consumes the pointer on the way, so
+	// the outcome's interaction gate below is belt-and-braces.
+	cp := &store.Checkpoint{NodeID: "implement", InteractionID: "I-stale",
+		InteractionQuestions: map[string]any{"q": "?"}}
+	if err := s.PauseRun(ctx, "r-fail", cp); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpdateRunStatusCoded(ctx, "r-fail", store.RunStatusFailedResumable,
+		"boom at implement", store.FailureExecutionFailed); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/trigger/runoutcome_node_test.go
+++ b/pkg/trigger/runoutcome_node_test.go
@@ -1,0 +1,37 @@
+package trigger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// A FAILED run's checkpoint node is the failure anchor, not stale pause
+// evidence. usernotify renders it ("The run failed at node X"), so gating
+// nodeID on IsPaused() alongside interactionID would silently degrade
+// every run-failed push to the generic body. Only the interaction id is a
+// consumable pause pointer — that one must NOT ride a terminal outcome.
+func TestRunOutcomeKeepsFailureNodeAndDropsInteraction(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	if _, err := s.CreateRun(ctx, "r-fail", "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	cp := &store.Checkpoint{NodeID: "implement", InteractionID: "I-stale"}
+	if err := s.FailRunResumable(ctx, "r-fail", cp, "boom at implement", store.FailureExecutionFailed); err != nil {
+		t.Fatal(err)
+	}
+
+	ev := BuildRunOutcome(ctx, s, "r-fail", nil)
+	if node, _ := ev.Payload["node_id"].(string); node != "implement" {
+		t.Errorf("run-failed outcome carries node_id=%q, want %q — usernotify renders \"The run failed at node X\" and falls back to the generic body without it", node, "implement")
+	}
+	if inter, ok := ev.Payload["interaction_id"]; ok {
+		t.Errorf("run-failed outcome carries interaction_id=%v — a non-paused outcome must not deep-link to an interaction", inter)
+	}
+}

--- a/pkg/worktreepool/classify.go
+++ b/pkg/worktreepool/classify.go
@@ -948,12 +948,7 @@ func runLockHeld(storeDir, runID string) bool {
 // reclaim. Spared by default, released by --include-resumable, which is
 // the same opt-in `runs prune` requires before it touches them.
 func isResumable(st store.RunStatus) bool {
-	switch st {
-	case store.RunStatusFailedResumable, store.RunStatusCancelled,
-		store.RunStatusPausedOperator, store.RunStatusPausedWaitingHuman:
-		return true
-	}
-	return false
+	return st.CanOperatorResume()
 }
 
 func isPausedResumable(st store.RunStatus) bool {

--- a/studio/src/api/runs/types.ts
+++ b/studio/src/api/runs/types.ts
@@ -65,6 +65,8 @@ export interface RunSummary {
   updated_at: string;
   finished_at?: string;
   error?: string;
+  // Machine-readable classification of `error` (ADR-095); absent = unknown.
+  failure_code?: string;
   active: boolean;
   // When a failed_resumable run will be resumed automatically, once the
   // provider quota window that killed it reopens. Absent when no retry is
@@ -271,6 +273,8 @@ export interface RunHeader {
   updated_at: string;
   finished_at?: string;
   error?: string;
+  // Machine-readable classification of `error` (ADR-095); absent = unknown.
+  failure_code?: string;
   // Typed for the budget-consumption + paused-node fields the UI reads;
   // the rest of the checkpoint stays opaque. See RunCheckpoint.
   checkpoint?: RunCheckpoint;

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5452,6 +5452,7 @@ export interface components {
             current_run_start?: string;
             deployment?: components["schemas"]["DeploymentReport"];
             error?: string;
+            failure_code?: string;
             fallbacks_used?: components["schemas"]["FallbackUsage"][];
             file_path?: string;
             final_branch?: string;
@@ -5533,6 +5534,7 @@ export interface components {
             /** Format: date-time */
             created_at: string;
             error?: string;
+            failure_code?: string;
             file_path?: string;
             final_branch?: string;
             final_branch_error?: string;


### PR DESCRIPTION
Phase 2 of the cloud-reliability programme (card native:f26342ab). Design + full contract: [docs/adr/095-terminal-state-contract-and-failure-taxonomy.md](docs/adr/095-terminal-state-contract-and-failure-taxonomy.md).

## What ships

- **Policy predicates on `store.RunStatus`** ([pkg/store/lifecycle.go](pkg/store/lifecycle.go)) — IsFinalSuccess/IsFinalFailure/IsTerminalResumable/CanOperatorResume/RequiresResumeAnswers/CanAutoResume/CountsAgainstLaunchLimit/CanBeCancelled/CarriesFailureCode/CarriesPausePointer — with the policy-bearing status switches across server/runview/cli/notify/worktreepool/operatormcp migrated onto them, and an AST **negative-space guard** over 11 packages (function-anchored allowlist) so a new status switch must either use a predicate or justify itself.
- **`Run.FailureCode` persisted** atomically with the status by BOTH store twins (set on failure statuses, cleared by every non-failure transition, open-world: empty = unknown, never free). `runtime.ErrorCode` becomes a type alias of `store.FailureCode`; engine failure paths, usage-cap CAS, runview orphan/interrupt reconcile all write typed causes. Alerts (OpsDispatcher episode keys, webhook text, errtrack) and API projections carry it.
- **The checkpoint contract (§5): a status transition NEVER destroys the checkpoint** — the running claim used to clear it, which on a cloud pod destroyed the resume point the moment a resumed run was claimed (5 park writers pass no checkpoint of their own → resume from entry). Only DeleteRun and the rewind machinery remove one.
- **The pause pointer is a consumable** (`CarriesPausePointer` = paused ∨ queued): consumed by the resume that uses it (one choke point: `claimForResume` claims AND consumes, both resume paths), and by every transition into a status that cannot carry it — closing a pre-existing human-gate bypass where a cancelled-then-cloud-resumed run crossed its gate with an empty answer. The queued hop preserves (the runner's router reads it to route the answers resume). All three checkpoint writers (transition tail, SaveRun, SaveCheckpoint) hold the discipline on both twins, conformance-proven (`PausePointerLifecycle`, `FailureCodeLifecycle`, `TransitionSideEffects`, `TombstoneRefusesWriters`), every canary mutation-proven red.

## Review

`::loop` — 6 adversarial rounds (opus, executed proofs, mutation-tested canaries), each round attacking the previous round's fixes: t1 16 findings (5 high) · t2 8 (1 CRITICAL — the checkpoint-destroying claim, contract inverted) · t3 5 (pause-pointer consumption) · t4 6 (3 high — review-gate twin, positional oracles, node_id gate) · t5 4 (1 high — the cancelled-run gate bypass) · t6 STERILE (0 high/crit; 2 latent med fixed). Revi being down, this loop + the sterile close is the gate (régime spécial arbitré par l'opérateur).

Follow-up cards on the local board (`source:adr095-loop`): remaining park writers, persisted-code readers, SaveRun version-CAS, cloud review-gate queued claim, ops hygiene batch.

## Compat

- `failure_code` / checkpoint fields are advisory additions — no queue schema bump, no migration; an old binary's full-doc SaveRun drops them (accepted, ADR §4 — deploy server+runner together).
- `openapi.json` regenerated in-branch; studio schema untouched beyond generated types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)