### PR TITLE
feat(secrets): several keys of one provider become an ordered fallback chain

### DIFF
--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -315,6 +315,13 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, task Task) (result Resu
 	// later resume can detect a credential change.
 	opts, currentFingerprint := b.setupCredsAndSession(ctx, task, opts)
 
+	// Stamp every usage reading with the provider-routing label of THIS
+	// session. One wrap here covers all three detection sites (the
+	// rate_limit_event stream and both text-relayed refusal paths): the
+	// consumer keys the reading under the credential the session actually
+	// ran on, not the bundle's default precedence.
+	task.Hooks.OnUsageWindow = stampUsageSource(task.Hooks.OnUsageWindow, currentFingerprint)
+
 	// Structured output handling. claude CLI >= 2.1 accepts --json-schema
 	// (WithOutputFormat) TOGETHER with --allowedTools in a single pass: the
 	// agent does its tool work and then calls the native StructuredOutput

--- a/pkg/backend/delegate/claude_code_cred_test.go
+++ b/pkg/backend/delegate/claude_code_cred_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/sandbox"
 	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/usagecap"
 )
 
 // resetClaudeCredEnv scrubs every process-env var that participates in
@@ -371,3 +372,27 @@ func (noopLikeRun) Driver() string { return "noop" }
 type k8sLikeRun struct{ sandbox.Run }
 
 func (k8sLikeRun) Driver() string { return "kubernetes" }
+
+// The usage-source stamp: every reading leaving a session names the
+// provider routing it ran on, so the runner's meter charges the refusal
+// to the credential that was actually spent.
+func TestStampUsageSource(t *testing.T) {
+	var got usagecap.Reading
+	hook := stampUsageSource(func(r usagecap.Reading) error { got = r; return nil }, "anthropic-direct")
+	if err := hook(usagecap.Reading{Window: usagecap.WindowFrequency}); err != nil {
+		t.Fatalf("hook: %v", err)
+	}
+	if got.Source != "anthropic-direct" {
+		t.Fatalf("Source = %q, want the session fingerprint", got.Source)
+	}
+	// A reading that already names its source keeps it.
+	if err := hook(usagecap.Reading{Source: "facade:x"}); err != nil {
+		t.Fatalf("hook: %v", err)
+	}
+	if got.Source != "facade:x" {
+		t.Fatalf("Source = %q, want the reading's own label preserved", got.Source)
+	}
+	if stampUsageSource(nil, "x") != nil {
+		t.Fatal("no observer must stay no observer")
+	}
+}

--- a/pkg/backend/delegate/claude_code_creds.go
+++ b/pkg/backend/delegate/claude_code_creds.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/backend/delegate/claudesdk"
 	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/usagecap"
 )
 
 func resolveMaxConsecutiveToolErrors() int {
@@ -242,6 +243,24 @@ func providerFingerprint(env map[string]string) string {
 	// path) lands here too — it means "use the inherited ANTHROPIC_API_KEY
 	// from the process env", which is also Anthropic-direct semantically.
 	return "anthropic-env"
+}
+
+// stampUsageSource wraps an OnUsageWindow hook so every reading leaving a
+// session names the provider routing it ran on — the runner's meter then
+// charges a refusal to the credential that was actually spent. Task and
+// TaskHooks travel by value, so the wrap lives and dies with one Execute
+// call: a fallback attempt that re-enters with a different provider stamps
+// its own label. A reading that already names its source keeps it.
+func stampUsageSource(inner func(usagecap.Reading) error, fingerprint string) func(usagecap.Reading) error {
+	if inner == nil {
+		return nil
+	}
+	return func(r usagecap.Reading) error {
+		if r.Source == "" {
+			r.Source = fingerprint
+		}
+		return inner(r)
+	}
 }
 
 // anthropicCredEnvForCLI is the testable core: it returns the env

--- a/pkg/runner/usage_cap.go
+++ b/pkg/runner/usage_cap.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
@@ -29,47 +30,82 @@ import (
 // The operator's ceiling therefore inherits, for free, the one property
 // that matters — a capped run is not lost, it is waiting.
 
-// usageCapKey identifies the credential whose windows a run draws on.
-//
-// A tenant that brought its own subscription must not be blocked by what
-// another tenant spent, and runs that fall back to the deployment's own
-// credential must be pooled together — they really are one meter. The run's
-// resolved credentials answer both: a bundle carrying an Anthropic key or
-// OAuth dir the TENANT resolved is the tenant's own; anything else —
-// including a bundle slot the publisher filled from the DB-backed platform
-// tier, which rides the bundle exactly like a tenant credential but is the
-// deployment's single meter — is the platform's.
-func usageCapKey(ctx context.Context, msg *queue.RunMessage) string {
-	scope := usagecap.ScopePlatform
-	credFP := ""
-	if creds, ok := secrets.CredentialsFromContext(ctx); ok {
-		tenantOwnZai := creds.APIKey(secrets.ProviderZAI) != "" &&
-			!creds.IsPlatformSourced(string(secrets.ProviderZAI))
-		tenantOwnKey := creds.APIKey(secrets.ProviderAnthropic) != "" &&
-			!creds.IsPlatformSourced(string(secrets.ProviderAnthropic))
-		tenantOwnOAuth := creds.OAuthDir(delegate.BackendClaudeCode) != "" &&
-			!creds.IsPlatformSourced(delegate.BackendClaudeCode)
-		if tenantOwnZai || tenantOwnKey || tenantOwnOAuth {
-			scope = usagecap.TenantScope(msg.TenantID)
-		}
-		// The meter follows the CREDENTIAL: same preference order as the
-		// delegate (z.ai AUTH_TOKEN over an Anthropic API key over an
-		// OAuth dir — anthropicCredEnvForCLI's contract), so the
-		// fingerprint names the credential the run will actually spend.
-		// A rotated token therefore opens a fresh meter instead of
-		// inheriting the readings of the account it replaced. Metering a
-		// z.ai-served run under the anthropic slot was the miss that let
-		// a refused key keep a clean meter while every reading landed on
-		// a credential the run never spent.
-		if fp := creds.Fingerprint(string(secrets.ProviderZAI)); fp != "" {
-			credFP = fp
-		} else if fp := creds.Fingerprint(string(secrets.ProviderAnthropic)); fp != "" {
-			credFP = fp
-		} else if fp := creds.Fingerprint(delegate.BackendClaudeCode); fp != "" {
-			credFP = fp
+// runCredKeys is the per-run credential identity the meter draws on: the
+// scope (tenant-own vs platform) plus one fingerprint per credential SHAPE
+// the bundle holds. A reading is keyed by the shape the node actually
+// exercised — the delegate stamps its provider-routing label on each
+// Reading (usagecap.Reading.Source) — because a bundle may carry both a
+// z.ai token and an Anthropic key, and a node pinned `provider: anthropic`
+// spends the Anthropic key while the bundle-default precedence points at
+// z.ai. Charging that refusal to the z.ai fingerprint would make the
+// evidence-based skip park the healthy key and keep the frozen one.
+type runCredKeys struct {
+	scope       string
+	zaiFP       string
+	anthropicFP string
+	oauthFP     string
+}
+
+// usageCapCredKeys reads the run's resolved credentials once. Scope: a
+// bundle carrying any credential the TENANT resolved is the tenant's own;
+// anything else — including a slot the publisher filled from the DB-backed
+// platform tier, which rides the bundle exactly like a tenant credential
+// but is the deployment's single meter — is the platform's.
+func usageCapCredKeys(ctx context.Context, msg *queue.RunMessage) runCredKeys {
+	k := runCredKeys{scope: usagecap.ScopePlatform}
+	creds, ok := secrets.CredentialsFromContext(ctx)
+	if !ok {
+		return k
+	}
+	tenantOwnZai := creds.APIKey(secrets.ProviderZAI) != "" &&
+		!creds.IsPlatformSourced(string(secrets.ProviderZAI))
+	tenantOwnKey := creds.APIKey(secrets.ProviderAnthropic) != "" &&
+		!creds.IsPlatformSourced(string(secrets.ProviderAnthropic))
+	tenantOwnOAuth := creds.OAuthDir(delegate.BackendClaudeCode) != "" &&
+		!creds.IsPlatformSourced(delegate.BackendClaudeCode)
+	if tenantOwnZai || tenantOwnKey || tenantOwnOAuth {
+		k.scope = usagecap.TenantScope(msg.TenantID)
+	}
+	k.zaiFP = creds.Fingerprint(string(secrets.ProviderZAI))
+	k.anthropicFP = creds.Fingerprint(string(secrets.ProviderAnthropic))
+	k.oauthFP = creds.Fingerprint(delegate.BackendClaudeCode)
+	return k
+}
+
+// forSource keys a reading under the credential its session actually ran
+// on. The source labels are providerFingerprint's vocabulary: a facade URL
+// is the z.ai token, "anthropic-direct" the Anthropic API key,
+// "anthropic-oauth" the OAuth dir. An empty label (older binary) and
+// "anthropic-env" (inherited pod env — no bundle credential at all) fall
+// back to the bundle-default precedence: z.ai AUTH_TOKEN over an Anthropic
+// API key over an OAuth dir, anthropicCredEnvForCLI's contract. A rotated
+// token therefore opens a fresh meter instead of inheriting the readings
+// of the account it replaced.
+func (k runCredKeys) forSource(source string) string {
+	fp := ""
+	switch {
+	case strings.HasPrefix(source, "facade:") && k.zaiFP != "":
+		fp = k.zaiFP
+	case source == "anthropic-direct" && k.anthropicFP != "":
+		fp = k.anthropicFP
+	case source == "anthropic-oauth" && k.oauthFP != "":
+		fp = k.oauthFP
+	default:
+		if k.zaiFP != "" {
+			fp = k.zaiFP
+		} else if k.anthropicFP != "" {
+			fp = k.anthropicFP
+		} else if k.oauthFP != "" {
+			fp = k.oauthFP
 		}
 	}
-	return usagecap.Key(delegate.BackendClaudeCode, scope, credFP)
+	return usagecap.Key(delegate.BackendClaudeCode, k.scope, fp)
+}
+
+// usageCapKey is the run's DEFAULT credential key — what the pre-flight
+// consults before any node has run (no session, so no source label yet).
+func usageCapKey(ctx context.Context, msg *queue.RunMessage) string {
+	return usageCapCredKeys(ctx, msg).forSource("")
 }
 
 // usageGuardFor builds the guard for one run: the machine-wide policy
@@ -88,12 +124,17 @@ func (r *Runner) usageGuardFor(ctx context.Context, msg *queue.RunMessage, logge
 	if pol, static := r.cfg.UsageCapSource.(usagecap.StaticPolicy); static && !usagecap.Policy(pol).Enabled() {
 		return nil
 	}
-	key := usageCapKey(ctx, msg)
+	keys := usageCapCredKeys(ctx, msg)
 	store := r.cfg.UsageCaps
 	return usagecap.NewGuardWithSource(r.cfg.UsageCapSource, func(reading usagecap.Reading) {
 		if store == nil {
 			return
 		}
+		// Keyed per reading, not per run: the session's provider-routing
+		// label names the credential the node actually spent, and a run
+		// whose nodes pin different providers must not charge one key's
+		// refusal to another's meter.
+		key := keys.forSource(reading.Source)
 		// Detached: the reading that stops a run arrives exactly as that
 		// run's context is about to be cancelled, and it is the single
 		// most valuable thing to publish.

--- a/pkg/runner/usage_cap.go
+++ b/pkg/runner/usage_cap.go
@@ -43,19 +43,27 @@ func usageCapKey(ctx context.Context, msg *queue.RunMessage) string {
 	scope := usagecap.ScopePlatform
 	credFP := ""
 	if creds, ok := secrets.CredentialsFromContext(ctx); ok {
+		tenantOwnZai := creds.APIKey(secrets.ProviderZAI) != "" &&
+			!creds.IsPlatformSourced(string(secrets.ProviderZAI))
 		tenantOwnKey := creds.APIKey(secrets.ProviderAnthropic) != "" &&
 			!creds.IsPlatformSourced(string(secrets.ProviderAnthropic))
 		tenantOwnOAuth := creds.OAuthDir(delegate.BackendClaudeCode) != "" &&
 			!creds.IsPlatformSourced(delegate.BackendClaudeCode)
-		if tenantOwnKey || tenantOwnOAuth {
+		if tenantOwnZai || tenantOwnKey || tenantOwnOAuth {
 			scope = usagecap.TenantScope(msg.TenantID)
 		}
 		// The meter follows the CREDENTIAL: same preference order as the
-		// delegate (a ctx API key outranks an OAuth dir), so the
+		// delegate (z.ai AUTH_TOKEN over an Anthropic API key over an
+		// OAuth dir — anthropicCredEnvForCLI's contract), so the
 		// fingerprint names the credential the run will actually spend.
 		// A rotated token therefore opens a fresh meter instead of
-		// inheriting the readings of the account it replaced.
-		if fp := creds.Fingerprint(string(secrets.ProviderAnthropic)); fp != "" {
+		// inheriting the readings of the account it replaced. Metering a
+		// z.ai-served run under the anthropic slot was the miss that let
+		// a refused key keep a clean meter while every reading landed on
+		// a credential the run never spent.
+		if fp := creds.Fingerprint(string(secrets.ProviderZAI)); fp != "" {
+			credFP = fp
+		} else if fp := creds.Fingerprint(string(secrets.ProviderAnthropic)); fp != "" {
 			credFP = fp
 		} else if fp := creds.Fingerprint(delegate.BackendClaudeCode); fp != "" {
 			credFP = fp

--- a/pkg/runner/usage_cap_test.go
+++ b/pkg/runner/usage_cap_test.go
@@ -474,3 +474,53 @@ func TestUsageCapKey_FingerprintFollowsTheSpendingCredential(t *testing.T) {
 		t.Errorf("legacy fingerprint-less credentials = %q, want the historical key %q", got, want)
 	}
 }
+
+// A reading is keyed under the credential its session ACTUALLY ran on —
+// the delegate's provider-routing label — not the bundle's default
+// precedence. A bundle holding both a z.ai token and an Anthropic key
+// previously charged an anthropic-pinned node's refusal to the z.ai
+// fingerprint, and the evidence-based skip then parked the healthy key
+// while keeping the frozen one.
+func TestUsageCapCredKeys_ReadingFollowsTheSessionSource(t *testing.T) {
+	msg := &queue.RunMessage{TenantID: "team-7"}
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		APIKeys: map[secrets.Provider]string{
+			secrets.ProviderZAI:       "zai-token",
+			secrets.ProviderAnthropic: "sk-ant",
+		},
+		OAuthCredentialFiles: map[string]string{delegate.BackendClaudeCode: "/tmp/oauth"},
+		Fingerprints: map[string]string{
+			string(secrets.ProviderZAI):       "fp-zai",
+			string(secrets.ProviderAnthropic): "fp-ant",
+			delegate.BackendClaudeCode:        "fp-oauth",
+		},
+	})
+	keys := usageCapCredKeys(ctx, msg)
+	scope := usagecap.TenantScope("team-7")
+
+	cases := []struct{ source, wantFP string }{
+		// Empty (older binary) and the inherited-env label follow the
+		// bundle default: z.ai first, the delegate's own precedence.
+		{"", "fp-zai"},
+		{"anthropic-env", "fp-zai"},
+		{"facade:https://api.z.ai/api/anthropic", "fp-zai"},
+		{"anthropic-direct", "fp-ant"},
+		{"anthropic-oauth", "fp-oauth"},
+	}
+	for _, c := range cases {
+		if got := keys.forSource(c.source); got != usagecap.Key(delegate.BackendClaudeCode, scope, c.wantFP) {
+			t.Errorf("forSource(%q) = %q, want fingerprint %q", c.source, got, c.wantFP)
+		}
+	}
+
+	// A source naming a shape the bundle does not hold falls back to the
+	// default rather than inventing an empty-fingerprint meter.
+	partial := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		APIKeys:      map[secrets.Provider]string{secrets.ProviderAnthropic: "sk-ant"},
+		Fingerprints: map[string]string{string(secrets.ProviderAnthropic): "fp-ant"},
+	})
+	pk := usageCapCredKeys(partial, msg)
+	if got := pk.forSource("facade:https://api.z.ai"); got != usagecap.Key(delegate.BackendClaudeCode, usagecap.TenantScope("team-7"), "fp-ant") {
+		t.Errorf("facade source without a zai credential = %q, want the default fallback", got)
+	}
+}

--- a/pkg/secrets/byok.go
+++ b/pkg/secrets/byok.go
@@ -202,6 +202,13 @@ type Resolution struct {
 // When sealer is non-nil, every Resolution.Plaintext is decrypted; on
 // decrypt failure the resolution is skipped and an error is logged
 // to logErr. Pass nil sealer to get sealed blobs only.
+// A nil usable predicate accepts every key. A non-nil one is consulted in
+// the priority walk (pass 2) ONLY: a key it refuses is skipped and the walk
+// takes the NEXT visible key of that provider, which is what turns several
+// keys of one provider into an ordered fallback chain. An explicit
+// keyOverrides pin is deliberately NOT filtered — the operator named that
+// key, and honouring the pin over the optimisation is what keeps the
+// predicate an optimisation.
 func Resolve(
 	ctx context.Context,
 	store ApiKeyStore,
@@ -209,6 +216,7 @@ func Resolve(
 	providers []Provider,
 	keyOverrides map[Provider]string,
 	sealer Sealer,
+	usable func(ApiKey) bool,
 ) (map[Provider]Resolution, error) {
 	if teamID == "" {
 		return nil, fmt.Errorf("secrets: team id required for resolve")
@@ -258,6 +266,9 @@ func Resolve(
 			continue
 		}
 		if _, already := out[k.Provider]; already {
+			continue
+		}
+		if usable != nil && !usable(k) {
 			continue
 		}
 		if r, ok := buildResolution(k, sealer, userID); ok {

--- a/pkg/secrets/byok_test.go
+++ b/pkg/secrets/byok_test.go
@@ -50,7 +50,7 @@ func TestResolve_PrioritizesUserOverTeam(t *testing.T) {
 	mkKey(t, store, sealer, "team", "", ProviderOpenAI, "team-default", "sk-team-default", true)
 	user := mkKey(t, store, sealer, "team", "alice", ProviderOpenAI, "alice-default", "sk-alice-default", true)
 
-	got, err := Resolve(context.Background(), store, "team", "alice", []Provider{ProviderOpenAI}, nil, sealer)
+	got, err := Resolve(context.Background(), store, "team", "alice", []Provider{ProviderOpenAI}, nil, sealer, nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestResolve_FallsBackToTeam(t *testing.T) {
 	sealer := newSealer(t)
 	team := mkKey(t, store, sealer, "team", "", ProviderOpenAI, "team-default", "sk-team-default", true)
 
-	got, _ := Resolve(context.Background(), store, "team", "bob", []Provider{ProviderOpenAI}, nil, sealer)
+	got, _ := Resolve(context.Background(), store, "team", "bob", []Provider{ProviderOpenAI}, nil, sealer, nil)
 	r := got[ProviderOpenAI]
 	if r.KeyID != team.ID || string(r.Plaintext) != "sk-team-default" || r.SourceScope != "team" {
 		t.Fatalf("expected team default, got %+v", r)
@@ -84,7 +84,7 @@ func TestResolve_OverrideWins(t *testing.T) {
 	got, _ := Resolve(context.Background(), store, "team", "alice",
 		[]Provider{ProviderOpenAI},
 		map[Provider]string{ProviderOpenAI: other.ID},
-		sealer)
+		sealer, nil)
 	r := got[ProviderOpenAI]
 	if r.KeyID != other.ID || string(r.Plaintext) != "sk-other" {
 		t.Fatalf("override should win: got %s, default was %s", r.KeyID, def.ID)
@@ -96,7 +96,7 @@ func TestResolve_HidesOtherUsersKeys(t *testing.T) {
 	sealer := newSealer(t)
 	mkKey(t, store, sealer, "team", "carol", ProviderOpenAI, "carol-only", "sk-carol", true)
 
-	got, _ := Resolve(context.Background(), store, "team", "alice", []Provider{ProviderOpenAI}, nil, sealer)
+	got, _ := Resolve(context.Background(), store, "team", "alice", []Provider{ProviderOpenAI}, nil, sealer, nil)
 	if _, ok := got[ProviderOpenAI]; ok {
 		t.Fatalf("alice should not see carol's user-scoped key")
 	}
@@ -108,7 +108,7 @@ func TestResolve_OmitsProviderWhenNoKey(t *testing.T) {
 	mkKey(t, store, sealer, "team", "", ProviderOpenAI, "team", "sk-t", true)
 
 	got, _ := Resolve(context.Background(), store, "team", "alice",
-		[]Provider{ProviderOpenAI, ProviderAnthropic}, nil, sealer)
+		[]Provider{ProviderOpenAI, ProviderAnthropic}, nil, sealer, nil)
 	if _, ok := got[ProviderAnthropic]; ok {
 		t.Fatal("anthropic should be omitted (no key)")
 	}
@@ -211,7 +211,7 @@ func TestResolve_UserNonDefaultBeatsTeamDefault(t *testing.T) {
 	mkKey(t, store, sealer, "team", "", ProviderOpenAI, "team-default", "sk-team", true)
 	user := mkKey(t, store, sealer, "team", "alice", ProviderOpenAI, "alice-plain", "sk-alice", false)
 
-	got, err := Resolve(context.Background(), store, "team", "alice", []Provider{ProviderOpenAI}, nil, sealer)
+	got, err := Resolve(context.Background(), store, "team", "alice", []Provider{ProviderOpenAI}, nil, sealer, nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -243,5 +243,56 @@ func TestSealRunBundleRoundTrip(t *testing.T) {
 	// AAD pinning: opening with a different run id must fail.
 	if _, err := OpenRunBundle(sealer, "run-999", sealed); err == nil {
 		t.Fatal("expected AAD mismatch failure when run id changes")
+	}
+}
+
+// The usable predicate turns several keys of one provider into an ordered
+// fallback chain: a refused key is passed over and the walk yields the
+// NEXT one. Measured need (2026-09-02): a provider froze one key's account
+// and the resolver kept sealing it into every fresh run.
+func TestResolve_UsablePredicateWalksToTheNextKey(t *testing.T) {
+	store := NewMemoryApiKeyStore()
+	sealer := newSealer(t)
+	first := mkKey(t, store, sealer, "team", "", ProviderZAI, "primary", "sk-zai-1", true)
+	second := mkKey(t, store, sealer, "team", "", ProviderZAI, "backup", "sk-zai-2", false)
+
+	refuse := map[string]bool{first.ID: true}
+	got, err := Resolve(context.Background(), store, "team", "alice", []Provider{ProviderZAI}, nil, sealer,
+		func(k ApiKey) bool { return !refuse[k.ID] })
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if r := got[ProviderZAI]; r.KeyID != second.ID {
+		t.Fatalf("expected the backup key after the primary was refused, got %+v", r)
+	}
+
+	// Every key refused: the provider is OMITTED, so the later credential
+	// tiers get their turn — an empty slot beats a poisoned one.
+	got, err = Resolve(context.Background(), store, "team", "alice", []Provider{ProviderZAI}, nil, sealer,
+		func(ApiKey) bool { return false })
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if _, ok := got[ProviderZAI]; ok {
+		t.Fatalf("expected no resolution when every key is refused, got %+v", got[ProviderZAI])
+	}
+}
+
+// An explicit override pin is NOT filtered by the predicate: the operator
+// named that key, and honouring the pin over the optimisation is what
+// keeps the predicate an optimisation.
+func TestResolve_UsablePredicateDoesNotFilterPins(t *testing.T) {
+	store := NewMemoryApiKeyStore()
+	sealer := newSealer(t)
+	pinned := mkKey(t, store, sealer, "team", "", ProviderZAI, "pinned", "sk-zai-pinned", false)
+
+	got, err := Resolve(context.Background(), store, "team", "alice", []Provider{ProviderZAI},
+		map[Provider]string{ProviderZAI: pinned.ID}, sealer,
+		func(ApiKey) bool { return false })
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if r := got[ProviderZAI]; r.KeyID != pinned.ID {
+		t.Fatalf("expected the pinned key despite the predicate, got %+v", r)
 	}
 }

--- a/pkg/server/cloudpublisher/apikey_skip_test.go
+++ b/pkg/server/cloudpublisher/apikey_skip_test.go
@@ -1,0 +1,59 @@
+package cloudpublisher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/usagecap"
+)
+
+// The BYOK walk's evidence predicate, both faces: only a fresh quota-family
+// refusal under the KEY'S OWN fingerprint skips it. Everything uncertain —
+// no reading, another provider's meter, the pay-as-you-go overage channel —
+// keeps the key usable, because a wrong skip silently moves spend onto a
+// credential nobody chose.
+func TestApiKeyUsable(t *testing.T) {
+	st := usagecap.NewMemStore()
+	p := &Publisher{usageCaps: st, logger: iterlog.New(iterlog.LevelError, nil)}
+	scope := usagecap.TenantScope("team")
+	key := secrets.ApiKey{Provider: secrets.ProviderZAI, Name: "primary", Fingerprint: "fp-zai-1"}
+
+	usable := p.apiKeyUsable(context.Background(), scope, "run-x")
+	if !usable(key) {
+		t.Fatal("no evidence must mean usable")
+	}
+
+	// The provider refused this key's account rate (the frequency window
+	// #610 records) — the walk must pass it over.
+	if err := st.Record(context.Background(),
+		usagecap.Key(delegate.BackendClaudeCode, scope, "fp-zai-1"),
+		usagecap.Reading{Window: usagecap.WindowFrequency, Status: usagecap.StatusRejected,
+			ObservedAt: time.Now()}); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if usable(key) {
+		t.Fatal("a fresh frequency refusal under the key's fingerprint must skip it")
+	}
+
+	// Hysteric guards: a rejected OVERAGE reading is money, not quota; and
+	// a provider with no metered backend has no evidence to act on.
+	st2 := usagecap.NewMemStore()
+	p2 := &Publisher{usageCaps: st2, logger: iterlog.New(iterlog.LevelError, nil)}
+	if err := st2.Record(context.Background(),
+		usagecap.Key(delegate.BackendClaudeCode, scope, "fp-zai-1"),
+		usagecap.Reading{Window: usagecap.WindowOverage, Status: usagecap.StatusRejected,
+			ObservedAt: time.Now()}); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if !p2.apiKeyUsable(context.Background(), scope, "run-x")(key) {
+		t.Fatal("a rejected overage reading is no quota evidence — the key must stay usable")
+	}
+	other := secrets.ApiKey{Provider: secrets.ProviderOpenAI, Name: "m", Fingerprint: "fp-zai-1"}
+	if !usable(other) {
+		t.Fatal("a provider with no metered backend must never be skipped")
+	}
+}

--- a/pkg/server/cloudpublisher/apikey_skip_test.go
+++ b/pkg/server/cloudpublisher/apikey_skip_test.go
@@ -57,3 +57,133 @@ func TestApiKeyUsable(t *testing.T) {
 		t.Fatal("a provider with no metered backend must never be skipped")
 	}
 }
+
+// seedKeyFP seeds a sealed API key carrying an explicit fingerprint — the
+// identity the evidence predicate matches refusals against.
+func seedKeyFP(t *testing.T, st secrets.ApiKeyStore, sealer secrets.Sealer, teamID string, provider secrets.Provider, plaintext, fp string) {
+	t.Helper()
+	id := secrets.NewApiKeyID()
+	sealed, err := secrets.SealAPIKey(sealer, id, []byte(plaintext))
+	if err != nil {
+		t.Fatalf("seal key: %v", err)
+	}
+	if err := st.Create(context.Background(), secrets.ApiKey{
+		ID: id, ScopeTeamID: teamID, Provider: provider, Fingerprint: fp,
+		Name: string(provider) + "-" + fp, SealedSecret: sealed, CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create key: %v", err)
+	}
+}
+
+func recordRefusal(t *testing.T, st usagecap.Store, scope, fp string) {
+	t.Helper()
+	if err := st.Record(context.Background(),
+		usagecap.Key(delegate.BackendClaudeCode, scope, fp),
+		usagecap.Reading{Window: usagecap.WindowFrequency, Status: usagecap.StatusRejected,
+			ObservedAt: time.Now()}); err != nil {
+		t.Fatalf("record refusal: %v", err)
+	}
+}
+
+// A provider whose ONLY key is refused must still fund the run when no
+// other tier can serve its wire: the run then makes one refused call and
+// parks on a durable usage-window retry, instead of being published with
+// an empty wire that fails on a no-credential auth error nothing retries.
+func TestApiKeySkip_refusedOnlyKeyIsRestored(t *testing.T) {
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	keys := secrets.NewMemoryApiKeyStore()
+	seedKeyFP(t, keys, sealer, "team1", secrets.ProviderAnthropic, "sk-only", "fp-a")
+	caps := usagecap.NewMemStore()
+	recordRefusal(t, caps, usagecap.TenantScope("team1"), "fp-a")
+
+	p := &Publisher{apiKeys: keys, usageCaps: caps,
+		runSecrets: secrets.NewMemoryRunSecretsStore(), sealer: sealer, logger: testLogger()}
+	rs := p.runSecrets.(*secrets.MemoryRunSecretsStore)
+
+	b := resolveBundle(t, p, rs, sealer, "run-r1", "team1", "owner1")
+	if got := b.APIKeys[secrets.ProviderAnthropic]; got != "sk-only" {
+		t.Fatalf("anthropic key = %q, want the refused key RESTORED — an empty wire is a stuck run", got)
+	}
+	if b.PlatformSourced[string(secrets.ProviderAnthropic)] {
+		t.Fatal("a restored TENANT key must not be marked platform-sourced")
+	}
+}
+
+// With a second key of the same provider, the walk serves it and the
+// refused one stays out — restore is strictly the no-other-option path.
+func TestApiKeySkip_secondKeyServesNoRestore(t *testing.T) {
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	keys := secrets.NewMemoryApiKeyStore()
+	seedKeyFP(t, keys, sealer, "team1", secrets.ProviderAnthropic, "sk-frozen", "fp-a")
+	seedKeyFP(t, keys, sealer, "team1", secrets.ProviderAnthropic, "sk-healthy", "fp-b")
+	caps := usagecap.NewMemStore()
+	recordRefusal(t, caps, usagecap.TenantScope("team1"), "fp-a")
+
+	p := &Publisher{apiKeys: keys, usageCaps: caps,
+		runSecrets: secrets.NewMemoryRunSecretsStore(), sealer: sealer, logger: testLogger()}
+	rs := p.runSecrets.(*secrets.MemoryRunSecretsStore)
+
+	b := resolveBundle(t, p, rs, sealer, "run-r2", "team1", "owner1")
+	if got := b.APIKeys[secrets.ProviderAnthropic]; got != "sk-healthy" {
+		t.Fatalf("anthropic key = %q, want the healthy second key", got)
+	}
+}
+
+// The refused tenant key must not block the fall-through: a healthy
+// platform key on the same wire serves the run — the manual key-removal
+// this PR retires. The tenant key is NOT restored over it.
+func TestApiKeySkip_refusedTenantKeyFallsThroughToPlatform(t *testing.T) {
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	keys := secrets.NewMemoryApiKeyStore()
+	seedKeyFP(t, keys, sealer, "team1", secrets.ProviderAnthropic, "sk-frozen", "fp-a")
+	seedKeyFP(t, keys, sealer, secrets.PlatformTenantID, secrets.ProviderAnthropic, "sk-platform", "fp-p")
+	caps := usagecap.NewMemStore()
+	recordRefusal(t, caps, usagecap.TenantScope("team1"), "fp-a")
+
+	p := &Publisher{apiKeys: keys, usageCaps: caps,
+		runSecrets: secrets.NewMemoryRunSecretsStore(), sealer: sealer, logger: testLogger()}
+	rs := p.runSecrets.(*secrets.MemoryRunSecretsStore)
+
+	b := resolveBundle(t, p, rs, sealer, "run-r3", "team1", "owner1")
+	if got := b.APIKeys[secrets.ProviderAnthropic]; got != "sk-platform" {
+		t.Fatalf("anthropic key = %q, want the platform key — the fallback chain must engage", got)
+	}
+	if !b.PlatformSourced[string(secrets.ProviderAnthropic)] {
+		t.Fatal("the platform fill must keep its shared-meter scope")
+	}
+}
+
+// The platform tier itself: its refused-but-only key is restored WITH its
+// platform metering scope — the last DB-backed tier is never left empty,
+// the rule its OAuth sibling states.
+func TestApiKeySkip_refusedPlatformKeyIsRestoredPlatformSourced(t *testing.T) {
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	keys := secrets.NewMemoryApiKeyStore()
+	seedKeyFP(t, keys, sealer, secrets.PlatformTenantID, secrets.ProviderZAI, "sk-zai-platform", "fp-z")
+	caps := usagecap.NewMemStore()
+	recordRefusal(t, caps, usagecap.ScopePlatform, "fp-z")
+
+	p := &Publisher{apiKeys: keys, usageCaps: caps,
+		runSecrets: secrets.NewMemoryRunSecretsStore(), sealer: sealer, logger: testLogger()}
+	rs := p.runSecrets.(*secrets.MemoryRunSecretsStore)
+
+	b := resolveBundle(t, p, rs, sealer, "run-r4", "team1", "owner1")
+	if got := b.APIKeys[secrets.ProviderZAI]; got != "sk-zai-platform" {
+		t.Fatalf("zai key = %q, want the refused platform key RESTORED", got)
+	}
+	if !b.PlatformSourced[string(secrets.ProviderZAI)] {
+		t.Fatal("a restored PLATFORM key must keep its platform-sourced metering scope")
+	}
+}

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -356,6 +356,10 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 		PlatformSourced:    map[string]bool{},
 	}
 
+	// Refused-but-only keys, per provider, remembered across the tiers for
+	// the restore step — the api-key twin of skippedForfaits below.
+	skippedAPIKeys := map[secrets.Provider]skippedAPIKey{}
+
 	// 1. BYOK API keys.
 	if p.apiKeys != nil {
 		// Per-webhook key overrides (provider name → api_key id) take
@@ -383,6 +387,26 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 			}
 			bundle.APIKeys[prov] = string(r.Plaintext)
 			usedIDs = append(usedIDs, r.KeyID)
+		}
+		// A provider whose EVERY key was refused resolves to nothing under
+		// the predicate. Remember what an unfiltered walk would have chosen:
+		// if the end of the resolution finds that wire still empty — no
+		// second key, no forfait, no pool grant, no platform credential —
+		// the refused key is restored, because a run that makes one refused
+		// call parks on a durable usage-window retry, while a run published
+		// with an empty wire fails on a no-credential auth error nothing
+		// retries (or silently spends the runner pod's ambient env).
+		if refused := providersWithoutKey(allKnownProviders, bundle.APIKeys); len(refused) > 0 {
+			fallback, ferr := secrets.Resolve(ctx, p.apiKeys, tenantID, ownerID, refused, overrides, p.sealer, nil)
+			if ferr != nil {
+				p.logger.Warn("cloudpublisher: refused-key fallback resolve: %v", ferr)
+			}
+			for prov, r := range fallback {
+				if len(r.Plaintext) == 0 {
+					continue
+				}
+				skippedAPIKeys[prov] = skippedAPIKey{plaintext: string(r.Plaintext), keyID: r.KeyID}
+			}
 		}
 		// Bumping last_used_at is best-effort observability, not on
 		// the launch's critical path. Fire it detached with a short
@@ -565,21 +589,36 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 	//    run runs on its donor — filling alongside would outrank the lent
 	//    credential while still consuming the donor's quota and slot.
 	if res.grant == nil {
-		p.fillFromPlatform(ctx, runID, &bundle)
+		p.fillFromPlatform(ctx, runID, &bundle, skippedAPIKeys)
 	}
 
-	// A skipped forfait is only an improvement when some other tier could
-	// actually serve its wire. If nothing did — no second forfait, no
-	// pool grant, no platform credential — restore it: the run then
-	// parks on the provider refusal with a DURABLE usage-window retry,
-	// instead of failing on a no-credential auth error nothing retries.
-	if len(skippedForfaits) > 0 {
+	// A skipped credential is only an improvement when some other tier
+	// could actually serve its wire. If nothing did — no second key, no
+	// second forfait, no pool grant, no platform credential — restore it:
+	// the run then parks on the provider refusal with a DURABLE
+	// usage-window retry, instead of failing on a no-credential auth
+	// error nothing retries. Keys before forfaits, in allKnownProviders
+	// order, matching both the delegate's precedence on a shared wire and
+	// the deterministic-winner rule of fillFromPlatform.
+	if len(skippedForfaits) > 0 || len(skippedAPIKeys) > 0 {
 		taken := map[string]bool{}
 		for prov := range bundle.APIKeys {
 			taken[secrets.WireFamily(string(prov))] = true
 		}
 		for kind := range bundle.OAuthCredentials {
 			taken[secrets.WireFamily(kind)] = true
+		}
+		for _, prov := range allKnownProviders {
+			sk, ok := skippedAPIKeys[prov]
+			if !ok || taken[secrets.WireFamily(string(prov))] {
+				continue
+			}
+			bundle.APIKeys[prov] = sk.plaintext
+			if sk.platform {
+				bundle.PlatformSourced[string(prov)] = true
+			}
+			taken[secrets.WireFamily(string(prov))] = true
+			p.logger.Info("cloudpublisher: refused api-key RESTORED for run=%s provider=%s — no other tier could serve; a parked run with a durable retry beats a stuck one", runID, prov)
 		}
 		for kind, sf := range skippedForfaits {
 			if taken[secrets.WireFamily(kind)] {
@@ -680,7 +719,7 @@ func setOAuthFingerprint(bundle *secrets.RunBundle, kind, fp string) {
 // Best-effort like the pool: a degraded store read or unseal failure logs
 // and leaves the slot to the env fallback — it must never fail a launch
 // that env can still serve.
-func (p *Publisher) fillFromPlatform(ctx context.Context, runID string, bundle *secrets.RunBundle) {
+func (p *Publisher) fillFromPlatform(ctx context.Context, runID string, bundle *secrets.RunBundle, skippedAPIKeys map[secrets.Provider]skippedAPIKey) {
 	if p.sealer == nil {
 		return
 	}
@@ -737,6 +776,27 @@ func (p *Publisher) fillFromPlatform(ctx context.Context, runID string, bundle *
 							_ = p.apiKeys.MarkUsed(bg, id, t)
 						}
 					})
+				}
+			}
+			// This tier is the last DB-backed one and the runner's env
+			// backstop is invisible from here, so a refused platform key
+			// must not vanish outright — the rule the OAuth branch below
+			// states verbatim. It is remembered for the restore step
+			// instead, behind any tenant key of the same provider, whose
+			// restore takes precedence.
+			if refused := providersWithoutKey(missing, bundle.APIKeys); len(refused) > 0 {
+				fallback, ferr := secrets.Resolve(pctx, p.apiKeys, secrets.PlatformTenantID, "", refused, nil, p.sealer, nil)
+				if ferr != nil {
+					p.logger.Warn("cloudpublisher: platform refused-key fallback resolve: %v", ferr)
+				}
+				for prov, r := range fallback {
+					if len(r.Plaintext) == 0 {
+						continue
+					}
+					if _, seen := skippedAPIKeys[prov]; seen {
+						continue
+					}
+					skippedAPIKeys[prov] = skippedAPIKey{plaintext: string(r.Plaintext), keyID: r.KeyID, platform: true}
 				}
 			}
 		}
@@ -806,6 +866,28 @@ var poolWantOrder = func() []credpool.Credential {
 type skippedForfait struct {
 	payload []byte
 	fp      string
+}
+
+// skippedAPIKey is a provider's refused-but-only key, held back by the
+// evidence predicate and restored when no other tier served its wire.
+// platform marks the deployment's own key so the restore keeps its
+// PlatformSourced metering scope.
+type skippedAPIKey struct {
+	plaintext string
+	keyID     string
+	platform  bool
+}
+
+// providersWithoutKey returns the subset of provs that filled no API-key
+// slot — the candidates for the refused-key fallback lookup.
+func providersWithoutKey(provs []secrets.Provider, apiKeys map[secrets.Provider]string) []secrets.Provider {
+	var missing []secrets.Provider
+	for _, prov := range provs {
+		if apiKeys[prov] == "" {
+			missing = append(missing, prov)
+		}
+	}
+	return missing
 }
 
 // usageCapLookupTimeout bounds the meter read on the launch path — the

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -367,7 +367,11 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 				overrides[secrets.Provider(prov)] = keyID
 			}
 		}
-		resolved, err := secrets.Resolve(ctx, p.apiKeys, tenantID, ownerID, allKnownProviders, overrides, p.sealer)
+		// Evidence-based skip: a key the provider freshly refused is
+		// passed over so the priority walk yields the next key of that
+		// provider — the BYOK tier becomes an ordered fallback chain.
+		resolved, err := secrets.Resolve(ctx, p.apiKeys, tenantID, ownerID, allKnownProviders, overrides, p.sealer,
+			p.apiKeyUsable(ctx, usagecap.TenantScope(tenantID), runID))
 		if err != nil {
 			return credResolution{}, fmt.Errorf("cloudpublisher: resolve creds: %w", err)
 		}
@@ -700,7 +704,8 @@ func (p *Publisher) fillFromPlatform(ctx context.Context, runID string, bundle *
 		}
 		if len(missing) > 0 {
 			pctx := store.WithTenant(ctx, secrets.PlatformTenantID)
-			resolved, err := secrets.Resolve(pctx, p.apiKeys, secrets.PlatformTenantID, "", missing, nil, p.sealer)
+			resolved, err := secrets.Resolve(pctx, p.apiKeys, secrets.PlatformTenantID, "", missing, nil, p.sealer,
+				p.apiKeyUsable(pctx, usagecap.ScopePlatform, runID))
 			if err != nil {
 				p.logger.Warn("cloudpublisher: platform api-key resolve: %v", err)
 			} else {
@@ -829,27 +834,29 @@ const usageCapLookupTimeout = 5 * time.Second
 //     reset", so a window that reopened stops blocking by itself);
 //   - allowed/warning at ANY utilization, reset instant or not ⇒ usable.
 func (p *Publisher) forfaitWindowClosed(ctx context.Context, tenantID, ownerKey string, rec secrets.OAuthRecord) (time.Time, string) {
-	if p.usageCaps == nil || rec.Fingerprint == "" {
-		return time.Time{}, ""
-	}
 	backend := usageBackendForKind(rec.Kind)
-	if backend == "" {
-		return time.Time{}, ""
-	}
-	// Same key the runner meters under: the credential's own fingerprint,
-	// in the scope that credential belongs to (a tenant's own forfait
-	// never merges with the platform's).
 	scope := usagecap.ScopePlatform
 	if ownerKey != secrets.PlatformOwnerKey && tenantID != "" {
 		scope = usagecap.TenantScope(tenantID)
 	}
+	return p.refusedUntil(ctx, backend, scope, rec.Fingerprint, string(rec.Kind))
+}
+
+// refusedUntil is the ONE evidence reading shared by every credential-skip
+// site (the oauth-forfait tiers and the BYOK api-key walk): it reports when
+// fresh provider refusals against this credential lapse, or the zero time
+// when the credential is usable. label is for the lookup-failure log only.
+func (p *Publisher) refusedUntil(ctx context.Context, backend string, scope string, fingerprint, label string) (time.Time, string) {
+	if p.usageCaps == nil || fingerprint == "" || backend == "" {
+		return time.Time{}, ""
+	}
 	lctx, cancel := context.WithTimeout(ctx, usageCapLookupTimeout)
 	defer cancel()
-	readings, err := p.usageCaps.Latest(lctx, usagecap.Key(backend, scope, rec.Fingerprint))
+	readings, err := p.usageCaps.Latest(lctx, usagecap.Key(backend, scope, fingerprint))
 	if err != nil {
 		// The meter is an optimisation; its failure must not change which
 		// credential a run gets.
-		p.logger.Warn("cloudpublisher: usage-cap lookup for %s/%s: %v", rec.Kind, rec.Fingerprint, err)
+		p.logger.Warn("cloudpublisher: usage-cap lookup for %s/%s: %v", label, fingerprint, err)
 		return time.Time{}, ""
 	}
 	now := time.Now()
@@ -891,6 +898,37 @@ func usageBackendForKind(kind secrets.OAuthKind) string {
 		return delegate.BackendClaudeCode
 	}
 	return ""
+}
+
+// usageBackendForProvider maps a BYOK api-key provider to the meter backend
+// its refusals are recorded under. Anthropic-shaped keys (the real one and
+// the z.ai facade) are spent by claude_code sessions, so that is where the
+// runner meters them. "" for a provider with no metered evidence — those
+// keys are never skipped.
+func usageBackendForProvider(prov secrets.Provider) string {
+	switch prov {
+	case secrets.ProviderAnthropic, secrets.ProviderZAI:
+		return delegate.BackendClaudeCode
+	}
+	return ""
+}
+
+// apiKeyUsable builds the Resolve predicate for one resolution: a key with
+// fresh provider-refusal evidence under its fingerprint is skipped, and the
+// priority walk hands the NEXT key of that provider over — the ordered
+// fallback the 2026-09-02 fair-usage freeze was routed around by hand.
+// Everything uncertain means "usable", same contract as refusedUntil.
+func (p *Publisher) apiKeyUsable(ctx context.Context, scope string, runID string) func(secrets.ApiKey) bool {
+	return func(k secrets.ApiKey) bool {
+		backend := usageBackendForProvider(k.Provider)
+		until, why := p.refusedUntil(ctx, backend, scope, k.Fingerprint, string(k.Provider))
+		if until.IsZero() {
+			return true
+		}
+		p.logger.Info("cloudpublisher: api-key(%s) %q SKIPPED for run=%s — %s (reopens %s); trying the next key of this provider",
+			k.Provider, k.Name, runID, why, until.UTC().Format(time.RFC3339))
+		return false
+	}
 }
 
 // providerOfWant maps a want back to the LLM provider it authenticates

--- a/pkg/usagecap/usagecap.go
+++ b/pkg/usagecap/usagecap.go
@@ -203,6 +203,15 @@ type Reading struct {
 	ResetsAt time.Time
 	// ObservedAt is when iterion saw the reading.
 	ObservedAt time.Time
+	// Source is the delegate's provider-routing label for the session
+	// that produced this reading (providerFingerprint: "facade:<url>",
+	// "anthropic-direct", "anthropic-oauth", "anthropic-env"). It lets
+	// the publisher key the reading under the credential the node
+	// ACTUALLY spent — a node pinned `provider: anthropic` must not
+	// charge its refusal to the z.ai key sharing the bundle. Empty on
+	// readings from older binaries; consumers fall back to the bundle's
+	// default precedence then. Never carries a secret.
+	Source string
 }
 
 // Provider status values.


### PR DESCRIPTION
## Completes the chain #601+#610 opened

The fair-usage freeze (2026-09-02) exposed the last fixed link: the BYOK tier resolves ONE key per provider, so a key whose account the provider froze was **resealed into every fresh launch** until an operator removed it by hand — measured: two manual key removals, five run cancels, three relaunch waves in one morning.

Three pieces, one evidence source:

1. **`secrets.Resolve` takes a `usable` predicate** consulted in its existing priority walk (user-default → user → team-default → team): a refused key is skipped and the walk yields the NEXT visible key of that provider — several keys of one provider become an ordered fallback chain, with zero new ordering machinery. Explicit `keyOverrides` pins are deliberately not filtered: the operator named that key.
2. **The publisher supplies the predicate from the same evidence the forfait-window skip uses** — `refusedUntil`, extracted as the one shared reading (fresh `StatusRejected` under the key's own fingerprint, quota families only, everything uncertain = usable). Both resolution sites (tenant and platform backstop) are wired.
3. **`usageCapKey` now follows the delegate's real precedence** (z.ai `AUTH_TOKEN` over Anthropic API key over OAuth dir) for scope AND fingerprint. A z.ai-served run used to meter under the anthropic slot — the refused key kept a clean meter, so no evidence-based skip could ever have seen it. This is what makes #610's frequency evidence actually land on the credential that earned it.

## Falsified both ways

- dropping the predicate consult in the walk → walk test red;
- dropping z.ai from the metered-backend map → evidence test red;
- hysteric side pinned: overage-rejected reading keeps the key usable, a foreign provider with no metered backend is never skipped, an all-refused provider is OMITTED (the later tiers get their turn) rather than served a poisoned key.

2818 tests green across 27 packages locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)