### PR TITLE
fix(forge): refresh lead must exceed the tick period, or a token phase-locks onto its own expiry

### DIFF
--- a/pkg/server/server_lifecycle.go
+++ b/pkg/server/server_lifecycle.go
@@ -20,6 +20,23 @@ import (
 	"github.com/SocialGouv/iterion/pkg/usernotify/webpush"
 )
 
+// Forge refresh cadence. The invariant is Lead > tick period: a GitHub App
+// installation token lives 1h and RunOnce only refreshes what expires within
+// Lead, so with Lead below the tick period a token can go from "not yet due"
+// to "expired" between two ticks. The refresh then lands AT expiry — and
+// because the next mint inherits that phase (mint at T ⇒ expiry T+1h ⇒ next
+// mint at the first tick ≥ T+1h−Lead), the connection locks onto an
+// always-refreshed-at-death cycle: any run whose launch minute sits just
+// before the lock point is sealed a token with seconds of life, its clones
+// and pushes failing "Invalid username or token" / "could not read Username"
+// (Senti's hourly `17 * * * *` vs a :17:24 lock, 2026-09-03). With
+// Lead > tick, every token is re-minted 5–15 minutes BEFORE expiry, so a
+// sealed token always carries at least Lead − tick of remaining life.
+const (
+	forgeRefreshLead = 15 * time.Minute
+	forgeRefreshTick = 10 * time.Minute
+)
+
 // Addr returns the actual bound address (host:port) once ListenAndServe has
 // successfully created its listener. It blocks until the listener is ready or
 // the context is cancelled. Used by the desktop host when Port=0 was passed
@@ -178,7 +195,7 @@ func (s *Server) ListenAndServe() error {
 			Sealer:         s.sealer,
 			RefresherFor:   s.forgeRefresherFor,
 			SecurityMinter: s.forgeSecurityTokenMinter,
-			Lead:           5 * time.Minute,
+			Lead:           forgeRefreshLead,
 		}
 		go func() {
 			ctx, cancel := context.WithCancel(context.Background())
@@ -187,7 +204,14 @@ func (s *Server) ListenAndServe() error {
 				<-s.shutdown
 				cancel()
 			}()
-			t := time.NewTicker(10 * time.Minute)
+			// Boot sweep: a rolling deploy re-phases the ticker below onto the
+			// new pod's start time, so a token that was about to be refreshed by
+			// the old replica's next tick could otherwise sit dying until this
+			// replica's first tick, up to a full period away.
+			if _, err := worker.RunOnce(ctx); err != nil && s.logger != nil {
+				s.logger.Warn("forge token refresh: %v", err)
+			}
+			t := time.NewTicker(forgeRefreshTick)
 			defer t.Stop()
 			for {
 				select {

--- a/pkg/server/server_lifecycle_test.go
+++ b/pkg/server/server_lifecycle_test.go
@@ -1,0 +1,15 @@
+package server
+
+import "testing"
+
+// The forge refresh worker only refreshes tokens expiring within Lead, on a
+// fixed ticker: with Lead at or below the tick period, a 1h installation
+// token can expire between two ticks, the refresh phase-locks onto the
+// expiry instant, and every run launched just before that instant is sealed
+// a token with seconds of life (see the constants' comment for the incident
+// this encodes).
+func TestForgeRefreshLeadExceedsTickPeriod(t *testing.T) {
+	if forgeRefreshLead <= forgeRefreshTick {
+		t.Fatalf("forgeRefreshLead (%v) must exceed forgeRefreshTick (%v): a lead at or below the tick period lets a token expire between two sweeps and phase-locks its refresh onto the expiry instant", forgeRefreshLead, forgeRefreshTick)
+	}
+}


### PR DESCRIPTION
## Incident (prod, 2026-09-03)

Senti (vuln-watch, hourly `17 * * * *`) posted the same two CVEs (CVE-2025-31125 / CVE-2025-30208) to the Mattermost security channel three times in a row, and its runs parked on the DLQ.

Chain:
1. The forge `RefreshWorker` renews a connection token only when it expires within `Lead` (**5m**), swept on a **10m** ticker. With `Lead < tick`, a 1h GitHub App installation token can go from "not yet due" to "expired" between two sweeps — the refresh then lands **at** expiry.
2. Each mint inherits that phase (mint at T ⇒ expiry T+1h ⇒ next mint at the first tick ≥ T+1h−Lead), so the connection **locks onto an always-refreshed-at-death cycle**.
3. The morning server restart re-phased the tick grid; the SocialGouv forge token locked onto `:17:24` — 16 s after Senti's `:17:08` seal (`resolveAndSealCredentials` seals the stored value verbatim, no freshness check).
4. Each run: clone barely made it (or not — the 09:17 run died on it), the alert was **delivered**, then `commit_state`'s `git push` presented the now-dead token → 401 → git re-prompts → `could not read Username` → state never persisted → the dedup state was lost with the pod → same CVEs re-alerted the next hour. NATS redeliveries re-cloned with the same sealed dead token → `Invalid username or token` → `DLQ_PARKED`.

Runs up to 08:17 pushed fine — the previous boot's phase left ~55 min of margin. Not a dedup bug, not a revoked credential: a phase-lock.

## Fix

- `Lead` **15m** > tick **10m**: every token is re-minted 5–15 minutes *before* expiry, so a sealed token always carries ≥ `Lead − tick` of remaining life (constants extracted with the invariant documented).
- **Boot sweep** (`RunOnce` before the ticker): covers the rolling-deploy window where the old replica's next tick would have refreshed a dying token that the new replica's first tick is up to a full period away from.
- Regression test pinning `forgeRefreshLead > forgeRefreshTick`.

## Ops already applied (no code)

- Prod Senti schedule moved `17 * * * *` → `25 * * * *` (clear of both the `:17:24` forge-token phase and the `:47:23` dependabot-map phase) — stops the spam before this ships.
- Note: `POST /forge/connections/{id}/refresh` is a health probe (mints a probe token); it does **not** rewrite the managed secret, so it can't be used to re-phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)