### PR TITLE
feat(webhooks): GitHub review-thread conversations — reply to a suggestion, get an in-thread answer

### DIFF
--- a/bots/revi-converse/manifest.yaml
+++ b/bots/revi-converse/manifest.yaml
@@ -28,7 +28,10 @@ triggers: [revi-converse, ask, converse]
 # Forge-access requirements for the studio Integrations auto-provisioner
 # (advisory + discovery-time — the runtime does not read this).
 forge:
-  events: [pull_request_comment]  # conversational sibling only; no PR-open auto-trigger
+  # pull_request_comment feeds /revi <question>; pull_request_review_comment
+  # feeds reply-to-a-suggestion (the GitHub review-thread firehose — only
+  # this bot's presence makes a repo subscribe it). No PR-open auto-trigger.
+  events: [pull_request_comment, pull_request_review_comment]
   token_scopes:
     pull_requests: write     # reply in-thread via the forge_token
     repository: read

--- a/docs/forge-conversations.md
+++ b/docs/forge-conversations.md
@@ -54,14 +54,20 @@ entries there:
   two-route `command_map`, and `ResolveCommandRoute` picks by args
   presence. Bare `/revi` stays a re-review.
 
-Enablement is provisioning, not code: `pull_request_comment` in a
-bot's manifest `forge.events` now expands on GitHub to BOTH wire
-events ([pkg/forge/event_map.go](../pkg/forge/event_map.go)), so a
-(re-)provision subscribes the hook and regenerates the config's
-`event_allowlist` together; webhooks provisioned before that stay
-inert on review-thread replies until re-provisioned, and the converse
-bot must be in the webhook's `bot_ids`. Forgejo is deliberately not
-wired yet (its dispatch never routes the event).
+Enablement is provisioning, not code: the review-thread firehose is
+its OWN normalized manifest event, `pull_request_review_comment`
+([pkg/forge/event_map.go](../pkg/forge/event_map.go)), declared by
+`revi-converse` — deliberately NOT folded into `pull_request_comment`,
+which nine catalog bots declare: one submitted review fires one wire
+delivery per inline comment, each charged against the webhook rate
+bucket and the org monthly quota before any handler filters it, so
+only a repo whose `bot_ids` actually include the conversational bot
+subscribes that volume. A (re-)provision with the converse bot
+subscribes the hook and regenerates the config's `event_allowlist`
+together; webhooks provisioned without it stay inert on review-thread
+replies. Forgejo is deliberately not wired yet (its dispatch never
+routes the event, and the normalized event maps to no Forgejo native
+event).
 
 ## Model — stateless, the thread is the state
 

--- a/docs/forge-conversations.md
+++ b/docs/forge-conversations.md
@@ -23,8 +23,11 @@ entries there:
 - **Reply to an inline suggestion** (`pull_request_review_comment`,
   action created): `handlePRForgeReviewThreadReply`
   ([pkg/server/webhooks_prforge.go](../pkg/server/webhooks_prforge.go))
-  filters (open PR, event/project allowlists), runs the loop-guard
-  FIRST and without forge I/O (`isIterionForgeBotAuthor` — the bot's
+  filters (open PR, event/project allowlists), drops thread-OPENING
+  comments from the payload alone (`in_reply_to` empty ⇒ nobody is in
+  that thread yet — every inline comment of a bot review echoes back
+  as one, so this spares the whole fetch), runs the loop-guard next,
+  still without forge I/O (`isIterionForgeBotAuthor` — the bot's
   own answer echoes back as this very event), requires the converse
   bot in the webhook scope (`roleBots().ReviConverse` +
   `cfg.AllowsBot`), then gates: the thread is fetched
@@ -32,7 +35,9 @@ entries there:
   comment by the bot identity — a human↔human thread never triggers —
   and the replier must clear `authorized_repliers` or
   `min_replier_role`. The launch carries `converse_question` (the
-  reply body), `thread_context` (the thread transcript) and
+  reply body), `thread_context` (the thread transcript, bot entries
+  labelled, capped by the same 16k anchor+newest budget as the GitLab
+  lane — `webhooks.CapTranscript`) and
   `discussion_id` = the **thread root** comment id — exactly what
   GitHub's `/pulls/{n}/comments/{id}/replies` endpoint wants (the
   bot's `forge-reply.md` §4). Idempotency: one launch per reply

--- a/docs/forge-conversations.md
+++ b/docs/forge-conversations.md
@@ -26,12 +26,16 @@ entries there:
   filters (open PR, event/project allowlists), drops thread-OPENING
   comments from the payload alone (`in_reply_to` empty ⇒ nobody is in
   that thread yet — every inline comment of a bot review echoes back
-  as one, so this spares the whole fetch), runs the loop-guard next,
+  as one, so this spares the whole fetch), drops fork PRs the same
+  payload-only way (`IsCrossRepo` — the base clone URL and the head
+  ref would not name one repository), runs the loop-guard next,
   still without forge I/O (`isIterionForgeBotAuthor` — the bot's
   own answer echoes back as this very event), requires the converse
   bot in the webhook scope (`roleBots().ReviConverse` +
   `cfg.AllowsBot`), then gates: the thread is fetched
-  (`ListPRReviewComments`, capped pagination) and must contain a
+  (`ListPRReviewComments` — newest-first capped pagination, handed
+  back chronological, so a long-lived PR's cap never blinds the gate
+  on the thread just replied to) and must contain a
   comment by the bot identity — a human↔human thread never triggers —
   and the replier must clear `authorized_repliers` or
   `min_replier_role`. The launch carries `converse_question` (the

--- a/docs/forge-conversations.md
+++ b/docs/forge-conversations.md
@@ -1,4 +1,4 @@
-# Forge conversations — replying to the bot (GitLab notes → run → in-thread reply)
+# Forge conversations — replying to the bot (forge threads → run → in-thread reply)
 
 How an authorized forge user "talks back" to a bot (reply to its review,
 ask a question, or `/revi` for a re-review) and gets a response **in the
@@ -10,9 +10,49 @@ DSL stays small.
 
 Status: A1 (note parsing), A2 (handler + authz + loop-guard +
 reply-in-thread trigger), A3 (conversation vars incl. the fetched thread
-transcript as `thread_context`) and A5 (`revi-converse`) are shipped.
+transcript as `thread_context`) and A5 (`revi-converse`) are shipped —
+on **GitLab** (notes) and on **GitHub** (review threads, below).
 A4 (`forge.reply` capability) is the remaining deferred step — the reply
 POST is skill-based (`curl`) until then.
+
+## GitHub — replying inside a review thread
+
+GitHub splits PR comments across two wire events, so the lane has two
+entries there:
+
+- **Reply to an inline suggestion** (`pull_request_review_comment`,
+  action created): `handlePRForgeReviewThreadReply`
+  ([pkg/server/webhooks_prforge.go](../pkg/server/webhooks_prforge.go))
+  filters (open PR, event/project allowlists), runs the loop-guard
+  FIRST and without forge I/O (`isIterionForgeBotAuthor` — the bot's
+  own answer echoes back as this very event), requires the converse
+  bot in the webhook scope (`roleBots().ReviConverse` +
+  `cfg.AllowsBot`), then gates: the thread is fetched
+  (`ListPRReviewComments`, capped pagination) and must contain a
+  comment by the bot identity — a human↔human thread never triggers —
+  and the replier must clear `authorized_repliers` or
+  `min_replier_role`. The launch carries `converse_question` (the
+  reply body), `thread_context` (the thread transcript) and
+  `discussion_id` = the **thread root** comment id — exactly what
+  GitHub's `/pulls/{n}/comments/{id}/replies` endpoint wants (the
+  bot's `forge-reply.md` §4). Idempotency: one launch per reply
+  comment (`rc|…` key space).
+- **`/revi <question>` as a plain PR comment** (`issue_comment`): no
+  special-casing — the generic command registry routes it. The
+  manifests declare complementary disambiguators
+  (`review-pr` `when_args_empty`, `revi-converse` `when_args_present`
+  + `args_var: converse_question`), the provision derives the
+  two-route `command_map`, and `ResolveCommandRoute` picks by args
+  presence. Bare `/revi` stays a re-review.
+
+Enablement is provisioning, not code: `pull_request_comment` in a
+bot's manifest `forge.events` now expands on GitHub to BOTH wire
+events ([pkg/forge/event_map.go](../pkg/forge/event_map.go)), so a
+(re-)provision subscribes the hook and regenerates the config's
+`event_allowlist` together; webhooks provisioned before that stay
+inert on review-thread replies until re-provisioned, and the converse
+bot must be in the webhook's `bot_ids`. Forgejo is deliberately not
+wired yet (its dispatch never routes the event).
 
 ## Model — stateless, the thread is the state
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -152,7 +152,20 @@ failures; [pkg/server/webhooks_github.go](../pkg/server/webhooks_github.go)):
   `IsCrossRepo`). A PR opened by iterion's **own forge bot** (another iterion
   bot's PR — see below) is also skipped.
 - **`issue_comment`** → the universal `/command` slash path (e.g.
-  `/featurly <prompt>`, `/billy`), routed through the command registry.
+  `/featurly <prompt>`, `/billy`), routed through the command registry —
+  including the `/revi <question>` ⇄ bare `/revi` split, resolved by the
+  manifests' complementary `when_args_empty`/`when_args_present`
+  disambiguators (question → the converse bot, bare → re-review).
+- **`pull_request_review_comment`** with action `created` → the
+  conversational reply lane: replying inside one of the bot's review
+  threads launches the converse bot, which answers **in the same
+  thread**. Loop-guarded (the bot's own answer echoes back as this
+  event), thread-classified (a human↔human thread never triggers), and
+  replier-gated like every comment lane. Requires the converse bot in
+  `bot_ids` and the event in `event_allowlist` (a re-provision
+  regenerates both — `pull_request_comment` in a manifest now expands
+  to both GitHub wire events). GitHub only for now. See
+  [forge-conversations.md](forge-conversations.md).
 - **`issues`** with action `labeled` → launches the webhook's bot with
   the labeled issue turned into a feature task. The handler derives
   `feature_prompt` (issue title + body), `open_mr=true`, and

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -163,8 +163,11 @@ failures; [pkg/server/webhooks_github.go](../pkg/server/webhooks_github.go)):
   event), thread-classified (a human↔human thread never triggers), and
   replier-gated like every comment lane. Requires the converse bot in
   `bot_ids` and the event in `event_allowlist` (a re-provision
-  regenerates both — `pull_request_comment` in a manifest now expands
-  to both GitHub wire events). GitHub only for now. See
+  regenerates both from the converse bot's own manifest event
+  `pull_request_review_comment` — deliberately separate from
+  `pull_request_comment`, so repos without the conversational bot
+  never subscribe the per-inline-comment delivery firehose). GitHub
+  only for now. See
   [forge-conversations.md](forge-conversations.md).
 - **`issues`** with action `labeled` → launches the webhook's bot with
   the labeled issue turned into a feature task. The handler derives

--- a/pkg/bundle/manifest.go
+++ b/pkg/bundle/manifest.go
@@ -410,15 +410,25 @@ type ConfigShareSpec struct {
 // block. The auto-provisioner (pkg/forge) maps each entry to the
 // per-provider native event when it creates the forge-side hook:
 //
-//	pull_request          -> gitlab "merge_requests_events",
-//	                         github / forgejo "pull_request"
-//	pull_request_comment  -> gitlab "note_events",
-//	                         github / forgejo "issue_comment"
-//	issue_labeled         -> github / forgejo "issues"
-//	                         (gitlab "issues_events" — not yet wired inbound)
+//	pull_request                 -> gitlab "merge_requests_events",
+//	                                github / forgejo "pull_request"
+//	pull_request_comment         -> gitlab "note_events",
+//	                                github / forgejo "issue_comment"
+//	pull_request_review_comment  -> gitlab "note_events",
+//	                                github "pull_request_review_comment"
+//	                                (forgejo — not wired)
+//	issue_labeled                -> github / forgejo "issues"
+//	                                (gitlab "issues_events" — not yet wired inbound)
 const (
 	ForgeEventPullRequest        = "pull_request"
 	ForgeEventPullRequestComment = "pull_request_comment"
+	// ForgeEventPullRequestReviewComment subscribes the comments INSIDE PR
+	// review threads (GitHub fires one delivery per inline comment of every
+	// submitted review — a firehose). Deliberately its own event, not part
+	// of pull_request_comment: only a bot that actually consumes
+	// review-thread replies (the conversational reply-to-a-suggestion lane)
+	// should make every repo pay that delivery volume.
+	ForgeEventPullRequestReviewComment = "pull_request_review_comment"
 	// ForgeEventIssueLabeled subscribes the repo hook to the forge-native
 	// "issues" event; labeling an issue launches an implementer bot that
 	// opens a PR back-linked to the issue (see the GitHub issues handler).
@@ -435,9 +445,10 @@ const DefaultForgeSecretName = "forge_token"
 // manifest may declare in forge.events. decodeManifest rejects anything
 // else so a typo fails fast at parse time (same bar as attachments:).
 var KnownForgeEvents = map[string]bool{
-	ForgeEventPullRequest:        true,
-	ForgeEventPullRequestComment: true,
-	ForgeEventIssueLabeled:       true,
+	ForgeEventPullRequest:              true,
+	ForgeEventPullRequestComment:       true,
+	ForgeEventPullRequestReviewComment: true,
+	ForgeEventIssueLabeled:             true,
 }
 
 // knownForgeEventNames lists the accepted events, sorted for a stable

--- a/pkg/forge/event_map.go
+++ b/pkg/forge/event_map.go
@@ -24,14 +24,23 @@ var normalizedToNative = map[string]map[Provider][]string{
 	// GitHub splits PR comments across TWO wire events: top-level PR
 	// comments arrive as issue_comment, replies inside a review thread as
 	// pull_request_review_comment. GitLab's single "note" covers both. The
-	// normalized name means "comments on the PR", so the GitHub hook must
-	// subscribe both — the review-thread half is what feeds the
-	// reply-to-a-suggestion conversational lane. Forgejo stays on
-	// issue_comment only until that lane is validated there.
+	// review-thread half is deliberately NOT part of this event: one
+	// submitted review fires one pull_request_review_comment delivery per
+	// inline comment, each charged against the webhook rate bucket and the
+	// org monthly quota before any handler filters it — a firehose only the
+	// conversational lane consumes, declared separately below.
 	bundle.ForgeEventPullRequestComment: {
 		ProviderGitLab:  {"note"},
-		ProviderGitHub:  {"issue_comment", "pull_request_review_comment"},
+		ProviderGitHub:  {"issue_comment"},
 		ProviderForgejo: {"issue_comment"},
+	},
+	// The comments INSIDE PR review threads — feeds the
+	// reply-to-a-suggestion conversational lane. GitLab's "note" already
+	// carries thread replies (dedup with pull_request_comment keeps one);
+	// Forgejo is not wired (its dispatch never routes the event).
+	bundle.ForgeEventPullRequestReviewComment: {
+		ProviderGitLab: {"note"},
+		ProviderGitHub: {"pull_request_review_comment"},
 	},
 	// issue_labeled → the forge-native "issues" event. GitLab models it as a
 	// boolean hook field (issues_events); the gitlab admin client translates

--- a/pkg/forge/event_map.go
+++ b/pkg/forge/event_map.go
@@ -15,24 +15,31 @@ import (
 // This same native vocabulary is what the inbound matchers + a
 // webhooks.Config.EventAllowlist expect, so the orchestrator uses it for
 // both the forge-side hook AND the iterion-side allowlist.
-var normalizedToNative = map[string]map[Provider]string{
+var normalizedToNative = map[string]map[Provider][]string{
 	bundle.ForgeEventPullRequest: {
-		ProviderGitLab:  "merge_request",
-		ProviderGitHub:  "pull_request",
-		ProviderForgejo: "pull_request",
+		ProviderGitLab:  {"merge_request"},
+		ProviderGitHub:  {"pull_request"},
+		ProviderForgejo: {"pull_request"},
 	},
+	// GitHub splits PR comments across TWO wire events: top-level PR
+	// comments arrive as issue_comment, replies inside a review thread as
+	// pull_request_review_comment. GitLab's single "note" covers both. The
+	// normalized name means "comments on the PR", so the GitHub hook must
+	// subscribe both — the review-thread half is what feeds the
+	// reply-to-a-suggestion conversational lane. Forgejo stays on
+	// issue_comment only until that lane is validated there.
 	bundle.ForgeEventPullRequestComment: {
-		ProviderGitLab:  "note",
-		ProviderGitHub:  "issue_comment",
-		ProviderForgejo: "issue_comment",
+		ProviderGitLab:  {"note"},
+		ProviderGitHub:  {"issue_comment", "pull_request_review_comment"},
+		ProviderForgejo: {"issue_comment"},
 	},
 	// issue_labeled → the forge-native "issues" event. GitLab models it as a
 	// boolean hook field (issues_events); the gitlab admin client translates
 	// this native "issues" name to that field.
 	bundle.ForgeEventIssueLabeled: {
-		ProviderGitLab:  "issues",
-		ProviderGitHub:  "issues",
-		ProviderForgejo: "issues",
+		ProviderGitLab:  {"issues"},
+		ProviderGitHub:  {"issues"},
+		ProviderForgejo: {"issues"},
 	},
 }
 
@@ -49,12 +56,13 @@ func ToNativeEvents(p Provider, normalized []string) []string {
 		if !ok {
 			continue
 		}
-		native, ok := m[p]
-		if !ok || seen[native] {
-			continue
+		for _, native := range m[p] {
+			if seen[native] {
+				continue
+			}
+			seen[native] = true
+			out = append(out, native)
 		}
-		seen[native] = true
-		out = append(out, native)
 	}
 	sort.Strings(out)
 	return out

--- a/pkg/forge/event_map_test.go
+++ b/pkg/forge/event_map_test.go
@@ -15,7 +15,9 @@ func TestToNativeEvents(t *testing.T) {
 		want     []string
 	}{
 		{ProviderGitLab, all, []string{"merge_request", "note"}},
-		{ProviderGitHub, all, []string{"issue_comment", "pull_request"}},
+		// GitHub's pull_request_comment expands to BOTH wire events: the
+		// review-thread half feeds the reply-to-a-suggestion lane.
+		{ProviderGitHub, all, []string{"issue_comment", "pull_request", "pull_request_review_comment"}},
 		{ProviderForgejo, all, []string{"issue_comment", "pull_request"}},
 		{ProviderGitLab, []string{bundle.ForgeEventPullRequest}, []string{"merge_request"}},
 		// issue_labeled → "issues" native event on every provider (gitlab's

--- a/pkg/forge/event_map_test.go
+++ b/pkg/forge/event_map_test.go
@@ -15,10 +15,18 @@ func TestToNativeEvents(t *testing.T) {
 		want     []string
 	}{
 		{ProviderGitLab, all, []string{"merge_request", "note"}},
-		// GitHub's pull_request_comment expands to BOTH wire events: the
-		// review-thread half feeds the reply-to-a-suggestion lane.
-		{ProviderGitHub, all, []string{"issue_comment", "pull_request", "pull_request_review_comment"}},
+		// pull_request_comment does NOT include the review-thread firehose:
+		// only a bot that declares pull_request_review_comment (the
+		// conversational lane) makes a repo subscribe it.
+		{ProviderGitHub, all, []string{"issue_comment", "pull_request"}},
 		{ProviderForgejo, all, []string{"issue_comment", "pull_request"}},
+		{ProviderGitHub, []string{bundle.ForgeEventPullRequestReviewComment}, []string{"pull_request_review_comment"}},
+		// Forgejo's review-thread lane is not wired: no native subscription.
+		{ProviderForgejo, []string{bundle.ForgeEventPullRequestReviewComment}, nil},
+		// GitLab's single "note" carries both comment shapes — declaring the
+		// pair still subscribes one native event.
+		{ProviderGitLab, []string{bundle.ForgeEventPullRequestComment, bundle.ForgeEventPullRequestReviewComment}, []string{"note"}},
+		{ProviderGitHub, []string{bundle.ForgeEventPullRequestComment, bundle.ForgeEventPullRequestReviewComment}, []string{"issue_comment", "pull_request_review_comment"}},
 		{ProviderGitLab, []string{bundle.ForgeEventPullRequest}, []string{"merge_request"}},
 		// issue_labeled → "issues" native event on every provider (gitlab's
 		// admin client maps it to the issues_events boolean hook field).

--- a/pkg/forge/github/reviews.go
+++ b/pkg/forge/github/reviews.go
@@ -139,19 +139,21 @@ type prReviewCommentWire struct {
 }
 
 // ListPRReviewComments returns the PR's review-thread comments (the inline
-// diff comments and their replies), oldest first as GitHub serves them.
-// Backs the reply-in-thread conversational gate: it needs the whole set to
+// diff comments and their replies), in chronological order. Backs the
+// reply-in-thread conversational gate: it needs the whole set to
 // reconstruct one thread (id == root || in_reply_to_id == root) and decide
-// whether the bot participates in it. Pagination is capped: a conversation
-// gate does not need more than the first pages, and an unbounded walk on a
-// pathological PR would stall the webhook hot path.
+// whether the bot participates in it. Pagination is capped at the NEWEST
+// pages (fetched newest-first, then reversed): the gate classifies the
+// thread just replied to, which lives at the new end — a cap on the oldest
+// pages would blind it exactly on the long-lived PRs that exceed it — and
+// an unbounded walk on a pathological PR would stall the webhook hot path.
 func (c *AdminClient) ListPRReviewComments(ctx context.Context, repo string, number int) ([]forge.PRReviewComment, error) {
 	const perPage = 100
 	const maxPages = 5
 	out := make([]forge.PRReviewComment, 0, perPage)
 	for page := 1; page <= maxPages; page++ {
 		var resp []prReviewCommentWire
-		path := "/repos/" + repo + "/pulls/" + strconv.Itoa(number) + "/comments?per_page=" + strconv.Itoa(perPage) + "&page=" + strconv.Itoa(page)
+		path := "/repos/" + repo + "/pulls/" + strconv.Itoa(number) + "/comments?sort=created&direction=desc&per_page=" + strconv.Itoa(perPage) + "&page=" + strconv.Itoa(page)
 		code, err := c.do(ctx, http.MethodGet, path, nil, &resp)
 		if err != nil {
 			return nil, err
@@ -172,6 +174,9 @@ func (c *AdminClient) ListPRReviewComments(ctx context.Context, repo string, num
 		if len(resp) < perPage {
 			break
 		}
+	}
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
 	}
 	return out, nil
 }

--- a/pkg/forge/github/reviews.go
+++ b/pkg/forge/github/reviews.go
@@ -125,3 +125,53 @@ func (a *AppClient) CreatePullReview(ctx context.Context, repo string, number in
 	}
 	return rest.CreatePullReview(ctx, repo, number, in)
 }
+
+// prReviewCommentWire is the list shape of GET /repos/{repo}/pulls/{n}/comments.
+type prReviewCommentWire struct {
+	ID        int64  `json:"id"`
+	InReplyTo int64  `json:"in_reply_to_id"`
+	Body      string `json:"body"`
+	Path      string `json:"path"`
+	CreatedAt string `json:"created_at"`
+	User      struct {
+		Login string `json:"login"`
+	} `json:"user"`
+}
+
+// ListPRReviewComments returns the PR's review-thread comments (the inline
+// diff comments and their replies), oldest first as GitHub serves them.
+// Backs the reply-in-thread conversational gate: it needs the whole set to
+// reconstruct one thread (id == root || in_reply_to_id == root) and decide
+// whether the bot participates in it. Pagination is capped: a conversation
+// gate does not need more than the first pages, and an unbounded walk on a
+// pathological PR would stall the webhook hot path.
+func (c *AdminClient) ListPRReviewComments(ctx context.Context, repo string, number int) ([]forge.PRReviewComment, error) {
+	const perPage = 100
+	const maxPages = 5
+	out := make([]forge.PRReviewComment, 0, perPage)
+	for page := 1; page <= maxPages; page++ {
+		var resp []prReviewCommentWire
+		path := "/repos/" + repo + "/pulls/" + strconv.Itoa(number) + "/comments?per_page=" + strconv.Itoa(perPage) + "&page=" + strconv.Itoa(page)
+		code, err := c.do(ctx, http.MethodGet, path, nil, &resp)
+		if err != nil {
+			return nil, err
+		}
+		if code != http.StatusOK {
+			return nil, statusErr("GET pull review comments", code)
+		}
+		for _, w := range resp {
+			out = append(out, forge.PRReviewComment{
+				ID:        w.ID,
+				InReplyTo: w.InReplyTo,
+				Body:      w.Body,
+				Path:      w.Path,
+				CreatedAt: w.CreatedAt,
+				Author:    w.User.Login,
+			})
+		}
+		if len(resp) < perPage {
+			break
+		}
+	}
+	return out, nil
+}

--- a/pkg/forge/github/reviews_test.go
+++ b/pkg/forge/github/reviews_test.go
@@ -117,3 +117,37 @@ func TestGitHubCreatePullReview_ErrorSurfaces(t *testing.T) {
 		t.Fatal("a 403 must surface as an error, never fake success")
 	}
 }
+
+// The conversation gate needs the NEWEST comments (the thread just replied
+// to), so the capped walk fetches newest-first and hands back chronological
+// order.
+func TestGitHubListPRReviewComments_NewestFirstCapReversed(t *testing.T) {
+	pages := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/o/r/pulls/7/comments", func(w http.ResponseWriter, r *http.Request) {
+		pages++
+		q := r.URL.Query()
+		if q.Get("sort") != "created" || q.Get("direction") != "desc" {
+			t.Fatalf("must request newest-first: %s", r.URL.RawQuery)
+		}
+		// One short page, newest first.
+		_ = json.NewEncoder(w).Encode([]map[string]any{
+			{"id": 9002, "in_reply_to_id": 9001, "body": "newest", "user": map[string]any{"login": "alice"}},
+			{"id": 9001, "body": "oldest", "user": map[string]any{"login": "revi-bot"}},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := &AdminClient{HTTP: srv.Client(), APIBase: srv.URL, Token: "t"}
+	out, err := c.ListPRReviewComments(context.Background(), "o/r", 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pages != 1 || len(out) != 2 {
+		t.Fatalf("pages=%d len=%d", pages, len(out))
+	}
+	if out[0].ID != 9001 || out[1].ID != 9002 {
+		t.Fatalf("callers must receive chronological order: %+v", out)
+	}
+}

--- a/pkg/forge/issues.go
+++ b/pkg/forge/issues.go
@@ -228,3 +228,16 @@ const (
 	CISkipped   = "skipped"
 	CIUnknown   = "unknown"
 )
+
+// PRReviewComment is one comment in a PR's review threads (an inline diff
+// comment or a reply inside one). InReplyTo == 0 marks a thread root; every
+// reply carries the root's id. Consumed by the inbound-webhook
+// reply-in-thread conversational gate.
+type PRReviewComment struct {
+	ID        int64
+	InReplyTo int64
+	Body      string
+	Path      string
+	CreatedAt string
+	Author    string
+}

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -1069,12 +1069,17 @@ func carryOperatorWebhookSettings(cfg *webhooks.Config, prev webhooks.Config) {
 	cfg.LastUsedAt = prev.LastUsedAt
 
 	// Rate limit: enforced by the inbound middleware, so losing an operator's
-	// raise means deliveries silently 429 and reviews never launch. Its own
-	// sibling in the `// Limits.` block (MonthlyCallLimit) is carried above;
-	// the zero value means "never set", where the provision's default stands.
-	if prev.RateLimit != (webhooks.Rate{}) {
+	// raise means deliveries silently 429 and reviews never launch — but an
+	// UNPINNED value is the provisioner's own former default, and carrying it
+	// would freeze every existing webhook on the burst it was born with,
+	// making a default bump unreachable by re-provision (the review-comment
+	// fan-out needs the raised burst precisely on already-provisioned repos).
+	// Only an API-set value (RateLimitPinned, same rule as ReviewOnSyncPinned)
+	// survives the rebuild.
+	if prev.RateLimitPinned && prev.RateLimit != (webhooks.Rate{}) {
 		cfg.RateLimit = prev.RateLimit
 	}
+	cfg.RateLimitPinned = prev.RateLimitPinned
 
 	// MinReplierRole: a conditional merge, never an overwrite — the provision
 	// stamps a manifest-derived FLOOR (the max requirement over the enabled

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -539,7 +539,12 @@ func (o *Orchestrator) Provision(ctx context.Context, req ProvisionRequest) (Pro
 		ReviewOnSync:       reviewOnSync,
 		ReviewOnSyncPinned: reviewOnSyncPinned,
 		ForgeBaseURL:       conn.BaseURL(),
-		RateLimit:          webhooks.Rate{Rate: 1, Burst: 10},
+		// The burst must absorb a full review fan-out: one submitted review
+		// fires one pull_request_review_comment delivery PER inline comment,
+		// near-simultaneously, and the bucket is charged BEFORE the handler
+		// can filter the echoes — overflow answers 429, which GitHub never
+		// redelivers and counts toward auto-disabling the hook.
+		RateLimit:          webhooks.Rate{Rate: 2, Burst: 60},
 		LaunchVars:         nilIfEmpty(launchVars),
 		OperatorLaunchVars: nilIfEmpty(maps.Clone(operatorVars)),
 		Overlap:            operatorOverlap,

--- a/pkg/forge/orchestrator.go
+++ b/pkg/forge/orchestrator.go
@@ -1043,6 +1043,26 @@ func managedSecretName(conn *Connection) string {
 // the carry would silently override the caller. Two fields are CONDITIONAL
 // exceptions, each commented in place: RateLimit (zero means never set) and
 // MinReplierRole (a provision-derived floor merged stricter-of).
+// provisionRateDefaults are every RateLimit value the provisioner itself has
+// ever stamped on a config (current default last). The carry uses it to tell
+// a provisioner-owned value (migrates to the current default) from an
+// operator's pre-RateLimitPinned PATCH (adopted as pinned): nothing but the
+// provisioner and the PATCH route ever writes the field, so an unpinned
+// value outside this set can only be an operator's explicit choice.
+var provisionRateDefaults = []webhooks.Rate{
+	{Rate: 1, Burst: 10},
+	{Rate: 2, Burst: 60},
+}
+
+func isProvisionRateDefault(r webhooks.Rate) bool {
+	for _, d := range provisionRateDefaults {
+		if r == d {
+			return true
+		}
+	}
+	return false
+}
+
 func carryOperatorWebhookSettings(cfg *webhooks.Config, prev webhooks.Config) {
 	// Enabled is the operator's per-repo kill switch (PATCH {"enabled":false}
 	// → every inbound delivery answers 410) — a re-provision must not
@@ -1070,16 +1090,26 @@ func carryOperatorWebhookSettings(cfg *webhooks.Config, prev webhooks.Config) {
 
 	// Rate limit: enforced by the inbound middleware, so losing an operator's
 	// raise means deliveries silently 429 and reviews never launch — but an
-	// UNPINNED value is the provisioner's own former default, and carrying it
-	// would freeze every existing webhook on the burst it was born with,
-	// making a default bump unreachable by re-provision (the review-comment
-	// fan-out needs the raised burst precisely on already-provisioned repos).
-	// Only an API-set value (RateLimitPinned, same rule as ReviewOnSyncPinned)
-	// survives the rebuild.
-	if prev.RateLimitPinned && prev.RateLimit != (webhooks.Rate{}) {
+	// UNPINNED provisioner default, if carried, would freeze every existing
+	// webhook on the burst it was born with, making a default bump
+	// unreachable by re-provision (the review-comment fan-out needs the
+	// raised burst precisely on already-provisioned repos). So: an API-set
+	// value (RateLimitPinned, same rule as ReviewOnSyncPinned) survives the
+	// rebuild; a stored value the provisioner NEVER stamped can only be an
+	// operator's PATCH from before the pin existed — adopted as pinned
+	// rather than silently replaced (an explicit choice, raise or
+	// deliberate throttle alike); only recognized provisioner defaults
+	// migrate to the current one.
+	switch {
+	case prev.RateLimitPinned && prev.RateLimit != (webhooks.Rate{}):
 		cfg.RateLimit = prev.RateLimit
+		cfg.RateLimitPinned = true
+	case !prev.RateLimitPinned && prev.RateLimit != (webhooks.Rate{}) && !isProvisionRateDefault(prev.RateLimit):
+		cfg.RateLimit = prev.RateLimit
+		cfg.RateLimitPinned = true
+	default:
+		cfg.RateLimitPinned = prev.RateLimitPinned
 	}
-	cfg.RateLimitPinned = prev.RateLimitPinned
 
 	// MinReplierRole: a conditional merge, never an overwrite — the provision
 	// stamps a manifest-derived FLOOR (the max requirement over the enabled

--- a/pkg/forge/orchestrator_botrules_test.go
+++ b/pkg/forge/orchestrator_botrules_test.go
@@ -682,3 +682,49 @@ func TestProvision_ReprovisionMigratesUnpinnedRateLimitDefault(t *testing.T) {
 		t.Error("a migrated default must stay unpinned (still provisioner-owned)")
 	}
 }
+
+// An operator's rate PATCHed BEFORE RateLimitPinned existed decodes as
+// unpinned — but its value is one the provisioner never stamps, so the
+// carry must ADOPT it (as pinned) instead of silently replacing an explicit
+// choice with the new default.
+func TestProvision_ReprovisionAdoptsPrePinOperatorRateLimit(t *testing.T) {
+	o, _, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	res, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"dep-guard"}, ActorID: "u1",
+	})
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	cfg, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A deliberate throttle set through PATCH before the pin flag shipped:
+	// stored unpinned, but not a value the provisioner ever writes.
+	cfg.RateLimit = webhooks.Rate{Rate: 7, Burst: 123}
+	cfg.RateLimitPinned = false
+	if err := o.Webhooks.Update(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"dep-guard", "gate-bot"}, ActorID: "u1",
+	}); err != nil {
+		t.Fatalf("re-provision: %v", err)
+	}
+	after, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.RateLimit != (webhooks.Rate{Rate: 7, Burst: 123}) {
+		t.Errorf("rate_limit = %+v, want the operator's pre-pin tuning preserved", after.RateLimit)
+	}
+	if !after.RateLimitPinned {
+		t.Error("an adopted operator value must come back pinned so the next rebuild needs no heuristic")
+	}
+}

--- a/pkg/forge/orchestrator_botrules_test.go
+++ b/pkg/forge/orchestrator_botrules_test.go
@@ -549,6 +549,7 @@ func TestProvision_ReprovisionKeepsOperatorWebhookSettings(t *testing.T) {
 	cfg.KeyOverrides = map[string]string{"anthropic": "key-1"}
 	cfg.RetryMaxAttempts = 3
 	cfg.RateLimit = webhooks.Rate{Rate: 10, Burst: 200}
+	cfg.RateLimitPinned = true // the PATCH route stamps this on every rate_limit set
 	if err := o.Webhooks.Update(ctx, cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -631,5 +632,53 @@ func TestCarryOperatorWebhookSettings_EnabledKillSwitchSurvives(t *testing.T) {
 	carryOperatorWebhookSettings(&cfg, webhooks.Config{Enabled: true})
 	if !cfg.Enabled {
 		t.Fatal("an enabled webhook must stay enabled through re-provision")
+	}
+}
+
+// The other half of the RateLimit carry: an UNPINNED value is the
+// provisioner's own former default, and a re-provision must move it to the
+// CURRENT default — otherwise a default bump (1/10 → 2/60, sized for the
+// review-comment fan-out) never reaches an already-provisioned repo and the
+// rollout gesture that subscribes the new event leaves the old burst in
+// place.
+func TestProvision_ReprovisionMigratesUnpinnedRateLimitDefault(t *testing.T) {
+	o, _, sealer := newTestOrch(t)
+	seedConn(t, o, sealer)
+	ctx := context.Background()
+
+	res, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"dep-guard"}, ActorID: "u1",
+	})
+	if err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+	cfg, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// What every pre-bump provision left behind: the historical default,
+	// never touched by an operator.
+	cfg.RateLimit = webhooks.Rate{Rate: 1, Burst: 10}
+	cfg.RateLimitPinned = false
+	if err := o.Webhooks.Update(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := o.Provision(ctx, ProvisionRequest{
+		TenantID: "t1", ConnectionID: "conn-1", RepoFullName: "group/api",
+		BotIDs: []string{"dep-guard", "gate-bot"}, ActorID: "u1",
+	}); err != nil {
+		t.Fatalf("re-provision: %v", err)
+	}
+	after, err := o.Webhooks.Get(ctx, res.WebhookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.RateLimit != (webhooks.Rate{Rate: 2, Burst: 60}) {
+		t.Errorf("rate_limit = %+v, want the current provision default — an unpinned historical default must not survive a re-provision", after.RateLimit)
+	}
+	if after.RateLimitPinned {
+		t.Error("a migrated default must stay unpinned (still provisioner-owned)")
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -257,6 +257,11 @@ type Server struct {
 	// PR-surface command comment (the issue_comment payload carries no head
 	// branch — test seam). nil → realWebhookPRForgePRResolver.
 	webhookPRForgePRResolver func(ctx context.Context, cfg webhooks.Config, provider webhooks.Provider, p prforge.ParsedNote, route webhooks.CommandRoute) (forge.PullRef, error)
+	// webhookPRForgeReviewReplyGate overrides the review-thread reply gate
+	// (forge token + thread fetch + bot-in-thread + replier authz — test
+	// seam). Returns (authorized, threadContext, reason, err). nil →
+	// realWebhookPRForgeReviewReplyGate.
+	webhookPRForgeReviewReplyGate func(ctx context.Context, cfg webhooks.Config, provider webhooks.Provider, p prforge.ParsedReviewComment, botID string) (bool, string, string, error)
 	// webhookIterionBotAuthor overrides the "is this PR/MR authored by iterion's
 	// own forge bot" check that keeps the PR-open auto-review lane from launching
 	// Revi on another iterion bot's PR (test seam — the real impl resolves the

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -319,10 +319,15 @@ func (s *Server) realIterionBotAuthor(ctx context.Context, cfg webhooks.Config, 
 // iterionBotAuthorPredicate gives the same verdict as isIterionForgeBotAuthor
 // as a cheap per-login comparator, for call sites that classify MANY logins in
 // one delivery (a review-thread walk): the connection store is read once, not
-// once per login. Honours the webhookIterionBotAuthor test seam.
-func (s *Server) iterionBotAuthorPredicate(ctx context.Context, cfg webhooks.Config) func(string) bool {
+// once per login. The second return reports whether ANY identity resolved —
+// on a GitHub PAT/OAuth connection with no configured logins the set is
+// legitimately empty (iterionBotLogins gates the account fallback to GitLab),
+// and a caller whose safety rests on the classification must fail closed
+// rather than read "always false" as "no bot here". Honours the
+// webhookIterionBotAuthor test seam.
+func (s *Server) iterionBotAuthorPredicate(ctx context.Context, cfg webhooks.Config) (func(string) bool, bool) {
 	if s.webhookIterionBotAuthor != nil {
-		return func(login string) bool { return s.webhookIterionBotAuthor(ctx, cfg, login) }
+		return func(login string) bool { return s.webhookIterionBotAuthor(ctx, cfg, login) }, true
 	}
 	logins := iterionBotLogins(cfg, forge.Connection{})
 	if conn, ok := s.webhookForgeConnection(ctx, cfg); ok {
@@ -341,7 +346,7 @@ func (s *Server) iterionBotAuthorPredicate(ctx context.Context, cfg webhooks.Con
 			}
 		}
 		return false
-	}
+	}, len(logins) > 0
 }
 
 // iterionBotLogins is THE definition of "iterion's own identity on this

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -316,6 +316,34 @@ func (s *Server) realIterionBotAuthor(ctx context.Context, cfg webhooks.Config, 
 	return false
 }
 
+// iterionBotAuthorPredicate gives the same verdict as isIterionForgeBotAuthor
+// as a cheap per-login comparator, for call sites that classify MANY logins in
+// one delivery (a review-thread walk): the connection store is read once, not
+// once per login. Honours the webhookIterionBotAuthor test seam.
+func (s *Server) iterionBotAuthorPredicate(ctx context.Context, cfg webhooks.Config) func(string) bool {
+	if s.webhookIterionBotAuthor != nil {
+		return func(login string) bool { return s.webhookIterionBotAuthor(ctx, cfg, login) }
+	}
+	logins := iterionBotLogins(cfg, forge.Connection{})
+	if conn, ok := s.webhookForgeConnection(ctx, cfg); ok {
+		// The full set: iterionBotLogins starts from the configured
+		// identities, so this supersedes the zero-connection list.
+		logins = iterionBotLogins(cfg, conn)
+	}
+	return func(login string) bool {
+		login = strings.TrimSpace(login)
+		if login == "" {
+			return false
+		}
+		for _, l := range logins {
+			if strings.EqualFold(login, l) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
 // iterionBotLogins is THE definition of "iterion's own identity on this
 // webhook's forge" — the single set both consumers read: the bot-author
 // skip (is this event's actor the bot?) and the re-request-review trigger

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -50,6 +50,12 @@ func (s *Server) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
 		// comment. Routes through the command registry to its bot.
 		s.handlePRForgeComment(ctx, w, r, cfg, webhooks.ProviderGitHub, body, payloadHash, srcIP)
 		return
+	case prforge.EventHeaderReviewComment:
+		// Conversational path: a reply inside one of the bot's review threads
+		// IS a question — routes to the converse bot, which answers in the
+		// same thread. GitHub-only (Forgejo's dispatch does not route here).
+		s.handlePRForgeReviewThreadReply(ctx, w, r, cfg, webhooks.ProviderGitHub, body, payloadHash, srcIP)
+		return
 	case prforge.EventHeaderIssues:
 		// Issue lifecycle path: labeling an issue (e.g. "implement") — or, with
 		// AutoImplementOnOpen, opening one — launches an implementer bot

--- a/pkg/server/webhooks_prforge.go
+++ b/pkg/server/webhooks_prforge.go
@@ -388,8 +388,17 @@ func (s *Server) handlePRForgeReviewThreadReply(ctx context.Context, w http.Resp
 		filtered("out of scope (not a new open-PR review comment / event / project)")
 		return
 	}
-	// Loop-guard FIRST and without forge I/O: the converse bot answers with
-	// the same PAT identity, so its own reply echoes back as this event.
+	// A thread-opening comment roots its own thread: nobody — the bot
+	// included — is in that thread yet, so it can never be a reply to the
+	// bot. Decidable from the payload alone, before any I/O; every inline
+	// comment of a bot review echoes back as one of these.
+	if p.ThreadRootID == p.CommentID {
+		filtered("thread-opening comment (not a reply)")
+		return
+	}
+	// Loop-guard next, still without forge I/O: the converse bot answers
+	// with the same PAT identity, so its own reply echoes back as this
+	// event.
 	if s.isIterionForgeBotAuthor(ctx, cfg, p.AuthorLogin) {
 		filtered("self reply (loop-guard)")
 		return
@@ -463,11 +472,7 @@ func buildPRForgeReviewReplyVars(p prforge.ParsedReviewComment, threadContext st
 }
 
 // realWebhookPRForgeReviewReplyGate is the production reply gate: resolve
-// the bot's forge token, fetch the PR's review comments, keep only the
-// reply's thread, and authorize BOTH halves — the thread must be one of
-// iterion's own (a comment by the bot identity in it; a human↔human thread
-// never triggers), and the replier must clear the allowlist or the webhook's
-// MinReplierRole. Returns the thread transcript for the bot's grounding.
+// the bot's forge token and hand the thread work to reviewReplyGateWithAPI.
 // ok=false + reason for benign refusals; err only for infra failure.
 func (s *Server) realWebhookPRForgeReviewReplyGate(ctx context.Context, cfg webhooks.Config, provider webhooks.Provider, p prforge.ParsedReviewComment, botID string) (bool, string, string, error) {
 	token, terr := s.resolveForgeToken(ctx, cfg, botID)
@@ -483,33 +488,59 @@ func (s *Server) realWebhookPRForgeReviewReplyGate(ctx context.Context, cfg webh
 	if !ok {
 		return false, "", "review-thread conversations are not supported on this provider yet", nil
 	}
+	return s.reviewReplyGateWithAPI(ctx, cfg, p, api)
+}
+
+// reviewReplyGateWithAPI is the token-free core of the reply gate — split
+// from the wrapper so tests drive it with a fake thread API. It fetches the
+// PR's review comments, keeps only the reply's thread, and authorizes BOTH
+// halves: the thread must be one of iterion's own (a comment by the bot
+// identity in it; a human↔human thread never triggers), and the replier must
+// clear the allowlist or the webhook's MinReplierRole. Returns the thread
+// transcript for the bot's grounding.
+func (s *Server) reviewReplyGateWithAPI(ctx context.Context, cfg webhooks.Config, p prforge.ParsedReviewComment, api prforgeReviewThreadAPI) (bool, string, string, error) {
 	comments, err := api.ListPRReviewComments(ctx, p.ProjectPath, int(p.PRNumber))
 	if err != nil {
 		return false, "", "", err
 	}
-	var transcript strings.Builder
-	botInThread := false
-	for _, c := range comments {
-		if c.ID != p.ThreadRootID && c.InReplyTo != p.ThreadRootID {
-			continue
-		}
-		if c.ID != p.CommentID && s.isIterionForgeBotAuthor(ctx, cfg, c.Author) {
-			botInThread = true
-		}
-		fmt.Fprintf(&transcript, "%s (%s):\n%s\n---\n", c.Author, c.CreatedAt, strings.TrimSpace(c.Body))
-	}
+	botInThread, transcript := classifyReviewThread(comments, p, s.iterionBotAuthorPredicate(ctx, cfg))
 	if !botInThread {
 		return false, "", "not a bot review thread (no iterion comment in it)", nil
 	}
 	if prforgeInAllowlist(cfg.AuthorizedRepliers, p.AuthorLogin) {
-		return true, transcript.String(), "allowlist", nil
+		return true, transcript, "allowlist", nil
 	}
 	perm, err := api.CollaboratorPermission(ctx, p.ProjectPath, p.AuthorLogin)
 	if err != nil {
 		return false, "", "", err
 	}
 	if prforgePermRank(perm) >= replierMinRoleRank(cfg.MinReplierRole) {
-		return true, transcript.String(), "role", nil
+		return true, transcript, "role", nil
 	}
 	return false, "", "replier not authorized: " + p.AuthorLogin, nil
+}
+
+// classifyReviewThread keeps only the reply's thread out of the PR's review
+// comments and decides the gate's thread half: whether the bot identity
+// participates in it — the trigger comment itself never counts, so a thread
+// where only the human's reply exists stays untriggerable — plus the
+// transcript, bot entries labelled and the whole capped by the same
+// anchor+newest budget as the GitLab twin (maxThreadContextChars).
+func classifyReviewThread(comments []forge.PRReviewComment, p prforge.ParsedReviewComment, isBot func(string) bool) (bool, string) {
+	botInThread := false
+	rendered := make([]string, 0, len(comments))
+	for _, c := range comments {
+		if c.ID != p.ThreadRootID && c.InReplyTo != p.ThreadRootID {
+			continue
+		}
+		who := c.Author
+		if isBot(c.Author) {
+			if c.ID != p.CommentID {
+				botInThread = true
+			}
+			who += " (you, the bot)"
+		}
+		rendered = append(rendered, fmt.Sprintf("%s (%s):\n%s", who, c.CreatedAt, strings.TrimSpace(c.Body)))
+	}
+	return botInThread, webhooks.CapTranscript(rendered, maxThreadContextChars)
 }

--- a/pkg/server/webhooks_prforge.go
+++ b/pkg/server/webhooks_prforge.go
@@ -379,9 +379,11 @@ func (s *Server) handlePRForgeReviewThreadReply(ctx context.Context, w http.Resp
 	}
 	// The allowlist must name the event (or be empty = zero-config): configs
 	// provisioned before this lane carry ["issue_comment","pull_request"]
-	// and stay inert until re-provisioned — forge.ToNativeEvents now expands
-	// pull_request_comment to both GitHub wire events, so a re-provision
-	// regenerates hook AND allowlist together.
+	// and stay inert until re-provisioned WITH the converse bot —
+	// pull_request_review_comment is its own normalized manifest event,
+	// declared by the converse bot alone (not folded into
+	// pull_request_comment), so only its presence in bot_ids makes the
+	// re-provision subscribe the hook and regenerate the allowlist.
 	if p.Action != "created" || p.PRState != "open" ||
 		!webhooks.MatchEvent(cfg.EventAllowlist, "pull_request_review_comment", "pull_request_review_comment") ||
 		!webhooks.MatchProject(cfg.ProjectAllowlist, p.ProjectPath) {
@@ -524,6 +526,15 @@ func (s *Server) reviewReplyGateWithAPI(ctx context.Context, cfg webhooks.Config
 		// Fail closed with an honest reason — "not a bot review thread"
 		// would misdiagnose a dead identity resolution as a human thread.
 		return false, "", "bot identity unresolved; cannot classify reply", nil
+	}
+	// The completing half of the handler's loop-guard: that one reads the
+	// connection-derived set only, which on a PAT/OAuth connection is empty
+	// — yet the token identity resolved above is exactly who the bot's own
+	// in-thread answer posts as. Without this check that answer walks the
+	// whole gate, authorizes itself (the posting account has write), and
+	// the conversation answers itself forever.
+	if isBot(p.AuthorLogin) {
+		return false, "", "self reply (loop-guard, token identity)", nil
 	}
 	comments, err := api.ListPRReviewComments(ctx, p.ProjectPath, int(p.PRNumber))
 	if err != nil {

--- a/pkg/server/webhooks_prforge.go
+++ b/pkg/server/webhooks_prforge.go
@@ -508,11 +508,28 @@ func (s *Server) realWebhookPRForgeReviewReplyGate(ctx context.Context, cfg webh
 // clear the allowlist or the webhook's MinReplierRole. Returns the thread
 // transcript for the bot's grounding.
 func (s *Server) reviewReplyGateWithAPI(ctx context.Context, cfg webhooks.Config, p prforge.ParsedReviewComment, api prforgeReviewThreadAPI) (bool, string, string, error) {
+	isBot, haveIdentity := s.iterionBotAuthorPredicate(ctx, cfg)
+	// The connection-derived set can be legitimately empty (a GitHub
+	// PAT/OAuth connection names no [bot] identity). The identity that
+	// actually POSTS our reviews is the token's own — resolve it like the
+	// GitLab twin (CurrentUser) and union it in, so the lane lives on those
+	// connections. WhoAmI failing on an App installation token is fine: the
+	// [bot] slug already covers that shape.
+	if id, werr := api.WhoAmI(ctx); werr == nil && strings.TrimSpace(id.Login) != "" {
+		tokenLogin, base := id.Login, isBot
+		isBot = func(login string) bool { return base(login) || strings.EqualFold(login, tokenLogin) }
+		haveIdentity = true
+	}
+	if !haveIdentity {
+		// Fail closed with an honest reason — "not a bot review thread"
+		// would misdiagnose a dead identity resolution as a human thread.
+		return false, "", "bot identity unresolved; cannot classify reply", nil
+	}
 	comments, err := api.ListPRReviewComments(ctx, p.ProjectPath, int(p.PRNumber))
 	if err != nil {
 		return false, "", "", err
 	}
-	botInThread, transcript := classifyReviewThread(comments, p, s.iterionBotAuthorPredicate(ctx, cfg))
+	botInThread, transcript := classifyReviewThread(comments, p, isBot)
 	if !botInThread {
 		return false, "", "not a bot review thread (no iterion comment in it)", nil
 	}

--- a/pkg/server/webhooks_prforge.go
+++ b/pkg/server/webhooks_prforge.go
@@ -396,6 +396,15 @@ func (s *Server) handlePRForgeReviewThreadReply(ctx context.Context, w http.Resp
 		filtered("thread-opening comment (not a reply)")
 		return
 	}
+	// Fork guard, payload-only: on a fork PR the launch pair (base repo's
+	// CloneURL + head-repo SourceBranch) does not name one repository — the
+	// checkout would miss, or silently hit a same-named BASE branch and the
+	// bot would answer grounded in the wrong code. Same posture as the PR
+	// auto lane: filtered.
+	if p.IsCrossRepo() {
+		filtered("fork PR — review-thread replies are same-repo only")
+		return
+	}
 	// Loop-guard next, still without forge I/O: the converse bot answers
 	// with the same PAT identity, so its own reply echoes back as this
 	// event.

--- a/pkg/server/webhooks_prforge.go
+++ b/pkg/server/webhooks_prforge.go
@@ -342,3 +342,174 @@ func prforgePermRank(perm string) int {
 func replierMinRoleRank(role string) int {
 	return webhooks.ReplierRoleRank(role)
 }
+
+// ---------------------------------------------------------------------------
+// Review-thread conversations (GitHub) — reply to a Revi suggestion, get an
+// in-thread answer. The GitHub twin of the GitLab note reply-in-thread lane
+// (docs/forge-conversations.md); Forgejo is NOT wired yet (its dispatch never
+// routes the event here).
+// ---------------------------------------------------------------------------
+
+// prforgeReviewThreadAPI extends the replier surface with the thread fetch
+// the reply gate needs. github.AdminClient satisfies it; the Forgejo client
+// deliberately does not (the lane is GitHub-only until Forgejo's
+// review-comment API is validated).
+type prforgeReviewThreadAPI interface {
+	prforgeReplierAPI
+	ListPRReviewComments(ctx context.Context, repo string, number int) ([]forge.PRReviewComment, error)
+}
+
+// handlePRForgeReviewThreadReply routes a pull_request_review_comment event
+// (a reply inside a PR review thread) to the converse bot when the thread is
+// one of iterion's own: replying to a Revi suggestion IS the question, no
+// slash-command needed. Mirrors the GitLab note lane's reply-in-thread half.
+// Every benign refusal is a 200/filtered so the forge never auto-disables
+// the hook.
+func (s *Server) handlePRForgeReviewThreadReply(ctx context.Context, w http.ResponseWriter, r *http.Request, cfg webhooks.Config, provider webhooks.Provider, body []byte, payloadHash, srcIP string) {
+	p, err := prforge.ParseReviewComment(body)
+	if err != nil {
+		s.recordTerminalWebhookDelivery(ctx, cfg, webhookEventMeta{Kind: "review_comment"}, webhooks.StatusFiltered, payloadHash, srcIP, "invalid pull_request_review_comment payload")
+		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+		return
+	}
+	meta := prforgeReviewCommentMeta(p)
+	filtered := func(reason string) {
+		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, reason)
+		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+	}
+	// The allowlist must name the event (or be empty = zero-config): configs
+	// provisioned before this lane carry ["issue_comment","pull_request"]
+	// and stay inert until re-provisioned — forge.ToNativeEvents now expands
+	// pull_request_comment to both GitHub wire events, so a re-provision
+	// regenerates hook AND allowlist together.
+	if p.Action != "created" || p.PRState != "open" ||
+		!webhooks.MatchEvent(cfg.EventAllowlist, "pull_request_review_comment", "pull_request_review_comment") ||
+		!webhooks.MatchProject(cfg.ProjectAllowlist, p.ProjectPath) {
+		filtered("out of scope (not a new open-PR review comment / event / project)")
+		return
+	}
+	// Loop-guard FIRST and without forge I/O: the converse bot answers with
+	// the same PAT identity, so its own reply echoes back as this event.
+	if s.isIterionForgeBotAuthor(ctx, cfg, p.AuthorLogin) {
+		filtered("self reply (loop-guard)")
+		return
+	}
+	// ONE role snapshot: the enable-gate and the launch below must name the
+	// same converse bot.
+	converseBot := s.roleBots().ReviConverse
+	if !s.canRouteToConverseBot(cfg, converseBot) {
+		filtered("converse bot not enabled on this webhook")
+		return
+	}
+	gate := s.webhookPRForgeReviewReplyGate
+	if gate == nil {
+		gate = s.realWebhookPRForgeReviewReplyGate
+	}
+	authorized, threadContext, reason, aerr := gate(ctx, cfg, provider, p, converseBot)
+	if aerr != nil {
+		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusLaunchError, payloadHash, srcIP, "authz check: "+aerr.Error())
+		httpError(w, http.StatusBadGateway, "authorization check failed")
+		return
+	}
+	if !authorized {
+		filtered(reason)
+		return
+	}
+	if s.logger != nil {
+		s.logger.Debug("webhooks: %s review-thread reply %s#%d by %s authorized (%s)", provider, p.ProjectPath, p.PRNumber, p.AuthorLogin, reason)
+	}
+	vars := applyWebhookVarLayers(buildPRForgeReviewReplyVars(p, threadContext, nil), cfg)
+	// Idempotency: one launch per reply comment; "rc|" keeps the key space
+	// disjoint from the pr|/cmd| paths.
+	idemKey := knowledge.ChecksumHex([]byte(fmt.Sprintf("rc|%s|%s|%d|%s", cfg.TenantID, cfg.ID, p.RepoID, p.SubjectID())))
+	s.insertAndLaunchWebhook(ctx, w, r, cfg, meta, idemKey, converseBot, vars, p.CloneURL, p.SourceBranch, payloadHash, srcIP)
+}
+
+// prforgeReviewCommentMeta builds the delivery-audit meta for a review-thread
+// reply.
+func prforgeReviewCommentMeta(p prforge.ParsedReviewComment) webhookEventMeta {
+	return webhookEventMeta{
+		Kind:         "review_comment",
+		Action:       "comment",
+		ProjectPath:  p.ProjectPath,
+		SubjectID:    p.SubjectID(),
+		SubjectURL:   p.PRURL,
+		SubjectSHA:   p.HeadSHA,
+		SenderHandle: p.AuthorLogin,
+	}
+}
+
+// buildPRForgeReviewReplyVars composes the converse launch vars for a
+// review-thread reply: the PR context (reviewPRVars) + the conversation vars
+// the converse bot declares. discussion_id is the THREAD ROOT comment id —
+// exactly what GitHub's /pulls/{n}/comments/{id}/replies endpoint wants (see
+// bots/revi-converse/skills/forge-reply.md §4). No re_review flag: a reply
+// is a question, never a fresh review.
+func buildPRForgeReviewReplyVars(p prforge.ParsedReviewComment, threadContext string, launchVars map[string]string) map[string]string {
+	question := strings.TrimSpace(p.CommentBody)
+	vars := reviewPRVars(p.PRURL, p.TargetBranch, strings.TrimSpace(p.PRTitle+"\n\n"+p.PRBody), launchVars, map[string]string{
+		"source_branch":     p.SourceBranch,
+		"head_sha":          p.HeadSHA,
+		"conversation_mode": "reply",
+		"discussion_id":     fmt.Sprintf("%d", p.ThreadRootID),
+		"trigger_note":      p.CommentBody,
+		"replier":           p.AuthorLogin,
+		"converse_question": question,
+	})
+	if threadContext != "" {
+		vars["thread_context"] = threadContext
+	}
+	return vars
+}
+
+// realWebhookPRForgeReviewReplyGate is the production reply gate: resolve
+// the bot's forge token, fetch the PR's review comments, keep only the
+// reply's thread, and authorize BOTH halves — the thread must be one of
+// iterion's own (a comment by the bot identity in it; a human↔human thread
+// never triggers), and the replier must clear the allowlist or the webhook's
+// MinReplierRole. Returns the thread transcript for the bot's grounding.
+// ok=false + reason for benign refusals; err only for infra failure.
+func (s *Server) realWebhookPRForgeReviewReplyGate(ctx context.Context, cfg webhooks.Config, provider webhooks.Provider, p prforge.ParsedReviewComment, botID string) (bool, string, string, error) {
+	token, terr := s.resolveForgeToken(ctx, cfg, botID)
+	if terr != nil || token == "" {
+		return false, "", "no forge token resolved (configure a forge_token binding)", nil
+	}
+	baseURL := strings.TrimSpace(cfg.ForgeBaseURL)
+	if baseURL == "" {
+		return false, "", "no forge base url on this webhook", nil
+	}
+	client := prforgeReplierClient(provider, s.forgeHTTPClient(), baseURL, token)
+	api, ok := client.(prforgeReviewThreadAPI)
+	if !ok {
+		return false, "", "review-thread conversations are not supported on this provider yet", nil
+	}
+	comments, err := api.ListPRReviewComments(ctx, p.ProjectPath, int(p.PRNumber))
+	if err != nil {
+		return false, "", "", err
+	}
+	var transcript strings.Builder
+	botInThread := false
+	for _, c := range comments {
+		if c.ID != p.ThreadRootID && c.InReplyTo != p.ThreadRootID {
+			continue
+		}
+		if c.ID != p.CommentID && s.isIterionForgeBotAuthor(ctx, cfg, c.Author) {
+			botInThread = true
+		}
+		fmt.Fprintf(&transcript, "%s (%s):\n%s\n---\n", c.Author, c.CreatedAt, strings.TrimSpace(c.Body))
+	}
+	if !botInThread {
+		return false, "", "not a bot review thread (no iterion comment in it)", nil
+	}
+	if prforgeInAllowlist(cfg.AuthorizedRepliers, p.AuthorLogin) {
+		return true, transcript.String(), "allowlist", nil
+	}
+	perm, err := api.CollaboratorPermission(ctx, p.ProjectPath, p.AuthorLogin)
+	if err != nil {
+		return false, "", "", err
+	}
+	if prforgePermRank(perm) >= replierMinRoleRank(cfg.MinReplierRole) {
+		return true, transcript.String(), "role", nil
+	}
+	return false, "", "replier not authorized: " + p.AuthorLogin, nil
+}

--- a/pkg/server/webhooks_reviewthread_test.go
+++ b/pkg/server/webhooks_reviewthread_test.go
@@ -418,3 +418,39 @@ func TestClassifyReviewThread(t *testing.T) {
 		}
 	})
 }
+
+// A fork PR pairs the BASE repo's clone URL with a HEAD-repo ref — the
+// launch would check out missing or wrong code — so the reply lane filters
+// cross-repo PRs from the payload alone, before the gate.
+func TestGitHubWebhook_ReviewThreadForkPRFiltered(t *testing.T) {
+	s := newWebhookTestServer(t)
+	s.cfg.Bots.Paths = []string{botsDirAbs(t)}
+	launches, gates := 0, 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		launches++
+		return "run-x", nil
+	}
+	s.webhookPRForgeReviewReplyGate = func(context.Context, webhooks.Config, webhooks.Provider, prforge.ParsedReviewComment, string) (bool, string, string, error) {
+		gates++
+		return true, "", "allowlist", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"review-pr", "revi-converse"}
+	cfg.EventAllowlist = []string{"issue_comment", "pull_request", "pull_request_review_comment"}
+
+	body := `{
+  "action": "created",
+  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+  "comment": {"id": 9002, "in_reply_to_id": 9001, "body": "why?", "user": {"login": "alice"}},
+  "pull_request": {"number": 7, "state": "open", "title": "Add X", "body": "desc",
+    "html_url": "https://github.com/acme/widgets/pull/7",
+    "head": {"sha": "abc123", "ref": "main", "repo": {"full_name": "mallory/widgets"}},
+    "base": {"ref": "main"}},
+  "sender": {"login": "alice"}
+}`
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), body, prforge.EventHeaderReviewComment, pt))
+	if w.Code != http.StatusOK || launches != 0 || gates != 0 {
+		t.Fatalf("fork reply must filter payload-only: code=%d launches=%d gates=%d", w.Code, launches, gates)
+	}
+}

--- a/pkg/server/webhooks_reviewthread_test.go
+++ b/pkg/server/webhooks_reviewthread_test.go
@@ -494,4 +494,18 @@ func TestReviewReplyGateWithAPI_TokenIdentity(t *testing.T) {
 			t.Fatalf("an unclassifiable delivery must not pay the comment walk: %d calls", api.listCalls)
 		}
 	})
+
+	t.Run("the token identity also loop-guards: the bot's own answer never converses with itself", func(t *testing.T) {
+		s := newWebhookTestServer(t) // PAT shape: connection-derived set empty, handler guard blind
+		api := &fakeThreadAPI{comments: botThread, who: forge.Identity{Login: "revi-bot"}}
+		selfReply := p
+		selfReply.AuthorLogin = "revi-bot"
+		ok, _, reason, err := s.reviewReplyGateWithAPI(context.Background(), webhooks.Config{AuthorizedRepliers: []string{"alice"}}, selfReply, api)
+		if err != nil || ok || reason != "self reply (loop-guard, token identity)" {
+			t.Fatalf("ok=%v reason=%q err=%v", ok, reason, err)
+		}
+		if api.listCalls != 0 {
+			t.Fatalf("a self reply must be refused before the comment walk: %d calls", api.listCalls)
+		}
+	})
 }

--- a/pkg/server/webhooks_reviewthread_test.go
+++ b/pkg/server/webhooks_reviewthread_test.go
@@ -287,13 +287,16 @@ func TestGitHubWebhook_ReviewThreadTopLevelCommentFiltered(t *testing.T) {
 type fakeThreadAPI struct {
 	comments  []forge.PRReviewComment
 	listErr   error
+	listCalls int
 	perm      string
 	permErr   error
 	permCalls int
+	who       forge.Identity
+	whoErr    error
 }
 
 func (f *fakeThreadAPI) WhoAmI(context.Context) (forge.Identity, error) {
-	return forge.Identity{}, nil
+	return f.who, f.whoErr
 }
 func (f *fakeThreadAPI) CollaboratorPermission(context.Context, string, string) (string, error) {
 	f.permCalls++
@@ -303,6 +306,7 @@ func (f *fakeThreadAPI) GetPullRequest(context.Context, string, int) (forge.Pull
 	return forge.PullRef{}, nil
 }
 func (f *fakeThreadAPI) ListPRReviewComments(context.Context, string, int) ([]forge.PRReviewComment, error) {
+	f.listCalls++
 	return f.comments, f.listErr
 }
 
@@ -453,4 +457,41 @@ func TestGitHubWebhook_ReviewThreadForkPRFiltered(t *testing.T) {
 	if w.Code != http.StatusOK || launches != 0 || gates != 0 {
 		t.Fatalf("fork reply must filter payload-only: code=%d launches=%d gates=%d", w.Code, launches, gates)
 	}
+}
+
+// A GitHub PAT/OAuth connection derives NO [bot] identity from the
+// connection (iterionBotLogins gates the account fallback to GitLab) — the
+// identity that posts our reviews is the token's own. The gate must resolve
+// it via WhoAmI so the lane lives on those connections, and must fail
+// CLOSED with an honest reason when nothing at all resolves.
+func TestReviewReplyGateWithAPI_TokenIdentity(t *testing.T) {
+	p := prforge.ParsedReviewComment{ProjectPath: "acme/widgets", PRNumber: 7, CommentID: 9002, ThreadRootID: 9001, AuthorLogin: "alice"}
+	botThread := []forge.PRReviewComment{
+		{ID: 9001, Author: "revi-bot", Body: "the SSRF is reachable", CreatedAt: "2026-09-02T10:00:00Z"},
+		{ID: 9002, InReplyTo: 9001, Author: "alice", Body: "why?", CreatedAt: "2026-09-02T10:05:00Z"},
+	}
+
+	t.Run("WhoAmI serves a PAT connection with no configured identity", func(t *testing.T) {
+		s := newWebhookTestServer(t) // no webhookIterionBotAuthor seam: the real predicate resolves empty
+		api := &fakeThreadAPI{comments: botThread, who: forge.Identity{Login: "revi-bot"}}
+		ok, transcript, reason, err := s.reviewReplyGateWithAPI(context.Background(), webhooks.Config{AuthorizedRepliers: []string{"alice"}}, p, api)
+		if err != nil || !ok || reason != "allowlist" {
+			t.Fatalf("ok=%v reason=%q err=%v", ok, reason, err)
+		}
+		if !strings.Contains(transcript, "revi-bot (you, the bot)") {
+			t.Fatalf("the token identity must classify (and label) the thread: %q", transcript)
+		}
+	})
+
+	t.Run("nothing resolved fails closed before any thread fetch", func(t *testing.T) {
+		s := newWebhookTestServer(t)
+		api := &fakeThreadAPI{comments: botThread, whoErr: fmt.Errorf("403 installation token")}
+		ok, _, reason, err := s.reviewReplyGateWithAPI(context.Background(), webhooks.Config{AuthorizedRepliers: []string{"alice"}}, p, api)
+		if err != nil || ok || reason != "bot identity unresolved; cannot classify reply" {
+			t.Fatalf("ok=%v reason=%q err=%v", ok, reason, err)
+		}
+		if api.listCalls != 0 {
+			t.Fatalf("an unclassifiable delivery must not pay the comment walk: %d calls", api.listCalls)
+		}
+	})
 }

--- a/pkg/server/webhooks_reviewthread_test.go
+++ b/pkg/server/webhooks_reviewthread_test.go
@@ -1,0 +1,246 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
+)
+
+// ghReviewCommentReply builds a pull_request_review_comment payload: `author`
+// replies inside the thread rooted at comment 9001 on open PR #7.
+func ghReviewCommentReply(author, body string) string {
+	return fmt.Sprintf(`{
+  "action": "created",
+  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+  "comment": {"id": 9002, "in_reply_to_id": 9001, "body": %q,
+    "html_url": "https://github.com/acme/widgets/pull/7#discussion_r9002",
+    "path": "pkg/x/y.go", "user": {"login": %q}},
+  "pull_request": {"number": 7, "state": "open", "title": "Add X", "body": "desc",
+    "html_url": "https://github.com/acme/widgets/pull/7",
+    "head": {"sha": "abc123", "ref": "feature/x"}, "base": {"ref": "main"}},
+  "sender": {"login": %q}
+}`, body, author, author)
+}
+
+// The happy path: an authorized human replies in one of the bot's review
+// threads → the converse bot launches with the reply as the question, the
+// thread transcript, and the thread ROOT id as discussion_id (what GitHub's
+// reply endpoint wants).
+func TestGitHubWebhook_ReviewThreadReplyLaunchesConverse(t *testing.T) {
+	s := newWebhookTestServer(t)
+	s.cfg.Bots.Paths = []string{botsDirAbs(t)}
+	var gotBot string
+	var gotVars map[string]string
+	calls := 0
+	s.webhookLaunchBot = func(_ context.Context, botID string, vars map[string]string, _, _, _ string, _, _ map[string]string) (string, error) {
+		calls++
+		gotBot, gotVars = botID, vars
+		return "run-rt-1", nil
+	}
+	s.webhookPRForgeReviewReplyGate = func(context.Context, webhooks.Config, webhooks.Provider, prforge.ParsedReviewComment, string) (bool, string, string, error) {
+		return true, "revi (2026-09-02):\nthe SSRF is reachable\n---\n", "allowlist", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"review-pr", "revi-converse"}
+	cfg.EventAllowlist = []string{"issue_comment", "pull_request", "pull_request_review_comment"} // post-fix provisioned shape
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewCommentReply("alice", "why is this SSRF reachable?"), prforge.EventHeaderReviewComment, pt))
+	if w.Code != http.StatusAccepted || calls != 1 {
+		t.Fatalf("reply: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+	if gotBot != "revi-converse" {
+		t.Fatalf("expected revi-converse, got %q", gotBot)
+	}
+	if gotVars["converse_question"] != "why is this SSRF reachable?" {
+		t.Fatalf("converse_question: %v", gotVars["converse_question"])
+	}
+	if gotVars["discussion_id"] != "9001" {
+		t.Fatalf("discussion_id must be the THREAD ROOT id: %v", gotVars["discussion_id"])
+	}
+	if !strings.Contains(gotVars["thread_context"], "the SSRF is reachable") {
+		t.Fatalf("thread_context not threaded: %v", gotVars["thread_context"])
+	}
+	if gotVars["pr_url"] != "https://github.com/acme/widgets/pull/7" || gotVars["head_sha"] != "abc123" || gotVars["base_ref"] != "main" {
+		t.Fatalf("PR context vars: %v", gotVars)
+	}
+	if _, present := gotVars["re_review"]; present {
+		t.Fatalf("re_review must not be set on the converse path: %v", gotVars)
+	}
+}
+
+// The bot's own reply echoes back as the same event — the loop-guard must
+// filter it BEFORE any forge I/O, or the conversation ping-pongs forever.
+func TestGitHubWebhook_ReviewThreadReplyLoopGuard(t *testing.T) {
+	s := newWebhookTestServer(t)
+	s.cfg.Bots.Paths = []string{botsDirAbs(t)}
+	calls := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		calls++
+		return "run-x", nil
+	}
+	s.webhookIterionBotAuthor = func(_ context.Context, _ webhooks.Config, login string) bool {
+		return strings.EqualFold(login, "iterion-bot")
+	}
+	gateCalled := false
+	s.webhookPRForgeReviewReplyGate = func(context.Context, webhooks.Config, webhooks.Provider, prforge.ParsedReviewComment, string) (bool, string, string, error) {
+		gateCalled = true
+		return true, "", "allowlist", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"review-pr", "revi-converse"}
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewCommentReply("iterion-bot", "here is my answer"), prforge.EventHeaderReviewComment, pt))
+	if w.Code != http.StatusOK || calls != 0 {
+		t.Fatalf("self reply must filter: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+	if gateCalled {
+		t.Fatal("loop-guard must run BEFORE the gate (no forge I/O on the bot's own echo)")
+	}
+}
+
+// A reply in a human↔human thread (no bot comment in it) must not trigger:
+// the gate classifies and refuses, the delivery is filtered.
+func TestGitHubWebhook_ReviewThreadReplyNotBotThread(t *testing.T) {
+	s := newWebhookTestServer(t)
+	s.cfg.Bots.Paths = []string{botsDirAbs(t)}
+	calls := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		calls++
+		return "run-x", nil
+	}
+	s.webhookPRForgeReviewReplyGate = func(context.Context, webhooks.Config, webhooks.Provider, prforge.ParsedReviewComment, string) (bool, string, string, error) {
+		return false, "", "not a bot review thread (no iterion comment in it)", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"review-pr", "revi-converse"}
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewCommentReply("alice", "ping @bob thoughts?"), prforge.EventHeaderReviewComment, pt))
+	if w.Code != http.StatusOK || calls != 0 {
+		t.Fatalf("human thread must filter: code=%d calls=%d", w.Code, calls)
+	}
+}
+
+// Without the converse bot in the webhook scope the lane is inert — the
+// reply filters instead of falling back to a re-review (a reply is a
+// question; answering it with a fresh full review would be wrong).
+func TestGitHubWebhook_ReviewThreadReplyConverseNotEnabled(t *testing.T) {
+	s := newWebhookTestServer(t)
+	s.cfg.Bots.Paths = []string{botsDirAbs(t)}
+	calls := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		calls++
+		return "run-x", nil
+	}
+	cfg, pt := ghConfig(t, s) // BotIDs = ["review-pr"] only
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewCommentReply("alice", "question?"), prforge.EventHeaderReviewComment, pt))
+	if w.Code != http.StatusOK || calls != 0 {
+		t.Fatalf("converse-less webhook must filter: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+}
+
+// A reply on a closed PR filters — nothing to converse about.
+func TestGitHubWebhook_ReviewThreadReplyClosedPR(t *testing.T) {
+	s := newWebhookTestServer(t)
+	s.cfg.Bots.Paths = []string{botsDirAbs(t)}
+	calls := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		calls++
+		return "run-x", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"review-pr", "revi-converse"}
+
+	body := strings.Replace(ghReviewCommentReply("alice", "question?"), `"state": "open"`, `"state": "closed"`, 1)
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), body, prforge.EventHeaderReviewComment, pt))
+	if w.Code != http.StatusOK || calls != 0 {
+		t.Fatalf("closed PR must filter: code=%d calls=%d", w.Code, calls)
+	}
+}
+
+// `/revi <question>` in a PR comment routes to the converse bot through the
+// GENERIC command registry — the manifests' complementary disambiguators
+// (review-pr when_args_empty / revi-converse when_args_present), no
+// bot-specific branch in the handler. The CommandMap here is exactly what
+// the orchestrator derives from those manifests at provision.
+func TestGitHubWebhook_ReviQuestionRoutesViaCommandRegistry(t *testing.T) {
+	s := newWebhookTestServer(t)
+	s.cfg.Bots.Paths = []string{botsDirAbs(t)}
+	var gotBot string
+	var gotVars map[string]string
+	calls := 0
+	s.webhookLaunchBot = func(_ context.Context, botID string, vars map[string]string, _, _, _ string, _, _ map[string]string) (string, error) {
+		calls++
+		gotBot, gotVars = botID, vars
+		return "run-q-1", nil
+	}
+	s.webhookPRForgeCommandGate = func(context.Context, webhooks.Config, webhooks.Provider, prforge.ParsedNote, webhooks.CommandRoute) (bool, string, error) {
+		return true, "allowlist", nil
+	}
+	s.webhookPRForgePRResolver = func(context.Context, webhooks.Config, webhooks.Provider, prforge.ParsedNote, webhooks.CommandRoute) (forge.PullRef, error) {
+		return forge.PullRef{Number: 7, State: "open", SourceBranch: "feature/x", TargetBranch: "main", HeadSHA: "abc123"}, nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"review-pr", "revi-converse"}
+	cfg.CommandMap = map[string][]webhooks.CommandRoute{
+		"revi": {
+			{BotID: "review-pr", Mode: "direct", Scope: "pr", Disambiguator: "when_args_empty"},
+			{BotID: "revi-converse", Mode: "direct", Scope: "pr", Disambiguator: "when_args_present", ArgsVar: "converse_question"},
+		},
+	}
+
+	body := `{
+  "action": "created",
+  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+  "issue": {"number": 7, "title": "Add X", "body": "desc", "state": "open",
+    "html_url": "https://github.com/acme/widgets/pull/7",
+    "pull_request": {"html_url": "https://github.com/acme/widgets/pull/7"}},
+  "comment": {"id": 555, "body": "/revi why is the SSRF critical?",
+    "html_url": "https://github.com/acme/widgets/pull/7#issuecomment-555"},
+  "sender": {"login": "alice"}
+}`
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), body, prforge.EventHeaderIssueComment, pt))
+	if w.Code != http.StatusAccepted || calls != 1 {
+		t.Fatalf("revi question: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
+	}
+	if gotBot != "revi-converse" {
+		t.Fatalf("expected revi-converse via the registry, got %q", gotBot)
+	}
+	if gotVars["converse_question"] != "why is the SSRF critical?" {
+		t.Fatalf("args_var must carry the question: %v", gotVars["converse_question"])
+	}
+}
+
+// A config provisioned BEFORE the lane (allowlist without the review-comment
+// event) stays inert until re-provisioned — pins the migration semantics.
+func TestGitHubWebhook_ReviewThreadReplyPreLaneConfigInert(t *testing.T) {
+	s := newWebhookTestServer(t)
+	s.cfg.Bots.Paths = []string{botsDirAbs(t)}
+	calls := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		calls++
+		return "run-x", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"review-pr", "revi-converse"}
+	cfg.EventAllowlist = []string{"issue_comment", "pull_request"} // pre-lane shape
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghReviewCommentReply("alice", "question?"), prforge.EventHeaderReviewComment, pt))
+	if w.Code != http.StatusOK || calls != 0 {
+		t.Fatalf("pre-lane config must filter until re-provision: code=%d calls=%d", w.Code, calls)
+	}
+}

--- a/pkg/server/webhooks_reviewthread_test.go
+++ b/pkg/server/webhooks_reviewthread_test.go
@@ -244,3 +244,177 @@ func TestGitHubWebhook_ReviewThreadReplyPreLaneConfigInert(t *testing.T) {
 		t.Fatalf("pre-lane config must filter until re-provision: code=%d calls=%d", w.Code, calls)
 	}
 }
+
+// Every inline comment of a bot review echoes back as a thread-OPENING
+// pull_request_review_comment (no in_reply_to): nobody can already be in a
+// thread this comment creates, so the lane filters it from the payload
+// alone — no store read, no forge fetch, the gate is never invoked.
+func TestGitHubWebhook_ReviewThreadTopLevelCommentFiltered(t *testing.T) {
+	s := newWebhookTestServer(t)
+	s.cfg.Bots.Paths = []string{botsDirAbs(t)}
+	launches, gates := 0, 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		launches++
+		return "run-x", nil
+	}
+	s.webhookPRForgeReviewReplyGate = func(context.Context, webhooks.Config, webhooks.Provider, prforge.ParsedReviewComment, string) (bool, string, string, error) {
+		gates++
+		return true, "", "allowlist", nil
+	}
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"review-pr", "revi-converse"}
+	cfg.EventAllowlist = []string{"issue_comment", "pull_request", "pull_request_review_comment"}
+
+	body := `{
+  "action": "created",
+  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+  "comment": {"id": 9001, "body": "inline note on a diff line",
+    "html_url": "https://github.com/acme/widgets/pull/7#discussion_r9001",
+    "path": "pkg/x/y.go", "user": {"login": "alice"}},
+  "pull_request": {"number": 7, "state": "open", "title": "Add X", "body": "desc",
+    "html_url": "https://github.com/acme/widgets/pull/7",
+    "head": {"sha": "abc123", "ref": "feature/x"}, "base": {"ref": "main"}},
+  "sender": {"login": "alice"}
+}`
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), body, prforge.EventHeaderReviewComment, pt))
+	if w.Code != http.StatusOK || launches != 0 || gates != 0 {
+		t.Fatalf("thread-opening comment must filter payload-only: code=%d launches=%d gates=%d", w.Code, launches, gates)
+	}
+}
+
+// fakeThreadAPI drives reviewReplyGateWithAPI without a forge.
+type fakeThreadAPI struct {
+	comments  []forge.PRReviewComment
+	listErr   error
+	perm      string
+	permErr   error
+	permCalls int
+}
+
+func (f *fakeThreadAPI) WhoAmI(context.Context) (forge.Identity, error) {
+	return forge.Identity{}, nil
+}
+func (f *fakeThreadAPI) CollaboratorPermission(context.Context, string, string) (string, error) {
+	f.permCalls++
+	return f.perm, f.permErr
+}
+func (f *fakeThreadAPI) GetPullRequest(context.Context, string, int) (forge.PullRef, error) {
+	return forge.PullRef{}, nil
+}
+func (f *fakeThreadAPI) ListPRReviewComments(context.Context, string, int) ([]forge.PRReviewComment, error) {
+	return f.comments, f.listErr
+}
+
+// The REAL gate core (not the handler stub): thread-membership filter,
+// bot-in-thread classification, allowlist vs role authorization, and error
+// propagation, on a fake thread API.
+func TestReviewReplyGateWithAPI(t *testing.T) {
+	newGateServer := func(t *testing.T) *Server {
+		s := newWebhookTestServer(t)
+		s.webhookIterionBotAuthor = func(_ context.Context, _ webhooks.Config, login string) bool {
+			return login == "revi-bot"
+		}
+		return s
+	}
+	p := prforge.ParsedReviewComment{ProjectPath: "acme/widgets", PRNumber: 7, CommentID: 9002, ThreadRootID: 9001, AuthorLogin: "alice"}
+	botThread := []forge.PRReviewComment{
+		{ID: 9001, Author: "revi-bot", Body: "the SSRF is reachable", CreatedAt: "2026-09-02T10:00:00Z"},
+		{ID: 9002, InReplyTo: 9001, Author: "alice", Body: "why?", CreatedAt: "2026-09-02T10:05:00Z"},
+		{ID: 777, Author: "mallory", Body: "unrelated thread", CreatedAt: "2026-09-02T09:00:00Z"},
+	}
+
+	t.Run("allowlist authorizes without a role probe", func(t *testing.T) {
+		s := newGateServer(t)
+		api := &fakeThreadAPI{comments: botThread}
+		ok, transcript, reason, err := s.reviewReplyGateWithAPI(context.Background(), webhooks.Config{AuthorizedRepliers: []string{"alice"}}, p, api)
+		if err != nil || !ok || reason != "allowlist" {
+			t.Fatalf("ok=%v reason=%q err=%v", ok, reason, err)
+		}
+		if api.permCalls != 0 {
+			t.Fatalf("allowlist path must not probe the role: %d calls", api.permCalls)
+		}
+		if !strings.Contains(transcript, "revi-bot (you, the bot)") || !strings.Contains(transcript, "the SSRF is reachable") {
+			t.Fatalf("transcript must label the bot's anchor: %q", transcript)
+		}
+		if strings.Contains(transcript, "unrelated thread") {
+			t.Fatalf("transcript leaked another thread: %q", transcript)
+		}
+	})
+
+	t.Run("role gate", func(t *testing.T) {
+		s := newGateServer(t)
+		ok, _, reason, err := s.reviewReplyGateWithAPI(context.Background(), webhooks.Config{MinReplierRole: "developer"}, p, &fakeThreadAPI{comments: botThread, perm: "write"})
+		if err != nil || !ok || reason != "role" {
+			t.Fatalf("write>=developer must pass: ok=%v reason=%q err=%v", ok, reason, err)
+		}
+		ok, _, reason, err = s.reviewReplyGateWithAPI(context.Background(), webhooks.Config{MinReplierRole: "developer"}, p, &fakeThreadAPI{comments: botThread, perm: "read"})
+		if err != nil || ok || !strings.HasPrefix(reason, "replier not authorized") {
+			t.Fatalf("read<developer must refuse: ok=%v reason=%q err=%v", ok, reason, err)
+		}
+	})
+
+	t.Run("human-only thread never triggers", func(t *testing.T) {
+		s := newGateServer(t)
+		api := &fakeThreadAPI{comments: []forge.PRReviewComment{
+			{ID: 9001, Author: "bob", Body: "top-level human note"},
+			{ID: 9002, InReplyTo: 9001, Author: "alice", Body: "why?"},
+		}}
+		ok, _, reason, err := s.reviewReplyGateWithAPI(context.Background(), webhooks.Config{AuthorizedRepliers: []string{"alice"}}, p, api)
+		if err != nil || ok || !strings.HasPrefix(reason, "not a bot review thread") {
+			t.Fatalf("ok=%v reason=%q err=%v", ok, reason, err)
+		}
+		if api.permCalls != 0 {
+			t.Fatalf("thread gate must refuse before any authz probe: %d calls", api.permCalls)
+		}
+	})
+
+	t.Run("infra errors propagate", func(t *testing.T) {
+		s := newGateServer(t)
+		if _, _, _, err := s.reviewReplyGateWithAPI(context.Background(), webhooks.Config{}, p, &fakeThreadAPI{listErr: fmt.Errorf("boom")}); err == nil {
+			t.Fatal("list error must propagate, not filter")
+		}
+		if _, _, _, err := s.reviewReplyGateWithAPI(context.Background(), webhooks.Config{}, p, &fakeThreadAPI{comments: botThread, permErr: fmt.Errorf("boom")}); err == nil {
+			t.Fatal("permission error must propagate, not filter")
+		}
+	})
+}
+
+// classifyReviewThread invariants the gate's security half rests on: the
+// trigger comment can never self-certify the thread as the bot's, and the
+// transcript obeys the shared anchor+newest cap.
+func TestClassifyReviewThread(t *testing.T) {
+	isBot := func(login string) bool { return login == "revi-bot" }
+	p := prforge.ParsedReviewComment{CommentID: 9002, ThreadRootID: 9001}
+
+	t.Run("trigger comment never counts as the bot", func(t *testing.T) {
+		botInThread, _ := classifyReviewThread([]forge.PRReviewComment{
+			{ID: 9001, Author: "bob", Body: "human root"},
+			{ID: 9002, InReplyTo: 9001, Author: "revi-bot", Body: "trigger itself"},
+		}, p, isBot)
+		if botInThread {
+			t.Fatal("a bot-authored trigger must not certify its own thread")
+		}
+	})
+
+	t.Run("transcript capped by the shared budget", func(t *testing.T) {
+		big := strings.Repeat("x", 4000)
+		comments := []forge.PRReviewComment{{ID: 9001, Author: "revi-bot", Body: "anchor: " + big}}
+		for i := int64(0); i < 6; i++ {
+			comments = append(comments, forge.PRReviewComment{ID: 9100 + i, InReplyTo: 9001, Author: "alice", Body: big})
+		}
+		botInThread, transcript := classifyReviewThread(comments, p, isBot)
+		if !botInThread {
+			t.Fatal("bot anchor must certify the thread")
+		}
+		if len(transcript) > maxThreadContextChars {
+			t.Fatalf("transcript exceeds the shared cap: %d > %d", len(transcript), maxThreadContextChars)
+		}
+		if !strings.Contains(transcript, "earlier notes omitted") {
+			t.Fatalf("over-budget transcript must carry the omission marker")
+		}
+		if !strings.HasPrefix(transcript, "revi-bot (you, the bot)") {
+			t.Fatalf("the thread anchor must be kept first: %q", transcript[:80])
+		}
+	})
+}

--- a/pkg/server/webhooks_routes.go
+++ b/pkg/server/webhooks_routes.go
@@ -273,6 +273,7 @@ func (s *Server) handleCreateWebhook(w http.ResponseWriter, r *http.Request) {
 		Overlap:             overlapOrEmpty(req.Overlap),
 		AutoImplementOnOpen: req.AutoImplementOnOpen != nil && *req.AutoImplementOnOpen,
 		RateLimit:           rate,
+		RateLimitPinned:     req.RateLimit != nil, // same rule as ReviewOnSyncPinned
 		LaunchVars:          req.LaunchVars,
 		KeyOverrides:        req.KeyOverrides,
 		SecretOverrides:     req.SecretOverrides,
@@ -468,6 +469,7 @@ func (s *Server) handleUpdateWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.RateLimit != nil {
 		cfg.RateLimit = *req.RateLimit
+		cfg.RateLimitPinned = true
 	}
 	if req.MonthlyCallLimit != nil {
 		cfg.MonthlyCallLimit = *req.MonthlyCallLimit

--- a/pkg/webhooks/gitlab/client.go
+++ b/pkg/webhooks/gitlab/client.go
@@ -8,7 +8,8 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"unicode/utf8"
+
+	"github.com/SocialGouv/iterion/pkg/webhooks"
 )
 
 // GitLab numeric access levels.
@@ -169,12 +170,10 @@ func NotesHaveAuthor(notes []DiscussionNote, userID int64) bool {
 // FormatThreadTranscript renders a discussion's notes as the plain-text
 // transcript the converse bot receives as {{vars.thread_context}}:
 // chronological, system notes skipped, the bot's own notes labelled so the
-// model knows which earlier statements are its own. maxChars caps the
-// result — the FIRST note (the thread anchor, typically the review comment
-// the operator replied to) is always kept, then the most recent notes fill
-// the remaining budget with an omission marker for the middle.
+// model knows which earlier statements are its own. The budget policy
+// (anchor kept, newest notes fill, omission marker) is the shared
+// webhooks.CapTranscript, one policy for every forge's conversation lane.
 func FormatThreadTranscript(notes []DiscussionNote, botUserID int64, maxChars int) string {
-	const sep = "\n\n---\n\n"
 	rendered := make([]string, 0, len(notes))
 	for _, n := range notes {
 		if n.System {
@@ -186,40 +185,5 @@ func FormatThreadTranscript(notes []DiscussionNote, botUserID int64, maxChars in
 		}
 		rendered = append(rendered, who+":\n"+strings.TrimSpace(n.Body))
 	}
-	if len(rendered) == 0 {
-		return ""
-	}
-	full := strings.Join(rendered, sep)
-	if maxChars <= 0 || len(full) <= maxChars {
-		return full
-	}
-	// Over budget: anchor + newest notes, omission marker in between.
-	const omitted = "[… earlier notes omitted …]"
-	anchor := rendered[0]
-	budget := maxChars - len(anchor) - len(omitted) - 2*len(sep)
-	var tail []string
-	for i := len(rendered) - 1; i >= 1; i-- {
-		need := len(rendered[i]) + len(sep)
-		if need > budget {
-			break
-		}
-		budget -= need
-		tail = append([]string{rendered[i]}, tail...)
-	}
-	parts := []string{anchor}
-	if len(tail) < len(rendered)-1 {
-		parts = append(parts, omitted)
-	}
-	parts = append(parts, tail...)
-	out := strings.Join(parts, sep)
-	if len(out) > maxChars {
-		// The anchor alone overflows the budget — hard-truncate on a rune
-		// boundary so the transcript stays valid UTF-8.
-		cut := maxChars
-		for cut > 0 && !utf8.RuneStart(out[cut]) {
-			cut--
-		}
-		out = out[:cut] + "\n[… truncated …]"
-	}
-	return out
+	return webhooks.CapTranscript(rendered, maxChars)
 }

--- a/pkg/webhooks/prforge/reviewcomment.go
+++ b/pkg/webhooks/prforge/reviewcomment.go
@@ -1,0 +1,116 @@
+package prforge
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// EventHeaderReviewComment is the X-GitHub-Event value for a comment in a
+// PR review thread (an inline comment on the diff, or a reply inside one of
+// those threads). Distinct from issue_comment: a review-thread reply never
+// arrives as issue_comment, so the conversational reply-to-a-suggestion lane
+// needs this event subscribed on the hook and handled here.
+const EventHeaderReviewComment = "pull_request_review_comment"
+
+// ReviewCommentEvent is the subset of the pull_request_review_comment
+// webhook payload we decode (GitHub wire shape).
+type ReviewCommentEvent struct {
+	Action     string     `json:"action"` // "created" | "edited" | "deleted"
+	Repository Repository `json:"repository"`
+	Comment    struct {
+		ID        int64  `json:"id"`
+		InReplyTo int64  `json:"in_reply_to_id"` // 0 ⇒ this comment starts its thread
+		Body      string `json:"body"`
+		HTMLURL   string `json:"html_url"`
+		Path      string `json:"path"`
+		User      Sender `json:"user"`
+	} `json:"comment"`
+	PullRequest struct {
+		Number  int64  `json:"number"`
+		State   string `json:"state"` // "open" | "closed"
+		Title   string `json:"title"`
+		Body    string `json:"body"`
+		HTMLURL string `json:"html_url"`
+		Head    struct {
+			SHA string `json:"sha"`
+			Ref string `json:"ref"`
+		} `json:"head"`
+		Base struct {
+			Ref string `json:"ref"`
+		} `json:"base"`
+	} `json:"pull_request"`
+	Sender Sender `json:"sender"`
+}
+
+// ParsedReviewComment is the normalized review-thread-comment view the
+// inbound handler consumes — the GitHub twin of gitlab.ParsedNote's
+// reply-in-thread half. Unlike issue_comment, the payload carries the full
+// PR head/base, so no follow-up API resolution is needed to launch.
+type ParsedReviewComment struct {
+	RepoID       int64
+	ProjectPath  string // "owner/repo"
+	CloneURL     string
+	PRNumber     int64
+	PRState      string // "open" | "closed"
+	PRTitle      string
+	PRBody       string
+	PRURL        string
+	HeadSHA      string
+	SourceBranch string // PR head ref
+	TargetBranch string // PR base ref
+	CommentID    int64
+	// ThreadRootID is the top-level comment id of the thread this comment
+	// belongs to: in_reply_to_id when the comment is a reply, else the
+	// comment's own id. It is what GitHub's reply endpoint
+	// (/pulls/{n}/comments/{id}/replies) wants as {id}, so it is handed to
+	// the bot as discussion_id.
+	ThreadRootID int64
+	CommentBody  string
+	CommentURL   string
+	CommentPath  string // file the thread anchors to
+	AuthorLogin  string
+	Action       string
+}
+
+// ParseReviewComment decodes a pull_request_review_comment webhook body
+// (GitHub wire shape).
+func ParseReviewComment(body []byte) (ParsedReviewComment, error) {
+	var e ReviewCommentEvent
+	if err := json.Unmarshal(body, &e); err != nil {
+		return ParsedReviewComment{}, fmt.Errorf("prforge: decode pull_request_review_comment event: %w", err)
+	}
+	p := ParsedReviewComment{
+		RepoID:       e.Repository.ID,
+		ProjectPath:  e.Repository.FullName,
+		CloneURL:     e.Repository.CloneURL,
+		PRNumber:     e.PullRequest.Number,
+		PRState:      e.PullRequest.State,
+		PRTitle:      e.PullRequest.Title,
+		PRBody:       e.PullRequest.Body,
+		PRURL:        e.PullRequest.HTMLURL,
+		HeadSHA:      e.PullRequest.Head.SHA,
+		SourceBranch: e.PullRequest.Head.Ref,
+		TargetBranch: e.PullRequest.Base.Ref,
+		CommentID:    e.Comment.ID,
+		ThreadRootID: e.Comment.InReplyTo,
+		CommentBody:  e.Comment.Body,
+		CommentURL:   e.Comment.HTMLURL,
+		CommentPath:  e.Comment.Path,
+		AuthorLogin:  e.Comment.User.Login,
+		Action:       e.Action,
+	}
+	if p.ThreadRootID == 0 {
+		p.ThreadRootID = p.CommentID
+	}
+	if p.AuthorLogin == "" {
+		p.AuthorLogin = e.Sender.Login
+	}
+	return p, nil
+}
+
+// SubjectID is the stable per-comment id used in delivery records +
+// idempotency (one launch per reply).
+func (p ParsedReviewComment) SubjectID() string {
+	return "rc:" + strconv.FormatInt(p.CommentID, 10)
+}

--- a/pkg/webhooks/prforge/reviewcomment.go
+++ b/pkg/webhooks/prforge/reviewcomment.go
@@ -33,8 +33,11 @@ type ReviewCommentEvent struct {
 		Body    string `json:"body"`
 		HTMLURL string `json:"html_url"`
 		Head    struct {
-			SHA string `json:"sha"`
-			Ref string `json:"ref"`
+			SHA  string `json:"sha"`
+			Ref  string `json:"ref"`
+			Repo struct {
+				FullName string `json:"full_name"`
+			} `json:"repo"`
 		} `json:"head"`
 		Base struct {
 			Ref string `json:"ref"`
@@ -71,6 +74,21 @@ type ParsedReviewComment struct {
 	CommentPath  string // file the thread anchors to
 	AuthorLogin  string
 	Action       string
+	// HeadRepoFullName is the "owner/repo" the PR's head branch lives in —
+	// differs from ProjectPath on a fork PR; empty when the payload omits
+	// head.repo. Read by IsCrossRepo for the fork guard.
+	HeadRepoFullName string
+}
+
+// IsCrossRepo reports whether the PR's head branch lives in a DIFFERENT repo
+// than its base — i.e. the PR comes from a fork. Same semantics as
+// Parsed.IsCrossRepo: on a fork, CloneURL (the BASE repo) and SourceBranch
+// (a HEAD-repo ref) do not name the same repository, so a launch would check
+// out a missing — or worse, a same-named base — branch. An empty head repo
+// (minimal/legacy payloads) is treated as same-repo to avoid falsely gating
+// a trusted internal PR.
+func (p ParsedReviewComment) IsCrossRepo() bool {
+	return p.HeadRepoFullName != "" && p.HeadRepoFullName != p.ProjectPath
 }
 
 // ParseReviewComment decodes a pull_request_review_comment webhook body
@@ -99,6 +117,8 @@ func ParseReviewComment(body []byte) (ParsedReviewComment, error) {
 		CommentPath:  e.Comment.Path,
 		AuthorLogin:  e.Comment.User.Login,
 		Action:       e.Action,
+
+		HeadRepoFullName: e.PullRequest.Head.Repo.FullName,
 	}
 	if p.ThreadRootID == 0 {
 		p.ThreadRootID = p.CommentID

--- a/pkg/webhooks/prforge/reviewcomment_test.go
+++ b/pkg/webhooks/prforge/reviewcomment_test.go
@@ -52,3 +52,32 @@ func TestParseReviewCommentTopLevelIsItsOwnRoot(t *testing.T) {
 		t.Fatalf("a thread-opening comment roots its own thread: %+v", p)
 	}
 }
+
+func TestParseReviewCommentForkCarriesHeadRepo(t *testing.T) {
+	body := []byte(`{
+  "action": "created",
+  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+  "comment": {"id": 9002, "in_reply_to_id": 9001, "body": "q", "user": {"login": "mallory"}},
+  "pull_request": {"number": 7, "state": "open",
+    "head": {"sha": "abc", "ref": "main", "repo": {"full_name": "mallory/widgets"}},
+    "base": {"ref": "main"}},
+  "sender": {"login": "mallory"}
+}`)
+	p, err := ParseReviewComment(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.HeadRepoFullName != "mallory/widgets" || !p.IsCrossRepo() {
+		t.Fatalf("fork head repo must be decoded and flagged: %+v", p)
+	}
+}
+
+func TestParseReviewCommentLegacyPayloadIsSameRepo(t *testing.T) {
+	p, err := ParseReviewComment([]byte(reviewCommentReplyFixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.IsCrossRepo() {
+		t.Fatalf("a payload without head.repo must stay same-repo (no false gating): %+v", p)
+	}
+}

--- a/pkg/webhooks/prforge/reviewcomment_test.go
+++ b/pkg/webhooks/prforge/reviewcomment_test.go
@@ -1,0 +1,54 @@
+package prforge
+
+import "testing"
+
+const reviewCommentReplyFixture = `{
+  "action": "created",
+  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+  "comment": {"id": 9002, "in_reply_to_id": 9001, "body": "why is this reachable?",
+    "html_url": "https://github.com/acme/widgets/pull/7#discussion_r9002",
+    "path": "pkg/x/y.go", "user": {"login": "alice"}},
+  "pull_request": {"number": 7, "state": "open", "title": "Add X", "body": "desc",
+    "html_url": "https://github.com/acme/widgets/pull/7",
+    "head": {"sha": "abc123", "ref": "feature/x"}, "base": {"ref": "main"}},
+  "sender": {"login": "alice"}
+}`
+
+func TestParseReviewComment(t *testing.T) {
+	p, err := ParseReviewComment([]byte(reviewCommentReplyFixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.ProjectPath != "acme/widgets" || p.PRNumber != 7 || p.PRState != "open" {
+		t.Fatalf("PR context: %+v", p)
+	}
+	if p.CommentID != 9002 || p.ThreadRootID != 9001 {
+		t.Fatalf("a reply's ThreadRootID must be in_reply_to_id: %+v", p)
+	}
+	if p.AuthorLogin != "alice" || p.CommentBody != "why is this reachable?" {
+		t.Fatalf("comment fields: %+v", p)
+	}
+	if p.HeadSHA != "abc123" || p.SourceBranch != "feature/x" || p.TargetBranch != "main" {
+		t.Fatalf("branch fields: %+v", p)
+	}
+	if p.SubjectID() != "rc:9002" {
+		t.Fatalf("SubjectID: %q", p.SubjectID())
+	}
+}
+
+func TestParseReviewCommentTopLevelIsItsOwnRoot(t *testing.T) {
+	body := []byte(`{
+  "action": "created",
+  "repository": {"id": 42, "full_name": "acme/widgets"},
+  "comment": {"id": 9001, "body": "inline note", "user": {"login": "revi-bot"}},
+  "pull_request": {"number": 7, "state": "open"},
+  "sender": {"login": "revi-bot"}
+}`)
+	p, err := ParseReviewComment(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.ThreadRootID != 9001 {
+		t.Fatalf("a thread-opening comment roots its own thread: %+v", p)
+	}
+}

--- a/pkg/webhooks/transcript.go
+++ b/pkg/webhooks/transcript.go
@@ -1,0 +1,56 @@
+package webhooks
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// transcriptSep separates rendered thread entries in a conversation
+// transcript handed to a converse bot.
+const transcriptSep = "\n\n---\n\n"
+
+// CapTranscript joins rendered thread entries (chronological) into the
+// transcript a converse bot receives, bounded by maxChars: the FIRST entry
+// (the thread anchor — typically the review comment the operator replied to)
+// is always kept, then the most recent entries fill the remaining budget,
+// with an omission marker replacing the middle. maxChars <= 0 means no cap.
+// Shared by the GitLab note lane and the GitHub review-thread lane so both
+// transcripts obey one budget policy.
+func CapTranscript(rendered []string, maxChars int) string {
+	if len(rendered) == 0 {
+		return ""
+	}
+	full := strings.Join(rendered, transcriptSep)
+	if maxChars <= 0 || len(full) <= maxChars {
+		return full
+	}
+	// Over budget: anchor + newest entries, omission marker in between.
+	const omitted = "[… earlier notes omitted …]"
+	anchor := rendered[0]
+	budget := maxChars - len(anchor) - len(omitted) - 2*len(transcriptSep)
+	var tail []string
+	for i := len(rendered) - 1; i >= 1; i-- {
+		need := len(rendered[i]) + len(transcriptSep)
+		if need > budget {
+			break
+		}
+		budget -= need
+		tail = append([]string{rendered[i]}, tail...)
+	}
+	parts := []string{anchor}
+	if len(tail) < len(rendered)-1 {
+		parts = append(parts, omitted)
+	}
+	parts = append(parts, tail...)
+	out := strings.Join(parts, transcriptSep)
+	if len(out) > maxChars {
+		// The anchor alone overflows the budget — hard-truncate on a rune
+		// boundary so the transcript stays valid UTF-8.
+		cut := maxChars
+		for cut > 0 && !utf8.RuneStart(out[cut]) {
+			cut--
+		}
+		out = out[:cut] + "\n[… truncated …]"
+	}
+	return out
+}

--- a/pkg/webhooks/types.go
+++ b/pkg/webhooks/types.go
@@ -222,7 +222,15 @@ type Config struct {
 	ForgeBaseURL string `bson:"forge_base_url,omitempty" json:"forge_base_url,omitempty"`
 
 	// Limits.
-	RateLimit        Rate `bson:"rate_limit" json:"rate_limit"`
+	RateLimit Rate `bson:"rate_limit" json:"rate_limit"`
+	// RateLimitPinned records that an operator set RateLimit EXPLICITLY
+	// through the webhook API (create or PATCH). The re-provision carry
+	// preserves a pinned value — losing an operator's raise means
+	// deliveries silently 429. An UNPINNED value is presumed
+	// provisioner-owned: a re-provision moves it to the current
+	// provisioning default, so a default bump actually reaches existing
+	// webhooks instead of freezing each on the burst it was born with.
+	RateLimitPinned  bool `bson:"rate_limit_pinned,omitempty" json:"rate_limit_pinned,omitempty"`
 	MonthlyCallLimit int  `bson:"monthly_call_limit,omitempty" json:"monthly_call_limit,omitempty"` // 0 = inherit org
 
 	// OperatorLaunchVars are the per-repo overrides an operator pinned on the


### PR DESCRIPTION
Replying inside one of Revi's review threads on **GitHub** now launches the converse bot, which answers **in the same thread** — the GitHub half of the conversational lane (docs/forge-conversations.md). Asked by the operator right after the Revu→Revi migration put 13 GitHub repos on Revi; board card `native:bb0913cb`.

## What ships

- **`pull_request_review_comment` parser** — `ParsedReviewComment`; `ThreadRootID` = `in_reply_to_id || id`, i.e. exactly what GitHub's `/pulls/{n}/comments/{id}/replies` endpoint wants, handed to the bot as `discussion_id`.
- **`handlePRForgeReviewThreadReply`** — loop-guard FIRST and with zero forge I/O (the bot's own answer echoes back as this very event); converse bot required in the webhook scope; then the gate fetches the thread (`ListPRReviewComments`, capped pagination), requires a comment by the bot identity IN it (a human↔human thread never triggers), authorizes the replier (allowlist OR `min_replier_role`), and hands the transcript to the launch as `thread_context`. One launch per reply comment (`rc|` idempotency space).
- **`/revi <question>` on GitHub = zero code** — the manifests' complementary disambiguators (`review-pr` `when_args_empty` / `revi-converse` `when_args_present` + `args_var: converse_question`) already route it through the generic command registry; a dedicated test pins that exact path. **No bot id is hardcoded anywhere in the lane** (the role resolves through `roleBots()`, the command split through manifests — per the engine-stays-bot-agnostic rule).
- **`forge.event_map`**: `pull_request_comment` now expands on GitHub to BOTH wire events — GitHub splits PR comments across `issue_comment` + `pull_request_review_comment` where GitLab's single `note` covers both. A (re-)provision regenerates the hook subscription AND the config's `event_allowlist` together. Pre-lane configs stay **inert** on review-thread replies until re-provisioned (pinned by test). Forgejo deliberately unchanged (dispatch never routes the event there).

Bot-side: nothing changes — `bots/revi-converse` already speaks GitHub (`skills/forge-reply.md` §4).

## Rollout (post-merge, operator)

Re-provision each repo with `revi-converse` added to `bot_ids` (`POST /api/teams/{id}/forge/repo-bots`): the changed bot set defeats the provisioner's idempotent short-circuit, so hook events + allowlist regenerate in the same gesture, and `carryOperatorWebhookSettings` (#605) preserves `review_request_logins` & co. Then a REAL end-to-end test on a live PR (review → reply to an inline comment → in-thread answer) — committed to in the session.

Known refinement left out (noted, not hidden): the provisioner's idempotent short-circuit compares *normalized* events, so a repo whose bot set does NOT change would keep its old native hook events after an event_map change; our rollout changes the bot set everywhere, and generalizing the comparator is a separate small change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)