### PR TITLE
fix(oauth): pre-fill the account name on reconnect, cap the label, publish the team OAuth routes in the spec

### DIFF
--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -243,7 +243,9 @@ the `fingerprint`, which is the SAME string the logs print, so a log line
 and the API join without a human in the middle. The studio shows both on
 every connection card (Settings → Subscriptions, a team's Model providers
 tab, Admin → LLM credentials) with a *Name account* action, and both
-connect forms take the name up front.
+connect forms take the name up front — pre-filled with the current one,
+so a routine rotation through the studio keeps its name unless you
+change it.
 
 **The name follows the fingerprint.** A re-connect that names no account
 keeps the previous label only when it provably re-connects the same

--- a/docs/cloud-rest-api.md
+++ b/docs/cloud-rest-api.md
@@ -255,7 +255,7 @@ Full reference: [webhooks.md](webhooks.md).
 | `POST` | `/api/me/oauth/{kind}/authorize/complete` | member | Finish that handshake |
 | `POST` | `/api/me/oauth/{kind}/credentials` | member | Upload pasted `credentials.json` / `auth.json` |
 | `POST` | `/api/me/oauth/{kind}/refresh` | member | Refresh stored access token against the IdP |
-| `PATCH` | `/api/me/oauth/{kind}` | member | Name the account behind the credential (`{"account_label": "…"}`, `""` clears) — metadata only, the sealed credential is untouched |
+| `PATCH` | `/api/me/oauth/{kind}` | member | Name the account behind the credential (`{"account_label": "…"}`, `""` clears; ≤ 120 characters) — metadata only, the sealed credential is untouched |
 | `DELETE` | `/api/me/oauth/{kind}` | member | Disconnect |
 
 `authorize/complete` and `credentials` take an optional `?account_label=`

--- a/openapi.json
+++ b/openapi.json
@@ -8987,6 +8987,202 @@
         ]
       }
     },
+    "/api/teams/{id}/oauth/connections": {
+      "get": {
+        "operationId": "getTeamsByIdOauthConnections",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "GET /api/teams/{id}/oauth/connections",
+        "tags": [
+          "teams"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/api/teams/{id}/oauth/{kind}": {
+      "delete": {
+        "operationId": "deleteTeamsByIdOauthByKind",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "DELETE /api/teams/{id}/oauth/{kind}",
+        "tags": [
+          "teams"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "in": "path",
+          "name": "kind",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "patch": {
+        "operationId": "patchTeamsByIdOauthByKind",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "PATCH /api/teams/{id}/oauth/{kind}",
+        "tags": [
+          "teams"
+        ]
+      }
+    },
+    "/api/teams/{id}/oauth/{kind}/authorize/complete": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "in": "path",
+          "name": "kind",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "postTeamsByIdOauthByKindAuthorizeComplete",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "POST /api/teams/{id}/oauth/{kind}/authorize/complete",
+        "tags": [
+          "teams"
+        ]
+      }
+    },
+    "/api/teams/{id}/oauth/{kind}/authorize/start": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "in": "path",
+          "name": "kind",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "postTeamsByIdOauthByKindAuthorizeStart",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "POST /api/teams/{id}/oauth/{kind}/authorize/start",
+        "tags": [
+          "teams"
+        ]
+      }
+    },
+    "/api/teams/{id}/oauth/{kind}/credentials": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "in": "path",
+          "name": "kind",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "postTeamsByIdOauthByKindCredentials",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "POST /api/teams/{id}/oauth/{kind}/credentials",
+        "tags": [
+          "teams"
+        ]
+      }
+    },
+    "/api/teams/{id}/oauth/{kind}/refresh": {
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "in": "path",
+          "name": "kind",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "post": {
+        "operationId": "postTeamsByIdOauthByKindRefresh",
+        "responses": {
+          "default": {
+            "description": "Response"
+          }
+        },
+        "summary": "POST /api/teams/{id}/oauth/{kind}/refresh",
+        "tags": [
+          "teams"
+        ]
+      }
+    },
     "/api/teams/{id}/plugin-sources": {
       "get": {
         "operationId": "getTeamsByIdPluginSources",

--- a/pkg/server/oauth_routes.go
+++ b/pkg/server/oauth_routes.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/credpool"
@@ -241,6 +242,13 @@ func (s *Server) completeOAuthForOwner(w http.ResponseWriter, r *http.Request, o
 	if pasteState == "" {
 		pasteState = frag
 	}
+	// Validate the name BEFORE consuming the pending authorization: a
+	// refused label must not cost the operator a restarted connect.
+	accountLabel, err := normalizeOAuthAccountLabel(r.URL.Query().Get("account_label"))
+	if err != nil {
+		httpError(w, http.StatusBadRequest, "%s", err.Error())
+		return
+	}
 	pending, err := s.oauthPending.Take(r.Context(), ownerKey, kind)
 	if err != nil {
 		httpError(w, http.StatusBadRequest, "no pending authorization (expired? restart the connect)")
@@ -268,7 +276,7 @@ func (s *Server) completeOAuthForOwner(w http.ResponseWriter, r *http.Request, o
 		httpError(w, http.StatusInternalServerError, "build credentials: %v", err)
 		return
 	}
-	rec, err := s.sealOAuthRecord(r.Context(), ownerKey, kind, blob, r.URL.Query().Get("account_label"))
+	rec, err := s.sealOAuthRecord(r.Context(), ownerKey, kind, blob, accountLabel)
 	if err != nil {
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
@@ -294,7 +302,12 @@ func (s *Server) uploadOAuthForOwner(w http.ResponseWriter, r *http.Request, own
 		httpError(w, http.StatusBadRequest, "empty body — paste the credentials.json / auth.json content")
 		return
 	}
-	rec, err := s.sealOAuthRecord(r.Context(), ownerKey, kind, body, r.URL.Query().Get("account_label"))
+	accountLabel, err := normalizeOAuthAccountLabel(r.URL.Query().Get("account_label"))
+	if err != nil {
+		httpError(w, http.StatusBadRequest, "%s", err.Error())
+		return
+	}
+	rec, err := s.sealOAuthRecord(r.Context(), ownerKey, kind, body, accountLabel)
 	if err != nil {
 		httpError(w, http.StatusBadRequest, "%s", err.Error())
 		return
@@ -304,9 +317,26 @@ func (s *Server) uploadOAuthForOwner(w http.ResponseWriter, r *http.Request, own
 	writeJSON(w, toOAuthView(rec))
 }
 
+// maxOAuthAccountLabel bounds the account name. It is a display string —
+// a handle a human recalls ("jothedev", "SocialGouv Revi") — and the
+// connect paths take it as a query parameter, where nothing but the
+// server's header limit would otherwise bound it.
+const maxOAuthAccountLabel = 120
+
+// normalizeOAuthAccountLabel is the one place a label is accepted from a
+// caller (both connect paths and the rename), so the bound holds everywhere.
+func normalizeOAuthAccountLabel(raw string) (string, error) {
+	label := strings.TrimSpace(raw)
+	if n := utf8.RuneCountInString(label); n > maxOAuthAccountLabel {
+		return "", fmt.Errorf("account_label is %d characters, max %d", n, maxOAuthAccountLabel)
+	}
+	return label, nil
+}
+
 // sealOAuthRecord validates a credentials blob, extracts expiry/scope
 // metadata, seals it bound to (ownerKey, kind), and upserts the record.
-// Shared by the browser flow and the paste path.
+// Shared by the browser flow and the paste path; accountLabel arrives
+// already normalized by the handler.
 func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secrets.OAuthKind, blob []byte, accountLabel string) (secrets.OAuthRecord, error) {
 	now := time.Now().UTC()
 	rec := secrets.OAuthRecord{
@@ -365,7 +395,7 @@ func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secr
 	// there would answer "whose subscription paid?" with the wrong person.
 	// Absent beats wrong: the operator names it (`account_label`) or the
 	// listing shows no name.
-	rec.AccountLabel = strings.TrimSpace(accountLabel)
+	rec.AccountLabel = accountLabel
 	if rec.AccountLabel == "" {
 		if prev, err := s.oauthStore.Get(ctx, ownerKey, kind); err == nil && prev.Fingerprint == rec.Fingerprint {
 			rec.AccountLabel = prev.AccountLabel
@@ -439,7 +469,11 @@ func (s *Server) renameOAuthForOwner(w http.ResponseWriter, r *http.Request, own
 		httpError(w, http.StatusBadRequest, "account_label required (send \"\" to clear it)")
 		return
 	}
-	label := strings.TrimSpace(*req.AccountLabel)
+	label, err := normalizeOAuthAccountLabel(*req.AccountLabel)
+	if err != nil {
+		httpError(w, http.StatusBadRequest, "%s", err.Error())
+		return
+	}
 	// Store-level metadata write, not Get → Upsert: the latter would carry
 	// the sealed payload this handler read back over whatever a concurrent
 	// refresh committed in between.

--- a/pkg/server/oauth_routes_test.go
+++ b/pkg/server/oauth_routes_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -340,6 +341,22 @@ func TestOAuthAccountLabel(t *testing.T) {
 		}
 		if rec, _ := store.Get(t.Context(), "jo", secrets.OAuthKindClaudeCode); rec.AccountLabel != "" {
 			t.Fatalf("store label = %q after clearing", rec.AccountLabel)
+		}
+	})
+
+	t.Run("a label past the cap is refused on every path that accepts one", func(t *testing.T) {
+		long := strings.Repeat("é", maxOAuthAccountLabel+1)
+		if code, body := oauthCall(t, hs, http.MethodPatch, "/api/me/oauth/claude_code", jo, `{"account_label":"`+long+`"}`); code != http.StatusBadRequest {
+			t.Fatalf("rename with a %d-rune label = %d body=%s, want 400", maxOAuthAccountLabel+1, code, body)
+		}
+		if code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials?account_label="+url.QueryEscape(long), jo, blob("sk-ant-oat01-B")); code != http.StatusBadRequest {
+			t.Fatalf("connect with a %d-rune label = %d body=%s, want 400", maxOAuthAccountLabel+1, code, body)
+		}
+		// Exactly at the cap is fine — the bound is on length, not on
+		// bytes, so a French name is not cut shorter than an ASCII one.
+		atCap := strings.Repeat("é", maxOAuthAccountLabel)
+		if code, body := oauthCall(t, hs, http.MethodPatch, "/api/me/oauth/claude_code", jo, `{"account_label":"`+atCap+`"}`); code != http.StatusOK {
+			t.Fatalf("rename with a %d-rune label = %d body=%s, want 200", maxOAuthAccountLabel, code, body)
 		}
 	})
 

--- a/pkg/server/openapi_spec.go
+++ b/pkg/server/openapi_spec.go
@@ -3,6 +3,8 @@ package server
 import (
 	"fmt"
 	"os"
+	"strings"
+	"time"
 
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/botsource"
 	"github.com/SocialGouv/iterion/pkg/credpool"
 	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/identity"
 	"github.com/SocialGouv/iterion/pkg/orgusage"
 	"github.com/SocialGouv/iterion/pkg/pat"
 	"github.com/SocialGouv/iterion/pkg/platformcfg"
@@ -43,6 +46,25 @@ func BuildOpenAPISpec() (map[string]any, error) {
 		return nil, fmt.Errorf("temp run store: %w", err)
 	}
 
+	// A REAL auth service over a memory identity store, not a bare
+	// &auth.Service{}: the team-scoped families (team OAuth-forfait, …)
+	// register only when authStore() resolves, and a nil store silently
+	// left every one of them out of the published spec and the generated
+	// client. Nothing here is ever invoked; the store only has to exist.
+	signer, err := auth.NewJWTSigner(strings.Repeat("0", 43), 15*time.Minute)
+	if err != nil {
+		return nil, fmt.Errorf("spec signer: %w", err)
+	}
+	authSvc, err := auth.NewService(auth.Config{
+		Store:      identity.NewMemoryStore(),
+		Sessions:   auth.NewMemorySessionStore(),
+		Signer:     signer,
+		RefreshTTL: time.Hour,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("spec auth service: %w", err)
+	}
+
 	cfg := Config{
 		StoreDir:                tmp,
 		WorkDir:                 tmp,
@@ -51,7 +73,7 @@ func BuildOpenAPISpec() (map[string]any, error) {
 
 		// Gate fields — non-nil stubs so every register*() fires. None are
 		// invoked here (registration only calls s.mux.Handle).
-		AuthService:        &auth.Service{},
+		AuthService:        authSvc,
 		Sealer:             specNoopSealer{},
 		ApiKeys:            secrets.NewMemoryApiKeyStore(),
 		GenericSecrets:     secrets.NewMemoryGenericSecretStore(),

--- a/studio/src/api/schema.ts
+++ b/studio/src/api/schema.ts
@@ -3952,6 +3952,126 @@ export interface paths {
         patch: operations["patchTeamsByIdMembersByUserId"];
         trace?: never;
     };
+    "/api/teams/{id}/oauth/connections": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        /** GET /api/teams/{id}/oauth/connections */
+        get: operations["getTeamsByIdOauthConnections"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/teams/{id}/oauth/{kind}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                kind: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** DELETE /api/teams/{id}/oauth/{kind} */
+        delete: operations["deleteTeamsByIdOauthByKind"];
+        options?: never;
+        head?: never;
+        /** PATCH /api/teams/{id}/oauth/{kind} */
+        patch: operations["patchTeamsByIdOauthByKind"];
+        trace?: never;
+    };
+    "/api/teams/{id}/oauth/{kind}/authorize/complete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                kind: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** POST /api/teams/{id}/oauth/{kind}/authorize/complete */
+        post: operations["postTeamsByIdOauthByKindAuthorizeComplete"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/teams/{id}/oauth/{kind}/authorize/start": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                kind: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** POST /api/teams/{id}/oauth/{kind}/authorize/start */
+        post: operations["postTeamsByIdOauthByKindAuthorizeStart"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/teams/{id}/oauth/{kind}/credentials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                kind: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** POST /api/teams/{id}/oauth/{kind}/credentials */
+        post: operations["postTeamsByIdOauthByKindCredentials"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/teams/{id}/oauth/{kind}/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                kind: string;
+            };
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** POST /api/teams/{id}/oauth/{kind}/refresh */
+        post: operations["postTeamsByIdOauthByKindRefresh"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/teams/{id}/plugin-sources": {
         parameters: {
             query?: never;
@@ -11509,6 +11629,152 @@ export interface operations {
             path: {
                 id: string;
                 user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getTeamsByIdOauthConnections: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    deleteTeamsByIdOauthByKind: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                kind: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    patchTeamsByIdOauthByKind: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                kind: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    postTeamsByIdOauthByKindAuthorizeComplete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                kind: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    postTeamsByIdOauthByKindAuthorizeStart: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                kind: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    postTeamsByIdOauthByKindCredentials: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                kind: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    postTeamsByIdOauthByKindRefresh: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                kind: string;
             };
             cookie?: never;
         };

--- a/studio/src/views/account/OAuthConnections.tsx
+++ b/studio/src/views/account/OAuthConnections.tsx
@@ -109,6 +109,15 @@ export default function OAuthConnections({
     reload();
   };
 
+  // A connect form opens with the name the connection already carries: a
+  // claude_code re-connect always mints a new fingerprint (the blob is the
+  // identity), so without this every routine rotation through the studio
+  // would un-name the credential. The operator clears or changes it on a
+  // real account swap.
+  const openWithCurrentName = (kind: OAuthKind) => {
+    setLabel(conns.find((c) => c.kind === kind)?.account_label ?? "");
+  };
+
   // --- browser OAuth (claude_code) ---
   const startConnect = async (kind: OAuthKind) => {
     setBusy(true);
@@ -118,6 +127,7 @@ export default function OAuthConnections({
       window.open(authorize_url, "_blank", "noopener,noreferrer");
       setConnecting(kind);
       setCode("");
+      openWithCurrentName(kind);
     } catch (e) {
       setMutErr(errorMessage(e));
     } finally {
@@ -417,6 +427,7 @@ export default function OAuthConnections({
                         onClick={() => {
                           setPasteKind(kind);
                           setDraft("");
+                          openWithCurrentName(kind);
                         }}
                       >
                         {conn ? "Update credentials" : "Connect"}
@@ -428,6 +439,7 @@ export default function OAuthConnections({
                         onClick={() => {
                           setPasteKind(kind);
                           setDraft("");
+                          openWithCurrentName(kind);
                         }}
                       >
                         Advanced: paste file


### PR DESCRIPTION
Follow-ups from the second review round of #653 (its open questions, taken as they were asked).

- **Pre-fill the name on reconnect.** A claude_code re-connect always mints a new fingerprint (the blob is the identity), so under "the name follows the fingerprint" every routine rotation through the studio would have un-named the credential unless the operator retyped it. Both connect forms now open pre-filled with the connection's current name; clearing or changing it stays a deliberate act — which is exactly the account-swap case.
- **Label cap.** The label reached the connect paths as a query parameter bounded only by the server's header limit. One normalizer now sits on every path that accepts a label (both connect handlers — before the pending authorization is consumed, so a refused name never costs a restarted connect — and the rename): 120 characters, counted in runes so a French name is not cut shorter than an ASCII one. Test: over the cap → 400 on PATCH and on connect; exactly at the cap → 200.
- **Team OAuth routes published.** The whole `/api/teams/{id}/oauth/*` family was absent from `openapi.json` and the generated client: the spec generator built its Server on a bare `&auth.Service{}`, whose nil identity store kept `registerOAuthTeamRoutes()` from ever firing. It now carries a real service over a memory store, so the six team routes (including the PATCH `docs/cloud-rest-api.md` already promised) are published — `openapi.json` +196 / `schema.ts` +266, additions only.

Deliberately not folded in: the refresh paths' whole-record rewrite, which can still revert a concurrent rename — carded as #656.

🤖 Generated with [Claude Code](https://claude.com/claude-code)