### PR TITLE
docs(rollout): server-first is the default because its park is replayable

### DIFF
--- a/docs/cloud-deployment.md
+++ b/docs/cloud-deployment.md
@@ -303,8 +303,12 @@ them:
 
 > **Schema bump?** If the deploy changes the queue wire version
 > (`pkg/queue/types.go` `SchemaVersion`), pod turnover is the *easy* half —
-> the mixed-version window also needs the drained-queue-or-DLQ-replay
-> procedure in [docs/cloud-queue-schema-rollout.md](cloud-queue-schema-rollout.md).
+> the mixed-version window is governed by
+> [docs/cloud-queue-schema-rollout.md](cloud-queue-schema-rollout.md). Read
+> its *Deploy ordering* section first: a bump that leaves `MinSchemaVersion`
+> alone is a runner-first rollout that rejects nothing and needs neither a
+> drained queue nor a DLQ replay; those two procedures are for a bump that
+> RAISES `MinSchemaVersion` past what is still queued.
 
 ### Generation-aware rollout
 

--- a/docs/cloud-deployment.md
+++ b/docs/cloud-deployment.md
@@ -305,10 +305,10 @@ them:
 > (`pkg/queue/types.go` `SchemaVersion`), pod turnover is the *easy* half —
 > the mixed-version window is governed by
 > [docs/cloud-queue-schema-rollout.md](cloud-queue-schema-rollout.md). Read
-> its *Deploy ordering* section first: a bump that leaves `MinSchemaVersion`
-> alone is a runner-first rollout that rejects nothing and needs neither a
-> drained queue nor a DLQ replay; those two procedures are for a bump that
-> RAISES `MinSchemaVersion` past what is still queued.
+> its *Deploy ordering* section first. The default is **server-first**, which
+> keeps any parked message on the replayable side; a bump that leaves
+> `MinSchemaVersion` alone additionally allows runner-first, which rejects
+> nothing and needs neither a drained queue nor a DLQ replay.
 
 ### Generation-aware rollout
 

--- a/docs/cloud-queue-schema-rollout.md
+++ b/docs/cloud-queue-schema-rollout.md
@@ -12,10 +12,14 @@ ordering alone is not sufficient (issue #481).
   `[MinSchemaVersion, SchemaVersion]` and rejects anything outside it in both
   directions. The current v12 consumer accepts v10/v11 backlog explicitly;
   this is not implicit forward compatibility.
-- **Server first.** Deploy the server (producer) before the runners. The new
-  server is the only side that can start emitting the new version; runners
-  that don't speak it yet hold those messages (see below) instead of
-  destroying them.
+- **Roll the permissive side first.** The server is the only side that can
+  start emitting the new version, so the fleet that must already tolerate it
+  is the runners: deploy them first whenever their window still covers what
+  the old server emits (`Min(new) <= Max(old)` — the ordinary case, and then
+  nothing is ever rejected). Only when a bump raises `MinSchemaVersion` past
+  the old server's version does the server go first, with runners that don't
+  speak it yet holding those messages (see below) instead of destroying them.
+  Full rule and the measured evidence: *Deploy ordering* below.
 - **Additive field whose omission changes operator intent = breaking
   change.** If a new field carries a decision the caller explicitly made
   (budget caps, skills, auto-memory, loop guard, model pins…), a stale runner
@@ -69,9 +73,11 @@ A v12 runner treats v10/v11 messages with no field as epoch 0.
 
 Do not combine the schema bump and first non-zero epoch:
 
-1. **Release A:** deploy v12 with `config.rollout.runnerEpoch: 0`, using Path
-   A (recommended) or Path B below. Verify all server and runner probes show
-   `epoch: 0`.
+1. **Release A:** deploy v12 with `config.rollout.runnerEpoch: 0`. v11 → v12
+   stays inside the compatibility window, so this is a runner-first rollout
+   and neither Path A nor Path B applies — see *Deploy ordering* below.
+   Verify all server and runner probes show `epoch: 0`. (Done in prod on
+   2026-09-02: runner fleet, then server, DLQ untouched throughout.)
 2. **Release B:** set the epoch to 1. New publishers stamp epoch 1. Old v12
    runners delayed-Nak those messages; new runners accept both epoch 0 and 1.
 

--- a/docs/cloud-queue-schema-rollout.md
+++ b/docs/cloud-queue-schema-rollout.md
@@ -5,12 +5,11 @@ How to ship a `queue.RunMessage` schema bump (`pkg/queue/types.go`,
 and without losing runs while the server and runner fleets run mixed
 versions. Read it before every schema bump.
 
-Ordering carries most of the weight, but you have to pick the right one:
-roll the **permissive** side first, and the drain/replay paths below are for
-the bump where no ordering can help. See *Deploy ordering* for the test.
-(Before #481 there was no compatibility window and no recoverable mismatch,
-so ordering alone genuinely was not sufficient — that is the era the
-drain/replay paths were written for.)
+This runbook is **mandatory** for every schema bump, and ordering is the first
+decision it makes for you: **server-first by default**, because that puts any
+parked message on the replayable side. Runner-first is an optimization with a
+precondition — see *Deploy ordering* — and the drain/replay paths below are
+what you fall back to when neither ordering can spare the queue.
 
 ## Wire compatibility policy
 
@@ -18,17 +17,14 @@ drain/replay paths were written for.)
   `[MinSchemaVersion, SchemaVersion]` and rejects anything outside it in both
   directions. The current v12 consumer accepts v10/v11 backlog explicitly;
   this is not implicit forward compatibility.
-- **Roll the permissive side first — after checking which side that is.** The
-  server is the only side that can start emitting the new version, so the fleet
-  that must already tolerate it is the runners, and they normally go first.
-  The test is `MinSchemaVersion(new runner)` against the **oldest version still
-  resident in the stream** — not against the old server's `SchemaVersion`, which
-  is only a proxy and breaks on the commonest bump shape (`Min` raised by one).
-  When `Min` rises above what is still queued, the server goes first instead and
-  the drain/replay paths apply, with runners that don't speak the new version
-  holding those messages (see below) rather than destroying them. Never assume
-  the direction: *Deploy ordering* below has the full rule, the history, and the
-  measured evidence.
+- **Server first by default.** Both orders can park a message; only one park is
+  replayable. Old runners rejecting the new version park messages a DLQ replay
+  fixes once the fleet is upgraded; new runners rejecting a version below their
+  `MinSchemaVersion` park messages a replay can never fix. Server-first keeps the
+  risk on the recoverable side, which is why it shipped WITH the window
+  (`bdafa72a0`) rather than before it. Roll the runners first only when nothing
+  below `Min(new)` can still be queued — the precondition, its check, and the
+  measured case are in *Deploy ordering* below.
 - **Additive field whose omission changes operator intent = breaking
   change.** If a new field carries a decision the caller explicitly made
   (budget caps, skills, auto-memory, loop guard, model pins…), a stale runner
@@ -83,10 +79,11 @@ A v12 runner treats v10/v11 messages with no field as epoch 0.
 Do not combine the schema bump and first non-zero epoch:
 
 1. **Release A:** deploy v12 with `config.rollout.runnerEpoch: 0`. v11 → v12
-   stays inside the compatibility window, so this is a runner-first rollout
-   and neither Path A nor Path B applies — see *Deploy ordering* below.
-   Verify all server and runner probes show `epoch: 0`. (Done in prod on
-   2026-09-02: runner fleet, then server, DLQ untouched throughout.)
+   leaves `MinSchemaVersion` at 10, so the runner-first precondition holds and
+   neither Path A nor Path B applies — see *Deploy ordering* below. Verify all
+   server and runner probes show `epoch: 0`. (Done in prod on 2026-09-02:
+   runner fleet, then server, DLQ untouched throughout — the measurement at
+   the end of *Deploy ordering*.)
 2. **Release B:** set the epoch to 1. New publishers stamp epoch 1. Old v12
    runners delayed-Nak those messages; new runners accept both epoch 0 and 1.
 
@@ -107,70 +104,65 @@ current high-water mark. Never restore a lower-epoch Helm revision directly.
 
 ## Deploy ordering: which side rolls first
 
-Ordering is decided by ONE question — **can the new runner still admit
-everything it may be handed?** Admission is decided per MESSAGE, against
-`env.V` ([pkg/runner/loop_nats.go](../pkg/runner/loop_nats.go)), with no
-notion of who published it, and the stream retains messages for `MaxAge`
-(default 24h). So the test is against the oldest version still **resident in
-the stream**, which is normally the old server's but is not the same thing:
+Both orders can park a message. They differ in **whether the park is
+recoverable**, and that — not "which side rejects less" — is what decides.
 
-    MinSchemaVersion(new runner) <= oldest V still queued
+| roll first | what gets rejected | recovery |
+|---|---|---|
+| **server** | old runners reject the new vN+1 | **replayable**: once every runner is new, `/api/admin/dlq/$SEQ/replay` re-publishes the same bytes and they are accepted |
+| **runners** | new runners reject anything still queued *below* `Min(new)` | **not replayable**: a replay re-publishes the same old bytes, the new fleet rejects them identically and re-parks (Path B step 5) — recovery is a per-run resume plus a DLQ delete |
 
-`SchemaVersion(old server)` is the right proxy whenever the queue holds
-nothing older than what that server emits — true after a quiet period, and
-true by construction when `MinSchemaVersion` is unchanged. It is **not** true
-for a bump that RAISES `MinSchemaVersion` less than `MaxAge` after the
-previous rollout: v11 messages published 20h ago are still resident, and a
-v13 runner with `Min` raised to 12 rejects them even though `12 <= 12` holds
-against the server. `MinSchemaVersion` has advanced before (it was 8 during
-v9), so check the queue rather than assume.
+Server-first is therefore the safe default, and deliberately so: it was
+authored together with the compatibility window (`bdafa72a0` adds both
+`MinSchemaVersion = 8` and the rule), not before it. The window did not make
+it obsolete — it put the parking risk on the side that can be undone.
 
-### Runner-first, when that holds
+**Runner-first is an optimization, valid under one condition:** that nothing
+below `Min(new runner)` can still be in the stream. Then new runners admit
+everything — including what the old server is still publishing — and *nothing
+is rejected in either direction*, so neither Path A nor Path B is needed.
 
-It holds when `MinSchemaVersion` is unchanged, and when it rises no higher
-than the oldest version still queued. **Do not assume it — check.** History
-says the check matters: since the window shipped, `MinSchemaVersion` went 8
-(v9) → 9 (v10) → 10 (v11) and only stayed put at v12. Three of four bumps
-raised it, each by exactly one, i.e. to equal the *previous* `SchemaVersion` —
-the shape that passes a naive "`Min(new) <= Max(old server)`" test while still
-rejecting anything one version older left in the stream.
+### Deciding which you are in
 
-When the check passes, roll the **runners first**:
+`MinSchemaVersion` unchanged by the bump ⇒ runner-first is safe with no
+further check: the new window is a superset of the old one, so no resident
+message can fall below it.
 
-- new runners accept `[Min(new) … Max(new)]`, so the old server's vN messages
-  are still admitted — the "reverse case" of Path B step 5 cannot arise;
-- the old runners never see a vN+1 message, because the server is still
-  publishing vN;
-- then roll the server. Every runner already accepts vN+1.
+`MinSchemaVersion` raised ⇒ **check the queue**, or take server-first. A
+raised `Min` is the common shape, not the exception:
 
-Nothing is rejected in either direction, so no maintenance window and no DLQ
-replay are needed — Path A and Path B both become unnecessary.
+    8 (v9) → 9 (v10) → 10 (v11) → 10 (v12)
 
-Doing it the other way round turns that certainty into a race: a vN+1 server
-publishing into a vN-only fleet gets every delivery delayed-Naked until a
-new-version runner is Ready. With the chart's `maxSurge: 100%` /
-`maxUnavailable: 0` that is usually early in the roll — the 30s delay exists
-precisely to stretch the 8-delivery budget over ~4 minutes and cover a
-rolling restart (see *What a mixed fleet does* above, and the constant's own
-justification in [pkg/queue/nats/nats.go](../pkg/queue/nats/nats.go)). What
-matters is time-to-first-Ready-new-runner, not the full roll, which under
-`drainMode: complete` can take hours. A fleet whose new pods are slow to
-become Ready spends the budget and parks the run `failed_resumable`.
-Runner-first removes that race instead of timing it.
+Three of the four bumps since the window shipped raised it, each by exactly
+one. That shape is a trap for the naive test `Min(new) <= SchemaVersion(old
+server)`: it passes, while a message *one version older* still queued is
+rejected — unrecoverably.
 
-### Server-first, when it does not
+What "still in the stream" means here is narrower than it sounds. The runs
+stream is created with `Retention: WorkQueuePolicy`
+([pkg/queue/nats/nats.go](../pkg/queue/nats/nats.go)), so an ACKed message is
+removed immediately; `MaxAge` (24h) bounds only how long an **unacked** one
+may linger. Residue is therefore not "everything published in the last 24h" —
+it is what is still pending or still being redelivered: a run whose deliveries
+are bouncing, or a backlog the fleet has not reached. `iterion_nats_pending_messages`
+= 0 is the clean signal; a non-zero pending count on a `Min`-raising bump is
+the case to take seriously.
 
-If `MinSchemaVersion(new)` rises **above the oldest version still resident in
-the stream**, new runners would reject that backlog. Ordering cannot save it in
-either direction: deploy the server first and follow Path A (drain) or Path B
-(DLQ replay) below.
+### The cost of server-first, stated honestly
 
-Note the predicate is the resident one, not `Min(new) > SchemaVersion(old
-server)`. Those differ exactly in the historically common shape — `Min` raised
-by one, to equal the old server's version — where the server test says "safe,
-skip both paths" while a message one version older is still in the stream
-waiting to be parked unreplayably. When in doubt, drain (Path A): it is the
-only branch that does not depend on knowing what is queued.
+A vN+1 server publishing into a vN-only fleet gets every delivery
+delayed-Naked until a new-version runner is Ready. That is a race, not a
+certainty of loss: the 30s delay exists precisely to stretch the 8-delivery
+budget over ~4 minutes and cover a rolling restart (see *What a mixed fleet
+does* above and the constant's own justification), and under the chart's
+`maxSurge: 100%` / `maxUnavailable: 0` the first new runner is usually Ready
+early in the roll. What races the budget is time-to-first-Ready-new-runner,
+not the full roll — which under `drainMode: complete` can take hours.
+
+A fleet slow to become Ready spends the budget and parks the run
+`failed_resumable` — replayably. Runner-first removes that race; it is worth
+taking **when the condition above holds**, and it is what the v11 → v12
+cutover used (see the measurement below).
 
 ### Sequencing the two Deployments
 
@@ -188,8 +180,8 @@ helm upgrade iterion ./charts/iterion \
 helm upgrade iterion ./charts/iterion --set image.tag=<new-tag>
 ```
 
-**The snippet above is the runner-first order — do not copy it verbatim for
-Path A or Path B below.** Those are the server-first case; it is a different
+**The snippet above is the runner-first order — the optimization, not the
+default.** Path A and Path B below are server-first, and that is a different
 command, not a swap of the two values (`image.tag` takes a tag,
 `runner.image` a full reference, so exchanging them renders an invalid image):
 
@@ -218,8 +210,15 @@ overrides `iterion.image` for the runner container, so phase 1's
 advance it rather than rely on the shared tag.
 
 If your deploy pipeline sequences Deployments itself, use it instead — the
-requirement is only that the side which must be permissive is Ready before the
-side which changes what it emits.
+requirement is only that the two Deployments do not roll together.
+
+**Both snippets sequence the IMAGE only.** A release that also moves
+`config.rollout.runnerEpoch` does not get sequenced by them: that is a single
+value rendered as a literal `ITERION_RUNNER_EPOCH` into BOTH PodTemplates
+(server-deployment.yaml and runner-deployment.yaml), so phase 1 rolls both
+Deployments. Move the epoch in its own release — which is what the two-release
+Release A / Release B protocol above already prescribes — not in the same one
+as a schema bump.
 
 > Measured on the v11 → v12 cutover (2026-09-02, prod: 12 runner pods, 3 server
 > pods, live traffic including a run executing across the runner roll).
@@ -229,15 +228,17 @@ side which changes what it emits.
 
 ## Rollout procedure for a schema bump vN → vN+1
 
-These two paths are for the **server-first** case only — a bump that raises
-`MinSchemaVersion` past the old server's version. When the compatibility
-window still covers the old wire (the ordinary case), roll runner-first per
-the section above and neither path applies: nothing is ever rejected, so
-there is nothing to drain or replay.
+These two paths accompany the **server-first** default. Choose **one** of
+them: ordering alone is not a third option, because a server-first roll still
+parks the new version on the old fleet if no upgraded runner becomes Ready
+inside the delivery budget — Path A avoids that by draining first, Path B
+accepts it and replays afterwards.
 
-Within the server-first case, choose **one** of the two. Ordering alone is
-not a third option there: it leaves the reverse case — vN+1 runners rejecting
-vN messages still in the queue — to chance.
+They are unnecessary **only** when the runner-first precondition holds —
+nothing below `Min(new runner)` can still be queued, which is automatic when
+the bump leaves `MinSchemaVersion` alone. Then nothing is rejected in either
+direction and there is nothing to drain or replay. See *Deploy ordering*
+above; do not infer that case from the old server's version alone.
 
 ### Path A — drained queue before cutover
 
@@ -251,9 +252,10 @@ later bump as well.
 3. Deploy the server (vN+1), then roll the runners (vN+1) — the **SERVER-FIRST
    snippet** above, not the runner-first one. (If step 1 held a real
    maintenance window and step 2 reached zero, ordering is moot here: nothing
-   is left for either side to reject. It is not moot when step 1 was skipped
-   and launches continued, which the step explicitly allows — so follow the
-   order regardless.)
+   is left for either side to reject — and a drained queue is exactly the
+   precondition that also makes runner-first safe, so either order works. It is
+   not moot when step 1 was skipped and launches continued, which the step
+   explicitly allows — so follow the order regardless.)
 4. Sanity-check: one launch end-to-end, DLQ depth 0.
 
 ### Path B — DLQ identification + replay after cutover

--- a/docs/cloud-queue-schema-rollout.md
+++ b/docs/cloud-queue-schema-rollout.md
@@ -3,8 +3,14 @@
 How to ship a `queue.RunMessage` schema bump (`pkg/queue/types.go`,
 `SchemaVersion`) without executing a payload with silently dropped semantics,
 and without losing runs while the server and runner fleets run mixed
-versions. This runbook is **mandatory** for every schema bump — deployment
-ordering alone is not sufficient (issue #481).
+versions. Read it before every schema bump.
+
+Ordering carries most of the weight, but you have to pick the right one:
+roll the **permissive** side first, and the drain/replay paths below are for
+the bump where no ordering can help. See *Deploy ordering* for the test.
+(Before #481 there was no compatibility window and no recoverable mismatch,
+so ordering alone genuinely was not sufficient — that is the era the
+drain/replay paths were written for.)
 
 ## Wire compatibility policy
 
@@ -167,12 +173,30 @@ helm upgrade iterion ./charts/iterion --set image.tag=<new-tag>
 ```
 
 **The snippet above is the runner-first order — do not copy it verbatim for
-Path A or Path B below.** Both are the server-first case and need the two
-`--set` values swapped (server on `<new-tag>`, `runner.image` held on the old
-one in phase 1). Getting that backwards on Path B is the destructive
-direction: it rolls the runners into a queue full of vN messages they reject,
-and per Path B step 5 those parked messages are **unreplayable** — recovery
-is a per-run resume plus a DLQ delete.
+Path A or Path B below.** Those are the server-first case; it is a different
+command, not a swap of the two values (`image.tag` takes a tag,
+`runner.image` a full reference, so exchanging them renders an invalid image):
+
+```bash
+# SERVER-FIRST — Path A step 3 and Path B step 1 only.
+# Phase 1 — roll the server, holding the runners on the OLD image.
+helm upgrade iterion ./charts/iterion \
+  --set image.tag=<new-tag> \
+  --set runner.image=ghcr.io/socialgouv/iterion:<old-tag>
+
+# Phase 2 — once the server is Ready on <new-tag>, release the runners.
+helm upgrade iterion ./charts/iterion --set image.tag=<new-tag>
+```
+
+Getting that backwards on Path B is the destructive direction: it rolls the
+runners into a queue full of vN messages they reject, and per Path B step 5
+those parked messages are **unreplayable** — recovery is a per-run resume
+plus a DLQ delete.
+
+Both snippets assume `image.digest` is unset. A values-pinned digest **wins
+over `image.tag`**, so these `--set image.tag=` phases become silent no-ops;
+pin the phase's digest instead (see
+[cloud-deployment.md](cloud-deployment.md#pinning-the-image)).
 
 If your deploy pipeline sequences Deployments itself, use it instead — the
 requirement is only that the side which must be permissive is Ready before the
@@ -205,12 +229,12 @@ later bump as well.
    window follow Path B — which, for v7 → v8, they cannot: keep the window.
 2. Wait for the queue to drain: `iterion_nats_pending_messages` = 0 and no
    `queued` runs older than the AckWait window.
-3. Deploy the server (vN+1), then roll the runners (vN+1) — the two-phase
-   chart upgrade above **with its two `--set` values swapped**, since that
-   snippet is written runner-first. (Once step 2 has drained the queue to
-   zero, ordering is in fact moot — nothing is left for either side to
-   reject. Keep the server-first order anyway so the step reads the same in
-   both paths.)
+3. Deploy the server (vN+1), then roll the runners (vN+1) — the **SERVER-FIRST
+   snippet** above, not the runner-first one. (If step 1 held a real
+   maintenance window and step 2 reached zero, ordering is moot here: nothing
+   is left for either side to reject. It is not moot when step 1 was skipped
+   and launches continued, which the step explicitly allows — so follow the
+   order regardless.)
 4. Sanity-check: one launch end-to-end, DLQ depth 0.
 
 ### Path B — DLQ identification + replay after cutover
@@ -222,11 +246,10 @@ v7 → v8 cutover itself the outgoing runners are pre-#481 builds: they bare-
 empty DLQ and a run stuck `queued` — the exact loss #481 closes. **Do not
 run Path B for v7 → v8; use Path A.**
 
-1. Deploy the server (vN+1) first, then roll the runners — the two-phase
-   upgrade above **with its two `--set` values swapped**, since that snippet
-   is written runner-first and this path is the one where the wrong order
-   parks messages that step 5 cannot replay. During the window, stale runners
-   hold vN+1 messages via delayed
+1. Deploy the server (vN+1) first, then roll the runners — the **SERVER-FIRST
+   snippet** above, not the runner-first one. This is the path where the wrong
+   order parks messages that step 5 cannot replay. During the window, stale
+   runners hold vN+1 messages via delayed
    Naks; after MaxDeliver they park them on the DLQ and flip the runs to
    `failed_resumable`.
 2. Once **all** runners run vN+1, list the DLQ and identify the parked

--- a/docs/cloud-queue-schema-rollout.md
+++ b/docs/cloud-queue-schema-rollout.md
@@ -90,33 +90,79 @@ current high-water mark. Never restore a lower-epoch Helm revision directly.
 > burns the MaxDeliver budget in seconds, JetStream drops the message, and
 > nothing is parked to replay. That asymmetry drives the path choice below.
 
-## Server-first ordering with the shipped chart
+## Deploy ordering: which side rolls first
 
-Every procedure below hinges on deploying the server (producer) before the
-runners. A plain `helm upgrade` does NOT give you that ordering: the server
-and runner Deployments both resolve to the same image tag
-(`include "iterion.image" .`), so they roll together. Use the chart's
-per-runner image override to sequence the two phases:
+Ordering is decided by ONE question — **does the new runner's accepted window
+still cover what the old server publishes?** In symbols, comparing the two
+builds you are moving between:
+
+    MinSchemaVersion(new runner) <= SchemaVersion(old server)
+
+### Runner-first, when that holds
+
+It holds for any bump that stays inside the compatibility window, which is the
+ordinary case since #481 introduced one (`MinSchemaVersion` 10 has trailed
+`SchemaVersion` by several versions ever since). Roll the **runners first**:
+
+- new runners accept `[Min(new) … Max(new)]`, so the old server's vN messages
+  are still admitted — the "reverse case" of Path B step 5 cannot arise;
+- the old runners never see a vN+1 message, because the server is still
+  publishing vN;
+- then roll the server. Every runner already accepts vN+1.
+
+The rejection window is **zero**, so no maintenance window and no DLQ replay
+are needed — Path A and Path B both become unnecessary.
+
+Doing it the other way round is what costs: a vN+1 server publishing into a
+vN-only fleet gets every delivery delayed-Naked, and a run is parked
+`failed_resumable` once MaxDeliver is spent — ~4 minutes at the defaults
+(8 × 30s), typically less than a full runner Deployment roll.
+
+### Server-first, when it does not
+
+If a bump raises `MinSchemaVersion` past the old server's `SchemaVersion`, new
+runners would reject the vN messages still in the queue. Ordering cannot save
+that case in either direction: deploy the server first and follow Path A
+(drain) or Path B (DLQ replay) below.
+
+### Sequencing the two Deployments
+
+A plain `helm upgrade` rolls both together: the server and runner Deployments
+resolve to the same image tag (`include "iterion.image" .`). Use the chart's
+per-runner image override to sequence the phases — here in runner-first order:
 
 ```bash
-# Phase 1 — pin the runners to the CURRENT (old) image, roll the server only.
+# Phase 1 — pin the runners to the NEW image, leaving the server on the old tag.
 helm upgrade iterion ./charts/iterion \
-  --set image.tag=<new-tag> \
-  --set runner.image=ghcr.io/socialgouv/iterion:<old-tag>
+  --set image.tag=<old-tag> \
+  --set runner.image=ghcr.io/socialgouv/iterion:<new-tag>
 
-# Phase 2 — once the server runs <new-tag>, unpin and roll the runners.
+# Phase 2 — once every runner is Ready on <new-tag>, roll the server.
 helm upgrade iterion ./charts/iterion --set image.tag=<new-tag>
 ```
 
-(If your deploy pipeline sequences Deployments itself, use it instead — the
-requirement is only that no vN+1 message is published before the procedure
-below is chosen and running.)
+Swap the two `--set` values for the server-first case. If your deploy pipeline
+sequences Deployments itself, use it instead — the requirement is only that the
+side which must be permissive is Ready before the side which changes what it
+emits.
+
+> Measured on the v11 → v12 cutover (2026-09-02, prod: 12 runner pods, 3 server
+> pods, live traffic including a run executing across the runner roll).
+> Runner-first left the DLQ byte-identical — depth 30, `last_seq` 220, newest
+> message hours older than the rollout — with no
+> `iterion_runner_admission_rejected_total` sample anywhere in the fleet.
 
 ## Rollout procedure for a schema bump vN → vN+1
 
-Choose **one** of the two paths below. Deployment ordering alone (server
-first) is NOT a third option: it leaves the reverse case — vN+1 runners
-rejecting vN messages still in the queue — to chance.
+These two paths are for the **server-first** case only — a bump that raises
+`MinSchemaVersion` past the old server's version. When the compatibility
+window still covers the old wire (the ordinary case), roll runner-first per
+the section above and neither path applies: nothing is ever rejected, so
+there is nothing to drain or replay.
+
+Within the server-first case, choose **one** of the two. Ordering alone is
+not a third option there: it leaves the reverse case — vN+1 runners rejecting
+vN messages still in the queue — to chance.
 
 ### Path A — drained queue before cutover
 

--- a/docs/cloud-queue-schema-rollout.md
+++ b/docs/cloud-queue-schema-rollout.md
@@ -21,10 +21,10 @@ what you fall back to when neither ordering can spare the queue.
   replayable. Old runners rejecting the new version park messages a DLQ replay
   fixes once the fleet is upgraded; new runners rejecting a version below their
   `MinSchemaVersion` park messages a replay can never fix. Server-first keeps the
-  risk on the recoverable side, which is why it shipped WITH the window
-  (`bdafa72a0`) rather than before it. Roll the runners first only when nothing
-  below `Min(new)` can still be queued — the precondition, its check, and the
-  measured case are in *Deploy ordering* below.
+  risk on the recoverable side. Roll the runners first only when nothing below
+  `Min(new)` can still be queued — automatic when the bump leaves
+  `MinSchemaVersion` alone, and otherwise not worth asserting from a gauge. The
+  precondition and the measured case are in *Deploy ordering* below.
 - **Additive field whose omission changes operator intent = breaking
   change.** If a new field carries a decision the caller explicitly made
   (budget caps, skills, auto-memory, loop guard, model pins…), a stale runner
@@ -113,9 +113,9 @@ recoverable**, and that — not "which side rejects less" — is what decides.
 | **runners** | new runners reject anything still queued *below* `Min(new)` | **not replayable**: a replay re-publishes the same old bytes, the new fleet rejects them identically and re-parks (Path B step 5) — recovery is a per-run resume plus a DLQ delete |
 
 Server-first is therefore the safe default, and deliberately so: it was
-authored together with the compatibility window (`bdafa72a0` adds both
-`MinSchemaVersion = 8` and the rule), not before it. The window did not make
-it obsolete — it put the parking risk on the side that can be undone.
+not for historical reasons: it puts the parking risk on the side that can be
+undone. The compatibility window narrowed *when* a mismatch happens; it did
+not change which mismatch is recoverable.
 
 **Runner-first is an optimization, valid under one condition:** that nothing
 below `Min(new runner)` can still be in the stream. Then new runners admit
@@ -128,25 +128,33 @@ is rejected in either direction*, so neither Path A nor Path B is needed.
 further check: the new window is a superset of the old one, so no resident
 message can fall below it.
 
-`MinSchemaVersion` raised ⇒ **check the queue**, or take server-first. A
-raised `Min` is the common shape, not the exception:
+`MinSchemaVersion` raised ⇒ **do not attempt runner-first on an observation.**
+Take server-first, or drain first (Path A) — draining *makes* the queue empty
+instead of trying to prove that it is, which is the only form of the check
+worth trusting when the failure is unrecoverable.
 
-    8 (v9) → 9 (v10) → 10 (v11) → 10 (v12)
+`iterion_nats_pending_messages` looks like the oracle and is not: `pollPending`
+leaves the gauge at its last successful value when the poll errors, warning
+only after five consecutive failures ([pkg/runner/loop_nats.go](../pkg/runner/loop_nats.go)),
+so a queue that filled while polling was broken still reads 0 — stale in
+exactly the dangerous direction.
 
-Three of the four bumps since the window shipped raised it, each by exactly
-one. That shape is a trap for the naive test `Min(new) <= SchemaVersion(old
-server)`: it passes, while a message *one version older* still queued is
-rejected — unrecoverably.
+`Min` does move. Across the versions that have one:
 
-What "still in the stream" means here is narrower than it sounds. The runs
-stream is created with `Retention: WorkQueuePolicy`
+    v9: 8 → v10: 9 → v11: 10 → v12: 10
+
+two of the three transitions raised it, each by exactly one — to equal the
+*previous* `SchemaVersion`. That is the shape that fools the naive test
+`Min(new) <= SchemaVersion(old server)`: it passes, while a message one
+version older still queued is rejected unrecoverably.
+
+For what it is worth, "still in the stream" is narrower than it sounds: the
+runs stream is `Retention: WorkQueuePolicy`
 ([pkg/queue/nats/nats.go](../pkg/queue/nats/nats.go)), so an ACKed message is
-removed immediately; `MaxAge` (24h) bounds only how long an **unacked** one
-may linger. Residue is therefore not "everything published in the last 24h" —
-it is what is still pending or still being redelivered: a run whose deliveries
-are bouncing, or a backlog the fleet has not reached. `iterion_nats_pending_messages`
-= 0 is the clean signal; a non-zero pending count on a `Min`-raising bump is
-the case to take seriously.
+removed immediately and `MaxAge` (24h) bounds only how long an **unacked** one
+lingers. Residue is what is pending or still being redelivered, not everything
+published in the last day. That makes the residue small — it does not make it
+observable.
 
 ### The cost of server-first, stated honestly
 
@@ -234,11 +242,12 @@ parks the new version on the old fleet if no upgraded runner becomes Ready
 inside the delivery budget — Path A avoids that by draining first, Path B
 accepts it and replays afterwards.
 
-They are unnecessary **only** when the runner-first precondition holds —
+Both become unnecessary **only** when the runner-first precondition holds —
 nothing below `Min(new runner)` can still be queued, which is automatic when
 the bump leaves `MinSchemaVersion` alone. Then nothing is rejected in either
-direction and there is nothing to drain or replay. See *Deploy ordering*
-above; do not infer that case from the old server's version alone.
+direction, so there is nothing to drain or replay. See *Deploy ordering*
+above; do not infer that case from the old server's version alone. Path A's
+"recommended default" below is scoped to the bumps that still need a path.
 
 ### Path A — drained queue before cutover
 

--- a/docs/cloud-queue-schema-rollout.md
+++ b/docs/cloud-queue-schema-rollout.md
@@ -18,14 +18,17 @@ drain/replay paths were written for.)
   `[MinSchemaVersion, SchemaVersion]` and rejects anything outside it in both
   directions. The current v12 consumer accepts v10/v11 backlog explicitly;
   this is not implicit forward compatibility.
-- **Roll the permissive side first.** The server is the only side that can
-  start emitting the new version, so the fleet that must already tolerate it
-  is the runners: deploy them first whenever their window still covers what
-  the old server emits (`Min(new) <= Max(old)` — the ordinary case, and then
-  nothing is ever rejected). Only when a bump raises `MinSchemaVersion` past
-  the old server's version does the server go first, with runners that don't
-  speak it yet holding those messages (see below) instead of destroying them.
-  Full rule and the measured evidence: *Deploy ordering* below.
+- **Roll the permissive side first — after checking which side that is.** The
+  server is the only side that can start emitting the new version, so the fleet
+  that must already tolerate it is the runners, and they normally go first.
+  The test is `MinSchemaVersion(new runner)` against the **oldest version still
+  resident in the stream** — not against the old server's `SchemaVersion`, which
+  is only a proxy and breaks on the commonest bump shape (`Min` raised by one).
+  When `Min` rises above what is still queued, the server goes first instead and
+  the drain/replay paths apply, with runners that don't speak the new version
+  holding those messages (see below) rather than destroying them. Never assume
+  the direction: *Deploy ordering* below has the full rule, the history, and the
+  measured evidence.
 - **Additive field whose omission changes operator intent = breaking
   change.** If a new field carries a decision the caller explicitly made
   (budget caps, skills, auto-memory, loop guard, model pins…), a stale runner
@@ -124,9 +127,15 @@ v9), so check the queue rather than assume.
 
 ### Runner-first, when that holds
 
-It holds for any bump that leaves `MinSchemaVersion` alone — the ordinary
-case since #481 introduced a window (`MinSchemaVersion` 10 has trailed
-`SchemaVersion` by several versions ever since). Roll the **runners first**:
+It holds when `MinSchemaVersion` is unchanged, and when it rises no higher
+than the oldest version still queued. **Do not assume it — check.** History
+says the check matters: since the window shipped, `MinSchemaVersion` went 8
+(v9) → 9 (v10) → 10 (v11) and only stayed put at v12. Three of four bumps
+raised it, each by exactly one, i.e. to equal the *previous* `SchemaVersion` —
+the shape that passes a naive "`Min(new) <= Max(old server)`" test while still
+rejecting anything one version older left in the stream.
+
+When the check passes, roll the **runners first**:
 
 - new runners accept `[Min(new) … Max(new)]`, so the old server's vN messages
   are still admitted — the "reverse case" of Path B step 5 cannot arise;
@@ -151,10 +160,17 @@ Runner-first removes that race instead of timing it.
 
 ### Server-first, when it does not
 
-If a bump raises `MinSchemaVersion` past the old server's `SchemaVersion`, new
-runners would reject the vN messages still in the queue. Ordering cannot save
-that case in either direction: deploy the server first and follow Path A
-(drain) or Path B (DLQ replay) below.
+If `MinSchemaVersion(new)` rises **above the oldest version still resident in
+the stream**, new runners would reject that backlog. Ordering cannot save it in
+either direction: deploy the server first and follow Path A (drain) or Path B
+(DLQ replay) below.
+
+Note the predicate is the resident one, not `Min(new) > SchemaVersion(old
+server)`. Those differ exactly in the historically common shape — `Min` raised
+by one, to equal the old server's version — where the server test says "safe,
+skip both paths" while a message one version older is still in the stream
+waiting to be parked unreplayably. When in doubt, drain (Path A): it is the
+only branch that does not depend on knowing what is queued.
 
 ### Sequencing the two Deployments
 
@@ -193,10 +209,13 @@ runners into a queue full of vN messages they reject, and per Path B step 5
 those parked messages are **unreplayable** — recovery is a per-run resume
 plus a DLQ delete.
 
-Both snippets assume `image.digest` is unset. A values-pinned digest **wins
-over `image.tag`**, so these `--set image.tag=` phases become silent no-ops;
-pin the phase's digest instead (see
-[cloud-deployment.md](cloud-deployment.md#pinning-the-image)).
+Both snippets assume the install moves its image via `image.tag`. If your
+values pin the image some other way, `--set image.tag=` may not move it at
+all — check that the rendered PodTemplate actually changed before treating a
+phase as done. Note `runner.image`, when set in a values file, already
+overrides `iterion.image` for the runner container, so phase 1's
+`--set runner.image=` must name a full reference and phase 2 must clear or
+advance it rather than rely on the shared tag.
 
 If your deploy pipeline sequences Deployments itself, use it instead — the
 requirement is only that the side which must be permissive is Ready before the

--- a/docs/cloud-queue-schema-rollout.md
+++ b/docs/cloud-queue-schema-rollout.md
@@ -98,16 +98,28 @@ current high-water mark. Never restore a lower-epoch Helm revision directly.
 
 ## Deploy ordering: which side rolls first
 
-Ordering is decided by ONE question — **does the new runner's accepted window
-still cover what the old server publishes?** In symbols, comparing the two
-builds you are moving between:
+Ordering is decided by ONE question — **can the new runner still admit
+everything it may be handed?** Admission is decided per MESSAGE, against
+`env.V` ([pkg/runner/loop_nats.go](../pkg/runner/loop_nats.go)), with no
+notion of who published it, and the stream retains messages for `MaxAge`
+(default 24h). So the test is against the oldest version still **resident in
+the stream**, which is normally the old server's but is not the same thing:
 
-    MinSchemaVersion(new runner) <= SchemaVersion(old server)
+    MinSchemaVersion(new runner) <= oldest V still queued
+
+`SchemaVersion(old server)` is the right proxy whenever the queue holds
+nothing older than what that server emits — true after a quiet period, and
+true by construction when `MinSchemaVersion` is unchanged. It is **not** true
+for a bump that RAISES `MinSchemaVersion` less than `MaxAge` after the
+previous rollout: v11 messages published 20h ago are still resident, and a
+v13 runner with `Min` raised to 12 rejects them even though `12 <= 12` holds
+against the server. `MinSchemaVersion` has advanced before (it was 8 during
+v9), so check the queue rather than assume.
 
 ### Runner-first, when that holds
 
-It holds for any bump that stays inside the compatibility window, which is the
-ordinary case since #481 introduced one (`MinSchemaVersion` 10 has trailed
+It holds for any bump that leaves `MinSchemaVersion` alone — the ordinary
+case since #481 introduced a window (`MinSchemaVersion` 10 has trailed
 `SchemaVersion` by several versions ever since). Roll the **runners first**:
 
 - new runners accept `[Min(new) … Max(new)]`, so the old server's vN messages
@@ -116,13 +128,20 @@ ordinary case since #481 introduced one (`MinSchemaVersion` 10 has trailed
   publishing vN;
 - then roll the server. Every runner already accepts vN+1.
 
-The rejection window is **zero**, so no maintenance window and no DLQ replay
-are needed — Path A and Path B both become unnecessary.
+Nothing is rejected in either direction, so no maintenance window and no DLQ
+replay are needed — Path A and Path B both become unnecessary.
 
-Doing it the other way round is what costs: a vN+1 server publishing into a
-vN-only fleet gets every delivery delayed-Naked, and a run is parked
-`failed_resumable` once MaxDeliver is spent — ~4 minutes at the defaults
-(8 × 30s), typically less than a full runner Deployment roll.
+Doing it the other way round turns that certainty into a race: a vN+1 server
+publishing into a vN-only fleet gets every delivery delayed-Naked until a
+new-version runner is Ready. With the chart's `maxSurge: 100%` /
+`maxUnavailable: 0` that is usually early in the roll — the 30s delay exists
+precisely to stretch the 8-delivery budget over ~4 minutes and cover a
+rolling restart (see *What a mixed fleet does* above, and the constant's own
+justification in [pkg/queue/nats/nats.go](../pkg/queue/nats/nats.go)). What
+matters is time-to-first-Ready-new-runner, not the full roll, which under
+`drainMode: complete` can take hours. A fleet whose new pods are slow to
+become Ready spends the budget and parks the run `failed_resumable`.
+Runner-first removes that race instead of timing it.
 
 ### Server-first, when it does not
 
@@ -147,10 +166,17 @@ helm upgrade iterion ./charts/iterion \
 helm upgrade iterion ./charts/iterion --set image.tag=<new-tag>
 ```
 
-Swap the two `--set` values for the server-first case. If your deploy pipeline
-sequences Deployments itself, use it instead — the requirement is only that the
-side which must be permissive is Ready before the side which changes what it
-emits.
+**The snippet above is the runner-first order — do not copy it verbatim for
+Path A or Path B below.** Both are the server-first case and need the two
+`--set` values swapped (server on `<new-tag>`, `runner.image` held on the old
+one in phase 1). Getting that backwards on Path B is the destructive
+direction: it rolls the runners into a queue full of vN messages they reject,
+and per Path B step 5 those parked messages are **unreplayable** — recovery
+is a per-run resume plus a DLQ delete.
+
+If your deploy pipeline sequences Deployments itself, use it instead — the
+requirement is only that the side which must be permissive is Ready before the
+side which changes what it emits.
 
 > Measured on the v11 → v12 cutover (2026-09-02, prod: 12 runner pods, 3 server
 > pods, live traffic including a run executing across the runner roll).
@@ -179,8 +205,12 @@ later bump as well.
    window follow Path B — which, for v7 → v8, they cannot: keep the window.
 2. Wait for the queue to drain: `iterion_nats_pending_messages` = 0 and no
    `queued` runs older than the AckWait window.
-3. Deploy the server (vN+1), then roll the runners (vN+1) — per the
-   two-phase chart upgrade above.
+3. Deploy the server (vN+1), then roll the runners (vN+1) — the two-phase
+   chart upgrade above **with its two `--set` values swapped**, since that
+   snippet is written runner-first. (Once step 2 has drained the queue to
+   zero, ordering is in fact moot — nothing is left for either side to
+   reject. Keep the server-first order anyway so the step reads the same in
+   both paths.)
 4. Sanity-check: one launch end-to-end, DLQ depth 0.
 
 ### Path B — DLQ identification + replay after cutover
@@ -192,8 +222,11 @@ v7 → v8 cutover itself the outgoing runners are pre-#481 builds: they bare-
 empty DLQ and a run stuck `queued` — the exact loss #481 closes. **Do not
 run Path B for v7 → v8; use Path A.**
 
-1. Deploy the server (vN+1) first, then roll the runners (two-phase upgrade
-   above). During the window, stale runners hold vN+1 messages via delayed
+1. Deploy the server (vN+1) first, then roll the runners — the two-phase
+   upgrade above **with its two `--set` values swapped**, since that snippet
+   is written runner-first and this path is the one where the wrong order
+   parks messages that step 5 cannot replay. During the window, stale runners
+   hold vN+1 messages via delayed
    Naks; after MaxDeliver they park them on the DLQ and flip the runs to
    `failed_resumable`.
 2. Once **all** runners run vN+1, list the DLQ and identify the parked

--- a/docs/cloud-queue-schema-rollout.md
+++ b/docs/cloud-queue-schema-rollout.md
@@ -79,11 +79,13 @@ A v12 runner treats v10/v11 messages with no field as epoch 0.
 Do not combine the schema bump and first non-zero epoch:
 
 1. **Release A:** deploy v12 with `config.rollout.runnerEpoch: 0`. v11 → v12
-   leaves `MinSchemaVersion` at 10, so the runner-first precondition holds and
-   neither Path A nor Path B applies — see *Deploy ordering* below. Verify all
-   server and runner probes show `epoch: 0`. (Done in prod on 2026-09-02:
-   runner fleet, then server, DLQ untouched throughout — the measurement at
-   the end of *Deploy ordering*.)
+   leaves `MinSchemaVersion` at 10, so the runner-first precondition holds:
+   roll the **runners, then the server**, and neither Path A nor Path B is
+   needed — see *Deploy ordering* below. (Rolling server-first here is also
+   correct; the paths are only dispensable if you actually take the
+   runner-first order.) Verify all server and runner probes show `epoch: 0`.
+   (Done in prod on 2026-09-02 exactly that way: runner fleet, then server,
+   DLQ untouched throughout — the measurement at the end of *Deploy ordering*.)
 2. **Release B:** set the epoch to 1. New publishers stamp epoch 1. Old v12
    runners delayed-Nak those messages; new runners accept both epoch 0 and 1.
 
@@ -112,10 +114,10 @@ recoverable**, and that — not "which side rejects less" — is what decides.
 | **server** | old runners reject the new vN+1 | **replayable**: once every runner is new, `/api/admin/dlq/$SEQ/replay` re-publishes the same bytes and they are accepted |
 | **runners** | new runners reject anything still queued *below* `Min(new)` | **not replayable**: a replay re-publishes the same old bytes, the new fleet rejects them identically and re-parks (Path B step 5) — recovery is a per-run resume plus a DLQ delete |
 
-Server-first is therefore the safe default, and deliberately so: it was
-not for historical reasons: it puts the parking risk on the side that can be
-undone. The compatibility window narrowed *when* a mismatch happens; it did
-not change which mismatch is recoverable.
+Server-first is therefore the safe default, for that reason and not a
+historical one: it puts the parking risk on the side that can be undone. The
+compatibility window changed *how often* a mismatch happens; it did not change
+which mismatch is recoverable.
 
 **Runner-first is an optimization, valid under one condition:** that nothing
 below `Min(new runner)` can still be in the stream. Then new runners admit
@@ -242,11 +244,13 @@ parks the new version on the old fleet if no upgraded runner becomes Ready
 inside the delivery budget — Path A avoids that by draining first, Path B
 accepts it and replays afterwards.
 
-Both become unnecessary **only** when the runner-first precondition holds —
-nothing below `Min(new runner)` can still be queued, which is automatic when
-the bump leaves `MinSchemaVersion` alone. Then nothing is rejected in either
-direction, so there is nothing to drain or replay. See *Deploy ordering*
-above; do not infer that case from the old server's version alone. Path A's
+Both become unnecessary only when you **actually roll runner-first AND its
+precondition holds** — nothing below `Min(new runner)` can still be queued,
+which is automatic when the bump leaves `MinSchemaVersion` alone. Then nothing
+is rejected in either direction, so there is nothing to drain or replay. The
+precondition alone does not exempt you: a server-first roll still needs one of
+these paths whatever the precondition says. See *Deploy ordering* above, and
+do not infer the precondition from the old server's version alone. Path A's
 "recommended default" below is scoped to the bumps that still need a path.
 
 ### Path A — drained queue before cutover

--- a/pkg/queue/types.go
+++ b/pkg/queue/types.go
@@ -19,21 +19,20 @@ import (
 
 // SchemaVersion is incremented at every breaking change to the wire
 // payload. Producers always set RunMessage.V = SchemaVersion; consumers
-// reject any V outside [MinSchemaVersion, SchemaVersion], so a rolling
-// upgrade must roll the PERMISSIVE side first — see the ordering bullet
-// below.
+// reject any V outside [MinSchemaVersion, SchemaVersion] in both directions,
+// so a rolling upgrade has to choose which side rolls first — see the
+// ordering bullet below.
 //
 // Wire compatibility policy (enforced — see docs/cloud-queue-schema-rollout.md):
-//   - Roll the side that must already tolerate the other FIRST. Ordinarily
-//     that is the runners: while MinSchemaVersion(new) is at or below the
-//     oldest V still RESIDENT in the stream, new runners admit everything
-//     they may be handed, so nothing is ever rejected. SchemaVersion(old
-//     server) is the usual proxy for that, but only a proxy — admission is
-//     per message, and the stream retains MaxAge (24h), so a bump that RAISES
-//     MinSchemaVersion within that window can still meet older queued
-//     messages. Deploy the server first when MinSchemaVersion rises past what
-//     is still queued: there new runners would reject the backlog, and the
-//     runbook's drain/replay paths apply. A mismatch in
+//   - Deploy the server (producer) first by default. Both orders can park a
+//     message; only one park is replayable. Old runners rejecting the new
+//     version park messages a DLQ replay fixes once the fleet is upgraded;
+//     new runners rejecting a version below their MinSchemaVersion park
+//     messages a replay can never fix (it re-publishes the same bytes). Roll
+//     the runners first only when nothing below MinSchemaVersion(new) can
+//     still be queued — automatic when the bump leaves MinSchemaVersion
+//     alone, otherwise a check against the queue, never against the old
+//     server's SchemaVersion. A mismatch in
 //     either direction is TRANSIENT, never terminal: the consumer holds the
 //     message with a delayed Nak and, once MaxDeliver is exhausted, parks it
 //     on the DLQ with the run document flipped to an actionable status —
@@ -81,11 +80,12 @@ import (
 // the platform-override feature exists to prevent. Consumers accept BOTH v8
 // and v9 (MinSchemaVersion): the change is purely additive, so a NEW runner
 // consumes old queued v8 messages. (The reverse does not hold — a pre-bump
-// runner rejects v9 — which is exactly why the permissive side, the runners,
-// goes first: dual-accept closes the stranded-v8-message half of the window,
-// and rolling runners first closes the other half by never letting a v9
-// message meet a v8-only consumer. An earlier revision of this note read
-// "server-first ordering remains required"; that was the pre-window rule.)
+// runner rejects v9 — so the server-first ordering, or a same-release roll of
+// both, remains the default; dual-accept removes only the stranded-v8-message
+// half of the window. Rolling the runners first removes the other half, but
+// only when nothing below the new Min can still be queued: a runner-first roll
+// parks such a message UNREPLAYABLY, while a server-first one parks the new
+// version replayably. See the runbook's Deploy ordering section.)
 //
 // v=10 (2026-08-29): added Fallback so the operator's single run-level
 // fallback route (`--fallback` / launch `fallback`) reaches the runner.

--- a/pkg/queue/types.go
+++ b/pkg/queue/types.go
@@ -18,13 +18,19 @@ import (
 )
 
 // SchemaVersion is incremented at every breaking change to the wire
-// payload. Producers always set RunMessage.V = SchemaVersion;
-// consumers reject any V they don't recognise so that a
-// rolling-upgrade always upgrades the server first (which then never
-// emits an unsupported version).
+// payload. Producers always set RunMessage.V = SchemaVersion; consumers
+// reject any V outside [MinSchemaVersion, SchemaVersion], so a rolling
+// upgrade must roll the PERMISSIVE side first — see the ordering bullet
+// below.
 //
 // Wire compatibility policy (enforced — see docs/cloud-queue-schema-rollout.md):
-//   - Deploy the server (producer) first, then the runners. A mismatch in
+//   - Roll the side that must already tolerate the other FIRST. Ordinarily
+//     that is the runners: while MinSchemaVersion(new) <= SchemaVersion(old
+//     server), new runners still admit what the old server emits, so nothing
+//     is ever rejected. Deploy the server first only when a bump RAISES
+//     MinSchemaVersion past the old server's version — there new runners
+//     would reject the queued backlog, and the runbook's drain/replay paths
+//     apply. A mismatch in
 //     either direction is TRANSIENT, never terminal: the consumer holds the
 //     message with a delayed Nak and, once MaxDeliver is exhausted, parks it
 //     on the DLQ with the run document flipped to an actionable status —
@@ -71,10 +77,12 @@ import (
 // silently serves STALE code/skills for an overridden bot — the exact façade
 // the platform-override feature exists to prevent. Consumers accept BOTH v8
 // and v9 (MinSchemaVersion): the change is purely additive, so a NEW runner
-// consumes old queued v8 messages. (The reverse still holds the standard
-// policy: a pre-bump runner rejects v9, so the server-first ordering — or a
-// same-release roll of both — remains required; dual-accept removes only
-// the stranded-v8-message half of the window.)
+// consumes old queued v8 messages. (The reverse does not hold — a pre-bump
+// runner rejects v9 — which is exactly why the permissive side, the runners,
+// goes first: dual-accept closes the stranded-v8-message half of the window,
+// and rolling runners first closes the other half by never letting a v9
+// message meet a v8-only consumer. An earlier revision of this note read
+// "server-first ordering remains required"; that was the pre-window rule.)
 //
 // v=10 (2026-08-29): added Fallback so the operator's single run-level
 // fallback route (`--fallback` / launch `fallback`) reaches the runner.

--- a/pkg/queue/types.go
+++ b/pkg/queue/types.go
@@ -25,12 +25,15 @@ import (
 //
 // Wire compatibility policy (enforced — see docs/cloud-queue-schema-rollout.md):
 //   - Roll the side that must already tolerate the other FIRST. Ordinarily
-//     that is the runners: while MinSchemaVersion(new) <= SchemaVersion(old
-//     server), new runners still admit what the old server emits, so nothing
-//     is ever rejected. Deploy the server first only when a bump RAISES
-//     MinSchemaVersion past the old server's version — there new runners
-//     would reject the queued backlog, and the runbook's drain/replay paths
-//     apply. A mismatch in
+//     that is the runners: while MinSchemaVersion(new) is at or below the
+//     oldest V still RESIDENT in the stream, new runners admit everything
+//     they may be handed, so nothing is ever rejected. SchemaVersion(old
+//     server) is the usual proxy for that, but only a proxy — admission is
+//     per message, and the stream retains MaxAge (24h), so a bump that RAISES
+//     MinSchemaVersion within that window can still meet older queued
+//     messages. Deploy the server first when MinSchemaVersion rises past what
+//     is still queued: there new runners would reject the backlog, and the
+//     runbook's drain/replay paths apply. A mismatch in
 //     either direction is TRANSIENT, never terminal: the consumer holds the
 //     message with a delayed Nak and, once MaxDeliver is exhausted, parks it
 //     on the DLQ with the run document flipped to an actionable status —


### PR DESCRIPTION
## Summary

The queue-schema runbook prescribed **server-first unconditionally**. That rule predates the compatibility *window* #481 introduced: it was written when a consumer accepted exactly one wire version, so a new runner really did reject the old messages still queued (Path B step 5's "reverse case").

With `MinSchemaVersion` trailing `SchemaVersion` — **10 vs 12** today — that reverse case cannot arise for a bump inside the window, and the prescribed order is the expensive one:

- **server-first**: a vN+1 server publishes into a vN-only fleet → every delivery delayed-Naked → a run is parked `failed_resumable` once MaxDeliver is spent (~4 min at 8 × 30s, typically less than a runner Deployment roll). That is exactly why the runbook then needs a maintenance window (Path A) or a DLQ replay (Path B).
- **runner-first**: new runners accept the old server's vN, then the server flips to vN+1 which every runner already accepts. Rejection window is **zero**; neither path applies.

The rule is stated with its **precondition** (`Min(new) <= Max(old)`) rather than inverted blindly — server-first plus Path A/B remains correct when a bump raises `MinSchemaVersion` past the old version.

## Evidence

Measured on the **v11 → v12 cutover in production** (2026-09-02 — the deploy of #628 itself: 12 runner pods, 3 server pods, live traffic including a run executing across the runner roll):

- DLQ byte-identical afterwards — depth 30, `last_seq` 220, newest message hours older than the rollout;
- no `iterion_runner_admission_rejected_total` sample anywhere in the fleet;
- no `iterion_rollout_epoch_regression_total`; zero pod restarts;
- scheduled run at 21:17 `finished` end-to-end through the new wire.

## Scope

Three sites of the same rule, all in `docs/cloud-queue-schema-rollout.md`: the compatibility-policy bullet (the one a reader meets first), the ordering section itself, and the v12 Release A step that still routed through Path A/B. The `docs/reviews/` audit entry is a dated record and is deliberately left as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)