### PR TITLE
fix(server): refuse team-less identities at the auth choke — no more empty-tenant panics on /api/runs* (Sentry ITERION-13/-1W/-1Z)

### DIFF
--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -133,11 +133,14 @@ func (s *Server) requireAuth(next http.Handler) http.Handler {
 //     irrelevant there by design
 //   - /api/admin/ : super-admin surfaces (WithoutTenantFilter by design;
 //     non-admins are 403'd by requireSuperAdmin)
-var tenantFreePrefixes = []string{"/api/auth/", "/api/me", "/api/orgs", "/api/teams/", "/api/admin/"}
+// Prefixes end with "/" and are matched segment-exactly below —
+// "/api/me/" must NOT admit "/api/memory/..." (tenant-scoped workspace
+// memory), which a bare HasPrefix("/api/me") would.
+var tenantFreePrefixes = []string{"/api/auth/", "/api/me/", "/api/orgs/", "/api/teams/", "/api/admin/"}
 
 func tenantFreePath(p string) bool {
 	for _, pre := range tenantFreePrefixes {
-		if strings.HasPrefix(p, pre) {
+		if strings.HasPrefix(p, pre) || p == strings.TrimSuffix(pre, "/") {
 			return true
 		}
 	}

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -133,12 +133,25 @@ func (s *Server) requireAuth(next http.Handler) http.Handler {
 //     irrelevant there by design
 //   - /api/admin/ : super-admin surfaces (WithoutTenantFilter by design;
 //     non-admins are 403'd by requireSuperAdmin)
+//
 // Prefixes end with "/" and are matched segment-exactly below —
 // "/api/me/" must NOT admit "/api/memory/..." (tenant-scoped workspace
 // memory), which a bare HasPrefix("/api/me") would.
 var tenantFreePrefixes = []string{"/api/auth/", "/api/me/", "/api/orgs/", "/api/teams/", "/api/admin/"}
 
 func tenantFreePath(p string) bool {
+	return tenantFreePathMethod("", p)
+}
+
+// tenantFreePathMethod is tenantFreePath plus the method-scoped public
+// surfaces: marketplace READS are public for anonymous callers, so a
+// signed-in but team-less viewer must not get LESS than an anonymous
+// one (gate F2 — the choke used to 403 before the routing bypass could
+// apply). The handlers are tenant-agnostic for a caller with no tenant.
+func tenantFreePathMethod(method, p string) bool {
+	if isPublicMarketplaceRead(method, p) {
+		return true
+	}
 	for _, pre := range tenantFreePrefixes {
 		if strings.HasPrefix(p, pre) || p == strings.TrimSuffix(pre, "/") {
 			return true
@@ -155,9 +168,9 @@ func tenantFreePath(p string) bool {
 func (s *Server) stampAuthedContext(w http.ResponseWriter, r *http.Request, id auth.Identity) (context.Context, bool) {
 	ctx := auth.WithIdentity(r.Context(), id)
 	if id.TeamID == "" {
-		if !tenantFreePath(r.URL.Path) {
+		if !tenantFreePathMethod(r.Method, r.URL.Path) {
 			httpError(w, http.StatusForbidden,
-				"credential has no active team — switch to a team (or re-issue the token with one) before calling tenant-scoped endpoints")
+				"credential has no active team — switch to a team in the studio, or re-create the token/ticket with an explicit team, before calling tenant-scoped endpoints")
 			return nil, false
 		}
 		// No tenant to stamp: tenant-free handlers read the auth

--- a/pkg/server/middleware.go
+++ b/pkg/server/middleware.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strings"
@@ -56,8 +57,10 @@ func (s *Server) requireAuth(next http.Handler) http.Handler {
 				httpError(w, http.StatusUnauthorized, "invalid or expired ws ticket")
 				return
 			}
-			ctx := auth.WithIdentity(r.Context(), id)
-			ctx = store.WithIdentity(ctx, id.TeamID, id.UserID)
+			ctx, ok := s.stampAuthedContext(w, r, id)
+			if !ok {
+				return
+			}
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
@@ -99,10 +102,67 @@ func (s *Server) requireAuth(next http.Handler) http.Handler {
 		// and the store-level tenant_id / user_id (for the Mongo
 		// query filters in pkg/store/mongo). The store layer keeps
 		// its own keys so it can stay independent of pkg/auth.
-		ctx := auth.WithIdentity(r.Context(), id)
-		ctx = store.WithIdentity(ctx, id.TeamID, id.UserID)
+		ctx, ok := s.stampAuthedContext(w, r, id)
+		if !ok {
+			return
+		}
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// tenantFreePrefixes lists the routes an authenticated but TEAM-LESS
+// identity may still reach: the account/tenancy surfaces needed to GET
+// an active team (profile, sessions, switch-team — which mints a
+// teamful JWT — under /api/auth/), org bootstrap (/api/orgs), and the
+// super-admin surfaces (/api/admin/), which query the store under
+// WithoutTenantFilter by design (non-admins are 403'd by
+// requireSuperAdmin regardless). Everything else is tenant-scoped:
+// letting a team-less ctx through used to reach the Mongo store's
+// fail-closed tenant guard as a recovered PANIC on every request — a
+// silent 500 for the caller and pure noise burying real crashes
+// (Sentry ITERION-13/-1W/-1Z, 1800+ events). The rejection below is
+// explicit and actionable instead; the store guard stays as the
+// last-resort backstop.
+//   - /api/auth/  : profile, sessions, switch-team (mints a teamful JWT)
+//   - /api/me     : USER-scoped resources (oauth connections, sso links —
+//     their handlers key on id.UserID, never the tenant)
+//   - /api/orgs   : org bootstrap/listing
+//   - /api/teams/ : team administration scoped by the PATH's team id —
+//     the handlers resolve membership and stamp the target
+//     team themselves; the caller's ACTIVE team is
+//     irrelevant there by design
+//   - /api/admin/ : super-admin surfaces (WithoutTenantFilter by design;
+//     non-admins are 403'd by requireSuperAdmin)
+var tenantFreePrefixes = []string{"/api/auth/", "/api/me", "/api/orgs", "/api/teams/", "/api/admin/"}
+
+func tenantFreePath(p string) bool {
+	for _, pre := range tenantFreePrefixes {
+		if strings.HasPrefix(p, pre) {
+			return true
+		}
+	}
+	return false
+}
+
+// stampAuthedContext writes the resolved identity onto the request
+// context — the auth identity always, the store-level tenant only when
+// the identity carries one. A team-less identity on a tenant-scoped
+// route is refused here (the ONE choke point for every requireAuth
+// route), never handed to the store with an empty tenant.
+func (s *Server) stampAuthedContext(w http.ResponseWriter, r *http.Request, id auth.Identity) (context.Context, bool) {
+	ctx := auth.WithIdentity(r.Context(), id)
+	if id.TeamID == "" {
+		if !tenantFreePath(r.URL.Path) {
+			httpError(w, http.StatusForbidden,
+				"credential has no active team — switch to a team (or re-issue the token with one) before calling tenant-scoped endpoints")
+			return nil, false
+		}
+		// No tenant to stamp: tenant-free handlers read the auth
+		// identity (or opt out via WithoutTenantFilter); any
+		// tenant-scoped store call remains guarded fail-closed.
+		return ctx, true
+	}
+	return store.WithIdentity(ctx, id.TeamID, id.UserID), true
 }
 
 // isSuperAdmin reports whether the request carries a platform

--- a/pkg/server/middleware_tenant_test.go
+++ b/pkg/server/middleware_tenant_test.go
@@ -103,3 +103,15 @@ func TestTenantFreePathIsSegmentExact(t *testing.T) {
 		}
 	}
 }
+
+// Gate F2: a signed-in but team-less viewer must not get LESS than an
+// anonymous one on the public marketplace reads.
+func TestTenantFreeAdmitsPublicMarketplaceReads(t *testing.T) {
+	t.Parallel()
+	if !tenantFreePathMethod("GET", "/api/v1/marketplace/bots") {
+		t.Fatal("GET /api/v1/marketplace/bots must stay reachable for a team-less signed-in viewer")
+	}
+	if tenantFreePathMethod("POST", "/api/v1/marketplace/bots") {
+		t.Fatal("marketplace WRITES are not public")
+	}
+}

--- a/pkg/server/middleware_tenant_test.go
+++ b/pkg/server/middleware_tenant_test.go
@@ -77,3 +77,29 @@ func TestRequireAuthRefusesTeamlessOnTenantScopedRoutes(t *testing.T) {
 		t.Fatalf("teamful request tenant = (%q, %v), want (team-9, true)", sawTenant, sawTenantOK)
 	}
 }
+
+// The allowlist is segment-exact: "/api/me/" must not admit
+// "/api/memory/…" (tenant-scoped workspace memory) — a bare prefix
+// match would silently reopen the empty-tenant hole there.
+func TestTenantFreePathIsSegmentExact(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"/api/me":              true,
+		"/api/me/oauth/claude": true,
+		"/api/memory/usage":    false,
+		"/api/memory":          false,
+		"/api/orgs":            true,
+		"/api/orgsomething":    false,
+		"/api/teams/t1/audit":  true,
+		"/api/teamsync":        false,
+		"/api/auth/me":         true,
+		"/api/admin/llm":       true,
+		"/api/administrivia":   false,
+		"/api/runs":            false,
+	}
+	for p, want := range cases {
+		if got := tenantFreePath(p); got != want {
+			t.Errorf("tenantFreePath(%q) = %v, want %v", p, got, want)
+		}
+	}
+}

--- a/pkg/server/middleware_tenant_test.go
+++ b/pkg/server/middleware_tenant_test.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// A team-less authenticated identity used to sail through requireAuth
+// and reach the Mongo store with an EMPTY tenant in ctx — the store's
+// fail-closed guard then panicked on every request (a recovered 500,
+// Sentry ITERION-13/-1W/-1Z, 1800+ events). The choke point refuses it
+// with an explicit 403 on tenant-scoped routes, and still admits the
+// tenancy-management surfaces the user needs to GET a team.
+func TestRequireAuthRefusesTeamlessOnTenantScopedRoutes(t *testing.T) {
+	t.Parallel()
+	secret := base64.StdEncoding.EncodeToString(make([]byte, 32))
+	signer, err := auth.NewJWTSigner(secret, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{signer: signer}
+
+	mint := func(teamID string) string {
+		tok, _, err := signer.IssueAccess(auth.Identity{UserID: "u1", Email: "u@x", TeamID: teamID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return tok
+	}
+
+	var sawTenant string
+	var sawTenantOK bool
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawTenant, sawTenantOK = store.TenantFromContext(r.Context())
+		w.WriteHeader(http.StatusNoContent)
+	})
+	h := s.requireAuth(inner)
+
+	call := func(path, token string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest("GET", path, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		return w
+	}
+
+	// Team-less on a tenant-scoped route: explicit 403, handler never runs.
+	sawTenantOK = false
+	if w := call("/api/runs", mint("")); w.Code != http.StatusForbidden {
+		t.Fatalf("teamless GET /api/runs = %d, want 403 — an empty tenant in ctx panics the mongo guard as a silent 500", w.Code)
+	}
+	if sawTenantOK {
+		t.Fatal("handler ran despite the refusal")
+	}
+
+	// Team-less on the tenancy-management surface: admitted, NO store
+	// tenant stamped (the guard stays the backstop for a stray
+	// tenant-scoped call).
+	if w := call("/api/auth/me", mint("")); w.Code != http.StatusNoContent {
+		t.Fatalf("teamless GET /api/auth/me = %d, want 204 — the user must be able to reach switch-team", w.Code)
+	}
+	if sawTenantOK {
+		t.Fatalf("teamless admitted request carried a store tenant %q — must carry none", sawTenant)
+	}
+
+	// Teamful identity: unchanged — tenant stamped, handler runs.
+	if w := call("/api/runs", mint("team-9")); w.Code != http.StatusNoContent {
+		t.Fatalf("teamful GET /api/runs = %d, want 204", w.Code)
+	}
+	if !sawTenantOK || sawTenant != "team-9" {
+		t.Fatalf("teamful request tenant = (%q, %v), want (team-9, true)", sawTenant, sawTenantOK)
+	}
+}

--- a/pkg/server/pat_routes.go
+++ b/pkg/server/pat_routes.go
@@ -67,6 +67,21 @@ func (s *Server) handleCreatePAT(w http.ResponseWriter, r *http.Request) {
 		httpError(w, http.StatusForbidden, "not a member of team %q", req.TeamID)
 		return
 	}
+	// Pin the creator's ACTIVE team when none is requested — and refuse
+	// outright when there is neither: a PAT identity is fixed, so an
+	// unpinned token whose owner has no team could never authenticate
+	// (identityFromPAT refuses it), yet it would still be minted 201
+	// with its plaintext shown once — a dead credential and a support
+	// ticket. Super-admins keep unpinned tokens (the /api/admin
+	// surfaces are tenant-free by design). Gate F1 of the PR review.
+	if req.TeamID == "" && !id.IsSuperAdmin {
+		if id.TeamID == "" {
+			httpError(w, http.StatusBadRequest,
+				"team_id required — your account has no active team, so an unpinned token could never authenticate")
+			return
+		}
+		req.TeamID = id.TeamID
+	}
 	now := time.Now().UTC()
 	var expiresAt *time.Time
 	if req.ExpiresInDays > 0 {

--- a/pkg/server/pat_routes.go
+++ b/pkg/server/pat_routes.go
@@ -174,6 +174,15 @@ func (s *Server) identityFromPAT(ctx context.Context, presented string) (auth.Id
 	if teamID == "" {
 		teamID = u.DefaultTeamID
 	}
+	// A PAT identity is FIXED — no session to switch teams on — so a
+	// token that resolves to no team can never do tenant-scoped work.
+	// Refuse it explicitly here rather than 403 it per-request (super-
+	// admins excepted: the /api/admin surfaces are tenant-free by
+	// design). This is the mint-side half of the requireAuth tenant
+	// choke (Sentry ITERION-13/-1W/-1Z).
+	if teamID == "" && !u.IsSuperAdmin {
+		return auth.Identity{}, errors.New("token carries no team scope (owner has no default team) — re-create it with an explicit team")
+	}
 	var role identity.Role
 	var orgID string
 	if teamID != "" {


### PR DESCRIPTION
First fix out of the Sentry feedback loop ([docs/sentry-feedback-loop.md](docs/sentry-feedback-loop.md)) — card native:c4573216 (p8, 1800+ events since 2026-08-24).

## The defect

An authenticated identity whose `TeamID` resolved empty (team-less PAT with a team-less owner, GitHub-gated user pre-grant) passed `requireAuth` and reached Mongo with an EMPTY tenant in ctx. The store's fail-closed guard — correct, the alternative is cross-tenant leakage — then panicked per request: a recovered 500 for the caller and steady-state Sentry noise (`GET /api/runs` ×1763, `GET /api/runs/{id}`, the run WebSocket).

## The fix — one choke point

- `stampAuthedContext` (shared by the ws-ticket and bearer paths of `requireAuth`): a team-less identity on a tenant-scoped route gets an explicit, actionable **403**; on the tenant-free surfaces (`/api/auth/`, `/api/me`, `/api/orgs`, `/api/teams/` path-scoped admin, `/api/admin/`) it is admitted with **no store tenant stamped** — the guard stays the last-resort backstop.
- Mint-side belt: `identityFromPAT` refuses a token resolving to no team for a non-super-admin owner (a PAT can never switch teams — it could never do tenant-scoped work anyway; the error says how to re-create it).

## Proof

Choke test drives real JWTs through `requireAuth`: refusal (handler never runs), tenant-free admission (no stamped tenant), teamful unchanged — mutation-proven red. Full suite 133 pkgs green; the two suites that legitimately mint team-less identities (`/api/me/oauth`, `/api/teams/{id}/forge`) pass because those surfaces are user-/path-scoped by design and documented as such in the allowlist.

Post-deploy check: ITERION-13/-1W/-1Z stop receiving events; `iterion remote api GET /api/runs` with a team-less credential returns 403 with the actionable message, not 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)