### PR TITLE
feat(webhooks): an explicitly named review identity lights the re-request lane on GitHub

### DIFF
--- a/docs/forge-integrations.md
+++ b/docs/forge-integrations.md
@@ -164,10 +164,14 @@ Both write routes also carry the repo's **operator-owned** settings —
 `launch_vars`, `overlap`, `hold_labels`, `label_allowlist`,
 `auto_fix_on_gate_failure`. They live on the integration because provisioning
 rebuilds the whole webhook config from the manifests: anything set only on that
-config is wiped by the next enable/update. Omitting a field keeps the stored
-value; an explicit empty list clears it. `label_allowlist` is the one that
-decides which freshly-applied issue label dispatches the implementer (empty =
-any label does).
+config is wiped by the next enable/update — **except** the operator-only
+webhook fields with no integration half (`review_request_logins`,
+`authorized_repliers`, `key_overrides`, rate/monthly limits, …), which the
+rebuild carries forward from the previous config precisely because the webhook
+PATCH is their only storage (see `carryOperatorWebhookSettings`). Omitting a
+field keeps the stored value; an explicit empty list clears it.
+`label_allowlist` is the one that decides which freshly-applied issue label
+dispatches the implementer (empty = any label does).
 
 ## Provider support
 

--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -183,15 +183,20 @@ What the pin disarms, end to end:
   `review_on_sync: false` PATCH on the webhook config (which the next
   provision's derivation would overwrite).
 
-Re-review stays on demand through two gestures, both exempt from the
-hold-label pause (a deliberate manual trigger, like any `/command`):
+Re-review stays on demand through two gestures — with different hold-label
+postures:
 
-- a **`/revi` comment** on the MR/PR;
+- a **`/revi` comment** on the MR/PR — exempt from the hold-label pause, like
+  any `/command`: a comment is unambiguously a deliberate human trigger;
 - the forge-native **"Re-request review" button** on iterion's bot reviewer
-  (see [webhooks.md](webhooks.md#re-request-review)). On GitLab the publish
-  step self-assigns the bot as an MR reviewer after each review precisely so
-  this button exists; each click re-reviews the current head, even twice on
-  the same head.
+  (see [webhooks.md](webhooks.md#re-request-review)) — **vetoed by the hold
+  label**: the forge emits the same event for a CODEOWNERS auto-request,
+  which needs no permission from the requester and carries nothing to tell it
+  from a click, so the lane cannot claim a command's deliberateness (the
+  rationale lives with the lane in webhooks.md). On GitLab the publish step
+  self-assigns the bot as an MR reviewer after each review precisely so this
+  button exists; each click re-reviews the current head, even twice on the
+  same head.
 
 Removing the pin restores the gating posture: the next provision re-derives
 `review_on_sync: true` from the `statuses` scope.

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -262,30 +262,49 @@ the MR/PR's current head:
   That identity is the **App bot login only** (`<app_slug>[bot]`): a
   PAT/OAuth connection's account may be a HUMAN's, and treating it as the
   bot would turn an ordinary human-to-human review request into an LLM
-  launch (and disarm the anti-loop actor guard). In practice the lane is
-  therefore **currently inert on both**: a GitHub App cannot be a PR
-  reviewer at all (forge restriction), and a Forgejo connection never
-  carries an App slug (there is no Forgejo App kind) — `/revi` is the
-  on-demand path there. The wiring exists so a future bot-account
-  connection kind lights it up without touching the handlers; **GitLab is
-  the button forge today.**
+  launch (and disarm the anti-loop actor guard). A GitHub App cannot be a
+  PR reviewer at all (forge restriction) and a Forgejo connection carries
+  no App slug (there is no Forgejo App kind), so the derived identity
+  leaves the lane inert on both.
+
+  **`review_request_logins` is what lights it up.** The operator names the
+  review identity explicitly on the webhook, and those logins join the same
+  set both halves of the guard read — so the lane answers their request AND
+  the actor guard recognises their own writes. On GitHub that identity has
+  to be a **User account reached through a `pat` connection**: only a user
+  can be a requested reviewer, and the review must be POSTED by that same
+  account for the forge to clear the pending request and re-arm the button.
+  Nothing is derived from the connection for this — see the config table.
 
 Semantics, shared with `/revi` (deliberate manual gesture):
 
-- **exempt from the hold-label pause** — the label pauses *automation*;
-- **repeatable** — each click is its own delivery (the idempotency key is
-  salted with the MR/PR `updated_at`), so re-requesting twice on the same
-  head reviews twice; forge redeliveries of the same click stay deduped;
+- **NOT exempt from the hold-label pause** — unlike `/revi`. The forge
+  emits the same event for a CODEOWNERS auto-request, which needs no
+  permission from the requester and carries no field distinguishing it
+  from a click ([about-code-owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)),
+  so the lane cannot claim a command's deliberateness — and the label's
+  promise is that it freezes *every* automation on one PR;
+- **repeatable once the head's review has FINISHED** — such a click is its
+  own delivery (the idempotency key is then salted with the MR/PR
+  `updated_at`), so re-requesting twice on the same head reviews twice. On
+  GitHub a click landing while a review of that head is still in flight
+  collapses onto it instead (the CODEOWNERS auto-request dedupe), and a
+  click on a head no review has claimed yet takes the ordinary per-head
+  key; GitLab keeps the unconditional salt (its lane only arms on an
+  `update` action, so an open-time reviewer assignment never double-fires);
+  forge redeliveries of the same click stay deduped;
 - **open PRs/MRs only** — reviewer edits arrive freely on closed/merged
   ones and never burn a run;
 - **replier-gated like `/revi`** — the click is authorized through the
   same `authorized_repliers` allowlist / `min_replier_role` project-role
-  gate (default developer) as every other manual trigger. "The forge
-  gates reviewer edits" is not enough: GitLab lets an MR AUTHOR edit
-  their own MR's reviewers without holding a project role, which would
-  hand a fork contributor a repeatable trigger. An unauthorized click is
-  demoted — the delivery rides whatever automatic lane still admits it
-  (with the hold label honoured) or is filtered;
+  gate (default developer) as every other manual trigger, on every
+  provider. "The forge gates reviewer edits" is not enough: GitLab lets
+  an MR AUTHOR edit their own MR's reviewers without holding a project
+  role, and GitHub grants "request review" at the **Triage** role —
+  below the write floor the command gate enforces — either of which
+  would hand an under-privileged account a repeatable trigger. An
+  unauthorized click is demoted — the delivery rides whatever automatic
+  lane still admits it (with the hold label honoured) or is filtered;
 - **never self-triggering** — a reviewers change whose *actor* is the bot
   itself (the self-assign echoing back) is filtered
   ([pkg/server/webhooks_common.go:isIterionBotReviewRequest](../pkg/server/webhooks_common.go)).
@@ -578,6 +597,7 @@ are accepted by `POST` / `PATCH`:
 
 | Key | Default | Meaning |
 |---|---|---|
+| `review_request_logins` | *(empty)* | Logins whose `review_requested` / reviewer-add delivery relaunches the reviewer, IN ADDITION to the identity derived from the connection. **This is what makes the lane work on GitHub**, where only a User account can be a requested reviewer: name a bot user reached through a `pat` connection, so the review is posted by that same account and the forge re-arms the button. Explicit only — never derived from a connection's account, which on the PAT path is typically a maintainer's own, and deriving would turn every reviewer ping addressed to that human into a bot run. The logins join the shared identity set, so the anti-loop actor guard recognises them too. |
 | `review_on_sync` | `false` | Re-review on each push to a PR head, so a required status re-evaluates on the revision that fixed it. Required for a blocking [merge gate](merge-gate.md). |
 | `overlap` | *(empty = allow)* | Concurrency policy for runs this webhook launches, keyed on (webhook, subject, bot) — one PR's reviews, not the whole repo's. `allow` / `skip` / `supersede`. **Empty means allow**, not `pkg/schedgate`'s `skip` default: a webhook is event-driven and every delivery has always launched, so the gate applies only when explicitly set. `supersede` is the one worth setting alongside `review_on_sync` — three pushes in two minutes otherwise launch three runs, two of which review dead commits. |
 | `operator_launch_vars` | — | Vars layered **between** the handler-derived base and a bot's own rule vars (precedence: base < bot rule vars < these). Kept separate from `launch_vars` so co-enabling two bots that declare the same key does not make them share whichever value won. |

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -287,12 +287,16 @@ Semantics, shared with `/revi` (deliberate manual gesture):
 - **repeatable once the head's review has FINISHED** — such a click is its
   own delivery (the idempotency key is then salted with the MR/PR
   `updated_at`), so re-requesting twice on the same head reviews twice. On
-  GitHub a click landing while a review of that head is still in flight
-  collapses onto it instead (the CODEOWNERS auto-request dedupe), and a
+  GitHub a click landing while EVERY fanned-out bot's review of that head is
+  still in flight collapses onto them instead (the CODEOWNERS auto-request
+  dedupe) — unless the webhook's `overlap` is `supersede`, which takes
+  precedence: the click salts, the stale run is cancelled and the fresh one
+  replaces it ("newest request wins" is the operator's explicit choice). A
   click on a head no review has claimed yet takes the ordinary per-head
-  key; GitLab keeps the unconditional salt (its lane only arms on an
-  `update` action, so an open-time reviewer assignment never double-fires);
-  forge redeliveries of the same click stay deduped;
+  key. GitLab keeps the unconditional salt (its lane only arms on an
+  `update` action, so the open itself never double-fires; an auto-assign
+  arriving as a follow-up update salts per click, bounded by the overlap
+  policy); forge redeliveries of the same click stay deduped;
 - **open PRs/MRs only** — reviewer edits arrive freely on closed/merged
   ones and never burn a run;
 - **replier-gated like `/revi`** — the click is authorized through the

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -1027,6 +1027,9 @@ func managedSecretName(conn *Connection) string {
 // Deliberately NOT carried: the bot scope (BotIDs / WildcardBots /
 // DefaultBotID / BotRules / CommandMap), the allowlists and the routing table —
 // those are what a provision exists to recompute from the enabled bots.
+// Name is provision-owned (provisionedWebhookName) and LaunchVars threads
+// through the RepoIntegration (the operator-settings resolution above), so
+// neither belongs here.
 //
 // INVARIANT: a field listed here must have NO ProvisionRequest input. The
 // carry is an unconditional overwrite placed after the literal, so the day one
@@ -1036,6 +1039,13 @@ func managedSecretName(conn *Connection) string {
 // exceptions, each commented in place: RateLimit (zero means never set) and
 // MinReplierRole (a provision-derived floor merged stricter-of).
 func carryOperatorWebhookSettings(cfg *webhooks.Config, prev webhooks.Config) {
+	// Enabled is the operator's per-repo kill switch (PATCH {"enabled":false}
+	// → every inbound delivery answers 410) — a re-provision must not
+	// silently re-arm the lanes it paused. Safe to carry unconditionally:
+	// this function only runs when a previous config exists, so the
+	// provision literal's Enabled:true still governs first creation, and
+	// re-enabling goes through the same PATCH that paused it.
+	cfg.Enabled = prev.Enabled
 	cfg.ReviewRequestLogins = prev.ReviewRequestLogins
 	cfg.AuthorizedRepliers = prev.AuthorizedRepliers
 	cfg.KeyOverrides = prev.KeyOverrides

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -565,6 +565,7 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		if hasPrevCfg {
 			cfg.CreatedAt = prevCfg.CreatedAt
 			cfg.CreatedBy = prevCfg.CreatedBy
+			carryOperatorWebhookSettings(&cfg, prevCfg)
 		}
 		cfg.RotatedAt = &now
 		if err := o.Webhooks.Update(ctx, cfg); err != nil {
@@ -1009,6 +1010,85 @@ func managedSecretName(conn *Connection) string {
 		short = short[:8]
 	}
 	return "forge_" + string(conn.Provider) + "_" + short
+}
+
+// carryOperatorWebhookSettings preserves the operator-settable webhook fields
+// this provision does NOT stamp. Re-provisioning rebuilds the whole Config
+// literal, so a field that is neither stamped from the integration nor carried
+// here is silently reset the next time any bot is enabled or disabled on the
+// repo — and the webhook PATCH endpoint that sets these has no ProvisionedBy
+// guard, so they are settable precisely on the managed configs this rebuilds.
+//
+// It is the complement of the operator-settings resolution above (LaunchVars /
+// Overlap / HoldLabels / LabelAllowlist), which threads through the
+// RepoIntegration because the provisioning API can also set those. These have
+// no integration half: preserving the previous config IS their storage.
+//
+// Deliberately NOT carried: the bot scope (BotIDs / WildcardBots /
+// DefaultBotID / BotRules / CommandMap), the allowlists and the routing table —
+// those are what a provision exists to recompute from the enabled bots.
+//
+// INVARIANT: a field listed here must have NO ProvisionRequest input. The
+// carry is an unconditional overwrite placed after the literal, so the day one
+// of these becomes settable through the provisioning API, it has to move to
+// the operator-settings resolution above (the LaunchVars / HoldLabels shape) or
+// the carry would silently override the caller. Two fields are CONDITIONAL
+// exceptions, each commented in place: RateLimit (zero means never set) and
+// MinReplierRole (a provision-derived floor merged stricter-of).
+func carryOperatorWebhookSettings(cfg *webhooks.Config, prev webhooks.Config) {
+	cfg.ReviewRequestLogins = prev.ReviewRequestLogins
+	cfg.AuthorizedRepliers = prev.AuthorizedRepliers
+	cfg.KeyOverrides = prev.KeyOverrides
+	cfg.MonthlyCallLimit = prev.MonthlyCallLimit
+	cfg.AutoImplementOnOpen = prev.AutoImplementOnOpen
+	cfg.BranchImproveAsPR = prev.BranchImproveAsPR
+	cfg.BlockForkPRs = prev.BlockForkPRs
+	cfg.RetryUsageWindow = prev.RetryUsageWindow
+	cfg.RetryMaxAttempts = prev.RetryMaxAttempts
+	cfg.RetryMaxWait = prev.RetryMaxWait
+	cfg.RetryJitter = prev.RetryJitter
+	// The liveness stamp is written by MarkUsed with a $set; the rebuild
+	// REPLACES the whole document, so without this every re-provision erases
+	// "when did this webhook last receive anything" — the one field an
+	// operator reads to tell a silent hook from an idle repo.
+	cfg.LastUsedAt = prev.LastUsedAt
+
+	// Rate limit: enforced by the inbound middleware, so losing an operator's
+	// raise means deliveries silently 429 and reviews never launch. Its own
+	// sibling in the `// Limits.` block (MonthlyCallLimit) is carried above;
+	// the zero value means "never set", where the provision's default stands.
+	if prev.RateLimit != (webhooks.Rate{}) {
+		cfg.RateLimit = prev.RateLimit
+	}
+
+	// MinReplierRole: a conditional merge, never an overwrite — the provision
+	// stamps a manifest-derived FLOOR (the max requirement over the enabled
+	// bots), which a blind carry would override. But the field is also
+	// PATCH-settable with no ProvisionedBy guard, and an operator's RAISE is
+	// a security control every replier gate reads (`/command`, `/revi`, the
+	// re-request button); resetting it to the derived value on the next bot
+	// toggle silently lowers the floor. Keep the stricter of the two — with
+	// an unset prev deferring to the derivation: the gates read "" as
+	// developer, but the DERIVATION ranks "" as zero (webhookRoleRank) so a
+	// manifest may legitimately land a sub-developer floor, and a never-set
+	// prev must not discard it (R948c68).
+	if prev.MinReplierRole != "" &&
+		webhooks.ReplierRoleRank(prev.MinReplierRole) > webhooks.ReplierRoleRank(cfg.MinReplierRole) {
+		cfg.MinReplierRole = prev.MinReplierRole
+	}
+
+	// Secret overrides MERGE rather than replace: the provision owns the keys
+	// it derives from the enabled bots (rewriting them is how a rotation
+	// lands), while an operator's own pin — a bot posting under a different
+	// forge identity — has nowhere else to live.
+	for k, v := range prev.SecretOverrides {
+		if _, stamped := cfg.SecretOverrides[k]; !stamped {
+			if cfg.SecretOverrides == nil {
+				cfg.SecretOverrides = map[string]string{}
+			}
+			cfg.SecretOverrides[k] = v
+		}
+	}
 }
 
 func singleBotDefault(bots []string) string {

--- a/pkg/forge/orchestrator_botrules_test.go
+++ b/pkg/forge/orchestrator_botrules_test.go
@@ -618,3 +618,18 @@ func TestCarryOperatorWebhookSettings_MinReplierRoleStricterOf(t *testing.T) {
 		t.Fatalf("unset prev must defer to a sub-developer derived floor: %q", cfg.MinReplierRole)
 	}
 }
+
+// R8a3f4e: Enabled is the operator's per-repo kill switch — a re-provision
+// (any bot toggle) must not silently re-arm the inbound lanes it paused.
+func TestCarryOperatorWebhookSettings_EnabledKillSwitchSurvives(t *testing.T) {
+	cfg := webhooks.Config{Enabled: true} // what the provision literal stamps
+	carryOperatorWebhookSettings(&cfg, webhooks.Config{Enabled: false})
+	if cfg.Enabled {
+		t.Fatal("a re-provision must not re-arm a webhook the operator disabled")
+	}
+	cfg = webhooks.Config{Enabled: true}
+	carryOperatorWebhookSettings(&cfg, webhooks.Config{Enabled: true})
+	if !cfg.Enabled {
+		t.Fatal("an enabled webhook must stay enabled through re-provision")
+	}
+}

--- a/pkg/forge/orchestrator_botrules_test.go
+++ b/pkg/forge/orchestrator_botrules_test.go
@@ -2,6 +2,7 @@ package forge
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/bundle"
@@ -516,5 +517,104 @@ func TestProvision_NoOpReprovisionBackfillsBotRules(t *testing.T) {
 	}
 	if len(fa.hooks) != hooksBefore {
 		t.Errorf("backfill must not touch the forge hook")
+	}
+}
+
+// A re-provision rebuilds the whole webhook Config, so a field it neither
+// stamps nor carries is reset the next time any bot is toggled on the repo —
+// and the PATCH endpoint that sets these has no ProvisionedBy guard, so they
+// are settable precisely on the managed configs it rebuilds. The armed review
+// identity is one of them: losing it disarms the 🔁 button in silence.
+func TestProvision_ReprovisionKeepsOperatorWebhookSettings(t *testing.T) {
+	o, _, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	res, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"dep-guard"}, ActorID: "u1",
+	})
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	cfg, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// What an operator sets the documented way (PATCH /webhooks/{id}).
+	cfg.ReviewRequestLogins = []string{"iterion-bot"}
+	cfg.AuthorizedRepliers = []string{"alice"}
+	cfg.MonthlyCallLimit = 500
+	cfg.AutoImplementOnOpen = true
+	cfg.KeyOverrides = map[string]string{"anthropic": "key-1"}
+	cfg.RetryMaxAttempts = 3
+	cfg.RateLimit = webhooks.Rate{Rate: 10, Burst: 200}
+	if err := o.Webhooks.Update(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Any later bot change re-provisions the repo.
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"dep-guard", "gate-bot"}, ActorID: "u1",
+	}); err != nil {
+		t.Fatalf("re-provision: %v", err)
+	}
+	after, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(after.ReviewRequestLogins, []string{"iterion-bot"}) {
+		t.Errorf("review_request_logins = %v, want [iterion-bot] — the 🔁 lane silently disarmed", after.ReviewRequestLogins)
+	}
+	if !slices.Equal(after.AuthorizedRepliers, []string{"alice"}) {
+		t.Errorf("authorized_repliers = %v, want [alice]", after.AuthorizedRepliers)
+	}
+	if after.MonthlyCallLimit != 500 || after.RetryMaxAttempts != 3 || !after.AutoImplementOnOpen {
+		t.Errorf("monthly=%d retries=%d auto_implement=%v", after.MonthlyCallLimit, after.RetryMaxAttempts, after.AutoImplementOnOpen)
+	}
+	if after.KeyOverrides["anthropic"] != "key-1" {
+		t.Errorf("key_overrides = %v, want the operator's BYOK pin", after.KeyOverrides)
+	}
+	if after.RateLimit != (webhooks.Rate{Rate: 10, Burst: 200}) {
+		t.Errorf("rate_limit = %+v, want the operator's raise — a reset silently 429s deliveries", after.RateLimit)
+	}
+	// The bot set is what a provision DOES recompute — it must not be frozen.
+	if !after.AllowsBot("gate-bot") {
+		t.Error("the newly enabled bot must be permitted — the carry must not freeze the bot scope")
+	}
+}
+
+// R51dbee: MinReplierRole is merged stricter-of, never overwritten — the
+// provision stamps a manifest-derived floor, but an operator's RAISE is a
+// security control every replier gate reads, and a bot toggle must not
+// silently lower it.
+func TestCarryOperatorWebhookSettings_MinReplierRoleStricterOf(t *testing.T) {
+	// Operator raised the floor above the derived value: the raise survives.
+	cfg := webhooks.Config{MinReplierRole: "developer"}
+	carryOperatorWebhookSettings(&cfg, webhooks.Config{MinReplierRole: "maintainer"})
+	if cfg.MinReplierRole != "maintainer" {
+		t.Fatalf("operator raise lost on re-provision: %q", cfg.MinReplierRole)
+	}
+	// Manifest floor higher than anything the operator set ("" reads as
+	// developer): the floor stands.
+	cfg = webhooks.Config{MinReplierRole: "maintainer"}
+	carryOperatorWebhookSettings(&cfg, webhooks.Config{})
+	if cfg.MinReplierRole != "maintainer" {
+		t.Fatalf("manifest floor must stand over an unset previous: %q", cfg.MinReplierRole)
+	}
+	// Equal ranks ("" == developer): the derivation's value stands unchanged.
+	cfg = webhooks.Config{MinReplierRole: "developer"}
+	carryOperatorWebhookSettings(&cfg, webhooks.Config{})
+	if cfg.MinReplierRole != "developer" {
+		t.Fatalf("equal ranks must keep the derived value: %q", cfg.MinReplierRole)
+	}
+	// R948c68: a never-set prev ("") must NOT discard a manifest's deliberate
+	// sub-developer floor — the gates read "" as developer (rank 3), but the
+	// derivation ranks "" as zero, so "reporter" here was legitimately won.
+	cfg = webhooks.Config{MinReplierRole: "reporter"}
+	carryOperatorWebhookSettings(&cfg, webhooks.Config{})
+	if cfg.MinReplierRole != "reporter" {
+		t.Fatalf("unset prev must defer to a sub-developer derived floor: %q", cfg.MinReplierRole)
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -278,6 +278,11 @@ type Server struct {
 	// webhookReviewRequestGate (test seam). nil →
 	// realWebhookPRForgeReviewRequestGate.
 	webhookPRForgeReviewRequestGate func(ctx context.Context, cfg webhooks.Config, p prforge.Parsed, botID string) (authorized bool, reason string, err error)
+	// webhookRunIsLive overrides the "is this run still in flight" probe
+	// behind the re-request lane's collapse of a CODEOWNERS auto-request
+	// onto the open review of the same head (test seam). nil → the real
+	// impl reads the run's status through the runview service.
+	webhookRunIsLive func(ctx context.Context, runID string) bool
 	// webhookHandoff overrides the lookup of what an earlier run on the same
 	// PR produced (a review, or a fixer's reply to one), which seeds a launch var
 	// the launched bot declared it consumes (test seam). nil → realWebhookHandoff.

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -729,10 +729,7 @@ func (s *Server) supersedeLiveRuns(ctx context.Context, cfg webhooks.Config, met
 			return s.runs.CancelWithReason(runID, supersededRunReason)
 		}
 	}
-	if cfg.Overlap == "" || s.webhookDeliveries == nil || cancel == nil {
-		return
-	}
-	if decision, _ := schedgate.EvaluateOverlap([]string{"probe"}, cfg.OverlapPolicy()); decision != schedgate.DecisionSupersede {
+	if s.webhookDeliveries == nil || cancel == nil || !overlapSupersedes(cfg) {
 		return
 	}
 	if meta.SubjectID == "" {
@@ -773,13 +770,22 @@ const supersedeLookback = 50
 
 // headReviewClaim reports whether the ordinary per-head key space of this
 // delivery's head is already claimed by an earlier review launch, and whether
-// any of those launches is still in flight. It drives the re-request lane's
-// three-way idempotency choice (collapse / salt / claim) — see the caller in
-// handlePRForgeReview. Absence of the deliveries store reads as unclaimed and
-// a failed run lookup as not-live: the button must keep working when the
-// state cannot be known, at the price of a possible duplicate (the historical
-// behaviour). A StatusLaunchError row is NOT a claim (mirrors the launch
-// tail: a failed launch is retryable); a StatusAccepted row is a launch in
+// EVERY fanned-out rule's claim is still in flight — the only state in which
+// the click has nothing left to serve. Rb9e7c9: with several bots on the
+// event, one live run must not swallow the re-review of a bot whose own run
+// finished, nor a retryable launch_error's relaunch — so a single not-live
+// rule declines the collapse and the delivery salts. It drives the
+// re-request lane's three-way idempotency choice (collapse / salt / claim) —
+// see the caller in handlePRForgeReview.
+//
+// Failure posture: THE BUTTON KEEPS WORKING. Absence of the deliveries store
+// reads as unclaimed, a failed RUN lookup as not-live, and a failed STORE
+// read (≠ not-found) as claimed-but-not-live — claimed is what routes the
+// delivery onto the salted key, so a store hiccup costs at most a duplicate
+// review, never a silently deduped no-op (R1545ff; a not-found miss keeps
+// the per-head key, whose row the launch tail retries or dedupes exactly).
+// A StatusLaunchError row is NOT a claim (mirrors the launch tail: a failed
+// launch is retryable via its own key); a StatusAccepted row is a launch in
 // progress — in flight by definition, but only within acceptedLaunchWindow
 // of its receipt: a process dying between the insert and the post-launch
 // update strands the row at accepted forever, and reading that as live would
@@ -788,20 +794,43 @@ func (s *Server) headReviewClaim(ctx context.Context, cfg webhooks.Config, rules
 	if s.webhookDeliveries == nil {
 		return false, false
 	}
+	live = true
 	for _, rule := range rules {
 		d, err := s.webhookDeliveries.GetByIdempotencyKey(ctx, forgeIdemKey(headBase, rule.BotID, cfg.HasBotRules()))
-		if err != nil || d.Status == webhooks.StatusLaunchError {
+		switch {
+		case errors.Is(err, webhooks.ErrNotFound):
+			live = false
+			continue
+		case err != nil:
+			claimed, live = true, false
+			continue
+		case d.Status == webhooks.StatusLaunchError:
+			live = false
 			continue
 		}
 		claimed = true
-		if d.Status == webhooks.StatusAccepted && time.Since(d.ReceivedAt) < acceptedLaunchWindow {
-			return true, true
-		}
-		if d.RunID != "" && s.webhookRunLive(ctx, d.RunID) {
-			return true, true
+		switch {
+		case d.Status == webhooks.StatusAccepted && time.Since(d.ReceivedAt) < acceptedLaunchWindow:
+			// launch in progress — in flight.
+		case d.RunID != "" && s.webhookRunLive(ctx, d.RunID):
+			// run still expected to produce its review — in flight.
+		default:
+			live = false
 		}
 	}
-	return claimed, false
+	return claimed, claimed && live
+}
+
+// overlapSupersedes reports whether this webhook's overlap policy resolves to
+// supersede — the single predicate shared by the launch tail's cancel pass
+// (supersedeLiveRuns) and the re-request collapse, which DEFERS to it: an
+// explicit supersede is the operator saying "newest request wins".
+func overlapSupersedes(cfg webhooks.Config) bool {
+	if cfg.Overlap == "" {
+		return false
+	}
+	decision, _ := schedgate.EvaluateOverlap([]string{"probe"}, cfg.OverlapPolicy())
+	return decision == schedgate.DecisionSupersede
 }
 
 // acceptedLaunchWindow bounds how long a StatusAccepted delivery row reads as

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -295,6 +295,15 @@ func (s *Server) realIterionBotAuthor(ctx context.Context, cfg webhooks.Config, 
 	if login == "" {
 		return false
 	}
+	// Configured identities first, and WITHOUT a connection lookup — the other
+	// half of the pair reads them the same way. An identity only the
+	// review-request half recognised would launch on the bot's own reviewer
+	// write echoing back, which is the loop this guard exists to close.
+	for _, l := range iterionBotLogins(cfg, forge.Connection{}) {
+		if strings.EqualFold(login, l) {
+			return true
+		}
+	}
 	conn, ok := s.webhookForgeConnection(ctx, cfg)
 	if !ok {
 		return false
@@ -323,7 +332,16 @@ func (s *Server) realIterionBotAuthor(ctx context.Context, cfg webhooks.Config, 
 //     human's PRs unreviewable on one side and turn an ordinary
 //     human-to-human review request into an LLM launch on the other.
 func iterionBotLogins(cfg webhooks.Config, conn forge.Connection) []string {
+	// Operator-configured identities first: they are the only ones that can
+	// name a USER account, which on GitHub is the only thing that can be a
+	// requested reviewer. See Config.ReviewRequestLogins for why this is never
+	// derived from the connection.
 	var logins []string
+	for _, l := range cfg.ReviewRequestLogins {
+		if l = strings.TrimPrefix(strings.TrimSpace(l), "@"); l != "" {
+			logins = append(logins, l)
+		}
+	}
 	if conn.AppSlug != "" {
 		logins = append(logins, conn.AppSlug+"[bot]")
 	}
@@ -381,6 +399,14 @@ func (s *Server) isIterionBotReviewRequest(ctx context.Context, cfg webhooks.Con
 // on the bot's own reviewer-write echo (the actor guard couldn't name it)
 // and would treat a human account's review requests as bot triggers.
 func (s *Server) realIterionBotReviewRequest(ctx context.Context, cfg webhooks.Config, requested func(login string) bool) bool {
+	// A configured identity needs no connection lookup: it is the operator's
+	// explicit statement of who the button addresses, and it must arm the lane
+	// even when the provisioning marker cannot be resolved.
+	for _, l := range iterionBotLogins(cfg, forge.Connection{}) {
+		if requested(l) {
+			return true
+		}
+	}
 	conn, ok := s.webhookForgeConnection(ctx, cfg)
 	if !ok {
 		return false
@@ -744,6 +770,67 @@ func (s *Server) supersedeLiveRuns(ctx context.Context, cfg webhooks.Config, met
 // live runs are necessarily among the most recent deliveries on its webhook,
 // and an unbounded scan would put the whole delivery history on the hot path.
 const supersedeLookback = 50
+
+// headReviewClaim reports whether the ordinary per-head key space of this
+// delivery's head is already claimed by an earlier review launch, and whether
+// any of those launches is still in flight. It drives the re-request lane's
+// three-way idempotency choice (collapse / salt / claim) — see the caller in
+// handlePRForgeReview. Absence of the deliveries store reads as unclaimed and
+// a failed run lookup as not-live: the button must keep working when the
+// state cannot be known, at the price of a possible duplicate (the historical
+// behaviour). A StatusLaunchError row is NOT a claim (mirrors the launch
+// tail: a failed launch is retryable); a StatusAccepted row is a launch in
+// progress — in flight by definition, but only within acceptedLaunchWindow
+// of its receipt: a process dying between the insert and the post-launch
+// update strands the row at accepted forever, and reading that as live would
+// permanently disarm the button for the head (Rf96744).
+func (s *Server) headReviewClaim(ctx context.Context, cfg webhooks.Config, rules []webhooks.BotRule, headBase string) (claimed, live bool) {
+	if s.webhookDeliveries == nil {
+		return false, false
+	}
+	for _, rule := range rules {
+		d, err := s.webhookDeliveries.GetByIdempotencyKey(ctx, forgeIdemKey(headBase, rule.BotID, cfg.HasBotRules()))
+		if err != nil || d.Status == webhooks.StatusLaunchError {
+			continue
+		}
+		claimed = true
+		if d.Status == webhooks.StatusAccepted && time.Since(d.ReceivedAt) < acceptedLaunchWindow {
+			return true, true
+		}
+		if d.RunID != "" && s.webhookRunLive(ctx, d.RunID) {
+			return true, true
+		}
+	}
+	return claimed, false
+}
+
+// acceptedLaunchWindow bounds how long a StatusAccepted delivery row reads as
+// "launch in progress" to the re-request collapse. A live launch resolves to
+// launched/launch_error within seconds; a row older than this was stranded by
+// a crash and must not keep collapsing re-requests.
+const acceptedLaunchWindow = 10 * time.Minute
+
+// webhookRunLive resolves the seam: is this run still expected to produce its
+// review (queued, running, or paused)? Terminal statuses — and a run the
+// store cannot load — read as not-live, so a re-request on them relaunches.
+func (s *Server) webhookRunLive(ctx context.Context, runID string) bool {
+	if s.webhookRunIsLive != nil {
+		return s.webhookRunIsLive(ctx, runID)
+	}
+	if s.runs == nil {
+		return false
+	}
+	run, err := s.runs.LoadRunCtx(store.WithoutTenantFilter(ctx), runID)
+	if err != nil || run == nil {
+		return false
+	}
+	switch run.Status {
+	case store.RunStatusQueued, store.RunStatusRunning,
+		store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator:
+		return true
+	}
+	return false
+}
 
 // supersededRunReason is recorded as the run error of a run cancelled by the
 // overlap=supersede lane. Kept short: the merge-gate synthetic description

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -195,9 +195,9 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 	// Deliberately AFTER the event/project/author scope filter (R0c3aab):
 	// an out-of-scope delivery must never cost a forge API call, nor be
 	// able to 502 the endpoint. An unauthorized click DEMOTES the gesture —
-	// the delivery then rides whatever automatic lane still admits it, with
-	// the hold label RE-APPLIED (it was provisionally waived under the
-	// gesture's authority) — or is filtered. An authz ERROR demotes too
+	// the delivery then rides whatever automatic lane still admits it, or
+	// is filtered (the hold gate already ran unconditionally above — the
+	// re-request has no exemption to lose). An authz ERROR demotes too
 	// when an automatic lane co-rides the event (R34eb8c — a transient
 	// members-API failure must not strand a merge-gate resync), and 502s
 	// only when the click was the delivery's sole reason (so the forge
@@ -304,9 +304,12 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 		// the click salts unconditionally: that policy is the operator saying
 		// "newest request wins", so the launch tail's supersede pass cancels
 		// the stale run and the fresh one replaces it — collapsing would
-		// silently override that choice. The CODEOWNERS double resolves
-		// there too: the auto-request supersedes the open's run, one
-		// survivor.
+		// silently override that choice. The CODEOWNERS double is then
+		// bounded by that policy, not eliminated: an auto-request landing
+		// after the open's launch supersedes it, while a tight concurrent
+		// pair can briefly double-run (the supersede pass only sees
+		// LAUNCHED rows, not one still in its accepted window) — the
+		// pre-existing supersede semantics, not a new exposure.
 		if overlapSupersedes(cfg) {
 			idemBase = fmt.Sprintf("%srereq|%s|%s|%s|%d|%s|%s", idemPrefix, cfg.TenantID, cfg.ID, p.ProjectPath, p.PRNumber, p.HeadSHA, p.UpdatedAt)
 		} else {

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -299,15 +299,27 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 		//     so a concurrent or late `opened` for the same head dedupes
 		//     against it instead of double-launching (order-independent).
 		// re_review marks the posted summary like the `/revi` comment path.
-		claimed, inFlight := s.headReviewClaim(ctx, cfg, rules, idemBase)
-		if inFlight {
-			s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP,
-				"re-request collapsed — a review of this head is already in flight")
-			writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
-			return
-		}
-		if claimed {
+		//
+		// Under an explicit `overlap: supersede` the collapse is SKIPPED and
+		// the click salts unconditionally: that policy is the operator saying
+		// "newest request wins", so the launch tail's supersede pass cancels
+		// the stale run and the fresh one replaces it — collapsing would
+		// silently override that choice. The CODEOWNERS double resolves
+		// there too: the auto-request supersedes the open's run, one
+		// survivor.
+		if overlapSupersedes(cfg) {
 			idemBase = fmt.Sprintf("%srereq|%s|%s|%s|%d|%s|%s", idemPrefix, cfg.TenantID, cfg.ID, p.ProjectPath, p.PRNumber, p.HeadSHA, p.UpdatedAt)
+		} else {
+			claimed, inFlight := s.headReviewClaim(ctx, cfg, rules, idemBase)
+			if inFlight {
+				s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP,
+					"re-request collapsed — a review of this head is already in flight")
+				writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+				return
+			}
+			if claimed {
+				idemBase = fmt.Sprintf("%srereq|%s|%s|%s|%d|%s|%s", idemPrefix, cfg.TenantID, cfg.ID, p.ProjectPath, p.PRNumber, p.HeadSHA, p.UpdatedAt)
+			}
 		}
 		extra["re_review"] = "true"
 	}

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -107,11 +107,12 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 	// re-review, only on an OPEN PR (reviewer edits arrive freely on
 	// closed/merged ones). Never when the actor IS the bot: its own
 	// reviewer-write echoing back must not launch a review of itself. The
-	// identity matched is iterionBotLogins — on GitHub/Forgejo that is the
-	// App bot login only (a PAT/OAuth account may be a HUMAN's), and a
-	// GitHub App cannot be a reviewer at all, so on GitHub this lane stays
-	// inert and `/revi` is the on-demand path. The gesture is PROVISIONAL
-	// until the replier gate below the scope filter confirms it (R6a15fe).
+	// identity matched is iterionBotLogins — the connection-derived App bot
+	// login PLUS cfg.ReviewRequestLogins, and on GitHub only the latter can
+	// arm the lane (a GitHub App cannot be a requested reviewer at all; a
+	// PAT/OAuth account may be a HUMAN's, so it is never derived either).
+	// The gesture is PROVISIONAL until the replier gate below the scope
+	// filter confirms it (R6a15fe).
 	reviewRequested := strings.EqualFold(p.State, "open") &&
 		s.isIterionBotReviewRequest(ctx, cfg, p.ReviewRequestedFrom) &&
 		!s.isIterionForgeBotAuthor(ctx, cfg, p.SenderLogin)
@@ -127,9 +128,15 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 	// vetoes EVERY auto-launch this handler can do (auto-heal and review alike)
 	// — the operator's escape hatch to pause automation on one PR. Placed before
 	// any launch decision so it covers all of them. A human can still trigger a
-	// bot manually via a `/command` — and a review re-request is the same
-	// deliberate gesture, so it is exempt too.
-	if !reviewRequested && s.suppressedByHoldLabel(ctx, w, cfg, meta, p.Labels, payloadHash, srcIP) {
+	// bot manually via a `/command`.
+	//
+	// A review re-request is NOT exempt, unlike a command. The forge emits the
+	// same event for a CODEOWNERS auto-request, which needs no permission from
+	// the requester and carries no field distinguishing it from a click — so
+	// "a re-request is a deliberate human gesture" is not a property this
+	// handler can rely on. And the label's whole purpose is to freeze every
+	// automation on one PR: an operator who set it has to be able to trust it.
+	if s.suppressedByHoldLabel(ctx, w, cfg, meta, p.Labels, payloadHash, srcIP) {
 		return
 	}
 
@@ -223,9 +230,9 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 				return
 			}
 		}
-		if !reviewRequested && s.suppressedByHoldLabel(ctx, w, cfg, meta, p.Labels, payloadHash, srcIP) {
-			return
-		}
+		// No post-demote hold re-check here: the hold gate above runs
+		// unconditionally (the re-request lost its exemption — see the
+		// CODEOWNERS rationale there), so a held PR never reaches this block.
 	}
 
 	// Iterion-bot guard: a PR opened by iterion's OWN forge bot (Doki/Willy/
@@ -275,12 +282,33 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 	// exclusive by action (review_requested vs synchronize) — the guard pins
 	// the invariant against a forge overloading one action with both.
 	if reviewRequested && !gateResync {
-		// A deliberate re-request must relaunch even on a head the auto-review
-		// already claimed — and again on a second click. The PR's updated_at
-		// salts the key so each click is its own delivery; "rereq|" keeps it
-		// disjoint from the open/resync space. re_review marks the posted
-		// summary like the `/revi` comment path does.
-		idemBase = fmt.Sprintf("%srereq|%s|%s|%s|%d|%s|%s", idemPrefix, cfg.TenantID, cfg.ID, p.ProjectPath, p.PRNumber, p.HeadSHA, p.UpdatedAt)
+		// With the identity in CODEOWNERS — the setup this lane targets — a
+		// single PR open delivers BOTH `opened` and an automatic
+		// `review_requested`, and an unconditionally salted key would launch
+		// a second full review of a head whose review just started (2× spend
+		// per PR, two runs racing on one commit status). The payload cannot
+		// tell that auto-request from a click, but the STATE can. Three-way
+		// choice on the ordinary per-head claim:
+		//   - claimed and still in flight → the request is already being
+		//     served; collapse this delivery onto it (filtered, with the
+		//     reason in the audit row);
+		//   - claimed and finished → the ordinary re-review gesture: salt
+		//     with updated_at so each click is its own delivery, disjoint
+		//     "rereq|" space, and again on a second click;
+		//   - unclaimed → first review of this head: keep the per-head key,
+		//     so a concurrent or late `opened` for the same head dedupes
+		//     against it instead of double-launching (order-independent).
+		// re_review marks the posted summary like the `/revi` comment path.
+		claimed, inFlight := s.headReviewClaim(ctx, cfg, rules, idemBase)
+		if inFlight {
+			s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP,
+				"re-request collapsed — a review of this head is already in flight")
+			writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+			return
+		}
+		if claimed {
+			idemBase = fmt.Sprintf("%srereq|%s|%s|%s|%d|%s|%s", idemPrefix, cfg.TenantID, cfg.ID, p.ProjectPath, p.PRNumber, p.HeadSHA, p.UpdatedAt)
+		}
 		extra["re_review"] = "true"
 	}
 

--- a/pkg/server/webhooks_github_test.go
+++ b/pkg/server/webhooks_github_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/secrets"
 	"github.com/SocialGouv/iterion/pkg/webhooks"
@@ -903,5 +904,225 @@ func TestGitHubWebhook_GateResyncSurvivesBotGuard(t *testing.T) {
 	}
 	if *launched2 != 0 {
 		t.Error("a bot-opened PR must not auto-review")
+	}
+}
+
+// The GitHub arming half of review_request_logins: a configured USER login
+// arms the lane where the connection-derived identity cannot (a GitHub App
+// is never a requested reviewer), and BOTH halves of the loop guard read the
+// same set — the actor half must recognise the configured identity's own
+// reviewer-write echo.
+func TestGitHubWebhook_ReviewRequestedArmsOnConfiguredLogin(t *testing.T) {
+	s := newWebhookTestServer(t)
+	calls := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		calls++
+		return fmt.Sprintf("run-%d", calls), nil
+	}
+	// Replier authorized — this test exercises identity matching, not the gate.
+	s.webhookPRForgeReviewRequestGate = func(context.Context, webhooks.Config, prforge.Parsed, string) (bool, string, error) {
+		return true, "allowlist", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.ReviewRequestLogins = []string{"@iterion-bot"} // a pasted "@handle" is tolerated
+
+	// Addressed to the configured identity → the reviewer launches.
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewRequested("alice", "Iterion-Bot", "2026-09-01T10:00:00Z"), prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusAccepted || calls != 1 {
+		t.Fatalf("configured identity: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+	// Addressed to anyone else → filtered, as this action always was.
+	w = httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewRequested("alice", "bob", "2026-09-01T10:05:00Z"), prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusOK || calls != 1 {
+		t.Fatalf("other reviewer: code=%d calls=%d", w.Code, calls)
+	}
+	// The configured identity as ACTOR — its own reviewer write echoing back —
+	// must not launch: both halves of the guard read the same set.
+	w = httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewRequested("iterion-bot", "iterion-bot", "2026-09-01T10:10:00Z"), prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusOK || calls != 1 {
+		t.Fatalf("self request: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+	// Nothing configured → the lane is inert, exactly as before.
+	bare, pt2 := ghConfig(t, s)
+	w = httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(bare), ghReviewRequested("alice", "iterion-bot", "2026-09-01T10:15:00Z"), prforge.EventHeaderPullRequest, pt2))
+	if w.Code != http.StatusOK || calls != 1 {
+		t.Fatalf("unarmed webhook: code=%d calls=%d", w.Code, calls)
+	}
+}
+
+// The hold label freezes EVERY automation on a PR, the re-request included.
+// The forge emits the same event for a CODEOWNERS auto-request, which needs no
+// permission from the requester and carries nothing to tell it from a click —
+// so the lane cannot claim the deliberateness a `/command` has.
+func TestGitHubWebhook_ReviewRequestedRespectsHoldLabel(t *testing.T) {
+	s := newWebhookTestServer(t)
+	calls := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		calls++
+		return "run-1", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.ReviewRequestLogins = []string{"iterion-bot"}
+	cfg.HoldLabels = []string{"iterion:hold"}
+
+	body := strings.Replace(
+		ghReviewRequested("alice", "iterion-bot", "2026-09-01T10:00:00Z"),
+		`"state": "open",`, `"state": "open", "labels": [{"name": "iterion:hold"}],`, 1)
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), body, prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusOK || calls != 0 {
+		t.Fatalf("held PR: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+	rows, err := s.webhookDeliveries.ListByWebhook(context.Background(), cfg.TenantID, cfg.ID, 5)
+	if err != nil || len(rows) == 0 {
+		t.Fatalf("no delivery row recorded (%v)", err)
+	}
+	if !strings.Contains(rows[0].Error, "hold label") {
+		t.Fatalf("audit reason = %q, want the hold-label explanation", rows[0].Error)
+	}
+}
+
+// R35dde4: with the identity in CODEOWNERS, a single PR open delivers BOTH
+// `opened` and an automatic `review_requested` — the second must collapse
+// onto the review the first just launched, not double-spend on the same
+// head. Once that review FINISHES, the same gesture is the ordinary
+// re-review click and relaunches.
+func TestGitHubWebhook_ReviewRequestedCollapsesOntoLiveReview(t *testing.T) {
+	s := newWebhookTestServer(t)
+	calls := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		calls++
+		return fmt.Sprintf("run-%d", calls), nil
+	}
+	s.webhookPRForgeReviewRequestGate = func(context.Context, webhooks.Config, prforge.Parsed, string) (bool, string, error) {
+		return true, "allowlist", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.ReviewRequestLogins = []string{"iterion-bot"}
+
+	// PR open claims the head and launches run-1…
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghOpenPR, prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusAccepted || calls != 1 {
+		t.Fatalf("open: code=%d calls=%d", w.Code, calls)
+	}
+
+	// …the CODEOWNERS auto-request lands seconds later while run-1 is live:
+	// collapsed, with the reason in the audit row.
+	s.webhookRunIsLive = func(_ context.Context, runID string) bool { return runID == "run-1" }
+	w = httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewRequested("alice", "iterion-bot", "2026-09-01T10:00:00Z"), prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusOK || calls != 1 {
+		t.Fatalf("auto-request on a live review must collapse: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+	rows, err := s.webhookDeliveries.ListByWebhook(context.Background(), cfg.TenantID, cfg.ID, 5)
+	if err != nil || len(rows) == 0 {
+		t.Fatalf("no delivery row recorded (%v)", err)
+	}
+	found := false
+	for _, row := range rows {
+		if strings.Contains(row.Error, "already in flight") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no delivery row carries the collapse reason: %+v", rows)
+	}
+
+	// Review finished → the same gesture is a deliberate re-review: relaunch.
+	s.webhookRunIsLive = func(context.Context, string) bool { return false }
+	w = httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewRequested("alice", "iterion-bot", "2026-09-01T10:05:00Z"), prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusAccepted || calls != 2 {
+		t.Fatalf("re-request after the review finished must relaunch: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+}
+
+// Rf96744: a delivery row stranded at `accepted` (a crash between the insert
+// and the post-launch update) must not read as in-flight forever — past the
+// launch window the re-request lane treats it as a finished claim and the
+// button relaunches instead of collapsing for good.
+func TestGitHubWebhook_ReviewRequestedIgnoresStrandedAcceptedRow(t *testing.T) {
+	s := newWebhookTestServer(t)
+	calls := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		calls++
+		return "run-1", nil
+	}
+	s.webhookPRForgeReviewRequestGate = func(context.Context, webhooks.Config, prforge.Parsed, string) (bool, string, error) {
+		return true, "allowlist", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.ReviewRequestLogins = []string{"iterion-bot"}
+
+	// Seed the per-head claim as a stranded `accepted` row: no RunID, and
+	// received well past the launch window.
+	headBase := fmt.Sprintf("gh|%s|%s|acme/widgets|7|abc123", cfg.TenantID, cfg.ID)
+	if err := s.webhookDeliveries.Insert(context.Background(), webhooks.Delivery{
+		ID: "stranded", TenantID: cfg.TenantID, WebhookID: cfg.ID, Provider: cfg.Provider,
+		IdempotencyKey: forgeIdemKey(headBase, "review-pr", cfg.HasBotRules()),
+		Status:         webhooks.StatusAccepted,
+		ReceivedAt:     time.Now().UTC().Add(-2 * acceptedLaunchWindow),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewRequested("alice", "iterion-bot", "2026-09-01T10:00:00Z"), prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusAccepted || calls != 1 {
+		t.Fatalf("re-request past a stranded accepted row must relaunch: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+
+	// A FRESH accepted row is a launch in progress: the same gesture collapses.
+	if err := s.webhookDeliveries.Insert(context.Background(), webhooks.Delivery{
+		ID: "in-progress", TenantID: cfg.TenantID, WebhookID: cfg.ID, Provider: cfg.Provider,
+		IdempotencyKey: forgeIdemKey(fmt.Sprintf("gh|%s|%s|acme/widgets|8|def456", cfg.TenantID, cfg.ID), "review-pr", cfg.HasBotRules()),
+		Status:         webhooks.StatusAccepted,
+		ReceivedAt:     time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed fresh: %v", err)
+	}
+	body := strings.Replace(ghReviewRequested("alice", "iterion-bot", "2026-09-01T10:05:00Z"), `"number": 7,`, `"number": 8,`, 2)
+	body = strings.Replace(body, `"sha": "abc123"`, `"sha": "def456"`, 1)
+	w = httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), body, prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusOK || calls != 1 {
+		t.Fatalf("re-request on a fresh accepted row must collapse: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+}
+
+// R35dde4, order independence: when the auto-request outruns the `opened`
+// delivery, it claims the ordinary per-head key — so the late open dedupes
+// against it instead of launching a second review of the same head.
+func TestGitHubWebhook_ReviewRequestedBeforeOpenClaimsHeadKey(t *testing.T) {
+	s := newWebhookTestServer(t)
+	calls := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		calls++
+		return "run-1", nil
+	}
+	s.webhookPRForgeReviewRequestGate = func(context.Context, webhooks.Config, prforge.Parsed, string) (bool, string, error) {
+		return true, "allowlist", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.ReviewRequestLogins = []string{"iterion-bot"}
+
+	// Reordered pair: the auto-request arrives first, on an unclaimed head —
+	// it launches the review under the per-head key.
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewRequested("alice", "iterion-bot", "2026-09-01T10:00:00Z"), prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusAccepted || calls != 1 {
+		t.Fatalf("re-request on an unclaimed head must launch: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+
+	// The late `opened` for the same head dedupes against that claim.
+	w = httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghOpenPR, prforge.EventHeaderPullRequest, pt))
+	if calls != 1 {
+		t.Fatalf("late open must dedupe against the re-request's claim: calls=%d body=%s", calls, w.Body.String())
 	}
 }

--- a/pkg/server/webhooks_github_test.go
+++ b/pkg/server/webhooks_github_test.go
@@ -1126,3 +1126,137 @@ func TestGitHubWebhook_ReviewRequestedBeforeOpenClaimsHeadKey(t *testing.T) {
 		t.Fatalf("late open must dedupe against the re-request's claim: calls=%d body=%s", calls, w.Body.String())
 	}
 }
+
+// The collapse DEFERS to an explicit `overlap: supersede` (the operator's
+// "newest request wins"): a click during a live review salts as before, the
+// launch tail cancels the stale run, and the fresh one replaces it — instead
+// of the click being silently dropped.
+func TestGitHubWebhook_ReviewRequestedSupersedeSkipsCollapse(t *testing.T) {
+	s := newWebhookTestServer(t)
+	calls := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		calls++
+		return fmt.Sprintf("run-%d", calls), nil
+	}
+	var cancelled []string
+	s.webhookCancelRun = func(runID string) error { cancelled = append(cancelled, runID); return nil }
+	s.webhookPRForgeReviewRequestGate = func(context.Context, webhooks.Config, prforge.Parsed, string) (bool, string, error) {
+		return true, "allowlist", nil
+	}
+	s.webhookRunIsLive = func(_ context.Context, runID string) bool { return runID == "run-1" }
+	cfg, pt := ghConfig(t, s)
+	cfg.ReviewRequestLogins = []string{"iterion-bot"}
+	cfg.Overlap = "supersede"
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghOpenPR, prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusAccepted || calls != 1 {
+		t.Fatalf("open: code=%d calls=%d", w.Code, calls)
+	}
+
+	// Click while run-1 is live: NOT collapsed — superseded and relaunched.
+	w = httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewRequested("alice", "iterion-bot", "2026-09-02T08:00:00Z"), prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusAccepted || calls != 2 {
+		t.Fatalf("supersede click must relaunch: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+	found := false
+	for _, id := range cancelled {
+		if id == "run-1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("the stale run must be superseded (cancelled): %v", cancelled)
+	}
+}
+
+// Rb9e7c9: the collapse is ALL-rules-in-flight. With two bots fanned out, one
+// live run must not swallow the click for the bot whose review already
+// finished — a single not-live rule declines the collapse and the whole
+// delivery salts.
+func TestGitHubWebhook_ReviewRequestedMixedFanoutRelaunches(t *testing.T) {
+	s := newWebhookTestServer(t)
+	calls := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		calls++
+		return fmt.Sprintf("run-%d", calls), nil
+	}
+	s.webhookPRForgeReviewRequestGate = func(context.Context, webhooks.Config, prforge.Parsed, string) (bool, string, error) {
+		return true, "allowlist", nil
+	}
+	// Only the first bot's run is still in flight.
+	s.webhookRunIsLive = func(_ context.Context, runID string) bool { return runID == "run-1" }
+	cfg, pt := ghConfig(t, s)
+	cfg.ReviewRequestLogins = []string{"iterion-bot"}
+	cfg.BotIDs = []string{"review-pr", "second-bot"}
+	cfg.BotRules = []webhooks.BotRule{
+		{BotID: "review-pr", Events: []string{"pull_request"}},
+		{BotID: "second-bot", Events: []string{"pull_request"}},
+	}
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghOpenPR, prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusAccepted || calls != 2 {
+		t.Fatalf("open must fan out to both bots: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+
+	// run-1 live, run-2 finished → the click must NOT collapse: both relaunch.
+	w = httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewRequested("alice", "iterion-bot", "2026-09-02T08:05:00Z"), prforge.EventHeaderPullRequest, pt))
+	if calls != 4 {
+		t.Fatalf("mixed fan-out click must salt and relaunch both: calls=%d body=%s", calls, w.Body.String())
+	}
+}
+
+// flakyDeliveryStore fails the FIRST GetByIdempotencyKey with a generic (non
+// not-found) error, then delegates — the shape of a transient store hiccup.
+type flakyDeliveryStore struct {
+	webhooks.DeliveryStore
+	failedOnce bool
+}
+
+func (f *flakyDeliveryStore) GetByIdempotencyKey(ctx context.Context, key string) (webhooks.Delivery, error) {
+	if !f.failedOnce {
+		f.failedOnce = true
+		return webhooks.Delivery{}, fmt.Errorf("store hiccup")
+	}
+	return f.DeliveryStore.GetByIdempotencyKey(ctx, key)
+}
+
+// R1545ff: a transient store read error fails TOWARD the salted key (a
+// possible duplicate review), never toward the per-head key where the launch
+// tail dedupes the click into a silent no-op.
+func TestGitHubWebhook_ReviewRequestedStoreErrorSalts(t *testing.T) {
+	s := newWebhookTestServer(t)
+	calls := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		calls++
+		return "run-9", nil
+	}
+	s.webhookPRForgeReviewRequestGate = func(context.Context, webhooks.Config, prforge.Parsed, string) (bool, string, error) {
+		return true, "allowlist", nil
+	}
+	s.webhookRunIsLive = func(context.Context, string) bool { return false }
+	cfg, pt := ghConfig(t, s)
+	cfg.ReviewRequestLogins = []string{"iterion-bot"}
+
+	// A finished review already claimed the per-head key.
+	headBase := fmt.Sprintf("gh|%s|%s|acme/widgets|7|abc123", cfg.TenantID, cfg.ID)
+	if err := s.webhookDeliveries.Insert(context.Background(), webhooks.Delivery{
+		ID: "prior", TenantID: cfg.TenantID, WebhookID: cfg.ID, Provider: cfg.Provider,
+		IdempotencyKey: forgeIdemKey(headBase, "review-pr", cfg.HasBotRules()),
+		Status:         webhooks.StatusLaunched, RunID: "run-0",
+		ReceivedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	// The claim probe's read fails once (transient), then the store recovers.
+	s.webhookDeliveries = &flakyDeliveryStore{DeliveryStore: s.webhookDeliveries}
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewRequested("alice", "iterion-bot", "2026-09-02T08:10:00Z"), prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusAccepted || calls != 1 {
+		t.Fatalf("store hiccup must salt and launch, not dedupe to a no-op: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+}

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -132,10 +132,10 @@ func (s *Server) handleGitLabMergeRequestEvent(ctx context.Context, w http.Respo
 	// gate — the button must too. "The forge gates who may edit reviewers"
 	// is not sufficient: GitLab lets an MR AUTHOR edit their own MR's
 	// reviewers without holding a project role, which would hand a fork
-	// contributor a repeatable, hold-label-exempt trigger. An unauthorized
-	// click simply DEMOTES reviewRequested — the delivery then rides
-	// whatever lane still admits it (resync) or is filtered, with the
-	// hold-label exemption gone along with the gesture's authority.
+	// contributor a repeatable trigger. An unauthorized click simply
+	// DEMOTES reviewRequested — the delivery then rides whatever lane
+	// still admits it (resync) or is filtered. (The hold gate below runs
+	// unconditionally either way: a re-request has no exemption.)
 	if reviewRequested {
 		gate := s.webhookReviewRequestGate
 		if gate == nil {

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -169,10 +169,11 @@ func (s *Server) handleGitLabMergeRequestEvent(ctx context.Context, w http.Respo
 	}
 
 	// Hold-label gate (bot-agnostic, opt-in): a configured hold label on the MR
-	// vetoes the auto-review. Same escape hatch as the GitHub PR path. An
-	// AUTHORIZED re-request is exempt like the `/command` lanes: the label
-	// pauses automation, not a deliberate manual trigger.
-	if !reviewRequested && s.suppressedByHoldLabel(ctx, w, cfg, meta, p.Labels, payloadHash, srcIP) {
+	// vetoes the auto-review. Same escape hatch as the GitHub PR path.
+	// A re-request is NOT exempt: the label freezes every automation on one
+	// MR, and that promise is what makes it usable at all (see the GitHub
+	// lane for the auto-request case the exemption could not tell apart).
+	if s.suppressedByHoldLabel(ctx, w, cfg, meta, p.Labels, payloadHash, srcIP) {
 		return
 	}
 

--- a/pkg/server/webhooks_gitlab_test.go
+++ b/pkg/server/webhooks_gitlab_test.go
@@ -934,3 +934,40 @@ func TestGitLabWebhook_ConcurrentDuplicateReleasesQuota(t *testing.T) {
 		t.Fatalf("org monthly runs = %d, want 1 (loser must release its quota unit)", u.Runs)
 	}
 }
+
+// The hold label freezes EVERY automation on an MR, the re-request included —
+// same promise as the GitHub lane (the forge emits the same event for an
+// auto-request, so the click's deliberateness is not a property this handler
+// can rely on). The click here is AUTHORIZED: the veto must hold anyway.
+func TestGitLabWebhook_ReRequestRespectsHoldLabel(t *testing.T) {
+	s := newWebhookTestServer(t)
+	calls := 0
+	s.webhookLaunchBot = func(_ context.Context, _ string, _ map[string]string, _, _, _ string, _, _ map[string]string) (string, error) {
+		calls++
+		return "run-1", nil
+	}
+	s.webhookIterionBotReviewRequest = func(_ context.Context, _ webhooks.Config, requested func(string) bool) bool {
+		return requested("iterion-bot")
+	}
+	s.webhookReviewRequestGate = func(context.Context, webhooks.Config, gitlab.Parsed, string) (bool, string, error) {
+		return true, "allowlist", nil
+	}
+	cfg := glConfig()
+	cfg.HoldLabels = []string{"iterion:hold"}
+
+	body := strings.Replace(
+		glReRequestMR("alice", "iterion-bot", "2026-09-01 10:00:00 UTC", true),
+		`"project": {`, `"labels": [{"title": "iterion:hold"}], "project": {`, 1)
+	w := httptest.NewRecorder()
+	s.handleGitLabWebhook(w, glReq(gitlabCtx(cfg), body, gitlab.EventHeaderMergeRequest))
+	if w.Code != http.StatusOK || calls != 0 {
+		t.Fatalf("held MR: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+	rows, err := s.webhookDeliveries.ListByWebhook(context.Background(), cfg.TenantID, cfg.ID, 5)
+	if err != nil || len(rows) == 0 {
+		t.Fatalf("no delivery row recorded (%v)", err)
+	}
+	if !strings.Contains(rows[0].Error, "hold label") {
+		t.Fatalf("audit reason = %q, want the hold-label explanation", rows[0].Error)
+	}
+}

--- a/pkg/server/webhooks_prforge.go
+++ b/pkg/server/webhooks_prforge.go
@@ -273,10 +273,11 @@ func prforgeBaseURLFromRef(ref string) (baseURL, refusal string) {
 // GitHub/Forgejo lane — the same replier controls as the `/command` gate
 // (allowlist OR CollaboratorPermission ≥ the webhook's min_replier_role).
 // R6a15fe: the GitLab twin was gated in R7e050f for exactly this reason
-// ("the forge gates reviewer edits" is not an authorization story); this
-// lane is inert today (no connection shape can be a requested reviewer),
-// but wiring kept for a future connection kind must not arrive ungated.
-// Fail-closed on token resolution, like the GitLab twin.
+// ("the forge gates reviewer edits" is not an authorization story) — and
+// the lane is LIVE here: cfg.ReviewRequestLogins arms it with a User
+// identity (GitHub grants "request review" at the Triage role, below the
+// write floor this gate enforces). Fail-closed on token resolution, like
+// the GitLab twin.
 func (s *Server) realWebhookPRForgeReviewRequestGate(ctx context.Context, cfg webhooks.Config, p prforge.Parsed, botID string) (bool, string, error) {
 	token, terr := s.resolveForgeToken(ctx, cfg, botID)
 	if terr != nil || token == "" {

--- a/pkg/server/webhooks_prforge.go
+++ b/pkg/server/webhooks_prforge.go
@@ -335,19 +335,9 @@ func prforgePermRank(perm string) int {
 
 // replierMinRoleRank maps a MinReplierRole (gitlab vocabulary) to a rank.
 // Empty defaults to "developer" (matching the GitLab gate default), which
-// equals a GitHub "write" collaborator.
+// equals a GitHub "write" collaborator. Thin delegate: the table lives in
+// pkg/webhooks so the provision carry's stricter-of merge reads the same
+// ordering as the gates.
 func replierMinRoleRank(role string) int {
-	switch strings.ToLower(strings.TrimSpace(role)) {
-	case "owner":
-		return 5
-	case "maintainer":
-		return 4
-	case "developer", "":
-		return 3
-	case "reporter":
-		return 2
-	case "guest":
-		return 1
-	}
-	return 3
+	return webhooks.ReplierRoleRank(role)
 }

--- a/pkg/server/webhooks_routes.go
+++ b/pkg/server/webhooks_routes.go
@@ -39,20 +39,21 @@ func (s *Server) registerWebhookRoutes() {
 }
 
 type webhookConfigReq struct {
-	Name             *string  `json:"name,omitempty"`
-	Provider         *string  `json:"provider,omitempty"`
-	SignMode         *string  `json:"sign_mode,omitempty"`
-	Enabled          *bool    `json:"enabled,omitempty"`
-	BotIDs           []string `json:"bot_ids,omitempty"`
-	WildcardBots     *bool    `json:"wildcard_bots,omitempty"`
-	DefaultBotID     *string  `json:"default_bot_id,omitempty"`
-	ProjectAllowlist []string `json:"project_allowlist,omitempty"`
-	EventAllowlist   []string `json:"event_allowlist,omitempty"`
-	AuthorAllowlist  []string `json:"author_allowlist,omitempty"`
-	LabelAllowlist   []string `json:"label_allowlist,omitempty"`
-	HoldLabels       []string `json:"hold_labels,omitempty"`
-	BlockForkPRs     *bool    `json:"block_fork_prs,omitempty"`
-	ReviewOnSync     *bool    `json:"review_on_sync,omitempty"`
+	Name                *string  `json:"name,omitempty"`
+	Provider            *string  `json:"provider,omitempty"`
+	SignMode            *string  `json:"sign_mode,omitempty"`
+	Enabled             *bool    `json:"enabled,omitempty"`
+	BotIDs              []string `json:"bot_ids,omitempty"`
+	WildcardBots        *bool    `json:"wildcard_bots,omitempty"`
+	DefaultBotID        *string  `json:"default_bot_id,omitempty"`
+	ProjectAllowlist    []string `json:"project_allowlist,omitempty"`
+	EventAllowlist      []string `json:"event_allowlist,omitempty"`
+	AuthorAllowlist     []string `json:"author_allowlist,omitempty"`
+	LabelAllowlist      []string `json:"label_allowlist,omitempty"`
+	HoldLabels          []string `json:"hold_labels,omitempty"`
+	BlockForkPRs        *bool    `json:"block_fork_prs,omitempty"`
+	ReviewOnSync        *bool    `json:"review_on_sync,omitempty"`
+	ReviewRequestLogins []string `json:"review_request_logins,omitempty"`
 	// ReviewOnSyncPinned clears (false) or restates (true) the provenance
 	// pin an explicit review_on_sync set leaves behind; absent = derived
 	// from whether review_on_sync itself is being set.
@@ -267,6 +268,7 @@ func (s *Server) handleCreateWebhook(w http.ResponseWriter, r *http.Request) {
 		HoldLabels:          req.HoldLabels,
 		BlockForkPRs:        req.BlockForkPRs != nil && *req.BlockForkPRs,
 		ReviewOnSync:        req.ReviewOnSync != nil && *req.ReviewOnSync,
+		ReviewRequestLogins: req.ReviewRequestLogins,
 		ReviewOnSyncPinned:  req.ReviewOnSync != nil, // an explicit set at create is a decision too
 		Overlap:             overlapOrEmpty(req.Overlap),
 		AutoImplementOnOpen: req.AutoImplementOnOpen != nil && *req.AutoImplementOnOpen,
@@ -489,6 +491,9 @@ func (s *Server) handleUpdateWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.AuthorizedRepliers != nil {
 		cfg.AuthorizedRepliers = req.AuthorizedRepliers
+	}
+	if req.ReviewRequestLogins != nil {
+		cfg.ReviewRequestLogins = req.ReviewRequestLogins
 	}
 	if req.MinReplierRole != nil {
 		cfg.MinReplierRole = *req.MinReplierRole

--- a/pkg/server/webhooks_routes_test.go
+++ b/pkg/server/webhooks_routes_test.go
@@ -484,3 +484,73 @@ func TestWebhookHoldLabelsRoundTrip(t *testing.T) {
 		t.Fatalf("hold_labels not clearable: %v", stored.HoldLabels)
 	}
 }
+
+// TestWebhookReviewRequestLoginsPatch pins the PATCH ingress for
+// review_request_logins. A managed webhook is created by the orchestrator
+// (Provision), never by POST — so PATCH is the ONLY writer that can arm the
+// re-request lane on the configs the feature exists for. Create-only would
+// make the field dead on every provisioned repo.
+func TestWebhookReviewRequestLoginsPatch(t *testing.T) {
+	s := newWebhookTestServer(t)
+	ctx := superAdminCtx()
+
+	w := httptest.NewRecorder()
+	body := `{"name":"gh","bot_ids":["review-pr"],"review_request_logins":["iterion-bot"]}`
+	s.handleCreateWebhook(w, whReq(ctx, "POST", "/api/teams/t1/webhooks", body, "t1", ""))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create: code=%d body=%s", w.Code, w.Body.String())
+	}
+	var created struct {
+		Config webhooks.Config `json:"config"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if !slices.Equal(created.Config.ReviewRequestLogins, []string{"iterion-bot"}) {
+		t.Fatalf("review_request_logins dropped on create: %v", created.Config.ReviewRequestLogins)
+	}
+
+	// PATCH replaces the set — arming a provisioned webhook after the fact.
+	w = httptest.NewRecorder()
+	s.handleUpdateWebhook(w, whReq(ctx, "PATCH", "/api/teams/t1/webhooks/"+created.Config.ID,
+		`{"review_request_logins":["revu-bot"]}`, "t1", created.Config.ID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("patch: code=%d body=%s", w.Code, w.Body.String())
+	}
+	stored, err := s.webhookConfigs.Get(context.Background(), created.Config.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !slices.Equal(stored.ReviewRequestLogins, []string{"revu-bot"}) {
+		t.Fatalf("review_request_logins not applied on patch: %v", stored.ReviewRequestLogins)
+	}
+
+	// An omitted field leaves it untouched (a PATCH of something else must
+	// not silently disarm the button)...
+	w = httptest.NewRecorder()
+	s.handleUpdateWebhook(w, whReq(ctx, "PATCH", "/api/teams/t1/webhooks/"+created.Config.ID,
+		`{"name":"renamed"}`, "t1", created.Config.ID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("patch name: code=%d body=%s", w.Code, w.Body.String())
+	}
+	if stored, err = s.webhookConfigs.Get(context.Background(), created.Config.ID); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !slices.Equal(stored.ReviewRequestLogins, []string{"revu-bot"}) {
+		t.Fatalf("an unrelated patch cleared review_request_logins: %v", stored.ReviewRequestLogins)
+	}
+
+	// ...and an explicit empty list disarms it.
+	w = httptest.NewRecorder()
+	s.handleUpdateWebhook(w, whReq(ctx, "PATCH", "/api/teams/t1/webhooks/"+created.Config.ID,
+		`{"review_request_logins":[]}`, "t1", created.Config.ID))
+	if w.Code != http.StatusOK {
+		t.Fatalf("patch clear: code=%d body=%s", w.Code, w.Body.String())
+	}
+	if stored, err = s.webhookConfigs.Get(context.Background(), created.Config.ID); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(stored.ReviewRequestLogins) != 0 {
+		t.Fatalf("review_request_logins not clearable: %v", stored.ReviewRequestLogins)
+	}
+}

--- a/pkg/webhooks/match.go
+++ b/pkg/webhooks/match.go
@@ -158,3 +158,28 @@ func matchProjectPattern(pat, path string) bool {
 	}
 	return pat == path
 }
+
+// ReplierRoleRank maps a MinReplierRole value (gitlab vocabulary: guest |
+// reporter | developer | maintainer | owner) to an ordered rank AS THE GATES
+// READ IT: empty — never set — defaults to developer, and an unknown string
+// reads as that same default rather than silently opening the gate. Shared
+// by pkg/server's replier gates and the provision carry's stricter-of
+// comparison. NOT used by the provision's own derivation, whose table
+// deliberately ranks "" as zero ("no bot requires anything yet") so a
+// manifest can land a sub-developer floor — a caller comparing a
+// possibly-unset value must guard the empty string itself.
+func ReplierRoleRank(role string) int {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case "owner":
+		return 5
+	case "maintainer":
+		return 4
+	case "developer", "":
+		return 3
+	case "reporter":
+		return 2
+	case "guest":
+		return 1
+	}
+	return 3
+}

--- a/pkg/webhooks/types.go
+++ b/pkg/webhooks/types.go
@@ -162,6 +162,26 @@ type Config struct {
 	// triage+ rights on the forge, which IS the approval gesture.
 	MinAuthorRole string `bson:"min_author_role,omitempty" json:"min_author_role,omitempty"`
 
+	// ReviewRequestLogins names the review identities whose (re-)request the
+	// on-demand re-review lane answers, IN ADDITION to the one derived from the
+	// webhook's forge connection. It is what makes that lane reachable on
+	// GitHub at all: a GitHub App cannot be a requested reviewer, so the button
+	// only exists for a User account — and the review must be POSTED by that
+	// same account for the forge to clear the pending request and re-arm it,
+	// which is what a `pat` connection to a dedicated bot user gives.
+	//
+	// EXPLICIT ONLY, never derived from the connection's account: the PAT
+	// connect path stamps whatever token was pasted, typically a maintainer's
+	// own, and deriving would turn every ordinary reviewer ping addressed to
+	// that human into a bot run — the reasoning isIterionForgeBotAuthor already
+	// applies when it refuses to trust AccountLogin on GitHub.
+	//
+	// The logins join iterionBotLogins, so BOTH halves of the identity read the
+	// same set: the lane answers their request, and the actor guard recognises
+	// their own PRs and their own reviewer-writes. An identity only one half
+	// knew would launch on the bot's own echo.
+	ReviewRequestLogins []string `bson:"review_request_logins,omitempty" json:"review_request_logins,omitempty"`
+
 	// ReviewOnSync, when true, re-runs the review bot on a PR "synchronize"
 	// (a push to the PR head), not only on opened/reopened. OFF by default
 	// (a push is normally on-demand re-review — see prforge.IsReviewable, kept


### PR DESCRIPTION
`Config.ReviewRequestLogins` names the bot **User** account whose review requests arm the re-request lane — the one shape GitHub can re-request (a GitHub App cannot be a requested reviewer; deriving from a PAT/OAuth connection would turn every reviewer ping at a human maintainer into a bot run, so the identity is explicit only). The logins join `iterionBotLogins`, so both halves of the loop guard read one set. Settable at create AND PATCH (the orchestrator provisions managed configs, so PATCH is the only writer that can arm them).

Carried with it, shaped by four Revi rounds on this PR (3→3→5→0 findings, all real, every behaviour guard mutation-verified):

- **the hold label's veto over the lane** on both providers (the forge emits the same event for a CODEOWNERS auto-request — nothing distinguishes it from a click);
- **the CODEOWNERS double-launch closed on idempotency**: three-way per-head choice — in flight → collapse (audited), finished → salt (repeatable click), unclaimed → per-head key (order-independent); stranded `accepted` rows expire after 10 min;
- **`carryOperatorWebhookSettings`**: a re-provision no longer wipes the operator-settable webhook fields (`review_request_logins`, `authorized_repliers`, `key_overrides`, limits…); `min_replier_role` merges stricter-of-the-two on the shared `webhooks.ReplierRoleRank` ordering;
- docs: webhooks.md / merge-gate.md / forge-integrations.md aligned.

**History note**: originally stacked on #604; rebuilt as this single commit on `main` after #604 merged and #608 landed the GitHub/Forgejo replier gate there (convergent fix — both Revi loops demanded the same gate). The full review dialogue lives in the comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
