### PR TITLE
fix(webhooks): the re-request replier gate reaches the prforge lane; an authz error never strands a co-riding resync

### DIFF
--- a/pkg/runner/org_spend_test.go
+++ b/pkg/runner/org_spend_test.go
@@ -63,20 +63,22 @@ func TestRecordOrgSpendKey(t *testing.T) {
 // launched without --timeout, where a wedged clone used to pin the
 // runner pod (one in-flight run each) forever.
 func TestGitOpTimeoutBoundsSubprocess(t *testing.T) {
-	old := gitOpTimeout
-	gitOpTimeout = 300 * time.Millisecond
-	defer func() { gitOpTimeout = old }()
-
 	r := &Runner{cfg: Config{Logger: iterlog.Nop()}}
 	// A fetch against RFC 5737 TEST-NET-1 blackholes (SYN never answered)
 	// on typical hosts, wedging git in the TCP connect — the shape of a
 	// stalled remote. On environments that instead answer/refuse fast the
 	// command errors immediately and the elapsed assertion still holds:
 	// the property under test is "runGit RETURNS promptly", not the error.
+	// The init setup runs under the DEFAULT timeout: on a loaded CI
+	// runner even `git init` can outlive a tight test override.
 	dir := t.TempDir()
 	if err := r.runGit(context.Background(), dir, "", "init", "-q"); err != nil {
 		t.Fatalf("git init: %v", err)
 	}
+
+	old := gitOpTimeout
+	gitOpTimeout = time.Second
+	defer func() { gitOpTimeout = old }()
 	start := time.Now()
 	_ = r.runGit(context.Background(), dir, "", "fetch", "http://192.0.2.1/repo.git")
 	if elapsed := time.Since(start); elapsed > 5*time.Second {

--- a/pkg/runtime/budget_test.go
+++ b/pkg/runtime/budget_test.go
@@ -1785,13 +1785,16 @@ func TestBudgetGraceCoversDuration(t *testing.T) {
 		Prompts: map[string]*ir.Prompt{},
 		Vars:    map[string]*ir.Var{},
 		Loops:   map[string]*ir.Loop{},
-		Budget:  &ir.Budget{MaxDuration: "300ms"},
+		Budget:  &ir.Budget{MaxDuration: "2s"},
 	}
 
 	exec := newStubExecutor()
 	tailRan := false
 	exec.on("work", func(_ map[string]any) (map[string]any, error) {
-		time.Sleep(350 * time.Millisecond) // past the 300ms cap, inside the 450ms graced ceiling
+		// Past the 2s cap, inside the 3.8s graced ceiling (2s × 1.9) with
+		// ~1.5s of slack: a loaded CI runner adds close to a second of
+		// engine overhead, which a tighter window reads as a real overrun.
+		time.Sleep(2300 * time.Millisecond)
 		return map[string]any{"ok": true}, nil
 	})
 	exec.on("tail", func(_ map[string]any) (map[string]any, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -269,6 +269,10 @@ type Server struct {
 	// controls as every other manual trigger). nil →
 	// realWebhookReviewRequestGate.
 	webhookReviewRequestGate func(ctx context.Context, cfg webhooks.Config, p gitlab.Parsed, botID string) (authorized bool, reason string, err error)
+	// webhookPRForgeReviewRequestGate is the GitHub/Forgejo twin of
+	// webhookReviewRequestGate (test seam). nil →
+	// realWebhookPRForgeReviewRequestGate.
+	webhookPRForgeReviewRequestGate func(ctx context.Context, cfg webhooks.Config, p prforge.Parsed, botID string) (authorized bool, reason string, err error)
 	// webhookHandoff overrides the lookup of what an earlier run on the same
 	// PR produced (a review, or a fixer's reply to one), which seeds a launch var
 	// the launched bot declared it consumes (test seam). nil → realWebhookHandoff.

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -104,14 +104,14 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 	// A review request explicitly targeting iterion's own forge identity —
 	// the "Re-request review" button (or first "Request review") on the bot
 	// reviewer — is the button form of `/revi`: a deliberate on-demand
-	// re-review. The forge itself gates who may edit a PR's reviewers (write
-	// access), so no extra replier authz applies — but only on an OPEN PR
-	// (reviewer edits arrive freely on closed/merged ones). Never when the
-	// actor IS the bot: its own reviewer-write echoing back must not launch
-	// a review of itself. The identity matched is iterionBotLogins — on
-	// GitHub/Forgejo that is the App bot login only (a PAT/OAuth account may
-	// be a HUMAN's), and a GitHub App cannot be a reviewer at all, so on
-	// GitHub this lane stays inert and `/revi` is the on-demand path.
+	// re-review, only on an OPEN PR (reviewer edits arrive freely on
+	// closed/merged ones). Never when the actor IS the bot: its own
+	// reviewer-write echoing back must not launch a review of itself. The
+	// identity matched is iterionBotLogins — on GitHub/Forgejo that is the
+	// App bot login only (a PAT/OAuth account may be a HUMAN's), and a
+	// GitHub App cannot be a reviewer at all, so on GitHub this lane stays
+	// inert and `/revi` is the on-demand path. The gesture is PROVISIONAL
+	// until the replier gate below the scope filter confirms it (R6a15fe).
 	reviewRequested := strings.EqualFold(p.State, "open") &&
 		s.isIterionBotReviewRequest(ctx, cfg, p.ReviewRequestedFrom) &&
 		!s.isIterionForgeBotAuthor(ctx, cfg, p.SenderLogin)
@@ -120,49 +120,8 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 	// so the revi/review status re-evaluates on the new head SHA. Never on a
 	// closed/merged PR (a push to a dead PR's branch still delivers
 	// synchronize); fail-open on a payload without `state` — a filtered
-	// resync strands the required check. Computed here (not at the review
-	// filter below) because the replier gate's error policy reads it.
+	// resync strands the required check.
 	gateResync := cfg.ReviewOnSync && p.IsSynchronize() && p.StateOpenOrUnknown()
-
-	// Replier authorization (R6a15fe — the GitLab twin's R7e050f gate,
-	// applied to this lane too): a manual gesture rides the same
-	// AuthorizedRepliers/MinReplierRole controls as every `/command`. An
-	// unauthorized click DEMOTES the gesture (the delivery then rides
-	// whatever automatic lane still admits it, hold label honoured, or is
-	// filtered). An authz ERROR demotes too when an automatic lane co-rides
-	// the event (R34eb8c — a transient members-API failure must not strand
-	// a merge-gate resync), and 502s only when the click was the delivery's
-	// sole reason (so the forge redelivers it).
-	if reviewRequested {
-		botID := ""
-		if rr := s.resolveForgeEventBots(cfg, bundle.ForgeEventPullRequest, p.Author()); len(rr) > 0 {
-			botID = rr[0].BotID
-		}
-		gate := s.webhookPRForgeReviewRequestGate
-		if gate == nil {
-			gate = s.realWebhookPRForgeReviewRequestGate
-		}
-		authorized, reason, gerr := gate(ctx, cfg, p, botID)
-		if gerr != nil {
-			if p.IsReviewable() || gateResync {
-				if s.logger != nil {
-					s.logger.Warn("webhooks: %s re-request authz errored (%v) — gesture demoted, the automatic lane proceeds", cfg.Provider, gerr)
-				}
-				reviewRequested = false
-			} else {
-				s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusLaunchError, payloadHash, srcIP, "re-request authz check: "+gerr.Error())
-				httpError(w, http.StatusBadGateway, "authorization check failed")
-				return
-			}
-		} else if !authorized {
-			reviewRequested = false
-			if !p.IsReviewable() && !gateResync && !p.NeedsAutoHeal() {
-				s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, reason)
-				writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
-				return
-			}
-		}
-	}
 
 	// Hold-label gate (bot-agnostic, opt-in): a configured hold label on the PR
 	// vetoes EVERY auto-launch this handler can do (auto-heal and review alike)
@@ -221,6 +180,52 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, "")
 		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
 		return
+	}
+
+	// Replier authorization (R6a15fe — the GitLab twin's R7e050f gate,
+	// applied to this lane too): a manual gesture rides the same
+	// AuthorizedRepliers/MinReplierRole controls as every `/command`.
+	// Deliberately AFTER the event/project/author scope filter (R0c3aab):
+	// an out-of-scope delivery must never cost a forge API call, nor be
+	// able to 502 the endpoint. An unauthorized click DEMOTES the gesture —
+	// the delivery then rides whatever automatic lane still admits it, with
+	// the hold label RE-APPLIED (it was provisionally waived under the
+	// gesture's authority) — or is filtered. An authz ERROR demotes too
+	// when an automatic lane co-rides the event (R34eb8c — a transient
+	// members-API failure must not strand a merge-gate resync), and 502s
+	// only when the click was the delivery's sole reason (so the forge
+	// redelivers it).
+	if reviewRequested {
+		botID := ""
+		if rr := s.resolveForgeEventBots(cfg, bundle.ForgeEventPullRequest, p.Author()); len(rr) > 0 {
+			botID = rr[0].BotID
+		}
+		gate := s.webhookPRForgeReviewRequestGate
+		if gate == nil {
+			gate = s.realWebhookPRForgeReviewRequestGate
+		}
+		authorized, reason, gerr := gate(ctx, cfg, p, botID)
+		switch {
+		case gerr != nil && (p.IsReviewable() || gateResync):
+			if s.logger != nil {
+				s.logger.Warn("webhooks: %s re-request authz errored (%v) — gesture demoted, the automatic lane proceeds", cfg.Provider, gerr)
+			}
+			reviewRequested = false
+		case gerr != nil:
+			s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusLaunchError, payloadHash, srcIP, "re-request authz check: "+gerr.Error())
+			httpError(w, http.StatusBadGateway, "authorization check failed")
+			return
+		case !authorized:
+			reviewRequested = false
+			if !p.IsReviewable() && !gateResync {
+				s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, reason)
+				writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+				return
+			}
+		}
+		if !reviewRequested && s.suppressedByHoldLabel(ctx, w, cfg, meta, p.Labels, payloadHash, srcIP) {
+			return
+		}
 	}
 
 	// Iterion-bot guard: a PR opened by iterion's OWN forge bot (Doki/Willy/

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -116,6 +116,54 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 		s.isIterionBotReviewRequest(ctx, cfg, p.ReviewRequestedFrom) &&
 		!s.isIterionForgeBotAuthor(ctx, cfg, p.SenderLogin)
 
+	// The merge gate opts synchronize (a push to the head) back into review
+	// so the revi/review status re-evaluates on the new head SHA. Never on a
+	// closed/merged PR (a push to a dead PR's branch still delivers
+	// synchronize); fail-open on a payload without `state` — a filtered
+	// resync strands the required check. Computed here (not at the review
+	// filter below) because the replier gate's error policy reads it.
+	gateResync := cfg.ReviewOnSync && p.IsSynchronize() && p.StateOpenOrUnknown()
+
+	// Replier authorization (R6a15fe — the GitLab twin's R7e050f gate,
+	// applied to this lane too): a manual gesture rides the same
+	// AuthorizedRepliers/MinReplierRole controls as every `/command`. An
+	// unauthorized click DEMOTES the gesture (the delivery then rides
+	// whatever automatic lane still admits it, hold label honoured, or is
+	// filtered). An authz ERROR demotes too when an automatic lane co-rides
+	// the event (R34eb8c — a transient members-API failure must not strand
+	// a merge-gate resync), and 502s only when the click was the delivery's
+	// sole reason (so the forge redelivers it).
+	if reviewRequested {
+		botID := ""
+		if rr := s.resolveForgeEventBots(cfg, bundle.ForgeEventPullRequest, p.Author()); len(rr) > 0 {
+			botID = rr[0].BotID
+		}
+		gate := s.webhookPRForgeReviewRequestGate
+		if gate == nil {
+			gate = s.realWebhookPRForgeReviewRequestGate
+		}
+		authorized, reason, gerr := gate(ctx, cfg, p, botID)
+		if gerr != nil {
+			if p.IsReviewable() || gateResync {
+				if s.logger != nil {
+					s.logger.Warn("webhooks: %s re-request authz errored (%v) — gesture demoted, the automatic lane proceeds", cfg.Provider, gerr)
+				}
+				reviewRequested = false
+			} else {
+				s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusLaunchError, payloadHash, srcIP, "re-request authz check: "+gerr.Error())
+				httpError(w, http.StatusBadGateway, "authorization check failed")
+				return
+			}
+		} else if !authorized {
+			reviewRequested = false
+			if !p.IsReviewable() && !gateResync && !p.NeedsAutoHeal() {
+				s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, reason)
+				writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+				return
+			}
+		}
+	}
+
 	// Hold-label gate (bot-agnostic, opt-in): a configured hold label on the PR
 	// vetoes EVERY auto-launch this handler can do (auto-heal and review alike)
 	// — the operator's escape hatch to pause automation on one PR. Placed before
@@ -160,13 +208,8 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 		return
 	}
 
-	// The merge gate opts synchronize (a push to the head) back into review so
-	// the revi/review status re-evaluates on the new head SHA; otherwise only
-	// opened/reopened/ready_for_review review (on-demand re-review on push).
-	// Never on a closed/merged PR (a push to a dead PR's branch still
-	// delivers synchronize); fail-open on a payload without `state` — a
-	// filtered resync strands the required check.
-	gateResync := cfg.ReviewOnSync && p.IsSynchronize() && p.StateOpenOrUnknown()
+	// Auto-review on opened/reopened/ready_for_review, plus the resync and
+	// re-request lanes resolved above.
 	reviewable := p.IsReviewable() || gateResync || reviewRequested
 	if !reviewable ||
 		!webhooks.MatchEvent(cfg.EventAllowlist, "pull_request", "pull_request") ||

--- a/pkg/server/webhooks_github_test.go
+++ b/pkg/server/webhooks_github_test.go
@@ -141,6 +141,9 @@ func TestGitHubWebhook_ReviewRequestedLaunches(t *testing.T) {
 	s.webhookIterionBotAuthor = func(_ context.Context, _ webhooks.Config, login string) bool {
 		return login == "iterion-bot"
 	}
+	s.webhookPRForgeReviewRequestGate = func(context.Context, webhooks.Config, prforge.Parsed, string) (bool, string, error) {
+		return true, "test-gate", nil
+	}
 	cfg, pt := ghConfig(t, s)
 
 	// The open claims the head under the ordinary key space…
@@ -746,6 +749,40 @@ func TestGitHubWebhook_BotNotAllowed(t *testing.T) {
 	}
 	if got := w.Body.String(); !strings.Contains(got, webhooks.StatusFiltered) {
 		t.Fatalf("bot not allowed: want filtered status, got %s", got)
+	}
+}
+
+// R6a15fe: the GitHub/Forgejo re-request lane rides the same replier gate as
+// its GitLab twin — with no stub the production gate fail-closes on the
+// missing forge token, an explicit refusal filters, and an authz ERROR 502s
+// only when the click was the delivery's sole reason (R34eb8c).
+func TestGitHubWebhook_ReviewRequestedUnauthorizedFiltered(t *testing.T) {
+	s := newWebhookTestServer(t)
+	var calls int
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		calls++
+		return "run1", nil
+	}
+	s.webhookIterionBotReviewRequest = func(_ context.Context, _ webhooks.Config, requested func(string) bool) bool {
+		return requested("iterion-bot")
+	}
+	cfg, pt := ghConfig(t, s)
+
+	// Production gate, no stub: no forge token → refused, filtered.
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewRequested("mallory", "iterion-bot", "2026-09-01T10:00:00Z"), prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusOK || calls != 0 {
+		t.Fatalf("unauthorized: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+
+	// Authz error on a re-request-only delivery → 502 (forge redelivers).
+	s.webhookPRForgeReviewRequestGate = func(context.Context, webhooks.Config, prforge.Parsed, string) (bool, string, error) {
+		return false, "", context.DeadlineExceeded
+	}
+	w2 := httptest.NewRecorder()
+	s.handleGitHubWebhook(w2, ghReq(ghCtx(cfg), ghReviewRequested("mallory", "iterion-bot", "2026-09-01T10:01:00Z"), prforge.EventHeaderPullRequest, pt))
+	if w2.Code != http.StatusBadGateway || calls != 0 {
+		t.Fatalf("authz error must 502: code=%d calls=%d body=%s", w2.Code, calls, w2.Body.String())
 	}
 }
 

--- a/pkg/server/webhooks_github_test.go
+++ b/pkg/server/webhooks_github_test.go
@@ -786,6 +786,42 @@ func TestGitHubWebhook_ReviewRequestedUnauthorizedFiltered(t *testing.T) {
 	}
 }
 
+// R0c3aab: the replier gate runs AFTER the event/project/author scope filter
+// — an out-of-scope delivery must never cost a forge API call nor be able to
+// 502 the endpoint. And when the gate demotes the gesture, the hold label it
+// had provisionally waived is re-applied.
+func TestGitHubWebhook_ReviewRequestScopeFilterBeforeGate(t *testing.T) {
+	s := newWebhookTestServer(t)
+	var launches, gateCalls int
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		launches++
+		return "run1", nil
+	}
+	s.webhookIterionBotReviewRequest = func(_ context.Context, _ webhooks.Config, requested func(string) bool) bool {
+		return requested("iterion-bot")
+	}
+	s.webhookPRForgeReviewRequestGate = func(context.Context, webhooks.Config, prforge.Parsed, string) (bool, string, error) {
+		gateCalls++
+		return false, "", context.DeadlineExceeded // would 502 if ever reached
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.ProjectAllowlist = []string{"other/repo"} // acme/widgets is out of scope
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewRequested("alice", "iterion-bot", "2026-09-01T12:00:00Z"), prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusOK || launches != 0 {
+		t.Fatalf("out-of-scope must filter: code=%d launches=%d body=%s", w.Code, launches, w.Body.String())
+	}
+	if gateCalls != 0 {
+		t.Fatalf("out-of-scope delivery reached the forge authz gate (%d calls) — scope filters must run first", gateCalls)
+	}
+	// (The demote+hold-label re-apply branch is defensive here: on prforge
+	// the review_requested / synchronize / opened actions are mutually
+	// exclusive, so a demoted gesture never co-rides an admissible lane.
+	// The reachable version of that path is the GitLab lane's, covered by
+	// TestGitLabWebhook_ReRequestUnauthorizedReplierFiltered.)
+}
+
 // The gate-resync lane shares the closed-PR rule with the re-request lane
 // (its sibling term): a push to a closed/merged PR's branch still delivers
 // `synchronize` and must not burn a review. A payload WITHOUT a state stays

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -95,12 +95,13 @@ func (s *Server) handleGitLabMergeRequestEvent(ctx context.Context, w http.Respo
 	// A review request explicitly targeting iterion's own bot account — the
 	// GitLab "Re-request review" sidebar button, or adding the bot to the
 	// reviewer set — is the button form of `/revi`: a deliberate on-demand
-	// re-review. GitLab itself gates who can edit an MR's reviewers, so no
-	// extra replier authz applies here. Only on an OPEN MR (reviewer edits
-	// arrive freely on closed/merged ones — mirroring the Note lane's
-	// closed-MR filter). Never when the actor IS the bot: the publish tail
-	// self-assigns the bot as reviewer after each review, and that PUT
-	// echoes straight back to this handler.
+	// re-review, PROVISIONAL until the replier gate below confirms the
+	// clicker (GitLab lets an MR author edit reviewers without a project
+	// role — "the forge gates it" is not an authorization story). Only on
+	// an OPEN MR (reviewer edits arrive freely on closed/merged ones —
+	// mirroring the Note lane's closed-MR filter). Never when the actor IS
+	// the bot: the publish tail self-assigns the bot as reviewer after each
+	// review, and that PUT echoes straight back to this handler.
 	reviewRequested := p.Action == "update" &&
 		strings.EqualFold(p.State, "opened") &&
 		s.isIterionBotReviewRequest(ctx, cfg, p.ReviewRequestedFrom) &&

--- a/pkg/server/webhooks_gitlab.go
+++ b/pkg/server/webhooks_gitlab.go
@@ -142,11 +142,22 @@ func (s *Server) handleGitLabMergeRequestEvent(ctx context.Context, w http.Respo
 		}
 		authorized, reason, gerr := gate(ctx, cfg, p, rules[0].BotID)
 		if gerr != nil {
-			s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusLaunchError, payloadHash, srcIP, "re-request authz check: "+gerr.Error())
-			httpError(w, http.StatusBadGateway, "authorization check failed")
-			return
-		}
-		if !authorized {
+			// R34eb8c: an authz ERROR must not strand an automatic lane
+			// co-riding the same event (one update can be BOTH a push and a
+			// reviewers change) — demote the gesture and let the resync
+			// proceed. 502 only when the click was the delivery's sole
+			// reason, so the forge redelivers it.
+			if p.IsReviewable() || gateResync {
+				if s.logger != nil {
+					s.logger.Warn("webhooks: gitlab re-request authz errored (%v) — gesture demoted, the automatic lane proceeds", gerr)
+				}
+				reviewRequested = false
+			} else {
+				s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusLaunchError, payloadHash, srcIP, "re-request authz check: "+gerr.Error())
+				httpError(w, http.StatusBadGateway, "authorization check failed")
+				return
+			}
+		} else if !authorized {
 			reviewRequested = false
 			if !p.IsReviewable() && !gateResync {
 				s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, reason)

--- a/pkg/server/webhooks_gitlab_test.go
+++ b/pkg/server/webhooks_gitlab_test.go
@@ -397,7 +397,8 @@ func TestGitLabWebhook_ReRequestUnauthorizedReplierFiltered(t *testing.T) {
 		t.Fatalf("refused re-request must filter: code=%d calls=%d body=%s", w2.Code, calls, w2.Body.String())
 	}
 
-	// An authz ERROR is a 502 so the forge redelivers (mirror of the note gate).
+	// An authz ERROR on a re-request-only delivery is a 502 so the forge
+	// redelivers (mirror of the note gate).
 	s.webhookReviewRequestGate = func(context.Context, webhooks.Config, gitlab.Parsed, string) (bool, string, error) {
 		return false, "", context.DeadlineExceeded
 	}
@@ -405,6 +406,26 @@ func TestGitLabWebhook_ReRequestUnauthorizedReplierFiltered(t *testing.T) {
 	s.handleGitLabWebhook(w3, glReq(gitlabCtx(cfg), glReRequestMR("mallory", "iterion-bot", "2026-09-01 10:02:00 UTC", true), gitlab.EventHeaderMergeRequest))
 	if w3.Code != http.StatusBadGateway || calls != 0 {
 		t.Fatalf("authz error must 502: code=%d calls=%d body=%s", w3.Code, calls, w3.Body.String())
+	}
+
+	// R34eb8c: when an automatic lane co-rides the event (push + reviewers
+	// diff, ReviewOnSync on), the same authz error must NOT strand it — the
+	// gesture is demoted and the resync launches.
+	cfg2 := glConfig()
+	cfg2.ReviewOnSync = true
+	coRiding := `{
+	  "object_kind": "merge_request",
+	  "user": {"username": "mallory"},
+	  "project": {"id": 42, "path_with_namespace": "acme/widgets", "git_http_url": "https://gitlab.com/acme/widgets.git"},
+	  "object_attributes": {"iid": 7, "action": "update", "state": "opened", "oldrev": "sha0", "source_branch": "feature/x", "target_branch": "main",
+	    "title": "Add X", "description": "desc", "url": "https://gitlab.com/acme/widgets/-/merge_requests/7",
+	    "updated_at": "2026-09-01 10:03:00 UTC", "last_commit": {"id": "sha-co"}},
+	  "changes": {"reviewers": {"previous": [], "current": [{"id": 575, "username": "iterion-bot", "re_requested": true}]}}
+	}`
+	w4 := httptest.NewRecorder()
+	s.handleGitLabWebhook(w4, glReq(gitlabCtx(cfg2), coRiding, gitlab.EventHeaderMergeRequest))
+	if w4.Code != http.StatusAccepted || calls != 1 {
+		t.Fatalf("authz error must not strand the co-riding resync: code=%d calls=%d body=%s", w4.Code, calls, w4.Body.String())
 	}
 }
 

--- a/pkg/server/webhooks_prforge.go
+++ b/pkg/server/webhooks_prforge.go
@@ -252,14 +252,56 @@ func prforgeBaseURL(cfg webhooks.Config, p prforge.ParsedNote) (baseURL, refusal
 	if ref == "" {
 		ref = p.CommentURL
 	}
+	return prforgeBaseURLFromRef(ref)
+}
+
+// prforgeBaseURLFromRef derives (and host-gates) the forge web base from a
+// payload URL — the shared tail of prforgeBaseURL, reused by the
+// review-request replier gate whose subject is the PR itself.
+func prforgeBaseURLFromRef(ref string) (baseURL, refusal string) {
 	u, err := url.Parse(ref)
 	if err != nil || u.Host == "" || u.User != nil {
-		return "", "comment URL has no usable forge host"
+		return "", "payload URL has no usable forge host"
 	}
 	if !forgeHostAllowed(u.Host) {
 		return "", "forge host not in ITERION_WEBHOOK_FORGE_HOSTS allowlist"
 	}
 	return u.Scheme + "://" + u.Host, ""
+}
+
+// realWebhookPRForgeReviewRequestGate authorizes a review re-request on the
+// GitHub/Forgejo lane — the same replier controls as the `/command` gate
+// (allowlist OR CollaboratorPermission ≥ the webhook's min_replier_role).
+// R6a15fe: the GitLab twin was gated in R7e050f for exactly this reason
+// ("the forge gates reviewer edits" is not an authorization story); this
+// lane is inert today (no connection shape can be a requested reviewer),
+// but wiring kept for a future connection kind must not arrive ungated.
+// Fail-closed on token resolution, like the GitLab twin.
+func (s *Server) realWebhookPRForgeReviewRequestGate(ctx context.Context, cfg webhooks.Config, p prforge.Parsed, botID string) (bool, string, error) {
+	token, terr := s.resolveForgeToken(ctx, cfg, botID)
+	if terr != nil || token == "" {
+		return false, "re-request refused: no forge token resolved (configure a forge_token binding)", nil
+	}
+	baseURL := cfg.ForgeBaseURL
+	if baseURL == "" {
+		var refusal string
+		baseURL, refusal = prforgeBaseURLFromRef(p.PRURL)
+		if refusal != "" {
+			return false, refusal, nil
+		}
+	}
+	api := prforgeReplierClient(cfg.Provider, s.forgeHTTPClient(), baseURL, token)
+	if prforgeInAllowlist(cfg.AuthorizedRepliers, p.SenderLogin) {
+		return true, "allowlist", nil
+	}
+	perm, err := api.CollaboratorPermission(ctx, p.ProjectPath, p.SenderLogin)
+	if err != nil {
+		return false, "", err
+	}
+	if prforgePermRank(perm) >= replierMinRoleRank(cfg.MinReplierRole) {
+		return true, "role", nil
+	}
+	return false, "re-request review by unauthorized replier: " + p.SenderLogin, nil
 }
 
 func prforgeInAllowlist(allow []string, login string) bool {


### PR DESCRIPTION
Follow-up to #604 — the two medium findings from Revi's third pass there, fixed while the PR sat locked in the merge queue:

- **R6a15fe [security]** — #604's R7e050f gated the GitLab re-request lane and stopped there: its GitHub/Forgejo sibling granted the gesture on identity alone. The lane is inert today (no connection shape can be a requested reviewer there), but wiring kept for a future connection kind must not arrive ungated — it now rides the same replier controls as the `/command` gate (allowlist OR CollaboratorPermission ≥ `min_replier_role`, fail-closed on token resolution), demoting an unauthorized click exactly like the GitLab twin.
- **R34eb8c [error-handling]** — an authz-check ERROR 502'd the whole delivery, stranding a merge-gate resync co-riding the same event (one GitLab update can be BOTH a push and a reviewers diff). Both lanes now demote the gesture and let the automatic lane proceed when one co-rides; the 502 (so the forge redelivers) remains only when the click was the delivery's sole reason.

Each fix is mutation-proven (guard removed → its test red); full suite + lint green on top of the merged #604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)