### PR TITLE
fix(mcp): make the explicitly-named wildcard's fatal boot a decision, not an accident

### DIFF
--- a/pkg/backend/model/executor_mcp_forward_test.go
+++ b/pkg/backend/model/executor_mcp_forward_test.go
@@ -140,10 +140,14 @@ func TestExplicitMCPWildcardBootFailureFailsTheNode(t *testing.T) {
 	if err == nil {
 		t.Fatal("an explicitly named MCP server that cannot boot must fail the node")
 	}
-	// The message has to name the server and say the node asked for it, or the
+	// The message has to name the server AND the entry that pulled it in, or the
 	// operator cannot tell this apart from a tool that simply does not exist.
-	if !strings.Contains(err.Error(), "deadsrv") || !strings.Contains(err.Error(), "explicitly") {
-		t.Errorf("error must name the server and its declared origin: %v", err)
+	// Asserted on those two facts rather than on the wording: the entry is data,
+	// so a reword that keeps it stays green, and the pre-change message
+	// ("ensure MCP server %q for wildcard") carried the server alone — which is
+	// where this test gets its teeth.
+	if !strings.Contains(err.Error(), "deadsrv") || !strings.Contains(err.Error(), "mcp.deadsrv.*") {
+		t.Errorf("error must name the server and the wildcard entry: %v", err)
 	}
 	if len(degraded) != 0 {
 		t.Errorf("a declared dependency must never be reported as a degrade: %+v", degraded)

--- a/pkg/backend/model/executor_mcp_forward_test.go
+++ b/pkg/backend/model/executor_mcp_forward_test.go
@@ -106,3 +106,46 @@ func TestBuildTaskAmbientMCPServerBootFailureDegradesNotFails(t *testing.T) {
 		t.Fatalf("the drop must be observable via OnMCPServerDegraded: %+v", degraded)
 	}
 }
+
+// The other half of the same rule, and the reason the ambient degrade is safe:
+// a server the node names EXPLICITLY is a declared dependency, so its boot
+// failure fails the node loud. Without this test the asymmetry reads as an
+// accident of which branch returns, and the tolerant half would erode onto the
+// declared path — silently running an agent without the tools it asked for.
+func TestExplicitMCPWildcardBootFailureFailsTheNode(t *testing.T) {
+	tr := tool.NewRegistry()
+	if err := tr.RegisterBuiltin("bash", "bash", nil, func(context.Context, json.RawMessage) (string, error) {
+		return "ok", nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	e := &ClawExecutor{
+		logger:       iterlog.Nop(),
+		toolRegistry: tr,
+		mcpManager: mcp.NewManager(map[string]*mcp.ServerConfig{
+			"deadsrv": {Command: "/nonexistent/iterion-test-mcp-server"},
+		}),
+	}
+	var degraded []MCPServerDegradedInfo
+	e.hooks.OnMCPServerDegraded = func(_ string, info MCPServerDegradedInfo) {
+		degraded = append(degraded, info)
+	}
+
+	// Named in the node's own tool list, NOT in activeMCPServers — the whole
+	// distinction between a declared dependency and an inherited one.
+	node := &ir.AgentNode{BaseNode: ir.BaseNode{ID: "n"}}
+	f := backendFields{id: "n", model: "anthropic/claude-opus-5", tools: []string{"bash", "mcp.deadsrv.*"}}
+
+	_, err := e.buildTask(context.Background(), node, f, map[string]any{}, delegate.BackendClaw, nil)
+	if err == nil {
+		t.Fatal("an explicitly named MCP server that cannot boot must fail the node")
+	}
+	// The message has to name the server and say the node asked for it, or the
+	// operator cannot tell this apart from a tool that simply does not exist.
+	if !strings.Contains(err.Error(), "deadsrv") || !strings.Contains(err.Error(), "explicitly") {
+		t.Errorf("error must name the server and its declared origin: %v", err)
+	}
+	if len(degraded) != 0 {
+		t.Errorf("a declared dependency must never be reported as a degrade: %+v", degraded)
+	}
+}

--- a/pkg/backend/model/executor_toolresolve.go
+++ b/pkg/backend/model/executor_toolresolve.go
@@ -96,17 +96,28 @@ func (e *ClawExecutor) expandWildcards(ctx context.Context, node ir.Node, names 
 		}
 		// Ensure the server is connected so its tools are in the registry.
 		//
-		// A wildcard reaching here is a DECLARED dependency, so a boot failure
-		// is fatal on purpose: ambient servers (target repo `.mcp.json`, plugin
-		// catalog) are ensured one by one upstream in buildTask and dropped
-		// with an `mcp_server_degraded` event when they cannot boot, so they
-		// never arrive as a wildcard. The asymmetry with the empty-match
-		// warning below is the point — unreachable means the node asked for
-		// something the host cannot supply, empty means the server booted and
-		// has nothing to offer.
+		// A wildcard that FAILS here is a declared dependency, so the boot
+		// failure is fatal on purpose. Ambient servers (target repo
+		// `.mcp.json`, plugin catalog) DO reach this loop as wildcards —
+		// buildTask splices each one in as `mcp.<srv>.*` — but only after
+		// ensuring it one by one and dropping the ones that cannot boot with
+		// an `mcp_server_degraded` event, so every ambient wildcard that gets
+		// here is already `discovered` and the EnsureServers below is a no-op
+		// for it. Keep that ordering: splice an unensured ambient server in
+		// and its boot failure is fatal again. The asymmetry with the
+		// empty-match warning below is the point — unreachable means the node
+		// asked for something the host cannot supply, empty means the server
+		// booted and has nothing to offer.
 		if e.mcpManager != nil && e.toolRegistry != nil {
 			if err := e.mcpManager.EnsureServers(ctx, e.toolRegistry, []string{server}); err != nil {
-				return nil, fmt.Errorf("model: MCP server %q, named explicitly by this node as %q, cannot boot: %w (drop the wildcard to make the server optional — an ambient server degrades to a warning instead)", server, name, err)
+				// State the RULE, not the instance: at this point the code
+				// cannot tell a node-declared server from an ambient one that
+				// was already ensured, so naming the provenance would assert
+				// something it does not know.
+				return nil, fmt.Errorf("model: MCP server %q, required by this node as %q, cannot boot: %w "+
+					"(a server the node names explicitly is a declared dependency and fails the node; the same "+
+					"server inherited from the target repo's .mcp.json or the plugin catalog degrades to a "+
+					"warning instead)", server, name, err)
 			}
 		}
 		if e.toolRegistry == nil {

--- a/pkg/backend/model/executor_toolresolve.go
+++ b/pkg/backend/model/executor_toolresolve.go
@@ -95,9 +95,18 @@ func (e *ClawExecutor) expandWildcards(ctx context.Context, node ir.Node, names 
 			return nil, fmt.Errorf("model: invalid wildcard %q: %w", name, err)
 		}
 		// Ensure the server is connected so its tools are in the registry.
+		//
+		// A wildcard reaching here is a DECLARED dependency, so a boot failure
+		// is fatal on purpose: ambient servers (target repo `.mcp.json`, plugin
+		// catalog) are ensured one by one upstream in buildTask and dropped
+		// with an `mcp_server_degraded` event when they cannot boot, so they
+		// never arrive as a wildcard. The asymmetry with the empty-match
+		// warning below is the point — unreachable means the node asked for
+		// something the host cannot supply, empty means the server booted and
+		// has nothing to offer.
 		if e.mcpManager != nil && e.toolRegistry != nil {
 			if err := e.mcpManager.EnsureServers(ctx, e.toolRegistry, []string{server}); err != nil {
-				return nil, fmt.Errorf("model: ensure MCP server %q for wildcard: %w", server, err)
+				return nil, fmt.Errorf("model: MCP server %q, named explicitly by this node as %q, cannot boot: %w (drop the wildcard to make the server optional — an ambient server degrades to a warning instead)", server, name, err)
 			}
 		}
 		if e.toolRegistry == nil {


### PR DESCRIPTION
Closes #638 — the residual half, after #633 removed the one that was bleeding.

## What was actually wrong

#633 settled the rule: an **ambient** MCP server (target repo `.mcp.json`, plugin catalog) that cannot boot costs its own tools, never the run; a server the node names **explicitly** is a declared dependency and still fails loud. That is the right rule, and `docs/backends.md` states it.

What it did not do is say so **at the code site**. In `expandWildcards`, two branches sit ten lines apart:

- server cannot boot → `return nil, err` (fatal)
- server booted, exposes no tools → `logger.Warn` (tolerated)

Nothing there explained why, and the error message named neither the declaration nor a way out — so a reader inferred the rule from whichever branch happened to return, and the tolerant branch is exactly the one that drifts onto the declared path under maintenance pressure. #638 asked for a decision rather than an accident; this is the decision, written down and pinned.

## Changes

- **A comment that states the rule**, including why the two branches legitimately differ: unreachable means the node asked for something the host cannot supply; empty means the server booted and has nothing to offer.
- **An actionable error.** It names the server, says the node asked for it explicitly, and points at the escape hatch — drop the wildcard and the same server degrades to a warning as an ambient one. Previously: `model: ensure MCP server "sentry" for wildcard: …`.
- **The mirror test.** The ambient degrade already has one (`TestBuildTaskAmbientMCPServerBootFailureDegradesNotFails`); its counterpart asserts the declared path stays fatal, that the message carries the two facts an operator needs, and that a declared dependency is never reported through `OnMCPServerDegraded`.

## Verification

The test is red without the source change and green with it:

```
--- FAIL: TestExplicitMCPWildcardBootFailureFailsTheNode (0.00s)
    executor_mcp_forward_test.go:146: error must name the server and its declared origin:
    model: node "n": model: ensure MCP server "deadsrv" for wildcard: …
```

`gofmt`, `go vet`, and the full `pkg/backend/model` suite pass.

No behaviour change on the happy path, and none on the failure path either — this is a characterization test plus a readable failure. That is deliberate: the bug #638 opened on was a **documentation-at-the-site** defect, and the production bite was #633's to fix.