### PR TITLE
fix(runner): a stalled resume is adopted, re-budgeted and told apart from a quota pause

### DIFF
--- a/cmd/iterion/remote_runs.go
+++ b/cmd/iterion/remote_runs.go
@@ -240,10 +240,15 @@ var remoteRunsPauseCmd = &cobra.Command{
 }
 
 var (
-	remoteResumeAnswers string
-	remoteResumeFile    string
-	remoteResumeForce   bool
-	remoteResumeTimeout string
+	remoteResumeAnswers             string
+	remoteResumeFile                string
+	remoteResumeForce               bool
+	remoteResumeTimeout             string
+	remoteResumeMaxCostUSD          float64
+	remoteResumeMaxTokens           int
+	remoteResumeMaxDuration         string
+	remoteResumeMaxIterations       int
+	remoteResumeMaxParallelBranches int
 )
 
 var remoteRunsResumeCmd = &cobra.Command{
@@ -253,10 +258,15 @@ var remoteRunsResumeCmd = &cobra.Command{
 	RunE: remoteRunE(func(cmd *cobra.Command, args []string, c *cli.RemoteClient, p *cli.Printer) error {
 		answers := strings.TrimPrefix(remoteResumeAnswers, "@")
 		return cli.RemoteRunsResume(cmd.Context(), c, p, args[0], cli.RemoteRunsResumeOptions{
-			AnswersFile: answers,
-			FilePath:    remoteResumeFile,
-			Force:       remoteResumeForce,
-			Timeout:     remoteResumeTimeout,
+			AnswersFile:         answers,
+			FilePath:            remoteResumeFile,
+			Force:               remoteResumeForce,
+			Timeout:             remoteResumeTimeout,
+			MaxCostUSD:          remoteResumeMaxCostUSD,
+			MaxTokens:           remoteResumeMaxTokens,
+			MaxDuration:         remoteResumeMaxDuration,
+			MaxIterations:       remoteResumeMaxIterations,
+			MaxParallelBranches: remoteResumeMaxParallelBranches,
 		})
 	}),
 }
@@ -475,6 +485,14 @@ func init() {
 	remoteRunsResumeCmd.Flags().StringVar(&remoteResumeFile, "file", "", "Push a modified workflow file with the resume")
 	remoteRunsResumeCmd.Flags().BoolVar(&remoteResumeForce, "force", false, "Resume even if the workflow source changed")
 	remoteRunsResumeCmd.Flags().StringVar(&remoteResumeTimeout, "timeout", "", "New timeout for the resumed run")
+	// #652 part 2: the local `iterion resume` accepts --max-* to raise
+	// the cap; the remote equivalent now does too. Non-zero beats the
+	// run doc's persisted launch ask on THIS resume; zero inherits.
+	remoteRunsResumeCmd.Flags().Float64Var(&remoteResumeMaxCostUSD, "max-cost-usd", 0, "Raise the cost cap on THIS resume (USD)")
+	remoteRunsResumeCmd.Flags().IntVar(&remoteResumeMaxTokens, "max-tokens", 0, "Raise the token cap on THIS resume")
+	remoteRunsResumeCmd.Flags().StringVar(&remoteResumeMaxDuration, "max-duration", "", "Raise the duration cap on THIS resume (Go duration)")
+	remoteRunsResumeCmd.Flags().IntVar(&remoteResumeMaxIterations, "max-iterations", 0, "Raise the loop-iterations cap on THIS resume")
+	remoteRunsResumeCmd.Flags().IntVar(&remoteResumeMaxParallelBranches, "max-parallel-branches", 0, "Raise the parallel-branches cap on THIS resume")
 
 	remoteRunsForkCmd.Flags().StringVar(&remoteForkNode, "node", "", "Node id to fork at (required)")
 	remoteRunsForkCmd.Flags().IntVar(&remoteForkTurn, "turn", 0, "LLM turn index to rewind to")

--- a/docs/cloud-architecture.md
+++ b/docs/cloud-architecture.md
@@ -140,6 +140,19 @@ Pinned semantics:
   ([pkg/runner/loop.go](../pkg/runner/loop.go), look for "parking on
   DLQ"). The original NATS message is Term'd; the DLQ copy is the
   recoverable artifact.
+- **Delayed re-offers.** Two outcomes hand the message back with a
+  delay instead of at once, so the redelivery budget is not burnt inside
+  a condition that needs wall-clock time to clear: a run whose sandbox
+  setup phase timed out (`SANDBOX_SETUP_TIMEOUT`, a stuck workspace copy)
+  is re-offered to a fresh pod after 2 minutes, and the run's timeline
+  carries a `run_redelivery_deferred` event naming the reason, the delay
+  and the attempt's rank — the DLQ park still applies on the last
+  delivery; a `running` doc written more recently than the runner's
+  adoption floor (a lapsed-but-alive pod may still be unwinding) is
+  re-offered after the floor's remainder. On the LAST permitted delivery
+  that young doc is Term'd instead and the log says so — JetStream would
+  not re-offer it anyway — and the orphan sweeper below owns it from
+  there; nothing is written over a possibly-live writer.
 - **DLQ retention**: 7 days
   ([pkg/queue/nats/nats.go:DefaultDLQMaxAge](../pkg/queue/nats/nats.go)).
   An operator triages via the admin endpoints

--- a/docs/persisted-formats.md
+++ b/docs/persisted-formats.md
@@ -203,7 +203,7 @@ emitter when a consumer needs an exact payload contract.
 
 | Family | Persisted event types |
 |---|---|
-| Run lifecycle/control | `run_started`, `run_paused`, `human_input_requested`, `human_answers_recorded`, `interaction_answered`, `run_resumed`, `run_auto_resumed`, `run_retry_scheduled`, `run_workspace_reset`, `run_workspace_bank_restored`, `run_steered`, `run_health`, `run_finished`, `run_failed`, `run_cancelled`, `run_interrupted` |
+| Run lifecycle/control | `run_started`, `run_paused`, `human_input_requested`, `human_answers_recorded`, `interaction_answered`, `run_resumed`, `run_auto_resumed`, `run_retry_scheduled`, `run_workspace_reset`, `run_workspace_bank_restored`, `run_redelivery_deferred`, `run_steered`, `run_health`, `run_finished`, `run_failed`, `run_cancelled`, `run_interrupted` |
 | Graph/budget/artifacts | `branch_started`, `branch_finished`, `branch_abandoned`, `node_started`, `node_recovery`, `node_verified_action`, `node_finished`, `edge_selected`, `join_ready`, `budget_warning`, `budget_exceeded`, `budget_exit_grace`, `artifact_written`, `plan_written` |
 | LLM, delegation, and tools | `llm_request`, `llm_prompt`, `llm_retry`, `llm_step_finished`, `assistant_text`, `llm_compacted`, `tool_started`, `tool_called`, `tool_error`, `delegate_started`, `delegate_finished`, `delegate_error`, `delegate_retry`, `model_fallback`, `model_drift` |
 | Review gate | `review_turn`, `review_verdict`, `review_merged` |

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -169,32 +169,36 @@ repeating the old cap causes the re-executed node to hit the same guard.
 resume`) accepts the same budget-override flags as the local CLI —
 `--max-cost-usd`, `--max-tokens`, `--max-duration`, `--max-iterations`,
 `--max-parallel-branches`. The wire body carries them as
-`{"budget": {"max_duration": "4h", ...}}`; a non-zero field beats the
-launch ask persisted on the run doc for THIS resume publication (a zero
-field inherits). Without an override the resume replays from the run
-doc as before.
+`{"budget": {"max_duration": "4h", ...}}`; the override MERGES per
+field over the launch ask persisted on the run doc — a non-zero field
+in the spec beats the doc, a zero field inherits it. Passing only
+`--max-duration 4h` therefore raises the duration without erasing the
+launch's cost/tokens caps. Without any override the resume replays
+from the doc as before.
 
 Two mechanics matter when raising a cap here:
 
 - **The consumed accounting travels across resume.** The checkpoint
-  restores `budget_elapsed_ns`, `budget_cost_usd`, `budget_tokens` and
-  `budget_iterations` on every axis, so a resume with no override
-  restarts against the same clock that killed it. Measure: a run
-  parked on a 2h30m duration cap (elapsed = 9902 s) resumed bare walks
-  another 5 min and dies at 9901.6 s + 10% = the exit-grace ceiling.
-  The escape hatch is exactly what `--max-*` on resume raises.
-- **The cap raised on THIS resume rides the RunMessage only.** It does
-  NOT overwrite the launch ask on the run doc, so a subsequent
-  unattended auto-retry (usage-window sweeper) reverts to the launch
-  value. The pattern is therefore "operator raises cap on the manual
-  resume that unblocks the run; the run completes, and the launch ask
-  goes back to being the reference for future retries". Persisting a
-  cap-raise across attempts is a separate follow-up.
+  restores `budget_elapsed_ns`, `budget_cost_usd`, `budget_tokens_used`
+  and `budget_iterations_used` on every axis, so a resume with no
+  override restarts against the same clock that killed it. Measure: a
+  run parked on a 2h30m duration cap (elapsed = 9902 s) resumed bare
+  walks another 5 min and dies at 9901.6 s + 10% = the exit-grace
+  ceiling. The escape hatch is exactly what `--max-*` on resume raises.
+- **The merged ask is persisted onto the run doc.** So a subsequent
+  unattended auto-retry (usage-window sweeper) keeps the raised cap
+  instead of reverting to the launch ask that already killed the run.
+  A run resumed with `--max-cost-usd 120` retries at $120, not at the
+  launch's $10.
 
-Both the source-swap trick (`{"source": "<the workflow text with a
-larger cap>", "force": true}`) and the `--max-*` flags reach the same
-`resolveResumeBudgetAsk` choke point in `cloudpublisher.SubmitResume` —
-the two are equivalent recoveries, use whichever is closer to hand.
+The `--max-*` flags are the recommended path. The historical
+"source-swap" recovery (POST `{"source": "<the .bot with a larger
+cap>", "force": true}`) is NOT equivalent: it edits `wf.Budget` before
+compile, and `resolveResumeBudgetAsk` then still merges the persisted
+launch ask over top — on a run whose launch ask carried an explicit
+cap the swap is overridden and the run dies at the persisted cap.
+Prefer the flags; the swap is retained as a last-resort escape for the
+case where no launch ask was ever recorded.
 
 ## Rewind: resume from an *earlier* node
 

--- a/docs/resume.md
+++ b/docs/resume.md
@@ -166,14 +166,35 @@ When raising a budget, choose a cap above the amount already consumed. Merely
 repeating the old cap causes the re-executed node to hit the same guard.
 
 **Cloud runs.** `POST /api/runs/{id}/resume` (and `iterion remote runs
-resume`) carries **no budget-override fields**: a run that died on a cap
-cannot be re-budgeted from the resume request. The consumed accounting rides
-the checkpoint, so a bare resume of a duration death restarts and dies again
-at the exit-grace ceiling. The working escape hatch is the source itself —
-resume with `{"source": "<the workflow text with a larger cap>", "force":
-true}`: the checkpoint restarts at the failed node with the new caps, the run
-record keeps showing the launch-time budget (a snapshot). A cloud twin of the
-CLI overrides is tracked as SocialGouv/iterion#652.
+resume`) accepts the same budget-override flags as the local CLI —
+`--max-cost-usd`, `--max-tokens`, `--max-duration`, `--max-iterations`,
+`--max-parallel-branches`. The wire body carries them as
+`{"budget": {"max_duration": "4h", ...}}`; a non-zero field beats the
+launch ask persisted on the run doc for THIS resume publication (a zero
+field inherits). Without an override the resume replays from the run
+doc as before.
+
+Two mechanics matter when raising a cap here:
+
+- **The consumed accounting travels across resume.** The checkpoint
+  restores `budget_elapsed_ns`, `budget_cost_usd`, `budget_tokens` and
+  `budget_iterations` on every axis, so a resume with no override
+  restarts against the same clock that killed it. Measure: a run
+  parked on a 2h30m duration cap (elapsed = 9902 s) resumed bare walks
+  another 5 min and dies at 9901.6 s + 10% = the exit-grace ceiling.
+  The escape hatch is exactly what `--max-*` on resume raises.
+- **The cap raised on THIS resume rides the RunMessage only.** It does
+  NOT overwrite the launch ask on the run doc, so a subsequent
+  unattended auto-retry (usage-window sweeper) reverts to the launch
+  value. The pattern is therefore "operator raises cap on the manual
+  resume that unblocks the run; the run completes, and the launch ask
+  goes back to being the reference for future retries". Persisting a
+  cap-raise across attempts is a separate follow-up.
+
+Both the source-swap trick (`{"source": "<the workflow text with a
+larger cap>", "force": true}`) and the `--max-*` flags reach the same
+`resolveResumeBudgetAsk` choke point in `cloudpublisher.SubmitResume` —
+the two are equivalent recoveries, use whichever is closer to hand.
 
 ## Rewind: resume from an *earlier* node
 

--- a/pkg/cli/remote_runs.go
+++ b/pkg/cli/remote_runs.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 )
 
 // remoteRunSummary mirrors runview.RunSummary's CLI-visible fields.
@@ -545,6 +547,19 @@ func RemoteRunsResume(ctx context.Context, c *RemoteClient, p *Printer, id strin
 		req["timeout"] = opts.Timeout
 	}
 	if budget := resumeBudgetBody(opts); budget != nil {
+		// E3 (#652 review round 1): validate client-side so a typo
+		// (--max-duration "4 hours") fails immediately with an
+		// actionable message, before the round trip. The server
+		// re-validates as the authoritative gate.
+		if err := (ir.BudgetOverrides{
+			MaxCostUSD:          opts.MaxCostUSD,
+			MaxTokens:           opts.MaxTokens,
+			MaxDuration:         opts.MaxDuration,
+			MaxIterations:       opts.MaxIterations,
+			MaxParallelBranches: opts.MaxParallelBranches,
+		}).Validate(); err != nil {
+			return fmt.Errorf("invalid budget: %w", err)
+		}
 		req["budget"] = budget
 	}
 	return RemoteRunsAction(ctx, c, p, id, "resume", req)

--- a/pkg/cli/remote_runs.go
+++ b/pkg/cli/remote_runs.go
@@ -506,6 +506,15 @@ type RemoteRunsResumeOptions struct {
 	FilePath    string // optionally push a modified workflow
 	Force       bool
 	Timeout     string
+	// Budget overrides: non-zero fields beat the run doc's persisted
+	// launch ask on THIS resume — the "raise the cap + resume"
+	// recovery the local CLI has (`iterion resume --max-*`), extended
+	// to the remote path per #652 part 2. Zero fields inherit.
+	MaxCostUSD          float64
+	MaxTokens           int
+	MaxDuration         string
+	MaxIterations       int
+	MaxParallelBranches int
 }
 
 func RemoteRunsResume(ctx context.Context, c *RemoteClient, p *Printer, id string, opts RemoteRunsResumeOptions) error {
@@ -535,7 +544,37 @@ func RemoteRunsResume(ctx context.Context, c *RemoteClient, p *Printer, id strin
 	if opts.Timeout != "" {
 		req["timeout"] = opts.Timeout
 	}
+	if budget := resumeBudgetBody(opts); budget != nil {
+		req["budget"] = budget
+	}
 	return RemoteRunsAction(ctx, c, p, id, "resume", req)
+}
+
+// resumeBudgetBody projects the non-zero budget fields onto the wire
+// object, or returns nil when every field is zero so an ask-less resume
+// stays byte-identical to the pre-#652 payload (older servers ignore
+// the unknown "budget" field, but a nil is cleaner).
+func resumeBudgetBody(opts RemoteRunsResumeOptions) map[string]any {
+	body := map[string]any{}
+	if opts.MaxCostUSD > 0 {
+		body["max_cost_usd"] = opts.MaxCostUSD
+	}
+	if opts.MaxTokens > 0 {
+		body["max_tokens"] = opts.MaxTokens
+	}
+	if opts.MaxDuration != "" {
+		body["max_duration"] = opts.MaxDuration
+	}
+	if opts.MaxIterations > 0 {
+		body["max_iterations"] = opts.MaxIterations
+	}
+	if opts.MaxParallelBranches > 0 {
+		body["max_parallel_branches"] = opts.MaxParallelBranches
+	}
+	if len(body) == 0 {
+		return nil
+	}
+	return body
 }
 
 func RemoteRunsDelete(ctx context.Context, c *RemoteClient, p *Printer, id string) error {

--- a/pkg/cli/remote_runs_resume_test.go
+++ b/pkg/cli/remote_runs_resume_test.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// E3 (#652 review round 1): the remote CLI must validate the budget
+// override client-side so a typo (`--max-duration "4 hours"`) fails
+// immediately with an actionable message, before the round trip.
+// The server re-validates as the authoritative gate; the client-side
+// check is the fast-fail so an operator doesn't wait on a wire error.
+func TestRemoteRunsResume_RejectsMalformedBudgetDuration(t *testing.T) {
+	// Empty RemoteClient — the validate step short-circuits before any
+	// network I/O, so the client's URL/token/etc are irrelevant here.
+	err := RemoteRunsResume(context.Background(), &RemoteClient{}, &Printer{}, "run-1", RemoteRunsResumeOptions{
+		MaxDuration: "4 hours", // typo — must be "4h"
+	})
+	if err == nil {
+		t.Fatal("RemoteRunsResume accepted a malformed max_duration; the operator would wait on the round-trip error")
+	}
+	if !strings.Contains(err.Error(), "budget") || !strings.Contains(err.Error(), "max_duration") {
+		t.Fatalf("error = %v, want it to name the budget field and max_duration", err)
+	}
+}

--- a/pkg/cli/resume.go
+++ b/pkg/cli/resume.go
@@ -243,10 +243,27 @@ func RunResumeWithFile(ctx context.Context, iterFile string, opts ResumeOptions,
 	// CLI budget overrides — applied before buildResumeExecutor (which
 	// snapshots Budget), same seam as the run path. Lets an operator raise
 	// a cap and resume a budget-exceeded run without editing the .bot.
+	// The ask persisted on the run doc replays FIRST (an ask-less resume
+	// keeps the cap the run was launched with, never the .bot's own), the
+	// flags merge over it per field; a raise is persisted back so the
+	// next resume — and the doc's own snapshot — carry it. The detached
+	// studio resume reaches this same line through its subprocess.
 	if err := opts.Budget.Validate(); err != nil {
 		return UserInputError(err)
 	}
-	applyBudgetOverrides(wf, opts.Budget)
+	if merged := runtime.MergeResumeBudgetAsk(&opts.Budget, r.BudgetOverrides); merged != nil {
+		applyBudgetOverrides(wf, *merged)
+		if !opts.Budget.IsZero() {
+			if perr := s.SetRunBudgetOverrides(ctx, r.ID, runtime.RunBudgetOverridesOf(merged)); perr != nil {
+				logger.Warn("resume: persist merged budget ask on %s: %v", r.ID, perr)
+			}
+			if snap := runtime.SnapshotBudgetForPersist(wf.Budget); snap != nil {
+				if serr := s.SetRunBudgetSnapshot(ctx, r.ID, snap); serr != nil {
+					logger.Warn("resume: refresh budget snapshot on %s: %v", r.ID, serr)
+				}
+			}
+		}
+	}
 
 	// DSL-declared supervisors resume with the run: the resumed stretch is
 	// the same campaign the supervisor was declared to watch. Same wiring

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -260,6 +260,12 @@ func RunRun(ctx context.Context, opts RunOptions, p *Printer) error {
 		return UserInputError(err)
 	}
 	applyBudgetOverrides(wf, opts.Budget)
+	// The raw ask is persisted on the run doc (Run.BudgetOverrides) as the
+	// resume path's replay source — an ask-less `iterion resume` keeps the
+	// cap this launch asked for instead of the .bot's own. The detached
+	// studio launch reaches this same line through its `iterion run`
+	// subprocess, so one option covers both.
+	engineOpts = append(engineOpts, runtime.WithBudgetAsk(&opts.Budget))
 
 	runName := store.GenerateRunName(iterFile + ":" + runID)
 	storeDir := runStoreDir(iterFile, opts.StoreDir)

--- a/pkg/dispatcher/stuckcard_test.go
+++ b/pkg/dispatcher/stuckcard_test.go
@@ -38,6 +38,10 @@ func TestDecideStuckCard(t *testing.T) {
 		{"retry armed is platform-owned", run(store.RunStatusFailedResumable, func(r *store.Run) {
 			r.ContinuationState = store.ContinuationRetryArmed
 		}), nil, StuckKeep},
+		{"an orphan adopted by a delivery is platform-owned", run(store.RunStatusFailedResumable, func(r *store.Run) {
+			r.FailureCode = store.FailureProcessOrphaned
+			r.ContinuationState = store.ContinuationRedeliveryPending
+		}), nil, StuckKeep},
 		{"finished completes the card", run(store.RunStatusFinished), nil, StuckComplete},
 		{"terminal failure files the card", run(store.RunStatusFailed), nil, StuckFail},
 		{"resumable goes back to the retry machinery", run(store.RunStatusFailedResumable), nil, StuckRepark},
@@ -97,5 +101,20 @@ func TestDecideStuckCard_CardContext(t *testing.T) {
 	if got := DecideStuckCard(nil, nil, stale); got.Action != StuckReleaseOnly {
 		t.Fatalf("no run + running card past the stamp window = %s (%s), want release — "+
 			"a held card is invisible to the dispatch poll", got.Action, got.Reason)
+	}
+}
+
+// The exact doc the runner's under-lock adoption writes — failed_resumable,
+// PROCESS_ORPHANED, redelivery_pending — is about to be resumed by the very
+// delivery that wrote it. The pre-transfer decision must keep the card:
+// a transfer would re-park it into a duplicate run on cloud.
+func TestDecideTransfer_KeepsAnAdoptedOrphan(t *testing.T) {
+	adopted := &store.Run{
+		ID: "r1", Status: store.RunStatusFailedResumable,
+		FailureCode: store.FailureProcessOrphaned, ContinuationState: store.ContinuationRedeliveryPending,
+	}
+	got := DecideTransfer(adopted, nil, StuckCard{State: "in_progress", RunningState: "in_progress", LaunchStates: []string{"ready"}})
+	if got.Action != StuckKeep {
+		t.Fatalf("action = %s (%s), want keep — the platform owns this run's next seconds", got.Action, got.Reason)
 	}
 }

--- a/pkg/dsl/ir/budget_override.go
+++ b/pkg/dsl/ir/budget_override.go
@@ -28,10 +28,14 @@ type BudgetOverrides struct {
 	CapImposed bool
 }
 
-// IsZero reports whether no override was supplied.
+// IsZero reports whether no override was supplied. CapImposed alone is
+// not an override: it marks a clamp that already lowered a cap, so it
+// only ever travels next to that cap — a value carrying nothing but the
+// marker has nothing to apply, nothing to put on the wire and nothing to
+// persist (it used to persist as an empty `budget_overrides: {}`).
 func (o BudgetOverrides) IsZero() bool {
 	return o.MaxCostUSD <= 0 && o.MaxTokens <= 0 && o.MaxDuration == "" &&
-		o.MaxIterations <= 0 && o.MaxParallelBranches <= 0 && !o.CapImposed
+		o.MaxIterations <= 0 && o.MaxParallelBranches <= 0
 }
 
 // Validate rejects a malformed MaxDuration early with an actionable

--- a/pkg/dsl/ir/budget_override_test.go
+++ b/pkg/dsl/ir/budget_override_test.go
@@ -97,4 +97,12 @@ func TestBudgetOverridesIsZero(t *testing.T) {
 	if (BudgetOverrides{MaxCostUSD: 1}).IsZero() {
 		t.Fatal("non-empty BudgetOverrides should not be zero")
 	}
+	// The imposed-cap marker alone carries no cap: nothing to apply, put
+	// on the wire, or persist (it used to persist as an empty object).
+	if !(BudgetOverrides{CapImposed: true}).IsZero() {
+		t.Fatal("CapImposed-only BudgetOverrides should be zero — the marker never travels without the cap it marks")
+	}
+	if !(BudgetOverrides{MaxCostUSD: 5, CapImposed: true}).IsZero() == false {
+		t.Fatal("a clamped cap with its marker should not be zero")
+	}
 }

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -2146,14 +2146,7 @@ func applyBudgetOverrides(wf *ir.Workflow, b *queue.BudgetOverrides, logger *ite
 	if wf == nil || b == nil {
 		return nil
 	}
-	o := ir.BudgetOverrides{
-		MaxCostUSD:          b.MaxCostUSD,
-		MaxTokens:           b.MaxTokens,
-		MaxDuration:         b.MaxDuration,
-		MaxIterations:       b.MaxIterations,
-		MaxParallelBranches: b.MaxParallelBranches,
-		CapImposed:          b.CapImposed,
-	}
+	o := *runtime.BudgetOverridesFromWire(b)
 	if o.IsZero() {
 		return nil
 	}

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -81,7 +81,18 @@ func logDeliveryErr(logger *iterlog.Logger, op, runID string, err error) {
 // delivery.Ack())` recurs on every ack-and-return path in processOne;
 // this helper is the single point that pairs the action with its
 // breadcrumb.
-func ackTerminal(logger *iterlog.Logger, delivery *natsq.Delivery, op, runID string) {
+// jsDelivery is the slice of *natsq.Delivery the admission, lock and
+// terminal-dispatch helpers touch — an interface so those decisions are
+// unit-testable without a JetStream message.
+type jsDelivery interface {
+	Ack() error
+	Nak() error
+	NakWithDelay(delay time.Duration) error
+	Term() error
+	NumDelivered() int
+}
+
+func ackTerminal(logger *iterlog.Logger, delivery jsDelivery, op, runID string) {
 	logDeliveryErr(logger, op, runID, delivery.Ack())
 }
 
@@ -89,7 +100,7 @@ func ackTerminal(logger *iterlog.Logger, delivery *natsq.Delivery, op, runID str
 // logDeliveryErr. Use for transient failures where JetStream
 // redelivery is the safety net (lock held, store transient, heartbeat
 // loss, generic engine failure).
-func nakTerminal(logger *iterlog.Logger, delivery *natsq.Delivery, op, runID string) {
+func nakTerminal(logger *iterlog.Logger, delivery jsDelivery, op, runID string) {
 	logDeliveryErr(logger, op, runID, delivery.Nak())
 }
 
@@ -97,7 +108,7 @@ func nakTerminal(logger *iterlog.Logger, delivery *natsq.Delivery, op, runID str
 // logDeliveryErr. Use for poisoned/forged messages whose redelivery
 // would loop forever (decode failure, run-not-found, tenant
 // mismatch, DLQ-parked).
-func termTerminal(logger *iterlog.Logger, delivery *natsq.Delivery, op, runID string) {
+func termTerminal(logger *iterlog.Logger, delivery jsDelivery, op, runID string) {
 	logDeliveryErr(logger, op, runID, delivery.Term())
 }
 
@@ -109,6 +120,10 @@ const (
 	actionAck deliveryAction = iota
 	actionNak
 	actionTerm
+	// actionNakDelayed re-offers the delivery after preconditionOutcome.delay
+	// — the under-lock adoption's answer to a running doc younger than the
+	// staleness floor, so the remaining deliveries are not burnt inside it.
+	actionNakDelayed
 )
 
 // logLevel mirrors the three log channels processOne uses for its
@@ -133,6 +148,7 @@ type preconditionOutcome struct {
 	finalStatus string
 	op          string // for logDeliveryErr
 	action      deliveryAction
+	delay       time.Duration // actionNakDelayed only
 	level       logLevel
 	logFmt      string
 	logArgs     []any
@@ -164,6 +180,11 @@ type execOutcome struct {
 // logs outcome.{level,logFmt,logArgs} and invokes the corresponding
 // {ack,nak,term}Terminal with outcome.{op, finalStatus} on the
 // delivery before returning.
+//
+// It never WRITES the run: this runs before the per-run lock, and the
+// lock is the only liveness authority. A `running` doc proceeds as-is;
+// whether it is an orphan is decided under the lock
+// (adoptRunningUnderLock).
 //
 // Tenant validation is intentionally OUT of this helper: the failed-
 // Term log message for a tenant mismatch is a security-shaped alarm
@@ -209,15 +230,23 @@ func (r *Runner) resolveDeliveryPreconditions(msg *queue.RunMessage) preconditio
 			logArgs:     []any{msg.RunID, preErr},
 		}
 	}
-	// Redelivered launch messages can arrive after the first attempt
-	// already persisted resumable state (failed_resumable,
-	// paused_operator, or cancellation-with-checkpoint during shutdown).
-	// Re-running them through Engine.Run would be a poison loop because
-	// runResolveDoc refuses to restart non-queued statuses; convert the
-	// in-memory dispatch to Resume so JetStream redelivery actually uses
-	// the checkpoint it exists to protect. A pre-pickup user-cancelled run
-	// has no checkpoint and remains a stale delivery to ack/drop.
-	switch preRun.Status {
+	return dispositionForStatus(msg, preRun)
+}
+
+// dispositionForStatus is the status switch of the admission gauntlet,
+// shared by the pre-lock pass and by the under-lock re-read of a running
+// doc: the same status must mean the same thing wherever it is read.
+//
+// Redelivered launch messages can arrive after the first attempt
+// already persisted resumable state (failed_resumable,
+// paused_operator, or cancellation-with-checkpoint during shutdown).
+// Re-running them through Engine.Run would be a poison loop because
+// runResolveDoc refuses to restart non-queued statuses; convert the
+// in-memory dispatch to Resume so JetStream redelivery actually uses
+// the checkpoint it exists to protect. A pre-pickup user-cancelled run
+// has no checkpoint and remains a stale delivery to ack/drop.
+func dispositionForStatus(msg *queue.RunMessage, run *store.Run) preconditionOutcome {
+	switch run.Status {
 	case store.RunStatusCancelled:
 		// Cancelled is terminal for a REDELIVERED launch message,
 		// checkpoint or not: auto-resuming here turned any lost ack of
@@ -243,120 +272,183 @@ func (r *Runner) resolveDeliveryPreconditions(msg *queue.RunMessage) preconditio
 			msg.Resume = &queue.ResumeSpec{}
 			return preconditionOutcome{
 				proceed: true,
-				preRun:  preRun,
+				preRun:  run,
 				level:   logInfo,
 				logFmt:  "runner: run %s redelivered in status %s — resuming",
-				logArgs: []any{msg.RunID, preRun.Status},
+				logArgs: []any{msg.RunID, run.Status},
 			}
 		}
 	case store.RunStatusFinished, store.RunStatusFailed, store.RunStatusPausedWaitingHuman:
 		return preconditionOutcome{
-			finalStatus: string(preRun.Status),
+			finalStatus: string(run.Status),
 			op:          "ack-stale-status",
 			action:      actionAck,
 			level:       logInfo,
 			logFmt:      "runner: run %s already in status %s — dropping stale delivery",
-			logArgs:     []any{msg.RunID, preRun.Status},
-		}
-	case store.RunStatusRunning:
-		// A `running` document + no live NATS-KV lease is an orphaned
-		// run: the holder pod died before its terminal write. Without
-		// this case a redelivered resume message would hit Engine.Resume
-		// with `running`, throw `cannot resume run … with status
-		// "running"`, and burn every retry — up to eight in a couple of
-		// minutes — before the DLQ park. Observed live 2026-09-03 (#669
-		// part 2): seven redeliveries in two minutes, then DLQ_PARKED
-		// announced as a quota pause.
-		if adopted := r.adoptStaleRunning(msg, preRun); adopted != nil {
-			return *adopted
+			logArgs:     []any{msg.RunID, run.Status},
 		}
 	}
-	return preconditionOutcome{proceed: true, preRun: preRun}
+	// running (a live owner, or an orphan — told apart under the lock),
+	// queued (the publisher's pre-flip of this very attempt), and any
+	// status this switch does not know: proceed.
+	return preconditionOutcome{proceed: true, preRun: run}
 }
 
-// adoptStaleRunning promotes an orphaned `running` run to
-// `failed_resumable` and converts the delivery into a resume so the
-// checkpoint the doc still points at is honoured. Returns nil when the
-// lease is present (the run has a live owner — abstain and let the
-// existing per-run lock CAS handle the race), the lease check is not
-// wired, or the lease/CAS probe fails (the orphan sweeper's 60s tick
-// remains the reconciliation net). Never mutates preRun.Status on the
-// caller's copy — the CAS is the only truth.
-func (r *Runner) adoptStaleRunning(msg *queue.RunMessage, preRun *store.Run) *preconditionOutcome {
-	checker := r.resolveLeaseChecker()
-	if checker == nil {
-		return nil
+// runningAdoptionFloor is how old a `running` doc's last write must be
+// before a delivery that holds the run's lock may adopt it as an orphan.
+// The lock proves nobody holds the LEASE; it does not prove the previous
+// holder is gone. A pod whose lease lapsed while it was alive (a NATS
+// blip longer than the TTL, a GC pause) keeps writing from `running`
+// during its unwind, and its terminal write is unconditional — it would
+// land on top of the adopter's resumed run. Sized on that mechanism:
+//
+//	lease TTL (DefaultLockTTL)          60s   the lapse itself
+//	+ heartbeat tick (HeartbeatInterval) 20s   the pod notices at its next refresh
+//	+ unwind (sandbox export, bank)     120s   the interrupted engine's own exit
+//	+ margin                             40s
+//	= 4m
+//
+// A doc written more recently than that is re-offered after the
+// remainder (a delayed Nak) instead of burning a delivery. Not the
+// sweeper's 10m: that floor guards a lock-less probe against a run
+// between claim and first heartbeat; here the lock is held, and the
+// question is only how long a dead pod's last words can arrive late. The
+// floor is a heuristic, not a fence: a pod silent for longer than the
+// floor before losing its lease could still be unwinding.
+const runningAdoptionFloor = 4 * time.Minute
+
+// lockProvesLiveness reports whether a held run lock is a liveness
+// authority: the NATS-KV lease is (the queue sweeper and the k8s reaper
+// trust the same signal); the Mongo store's lock-less no-op is not, and
+// under it an orphan cannot be told from a live owner — the admission
+// then leaves the status to the engine, as it always did.
+func (r *Runner) lockProvesLiveness() bool {
+	return r.cfg.NATS != nil || r.lockLivenessOverride
+}
+
+// maxDeliver is the queue's redelivery budget for the promote log line,
+// 0 when no queue is wired.
+func (r *Runner) maxDeliver() int {
+	if r.cfg.NATS == nil {
+		return 0
 	}
-	leaseCtx, leaseCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer leaseCancel()
-	locked, lerr := checker.IsRunLocked(leaseCtx, msg.RunID)
-	if lerr != nil {
-		// Lease unknown — fail safe: the sweeper's periodic probe will
-		// notice the same orphan later. A single warn per attempt so a
-		// persistent probe outage is visible.
-		return &preconditionOutcome{
+	return r.cfg.NATS.MaxDeliver()
+}
+
+// adoptRunningUnderLock decides what to do with a doc the pre-lock pass
+// read as `running`, now that this delivery holds the run's lock: nobody
+// holds the lease, so either the holder pod died before its terminal
+// write (an orphan — #669 part 2: seven redeliveries in two minutes each
+// refused on `cannot resume run … with status "running"`, then a DLQ
+// park) or it lapsed while alive and is still unwinding. The doc is
+// re-read under the lock (the pre-lock copy is stale by construction),
+// a status a peer moved meanwhile takes the ordinary disposition, a
+// young `running` doc is re-offered after the floor's remainder, and an
+// old one is promoted to failed_resumable — the continuation is
+// redelivery_pending, because THIS delivery resumes it next: a `final`
+// marker would let the board dispatcher block its card, the stuck-card
+// watchdog re-park it into a duplicate run and the outcome router route
+// it, all inside the seconds before the resume claims it. The delivery
+// is converted into a resume so the checkpoint is honoured.
+func (r *Runner) adoptRunningUnderLock(msg *queue.RunMessage, preRun *store.Run, delivery jsDelivery, now time.Time) preconditionOutcome {
+	if !r.lockProvesLiveness() {
+		return preconditionOutcome{
 			proceed: true,
 			preRun:  preRun,
-			level:   logWarn,
-			logFmt:  "runner: run %s in status running: lease probe failed (%v) — falling through to admission; the sweeper is the reconciliation net",
-			logArgs: []any{msg.RunID, lerr},
+			level:   logInfo,
+			logFmt:  "runner: run %s reads running with no lease authority wired — an orphan cannot be told from a live owner, leaving the status to the engine",
+			logArgs: []any{msg.RunID},
 		}
 	}
-	if locked {
-		// Live owner — this delivery is racing an actual in-flight run;
-		// the per-run lock in processOne is the authoritative gate.
-		return nil
+	loadCtx, loadCancel := context.WithTimeout(
+		store.WithIdentity(context.Background(), msg.TenantID, msg.OwnerID),
+		5*time.Second)
+	run, err := r.cfg.Store.LoadRun(loadCtx, msg.RunID)
+	loadCancel()
+	if err != nil || run == nil {
+		// The lock is released on the way out; a redelivery re-reads.
+		return preconditionOutcome{
+			finalStatus: "store_load_transient",
+			op:          "nak-store-load-transient",
+			action:      actionNak,
+			level:       logWarn,
+			logFmt:      "runner: run %s: re-read under the lock failed (%v) — naking",
+			logArgs:     []any{msg.RunID, err},
+		}
 	}
-	// Orphan: CAS to failed_resumable and hand the delivery back as a
-	// resume so JetStream redelivery uses the checkpoint the run doc
-	// preserved. UpdateRunOutcome is a CAS on the expected status set,
-	// so a peer that raced us to the same conclusion loses without
-	// harm. Detach the write ctx: the caller has a very short LoadRun
-	// budget above and Shutdown may be firing.
+	if run.Status != store.RunStatusRunning {
+		// A peer moved it between our two reads (its own terminal write
+		// landing late, the sweeper, an operator): the ordinary
+		// disposition applies to what the doc says now.
+		return dispositionForStatus(msg, run)
+	}
+	age := runningAdoptionFloor
+	if !run.UpdatedAt.IsZero() {
+		age = now.Sub(run.UpdatedAt)
+	}
+	delivered, maxDeliver := delivery.NumDelivered(), r.maxDeliver()
+	if age < runningAdoptionFloor {
+		remaining := runningAdoptionFloor - age
+		return preconditionOutcome{
+			finalStatus: "running_young",
+			op:          "nak-running-young",
+			action:      actionNakDelayed,
+			delay:       remaining,
+			level:       logWarn,
+			logFmt:      "runner: run %s reads running under our lock but its doc was written %s ago (< %s adoption floor — a lapsed-but-alive pod may still be unwinding); delivery %d/%d re-offered in %s",
+			logArgs:     []any{msg.RunID, age.Round(time.Second), runningAdoptionFloor, delivered, maxDeliver, remaining.Round(time.Second)},
+		}
+	}
 	casCtx, casCancel := context.WithTimeout(
 		store.WithIdentity(context.Background(), msg.TenantID, msg.OwnerID),
 		5*time.Second)
 	defer casCancel()
 	changed, cerr := r.cfg.Store.UpdateRunOutcome(casCtx, msg.RunID,
 		store.RunStatusFailedResumable,
-		"promoted from running: NATS-KV lease absent, holder pod is gone (admission-time orphan)",
-		store.RunOutcomeMeta{Code: store.FailureProcessOrphaned, Continuation: store.ContinuationFinal},
+		fmt.Sprintf("promoted from running under the delivery's lock: no lease holder, last doc write %s ago (admission-time orphan)", age.Round(time.Second)),
+		store.RunOutcomeMeta{Code: store.FailureProcessOrphaned, Continuation: store.ContinuationRedeliveryPending},
 		[]store.RunStatus{store.RunStatusRunning})
 	if cerr != nil {
-		// The CAS write itself failed (store outage, etc.). Fall
-		// through: an unmodified `running` doc still lets Engine.Resume
-		// hit the "cannot resume" error, which redelivery retries — the
-		// old behaviour, no regression, and the failure is loud.
-		return &preconditionOutcome{
+		// The CAS itself failed (store outage). Fall through unchanged:
+		// the engine refuses a running doc, the delivery naks, the next
+		// one re-decides — loud, and no worse than before.
+		return preconditionOutcome{
 			proceed: true,
-			preRun:  preRun,
+			preRun:  run,
 			level:   logWarn,
-			logFmt:  "runner: run %s stale-running orphan CAS failed (%v) — falling through to admission",
+			logFmt:  "runner: run %s: stale-running promote CAS failed (%v) — falling through to the engine",
 			logArgs: []any{msg.RunID, cerr},
 		}
 	}
 	if !changed {
-		// A peer already promoted it (status drifted off `running`
-		// between our LoadRun and CAS). Fall through: the current
-		// status may already be a resumable one the switch above would
-		// have handled; the next admission will see the new status.
-		return &preconditionOutcome{
-			proceed: true,
-			preRun:  preRun,
-			level:   logInfo,
-			logFmt:  "runner: run %s stale-running status drifted before promote — deferring to next admission",
-			logArgs: []any{msg.RunID},
+		// Moved between the re-read and the CAS: read once more and take
+		// what the doc says now.
+		reCtx, reCancel := context.WithTimeout(
+			store.WithIdentity(context.Background(), msg.TenantID, msg.OwnerID),
+			5*time.Second)
+		moved, merr := r.cfg.Store.LoadRun(reCtx, msg.RunID)
+		reCancel()
+		if merr != nil || moved == nil {
+			return preconditionOutcome{
+				finalStatus: "store_load_transient",
+				op:          "nak-store-load-transient",
+				action:      actionNak,
+				level:       logWarn,
+				logFmt:      "runner: run %s: re-read after a declined promote failed (%v) — naking",
+				logArgs:     []any{msg.RunID, merr},
+			}
 		}
+		return dispositionForStatus(msg, moved)
 	}
 	if msg.Resume == nil {
 		msg.Resume = &queue.ResumeSpec{}
 	}
-	return &preconditionOutcome{
+	return preconditionOutcome{
 		proceed: true,
-		preRun:  preRun,
+		preRun:  run,
 		level:   logWarn,
-		logFmt:  "runner: run %s promoted from stale running (no live lease) — resuming (#669 part 2)",
-		logArgs: []any{msg.RunID},
+		logFmt:  "runner: run %s adopted from stale running (lock acquired, no lease holder; prior status running, last doc write %s ago; delivery %d/%d) — resuming from its checkpoint",
+		logArgs: []any{msg.RunID, age.Round(time.Second), delivered, maxDeliver},
 	}
 }
 
@@ -643,7 +735,7 @@ func logAt(logger *iterlog.Logger, level logLevel, format string, args ...any) {
 
 // dispatchTerminal performs the JetStream state transition selected
 // by `action` and surfaces any error via logDeliveryErr.
-func dispatchTerminal(logger *iterlog.Logger, delivery *natsq.Delivery, action deliveryAction, op, runID string) {
+func dispatchTerminal(logger *iterlog.Logger, delivery jsDelivery, action deliveryAction, op, runID string) {
 	switch action {
 	case actionAck:
 		ackTerminal(logger, delivery, op, runID)
@@ -652,6 +744,16 @@ func dispatchTerminal(logger *iterlog.Logger, delivery *natsq.Delivery, action d
 	case actionTerm:
 		termTerminal(logger, delivery, op, runID)
 	}
+}
+
+// dispatchPrecondition dispatches an admission outcome, including the
+// delayed Nak the under-lock adoption uses to wait out its floor.
+func dispatchPrecondition(logger *iterlog.Logger, delivery jsDelivery, out preconditionOutcome, runID string) {
+	if out.action == actionNakDelayed {
+		logDeliveryErr(logger, out.op, runID, delivery.NakWithDelay(out.delay))
+		return
+	}
+	dispatchTerminal(logger, delivery, out.action, out.op, runID)
 }
 
 // Config is the runner bootstrap.
@@ -855,25 +957,10 @@ type Runner struct {
 	sandboxRunsMu sync.Mutex
 	sandboxRuns   map[string]sandbox.Run
 
-	// leaseCheckOverride replaces the r.cfg.NATS lease probe in unit
-	// tests exercising the admission path without a live queue.
-	// Nil in production; the runner uses r.cfg.NATS then.
-	leaseCheckOverride runLeaseChecker
-}
-
-// resolveLeaseChecker returns whatever probe is currently wired for the
-// admission path's orphan check. Nil when no queue is wired (local mode,
-// tests without an override), which keeps the admission behaviour
-// backwards-compatible: fall through to the existing "cannot resume"
-// failure loop rather than promote a run under an untestable premise.
-func (r *Runner) resolveLeaseChecker() runLeaseChecker {
-	if r.leaseCheckOverride != nil {
-		return r.leaseCheckOverride
-	}
-	if r.cfg.NATS == nil {
-		return nil
-	}
-	return r.cfg.NATS
+	// lockLivenessOverride declares, in unit tests without a queue, that
+	// the store's run lock is a liveness authority (the filesystem flock
+	// is one). False in production; the runner reads r.cfg.NATS then.
+	lockLivenessOverride bool
 }
 
 type inFlight struct {
@@ -1253,7 +1340,7 @@ func (r *Runner) processOne(parent context.Context, delivery *natsq.Delivery) {
 	logAt(logger, pre.level, pre.logFmt, pre.logArgs...)
 	if !pre.proceed {
 		finalStatus = pre.finalStatus
-		dispatchTerminal(logger, delivery, pre.action, pre.op, msg.RunID)
+		dispatchPrecondition(logger, delivery, pre, msg.RunID)
 		return
 	}
 
@@ -1277,6 +1364,20 @@ func (r *Runner) processOne(parent context.Context, delivery *natsq.Delivery) {
 			logger.Warn("runner: lock release for %s: %v", msg.RunID, err)
 		}
 	}()
+
+	// A doc still `running` now that we hold its lock has no live lease
+	// holder: an orphan to adopt, or a lapsed-but-alive pod still
+	// unwinding — decided under the lock, never before it. A deferred
+	// answer releases the lock on the way out.
+	if pre.preRun.Status == store.RunStatusRunning {
+		adopt := r.adoptRunningUnderLock(msg, pre.preRun, delivery, time.Now().UTC())
+		logAt(logger, adopt.level, adopt.logFmt, adopt.logArgs...)
+		if !adopt.proceed {
+			finalStatus = adopt.finalStatus
+			dispatchPrecondition(logger, delivery, adopt, msg.RunID)
+			return
+		}
+	}
 
 	// Heartbeat goroutine: refresh the NATS lease while we own it. On
 	// refresh failure it cancels runCtx WITH the interrupted cause so the

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -258,8 +258,106 @@ func (r *Runner) resolveDeliveryPreconditions(msg *queue.RunMessage) preconditio
 			logFmt:      "runner: run %s already in status %s — dropping stale delivery",
 			logArgs:     []any{msg.RunID, preRun.Status},
 		}
+	case store.RunStatusRunning:
+		// A `running` document + no live NATS-KV lease is an orphaned
+		// run: the holder pod died before its terminal write. Without
+		// this case a redelivered resume message would hit Engine.Resume
+		// with `running`, throw `cannot resume run … with status
+		// "running"`, and burn every retry — up to eight in a couple of
+		// minutes — before the DLQ park. Observed live 2026-09-03 (#669
+		// part 2): seven redeliveries in two minutes, then DLQ_PARKED
+		// announced as a quota pause.
+		if adopted := r.adoptStaleRunning(msg, preRun); adopted != nil {
+			return *adopted
+		}
 	}
 	return preconditionOutcome{proceed: true, preRun: preRun}
+}
+
+// adoptStaleRunning promotes an orphaned `running` run to
+// `failed_resumable` and converts the delivery into a resume so the
+// checkpoint the doc still points at is honoured. Returns nil when the
+// lease is present (the run has a live owner — abstain and let the
+// existing per-run lock CAS handle the race), the lease check is not
+// wired, or the lease/CAS probe fails (the orphan sweeper's 60s tick
+// remains the reconciliation net). Never mutates preRun.Status on the
+// caller's copy — the CAS is the only truth.
+func (r *Runner) adoptStaleRunning(msg *queue.RunMessage, preRun *store.Run) *preconditionOutcome {
+	checker := r.resolveLeaseChecker()
+	if checker == nil {
+		return nil
+	}
+	leaseCtx, leaseCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer leaseCancel()
+	locked, lerr := checker.IsRunLocked(leaseCtx, msg.RunID)
+	if lerr != nil {
+		// Lease unknown — fail safe: the sweeper's periodic probe will
+		// notice the same orphan later. A single warn per attempt so a
+		// persistent probe outage is visible.
+		return &preconditionOutcome{
+			proceed: true,
+			preRun:  preRun,
+			level:   logWarn,
+			logFmt:  "runner: run %s in status running: lease probe failed (%v) — falling through to admission; the sweeper is the reconciliation net",
+			logArgs: []any{msg.RunID, lerr},
+		}
+	}
+	if locked {
+		// Live owner — this delivery is racing an actual in-flight run;
+		// the per-run lock in processOne is the authoritative gate.
+		return nil
+	}
+	// Orphan: CAS to failed_resumable and hand the delivery back as a
+	// resume so JetStream redelivery uses the checkpoint the run doc
+	// preserved. UpdateRunOutcome is a CAS on the expected status set,
+	// so a peer that raced us to the same conclusion loses without
+	// harm. Detach the write ctx: the caller has a very short LoadRun
+	// budget above and Shutdown may be firing.
+	casCtx, casCancel := context.WithTimeout(
+		store.WithIdentity(context.Background(), msg.TenantID, msg.OwnerID),
+		5*time.Second)
+	defer casCancel()
+	changed, cerr := r.cfg.Store.UpdateRunOutcome(casCtx, msg.RunID,
+		store.RunStatusFailedResumable,
+		"promoted from running: NATS-KV lease absent, holder pod is gone (admission-time orphan)",
+		store.RunOutcomeMeta{Code: store.FailureProcessOrphaned, Continuation: store.ContinuationFinal},
+		[]store.RunStatus{store.RunStatusRunning})
+	if cerr != nil {
+		// The CAS write itself failed (store outage, etc.). Fall
+		// through: an unmodified `running` doc still lets Engine.Resume
+		// hit the "cannot resume" error, which redelivery retries — the
+		// old behaviour, no regression, and the failure is loud.
+		return &preconditionOutcome{
+			proceed: true,
+			preRun:  preRun,
+			level:   logWarn,
+			logFmt:  "runner: run %s stale-running orphan CAS failed (%v) — falling through to admission",
+			logArgs: []any{msg.RunID, cerr},
+		}
+	}
+	if !changed {
+		// A peer already promoted it (status drifted off `running`
+		// between our LoadRun and CAS). Fall through: the current
+		// status may already be a resumable one the switch above would
+		// have handled; the next admission will see the new status.
+		return &preconditionOutcome{
+			proceed: true,
+			preRun:  preRun,
+			level:   logInfo,
+			logFmt:  "runner: run %s stale-running status drifted before promote — deferring to next admission",
+			logArgs: []any{msg.RunID},
+		}
+	}
+	if msg.Resume == nil {
+		msg.Resume = &queue.ResumeSpec{}
+	}
+	return &preconditionOutcome{
+		proceed: true,
+		preRun:  preRun,
+		level:   logWarn,
+		logFmt:  "runner: run %s promoted from stale running (no live lease) — resuming (#669 part 2)",
+		logArgs: []any{msg.RunID},
+	}
 }
 
 // classifyExecResult turns engine.Run's (success-or-error) outcome
@@ -738,6 +836,26 @@ type Runner struct {
 	// alone never reaches it. See sandbox_registry.go.
 	sandboxRunsMu sync.Mutex
 	sandboxRuns   map[string]sandbox.Run
+
+	// leaseCheckOverride replaces the r.cfg.NATS lease probe in unit
+	// tests exercising the admission path without a live queue.
+	// Nil in production; the runner uses r.cfg.NATS then.
+	leaseCheckOverride runLeaseChecker
+}
+
+// resolveLeaseChecker returns whatever probe is currently wired for the
+// admission path's orphan check. Nil when no queue is wired (local mode,
+// tests without an override), which keeps the admission behaviour
+// backwards-compatible: fall through to the existing "cannot resume"
+// failure loop rather than promote a run under an untestable premise.
+func (r *Runner) resolveLeaseChecker() runLeaseChecker {
+	if r.leaseCheckOverride != nil {
+		return r.leaseCheckOverride
+	}
+	if r.cfg.NATS == nil {
+		return nil
+	}
+	return r.cfg.NATS
 }
 
 type inFlight struct {

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -452,6 +452,24 @@ func classifyExecResult(execErr error, runID string) execOutcome {
 			logArgs:     []any{runID, execErr},
 		}
 	}
+	// A sandbox setup phase that hit its own bound (workspace copy / git
+	// fixup, sandbox.ErrPhaseTimeout): the engine wrote failed_resumable
+	// + SANDBOX_SETUP_TIMEOUT. Nak so a fresh pod retries — the stall is
+	// a transient infrastructure condition a healthy pod routinely
+	// clears. Deliberately NOT an interruption: the DLQ park on the last
+	// permitted delivery still applies, so a stall that repeats through
+	// every delivery ends parked and announced instead of naking into
+	// nothing.
+	if errors.Is(execErr, sandbox.ErrPhaseTimeout) {
+		return execOutcome{
+			finalStatus: "sandbox_setup_timeout",
+			op:          "nak-sandbox-setup-timeout",
+			action:      actionNak,
+			level:       logWarn,
+			logFmt:      "runner: run %s: sandbox setup phase timed out (resumable) — naking for a fresh pod (%v)",
+			logArgs:     []any{runID, execErr},
+		}
+	}
 	// Operator cancel: terminal cancelled, acked (redelivery drops it).
 	if errors.Is(execErr, runtime.ErrRunCancelled) {
 		return execOutcome{

--- a/pkg/runner/loop.go
+++ b/pkg/runner/loop.go
@@ -163,10 +163,29 @@ type execOutcome struct {
 	finalStatus string
 	op          string
 	action      deliveryAction
+	delay       time.Duration // actionNakDelayed only
 	level       logLevel
 	logFmt      string
 	logArgs     []any
 }
+
+// isNakAction reports whether a delivery action hands the message back to
+// JetStream for redelivery — immediately or after a delay. Every consumer
+// that reasons about "will this run come back on its own" (the pool lease
+// report, the continuation promote, the outcome side effects) must read
+// the two the same way: a delayed Nak is still a Nak.
+func isNakAction(a deliveryAction) bool {
+	return a == actionNak || a == actionNakDelayed
+}
+
+// sandboxSetupTimeoutNakDelay spaces the redeliveries of a run whose
+// sandbox setup phase timed out. The stall is infrastructure catching its
+// breath (a stuck kubectl-exec pipe, a rescheduled apiserver, a copy the
+// pod cannot finish in the phase budget); a bare Nak re-offers within
+// seconds, so a copy that ALWAYS stalls burns the whole delivery budget
+// as back-to-back pods (8 × the 15-minute phase budget ≈ 2 hours) before
+// the DLQ park, and nothing on the run's timeline says so in between.
+const sandboxSetupTimeoutNakDelay = 2 * time.Minute
 
 // resolveDeliveryPreconditions runs the pre-lock store gauntlet:
 // LoadRun (with its own short detached timeout context so a runner
@@ -326,11 +345,12 @@ func (r *Runner) lockProvesLiveness() bool {
 	return r.cfg.NATS != nil || r.lockLivenessOverride
 }
 
-// maxDeliver is the queue's redelivery budget for the promote log line,
-// 0 when no queue is wired.
+// maxDeliver is the queue's redelivery budget, 0 when no queue is wired
+// (a test may pin one through maxDeliverOverride, the way
+// lockLivenessOverride pins the lease authority).
 func (r *Runner) maxDeliver() int {
 	if r.cfg.NATS == nil {
-		return 0
+		return r.maxDeliverOverride
 	}
 	return r.cfg.NATS.MaxDeliver()
 }
@@ -389,6 +409,30 @@ func (r *Runner) adoptRunningUnderLock(msg *queue.RunMessage, preRun *store.Run,
 	delivered, maxDeliver := delivery.NumDelivered(), r.maxDeliver()
 	if age < runningAdoptionFloor {
 		remaining := runningAdoptionFloor - age
+		if maxDeliver > 0 && delivered >= maxDeliver {
+			// The LAST permitted delivery: JetStream will not re-offer it
+			// whatever we answer, so a delayed Nak here would claim a
+			// re-offer that never comes and leave the doc `running` with
+			// nothing saying who reconciles it. Nothing is written — the
+			// floor exists precisely because the previous holder may still
+			// be alive and about to write its own terminal status, and a
+			// DLQ park over a live writer would be clobbered or clobber it.
+			// The server's orphan sweeper owns this doc: once it crosses the
+			// sweeper's staleness floor with no lease, it is flipped to
+			// failed_resumable (PROCESS_ORPHANED, final), which every
+			// consumer that waits on a dead run — the gate reconciler
+			// foremost — already acts on. Term makes the queue's side
+			// explicit instead of letting the message age out on its
+			// ack-wait.
+			return preconditionOutcome{
+				finalStatus: "running_young_last_delivery",
+				op:          "term-running-young-last-delivery",
+				action:      actionTerm,
+				level:       logWarn,
+				logFmt:      "runner: run %s reads running under our lock but its doc was written %s ago (< %s adoption floor — a lapsed-but-alive pod may still be unwinding) and this is the LAST permitted delivery (%d/%d): JetStream will not re-offer it — terming; if the previous holder never writes its terminal status, the orphan sweeper flips the doc to failed_resumable once it crosses the sweeper's staleness floor",
+				logArgs:     []any{msg.RunID, age.Round(time.Second), runningAdoptionFloor, delivered, maxDeliver},
+			}
+		}
 		return preconditionOutcome{
 			finalStatus: "running_young",
 			op:          "nak-running-young",
@@ -546,8 +590,9 @@ func classifyExecResult(execErr error, runID string) execOutcome {
 	}
 	// A sandbox setup phase that hit its own bound (workspace copy / git
 	// fixup, sandbox.ErrPhaseTimeout): the engine wrote failed_resumable
-	// + SANDBOX_SETUP_TIMEOUT. Nak so a fresh pod retries — the stall is
-	// a transient infrastructure condition a healthy pod routinely
+	// + SANDBOX_SETUP_TIMEOUT. Nak — after sandboxSetupTimeoutNakDelay,
+	// not at once — so a fresh pod retries once the infrastructure has had
+	// a moment: the stall is a transient condition a healthy pod routinely
 	// clears. Deliberately NOT an interruption: the DLQ park on the last
 	// permitted delivery still applies, so a stall that repeats through
 	// every delivery ends parked and announced instead of naking into
@@ -556,10 +601,11 @@ func classifyExecResult(execErr error, runID string) execOutcome {
 		return execOutcome{
 			finalStatus: "sandbox_setup_timeout",
 			op:          "nak-sandbox-setup-timeout",
-			action:      actionNak,
+			action:      actionNakDelayed,
+			delay:       sandboxSetupTimeoutNakDelay,
 			level:       logWarn,
-			logFmt:      "runner: run %s: sandbox setup phase timed out (resumable) — naking for a fresh pod (%v)",
-			logArgs:     []any{runID, execErr},
+			logFmt:      "runner: run %s: sandbox setup phase timed out (resumable) — re-offered to a fresh pod in %s (%v)",
+			logArgs:     []any{runID, sandboxSetupTimeoutNakDelay, execErr},
 		}
 	}
 	// Operator cancel: terminal cancelled, acked (redelivery drops it).
@@ -749,11 +795,23 @@ func dispatchTerminal(logger *iterlog.Logger, delivery jsDelivery, action delive
 // dispatchPrecondition dispatches an admission outcome, including the
 // delayed Nak the under-lock adoption uses to wait out its floor.
 func dispatchPrecondition(logger *iterlog.Logger, delivery jsDelivery, out preconditionOutcome, runID string) {
-	if out.action == actionNakDelayed {
-		logDeliveryErr(logger, out.op, runID, delivery.NakWithDelay(out.delay))
+	dispatchDelivery(logger, delivery, out.action, out.delay, out.op, runID)
+}
+
+// dispatchExecOutcome dispatches an execution outcome, including the
+// delayed Nak a sandbox setup timeout is re-offered with.
+func dispatchExecOutcome(logger *iterlog.Logger, delivery jsDelivery, out execOutcome, runID string) {
+	dispatchDelivery(logger, delivery, out.action, out.delay, out.op, runID)
+}
+
+// dispatchDelivery is the one place a delayed Nak is turned into
+// NakWithDelay; every other action goes through dispatchTerminal.
+func dispatchDelivery(logger *iterlog.Logger, delivery jsDelivery, action deliveryAction, delay time.Duration, op, runID string) {
+	if action == actionNakDelayed {
+		logDeliveryErr(logger, op, runID, delivery.NakWithDelay(delay))
 		return
 	}
-	dispatchTerminal(logger, delivery, out.action, out.op, runID)
+	dispatchTerminal(logger, delivery, action, op, runID)
 }
 
 // Config is the runner bootstrap.
@@ -961,6 +1019,9 @@ type Runner struct {
 	// the store's run lock is a liveness authority (the filesystem flock
 	// is one). False in production; the runner reads r.cfg.NATS then.
 	lockLivenessOverride bool
+	// maxDeliverOverride pins the redelivery budget in unit tests without
+	// a queue. 0 in production; the runner reads r.cfg.NATS then.
+	maxDeliverOverride int
 }
 
 type inFlight struct {
@@ -1464,7 +1525,7 @@ func (r *Runner) processOne(parent context.Context, delivery *natsq.Delivery) {
 	// nothing — and a lease left open there strands the donor's slot and
 	// committed allowance until the 12h TTL.
 	redeliverable := r.cfg.NATS != nil && delivery.NumDelivered() < r.cfg.NATS.MaxDeliver()
-	r.recordPoolSpend(msg, usage, err, outcome.action == actionNak && redeliverable)
+	r.recordPoolSpend(msg, usage, err, isNakAction(outcome.action) && redeliverable)
 
 	if outcomeSideEffectsFire(err, outcome.action) {
 		fireOutcome()
@@ -1477,7 +1538,7 @@ func (r *Runner) processOne(parent context.Context, delivery *natsq.Delivery) {
 	// and without inventing an episode. A Nak into nothing (last
 	// permitted delivery of an ErrRunInterrupted, exempt from DLQ)
 	// stays unknown, which is honest: nobody owns that run's future.
-	if outcome.action == actionNak && redeliverable && r.cfg.Store != nil {
+	if isNakAction(outcome.action) && redeliverable && r.cfg.Store != nil {
 		bg, cancel := context.WithTimeout(context.WithoutCancel(runCtx), 10*time.Second)
 		sctx := store.WithIdentity(bg, msg.TenantID, msg.OwnerID)
 		if _, serr := r.cfg.Store.UpdateRunOutcome(sctx, msg.RunID, store.RunStatusFailedResumable, "",
@@ -1486,22 +1547,57 @@ func (r *Runner) processOne(parent context.Context, delivery *natsq.Delivery) {
 			logger.Warn("runner: continuation promote for %s: %v", msg.RunID, serr)
 		}
 		cancel()
+		// A DELAYED redelivery leaves the run parked for minutes with
+		// nothing on its timeline between two attempts: say why, and for
+		// how long, where the operator reads.
+		if outcome.action == actionNakDelayed {
+			r.recordRedeliveryDeferred(msg, outcome, err, delivery.NumDelivered(), r.cfg.NATS.MaxDeliver())
+		}
 	}
 	logAt(logger, outcome.level, outcome.logFmt, outcome.logArgs...)
 	finalStatus = outcome.finalStatus
-	dispatchTerminal(logger, delivery, outcome.action, outcome.op, msg.RunID)
+	dispatchExecOutcome(logger, delivery, outcome, msg.RunID)
+}
+
+// recordRedeliveryDeferred puts a delayed redelivery on the run's
+// timeline — the only trace, between two attempts, of why the run sits
+// failed_resumable and when the next pod picks it up. Best-effort and
+// bounded like every teardown-path timeline write: a wedged store must
+// not pin the pod, and a missed event never changes the disposition.
+func (r *Runner) recordRedeliveryDeferred(msg *queue.RunMessage, outcome execOutcome, execErr error, delivered, maxDeliver int) {
+	if r.cfg.Store == nil {
+		return
+	}
+	data := map[string]any{
+		"reason":        outcome.finalStatus,
+		"delay_seconds": int(outcome.delay / time.Second),
+		"delivery":      delivered,
+		"max_deliver":   maxDeliver,
+	}
+	if execErr != nil {
+		data["error"] = execErr.Error()
+	}
+	wctx, cancel := context.WithTimeout(context.Background(), parkStoreOpTimeout)
+	defer cancel()
+	idCtx := store.WithIdentity(wctx, msg.TenantID, msg.OwnerID)
+	if _, err := r.cfg.Store.AppendEvent(idCtx, msg.RunID, store.Event{
+		Type: store.EventRunRedeliveryDeferred,
+		Data: data,
+	}); err != nil {
+		r.cfg.Logger.Warn("runner: run %s: could not emit run_redelivery_deferred: %v", msg.RunID, err)
+	}
 }
 
 // outcomeSideEffectsFire reports whether a delivery ending on the plain
 // dispatch path (no park) is a FINAL disposition that must fire the
 // run-outcome side effects (completion webhook + run.<outcome> event). A
-// Nak is not final — JetStream redelivers and the run auto-resumes, so
-// user-facing "run failed" episodes must wait for a disposition that
-// actually settles the run. Named (rather than inlined) so the
-// err → fires mapping is pinned by a table test next to
+// Nak — immediate or delayed — is not final: JetStream redelivers and the
+// run auto-resumes, so user-facing "run failed" episodes must wait for a
+// disposition that actually settles the run. Named (rather than inlined)
+// so the err → fires mapping is pinned by a table test next to
 // TestClassifyExecResult.
 func outcomeSideEffectsFire(execErr error, action deliveryAction) bool {
-	return !errors.Is(execErr, runtime.ErrRunInterrupted) && action != actionNak
+	return !errors.Is(execErr, runtime.ErrRunInterrupted) && !isNakAction(action)
 }
 
 // startProcessSpan builds the runner-side OTel root span for this

--- a/pkg/runner/loop_lock.go
+++ b/pkg/runner/loop_lock.go
@@ -18,7 +18,7 @@ import (
 // lock error is a transient-store shape and also Nak'd. Returns
 // (lock, true, "") on success; (nil, false, finalStatus) when the caller
 // must abandon the delivery (finalStatus is the metric label).
-func (r *Runner) acquireRunLock(runCtx context.Context, msg *queue.RunMessage, delivery *natsq.Delivery, logger *iterlog.Logger) (store.RunLock, bool, string) {
+func (r *Runner) acquireRunLock(runCtx context.Context, msg *queue.RunMessage, delivery jsDelivery, logger *iterlog.Logger) (store.RunLock, bool, string) {
 	// Acquire the distributed lock. Two competing runners on the
 	// same run is the contention this guards against.
 	lock, err := r.cfg.Store.LockRun(runCtx, msg.RunID)

--- a/pkg/runner/loop_nats.go
+++ b/pkg/runner/loop_nats.go
@@ -143,6 +143,26 @@ func (p admissionMismatchPlan) lostRunError(mismatchErr, parkErr error) string {
 	return fmt.Sprintf("schema version mismatch: %v (delivery budget exhausted and DLQ park failed: %v — no queue copy remains; relaunch this run)", mismatchErr, parkErr)
 }
 
+// admissionParkOutcome is the typed WHY stamped on the run doc when the
+// admission park flips it. A message parked on the DLQ is a DLQ park
+// whatever refused it — the same code the generic park in processOne
+// writes, so the one reader of the code (the gate notice) tells an
+// operator-replay park from a quota pause on either path. A payload the
+// DLQ could NOT take (the queue entry is lost, the doc says "relaunch")
+// keeps the refusal's own cause where the taxonomy names one — a schema
+// mismatch — and honestly stays unknown for a future-epoch fence, which
+// has no code. Both are final: nothing on the platform wakes the run.
+func admissionParkOutcome(kind admissionMismatchKind, payloadParked bool) store.RunOutcomeMeta {
+	meta := store.RunOutcomeMeta{Continuation: store.ContinuationFinal}
+	switch {
+	case payloadParked:
+		meta.Code = store.FailureDLQParked
+	case kind == admissionMismatchSchema:
+		meta.Code = store.FailureQueueSchemaMismatch
+	}
+	return meta
+}
+
 // handleAdmissionMismatch is the common recoverable disposition for schema
 // and generation fences. Both conditions are expected during a mixed-fleet
 // rollout and both become explicit, resumable failures if MaxDeliver is spent.
@@ -228,7 +248,7 @@ func (r *Runner) handleAdmissionMismatch(delivery *natsq.Delivery, kind admissio
 			// lookup could otherwise close that successor.
 			poolRelease = r.cfg.CredPool.CaptureRelease(flipCtx, env.RunID)
 		}
-		changed, serr := attempts.FailQueuedRunIfAttempt(sctx, env.RunID, runErr, publishedAt)
+		changed, serr := attempts.FailQueuedRunIfAttempt(sctx, env.RunID, runErr, publishedAt, admissionParkOutcome(kind, payloadParked))
 		flipCancel()
 		if serr != nil {
 			logger.Warn("runner: %s admission-rejection status flip for %s: %v", plan.reason, env.RunID, serr)

--- a/pkg/runner/loop_tenant.go
+++ b/pkg/runner/loop_tenant.go
@@ -3,7 +3,6 @@ package runner
 import (
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/queue"
-	natsq "github.com/SocialGouv/iterion/pkg/queue/nats"
 )
 
 // verifyTenantOrTerm refuses a delivery whose message tenant doesn't
@@ -16,7 +15,7 @@ import (
 // the operator to purge the JetStream subject manually — the generic
 // logDeliveryErr breadcrumb wouldn't surface it. Returns true to proceed,
 // false when the caller must abandon the delivery.
-func (r *Runner) verifyTenantOrTerm(pre preconditionOutcome, msg *queue.RunMessage, delivery *natsq.Delivery, logger *iterlog.Logger) bool {
+func (r *Runner) verifyTenantOrTerm(pre preconditionOutcome, msg *queue.RunMessage, delivery jsDelivery, logger *iterlog.Logger) bool {
 	if pre.preRun.TenantID == msg.TenantID {
 		return true
 	}

--- a/pkg/runner/loop_test.go
+++ b/pkg/runner/loop_test.go
@@ -20,6 +20,7 @@ import (
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/queue"
 	"github.com/SocialGouv/iterion/pkg/runtime"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
 	"github.com/SocialGouv/iterion/pkg/secrets"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
@@ -429,6 +430,13 @@ func TestClassifyExecResult(t *testing.T) {
 		// the first attempt's. errors.Is short-circuits, so this is one
 		// reordering away from silently regressing.
 		{"budget beats interrupted", errors.Join(runtime.ErrRunInterrupted, runtime.ErrBudgetExceeded), "budget_exceeded", actionAck},
+		// A sandbox setup phase that hit its own bound: the engine wrote
+		// failed_resumable + SANDBOX_SETUP_TIMEOUT; Nak so a fresh pod
+		// retries. Its own status label, not "interrupted": the DLQ park
+		// on the last delivery must still apply to it.
+		{"sandbox phase timeout naks for a fresh pod", fmt.Errorf("runtime: sandbox: %w",
+			errors.Join(sandbox.ErrPhaseTimeout, context.DeadlineExceeded, errors.New("in-pod tar extract: signal: killed"))),
+			"sandbox_setup_timeout", actionNak},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -466,6 +474,7 @@ func TestOutcomeSideEffectsFire(t *testing.T) {
 		{"wrapped generic failure naks — no fire", fmt.Errorf("engine: %w", errors.New("boom")), false},
 		{"interrupted naks — no fire", runtime.ErrRunInterrupted, false},
 		{"wrapped interrupted naks — no fire", fmt.Errorf("%w: at node n1", runtime.ErrRunInterrupted), false},
+		{"sandbox phase timeout naks — no fire", fmt.Errorf("runtime: sandbox: %w", sandbox.ErrPhaseTimeout), false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/runner/loop_test.go
+++ b/pkg/runner/loop_test.go
@@ -432,12 +432,13 @@ func TestClassifyExecResult(t *testing.T) {
 		// reordering away from silently regressing.
 		{"budget beats interrupted", errors.Join(runtime.ErrRunInterrupted, runtime.ErrBudgetExceeded), "budget_exceeded", actionAck},
 		// A sandbox setup phase that hit its own bound: the engine wrote
-		// failed_resumable + SANDBOX_SETUP_TIMEOUT; Nak so a fresh pod
-		// retries. Its own status label, not "interrupted": the DLQ park
-		// on the last delivery must still apply to it.
-		{"sandbox phase timeout naks for a fresh pod", fmt.Errorf("runtime: sandbox: %w",
+		// failed_resumable + SANDBOX_SETUP_TIMEOUT; Nak — DELAYED — so a
+		// fresh pod retries once the infrastructure has had a moment. Its
+		// own status label, not "interrupted": the DLQ park on the last
+		// delivery must still apply to it.
+		{"sandbox phase timeout naks for a fresh pod, after a delay", fmt.Errorf("runtime: sandbox: %w",
 			errors.Join(sandbox.ErrPhaseTimeout, context.DeadlineExceeded, errors.New("in-pod tar extract: signal: killed"))),
-			"sandbox_setup_timeout", actionNak},
+			"sandbox_setup_timeout", actionNakDelayed},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -449,6 +450,71 @@ func TestClassifyExecResult(t *testing.T) {
 				t.Errorf("action = %v, want %v", out.action, c.wantAction)
 			}
 		})
+	}
+}
+
+// A sandbox setup timeout is re-offered with sandboxSetupTimeoutNakDelay,
+// through NakWithDelay — a bare Nak re-offers within seconds, and a copy
+// that always stalls then burns the delivery budget as back-to-back pods
+// (8 × the phase budget before the DLQ park, #669's measured shape).
+func TestClassifyExecResult_SandboxSetupTimeoutIsReofferedAfterADelay(t *testing.T) {
+	err := fmt.Errorf("runtime: sandbox: %w",
+		errors.Join(sandbox.ErrPhaseTimeout, context.DeadlineExceeded, errors.New("in-pod tar extract: signal: killed")))
+	out := classifyExecResult(err, "run-1")
+	if out.delay != sandboxSetupTimeoutNakDelay || out.delay <= 0 {
+		t.Fatalf("delay = %s, want %s — an immediate re-offer is 8 back-to-back pods", out.delay, sandboxSetupTimeoutNakDelay)
+	}
+	d := &fakeDelivery{delivered: 3}
+	dispatchExecOutcome(iterlog.Nop(), d, out, "run-1")
+	if len(d.nakDelays) != 1 || d.nakDelays[0] != sandboxSetupTimeoutNakDelay || d.naks != 0 || d.terms != 0 || d.acks != 0 {
+		t.Fatalf("delivery transitions = %+v, want exactly one NakWithDelay(%s)", d, sandboxSetupTimeoutNakDelay)
+	}
+}
+
+// The delayed redelivery lands on the run's timeline, naming the phase
+// timeout, the delay and the attempt's rank — the only trace between two
+// attempts of why the run sits failed_resumable.
+func TestRecordRedeliveryDeferred_PutsThePhaseTimeoutOnTheTimeline(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	const id = "run-deferred"
+	ctx := store.WithIdentity(context.Background(), "team-1", "u1")
+	if err := st.SaveRun(ctx, &store.Run{ID: id, TenantID: "team-1", OwnerID: "u1", Status: store.RunStatusFailedResumable}); err != nil {
+		t.Fatal(err)
+	}
+	r := &Runner{cfg: Config{Store: st, Logger: iterlog.Nop()}}
+	msg := &queue.RunMessage{RunID: id, TenantID: "team-1", OwnerID: "u1"}
+	execErr := fmt.Errorf("runtime: sandbox: %w", errors.Join(sandbox.ErrPhaseTimeout, errors.New("workspace copy stalled")))
+	out := classifyExecResult(execErr, id)
+
+	r.recordRedeliveryDeferred(msg, out, execErr, 3, 8)
+
+	events, err := st.LoadEvents(ctx, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ev *store.Event
+	for _, e := range events {
+		if e.Type == store.EventRunRedeliveryDeferred {
+			ev = e
+		}
+	}
+	if ev == nil {
+		t.Fatal("no run_redelivery_deferred on the timeline — between two attempts the operator sees nothing")
+	}
+	if got, _ := ev.Data["reason"].(string); got != "sandbox_setup_timeout" {
+		t.Fatalf("reason = %q, want sandbox_setup_timeout", got)
+	}
+	if got, _ := ev.Data["delay_seconds"].(float64); int(got) != int(sandboxSetupTimeoutNakDelay/time.Second) {
+		t.Fatalf("delay_seconds = %v, want %d", ev.Data["delay_seconds"], int(sandboxSetupTimeoutNakDelay/time.Second))
+	}
+	if got, _ := ev.Data["error"].(string); !strings.Contains(got, "workspace copy stalled") {
+		t.Fatalf("error = %q, want the engine's cause", got)
+	}
+	if d, _ := ev.Data["delivery"].(float64); int(d) != 3 {
+		t.Fatalf("delivery = %v, want 3", ev.Data["delivery"])
 	}
 }
 
@@ -468,6 +534,11 @@ func TestOutcomeSideEffectsFire(t *testing.T) {
 	}{
 		{"finished fires", nil, true},
 		{"paused fires", runtime.ErrRunPaused, true},
+		// A DELAYED nak is still a nak: the run comes back on its own, so
+		// firing here would push one "run failed" episode per stalled
+		// sandbox attempt.
+		{"sandbox setup timeout (delayed nak) does not fire", fmt.Errorf("runtime: sandbox: %w",
+			errors.Join(sandbox.ErrPhaseTimeout, context.DeadlineExceeded, errors.New("copy stalled"))), false},
 		{"operator pause fires", runtime.ErrRunPausedOperator, true},
 		{"operator cancel fires", runtime.ErrRunCancelled, true},
 		{"budget exceeded fires (acked, no auto-resume)", runtime.ErrBudgetExceeded, true},
@@ -1259,6 +1330,49 @@ func TestAdoptRunningUnderLock_YoungDocIsReofferedAfterTheFloor(t *testing.T) {
 		t.Fatalf("the lock was not released for the re-offered delivery: %v", err)
 	}
 	_ = next.Unlock()
+}
+
+// A young `running` doc on the LAST permitted delivery: JetStream will not
+// re-offer it whatever we answer, so the delivery must not claim a
+// re-offer ("re-offered in Ns") that never comes. Nothing is written — the
+// floor exists because the previous holder may still be unwinding — the
+// message is termed, and the log names the owner of what happens next:
+// the orphan sweeper.
+func TestAdoptRunningUnderLock_YoungDocOnLastDeliveryTermsAndNamesTheSweeper(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	const id = "run-young-last"
+	doc := seedRunningRun(t, st, id)
+	r := &Runner{cfg: Config{Store: st, Logger: iterlog.Nop()}, lockLivenessOverride: true, maxDeliverOverride: 8}
+	msg := &queue.RunMessage{RunID: id, TenantID: "team-1", OwnerID: "u1"}
+	d := &fakeDelivery{delivered: 8}
+
+	out := r.adoptRunningUnderLock(msg, doc, d, doc.UpdatedAt.Add(time.Minute))
+
+	if out.proceed {
+		t.Fatalf("a young doc was adopted on the last delivery (%+v) — the floor still applies", out)
+	}
+	if out.action == actionNakDelayed {
+		t.Fatalf("action = delayed Nak on delivery %d/%d — JetStream will not re-offer it, so a 're-offered in Ns' log line is false and nothing parks or reconciles the doc", d.delivered, r.maxDeliver())
+	}
+	if out.action != actionTerm {
+		t.Fatalf("action = %v, want Term (explicit on the queue side; the sweeper owns the doc)", out.action)
+	}
+	if !strings.Contains(out.logFmt, "LAST permitted delivery") || !strings.Contains(out.logFmt, "orphan sweeper") {
+		t.Fatalf("the log must say this is the last delivery and who reconciles the doc, got %q", out.logFmt)
+	}
+	dispatchPrecondition(iterlog.Nop(), d, out, id)
+	if d.terms != 1 || len(d.nakDelays) != 0 || d.naks != 0 {
+		t.Fatalf("delivery transitions = %+v, want exactly one Term", d)
+	}
+	if got := loadStatus(t, st, id); got.Status != store.RunStatusRunning || got.FailureCode != "" {
+		t.Fatalf("doc = %s/%q, want running left untouched — a park over a possibly-live writer clobbers or is clobbered", got.Status, got.FailureCode)
+	}
+	if msg.Resume != nil {
+		t.Fatal("the termed delivery was converted to a resume")
+	}
 }
 
 // A `running` doc older than the floor, under our lock, is an orphan:

--- a/pkg/runner/loop_test.go
+++ b/pkg/runner/loop_test.go
@@ -439,6 +439,16 @@ func TestClassifyExecResult(t *testing.T) {
 		{"sandbox phase timeout naks for a fresh pod, after a delay", fmt.Errorf("runtime: sandbox: %w",
 			errors.Join(sandbox.ErrPhaseTimeout, context.DeadlineExceeded, errors.New("in-pod tar extract: signal: killed"))),
 			"sandbox_setup_timeout", actionNakDelayed},
+		// The resume arms' sandbox-start park returns the same sentinels the
+		// status carries (runtime.parkResumeSandboxFailure): an operator
+		// cancel during sandbox start acks, a drain naks exempt from the DLQ
+		// park. A bare "runtime: sandbox: docker start: context canceled"
+		// would classify as a generic failure — an operator cancel burning a
+		// delivery, a drain parked on the DLQ.
+		{"resume-arm cancel during sandbox start acks", fmt.Errorf("%w: sandbox start: %v", runtime.ErrRunCancelled, errors.New("docker start: context canceled")),
+			"cancelled", actionAck},
+		{"resume-arm drain during sandbox start naks", fmt.Errorf("%w: sandbox start: %v", runtime.ErrRunInterrupted, errors.New("kubectl exec: signal: killed")),
+			"interrupted", actionNak},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/runner/loop_test.go
+++ b/pkg/runner/loop_test.go
@@ -19,6 +19,7 @@ import (
 	gitlib "github.com/SocialGouv/iterion/pkg/git"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/queue"
+	natsq "github.com/SocialGouv/iterion/pkg/queue/nats"
 	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
 	"github.com/SocialGouv/iterion/pkg/secrets"
@@ -563,134 +564,6 @@ func TestResolveDeliveryPreconditions(t *testing.T) {
 	}
 }
 
-// admLeaseChecker plugs a scripted IsRunLocked answer into the admission
-// path — the ADR-095 lease is the queue sweeper's authority too, so this
-// interface must stay in step with the sweeper's.
-type admLeaseChecker struct {
-	locked map[string]bool
-	err    error
-}
-
-func (f *admLeaseChecker) IsRunLocked(_ context.Context, runID string) (bool, error) {
-	if f.err != nil {
-		return false, f.err
-	}
-	return f.locked[runID], nil
-}
-
-// TestAdoptStaleRunning_OrphanIsPromotedToResume pins the admission
-// path's #669 part 2 fix: a `running` doc with no live NATS-KV lease is
-// an orphan (its holder pod died before writing a terminal status),
-// and admission must CAS it to failed_resumable + convert the delivery
-// into a resume — not burn the message's MaxDeliver on
-// `cannot resume run … with status "running"`.
-func TestAdoptStaleRunning_OrphanIsPromotedToResume(t *testing.T) {
-	st, err := store.New(t.TempDir())
-	if err != nil {
-		t.Fatalf("store.New: %v", err)
-	}
-	ctx := store.WithIdentity(context.Background(), "team-1", "u1")
-	if err := st.SaveRun(ctx, &store.Run{
-		ID:           "run-orphan",
-		TenantID:     "team-1",
-		OwnerID:      "u1",
-		WorkflowName: "wf",
-		Status:       store.RunStatusRunning,
-		Checkpoint:   &store.Checkpoint{NodeID: "n1"},
-	}); err != nil {
-		t.Fatalf("SaveRun: %v", err)
-	}
-
-	r := &Runner{
-		cfg:                Config{Store: st, Logger: iterlog.Nop()},
-		leaseCheckOverride: &admLeaseChecker{locked: map[string]bool{}}, // no lease → orphan
-	}
-	msg := &queue.RunMessage{RunID: "run-orphan", TenantID: "team-1", OwnerID: "u1"}
-	out := r.resolveDeliveryPreconditions(msg)
-	if !out.proceed {
-		t.Fatalf("orphan admission did not proceed: %+v — a `running` doc + no lease is exactly the bug this fix exists to catch", out)
-	}
-	if msg.Resume == nil {
-		t.Fatalf("msg.Resume still nil after orphan promotion — Engine.Resume will now throw `cannot resume run … with status running`, i.e. the friction is unfixed")
-	}
-	got, err := st.LoadRun(ctx, "run-orphan")
-	if err != nil {
-		t.Fatalf("LoadRun: %v", err)
-	}
-	if got.Status != store.RunStatusFailedResumable {
-		t.Fatalf("status after promote = %s, want failed_resumable (the CAS to resumable status is what makes the resume runnable)", got.Status)
-	}
-	if got.FailureCode != store.FailureProcessOrphaned {
-		t.Fatalf("FailureCode after promote = %q, want PROCESS_ORPHANED (audit trail for the orphan-adoption path)", got.FailureCode)
-	}
-}
-
-// A live-lease case must NOT promote: another pod holds the run.
-func TestAdoptStaleRunning_LiveLeaseAbstains(t *testing.T) {
-	st, err := store.New(t.TempDir())
-	if err != nil {
-		t.Fatalf("store.New: %v", err)
-	}
-	ctx := store.WithIdentity(context.Background(), "team-1", "u1")
-	if err := st.SaveRun(ctx, &store.Run{
-		ID:           "run-alive",
-		TenantID:     "team-1",
-		OwnerID:      "u1",
-		WorkflowName: "wf",
-		Status:       store.RunStatusRunning,
-	}); err != nil {
-		t.Fatalf("SaveRun: %v", err)
-	}
-	r := &Runner{
-		cfg:                Config{Store: st, Logger: iterlog.Nop()},
-		leaseCheckOverride: &admLeaseChecker{locked: map[string]bool{"run-alive": true}},
-	}
-	msg := &queue.RunMessage{RunID: "run-alive", TenantID: "team-1", OwnerID: "u1"}
-	out := r.resolveDeliveryPreconditions(msg)
-	if !out.proceed {
-		t.Fatalf("live-lease running should proceed to per-run lock, got %+v", out)
-	}
-	if msg.Resume != nil {
-		t.Fatalf("live-lease running got Resume set — would clobber the live owner's checkpoint")
-	}
-	got, err := st.LoadRun(ctx, "run-alive")
-	if err != nil {
-		t.Fatalf("LoadRun: %v", err)
-	}
-	if got.Status != store.RunStatusRunning {
-		t.Fatalf("live-lease running was flipped to %s — the owner would then lose its checkpoint claim", got.Status)
-	}
-}
-
-// No lease checker wired (local mode, tests) → today's fall-through
-// behaviour is preserved: proceed with the doc as-is, no CAS.
-func TestAdoptStaleRunning_NoCheckerFallsThrough(t *testing.T) {
-	st, err := store.New(t.TempDir())
-	if err != nil {
-		t.Fatalf("store.New: %v", err)
-	}
-	ctx := store.WithIdentity(context.Background(), "team-1", "u1")
-	if err := st.SaveRun(ctx, &store.Run{
-		ID: "run-no-checker", TenantID: "team-1", OwnerID: "u1",
-		WorkflowName: "wf", Status: store.RunStatusRunning,
-	}); err != nil {
-		t.Fatalf("SaveRun: %v", err)
-	}
-	r := &Runner{cfg: Config{Store: st, Logger: iterlog.Nop()}}
-	msg := &queue.RunMessage{RunID: "run-no-checker", TenantID: "team-1", OwnerID: "u1"}
-	out := r.resolveDeliveryPreconditions(msg)
-	if !out.proceed {
-		t.Fatalf("no-checker fall-through must proceed, got %+v", out)
-	}
-	if msg.Resume != nil {
-		t.Fatalf("no-checker path must NOT synthesize a resume (the lease-truth is missing — a wrong promote would race)")
-	}
-	got, err := st.LoadRun(ctx, "run-no-checker")
-	if err != nil || got.Status != store.RunStatusRunning {
-		t.Fatalf("status = %s (err %v), want running (no-checker fall-through is a no-op)", got.Status, err)
-	}
-}
-
 // ---------------------------------------------------------------------------
 // injectCredentials / deleteRunSecrets
 // ---------------------------------------------------------------------------
@@ -1208,4 +1081,274 @@ func TestRecordRunGitMeta(t *testing.T) {
 			t.Error("pod-confirmed empty snapshot was not persisted")
 		}
 	})
+}
+
+// The admission gauntlet runs BEFORE the per-run lock. A `running` doc
+// must leave it untouched: the lease is the only liveness authority, and
+// a write here — with the lease possibly held by a live sibling — would
+// mislabel a live run, then Nak away when the lock refuses. Adoption of
+// an orphan happens under the lock, never here.
+func TestResolveDeliveryPreconditions_RunningIsNotWrittenBeforeTheLock(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	ctx := store.WithIdentity(context.Background(), "team-1", "u1")
+	if err := st.SaveRun(ctx, &store.Run{
+		ID: "run-running-prelock", TenantID: "team-1", OwnerID: "u1",
+		WorkflowName: "wf", Status: store.RunStatusRunning,
+		Checkpoint: &store.Checkpoint{NodeID: "n1"},
+	}); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+	r := &Runner{cfg: Config{Store: st, Logger: iterlog.Nop()}, lockLivenessOverride: true}
+	msg := &queue.RunMessage{RunID: "run-running-prelock", TenantID: "team-1", OwnerID: "u1"}
+	out := r.resolveDeliveryPreconditions(msg)
+	if !out.proceed {
+		t.Fatalf("a running doc must proceed to the lock, got %+v", out)
+	}
+	if msg.Resume != nil {
+		t.Fatal("the delivery was converted to a resume BEFORE the lock — the write it implies raced whoever holds the lease")
+	}
+	got, err := st.LoadRun(ctx, "run-running-prelock")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.Status != store.RunStatusRunning {
+		t.Fatalf("status = %s: the doc was written BEFORE the lock — a live sibling's run just got mislabelled", got.Status)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Under-lock adoption of a stale `running` doc
+// ---------------------------------------------------------------------------
+
+// fakeDelivery records the JetStream transition a decision takes.
+type fakeDelivery struct {
+	delivered         int
+	acks, naks, terms int
+	nakDelays         []time.Duration
+}
+
+func (d *fakeDelivery) Ack() error  { d.acks++; return nil }
+func (d *fakeDelivery) Nak() error  { d.naks++; return nil }
+func (d *fakeDelivery) Term() error { d.terms++; return nil }
+func (d *fakeDelivery) NakWithDelay(delay time.Duration) error {
+	d.nakDelays = append(d.nakDelays, delay)
+	return nil
+}
+func (d *fakeDelivery) NumDelivered() int { return d.delivered }
+
+// lockHeldStore answers every LockRun with the lease-held signal: a
+// sibling pod owns the run.
+type lockHeldStore struct{ store.RunStore }
+
+func (lockHeldStore) LockRun(context.Context, string) (store.RunLock, error) {
+	return nil, natsq.ErrLockHeld
+}
+
+// seedRunningRun persists a `running` doc with a checkpoint and returns
+// it as the store reads it (UpdatedAt stamped by the save).
+func seedRunningRun(t *testing.T, st store.RunStore, id string) *store.Run {
+	t.Helper()
+	ctx := store.WithIdentity(context.Background(), "team-1", "u1")
+	if err := st.SaveRun(ctx, &store.Run{
+		ID: id, TenantID: "team-1", OwnerID: "u1", WorkflowName: "wf",
+		Status: store.RunStatusRunning, Checkpoint: &store.Checkpoint{NodeID: "n1"},
+		// Every real doc carries a last-write time (CreateRun and each
+		// status transition stamp it); a zero one is the legacy shape.
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+	run, err := st.LoadRun(ctx, id)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	return run
+}
+
+func loadStatus(t *testing.T, st store.RunStore, id string) *store.Run {
+	t.Helper()
+	run, err := st.LoadRun(store.WithIdentity(context.Background(), "team-1", "u1"), id)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	return run
+}
+
+// A lease held by another pod is a live owner: the delivery naks away and
+// NOTHING is written — adoption never runs, because it runs after the
+// lock and the lock refused.
+func TestAcquireRunLock_LeaseHeldByAnotherNaksWithoutWrite(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	const id = "run-held"
+	seedRunningRun(t, st, id)
+	r := &Runner{cfg: Config{Store: lockHeldStore{st}, Logger: iterlog.Nop()}, lockLivenessOverride: true}
+	msg := &queue.RunMessage{RunID: id, TenantID: "team-1", OwnerID: "u1"}
+	d := &fakeDelivery{delivered: 3}
+
+	_, ok, status := r.acquireRunLock(context.Background(), msg, d, iterlog.Nop())
+
+	if ok || status != "lock_held" {
+		t.Fatalf("acquireRunLock = (%v, %q), want (false, lock_held)", ok, status)
+	}
+	if d.naks != 1 || d.acks != 0 || d.terms != 0 || len(d.nakDelays) != 0 {
+		t.Fatalf("delivery transitions = %+v, want exactly one Nak (the sibling keeps the run)", d)
+	}
+	if got := loadStatus(t, st, id); got.Status != store.RunStatusRunning || got.FailureCode != "" {
+		t.Fatalf("doc = %s/%q after a refused lock — a live sibling's run was written to", got.Status, got.FailureCode)
+	}
+	if msg.Resume != nil {
+		t.Fatal("the delivery was converted to a resume although the lock refused")
+	}
+}
+
+// A `running` doc written more recently than the adoption floor is not
+// adopted: the previous holder may be a lapsed-but-alive pod still
+// unwinding, whose unconditional terminal write would land on top of the
+// adopter. The delivery is re-offered after the floor's remainder — a
+// delayed Nak, so the redelivery budget is not burnt inside the floor —
+// and the lock is released for it.
+func TestAdoptRunningUnderLock_YoungDocIsReofferedAfterTheFloor(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	const id = "run-young"
+	doc := seedRunningRun(t, st, id)
+	r := &Runner{cfg: Config{Store: st, Logger: iterlog.Nop()}, lockLivenessOverride: true}
+	msg := &queue.RunMessage{RunID: id, TenantID: "team-1", OwnerID: "u1"}
+	lock, err := st.LockRun(context.Background(), id)
+	if err != nil {
+		t.Fatalf("LockRun: %v", err)
+	}
+	d := &fakeDelivery{delivered: 2}
+
+	out := r.adoptRunningUnderLock(msg, doc, d, doc.UpdatedAt.Add(time.Minute))
+
+	if out.proceed {
+		t.Fatalf("a doc written 1m ago was adopted (%+v) — inside the %s floor a lapsed pod may still be unwinding", out, runningAdoptionFloor)
+	}
+	if out.action != actionNakDelayed {
+		t.Fatalf("action = %v, want a delayed Nak", out.action)
+	}
+	if want := runningAdoptionFloor - time.Minute; out.delay > want || out.delay < want-2*time.Second {
+		t.Fatalf("delay = %s, want the floor's remainder ≈ %s", out.delay, want)
+	}
+	dispatchPrecondition(iterlog.Nop(), d, out, id)
+	if len(d.nakDelays) != 1 || d.nakDelays[0] != out.delay || d.naks != 0 {
+		t.Fatalf("delivery transitions = %+v, want one NakWithDelay(%s) and no bare Nak (seven bare naks in two minutes is the #669 log)", d, out.delay)
+	}
+	if got := loadStatus(t, st, id); got.Status != store.RunStatusRunning {
+		t.Fatalf("doc = %s, want running left untouched", got.Status)
+	}
+	if msg.Resume != nil {
+		t.Fatal("a deferred delivery must not be converted to a resume")
+	}
+	// The lock is released on the way out of processOne; the next
+	// delivery must be able to take it.
+	if err := lock.Unlock(); err != nil {
+		t.Fatalf("Unlock: %v", err)
+	}
+	next, err := st.LockRun(context.Background(), id)
+	if err != nil {
+		t.Fatalf("the lock was not released for the re-offered delivery: %v", err)
+	}
+	_ = next.Unlock()
+}
+
+// A `running` doc older than the floor, under our lock, is an orphan:
+// promoted to failed_resumable + PROCESS_ORPHANED with continuation
+// redelivery_pending — THIS delivery resumes it next, so nothing that
+// acts on `final` (the board dispatcher, the stuck-card watchdog, the
+// outcome router) may act in the window — and the delivery is converted
+// into a resume so the checkpoint is honoured.
+func TestAdoptRunningUnderLock_OldDocIsAdoptedAsRedeliveryPending(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	const id = "run-orphan"
+	doc := seedRunningRun(t, st, id)
+	r := &Runner{cfg: Config{Store: st, Logger: iterlog.Nop()}, lockLivenessOverride: true}
+	msg := &queue.RunMessage{RunID: id, TenantID: "team-1", OwnerID: "u1"}
+	d := &fakeDelivery{delivered: 2}
+
+	out := r.adoptRunningUnderLock(msg, doc, d, doc.UpdatedAt.Add(10*time.Minute))
+
+	if !out.proceed {
+		t.Fatalf("an orphan older than the floor was not adopted: %+v", out)
+	}
+	if msg.Resume == nil {
+		t.Fatal("msg.Resume still nil after the promote — Engine.Resume would refuse `running` and burn the delivery (#669 part 2)")
+	}
+	got := loadStatus(t, st, id)
+	if got.Status != store.RunStatusFailedResumable {
+		t.Fatalf("status = %s, want failed_resumable", got.Status)
+	}
+	if got.FailureCode != store.FailureProcessOrphaned {
+		t.Fatalf("FailureCode = %q, want PROCESS_ORPHANED", got.FailureCode)
+	}
+	if got.ContinuationState != store.ContinuationRedeliveryPending {
+		t.Fatalf("ContinuationState = %q, want redelivery_pending — `final` lets three consumers act on a run this very delivery is about to resume", got.ContinuationState)
+	}
+	if !strings.Contains(out.logFmt, "delivery %d/%d") || !strings.Contains(out.logFmt, "last doc write") {
+		t.Fatalf("the promote line must carry the doc age and the delivery count, got %q", out.logFmt)
+	}
+}
+
+// Without a lease authority (no queue wired, a lock-less store) a held
+// lock proves nothing: the doc is left to the engine, unwritten.
+func TestAdoptRunningUnderLock_NoLeaseAuthorityLeavesTheDocAlone(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	const id = "run-no-authority"
+	doc := seedRunningRun(t, st, id)
+	r := &Runner{cfg: Config{Store: st, Logger: iterlog.Nop()}}
+	msg := &queue.RunMessage{RunID: id, TenantID: "team-1", OwnerID: "u1"}
+
+	out := r.adoptRunningUnderLock(msg, doc, &fakeDelivery{}, doc.UpdatedAt.Add(time.Hour))
+
+	if !out.proceed || msg.Resume != nil {
+		t.Fatalf("no-authority path must proceed unchanged, got %+v (resume=%v)", out, msg.Resume != nil)
+	}
+	if got := loadStatus(t, st, id); got.Status != store.RunStatusRunning {
+		t.Fatalf("doc = %s, want running — a wrong promote under an untestable premise", got.Status)
+	}
+}
+
+// The pre-lock copy is stale by construction: a peer's terminal write
+// that landed between the two reads is honoured through the ordinary
+// disposition — resumed now, not deferred on the stale copy's age, and
+// with no CAS of our own over its cause.
+func TestAdoptRunningUnderLock_PeerMovedTheDocTakesItsDisposition(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	const id = "run-moved"
+	stale := seedRunningRun(t, st, id)
+	ctx := store.WithIdentity(context.Background(), "team-1", "u1")
+	if err := st.UpdateRunStatusCoded(ctx, id, store.RunStatusFailedResumable, "interrupted at node n1", store.FailureInterrupted); err != nil {
+		t.Fatalf("peer write: %v", err)
+	}
+	r := &Runner{cfg: Config{Store: st, Logger: iterlog.Nop()}, lockLivenessOverride: true}
+	msg := &queue.RunMessage{RunID: id, TenantID: "team-1", OwnerID: "u1"}
+
+	// The stale copy reads young: judged on it, the delivery would be
+	// deferred for the floor's remainder while the doc is resumable NOW.
+	out := r.adoptRunningUnderLock(msg, stale, &fakeDelivery{}, stale.UpdatedAt.Add(time.Minute))
+
+	if !out.proceed || msg.Resume == nil {
+		t.Fatalf("a peer-moved failed_resumable must convert to a resume now, got %+v (resume=%v)", out, msg.Resume != nil)
+	}
+	if got := loadStatus(t, st, id); got.FailureCode != store.FailureInterrupted {
+		t.Fatalf("FailureCode = %q, want the peer's INTERRUPTED kept — the adoption must not overwrite a cause it did not establish", got.FailureCode)
+	}
 }

--- a/pkg/runner/loop_test.go
+++ b/pkg/runner/loop_test.go
@@ -554,6 +554,134 @@ func TestResolveDeliveryPreconditions(t *testing.T) {
 	}
 }
 
+// admLeaseChecker plugs a scripted IsRunLocked answer into the admission
+// path — the ADR-095 lease is the queue sweeper's authority too, so this
+// interface must stay in step with the sweeper's.
+type admLeaseChecker struct {
+	locked map[string]bool
+	err    error
+}
+
+func (f *admLeaseChecker) IsRunLocked(_ context.Context, runID string) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	return f.locked[runID], nil
+}
+
+// TestAdoptStaleRunning_OrphanIsPromotedToResume pins the admission
+// path's #669 part 2 fix: a `running` doc with no live NATS-KV lease is
+// an orphan (its holder pod died before writing a terminal status),
+// and admission must CAS it to failed_resumable + convert the delivery
+// into a resume — not burn the message's MaxDeliver on
+// `cannot resume run … with status "running"`.
+func TestAdoptStaleRunning_OrphanIsPromotedToResume(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	ctx := store.WithIdentity(context.Background(), "team-1", "u1")
+	if err := st.SaveRun(ctx, &store.Run{
+		ID:           "run-orphan",
+		TenantID:     "team-1",
+		OwnerID:      "u1",
+		WorkflowName: "wf",
+		Status:       store.RunStatusRunning,
+		Checkpoint:   &store.Checkpoint{NodeID: "n1"},
+	}); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+
+	r := &Runner{
+		cfg:                Config{Store: st, Logger: iterlog.Nop()},
+		leaseCheckOverride: &admLeaseChecker{locked: map[string]bool{}}, // no lease → orphan
+	}
+	msg := &queue.RunMessage{RunID: "run-orphan", TenantID: "team-1", OwnerID: "u1"}
+	out := r.resolveDeliveryPreconditions(msg)
+	if !out.proceed {
+		t.Fatalf("orphan admission did not proceed: %+v — a `running` doc + no lease is exactly the bug this fix exists to catch", out)
+	}
+	if msg.Resume == nil {
+		t.Fatalf("msg.Resume still nil after orphan promotion — Engine.Resume will now throw `cannot resume run … with status running`, i.e. the friction is unfixed")
+	}
+	got, err := st.LoadRun(ctx, "run-orphan")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.Status != store.RunStatusFailedResumable {
+		t.Fatalf("status after promote = %s, want failed_resumable (the CAS to resumable status is what makes the resume runnable)", got.Status)
+	}
+	if got.FailureCode != store.FailureProcessOrphaned {
+		t.Fatalf("FailureCode after promote = %q, want PROCESS_ORPHANED (audit trail for the orphan-adoption path)", got.FailureCode)
+	}
+}
+
+// A live-lease case must NOT promote: another pod holds the run.
+func TestAdoptStaleRunning_LiveLeaseAbstains(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	ctx := store.WithIdentity(context.Background(), "team-1", "u1")
+	if err := st.SaveRun(ctx, &store.Run{
+		ID:           "run-alive",
+		TenantID:     "team-1",
+		OwnerID:      "u1",
+		WorkflowName: "wf",
+		Status:       store.RunStatusRunning,
+	}); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+	r := &Runner{
+		cfg:                Config{Store: st, Logger: iterlog.Nop()},
+		leaseCheckOverride: &admLeaseChecker{locked: map[string]bool{"run-alive": true}},
+	}
+	msg := &queue.RunMessage{RunID: "run-alive", TenantID: "team-1", OwnerID: "u1"}
+	out := r.resolveDeliveryPreconditions(msg)
+	if !out.proceed {
+		t.Fatalf("live-lease running should proceed to per-run lock, got %+v", out)
+	}
+	if msg.Resume != nil {
+		t.Fatalf("live-lease running got Resume set — would clobber the live owner's checkpoint")
+	}
+	got, err := st.LoadRun(ctx, "run-alive")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.Status != store.RunStatusRunning {
+		t.Fatalf("live-lease running was flipped to %s — the owner would then lose its checkpoint claim", got.Status)
+	}
+}
+
+// No lease checker wired (local mode, tests) → today's fall-through
+// behaviour is preserved: proceed with the doc as-is, no CAS.
+func TestAdoptStaleRunning_NoCheckerFallsThrough(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	ctx := store.WithIdentity(context.Background(), "team-1", "u1")
+	if err := st.SaveRun(ctx, &store.Run{
+		ID: "run-no-checker", TenantID: "team-1", OwnerID: "u1",
+		WorkflowName: "wf", Status: store.RunStatusRunning,
+	}); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+	r := &Runner{cfg: Config{Store: st, Logger: iterlog.Nop()}}
+	msg := &queue.RunMessage{RunID: "run-no-checker", TenantID: "team-1", OwnerID: "u1"}
+	out := r.resolveDeliveryPreconditions(msg)
+	if !out.proceed {
+		t.Fatalf("no-checker fall-through must proceed, got %+v", out)
+	}
+	if msg.Resume != nil {
+		t.Fatalf("no-checker path must NOT synthesize a resume (the lease-truth is missing — a wrong promote would race)")
+	}
+	got, err := st.LoadRun(ctx, "run-no-checker")
+	if err != nil || got.Status != store.RunStatusRunning {
+		t.Fatalf("status = %s (err %v), want running (no-checker fall-through is a no-op)", got.Status, err)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // injectCredentials / deleteRunSecrets
 // ---------------------------------------------------------------------------

--- a/pkg/runner/rollout_test.go
+++ b/pkg/runner/rollout_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/store"
 	natsq "github.com/SocialGouv/iterion/pkg/queue/nats"
 )
 
@@ -86,5 +87,36 @@ func TestPlanAdmissionMismatch(t *testing.T) {
 
 	if plan := planAdmissionMismatch(admissionMismatchFutureEpoch, mismatchErr, 0, env, 99, 0); plan.final {
 		t.Fatal("a missing delivery budget must remain on the delayed-Nak path")
+	}
+}
+
+// The admission park stamps the same typed WHY the generic DLQ park in
+// processOne writes: a parked payload is DLQ_PARKED whatever fence
+// refused it (the gate notice keys on the code, and read "" as a quota
+// pause on this path — #669 part 4). A payload the DLQ could not take
+// keeps the refusal's own cause where one exists and stays honestly
+// unknown otherwise; every outcome is final.
+func TestAdmissionParkOutcome(t *testing.T) {
+	cases := []struct {
+		name   string
+		kind   admissionMismatchKind
+		parked bool
+		want   store.FailureCode
+	}{
+		{"schema fence, parked", admissionMismatchSchema, true, store.FailureDLQParked},
+		{"future-epoch fence, parked", admissionMismatchFutureEpoch, true, store.FailureDLQParked},
+		{"schema fence, DLQ refused the payload", admissionMismatchSchema, false, store.FailureQueueSchemaMismatch},
+		{"future-epoch fence, DLQ refused the payload", admissionMismatchFutureEpoch, false, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := admissionParkOutcome(c.kind, c.parked)
+			if got.Code != c.want {
+				t.Fatalf("code = %q, want %q", got.Code, c.want)
+			}
+			if got.Continuation != store.ContinuationFinal {
+				t.Fatalf("continuation = %q, want final — nothing on the platform wakes an admission-parked run", got.Continuation)
+			}
+		})
 	}
 }

--- a/pkg/runner/rollout_test.go
+++ b/pkg/runner/rollout_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/SocialGouv/iterion/pkg/queue"
-	"github.com/SocialGouv/iterion/pkg/store"
 	natsq "github.com/SocialGouv/iterion/pkg/queue/nats"
+	"github.com/SocialGouv/iterion/pkg/store"
 )
 
 func TestRunnerEpochAdmissionRelation(t *testing.T) {

--- a/pkg/runtime/budget_ask_persist_test.go
+++ b/pkg/runtime/budget_ask_persist_test.go
@@ -1,0 +1,18 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+)
+
+// The imposed-cap marker alone persists as nothing, not as an empty
+// object: it only ever travels next to the cap it marks.
+func TestRunBudgetOverridesOf_CapImposedAloneIsNothing(t *testing.T) {
+	if got := RunBudgetOverridesOf(&ir.BudgetOverrides{CapImposed: true}); got != nil {
+		t.Fatalf("RunBudgetOverridesOf(CapImposed only) = %+v, want nil (it persisted as an empty budget_overrides: {} on the doc)", got)
+	}
+	if got := RunBudgetOverridesOf(&ir.BudgetOverrides{MaxCostUSD: 5, CapImposed: true}); got == nil || got.MaxCostUSD != 5 {
+		t.Fatalf("RunBudgetOverridesOf(clamped cap) = %+v, want the cap persisted", got)
+	}
+}

--- a/pkg/runtime/budget_persist.go
+++ b/pkg/runtime/budget_persist.go
@@ -32,3 +32,42 @@ func SnapshotBudgetForPersist(b *ir.Budget) *store.RunBudget {
 		MaxParallelBranches: b.MaxParallelBranches,
 	}
 }
+
+// BudgetOverridesFromRun lifts the budget ask persisted on a run doc
+// back into the override shape ApplyBudgetOverrides consumes — the
+// resume path's replay source, on every surface (in-process, detached,
+// cloud publish). Nil in, nil out. The one converter, so the doc→wire
+// and doc→engine readings of the ask cannot drift.
+func BudgetOverridesFromRun(o *store.RunBudgetOverrides) *ir.BudgetOverrides {
+	if o == nil {
+		return nil
+	}
+	return &ir.BudgetOverrides{
+		MaxCostUSD:          o.MaxCostUSD,
+		MaxTokens:           o.MaxTokens,
+		MaxDuration:         o.MaxDuration,
+		MaxIterations:       o.MaxIterations,
+		MaxParallelBranches: o.MaxParallelBranches,
+	}
+}
+
+// EffectiveBudgetSnapshot projects what a run's caps become once ask is
+// applied over the workflow's declared budget — the same "non-zero
+// wins, zero inherits" merge ApplyBudgetOverrides performs on the
+// executor side — WITHOUT mutating wf: a publisher stamping the doc from
+// the merged ask must not edit the workflow it was handed. Nil when
+// neither the workflow nor the ask carries a cap.
+func EffectiveBudgetSnapshot(wf *ir.Workflow, ask *ir.BudgetOverrides) *store.RunBudget {
+	var eff ir.Budget
+	if wf != nil && wf.Budget != nil {
+		eff = *wf.Budget
+	}
+	scratch := &ir.Workflow{Budget: &eff}
+	if ask != nil && !ask.IsZero() {
+		ir.ApplyBudgetOverrides(scratch, *ask)
+	}
+	if *scratch.Budget == (ir.Budget{}) {
+		return nil
+	}
+	return SnapshotBudgetForPersist(scratch.Budget)
+}

--- a/pkg/runtime/budget_persist.go
+++ b/pkg/runtime/budget_persist.go
@@ -5,7 +5,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
-// snapshotBudgetForPersist projects the EFFECTIVE ir.Budget onto the
+// SnapshotBudgetForPersist projects the EFFECTIVE ir.Budget onto the
 // display-only store.RunBudget persisted on the run. The effective budget
 // is simply what `e.workflow.Budget` holds by the time the run doc is
 // stamped at runResolveDoc: applyBudgetOverrides (CLI) and
@@ -19,7 +19,7 @@ import (
 // no cap and the studio Overview degrades to bare stats. MaxDuration is
 // resolved through ExpandEnvWithDefault so a "${DUR:-30m}" source persists
 // as the concrete "30m" the frontend parses.
-func snapshotBudgetForPersist(b *ir.Budget) *store.RunBudget {
+func SnapshotBudgetForPersist(b *ir.Budget) *store.RunBudget {
 	if b == nil {
 		return nil
 	}

--- a/pkg/runtime/budget_persist.go
+++ b/pkg/runtime/budget_persist.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	"github.com/SocialGouv/iterion/pkg/queue"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -49,6 +50,79 @@ func BudgetOverridesFromRun(o *store.RunBudgetOverrides) *ir.BudgetOverrides {
 		MaxIterations:       o.MaxIterations,
 		MaxParallelBranches: o.MaxParallelBranches,
 	}
+}
+
+// RunBudgetOverridesOf is the inverse of BudgetOverridesFromRun: the ask
+// in its persisted form. Nil (or all-zero) in, nil out, so an ask-less
+// launch persists nothing and the doc stays byte-identical.
+func RunBudgetOverridesOf(o *ir.BudgetOverrides) *store.RunBudgetOverrides {
+	if o == nil || o.IsZero() {
+		return nil
+	}
+	return &store.RunBudgetOverrides{
+		MaxCostUSD:          o.MaxCostUSD,
+		MaxTokens:           o.MaxTokens,
+		MaxDuration:         o.MaxDuration,
+		MaxIterations:       o.MaxIterations,
+		MaxParallelBranches: o.MaxParallelBranches,
+	}
+}
+
+// BudgetOverridesFromWire lifts the queue's wire mirror of a budget ask
+// back into the override shape — the one converter in that direction,
+// shared by the runner (which applies the wire to the workflow it runs)
+// and the publisher (which stamps the doc from the very figure it put on
+// the wire). Nil in, nil out.
+func BudgetOverridesFromWire(b *queue.BudgetOverrides) *ir.BudgetOverrides {
+	if b == nil {
+		return nil
+	}
+	return &ir.BudgetOverrides{
+		MaxCostUSD:          b.MaxCostUSD,
+		MaxTokens:           b.MaxTokens,
+		MaxDuration:         b.MaxDuration,
+		MaxIterations:       b.MaxIterations,
+		MaxParallelBranches: b.MaxParallelBranches,
+		CapImposed:          b.CapImposed,
+	}
+}
+
+// MergeResumeBudgetAsk MERGES a THIS-RESUME override (the CLI/API budget
+// flags on the resume request) OVER the launch ask persisted on the run
+// doc, per field — the "non-zero wins, zero inherits" rule
+// ApplyBudgetOverrides enforces on the executor side, so `--max-duration
+// 4h` alone raises the duration without erasing the launch's cost/token
+// caps. The one merge, on every resume surface (in-process, detached,
+// the CLI, the cloud publisher), so the caps a resumed run executes
+// against cannot depend on which door it came through. Nil when neither
+// side carries an ask.
+func MergeResumeBudgetAsk(fromSpec *ir.BudgetOverrides, fromDoc *store.RunBudgetOverrides) *ir.BudgetOverrides {
+	base := BudgetOverridesFromRun(fromDoc)
+	if fromSpec == nil || fromSpec.IsZero() {
+		return base
+	}
+	if base == nil {
+		base = &ir.BudgetOverrides{}
+	}
+	if fromSpec.MaxCostUSD > 0 {
+		base.MaxCostUSD = fromSpec.MaxCostUSD
+	}
+	if fromSpec.MaxTokens > 0 {
+		base.MaxTokens = fromSpec.MaxTokens
+	}
+	if fromSpec.MaxDuration != "" {
+		base.MaxDuration = fromSpec.MaxDuration
+	}
+	if fromSpec.MaxIterations > 0 {
+		base.MaxIterations = fromSpec.MaxIterations
+	}
+	if fromSpec.MaxParallelBranches > 0 {
+		base.MaxParallelBranches = fromSpec.MaxParallelBranches
+	}
+	if fromSpec.CapImposed {
+		base.CapImposed = true
+	}
+	return base
 }
 
 // EffectiveBudgetSnapshot projects what a run's caps become once ask is

--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -118,6 +118,7 @@ type Engine struct {
 	autoMerge                bool                     // worktree finalization: when true, apply mergeStrategy at end of run; otherwise leave merge_status=pending for UI; set via WithAutoMerge
 	modelOverrides           []store.RunModelOverride // launch-time per-node/-group model/backend pins, persisted display-only on the run so the studio Overview shows what it launched with; set via WithModelOverrides
 	routingPolicy            *store.RoutingPolicy     // launch-frozen outcome contract, persisted on the run doc (same replay-from-doc doctrine as the model pins); set via WithRoutingPolicy
+	budgetAsk                *ir.BudgetOverrides      // the operator's launch-time budget ask, persisted verbatim on the run doc as the resume path's replay source (same doctrine as the model pins); set via WithBudgetAsk
 	validateOutputs          bool                     // when true, validate node outputs against declared schemas
 	forceResume              bool                     // when true, skip workflow hash check on resume
 	workDir                  string                   // working directory for subprocesses + PROJECT_DIR expansion; defaults to os.Getwd() at Run() time

--- a/pkg/runtime/engine.go
+++ b/pkg/runtime/engine.go
@@ -492,6 +492,12 @@ func (e *Engine) markFailedBestEffort(ctx context.Context, runID, phase string, 
 // setupFailureStatus classifies a pre-execLoop failure, mirroring what
 // handleContextDoneWithCheckpoint decides inside a node.
 //
+//   - a sandbox driver's bounded setup phase timing out
+//     (sandbox.ErrPhaseTimeout) — a transient infrastructure stall (a
+//     stuck kubectl-exec pipe, a rescheduled apiserver): the CHILD ctx
+//     expired while the run ctx stayed live. failed_resumable, so the
+//     runner's NAK redelivers the run to a healthy pod, which routinely
+//     clears the stall;
 //   - the run ctx cancelled with ErrRunInterrupted (runner drain, lost
 //     heartbeat) — infrastructure took the run away: failed_resumable, so
 //     the ordinary retry puts it on a healthy pod;
@@ -503,6 +509,15 @@ func (e *Engine) markFailedBestEffort(ctx context.Context, runID, phase string, 
 // cancelling, so what surfaces is whatever the interrupted step returned
 // (a killed `kubectl exec`, a half-written worktree), never the cause.
 func setupFailureStatus(ctx context.Context, phase string, cause error) (store.RunStatus, string, store.FailureCode) {
+	// Checked BEFORE the ctx: a phase timeout fires on a child ctx and
+	// leaves the run ctx live, so the "ctx.Err() == nil ⇒ failed" arm
+	// below would hard-fail — and the queue would drop — a run a peer pod
+	// resumes in seconds.
+	if errors.Is(cause, sandbox.ErrPhaseTimeout) {
+		return store.RunStatusFailedResumable,
+			fmt.Sprintf("%s: sandbox setup phase timed out (resumable — a fresh pod on redelivery routinely clears the stall): %v", phase, cause),
+			store.FailureSandboxSetupTimeout
+	}
 	if ctx == nil || ctx.Err() == nil {
 		return store.RunStatusFailed, fmt.Sprintf("%s: %v", phase, cause), setupFailureCode(cause)
 	}
@@ -530,6 +545,12 @@ func setupFailureCode(cause error) store.FailureCode {
 // is redelivered to a healthy pod) and ACKs on anything else. Without it
 // the status written above would say resumable while the queue had
 // already dropped the run — the two halves have to agree.
+//
+// A sandbox phase timeout is NOT dressed up as an interruption: it keeps
+// its own sentinel (sandbox.ErrPhaseTimeout, wrapped through by the
+// driver), and the runner's ack policy classifies that shape itself — a
+// NAK for redelivery, with the DLQ park still applying on the last
+// permitted delivery, which an interruption is exempt from.
 func (e *Engine) setupErr(ctx context.Context, err error) error {
 	if ctx != nil && ctx.Err() != nil && errors.Is(context.Cause(ctx), ErrRunInterrupted) {
 		return fmt.Errorf("%w: %v", ErrRunInterrupted, err)

--- a/pkg/runtime/engine_options.go
+++ b/pkg/runtime/engine_options.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/SocialGouv/iterion/pkg/bundle"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -230,6 +231,27 @@ func WithRunName(name string) EngineOption {
 // selected.
 func WithPreset(name string) EngineOption {
 	return func(e *Engine) { e.preset = name }
+}
+
+// WithBudgetAsk records the operator's launch-time budget ask (the
+// `--max-*` flags, the launch modal's budget object) so runResolveDoc
+// persists it on the run doc as Run.BudgetOverrides — the replay source
+// every resume surface reads, so an ask-less resume keeps the cap the
+// operator launched with instead of falling back to the .bot's own. The
+// effective caps (Run.Budget) are stamped separately from wf.Budget,
+// which the caller has already applied the ask to. Nil or all-zero
+// persists nothing. Every LOCAL launch surface passes it (the CLI, the
+// in-process service, and through the CLI the detached subprocess); the
+// cloud publisher persists the ask itself at publish time and the
+// runner therefore does not.
+func WithBudgetAsk(o *ir.BudgetOverrides) EngineOption {
+	return func(e *Engine) {
+		if o == nil || o.IsZero() {
+			return
+		}
+		ask := *o
+		e.budgetAsk = &ask
+	}
 }
 
 // WithSource records the originating action that produced this run.

--- a/pkg/runtime/engine_run.go
+++ b/pkg/runtime/engine_run.go
@@ -267,7 +267,7 @@ func (e *Engine) runResolveDoc(ctx context.Context, runID string, inputs map[str
 		run = created
 	}
 	if e.workflowHash != "" || e.workflowSource != "" || e.filePath != "" || e.parentRunID != "" || e.parentNodeID != "" || e.runName != "" || e.mergeStrategy != "" || e.autoMerge || e.preset != "" || e.bundle != nil || e.source != nil || e.callbackURL != "" || len(e.modelOverrides) > 0 || e.workflow.Budget != nil ||
-		e.routingPolicy != nil {
+		e.routingPolicy != nil || e.budgetAsk != nil {
 		if e.workflowHash != "" {
 			run.WorkflowHash = e.workflowHash
 		}
@@ -317,6 +317,12 @@ func (e *Engine) runResolveDoc(ctx context.Context, runID string, inputs map[str
 		// prior snapshot if a --force resume dropped the budget: block.
 		if b := SnapshotBudgetForPersist(e.workflow.Budget); b != nil {
 			run.Budget = b
+		}
+		// The raw ask next to the effective caps: what a resume replays
+		// (Run.Budget is what it displays). Only ever set here, at launch;
+		// a raise on resume is persisted by the resume surface itself.
+		if e.budgetAsk != nil {
+			run.BudgetOverrides = RunBudgetOverridesOf(e.budgetAsk)
 		}
 		if e.bundle != nil {
 			run.BundleHash = e.bundle.Hash

--- a/pkg/runtime/engine_run.go
+++ b/pkg/runtime/engine_run.go
@@ -315,7 +315,7 @@ func (e *Engine) runResolveDoc(ctx context.Context, runID string, inputs map[str
 		// with a denominator. A resume that raises a cap re-parses the
 		// budget, so overwriting is correct; the non-nil guard preserves a
 		// prior snapshot if a --force resume dropped the budget: block.
-		if b := snapshotBudgetForPersist(e.workflow.Budget); b != nil {
+		if b := SnapshotBudgetForPersist(e.workflow.Budget); b != nil {
 			run.Budget = b
 		}
 		if e.bundle != nil {

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -727,7 +727,7 @@ func (e *Engine) parkResumeSandboxFailure(ctx context.Context, runID string, cp 
 		cp = &store.Checkpoint{NodeID: fallbackNode}
 	}
 	status, msg, code := setupFailureStatus(ctx, "sandbox start", sbErr)
-	writeCtx, cancelWrite := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	writeCtx, cancelWrite := context.WithTimeout(context.WithoutCancel(ctx), resumeParkWriteBudget)
 	defer cancelWrite()
 	if status == store.RunStatusCancelled {
 		if err := e.store.SaveCheckpoint(writeCtx, runID, cp); err != nil && e.logger != nil {
@@ -735,18 +735,38 @@ func (e *Engine) parkResumeSandboxFailure(ctx context.Context, runID string, cp 
 		}
 		changed, err := e.store.UpdateRunStatusIfCoded(writeCtx, runID, store.RunStatusCancelled, msg, code,
 			[]store.RunStatus{store.RunStatusRunning})
-		if err != nil && e.logger != nil {
+		switch {
+		case err != nil && e.logger != nil:
 			e.logger.Warn("runtime: resume: could not record the cancel during sandbox start for run %s: %v — run left non-terminal", runID, err)
-		} else if !changed && e.logger != nil {
-			e.logger.Warn("runtime: resume: cancel during sandbox start for run %s not recorded — the doc had already left `running` (a publisher or peer wrote its terminal status first; that recorded reason stands)", runID)
+		case !changed && e.logger != nil:
+			// The nominal cloud shape: the publisher CASes the doc to
+			// `cancelled` with the operator's reason BEFORE the cancel
+			// subject reaches this engine, so the decline is expected and
+			// the recorded reason stands. Anything else that moved the doc
+			// off `running` is worth a look.
+			cur, lerr := e.store.LoadRun(writeCtx, runID)
+			switch {
+			case lerr == nil && cur != nil && cur.Status == store.RunStatusCancelled:
+				e.logger.Info("runtime: resume: cancel during sandbox start for run %s already recorded (%q) — keeping that reason", runID, cur.Error)
+			case lerr == nil && cur != nil:
+				e.logger.Warn("runtime: resume: cancel during sandbox start for run %s not recorded — the doc had already left `running` for %s (a peer wrote its terminal status first; that status stands)", runID, cur.Status)
+			default:
+				e.logger.Warn("runtime: resume: cancel during sandbox start for run %s not recorded — the doc had already left `running`, and re-reading it failed (%v)", runID, lerr)
+			}
 		}
 		return fmt.Errorf("%w: sandbox start: %v", ErrRunCancelled, sbErr)
 	}
 	if err := e.store.FailRunResumable(writeCtx, runID, cp, msg, code); err != nil {
 		// Fall back to a plain terminal status so the run does not linger
-		// as `running`; if THAT fails too the run is stuck non-terminal
-		// (an orphan the operator must hand-hack), so say so.
-		if uerr := e.store.UpdateRunStatusCoded(writeCtx, runID, store.RunStatusFailed, msg, code); uerr != nil && e.logger != nil {
+		// as `running`. On its OWN short budget: the park's budget is what
+		// a wedged store has just consumed, and a fallback sharing it
+		// would be dead code on exactly the timeout it exists for. If THAT
+		// fails too the run is stuck non-terminal until the runner's
+		// redelivery adopts the `running` doc under the lock, so say so.
+		fbCtx, cancelFb := context.WithTimeout(context.WithoutCancel(ctx), resumeParkFallbackBudget)
+		uerr := e.store.UpdateRunStatusCoded(fbCtx, runID, store.RunStatusFailed, msg, code)
+		cancelFb()
+		if uerr != nil && e.logger != nil {
 			e.logger.Warn("runtime: resume: could not finalize run %s after sandbox failure (FailRunResumable: %v; UpdateRunStatus fallback: %v) — run left non-terminal", runID, err, uerr)
 		}
 	}
@@ -755,6 +775,16 @@ func (e *Engine) parkResumeSandboxFailure(ctx context.Context, runID string, cp 
 	}
 	return fmt.Errorf("runtime: sandbox: %w", sbErr)
 }
+
+// resumeParkWriteBudget bounds the resume-arm park's writes (the same 5s
+// teardown-write convention as the node loop); resumeParkFallbackBudget
+// is the terminal fallback's own, shorter bound — separate because the
+// first is what a wedged store has just spent. Vars so a test can shrink
+// them.
+var (
+	resumeParkWriteBudget    = 5 * time.Second
+	resumeParkFallbackBudget = 2 * time.Second
+)
 
 // resumeFromFailure resumes a failed_resumable run by re-executing from
 // the failing node (with checkpoint) or by restarting from the workflow

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -632,34 +632,7 @@ func (e *Engine) resumeRebuildState(ctx context.Context, r *store.Run, cp *store
 	}
 	sandboxCleanup, sbErr := e.startSandbox(ctx, runID, repoRoot, resolveWorktreeGitDir(repoRoot, r.WorkDir), r.Inputs)
 	if sbErr != nil {
-		// Same rationale as resumeFromFailure: a sandbox-start failure
-		// at resume time is almost always recoverable (stale container,
-		// docker hiccup, image pull race). Marking failed_resumable
-		// preserves the captured human answers + checkpoint so a
-		// follow-up /resume can complete once docker is unblocked.
-		//
-		// PRESERVE the rich checkpoint (outputs, loop counters, artifact
-		// versions) — a NodeID-only stub would wipe everything the bot
-		// accumulated and force the next resume to restart from entry,
-		// defeating the failed_resumable contract. Observed 2026-05-25
-		// during the issue #5 dogfood (finding `resume-orphan-gap.md`):
-		// repeated sandbox-failure resumes silently nil'd Outputs across
-		// 4 attempts before a watchexec restart re-fired the entire bot
-		// from `plan`, wasting 1.5h of prior work.
-		preservedCp := r.Checkpoint
-		if preservedCp == nil {
-			preservedCp = &store.Checkpoint{NodeID: humanNodeID}
-		}
-		if err := e.store.FailRunResumable(ctx, runID, preservedCp, sbErr.Error(), ""); err != nil {
-			// FailRunResumable failed too — fall back to a hard
-			// "failed" status flip so the run doesn't appear stuck.
-			// If even that fails, log loudly: the store is in a bad
-			// state and silently dropping the second failure would
-			// leave the run in `running` forever.
-			if uerr := e.store.UpdateRunStatus(ctx, runID, store.RunStatusFailed, sbErr.Error()); uerr != nil && e.logger != nil {
-				e.logger.Warn("runtime: resume: failed both FailRunResumable (%v) and UpdateRunStatus (%v) for run %s after sandbox error: %v", err, uerr, runID, sbErr)
-			}
-		}
+		e.parkResumeSandboxFailure(ctx, runID, r.Checkpoint, humanNodeID, sbErr)
 		return nil, nil, fmt.Errorf("runtime: sandbox: %w", sbErr)
 	}
 
@@ -713,6 +686,53 @@ func (e *Engine) resumeRebuildState(ctx context.Context, r *store.Run, cp *store
 	return rs, sandboxCleanup, nil
 }
 
+// parkResumeSandboxFailure records a sandbox-start failure met on a
+// resume arm — the one place both arms (pause, failure) write it, so a
+// resumed run's park cannot drift from a launched run's.
+//
+// The run stays RESUMABLE whatever the cause: a stale container, a
+// docker hiccup, an image-pull race clear from the operator's side, and
+// a terminal `failed` would force a fresh launch that loses every
+// committed node. The rich checkpoint is PRESERVED (outputs, loop
+// counters, artifact versions) — a NodeID-only stub would wipe
+// everything the bot accumulated and restart the next resume from the
+// entry; fallbackNode only serves a run that never earned one.
+//
+// The cause is TYPED through the classification the launch path uses
+// (setupFailureStatus), so the runner's retry lane reads a resumed run
+// exactly as a launched one: a sandbox phase timeout lands as
+// SANDBOX_SETUP_TIMEOUT (a redelivery to a fresh pod routinely clears
+// the stall), a drain as INTERRUPTED. An operator cancel is honoured as
+// `cancelled` with the checkpoint kept — the same CAS shape the node
+// loop uses, so a reason the publisher already recorded is never
+// overwritten. Every write is loud on failure: a park that does not
+// land leaves the run `running` until the orphan reconcile catches it,
+// and that must be said, not swallowed.
+func (e *Engine) parkResumeSandboxFailure(ctx context.Context, runID string, cp *store.Checkpoint, fallbackNode string, sbErr error) {
+	if cp == nil {
+		cp = &store.Checkpoint{NodeID: fallbackNode}
+	}
+	status, msg, code := setupFailureStatus(ctx, "sandbox start", sbErr)
+	if status == store.RunStatusCancelled {
+		if err := e.store.SaveCheckpoint(ctx, runID, cp); err != nil && e.logger != nil {
+			e.logger.Warn("runtime: resume: save checkpoint on cancel during sandbox start for run %s: %v", runID, err)
+		}
+		if _, err := e.store.UpdateRunStatusIfCoded(ctx, runID, store.RunStatusCancelled, msg, code,
+			[]store.RunStatus{store.RunStatusRunning}); err != nil && e.logger != nil {
+			e.logger.Warn("runtime: resume: could not record the cancel during sandbox start for run %s: %v — run left non-terminal", runID, err)
+		}
+		return
+	}
+	if err := e.store.FailRunResumable(ctx, runID, cp, msg, code); err != nil {
+		// Fall back to a plain terminal status so the run does not linger
+		// as `running`; if THAT fails too the run is stuck non-terminal
+		// (an orphan the operator must hand-hack), so say so.
+		if uerr := e.store.UpdateRunStatusCoded(ctx, runID, store.RunStatusFailed, msg, code); uerr != nil && e.logger != nil {
+			e.logger.Warn("runtime: resume: could not finalize run %s after sandbox failure (FailRunResumable: %v; UpdateRunStatus fallback: %v) — run left non-terminal", runID, err, uerr)
+		}
+	}
+}
+
 // resumeFromFailure resumes a failed_resumable run by re-executing from
 // the failing node (with checkpoint) or by restarting from the workflow
 // entry node (no checkpoint). The "no checkpoint" path matters when a
@@ -758,34 +778,7 @@ func (e *Engine) resumeFromFailure(ctx context.Context, r *store.Run) error {
 	}
 	sandboxCleanup, sbErr := e.startSandbox(ctx, runID, repoRoot, resolveWorktreeGitDir(repoRoot, r.WorkDir), r.Inputs)
 	if sbErr != nil {
-		// Sandbox-start failures on resume are almost always recoverable
-		// from the operator's side: stale containers (force-removable),
-		// docker daemon hiccups, image pull races, etc. Marking the run
-		// `failed_resumable` instead of `failed` keeps the door open for
-		// a second /resume after the operator addresses the underlying
-		// cause — the alternative (status=failed) is terminal and forces
-		// a fresh launch that loses all committed per-package work.
-		// PRESERVE the rich checkpoint — same rationale as the sister
-		// branch in resumeFromPause: a NodeID-only stub here would wipe
-		// Outputs/LoopCounters/etc and force the next resume to restart
-		// from entry. Issue #5's 2026-05-25 dogfood showed this in
-		// practice: 4 sandbox-related sub-failures across the run
-		// silently degraded the checkpoint until a final watchexec
-		// restart re-ran the bot from `plan`, throwing away 1.5h of
-		// fix_claude iterations.
-		preservedCp := cp
-		if preservedCp == nil {
-			preservedCp = &store.Checkpoint{NodeID: e.workflow.Entry}
-		}
-		if frErr := e.store.FailRunResumable(ctx, runID, preservedCp, sbErr.Error(), ""); frErr != nil {
-			// FailRunResumable failed — fall back to a plain terminal status so
-			// the run doesn't linger as `running`. If THAT also fails the run is
-			// stuck non-terminal (an orphan the operator must hand-hack), so
-			// surface it instead of swallowing the error.
-			if usErr := e.store.UpdateRunStatus(ctx, runID, store.RunStatusFailed, sbErr.Error()); usErr != nil && e.logger != nil {
-				e.logger.Warn("runtime: resume: could not finalize run %s after sandbox failure (FailRunResumable: %v; UpdateRunStatus fallback: %v) — run left non-terminal", runID, frErr, usErr)
-			}
-		}
+		e.parkResumeSandboxFailure(ctx, runID, cp, e.workflow.Entry, sbErr)
 		return fmt.Errorf("runtime: sandbox: %w", sbErr)
 	}
 	defer sandboxCleanup()

--- a/pkg/runtime/resume.go
+++ b/pkg/runtime/resume.go
@@ -632,8 +632,7 @@ func (e *Engine) resumeRebuildState(ctx context.Context, r *store.Run, cp *store
 	}
 	sandboxCleanup, sbErr := e.startSandbox(ctx, runID, repoRoot, resolveWorktreeGitDir(repoRoot, r.WorkDir), r.Inputs)
 	if sbErr != nil {
-		e.parkResumeSandboxFailure(ctx, runID, r.Checkpoint, humanNodeID, sbErr)
-		return nil, nil, fmt.Errorf("runtime: sandbox: %w", sbErr)
+		return nil, nil, e.parkResumeSandboxFailure(ctx, runID, r.Checkpoint, humanNodeID, sbErr)
 	}
 
 	rs := e.newRunState(runID, r.Inputs)
@@ -708,29 +707,53 @@ func (e *Engine) resumeRebuildState(ctx context.Context, r *store.Run, cp *store
 // overwritten. Every write is loud on failure: a park that does not
 // land leaves the run `running` until the orphan reconcile catches it,
 // and that must be said, not swallowed.
-func (e *Engine) parkResumeSandboxFailure(ctx context.Context, runID string, cp *store.Checkpoint, fallbackNode string, sbErr error) {
+//
+// The writes ride a DETACHED, bounded context: on the cancel and drain
+// arms the run ctx is the very ctx that was just cancelled, and a store
+// that honours it (Mongo) would refuse every write — the run would read
+// `running` forever with the park logged as "context canceled". Same
+// convention as the node loop's handleContextDoneWithCheckpoint and the
+// launch path's markFailedBestEffort.
+//
+// The returned error is what the runner classifies, so it carries the
+// same sentinel the status carries — ErrRunCancelled for an operator
+// cancel (acked, never redelivered), ErrRunInterrupted for a drain
+// (naked, exempt from the DLQ park), the driver's own sandbox.ErrPhaseTimeout
+// for a stall (naked with a delay) — mirroring setupErr on the launch
+// path. A bare wrap would read as a generic failure: an operator cancel
+// burning a delivery, a drain parked on the DLQ.
+func (e *Engine) parkResumeSandboxFailure(ctx context.Context, runID string, cp *store.Checkpoint, fallbackNode string, sbErr error) error {
 	if cp == nil {
 		cp = &store.Checkpoint{NodeID: fallbackNode}
 	}
 	status, msg, code := setupFailureStatus(ctx, "sandbox start", sbErr)
+	writeCtx, cancelWrite := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancelWrite()
 	if status == store.RunStatusCancelled {
-		if err := e.store.SaveCheckpoint(ctx, runID, cp); err != nil && e.logger != nil {
+		if err := e.store.SaveCheckpoint(writeCtx, runID, cp); err != nil && e.logger != nil {
 			e.logger.Warn("runtime: resume: save checkpoint on cancel during sandbox start for run %s: %v", runID, err)
 		}
-		if _, err := e.store.UpdateRunStatusIfCoded(ctx, runID, store.RunStatusCancelled, msg, code,
-			[]store.RunStatus{store.RunStatusRunning}); err != nil && e.logger != nil {
+		changed, err := e.store.UpdateRunStatusIfCoded(writeCtx, runID, store.RunStatusCancelled, msg, code,
+			[]store.RunStatus{store.RunStatusRunning})
+		if err != nil && e.logger != nil {
 			e.logger.Warn("runtime: resume: could not record the cancel during sandbox start for run %s: %v — run left non-terminal", runID, err)
+		} else if !changed && e.logger != nil {
+			e.logger.Warn("runtime: resume: cancel during sandbox start for run %s not recorded — the doc had already left `running` (a publisher or peer wrote its terminal status first; that recorded reason stands)", runID)
 		}
-		return
+		return fmt.Errorf("%w: sandbox start: %v", ErrRunCancelled, sbErr)
 	}
-	if err := e.store.FailRunResumable(ctx, runID, cp, msg, code); err != nil {
+	if err := e.store.FailRunResumable(writeCtx, runID, cp, msg, code); err != nil {
 		// Fall back to a plain terminal status so the run does not linger
 		// as `running`; if THAT fails too the run is stuck non-terminal
 		// (an orphan the operator must hand-hack), so say so.
-		if uerr := e.store.UpdateRunStatusCoded(ctx, runID, store.RunStatusFailed, msg, code); uerr != nil && e.logger != nil {
+		if uerr := e.store.UpdateRunStatusCoded(writeCtx, runID, store.RunStatusFailed, msg, code); uerr != nil && e.logger != nil {
 			e.logger.Warn("runtime: resume: could not finalize run %s after sandbox failure (FailRunResumable: %v; UpdateRunStatus fallback: %v) — run left non-terminal", runID, err, uerr)
 		}
 	}
+	if code == store.FailureInterrupted {
+		return fmt.Errorf("%w: sandbox start: %v", ErrRunInterrupted, sbErr)
+	}
+	return fmt.Errorf("runtime: sandbox: %w", sbErr)
 }
 
 // resumeFromFailure resumes a failed_resumable run by re-executing from
@@ -778,8 +801,7 @@ func (e *Engine) resumeFromFailure(ctx context.Context, r *store.Run) error {
 	}
 	sandboxCleanup, sbErr := e.startSandbox(ctx, runID, repoRoot, resolveWorktreeGitDir(repoRoot, r.WorkDir), r.Inputs)
 	if sbErr != nil {
-		e.parkResumeSandboxFailure(ctx, runID, cp, e.workflow.Entry, sbErr)
-		return fmt.Errorf("runtime: sandbox: %w", sbErr)
+		return e.parkResumeSandboxFailure(ctx, runID, cp, e.workflow.Entry, sbErr)
 	}
 	defer sandboxCleanup()
 

--- a/pkg/runtime/resume_sandbox_park_test.go
+++ b/pkg/runtime/resume_sandbox_park_test.go
@@ -1,11 +1,13 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
@@ -119,6 +121,100 @@ func TestParkResumeSandboxFailure_DrainLandsOnACtxHonouringStore(t *testing.T) {
 	}
 	if !errors.Is(err, ErrRunInterrupted) {
 		t.Fatalf("returned error = %v, want ErrRunInterrupted — without it the drain misses the DLQ exemption", err)
+	}
+}
+
+// wedgedStore consumes the whole write budget on FailRunResumable (a store
+// that never answers) and refuses the fallback when the ctx it is handed
+// is already dead — so a fallback sharing the park's budget is dead code
+// on exactly the timeout it exists for.
+type wedgedStore struct{ store.RunStore }
+
+func (s wedgedStore) FailRunResumable(ctx context.Context, id string, _ *store.Checkpoint, _ string, _ store.FailureCode) error {
+	<-ctx.Done()
+	return fmt.Errorf("fail resumable %s: %w", id, ctx.Err())
+}
+
+func (s wedgedStore) UpdateRunStatusCoded(ctx context.Context, id string, status store.RunStatus, runErr string, code store.FailureCode) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("update status %s: %w", id, err)
+	}
+	return s.RunStore.UpdateRunStatusCoded(ctx, id, status, runErr, code)
+}
+
+// When the park's own write times out, the terminal fallback must still
+// get a chance: on its own budget it lands `failed`; on the park's spent
+// budget it is dead code and the run stays `running`.
+func TestParkResumeSandboxFailure_FallbackHasItsOwnBudget(t *testing.T) {
+	prevWrite, prevFb := resumeParkWriteBudget, resumeParkFallbackBudget
+	resumeParkWriteBudget, resumeParkFallbackBudget = 100*time.Millisecond, 500*time.Millisecond
+	t.Cleanup(func() { resumeParkWriteBudget, resumeParkFallbackBudget = prevWrite, prevFb })
+
+	fs := tmpStore(t)
+	e := &Engine{store: wedgedStore{fs}, logger: iterlog.Nop()}
+	const runID = "run-resume-sandbox-wedged"
+	cp := seedRunningResume(t, fs, runID)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(ErrRunInterrupted)
+	err := e.parkResumeSandboxFailure(ctx, runID, cp, "entry", errors.New("kubectl exec: signal: killed"))
+	if !errors.Is(err, ErrRunInterrupted) {
+		t.Fatalf("returned error = %v, want ErrRunInterrupted regardless of the store", err)
+	}
+	r, _ := fs.LoadRun(context.Background(), runID)
+	if r.Status != store.RunStatusFailed {
+		t.Fatalf("status = %s after the park's write timed out, want failed from the fallback — on the park's spent budget the fallback is dead code and the run sits running until the redelivery adopts it", r.Status)
+	}
+}
+
+// The nominal cloud cancel: the publisher CASes the doc to `cancelled`
+// with the operator's reason BEFORE the cancel subject reaches the engine,
+// so the park's own CAS from `running` is expected to decline. That is
+// Info, not a warning — the recorded reason stands.
+func TestParkResumeSandboxFailure_PublisherFirstCancelIsInfoNotWarn(t *testing.T) {
+	fs := tmpStore(t)
+	var logs bytes.Buffer
+	e := &Engine{store: fs, logger: iterlog.New(iterlog.LevelInfo, &logs)}
+	const runID = "run-resume-sandbox-cancel-first"
+	cp := seedRunningResume(t, fs, runID)
+	if err := fs.UpdateRunStatusCoded(context.Background(), runID, store.RunStatusCancelled, "cancelled by user", store.FailureCancelled); err != nil {
+		t.Fatalf("publisher-first cancel: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = e.parkResumeSandboxFailure(ctx, runID, cp, "entry", errors.New("docker start: context canceled"))
+
+	r, _ := fs.LoadRun(context.Background(), runID)
+	if r.Status != store.RunStatusCancelled || r.Error != "cancelled by user" {
+		t.Fatalf("doc = %s/%q, want the publisher's cancel and reason kept", r.Status, r.Error)
+	}
+	if strings.Contains(logs.String(), "⚠️") {
+		t.Fatalf("a warning fired on the nominal publisher-first cancel:\n%s", logs.String())
+	}
+	if !strings.Contains(logs.String(), "already recorded") {
+		t.Fatalf("expected an Info line saying the cancel was already recorded, got:\n%s", logs.String())
+	}
+}
+
+// A doc that left `running` for anything OTHER than cancelled is worth a
+// warning: something else wrote the terminal status first.
+func TestParkResumeSandboxFailure_DocMovedElsewhereIsWarn(t *testing.T) {
+	fs := tmpStore(t)
+	var logs bytes.Buffer
+	e := &Engine{store: fs, logger: iterlog.New(iterlog.LevelInfo, &logs)}
+	const runID = "run-resume-sandbox-cancel-moved"
+	cp := seedRunningResume(t, fs, runID)
+	if err := fs.UpdateRunStatus(context.Background(), runID, store.RunStatusFinished, ""); err != nil {
+		t.Fatalf("peer write: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = e.parkResumeSandboxFailure(ctx, runID, cp, "entry", errors.New("docker start: context canceled"))
+
+	if !strings.Contains(logs.String(), "⚠️") || !strings.Contains(logs.String(), "finished") {
+		t.Fatalf("expected a warning naming the status the doc moved to, got:\n%s", logs.String())
 	}
 }
 

--- a/pkg/runtime/resume_sandbox_park_test.go
+++ b/pkg/runtime/resume_sandbox_park_test.go
@@ -1,0 +1,142 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// Both resume arms park a sandbox-start failure through one helper. What
+// the arms used to write was FailRunResumable(…, sbErr.Error(), ""): the
+// checkpoint survived but the cause did not — a sandbox phase timeout on
+// a RESUMED run carried no SANDBOX_SETUP_TIMEOUT, exactly the shape #669
+// measured (a resumed review stalled in sandbox start). The typed code is
+// what the runner's retry lane and the gate notice read.
+
+func seedRunningResume(t *testing.T, s store.RunStore, runID string) *store.Checkpoint {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := s.CreateRun(ctx, runID, "wf", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	cp := &store.Checkpoint{
+		NodeID:  "campaign",
+		Outputs: map[string]map[string]any{"plan": {"steps": 3}},
+	}
+	if err := s.SaveCheckpoint(ctx, runID, cp); err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+	if err := s.UpdateRunStatus(ctx, runID, store.RunStatusRunning, ""); err != nil {
+		t.Fatalf("UpdateRunStatus(running): %v", err)
+	}
+	return cp
+}
+
+func TestParkResumeSandboxFailure_PhaseTimeoutIsTypedAndKeepsTheCheckpoint(t *testing.T) {
+	s := tmpStore(t)
+	e := &Engine{store: s, logger: iterlog.Nop()}
+	const runID = "run-resume-sandbox-timeout"
+	cp := seedRunningResume(t, s, runID)
+
+	sbErr := fmt.Errorf("kubernetes: workspace copy phase timed out: %w",
+		errors.Join(sandbox.ErrPhaseTimeout, context.DeadlineExceeded, errors.New("in-pod tar extract stalled")))
+	e.parkResumeSandboxFailure(context.Background(), runID, cp, "entry", sbErr)
+
+	r, err := s.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.Status != store.RunStatusFailedResumable {
+		t.Fatalf("status = %s, want failed_resumable (the documented resume-arm contract)", r.Status)
+	}
+	if r.FailureCode != store.FailureSandboxSetupTimeout {
+		t.Fatalf("FailureCode = %q, want SANDBOX_SETUP_TIMEOUT — on a resumed run the phase timeout lands untyped, so the retry lane and the gate notice cannot tell it from a generic failure (#669's own shape)", r.FailureCode)
+	}
+	if !strings.Contains(r.Error, "sandbox setup phase timed out") || !strings.Contains(r.Error, "in-pod tar extract stalled") {
+		t.Fatalf("Error = %q, want the classification's message with the cause kept", r.Error)
+	}
+	if r.Checkpoint == nil || r.Checkpoint.NodeID != "campaign" || r.Checkpoint.Outputs["plan"] == nil {
+		t.Fatalf("checkpoint after the park = %+v, want the rich checkpoint preserved (a stub would restart the next resume from the entry)", r.Checkpoint)
+	}
+}
+
+func TestParkResumeSandboxFailure_DrainIsInterruptedAndResumable(t *testing.T) {
+	s := tmpStore(t)
+	e := &Engine{store: s, logger: iterlog.Nop()}
+	const runID = "run-resume-sandbox-drain"
+	cp := seedRunningResume(t, s, runID)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(ErrRunInterrupted)
+	e.parkResumeSandboxFailure(ctx, runID, cp, "entry", errors.New("kubectl exec: signal: killed"))
+
+	r, _ := s.LoadRun(context.Background(), runID)
+	if r.Status != store.RunStatusFailedResumable || r.FailureCode != store.FailureInterrupted {
+		t.Fatalf("status/code = %s/%q, want failed_resumable/INTERRUPTED", r.Status, r.FailureCode)
+	}
+}
+
+func TestParkResumeSandboxFailure_OperatorCancelIsCancelledWithTheCheckpoint(t *testing.T) {
+	s := tmpStore(t)
+	e := &Engine{store: s, logger: iterlog.Nop()}
+	const runID = "run-resume-sandbox-cancel"
+	cp := seedRunningResume(t, s, runID)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	e.parkResumeSandboxFailure(ctx, runID, cp, "entry", errors.New("docker start: context canceled"))
+
+	r, _ := s.LoadRun(context.Background(), runID)
+	if r.Status != store.RunStatusCancelled || r.FailureCode != store.FailureCancelled {
+		t.Fatalf("status/code = %s/%q, want cancelled/CANCELLED (the launch path says who stopped it; the resume arm must too)", r.Status, r.FailureCode)
+	}
+	if r.Checkpoint == nil || r.Checkpoint.NodeID != "campaign" {
+		t.Fatalf("checkpoint after the cancel = %+v, want kept — cancelled is a resumable status", r.Checkpoint)
+	}
+}
+
+func TestParkResumeSandboxFailure_PlainErrorStaysResumableAndUntyped(t *testing.T) {
+	s := tmpStore(t)
+	e := &Engine{store: s, logger: iterlog.Nop()}
+	const runID = "run-resume-sandbox-plain"
+	cp := seedRunningResume(t, s, runID)
+
+	e.parkResumeSandboxFailure(context.Background(), runID, cp, "entry", errors.New("docker: image pull: connection reset"))
+
+	r, _ := s.LoadRun(context.Background(), runID)
+	if r.Status != store.RunStatusFailedResumable {
+		t.Fatalf("status = %s, want failed_resumable — a docker hiccup on resume must stay resumable, unlike the launch path", r.Status)
+	}
+	if r.FailureCode != "" {
+		t.Fatalf("FailureCode = %q, want unknown (empty) for a cause the taxonomy does not name", r.FailureCode)
+	}
+	if !strings.Contains(r.Error, "sandbox start") || !strings.Contains(r.Error, "connection reset") {
+		t.Fatalf("Error = %q, want the phase and the cause", r.Error)
+	}
+}
+
+// A run that never earned a checkpoint parks on the fallback node.
+func TestParkResumeSandboxFailure_NoCheckpointParksOnTheFallbackNode(t *testing.T) {
+	s := tmpStore(t)
+	e := &Engine{store: s, logger: iterlog.Nop()}
+	const runID = "run-resume-sandbox-nocp"
+	if _, err := s.CreateRun(context.Background(), runID, "wf", nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpdateRunStatus(context.Background(), runID, store.RunStatusRunning, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	e.parkResumeSandboxFailure(context.Background(), runID, nil, "plan", errors.New("boom"))
+
+	r, _ := s.LoadRun(context.Background(), runID)
+	if r.Checkpoint == nil || r.Checkpoint.NodeID != "plan" {
+		t.Fatalf("checkpoint = %+v, want a stub on the fallback node", r.Checkpoint)
+	}
+}

--- a/pkg/runtime/resume_sandbox_park_test.go
+++ b/pkg/runtime/resume_sandbox_park_test.go
@@ -38,6 +38,90 @@ func seedRunningResume(t *testing.T, s store.RunStore, runID string) *store.Chec
 	return cp
 }
 
+// ctxHonouringStore refuses every write the park issues once the ctx it
+// is handed is done — what the Mongo driver does, and what the fs store
+// (which ignores ctx) does not. The cancel and drain arms park on the
+// very ctx that was just cancelled, so a test on the fs store alone
+// certifies a stub.
+type ctxHonouringStore struct{ store.RunStore }
+
+func (s ctxHonouringStore) SaveCheckpoint(ctx context.Context, id string, cp *store.Checkpoint) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("save checkpoint %s: %w", id, err)
+	}
+	return s.RunStore.SaveCheckpoint(ctx, id, cp)
+}
+
+func (s ctxHonouringStore) UpdateRunStatusIfCoded(ctx context.Context, id string, status store.RunStatus, runErr string, code store.FailureCode, from []store.RunStatus) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, fmt.Errorf("update status if %s: %w", id, err)
+	}
+	return s.RunStore.UpdateRunStatusIfCoded(ctx, id, status, runErr, code, from)
+}
+
+func (s ctxHonouringStore) FailRunResumable(ctx context.Context, id string, cp *store.Checkpoint, runErr string, code store.FailureCode) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("fail resumable %s: %w", id, err)
+	}
+	return s.RunStore.FailRunResumable(ctx, id, cp, runErr, code)
+}
+
+func (s ctxHonouringStore) UpdateRunStatusCoded(ctx context.Context, id string, status store.RunStatus, runErr string, code store.FailureCode) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("update status %s: %w", id, err)
+	}
+	return s.RunStore.UpdateRunStatusCoded(ctx, id, status, runErr, code)
+}
+
+// The operator-cancel arm on a ctx-honouring store: the ctx is the one
+// that was just cancelled, so a park written on it lands nowhere — the
+// run reads `running` with the park logged as "context canceled". The
+// write must ride a detached ctx, and the error handed to the runner must
+// carry ErrRunCancelled so the delivery is acked, not burnt.
+func TestParkResumeSandboxFailure_OperatorCancelLandsOnACtxHonouringStore(t *testing.T) {
+	fs := tmpStore(t)
+	e := &Engine{store: ctxHonouringStore{fs}, logger: iterlog.Nop()}
+	const runID = "run-resume-sandbox-cancel-mongo"
+	cp := seedRunningResume(t, fs, runID)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := e.parkResumeSandboxFailure(ctx, runID, cp, "entry", errors.New("docker start: context canceled"))
+
+	r, _ := fs.LoadRun(context.Background(), runID)
+	if r.Status != store.RunStatusCancelled || r.FailureCode != store.FailureCancelled {
+		t.Fatalf("status/code = %s/%q, want cancelled/CANCELLED — the park was written on the cancelled ctx and a ctx-honouring store refused it (the run reads running forever on Mongo)", r.Status, r.FailureCode)
+	}
+	if r.Checkpoint == nil || r.Checkpoint.NodeID != "campaign" {
+		t.Fatalf("checkpoint = %+v, want kept", r.Checkpoint)
+	}
+	if !errors.Is(err, ErrRunCancelled) {
+		t.Fatalf("returned error = %v, want ErrRunCancelled — a bare wrap classifies as a generic failure and the runner naks an operator cancel", err)
+	}
+}
+
+// The drain arm on a ctx-honouring store: same detached write, and the
+// error carries ErrRunInterrupted so the runner naks it exempt from the
+// DLQ park.
+func TestParkResumeSandboxFailure_DrainLandsOnACtxHonouringStore(t *testing.T) {
+	fs := tmpStore(t)
+	e := &Engine{store: ctxHonouringStore{fs}, logger: iterlog.Nop()}
+	const runID = "run-resume-sandbox-drain-mongo"
+	cp := seedRunningResume(t, fs, runID)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(ErrRunInterrupted)
+	err := e.parkResumeSandboxFailure(ctx, runID, cp, "entry", errors.New("kubectl exec: signal: killed"))
+
+	r, _ := fs.LoadRun(context.Background(), runID)
+	if r.Status != store.RunStatusFailedResumable || r.FailureCode != store.FailureInterrupted {
+		t.Fatalf("status/code = %s/%q, want failed_resumable/INTERRUPTED — the park was refused on the cancelled ctx", r.Status, r.FailureCode)
+	}
+	if !errors.Is(err, ErrRunInterrupted) {
+		t.Fatalf("returned error = %v, want ErrRunInterrupted — without it the drain misses the DLQ exemption", err)
+	}
+}
+
 func TestParkResumeSandboxFailure_PhaseTimeoutIsTypedAndKeepsTheCheckpoint(t *testing.T) {
 	s := tmpStore(t)
 	e := &Engine{store: s, logger: iterlog.Nop()}
@@ -46,7 +130,10 @@ func TestParkResumeSandboxFailure_PhaseTimeoutIsTypedAndKeepsTheCheckpoint(t *te
 
 	sbErr := fmt.Errorf("kubernetes: workspace copy phase timed out: %w",
 		errors.Join(sandbox.ErrPhaseTimeout, context.DeadlineExceeded, errors.New("in-pod tar extract stalled")))
-	e.parkResumeSandboxFailure(context.Background(), runID, cp, "entry", sbErr)
+	perr := e.parkResumeSandboxFailure(context.Background(), runID, cp, "entry", sbErr)
+	if !errors.Is(perr, sandbox.ErrPhaseTimeout) || errors.Is(perr, ErrRunInterrupted) || errors.Is(perr, ErrRunCancelled) {
+		t.Fatalf("returned error = %v, want the driver's phase-timeout sentinel kept and no interruption/cancel dressing (the runner classifies it as a delayed nak)", perr)
+	}
 
 	r, err := s.LoadRun(context.Background(), runID)
 	if err != nil {

--- a/pkg/runtime/setup_failure_status_test.go
+++ b/pkg/runtime/setup_failure_status_test.go
@@ -3,10 +3,12 @@ package runtime
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
@@ -44,6 +46,50 @@ func TestSetupFailureStatus(t *testing.T) {
 				t.Errorf("the message must keep the phase and the cause; got %q", msg)
 			}
 		})
+	}
+}
+
+// A sandbox phase timeout is a transient infrastructure stall (a stuck
+// kubectl-exec pipe, a rescheduled apiserver): the child ctx expired
+// while the run ctx stayed live. It must classify to failed_resumable +
+// SANDBOX_SETUP_TIMEOUT so the redelivery resumes on a healthy pod —
+// not the default RunStatusFailed the live-ctx arm produces, which the
+// queue then drops as a stale delivery.
+func TestSetupFailureStatus_PhaseTimeoutIsResumable(t *testing.T) {
+	// Wrap like runWithPhaseTimeout does: sandbox.ErrPhaseTimeout +
+	// context.DeadlineExceeded + inner cause via errors.Join.
+	inner := errors.New("kubectl-exec pipe stalled")
+	cause := fmt.Errorf("kubernetes: workspace copy phase timed out: %w",
+		errors.Join(sandbox.ErrPhaseTimeout, context.DeadlineExceeded, inner))
+
+	got, msg, code := setupFailureStatus(context.Background(), "sandbox start", cause)
+	if got != store.RunStatusFailedResumable {
+		t.Fatalf("phase-timeout status = %q, want failed_resumable — the runner would ACK the delivery and hard-fail a run a peer pod would resume in seconds (E6)", got)
+	}
+	if code != store.FailureSandboxSetupTimeout {
+		t.Fatalf("phase-timeout code = %q, want SANDBOX_SETUP_TIMEOUT — the retry lane needs the taxonomy entry", code)
+	}
+	if !strings.Contains(msg, "sandbox setup phase timed out") {
+		t.Fatalf("message must say what happened, got %q", msg)
+	}
+}
+
+// setupErr hands the phase timeout to the runner under its OWN sentinel:
+// the runner's ack policy classifies sandbox.ErrPhaseTimeout itself. It
+// must not be dressed up as ErrRunInterrupted — an interruption is exempt
+// from the DLQ park, so a stall repeating through every permitted
+// delivery would nak into nothing instead of parking and being announced.
+func TestSetupErr_PhaseTimeoutKeepsItsOwnSentinel(t *testing.T) {
+	e := &Engine{}
+	inner := errors.New("stalled")
+	phaseTimeout := fmt.Errorf("kubernetes: workspace copy phase timed out: %w",
+		errors.Join(sandbox.ErrPhaseTimeout, context.DeadlineExceeded, inner))
+	err := e.setupErr(context.Background(), phaseTimeout)
+	if !errors.Is(err, sandbox.ErrPhaseTimeout) {
+		t.Fatalf("phase-timeout identity lost after setupErr; got %v", err)
+	}
+	if errors.Is(err, ErrRunInterrupted) {
+		t.Fatalf("phase-timeout was dressed up as an interruption: %v — the runner would exempt it from the DLQ park", err)
 	}
 }
 

--- a/pkg/runview/detached.go
+++ b/pkg/runview/detached.go
@@ -154,6 +154,27 @@ func buildRunnerCmd(ctx context.Context, bin string, spec detachedSpec) (*exec.C
 		for k, v := range spec.Answers {
 			args = append(args, "--answer", k+"="+v)
 		}
+		// E2 (#652 review round 1): forward budget overrides as CLI
+		// flags so a detached resume raises the cap identically to
+		// the in-process / cloud paths. Without it the child re-parsed
+		// the .bot's cap and died at the same wall.
+		if b := spec.Budget; b != nil {
+			if b.MaxCostUSD > 0 {
+				args = append(args, "--max-cost-usd", strconv.FormatFloat(b.MaxCostUSD, 'f', -1, 64))
+			}
+			if b.MaxTokens > 0 {
+				args = append(args, "--max-tokens", strconv.Itoa(b.MaxTokens))
+			}
+			if b.MaxDuration != "" {
+				args = append(args, "--max-duration", b.MaxDuration)
+			}
+			if b.MaxIterations > 0 {
+				args = append(args, "--max-iterations", strconv.Itoa(b.MaxIterations))
+			}
+			if b.MaxParallelBranches > 0 {
+				args = append(args, "--max-parallel-branches", strconv.Itoa(b.MaxParallelBranches))
+			}
+		}
 	default:
 		return nil, fmt.Errorf("runview: detached: unknown command %q", spec.Command)
 	}
@@ -393,6 +414,11 @@ func (s *Service) resumeDetached(parent context.Context, spec ResumeSpec) (*Laun
 		Supervisors:     spec.Supervisors,
 		Force:           spec.Force,
 		Timeout:         spec.Timeout,
+		// E2 (#652 review round 1): forward the resume-time budget
+		// override so the detached CLI subprocess raises the cap too.
+		// Without it a --max-cost-usd on a detached resume was inert
+		// — the child ran the launch-time figure that killed the run.
+		Budget: spec.Budget,
 	})
 	if err != nil {
 		s.dropRunLog(spec.RunID)

--- a/pkg/runview/detached_resume_budget_test.go
+++ b/pkg/runview/detached_resume_budget_test.go
@@ -1,0 +1,70 @@
+package runview
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+)
+
+// E2 part 2: the detached-resume subprocess CLI must receive the
+// resume-time budget flags. buildRunnerCmd's runnerCommandResume case
+// did not emit any of the --max-* flags, so a detached resume ran the
+// child on the .bot's launch-time cap — silently ignoring the operator's
+// raise-the-cap ask. Same shape as the launch case that has always
+// emitted them.
+func TestBuildRunnerCmd_ResumeEmitsBudgetFlags(t *testing.T) {
+	cmd, err := buildRunnerCmd(context.Background(), "iterion", detachedSpec{
+		Command:  runnerCommandResume,
+		RunID:    "run-1",
+		FilePath: "/tmp/wf.bot",
+		StoreDir: "/tmp/store",
+		Budget: &ir.BudgetOverrides{
+			MaxCostUSD:          120,
+			MaxTokens:           5_000_000,
+			MaxDuration:         "4h",
+			MaxIterations:       50,
+			MaxParallelBranches: 8,
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildRunnerCmd: %v", err)
+	}
+	args := strings.Join(cmd.Args, " ")
+	for flag, want := range map[string]string{
+		"--max-cost-usd":          "120",
+		"--max-tokens":            "5000000",
+		"--max-duration":          "4h",
+		"--max-iterations":        "50",
+		"--max-parallel-branches": "8",
+	} {
+		if !strings.Contains(args, flag+" "+want) {
+			t.Errorf("detached-resume args missing %q — the child would ignore the operator's raise-the-cap ask (E2)\nfull: %s", flag+" "+want, args)
+		}
+	}
+}
+
+// A resume spec with no budget must NOT emit any budget flag: an empty
+// ask stays byte-identical to the pre-fix wire, and a zero-valued flag
+// on the child (`--max-cost-usd 0`) would erase the .bot's cap.
+func TestBuildRunnerCmd_ResumeWithoutBudgetEmitsNoBudgetFlags(t *testing.T) {
+	cmd, err := buildRunnerCmd(context.Background(), "iterion", detachedSpec{
+		Command:  runnerCommandResume,
+		RunID:    "run-2",
+		FilePath: "/tmp/wf.bot",
+		StoreDir: "/tmp/store",
+	})
+	if err != nil {
+		t.Fatalf("buildRunnerCmd: %v", err)
+	}
+	args := strings.Join(cmd.Args, " ")
+	for _, flag := range []string{
+		"--max-cost-usd", "--max-tokens", "--max-duration",
+		"--max-iterations", "--max-parallel-branches",
+	} {
+		if strings.Contains(args, flag) {
+			t.Errorf("empty-budget resume emitted %q — a zero flag would erase the .bot's cap in the child\nfull: %s", flag, args)
+		}
+	}
+}

--- a/pkg/runview/service.go
+++ b/pkg/runview/service.go
@@ -373,6 +373,14 @@ type ResumeSpec struct {
 	// Supervisors re-states the run-level supervisors kill switch
 	// ("", "on", "off"), for the same reason AutoMemory does.
 	Supervisors string
+	// Budget re-states the operator's cap ask FOR THIS RESUME. Non-nil
+	// overrides the launch-time budget persisted on the run doc (which
+	// is otherwise the replay source) — the "raise the cap + resume"
+	// recovery. Persisted to the run doc so a subsequent auto-retry
+	// keeps the raised cap instead of silently reverting to the launch
+	// ask that already killed the run. Nil = inherit the doc's replay
+	// source (today's behaviour).
+	Budget *ir.BudgetOverrides
 }
 
 // RunSummary is the lightweight per-row shape returned by List.

--- a/pkg/runview/service_launch.go
+++ b/pkg/runview/service_launch.go
@@ -496,31 +496,28 @@ func (s *Service) Resume(parent context.Context, spec ResumeSpec) (*LaunchResult
 		return nil, err
 	}
 
-	// E2 (#652 review round 1): apply the resume budget override to wf
-	// BEFORE the branch fork, so every downstream path (cloud publish,
-	// detached, in-process) executes against the raised caps. The
-	// executor snapshots Budget at construction time, so this must
-	// happen before BuildExecutor below. Same ordering + merge contract
-	// as Launch (service_launch.go:250).
-	//
-	// The persisted r.Budget snapshot (studio Overview) is also
-	// refreshed so the operator sees the raised cap immediately, not
-	// the launch-time figure that just killed the run. Best-effort:
-	// a store blip here does not fail the resume.
-	if spec.Budget != nil && !spec.Budget.IsZero() {
+	// The budget a resume executes against composes, per field, the ask
+	// persisted at launch (the doc's replay source) and THIS resume's
+	// ask — non-zero wins, zero inherits — applied to wf BEFORE the
+	// branch fork so every downstream path (cloud publish, detached,
+	// in-process) sees the same caps. The executor snapshots Budget at
+	// construction time, so this must happen before BuildExecutor below.
+	// Same merge the cloud wire performs (resolveResumeBudgetAsk).
+	if fromDoc := runtime.BudgetOverridesFromRun(r.BudgetOverrides); fromDoc != nil {
+		ir.ApplyBudgetOverrides(wf, *fromDoc)
+	}
+	raised := spec.Budget != nil && !spec.Budget.IsZero()
+	if raised {
 		ir.ApplyBudgetOverrides(wf, *spec.Budget)
-		if snap := runtime.SnapshotBudgetForPersist(wf.Budget); snap != nil {
-			r.Budget = snap
-			if serr := s.store.SaveRun(parent, r); serr != nil && s.logger != nil {
-				s.logger.Warn("runview: resume: refresh budget snapshot on %s: %v", spec.RunID, serr)
-			}
-		}
 	}
 
 	// Cloud-mode resume: republish the RunMessage with ResumeSpec
 	// set so the runner pool re-enters the engine via Engine.Resume.
 	// Plan §F (T-33). CAS protection on the Mongo checkpoint lives
-	// in MongoRunStore.SaveCheckpoint (CASVersion increment).
+	// in MongoRunStore.SaveCheckpoint (CASVersion increment). The doc's
+	// effective-caps snapshot is the publisher's to stamp, from the
+	// merged ask, after its own status CAS — not this layer's: the wire
+	// carries the merge, and the doc copy loaded above is stale by then.
 	if s.publisher != nil {
 		if err := s.publisher.SubmitResume(parent, spec, wf, hash); err != nil {
 			return nil, err
@@ -528,6 +525,21 @@ func (s *Service) Resume(parent context.Context, spec ResumeSpec) (*LaunchResult
 		closed := make(chan struct{})
 		close(closed)
 		return &LaunchResult{RunID: spec.RunID, Done: closed}, nil
+	}
+
+	// Local paths (detached subprocess, in-process): the engine stamps
+	// Run.Budget only at launch, so a raised cap is written here — the
+	// studio Overview shows the cap the run now executes against, not
+	// the launch-time figure that just killed it. Granular on purpose: a
+	// whole-doc SaveRun from the copy loaded at the top of this method
+	// would revert any transition that landed since (a cancel, a
+	// finish). Best-effort: a store blip here does not fail the resume.
+	if raised {
+		if snap := runtime.SnapshotBudgetForPersist(wf.Budget); snap != nil {
+			if serr := s.store.SetRunBudgetSnapshot(parent, spec.RunID, snap); serr != nil && s.logger != nil {
+				s.logger.Warn("runview: resume: refresh budget snapshot on %s: %v", spec.RunID, serr)
+			}
+		}
 	}
 
 	if detachedEnabled() {

--- a/pkg/runview/service_launch.go
+++ b/pkg/runview/service_launch.go
@@ -418,6 +418,16 @@ func (s *Service) Resume(parent context.Context, spec ResumeSpec) (*LaunchResult
 	if err := supervise.ValidateSupervisorsMode(spec.Supervisors); err != nil {
 		return nil, fmt.Errorf("supervisors: %w", err)
 	}
+	// E3 (part of #652 review round 1): validate the resume budget
+	// ask synchronously — a malformed max_duration ("4 hours") would
+	// otherwise ride RunMessage.Budget through the cloud queue, fail
+	// the runner's applyBudgetOverrides on EVERY redelivery, and burn
+	// the delivery budget into a DLQ park. Same pre-flight as Launch.
+	if spec.Budget != nil {
+		if err := spec.Budget.Validate(); err != nil {
+			return nil, fmt.Errorf("budget: %w", err)
+		}
+	}
 
 	// Wait out a previous runner that is still tearing down, BEFORE anything
 	// takes a resource it holds. This is the top of the resume path on purpose:
@@ -484,6 +494,27 @@ func (s *Service) Resume(parent context.Context, spec ResumeSpec) (*LaunchResult
 	}
 	if err := runtime.ValidateResumeWorkflowHash(r.ID, r.WorkflowHash, hash, spec.Force); err != nil {
 		return nil, err
+	}
+
+	// E2 (#652 review round 1): apply the resume budget override to wf
+	// BEFORE the branch fork, so every downstream path (cloud publish,
+	// detached, in-process) executes against the raised caps. The
+	// executor snapshots Budget at construction time, so this must
+	// happen before BuildExecutor below. Same ordering + merge contract
+	// as Launch (service_launch.go:250).
+	//
+	// The persisted r.Budget snapshot (studio Overview) is also
+	// refreshed so the operator sees the raised cap immediately, not
+	// the launch-time figure that just killed the run. Best-effort:
+	// a store blip here does not fail the resume.
+	if spec.Budget != nil && !spec.Budget.IsZero() {
+		ir.ApplyBudgetOverrides(wf, *spec.Budget)
+		if snap := runtime.SnapshotBudgetForPersist(wf.Budget); snap != nil {
+			r.Budget = snap
+			if serr := s.store.SaveRun(parent, r); serr != nil && s.logger != nil {
+				s.logger.Warn("runview: resume: refresh budget snapshot on %s: %v", spec.RunID, serr)
+			}
+		}
 	}
 
 	// Cloud-mode resume: republish the RunMessage with ResumeSpec

--- a/pkg/runview/service_launch.go
+++ b/pkg/runview/service_launch.go
@@ -358,7 +358,7 @@ func (s *Service) startInProcess(parent context.Context, runID string, spec Laun
 		spec.AttachmentPromote, spec.Preset, toRunModelOverrides(spec.ModelOverrides),
 		spec.ParentRunID,
 		precreateInputs,
-		launchExtras{workDir: spec.WorkDir, dailyCap: spec.DailyCap, source: spec.SourceRef, routingPolicy: spec.RoutingPolicy, onOutcome: spec.OnOutcome, observers: spec.ExtraObservers, loopBudgetGuard: spec.LoopBudgetGuard, supervisors: spec.Supervisors},
+		launchExtras{workDir: spec.WorkDir, dailyCap: spec.DailyCap, source: spec.SourceRef, routingPolicy: spec.RoutingPolicy, onOutcome: spec.OnOutcome, observers: spec.ExtraObservers, loopBudgetGuard: spec.LoopBudgetGuard, supervisors: spec.Supervisors, budgetAsk: spec.Budget},
 		s.store,
 		func(ctx context.Context, eng *runtime.Engine) error {
 			return eng.Run(ctx, runID, inputs)
@@ -527,14 +527,21 @@ func (s *Service) Resume(parent context.Context, spec ResumeSpec) (*LaunchResult
 		return &LaunchResult{RunID: spec.RunID, Done: closed}, nil
 	}
 
-	// Local paths (detached subprocess, in-process): the engine stamps
-	// Run.Budget only at launch, so a raised cap is written here — the
-	// studio Overview shows the cap the run now executes against, not
-	// the launch-time figure that just killed it. Granular on purpose: a
-	// whole-doc SaveRun from the copy loaded at the top of this method
-	// would revert any transition that landed since (a cancel, a
-	// finish). Best-effort: a store blip here does not fail the resume.
+	// Local paths (detached subprocess, in-process): a raised cap is
+	// persisted here twice over, the way SubmitResume does it on the
+	// cloud path — the MERGED ask as the replay source (so the next
+	// resume, ask-less or not, and the detached subprocess that re-reads
+	// the doc, keep the raise), and the effective caps as the snapshot
+	// the studio Overview draws, since the engine stamps Run.Budget only
+	// at launch. Both granular on purpose: a whole-doc SaveRun from the
+	// copy loaded at the top of this method would revert any transition
+	// that landed since (a cancel, a finish). Best-effort: a store blip
+	// here does not fail the resume.
 	if raised {
+		merged := runtime.MergeResumeBudgetAsk(spec.Budget, r.BudgetOverrides)
+		if perr := s.store.SetRunBudgetOverrides(parent, spec.RunID, runtime.RunBudgetOverridesOf(merged)); perr != nil && s.logger != nil {
+			s.logger.Warn("runview: resume: persist merged budget ask on %s: %v", spec.RunID, perr)
+		}
 		if snap := runtime.SnapshotBudgetForPersist(wf.Budget); snap != nil {
 			if serr := s.store.SetRunBudgetSnapshot(parent, spec.RunID, snap); serr != nil && s.logger != nil {
 				s.logger.Warn("runview: resume: refresh budget snapshot on %s: %v", spec.RunID, serr)
@@ -918,6 +925,10 @@ type launchExtras struct {
 	// run-level kill switch for DSL-declared supervisor watchers,
 	// resolved above ITERION_SUPERVISORS.
 	supervisors string
+	// budgetAsk mirrors LaunchSpec.Budget: the operator's launch-time
+	// budget ask, handed to the engine so the run doc persists it as the
+	// replay source every resume surface reads (runtime.WithBudgetAsk).
+	budgetAsk *ir.BudgetOverrides
 }
 
 // engineOptions builds the standard option set for both Launch and
@@ -972,6 +983,9 @@ func (s *Service) engineOptions(runLogger *iterlog.Logger, hash, filePath, runNa
 	// onto the run record. Nil for CLI / studio / fork launches.
 	if ex.source != nil {
 		opts = append(opts, runtime.WithSource(ex.source))
+	}
+	if ex.budgetAsk != nil {
+		opts = append(opts, runtime.WithBudgetAsk(ex.budgetAsk))
 	}
 	// Run-health alerting. In-process runs feed the broker directly (not
 	// the events.jsonl file tailer, which only runs for detached /

--- a/pkg/runview/service_resume_budget_test.go
+++ b/pkg/runview/service_resume_budget_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/SocialGouv/iterion/pkg/dsl/ir"
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
 )
 
 // E2: ResumeSpec.Budget is silently dropped on the in-process resume
@@ -53,6 +54,69 @@ func TestResume_RejectsMalformedBudgetDurationSynchronously(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "max_duration") {
 		t.Fatalf("Resume error = %v, want it to name max_duration", err)
+	}
+}
+
+// The launch ask must be persisted on the LOCAL run doc — only the cloud
+// publisher wrote Run.BudgetOverrides, so on every local surface an
+// ask-less resume replayed nothing and the operator's launch cap was
+// silently replaced by the .bot's own. Probe: .bot cap $60, launch
+// --max-cost-usd 120, $100 already spent, ask-less resume (the studio's
+// answer-form path) → BUDGET_EXCEEDED "cost_usd (100/60)" while the doc
+// still advertised 120.
+func TestResume_AskLessLocalResumeKeepsTheLaunchCap(t *testing.T) {
+	dir := t.TempDir()
+	botPath := filepath.Join(dir, "resume_budget_test.bot")
+	if err := os.WriteFile(botPath, []byte(resumeBudgetInProcBot), 0o644); err != nil {
+		t.Fatalf("write bot: %v", err)
+	}
+	t.Setenv(envDetached, "0")
+	svc, err := NewService(dir, WithLogger(iterlog.Nop()))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	ctx := context.Background()
+
+	res, err := svc.Launch(ctx, LaunchSpec{FilePath: botPath, Budget: &ir.BudgetOverrides{MaxCostUSD: 120}})
+	if err != nil {
+		t.Fatalf("Launch: %v", err)
+	}
+	select {
+	case <-res.Done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("launch did not terminate")
+	}
+	r, err := svc.store.LoadRun(ctx, res.RunID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.BudgetOverrides == nil || r.BudgetOverrides.MaxCostUSD != 120 {
+		t.Fatalf("run.BudgetOverrides after a local launch = %+v, want the $120 ask persisted — without it every local resume replays nothing", r.BudgetOverrides)
+	}
+
+	// $100 already spent, re-armed as resumable: the resume preflight
+	// restores the spend and checks it against the cap the run resumes with.
+	if err := svc.store.SaveCheckpoint(ctx, res.RunID, &store.Checkpoint{NodeID: "done", BudgetCostUSD: 100}); err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+	if err := svc.store.UpdateRunStatus(ctx, res.RunID, store.RunStatusFailedResumable, "budget exceeded"); err != nil {
+		t.Fatalf("UpdateRunStatus: %v", err)
+	}
+	res2, err := svc.Resume(ctx, ResumeSpec{RunID: res.RunID, FilePath: botPath}) // ask-less
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	select {
+	case <-res2.Done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("resume did not terminate")
+	}
+	got, err := svc.store.LoadRun(ctx, res.RunID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.Status != store.RunStatusFinished {
+		t.Fatalf("status after the ask-less resume = %s (%s), want finished — the launch's $120 cap was replaced by the .bot's $60 on resume", got.Status, got.Error)
 	}
 }
 

--- a/pkg/runview/service_resume_budget_test.go
+++ b/pkg/runview/service_resume_budget_test.go
@@ -1,0 +1,110 @@
+package runview
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+)
+
+// E2: ResumeSpec.Budget is silently dropped on the in-process resume
+// path (the runview.Service is built without a publisher and outside
+// detached mode). Launch applies the override at service_launch.go:250;
+// Resume did not, so the wf handed to BuildExecutor still carried the
+// .bot's cap — a `--max-cost-usd 999` resume of a $60-capped run kept
+// the $60 in the snapshot AND in the running engine's SharedBudget.
+// Probe: seed a run with budget=$60 → in-process resume with
+// spec.Budget=$120 → doc's r.Budget.MaxCostUSD stays $60 without the
+// fix. The runResolveDoc snapshot is our oracle — same one the studio
+// Overview reads.
+const resumeBudgetInProcBot = `
+workflow resume_budget_test:
+  worktree: none
+  repo_devbox: off
+  budget:
+    max_cost_usd: 60
+    max_tokens: 5000
+  entry: done
+`
+
+// E3: Resume must reject a malformed max_duration synchronously with
+// an actionable error, else a typo ("4 hours") rides RunMessage.Budget
+// to the runner, fails applyBudgetOverrides on every redelivery, and
+// burns 8 deliveries into a DLQ park. Launch already does this
+// (service_launch.go:128); Resume didn't.
+func TestResume_RejectsMalformedBudgetDurationSynchronously(t *testing.T) {
+	dir := t.TempDir()
+	svc, err := NewService(dir, WithLogger(iterlog.Nop()))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	_, err = svc.Resume(context.Background(), ResumeSpec{
+		RunID:    "run-any",
+		FilePath: "wf.bot",
+		Budget:   &ir.BudgetOverrides{MaxDuration: "4 hours"},
+	})
+	if err == nil {
+		t.Fatal("Resume accepted a malformed max_duration; the runner would fail on every redelivery")
+	}
+	if !strings.Contains(err.Error(), "max_duration") {
+		t.Fatalf("Resume error = %v, want it to name max_duration", err)
+	}
+}
+
+// TestResume_AppliesBudgetOverridesInProcess covers the finding:
+// spec.Budget must reach ApplyBudgetOverrides in the in-process path
+// so the run doc's next snapshot reflects the raised cap.
+func TestResume_AppliesBudgetOverridesInProcess(t *testing.T) {
+	dir := t.TempDir()
+	botPath := filepath.Join(dir, "resume_budget_test.bot")
+	if err := os.WriteFile(botPath, []byte(resumeBudgetInProcBot), 0o644); err != nil {
+		t.Fatalf("write bot: %v", err)
+	}
+
+	// No publisher, no detached. Force the in-process branch.
+	t.Setenv(envDetached, "0")
+	svc, err := NewService(dir, WithLogger(iterlog.Nop()))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	const runID = "run-inproc-resume-budget"
+	_, workflowHash, err := CompileWorkflowWithHash(botPath)
+	if err != nil {
+		t.Fatalf("CompileWorkflowWithHash: %v", err)
+	}
+	seedPausedOperatorRun(t, svc, runID, workflowHash)
+
+	res, err := svc.Resume(context.Background(), ResumeSpec{
+		RunID:    runID,
+		FilePath: botPath,
+		Budget:   &ir.BudgetOverrides{MaxCostUSD: 120},
+	})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	select {
+	case <-res.Done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("in-process resume did not terminate")
+	}
+	r, err := svc.store.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if r.Budget == nil {
+		t.Fatal("run.Budget = nil after resume; the runResolveDoc snapshot should exist")
+	}
+	if r.Budget.MaxCostUSD != 120 {
+		t.Fatalf("run.Budget.MaxCostUSD = %v after resume with spec.Budget=$120, want 120 (E2: in-process resume dropped the override — the engine used the .bot's $60 in SharedBudget while the studio showed the same silent lie)", r.Budget.MaxCostUSD)
+	}
+	// The non-overridden field must survive as the .bot's value (per-field merge).
+	if r.Budget.MaxTokens != 5000 {
+		t.Fatalf("run.Budget.MaxTokens = %v, want 5000 (a partial override must not erase untouched caps)", r.Budget.MaxTokens)
+	}
+}

--- a/pkg/runview/service_resume_snapshot_test.go
+++ b/pkg/runview/service_resume_snapshot_test.go
@@ -1,0 +1,144 @@
+package runview
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// A resume that raises a cap loads the run doc at its top and only knows
+// the caps after the compile — a window in which another writer (an
+// operator cancel, the run finishing under a still-live pod, the sweeper)
+// can move the doc. The snapshot write must land on the CURRENT doc:
+// a whole-document SaveRun from the copy loaded at the top reverts the
+// concurrent transition, and on the cloud path the reverted doc then
+// passes SubmitResume's status CAS as if nothing had happened.
+
+// seedResumableRun persists a paused_operator run whose hash matches
+// fillerBotSrc, with a checkpoint so a resume has somewhere to restart.
+func seedResumableRun(t *testing.T, st store.RunStore, runID string) {
+	t.Helper()
+	_, hash, err := compileForLaunch("", fillerBotSrc, "")
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if err := st.SaveRun(context.Background(), &store.Run{
+		FormatVersion: store.RunFormatVersion,
+		ID:            runID,
+		WorkflowName:  "main",
+		WorkflowHash:  hash,
+		FilePath:      "/opt/iterion/bots/stored-bot/main.bot",
+		Status:        store.RunStatusPausedOperator,
+		Checkpoint:    &store.Checkpoint{NodeID: "work"},
+	}); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+}
+
+// Cloud path: an operator cancel that lands between the resume's load and
+// its budget write must survive it, typed cause included.
+func TestResume_CloudPathBudgetWriteDoesNotRevertAConcurrentCancel(t *testing.T) {
+	dir := t.TempDir()
+	st, err := store.New(dir, store.WithLogger(iterlog.Nop()))
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	ctx := context.Background()
+	const runID = "run-cancel-under-resume"
+	seedResumableRun(t, st, runID)
+
+	svc, err := NewService(dir,
+		WithLogger(iterlog.Nop()),
+		WithStore(st),
+		WithLaunchPublisher(&stubLaunchPublisher{}),
+		WithResumeSourceFiller(func(_ context.Context, run *store.Run, spec *ResumeSpec) (func(), error) {
+			spec.Source = fillerBotSrc
+			// The cancel lands after the resume loaded its copy of the doc.
+			if err := st.UpdateRunStatusCoded(ctx, run.ID, store.RunStatusCancelled, "cancelled by the operator", store.FailureCancelled); err != nil {
+				t.Fatalf("inject cancel: %v", err)
+			}
+			return nil, nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	if _, err := svc.Resume(ctx, ResumeSpec{
+		RunID:    runID,
+		FilePath: "/opt/iterion/bots/stored-bot/main.bot",
+		Budget:   &ir.BudgetOverrides{MaxCostUSD: 120},
+	}); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+
+	got, err := st.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.Status != store.RunStatusCancelled || got.FailureCode != store.FailureCancelled {
+		t.Fatalf("doc after the resume = %s/%q, want cancelled/CANCELLED — the budget write reverted the operator's cancel from a stale copy (and on cloud that reverted doc passes SubmitResume's CAS)", got.Status, got.FailureCode)
+	}
+}
+
+// In-process path: a run that FINISHED between the resume's load and its
+// budget write must not be resurrected into a second execution.
+func TestResume_InProcessBudgetWriteDoesNotResurrectAFinishedRun(t *testing.T) {
+	dir := t.TempDir()
+	st, err := store.New(dir, store.WithLogger(iterlog.Nop()))
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	ctx := context.Background()
+	const runID = "run-finished-under-resume"
+	seedResumableRun(t, st, runID)
+
+	t.Setenv(envDetached, "0")
+	svc, err := NewService(dir,
+		WithLogger(iterlog.Nop()),
+		WithStore(st),
+		WithResumeSourceFiller(func(_ context.Context, run *store.Run, spec *ResumeSpec) (func(), error) {
+			spec.Source = fillerBotSrc
+			if err := st.UpdateRunStatus(ctx, run.ID, store.RunStatusFinished, ""); err != nil {
+				t.Fatalf("inject finish: %v", err)
+			}
+			return nil, nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	res, err := svc.Resume(ctx, ResumeSpec{
+		RunID:    runID,
+		FilePath: "/opt/iterion/bots/stored-bot/main.bot",
+		Budget:   &ir.BudgetOverrides{MaxCostUSD: 120},
+	})
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	select {
+	case <-res.Done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("resume did not settle")
+	}
+
+	events, err := st.LoadEvents(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	for _, e := range events {
+		if e.Type == store.EventRunResumed {
+			t.Fatalf("a finished run was resumed (run_resumed on the timeline) — the budget write from the stale copy put it back to paused_operator and the under-lock re-validation accepted the resurrected doc")
+		}
+	}
+	got, err := st.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.Status != store.RunStatusFinished {
+		t.Fatalf("doc after the refused resume = %s, want finished untouched", got.Status)
+	}
+}

--- a/pkg/sandbox/errors.go
+++ b/pkg/sandbox/errors.go
@@ -1,0 +1,24 @@
+package sandbox
+
+import "errors"
+
+// ErrPhaseTimeout is the sentinel a driver returns when a bounded SETUP
+// phase (workspace copy, git fixup, …) exceeds its per-phase budget.
+// Distinct from the run's own max_duration and from a
+// context.DeadlineExceeded on the run ctx: it fires on a CHILD ctx whose
+// deadline is a driver-internal safety bound, while the run ctx stays
+// live. Drivers wrap it with errors.Join so the underlying cause and
+// context.DeadlineExceeded stay reachable through errors.Is as well.
+//
+// Consumers:
+//
+//   - the runtime setup classifier (pkg/runtime setupFailureStatus)
+//     persists RunStatusFailedResumable + FailureSandboxSetupTimeout
+//     instead of the default hard RunStatusFailed: the stall is a
+//     transient infrastructure condition (a stuck kubectl-exec pipe, a
+//     rescheduled apiserver) that a fresh pod routinely clears;
+//   - the cloud runner's ack policy (pkg/runner classifyExecResult) NAKs
+//     the delivery so JetStream redelivers to a healthy pod; a stall that
+//     persists through every permitted delivery parks on the DLQ like any
+//     other repeated failure.
+var ErrPhaseTimeout = errors.New("sandbox: setup phase timeout")

--- a/pkg/sandbox/kubernetes/driver.go
+++ b/pkg/sandbox/kubernetes/driver.go
@@ -49,6 +49,65 @@ const PodIPEnvVar = "ITERION_POD_IP"
 // multi-GB images take 30-60s).
 const DefaultPodReadyTimeoutSecs = 180
 
+// DefaultWorkspaceCopyTimeout bounds populateWorkspace (host tar |
+// kubectl exec pod tar) end-to-end. The pod-Ready wait had a cap; the
+// workspace copy did NOT, so a stuck kubectl-exec pipe would block the
+// run until the outer max_duration fired — hours later, with no
+// `sandbox_started` event to warn on. Observed live 2026-09-03 (#669
+// part 1): a resumed review sat 2h 26m in the sandbox-start phase, was
+// wiped by a runner rollout, and its message re-delivered onto a stale
+// `running` status. Overridable per host via
+// ITERION_SANDBOX_WORKSPACE_COPY_TIMEOUT (Go duration).
+const DefaultWorkspaceCopyTimeout = 5 * time.Minute
+
+// workspaceCopyTimeoutEnv is the override key. Read once per call so
+// tests can flip it between subcases.
+const workspaceCopyTimeoutEnv = "ITERION_SANDBOX_WORKSPACE_COPY_TIMEOUT"
+
+// resolveWorkspaceCopyTimeout returns the effective per-phase timeout,
+// honouring the env override with a fail-safe fallback: a garbage or
+// non-positive value falls back to the default (a copy phase left
+// unbounded is exactly the bug this exists to close).
+func resolveWorkspaceCopyTimeout() time.Duration {
+	raw := strings.TrimSpace(os.Getenv(workspaceCopyTimeoutEnv))
+	if raw == "" {
+		return DefaultWorkspaceCopyTimeout
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return DefaultWorkspaceCopyTimeout
+	}
+	return d
+}
+
+// runWithPhaseTimeout runs fn under a bounded child context. On a
+// deadline strike it returns a wrapped error naming the phase and the
+// wall-clock elapsed time so a stall shows up as a typed, visible
+// failure in the runner logs — the "typed, visible error/event (name
+// the phase and the elapsed time)" #669 part 1 asks for.
+//
+// The returned error carries fmt.Errorf's %w wrapping AND the sentinel
+// context.DeadlineExceeded via errors.Is, so upstream classifiers can
+// detect the phase-timeout shape without prose matching.
+func runWithPhaseTimeout(ctx context.Context, phase string, timeout time.Duration, fn func(context.Context) error) error {
+	phaseCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	start := time.Now()
+	err := fn(phaseCtx)
+	if err == nil {
+		return nil
+	}
+	// Only surface the phase-timeout wrapper when THIS phase's deadline
+	// fired — an outer ctx cancel (run cancel, pod SIGTERM) keeps its
+	// own shape so callers do not misclassify a cooperative stop as an
+	// unbounded stall.
+	if phaseCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
+		return fmt.Errorf("kubernetes: %s phase timed out after %s (deadline %s exceeded): %w",
+			phase, time.Since(start).Round(time.Millisecond), timeout, err)
+	}
+	return err
+}
+
 // Downward-API env vars the runner pod's Helm chart should inject so the
 // driver can set an ownerReference on every per-run resource (sandbox
 // pod, Secrets, NetworkPolicy) pointing back at the runner pod. When a
@@ -400,12 +459,24 @@ func (d *Driver) Start(ctx context.Context, prepared sandbox.PreparedSpec, info 
 	// via a tar stream. Without this the sandbox starts with an empty
 	// workspace (the V1 limitation, docs/sandbox.md) and a repo-bound bot
 	// has nothing to work on. Skipped for workspace-less runs.
+	//
+	// #669 part 1: the copy is BOUNDED. The pod-Ready wait had its own
+	// cap (DefaultPodReadyTimeoutSecs); the tar stream + git fixup did
+	// not, so a stuck kubectl-exec pipe blocked the run until the outer
+	// max_duration fired — hours later, with no `sandbox_started` event
+	// to warn on. resolveWorkspaceCopyTimeout is the phase budget
+	// (default 5m, ITERION_SANDBOX_WORKSPACE_COPY_TIMEOUT overrides).
 	if info.WorkspacePath != "" {
-		if err := r.populateWorkspace(ctx, info.WorkspacePath, p.workspace); err != nil {
+		copyTimeout := resolveWorkspaceCopyTimeout()
+		if err := runWithPhaseTimeout(ctx, "workspace copy", copyTimeout, func(ctx context.Context) error {
+			return r.populateWorkspace(ctx, info.WorkspacePath, p.workspace)
+		}); err != nil {
 			_ = r.Cleanup(ctx)
 			return nil, fmt.Errorf("kubernetes: populate workspace: %w", err)
 		}
-		if err := r.fixupWorkspaceGit(ctx, p.workspace); err != nil {
+		if err := runWithPhaseTimeout(ctx, "workspace git fixup", copyTimeout, func(ctx context.Context) error {
+			return r.fixupWorkspaceGit(ctx, p.workspace)
+		}); err != nil {
 			_ = r.Cleanup(ctx)
 			return nil, fmt.Errorf("kubernetes: fixup workspace git: %w", err)
 		}

--- a/pkg/sandbox/kubernetes/driver.go
+++ b/pkg/sandbox/kubernetes/driver.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -50,24 +51,38 @@ const PodIPEnvVar = "ITERION_POD_IP"
 const DefaultPodReadyTimeoutSecs = 180
 
 // DefaultWorkspaceCopyTimeout bounds populateWorkspace (host tar |
-// kubectl exec pod tar) end-to-end. The pod-Ready wait had a cap; the
-// workspace copy did NOT, so a stuck kubectl-exec pipe would block the
-// run until the outer max_duration fired — hours later, with no
-// `sandbox_started` event to warn on. Observed live 2026-09-03 (#669
-// part 1): a resumed review sat 2h 26m in the sandbox-start phase, was
-// wiped by a runner rollout, and its message re-delivered onto a stale
-// `running` status. Overridable per host via
-// ITERION_SANDBOX_WORKSPACE_COPY_TIMEOUT (Go duration).
-const DefaultWorkspaceCopyTimeout = 5 * time.Minute
+// kubectl exec pod tar) and the git fixup that follows, each end-to-end.
+// The pod-Ready wait has its own cap; without this one a stuck
+// kubectl-exec pipe blocks the run until the outer max_duration fires —
+// hours later, with no `sandbox_started` event to warn on (a resumed
+// review sat 2h 26m in the sandbox-start phase, was wiped by a runner
+// rollout, and its message re-delivered onto a stale `running` status —
+// #669 part 1).
+//
+// Fifteen minutes because no measured copy duration exists to size it
+// from: iterion's own checkout is 355 MB streamed through the apiserver,
+// and a cold copy on a slow apiserver must not be killed for being slow
+// but healthy. The halfway warning in runWithPhaseTimeout makes such a
+// copy visible at 7m30s, before the bound strikes. Overridable per host
+// via ITERION_SANDBOX_WORKSPACE_COPY_TIMEOUT (a Go duration).
+const DefaultWorkspaceCopyTimeout = 15 * time.Minute
 
 // workspaceCopyTimeoutEnv is the override key. Read once per call so
 // tests can flip it between subcases.
 const workspaceCopyTimeoutEnv = "ITERION_SANDBOX_WORKSPACE_COPY_TIMEOUT"
 
+// workspaceCopyTimeoutWarnOnce bounds the "unparseable override" warning
+// to one stderr line per process (the ITERION_BUDGET_EXIT_GRACE
+// convention): an operator input silently replaced by the default is an
+// override that never took, with nothing saying so.
+var workspaceCopyTimeoutWarnOnce sync.Once
+
 // resolveWorkspaceCopyTimeout returns the effective per-phase timeout,
 // honouring the env override with a fail-safe fallback: a garbage or
-// non-positive value falls back to the default (a copy phase left
-// unbounded is exactly the bug this exists to close).
+// non-positive value ("banana", "0", "-5m", or "5" — which Go parses as
+// five NANOseconds, not the five minutes the operator meant) falls back
+// to the default (a copy phase left unbounded is exactly the bug this
+// exists to close) and warns once, naming the value and the default.
 func resolveWorkspaceCopyTimeout() time.Duration {
 	raw := strings.TrimSpace(os.Getenv(workspaceCopyTimeoutEnv))
 	if raw == "" {
@@ -75,35 +90,83 @@ func resolveWorkspaceCopyTimeout() time.Duration {
 	}
 	d, err := time.ParseDuration(raw)
 	if err != nil || d <= 0 {
+		workspaceCopyTimeoutWarnOnce.Do(func() {
+			// Stderr, not the driver logger: a leaf helper with no
+			// logger in reach.
+			fmt.Fprintf(os.Stderr,
+				"iterion: %s=%q is not a positive Go duration (use e.g. 5m, 15m, 2h) — using the default %s\n",
+				workspaceCopyTimeoutEnv, raw, DefaultWorkspaceCopyTimeout)
+		})
 		return DefaultWorkspaceCopyTimeout
 	}
 	return d
 }
 
-// runWithPhaseTimeout runs fn under a bounded child context. On a
-// deadline strike it returns a wrapped error naming the phase and the
-// wall-clock elapsed time so a stall shows up as a typed, visible
-// failure in the runner logs — the "typed, visible error/event (name
-// the phase and the elapsed time)" #669 part 1 asks for.
+// phaseTimeoutWarnRatio is where the halfway-mark warning fires, as a
+// fraction of the phase budget: a slow-but-healthy copy shows up on the
+// runner log BEFORE the bound strikes, with enough runway left to tell
+// "clogged and finishing" from "wedged". A var so tests can lower it.
+var phaseTimeoutWarnRatio = 0.5
+
+// runWithPhaseTimeout runs fn under a bounded child context. When THIS
+// phase's deadline strikes it returns an error naming the phase and the
+// wall-clock elapsed time, wrapping sandbox.ErrPhaseTimeout,
+// context.DeadlineExceeded AND fn's own error through errors.Join, so
+// every consumer can classify the shape with errors.Is (the setup
+// classifier routes it to failed_resumable, the runner NAKs it) and the
+// operator still reads the actual cause. An outer ctx cancellation (run
+// cancel, pod SIGTERM) keeps its own shape: a cooperative stop is not a
+// stall.
 //
-// The returned error carries fmt.Errorf's %w wrapping AND the sentinel
-// context.DeadlineExceeded via errors.Is, so upstream classifiers can
-// detect the phase-timeout shape without prose matching.
-func runWithPhaseTimeout(ctx context.Context, phase string, timeout time.Duration, fn func(context.Context) error) error {
+// The bound is only as strong as fn's ctx discipline. fn is called
+// synchronously and nothing races the deadline: the child ctx expires,
+// and whatever fn does with that is the whole enforcement. For the
+// workspace copy that is exec.CommandContext killing the LOCAL tar and
+// kubectl processes; the in-pod tar behind `kubectl exec` is not reached
+// by that signal (Setpgid signals only the leader), it dies with the
+// pipe. A callee that ignores its ctx and returns nil after the deadline
+// therefore completes — and is warned about, so a phase that burned its
+// whole budget and won by a hair is visible before the next occurrence
+// trips the bound.
+//
+// The halfway warning (phaseTimeoutWarnRatio × timeout) runs on a side
+// goroutine that fn's return cancels; on an early return it emits
+// nothing.
+func runWithPhaseTimeout(ctx context.Context, logger *iterlog.Logger, phase string, timeout time.Duration, fn func(context.Context) error) error {
+	if logger == nil {
+		logger = iterlog.Nop()
+	}
 	phaseCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	start := time.Now()
+
+	// The warn delay is computed here, not in the goroutine, so the
+	// ratio is read before the goroutine exists (tests lower it).
+	warnAfter := time.Duration(float64(timeout) * phaseTimeoutWarnRatio)
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-done:
+		case <-time.After(warnAfter):
+			logger.Warn("sandbox: %s phase still running after %s of its %s budget — a stall from here on fails the phase (ITERION_SANDBOX_WORKSPACE_COPY_TIMEOUT raises the bound)",
+				phase, time.Since(start).Round(time.Second), timeout)
+		}
+	}()
+
 	err := fn(phaseCtx)
+	close(done)
+
 	if err == nil {
+		if phaseCtx.Err() != nil {
+			logger.Warn("sandbox: %s phase completed at or past its %s budget (elapsed %s) — raise ITERION_SANDBOX_WORKSPACE_COPY_TIMEOUT or investigate the delay",
+				phase, timeout, time.Since(start).Round(time.Millisecond))
+		}
 		return nil
 	}
-	// Only surface the phase-timeout wrapper when THIS phase's deadline
-	// fired — an outer ctx cancel (run cancel, pod SIGTERM) keeps its
-	// own shape so callers do not misclassify a cooperative stop as an
-	// unbounded stall.
 	if phaseCtx.Err() == context.DeadlineExceeded && ctx.Err() == nil {
 		return fmt.Errorf("kubernetes: %s phase timed out after %s (deadline %s exceeded): %w",
-			phase, time.Since(start).Round(time.Millisecond), timeout, err)
+			phase, time.Since(start).Round(time.Millisecond), timeout,
+			errors.Join(sandbox.ErrPhaseTimeout, context.DeadlineExceeded, err))
 	}
 	return err
 }
@@ -460,21 +523,21 @@ func (d *Driver) Start(ctx context.Context, prepared sandbox.PreparedSpec, info 
 	// workspace (the V1 limitation, docs/sandbox.md) and a repo-bound bot
 	// has nothing to work on. Skipped for workspace-less runs.
 	//
-	// #669 part 1: the copy is BOUNDED. The pod-Ready wait had its own
-	// cap (DefaultPodReadyTimeoutSecs); the tar stream + git fixup did
-	// not, so a stuck kubectl-exec pipe blocked the run until the outer
-	// max_duration fired — hours later, with no `sandbox_started` event
-	// to warn on. resolveWorkspaceCopyTimeout is the phase budget
-	// (default 5m, ITERION_SANDBOX_WORKSPACE_COPY_TIMEOUT overrides).
+	// Both phases are BOUNDED (the pod-Ready wait has its own cap,
+	// DefaultPodReadyTimeoutSecs): a stuck kubectl-exec pipe must fail the
+	// phase as a typed error, not block the run until the outer
+	// max_duration fires. resolveWorkspaceCopyTimeout is the budget
+	// (DefaultWorkspaceCopyTimeout; ITERION_SANDBOX_WORKSPACE_COPY_TIMEOUT
+	// overrides).
 	if info.WorkspacePath != "" {
 		copyTimeout := resolveWorkspaceCopyTimeout()
-		if err := runWithPhaseTimeout(ctx, "workspace copy", copyTimeout, func(ctx context.Context) error {
+		if err := runWithPhaseTimeout(ctx, d.logger, "workspace copy", copyTimeout, func(ctx context.Context) error {
 			return r.populateWorkspace(ctx, info.WorkspacePath, p.workspace)
 		}); err != nil {
 			_ = r.Cleanup(ctx)
 			return nil, fmt.Errorf("kubernetes: populate workspace: %w", err)
 		}
-		if err := runWithPhaseTimeout(ctx, "workspace git fixup", copyTimeout, func(ctx context.Context) error {
+		if err := runWithPhaseTimeout(ctx, d.logger, "workspace git fixup", copyTimeout, func(ctx context.Context) error {
 			return r.fixupWorkspaceGit(ctx, p.workspace)
 		}); err != nil {
 			_ = r.Cleanup(ctx)

--- a/pkg/sandbox/kubernetes/stderr_capture_test.go
+++ b/pkg/sandbox/kubernetes/stderr_capture_test.go
@@ -1,0 +1,49 @@
+package kubernetes
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+// captureStderr redirects os.Stderr to a pipe for the caller's scope,
+// returns a `read` callback that drains everything so far, and a
+// `restore` function to undo the redirect. Used by the workspace-copy
+// timeout tests to verify the E7 (garbage env warn) and E8 (halfway /
+// overrun) stderr-side signals.
+func captureStderr(t *testing.T) (read func() string, restore func()) {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	restored := false
+	restore = func() {
+		if restored {
+			return
+		}
+		restored = true
+		os.Stderr = orig
+		_ = w.Close()
+		_ = r.Close()
+	}
+	read = func() string {
+		// Close the write side so ReadAll sees EOF, then re-open a
+		// fresh pipe so the caller can drain multiple times without
+		// blocking. Order matters — close BEFORE reopening.
+		os.Stderr = orig
+		_ = w.Close()
+		buf, _ := io.ReadAll(r)
+		_ = r.Close()
+		// Prepare a fresh pipe so a subsequent read is possible.
+		nr, nw, perr := os.Pipe()
+		if perr == nil {
+			r, w = nr, nw
+			os.Stderr = w
+		}
+		return string(buf)
+	}
+	return read, restore
+}

--- a/pkg/sandbox/kubernetes/workspace_copy_timeout_test.go
+++ b/pkg/sandbox/kubernetes/workspace_copy_timeout_test.go
@@ -1,11 +1,19 @@
 package kubernetes
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
 )
 
 // #669 part 1: the workspace-copy phase of the kubernetes driver used
@@ -17,11 +25,35 @@ import (
 // status). The phase must fail with a typed, visible error naming both
 // the phase and the elapsed wall-clock time.
 
+// lockedBuffer is a goroutine-safe io.Writer for capturing the driver
+// logger: the halfway warning is written from a side goroutine.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func captureLogger() (*iterlog.Logger, *lockedBuffer) {
+	buf := &lockedBuffer{}
+	return iterlog.New(iterlog.LevelWarn, buf), buf
+}
+
 // A stall past the phase budget must surface as a typed timeout error
 // naming the phase and the elapsed time.
 func TestRunWithPhaseTimeout_StallSurfacesAsTypedError(t *testing.T) {
 	ctx := context.Background()
-	err := runWithPhaseTimeout(ctx, "workspace copy", 30*time.Millisecond, func(pctx context.Context) error {
+	err := runWithPhaseTimeout(ctx, iterlog.Nop(), "workspace copy", 30*time.Millisecond, func(pctx context.Context) error {
 		select {
 		case <-pctx.Done():
 			return pctx.Err()
@@ -41,7 +73,7 @@ func TestRunWithPhaseTimeout_StallSurfacesAsTypedError(t *testing.T) {
 		t.Fatalf("timeout error must name the PHASE, got %q", msg)
 	}
 	if !strings.Contains(msg, "deadline 30ms exceeded") {
-		t.Fatalf("timeout error must name the deadline the operator set (needed to distinguish a 5m fleet default from a raised cap), got %q", msg)
+		t.Fatalf("timeout error must name the deadline the operator set (needed to distinguish the fleet default from a raised cap), got %q", msg)
 	}
 }
 
@@ -49,7 +81,7 @@ func TestRunWithPhaseTimeout_StallSurfacesAsTypedError(t *testing.T) {
 // double-wrapping of a nil error, no bogus timeout report).
 func TestRunWithPhaseTimeout_NominalCompletionIsPassthrough(t *testing.T) {
 	ctx := context.Background()
-	err := runWithPhaseTimeout(ctx, "workspace copy", time.Second, func(context.Context) error {
+	err := runWithPhaseTimeout(ctx, iterlog.Nop(), "workspace copy", time.Second, func(context.Context) error {
 		return nil
 	})
 	if err != nil {
@@ -63,7 +95,7 @@ func TestRunWithPhaseTimeout_NominalCompletionIsPassthrough(t *testing.T) {
 func TestRunWithPhaseTimeout_InnerErrorIsNotMisreportedAsTimeout(t *testing.T) {
 	ctx := context.Background()
 	sentinel := errors.New("tar: broken pipe")
-	err := runWithPhaseTimeout(ctx, "workspace copy", time.Second, func(context.Context) error {
+	err := runWithPhaseTimeout(ctx, iterlog.Nop(), "workspace copy", time.Second, func(context.Context) error {
 		return sentinel
 	})
 	if err == nil {
@@ -71,6 +103,9 @@ func TestRunWithPhaseTimeout_InnerErrorIsNotMisreportedAsTimeout(t *testing.T) {
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("inner tar-broken-pipe misreported as a phase timeout: %v — the ops would chase the wrong bug", err)
+	}
+	if errors.Is(err, sandbox.ErrPhaseTimeout) {
+		t.Fatalf("inner error carries the phase-timeout sentinel: %v — the setup classifier would park a hard failure as resumable", err)
 	}
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("inner error identity lost; got %v", err)
@@ -86,13 +121,13 @@ func TestRunWithPhaseTimeout_OuterCancelIsNotMisreportedAsPhaseTimeout(t *testin
 	// Cancel BEFORE fn runs so phaseCtx.Err() will read Canceled, not
 	// DeadlineExceeded, when we check it.
 	cancel()
-	err := runWithPhaseTimeout(parent, "workspace copy", time.Hour, func(pctx context.Context) error {
+	err := runWithPhaseTimeout(parent, iterlog.Nop(), "workspace copy", time.Hour, func(pctx context.Context) error {
 		return pctx.Err()
 	})
 	if err == nil {
 		t.Fatal("cancelled outer ctx must surface")
 	}
-	if strings.Contains(err.Error(), "phase timed out") {
+	if strings.Contains(err.Error(), "phase timed out") || errors.Is(err, sandbox.ErrPhaseTimeout) {
 		t.Fatalf("outer cancel misreported as phase timeout: %v (would flood the ops channel on every pod SIGTERM)", err)
 	}
 }
@@ -117,5 +152,159 @@ func TestResolveWorkspaceCopyTimeout_GarbageFallsBackToDefault(t *testing.T) {
 	t.Setenv(workspaceCopyTimeoutEnv, "0")
 	if got := resolveWorkspaceCopyTimeout(); got != DefaultWorkspaceCopyTimeout {
 		t.Fatalf("zero override = %s, want default %s", got, DefaultWorkspaceCopyTimeout)
+	}
+}
+
+// Garbage in ITERION_SANDBOX_WORKSPACE_COPY_TIMEOUT must be VISIBLE:
+// silently returning the default lets the operator believe the override
+// took ("5" reads as five nanoseconds to Go, five minutes to a human).
+// Same convention as ITERION_BUDGET_EXIT_GRACE: one stderr line per
+// process, naming the value and the default.
+func TestResolveWorkspaceCopyTimeout_GarbageEnvIsWarnedOnce(t *testing.T) {
+	stderr, restore := captureStderr(t)
+	defer restore()
+
+	// Reset the sync.Once so the warn fires within THIS test.
+	workspaceCopyTimeoutWarnOnce = sync.Once{}
+
+	t.Setenv(workspaceCopyTimeoutEnv, "5")
+	_ = resolveWorkspaceCopyTimeout()
+	got := stderr()
+	if !strings.Contains(got, workspaceCopyTimeoutEnv) {
+		t.Fatalf("stderr = %q, want it to name %s (garbage was silently swallowed before)", got, workspaceCopyTimeoutEnv)
+	}
+	if !strings.Contains(got, `"5"`) || !strings.Contains(got, DefaultWorkspaceCopyTimeout.String()) {
+		t.Fatalf("stderr = %q, want it to echo the operator's value and the default that replaced it", got)
+	}
+
+	// Second call in the same process must NOT re-warn (sync.Once).
+	_ = resolveWorkspaceCopyTimeout()
+	if got := stderr(); got != "" {
+		t.Fatalf("second call re-warned: %q — expected sync.Once suppression", got)
+	}
+}
+
+// The wrapped error must expose BOTH sandbox.ErrPhaseTimeout AND
+// context.DeadlineExceeded via errors.Is even when the callee's own
+// error is neither — a `%w` on the inner cause alone hides the deadline
+// shape from the setup classifier. Stub callee: the shape, in isolation.
+func TestRunWithPhaseTimeout_WrapsPhaseTimeoutSentinelViaErrorsIs(t *testing.T) {
+	ctx := context.Background()
+	sentinel := errors.New("kubectl-exec pipe stalled")
+	err := runWithPhaseTimeout(ctx, iterlog.Nop(), "workspace copy", 30*time.Millisecond, func(pctx context.Context) error {
+		// Ignores pctx: a callee whose helpers do not respect ctx.
+		time.Sleep(80 * time.Millisecond)
+		return sentinel
+	})
+	if err == nil {
+		t.Fatal("stall returned no error")
+	}
+	if !errors.Is(err, sandbox.ErrPhaseTimeout) {
+		t.Fatalf("errors.Is(err, sandbox.ErrPhaseTimeout) = false — the setup classifier cannot route this to failed_resumable")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("errors.Is(err, context.DeadlineExceeded) = false — the deadline shape is invisible to every consumer")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("errors.Is(err, inner) = false — the operator loses the actual cause; got %v", err)
+	}
+}
+
+// The same shape driven through the REAL populateWorkspace: a kubectl
+// shim on PATH that never reads its stdin and never exits is the in-pod
+// tar side of the copy pipe, wedged. The phase must strike its own
+// deadline (the LOCAL kubectl is killed through exec.CommandContext —
+// the enforcement the doc comment promises), and the error must carry
+// the sentinel, the deadline and the real cause.
+func TestRunWithPhaseTimeout_RealWorkspaceCopyStallIsClassified(t *testing.T) {
+	if _, err := exec.LookPath("tar"); err != nil {
+		t.Skip("tar not on PATH")
+	}
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not on PATH")
+	}
+	shimDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(shimDir, kubeBinaryName), []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "README.md"), []byte("payload\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := &Run{driver: &Driver{logger: iterlog.Nop()}, podName: "sandbox-x", namespace: "ns"}
+
+	start := time.Now()
+	err := runWithPhaseTimeout(context.Background(), iterlog.Nop(), "workspace copy", 300*time.Millisecond, func(ctx context.Context) error {
+		return r.populateWorkspace(ctx, src, "/workspace")
+	})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("a wedged in-pod tar returned no error — the copy would block until the run's max_duration")
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("the phase returned after %s — the deadline did not kill the stalled kubectl", elapsed)
+	}
+	if !errors.Is(err, sandbox.ErrPhaseTimeout) {
+		t.Fatalf("real stall does not carry sandbox.ErrPhaseTimeout: %v", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("real stall does not carry context.DeadlineExceeded: %v", err)
+	}
+	if !strings.Contains(err.Error(), "in-pod tar extract") {
+		t.Fatalf("real stall lost populateWorkspace's own cause: %v", err)
+	}
+}
+
+// A callee that ignores its ctx and returns nil past the deadline is
+// warned about: a phase that burned its whole budget and won by a hair
+// must be visible before the next occurrence trips the bound.
+func TestRunWithPhaseTimeout_OverrunButNilCalleeWarns(t *testing.T) {
+	logger, out := captureLogger()
+	err := runWithPhaseTimeout(context.Background(), logger, "workspace copy", 10*time.Millisecond, func(pctx context.Context) error {
+		time.Sleep(30 * time.Millisecond) // past the deadline, ignoring pctx
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("nil-return-past-deadline unexpectedly errored: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "workspace copy phase completed at or past its") {
+		t.Fatalf("overrun warning missing: %q (silent success past budget hides the next occurrence's failure)", got)
+	}
+}
+
+// The halfway-mark warning fires while the phase is still running, so a
+// slow-but-healthy copy is visible BEFORE the bound strikes.
+func TestRunWithPhaseTimeout_HalfwayMarkWarns(t *testing.T) {
+	prev := phaseTimeoutWarnRatio
+	phaseTimeoutWarnRatio = 0.25
+	defer func() { phaseTimeoutWarnRatio = prev }()
+
+	logger, out := captureLogger()
+	err := runWithPhaseTimeout(context.Background(), logger, "workspace copy", 400*time.Millisecond, func(pctx context.Context) error {
+		time.Sleep(200 * time.Millisecond) // past the 25% mark, under the deadline
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "workspace copy phase still running") {
+		t.Fatalf("halfway warning did not fire: %q (a slow copy needs a signal BEFORE the deadline)", got)
+	}
+}
+
+// A phase that finishes before the halfway mark says nothing: the
+// warning is for slow copies, not a heartbeat.
+func TestRunWithPhaseTimeout_FastPhaseIsSilent(t *testing.T) {
+	logger, out := captureLogger()
+	err := runWithPhaseTimeout(context.Background(), logger, "workspace copy", time.Second, func(context.Context) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := out.String(); got != "" {
+		t.Fatalf("a fast phase warned: %q", got)
 	}
 }

--- a/pkg/sandbox/kubernetes/workspace_copy_timeout_test.go
+++ b/pkg/sandbox/kubernetes/workspace_copy_timeout_test.go
@@ -1,0 +1,121 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #669 part 1: the workspace-copy phase of the kubernetes driver used
+// only the outer context's deadline (the run's max_duration). A stuck
+// kubectl-exec tar hangs the run silently until the outer cap fires —
+// hours later — with no `sandbox_started` event to warn on. Observed
+// live 2026-09-03 (2h 26m spent in this phase before a runner rollout
+// wiped the pod and re-delivered the message onto a stale `running`
+// status). The phase must fail with a typed, visible error naming both
+// the phase and the elapsed wall-clock time.
+
+// A stall past the phase budget must surface as a typed timeout error
+// naming the phase and the elapsed time.
+func TestRunWithPhaseTimeout_StallSurfacesAsTypedError(t *testing.T) {
+	ctx := context.Background()
+	err := runWithPhaseTimeout(ctx, "workspace copy", 30*time.Millisecond, func(pctx context.Context) error {
+		select {
+		case <-pctx.Done():
+			return pctx.Err()
+		case <-time.After(2 * time.Second):
+			t.Fatal("phase context did not fire the deadline")
+			return nil
+		}
+	})
+	if err == nil {
+		t.Fatal("phase stall did not surface as an error — the run would block on the outer ctx (the exact bug #669 part 1 measured live)")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("phase timeout must wrap context.DeadlineExceeded (errors.Is), got %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "workspace copy phase timed out") {
+		t.Fatalf("timeout error must name the PHASE, got %q", msg)
+	}
+	if !strings.Contains(msg, "deadline 30ms exceeded") {
+		t.Fatalf("timeout error must name the deadline the operator set (needed to distinguish a 5m fleet default from a raised cap), got %q", msg)
+	}
+}
+
+// A phase completing under budget must pass through untouched (no
+// double-wrapping of a nil error, no bogus timeout report).
+func TestRunWithPhaseTimeout_NominalCompletionIsPassthrough(t *testing.T) {
+	ctx := context.Background()
+	err := runWithPhaseTimeout(ctx, "workspace copy", time.Second, func(context.Context) error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("nominal phase must not error, got %v", err)
+	}
+}
+
+// A phase erroring for its own reason (not a timeout) keeps its native
+// error shape — the operator needs to see the real cause (e.g. a git
+// fixup failure), not "the phase timed out".
+func TestRunWithPhaseTimeout_InnerErrorIsNotMisreportedAsTimeout(t *testing.T) {
+	ctx := context.Background()
+	sentinel := errors.New("tar: broken pipe")
+	err := runWithPhaseTimeout(ctx, "workspace copy", time.Second, func(context.Context) error {
+		return sentinel
+	})
+	if err == nil {
+		t.Fatal("inner error was swallowed")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("inner tar-broken-pipe misreported as a phase timeout: %v — the ops would chase the wrong bug", err)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("inner error identity lost; got %v", err)
+	}
+}
+
+// An OUTER context cancellation (run cancel, pod SIGTERM) must keep
+// its own shape — the phase-timeout wrapper is only for the phase's
+// OWN deadline, otherwise a cooperative stop would look like an
+// unbounded stall in every log parser.
+func TestRunWithPhaseTimeout_OuterCancelIsNotMisreportedAsPhaseTimeout(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	// Cancel BEFORE fn runs so phaseCtx.Err() will read Canceled, not
+	// DeadlineExceeded, when we check it.
+	cancel()
+	err := runWithPhaseTimeout(parent, "workspace copy", time.Hour, func(pctx context.Context) error {
+		return pctx.Err()
+	})
+	if err == nil {
+		t.Fatal("cancelled outer ctx must surface")
+	}
+	if strings.Contains(err.Error(), "phase timed out") {
+		t.Fatalf("outer cancel misreported as phase timeout: %v (would flood the ops channel on every pod SIGTERM)", err)
+	}
+}
+
+// The env override is honoured (operator can raise the cap for a slow
+// cluster or a huge workspace without editing the binary).
+func TestResolveWorkspaceCopyTimeout_HonoursEnv(t *testing.T) {
+	t.Setenv(workspaceCopyTimeoutEnv, "12m")
+	got := resolveWorkspaceCopyTimeout()
+	if want := 12 * time.Minute; got != want {
+		t.Fatalf("resolveWorkspaceCopyTimeout = %s, want %s (operator override lost)", got, want)
+	}
+}
+
+// Garbage in env falls back to the default rather than disabling the
+// bound — the exact "fail closed" iterion convention.
+func TestResolveWorkspaceCopyTimeout_GarbageFallsBackToDefault(t *testing.T) {
+	t.Setenv(workspaceCopyTimeoutEnv, "not-a-duration")
+	if got := resolveWorkspaceCopyTimeout(); got != DefaultWorkspaceCopyTimeout {
+		t.Fatalf("garbage override = %s, want default %s (unbounded copy = the bug this fix closes)", got, DefaultWorkspaceCopyTimeout)
+	}
+	t.Setenv(workspaceCopyTimeoutEnv, "0")
+	if got := resolveWorkspaceCopyTimeout(); got != DefaultWorkspaceCopyTimeout {
+		t.Fatalf("zero override = %s, want default %s", got, DefaultWorkspaceCopyTimeout)
+	}
+}

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -1705,6 +1705,21 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 	if p.metrics != nil {
 		p.metrics.RunsCreatedTotal.WithLabelValues("resumed").Inc()
 	}
+	// E4 (#652 review round 1): persist the MERGED budget ask onto the
+	// run doc, so a subsequent unattended auto-retry (usage-window
+	// sweeper) keeps the raised cap rather than reverting to the
+	// launch ask that already killed the run. Only when the operator
+	// asked for a change on THIS resume — an ask-less resume leaves
+	// the doc untouched. Granular SetRunBudgetOverrides so the CAS
+	// status transition above (queued) stays intact. Best-effort.
+	if spec.Budget != nil && !spec.Budget.IsZero() {
+		merged := resolveResumeBudgetAsk(spec.Budget, prior.BudgetOverrides)
+		persistCtx, persistCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		if err := p.store.SetRunBudgetOverrides(persistCtx, spec.RunID, runBudgetOverrides(merged)); err != nil && p.logger != nil {
+			p.logger.Warn("cloudpublisher: persist merged budget ask for %s after resume: %v", spec.RunID, err)
+		}
+		persistCancel()
+	}
 	// Disarm any usage-window retry the retry sweeper had armed for this
 	// run: an operator (or the auto-retry) is resuming it NOW, and a
 	// surviving retry_after re-fires the sweeper days later on a run that
@@ -1714,10 +1729,17 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 	// resume: the sweep's ClaimRunRetry CAS still checks the run status
 	// (which is now queued/running), so the worst case is one spurious
 	// abandon audit line.
+	//
+	// E5 (#652 review round 1): bound the detached-context write like
+	// every other sibling detached store call (publisher.go:1553's
+	// rollback uses 10s, usage_retry follows the same convention) so a
+	// wedged store cannot pin the resume goroutine indefinitely.
 	if retryStore := store.AsRunRetryStore(p.store); retryStore != nil {
-		if err := retryStore.ClearRunRetry(context.WithoutCancel(ctx), spec.RunID); err != nil && p.logger != nil {
+		clearCtx, clearCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		if err := retryStore.ClearRunRetry(clearCtx, spec.RunID); err != nil && p.logger != nil {
 			p.logger.Warn("cloudpublisher: clear armed retry for %s after manual resume: %v", spec.RunID, err)
 		}
+		clearCancel()
 	}
 	return nil
 }
@@ -2136,17 +2158,48 @@ func runBudgetOverrides(o *ir.BudgetOverrides) *store.RunBudgetOverrides {
 	}
 }
 
-// resolveResumeBudgetAsk chooses between a THIS-RESUME override (the
-// CLI/API budget flags on the resume request) and the persisted launch
-// ask that lives on the run doc. The this-resume override wins when
-// non-nil and non-empty — that IS the "raise the cap + resume"
-// recovery — else the doc's replay is honoured (today's behaviour, and
-// the only path an unattended auto-retry can travel). #652 part 2.
+// resolveResumeBudgetAsk MERGES the THIS-RESUME override (the CLI/API
+// budget flags on the resume request) OVER the persisted launch ask
+// on the run doc, per field. The contract is the same "non-zero wins,
+// zero inherits" rule ApplyBudgetOverrides enforces on the executor
+// side, and the same shape ir.BudgetOverrides itself documents.
+//
+// Wholesale-replace (an earlier variant of this helper) was E1's
+// finding: `--max-duration 4h` alone erased the launch's $50 / 5e6-
+// token envelope on the wire, ApplyBudgetOverrides then left the
+// .bot's own cap in place, and restoreCheckpoint put the banked
+// spend back over it — the run died on BUDGET_EXCEEDED before the
+// first node. Zero-value fields in the spec inherit the doc value;
+// non-zero fields override.
+//
+// #652 part 2.
 func resolveResumeBudgetAsk(fromSpec *ir.BudgetOverrides, fromDoc *store.RunBudgetOverrides) *ir.BudgetOverrides {
-	if fromSpec != nil && !fromSpec.IsZero() {
-		return fromSpec
+	base := budgetOverridesFromRun(fromDoc)
+	if fromSpec == nil || fromSpec.IsZero() {
+		return base
 	}
-	return budgetOverridesFromRun(fromDoc)
+	if base == nil {
+		base = &ir.BudgetOverrides{}
+	}
+	if fromSpec.MaxCostUSD > 0 {
+		base.MaxCostUSD = fromSpec.MaxCostUSD
+	}
+	if fromSpec.MaxTokens > 0 {
+		base.MaxTokens = fromSpec.MaxTokens
+	}
+	if fromSpec.MaxDuration != "" {
+		base.MaxDuration = fromSpec.MaxDuration
+	}
+	if fromSpec.MaxIterations > 0 {
+		base.MaxIterations = fromSpec.MaxIterations
+	}
+	if fromSpec.MaxParallelBranches > 0 {
+		base.MaxParallelBranches = fromSpec.MaxParallelBranches
+	}
+	if fromSpec.CapImposed {
+		base.CapImposed = true
+	}
+	return base
 }
 
 // budgetOverridesFromRun replays a run doc's persisted budget ask onto a

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -1664,7 +1664,15 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 		// doctrine as ModelOverrides below): cloud resumes are often
 		// unattended auto-retries, so nothing else can re-state it, and a
 		// dropped override silently reverts the run to the workflow's cap.
-		Budget:         clampBudgetToGrant(budgetOverridesFromRun(prior.BudgetOverrides), wf, creds.grant, checkpointCostUSD(prior), p.logger, spec.RunID),
+		//
+		// #652 part 2: a THIS-RESUME override (spec.Budget, set by the
+		// remote CLI's --max-* flags) BEATS the persisted replay — the
+		// documented "raise the cap + resume" recovery would be inert
+		// otherwise, and the run would die at the same wall. The override
+		// is also persisted to the run doc below so a subsequent
+		// auto-retry keeps the raised cap rather than reverting to the
+		// launch ask that already killed the run.
+		Budget:         clampBudgetToGrant(resolveResumeBudgetAsk(spec.Budget, prior.BudgetOverrides), wf, creds.grant, checkpointCostUSD(prior), p.logger, spec.RunID),
 		BackendConfig:  queue.BackendConfig{Default: queue.BackendClaw},
 		PublishedAtRFC: time.Now().UTC().Format(time.RFC3339Nano),
 		// A resumed attempt must honour the SAME pins the launch declared —
@@ -1696,6 +1704,20 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 	republished = true
 	if p.metrics != nil {
 		p.metrics.RunsCreatedTotal.WithLabelValues("resumed").Inc()
+	}
+	// Disarm any usage-window retry the retry sweeper had armed for this
+	// run: an operator (or the auto-retry) is resuming it NOW, and a
+	// surviving retry_after re-fires the sweeper days later on a run that
+	// finished. Observed live (#669 part 3): a manual resume left the pre-park
+	// retry_state in place, and the 09-08 21:07 sweep would have claimed a
+	// completed run. Best-effort — a store blip here does not cancel the
+	// resume: the sweep's ClaimRunRetry CAS still checks the run status
+	// (which is now queued/running), so the worst case is one spurious
+	// abandon audit line.
+	if retryStore := store.AsRunRetryStore(p.store); retryStore != nil {
+		if err := retryStore.ClearRunRetry(context.WithoutCancel(ctx), spec.RunID); err != nil && p.logger != nil {
+			p.logger.Warn("cloudpublisher: clear armed retry for %s after manual resume: %v", spec.RunID, err)
+		}
 	}
 	return nil
 }
@@ -2112,6 +2134,19 @@ func runBudgetOverrides(o *ir.BudgetOverrides) *store.RunBudgetOverrides {
 		MaxIterations:       o.MaxIterations,
 		MaxParallelBranches: o.MaxParallelBranches,
 	}
+}
+
+// resolveResumeBudgetAsk chooses between a THIS-RESUME override (the
+// CLI/API budget flags on the resume request) and the persisted launch
+// ask that lives on the run doc. The this-resume override wins when
+// non-nil and non-empty — that IS the "raise the cap + resume"
+// recovery — else the doc's replay is honoured (today's behaviour, and
+// the only path an unattended auto-retry can travel). #652 part 2.
+func resolveResumeBudgetAsk(fromSpec *ir.BudgetOverrides, fromDoc *store.RunBudgetOverrides) *ir.BudgetOverrides {
+	if fromSpec != nil && !fromSpec.IsZero() {
+		return fromSpec
+	}
+	return budgetOverridesFromRun(fromDoc)
 }
 
 // budgetOverridesFromRun replays a run doc's persisted budget ask onto a

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -41,6 +41,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/pluginsource"
 	"github.com/SocialGouv/iterion/pkg/queue"
 	natsq "github.com/SocialGouv/iterion/pkg/queue/nats"
+	"github.com/SocialGouv/iterion/pkg/runtime"
 	"github.com/SocialGouv/iterion/pkg/runview"
 	"github.com/SocialGouv/iterion/pkg/secrets"
 	"github.com/SocialGouv/iterion/pkg/store"
@@ -1712,11 +1713,24 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 	// asked for a change on THIS resume — an ask-less resume leaves
 	// the doc untouched. Granular SetRunBudgetOverrides so the CAS
 	// status transition above (queued) stays intact. Best-effort.
+	//
+	// The doc's effective-caps snapshot (Run.Budget, the studio
+	// Overview's denominator) is stamped alongside, from the SAME merged
+	// ask the wire carries: the engine stamps it only at launch, so
+	// without this write the doc would keep showing the launch-time cap
+	// for the rest of the resumed run. The platform ceiling is the
+	// runner's to apply (its environment, not the publisher's); a cap
+	// raised above it is clamped on the pod and logged there.
 	if spec.Budget != nil && !spec.Budget.IsZero() {
 		merged := resolveResumeBudgetAsk(spec.Budget, prior.BudgetOverrides)
 		persistCtx, persistCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 		if err := p.store.SetRunBudgetOverrides(persistCtx, spec.RunID, runBudgetOverrides(merged)); err != nil && p.logger != nil {
 			p.logger.Warn("cloudpublisher: persist merged budget ask for %s after resume: %v", spec.RunID, err)
+		}
+		if snap := runtime.EffectiveBudgetSnapshot(wf, merged); snap != nil {
+			if err := p.store.SetRunBudgetSnapshot(persistCtx, spec.RunID, snap); err != nil && p.logger != nil {
+				p.logger.Warn("cloudpublisher: refresh budget snapshot for %s after resume: %v", spec.RunID, err)
+			}
 		}
 		persistCancel()
 	}
@@ -2174,7 +2188,7 @@ func runBudgetOverrides(o *ir.BudgetOverrides) *store.RunBudgetOverrides {
 //
 // #652 part 2.
 func resolveResumeBudgetAsk(fromSpec *ir.BudgetOverrides, fromDoc *store.RunBudgetOverrides) *ir.BudgetOverrides {
-	base := budgetOverridesFromRun(fromDoc)
+	base := runtime.BudgetOverridesFromRun(fromDoc)
 	if fromSpec == nil || fromSpec.IsZero() {
 		return base
 	}
@@ -2200,22 +2214,6 @@ func resolveResumeBudgetAsk(fromSpec *ir.BudgetOverrides, fromDoc *store.RunBudg
 		base.CapImposed = true
 	}
 	return base
-}
-
-// budgetOverridesFromRun replays a run doc's persisted budget ask onto a
-// resume publication, where clampBudgetToGrant re-clamps it against the
-// resume's own grant exactly like a fresh launch.
-func budgetOverridesFromRun(o *store.RunBudgetOverrides) *ir.BudgetOverrides {
-	if o == nil {
-		return nil
-	}
-	return &ir.BudgetOverrides{
-		MaxCostUSD:          o.MaxCostUSD,
-		MaxTokens:           o.MaxTokens,
-		MaxDuration:         o.MaxDuration,
-		MaxIterations:       o.MaxIterations,
-		MaxParallelBranches: o.MaxParallelBranches,
-	}
 }
 
 // runFallbackOf converts the launch's run-level fallback chain into the

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -1263,7 +1263,7 @@ func (p *Publisher) SubmitLaunch(ctx context.Context, runID string, spec runview
 		// run doc is the single source the resume path replays from. The
 		// clamped/effective figure is NOT what is stamped — the resume
 		// re-clamps against its own grant.
-		BudgetOverrides: runBudgetOverrides(spec.Budget),
+		BudgetOverrides: runtime.RunBudgetOverridesOf(spec.Budget),
 	}
 	// Typed provenance (schedule / dispatcher / trigger spine). The queued
 	// doc is the ONLY carrier: the RunMessage has no source field, and the
@@ -1636,6 +1636,16 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 	if contribErr != nil {
 		return contribErr
 	}
+	// The budget the resumed attempt executes against, computed ONCE: the
+	// launch ask replayed from the run doc, this resume's ask merged over
+	// it per field (#652 part 2 — the remote CLI's --max-* flags beat the
+	// persisted replay, or the documented "raise the cap + resume"
+	// recovery is inert), then clamped to the donor's remaining allowance
+	// when a credential-pool grant serves the run. It rides the wire below
+	// AND stamps the doc's effective-caps snapshot further down — the same
+	// figure, so the studio never advertises a cap the run does not have.
+	merged := runtime.MergeResumeBudgetAsk(spec.Budget, prior.BudgetOverrides)
+	wire := clampBudgetToGrant(merged, wf, creds.grant, checkpointCostUSD(prior), p.logger, spec.RunID)
 	msg := &queue.RunMessage{
 		V:             queue.SchemaVersion,
 		Contributions: contributions,
@@ -1665,15 +1675,10 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 		// doctrine as ModelOverrides below): cloud resumes are often
 		// unattended auto-retries, so nothing else can re-state it, and a
 		// dropped override silently reverts the run to the workflow's cap.
-		//
-		// #652 part 2: a THIS-RESUME override (spec.Budget, set by the
-		// remote CLI's --max-* flags) BEATS the persisted replay — the
-		// documented "raise the cap + resume" recovery would be inert
-		// otherwise, and the run would die at the same wall. The override
-		// is also persisted to the run doc below so a subsequent
-		// auto-retry keeps the raised cap rather than reverting to the
-		// launch ask that already killed the run.
-		Budget:         clampBudgetToGrant(resolveResumeBudgetAsk(spec.Budget, prior.BudgetOverrides), wf, creds.grant, checkpointCostUSD(prior), p.logger, spec.RunID),
+		// A THIS-RESUME override is also persisted to the run doc below so
+		// a subsequent auto-retry keeps the raised cap rather than
+		// reverting to the launch ask that already killed the run.
+		Budget:         wire,
 		BackendConfig:  queue.BackendConfig{Default: queue.BackendClaw},
 		PublishedAtRFC: time.Now().UTC().Format(time.RFC3339Nano),
 		// A resumed attempt must honour the SAME pins the launch declared —
@@ -1715,19 +1720,25 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 	// status transition above (queued) stays intact. Best-effort.
 	//
 	// The doc's effective-caps snapshot (Run.Budget, the studio
-	// Overview's denominator) is stamped alongside, from the SAME merged
-	// ask the wire carries: the engine stamps it only at launch, so
-	// without this write the doc would keep showing the launch-time cap
-	// for the rest of the resumed run. The platform ceiling is the
-	// runner's to apply (its environment, not the publisher's); a cap
-	// raised above it is clamped on the pod and logged there.
+	// Overview's denominator) is stamped alongside, from the figure the
+	// WIRE carries — merged AND clamped to the donor's allowance — never
+	// from the un-clamped ask: the engine stamps it only at launch (post-
+	// clamp, so the field means "enforced"), and a resume that stamped
+	// the ask would flip its meaning to "asked" for the rest of the run
+	// (the studio reading $120 while the pod dies at the donor's $5, with
+	// CapImposed denying the exit grace). The ask itself (the replay
+	// source) is persisted un-clamped on purpose: the allowance is
+	// re-derived on every resume. What this stamp cannot see is the
+	// PLATFORM ceiling (ITERION_CLOUD_MAX_*): it lives in the runner's
+	// environment, not the publisher's, and a cap raised above it is
+	// clamped on the pod and logged there — the doc over-reports by that
+	// margin until the engine re-stamps on resume (ticketed).
 	if spec.Budget != nil && !spec.Budget.IsZero() {
-		merged := resolveResumeBudgetAsk(spec.Budget, prior.BudgetOverrides)
 		persistCtx, persistCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
-		if err := p.store.SetRunBudgetOverrides(persistCtx, spec.RunID, runBudgetOverrides(merged)); err != nil && p.logger != nil {
+		if err := p.store.SetRunBudgetOverrides(persistCtx, spec.RunID, runtime.RunBudgetOverridesOf(merged)); err != nil && p.logger != nil {
 			p.logger.Warn("cloudpublisher: persist merged budget ask for %s after resume: %v", spec.RunID, err)
 		}
-		if snap := runtime.EffectiveBudgetSnapshot(wf, merged); snap != nil {
+		if snap := runtime.EffectiveBudgetSnapshot(wf, runtime.BudgetOverridesFromWire(wire)); snap != nil {
 			if err := p.store.SetRunBudgetSnapshot(persistCtx, spec.RunID, snap); err != nil && p.logger != nil {
 				p.logger.Warn("cloudpublisher: refresh budget snapshot for %s after resume: %v", spec.RunID, err)
 			}
@@ -2151,69 +2162,6 @@ func runModelOverrides(entries []runview.ModelOverrideEntry) []store.RunModelOve
 		out = append(out, store.RunModelOverride{Selector: e.Selector, Backend: e.Backend, Model: e.Model, Provider: e.Provider})
 	}
 	return out
-}
-
-// runBudgetOverrides converts the launch's raw budget ask into the
-// persisted run-doc form (the resume path's replay source, the budget
-// twin of runModelOverrides). An absent or all-zero ask persists as nil
-// so legacy docs and override-less launches stay byte-identical.
-// CapImposed is deliberately not persisted: it is a product of the grant
-// clamp, recomputed against the CURRENT grant on every publication.
-func runBudgetOverrides(o *ir.BudgetOverrides) *store.RunBudgetOverrides {
-	if o == nil || o.IsZero() {
-		return nil
-	}
-	return &store.RunBudgetOverrides{
-		MaxCostUSD:          o.MaxCostUSD,
-		MaxTokens:           o.MaxTokens,
-		MaxDuration:         o.MaxDuration,
-		MaxIterations:       o.MaxIterations,
-		MaxParallelBranches: o.MaxParallelBranches,
-	}
-}
-
-// resolveResumeBudgetAsk MERGES the THIS-RESUME override (the CLI/API
-// budget flags on the resume request) OVER the persisted launch ask
-// on the run doc, per field. The contract is the same "non-zero wins,
-// zero inherits" rule ApplyBudgetOverrides enforces on the executor
-// side, and the same shape ir.BudgetOverrides itself documents.
-//
-// Wholesale-replace (an earlier variant of this helper) was E1's
-// finding: `--max-duration 4h` alone erased the launch's $50 / 5e6-
-// token envelope on the wire, ApplyBudgetOverrides then left the
-// .bot's own cap in place, and restoreCheckpoint put the banked
-// spend back over it — the run died on BUDGET_EXCEEDED before the
-// first node. Zero-value fields in the spec inherit the doc value;
-// non-zero fields override.
-//
-// #652 part 2.
-func resolveResumeBudgetAsk(fromSpec *ir.BudgetOverrides, fromDoc *store.RunBudgetOverrides) *ir.BudgetOverrides {
-	base := runtime.BudgetOverridesFromRun(fromDoc)
-	if fromSpec == nil || fromSpec.IsZero() {
-		return base
-	}
-	if base == nil {
-		base = &ir.BudgetOverrides{}
-	}
-	if fromSpec.MaxCostUSD > 0 {
-		base.MaxCostUSD = fromSpec.MaxCostUSD
-	}
-	if fromSpec.MaxTokens > 0 {
-		base.MaxTokens = fromSpec.MaxTokens
-	}
-	if fromSpec.MaxDuration != "" {
-		base.MaxDuration = fromSpec.MaxDuration
-	}
-	if fromSpec.MaxIterations > 0 {
-		base.MaxIterations = fromSpec.MaxIterations
-	}
-	if fromSpec.MaxParallelBranches > 0 {
-		base.MaxParallelBranches = fromSpec.MaxParallelBranches
-	}
-	if fromSpec.CapImposed {
-		base.CapImposed = true
-	}
-	return base
 }
 
 // runFallbackOf converts the launch's run-level fallback chain into the

--- a/pkg/server/cloudpublisher/publisher.go
+++ b/pkg/server/cloudpublisher/publisher.go
@@ -1715,35 +1715,42 @@ func (p *Publisher) SubmitResume(ctx context.Context, spec runview.ResumeSpec, w
 	// run doc, so a subsequent unattended auto-retry (usage-window
 	// sweeper) keeps the raised cap rather than reverting to the
 	// launch ask that already killed the run. Only when the operator
-	// asked for a change on THIS resume — an ask-less resume leaves
-	// the doc untouched. Granular SetRunBudgetOverrides so the CAS
+	// asked for a change on THIS resume — an ask-less resume leaves the
+	// ASK untouched, and the ask is persisted UN-CLAMPED on purpose: the
+	// donor allowance is re-derived against the current grant on every
+	// resume, so a run capped at $5 today correctly replays its $120 ask
+	// once the donor recovers. Granular SetRunBudgetOverrides so the CAS
 	// status transition above (queued) stays intact. Best-effort.
-	//
+	persistCtx, persistCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer persistCancel()
+	if spec.Budget != nil && !spec.Budget.IsZero() {
+		if err := p.store.SetRunBudgetOverrides(persistCtx, spec.RunID, runtime.RunBudgetOverridesOf(merged)); err != nil && p.logger != nil {
+			p.logger.Warn("cloudpublisher: persist merged budget ask for %s after resume: %v", spec.RunID, err)
+		}
+	}
 	// The doc's effective-caps snapshot (Run.Budget, the studio
-	// Overview's denominator) is stamped alongside, from the figure the
-	// WIRE carries — merged AND clamped to the donor's allowance — never
-	// from the un-clamped ask: the engine stamps it only at launch (post-
-	// clamp, so the field means "enforced"), and a resume that stamped
-	// the ask would flip its meaning to "asked" for the rest of the run
-	// (the studio reading $120 while the pod dies at the donor's $5, with
-	// CapImposed denying the exit grace). The ask itself (the replay
-	// source) is persisted un-clamped on purpose: the allowance is
-	// re-derived on every resume. What this stamp cannot see is the
+	// Overview's denominator) is stamped on EVERY resume that puts a
+	// budget on the wire — ask or no ask — from the figure the wire
+	// carries (merged AND clamped to the donor's allowance), never from
+	// the ask: the allowance moves between resumes in both directions
+	// (an ask-less auto-retry can find a $5 donor after a $500 one, or
+	// the reverse), and the engine stamps this field only at launch
+	// (post-clamp, so the field means "enforced"). Enforcement is
+	// correct on the wire in every case; without this stamp it is the
+	// doc that lies — the studio reading $120 while the pod dies at the
+	// donor's $5 with CapImposed denying the exit grace, or $5 while the
+	// run may spend $120. A nil wire means nothing changed: the runner's
+	// post-ceiling launch stamp stands. What this stamp cannot see is the
 	// PLATFORM ceiling (ITERION_CLOUD_MAX_*): it lives in the runner's
 	// environment, not the publisher's, and a cap raised above it is
 	// clamped on the pod and logged there — the doc over-reports by that
 	// margin until the engine re-stamps on resume (ticketed).
-	if spec.Budget != nil && !spec.Budget.IsZero() {
-		persistCtx, persistCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
-		if err := p.store.SetRunBudgetOverrides(persistCtx, spec.RunID, runtime.RunBudgetOverridesOf(merged)); err != nil && p.logger != nil {
-			p.logger.Warn("cloudpublisher: persist merged budget ask for %s after resume: %v", spec.RunID, err)
-		}
+	if wire != nil {
 		if snap := runtime.EffectiveBudgetSnapshot(wf, runtime.BudgetOverridesFromWire(wire)); snap != nil {
 			if err := p.store.SetRunBudgetSnapshot(persistCtx, spec.RunID, snap); err != nil && p.logger != nil {
 				p.logger.Warn("cloudpublisher: refresh budget snapshot for %s after resume: %v", spec.RunID, err)
 			}
 		}
-		persistCancel()
 	}
 	// Disarm any usage-window retry the retry sweeper had armed for this
 	// run: an operator (or the auto-retry) is resuming it NOW, and a

--- a/pkg/server/cloudpublisher/publisher_budget_overrides_test.go
+++ b/pkg/server/cloudpublisher/publisher_budget_overrides_test.go
@@ -132,6 +132,63 @@ func TestSubmitResume_PersistsMergedAskOntoRunDoc(t *testing.T) {
 	}
 }
 
+// The doc's effective-caps snapshot (Run.Budget, what the studio Overview
+// draws) must read the MERGED ask the wire enforces — the doc's launch
+// ask per field, this resume's ask over it, the .bot's own cap only
+// where neither says anything. The engine stamps Run.Budget at launch
+// only, so a resume that raises a cap has to stamp it itself: doc ask
+// {$50, 2h30m}, .bot says $20, resume --max-duration 4h → the doc must
+// read $50 / 4h, never the .bot's $20 nor the launch's 2h30m.
+func TestSubmitResume_StampsTheMergedCapOnTheDocSnapshot(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	ctx := store.WithIdentity(context.Background(), "team-a", "u1")
+	const runID = "run-snapshot-merged-cap"
+	if err := st.SaveRun(ctx, &store.Run{
+		ID: runID, TenantID: "team-a", OwnerID: "u1",
+		Status:          store.RunStatusFailedResumable,
+		Budget:          &store.RunBudget{MaxCostUSD: 50, MaxDuration: "2h30m", MaxTokens: 5000}, // the engine's launch stamp
+		BudgetOverrides: &store.RunBudgetOverrides{MaxCostUSD: 50, MaxDuration: "2h30m"},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	p := &Publisher{
+		store:      st,
+		publishRun: func(context.Context, *queue.RunMessage) error { return nil },
+	}
+	wf := &ir.Workflow{Name: "wf", Budget: &ir.Budget{MaxCostUSD: 20, MaxDuration: "2h30m", MaxTokens: 5000}}
+	spec := runview.ResumeSpec{
+		RunID: runID, FilePath: "wf.bot",
+		Source: "workflow wf:\n  entry: done\n",
+		Budget: &ir.BudgetOverrides{MaxDuration: "4h"},
+	}
+	if err := p.SubmitResume(ctx, spec, wf, "hash"); err != nil {
+		t.Fatalf("SubmitResume: %v", err)
+	}
+	got, err := st.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.Budget == nil {
+		t.Fatal("Budget = nil after resume; the snapshot stamp did not fire")
+	}
+	if got.Budget.MaxDuration != "4h" {
+		t.Fatalf("doc Budget.MaxDuration = %q, want 4h — the doc keeps showing the launch-time cap that killed the run for the rest of the resumed run", got.Budget.MaxDuration)
+	}
+	if got.Budget.MaxCostUSD != 50 {
+		t.Fatalf("doc Budget.MaxCostUSD = %v, want the doc ask's 50 (the wire enforces the per-field merge; a stamp from wf+spec alone would under-report the .bot's 20)", got.Budget.MaxCostUSD)
+	}
+	if got.Budget.MaxTokens != 5000 {
+		t.Fatalf("doc Budget.MaxTokens = %v, want the .bot's 5000 inherited where no ask says otherwise", got.Budget.MaxTokens)
+	}
+	// The status CAS SubmitResume applied stays intact: the stamp is granular.
+	if got.Status != store.RunStatusQueued {
+		t.Fatalf("status after the stamp = %s, want queued (the snapshot write must not revert the resume's own transition)", got.Status)
+	}
+}
+
 // A resume with NO budget override must leave the doc's BudgetOverrides
 // untouched — an unattended auto-retry running `resolveResumeBudgetAsk`
 // with a nil spec.Budget must not clobber the launch ask.

--- a/pkg/server/cloudpublisher/publisher_budget_overrides_test.go
+++ b/pkg/server/cloudpublisher/publisher_budget_overrides_test.go
@@ -84,6 +84,144 @@ func TestSubmitLaunchWithoutBudgetAskPersistsNone(t *testing.T) {
 	}
 }
 
+// E4: SubmitResume MUST persist the MERGED ask onto the run doc so an
+// unattended usage-window auto-retry days later keeps the raised cap
+// instead of reverting to the launch ask that killed the run. Round-1
+// probe: `--max-cost-usd 120` resume left doc.BudgetOverrides.
+// MaxCostUSD = 10 (the launch ask).
+func TestSubmitResume_PersistsMergedAskOntoRunDoc(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	ctx := store.WithIdentity(context.Background(), "team-a", "u1")
+	const runID = "run-persist-merged-ask"
+	if err := st.SaveRun(ctx, &store.Run{
+		ID: runID, TenantID: "team-a", OwnerID: "u1",
+		Status:          store.RunStatusFailedResumable,
+		BudgetOverrides: &store.RunBudgetOverrides{MaxCostUSD: 10, MaxDuration: "2h"},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	p := &Publisher{
+		store:      st,
+		publishRun: func(context.Context, *queue.RunMessage) error { return nil },
+	}
+	wf := &ir.Workflow{Name: "wf"}
+	spec := runview.ResumeSpec{
+		RunID: runID, FilePath: "wf.bot",
+		Source: "workflow wf:\n  entry: done\n",
+		Budget: &ir.BudgetOverrides{MaxCostUSD: 120},
+	}
+	if err := p.SubmitResume(ctx, spec, wf, "hash"); err != nil {
+		t.Fatalf("SubmitResume: %v", err)
+	}
+	got, err := st.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.BudgetOverrides == nil {
+		t.Fatal("BudgetOverrides = nil after resume; the persist step did not fire")
+	}
+	if got.BudgetOverrides.MaxCostUSD != 120 {
+		t.Fatalf("persisted MaxCostUSD = %v, want 120 (E4: the raised cap does not survive the resume — a subsequent auto-retry dies at the same wall)", got.BudgetOverrides.MaxCostUSD)
+	}
+	// A partial override must NOT erase the launch's other caps on the doc.
+	if got.BudgetOverrides.MaxDuration != "2h" {
+		t.Fatalf("persisted MaxDuration = %q, want 2h (a partial resume ask must not clear the launch's untouched caps)", got.BudgetOverrides.MaxDuration)
+	}
+}
+
+// A resume with NO budget override must leave the doc's BudgetOverrides
+// untouched — an unattended auto-retry running `resolveResumeBudgetAsk`
+// with a nil spec.Budget must not clobber the launch ask.
+func TestSubmitResume_LeavesDocBudgetIntactWithoutOverride(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	ctx := store.WithIdentity(context.Background(), "team-a", "u1")
+	const runID = "run-no-budget-ask"
+	baseline := &store.RunBudgetOverrides{MaxCostUSD: 50}
+	if err := st.SaveRun(ctx, &store.Run{
+		ID: runID, TenantID: "team-a", OwnerID: "u1",
+		Status:          store.RunStatusFailedResumable,
+		BudgetOverrides: baseline,
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	p := &Publisher{
+		store:      st,
+		publishRun: func(context.Context, *queue.RunMessage) error { return nil },
+	}
+	spec := runview.ResumeSpec{RunID: runID, FilePath: "wf.bot", Source: "workflow wf:\n  entry: done\n"}
+	if err := p.SubmitResume(ctx, spec, &ir.Workflow{Name: "wf"}, "hash"); err != nil {
+		t.Fatalf("SubmitResume: %v", err)
+	}
+	got, err := st.LoadRun(ctx, runID)
+	if err != nil || got.BudgetOverrides == nil || got.BudgetOverrides.MaxCostUSD != 50 {
+		t.Fatalf("doc.BudgetOverrides = %+v (err %v), want the launch ask $50 preserved (an ask-less resume must not clobber the persisted launch ask)", got.BudgetOverrides, err)
+	}
+}
+
+// E1: a partial CLI override (`--max-duration 4h` alone) must MERGE
+// with the launch's other caps persisted on the run doc, not replace
+// the whole envelope. The wholesale-replace variant erased the
+// launch's $50 / 5e6 caps → ApplyBudgetOverrides left the .bot's own
+// MaxCostUSD ($5 in the probe) → restoreCheckpoint put the banked
+// $30 back and the run died on BUDGET_EXCEEDED before the first
+// node. The documented contract is per-field "non-zero wins, zero
+// inherits", the same rule ApplyBudgetOverrides enforces on the
+// executor side.
+func TestSubmitResumeMergesPartialSpecBudgetOverDocAsk(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	ctx := store.WithIdentity(context.Background(), "team-a", "u1")
+	const runID = "run-partial-resume-budget"
+	if err := st.SaveRun(ctx, &store.Run{
+		ID: runID, TenantID: "team-a", OwnerID: "u1",
+		Status: store.RunStatusFailedResumable,
+		BudgetOverrides: &store.RunBudgetOverrides{
+			MaxCostUSD: 50, MaxTokens: 5_000_000, MaxDuration: "2h30m",
+		},
+	}); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	var published *queue.RunMessage
+	p := &Publisher{
+		store: st,
+		publishRun: func(_ context.Context, m *queue.RunMessage) error {
+			published = m
+			return nil
+		},
+	}
+	wf := &ir.Workflow{Name: "wf", Budget: &ir.Budget{MaxDuration: "4h"}}
+	// Operator asks only for a longer duration; the launch's $50 /
+	// 5e6-token envelope must SURVIVE the resume.
+	spec := runview.ResumeSpec{
+		RunID: runID, FilePath: "wf.bot",
+		Source: "workflow wf:\n  entry: done\n",
+		Budget: &ir.BudgetOverrides{MaxDuration: "4h"},
+	}
+	if err := p.SubmitResume(ctx, spec, wf, "hash"); err != nil {
+		t.Fatalf("SubmitResume: %v", err)
+	}
+	if published == nil || published.Budget == nil {
+		t.Fatal("nothing published or budget dropped from the wire")
+	}
+	if published.Budget.MaxDuration != "4h" {
+		t.Fatalf("wire max_duration = %q, want 4h (the operator's ask)", published.Budget.MaxDuration)
+	}
+	if published.Budget.MaxCostUSD != 50 {
+		t.Fatalf("wire max_cost_usd = %v, want 50 (the launch ask must survive a partial resume override — E1)", published.Budget.MaxCostUSD)
+	}
+	if published.Budget.MaxTokens != 5_000_000 {
+		t.Fatalf("wire max_tokens = %v, want 5_000_000 (the launch ask must survive a partial resume override — E1)", published.Budget.MaxTokens)
+	}
+}
+
 // #652 part 2: `iterion remote runs resume --max-duration 4h` (and its
 // peer overrides) must beat the launch ask persisted on the run doc.
 // Otherwise the documented "raise the cap + resume" recovery is inert

--- a/pkg/server/cloudpublisher/publisher_budget_overrides_test.go
+++ b/pkg/server/cloudpublisher/publisher_budget_overrides_test.go
@@ -84,6 +84,51 @@ func TestSubmitLaunchWithoutBudgetAskPersistsNone(t *testing.T) {
 	}
 }
 
+// #652 part 2: `iterion remote runs resume --max-duration 4h` (and its
+// peer overrides) must beat the launch ask persisted on the run doc.
+// Otherwise the documented "raise the cap + resume" recovery is inert
+// on cloud runs and the resumed run dies at exactly the same wall.
+func TestSubmitResumeThisResumeBudgetBeatsDocReplay(t *testing.T) {
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	ctx := store.WithIdentity(context.Background(), "team-a", "u1")
+	const runID = "run-cli-resume-raise-cap"
+	if err := st.SaveRun(ctx, &store.Run{
+		ID: runID, TenantID: "team-a", OwnerID: "u1",
+		Status:          store.RunStatusFailedResumable,
+		BudgetOverrides: &store.RunBudgetOverrides{MaxDuration: "2h30m"}, // the launch ask that killed it
+	}); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	var published *queue.RunMessage
+	p := &Publisher{
+		store: st,
+		publishRun: func(_ context.Context, m *queue.RunMessage) error {
+			published = m
+			return nil
+		},
+	}
+	wf := &ir.Workflow{Name: "wf", Budget: &ir.Budget{MaxDuration: "4h"}}
+	// The resume ask raises to 4h — the recovery the operator would
+	// have typed at the remote CLI.
+	spec := runview.ResumeSpec{
+		RunID: runID, FilePath: "wf.bot",
+		Source: "workflow wf:\n  entry: done\n",
+		Budget: &ir.BudgetOverrides{MaxDuration: "4h"},
+	}
+	if err := p.SubmitResume(ctx, spec, wf, "hash"); err != nil {
+		t.Fatalf("SubmitResume: %v", err)
+	}
+	if published == nil || published.Budget == nil {
+		t.Fatal("nothing published or budget dropped from the wire")
+	}
+	if published.Budget.MaxDuration != "4h" {
+		t.Fatalf("resume wire duration = %q, want 4h — the this-resume override was silently ignored and the resumed run will die at 2h30m again (#652 part 2)", published.Budget.MaxDuration)
+	}
+}
+
 func TestSubmitResumeReplaysTheLaunchBudgetAsk(t *testing.T) {
 	st, err := store.New(t.TempDir())
 	if err != nil {

--- a/pkg/server/cloudpublisher/publisher_budget_wire_test.go
+++ b/pkg/server/cloudpublisher/publisher_budget_wire_test.go
@@ -1,0 +1,108 @@
+package cloudpublisher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/credpool"
+	"github.com/SocialGouv/iterion/pkg/dsl/ir"
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/queue"
+	"github.com/SocialGouv/iterion/pkg/runview"
+	"github.com/SocialGouv/iterion/pkg/secrets"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// The doc's effective-caps snapshot must read the figure the WIRE carries,
+// not the un-clamped ask: a credential-pool grant clamps the resume's cost
+// cap to the donor's remaining allowance (with CapImposed, so no exit
+// grace), and at launch the runner stamps Run.Budget post-clamp. A resume
+// that stamped the ask flips the field's meaning from "enforced" to
+// "asked" within one run: the studio reads $120 while the pod dies
+// BUDGET_EXCEEDED at the donor's $5.
+func TestSubmitResume_StampsTheClampedWireCapNotTheAsk(t *testing.T) {
+	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("sealer: %v", err)
+	}
+	ctx := context.Background()
+	oauth := secrets.NewMemoryOAuthStore()
+	seedOAuth(t, oauth, sealer, "donor", "sk-ant-donated")
+	pools := credpool.NewMemoryPoolStore()
+	if err := pools.Upsert(ctx, credpool.Pool{
+		ID: "pool-1", OrgID: poolOrg, Enabled: true,
+		// The requesting team is admitted by name: the publisher under test
+		// has no identity store, so the run's org resolves to "".
+		Audience: credpool.Audience{Teams: []string{poolTeam}},
+	}); err != nil {
+		t.Fatalf("seed pool: %v", err)
+	}
+	pledges := credpool.NewMemoryPledgeStore()
+	if err := pledges.Upsert(ctx, credpool.Pledge{
+		ID: credpool.PledgeID("donor", credpool.SourceOAuth, "claude_code"), PoolID: "pool-1",
+		UserID: "donor", Credential: credpool.Credential{Source: credpool.SourceOAuth, Ref: "claude_code"},
+		Enabled: true, Health: credpool.HealthOK, Limits: credpool.Limits{MaxUSDPerDay: 5},
+	}); err != nil {
+		t.Fatalf("seed pledge: %v", err)
+	}
+	broker := credpool.NewBroker(credpool.BrokerConfig{
+		Pools: pools, Pledges: pledges, Leases: credpool.NewMemoryLeaseStore(), Ledger: credpool.NewMemoryLedger(),
+		OAuth: oauth, Sealer: sealer, Logger: testLogger(),
+	})
+	if broker == nil {
+		t.Fatal("broker is nil with every dependency wired")
+	}
+
+	st, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	var published *queue.RunMessage
+	p := &Publisher{
+		store:      st,
+		runSecrets: secrets.NewMemoryRunSecretsStore(),
+		sealer:     sealer,
+		credPool:   broker,
+		logger:     iterlog.New(iterlog.LevelError, nil),
+		publishRun: func(_ context.Context, m *queue.RunMessage) error {
+			published = m
+			return nil
+		},
+	}
+	tctx := store.WithIdentity(ctx, poolTeam, "requester")
+	const runID = "run-donor-clamped-resume"
+	if err := st.SaveRun(tctx, &store.Run{
+		ID: runID, TenantID: poolTeam, OwnerID: "requester",
+		Status: store.RunStatusFailedResumable,
+		Budget: &store.RunBudget{MaxCostUSD: 20}, // the launch stamp
+	}); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	wf := &ir.Workflow{Name: "wf", Budget: &ir.Budget{MaxCostUSD: 20}}
+	spec := runview.ResumeSpec{
+		RunID: runID, FilePath: "wf.bot",
+		Source: "workflow wf:\n  entry: done\n",
+		Budget: &ir.BudgetOverrides{MaxCostUSD: 120},
+	}
+	if err := p.SubmitResume(tctx, spec, wf, "hash"); err != nil {
+		t.Fatalf("SubmitResume: %v", err)
+	}
+	if published == nil || published.Budget == nil {
+		t.Fatal("nothing published or budget dropped from the wire")
+	}
+	if published.Budget.MaxCostUSD != 5 || !published.Budget.CapImposed {
+		t.Fatalf("wire budget = %+v, want the donor's $5 with CapImposed (the premise: the grant clamps the wire)", published.Budget)
+	}
+	got, err := st.LoadRun(tctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.Budget == nil || got.Budget.MaxCostUSD != 5 {
+		t.Fatalf("doc Budget = %+v, want MaxCostUSD 5 — the doc advertises the un-clamped ask while the run is capped at the donor's $5 (CapImposed, no exit grace) and dies BUDGET_EXCEEDED there", got.Budget)
+	}
+	// The replay source keeps the un-clamped ask: the allowance is
+	// re-derived against the CURRENT grant on every resume.
+	if got.BudgetOverrides == nil || got.BudgetOverrides.MaxCostUSD != 120 {
+		t.Fatalf("doc BudgetOverrides = %+v, want the raw $120 ask persisted un-clamped", got.BudgetOverrides)
+	}
+}

--- a/pkg/server/cloudpublisher/publisher_budget_wire_test.go
+++ b/pkg/server/cloudpublisher/publisher_budget_wire_test.go
@@ -19,8 +19,16 @@ import (
 // grace), and at launch the runner stamps Run.Budget post-clamp. A resume
 // that stamped the ask flips the field's meaning from "enforced" to
 // "asked" within one run: the studio reads $120 while the pod dies
-// BUDGET_EXCEEDED at the donor's $5.
-func TestSubmitResume_StampsTheClampedWireCapNotTheAsk(t *testing.T) {
+// BUDGET_EXCEEDED at the donor's $5. And the allowance is re-derived on
+// EVERY resume — the ask-less auto-retry included — so the stamp must
+// follow the wire on every resume, in both directions.
+
+// donorClampedPublisher builds a publisher whose only credential is a
+// pooled donor subscription with the given daily allowance; the pool
+// admits the requesting team by name (no identity store, so the run's
+// org resolves to ""). Every publish is captured.
+func donorClampedPublisher(t *testing.T, maxUSDPerDay float64) (*Publisher, store.RunStore, *[]*queue.RunMessage) {
+	t.Helper()
 	sealer, err := secrets.NewAESGCMSealer(make([]byte, 32))
 	if err != nil {
 		t.Fatalf("sealer: %v", err)
@@ -31,8 +39,6 @@ func TestSubmitResume_StampsTheClampedWireCapNotTheAsk(t *testing.T) {
 	pools := credpool.NewMemoryPoolStore()
 	if err := pools.Upsert(ctx, credpool.Pool{
 		ID: "pool-1", OrgID: poolOrg, Enabled: true,
-		// The requesting team is admitted by name: the publisher under test
-		// has no identity store, so the run's org resolves to "".
 		Audience: credpool.Audience{Teams: []string{poolTeam}},
 	}); err != nil {
 		t.Fatalf("seed pool: %v", err)
@@ -41,7 +47,7 @@ func TestSubmitResume_StampsTheClampedWireCapNotTheAsk(t *testing.T) {
 	if err := pledges.Upsert(ctx, credpool.Pledge{
 		ID: credpool.PledgeID("donor", credpool.SourceOAuth, "claude_code"), PoolID: "pool-1",
 		UserID: "donor", Credential: credpool.Credential{Source: credpool.SourceOAuth, Ref: "claude_code"},
-		Enabled: true, Health: credpool.HealthOK, Limits: credpool.Limits{MaxUSDPerDay: 5},
+		Enabled: true, Health: credpool.HealthOK, Limits: credpool.Limits{MaxUSDPerDay: maxUSDPerDay},
 	}); err != nil {
 		t.Fatalf("seed pledge: %v", err)
 	}
@@ -52,12 +58,11 @@ func TestSubmitResume_StampsTheClampedWireCapNotTheAsk(t *testing.T) {
 	if broker == nil {
 		t.Fatal("broker is nil with every dependency wired")
 	}
-
 	st, err := store.New(t.TempDir())
 	if err != nil {
 		t.Fatalf("store.New: %v", err)
 	}
-	var published *queue.RunMessage
+	published := &[]*queue.RunMessage{}
 	p := &Publisher{
 		store:      st,
 		runSecrets: secrets.NewMemoryRunSecretsStore(),
@@ -65,19 +70,39 @@ func TestSubmitResume_StampsTheClampedWireCapNotTheAsk(t *testing.T) {
 		credPool:   broker,
 		logger:     iterlog.New(iterlog.LevelError, nil),
 		publishRun: func(_ context.Context, m *queue.RunMessage) error {
-			published = m
+			*published = append(*published, m)
 			return nil
 		},
 	}
-	tctx := store.WithIdentity(ctx, poolTeam, "requester")
-	const runID = "run-donor-clamped-resume"
+	return p, st, published
+}
+
+func seedDonorRun(t *testing.T, st store.RunStore, runID string, budget *store.RunBudget, ask *store.RunBudgetOverrides) context.Context {
+	t.Helper()
+	tctx := store.WithIdentity(context.Background(), poolTeam, "requester")
 	if err := st.SaveRun(tctx, &store.Run{
 		ID: runID, TenantID: poolTeam, OwnerID: "requester",
-		Status: store.RunStatusFailedResumable,
-		Budget: &store.RunBudget{MaxCostUSD: 20}, // the launch stamp
+		Status:          store.RunStatusFailedResumable,
+		Budget:          budget,
+		BudgetOverrides: ask,
 	}); err != nil {
 		t.Fatalf("seed run: %v", err)
 	}
+	return tctx
+}
+
+func lastPublished(t *testing.T, published *[]*queue.RunMessage) *queue.RunMessage {
+	t.Helper()
+	if len(*published) == 0 {
+		t.Fatal("nothing published")
+	}
+	return (*published)[len(*published)-1]
+}
+
+func TestSubmitResume_StampsTheClampedWireCapNotTheAsk(t *testing.T) {
+	p, st, published := donorClampedPublisher(t, 5)
+	const runID = "run-donor-clamped-resume"
+	tctx := seedDonorRun(t, st, runID, &store.RunBudget{MaxCostUSD: 20}, nil) // the launch stamp
 	wf := &ir.Workflow{Name: "wf", Budget: &ir.Budget{MaxCostUSD: 20}}
 	spec := runview.ResumeSpec{
 		RunID: runID, FilePath: "wf.bot",
@@ -87,11 +112,9 @@ func TestSubmitResume_StampsTheClampedWireCapNotTheAsk(t *testing.T) {
 	if err := p.SubmitResume(tctx, spec, wf, "hash"); err != nil {
 		t.Fatalf("SubmitResume: %v", err)
 	}
-	if published == nil || published.Budget == nil {
-		t.Fatal("nothing published or budget dropped from the wire")
-	}
-	if published.Budget.MaxCostUSD != 5 || !published.Budget.CapImposed {
-		t.Fatalf("wire budget = %+v, want the donor's $5 with CapImposed (the premise: the grant clamps the wire)", published.Budget)
+	msg := lastPublished(t, published)
+	if msg.Budget == nil || msg.Budget.MaxCostUSD != 5 || !msg.Budget.CapImposed {
+		t.Fatalf("wire budget = %+v, want the donor's $5 with CapImposed (the premise: the grant clamps the wire)", msg.Budget)
 	}
 	got, err := st.LoadRun(tctx, runID)
 	if err != nil {
@@ -104,5 +127,58 @@ func TestSubmitResume_StampsTheClampedWireCapNotTheAsk(t *testing.T) {
 	// re-derived against the CURRENT grant on every resume.
 	if got.BudgetOverrides == nil || got.BudgetOverrides.MaxCostUSD != 120 {
 		t.Fatalf("doc BudgetOverrides = %+v, want the raw $120 ask persisted un-clamped", got.BudgetOverrides)
+	}
+}
+
+// Over-report: an earlier resume stamped $120 under a $500 donor; the
+// ask-less auto-retry lands on a $5 donor. The wire says 5 + CapImposed,
+// and so must the doc — the ask stays 120.
+func TestSubmitResume_AskLessResumeRestampsTheDocWhenTheAllowanceShrinks(t *testing.T) {
+	p, st, published := donorClampedPublisher(t, 5)
+	const runID = "run-donor-shrank"
+	tctx := seedDonorRun(t, st, runID, &store.RunBudget{MaxCostUSD: 120}, &store.RunBudgetOverrides{MaxCostUSD: 120})
+	wf := &ir.Workflow{Name: "wf", Budget: &ir.Budget{MaxCostUSD: 20}}
+	spec := runview.ResumeSpec{RunID: runID, FilePath: "wf.bot", Source: "workflow wf:\n  entry: done\n"} // ask-less
+	if err := p.SubmitResume(tctx, spec, wf, "hash"); err != nil {
+		t.Fatalf("SubmitResume: %v", err)
+	}
+	msg := lastPublished(t, published)
+	if msg.Budget == nil || msg.Budget.MaxCostUSD != 5 || !msg.Budget.CapImposed {
+		t.Fatalf("wire budget = %+v, want {5, CapImposed} (the premise)", msg.Budget)
+	}
+	got, err := st.LoadRun(tctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.Budget == nil || got.Budget.MaxCostUSD != 5 {
+		t.Fatalf("doc Budget = %+v after an ask-less resume onto a $5 donor, want 5 — the studio shows $120 while the pod dies at $5 with no exit grace", got.Budget)
+	}
+	if got.BudgetOverrides == nil || got.BudgetOverrides.MaxCostUSD != 120 {
+		t.Fatalf("doc BudgetOverrides = %+v, want the $120 ask left un-clamped (a later resume must replay it once the donor recovers)", got.BudgetOverrides)
+	}
+}
+
+// Under-report: an earlier resume was clamped to $5; the ask-less
+// auto-retry lands on a $500 donor. The wire says 120 (no clamp), and so
+// must the doc.
+func TestSubmitResume_AskLessResumeRestampsTheDocWhenTheAllowanceRecovers(t *testing.T) {
+	p, st, published := donorClampedPublisher(t, 500)
+	const runID = "run-donor-recovered"
+	tctx := seedDonorRun(t, st, runID, &store.RunBudget{MaxCostUSD: 5}, &store.RunBudgetOverrides{MaxCostUSD: 120})
+	wf := &ir.Workflow{Name: "wf", Budget: &ir.Budget{MaxCostUSD: 20}}
+	spec := runview.ResumeSpec{RunID: runID, FilePath: "wf.bot", Source: "workflow wf:\n  entry: done\n"} // ask-less
+	if err := p.SubmitResume(tctx, spec, wf, "hash"); err != nil {
+		t.Fatalf("SubmitResume: %v", err)
+	}
+	msg := lastPublished(t, published)
+	if msg.Budget == nil || msg.Budget.MaxCostUSD != 120 || msg.Budget.CapImposed {
+		t.Fatalf("wire budget = %+v, want {120, no clamp} (the premise)", msg.Budget)
+	}
+	got, err := st.LoadRun(tctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.Budget == nil || got.Budget.MaxCostUSD != 120 {
+		t.Fatalf("doc Budget = %+v after an ask-less resume onto a $500 donor, want 120 — the studio shows $5 while the run may spend $120", got.Budget)
 	}
 }

--- a/pkg/server/cloudpublisher/publisher_resume_test.go
+++ b/pkg/server/cloudpublisher/publisher_resume_test.go
@@ -88,6 +88,108 @@ func TestSubmitResume_PublishFailureRestoresOperatorPause(t *testing.T) {
 	}
 }
 
+// retryStoreSpy wraps a RunStore and adds RunRetryStore so we can observe
+// whether SubmitResume disarms the retry state on a successful publish.
+type retryStoreSpy struct {
+	store.RunStore
+	cleared []string
+	claimed []string
+	armed   []string
+	// abandoned is left unused but part of the interface contract.
+	abandoned []string
+}
+
+func (r *retryStoreSpy) ScheduleRunRetry(_ context.Context, runID string, _ time.Time, _, _ string, _ int) (bool, int, error) {
+	r.armed = append(r.armed, runID)
+	return true, 1, nil
+}
+func (r *retryStoreSpy) ClaimRunRetry(_ context.Context, runID string, _ time.Time) (bool, error) {
+	r.claimed = append(r.claimed, runID)
+	return true, nil
+}
+func (r *retryStoreSpy) ClearRunRetry(_ context.Context, runID string) error {
+	r.cleared = append(r.cleared, runID)
+	return nil
+}
+func (r *retryStoreSpy) AbandonRunRetry(_ context.Context, runID, _ string) error {
+	r.abandoned = append(r.abandoned, runID)
+	return nil
+}
+
+// #669 part 3: a manual resume never called ClearRunRetry, so a
+// usage-window retry_after armed BEFORE the operator resumed survived it
+// and re-fired days later on a run that had finished. SubmitResume is the
+// single choke point for a cloud resume — it must clear on success.
+func TestSubmitResume_ClearsArmedRetryOnSuccessfulPublish(t *testing.T) {
+	base, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	spy := &retryStoreSpy{RunStore: base}
+	ctx := store.WithIdentity(context.Background(), "team", "alice")
+	const runID = "run-manual-resume-with-armed-retry"
+	at := time.Now().UTC().Add(24 * time.Hour)
+	if err := base.SaveRun(ctx, &store.Run{
+		ID: runID, TenantID: "team", OwnerID: "alice",
+		Status:     store.RunStatusFailedResumable,
+		RetryState: &store.RunRetryState{RetryAfter: &at, Reason: "usage_window", Attempts: 2},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	p := &Publisher{
+		store: spy,
+		publishRun: func(context.Context, *queue.RunMessage) error {
+			return nil
+		},
+	}
+	wf := &ir.Workflow{Name: "wf"}
+	spec := runview.ResumeSpec{
+		RunID: runID, FilePath: "wf.bot",
+		Source: "workflow wf:\n  entry: done\n",
+	}
+	if err := p.SubmitResume(ctx, spec, wf, "hash"); err != nil {
+		t.Fatalf("SubmitResume: %v", err)
+	}
+	if len(spy.cleared) != 1 || spy.cleared[0] != runID {
+		t.Fatalf("ClearRunRetry calls = %v, want exactly [%q] — an unarmed retry survives the manual resume otherwise (#669 part 3)", spy.cleared, runID)
+	}
+}
+
+// A publish failure must NOT clear the retry state: rollback restores the
+// resumable status, and dropping the armed retry would strand a run whose
+// only remaining wake-up was the sweeper.
+func TestSubmitResume_KeepsRetryStateOnPublishFailure(t *testing.T) {
+	base, err := store.New(t.TempDir())
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	spy := &retryStoreSpy{RunStore: base}
+	ctx := store.WithIdentity(context.Background(), "team", "alice")
+	const runID = "run-manual-resume-publish-fails"
+	at := time.Now().UTC().Add(24 * time.Hour)
+	if err := base.SaveRun(ctx, &store.Run{
+		ID: runID, TenantID: "team", OwnerID: "alice",
+		Status:     store.RunStatusFailedResumable,
+		RetryState: &store.RunRetryState{RetryAfter: &at, Reason: "usage_window"},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	p := &Publisher{
+		store: spy,
+		publishRun: func(context.Context, *queue.RunMessage) error {
+			return errors.New("nats unavailable")
+		},
+	}
+	wf := &ir.Workflow{Name: "wf"}
+	spec := runview.ResumeSpec{RunID: runID, FilePath: "wf.bot", Source: "workflow wf:\n  entry: done\n"}
+	if err := p.SubmitResume(ctx, spec, wf, "hash"); err == nil {
+		t.Fatal("SubmitResume returned nil, want publish failure")
+	}
+	if len(spy.cleared) != 0 {
+		t.Fatalf("publish failure cleared %v retries, want none (a rollback that also drops the armed retry strands the run)", spy.cleared)
+	}
+}
+
 func TestSubmitResume_ConcurrentRequestsPublishOnce(t *testing.T) {
 	base, err := store.New(t.TempDir())
 	if err != nil {

--- a/pkg/server/forge_gate_dlq_notice.go
+++ b/pkg/server/forge_gate_dlq_notice.go
@@ -1,0 +1,140 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// A run parked on the dead-letter queue is not paused: the queue exhausted
+// its deliveries and nothing on the platform wakes it. Its gate is repaired
+// by the reconciler like any dead review (a synthetic failure on the head,
+// one relaunch per head), and the developer reading the PR has to be told
+// that — not "resumes automatically at 21:07", which is what a park keyed on
+// a leftover retry_after used to say (#669 part 4).
+//
+// Keyed on the persisted FailureCode alone, never on RetryState: the code is
+// the typed WHY the two DLQ writers stamp, and a retry_after has no bearing
+// on whether a parked message comes back.
+
+// gateDLQNoticeMarker tags the comment so a reader (or a de-dup pass) can
+// find iterion's own DLQ notices without parsing prose. Distinct from the
+// pause marker: the two say opposite things about what happens next.
+const gateDLQNoticeMarker = "<!-- iterion:gate-dlq-parked -->"
+
+// noticeGateDLQParked posts the DLQ notice on the PR a parked run gates.
+// Best-effort in every branch, like the pause notice: the repair the
+// reconciler performs next does not depend on the comment landing, so a
+// comment that cannot be posted never becomes an error. Silent (Debug) on
+// every miss — a run that gates nothing is the common case.
+func (s *Server) noticeGateDLQParked(ctx context.Context, run *store.Run) {
+	if s == nil || run == nil || run.FailureCode != store.FailureDLQParked {
+		return
+	}
+	target, ok := s.gateNoticeTarget(ctx, run, "DLQ notice")
+	if !ok {
+		return
+	}
+	body := gateDLQNoticeBody(run)
+	if _, err := target.commenter.CommentIssue(ctx, target.repo, target.number, body); err != nil {
+		s.gateNoticeDebug(run, "DLQ notice", "%v", err)
+		return
+	}
+	if s.logger != nil {
+		s.logger.Info("forge gate: run %s parked on the DLQ — operator notice posted on %s (the reconciler repairs the check; replay or discard via iterion remote admin dlq)",
+			run.ID, target.prURL)
+	}
+}
+
+// gateNoticeTarget resolves where a gate notice about run may be posted and
+// who posts it: the PR named by pr_url, through the connection the run's
+// publish grant names — with the grant's scope re-enforced (repo, tenant,
+// host) exactly as the publish endpoint and the reconciler enforce it,
+// because pr_url is a LAUNCH VAR and a grant for repo A must not let
+// iterion's forge identity comment on any repo B the connection reaches.
+// A run holding no grant, owing no verdict (no gate_context, or the gate
+// pinned off), or whose grant/connection/forge cannot be resolved yields
+// ok=false, each miss logged at Debug with its reason.
+type gateNoticeTarget struct {
+	commenter forgeIssueCommenter
+	repo      string
+	number    int
+	prURL     string
+}
+
+func (s *Server) gateNoticeTarget(ctx context.Context, run *store.Run, what string) (gateNoticeTarget, bool) {
+	if s.forgePublishTokens == nil || s.forgeConnections == nil {
+		return gateNoticeTarget{}, false
+	}
+	prURL := strings.TrimSpace(runInputString(run, "pr_url"))
+	token := strings.TrimSpace(runInputString(run, forgePublishVarToken))
+	if prURL == "" || token == "" {
+		return gateNoticeTarget{}, false // holds no publish grant: nothing to tell anyone
+	}
+	// Holding a grant is NOT owing a verdict — the server mints one for ANY
+	// bot launched with a pr_url. Same two conditions the reconciler uses.
+	if strings.TrimSpace(runInputString(run, "gate_context")) == "" || runGateDisabled(run) {
+		return gateNoticeTarget{}, false
+	}
+	grant, ok := s.forgePublishTokens.lookup(token)
+	if !ok {
+		s.gateNoticeDebug(run, what, "its publish grant is expired or revoked")
+		return gateNoticeTarget{}, false
+	}
+	host, repo, number, err := forge.ParsePullURL(prURL)
+	if err != nil {
+		s.gateNoticeDebug(run, what, "its pr_url does not parse: %v", err)
+		return gateNoticeTarget{}, false
+	}
+	if !strings.EqualFold(strings.TrimSpace(repo), strings.TrimSpace(grant.Repo)) {
+		s.gateNoticeDebug(run, what, "its grant covers %s — refusing to comment outside the grant's repo", grant.Repo)
+		return gateNoticeTarget{}, false
+	}
+	conn, err := s.forgeConnections.Get(store.WithoutTenantFilter(ctx), grant.ConnectionID)
+	if err != nil {
+		s.gateNoticeDebug(run, what, "its connection %s is unreadable: %v", grant.ConnectionID, err)
+		return gateNoticeTarget{}, false
+	}
+	if conn.TenantID != grant.TeamID {
+		s.gateNoticeDebug(run, what, "its connection %s belongs to another tenant", grant.ConnectionID)
+		return gateNoticeTarget{}, false
+	}
+	if connHost := hostOfURL(conn.BaseURL()); connHost == "" || !strings.EqualFold(connHost, host) {
+		s.gateNoticeDebug(run, what, "its connection points at %q, not %q", hostOfURL(conn.BaseURL()), host)
+		return gateNoticeTarget{}, false
+	}
+	commenter, err := s.issueCommenterFor(ctx, conn)
+	if err != nil || commenter == nil {
+		s.gateNoticeDebug(run, what, "no comment client for %s: %v", conn.Provider, err)
+		return gateNoticeTarget{}, false
+	}
+	return gateNoticeTarget{commenter: commenter, repo: repo, number: number, prURL: prURL}, true
+}
+
+func (s *Server) gateNoticeDebug(run *store.Run, what, format string, args ...any) {
+	if s.logger == nil {
+		return
+	}
+	s.logger.Debug("forge gate: %s for run %s on %s not posted: "+format,
+		append([]any{what, run.ID, runInputString(run, "pr_url")}, args...)...)
+}
+
+// gateDLQNoticeBody renders the comment for the developer whose PR it lands
+// on: what happened, that waiting does nothing, and what iterion does next
+// versus what needs a human. Role-neutral on purpose — the required check
+// the run owed is what makes it worth saying, whichever bot owed it.
+func gateDLQNoticeBody(run *store.Run) string {
+	var b strings.Builder
+	b.WriteString(gateDLQNoticeMarker)
+	b.WriteString("\n⏸️ **Run parked on the dead-letter queue — automation has stopped for it.** Nothing is wrong with this pull request.\n\n")
+	b.WriteString("iterion exhausted its redelivery budget for this run and parked its message on the DLQ; nothing resumes it on a schedule. ")
+	b.WriteString("The check this run owed is marked **failed** on this head, and iterion relaunches the bot **once** on this head where the repository's automation allows it — that fresh run posts its own verdict. ")
+	b.WriteString("If no relaunch follows, or it dies too, an operator replays or discards the parked message with `iterion remote admin dlq`, or re-triggers the bot (push again, or comment its command).\n")
+	if cause := gatePauseCause(run); cause != "" {
+		fmt.Fprintf(&b, "\n> %s\n", cause)
+	}
+	return b.String()
+}

--- a/pkg/server/forge_gate_dlq_notice_test.go
+++ b/pkg/server/forge_gate_dlq_notice_test.go
@@ -1,0 +1,160 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SocialGouv/iterion/pkg/forge"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+// dlqGateFixture: a gating run parked on the DLQ, a stub forge that records
+// both the commit statuses and the PR comments.
+func dlqGateFixture(t *testing.T, retry *store.RunRetryState) (*Server, string, *listingGateClient, *stubCommenter) {
+	t.Helper()
+	gc := &listingGateClient{fakeGateClient: fakeGateClient{headSHA: "deadbeef"}}
+	s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+	c := &stubCommenter{}
+	s.forgeIssueCommenterFor = func(context.Context, forge.Connection) (forgeIssueCommenter, error) {
+		return c, nil
+	}
+	run, err := s.cfg.Store.LoadRun(context.Background(), runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.Status = store.RunStatusFailedResumable
+	run.FailureCode = store.FailureDLQParked
+	run.ContinuationState = store.ContinuationFinal
+	run.Error = "max deliveries exhausted: runtime: cannot resume run x with status \"running\" (parked on DLQ — replay via /api/admin/dlq)"
+	run.RetryState = retry
+	if err := s.cfg.Store.SaveRun(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+	return s, runID, gc, c
+}
+
+func assertDLQNotice(t *testing.T, bodies []string) {
+	t.Helper()
+	if len(bodies) != 1 {
+		t.Fatalf("want exactly one DLQ notice, got %d: %v", len(bodies), bodies)
+	}
+	body := bodies[0]
+	if !strings.Contains(body, gateDLQNoticeMarker) {
+		t.Fatalf("notice lacks the DLQ marker:\n%s", body)
+	}
+	if strings.Contains(body, "quota") || strings.Contains(body, "resume it **automatically") {
+		t.Fatalf("DLQ park announced as a quota pause — the #669 lie:\n%s", body)
+	}
+	for _, want := range []string{"dead-letter queue", "iterion remote admin dlq", "marked **failed**", "relaunches the bot **once**"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("DLQ notice missing %q:\n%s", want, body)
+		}
+	}
+}
+
+// A DLQ park is final for automation whatever retry_after still says on
+// the doc: the reconciler must NOT stand down on it, and the PR must be
+// told the truth — the check is marked failed, a relaunch may follow, an
+// operator replays the message — not "resumes automatically at HH:MM".
+func TestGateReconcile_DLQParkDoesNotStandDownOnALeftoverRetry(t *testing.T) {
+	at := time.Now().UTC().Add(4 * 24 * time.Hour)
+	s, runID, gc, c := dlqGateFixture(t, &store.RunRetryState{RetryAfter: &at, Reason: "usage_window", Attempts: 1})
+
+	if err := s.reconcileGateForRun(context.Background(), terminalEvent(runID)); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if gc.setCalls != 1 {
+		t.Fatalf("posted %d statuses, want 1 — a DLQ-parked run is dead for automation, the leftover retry_after wakes nothing", gc.setCalls)
+	}
+	if gc.last.State != forge.CommitStateFailure || !isSyntheticGateInterruption(gc.last.Description) {
+		t.Fatalf("status = %q %q, want the synthetic failure", gc.last.State, gc.last.Description)
+	}
+	assertDLQNotice(t, c.bodies)
+
+	// The sweep re-offers the same run every minute: no second comment.
+	_ = s.reconcileGateForRunID(context.Background(), runID, gateTriggerSweep)
+	if len(c.bodies) != 1 {
+		t.Fatalf("the sweep re-posted the DLQ notice (%d comments) — one park, one notice", len(c.bodies))
+	}
+}
+
+// The notice is gated on the FailureCode alone. An operator resume clears
+// retry_after before the park that follows, so the #669 shape carries NO
+// retry state at all — and the wording that used to key on it never posted.
+func TestGateReconcile_DLQNoticePostsWithoutRetryState(t *testing.T) {
+	s, runID, gc, c := dlqGateFixture(t, nil)
+
+	if err := s.reconcileGateForRun(context.Background(), terminalEvent(runID)); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	assertDLQNotice(t, c.bodies)
+	if gc.setCalls != 1 {
+		t.Fatalf("posted %d statuses, want 1", gc.setCalls)
+	}
+}
+
+// The admission-mismatch park (a rollout's epoch/schema fence on the last
+// delivery) flips the doc through FailQueuedRunIfAttempt. Driven through
+// the real store twin: the code it stamps is what the notice keys on, so
+// the composition — park, then reconcile — must produce the DLQ wording,
+// not silence or the quota text.
+func TestGateReconcile_AdmissionParkReachesTheDLQNotice(t *testing.T) {
+	gc := &listingGateClient{fakeGateClient: fakeGateClient{headSHA: "deadbeef"}}
+	s, runID := gateReconcileFixture(t, gatingInputs(), gc)
+	c := &stubCommenter{}
+	s.forgeIssueCommenterFor = func(context.Context, forge.Connection) (forgeIssueCommenter, error) {
+		return c, nil
+	}
+	ctx := context.Background()
+	// The publisher's pre-flip: the run is queued for its attempt.
+	if err := s.cfg.Store.UpdateRunStatus(ctx, runID, store.RunStatusFailedResumable, "usage window shut"); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := s.cfg.Store.UpdateRunStatusIf(ctx, runID, store.RunStatusQueued, "", []store.RunStatus{store.RunStatusFailedResumable}); err != nil || !changed {
+		t.Fatalf("queue the attempt: (%v, %v)", changed, err)
+	}
+	queued, err := s.cfg.Store.LoadRun(ctx, runID)
+	if err != nil || queued.QueuedAt == nil {
+		t.Fatalf("queued marker missing: %+v %v", queued, err)
+	}
+	attempts := store.AsQueuedAttemptStore(s.cfg.Store)
+	if attempts == nil {
+		t.Fatal("the test store must implement QueuedAttemptStore")
+	}
+	changed, err := attempts.FailQueuedRunIfAttempt(ctx, runID,
+		"schema version mismatch: v9 unsupported (queue message v9 parked on DLQ — replay via /api/admin/dlq only once the runner fleet speaks schema v9)",
+		queued.QueuedAt.Add(time.Second), store.RunOutcomeMeta{Code: store.FailureDLQParked, Continuation: store.ContinuationFinal})
+	if err != nil || !changed {
+		t.Fatalf("admission park CAS = (%v, %v), want (true, nil)", changed, err)
+	}
+
+	if err := s.reconcileGateForRun(ctx, terminalEvent(runID)); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	assertDLQNotice(t, c.bodies)
+	if gc.setCalls != 1 {
+		t.Fatalf("posted %d statuses, want 1 — the parked review owes the PR a verdict", gc.setCalls)
+	}
+}
+
+// A run that gates nothing gets no DLQ notice, however it was parked.
+func TestNoticeGateDLQParked_SilentForANonGatingRun(t *testing.T) {
+	gc := &listingGateClient{fakeGateClient: fakeGateClient{headSHA: "deadbeef"}}
+	s, runID := gateReconcileFixture(t, map[string]any{"pr_url": "https://github.com/o/r/pull/42", forgePublishVarToken: "tok-gate"}, gc)
+	c := &stubCommenter{}
+	s.forgeIssueCommenterFor = func(context.Context, forge.Connection) (forgeIssueCommenter, error) {
+		return c, nil
+	}
+	run, _ := s.cfg.Store.LoadRun(context.Background(), runID)
+	run.Status = store.RunStatusFailedResumable
+	run.FailureCode = store.FailureDLQParked
+	_ = s.cfg.Store.SaveRun(context.Background(), run)
+
+	s.noticeGateDLQParked(context.Background(), run)
+
+	if len(c.bodies) != 0 {
+		t.Fatalf("a run owing no verdict posted a DLQ notice: %v", c.bodies)
+	}
+}

--- a/pkg/server/forge_gate_pause_notice.go
+++ b/pkg/server/forge_gate_pause_notice.go
@@ -113,13 +113,8 @@ func (s *Server) noticeGatePausedForRetry(ctx context.Context, run *store.Run) {
 		return
 	}
 	if s.logger != nil {
-		if run.FailureCode == store.FailureDLQParked {
-			s.logger.Info("forge gate: run %s parked on the DLQ — operator notice posted on %s (replay via iterion remote admin dlq)",
-				run.ID, prURL)
-		} else {
-			s.logger.Info("forge gate: run %s parked on a provider quota — pause notice posted on %s (retry at %s)",
-				run.ID, prURL, run.RetryState.RetryAfter.Format(time.RFC3339))
-		}
+		s.logger.Info("forge gate: run %s parked on a provider quota — pause notice posted on %s (retry at %s)",
+			run.ID, prURL, run.RetryState.RetryAfter.Format(time.RFC3339))
 	}
 }
 
@@ -153,17 +148,7 @@ func (s *Server) issueCommenterFor(ctx context.Context, conn forge.Connection) (
 // gatePauseNoticeBody renders the comment. Written for the developer whose
 // PR it lands on, not for an operator: what happened, when it resumes, and
 // whether waiting suffices.
-//
-// A DLQ_PARKED run branches on FailureCode: an operator resume never clears
-// the RunRetryState left by the pre-park usage-window (#669 part 3), so a
-// bare RetryAfter-driven notice would falsely promise an automatic resume
-// for a run that only replay-by-hand can wake. The FailureCode is the
-// truth — DLQ_PARKED means the queue exhausted its deliveries and only an
-// operator (`iterion remote admin dlq`) can replay the message.
 func gatePauseNoticeBody(run *store.Run, now time.Time) string {
-	if run.FailureCode == store.FailureDLQParked {
-		return gatePauseNoticeBodyDLQParked(run)
-	}
 	at := run.RetryState.RetryAfter.UTC()
 	var b strings.Builder
 	b.WriteString(gatePauseNoticeMarker)
@@ -181,20 +166,6 @@ func gatePauseNoticeBody(run *store.Run, now time.Time) string {
 				"account admin raises it (or when the month rolls over), not on a\n" +
 				"provider window schedule.\n")
 		}
-	}
-	return b.String()
-}
-
-// gatePauseNoticeBodyDLQParked renders the DLQ variant: the queue exhausted
-// its deliveries for this run (max_deliveries), so nothing wakes it on a
-// schedule — an operator has to replay the parked message.
-func gatePauseNoticeBodyDLQParked(run *store.Run) string {
-	var b strings.Builder
-	b.WriteString(gatePauseNoticeMarker)
-	b.WriteString("\n⏸️ **Review parked on the DLQ — needs an operator.** Nothing is wrong with this pull request.\n\n")
-	b.WriteString("iterion exhausted its redelivery budget for this run and parked the message on the dead-letter queue. Waiting will NOT resume it — an operator has to replay it with `iterion remote admin dlq` (or discard it).\n")
-	if cause := gatePauseCause(run); cause != "" {
-		fmt.Fprintf(&b, "\n> %s\n", cause)
 	}
 	return b.String()
 }

--- a/pkg/server/forge_gate_pause_notice.go
+++ b/pkg/server/forge_gate_pause_notice.go
@@ -113,8 +113,13 @@ func (s *Server) noticeGatePausedForRetry(ctx context.Context, run *store.Run) {
 		return
 	}
 	if s.logger != nil {
-		s.logger.Info("forge gate: run %s parked on a provider quota — pause notice posted on %s (retry at %s)",
-			run.ID, prURL, run.RetryState.RetryAfter.Format(time.RFC3339))
+		if run.FailureCode == store.FailureDLQParked {
+			s.logger.Info("forge gate: run %s parked on the DLQ — operator notice posted on %s (replay via iterion remote admin dlq)",
+				run.ID, prURL)
+		} else {
+			s.logger.Info("forge gate: run %s parked on a provider quota — pause notice posted on %s (retry at %s)",
+				run.ID, prURL, run.RetryState.RetryAfter.Format(time.RFC3339))
+		}
 	}
 }
 
@@ -148,7 +153,17 @@ func (s *Server) issueCommenterFor(ctx context.Context, conn forge.Connection) (
 // gatePauseNoticeBody renders the comment. Written for the developer whose
 // PR it lands on, not for an operator: what happened, when it resumes, and
 // whether waiting suffices.
+//
+// A DLQ_PARKED run branches on FailureCode: an operator resume never clears
+// the RunRetryState left by the pre-park usage-window (#669 part 3), so a
+// bare RetryAfter-driven notice would falsely promise an automatic resume
+// for a run that only replay-by-hand can wake. The FailureCode is the
+// truth — DLQ_PARKED means the queue exhausted its deliveries and only an
+// operator (`iterion remote admin dlq`) can replay the message.
 func gatePauseNoticeBody(run *store.Run, now time.Time) string {
+	if run.FailureCode == store.FailureDLQParked {
+		return gatePauseNoticeBodyDLQParked(run)
+	}
 	at := run.RetryState.RetryAfter.UTC()
 	var b strings.Builder
 	b.WriteString(gatePauseNoticeMarker)
@@ -166,6 +181,20 @@ func gatePauseNoticeBody(run *store.Run, now time.Time) string {
 				"account admin raises it (or when the month rolls over), not on a\n" +
 				"provider window schedule.\n")
 		}
+	}
+	return b.String()
+}
+
+// gatePauseNoticeBodyDLQParked renders the DLQ variant: the queue exhausted
+// its deliveries for this run (max_deliveries), so nothing wakes it on a
+// schedule — an operator has to replay the parked message.
+func gatePauseNoticeBodyDLQParked(run *store.Run) string {
+	var b strings.Builder
+	b.WriteString(gatePauseNoticeMarker)
+	b.WriteString("\n⏸️ **Review parked on the DLQ — needs an operator.** Nothing is wrong with this pull request.\n\n")
+	b.WriteString("iterion exhausted its redelivery budget for this run and parked the message on the dead-letter queue. Waiting will NOT resume it — an operator has to replay it with `iterion remote admin dlq` (or discard it).\n")
+	if cause := gatePauseCause(run); cause != "" {
+		fmt.Fprintf(&b, "\n> %s\n", cause)
 	}
 	return b.String()
 }

--- a/pkg/server/forge_gate_pause_notice_test.go
+++ b/pkg/server/forge_gate_pause_notice_test.go
@@ -170,4 +170,39 @@ func TestGatePausedNoticePostsOnThePR(t *testing.T) {
 			t.Fatalf("a non-gating run must post nothing, got %v", c.bodies)
 		}
 	})
+
+	// A DLQ-parked run reaches this path with the same RetryState the
+	// pre-park usage-window carried (an operator resume never clears it —
+	// see #669 part 3), so a bare RetryAfter-driven notice would falsely
+	// promise an automatic resume for a run that only replay-by-hand can
+	// wake. The FailureCode is the truth: DLQ_PARKED means an operator has
+	// to act; the notice must name the DLQ, name the admin path, and NOT
+	// print the "resume automatically at HH:MM" line.
+	t.Run("a DLQ park names the operator path, not a schedule", func(t *testing.T) {
+		s, c := newWorld(t)
+		at := time.Now().UTC().Add(time.Hour)
+		run := parkedRun(t, s, "max deliveries exhausted: some cause (parked on DLQ — replay via /api/admin/dlq)", at)
+		run.FailureCode = store.FailureDLQParked
+		if err := s.cfg.Store.SaveRun(context.Background(), run); err != nil {
+			t.Fatal(err)
+		}
+
+		s.noticeGatePausedForRetry(context.Background(), run)
+
+		if len(c.bodies) != 1 {
+			t.Fatalf("a DLQ park must post one operator-shaped notice, got %d", len(c.bodies))
+		}
+		body := c.bodies[0]
+		if strings.Contains(body, "provider's quota is exhausted") {
+			t.Fatalf("DLQ park was announced as a quota pause — the FailureCode-blind read #669 measured live:\n%s", body)
+		}
+		if strings.Contains(body, "resume it **automatically") || strings.Contains(body, at.Format("15:04 UTC")) {
+			t.Fatalf("DLQ park promised an automatic resume that never comes:\n%s", body)
+		}
+		for _, want := range []string{"parked on the DLQ", "iterion remote admin dlq", "operator"} {
+			if !strings.Contains(body, want) {
+				t.Fatalf("DLQ notice missing %q:\n%s", want, body)
+			}
+		}
+	})
 }

--- a/pkg/server/forge_gate_pause_notice_test.go
+++ b/pkg/server/forge_gate_pause_notice_test.go
@@ -170,39 +170,4 @@ func TestGatePausedNoticePostsOnThePR(t *testing.T) {
 			t.Fatalf("a non-gating run must post nothing, got %v", c.bodies)
 		}
 	})
-
-	// A DLQ-parked run reaches this path with the same RetryState the
-	// pre-park usage-window carried (an operator resume never clears it —
-	// see #669 part 3), so a bare RetryAfter-driven notice would falsely
-	// promise an automatic resume for a run that only replay-by-hand can
-	// wake. The FailureCode is the truth: DLQ_PARKED means an operator has
-	// to act; the notice must name the DLQ, name the admin path, and NOT
-	// print the "resume automatically at HH:MM" line.
-	t.Run("a DLQ park names the operator path, not a schedule", func(t *testing.T) {
-		s, c := newWorld(t)
-		at := time.Now().UTC().Add(time.Hour)
-		run := parkedRun(t, s, "max deliveries exhausted: some cause (parked on DLQ — replay via /api/admin/dlq)", at)
-		run.FailureCode = store.FailureDLQParked
-		if err := s.cfg.Store.SaveRun(context.Background(), run); err != nil {
-			t.Fatal(err)
-		}
-
-		s.noticeGatePausedForRetry(context.Background(), run)
-
-		if len(c.bodies) != 1 {
-			t.Fatalf("a DLQ park must post one operator-shaped notice, got %d", len(c.bodies))
-		}
-		body := c.bodies[0]
-		if strings.Contains(body, "provider's quota is exhausted") {
-			t.Fatalf("DLQ park was announced as a quota pause — the FailureCode-blind read #669 measured live:\n%s", body)
-		}
-		if strings.Contains(body, "resume it **automatically") || strings.Contains(body, at.Format("15:04 UTC")) {
-			t.Fatalf("DLQ park promised an automatic resume that never comes:\n%s", body)
-		}
-		for _, want := range []string{"parked on the DLQ", "iterion remote admin dlq", "operator"} {
-			if !strings.Contains(body, want) {
-				t.Fatalf("DLQ notice missing %q:\n%s", want, body)
-			}
-		}
-	})
 }

--- a/pkg/server/forge_gate_reconcile.go
+++ b/pkg/server/forge_gate_reconcile.go
@@ -177,17 +177,32 @@ func (s *Server) reconcileGateForRunID(ctx context.Context, runID, via string) e
 	if run.Status == store.RunStatusPausedWaitingHuman || run.Status == store.RunStatusPausedOperator {
 		return nil
 	}
-	// A resumable failure is only "not dead" when something will actually
-	// resume it. The runner arms a durable retry for usage-window failures
-	// (persisted BEFORE the outcome event fires — pkg/runner/loop.go parks
-	// first, then fires), and that armed retry is the whole promise. Every
-	// other failed_resumable — budget exceeded, retries exhausted, a plain
-	// execution failure — sits until a human notices, which with an absent
-	// required check is never. Observed in production 2026-08-03: a Vetty run
-	// died on its own duration budget mid-audit and the PR it gated stayed
-	// silently unmergeable. Those runs ARE dead; reconcile them.
-	if run.Status == store.RunStatusFailedResumable &&
+	// A DLQ park is FINAL for automation whatever RetryState still says:
+	// the queue exhausted its deliveries and only an operator's replay
+	// puts the message back. A retry_after can survive on such a doc (the
+	// usage-window park that preceded an operator resume, when the clear
+	// on resume did not land), and standing down on it would leave the
+	// required check on its in-flight claim for a run nothing will wake.
+	// So: say so on the PR once (the event path — the sweep re-offers the
+	// same run every minute for an hour), then fall through to the
+	// dead-review repair below, which is what actually happens next — the
+	// synthetic failure on the head and one relaunch per head.
+	if run.Status == store.RunStatusFailedResumable && run.FailureCode == store.FailureDLQParked {
+		if via == gateTriggerEvent {
+			s.noticeGateDLQParked(ctx, run)
+		}
+	} else if run.Status == store.RunStatusFailedResumable &&
 		run.RetryState != nil && run.RetryState.RetryAfter != nil {
+		// A resumable failure is only "not dead" when something will
+		// actually resume it. The runner arms a durable retry for
+		// usage-window failures (persisted BEFORE the outcome event fires
+		// — pkg/runner/loop.go parks first, then fires), and that armed
+		// retry is the whole promise. Every other failed_resumable —
+		// budget exceeded, retries exhausted, a plain execution failure —
+		// sits until a human notices, which with an absent required check
+		// is never. Observed in production 2026-08-03: a Vetty run died on
+		// its own duration budget mid-audit and the PR it gated stayed
+		// silently unmergeable. Those runs ARE dead; reconcile them.
 		// Not dead, but not silent either: the check stays on its in-flight
 		// claim, which reads identically to a review that died. Say on the
 		// PR that it parked and when it resumes — on the EVENT only, since

--- a/pkg/server/retry_sweeper.go
+++ b/pkg/server/retry_sweeper.go
@@ -118,6 +118,25 @@ func (s *Server) resumeDueRetry(ctx context.Context, retryStore store.RunRetrySt
 		return
 	}
 
+	// A DLQ park is final for automation — only an operator's replay or
+	// resume wakes it — and the gate reconciler has already answered for
+	// it. The transition tail disarms retry_after on every final write
+	// (statusTransitionSet / applyStatusTransitionOutcome), so an armed
+	// retry on a parked doc is one that predates that rule or bypassed the
+	// tail; resuming it would run the bot a second time on the same head,
+	// sharing the reconciler's gate context. Disarm it and say so. The
+	// park's own outcome event already reached every consumer, so this
+	// path must NOT replay it (the DLQ notice has no dedup of its own).
+	// The read is a guard, not a gate: a store that cannot answer leaves
+	// the retry row as the authority, loudly.
+	if run, lerr := s.cfg.Store.LoadRun(runCtx, ref.ID); lerr != nil {
+		s.warnf("retry sweeper: run %s: cannot read the run doc before resuming its retry (%v) — proceeding on the retry row alone", ref.ID, lerr)
+	} else if run != nil && run.FailureCode == store.FailureDLQParked {
+		s.disarmRetry(runCtx, retryStore, ref.TenantID, ref.ID,
+			"auto-retry abandoned: the run is parked on the DLQ (DLQ_PARKED) — its armed retry was stale; only an operator replay (iterion remote admin dlq) or resume wakes it")
+		return
+	}
+
 	// An automatic resume spends real money, so it passes the same
 	// admission gate as the operator-initiated one. Whether a denial ends
 	// the retry depends on the denial: a monthly quota refills on the 1st
@@ -199,19 +218,13 @@ func retryDenialIsTransient(reason string) bool {
 	}
 }
 
-// abandonRetry records a permanent stop and audits it.
+// abandonRetry records a permanent stop, audits it, and republishes the
+// run's outcome so the consumers that stood down on the armed retry get
+// the event they were promised.
 func (s *Server) abandonRetry(ctx context.Context, retryStore store.RunRetryStore, tenantID, runID, reason string) {
-	if err := retryStore.AbandonRunRetry(ctx, runID, reason); err != nil {
-		// The abandon did not land: the retry stays claimable, the next sweep
-		// tick walks this path again, and republishing NOW would repeat on
-		// every tick until the write finally sticks. The single republish
-		// belongs to the tick that actually makes the stop permanent.
-		s.warnf("retry sweeper: abandon %s: %v", runID, err)
+	if !s.disarmRetry(ctx, retryStore, tenantID, runID, reason) {
 		return
 	}
-	s.countRetry("abandoned")
-	s.auditSystem(tenantID, "retry-sweeper", "run.retry.abandoned", "run", runID, map[string]any{"reason": reason})
-	s.warnf("retry sweeper: run %s: %s", runID, reason)
 
 	// The run's terminal event fired back when it FAILED — while a retry was
 	// still armed, so every outcome consumer that defers to an armed retry
@@ -226,6 +239,22 @@ func (s *Server) abandonRetry(ctx context.Context, retryStore store.RunRetryStor
 			s.warnf("retry sweeper: republish outcome for abandoned run %s: %v", runID, err)
 		}
 	}
+}
+
+// disarmRetry is the abandon WITHOUT the outcome replay: the store write,
+// the counter, the audit line and the log. False when the write did not
+// land — the retry then stays claimable, the next sweep tick walks the
+// same path again, and anything a caller would do on top (a republish)
+// must wait for the tick that actually makes the stop permanent.
+func (s *Server) disarmRetry(ctx context.Context, retryStore store.RunRetryStore, tenantID, runID, reason string) bool {
+	if err := retryStore.AbandonRunRetry(ctx, runID, reason); err != nil {
+		s.warnf("retry sweeper: abandon %s: %v", runID, err)
+		return false
+	}
+	s.countRetry("abandoned")
+	s.auditSystem(tenantID, "retry-sweeper", "run.retry.abandoned", "run", runID, map[string]any{"reason": reason})
+	s.warnf("retry sweeper: run %s: %s", runID, reason)
+	return true
 }
 
 // reArmRetry gives a failed resume another chance inside the attempt

--- a/pkg/server/retry_sweeper.go
+++ b/pkg/server/retry_sweeper.go
@@ -130,7 +130,7 @@ func (s *Server) resumeDueRetry(ctx context.Context, retryStore store.RunRetrySt
 	// The read is a guard, not a gate: a store that cannot answer leaves
 	// the retry row as the authority, loudly.
 	if run, lerr := s.cfg.Store.LoadRun(runCtx, ref.ID); lerr != nil {
-		s.warnf("retry sweeper: run %s: cannot read the run doc before resuming its retry (%v) — proceeding on the retry row alone", ref.ID, lerr)
+		s.warnf("retry sweeper: run %s: cannot read the run doc before resuming its retry (%v) — proceeding on the retry row alone: a DLQ-parked run whose stale retry survived would be resumed on top of the gate reconciler's repair", ref.ID, lerr)
 	} else if run != nil && run.FailureCode == store.FailureDLQParked {
 		s.disarmRetry(runCtx, retryStore, ref.TenantID, ref.ID,
 			"auto-retry abandoned: the run is parked on the DLQ (DLQ_PARKED) — its armed retry was stale; only an operator replay (iterion remote admin dlq) or resume wakes it")

--- a/pkg/server/retry_sweeper_test.go
+++ b/pkg/server/retry_sweeper_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -311,6 +312,58 @@ func TestSweepDueRetries_AbandonRepublishesTheRunOutcome(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("no run outcome republished on abandon — the reconciler never learns the run is permanently dead")
+	}
+}
+
+// A run parked on the DLQ (final for automation — the gate reconciler has
+// already posted the synthetic failure and relaunched once per head) that
+// still carries an armed retry_after must be DISARMED, not resumed: a
+// resume here runs the bot a second time on the same PR head, sharing one
+// gate context. And the disarm must not replay the run's outcome event —
+// the DLQ notice keys on that event firing once per park.
+func TestSweepDueRetries_DLQParkedRunIsDisarmedNotResumed(t *testing.T) {
+	st := newFakeRetryStore()
+	st.claimWins["run-dlq"] = true
+	st.loadRun["run-dlq"] = &store.Run{
+		ID: "run-dlq", TenantID: "team-1",
+		Status:            store.RunStatusFailedResumable,
+		FailureCode:       store.FailureDLQParked,
+		ContinuationState: store.ContinuationFinal,
+	}
+	resumer := &fakeResumer{}
+	// Local mode on purpose: the fixture bot resolves, so the only thing
+	// between the claim and a Resume call is the DLQ guard.
+	s := newRetrySweeperServer(t, st, resumer)
+
+	bus := eventbus.NewInProcBus(nil)
+	s.cfg.EventsBus = bus
+	replayed := make(chan trigger.Event, 1)
+	if _, err := bus.Subscribe("probe", trigger.Matcher{
+		Sources: []trigger.Source{trigger.SourceRun},
+		Kinds:   []string{trigger.KindRunFailed},
+	}, func(_ context.Context, ev trigger.Event) error {
+		replayed <- ev
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s.sweepDueRetries(context.Background(), &fakeRetryLister{refs: []mongostore.RetryDueRef{dueRef("run-dlq", time.Now().UTC().Add(-time.Minute))}}, resumer, time.Now().UTC())
+
+	if len(resumer.calls) != 0 {
+		t.Fatalf("Resume called %d times for a DLQ-parked run, want 0 — two runs of the bot on one PR head sharing one gate context", len(resumer.calls))
+	}
+	reason, ok := st.abandoned["run-dlq"]
+	if !ok {
+		t.Fatal("the stale retry was not disarmed — the next sweep tick claims it again")
+	}
+	if !strings.Contains(reason, "DLQ") {
+		t.Fatalf("abandon reason = %q, want it to name the DLQ park", reason)
+	}
+	select {
+	case ev := <-replayed:
+		t.Fatalf("the park's outcome was replayed (%s) — the DLQ notice has no dedup of its own and would post on the PR a second time", ev.Kind)
+	case <-time.After(300 * time.Millisecond):
 	}
 }
 

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -570,6 +570,19 @@ func (s *Server) handleResumeRun(w http.ResponseWriter, r *http.Request) {
 		span.SetStatus(codes.Error, "invalid request")
 		return
 	}
+	// The budget ask is validated at admission, before any store access:
+	// a malformed max_duration ("4 hours") would otherwise ride
+	// RunMessage.Budget onto the queue, fail the runner's
+	// applyBudgetOverrides on EVERY redelivery, and burn the delivery
+	// budget into a DLQ park. Same gate as handleLaunchRun.
+	budget := req.Budget.toOverrides()
+	if budget != nil {
+		if err := budget.Validate(); err != nil {
+			s.httpErrorFor(w, r, http.StatusBadRequest, "invalid budget: %v", err)
+			span.SetStatus(codes.Error, "invalid budget")
+			return
+		}
+	}
 	// Load the run once: its persisted FilePath is the fallback when the body
 	// omits one, and its TenantID is required to scope the resume's Mongo
 	// queries (see below). LoadRunCtx looks a run up by id without a tenant
@@ -672,7 +685,7 @@ func (s *Server) handleResumeRun(w http.ResponseWriter, r *http.Request) {
 		Answers:  answers,
 		Force:    req.Force,
 		Timeout:  timeout,
-		Budget:   req.Budget.toOverrides(),
+		Budget:   budget,
 	}
 	if resumeLB != nil {
 		resumeSpec.BundleDir, resumeSpec.BotBundle = resumeLB.BundleDir, resumeLB.Ref

--- a/pkg/server/runs_launch.go
+++ b/pkg/server/runs_launch.go
@@ -261,6 +261,14 @@ type resumeRunRequest struct {
 	// `file` field instead carries its upload inline in Answers as
 	// `{"upload_id": "..."}`. See runs_answer_uploads.go.
 	Attachments []string `json:"attachments,omitempty"`
+	// Budget is the this-resume cap ask — the wire counterpart of the
+	// CLI's --max-cost-usd / --max-duration / --max-tokens flags on
+	// `iterion resume`. Non-nil beats the run doc's persisted launch
+	// ask, honouring the "raise the cap + resume" recovery on remote
+	// runs where an operator can no longer edit a local .bot to widen
+	// the cap. Zero fields inherit. Wired through
+	// runview.ResumeSpec.Budget → cloudpublisher.SubmitResume. #652 part 2.
+	Budget *launchBudgetSpec `json:"budget,omitempty"`
 }
 
 func (s *Server) handleLaunchRun(w http.ResponseWriter, r *http.Request) {
@@ -664,6 +672,7 @@ func (s *Server) handleResumeRun(w http.ResponseWriter, r *http.Request) {
 		Answers:  answers,
 		Force:    req.Force,
 		Timeout:  timeout,
+		Budget:   req.Budget.toOverrides(),
 	}
 	if resumeLB != nil {
 		resumeSpec.BundleDir, resumeSpec.BotBundle = resumeLB.BundleDir, resumeLB.Ref

--- a/pkg/server/runs_resume_budget_test.go
+++ b/pkg/server/runs_resume_budget_test.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/auth"
+)
+
+// The resume endpoint validates the budget ask at admission — the third
+// site of the class (Service.Resume and the remote CLI are the other two).
+// Without it a malformed max_duration rides RunMessage.Budget onto the
+// queue and fails the runner's applyBudgetOverrides on every redelivery
+// until the DLQ park. The validation runs before any store access: the
+// harness has no run service at all, so reaching the store would panic.
+func TestHandleResumeRun_RejectsMalformedBudgetBeforeStoreAccess(t *testing.T) {
+	s := newOrgTestServer(t)
+	seedTeam(t, s, "t1", "acme")
+	ctx := auth.WithIdentity(context.Background(), auth.Identity{UserID: "u1", TeamID: "t1"})
+	r := orgReq(ctx, "POST", "/api/runs/run-123/resume", `{"budget":{"max_duration":"4 hours"}}`, "run-123")
+	w := httptest.NewRecorder()
+	s.handleResumeRun(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("malformed budget on resume: code=%d body=%s, want 400 — the ask would ride the queue and fail on every redelivery", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "max_duration") {
+		t.Fatalf("400 body must name the offending field, got %s", w.Body.String())
+	}
+}

--- a/pkg/store/event.go
+++ b/pkg/store/event.go
@@ -158,6 +158,18 @@ const (
 	//     branch advanced past the recorded head, unrelated_history,
 	//     fetch_failed, …) — the failure shape, with restored=false
 	EventRunWorkspaceBankRestored EventType = "run_workspace_bank_restored"
+	// EventRunRedeliveryDeferred marks a delivery the runner handed back
+	// to the queue with a DELAY instead of at once — a sandbox setup
+	// phase that timed out is re-offered to a fresh pod minutes later so
+	// the infrastructure can clear the stall. Between two attempts the run
+	// sits failed_resumable with nothing else on its timeline; this event
+	// says why and for how long. Data:
+	//   - reason: the runner's outcome label ("sandbox_setup_timeout")
+	//   - delay_seconds: how long JetStream holds the message
+	//   - delivery / max_deliver: this attempt's rank in the redelivery
+	//     budget (the DLQ park follows the last one)
+	//   - error: the engine's error text
+	EventRunRedeliveryDeferred EventType = "run_redelivery_deferred"
 	// EventRunBankRefused marks THIS attempt's head being dropped by the
 	// runner's death bank while an EARLIER attempt of the same run keeps
 	// the storage branch — because that attempt banked a strictly richer

--- a/pkg/store/granular_setters_test.go
+++ b/pkg/store/granular_setters_test.go
@@ -1,0 +1,124 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+// TestStaleSaveRunRevertsATransition pins the hazard the granular
+// setters exist to avoid, so the reason for their shape is executable
+// rather than only written down. SaveRun replaces the whole document
+// from the caller's copy; when a status transition lands between the
+// load and the save, that copy is stale and the transition is undone.
+//
+// This is the documented, deliberate SaveRun read-modify-write hazard
+// (a version CAS is the real fix — follow-up), NOT a defect of this
+// test's subject: it is the baseline that makes
+// TestSetRunBudgetOverridesDoesNotReplaceTheDocument meaningful.
+func TestStaleSaveRunRevertsATransition(t *testing.T) {
+	s := tmpStore(t)
+	ctx := context.Background()
+
+	if _, err := s.CreateRun(ctx, "r", "demo", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if err := s.UpdateRunStatus(ctx, "r", RunStatusQueued, ""); err != nil {
+		t.Fatalf("to queued: %v", err)
+	}
+
+	stale, err := s.LoadRun(ctx, "r")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+
+	// The operator cancels while the caller holds its copy.
+	ok, err := s.UpdateRunStatusIf(ctx, "r", RunStatusCancelled, "operator cancel", []RunStatus{RunStatusQueued})
+	if err != nil || !ok {
+		t.Fatalf("cancel CAS: ok=%v err=%v", ok, err)
+	}
+
+	stale.BudgetOverrides = &RunBudgetOverrides{MaxCostUSD: 120}
+	if err := s.SaveRun(ctx, stale); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+
+	got, err := s.LoadRun(ctx, "r")
+	if err != nil {
+		t.Fatalf("LoadRun after: %v", err)
+	}
+	if got.Status != RunStatusCancelled {
+		t.Logf("whole-doc SaveRun from a stale copy reverted %s -> %s (error %q lost)",
+			RunStatusCancelled, got.Status, "operator cancel")
+	} else {
+		t.Fatal("SaveRun no longer replaces the whole document from the caller's copy — " +
+			"the granular setters' rationale changed; revisit them and this test")
+	}
+}
+
+// TestSetRunBudgetOverridesDoesNotReplaceTheDocument asserts the
+// granular contract iface.go declares for the budget-ask setter: it
+// touches budget_overrides + updated_at and nothing else.
+//
+// What this test actually catches, stated plainly so it is not read as
+// proving more than it does: the load-modify-SaveRun form fails the
+// updated_at half outright (SaveRun stamps no timestamp of its own, so
+// the field-scoped write left the doc's mtime at its previous value
+// while the Mongo twin's $set advances it). The peer-field assertions
+// below are defence in depth — SaveRun's own bookkeeping happens to
+// shield most of them on a SERIAL call, so they would only fire if that
+// bookkeeping regressed. The half no in-process test can schedule
+// reliably is the timed one: a transition landing inside the
+// load-save window, whose consequence is pinned by
+// TestStaleSaveRunRevertsATransition above.
+func TestSetRunBudgetOverridesDoesNotReplaceTheDocument(t *testing.T) {
+	s := tmpStore(t)
+	ctx := context.Background()
+
+	if _, err := s.CreateRun(ctx, "r", "demo", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	// A parked run carries a failure code and a checkpoint; the resume
+	// raises the cap on exactly this shape.
+	if err := s.UpdateRunStatusCoded(ctx, "r", RunStatusFailedResumable, "budget exceeded", FailureBudgetExceeded); err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	if err := s.SaveCheckpoint(ctx, "r", &Checkpoint{NodeID: "implement"}); err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+
+	before, err := s.LoadRun(ctx, "r")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+
+	if err := s.SetRunBudgetOverrides(ctx, "r", &RunBudgetOverrides{MaxCostUSD: 120, MaxDuration: "4h"}); err != nil {
+		t.Fatalf("SetRunBudgetOverrides: %v", err)
+	}
+
+	got, err := s.LoadRun(ctx, "r")
+	if err != nil {
+		t.Fatalf("LoadRun after: %v", err)
+	}
+	if got.BudgetOverrides == nil || got.BudgetOverrides.MaxCostUSD != 120 || got.BudgetOverrides.MaxDuration != "4h" {
+		t.Fatalf("BudgetOverrides = %+v, want the raised ask", got.BudgetOverrides)
+	}
+	// Every peer field the whole-document path would have re-derived.
+	if got.Status != before.Status {
+		t.Errorf("Status = %s, want %s untouched", got.Status, before.Status)
+	}
+	if got.FailureCode != before.FailureCode {
+		t.Errorf("FailureCode = %q, want %q untouched", got.FailureCode, before.FailureCode)
+	}
+	if got.Error != before.Error {
+		t.Errorf("Error = %q, want %q untouched", got.Error, before.Error)
+	}
+	if got.OutcomeSeq != before.OutcomeSeq {
+		t.Errorf("OutcomeSeq = %d, want %d untouched (a whole-doc write re-runs the outcome bookkeeping)", got.OutcomeSeq, before.OutcomeSeq)
+	}
+	if got.Checkpoint == nil || before.Checkpoint == nil || got.Checkpoint.NodeID != before.Checkpoint.NodeID {
+		t.Errorf("Checkpoint = %+v, want %+v untouched", got.Checkpoint, before.Checkpoint)
+	}
+	if !got.UpdatedAt.After(before.UpdatedAt) {
+		t.Errorf("UpdatedAt = %s, want it advanced past %s", got.UpdatedAt, before.UpdatedAt)
+	}
+}

--- a/pkg/store/iface.go
+++ b/pkg/store/iface.go
@@ -272,7 +272,13 @@ type QueuedAttemptStore interface {
 	// FailQueuedRunIfAttempt moves a queued run to failed_resumable only when
 	// its current QueuedAt is not newer than the delivery's PublishedAt. The
 	// comparison and status transition are one atomic store operation.
-	FailQueuedRunIfAttempt(ctx context.Context, id, runErr string, publishedAt time.Time) (changed bool, err error)
+	//
+	// meta is the typed WHY of the flip, persisted with it exactly like
+	// UpdateRunOutcome's: the queue's admission park is a DLQ park
+	// (FailureDLQParked, ContinuationFinal — nothing wakes the run but an
+	// operator's replay), and every reader of the code must see the same
+	// value whichever of the two DLQ writers flipped the doc.
+	FailQueuedRunIfAttempt(ctx context.Context, id, runErr string, publishedAt time.Time, meta RunOutcomeMeta) (changed bool, err error)
 }
 
 // AsQueuedAttemptStore returns the attempt-aware status capability, or nil

--- a/pkg/store/iface.go
+++ b/pkg/store/iface.go
@@ -84,6 +84,17 @@ type RunStore interface {
 	SetRunCredFingerprints(ctx context.Context, runID string, fingerprints []string) error
 	CountAliveRunsWithCredFingerprint(ctx context.Context, fingerprint, excludeRunID string) (int, error)
 
+	// SetRunBudgetOverrides updates the persisted launch-time budget
+	// ask on the run — the resume path's replay source. Called by
+	// SubmitResume when the operator raises a cap on THIS resume, so
+	// a subsequent unattended auto-retry keeps the raised cap rather
+	// than reverting to the launch ask that already killed the run
+	// (E4, #652 review round 1). Nil clears the field. Granular:
+	// touches only budget_overrides + updated_at, no other field is
+	// disturbed — SaveRun's whole-doc replace is unsafe here because
+	// the resume has already CAS-transitioned the doc to `queued`.
+	SetRunBudgetOverrides(ctx context.Context, runID string, o *RunBudgetOverrides) error
+
 	// PatchRunSteering persists the live-steering state (accumulated
 	// loop grants + absolute budget raises) on the run record so a
 	// resume re-applies them. nil map / nil raises leave the stored

--- a/pkg/store/iface.go
+++ b/pkg/store/iface.go
@@ -95,6 +95,19 @@ type RunStore interface {
 	// the resume has already CAS-transitioned the doc to `queued`.
 	SetRunBudgetOverrides(ctx context.Context, runID string, o *RunBudgetOverrides) error
 
+	// SetRunBudgetSnapshot updates the persisted EFFECTIVE caps
+	// (Run.Budget, the studio Overview's denominator) — the display twin
+	// of the ask above. Written by every resume surface that raises a
+	// cap, right after its own status transition: the engine stamps
+	// Run.Budget only at launch (runResolveDoc), so without this write
+	// the doc keeps showing the launch-time figure that just killed the
+	// run. Nil clears the field. Granular for the same reason as
+	// SetRunBudgetOverrides: the doc copy a resume loaded at its top is
+	// stale by the time the caps are known, and a whole-doc SaveRun from
+	// it would revert any transition (a cancel, a runner's terminal
+	// write, the sweeper's flip) that landed in between.
+	SetRunBudgetSnapshot(ctx context.Context, runID string, b *RunBudget) error
+
 	// PatchRunSteering persists the live-steering state (accumulated
 	// loop grants + absolute budget raises) on the run record so a
 	// resume re-applies them. nil map / nil raises leave the stored

--- a/pkg/store/lifecycle.go
+++ b/pkg/store/lifecycle.go
@@ -94,6 +94,16 @@ const (
 	// FailureDLQParked: the queue exhausted its deliveries for this run
 	// and parked it on the DLQ — replay via /api/admin/dlq.
 	FailureDLQParked FailureCode = "DLQ_PARKED"
+	// FailureSandboxSetupTimeout: a sandbox driver's bounded SETUP
+	// phase (workspace copy, git fixup, …) exceeded its per-phase
+	// budget. Distinct from FailureTimeout (a node's deadline — raising
+	// max_duration is not the cure here) and from FailureInterrupted
+	// (runner drain / lost heartbeat): the phase ran on a
+	// driver-internal child ctx with a driver-internal bound while the
+	// run ctx stayed live. Persisted on RunStatusFailedResumable so the
+	// redelivery lands on a healthy pod, where a stuck kubectl-exec pipe
+	// routinely clears.
+	FailureSandboxSetupTimeout FailureCode = "SANDBOX_SETUP_TIMEOUT"
 )
 
 // AllRunStatuses is the exhaustive status vocabulary, for callers that

--- a/pkg/store/lifecycle_negative_space_test.go
+++ b/pkg/store/lifecycle_negative_space_test.go
@@ -296,8 +296,8 @@ var negativeSpaceAllowlist = map[string]allowEntry{
 
 	// -- pkg/runner.
 	"pkg/runner/loop.go :: Failed+Finished":                     {[]string{"bankableStatus"}, "forge-banking outcomes (finalStatus strings; budget_exceeded rides along outside the run-status vocabulary)"},
-	"pkg/runner/loop.go :: Failed+Finished+PausedWaitingHuman":  {[]string{"resolveDeliveryPreconditions"}, "stale-delivery drop set: shapes a redelivery can never legitimately target"},
-	"pkg/runner/loop.go :: FailedResumable+PausedOperator":      {[]string{"resolveDeliveryPreconditions"}, "redelivery auto-convert-to-Resume pair (dispatcher-parked shapes)"},
+	"pkg/runner/loop.go :: Failed+Finished+PausedWaitingHuman":  {[]string{"dispositionForStatus"}, "stale-delivery drop set: shapes a redelivery can never legitimately target (the admission switch, shared by the pre-lock pass and the under-lock re-read)"},
+	"pkg/runner/loop.go :: FailedResumable+PausedOperator":      {[]string{"dispositionForStatus"}, "redelivery auto-convert-to-Resume pair (dispatcher-parked shapes; same switch)"},
 	"pkg/runner/loop_nats.go :: FailedResumable+Queued+Running": {[]string{"parkOnDLQOnFinalDelivery"}, "DLQ park CAS: claimed/queued attempts AND the engine's own failed_resumable write — on the nominal path the engine parks first, and a CAS that excluded it dropped the DLQ_PARKED cause silently (gate F4)"},
 	"pkg/runner/usage_cap.go :: Queued+Running":                 {[]string{"usageCapPreflight"}, "usage-cap park CAS: only a claimed-or-queued attempt may be parked"},
 

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -1098,7 +1098,7 @@ func (s *Store) UpdateRunMergeIf(ctx context.Context, id string, upd store.RunMe
 // status-only CAS above. queued_at and status are matched in the SAME Mongo
 // update so a concurrent resume cannot slip a newer queued attempt between a
 // read and the failure write.
-func (s *Store) FailQueuedRunIfAttempt(ctx context.Context, id, runErr string, publishedAt time.Time) (bool, error) {
+func (s *Store) FailQueuedRunIfAttempt(ctx context.Context, id, runErr string, publishedAt time.Time, meta store.RunOutcomeMeta) (bool, error) {
 	if publishedAt.IsZero() {
 		return false, fmt.Errorf("store/mongo: fail queued attempt %s without published_at", id)
 	}
@@ -1114,10 +1114,9 @@ func (s *Store) FailQueuedRunIfAttempt(ctx context.Context, id, runErr string, p
 			bson.M{"queued_at": nil},
 		},
 	}))
-	// Queue-park classification is follow-up; the empty code reads as
-	// unknown, which is honest here. The filter pins status=queued, so
-	// the transition-gated episode increment always fires.
-	pipeline := statusTransitionPipeline(statusTransitionSet(store.RunStatusFailedResumable, runErr, store.RunOutcomeMeta{}, now))
+	// The filter pins status=queued, so the transition-gated episode
+	// increment always fires; meta rides the same write as the flip.
+	pipeline := statusTransitionPipeline(statusTransitionSet(store.RunStatusFailedResumable, runErr, meta, now))
 	res, err := s.runs.UpdateOne(ctx, filter, pipeline)
 	if err != nil {
 		return false, fmt.Errorf("store/mongo: fail queued attempt %s: %w", id, err)

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -912,6 +912,23 @@ func statusTransitionSet(status store.RunStatus, runErr string, meta store.RunOu
 		set["continuation_state"] = bson.M{"$cond": bson.A{statusChanged, "$$REMOVE",
 			bson.M{"$ifNull": bson.A{"$continuation_state", "$$REMOVE"}}}}
 	}
+	// A `final` continuation says nobody on the platform owns the run's
+	// future; an armed retry says the sweeper does. The two cannot both
+	// be true, and a doc carrying both gets BOTH automations — the gate
+	// reconciler's dead-review repair AND the sweeper's auto-resume, two
+	// runs of the bot on one PR head. Every final writer (the DLQ park,
+	// the orphan sweeper, the PR-close cancel) therefore disarms
+	// retry_after here, at the one tail they all go through; the rest
+	// of the retry bookkeeping (attempts, reason, last_error) is the
+	// run's history and stays. Same guarded $unsetField shape as the
+	// pause pointer above: a doc with no retry state must not grow one.
+	if meta.Continuation == store.ContinuationFinal {
+		set[retryStateField] = bson.M{"$cond": bson.A{
+			bson.M{"$eq": bson.A{bson.M{"$type": "$" + retryStateField}, "object"}},
+			bson.M{"$unsetField": bson.M{"field": "retry_after", "input": "$" + retryStateField}},
+			"$" + retryStateField,
+		}}
+	}
 	return set
 }
 

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -709,6 +709,27 @@ func (s *Store) SetRunBudgetOverrides(ctx context.Context, id string, o *store.R
 	return nil
 }
 
+// SetRunBudgetSnapshot persists the effective caps (see store.RunStore).
+// Granular $set (with $unset for nil), like SetRunBudgetOverrides, so the
+// status transition a resume just applied stays intact.
+func (s *Store) SetRunBudgetSnapshot(ctx context.Context, id string, b *store.RunBudget) error {
+	filter := notDeleted(withTenantFilter(ctx, bson.M{"_id": id}))
+	update := bson.M{"$set": bson.M{"updated_at": time.Now().UTC()}}
+	if b == nil {
+		update["$unset"] = bson.M{"budget": ""}
+	} else {
+		update["$set"].(bson.M)["budget"] = b
+	}
+	res, err := s.runs.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return fmt.Errorf("store/mongo: set run budget snapshot: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return store.ErrRunNotFound
+	}
+	return nil
+}
+
 // CountAliveRunsWithCredFingerprint counts queued/running runs stamped
 // with fingerprint (see store.RunStore). Deliberately NO tenant filter —
 // a platform key serves every tenant on one ceiling.

--- a/pkg/store/mongo/runs.go
+++ b/pkg/store/mongo/runs.go
@@ -688,6 +688,27 @@ func (s *Store) SetRunCredFingerprints(ctx context.Context, id string, fingerpri
 	return nil
 }
 
+// SetRunBudgetOverrides persists the operator's launch-time budget ask
+// (see store.RunStore). Granular $set (with $unset for nil) so the CAS
+// status transition SubmitResume just applied stays intact.
+func (s *Store) SetRunBudgetOverrides(ctx context.Context, id string, o *store.RunBudgetOverrides) error {
+	filter := notDeleted(withTenantFilter(ctx, bson.M{"_id": id}))
+	update := bson.M{"$set": bson.M{"updated_at": time.Now().UTC()}}
+	if o == nil {
+		update["$unset"] = bson.M{"budget_overrides": ""}
+	} else {
+		update["$set"].(bson.M)["budget_overrides"] = o
+	}
+	res, err := s.runs.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return fmt.Errorf("store/mongo: set run budget overrides: %w", err)
+	}
+	if res.MatchedCount == 0 {
+		return store.ErrRunNotFound
+	}
+	return nil
+}
+
 // CountAliveRunsWithCredFingerprint counts queued/running runs stamped
 // with fingerprint (see store.RunStore). Deliberately NO tenant filter —
 // a platform key serves every tenant on one ceiling.

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -591,7 +591,7 @@ func (s *FilesystemRunStore) UpdateRunOutcome(_ context.Context, id string, stat
 // by publishedAt. A later resume refreshes QueuedAt before publishing, so an
 // older delivery cannot clobber that new attempt during its queued→running
 // hand-off window.
-func (s *FilesystemRunStore) FailQueuedRunIfAttempt(_ context.Context, id, runErr string, publishedAt time.Time) (bool, error) {
+func (s *FilesystemRunStore) FailQueuedRunIfAttempt(_ context.Context, id, runErr string, publishedAt time.Time, meta RunOutcomeMeta) (bool, error) {
 	if publishedAt.IsZero() {
 		return false, fmt.Errorf("store: fail queued attempt %s without published_at", id)
 	}
@@ -605,9 +605,7 @@ func (s *FilesystemRunStore) FailQueuedRunIfAttempt(_ context.Context, id, runEr
 	if r.Status != RunStatusQueued || (r.QueuedAt != nil && r.QueuedAt.After(publishedAt)) {
 		return false, nil
 	}
-	// Classification of the queue-park writer is follow-up work; the
-	// empty code reads as unknown, which is honest here.
-	if err := s.applyStatusTransition(r, RunStatusFailedResumable, runErr, ""); err != nil {
+	if err := s.applyStatusTransitionOutcome(r, RunStatusFailedResumable, runErr, meta); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -1009,6 +1009,21 @@ func (s *FilesystemRunStore) SetRunBudgetOverrides(ctx context.Context, runID st
 	return s.SaveRun(ctx, r)
 }
 
+// SetRunBudgetSnapshot persists the effective caps (see RunStore).
+// Load-modify-save under the store mutex, like the other fs-side
+// patches, so a status transition racing this write is never reverted.
+func (s *FilesystemRunStore) SetRunBudgetSnapshot(_ context.Context, runID string, b *RunBudget) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, err := s.loadRunRaw(runID)
+	if err != nil {
+		return err
+	}
+	r.Budget = b
+	r.UpdatedAt = time.Now().UTC()
+	return s.writeRun(r)
+}
+
 // CountAliveRunsWithCredFingerprint counts queued/running runs stamped
 // with fingerprint (see RunStore). Scan-and-filter like the other
 // fs-side reverse queries — local scale, no secondary index.

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -648,6 +648,12 @@ func (s *FilesystemRunStore) applyStatusTransitionOutcome(r *Run, status RunStat
 	} else if transition {
 		r.ContinuationState = ""
 	}
+	// A final continuation and an armed retry contradict each other (see
+	// the Mongo twin, statusTransitionSet): disarm at the tail every final
+	// writer goes through, keeping the rest of the retry bookkeeping.
+	if meta.Continuation == ContinuationFinal && r.RetryState != nil {
+		r.RetryState.RetryAfter = nil
+	}
 	r.Status = status
 	r.UpdatedAt = time.Now().UTC()
 	// A transition always states its own message (empty included); a

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -999,6 +999,18 @@ func (s *FilesystemRunStore) SetRunCredFingerprints(ctx context.Context, runID s
 	return s.SaveRun(ctx, r)
 }
 
+// SetRunBudgetOverrides persists the operator's launch-time budget ask
+// (see RunStore). Load-modify-save, like the other fs-side patches: no
+// partial update on the filesystem store.
+func (s *FilesystemRunStore) SetRunBudgetOverrides(ctx context.Context, runID string, o *RunBudgetOverrides) error {
+	r, err := s.LoadRun(ctx, runID)
+	if err != nil {
+		return err
+	}
+	r.BudgetOverrides = o
+	return s.SaveRun(ctx, r)
+}
+
 // CountAliveRunsWithCredFingerprint counts queued/running runs stamped
 // with fingerprint (see RunStore). Scan-and-filter like the other
 // fs-side reverse queries — local scale, no secondary index.

--- a/pkg/store/store_run.go
+++ b/pkg/store/store_run.go
@@ -1004,15 +1004,22 @@ func (s *FilesystemRunStore) SetRunCredFingerprints(ctx context.Context, runID s
 }
 
 // SetRunBudgetOverrides persists the operator's launch-time budget ask
-// (see RunStore). Load-modify-save, like the other fs-side patches: no
-// partial update on the filesystem store.
-func (s *FilesystemRunStore) SetRunBudgetOverrides(ctx context.Context, runID string, o *RunBudgetOverrides) error {
-	r, err := s.LoadRun(ctx, runID)
+// (see RunStore). Load-modify-save under the store mutex, like
+// SetRunBudgetSnapshot below, so a status transition racing this write
+// is never reverted: SaveRun replaces the whole document from a copy
+// loaded before the lock, which would undo a cancel — and would apply
+// its own failure-code and pause-pointer normalisation to a field-scoped
+// write that has no business touching either.
+func (s *FilesystemRunStore) SetRunBudgetOverrides(_ context.Context, runID string, o *RunBudgetOverrides) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, err := s.loadRunRaw(runID)
 	if err != nil {
 		return err
 	}
 	r.BudgetOverrides = o
-	return s.SaveRun(ctx, r)
+	r.UpdatedAt = time.Now().UTC()
+	return s.writeRun(r)
 }
 
 // SetRunBudgetSnapshot persists the effective caps (see RunStore).

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -81,6 +81,7 @@ func RunWithOpts(t *testing.T, factory Factory, opts Opts) {
 	t.Run("ReverseTreeQueries", func(t *testing.T) { testReverseTreeQueries(t, factory(t)) })
 	t.Run("ScheduleReverseQuery", func(t *testing.T) { testScheduleReverseQuery(t, factory(t)) })
 	t.Run("CredFingerprintMeter", func(t *testing.T) { testCredFingerprintMeter(t, factory(t)) })
+	t.Run("SetRunBudgetOverrides", func(t *testing.T) { testSetRunBudgetOverrides(t, factory(t)) })
 	t.Run("DeleteRun", func(t *testing.T) { testDeleteRun(t, factory(t)) })
 	t.Run("RunLogStore", func(t *testing.T) { testRunLogStore(t, factory(t)) })
 	t.Run("TurnStore", func(t *testing.T) { testTurnStore(t, factory(t)) })
@@ -2556,5 +2557,69 @@ func testCredFingerprintMeter(t *testing.T, s store.RunStore) {
 	}
 	if n, err = s.CountAliveRunsWithCredFingerprint(ctx, "fp-anthropic", ""); err != nil || n != 2 {
 		t.Errorf("alive(fp-anthropic) after re-stamp = %d/%v, want 2", n, err)
+	}
+}
+
+// testSetRunBudgetOverrides exercises the granular budget-ask setter
+// SubmitResume calls when the operator raises a cap on THIS resume
+// (E4, #652 review round 1). Contract: replaces the field wholesale,
+// nil clears, touches nothing else on the doc — SubmitResume has
+// already CAS-transitioned the status to `queued` and a whole-doc
+// SaveRun would clobber it.
+func testSetRunBudgetOverrides(t *testing.T, s store.RunStore) {
+	t.Helper()
+	ctx := testCtx()
+
+	// Seed a run with a launch-time budget ask; also set a peer field
+	// (Status) so the granular-update contract is verifiable.
+	if _, err := s.CreateRun(ctx, "bo_run", "demo", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	r, err := s.LoadRun(ctx, "bo_run")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	r.Status = store.RunStatusQueued
+	r.BudgetOverrides = &store.RunBudgetOverrides{MaxCostUSD: 50, MaxDuration: "2h30m"}
+	if err := s.SaveRun(ctx, r); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+
+	// Raise the cap — SubmitResume's E4 write.
+	if err := s.SetRunBudgetOverrides(ctx, "bo_run", &store.RunBudgetOverrides{MaxCostUSD: 120, MaxDuration: "4h", MaxTokens: 5_000_000}); err != nil {
+		t.Fatalf("SetRunBudgetOverrides: %v", err)
+	}
+	got, err := s.LoadRun(ctx, "bo_run")
+	if err != nil {
+		t.Fatalf("LoadRun after set: %v", err)
+	}
+	if got.BudgetOverrides == nil {
+		t.Fatal("BudgetOverrides = nil after set")
+	}
+	if got.BudgetOverrides.MaxCostUSD != 120 || got.BudgetOverrides.MaxDuration != "4h" || got.BudgetOverrides.MaxTokens != 5_000_000 {
+		t.Fatalf("BudgetOverrides after set = %+v, want the raised ask", got.BudgetOverrides)
+	}
+	// The peer field must survive — SetRunBudgetOverrides must not
+	// clobber the status (SubmitResume relies on this).
+	if got.Status != store.RunStatusQueued {
+		t.Fatalf("Status after SetRunBudgetOverrides = %s, want queued (a whole-doc replace would revert the CAS transition)", got.Status)
+	}
+
+	// Nil clears (the field is opt-in).
+	if err := s.SetRunBudgetOverrides(ctx, "bo_run", nil); err != nil {
+		t.Fatalf("SetRunBudgetOverrides(nil): %v", err)
+	}
+	got, err = s.LoadRun(ctx, "bo_run")
+	if err != nil {
+		t.Fatalf("LoadRun after clear: %v", err)
+	}
+	if got.BudgetOverrides != nil {
+		t.Fatalf("BudgetOverrides after nil set = %+v, want nil (clear)", got.BudgetOverrides)
+	}
+
+	// A missing run returns ErrRunNotFound.
+	err = s.SetRunBudgetOverrides(ctx, "does-not-exist", &store.RunBudgetOverrides{MaxCostUSD: 1})
+	if err == nil {
+		t.Fatal("SetRunBudgetOverrides on missing run returned nil, want ErrRunNotFound")
 	}
 }

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -2595,6 +2595,13 @@ func testSetRunBudgetOverrides(t *testing.T, s store.RunStore) {
 	if err := s.SaveRun(ctx, r); err != nil {
 		t.Fatalf("SaveRun: %v", err)
 	}
+	seeded, err := s.LoadRun(ctx, "bo_run")
+	if err != nil {
+		t.Fatalf("LoadRun seeded: %v", err)
+	}
+	// Mongo stores updated_at at millisecond resolution, so give the
+	// setter's stamp a tick it can be strictly greater in.
+	time.Sleep(2 * time.Millisecond)
 
 	// Raise the cap — SubmitResume's E4 write.
 	if err := s.SetRunBudgetOverrides(ctx, "bo_run", &store.RunBudgetOverrides{MaxCostUSD: 120, MaxDuration: "4h", MaxTokens: 5_000_000}); err != nil {
@@ -2610,10 +2617,19 @@ func testSetRunBudgetOverrides(t *testing.T, s store.RunStore) {
 	if got.BudgetOverrides.MaxCostUSD != 120 || got.BudgetOverrides.MaxDuration != "4h" || got.BudgetOverrides.MaxTokens != 5_000_000 {
 		t.Fatalf("BudgetOverrides after set = %+v, want the raised ask", got.BudgetOverrides)
 	}
-	// The peer field must survive — SetRunBudgetOverrides must not
-	// clobber the status (SubmitResume relies on this).
+	// The peer field must survive. NOTE this is a SERIAL call, so it
+	// does NOT prove the granularity the interface promises: a
+	// load-modify-save satisfies it trivially, nothing having changed
+	// between the load and the save. The granular shape is pinned
+	// per-twin instead (fs: TestSetRunBudgetOverridesDoesNotReplaceTheDocument
+	// on updated_at + the peer fields; mongo: the $set/$unset itself).
 	if got.Status != store.RunStatusQueued {
 		t.Fatalf("Status after SetRunBudgetOverrides = %s, want queued (a whole-doc replace would revert the CAS transition)", got.Status)
+	}
+	// updated_at is the half a whole-document replace fails even
+	// serially — SaveRun stamps no timestamp of its own.
+	if !got.UpdatedAt.After(seeded.UpdatedAt) {
+		t.Fatalf("UpdatedAt after SetRunBudgetOverrides = %s, want it advanced past %s (the setter owns budget_overrides AND updated_at)", got.UpdatedAt, seeded.UpdatedAt)
 	}
 
 	// Nil clears (the field is opt-in).

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -82,6 +82,7 @@ func RunWithOpts(t *testing.T, factory Factory, opts Opts) {
 	t.Run("ScheduleReverseQuery", func(t *testing.T) { testScheduleReverseQuery(t, factory(t)) })
 	t.Run("CredFingerprintMeter", func(t *testing.T) { testCredFingerprintMeter(t, factory(t)) })
 	t.Run("SetRunBudgetOverrides", func(t *testing.T) { testSetRunBudgetOverrides(t, factory(t)) })
+	t.Run("SetRunBudgetSnapshot", func(t *testing.T) { testSetRunBudgetSnapshot(t, factory(t)) })
 	t.Run("DeleteRun", func(t *testing.T) { testDeleteRun(t, factory(t)) })
 	t.Run("RunLogStore", func(t *testing.T) { testRunLogStore(t, factory(t)) })
 	t.Run("TurnStore", func(t *testing.T) { testTurnStore(t, factory(t)) })
@@ -2630,5 +2631,59 @@ func testSetRunBudgetOverrides(t *testing.T, s store.RunStore) {
 	err = s.SetRunBudgetOverrides(ctx, "does-not-exist", &store.RunBudgetOverrides{MaxCostUSD: 1})
 	if err == nil {
 		t.Fatal("SetRunBudgetOverrides on missing run returned nil, want ErrRunNotFound")
+	}
+}
+
+// testSetRunBudgetSnapshot exercises the granular effective-caps setter
+// every resume surface that raises a cap writes. Contract: replaces
+// Run.Budget wholesale, nil clears, touches nothing else on the doc — a
+// transition that landed between the resume's load and this write (here
+// a cancel with its typed cause) must survive, which a whole-doc SaveRun
+// from the stale copy would revert.
+func testSetRunBudgetSnapshot(t *testing.T, s store.RunStore) {
+	t.Helper()
+	ctx := testCtx()
+	if _, err := s.CreateRun(ctx, "bs_run", "demo", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	r, err := s.LoadRun(ctx, "bs_run")
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	r.Budget = &store.RunBudget{MaxCostUSD: 20, MaxDuration: "2h30m", MaxTokens: 5000}
+	if err := s.SaveRun(ctx, r); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+	// The concurrent transition the granular write must not revert.
+	if err := s.UpdateRunStatusCoded(ctx, "bs_run", store.RunStatusCancelled, "cancelled by the operator", store.FailureCancelled); err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+
+	if err := s.SetRunBudgetSnapshot(ctx, "bs_run", &store.RunBudget{MaxCostUSD: 50, MaxDuration: "4h", MaxTokens: 5000}); err != nil {
+		t.Fatalf("SetRunBudgetSnapshot: %v", err)
+	}
+	got, err := s.LoadRun(ctx, "bs_run")
+	if err != nil {
+		t.Fatalf("LoadRun after set: %v", err)
+	}
+	if got.Budget == nil || got.Budget.MaxCostUSD != 50 || got.Budget.MaxDuration != "4h" || got.Budget.MaxTokens != 5000 {
+		t.Fatalf("Budget after set = %+v, want the raised effective caps", got.Budget)
+	}
+	if got.Status != store.RunStatusCancelled || got.FailureCode != store.FailureCancelled {
+		t.Fatalf("status/code after SetRunBudgetSnapshot = %s/%q, want cancelled/CANCELLED untouched (a whole-doc replace from the pre-cancel copy reverts the operator's cancel)", got.Status, got.FailureCode)
+	}
+
+	if err := s.SetRunBudgetSnapshot(ctx, "bs_run", nil); err != nil {
+		t.Fatalf("SetRunBudgetSnapshot(nil): %v", err)
+	}
+	got, err = s.LoadRun(ctx, "bs_run")
+	if err != nil {
+		t.Fatalf("LoadRun after clear: %v", err)
+	}
+	if got.Budget != nil {
+		t.Fatalf("Budget after nil set = %+v, want nil (clear)", got.Budget)
+	}
+	if err := s.SetRunBudgetSnapshot(ctx, "does-not-exist", &store.RunBudget{MaxCostUSD: 1}); err == nil {
+		t.Fatal("SetRunBudgetSnapshot on a missing run returned nil, want ErrRunNotFound")
 	}
 }

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -66,6 +66,7 @@ func RunWithOpts(t *testing.T, factory Factory, opts Opts) {
 	t.Run("ParallelCheckpointRoundTrip", func(t *testing.T) { testParallelCheckpointRoundTrip(t, factory(t)) })
 	t.Run("FailureCodeLifecycle", func(t *testing.T) { testFailureCodeLifecycle(t, factory(t)) })
 	t.Run("TransitionSideEffects", func(t *testing.T) { testTransitionSideEffects(t, factory(t)) })
+	t.Run("FinalContinuationDisarmsRetry", func(t *testing.T) { testFinalContinuationDisarmsRetry(t, factory(t)) })
 	t.Run("TombstoneRefusesWriters", func(t *testing.T) { testTombstoneRefusesWriters(t, factory(t)) })
 	t.Run("PausePointerLifecycle", func(t *testing.T) { testPausePointerLifecycle(t, factory(t)) })
 	t.Run("EventSeqMonotone", func(t *testing.T) { testEventSeqMonotone(t, factory(t)) })
@@ -2631,6 +2632,88 @@ func testSetRunBudgetOverrides(t *testing.T, s store.RunStore) {
 	err = s.SetRunBudgetOverrides(ctx, "does-not-exist", &store.RunBudgetOverrides{MaxCostUSD: 1})
 	if err == nil {
 		t.Fatal("SetRunBudgetOverrides on missing run returned nil, want ErrRunNotFound")
+	}
+}
+
+// testFinalContinuationDisarmsRetry pins the transition-tail rule: a
+// `final` continuation (the DLQ park, the orphan sweeper, the PR-close
+// cancel) disarms retry_state.retry_after on both twins, because a doc
+// carrying both a final continuation and an armed retry gets BOTH
+// automations — the gate reconciler's dead-review repair and the
+// sweeper's auto-resume. The rest of the retry bookkeeping is history and
+// stays; a non-final write leaves the retry armed; a doc that never
+// carried retry state does not grow one.
+func testFinalContinuationDisarmsRetry(t *testing.T, s store.RunStore) {
+	t.Helper()
+	ctx := testCtx()
+	const runID = "run_final_disarms_retry"
+	if _, err := s.CreateRun(ctx, runID, "demo", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	r, err := s.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	at := time.Now().UTC().Add(72 * time.Hour).Truncate(time.Millisecond)
+	r.Status = store.RunStatusFailedResumable
+	r.ContinuationState = store.ContinuationRetryArmed
+	r.RetryState = &store.RunRetryState{RetryAfter: &at, Reason: "usage_window", Code: "USAGE_LIMIT_BLOCKED", Attempts: 1}
+	if err := s.SaveRun(ctx, r); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+
+	// The runner's redelivery promote is not final: the retry stays armed.
+	changed, err := s.UpdateRunOutcome(ctx, runID, store.RunStatusFailedResumable, "",
+		store.RunOutcomeMeta{Continuation: store.ContinuationRedeliveryPending}, []store.RunStatus{store.RunStatusFailedResumable})
+	if err != nil || !changed {
+		t.Fatalf("redelivery promote: changed=%v err=%v", changed, err)
+	}
+	got, err := s.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.RetryState == nil || got.RetryState.RetryAfter == nil || !got.RetryState.RetryAfter.Equal(at) {
+		t.Fatalf("retry state after a non-final write = %+v, want retry_after %s still armed", got.RetryState, at)
+	}
+
+	// The DLQ park is final: the arming goes, the bookkeeping stays.
+	changed, err = s.UpdateRunOutcome(ctx, runID, store.RunStatusFailedResumable, "max deliveries exhausted (parked on DLQ)",
+		store.RunOutcomeMeta{Code: store.FailureDLQParked, Continuation: store.ContinuationFinal}, []store.RunStatus{store.RunStatusFailedResumable})
+	if err != nil || !changed {
+		t.Fatalf("DLQ park: changed=%v err=%v", changed, err)
+	}
+	got, err = s.LoadRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.RetryState == nil {
+		t.Fatal("retry state gone after the final write — attempts/reason are the run's history and must stay")
+	}
+	if got.RetryState.RetryAfter != nil {
+		t.Fatalf("retry_after = %s after a final continuation, want disarmed — the sweeper would auto-resume a DLQ-parked run the gate reconciler already repaired", got.RetryState.RetryAfter)
+	}
+	if got.RetryState.Attempts != 1 || got.RetryState.Reason != "usage_window" || got.RetryState.Code != "USAGE_LIMIT_BLOCKED" {
+		t.Fatalf("retry bookkeeping after the final write = %+v, want attempts/reason/code kept", got.RetryState)
+	}
+	if got.ContinuationState != store.ContinuationFinal || got.FailureCode != store.FailureDLQParked {
+		t.Fatalf("continuation/code = %q/%q, want final/DLQ_PARKED (the disarm must not disturb the transition)", got.ContinuationState, got.FailureCode)
+	}
+
+	// A doc that never carried retry state must not grow one.
+	const bare = "run_final_no_retry_state"
+	if _, err := s.CreateRun(ctx, bare, "demo", nil); err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if _, err := s.UpdateRunOutcome(ctx, bare, store.RunStatusFailedResumable, "orphaned",
+		store.RunOutcomeMeta{Code: store.FailureProcessOrphaned, Continuation: store.ContinuationFinal}, nil); err != nil {
+		t.Fatalf("final write on a bare doc: %v", err)
+	}
+	got, err = s.LoadRun(ctx, bare)
+	if err != nil {
+		t.Fatalf("LoadRun: %v", err)
+	}
+	if got.RetryState != nil {
+		t.Fatalf("a final write materialised retry state %+v on a doc that never had one", got.RetryState)
 	}
 }
 

--- a/pkg/store/storetest/conformance.go
+++ b/pkg/store/storetest/conformance.go
@@ -189,7 +189,7 @@ func testQueuedAttemptCAS(t *testing.T, s store.RunStore) {
 	}
 
 	// A delivery from before this requeue must not fail the new attempt.
-	changed, err = attempts.FailQueuedRunIfAttempt(ctx, runID, "stale", r.QueuedAt.Add(-time.Second))
+	changed, err = attempts.FailQueuedRunIfAttempt(ctx, runID, "stale", r.QueuedAt.Add(-time.Second), store.RunOutcomeMeta{Code: store.FailureDLQParked, Continuation: store.ContinuationFinal})
 	if err != nil || changed {
 		t.Fatalf("stale attempt CAS = (%t, %v), want (false, nil)", changed, err)
 	}
@@ -198,12 +198,21 @@ func testQueuedAttemptCAS(t *testing.T, s store.RunStore) {
 	}
 
 	// The delivery belonging to this attempt may perform the terminal flip.
-	changed, err = attempts.FailQueuedRunIfAttempt(ctx, runID, "schema mismatch", r.QueuedAt.Add(time.Second))
+	changed, err = attempts.FailQueuedRunIfAttempt(ctx, runID, "schema mismatch", r.QueuedAt.Add(time.Second), store.RunOutcomeMeta{Code: store.FailureDLQParked, Continuation: store.ContinuationFinal})
 	if err != nil || !changed {
 		t.Fatalf("current attempt CAS = (%t, %v), want (true, nil)", changed, err)
 	}
-	if got, _ := s.LoadRun(ctx, runID); got == nil || got.Status != store.RunStatusFailedResumable {
+	got, _ := s.LoadRun(ctx, runID)
+	if got == nil || got.Status != store.RunStatusFailedResumable {
 		t.Fatalf("current attempt left run at %+v, want failed_resumable", got)
+	}
+	// The park's typed WHY rides the same write as the flip: a DLQ park
+	// with an empty code reads as a quota pause to the gate notice.
+	if got.FailureCode != store.FailureDLQParked {
+		t.Fatalf("FailureCode after the admission park = %q, want %s (the notice keys on it)", got.FailureCode, store.FailureDLQParked)
+	}
+	if got.ContinuationState != store.ContinuationFinal {
+		t.Fatalf("ContinuationState after the admission park = %q, want final (nothing on the platform wakes a parked run)", got.ContinuationState)
 	}
 }
 

--- a/studio/src/api/runs/events.ts
+++ b/studio/src/api/runs/events.ts
@@ -407,6 +407,7 @@ export type PassthroughEventType =
   | "run_auto_resumed"
   | "run_workspace_reset"
   | "run_workspace_bank_restored"
+  | "run_redelivery_deferred"
   | "run_bank_refused"
   | "run_bank_superseded"
   | "run_bank_attempt"


### PR DESCRIPTION
Wave 1 of the board-203 triage, resume/runner cluster. Two tickets, then four adversarial-review rounds whose findings are folded in.

Closes #669
Refs #652 — the re-budget half. **Its re-anchor half landed on main meanwhile** (`ea2b27481`, #674, better: it restores the parked ref too and checks out the chain's base before fast-forwarding, so the reflog still names the run's real starting point). Our three re-anchor commits were dropped from this branch rather than merged with it.

## What was wrong

**#669 — a resumed run stalled in sandbox start, died with the runner rollout, and was announced as a quota pause.** Four independent causes, all now closed:
- The k8s workspace copy had no deadline: a stalled `tar` blocked until the pod was rolled. It is bounded (15 min, env-overridable, warned at the halfway mark) and a strike is a typed, *resumable* failure that NAKs to a fresh pod — the round-1 fix made it a hard `failed` that the runner ACKed, which was worse than the bug.
- A run reading `running` with no live NATS-KV lease burned its 8 deliveries against "cannot resume a running run". It is adopted — but **under the lock**, never before it: the first version elected the orphan by a read while the write landed 13 lines earlier, so a live run could be labelled dead by a pod that did not own it. A staleness floor sized on the lease TTL + heartbeat + unwind budget keeps a pod that is merely lapsed from being adopted mid-unwind.
- The adoption stamped `ContinuationFinal` on a run it was itself about to resume — three control-plane consumers act on that (a board card moved to blocked "one-way door", the ADR-096 stuck-card repark launching a duplicate run, the outcome router).
- The DLQ notice matched only one of the two park writers, so the rollout shape — the one #669 is about — rendered the quota text while the run's own error said "parked on DLQ". The reconciler no longer stands down on a DLQ park either, so the required check stops sitting `pending` for a run nothing will wake.

**#652 (re-budget half) — the operator could not raise a cap and have it stick.** `--max-*` on `iterion remote runs resume` reaches the wire, merges *per field* over the launch ask (a lone `--max-duration` used to silently delete the cost cap), is validated before any store access, and is persisted so an unattended auto-retry keeps the raised cap. The doc's effective caps are stamped from what the wire actually enforces — including when a credential-pool donor's allowance clamps it, and on the ask-less resumes the sweeper makes, so the studio stops advertising a cap the run does not have.

## Review

Four internal rounds. Round 3 found what two local rounds had walked past, and it took a probe against a **real Mongo** to see it: the round-2 teardown wrote on the context that had just been cancelled — invisible on the filesystem store, which ignores ctx, so the shipped test certified a double. An operator's cancel of a run stuck in sandbox start left the doc `running`. The class fix follows the convention the launch path already had (`WithoutCancel` + a bounded write) and returns the sentinel the status carries, so the queue acks a cancel instead of naking it.

`task check` green (135 packages, e2e included), `-race` on every touched package, mongo conformance against a live replica set for the store twins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)