### PR TITLE
docs: bilan of the /billy run on #646 + the runbook gaps it surfaced (#650 #652 #662 #663)

### DIFF
--- a/docs/bot-runs/branch-improve-loop.md
+++ b/docs/bot-runs/branch-improve-loop.md
@@ -1,5 +1,80 @@
 # Billy — branch-improvement validation
 
+## 2026-09-03 — `/billy` on the watchdog PR: three deaths, the banked chain delivered by hand (run 01a06728)
+
+- Status: **partial.** The fixer's work landed (17 commits on
+  SocialGouv/iterion#646, the ADR-096 claim-lease + watchdog PR) but never
+  through his own delivery tail: the run died three times before
+  `push_back`, and the operator fast-forwarded the banked chain onto the PR
+  branch. The PR merged the same evening (`e194aebe0`, v3.99.0, deployed).
+- Versions: iterion cloud prod (runner v3.96.1 digest, server ~v3.97) · bot
+  `branch-improve-loop` 1.2.1 · branch base `fa9c8b1be`.
+- Method: the documented habit — Revi left 1 medium (`Ra74e4c`) + 2 low + 7
+  questions on #646; `/billy` as maintainer; `review_mode=mono`; bot budget
+  `max_duration 2h30m` / `max_cost_usd 75`. An Anthropic incident was in
+  progress during the first attempt.
+- Result:
+
+  | attempt | wall-clock | outcome |
+  |---|---|---|
+  | 1 — 12:05→14:37Z | 2h32 | `BUDGET_EXCEEDED: duration (9004.7s/9000s)` mid-`campaign` (iter 3/8), $34.47; **6 commits banked** on `iterion/run-01a06728…` |
+  | 2 — bare `remote runs resume` | 15 min | re-died at 9901.6 s = the 110 % exit-grace ceiling (the consumed duration axis rides the checkpoint) |
+  | 3 — resume with `source` inline (`max_duration: 6h`) + `force` | 1h47 | restarted the campaign FROM SCRATCH (the resume re-clones the branch head, the banked chain is not re-imported), **17 commits** banked, died `USAGE_LIMIT_BLOCKED` (Claude session limit, usage_window retry armed) |
+  | 4 — auto retry 20:09Z | — | cancelled by the operator: it would have died on iterion's own weekly cap (95 %, hard) |
+
+  Operator delivery 17:43Z: fast-forward of the banked chain (17 commits,
+  verbatim) + one test-only fix + merge of `origin/main` → PR head
+  `196b18966`; the re-review fired by itself 3 s later (`review_on_sync`)
+  and came back green (0 ≥high, 2 low + 7 questions → #660). A merge-queue
+  ejection (#658 merged ahead, same flaky test touched) forced a second
+  merge (`385d8677e`); that head's re-review then died on the **weekly**
+  usage cap (`seven_day window at 95% ≥ 95%`, reset 2026-09-08) and parked
+  the gate for five days — `/revi approve` failed on the GitHub App
+  integration (#662), the override status was posted by hand.
+- Value: **high on substance.** Beyond Revi's findings (all addressed —
+  `launchTicketNow` CAS anchored on the read state, the reaper gate
+  misspelling made loud, the CI mongo-gate guard scoped), the campaign found
+  defects a 20-round adversarial loop had missed: a false "claim lost" when
+  the owner's own release races an in-flight heartbeat (`Releasing()`
+  latch), `cmdClaimLost` cancelling the NEXT run holding the card (run id on
+  the message), a lost fence at launch that still launched (both twins), the
+  mongo terminal sink as check-then-act (now a CAS with re-evaluation),
+  `SetStateFrom(x→x)` disagreeing across twins, the reconciler's tokenless
+  write overwriting an operator's drag (`SetStateFromReason` CAS), "a
+  release is the last act of a disposition", `store.RunAbsent` shared across
+  the four run-pointer authorities, the FS renew blocking `Stop()` on the
+  actor.
+- Findings / misses: his new `TestAdapterRenewClaim_HonoursCancelMidCall`
+  failed deterministically (10/10, plain and `-race`: the detached renewal
+  wrote into `t.TempDir()` during cleanup) — **a banked chain is committed
+  in stride but not gate-verified** (`verify_run` only runs at the end of a
+  pass). He applied `Releasing()` on the local twin and missed the cloud
+  `processCard` (Revi's `Rf238b1`, #660). His delivery tail was never
+  exercised: he never pushed himself, so by design he would have stamped
+  nothing on a head the operator pushed.
+- Engine hardening (GitHub board): #652 — resume re-clones the branch head
+  and restarts the campaign, ignoring the banked chain (proposal: re-anchor
+  on `FinalBranch` when it fast-forwards from the clone base); the cloud
+  `POST /api/runs/{id}/resume` has no budget overrides (workaround: `source`
+  inline + `force`); the consumed duration axis rides the checkpoint; the
+  exit grace does not protect a node cancelled in flight. #650 — the
+  gate-paused notice says "Review paused … a new push restarts it sooner"
+  for a FIXER (`forge_gate_pause_notice.go` filters on `gate_context`,
+  which a gating fixer carries). #662 — `/revi approve` → `set commit
+  status: forge: insufficient scope`, webhook 502. #663 — the parked review
+  revived 2 s after `stopRunsForDeadPR` (redelivery race). Verified working:
+  the death bank (`pushBank`, richer-chain supersede), the usage-window
+  retry (`run_retry_scheduled`, reset parsed from the typed error),
+  `review_on_sync`, stop-on-close for the auto-heal lane run.
+- Lessons for next run: size the fixer's `max_duration` for this repo's
+  verify gate (2h30 with ~1h of plan phases is too tight) or slim the plan
+  phases when `consumes: review` carries few findings; push in stride on
+  the PR branch (the work branch IS the PR branch); never bare-resume a
+  duration death on cloud; a banked chain is deliverable by hand only after
+  the full validation; when the weekly cap parks the gate, the documented
+  override is broken until #662 lands — budget a manual status or the admin
+  bypass.
+
 ## 2026-08-30 — three launches, zero delivery: the duration cap and the weekly cap (runs 01a0517a, 01a051dd, 01a05216)
 
 - Status: **failed.** `/billy` on SocialGouv/iterion#579 (the CHANGELOG

--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -153,10 +153,20 @@ notice says so explicitly — a ceiling reopens when an admin raises it (or
 the month rolls), so the armed retries can otherwise exhaust themselves
 against a wall.
 
+The notice is posted for **every run that owes the gate a verdict** —
+which includes a fixer that gates the head it pushes — but its wording is
+the review's ("the verdict lands here … a new push restarts it sooner"), so
+a parked fixer reads as a parked review, and the advice is the one thing not
+to do while a fixer works. Known gap, tracked as SocialGouv/iterion#650: the
+notice should name the parked run's role.
+
 Symmetrically, a pull request that **closes or merges** ends every run bound
 to it and **disarms** their retries: an in-flight review would keep spending
 quota on a diff nobody will merge, and a parked one would wake hours later
-to comment on a dead PR. See [webhooks.md](webhooks.md).
+to comment on a dead PR. See [webhooks.md](webhooks.md). Known gap
+(SocialGouv/iterion#663): a redelivery already in flight at the close can
+re-claim the run seconds after it was stopped — check `iterion remote runs
+list` after a merge and cancel a reviver by hand.
 
 ## Disabling the gate per repo — first review only, re-review on demand
 
@@ -423,6 +433,13 @@ Three ways, in order of preference:
    through. The status carries "approved by @user: reason" and links to the
    comment as the audit trail. It does **not** launch a re-review. *(GitHub +
    Forgejo today; GitLab `/revi approve` on a note is a follow-on.)*
+   **Known gap (SocialGouv/iterion#662):** on a GitHub App integration the
+   command currently fails with `set commit status: forge: insufficient
+   scope` (the webhook answers 502) — until it lands, the admin can write the
+   same status by hand (`POST /repos/{owner}/{repo}/statuses/{sha}`, the
+   repo's `gate_context`, `state: success`, "approved by @user: reason" as
+   the description, the comment URL as `target_url`), which the armed
+   auto-merge then picks up like any other green.
 3. **Admin merge-queue bypass** — the last resort, always available to repo
    admins.
 

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -151,6 +151,16 @@ The resume command accepts the same recovery-relevant controls as launch:
 When raising a budget, choose a cap above the amount already consumed. Merely
 repeating the old cap causes the re-executed node to hit the same guard.
 
+**Cloud runs.** `POST /api/runs/{id}/resume` (and `iterion remote runs
+resume`) carries **no budget-override fields**: a run that died on a cap
+cannot be re-budgeted from the resume request. The consumed accounting rides
+the checkpoint, so a bare resume of a duration death restarts and dies again
+at the exit-grace ceiling. The working escape hatch is the source itself —
+resume with `{"source": "<the workflow text with a larger cap>", "force":
+true}`: the checkpoint restarts at the failed node with the new caps, the run
+record keeps showing the launch-time budget (a snapshot). A cloud twin of the
+CLI overrides is tracked as SocialGouv/iterion#652.
+
 ## Rewind: resume from an *earlier* node
 
 Resume always restarts at the checkpoint node. `iterion rewind` moves that

--- a/docs/revi-billy-loop.md
+++ b/docs/revi-billy-loop.md
@@ -72,13 +72,23 @@ The webhook tail resolves everything from the PR and the repo integration:
    (`/revi approve [reason]`, maintainer-gated).
 
    That third step is **not free** — it needs `review_on_sync` on the repo's
-   webhook config, which is **off by default** (a push is otherwise an
-   on-demand re-review, deliberately budget-frugal). It is the same switch the
-   merge gate needs, so a repo whose `revi/review` is a required check has it
-   on; a repo that only ever auto-reviews on open does not, and Billy's push
-   there ends the loop until someone comments `/revi`. Check it before
-   concluding the loop is broken:
+   webhook config. The orchestrator **derives it ON** whenever a bot of the
+   webhook gates merges (declares the `statuses` scope) and the gate is not
+   disabled, unless an operator pinned the value
+   ([pkg/forge/orchestrator.go](../pkg/forge/orchestrator.go),
+   `ReviewOnSyncPinned`); a repo that only ever auto-reviews on open has it
+   off, and Billy's push there ends the loop until someone comments `/revi`.
+   Check it before concluding the loop is broken:
    `iterion remote api GET /api/teams/<team-id>/webhooks` → `review_on_sync`.
+
+4. **While Billy runs, the PR looks untouched** — `revi/review` stays green
+   on the OLD head and no status says a fixer is at work: the only signals
+   are the run itself (`iterion remote runs list`, the run console) and,
+   when he parks on a quota, the platform's pause notice. That notice is
+   written for a review and currently mislabels a parked fixer ("Review
+   paused … a new push restarts it sooner" — a push is exactly what NOT to
+   do while he works; SocialGouv/iterion#650). Nothing is wrong: wait for
+   his push, or for the `pending` claim that follows it.
 
 ## Session discipline (the gotchas)
 
@@ -96,6 +106,30 @@ The webhook tail resolves everything from the PR and the repo integration:
   `usage cap: … window` is `failed_resumable` with the usage-window retry
   armed — it resumes at the provider reset by itself
   ([usage-caps.md](usage-caps.md)). Don't relaunch it by hand.
+- **A death is not a loss — the pod's commits are BANKED** on
+  `iterion/run-<run-id>` (`final_branch` / `final_commit` on the run doc;
+  the richer chain of successive attempts wins). But a **resume re-clones
+  the branch head and restarts the campaign from scratch**, redoing the
+  banked work (SocialGouv/iterion#652). If the retry cannot finish in the
+  budget left, deliver the banked chain by hand: fast-forward it onto the
+  PR branch AFTER the full validation (`task check`, `-race`, conformance —
+  a chain committed in stride is not gate-verified and can be red), say so
+  on the PR, and let `review_on_sync` re-review the head.
+- **Never bare-resume a duration death on cloud.** The consumed duration
+  axis rides the checkpoint, so `iterion remote runs resume` restarts and
+  dies at the 110 % exit-grace ceiling (15 min of pod for nothing). The
+  cloud resume endpoint has no budget-override fields; raise the cap by
+  resuming with the bot source inline: `POST /api/runs/<id>/resume` with
+  `{"source": <main.bot with a larger max_duration>, "force": true}` — the
+  checkpoint restarts inside `campaign`, the plan phases are not re-paid.
+- **When the WEEKLY cap parks the gate**, the reset can be days out and
+  the review's `pending` claim blocks the PR that long. The documented
+  maintainer override (`/revi approve`, [merge-gate.md](merge-gate.md))
+  currently fails on a GitHub App integration (`set commit status: forge:
+  insufficient scope`, SocialGouv/iterion#662): the fallbacks are the
+  admin's own status write on the head (same context, "approved by
+  @user: reason" in the description, the comment as `target_url`) or the
+  admin merge-queue bypass.
 - **"Don't hand-fix" assumes Billy can run.** When the *weekly* cap is
   hard-blocking, the reset can be days out and the habit has no path: fix the
   findings yourself, say so on the PR against their finding ids, and write the
@@ -114,3 +148,7 @@ Every `/billy` run on this repo gets a dated bilan in
 found here is a defect to fix in stride — in the bot
 (`bots/branch-improve-loop/`) or the engine — that is the point of running the
 loop on ourselves.
+
+The 2026-09-03 run on the watchdog PR (#646) is the reference for the
+banked-chain delivery and the weekly-cap wall:
+[bot-runs/branch-improve-loop.md](bot-runs/branch-improve-loop.md).


### PR DESCRIPTION
Docs only — the dogfood bilan of `/billy` on #646 (run `01a06728`: three deaths, the banked chain delivered by hand, the weekly-cap wall) and the runbook updates that carry its lessons where the next agent will look:

- `docs/bot-runs/branch-improve-loop.md` — the 2026-09-03 section (attempts table, value, misses, engine hardening, lessons).
- `docs/revi-billy-loop.md` — `review_on_sync` is **derived ON** when a bot gates merges (was documented as "off by default"); the fixer-in-flight phase; a death is not a loss (banked chain) but a resume redoes the work (#652); never bare-resume a duration death on cloud; when the weekly cap parks the gate, `/revi approve` is broken (#662) — fallbacks.
- `docs/merge-gate.md` — known gaps marked in place: the pause notice mislabels a parked fixer (#650), the close-time redelivery race (#663), `/revi approve` insufficient scope (#662).
- `docs/resume.md` — the cloud resume has no budget overrides; `source` inline + `force` is the escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
