### PR TITLE
fix(review-pr): raise max_duration 45m → 90m

### DIFF
--- a/bots/review-pr/main.bot
+++ b/bots/review-pr/main.bot
@@ -1105,7 +1105,10 @@ workflow review_pr:
     ## Two read-only reviewer branches run in parallel; emit runs alone
     ## afterwards.
     max_parallel_branches: 2
-    max_duration: "45m"
+    ## The money guard is max_cost_usd; the duration cap only needs to
+    ## catch a hung run. 45m killed real reviews mid-publish (a forfait
+    ## retry or a big diff walks past it while spending nothing).
+    max_duration: "90m"
     max_cost_usd: 20
 
   ## EFFICIENCY: an empty review diff skips both LLM reviewers + emit.


### PR DESCRIPTION
Replaces #632 (which had inherited an unrelated commit from another session's local main — closed, that commit is untouched in its own checkout).

The duration cap protects no money (`max_cost_usd` does) — it only needs to catch a genuinely hung run. At 45m it killed real reviews mid-publish: on the 2026-09-02 pilot, round 7's `converge` node was refused at 92% of the duration axis after the review itself had completed, so the gate's verdict was never posted and had to be published by hand.

Change requested by @devthejo after that analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)