### PR TITLE
test(dispatcher): drain ceiling one budget under the sequential floor

### DIFF
--- a/pkg/dispatcher/reaper_test.go
+++ b/pkg/dispatcher/reaper_test.go
@@ -878,13 +878,19 @@ func TestShutdown_DrainIsBoundedByOneCardsBudgets(t *testing.T) {
 	// sequential floor — thin enough that a loaded machine read its own
 	// noise as a regression (measured: 123ms against a 120ms ceiling under
 	// a full-package run, green in isolation). Eight cards widen the gap
-	// to 8 units versus 2 at no extra cost, and the ceiling now sits
-	// between them with room on both sides (observed parallel ~100-115ms,
+	// to 8 units versus 2 at no extra cost (observed parallel ~100-115ms,
 	// sequential floor 320ms).
+	//
+	// The ceiling is set ONE budget under the sequential floor, not lower:
+	// a genuinely sequential drain still always trips it (≥320ms), while
+	// everything below is CI scheduling noise this test must not read as a
+	// regression — a 5-budget ceiling (200ms) ejected two green merge-queue
+	// groups in 12h on 202.5ms and 222ms measurements, ~2× the observed
+	// parallel time but nowhere near sequential.
 	const (
 		drainCards  = 8
 		cardBudget  = 40 * time.Millisecond
-		drainCeling = 5 * cardBudget
+		drainCeling = (drainCards - 1) * cardBudget
 	)
 	c.shutdownRevertBudget, c.shutdownReleaseBudget = cardBudget, cardBudget
 	c.cfg.Store(&Config{Agent: AgentConfig{RunningState: native.StateInProgress}})


### PR DESCRIPTION
The 200ms ceiling ejected two fully green PRs from the merge queue in 12h (202.5ms and 222ms measurements — CI scheduling noise, ~2× observed parallel time, nowhere near the 320ms sequential floor). The property under test is separation: 280ms (7 budgets) still always trips on a sequential drain while tolerating a loaded runner.

Ran 5× plain + 3× -race locally, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)