### PR TITLE
feat(secrets): per-key concurrency ceiling — the operator's answer to fair-usage limits no provider will quantify

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2171,6 +2171,9 @@
           "last_used_at": {
             "type": "string"
           },
+          "max_concurrent_runs": {
+            "type": "integer"
+          },
           "name": {
             "type": "string"
           },
@@ -2329,6 +2332,9 @@
         "properties": {
           "is_default": {
             "type": "boolean"
+          },
+          "max_concurrent_runs": {
+            "type": "integer"
           },
           "name": {
             "type": "string"
@@ -2973,6 +2979,9 @@
         "properties": {
           "is_default": {
             "type": "boolean"
+          },
+          "max_concurrent_runs": {
+            "type": "integer"
           },
           "name": {
             "type": "string"

--- a/pkg/secrets/byok.go
+++ b/pkg/secrets/byok.go
@@ -134,6 +134,16 @@ type ApiKey struct {
 	LastUsedAt   *time.Time `bson:"last_used_at,omitempty" json:"last_used_at,omitempty"`
 	ExpiresAt    *time.Time `bson:"expires_at,omitempty" json:"expires_at,omitempty"`
 	Fingerprint  string     `bson:"fingerprint,omitempty" json:"fingerprint,omitempty"`
+	// MaxConcurrentRuns caps how many ALIVE runs (queued or running) may
+	// hold this key at once; 0 means uncapped. Providers that enforce
+	// fair-usage frequency limits publish NO numeric bound to adapt to —
+	// the operator sets one here, and the resolver's usable-predicate
+	// walks past a key at its ceiling exactly like a refused one, so the
+	// next key or tier serves instead of tripping the provider. A SOFT
+	// cap by design: the refused-key restore still hands the key out when
+	// no other tier could serve its wire — progress beats the ceiling
+	// when the alternative is a run with no credential at all.
+	MaxConcurrentRuns int `bson:"max_concurrent_runs,omitempty" json:"max_concurrent_runs,omitempty"`
 }
 
 // ApiKeyStore is the persistence interface for BYOK records.
@@ -184,6 +194,10 @@ type Resolution struct {
 	Plaintext   []byte
 	SealedBlob  []byte
 	SourceScope string // "user" or "team" — for audit logging
+	// Fingerprint is the chosen key's stable audit identity, carried so
+	// the publisher can stamp the run document with the credentials it
+	// actually sealed (the concurrency meter counts alive runs by it).
+	Fingerprint string
 }
 
 // Resolve returns at most one ApiKey for each requested provider,
@@ -308,6 +322,7 @@ func buildResolution(k ApiKey, sealer Sealer, currentUserID string) (Resolution,
 		KeyID:       k.ID,
 		SealedBlob:  k.SealedSecret,
 		SourceScope: scope,
+		Fingerprint: k.Fingerprint,
 	}
 	if sealer == nil {
 		return r, true

--- a/pkg/server/byok_routes.go
+++ b/pkg/server/byok_routes.go
@@ -36,6 +36,8 @@ type apiKeyView struct {
 	ScopeUserID string  `json:"scope_user_id,omitempty"`
 	CreatedAt   string  `json:"created_at"`
 	LastUsedAt  *string `json:"last_used_at,omitempty"`
+	// 0 = uncapped; see secrets.ApiKey.MaxConcurrentRuns.
+	MaxConcurrentRuns int `json:"max_concurrent_runs,omitempty"`
 }
 
 type createApiKeyReq struct {
@@ -43,12 +45,17 @@ type createApiKeyReq struct {
 	Name      string `json:"name"`
 	Secret    string `json:"secret"`
 	IsDefault bool   `json:"is_default,omitempty"`
+	// MaxConcurrentRuns caps how many alive runs may hold this key at
+	// once (0 = uncapped) — the operator-side answer to providers whose
+	// fair-usage limits publish no numeric bound.
+	MaxConcurrentRuns int `json:"max_concurrent_runs,omitempty"`
 }
 
 type updateApiKeyReq struct {
-	Name      *string `json:"name,omitempty"`
-	IsDefault *bool   `json:"is_default,omitempty"`
-	Secret    *string `json:"secret,omitempty"` // rotate
+	Name              *string `json:"name,omitempty"`
+	IsDefault         *bool   `json:"is_default,omitempty"`
+	Secret            *string `json:"secret,omitempty"` // rotate
+	MaxConcurrentRuns *int    `json:"max_concurrent_runs,omitempty"`
 }
 
 func (s *Server) toApiKeyView(k secrets.ApiKey) apiKeyView {
@@ -62,6 +69,8 @@ func (s *Server) toApiKeyView(k secrets.ApiKey) apiKeyView {
 		ScopeUserID: k.ScopeUserID,
 		CreatedAt:   k.CreatedAt.Format(time.RFC3339),
 		LastUsedAt:  optRFC3339(k.LastUsedAt),
+
+		MaxConcurrentRuns: k.MaxConcurrentRuns,
 	}
 }
 
@@ -177,6 +186,10 @@ func (s *Server) handleCreateApiKey(w http.ResponseWriter, r *http.Request, team
 		httpError(w, http.StatusBadRequest, "name + secret required")
 		return
 	}
+	if req.MaxConcurrentRuns < 0 {
+		httpError(w, http.StatusBadRequest, "max_concurrent_runs must be >= 0 (0 = uncapped)")
+		return
+	}
 	keyID := secrets.NewApiKeyID()
 	sealed, err := secrets.SealAPIKey(s.sealer, keyID, []byte(req.Secret))
 	if err != nil {
@@ -196,6 +209,8 @@ func (s *Server) handleCreateApiKey(w http.ResponseWriter, r *http.Request, team
 		CreatedBy:    id.UserID,
 		CreatedAt:    now,
 		Fingerprint:  secrets.FingerprintSHA256(req.Secret),
+
+		MaxConcurrentRuns: req.MaxConcurrentRuns,
 	}
 	ctx := apiKeyTenantCtx(r)
 	if err := s.apiKeys.Create(ctx, key); err != nil {
@@ -247,6 +262,13 @@ func (s *Server) handleUpdateApiKey(w http.ResponseWriter, r *http.Request) {
 		key.SealedSecret = sealed
 		key.Last4 = secrets.Last4(*req.Secret)
 		key.Fingerprint = secrets.FingerprintSHA256(*req.Secret)
+	}
+	if req.MaxConcurrentRuns != nil {
+		if *req.MaxConcurrentRuns < 0 {
+			httpError(w, http.StatusBadRequest, "max_concurrent_runs must be >= 0 (0 = uncapped)")
+			return
+		}
+		key.MaxConcurrentRuns = *req.MaxConcurrentRuns
 	}
 	if req.IsDefault != nil {
 		key.IsDefault = *req.IsDefault

--- a/pkg/server/cloudpublisher/apikey_skip_test.go
+++ b/pkg/server/cloudpublisher/apikey_skip_test.go
@@ -6,7 +6,10 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/secrets"
 	"github.com/SocialGouv/iterion/pkg/store"
 	"github.com/SocialGouv/iterion/pkg/usagecap"
@@ -353,5 +356,81 @@ func TestResolve_ceilingWalksToNextKeyAndStampsFingerprints(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("fingerprints = %v, want fp-zai-b harvested", creds.fingerprints)
+	}
+}
+
+// The wiring layer — the exact gap the launch-side stamp fell through
+// (written before the run document existed, warn-and-lose): a LAUNCHED
+// run's document must carry the sealed credentials' fingerprints via the
+// launch's single SaveRun, and a RESUME whose re-resolution finds nothing
+// must CLEAR the stamp, not keep metering a credential the run no longer
+// holds.
+func TestSubmitLaunchAndResume_credFingerprintsRideTheRunDocument(t *testing.T) {
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	rs, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	keys := secrets.NewMemoryApiKeyStore()
+	ctx := store.WithIdentity(context.Background(), "team1", "owner1")
+	kid := secrets.NewApiKeyID()
+	sealed, _ := secrets.SealAPIKey(sealer, kid, []byte("zai-key"))
+	if err := keys.Create(ctx, secrets.ApiKey{ID: kid, ScopeTeamID: "team1", Provider: secrets.ProviderZAI,
+		Name: "zai", SealedSecret: sealed, Fingerprint: "fp-wired", CreatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("create key: %v", err)
+	}
+
+	p := &Publisher{
+		apiKeys:    keys,
+		usageCaps:  usagecap.NewMemStore(),
+		store:      rs,
+		runSecrets: secrets.NewMemoryRunSecretsStore(),
+		sealer:     sealer,
+		logger:     testLogger(),
+		publishRun: func(context.Context, *queue.RunMessage) error { return nil },
+	}
+	wf := &ir.Workflow{Name: "wf"}
+	if _, err := p.SubmitLaunch(ctx, "run-w1", runview.LaunchSpec{
+		FilePath: "wf.bot", Source: "workflow wf:\n  start -> done\n",
+	}, wf, "hash"); err != nil {
+		t.Fatalf("SubmitLaunch: %v", err)
+	}
+	run, err := rs.LoadRun(ctx, "run-w1")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	found := false
+	for _, fp := range run.CredFingerprints {
+		if fp == "fp-wired" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("launched run carries %v, want fp-wired — the ceiling is blind to launches otherwise", run.CredFingerprints)
+	}
+
+	// The key disappears; the resume's re-resolution finds nothing and
+	// must CLEAR the stamp.
+	if err := keys.Delete(ctx, kid); err != nil {
+		t.Fatalf("delete key: %v", err)
+	}
+	run.Status = store.RunStatusPausedOperator
+	if err := rs.SaveRun(ctx, run); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+	if err := p.SubmitResume(ctx, runview.ResumeSpec{
+		RunID: "run-w1", FilePath: "wf.bot", Source: "workflow wf:\n  start -> done\n",
+	}, wf, "hash"); err != nil {
+		t.Fatalf("SubmitResume: %v", err)
+	}
+	run, err = rs.LoadRun(ctx, "run-w1")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if len(run.CredFingerprints) != 0 {
+		t.Fatalf("resumed run still carries %v — a stale stamp holds a slot on a credential the run no longer has", run.CredFingerprints)
 	}
 }

--- a/pkg/server/cloudpublisher/apikey_skip_test.go
+++ b/pkg/server/cloudpublisher/apikey_skip_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/store"
 	"github.com/SocialGouv/iterion/pkg/usagecap"
 )
 
@@ -236,5 +237,121 @@ func TestOAuthForfait_authRefusalFallsThroughToPlatform(t *testing.T) {
 	b := resolveBundle(t, p, rs, sealer, "run-a1", "team1", "owner1")
 	if got := string(b.OAuthCredentials["claude_code"]); !contains(got, "sk-ant-platform") {
 		t.Fatalf("claude_code blob = %q, want the PLATFORM forfait — the auth-dead record must be walked past", got)
+	}
+}
+
+// The concurrency ceiling: a key with MaxConcurrentRuns at its count of
+// alive stamped runs is passed over like a refused one — the walk serves
+// the next key of the provider — and the run being resolved never counts
+// toward its own ceiling.
+func TestApiKeyUsable_concurrencyCeiling(t *testing.T) {
+	rs, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	ctx := context.Background()
+	mkRun := func(id string, status store.RunStatus, fp string) {
+		if _, err := rs.CreateRun(ctx, id, "demo", nil); err != nil {
+			t.Fatalf("CreateRun: %v", err)
+		}
+		r, _ := rs.LoadRun(ctx, id)
+		r.Status = status
+		if err := rs.SaveRun(ctx, r); err != nil {
+			t.Fatalf("SaveRun: %v", err)
+		}
+		if err := rs.SetRunCredFingerprints(ctx, id, []string{fp}); err != nil {
+			t.Fatalf("stamp: %v", err)
+		}
+	}
+	mkRun("alive-1", store.RunStatusRunning, "fp-capped")
+	mkRun("alive-2", store.RunStatusQueued, "fp-capped")
+
+	p := &Publisher{usageCaps: usagecap.NewMemStore(), store: rs, logger: testLogger()}
+	usable := p.apiKeyUsable(ctx, usagecap.TenantScope("team"), "run-new")
+
+	capped := secrets.ApiKey{Provider: secrets.ProviderZAI, Name: "capped", Fingerprint: "fp-capped", MaxConcurrentRuns: 2}
+	if usable(capped) {
+		t.Fatal("a key at its ceiling (2/2 alive) must be passed over")
+	}
+	roomy := secrets.ApiKey{Provider: secrets.ProviderZAI, Name: "roomy", Fingerprint: "fp-capped", MaxConcurrentRuns: 3}
+	if !usable(roomy) {
+		t.Fatal("a key under its ceiling (2/3) must stay usable")
+	}
+	uncapped := secrets.ApiKey{Provider: secrets.ProviderZAI, Name: "uncapped", Fingerprint: "fp-capped"}
+	if !usable(uncapped) {
+		t.Fatal("MaxConcurrentRuns=0 means uncapped")
+	}
+
+	// The run being resolved is already persisted and stamped (a resume):
+	// it must not consume its own slot.
+	if !p.apiKeyUsable(ctx, usagecap.TenantScope("team"), "alive-1")(capped) {
+		t.Fatal("a resume must not count itself toward the key's ceiling")
+	}
+}
+
+// End to end at the resolution: the capped key's provider slot walks to
+// the SECOND key of the same provider, and the run-doc stamp records the
+// credentials the bundle actually sealed.
+func TestResolve_ceilingWalksToNextKeyAndStampsFingerprints(t *testing.T) {
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	rs, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	ctx := store.WithTenant(context.Background(), "team1")
+	keys := secrets.NewMemoryApiKeyStore()
+	// Two zai keys: the first is capped at 1 with one alive run holding it.
+	id1 := secrets.NewApiKeyID()
+	sealed1, _ := secrets.SealAPIKey(sealer, id1, []byte("zai-capped"))
+	if err := keys.Create(ctx, secrets.ApiKey{ID: id1, ScopeTeamID: "team1", Provider: secrets.ProviderZAI,
+		Name: "zai-a", SealedSecret: sealed1, Fingerprint: "fp-zai-a", MaxConcurrentRuns: 1, CreatedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id2 := secrets.NewApiKeyID()
+	sealed2, _ := secrets.SealAPIKey(sealer, id2, []byte("zai-roomy"))
+	if err := keys.Create(ctx, secrets.ApiKey{ID: id2, ScopeTeamID: "team1", Provider: secrets.ProviderZAI,
+		Name: "zai-b", SealedSecret: sealed2, Fingerprint: "fp-zai-b", CreatedAt: time.Now().UTC().Add(time.Second)}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := rs.CreateRun(ctx, "holder", "demo", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	hr, _ := rs.LoadRun(ctx, "holder")
+	hr.Status = store.RunStatusRunning
+	_ = rs.SaveRun(ctx, hr)
+	_ = rs.SetRunCredFingerprints(ctx, "holder", []string{"fp-zai-a"})
+	// The run being resolved must pre-exist for the stamp.
+	if _, err := rs.CreateRun(ctx, "run-c1", "demo", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	p := &Publisher{apiKeys: keys, usageCaps: usagecap.NewMemStore(), store: rs,
+		runSecrets: secrets.NewMemoryRunSecretsStore(), sealer: sealer, logger: testLogger()}
+	rsec := p.runSecrets.(*secrets.MemoryRunSecretsStore)
+
+	b := resolveBundle(t, p, rsec, sealer, "run-c1", "team1", "owner1")
+	if got := b.APIKeys[secrets.ProviderZAI]; got != "zai-roomy" {
+		t.Fatalf("zai key = %q, want the second key — the capped one is full", got)
+	}
+	// The harvest names the credential the bundle ACTUALLY sealed — the
+	// meter would count the wrong key otherwise.
+	creds, err := p.resolveAndSealCredentials(ctx, "run-c2", "", "team1", "owner1", "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	found := false
+	for _, fp := range creds.fingerprints {
+		if fp == "fp-zai-a" {
+			t.Fatalf("fingerprints %v name the capped key the bundle did not seal", creds.fingerprints)
+		}
+		if fp == "fp-zai-b" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("fingerprints = %v, want fp-zai-b harvested", creds.fingerprints)
 	}
 }

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -359,6 +360,9 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 	// Refused-but-only keys, per provider, remembered across the tiers for
 	// the restore step — the api-key twin of skippedForfaits below.
 	skippedAPIKeys := map[secrets.Provider]skippedAPIKey{}
+	// Audit identity of the API key that filled each provider slot, for
+	// the run-document stamp (the OAuth side rides bundle.OAuthFingerprints).
+	apiKeyFPs := map[secrets.Provider]string{}
 
 	// 1. BYOK API keys.
 	if p.apiKeys != nil {
@@ -386,6 +390,7 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 				continue
 			}
 			bundle.APIKeys[prov] = string(r.Plaintext)
+			apiKeyFPs[prov] = r.Fingerprint
 			usedIDs = append(usedIDs, r.KeyID)
 		}
 		// A provider whose EVERY key was refused resolves to nothing under
@@ -405,7 +410,7 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 				if len(r.Plaintext) == 0 {
 					continue
 				}
-				skippedAPIKeys[prov] = skippedAPIKey{plaintext: string(r.Plaintext), keyID: r.KeyID}
+				skippedAPIKeys[prov] = skippedAPIKey{plaintext: string(r.Plaintext), keyID: r.KeyID, fingerprint: r.Fingerprint}
 			}
 		}
 		// Bumping last_used_at is best-effort observability, not on
@@ -589,7 +594,7 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 	//    run runs on its donor — filling alongside would outrank the lent
 	//    credential while still consuming the donor's quota and slot.
 	if res.grant == nil {
-		p.fillFromPlatform(ctx, runID, &bundle, skippedAPIKeys)
+		p.fillFromPlatform(ctx, runID, &bundle, skippedAPIKeys, apiKeyFPs)
 	}
 
 	// A skipped credential is only an improvement when some other tier
@@ -614,6 +619,7 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 				continue
 			}
 			bundle.APIKeys[prov] = sk.plaintext
+			apiKeyFPs[prov] = sk.fingerprint
 			if sk.platform {
 				bundle.PlatformSourced[string(prov)] = true
 			}
@@ -647,6 +653,23 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 		oauthKinds = append(oauthKinds, kind)
 	}
 	res.families = reviewtopology.FamiliesFromCredentialNames(providers, oauthKinds)
+	// Harvest every sealed credential's audit identity for the run-doc
+	// stamp: API keys from the slot records above, OAuth from the bundle's
+	// own fingerprint map (each fill site stamps it there).
+	seen := map[string]bool{}
+	for _, fp := range apiKeyFPs {
+		if fp != "" && !seen[fp] {
+			seen[fp] = true
+			res.fingerprints = append(res.fingerprints, fp)
+		}
+	}
+	for _, fp := range bundle.OAuthFingerprints {
+		if fp != "" && !seen[fp] {
+			seen[fp] = true
+			res.fingerprints = append(res.fingerprints, fp)
+		}
+	}
+	sort.Strings(res.fingerprints)
 
 	if len(bundle.APIKeys) == 0 && len(bundle.GenericSecrets) == 0 && len(bundle.OAuthCredentials) == 0 {
 		return res, nil
@@ -686,6 +709,11 @@ type credResolution struct {
 	// topology vars for a queued run. Empty = nothing resolved (env
 	// fallback), in which case no injection happens.
 	families reviewtopology.FamilySet
+	// fingerprints are the audit identities of every credential the
+	// bundle sealed — API keys and OAuth records alike, never secrets.
+	// The caller stamps them on the run document so the per-key
+	// concurrency meter can count alive runs by credential.
+	fingerprints []string
 }
 
 // setOAuthFingerprint stamps the audit identity of the credential that
@@ -719,7 +747,7 @@ func setOAuthFingerprint(bundle *secrets.RunBundle, kind, fp string) {
 // Best-effort like the pool: a degraded store read or unseal failure logs
 // and leaves the slot to the env fallback — it must never fail a launch
 // that env can still serve.
-func (p *Publisher) fillFromPlatform(ctx context.Context, runID string, bundle *secrets.RunBundle, skippedAPIKeys map[secrets.Provider]skippedAPIKey) {
+func (p *Publisher) fillFromPlatform(ctx context.Context, runID string, bundle *secrets.RunBundle, skippedAPIKeys map[secrets.Provider]skippedAPIKey, apiKeyFPs map[secrets.Provider]string) {
 	if p.sealer == nil {
 		return
 	}
@@ -763,6 +791,7 @@ func (p *Publisher) fillFromPlatform(ctx context.Context, runID string, bundle *
 					}
 					bundle.APIKeys[prov] = string(r.Plaintext)
 					bundle.PlatformSourced[string(prov)] = true
+					apiKeyFPs[prov] = r.Fingerprint
 					taken[secrets.WireFamily(string(prov))] = true
 					usedIDs = append(usedIDs, r.KeyID)
 					p.logger.Info("cloudpublisher: platform credential used run=%s slot=%s", runID, prov)
@@ -796,7 +825,7 @@ func (p *Publisher) fillFromPlatform(ctx context.Context, runID string, bundle *
 					if _, seen := skippedAPIKeys[prov]; seen {
 						continue
 					}
-					skippedAPIKeys[prov] = skippedAPIKey{plaintext: string(r.Plaintext), keyID: r.KeyID, platform: true}
+					skippedAPIKeys[prov] = skippedAPIKey{plaintext: string(r.Plaintext), keyID: r.KeyID, fingerprint: r.Fingerprint, platform: true}
 				}
 			}
 		}
@@ -873,9 +902,10 @@ type skippedForfait struct {
 // platform marks the deployment's own key so the restore keeps its
 // PlatformSourced metering scope.
 type skippedAPIKey struct {
-	plaintext string
-	keyID     string
-	platform  bool
+	plaintext   string
+	keyID       string
+	fingerprint string
+	platform    bool
 }
 
 // providersWithoutKey returns the subset of provs that filled no API-key
@@ -1011,6 +1041,23 @@ func usageBackendForProvider(prov secrets.Provider) string {
 // Everything uncertain means "usable", same contract as refusedUntil.
 func (p *Publisher) apiKeyUsable(ctx context.Context, scope string, runID string) func(secrets.ApiKey) bool {
 	return func(k secrets.ApiKey) bool {
+		// Concurrency ceiling first — cheaper than the meter read, and a
+		// key at its ceiling must rest whatever its refusal history says.
+		// Providers with fair-usage frequency limits publish no numeric
+		// bound to adapt to; the operator sets one on the key, and the
+		// walk passes a full key over exactly like a refused one. Fails
+		// OPEN on a count error: the ceiling is protection against
+		// tripping a provider, not a correctness invariant.
+		if k.MaxConcurrentRuns > 0 && p.store != nil && k.Fingerprint != "" {
+			n, err := p.store.CountAliveRunsWithCredFingerprint(ctx, k.Fingerprint, runID)
+			if err != nil {
+				p.logger.Warn("cloudpublisher: concurrency count for api-key(%s) %q: %v — ceiling not applied", k.Provider, k.Name, err)
+			} else if n >= k.MaxConcurrentRuns {
+				p.logger.Info("cloudpublisher: api-key(%s) %q AT ITS CEILING for run=%s (%d/%d alive runs); trying the next key of this provider",
+					k.Provider, k.Name, runID, n, k.MaxConcurrentRuns)
+				return false
+			}
+		}
 		backend := usageBackendForProvider(k.Provider)
 		until, why := p.refusedUntil(ctx, backend, scope, k.Fingerprint, string(k.Provider))
 		if until.IsZero() {
@@ -1217,6 +1264,16 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 	if err != nil {
 		return 0, err
 	}
+	// Stamp the sealed credentials' audit identities on the run document
+	// (never secrets): the per-key concurrency meter counts alive runs by
+	// them. Best-effort — a failed stamp degrades the ceiling toward
+	// uncapped (fail-open, like the meter), never the launch.
+	if len(creds.fingerprints) > 0 {
+		if serr := p.store.SetRunCredFingerprints(ctx, runID, creds.fingerprints); serr != nil {
+			p.logger.Warn("cloudpublisher: stamp cred fingerprints on run %s: %v", runID, serr)
+		}
+	}
+
 	// A run served by the pool may not spend more than what remains of its
 	// donor's allowance. This is the enforcement: the engine stops the run
 	// on its own cost budget, instead of the overspend being discovered
@@ -1517,6 +1574,14 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 	}
 	if secretsErr != nil {
 		return secretsErr
+	}
+	// Re-stamp on resume: re-resolution may have picked different
+	// credentials, and a stale stamp meters a key this run no longer
+	// holds. Same best-effort contract as the launch-side stamp.
+	if len(creds.fingerprints) > 0 {
+		if serr := p.store.SetRunCredFingerprints(secretsCtx, spec.RunID, creds.fingerprints); serr != nil {
+			p.logger.Warn("cloudpublisher: re-stamp cred fingerprints on run %s: %v", spec.RunID, serr)
+		}
 	}
 	// Re-resolved on resume too: the engine re-mirrors skills on every resume,
 	// so a resumed run must carry the same payload a fresh launch would.

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -1264,15 +1264,14 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 	if err != nil {
 		return 0, err
 	}
-	// Stamp the sealed credentials' audit identities on the run document
-	// (never secrets): the per-key concurrency meter counts alive runs by
-	// them. Best-effort — a failed stamp degrades the ceiling toward
-	// uncapped (fail-open, like the meter), never the launch.
-	if len(creds.fingerprints) > 0 {
-		if serr := p.store.SetRunCredFingerprints(ctx, runID, creds.fingerprints); serr != nil {
-			p.logger.Warn("cloudpublisher: stamp cred fingerprints on run %s: %v", runID, serr)
-		}
-	}
+	// The sealed credentials' audit identities ride the run document's
+	// single SaveRun below (never secrets): the per-key concurrency meter
+	// counts alive runs by them. Assigned on the in-memory doc rather
+	// than patched afterwards — at this point the document does NOT
+	// exist yet (the launch's one persist comes later), and a patch here
+	// would be a warn-and-lose no-op that leaves the ceiling blind to
+	// every launched run.
+	r.CredFingerprints = creds.fingerprints
 
 	// A run served by the pool may not spend more than what remains of its
 	// donor's allowance. This is the enforcement: the engine stops the run
@@ -1575,13 +1574,15 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 	if secretsErr != nil {
 		return secretsErr
 	}
-	// Re-stamp on resume: re-resolution may have picked different
-	// credentials, and a stale stamp meters a key this run no longer
-	// holds. Same best-effort contract as the launch-side stamp.
-	if len(creds.fingerprints) > 0 {
-		if serr := p.store.SetRunCredFingerprints(secretsCtx, spec.RunID, creds.fingerprints); serr != nil {
-			p.logger.Warn("cloudpublisher: re-stamp cred fingerprints on run %s: %v", spec.RunID, serr)
-		}
+	// Re-stamp on resume, UNCONDITIONALLY: re-resolution may have picked
+	// different credentials — or none at all (key deleted, every
+	// candidate refused with nothing to restore, env fallback) — and a
+	// stale stamp would hold a slot on a credential the run demonstrably
+	// no longer carries, for its whole remaining alive life. An empty
+	// re-resolution therefore CLEARS the stamp. Best-effort: a failed
+	// write degrades the ceiling toward uncapped, never the resume.
+	if serr := p.store.SetRunCredFingerprints(secretsCtx, spec.RunID, creds.fingerprints); serr != nil {
+		p.logger.Warn("cloudpublisher: re-stamp cred fingerprints on run %s: %v", spec.RunID, serr)
 	}
 	// Re-resolved on resume too: the engine re-mirrors skills on every resume,
 	// so a resumed run must carry the same payload a fresh launch would.

--- a/pkg/store/iface.go
+++ b/pkg/store/iface.go
@@ -67,6 +67,23 @@ type RunStore interface {
 	// scheduleID is empty.
 	ListRunsBySchedule(ctx context.Context, scheduleID string) ([]string, error)
 
+	// Credential-concurrency meter (secrets.ApiKey.MaxConcurrentRuns).
+	//
+	// SetRunCredFingerprints stamps the run with the stable audit
+	// identities of the credentials the publisher sealed for it — never
+	// secrets. Re-stamped on every resume: re-resolution may pick
+	// different credentials, and a stale stamp would meter a key the run
+	// no longer holds.
+	//
+	// CountAliveRunsWithCredFingerprint counts runs in the queued or
+	// running states stamped with fingerprint, excluding excludeRunID
+	// (the run being resolved is already persisted and must not count
+	// itself toward its own ceiling). Deliberately NOT tenant-scoped:
+	// a platform key serves every tenant on one ceiling, and a tenant
+	// key's runs all live in one tenant anyway.
+	SetRunCredFingerprints(ctx context.Context, runID string, fingerprints []string) error
+	CountAliveRunsWithCredFingerprint(ctx context.Context, fingerprint, excludeRunID string) (int, error)
+
 	// PatchRunSteering persists the live-steering state (accumulated
 	// loop grants + absolute budget raises) on the run record so a
 	// resume re-applies them. nil map / nil raises leave the stored

--- a/pkg/store/lifecycle.go
+++ b/pkg/store/lifecycle.go
@@ -113,6 +113,17 @@ func (s RunStatus) CarriesFailureCode() bool {
 	return s == RunStatusFailed || s == RunStatusFailedResumable || s == RunStatusCancelled
 }
 
+// HoldsCredentialSlot names the statuses that count toward a
+// credential's concurrency ceiling (secrets.ApiKey.MaxConcurrentRuns):
+// running is spending, and queued is about to — admitting a burst of
+// queued runs against a full key is exactly the thundering herd the
+// ceiling exists to stop. Parked (failed_resumable) and paused runs
+// hold NO slot: they spend nothing while they wait, and their resume
+// re-resolves credentials against the ceiling like any claim.
+func (s RunStatus) HoldsCredentialSlot() bool {
+	return s == RunStatusRunning || s == RunStatusQueued
+}
+
 // CarriesPausePointer reports whether a run in this status may
 // truthfully carry a pending-interaction pointer on its checkpoint
 // (Checkpoint.InteractionID / InteractionQuestions). True for the

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -673,6 +673,48 @@ func (s *Store) CountActiveRunsByTenant(ctx context.Context, tenantID string) (i
 // PatchRunSteering persists the live-steering state (loop grants +
 // absolute budget raises) with a partial $set, tenant-scoped. Partial:
 // nil inputs leave the stored field untouched.
+// SetRunCredFingerprints stamps the sealed credentials' audit identities
+// on the run document (see store.RunStore). Tenant-scoped like every
+// other targeted patch: the caller stamps a run it just persisted.
+func (s *Store) SetRunCredFingerprints(ctx context.Context, id string, fingerprints []string) error {
+	set := bson.M{"cred_fingerprints": fingerprints, "updated_at": time.Now().UTC()}
+	res, err := s.runs.UpdateOne(ctx, notDeleted(withTenantFilter(ctx, bson.M{"_id": id})), bson.M{"$set": set})
+	if err != nil {
+		return fmt.Errorf("store/mongo: set run cred fingerprints: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return store.ErrRunNotFound
+	}
+	return nil
+}
+
+// CountAliveRunsWithCredFingerprint counts queued/running runs stamped
+// with fingerprint (see store.RunStore). Deliberately NO tenant filter —
+// a platform key serves every tenant on one ceiling.
+func (s *Store) CountAliveRunsWithCredFingerprint(ctx context.Context, fingerprint, excludeRunID string) (int, error) {
+	if fingerprint == "" {
+		return 0, nil
+	}
+	holding := make([]string, 0, 2)
+	for _, st := range store.AllRunStatuses {
+		if st.HoldsCredentialSlot() {
+			holding = append(holding, string(st))
+		}
+	}
+	filter := notDeleted(bson.M{
+		"cred_fingerprints": fingerprint,
+		"status":            bson.M{"$in": holding},
+	})
+	if excludeRunID != "" {
+		filter["_id"] = bson.M{"$ne": excludeRunID}
+	}
+	n, err := s.runs.CountDocuments(ctx, filter)
+	if err != nil {
+		return 0, fmt.Errorf("store/mongo: count runs by cred fingerprint: %w", err)
+	}
+	return int(n), nil
+}
+
 func (s *Store) PatchRunSteering(ctx context.Context, id string, loopOverrides map[string]int, budgetRaises *store.RunBudgetRaises) error {
 	set := bson.M{"updated_at": time.Now().UTC()}
 	if loopOverrides != nil {

--- a/pkg/store/run.go
+++ b/pkg/store/run.go
@@ -313,6 +313,14 @@ type Run struct {
 	// runs. The studio surfaces parent/child relationships via these
 	// fields; aggregation is by polling children's terminal status.
 	ParentRunID string `json:"parent_run_id,omitempty" bson:"parent_run_id,omitempty"`
+
+	// CredFingerprints are the stable audit identities of the credentials
+	// the publisher sealed for this run (API-key and OAuth fingerprints —
+	// never secrets). Stamped at launch and RE-stamped at every resume,
+	// because re-resolution may pick different credentials. The per-key
+	// concurrency meter (secrets.ApiKey.MaxConcurrentRuns) counts alive
+	// runs through this field.
+	CredFingerprints []string `json:"cred_fingerprints,omitempty" bson:"cred_fingerprints,omitempty"`
 	// ParentNodeID is the IR node id of the subbot node in the parent
 	// workflow that spawned this child run; empty for root runs and
 	// non-subbot children.

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -987,6 +987,42 @@ func (s *FilesystemRunStore) ListChildRuns(ctx context.Context, parentRunID stri
 	})
 }
 
+// SetRunCredFingerprints stamps the sealed credentials' audit identities
+// on the run document (see RunStore). Load-modify-save, like the other
+// fs-side patches: the filesystem store has no partial update.
+func (s *FilesystemRunStore) SetRunCredFingerprints(ctx context.Context, runID string, fingerprints []string) error {
+	r, err := s.LoadRun(ctx, runID)
+	if err != nil {
+		return err
+	}
+	r.CredFingerprints = fingerprints
+	return s.SaveRun(ctx, r)
+}
+
+// CountAliveRunsWithCredFingerprint counts queued/running runs stamped
+// with fingerprint (see RunStore). Scan-and-filter like the other
+// fs-side reverse queries — local scale, no secondary index.
+func (s *FilesystemRunStore) CountAliveRunsWithCredFingerprint(ctx context.Context, fingerprint, excludeRunID string) (int, error) {
+	if fingerprint == "" {
+		return 0, nil
+	}
+	ids, err := s.filterRunsSorted(ctx, func(r *Run) bool {
+		if r.ID == excludeRunID || !r.Status.HoldsCredentialSlot() {
+			return false
+		}
+		for _, fp := range r.CredFingerprints {
+			if fp == fingerprint {
+				return true
+			}
+		}
+		return false
+	})
+	if err != nil {
+		return 0, err
+	}
+	return len(ids), nil
+}
+
 // filterRunsSorted scans every run, keeps those matching pred, and
 // returns their ids sorted by CreatedAt ascending. Shared by the
 // fs-side reverse-tree queries.

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -80,6 +80,7 @@ func RunWithOpts(t *testing.T, factory Factory, opts Opts) {
 	t.Run("NodesServed", func(t *testing.T) { testNodesServed(t, factory(t)) })
 	t.Run("ReverseTreeQueries", func(t *testing.T) { testReverseTreeQueries(t, factory(t)) })
 	t.Run("ScheduleReverseQuery", func(t *testing.T) { testScheduleReverseQuery(t, factory(t)) })
+	t.Run("CredFingerprintMeter", func(t *testing.T) { testCredFingerprintMeter(t, factory(t)) })
 	t.Run("DeleteRun", func(t *testing.T) { testDeleteRun(t, factory(t)) })
 	t.Run("RunLogStore", func(t *testing.T) { testRunLogStore(t, factory(t)) })
 	t.Run("TurnStore", func(t *testing.T) { testTurnStore(t, factory(t)) })
@@ -2489,5 +2490,71 @@ func testRouteDecisionRegistry(t *testing.T, s store.RunStore) {
 	ids, err = rds.ListRoutableRuns(ctx, time.Now().Add(-time.Hour), 1)
 	if err != nil || len(ids) != 1 || ids[0] != "routable-b" {
 		t.Fatalf("ListRoutableRuns(limit=1) = (%v, %v), want the oldest routable run [routable-b]", ids, err)
+	}
+}
+
+// testCredFingerprintMeter exercises the credential-concurrency meter
+// pair: SetRunCredFingerprints (stamp + re-stamp) and
+// CountAliveRunsWithCredFingerprint (queued/running only, exclusion of
+// the run being resolved, empty fingerprint counts nothing).
+func testCredFingerprintMeter(t *testing.T, s store.RunStore) {
+	t.Helper()
+	ctx := testCtx()
+
+	mk := func(id string, status store.RunStatus, fps ...string) {
+		if _, err := s.CreateRun(ctx, id, "demo", nil); err != nil {
+			t.Fatalf("CreateRun %s: %v", id, err)
+		}
+		r, err := s.LoadRun(ctx, id)
+		if err != nil {
+			t.Fatalf("LoadRun %s: %v", id, err)
+		}
+		r.Status = status
+		if err := s.SaveRun(ctx, r); err != nil {
+			t.Fatalf("SaveRun %s: %v", id, err)
+		}
+		if len(fps) > 0 {
+			if err := s.SetRunCredFingerprints(ctx, id, fps); err != nil {
+				t.Fatalf("SetRunCredFingerprints %s: %v", id, err)
+			}
+		}
+	}
+
+	mk("fp_run1", store.RunStatusRunning, "fp-zai", "fp-oauth")
+	mk("fp_run2", store.RunStatusQueued, "fp-zai")
+	// Terminal and parked runs hold no slot.
+	mk("fp_done", store.RunStatusFinished, "fp-zai")
+	mk("fp_parked", store.RunStatusFailedResumable, "fp-zai")
+	// A run with other credentials does not count.
+	mk("fp_other", store.RunStatusRunning, "fp-anthropic")
+
+	n, err := s.CountAliveRunsWithCredFingerprint(ctx, "fp-zai", "")
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("alive(fp-zai) = %d, want 2 (running + queued; finished and parked hold no slot)", n)
+	}
+
+	// The run being resolved never counts toward its own ceiling.
+	if n, err = s.CountAliveRunsWithCredFingerprint(ctx, "fp-zai", "fp_run1"); err != nil || n != 1 {
+		t.Errorf("alive(fp-zai, excl fp_run1) = %d/%v, want 1", n, err)
+	}
+
+	// An empty fingerprint is not a meter.
+	if n, err = s.CountAliveRunsWithCredFingerprint(ctx, "", ""); err != nil || n != 0 {
+		t.Errorf("alive(empty) = %d/%v, want 0", n, err)
+	}
+
+	// Re-stamp replaces wholesale: a resume that resolved different
+	// credentials must not keep metering the old ones.
+	if err := s.SetRunCredFingerprints(ctx, "fp_run2", []string{"fp-anthropic"}); err != nil {
+		t.Fatalf("re-stamp: %v", err)
+	}
+	if n, err = s.CountAliveRunsWithCredFingerprint(ctx, "fp-zai", ""); err != nil || n != 1 {
+		t.Errorf("alive(fp-zai) after re-stamp = %d/%v, want 1", n, err)
+	}
+	if n, err = s.CountAliveRunsWithCredFingerprint(ctx, "fp-anthropic", ""); err != nil || n != 2 {
+		t.Errorf("alive(fp-anthropic) after re-stamp = %d/%v, want 2", n, err)
 	}
 }

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -5734,6 +5734,7 @@ export interface components {
             is_default: boolean;
             last4?: string;
             last_used_at?: string;
+            max_concurrent_runs?: number;
             name: string;
             provider: string;
             scope_user_id?: string;
@@ -5783,6 +5784,7 @@ export interface components {
         };
         createApiKeyReq: {
             is_default?: boolean;
+            max_concurrent_runs?: number;
             name: string;
             provider: string;
             secret: string;
@@ -5969,6 +5971,7 @@ export interface components {
         };
         updateApiKeyReq: {
             is_default?: boolean;
+            max_concurrent_runs?: number;
             name?: string;
             secret?: string;
         };


### PR DESCRIPTION
## Why

A provider that freezes an account for "usage pattern" violations publishes **no numeric bound to adapt to**: the refusal names no allowed frequency, the successful responses carry no rate headers, and the threshold only reveals itself by tripping it — which froze an entire fleet behind one credential and cost a morning of manual purges. The evidence machinery (#610/#612/#624) routes around a refusal AFTER it happens; this PR keeps it from happening: the operator sets the bound the provider won't state.

## What

- **`ApiKey.MaxConcurrentRuns`** (0 = uncapped), settable on the create/update routes and returned in the views.
- **Run-doc stamp**: the publisher records every sealed credential's audit identity on the run document (`cred_fingerprints` — never secrets), re-stamped on resume because re-resolution may pick different keys.
- **Enforcement at the existing chokepoint**: `apiKeyUsable` counts alive stamped runs and passes a full key over exactly like a refused one — the #612 walk serves the next key or tier (a capped z.ai key with an Anthropic fallback behind it is the exact deployment this is for).
- **`RunStatus.HoldsCredentialSlot()`**: queued and running hold a slot (admitting a queued burst against a full key is the thundering herd the ceiling stops); parked and paused do not — they spend nothing, and their resume re-resolves against the ceiling like any claim. Derived, not hand-rolled (the negative-space meta-test enforces it).
- **Soft cap by design**: the refused-key restore still hands the key out when no other tier could serve its wire — progress beats the ceiling when the alternative is a credential-less run.
- **Self-exclusion**: the run being resolved never counts toward its own ceiling (a resume would self-deadlock otherwise).
- **Fails open** on a count error: the ceiling protects a provider relationship, not a correctness invariant.

## Falsified both ways

- Disabling the enforcement reds the ceiling tests (blind face); widening `HoldsCredentialSlot` to parked runs reds the conformance meter test (hysteric face — a parked fleet must not hold the key hostage).
- Conformance covers: statuses, self-exclusion, empty-fingerprint no-op, and wholesale re-stamp on resume.
- End-to-end at the resolution: a capped-and-full key's slot walks to the second key of the provider, and the harvest names the credential the bundle actually sealed (metering the wrong key was #612's Rd04837 — pinned against here too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)