### PR TITLE
fix(chart): let image.digest pin the server, so one ReplicaSet is one build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -538,6 +538,22 @@ jobs:
         run: helm lint charts/iterion -f charts/iterion/values-dev.yaml
       - name: helm lint --strict (values-prod.yaml)
         run: helm lint charts/iterion -f charts/iterion/values-prod.yaml --strict
+      # `helm lint` renders nothing image-shaped, and cloud-e2e only ever
+      # installs via image.tag — so without these two the digest branch of
+      # `iterion.image` is exercised by no CI job at all, and a refactor could
+      # drop it (or its shape guard) silently. A malformed digest is the case
+      # that matters: it renders a string helm accepts and only kubelet
+      # rejects, so the rollout stalls instead of failing.
+      - name: image.digest renders and rejects a malformed value
+        run: |
+          set -euo pipefail
+          digest="sha256:$(printf 'a%.0s' $(seq 64))"
+          helm template t charts/iterion --set "image.digest=$digest" \
+            | grep -q "image: ghcr.io/socialgouv/iterion@$digest"
+          if helm template t charts/iterion --set image.digest=deadbeef >/dev/null 2>&1; then
+            echo "::error::a malformed image.digest rendered instead of failing"
+            exit 1
+          fi
 
   golangci:
     # Curated golangci-lint pass (.golangci.yml): errcheck, govet,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -548,8 +548,14 @@ jobs:
         run: |
           set -euo pipefail
           digest="sha256:$(printf 'a%.0s' $(seq 64))"
-          helm template t charts/iterion --set "image.digest=$digest" \
-            | grep -q "image: ghcr.io/socialgouv/iterion@$digest"
+          # `--set image.tag=edge` also pins the documented precedence
+          # (digest wins), the property a refactor of the `if` is likeliest to
+          # invert. Render to a FILE: `grep -q` exits on its first match, which
+          # SIGPIPEs helm mid-write and, under `pipefail`, reddens the step on
+          # an assertion that actually passed.
+          helm template t charts/iterion --set image.tag=edge \
+            --set "image.digest=$digest" > /tmp/render-digest.yaml
+          grep -q "image: ghcr.io/socialgouv/iterion@$digest" /tmp/render-digest.yaml
           if helm template t charts/iterion --set image.digest=deadbeef >/dev/null 2>&1; then
             echo "::error::a malformed image.digest rendered instead of failing"
             exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -556,6 +556,14 @@ jobs:
           helm template t charts/iterion --set image.tag=edge \
             --set "image.digest=$digest" > /tmp/render-digest.yaml
           grep -q "image: ghcr.io/socialgouv/iterion@$digest" /tmp/render-digest.yaml
+          # ...and that NOTHING still resolves through the tag. The render has
+          # two iterion.image containers (server + runner fallback) and grep -q
+          # stops at the first, so a refactor routing only one of them through
+          # the digest would otherwise still pass.
+          if grep -q "image: ghcr.io/socialgouv/iterion:edge" /tmp/render-digest.yaml; then
+            echo "::error::a container still resolved through image.tag despite image.digest being set"
+            exit 1
+          fi
           if helm template t charts/iterion --set image.digest=deadbeef >/dev/null 2>&1; then
             echo "::error::a malformed image.digest rendered instead of failing"
             exit 1

--- a/charts/iterion/README.md
+++ b/charts/iterion/README.md
@@ -44,7 +44,7 @@ groups:
 | Group | What it controls |
 |---|---|
 | `mode` | `local` (single-pod studio + PVC) vs `cloud` (the platform) |
-| `image` | Repository/tag/pullPolicy — one image for server + runner |
+| `image` | Repository/tag/**digest**/pullPolicy — one image for server + runner. `digest` wins over `tag`; prefer it over a moving tag (`edge`/`main`), which is resolved per pod and can leave one ReplicaSet running two builds — see [cloud-deployment.md](../../docs/cloud-deployment.md#pinning-the-image) |
 | `server` | Replicas, full-surge `strategy`, resources, command/args, metrics port |
 | `runner` | Pool enable/replicas/resources, full-surge `strategy`, `keda.*` (JetStream lag scaler), `sandbox.enabled` (+RBAC for per-run pods) |
 | `config` | Non-secret env: `rollout.*` (monotonic runner epoch), `mongo.*`, `nats.*`, `s3.*`, `runner.*`, `auth.*` (public half: publicUrl, cookies, TTLs, signupMode, OIDC client ids), `smtp.*` (host/port/from — enables invitations + password-reset email), `orgDefaults.*` (platform-wide launch limits → `ITERION_ORG_DEFAULT_*`), `log.*` |

--- a/charts/iterion/templates/_helpers.tpl
+++ b/charts/iterion/templates/_helpers.tpl
@@ -54,7 +54,7 @@ the tag points at then, with no rollout-history entry. Measured on prod
 v3.93.0 at once. A digest is the only reference that makes "one ReplicaSet =
 one build" true, which is what the per-PodTemplate rollout epoch assumes one
 layer up.
-*/}}
+
 A malformed digest must abort the render, not reach the cluster: a bad shape
 still concatenates into a syntactically fine string that helm lints happily
 and only kubelet rejects (`InvalidImageName`), so no pod ever starts — behind

--- a/charts/iterion/templates/_helpers.tpl
+++ b/charts/iterion/templates/_helpers.tpl
@@ -44,10 +44,24 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Container image reference. Defaults to .Chart.AppVersion when
 .Values.image.tag is empty so a fresh chart pull tracks the binary
 release out of the box.
+
+.Values.image.digest wins over the tag when set. A MOVING tag (`edge`,
+`main`, `latest`) is resolved per POD, at that pod's own start time — so a
+publish landing mid-rollout splits one ReplicaSet across two builds, and a
+later HPA/KEDA scale-up from an existing ReplicaSet silently pulls whatever
+the tag points at then, with no rollout-history entry. Measured on prod
+2026-09-02: three server pods of ReplicaSet 548c4b7f7d serving v3.92.0 and
+v3.93.0 at once. A digest is the only reference that makes "one ReplicaSet =
+one build" true, which is what the per-PodTemplate rollout epoch assumes one
+layer up.
 */}}
 {{- define "iterion.image" -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else -}}
 {{- $tag := default .Chart.AppVersion .Values.image.tag -}}
 {{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/iterion/templates/_helpers.tpl
+++ b/charts/iterion/templates/_helpers.tpl
@@ -55,8 +55,21 @@ v3.93.0 at once. A digest is the only reference that makes "one ReplicaSet =
 one build" true, which is what the per-PodTemplate rollout epoch assumes one
 layer up.
 */}}
+A malformed digest must abort the render, not reach the cluster: a bad shape
+still concatenates into a syntactically fine string that helm lints happily
+and only kubelet rejects (`InvalidImageName`), so no pod ever starts — behind
+`maxUnavailable: 0` the rollout then stalls in silence while the old pods keep
+serving, and a KEDA scale-up simply never gets capacity. This chart has
+already been bitten by the shape once, on the neighbouring field: a digest
+written into `tag:` rendered `…iterion:@sha256:…` (see
+docs/bot-runs/dep-update-guard.md). Same reasoning as
+`iterion.nats.monitoringEndpoint`'s `required` below.
+*/}}
 {{- define "iterion.image" -}}
 {{- if .Values.image.digest -}}
+{{- if not (regexMatch "^sha256:[0-9a-f]{64}$" .Values.image.digest) -}}
+{{- fail (printf "image.digest must be sha256:<64 hex chars>, got %q — pass the digest alone, not a tag or a full image reference" .Values.image.digest) -}}
+{{- end -}}
 {{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
 {{- else -}}
 {{- $tag := default .Chart.AppVersion .Values.image.tag -}}

--- a/charts/iterion/values.yaml
+++ b/charts/iterion/values.yaml
@@ -5,6 +5,15 @@
 image:
   repository: ghcr.io/socialgouv/iterion
   tag: ""              # defaults to .Chart.AppVersion when empty
+  # Wins over `tag` when set (`sha256:…`). Prefer it whenever `tag` is a
+  # MOVING tag (edge/main/latest): a tag is resolved per pod at that pod's own
+  # start time, so a publish landing mid-rollout splits one ReplicaSet across
+  # two builds, and a later HPA/KEDA scale-up from an existing ReplicaSet pulls
+  # whatever the tag means then — no rollout entry, no signal. A digest is what
+  # makes "one ReplicaSet = one build" true, which the rollout epoch assumes.
+  # Cost: each deploy becomes an explicit digest bump (the ritual runner.image
+  # already follows). See docs/cloud-deployment.md#pinning-the-image.
+  digest: ""
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/iterion/values.yaml
+++ b/charts/iterion/values.yaml
@@ -11,8 +11,11 @@ image:
   # two builds, and a later HPA/KEDA scale-up from an existing ReplicaSet pulls
   # whatever the tag means then — no rollout entry, no signal. A digest is what
   # makes "one ReplicaSet = one build" true, which the rollout epoch assumes.
-  # Cost: each deploy becomes an explicit digest bump (the ritual runner.image
-  # already follows). See docs/cloud-deployment.md#pinning-the-image.
+  # Cost: each deploy becomes an explicit digest bump instead of a rollout
+  # restart. Note this pins the SHARED image only: `runner.image` below is
+  # empty by default and falls back to this same reference, so a runner pool
+  # given its own image must be pinned there too.
+  # See docs/cloud-deployment.md#pinning-the-image.
   digest: ""
   pullPolicy: IfNotPresent
 

--- a/docs/cloud-deployment.md
+++ b/docs/cloud-deployment.md
@@ -316,9 +316,18 @@ installs use one to iterate fast. Know what it costs: a tag is resolved
   measured on prod 2026-09-02, three server pods of ReplicaSet `548c4b7f7d`
   serving v3.92.0 and v3.93.0 at once, visible outside as `/healthz` and
   `/api/server/info` disagreeing on `commit`;
-- a later HPA/KEDA scale-up creates a pod **from an existing ReplicaSet** and
-  pulls whatever the tag means *then* — the ReplicaSet drifts with no rollout
+- a later HPA/KEDA scale-up creates a pod **from an existing ReplicaSet**, and
+  what it runs depends on `pullPolicy`. With `Always` it is whatever the tag
+  means *then*; with the chart default **`IfNotPresent`** kubelet does not
+  re-resolve a tag it already has cached on that node, so the pod runs an
+  arbitrarily *older* layer. Either way the ReplicaSet drifts with no rollout
   entry and no signal.
+
+`IfNotPresent` has a second consequence worth stating plainly: on a moving
+tag, `kubectl rollout restart` is **not** a reliable way to reach the current
+build — a node with the tag cached serves the cached layer. Fast iteration on
+`:edge` needs `pullPolicy: Always` at minimum, and even then buys only
+"current at each pod's start time", not "one build".
 
 That matters beyond cosmetics once the rollout epoch is in play: the epoch
 rides the PodTemplate, which assumes one ReplicaSet is one build.
@@ -340,6 +349,18 @@ gh api /orgs/<org>/packages/container/iterion/versions \
 
 The trade-off is real and yours: a digest turns each deploy into an explicit
 bump instead of a `rollout restart`.
+
+> **Once `digest` is set in a values file, every `--set image.tag=…` becomes a
+> silent no-op** — the upgrade succeeds, no PodTemplate field changes, nothing
+> rolls, and nothing warns. That bites the sequencing recipes in
+> [cloud-queue-schema-rollout.md](cloud-queue-schema-rollout.md), where the
+> phase-1 command also sets `runner.image` — which IS consumed verbatim. On a
+> digest-pinned install that phase rolls only the *runners*, to the old tag,
+> while the server stays put: pods restart, the upgrade reports success, and
+> an operator who reads that as "the server is on the new build" then publishes
+> new-version messages from the old one. **Move a digest-pinned install by
+> bumping `image.digest`** (and `runner.image` to a digest reference), never by
+> `--set image.tag`.
 
 **The chart pins nothing by default**, and `image.digest` pins the *shared*
 image only. `runner.image` — the per-runner-pod override — is empty by

--- a/docs/cloud-deployment.md
+++ b/docs/cloud-deployment.md
@@ -306,6 +306,43 @@ them:
 > the mixed-version window also needs the drained-queue-or-DLQ-replay
 > procedure in [docs/cloud-queue-schema-rollout.md](cloud-queue-schema-rollout.md).
 
+### Pinning the image
+
+`image.tag` accepts a **moving** tag (`edge`, `main`, `latest`) and many
+installs use one to iterate fast. Know what it costs: a tag is resolved
+**per pod, at that pod's own start time**, so
+
+- a publish landing mid-rollout splits **one ReplicaSet across two builds** —
+  measured on prod 2026-09-02, three server pods of ReplicaSet `548c4b7f7d`
+  serving v3.92.0 and v3.93.0 at once, visible outside as `/healthz` and
+  `/api/server/info` disagreeing on `commit`;
+- a later HPA/KEDA scale-up creates a pod **from an existing ReplicaSet** and
+  pulls whatever the tag means *then* — the ReplicaSet drifts with no rollout
+  entry and no signal.
+
+That matters beyond cosmetics once the rollout epoch is in play: the epoch
+rides the PodTemplate, which assumes one ReplicaSet is one build.
+
+`image.digest` (`sha256:…`) wins over `image.tag` and is the only reference
+that makes that true:
+
+```yaml
+image:
+  repository: ghcr.io/socialgouv/iterion
+  digest: sha256:…        # wins over `tag`
+```
+
+```sh
+# resolve the moving tag to the digest it currently points at
+gh api /orgs/<org>/packages/container/iterion/versions \
+  --jq '[.[]|select(.metadata.container.tags|index("edge"))][0].name'
+```
+
+The trade-off is real and yours: a digest turns each deploy into an explicit
+bump instead of a `rollout restart`. That is the ritual `runner.image` already
+follows — the runner is digest-pinned precisely so a moving tag cannot roll
+the Deployment (and kill in-flight runs) on every merge to main.
+
 ### Generation-aware rollout
 
 The chart uses `RollingUpdate` with `maxSurge: 100%` and

--- a/docs/cloud-deployment.md
+++ b/docs/cloud-deployment.md
@@ -339,9 +339,18 @@ gh api /orgs/<org>/packages/container/iterion/versions \
 ```
 
 The trade-off is real and yours: a digest turns each deploy into an explicit
-bump instead of a `rollout restart`. That is the ritual `runner.image` already
-follows — the runner is digest-pinned precisely so a moving tag cannot roll
-the Deployment (and kill in-flight runs) on every merge to main.
+bump instead of a `rollout restart`.
+
+**The chart pins nothing by default**, and `image.digest` pins the *shared*
+image only. `runner.image` — the per-runner-pod override — is empty by
+default and falls back to that same reference, so a runner pool given its own
+image keeps the hazard until it is pinned there too. That half matters more
+under the rollout epoch: a pod created from an old ReplicaSet keeps its
+literal `ITERION_RUNNER_EPOCH` while pulling whatever the tag means now.
+
+(SocialGouv's own prod values do pin the runner by digest, for a second
+reason: a moving tag rolled the runner Deployment on every merge to main and
+killed in-flight runs. That is a values-level choice, not a chart default.)
 
 ### Generation-aware rollout
 

--- a/docs/cloud-public-exposure-checklist.md
+++ b/docs/cloud-public-exposure-checklist.md
@@ -49,7 +49,7 @@ How to verify: `kubectl describe pod <iterion-server-pod> | grep -i secret` — 
 ## 5. Image supply chain
 
 - [ ] **Trivy CI** runs on PRs, pushes to `main`, weekly schedule, and post-image builds; the workflow publishes SARIF/results summaries for HIGH/CRITICAL findings but intentionally does **not** fail the PR or image release by itself. If you require a hard gate, configure branch protection or a code-scanning rule outside the current workflow. See [.github/workflows/trivy.yml](../.github/workflows/trivy.yml).
-- [ ] **Image references** in production values use `image: ghcr.io/socialgouv/iterion:<digest>@sha256:…`, not floating tags like `:latest` or `:v1`.
+- [ ] **Image references** in production values are digest-pinned, not floating tags like `:latest`, `:edge` or `:v1`. Set `image.digest: sha256:…` (it wins over `image.tag`, and the chart refuses any other shape); pin `runner.image` separately when the runner pool has its own image, since it falls back to the shared reference. Note the form is `repository@sha256:…` — a digest written into the `tag:` field renders `…iterion:@sha256:…`, which only kubelet rejects. See [cloud-deployment.md](cloud-deployment.md#pinning-the-image).
 - [ ] **Sandbox image** is pre-built and digest-pinned. The Kubernetes driver rejects `sandbox.build:` by design — production deployments reference a CI-built `iterion-sandbox-slim:<version>` digest.
 - [ ] **Cosign / sigstore** signatures verified at admission for production. (Optional but recommended; falls outside the chart's scope.)
 


### PR DESCRIPTION
Closes #636.

## The defect

`iterion.image` could only build `repo:tag`:

```
{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
{{- printf "%s:%s" .Values.image.repository $tag -}}
```

So *"pin the server by digest"* was **not expressible in the chart at all** — the operator's only lever was a tag, which is precisely the thing that moves. `runner.image` is consumed verbatim and could already carry a digest; the shared server image had no equivalent seam.

## Why it bites

A tag is resolved **per pod, at that pod's own start time**. Measured on prod on 2026-09-02, three server pods of the **same ReplicaSet** `548c4b7f7d`:

```
iterion-548c4b7f7d-4zjbs: v3.92.0  d4611df0
iterion-548c4b7f7d-j6rnt: v3.93.0  5c0a1ea2
iterion-548c4b7f7d-mll88: v3.93.0  5c0a1ea2
```

Visible from outside as `/healthz` and `/api/server/info` disagreeing on `commit` depending on which pod answered. Same mechanism, quieter symptom: an HPA/KEDA scale-up creates a pod **from an existing ReplicaSet** and pulls whatever the tag means *then* — the ReplicaSet drifts with no rollout-history entry and no signal.

This reaches past cosmetics now that #628 landed: the rollout epoch rides the PodTemplate, and that carrier assumes **one ReplicaSet is one build**. A moving tag makes it false one layer below the fence.

## The change

`image.digest` wins over `image.tag`. Additive and narrow:

- the tag path is untouched, `.Chart.AppVersion` fallback intact — a fresh chart pull behaves exactly as before;
- the hazard is documented where an operator meets it (values comment, chart README row, new *Pinning the image* section in `docs/cloud-deployment.md`, with the one-liner that resolves a moving tag to its current digest).

Deliberately **not** included: flipping any install to a digest. That is a real trade-off owned by the operator — it costs the `rollout restart` fast loop that `:edge` exists to provide, replacing it with a per-deploy digest bump (the ritual `runner.image` already follows, for a different reason: a moving tag rolled the runner Deployment on every merge and killed in-flight runs).

## Verification

Rendered all three ways:

| values | rendered |
|---|---|
| default | `ghcr.io/socialgouv/iterion:3.94.0` |
| `--set image.digest=sha256:…` | `ghcr.io/socialgouv/iterion@sha256:…` |
| `--set image.tag=edge --set image.digest=sha256:…` | `ghcr.io/socialgouv/iterion@sha256:…` |

`helm lint` green on `values-dev.yaml` and on `values-prod.yaml --strict`.

~~which rejects unknown keys, so the new key is properly declared~~ — **corrected**: there is no `values.schema.json` and `--strict` only promotes lint warnings to errors, so it would have passed with the key undeclared. It proves nothing about declaration; the three render results above are the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
