### PR TITLE
fix(credentials): the wants a run actually needs, and a refusal that says why

### DIFF
--- a/cmd/iterion/runner.go
+++ b/cmd/iterion/runner.go
@@ -317,14 +317,14 @@ func runRunner(cmd *cobra.Command, _ []string) error {
 		// BYOK store shared with the publisher — the runner bumps
 		// `last_used_at` at metering time so the studio distinguishes an
 		// idle key from one currently serving (#659 pt 2).
-		ApiKeys: secrets.NewMongoApiKeyStore(st.DB()),
-		MemoryStore:         memStore,
-		OrgUsage:            orgUsageCounter,
-		CredPool:            credBroker,
-		UsageCapSource:      usageCapSource,
-		UsageCaps:           usageCapStore,
-		BotsPaths:           botsPaths,
-		BotSources:          botsource.NewMongoStore(st.DB()),
+		ApiKeys:        secrets.NewMongoApiKeyStore(st.DB()),
+		MemoryStore:    memStore,
+		OrgUsage:       orgUsageCounter,
+		CredPool:       credBroker,
+		UsageCapSource: usageCapSource,
+		UsageCaps:      usageCapStore,
+		BotsPaths:      botsPaths,
+		BotSources:     botsource.NewMongoStore(st.DB()),
 		// Sandbox-by-default: the runner is a product entry point like
 		// `iterion run` — an unset ITERION_SANDBOX_DEFAULT resolves to
 		// auto. Discovered live (run 019f8a05): lifting the chart's

--- a/cmd/iterion/runner.go
+++ b/cmd/iterion/runner.go
@@ -314,6 +314,10 @@ func runRunner(cmd *cobra.Command, _ []string) error {
 		RunSecrets:          runSecretsStore,
 		Sealer:              sealer,
 		GenericSecrets:      secrets.NewMongoGenericSecretStore(st.DB()),
+		// BYOK store shared with the publisher — the runner bumps
+		// `last_used_at` at metering time so the studio distinguishes an
+		// idle key from one currently serving (#659 pt 2).
+		ApiKeys: secrets.NewMongoApiKeyStore(st.DB()),
 		MemoryStore:         memStore,
 		OrgUsage:            orgUsageCounter,
 		CredPool:            credBroker,

--- a/docs/byok.md
+++ b/docs/byok.md
@@ -49,7 +49,7 @@ One document per key, sealed at rest. [pkg/secrets/byok.go](../pkg/secrets/byok.
 | `last4` / `fingerprint` | shown in UI; the key itself is never returned. `fingerprint` is `FingerprintSHA256(plaintext)` — the audit identity the run document, the GRANTED log line and the metering bump all key on; indexed (sparse) by `EnsureSchema` |
 | `sealed_secret` | the ciphertext (`SealAPIKey(sealer, keyID, plaintext)`); JSON-hidden (`json:"-"`) |
 | `is_default` | the default for its `(team, user, provider)` tuple — `ClearDefault` keeps it unique |
-| `last_used_at` | best-effort observability: bumped by id at resolution (`MarkUsed`, detached off the launch path) and by **fingerprint** at the START and END of every runner attempt (`MarkFingerprintUsed`, no tenant filter — a lent or platform key moves on its own row). Nothing moves it during a turn, so a long attempt shows its start until it ends |
+| `last_used_at` | best-effort observability: bumped by id at resolution (`MarkUsed`, detached off the launch path) and by **fingerprint** at the START and END of every runner attempt (`MarkFingerprintUsed`, no tenant filter — a lent or platform key moves on its own row). The start stamp lands once the run is ADMITTED, after the usage-cap pre-flight: a run parked on a ceiling never held the key and never dates it. Nothing moves it during a turn, so a long attempt shows its start until it ends |
 | `expires_at` | optional |
 
 - Interface: `ApiKeyStore` (Create/Get/GetOwned/Update/Delete/ListByTeam/ListByUser/MarkUsed/MarkFingerprintUsed/ClearDefault) — [pkg/secrets/byok.go](../pkg/secrets/byok.go). `GetOwned` is the credential pool's cross-tenant read, bounded by ownership; `MarkFingerprintUsed` the runner's metering bump.

--- a/docs/byok.md
+++ b/docs/byok.md
@@ -46,13 +46,14 @@ One document per key, sealed at rest. [pkg/secrets/byok.go](../pkg/secrets/byok.
 | `scope_user` | set ⇒ user-scoped (personal); empty ⇒ **org-wide** |
 | `provider` | `anthropic` \| `openai` \| `bedrock` \| `vertex` \| `azure` \| `openrouter` \| `xai` \| `zai` ([byok.go:50-63](../pkg/secrets/byok.go#L50)) |
 | `name` | human label |
-| `last4` / `fingerprint` | shown in UI; the key itself is never returned |
+| `last4` / `fingerprint` | shown in UI; the key itself is never returned. `fingerprint` is `FingerprintSHA256(plaintext)` — the audit identity the run document, the GRANTED log line and the metering bump all key on; indexed (sparse) by `EnsureSchema` |
 | `sealed_secret` | the ciphertext (`SealAPIKey(sealer, keyID, plaintext)`); JSON-hidden (`json:"-"`) |
 | `is_default` | the default for its `(team, user, provider)` tuple — `ClearDefault` keeps it unique |
-| `last_used_at` | best-effort observability (`MarkUsed`, fired detached off the launch path) |
+| `last_used_at` | best-effort observability: bumped by id at resolution (`MarkUsed`, detached off the launch path) and by **fingerprint** at the START and END of every runner attempt (`MarkFingerprintUsed`, no tenant filter — a lent or platform key moves on its own row). Nothing moves it during a turn, so a long attempt shows its start until it ends |
 | `expires_at` | optional |
 
-- Interface: `ApiKeyStore` (Create/Get/Update/Delete/ListByTeam/ListByUser/MarkUsed/ClearDefault) — [byok.go:112](../pkg/secrets/byok.go#L112).
+- Interface: `ApiKeyStore` (Create/Get/GetOwned/Update/Delete/ListByTeam/ListByUser/MarkUsed/MarkFingerprintUsed/ClearDefault) — [pkg/secrets/byok.go](../pkg/secrets/byok.go). `GetOwned` is the credential pool's cross-tenant read, bounded by ownership; `MarkFingerprintUsed` the runner's metering bump.
+- Ingestion gate: the create and rotate routes refuse (`400`) a value whose shape could not authenticate — [`secrets.ValidateAPIKeyShape`](../pkg/secrets/credential_shape.go): a bearer token with any white-space, control or invisible character for the bearer providers; anything but a JSON object for `bedrock` / `vertex`, whose credential is a document. See the ingestion-gate section of [cloud-llm-credentials.md](cloud-llm-credentials.md).
 - Backings: `MongoApiKeyStore` (prod) + `MemoryApiKeyStore` (tests).
 - Wired in the server at [cmd/iterion/server.go:193](../cmd/iterion/server.go#L193) (`NewMongoApiKeyStore(st.DB())` + `EnsureSchema`), handed to both the HTTP server (`ApiKeys:` config) and the cloud publisher.
 

--- a/docs/cloud-llm-credentials.md
+++ b/docs/cloud-llm-credentials.md
@@ -116,6 +116,36 @@ OpenAI's ChatGPT-forfait has never had an equivalent restriction.
   Re-run `codex login` with "Sign in with ChatGPT" and upload the file
   unedited.
 
+## Ingestion gate — what a `400` on provisioning means
+
+Both provisioning paths refuse, at write time, a credential whose SHAPE could
+not authenticate — the two paid failures were a terminal transcript pasted as
+an accessToken and a bare record the CLI reads as "Not logged in", each
+accepted silently and each burning a fleet of runs on 401s before the cause
+was found (#627). The gate is
+[`secrets.ValidateTokenShape` / `ValidateAPIKeyShape`](../pkg/secrets/credential_shape.go):
+
+- **A bearer token is one run of visible characters.** Any white-space
+  (ASCII or not — a no-break space glued on by a rendered page counts), any
+  control, format or non-printing rune, NUL, invalid UTF-8: refused, naming
+  the rune and its position, never the value.
+- **Providers whose credential is a JSON document** (`bedrock`, `vertex` —
+  [`Provider.CredentialIsJSON`](../pkg/secrets/byok.go)) must send a JSON
+  **object**; the token rule does not apply to them.
+- **A pasted `claude_code` credentials.json** must carry `expiresAt` and a
+  non-empty `scopes` (absent → the CLI considers itself logged out). An
+  expired `accessToken` is refused **only when the record has no
+  `refreshToken`**; with one, the record is accepted and the refresh worker
+  renews it. The browser flow builds its own blob from the token exchange and
+  is held to the token-shape check only (an exchange may answer without an
+  expiry or a scope).
+- **Codex `auth.json`**: the token-shape check on `tokens.access_token`.
+
+A refusal answers `400` with the reason, and leaves a trace an operator can
+find after the fact: a `Warn` in the server log and an audit event
+(`byok.refused`, `oauth.org.refused`, `platform.llm_*.refused`) naming the
+field and the reason — never the value. Nothing is stored on a refusal.
+
 ## Provisioning cookbook (via `iterion remote`, authenticated)
 
 ```sh
@@ -124,14 +154,18 @@ iterion remote api-keys create --provider anthropic --name mykey --from-file ~/a
 iterion remote api-keys create --provider openai   --name mykey --from-file ~/openai.key
 
 # Anthropic OAuth-forfait (cloud upload reaches claude_code and claw;
-# pi bridge pending) — send the WHOLE credentials.json. A body carrying only
-# accessToken is accepted but stored
-# NON-refreshable (`sealOAuthRecord` sets NotRefreshable when refreshToken is
-# absent), so the connection dies silently at the next token expiry:
+# pi bridge pending) — send the WHOLE credentials.json. The server REFUSES
+# (400, see "Ingestion gate" below) a claude_code paste missing expiresAt or
+# scopes (the shape the CLI reads as "Not logged in") and a body without a
+# refreshToken whose token has already expired; a body with a refreshToken
+# is accepted even when the token has expired — the refresh worker renews
+# it on its next pass:
 iterion remote api POST /api/me/oauth/claude_code/credentials \
   --data "@$HOME/.claude/.credentials.json"
 # (Linux/WSL path. On macOS Claude Code keeps these in the Keychain, so there
-#  may be no file to read until you export it.)
+#  may be no file to read until you export it. Run any `claude` command first
+#  so the file is fresh: a stale export carries a refreshToken and connects,
+#  but the first refresh is what makes it serve.)
 
 # OpenAI ChatGPT-forfait (claw + openai/* model) — the Codex auth.json.
 # Note `"@$HOME/…"`, not `@~/…`: the shell only expands a tilde at the START

--- a/docs/credential-pool.md
+++ b/docs/credential-pool.md
@@ -75,6 +75,21 @@ A pledge only ever answers a request for its OWN source and ref: a
 subscription never stands in for a metered key, because they are billed to
 different places.
 
+**What the run is asked for** (`wantsFor`, over
+[`model.EffectiveProviders`](../pkg/backend/model/override_fold.go)) is
+narrowed to the providers the run's routes actually pin — the DSL under the
+launch's model overrides, node `fallbacks:` routes and the run-level
+`--fallback` chain, read the way the executor reads them (`${VAR}` expanded,
+chains split, `provider:model` steps). The narrowing is exact per provider
+because the delegates are: a `zai` hint spends a z.ai key and nothing else,
+`anthropic` the Anthropic key or the claude_code forfait. And it **fails
+open**: one route the walk cannot name — a node with no pin, an explicit
+`auto`, a `${VAR}` empty on the server, a hint nobody knows, a model-answering
+node with no `LLMFields` — widens the request back to the full order, because
+that route takes whatever the process holds. A pin that matches no known
+provider is named in a `Warn` (`asked for the FULL order … provider hint(s)
+match no known provider`) rather than skipping the tier.
+
 ## Enforcement: the run's own budget is the ceiling
 
 A grant carries the donor's **remaining allowance**, and the launch clamps
@@ -104,6 +119,29 @@ its sharing window, or when the requested bot is not in its allow-list.
 Among the rest, selection ranks by the **fraction of what each donor
 offered** that has been consumed today — so a modest pledge is not drained
 before a generous one — with least-recently-served as the tie-break.
+
+**When nobody serves, the server log says why** — once, at the moment the
+abstention is final, at `Warn` (the level that survives
+`ITERION_LOG_LEVEL=info`). The broker returns a typed
+`credpool.NoDonorError` (unwrapping to `ErrNoDonor`) and the publisher
+renders it:
+
+```
+credential pool declined run <id> — reason=no_eligible_pledge pools_enabled=2 pools_admitted=1 pledges_considered=1 skips=<pledge-id>:paused wants=oauth:claude_code,…
+```
+
+`pools_enabled` is every enabled pool, `pools_admitted` those whose audience
+opened to the request, `pledges_considered` only the pledges of a kind the
+run asked for, and `skips` names each considered pledge with the state that
+held it out: `paused`, `unhealthy`, `out_of_hours`, `bot_filtered`,
+`cooling`, `exhausted` (a ceiling really spent), `serving` (every slot busy,
+or a ceiling met while the donor has runs in flight). `audience_rejected`
+gets the same treatment. Two reasons are static configuration and log at
+`Debug` instead — `pool_disabled` (no broker wired) and `no_enabled_pool` —
+so a platform-funded deployment without a pool does not page the error
+tracker on every launch. The definitive signal for a run that resolved
+**no credential at all** (every tier abstained, on a workflow that can call
+a model) is one `Warn` at the end of resolution naming the tiers consulted.
 
 Two states are set from a run's outcome:
 

--- a/docs/usage-caps.md
+++ b/docs/usage-caps.md
@@ -217,6 +217,22 @@ cap is blocking, so the common case pays nothing). The mid-run guard stays
 armed in both cases, so a workflow that turns out to spend anyway is still
 stopped at the call.
 
+**And only when it could spend the wire the cap meters.** The readings come
+from the claude_code delegate's session telemetry and nowhere else, and the
+pre-flight key is built from the run's Anthropic-wire credentials (or the
+platform's). A run whose every route is pinned off that wire — both LLM nodes
+on `claw` + `openai/…`, a `codex` bot — cannot spend the capped subscription,
+and parking it for the anthropic weekly reset strands it for nothing: a fully
+pinned two-node rite froze for five days that way while its single-node
+sibling on the identical pin ran (#668). The cloud runner's pre-flight asks
+[`model.AnthropicWireReachable`](../pkg/backend/model/wire_reach.go) under the
+launch's own overrides and fallback chain, and lets the run through when the
+answer is no. Every uncertainty answers "reachable" and keeps the guard
+armed: an empty, `auto` or `claude_code` backend, `claw`/`pi` with a provider
+it cannot resolve, any `anthropic`/`zai` hint on any backend, a
+model-answering node with no `LLMFields`, a `fallbacks:` route or run-level
+`--fallback` stage with any of those.
+
 ## Cloud
 
 Every pod sees only its own session, so readings are shared through the

--- a/docs/usage-caps.md
+++ b/docs/usage-caps.md
@@ -226,12 +226,21 @@ and parking it for the anthropic weekly reset strands it for nothing: a fully
 pinned two-node rite froze for five days that way while its single-node
 sibling on the identical pin ran (#668). The cloud runner's pre-flight asks
 [`model.AnthropicWireReachable`](../pkg/backend/model/wire_reach.go) under the
-launch's own overrides and fallback chain, and lets the run through when the
-answer is no. Every uncertainty answers "reachable" and keeps the guard
-armed: an empty, `auto` or `claude_code` backend, `claw`/`pi` with a provider
-it cannot resolve, any `anthropic`/`zai` hint on any backend, a
-model-answering node with no `LLMFields`, a `fallbacks:` route or run-level
-`--fallback` stage with any of those.
+launch's own overrides, and lets the run through when the answer is no. Every
+uncertainty answers "reachable" and keeps the guard armed: an empty, `auto` or
+`claude_code` backend, `claw`/`pi` with a provider it cannot resolve, any
+`anthropic`/`zai` hint on any backend, a model-answering node with no
+`LLMFields`.
+
+**Primary routes only.** A `fallbacks:` route or a run-level `--fallback`
+stage onto the wire does not arm the pre-flight: the primary can carry the
+whole run without ever touching the wire, and the rescue route fires only on
+a failure the mid-run guard and the delegate's own usage-window
+classification already refuse at dispatch. Refusing such a run in advance
+would park work that could not possibly spend the capped subscription — the
+one thing the pre-flight promises not to do. The credential the rescue route
+needs is still sealed into the run: the wants derivation widens on the chain,
+it is only this guard that ignores it.
 
 ## Cloud
 

--- a/pkg/backend/model/override_fold.go
+++ b/pkg/backend/model/override_fold.go
@@ -211,18 +211,13 @@ func (a *providerAccumulator) resolveRoute(provider, mdl string) {
 // EVERY step resolved to a known provider (an empty field, an "auto"
 // step, an empty ${VAR} or an unknown name all answer false).
 func (a *providerAccumulator) chain(raw string) bool {
-	expanded := strings.TrimSpace(ir.ExpandEnvWithDefault(raw))
-	if expanded == "" {
-		return false
+	hints, unresolved := chainHints(raw)
+	if unresolved {
+		a.narrowSafe = false
 	}
-	resolved := true
-	for _, part := range strings.Split(expanded, ",") {
-		token := strings.TrimSpace(part)
-		if token == "" {
-			continue // stray, leading or trailing comma
-		}
-		hint, _, _ := ir.SplitProviderStep(token)
-		if !a.hint(hint) {
+	resolved := !unresolved
+	for _, h := range hints {
+		if !a.hint(h) {
 			resolved = false
 		}
 	}
@@ -245,6 +240,35 @@ func (a *providerAccumulator) hint(raw string) bool {
 		a.narrowSafe = false
 		return false
 	}
+}
+
+// chainHints splits a `provider:` field into its lower-cased hints the
+// way the executor's resolveProviderChain does: env expansion on the whole
+// field first, then `,`, then the `provider:model` step form. Reports
+// unresolved=true when the field is empty or any step is "auto" — a step
+// that defers to whatever the process holds.
+func chainHints(raw string) (hints []string, unresolved bool) {
+	expanded := strings.TrimSpace(ir.ExpandEnvWithDefault(raw))
+	if expanded == "" {
+		return nil, true
+	}
+	for _, part := range strings.Split(expanded, ",") {
+		token := strings.TrimSpace(part)
+		if token == "" {
+			continue // stray, leading or trailing comma
+		}
+		hint, _, _ := ir.SplitProviderStep(token)
+		hint = strings.ToLower(strings.TrimSpace(hint))
+		if hint == "" || hint == "auto" {
+			unresolved = true
+			continue
+		}
+		hints = append(hints, hint)
+	}
+	if len(hints) == 0 {
+		unresolved = true
+	}
+	return hints, unresolved
 }
 
 // providerFromModelPrefix extracts the provider half of a

--- a/pkg/backend/model/override_fold.go
+++ b/pkg/backend/model/override_fold.go
@@ -105,6 +105,14 @@ func EffectiveProviders(wf *ir.Workflow, overrides ModelOverrides, runFallbacks 
 		}
 		seenAnyLLM = true
 		acc.resolveNode(n, fields, overrides)
+		// `interaction: llm|llm_or_human` answers the node's questions
+		// with a DIRECT generation on `interaction_model` (falling back
+		// to the node's model) — a second route the node may spend on.
+		if inf, ok := n.(interface{ GetInteractionFields() *ir.InteractionFields }); ok {
+			if f := inf.GetInteractionFields(); f != nil && (f.Interaction == ir.InteractionLLM || f.Interaction == ir.InteractionLLMOrHuman) {
+				acc.resolveDirect(f.InteractionModel, fields.Model)
+			}
+		}
 		// A `fallbacks:` route (ADR-087) is a path the run may take: a
 		// primary on claw/openai whose rescue is anthropic MUST be able
 		// to spend an anthropic credential, or the route is unreachable.
@@ -170,58 +178,80 @@ func (a *providerAccumulator) result() ProviderResolution {
 	return res
 }
 
-// resolveNode applies the executor's precedence to one LLM node: a
-// provider override collapses the chain; else a `provider/` prefix on the
-// effective model (override, then DSL) pins; else the DSL `provider:`
-// chain, expanded then split. Anything the walk cannot resolve widens.
+// resolveNode applies the executor's precedence to one LLM node, in the
+// executor's order: a launch-time provider override collapses the chain;
+// else the DSL `provider:` chain decides — the hint IS the route, and the
+// model's `provider/` prefix says nothing about which credential is spent
+// (claude_code strips `anthropic/` and, on a `zai` hint, spends ONLY the
+// z.ai key; pi's documented z.ai form is `model: "anthropic/glm-5.2"` +
+// `provider: "zai"`, the hint overriding the prefix); only a node with no
+// hint at all routes on the prefix of its effective model (override, then
+// DSL), the way claw's registry does. Anything the walk cannot resolve
+// widens.
 func (a *providerAccumulator) resolveNode(node ir.Node, fields *ir.LLMFields, overrides ModelOverrides) {
 	ov := overrides.ForNode(node.NodeID(), node.NodeKind())
 	if strings.TrimSpace(ov.Provider) != "" {
 		a.hint(ov.Provider)
 		return
 	}
+	if a.chainDecides(fields.Provider) {
+		return
+	}
 	mdl := ov.Model
 	if mdl == "" {
 		mdl = fields.Model
 	}
-	if p := providerFromModelPrefix(mdl); p != "" {
-		a.hint(p)
-		return
-	}
-	if !a.chain(fields.Provider) {
-		a.narrowSafe = false
-	}
+	a.prefixOrWiden(mdl)
 }
 
-// resolveRoute is the fallback-route half: a `provider:model` step has
-// the same two sources as a node (a hint, or a model prefix). A route
-// that pins neither inherits whatever the process holds, which the walk
-// cannot name — widen.
+// resolveRoute is the fallback-route half, with the same precedence: the
+// route's own hint decides; a route without one routes on its model's
+// prefix; one that pins neither inherits whatever the process holds,
+// which the walk cannot name — widen.
 func (a *providerAccumulator) resolveRoute(provider, mdl string) {
-	if p := providerFromModelPrefix(mdl); p != "" {
-		a.hint(p)
+	if a.chainDecides(provider) {
 		return
 	}
-	if !a.chain(provider) {
-		a.narrowSafe = false
-	}
+	a.prefixOrWiden(mdl)
 }
 
-// chain resolves a `provider:` field the executor's way. Reports whether
-// EVERY step resolved to a known provider (an empty field, an "auto"
-// step, an empty ${VAR} or an unknown name all answer false).
-func (a *providerAccumulator) chain(raw string) bool {
+// resolveDirect is the direct-generation half (an `interaction_model`):
+// no hint applies there, the model spec alone routes — its own prefix,
+// or the node model's when it is empty.
+func (a *providerAccumulator) resolveDirect(interactionModel, nodeModel string) {
+	mdl := interactionModel
+	if strings.TrimSpace(mdl) == "" {
+		mdl = nodeModel
+	}
+	a.prefixOrWiden(mdl)
+}
+
+// chainDecides records a `provider:` chain's hints and reports whether the
+// chain named at least one — in which case it IS the route and the caller
+// looks no further. A chain with hints AND an unresolved step ("auto", an
+// empty ${VAR}) still decides, and still widens.
+func (a *providerAccumulator) chainDecides(raw string) bool {
 	hints, unresolved := chainHints(raw)
+	if len(hints) == 0 {
+		return false
+	}
 	if unresolved {
 		a.narrowSafe = false
 	}
-	resolved := !unresolved
 	for _, h := range hints {
-		if !a.hint(h) {
-			resolved = false
-		}
+		a.hint(h)
 	}
-	return resolved
+	return true
+}
+
+// prefixOrWiden routes on a model spec's `provider/` prefix, or widens
+// when it has none.
+func (a *providerAccumulator) prefixOrWiden(mdl string) {
+	if p := providerFromModelPrefix(mdl); p != "" {
+		a.hint(p)
+		return
+	}
+	a.narrowSafe = false
 }
 
 // hint classifies one provider name. Known → recorded, true. Empty or

--- a/pkg/backend/model/override_fold.go
+++ b/pkg/backend/model/override_fold.go
@@ -1,0 +1,258 @@
+package model
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+)
+
+// OverrideEntry is the neutral shape every model-override folder passes
+// in. `runview.ModelOverrideEntry`, `store.RunModelOverride` and
+// `queue.ModelOverride` are field-identical — a tiny adapter per site
+// beats importing three types here.
+type OverrideEntry struct {
+	Selector string
+	Backend  string
+	Model    string
+	Provider string
+}
+
+// OverridesFrom folds neutral entries into the executor's per-node
+// overrides. It is the ONE fold: runview (launch), the cloud publisher
+// (launch + resume) and the runner (wire) all adapt onto it, so a cloud
+// run resolves per-node models exactly like a local launch with the same
+// flags — and a judge-kind selector cannot be honoured on one surface and
+// dropped on another (#668).
+func OverridesFrom(entries []OverrideEntry) ModelOverrides {
+	var o ModelOverrides
+	for _, e := range entries {
+		if e.Backend != "" {
+			o.SetBackend(e.Selector, e.Backend)
+		}
+		if e.Model != "" {
+			o.SetModel(e.Selector, e.Model)
+		}
+		if e.Provider != "" {
+			o.SetProvider(e.Selector, e.Provider)
+		}
+	}
+	return o
+}
+
+// FallbackEntry is the neutral run-level fallback-chain shape the
+// derivation consumes. `runview.FallbackEntry`, `store.RunFallbackEntry`
+// and `queue.RunFallbackEntry` are field-identical on (Backend, Model,
+// Provider); a per-node `fallbacks:` block is read directly through
+// `ir.LLMNode.GetFallbacks()` and does not use this type.
+type FallbackEntry struct {
+	Backend  string
+	Model    string
+	Provider string
+}
+
+// ProviderResolution is what EffectiveProviders learned about a run.
+type ProviderResolution struct {
+	// Providers is the union of KNOWN provider names some route of the
+	// run may spend: every LLM node under its overrides, every node
+	// `fallbacks:` route, the run-level chain. Sorted, deduplicated,
+	// lower-cased. Names the caller does not know never enter it.
+	Providers []string
+	// NarrowSafe is false when some route the run may take could not be
+	// resolved to a known provider: an LLM node with no pin, an explicit
+	// "auto", a ${VAR} empty at resolution time, a hint the caller does
+	// not know, a model-calling node that carries no LLMFields at all
+	// (a human node answering with a model, a subbot), or a fallback
+	// route that pins nothing. A caller NARROWING a request on Providers
+	// must fail OPEN when it is false — treat the run as able to spend
+	// every provider — because a node that resolved to nothing takes
+	// whatever credential the process holds (claw substitutes the first
+	// available provider; claude_code walks its bundle precedence).
+	NarrowSafe bool
+	// Unknown lists the hints that named something and matched no known
+	// provider — a typo in `provider:`, a model prefix the pool never
+	// lends — so the caller can say WHICH pin made it widen. Sorted.
+	Unknown []string
+}
+
+// EffectiveProviders is the walk every "which providers does this run
+// actually target?" question goes through — the pool's wants derivation
+// and any future site that needs the answer. It reads the DSL under
+// launch-time overrides, node `fallbacks:` blocks and the run-level
+// fallback chain, resolved like the executor's own resolveProviderChain:
+// `ir.ExpandEnvWithDefault` → split on `,` → `ir.SplitProviderStep` →
+// `auto` means unresolved. A provider override collapses the chain; a
+// `provider/model` prefix on the effective model counts as a pin.
+//
+// `known` is the caller's provider vocabulary. A nil `wf` or an empty
+// `known` yields the zero value (NarrowSafe false), which every caller
+// reads as "fail open".
+func EffectiveProviders(wf *ir.Workflow, overrides ModelOverrides, runFallbacks []FallbackEntry, known map[string]bool) ProviderResolution {
+	if wf == nil || len(known) == 0 {
+		return ProviderResolution{}
+	}
+	acc := &providerAccumulator{known: known, providers: map[string]bool{}, unknown: map[string]bool{}, narrowSafe: true}
+	seenAnyLLM := false
+	for _, n := range wf.Nodes {
+		fields, ok := llmFieldsOf(n)
+		if !ok {
+			if ir.NodeUsesLLM(n) {
+				// Spends, but exposes nothing to resolve.
+				seenAnyLLM = true
+				acc.narrowSafe = false
+			}
+			continue
+		}
+		seenAnyLLM = true
+		acc.resolveNode(n, fields, overrides)
+		// A `fallbacks:` route (ADR-087) is a path the run may take: a
+		// primary on claw/openai whose rescue is anthropic MUST be able
+		// to spend an anthropic credential, or the route is unreachable.
+		if gf, ok := n.(interface{ GetFallbacks() []ir.Fallback }); ok {
+			for _, fb := range gf.GetFallbacks() {
+				if fb.Action == ir.FallbackActionSkip {
+					continue // executes nothing
+				}
+				acc.resolveRoute(fb.Provider, fb.Model)
+			}
+		}
+	}
+	if !seenAnyLLM {
+		// Nothing spends: nothing to narrow on, and nothing unresolved.
+		return ProviderResolution{NarrowSafe: true}
+	}
+	// The run-level chain (`--fallback` / spec.Fallback / prior.Fallback)
+	// lands on every agent node through ir.ApplyRunFallback — the same
+	// reasoning as an authored route.
+	for _, fb := range runFallbacks {
+		if fb.Backend == "" && fb.Model == "" && fb.Provider == "" {
+			continue // ApplyRunFallback drops the empty stage too
+		}
+		acc.resolveRoute(fb.Provider, fb.Model)
+	}
+	return acc.result()
+}
+
+// llmFieldsOf returns the LLMFields a node resolves its route from: agent
+// and judge nodes always, a router only in its `llm` mode (its embedded
+// fields are empty otherwise, and the deterministic modes spend nothing).
+func llmFieldsOf(n ir.Node) (*ir.LLMFields, bool) {
+	switch node := n.(type) {
+	case *ir.RouterNode:
+		if node.RouterMode == ir.RouterLLM {
+			return &node.LLMFields, true
+		}
+		return nil, false
+	}
+	if f, ok := n.(interface{ GetLLMFields() *ir.LLMFields }); ok {
+		return f.GetLLMFields(), true
+	}
+	return nil, false
+}
+
+type providerAccumulator struct {
+	known      map[string]bool
+	providers  map[string]bool
+	unknown    map[string]bool
+	narrowSafe bool
+}
+
+func (a *providerAccumulator) result() ProviderResolution {
+	res := ProviderResolution{NarrowSafe: a.narrowSafe}
+	for p := range a.providers {
+		res.Providers = append(res.Providers, p)
+	}
+	for u := range a.unknown {
+		res.Unknown = append(res.Unknown, u)
+	}
+	sort.Strings(res.Providers)
+	sort.Strings(res.Unknown)
+	return res
+}
+
+// resolveNode applies the executor's precedence to one LLM node: a
+// provider override collapses the chain; else a `provider/` prefix on the
+// effective model (override, then DSL) pins; else the DSL `provider:`
+// chain, expanded then split. Anything the walk cannot resolve widens.
+func (a *providerAccumulator) resolveNode(node ir.Node, fields *ir.LLMFields, overrides ModelOverrides) {
+	ov := overrides.ForNode(node.NodeID(), node.NodeKind())
+	if strings.TrimSpace(ov.Provider) != "" {
+		a.hint(ov.Provider)
+		return
+	}
+	mdl := ov.Model
+	if mdl == "" {
+		mdl = fields.Model
+	}
+	if p := providerFromModelPrefix(mdl); p != "" {
+		a.hint(p)
+		return
+	}
+	if !a.chain(fields.Provider) {
+		a.narrowSafe = false
+	}
+}
+
+// resolveRoute is the fallback-route half: a `provider:model` step has
+// the same two sources as a node (a hint, or a model prefix). A route
+// that pins neither inherits whatever the process holds, which the walk
+// cannot name — widen.
+func (a *providerAccumulator) resolveRoute(provider, mdl string) {
+	if p := providerFromModelPrefix(mdl); p != "" {
+		a.hint(p)
+		return
+	}
+	if !a.chain(provider) {
+		a.narrowSafe = false
+	}
+}
+
+// chain resolves a `provider:` field the executor's way. Reports whether
+// EVERY step resolved to a known provider (an empty field, an "auto"
+// step, an empty ${VAR} or an unknown name all answer false).
+func (a *providerAccumulator) chain(raw string) bool {
+	expanded := strings.TrimSpace(ir.ExpandEnvWithDefault(raw))
+	if expanded == "" {
+		return false
+	}
+	resolved := true
+	for _, part := range strings.Split(expanded, ",") {
+		token := strings.TrimSpace(part)
+		if token == "" {
+			continue // stray, leading or trailing comma
+		}
+		hint, _, _ := ir.SplitProviderStep(token)
+		if !a.hint(hint) {
+			resolved = false
+		}
+	}
+	return resolved
+}
+
+// hint classifies one provider name. Known → recorded, true. Empty or
+// "auto" → unresolved, false. Anything else → recorded as Unknown, false.
+func (a *providerAccumulator) hint(raw string) bool {
+	h := strings.ToLower(strings.TrimSpace(ir.ExpandEnvWithDefault(raw)))
+	switch {
+	case h == "" || h == "auto":
+		a.narrowSafe = false
+		return false
+	case a.known[h]:
+		a.providers[h] = true
+		return true
+	default:
+		a.unknown[h] = true
+		a.narrowSafe = false
+		return false
+	}
+}
+
+// providerFromModelPrefix extracts the provider half of a
+// `provider/model` string (env refs expanded), or "" when there is none.
+func providerFromModelPrefix(model string) string {
+	prov, _, cut := strings.Cut(strings.TrimSpace(ir.ExpandEnvWithDefault(model)), "/")
+	if !cut {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(prov))
+}

--- a/pkg/backend/model/override_fold_test.go
+++ b/pkg/backend/model/override_fold_test.go
@@ -1,0 +1,276 @@
+package model
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+)
+
+// The pool's wants derivation and any other "what does this run target?"
+// site go through EffectiveProviders. These tests pin the semantics the
+// round-1 A/B probes covered on the real catalog bots:
+//
+//   - provider chain forms (`"zai,anthropic"`, `"zai:glm-5.2,anthropic:..."`)
+//   - env expansion (`${RESCUE_PROVIDER:-zai}` — secured-renovacy's 13 nodes)
+//   - explicit "auto" tokens and empty chains (sec-audit-source's
+//     `${ITERION_SEC_AUDIT_PROVIDER_CHAIN:-}`)
+//   - unknown provider names (widen AND name the pin, never narrow)
+//   - MIXED runs (an unpinned node next to a pinned peer)
+//   - node `fallbacks:` blocks and the run-level fallback chain
+//   - model-calling nodes that expose no LLMFields (widen)
+
+var knownForTest = map[string]bool{
+	"anthropic":  true,
+	"openai":     true,
+	"bedrock":    true,
+	"vertex":     true,
+	"azure":      true,
+	"openrouter": true,
+	"xai":        true,
+	"zai":        true,
+}
+
+func sortedCopy(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}
+
+func agentWith(id, provider, mdl string) *ir.AgentNode {
+	return &ir.AgentNode{
+		BaseNode:  ir.BaseNode{ID: id},
+		LLMFields: ir.LLMFields{Provider: provider, Model: mdl},
+	}
+}
+
+func TestEffectiveProviders_ProviderChainForms(t *testing.T) {
+	cases := []struct {
+		name        string
+		provider    string
+		model       string
+		wantProvs   []string
+		wantNarrow  bool
+		wantUnknown []string
+	}{
+		{"comma-separated hints", "zai,anthropic", "", []string{"anthropic", "zai"}, true, nil},
+		{"provider:model steps", "zai:glm-5.2,anthropic:claude-opus-5", "", []string{"anthropic", "zai"}, true, nil},
+		{"model prefix only", "", "openai/gpt-5", []string{"openai"}, true, nil},
+		{"explicit auto widens", "auto", "", nil, false, nil},
+		{"empty widens", "", "", nil, false, nil},
+		{"unknown provider widens and is named", "fake-provider", "", nil, false, []string{"fake-provider"}},
+		{"unknown model prefix widens and is named", "", "fake-provider/gpt-x", nil, false, []string{"fake-provider"}},
+		// A chain mixing a known name with an unknown one still lists the
+		// known name (for the log line) but widens: narrowing would drop
+		// the donations the unknown half could have taken.
+		{"mixed known + unknown widens", "anthropic,unknown-vendor", "", []string{"anthropic"}, false, []string{"unknown-vendor"}},
+		{"auto step inside a chain widens", "anthropic,auto", "", []string{"anthropic"}, false, nil},
+		{"stray commas are not steps", " zai , , anthropic ,", "", []string{"anthropic", "zai"}, true, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wf := &ir.Workflow{Nodes: map[string]ir.Node{"a": agentWith("a", tc.provider, tc.model)}}
+			got := EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest)
+			if got.NarrowSafe != tc.wantNarrow {
+				t.Errorf("NarrowSafe = %v, want %v", got.NarrowSafe, tc.wantNarrow)
+			}
+			if want := sortedCopy(tc.wantProvs); !slicesEqual(got.Providers, want) {
+				t.Errorf("Providers = %v, want %v", got.Providers, want)
+			}
+			if want := sortedCopy(tc.wantUnknown); !slicesEqual(got.Unknown, want) {
+				t.Errorf("Unknown = %v, want %v", got.Unknown, want)
+			}
+		})
+	}
+}
+
+func TestEffectiveProviders_EnvExpansion(t *testing.T) {
+	// The executor's resolveProviderChain applies ir.ExpandEnvWithDefault;
+	// the walk MUST do the same, so `provider: "${RESCUE_PROVIDER:-zai}"`
+	// with the var unset resolves to zai — the shape secured-renovacy
+	// ships on 13 nodes. Read verbatim it is an unknown name.
+	t.Setenv("RESCUE_PROVIDER", "")
+	wf := &ir.Workflow{Nodes: map[string]ir.Node{"a": agentWith("a", "${RESCUE_PROVIDER:-zai}", "")}}
+	got := EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest)
+	if !got.NarrowSafe {
+		t.Fatalf("NarrowSafe = false, want true — a ${VAR:-default} chain resolves to its default; got %+v", got)
+	}
+	if !slicesEqual(got.Providers, []string{"zai"}) {
+		t.Fatalf("Providers = %v, want [zai]", got.Providers)
+	}
+
+	// The env may supply the whole chain.
+	t.Setenv("PROVIDERS", "anthropic,openai")
+	wf = &ir.Workflow{Nodes: map[string]ir.Node{"a": agentWith("a", "${PROVIDERS}", "")}}
+	got = EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest)
+	if !got.NarrowSafe || !slicesEqual(got.Providers, []string{"anthropic", "openai"}) {
+		t.Fatalf("env-supplied chain: got %+v, want [anthropic openai] narrow-safe", got)
+	}
+
+	// An env ref with no default and no value is an EMPTY chain: the node
+	// takes whatever the process holds, so the walk widens.
+	t.Setenv("ITERION_SEC_AUDIT_PROVIDER_CHAIN", "")
+	wf = &ir.Workflow{Nodes: map[string]ir.Node{"a": agentWith("a", "${ITERION_SEC_AUDIT_PROVIDER_CHAIN:-}", "")}}
+	got = EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest)
+	if got.NarrowSafe || len(got.Providers) != 0 || len(got.Unknown) != 0 {
+		t.Fatalf("empty-by-default chain must widen with nothing named: got %+v", got)
+	}
+}
+
+func TestEffectiveProviders_MixedResolvedAndUnresolvedWidens(t *testing.T) {
+	// The ADR-091 shape: one openai-pinned peer next to an unpinned main
+	// implementer. The pre-fix walk narrowed wants to {openai}, silently
+	// dropping the implementer's claude_code forfait. Widen instead.
+	wf := &ir.Workflow{Nodes: map[string]ir.Node{
+		"implementer": agentWith("implementer", "", ""),
+		"reviewer":    agentWith("reviewer", "openai", ""),
+	}}
+	got := EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest)
+	if got.NarrowSafe {
+		t.Fatalf("NarrowSafe = true — a mixed unpinned+pinned run must widen; got %+v", got)
+	}
+	if !slicesEqual(got.Providers, []string{"openai"}) {
+		t.Errorf("Providers = %v, want [openai] (still listed for the log line)", got.Providers)
+	}
+}
+
+func TestEffectiveProviders_HonoursOverrides(t *testing.T) {
+	// A launch override collapses the resolution exactly like the
+	// executor's resolveProviderChain: the provider override wins over
+	// the DSL model's prefix, on a judge-kind selector too (#668).
+	wf := &ir.Workflow{Nodes: map[string]ir.Node{
+		"j": &ir.JudgeNode{BaseNode: ir.BaseNode{ID: "j"}, LLMFields: ir.LLMFields{Model: "anthropic/claude-opus-5"}},
+	}}
+	var overrides ModelOverrides
+	overrides.SetProvider("judge", "openai")
+	overrides.SetModel("judge", "openai/gpt-5")
+	got := EffectiveProviders(wf, overrides, nil, knownForTest)
+	if !got.NarrowSafe || !slicesEqual(got.Providers, []string{"openai"}) {
+		t.Fatalf("got %+v, want [openai] narrow-safe", got)
+	}
+
+	// A model-only override carries its prefix too.
+	var modelOnly ModelOverrides
+	modelOnly.SetModel("j", "openai/gpt-5")
+	got = EffectiveProviders(wf, modelOnly, nil, knownForTest)
+	if !got.NarrowSafe || !slicesEqual(got.Providers, []string{"openai"}) {
+		t.Fatalf("model-only override: got %+v, want [openai] narrow-safe", got)
+	}
+}
+
+func TestEffectiveProviders_NodeFallbacksContribute(t *testing.T) {
+	// G3: a `fallbacks:` route names a provider the run may spend; a pool
+	// granting only the primary's provider would leave it unreachable.
+	wf := &ir.Workflow{Nodes: map[string]ir.Node{
+		"a": &ir.AgentNode{
+			BaseNode:  ir.BaseNode{ID: "a"},
+			LLMFields: ir.LLMFields{Provider: "openai"},
+			Fallbacks: []ir.Fallback{
+				{Name: "rescue", Backend: "claw", Model: "anthropic/claude-opus-5", Provider: "anthropic"},
+				// A skip route executes nothing — it must not widen.
+				{Name: "give-up", Action: ir.FallbackActionSkip},
+			},
+		},
+	}}
+	got := EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest)
+	if !got.NarrowSafe {
+		t.Fatalf("NarrowSafe = false, want true (primary, rescue resolve; skip is inert): %+v", got)
+	}
+	if !slicesEqual(got.Providers, []string{"anthropic", "openai"}) {
+		t.Fatalf("Providers = %v, want [anthropic openai]", got.Providers)
+	}
+
+	// A route that pins nothing inherits whatever the process holds —
+	// the walk cannot name it, so it widens.
+	wf.Nodes["a"].(*ir.AgentNode).Fallbacks = []ir.Fallback{{Name: "blind", Backend: "claude_code"}}
+	got = EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest)
+	if got.NarrowSafe {
+		t.Fatalf("a fallback route with no provider must widen: %+v", got)
+	}
+}
+
+func TestEffectiveProviders_RunLevelFallbackChain(t *testing.T) {
+	// G3: --fallback / spec.Fallback / prior.Fallback add providers the
+	// same way an authored route does.
+	wf := &ir.Workflow{Nodes: map[string]ir.Node{"a": agentWith("a", "openai", "")}}
+	got := EffectiveProviders(wf, ModelOverrides{}, []FallbackEntry{{Backend: "claw", Provider: "anthropic"}}, knownForTest)
+	if !got.NarrowSafe || !slicesEqual(got.Providers, []string{"anthropic", "openai"}) {
+		t.Fatalf("got %+v, want [anthropic openai] narrow-safe", got)
+	}
+	// The empty stage ApplyRunFallback drops is dropped here too.
+	got = EffectiveProviders(wf, ModelOverrides{}, []FallbackEntry{{}}, knownForTest)
+	if !got.NarrowSafe || !slicesEqual(got.Providers, []string{"openai"}) {
+		t.Fatalf("empty stage: got %+v, want [openai] narrow-safe", got)
+	}
+}
+
+func TestEffectiveProviders_RouterAndHumanNodes(t *testing.T) {
+	// A router in `llm` mode spends through its embedded LLMFields — it
+	// resolves like an agent. A router in a deterministic mode spends
+	// nothing and must not widen.
+	wf := &ir.Workflow{Nodes: map[string]ir.Node{
+		"a": agentWith("a", "openai", ""),
+		"r": &ir.RouterNode{BaseNode: ir.BaseNode{ID: "r"}, RouterMode: ir.RouterLLM, LLMFields: ir.LLMFields{Provider: "anthropic"}},
+		"f": &ir.RouterNode{BaseNode: ir.BaseNode{ID: "f"}, RouterMode: ir.RouterFanOutAll},
+	}}
+	got := EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest)
+	if !got.NarrowSafe || !slicesEqual(got.Providers, []string{"anthropic", "openai"}) {
+		t.Fatalf("llm router: got %+v, want [anthropic openai] narrow-safe", got)
+	}
+
+	// A human node answering with a model exposes no LLMFields: it
+	// spends on a provider the walk cannot name, so it widens.
+	wf.Nodes["h"] = &ir.HumanNode{BaseNode: ir.BaseNode{ID: "h"}, InteractionFields: ir.InteractionFields{Interaction: ir.InteractionLLM}}
+	got = EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest)
+	if got.NarrowSafe {
+		t.Fatalf("a model-answering human node must widen: %+v", got)
+	}
+	// A plain human node does not.
+	wf.Nodes["h"] = &ir.HumanNode{BaseNode: ir.BaseNode{ID: "h"}}
+	if got = EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest); !got.NarrowSafe {
+		t.Fatalf("a human-only node must not widen: %+v", got)
+	}
+}
+
+func TestEffectiveProviders_NoLLMNodeAndNilInputs(t *testing.T) {
+	wf := &ir.Workflow{Nodes: map[string]ir.Node{"t": &ir.ToolNode{BaseNode: ir.BaseNode{ID: "t"}}}}
+	if got := EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest); !got.NarrowSafe || len(got.Providers) != 0 {
+		t.Fatalf("tool-only workflow: got %+v, want empty and narrow-safe", got)
+	}
+	if got := EffectiveProviders(nil, ModelOverrides{}, nil, knownForTest); got.NarrowSafe {
+		t.Fatalf("nil workflow must fail open: %+v", got)
+	}
+	if got := EffectiveProviders(wf, ModelOverrides{}, nil, nil); got.NarrowSafe {
+		t.Fatalf("empty vocabulary must fail open: %+v", got)
+	}
+}
+
+func TestOverridesFrom_FoldsEveryField(t *testing.T) {
+	o := OverridesFrom([]OverrideEntry{
+		{Selector: "judge", Backend: "claw", Model: "openai/gpt-5", Provider: "openai"},
+		{Selector: "plan", Model: "claude-opus-5"},
+	})
+	j := o.ForNode("verdict", ir.NodeJudge)
+	if j.Backend != "claw" || j.Model != "openai/gpt-5" || j.Provider != "openai" {
+		t.Fatalf("judge-kind selector: got %+v", j)
+	}
+	p := o.ForNode("plan", ir.NodeAgent)
+	if p.Model != "claude-opus-5" || p.Backend != "" || p.Provider != "" {
+		t.Fatalf("node selector: got %+v", p)
+	}
+	if !OverridesFrom(nil).Empty() {
+		t.Fatal("no entries must fold to an empty override set")
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/backend/model/override_fold_test.go
+++ b/pkg/backend/model/override_fold_test.go
@@ -274,3 +274,97 @@ func slicesEqual(a, b []string) bool {
 	}
 	return true
 }
+
+// Round 2 S1: the hint IS the route. The executor's resolveProviderChain
+// never reads the model's `provider/` prefix — on claude_code a `zai` hint
+// spends ONLY the z.ai key (and the `anthropic/` prefix is stripped), on
+// pi the hint overrides the prefix and `model: "anthropic/glm-5.2"` +
+// `provider: "zai"` is THE documented z.ai form. Round 1's walk returned
+// on the prefix first and reported [anthropic] for every one of these,
+// so the only donor able to serve (a z.ai key) was never considered.
+func TestEffectiveProviders_HintWinsOverModelPrefix(t *testing.T) {
+	t.Setenv("RESCUE_PROVIDER", "")
+	nodeOf := func(backend, provider, mdl string) *ir.AgentNode {
+		return &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: backend, Provider: provider, Model: mdl}}
+	}
+	rows := []struct {
+		name      string
+		node      *ir.AgentNode
+		overrides ModelOverrides
+		want      []string
+	}{
+		{"claude_code + anthropic/ prefix + zai hint → zai", nodeOf("claude_code", "zai", "anthropic/claude-opus-4-8"), ModelOverrides{}, []string{"zai"}},
+		{"claude_code + anthropic/ prefix + chain zai,anthropic → the chain", nodeOf("claude_code", "zai,anthropic", "anthropic/claude-opus-4-8"), ModelOverrides{}, []string{"anthropic", "zai"}},
+		{"pi documented z.ai form: anthropic/glm-5.2 + zai → zai", nodeOf("pi", "zai", "anthropic/glm-5.2"), ModelOverrides{}, []string{"zai"}},
+		{"secured-renovacy shape with an anthropic/ model → zai", nodeOf("claude_code", "${RESCUE_PROVIDER:-zai}", "anthropic/claude-opus-4-8"), ModelOverrides{}, []string{"zai"}},
+	}
+	for _, row := range rows {
+		t.Run(row.name, func(t *testing.T) {
+			wf := &ir.Workflow{Nodes: map[string]ir.Node{"a": row.node}}
+			got := EffectiveProviders(wf, row.overrides, nil, knownForTest)
+			if !got.NarrowSafe || !slicesEqual(got.Providers, row.want) {
+				t.Fatalf("got %+v, want %v narrow-safe", got, row.want)
+			}
+		})
+	}
+
+	// A launch `--model agent=anthropic/…` over a `provider: zai` node:
+	// the executor keeps the DSL chain (only a PROVIDER override collapses
+	// it), so the wants still say zai.
+	var modelOnly ModelOverrides
+	modelOnly.SetModel("a", "anthropic/claude-opus-4-8")
+	wf := &ir.Workflow{Nodes: map[string]ir.Node{"a": nodeOf("claude_code", "zai", "")}}
+	if got := EffectiveProviders(wf, modelOnly, nil, knownForTest); !got.NarrowSafe || !slicesEqual(got.Providers, []string{"zai"}) {
+		t.Fatalf("model override over a zai hint: got %+v, want [zai]", got)
+	}
+	// A PROVIDER override does collapse it.
+	var provOv ModelOverrides
+	provOv.SetProvider("a", "anthropic")
+	if got := EffectiveProviders(wf, provOv, nil, knownForTest); !got.NarrowSafe || !slicesEqual(got.Providers, []string{"anthropic"}) {
+		t.Fatalf("provider override over a zai hint: got %+v, want [anthropic]", got)
+	}
+	// No hint at all: the prefix routes (claw's registry).
+	wf = &ir.Workflow{Nodes: map[string]ir.Node{"a": nodeOf("claw", "auto", "openai/gpt-5")}}
+	if got := EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest); !got.NarrowSafe || !slicesEqual(got.Providers, []string{"openai"}) {
+		t.Fatalf("auto hint + prefix: got %+v, want [openai]", got)
+	}
+	// A fallback route follows the same rule: its hint beats its prefix.
+	wf = &ir.Workflow{Nodes: map[string]ir.Node{"a": &ir.AgentNode{
+		BaseNode:  ir.BaseNode{ID: "a"},
+		LLMFields: ir.LLMFields{Backend: "claude_code", Provider: "anthropic"},
+		Fallbacks: []ir.Fallback{{Name: "rescue", Provider: "zai", Model: "anthropic/glm-5.2"}},
+	}}}
+	if got := EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest); !got.NarrowSafe || !slicesEqual(got.Providers, []string{"anthropic", "zai"}) {
+		t.Fatalf("fallback hint over prefix: got %+v, want [anthropic zai]", got)
+	}
+}
+
+// Round 2 S11: `interaction: llm` answers the node's questions with a
+// DIRECT generation on `interaction_model` (falling back to the node's
+// model) — a route no hint applies to. Its prefix joins the wants; a
+// spec with no prefix widens.
+func TestEffectiveProviders_InteractionModelIsARoute(t *testing.T) {
+	node := func(interaction ir.InteractionMode, interactionModel, mdl string) *ir.AgentNode {
+		return &ir.AgentNode{
+			BaseNode:          ir.BaseNode{ID: "a"},
+			LLMFields:         ir.LLMFields{Backend: "claude_code", Provider: "zai", Model: mdl},
+			InteractionFields: ir.InteractionFields{Interaction: interaction, InteractionModel: interactionModel},
+		}
+	}
+	wf := &ir.Workflow{Nodes: map[string]ir.Node{"a": node(ir.InteractionLLM, "openai/gpt-5", "")}}
+	if got := EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest); !got.NarrowSafe || !slicesEqual(got.Providers, []string{"openai", "zai"}) {
+		t.Fatalf("interaction_model openai/…: got %+v, want [openai zai]", got)
+	}
+	wf = &ir.Workflow{Nodes: map[string]ir.Node{"a": node(ir.InteractionLLMOrHuman, "", "anthropic/claude-opus-4-8")}}
+	if got := EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest); !got.NarrowSafe || !slicesEqual(got.Providers, []string{"anthropic", "zai"}) {
+		t.Fatalf("interaction falls back to the node model's prefix: got %+v, want [anthropic zai]", got)
+	}
+	wf = &ir.Workflow{Nodes: map[string]ir.Node{"a": node(ir.InteractionLLM, "", "")}}
+	if got := EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest); got.NarrowSafe {
+		t.Fatalf("interaction on a bare model spec must widen: got %+v", got)
+	}
+	wf = &ir.Workflow{Nodes: map[string]ir.Node{"a": node(ir.InteractionHuman, "openai/gpt-5", "")}}
+	if got := EffectiveProviders(wf, ModelOverrides{}, nil, knownForTest); !got.NarrowSafe || !slicesEqual(got.Providers, []string{"zai"}) {
+		t.Fatalf("a human interaction spends nothing on interaction_model: got %+v, want [zai]", got)
+	}
+}

--- a/pkg/backend/model/wire_reach.go
+++ b/pkg/backend/model/wire_reach.go
@@ -1,0 +1,119 @@
+package model
+
+import (
+	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+)
+
+// anthropicWireProviders are the credential-routing hints that spend an
+// Anthropic-wire credential: the direct API key / OAuth forfait, and the
+// z.ai facade that rides the same wire.
+var anthropicWireProviders = map[string]bool{"anthropic": true, "zai": true}
+
+// AnthropicWireReachable reports whether some route the run may take can
+// execute against the Anthropic wire — the wire the operator's usage cap
+// meters (its readings come from the claude_code delegate's own session
+// telemetry and nowhere else). A pre-flight guard that refuses a run in
+// advance must ask this: a run whose every route is claw/openai cannot
+// spend the capped subscription, and parking it for the anthropic weekly
+// reset protects nothing (#668).
+//
+// CONSERVATIVE in the direction that matters — every uncertainty answers
+// true, keeping the guard armed:
+//   - a backend that is claude_code, empty or "auto" (the resolver may
+//     pick claude_code from the host's credentials);
+//   - claw or pi with a provider it cannot resolve (claw substitutes the
+//     first available provider, which may be anthropic);
+//   - any resolved hint that is anthropic or zai, on any backend;
+//   - a model-calling node that exposes no LLMFields (human answering
+//     with a model, subbot, agent-rung recovery), a nil workflow;
+//   - a `fallbacks:` route or run-level stage with any of the above.
+//
+// Only a run whose EVERY route is pinned off the wire — codex/kimi/grok,
+// or claw/pi with a resolved non-anthropic provider — answers false.
+func AnthropicWireReachable(wf *ir.Workflow, overrides ModelOverrides, runFallbacks []FallbackEntry) bool {
+	if wf == nil {
+		return true
+	}
+	wfBackend := strings.TrimSpace(ir.ExpandEnvWithDefault(wf.DefaultBackend))
+	for _, n := range wf.Nodes {
+		fields, ok := llmFieldsOf(n)
+		if !ok {
+			if ir.NodeUsesLLM(n) {
+				return true
+			}
+			continue
+		}
+		ov := overrides.ForNode(n.NodeID(), n.NodeKind())
+		backend := firstNonEmpty(strings.TrimSpace(ov.Backend), strings.TrimSpace(ir.ExpandEnvWithDefault(fields.Backend)), wfBackend)
+		mdl := firstNonEmpty(ov.Model, fields.Model)
+		if routeOnAnthropicWire(backend, ov.Provider, fields.Provider, mdl) {
+			return true
+		}
+		if gf, ok := n.(interface{ GetFallbacks() []ir.Fallback }); ok {
+			for _, fb := range gf.GetFallbacks() {
+				if fb.Action == ir.FallbackActionSkip {
+					continue
+				}
+				// A route inherits the node's backend and model when it
+				// pins none; its provider is its own ("" = auto).
+				fbBackend := firstNonEmpty(strings.TrimSpace(ir.ExpandEnvWithDefault(fb.Backend)), backend)
+				if routeOnAnthropicWire(fbBackend, fb.Provider, "", firstNonEmpty(fb.Model, mdl)) {
+					return true
+				}
+			}
+		}
+		// The run-level chain lands on agent nodes through
+		// ir.ApplyRunFallback; asked of every LLM node here, which only
+		// ever errs towards keeping the guard armed.
+		for _, fb := range runFallbacks {
+			if fb.Backend == "" && fb.Model == "" && fb.Provider == "" {
+				continue
+			}
+			fbBackend := firstNonEmpty(strings.TrimSpace(ir.ExpandEnvWithDefault(fb.Backend)), backend)
+			if routeOnAnthropicWire(fbBackend, fb.Provider, "", firstNonEmpty(fb.Model, mdl)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// routeOnAnthropicWire decides for one route. overrideProvider collapses
+// the chain when set (the executor's precedence); else a `provider/`
+// prefix on the model pins; else the DSL chain is walked.
+func routeOnAnthropicWire(backend, overrideProvider, chain, mdl string) bool {
+	backend = strings.ToLower(backend)
+	switch backend {
+	case "", "auto", delegate.BackendClaudeCode:
+		return true
+	}
+	var hints []string
+	unresolved := false
+	switch {
+	case strings.TrimSpace(overrideProvider) != "":
+		hints, unresolved = chainHints(overrideProvider)
+	case providerFromModelPrefix(mdl) != "":
+		hints = []string{providerFromModelPrefix(mdl)}
+	default:
+		hints, unresolved = chainHints(chain)
+	}
+	for _, h := range hints {
+		if anthropicWireProviders[h] {
+			return true
+		}
+	}
+	if !unresolved {
+		return false
+	}
+	// Unresolved on a backend that picks its provider from what the
+	// process holds: may land on anthropic. The CLI backends bound to one
+	// vendor cannot.
+	switch backend {
+	case delegate.BackendCodex, delegate.BackendKimi, delegate.BackendGrok:
+		return false
+	}
+	return true
+}

--- a/pkg/backend/model/wire_reach.go
+++ b/pkg/backend/model/wire_reach.go
@@ -28,12 +28,20 @@ var anthropicWireProviders = map[string]bool{"anthropic": true, "zai": true}
 //     first available provider, which may be anthropic);
 //   - any resolved hint that is anthropic or zai, on any backend;
 //   - a model-calling node that exposes no LLMFields (human answering
-//     with a model, subbot, agent-rung recovery), a nil workflow;
-//   - a `fallbacks:` route or run-level stage with any of the above.
+//     with a model, subbot, agent-rung recovery), a nil workflow.
 //
-// Only a run whose EVERY route is pinned off the wire — codex/kimi/grok,
-// or claw/pi with a resolved non-anthropic provider — answers false.
-func AnthropicWireReachable(wf *ir.Workflow, overrides ModelOverrides, runFallbacks []FallbackEntry) bool {
+// PRIMARY routes only. A `fallbacks:` route onto the wire does not arm
+// the guard: the primary can carry the whole run without ever touching
+// it, and the rescue route only fires on a failure the mid-run guard and
+// the delegate's own usage-window classification already refuse at
+// dispatch. Arming on it would refuse IN ADVANCE a run that could not
+// possibly spend the capped subscription — the rule this pre-flight
+// exists to honour.
+//
+// Only a run whose every primary route is pinned off the wire —
+// codex/kimi/grok, or claw/pi with a resolved non-anthropic provider —
+// answers false.
+func AnthropicWireReachable(wf *ir.Workflow, overrides ModelOverrides) bool {
 	if wf == nil {
 		return true
 	}
@@ -51,31 +59,6 @@ func AnthropicWireReachable(wf *ir.Workflow, overrides ModelOverrides, runFallba
 		mdl := firstNonEmpty(ov.Model, fields.Model)
 		if routeOnAnthropicWire(backend, ov.Provider, fields.Provider, mdl) {
 			return true
-		}
-		if gf, ok := n.(interface{ GetFallbacks() []ir.Fallback }); ok {
-			for _, fb := range gf.GetFallbacks() {
-				if fb.Action == ir.FallbackActionSkip {
-					continue
-				}
-				// A route inherits the node's backend and model when it
-				// pins none; its provider is its own ("" = auto).
-				fbBackend := firstNonEmpty(strings.TrimSpace(ir.ExpandEnvWithDefault(fb.Backend)), backend)
-				if routeOnAnthropicWire(fbBackend, fb.Provider, "", firstNonEmpty(fb.Model, mdl)) {
-					return true
-				}
-			}
-		}
-		// The run-level chain lands on agent nodes through
-		// ir.ApplyRunFallback; asked of every LLM node here, which only
-		// ever errs towards keeping the guard armed.
-		for _, fb := range runFallbacks {
-			if fb.Backend == "" && fb.Model == "" && fb.Provider == "" {
-				continue
-			}
-			fbBackend := firstNonEmpty(strings.TrimSpace(ir.ExpandEnvWithDefault(fb.Backend)), backend)
-			if routeOnAnthropicWire(fbBackend, fb.Provider, "", firstNonEmpty(fb.Model, mdl)) {
-				return true
-			}
 		}
 	}
 	return false

--- a/pkg/backend/model/wire_reach.go
+++ b/pkg/backend/model/wire_reach.go
@@ -81,9 +81,12 @@ func AnthropicWireReachable(wf *ir.Workflow, overrides ModelOverrides, runFallba
 	return false
 }
 
-// routeOnAnthropicWire decides for one route. overrideProvider collapses
-// the chain when set (the executor's precedence); else a `provider/`
-// prefix on the model pins; else the DSL chain is walked.
+// routeOnAnthropicWire decides for one route, in the executor's
+// precedence: a provider override collapses the chain; else the DSL chain
+// decides when it names a hint (the hint IS the route — on pi the hint
+// overrides the model's prefix, on claude_code the prefix is stripped);
+// only a route with no hint at all routes on its model's `provider/`
+// prefix.
 func routeOnAnthropicWire(backend, overrideProvider, chain, mdl string) bool {
 	backend = strings.ToLower(backend)
 	switch backend {
@@ -95,10 +98,13 @@ func routeOnAnthropicWire(backend, overrideProvider, chain, mdl string) bool {
 	switch {
 	case strings.TrimSpace(overrideProvider) != "":
 		hints, unresolved = chainHints(overrideProvider)
-	case providerFromModelPrefix(mdl) != "":
-		hints = []string{providerFromModelPrefix(mdl)}
 	default:
 		hints, unresolved = chainHints(chain)
+		if len(hints) == 0 {
+			if p := providerFromModelPrefix(mdl); p != "" {
+				hints, unresolved = []string{p}, false
+			}
+		}
 	}
 	for _, h := range hints {
 		if anthropicWireProviders[h] {

--- a/pkg/backend/model/wire_reach_test.go
+++ b/pkg/backend/model/wire_reach_test.go
@@ -45,6 +45,10 @@ func TestAnthropicWireReachable(t *testing.T) {
 		), false},
 		{"pi + anthropic provider", wfOf(&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "pi", Provider: "anthropic"}}), true},
 		{"pi + openai provider", wfOf(&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "pi", Provider: "openai"}}), false},
+		// Round 2 S2: the hint IS the route on pi (it overrides the model's
+		// prefix), so an anthropic hint under an openai/ model is on the wire.
+		{"pi + openai/ prefix + anthropic hint → hint wins", wfOf(&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "pi", Provider: "anthropic", Model: "openai/gpt-5.5"}}), true},
+		{"claw + anthropic/ prefix + openai hint → hint wins, off the wire", wfOf(&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai", Model: "anthropic/claude-opus-4-8"}}), false},
 		{"one off-wire node next to one unpinned node", wfOf(
 			&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai"}},
 			agentWith("b", "", ""),

--- a/pkg/backend/model/wire_reach_test.go
+++ b/pkg/backend/model/wire_reach_test.go
@@ -1,0 +1,124 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+)
+
+// The usage cap meters the Anthropic wire only (its readings come from
+// the claude_code delegate). A run parked "for the anthropic weekly reset"
+// while every one of its routes is claw/openai is the #668 incident;
+// every uncertainty must keep the guard armed instead.
+func TestAnthropicWireReachable(t *testing.T) {
+	t.Setenv("RESCUE_PROVIDER", "")
+	wfOf := func(nodes ...ir.Node) *ir.Workflow {
+		wf := &ir.Workflow{Nodes: map[string]ir.Node{}}
+		for _, n := range nodes {
+			wf.Nodes[n.NodeID()] = n
+		}
+		return wf
+	}
+	cases := []struct {
+		name string
+		wf   *ir.Workflow
+		want bool
+	}{
+		{"nil workflow is unknown", nil, true},
+		{"tool-only spends nothing", wfOf(&ir.ToolNode{BaseNode: ir.BaseNode{ID: "t"}}), false},
+		{"unpinned node may resolve to claude_code", wfOf(agentWith("a", "", "")), true},
+		{"claude_code backend", wfOf(&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "claude_code", Provider: "openai"}}), true},
+		{"workflow default_backend claude_code", &ir.Workflow{DefaultBackend: "claude_code", Nodes: map[string]ir.Node{"a": agentWith("a", "openai", "")}}, true},
+		{"claw + openai model + openai provider (probe 1/2)", wfOf(
+			&ir.AgentNode{BaseNode: ir.BaseNode{ID: "oracle"}, LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai", Model: "openai/gpt-5.6-sol"}},
+			&ir.JudgeNode{BaseNode: ir.BaseNode{ID: "mutants"}, LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai", Model: "openai/gpt-5.6-sol"}},
+		), false},
+		{"claw + openai model prefix only", wfOf(&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "claw", Model: "openai/gpt-5"}}), false},
+		{"claw + anthropic provider", wfOf(&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "claw", Provider: "anthropic"}}), true},
+		{"claw + zai facade", wfOf(&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "claw", Provider: "${RESCUE_PROVIDER:-zai}"}}), true},
+		{"claw with no provider substitutes what the process holds", wfOf(&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "claw"}}), true},
+		{"claw chain openai,anthropic reaches the wire", wfOf(&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai,anthropic"}}), true},
+		{"codex is bound to openai", wfOf(&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "codex"}}), false},
+		{"kimi and grok are bound to their vendor", wfOf(
+			&ir.AgentNode{BaseNode: ir.BaseNode{ID: "k"}, LLMFields: ir.LLMFields{Backend: "kimi", Model: "kimi-code/kimi-for-coding"}},
+			&ir.AgentNode{BaseNode: ir.BaseNode{ID: "g"}, LLMFields: ir.LLMFields{Backend: "grok"}},
+		), false},
+		{"pi + anthropic provider", wfOf(&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "pi", Provider: "anthropic"}}), true},
+		{"pi + openai provider", wfOf(&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "pi", Provider: "openai"}}), false},
+		{"one off-wire node next to one unpinned node", wfOf(
+			&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai"}},
+			agentWith("b", "", ""),
+		), true},
+		{"llm router on the wire", wfOf(
+			&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai"}},
+			&ir.RouterNode{BaseNode: ir.BaseNode{ID: "r"}, RouterMode: ir.RouterLLM, LLMFields: ir.LLMFields{Backend: "claude_code"}},
+		), true},
+		{"deterministic router spends nothing", wfOf(
+			&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai"}},
+			&ir.RouterNode{BaseNode: ir.BaseNode{ID: "r"}, RouterMode: ir.RouterFanOutAll},
+		), false},
+		{"human answering with a model is unknowable", wfOf(
+			&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai"}},
+			&ir.HumanNode{BaseNode: ir.BaseNode{ID: "h"}, InteractionFields: ir.InteractionFields{Interaction: ir.InteractionLLM}},
+		), true},
+		{"node fallback route onto claude_code", wfOf(&ir.AgentNode{
+			BaseNode:  ir.BaseNode{ID: "a"},
+			LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai", Model: "openai/gpt-5"},
+			Fallbacks: []ir.Fallback{{Name: "rescue", Backend: "claude_code"}},
+		}), true},
+		{"node fallback route inheriting an off-wire model", wfOf(&ir.AgentNode{
+			BaseNode:  ir.BaseNode{ID: "a"},
+			LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai", Model: "openai/gpt-5"},
+			Fallbacks: []ir.Fallback{{Name: "cheaper", Model: "openai/gpt-5-mini"}},
+		}), false},
+		{"skip route executes nothing", wfOf(&ir.AgentNode{
+			BaseNode:  ir.BaseNode{ID: "a"},
+			LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai", Model: "openai/gpt-5"},
+			Fallbacks: []ir.Fallback{{Name: "give-up", Action: ir.FallbackActionSkip}},
+		}), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := AnthropicWireReachable(tc.wf, ModelOverrides{}, nil); got != tc.want {
+				t.Fatalf("AnthropicWireReachable = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAnthropicWireReachable_OverridesAndRunFallback(t *testing.T) {
+	// #668 exactly: a DSL-unpinned judge would resolve to claude_code, but
+	// the launch pinned both the agent and the judge kind to claw/openai.
+	// The overrides are what the executor will honour, so the predicate
+	// must read them.
+	wf := &ir.Workflow{Nodes: map[string]ir.Node{
+		"oracle_campaign":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "oracle_campaign"}},
+		"mutants_adversary": &ir.JudgeNode{BaseNode: ir.BaseNode{ID: "mutants_adversary"}},
+	}}
+	if !AnthropicWireReachable(wf, ModelOverrides{}, nil) {
+		t.Fatal("unpinned run must count as on the wire")
+	}
+	var both ModelOverrides
+	for _, sel := range []string{"oracle_campaign", "mutants_adversary"} {
+		both.SetBackend(sel, "claw")
+		both.SetModel(sel, "openai/gpt-5.6-sol")
+		both.SetProvider(sel, "openai")
+	}
+	if AnthropicWireReachable(wf, both, nil) {
+		t.Fatal("both nodes pinned to claw/openai by override: the run cannot touch the wire")
+	}
+	// Pinning the agent only leaves the judge on claude_code.
+	var agentOnly ModelOverrides
+	agentOnly.SetBackend("oracle_campaign", "claw")
+	agentOnly.SetProvider("oracle_campaign", "openai")
+	if !AnthropicWireReachable(wf, agentOnly, nil) {
+		t.Fatal("the judge still resolves to claude_code")
+	}
+	// A run-level --fallback onto claude_code re-opens the wire.
+	if !AnthropicWireReachable(wf, both, []FallbackEntry{{Backend: "claude_code"}}) {
+		t.Fatal("a run-level fallback onto claude_code is a route the run may take")
+	}
+	if AnthropicWireReachable(wf, both, []FallbackEntry{{Backend: "claw", Provider: "openai", Model: "openai/gpt-5"}}) {
+		t.Fatal("a run-level fallback that stays off the wire must not re-arm the guard")
+	}
+}

--- a/pkg/backend/model/wire_reach_test.go
+++ b/pkg/backend/model/wire_reach_test.go
@@ -65,11 +65,14 @@ func TestAnthropicWireReachable(t *testing.T) {
 			&ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai"}},
 			&ir.HumanNode{BaseNode: ir.BaseNode{ID: "h"}, InteractionFields: ir.InteractionFields{Interaction: ir.InteractionLLM}},
 		), true},
-		{"node fallback route onto claude_code", wfOf(&ir.AgentNode{
+		// PRIMARY routes only: a rescue route onto the wire fires on a
+		// failure the mid-run guard already refuses, so it cannot justify
+		// refusing the run before it starts.
+		{"node fallback route onto claude_code does not arm the guard", wfOf(&ir.AgentNode{
 			BaseNode:  ir.BaseNode{ID: "a"},
 			LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai", Model: "openai/gpt-5"},
 			Fallbacks: []ir.Fallback{{Name: "rescue", Backend: "claude_code"}},
-		}), true},
+		}), false},
 		{"node fallback route inheriting an off-wire model", wfOf(&ir.AgentNode{
 			BaseNode:  ir.BaseNode{ID: "a"},
 			LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai", Model: "openai/gpt-5"},
@@ -83,14 +86,14 @@ func TestAnthropicWireReachable(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := AnthropicWireReachable(tc.wf, ModelOverrides{}, nil); got != tc.want {
+			if got := AnthropicWireReachable(tc.wf, ModelOverrides{}); got != tc.want {
 				t.Fatalf("AnthropicWireReachable = %v, want %v", got, tc.want)
 			}
 		})
 	}
 }
 
-func TestAnthropicWireReachable_OverridesAndRunFallback(t *testing.T) {
+func TestAnthropicWireReachable_Overrides(t *testing.T) {
 	// #668 exactly: a DSL-unpinned judge would resolve to claude_code, but
 	// the launch pinned both the agent and the judge kind to claw/openai.
 	// The overrides are what the executor will honour, so the predicate
@@ -99,7 +102,7 @@ func TestAnthropicWireReachable_OverridesAndRunFallback(t *testing.T) {
 		"oracle_campaign":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "oracle_campaign"}},
 		"mutants_adversary": &ir.JudgeNode{BaseNode: ir.BaseNode{ID: "mutants_adversary"}},
 	}}
-	if !AnthropicWireReachable(wf, ModelOverrides{}, nil) {
+	if !AnthropicWireReachable(wf, ModelOverrides{}) {
 		t.Fatal("unpinned run must count as on the wire")
 	}
 	var both ModelOverrides
@@ -108,21 +111,14 @@ func TestAnthropicWireReachable_OverridesAndRunFallback(t *testing.T) {
 		both.SetModel(sel, "openai/gpt-5.6-sol")
 		both.SetProvider(sel, "openai")
 	}
-	if AnthropicWireReachable(wf, both, nil) {
+	if AnthropicWireReachable(wf, both) {
 		t.Fatal("both nodes pinned to claw/openai by override: the run cannot touch the wire")
 	}
 	// Pinning the agent only leaves the judge on claude_code.
 	var agentOnly ModelOverrides
 	agentOnly.SetBackend("oracle_campaign", "claw")
 	agentOnly.SetProvider("oracle_campaign", "openai")
-	if !AnthropicWireReachable(wf, agentOnly, nil) {
+	if !AnthropicWireReachable(wf, agentOnly) {
 		t.Fatal("the judge still resolves to claude_code")
-	}
-	// A run-level --fallback onto claude_code re-opens the wire.
-	if !AnthropicWireReachable(wf, both, []FallbackEntry{{Backend: "claude_code"}}) {
-		t.Fatal("a run-level fallback onto claude_code is a route the run may take")
-	}
-	if AnthropicWireReachable(wf, both, []FallbackEntry{{Backend: "claw", Provider: "openai", Model: "openai/gpt-5"}}) {
-		t.Fatal("a run-level fallback that stays off the wire must not re-arm the guard")
 	}
 }

--- a/pkg/cli/read_secret_value_test.go
+++ b/pkg/cli/read_secret_value_test.go
@@ -39,6 +39,24 @@ func TestReadSecretValue_RejectsEmpty(t *testing.T) {
 		}
 	})
 
+	t.Run("a CRLF file keeps only the value", func(t *testing.T) {
+		// A file written on Windows ends \r\n. Trimming only \n left the
+		// \r glued to the token, and the server refused it as a control
+		// character "that looks like a terminal transcript" — the right
+		// refusal for the wrong reason, on a file that is perfectly fine.
+		f := filepath.Join(t.TempDir(), "crlf")
+		if err := os.WriteFile(f, []byte("sk-real\r\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		v, err := ReadSecretValue("", f, false)
+		if err != nil {
+			t.Fatalf("CRLF file rejected: %v", err)
+		}
+		if v != "sk-real" {
+			t.Fatalf("value = %q, want %q — a trailing CR reaches the server's shape gate", v, "sk-real")
+		}
+	})
+
 	t.Run("a real value passes", func(t *testing.T) {
 		t.Setenv("ITER_REAL_SECRET", "sk-real")
 		v, err := ReadSecretValue("ITER_REAL_SECRET", "", false)

--- a/pkg/cli/remote_secrets.go
+++ b/pkg/cli/remote_secrets.go
@@ -31,14 +31,18 @@ func ReadSecretValue(fromEnv, fromFile string, stdinOK bool) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		v = strings.TrimRight(string(b), "\n")
+		// CRLF too: a file written on Windows leaves a trailing \r, which
+		// the server's shape gate refuses as a control character with a
+		// message about a terminal transcript — right refusal, misleading
+		// cause, for a file that is perfectly fine.
+		v = strings.TrimRight(string(b), "\r\n")
 	case stdinOK:
 		r := bufio.NewReader(os.Stdin)
 		line, err := r.ReadString('\n')
 		if err != nil && line == "" {
 			return "", fmt.Errorf("read secret from stdin: %w", err)
 		}
-		v = strings.TrimRight(line, "\n")
+		v = strings.TrimRight(line, "\r\n")
 	default:
 		return "", fmt.Errorf("provide the value via --from-env <VAR>, --from-file <path>, or pipe it on stdin")
 	}

--- a/pkg/credpool/broker.go
+++ b/pkg/credpool/broker.go
@@ -264,8 +264,13 @@ func (b *Broker) Acquire(ctx context.Context, req Request) (*Grant, error) {
 	// them. Within a want, the requester's own org pool was sorted first.
 	//
 	// A pledge is counted only when it matches one of the requested
-	// wants — a pool full of kinds the run cannot spend never inflates
-	// the number an operator reads (round 1 G6). Skips accumulate every
+	// wants AND could ever serve this requester — a pool full of kinds
+	// the run cannot spend never inflates the number an operator reads
+	// (round 1 G6), and neither does the requester's own pledge, which
+	// the walk drops without a skip (a donor never serves their own
+	// run). Counting it left the line reading "one donor considered,
+	// none declined", which is the silence #654 exists to end. Skips
+	// accumulate every
 	// pledge that DID match and yet declined, with its per-pledge
 	// status (round 1 G5): "no_eligible_pledge" now discloses which
 	// donor was paused, unhealthy, out-of-hours, bot-filtered, cooling.
@@ -273,7 +278,7 @@ func (b *Broker) Acquire(ctx context.Context, req Request) (*Grant, error) {
 	seenPledge := map[string]bool{}
 	for _, pc := range allowed {
 		for _, p := range pc.candidates {
-			if !seenPledge[p.ID] && wantMatchesPledge(req.Wants, p) {
+			if !seenPledge[p.ID] && p.UserID != req.UserID && wantMatchesPledge(req.Wants, p) {
 				seenPledge[p.ID] = true
 				pledgesConsidered++
 			}
@@ -369,13 +374,21 @@ func (b *Broker) acquireKind(ctx context.Context, pool Pool, candidates []Pledge
 
 // skipStatus names why a ledger decline held a pledge out, for the skips
 // an abstention reports. A full slot set is "serving" by definition. A
-// spend/run ceiling met while the donor has runs in flight also reads
+// SPEND ceiling met while the donor has runs in flight also reads
 // "serving": part of what tripped it is allowance PROMISED to those runs,
 // which clears as they end — the same distinction the pledge view draws
 // for the donor, approximated here without the second ledger read that
 // view pays (an operator reading a log line, not a contributor reading
 // their own page). With nothing in flight the ceiling was really spent.
+//
+// A runs-per-day ceiling is NOT that shape: the count is consumed at
+// admission and never given back, so it reads "exhausted" whether or not
+// something is in flight — the same cause must not name itself two ways
+// depending on when the operator looked.
 func (d DenyReason) skipStatus(live LiveCommitment) Status {
+	if d == DenyRunsPerDay {
+		return StatusExhausted
+	}
 	if d == DenyConcurrency || live.Runs > 0 {
 		return StatusServing
 	}

--- a/pkg/credpool/broker.go
+++ b/pkg/credpool/broker.go
@@ -18,7 +18,69 @@ import (
 // whatever it would have done with no pool at all (env credentials, or a
 // visible "no credentials" at the LLM call site). Callers should log it and
 // carry on, never abort the launch on it.
+//
+// Concrete abstentions arrive as *NoDonorError, which unwraps to this
+// sentinel so a caller using errors.Is(err, ErrNoDonor) keeps working;
+// use errors.As to extract the reason for a Warn log.
 var ErrNoDonor = errors.New("credpool: no eligible donor")
+
+// NoDonorReason names WHY the pool abstained on this request. The four
+// values match the four return sites in Acquire/resolvePools, so a caller
+// can distinguish "the deployment has no pool at all" from "every donor
+// declined this request" without parsing prose.
+type NoDonorReason string
+
+const (
+	// ReasonPoolDisabled: nil *Broker — the deployment never wired a pool,
+	// or a store required to serve one is missing.
+	ReasonPoolDisabled NoDonorReason = "pool_disabled"
+	// ReasonNoEnabledPool: pools.ListEnabled returned nothing — an operator
+	// created no pool, or every pool is off (kill switch).
+	ReasonNoEnabledPool NoDonorReason = "no_enabled_pool"
+	// ReasonAudienceRejected: some pool(s) exist, but none opened its
+	// audience to this requester (wrong org / no reciprocity / not on the
+	// team allowlist).
+	ReasonAudienceRejected NoDonorReason = "audience_rejected"
+	// ReasonNoEligiblePledge: pools admitted the request, candidate pledges
+	// were walked, but every one declined (parked, out of its sharing
+	// window, ceiling reached, bot allow-list, concurrency, ledger refusal,
+	// donor is the requester, credential vanished).
+	ReasonNoEligiblePledge NoDonorReason = "no_eligible_pledge"
+)
+
+// NoDonorError is a typed ErrNoDonor: it carries the reason for the
+// abstention plus the counts of pools/pledges considered, so an operator
+// investigating a run that landed on the platform tier can tell whether
+// the pool was mute because no pool exists, because the audience refused
+// them, or because every donor was cooling down.
+//
+// Unwrap returns ErrNoDonor so callers using errors.Is keep working; use
+// errors.As(&NoDonorError{}) to read Reason.
+type NoDonorError struct {
+	Reason            NoDonorReason
+	PoolsConsidered   int
+	PledgesConsidered int
+}
+
+// Error renders the sentinel prose followed by the reason and counts.
+// Kept short — the caller usually logs it inside a longer sentence.
+func (e *NoDonorError) Error() string {
+	if e == nil {
+		return ErrNoDonor.Error()
+	}
+	return fmt.Sprintf("%s (reason=%s pools_considered=%d pledges_considered=%d)",
+		ErrNoDonor.Error(), e.Reason, e.PoolsConsidered, e.PledgesConsidered)
+}
+
+// Unwrap keeps `errors.Is(err, ErrNoDonor)` true for every abstention.
+func (e *NoDonorError) Unwrap() error { return ErrNoDonor }
+
+// noDonor builds a typed abstention. Small helper so a new site doesn't
+// forget to wrap the sentinel (which would leave `errors.As` failing
+// silently at the caller — the same class of defect #654 fixes).
+func noDonor(reason NoDonorReason, pools, pledges int) error {
+	return &NoDonorError{Reason: reason, PoolsConsidered: pools, PledgesConsidered: pledges}
+}
 
 // Broker selects a donor for a run and closes the loop when it ends.
 //
@@ -135,7 +197,7 @@ type Grant struct {
 // currently eligible.
 func (b *Broker) Acquire(ctx context.Context, req Request) (*Grant, error) {
 	if b == nil {
-		return nil, ErrNoDonor
+		return nil, noDonor(ReasonPoolDisabled, 0, 0)
 	}
 	if req.RunID == "" {
 		return nil, fmt.Errorf("credpool: acquire without a run id")
@@ -168,6 +230,16 @@ func (b *Broker) Acquire(ctx context.Context, req Request) (*Grant, error) {
 	// Want-major: the preference between credentials is the caller's
 	// (subscriptions before metered keys), and outranks which pool holds
 	// them. Within a want, the requester's own org pool was sorted first.
+	//
+	// pledgesConsidered is the size of the union of candidate pools the
+	// walk actually inspected — a value the abstention error carries so an
+	// operator can distinguish "the audience opened but every donor was
+	// cooling" from "the audience opened but no pledge matched a want the
+	// pool ever knew about".
+	pledgesConsidered := 0
+	for _, pc := range allowed {
+		pledgesConsidered += len(pc.candidates)
+	}
 	for _, want := range req.Wants {
 		for _, pc := range allowed {
 			grant, err := b.acquireKind(ctx, pc.pool, pc.candidates, req, want, now)
@@ -179,7 +251,7 @@ func (b *Broker) Acquire(ctx context.Context, req Request) (*Grant, error) {
 			}
 		}
 	}
-	return nil, ErrNoDonor
+	return nil, noDonor(ReasonNoEligiblePledge, len(allowed), pledgesConsidered)
 }
 
 // acquireKind tries one credential kind against an already-resolved
@@ -252,7 +324,7 @@ func (b *Broker) resolvePools(ctx context.Context, req Request) ([]poolCandidate
 		return nil, err
 	}
 	if len(pools) == 0 {
-		return nil, ErrNoDonor
+		return nil, noDonor(ReasonNoEnabledPool, 0, 0)
 	}
 	// Own-org pool first: a team drawing on its own pool must not be
 	// diverted to a community one that happens to sort earlier.
@@ -289,7 +361,7 @@ func (b *Broker) resolvePools(ctx context.Context, req Request) ([]poolCandidate
 		}
 	}
 	if len(allowed) == 0 {
-		return nil, ErrNoDonor
+		return nil, noDonor(ReasonAudienceRejected, len(pools), 0)
 	}
 	return allowed, nil
 }

--- a/pkg/credpool/broker.go
+++ b/pkg/credpool/broker.go
@@ -48,18 +48,44 @@ const (
 	ReasonNoEligiblePledge NoDonorReason = "no_eligible_pledge"
 )
 
+// PledgeSkip records why one candidate pledge did not serve the
+// request. The per-pledge Status the ticket asks for — pause, unhealthy,
+// out_of_hours, bot_filtered, cooling, no_credential — collapsed to
+// `no_eligible_pledge` before round 1 G5.
+type PledgeSkip struct {
+	PledgeID string
+	Status   Status
+}
+
 // NoDonorError is a typed ErrNoDonor: it carries the reason for the
-// abstention plus the counts of pools/pledges considered, so an operator
-// investigating a run that landed on the platform tier can tell whether
-// the pool was mute because no pool exists, because the audience refused
-// them, or because every donor was cooling down.
+// abstention plus the exact counts the walk saw and the per-pledge
+// skips, so an operator investigating a run that landed on the platform
+// tier can tell whether the pool was mute because no pool exists,
+// because the audience refused them, or because every donor was cooling
+// down — and specifically which donor was in which state.
 //
-// Unwrap returns ErrNoDonor so callers using errors.Is keep working; use
-// errors.As(&NoDonorError{}) to read Reason.
+// PoolsEnabled counts every pool `pools.ListEnabled` returned;
+// PoolsAdmitted counts the subset whose audience opened to this
+// request. On `audience_rejected` PoolsAdmitted is 0 by construction;
+// on `no_eligible_pledge` PoolsAdmitted > 0 and PoolsEnabled ≥
+// PoolsAdmitted. PledgesConsidered counts pledges the walk actually
+// looked at (source+ref matches a wanted credential) — a pool full of
+// kinds the run cannot spend no longer inflates the count (round 1 G6).
+//
+// Unwrap returns ErrNoDonor so callers using errors.Is keep working;
+// use errors.As(&NoDonorError{}) to read Reason / Skips.
 type NoDonorError struct {
-	Reason            NoDonorReason
-	PoolsConsidered   int
+	Reason NoDonorReason
+	// PoolsEnabled is every enabled pool the walk saw.
+	PoolsEnabled int
+	// PoolsAdmitted is the subset whose audience admitted this request.
+	PoolsAdmitted int
+	// PledgesConsidered counts pledges of a wanted (Source, Ref) —
+	// pledges of a kind the run cannot spend are never counted.
 	PledgesConsidered int
+	// Skips names every pledge the walk considered and the reason it
+	// declined. Empty at reasons other than `no_eligible_pledge`.
+	Skips []PledgeSkip
 }
 
 // Error renders the sentinel prose followed by the reason and counts.
@@ -68,8 +94,8 @@ func (e *NoDonorError) Error() string {
 	if e == nil {
 		return ErrNoDonor.Error()
 	}
-	return fmt.Sprintf("%s (reason=%s pools_considered=%d pledges_considered=%d)",
-		ErrNoDonor.Error(), e.Reason, e.PoolsConsidered, e.PledgesConsidered)
+	return fmt.Sprintf("%s (reason=%s pools_enabled=%d pools_admitted=%d pledges_considered=%d skips=%d)",
+		ErrNoDonor.Error(), e.Reason, e.PoolsEnabled, e.PoolsAdmitted, e.PledgesConsidered, len(e.Skips))
 }
 
 // Unwrap keeps `errors.Is(err, ErrNoDonor)` true for every abstention.
@@ -78,8 +104,14 @@ func (e *NoDonorError) Unwrap() error { return ErrNoDonor }
 // noDonor builds a typed abstention. Small helper so a new site doesn't
 // forget to wrap the sentinel (which would leave `errors.As` failing
 // silently at the caller — the same class of defect #654 fixes).
-func noDonor(reason NoDonorReason, pools, pledges int) error {
-	return &NoDonorError{Reason: reason, PoolsConsidered: pools, PledgesConsidered: pledges}
+func noDonor(reason NoDonorReason, poolsEnabled, poolsAdmitted, pledgesConsidered int, skips []PledgeSkip) error {
+	return &NoDonorError{
+		Reason:            reason,
+		PoolsEnabled:      poolsEnabled,
+		PoolsAdmitted:     poolsAdmitted,
+		PledgesConsidered: pledgesConsidered,
+		Skips:             skips,
+	}
 }
 
 // Broker selects a donor for a run and closes the loop when it ends.
@@ -197,7 +229,7 @@ type Grant struct {
 // currently eligible.
 func (b *Broker) Acquire(ctx context.Context, req Request) (*Grant, error) {
 	if b == nil {
-		return nil, noDonor(ReasonPoolDisabled, 0, 0)
+		return nil, noDonor(ReasonPoolDisabled, 0, 0, 0, nil)
 	}
 	if req.RunID == "" {
 		return nil, fmt.Errorf("credpool: acquire without a run id")
@@ -222,7 +254,7 @@ func (b *Broker) Acquire(ctx context.Context, req Request) (*Grant, error) {
 	// so the retry is admitted as new.
 	b.supersedeOpenLeases(ctx, req.RunID, now)
 
-	allowed, err := b.resolvePools(ctx, req)
+	poolsEnabled, allowed, err := b.resolvePools(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -231,70 +263,123 @@ func (b *Broker) Acquire(ctx context.Context, req Request) (*Grant, error) {
 	// (subscriptions before metered keys), and outranks which pool holds
 	// them. Within a want, the requester's own org pool was sorted first.
 	//
-	// pledgesConsidered is the size of the union of candidate pools the
-	// walk actually inspected — a value the abstention error carries so an
-	// operator can distinguish "the audience opened but every donor was
-	// cooling" from "the audience opened but no pledge matched a want the
-	// pool ever knew about".
+	// A pledge is counted only when it matches one of the requested
+	// wants — a pool full of kinds the run cannot spend never inflates
+	// the number an operator reads (round 1 G6). Skips accumulate every
+	// pledge that DID match and yet declined, with its per-pledge
+	// status (round 1 G5): "no_eligible_pledge" now discloses which
+	// donor was paused, unhealthy, out-of-hours, bot-filtered, cooling.
 	pledgesConsidered := 0
+	seenPledge := map[string]bool{}
 	for _, pc := range allowed {
-		pledgesConsidered += len(pc.candidates)
+		for _, p := range pc.candidates {
+			if !seenPledge[p.ID] && wantMatchesPledge(req.Wants, p) {
+				seenPledge[p.ID] = true
+				pledgesConsidered++
+			}
+		}
 	}
+	var allSkips []PledgeSkip
+	seenSkip := map[string]bool{}
 	for _, want := range req.Wants {
 		for _, pc := range allowed {
-			grant, err := b.acquireKind(ctx, pc.pool, pc.candidates, req, want, now)
+			grant, skips, err := b.acquireKind(ctx, pc.pool, pc.candidates, req, want, now)
 			if err != nil {
 				return nil, err
+			}
+			for _, s := range skips {
+				if !seenSkip[s.PledgeID] {
+					seenSkip[s.PledgeID] = true
+					allSkips = append(allSkips, s)
+				}
 			}
 			if grant != nil {
 				return grant, nil
 			}
 		}
 	}
-	return nil, noDonor(ReasonNoEligiblePledge, len(allowed), pledgesConsidered)
+	return nil, noDonor(ReasonNoEligiblePledge, poolsEnabled, len(allowed), pledgesConsidered, allSkips)
+}
+
+// wantMatchesPledge reports whether the pledge is of a kind any of the
+// requested wants would take — the eligibility filter for the "how many
+// pledges did the walk actually consider?" count.
+func wantMatchesPledge(wants []Credential, p Pledge) bool {
+	for _, w := range wants {
+		if p.Source == w.Source && p.Ref == w.Ref {
+			return true
+		}
+	}
+	return false
 }
 
 // acquireKind tries one credential kind against an already-resolved
-// candidate list. Returns (nil, nil) when no donor of that kind can serve —
-// the caller falls through to the next kind.
-func (b *Broker) acquireKind(ctx context.Context, pool Pool, candidates []Pledge, req Request, want Credential, now time.Time) (*Grant, error) {
+// candidate list. Returns (nil, skips, nil) when no donor of that kind
+// can serve — the caller falls through to the next kind. `skips` names
+// every candidate the walk did NOT admit and the per-pledge status the
+// caller can carry on NoDonorError.
+func (b *Broker) acquireKind(ctx context.Context, pool Pool, candidates []Pledge, req Request, want Credential, now time.Time) (*Grant, []PledgeSkip, error) {
 	eligible := make([]Pledge, 0, len(candidates))
+	var skips []PledgeSkip
 	for _, p := range candidates {
 		if p.Source != want.Source || p.Ref != want.Ref {
 			continue
 		}
 		// A donor never serves their own run: they would be lending to
 		// themselves, consuming pool bookkeeping for nothing and skewing
-		// the fairness ranking against the other donors.
+		// the fairness ranking against the other donors. Not a "skip"
+		// worth reporting: no operator investigation ever asks that.
 		if p.UserID == req.UserID {
 			continue
 		}
-		if ok, _ := p.AvailableForLaunch(now, req.BotID); ok {
+		if ok, status := p.AvailableForLaunch(now, req.BotID); ok {
 			eligible = append(eligible, p)
+		} else {
+			skips = append(skips, PledgeSkip{PledgeID: p.ID, Status: status})
 		}
 	}
 	if len(eligible) == 0 {
-		return nil, nil
+		return nil, skips, nil
 	}
 
 	ranked, err := b.rank(ctx, eligible, now)
 	if err != nil {
-		return nil, err
+		return nil, skips, err
 	}
 
 	// Walk the ranking: a donor whose ledger refuses (raced to their cap,
-	// concurrency full) simply yields to the next.
+	// concurrency full) or whose credential is gone simply yields to the
+	// next — and lands on the skips list under the status tryPledge
+	// decided, so the operator can tell "exhausted" from "serving" from
+	// "unhealthy" from "paused".
 	for _, p := range ranked {
-		grant, err := b.tryPledge(ctx, pool, p, req, now)
+		grant, status, err := b.tryPledge(ctx, pool, p, req, now)
 		if err != nil {
 			b.logger.Warn("credpool: pledge %s unusable for run %s: %v", p.ID, req.RunID, err)
+			skips = append(skips, PledgeSkip{PledgeID: p.ID, Status: StatusUnhealthy})
 			continue
 		}
 		if grant != nil {
-			return grant, nil
+			return grant, skips, nil
 		}
+		skips = append(skips, PledgeSkip{PledgeID: p.ID, Status: status})
 	}
-	return nil, nil
+	return nil, skips, nil
+}
+
+// skipStatus names why a ledger decline held a pledge out, for the skips
+// an abstention reports. A full slot set is "serving" by definition. A
+// spend/run ceiling met while the donor has runs in flight also reads
+// "serving": part of what tripped it is allowance PROMISED to those runs,
+// which clears as they end — the same distinction the pledge view draws
+// for the donor, approximated here without the second ledger read that
+// view pays (an operator reading a log line, not a contributor reading
+// their own page). With nothing in flight the ceiling was really spent.
+func (d DenyReason) skipStatus(live LiveCommitment) Status {
+	if d == DenyConcurrency || live.Runs > 0 {
+		return StatusServing
+	}
+	return StatusExhausted
 }
 
 // poolCandidates is one pool this requester may draw on, with its pledges.
@@ -318,13 +403,14 @@ type poolCandidates struct {
 // owning org is unreachable configuration. A deployment runs a handful of
 // pools, so this is a small list, and the requester's own org pool wins
 // when several would serve.
-func (b *Broker) resolvePools(ctx context.Context, req Request) ([]poolCandidates, error) {
+func (b *Broker) resolvePools(ctx context.Context, req Request) (poolsEnabled int, allowed []poolCandidates, err error) {
 	pools, err := b.pools.ListEnabled(ctx)
 	if err != nil {
-		return nil, err
+		return 0, nil, err
 	}
-	if len(pools) == 0 {
-		return nil, noDonor(ReasonNoEnabledPool, 0, 0)
+	poolsEnabled = len(pools)
+	if poolsEnabled == 0 {
+		return 0, nil, noDonor(ReasonNoEnabledPool, 0, 0, 0, nil)
 	}
 	// Own-org pool first: a team drawing on its own pool must not be
 	// diverted to a community one that happens to sort earlier.
@@ -336,11 +422,11 @@ func (b *Broker) resolvePools(ctx context.Context, req Request) ([]poolCandidate
 		return pools[i].ID < pools[j].ID
 	})
 	now := b.now()
-	allowed := make([]poolCandidates, 0, len(pools))
+	allowed = make([]poolCandidates, 0, len(pools))
 	for _, pool := range pools {
-		candidates, err := b.pledges.ListByPool(ctx, pool.ID)
-		if err != nil {
-			return nil, err
+		candidates, lerr := b.pledges.ListByPool(ctx, pool.ID)
+		if lerr != nil {
+			return 0, nil, lerr
 		}
 		hasActivePledge := false
 		if pool.Audience.NeedsPledgeLookup() && req.UserID != "" {
@@ -361,9 +447,9 @@ func (b *Broker) resolvePools(ctx context.Context, req Request) ([]poolCandidate
 		}
 	}
 	if len(allowed) == 0 {
-		return nil, noDonor(ReasonAudienceRejected, len(pools), 0)
+		return poolsEnabled, nil, noDonor(ReasonAudienceRejected, poolsEnabled, 0, 0, nil)
 	}
-	return allowed, nil
+	return poolsEnabled, allowed, nil
 }
 
 // rank orders eligible pledges by fairness: least consumed today first
@@ -416,7 +502,10 @@ func (b *Broker) rank(ctx context.Context, eligible []Pledge, now time.Time) ([]
 // tryPledge attempts one donor: concurrency + ledger admission, then
 // unsealing the credential and recording the lease. Returns (nil, nil) when
 // the donor declined for a quota reason — the caller moves on.
-func (b *Broker) tryPledge(ctx context.Context, pool Pool, p Pledge, req Request, now time.Time) (*Grant, error) {
+// tryPledge admits one eligible pledge or explains why not: a nil grant
+// with a Status names the decline (exhausted, serving, unhealthy) for the
+// abstention's skips; an error is a store failure the caller reports.
+func (b *Broker) tryPledge(ctx context.Context, pool Pool, p Pledge, req Request, now time.Time) (*Grant, Status, error) {
 	// What this donor already has at stake: the runs they are serving and
 	// the allowance promised to them. Both bound this admission — without
 	// the promised half, ten runs launched together would each be handed
@@ -427,7 +516,7 @@ func (b *Broker) tryPledge(ctx context.Context, pool Pool, p Pledge, req Request
 	// itself.
 	liveRuns, committed, err := b.leases.LiveCommitment(ctx, p.ID, req.RunID, now)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	live := LiveCommitment{Runs: liveRuns, CommittedUSD: committed}
 
@@ -439,7 +528,7 @@ func (b *Broker) tryPledge(ctx context.Context, pool Pool, p Pledge, req Request
 	// against it forever would let a crash-looping run draw unmetered.
 	readmitting, err := b.leases.HasServedAttempt(ctx, req.RunID, p.ID)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	var remaining float64
@@ -450,11 +539,11 @@ func (b *Broker) tryPledge(ctx context.Context, pool Pool, p Pledge, req Request
 		remaining, deny, err = b.ledger.Reserve(ctx, p.ID, now, p.Limits, live)
 	}
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if deny != DenyNone {
 		b.logger.Debug("credpool: pledge %s declined run %s (%s)", p.ID, req.RunID, deny)
-		return nil, nil
+		return nil, deny.skipStatus(live), nil
 	}
 
 	// From here on, any failure must give back whatever was consumed.
@@ -468,14 +557,14 @@ func (b *Broker) tryPledge(ctx context.Context, pool Pool, p Pledge, req Request
 	payload, fingerprint, gone, err := b.openCredential(ctx, p, now)
 	if err != nil {
 		release()
-		return nil, err
+		return nil, "", err
 	}
 	if gone != "" {
 		release()
 		// The donor pledged a credential that is no longer usable. Park the
 		// pledge rather than re-discovering this on every launch.
 		b.markUnhealthy(ctx, p.ID, HealthTokenExpired, gone)
-		return nil, nil
+		return nil, StatusUnhealthy, nil
 	}
 
 	lease := Lease{
@@ -495,7 +584,7 @@ func (b *Broker) tryPledge(ctx context.Context, pool Pool, p Pledge, req Request
 	}
 	if err := b.leases.Put(ctx, lease); err != nil {
 		release()
-		return nil, fmt.Errorf("credpool: record lease: %w", err)
+		return nil, "", fmt.Errorf("credpool: record lease: %w", err)
 	}
 
 	// Best-effort fairness bookkeeping; a miss only costs tie-break
@@ -513,7 +602,7 @@ func (b *Broker) tryPledge(ctx context.Context, pool Pool, p Pledge, req Request
 		Payload:      payload,
 		Fingerprint:  fingerprint,
 		RemainingUSD: remaining,
-	}, nil
+	}, "", nil
 }
 
 // meteredNote flags, in the launch log, the case where the allowance is

--- a/pkg/credpool/broker_test.go
+++ b/pkg/credpool/broker_test.go
@@ -718,7 +718,6 @@ func TestBroker_reciprocityAdmitsAForeignDonor(t *testing.T) {
 	}
 }
 
-
 // Every abstention arrives as a *NoDonorError naming WHY the pool did
 // not serve — the fix for #654, which observed a run fall silently
 // through the pool tier onto the platform credential ("half a day of

--- a/pkg/credpool/broker_test.go
+++ b/pkg/credpool/broker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -755,7 +756,7 @@ func TestBroker_AbstentionCarriesTypedReason(t *testing.T) {
 		}
 	})
 
-	t.Run("audience refuses → audience_rejected + pools_considered", func(t *testing.T) {
+	t.Run("audience refuses → audience_rejected + pools_enabled", func(t *testing.T) {
 		h := newHarness(t)
 		// A pool that opens itself only to its own org, called from a
 		// different org, is the reference case for audience rejection.
@@ -775,8 +776,8 @@ func TestBroker_AbstentionCarriesTypedReason(t *testing.T) {
 		if nd.Reason != ReasonAudienceRejected {
 			t.Errorf("reason = %q, want %q", nd.Reason, ReasonAudienceRejected)
 		}
-		if nd.PoolsConsidered != 1 {
-			t.Errorf("pools_considered = %d, want 1", nd.PoolsConsidered)
+		if nd.PoolsEnabled != 1 {
+			t.Errorf("pools_enabled = %d, want 1", nd.PoolsEnabled)
 		}
 	})
 
@@ -799,11 +800,159 @@ func TestBroker_AbstentionCarriesTypedReason(t *testing.T) {
 		if nd.Reason != ReasonNoEligiblePledge {
 			t.Errorf("reason = %q, want %q", nd.Reason, ReasonNoEligiblePledge)
 		}
-		if nd.PoolsConsidered != 1 {
-			t.Errorf("pools_considered = %d, want 1 (audience opened one pool)", nd.PoolsConsidered)
+		if nd.PoolsEnabled != 1 || nd.PoolsAdmitted != 1 {
+			t.Errorf("pools_enabled/admitted = %d/%d, want 1/1", nd.PoolsEnabled, nd.PoolsAdmitted)
 		}
 		if nd.PledgesConsidered != 1 {
 			t.Errorf("pledges_considered = %d, want 1 (one pledge on the pool, disabled)", nd.PledgesConsidered)
 		}
+		// #654 G5: the per-pledge skip carries the exact status the ticket
+		// asks for (paused / unhealthy / out_of_hours / bot_filtered /
+		// cooling), so an operator no longer sees the whole set collapse
+		// to a single reason.
+		if len(nd.Skips) != 1 || nd.Skips[0].Status != StatusPaused {
+			t.Errorf("skips = %+v, want one entry with status=%q for the paused donor", nd.Skips, StatusPaused)
+		}
 	})
+}
+
+// #654 G5: `no_eligible_pledge` used to swallow every per-pledge state —
+// a paused donor, a dead token, a closed sharing window, a bot allow-list
+// miss, a cooling quota, a spent ceiling and a full slot set all read the
+// same. Each case below seeds ONE donor in exactly that state and reads
+// the status the abstention names for them.
+func TestBroker_AbstentionSkipsNameEachPledgeStatus(t *testing.T) {
+	ctx := context.Background()
+	skipOf := func(t *testing.T, h *harness, runID string) PledgeSkip {
+		t.Helper()
+		_, err := h.broker.Acquire(ctx, h.request(runID))
+		var nd *NoDonorError
+		if !errors.As(err, &nd) {
+			t.Fatalf("want *NoDonorError, got %v", err)
+		}
+		if nd.Reason != ReasonNoEligiblePledge {
+			t.Fatalf("reason = %q, want %q", nd.Reason, ReasonNoEligiblePledge)
+		}
+		if len(nd.Skips) != 1 {
+			t.Fatalf("skips = %+v, want exactly the one donor", nd.Skips)
+		}
+		return nd.Skips[0]
+	}
+
+	t.Run("paused", func(t *testing.T) {
+		h := newHarness(t)
+		h.donor(t, "alice", Limits{}, func(p *Pledge) { p.Enabled = false })
+		if got := skipOf(t, h, "r"); got.Status != StatusPaused || got.PledgeID != PledgeID("alice", SourceOAuth, "claude_code") {
+			t.Errorf("skip = %+v, want alice paused", got)
+		}
+	})
+	t.Run("unhealthy (auth failing)", func(t *testing.T) {
+		h := newHarness(t)
+		h.donor(t, "alice", Limits{}, func(p *Pledge) { p.Health = HealthAuthFailed })
+		if got := skipOf(t, h, "r"); got.Status != StatusUnhealthy {
+			t.Errorf("skip = %+v, want unhealthy", got)
+		}
+	})
+	t.Run("out_of_hours", func(t *testing.T) {
+		h := newHarness(t)
+		// h.now is 12:00 UTC; a 01:00–02:00 window is shut.
+		h.donor(t, "alice", Limits{}, func(p *Pledge) { p.Window = &Window{StartHour: 1, EndHour: 2} })
+		if got := skipOf(t, h, "r"); got.Status != StatusOutOfHours {
+			t.Errorf("skip = %+v, want out_of_hours", got)
+		}
+	})
+	t.Run("bot_filtered", func(t *testing.T) {
+		h := newHarness(t)
+		h.donor(t, "alice", Limits{}, func(p *Pledge) { p.Bots = []string{"some-other-bot"} })
+		if got := skipOf(t, h, "r"); got.Status != StatusBotFiltered {
+			t.Errorf("skip = %+v, want bot_filtered", got)
+		}
+	})
+	t.Run("cooling", func(t *testing.T) {
+		h := newHarness(t)
+		until := h.now.Add(time.Hour)
+		h.donor(t, "alice", Limits{}, func(p *Pledge) { p.CooldownUntil = &until })
+		if got := skipOf(t, h, "r"); got.Status != StatusCooling {
+			t.Errorf("skip = %+v, want cooling", got)
+		}
+	})
+	t.Run("exhausted (daily run ceiling really spent)", func(t *testing.T) {
+		h := newHarness(t)
+		h.donor(t, "alice", Limits{MaxRunsPerDay: 1})
+		if _, err := h.broker.Acquire(ctx, h.request("r1")); err != nil {
+			t.Fatalf("first run must be served: %v", err)
+		}
+		// Settle the run so nothing is in flight: the next refusal is a
+		// ceiling REALLY spent, not allowance promised to a live run.
+		if err := h.broker.Report(ctx, "r1", Outcome{Condition: ConditionOK}); err != nil {
+			t.Fatalf("report: %v", err)
+		}
+		if got := skipOf(t, h, "r2"); got.Status != StatusExhausted {
+			t.Errorf("skip = %+v, want exhausted", got)
+		}
+	})
+	t.Run("serving (every allowed slot busy)", func(t *testing.T) {
+		h := newHarness(t)
+		h.donor(t, "alice", Limits{MaxConcurrentRuns: 1})
+		if _, err := h.broker.Acquire(ctx, h.request("r1")); err != nil {
+			t.Fatalf("first run must be served: %v", err)
+		}
+		if got := skipOf(t, h, "r2"); got.Status != StatusServing {
+			t.Errorf("skip = %+v, want serving", got)
+		}
+	})
+	t.Run("credential gone (parked as unhealthy)", func(t *testing.T) {
+		h := newHarness(t)
+		h.donor(t, "alice", Limits{})
+		if err := h.oauth.Delete(ctx, "alice", secrets.OAuthKindClaudeCode); err != nil {
+			t.Fatalf("delete donor credential: %v", err)
+		}
+		if got := skipOf(t, h, "r"); got.Status != StatusUnhealthy {
+			t.Errorf("skip = %+v, want unhealthy", got)
+		}
+	})
+}
+
+// #654 G6: the counts an abstention carries mean one thing each.
+// PoolsEnabled is every enabled pool; PoolsAdmitted the subset whose
+// audience opened to this request; PledgesConsidered only the pledges of
+// a kind the run asked for — a pool full of codex subscriptions does not
+// inflate the count on a claude_code request.
+func TestBroker_AbstentionCountsMeanOneThingEach(t *testing.T) {
+	ctx := context.Background()
+	h := newHarness(t)
+	// A second enabled pool, closed to the requester's org.
+	if err := h.pools.Upsert(ctx, Pool{ID: "pool-closed", OrgID: "someone-else", Enabled: true}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	// One matching donor, paused; one codex pledge the request never asks for.
+	h.donor(t, "alice", Limits{}, func(p *Pledge) { p.Enabled = false })
+	if err := h.pledges.Upsert(ctx, Pledge{
+		ID: PledgeID("bob", SourceOAuth, string(secrets.OAuthKindCodex)), PoolID: "pool-1",
+		UserID: "bob", Credential: Credential{Source: SourceOAuth, Ref: string(secrets.OAuthKindCodex)},
+		Enabled: true, Health: HealthOK,
+	}); err != nil {
+		t.Fatalf("seed codex pledge: %v", err)
+	}
+
+	_, err := h.broker.Acquire(ctx, h.request("r"))
+	var nd *NoDonorError
+	if !errors.As(err, &nd) {
+		t.Fatalf("want *NoDonorError, got %v", err)
+	}
+	if nd.PoolsEnabled != 2 {
+		t.Errorf("pools_enabled = %d, want 2 (both enabled pools)", nd.PoolsEnabled)
+	}
+	if nd.PoolsAdmitted != 1 {
+		t.Errorf("pools_admitted = %d, want 1 (the closed pool's audience refused)", nd.PoolsAdmitted)
+	}
+	if nd.PledgesConsidered != 1 {
+		t.Errorf("pledges_considered = %d, want 1 (bob's codex pledge is not a wanted kind)", nd.PledgesConsidered)
+	}
+	if len(nd.Skips) != 1 || nd.Skips[0].PledgeID != PledgeID("alice", SourceOAuth, "claude_code") {
+		t.Errorf("skips = %+v, want alice only", nd.Skips)
+	}
+	if !strings.Contains(nd.Error(), "pools_enabled=2") || !strings.Contains(nd.Error(), "pools_admitted=1") {
+		t.Errorf("Error() = %q, want both pool counts rendered", nd.Error())
+	}
 }

--- a/pkg/credpool/broker_test.go
+++ b/pkg/credpool/broker_test.go
@@ -717,3 +717,94 @@ func TestBroker_reciprocityAdmitsAForeignDonor(t *testing.T) {
 		t.Errorf("paused contributor = %v, want ErrNoDonor", err)
 	}
 }
+
+
+// Every abstention arrives as a *NoDonorError naming WHY the pool did
+// not serve — the fix for #654, which observed a run fall silently
+// through the pool tier onto the platform credential ("half a day of
+// investigation on a path that decides who pays"). Each of the four
+// abstention sites reports the reason it decided on, and all four
+// still unwrap to ErrNoDonor so callers using errors.Is keep working.
+func TestBroker_AbstentionCarriesTypedReason(t *testing.T) {
+	t.Run("nil broker → pool_disabled", func(t *testing.T) {
+		var b *Broker
+		_, err := b.Acquire(context.Background(), Request{RunID: "r"})
+		if !errors.Is(err, ErrNoDonor) {
+			t.Fatalf("errors.Is(err, ErrNoDonor) = false; got %v", err)
+		}
+		var nd *NoDonorError
+		if !errors.As(err, &nd) {
+			t.Fatalf("errors.As(*NoDonorError) = false; got %T %v", err, err)
+		}
+		if nd.Reason != ReasonPoolDisabled {
+			t.Errorf("reason = %q, want %q", nd.Reason, ReasonPoolDisabled)
+		}
+	})
+
+	t.Run("no enabled pool → no_enabled_pool", func(t *testing.T) {
+		h := newHarness(t)
+		_ = h.pools.Upsert(context.Background(), Pool{ID: "pool-1", OrgID: testOrg, Enabled: false})
+		req := h.request("r1")
+		req.Wants = []Credential{{Source: SourceOAuth, Ref: string(secrets.OAuthKindClaudeCode)}}
+		_, err := h.broker.Acquire(context.Background(), req)
+		var nd *NoDonorError
+		if !errors.As(err, &nd) {
+			t.Fatalf("errors.As failed on %v", err)
+		}
+		if nd.Reason != ReasonNoEnabledPool {
+			t.Errorf("reason = %q, want %q", nd.Reason, ReasonNoEnabledPool)
+		}
+	})
+
+	t.Run("audience refuses → audience_rejected + pools_considered", func(t *testing.T) {
+		h := newHarness(t)
+		// A pool that opens itself only to its own org, called from a
+		// different org, is the reference case for audience rejection.
+		if err := h.pools.Upsert(context.Background(), Pool{
+			ID: "pool-closed", OrgID: "someone-else", Enabled: true,
+		}); err != nil {
+			t.Fatalf("seed second pool: %v", err)
+		}
+		_ = h.pools.Upsert(context.Background(), Pool{ID: "pool-1", OrgID: testOrg, Enabled: false}) // leave only the closed one enabled
+		req := h.request("r2")
+		req.OrgID = "requesting-org" // audience.Allows will refuse
+		_, err := h.broker.Acquire(context.Background(), req)
+		var nd *NoDonorError
+		if !errors.As(err, &nd) {
+			t.Fatalf("errors.As failed on %v", err)
+		}
+		if nd.Reason != ReasonAudienceRejected {
+			t.Errorf("reason = %q, want %q", nd.Reason, ReasonAudienceRejected)
+		}
+		if nd.PoolsConsidered != 1 {
+			t.Errorf("pools_considered = %d, want 1", nd.PoolsConsidered)
+		}
+	})
+
+	t.Run("candidates walked but none served → no_eligible_pledge + counts", func(t *testing.T) {
+		h := newHarness(t)
+		// One donor whose pledge is DISABLED — passes audience, walks the
+		// candidates, and every one declines at eligibility. This is the
+		// "every donor is currently unavailable" case, mute in prod.
+		p := h.donor(t, "alice", Limits{})
+		p.Enabled = false
+		if err := h.pledges.Upsert(context.Background(), p); err != nil {
+			t.Fatalf("disable pledge: %v", err)
+		}
+		req := h.request("r3")
+		_, err := h.broker.Acquire(context.Background(), req)
+		var nd *NoDonorError
+		if !errors.As(err, &nd) {
+			t.Fatalf("errors.As failed on %v", err)
+		}
+		if nd.Reason != ReasonNoEligiblePledge {
+			t.Errorf("reason = %q, want %q", nd.Reason, ReasonNoEligiblePledge)
+		}
+		if nd.PoolsConsidered != 1 {
+			t.Errorf("pools_considered = %d, want 1 (audience opened one pool)", nd.PoolsConsidered)
+		}
+		if nd.PledgesConsidered != 1 {
+			t.Errorf("pledges_considered = %d, want 1 (one pledge on the pool, disabled)", nd.PledgesConsidered)
+		}
+	})
+}

--- a/pkg/credpool/broker_test.go
+++ b/pkg/credpool/broker_test.go
@@ -891,6 +891,20 @@ func TestBroker_AbstentionSkipsNameEachPledgeStatus(t *testing.T) {
 			t.Errorf("skip = %+v, want exhausted", got)
 		}
 	})
+	t.Run("exhausted (daily run ceiling, WITH a run still in flight)", func(t *testing.T) {
+		h := newHarness(t)
+		h.donor(t, "alice", Limits{MaxRunsPerDay: 1})
+		if _, err := h.broker.Acquire(ctx, h.request("r1")); err != nil {
+			t.Fatalf("first run must be served: %v", err)
+		}
+		// r1 is NOT settled: the day's single run is spent all the same —
+		// a runs-per-day count is consumed at admission and never returned,
+		// so the same cause must not read "serving" here and "exhausted"
+		// once r1 ends.
+		if got := skipOf(t, h, "r2"); got.Status != StatusExhausted {
+			t.Errorf("skip = %+v, want exhausted even with a run in flight", got)
+		}
+	})
 	t.Run("serving (every allowed slot busy)", func(t *testing.T) {
 		h := newHarness(t)
 		h.donor(t, "alice", Limits{MaxConcurrentRuns: 1})
@@ -954,5 +968,34 @@ func TestBroker_AbstentionCountsMeanOneThingEach(t *testing.T) {
 	}
 	if !strings.Contains(nd.Error(), "pools_enabled=2") || !strings.Contains(nd.Error(), "pools_admitted=1") {
 		t.Errorf("Error() = %q, want both pool counts rendered", nd.Error())
+	}
+}
+
+// The requester's own pledge is dropped by the walk without a skip (a
+// donor never serves their own run), so counting it produced the least
+// useful line the pool can print: "one donor considered, none declined"
+// — the silence #654 exists to end, dressed as a number.
+func TestBroker_AbstentionDoesNotCountTheRequestersOwnPledge(t *testing.T) {
+	ctx := context.Background()
+	h := newHarness(t)
+	// The ONLY matching pledge belongs to the requester.
+	if err := h.pledges.Upsert(ctx, Pledge{
+		ID: PledgeID("requester", SourceOAuth, string(secrets.OAuthKindClaudeCode)), PoolID: "pool-1",
+		UserID: "requester", Credential: Credential{Source: SourceOAuth, Ref: string(secrets.OAuthKindClaudeCode)},
+		Enabled: true, Health: HealthOK,
+	}); err != nil {
+		t.Fatalf("seed own pledge: %v", err)
+	}
+
+	_, err := h.broker.Acquire(ctx, h.request("r"))
+	var nd *NoDonorError
+	if !errors.As(err, &nd) {
+		t.Fatalf("want *NoDonorError, got %v", err)
+	}
+	if nd.PledgesConsidered != 0 {
+		t.Errorf("pledges_considered = %d, want 0 — the requester's own pledge could never serve them", nd.PledgesConsidered)
+	}
+	if len(nd.Skips) != 0 {
+		t.Errorf("skips = %+v, want none", nd.Skips)
 	}
 }

--- a/pkg/dsl/ir/uses_llm.go
+++ b/pkg/dsl/ir/uses_llm.go
@@ -113,6 +113,15 @@ func (w *Workflow) AlwaysReachesLLM() bool {
 	return true
 }
 
+// NodeUsesLLM reports whether one node can call a model — the per-node
+// half of UsesLLM, exported for the walks outside this package that must
+// stay CONSERVATIVE about spend (a credential-wants derivation that
+// narrows a pool request, a usage-cap wire predicate): a node this answers
+// true for but that exposes no LLMFields (a human node answering with a
+// model, a Verified Action's agent rung, a subbot) cannot be resolved to
+// a provider, and a caller must widen rather than assume it spends nothing.
+func NodeUsesLLM(n Node) bool { return nodeUsesLLM(n) }
+
 // nodeUsesLLM answers for one node. Kept separate so the reasoning per node
 // kind stays readable, and each `true` names why it is one.
 func nodeUsesLLM(n Node) bool {

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -1411,7 +1411,7 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 	// container: at this point the run has cost nothing yet, so a capped
 	// run parks for free instead of paying a workspace and one LLM call to
 	// rediscover a ceiling another pod already measured.
-	if capErr := r.usageCapPreflight(ctx, wf, msg, r.cfg.Logger); capErr != nil {
+	if capErr := r.admitAttempt(ctx, wf, msg); capErr != nil {
 		return capErr
 	}
 

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -2073,4 +2073,3 @@ func modelOverridesFromMsg(entries []queue.ModelOverride) model.ModelOverrides {
 	}
 	return model.OverridesFrom(out)
 }
-

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -2043,10 +2043,6 @@ func stringifyVars(in map[string]any) (map[string]string, error) {
 	return out, nil
 }
 
-// modelOverridesFromMsg folds the wire pins into the executor's override
-// set — the runner-side twin of runview's launch-entry fold, so a cloud
-// run resolves per-node models exactly like a local launch with the same
-// flags.
 // runFallbackFromMsg folds the wire chain into the IR form the executor
 // applies. Names are stamped here (not on the wire) so every consumer
 // reports the stages under the recognisable launch-route label.
@@ -2066,18 +2062,14 @@ func runFallbackFromMsg(entries queue.RunFallback) []ir.Fallback {
 	return out
 }
 
+// modelOverridesFromMsg adapts the wire pins onto model.OverridesFrom —
+// the one fold runview's launch entries and the publisher's launch/resume
+// entries also go through, so a cloud run resolves per-node models
+// exactly like a local launch with the same flags.
 func modelOverridesFromMsg(entries []queue.ModelOverride) model.ModelOverrides {
-	var o model.ModelOverrides
-	for _, e := range entries {
-		if e.Backend != "" {
-			o.SetBackend(e.Selector, e.Backend)
-		}
-		if e.Model != "" {
-			o.SetModel(e.Selector, e.Model)
-		}
-		if e.Provider != "" {
-			o.SetProvider(e.Selector, e.Provider)
-		}
+	out := make([]model.OverrideEntry, len(entries))
+	for i, e := range entries {
+		out[i] = model.OverrideEntry{Selector: e.Selector, Backend: e.Backend, Model: e.Model, Provider: e.Provider}
 	}
-	return o
+	return model.OverridesFrom(out)
 }

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -608,6 +608,14 @@ type Config struct {
 	// RunBundle.GenericSecretRefs. nil → no refresh (snapshot only).
 	GenericSecrets secrets.GenericSecretStore
 
+	// ApiKeys, when non-nil, is the BYOK store shared with the publisher.
+	// The runner bumps `last_used_at` on every credential the run actually
+	// spent tokens on at metering time (recordOrgSpend), so the studio
+	// distinguishes an idle key from one currently serving — the mute
+	// launch-grant-only signal fixed by #659 pt 2. nil disables the bump;
+	// today's launch-time-only behaviour is preserved byte-identical.
+	ApiKeys secrets.ApiKeyStore
+
 	// UsageCapSource answers the operator's ceiling on the LLM
 	// subscription's own usage windows (pkg/usagecap) — consulted per
 	// evaluation, so a DB-backed source (usagecap.Resolver) makes a
@@ -1581,8 +1589,10 @@ func (r *Runner) executeRun(ctx context.Context, msg *queue.RunMessage, usageOut
 	// Charge the run's spend whatever the outcome — paused, cancelled and
 	// failed attempts incurred real LLM spend. The credential pool's half is
 	// reported by the caller instead, which alone knows whether this
-	// delivery is the last one.
-	defer func() { r.recordOrgSpend(msg, usage) }()
+	// delivery is the last one. Ctx captures the credentials the executor
+	// runs under so #659 pt 2's `last_used_at` bump reads the same
+	// fingerprints the delegate actually spent tokens on.
+	defer func() { r.recordOrgSpend(ctx, msg, usage) }()
 
 	engineOpts := []runtime.EngineOption{
 		runtime.WithLogger(runLogger),

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -2074,16 +2074,3 @@ func modelOverridesFromMsg(entries []queue.ModelOverride) model.ModelOverrides {
 	return model.OverridesFrom(out)
 }
 
-// runFallbackEntriesFromMsg adapts the wire chain onto the neutral shape
-// the pre-run analyses read (the usage-cap wire predicate) — the runner
-// twin of the publisher's launch/resume adapters.
-func runFallbackEntriesFromMsg(entries queue.RunFallback) []model.FallbackEntry {
-	if len(entries) == 0 {
-		return nil
-	}
-	out := make([]model.FallbackEntry, len(entries))
-	for i, e := range entries {
-		out[i] = model.FallbackEntry{Backend: e.Backend, Model: e.Model, Provider: e.Provider}
-	}
-	return out
-}

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -2073,3 +2073,17 @@ func modelOverridesFromMsg(entries []queue.ModelOverride) model.ModelOverrides {
 	}
 	return model.OverridesFrom(out)
 }
+
+// runFallbackEntriesFromMsg adapts the wire chain onto the neutral shape
+// the pre-run analyses read (the usage-cap wire predicate) — the runner
+// twin of the publisher's launch/resume adapters.
+func runFallbackEntriesFromMsg(entries queue.RunFallback) []model.FallbackEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]model.FallbackEntry, len(entries))
+	for i, e := range entries {
+		out[i] = model.FallbackEntry{Backend: e.Backend, Model: e.Model, Provider: e.Provider}
+	}
+	return out
+}

--- a/pkg/runner/loop_credentials.go
+++ b/pkg/runner/loop_credentials.go
@@ -139,10 +139,6 @@ func (r *Runner) injectCredentials(ctx context.Context, msg *queue.RunMessage) (
 		r.startOAuthRefreshers(stopRefresh, msg.RunID, refreshFiles)
 	}
 	ctx = secrets.WithCredentials(ctx, creds)
-	// The attempt holds these keys from here on: say so now, not only when
-	// it ends — a multi-hour attempt otherwise reads as an idle key for
-	// its whole duration (#659 pt 2).
-	r.markCredFingerprintsUsed(ctx, msg, time.Now().UTC())
 	return ctx, cleanup, nil
 }
 

--- a/pkg/runner/loop_credentials.go
+++ b/pkg/runner/loop_credentials.go
@@ -138,7 +138,12 @@ func (r *Runner) injectCredentials(ctx context.Context, msg *queue.RunMessage) (
 		cancelRefresh = func() { once.Do(func() { close(stopRefresh) }) }
 		r.startOAuthRefreshers(stopRefresh, msg.RunID, refreshFiles)
 	}
-	return secrets.WithCredentials(ctx, creds), cleanup, nil
+	ctx = secrets.WithCredentials(ctx, creds)
+	// The attempt holds these keys from here on: say so now, not only when
+	// it ends — a multi-hour attempt otherwise reads as an idle key for
+	// its whole duration (#659 pt 2).
+	r.markCredFingerprintsUsed(ctx, msg, time.Now().UTC())
+	return ctx, cleanup, nil
 }
 
 // deleteRunSecrets best-effort removes the persistent sealed bundle for

--- a/pkg/runner/loop_spend.go
+++ b/pkg/runner/loop_spend.go
@@ -9,36 +9,91 @@ import (
 	"github.com/SocialGouv/iterion/pkg/queue"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/runtime/recovery"
+	"github.com/SocialGouv/iterion/pkg/secrets"
 )
 
 // recordOrgSpend charges the run's accumulated LLM consumption to the
-// org's monthly usage bucket. Called at the end of every execution
+// org's monthly usage bucket AND bumps `last_used_at` on every credential
+// the run actually spent tokens on. Called at the end of every execution
 // attempt — paused/cancelled/failed attempts incurred real spend too,
 // and a redelivered attempt re-charges only what it re-executed.
-// Detached ctx: a Mongo blip must not fail the run path; the miss is
-// logged and the Prometheus counters still carry the global totals.
-func (r *Runner) recordOrgSpend(msg *queue.RunMessage, usage *metricsEmitter) {
-	if r.cfg.OrgUsage == nil || usage == nil || msg.TenantID == "" {
+// Detached ctx on both writes: a Mongo blip must not fail the run path;
+// misses are logged and the Prometheus counters still carry the global
+// totals. The `last_used_at` bump reads the credential fingerprints out
+// of ctx (secrets.WithCredentials was set by injectCredentials), so it
+// keys on what the delegate actually spent — not what was granted at
+// launch, which is the mute-frozen-at-launch signal the previous shape
+// left an operator with (#659 pt 2).
+func (r *Runner) recordOrgSpend(ctx context.Context, msg *queue.RunMessage, usage *metricsEmitter) {
+	if usage == nil {
 		return
 	}
 	costUSD, in, out := usage.RunTotals()
-	if costUSD <= 0 && in <= 0 && out <= 0 {
+	spent := costUSD > 0 || in > 0 || out > 0
+	if !spent {
 		return
 	}
-	// Charge the same usage key the launch gate metered the run on:
-	// the parent org (caps sum across the org's teams — charging the
-	// team key instead leaves the org's cost-cap document at zero, so
-	// the cap never trips in a multi-team org). OrgID is empty on
-	// pre-orgid messages and org-less pre-backfill teams — both were
-	// metered on the team key, so fall back to it.
-	key := msg.OrgID
-	if key == "" {
-		key = msg.TenantID
+	now := time.Now().UTC()
+
+	// Half 1: org usage bucket — the existing behaviour.
+	if r.cfg.OrgUsage != nil && msg.TenantID != "" {
+		// Charge the same usage key the launch gate metered the run on:
+		// the parent org (caps sum across the org's teams — charging the
+		// team key instead leaves the org's cost-cap document at zero,
+		// so the cap never trips in a multi-team org). OrgID is empty on
+		// pre-orgid messages and org-less pre-backfill teams — both were
+		// metered on the team key, so fall back to it.
+		key := msg.OrgID
+		if key == "" {
+			key = msg.TenantID
+		}
+		bg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := r.cfg.OrgUsage.AddSpend(bg, key, now, costUSD, in, out); err != nil {
+			r.cfg.Logger.Warn("runner: org spend record for %s (run %s): %v", key, msg.RunID, err)
+		}
+		cancel()
+	}
+
+	// Half 2: per-credential last_used_at bump. Best-effort: nothing to
+	// bump when the bundle carried no fingerprints (legacy run, env
+	// fallback) or the ApiKey store is not wired.
+	r.markCredFingerprintsUsed(ctx, msg, now)
+}
+
+// markCredFingerprintsUsed bumps `last_used_at` on every API key whose
+// fingerprint sits in the run's injected credentials. Best-effort: a
+// missing store, empty fingerprints, or a store failure all quietly
+// leave the observation on the floor rather than fail the run. Detached
+// context (5s bound) so the metering path is unaffected by cancellation.
+func (r *Runner) markCredFingerprintsUsed(ctx context.Context, msg *queue.RunMessage, at time.Time) {
+	if r.cfg.ApiKeys == nil {
+		return
+	}
+	creds, ok := secrets.CredentialsFromContext(ctx)
+	if !ok || len(creds.Fingerprints) == 0 {
+		return
+	}
+	// Deduplicate: several slots may map to the same fingerprint (an
+	// OAuth kind and the anthropic API key both keyed on the same
+	// account) and the update is idempotent, but the DB round-trips
+	// are not free.
+	seen := map[string]bool{}
+	fps := make([]string, 0, len(creds.Fingerprints))
+	for _, fp := range creds.Fingerprints {
+		if fp != "" && !seen[fp] {
+			seen[fp] = true
+			fps = append(fps, fp)
+		}
+	}
+	if len(fps) == 0 {
+		return
 	}
 	bg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := r.cfg.OrgUsage.AddSpend(bg, key, time.Now().UTC(), costUSD, in, out); err != nil {
-		r.cfg.Logger.Warn("runner: org spend record for %s (run %s): %v", key, msg.RunID, err)
+	for _, fp := range fps {
+		if err := r.cfg.ApiKeys.MarkFingerprintUsed(bg, fp, at); err != nil {
+			r.cfg.Logger.Warn("runner: mark api-key fingerprint used (run %s fp=%s): %v", msg.RunID, fp, err)
+		}
 	}
 }
 

--- a/pkg/runner/loop_spend.go
+++ b/pkg/runner/loop_spend.go
@@ -13,18 +13,25 @@ import (
 )
 
 // recordOrgSpend charges the run's accumulated LLM consumption to the
-// org's monthly usage bucket AND bumps `last_used_at` on every credential
-// the run actually spent tokens on. Called at the end of every execution
-// attempt — paused/cancelled/failed attempts incurred real spend too,
-// and a redelivered attempt re-charges only what it re-executed.
-// Detached ctx on both writes: a Mongo blip must not fail the run path;
-// misses are logged and the Prometheus counters still carry the global
-// totals. The `last_used_at` bump reads the credential fingerprints out
-// of ctx (secrets.WithCredentials was set by injectCredentials), so it
-// keys on what the delegate actually spent — not what was granted at
-// launch, which is the mute-frozen-at-launch signal the previous shape
-// left an operator with (#659 pt 2).
+// org's monthly usage bucket AND bumps `last_used_at` on every API key
+// the attempt held. Called at the end of every execution attempt —
+// paused/cancelled/failed attempts incurred real spend too, and a
+// redelivered attempt re-charges only what it re-executed. Detached ctx
+// on both writes: a Mongo blip must not fail the run path; misses are
+// logged and the Prometheus counters still carry the global totals.
+//
+// The bump is NOT behind the spend gate. RunTotals is a lossy signal —
+// a delegate that streams no usage, a run refused at its first call —
+// and the key was held for the whole attempt either way; gating the bump
+// on it is what left `last_used_at` frozen for hours on a key that was
+// serving (#659 pt 2). Bumped at attempt START too (injectCredentials);
+// nothing moves it DURING a turn — there is no live per-call signal to
+// key on, so a long attempt shows its start until it ends.
 func (r *Runner) recordOrgSpend(ctx context.Context, msg *queue.RunMessage, usage *metricsEmitter) {
+	now := time.Now().UTC()
+	// Half 2 first: the held keys are a fact of the attempt, whatever it
+	// measured.
+	r.markCredFingerprintsUsed(ctx, msg, now)
 	if usage == nil {
 		return
 	}
@@ -33,7 +40,6 @@ func (r *Runner) recordOrgSpend(ctx context.Context, msg *queue.RunMessage, usag
 	if !spent {
 		return
 	}
-	now := time.Now().UTC()
 
 	// Half 1: org usage bucket — the existing behaviour.
 	if r.cfg.OrgUsage != nil && msg.TenantID != "" {
@@ -53,18 +59,17 @@ func (r *Runner) recordOrgSpend(ctx context.Context, msg *queue.RunMessage, usag
 		}
 		cancel()
 	}
-
-	// Half 2: per-credential last_used_at bump. Best-effort: nothing to
-	// bump when the bundle carried no fingerprints (legacy run, env
-	// fallback) or the ApiKey store is not wired.
-	r.markCredFingerprintsUsed(ctx, msg, now)
 }
 
 // markCredFingerprintsUsed bumps `last_used_at` on every API key whose
-// fingerprint sits in the run's injected credentials. Best-effort: a
-// missing store, empty fingerprints, or a store failure all quietly
-// leave the observation on the floor rather than fail the run. Detached
-// context (5s bound) so the metering path is unaffected by cancellation.
+// fingerprint sits in the run's injected credentials — at attempt start
+// (from injectCredentials) and at attempt end (from recordOrgSpend).
+// Best-effort: a missing store, empty fingerprints, or a store failure
+// all quietly leave the observation on the floor rather than fail the
+// run. Detached context (5s bound) so the metering path is unaffected by
+// cancellation. Cross-tenant by design: the store matches on the
+// fingerprint alone, so a lent or platform key moves on ITS row, and an
+// operator who saved one secret on two tenants sees both move.
 func (r *Runner) markCredFingerprintsUsed(ctx context.Context, msg *queue.RunMessage, at time.Time) {
 	if r.cfg.ApiKeys == nil {
 		return
@@ -73,13 +78,17 @@ func (r *Runner) markCredFingerprintsUsed(ctx context.Context, msg *queue.RunMes
 	if !ok || len(creds.Fingerprints) == 0 {
 		return
 	}
-	// Deduplicate: several slots may map to the same fingerprint (an
-	// OAuth kind and the anthropic API key both keyed on the same
-	// account) and the update is idempotent, but the DB round-trips
-	// are not free.
+	// Only API-key slots: an OAuth slot's fingerprint (a subscription's
+	// connect-time identity) lives in the OAuth store and would only
+	// cost the api_keys collection a lookup that matches nothing.
+	// Deduplicated: the update is idempotent, the round-trips are not
+	// free.
 	seen := map[string]bool{}
 	fps := make([]string, 0, len(creds.Fingerprints))
-	for _, fp := range creds.Fingerprints {
+	for slot, fp := range creds.Fingerprints {
+		if secrets.OAuthKind(slot).Valid() {
+			continue
+		}
 		if fp != "" && !seen[fp] {
 			seen[fp] = true
 			fps = append(fps, fp)

--- a/pkg/runner/org_spend_test.go
+++ b/pkg/runner/org_spend_test.go
@@ -157,12 +157,14 @@ func TestMetricsEmitter_RunTotalsAccumulate(t *testing.T) {
 	}
 }
 
-// #659 pt 2: at metering time the runner bumps `last_used_at` on every
-// API key whose fingerprint sits in the resolved credentials, so the
-// studio distinguishes an idle key from one currently serving. The
-// launch-grant-only bump left `last_used_at` frozen for hours on keys
-// actively spending — measured live 2026-09-03 ("2.5h idle while
-// serving a third run's delegate the whole time").
+// #659 pt 2: the runner bumps `last_used_at` on every API key whose
+// fingerprint sits in the resolved credentials, at the START and at the
+// END of each attempt — nothing moves it during a turn (there is no live
+// per-call signal), so the studio can tell a key idle for hours from one
+// an attempt is holding, to attempt granularity. The launch-grant-only
+// bump left `last_used_at` frozen for hours on keys actively spending —
+// measured live 2026-09-03 ("2.5h idle while serving a third run's
+// delegate the whole time").
 //
 // The oracle is the STORE: after recordOrgSpend, the key's
 // last_used_at moves to the metering timestamp — even though msg.SecretsRef
@@ -217,5 +219,116 @@ func TestRecordOrgSpend_BumpsApiKeyFingerprintUsed(t *testing.T) {
 	}
 	if time.Since(*got.LastUsedAt) > 5*time.Second {
 		t.Fatalf("last_used_at stale (%s ago)", time.Since(*got.LastUsedAt))
+	}
+}
+
+// seedFingerprintedKey stores one sealed anthropic key carrying the
+// fingerprint of its plaintext, the way the BYOK route stamps it.
+func seedFingerprintedKey(t *testing.T, apiKeys secrets.ApiKeyStore, sealer secrets.Sealer, plaintext string) (id, fp string) {
+	t.Helper()
+	tenantCtx := store.WithTenant(context.Background(), "team-a")
+	id = secrets.NewApiKeyID()
+	sealed, err := secrets.SealAPIKey(sealer, id, []byte(plaintext))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp = secrets.FingerprintSHA256(plaintext)
+	if err := apiKeys.Create(tenantCtx, secrets.ApiKey{
+		ID: id, ScopeTeamID: "team-a", Provider: secrets.ProviderAnthropic,
+		Name: "live", SealedSecret: sealed, Fingerprint: fp,
+	}); err != nil {
+		t.Fatalf("seed key: %v", err)
+	}
+	return id, fp
+}
+
+// An attempt that measured nothing still HELD the key — a delegate that
+// streamed no usage, a run refused at its first call. RunTotals is lossy;
+// the bump must not hide behind it (the 2.5h incident reproduces exactly
+// when it does).
+func TestRecordOrgSpend_BumpsFingerprintEvenWithZeroUsage(t *testing.T) {
+	apiKeys := secrets.NewMemoryApiKeyStore()
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, fp := seedFingerprintedKey(t, apiKeys, sealer, "sk-ant-quiet")
+	r := &Runner{cfg: Config{ApiKeys: apiKeys, OrgUsage: orgusage.NewMemoryCounter(), Logger: iterlog.Nop()}}
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		Fingerprints: map[string]string{string(secrets.ProviderAnthropic): fp},
+	})
+	// Zero totals: the gate that used to swallow the bump.
+	r.recordOrgSpend(ctx, &queue.RunMessage{RunID: "run-1", TenantID: "team-a", OrgID: "org-1"}, newMetricsEmitter(nil, nil))
+	got, err := apiKeys.Get(store.WithTenant(context.Background(), "team-a"), id)
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	if got.LastUsedAt == nil {
+		t.Fatal("last_used_at not bumped on a zero-usage attempt end — the bump is still behind the spend gate")
+	}
+}
+
+// The attempt-START half: injectCredentials stamps the credentials into
+// ctx and bumps the held keys right there, so a multi-hour attempt does
+// not read as an idle key until it ends. Proven through the real
+// sealed-bundle path, not by calling the bump directly.
+func TestInjectCredentials_BumpsHeldKeysAtAttemptStart(t *testing.T) {
+	sealer := testSealer(t)
+	apiKeys := secrets.NewMemoryApiKeyStore()
+	id, _ := seedFingerprintedKey(t, apiKeys, sealer, "sk-ant-held")
+	rs := secrets.NewMemoryRunSecretsStore()
+	sealed, err := secrets.SealRunBundle(sealer, "run-1", secrets.RunBundle{
+		APIKeys: map[secrets.Provider]string{secrets.ProviderAnthropic: "sk-ant-held"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rs.Put(context.Background(), secrets.RunSecretsRecord{ID: "ref-1", TenantID: "team-a", RunID: "run-1", SealedBundle: sealed}); err != nil {
+		t.Fatal(err)
+	}
+	r := &Runner{cfg: Config{Logger: iterlog.Nop(), RunSecrets: rs, Sealer: sealer, ApiKeys: apiKeys}}
+	_, cleanup, err := r.injectCredentials(context.Background(), &queue.RunMessage{RunID: "run-1", TenantID: "team-a", SecretsRef: "ref-1"})
+	if err != nil {
+		t.Fatalf("injectCredentials: %v", err)
+	}
+	defer cleanup()
+	got, err := apiKeys.Get(store.WithTenant(context.Background(), "team-a"), id)
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	if got.LastUsedAt == nil {
+		t.Fatal("last_used_at not bumped at attempt start — the key reads idle until the attempt ends")
+	}
+}
+
+// fingerprintSpyStore records which fingerprints the runner asked the
+// api_keys store to bump.
+type fingerprintSpyStore struct {
+	secrets.ApiKeyStore
+	asked []string
+}
+
+func (s *fingerprintSpyStore) MarkFingerprintUsed(ctx context.Context, fingerprint string, at time.Time) error {
+	s.asked = append(s.asked, fingerprint)
+	return s.ApiKeyStore.MarkFingerprintUsed(ctx, fingerprint, at)
+}
+
+// An OAuth slot's fingerprint is a subscription's identity in the OAuth
+// store; asking the api_keys collection for it is a lookup that matches
+// nothing. Only API-key slots reach the store.
+func TestMarkCredFingerprintsUsed_SkipsOAuthSlots(t *testing.T) {
+	spy := &fingerprintSpyStore{ApiKeyStore: secrets.NewMemoryApiKeyStore()}
+	r := &Runner{cfg: Config{ApiKeys: spy, Logger: iterlog.Nop()}}
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		Fingerprints: map[string]string{
+			string(secrets.ProviderAnthropic):   "aaaa000011112222",
+			string(secrets.ProviderOpenAI):      "aaaa000011112222", // same secret on two slots: asked once
+			string(secrets.OAuthKindClaudeCode): "cccc333344445555",
+			string(secrets.OAuthKindCodex):      "dddd333344445555",
+		},
+	})
+	r.markCredFingerprintsUsed(ctx, &queue.RunMessage{RunID: "run-1"}, time.Now().UTC())
+	if len(spy.asked) != 1 || spy.asked[0] != "aaaa000011112222" {
+		t.Fatalf("store asked for %v, want exactly the one API-key fingerprint", spy.asked)
 	}
 }

--- a/pkg/runner/org_spend_test.go
+++ b/pkg/runner/org_spend_test.go
@@ -157,7 +157,6 @@ func TestMetricsEmitter_RunTotalsAccumulate(t *testing.T) {
 	}
 }
 
-
 // #659 pt 2: at metering time the runner bumps `last_used_at` on every
 // API key whose fingerprint sits in the resolved credentials, so the
 // studio distinguishes an idle key from one currently serving. The

--- a/pkg/runner/org_spend_test.go
+++ b/pkg/runner/org_spend_test.go
@@ -8,6 +8,7 @@ import (
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/orgusage"
 	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/secrets"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -36,7 +37,7 @@ func TestRecordOrgSpendKey(t *testing.T) {
 			usage.runOutputTokens = 50
 			usage.mu.Unlock()
 
-			r.recordOrgSpend(&queue.RunMessage{RunID: "run-1", TenantID: "team-a", OrgID: tc.orgID}, usage)
+			r.recordOrgSpend(context.Background(), &queue.RunMessage{RunID: "run-1", TenantID: "team-a", OrgID: tc.orgID}, usage)
 
 			now := time.Now().UTC()
 			got, err := counter.Usage(context.Background(), tc.wantKey, now)
@@ -96,12 +97,12 @@ func TestRecordOrgSpend_NoOpShapes(t *testing.T) {
 		usage.mu.Lock()
 		usage.runCostUSD = 1
 		usage.mu.Unlock()
-		r.recordOrgSpend(&queue.RunMessage{RunID: "run-1", TenantID: "team-a"}, usage)
+		r.recordOrgSpend(context.Background(), &queue.RunMessage{RunID: "run-1", TenantID: "team-a"}, usage)
 	})
 	t.Run("zero totals record nothing", func(t *testing.T) {
 		counter := orgusage.NewMemoryCounter()
 		r := &Runner{cfg: Config{OrgUsage: counter, Logger: iterlog.Nop()}}
-		r.recordOrgSpend(&queue.RunMessage{RunID: "run-1", TenantID: "team-a", OrgID: "org-1"}, newMetricsEmitter(nil, nil))
+		r.recordOrgSpend(context.Background(), &queue.RunMessage{RunID: "run-1", TenantID: "team-a", OrgID: "org-1"}, newMetricsEmitter(nil, nil))
 		if u, _ := counter.Usage(context.Background(), "org-1", time.Now().UTC()); u.CostUSD != 0 || u.InputTokens != 0 {
 			t.Fatalf("zero-spend attempt recorded usage: %+v", u)
 		}
@@ -113,14 +114,14 @@ func TestRecordOrgSpend_NoOpShapes(t *testing.T) {
 		usage.mu.Lock()
 		usage.runCostUSD = 2
 		usage.mu.Unlock()
-		r.recordOrgSpend(&queue.RunMessage{RunID: "run-1"}, usage)
+		r.recordOrgSpend(context.Background(), &queue.RunMessage{RunID: "run-1"}, usage)
 		if u, _ := counter.Usage(context.Background(), "", time.Now().UTC()); u.CostUSD != 0 {
 			t.Fatalf("tenant-less spend recorded: %+v", u)
 		}
 	})
 	t.Run("nil usage", func(t *testing.T) {
 		r := &Runner{cfg: Config{OrgUsage: orgusage.NewMemoryCounter(), Logger: iterlog.Nop()}}
-		r.recordOrgSpend(&queue.RunMessage{RunID: "run-1", TenantID: "team-a"}, nil)
+		r.recordOrgSpend(context.Background(), &queue.RunMessage{RunID: "run-1", TenantID: "team-a"}, nil)
 	})
 }
 
@@ -153,5 +154,69 @@ func TestMetricsEmitter_RunTotalsAccumulate(t *testing.T) {
 	}
 	if cost <= 0 {
 		t.Errorf("cost = %v, want > 0 for a priced claw model", cost)
+	}
+}
+
+
+// #659 pt 2: at metering time the runner bumps `last_used_at` on every
+// API key whose fingerprint sits in the resolved credentials, so the
+// studio distinguishes an idle key from one currently serving. The
+// launch-grant-only bump left `last_used_at` frozen for hours on keys
+// actively spending — measured live 2026-09-03 ("2.5h idle while
+// serving a third run's delegate the whole time").
+//
+// The oracle is the STORE: after recordOrgSpend, the key's
+// last_used_at moves to the metering timestamp — even though msg.SecretsRef
+// was never touched (the runner reads Credentials from ctx, which
+// injectCredentials stamped for the whole executeRun).
+func TestRecordOrgSpend_BumpsApiKeyFingerprintUsed(t *testing.T) {
+	apiKeys := secrets.NewMemoryApiKeyStore()
+	tenantCtx := store.WithTenant(context.Background(), "team-a")
+	id := secrets.NewApiKeyID()
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sealed, err := secrets.SealAPIKey(sealer, id, []byte("sk-ant-live"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp := secrets.FingerprintSHA256("sk-ant-live")
+	if err := apiKeys.Create(tenantCtx, secrets.ApiKey{
+		ID: id, ScopeTeamID: "team-a", Provider: secrets.ProviderAnthropic,
+		Name: "live", SealedSecret: sealed, Fingerprint: fp,
+	}); err != nil {
+		t.Fatalf("seed key: %v", err)
+	}
+	if got, _ := apiKeys.Get(tenantCtx, id); got.LastUsedAt != nil {
+		t.Fatalf("fresh key must have no last_used_at")
+	}
+
+	r := &Runner{cfg: Config{
+		ApiKeys:  apiKeys,
+		OrgUsage: orgusage.NewMemoryCounter(),
+		Logger:   iterlog.Nop(),
+	}}
+	usage := newMetricsEmitter(nil, nil)
+	usage.mu.Lock()
+	usage.runCostUSD = 1
+	usage.mu.Unlock()
+
+	// Simulate what injectCredentials stamps on the executeRun ctx.
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		Fingerprints: map[string]string{string(secrets.ProviderAnthropic): fp},
+	})
+	r.recordOrgSpend(ctx, &queue.RunMessage{RunID: "run-1", TenantID: "team-a", OrgID: "org-1"}, usage)
+
+	// Best-effort store writes settle synchronously in the memory store.
+	got, err := apiKeys.Get(tenantCtx, id)
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	if got.LastUsedAt == nil {
+		t.Fatalf("last_used_at not bumped — the metering-time bump did not run")
+	}
+	if time.Since(*got.LastUsedAt) > 5*time.Second {
+		t.Fatalf("last_used_at stale (%s ago)", time.Since(*got.LastUsedAt))
 	}
 }

--- a/pkg/runner/org_spend_test.go
+++ b/pkg/runner/org_spend_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/queue"
 	"github.com/SocialGouv/iterion/pkg/secrets"
 	"github.com/SocialGouv/iterion/pkg/store"
+	"github.com/SocialGouv/iterion/pkg/usagecap"
 )
 
 // TestRecordOrgSpendKey pins the usage key the runner charges spend to:
@@ -268,11 +269,12 @@ func TestRecordOrgSpend_BumpsFingerprintEvenWithZeroUsage(t *testing.T) {
 	}
 }
 
-// The attempt-START half: injectCredentials stamps the credentials into
-// ctx and bumps the held keys right there, so a multi-hour attempt does
-// not read as an idle key until it ends. Proven through the real
-// sealed-bundle path, not by calling the bump directly.
-func TestInjectCredentials_BumpsHeldKeysAtAttemptStart(t *testing.T) {
+// The attempt-START half, and its order: admitAttempt bumps the held keys
+// as soon as the run is admitted, so a multi-hour attempt does not read as
+// an idle key until it ends — and NOT before the pre-flight, so a run
+// parked on a ceiling never dates a key it will not spend. Proven through
+// the real sealed-bundle path, not by calling the bump directly.
+func TestAdmitAttempt_BumpsHeldKeysOnceAdmitted(t *testing.T) {
 	sealer := testSealer(t)
 	apiKeys := secrets.NewMemoryApiKeyStore()
 	id, _ := seedFingerprintedKey(t, apiKeys, sealer, "sk-ant-held")
@@ -287,17 +289,68 @@ func TestInjectCredentials_BumpsHeldKeysAtAttemptStart(t *testing.T) {
 		t.Fatal(err)
 	}
 	r := &Runner{cfg: Config{Logger: iterlog.Nop(), RunSecrets: rs, Sealer: sealer, ApiKeys: apiKeys}}
-	_, cleanup, err := r.injectCredentials(context.Background(), &queue.RunMessage{RunID: "run-1", TenantID: "team-a", SecretsRef: "ref-1"})
+	msg := &queue.RunMessage{RunID: "run-1", TenantID: "team-a", SecretsRef: "ref-1"}
+	ctx, cleanup, err := r.injectCredentials(context.Background(), msg)
 	if err != nil {
 		t.Fatalf("injectCredentials: %v", err)
 	}
 	defer cleanup()
+
+	read := func(t *testing.T) *secrets.ApiKey {
+		t.Helper()
+		got, err := apiKeys.Get(store.WithTenant(context.Background(), "team-a"), id)
+		if err != nil {
+			t.Fatalf("read key: %v", err)
+		}
+		return &got
+	}
+	// Holding the plaintext is not spending it: nothing is stamped until
+	// the run is admitted.
+	if k := read(t); k.LastUsedAt != nil {
+		t.Fatal("last_used_at stamped by injectCredentials alone — a run the pre-flight parks would date a key it never spent")
+	}
+	if err := r.admitAttempt(ctx, nil, msg); err != nil {
+		t.Fatalf("admitAttempt on an uncapped runner: %v", err)
+	}
+	if k := read(t); k.LastUsedAt == nil {
+		t.Fatal("last_used_at not bumped once the attempt was admitted — the key reads idle until the attempt ends")
+	}
+}
+
+// The other side of the order: a run the pre-flight parks must leave every
+// key exactly as idle as it found it.
+func TestAdmitAttempt_ParkedRunStampsNothing(t *testing.T) {
+	sealer := testSealer(t)
+	apiKeys := secrets.NewMemoryApiKeyStore()
+	id, fp := seedFingerprintedKey(t, apiKeys, sealer, "sk-ant-capped")
+
+	ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+		APIKeys:      map[secrets.Provider]string{secrets.ProviderAnthropic: "sk-ant-capped"},
+		Fingerprints: map[string]string{string(secrets.ProviderAnthropic): fp},
+	})
+	msg := &queue.RunMessage{RunID: "run-capped", TenantID: "team-a"}
+
+	caps := usagecap.NewMemStore()
+	if err := caps.Record(context.Background(), usageCapKey(ctx, msg), usagecap.Reading{
+		Window:      usagecap.WindowSevenDay,
+		Utilization: 0.95,
+		Status:      usagecap.StatusRejected,
+		ResetsAt:    time.Now().UTC().Add(5 * 24 * time.Hour),
+		ObservedAt:  time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	r := capRunner(capTestPolicy(), caps, &capStatusStore{})
+	r.cfg.ApiKeys = apiKeys
+	if err := r.admitAttempt(ctx, capLLMWorkflow(), msg); err == nil {
+		t.Fatal("a capped run must be parked by the pre-flight")
+	}
 	got, err := apiKeys.Get(store.WithTenant(context.Background(), "team-a"), id)
 	if err != nil {
 		t.Fatalf("read key: %v", err)
 	}
-	if got.LastUsedAt == nil {
-		t.Fatal("last_used_at not bumped at attempt start — the key reads idle until the attempt ends")
+	if got.LastUsedAt != nil {
+		t.Fatalf("a parked run stamped last_used_at (%v) on a key it never spent", got.LastUsedAt)
 	}
 }
 

--- a/pkg/runner/usage_cap.go
+++ b/pkg/runner/usage_cap.go
@@ -192,9 +192,12 @@ func (r *Runner) usageCapPreflight(ctx context.Context, wf *ir.Workflow, msg *qu
 	// never spend what the cap protects: parking it for the anthropic
 	// weekly reset strands it for nothing, which is how a fully pinned
 	// two-node rite froze for five days while its single-node sibling
-	// sailed through (#668). Read under the launch's own overrides and
-	// fallback chain; every uncertainty answers "reachable".
-	if !model.AnthropicWireReachable(wf, modelOverridesFromMsg(msg.ModelOverrides), runFallbackEntriesFromMsg(msg.Fallback)) {
+	// sailed through (#668). Read under the launch's own overrides, on
+	// PRIMARY routes only — a rescue `fallbacks:` route onto the wire
+	// fires on a failure the mid-run guard already refuses, and cannot
+	// justify refusing the run before it starts. Every uncertainty
+	// answers "reachable".
+	if !model.AnthropicWireReachable(wf, modelOverridesFromMsg(msg.ModelOverrides)) {
 		if logger != nil {
 			logger.Debug("runner: run %s targets no anthropic-wire route — usage cap not applied", msg.RunID)
 		}

--- a/pkg/runner/usage_cap.go
+++ b/pkg/runner/usage_cap.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/queue"
@@ -181,6 +182,21 @@ func (r *Runner) usageCapPreflight(ctx context.Context, wf *ir.Workflow, msg *qu
 	if !wf.AlwaysReachesLLM() {
 		if logger != nil {
 			logger.Debug("runner: run %s makes no model call — usage cap not applied", msg.RunID)
+		}
+		return nil
+	}
+	// The cap meters the Anthropic wire — its readings come from the
+	// claude_code delegate and nowhere else — and the key below is built
+	// from the run's anthropic-wire credentials (or the platform's). A run
+	// whose every route is pinned off that wire (claw/openai, codex) can
+	// never spend what the cap protects: parking it for the anthropic
+	// weekly reset strands it for nothing, which is how a fully pinned
+	// two-node rite froze for five days while its single-node sibling
+	// sailed through (#668). Read under the launch's own overrides and
+	// fallback chain; every uncertainty answers "reachable".
+	if !model.AnthropicWireReachable(wf, modelOverridesFromMsg(msg.ModelOverrides), runFallbackEntriesFromMsg(msg.Fallback)) {
+		if logger != nil {
+			logger.Debug("runner: run %s targets no anthropic-wire route — usage cap not applied", msg.RunID)
 		}
 		return nil
 	}

--- a/pkg/runner/usage_cap.go
+++ b/pkg/runner/usage_cap.go
@@ -249,3 +249,20 @@ func (r *Runner) usageCapPreflight(ctx context.Context, wf *ir.Workflow, msg *qu
 		SelfImposed: true,
 	}
 }
+
+// admitAttempt is the last gate before an attempt can spend anything, and
+// the moment it takes hold of what it will spend. The pre-flight decides
+// whether the run may start at all; only once it has, the attempt stamps
+// its credentials as held, so a multi-hour attempt does not read as an
+// idle key for its whole duration (#659 pt 2).
+//
+// The order is the point, both ways: a run parked on a ceiling never held
+// anything (stamping it would date a key that served nothing), and a run
+// that starts must not wait until it ends to say which key it is spending.
+func (r *Runner) admitAttempt(ctx context.Context, wf *ir.Workflow, msg *queue.RunMessage) error {
+	if err := r.usageCapPreflight(ctx, wf, msg, r.cfg.Logger); err != nil {
+		return err
+	}
+	r.markCredFingerprintsUsed(ctx, msg, time.Now().UTC())
+	return nil
+}

--- a/pkg/runner/usage_cap_test.go
+++ b/pkg/runner/usage_cap_test.go
@@ -524,3 +524,131 @@ func TestUsageCapCredKeys_ReadingFollowsTheSessionSource(t *testing.T) {
 		t.Errorf("facade source without a zai credential = %q, want the default fallback", got)
 	}
 }
+
+// #668, the incident as measured: a two-node rite with BOTH LLM nodes
+// pinned to claw + openai/gpt-5.6-sol was refused USAGE_LIMIT_BLOCKED for
+// the anthropic weekly reset — five days out — while its single-node
+// sibling on the identical pin sailed through. The cap meters the
+// Anthropic wire only; a run that cannot touch it must launch. Two
+// tenant shapes were probed: both keys held and the anthropic one capped,
+// and an openai-only tenant metered on the platform key.
+func TestUsageCapPreflight_SparesARunPinnedOffTheAnthropicWire(t *testing.T) {
+	offWire := func() *ir.Workflow {
+		return &ir.Workflow{
+			Name:  "rite",
+			Entry: "oracle_campaign",
+			Nodes: map[string]ir.Node{
+				"oracle_campaign":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "oracle_campaign"}, LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai", Model: "openai/gpt-5.6-sol"}},
+				"mutants_adversary": &ir.JudgeNode{BaseNode: ir.BaseNode{ID: "mutants_adversary"}, LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai", Model: "openai/gpt-5.6-sol"}},
+				"done":              &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+			},
+			Edges: []*ir.Edge{{From: "oracle_campaign", To: "mutants_adversary"}, {From: "mutants_adversary", To: "done"}},
+		}
+	}
+	capped := func(t *testing.T, caps usagecap.Store, key string) {
+		t.Helper()
+		if err := caps.Record(context.Background(), key, usagecap.Reading{
+			Window:      usagecap.WindowSevenDay,
+			Utilization: 0.95,
+			Status:      usagecap.StatusRejected,
+			ResetsAt:    time.Now().UTC().Add(5 * 24 * time.Hour),
+			ObservedAt:  time.Now().UTC(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("tenant holds both keys, the anthropic meter is capped", func(t *testing.T) {
+		msg := &queue.RunMessage{RunID: "rite-1", TenantID: "team-7"}
+		ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+			APIKeys: map[secrets.Provider]string{secrets.ProviderAnthropic: "sk-ant", secrets.ProviderOpenAI: "sk-oai"},
+			Fingerprints: map[string]string{
+				string(secrets.ProviderAnthropic): "aaaa000011112222",
+				string(secrets.ProviderOpenAI):    "bbbb000011112222",
+			},
+		})
+		caps := usagecap.NewMemStore()
+		capped(t, caps, usageCapKey(ctx, msg))
+		rs := &capStatusStore{}
+		r := capRunner(capTestPolicy(), caps, rs)
+
+		if err := r.usageCapPreflight(ctx, offWire(), msg, iterlog.Nop()); err != nil {
+			t.Fatalf("a run pinned off the anthropic wire was parked on the anthropic cap: %v", err)
+		}
+		if rs.calls != 0 {
+			t.Errorf("flipped the run's status %d times without blocking it", rs.calls)
+		}
+		// The same ledger still refuses a run with ONE node on the wire.
+		onWire := offWire()
+		onWire.Nodes["mutants_adversary"] = &ir.JudgeNode{BaseNode: ir.BaseNode{ID: "mutants_adversary"}}
+		if err := r.usageCapPreflight(ctx, onWire, msg, iterlog.Nop()); err == nil {
+			t.Error("an unpinned judge resolves to claude_code: the capped run must still be refused")
+		}
+	})
+
+	t.Run("openai-only tenant is metered on the capped platform key", func(t *testing.T) {
+		msg := &queue.RunMessage{RunID: "rite-2", TenantID: "team-8"}
+		ctx := secrets.WithCredentials(context.Background(), secrets.Credentials{
+			APIKeys:      map[secrets.Provider]string{secrets.ProviderOpenAI: "sk-oai"},
+			Fingerprints: map[string]string{string(secrets.ProviderOpenAI): "bbbb000011112222"},
+		})
+		caps := usagecap.NewMemStore()
+		key := usageCapKey(ctx, msg)
+		if want := usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform, ""); key != want {
+			t.Fatalf("an openai-only tenant keys on %q, want the platform key %q", key, want)
+		}
+		capped(t, caps, key)
+		rs := &capStatusStore{}
+		r := capRunner(capTestPolicy(), caps, rs)
+
+		if err := r.usageCapPreflight(ctx, offWire(), msg, iterlog.Nop()); err != nil {
+			t.Fatalf("an openai-only run was parked on the platform's anthropic cap: %v", err)
+		}
+		if err := r.usageCapPreflight(ctx, capLLMWorkflow(), msg, iterlog.Nop()); err == nil {
+			t.Error("an unpinned run may spend the platform forfait: it must still be refused")
+		}
+	})
+
+	t.Run("launch overrides pin a DSL-unpinned judge off the wire", func(t *testing.T) {
+		// The DSL alone would put both nodes on claude_code; the launch
+		// pinned both selectors to claw/openai — which is what the
+		// executor honours, so it is what the pre-flight must read.
+		ctx := context.Background()
+		caps := usagecap.NewMemStore()
+		capped(t, caps, usagecap.Key(delegate.BackendClaudeCode, usagecap.ScopePlatform, ""))
+		rs := &capStatusStore{}
+		r := capRunner(capTestPolicy(), caps, rs)
+		wf := &ir.Workflow{
+			Name:  "rite",
+			Entry: "oracle_campaign",
+			Nodes: map[string]ir.Node{
+				"oracle_campaign":   &ir.AgentNode{BaseNode: ir.BaseNode{ID: "oracle_campaign"}},
+				"mutants_adversary": &ir.JudgeNode{BaseNode: ir.BaseNode{ID: "mutants_adversary"}},
+				"done":              &ir.DoneNode{BaseNode: ir.BaseNode{ID: "done"}},
+			},
+			Edges: []*ir.Edge{{From: "oracle_campaign", To: "mutants_adversary"}, {From: "mutants_adversary", To: "done"}},
+		}
+		pin := func(selectors ...string) []queue.ModelOverride {
+			out := make([]queue.ModelOverride, 0, len(selectors))
+			for _, sel := range selectors {
+				out = append(out, queue.ModelOverride{Selector: sel, Backend: "claw", Model: "openai/gpt-5.6-sol", Provider: "openai"})
+			}
+			return out
+		}
+		both := &queue.RunMessage{RunID: "rite-3", ModelOverrides: pin("oracle_campaign", "mutants_adversary")}
+		if err := r.usageCapPreflight(ctx, wf, both, iterlog.Nop()); err != nil {
+			t.Fatalf("both selectors pinned off the wire, yet parked: %v", err)
+		}
+		agentOnly := &queue.RunMessage{RunID: "rite-4", ModelOverrides: pin("oracle_campaign")}
+		if err := r.usageCapPreflight(ctx, wf, agentOnly, iterlog.Nop()); err == nil {
+			t.Error("the judge still resolves to claude_code: the capped run must be refused")
+		}
+		// A run-level --fallback onto claude_code is a route the run may
+		// take; the guard stays armed for it.
+		rescued := &queue.RunMessage{RunID: "rite-5", ModelOverrides: pin("oracle_campaign", "mutants_adversary"),
+			Fallback: queue.RunFallback{{Backend: "claude_code"}}}
+		if err := r.usageCapPreflight(ctx, wf, rescued, iterlog.Nop()); err == nil {
+			t.Error("a run-level fallback onto claude_code re-opens the wire: the capped run must be refused")
+		}
+	})
+}

--- a/pkg/runner/usage_cap_test.go
+++ b/pkg/runner/usage_cap_test.go
@@ -643,12 +643,15 @@ func TestUsageCapPreflight_SparesARunPinnedOffTheAnthropicWire(t *testing.T) {
 		if err := r.usageCapPreflight(ctx, wf, agentOnly, iterlog.Nop()); err == nil {
 			t.Error("the judge still resolves to claude_code: the capped run must be refused")
 		}
-		// A run-level --fallback onto claude_code is a route the run may
-		// take; the guard stays armed for it.
+		// A run-level --fallback onto claude_code is a RESCUE route: it
+		// fires only on a failure the mid-run guard and the delegate's
+		// usage-window classification already refuse at dispatch. The
+		// pre-flight refuses in advance only what could not possibly
+		// avoid spending, so it must let this run start.
 		rescued := &queue.RunMessage{RunID: "rite-5", ModelOverrides: pin("oracle_campaign", "mutants_adversary"),
 			Fallback: queue.RunFallback{{Backend: "claude_code"}}}
-		if err := r.usageCapPreflight(ctx, wf, rescued, iterlog.Nop()); err == nil {
-			t.Error("a run-level fallback onto claude_code re-opens the wire: the capped run must be refused")
+		if err := r.usageCapPreflight(ctx, wf, rescued, iterlog.Nop()); err != nil {
+			t.Errorf("a rescue route must not park a run whose every primary route is off the wire: %v", err)
 		}
 	})
 }

--- a/pkg/runview/service.go
+++ b/pkg/runview/service.go
@@ -293,21 +293,14 @@ func toRunFallback(entries []FallbackEntry) []ir.Fallback {
 	return out
 }
 
-// toModelOverrides folds the launch entries into the engine's ModelOverrides.
+// toModelOverrides folds the launch entries into the engine's ModelOverrides
+// through model.OverridesFrom — the one fold every launch surface shares.
 func toModelOverrides(entries []ModelOverrideEntry) model.ModelOverrides {
-	var o model.ModelOverrides
-	for _, e := range entries {
-		if e.Backend != "" {
-			o.SetBackend(e.Selector, e.Backend)
-		}
-		if e.Model != "" {
-			o.SetModel(e.Selector, e.Model)
-		}
-		if e.Provider != "" {
-			o.SetProvider(e.Selector, e.Provider)
-		}
+	out := make([]model.OverrideEntry, len(entries))
+	for i, e := range entries {
+		out[i] = model.OverrideEntry{Selector: e.Selector, Backend: e.Backend, Model: e.Model, Provider: e.Provider}
 	}
-	return o
+	return model.OverridesFrom(out)
 }
 
 // toRunModelOverrides converts the launch entries into the persisted,

--- a/pkg/secrets/byok.go
+++ b/pkg/secrets/byok.go
@@ -106,6 +106,19 @@ func (p Provider) Valid() bool {
 	return false
 }
 
+// CredentialIsJSON reports whether this provider's BYOK value is a JSON
+// credential document rather than a bearer token: Bedrock takes an
+// AWS-style credential object, Vertex a service-account file. The shape
+// gate at ingestion reads this so the two are not refused as "a terminal
+// transcript" for containing newlines and spaces.
+func (p Provider) CredentialIsJSON() bool {
+	switch p {
+	case ProviderBedrock, ProviderVertex:
+		return true
+	}
+	return false
+}
+
 // ApiKey is a BYOK record: a single API key (or AWS-style credential
 // blob, JSON-encoded inside SealedSecret) attached to a team and
 // optionally scoped to a single user. The plaintext secret is never

--- a/pkg/secrets/byok.go
+++ b/pkg/secrets/byok.go
@@ -535,6 +535,11 @@ func (s *MongoApiKeyStore) EnsureSchema(ctx context.Context) error {
 	_, err := s.coll.Indexes().CreateMany(ctx, []mongo.IndexModel{
 		{Keys: bson.D{{Key: "scope_team", Value: 1}, {Key: "scope_user", Value: 1}, {Key: "provider", Value: 1}}, Options: options.Index().SetName("team_user_provider")},
 		{Keys: bson.D{{Key: "scope_team", Value: 1}, {Key: "provider", Value: 1}, {Key: "is_default", Value: 1}}, Options: options.Index().SetName("team_provider_default")},
+		// MarkFingerprintUsed's predicate: every attempt start and end
+		// bumps by fingerprint, with no tenant filter (a lent or platform
+		// key moves on its own row). Unindexed it was a collection scan
+		// per attempt. Sparse: rows that predate stamping carry none.
+		{Keys: bson.D{{Key: "fingerprint", Value: 1}}, Options: options.Index().SetName("fingerprint").SetSparse(true)},
 	})
 	if err != nil && !mongoutil.IsIndexConflict(err) {
 		return fmt.Errorf("secrets: ensure api_keys indexes: %w", err)

--- a/pkg/secrets/byok.go
+++ b/pkg/secrets/byok.go
@@ -172,6 +172,16 @@ type ApiKeyStore interface {
 	ListByUser(ctx context.Context, teamID, userID string) ([]ApiKey, error)
 	// MarkUsed updates last_used_at without altering anything else.
 	MarkUsed(ctx context.Context, id string, at time.Time) error
+	// MarkFingerprintUsed bumps last_used_at on every key whose stable
+	// audit identity matches the given fingerprint. Called by the runner
+	// at metering time (recordOrgSpend) so an operator can tell an idle
+	// key from one that is actively serving — a distinction the previous
+	// launch-grant-only signal could not make (#659 pt 2). Match by
+	// fingerprint on purpose: the runner knows what the bundle sealed,
+	// not the row ids under it; and no tenant filter, since the run may
+	// legitimately spend a key sourced from another tier (pool grant,
+	// platform tier). A missing fingerprint is a no-op, not an error.
+	MarkFingerprintUsed(ctx context.Context, fingerprint string, at time.Time) error
 	// ClearDefault removes the is_default flag from any other key in
 	// the same (team, user, provider) tuple. Used when a new key is
 	// created with is_default=true or an existing one is promoted.
@@ -465,6 +475,26 @@ func (m *MemoryApiKeyStore) MarkUsed(_ context.Context, id string, at time.Time)
 	return nil
 }
 
+// MarkFingerprintUsed bumps last_used_at on every key that carries this
+// fingerprint. Empty fingerprint is a no-op (nothing to look up), never an
+// error — a runner metering a key that predates fingerprint stamping just
+// leaves the observation on the floor rather than failing the report.
+func (m *MemoryApiKeyStore) MarkFingerprintUsed(_ context.Context, fingerprint string, at time.Time) error {
+	if fingerprint == "" {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	t := at
+	for id, k := range m.keys {
+		if k.Fingerprint == fingerprint {
+			k.LastUsedAt = &t
+			m.keys[id] = k
+		}
+	}
+	return nil
+}
+
 func (m *MemoryApiKeyStore) ClearDefault(_ context.Context, teamID, userID string, provider Provider, exceptID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -613,6 +643,24 @@ func (s *MongoApiKeyStore) MarkUsed(ctx context.Context, id string, at time.Time
 	}
 	if _, err := s.coll.UpdateOne(ctx, filter, bson.M{"$set": bson.M{"last_used_at": at}}); err != nil {
 		return fmt.Errorf("secrets: mark used: %w", err)
+	}
+	return nil
+}
+
+// MarkFingerprintUsed updates last_used_at on every row matching the
+// fingerprint — no tenant filter, since the runner may legitimately meter
+// a key that belongs to another tenant (pool grant, platform tier). A
+// missing fingerprint (empty string) is a no-op — the metering path calls
+// this per stamped fp on the run doc, and a run predating fingerprint
+// stamping simply carries none. UpdateMany matches every matching row: the
+// rare case where two rows share a fingerprint (an operator saved the
+// same secret twice) still gets both bumped.
+func (s *MongoApiKeyStore) MarkFingerprintUsed(ctx context.Context, fingerprint string, at time.Time) error {
+	if fingerprint == "" {
+		return nil
+	}
+	if _, err := s.coll.UpdateMany(ctx, bson.M{"fingerprint": fingerprint}, bson.M{"$set": bson.M{"last_used_at": at}}); err != nil {
+		return fmt.Errorf("secrets: mark fingerprint used: %w", err)
 	}
 	return nil
 }

--- a/pkg/secrets/byok_mongo_test.go
+++ b/pkg/secrets/byok_mongo_test.go
@@ -172,6 +172,32 @@ func TestMongoApiKey_MarkFingerprintUsed(t *testing.T) {
 	s, ctx := mongoKeyStore(t)
 	now := time.Now().UTC().Truncate(time.Second)
 
+	// The bump runs at every attempt start and end with no tenant filter;
+	// its predicate must be indexed or it is a collection scan per
+	// attempt (#659). The schema is the contract, so it is asserted here.
+	if err := s.EnsureSchema(ctx); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+	cur, err := s.coll.Indexes().List(ctx)
+	if err != nil {
+		t.Fatalf("list indexes: %v", err)
+	}
+	var indexes []struct {
+		Name string `bson:"name"`
+	}
+	if err := cur.All(ctx, &indexes); err != nil {
+		t.Fatalf("decode indexes: %v", err)
+	}
+	hasFP := false
+	for _, ix := range indexes {
+		if ix.Name == "fingerprint" {
+			hasFP = true
+		}
+	}
+	if !hasFP {
+		t.Fatalf("no index on fingerprint after EnsureSchema; got %+v", indexes)
+	}
+
 	// Two rows sharing a fingerprint (an operator saved the same secret
 	// twice on different tenants) — the update must land on BOTH, so a
 	// run spending either row moves the meter on both.

--- a/pkg/secrets/byok_mongo_test.go
+++ b/pkg/secrets/byok_mongo_test.go
@@ -164,7 +164,6 @@ func TestMongoApiKey_ScopeWithoutMatchingTenantIsUnreachable(t *testing.T) {
 	}
 }
 
-
 // The Mongo twin of TestMemoryApiKey_MarkFingerprintUsed: the metering
 // bump must land in prod on the real store, not only in unit-test
 // memory. Skipped without ITERION_TEST_MONGO_URI (mongo-conformance CI

--- a/pkg/secrets/byok_mongo_test.go
+++ b/pkg/secrets/byok_mongo_test.go
@@ -163,3 +163,63 @@ func TestMongoApiKey_ScopeWithoutMatchingTenantIsUnreachable(t *testing.T) {
 		t.Fatalf("the mis-stamped row is the one that answers here, got %+v", other)
 	}
 }
+
+
+// The Mongo twin of TestMemoryApiKey_MarkFingerprintUsed: the metering
+// bump must land in prod on the real store, not only in unit-test
+// memory. Skipped without ITERION_TEST_MONGO_URI (mongo-conformance CI
+// job gates it, like the other Mongo suites in this file).
+func TestMongoApiKey_MarkFingerprintUsed(t *testing.T) {
+	s, ctx := mongoKeyStore(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// Two rows sharing a fingerprint (an operator saved the same secret
+	// twice on different tenants) — the update must land on BOTH, so a
+	// run spending either row moves the meter on both.
+	if err := s.Create(store.WithTenant(ctx, "team-a"), ApiKey{
+		ID: "k1", TenantID: "team-a", ScopeTeamID: "team-a",
+		ScopeUserID: "u1", Provider: ProviderAnthropic, Name: "k1", Fingerprint: "fp-shared",
+	}); err != nil {
+		t.Fatalf("create k1: %v", err)
+	}
+	if err := s.Create(store.WithTenant(ctx, "team-b"), ApiKey{
+		ID: "k2", TenantID: "team-b", ScopeTeamID: "team-b",
+		ScopeUserID: "u2", Provider: ProviderAnthropic, Name: "k2", Fingerprint: "fp-shared",
+	}); err != nil {
+		t.Fatalf("create k2: %v", err)
+	}
+	if err := s.Create(store.WithTenant(ctx, "team-c"), ApiKey{
+		ID: "k3", TenantID: "team-c", ScopeTeamID: "team-c",
+		ScopeUserID: "u3", Provider: ProviderAnthropic, Name: "k3", Fingerprint: "fp-untouched",
+	}); err != nil {
+		t.Fatalf("create k3: %v", err)
+	}
+
+	if err := s.MarkFingerprintUsed(ctx, "", now); err != nil {
+		t.Errorf("empty fp errored: %v", err)
+	}
+	if err := s.MarkFingerprintUsed(ctx, "fp-shared", now); err != nil {
+		t.Fatalf("MarkFingerprintUsed: %v", err)
+	}
+	k1, err := s.Get(store.WithTenant(ctx, "team-a"), "k1")
+	if err != nil {
+		t.Fatalf("read k1: %v", err)
+	}
+	if k1.LastUsedAt == nil || !k1.LastUsedAt.Equal(now) {
+		t.Errorf("k1.last_used_at = %v, want %v", k1.LastUsedAt, now)
+	}
+	k2, err := s.Get(store.WithTenant(ctx, "team-b"), "k2")
+	if err != nil {
+		t.Fatalf("read k2: %v", err)
+	}
+	if k2.LastUsedAt == nil || !k2.LastUsedAt.Equal(now) {
+		t.Errorf("k2.last_used_at = %v, want %v (a shared fingerprint must land on every matching row)", k2.LastUsedAt, now)
+	}
+	k3, err := s.Get(store.WithTenant(ctx, "team-c"), "k3")
+	if err != nil {
+		t.Fatalf("read k3: %v", err)
+	}
+	if k3.LastUsedAt != nil {
+		t.Errorf("k3.last_used_at = %v, want nil (its fingerprint was untouched)", k3.LastUsedAt)
+	}
+}

--- a/pkg/secrets/byok_test.go
+++ b/pkg/secrets/byok_test.go
@@ -296,3 +296,51 @@ func TestResolve_UsablePredicateDoesNotFilterPins(t *testing.T) {
 		t.Fatalf("expected the pinned key despite the predicate, got %+v", r)
 	}
 }
+
+
+// MarkFingerprintUsed bumps last_used_at on every row whose stable audit
+// identity matches — the seam the runner drives at metering time so a
+// key currently serving is distinguishable from an idle one (#659 pt 2).
+// The launch-grant-only MarkUsed(id, ...) never moved after admission,
+// leaving the studio with a frozen last_used_at on keys actively being
+// spent — measured live 2026-09-03.
+func TestMemoryApiKey_MarkFingerprintUsed(t *testing.T) {
+	store := NewMemoryApiKeyStore()
+	sealer := newSealer(t)
+	k1 := mkKey(t, store, sealer, "team-a", "u1", ProviderAnthropic, "k1", "sk-ant-live", false)
+	k2 := mkKey(t, store, sealer, "team-b", "u2", ProviderAnthropic, "k2", "sk-ant-other", false)
+
+	if k1.LastUsedAt != nil || k2.LastUsedAt != nil {
+		t.Fatalf("fresh keys must have no last_used_at: %v %v", k1.LastUsedAt, k2.LastUsedAt)
+	}
+
+	t.Run("empty fingerprint is a no-op", func(t *testing.T) {
+		if err := store.MarkFingerprintUsed(context.Background(), "", time.Now()); err != nil {
+			t.Fatalf("empty fp errored: %v", err)
+		}
+		if got, _ := store.Get(context.Background(), k1.ID); got.LastUsedAt != nil {
+			t.Fatalf("empty fp bumped a row: %v", got.LastUsedAt)
+		}
+	})
+
+	t.Run("unknown fingerprint is a no-op", func(t *testing.T) {
+		if err := store.MarkFingerprintUsed(context.Background(), "no-such-fp", time.Now()); err != nil {
+			t.Fatalf("unknown fp errored: %v", err)
+		}
+	})
+
+	t.Run("matching fingerprint bumps THAT key, not the sibling", func(t *testing.T) {
+		now := time.Now().UTC().Truncate(time.Second)
+		if err := store.MarkFingerprintUsed(context.Background(), k1.Fingerprint, now); err != nil {
+			t.Fatalf("mark: %v", err)
+		}
+		got1, _ := store.Get(context.Background(), k1.ID)
+		got2, _ := store.Get(context.Background(), k2.ID)
+		if got1.LastUsedAt == nil || !got1.LastUsedAt.Equal(now) {
+			t.Fatalf("k1.last_used_at = %v, want %v (the metering bump did not land)", got1.LastUsedAt, now)
+		}
+		if got2.LastUsedAt != nil {
+			t.Fatalf("k2.last_used_at = %v, want nil (only k1's fingerprint was metered)", got2.LastUsedAt)
+		}
+	})
+}

--- a/pkg/secrets/byok_test.go
+++ b/pkg/secrets/byok_test.go
@@ -297,7 +297,6 @@ func TestResolve_UsablePredicateDoesNotFilterPins(t *testing.T) {
 	}
 }
 
-
 // MarkFingerprintUsed bumps last_used_at on every row whose stable audit
 // identity matches — the seam the runner drives at metering time so a
 // key currently serving is distinguishable from an idle one (#659 pt 2).

--- a/pkg/secrets/credential_shape.go
+++ b/pkg/secrets/credential_shape.go
@@ -1,0 +1,85 @@
+package secrets
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// ShapeError is a credential refused at ingestion because its SHAPE could
+// not authenticate — never a store or sealing failure. Field names what
+// was rejected, Reason why; neither carries the value. Handlers map it to
+// 400 and audit it; anything else stays a 500.
+type ShapeError struct {
+	Field  string
+	Reason string
+}
+
+func (e *ShapeError) Error() string { return e.Field + " " + e.Reason }
+
+// ValidateTokenShape rejects credential material that could not possibly
+// authenticate: a bearer token or api-key value is one run of visible
+// characters — never a terminal transcript, a credentials.json paste, a
+// CLI banner, or a value with an invisible character glued on. The check
+// is format-agnostic on purpose (no vendor prefix pin, which changes over
+// time) and covers the paid ingestion failures: an accessToken with
+// embedded newlines/ANSI escapes rendering every LLM call
+// `Bearer <transcript>` -> 401, and a key with a leading tab/space or a
+// no-break space that fools string-equality auth on the server side.
+//
+// The ASCII cases carry their own wording; every other white-space
+// (U+00A0, U+0085, U+2028, U+2029, U+3000, ...) and every non-printing
+// rune (U+200B, U+FEFF, controls, format characters) is refused by the
+// unicode catch-all, naming the rune and its position. Empty, NUL and
+// invalid UTF-8 are refused too. field only phrases the error so an
+// operator sees WHAT was rejected (accessToken vs api-key secret).
+func ValidateTokenShape(field, value string) error {
+	if value == "" {
+		return &ShapeError{Field: field, Reason: "is empty"}
+	}
+	if !utf8.ValidString(value) {
+		return &ShapeError{Field: field, Reason: "is not valid UTF-8 — this looks like binary data, not a token"}
+	}
+	for i, r := range value {
+		switch {
+		case r == 0x00:
+			return &ShapeError{Field: field, Reason: fmt.Sprintf("contains a NUL byte at position %d — this looks like binary data, not a token", i)}
+		case r == '\n' || r == '\r':
+			return &ShapeError{Field: field, Reason: fmt.Sprintf("contains a newline at position %d — this looks like a terminal transcript or credentials.json paste, not a bare token", i)}
+		case r == '\t':
+			return &ShapeError{Field: field, Reason: fmt.Sprintf("contains a tab at position %d — strip leading/trailing whitespace before pasting", i)}
+		case r == ' ':
+			return &ShapeError{Field: field, Reason: fmt.Sprintf("contains a space at position %d — a bearer token has none", i)}
+		case r < 0x20:
+			return &ShapeError{Field: field, Reason: fmt.Sprintf("contains a control character (U+%04X) at position %d — this looks like a terminal transcript, not a bare token", r, i)}
+		case r == 0x7f:
+			return &ShapeError{Field: field, Reason: fmt.Sprintf("contains a DEL byte at position %d — strip control characters before pasting", i)}
+		case unicode.IsSpace(r):
+			return &ShapeError{Field: field, Reason: fmt.Sprintf("contains a non-ASCII white-space character (U+%04X) at position %d — a bearer token has none; retype it rather than pasting from a rendered page", r, i)}
+		case !unicode.IsPrint(r):
+			return &ShapeError{Field: field, Reason: fmt.Sprintf("contains a non-printing character (U+%04X) at position %d — an invisible character glued to the token; retype it rather than pasting from a rendered page", r, i)}
+		}
+	}
+	return nil
+}
+
+// ValidateAPIKeyShape is the BYOK ingestion gate: a bearer-token provider
+// gets ValidateTokenShape; a provider whose credential is a JSON document
+// (Provider.CredentialIsJSON — Bedrock, Vertex) must carry a JSON OBJECT,
+// which legitimately contains the newlines and spaces the token rule
+// refuses.
+func ValidateAPIKeyShape(provider Provider, value string) error {
+	if !provider.CredentialIsJSON() {
+		return ValidateTokenShape("api-key secret", value)
+	}
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return &ShapeError{Field: "api-key secret", Reason: "is empty"}
+	}
+	if !strings.HasPrefix(trimmed, "{") || !json.Valid([]byte(trimmed)) {
+		return &ShapeError{Field: "api-key secret", Reason: fmt.Sprintf("must be a JSON credential object for provider %s (an AWS-style credential document, a service-account file), not a bearer token", provider)}
+	}
+	return nil
+}

--- a/pkg/secrets/credential_shape.go
+++ b/pkg/secrets/credential_shape.go
@@ -78,8 +78,15 @@ func ValidateAPIKeyShape(provider Provider, value string) error {
 	if trimmed == "" {
 		return &ShapeError{Field: "api-key secret", Reason: "is empty"}
 	}
-	if !strings.HasPrefix(trimmed, "{") || !json.Valid([]byte(trimmed)) {
+	var doc map[string]json.RawMessage
+	if !strings.HasPrefix(trimmed, "{") || json.Unmarshal([]byte(trimmed), &doc) != nil {
 		return &ShapeError{Field: "api-key secret", Reason: fmt.Sprintf("must be a JSON credential object for provider %s (an AWS-style credential document, a service-account file), not a bearer token", provider)}
+	}
+	// An EMPTY object parses and carries nothing: a credential that cannot
+	// authenticate is refused at ingestion like any other, rather than
+	// discovered at the first call.
+	if len(doc) == 0 {
+		return &ShapeError{Field: "api-key secret", Reason: fmt.Sprintf("is an empty JSON object — a %s credential document must carry its fields", provider)}
 	}
 	return nil
 }

--- a/pkg/secrets/credential_shape_test.go
+++ b/pkg/secrets/credential_shape_test.go
@@ -74,6 +74,8 @@ func TestValidateAPIKeyShape_PerProvider(t *testing.T) {
 		{"bedrock JSON array refused", ProviderBedrock, "[1,2]", "JSON credential object"},
 		{"bedrock truncated JSON refused", ProviderBedrock, "{\"aws_access_key_id\":", "JSON credential object"},
 		{"vertex empty refused", ProviderVertex, "   ", "empty"},
+		{"bedrock empty JSON object refused", ProviderBedrock, "{}", "empty JSON object"},
+		{"vertex empty JSON object refused", ProviderVertex, "{ }", "empty JSON object"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/secrets/credential_shape_test.go
+++ b/pkg/secrets/credential_shape_test.go
@@ -1,0 +1,102 @@
+package secrets
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// The ASCII-only gate let every non-ASCII white-space and format rune
+// through, and an NBSP-glued token was sealed through the chokepoint
+// (#627 round 1). Each rune below must be refused, naming itself and its
+// position, and the error must be the typed ShapeError the handlers map
+// to 400 — never the value.
+func TestValidateTokenShape_RefusesUnicodeWhitespaceAndInvisibles(t *testing.T) {
+	runes := []struct {
+		name string
+		r    rune
+	}{
+		{"NO-BREAK SPACE", 0x00A0},
+		{"NEXT LINE", 0x0085},
+		{"ZERO WIDTH SPACE", 0x200B},
+		{"LINE SEPARATOR", 0x2028},
+		{"PARAGRAPH SEPARATOR", 0x2029},
+		{"IDEOGRAPHIC SPACE", 0x3000},
+		{"ZERO WIDTH NO-BREAK SPACE (BOM)", 0xFEFF},
+	}
+	for _, tc := range runes {
+		t.Run(tc.name, func(t *testing.T) {
+			value := "sk-ant-oat01-good" + string(tc.r) + "tail"
+			err := ValidateTokenShape("accessToken", value)
+			if err == nil {
+				t.Fatalf("U+%04X was accepted", tc.r)
+			}
+			var se *ShapeError
+			if !errors.As(err, &se) {
+				t.Fatalf("got %T, want *ShapeError so the handler maps it to 400", err)
+			}
+			want := fmt.Sprintf("U+%04X", tc.r)
+			if !strings.Contains(err.Error(), want) || !strings.Contains(err.Error(), "position 17") {
+				t.Fatalf("error %q must name %s and position 17", err.Error(), want)
+			}
+			if strings.Contains(err.Error(), "sk-ant-oat01-good") {
+				t.Fatalf("error leaks the value: %q", err.Error())
+			}
+		})
+	}
+	if err := ValidateTokenShape("accessToken", "sk-ant-\xff-bad"); err == nil || !strings.Contains(err.Error(), "UTF-8") {
+		t.Fatalf("invalid UTF-8 must be refused as such, got %v", err)
+	}
+	if err := ValidateTokenShape("accessToken", "sk-ant-oat01-fine-héllo"); err != nil {
+		t.Fatalf("a printable non-ASCII letter is a legal token character: %v", err)
+	}
+}
+
+// Bedrock and Vertex hold a JSON credential document, not a bearer token
+// (documented on ApiKey, offered by the studio picker, listed in
+// docs/byok.md). Refusing them as "a terminal transcript" for containing
+// newlines was round 1's H3; the shape rule is per provider.
+func TestValidateAPIKeyShape_PerProvider(t *testing.T) {
+	awsBlob := "{\n  \"aws_access_key_id\": \"AKIA...\",\n  \"aws_secret_access_key\": \"x\"\n}"
+	cases := []struct {
+		name     string
+		provider Provider
+		value    string
+		wantErr  string
+	}{
+		{"anthropic bearer ok", ProviderAnthropic, "sk-ant-api03-realkey", ""},
+		{"anthropic with a space refused", ProviderAnthropic, "sk-ant good", "space"},
+		{"anthropic with NBSP refused", ProviderAnthropic, "sk-ant\u00a0good", "U+00A0"},
+		{"bedrock JSON object ok", ProviderBedrock, awsBlob, ""},
+		{"vertex JSON object ok", ProviderVertex, "{\"type\":\"service_account\",\"project_id\":\"p\"}", ""},
+		{"bedrock bearer-looking refused", ProviderBedrock, "AKIAIOSFODNN7EXAMPLE", "JSON credential object"},
+		{"bedrock JSON array refused", ProviderBedrock, "[1,2]", "JSON credential object"},
+		{"bedrock truncated JSON refused", ProviderBedrock, "{\"aws_access_key_id\":", "JSON credential object"},
+		{"vertex empty refused", ProviderVertex, "   ", "empty"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAPIKeyShape(tc.provider, tc.value)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("refused: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("accepted")
+			}
+			var se *ShapeError
+			if !errors.As(err, &se) {
+				t.Fatalf("got %T, want *ShapeError", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q, want it to mention %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+	if ProviderAnthropic.CredentialIsJSON() || ProviderOpenAI.CredentialIsJSON() || ProviderZAI.CredentialIsJSON() {
+		t.Fatal("bearer providers must not be JSON-credential providers")
+	}
+}

--- a/pkg/secrets/local.go
+++ b/pkg/secrets/local.go
@@ -522,6 +522,44 @@ func ValidGenericSecretName(name string) bool {
 	return true
 }
 
+// ValidateTokenShape rejects credential material that could not possibly
+// authenticate — a bearer token or api-key value must be a single line of
+// printable ASCII/UTF-8, never a terminal transcript, credentials.json paste
+// or CLI banner. The check is format-agnostic on purpose (no vendor prefix
+// pin, which changes over time) and covers the two paid ingestion failures:
+// an accessToken with embedded newlines/ANSI escapes rendering every LLM
+// call `Bearer <transcript>` → 401, and an api-key secret with a leading
+// tab/space that fools string-equality auth on the server side.
+//
+// Empty and NUL bytes are refused too — an empty value is caught by the
+// caller's own presence check but doubling up here means a future call site
+// cannot introduce the regression by accident.
+//
+// The kind argument is used only to phrase the error message so an operator
+// sees WHAT the server rejected (accessToken vs api-key secret).
+func ValidateTokenShape(kind, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s is empty", kind)
+	}
+	for i, r := range value {
+		switch {
+		case r == 0x00:
+			return fmt.Errorf("%s contains a NUL byte at position %d — this looks like binary data, not a token", kind, i)
+		case r == '\n' || r == '\r':
+			return fmt.Errorf("%s contains a newline at position %d — this looks like a terminal transcript or credentials.json paste, not a bare token", kind, i)
+		case r == '\t':
+			return fmt.Errorf("%s contains a tab at position %d — strip leading/trailing whitespace before pasting", kind, i)
+		case r == ' ':
+			return fmt.Errorf("%s contains a space at position %d — a bearer token has none", kind, i)
+		case r < 0x20:
+			return fmt.Errorf("%s contains a control character (U+%04X) at position %d — this looks like a terminal transcript, not a bare token", kind, r, i)
+		case r == 0x7f:
+			return fmt.Errorf("%s contains a DEL byte at position %d — strip control characters before pasting", kind, i)
+		}
+	}
+	return nil
+}
+
 // compile-time interface checks
 var (
 	_ GenericSecretStore = (*FileGenericSecretStore)(nil)

--- a/pkg/secrets/local.go
+++ b/pkg/secrets/local.go
@@ -522,44 +522,6 @@ func ValidGenericSecretName(name string) bool {
 	return true
 }
 
-// ValidateTokenShape rejects credential material that could not possibly
-// authenticate — a bearer token or api-key value must be a single line of
-// printable ASCII/UTF-8, never a terminal transcript, credentials.json paste
-// or CLI banner. The check is format-agnostic on purpose (no vendor prefix
-// pin, which changes over time) and covers the two paid ingestion failures:
-// an accessToken with embedded newlines/ANSI escapes rendering every LLM
-// call `Bearer <transcript>` → 401, and an api-key secret with a leading
-// tab/space that fools string-equality auth on the server side.
-//
-// Empty and NUL bytes are refused too — an empty value is caught by the
-// caller's own presence check but doubling up here means a future call site
-// cannot introduce the regression by accident.
-//
-// The kind argument is used only to phrase the error message so an operator
-// sees WHAT the server rejected (accessToken vs api-key secret).
-func ValidateTokenShape(kind, value string) error {
-	if value == "" {
-		return fmt.Errorf("%s is empty", kind)
-	}
-	for i, r := range value {
-		switch {
-		case r == 0x00:
-			return fmt.Errorf("%s contains a NUL byte at position %d — this looks like binary data, not a token", kind, i)
-		case r == '\n' || r == '\r':
-			return fmt.Errorf("%s contains a newline at position %d — this looks like a terminal transcript or credentials.json paste, not a bare token", kind, i)
-		case r == '\t':
-			return fmt.Errorf("%s contains a tab at position %d — strip leading/trailing whitespace before pasting", kind, i)
-		case r == ' ':
-			return fmt.Errorf("%s contains a space at position %d — a bearer token has none", kind, i)
-		case r < 0x20:
-			return fmt.Errorf("%s contains a control character (U+%04X) at position %d — this looks like a terminal transcript, not a bare token", kind, r, i)
-		case r == 0x7f:
-			return fmt.Errorf("%s contains a DEL byte at position %d — strip control characters before pasting", kind, i)
-		}
-	}
-	return nil
-}
-
 // compile-time interface checks
 var (
 	_ GenericSecretStore = (*FileGenericSecretStore)(nil)

--- a/pkg/server/admin_llm_routes_test.go
+++ b/pkg/server/admin_llm_routes_test.go
@@ -249,7 +249,7 @@ func TestAdminLLM_OAuthPasteStoresUnderThePlatformOwner(t *testing.T) {
 	_, oauth, sealer, _, hs, adminTok, _ := newAdminLLMServer(t)
 
 	code, body := llmDo(t, hs, "POST", "/api/admin/llm/oauth/claude_code/credentials", adminTok,
-		`{"claudeAiOauth":{"accessToken":"sk-ant-platform-forfait"}}`)
+		`{"claudeAiOauth":{"accessToken":"sk-ant-platform-forfait","expiresAt":4102444800000,"scopes":["user:inference"]}}`)
 	if code != http.StatusOK {
 		t.Fatalf("paste: status=%d body=%s", code, body)
 	}
@@ -350,7 +350,7 @@ func TestAdminLLM_OAuthAuditsOnlyRealMutations(t *testing.T) {
 
 	// A real connect, then a real delete, DO audit — exactly one each.
 	if code, _ := llmDo(t, hs, "POST", "/api/admin/llm/oauth/claude_code/credentials", adminTok,
-		`{"claudeAiOauth":{"accessToken":"sk-ant-real"}}`); code != http.StatusOK {
+		`{"claudeAiOauth":{"accessToken":"sk-ant-real","expiresAt":4102444800000,"scopes":["user:inference"]}}`); code != http.StatusOK {
 		t.Fatal("real connect failed")
 	}
 	// Guard the fixture: the connect really landed under the platform owner.

--- a/pkg/server/byok_routes.go
+++ b/pkg/server/byok_routes.go
@@ -186,6 +186,15 @@ func (s *Server) handleCreateApiKey(w http.ResponseWriter, r *http.Request, team
 		httpError(w, http.StatusBadRequest, "name + secret required")
 		return
 	}
+	// Ingestion gate — reject a pasted transcript / credentials.json blob
+	// before it lands in the store. The exact backstop as sealOAuthRecord:
+	// a bearer token has no whitespace or control character, and letting
+	// one through here would burn a fleet of runs on 401s before the cause
+	// is found.
+	if err := secrets.ValidateTokenShape("api-key secret", req.Secret); err != nil {
+		httpError(w, http.StatusBadRequest, "%s", err.Error())
+		return
+	}
 	if req.MaxConcurrentRuns < 0 {
 		httpError(w, http.StatusBadRequest, "max_concurrent_runs must be >= 0 (0 = uncapped)")
 		return
@@ -254,6 +263,13 @@ func (s *Server) handleUpdateApiKey(w http.ResponseWriter, r *http.Request) {
 		key.Name = *req.Name
 	}
 	if req.Secret != nil && *req.Secret != "" {
+		// Same ingestion gate as create — a rotate that pastes a transcript
+		// is exactly as bad as a create that pastes one, and the runtime
+		// error is identical (401 on every call). Refuse it here.
+		if err := secrets.ValidateTokenShape("api-key secret", *req.Secret); err != nil {
+			httpError(w, http.StatusBadRequest, "%s", err.Error())
+			return
+		}
 		sealed, err := secrets.SealAPIKey(s.sealer, key.ID, []byte(*req.Secret))
 		if err != nil {
 			httpError(w, http.StatusInternalServerError, "seal: %v", err)

--- a/pkg/server/byok_routes.go
+++ b/pkg/server/byok_routes.go
@@ -187,12 +187,11 @@ func (s *Server) handleCreateApiKey(w http.ResponseWriter, r *http.Request, team
 		return
 	}
 	// Ingestion gate — reject a pasted transcript / credentials.json blob
-	// before it lands in the store. The exact backstop as sealOAuthRecord:
-	// a bearer token has no whitespace or control character, and letting
-	// one through here would burn a fleet of runs on 401s before the cause
-	// is found.
-	if err := secrets.ValidateTokenShape("api-key secret", req.Secret); err != nil {
-		httpError(w, http.StatusBadRequest, "%s", err.Error())
+	// before it lands in the store, the same backstop as sealOAuthRecord.
+	// Per provider: a bearer token has no whitespace or control character;
+	// Bedrock/Vertex carry a JSON credential document instead.
+	if err := secrets.ValidateAPIKeyShape(provider, req.Secret); err != nil {
+		s.refuseApiKey(w, r, teamID, "", provider, err)
 		return
 	}
 	if req.MaxConcurrentRuns < 0 {
@@ -236,6 +235,22 @@ func (s *Server) handleCreateApiKey(w http.ResponseWriter, r *http.Request, team
 	writeJSON(w, s.toApiKeyView(key))
 }
 
+// refuseApiKey answers a BYOK shape refusal (create or rotate): 400 with
+// the reason, plus the trace the success path already leaves — a Warn
+// and an audit event naming the provider, the field and the reason,
+// never the value — so a paste that would have burned a fleet of runs
+// on 401s is findable after the fact. keyID is empty on a create.
+func (s *Server) refuseApiKey(w http.ResponseWriter, r *http.Request, teamID, keyID string, provider secrets.Provider, err error) {
+	field, reason := "secret", err.Error()
+	var se *secrets.ShapeError
+	if errors.As(err, &se) {
+		field, reason = se.Field, se.Reason
+	}
+	s.logger.Warn("byok: team=%s key=%q provider=%s credential REFUSED at ingestion (field=%s): %s", teamID, keyID, provider, field, reason)
+	s.auditApiKey(r, teamID, "refused", keyID, map[string]any{"provider": string(provider), "field": field, "reason": reason})
+	httpError(w, http.StatusBadRequest, "%s", err.Error())
+}
+
 func (s *Server) handleUpdateApiKey(w http.ResponseWriter, r *http.Request) {
 	id, _ := auth.FromContext(r.Context())
 	keyID := r.PathValue("key_id")
@@ -266,8 +281,8 @@ func (s *Server) handleUpdateApiKey(w http.ResponseWriter, r *http.Request) {
 		// Same ingestion gate as create — a rotate that pastes a transcript
 		// is exactly as bad as a create that pastes one, and the runtime
 		// error is identical (401 on every call). Refuse it here.
-		if err := secrets.ValidateTokenShape("api-key secret", *req.Secret); err != nil {
-			httpError(w, http.StatusBadRequest, "%s", err.Error())
+		if err := secrets.ValidateAPIKeyShape(key.Provider, *req.Secret); err != nil {
+			s.refuseApiKey(w, r, key.ScopeTeamID, key.ID, key.Provider, err)
 			return
 		}
 		sealed, err := secrets.SealAPIKey(s.sealer, key.ID, []byte(*req.Secret))

--- a/pkg/server/byok_routes_test.go
+++ b/pkg/server/byok_routes_test.go
@@ -89,3 +89,72 @@ func TestApiKeyTenantCtx_KeepsTheActiveTeamWhenNoPathTeam(t *testing.T) {
 		t.Fatalf("want the active team team-a, got %q (ok=%v)", got, ok)
 	}
 }
+
+// A BYOK secret with whitespace or a control character cannot possibly
+// authenticate: a bearer token has none, and the shape has been paid for
+// live (a transcript pasted as accessToken, hours of dead-on-arrival runs
+// before the cause was found). #627's ingestion gate refuses it before it
+// ever lands in the store — same contract as sealOAuthRecord.
+//
+// The oracle is the STORE, not the response status: a 400 with a silent
+// write would still leave the garbage on disk for the runs to pick up.
+func TestCreateApiKey_RejectsMalformedSecret(t *testing.T) {
+	sealer, err := secrets.NewAESGCMSealer(bytes.Repeat([]byte{5}, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spy := &tenantSpyKeyStore{ApiKeyStore: secrets.NewMemoryApiKeyStore()}
+	srv := &Server{apiKeys: spy, sealer: sealer}
+
+	cases := []struct {
+		name, body, wantInErr string
+	}{
+		{"newline in secret", `{"provider":"anthropic","name":"bad","secret":"sk-ant-good\nWelcome"}`, "newline"},
+		{"tab in secret", `{"provider":"anthropic","name":"bad","secret":"\tsk-ant-good"}`, "tab"},
+		{"space in secret", `{"provider":"anthropic","name":"bad","secret":"sk-ant good"}`, "space"},
+		// The JSON string "[32msecret" carries a real ESC byte, which
+		// is a control character even though it looks like ANSI on screen.
+		{"ANSI escape (terminal transcript)", `{"provider":"anthropic","name":"bad","secret":"\u001b[32msk-ant-good\u001b[0m"}`, "control character"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("POST", "/api/teams/team-a/api-keys", strings.NewReader(tc.body))
+			r.SetPathValue("id", "team-a")
+			ctx := auth.WithIdentity(r.Context(), auth.Identity{UserID: "u1", IsSuperAdmin: true, TeamID: "team-a"})
+			r = r.WithContext(store.WithTenant(ctx, "team-a"))
+
+			w := httptest.NewRecorder()
+			srv.handleCreateTeamApiKey(w, r)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d body=%s, want 400 (garbage secret rejected at ingestion)", w.Code, w.Body.String())
+			}
+			if !strings.Contains(w.Body.String(), tc.wantInErr) {
+				t.Fatalf("error body = %q, want it to mention %q", w.Body.String(), tc.wantInErr)
+			}
+		})
+	}
+}
+
+// A well-formed secret still passes and lands sealed — the shape gate is
+// format-agnostic on the token contents (no vendor prefix pin) so a legal
+// value crosses it unchanged.
+func TestCreateApiKey_AcceptsHealthySecret(t *testing.T) {
+	sealer, err := secrets.NewAESGCMSealer(bytes.Repeat([]byte{5}, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spy := &tenantSpyKeyStore{ApiKeyStore: secrets.NewMemoryApiKeyStore()}
+	srv := &Server{apiKeys: spy, sealer: sealer}
+
+	body := `{"provider":"anthropic","name":"healthy","secret":"sk-ant-api03-realkey"}`
+	r := httptest.NewRequest("POST", "/api/teams/team-a/api-keys", strings.NewReader(body))
+	r.SetPathValue("id", "team-a")
+	ctx := auth.WithIdentity(r.Context(), auth.Identity{UserID: "u1", IsSuperAdmin: true, TeamID: "team-a"})
+	r = r.WithContext(store.WithTenant(ctx, "team-a"))
+
+	w := httptest.NewRecorder()
+	srv.handleCreateTeamApiKey(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("healthy create = %d body=%s", w.Code, w.Body.String())
+	}
+}

--- a/pkg/server/byok_routes_test.go
+++ b/pkg/server/byok_routes_test.go
@@ -3,12 +3,16 @@ package server
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/SocialGouv/iterion/pkg/audit"
 	"github.com/SocialGouv/iterion/pkg/auth"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/secrets"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -156,5 +160,96 @@ func TestCreateApiKey_AcceptsHealthySecret(t *testing.T) {
 	srv.handleCreateTeamApiKey(w, r)
 	if w.Code != http.StatusOK {
 		t.Fatalf("healthy create = %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// byokServer builds the minimal handler-level server the BYOK tests use,
+// with a Warn-level log buffer and a memory audit store so a refusal's
+// trace is observable.
+func byokServer(t *testing.T) (*Server, *tenantSpyKeyStore, *bytes.Buffer, *audit.MemoryStore) {
+	t.Helper()
+	sealer, err := secrets.NewAESGCMSealer(bytes.Repeat([]byte{5}, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spy := &tenantSpyKeyStore{ApiKeyStore: secrets.NewMemoryApiKeyStore()}
+	var logs bytes.Buffer
+	auditStore := audit.NewMemoryStore()
+	srv := &Server{apiKeys: spy, sealer: sealer, logger: iterlog.New(iterlog.LevelWarn, &logs), auditStore: auditStore}
+	return srv, spy, &logs, auditStore
+}
+
+func createTeamKey(t *testing.T, srv *Server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest("POST", "/api/teams/team-a/api-keys", strings.NewReader(body))
+	r.SetPathValue("id", "team-a")
+	ctx := auth.WithIdentity(r.Context(), auth.Identity{UserID: "u1", IsSuperAdmin: true, TeamID: "team-a"})
+	r = r.WithContext(store.WithTenant(ctx, "team-a"))
+	w := httptest.NewRecorder()
+	srv.handleCreateTeamApiKey(w, r)
+	return w
+}
+
+// Bedrock and Vertex BYOK values are JSON credential documents — the
+// ApiKey doc, the studio picker and docs/byok.md all say so — and the
+// token rule refused them as "a terminal transcript" for their newlines
+// (#627 round 1). The shape rule is per provider: a JSON object passes,
+// a bearer-looking value on those providers is refused with its own
+// message, and the bearer providers keep the token rule.
+func TestCreateApiKey_ShapeRuleIsPerProvider(t *testing.T) {
+	srv, spy, _, _ := byokServer(t)
+	awsBlob := `{\n  \"aws_access_key_id\": \"AKIA...\",\n  \"aws_secret_access_key\": \"x\"\n}`
+
+	if w := createTeamKey(t, srv, `{"provider":"bedrock","name":"aws","secret":"`+awsBlob+`"}`); w.Code != http.StatusOK {
+		t.Fatalf("bedrock JSON blob = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+	if w := createTeamKey(t, srv, `{"provider":"vertex","name":"gcp","secret":"{\"type\":\"service_account\",\"project_id\":\"p\"}"}`); w.Code != http.StatusOK {
+		t.Fatalf("vertex JSON blob = %d body=%s, want 200", w.Code, w.Body.String())
+	}
+	keys, err := spy.ListByTeam(store.WithTenant(context.Background(), "team-a"), "team-a", "")
+	if err != nil || len(keys) != 2 {
+		t.Fatalf("stored keys = %d (%v), want the two JSON credentials sealed", len(keys), err)
+	}
+	if w := createTeamKey(t, srv, `{"provider":"bedrock","name":"aws","secret":"AKIAIOSFODNN7EXAMPLE"}`); w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "JSON credential object") {
+		t.Fatalf("bedrock bearer-looking = %d body=%s, want 400 with the JSON-object message", w.Code, w.Body.String())
+	}
+	if w := createTeamKey(t, srv, `{"provider":"anthropic","name":"k","secret":"{\"not\":\"a token\"}"}`); w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "space") {
+		t.Fatalf("anthropic JSON-looking = %d body=%s, want 400 under the token rule", w.Code, w.Body.String())
+	}
+}
+
+// The ASCII-only gate let a NO-BREAK SPACE through; refused now, naming
+// the rune, and the refusal leaves a Warn + an audit event naming the
+// field and reason — never the value.
+func TestCreateApiKey_RefusesUnicodeWhitespaceAndLeavesATrace(t *testing.T) {
+	srv, spy, logs, auditStore := byokServer(t)
+	w := createTeamKey(t, srv, `{"provider":"anthropic","name":"k","secret":"sk-ant-api03-real\u00a0key"}`)
+	if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "U+00A0") {
+		t.Fatalf("status = %d body=%s, want 400 naming U+00A0", w.Code, w.Body.String())
+	}
+	if keys, _ := spy.ListByTeam(store.WithTenant(context.Background(), "team-a"), "team-a", ""); len(keys) != 0 {
+		t.Fatalf("a refused key was stored: %+v", keys)
+	}
+	if l := logs.String(); !strings.Contains(l, "REFUSED at ingestion") || !strings.Contains(l, "provider=anthropic") || strings.Contains(l, "sk-ant-api03-real") {
+		t.Fatalf("want a Warn naming the provider and never the value; got:\n%s", l)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		events, err := auditStore.ListByTenant(context.Background(), "team-a", audit.Page{Limit: 10})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range events {
+			if e.Action == "byok.refused" {
+				if e.Meta["provider"] != "anthropic" || e.Meta["field"] != "api-key secret" || strings.Contains(fmt.Sprint(e.Meta), "sk-ant-api03-real") {
+					t.Fatalf("audit event = %+v, want provider + field + reason and never the value", e)
+				}
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no byok.refused audit event; got %+v", events)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 }

--- a/pkg/server/cloudpublisher/apikey_skip_test.go
+++ b/pkg/server/cloudpublisher/apikey_skip_test.go
@@ -342,7 +342,7 @@ func TestResolve_ceilingWalksToNextKeyAndStampsFingerprints(t *testing.T) {
 	}
 	// The harvest names the credential the bundle ACTUALLY sealed — the
 	// meter would count the wrong key otherwise.
-	creds, err := p.resolveAndSealCredentials(ctx, "run-c2", "", "team1", "owner1", "", nil, nil, nil, model.ModelOverrides{})
+	creds, err := p.resolveAndSealCredentials(ctx, "run-c2", "", "team1", "owner1", "", nil, nil, nil, model.ModelOverrides{}, nil)
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}

--- a/pkg/server/cloudpublisher/apikey_skip_test.go
+++ b/pkg/server/cloudpublisher/apikey_skip_test.go
@@ -1,6 +1,7 @@
 package cloudpublisher
 
 import (
+	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"context"
 	"testing"
 	"time"
@@ -341,7 +342,7 @@ func TestResolve_ceilingWalksToNextKeyAndStampsFingerprints(t *testing.T) {
 	}
 	// The harvest names the credential the bundle ACTUALLY sealed — the
 	// meter would count the wrong key otherwise.
-	creds, err := p.resolveAndSealCredentials(ctx, "run-c2", "", "team1", "owner1", "", nil, nil, nil)
+	creds, err := p.resolveAndSealCredentials(ctx, "run-c2", "", "team1", "owner1", "", nil, nil, nil, model.ModelOverrides{})
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}

--- a/pkg/server/cloudpublisher/apikey_skip_test.go
+++ b/pkg/server/cloudpublisher/apikey_skip_test.go
@@ -1,8 +1,8 @@
 package cloudpublisher
 
 import (
-	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"context"
+	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"testing"
 	"time"
 

--- a/pkg/server/cloudpublisher/credpool_apikey_grant_test.go
+++ b/pkg/server/cloudpublisher/credpool_apikey_grant_test.go
@@ -103,3 +103,87 @@ func TestPoolTier_apiKeyGrantIsStampedAndLabelled(t *testing.T) {
 		t.Fatalf("bundle xai slot = %q, want the lent key", bundle.APIKeys[secrets.ProviderXAI])
 	}
 }
+
+// zaiDonorPublisher wires a real broker with ONE donor lending a personal
+// z.ai key, for a tenant that holds nothing of its own.
+func zaiDonorPublisher(t *testing.T, buf *bytes.Buffer) (*Publisher, string) {
+	t.Helper()
+	ctx := context.Background()
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	apiKeys := secrets.NewMemoryApiKeyStore()
+	keyID := secrets.NewApiKeyID()
+	sealed, err := secrets.SealAPIKey(sealer, keyID, []byte("zai-donated-key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp := secrets.FingerprintSHA256("zai-donated-key")
+	if err := apiKeys.Create(store.WithTenant(ctx, "donor-team"), secrets.ApiKey{
+		ID: keyID, TenantID: "donor-team", ScopeTeamID: "donor-team", ScopeUserID: "donor",
+		Provider: secrets.ProviderZAI, Name: "lent", SealedSecret: sealed, Fingerprint: fp,
+	}); err != nil {
+		t.Fatalf("seed key: %v", err)
+	}
+	pools := credpool.NewMemoryPoolStore()
+	if err := pools.Upsert(ctx, credpool.Pool{ID: "pool-1", OrgID: poolOrg, Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	pledges := credpool.NewMemoryPledgeStore()
+	if err := pledges.Upsert(ctx, credpool.Pledge{
+		ID: credpool.PledgeID("donor", credpool.SourceAPIKey, "zai"), PoolID: "pool-1", UserID: "donor",
+		Credential: credpool.Credential{Source: credpool.SourceAPIKey, Ref: "zai", KeyID: keyID},
+		Enabled:    true, Health: credpool.HealthOK, Limits: credpool.Limits{MaxUSDPerDay: 5},
+	}); err != nil {
+		t.Fatalf("seed pledge: %v", err)
+	}
+	broker := credpool.NewBroker(credpool.BrokerConfig{
+		Pools: pools, Pledges: pledges, Leases: credpool.NewMemoryLeaseStore(), Ledger: credpool.NewMemoryLedger(),
+		OAuth: secrets.NewMemoryOAuthStore(), APIKeys: apiKeys, Sealer: sealer, Logger: testLogger(),
+	})
+	if broker == nil {
+		t.Fatal("broker is nil with every dependency wired")
+	}
+	return &Publisher{runSecrets: secrets.NewMemoryRunSecretsStore(), sealer: sealer, credPool: broker, logger: iterlog.New(iterlog.LevelInfo, buf)}, fp
+}
+
+// Round 2 S1, end to end on the real broker: a node pinned `provider: zai`
+// spends ONLY a z.ai key (claude_code refuses to fall through), so the
+// z.ai donor must be the one considered — whatever the model's prefix
+// says. Round 1's walk read the `anthropic/` prefix first and asked for
+// [oauth:claude_code api_key:anthropic]: pledges_considered=0, "no
+// credential resolved", the only donor able to serve never considered —
+// and an anthropic donation would have been granted and never used.
+func TestPoolTier_zaiHintUnderAnAnthropicPrefixTakesTheZaiDonor(t *testing.T) {
+	shapes := []struct {
+		name string
+		wf   *ir.Workflow
+	}{
+		{"control: bare model + zai hint", &ir.Workflow{Nodes: map[string]ir.Node{"a": &ir.AgentNode{
+			BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "claude_code", Provider: "zai"},
+		}}}},
+		{"regression shape: anthropic/ prefix + zai hint", &ir.Workflow{Nodes: map[string]ir.Node{"a": &ir.AgentNode{
+			BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "claude_code", Provider: "zai", Model: "anthropic/claude-opus-4-8"},
+		}}}},
+		{"pi documented z.ai form", &ir.Workflow{Nodes: map[string]ir.Node{"a": &ir.AgentNode{
+			BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "pi", Provider: "zai", Model: "anthropic/glm-5.2"},
+		}}}},
+	}
+	for _, sh := range shapes {
+		t.Run(sh.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			p, fp := zaiDonorPublisher(t, &buf)
+			creds, err := p.resolveAndSealCredentials(store.WithTenant(context.Background(), poolTeam), "run-zai", poolOrg, poolTeam, "requester", "bot", sh.wf, nil, nil, model.ModelOverrides{}, nil)
+			if err != nil {
+				t.Fatalf("resolveAndSealCredentials: %v", err)
+			}
+			if creds.grant == nil || creds.grant.Ref != "zai" {
+				t.Fatalf("want the z.ai donor granted, got %+v; log:\n%s", creds.grant, buf.String())
+			}
+			if log := buf.String(); !strings.Contains(log, "pool(api_key:zai fp="+fp+")") || strings.Contains(log, "no credential resolved") {
+				t.Fatalf("want the GRANTED line naming the z.ai donor and no terminal Warn; got:\n%s", log)
+			}
+		})
+	}
+}

--- a/pkg/server/cloudpublisher/credpool_apikey_grant_test.go
+++ b/pkg/server/cloudpublisher/credpool_apikey_grant_test.go
@@ -1,0 +1,105 @@
+package cloudpublisher
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/model"
+	"github.com/SocialGouv/iterion/pkg/credpool"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// #659 pt 1: a METERED donor key granted by the pool used to reach the
+// GRANTED line as `byok(api_key:xai fp=<unstamped>)` — the api-key fill
+// site never stamped the fingerprint the OAuth site does — and the same
+// omission kept it off the run document's fingerprints, so the per-key
+// concurrency meter could not count the run and the metering-time
+// last_used_at bump had nothing to key on. The oracle is the real
+// broker over a real sealed key: the line names the tier and the hash,
+// the run-doc fingerprints carry it, the bundle carries the key.
+func TestPoolTier_apiKeyGrantIsStampedAndLabelled(t *testing.T) {
+	ctx := context.Background()
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	// The donor's PERSONAL xai key, sealed the way the BYOK route seals it.
+	apiKeys := secrets.NewMemoryApiKeyStore()
+	keyID := secrets.NewApiKeyID()
+	sealed, err := secrets.SealAPIKey(sealer, keyID, []byte("xai-donated-key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantFP := secrets.FingerprintSHA256("xai-donated-key")
+	if err := apiKeys.Create(store.WithTenant(ctx, "donor-team"), secrets.ApiKey{
+		ID: keyID, TenantID: "donor-team", ScopeTeamID: "donor-team", ScopeUserID: "donor",
+		Provider: secrets.ProviderXAI, Name: "lent", SealedSecret: sealed, Fingerprint: wantFP,
+	}); err != nil {
+		t.Fatalf("seed key: %v", err)
+	}
+	pools := credpool.NewMemoryPoolStore()
+	if err := pools.Upsert(ctx, credpool.Pool{ID: "pool-1", OrgID: poolOrg, Enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	pledges := credpool.NewMemoryPledgeStore()
+	if err := pledges.Upsert(ctx, credpool.Pledge{
+		ID: credpool.PledgeID("donor", credpool.SourceAPIKey, "xai"), PoolID: "pool-1", UserID: "donor",
+		Credential: credpool.Credential{Source: credpool.SourceAPIKey, Ref: "xai", KeyID: keyID},
+		Enabled:    true, Health: credpool.HealthOK, Limits: credpool.Limits{MaxUSDPerDay: 5},
+	}); err != nil {
+		t.Fatalf("seed pledge: %v", err)
+	}
+	broker := credpool.NewBroker(credpool.BrokerConfig{
+		Pools: pools, Pledges: pledges, Leases: credpool.NewMemoryLeaseStore(), Ledger: credpool.NewMemoryLedger(),
+		OAuth: secrets.NewMemoryOAuthStore(), APIKeys: apiKeys, Sealer: sealer, Logger: testLogger(),
+	})
+	if broker == nil {
+		t.Fatal("broker is nil with every dependency wired")
+	}
+	var buf bytes.Buffer
+	rs := secrets.NewMemoryRunSecretsStore()
+	p := &Publisher{runSecrets: rs, sealer: sealer, credPool: broker, logger: iterlog.New(iterlog.LevelInfo, &buf)}
+
+	wf := &ir.Workflow{Nodes: map[string]ir.Node{"a": &ir.AgentNode{
+		BaseNode: ir.BaseNode{ID: "a"}, LLMFields: ir.LLMFields{Backend: "claw", Provider: "xai", Model: "xai/grok-4"},
+	}}}
+	creds, err := p.resolveAndSealCredentials(store.WithTenant(ctx, poolTeam), "run-xai", poolOrg, poolTeam, "requester", "bot", wf, nil, nil, model.ModelOverrides{}, nil)
+	if err != nil {
+		t.Fatalf("resolveAndSealCredentials: %v", err)
+	}
+	if creds.grant == nil || creds.grant.Source != credpool.SourceAPIKey {
+		t.Fatalf("want an api_key grant, got %+v; log:\n%s", creds.grant, buf.String())
+	}
+	log := buf.String()
+	if !strings.Contains(log, "pool(api_key:xai fp="+wantFP+")") {
+		t.Fatalf("GRANTED line must name the pool tier and the donor key's fingerprint; got:\n%s", log)
+	}
+	if strings.Contains(log, "<unstamped>") || strings.Contains(log, "xai-donated-key") {
+		t.Fatalf("GRANTED line is unstamped or leaks the key:\n%s", log)
+	}
+	found := false
+	for _, fp := range creds.fingerprints {
+		if fp == wantFP {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("run-doc fingerprints = %v, want the lent key's %s", creds.fingerprints, wantFP)
+	}
+	rec, err := rs.Get(ctx, creds.secretsRef)
+	if err != nil {
+		t.Fatalf("RunSecrets.Get: %v", err)
+	}
+	bundle, err := secrets.OpenRunBundle(sealer, "run-xai", rec.SealedBundle)
+	if err != nil {
+		t.Fatalf("OpenRunBundle: %v", err)
+	}
+	if bundle.APIKeys[secrets.ProviderXAI] != "xai-donated-key" {
+		t.Fatalf("bundle xai slot = %q, want the lent key", bundle.APIKeys[secrets.ProviderXAI])
+	}
+}

--- a/pkg/server/cloudpublisher/credpool_tier_test.go
+++ b/pkg/server/cloudpublisher/credpool_tier_test.go
@@ -1,8 +1,10 @@
 package cloudpublisher
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -331,4 +333,75 @@ func TestPoolTier_grantCarriesTheDonorCredentialsIdentity(t *testing.T) {
 	if got := bundle.OAuthFingerprints["claude_code"]; got != want {
 		t.Errorf("OAuthFingerprints[claude_code] = %q, want %q — the borrower's meter would follow the slot, not the lent credential", got, want)
 	}
+}
+
+
+// acquireFromPool must LOG A WARN naming the reason at the moment an
+// abstention becomes final. The mute prod incident (2026-09-03, half a
+// day of investigation) had the pool return nil to the caller and the
+// server logs carry no line — an operator could not distinguish "no
+// pool" from "audience refused" from "every donor cooling". The Warn
+// line is the fix: one line per abstention, at the level that survives
+// `ITERION_LOG_LEVEL=info` (Debug was the mute channel).
+//
+// The oracle is the LOG output the publisher emitted, not the returned
+// value — the caller (resolveAndSealCredentials) has always fallen
+// through on nil, so the ABSENCE of a log was the bug.
+func TestAcquireFromPool_LogsWarnWithReasonOnAbstention(t *testing.T) {
+	bufFor := func(t *testing.T) *bytes.Buffer {
+		t.Helper()
+		var buf bytes.Buffer
+		return &buf
+	}
+
+	t.Run("nil broker → warn(pool_disabled)", func(t *testing.T) {
+		buf := bufFor(t)
+		p := &Publisher{logger: iterlog.New(iterlog.LevelInfo, buf)}
+		if g := p.acquireFromPool(context.Background(), "run-1", "org", "team", "user", "bot", &ir.Workflow{}); g != nil {
+			t.Fatalf("nil broker must not grant, got %+v", g)
+		}
+		log := buf.String()
+		if !strings.Contains(log, "⚠️") || !strings.Contains(log, "run-1") || !strings.Contains(log, "pool_disabled") {
+			t.Fatalf("want a Warn line naming run-1 and pool_disabled; got:\n%s", log)
+		}
+	})
+
+	t.Run("wants == 0 → warn(bot pins ...)", func(t *testing.T) {
+		buf := bufFor(t)
+		// Broker present but the wants-derivation returns empty: build a
+		// workflow with a model pin the pool never lends (a fake provider).
+		f := newPoolFixture(t, credpool.Limits{MaxUSDPerDay: 5})
+		f.pub.logger = iterlog.New(iterlog.LevelInfo, buf)
+		wf := &ir.Workflow{Nodes: map[string]ir.Node{
+			"a": &ir.AgentNode{
+				BaseNode:  ir.BaseNode{ID: "a"},
+				LLMFields: ir.LLMFields{Model: "fake-provider/some-model"},
+			},
+		}}
+		if g := f.pub.acquireFromPool(context.Background(), "run-2", poolOrg, poolTeam, "u", "bot", wf); g != nil {
+			t.Fatalf("wants==0 must not grant, got %+v", g)
+		}
+		log := buf.String()
+		if !strings.Contains(log, "⚠️") || !strings.Contains(log, "run-2") || !strings.Contains(log, "pinned=fake-provider") {
+			t.Fatalf("want a Warn line naming run-2 and the pinned provider; got:\n%s", log)
+		}
+	})
+
+	t.Run("no eligible pledge → warn(no_eligible_pledge)", func(t *testing.T) {
+		buf := bufFor(t)
+		f := newPoolFixture(t, credpool.Limits{})
+		f.pub.logger = iterlog.New(iterlog.LevelInfo, buf)
+		// Disable the donor: audience opens, walk finds nothing eligible.
+		pledge, _ := f.pledges.Get(context.Background(), credpool.PledgeID("donor", credpool.SourceOAuth, "claude_code"))
+		pledge.Enabled = false
+		_ = f.pledges.Upsert(context.Background(), pledge)
+
+		if g := f.pub.acquireFromPool(context.Background(), "run-3", poolOrg, poolTeam, "u", "bot", &ir.Workflow{}); g != nil {
+			t.Fatalf("no eligible pledge must not grant, got %+v", g)
+		}
+		log := buf.String()
+		if !strings.Contains(log, "⚠️") || !strings.Contains(log, "run-3") || !strings.Contains(log, "no_eligible_pledge") {
+			t.Fatalf("want a Warn line naming run-3 and no_eligible_pledge; got:\n%s", log)
+		}
+	})
 }

--- a/pkg/server/cloudpublisher/credpool_tier_test.go
+++ b/pkg/server/cloudpublisher/credpool_tier_test.go
@@ -1,6 +1,7 @@
 package cloudpublisher
 
 import (
+	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -84,7 +85,7 @@ func newPoolFixture(t *testing.T, limits credpool.Limits) *poolFixture {
 func (f *poolFixture) resolve(t *testing.T, runID string, wf *ir.Workflow) (secrets.RunBundle, credResolution) {
 	t.Helper()
 	ctx := store.WithTenant(context.Background(), poolTeam)
-	creds, err := f.pub.resolveAndSealCredentials(ctx, runID, poolOrg, poolTeam, "requester", "docs-refresh", wf, nil, nil)
+	creds, err := f.pub.resolveAndSealCredentials(ctx, runID, poolOrg, poolTeam, "requester", "docs-refresh", wf, nil, nil, model.ModelOverrides{})
 	if err != nil {
 		t.Fatalf("resolveAndSealCredentials: %v", err)
 	}
@@ -286,7 +287,7 @@ func TestWantsFor_narrowsToTheProvidersTheRunPinned(t *testing.T) {
 	wf := &ir.Workflow{Nodes: map[string]ir.Node{
 		"a": &ir.AgentNode{LLMFields: ir.LLMFields{Model: "anthropic/claude-opus-5"}},
 	}}
-	got := wantsFor(wf)
+	got := wantsFor(wf, model.ModelOverrides{})
 	if len(got) == 0 {
 		t.Fatal("a pinned run was left with nothing to ask for")
 	}
@@ -308,7 +309,7 @@ func TestWantsFor_unpinnedRunKeepsTheWholeOrder(t *testing.T) {
 	for _, wf := range []*ir.Workflow{nil, {Nodes: map[string]ir.Node{
 		"a": &ir.AgentNode{LLMFields: ir.LLMFields{Model: ""}},
 	}}} {
-		if got := wantsFor(wf); len(got) != len(poolWantOrder) {
+		if got := wantsFor(wf, model.ModelOverrides{}); len(got) != len(poolWantOrder) {
 			t.Errorf("unpinned run asks for %d want(s), want the full %d", len(got), len(poolWantOrder))
 		}
 	}
@@ -357,7 +358,7 @@ func TestAcquireFromPool_LogsWarnWithReasonOnAbstention(t *testing.T) {
 	t.Run("nil broker → warn(pool_disabled)", func(t *testing.T) {
 		buf := bufFor(t)
 		p := &Publisher{logger: iterlog.New(iterlog.LevelInfo, buf)}
-		if g := p.acquireFromPool(context.Background(), "run-1", "org", "team", "user", "bot", &ir.Workflow{}); g != nil {
+		if g := p.acquireFromPool(context.Background(), "run-1", "org", "team", "user", "bot", &ir.Workflow{}, model.ModelOverrides{}); g != nil {
 			t.Fatalf("nil broker must not grant, got %+v", g)
 		}
 		log := buf.String()
@@ -378,7 +379,7 @@ func TestAcquireFromPool_LogsWarnWithReasonOnAbstention(t *testing.T) {
 				LLMFields: ir.LLMFields{Model: "fake-provider/some-model"},
 			},
 		}}
-		if g := f.pub.acquireFromPool(context.Background(), "run-2", poolOrg, poolTeam, "u", "bot", wf); g != nil {
+		if g := f.pub.acquireFromPool(context.Background(), "run-2", poolOrg, poolTeam, "u", "bot", wf, model.ModelOverrides{}); g != nil {
 			t.Fatalf("wants==0 must not grant, got %+v", g)
 		}
 		log := buf.String()
@@ -396,7 +397,7 @@ func TestAcquireFromPool_LogsWarnWithReasonOnAbstention(t *testing.T) {
 		pledge.Enabled = false
 		_ = f.pledges.Upsert(context.Background(), pledge)
 
-		if g := f.pub.acquireFromPool(context.Background(), "run-3", poolOrg, poolTeam, "u", "bot", &ir.Workflow{}); g != nil {
+		if g := f.pub.acquireFromPool(context.Background(), "run-3", poolOrg, poolTeam, "u", "bot", &ir.Workflow{}, model.ModelOverrides{}); g != nil {
 			t.Fatalf("no eligible pledge must not grant, got %+v", g)
 		}
 		log := buf.String()

--- a/pkg/server/cloudpublisher/credpool_tier_test.go
+++ b/pkg/server/cloudpublisher/credpool_tier_test.go
@@ -1,10 +1,10 @@
 package cloudpublisher
 
 import (
-	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"bytes"
 	"context"
 	"encoding/json"
+	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"strings"
 	"testing"
 	"time"
@@ -335,7 +335,6 @@ func TestPoolTier_grantCarriesTheDonorCredentialsIdentity(t *testing.T) {
 		t.Errorf("OAuthFingerprints[claude_code] = %q, want %q — the borrower's meter would follow the slot, not the lent credential", got, want)
 	}
 }
-
 
 // acquireFromPool must LOG A WARN naming the reason at the moment an
 // abstention becomes final. The mute prod incident (2026-09-03, half a

--- a/pkg/server/cloudpublisher/credpool_tier_test.go
+++ b/pkg/server/cloudpublisher/credpool_tier_test.go
@@ -85,7 +85,7 @@ func newPoolFixture(t *testing.T, limits credpool.Limits) *poolFixture {
 func (f *poolFixture) resolve(t *testing.T, runID string, wf *ir.Workflow) (secrets.RunBundle, credResolution) {
 	t.Helper()
 	ctx := store.WithTenant(context.Background(), poolTeam)
-	creds, err := f.pub.resolveAndSealCredentials(ctx, runID, poolOrg, poolTeam, "requester", "docs-refresh", wf, nil, nil, model.ModelOverrides{})
+	creds, err := f.pub.resolveAndSealCredentials(ctx, runID, poolOrg, poolTeam, "requester", "docs-refresh", wf, nil, nil, model.ModelOverrides{}, nil)
 	if err != nil {
 		t.Fatalf("resolveAndSealCredentials: %v", err)
 	}
@@ -287,7 +287,7 @@ func TestWantsFor_narrowsToTheProvidersTheRunPinned(t *testing.T) {
 	wf := &ir.Workflow{Nodes: map[string]ir.Node{
 		"a": &ir.AgentNode{LLMFields: ir.LLMFields{Model: "anthropic/claude-opus-5"}},
 	}}
-	got := wantsFor(wf, model.ModelOverrides{})
+	got, _ := wantsFor(wf, model.ModelOverrides{}, nil)
 	if len(got) == 0 {
 		t.Fatal("a pinned run was left with nothing to ask for")
 	}
@@ -309,7 +309,7 @@ func TestWantsFor_unpinnedRunKeepsTheWholeOrder(t *testing.T) {
 	for _, wf := range []*ir.Workflow{nil, {Nodes: map[string]ir.Node{
 		"a": &ir.AgentNode{LLMFields: ir.LLMFields{Model: ""}},
 	}}} {
-		if got := wantsFor(wf, model.ModelOverrides{}); len(got) != len(poolWantOrder) {
+		if got, _ := wantsFor(wf, model.ModelOverrides{}, nil); len(got) != len(poolWantOrder) {
 			t.Errorf("unpinned run asks for %d want(s), want the full %d", len(got), len(poolWantOrder))
 		}
 	}
@@ -357,7 +357,7 @@ func TestAcquireFromPool_LogsWarnWithReasonOnAbstention(t *testing.T) {
 	t.Run("nil broker → warn(pool_disabled)", func(t *testing.T) {
 		buf := bufFor(t)
 		p := &Publisher{logger: iterlog.New(iterlog.LevelInfo, buf)}
-		if g := p.acquireFromPool(context.Background(), "run-1", "org", "team", "user", "bot", &ir.Workflow{}, model.ModelOverrides{}); g != nil {
+		if g := p.acquireFromPool(context.Background(), "run-1", "org", "team", "user", "bot", &ir.Workflow{}, model.ModelOverrides{}, nil); g != nil {
 			t.Fatalf("nil broker must not grant, got %+v", g)
 		}
 		log := buf.String()
@@ -366,10 +366,13 @@ func TestAcquireFromPool_LogsWarnWithReasonOnAbstention(t *testing.T) {
 		}
 	})
 
-	t.Run("wants == 0 → warn(bot pins ...)", func(t *testing.T) {
+	t.Run("unknown provider pin → fails OPEN: warn naming the pin, pool consulted, donor granted", func(t *testing.T) {
+		// A pin the pool does not know (a typo, a prefix it never lends)
+		// must NOT narrow the wants to nothing — that skipped the pool
+		// tier on every credential-less run of a bot with a bad hint.
+		// The walk widens to the full order, says WHICH pin made it, and
+		// the fixture's donor serves the run.
 		buf := bufFor(t)
-		// Broker present but the wants-derivation returns empty: build a
-		// workflow with a model pin the pool never lends (a fake provider).
 		f := newPoolFixture(t, credpool.Limits{MaxUSDPerDay: 5})
 		f.pub.logger = iterlog.New(iterlog.LevelInfo, buf)
 		wf := &ir.Workflow{Nodes: map[string]ir.Node{
@@ -378,12 +381,13 @@ func TestAcquireFromPool_LogsWarnWithReasonOnAbstention(t *testing.T) {
 				LLMFields: ir.LLMFields{Model: "fake-provider/some-model"},
 			},
 		}}
-		if g := f.pub.acquireFromPool(context.Background(), "run-2", poolOrg, poolTeam, "u", "bot", wf, model.ModelOverrides{}); g != nil {
-			t.Fatalf("wants==0 must not grant, got %+v", g)
+		g := f.pub.acquireFromPool(context.Background(), "run-2", poolOrg, poolTeam, "u", "bot", wf, model.ModelOverrides{}, nil)
+		if g == nil {
+			t.Fatalf("unknown pin must fail open and take the donor; got no grant. log:\n%s", buf.String())
 		}
 		log := buf.String()
-		if !strings.Contains(log, "⚠️") || !strings.Contains(log, "run-2") || !strings.Contains(log, "pinned=fake-provider") {
-			t.Fatalf("want a Warn line naming run-2 and the pinned provider; got:\n%s", log)
+		if !strings.Contains(log, "⚠️") || !strings.Contains(log, "run-2") || !strings.Contains(log, "fake-provider") || !strings.Contains(log, "FULL order") {
+			t.Fatalf("want a Warn line naming run-2, the unknown pin and the widening; got:\n%s", log)
 		}
 	})
 
@@ -396,7 +400,7 @@ func TestAcquireFromPool_LogsWarnWithReasonOnAbstention(t *testing.T) {
 		pledge.Enabled = false
 		_ = f.pledges.Upsert(context.Background(), pledge)
 
-		if g := f.pub.acquireFromPool(context.Background(), "run-3", poolOrg, poolTeam, "u", "bot", &ir.Workflow{}, model.ModelOverrides{}); g != nil {
+		if g := f.pub.acquireFromPool(context.Background(), "run-3", poolOrg, poolTeam, "u", "bot", &ir.Workflow{}, model.ModelOverrides{}, nil); g != nil {
 			t.Fatalf("no eligible pledge must not grant, got %+v", g)
 		}
 		log := buf.String()

--- a/pkg/server/cloudpublisher/credpool_tier_test.go
+++ b/pkg/server/cloudpublisher/credpool_tier_test.go
@@ -24,6 +24,7 @@ type poolFixture struct {
 	pub     *Publisher
 	rs      *secrets.MemoryRunSecretsStore
 	sealer  secrets.Sealer
+	pools   *credpool.MemoryPoolStore
 	pledges *credpool.MemoryPledgeStore
 	ledger  *credpool.MemoryLedger
 }
@@ -76,7 +77,7 @@ func newPoolFixture(t *testing.T, limits credpool.Limits) *poolFixture {
 			credPool:   broker,
 			logger:     iterlog.New(iterlog.LevelError, nil),
 		},
-		rs: rs, sealer: sealer, pledges: pledges, ledger: ledger,
+		rs: rs, sealer: sealer, pools: pools, pledges: pledges, ledger: ledger,
 	}
 }
 
@@ -353,16 +354,48 @@ func TestAcquireFromPool_LogsWarnWithReasonOnAbstention(t *testing.T) {
 		var buf bytes.Buffer
 		return &buf
 	}
+	// The logger's level glyphs: Warn lines carry ⚠️, Debug lines 🔍.
+	const warnGlyph, debugGlyph = "⚠️", "🔍"
 
-	t.Run("nil broker → warn(pool_disabled)", func(t *testing.T) {
+	t.Run("nil broker → DEBUG(pool_disabled), never a Warn", func(t *testing.T) {
+		// A deployment with no pool is static configuration; a Warn per
+		// credential-less launch would be forwarded to the error tracker
+		// forever. The signal is the terminal "no credential" Warn.
 		buf := bufFor(t)
-		p := &Publisher{logger: iterlog.New(iterlog.LevelInfo, buf)}
+		p := &Publisher{logger: iterlog.New(iterlog.LevelDebug, buf)}
 		if g := p.acquireFromPool(context.Background(), "run-1", "org", "team", "user", "bot", &ir.Workflow{}, model.ModelOverrides{}, nil); g != nil {
 			t.Fatalf("nil broker must not grant, got %+v", g)
 		}
 		log := buf.String()
-		if !strings.Contains(log, "⚠️") || !strings.Contains(log, "run-1") || !strings.Contains(log, "pool_disabled") {
-			t.Fatalf("want a Warn line naming run-1 and pool_disabled; got:\n%s", log)
+		if strings.Contains(log, warnGlyph) {
+			t.Fatalf("nil broker must not Warn; got:\n%s", log)
+		}
+		if !strings.Contains(log, debugGlyph) || !strings.Contains(log, "run-1") || !strings.Contains(log, "pool_disabled") {
+			t.Fatalf("want a Debug line naming run-1 and pool_disabled; got:\n%s", log)
+		}
+	})
+
+	t.Run("no enabled pool → DEBUG(no_enabled_pool), never a Warn", func(t *testing.T) {
+		buf := bufFor(t)
+		f := newPoolFixture(t, credpool.Limits{})
+		f.pub.logger = iterlog.New(iterlog.LevelDebug, buf)
+		pool, err := f.pools.GetByOrg(context.Background(), poolOrg)
+		if err != nil {
+			t.Fatalf("get pool: %v", err)
+		}
+		pool.Enabled = false
+		if err := f.pools.Upsert(context.Background(), pool); err != nil {
+			t.Fatalf("disable pool: %v", err)
+		}
+		if g := f.pub.acquireFromPool(context.Background(), "run-np", poolOrg, poolTeam, "u", "bot", &ir.Workflow{}, model.ModelOverrides{}, nil); g != nil {
+			t.Fatalf("disabled pool must not grant, got %+v", g)
+		}
+		log := buf.String()
+		if strings.Contains(log, warnGlyph) {
+			t.Fatalf("a disabled pool is static configuration and must not Warn; got:\n%s", log)
+		}
+		if !strings.Contains(log, debugGlyph) || !strings.Contains(log, "run-np") || !strings.Contains(log, "no_enabled_pool") {
+			t.Fatalf("want a Debug line naming run-np and no_enabled_pool; got:\n%s", log)
 		}
 	})
 
@@ -386,17 +419,18 @@ func TestAcquireFromPool_LogsWarnWithReasonOnAbstention(t *testing.T) {
 			t.Fatalf("unknown pin must fail open and take the donor; got no grant. log:\n%s", buf.String())
 		}
 		log := buf.String()
-		if !strings.Contains(log, "⚠️") || !strings.Contains(log, "run-2") || !strings.Contains(log, "fake-provider") || !strings.Contains(log, "FULL order") {
+		if !strings.Contains(log, warnGlyph) || !strings.Contains(log, "run-2") || !strings.Contains(log, "fake-provider") || !strings.Contains(log, "FULL order") {
 			t.Fatalf("want a Warn line naming run-2, the unknown pin and the widening; got:\n%s", log)
 		}
 	})
 
-	t.Run("no eligible pledge → warn(no_eligible_pledge)", func(t *testing.T) {
+	t.Run("no eligible pledge → WARN(no_eligible_pledge) naming each pledge's state", func(t *testing.T) {
 		buf := bufFor(t)
 		f := newPoolFixture(t, credpool.Limits{})
 		f.pub.logger = iterlog.New(iterlog.LevelInfo, buf)
 		// Disable the donor: audience opens, walk finds nothing eligible.
-		pledge, _ := f.pledges.Get(context.Background(), credpool.PledgeID("donor", credpool.SourceOAuth, "claude_code"))
+		pledgeID := credpool.PledgeID("donor", credpool.SourceOAuth, "claude_code")
+		pledge, _ := f.pledges.Get(context.Background(), pledgeID)
 		pledge.Enabled = false
 		_ = f.pledges.Upsert(context.Background(), pledge)
 
@@ -404,8 +438,57 @@ func TestAcquireFromPool_LogsWarnWithReasonOnAbstention(t *testing.T) {
 			t.Fatalf("no eligible pledge must not grant, got %+v", g)
 		}
 		log := buf.String()
-		if !strings.Contains(log, "⚠️") || !strings.Contains(log, "run-3") || !strings.Contains(log, "no_eligible_pledge") {
+		if !strings.Contains(log, warnGlyph) || !strings.Contains(log, "run-3") || !strings.Contains(log, "no_eligible_pledge") {
 			t.Fatalf("want a Warn line naming run-3 and no_eligible_pledge; got:\n%s", log)
 		}
+		// The per-pledge state the ticket asks for rides the same line.
+		if !strings.Contains(log, "pools_enabled=1") || !strings.Contains(log, "pools_admitted=1") || !strings.Contains(log, "skips="+pledgeID+":paused") {
+			t.Fatalf("want the counts and the paused donor named on the Warn line; got:\n%s", log)
+		}
 	})
+}
+
+// The definitive "no credential at all" Warn: once per resolution, at the
+// END of resolveAndSealCredentials, when every tier abstained on a run
+// that CAN call a model — and not for a tool-only workflow, which spends
+// nothing and would otherwise page the tracker on every launch.
+func TestResolveAndSealCredentials_WarnsOnceWhenNothingResolvedForASpendingRun(t *testing.T) {
+	spending := &ir.Workflow{Nodes: map[string]ir.Node{"a": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}}}}
+	toolOnly := &ir.Workflow{Nodes: map[string]ir.Node{"t": &ir.ToolNode{BaseNode: ir.BaseNode{ID: "t"}}}}
+
+	for _, tc := range []struct {
+		name     string
+		wf       *ir.Workflow
+		wantWarn bool
+	}{
+		{"spending workflow, every tier abstained", spending, true},
+		{"nil workflow (unknown) is treated as spending", nil, true},
+		{"tool-only workflow spends nothing", toolOnly, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			f := newPoolFixture(t, credpool.Limits{})
+			f.pub.logger = iterlog.New(iterlog.LevelInfo, &buf)
+			// Disable the donor so the pool declines too.
+			pledge, _ := f.pledges.Get(context.Background(), credpool.PledgeID("donor", credpool.SourceOAuth, "claude_code"))
+			pledge.Enabled = false
+			_ = f.pledges.Upsert(context.Background(), pledge)
+
+			ctx := store.WithTenant(context.Background(), poolTeam)
+			creds, err := f.pub.resolveAndSealCredentials(ctx, "run-terminal", poolOrg, poolTeam, "u", "bot", tc.wf, nil, nil, model.ModelOverrides{}, nil)
+			if err != nil {
+				t.Fatalf("resolveAndSealCredentials: %v", err)
+			}
+			if creds.secretsRef != "" {
+				t.Fatalf("nothing should have been sealed, got ref %q", creds.secretsRef)
+			}
+			got := strings.Count(buf.String(), "no credential resolved for run=run-terminal")
+			if tc.wantWarn && got != 1 {
+				t.Fatalf("want exactly one terminal Warn, got %d; log:\n%s", got, buf.String())
+			}
+			if !tc.wantWarn && got != 0 {
+				t.Fatalf("a tool-only run must not Warn; log:\n%s", buf.String())
+			}
+		})
+	}
 }

--- a/pkg/server/cloudpublisher/credpool_tier_test.go
+++ b/pkg/server/cloudpublisher/credpool_tier_test.go
@@ -492,3 +492,53 @@ func TestResolveAndSealCredentials_WarnsOnceWhenNothingResolvedForASpendingRun(t
 		})
 	}
 }
+
+// A generic secret is not an LLM credential. A webhook-launched review
+// resolves a forge or tracker token into the same bundle, which is the most
+// common cloud shape — gating the definitive Warn on the whole bundle
+// silenced it exactly there, and with the pool's static reasons at Debug the
+// run went out with no trace at all that no model credential was found.
+func TestResolveAndSealCredentials_WarnsWhenOnlyAGenericSecretResolved(t *testing.T) {
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	genericStore := secrets.NewMemoryGenericSecretStore()
+	secretID := secrets.NewGenericSecretID()
+	sealed, err := secrets.SealGenericSecret(sealer, secretID, []byte("ghp-forge-token"))
+	if err != nil {
+		t.Fatalf("SealGenericSecret: %v", err)
+	}
+	if err := genericStore.Create(context.Background(), secrets.GenericSecret{
+		ID: secretID, ScopeTeamID: poolTeam, Name: "forge_token",
+		SealedSecret: sealed, CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	var buf bytes.Buffer
+	p := &Publisher{
+		genericSecrets: genericStore,
+		runSecrets:     secrets.NewMemoryRunSecretsStore(),
+		sealer:         sealer,
+		logger:         iterlog.New(iterlog.LevelInfo, &buf),
+	}
+	wf := &ir.Workflow{
+		Nodes:   map[string]ir.Node{"a": &ir.AgentNode{BaseNode: ir.BaseNode{ID: "a"}}},
+		Secrets: map[string]*ir.Secret{"forge_token": {Name: "forge_token"}},
+	}
+
+	ctx := store.WithTenant(context.Background(), poolTeam)
+	creds, err := p.resolveAndSealCredentials(ctx, "run-generic-only", poolOrg, poolTeam, "requester", "review-pr", wf, nil, nil, model.ModelOverrides{}, nil)
+	if err != nil {
+		t.Fatalf("resolveAndSealCredentials: %v", err)
+	}
+	// The generic secret still seals — the Warn is about the LLM tiers, not
+	// about refusing the run.
+	if creds.secretsRef == "" {
+		t.Fatalf("the generic secret must still be sealed into a bundle")
+	}
+	if got := strings.Count(buf.String(), "no credential resolved for run=run-generic-only"); got != 1 {
+		t.Fatalf("want exactly one terminal Warn for a run funded by no LLM credential, got %d; log:\n%s", got, buf.String())
+	}
+}

--- a/pkg/server/cloudpublisher/oauth_fallback_test.go
+++ b/pkg/server/cloudpublisher/oauth_fallback_test.go
@@ -1,8 +1,8 @@
 package cloudpublisher
 
 import (
-	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"context"
+	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"io"
 	"testing"
 

--- a/pkg/server/cloudpublisher/oauth_fallback_test.go
+++ b/pkg/server/cloudpublisher/oauth_fallback_test.go
@@ -41,7 +41,7 @@ func seededFP(ownerKey string) string { return "fp-" + ownerKey }
 func resolveBundle(t *testing.T, p *Publisher, runSecrets *secrets.MemoryRunSecretsStore, sealer secrets.Sealer, runID, tenant, owner string) secrets.RunBundle {
 	t.Helper()
 	ctx := store.WithTenant(context.Background(), tenant)
-	creds, err := p.resolveAndSealCredentials(ctx, runID, "", tenant, owner, "", nil, nil, nil, model.ModelOverrides{})
+	creds, err := p.resolveAndSealCredentials(ctx, runID, "", tenant, owner, "", nil, nil, nil, model.ModelOverrides{}, nil)
 	if err != nil {
 		t.Fatalf("resolveAndSealCredentials: %v", err)
 	}

--- a/pkg/server/cloudpublisher/oauth_fallback_test.go
+++ b/pkg/server/cloudpublisher/oauth_fallback_test.go
@@ -1,6 +1,7 @@
 package cloudpublisher
 
 import (
+	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"context"
 	"io"
 	"testing"
@@ -40,7 +41,7 @@ func seededFP(ownerKey string) string { return "fp-" + ownerKey }
 func resolveBundle(t *testing.T, p *Publisher, runSecrets *secrets.MemoryRunSecretsStore, sealer secrets.Sealer, runID, tenant, owner string) secrets.RunBundle {
 	t.Helper()
 	ctx := store.WithTenant(context.Background(), tenant)
-	creds, err := p.resolveAndSealCredentials(ctx, runID, "", tenant, owner, "", nil, nil, nil)
+	creds, err := p.resolveAndSealCredentials(ctx, runID, "", tenant, owner, "", nil, nil, nil, model.ModelOverrides{})
 	if err != nil {
 		t.Fatalf("resolveAndSealCredentials: %v", err)
 	}

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -685,6 +685,15 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 		return res, nil
 	}
 
+	// #659 pt 1: log the granted credential set once per run, symmetric
+	// with the per-tier SKIPPED lines above. This is what lets an
+	// operator answer "which credential funded that run?" from the
+	// server logs, instead of grepping /proc/<pid>/environ inside a pod
+	// (measured, 2026-09-03). Only fingerprints (never plaintext) and
+	// tier tags — bundle.PlatformSourced already tracks the platform
+	// vs tenant/tier split.
+	logGrantedCredentials(p.logger, runID, bundle, apiKeyFPs, res.grant)
+
 	sealed, err := secrets.SealRunBundle(p.sealer, runID, bundle)
 	if err != nil {
 		return res, fmt.Errorf("cloudpublisher: seal bundle: %w", err)
@@ -1376,6 +1385,60 @@ func providersSummary(provs []string) string {
 		return "pinned=<none>"
 	}
 	return "pinned=" + strings.Join(provs, ",")
+}
+
+// logGrantedCredentials emits ONE INFO line per run listing which
+// credential funded which slot at the end of resolveAndSealCredentials.
+// Symmetric with the per-tier SKIPPED log lines the file already emits
+// (a grant used to be silent — #659 pt 1), and the answer an operator
+// needed to `grep run=<id>` for instead of `/proc/<pid>/environ` inside
+// a pod (measured, 2026-09-03). The line carries the credential's
+// TIER (byok / oauth-forfait / pool / platform), the slot name
+// (provider or oauth kind), and the FINGERPRINT — never plaintext.
+func logGrantedCredentials(logger *iterlog.Logger, runID string, bundle secrets.RunBundle, apiKeyFPs map[secrets.Provider]string, grant *credpool.Grant) {
+	if logger == nil {
+		return
+	}
+	parts := make([]string, 0, len(bundle.APIKeys)+len(bundle.OAuthCredentials))
+	// API keys — the PlatformSourced map tells apart platform-tier
+	// grants (deployment-wide fallback keys) from tenant BYOK.
+	for _, prov := range allKnownProviders {
+		if _, ok := bundle.APIKeys[prov]; !ok {
+			continue
+		}
+		tier := "byok"
+		if bundle.PlatformSourced[string(prov)] {
+			tier = "platform"
+		}
+		fp := apiKeyFPs[prov]
+		if fp == "" {
+			fp = "<unstamped>"
+		}
+		parts = append(parts, fmt.Sprintf("%s(api_key:%s fp=%s)", tier, prov, fp))
+	}
+	// OAuth-forfait — grant != nil means a donor's subscription came in
+	// via the pool tier; the platform sentinel marks the deployment's
+	// own fallback forfait; otherwise it is a user-or-org connect.
+	for _, kind := range []string{string(secrets.OAuthKindClaudeCode), string(secrets.OAuthKindCodex)} {
+		if _, ok := bundle.OAuthCredentials[kind]; !ok {
+			continue
+		}
+		tier := "oauth-forfait"
+		if grant != nil && string(grant.Ref) == kind && grant.Source == credpool.SourceOAuth {
+			tier = "pool"
+		} else if bundle.PlatformSourced[kind] {
+			tier = "platform"
+		}
+		fp := bundle.OAuthFingerprints[kind]
+		if fp == "" {
+			fp = "<unstamped>"
+		}
+		parts = append(parts, fmt.Sprintf("%s(oauth:%s fp=%s)", tier, kind, fp))
+	}
+	if len(parts) == 0 {
+		return
+	}
+	logger.Info("cloudpublisher: credentials GRANTED for run=%s — %s", runID, strings.Join(parts, ", "))
 }
 
 // SubmitLaunch persists the run as queued in Mongo, then publishes

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -682,6 +682,16 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 	sort.Strings(res.fingerprints)
 
 	if len(bundle.APIKeys) == 0 && len(bundle.GenericSecrets) == 0 && len(bundle.OAuthCredentials) == 0 {
+		// The moment "no credential" becomes definitive: every tier
+		// abstained, and the runner will either spend its pod's ambient
+		// env or fail at the first LLM call. ONE Warn here, naming the
+		// tiers consulted — the per-tier lines above say which said no
+		// and why. A workflow that cannot call a model (tool-only, a
+		// nil workflow is unknown) spends nothing and gets no Warn.
+		if wf == nil || wf.UsesLLM() {
+			p.logger.Warn("cloudpublisher: no credential resolved for run=%s tenant=%s — tiers consulted: byok, oauth-forfait, pool, platform; the runner falls back to its env or fails at the first LLM call",
+				runID, tenantID)
+		}
 		return res, nil
 	}
 
@@ -1246,10 +1256,12 @@ func wantsFor(wf *ir.Workflow, overrides model.ModelOverrides, runFallbacks []mo
 // decides who pays (#654).
 func (p *Publisher) acquireFromPool(ctx context.Context, runID, orgID, tenantID, ownerID, botID string, wf *ir.Workflow, overrides model.ModelOverrides, runFallbacks []model.FallbackEntry) *credpool.Grant {
 	if p.credPool == nil {
-		// No pool at all — a static configuration fact, but log it once per
-		// run so the trace of "which tier funded this run" starts at the
-		// pool tier for every run, not only the ones that got a grant.
-		p.logger.Warn("cloudpublisher: credential pool NOT CONSULTED for run %s — no pool broker wired (reason=%s)",
+		// No pool at all — a static configuration fact. Debug, not Warn:
+		// pkg/log forwards Warn to the error tracker's breadcrumbs, and a
+		// platform-funded deployment with no pool would emit one per
+		// credential-less launch, forever. The definitive "no credential"
+		// Warn at the end of resolveAndSealCredentials is the signal.
+		p.logger.Debug("cloudpublisher: credential pool NOT CONSULTED for run %s — no pool broker wired (reason=%s)",
 			runID, credpool.ReasonPoolDisabled)
 		return nil
 	}
@@ -1291,8 +1303,17 @@ func (p *Publisher) acquireFromPool(ctx context.Context, runID, orgID, tenantID,
 		// pool answered nothing".
 		var nd *credpool.NoDonorError
 		if errors.As(err, &nd) {
-			p.logger.Warn("cloudpublisher: credential pool declined run %s — reason=%s pools_considered=%d pledges_considered=%d wants=%s",
-				runID, nd.Reason, nd.PoolsConsidered, nd.PledgesConsidered, wantsSummary(wants))
+			if nd.Reason == credpool.ReasonNoEnabledPool {
+				// Static configuration, like the nil broker above.
+				p.logger.Debug("cloudpublisher: credential pool NOT CONSULTED for run %s — no enabled pool (reason=%s)", runID, nd.Reason)
+				return nil
+			}
+			// A pool EXISTS and refused: which pools opened, how many
+			// pledges of a wanted kind were walked, and what state held
+			// each one out (paused / unhealthy / out_of_hours /
+			// bot_filtered / cooling / exhausted / serving).
+			p.logger.Warn("cloudpublisher: credential pool declined run %s — reason=%s pools_enabled=%d pools_admitted=%d pledges_considered=%d skips=%s wants=%s",
+				runID, nd.Reason, nd.PoolsEnabled, nd.PoolsAdmitted, nd.PledgesConsidered, pledgeSkipSummary(nd.Skips), wantsSummary(wants))
 			return nil
 		}
 		if errors.Is(err, credpool.ErrNoDonor) {
@@ -1332,6 +1353,20 @@ func providersSummary(provs []string) string {
 		return "pinned=<none>"
 	}
 	return "pinned=" + strings.Join(provs, ",")
+}
+
+// pledgeSkipSummary renders the per-pledge decline states an abstention
+// carries — `<pledge-id>:<status>` per donor, "<none>" when the walk
+// considered nobody.
+func pledgeSkipSummary(skips []credpool.PledgeSkip) string {
+	if len(skips) == 0 {
+		return "<none>"
+	}
+	parts := make([]string, 0, len(skips))
+	for _, sk := range skips {
+		parts = append(parts, sk.PledgeID+":"+string(sk.Status))
+	}
+	return strings.Join(parts, ",")
 }
 
 // logGrantedCredentials emits ONE INFO line per run listing which

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -1424,7 +1424,7 @@ func logGrantedCredentials(logger *iterlog.Logger, runID string, bundle secrets.
 			continue
 		}
 		tier := "oauth-forfait"
-		if grant != nil && string(grant.Ref) == kind && grant.Source == credpool.SourceOAuth {
+		if grant != nil && grant.Ref == kind && grant.Source == credpool.SourceOAuth {
 			tier = "pool"
 		} else if bundle.PlatformSourced[kind] {
 			tier = "platform"

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -688,17 +688,23 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 	}
 	sort.Strings(res.fingerprints)
 
-	if len(bundle.APIKeys) == 0 && len(bundle.GenericSecrets) == 0 && len(bundle.OAuthCredentials) == 0 {
-		// The moment "no credential" becomes definitive: every tier
-		// abstained, and the runner will either spend its pod's ambient
-		// env or fail at the first LLM call. ONE Warn here, naming the
-		// tiers consulted — the per-tier lines above say which said no
-		// and why. A workflow that cannot call a model (tool-only, a
-		// nil workflow is unknown) spends nothing and gets no Warn.
-		if wf == nil || wf.UsesLLM() {
-			p.logger.Warn("cloudpublisher: no credential resolved for run=%s tenant=%s — tiers consulted: byok, oauth-forfait, pool, platform; the runner falls back to its env or fails at the first LLM call",
-				runID, tenantID)
-		}
+	// The moment "no LLM credential" becomes definitive: every tier
+	// abstained, and the runner will either spend its pod's ambient env or
+	// fail at the first LLM call. ONE Warn here, naming the tiers consulted
+	// — the per-tier lines above say which said no and why. A workflow that
+	// cannot call a model (tool-only, a nil workflow is unknown) spends
+	// nothing and gets no Warn.
+	//
+	// Generic secrets do not fund an LLM call: a webhook-launched review
+	// resolves a forge or tracker token into this same bundle, which is the
+	// most common cloud shape, so gating the Warn on the whole bundle would
+	// silence it exactly where it matters.
+	noLLMCred := len(bundle.APIKeys) == 0 && len(bundle.OAuthCredentials) == 0
+	if noLLMCred && (wf == nil || wf.UsesLLM()) {
+		p.logger.Warn("cloudpublisher: no credential resolved for run=%s tenant=%s — tiers consulted: byok, oauth-forfait, pool, platform; the runner falls back to its env or fails at the first LLM call",
+			runID, tenantID)
+	}
+	if noLLMCred && len(bundle.GenericSecrets) == 0 {
 		return res, nil
 	}
 

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -588,7 +588,14 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 				// parked by the readings of the account it replaced.
 				setOAuthFingerprint(&bundle, grant.Ref, grant.Fingerprint)
 			case credpool.SourceAPIKey:
-				bundle.APIKeys[secrets.Provider(grant.Ref)] = string(grant.Payload)
+				prov := secrets.Provider(grant.Ref)
+				bundle.APIKeys[prov] = string(grant.Payload)
+				// The lent key's own audit identity — the same hash the
+				// BYOK record carries and the runner derives, so the
+				// GRANTED line, the run-document stamp and the metering-time
+				// last_used_at bump all name the donor's key, not an
+				// unstamped slot.
+				apiKeyFPs[prov] = secrets.FingerprintSHA256(string(grant.Payload))
 			}
 			res.grant = grant
 		}
@@ -1389,7 +1396,10 @@ func logGrantedCredentials(logger *iterlog.Logger, runID string, bundle secrets.
 			continue
 		}
 		tier := "byok"
-		if bundle.PlatformSourced[string(prov)] {
+		switch {
+		case grant != nil && grant.Source == credpool.SourceAPIKey && grant.Ref == string(prov):
+			tier = "pool"
+		case bundle.PlatformSourced[string(prov)]:
 			tier = "platform"
 		}
 		fp := apiKeyFPs[prov]

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -343,7 +343,7 @@ func (p *Publisher) appBotLoginForForgeToken(ctx context.Context, tenantID strin
 // tenant has none — seals the resulting bundle, and persists it under a
 // fresh secrets ref. An empty ref means no credentials are available; the
 // runner then falls back to env.
-func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID, tenantID, ownerID, botID string, wf *ir.Workflow, keyOverrides, secretOverrides map[string]string, modelOverrides model.ModelOverrides) (credResolution, error) {
+func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID, tenantID, ownerID, botID string, wf *ir.Workflow, keyOverrides, secretOverrides map[string]string, modelOverrides model.ModelOverrides, runFallbacks []model.FallbackEntry) (credResolution, error) {
 	if p.runSecrets == nil || p.sealer == nil {
 		return credResolution{}, nil
 	}
@@ -576,7 +576,7 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 	//    credentials" is the condition the pool exists for.
 	res := credResolution{}
 	if len(bundle.APIKeys) == 0 && len(bundle.OAuthCredentials) == 0 {
-		if grant := p.acquireFromPool(ctx, runID, orgID, tenantID, ownerID, botID, wf, modelOverrides); grant != nil {
+		if grant := p.acquireFromPool(ctx, runID, orgID, tenantID, ownerID, botID, wf, modelOverrides, runFallbacks); grant != nil {
 			// The lent credential goes in the slot its KIND belongs to, so
 			// the runner cannot tell a donation from the tenant's own.
 			switch grant.Source {
@@ -1140,141 +1140,91 @@ func providerOfWant(w credpool.Credential) string {
 	return ""
 }
 
-// buildModelOverrides folds the launch-time per-node/-group directives
-// (studio Launch dropdowns / --model / --backend / --provider) into the
-// engine's effective-per-node lookup — the same type the executor consults.
-// Kept in publisher.go on purpose: this file's node-walks (wants
-// derivation, wants=0 diagnostic) must read the SAME overrides the runner
-// applies, and duplicating the fold here beats importing an unexported
-// helper from runview.
+// buildModelOverrides folds launch entries into the executor's overrides.
+// A tiny type-adapter over model.OverridesFrom — the single source of
+// truth now lives in pkg/backend/model, next to ModelOverrides itself,
+// so the runner's own fold consumes the same helper.
 func buildModelOverrides(entries []runview.ModelOverrideEntry) model.ModelOverrides {
-	var o model.ModelOverrides
-	for _, e := range entries {
-		if e.Backend != "" {
-			o.SetBackend(e.Selector, e.Backend)
-		}
-		if e.Model != "" {
-			o.SetModel(e.Selector, e.Model)
-		}
-		if e.Provider != "" {
-			o.SetProvider(e.Selector, e.Provider)
-		}
+	out := make([]model.OverrideEntry, len(entries))
+	for i, e := range entries {
+		out[i] = model.OverrideEntry{Selector: e.Selector, Backend: e.Backend, Model: e.Model, Provider: e.Provider}
 	}
-	return o
+	return model.OverridesFrom(out)
 }
 
-// buildModelOverridesFromRun is the resume-path twin: the launch's
-// overrides were stamped on the run document as []store.RunModelOverride
-// (display-safe form). Replayed here so a resumed run walks its
-// credential resolution under exactly the pins the operator used.
+// buildModelOverridesFromRun is the resume-path twin (persisted form).
 func buildModelOverridesFromRun(entries []store.RunModelOverride) model.ModelOverrides {
-	var o model.ModelOverrides
-	for _, e := range entries {
-		if e.Backend != "" {
-			o.SetBackend(e.Selector, e.Backend)
-		}
-		if e.Model != "" {
-			o.SetModel(e.Selector, e.Model)
-		}
-		if e.Provider != "" {
-			o.SetProvider(e.Selector, e.Provider)
-		}
+	out := make([]model.OverrideEntry, len(entries))
+	for i, e := range entries {
+		out[i] = model.OverrideEntry{Selector: e.Selector, Backend: e.Backend, Model: e.Model, Provider: e.Provider}
 	}
-	return o
+	return model.OverridesFrom(out)
 }
 
-// effectiveNodeTargeting resolves the (backend, model, provider) actually
-// spent by an LLM node — the DSL values, then any launch-time override
-// (studio Launch dropdowns / --model / --backend / --provider) applied on
-// top. It is the ONE place in this file that turns "what a node targets"
-// into a triple, so every node-walk (the pool's wants-derivation, the
-// wants=0 diagnostic, any future site that decides "which providers does
-// this run actually need?") reads the SAME effective view the runner will.
-//
-// A judge kind pinned to claw/openai by override used to be invisible
-// here: wantsFor read only the DSL Model, and a launch that pinned the
-// judge to openai still made the pool request say "anthropic" (#668).
-//
-// Returns "", "", "" for a node that carries no LLMFields (routers,
-// tools, human, compute…) — those spend no credential.
-func effectiveNodeTargeting(node ir.Node, overrides model.ModelOverrides) (backend, mdl, provider string) {
-	f, ok := node.(interface{ GetLLMFields() *ir.LLMFields })
-	if !ok {
-		return "", "", ""
-	}
-	fields := f.GetLLMFields()
-	backend, mdl, provider = fields.Backend, fields.Model, fields.Provider
-	if overrides.Empty() {
-		return
-	}
-	ov := overrides.ForNode(node.NodeID(), node.NodeKind())
-	if ov.Backend != "" {
-		backend = ov.Backend
-	}
-	if ov.Model != "" {
-		mdl = ov.Model
-	}
-	if ov.Provider != "" {
-		provider = ov.Provider
-	}
-	return
-}
-
-// pinnedProviders walks every LLM node under overrides and returns the
-// set of providers the run's effective targeting actually asks for. The
-// order is deterministic (alphabetical), so log lines are diffable.
-//
-// A provider is derived from EITHER the explicit `provider:` field OR
-// the `<prov>/<model>` prefix on `model:`. The DSL already accepts a
-// provider on either field, and picking either half unifies the two so
-// a node that pins provider only ("--provider openai") counts the same
-// as one that pins the model qualifier ("openai/gpt-5").
-func pinnedProviders(wf *ir.Workflow, overrides model.ModelOverrides) []string {
-	if wf == nil {
+// runFallbackEntries adapts the launch's fallback chain onto
+// model.FallbackEntry, so the wants derivation sees the operator's
+// run-level `--fallback` alongside per-node fallbacks.
+func runFallbackEntries(entries []runview.FallbackEntry) []model.FallbackEntry {
+	if len(entries) == 0 {
 		return nil
 	}
-	pinned := map[string]bool{}
-	for _, n := range wf.Nodes {
-		_, mdl, prov := effectiveNodeTargeting(n, overrides)
-		if prov != "" {
-			pinned[prov] = true
-			continue
-		}
-		if p, _, cut := strings.Cut(mdl, "/"); cut && p != "" {
-			pinned[p] = true
-		}
+	out := make([]model.FallbackEntry, len(entries))
+	for i, e := range entries {
+		out[i] = model.FallbackEntry{Backend: e.Backend, Model: e.Model, Provider: e.Provider}
 	}
-	if len(pinned) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(pinned))
-	for p := range pinned {
-		out = append(out, p)
-	}
-	sort.Strings(out)
 	return out
 }
 
-// wantsFor narrows the pool request to donations a run can actually spend.
+// runFallbackEntriesFromRun is the resume-path twin.
+func runFallbackEntriesFromRun(entries []store.RunFallbackEntry) []model.FallbackEntry {
+	if len(entries) == 0 {
+		return nil
+	}
+	out := make([]model.FallbackEntry, len(entries))
+	for i, e := range entries {
+		out[i] = model.FallbackEntry{Backend: e.Backend, Model: e.Model, Provider: e.Provider}
+	}
+	return out
+}
+
+// knownPoolProviders is the provider vocabulary the wants derivation
+// resolves against — derived from allKnownProviders so the two cannot
+// drift. A hint outside it names a pin the pool cannot serve by name.
+var knownPoolProviders = func() map[string]bool {
+	m := make(map[string]bool, len(allKnownProviders))
+	for _, p := range allKnownProviders {
+		m[strings.ToLower(string(p))] = true
+	}
+	return m
+}()
+
+// wantsFor narrows the pool request to donations a run can actually spend,
+// and returns the resolution it narrowed on for the log lines.
 //
 // A bot that pins `model: "anthropic/…"` has no use for a lent z.ai key:
 // granting one would consume a unit of the donor's daily runs and hold a
 // concurrency slot for a run that then fails at the first LLM call, and
-// every retry would pick the same wrong donation. A run that pins nothing
-// takes the full order — claw substitutes the first available provider, so
-// any donation serves it.
+// every retry would pick the same wrong donation. The narrowing is exact
+// per provider because the delegates are: a `zai` hint spends a z.ai key
+// and nothing else (no fall-through to the OAuth dir), `anthropic` spends
+// the Anthropic key or the claude_code forfait.
 //
-// Overrides ride the SAME derivation as the DSL, so a launch that pins
-// every LLM node to claw/openai (studio Launch dropdowns / --model) is
-// reflected in the wants — the missing wire that let a judge-kind
-// override slip past this walk in #668.
-func wantsFor(wf *ir.Workflow, overrides model.ModelOverrides) []credpool.Credential {
-	provs := pinnedProviders(wf, overrides)
-	if len(provs) == 0 {
-		return poolWantOrder
+// And it FAILS OPEN. A run that pins nothing takes the FULL order — claw
+// substitutes the first available provider, so any donation serves it —
+// and so does any run with ONE route the walk cannot resolve (no pin, an
+// explicit "auto", a ${VAR} empty here, a name nobody knows, a
+// model-answering node with no LLMFields): that route takes whatever the
+// process holds, so narrowing on its pinned peers would drop the very
+// donation it needs. A run whose cross-family reviewer pins openai but
+// whose implementer pins nothing keeps the claude_code forfait in its
+// wants, and a typo in a provider hint costs a Warn, never the pool tier.
+func wantsFor(wf *ir.Workflow, overrides model.ModelOverrides, runFallbacks []model.FallbackEntry) ([]credpool.Credential, model.ProviderResolution) {
+	res := model.EffectiveProviders(wf, overrides, runFallbacks, knownPoolProviders)
+	if !res.NarrowSafe || len(res.Providers) == 0 {
+		return poolWantOrder, res
 	}
-	pinned := make(map[string]bool, len(provs))
-	for _, p := range provs {
+	pinned := make(map[string]bool, len(res.Providers))
+	for _, p := range res.Providers {
 		pinned[p] = true
 	}
 	out := make([]credpool.Credential, 0, len(poolWantOrder))
@@ -1283,7 +1233,7 @@ func wantsFor(wf *ir.Workflow, overrides model.ModelOverrides) []credpool.Creden
 			out = append(out, w)
 		}
 	}
-	return out
+	return out, res
 }
 
 // acquireFromPool asks the credential pool for a donor. Returns nil when no
@@ -1294,7 +1244,7 @@ func wantsFor(wf *ir.Workflow, overrides model.ModelOverrides) []credpool.Creden
 // credential (platform tier) or fail at the LLM call, both worth a line an
 // operator can grep instead of half a day of investigation on a path that
 // decides who pays (#654).
-func (p *Publisher) acquireFromPool(ctx context.Context, runID, orgID, tenantID, ownerID, botID string, wf *ir.Workflow, overrides model.ModelOverrides) *credpool.Grant {
+func (p *Publisher) acquireFromPool(ctx context.Context, runID, orgID, tenantID, ownerID, botID string, wf *ir.Workflow, overrides model.ModelOverrides, runFallbacks []model.FallbackEntry) *credpool.Grant {
 	if p.credPool == nil {
 		// No pool at all — a static configuration fact, but log it once per
 		// run so the trace of "which tier funded this run" starts at the
@@ -1303,21 +1253,29 @@ func (p *Publisher) acquireFromPool(ctx context.Context, runID, orgID, tenantID,
 			runID, credpool.ReasonPoolDisabled)
 		return nil
 	}
-	wants := wantsFor(wf, overrides)
+	// One walk per launch: the wants, the diagnostics and the consulted
+	// line all read the same resolution.
+	wants, res := wantsFor(wf, overrides, runFallbacks)
+	if len(res.Unknown) > 0 {
+		// A pin nobody knows never narrows the request to nothing: the
+		// walk widened to the full order instead. Name the pin — a typo
+		// in `provider:` is worth one line, not a silently skipped tier.
+		p.logger.Warn("cloudpublisher: credential pool asked for the FULL order for run %s — provider hint(s) match no known provider: %s (%s)",
+			runID, strings.Join(res.Unknown, ","), providersSummary(res.Providers))
+	}
 	if len(wants) == 0 {
-		// The bot pins providers the pool never lends: asking would burn a
-		// walk that could not possibly succeed. Log it: today this is what
-		// "the pool was consulted and answered nothing" looks like when the
-		// judge-kind override arrived (see #668).
+		// Every route resolved to a KNOWN provider the pool never lends.
+		// The want order covers every known provider today, so this is
+		// the guard for a narrower order tomorrow, not a live path.
 		p.logger.Warn("cloudpublisher: credential pool NOT CONSULTED for run %s — bot pins provider(s) no donation matches (%s)",
-			runID, poolWantsSummary(wf, overrides))
+			runID, providersSummary(res.Providers))
 		return nil
 	}
 	// Trace the derived wants once per run — the pointer the incident
 	// this fix serves (#668) asked for so an operator can see what the
 	// resolver is asking on their behalf, not only what it got back.
-	p.logger.Info("cloudpublisher: credential pool consulted for run %s — wants=%s (pinned providers=%s)",
-		runID, wantsSummary(wants), providersSummary(pinnedProviders(wf, overrides)))
+	p.logger.Info("cloudpublisher: credential pool consulted for run %s — wants=%s (%s narrow_safe=%v)",
+		runID, wantsSummary(wants), providersSummary(res.Providers), res.NarrowSafe)
 	grant, err := p.credPool.Acquire(ctx, credpool.Request{
 		RunID:    runID,
 		OrgID:    orgID,
@@ -1358,24 +1316,13 @@ func (p *Publisher) acquireFromPool(ctx context.Context, runID, orgID, tenantID,
 // that answers "was this decision even made against the right set?".
 func wantsSummary(wants []credpool.Credential) string {
 	if len(wants) == 0 {
-		return "none"
+		return "<none>"
 	}
 	parts := make([]string, 0, len(wants))
 	for _, w := range wants {
-		parts = append(parts, w.String())
+		parts = append(parts, string(w.Source)+":"+w.Ref)
 	}
 	return strings.Join(parts, ",")
-}
-
-// poolWantsSummary is the wants=0 branch's diagnostic: it names the pins
-// the workflow carries under the launch's overrides, so an operator can
-// tell WHY the pool was skipped before it was asked. Kept small — the log
-// line rides the launch path.
-func poolWantsSummary(wf *ir.Workflow, overrides model.ModelOverrides) string {
-	if wf == nil {
-		return "pinned=<no-workflow>"
-	}
-	return providersSummary(pinnedProviders(wf, overrides))
 }
 
 // providersSummary renders a set of provider names for a log line.
@@ -1534,7 +1481,7 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 	//     NO run record behind (never a stray queued/running run for a launch
 	//     that could not resolve its mandatory credentials).
 	orgID := p.orgIDForTeam(ctx, tenantID)
-	creds, err := p.resolveAndSealCredentials(ctx, runID, orgID, tenantID, ownerID, spec.BotID, wf, spec.KeyOverrides, spec.SecretOverrides, buildModelOverrides(spec.ModelOverrides))
+	creds, err := p.resolveAndSealCredentials(ctx, runID, orgID, tenantID, ownerID, spec.BotID, wf, spec.KeyOverrides, spec.SecretOverrides, buildModelOverrides(spec.ModelOverrides), runFallbackEntries(spec.Fallback))
 	// A donor's admission is consumed the moment it is granted. Armed BEFORE
 	// the error check: resolveAndSealCredentials can fail AFTER acquiring —
 	// sealing the bundle, persisting it — and still returns the grant. Every
@@ -1851,7 +1798,7 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 	secretsCtx := store.WithTenant(ctx, prior.TenantID)
 	secretsCtx = store.WithOwner(secretsCtx, prior.OwnerID)
 	priorOrgID := p.orgIDForTeam(ctx, prior.TenantID)
-	creds, secretsErr := p.resolveAndSealCredentials(secretsCtx, spec.RunID, priorOrgID, prior.TenantID, prior.OwnerID, prior.BotID, wf, prior.KeyOverrides, prior.SecretOverrides, buildModelOverridesFromRun(prior.ModelOverrides))
+	creds, secretsErr := p.resolveAndSealCredentials(secretsCtx, spec.RunID, priorOrgID, prior.TenantID, prior.OwnerID, prior.BotID, wf, prior.KeyOverrides, prior.SecretOverrides, buildModelOverridesFromRun(prior.ModelOverrides), runFallbackEntriesFromRun(prior.Fallback))
 	// Armed before the error check — see SubmitLaunch.
 	if creds.grant != nil {
 		defer func() {

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -1166,13 +1166,28 @@ func wantsFor(wf *ir.Workflow) []credpool.Credential {
 // acquireFromPool asks the credential pool for a donor. Returns nil when no
 // pool is wired, none serves this requester, or every donor is currently
 // unavailable — all ordinary outcomes that must let the launch proceed
-// exactly as it would have without a pool.
+// exactly as it would have without a pool. Every abstention is logged Warn
+// at the moment it becomes final: the run is about to spend someone else's
+// credential (platform tier) or fail at the LLM call, both worth a line an
+// operator can grep instead of half a day of investigation on a path that
+// decides who pays (#654).
 func (p *Publisher) acquireFromPool(ctx context.Context, runID, orgID, tenantID, ownerID, botID string, wf *ir.Workflow) *credpool.Grant {
 	if p.credPool == nil {
+		// No pool at all — a static configuration fact, but log it once per
+		// run so the trace of "which tier funded this run" starts at the
+		// pool tier for every run, not only the ones that got a grant.
+		p.logger.Warn("cloudpublisher: credential pool NOT CONSULTED for run %s — no pool broker wired (reason=%s)",
+			runID, credpool.ReasonPoolDisabled)
 		return nil
 	}
 	wants := wantsFor(wf)
 	if len(wants) == 0 {
+		// The bot pins providers the pool never lends: asking would burn a
+		// walk that could not possibly succeed. Log it: today this is what
+		// "the pool was consulted and answered nothing" looks like when the
+		// judge-kind override arrived (see #668).
+		p.logger.Warn("cloudpublisher: credential pool NOT CONSULTED for run %s — bot pins provider(s) no donation matches (%s)",
+			runID, poolWantsSummary(wf))
 		return nil
 	}
 	grant, err := p.credPool.Acquire(ctx, credpool.Request{
@@ -1184,17 +1199,72 @@ func (p *Publisher) acquireFromPool(ctx context.Context, runID, orgID, tenantID,
 		Wants:    wants,
 	})
 	if err != nil {
-		if !errors.Is(err, credpool.ErrNoDonor) {
-			// A store failure must not fail the launch: the pool is a
-			// best-effort extra tier, and a run with no credential still
-			// surfaces a legible error at the LLM call site.
-			p.logger.Warn("cloudpublisher: credential pool lookup for run %s: %v", runID, err)
+		// A typed abstention names the reason: distinguishing "the audience
+		// refused me" from "every donor was cooling" is exactly the class
+		// of ambiguity that turned a half-day of investigation into "the
+		// pool answered nothing".
+		var nd *credpool.NoDonorError
+		if errors.As(err, &nd) {
+			p.logger.Warn("cloudpublisher: credential pool declined run %s — reason=%s pools_considered=%d pledges_considered=%d wants=%s",
+				runID, nd.Reason, nd.PoolsConsidered, nd.PledgesConsidered, wantsSummary(wants))
+			return nil
 		}
+		if errors.Is(err, credpool.ErrNoDonor) {
+			// A wrapper we did not recognise still counts as an abstention;
+			// keep it visible instead of falling silently to the next tier.
+			p.logger.Warn("cloudpublisher: credential pool declined run %s — %v", runID, err)
+			return nil
+		}
+		// A store failure must not fail the launch: the pool is a
+		// best-effort extra tier, and a run with no credential still
+		// surfaces a legible error at the LLM call site.
+		p.logger.Warn("cloudpublisher: credential pool lookup for run %s: %v", runID, err)
 		return nil
 	}
 	p.logger.Info("cloudpublisher: run %s runs on a pooled contributor credential (donor=%s %s allowance=$%.2f)",
 		runID, grant.DonorID, grant.Credential, grant.RemainingUSD)
 	return grant
+}
+
+// wantsSummary renders a wants list for the abstention log — the field
+// that answers "was this decision even made against the right set?".
+func wantsSummary(wants []credpool.Credential) string {
+	if len(wants) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(wants))
+	for _, w := range wants {
+		parts = append(parts, w.String())
+	}
+	return strings.Join(parts, ",")
+}
+
+// poolWantsSummary is the wants=0 branch's diagnostic: it names the pins
+// the workflow carries, so an operator can tell WHY the pool was skipped
+// before it was asked. Kept small — the log line rides the launch path.
+func poolWantsSummary(wf *ir.Workflow) string {
+	if wf == nil {
+		return "pinned=<no-workflow>"
+	}
+	pinned := map[string]bool{}
+	for _, n := range wf.Nodes {
+		f, ok := n.(interface{ GetLLMFields() *ir.LLMFields })
+		if !ok {
+			continue
+		}
+		if prov, _, cut := strings.Cut(f.GetLLMFields().Model, "/"); cut && prov != "" {
+			pinned[prov] = true
+		}
+	}
+	if len(pinned) == 0 {
+		return "pinned=<none>"
+	}
+	provs := make([]string, 0, len(pinned))
+	for p := range pinned {
+		provs = append(provs, p)
+	}
+	sort.Strings(provs)
+	return "pinned=" + strings.Join(provs, ",")
 }
 
 // SubmitLaunch persists the run as queued in Mongo, then publishes

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -26,6 +26,7 @@ import (
 	"os"
 
 	"github.com/SocialGouv/iterion/pkg/backend/delegate"
+	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"github.com/SocialGouv/iterion/pkg/cloud/metrics"
 	"github.com/SocialGouv/iterion/pkg/credpool"
 	"github.com/SocialGouv/iterion/pkg/reviewtopology"
@@ -342,7 +343,7 @@ func (p *Publisher) appBotLoginForForgeToken(ctx context.Context, tenantID strin
 // tenant has none — seals the resulting bundle, and persists it under a
 // fresh secrets ref. An empty ref means no credentials are available; the
 // runner then falls back to env.
-func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID, tenantID, ownerID, botID string, wf *ir.Workflow, keyOverrides, secretOverrides map[string]string) (credResolution, error) {
+func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID, tenantID, ownerID, botID string, wf *ir.Workflow, keyOverrides, secretOverrides map[string]string, modelOverrides model.ModelOverrides) (credResolution, error) {
 	if p.runSecrets == nil || p.sealer == nil {
 		return credResolution{}, nil
 	}
@@ -575,7 +576,7 @@ func (p *Publisher) resolveAndSealCredentials(ctx context.Context, runID, orgID,
 	//    credentials" is the condition the pool exists for.
 	res := credResolution{}
 	if len(bundle.APIKeys) == 0 && len(bundle.OAuthCredentials) == 0 {
-		if grant := p.acquireFromPool(ctx, runID, orgID, tenantID, ownerID, botID, wf); grant != nil {
+		if grant := p.acquireFromPool(ctx, runID, orgID, tenantID, ownerID, botID, wf, modelOverrides); grant != nil {
 			// The lent credential goes in the slot its KIND belongs to, so
 			// the runner cannot tell a donation from the tenant's own.
 			switch grant.Source {
@@ -1130,6 +1131,121 @@ func providerOfWant(w credpool.Credential) string {
 	return ""
 }
 
+// buildModelOverrides folds the launch-time per-node/-group directives
+// (studio Launch dropdowns / --model / --backend / --provider) into the
+// engine's effective-per-node lookup — the same type the executor consults.
+// Kept in publisher.go on purpose: this file's node-walks (wants
+// derivation, wants=0 diagnostic) must read the SAME overrides the runner
+// applies, and duplicating the fold here beats importing an unexported
+// helper from runview.
+func buildModelOverrides(entries []runview.ModelOverrideEntry) model.ModelOverrides {
+	var o model.ModelOverrides
+	for _, e := range entries {
+		if e.Backend != "" {
+			o.SetBackend(e.Selector, e.Backend)
+		}
+		if e.Model != "" {
+			o.SetModel(e.Selector, e.Model)
+		}
+		if e.Provider != "" {
+			o.SetProvider(e.Selector, e.Provider)
+		}
+	}
+	return o
+}
+
+// buildModelOverridesFromRun is the resume-path twin: the launch's
+// overrides were stamped on the run document as []store.RunModelOverride
+// (display-safe form). Replayed here so a resumed run walks its
+// credential resolution under exactly the pins the operator used.
+func buildModelOverridesFromRun(entries []store.RunModelOverride) model.ModelOverrides {
+	var o model.ModelOverrides
+	for _, e := range entries {
+		if e.Backend != "" {
+			o.SetBackend(e.Selector, e.Backend)
+		}
+		if e.Model != "" {
+			o.SetModel(e.Selector, e.Model)
+		}
+		if e.Provider != "" {
+			o.SetProvider(e.Selector, e.Provider)
+		}
+	}
+	return o
+}
+
+// effectiveNodeTargeting resolves the (backend, model, provider) actually
+// spent by an LLM node — the DSL values, then any launch-time override
+// (studio Launch dropdowns / --model / --backend / --provider) applied on
+// top. It is the ONE place in this file that turns "what a node targets"
+// into a triple, so every node-walk (the pool's wants-derivation, the
+// wants=0 diagnostic, any future site that decides "which providers does
+// this run actually need?") reads the SAME effective view the runner will.
+//
+// A judge kind pinned to claw/openai by override used to be invisible
+// here: wantsFor read only the DSL Model, and a launch that pinned the
+// judge to openai still made the pool request say "anthropic" (#668).
+//
+// Returns "", "", "" for a node that carries no LLMFields (routers,
+// tools, human, compute…) — those spend no credential.
+func effectiveNodeTargeting(node ir.Node, overrides model.ModelOverrides) (backend, mdl, provider string) {
+	f, ok := node.(interface{ GetLLMFields() *ir.LLMFields })
+	if !ok {
+		return "", "", ""
+	}
+	fields := f.GetLLMFields()
+	backend, mdl, provider = fields.Backend, fields.Model, fields.Provider
+	if overrides.Empty() {
+		return
+	}
+	ov := overrides.ForNode(node.NodeID(), node.NodeKind())
+	if ov.Backend != "" {
+		backend = ov.Backend
+	}
+	if ov.Model != "" {
+		mdl = ov.Model
+	}
+	if ov.Provider != "" {
+		provider = ov.Provider
+	}
+	return
+}
+
+// pinnedProviders walks every LLM node under overrides and returns the
+// set of providers the run's effective targeting actually asks for. The
+// order is deterministic (alphabetical), so log lines are diffable.
+//
+// A provider is derived from EITHER the explicit `provider:` field OR
+// the `<prov>/<model>` prefix on `model:`. The DSL already accepts a
+// provider on either field, and picking either half unifies the two so
+// a node that pins provider only ("--provider openai") counts the same
+// as one that pins the model qualifier ("openai/gpt-5").
+func pinnedProviders(wf *ir.Workflow, overrides model.ModelOverrides) []string {
+	if wf == nil {
+		return nil
+	}
+	pinned := map[string]bool{}
+	for _, n := range wf.Nodes {
+		_, mdl, prov := effectiveNodeTargeting(n, overrides)
+		if prov != "" {
+			pinned[prov] = true
+			continue
+		}
+		if p, _, cut := strings.Cut(mdl, "/"); cut && p != "" {
+			pinned[p] = true
+		}
+	}
+	if len(pinned) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(pinned))
+	for p := range pinned {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // wantsFor narrows the pool request to donations a run can actually spend.
 //
 // A bot that pins `model: "anthropic/…"` has no use for a lent z.ai key:
@@ -1138,21 +1254,19 @@ func providerOfWant(w credpool.Credential) string {
 // every retry would pick the same wrong donation. A run that pins nothing
 // takes the full order — claw substitutes the first available provider, so
 // any donation serves it.
-func wantsFor(wf *ir.Workflow) []credpool.Credential {
-	pinned := map[string]bool{}
-	if wf != nil {
-		for _, n := range wf.Nodes {
-			f, ok := n.(interface{ GetLLMFields() *ir.LLMFields })
-			if !ok {
-				continue
-			}
-			if prov, _, cut := strings.Cut(f.GetLLMFields().Model, "/"); cut && prov != "" {
-				pinned[prov] = true
-			}
-		}
-	}
-	if len(pinned) == 0 {
+//
+// Overrides ride the SAME derivation as the DSL, so a launch that pins
+// every LLM node to claw/openai (studio Launch dropdowns / --model) is
+// reflected in the wants — the missing wire that let a judge-kind
+// override slip past this walk in #668.
+func wantsFor(wf *ir.Workflow, overrides model.ModelOverrides) []credpool.Credential {
+	provs := pinnedProviders(wf, overrides)
+	if len(provs) == 0 {
 		return poolWantOrder
+	}
+	pinned := make(map[string]bool, len(provs))
+	for _, p := range provs {
+		pinned[p] = true
 	}
 	out := make([]credpool.Credential, 0, len(poolWantOrder))
 	for _, w := range poolWantOrder {
@@ -1171,7 +1285,7 @@ func wantsFor(wf *ir.Workflow) []credpool.Credential {
 // credential (platform tier) or fail at the LLM call, both worth a line an
 // operator can grep instead of half a day of investigation on a path that
 // decides who pays (#654).
-func (p *Publisher) acquireFromPool(ctx context.Context, runID, orgID, tenantID, ownerID, botID string, wf *ir.Workflow) *credpool.Grant {
+func (p *Publisher) acquireFromPool(ctx context.Context, runID, orgID, tenantID, ownerID, botID string, wf *ir.Workflow, overrides model.ModelOverrides) *credpool.Grant {
 	if p.credPool == nil {
 		// No pool at all — a static configuration fact, but log it once per
 		// run so the trace of "which tier funded this run" starts at the
@@ -1180,16 +1294,21 @@ func (p *Publisher) acquireFromPool(ctx context.Context, runID, orgID, tenantID,
 			runID, credpool.ReasonPoolDisabled)
 		return nil
 	}
-	wants := wantsFor(wf)
+	wants := wantsFor(wf, overrides)
 	if len(wants) == 0 {
 		// The bot pins providers the pool never lends: asking would burn a
 		// walk that could not possibly succeed. Log it: today this is what
 		// "the pool was consulted and answered nothing" looks like when the
 		// judge-kind override arrived (see #668).
 		p.logger.Warn("cloudpublisher: credential pool NOT CONSULTED for run %s — bot pins provider(s) no donation matches (%s)",
-			runID, poolWantsSummary(wf))
+			runID, poolWantsSummary(wf, overrides))
 		return nil
 	}
+	// Trace the derived wants once per run — the pointer the incident
+	// this fix serves (#668) asked for so an operator can see what the
+	// resolver is asking on their behalf, not only what it got back.
+	p.logger.Info("cloudpublisher: credential pool consulted for run %s — wants=%s (pinned providers=%s)",
+		runID, wantsSummary(wants), providersSummary(pinnedProviders(wf, overrides)))
 	grant, err := p.credPool.Acquire(ctx, credpool.Request{
 		RunID:    runID,
 		OrgID:    orgID,
@@ -1240,30 +1359,22 @@ func wantsSummary(wants []credpool.Credential) string {
 }
 
 // poolWantsSummary is the wants=0 branch's diagnostic: it names the pins
-// the workflow carries, so an operator can tell WHY the pool was skipped
-// before it was asked. Kept small — the log line rides the launch path.
-func poolWantsSummary(wf *ir.Workflow) string {
+// the workflow carries under the launch's overrides, so an operator can
+// tell WHY the pool was skipped before it was asked. Kept small — the log
+// line rides the launch path.
+func poolWantsSummary(wf *ir.Workflow, overrides model.ModelOverrides) string {
 	if wf == nil {
 		return "pinned=<no-workflow>"
 	}
-	pinned := map[string]bool{}
-	for _, n := range wf.Nodes {
-		f, ok := n.(interface{ GetLLMFields() *ir.LLMFields })
-		if !ok {
-			continue
-		}
-		if prov, _, cut := strings.Cut(f.GetLLMFields().Model, "/"); cut && prov != "" {
-			pinned[prov] = true
-		}
-	}
-	if len(pinned) == 0 {
+	return providersSummary(pinnedProviders(wf, overrides))
+}
+
+// providersSummary renders a set of provider names for a log line.
+// "<none>" when empty — the log stays readable when a walk found nothing.
+func providersSummary(provs []string) string {
+	if len(provs) == 0 {
 		return "pinned=<none>"
 	}
-	provs := make([]string, 0, len(pinned))
-	for p := range pinned {
-		provs = append(provs, p)
-	}
-	sort.Strings(provs)
 	return "pinned=" + strings.Join(provs, ",")
 }
 
@@ -1360,7 +1471,7 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 	//     NO run record behind (never a stray queued/running run for a launch
 	//     that could not resolve its mandatory credentials).
 	orgID := p.orgIDForTeam(ctx, tenantID)
-	creds, err := p.resolveAndSealCredentials(ctx, runID, orgID, tenantID, ownerID, spec.BotID, wf, spec.KeyOverrides, spec.SecretOverrides)
+	creds, err := p.resolveAndSealCredentials(ctx, runID, orgID, tenantID, ownerID, spec.BotID, wf, spec.KeyOverrides, spec.SecretOverrides, buildModelOverrides(spec.ModelOverrides))
 	// A donor's admission is consumed the moment it is granted. Armed BEFORE
 	// the error check: resolveAndSealCredentials can fail AFTER acquiring —
 	// sealing the bundle, persisting it — and still returns the grant. Every
@@ -1677,7 +1788,7 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 	secretsCtx := store.WithTenant(ctx, prior.TenantID)
 	secretsCtx = store.WithOwner(secretsCtx, prior.OwnerID)
 	priorOrgID := p.orgIDForTeam(ctx, prior.TenantID)
-	creds, secretsErr := p.resolveAndSealCredentials(secretsCtx, spec.RunID, priorOrgID, prior.TenantID, prior.OwnerID, prior.BotID, wf, prior.KeyOverrides, prior.SecretOverrides)
+	creds, secretsErr := p.resolveAndSealCredentials(secretsCtx, spec.RunID, priorOrgID, prior.TenantID, prior.OwnerID, prior.BotID, wf, prior.KeyOverrides, prior.SecretOverrides, buildModelOverridesFromRun(prior.ModelOverrides))
 	// Armed before the error check — see SubmitLaunch.
 	if creds.grant != nil {
 		defer func() {

--- a/pkg/server/cloudpublisher/publisher_model_overrides_test.go
+++ b/pkg/server/cloudpublisher/publisher_model_overrides_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/SocialGouv/iterion/pkg/backend/model"
+	"github.com/SocialGouv/iterion/pkg/credpool"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	"github.com/SocialGouv/iterion/pkg/queue"
 	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/secrets"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -125,4 +128,122 @@ func TestSubmitResumeReplaysRunDocOverrides(t *testing.T) {
 		published.ModelOverrides[0] != (queue.ModelOverride{Selector: "agent", Backend: "claude_code", Model: "claude-fable-5"}) {
 		t.Fatalf("resume overrides = %+v, want the launch pin replayed from the run doc", published.ModelOverrides)
 	}
+}
+
+
+// The pool's wants-derivation must read the launch-time model overrides,
+// not only the DSL. #668: a bot with an agent + judge, both pinned to
+// claw/openai by launch-time overrides, still had the pool tier walk on
+// "anthropic" (the DSL value) because wantsFor read only the raw model
+// field. A run that resolved no credential of its own then asked for a
+// donation on the wrong wire, held a slot, and every retry re-picked
+// the same wrong route.
+//
+// The fix is a shared helper (effectiveNodeTargeting) that applies
+// overrides once and every node-walk in the file reads it. This test
+// pins the helper's contract on the ONLY caller the pool tier has —
+// wantsFor — because that's the site the incident traced back to.
+func TestWantsFor_HonoursLaunchTimeModelOverrides(t *testing.T) {
+	provider := func(w credpool.Credential) string {
+		if w.Source == credpool.SourceAPIKey {
+			return w.Ref
+		}
+		switch secrets.OAuthKind(w.Ref) {
+		case secrets.OAuthKindClaudeCode:
+			return "anthropic"
+		case secrets.OAuthKindCodex:
+			return "openai"
+		}
+		return ""
+	}
+	provs := func(ws []credpool.Credential) []string {
+		out := make([]string, 0, len(ws))
+		for _, w := range ws {
+			if p := provider(w); p != "" {
+				out = append(out, p)
+			}
+		}
+		return out
+	}
+	contains := func(list []string, x string) bool {
+		for _, s := range list {
+			if s == x {
+				return true
+			}
+		}
+		return false
+	}
+
+	// The exact scenario from the ticket: two-node DAG, both pinned by
+	// launch-time overrides to claw/openai. The DSL says "anthropic/…".
+	wf := &ir.Workflow{Nodes: map[string]ir.Node{
+		"oracle_campaign": &ir.AgentNode{
+			BaseNode:  ir.BaseNode{ID: "oracle_campaign"},
+			LLMFields: ir.LLMFields{Model: "anthropic/claude-opus-4"},
+		},
+		"mutants_adversary": &ir.JudgeNode{
+			BaseNode:  ir.BaseNode{ID: "mutants_adversary"},
+			LLMFields: ir.LLMFields{Model: "anthropic/claude-sonnet-4"},
+		},
+	}}
+
+	t.Run("both nodes pinned to openai/claw by override → no anthropic want", func(t *testing.T) {
+		var overrides model.ModelOverrides
+		overrides.SetBackend("oracle_campaign", "claw")
+		overrides.SetModel("oracle_campaign", "openai/gpt-5.6-sol")
+		overrides.SetProvider("oracle_campaign", "openai")
+		overrides.SetBackend("mutants_adversary", "claw")
+		overrides.SetModel("mutants_adversary", "openai/gpt-5.6-sol")
+		overrides.SetProvider("mutants_adversary", "openai")
+
+		got := provs(wantsFor(wf, overrides))
+		if contains(got, "anthropic") {
+			t.Fatalf("wants still asks for anthropic: %v — the judge-kind override is not reaching wantsFor", got)
+		}
+		if !contains(got, "openai") {
+			t.Fatalf("wants must ask for openai (both nodes pinned to it): got %v", got)
+		}
+	})
+
+	t.Run("kind selector: 'judge' override still routes wants to openai", func(t *testing.T) {
+		// The ticket's minimal shape: agent node's DSL is unchanged
+		// (anthropic), but the JUDGE is pinned to openai via a kind
+		// selector. Wants must reflect what each node actually runs on.
+		var overrides model.ModelOverrides
+		overrides.SetProvider("judge", "openai")
+		overrides.SetModel("judge", "openai/gpt-5")
+
+		got := provs(wantsFor(wf, overrides))
+		// The agent still wants anthropic (unchanged), but the judge now
+		// contributes openai — the mixed set the run actually needs.
+		if !contains(got, "anthropic") || !contains(got, "openai") {
+			t.Fatalf("wants = %v, want both anthropic (agent unchanged) and openai (judge overridden)", got)
+		}
+	})
+
+	t.Run("empty overrides → identical to the pre-fix DSL walk", func(t *testing.T) {
+		got := provs(wantsFor(wf, model.ModelOverrides{}))
+		if !contains(got, "anthropic") {
+			t.Fatalf("wants without overrides must still see the DSL pin: got %v", got)
+		}
+		if contains(got, "openai") {
+			t.Fatalf("wants without overrides must NOT ask for openai: got %v", got)
+		}
+	})
+
+	t.Run("wants=0 route: fake-provider pin still produces empty wants", func(t *testing.T) {
+		// Extra guardrail: an operator adding a fake-provider pin ends up
+		// with an empty wants list (documented in the poolWantsSummary
+		// diagnostic), which is what triggers the acquireFromPool
+		// wants=0 Warn line.
+		wfFake := &ir.Workflow{Nodes: map[string]ir.Node{
+			"a": &ir.AgentNode{
+				BaseNode:  ir.BaseNode{ID: "a"},
+				LLMFields: ir.LLMFields{Model: "fake-provider/gpt-x"},
+			},
+		}}
+		if len(wantsFor(wfFake, model.ModelOverrides{})) != 0 {
+			t.Fatal("a fake-provider pin must produce an empty wants list, so the wants=0 Warn is what an operator sees")
+		}
+	})
 }

--- a/pkg/server/cloudpublisher/publisher_model_overrides_test.go
+++ b/pkg/server/cloudpublisher/publisher_model_overrides_test.go
@@ -130,7 +130,6 @@ func TestSubmitResumeReplaysRunDocOverrides(t *testing.T) {
 	}
 }
 
-
 // The pool's wants-derivation must read the launch-time model overrides,
 // not only the DSL. #668: a bot with an agent + judge, both pinned to
 // claw/openai by launch-time overrides, still had the pool tier walk on

--- a/pkg/server/cloudpublisher/publisher_model_overrides_test.go
+++ b/pkg/server/cloudpublisher/publisher_model_overrides_test.go
@@ -195,7 +195,8 @@ func TestWantsFor_HonoursLaunchTimeModelOverrides(t *testing.T) {
 		overrides.SetModel("mutants_adversary", "openai/gpt-5.6-sol")
 		overrides.SetProvider("mutants_adversary", "openai")
 
-		got := provs(wantsFor(wf, overrides))
+		w, _ := wantsFor(wf, overrides, nil)
+		got := provs(w)
 		if contains(got, "anthropic") {
 			t.Fatalf("wants still asks for anthropic: %v — the judge-kind override is not reaching wantsFor", got)
 		}
@@ -212,7 +213,8 @@ func TestWantsFor_HonoursLaunchTimeModelOverrides(t *testing.T) {
 		overrides.SetProvider("judge", "openai")
 		overrides.SetModel("judge", "openai/gpt-5")
 
-		got := provs(wantsFor(wf, overrides))
+		w, _ := wantsFor(wf, overrides, nil)
+		got := provs(w)
 		// The agent still wants anthropic (unchanged), but the judge now
 		// contributes openai — the mixed set the run actually needs.
 		if !contains(got, "anthropic") || !contains(got, "openai") {
@@ -221,7 +223,8 @@ func TestWantsFor_HonoursLaunchTimeModelOverrides(t *testing.T) {
 	})
 
 	t.Run("empty overrides → identical to the pre-fix DSL walk", func(t *testing.T) {
-		got := provs(wantsFor(wf, model.ModelOverrides{}))
+		w, _ := wantsFor(wf, model.ModelOverrides{}, nil)
+		got := provs(w)
 		if !contains(got, "anthropic") {
 			t.Fatalf("wants without overrides must still see the DSL pin: got %v", got)
 		}
@@ -230,19 +233,23 @@ func TestWantsFor_HonoursLaunchTimeModelOverrides(t *testing.T) {
 		}
 	})
 
-	t.Run("wants=0 route: fake-provider pin still produces empty wants", func(t *testing.T) {
-		// Extra guardrail: an operator adding a fake-provider pin ends up
-		// with an empty wants list (documented in the poolWantsSummary
-		// diagnostic), which is what triggers the acquireFromPool
-		// wants=0 Warn line.
+	t.Run("wants=0 route: a pin that matches no known provider fails OPEN", func(t *testing.T) {
+		// Round 1 G2: a pin the pool does not know (fake-provider,
+		// unknown ${VAR}, "auto") must NOT narrow the wants to nothing.
+		// The pre-round-1 code did narrow — a bot's provider-hint typo
+		// silently skipped the pool tier — the exact regression the
+		// review caught end-to-end on secured-renovacy. Widen instead:
+		// EffectiveProviders returns narrowSafe=false, wantsFor falls
+		// back to the full order.
 		wfFake := &ir.Workflow{Nodes: map[string]ir.Node{
 			"a": &ir.AgentNode{
 				BaseNode:  ir.BaseNode{ID: "a"},
 				LLMFields: ir.LLMFields{Model: "fake-provider/gpt-x"},
 			},
 		}}
-		if len(wantsFor(wfFake, model.ModelOverrides{})) != 0 {
-			t.Fatal("a fake-provider pin must produce an empty wants list, so the wants=0 Warn is what an operator sees")
+		got, _ := wantsFor(wfFake, model.ModelOverrides{}, nil)
+		if len(got) != len(poolWantOrder) {
+			t.Fatalf("unknown-provider pin narrowed wants to %d, want the full %d (fail open)", len(got), len(poolWantOrder))
 		}
 	})
 }

--- a/pkg/server/cloudpublisher/publisher_secrets_test.go
+++ b/pkg/server/cloudpublisher/publisher_secrets_test.go
@@ -1,13 +1,15 @@
 package cloudpublisher
 
 import (
-	"github.com/SocialGouv/iterion/pkg/backend/model"
+	"bytes"
 	"context"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/queue"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/secrets"
@@ -352,5 +354,64 @@ func TestSubmitResume_RequiredSecretUnresolved_KeepsResumableStatus(t *testing.T
 	}
 	if len(published) != 0 {
 		t.Fatalf("no message should be published, got %d", len(published))
+	}
+}
+
+
+// #659 pt 1: an operator investigating "whose credential funded that
+// run?" must find the answer in the server logs — not in
+// `/proc/<pid>/environ` inside a pod (measured, 2026-09-03). The seal
+// path used to print per-tier SKIPPED lines but nothing on a GRANT, so
+// the log was one-sided. resolveAndSealCredentials now emits ONE INFO
+// line per run naming every credential that lands in the sealed bundle,
+// with its TIER (byok / oauth-forfait / pool / platform), slot (provider
+// or oauth kind) and fingerprint. Never plaintext.
+//
+// The oracle is the LOG output, not the return value — the return has
+// always been informative enough, the gap was the operator's inability
+// to correlate it to a run without ad-hoc grep pipelines.
+func TestResolveAndSealCredentials_LogsGrantedCredentialSet(t *testing.T) {
+	var buf bytes.Buffer
+	sealer, err := secrets.NewAESGCMSealer(bytes.Repeat([]byte{9}, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	apiKeys := secrets.NewMemoryApiKeyStore()
+	tenantCtx := store.WithTenant(context.Background(), "team-1")
+	id := secrets.NewApiKeyID()
+	sealed, err := secrets.SealAPIKey(sealer, id, []byte("sk-ant-real"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := apiKeys.Create(tenantCtx, secrets.ApiKey{
+		ID: id, ScopeTeamID: "team-1", Provider: secrets.ProviderAnthropic,
+		Name: "k1", Last4: "real", SealedSecret: sealed,
+		Fingerprint: secrets.FingerprintSHA256("sk-ant-real"),
+	}); err != nil {
+		t.Fatalf("create key: %v", err)
+	}
+
+	p := &Publisher{
+		apiKeys:    apiKeys,
+		sealer:     sealer,
+		runSecrets: secrets.NewMemoryRunSecretsStore(),
+		logger:     iterlog.New(iterlog.LevelInfo, &buf),
+	}
+	if _, err := p.resolveAndSealCredentials(tenantCtx, "run-log-1", "", "team-1", "u1", "bot",
+		&ir.Workflow{}, nil, nil, model.ModelOverrides{}); err != nil {
+		t.Fatalf("resolveAndSealCredentials: %v", err)
+	}
+	log := buf.String()
+	if !strings.Contains(log, "GRANTED for run=run-log-1") {
+		t.Fatalf("expected a GRANTED line for the run; got:\n%s", log)
+	}
+	if !strings.Contains(log, "byok(api_key:anthropic") {
+		t.Fatalf("expected the tier/slot naming; got:\n%s", log)
+	}
+	if strings.Contains(log, "sk-ant-real") {
+		t.Fatalf("secret plaintext leaked into the log line: %s", log)
+	}
+	if !strings.Contains(log, "fp="+secrets.FingerprintSHA256("sk-ant-real")) {
+		t.Fatalf("expected the credential fingerprint in the log; got:\n%s", log)
 	}
 }

--- a/pkg/server/cloudpublisher/publisher_secrets_test.go
+++ b/pkg/server/cloudpublisher/publisher_secrets_test.go
@@ -47,7 +47,7 @@ func TestResolveAndSealCredentials_GenericWorkflowSecrets(t *testing.T) {
 		"kubeconfig": {As: "file"},
 	}}
 	ctx := store.WithTenant(context.Background(), "team")
-	creds, err := p.resolveAndSealCredentials(ctx, "run-1", "", "team", "alice", "", wf, nil, nil, model.ModelOverrides{})
+	creds, err := p.resolveAndSealCredentials(ctx, "run-1", "", "team", "alice", "", wf, nil, nil, model.ModelOverrides{}, nil)
 	if err != nil {
 		t.Fatalf("resolveAndSealCredentials: %v", err)
 	}
@@ -223,7 +223,7 @@ func TestResolveAndSealCredentials_RequiredSecretUnresolvedFails(t *testing.T) {
 		"test_e2e_canary": {As: "file"}, // non-optional, no inline value
 	}}
 	ctx := store.WithTenant(context.Background(), "team")
-	_, err = p.resolveAndSealCredentials(ctx, "run-1", "", "team", "alice", "", wf, nil, nil, model.ModelOverrides{})
+	_, err = p.resolveAndSealCredentials(ctx, "run-1", "", "team", "alice", "", wf, nil, nil, model.ModelOverrides{}, nil)
 	if err == nil {
 		t.Fatal("expected launch to fail for an unresolved required secret")
 	}
@@ -249,7 +249,7 @@ func TestResolveAndSealCredentials_OptionalSecretUnresolvedSkips(t *testing.T) {
 		"test_e2e_canary": {As: "file", Optional: true},
 	}}
 	ctx := store.WithTenant(context.Background(), "team")
-	creds, err := p.resolveAndSealCredentials(ctx, "run-1", "", "team", "alice", "", wf, nil, nil, model.ModelOverrides{})
+	creds, err := p.resolveAndSealCredentials(ctx, "run-1", "", "team", "alice", "", wf, nil, nil, model.ModelOverrides{}, nil)
 	if err != nil {
 		t.Fatalf("optional unresolved secret must not fail launch: %v", err)
 	}
@@ -397,7 +397,7 @@ func TestResolveAndSealCredentials_LogsGrantedCredentialSet(t *testing.T) {
 		logger:     iterlog.New(iterlog.LevelInfo, &buf),
 	}
 	if _, err := p.resolveAndSealCredentials(tenantCtx, "run-log-1", "", "team-1", "u1", "bot",
-		&ir.Workflow{}, nil, nil, model.ModelOverrides{}); err != nil {
+		&ir.Workflow{}, nil, nil, model.ModelOverrides{}, nil); err != nil {
 		t.Fatalf("resolveAndSealCredentials: %v", err)
 	}
 	log := buf.String()

--- a/pkg/server/cloudpublisher/publisher_secrets_test.go
+++ b/pkg/server/cloudpublisher/publisher_secrets_test.go
@@ -1,6 +1,7 @@
 package cloudpublisher
 
 import (
+	"github.com/SocialGouv/iterion/pkg/backend/model"
 	"context"
 	"strings"
 	"testing"
@@ -44,7 +45,7 @@ func TestResolveAndSealCredentials_GenericWorkflowSecrets(t *testing.T) {
 		"kubeconfig": {As: "file"},
 	}}
 	ctx := store.WithTenant(context.Background(), "team")
-	creds, err := p.resolveAndSealCredentials(ctx, "run-1", "", "team", "alice", "", wf, nil, nil)
+	creds, err := p.resolveAndSealCredentials(ctx, "run-1", "", "team", "alice", "", wf, nil, nil, model.ModelOverrides{})
 	if err != nil {
 		t.Fatalf("resolveAndSealCredentials: %v", err)
 	}
@@ -220,7 +221,7 @@ func TestResolveAndSealCredentials_RequiredSecretUnresolvedFails(t *testing.T) {
 		"test_e2e_canary": {As: "file"}, // non-optional, no inline value
 	}}
 	ctx := store.WithTenant(context.Background(), "team")
-	_, err = p.resolveAndSealCredentials(ctx, "run-1", "", "team", "alice", "", wf, nil, nil)
+	_, err = p.resolveAndSealCredentials(ctx, "run-1", "", "team", "alice", "", wf, nil, nil, model.ModelOverrides{})
 	if err == nil {
 		t.Fatal("expected launch to fail for an unresolved required secret")
 	}
@@ -246,7 +247,7 @@ func TestResolveAndSealCredentials_OptionalSecretUnresolvedSkips(t *testing.T) {
 		"test_e2e_canary": {As: "file", Optional: true},
 	}}
 	ctx := store.WithTenant(context.Background(), "team")
-	creds, err := p.resolveAndSealCredentials(ctx, "run-1", "", "team", "alice", "", wf, nil, nil)
+	creds, err := p.resolveAndSealCredentials(ctx, "run-1", "", "team", "alice", "", wf, nil, nil, model.ModelOverrides{})
 	if err != nil {
 		t.Fatalf("optional unresolved secret must not fail launch: %v", err)
 	}

--- a/pkg/server/cloudpublisher/publisher_secrets_test.go
+++ b/pkg/server/cloudpublisher/publisher_secrets_test.go
@@ -357,7 +357,6 @@ func TestSubmitResume_RequiredSecretUnresolved_KeepsResumableStatus(t *testing.T
 	}
 }
 
-
 // #659 pt 1: an operator investigating "whose credential funded that
 // run?" must find the answer in the server logs — not in
 // `/proc/<pid>/environ` inside a pod (measured, 2026-09-03). The seal

--- a/pkg/server/cloudpublisher/wants_failopen_test.go
+++ b/pkg/server/cloudpublisher/wants_failopen_test.go
@@ -1,0 +1,219 @@
+package cloudpublisher
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/backend/model"
+	"github.com/SocialGouv/iterion/pkg/credpool"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// The wants derivation reads `provider:` the way the executor does and
+// FAILS OPEN on anything it cannot resolve. Each row below is a shape the
+// round-1 A/B probe ran against the real catalog bots, where a verbatim
+// read of `provider:` narrowed the pool request from the full order to
+// NOTHING and every credential-less run of those bots skipped the pool
+// tier in silence.
+
+func wantKeys(wants []credpool.Credential) []string {
+	out := make([]string, 0, len(wants))
+	for _, w := range wants {
+		out = append(out, string(w.Source)+":"+w.Ref)
+	}
+	return out
+}
+
+func hasWant(wants []credpool.Credential, key string) bool {
+	for _, k := range wantKeys(wants) {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+func node(id, backend, provider, mdl string) *ir.AgentNode {
+	return &ir.AgentNode{
+		BaseNode:  ir.BaseNode{ID: id},
+		LLMFields: ir.LLMFields{Backend: backend, Provider: provider, Model: mdl},
+	}
+}
+
+// securedRenovacyShape is bots/secured-renovacy: thirteen claude_code
+// nodes pinned `provider: "${RESCUE_PROVIDER:-zai}"` next to nodes that
+// pin nothing under `default_backend: claude_code`.
+func securedRenovacyShape() *ir.Workflow {
+	return &ir.Workflow{
+		DefaultBackend: "claude_code",
+		Nodes: map[string]ir.Node{
+			"detect_stack":  node("detect_stack", "claude_code", "${RESCUE_PROVIDER:-zai}", ""),
+			"plan_upgrades": node("plan_upgrades", "claude_code", "${RESCUE_PROVIDER:-zai}", ""),
+			"campaign":      node("campaign", "", "", ""),
+		},
+	}
+}
+
+func TestWantsFor_ABRows_FailOpenOnUnresolvedAndNarrowOnResolved(t *testing.T) {
+	t.Setenv("RESCUE_PROVIDER", "")
+	t.Setenv("ITERION_SEC_AUDIT_BACKEND", "")
+	t.Setenv("ITERION_SEC_AUDIT_PROVIDER_CHAIN", "")
+	full := len(poolWantOrder)
+	anthropicWire := []string{"oauth:claude_code", "api_key:anthropic", "api_key:zai"}
+
+	rows := []struct {
+		name      string
+		wf        *ir.Workflow
+		wantCount int
+		wantHas   []string
+	}{
+		{
+			name:      "secured-renovacy: zai-pinned nodes next to unpinned peers → full order",
+			wf:        securedRenovacyShape(),
+			wantCount: full,
+			wantHas:   []string{"oauth:claude_code", "api_key:zai"},
+		},
+		{
+			name: "sec-audit-source triage: ${…_CHAIN:-} expands to an empty chain → full order",
+			wf: &ir.Workflow{Nodes: map[string]ir.Node{
+				"triage": node("triage", "${ITERION_SEC_AUDIT_BACKEND:-claude_code}", "${ITERION_SEC_AUDIT_PROVIDER_CHAIN:-}", ""),
+			}},
+			wantCount: full,
+			wantHas:   []string{"oauth:claude_code"},
+		},
+		{
+			name:      "chain zai,anthropic → the anthropic wire, exactly",
+			wf:        &ir.Workflow{Nodes: map[string]ir.Node{"a": node("a", "claude_code", "zai,anthropic", "")}},
+			wantCount: len(anthropicWire),
+			wantHas:   anthropicWire,
+		},
+		{
+			name:      "chain zai:glm-5.2,anthropic:claude-opus-4-8 → the anthropic wire, exactly",
+			wf:        &ir.Workflow{Nodes: map[string]ir.Node{"a": node("a", "claude_code", "zai:glm-5.2,anthropic:claude-opus-4-8", "")}},
+			wantCount: len(anthropicWire),
+			wantHas:   anthropicWire,
+		},
+		{
+			name:      "explicit auto → full order",
+			wf:        &ir.Workflow{Nodes: map[string]ir.Node{"a": node("a", "claude_code", "auto", "")}},
+			wantCount: full,
+		},
+		{
+			name: "MIXED: unpinned claude_code node + openai-pinned peer → full order, both wires kept",
+			wf: &ir.Workflow{Nodes: map[string]ir.Node{
+				"implement": node("implement", "claude_code", "", ""),
+				"review":    node("review", "claw", "openai", "openai/gpt-5.6-sol"),
+			}},
+			wantCount: full,
+			wantHas:   []string{"oauth:claude_code", "api_key:openai"},
+		},
+	}
+	for _, row := range rows {
+		t.Run(row.name, func(t *testing.T) {
+			got, res := wantsFor(row.wf, model.ModelOverrides{}, nil)
+			if len(got) != row.wantCount {
+				t.Fatalf("wants = %v (%d), want %d — resolution %+v", wantKeys(got), len(got), row.wantCount, res)
+			}
+			for _, k := range row.wantHas {
+				if !hasWant(got, k) {
+					t.Errorf("wants %v lack %s — resolution %+v", wantKeys(got), k, res)
+				}
+			}
+		})
+	}
+}
+
+// The end-to-end half of the same regression, on the real broker: the
+// secured-renovacy shape, a tenant with no credential, one claude_code
+// donor. Before the fix the wants were empty, the pool was never asked,
+// and the run fell to the platform tier.
+func TestPoolTier_securedRenovacyShapeIsServedByADonor(t *testing.T) {
+	t.Setenv("RESCUE_PROVIDER", "")
+	var buf bytes.Buffer
+	f := newPoolFixture(t, credpool.Limits{MaxUSDPerDay: 5})
+	f.pub.logger = iterlog.New(iterlog.LevelInfo, &buf)
+
+	bundle, creds := f.resolve(t, "run-renovacy", securedRenovacyShape())
+	if creds.grant == nil {
+		t.Fatalf("no grant — the pool was not asked or refused; log:\n%s", buf.String())
+	}
+	if len(bundle.OAuthCredentials["claude_code"]) == 0 {
+		t.Fatal("the donor's claude_code forfait is not in the sealed bundle")
+	}
+	if log := buf.String(); !strings.Contains(log, "credential pool consulted for run run-renovacy") {
+		t.Fatalf("want the consulted line; got:\n%s", log)
+	}
+}
+
+// G3: a node's `fallbacks:` routes are paths the run may take. A run
+// primary on claw/openai whose rescue route is anthropic must be able to
+// spend an anthropic credential, or the route is unreachable on a
+// pool-funded run.
+func TestWantsFor_NodeFallbacksWidenTheWants(t *testing.T) {
+	primaryOnly := &ir.Workflow{Nodes: map[string]ir.Node{"a": node("a", "claw", "openai", "openai/gpt-5.6-sol")}}
+	got, _ := wantsFor(primaryOnly, model.ModelOverrides{}, nil)
+	if hasWant(got, "api_key:anthropic") || hasWant(got, "oauth:claude_code") {
+		t.Fatalf("openai-only run must not ask for anthropic: %v", wantKeys(got))
+	}
+
+	withRescue := &ir.Workflow{Nodes: map[string]ir.Node{"a": &ir.AgentNode{
+		BaseNode:  ir.BaseNode{ID: "a"},
+		LLMFields: ir.LLMFields{Backend: "claw", Provider: "openai", Model: "openai/gpt-5.6-sol"},
+		Fallbacks: []ir.Fallback{{Name: "rescue", Backend: "claude_code", Provider: "anthropic"}},
+	}}}
+	got, _ = wantsFor(withRescue, model.ModelOverrides{}, nil)
+	for _, k := range []string{"api_key:openai", "oauth:codex", "api_key:anthropic", "oauth:claude_code"} {
+		if !hasWant(got, k) {
+			t.Errorf("wants %v lack %s — the rescue route's provider was dropped", wantKeys(got), k)
+		}
+	}
+	if hasWant(got, "api_key:zai") {
+		t.Errorf("wants %v include zai, which no route pins", wantKeys(got))
+	}
+}
+
+// G3, the run-level half through the REAL launch path: `spec.Fallback`
+// (the operator's --fallback) must reach the wants derivation, not only
+// the IR the runner applies later. The oracle is the consulted line the
+// publisher logs, which names the wants it asked for.
+func TestSubmitLaunch_RunLevelFallbackReachesTheWants(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	var buf bytes.Buffer
+	f := newPoolFixture(t, credpool.Limits{MaxUSDPerDay: 5})
+	f.pub.store = st
+	f.pub.logger = iterlog.New(iterlog.LevelInfo, &buf)
+	f.pub.publishRun = func(context.Context, *queue.RunMessage) error { return nil }
+
+	ctx := store.WithIdentity(context.Background(), poolTeam, "requester")
+	wf := &ir.Workflow{Name: "wf", Nodes: map[string]ir.Node{"a": node("a", "claw", "openai", "openai/gpt-5.6-sol")}}
+	spec := runview.LaunchSpec{
+		FilePath: "wf.bot",
+		Source:   "workflow wf:\n  a -> done\n",
+		Fallback: []runview.FallbackEntry{{Backend: "claude_code", Provider: "anthropic"}},
+	}
+	if _, err := f.pub.SubmitLaunch(ctx, "run-fb-1", spec, wf, "hash"); err != nil {
+		t.Fatalf("SubmitLaunch: %v", err)
+	}
+	log := buf.String()
+	line := ""
+	for _, l := range strings.Split(log, "\n") {
+		if strings.Contains(l, "credential pool consulted for run run-fb-1") {
+			line = l
+		}
+	}
+	if line == "" {
+		t.Fatalf("no consulted line for run-fb-1; log:\n%s", log)
+	}
+	if !strings.Contains(line, "api_key:anthropic") || !strings.Contains(line, "oauth:claude_code") {
+		t.Fatalf("the run-level fallback's provider did not reach the wants: %s", line)
+	}
+}

--- a/pkg/server/oauth_routes.go
+++ b/pkg/server/oauth_routes.go
@@ -356,10 +356,31 @@ func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secr
 		if v.ClaudeAIOauth.AccessToken == "" {
 			return secrets.OAuthRecord{}, errors.New("credentials.json missing claudeAiOauth.accessToken")
 		}
-		if v.ClaudeAIOauth.ExpiresAt > 0 {
-			t := time.UnixMilli(v.ClaudeAIOauth.ExpiresAt).UTC()
-			rec.AccessTokenExpiresAt = &t
+		// Ingestion gate — the runtime backstop is #624's evidence-based skip,
+		// this end catches the garbage before it ever reaches a run: an
+		// accessToken with a newline/tab/ANSI escape is a transcript, not a
+		// bearer token, and every downstream call would die with a legible
+		// "Header has invalid value" for hours before the cause was found.
+		if err := secrets.ValidateTokenShape("claudeAiOauth.accessToken", v.ClaudeAIOauth.AccessToken); err != nil {
+			return secrets.OAuthRecord{}, err
 		}
+		// A claude_code record without an expiresAt or scopes is what the CLI
+		// reads as "Not logged in" — the credential exists on the server side
+		// and can never serve a run. Refusing it here means the operator sees
+		// the problem at paste time, not on a paid fleet of dead-on-arrival
+		// runs. The clock is stamped at the same time the caller stamps
+		// CreatedAt so a nearly-expired paste is caught by the same call.
+		if v.ClaudeAIOauth.ExpiresAt <= 0 {
+			return secrets.OAuthRecord{}, errors.New("credentials.json missing claudeAiOauth.expiresAt — a claude_code record without it is read by the CLI as 'Not logged in'; re-run `claude login` and paste the fresh credentials.json")
+		}
+		exp := time.UnixMilli(v.ClaudeAIOauth.ExpiresAt).UTC()
+		if !exp.After(now) {
+			return secrets.OAuthRecord{}, fmt.Errorf("credentials.json accessToken already expired at %s — re-run `claude login` and paste the fresh credentials.json", exp.Format(time.RFC3339))
+		}
+		if len(v.ClaudeAIOauth.Scopes) == 0 {
+			return secrets.OAuthRecord{}, errors.New("credentials.json missing claudeAiOauth.scopes — a claude_code record without any scope is read by the CLI as 'Not logged in'; re-run `claude login` and paste the fresh credentials.json")
+		}
+		rec.AccessTokenExpiresAt = &exp
 		rec.NotRefreshable = v.ClaudeAIOauth.RefreshToken == ""
 		rec.Scopes = v.ClaudeAIOauth.Scopes
 	case secrets.OAuthKindCodex:
@@ -369,6 +390,11 @@ func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secr
 		}
 		if v.Tokens.AccessToken == "" {
 			return secrets.OAuthRecord{}, errors.New("auth.json missing tokens.access_token")
+		}
+		// Same shape gate as claude_code — a whitespace/control char in a
+		// bearer token is a paste accident, not a legal credential.
+		if err := secrets.ValidateTokenShape("tokens.access_token", v.Tokens.AccessToken); err != nil {
+			return secrets.OAuthRecord{}, err
 		}
 		if v.Tokens.ExpiresIn > 0 {
 			t := time.Now().Add(time.Duration(v.Tokens.ExpiresIn) * time.Second).UTC()

--- a/pkg/server/oauth_routes.go
+++ b/pkg/server/oauth_routes.go
@@ -276,8 +276,11 @@ func (s *Server) completeOAuthForOwner(w http.ResponseWriter, r *http.Request, o
 		httpError(w, http.StatusInternalServerError, "build credentials: %v", err)
 		return
 	}
-	rec, err := s.sealOAuthRecord(r.Context(), ownerKey, kind, blob, accountLabel)
+	rec, err := s.sealOAuthRecord(r.Context(), ownerKey, kind, blob, accountLabel, credentialServerBuilt)
 	if err != nil {
+		if s.refuseOAuthCredential(w, r, ownerKey, kind, "browser", err) {
+			return
+		}
 		httpError(w, http.StatusInternalServerError, "%s", err.Error())
 		return
 	}
@@ -307,8 +310,11 @@ func (s *Server) uploadOAuthForOwner(w http.ResponseWriter, r *http.Request, own
 		httpError(w, http.StatusBadRequest, "%s", err.Error())
 		return
 	}
-	rec, err := s.sealOAuthRecord(r.Context(), ownerKey, kind, body, accountLabel)
+	rec, err := s.sealOAuthRecord(r.Context(), ownerKey, kind, body, accountLabel, credentialPasted)
 	if err != nil {
+		if s.refuseOAuthCredential(w, r, ownerKey, kind, "paste", err) {
+			return
+		}
 		httpError(w, http.StatusBadRequest, "%s", err.Error())
 		return
 	}
@@ -333,11 +339,42 @@ func normalizeOAuthAccountLabel(raw string) (string, error) {
 	return label, nil
 }
 
+// credentialOrigin says who built the blob sealOAuthRecord is gating: a
+// human paste, or the server itself out of a token exchange. The
+// presence rules differ — a pasted claude_code record must carry what
+// the CLI needs to consider itself logged in (expiresAt, scopes), while
+// the exchange legitimately omits an expiry or a scope (the refresh
+// tests model scope-less responses) and the server-built blob only gets
+// the token-shape check.
+type credentialOrigin int
+
+const (
+	credentialPasted credentialOrigin = iota
+	credentialServerBuilt
+)
+
+// refuseOAuthCredential is the refusal branch both connect paths share:
+// a typed shape refusal answers 400 with the reason, and leaves a trace —
+// a Warn and an audit event naming the field and the reason, never the
+// value — so a paste that would have burned a fleet of runs on 401s is
+// findable after the fact. Reports whether it handled the error.
+func (s *Server) refuseOAuthCredential(w http.ResponseWriter, r *http.Request, ownerKey string, kind secrets.OAuthKind, flow string, err error) bool {
+	var se *secrets.ShapeError
+	if !errors.As(err, &se) {
+		return false
+	}
+	s.logger.Warn("oauth: owner=%s kind=%s credential REFUSED at ingestion (flow=%s field=%s): %s", ownerKey, kind, flow, se.Field, se.Reason)
+	s.auditOAuthByOwner(r, ownerKey, "refused", kind, map[string]any{"flow": flow, "field": se.Field, "reason": se.Reason})
+	httpError(w, http.StatusBadRequest, "%s", err.Error())
+	return true
+}
+
 // sealOAuthRecord validates a credentials blob, extracts expiry/scope
 // metadata, seals it bound to (ownerKey, kind), and upserts the record.
 // Shared by the browser flow and the paste path; accountLabel arrives
-// already normalized by the handler.
-func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secrets.OAuthKind, blob []byte, accountLabel string) (secrets.OAuthRecord, error) {
+// already normalized by the handler. Every refusal of the blob's SHAPE is
+// a *secrets.ShapeError; anything else is a parse, seal or store failure.
+func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secrets.OAuthKind, blob []byte, accountLabel string, origin credentialOrigin) (secrets.OAuthRecord, error) {
 	now := time.Now().UTC()
 	rec := secrets.OAuthRecord{
 		// ID is derived in the OAuth store's Upsert (memory + Mongo
@@ -354,7 +391,7 @@ func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secr
 			return secrets.OAuthRecord{}, err
 		}
 		if v.ClaudeAIOauth.AccessToken == "" {
-			return secrets.OAuthRecord{}, errors.New("credentials.json missing claudeAiOauth.accessToken")
+			return secrets.OAuthRecord{}, &secrets.ShapeError{Field: "claudeAiOauth.accessToken", Reason: "is missing from credentials.json"}
 		}
 		// Ingestion gate — the runtime backstop is #624's evidence-based skip,
 		// this end catches the garbage before it ever reaches a run: an
@@ -364,32 +401,45 @@ func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secr
 		if err := secrets.ValidateTokenShape("claudeAiOauth.accessToken", v.ClaudeAIOauth.AccessToken); err != nil {
 			return secrets.OAuthRecord{}, err
 		}
-		// A claude_code record without an expiresAt or scopes is what the CLI
-		// reads as "Not logged in" — the credential exists on the server side
-		// and can never serve a run. Refusing it here means the operator sees
-		// the problem at paste time, not on a paid fleet of dead-on-arrival
-		// runs. The clock is stamped at the same time the caller stamps
-		// CreatedAt so a nearly-expired paste is caught by the same call.
-		if v.ClaudeAIOauth.ExpiresAt <= 0 {
-			return secrets.OAuthRecord{}, errors.New("credentials.json missing claudeAiOauth.expiresAt — a claude_code record without it is read by the CLI as 'Not logged in'; re-run `claude login` and paste the fresh credentials.json")
-		}
-		exp := time.UnixMilli(v.ClaudeAIOauth.ExpiresAt).UTC()
-		if !exp.After(now) {
-			return secrets.OAuthRecord{}, fmt.Errorf("credentials.json accessToken already expired at %s — re-run `claude login` and paste the fresh credentials.json", exp.Format(time.RFC3339))
-		}
-		if len(v.ClaudeAIOauth.Scopes) == 0 {
-			return secrets.OAuthRecord{}, errors.New("credentials.json missing claudeAiOauth.scopes — a claude_code record without any scope is read by the CLI as 'Not logged in'; re-run `claude login` and paste the fresh credentials.json")
-		}
-		rec.AccessTokenExpiresAt = &exp
 		rec.NotRefreshable = v.ClaudeAIOauth.RefreshToken == ""
 		rec.Scopes = v.ClaudeAIOauth.Scopes
+		if v.ClaudeAIOauth.ExpiresAt > 0 {
+			exp := time.UnixMilli(v.ClaudeAIOauth.ExpiresAt).UTC()
+			rec.AccessTokenExpiresAt = &exp
+		}
+		if origin == credentialPasted {
+			// A pasted claude_code record without an expiresAt or scopes is
+			// what the CLI reads as "Not logged in" — the credential exists
+			// server-side and can never serve a run. Refuse it at paste
+			// time, not on a paid fleet of dead-on-arrival runs.
+			if rec.AccessTokenExpiresAt == nil {
+				return secrets.OAuthRecord{}, &secrets.ShapeError{Field: "claudeAiOauth.expiresAt", Reason: "is missing from credentials.json — a claude_code record without it is read by the CLI as 'Not logged in'; paste the current credentials.json of a logged-in Claude Code (run any `claude` command first so it is fresh)"}
+			}
+			if len(rec.Scopes) == 0 {
+				return secrets.OAuthRecord{}, &secrets.ShapeError{Field: "claudeAiOauth.scopes", Reason: "is missing from credentials.json — a claude_code record without any scope is read by the CLI as 'Not logged in'; paste the current credentials.json of a logged-in Claude Code"}
+			}
+		}
+		// An EXPIRED access token is only dead when nothing can renew it.
+		// With a refreshToken the record is exactly what the refresh worker
+		// exists for (ExpiringBefore lists expired records too, and RunOnce
+		// refreshes every refreshable one), so a stale export from a
+		// logged-in machine connects and heals on the worker's next pass.
+		// Without one, only a fresh paste can help — and `claude login` is
+		// the wrong advice for a machine that IS logged in and merely
+		// exported a stale file.
+		if rec.AccessTokenExpiresAt != nil && !rec.AccessTokenExpiresAt.After(now) {
+			if rec.NotRefreshable {
+				return secrets.OAuthRecord{}, &secrets.ShapeError{Field: "claudeAiOauth.accessToken", Reason: fmt.Sprintf("already expired at %s and the record carries no refreshToken, so nothing can renew it — paste the current credentials.json of a logged-in Claude Code (it carries a refreshToken), or connect through the browser flow", rec.AccessTokenExpiresAt.Format(time.RFC3339))}
+			}
+			s.logger.Info("oauth: owner=%s kind=%s accessToken expired at %s but refreshable — accepted; the refresh worker renews it on its next pass", ownerKey, kind, rec.AccessTokenExpiresAt.Format(time.RFC3339))
+		}
 	case secrets.OAuthKindCodex:
 		v, err := secrets.ParseCodexView(blob)
 		if err != nil {
 			return secrets.OAuthRecord{}, err
 		}
 		if v.Tokens.AccessToken == "" {
-			return secrets.OAuthRecord{}, errors.New("auth.json missing tokens.access_token")
+			return secrets.OAuthRecord{}, &secrets.ShapeError{Field: "tokens.access_token", Reason: "is missing from auth.json"}
 		}
 		// Same shape gate as claude_code — a whitespace/control char in a
 		// bearer token is a paste accident, not a legal credential.

--- a/pkg/server/oauth_routes.go
+++ b/pkg/server/oauth_routes.go
@@ -353,6 +353,24 @@ const (
 	credentialServerBuilt
 )
 
+// pastedBlobParseError gives a blob that is not even JSON the same typed
+// refusal a bad FIELD gets, so the paste path's Warn + audit cover the
+// shape #627 was filed on: a terminal transcript pasted whole, which
+// ParseAnthropicView/ParseCodexView reject as a plain parse error and the
+// refusal branch therefore let through with no trace at all. A
+// server-built blob keeps the raw error — nobody pasted it, and the token
+// exchange's own failure is the interesting one.
+func pastedBlobParseError(file string, origin credentialOrigin, err error) error {
+	var se *secrets.ShapeError
+	if origin != credentialPasted || errors.As(err, &se) {
+		return err
+	}
+	return &secrets.ShapeError{
+		Field:  file,
+		Reason: fmt.Sprintf("is not a JSON object (%v) — paste the file itself, not a terminal transcript or a fragment of it", err),
+	}
+}
+
 // refuseOAuthCredential is the refusal branch both connect paths share:
 // a typed shape refusal answers 400 with the reason, and leaves a trace —
 // a Warn and an audit event naming the field and the reason, never the
@@ -388,7 +406,7 @@ func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secr
 	case secrets.OAuthKindClaudeCode:
 		v, err := secrets.ParseAnthropicView(blob)
 		if err != nil {
-			return secrets.OAuthRecord{}, err
+			return secrets.OAuthRecord{}, pastedBlobParseError("credentials.json", origin, err)
 		}
 		if v.ClaudeAIOauth.AccessToken == "" {
 			return secrets.OAuthRecord{}, &secrets.ShapeError{Field: "claudeAiOauth.accessToken", Reason: "is missing from credentials.json"}
@@ -436,7 +454,7 @@ func (s *Server) sealOAuthRecord(ctx context.Context, ownerKey string, kind secr
 	case secrets.OAuthKindCodex:
 		v, err := secrets.ParseCodexView(blob)
 		if err != nil {
-			return secrets.OAuthRecord{}, err
+			return secrets.OAuthRecord{}, pastedBlobParseError("auth.json", origin, err)
 		}
 		if v.Tokens.AccessToken == "" {
 			return secrets.OAuthRecord{}, &secrets.ShapeError{Field: "tokens.access_token", Reason: "is missing from auth.json"}

--- a/pkg/server/oauth_routes_test.go
+++ b/pkg/server/oauth_routes_test.go
@@ -734,3 +734,35 @@ func TestOAuthCredentialIngestion_RefusalLeavesATrace(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 }
+
+// A whole terminal transcript pasted into the box is the shape #627 was
+// filed on. It fails to PARSE, which is not a ShapeError — so the refusal
+// branch let it through with no Warn and no audit entry, exactly the
+// invisible failure the ticket exists to end. The 400 alone is not enough:
+// the operator who pasted it is not the one who reads the run's 401s hours
+// later.
+func TestOAuthCredentialIngestion_TranscriptPasteLeavesATrace(t *testing.T) {
+	srv, hs, signer, oauthStore := oauthTestServer(t)
+	var buf bytes.Buffer
+	srv.logger = iterlog.New(iterlog.LevelInfo, &buf)
+	alice := oauthJWT(t, signer, "alice")
+
+	blob := "\x1b[32mWelcome to Claude Code\x1b[0m\n" +
+		`{"claudeAiOauth":{"accessToken":"sk-ant-oat01-secret","refreshToken":"rt","expiresAt":4102444800000,"scopes":["user:inference"]}}`
+
+	code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", alice, blob)
+	if code != http.StatusBadRequest {
+		t.Fatalf("upload = %d body=%s, want 400 for a transcript paste", code, body)
+	}
+	if _, err := oauthStore.Get(t.Context(), "alice", secrets.OAuthKindClaudeCode); err == nil {
+		t.Fatal("a transcript paste was stored")
+	}
+	log := buf.String()
+	if !strings.Contains(log, "REFUSED at ingestion") || !strings.Contains(log, "credentials.json") {
+		t.Fatalf("a refused paste must leave a Warn naming the file it could not read; got:\n%s", log)
+	}
+	// The trace names the shape, never the material.
+	if strings.Contains(log, "sk-ant-oat01-secret") || strings.Contains(body, "sk-ant-oat01-secret") {
+		t.Fatalf("the refusal echoed the token; log:\n%s\nbody: %s", log, body)
+	}
+}

--- a/pkg/server/oauth_routes_test.go
+++ b/pkg/server/oauth_routes_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -213,7 +214,10 @@ func TestOAuthAccountLabel(t *testing.T) {
 	srv, hs, signer, store := oauthTestServer(t)
 	jo := oauthJWT(t, signer, "jo")
 	blob := func(tok string) string {
-		return `{"claudeAiOauth":{"accessToken":"` + tok + `","refreshToken":"rt","expiresAt":4102444800000}}`
+		// Include a scope: sealOAuthRecord's ingestion gate refuses a
+		// claude_code record with no scope (the shape the CLI reads as
+		// "Not logged in").
+		return `{"claudeAiOauth":{"accessToken":"` + tok + `","refreshToken":"rt","expiresAt":4102444800000,"scopes":["user:inference"]}}`
 	}
 	codexBlob := func(tok, account string) string {
 		return `{"tokens":{"access_token":"` + tok + `","refresh_token":"rt","account_id":"` + account + `"},"auth_mode":"chatgpt"}`
@@ -417,3 +421,109 @@ func (s *oauthUpsertSpy) Upsert(ctx context.Context, rec secrets.OAuthRecord) er
 	s.upserts++
 	return s.OAuthStore.Upsert(ctx, rec)
 }
+
+// TestOAuthCredentialIngestionValidatesShape locks the paid failures behind
+// the /api/me/oauth/{kind}/credentials paste path (#627):
+//   - a claude_code accessToken with an embedded newline (terminal-transcript
+//     paste, the shape the prod incident reported): every downstream call
+//     would die on `Bearer <transcript>` — refused at ingestion.
+//   - a claude_code record with no scopes and/or no expiresAt: the shape the
+//     CLI reads as "Not logged in" — refused at ingestion so the operator
+//     sees it at paste time, not on a fleet of dead-on-arrival runs.
+//   - a claude_code record with an ALREADY-EXPIRED accessToken.
+//   - a healthy full-shape blob still passes and lands sealed.
+//
+// The oracle is the STORE (no record must have been written), not just the
+// response status — a 400 with a silent write would still leave the garbage
+// on disk for the runs to pick up.
+func TestOAuthCredentialIngestionValidatesShape(t *testing.T) {
+	_, hs, signer, oauthStore := oauthTestServer(t)
+	alice := oauthJWT(t, signer, "alice")
+
+	claudeBlob := func(tok string, expiresAtMs int64, scopes string) string {
+		exp := ""
+		if expiresAtMs > 0 {
+			exp = fmt.Sprintf(`,"expiresAt":%d`, expiresAtMs)
+		}
+		sc := ""
+		if scopes != "" {
+			sc = `,"scopes":` + scopes
+		}
+		return `{"claudeAiOauth":{"accessToken":"` + tok + `","refreshToken":"rt"` + exp + sc + `}}`
+	}
+
+	for _, tc := range []struct {
+		name, blob, wantInErr string
+	}{
+		{
+			name:      "accessToken carrying an embedded newline",
+			blob:      `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-good\nWelcome to claude","refreshToken":"rt","expiresAt":4102444800000,"scopes":["user:inference"]}}`,
+			wantInErr: "newline",
+		},
+		{
+			name:      "accessToken carrying a tab",
+			blob:      `{"claudeAiOauth":{"accessToken":"\tsk-ant-oat01-good","refreshToken":"rt","expiresAt":4102444800000,"scopes":["user:inference"]}}`,
+			wantInErr: "tab",
+		},
+		{
+			name:      "accessToken carrying a space",
+			blob:      `{"claudeAiOauth":{"accessToken":"sk-ant-oat01 good","refreshToken":"rt","expiresAt":4102444800000,"scopes":["user:inference"]}}`,
+			wantInErr: "space",
+		},
+		{
+			name:      "accessToken carrying an ANSI escape (terminal transcript)",
+			blob:      `{"claudeAiOauth":{"accessToken":"\u001b[32msk-ant-oat01-good\u001b[0m","refreshToken":"rt","expiresAt":4102444800000,"scopes":["user:inference"]}}`,
+			wantInErr: "control character",
+		},
+		{
+			name:      "claude_code with no scopes",
+			blob:      claudeBlob("sk-ant-oat01-good", 4102444800000, ""),
+			wantInErr: "scopes",
+		},
+		{
+			name:      "claude_code with no expiresAt",
+			blob:      claudeBlob("sk-ant-oat01-good", 0, `["user:inference"]`),
+			wantInErr: "expiresAt",
+		},
+		{
+			name:      "claude_code with an already-expired accessToken",
+			blob:      claudeBlob("sk-ant-oat01-good", time.Now().Add(-time.Hour).UnixMilli(), `["user:inference"]`),
+			wantInErr: "expired",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Wipe first so a residue from an earlier subtest cannot mask a
+			// silent write here.
+			_ = oauthStore.Delete(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+
+			code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", alice, tc.blob)
+			if code != http.StatusBadRequest {
+				t.Fatalf("upload = %d body=%s, want 400 (garbage credential rejected at ingestion)", code, body)
+			}
+			if !strings.Contains(body, tc.wantInErr) {
+				t.Fatalf("error body = %q, want it to mention %q", body, tc.wantInErr)
+			}
+			// The store is the oracle: nothing must have been persisted.
+			if _, err := oauthStore.Get(t.Context(), "alice", secrets.OAuthKindClaudeCode); err == nil {
+				t.Fatal("a rejected credential was silently stored — every downstream call would now die on a Bearer transcript")
+			}
+		})
+	}
+
+	t.Run("healthy full-shape blob still passes", func(t *testing.T) {
+		_ = oauthStore.Delete(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+		blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-good","refreshToken":"rt","expiresAt":4102444800000,"scopes":["user:inference"]}}`
+		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", alice, blob)
+		if code != http.StatusOK {
+			t.Fatalf("upload = %d body=%s, want 200 for a well-shaped credential", code, body)
+		}
+		rec, err := oauthStore.Get(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+		if err != nil {
+			t.Fatalf("store Get: %v", err)
+		}
+		if len(rec.SealedPayload) == 0 || len(rec.Scopes) == 0 || rec.AccessTokenExpiresAt == nil {
+			t.Fatalf("healthy blob landed with wrong shape: sealed=%d scopes=%v expiresAt=%v", len(rec.SealedPayload), rec.Scopes, rec.AccessTokenExpiresAt)
+		}
+	})
+}
+

--- a/pkg/server/oauth_routes_test.go
+++ b/pkg/server/oauth_routes_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -12,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/SocialGouv/iterion/pkg/audit"
 	"github.com/SocialGouv/iterion/pkg/auth"
 	"github.com/SocialGouv/iterion/pkg/identity"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
@@ -486,8 +488,10 @@ func TestOAuthCredentialIngestionValidatesShape(t *testing.T) {
 			wantInErr: "expiresAt",
 		},
 		{
-			name:      "claude_code with an already-expired accessToken",
-			blob:      claudeBlob("sk-ant-oat01-good", time.Now().Add(-time.Hour).UnixMilli(), `["user:inference"]`),
+			// With a refreshToken an expired record is accepted (the refresh
+			// worker renews it); only the unrenewable shape is refused.
+			name:      "claude_code with an already-expired accessToken and no refreshToken",
+			blob:      fmt.Sprintf(`{"claudeAiOauth":{"accessToken":"sk-ant-oat01-good","expiresAt":%d,"scopes":["user:inference"]}}`, time.Now().Add(-time.Hour).UnixMilli()),
 			wantInErr: "expired",
 		},
 	} {
@@ -525,4 +529,208 @@ func TestOAuthCredentialIngestionValidatesShape(t *testing.T) {
 			t.Fatalf("healthy blob landed with wrong shape: sealed=%d scopes=%v expiresAt=%v", len(rec.SealedPayload), rec.Scopes, rec.AccessTokenExpiresAt)
 		}
 	})
+}
+
+// An expired access token is only dead when nothing can renew it. The
+// refresh worker heals exactly the expired-but-refreshable record
+// (ExpiringBefore lists expired ones; RunOnce refreshes every refreshable
+// one), and every producer funnels through sealOAuthRecord — so refusing
+// that shape at paste time left a stale export from a LOGGED-IN machine
+// unconnectable, with `claude login` as the wrong remedy (#627 round 1).
+func TestOAuthCredentialIngestion_ExpiredIsRefusedOnlyWithoutARefreshToken(t *testing.T) {
+	_, hs, signer, oauthStore := oauthTestServer(t)
+	alice := oauthJWT(t, signer, "alice")
+	expired := time.Now().Add(-time.Hour).UnixMilli()
+
+	t.Run("expired + refreshToken → accepted, refreshable", func(t *testing.T) {
+		_ = oauthStore.Delete(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+		blob := fmt.Sprintf(`{"claudeAiOauth":{"accessToken":"sk-ant-oat01-stale","refreshToken":"rt","expiresAt":%d,"scopes":["user:inference"]}}`, expired)
+		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", alice, blob)
+		if code != http.StatusOK {
+			t.Fatalf("upload = %d body=%s, want 200 (the refresh worker renews it)", code, body)
+		}
+		var view oauthConnectionView
+		if err := json.Unmarshal([]byte(body), &view); err != nil {
+			t.Fatalf("decode view: %v", err)
+		}
+		if !view.Refreshable {
+			t.Fatalf("view.refreshable = false, want true: %s", body)
+		}
+		rec, err := oauthStore.Get(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+		if err != nil {
+			t.Fatalf("stored record: %v", err)
+		}
+		if rec.NotRefreshable || rec.AccessTokenExpiresAt == nil || rec.AccessTokenExpiresAt.After(time.Now()) {
+			t.Fatalf("stored record = %+v, want refreshable with its past expiry kept (ExpiringBefore must list it)", rec)
+		}
+	})
+
+	t.Run("expired + no refreshToken → refused, remedy names the refreshToken", func(t *testing.T) {
+		_ = oauthStore.Delete(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+		blob := fmt.Sprintf(`{"claudeAiOauth":{"accessToken":"sk-ant-oat01-stale","expiresAt":%d,"scopes":["user:inference"]}}`, expired)
+		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", alice, blob)
+		if code != http.StatusBadRequest {
+			t.Fatalf("upload = %d body=%s, want 400", code, body)
+		}
+		if !strings.Contains(body, "expired") || !strings.Contains(body, "refreshToken") || strings.Contains(body, "claude login") {
+			t.Fatalf("remedy must say the record cannot be renewed and what to paste instead, never `claude login`: %s", body)
+		}
+		if _, err := oauthStore.Get(t.Context(), "alice", secrets.OAuthKindClaudeCode); err == nil {
+			t.Fatal("a refused credential was silently stored")
+		}
+	})
+
+	t.Run("missing expiresAt → refused", func(t *testing.T) {
+		_ = oauthStore.Delete(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+		blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-good","refreshToken":"rt","scopes":["user:inference"]}}`
+		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", alice, blob)
+		if code != http.StatusBadRequest || !strings.Contains(body, "expiresAt") {
+			t.Fatalf("upload = %d body=%s, want 400 naming expiresAt", code, body)
+		}
+	})
+}
+
+// The ASCII-only gate let a NO-BREAK SPACE glued to the token through the
+// chokepoint and SEALED it. End to end through the paste path: refused,
+// naming the rune, nothing stored.
+func TestOAuthCredentialIngestion_RefusesUnicodeWhitespaceEndToEnd(t *testing.T) {
+	_, hs, signer, oauthStore := oauthTestServer(t)
+	alice := oauthJWT(t, signer, "alice")
+	blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-good\u00a0tail","refreshToken":"rt","expiresAt":4102444800000,"scopes":["user:inference"]}}`
+	code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/credentials", alice, blob)
+	if code != http.StatusBadRequest || !strings.Contains(body, "U+00A0") {
+		t.Fatalf("upload = %d body=%s, want 400 naming U+00A0", code, body)
+	}
+	if _, err := oauthStore.Get(t.Context(), "alice", secrets.OAuthKindClaudeCode); err == nil {
+		t.Fatal("an NBSP-glued token was sealed through the chokepoint")
+	}
+}
+
+// cannedTokenTransport answers the Anthropic token exchange in-process.
+type cannedTokenTransport struct {
+	status int
+	body   string
+	seen   *http.Request
+}
+
+func (c *cannedTokenTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	c.seen = r
+	return &http.Response{
+		StatusCode: c.status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(c.body)),
+		Request:    r,
+	}, nil
+}
+
+// seedPending puts a browser-flow pending authorization for owner+kind
+// and returns its state.
+func seedPending(t *testing.T, srv *Server, ownerKey string) string {
+	t.Helper()
+	sealedVerifier, err := secrets.SealOAuthVerifier(srv.sealer, ownerKey, secrets.OAuthKindClaudeCode, "verifier-x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if err := srv.oauthPending.Put(t.Context(), secrets.OAuthPending{
+		OwnerKey: ownerKey, Kind: secrets.OAuthKindClaudeCode, SealedVerifier: sealedVerifier,
+		State: "state-x", RedirectURI: "https://example.invalid/cb", CreatedAt: now, ExpiresAt: now.Add(time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return "state-x"
+}
+
+// The browser flow builds the blob itself: BuildAnthropicCredentials
+// omits expiresAt when the exchange returns no expires_in and scopes when
+// it returns no scope (the repo's refresh tests model scope-less
+// responses). The paste-path presence rules do not apply to it — and
+// with the pending authorization already consumed, a refusal costs the
+// operator a restarted connect, so the server-built blob gets the
+// token-shape check only. A shape refusal there is a 400, not a 500.
+func TestOAuthBrowserCompletion_ServerBuiltBlobIsNotHeldToPasteRules(t *testing.T) {
+	srv, hs, signer, oauthStore := oauthTestServer(t)
+	alice := oauthJWT(t, signer, "alice")
+	srv.oauthPending = secrets.NewMemoryOAuthPendingStore()
+	srv.cfg.AnthropicOAuthClientID = "client-x"
+
+	t.Run("scope-less, expiry-less exchange → stored", func(t *testing.T) {
+		_ = oauthStore.Delete(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+		state := seedPending(t, srv, "alice")
+		rt := &cannedTokenTransport{status: 200, body: `{"access_token":"sk-ant-oat01-browser-token","refresh_token":"rt-browser","token_type":"Bearer"}`}
+		srv.httpClient = &http.Client{Transport: rt}
+		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/authorize/complete", alice, `{"code":"code-x","state":"`+state+`"}`)
+		if code != http.StatusOK {
+			t.Fatalf("complete = %d body=%s, want 200", code, body)
+		}
+		if rt.seen == nil {
+			t.Fatal("the exchange never reached the token endpoint")
+		}
+		rec, err := oauthStore.Get(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+		if err != nil {
+			t.Fatalf("stored record: %v", err)
+		}
+		if rec.NotRefreshable || rec.AccessTokenExpiresAt != nil || len(rec.Scopes) != 0 {
+			t.Fatalf("stored record = %+v, want refreshable with no expiry and no scopes (as the exchange answered)", rec)
+		}
+	})
+
+	t.Run("exchange answers a malformed token → 400, nothing stored", func(t *testing.T) {
+		_ = oauthStore.Delete(t.Context(), "alice", secrets.OAuthKindClaudeCode)
+		state := seedPending(t, srv, "alice")
+		srv.httpClient = &http.Client{Transport: &cannedTokenTransport{status: 200, body: `{"access_token":"sk-ant-oat01-browser\ntoken","refresh_token":"rt"}`}}
+		code, body := oauthCall(t, hs, http.MethodPost, "/api/me/oauth/claude_code/authorize/complete", alice, `{"code":"code-x","state":"`+state+`"}`)
+		if code != http.StatusBadRequest || !strings.Contains(body, "newline") {
+			t.Fatalf("complete = %d body=%s, want 400 naming the newline", code, body)
+		}
+		if _, err := oauthStore.Get(t.Context(), "alice", secrets.OAuthKindClaudeCode); err == nil {
+			t.Fatal("a refused credential was stored")
+		}
+	})
+}
+
+// A refusal leaves a trace: a Warn and, on an audited owner (a team's
+// org credential), an audit event naming the field and the reason —
+// never the value. Before this only the success path wrote anything.
+func TestOAuthCredentialIngestion_RefusalLeavesATrace(t *testing.T) {
+	srv, hs, signer, oauthStore := oauthTestServer(t)
+	var logs bytes.Buffer
+	srv.logger = iterlog.New(iterlog.LevelWarn, &logs)
+	auditStore := audit.NewMemoryStore()
+	srv.auditStore = auditStore
+	tok, _, err := signer.IssueAccess(auth.Identity{UserID: "root", Email: "root@x", IsSuperAdmin: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat01-good\nWelcome","refreshToken":"rt","expiresAt":4102444800000,"scopes":["user:inference"]}}`
+	code, body := oauthCall(t, hs, http.MethodPost, "/api/teams/team-x/oauth/claude_code/credentials", tok, blob)
+	if code != http.StatusBadRequest {
+		t.Fatalf("upload = %d body=%s, want 400", code, body)
+	}
+	if _, err := oauthStore.Get(t.Context(), secrets.OrgOwnerKey("team-x"), secrets.OAuthKindClaudeCode); err == nil {
+		t.Fatal("a refused credential was stored")
+	}
+	if l := logs.String(); !strings.Contains(l, "REFUSED at ingestion") || !strings.Contains(l, "claudeAiOauth.accessToken") || strings.Contains(l, "sk-ant-oat01-good") {
+		t.Fatalf("want a Warn naming the field and never the value; got:\n%s", l)
+	}
+	// The audit insert is detached; poll briefly.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		events, err := auditStore.ListByTenant(t.Context(), "team-x", audit.Page{Limit: 10})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range events {
+			if e.Action == "oauth.org.refused" {
+				if e.Meta["field"] != "claudeAiOauth.accessToken" || e.Meta["reason"] == nil || strings.Contains(fmt.Sprint(e.Meta), "sk-ant-oat01-good") {
+					t.Fatalf("audit event = %+v, want field + reason and never the value", e)
+				}
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no oauth.org.refused audit event; got %+v", events)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 }

--- a/pkg/server/oauth_routes_test.go
+++ b/pkg/server/oauth_routes_test.go
@@ -526,4 +526,3 @@ func TestOAuthCredentialIngestionValidatesShape(t *testing.T) {
 		}
 	})
 }
-


### PR DESCRIPTION
Wave 1 of the board-203 triage, credential-resolution cluster. Four tickets, then three adversarial-review rounds whose findings are folded in.

Closes #668
Closes #654
Closes #627
Refs #659 (points 1-2 only — the run API exposing fingerprints stays open)

## What was wrong

**#668 — a fully pinned bot still asked for anthropic, and was still parked on its meter.** Two separate causes, both proven:
- `resolveAndSealCredentials` and `wantsFor` derived the wanted providers from the DSL without applying the launch's `model_overrides`, so a judge pinned to claw/openai still wanted a claude_code forfait.
- The incident itself came from a *third* site the ticket did not name: `usageCapPreflight` keys on the DEFAULT credential (z.ai → anthropic → oauth) under a hardcoded `claude_code` backend, so a run pinned entirely off the anthropic wire — even a tenant holding no anthropic credential at all — was refused on the anthropic (or platform) reading. It now fails open when no *primary* route can reach that wire; a rescue `fallbacks:` route no longer arms the guard, because the mid-run guard already refuses at dispatch what the pre-flight would be refusing in advance.

**#654 — the pool abstained in silence.** `ErrNoDonor` carried nothing, so an operator could not tell a broker bug from a mis-set audience from a donor asleep. The abstention is now typed (`NoDonorError`) with a reason, the pool/pledge counts, and a per-pledge status; the definitive "no credential at all" Warn no longer disappears when the bundle happens to carry a generic secret — the shape every webhook-launched review has.

**#627 — a pasted non-token was discovered at run time.** Ingestion now refuses whitespace, control characters and the invisible Unicode a copy-paste carries, and names what it rejected without echoing it. An expired-but-refreshable `credentials.json` is *accepted* (the refresh worker heals exactly that record); only an unrenewable one is refused.

**#659 (1-2) — nobody could tell which key served which run.** One INFO line per run names the granted set by tier and fingerprint; `last_used_at` moves at the start and the end of every attempt — the start stamp landing once the run is admitted, so a run parked on a ceiling does not date a key it never spent.

## Review

Two internal rounds (16 findings each, every one proven by an executed probe and fixed red-first), then the fixes re-attacked. Round 2 caught a regression the first pass introduced: reading `provider:` verbatim collapsed the wants to zero for the catalog bots whose nodes carry `provider: "${RESCUE_PROVIDER:-zai}"`, which would have skipped the pool tier entirely on every credential-less run. The resolution now follows the executor's own order — override, then the DSL chain, then the model prefix — because on claude_code and pi the hint IS the route.

`task check` green (lint + tests + goldens + studio), `-race` on every touched package, mongo conformance run against a live replica set for the store twins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)