### PR TITLE
fix(mcp): ambient MCP server boot failure degrades the node's tool set, never the run

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -651,6 +651,19 @@ subprocess argv. `ITERION_CLAUDE_CODE_STRICT_MCP=0` is the escape hatch that
 restores host-config inheritance. Settings remain inherited independently
 (`--setting-sources`, above).
 
+**Ambient servers degrade per-server, on every backend.** A server a node
+never named — inherited from the target repo's `.mcp.json` or the plugin
+catalog — that fails to boot costs its OWN tools, never the run:
+claude_code's CLI skips a server it cannot start, pi bounds each connect
+with `ITERION_PI_MCP_CONNECT_TIMEOUT_MS`, and claw's in-process splice
+skips it with a Warn log plus a `mcp_server_degraded` run event (server,
+source, error), so the drop is in the run record, not just the process
+log. Typical case: a repo-scoped server needing a credential the
+execution host doesn't have (a token-less Sentry server on a cloud
+runner pod). A tool the node names EXPLICITLY on a dead server still
+fails loud at resolution — a declared dependency is never silently
+dropped.
+
 ### `codex`
 
 The Codex backend delegates to the installed Codex CLI through the pinned Agent

--- a/pkg/backend/model/executor_build_task.go
+++ b/pkg/backend/model/executor_build_task.go
@@ -998,11 +998,30 @@ func (e *ClawExecutor) buildTask(ctx context.Context, node ir.Node, f backendFie
 		// an `mcp.<server>.*` wildcard. This is what lets a claw node reach the
 		// firecrawl scrape/search MCP (self-hosted, searxng-backed) instead of
 		// only claw's native direct-HTTP web_fetch — the wiring gap that made
-		// firecrawl claude_code-only. resolveToolsForNode starts the servers and
-		// expands + dedups the wildcards; the len(effectiveTools)>0 gate keeps
-		// tool-less judges lean (no ambient fetch tools, no behaviour change).
-		if e.mcpManager != nil {
+		// firecrawl claude_code-only. resolveToolsForNode expands + dedups the
+		// wildcards; the len(effectiveTools)>0 gate keeps tool-less judges
+		// lean (no ambient fetch tools, no behaviour change).
+		//
+		// Each server is ensured HERE, one by one: these are ambient (the
+		// node never named them — they arrive from the target repo's
+		// .mcp.json or the plugin catalog), so one that cannot boot costs
+		// its own tools, never the run. The other backends already degrade
+		// per-server (claude_code's CLI skips a server it cannot start; pi
+		// bounds each connect with a timeout) — hard-failing here was a
+		// claw-path parity defect: one token-less repo server killed every
+		// claw node of the run. A tool the node names EXPLICITLY on a dead
+		// server still fails loud in resolveToolsForNode.
+		if e.mcpManager != nil && e.toolRegistry != nil {
 			for _, srv := range f.activeMCPServers {
+				if err := e.mcpManager.EnsureServers(ctx, e.toolRegistry, []string{srv}); err != nil {
+					if e.logger != nil {
+						e.logger.Warn("[%s] ambient MCP server %q failed to boot — the node runs WITHOUT its tools: %v", f.id, srv, err)
+					}
+					if e.hooks.OnMCPServerDegraded != nil {
+						e.hooks.OnMCPServerDegraded(f.id, MCPServerDegradedInfo{Server: srv, Source: "ambient", Err: err})
+					}
+					continue
+				}
 				clawTools = append(clawTools, "mcp."+srv+".*")
 			}
 		}

--- a/pkg/backend/model/executor_hooks.go
+++ b/pkg/backend/model/executor_hooks.go
@@ -145,6 +145,15 @@ type SessionDegradedInfo struct {
 	Err    error // the failure the dropped session is being blamed for
 }
 
+// MCPServerDegradedInfo describes an ambient MCP server dropped from a
+// node's tool set because it failed to boot, passed to the
+// OnMCPServerDegraded hook.
+type MCPServerDegradedInfo struct {
+	Server string // MCP server name that failed to boot
+	Source string // where the server came from — "ambient" (repo .mcp.json / plugin catalog)
+	Err    error  // the boot failure the dropped tools are blamed for
+}
+
 // EventHooks allows the executor to emit observability events back to the caller.
 type EventHooks struct {
 	OnLLMRequest    func(nodeID string, info LLMRequestInfo)
@@ -204,6 +213,14 @@ type EventHooks struct {
 	// record; the process log alone leaves a downstream gate blind.
 	OnSessionDegraded func(nodeID string, info SessionDegradedInfo)
 
+	// OnMCPServerDegraded fires when an AMBIENT MCP server (repo
+	// .mcp.json / plugin catalog — never named by the node) fails to
+	// boot and is dropped from the node's tool set. Purely observational
+	// — the node runs on without that server's tools — but it is the
+	// only thing that puts "this node ran without an inherited server"
+	// in the run record.
+	OnMCPServerDegraded func(nodeID string, info MCPServerDegradedInfo)
+
 	// OnNodeFinished fires after a node's executor returns successfully.
 	// The output map carries iterion's conventional usage keys (`_tokens`,
 	// `_cost_usd`, `_model`) so observers (e.g. the Prometheus exporter)
@@ -255,22 +272,23 @@ func chainCb6[A, B, C, D, E, F any](a, b func(A, B, C, D, E, F)) func(A, B, C, D
 // closure.
 func ChainHooks(a, b EventHooks) EventHooks {
 	return EventHooks{
-		OnLLMRequest:       chainCb2(a.OnLLMRequest, b.OnLLMRequest),
-		OnLLMPrompt:        chainCb3(a.OnLLMPrompt, b.OnLLMPrompt),
-		OnLLMResponse:      chainCb2(a.OnLLMResponse, b.OnLLMResponse),
-		OnLLMRetry:         chainCb2(a.OnLLMRetry, b.OnLLMRetry),
-		OnLLMStepFinish:    chainCb2(a.OnLLMStepFinish, b.OnLLMStepFinish),
-		OnLLMTurnCapture:   chainCb2(a.OnLLMTurnCapture, b.OnLLMTurnCapture),
-		OnLLMCompacted:     chainCb2(a.OnLLMCompacted, b.OnLLMCompacted),
-		OnToolStarted:      chainCb2(a.OnToolStarted, b.OnToolStarted),
-		OnToolCall:         chainCb2(a.OnToolCall, b.OnToolCall),
-		OnToolNodeResult:   chainCb6(a.OnToolNodeResult, b.OnToolNodeResult),
-		OnDelegateStarted:  chainCb2(a.OnDelegateStarted, b.OnDelegateStarted),
-		OnDelegateFinished: chainCb2(a.OnDelegateFinished, b.OnDelegateFinished),
-		OnDelegateError:    chainCb2(a.OnDelegateError, b.OnDelegateError),
-		OnDelegateRetry:    chainCb2(a.OnDelegateRetry, b.OnDelegateRetry),
-		OnProviderFallback: chainCb2(a.OnProviderFallback, b.OnProviderFallback),
-		OnSessionDegraded:  chainCb2(a.OnSessionDegraded, b.OnSessionDegraded),
-		OnNodeFinished:     chainCb2(a.OnNodeFinished, b.OnNodeFinished),
+		OnLLMRequest:        chainCb2(a.OnLLMRequest, b.OnLLMRequest),
+		OnLLMPrompt:         chainCb3(a.OnLLMPrompt, b.OnLLMPrompt),
+		OnLLMResponse:       chainCb2(a.OnLLMResponse, b.OnLLMResponse),
+		OnLLMRetry:          chainCb2(a.OnLLMRetry, b.OnLLMRetry),
+		OnLLMStepFinish:     chainCb2(a.OnLLMStepFinish, b.OnLLMStepFinish),
+		OnLLMTurnCapture:    chainCb2(a.OnLLMTurnCapture, b.OnLLMTurnCapture),
+		OnLLMCompacted:      chainCb2(a.OnLLMCompacted, b.OnLLMCompacted),
+		OnToolStarted:       chainCb2(a.OnToolStarted, b.OnToolStarted),
+		OnToolCall:          chainCb2(a.OnToolCall, b.OnToolCall),
+		OnToolNodeResult:    chainCb6(a.OnToolNodeResult, b.OnToolNodeResult),
+		OnDelegateStarted:   chainCb2(a.OnDelegateStarted, b.OnDelegateStarted),
+		OnDelegateFinished:  chainCb2(a.OnDelegateFinished, b.OnDelegateFinished),
+		OnDelegateError:     chainCb2(a.OnDelegateError, b.OnDelegateError),
+		OnDelegateRetry:     chainCb2(a.OnDelegateRetry, b.OnDelegateRetry),
+		OnProviderFallback:  chainCb2(a.OnProviderFallback, b.OnProviderFallback),
+		OnSessionDegraded:   chainCb2(a.OnSessionDegraded, b.OnSessionDegraded),
+		OnMCPServerDegraded: chainCb2(a.OnMCPServerDegraded, b.OnMCPServerDegraded),
+		OnNodeFinished:      chainCb2(a.OnNodeFinished, b.OnNodeFinished),
 	}
 }

--- a/pkg/backend/model/executor_mcp_forward_test.go
+++ b/pkg/backend/model/executor_mcp_forward_test.go
@@ -2,10 +2,13 @@ package model
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
 	"github.com/SocialGouv/iterion/pkg/backend/mcp"
+	"github.com/SocialGouv/iterion/pkg/backend/tool"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 )
@@ -51,5 +54,55 @@ func TestBuildTaskForwardsDeclaredMCPServersPerBackend(t *testing.T) {
 		if mcpForwardingBackends[backend] {
 			t.Errorf("%s must not receive Task.MCPServers", backend)
 		}
+	}
+}
+
+// An AMBIENT MCP server (repo .mcp.json / plugin catalog — never named by
+// the node) that cannot boot must cost its own tools, never the run: the
+// other backends already degrade per-server, and hard-failing the claw
+// splice let one token-less repo server kill every claw node of a run
+// (native:b2e46831 — the repo-scoped sentry server on runner pods).
+func TestBuildTaskAmbientMCPServerBootFailureDegradesNotFails(t *testing.T) {
+	tr := tool.NewRegistry()
+	for _, name := range []string{"bash", "todo_write"} {
+		if err := tr.RegisterBuiltin(name, name, nil, func(context.Context, json.RawMessage) (string, error) {
+			return "ok", nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	e := &ClawExecutor{
+		logger:       iterlog.Nop(),
+		toolRegistry: tr,
+		mcpManager: mcp.NewManager(map[string]*mcp.ServerConfig{
+			"deadsrv": {Command: "/nonexistent/iterion-test-mcp-server"},
+		}),
+	}
+	var degraded []MCPServerDegradedInfo
+	e.hooks.OnMCPServerDegraded = func(_ string, info MCPServerDegradedInfo) {
+		degraded = append(degraded, info)
+	}
+
+	node := &ir.AgentNode{BaseNode: ir.BaseNode{ID: "n"}, ActiveMCPServers: []string{"deadsrv"}}
+	f := backendFields{id: "n", model: "anthropic/claude-opus-5", tools: []string{"bash"}, activeMCPServers: []string{"deadsrv"}}
+
+	task, err := e.buildTask(context.Background(), node, f, map[string]any{}, delegate.BackendClaw, nil)
+	if err != nil {
+		t.Fatalf("an ambient server that cannot boot must not fail the node: %v", err)
+	}
+	names := make([]string, 0, len(task.ToolDefs))
+	for _, td := range task.ToolDefs {
+		names = append(names, td.Name)
+	}
+	if len(task.ToolDefs) == 0 {
+		t.Fatal("the node's own tools must survive the degraded server")
+	}
+	for _, n := range names {
+		if strings.HasPrefix(n, "mcp.deadsrv.") {
+			t.Fatalf("dead server's tools leaked into the task: %v", names)
+		}
+	}
+	if len(degraded) != 1 || degraded[0].Server != "deadsrv" || degraded[0].Source != "ambient" || degraded[0].Err == nil {
+		t.Fatalf("the drop must be observable via OnMCPServerDegraded: %+v", degraded)
 	}
 }

--- a/pkg/backend/model/hooks.go
+++ b/pkg/backend/model/hooks.go
@@ -976,6 +976,23 @@ func (h *storeHooks) onSessionDegraded(nodeID string, info SessionDegradedInfo) 
 		nodeID, info.BackendName, info.SessionID, info.Reason, errMsg)
 }
 
+// onMCPServerDegraded implements the OnMCPServerDegraded hook: it turns a
+// dropped ambient MCP server into a first-class store event.
+//
+// Warn-level: the node is about to run, but without the tools of a
+// server the environment (repo .mcp.json / plugin catalog) put in its
+// reach — the only other trace is a process log line.
+func (h *storeHooks) onMCPServerDegraded(nodeID string, info MCPServerDegradedInfo) {
+	data := map[string]any{
+		"server": info.Server,
+		"source": info.Source,
+	}
+	if info.Err != nil {
+		data["error"] = info.Err.Error()
+	}
+	h.emit(nodeID, store.EventMCPServerDegraded, data)
+}
+
 // onProviderFallback implements the OnProviderFallback hook: it turns a
 // chain fall-through into a first-class store event.
 //
@@ -1157,20 +1174,21 @@ func NewStoreEventHooks(ctx context.Context, emitter EventEmitter, runID string,
 		OnLLMRequest: h.onLLMRequest,
 		// OnLLMResponse is intentionally nil: response data surfaces through
 		// llm_step_finished events with richer per-step detail.
-		OnLLMRetry:         h.onLLMRetry,
-		OnLLMStepFinish:    h.onLLMStepFinish,
-		OnAssistantText:    h.onAssistantText,
-		OnUsageCap:         h.onUsageCap,
-		OnLLMTurnCapture:   h.onLLMTurnCapture,
-		OnLLMCompacted:     h.onLLMCompacted,
-		OnToolStarted:      h.onToolStarted,
-		OnToolCall:         h.onToolCall,
-		OnDelegateStarted:  h.onDelegateStarted,
-		OnDelegateFinished: h.onDelegateFinished,
-		OnDelegateError:    h.onDelegateError,
-		OnDelegateRetry:    h.onDelegateRetry,
-		OnProviderFallback: h.onProviderFallback,
-		OnSessionDegraded:  h.onSessionDegraded,
+		OnLLMRetry:          h.onLLMRetry,
+		OnLLMStepFinish:     h.onLLMStepFinish,
+		OnAssistantText:     h.onAssistantText,
+		OnUsageCap:          h.onUsageCap,
+		OnLLMTurnCapture:    h.onLLMTurnCapture,
+		OnLLMCompacted:      h.onLLMCompacted,
+		OnToolStarted:       h.onToolStarted,
+		OnToolCall:          h.onToolCall,
+		OnDelegateStarted:   h.onDelegateStarted,
+		OnDelegateFinished:  h.onDelegateFinished,
+		OnDelegateError:     h.onDelegateError,
+		OnDelegateRetry:     h.onDelegateRetry,
+		OnProviderFallback:  h.onProviderFallback,
+		OnSessionDegraded:   h.onSessionDegraded,
+		OnMCPServerDegraded: h.onMCPServerDegraded,
 		// OnToolNodeResult handles direct tool nodes with full I/O content.
 		OnToolNodeResult: h.onToolNodeResult,
 	}

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -447,6 +447,21 @@ const (
 	// Data keys: backend, session_id (the id that failed to serve),
 	// reason (delegate.FallbackCategory), error.
 	EventSessionDegraded EventType = "session_degraded"
+	// EventMCPServerDegraded records an AMBIENT MCP server (inherited from
+	// the target repo's .mcp.json or the plugin catalog — never named by
+	// the node) that failed to boot when the executor spliced the node's
+	// active servers into its tool set. The node runs on WITHOUT that
+	// server's tools instead of failing: the node never asked for it, and
+	// the other backends already degrade per-server (claude_code's CLI
+	// skips a server it cannot start; pi bounds each connect with a
+	// timeout) — failing the run here was a claw-path parity defect that
+	// let one unbootable repo server (e.g. a token-less sentry on a
+	// runner pod) kill every plan/review node. A server the node names
+	// EXPLICITLY (a concrete mcp.<server>.<tool> in tools:) still fails
+	// loud at resolution.
+	//
+	// Data keys: server, source ("ambient"), error.
+	EventMCPServerDegraded EventType = "mcp_server_degraded"
 	// EventSandboxBuildStarted fires when the engine calls
 	// [sandbox.Builder.Build] between Prepare and Start (V2-6, docker
 	// driver via `docker buildx build --load`). Data:


### PR DESCRIPTION
One unbootable repo-inherited MCP server killed every claw node of a run — `plan_review` died 3× on 2026-09-02 with `ensure MCP server "sentry" for wildcard: … EOF` (the repo-scoped sentry server of #596 cannot boot on runner pods, which carry no `SENTRY_ACCESS_TOKEN`), neutralising the zero-touch fixer lane. Card: `native:b2e46831`.

**Semantics** (backend parity): an AMBIENT server — inherited from the target repo's `.mcp.json` or the plugin catalog, never named by the node — that fails to boot now costs its own tools, never the run. claude_code (CLI skips unstartable servers) and pi (`ITERION_PI_MCP_CONNECT_TIMEOUT_MS`) already behaved this way; the claw in-process splice was the only hard-failing path. The drop is loud: Warn log + a first-class `mcp_server_degraded` event (server, source, error), mirroring `session_degraded`. An EXPLICIT `mcp.<server>.<tool>` on a dead server still fails the node at resolution — declared dependencies are never silently dropped.

Test drives the real `mcp.Manager` with an unbootable command through `buildTask`: node builds, native tools survive, hook fires, dead server's tools absent. The red canary is the production failure itself (identical error string on the old path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)