### PR TITLE
fix(cloudpublisher): the walk consults the operator's hard caps — a capped forfait is passed over like a refused one

### DIFF
--- a/cmd/iterion/server.go
+++ b/cmd/iterion/server.go
@@ -367,9 +367,23 @@ func runServer(cmd *cobra.Command, _ []string) error {
 		// The fleet's shared meter: a forfait the provider has refused is
 		// skipped at launch so the run falls through to the next
 		// credential tier instead of parking for a reset it could have
-		// avoided. Evidence-only — the operator's cap policy is the
-		// runner's business, not the launch's.
+		// avoided.
 		UsageCaps: usagecap.NewMongoStore(st.DB()),
+		// The operator's cap posture, consulted by the walk over the same
+		// readings: the runner's pre-flight parks on a hard cap before any
+		// node runs, so a capped credential must be passed over like a
+		// refused one or the tiers stop being a fallback chain. Own
+		// resolver instance — the admin PUT invalidates the server's, this
+		// one converges within the resolver's TTL bound.
+		CapPolicy: func() usagecap.PolicySource {
+			envPol, envErr := usagecap.FromEnv()
+			if envErr != nil {
+				logger.Warn("server: publisher cap policy disabled — env policy invalid: %v", envErr)
+				return nil
+			}
+			return usagecap.NewResolver(stores.usageCapSettings, envPol,
+				usagecap.WithWarnLogger(logger.Warn))
+		}(),
 		// The SAME resolver instance the server's admin PUT invalidates —
 		// publish-time pinning sees a mutation immediately on this replica.
 		SandboxImage: func(ctx context.Context) string {

--- a/pkg/backend/delegate/claude_code_stream.go
+++ b/pkg/backend/delegate/claude_code_stream.go
@@ -1008,6 +1008,16 @@ func classifyRateLimit(text string, now time.Time) (kind string, window usagecap
 	if !isUsageWindowText(lower) {
 		return RateLimitKindTransient, "", time.Time{}
 	}
+	// The refusal names its window between "your" and "limit" ("weekly",
+	// "session"…). Naming it matters beyond retry timing: a nameless
+	// window records NO reading (both recording sites are gated on the
+	// name), so a real weekly wall stays invisible to the resolution
+	// walk, which re-grants the same walled credential on every retry.
+	// Only the weekly noun maps today; "session"/bare-5h shapes keep ""
+	// until they get a window constant of their own.
+	if strings.Contains(lower, "weekly") {
+		return RateLimitKindUsageWindow, usagecap.WindowSevenDay, parseResetHint(lower, now)
+	}
 	return RateLimitKindUsageWindow, "", parseResetHint(lower, now)
 }
 

--- a/pkg/backend/delegate/usage_limit_test.go
+++ b/pkg/backend/delegate/usage_limit_test.go
@@ -3,6 +3,8 @@ package delegate
 import (
 	"testing"
 	"time"
+
+	"github.com/SocialGouv/iterion/pkg/usagecap"
 )
 
 func TestClassifyRateLimit(t *testing.T) {
@@ -54,10 +56,11 @@ func TestClassifyRateLimit(t *testing.T) {
 			wantReset: time.Date(2026, 7, 18, 10, 30, 0, 0, time.UTC), // 10:30 already past 14:00 → next day
 		},
 		{
-			name:      "weekly limit with pm clock (feed-watch runner 019f7eee)",
-			text:      "You've hit your weekly limit · resets 9pm (Europe/Paris)",
-			wantKind:  RateLimitKindUsageWindow,
-			wantReset: time.Date(2026, 7, 17, 21, 0, 0, 0, time.UTC),
+			name:       "weekly limit with pm clock (feed-watch runner 019f7eee)",
+			text:       "You've hit your weekly limit · resets 9pm (Europe/Paris)",
+			wantKind:   RateLimitKindUsageWindow,
+			wantWindow: string(usagecap.WindowSevenDay),
+			wantReset:  time.Date(2026, 7, 17, 21, 0, 0, 0, time.UTC),
 		},
 		{
 			name:      "zai 5h facade",
@@ -83,11 +86,15 @@ func TestClassifyRateLimit(t *testing.T) {
 		{
 			// The shape a WEEKLY cap actually prints: a month name and day
 			// before the clock. Seven scheduled prod runs died on this on
-			// 2026-07-27 with the reset ~35h out.
-			name:      "weekly limit with dated reset",
-			text:      "You've hit your weekly limit · resets Jul 28, 9pm (UTC)",
-			wantKind:  RateLimitKindUsageWindow,
-			wantReset: time.Date(2026, 7, 28, 21, 0, 0, 0, time.UTC),
+			// 2026-07-27 with the reset ~35h out. The window is NAMED so a
+			// StatusRejected reading is recorded: nameless, the resolution
+			// walk re-granted the same weekly-walled forfait on every
+			// retry (four identical parks measured on 2026-09-04).
+			name:       "weekly limit with dated reset",
+			text:       "You've hit your weekly limit · resets Jul 28, 9pm (UTC)",
+			wantKind:   RateLimitKindUsageWindow,
+			wantWindow: string(usagecap.WindowSevenDay),
+			wantReset:  time.Date(2026, 7, 28, 21, 0, 0, 0, time.UTC),
 		},
 		{
 			// An explicit absolute instant needs no year inference, so it is

--- a/pkg/server/cloudpublisher/forfait_window_fallback_test.go
+++ b/pkg/server/cloudpublisher/forfait_window_fallback_test.go
@@ -281,3 +281,63 @@ func TestForfaitWindowClosed_restoredWhenNoTierCanServe(t *testing.T) {
 		t.Fatalf("the refused forfait must be RESTORED when no tier can serve, got %q", got)
 	}
 }
+
+// A hard OPERATOR cap closes the window exactly like a provider refusal:
+// the runner's pre-flight parks on it before any node runs, so handing the
+// capped forfait over just replays the park on every retry. Measured on
+// 2026-09-04: a weekly forfait at 97% (provider still ALLOWING) was
+// re-granted on four consecutive attempts while the next tier sat idle —
+// the park writes no refusal, so no signal ever broke the loop.
+func TestForfaitWindowClosed_operatorHardCapFallsThrough(t *testing.T) {
+	f := newPoolFixture(t, credpool.Limits{MaxUSDPerDay: 5})
+	fp := withTenantForfait(t, f, "sk-ant-tenant-own")
+	meterSays(t, f, fp, usagecap.Reading{
+		Window: usagecap.WindowSevenDay, Status: usagecap.StatusWarning, Utilization: 0.97,
+		ResetsAt: time.Now().Add(4 * 24 * time.Hour), ObservedAt: time.Now(),
+	})
+
+	// Without a policy the walk stays refusal-evidence-only: utilization
+	// alone must not bench a credential (the shipped no-cap deployment).
+	if got := bundleToken(t, f, "run-no-policy"); !contains(got, "sk-ant-tenant-own") {
+		t.Fatalf("no policy: run must keep the tenant's forfait, got %q", got)
+	}
+
+	// A soft cap warns; it never closes the window.
+	f.pub.capPolicy = usagecap.StaticPolicy(usagecap.Policy{
+		Week: usagecap.WindowPolicy{MaxPercent: 95, Mode: usagecap.ModeSoft}})
+	if got := bundleToken(t, f, "run-soft-cap"); !contains(got, "sk-ant-tenant-own") {
+		t.Fatalf("soft cap: run must keep the tenant's forfait, got %q", got)
+	}
+
+	// Hard cap at/below the reading's utilization: the pre-flight would
+	// park this run — the walk must fall through to the pool instead.
+	f.pub.capPolicy = usagecap.StaticPolicy(usagecap.Policy{
+		Week: usagecap.WindowPolicy{MaxPercent: 95, Mode: usagecap.ModeHard}})
+	got := bundleToken(t, f, "run-hard-cap")
+	if got == "" {
+		t.Fatal("the run got NO credential: the cap skip must fall through, not empty the bundle")
+	}
+	if contains(got, "sk-ant-tenant-own") {
+		t.Fatalf("the hard-capped forfait was handed over anyway: %q", got)
+	}
+	if !contains(got, "sk-ant-donated") {
+		t.Fatalf("expected the donor's credential from the pool, got %q", got)
+	}
+}
+
+// A hard cap with NO reset instant must NOT close the window: benching a
+// credential on a utilization snapshot with no reopening date would be a
+// permanent skip on stale numbers.
+func TestForfaitWindowClosed_operatorCapWithoutResetStaysUsable(t *testing.T) {
+	f := newPoolFixture(t, credpool.Limits{MaxUSDPerDay: 5})
+	fp := withTenantForfait(t, f, "sk-ant-tenant-own")
+	f.pub.capPolicy = usagecap.StaticPolicy(usagecap.Policy{
+		Week: usagecap.WindowPolicy{MaxPercent: 95, Mode: usagecap.ModeHard}})
+	meterSays(t, f, fp, usagecap.Reading{
+		Window: usagecap.WindowSevenDay, Status: usagecap.StatusWarning, Utilization: 0.97,
+		ObservedAt: time.Now(),
+	})
+	if got := bundleToken(t, f, "run-capped-no-reset"); !contains(got, "sk-ant-tenant-own") {
+		t.Fatalf("no reset instant: run must keep the tenant's forfait, got %q", got)
+	}
+}

--- a/pkg/server/cloudpublisher/forfait_window_fallback_test.go
+++ b/pkg/server/cloudpublisher/forfait_window_fallback_test.go
@@ -282,13 +282,13 @@ func TestForfaitWindowClosed_restoredWhenNoTierCanServe(t *testing.T) {
 	}
 }
 
-// A hard OPERATOR cap closes the window exactly like a provider refusal:
-// the runner's pre-flight parks on it before any node runs, so handing the
-// capped forfait over just replays the park on every retry. Measured on
-// 2026-09-04: a weekly forfait at 97% (provider still ALLOWING) was
-// re-granted on four consecutive attempts while the next tier sat idle —
+// An OPERATOR cap closes the window exactly like a provider refusal: the
+// runner's pre-flight parks on Decision.Blocked before any node runs, so
+// handing the capped forfait over just replays the park on every retry.
+// Measured on 2026-09-04: a weekly forfait at 97% (provider still ALLOWING)
+// was re-granted on four consecutive attempts while the next tier sat idle —
 // the park writes no refusal, so no signal ever broke the loop.
-func TestForfaitWindowClosed_operatorHardCapFallsThrough(t *testing.T) {
+func TestForfaitWindowClosed_operatorCapFallsThrough(t *testing.T) {
 	f := newPoolFixture(t, credpool.Limits{MaxUSDPerDay: 5})
 	fp := withTenantForfait(t, f, "sk-ant-tenant-own")
 	meterSays(t, f, fp, usagecap.Reading{
@@ -302,15 +302,14 @@ func TestForfaitWindowClosed_operatorHardCapFallsThrough(t *testing.T) {
 		t.Fatalf("no policy: run must keep the tenant's forfait, got %q", got)
 	}
 
-	// A soft cap warns; it never closes the window.
+	// Under the cap: nothing to skip.
 	f.pub.capPolicy = usagecap.StaticPolicy(usagecap.Policy{
-		Week: usagecap.WindowPolicy{MaxPercent: 95, Mode: usagecap.ModeSoft}})
-	if got := bundleToken(t, f, "run-soft-cap"); !contains(got, "sk-ant-tenant-own") {
-		t.Fatalf("soft cap: run must keep the tenant's forfait, got %q", got)
+		Week: usagecap.WindowPolicy{MaxPercent: 99, Mode: usagecap.ModeHard}})
+	if got := bundleToken(t, f, "run-under-cap"); !contains(got, "sk-ant-tenant-own") {
+		t.Fatalf("under cap: run must keep the tenant's forfait, got %q", got)
 	}
 
-	// Hard cap at/below the reading's utilization: the pre-flight would
-	// park this run — the walk must fall through to the pool instead.
+	// Hard cap reached: the pre-flight would park this run — fall through.
 	f.pub.capPolicy = usagecap.StaticPolicy(usagecap.Policy{
 		Week: usagecap.WindowPolicy{MaxPercent: 95, Mode: usagecap.ModeHard}})
 	got := bundleToken(t, f, "run-hard-cap")
@@ -325,10 +324,35 @@ func TestForfaitWindowClosed_operatorHardCapFallsThrough(t *testing.T) {
 	}
 }
 
-// A hard cap with NO reset instant must NOT close the window: benching a
-// credential on a utilization snapshot with no reopening date would be a
-// permanent skip on stale numbers.
-func TestForfaitWindowClosed_operatorCapWithoutResetStaysUsable(t *testing.T) {
+// SOFT counts too, and this is the shipped default posture: five-hour caps
+// default to soft, and soft means "never interrupts work in flight" — it
+// still lets no NEW run start (docs/usage-caps.md). The pre-flight parks on
+// Decision.Blocked whatever the mode, so a walk that skipped only on hard
+// would reproduce the measured starvation loop on the DEFAULT deployment,
+// bounded by the five-hour reset instead of four days.
+func TestForfaitWindowClosed_operatorSoftCapAlsoFallsThrough(t *testing.T) {
+	f := newPoolFixture(t, credpool.Limits{MaxUSDPerDay: 5})
+	fp := withTenantForfait(t, f, "sk-ant-tenant-own")
+	f.pub.capPolicy = usagecap.StaticPolicy(usagecap.Policy{
+		FiveHour: usagecap.WindowPolicy{MaxPercent: 85, Mode: usagecap.ModeSoft}})
+	meterSays(t, f, fp, usagecap.Reading{
+		Window: usagecap.WindowFiveHour, Status: usagecap.StatusWarning, Utilization: 0.9,
+		ResetsAt: time.Now().Add(2 * time.Hour), ObservedAt: time.Now(),
+	})
+	got := bundleToken(t, f, "run-soft-cap")
+	if contains(got, "sk-ant-tenant-own") {
+		t.Fatalf("the soft-capped forfait was handed over: the pre-flight parks on Blocked, got %q", got)
+	}
+	if !contains(got, "sk-ant-donated") {
+		t.Fatalf("expected the donor's credential from the pool, got %q", got)
+	}
+}
+
+// A capped reading with NO reset instant is trusted for its own staleness
+// bound — the same synthesis the refusal branch applies. Without it the
+// walk re-grants a credential the pre-flight parks on, once an hour, for as
+// long as the operator's cap stays reached.
+func TestForfaitWindowClosed_operatorCapWithoutResetIsBounded(t *testing.T) {
 	f := newPoolFixture(t, credpool.Limits{MaxUSDPerDay: 5})
 	fp := withTenantForfait(t, f, "sk-ant-tenant-own")
 	f.pub.capPolicy = usagecap.StaticPolicy(usagecap.Policy{
@@ -337,7 +361,17 @@ func TestForfaitWindowClosed_operatorCapWithoutResetStaysUsable(t *testing.T) {
 		Window: usagecap.WindowSevenDay, Status: usagecap.StatusWarning, Utilization: 0.97,
 		ObservedAt: time.Now(),
 	})
-	if got := bundleToken(t, f, "run-capped-no-reset"); !contains(got, "sk-ant-tenant-own") {
-		t.Fatalf("no reset instant: run must keep the tenant's forfait, got %q", got)
+	if got := bundleToken(t, f, "run-capped-no-reset"); contains(got, "sk-ant-tenant-own") {
+		t.Fatalf("a capped reading with no reset must still skip (bounded by staleness), got %q", got)
+	}
+
+	// Past the staleness bound the reading is ignored by Fresh, and the
+	// credential comes back on its own — the skip is self-healing.
+	meterSays(t, f, fp, usagecap.Reading{
+		Window: usagecap.WindowSevenDay, Status: usagecap.StatusWarning, Utilization: 0.97,
+		ObservedAt: time.Now().Add(-2 * usagecap.DefaultMaxAge),
+	})
+	if got := bundleToken(t, f, "run-capped-stale"); !contains(got, "sk-ant-tenant-own") {
+		t.Fatalf("a STALE capped reading must not bench the forfait, got %q", got)
 	}
 }

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -1029,17 +1029,29 @@ func (p *Publisher) refusedUntil(ctx context.Context, backend string, scope stri
 	if until.IsZero() && p.capPolicy != nil {
 		// No provider refusal on record — but the runner's pre-flight
 		// enforces the operator's caps over these same readings and parks
-		// BEFORE any node runs. A hard cap with a known reset therefore
-		// closes the window here too; otherwise the walk re-grants the
-		// same capped credential on every retry while a usable lower
-		// tier sits unreached, and the park writes no refusal that would
-		// ever break the loop. Hard only: a soft cap warns, it does not
-		// park. A blocked window with NO reset instant stays usable —
-		// benching a credential with no reopening date would be a
-		// permanent skip on a utilization snapshot.
-		if d := usagecap.Preflight(readings, p.capPolicy.Effective(ctx), now, usagecap.DefaultMaxAge); d.Blocked && d.Stop && !d.ResetsAt.IsZero() {
-			until = d.ResetsAt
-			why = fmt.Sprintf("the operator's hard cap on the %s window is reached (%.0f%% ≥ %.0f%%)", d.Window, d.Percent, d.Cap)
+		// BEFORE any node runs; otherwise the walk re-grants the same
+		// capped credential on every retry while a usable lower tier sits
+		// unreached, and the park writes no refusal that would ever break
+		// the loop.
+		//
+		// The gate mirrored is Decision.Blocked, NOT Stop: soft means
+		// "never interrupts work in flight", and it still lets no NEW run
+		// start (docs/usage-caps.md) — which is precisely what a launch
+		// is. Requiring Stop would leave the shipped default posture (5h
+		// soft) reproducing the very loop this closes, and would also
+		// mask a hard week decision whenever Preflight's latest-reset
+		// arbitration picks a soft five-hour one.
+		//
+		// A blocked window with no reset instant is trusted for the
+		// reading's own staleness bound, the same synthesis the refusal
+		// branch above applies: bounded, self-healing, and symmetric.
+		if d := usagecap.Preflight(readings, p.capPolicy.Effective(ctx), now, usagecap.DefaultMaxAge); d.Blocked {
+			reopen := d.ResetsAt
+			if reopen.IsZero() {
+				reopen = now.Add(usagecap.DefaultMaxAge)
+			}
+			until = reopen
+			why = fmt.Sprintf("the operator's cap on the %s window is reached (%.0f%% ≥ %.0f%%)", d.Window, d.Percent, d.Cap)
 		}
 	}
 	return until, why

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -105,6 +105,13 @@ type Config struct {
 	// whose window is CLOSED, which is what lets the run fall through to
 	// the next credential tier instead of parking for a reset.
 	UsageCaps usagecap.Store
+	// CapPolicy, when non-nil, is the operator's usage-cap posture
+	// (pkg/usagecap PolicySource). The walk consults it over the SAME
+	// readings as the refusal skip: a credential the runner's pre-flight
+	// is certain to park (hard cap reached, reset instant known) is
+	// passed over like a refused one, so the tiers stay a fallback chain.
+	// Nil keeps the walk refusal-evidence-only.
+	CapPolicy usagecap.PolicySource
 	// CredPool, when non-nil, lets a run with no credential of its own
 	// draw on a contributor's lent subscription (pkg/credpool). Nil — the
 	// default — simply means no pool tier.
@@ -151,6 +158,7 @@ type Publisher struct {
 	sandboxImage   func(context.Context) string
 	credPool       *credpool.Broker
 	usageCaps      usagecap.Store
+	capPolicy      usagecap.PolicySource
 	identity       TeamResolver
 
 	// orgCache memoizes team → org id so the publish hot path doesn't
@@ -244,6 +252,7 @@ func New(cfg Config) (*Publisher, error) {
 		sandboxImage:   cfg.SandboxImage,
 		credPool:       cfg.CredPool,
 		usageCaps:      cfg.UsageCaps,
+		capPolicy:      cfg.CapPolicy,
 		identity:       cfg.Identity,
 	}, nil
 }
@@ -928,14 +937,20 @@ const usageCapLookupTimeout = 5 * time.Second
 // forfaitWindowClosed reports when a forfait's provider window is closed
 // (and why), or the zero time when it is usable.
 //
-// The ONLY evidence that closes a window is the provider's own refusal: a
-// fresh StatusRejected reading. The operator's percentage caps are
-// deliberately not consulted — a cap is a ceiling on THIS deployment's
-// spending, not evidence the provider would refuse, and skipping on it
-// would push work onto a donor (or the platform's own meter) to keep a
-// tenant under its own budget. A provider refusal, conversely, needs no
-// operator policy to be true — so the skip also works on a deployment
-// that never configured a cap.
+// Two signals close a window, because two gates can park the run:
+//   - the provider's own refusal (a fresh StatusRejected reading) — true
+//     without any operator policy, so the skip works on a deployment
+//     that never configured a cap;
+//   - the operator's HARD usage cap over the same readings (CapPolicy,
+//     usagecap.Preflight): the runner's pre-flight enforces it before
+//     any node runs, so a credential at a hard cap with a known reset
+//     is not a usable credential — granting it parks the run for that
+//     reset while a lower tier could have served. Soft caps warn, they
+//     never close a window here. (This deliberately supersedes the
+//     earlier evidence-only doctrine: it kept the walk from spending
+//     another tier to dodge a tenant budget, but the week cap is the
+//     operator's machine-wide posture, the fallthrough tiers are the
+//     same operator's, and the pre-flight parks either way.)
 //
 // Everything uncertain means "usable", because a wrong skip spends
 // somebody else's quota for a subscription that would have worked:
@@ -1009,6 +1024,22 @@ func (p *Publisher) refusedUntil(ctx context.Context, backend string, scope stri
 			default:
 				why = fmt.Sprintf("provider refused the %s window (%.0f%% used)", r.Window, r.Percent())
 			}
+		}
+	}
+	if until.IsZero() && p.capPolicy != nil {
+		// No provider refusal on record — but the runner's pre-flight
+		// enforces the operator's caps over these same readings and parks
+		// BEFORE any node runs. A hard cap with a known reset therefore
+		// closes the window here too; otherwise the walk re-grants the
+		// same capped credential on every retry while a usable lower
+		// tier sits unreached, and the park writes no refusal that would
+		// ever break the loop. Hard only: a soft cap warns, it does not
+		// park. A blocked window with NO reset instant stays usable —
+		// benching a credential with no reopening date would be a
+		// permanent skip on a utilization snapshot.
+		if d := usagecap.Preflight(readings, p.capPolicy.Effective(ctx), now, usagecap.DefaultMaxAge); d.Blocked && d.Stop && !d.ResetsAt.IsZero() {
+			until = d.ResetsAt
+			why = fmt.Sprintf("the operator's hard cap on the %s window is reached (%.0f%% ≥ %.0f%%)", d.Window, d.Percent, d.Cap)
 		}
 	}
 	return until, why


### PR DESCRIPTION
## The measured loop (2026-09-04, production)

A weekly forfait at **97% utilization** — provider still ALLOWING, operator hard cap 95, reset four days out — was granted by the resolution on **four consecutive retry attempts**. The runner's pre-flight parked each one in ~1s (`usagecap.Preflight` enforces the operator cap before any node runs), and because a park writes no refusal reading, no signal ever engaged the credential-tier fallback: a fresh org-tier forfait at ~0% sat unreached the whole time. Server logs per attempt: `oauth-forfait(user) used … fp=<walled>` → `run_parked … USAGE_LIMIT_BLOCKED`.

Root: the walk and the pre-flight answer different questions off the same readings — `refusedUntil` only honours `StatusRejected` (provider refusals), by a doctrine comment this PR deliberately supersedes: the week cap is the operator's machine-wide posture, the fallthrough tiers belong to the same operator, and the pre-flight parks either way.

## Two closures

1. **`refusedUntil` (the shared skip chokepoint — forfait tiers AND the BYOK api-key walk)**: when no provider refusal is on record, fall back to `usagecap.Preflight` over the same readings. A **hard** cap with a **known reset** closes the window; soft caps warn and never close; a blocked window with no reset instant stays usable (no permanent bench on a snapshot). `Config.CapPolicy` nil keeps the walk refusal-evidence-only — the shipped no-cap deployment is untouched.
2. **`classifyRateLimit` names the weekly window** on text-relayed refusals ("hit your weekly limit …"): both recording sites gate on the window name, so a REAL weekly refusal previously wrote no reading and was equally invisible to the walk. Only the weekly noun maps; session/bare-5h shapes keep `""` until they get a constant of their own.

## Falsified both ways

- Mutant A (fallback neutralized) → `TestForfaitWindowClosed_operatorHardCapFallsThrough` fails: *"the hard-capped forfait was handed over anyway"*.
- Mutant B (weekly detection broken) → both weekly `TestClassifyRateLimit` cases fail.
- Restored: 1207 tests green across the four touched packages (`cloudpublisher`, `delegate`, `usagecap`, `runner`).
- Guards under test: no-policy → granted; soft cap → granted; hard cap w/o reset → granted; hard cap w/ reset → falls through to the pool donor.

Closes #677. Related: #659 (the grant logs that made this diagnosable), #661, #668 (same starvation family, judge-node overrides — still open).