### PR TITLE
fix(quota): classify an account spend ceiling, tell the PR when a review parks, stop runs on a closed PR

### DIFF
--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -40,6 +40,9 @@ PR opened / pushed ──▶ launch claims the head:  revi/review = pending
 
                run dies without publishing ──▶ reconciler posts failure
                                                (event + 1-min sweep)
+       run PARKS on a provider quota ──▶ check stays claimed, pause notice
+                                          comments when it resumes
+              pull request closed/merged ──▶ its runs stop, retries disarmed
 ```
 
 The context is claimed at launch and answered at the end, so the check is never
@@ -135,6 +138,25 @@ cases the derivation does not cover.
 
 Repo admins keep their merge-queue bypass, so a stuck gate is never a hard
 block for an admin.
+
+### A paused review says so on the PR
+
+A review that hits the provider's quota does not die: the runner arms a
+durable retry and the reconciler leaves the check alone, because that armed
+retry is the promise. But the check then sits on its in-flight claim, which
+reads exactly like a review that died — and nothing said how long to wait.
+So the park **comments on the pull request**, once per park (fired from the
+run-outcome event, never the every-minute sweep): what happened, the instant
+the retry fires, the attempt number, and the provider's own sentence. When
+that sentence is an account **spend ceiling** rather than a time window, the
+notice says so explicitly — a ceiling reopens when an admin raises it (or
+the month rolls), so the armed retries can otherwise exhaust themselves
+against a wall.
+
+Symmetrically, a pull request that **closes or merges** ends every run bound
+to it and **disarms** their retries: an in-flight review would keep spending
+quota on a diff nobody will merge, and a parked one would wake hours later
+to comment on a dead PR. See [webhooks.md](webhooks.md).
 
 ## Disabling the gate per repo — first review only, re-review on demand
 

--- a/docs/quotas-and-limits.md
+++ b/docs/quotas-and-limits.md
@@ -124,9 +124,24 @@ Cost metering is "floor, not invoice":
   ([pkg/runner/loop_metrics.go:240-260](../pkg/runner/loop_metrics.go),
   [loop_spend.go](../pkg/runner/loop_spend.go)).
 - It is still a floor, not an invoice: a delegate that reports no cost
-  contributes none, and a subscription-billed run ("forfait") legitimately
-  reports `$0` because no per-call charge exists. Treat the monthly USD cap as
-  a trend signal rather than a billing ledger.
+  contributes none. Treat the monthly USD cap as a trend signal rather than a
+  billing ledger.
+- **A forfait run does NOT report `$0`** — and reading `cost_usd` as money
+  spent is the misreading this bullet exists to prevent. `claude_code` prints
+  `total_cost_usd` on every call whatever pays for it: on a **subscription**
+  it is the price those same calls WOULD have cost metered, cache creation
+  billed at 1.25× and cache reads at 0.1× included. Measured 2026-09-03 on a
+  cloud runner holding a forfait: `claude -p "reply pong"` — three input
+  tokens, five output — reported **$0.0402**, because it created 5 751 cache
+  tokens and read 17 120. Nothing was charged; the plan is flat. So an org
+  showing `cost_usd_this_month: 1991` on forfait-served runs has spent that in
+  *equivalent API price*, not in money: the only real money on a subscription
+  is the **extra-usage** overage, which the provider's own console is the sole
+  authority on.
+- And the bucket is the **ORG**, not the credential: `recordOrgSpend` charges
+  `msg.OrgID` whatever tier served the run (team forfait, credential pool,
+  platform keys, BYOK). The figure answers "what did this org consume", never
+  "what did this key cost".
 
 ## Reading usage
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -135,6 +135,14 @@ event paths trigger; ping / push / everything else is silently filtered
 (returns 200 — a 4xx makes GitHub disable the webhook after repeated
 failures; [pkg/server/webhooks_github.go](../pkg/server/webhooks_github.go)):
 
+- **`pull_request`** with action **`closed`** (merged or not) → every run
+  still bound to that PR is **stopped**, and any armed usage-window retry is
+  **disarmed**. Scoped to the PR's own subject and across every bot, unlike
+  `overlap: supersede` which replaces one bot's work with newer work of the
+  same bot. Without it a review in flight keeps spending provider quota on a
+  diff nobody will merge, and a review PARKED on a quota window wakes hours
+  later to comment on a dead pull request. Nothing is ever launched on this
+  action.
 - **`pull_request`** with action `opened`, `reopened`, or `ready_for_review`
   — **plus `synchronize` when the webhook sets `review_on_sync`**, so a push
   to the head re-reviews and the `revi/review` status re-evaluates on the new

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -137,7 +137,11 @@ failures; [pkg/server/webhooks_github.go](../pkg/server/webhooks_github.go)):
 
 - **`pull_request`** with action **`closed`** (merged or not) → every run
   still bound to that PR is **stopped**, and any armed usage-window retry is
-  **disarmed**. Scoped to the PR's own subject and across every bot, unlike
+  **disarmed**. That includes the runs a **comment** launched (`/billy`, a
+  review-thread reply): those record the comment's own id as their subject,
+  so the delivery carries a `parent_subject_id` pointing at the pull
+  request, and the stop matches on either. Scoped to the PR across every
+  bot, unlike
   `overlap: supersede` which replaces one bot's work with newer work of the
   same bot. Without it a review in flight keeps spending provider quota on a
   diff nobody will merge, and a review PARKED on a quota window wakes hours

--- a/pkg/backend/delegate/claude_code_ratelimit_test.go
+++ b/pkg/backend/delegate/claude_code_ratelimit_test.go
@@ -32,6 +32,21 @@ func TestIsRateLimitMessage(t *testing.T) {
 			want: true,
 		},
 		{
+			// The shape that re-opened the masking bug on 2026-09-03:
+			// THREE words and an apostrophe between "your" and "limit".
+			name: "org spend ceiling (real-world, run 01a06694)",
+			text: "You've hit your org's monthly spend limit · ask your admin to raise it at claude.ai/settings/usage",
+			want: true,
+		},
+		{
+			// The qualifier is bounded at three words on purpose: an
+			// agent narrating its own budget reasoning must not be read
+			// as the provider cutting us off.
+			name: "agent prose about limits is NOT a refusal",
+			text: "I checked whether we hit your project's documented per-user monthly request ceiling limit and we did not.",
+			want: false,
+		},
+		{
 			name: "future noun variant (daily) — tolerant match keeps this from re-masking",
 			text: "You've hit your daily limit · resets midnight (UTC)",
 			want: true,
@@ -107,5 +122,28 @@ func TestErrRateLimited_Error(t *testing.T) {
 	got := e.Error()
 	if !strings.Contains(got, "rate_limited") || !strings.Contains(got, BackendClaudeCode) {
 		t.Errorf("Error() = %q, want it to contain rate_limited + provider name", got)
+	}
+}
+
+// The codex bare-notice detector had the same masking gap the claude_code
+// regex was widened for: its prefixes carry no qualifier, so every
+// inserted-noun variant sailed through as a normal result. The opener
+// anchor keeps the prefix discipline that stops agent prose qualifying.
+func TestIsCodexBareLimitNoticeCoversNounVariants(t *testing.T) {
+	cases := []struct {
+		text string
+		want bool
+	}{
+		{"You've hit your usage limit.", true},              // enumerated prefix, unchanged
+		{"You've hit your weekly limit · resets 9pm", true}, // was missed
+		{"You've hit your session limit · resets 10:30am", true},
+		{"You've hit your org's monthly spend limit · ask your admin to raise it", true},
+		{"I verified we never hit your weekly limit on this account.", false}, // prose, not an opener
+		{"Selected model is at capacity.", true},
+	}
+	for _, c := range cases {
+		if got := isCodexBareLimitNotice(c.text); got != c.want {
+			t.Errorf("isCodexBareLimitNotice(%q) = %v, want %v", c.text, got, c.want)
+		}
 	}
 }

--- a/pkg/backend/delegate/claude_code_ratelimit_test.go
+++ b/pkg/backend/delegate/claude_code_ratelimit_test.go
@@ -3,6 +3,7 @@ package delegate
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestIsRateLimitMessage(t *testing.T) {
@@ -145,5 +146,33 @@ func TestIsCodexBareLimitNoticeCoversNounVariants(t *testing.T) {
 		if got := isCodexBareLimitNotice(c.text); got != c.want {
 			t.Errorf("isCodexBareLimitNotice(%q) = %v, want %v", c.text, got, c.want)
 		}
+	}
+}
+
+// A bare "spend limit" in the ACCEPTANCE gate would abort a node on
+// ordinary agent narration — and worse, record a StatusRejected reading
+// that routes every later run around that credential for an hour. The
+// ceiling reaches the gate through its provider-shaped opener instead.
+// Strings verified against this detector, not invented.
+func TestSpendLimitProseIsNotARefusal(t *testing.T) {
+	prose := []string{
+		"I'll add a spend limit check to the config.",
+		"The credpool docs say a metered pledge must carry a spend limit.",
+		"Question: should the org spend limit be configurable per team?",
+		"Now adding the spend limit classification to usagecap.go.",
+	}
+	for _, s := range prose {
+		if isRateLimitMessage(s) {
+			t.Errorf("agent prose must not read as a provider refusal: %q", s)
+		}
+	}
+	// The provider's own notice still does, through "hit your … limit".
+	real := "You've hit your org's monthly spend limit · ask your admin to raise it at claude.ai/settings/usage"
+	if !isRateLimitMessage(real) {
+		t.Fatalf("the provider notice must still be caught: %q", real)
+	}
+	kind, window, _ := classifyRateLimit(real, time.Now())
+	if kind != RateLimitKindUsageWindow || string(window) != "spend" {
+		t.Fatalf("kind=%q window=%q", kind, window)
 	}
 }

--- a/pkg/backend/delegate/claude_code_stream.go
+++ b/pkg/backend/delegate/claude_code_stream.go
@@ -828,10 +828,15 @@ func logAssistantContent(logger *iterlog.Logger, nodeID string, iteration int, b
 // normal result and fails structured-output validation with a misleading
 // "missing required field", crashing the run instead of producing a clean
 // resumable rate-limit (observed for "session" on a claude-sonnet-5 fixer,
-// see docs/bot-runs/whole-improve-loop.md; and for "weekly" on the
-// feed-watch veille runner, 2026-07-20). One tolerant pattern subsumes
-// every noun so a new window shape never re-opens this masking bug.
-var hitYourLimitRe = regexp.MustCompile(`hit your (?:[a-z0-9-]+ )?limit`)
+// see docs/bot-runs/whole-improve-loop.md; for "weekly" on the feed-watch
+// veille runner, 2026-07-20; and for the multi-word "org's monthly spend"
+// on three branch-improve-loop runs, 2026-09-03). The qualifier is
+// therefore up to THREE words and may carry an apostrophe — one tolerant
+// pattern subsumes every noun so a new window shape never re-opens this
+// masking bug. Bounded rather than open (`.*`) so an agent's prose about
+// limits cannot bridge two unrelated sentences into a false positive; the
+// 200-char cap in isRateLimitMessage is the second guard.
+var hitYourLimitRe = regexp.MustCompile(`hit your (?:[a-z0-9'’-]+ ){0,3}limit`)
 
 // rateLimitSignals are case-insensitive substrings of assistant text
 // that indicate the upstream provider has cut us off. The forfait
@@ -850,6 +855,10 @@ var rateLimitSignals = []string{
 	"quota exceeded",
 	"usage limit reached",
 	"request rejected (429)",
+	// The account spend ceiling. Kept here too — not only in
+	// hitYourLimitRe's reach — so a future rewording that drops the
+	// "hit your …" opener is still caught by the gate.
+	"spend limit",
 }
 
 // relayedAPIErrorPrefix opens the CLI's verbatim relay of an upstream
@@ -914,6 +923,19 @@ var accountRefusalSignals = []string{
 	"request frequency has been limited",
 }
 
+// spendLimitSignals mean the ACCOUNT's money ceiling is reached — its own
+// admin's budget, not a subscription window: "You've hit your org's
+// monthly spend limit · ask your admin to raise it at
+// claude.ai/settings/usage". Held apart from accountRefusalSignals
+// because the operator-facing cause differs (raise the ceiling vs wait
+// for the provider to relent), and the evidence is recorded under
+// WindowSpend so a skip explains itself honestly. The behaviour is the
+// same on both: no reset instant, park the run, route around the
+// credential — waiting inside the month buys nothing.
+var spendLimitSignals = []string{
+	"spend limit",
+}
+
 // classifyRateLimit refines a matched rate-limit message into
 // (Kind, Window, ResetAt). Window names the meter window the refusal is
 // evidence against, "" when the shape maps to none — the caller records
@@ -924,6 +946,13 @@ func classifyRateLimit(text string, now time.Time) (kind string, window usagecap
 	lower := strings.ToLower(text)
 	if isAccountRefusalText(lower) {
 		return RateLimitKindUsageWindow, usagecap.WindowFrequency, time.Time{}
+	}
+	// Before the generic window path: the spend notice also matches
+	// hitYourLimitRe, and falling through would file a money ceiling as a
+	// nameless window with a blind reset — a retry an hour later against a
+	// budget that only a human (or the next month) reopens.
+	if isSpendLimitText(lower) {
+		return RateLimitKindUsageWindow, usagecap.WindowSpend, time.Time{}
 	}
 	if !isUsageWindowText(lower) {
 		return RateLimitKindTransient, "", time.Time{}
@@ -936,6 +965,18 @@ func classifyRateLimit(text string, now time.Time) (kind string, window usagecap
 // classifyRateLimit and the flattened-error fallback: one definition.
 func isAccountRefusalText(lower string) bool {
 	for _, sig := range accountRefusalSignals {
+		if strings.Contains(lower, sig) {
+			return true
+		}
+	}
+	return false
+}
+
+// isSpendLimitText reports whether already-lowercased text carries the
+// account spend-ceiling shape. One definition, shared by the classifier
+// and the flattened-error fallback for the same reason as its siblings.
+func isSpendLimitText(lower string) bool {
+	for _, sig := range spendLimitSignals {
 		if strings.Contains(lower, sig) {
 			return true
 		}
@@ -956,10 +997,10 @@ func isUsageWindowText(lower string) bool {
 			return true
 		}
 	}
-	// An account-rate refusal parks the same way a shut window does, so
-	// the flattened-error fallback must recognise it through the same
-	// single definition.
-	return isAccountRefusalText(lower)
+	// An account-rate refusal and a spent budget both park the same way a
+	// shut window does, so the flattened-error fallback must recognise
+	// them through the same single definitions.
+	return isAccountRefusalText(lower) || isSpendLimitText(lower)
 }
 
 // UsageWindowInFlattenedError recovers the window signal from an error whose

--- a/pkg/backend/delegate/claude_code_stream.go
+++ b/pkg/backend/delegate/claude_code_stream.go
@@ -855,10 +855,14 @@ var rateLimitSignals = []string{
 	"quota exceeded",
 	"usage limit reached",
 	"request rejected (429)",
-	// The account spend ceiling. Kept here too — not only in
-	// hitYourLimitRe's reach — so a future rewording that drops the
-	// "hit your …" opener is still caught by the gate.
-	"spend limit",
+	// "spend limit" is deliberately NOT here. The account ceiling reaches
+	// this gate through hitYourLimitRe, whose "hit your … limit" opener is
+	// provider-shaped; the bare noun phrase is ordinary English an agent
+	// writes about its own work ("adding a spend limit check to the
+	// config"), and a false positive here does not merely mislabel — it
+	// ABORTS the node and records a StatusRejected reading that routes
+	// every later run around that credential for an hour. Same reasoning
+	// that dropped "rate_limit_error" above.
 }
 
 // relayedAPIErrorPrefix opens the CLI's verbatim relay of an upstream
@@ -932,6 +936,11 @@ var accountRefusalSignals = []string{
 // WindowSpend so a skip explains itself honestly. The behaviour is the
 // same on both: no reset instant, park the run, route around the
 // credential — waiting inside the month buys nothing.
+//
+// Reached ONLY from classifyRateLimit, i.e. after isRateLimitMessage has
+// already accepted the text as a provider refusal on a provider-shaped
+// opener. That ordering is what lets the signal stay a bare noun phrase:
+// it names which refusal this is, it never decides that one happened.
 var spendLimitSignals = []string{
 	"spend limit",
 }

--- a/pkg/backend/delegate/codex.go
+++ b/pkg/backend/delegate/codex.go
@@ -677,6 +677,17 @@ func isCodexBareLimitNotice(text string) bool {
 			}
 		}
 	}
+	// The enumerated prefixes carry no qualifier, so every inserted-noun
+	// variant ("… your weekly limit", "… your org's monthly spend limit")
+	// escapes them — the same masking bug the claude_code detector was
+	// widened for. hitYourLimitRe subsumes the whole family; anchoring it
+	// to a leading "you(')ve hit your" keeps the prefix discipline that
+	// stops an agent quoting a limit mid-paragraph from qualifying.
+	for _, opener := range []string{"you've hit your", "you’ve hit your", "you have hit your"} {
+		if strings.HasPrefix(lower, opener) && hitYourLimitRe.MatchString(lower) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/pkg/backend/delegate/usage_limit_test.go
+++ b/pkg/backend/delegate/usage_limit_test.go
@@ -26,6 +26,22 @@ func TestClassifyRateLimit(t *testing.T) {
 			wantWindow: "frequency",
 		},
 		{
+			// The account SPEND ceiling, verbatim from the wire
+			// (2026-09-03, run 01a06694): three words and an apostrophe
+			// between "your" and "limit" defeated the old one-word
+			// qualifier, so the notice sailed through as the node's
+			// answer and died as "structured output invalid: missing
+			// required field …" — three branch-improve-loop runs on one
+			// morning. It names its own window: a money ceiling reopens
+			// when an admin raises it, never on a reset instant, so
+			// filing it as a nameless window would arm a blind retry
+			// against a wall.
+			name:       "org spend ceiling names the spend window, no reset",
+			text:       "You've hit your org's monthly spend limit · ask your admin to raise it at claude.ai/settings/usage",
+			wantKind:   RateLimitKindUsageWindow,
+			wantWindow: "spend",
+		},
+		{
 			name:      "forfait limit with pm clock",
 			text:      "You've hit your limit · resets 3pm",
 			wantKind:  RateLimitKindUsageWindow,

--- a/pkg/forge/github/issues.go
+++ b/pkg/forge/github/issues.go
@@ -204,3 +204,17 @@ func (c *AdminClient) CommentIssue(ctx context.Context, repo string, number int,
 		CreatedAt: gc.CreatedAt,
 	}, nil
 }
+
+// CommentIssue on an App connection delegates to a management-token
+// AdminClient minted on demand — the same shape CreatePullReview uses, and
+// for the same reason: an App connection resolves to *AppClient, so a
+// capability implemented only on *AdminClient is INVISIBLE to every type
+// assertion the server does. That is not a fringe shape: the studio's
+// GitHub connect wizard creates App connections by default.
+func (a *AppClient) CommentIssue(ctx context.Context, repo string, number int, body string) (forge.CommentRef, error) {
+	rest, err := a.rest(ctx)
+	if err != nil {
+		return forge.CommentRef{}, err
+	}
+	return rest.CommentIssue(ctx, repo, number, body)
+}

--- a/pkg/forge/github/reviews_test.go
+++ b/pkg/forge/github/reviews_test.go
@@ -151,3 +151,14 @@ func TestGitHubListPRReviewComments_NewestFirstCapReversed(t *testing.T) {
 		t.Fatalf("callers must receive chronological order: %+v", out)
 	}
 }
+
+// An App connection resolves to *AppClient, so a capability implemented
+// only on *AdminClient is invisible to every type assertion the server
+// does — the pause notice was silently inert on the standard GitHub
+// shape. Assert the surface, not the behaviour: the delegation itself is
+// CreatePullReview's proven shape.
+func TestAppClientCarriesTheCommentCapability(t *testing.T) {
+	var _ interface {
+		CommentIssue(ctx context.Context, repo string, number int, body string) (forge.CommentRef, error)
+	} = (*AppClient)(nil)
+}

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -974,6 +974,8 @@ func (p *Publisher) refusedUntil(ctx context.Context, backend string, scope stri
 				why = "provider rejected the credential itself (auth failure)"
 			case usagecap.WindowFrequency:
 				why = "provider refused the account's request rate (fair-usage)"
+			case usagecap.WindowSpend:
+				why = "the account's spend ceiling is reached — an admin must raise it (claude.ai/settings/usage)"
 			default:
 				why = fmt.Sprintf("provider refused the %s window (%.0f%% used)", r.Window, r.Percent())
 			}

--- a/pkg/server/forge_gate_pause_notice.go
+++ b/pkg/server/forge_gate_pause_notice.go
@@ -51,7 +51,16 @@ func (s *Server) noticeGatePausedForRetry(ctx context.Context, run *store.Run) {
 	prURL := strings.TrimSpace(runInputString(run, "pr_url"))
 	token := strings.TrimSpace(runInputString(run, forgePublishVarToken))
 	if prURL == "" || token == "" {
-		return // not a gating run: nothing to tell anyone
+		return // holds no publish grant: nothing to tell anyone
+	}
+	// Holding a grant is NOT owing a verdict — the server mints one for
+	// ANY bot launched with a pr_url (the brancher, the docs amender, the
+	// fixer). The notice says "review paused … the verdict lands here",
+	// which for a fixer parked on the same quota is simply false, and
+	// there is no claimed check for it to explain. Same two conditions the
+	// reconciler uses to decide a run owes the gate a verdict.
+	if strings.TrimSpace(runInputString(run, "gate_context")) == "" || runGateDisabled(run) {
+		return
 	}
 	debugf := func(format string, args ...any) {
 		if s.logger != nil {
@@ -69,14 +78,22 @@ func (s *Server) noticeGatePausedForRetry(ctx context.Context, run *store.Run) {
 		debugf("its pr_url does not parse: %v", err)
 		return
 	}
+	// pr_url is a LAUNCH VAR and injectForgePublishVars honours a
+	// caller-pinned token, so the grant's scope has to be re-enforced here
+	// exactly as the publish endpoint and the reconciler enforce it —
+	// repo, tenant, host. Without the REPO half a run holding a legitimate
+	// grant for repo A could park on a quota and have iterion's forge
+	// identity comment on any repo B the connection reaches (for a GitHub
+	// App installation, typically the whole org).
+	if !strings.EqualFold(strings.TrimSpace(repo), strings.TrimSpace(grant.Repo)) {
+		debugf("its grant covers %s — refusing to comment outside the grant's repo", grant.Repo)
+		return
+	}
 	conn, err := s.forgeConnections.Get(store.WithoutTenantFilter(ctx), grant.ConnectionID)
 	if err != nil {
 		debugf("its connection %s is unreadable: %v", grant.ConnectionID, err)
 		return
 	}
-	// The same scope re-enforcement the publish path and the reconciler
-	// apply: pr_url is a launch var, so the grant's tenant and host are
-	// what bound where this token may speak.
 	if conn.TenantID != grant.TeamID {
 		debugf("its connection %s belongs to another tenant", grant.ConnectionID)
 		return

--- a/pkg/server/forge_gate_pause_notice.go
+++ b/pkg/server/forge_gate_pause_notice.go
@@ -1,0 +1,197 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// A review that parks on a provider quota is NOT dead: the runner armed a
+// durable retry, and the gate reconciler next door deliberately leaves such
+// a run alone — the armed retry is the promise. But nothing said so ON THE
+// PULL REQUEST. The required check sits on the in-flight claim ("review in
+// progress"), which is exactly what it says an hour before the retry fires
+// and exactly what it says if nothing ever comes back: the developer cannot
+// tell a review that will resume from one that died, and has no idea how
+// long to wait.
+//
+// So the park speaks, once, where the developer is looking. The comment
+// carries the three facts nothing else supplies: that the pause is a quota
+// (not a bug in their branch), WHEN the retry fires, and whether waiting is
+// actually enough — an account SPEND ceiling reopens when an admin raises
+// it, not on a schedule, so the armed retry may exhaust its attempts
+// against a wall.
+//
+// Fired from the run-outcome EVENT only, never the sweep: the sweep
+// re-offers the same run every minute for an hour, and this posts a
+// comment. One park = one outcome event = one comment; a second park
+// (the retry hit the same wall) legitimately produces a second one.
+
+// gatePauseNoticeMarker is the invisible provenance tag on the comment.
+// A future reader (or a de-dup pass) can find iterion's own pause notices
+// without parsing prose.
+const gatePauseNoticeMarker = "<!-- iterion:gate-paused -->"
+
+// noticeGatePausedForRetry posts the pause notice on the PR a parked run
+// gates. Best-effort in every branch: the run's retry is already armed and
+// durable, so a comment that cannot be posted must never turn into an
+// error the caller has to handle. Silent (Debug) on every miss — a run
+// that gates nothing is the common case, not an anomaly.
+func (s *Server) noticeGatePausedForRetry(ctx context.Context, run *store.Run) {
+	if s == nil || run == nil || run.RetryState == nil || run.RetryState.RetryAfter == nil {
+		return
+	}
+	if s.forgePublishTokens == nil || s.forgeConnections == nil {
+		return
+	}
+	prURL := strings.TrimSpace(runInputString(run, "pr_url"))
+	token := strings.TrimSpace(runInputString(run, forgePublishVarToken))
+	if prURL == "" || token == "" {
+		return // not a gating run: nothing to tell anyone
+	}
+	debugf := func(format string, args ...any) {
+		if s.logger != nil {
+			s.logger.Debug("forge gate: pause notice for run %s on %s not posted: "+format,
+				append([]any{run.ID, prURL}, args...)...)
+		}
+	}
+	grant, ok := s.forgePublishTokens.lookup(token)
+	if !ok {
+		debugf("its publish grant is expired or revoked")
+		return
+	}
+	host, repo, number, err := forge.ParsePullURL(prURL)
+	if err != nil {
+		debugf("its pr_url does not parse: %v", err)
+		return
+	}
+	conn, err := s.forgeConnections.Get(store.WithoutTenantFilter(ctx), grant.ConnectionID)
+	if err != nil {
+		debugf("its connection %s is unreadable: %v", grant.ConnectionID, err)
+		return
+	}
+	// The same scope re-enforcement the publish path and the reconciler
+	// apply: pr_url is a launch var, so the grant's tenant and host are
+	// what bound where this token may speak.
+	if conn.TenantID != grant.TeamID {
+		debugf("its connection %s belongs to another tenant", grant.ConnectionID)
+		return
+	}
+	if connHost := hostOfURL(conn.BaseURL()); connHost == "" || !strings.EqualFold(connHost, host) {
+		debugf("its connection points at %q, not %q", hostOfURL(conn.BaseURL()), host)
+		return
+	}
+	commenter, err := s.issueCommenterFor(ctx, conn)
+	if err != nil || commenter == nil {
+		debugf("no comment client for %s: %v", conn.Provider, err)
+		return
+	}
+	body := gatePauseNoticeBody(run, time.Now().UTC())
+	if _, err := commenter.CommentIssue(ctx, repo, number, body); err != nil {
+		debugf("%v", err)
+		return
+	}
+	if s.logger != nil {
+		s.logger.Info("forge gate: run %s parked on a provider quota — pause notice posted on %s (retry at %s)",
+			run.ID, prURL, run.RetryState.RetryAfter.Format(time.RFC3339))
+	}
+}
+
+// forgeIssueCommenter is the ONE method this notice needs. Narrow on
+// purpose (the same discipline as forgeGateClient): forge.IssueClient
+// bundles comments with list/create/update, and a provider adapter that
+// only knows how to comment must still be able to carry the notice.
+type forgeIssueCommenter interface {
+	CommentIssue(ctx context.Context, repo string, number int, body string) (forge.CommentRef, error)
+}
+
+// issueCommenterFor resolves the connection's comment capability, mirroring
+// gateClientFor: a provider that cannot comment yields (nil, nil) rather
+// than an error, because "this forge has no comment API wired" is not a
+// failure of the run.
+func (s *Server) issueCommenterFor(ctx context.Context, conn forge.Connection) (forgeIssueCommenter, error) {
+	if s.forgeIssueCommenterFor != nil {
+		return s.forgeIssueCommenterFor(ctx, conn)
+	}
+	admin, err := s.forgeAdminFor(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+	c, ok := admin.(forgeIssueCommenter)
+	if !ok {
+		return nil, nil
+	}
+	return c, nil
+}
+
+// gatePauseNoticeBody renders the comment. Written for the developer whose
+// PR it lands on, not for an operator: what happened, when it resumes, and
+// whether waiting suffices.
+func gatePauseNoticeBody(run *store.Run, now time.Time) string {
+	at := run.RetryState.RetryAfter.UTC()
+	var b strings.Builder
+	b.WriteString(gatePauseNoticeMarker)
+	b.WriteString("\n⏸️ **Review paused — the LLM provider's quota is exhausted.** Nothing is wrong with this pull request.\n\n")
+	fmt.Fprintf(&b, "iterion parked the review and will resume it **automatically at %s**%s",
+		at.Format("15:04 UTC on 2006-01-02"), humanizeIn(at, now))
+	if run.RetryState.Attempts > 0 {
+		fmt.Fprintf(&b, " — attempt %d", run.RetryState.Attempts)
+	}
+	b.WriteString(". The verdict lands here when it does; a new push restarts it sooner.\n")
+	if cause := gatePauseCause(run); cause != "" {
+		fmt.Fprintf(&b, "\n> %s\n", cause)
+		if isSpendCeilingCause(cause) {
+			b.WriteString("\n**Waiting may not be enough here**: a spend ceiling reopens when an\n" +
+				"account admin raises it (or when the month rolls over), not on a\n" +
+				"provider window schedule.\n")
+		}
+	}
+	return b.String()
+}
+
+// gatePauseCause extracts the provider's own sentence from the run error —
+// the part that tells a reader WHICH wall was hit. Bounded: the run error
+// can carry wrappers and a stack of context, and a comment is not a log.
+func gatePauseCause(run *store.Run) string {
+	msg := strings.TrimSpace(run.Error)
+	if msg == "" {
+		return ""
+	}
+	if i := strings.IndexByte(msg, '\n'); i >= 0 {
+		msg = strings.TrimSpace(msg[:i])
+	}
+	const maxCause = 300
+	if len(msg) > maxCause {
+		msg = strings.TrimSpace(msg[:maxCause]) + "…"
+	}
+	return msg
+}
+
+// isSpendCeilingCause reports whether the parked cause is an account SPEND
+// ceiling rather than a time window. The distinction is the only part of
+// the notice a developer can act on (ask an admin) versus wait out.
+func isSpendCeilingCause(cause string) bool {
+	return strings.Contains(strings.ToLower(cause), "spend limit")
+}
+
+// humanizeIn renders the wait as a parenthetical so the reader does not
+// have to subtract clocks. Empty when the instant is already past (a retry
+// eligible now, waiting on a runner slot).
+func humanizeIn(at, now time.Time) string {
+	d := at.Sub(now)
+	if d <= 0 {
+		return ""
+	}
+	switch {
+	case d < time.Minute:
+		return " (in under a minute)"
+	case d < time.Hour:
+		return fmt.Sprintf(" (in ~%d min)", int(d.Round(time.Minute).Minutes()))
+	default:
+		return fmt.Sprintf(" (in ~%.1f h)", d.Hours())
+	}
+}

--- a/pkg/server/forge_gate_pause_notice_test.go
+++ b/pkg/server/forge_gate_pause_notice_test.go
@@ -111,6 +111,45 @@ func TestGatePausedNoticePostsOnThePR(t *testing.T) {
 		}
 	})
 
+	t.Run("a grant for another repo cannot aim the comment", func(t *testing.T) {
+		s, c := newWorld(t)
+		// The grant covers acme/widgets; pr_url — a LAUNCH VAR — points
+		// elsewhere on the same host.
+		s.forgePublishTokens.Register("run-token", ForgePublishGrant{TeamID: team, ConnectionID: "c1", Repo: "acme/other"})
+		run := parkedRun(t, s, "rate_limited: You've hit your weekly limit", time.Now().UTC().Add(time.Hour))
+
+		s.noticeGatePausedForRetry(context.Background(), run)
+
+		if len(c.bodies) != 0 {
+			t.Fatalf("the grant's repo scope must bound where the bot identity speaks, got %v", c.bodies)
+		}
+	})
+
+	t.Run("a bot that owes no verdict stays silent", func(t *testing.T) {
+		s, c := newWorld(t)
+		at := time.Now().UTC().Add(time.Hour)
+		id, err := store.GenerateRunID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		// A fixer launched on the PR: it holds a publish grant (the server
+		// mints one for any bot with a pr_url) but claims no check.
+		run, err := s.cfg.Store.CreateRun(context.Background(), id, "branch-improve-loop", map[string]any{
+			"pr_url": prURL, forgePublishVarToken: "run-token",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		run.Status = store.RunStatusFailedResumable
+		run.RetryState = &store.RunRetryState{RetryAfter: &at}
+
+		s.noticeGatePausedForRetry(context.Background(), run)
+
+		if len(c.bodies) != 0 {
+			t.Fatalf("only a run owing a gate verdict may say \"the verdict lands here\", got %v", c.bodies)
+		}
+	})
+
 	t.Run("a run that gates nothing stays silent", func(t *testing.T) {
 		s, c := newWorld(t)
 		at := time.Now().UTC().Add(time.Hour)

--- a/pkg/server/forge_gate_pause_notice_test.go
+++ b/pkg/server/forge_gate_pause_notice_test.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+type stubCommenter struct {
+	bodies []string
+	repo   string
+	number int
+}
+
+func (c *stubCommenter) CommentIssue(_ context.Context, repo string, number int, body string) (forge.CommentRef, error) {
+	c.repo, c.number = repo, number
+	c.bodies = append(c.bodies, body)
+	return forge.CommentRef{}, nil
+}
+
+// A review parked on a provider quota leaves its required check on the
+// in-flight claim — which reads exactly like a review that died. The park
+// must therefore say so on the pull request: what happened, when it
+// resumes, and (for a spend ceiling) that waiting alone may not be enough.
+func TestGatePausedNoticePostsOnThePR(t *testing.T) {
+	const (
+		team  = "t1"
+		repo  = "acme/widgets"
+		prURL = "https://github.com/acme/widgets/pull/7"
+	)
+	newWorld := func(t *testing.T) (*Server, *stubCommenter) {
+		t.Helper()
+		s := newWebhookTestServer(t)
+		rs, err := store.New(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		s.cfg.Store = rs
+		conns := forge.NewMemoryConnectionStore()
+		if err := conns.Create(context.Background(), forge.Connection{
+			ID: "c1", TenantID: team, Provider: forge.ProviderGitHub,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		s.forgeConnections = conns
+		s.forgePublishTokens = NewForgePublishTokenRegistry()
+		s.forgePublishTokens.Register("run-token", ForgePublishGrant{TeamID: team, ConnectionID: "c1", Repo: repo})
+		c := &stubCommenter{}
+		s.forgeIssueCommenterFor = func(context.Context, forge.Connection) (forgeIssueCommenter, error) {
+			return c, nil
+		}
+		return s, c
+	}
+	parkedRun := func(t *testing.T, s *Server, errText string, at time.Time) *store.Run {
+		t.Helper()
+		id, err := store.GenerateRunID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		run, err := s.cfg.Store.CreateRun(context.Background(), id, "review-pr", map[string]any{
+			"pr_url": prURL, forgePublishVarToken: "run-token", "gate_context": "revi/review",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		run.Status = store.RunStatusFailedResumable
+		run.Error = errText
+		run.RetryState = &store.RunRetryState{RetryAfter: &at, Reason: "usage_window", Attempts: 2}
+		if err := s.cfg.Store.SaveRun(context.Background(), run); err != nil {
+			t.Fatal(err)
+		}
+		return run
+	}
+
+	t.Run("window park says when it resumes", func(t *testing.T) {
+		s, c := newWorld(t)
+		at := time.Now().UTC().Add(95 * time.Minute)
+		run := parkedRun(t, s, "node \"campaign\": rate_limited: You've hit your weekly limit · resets 9pm", at)
+
+		s.noticeGatePausedForRetry(context.Background(), run)
+
+		if len(c.bodies) != 1 {
+			t.Fatalf("exactly one notice must be posted, got %d", len(c.bodies))
+		}
+		body := c.bodies[0]
+		if c.repo != repo || c.number != 7 {
+			t.Fatalf("notice landed on %s#%d", c.repo, c.number)
+		}
+		for _, want := range []string{"Review paused", at.Format("15:04 UTC"), "attempt 2", "weekly limit"} {
+			if !strings.Contains(body, want) {
+				t.Fatalf("notice missing %q:\n%s", want, body)
+			}
+		}
+		if strings.Contains(body, "Waiting may not be enough") {
+			t.Fatal("a provider WINDOW does reopen on schedule — the spend caveat must not appear")
+		}
+	})
+
+	t.Run("spend ceiling warns that waiting may not suffice", func(t *testing.T) {
+		s, c := newWorld(t)
+		run := parkedRun(t, s, "node \"campaign\": rate_limited: You've hit your org's monthly spend limit · ask your admin to raise it", time.Now().UTC().Add(time.Hour))
+
+		s.noticeGatePausedForRetry(context.Background(), run)
+
+		if len(c.bodies) != 1 || !strings.Contains(c.bodies[0], "Waiting may not be enough") {
+			t.Fatalf("a spend ceiling must say an admin has to act:\n%v", c.bodies)
+		}
+	})
+
+	t.Run("a run that gates nothing stays silent", func(t *testing.T) {
+		s, c := newWorld(t)
+		at := time.Now().UTC().Add(time.Hour)
+		id, err := store.GenerateRunID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		run, err := s.cfg.Store.CreateRun(context.Background(), id, "feed-watch", map[string]any{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		run.Status = store.RunStatusFailedResumable
+		run.RetryState = &store.RunRetryState{RetryAfter: &at}
+
+		s.noticeGatePausedForRetry(context.Background(), run)
+
+		if len(c.bodies) != 0 {
+			t.Fatalf("a non-gating run must post nothing, got %v", c.bodies)
+		}
+	})
+}

--- a/pkg/server/forge_gate_reconcile.go
+++ b/pkg/server/forge_gate_reconcile.go
@@ -188,6 +188,13 @@ func (s *Server) reconcileGateForRunID(ctx context.Context, runID, via string) e
 	// silently unmergeable. Those runs ARE dead; reconcile them.
 	if run.Status == store.RunStatusFailedResumable &&
 		run.RetryState != nil && run.RetryState.RetryAfter != nil {
+		// Not dead, but not silent either: the check stays on its in-flight
+		// claim, which reads identically to a review that died. Say on the
+		// PR that it parked and when it resumes — on the EVENT only, since
+		// the sweep re-offers this same run every minute for an hour.
+		if via == gateTriggerEvent {
+			s.noticeGatePausedForRetry(ctx, run)
+		}
 		return nil
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -382,6 +382,11 @@ type Server struct {
 	// commit-status write). Nil → real admin client via forgeAdminFor.
 	forgeGateClientFor func(ctx context.Context, conn forge.Connection) (forgeGateClient, error)
 
+	// forgeIssueCommenterFor is a test seam overriding how a connection's
+	// PR-comment client is resolved (the parked-review pause notice).
+	// Nil → real admin client via forgeAdminFor.
+	forgeIssueCommenterFor func(ctx context.Context, conn forge.Connection) (forgeIssueCommenter, error)
+
 	// forgeReviewerAssignerFor is a test seam overriding how the
 	// publish-review handler resolves a connection's reviewer self-assign
 	// capability (nil result = capability absent). Nil field → real admin

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -93,13 +93,18 @@ const featureDevBotID = "feature-dev"
 // provider that doesn't have e.g. a project path leaves it empty and
 // the delivery row simply omits it.
 type webhookEventMeta struct {
-	Kind         string // "merge_request" | "pull_request" | "note" | "generic"
-	Action       string // "open" | "reopen" | "comment" | …
-	ProjectPath  string // "owner/repo" or equivalent
-	SubjectID    string // "mr:7" / "pr:42" / "note:99" — stable per-event id
-	SubjectURL   string // the subject's own web URL/ref (the issue/MR the comment is on) — back-linked as source_issue_ref for opens_mr commands
-	SubjectSHA   string // head SHA, when known
-	SenderHandle string // username for audit (logged only, never in delivery audit row v1)
+	Kind        string // "merge_request" | "pull_request" | "note" | "generic"
+	Action      string // "open" | "reopen" | "comment" | …
+	ProjectPath string // "owner/repo" or equivalent
+	SubjectID   string // "mr:7" / "pr:42" / "note:99" — stable per-event id
+	// ParentSubjectID is the PR/MR a comment subject hangs off ("pr:7"),
+	// empty when the subject is the pull request itself or a plain issue.
+	// Persisted on the delivery so "every run this pull request launched"
+	// is answerable across the comment lanes.
+	ParentSubjectID string
+	SubjectURL      string // the subject's own web URL/ref (the issue/MR the comment is on) — back-linked as source_issue_ref for opens_mr commands
+	SubjectSHA      string // head SHA, when known
+	SenderHandle    string // username for audit (logged only, never in delivery audit row v1)
 }
 
 // applyWebhookVarLayers puts the two webhook-level var layers onto a
@@ -612,19 +617,20 @@ func (s *Server) checkBotPermitted(
 // row to StatusLaunched once the launch returns.
 func newWebhookDelivery(cfg webhooks.Config, meta webhookEventMeta, status, payloadHash, srcIP string) webhooks.Delivery {
 	return webhooks.Delivery{
-		ID:          uuid.NewString(),
-		TenantID:    cfg.TenantID,
-		WebhookID:   cfg.ID,
-		Provider:    cfg.Provider,
-		EventKind:   meta.Kind,
-		EventAction: meta.Action,
-		ProjectPath: meta.ProjectPath,
-		SubjectID:   meta.SubjectID,
-		SubjectSHA:  meta.SubjectSHA,
-		PayloadHash: payloadHash,
-		Status:      status,
-		SourceIP:    srcIP,
-		ReceivedAt:  time.Now().UTC(),
+		ID:              uuid.NewString(),
+		TenantID:        cfg.TenantID,
+		WebhookID:       cfg.ID,
+		Provider:        cfg.Provider,
+		EventKind:       meta.Kind,
+		EventAction:     meta.Action,
+		ProjectPath:     meta.ProjectPath,
+		SubjectID:       meta.SubjectID,
+		ParentSubjectID: meta.ParentSubjectID,
+		SubjectSHA:      meta.SubjectSHA,
+		PayloadHash:     payloadHash,
+		Status:          status,
+		SourceIP:        srcIP,
+		ReceivedAt:      time.Now().UTC(),
 	}
 }
 

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -1185,3 +1185,82 @@ func (s *Server) launchWebhookTarget(
 	out.RunID, out.DeliveryID = runID, delivery.ID
 	return out
 }
+
+// prClosedRunReason names the cancel so the run list, and the merge-gate
+// synthetic status that quotes run.Error, say WHY. "cancelled by user"
+// there once sent operators hunting for a human who did nothing.
+const prClosedRunReason = "pull request closed or merged — nothing left to review"
+
+// stopRunsForDeadPR ends every run still bound to a pull request that just
+// closed or merged, and disarms any usage-window retry armed for one.
+//
+// Two distinct leaks, both observed: a run in FLIGHT keeps spending
+// provider quota on a diff nobody will merge, and a run PARKED on a
+// provider window is a promise to come back — hours later, to review and
+// comment on a dead pull request. Cancelling covers the first; the retry
+// disarm covers the second, and it is the one nothing else would do (the
+// retry lives in the store, not in the run's process).
+//
+// Scoped to the delivery's own subject (`pr:<n>`) across EVERY bot, unlike
+// supersedeLiveRuns which is per-bot: supersede replaces one bot's work
+// with newer work of the same bot, while a closed PR ends everyone's.
+// Best-effort throughout — the close event must answer 200 regardless, or
+// the forge starts disabling the hook.
+//
+// Returns how many runs it stopped, for the delivery audit reason.
+func (s *Server) stopRunsForDeadPR(ctx context.Context, cfg webhooks.Config, meta webhookEventMeta) int {
+	if s.webhookDeliveries == nil || meta.SubjectID == "" {
+		return 0
+	}
+	cancel := s.webhookCancelRun
+	if cancel == nil && s.runs != nil {
+		cancel = func(runID string) error {
+			return s.runs.CancelWithReason(runID, prClosedRunReason)
+		}
+	}
+	retries := store.AsRunRetryStore(s.cfg.Store)
+	if cancel == nil && retries == nil {
+		return 0
+	}
+	recent, err := s.webhookDeliveries.ListByWebhook(ctx, cfg.TenantID, cfg.ID, supersedeLookback)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Warn("webhooks: closed-PR stop lookup failed for %s %s: %v", cfg.ID, meta.SubjectID, err)
+		}
+		return 0
+	}
+	stopped := 0
+	seen := make(map[string]bool, len(recent))
+	for _, d := range recent {
+		if d.RunID == "" || d.SubjectID != meta.SubjectID || d.Status != webhooks.StatusLaunched {
+			continue
+		}
+		if seen[d.RunID] {
+			continue // one PR can have several deliveries per run's lifetime
+		}
+		seen[d.RunID] = true
+		// Disarm FIRST: a cancel that lands while a retry is still armed
+		// leaves the promise standing, and the sweeper would resume the
+		// run we just cancelled.
+		if retries != nil {
+			if aerr := retries.AbandonRunRetry(ctx, d.RunID, prClosedRunReason); aerr != nil && s.logger != nil {
+				s.logger.Debug("webhooks: could not disarm the retry of run %s on a closed PR: %v", d.RunID, aerr)
+			}
+		}
+		if cancel == nil {
+			continue
+		}
+		if cerr := cancel(d.RunID); cerr != nil {
+			// Ordinary: the run already finished. Only a live run cancels.
+			if s.logger != nil {
+				s.logger.Debug("webhooks: closed-PR stop could not cancel run %s (likely already finished): %v", d.RunID, cerr)
+			}
+			continue
+		}
+		stopped++
+		if s.logger != nil {
+			s.logger.Info("webhooks: stopped run %s (%s on %s) — its pull request closed or merged", d.RunID, d.BotID, meta.SubjectID)
+		}
+	}
+	return stopped
+}

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -1201,15 +1201,27 @@ const prClosedRunReason = "pull request closed or merged — nothing left to rev
 // disarm covers the second, and it is the one nothing else would do (the
 // retry lives in the store, not in the run's process).
 //
-// Scoped to the delivery's own subject (`pr:<n>`) across EVERY bot, unlike
-// supersedeLiveRuns which is per-bot: supersede replaces one bot's work
-// with newer work of the same bot, while a closed PR ends everyone's.
-// Best-effort throughout — the close event must answer 200 regardless, or
-// the forge starts disabling the hook.
+// Scoped to (project, subject) across EVERY bot, unlike supersedeLiveRuns
+// which is per-bot: supersede replaces one bot's work with newer work of
+// the same bot, while a closed PR ends everyone's. The PROJECT half is
+// load-bearing — a subject id ("pr:7") carries no repo and one webhook
+// config can serve several, so matching the subject alone would cancel a
+// same-numbered pull request of another repo.
 //
-// Returns how many runs it stopped, for the delivery audit reason.
+// The scan is the EXACT by-subject query, never the recency-bounded one
+// supersede uses: the run this exists to reach is the one parked hours
+// ago, i.e. precisely the delivery a 50-row window has already dropped.
+//
+// Only runs still LIVE are touched. A merged PR's history is mostly
+// finished reviews, and disarming a retry that was never armed writes a
+// stop reason onto a run that succeeded — a lie the next person debugging
+// retries would read as fact.
+//
+// Best-effort throughout — the close event must answer 200 regardless, or
+// the forge starts disabling the hook. Returns how many runs it actually
+// stopped, for the delivery audit reason.
 func (s *Server) stopRunsForDeadPR(ctx context.Context, cfg webhooks.Config, meta webhookEventMeta) int {
-	if s.webhookDeliveries == nil || meta.SubjectID == "" {
+	if s.webhookDeliveries == nil || meta.SubjectID == "" || meta.ProjectPath == "" {
 		return 0
 	}
 	cancel := s.webhookCancelRun
@@ -1222,23 +1234,23 @@ func (s *Server) stopRunsForDeadPR(ctx context.Context, cfg webhooks.Config, met
 	if cancel == nil && retries == nil {
 		return 0
 	}
-	recent, err := s.webhookDeliveries.ListByWebhook(ctx, cfg.TenantID, cfg.ID, supersedeLookback)
+	launched, err := s.webhookDeliveries.ListLaunchedBySubject(ctx, cfg.TenantID, cfg.ID, meta.ProjectPath, meta.SubjectID)
 	if err != nil {
 		if s.logger != nil {
-			s.logger.Warn("webhooks: closed-PR stop lookup failed for %s %s: %v", cfg.ID, meta.SubjectID, err)
+			s.logger.Warn("webhooks: closed-PR stop lookup failed for %s %s %s: %v", cfg.ID, meta.ProjectPath, meta.SubjectID, err)
 		}
 		return 0
 	}
 	stopped := 0
-	seen := make(map[string]bool, len(recent))
-	for _, d := range recent {
-		if d.RunID == "" || d.SubjectID != meta.SubjectID || d.Status != webhooks.StatusLaunched {
-			continue
-		}
-		if seen[d.RunID] {
-			continue // one PR can have several deliveries per run's lifetime
+	seen := make(map[string]bool, len(launched))
+	for _, d := range launched {
+		if d.RunID == "" || seen[d.RunID] {
+			continue // one PR has several deliveries per run's lifetime
 		}
 		seen[d.RunID] = true
+		if !s.runIsStoppable(ctx, d.RunID) {
+			continue
+		}
 		// Disarm FIRST: a cancel that lands while a retry is still armed
 		// leaves the promise standing, and the sweeper would resume the
 		// run we just cancelled.
@@ -1251,16 +1263,44 @@ func (s *Server) stopRunsForDeadPR(ctx context.Context, cfg webhooks.Config, met
 			continue
 		}
 		if cerr := cancel(d.RunID); cerr != nil {
-			// Ordinary: the run already finished. Only a live run cancels.
 			if s.logger != nil {
-				s.logger.Debug("webhooks: closed-PR stop could not cancel run %s (likely already finished): %v", d.RunID, cerr)
+				s.logger.Debug("webhooks: closed-PR stop could not cancel run %s (it may have just settled): %v", d.RunID, cerr)
 			}
 			continue
 		}
 		stopped++
 		if s.logger != nil {
-			s.logger.Info("webhooks: stopped run %s (%s on %s) — its pull request closed or merged", d.RunID, d.BotID, meta.SubjectID)
+			s.logger.Info("webhooks: stopped run %s (%s on %s %s) — its pull request closed or merged", d.RunID, d.BotID, meta.ProjectPath, meta.SubjectID)
 		}
 	}
 	return stopped
+}
+
+// runIsStoppable reports whether a run is still live enough for the
+// closed-PR stop to touch it: running/queued/paused (cancel it) or parked
+// with an armed retry (disarm the promise). A settled run is left alone —
+// writing a stop reason onto a review that finished hours ago tells the
+// next reader something false about it.
+//
+// Fails OPEN (true) when the run cannot be read: a store blip must not
+// strand a live run on a dead pull request, and both actions are no-ops
+// on a settled run anyway.
+func (s *Server) runIsStoppable(ctx context.Context, runID string) bool {
+	if s.cfg.Store == nil {
+		return true
+	}
+	run, err := s.cfg.Store.LoadRun(store.WithoutTenantFilter(ctx), runID)
+	if err != nil || run == nil {
+		return true
+	}
+	switch run.Status {
+	case store.RunStatusRunning, store.RunStatusQueued,
+		store.RunStatusPausedWaitingHuman, store.RunStatusPausedOperator:
+		return true
+	case store.RunStatusFailedResumable:
+		// Only the ones something will actually come back for.
+		return run.RetryState != nil && run.RetryState.RetryAfter != nil
+	default:
+		return false
+	}
 }

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -98,7 +98,9 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 	// PARKED on a usage window wakes up hours later — after the retry the
 	// gate reconciler is deliberately waiting on — to review, and comment
 	// on, a dead PR. Stopping is not launching, so it runs before the fork
-	// guard: a fork PR's `/command` runs must stop too.
+	// guard: a fork PR's `/command` runs must stop too — they are reached
+	// through the delivery's ParentSubjectID, since a command records the
+	// COMMENT's id as its own subject.
 	if p.IsClosed() {
 		stopped := s.stopRunsForDeadPR(ctx, cfg, meta)
 		reason := "pull request closed — no runs to stop"

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -92,6 +92,24 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 	}
 	meta := prforgePRMeta(p)
 
+	// A CLOSED or MERGED pull request ends every review it still owes.
+	// Two costs otherwise, both paid in production: a run in flight keeps
+	// burning provider quota to judge a diff nobody will merge, and a run
+	// PARKED on a usage window wakes up hours later — after the retry the
+	// gate reconciler is deliberately waiting on — to review, and comment
+	// on, a dead PR. Stopping is not launching, so it runs before the fork
+	// guard: a fork PR's `/command` runs must stop too.
+	if p.IsClosed() {
+		stopped := s.stopRunsForDeadPR(ctx, cfg, meta)
+		reason := "pull request closed — no runs to stop"
+		if stopped > 0 {
+			reason = fmt.Sprintf("pull request closed — stopped %d run(s) still bound to it", stopped)
+		}
+		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP, reason)
+		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
+		return
+	}
+
 	// Fork guard (UNCONDITIONAL on the auto path): a fork PR (head repo != base
 	// repo) is untrusted — an adversary can open one to run code in our runner
 	// with the forge token and to exhaust the tenant's budget. So an inbound PR

--- a/pkg/server/webhooks_pr_closed_test.go
+++ b/pkg/server/webhooks_pr_closed_test.go
@@ -30,10 +30,17 @@ func TestGitHubWebhook_ClosedPRStopsItsRuns(t *testing.T) {
 	// Two launched runs on this PR (two different bots) plus one on
 	// another PR, which must be left alone.
 	for _, d := range []webhooks.Delivery{
-		{ID: "d1", TenantID: cfg.TenantID, WebhookID: cfg.ID, SubjectID: "pr:7", BotID: "review-pr", RunID: "run-a", Status: webhooks.StatusLaunched},
-		{ID: "d2", TenantID: cfg.TenantID, WebhookID: cfg.ID, SubjectID: "pr:7", BotID: "branch-improve-loop", RunID: "run-b", Status: webhooks.StatusLaunched},
-		{ID: "d3", TenantID: cfg.TenantID, WebhookID: cfg.ID, SubjectID: "pr:9", BotID: "review-pr", RunID: "run-c", Status: webhooks.StatusLaunched},
-		{ID: "d4", TenantID: cfg.TenantID, WebhookID: cfg.ID, SubjectID: "pr:7", BotID: "review-pr", RunID: "run-d", Status: webhooks.StatusFiltered},
+		{ID: "d1", TenantID: cfg.TenantID, WebhookID: cfg.ID, ProjectPath: "acme/widgets", SubjectID: "pr:7", BotID: "review-pr", RunID: "run-a", Status: webhooks.StatusLaunched},
+		{ID: "d2", TenantID: cfg.TenantID, WebhookID: cfg.ID, ProjectPath: "acme/widgets", SubjectID: "pr:7", BotID: "branch-improve-loop", RunID: "run-b", Status: webhooks.StatusLaunched},
+		{ID: "d3", TenantID: cfg.TenantID, WebhookID: cfg.ID, ProjectPath: "acme/widgets", SubjectID: "pr:9", BotID: "review-pr", RunID: "run-c", Status: webhooks.StatusLaunched},
+		// A filtered delivery launched nothing, so it carries no run id —
+		// which is exactly what makes it invisible to the by-subject query
+		// (the store defines "launched" as having one, like CountLaunched).
+		{ID: "d4", TenantID: cfg.TenantID, WebhookID: cfg.ID, ProjectPath: "acme/widgets", SubjectID: "pr:7", BotID: "review-pr", Status: webhooks.StatusFiltered},
+		// SAME subject id, ANOTHER repo on the same multi-project webhook:
+		// PR numbers collide freely across repos, and cancelling this one
+		// would block an unrelated pull request.
+		{ID: "d5", TenantID: cfg.TenantID, WebhookID: cfg.ID, ProjectPath: "acme/other", SubjectID: "pr:7", BotID: "review-pr", RunID: "run-e", Status: webhooks.StatusLaunched},
 	} {
 		if err := s.webhookDeliveries.Insert(context.Background(), d); err != nil {
 			t.Fatal(err)
@@ -67,6 +74,9 @@ func TestGitHubWebhook_ClosedPRStopsItsRuns(t *testing.T) {
 		}
 		if id == "run-d" {
 			t.Fatal("a delivery that never launched carries no run to cancel")
+		}
+		if id == "run-e" {
+			t.Fatal("a same-numbered PR of ANOTHER repo was cancelled — the stop must be project-scoped")
 		}
 	}
 }

--- a/pkg/server/webhooks_pr_closed_test.go
+++ b/pkg/server/webhooks_pr_closed_test.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/webhooks"
+	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
+)
+
+const ghClosedPR = `{
+  "action": "closed",
+  "number": 7,
+  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+  "pull_request": {"number": 7, "title": "Add X", "body": "desc",
+    "html_url": "https://github.com/acme/widgets/pull/7", "state": "closed", "merged": true,
+    "head": {"ref": "feature/x", "sha": "abc123"}, "base": {"ref": "main"}},
+  "sender": {"login": "alice"}
+}`
+
+// A merged or closed pull request ends every review still bound to it: a
+// run in flight burns provider quota on a diff nobody will merge, and a
+// PARKED run would wake hours later to comment on a dead PR.
+func TestGitHubWebhook_ClosedPRStopsItsRuns(t *testing.T) {
+	s := newWebhookTestServer(t)
+	cfg, pt := ghConfig(t, s)
+
+	// Two launched runs on this PR (two different bots) plus one on
+	// another PR, which must be left alone.
+	for _, d := range []webhooks.Delivery{
+		{ID: "d1", TenantID: cfg.TenantID, WebhookID: cfg.ID, SubjectID: "pr:7", BotID: "review-pr", RunID: "run-a", Status: webhooks.StatusLaunched},
+		{ID: "d2", TenantID: cfg.TenantID, WebhookID: cfg.ID, SubjectID: "pr:7", BotID: "branch-improve-loop", RunID: "run-b", Status: webhooks.StatusLaunched},
+		{ID: "d3", TenantID: cfg.TenantID, WebhookID: cfg.ID, SubjectID: "pr:9", BotID: "review-pr", RunID: "run-c", Status: webhooks.StatusLaunched},
+		{ID: "d4", TenantID: cfg.TenantID, WebhookID: cfg.ID, SubjectID: "pr:7", BotID: "review-pr", RunID: "run-d", Status: webhooks.StatusFiltered},
+	} {
+		if err := s.webhookDeliveries.Insert(context.Background(), d); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var cancelled []string
+	s.webhookCancelRun = func(runID string) error {
+		cancelled = append(cancelled, runID)
+		return nil
+	}
+	launched := 0
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		launched++
+		return "run-x", nil
+	}
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghClosedPR, prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusOK {
+		t.Fatalf("a closed PR must answer 200/filtered (a 4xx gets the hook disabled): code=%d body=%s", w.Code, w.Body.String())
+	}
+	if launched != 0 {
+		t.Fatalf("a closed PR must launch nothing, launched=%d", launched)
+	}
+	if len(cancelled) != 2 {
+		t.Fatalf("both live runs of pr:7 must stop, got %v", cancelled)
+	}
+	for _, id := range cancelled {
+		if id == "run-c" {
+			t.Fatal("another PR's run was cancelled — the stop must be scoped to the subject")
+		}
+		if id == "run-d" {
+			t.Fatal("a delivery that never launched carries no run to cancel")
+		}
+	}
+}
+
+// The action is what says "this PR is over": a synchronize whose payload
+// happens to carry a closed state is a race, and must not end a review.
+func TestParsedIsClosed(t *testing.T) {
+	closed, err := prforge.ParsePullRequest([]byte(ghClosedPR))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !closed.IsClosed() {
+		t.Fatalf("merged PR must read as closed: %+v", closed)
+	}
+	open, err := prforge.ParsePullRequest([]byte(ghOpenPR))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if open.IsClosed() {
+		t.Fatal("an opened PR must not read as closed")
+	}
+}

--- a/pkg/server/webhooks_pr_closed_test.go
+++ b/pkg/server/webhooks_pr_closed_test.go
@@ -37,6 +37,11 @@ func TestGitHubWebhook_ClosedPRStopsItsRuns(t *testing.T) {
 		// which is exactly what makes it invisible to the by-subject query
 		// (the store defines "launched" as having one, like CountLaunched).
 		{ID: "d4", TenantID: cfg.TenantID, WebhookID: cfg.ID, ProjectPath: "acme/widgets", SubjectID: "pr:7", BotID: "review-pr", Status: webhooks.StatusFiltered},
+		// A `/billy` fixer launched from a COMMENT: its own subject is the
+		// comment id, and only the parent link ties it to pr:7. Before that
+		// link the stop could not reach it — the exact run whose quota it
+		// keeps burning on a merged PR.
+		{ID: "d6", TenantID: cfg.TenantID, WebhookID: cfg.ID, ProjectPath: "acme/widgets", SubjectID: "comment:99", ParentSubjectID: "pr:7", BotID: "branch-improve-loop", RunID: "run-f", Status: webhooks.StatusLaunched},
 		// SAME subject id, ANOTHER repo on the same multi-project webhook:
 		// PR numbers collide freely across repos, and cancelling this one
 		// would block an unrelated pull request.
@@ -65,8 +70,17 @@ func TestGitHubWebhook_ClosedPRStopsItsRuns(t *testing.T) {
 	if launched != 0 {
 		t.Fatalf("a closed PR must launch nothing, launched=%d", launched)
 	}
-	if len(cancelled) != 2 {
-		t.Fatalf("both live runs of pr:7 must stop, got %v", cancelled)
+	if len(cancelled) != 3 {
+		t.Fatalf("every live run of pr:7 must stop — including the comment-launched fixer, got %v", cancelled)
+	}
+	var sawComment bool
+	for _, id := range cancelled {
+		if id == "run-f" {
+			sawComment = true
+		}
+	}
+	if !sawComment {
+		t.Fatal("a /command run reaches the PR only through ParentSubjectID — the stop missed it")
 	}
 	for _, id := range cancelled {
 		if id == "run-c" {

--- a/pkg/server/webhooks_prforge.go
+++ b/pkg/server/webhooks_prforge.go
@@ -182,11 +182,12 @@ func buildPRForgeCommandVars(p prforge.ParsedNote, pr *forge.PullRef, route webh
 
 func prforgeNoteMeta(p prforge.ParsedNote) webhookEventMeta {
 	return webhookEventMeta{
-		Kind:         "issue_comment",
-		Action:       "comment",
-		ProjectPath:  p.ProjectPath,
-		SubjectID:    p.SubjectID(),
-		SenderHandle: p.AuthorLogin,
+		Kind:            "issue_comment",
+		Action:          "comment",
+		ProjectPath:     p.ProjectPath,
+		SubjectID:       p.SubjectID(),
+		ParentSubjectID: p.ParentSubjectID(),
+		SenderHandle:    p.AuthorLogin,
 		// IssueURL is the issue/PR the comment sits on — the back-link target a
 		// command bot posts its opened MR/PR URL onto (via the ensureBoardCard
 		// open_mr stamp). Works for both surfaces (Surface()=="pr"|"issue").
@@ -449,13 +450,14 @@ func (s *Server) handlePRForgeReviewThreadReply(ctx context.Context, w http.Resp
 // reply.
 func prforgeReviewCommentMeta(p prforge.ParsedReviewComment) webhookEventMeta {
 	return webhookEventMeta{
-		Kind:         "review_comment",
-		Action:       "comment",
-		ProjectPath:  p.ProjectPath,
-		SubjectID:    p.SubjectID(),
-		SubjectURL:   p.PRURL,
-		SubjectSHA:   p.HeadSHA,
-		SenderHandle: p.AuthorLogin,
+		Kind:            "review_comment",
+		Action:          "comment",
+		ProjectPath:     p.ProjectPath,
+		SubjectID:       p.SubjectID(),
+		ParentSubjectID: p.ParentSubjectID(),
+		SubjectURL:      p.PRURL,
+		SubjectSHA:      p.HeadSHA,
+		SenderHandle:    p.AuthorLogin,
 	}
 }
 

--- a/pkg/usagecap/usagecap.go
+++ b/pkg/usagecap/usagecap.go
@@ -72,6 +72,19 @@ const (
 	// around a credential the provider will not serve, and freshness for
 	// a reading with no reset instant is already bounded by ObservedAt.
 	WindowFrequency Window = "frequency"
+	// WindowSpend is not a provider window either: it is the ACCOUNT's
+	// money ceiling, set by its own admin ("You've hit your org's monthly
+	// spend limit · ask your admin to raise it"), relayed as text rather
+	// than as window telemetry. Distinct from WindowOverage — that is a
+	// channel the plan may spill INTO, this is the wall it stops at — and
+	// from WindowFrequency, which refuses the request RATE while the
+	// budget is intact. It carries no reset instant (a human raises the
+	// ceiling, or the calendar month rolls), so freshness is bounded by
+	// ObservedAt like the other two refusals, and the credential-tier
+	// skip is the consumer: a credential whose org budget is spent serves
+	// NOTHING, so the resolver must route around it instead of feeding
+	// every node of every run into the same wall.
+	WindowSpend Window = "spend"
 	// WindowAuth is not a provider window either: it is the provider
 	// REJECTING THE CREDENTIAL ITSELF — a dead token, an expired OAuth
 	// record, a malformed secret. Like WindowFrequency it exists as a
@@ -116,7 +129,7 @@ func FamilyOf(w Window) Family {
 		return FamilyFiveHour
 	case WindowSevenDay, WindowSevenDayOpus, WindowSevenDaySonnet, WindowSevenDayOverageIncluded:
 		return FamilyWeek
-	case WindowFrequency:
+	case WindowFrequency, WindowSpend:
 		return FamilyAccount
 	case WindowAuth:
 		return FamilyCredential

--- a/pkg/usagecap/usagecap_test.go
+++ b/pkg/usagecap/usagecap_test.go
@@ -234,3 +234,19 @@ func TestWindowAuth_evidenceNotCap(t *testing.T) {
 		t.Fatal("an auth refusal must never block a launch through the usage cap — it is routing evidence, not quota")
 	}
 }
+
+// WindowSpend exists for ONE consumer: the credential-tier skip, which is
+// gated on FamilyOf(window) != FamilyNone. Drop the case (or let the
+// window fall to default) and every spend refusal is filtered out at that
+// consumer — the feature goes inert with nothing failing. Sibling of
+// TestWindowAuth_evidenceNotCap, for the same reason.
+func TestWindowSpend_evidenceNotCap(t *testing.T) {
+	if got := FamilyOf(WindowSpend); got != FamilyAccount {
+		t.Fatalf("FamilyOf(WindowSpend) = %q, want %q — FamilyNone would make the evidence consumers drop it", got, FamilyAccount)
+	}
+	// It governs no operator cap: an account ceiling is the provider's
+	// wall, not a percentage iterion stops itself at.
+	if p := (Policy{}).For(FamilyAccount); p.Enabled() {
+		t.Fatalf("FamilyAccount must stay uncapped (the provider's wall, not a percentage we stop at), got %+v", p)
+	}
+}

--- a/pkg/webhooks/memory.go
+++ b/pkg/webhooks/memory.go
@@ -99,7 +99,8 @@ func (s *MemoryDeliveryStore) CountLaunched(_ context.Context, tenantID, webhook
 func (s *MemoryDeliveryStore) ListLaunchedBySubject(_ context.Context, tenantID, webhookID, projectPath, subjectID string) ([]Delivery, error) {
 	return s.kit.List(func(d Delivery) bool {
 		return d.TenantID == tenantID && d.WebhookID == webhookID &&
-			d.ProjectPath == projectPath && d.SubjectID == subjectID && d.RunID != ""
+			d.ProjectPath == projectPath && d.RunID != "" &&
+			(d.SubjectID == subjectID || d.ParentSubjectID == subjectID)
 	}), nil
 }
 

--- a/pkg/webhooks/memory.go
+++ b/pkg/webhooks/memory.go
@@ -95,6 +95,14 @@ func (s *MemoryDeliveryStore) CountLaunched(_ context.Context, tenantID, webhook
 	})), nil
 }
 
+// ListLaunchedBySubject returns the subject's launched deliveries.
+func (s *MemoryDeliveryStore) ListLaunchedBySubject(_ context.Context, tenantID, webhookID, projectPath, subjectID string) ([]Delivery, error) {
+	return s.kit.List(func(d Delivery) bool {
+		return d.TenantID == tenantID && d.WebhookID == webhookID &&
+			d.ProjectPath == projectPath && d.SubjectID == subjectID && d.RunID != ""
+	}), nil
+}
+
 // MemoryCounter is an in-process monthly Counter. Production uses the
 // Mongo CAS variant; this one is mutex-serialised.
 type MemoryCounter struct {

--- a/pkg/webhooks/mongo.go
+++ b/pkg/webhooks/mongo.go
@@ -132,6 +132,20 @@ func (s *MongoDeliveryStore) CountLaunched(ctx context.Context, tenantID, webhoo
 	return int(n), nil
 }
 
+// ListLaunchedBySubject returns the subject's launched deliveries, newest
+// first. Unbounded by design (see the interface): one pull request's own
+// launches are few, and the point is to miss none.
+func (s *MongoDeliveryStore) ListLaunchedBySubject(ctx context.Context, tenantID, webhookID, projectPath, subjectID string) ([]Delivery, error) {
+	return s.kit.List(ctx, bson.M{
+		"tenant_id":    tenantID,
+		"webhook_id":   webhookID,
+		"project_path": projectPath,
+		"subject_id":   subjectID,
+		"run_id":       bson.M{"$nin": bson.A{nil, ""}},
+	}, "list launched deliveries by subject", "decode launched deliveries",
+		options.Find().SetSort(bson.M{"received_at": -1}))
+}
+
 // ---- MongoCounter ----
 
 type MongoCounter struct{ col *mongo.Collection }

--- a/pkg/webhooks/mongo.go
+++ b/pkg/webhooks/mongo.go
@@ -140,8 +140,11 @@ func (s *MongoDeliveryStore) ListLaunchedBySubject(ctx context.Context, tenantID
 		"tenant_id":    tenantID,
 		"webhook_id":   webhookID,
 		"project_path": projectPath,
-		"subject_id":   subjectID,
 		"run_id":       bson.M{"$nin": bson.A{nil, ""}},
+		"$or": bson.A{
+			bson.M{"subject_id": subjectID},
+			bson.M{"parent_subject_id": subjectID},
+		},
 	}, "list launched deliveries by subject", "decode launched deliveries",
 		options.Find().SetSort(bson.M{"received_at": -1}))
 }

--- a/pkg/webhooks/prforge/note.go
+++ b/pkg/webhooks/prforge/note.go
@@ -103,6 +103,18 @@ func (p ParsedNote) SubjectID() string {
 	return "comment:" + strconv.FormatInt(p.CommentID, 10)
 }
 
+// ParentSubjectID names the PULL REQUEST a comment hangs off ("pr:7"), or
+// "" when the comment sits on a plain issue. Distinct from SubjectID,
+// which identifies the comment itself and is what per-comment idempotency
+// keys on: a consumer asking "what did this pull request launch" — the
+// closed-PR stop — cannot find a `/billy` run through "comment:99".
+func (p ParsedNote) ParentSubjectID() string {
+	if !p.IsPullRequest || p.IssueNumber == 0 {
+		return ""
+	}
+	return "pr:" + strconv.FormatInt(p.IssueNumber, 10)
+}
+
 // Command extracts a leading slash-command from the comment body, e.g.
 // "/featurly add export" → ("featurly", "add export"). Returns ("", "") when
 // the comment does not start with a command. Delegates to

--- a/pkg/webhooks/prforge/parser.go
+++ b/pkg/webhooks/prforge/parser.go
@@ -203,3 +203,13 @@ func (p Parsed) StateOpenOrUnknown() bool {
 func (p Parsed) SubjectID() string {
 	return "pr:" + strconv.FormatInt(p.PRNumber, 10)
 }
+
+// IsClosed reports whether this delivery says the pull request is over —
+// merged or closed unmerged, which for a review are the same fact: there
+// is nothing left to judge. Anchored on the ACTION rather than the state
+// alone, because a `synchronize` on a PR whose payload happens to carry
+// state=closed is a race, not a close event; the state check keeps a
+// stale/reopened payload from ending a live review.
+func (p Parsed) IsClosed() bool {
+	return p.Action == "closed" && strings.EqualFold(p.State, "closed")
+}

--- a/pkg/webhooks/prforge/reviewcomment.go
+++ b/pkg/webhooks/prforge/reviewcomment.go
@@ -129,6 +129,13 @@ func ParseReviewComment(body []byte) (ParsedReviewComment, error) {
 	return p, nil
 }
 
+// ParentSubjectID names the PULL REQUEST this review-thread comment hangs
+// off ("pr:7"). See ParsedNote.ParentSubjectID for why the parent link is
+// stored beside the comment's own subject id.
+func (p ParsedReviewComment) ParentSubjectID() string {
+	return "pr:" + strconv.FormatInt(p.PRNumber, 10)
+}
+
 // SubjectID is the stable per-comment id used in delivery records +
 // idempotency (one launch per reply).
 func (p ParsedReviewComment) SubjectID() string {

--- a/pkg/webhooks/store.go
+++ b/pkg/webhooks/store.go
@@ -40,14 +40,20 @@ type DeliveryStore interface {
 	// whole audit, never a recent-window scan a busy webhook can push the
 	// rows out of.
 	CountLaunched(ctx context.Context, tenantID, webhookID, eventKind, projectPath, subjectID string) (int, error)
-	// ListLaunchedBySubject returns every delivery of one subject in one
-	// project that launched a run, whatever its event kind. EXACT over the
-	// whole audit for the same reason CountLaunched is: its caller stops
-	// the runs a closed pull request left behind, and the run it most
-	// needs to reach is the one PARKED hours ago on a provider quota —
-	// precisely the row a recency-bounded scan has already dropped. Scoped
-	// by projectPath because a subject id ("pr:7") carries no repo and one
-	// webhook config can serve several.
+	// ListLaunchedBySubject returns every delivery that launched a run FOR
+	// one subject in one project — matching the subject itself OR its
+	// ParentSubjectID, whatever the event kind. The parent half is what
+	// makes it complete: a `/billy` fixer records "comment:99" and a
+	// review-thread reply "rc:99", so a caller asking "what did pr:7
+	// launch" would otherwise see only the PR-event lane and miss exactly
+	// the comment-launched runs.
+	//
+	// EXACT over the whole audit for the same reason CountLaunched is: its
+	// caller stops the runs a closed pull request left behind, and the run
+	// it most needs to reach is the one PARKED hours ago on a provider
+	// quota — precisely the row a recency-bounded scan has already
+	// dropped. Scoped by projectPath because a subject id carries no repo
+	// and one webhook config can serve several.
 	ListLaunchedBySubject(ctx context.Context, tenantID, webhookID, projectPath, subjectID string) ([]Delivery, error)
 }
 

--- a/pkg/webhooks/store.go
+++ b/pkg/webhooks/store.go
@@ -40,6 +40,15 @@ type DeliveryStore interface {
 	// whole audit, never a recent-window scan a busy webhook can push the
 	// rows out of.
 	CountLaunched(ctx context.Context, tenantID, webhookID, eventKind, projectPath, subjectID string) (int, error)
+	// ListLaunchedBySubject returns every delivery of one subject in one
+	// project that launched a run, whatever its event kind. EXACT over the
+	// whole audit for the same reason CountLaunched is: its caller stops
+	// the runs a closed pull request left behind, and the run it most
+	// needs to reach is the one PARKED hours ago on a provider quota —
+	// precisely the row a recency-bounded scan has already dropped. Scoped
+	// by projectPath because a subject id ("pr:7") carries no repo and one
+	// webhook config can serve several.
+	ListLaunchedBySubject(ctx context.Context, tenantID, webhookID, projectPath, subjectID string) ([]Delivery, error)
 }
 
 // Limits are the monthly call caps applied to a delivery. Zero means

--- a/pkg/webhooks/types.go
+++ b/pkg/webhooks/types.go
@@ -509,8 +509,16 @@ type Delivery struct {
 	EventAction string `bson:"event_action,omitempty" json:"event_action,omitempty"`
 	ProjectPath string `bson:"project_path,omitempty" json:"project_path,omitempty"`
 	SubjectID   string `bson:"subject_id,omitempty" json:"subject_id,omitempty"`
-	SubjectSHA  string `bson:"subject_sha,omitempty" json:"subject_sha,omitempty"`
-	PayloadHash string `bson:"payload_hash,omitempty" json:"payload_hash,omitempty"`
+	// ParentSubjectID names the subject this delivery's own subject hangs
+	// off — a comment's pull request ("pr:7") beside its own "comment:99".
+	// Without it a consumer asking "what did this pull request launch"
+	// finds only the PR-event lane: a `/billy` fixer and a review-thread
+	// reply record comment ids, so the closed-PR stop could not reach the
+	// very runs it exists to end. Empty when the subject has no parent
+	// (the PR/MR event itself, an issue comment).
+	ParentSubjectID string `bson:"parent_subject_id,omitempty" json:"parent_subject_id,omitempty"`
+	SubjectSHA      string `bson:"subject_sha,omitempty" json:"subject_sha,omitempty"`
+	PayloadHash     string `bson:"payload_hash,omitempty" json:"payload_hash,omitempty"`
 
 	Status     string     `bson:"status" json:"status"`
 	BotID      string     `bson:"bot_id,omitempty" json:"bot_id,omitempty"`


### PR DESCRIPTION
Three linked changes on the same failure: **a provider quota refusal that nobody could see**.

### 1. The refusal is classified (the bug that started this)
Three `branch-improve-loop` runs died this morning on `structured output invalid: missing required field …`. The node's real output was 99 bytes:

> You've hit your org's monthly spend limit · ask your admin to raise it at claude.ai/settings/usage

`hitYourLimitRe` tolerated exactly ONE qualifier word without an apostrophe; this wording puts three words and an apostrophe between "your" and "limit". The detector aborts on assistant text regardless of exit code — it just never matched, so the refusal became the node's answer and failed schema validation. Verbatim the masking bug the pattern's own comment documents ("session" 2026-07, "weekly" 2026-07-20), re-opened by a new wording.

- Qualifier widened to ≤3 words + apostrophes, **bounded** (not `.*`); the 200-char cap stays the second guard.
- Classified as its own `usagecap.WindowSpend` (FamilyAccount, no reset instant): a money ceiling reopens when an admin raises it or the month rolls, so filing it as a nameless window would arm a blind retry against a wall. The credential-tier skip now explains itself instead of printing "(0% used)" through the default branch.
- **Same class fixed in `codex`**: its enumerated prefixes carry no qualifier either, so `weekly`/`session`/`org's monthly spend` escaped them too. `pi` already routes through `isRateLimitMessage` and inherits.

*Canary: the new classify case returns `kind=transient` with the source change stashed — verified, not assumed.*

### 2. A paused review now says so on the pull request
A parked review is not dead (the runner arms a durable retry, and the reconciler deliberately leaves the check alone) — but the check then sits on its in-flight claim, which reads exactly like a review that died, and nothing said how long to wait. The park now **comments once** (fired from the run-outcome event, never the every-minute sweep): what happened, when the retry fires, the attempt, and the provider's own sentence. When that sentence is a **spend ceiling**, it says waiting may not be enough — an admin has to act.

### 3. A closed or merged PR stops its runs
An in-flight review keeps spending quota on a diff nobody will merge; a **parked** one wakes hours later to review and comment on a dead PR. `closed` now stops every run bound to the PR's subject **across bots** (unlike `overlap: supersede`, which is per-bot) and **disarms their retries first** — the retry lives in the store, so cancelling alone would leave the promise standing. Launches nothing; runs before the fork guard, since stopping is not launching.

Cards: `native:f2621d1e`. Operator note: the ceiling is a real prod condition right now on the org forfait — this makes runs park visibly and route around it instead of dying on a lie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)