### PR TITLE
fix(delegate): a fair-usage refusal parks the run and feeds the credential skip

### DIFF
--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -16,6 +16,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/backend/delegate/claudesdk"
 	"github.com/SocialGouv/iterion/pkg/backend/permission"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
+	"github.com/SocialGouv/iterion/pkg/usagecap"
 
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 )
@@ -526,9 +527,20 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, task Task) (result Resu
 	// the executor's transient retry.
 	if rm.Result != nil && isRateLimitMessage(*rm.Result) {
 		detail := strings.TrimSpace(*rm.Result)
-		kind, resetAt := classifyRateLimit(detail, time.Now())
+		kind, window, resetAt := classifyRateLimit(detail, time.Now())
 		b.Logger.Warn("[%s#%d/claude-code] provider quota/rate-limit result (%s) — failing: %.120s",
 			task.NodeID, task.Iteration, kind, detail)
+		// Same evidence duty as the stream path: a text-relayed refusal
+		// that names a meter window must reach the store, or the
+		// credential-tier skip stays blind to it.
+		if window != "" && task.Hooks.OnUsageWindow != nil {
+			_ = task.Hooks.OnUsageWindow(usagecap.Reading{
+				Window:     window,
+				Status:     usagecap.StatusRejected,
+				ObservedAt: time.Now().UTC(),
+				ResetsAt:   resetAt,
+			})
+		}
 		return result, &ErrRateLimited{Provider: BackendClaudeCode, Detail: detail, Kind: kind, ResetAt: resetAt}
 	}
 

--- a/pkg/backend/delegate/claude_code_stream.go
+++ b/pkg/backend/delegate/claude_code_stream.go
@@ -626,7 +626,19 @@ func (b *ClaudeCodeBackend) handleAssistantMessage(m *claudesdk.AssistantMessage
 				b.Logger.Warn("[%s#%d/claude-code] 🚦 rate-limit signal in assistant text — aborting: %s", task.NodeID, task.Iteration, truncate(tb.Text, 200))
 				cancelStream()
 				detail := strings.TrimSpace(tb.Text)
-				kind, resetAt := classifyRateLimit(detail, time.Now())
+				kind, window, resetAt := classifyRateLimit(detail, time.Now())
+				// A refusal relayed as text never reaches the meter the way
+				// a rate_limit_event does, so the credential-tier skip would
+				// stay blind to it at the next resolution. Record it when
+				// the shape names a window the evidence consumers know.
+				if window != "" && task.Hooks.OnUsageWindow != nil {
+					_ = task.Hooks.OnUsageWindow(usagecap.Reading{
+						Window:     window,
+						Status:     usagecap.StatusRejected,
+						ObservedAt: time.Now().UTC(),
+						ResetsAt:   resetAt,
+					})
+				}
 				return &ErrRateLimited{Provider: BackendClaudeCode, Detail: detail, Kind: kind, ResetAt: resetAt}
 			}
 			// Narration hook: surface the agent's mid-turn prose to the
@@ -840,16 +852,35 @@ var rateLimitSignals = []string{
 	"request rejected (429)",
 }
 
+// relayedAPIErrorPrefix opens the CLI's verbatim relay of an upstream
+// HTTP refusal. A block that STARTS with it is the provider talking, not
+// the agent: an agent quoting the message embeds it mid-paragraph.
+const relayedAPIErrorPrefix = "api error: request rejected (429)"
+
+// relayedAPIErrorMaxLen bounds the prefix-anchored acceptance. The
+// fair-usage refusal (~330 chars with its policy prose and request id)
+// is the longest relayed shape observed; anything past this is an agent
+// essay that happens to open with a quote.
+const relayedAPIErrorMaxLen = 600
+
 // isRateLimitMessage reports whether an assistant text block carries
 // a quota / rate-limit signal from the upstream provider. The text
 // length cap is load-bearing: real rate-limit notices are short
 // one-liners, whereas agents that reason aloud about rate limiting
 // produce much longer paragraphs that would false-positive otherwise.
+// One measured exception: the fair-usage refusal is a relayed API error
+// three times that long (four modernize/rite lanes burned their budgets
+// on it before it was recognised at all), so a block that BEGINS with
+// the relay prefix is accepted up to relayedAPIErrorMaxLen.
 func isRateLimitMessage(text string) bool {
-	if len(text) == 0 || len(text) > 200 {
+	if len(text) == 0 {
 		return false
 	}
 	lower := strings.ToLower(text)
+	if len(text) > 200 {
+		return len(text) <= relayedAPIErrorMaxLen &&
+			strings.HasPrefix(lower, relayedAPIErrorPrefix)
+	}
 	if hitYourLimitRe.MatchString(lower) {
 		return true
 	}
@@ -871,15 +902,45 @@ var usageWindowSignals = []string{
 	"usage limit reached",
 }
 
+// accountRefusalSignals mean the ACCOUNT's request rate is refused (a
+// fair-usage policy restriction), not that a metered window filled up.
+// The cure is the same as a shut window — this credential serves nothing
+// until the provider relents, so the run must park and the resolver must
+// route around it — but there is never a reset instant to parse, and the
+// meter evidence is recorded under WindowFrequency so the staleness
+// bound comes from the observation itself.
+var accountRefusalSignals = []string{
+	"fair usage policy",
+	"request frequency has been limited",
+}
+
 // classifyRateLimit refines a matched rate-limit message into
-// (Kind, ResetAt). All parsing is best-effort: an unrecognized shape
-// keeps Kind = transient and a zero ResetAt — never a hard failure.
-func classifyRateLimit(text string, now time.Time) (kind string, resetAt time.Time) {
+// (Kind, Window, ResetAt). Window names the meter window the refusal is
+// evidence against, "" when the shape maps to none — the caller records
+// a reading only when it does. All parsing is best-effort: an
+// unrecognized shape keeps Kind = transient and a zero ResetAt — never a
+// hard failure.
+func classifyRateLimit(text string, now time.Time) (kind string, window usagecap.Window, resetAt time.Time) {
 	lower := strings.ToLower(text)
-	if !isUsageWindowText(lower) {
-		return RateLimitKindTransient, time.Time{}
+	if isAccountRefusalText(lower) {
+		return RateLimitKindUsageWindow, usagecap.WindowFrequency, time.Time{}
 	}
-	return RateLimitKindUsageWindow, parseResetHint(lower, now)
+	if !isUsageWindowText(lower) {
+		return RateLimitKindTransient, "", time.Time{}
+	}
+	return RateLimitKindUsageWindow, "", parseResetHint(lower, now)
+}
+
+// isAccountRefusalText reports whether already-lowercased text carries an
+// account-rate refusal shape. Shared with isUsageWindowText's callers via
+// classifyRateLimit and the flattened-error fallback: one definition.
+func isAccountRefusalText(lower string) bool {
+	for _, sig := range accountRefusalSignals {
+		if strings.Contains(lower, sig) {
+			return true
+		}
+	}
+	return false
 }
 
 // isUsageWindowText reports whether already-lowercased text carries one of the
@@ -895,7 +956,10 @@ func isUsageWindowText(lower string) bool {
 			return true
 		}
 	}
-	return false
+	// An account-rate refusal parks the same way a shut window does, so
+	// the flattened-error fallback must recognise it through the same
+	// single definition.
+	return isAccountRefusalText(lower)
 }
 
 // UsageWindowInFlattenedError recovers the window signal from an error whose

--- a/pkg/backend/delegate/pi.go
+++ b/pkg/backend/delegate/pi.go
@@ -812,7 +812,10 @@ func piMatchesRateLimitText(msg string) bool {
 // split a subscription-window exhaustion (waiting is the only cure) from a
 // plain throttle worth retrying soon, and to recover any reset instant.
 func piRateLimited(msg string) error {
-	kind, resetAt := classifyRateLimit(msg, time.Now())
+	// The window is dropped here: pi/claw refusals have no meter consumer
+	// (usageBackendForKind maps only the claude_code forfait), and this
+	// helper has no hook to record through.
+	kind, _, resetAt := classifyRateLimit(msg, time.Now())
 	return &ErrRateLimited{
 		Provider: BackendPi,
 		Kind:     kind,

--- a/pkg/backend/delegate/usage_limit_test.go
+++ b/pkg/backend/delegate/usage_limit_test.go
@@ -8,11 +8,23 @@ import (
 func TestClassifyRateLimit(t *testing.T) {
 	now := time.Date(2026, 7, 17, 14, 0, 0, 0, time.UTC)
 	tests := []struct {
-		name      string
-		text      string
-		wantKind  string
-		wantReset time.Time
+		name       string
+		text       string
+		wantKind   string
+		wantWindow string
+		wantReset  time.Time
 	}{
+		{
+			// The fair-usage account restriction, verbatim from the wire
+			// (2026-09-02): it refuses the request RATE, carries no reset
+			// instant, and names the frequency window so the refusal
+			// reaches the meter as credential-skip evidence. Two lots and
+			// two rites burned their budgets on it unclassified.
+			name:       "fair-usage account refusal names the frequency window",
+			text:       "API Error: Request rejected (429) · [1313][Your account's current usage pattern does not comply with the Fair Usage Policy, and your request frequency has been limited. For details, please refer to the Subscription Service Agreement. To restore access, please submit a request.][202609021420552fc3f7d9844944b6]",
+			wantKind:   RateLimitKindUsageWindow,
+			wantWindow: "frequency",
+		},
 		{
 			name:      "forfait limit with pm clock",
 			text:      "You've hit your limit · resets 3pm",
@@ -73,14 +85,43 @@ func TestClassifyRateLimit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			kind, reset := classifyRateLimit(tt.text, now)
+			kind, window, reset := classifyRateLimit(tt.text, now)
 			if kind != tt.wantKind {
 				t.Fatalf("kind = %q, want %q", kind, tt.wantKind)
+			}
+			if string(window) != tt.wantWindow {
+				t.Fatalf("window = %q, want %q", window, tt.wantWindow)
 			}
 			if !reset.Equal(tt.wantReset) {
 				t.Fatalf("reset = %v, want %v", reset, tt.wantReset)
 			}
 		})
+	}
+}
+
+// TestIsRateLimitMessage_RelayedAPIErrorLength pins the two sides of the
+// prefix-anchored acceptance: the real fair-usage relay (~330 chars, over
+// the one-liner cap) must be seen, and an agent essay that merely embeds
+// or quotes the same words must not — the length cap is what keeps a
+// PARKING path from firing on prose.
+func TestIsRateLimitMessage_RelayedAPIErrorLength(t *testing.T) {
+	relay := "API Error: Request rejected (429) · [1313][Your account's current usage pattern does not comply with the Fair Usage Policy, and your request frequency has been limited. For details, please refer to the Subscription Service Agreement. To restore access, please submit a request.][202609021420552fc3f7d9844944b6]"
+	if len(relay) <= 200 {
+		t.Fatalf("fixture lost its point: the relay must exceed the one-liner cap, len=%d", len(relay))
+	}
+	if !isRateLimitMessage(relay) {
+		t.Fatal("the verbatim fair-usage relay must be recognised — this exact miss let the refusal become node output")
+	}
+	prose := "While auditing the client I read their Fair Usage Policy and noticed the request frequency has been limited in their nginx config; here is a long analysis of why that matters for the migration plan, with several paragraphs of detail that keep going well past any plausible relayed error length. " + relay
+	if isRateLimitMessage(prose) {
+		t.Fatal("an agent essay embedding the relay mid-text must not classify — it does not START with the relay prefix")
+	}
+	tooLong := relay + " ... and then the agent keeps narrating for hundreds of characters about what it plans to do next, which is no longer the provider talking but the model writing an essay around a quote, so the acceptance must cut off. Padding padding padding padding padding padding padding padding padding padding padding padding."
+	if len(tooLong) <= relayedAPIErrorMaxLen {
+		t.Fatalf("fixture lost its point: len=%d must exceed relayedAPIErrorMaxLen", len(tooLong))
+	}
+	if isRateLimitMessage(tooLong) {
+		t.Fatal("a prefix-opening text past the relay length bound must not classify")
 	}
 }
 

--- a/pkg/server/cloudpublisher/forfait_window_fallback_test.go
+++ b/pkg/server/cloudpublisher/forfait_window_fallback_test.go
@@ -85,6 +85,27 @@ func TestForfaitWindowClosed_fallsThroughToTheNextTier(t *testing.T) {
 	}
 }
 
+// A fair-usage/frequency refusal is account-level: it arrives as a relayed
+// error, never as window telemetry, so it carries NO reset instant — the
+// reading's own staleness bound is all there is. It must still skip the
+// forfait: four lanes measured on 2026-09-02 kept resolving a credential
+// the provider refused on every single request.
+func TestForfaitWindowClosed_frequencyRefusalSkips(t *testing.T) {
+	f := newPoolFixture(t, credpool.Limits{MaxUSDPerDay: 5})
+	fp := withTenantForfait(t, f, "sk-ant-tenant-own")
+	meterSays(t, f, fp, usagecap.Reading{
+		Window: usagecap.WindowFrequency, Status: usagecap.StatusRejected,
+		ObservedAt: time.Now(),
+	})
+	got := bundleToken(t, f, "run-frequency-refused")
+	if contains(got, "sk-ant-tenant-own") {
+		t.Fatalf("the frequency-refused forfait was handed over anyway: %q", got)
+	}
+	if !contains(got, "sk-ant-donated") {
+		t.Fatalf("expected the donor's credential from the pool, got %q", got)
+	}
+}
+
 // Conservative by construction: every uncertain answer means "usable", and
 // only the provider's own refusal is evidence. A wrong skip spends a
 // donor's quota (or drops to env) for a subscription that would have

--- a/pkg/usagecap/usagecap.go
+++ b/pkg/usagecap/usagecap.go
@@ -63,6 +63,15 @@ const (
 	// subscription quota, and the budget flags (--max-cost-usd) are what
 	// bound money.
 	WindowOverage Window = "overage"
+	// WindowFrequency is not a provider window at all: it is an
+	// account-level refusal of the REQUEST RATE (a fair-usage policy, a
+	// frequency restriction) relayed as an error rather than as window
+	// telemetry, so it never carries a reset instant. It exists as a
+	// window name so the refusal can be recorded as meter evidence: the
+	// credential-tier skip needs a fresh StatusRejected reading to route
+	// around a credential the provider will not serve, and freshness for
+	// a reading with no reset instant is already bounded by ObservedAt.
+	WindowFrequency Window = "frequency"
 )
 
 // Family groups the windows that share one operator-facing cap. An
@@ -72,6 +81,12 @@ type Family string
 const (
 	FamilyFiveHour Family = "5h"
 	FamilyWeek     Family = "week"
+	// FamilyAccount governs no operator cap today (Policy.For of an
+	// unconfigured family is inert), but it is NOT FamilyNone: a
+	// frequency refusal is real provider evidence, and the consumers
+	// that filter evidence on "does a cap family govern this window"
+	// must see it.
+	FamilyAccount Family = "account"
 	// FamilyNone marks a window no cap applies to.
 	FamilyNone Family = ""
 )
@@ -83,6 +98,8 @@ func FamilyOf(w Window) Family {
 		return FamilyFiveHour
 	case WindowSevenDay, WindowSevenDayOpus, WindowSevenDaySonnet, WindowSevenDayOverageIncluded:
 		return FamilyWeek
+	case WindowFrequency:
+		return FamilyAccount
 	default:
 		// Includes WindowOverage and any window a future CLI adds: an
 		// unknown window is not silently folded into a cap that was never


### PR DESCRIPTION
## The measured failure

A provider account fell under a fair-usage FREQUENCY restriction: every request answered with a ~330-char relayed 429 (`[1313] … your request frequency has been limited … submit a request to restore`). Overnight and this morning, on a production deployment:

- two modernize campaign nodes **finished with the refusal text as their output** (`work_remaining` = the 429 relay) after burning ~7h each — the one-liner length cap in `isRateLimitMessage` excluded the shape entirely, so it was never classified at all;
- one hardening run spun **six full DAG passes in 27 minutes**, its campaign agent's every first token being the relay;
- one run reached DLQ park via max deliveries on the same node;
- because credentials are sealed at claim and the meter held no evidence, **every fresh relaunch resealed the same refused credential**.

## The fix — one definition, three consequences

1. **Recognition**: a text block that *starts with* the relayed-API-error prefix (`API Error: Request rejected (429)`) is accepted up to 600 chars. Prefix-anchored on purpose: an agent essay quoting the message embeds it mid-paragraph and stays excluded; the length bound cuts off prefix-opening narration.
2. **Classification**: the fair-usage shapes classify as `usage_window` — waiting or routing around is the cure either way, so the whole existing park/durable-retry/redelivery path serves unchanged — under a new meter window `frequency` (family `account`). The family is real evidence for the credential-tier skip (#601) but inert for operator caps (no policy governs it), and freshness is bounded by the observation since this shape never carries a reset instant.
3. **Evidence**: both claude_code text-detection sites (stream block and result guard) now RECORD the refusal through the usage hook when the shape names a meter window, so `forfaitWindowClosed` routes the *next* resolution to the following tier instead of handing the refused credential back out.

The flattened-error fallback inherits the new shapes through the single `isUsageWindowText` definition.

## Falsified both ways

- dropping the `FamilyOf(frequency)` mapping → the publisher skip test goes red;
- dropping the prefix acceptance → the classifier test goes red;
- the prose fixtures (mid-paragraph quote; prefix-opening essay past the bound) pin the hysteric side.

`pkg/backend/delegate`, `pkg/usagecap`, `pkg/server/cloudpublisher`, `pkg/runner`, `pkg/backend/model`, `pkg/runtime`: 2932 tests green locally.

## Follow-up (next PR)

Ordered key-pool fallback *within* a tier: meter API-key refusals by key fingerprint and teach `secrets.Resolve` to exclude fresh-refused keys so its existing priority walk becomes a fallback chain. Kept out of this diff — it wires bundle→runner→resolver and deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)