### PR TITLE
feat(oauth): name the account behind a credential, and expose its fingerprint

### DIFF
--- a/cmd/iterion/remote_admin.go
+++ b/cmd/iterion/remote_admin.go
@@ -243,7 +243,7 @@ var remoteAdminLLMOAuthCmd = &cobra.Command{
 			if len(args) == 2 {
 				kind = args[1]
 			}
-			return cli.RemoteAdminLLMOAuthConnect(cmd.Context(), c, p, kind)
+			return cli.RemoteAdminLLMOAuthConnect(cmd.Context(), c, p, kind, strings.TrimSpace(remoteLLMAccountLabel))
 		case "name":
 			// Names the ACCOUNT behind a platform forfait. The listing
 			// prints only kind + fingerprint otherwise, and a fingerprint
@@ -252,7 +252,14 @@ var remoteAdminLLMOAuthCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			body, err := json.Marshal(map[string]string{"account_label": remoteLLMAccountLabel})
+			// The server reads "" as "clear the label", so a forgotten flag
+			// must be refused rather than sent — `name` exists because
+			// operators forget the naming step, and un-naming on that very
+			// mistake would be the worst possible default.
+			if !cmd.Flags().Changed("account-label") {
+				return fmt.Errorf("usage: admin llm oauth name %s --account-label <name> (pass --account-label \"\" to clear it)", kind)
+			}
+			body, err := json.Marshal(map[string]string{"account_label": strings.TrimSpace(remoteLLMAccountLabel)})
 			if err != nil {
 				return err
 			}
@@ -667,7 +674,7 @@ func init() {
 	remoteAdminLLMKeysCmd.Flags().StringVar(&remoteLLMName, "name", "", "Key display name for create")
 	remoteAdminLLMKeysCmd.Flags().BoolVar(&remoteLLMDefault, "default", false, "Make the created key the provider's default")
 	remoteAdminLLMKeysCmd.Flags().StringVar(&remoteLLMKeyData, "data", "", "Patch JSON for update (literal or @file)")
-	remoteAdminLLMOAuthCmd.Flags().StringVar(&remoteLLMAccountLabel, "account-label", "", "Name the account behind this forfait (set at `set`, or alone with `name`)")
+	remoteAdminLLMOAuthCmd.Flags().StringVar(&remoteLLMAccountLabel, "account-label", "", "Name the account behind this forfait (with `set`/`connect`, or alone with `name`; `name --account-label \"\"` clears it)")
 	remoteAdminLLMCmd.AddCommand(remoteAdminLLMKeysCmd, remoteAdminLLMOAuthCmd)
 
 	remoteAdminCapsCmd.Flags().IntVar(&remoteCapsFiveHour, "five-hour", 0, "Five-hour window cap percentage (0–100; 0 = no cap)")

--- a/cmd/iterion/remote_admin.go
+++ b/cmd/iterion/remote_admin.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/SocialGouv/iterion/pkg/cli"
@@ -134,6 +135,9 @@ var (
 	remoteLLMName     string
 	remoteLLMDefault  bool
 	remoteLLMKeyData  string
+	// remoteLLMAccountLabel names the ACCOUNT behind a forfait, so a
+	// listing says "jothedev" instead of a bare fingerprint.
+	remoteLLMAccountLabel string
 )
 
 var remoteAdminLLMCmd = &cobra.Command{
@@ -198,7 +202,7 @@ var remoteAdminLLMKeysCmd = &cobra.Command{
 }
 
 var remoteAdminLLMOAuthCmd = &cobra.Command{
-	Use:   "oauth [set|connect|refresh|delete] [kind]",
+	Use:   "oauth [set|connect|name|refresh|delete] [kind]",
 	Short: "Platform OAuth-forfait: list connections (default) or act on one kind (claude_code|codex)",
 	Args:  cobra.MaximumNArgs(2),
 	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
@@ -228,7 +232,11 @@ var remoteAdminLLMOAuthCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			return cli.RemoteSendPrint(cmd.Context(), c, p, "POST", "/api/admin/llm/oauth/"+kind+"/credentials", blob)
+			path := "/api/admin/llm/oauth/" + kind + "/credentials"
+			if lbl := strings.TrimSpace(remoteLLMAccountLabel); lbl != "" {
+				path += "?account_label=" + url.QueryEscape(lbl)
+			}
+			return cli.RemoteSendPrint(cmd.Context(), c, p, "POST", path, blob)
 		case "connect":
 			// Browser code flow; only claude_code supports it, so it defaults.
 			kind := "claude_code"
@@ -236,6 +244,19 @@ var remoteAdminLLMOAuthCmd = &cobra.Command{
 				kind = args[1]
 			}
 			return cli.RemoteAdminLLMOAuthConnect(cmd.Context(), c, p, kind)
+		case "name":
+			// Names the ACCOUNT behind a platform forfait. The listing
+			// prints only kind + fingerprint otherwise, and a fingerprint
+			// is what the server logs print — not what a human recalls.
+			kind, err := needKind()
+			if err != nil {
+				return err
+			}
+			body, err := json.Marshal(map[string]string{"account_label": remoteLLMAccountLabel})
+			if err != nil {
+				return err
+			}
+			return cli.RemoteSendPrint(cmd.Context(), c, p, "PATCH", "/api/admin/llm/oauth/"+kind, body)
 		case "refresh":
 			kind, err := needKind()
 			if err != nil {
@@ -249,7 +270,7 @@ var remoteAdminLLMOAuthCmd = &cobra.Command{
 			}
 			return cli.RemoteSendPrint(cmd.Context(), c, p, "DELETE", "/api/admin/llm/oauth/"+kind, nil)
 		default:
-			return fmt.Errorf("unknown oauth action %q (want set|connect|refresh|delete)", action)
+			return fmt.Errorf("unknown oauth action %q (want set|connect|name|refresh|delete)", action)
 		}
 	}),
 }
@@ -646,6 +667,7 @@ func init() {
 	remoteAdminLLMKeysCmd.Flags().StringVar(&remoteLLMName, "name", "", "Key display name for create")
 	remoteAdminLLMKeysCmd.Flags().BoolVar(&remoteLLMDefault, "default", false, "Make the created key the provider's default")
 	remoteAdminLLMKeysCmd.Flags().StringVar(&remoteLLMKeyData, "data", "", "Patch JSON for update (literal or @file)")
+	remoteAdminLLMOAuthCmd.Flags().StringVar(&remoteLLMAccountLabel, "account-label", "", "Name the account behind this forfait (set at `set`, or alone with `name`)")
 	remoteAdminLLMCmd.AddCommand(remoteAdminLLMKeysCmd, remoteAdminLLMOAuthCmd)
 
 	remoteAdminCapsCmd.Flags().IntVar(&remoteCapsFiveHour, "five-hour", 0, "Five-hour window cap percentage (0–100; 0 = no cap)")

--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -240,9 +240,27 @@ iterion remote admin llm oauth name claude_code --account-label "iterion platfor
 
 The listing then answers the question directly — `account_label` beside
 the `fingerprint`, which is the SAME string the logs print, so a log line
-and the API join without a human in the middle. A re-connect that names
-no account KEEPS the existing label: rotating a token is not renaming the
-account.
+and the API join without a human in the middle. The studio shows both on
+every connection card (Settings → Subscriptions, a team's Model providers
+tab, Admin → LLM credentials) with a *Name account* action, and both
+connect forms take the name up front.
+
+**The name follows the fingerprint.** A re-connect that names no account
+keeps the previous label only when it provably re-connects the same
+subscription — codex fingerprints derive from the account id, so a fresh
+`auth.json` of the same ChatGPT account keeps its name; a claude_code
+credentials blob carries no account id, so only re-pasting the SAME blob
+does. Any other unnamed re-connect drops the label rather than inherit
+it: the same owner key re-pointed at a different forfait — the swap
+measured on 2026-09-03, SocialGouv's key replaced by a personal one on
+the same team — would otherwise answer "whose subscription paid?" with
+the wrong person. Pass `account_label` when you rotate, or `name` it
+afterwards; an unnamed row is a visible gap, a wrongly named one is a
+confident lie.
+
+Renaming is a metadata write at the store (`SetAccountLabel`), never a
+read-modify-write of the record: the sealed payload a concurrent refresh
+just rotated is not carried back over.
 
 ## Platform credentials — rotate the deployment's fallback without a redeploy
 

--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -211,6 +211,39 @@ the ChatGPT-forfait wire gates models by the codex-cli `version:` header
 `ITERION_CODEX_VERSION` to a recent codex-cli version (gpt-5.5 needed
 ≥ 0.130).
 
+## Name the account behind every credential
+
+Nothing else identifies it. The payload is sealed, and when the publisher
+picks a credential it logs a FINGERPRINT:
+
+```
+cloudpublisher: oauth-forfait(org) used run=… kind=claude_code fp=700acc7b00f
+```
+
+Answering "whose subscription paid for that run?" from hex alone means
+grepping server logs and correlating by hand — measured on 2026-09-03,
+with three different fingerprints across three owners in one log window.
+
+So name it at connect time, and rename the ones already connected:
+
+```sh
+# at install (paste path; the browser flow takes the same query param)
+iterion remote api POST "/api/teams/$TEAM/oauth/claude_code/credentials?account_label=jothedev" --data @blob.json
+
+# rename later — metadata only, the sealed credential is untouched
+iterion remote api PATCH "/api/teams/$TEAM/oauth/claude_code" --data '{"account_label":"jothedev"}'
+
+# platform tier (super-admin), same idea
+iterion remote admin llm oauth set claude_code --from-file ./creds.json --account-label "iterion platform"
+iterion remote admin llm oauth name claude_code --account-label "iterion platform"
+```
+
+The listing then answers the question directly — `account_label` beside
+the `fingerprint`, which is the SAME string the logs print, so a log line
+and the API join without a human in the middle. A re-connect that names
+no account KEEPS the existing label: rotating a token is not renaming the
+account.
+
 ## Platform credentials — rotate the deployment's fallback without a redeploy
 
 The credential every tenant-less run used to inherit from the runner pod's

--- a/docs/cloud-rest-api.md
+++ b/docs/cloud-rest-api.md
@@ -255,13 +255,21 @@ Full reference: [webhooks.md](webhooks.md).
 | `POST` | `/api/me/oauth/{kind}/authorize/complete` | member | Finish that handshake |
 | `POST` | `/api/me/oauth/{kind}/credentials` | member | Upload pasted `credentials.json` / `auth.json` |
 | `POST` | `/api/me/oauth/{kind}/refresh` | member | Refresh stored access token against the IdP |
+| `PATCH` | `/api/me/oauth/{kind}` | member | Name the account behind the credential (`{"account_label": "…"}`, `""` clears) — metadata only, the sealed credential is untouched |
 | `DELETE` | `/api/me/oauth/{kind}` | member | Disconnect |
+
+`authorize/complete` and `credentials` take an optional `?account_label=`
+query parameter to name the account at connect time. The listing exposes
+`account_label` beside `fingerprint`, the same string the publisher logs
+when it picks a credential (see
+[cloud-llm-credentials.md](cloud-llm-credentials.md#name-the-account-behind-every-credential)).
 
 Every route above has a team-scoped mirror at
 `/api/teams/{id}/oauth/…` (`connections`, `{kind}/authorize/start`,
-`{kind}/authorize/complete`, `{kind}/credentials`, `{kind}/refresh`, and
-`DELETE {kind}`) for a forfait the whole team draws on rather than one
-operator.
+`{kind}/authorize/complete`, `{kind}/credentials`, `{kind}/refresh`,
+`PATCH {kind}`, and `DELETE {kind}`) for a forfait the whole team draws
+on rather than one operator, and a platform mirror at
+`/api/admin/llm/oauth/…` (super-admin).
 
 Source: [pkg/server/oauth_routes.go](../pkg/server/oauth_routes.go),
 [pkg/server/oauth_team_routes.go](../pkg/server/oauth_team_routes.go).

--- a/openapi.json
+++ b/openapi.json
@@ -3388,7 +3388,19 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "patch": {
+        "operationId": "patchAdminLlmOauthByKind",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "PATCH /api/admin/llm/oauth/{kind}",
+        "tags": [
+          "admin"
+        ]
+      }
     },
     "/api/admin/llm/oauth/{kind}/authorize/complete": {
       "parameters": [
@@ -4638,7 +4650,19 @@
             "type": "string"
           }
         }
-      ]
+      ],
+      "patch": {
+        "operationId": "patchMeOauthByKind",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "PATCH /api/me/oauth/{kind}",
+        "tags": [
+          "me"
+        ]
+      }
     },
     "/api/me/oauth/{kind}/authorize/complete": {
       "parameters": [

--- a/pkg/cli/remote_admin_llm.go
+++ b/pkg/cli/remote_admin_llm.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"regexp"
 	"sort"
@@ -119,8 +120,10 @@ func credentialSourceLabel(fromEnv, fromFile string) string {
 // RemoteAdminLLMOAuthConnect drives the browser code flow for the platform
 // forfait: authorize/start mints the URL, the operator authorizes in a
 // browser and pastes the resulting `code#state`, authorize/complete
-// exchanges it server-side into the stored credentials blob.
-func RemoteAdminLLMOAuthConnect(ctx context.Context, c *RemoteClient, p *Printer, kind string) error {
+// exchanges it server-side into the stored credentials blob. A non-empty
+// accountLabel names the account on that completing call, so the browser
+// path can name at connect time exactly like the paste path.
+func RemoteAdminLLMOAuthConnect(ctx context.Context, c *RemoteClient, p *Printer, kind, accountLabel string) error {
 	var start struct {
 		AuthorizeURL string `json:"authorize_url"`
 		State        string `json:"state"`
@@ -141,7 +144,11 @@ func RemoteAdminLLMOAuthConnect(ctx context.Context, c *RemoteClient, p *Printer
 		}
 		return fmt.Errorf("no authorization code pasted")
 	}
-	raw, err := c.Call(ctx, "POST", adminLLMOAuthBase(kind)+"/authorize/complete",
+	complete := adminLLMOAuthBase(kind) + "/authorize/complete"
+	if accountLabel != "" {
+		complete += "?account_label=" + url.QueryEscape(accountLabel)
+	}
+	raw, err := c.Call(ctx, "POST", complete,
 		map[string]string{"code": code, "state": start.State}, nil)
 	if err != nil {
 		return err

--- a/pkg/secrets/oauth.go
+++ b/pkg/secrets/oauth.go
@@ -103,7 +103,11 @@ type OAuthRecord struct {
 	// logs print only the fingerprint — so answering "whose subscription
 	// is this run spending?" meant grepping server logs and correlating
 	// hex by hand. Purely descriptive; no resolution path reads it.
-	AccountLabel string    `bson:"account_label,omitempty" json:"account_label,omitempty"`
+	//
+	// No bson omitempty: the Mongo store writes records through $set, and
+	// an omitted key leaves the OLD value in place — so clearing the label
+	// would report success and keep the stale name.
+	AccountLabel string    `bson:"account_label" json:"account_label,omitempty"`
 	CreatedAt    time.Time `bson:"created_at" json:"created_at"`
 	UpdatedAt    time.Time `bson:"updated_at" json:"updated_at"`
 }
@@ -117,6 +121,13 @@ type OAuthStore interface {
 	// ExpiringBefore returns records whose access token is set and
 	// expires before t — used by the background refresh worker.
 	ExpiringBefore(ctx context.Context, t time.Time) ([]OAuthRecord, error)
+	// SetAccountLabel writes ONLY the label (and updated_at) of an existing
+	// record; "" clears it. A rename must not travel through Upsert: that
+	// rewrites the whole record, sealed payload included, so a refresh
+	// committed between the caller's Get and its Upsert would be reverted
+	// to a token the provider may already have rotated out. Missing record
+	// → ErrOAuthNotFound.
+	SetAccountLabel(ctx context.Context, userID string, kind OAuthKind, label string) error
 }
 
 // ErrOAuthNotFound is the sentinel for missing records.
@@ -362,6 +373,20 @@ func (s *MemoryOAuthStore) ExpiringBefore(_ context.Context, t time.Time) ([]OAu
 	return out, nil
 }
 
+func (s *MemoryOAuthStore) SetAccountLabel(_ context.Context, userID string, kind OAuthKind, label string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := mkOAuthKey(userID, kind)
+	r, ok := s.m[key]
+	if !ok {
+		return ErrOAuthNotFound
+	}
+	r.AccountLabel = label
+	r.UpdatedAt = time.Now().UTC()
+	s.m[key] = r
+	return nil
+}
+
 // MongoOAuthStore — production impl.
 type MongoOAuthStore struct {
 	coll *mongo.Collection
@@ -425,6 +450,22 @@ func (s *MongoOAuthStore) ListByUser(ctx context.Context, userID string) ([]OAut
 
 func (s *MongoOAuthStore) Delete(ctx context.Context, userID string, kind OAuthKind) error {
 	return mongoutil.DeleteOneChecked(ctx, s.coll, bson.M{"user_id": userID, "kind": kind}, ErrOAuthNotFound, "secrets: delete oauth")
+}
+
+func (s *MongoOAuthStore) SetAccountLabel(ctx context.Context, userID string, kind OAuthKind, label string) error {
+	// A literal $set of the two keys, never the struct: the sealed payload
+	// and the fingerprint stay whatever the last connect/refresh wrote.
+	res, err := s.coll.UpdateOne(ctx,
+		bson.M{"user_id": userID, "kind": kind},
+		bson.M{"$set": bson.M{"account_label": label, "updated_at": time.Now().UTC()}},
+	)
+	if err != nil {
+		return fmt.Errorf("secrets: set oauth account label: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return ErrOAuthNotFound
+	}
+	return nil
 }
 
 func (s *MongoOAuthStore) ExpiringBefore(ctx context.Context, t time.Time) ([]OAuthRecord, error) {

--- a/pkg/secrets/oauth.go
+++ b/pkg/secrets/oauth.go
@@ -96,9 +96,16 @@ type OAuthRecord struct {
 	// account), self-healed on legacy records at their first refresh. It
 	// is what downstream metering keys on — re-posting credentials is the
 	// act that says "different subscription", so it re-stamps.
-	Fingerprint string    `bson:"fingerprint,omitempty" json:"fingerprint,omitempty"`
-	CreatedAt   time.Time `bson:"created_at" json:"created_at"`
-	UpdatedAt   time.Time `bson:"updated_at" json:"updated_at"`
+	Fingerprint string `bson:"fingerprint,omitempty" json:"fingerprint,omitempty"`
+	// AccountLabel names the ACCOUNT this credential belongs to, in the
+	// operator's own words ("jothedev", "SocialGouv Revi"). Nothing else
+	// in the record identifies it: the payload is sealed, and the runtime
+	// logs print only the fingerprint — so answering "whose subscription
+	// is this run spending?" meant grepping server logs and correlating
+	// hex by hand. Purely descriptive; no resolution path reads it.
+	AccountLabel string    `bson:"account_label,omitempty" json:"account_label,omitempty"`
+	CreatedAt    time.Time `bson:"created_at" json:"created_at"`
+	UpdatedAt    time.Time `bson:"updated_at" json:"updated_at"`
 }
 
 // OAuthStore is the persistence interface for sealed OAuth records.

--- a/pkg/secrets/oauth_mongo_test.go
+++ b/pkg/secrets/oauth_mongo_test.go
@@ -1,0 +1,105 @@
+package secrets
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+// The memory store replaces the whole record on Upsert, so a cleared label
+// clears in every in-memory test whatever the bson tags say. The Mongo
+// store writes through $set, where an omitted key keeps the OLD value —
+// the shape of bug only a real Mongo can show. Same gating as the other
+// conformance suites (CI's mongo-conformance job sets ITERION_TEST_MONGO_URI).
+func mongoOAuthStore(t *testing.T) (*MongoOAuthStore, context.Context) {
+	t.Helper()
+	uri := os.Getenv("ITERION_TEST_MONGO_URI")
+	if uri == "" {
+		t.Skip("ITERION_TEST_MONGO_URI not set; skipping Mongo oauth suite")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	t.Cleanup(cancel)
+	client, err := mongo.Connect(options.Client().ApplyURI(uri))
+	if err != nil {
+		t.Fatalf("mongo connect: %v", err)
+	}
+	nonce := make([]byte, 4)
+	_, _ = rand.Read(nonce)
+	db := client.Database("iterion_oauth_" + hex.EncodeToString(nonce))
+	t.Cleanup(func() {
+		drop, dropCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer dropCancel()
+		_ = db.Drop(drop)
+		_ = client.Disconnect(drop)
+	})
+	s := NewMongoOAuthStore(db)
+	if err := s.EnsureSchema(ctx); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	return s, ctx
+}
+
+// Clearing the label must clear it on the wire the production store uses:
+// with a bson omitempty on the field, the $set body carried no key for an
+// empty label and the API reported a clear that never happened.
+func TestMongoOAuth_EmptyLabelClearsThroughUpsert(t *testing.T) {
+	s, ctx := mongoOAuthStore(t)
+	rec := OAuthRecord{UserID: "alice", Kind: OAuthKindClaudeCode, SealedPayload: []byte("sealed"), Fingerprint: "fp-1", AccountLabel: "old name"}
+	if err := s.Upsert(ctx, rec); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	rec.AccountLabel = ""
+	if err := s.Upsert(ctx, rec); err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+	got, err := s.Get(ctx, "alice", OAuthKindClaudeCode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccountLabel != "" {
+		t.Fatalf("label after an empty-label upsert = %q, want cleared (bson omitempty would keep the stale name)", got.AccountLabel)
+	}
+}
+
+// A rename touches two keys and nothing else: the sealed payload and the
+// fingerprint stay whatever the last connect/refresh wrote, even when the
+// caller's copy of the record is stale.
+func TestMongoOAuth_SetAccountLabelIsMetadataOnly(t *testing.T) {
+	s, ctx := mongoOAuthStore(t)
+	if err := s.SetAccountLabel(ctx, "alice", OAuthKindCodex, "x"); !errors.Is(err, ErrOAuthNotFound) {
+		t.Fatalf("SetAccountLabel on a missing record = %v, want ErrOAuthNotFound", err)
+	}
+	if err := s.Upsert(ctx, OAuthRecord{UserID: "alice", Kind: OAuthKindCodex, SealedPayload: []byte("sealed-v1"), Fingerprint: "fp-1"}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	// A refresh lands a new payload before the rename is written.
+	if err := s.Upsert(ctx, OAuthRecord{UserID: "alice", Kind: OAuthKindCodex, SealedPayload: []byte("sealed-v2"), Fingerprint: "fp-1"}); err != nil {
+		t.Fatalf("refresh upsert: %v", err)
+	}
+	if err := s.SetAccountLabel(ctx, "alice", OAuthKindCodex, "alice@openai"); err != nil {
+		t.Fatalf("SetAccountLabel: %v", err)
+	}
+	got, err := s.Get(ctx, "alice", OAuthKindCodex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccountLabel != "alice@openai" {
+		t.Fatalf("label = %q", got.AccountLabel)
+	}
+	if string(got.SealedPayload) != "sealed-v2" || got.Fingerprint != "fp-1" {
+		t.Fatalf("rename disturbed the credential: payload=%q fp=%q", got.SealedPayload, got.Fingerprint)
+	}
+	if err := s.SetAccountLabel(ctx, "alice", OAuthKindCodex, ""); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if got, _ = s.Get(ctx, "alice", OAuthKindCodex); got.AccountLabel != "" {
+		t.Fatalf("label after clear = %q, want empty", got.AccountLabel)
+	}
+}

--- a/pkg/secrets/oauth_test.go
+++ b/pkg/secrets/oauth_test.go
@@ -60,6 +60,40 @@ func TestMemoryOAuthStoreUpsertGetDelete(t *testing.T) {
 	}
 }
 
+// A rename is a metadata write: the label moves, the sealed credential and
+// its fingerprint do not, and "" genuinely clears it (the Mongo twin is
+// asserted in oauth_mongo_test.go, where $set semantics make that the
+// interesting case).
+func TestMemoryOAuthStoreSetAccountLabel(t *testing.T) {
+	ctx := context.Background()
+	store := NewMemoryOAuthStore()
+	if err := store.SetAccountLabel(ctx, "alice", OAuthKindClaudeCode, "alice perso"); !errors.Is(err, ErrOAuthNotFound) {
+		t.Fatalf("SetAccountLabel on a missing record = %v, want ErrOAuthNotFound", err)
+	}
+	if err := store.Upsert(ctx, OAuthRecord{
+		UserID: "alice", Kind: OAuthKindClaudeCode,
+		SealedPayload: []byte("sealed"), Fingerprint: "fp-1", AccountLabel: "old name",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetAccountLabel(ctx, "alice", OAuthKindClaudeCode, "alice perso"); err != nil {
+		t.Fatalf("SetAccountLabel: %v", err)
+	}
+	got, err := store.Get(ctx, "alice", OAuthKindClaudeCode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccountLabel != "alice perso" || string(got.SealedPayload) != "sealed" || got.Fingerprint != "fp-1" {
+		t.Fatalf("after rename: %+v", got)
+	}
+	if err := store.SetAccountLabel(ctx, "alice", OAuthKindClaudeCode, ""); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if got, _ = store.Get(ctx, "alice", OAuthKindClaudeCode); got.AccountLabel != "" {
+		t.Fatalf("label after clear = %q, want empty", got.AccountLabel)
+	}
+}
+
 func TestMemoryOAuthStoreExpiringBefore(t *testing.T) {
 	ctx := context.Background()
 	store := NewMemoryOAuthStore()

--- a/pkg/server/admin_llm_routes.go
+++ b/pkg/server/admin_llm_routes.go
@@ -43,6 +43,7 @@ func (s *Server) registerAdminLLMRoutes() {
 		s.mux.Handle("POST /api/admin/llm/oauth/{kind}/authorize/start", s.requireSuperAdmin(http.HandlerFunc(s.handleAdminStartPlatformOAuth)))
 		s.mux.Handle("POST /api/admin/llm/oauth/{kind}/authorize/complete", s.requireSuperAdmin(http.HandlerFunc(s.handleAdminCompletePlatformOAuth)))
 		s.mux.Handle("POST /api/admin/llm/oauth/{kind}/refresh", s.requireSuperAdmin(http.HandlerFunc(s.handleAdminRefreshPlatformOAuth)))
+		s.mux.Handle("PATCH /api/admin/llm/oauth/{kind}", s.requireSuperAdmin(http.HandlerFunc(s.handleAdminRenamePlatformOAuth)))
 		s.mux.Handle("DELETE /api/admin/llm/oauth/{kind}", s.requireSuperAdmin(http.HandlerFunc(s.handleAdminDeletePlatformOAuth)))
 	}
 }
@@ -137,6 +138,13 @@ func (s *Server) handleAdminCompletePlatformOAuth(w http.ResponseWriter, r *http
 
 func (s *Server) handleAdminRefreshPlatformOAuth(w http.ResponseWriter, r *http.Request) {
 	s.refreshOAuthForOwner(w, r, secrets.PlatformOwnerKey, secrets.OAuthKind(r.PathValue("kind")))
+}
+
+// handleAdminRenamePlatformOAuth names the account behind a PLATFORM
+// forfait — the tier that serves every team with no credential of its
+// own, and therefore the one whose owner is hardest to recall.
+func (s *Server) handleAdminRenamePlatformOAuth(w http.ResponseWriter, r *http.Request) {
+	s.renameOAuthForOwner(w, r, secrets.PlatformOwnerKey, secrets.OAuthKind(r.PathValue("kind")))
 }
 
 func (s *Server) handleAdminDeletePlatformOAuth(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/admin_llm_routes_test.go
+++ b/pkg/server/admin_llm_routes_test.go
@@ -230,6 +230,8 @@ func TestAdminLLM_NonSuperAdminIsRefused(t *testing.T) {
 		{"POST", "/api/admin/llm/api-keys", userTok, http.StatusForbidden},
 		{"GET", "/api/admin/llm/oauth/connections", userTok, http.StatusForbidden},
 		{"POST", "/api/admin/llm/oauth/claude_code/credentials", userTok, http.StatusForbidden},
+		{"PATCH", "/api/admin/llm/oauth/claude_code", userTok, http.StatusForbidden},
+		{"PATCH", "/api/admin/llm/oauth/claude_code", "", http.StatusUnauthorized},
 		{"GET", "/api/admin/llm/api-keys", "", http.StatusUnauthorized},
 		{"POST", "/api/admin/llm/oauth/claude_code/credentials", "", http.StatusUnauthorized},
 	}
@@ -270,6 +272,18 @@ func TestAdminLLM_OAuthPasteStoresUnderThePlatformOwner(t *testing.T) {
 	}
 	if strings.Contains(string(body), "sk-ant-platform-forfait") {
 		t.Fatal("the connections list leaked the token")
+	}
+
+	// Naming the platform forfait is the same PATCH as the tenant tiers,
+	// under the super-admin gate; the listing is where the name must show.
+	if code, body = llmDo(t, hs, "PATCH", "/api/admin/llm/oauth/claude_code", adminTok, `{"account_label":"iterion platform"}`); code != http.StatusOK {
+		t.Fatalf("rename: status=%d body=%s", code, body)
+	}
+	if code, body = llmDo(t, hs, "GET", "/api/admin/llm/oauth/connections", adminTok, ""); code != http.StatusOK || !strings.Contains(string(body), `"account_label":"iterion platform"`) {
+		t.Fatalf("connections list after rename: status=%d body=%s", code, body)
+	}
+	if rec, err := oauth.Get(context.Background(), secrets.PlatformOwnerKey, secrets.OAuthKindClaudeCode); err != nil || rec.AccountLabel != "iterion platform" {
+		t.Fatalf("stored label = %q (err=%v)", rec.AccountLabel, err)
 	}
 
 	if code, body = llmDo(t, hs, "DELETE", "/api/admin/llm/oauth/claude_code", adminTok, ""); code >= 300 {

--- a/pkg/server/oauth_routes.go
+++ b/pkg/server/oauth_routes.go
@@ -28,13 +28,25 @@ func (s *Server) registerOAuthForfaitRoutes() {
 	// Raw blob paste — kept as a fallback (power users / Codex).
 	s.mux.Handle("POST /api/me/oauth/{kind}/credentials", s.requireAuth(http.HandlerFunc(s.handleUploadOAuthCredentials)))
 	s.mux.Handle("POST /api/me/oauth/{kind}/refresh", s.requireAuth(http.HandlerFunc(s.handleRefreshOAuth)))
+	s.mux.Handle("PATCH /api/me/oauth/{kind}", s.requireAuth(http.HandlerFunc(s.handleRenameOAuth)))
 	s.mux.Handle("DELETE /api/me/oauth/{kind}", s.requireAuth(http.HandlerFunc(s.handleDeleteOAuth)))
 }
 
 // oauthConnectionView is the safe-to-display projection of an
 // OAuthRecord. Plaintext / sealed payload never leave the server.
 type oauthConnectionView struct {
-	Kind                 string   `json:"kind"`
+	Kind string `json:"kind"`
+	// AccountLabel is the operator's name for the account behind this
+	// credential ("jothedev"). Empty on records connected before labels
+	// existed — rename them with PATCH.
+	AccountLabel string `json:"account_label,omitempty"`
+	// Fingerprint is the credential's stable id, and the SAME value the
+	// runtime prints when it picks a credential
+	// ("oauth-forfait(org) used … fp=700acc7b…"). Exposing it is what
+	// lets an operator answer "whose subscription served that run?"
+	// from the API instead of grepping server logs. Non-secret by
+	// construction: a hash, never the token.
+	Fingerprint          string   `json:"fingerprint,omitempty"`
 	Scopes               []string `json:"scopes,omitempty"`
 	AccessTokenExpiresAt *string  `json:"access_token_expires_at,omitempty"`
 	LastRefreshedAt      *string  `json:"last_refreshed_at,omitempty"`
@@ -48,6 +60,8 @@ type oauthConnectionView struct {
 func toOAuthView(r secrets.OAuthRecord) oauthConnectionView {
 	return oauthConnectionView{
 		Kind:                 string(r.Kind),
+		AccountLabel:         r.AccountLabel,
+		Fingerprint:          r.Fingerprint,
 		Scopes:               r.Scopes,
 		CreatedAt:            r.CreatedAt.Format(time.RFC3339),
 		UpdatedAt:            r.UpdatedAt.Format(time.RFC3339),
@@ -82,6 +96,12 @@ func (s *Server) handleUploadOAuthCredentials(w http.ResponseWriter, r *http.Req
 func (s *Server) handleRefreshOAuth(w http.ResponseWriter, r *http.Request) {
 	id, _ := auth.FromContext(r.Context())
 	s.refreshOAuthForOwner(w, r, id.UserID, secrets.OAuthKind(r.PathValue("kind")))
+}
+
+// handleRenameOAuth names the account behind the caller's own forfait.
+func (s *Server) handleRenameOAuth(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	s.renameOAuthForOwner(w, r, id.UserID, secrets.OAuthKind(r.PathValue("kind")))
 }
 
 func (s *Server) handleDeleteOAuth(w http.ResponseWriter, r *http.Request) {
@@ -248,7 +268,7 @@ func (s *Server) completeOAuthForOwner(w http.ResponseWriter, r *http.Request, o
 		httpError(w, http.StatusInternalServerError, "build credentials: %v", err)
 		return
 	}
-	rec, err := s.sealOAuthRecord(r.Context(), ownerKey, kind, blob)
+	rec, err := s.sealOAuthRecord(r.Context(), ownerKey, kind, blob, r.URL.Query().Get("account_label"))
 	if err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
@@ -274,12 +294,12 @@ func (s *Server) uploadOAuthForOwner(w http.ResponseWriter, r *http.Request, own
 		httpError(w, http.StatusBadRequest, "empty body — paste the credentials.json / auth.json content")
 		return
 	}
-	rec, err := s.sealOAuthRecord(r.Context(), ownerKey, kind, body)
+	rec, err := s.sealOAuthRecord(r.Context(), ownerKey, kind, body, r.URL.Query().Get("account_label"))
 	if err != nil {
 		httpError(w, http.StatusBadRequest, "%s", err.Error())
 		return
 	}
-	s.logger.Info("oauth: owner=%s kind=%s connected (sealed payload, expires=%v)", ownerKey, kind, rec.AccessTokenExpiresAt)
+	s.logger.Info("oauth: owner=%s kind=%s connected (sealed payload, account=%q fp=%s expires=%v)", ownerKey, kind, rec.AccountLabel, rec.Fingerprint, rec.AccessTokenExpiresAt)
 	s.auditOAuthByOwner(r, ownerKey, "connected", kind, map[string]any{"flow": "paste"})
 	writeJSON(w, toOAuthView(rec))
 }
@@ -287,7 +307,7 @@ func (s *Server) uploadOAuthForOwner(w http.ResponseWriter, r *http.Request, own
 // sealOAuthRecord validates a credentials blob, extracts expiry/scope
 // metadata, seals it bound to (ownerKey, kind), and upserts the record.
 // Shared by the browser flow and the paste path.
-func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secrets.OAuthKind, blob []byte) (secrets.OAuthRecord, error) {
+func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secrets.OAuthKind, blob []byte, accountLabel string) (secrets.OAuthRecord, error) {
 	now := time.Now().UTC()
 	rec := secrets.OAuthRecord{
 		// ID is derived in the OAuth store's Upsert (memory + Mongo
@@ -337,6 +357,16 @@ func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secr
 	// Derived from the account the payload names where it names one, so
 	// connecting ONE subscription twice does not open two meters.
 	rec.Fingerprint = secrets.SubscriptionFingerprint(kind, blob)
+	// A re-connect that names no account keeps the label the record
+	// already carried: rotating a token is not renaming the account, and
+	// silently blanking the name would put the operator back to reading
+	// fingerprints out of the logs.
+	rec.AccountLabel = strings.TrimSpace(accountLabel)
+	if rec.AccountLabel == "" {
+		if prev, err := s.oauthStore.Get(ctx, ownerKey, kind); err == nil {
+			rec.AccountLabel = prev.AccountLabel
+		}
+	}
 	if err := s.oauthStore.Upsert(ctx, rec); err != nil {
 		return secrets.OAuthRecord{}, err
 	}
@@ -379,6 +409,44 @@ func (s *Server) refreshOAuthForOwner(w http.ResponseWriter, r *http.Request, ow
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
 	}
+	writeJSON(w, toOAuthView(rec))
+}
+
+// renameOAuthForOwner sets (or clears) the account label on an existing
+// connection. It exists because the label is the only thing that maps a
+// credential back to a human account, and every record connected before
+// labels existed carries none — so the feature would be inert on exactly
+// the credentials an operator most needs to identify today. Renaming
+// touches metadata only: the sealed payload, fingerprint and expiry are
+// untouched, so a rename can never rotate or invalidate a live key.
+func (s *Server) renameOAuthForOwner(w http.ResponseWriter, r *http.Request, ownerKey string, kind secrets.OAuthKind) {
+	if !kind.Valid() {
+		httpError(w, http.StatusBadRequest, "unknown oauth kind")
+		return
+	}
+	var req struct {
+		AccountLabel *string `json:"account_label"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 4<<10)).Decode(&req); err != nil {
+		httpError(w, http.StatusBadRequest, "decode body: %v", err)
+		return
+	}
+	if req.AccountLabel == nil {
+		httpError(w, http.StatusBadRequest, "account_label required (send \"\" to clear it)")
+		return
+	}
+	rec, err := s.oauthStore.Get(r.Context(), ownerKey, kind)
+	if err != nil {
+		httpError(w, http.StatusNotFound, "no %s connection", kind)
+		return
+	}
+	rec.AccountLabel = strings.TrimSpace(*req.AccountLabel)
+	rec.UpdatedAt = time.Now().UTC()
+	if err := s.oauthStore.Upsert(r.Context(), rec); err != nil {
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	s.auditOAuthByOwner(r, ownerKey, "renamed", kind, map[string]any{"account_label": rec.AccountLabel})
 	writeJSON(w, toOAuthView(rec))
 }
 

--- a/pkg/server/oauth_routes.go
+++ b/pkg/server/oauth_routes.go
@@ -273,8 +273,8 @@ func (s *Server) completeOAuthForOwner(w http.ResponseWriter, r *http.Request, o
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
 	}
-	s.logger.Info("oauth: owner=%s kind=%s connected via browser flow (expires=%v)", ownerKey, kind, rec.AccessTokenExpiresAt)
-	s.auditOAuthByOwner(r, ownerKey, "connected", kind, map[string]any{"flow": "browser"})
+	s.logger.Info("oauth: owner=%s kind=%s connected via browser flow (account=%q fp=%s expires=%v)", ownerKey, kind, rec.AccountLabel, rec.Fingerprint, rec.AccessTokenExpiresAt)
+	s.auditOAuthByOwner(r, ownerKey, "connected", kind, map[string]any{"flow": "browser", "account_label": rec.AccountLabel, "fingerprint": rec.Fingerprint})
 	writeJSON(w, toOAuthView(rec))
 }
 
@@ -300,7 +300,7 @@ func (s *Server) uploadOAuthForOwner(w http.ResponseWriter, r *http.Request, own
 		return
 	}
 	s.logger.Info("oauth: owner=%s kind=%s connected (sealed payload, account=%q fp=%s expires=%v)", ownerKey, kind, rec.AccountLabel, rec.Fingerprint, rec.AccessTokenExpiresAt)
-	s.auditOAuthByOwner(r, ownerKey, "connected", kind, map[string]any{"flow": "paste"})
+	s.auditOAuthByOwner(r, ownerKey, "connected", kind, map[string]any{"flow": "paste", "account_label": rec.AccountLabel, "fingerprint": rec.Fingerprint})
 	writeJSON(w, toOAuthView(rec))
 }
 
@@ -357,13 +357,17 @@ func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secr
 	// Derived from the account the payload names where it names one, so
 	// connecting ONE subscription twice does not open two meters.
 	rec.Fingerprint = secrets.SubscriptionFingerprint(kind, blob)
-	// A re-connect that names no account keeps the label the record
-	// already carried: rotating a token is not renaming the account, and
-	// silently blanking the name would put the operator back to reading
-	// fingerprints out of the logs.
+	// The name follows the fingerprint. A re-connect that names no account
+	// keeps the previous label ONLY when it provably re-connects the same
+	// subscription (codex: same account id; claude_code: the same blob).
+	// Any other re-connect may be an account SWAP — the same owner key
+	// re-pointed at somebody else's forfait — and inheriting the old name
+	// there would answer "whose subscription paid?" with the wrong person.
+	// Absent beats wrong: the operator names it (`account_label`) or the
+	// listing shows no name.
 	rec.AccountLabel = strings.TrimSpace(accountLabel)
 	if rec.AccountLabel == "" {
-		if prev, err := s.oauthStore.Get(ctx, ownerKey, kind); err == nil {
+		if prev, err := s.oauthStore.Get(ctx, ownerKey, kind); err == nil && prev.Fingerprint == rec.Fingerprint {
 			rec.AccountLabel = prev.AccountLabel
 		}
 	}
@@ -435,18 +439,24 @@ func (s *Server) renameOAuthForOwner(w http.ResponseWriter, r *http.Request, own
 		httpError(w, http.StatusBadRequest, "account_label required (send \"\" to clear it)")
 		return
 	}
-	rec, err := s.oauthStore.Get(r.Context(), ownerKey, kind)
-	if err != nil {
-		httpError(w, http.StatusNotFound, "no %s connection", kind)
-		return
-	}
-	rec.AccountLabel = strings.TrimSpace(*req.AccountLabel)
-	rec.UpdatedAt = time.Now().UTC()
-	if err := s.oauthStore.Upsert(r.Context(), rec); err != nil {
+	label := strings.TrimSpace(*req.AccountLabel)
+	// Store-level metadata write, not Get → Upsert: the latter would carry
+	// the sealed payload this handler read back over whatever a concurrent
+	// refresh committed in between.
+	if err := s.oauthStore.SetAccountLabel(r.Context(), ownerKey, kind, label); err != nil {
+		if errors.Is(err, secrets.ErrOAuthNotFound) {
+			httpError(w, http.StatusNotFound, "no %s connection", kind)
+			return
+		}
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
 	}
-	s.auditOAuthByOwner(r, ownerKey, "renamed", kind, map[string]any{"account_label": rec.AccountLabel})
+	rec, err := s.oauthStore.Get(r.Context(), ownerKey, kind)
+	if err != nil {
+		httpError(w, http.StatusInternalServerError, "%s", err.Error())
+		return
+	}
+	s.auditOAuthByOwner(r, ownerKey, "renamed", kind, map[string]any{"account_label": label, "fingerprint": rec.Fingerprint})
 	writeJSON(w, toOAuthView(rec))
 }
 

--- a/pkg/server/oauth_routes_test.go
+++ b/pkg/server/oauth_routes_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -208,10 +209,13 @@ func TestOAuthConnections_SealsAndNeverEchoesTheCredential(t *testing.T) {
 // and the fingerprint is exposed beside it because it is the join key
 // the logs actually print.
 func TestOAuthAccountLabel(t *testing.T) {
-	_, hs, signer, store := oauthTestServer(t)
+	srv, hs, signer, store := oauthTestServer(t)
 	jo := oauthJWT(t, signer, "jo")
 	blob := func(tok string) string {
 		return `{"claudeAiOauth":{"accessToken":"` + tok + `","refreshToken":"rt","expiresAt":4102444800000}}`
+	}
+	codexBlob := func(tok, account string) string {
+		return `{"tokens":{"access_token":"` + tok + `","refresh_token":"rt","account_id":"` + account + `"},"auth_mode":"chatgpt"}`
 	}
 	view := func(body string) map[string]any {
 		t.Helper()
@@ -240,27 +244,73 @@ func TestOAuthAccountLabel(t *testing.T) {
 		}
 	})
 
-	t.Run("rotating the token keeps the account name", func(t *testing.T) {
-		// A re-connect with no label is a token rotation, not a rename:
-		// blanking the name here would put the operator back to reading
-		// fingerprints out of the logs.
-		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", jo, blob("sk-ant-oat01-B"))
+	t.Run("an unnamed re-connect of the same credential keeps the name", func(t *testing.T) {
+		// Same blob → same fingerprint → provably the same subscription:
+		// re-pasting a token is not renaming the account.
+		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", jo, blob("sk-ant-oat01-A"))
 		if code != http.StatusOK {
 			t.Fatalf("re-upload = %d body=%s", code, body)
 		}
 		if v := view(body); v["account_label"] != "jothedev" {
-			t.Fatalf("account_label = %v after rotation, want it preserved", v["account_label"])
+			t.Fatalf("account_label = %v after re-pasting the same blob, want it preserved", v["account_label"])
+		}
+	})
+
+	t.Run("an unnamed re-connect with a different fingerprint drops the name rather than inherit it", func(t *testing.T) {
+		// A claude_code blob carries no account id, so a different blob may
+		// be a rotation OR another person's forfait on the same owner key —
+		// the swap measured live on 2026-09-03. Inheriting the old name
+		// would answer "whose subscription paid?" with the wrong person;
+		// an absent name is a visible gap the operator can fill.
+		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", jo, blob("sk-ant-oat01-B"))
+		if code != http.StatusOK {
+			t.Fatalf("re-upload = %d body=%s", code, body)
+		}
+		if v := view(body); v["account_label"] != nil {
+			t.Fatalf("account_label = %v after a re-connect with a new fingerprint, want it dropped", v["account_label"])
 		}
 		rec, err := store.Get(t.Context(), "jo", secrets.OAuthKindClaudeCode)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if rec.AccountLabel != "jothedev" {
-			t.Fatalf("store label = %q", rec.AccountLabel)
+		if rec.AccountLabel != "" {
+			t.Fatalf("store label = %q, want empty", rec.AccountLabel)
 		}
 	})
 
-	t.Run("rename backfills a record connected before labels existed", func(t *testing.T) {
+	t.Run("codex: the name follows the account id across token rotations", func(t *testing.T) {
+		// Codex fingerprints derive from tokens.account_id, so a fresh
+		// auth.json of the SAME ChatGPT account keeps its name, and one
+		// from a different account provably is not it.
+		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/codex/credentials?account_label=jo%40openai", jo, codexBlob("tok-1", "acc-1"))
+		if code != http.StatusOK {
+			t.Fatalf("connect codex = %d body=%s", code, body)
+		}
+		code, body = oauthCall(t, hs, http.MethodPost, "/api/me/oauth/codex/credentials", jo, codexBlob("tok-2", "acc-1"))
+		if code != http.StatusOK {
+			t.Fatalf("rotate codex = %d body=%s", code, body)
+		}
+		if v := view(body); v["account_label"] != "jo@openai" {
+			t.Fatalf("account_label = %v after rotating tokens of the same account, want it preserved", v["account_label"])
+		}
+		code, body = oauthCall(t, hs, http.MethodPost, "/api/me/oauth/codex/credentials", jo, codexBlob("tok-3", "acc-2"))
+		if code != http.StatusOK {
+			t.Fatalf("swap codex = %d body=%s", code, body)
+		}
+		if v := view(body); v["account_label"] != nil {
+			t.Fatalf("account_label = %v after connecting a different account, want it dropped", v["account_label"])
+		}
+	})
+
+	t.Run("rename backfills a record connected before labels existed, without rewriting it", func(t *testing.T) {
+		// The rename must be a metadata write at the store, never a
+		// Get → Upsert of the whole record: that would carry the sealed
+		// payload this handler read back over whatever a concurrent refresh
+		// committed in between — a refresh token the provider may already
+		// have rotated out, which no later sweep can heal.
+		spy := &oauthUpsertSpy{OAuthStore: store}
+		srv.oauthStore = spy
+		t.Cleanup(func() { srv.oauthStore = store })
 		code, body := oauthCall(t, hs, http.MethodPatch, "/api/me/oauth/claude_code", jo, `{"account_label":"jo perso"}`)
 		if code != http.StatusOK {
 			t.Fatalf("rename = %d body=%s", code, body)
@@ -268,14 +318,28 @@ func TestOAuthAccountLabel(t *testing.T) {
 		if v := view(body); v["account_label"] != "jo perso" {
 			t.Fatalf("account_label = %v", v["account_label"])
 		}
-		// Metadata only: the sealed credential and its fingerprint are
-		// untouched, so a rename can never rotate or break a live key.
+		if spy.upserts != 0 {
+			t.Fatalf("rename issued %d Upsert(s) — it must not rewrite the sealed record", spy.upserts)
+		}
 		rec, err := store.Get(t.Context(), "jo", secrets.OAuthKindClaudeCode)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(rec.SealedPayload) == 0 || rec.Fingerprint == "" {
-			t.Fatal("rename must not disturb the credential itself")
+		if rec.AccountLabel != "jo perso" || len(rec.SealedPayload) == 0 || rec.Fingerprint == "" {
+			t.Fatalf("after rename: label=%q payload=%d bytes fp=%q", rec.AccountLabel, len(rec.SealedPayload), rec.Fingerprint)
+		}
+	})
+
+	t.Run("rename with an empty label clears it", func(t *testing.T) {
+		code, body := oauthCall(t, hs, http.MethodPatch, "/api/me/oauth/claude_code", jo, `{"account_label":""}`)
+		if code != http.StatusOK {
+			t.Fatalf("clear = %d body=%s", code, body)
+		}
+		if v := view(body); v["account_label"] != nil {
+			t.Fatalf("account_label = %v after clearing, want absent", v["account_label"])
+		}
+		if rec, _ := store.Get(t.Context(), "jo", secrets.OAuthKindClaudeCode); rec.AccountLabel != "" {
+			t.Fatalf("store label = %q after clearing", rec.AccountLabel)
 		}
 	})
 
@@ -285,4 +349,54 @@ func TestOAuthAccountLabel(t *testing.T) {
 			t.Fatalf("rename with no account_label = %d, want 400 (an omitted field must not clear the label)", code)
 		}
 	})
+
+	t.Run("rename of a kind that is not connected is 404", func(t *testing.T) {
+		nobody := oauthJWT(t, signer, "nobody")
+		code, _ := oauthCall(t, hs, http.MethodPatch, "/api/me/oauth/claude_code", nobody, `{"account_label":"x"}`)
+		if code != http.StatusNotFound {
+			t.Fatalf("rename with no connection = %d, want 404", code)
+		}
+	})
+
+	t.Run("team scope: a team admin names the forfait, a viewer cannot", func(t *testing.T) {
+		seedTeam(t, srv, "t1", "acme")
+		ctx := context.Background()
+		adm := seedTeamMember(t, srv, ctx, "adm", identity.RoleAdmin)
+		vie := seedTeamMember(t, srv, ctx, "vie", identity.RoleViewer)
+		admTok, _, err := signer.IssueAccess(adm)
+		if err != nil {
+			t.Fatal(err)
+		}
+		vieTok, _, err := signer.IssueAccess(vie)
+		if err != nil {
+			t.Fatal(err)
+		}
+		code, body := oauthCall(t, hs, http.MethodPost, "/api/teams/t1/oauth/claude_code/credentials?account_label=team%20forfait", admTok, blob("sk-ant-oat01-T"))
+		if code != http.StatusOK {
+			t.Fatalf("team connect = %d body=%s", code, body)
+		}
+		if code, _ := oauthCall(t, hs, http.MethodPatch, "/api/teams/t1/oauth/claude_code", vieTok, `{"account_label":"mine now"}`); code != http.StatusForbidden {
+			t.Fatalf("viewer rename = %d, want 403", code)
+		}
+		code, body = oauthCall(t, hs, http.MethodPatch, "/api/teams/t1/oauth/claude_code", admTok, `{"account_label":"SocialGouv Revi"}`)
+		if code != http.StatusOK {
+			t.Fatalf("admin rename = %d body=%s", code, body)
+		}
+		code, body = oauthCall(t, hs, http.MethodGet, "/api/teams/t1/oauth/connections", vieTok, "")
+		if code != http.StatusOK || !strings.Contains(body, `"account_label":"SocialGouv Revi"`) || !strings.Contains(body, `"fingerprint":"`) {
+			t.Fatalf("team listing = %d body=%s, want the new name beside the fingerprint", code, body)
+		}
+	})
+}
+
+// oauthUpsertSpy counts whole-record writes, so a test can prove a code path
+// that promises "metadata only" never rewrites the sealed payload.
+type oauthUpsertSpy struct {
+	secrets.OAuthStore
+	upserts int
+}
+
+func (s *oauthUpsertSpy) Upsert(ctx context.Context, rec secrets.OAuthRecord) error {
+	s.upserts++
+	return s.OAuthStore.Upsert(ctx, rec)
 }

--- a/pkg/server/oauth_routes_test.go
+++ b/pkg/server/oauth_routes_test.go
@@ -200,3 +200,89 @@ func TestOAuthConnections_SealsAndNeverEchoesTheCredential(t *testing.T) {
 		}
 	})
 }
+
+// Nothing on an OAuth record says WHOSE account it is: the payload is
+// sealed, and the runtime logs print only a fingerprint — so answering
+// "whose subscription served that run?" meant grepping server logs and
+// correlating hex by hand (measured, 2026-09-03). The label closes that,
+// and the fingerprint is exposed beside it because it is the join key
+// the logs actually print.
+func TestOAuthAccountLabel(t *testing.T) {
+	_, hs, signer, store := oauthTestServer(t)
+	jo := oauthJWT(t, signer, "jo")
+	blob := func(tok string) string {
+		return `{"claudeAiOauth":{"accessToken":"` + tok + `","refreshToken":"rt","expiresAt":4102444800000}}`
+	}
+	view := func(body string) map[string]any {
+		t.Helper()
+		var v map[string]any
+		if err := json.Unmarshal([]byte(body), &v); err != nil {
+			t.Fatalf("decode %q: %v", body, err)
+		}
+		return v
+	}
+
+	t.Run("connecting names the account, and the view exposes the join key", func(t *testing.T) {
+		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials?account_label=jothedev", jo, blob("sk-ant-oat01-A"))
+		if code != http.StatusOK {
+			t.Fatalf("upload = %d body=%s", code, body)
+		}
+		v := view(body)
+		if v["account_label"] != "jothedev" {
+			t.Fatalf("account_label = %v, want jothedev", v["account_label"])
+		}
+		fp, _ := v["fingerprint"].(string)
+		if fp == "" {
+			t.Fatal("fingerprint must be exposed — it is what the runtime logs print when picking a credential")
+		}
+		if strings.Contains(body, "sk-ant-oat01-A") {
+			t.Fatal("the credential itself must never come back")
+		}
+	})
+
+	t.Run("rotating the token keeps the account name", func(t *testing.T) {
+		// A re-connect with no label is a token rotation, not a rename:
+		// blanking the name here would put the operator back to reading
+		// fingerprints out of the logs.
+		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", jo, blob("sk-ant-oat01-B"))
+		if code != http.StatusOK {
+			t.Fatalf("re-upload = %d body=%s", code, body)
+		}
+		if v := view(body); v["account_label"] != "jothedev" {
+			t.Fatalf("account_label = %v after rotation, want it preserved", v["account_label"])
+		}
+		rec, err := store.Get(t.Context(), "jo", secrets.OAuthKindClaudeCode)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rec.AccountLabel != "jothedev" {
+			t.Fatalf("store label = %q", rec.AccountLabel)
+		}
+	})
+
+	t.Run("rename backfills a record connected before labels existed", func(t *testing.T) {
+		code, body := oauthCall(t, hs, http.MethodPatch, "/api/me/oauth/claude_code", jo, `{"account_label":"jo perso"}`)
+		if code != http.StatusOK {
+			t.Fatalf("rename = %d body=%s", code, body)
+		}
+		if v := view(body); v["account_label"] != "jo perso" {
+			t.Fatalf("account_label = %v", v["account_label"])
+		}
+		// Metadata only: the sealed credential and its fingerprint are
+		// untouched, so a rename can never rotate or break a live key.
+		rec, err := store.Get(t.Context(), "jo", secrets.OAuthKindClaudeCode)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rec.SealedPayload) == 0 || rec.Fingerprint == "" {
+			t.Fatal("rename must not disturb the credential itself")
+		}
+	})
+
+	t.Run("rename refuses an absent field rather than blanking the name", func(t *testing.T) {
+		code, _ := oauthCall(t, hs, http.MethodPatch, "/api/me/oauth/claude_code", jo, `{}`)
+		if code != http.StatusBadRequest {
+			t.Fatalf("rename with no account_label = %d, want 400 (an omitted field must not clear the label)", code)
+		}
+	})
+}

--- a/pkg/server/oauth_team_routes.go
+++ b/pkg/server/oauth_team_routes.go
@@ -24,6 +24,7 @@ func (s *Server) registerOAuthTeamRoutes() {
 	s.mux.Handle("POST /api/teams/{id}/oauth/{kind}/authorize/complete", s.requireAuth(http.HandlerFunc(s.handleTeamCompleteOAuth)))
 	s.mux.Handle("POST /api/teams/{id}/oauth/{kind}/credentials", s.requireAuth(http.HandlerFunc(s.handleTeamUploadOAuth)))
 	s.mux.Handle("POST /api/teams/{id}/oauth/{kind}/refresh", s.requireAuth(http.HandlerFunc(s.handleTeamRefreshOAuth)))
+	s.mux.Handle("PATCH /api/teams/{id}/oauth/{kind}", s.requireAuth(http.HandlerFunc(s.handleTeamRenameOAuth)))
 	s.mux.Handle("DELETE /api/teams/{id}/oauth/{kind}", s.requireAuth(http.HandlerFunc(s.handleTeamDeleteOAuth)))
 }
 
@@ -76,6 +77,18 @@ func (s *Server) handleTeamRefreshOAuth(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	s.refreshOAuthForOwner(w, r, secrets.OrgOwnerKey(teamID), secrets.OAuthKind(r.PathValue("kind")))
+}
+
+// handleTeamRenameOAuth names the account behind a team's forfait, so the
+// instance itself answers "whose subscription is this?".
+func (s *Server) handleTeamRenameOAuth(w http.ResponseWriter, r *http.Request) {
+	id, _ := auth.FromContext(r.Context())
+	teamID := r.PathValue("id")
+	if !s.canManageTeam(r.Context(), id, teamID) {
+		httpError(w, http.StatusForbidden, "forbidden")
+		return
+	}
+	s.renameOAuthForOwner(w, r, secrets.OrgOwnerKey(teamID), secrets.OAuthKind(r.PathValue("kind")))
 }
 
 func (s *Server) handleTeamDeleteOAuth(w http.ResponseWriter, r *http.Request) {

--- a/studio/src/api/byok.ts
+++ b/studio/src/api/byok.ts
@@ -35,6 +35,10 @@ export interface OAuthConnection {
   last_refreshed_at?: string;
   /** False when the stored payload has no refresh token — only a manual reconnect renews it. */
   refreshable?: boolean;
+  /** The account behind the credential, in the operator's words — absent until someone names it. */
+  account_label?: string;
+  /** Audit identity of the subscription: the string the publisher logs when it picks this credential. */
+  fingerprint?: string;
   created_at: string;
   updated_at: string;
 }
@@ -153,26 +157,52 @@ export async function startOAuthAuthorize(
 
 // completeOAuthAuthorize finishes the browser flow with the code the user
 // pasted from Anthropic's callback page (`code#state` accepted whole).
+// accountLabelQuery names the account on a connect call. An unnamed
+// connect keeps the previous name only when the fingerprint is unchanged
+// (server rule), so naming here is what keeps a rotation from un-naming.
+function accountLabelQuery(accountLabel?: string): string {
+  const label = accountLabel?.trim();
+  return label ? `?account_label=${encodeURIComponent(label)}` : "";
+}
+
 export async function completeOAuthAuthorize(
   kind: OAuthKind,
   input: { code: string; state?: string },
   scope: OAuthScope = { mine: true },
+  accountLabel?: string,
 ): Promise<OAuthConnection> {
-  return send(`${oauthBase(scope)}/${encodeURIComponent(kind)}/authorize/complete`, {
-    method: "POST",
-    body: JSON.stringify(input),
-  });
+  return send(
+    `${oauthBase(scope)}/${encodeURIComponent(kind)}/authorize/complete${accountLabelQuery(accountLabel)}`,
+    {
+      method: "POST",
+      body: JSON.stringify(input),
+    },
+  );
 }
 
 export async function uploadOAuthCredentials(
   kind: OAuthKind,
   blob: string,
   scope: OAuthScope = { mine: true },
+  accountLabel?: string,
 ): Promise<OAuthConnection> {
-  return send(`${oauthBase(scope)}/${encodeURIComponent(kind)}/credentials`, {
+  return send(`${oauthBase(scope)}/${encodeURIComponent(kind)}/credentials${accountLabelQuery(accountLabel)}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: blob,
+  });
+}
+
+// renameOAuth names (or, with "", un-names) the account behind a
+// connected credential. Metadata only: the sealed credential is untouched.
+export async function renameOAuth(
+  kind: OAuthKind,
+  accountLabel: string,
+  scope: OAuthScope = { mine: true },
+): Promise<OAuthConnection> {
+  return send(`${oauthBase(scope)}/${encodeURIComponent(kind)}`, {
+    method: "PATCH",
+    body: JSON.stringify({ account_label: accountLabel.trim() }),
   });
 }
 

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -187,7 +187,8 @@ export interface paths {
         delete: operations["deleteAdminLlmOauthByKind"];
         options?: never;
         head?: never;
-        patch?: never;
+        /** PATCH /api/admin/llm/oauth/{kind} */
+        patch: operations["patchAdminLlmOauthByKind"];
         trace?: never;
     };
     "/api/admin/llm/oauth/{kind}/authorize/complete": {
@@ -1177,7 +1178,8 @@ export interface paths {
         delete: operations["deleteMeOauthByKind"];
         options?: never;
         head?: never;
-        patch?: never;
+        /** PATCH /api/me/oauth/{kind} */
+        patch: operations["patchMeOauthByKind"];
         trace?: never;
     };
     "/api/me/oauth/{kind}/authorize/complete": {
@@ -6433,6 +6435,26 @@ export interface operations {
             };
         };
     };
+    patchAdminLlmOauthByKind: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                kind: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     postAdminLlmOauthByKindAuthorizeComplete: {
         parameters: {
             query?: never;
@@ -7728,6 +7750,26 @@ export interface operations {
         };
     };
     deleteMeOauthByKind: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                kind: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    patchMeOauthByKind: {
         parameters: {
             query?: never;
             header?: never;

--- a/studio/src/views/account/OAuthConnections.tsx
+++ b/studio/src/views/account/OAuthConnections.tsx
@@ -18,6 +18,7 @@ import {
   deleteOAuth,
   listOAuthConnections,
   refreshOAuth,
+  renameOAuth,
   startOAuthAuthorize,
   uploadOAuthCredentials,
 } from "@/api/byok";
@@ -87,6 +88,13 @@ export default function OAuthConnections({
   // Raw-paste fallback editor.
   const [pasteKind, setPasteKind] = useState<OAuthKind | null>(null);
   const [draft, setDraft] = useState("");
+  // Account name typed alongside either connect form. Naming at connect
+  // time is what keeps a rotation from un-naming: an unnamed re-connect
+  // keeps the previous name only when the fingerprint is unchanged.
+  const [label, setLabel] = useState("");
+  // Inline rename of an already-connected kind.
+  const [renaming, setRenaming] = useState<OAuthKind | null>(null);
+  const [renameDraft, setRenameDraft] = useState("");
   const { confirm, dialog } = useConfirm();
   const addToast = useUIStore((s) => s.addToast);
 
@@ -123,9 +131,10 @@ export default function OAuthConnections({
     setBusy(true);
     setMutErr(null);
     try {
-      await completeOAuthAuthorize(connecting, { code: code.trim() }, scope);
+      await completeOAuthAuthorize(connecting, { code: code.trim() }, scope, label);
       setConnecting(null);
       setCode("");
+      setLabel("");
       onConnected();
     } catch (e) {
       setMutErr(errorMessage(e));
@@ -141,10 +150,30 @@ export default function OAuthConnections({
     setBusy(true);
     setMutErr(null);
     try {
-      await uploadOAuthCredentials(pasteKind, draft, scope);
+      await uploadOAuthCredentials(pasteKind, draft, scope, label);
       setPasteKind(null);
       setDraft("");
+      setLabel("");
       onConnected();
+    } catch (e) {
+      setMutErr(errorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Rename: metadata only — the sealed credential is untouched. An empty
+  // name clears it, which the form says out loud.
+  const submitRename = async (ev: React.FormEvent) => {
+    ev.preventDefault();
+    if (!renaming) return;
+    setBusy(true);
+    setMutErr(null);
+    try {
+      await renameOAuth(renaming, renameDraft, scope);
+      setRenaming(null);
+      setRenameDraft("");
+      reload();
     } catch (e) {
       setMutErr(errorMessage(e));
     } finally {
@@ -253,6 +282,27 @@ export default function OAuthConnections({
                   </div>
                 </div>
 
+                {/* Whose subscription this is: the name beside the fingerprint the
+                    publisher logs when it picks the credential, so a log line and
+                    this card join by eye. */}
+                {conn && (
+                  <div className="text-xs text-fg-muted flex flex-wrap items-center gap-x-3 gap-y-1">
+                    <span>
+                      Account:{" "}
+                      {conn.account_label ? (
+                        <span className="text-fg font-medium">{conn.account_label}</span>
+                      ) : (
+                        <span className="italic">unnamed — name it so the instance says whose subscription this is</span>
+                      )}
+                    </span>
+                    {conn.fingerprint && (
+                      <span title={conn.fingerprint}>
+                        fp <code className="font-mono">{conn.fingerprint.slice(0, 11)}</code>
+                      </span>
+                    )}
+                  </div>
+                )}
+
                 {/* Browser flow code-paste panel (claude_code) */}
                 {browser && connecting === kind ? (
                   <form onSubmit={finishConnect} className="space-y-2">
@@ -268,6 +318,12 @@ export default function OAuthConnections({
                       onChange={(e) => setCode(e.target.value)}
                       required
                     />
+                    <Input
+                      aria-label="Account name (optional)"
+                      placeholder="Account name (optional) — whose subscription is this? e.g. jothedev"
+                      value={label}
+                      onChange={(e) => setLabel(e.target.value)}
+                    />
                     <div className="flex gap-2">
                       <Button variant="primary" type="submit" loading={busy}>
                         {busy ? "Connecting…" : "Finish connection"}
@@ -278,6 +334,7 @@ export default function OAuthConnections({
                         onClick={() => {
                           setConnecting(null);
                           setCode("");
+                          setLabel("");
                         }}
                       >
                         Cancel
@@ -298,6 +355,12 @@ export default function OAuthConnections({
                       onChange={(e) => setDraft(e.target.value)}
                       required
                     />
+                    <Input
+                      aria-label="Account name (optional)"
+                      placeholder="Account name (optional) — whose subscription is this? e.g. jothedev"
+                      value={label}
+                      onChange={(e) => setLabel(e.target.value)}
+                    />
                     <div className="flex gap-2">
                       <Button variant="primary" type="submit" loading={busy}>
                         {busy ? "Sealing…" : "Save"}
@@ -308,6 +371,34 @@ export default function OAuthConnections({
                         onClick={() => {
                           setPasteKind(null);
                           setDraft("");
+                          setLabel("");
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </form>
+                ) : renaming === kind ? (
+                  <form onSubmit={submitRename} className="space-y-2">
+                    <label htmlFor={`oauth-label-${kind}`} className="block text-xs text-fg-muted">
+                      Name the account behind this credential. Leave it empty to clear the name.
+                    </label>
+                    <Input
+                      id={`oauth-label-${kind}`}
+                      placeholder="e.g. jothedev"
+                      value={renameDraft}
+                      onChange={(e) => setRenameDraft(e.target.value)}
+                    />
+                    <div className="flex gap-2">
+                      <Button variant="primary" type="submit" loading={busy}>
+                        {busy ? "Saving…" : renameDraft.trim() ? "Save name" : "Clear name"}
+                      </Button>
+                      <Button
+                        variant="secondary"
+                        type="button"
+                        onClick={() => {
+                          setRenaming(null);
+                          setRenameDraft("");
                         }}
                       >
                         Cancel
@@ -344,6 +435,16 @@ export default function OAuthConnections({
                     )}
                     {conn && (
                       <>
+                        <Button
+                          variant="secondary"
+                          onClick={() => {
+                            setRenaming(kind);
+                            setRenameDraft(conn.account_label ?? "");
+                          }}
+                          disabled={busy}
+                        >
+                          {conn.account_label ? "Rename account" : "Name account"}
+                        </Button>
                         {!notRefreshable && (
                           <Button variant="secondary" onClick={() => refresh(kind)} disabled={busy}>
                             Refresh tokens


### PR DESCRIPTION
**The gap.** Nothing on an OAuth record says WHOSE account it is. The payload is sealed, the API view exposed neither a label nor the fingerprint, and the only place a credential is ever identified is a server log line the publisher writes when it picks one:

```
cloudpublisher: oauth-forfait(org) used run=… kind=claude_code fp=700acc7b00f
```

So answering *"whose subscription paid for that run?"* meant grepping server logs and correlating hex by hand — measured today while swapping a team forfait, with three different fingerprints across three owners in one log window.

**What ships.**
- `AccountLabel` on `secrets.OAuthRecord`, set with `?account_label=` on **both** connect paths (paste + browser flow).
- **Rename** via `PATCH` on the three scopes (`/me`, team, platform). This is the load-bearing half: every record connected before this carries no label, so without a rename the feature would be inert on exactly the credentials an operator needs to identify *today*. Rename is a store-level metadata write (`OAuthStore.SetAccountLabel`, a `$set` of two keys) — never a read-modify-write of the record, so it cannot carry a stale sealed payload back over a refresh committed meanwhile, and the route test proves a rename issues zero `Upsert`.
- **The name follows the fingerprint.** An unnamed re-connect keeps the previous label only when it provably re-connects the same subscription (codex: same `account_id`; claude_code: the same blob). Any other unnamed re-connect drops the label rather than inherit it: the same owner key re-pointed at somebody else's forfait — the swap this PR was born from — would otherwise answer the billing question with the wrong person. Absent beats wrong; name it at connect time or `PATCH` it after.
- The view also exposes the **fingerprint** — non-secret by construction (a hash, never the token) and the exact string the runtime prints, so a log line and the API join without a human in the middle.
- **Studio**: every connection card (personal, team, platform — one component) shows the account name beside the fingerprint, with a Name/Rename action; both connect forms take the name up front.
- CLI: `iterion remote admin llm oauth set|connect --account-label …`, plus a `name` action for the platform tier that refuses to run without the flag (sending `""` clears, so a forgotten flag must not).
- Connect and rename audits carry `account_label` + `fingerprint`.

Tests cover: labelling at connect; the fingerprint exposed while the credential never is; the label kept on a same-fingerprint re-connect and dropped on a new one (claude_code) / following the account id across token rotations and dropped on an account swap (codex); rename without a record rewrite; clearing; `PATCH` refusing an absent field; 404 on an unconnected kind; team admin vs viewer; the platform PATCH under the super-admin gate. A Mongo-shaped test (`pkg/secrets/oauth_mongo_test.go`, in the mongo-conformance suite) asserts the clear on the `$set` wire production uses — the in-memory store's full-map replace could never show that bug. Doc: a *"Name the account behind every credential"* section in `docs/cloud-llm-credentials.md` with the log line it exists to make joinable, and the PATCH route in `docs/cloud-rest-api.md`.

Asked for by @devthejo: *"prend l'habitude de nommer les clés, qu'on puisse savoir à quel compte elle correspond en regardant dans l'instance cloud prod iterion directement"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
