### PR TITLE
chore(vendor): bump claw-code-go — fix the model-registry race that reddens CI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,7 +121,7 @@ require (
 
 require (
 	github.com/SherClockHolmes/webpush-go v1.4.0
-	github.com/SocialGouv/claw-code-go v0.1.1-0.20260804154152-abd6de0284cf
+	github.com/SocialGouv/claw-code-go v0.1.1-0.20260903153114-1b47afb7a32a
 	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/aws/aws-sdk-go-v2 v1.43.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.37

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAw
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/SherClockHolmes/webpush-go v1.4.0 h1:ocnzNKWN23T9nvHi6IfyrQjkIc0oJWv1B1pULsf9i3s=
 github.com/SherClockHolmes/webpush-go v1.4.0/go.mod h1:XSq8pKX11vNV8MJEMwjrlTkxhAj1zKfxmyhdV7Pd6UA=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260804154152-abd6de0284cf h1:8iG4XDMo+gt7pcCrtJ55QZx6rQ64UzZtdmsD8NIf94E=
-github.com/SocialGouv/claw-code-go v0.1.1-0.20260804154152-abd6de0284cf/go.mod h1:c0yGvkNqLl+A4KNRBBEg1iP3dhnnM9z0XX6jCFlA15k=
+github.com/SocialGouv/claw-code-go v0.1.1-0.20260903153114-1b47afb7a32a h1:QEdbYdmL6qtb4x7Q31ULJXgMC01SgiWXBe863tkFlAM=
+github.com/SocialGouv/claw-code-go v0.1.1-0.20260903153114-1b47afb7a32a/go.mod h1:c0yGvkNqLl+A4KNRBBEg1iP3dhnnM9z0XX6jCFlA15k=
 github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
 github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/aws/aws-sdk-go-v2 v1.43.6 h1:RrmFcqCBxkJuf7g1axVo5krB4jM/AO8r5e5oujrgdoQ=

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/apikit/model_registry.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/apikit/model_registry.go
@@ -52,6 +52,14 @@ type ModelEntry struct {
 // read lock while RegisterModel takes a write lock. This avoids the race
 // condition that existed with the previous sync.Once approach where
 // RegisterModel wrote to maps without holding any lock after initialization.
+//
+// The lock guards the MAPS, not the entries they point at — and LookupModel
+// returns the *ModelEntry itself, which callers dereference after the read
+// lock is released (preflight.ModelTokenLimitForModel is one). So a
+// published entry is immutable: to change one, copy it, mutate the copy and
+// swap the map pointer under the write lock. Mutating reg.models[k] in place
+// races every reader still holding that pointer, and the mutex cannot see
+// the conflict.
 type ModelRegistry struct {
 	mu      sync.RWMutex
 	init    bool

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/apikit/model_registry_live.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/apikit/model_registry_live.go
@@ -153,11 +153,21 @@ func mergeLiveIntoRegistry(reg *ModelRegistry, cache *LiveCache) {
 		if ok {
 			// Update non-zero fields only — never zero out values that were
 			// curated in the embed registry but are missing from live data.
-			if e.ContextWindow > 0 {
-				existing.ContextWindow = e.ContextWindow
-			}
-			if e.MaxOutput > 0 {
-				existing.MaxOutput = e.MaxOutput
+			//
+			// Copy-then-swap, never mutate in place: a published entry is
+			// immutable because LookupModel hands its pointer to callers
+			// that dereference it once the read lock is gone (see the
+			// ModelRegistry doc comment). The write lock held here does not
+			// exclude those readers.
+			if e.ContextWindow > 0 || e.MaxOutput > 0 {
+				updated := *existing
+				if e.ContextWindow > 0 {
+					updated.ContextWindow = e.ContextWindow
+				}
+				if e.MaxOutput > 0 {
+					updated.MaxOutput = e.MaxOutput
+				}
+				reg.models[canonical] = &updated
 			}
 			// Add new aliases without removing existing ones.
 			for _, alias := range e.Aliases {

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/config/loader.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/config/loader.go
@@ -19,6 +19,9 @@ type Settings struct {
 	BlockedTools   []string `json:"blockedTools,omitempty"`
 	MaxTokens      int      `json:"maxTokens,omitempty"`
 	Theme          string   `json:"theme,omitempty"`
+	// AllowImmediateStructuredOutput disables the work-before-output guard.
+	// A pointer preserves explicit false values across layered settings.
+	AllowImmediateStructuredOutput *bool `json:"allowImmediateStructuredOutput,omitempty"`
 
 	// EnabledPlugins maps plugin IDs to their enabled state.
 	EnabledPlugins map[string]bool `json:"enabledPlugins,omitempty"`
@@ -140,6 +143,9 @@ func merge(dst, src *Settings) {
 	if src.Theme != "" {
 		dst.Theme = src.Theme
 	}
+	if src.AllowImmediateStructuredOutput != nil {
+		dst.AllowImmediateStructuredOutput = src.AllowImmediateStructuredOutput
+	}
 	if src.EnabledPlugins != nil {
 		dst.EnabledPlugins = src.EnabledPlugins
 	}
@@ -250,6 +256,9 @@ func WriteProject(s *Settings) error {
 	}
 	if s.Theme != "" {
 		existing["theme"] = s.Theme
+	}
+	if s.AllowImmediateStructuredOutput != nil {
+		existing["allowImmediateStructuredOutput"] = *s.AllowImmediateStructuredOutput
 	}
 
 	path := filepath.Join(".claude", "settings.json")

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/config/validate.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/config/validate.go
@@ -105,6 +105,7 @@ var topLevelFields = []fieldSpec{
 	{"theme", "string"},
 	{"allowedTools", "array"},
 	{"blockedTools", "array"},
+	{"allowImmediateStructuredOutput", "boolean"},
 }
 
 var hooksFields = []fieldSpec{

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/runtime/config.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/runtime/config.go
@@ -104,6 +104,9 @@ type Config struct {
 	// OutputFormat controls output mode: "text" (default), "json", "stream-json".
 	// Maps to Rust's --output-format flag.
 	OutputFormat string
+	// AllowImmediateStructuredOutput disables the default requirement that a
+	// work-capable session complete work before returning structured output.
+	AllowImmediateStructuredOutput bool
 
 	// Prompt holds the resolved system-prompt section toggles.
 	// nil means "all defaults" (every section on) — callers constructing a
@@ -368,6 +371,9 @@ func LoadConfig() *Config {
 	}
 	if s.Theme != "" {
 		cfg.Theme = s.Theme
+	}
+	if s.AllowImmediateStructuredOutput != nil {
+		cfg.AllowImmediateStructuredOutput = *s.AllowImmediateStructuredOutput
 	}
 
 	// Plugin configuration

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/runtime/conversation.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/runtime/conversation.go
@@ -91,6 +91,9 @@ type ConversationLoop struct {
 	// pending_tool_use_count is tracked per-turn; we track cumulative for the
 	// session to feed ToolCallCount() on the LoopAdapter).
 	toolCallCount atomic.Int64
+	// workToolCompleted records whether this session has completed at least one
+	// successful work-capable tool call.
+	workToolCompleted atomic.Bool
 
 	// Build-time info passed through to LoopAdapter. Set by the caller.
 	BuildVersion string
@@ -1014,7 +1017,7 @@ func (loop *ConversationLoop) ExecuteToolQuiet(ctx context.Context, name string,
 	case "notebook_edit":
 		result, err = tools.ExecuteNotebookEdit(input)
 	case "structured_output":
-		result, err = tools.ExecuteStructuredOutput(input)
+		result, err = loop.executeStructuredOutput(input)
 	case "enter_plan_mode":
 		result, err = tools.ExecuteEnterPlanMode(&loop.PlanModeActive, loop.planModeStateDir())
 		loop.queuePlanModeReminder(true, err)
@@ -1118,6 +1121,7 @@ func (loop *ConversationLoop) ExecuteToolQuiet(ctx context.Context, name string,
 					}
 				}
 				text := mcpResultText(mcpResult)
+				loop.recordWorkToolCompletion(name, mcpResult.IsError)
 				return api.ContentBlock{
 					Type:    "tool_result",
 					Content: []api.ContentBlock{{Type: "text", Text: text}},
@@ -1129,6 +1133,7 @@ func (loop *ConversationLoop) ExecuteToolQuiet(ctx context.Context, name string,
 	}
 
 	isError := err != nil
+	loop.recordWorkToolCompletion(name, isError)
 	text := result
 	if err != nil {
 		text = fmt.Sprintf("Error: %v", err)
@@ -1407,7 +1412,7 @@ func (loop *ConversationLoop) ExecuteTool(ctx context.Context, name string, inpu
 	case "notebook_edit":
 		result, err = tools.ExecuteNotebookEdit(input)
 	case "structured_output":
-		result, err = tools.ExecuteStructuredOutput(input)
+		result, err = loop.executeStructuredOutput(input)
 	case "enter_plan_mode":
 		result, err = tools.ExecuteEnterPlanMode(&loop.PlanModeActive, loop.planModeStateDir())
 		loop.queuePlanModeReminder(true, err)
@@ -1528,6 +1533,7 @@ func (loop *ConversationLoop) ExecuteTool(ctx context.Context, name string, inpu
 								"is_error":  ptIsError,
 							})
 						}
+						loop.recordWorkToolCompletion(name, ptIsError)
 						return api.ContentBlock{
 							Type:    "tool_result",
 							Content: []api.ContentBlock{{Type: "text", Text: ptText}},
@@ -1564,6 +1570,7 @@ func (loop *ConversationLoop) ExecuteTool(ctx context.Context, name string, inpu
 				}
 				mcpText = hooks.MergeHookFeedback(postResult.Messages, mcpText,
 					postResult.IsDenied() || postResult.IsFailed() || postResult.IsCancelled())
+				loop.recordWorkToolCompletion(name, mcpIsError)
 				return api.ContentBlock{
 					Type:    "tool_result",
 					Content: []api.ContentBlock{{Type: "text", Text: mcpText}},
@@ -1611,6 +1618,7 @@ func (loop *ConversationLoop) ExecuteTool(ctx context.Context, name string, inpu
 		}
 	}
 	loop.fireLifecyclePostToolUse(ctx, name, input, text, postErr)
+	loop.recordWorkToolCompletion(name, isError)
 
 	return api.ContentBlock{
 		Type: "tool_result",

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/runtime/structured_output.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/runtime/structured_output.go
@@ -1,0 +1,51 @@
+package runtime
+
+import (
+	"errors"
+
+	"github.com/SocialGouv/claw-code-go/internal/tools"
+)
+
+const structuredOutputRequiresWorkMessage = "structured_output rejected: no work has been performed yet in this session. Do the mission with the available tools first; call structured_output only when the mission is complete — it ends the session."
+
+var nonWorkTools = map[string]struct{}{
+	"structured_output": {},
+	"ask_user":          {},
+	"AskUserQuestion":   {},
+	"sleep":             {},
+	"config":            {},
+	"todo_write":        {},
+	"enter_plan_mode":   {},
+	"exit_plan_mode":    {},
+}
+
+func isWorkTool(name string) bool {
+	_, excluded := nonWorkTools[name]
+	return !excluded
+}
+
+func (loop *ConversationLoop) hasWorkCapableTools() bool {
+	for _, tool := range loop.allTools() {
+		if isWorkTool(tool.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+func (loop *ConversationLoop) recordWorkToolCompletion(name string, isError bool) {
+	if !isError && isWorkTool(name) {
+		loop.workToolCompleted.Store(true)
+	}
+}
+
+// executeStructuredOutput prevents schema-obedient models from treating the
+// final-output schema as a first-turn form to fill. Tool-less sessions remain
+// valid for pure structured-output probes, and callers can explicitly opt out.
+func (loop *ConversationLoop) executeStructuredOutput(input map[string]any) (string, error) {
+	allowImmediate := loop.Config != nil && loop.Config.AllowImmediateStructuredOutput
+	if !allowImmediate && loop.hasWorkCapableTools() && !loop.workToolCompleted.Load() {
+		return "", errors.New(structuredOutputRequiresWorkMessage)
+	}
+	return tools.ExecuteStructuredOutput(input)
+}

--- a/vendor/github.com/SocialGouv/claw-code-go/internal/tools/structured_output.go
+++ b/vendor/github.com/SocialGouv/claw-code-go/internal/tools/structured_output.go
@@ -9,7 +9,8 @@ import (
 func StructuredOutputTool() api.Tool {
 	return api.Tool{
 		Name: "structured_output",
-		Description: "Return structured data as the final output. " +
+		Description: "Return structured data as the final output. Calling this tool ENDS the session. " +
+			"Call it ONLY after the mission is fully complete; NEVER use it to describe planned or remaining work. " +
 			"Pass your structured object under the \"payload\" key " +
 			"(e.g. {\"payload\": {\"key\": \"value\"}}); the input is " +
 			"echoed back as-is.",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -69,7 +69,7 @@ github.com/AzureAD/microsoft-authentication-library-for-go/apps/public
 # github.com/SherClockHolmes/webpush-go v1.4.0
 ## explicit; go 1.13
 github.com/SherClockHolmes/webpush-go
-# github.com/SocialGouv/claw-code-go v0.1.1-0.20260804154152-abd6de0284cf
+# github.com/SocialGouv/claw-code-go v0.1.1-0.20260903153114-1b47afb7a32a
 ## explicit; go 1.25.0
 github.com/SocialGouv/claw-code-go/hooks
 github.com/SocialGouv/claw-code-go/internal/api


### PR DESCRIPTION
Brings in two claw commits. Only the first is a fix in the usual sense; the second changes behaviour for every claw agent node, so it is called out rather than buried in a vendor diff.

## `1b47afb` — the model-registry data race

`race` went red on #645, a PR touching none of this code:

```
WRITE apikit.mergeLiveIntoRegistry()            model_registry_live.go:157
READ  apikit.ModelTokenLimitForModel()          preflight.go:27
      runtime.DefaultCompactionConfigForModel() compact.go:54
      model.maybeCompact()                      generation_toolexec.go:327
```

`ModelRegistry` is documented thread-safe and is — for the **maps**. `models` is `map[string]*ModelEntry`, and `LookupModel` returns that pointer while releasing the read lock on return; callers then dereference it with no lock held. The live-refresh goroutine took the write lock, correctly, and mutated those structs in place. The two locks guarded different things, so the mutex never saw the conflict.

It fires on the ordinary path: `DefaultModelRegistry()` schedules `MaybeRefreshLive`, whose goroutine merges the disk cache and then the fetched one while any concurrent branch resolves a model's context window.

Fixed upstream by copy-then-swap ([claw-code-go#2](https://github.com/SocialGouv/claw-code-go/issues/2)), with the invariant written on the registry's doc comment so the next writer meets it. The regression test reproduces at **the same line the CI trace named** and is red without the fix:

```
WARNING: DATA RACE
Write at 0x00c0001f602c by goroutine 9:
  apikit.mergeLiveIntoRegistry()  model_registry_live.go:157
```

The race is intermittent, so **a green `race` job on this PR proves nothing** — the upstream red-first test is the evidence.

## `2587bbb` — terminal structured output now requires prior work

A schema-obedient model could submit the terminal schema on its first turn and finish without doing the requested work (measured upstream: 35 tokens in 5.6s). claw now rejects a terminal call until a work tool has succeeded, auto-relaxes when no work-capable tool is exposed, and ships a settings/CLI escape hatch.

**Every claw agent node inherits this.** It resembles the `structured output invalid` failures seen on recent fixer runs, but I did not establish that link — resemblance only.

## Verification

- `task test` — 134 packages, exit 0
- `pkg/backend/model` under `-race`, three consecutive runs — green
- `go mod verify` — all modules verified (bumped with `scripts/bump-claw.sh`, never a hand-written pseudo-version)