### PR TITLE
test(dispatcher): bound the subbot-lock probe by the test budget, not 60s

### DIFF
--- a/pkg/dispatcher/engine_runner_subbot_test.go
+++ b/pkg/dispatcher/engine_runner_subbot_test.go
@@ -235,7 +235,21 @@ func TestEngineRunner_SubbotChildHoldsRunLock(t *testing.T) {
 	// 60s burned, nothing actionable in the log).
 	var dispatchErr error
 	dispatched := false
-	deadline := time.Now().Add(60 * time.Second)
+	// Bound the probe by the TEST's own budget rather than a wall clock of its
+	// own. Nothing here is timing-sensitive any more — the child blocks on the
+	// release file — so this deadline bounds ONE thing: how long the parent run
+	// takes to reach the subbot node. A fixed 60s does not cover that under
+	// -race on a runner already busy with the rest of the suite, which is how
+	// this test ejected an unrelated PR from the merge queue. Reserve a margin
+	// so the failure is this test's own diagnosis, not the package timeout's
+	// goroutine dump.
+	probeStart := time.Now()
+	deadline := probeStart.Add(5 * time.Minute)
+	if d, ok := t.Deadline(); ok {
+		if budgeted := d.Add(-30 * time.Second); budgeted.Before(deadline) {
+			deadline = budgeted
+		}
+	}
 	for time.Now().Before(deadline) && !held {
 		select {
 		case dispatchErr = <-done:
@@ -292,7 +306,16 @@ func TestEngineRunner_SubbotChildHoldsRunLock(t *testing.T) {
 		t.Fatalf("Dispatch returned before any child run appeared — the subbot node was never reached: %v", dispatchErr)
 	}
 	if childID == "" {
-		t.Fatal("never observed a child run — the subbot node did not spawn one")
+		// Name WHICH of the two it is: a parent still running never reached the
+		// node (too slow for the budget), a terminal one reached the end
+		// without spawning (a real defect). Reporting only the symptom is what
+		// made the previous timeout unactionable.
+		parentStatus := "unknown"
+		if p, perr := probe.LoadRun(context.Background(), runID); perr == nil {
+			parentStatus = string(p.Status)
+		}
+		t.Fatalf("never observed a child run — the subbot node did not spawn one (parent %s is %q after %s)",
+			runID, parentStatus, time.Since(probeStart).Truncate(time.Second))
 	}
 	if !held {
 		t.Fatal("never caught the child mid-pass — its lock was never observed held while it was blocked on the release file")


### PR DESCRIPTION
This test ejected #645 — a PR touching only `pkg/backend/model` — from the merge queue today. It is the third unrelated test to block that PR, and the only one with a fix in reach.

## What is left of the flake

The sync-point deflake already landed: the child blocks on `release-lock-probe`, so **no timing window races the probe**. One wall clock survived it, and it bounds exactly one thing — how long the **parent** run takes to reach the subbot node.

Sixty seconds does not cover that under `-race` on a runner already busy with the rest of the suite:

```
--- FAIL: TestEngineRunner_SubbotChildHoldsRunLock (60.02s)
    never observed a child run — the subbot node did not spawn one
```

The important part of that trace is what it does **not** say. `Dispatch` had not returned, so the goroutine watch added for precisely this case could not fire — the parent was still on its way to the node. The bound was the binding constraint, not a defect in the code under test.

## The change

- **Take the bound from `t.Deadline()`** — the budget `go test -timeout` already gives the test — capped at 5 minutes, reserving 30s so the failure is this test's own diagnosis rather than the package timeout's goroutine dump.
- **Make that diagnosis discriminate.** A parent still `running` never reached the node (slow runner); a terminal one reached the end without spawning (real defect). The message now names which, with the parent's status and the elapsed time. Reporting only "did not spawn one" is what made the previous timeout unactionable.

## Verification, and its limits

`gofmt`, `go vet`, and the test green **3/3 under `-race`** locally — in 1.5s, which is precisely why the old bound never bit here either.

**A green run cannot prove a contention-dependent timeout is gone.** The evidence that this addresses the right thing is the CI trace above: 60s expiring with the parent still in flight. What would falsify it is the same failure recurring with the new message reporting a *terminal* parent — that would mean a genuine spawn defect, not a slow runner.

## Note for whoever cleans up

`fix/dispatcher-subbot-lock-test-flake` (`b05488738`, based on v3.64.2) is still on origin and is **superseded** — its sync-point work is on `main`, with an improvement on top. It reads as dormant work and is not; deleting it would save the next reader the detour I took.