### PR TITLE
test(server): assert the readyz share invariant, not the ping count

### DIFF
--- a/pkg/server/health_test.go
+++ b/pkg/server/health_test.go
@@ -409,16 +409,37 @@ func TestReadyzNeverMisreportsAFinishedCheck(t *testing.T) {
 //
 // Mutation coverage: make the losing probe report "stalled" instead of
 // waiting on the shared result → 7 of these 8 come back 503.
+//
+// The oracle is "never two pings of one check IN FLIGHT AT ONCE", not "the
+// ping ran exactly once". The two differ only by scheduling: the pile-up
+// window below is a sleep, so on a loaded machine a goroutine can reach the
+// handler after the shared ping already answered, and legitimately start a
+// fresh one — the registry entry is deleted on completion precisely so the
+// next probe gets a fresh answer rather than a stale one. Asserting the
+// count made that a failure (seen in CI: "the check ran 3 times"), while the
+// property the pod's life depends on — one dependency, one concurrent ping,
+// so a driver that never returns cannot strand N goroutines — held
+// throughout. Measuring concurrency directly keeps the mutation coverage: a
+// losing probe that pings on its own instead of sharing puts 8 pings on the
+// blocked gate at once, and peak reads 8.
 func TestReadyzConcurrentProbesShareOneAnswer(t *testing.T) {
 	t.Parallel()
 
 	gate := make(chan struct{})
-	var launches atomic.Int32
+	var launches, live, peak atomic.Int32
 	srv := New(Config{
 		ReadinessTimeout: time.Second,
 		ReadinessChecks: map[string]ReadinessCheck{
 			"mongo": {Critical: true, Ping: func(ctx context.Context) error {
 				launches.Add(1)
+				n := live.Add(1)
+				for {
+					got := peak.Load()
+					if n <= got || peak.CompareAndSwap(got, n) {
+						break
+					}
+				}
+				defer live.Add(-1)
 				<-gate
 				return nil
 			}},
@@ -448,8 +469,15 @@ func TestReadyzConcurrentProbesShareOneAnswer(t *testing.T) {
 			break
 		}
 	}
-	if got := launches.Load(); got != 1 {
-		t.Errorf("the check ran %d times for %d overlapping probes, want 1 shared run", got, probes)
+	if got := peak.Load(); got != 1 {
+		t.Errorf("%d pings of one check were in flight at once, want 1 — overlapping probes must share the answer", got)
+	}
+	// Non-vacuity: with the ping held on the gate for the whole pile-up
+	// window, probes that arrive during it MUST share. All eight launching
+	// their own would mean nothing was ever shared and the peak above only
+	// read 1 because they ran one after another.
+	if got := launches.Load(); got >= probes {
+		t.Errorf("the check ran %d times for %d probes — nothing was shared", got, probes)
 	}
 }
 


### PR DESCRIPTION
## Why

`TestReadyzConcurrentProbesShareOneAnswer` asserted that eight overlapping `/readyz` probes launch the dependency check **exactly once**. That is stricter than the property the pod's life depends on, and it is scheduling-dependent: the pile-up window is a `time.Sleep`, so on a loaded machine a goroutine can reach the handler *after* the shared ping already answered and legitimately start a fresh one — the registry entry is deleted on completion precisely so a later probe gets a fresh answer rather than a stale one.

CI hit exactly that on the merge-queue build of #674 (`the check ran 3 times for 8 overlapping probes`), dropping a clean PR out of the queue while the dedupe was working correctly.

I filed #676 with the wrong hypothesis ("a registration window in the dedupe"). There is none: `LoadOrStore` is atomic, and a loser can only become a winner once the previous ping has completed and deleted its entry. The corrected diagnosis is above.

## What

The test now measures the real invariant directly: the **peak number of pings of one check in flight at once**, which must be 1. That is what keeps a driver that never returns from stranding N goroutines until the pod OOMKills — the failure the dedupe exists to prevent.

- Mutation coverage is preserved **and demonstrated**: with the `LoadOrStore` sharing disabled, all eight pings sit on the blocked gate together and the peak reads 8, failing the test.
- A second assertion keeps it non-vacuous (`launches < probes`), so eight sequential runs cannot pass it.
- **No production code changed** — `pkg/server/health.go` is untouched.

## Verification

```
go test ./pkg/server/ -run TestReadyzConcurrentProbesShareOneAnswer -count=20   → ok

# with the LoadOrStore sharing mutated to never share:
    health_test.go:473: 8 pings of one check were in flight at once, want 1
    health_test.go:480: the check ran 8 times for 8 probes — nothing was shared
```

`gofmt` + `go vet` clean.

Closes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)
