### PR TITLE
fix(runner): a re-execution restores the chain its earlier attempt banked (#652)

### DIFF
--- a/docs/persisted-formats.md
+++ b/docs/persisted-formats.md
@@ -203,7 +203,7 @@ emitter when a consumer needs an exact payload contract.
 
 | Family | Persisted event types |
 |---|---|
-| Run lifecycle/control | `run_started`, `run_paused`, `human_input_requested`, `human_answers_recorded`, `interaction_answered`, `run_resumed`, `run_auto_resumed`, `run_retry_scheduled`, `run_workspace_reset`, `run_steered`, `run_health`, `run_finished`, `run_failed`, `run_cancelled`, `run_interrupted` |
+| Run lifecycle/control | `run_started`, `run_paused`, `human_input_requested`, `human_answers_recorded`, `interaction_answered`, `run_resumed`, `run_auto_resumed`, `run_retry_scheduled`, `run_workspace_reset`, `run_workspace_bank_restored`, `run_steered`, `run_health`, `run_finished`, `run_failed`, `run_cancelled`, `run_interrupted` |
 | Graph/budget/artifacts | `branch_started`, `branch_finished`, `branch_abandoned`, `node_started`, `node_recovery`, `node_verified_action`, `node_finished`, `edge_selected`, `join_ready`, `budget_warning`, `budget_exceeded`, `budget_exit_grace`, `artifact_written`, `plan_written` |
 | LLM, delegation, and tools | `llm_request`, `llm_prompt`, `llm_retry`, `llm_step_finished`, `assistant_text`, `llm_compacted`, `tool_started`, `tool_called`, `tool_error`, `delegate_started`, `delegate_finished`, `delegate_error`, `delegate_retry`, `model_fallback`, `model_drift` |
 | Review gate | `review_turn`, `review_verdict`, `review_merged` |

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -101,6 +101,20 @@ keyed on the checkpoint's existence rather than on the delivery being shaped
 as a resume, since a redelivery of a run still marked `running` re-clones the
 same way.
 
+What the fresh clone does NOT lose is committed work. A re-execution restores
+what the run's earlier attempt left on the forge — the storage branch its
+death bank recorded (`final_branch` / `final_commit`), else the newest attempt
+ref a pause or an interrupted delivery parked — and emits
+`run_workspace_bank_restored` naming the branch, the head and the base it was
+put back on. The restore is two-step (the chain's own base, then a
+fast-forward to its head) so the clone's reflog still reads "started from the
+run's base": a bot that derives what the run changed from the newest reflog
+entry that is not its own commit (docs-refresh's scope gate) does not mistake
+the commits the target branch gained meanwhile for the run's work. A bank
+branch that moved past the recorded head, or a chain with no common ancestor,
+is refused loudly (`restored: false` + `reason`) and the run continues on the
+fresh clone.
+
 The consequence for authoring: **do not separate a node that mutates the
 workspace from the node that persists the mutation by a resumable boundary
 unless something checks the two still agree.** Either commit inside the

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -1412,15 +1412,17 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 	// private repo) and point the engine there so ${PROJECT_DIR} is the repo
 	// under review. Otherwise use the runner's base WorkDir.
 	workDir := r.cfg.WorkDir
-	// gitBase is the clone's HEAD before the workflow runs — the baseline the
-	// per-run commit/file view is measured against. Captured here (while the
-	// clone is on-disk) so recordRunGitMeta can persist the commit/file
-	// metadata into the store before the pod's ephemeral workspace is wiped;
-	// the server pod, which has no worktree, serves the panels from that.
+	// gitBase is the clone's HEAD before the workflow runs — or, when a
+	// re-execution restored the chain an earlier attempt banked, the base that
+	// chain forked from — the baseline the per-run commit/file view and the
+	// bank are measured against. Captured here (while the clone is on-disk)
+	// so recordRunGitMeta can persist the commit/file metadata into the store
+	// before the pod's ephemeral workspace is wiped; the server pod, which
+	// has no worktree, serves the panels from that.
 	gitBase := ""
 	if strings.TrimSpace(msg.RepoURL) != "" {
 		cloneStart := time.Now()
-		repoDir, derr := r.prepareRepoWorkspace(ctx, msg)
+		repoDir, baseline, derr := r.prepareRepoWorkspace(ctx, msg)
 		// Observed on BOTH outcomes (a clone that limps 10 minutes into an
 		// auth failure is exactly what the histogram exists to show), with
 		// the same nil guard every other Metrics site carries.
@@ -1431,7 +1433,9 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 			return fmt.Errorf("runner: prepare repo workspace for %s: %w", msg.RunID, derr)
 		}
 		workDir = repoDir
-		if head, herr := gitlib.RevParseHead(repoDir); herr == nil {
+		if baseline != "" {
+			gitBase = baseline
+		} else if head, herr := gitlib.RevParseHead(repoDir); herr == nil {
 			gitBase = head
 		} else {
 			r.cfg.Logger.Warn("runner: run %s: capture git baseline: %v", msg.RunID, herr)

--- a/pkg/runner/loop_gitws.go
+++ b/pkg/runner/loop_gitws.go
@@ -151,7 +151,12 @@ func (r *Runner) recordWorkspaceReset(ctx context.Context, msg *queue.RunMessage
 // github_token from the sealed bundle). The default branch is cloned first so
 // the review base (typically `main`) is present, then the run's ref is fetched
 // and checked out so merge-base diffs resolve.
-func (r *Runner) prepareRepoWorkspace(ctx context.Context, msg *queue.RunMessage) (string, error) {
+//
+// A re-execution then restores what the run's earlier attempt banked or
+// parked on the forge (restoreBankedChain). The second return value is the
+// baseline the run's work is measured against: the restored chain's own base
+// when a chain was restored, "" when the clone's HEAD is the baseline.
+func (r *Runner) prepareRepoWorkspace(ctx context.Context, msg *queue.RunMessage) (string, string, error) {
 	// RepoURL/RepoSHA arrive from a webhook payload (the generic webhook
 	// body is fully attacker-controlled) and flow into git below
 	// unmodified. Validate the transport + ref shape BEFORE touching the
@@ -161,7 +166,7 @@ func (r *Runner) prepareRepoWorkspace(ctx context.Context, msg *queue.RunMessage
 	// mirroring the bot-install path.
 	pinnedIP, err := validateRepoTarget(ctx, msg.RepoURL, msg.RepoSHA)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	// SSRF connect-time hardening for the two TOCTOU vectors validateRepoTarget
 	// alone can't close (it resolves but git re-resolves at connect time):
@@ -200,14 +205,14 @@ func (r *Runner) prepareRepoWorkspace(ctx context.Context, msg *queue.RunMessage
 	if hostErr == nil && strings.HasPrefix(strings.ToLower(strings.TrimSpace(msg.RepoURL)), "https://") {
 		endpoint, stopProxy, perr := startCloneGuardProxy(host, !cloneAllowPrivate())
 		if perr != nil {
-			return "", fmt.Errorf("runner: %w", perr)
+			return "", "", fmt.Errorf("runner: %w", perr)
 		}
 		defer stopProxy()
 		gitEnv = cloneGuardEnv(endpoint)
 	}
 	dir := filepath.Join(r.cfg.WorkDir, "repos", msg.RunID)
 	if err := os.RemoveAll(dir); err != nil {
-		return "", fmt.Errorf("clean repo dir: %w", err)
+		return "", "", fmt.Errorf("clean repo dir: %w", err)
 	}
 	// A re-execution never inherits the previous attempt's tree: executeRun
 	// deletes this directory when the run returns, and the next claim is
@@ -215,11 +220,12 @@ func (r *Runner) prepareRepoWorkspace(ctx context.Context, msg *queue.RunMessage
 	// downstream node keeps reading "the previous node edited these files"
 	// against a tree where those edits no longer exist. That divergence used
 	// to be entirely silent — record it on the timeline.
-	if reason := r.reExecutionReason(ctx, msg); reason != "" {
+	reason := r.reExecutionReason(ctx, msg)
+	if reason != "" {
 		r.recordWorkspaceReset(ctx, msg, reason)
 	}
 	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
-		return "", fmt.Errorf("mkdir repo parent: %w", err)
+		return "", "", fmt.Errorf("mkdir repo parent: %w", err)
 	}
 
 	cloneURL, tok, appBotLogin := msg.RepoURL, "", ""
@@ -242,17 +248,24 @@ func (r *Runner) prepareRepoWorkspace(ctx context.Context, msg *queue.RunMessage
 			// workflow declares no forge_token secret, so the repo-targeted
 			// launch's SecretOverrides had nothing to fill (overrides only
 			// populate DECLARED secrets).
-			return "", fmt.Errorf("%w (clone ran credential-less: no forge_token/gitlab_token/github_token in the run's sealed bundle — a private repo needs the workflow to declare a forge_token secret for the launch override to fill)", err)
+			return "", "", fmt.Errorf("%w (clone ran credential-less: no forge_token/gitlab_token/github_token in the run's sealed bundle — a private repo needs the workflow to declare a forge_token secret for the launch override to fill)", err)
 		}
-		return "", err
+		return "", "", err
 	}
 	if ref := strings.TrimSpace(msg.RepoSHA); ref != "" {
 		if err := r.runGitEnv(ctx, dir, tok, gitEnv, "-c", "http.followRedirects=false", "fetch", "--no-tags", "--quiet", "origin", ref); err != nil {
-			return "", err
+			return "", "", err
 		}
 		if err := r.runGit(ctx, dir, tok, "checkout", "--quiet", "-B", ref, "FETCH_HEAD"); err != nil {
-			return "", err
+			return "", "", err
 		}
+	}
+	// A re-execution is not a fresh start: whatever the earlier attempt
+	// banked or parked on the forge is this run's own state, and the resumed
+	// nodes must find it in the tree, not only in the checkpoint's outputs.
+	baseline := ""
+	if reason != "" {
+		baseline = r.restoreBankedChain(ctx, msg, dir, tok, gitEnv)
 	}
 	// Cloud sandboxes have no ~/.gitconfig (the host bind-mount is dropped on
 	// kubernetes and the runner pod has none of its own), so seed an
@@ -279,21 +292,21 @@ func (r *Runner) prepareRepoWorkspace(ctx context.Context, msg *queue.RunMessage
 		}
 	}
 	if err := r.runGit(ctx, dir, "", "config", "user.name", authorName); err != nil {
-		return "", fmt.Errorf("runner: seed git author name in %s: %w", dir, err)
+		return "", "", fmt.Errorf("runner: seed git author name in %s: %w", dir, err)
 	}
 	if err := r.runGit(ctx, dir, "", "config", "user.email", authorEmail); err != nil {
-		return "", fmt.Errorf("runner: seed git author email in %s: %w", dir, err)
+		return "", "", fmt.Errorf("runner: seed git author email in %s: %w", dir, err)
 	}
 	if err := r.installGitCredentialStore(ctx, dir, msg.RepoURL, tok); err != nil {
 		// Fail the clone rather than proceed: the alternative is a workspace
 		// whose only credential is the frozen one in remote.origin.url, which
 		// works now and 403s hours later at push time — the exact failure this
 		// removes, and the hardest kind to attribute.
-		return "", fmt.Errorf("runner: wire git credentials for %s: %w", msg.RunID, err)
+		return "", "", fmt.Errorf("runner: wire git credentials for %s: %w", msg.RunID, err)
 	}
 	seedRunScratchIgnore(dir)
 	r.cfg.Logger.Info("runner: cloned %s@%s for run %s", msg.RepoURL, msg.RepoSHA, msg.RunID)
-	return dir, nil
+	return dir, baseline, nil
 }
 
 // gitAuthorName / gitAuthorEmail are the identity seeded into a cloud clone's

--- a/pkg/runner/loop_gitws_restore.go
+++ b/pkg/runner/loop_gitws_restore.go
@@ -1,0 +1,147 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// bankedChain names where an earlier attempt of a run left its commits on
+// the forge: the storage branch a terminal bank recorded on the run doc, or
+// the attempt ref a pause / interrupted delivery parked its work on.
+type bankedChain struct {
+	Source string // "bank" (FinalBranch/FinalCommit) | "parked" (run_bank_attempt ref)
+	Ref    string // branch name under refs/heads/
+	Head   string // the sha the attempt ended on
+}
+
+// findBankedChain reads the run doc first — a recorded FinalBranch/FinalCommit
+// pair is what `runs merge` trusts — then falls back to the newest parked
+// attempt ref on the timeline. Nothing found is the ordinary re-execution of
+// a run that never committed, not an error.
+func (r *Runner) findBankedChain(ctx context.Context, runID string) (bankedChain, error) {
+	run, err := r.cfg.Store.LoadRun(ctx, runID)
+	if err != nil {
+		return bankedChain{}, err
+	}
+	if run != nil && run.FinalBranch != "" && run.FinalCommit != "" {
+		return bankedChain{Source: "bank", Ref: run.FinalBranch, Head: run.FinalCommit}, nil
+	}
+	var parked bankedChain
+	err = r.cfg.Store.ScanEvents(ctx, runID, func(e *store.Event) bool {
+		if e.Type != store.EventRunBankAttempt {
+			return true
+		}
+		ref, _ := e.Data["ref"].(string)
+		head, _ := e.Data["head"].(string)
+		if ref != "" && head != "" {
+			parked = bankedChain{Source: "parked", Ref: ref, Head: head}
+		}
+		return true
+	})
+	return parked, err
+}
+
+// restoreBankedChain puts a re-executing run back on the commits its earlier
+// attempt banked or parked on the forge, so the resumed nodes continue where
+// the run stopped instead of on a bare clone of the target branch — the
+// checkpoint replays their upstream OUTPUTS, but a campaign that committed
+// three passes and reads `git log` to plan the fourth must find them in the
+// tree, and the PR tail must have them to deliver.
+//
+// The checkout is deliberately two-step — the chain's own base first, then a
+// fast-forward to its head — so the clone's reflog reads "started from
+// <base>": a bot that derives what THIS run changed from the newest reflog
+// entry that is not its own commit (docs-refresh's scope gate does) must not
+// see the commits the target branch gained meanwhile as the run's work, and
+// fail its own scope on them.
+//
+// Every refusal is loud and leaves the fresh clone as it was: the chain stays
+// where the forge holds it, the run just does not continue from it. Returns
+// the chain's base when a chain was restored — the baseline the run's commit
+// view and its bank are measured against — and "" otherwise.
+func (r *Runner) restoreBankedChain(ctx context.Context, msg *queue.RunMessage, dir, tok string, gitEnv []string) string {
+	chain, err := r.findBankedChain(ctx, msg.RunID)
+	if err != nil {
+		r.cfg.Logger.Warn("runner: run %s: could not look for a banked chain to restore (%v) — continuing on the fresh clone", msg.RunID, err)
+		r.recordBankRestore(ctx, msg, map[string]any{"restored": false, "reason": "lookup_failed", "error": err.Error()})
+		return ""
+	}
+	if chain.Ref == "" {
+		return ""
+	}
+	data := map[string]any{"source": chain.Source, "ref": chain.Ref, "head": chain.Head}
+	refuse := func(reason, detail string) string {
+		data["restored"] = false
+		data["reason"] = reason
+		if detail != "" {
+			data["error"] = detail
+		}
+		r.cfg.Logger.Warn("runner: run %s: NOT restoring the %s chain %s @ %.12s (%s: %s) — continuing on the fresh clone", msg.RunID, chain.Source, chain.Ref, chain.Head, reason, detail)
+		r.recordBankRestore(ctx, msg, data)
+		return ""
+	}
+	if err := r.runGitEnv(ctx, dir, tok, gitEnv, "-c", "http.followRedirects=false", "fetch", "--no-tags", "--quiet", "origin", "refs/heads/"+chain.Ref); err != nil {
+		return refuse("fetch_failed", err.Error())
+	}
+	fetched, err := r.runGitOutEnv(ctx, dir, "", nil, "rev-parse", "--verify", "FETCH_HEAD^{commit}")
+	if err != nil {
+		return refuse("fetch_unreadable", err.Error())
+	}
+	// The doc names the exact commit the attempt ended on; a ref that moved
+	// past it belongs to someone else's push, and continuing from it would
+	// silently adopt work this run never did.
+	if fetched = strings.TrimSpace(fetched); fetched != chain.Head {
+		return refuse("ref_moved", fmt.Sprintf("origin/%s is at %.12s, the run recorded %.12s", chain.Ref, fetched, chain.Head))
+	}
+	current, err := r.runGitOutEnv(ctx, dir, "", nil, "rev-parse", "--verify", "HEAD^{commit}")
+	if err != nil {
+		return refuse("head_unreadable", err.Error())
+	}
+	current = strings.TrimSpace(current)
+	base, err := r.runGitOutEnv(ctx, dir, "", nil, "merge-base", current, chain.Head)
+	if err != nil {
+		return refuse("unrelated_history", err.Error())
+	}
+	base = strings.TrimSpace(base)
+	branch, err := r.runGitOutEnv(ctx, dir, "", nil, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return refuse("branch_unreadable", err.Error())
+	}
+	if branch = strings.TrimSpace(branch); branch == "" || branch == "HEAD" {
+		branch = "iterion/resume"
+	}
+	if err := r.runGit(ctx, dir, "", "checkout", "--quiet", "-B", branch, base); err != nil {
+		return refuse("checkout_failed", err.Error())
+	}
+	if err := r.runGit(ctx, dir, "", "merge", "--ff-only", "--quiet", chain.Head); err != nil {
+		// Put the tree back where the clone left it: a half-restored
+		// workspace is worse than a fresh one.
+		if rerr := r.runGit(ctx, dir, "", "checkout", "--quiet", "-B", branch, current); rerr != nil {
+			r.cfg.Logger.Error("runner: run %s: could not return to the fresh clone head %.12s after a failed fast-forward: %v", msg.RunID, current, rerr)
+		}
+		return refuse("fast_forward_failed", err.Error())
+	}
+	data["restored"] = true
+	data["base"] = base
+	data["from"] = current
+	data["base_moved"] = base != current
+	r.cfg.Logger.Info("runner: run %s: restored the %s chain %s @ %.12s on its base %.12s (target branch %s at %.12s)", msg.RunID, chain.Source, chain.Ref, chain.Head, base, branch, current)
+	r.recordBankRestore(ctx, msg, data)
+	return base
+}
+
+// recordBankRestore puts the restore (or its refusal) on the run's timeline.
+// Observational: a store that refuses the append must not sink the run, but
+// the fact still reaches the pod log.
+func (r *Runner) recordBankRestore(ctx context.Context, msg *queue.RunMessage, data map[string]any) {
+	if _, err := r.cfg.Store.AppendEvent(ctx, msg.RunID, store.Event{
+		Type: store.EventRunWorkspaceBankRestored,
+		Data: data,
+	}); err != nil {
+		r.cfg.Logger.Warn("runner: run %s: could not emit %s: %v (data: %v)", msg.RunID, store.EventRunWorkspaceBankRestored, err, data)
+	}
+}

--- a/pkg/runner/restore_bank_test.go
+++ b/pkg/runner/restore_bank_test.go
@@ -1,0 +1,265 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// A re-executing repo-targeted run used to start on a bare clone of the
+// target branch: the commits its earlier attempt banked (or parked) on the
+// forge stayed reachable, but never in the tree the resumed nodes ran on —
+// docs-refresh 01a055f9 would have resumed its fourth pass on top of nothing
+// after banking three. restoreBankedChain puts the chain back, two-step, so
+// the reflog still reads "started from the run's own base".
+
+type restoreFixture struct {
+	r      *Runner
+	msg    *queue.RunMessage
+	ctx    context.Context
+	tmp    string
+	origin string
+	base0  string
+	clones int
+}
+
+func newRestoreFixture(t *testing.T) *restoreFixture {
+	t.Helper()
+	tmp := t.TempDir()
+	origin := filepath.Join(tmp, "origin.git")
+	gitOut(t, tmp, "init", "--quiet", "--bare", "--initial-branch=main", origin)
+	seed := filepath.Join(tmp, "seed")
+	gitOut(t, tmp, "clone", "--quiet", origin, seed)
+	gitOut(t, seed, "config", "user.email", "t@test.invalid")
+	gitOut(t, seed, "config", "user.name", "t")
+	gitOut(t, seed, "commit", "--quiet", "--allow-empty", "-m", "baseline")
+	gitOut(t, seed, "push", "--quiet", "origin", "HEAD:main")
+	base0 := gitOut(t, seed, "rev-parse", "HEAD")
+
+	st, err := store.New(filepath.Join(tmp, "store"))
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	msg := &queue.RunMessage{RunID: "run-restore-1", TenantID: "team-a", RepoURL: origin, RepoSHA: "main"}
+	ctx := store.WithIdentity(context.Background(), "team-a", "")
+	if err := st.SaveRun(ctx, &store.Run{ID: msg.RunID, TenantID: msg.TenantID}); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	return &restoreFixture{
+		r:      &Runner{cfg: Config{Logger: iterlog.Nop(), Store: st}},
+		msg:    msg,
+		ctx:    ctx,
+		tmp:    tmp,
+		origin: origin,
+		base0:  base0,
+	}
+}
+
+func (f *restoreFixture) scratchClone(t *testing.T) string {
+	t.Helper()
+	f.clones++
+	dir := filepath.Join(f.tmp, fmt.Sprintf("scratch-%d", f.clones))
+	gitOut(t, f.tmp, "clone", "--quiet", f.origin, dir)
+	gitOut(t, dir, "config", "user.email", "t@test.invalid")
+	gitOut(t, dir, "config", "user.name", "t")
+	return dir
+}
+
+// pushChain lands n commits on top of origin's main as <ref> — an earlier
+// attempt's banked (or parked) work — and returns its tip.
+func (f *restoreFixture) pushChain(t *testing.T, ref string, n int) string {
+	t.Helper()
+	dir := f.scratchClone(t)
+	for i := 1; i <= n; i++ {
+		gitOut(t, dir, "commit", "--quiet", "--allow-empty", "-m", fmt.Sprintf("docs(pass): commit %d\n\nBot: docs-refresh", i))
+	}
+	tip := gitOut(t, dir, "rev-parse", "HEAD")
+	gitOut(t, dir, "push", "--quiet", "origin", "HEAD:refs/heads/"+ref)
+	return tip
+}
+
+// advanceMain moves origin's main under the run and returns its new tip.
+func (f *restoreFixture) advanceMain(t *testing.T) string {
+	t.Helper()
+	dir := f.scratchClone(t)
+	gitOut(t, dir, "commit", "--quiet", "--allow-empty", "-m", "main moved meanwhile")
+	gitOut(t, dir, "push", "--quiet", "origin", "HEAD:main")
+	return gitOut(t, dir, "rev-parse", "HEAD")
+}
+
+// runnerClone is prepareRepoWorkspace's shape: a fresh clone, then the run's
+// ref fetched and checked out as a local branch of the same name.
+func (f *restoreFixture) runnerClone(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(f.tmp, "run")
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	gitOut(t, f.tmp, "clone", "--no-tags", "--quiet", f.origin, dir)
+	gitOut(t, dir, "fetch", "--no-tags", "--quiet", "origin", "main")
+	gitOut(t, dir, "checkout", "--quiet", "-B", "main", "FETCH_HEAD")
+	return dir
+}
+
+func (f *restoreFixture) restoreEvents(t *testing.T) []*store.Event {
+	t.Helper()
+	all, err := f.r.cfg.Store.LoadEvents(f.ctx, f.msg.RunID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	var out []*store.Event
+	for _, e := range all {
+		if e.Type == store.EventRunWorkspaceBankRestored {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func (f *restoreFixture) bank(t *testing.T, ref, head string) {
+	t.Helper()
+	run, err := f.r.cfg.Store.LoadRun(f.ctx, f.msg.RunID)
+	if err != nil || run == nil {
+		t.Fatalf("load run: %v", err)
+	}
+	run.FinalBranch, run.FinalCommit = ref, head
+	if err := f.r.cfg.Store.SaveRun(f.ctx, run); err != nil {
+		t.Fatalf("save run: %v", err)
+	}
+}
+
+// The target branch moved under the run: the chain is restored on ITS base,
+// the run's own commits are what sits ahead of origin/main, and the reflog
+// names the base right under the restored head.
+func TestRestoreBankedChainOnMovedBase(t *testing.T) {
+	f := newRestoreFixture(t)
+	ref := "iterion/run-" + f.msg.RunID
+	tip := f.pushChain(t, ref, 2)
+	f.bank(t, ref, tip)
+	moved := f.advanceMain(t)
+	dir := f.runnerClone(t)
+	if got := gitOut(t, dir, "rev-parse", "HEAD"); got != moved {
+		t.Fatalf("fixture: the fresh clone must sit on the moved main (%s), got %s", moved, got)
+	}
+
+	base := f.r.restoreBankedChain(f.ctx, f.msg, dir, "", nil)
+
+	if base != f.base0 {
+		t.Errorf("restore must report the chain's own base %s as the baseline, got %q", f.base0, base)
+	}
+	if got := gitOut(t, dir, "rev-parse", "HEAD"); got != tip {
+		t.Errorf("HEAD must be the banked head %s, got %s", tip, got)
+	}
+	if got := gitOut(t, dir, "rev-parse", "--abbrev-ref", "HEAD"); got != "main" {
+		t.Errorf("the run's branch name must survive the restore, got %q", got)
+	}
+	ahead := strings.Fields(gitOut(t, dir, "rev-list", "origin/main..HEAD"))
+	if len(ahead) != 2 {
+		t.Errorf("exactly the chain's 2 commits must sit ahead of origin/main, got %d: %v", len(ahead), ahead)
+	}
+	// Two-step checkout: newest reflog entry = the restored head, the one
+	// below it = the chain's base — never the moved target branch, which a
+	// scope gate reading "the newest entry that is not my own commit" would
+	// otherwise take for the run's starting point.
+	reflog := strings.Fields(gitOut(t, dir, "reflog", "show", "--format=%H", "HEAD"))
+	if len(reflog) < 2 || reflog[0] != tip || reflog[1] != f.base0 {
+		t.Errorf("reflog must read [head, base, …] = [%s, %s, …], got %v", tip, f.base0, reflog)
+	}
+	evs := f.restoreEvents(t)
+	if len(evs) != 1 {
+		t.Fatalf("want one %s event, got %d", store.EventRunWorkspaceBankRestored, len(evs))
+	}
+	d := evs[0].Data
+	if d["restored"] != true || d["source"] != "bank" || d["ref"] != ref || d["head"] != tip || d["base"] != f.base0 || d["base_moved"] != true || d["from"] != moved {
+		t.Errorf("event data: %v", d)
+	}
+}
+
+// A bank branch that moved past the recorded head is not this run's work
+// any more: refuse, keep the fresh clone, say why.
+func TestRestoreBankedChainRefusesMovedRef(t *testing.T) {
+	f := newRestoreFixture(t)
+	ref := "iterion/run-" + f.msg.RunID
+	tip := f.pushChain(t, ref, 1)
+	f.bank(t, ref, tip)
+	// Someone pushed one more commit on the bank branch after the doc was
+	// written.
+	dir := f.scratchClone(t)
+	gitOut(t, dir, "fetch", "--quiet", "origin", "refs/heads/"+ref)
+	gitOut(t, dir, "checkout", "--quiet", "-B", "bank", "FETCH_HEAD")
+	gitOut(t, dir, "commit", "--quiet", "--allow-empty", "-m", "foreign push")
+	gitOut(t, dir, "push", "--quiet", "origin", "HEAD:refs/heads/"+ref)
+	run := f.runnerClone(t)
+	before := gitOut(t, run, "rev-parse", "HEAD")
+
+	base := f.r.restoreBankedChain(f.ctx, f.msg, run, "", nil)
+
+	if base != "" {
+		t.Errorf("a moved ref must not be restored, got baseline %q", base)
+	}
+	if got := gitOut(t, run, "rev-parse", "HEAD"); got != before {
+		t.Errorf("the fresh clone must be left untouched (%s), got %s", before, got)
+	}
+	evs := f.restoreEvents(t)
+	if len(evs) != 1 || evs[0].Data["restored"] != false || evs[0].Data["reason"] != "ref_moved" {
+		t.Errorf("want one refusal event with reason ref_moved, got %v", evs)
+	}
+}
+
+// No terminal bank: the newest parked attempt ref on the timeline is the
+// chain to restore (a paused run, an interrupted delivery).
+func TestRestoreBankedChainFromParkedRef(t *testing.T) {
+	f := newRestoreFixture(t)
+	older := f.pushChain(t, "iterion/run-"+f.msg.RunID+"-parked-aaaaaaaaaaaa", 1)
+	newer := f.pushChain(t, "iterion/run-"+f.msg.RunID+"-parked-bbbbbbbbbbbb", 3)
+	for _, e := range []struct{ ref, head string }{
+		{"iterion/run-" + f.msg.RunID + "-parked-aaaaaaaaaaaa", older},
+		{"iterion/run-" + f.msg.RunID + "-parked-bbbbbbbbbbbb", newer},
+	} {
+		if _, err := f.r.cfg.Store.AppendEvent(f.ctx, f.msg.RunID, store.Event{
+			Type: store.EventRunBankAttempt,
+			Data: map[string]any{"cause": "paused", "ref": e.ref, "head": e.head},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dir := f.runnerClone(t)
+
+	base := f.r.restoreBankedChain(f.ctx, f.msg, dir, "", nil)
+
+	if base != f.base0 {
+		t.Errorf("baseline: want %s, got %q", f.base0, base)
+	}
+	if got := gitOut(t, dir, "rev-parse", "HEAD"); got != newer {
+		t.Errorf("the NEWEST parked ref must be restored (%s), got %s", newer, got)
+	}
+	evs := f.restoreEvents(t)
+	if len(evs) != 1 || evs[0].Data["source"] != "parked" || evs[0].Data["base_moved"] != false {
+		t.Errorf("event: %v", evs)
+	}
+}
+
+// A run that never banked anything re-executes exactly as before: no
+// restore, no event, fresh clone.
+func TestRestoreBankedChainNothingToRestore(t *testing.T) {
+	f := newRestoreFixture(t)
+	dir := f.runnerClone(t)
+	before := gitOut(t, dir, "rev-parse", "HEAD")
+
+	if base := f.r.restoreBankedChain(f.ctx, f.msg, dir, "", nil); base != "" {
+		t.Errorf("nothing banked must yield no baseline, got %q", base)
+	}
+	if got := gitOut(t, dir, "rev-parse", "HEAD"); got != before {
+		t.Errorf("HEAD moved from %s to %s with nothing to restore", before, got)
+	}
+	if evs := f.restoreEvents(t); len(evs) != 0 {
+		t.Errorf("no event expected when there is nothing to restore, got %v", evs)
+	}
+}

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -140,6 +140,24 @@ const (
 	//     resume publish) or "redelivery" (a checkpoint with no resume spec)
 	//   - repo_url / repo_sha: what the clone was re-anchored on
 	EventRunWorkspaceReset EventType = "run_workspace_reset"
+	// EventRunWorkspaceBankRestored marks a re-executing repo-backed run being
+	// put back on the commits its earlier attempt banked (the storage branch
+	// on the run doc) or parked (a run_bank_attempt ref), instead of starting
+	// on a bare clone of the target branch. Emitted right after the
+	// run_workspace_reset marker of the same claim; absent when the run had
+	// nothing banked. The restore checks out the chain's own base first and
+	// fast-forwards to its head, so the clone's reflog still names that base
+	// as the run's starting point. Data:
+	//   - restored: whether the tree now sits on the chain (false = refused,
+	//     fresh clone kept)
+	//   - source: "bank" (FinalBranch/FinalCommit) or "parked" (attempt ref)
+	//   - ref / head: the branch restored and the sha it was recorded at
+	//   - base / from / base_moved: the chain's base, the fresh clone's HEAD,
+	//     and whether the target branch moved under the run meanwhile
+	//   - reason / error: why a restore was refused (ref_moved when the
+	//     branch advanced past the recorded head, unrelated_history,
+	//     fetch_failed, …) — the failure shape, with restored=false
+	EventRunWorkspaceBankRestored EventType = "run_workspace_bank_restored"
 	// EventRunBankRefused marks THIS attempt's head being dropped by the
 	// runner's death bank while an EARLIER attempt of the same run keeps
 	// the storage branch — because that attempt banked a strictly richer

--- a/studio/src/api/runs/events.ts
+++ b/studio/src/api/runs/events.ts
@@ -406,6 +406,7 @@ export type PassthroughEventType =
   | "run_health"
   | "run_auto_resumed"
   | "run_workspace_reset"
+  | "run_workspace_bank_restored"
   | "run_bank_refused"
   | "run_bank_superseded"
   | "run_bank_attempt"


### PR DESCRIPTION
## Why

A resume or redelivery of a repo-targeted run re-cloned the target branch and started the remaining nodes on a bare tree. The commits the earlier attempt had **banked** (`final_branch`/`final_commit`) or **parked** (an attempt ref) stayed reachable on the forge but never reached the workspace: a campaign that had committed three passes planned its fourth on nothing, and the PR tail had nothing to deliver. docs-refresh `01a055f9` (33 commits, $188 of forfait) and Billy `01a06728` (#652) both stranded that way.

## What

- **`prepareRepoWorkspace`** now fetches the banked chain after the checkout (`restoreBankedChain`, `pkg/runner/loop_gitws_restore.go`) — the run doc's storage branch first, else the newest `run_bank_attempt` ref — and puts the tree on it **in two steps**: the chain's own base, then a fast-forward to its head. The clone's reflog therefore still names that base as the run's starting point: docs-refresh's scope gate reads the newest non-own reflog entry, and a direct checkout would make it count the commits the target branch gained meanwhile as the run's work (a phantom scope violation, the 07-24 class).
- The chain's base becomes the **baseline** the commit view (`recordRunGitMeta`) and the bank measure from — the run's work is the whole chain.
- Refusals are loud and leave the fresh clone: a bank branch that moved past the recorded head (`ref_moved`), no common ancestor, fetch failure. Every outcome lands on the timeline as **`run_workspace_bank_restored`** (`restored`, `source`, `ref`, `head`, `base`, `from`, `base_moved`, or `reason`/`error`).
- Docs: `docs/resume.md`, `docs/persisted-formats.md`; studio event union.

## Verification

- Real-git fixtures (`pkg/runner/restore_bank_test.go`): restore on a moved target branch (HEAD, reflog shape `[head, base, …]`, exactly the chain's commits ahead of `origin/main`, event data), refusal on a moved ref (clone untouched), the newest parked ref wins, nothing banked → unchanged.
- `go test ./pkg/runner/` (bank + restore + workspace-reset suites), `go vet`, `golangci-lint`, `task studio:typecheck` all green.
- Runner-side: needs the runner digest bump on prod. The live proof is the resume of `01a055f9` afterwards (its PR opened by the bot's own tail) — bilan to follow in `docs/bot-runs/docs-refresh.md`.

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)