### PR TITLE
fix(webhooks): a merge-queue heal stands down when the queue takes the PR back

### DIFF
--- a/docs/merge-gate.md
+++ b/docs/merge-gate.md
@@ -280,6 +280,35 @@ different shared `gate_context`, its merge-group workflow must mirror that same
 context (or otherwise run the gate on the merge-group SHA), or the required
 check will remain expected forever.
 
+#### Auto-heal, and when it stands down
+
+A PR the queue **ejects** for a healable reason (`MERGE_CONFLICT`,
+`CI_FAILURE`, `INVALID_MERGE_COMMIT`, `MERGE_CONFLICT_ERROR`) dispatches the
+brancher bot to rebase, reconcile the branch with the new base, and push so
+the PR re-enters the queue — the queue *detects* the break, the bot *repairs*
+it, no human. The heal is bounded to one attempt per head sha, and gated on
+same-repo + project/author allowlist + bot-permitted like every other lane.
+
+The heal **stops the moment the queue takes the PR back** (`enqueued`). This
+is not an optimisation: a heal still running past that point force-pushes the
+branch, and that push cancels the queue build in flight — ejecting the PR a
+second time, so the repair becomes the next breakage. The stop is keyed on the
+heal's own idempotency key at the PR's *current head*, which gives it two
+properties worth knowing:
+
+- a fixer a developer asked for with `/billy` rides a different key and is
+  never touched;
+- a heal that has **already pushed** advanced the head, and that push is what
+  re-enqueued the PR — so the enqueue it caused does not match its own key,
+  and the run is left to finish its delivery tail.
+
+Note what auto-heal cannot tell on its own: `CI_FAILURE` covers both "this
+branch genuinely breaks when combined with the base" and "an unrelated flaky
+test failed on the queue branch". In the second case the bot is dispatched
+against a PR with nothing to fix; it should report that and push nothing, but
+it still costs a run. If a flaky test is ejecting PRs, fix the test — the heal
+lane is not the place to absorb it.
+
 ## One gate, several bots
 
 A required check applies to **every** pull request. So on a repo where

--- a/pkg/server/webhooks_common.go
+++ b/pkg/server/webhooks_common.go
@@ -16,6 +16,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/schedgate"
 	"github.com/SocialGouv/iterion/pkg/store"
 	"github.com/SocialGouv/iterion/pkg/webhooks"
+	"github.com/SocialGouv/iterion/pkg/webhooks/prforge"
 )
 
 // maxWebhookBodyBytes caps the inbound payload every provider handler
@@ -1213,6 +1214,77 @@ func (s *Server) launchWebhookTarget(
 // synthetic status that quotes run.Error, say WHY. "cancelled by user"
 // there once sent operators hunting for a human who did nothing.
 const prClosedRunReason = "pull request closed or merged — nothing left to review"
+
+// prRequeuedRunReason names the auto-heal cancel for the same reason: a
+// reader finding a stopped fixer run has to learn that the queue took the
+// pull request back, not that someone gave up on it.
+const prRequeuedRunReason = "pull request re-entered the merge queue — the heal has nothing left to carry"
+
+// healIdempotencyKey is the identity of ONE auto-heal attempt: this
+// webhook, this pull request, this head. Both halves of the loop derive
+// the key here rather than formatting it themselves — the launch that
+// writes the delivery row and the requeue stop that looks it up must
+// agree byte for byte, and two copies of a format string drift.
+func healIdempotencyKey(cfg webhooks.Config, p prforge.Parsed) string {
+	return knowledge.ChecksumHex([]byte(fmt.Sprintf("heal|%s|%s|%s|%d|%s",
+		cfg.TenantID, cfg.ID, p.ProjectPath, p.PRNumber, p.HeadSHA)))
+}
+
+// stopHealRunForRequeuedPR cancels the auto-heal run launched for this
+// pull request's CURRENT head, once the merge queue has taken the PR back.
+//
+// The heal's whole job is to return an ejected PR to the queue. When the
+// PR is queued again the job is done — and a heal still running is now
+// actively harmful, because its delivery tail force-pushes the branch:
+// that push cancels the queue build in flight and ejects the PR a second
+// time, so the repair becomes the next breakage. Observed in production
+// (2026-09-04, iterion#682): a flaky test ejected a green PR, the heal
+// launched, the PR was re-enqueued, and only a manual cancel kept the
+// fixer's push from killing the queue run that went on to merge it.
+//
+// Scoped by the heal's own idempotency key, NOT by (project, subject):
+// a fixer the developer asked for with `/billy` rides a different key on
+// the same PR and must survive — this stop may only reach the run the
+// queue ejection itself started. Keyed on the head means a heal that has
+// ALREADY pushed (advancing the head, which is what re-enqueues the PR)
+// is not matched by the enqueue its own push caused: that run is finishing
+// the work this stop exists to let it finish.
+func (s *Server) stopHealRunForRequeuedPR(ctx context.Context, cfg webhooks.Config, p prforge.Parsed) int {
+	if s.webhookDeliveries == nil || p.PRNumber == 0 || p.HeadSHA == "" {
+		return 0
+	}
+	d, err := s.webhookDeliveries.GetByIdempotencyKey(ctx, healIdempotencyKey(cfg, p))
+	if err != nil || d.RunID == "" {
+		return 0 // no heal was launched for this head — the ordinary case
+	}
+	if !s.runIsStoppable(ctx, d.RunID) {
+		return 0
+	}
+	// Disarm before cancelling, like the closed-PR stop: a retry left armed
+	// would resume the very run we just stopped.
+	if retries := store.AsRunRetryStore(s.cfg.Store); retries != nil {
+		if aerr := retries.AbandonRunRetry(ctx, d.RunID, prRequeuedRunReason); aerr != nil && s.logger != nil {
+			s.logger.Debug("webhooks: could not disarm the retry of heal run %s on a re-queued PR: %v", d.RunID, aerr)
+		}
+	}
+	cancel := s.webhookCancelRun
+	if cancel == nil && s.runs != nil {
+		cancel = func(runID string) error { return s.runs.CancelWithReason(runID, prRequeuedRunReason) }
+	}
+	if cancel == nil {
+		return 0
+	}
+	if cerr := cancel(d.RunID); cerr != nil {
+		if s.logger != nil {
+			s.logger.Debug("webhooks: re-queue stop could not cancel heal run %s (it may have just settled): %v", d.RunID, cerr)
+		}
+		return 0
+	}
+	if s.logger != nil {
+		s.logger.Info("webhooks: stopped auto-heal run %s (%s on %s #%d) — its pull request is back in the merge queue", d.RunID, d.BotID, p.ProjectPath, p.PRNumber)
+	}
+	return 1
+}
 
 // stopRunsForDeadPR ends every run still bound to a pull request that just
 // closed or merged, and disarms any usage-window retry armed for one.

--- a/pkg/server/webhooks_github.go
+++ b/pkg/server/webhooks_github.go
@@ -187,7 +187,7 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 			writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
 			return
 		}
-		healIdem := knowledge.ChecksumHex([]byte(fmt.Sprintf("heal|%s|%s|%s|%d|%s", cfg.TenantID, cfg.ID, p.ProjectPath, p.PRNumber, p.HeadSHA)))
+		healIdem := healIdempotencyKey(cfg, p)
 		mission := fmt.Sprintf(
 			"This PR was ejected from the merge queue (reason: %s). Rebase the branch on `%s`, "+
 				"resolve any conflicts, and fix whatever breaks the build when the branch is combined "+
@@ -197,6 +197,25 @@ func (s *Server) handlePRForgeReview(ctx context.Context, w http.ResponseWriter,
 			p.DequeueReason, p.TargetBranch, p.TargetBranch, strings.TrimSpace(p.Title+"\n\n"+p.Description))
 		healVars := applyWebhookVarLayers(fixerPRVars(p.TargetBranch, p.SourceBranch, p.PRURL, mission, false, nil), cfg)
 		s.insertAndLaunchWebhook(ctx, w, r, cfg, meta, healIdem, brancher, healVars, p.CloneURL, p.SourceBranch, payloadHash, srcIP)
+		return
+	}
+
+	// The closing half of the auto-heal loop. A heal is a means to ONE end:
+	// carry an ejected pull request back into the merge queue. Once the PR
+	// is queued again — by GitHub itself, by another PR merging ahead, or by
+	// an operator re-enqueuing it — the heal has no end left to serve, and
+	// its own delivery tail becomes destructive: it force-pushes the branch,
+	// which cancels the queue build in flight and ejects the PR a second
+	// time. So the heal is stopped the moment the queue takes the PR back.
+	//
+	// The trigger is the queue's own `enqueued` event rather than a poll, so
+	// the window between "queued again" and "the heal pushes" is closed by
+	// the same authority that opened the heal.
+	if p.IsRequeued() {
+		stopped := s.stopHealRunForRequeuedPR(ctx, cfg, p)
+		s.recordTerminalWebhookDelivery(ctx, cfg, meta, webhooks.StatusFiltered, payloadHash, srcIP,
+			fmt.Sprintf("pull request re-entered the merge queue; auto-heal runs stopped: %d", stopped))
+		writeJSONStatus(w, http.StatusOK, map[string]string{"status": webhooks.StatusFiltered})
 		return
 	}
 

--- a/pkg/server/webhooks_github_test.go
+++ b/pkg/server/webhooks_github_test.go
@@ -1260,3 +1260,85 @@ func TestGitHubWebhook_ReviewRequestedStoreErrorSalts(t *testing.T) {
 		t.Fatalf("store hiccup must salt and launch, not dedupe to a no-op: code=%d calls=%d body=%s", w.Code, calls, w.Body.String())
 	}
 }
+
+// ghEnqueuedPR: the same pull request entering (or re-entering) the merge
+// queue, at the head sha given. `enqueued` is the queue's own event, and
+// the closing half of the auto-heal loop.
+func ghEnqueuedPR(headSHA string) string {
+	return fmt.Sprintf(`{
+  "action": "enqueued", "number": 9,
+  "repository": {"id": 42, "full_name": "acme/widgets", "clone_url": "https://github.com/acme/widgets.git"},
+  "pull_request": {"number": 9, "title": "Add subtract", "body": "Implements subtraction.",
+    "html_url": "https://github.com/acme/widgets/pull/9", "state": "open",
+    "head": {"ref": "feat/subtract", "sha": %q, "repo": {"full_name": "acme/widgets"}},
+    "base": {"ref": "main", "repo": {"full_name": "acme/widgets"}}},
+  "sender": {"login": "alice"}
+}`, headSHA)
+}
+
+// A heal exists only to carry an ejected PR back into the merge queue. Once
+// the queue has taken it back the heal has nothing left to do, and letting
+// it finish is actively harmful: its delivery tail force-pushes the branch,
+// which cancels the queue build in flight and ejects the PR a second time.
+// Observed in production on iterion#682 (2026-09-04), where a flaky test
+// ejected a green PR and only a manual cancel kept the fixer's push from
+// killing the queue run that went on to merge it.
+func TestGitHubWebhook_RequeuedPRStopsTheHeal(t *testing.T) {
+	s := newWebhookTestServer(t)
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		return "run-heal", nil
+	}
+	var cancelled []string
+	s.webhookCancelRun = func(runID string) error { cancelled = append(cancelled, runID); return nil }
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"review-pr", "branch-improve-loop"}
+
+	// The ejection launches the heal.
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghDequeuedPR, prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("dequeue: code=%d body=%s", w.Code, w.Body.String())
+	}
+
+	// The queue takes the PR back at the SAME head — the heal never pushed,
+	// so nothing it could still do is wanted.
+	w = httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghEnqueuedPR("aaa111"), prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusOK {
+		t.Fatalf("enqueue: code=%d body=%s", w.Code, w.Body.String())
+	}
+	if len(cancelled) != 1 || cancelled[0] != "run-heal" {
+		t.Fatalf("a PR back in the merge queue must stop its auto-heal run before that run force-pushes over the queue build; cancelled=%v", cancelled)
+	}
+}
+
+// The stop is keyed on the HEAD, not on the pull request. A heal that has
+// already pushed advanced the head — and that push is what re-enqueued the
+// PR. Killing it on the enqueue it caused would abort the run at its
+// delivery tail, exactly when it is doing the thing this lane wants.
+func TestGitHubWebhook_RequeuedAtANewHeadSparesTheHeal(t *testing.T) {
+	s := newWebhookTestServer(t)
+	s.webhookLaunchBot = func(context.Context, string, map[string]string, string, string, string, map[string]string, map[string]string) (string, error) {
+		return "run-heal", nil
+	}
+	var cancelled []string
+	s.webhookCancelRun = func(runID string) error { cancelled = append(cancelled, runID); return nil }
+	cfg, pt := ghConfig(t, s)
+	cfg.BotIDs = []string{"review-pr", "branch-improve-loop"}
+
+	w := httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghDequeuedPR, prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("dequeue: code=%d body=%s", w.Code, w.Body.String())
+	}
+
+	// Re-queued at the head the heal's own push produced.
+	w = httptest.NewRecorder()
+	s.handleGitHubWebhook(w, ghReq(ghCtx(cfg), ghEnqueuedPR("bbb222"), prforge.EventHeaderPullRequest, pt))
+	if w.Code != http.StatusOK {
+		t.Fatalf("enqueue: code=%d body=%s", w.Code, w.Body.String())
+	}
+	if len(cancelled) != 0 {
+		t.Fatalf("an enqueue at a NEW head is the heal's own push landing — it must not cancel the run that produced it; cancelled=%v", cancelled)
+	}
+}

--- a/pkg/webhooks/prforge/parser.go
+++ b/pkg/webhooks/prforge/parser.go
@@ -76,6 +76,13 @@ func (p Parsed) NeedsAutoHeal() bool {
 	return p.Action == "dequeued" && healableDequeueReasons[p.DequeueReason]
 }
 
+// IsRequeued reports whether the pull request just (re-)entered the merge
+// queue. It is the closing half of NeedsAutoHeal: a heal exists only to
+// carry an ejected PR back into the queue, so a PR that is back in it has
+// nothing left to heal — and a heal still running would force-push over
+// the head the queue is building.
+func (p Parsed) IsRequeued() bool { return p.Action == "enqueued" }
+
 // ParsePullRequest decodes a pull_request webhook body from GitHub or
 // Forgejo/Gitea (one shared wire shape). We reject empty bodies / wrong
 // shapes early so the handler can return a clean 400 instead of crashing


### PR DESCRIPTION
## What was wrong

The auto-heal lane launches the brancher bot when the merge queue **ejects** a PR, so it rebases and pushes and the PR re-enters the queue. Nothing closed that loop. Once the PR **was** back in the queue, the heal kept running — and its delivery tail force-pushes the branch, which **cancels the queue build in flight and ejects the PR a second time.** The repair becomes the next breakage.

## How it showed up

Production, #682, 2026-09-04:

| time | event |
|---|---|
| 21:14:14Z | a flaky test in `pkg/dispatcher` — a package #682 does not touch — ejects a **green** PR with `CI_FAILURE` |
| 21:14:17Z | auto-heal launches the fixer (3 seconds later) |
| 21:22Z | the PR is re-enqueued; a queue build starts |
| — | the fixer's plan step concludes *"no code issue in the diff. This is a re-queue, not a fix"* — and its mission still tells it to rebase and `git push --force-with-lease` |
| 21:40Z | a **manual cancel** is what let the queue run finish; #682 merged |

Without that manual cancel the push would have killed the build that merged the PR.

## The fix

An `enqueued` delivery stops the heal launched for that PR's **current head**.

Keyed on the heal's own idempotency key rather than on `(project, subject)`, which buys two properties a broader scope would lose:

- a fixer a developer asked for with `/billy` rides a different key and is never touched;
- a heal that has **already pushed** advanced the head — and that push is what re-enqueued the PR — so the enqueue it caused does not match its own key, and the run is left to finish its delivery tail.

Both halves now derive the key through one helper (`healIdempotencyKey`): the launch that writes the delivery row and the stop that looks it up must agree byte for byte, and two copies of a format string drift.

Shaped on the existing `stopRunsForDeadPR` precedent — same store lookup, same disarm-then-cancel order, same fail-open `runIsStoppable` probe.

`enqueued` previously fell through to the default filtered branch, so no other action changes behaviour.

## Tests

Both verified non-vacuous by mutation:

- `TestGitHubWebhook_RequeuedPRStopsTheHeal` — red without the guard: `cancelled=[]`.
- `TestGitHubWebhook_RequeuedAtANewHeadSparesTheHeal` — red when the key loses its head scope.

`go test ./pkg/server/ ./pkg/webhooks/...` green, `-race` green on both touched packages, `task lint` 0 issues.

## What this deliberately does not fix

`CI_FAILURE` covers both "this branch breaks when combined with the base" and "an unrelated flaky test failed on the queue branch", and the webhook cannot tell them apart cheaply. The heal is still dispatched in the second case; it should report "nothing to fix" and push nothing, but it costs a run. The flaky test that triggered this is #692 — that is where that half belongs, and `docs/merge-gate.md` now says so.

Refs #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)