### PR TITLE
fix(docs-refresh): 3.5.7 — scan_hints stops manufacturing the same false positives every pass

### DIFF
--- a/bots/docs-refresh/main.bot
+++ b/bots/docs-refresh/main.bot
@@ -783,6 +783,14 @@ def slugify(text):
     s = re.sub(r'[^\w\s-]', '', s)
     s = re.sub(r'\s', '-', s)
     return s.strip('-')
+QT = chr(34)
+AP = chr(39)
+## An explicit HTML anchor is a link target as much as a heading is. A doc
+## that writes a heading as an anchor + text addresses it by the anchor,
+## and a heading-only collector calls every such link dead -- measured on
+## the 2026-09-04 prod run, where both dead_anchor hints pointed at
+## anchors written exactly that way.
+ANCHOR_RE = re.compile('<a[^>]*?(?:name|id)=[' + QT + AP + ']([^' + QT + AP + ']+)')
 def headings_of(path):
     if path in _heading_cache:
         return _heading_cache[path]
@@ -793,10 +801,33 @@ def headings_of(path):
                 hm = re.match(r'\s{0,3}(#{1,6})\s+(.+)', ln)
                 if hm:
                     slugs.add(slugify(hm.group(2)))
+                for am in ANCHOR_RE.finditer(ln):
+                    slugs.add(am.group(1).strip().lower())
     except (FileNotFoundError, IsADirectoryError, PermissionError):
         pass
     _heading_cache[path] = slugs
     return slugs
+## A link starting with / is SITE-absolute, not filesystem-absolute: every
+## static-site generator (VitePress, MkDocs, Docusaurus, Jekyll) routes it
+## from the site root, and its extensionless form is that generator's clean
+## URL for a page file. os.path.join DROPS everything left of an absolute
+## path, so resolving one the ordinary way asked the filesystem for /dsl
+## and reported it dead -- 20 of the 22 hints on the 2026-09-04 prod run,
+## every one false, and re-adjudicated by the agent on EVERY pass because
+## the dismissals ledger lives in a per-run scratch the cloud wipes.
+## Resolve against the docs root then the repo root, trying the generator
+## conventions; empty means unresolved, which the caller reports as a SOFT
+## signal since a generator rewrite may still serve it.
+def resolve_site_absolute(path_part):
+    rel = path_part.lstrip('/')
+    if not rel:
+        return ''
+    for root in (docs_dir, ''):
+        base = os.path.join(root, rel) if root else rel
+        for cand in (base, base + '.md', os.path.join(base, 'index.md'), os.path.join(base, 'README.md')):
+            if os.path.exists(cand):
+                return os.path.normpath(cand)
+    return ''
 ## A cited path that is missing on disk is a DRIFT signal only if git
 ## ever TRACKED it (current index or a path deleted somewhere in
 ## history): docs constantly cite example/placeholder paths under real
@@ -844,8 +875,14 @@ for doc in files:
                 continue
             seen.add(key)
             checked_links += 1
-            tgt = doc if not path_part else os.path.normpath(os.path.join(os.path.dirname(doc), path_part))
-            if path_part and not os.path.exists(tgt):
+            site_absolute = path_part.startswith('/')
+            if site_absolute:
+                tgt = resolve_site_absolute(path_part)
+            else:
+                tgt = doc if not path_part else os.path.normpath(os.path.join(os.path.dirname(doc), path_part))
+            if site_absolute and not tgt:
+                add_hint(doc, lineno, 'dead_link', target, 'site-absolute link resolves to no page under ' + (docs_dir or '.') + ' or the repo root (a generator rewrite may still serve it)')
+            elif path_part and not site_absolute and not os.path.exists(tgt):
                 add_hint(doc, lineno, 'dead_link', target, 'link target not found: ' + tgt)
             elif frag and not re.match(r'^[Ll][0-9]', frag) and tgt.endswith('.md') and frag.lower() not in headings_of(tgt):
                 add_hint(doc, lineno, 'dead_anchor', target, 'no heading matching #' + frag + ' in ' + tgt)

--- a/bots/docs-refresh/manifest.yaml
+++ b/bots/docs-refresh/manifest.yaml
@@ -1,7 +1,21 @@
 name: docs-refresh
 display_name: Doki
 icon: 📚
-version: 3.5.6
+version: 3.5.7
+## 3.5.7 — scan_hints stops manufacturing the same false positives every
+## pass. A link written `/dsl` is SITE-absolute: every static-site
+## generator routes it from the site root, but `os.path.join` drops
+## everything left of an absolute path, so the scanner asked the
+## filesystem for `/dsl` and called it dead. On the 2026-09-04 prod run
+## that was 20 of 22 hints, all false; the other 2 were explicit HTML
+## anchors the heading-only collector could not see. The agent verified
+## and ledgered them on EVERY pass, and the ledger lives in a per-run
+## scratch the cloud wipes, so the waste repeated on every run. Site-
+## absolute links now resolve against the docs root then the repo root
+## through the generator conventions, and explicit `<a name>` / `id`
+## anchors count as link targets. A site-absolute link that resolves
+## nowhere is still surfaced, with a note saying a generator rewrite may
+## serve it — precision, not silence.
 ## 3.5.6 — the schedule invocation carries its own vars. A scheduled run on
 ## a cloud clone can only deliver through the PR tail, and a weekly is only
 ## affordable as an incremental pass — yet a schedule row created (or

--- a/bots/docs_refresh_hints_test.go
+++ b/bots/docs_refresh_hints_test.go
@@ -102,6 +102,72 @@ func TestDocsRefreshHintsProducer(t *testing.T) {
 		}
 	}
 
+	t.Run("site_absolute_links_and_html_anchors_are_not_dead", func(t *testing.T) {
+		// The two noise classes measured on prod run 01a055f9 (2026-09-04):
+		// 20 of its 22 hints were root-absolute links a static-site
+		// generator routes from the site root, and both "dead anchors"
+		// pointed at explicit HTML anchors. The agent re-adjudicated all of
+		// them on EVERY pass, because the dismissals ledger lives in a
+		// per-run scratch the cloud wipes — so the waste repeats forever
+		// until the scanner stops emitting them.
+		ws := t.TempDir()
+		write(t, ws, "docs/index.md", `# Docs
+
+Start with the [DSL](/dsl) and the [plugins](/plugins).
+Deploy with the [cloud overview](/cloud-overview), then read
+[the webhooks re-request lane](/webhooks#re-request-review).
+A folder page: [references](/references).
+`)
+		write(t, ws, "docs/dsl.md", "# DSL\n")
+		write(t, ws, "docs/plugins.md", "# Plugins\n")
+		write(t, ws, "docs/cloud-overview.md", "# Cloud overview\n")
+		write(t, ws, "docs/references/index.md", "# References\n")
+		// The heading carries its anchor as explicit HTML, exactly as
+		// docs/webhooks.md does upstream: the slug of the heading TEXT is
+		// not the anchor, so only an anchor-aware collector resolves it.
+		write(t, ws, "docs/webhooks.md", `# Webhooks
+
+### <a name="re-request-review"></a>Re-request a review
+
+Body.
+`)
+		got := run(t, ws, "", nil)
+
+		for _, h := range got.Hints {
+			if h.Kind == "dead_link" || h.Kind == "dead_anchor" {
+				t.Errorf("%s on %q (%s): a link a generator resolves must not be reported — %s",
+					h.Kind, h.Value, h.Doc, h.Note)
+			}
+		}
+		if got.CheckedLinks == 0 {
+			t.Fatal("no link was checked at all — the fixture would pass vacuously")
+		}
+	})
+
+	t.Run("site_absolute_link_to_nothing_stays_a_soft_signal", func(t *testing.T) {
+		// Precision is not silence: a site-absolute link that resolves to no
+		// page anywhere is still worth surfacing. The note must say the
+		// resolution is soft, because a generator rewrite can serve a route
+		// that has no page file — that honesty is what lets the agent judge
+		// instead of trusting the scanner.
+		ws := t.TempDir()
+		write(t, ws, "docs/index.md", "# Docs\n\nSee [the ghost](/no-such-page).\n")
+		got := run(t, ws, "", nil)
+
+		var found bool
+		for _, h := range got.Hints {
+			if h.Kind == "dead_link" && h.Value == "/no-such-page" {
+				found = true
+				if !strings.Contains(h.Note, "rewrite may still serve it") {
+					t.Errorf("the note must flag the signal as soft, got %q", h.Note)
+				}
+			}
+		}
+		if !found {
+			t.Error("a site-absolute link resolving to no page must still be surfaced")
+		}
+	})
+
 	t.Run("foreign_flag_examples_produce_zero_noise", func(t *testing.T) {
 		// The exact noise class that burned ~40 min on live run 019f8b50:
 		// docs quoting OTHER tools' flags. v3 must surface NOTHING here.


### PR DESCRIPTION
## Why

Prod run `01a055f9` (2026-09-04) reported 22 advisory hints. The campaign verified every one of them and found **all 22 false**:

- **20 dead links** were root-absolute links (`/dsl`, `/plugins`, `/cloud-overview`…). A link written `/dsl` is SITE-absolute: every static-site generator routes it from the site root. But `os.path.join` **drops everything left of an absolute path**, so `scan_hints` asked the filesystem for `/dsl`, found nothing, and called it dead.
- **2 dead anchors** pointed at explicit HTML anchors (`### <a name="re-request-review"></a>…`), which the heading-only slug collector cannot see.

The cost is not one wasted pass. The campaign re-verified and re-ledgered the same 22 on **every** pass, and the dismissals ledger lives in a per-run scratch directory the cloud wipes between runs. So the adjudication repeated on every pass of every run, indefinitely.

## What

- **Site-absolute links resolve like a generator routes them**: against `docs_dir` first, then the repo root, trying the conventions every generator shares — the exact path, `+ .md`, `/index.md`, `/README.md`.
- **Explicit `<a name="…">` / `id="…"` anchors are link targets** alongside heading slugs.
- **A site-absolute link that resolves nowhere is still surfaced**, with a note saying a generator rewrite may serve it. Precision, not silence: the honest note is what lets the agent judge instead of trusting the scanner.

Repo-agnostic by construction: nothing here names VitePress or any other generator, and the resolution falls back to the repo root when a project has no `docs_dir`.

## Verification

Two new subtests on real fixtures, run through the extracted `scan_hints` command exactly as the engine runs it.

Red-first, against the unfixed scanner:

```
--- FAIL: .../site_absolute_links_and_html_anchors_are_not_dead
    dead_link on "/dsl" ... link target not found: /dsl
    dead_link on "/plugins" ... link target not found: /plugins
    dead_link on "/cloud-overview" ... link target not found: /cloud-overview
    dead_link on "/webhooks#re-request-review" ... link target not found: /webhooks
    dead_link on "/references" ... link target not found: /references
--- FAIL: .../site_absolute_link_to_nothing_stays_a_soft_signal
```

Green with it, and the whole `./bots/` package passes (catalog freshness, universality, bundle consistency included). `iterion validate` OK, 10 nodes / 13 edges.

Manifest bumped to 3.5.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
