### PR TITLE
feat(usagecap): an auth-rejected credential becomes skip evidence — the third refusal family

### DIFF
--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -519,6 +519,18 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, task Task) (result Resu
 		detail := strings.TrimSpace(*rm.Result)
 		b.Logger.Error("[%s#%d/claude-code] authentication failed — failing fast: %.160s",
 			task.NodeID, task.Iteration, detail)
+		// Recorded as meter evidence before failing: without it the next
+		// resolution re-picks this same dead credential (re-resolution is
+		// already universal server-side — the missing piece was ever
+		// learning the credential is dead). The stamped Source keys the
+		// reading under the credential this session actually ran on.
+		if task.Hooks.OnUsageWindow != nil {
+			_ = task.Hooks.OnUsageWindow(usagecap.Reading{
+				Window:     usagecap.WindowAuth,
+				Status:     usagecap.StatusRejected,
+				ObservedAt: time.Now().UTC(),
+			})
+		}
 		return result, &ErrAuthFailed{
 			Provider: BackendClaudeCode,
 			Detail:   fmt.Sprintf("check the forfait CLAUDE_CODE_OAUTH_TOKEN or the Anthropic API key: %s", detail),

--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -517,7 +517,7 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, task Task) (result Resu
 	// a legible auth error. Non-transient (a retry can't revive a dead token).
 	if authErr := authFailureFast(rm.Result, task); authErr != nil {
 		b.Logger.Error("[%s#%d/claude-code] authentication failed — failing fast: %.160s",
-			task.NodeID, task.Iteration, strings.TrimSpace(*rm.Result))
+			task.NodeID, task.Iteration, redactAuthRender(strings.TrimSpace(*rm.Result)))
 		return result, authErr
 	}
 

--- a/pkg/backend/delegate/claude_code.go
+++ b/pkg/backend/delegate/claude_code.go
@@ -515,26 +515,10 @@ func (b *ClaudeCodeBackend) Execute(ctx context.Context, task Task) (result Resu
 	// field" schema error — the exact masking that turns a dead credential into
 	// a wild goose chase through the structured-output machinery. Fail fast with
 	// a legible auth error. Non-transient (a retry can't revive a dead token).
-	if rm.Result != nil && isAuthErrorResult(*rm.Result) {
-		detail := strings.TrimSpace(*rm.Result)
+	if authErr := authFailureFast(rm.Result, task); authErr != nil {
 		b.Logger.Error("[%s#%d/claude-code] authentication failed — failing fast: %.160s",
-			task.NodeID, task.Iteration, detail)
-		// Recorded as meter evidence before failing: without it the next
-		// resolution re-picks this same dead credential (re-resolution is
-		// already universal server-side — the missing piece was ever
-		// learning the credential is dead). The stamped Source keys the
-		// reading under the credential this session actually ran on.
-		if task.Hooks.OnUsageWindow != nil {
-			_ = task.Hooks.OnUsageWindow(usagecap.Reading{
-				Window:     usagecap.WindowAuth,
-				Status:     usagecap.StatusRejected,
-				ObservedAt: time.Now().UTC(),
-			})
-		}
-		return result, &ErrAuthFailed{
-			Provider: BackendClaudeCode,
-			Detail:   fmt.Sprintf("check the forfait CLAUDE_CODE_OAUTH_TOKEN or the Anthropic API key: %s", detail),
-		}
+			task.NodeID, task.Iteration, strings.TrimSpace(*rm.Result))
+		return result, authErr
 	}
 
 	// Quota / usage-window guard on the RESULT. The forfait's weekly / session /

--- a/pkg/backend/delegate/claude_code_autherr_test.go
+++ b/pkg/backend/delegate/claude_code_autherr_test.go
@@ -1,6 +1,11 @@
 package delegate
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/usagecap"
+)
 
 // TestIsAuthErrorResult guards the auth-failure classifier that keeps a dead
 // forfait token (or rejected API key) from masquerading as a structured-output
@@ -52,5 +57,33 @@ func TestIsAuthErrorResult_malformedCredential(t *testing.T) {
 	quoted := "The run failed because the log said: API Error: Header '14' has invalid value: 'Bearer x'. We should investigate the credential store."
 	if isAuthErrorResult(quoted) {
 		t.Fatal("prose quoting the error mid-answer must not classify")
+	}
+}
+
+// The evidence write: an auth failure must leave a rejected WindowAuth
+// reading behind (through the task hook, so the Source stamp applies)
+// before the typed error surfaces — otherwise the next resolution
+// re-picks the same dead credential.
+func TestAuthFailureFast_recordsEvidence(t *testing.T) {
+	var got []usagecap.Reading
+	task := Task{}
+	task.Hooks.OnUsageWindow = func(r usagecap.Reading) error { got = append(got, r); return nil }
+
+	res := "Failed to authenticate. API Error: 401 Invalid bearer token"
+	err := authFailureFast(&res, task)
+	var auth *ErrAuthFailed
+	if !errors.As(err, &auth) {
+		t.Fatalf("err = %v, want ErrAuthFailed", err)
+	}
+	if len(got) != 1 || got[0].Window != usagecap.WindowAuth || got[0].Status != usagecap.StatusRejected {
+		t.Fatalf("readings = %+v, want one rejected WindowAuth reading", got)
+	}
+
+	ok := "All done, docs aligned."
+	if authFailureFast(&ok, task) != nil || len(got) != 1 {
+		t.Fatal("a normal result must produce neither error nor evidence")
+	}
+	if authFailureFast(nil, task) != nil {
+		t.Fatal("a nil result must be a no-op")
 	}
 }

--- a/pkg/backend/delegate/claude_code_autherr_test.go
+++ b/pkg/backend/delegate/claude_code_autherr_test.go
@@ -126,13 +126,26 @@ func TestAuthFailureFast_looseSignatureFailsWithoutEvidence(t *testing.T) {
 		t.Fatalf("readings = %+v, want NONE — prose must not arm the credential skip", got)
 	}
 
-	// The CLI's own render of the same words, prefix-anchored, does.
+	// The CLI's own "Not logged in" render fails the node but writes no
+	// evidence either: it indicts the delivery, not the credential — a
+	// healthy forfait shadowed by the pod env produces the same render
+	// (claudeForfaitEnv's documented precedent), and benching the
+	// credential for it would skip a key that works everywhere else.
 	cli := "Not logged in · Please run /login"
 	if authFailureFast(&cli, task) == nil {
 		t.Fatal("the CLI render must fail the node")
 	}
+	if len(got) != 0 {
+		t.Fatalf("readings = %+v, want NONE — 'Not logged in' is delivery-ambiguous", got)
+	}
+
+	// A provider verdict on the credential itself does arm the skip.
+	verdict := "Failed to authenticate. API Error: 401 Invalid bearer token"
+	if authFailureFast(&verdict, task) == nil {
+		t.Fatal("the provider verdict must fail the node")
+	}
 	if len(got) != 1 {
-		t.Fatalf("readings = %+v, want one — the CLI's own render is high-confidence", got)
+		t.Fatalf("readings = %+v, want one — the provider rejected the credential itself", got)
 	}
 }
 

--- a/pkg/backend/delegate/claude_code_autherr_test.go
+++ b/pkg/backend/delegate/claude_code_autherr_test.go
@@ -2,6 +2,7 @@ package delegate
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/usagecap"
@@ -50,7 +51,14 @@ func TestIsAuthErrorResult(t *testing.T) {
 // so only a result that IS the error matches — an agent quoting one
 // mid-answer must not.
 func TestIsAuthErrorResult_malformedCredential(t *testing.T) {
-	long := "API Error: Header '14' has invalid value: 'Bearer \x1b[?2004hWelcome to Claude Code v2.1.220\nWelcome to Claude Code v2.1.220\n\n · Opening browser to sign in'"
+	// The paid real-world shape is a whole CLI login transcript quoted
+	// back as the header value — comfortably past the 200-byte prose cap,
+	// which is exactly why the prefix branch sits ABOVE that cap. The
+	// assertion on len pins the property the fixture exists for.
+	long := "API Error: Header '14' has invalid value: 'Bearer \x1b[?2004h\x1b[?1004h\x1b[?2031hWelcome to Claude Code v2.1.220\nWelcome to Claude Code v2.1.220\n\n · Opening browser to sign in…\nPaste code here if prompted > \nWelcome to Claude Code v2.1.220\n · Opening browser to sign in…'"
+	if len(long) <= 200 {
+		t.Fatalf("fixture is %d bytes — it must exceed the 200-byte prose cap to guard the branch ordering", len(long))
+	}
 	if !isAuthErrorResult(long) {
 		t.Fatal("the malformed-Authorization render must classify as an auth failure")
 	}
@@ -98,5 +106,49 @@ func TestIsAuthErrorResult_shortMalformedCredential(t *testing.T) {
 		if !isAuthErrorResult(s) {
 			t.Errorf("isAuthErrorResult(%q) = false, want true", s)
 		}
+	}
+}
+
+// Two thresholds, two blast radii: every auth render fails the node, but
+// only the CLI's own high-confidence shapes write skip evidence — a terse
+// agent answer containing "not logged in" must not bench a healthy
+// credential fleet-wide for an hour.
+func TestAuthFailureFast_looseSignatureFailsWithoutEvidence(t *testing.T) {
+	var got []usagecap.Reading
+	task := Task{}
+	task.Hooks.OnUsageWindow = func(r usagecap.Reading) error { got = append(got, r); return nil }
+
+	prose := "The deploy step failed: the gh CLI says you are not logged in."
+	if authFailureFast(&prose, task) == nil {
+		t.Fatal("the loose signature must still fail the node fast")
+	}
+	if len(got) != 0 {
+		t.Fatalf("readings = %+v, want NONE — prose must not arm the credential skip", got)
+	}
+
+	// The CLI's own render of the same words, prefix-anchored, does.
+	cli := "Not logged in · Please run /login"
+	if authFailureFast(&cli, task) == nil {
+		t.Fatal("the CLI render must fail the node")
+	}
+	if len(got) != 1 {
+		t.Fatalf("readings = %+v, want one — the CLI's own render is high-confidence", got)
+	}
+}
+
+// The rejected secret must never reach durable state: the Detail (run
+// document, failure events) and the operator log both go through
+// redactAuthRender, which drops everything after the identifying prefix.
+func TestAuthFailureFast_redactsTheQuotedCredential(t *testing.T) {
+	res := "API Error: Header '14' has invalid value: 'Bearer sk-ant-oat01-SECRETSECRETSECRET'"
+	err := authFailureFast(&res, Task{})
+	if err == nil {
+		t.Fatal("want an auth failure")
+	}
+	if msg := err.Error(); strings.Contains(msg, "SECRETSECRET") || strings.Contains(msg, "Bearer sk-") {
+		t.Fatalf("Detail leaks the credential: %q", msg)
+	}
+	if !strings.Contains(err.Error(), "has invalid value: <redacted>") {
+		t.Fatalf("Detail should keep the identifying prefix: %q", err.Error())
 	}
 }

--- a/pkg/backend/delegate/claude_code_autherr_test.go
+++ b/pkg/backend/delegate/claude_code_autherr_test.go
@@ -87,3 +87,16 @@ func TestAuthFailureFast_recordsEvidence(t *testing.T) {
 		t.Fatal("a nil result must be a no-op")
 	}
 }
+
+// R7cac91: the short-garbage half of the malformed-Authorization render —
+// a 54-byte result must classify, not panic on a fixed-width slice.
+func TestIsAuthErrorResult_shortMalformedCredential(t *testing.T) {
+	for _, s := range []string{
+		"API Error: Header '14' has invalid value: 'Bearer abc'",
+		"API Error: Header '1' has invalid value: 'Bearer '",
+	} {
+		if !isAuthErrorResult(s) {
+			t.Errorf("isAuthErrorResult(%q) = false, want true", s)
+		}
+	}
+}

--- a/pkg/backend/delegate/claude_code_autherr_test.go
+++ b/pkg/backend/delegate/claude_code_autherr_test.go
@@ -39,3 +39,18 @@ func TestIsAuthErrorResult(t *testing.T) {
 		}
 	}
 }
+
+// The malformed-credential render: a secret that is not a token at all is
+// quoted back inside an unbounded "API Error: Header …" line. Prefix-anchored
+// so only a result that IS the error matches — an agent quoting one
+// mid-answer must not.
+func TestIsAuthErrorResult_malformedCredential(t *testing.T) {
+	long := "API Error: Header '14' has invalid value: 'Bearer \x1b[?2004hWelcome to Claude Code v2.1.220\nWelcome to Claude Code v2.1.220\n\n · Opening browser to sign in'"
+	if !isAuthErrorResult(long) {
+		t.Fatal("the malformed-Authorization render must classify as an auth failure")
+	}
+	quoted := "The run failed because the log said: API Error: Header '14' has invalid value: 'Bearer x'. We should investigate the credential store."
+	if isAuthErrorResult(quoted) {
+		t.Fatal("prose quoting the error mid-answer must not classify")
+	}
+}

--- a/pkg/backend/delegate/claude_code_errmap.go
+++ b/pkg/backend/delegate/claude_code_errmap.go
@@ -79,6 +79,14 @@ func isModelUnavailableResult(s string) bool {
 // credential; the caller fails fast with a legible auth error.
 func isAuthErrorResult(s string) bool {
 	t := strings.TrimSpace(s)
+	// A malformed Authorization value (a secret that is not a token at
+	// all — the paid case embedded a whole CLI login transcript) renders
+	// as an API Error whose length is unbounded because the garbage value
+	// is quoted back. Prefix-anchored: the WHOLE result must be the API
+	// error, so an agent merely quoting one mid-answer cannot match.
+	if strings.HasPrefix(t, "API Error: Header '") && strings.Contains(t[:80], "has invalid value") {
+		return true
+	}
 	// Real auth renders are short one-liners (like a rate-limit notice); the cap
 	// keeps an agent discussing auth in a long answer from false-positiving.
 	if t == "" || len(t) > 200 {

--- a/pkg/backend/delegate/claude_code_errmap.go
+++ b/pkg/backend/delegate/claude_code_errmap.go
@@ -2,8 +2,12 @@ package delegate
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/usagecap"
 )
 
 // apiErrorResultStatusRe extracts the HTTP-ish status code the claude CLI
@@ -112,6 +116,31 @@ func isAuthErrorResult(s string) bool {
 		}
 	}
 	return false
+}
+
+// authFailureFast classifies a CLI result as a rendered authentication
+// failure, records the refusal as meter evidence, and returns the typed
+// error — nil when the result is not an auth render. The evidence write
+// comes BEFORE the failure on purpose: re-resolution is already universal
+// server-side, and without a reading the next resolution re-picks this
+// same dead credential, gating the healthy tiers off behind it. The
+// session's Source stamp keys the reading under the credential that
+// actually ran.
+func authFailureFast(result *string, task Task) error {
+	if result == nil || !isAuthErrorResult(*result) {
+		return nil
+	}
+	if task.Hooks.OnUsageWindow != nil {
+		_ = task.Hooks.OnUsageWindow(usagecap.Reading{
+			Window:     usagecap.WindowAuth,
+			Status:     usagecap.StatusRejected,
+			ObservedAt: time.Now().UTC(),
+		})
+	}
+	return &ErrAuthFailed{
+		Provider: BackendClaudeCode,
+		Detail:   fmt.Sprintf("check the forfait CLAUDE_CODE_OAUTH_TOKEN or the Anthropic API key: %s", strings.TrimSpace(*result)),
+	}
 }
 
 // retypeNetworkError re-classifies an opaque claude_code failure as an

--- a/pkg/backend/delegate/claude_code_errmap.go
+++ b/pkg/backend/delegate/claude_code_errmap.go
@@ -118,6 +118,50 @@ func isAuthErrorResult(s string) bool {
 	return false
 }
 
+// redactAuthRender strips the quoted credential out of an auth render:
+// the malformed-Authorization shape quotes the rejected secret back
+// verbatim, and this text flows into durable, run-readable state (the
+// run document, the failure events, the operator log) — none of which
+// is scrubbed. The prefix alone identifies the failure.
+func redactAuthRender(t string) string {
+	if i := strings.Index(t, "has invalid value"); i >= 0 {
+		return t[:i] + "has invalid value: <redacted>"
+	}
+	return t
+}
+
+// isHighConfidenceAuthRender reports whether the result is the CLI's OWN
+// auth-failure render — prefix-anchored shapes and distinctive wire
+// phrases — as opposed to prose that merely mentions logging in. Only
+// these arm the credential-skip evidence: a classifier false positive
+// used to cost one visibly-failed node, but an evidence write benches
+// the credential fleet-wide for DefaultMaxAge, so the loose substring
+// signatures ("not logged in" inside an agent's sentence) must not
+// reach it.
+func isHighConfidenceAuthRender(t string) bool {
+	if strings.HasPrefix(t, "API Error: Header '") && strings.Contains(t, "has invalid value") {
+		return true
+	}
+	low := strings.ToLower(t)
+	// The CLI's renders ARE the whole result; anchoring at the start is
+	// what separates them from an answer that quotes the same words.
+	if strings.HasPrefix(low, "not logged in") || strings.HasPrefix(low, "failed to authenticate") {
+		return true
+	}
+	for _, sig := range []string{
+		"invalid bearer token",
+		"authentication_error",
+		"invalid x-api-key",
+		"oauth token has expired",
+		"oauth token expired",
+	} {
+		if strings.Contains(low, sig) {
+			return true
+		}
+	}
+	return false
+}
+
 // authFailureFast classifies a CLI result as a rendered authentication
 // failure, records the refusal as meter evidence, and returns the typed
 // error — nil when the result is not an auth render. The evidence write
@@ -125,12 +169,15 @@ func isAuthErrorResult(s string) bool {
 // server-side, and without a reading the next resolution re-picks this
 // same dead credential, gating the healthy tiers off behind it. The
 // session's Source stamp keys the reading under the credential that
-// actually ran.
+// actually ran. Fail-fast and evidence are two thresholds on purpose:
+// every auth render fails the node legibly, but only the CLI's own
+// high-confidence shapes bench the credential.
 func authFailureFast(result *string, task Task) error {
 	if result == nil || !isAuthErrorResult(*result) {
 		return nil
 	}
-	if task.Hooks.OnUsageWindow != nil {
+	t := strings.TrimSpace(*result)
+	if isHighConfidenceAuthRender(t) && task.Hooks.OnUsageWindow != nil {
 		_ = task.Hooks.OnUsageWindow(usagecap.Reading{
 			Window:     usagecap.WindowAuth,
 			Status:     usagecap.StatusRejected,
@@ -139,7 +186,7 @@ func authFailureFast(result *string, task Task) error {
 	}
 	return &ErrAuthFailed{
 		Provider: BackendClaudeCode,
-		Detail:   fmt.Sprintf("check the forfait CLAUDE_CODE_OAUTH_TOKEN or the Anthropic API key: %s", strings.TrimSpace(*result)),
+		Detail:   fmt.Sprintf("check the forfait CLAUDE_CODE_OAUTH_TOKEN or the Anthropic API key: %s", redactAuthRender(t)),
 	}
 }
 

--- a/pkg/backend/delegate/claude_code_errmap.go
+++ b/pkg/backend/delegate/claude_code_errmap.go
@@ -143,11 +143,14 @@ func isHighConfidenceAuthRender(t string) bool {
 		return true
 	}
 	low := strings.ToLower(t)
-	// The CLI's renders ARE the whole result; anchoring at the start is
-	// what separates them from an answer that quotes the same words.
-	if strings.HasPrefix(low, "not logged in") || strings.HasPrefix(low, "failed to authenticate") {
-		return true
-	}
+	// "Not logged in" (and a bare "Failed to authenticate") are
+	// deliberately NOT here: they indict the DELIVERY, not the
+	// credential — this package documents a healthy materialised forfait
+	// rendered "Not logged in" by pod-env shadowing (claudeForfaitEnv,
+	// live run 019f8a6c), and benching the credential for a delivery
+	// fault would skip a key that works everywhere else. The dead-record
+	// half of that render belongs to ingestion-time validation. Only the
+	// provider's own verdict on the credential arms the skip:
 	for _, sig := range []string{
 		"invalid bearer token",
 		"authentication_error",

--- a/pkg/backend/delegate/claude_code_errmap.go
+++ b/pkg/backend/delegate/claude_code_errmap.go
@@ -88,7 +88,7 @@ func isAuthErrorResult(s string) bool {
 	// as an API Error whose length is unbounded because the garbage value
 	// is quoted back. Prefix-anchored: the WHOLE result must be the API
 	// error, so an agent merely quoting one mid-answer cannot match.
-	if strings.HasPrefix(t, "API Error: Header '") && strings.Contains(t[:80], "has invalid value") {
+	if strings.HasPrefix(t, "API Error: Header '") && strings.Contains(t, "has invalid value") {
 		return true
 	}
 	// Real auth renders are short one-liners (like a rate-limit notice); the cap

--- a/pkg/server/cloudpublisher/apikey_skip_test.go
+++ b/pkg/server/cloudpublisher/apikey_skip_test.go
@@ -187,3 +187,23 @@ func TestApiKeySkip_refusedPlatformKeyIsRestoredPlatformSourced(t *testing.T) {
 		t.Fatal("a restored PLATFORM key must keep its platform-sourced metering scope")
 	}
 }
+
+// The third evidence family: a provider that rejected the CREDENTIAL
+// ITSELF (dead token, malformed secret) must be walked past exactly like
+// a quota refusal — without this, a structurally-broken credential keeps
+// filling its slot on every re-resolution and gates the healthy tiers off.
+func TestApiKeyUsable_authRefusalSkips(t *testing.T) {
+	st := usagecap.NewMemStore()
+	p := &Publisher{usageCaps: st, logger: iterlog.New(iterlog.LevelError, nil)}
+	scope := usagecap.TenantScope("team")
+	key := secrets.ApiKey{Provider: secrets.ProviderAnthropic, Name: "dead", Fingerprint: "fp-dead"}
+	if err := st.Record(context.Background(),
+		usagecap.Key(delegate.BackendClaudeCode, scope, "fp-dead"),
+		usagecap.Reading{Window: usagecap.WindowAuth, Status: usagecap.StatusRejected,
+			ObservedAt: time.Now()}); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if p.apiKeyUsable(context.Background(), scope, "run-x")(key) {
+		t.Fatal("a fresh auth refusal under the key's fingerprint must skip it")
+	}
+}

--- a/pkg/server/cloudpublisher/apikey_skip_test.go
+++ b/pkg/server/cloudpublisher/apikey_skip_test.go
@@ -207,3 +207,34 @@ func TestApiKeyUsable_authRefusalSkips(t *testing.T) {
 		t.Fatal("a fresh auth refusal under the key's fingerprint must skip it")
 	}
 }
+
+// The forfait half of the auth family, end to end at the resolution: an
+// auth-refused user forfait is skipped — its evidence lives under the SAME
+// record fingerprint the runner keys "anthropic-oauth" readings by — and
+// the platform forfait serves instead. This is the dead-on-arrival-fleet
+// scenario: before, the dead record filled the slot on every re-resolution.
+func TestOAuthForfait_authRefusalFallsThroughToPlatform(t *testing.T) {
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	oauth := secrets.NewMemoryOAuthStore()
+	seedOAuth(t, oauth, sealer, "owner1", "sk-ant-dead")
+	seedOAuth(t, oauth, sealer, secrets.PlatformOwnerKey, "sk-ant-platform")
+	caps := usagecap.NewMemStore()
+	if err := caps.Record(context.Background(),
+		usagecap.Key(delegate.BackendClaudeCode, usagecap.TenantScope("team1"), seededFP("owner1")),
+		usagecap.Reading{Window: usagecap.WindowAuth, Status: usagecap.StatusRejected,
+			ObservedAt: time.Now()}); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+
+	p := &Publisher{oauthForfait: oauth, usageCaps: caps,
+		runSecrets: secrets.NewMemoryRunSecretsStore(), sealer: sealer, logger: testLogger()}
+	rs := p.runSecrets.(*secrets.MemoryRunSecretsStore)
+
+	b := resolveBundle(t, p, rs, sealer, "run-a1", "team1", "owner1")
+	if got := string(b.OAuthCredentials["claude_code"]); !contains(got, "sk-ant-platform") {
+		t.Fatalf("claude_code blob = %q, want the PLATFORM forfait — the auth-dead record must be walked past", got)
+	}
+}

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -967,7 +967,16 @@ func (p *Publisher) refusedUntil(ctx context.Context, backend string, scope stri
 		}
 		if reopen.After(until) {
 			until = reopen
-			why = fmt.Sprintf("provider refused the %s window (%.0f%% used)", r.Window, r.Percent())
+			// Frequency and auth are refusals, not windows with a fill
+			// level — "(0% used)" on them would read as a contradiction.
+			switch r.Window {
+			case usagecap.WindowAuth:
+				why = "provider rejected the credential itself (auth failure)"
+			case usagecap.WindowFrequency:
+				why = "provider refused the account's request rate (fair-usage)"
+			default:
+				why = fmt.Sprintf("provider refused the %s window (%.0f%% used)", r.Window, r.Percent())
+			}
 		}
 	}
 	return until, why

--- a/pkg/usagecap/usagecap.go
+++ b/pkg/usagecap/usagecap.go
@@ -72,6 +72,19 @@ const (
 	// around a credential the provider will not serve, and freshness for
 	// a reading with no reset instant is already bounded by ObservedAt.
 	WindowFrequency Window = "frequency"
+	// WindowAuth is not a provider window either: it is the provider
+	// REJECTING THE CREDENTIAL ITSELF — a dead token, an expired OAuth
+	// record, a malformed secret. Like WindowFrequency it exists as a
+	// window name so the refusal can be recorded as meter evidence: the
+	// credential-tier skip is the only consumer, and without this
+	// evidence a structurally-broken credential keeps filling its slot
+	// on every re-resolution, gating the pool and platform tiers off
+	// behind a credential that can never serve (five consecutive
+	// dead-on-arrival fleets were the lived cost). No reset instant —
+	// a dead credential does not heal on a schedule — so freshness is
+	// bounded by ObservedAt, giving a cheap periodic re-probe in case
+	// an operator rotated the secret in place.
+	WindowAuth Window = "auth"
 )
 
 // Family groups the windows that share one operator-facing cap. An
@@ -87,6 +100,11 @@ const (
 	// that filter evidence on "does a cap family govern this window"
 	// must see it.
 	FamilyAccount Family = "account"
+	// FamilyCredential mirrors FamilyAccount for WindowAuth: no
+	// operator cap governs it (an unconfigured family is inert in the
+	// guard), but it is real provider evidence the credential-tier
+	// skip must see — FamilyNone would filter it out at the consumer.
+	FamilyCredential Family = "credential"
 	// FamilyNone marks a window no cap applies to.
 	FamilyNone Family = ""
 )
@@ -100,6 +118,8 @@ func FamilyOf(w Window) Family {
 		return FamilyWeek
 	case WindowFrequency:
 		return FamilyAccount
+	case WindowAuth:
+		return FamilyCredential
 	default:
 		// Includes WindowOverage and any window a future CLI adds: an
 		// unknown window is not silently folded into a cap that was never

--- a/pkg/usagecap/usagecap_test.go
+++ b/pkg/usagecap/usagecap_test.go
@@ -219,3 +219,18 @@ func TestNilGuardIsInert(t *testing.T) {
 		t.Fatal("a nil guard must answer as an absent cap, so callers need no nil check")
 	}
 }
+
+// WindowAuth is credential-tier evidence, never an operator cap: FamilyOf
+// must expose it to the evidence consumers (non-None) while an ordinary
+// policy — which configures no "credential" family — must stay inert on
+// it, so an auth-dead credential parks NOTHING through the guard.
+func TestWindowAuth_evidenceNotCap(t *testing.T) {
+	if FamilyOf(WindowAuth) == FamilyNone {
+		t.Fatal("FamilyOf(WindowAuth) = FamilyNone — the evidence consumers would filter it out")
+	}
+	pol := Policy{FiveHour: WindowPolicy{MaxPercent: 85, Mode: ModeSoft}, Week: WindowPolicy{MaxPercent: 85, Mode: ModeHard}}
+	d := Preflight([]Reading{{Window: WindowAuth, Status: StatusRejected, ObservedAt: time.Now()}}, pol, time.Now(), DefaultMaxAge)
+	if d.Blocked {
+		t.Fatal("an auth refusal must never block a launch through the usage cap — it is routing evidence, not quota")
+	}
+}


### PR DESCRIPTION
## What

Re-resolution is already universal server-side — `SubmitResume` re-resolves ("Keys may have rotated between launch and resume") and the retry sweeper flows through it. Yet a structurally-broken credential (dead token, expired OAuth record, malformed secret) kept condemning run after run: it filled its slot on every re-resolution, gated the pool and platform tiers off behind it, and its failure produced **no evidence** for the credential-tier skip to act on. Quota refusals have a family (#601), frequency refusals have a family (#610) — the provider rejecting the credential ITSELF had none. Measured cost: five consecutive dead-on-arrival fleets in one morning, each requiring a manual purge-and-relaunch.

- **`WindowAuth` / `FamilyCredential`** (pkg/usagecap): the auth refusal recorded as meter evidence. Like `WindowFrequency` it carries no reset instant — a dead credential does not heal on a schedule — so freshness is bounded by `ObservedAt`, giving a cheap periodic re-probe in case an operator rotated the secret in place.
- **`authFailureFast`** (delegate): the existing auth fail-fast guard, extracted to a testable seam, now records a rejected `WindowAuth` reading through the task hook **before** failing — the #612 Source stamp keys it under the credential the session actually ran on.
- **Classifier**: the malformed-Authorization render (`API Error: Header '…' has invalid value: 'Bearer <garbage>'`, unbounded length because the garbage value is quoted back) now classifies as an auth failure — prefix-anchored so an agent quoting one mid-answer cannot match.
- **Zero publisher change**: `refusedUntil` accepts any non-None family, so the skip engages for BYOK keys and OAuth forfaits alike, and the #612 restore still guarantees a wire is never left empty.

## Falsified both ways

- Blind-judge face: removing the `FamilyOf(WindowAuth)` arm reds both the family test and the skip test (evidence filtered at the consumer).
- Hysteric face: `TestWindowAuth_evidenceNotCap` proves a fully-configured operator policy stays inert on an auth reading — routing evidence, never quota; nothing parks.
- Emission: `TestAuthFailureFast_recordsEvidence` pins exactly one rejected `WindowAuth` reading per auth failure, none on normal results.

## Out of scope

The Pi backend's `ErrAuthFailed` (pi.go) meters on a different wire and is untouched; wiring its evidence is follow-up material along with the escalating-backoff and pinned-key-visibility follow-ups noted on #612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)