### PR TITLE
feat(sandbox/kubernetes): run pods carry resource requests and a soft node spread

### DIFF
--- a/charts/iterion/templates/runner-deployment.yaml
+++ b/charts/iterion/templates/runner-deployment.yaml
@@ -117,6 +117,37 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.uid
+            {{- with .Values.runner.sandbox.scheduling }}
+            # Scheduling policy stamped on every per-run sandbox pod — literal
+            # PodTemplate values for the same reason as the epoch above: a pod
+            # created from an old ReplicaSet must keep the policy it was rolled
+            # out with. Unset values are not rendered. See docs/sandbox.md
+            # § "Scheduling: requests and node spread".
+            {{- with .requests }}
+            {{- if .cpu }}
+            - name: ITERION_SANDBOX_K8S_REQUESTS_CPU
+              value: {{ .cpu | quote }}
+            {{- end }}
+            {{- if .memory }}
+            - name: ITERION_SANDBOX_K8S_REQUESTS_MEMORY
+              value: {{ .memory | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with .limits }}
+            {{- if .cpu }}
+            - name: ITERION_SANDBOX_K8S_LIMITS_CPU
+              value: {{ .cpu | quote }}
+            {{- end }}
+            {{- if .memory }}
+            - name: ITERION_SANDBOX_K8S_LIMITS_MEMORY
+              value: {{ .memory | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .spread }}
+            - name: ITERION_SANDBOX_K8S_SPREAD
+              value: {{ .spread | quote }}
+            {{- end }}
+            {{- end }}
             {{- end }}
             {{- if .Values.runner.cache.enabled }}
             # Point Go's module + build caches at the shared RWX volume so a

--- a/charts/iterion/values.yaml
+++ b/charts/iterion/values.yaml
@@ -206,6 +206,12 @@ config:
   # ConfigMap (both the server and runner deployments envFrom it).
   # e.g. TZ: Europe/Paris — the binary embeds the IANA tz database
   # (time/tzdata), so TZ works even in tzdata-less images.
+  # Also the home of the kubernetes sandbox driver's scheduling policy for
+  # the per-run pods (docs/sandbox.md § "Scheduling: requests and node
+  # spread"): ITERION_SANDBOX_K8S_REQUESTS_CPU / _REQUESTS_MEMORY /
+  # _LIMITS_CPU / _LIMITS_MEMORY (Kubernetes quantities) and
+  # ITERION_SANDBOX_K8S_SPREAD (hostname | none | <topology key>). Without a
+  # request every run pod scores every node the same and they pile onto one.
   extraEnv: {}
   log:
     format: json

--- a/charts/iterion/values.yaml
+++ b/charts/iterion/values.yaml
@@ -149,6 +149,27 @@ runner:
   # sandbox feature; turn on per-environment via values-prod.yaml.
   sandbox:
     enabled: false
+    # Scheduling policy the kubernetes sandbox driver stamps on every
+    # per-run sandbox pod, rendered as LITERAL env on the runner PodTemplate
+    # (a pod from an old ReplicaSet keeps the policy it was rolled out
+    # with). Empty = not rendered: the pods request nothing and, on a
+    # multi-node cluster, pile onto the node that already holds the image
+    # (measured: 5 of 6 runs on one 8-core worker at 89 % CPU). Set at
+    # least the requests on any multi-node cluster — e.g. requests cpu "2",
+    # memory "4Gi", spread "hostname" — and bump config.rollout.runnerEpoch
+    # with the rollout like any runner change. Values are Kubernetes
+    # quantities; the runner refuses to start on a malformed one. See
+    # docs/sandbox.md § "Scheduling: requests and node spread".
+    scheduling:
+      requests:
+        cpu: ""
+        memory: ""
+      limits:
+        cpu: ""
+        memory: ""
+      # "" or "none" = no spread constraint; "hostname" = soft spread across
+      # nodes; or a prefixed label key every node carries.
+      spread: ""
   # --- Persistent build cache (warm runner pods) --------------------
   # A bot's verify gate re-clones the target repo per run into an
   # ephemeral workdir, so a fresh/scaled-up runner pod otherwise
@@ -206,12 +227,9 @@ config:
   # ConfigMap (both the server and runner deployments envFrom it).
   # e.g. TZ: Europe/Paris — the binary embeds the IANA tz database
   # (time/tzdata), so TZ works even in tzdata-less images.
-  # Also the home of the kubernetes sandbox driver's scheduling policy for
-  # the per-run pods (docs/sandbox.md § "Scheduling: requests and node
-  # spread"): ITERION_SANDBOX_K8S_REQUESTS_CPU / _REQUESTS_MEMORY /
-  # _LIMITS_CPU / _LIMITS_MEMORY (Kubernetes quantities) and
-  # ITERION_SANDBOX_K8S_SPREAD (hostname | none | <topology key>). Without a
-  # request every run pod scores every node the same and they pile onto one.
+  # NOT the place for generation-sensitive runner settings (the epoch, the
+  # sandbox pod scheduling policy): those are literal PodTemplate values —
+  # see runner.sandbox.scheduling.
   extraEnv: {}
   log:
     format: json

--- a/cmd/iterion/runner.go
+++ b/cmd/iterion/runner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/SocialGouv/iterion/pkg/platformcfg"
 	natsq "github.com/SocialGouv/iterion/pkg/queue/nats"
 	"github.com/SocialGouv/iterion/pkg/runner"
+	k8ssandbox "github.com/SocialGouv/iterion/pkg/sandbox/kubernetes"
 	"github.com/SocialGouv/iterion/pkg/secrets"
 	mongostore "github.com/SocialGouv/iterion/pkg/store/mongo"
 	"github.com/SocialGouv/iterion/pkg/usagecap"
@@ -287,6 +288,14 @@ func runRunner(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("runner: build events bus: %w", err)
 	}
+	// A malformed sandbox scheduling policy must stop the rollout here, before
+	// the consumer exists and the epoch mark advances: the sandbox driver
+	// factory skips constructor errors, so nothing downstream can refuse it —
+	// every run would fail at sandbox start instead.
+	if err := k8ssandbox.ValidateSchedulingEnv(); err != nil {
+		return fmt.Errorf("runner: sandbox scheduling policy: %w", err)
+	}
+
 	// Prove the durable consumer can be created before advancing the rollout
 	// high-water mark. The handle is inert until Runner.Run starts fetching.
 	preparedConsumer, err := natsConn.PrepareConsumer(rootCtx)

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -867,8 +867,11 @@ gates: the runner refuses to start (`runner: sandbox scheduling policy: …`,
 before it claims the rollout epoch — the driver factory skips constructor
 errors, so the driver cannot refuse for it), `iterion sandbox doctor` (basic
 and `--strict`) reports the policy in force or that error — `--strict` also
-checks that the nodes carry a custom spread key — and every `Start` returns
-it. Accept a rollout on the **admitted** pod (`kubectl get pod … -o
+checks that the nodes carry a custom spread key, which needs `nodes/list`, a
+cluster-scoped permission the chart's namespaced runner Role does not grant on
+purpose: in-cluster the check warns with kubectl's reason and the operator runs
+`kubectl get nodes -L <key>` from a context that can — and every `Start`
+returns it. Accept a rollout on the **admitted** pod (`kubectl get pod … -o
 jsonpath='{.spec.containers[0].resources}{.spec.topologySpreadConstraints}'`),
 then on a burst of runs: placement skew, `PodScheduled` reasons, start
 latency. A pod that never becomes Ready reports its `PodScheduled` condition

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -832,23 +832,48 @@ scheduler packs a campaign's runs onto whichever node already holds the
 sandbox image (image locality is the tie-breaker). Measured on a three-worker
 pool: five of six run pods on one 8-core node at 89 % CPU while two workers
 idled, and an oracle's 300 s application boot budget blown at 459 s. The
-driver therefore renders a deployment-level scheduling policy on every pod it
-creates, read from the runner's environment once at startup:
+driver therefore stamps a deployment-level scheduling policy on every pod it
+creates, read from the runner's environment once at startup — wired through
+the chart's `runner.sandbox.scheduling` values, which render as **literal
+PodTemplate env** (never the shared ConfigMap: a pod created from an old
+ReplicaSet must keep the policy it was rolled out with, the same reason the
+epoch is literal — bump `config.rollout.runnerEpoch` with the rollout like any
+runner change):
 
 | Env var | Effect |
 |---|---|
-| `ITERION_SANDBOX_K8S_REQUESTS_CPU` / `…_REQUESTS_MEMORY` | `resources.requests` of the workload container (Kubernetes quantities, e.g. `2`, `4Gi`). Unset → not rendered. |
-| `ITERION_SANDBOX_K8S_LIMITS_CPU` / `…_LIMITS_MEMORY` | `resources.limits`. Unset → not rendered (a run must be able to burst on a build). |
-| `ITERION_SANDBOX_K8S_SPREAD` | Topology key of a **soft** `topologySpreadConstraints` (maxSkew 1, `ScheduleAnyway`) over all `iterion.io/component=sandbox-run` pods. `hostname` (default) → `kubernetes.io/hostname`; `none` → no constraint; any other value is used verbatim (e.g. `topology.kubernetes.io/zone`). |
+| `ITERION_SANDBOX_K8S_REQUESTS_CPU` / `…_REQUESTS_MEMORY` | `resources.requests` of the workload container. Unset → not rendered. |
+| `ITERION_SANDBOX_K8S_LIMITS_CPU` / `…_LIMITS_MEMORY` | `resources.limits`. Unset → not rendered (a run must be able to burst on a build). A limit needs its request (the API server would otherwise copy the limit into the request at admission) and cannot be below it. |
+| `ITERION_SANDBOX_K8S_SPREAD` | Topology key of a **soft** `topologySpreadConstraints` (maxSkew 1, `ScheduleAnyway`) over every `iterion.io/component=sandbox-run` pod of the namespace. Unset / `none` / `off` → no constraint (the default: the scheduler's own policy, as before). `hostname` → `kubernetes.io/hostname`. Any other value must be a **prefixed** label key the nodes carry (e.g. `topology.kubernetes.io/zone`) — a bare word is refused, because the API server would accept it as a label no node has; and a soft constraint does **not** waive the label: nodes without it are excluded, a key no node carries leaves every run Pending. |
 
-The request is the floor a run needs to be co-scheduled sanely — it is what
-makes `LeastAllocated` spread the pods and what a cluster autoscaler sizes the
-pool on; the spread steers what equal requests leave equal. It is a policy of
-the deployment, not of the workflow: a bot cannot lower it. A malformed value
-is refused with the variable and the value named — on every `Start`, not in
-the constructor, because the driver factory skips any constructor error and
-would otherwise fall through to the noop driver in silence. Wire the values
-through the chart's `config.extraEnv` (rendered into the shared ConfigMap).
+Quantities are the subset operators write — a decimal (`2`, `.5`, `500m`),
+an exponent, or the SI/binary byte suffixes (`4Gi`); `m` on memory
+(milli-bytes) and a byte suffix on CPU are refused, as are zero quantities
+(a block that schedules like no block). The API server owns the rest.
+
+**Nothing is shipped by default.** Measured on a three-worker cluster with the
+image on one node only: no requests → 2/3/1, requests alone → 2/2/2, requests
+plus spread → 2/2/2 — the request is the half that moves the pods (it is what
+`LeastAllocated` scores and what a cluster autoscaler sizes the pool on); the
+spread steers what equal requests leave equal. Set at least the requests on any
+multi-node cluster. It is a policy of the deployment, not of the workflow: a
+bot cannot lower it. It is also a policy of the **attempt**: a resume
+force-deletes and re-creates the pod under the policy of the runner that
+claims it, so during a rollout the two fleets may render one run differently —
+every `sandbox_started` event records the policy the pod was rendered under.
+
+A malformed value is refused with the variable and the value named at **three**
+gates: the runner refuses to start (`runner: sandbox scheduling policy: …`,
+before it claims the rollout epoch — the driver factory skips constructor
+errors, so the driver cannot refuse for it), `iterion sandbox doctor` (basic
+and `--strict`) reports the policy in force or that error — `--strict` also
+checks that the nodes carry a custom spread key — and every `Start` returns
+it. Accept a rollout on the **admitted** pod (`kubectl get pod … -o
+jsonpath='{.spec.containers[0].resources}{.spec.topologySpreadConstraints}'`),
+then on a burst of runs: placement skew, `PodScheduled` reasons, start
+latency. A pod that never becomes Ready reports its `PodScheduled` condition
+in the error, so a request no node can hold reads differently from a slow
+image pull.
 
 Security defaults applied to every sibling pod:
 

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -825,6 +825,31 @@ TTL. Three cooperating mechanisms GC them without relying on `Cleanup`:
     plaintext-credential Secret would otherwise leak until the next rollout).
     Cadence: `ITERION_SANDBOX_REAP_INTERVAL` (default 60s; `0` = boot scan only).
 
+#### Scheduling: requests and node spread
+
+A sibling pod that requests nothing scores every node the same, so the
+scheduler packs a campaign's runs onto whichever node already holds the
+sandbox image (image locality is the tie-breaker). Measured on a three-worker
+pool: five of six run pods on one 8-core node at 89 % CPU while two workers
+idled, and an oracle's 300 s application boot budget blown at 459 s. The
+driver therefore renders a deployment-level scheduling policy on every pod it
+creates, read from the runner's environment once at startup:
+
+| Env var | Effect |
+|---|---|
+| `ITERION_SANDBOX_K8S_REQUESTS_CPU` / `…_REQUESTS_MEMORY` | `resources.requests` of the workload container (Kubernetes quantities, e.g. `2`, `4Gi`). Unset → not rendered. |
+| `ITERION_SANDBOX_K8S_LIMITS_CPU` / `…_LIMITS_MEMORY` | `resources.limits`. Unset → not rendered (a run must be able to burst on a build). |
+| `ITERION_SANDBOX_K8S_SPREAD` | Topology key of a **soft** `topologySpreadConstraints` (maxSkew 1, `ScheduleAnyway`) over all `iterion.io/component=sandbox-run` pods. `hostname` (default) → `kubernetes.io/hostname`; `none` → no constraint; any other value is used verbatim (e.g. `topology.kubernetes.io/zone`). |
+
+The request is the floor a run needs to be co-scheduled sanely — it is what
+makes `LeastAllocated` spread the pods and what a cluster autoscaler sizes the
+pool on; the spread steers what equal requests leave equal. It is a policy of
+the deployment, not of the workflow: a bot cannot lower it. A malformed value
+is refused with the variable and the value named — on every `Start`, not in
+the constructor, because the driver factory skips any constructor error and
+would otherwise fall through to the noop driver in silence. Wire the values
+through the chart's `config.extraEnv` (rendered into the shared ConfigMap).
+
 Security defaults applied to every sibling pod:
 
 | Setting                          | Value                              |

--- a/pkg/cli/sandbox.go
+++ b/pkg/cli/sandbox.go
@@ -73,9 +73,18 @@ func runSandboxDoctorBasic(p *Printer) error {
 	driver, driverErr := factory.Driver()
 	caps := sandbox.Capabilities{}
 	driverName := "<none>"
+	schedulingPolicy := ""
+	var schedulingErr error
 	if driver != nil {
 		driverName = driver.Name()
 		caps = driver.Capabilities()
+		if r, ok := driver.(sandbox.SchedulingPolicyReporter); ok {
+			schedulingPolicy, schedulingErr = r.SchedulingPolicy()
+			if schedulingErr != nil {
+				// The same error every run would hit at sandbox start.
+				schedulingPolicy = "INVALID: " + schedulingErr.Error()
+			}
+		}
 	}
 
 	containerRuntime := sandbox.HostHasDocker()
@@ -103,6 +112,7 @@ func runSandboxDoctorBasic(p *Printer) error {
 		"sandbox_default":     defaultMode,
 		"selected_driver":     driverName,
 		"available_drivers":   factory.Available(),
+		"scheduling_policy":   schedulingPolicy,
 		"iterion_binary":      binPath,
 		"iterion_binary_link": binLink.String(),
 		"capabilities": map[string]bool{

--- a/pkg/cli/sandbox_strict.go
+++ b/pkg/cli/sandbox_strict.go
@@ -312,7 +312,7 @@ func runSchedulingPolicyStrictCheck(report *SandboxStrictReport, driver sandbox.
 	policy, err := r.SchedulingPolicy()
 	if err != nil {
 		report.add("sandbox scheduling policy", CheckFail, err.Error(),
-			"fix the ITERION_SANDBOX_K8S_* value in the runner environment (chart config.extraEnv) — every run would fail at sandbox start")
+			"fix the ITERION_SANDBOX_K8S_* value in the runner environment (chart runner.sandbox.scheduling — not config.extraEnv: its ConfigMap value loses to the literal PodTemplate env) — every run would fail at sandbox start")
 		return
 	}
 	report.add("sandbox scheduling policy", CheckPass, policy, "")
@@ -357,7 +357,10 @@ func runK8sStrictChecks(ctx context.Context, report *SandboxStrictReport, spec *
 
 // runSpreadCoverageStrictCheck compares the nodes carrying the spread key to
 // the cluster's nodes. kubernetes.io/hostname needs no check: every node
-// carries it by construction.
+// carries it by construction. Listing nodes is cluster-scoped and the
+// chart's runner Role is namespace-scoped on purpose, so in-cluster the
+// check cannot answer: it warns with kubectl's reason and hands the
+// operator the command to run from a context that can.
 func runSpreadCoverageStrictCheck(ctx context.Context, report *SandboxStrictReport, key string) {
 	if key == "" || key == "kubernetes.io/hostname" {
 		return
@@ -368,7 +371,7 @@ func runSpreadCoverageStrictCheck(ctx context.Context, report *SandboxStrictRepo
 	switch {
 	case err != nil:
 		report.add("k8s spread key coverage", CheckWarn, err.Error(),
-			"could not list nodes; verify that every schedulable node carries the label "+key)
+			"could not list nodes (the chart's runner Role is namespace-scoped and grants no nodes/list); from an operator context run `kubectl get nodes -L "+key+"` and check every schedulable node carries the label")
 	case total == 0:
 		report.add("k8s spread key coverage", CheckWarn, "no node visible", "verify RBAC on nodes/list, then that every schedulable node carries the label "+key)
 	case labelled == 0:

--- a/pkg/cli/sandbox_strict.go
+++ b/pkg/cli/sandbox_strict.go
@@ -371,14 +371,15 @@ func runSpreadCoverageStrictCheck(ctx context.Context, report *SandboxStrictRepo
 	switch {
 	case err != nil:
 		// The cause is asserted only when the cluster (or the probe) said it:
-		// a Forbidden is the chart's namespaced Role, a deadline is the probe
-		// budget; anything else stays what kubectl said.
+		// a Forbidden is the chart's namespaced Role — the cluster's own word,
+		// checked first even when the probe also ran out of time — a deadline
+		// is the probe budget; anything else stays what kubectl said.
 		var cause string
 		switch {
-		case errors.Is(probeCtx.Err(), context.DeadlineExceeded):
-			cause = "the node list did not answer within " + doctorProbeTimeout().String() + " (ITERION_SANDBOX_DOCTOR_TIMEOUT raises it); "
 		case strings.Contains(err.Error(), "Forbidden"):
 			cause = "the chart's runner Role is namespace-scoped and grants no nodes/list on purpose; "
+		case errors.Is(probeCtx.Err(), context.DeadlineExceeded):
+			cause = "the node list did not answer within " + doctorProbeTimeout().String() + " (ITERION_SANDBOX_DOCTOR_TIMEOUT raises it); "
 		default:
 			cause = "could not list nodes; "
 		}

--- a/pkg/cli/sandbox_strict.go
+++ b/pkg/cli/sandbox_strict.go
@@ -150,6 +150,7 @@ func buildStrictReport(ctx context.Context, wf *ir.Workflow, opts SandboxDoctorO
 	} else {
 		report.add("driver available", CheckPass, "selected driver: "+driverName, "")
 	}
+	runSchedulingPolicyStrictCheck(report, driver)
 
 	// 3. Spec internal validity (pure, driver-agnostic).
 	if vErr := spec.Validate(); vErr != nil {
@@ -165,7 +166,7 @@ func buildStrictReport(ctx context.Context, wf *ir.Workflow, opts SandboxDoctorO
 	case "docker":
 		runDockerStrictChecks(ctx, report, spec)
 	case "kubernetes":
-		runK8sStrictChecks(ctx, report, spec, driverName)
+		runK8sStrictChecks(ctx, report, spec, driverName, driver)
 	}
 
 	// 6. Network allowlist syntax (driver-agnostic).
@@ -298,7 +299,26 @@ func runDockerStrictChecks(ctx context.Context, report *SandboxStrictReport, spe
 	}
 }
 
-func runK8sStrictChecks(ctx context.Context, report *SandboxStrictReport, spec *sandbox.Spec, driverName string) {
+// runSchedulingPolicyStrictCheck reports the scheduling policy a driver
+// stamps on its sandboxes. The driver parses it from the environment at
+// construction and, when it is malformed, fails every run at sandbox start
+// — never the constructor, which the factory would skip in silence. The
+// doctor is where that error must show before the first run pays for it.
+func runSchedulingPolicyStrictCheck(report *SandboxStrictReport, driver sandbox.Driver) {
+	r, ok := driver.(sandbox.SchedulingPolicyReporter)
+	if !ok {
+		return
+	}
+	policy, err := r.SchedulingPolicy()
+	if err != nil {
+		report.add("sandbox scheduling policy", CheckFail, err.Error(),
+			"fix the ITERION_SANDBOX_K8S_* value in the runner environment (chart config.extraEnv) — every run would fail at sandbox start")
+		return
+	}
+	report.add("sandbox scheduling policy", CheckPass, policy, "")
+}
+
+func runK8sStrictChecks(ctx context.Context, report *SandboxStrictReport, spec *sandbox.Spec, driverName string, driver sandbox.Driver) {
 	if vErr := kubernetes.ValidateSpec(*spec); vErr != nil {
 		report.add("k8s spec compatible", CheckFail, vErr.Error(),
 			"for cloud: pin sandbox.image (no build:), set host_state: none, set a numeric sandbox.user")
@@ -318,12 +338,47 @@ func runK8sStrictChecks(ctx context.Context, report *SandboxStrictReport, spec *
 			remediation = "select a context (`kubectl config use-context <name>`) or verify the in-cluster service account + API reachability"
 		}
 		report.add("k8s context", status, err.Error(), remediation)
-	} else {
-		detail := "context: " + kctx
-		if ns != "" {
-			detail += " (namespace: " + ns + ")"
-		}
-		report.add("k8s context", CheckPass, detail, "")
+		return
+	}
+	detail := "context: " + kctx
+	if ns != "" {
+		detail += " (namespace: " + ns + ")"
+	}
+	report.add("k8s context", CheckPass, detail, "")
+
+	// A spread over a topology key the nodes do not carry excludes those
+	// nodes from scheduling — a soft constraint does not waive the label —
+	// and a key no node carries leaves every run Pending. Only a reachable
+	// cluster can answer, hence after the ping.
+	if kd, ok := driver.(*kubernetes.Driver); ok {
+		runSpreadCoverageStrictCheck(ctx, report, kd.SpreadTopologyKey())
+	}
+}
+
+// runSpreadCoverageStrictCheck compares the nodes carrying the spread key to
+// the cluster's nodes. kubernetes.io/hostname needs no check: every node
+// carries it by construction.
+func runSpreadCoverageStrictCheck(ctx context.Context, report *SandboxStrictReport, key string) {
+	if key == "" || key == "kubernetes.io/hostname" {
+		return
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, doctorProbeTimeout())
+	defer cancel()
+	labelled, total, err := kubernetes.NodeLabelCoverage(probeCtx, key)
+	switch {
+	case err != nil:
+		report.add("k8s spread key coverage", CheckWarn, err.Error(),
+			"could not list nodes; verify that every schedulable node carries the label "+key)
+	case total == 0:
+		report.add("k8s spread key coverage", CheckWarn, "no node visible", "verify RBAC on nodes/list, then that every schedulable node carries the label "+key)
+	case labelled == 0:
+		report.add("k8s spread key coverage", CheckFail, fmt.Sprintf("no node carries %s (%d nodes)", key, total),
+			"every run pod would stay Pending — set ITERION_SANDBOX_K8S_SPREAD to hostname or to a label the nodes carry")
+	case labelled < total:
+		report.add("k8s spread key coverage", CheckWarn, fmt.Sprintf("%d of %d nodes carry %s", labelled, total, key),
+			"nodes without the label are excluded from run pod scheduling; label them or use hostname")
+	default:
+		report.add("k8s spread key coverage", CheckPass, fmt.Sprintf("%d of %d nodes carry %s", labelled, total, key), "")
 	}
 }
 

--- a/pkg/cli/sandbox_strict.go
+++ b/pkg/cli/sandbox_strict.go
@@ -370,10 +370,23 @@ func runSpreadCoverageStrictCheck(ctx context.Context, report *SandboxStrictRepo
 	labelled, total, err := kubernetes.NodeLabelCoverage(probeCtx, key)
 	switch {
 	case err != nil:
+		// The cause is asserted only when the cluster (or the probe) said it:
+		// a Forbidden is the chart's namespaced Role, a deadline is the probe
+		// budget; anything else stays what kubectl said.
+		var cause string
+		switch {
+		case errors.Is(probeCtx.Err(), context.DeadlineExceeded):
+			cause = "the node list did not answer within " + doctorProbeTimeout().String() + " (ITERION_SANDBOX_DOCTOR_TIMEOUT raises it); "
+		case strings.Contains(err.Error(), "Forbidden"):
+			cause = "the chart's runner Role is namespace-scoped and grants no nodes/list on purpose; "
+		default:
+			cause = "could not list nodes; "
+		}
 		report.add("k8s spread key coverage", CheckWarn, err.Error(),
-			"could not list nodes (the chart's runner Role is namespace-scoped and grants no nodes/list); from an operator context run `kubectl get nodes -L "+key+"` and check every schedulable node carries the label")
+			cause+"from an operator context run `kubectl get nodes -L "+key+"` and check every schedulable node carries the label")
 	case total == 0:
-		report.add("k8s spread key coverage", CheckWarn, "no node visible", "verify RBAC on nodes/list, then that every schedulable node carries the label "+key)
+		report.add("k8s spread key coverage", CheckWarn, "no node visible",
+			"the list answered with no node — check the context points at the right cluster, then from an operator context run `kubectl get nodes -L "+key+"` and check every schedulable node carries the label")
 	case labelled == 0:
 		report.add("k8s spread key coverage", CheckFail, fmt.Sprintf("no node carries %s (%d nodes)", key, total),
 			"every run pod would stay Pending — set ITERION_SANDBOX_K8S_SPREAD to hostname or to a label the nodes carry")

--- a/pkg/cli/sandbox_strict_test.go
+++ b/pkg/cli/sandbox_strict_test.go
@@ -213,6 +213,12 @@ func TestRunSchedulingPolicyStrictCheck(t *testing.T) {
 		if !strings.Contains(r.Checks[0].Detail, "ITERION_SANDBOX_K8S_REQUESTS_CPU") {
 			t.Fatalf("the failure must name the variable, got %+v", r.Checks[0])
 		}
+		// The knobs are literal PodTemplate env from runner.sandbox.scheduling;
+		// a value fixed in config.extraEnv (the shared ConfigMap) is lost to
+		// them — the remediation must send the operator to the right place.
+		if hint := r.Checks[0].Remediation; !strings.Contains(hint, "runner.sandbox.scheduling") || strings.Contains(hint, "(chart config.extraEnv)") {
+			t.Fatalf("the remediation must point at runner.sandbox.scheduling, got %q", hint)
+		}
 	})
 	t.Run("valid policy passes with its summary", func(t *testing.T) {
 		r := &SandboxStrictReport{}
@@ -261,6 +267,27 @@ func TestRunSpreadCoverageStrictCheck(t *testing.T) {
 		runSpreadCoverageStrictCheck(context.Background(), r, "topology.kubernetes.io/zone")
 		if r.Failed() || len(r.Checks) != 1 || r.Checks[0].Status != CheckWarn || !strings.Contains(r.Checks[0].Detail, "2 of 3") {
 			t.Fatalf("expected a 2 of 3 warning, got %+v", r.Checks)
+		}
+	})
+	// In-cluster the runner's namespaced Role cannot list nodes: the check
+	// must say why it could not answer and what to run instead.
+	t.Run("list refused warns with the reason and the operator command", func(t *testing.T) {
+		dir := t.TempDir()
+		script := "#!/bin/sh\necho 'Error from server (Forbidden): nodes is forbidden: User \"system:serviceaccount:ns:runner\" cannot list resource \"nodes\" in API group \"\" at the cluster scope' >&2\nexit 1\n"
+		if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+		r := &SandboxStrictReport{}
+		runSpreadCoverageStrictCheck(context.Background(), r, "example.com/rack")
+		if r.Failed() || len(r.Checks) != 1 || r.Checks[0].Status != CheckWarn {
+			t.Fatalf("expected one warning, got %+v", r.Checks)
+		}
+		if !strings.Contains(r.Checks[0].Detail, "Forbidden") {
+			t.Fatalf("the warning must carry kubectl's reason, got %+v", r.Checks[0])
+		}
+		if !strings.Contains(r.Checks[0].Remediation, "kubectl get nodes -L example.com/rack") {
+			t.Fatalf("the remediation must hand over the operator command, got %+v", r.Checks[0])
 		}
 	})
 }

--- a/pkg/cli/sandbox_strict_test.go
+++ b/pkg/cli/sandbox_strict_test.go
@@ -269,25 +269,63 @@ func TestRunSpreadCoverageStrictCheck(t *testing.T) {
 			t.Fatalf("expected a 2 of 3 warning, got %+v", r.Checks)
 		}
 	})
-	// In-cluster the runner's namespaced Role cannot list nodes: the check
-	// must say why it could not answer and what to run instead.
-	t.Run("list refused warns with the reason and the operator command", func(t *testing.T) {
+	// The cause is asserted only when known: in-cluster the runner's
+	// namespaced Role cannot list nodes (Forbidden), a slow cluster exhausts
+	// the probe budget, anything else stays what kubectl said — and every
+	// case hands over the operator command.
+	failingKubectl := func(t *testing.T, script string) {
+		t.Helper()
 		dir := t.TempDir()
-		script := "#!/bin/sh\necho 'Error from server (Forbidden): nodes is forbidden: User \"system:serviceaccount:ns:runner\" cannot list resource \"nodes\" in API group \"\" at the cluster scope' >&2\nexit 1\n"
 		if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
 			t.Fatal(err)
 		}
 		t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
-		r := &SandboxStrictReport{}
-		runSpreadCoverageStrictCheck(context.Background(), r, "example.com/rack")
+	}
+	oneWarning := func(t *testing.T, r *SandboxStrictReport) SandboxCheck {
+		t.Helper()
 		if r.Failed() || len(r.Checks) != 1 || r.Checks[0].Status != CheckWarn {
 			t.Fatalf("expected one warning, got %+v", r.Checks)
 		}
-		if !strings.Contains(r.Checks[0].Detail, "Forbidden") {
-			t.Fatalf("the warning must carry kubectl's reason, got %+v", r.Checks[0])
-		}
 		if !strings.Contains(r.Checks[0].Remediation, "kubectl get nodes -L example.com/rack") {
 			t.Fatalf("the remediation must hand over the operator command, got %+v", r.Checks[0])
+		}
+		return r.Checks[0]
+	}
+	t.Run("list forbidden names the chart's Role", func(t *testing.T) {
+		failingKubectl(t, "#!/bin/sh\necho 'Error from server (Forbidden): nodes is forbidden: User \"system:serviceaccount:ns:runner\" cannot list resource \"nodes\" in API group \"\" at the cluster scope' >&2\nexit 1\n")
+		r := &SandboxStrictReport{}
+		runSpreadCoverageStrictCheck(context.Background(), r, "example.com/rack")
+		c := oneWarning(t, r)
+		if !strings.Contains(c.Detail, "Forbidden") || !strings.Contains(c.Remediation, "namespace-scoped") {
+			t.Fatalf("a Forbidden must be explained by the namespaced Role, got %+v", c)
+		}
+	})
+	t.Run("list timeout names the probe budget, not RBAC", func(t *testing.T) {
+		failingKubectl(t, "#!/bin/sh\nsleep 5\n")
+		t.Setenv("ITERION_SANDBOX_DOCTOR_TIMEOUT", "200ms")
+		r := &SandboxStrictReport{}
+		runSpreadCoverageStrictCheck(context.Background(), r, "example.com/rack")
+		c := oneWarning(t, r)
+		if !strings.Contains(c.Remediation, "did not answer within 200ms") || strings.Contains(c.Remediation, "namespace-scoped") {
+			t.Fatalf("a timed-out probe must be named as such, got %+v", c)
+		}
+	})
+	t.Run("other list errors keep kubectl's reason and claim no cause", func(t *testing.T) {
+		failingKubectl(t, "#!/bin/sh\necho 'Unable to connect to the server: dial tcp 10.0.0.1:443: i/o timeout' >&2\nexit 1\n")
+		r := &SandboxStrictReport{}
+		runSpreadCoverageStrictCheck(context.Background(), r, "example.com/rack")
+		c := oneWarning(t, r)
+		if !strings.Contains(c.Detail, "Unable to connect") || strings.Contains(c.Remediation, "namespace-scoped") || strings.Contains(c.Remediation, "did not answer") {
+			t.Fatalf("an unknown cause must not be asserted, got %+v", c)
+		}
+	})
+	t.Run("an empty node list does not blame RBAC", func(t *testing.T) {
+		kubectlNodesShim(t, `{"items":[]}`)
+		r := &SandboxStrictReport{}
+		runSpreadCoverageStrictCheck(context.Background(), r, "example.com/rack")
+		c := oneWarning(t, r)
+		if strings.Contains(c.Remediation, "RBAC") || !strings.Contains(c.Remediation, "right cluster") {
+			t.Fatalf("a successful empty list is a context problem, not RBAC, got %+v", c)
 		}
 	})
 }

--- a/pkg/cli/sandbox_strict_test.go
+++ b/pkg/cli/sandbox_strict_test.go
@@ -301,13 +301,23 @@ func TestRunSpreadCoverageStrictCheck(t *testing.T) {
 		}
 	})
 	t.Run("list timeout names the probe budget, not RBAC", func(t *testing.T) {
-		failingKubectl(t, "#!/bin/sh\nsleep 5\n")
+		failingKubectl(t, "#!/bin/sh\nexec sleep 5\n")
 		t.Setenv("ITERION_SANDBOX_DOCTOR_TIMEOUT", "200ms")
 		r := &SandboxStrictReport{}
 		runSpreadCoverageStrictCheck(context.Background(), r, "example.com/rack")
 		c := oneWarning(t, r)
 		if !strings.Contains(c.Remediation, "did not answer within 200ms") || strings.Contains(c.Remediation, "namespace-scoped") {
 			t.Fatalf("a timed-out probe must be named as such, got %+v", c)
+		}
+	})
+	t.Run("a Forbidden written before the deadline still names the Role", func(t *testing.T) {
+		failingKubectl(t, "#!/bin/sh\necho 'Error from server (Forbidden): nodes is forbidden' >&2\nexec sleep 5\n")
+		t.Setenv("ITERION_SANDBOX_DOCTOR_TIMEOUT", "200ms")
+		r := &SandboxStrictReport{}
+		runSpreadCoverageStrictCheck(context.Background(), r, "example.com/rack")
+		c := oneWarning(t, r)
+		if !strings.Contains(c.Detail, "Forbidden") || !strings.Contains(c.Remediation, "namespace-scoped") || strings.Contains(c.Remediation, "did not answer") {
+			t.Fatalf("the cluster's own word must win over the inferred deadline, got %+v", c)
 		}
 	})
 	t.Run("other list errors keep kubectl's reason and claim no cause", func(t *testing.T) {

--- a/pkg/cli/sandbox_strict_test.go
+++ b/pkg/cli/sandbox_strict_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -180,6 +182,87 @@ func (f fakeDriver) Prepare(context.Context, sandbox.Spec) (sandbox.PreparedSpec
 }
 func (f fakeDriver) Start(context.Context, sandbox.PreparedSpec, sandbox.RunInfo) (sandbox.Run, error) {
 	return nil, nil
+}
+
+// fakePolicyDriver is a fakeDriver that also reports a scheduling policy,
+// the way the kubernetes driver does.
+type fakePolicyDriver struct {
+	fakeDriver
+	policy string
+	err    error
+}
+
+func (f fakePolicyDriver) SchedulingPolicy() (string, error) { return f.policy, f.err }
+
+// A malformed policy fails every run at sandbox start, never the
+// constructor — the doctor must surface it as a FAIL naming the cause.
+func TestRunSchedulingPolicyStrictCheck(t *testing.T) {
+	t.Run("driver without a policy adds nothing", func(t *testing.T) {
+		r := &SandboxStrictReport{}
+		runSchedulingPolicyStrictCheck(r, fakeDriver{name: "fake"})
+		if len(r.Checks) != 0 {
+			t.Fatalf("expected no check, got %+v", r.Checks)
+		}
+	})
+	t.Run("malformed policy fails", func(t *testing.T) {
+		r := &SandboxStrictReport{}
+		runSchedulingPolicyStrictCheck(r, fakePolicyDriver{err: errors.New("kubernetes: ITERION_SANDBOX_K8S_REQUESTS_CPU=\"two\" is not a Kubernetes quantity")})
+		if !hasFailNamed(r, "sandbox scheduling policy") {
+			t.Fatalf("expected a scheduling policy failure, got %+v", r.Checks)
+		}
+		if !strings.Contains(r.Checks[0].Detail, "ITERION_SANDBOX_K8S_REQUESTS_CPU") {
+			t.Fatalf("the failure must name the variable, got %+v", r.Checks[0])
+		}
+	})
+	t.Run("valid policy passes with its summary", func(t *testing.T) {
+		r := &SandboxStrictReport{}
+		runSchedulingPolicyStrictCheck(r, fakePolicyDriver{policy: "requests cpu=2 memory=4Gi, spread=kubernetes.io/hostname"})
+		if r.Failed() || len(r.Checks) != 1 || r.Checks[0].Detail != "requests cpu=2 memory=4Gi, spread=kubernetes.io/hostname" {
+			t.Fatalf("expected one passing check carrying the summary, got %+v", r.Checks)
+		}
+	})
+}
+
+// kubectlNodesShim puts a fake `kubectl` first on PATH whose `get nodes -o json`
+// answers with the given node labels.
+func kubectlNodesShim(t *testing.T, nodesJSON string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\ncase \"$*\" in \"get nodes \"*) printf '%s' '" + nodesJSON + "'; exit 0 ;; esac\nexit 1\n"
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// A spread over a label the nodes do not carry excludes them from scheduling
+// — soft or not — so the doctor must say which nodes carry it.
+func TestRunSpreadCoverageStrictCheck(t *testing.T) {
+	threeNodes := `{"items":[{"metadata":{"labels":{"topology.kubernetes.io/zone":"a"}}},{"metadata":{"labels":{}}},{"metadata":{"labels":{"topology.kubernetes.io/zone":"b"}}}]}`
+
+	t.Run("hostname needs no check", func(t *testing.T) {
+		r := &SandboxStrictReport{}
+		runSpreadCoverageStrictCheck(context.Background(), r, "kubernetes.io/hostname")
+		if len(r.Checks) != 0 {
+			t.Fatalf("expected no check, got %+v", r.Checks)
+		}
+	})
+	t.Run("no node carries the key fails", func(t *testing.T) {
+		kubectlNodesShim(t, threeNodes)
+		r := &SandboxStrictReport{}
+		runSpreadCoverageStrictCheck(context.Background(), r, "example.com/rack")
+		if !hasFailNamed(r, "k8s spread key coverage") {
+			t.Fatalf("expected a coverage failure, got %+v", r.Checks)
+		}
+	})
+	t.Run("partial coverage warns", func(t *testing.T) {
+		kubectlNodesShim(t, threeNodes)
+		r := &SandboxStrictReport{}
+		runSpreadCoverageStrictCheck(context.Background(), r, "topology.kubernetes.io/zone")
+		if r.Failed() || len(r.Checks) != 1 || r.Checks[0].Status != CheckWarn || !strings.Contains(r.Checks[0].Detail, "2 of 3") {
+			t.Fatalf("expected a 2 of 3 warning, got %+v", r.Checks)
+		}
+	})
 }
 
 func TestRunCapabilityStrictChecks(t *testing.T) {

--- a/pkg/runtime/sandbox.go
+++ b/pkg/runtime/sandbox.go
@@ -509,7 +509,7 @@ func resolveAndStartSandbox(ctx context.Context, p SandboxParams) (*activeSandbo
 		}
 		return nil, fmt.Errorf("runtime: sandbox: start: %w", err)
 	}
-	emitSandboxStarted(prepared, spec, driver.Name(), source, emitEvent)
+	emitSandboxStarted(prepared, spec, driver.Name(), source, schedulingSummary(driver), emitEvent)
 
 	active := &activeSandbox{
 		run:             run,

--- a/pkg/runtime/sandbox_lifecycle.go
+++ b/pkg/runtime/sandbox_lifecycle.go
@@ -11,18 +11,20 @@ import (
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
 	"github.com/SocialGouv/iterion/pkg/sandbox/docker"
+	"github.com/SocialGouv/iterion/pkg/sandbox/kubernetes"
 	"github.com/SocialGouv/iterion/pkg/sandbox/registry"
 	"github.com/SocialGouv/iterion/pkg/store"
 )
 
 // selectSandboxDriver picks the driver via the global factory and
-// wraps it with the engine's logger when it's the docker driver — so
-// `docker run`, postCreate execution, and container start messages
-// land in the run.log alongside the rest of the run. Without this swap
-// the factory hands back a sandbox.Driver whose default logger
-// discards output, and silent-failure modes (postCreate skipped
-// because spec was empty, image pull stalled, etc.) become impossible
-// to debug from logs alone.
+// wraps it with the engine's logger when it's the docker or kubernetes
+// driver — so `docker run`, `kubectl apply`, postCreate execution and
+// container start messages land in the run.log alongside the rest of
+// the run. Without this swap the factory hands back a sandbox.Driver
+// whose default logger discards output, and silent-failure modes
+// (postCreate skipped because spec was empty, image pull stalled, a
+// defaulted sandbox.user, the pod scheduling policy in force) become
+// impossible to debug from logs alone.
 func selectSandboxDriver(spec *sandbox.Spec, logger *iterlog.Logger) (sandbox.Driver, error) {
 	factory := sandbox.NewFactory(sandbox.FactoryOptions{
 		AvailableDrivers: registry.Default(),
@@ -32,11 +34,26 @@ func selectSandboxDriver(spec *sandbox.Spec, logger *iterlog.Logger) (sandbox.Dr
 		return nil, fmt.Errorf("runtime: sandbox: select driver: %w", err)
 	}
 	if logger != nil {
-		if dd, ok := driver.(*docker.Driver); ok {
-			driver = dd.WithLogger(logger)
+		switch d := driver.(type) {
+		case *docker.Driver:
+			driver = d.WithLogger(logger)
+		case *kubernetes.Driver:
+			driver = d.WithLogger(logger)
 		}
 	}
 	return driver, nil
+}
+
+// schedulingSummary is the driver's scheduling policy for the
+// sandbox_started event, "" when the driver has none or it is
+// misconfigured (Start reports that error itself).
+func schedulingSummary(driver sandbox.Driver) string {
+	if r, ok := driver.(sandbox.SchedulingPolicyReporter); ok {
+		if s, err := r.SchedulingPolicy(); err == nil {
+			return s
+		}
+	}
+	return ""
 }
 
 // startNoopSandbox runs the Prepare+Start sequence for the noop driver.
@@ -125,10 +142,15 @@ func buildSandboxImageIfRequested(
 // doesn't reveal whether `auto` resolved to the project's devcontainer
 // or to the slim fallback (the silent-fallback bug that ate the
 // modjo postCreate).
+//
+// The scheduling policy the driver stamped on the sandbox is recorded for
+// the same reason: a run resumed on another runner during a rollout is
+// re-rendered under THAT runner's policy, and the event is the only place
+// the difference is visible.
 func emitSandboxStarted(
 	prepared sandbox.PreparedSpec,
 	spec *sandbox.Spec,
-	driverName, source string,
+	driverName, source, scheduling string,
 	emitEvent func(store.EventType, map[string]any) error,
 ) {
 	resolvedImage := ""
@@ -138,11 +160,15 @@ func emitSandboxStarted(
 	if resolvedImage == "" {
 		resolvedImage = spec.Image
 	}
-	_ = emitEvent(store.EventSandboxStarted, map[string]any{
+	data := map[string]any{
 		"driver":          driverName,
 		"mode":            string(spec.Mode),
 		"source":          source,
 		"image":           resolvedImage,
 		"has_post_create": spec.PostCreate != "",
-	})
+	}
+	if scheduling != "" {
+		data["scheduling"] = scheduling
+	}
+	_ = emitEvent(store.EventSandboxStarted, data)
 }

--- a/pkg/runtime/sandbox_scheduling_event_test.go
+++ b/pkg/runtime/sandbox_scheduling_event_test.go
@@ -1,0 +1,52 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+	"github.com/SocialGouv/iterion/pkg/store"
+)
+
+type fakeSchedulingDriver struct {
+	sandbox.Driver
+	policy string
+	err    error
+}
+
+func (f fakeSchedulingDriver) SchedulingPolicy() (string, error) { return f.policy, f.err }
+
+// A resume on another runner re-renders the pod under THAT runner's policy;
+// the sandbox_started event is the only place the difference is visible, so
+// it must carry the policy — and only when the driver reports one.
+func TestSandboxStartedEventCarriesTheSchedulingPolicy(t *testing.T) {
+	var got map[string]any
+	emit := func(typ store.EventType, data map[string]any) error {
+		if typ == store.EventSandboxStarted {
+			got = data
+		}
+		return nil
+	}
+	spec := &sandbox.Spec{Image: "img"}
+
+	emitSandboxStarted(nil, spec, "kubernetes", "workflow", schedulingSummary(fakeSchedulingDriver{policy: "requests cpu=2, spread=kubernetes.io/hostname"}), emit)
+	if got["scheduling"] != "requests cpu=2, spread=kubernetes.io/hostname" {
+		t.Fatalf("sandbox_started must record the policy, got %v", got)
+	}
+
+	got = nil
+	emitSandboxStarted(nil, spec, "docker", "workflow", schedulingSummary(fakeSchedulingDriver{}), emit)
+	if _, present := got["scheduling"]; present {
+		t.Fatalf("no policy must not produce a scheduling field, got %v", got)
+	}
+
+	// A misconfigured policy is Start's error to report, not the event's.
+	if s := schedulingSummary(fakeSchedulingDriver{err: errTestPolicy}); s != "" {
+		t.Fatalf("a policy error must not be summarised, got %q", s)
+	}
+}
+
+type testPolicyError struct{}
+
+func (testPolicyError) Error() string { return "policy error" }
+
+var errTestPolicy error = testPolicyError{}

--- a/pkg/sandbox/iface.go
+++ b/pkg/sandbox/iface.go
@@ -300,6 +300,18 @@ type Builder interface {
 	Build(ctx context.Context, prepared PreparedSpec, info RunInfo) (PreparedSpec, error)
 }
 
+// SchedulingPolicyReporter is implemented by drivers that stamp a
+// deployment-level scheduling policy (resource requests, placement) on the
+// sandboxes they create. The runtime records the summary on the
+// sandbox_started event so a resume on another runner (a mixed fleet during
+// a rollout) is auditable, and the doctor reports the configuration error a
+// misconfigured policy would otherwise only raise at the first Start.
+type SchedulingPolicyReporter interface {
+	// SchedulingPolicy returns a one-line summary of the policy, or the
+	// configuration error every Start will return.
+	SchedulingPolicy() (string, error)
+}
+
 // RunInfo carries per-run metadata that drivers may need to label
 // containers/pods, scope mounts, or compute run-specific paths.
 type RunInfo struct {

--- a/pkg/sandbox/kubernetes/driver.go
+++ b/pkg/sandbox/kubernetes/driver.go
@@ -123,28 +123,23 @@ var suffixScale = map[string]float64{
 // number).
 func splitQuantity(v string) (number, suffix string) {
 	v = strings.TrimPrefix(v, "+")
+	// Scanned from the right: the number ends at its last digit or dot, and a
+	// valid exponent ends in a digit too (`1e3`, `1e+3`), so it stays inside
+	// the number; `E` and `Ei` end in a letter and are suffixes.
 	for i := len(v) - 1; i >= 0; i-- {
-		c := v[i]
-		if (c >= '0' && c <= '9') || c == '.' {
+		if c := v[i]; (c >= '0' && c <= '9') || c == '.' {
 			return v[:i+1], v[i+1:]
-		}
-		// An exponent's sign or digits are part of the number: stop at 'e'/'E'
-		// only when what precedes it is numeric and what follows it starts an
-		// exponent (`1e3`, `1e+3`) — not a suffix (`1E`, `1Ei`).
-		if (c == 'e' || c == 'E') && i > 0 && i < len(v)-1 &&
-			((v[i-1] >= '0' && v[i-1] <= '9') || v[i-1] == '.') &&
-			(v[i+1] == '+' || v[i+1] == '-' || (v[i+1] >= '0' && v[i+1] <= '9')) {
-			return v, ""
 		}
 	}
 	return "", v
 }
 
-// quantityValue converts a quantity matched by quantityRe to a float for
-// comparisons (a request against its limit). Precision is irrelevant here:
-// the API server re-parses the strings themselves. A value it cannot
-// evaluate is an error, never a silent zero: a zero would pass a limit
-// check it should fail.
+// quantityValue converts a quantity matched by quantityRe to a float for the
+// zero check and for comparisons (a request against its limit). Precision is
+// irrelevant here: the API server re-parses the strings themselves. A value
+// it cannot evaluate (an exponent out of float64 range, an unknown suffix)
+// is an error, never a silent zero; a value that evaluates to zero (`0`,
+// `0.0`, `0Gi`, an underflowing `1e-400`) is the caller's to refuse.
 func quantityValue(v string) (float64, error) {
 	number, suffix := splitQuantity(v)
 	f, err := strconv.ParseFloat(number, 64)
@@ -203,18 +198,6 @@ func (s podScheduling) String() string {
 	return strings.Join(parts, ", ")
 }
 
-// zeroQuantity reports a quantity whose mantissa has no non-zero digit
-// (`0`, `0.0`, `0Gi`, `0m`): it renders a resources block that schedules
-// exactly like no resources block, which is the one thing the policy exists
-// to prevent — an operator reading the pod would believe the floor is set.
-func zeroQuantity(v string) bool {
-	mantissa := strings.TrimLeft(v, "+")
-	if i := strings.IndexFunc(mantissa, func(r rune) bool { return r != '.' && (r < '0' || r > '9') }); i >= 0 {
-		mantissa = mantissa[:i]
-	}
-	return !strings.ContainsAny(mantissa, "123456789")
-}
-
 // ValidateSchedulingEnv parses the scheduling policy from the process
 // environment and returns the error every sandbox Start would return. The
 // runner calls it at bootstrap so a misconfigured pod never becomes ready —
@@ -252,7 +235,16 @@ func schedulingFromEnv(getenv func(string) string) (podScheduling, error) {
 		if !quantityRe.MatchString(v) {
 			return podScheduling{}, fmt.Errorf("kubernetes: %s=%q is not a Kubernetes quantity (want e.g. 500m, 2, 4Gi)", q.env, v)
 		}
-		if zeroQuantity(v) {
+		// Evaluated for every set variable, not only when a limit exists: a
+		// zero (`0`, `0Gi`, an underflowing `1e-400`) renders a resources block
+		// that schedules exactly like no resources block, which is the one
+		// thing the policy exists to prevent — an operator reading the pod
+		// would believe the floor is set.
+		value, err := quantityValue(v)
+		if err != nil {
+			return podScheduling{}, fmt.Errorf("kubernetes: %s: %w", q.env, err)
+		}
+		if value == 0 {
 			return podScheduling{}, fmt.Errorf("kubernetes: %s=%q is a zero quantity — it schedules like no request at all; unset the variable instead", q.env, v)
 		}
 		_, suffix := splitQuantity(v)

--- a/pkg/sandbox/kubernetes/driver.go
+++ b/pkg/sandbox/kubernetes/driver.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"os/exec"
 	"path"
@@ -146,14 +147,17 @@ func quantityValue(v string) (float64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("quantity %q: %w", v, err)
 	}
-	if suffix == "" {
-		return f, nil
+	if suffix != "" {
+		scale, ok := suffixScale[suffix]
+		if !ok {
+			return 0, fmt.Errorf("quantity %q: unknown suffix %q", v, suffix)
+		}
+		f *= scale
 	}
-	scale, ok := suffixScale[suffix]
-	if !ok {
-		return 0, fmt.Errorf("quantity %q: unknown suffix %q", v, suffix)
+	if math.IsInf(f, 0) {
+		return 0, fmt.Errorf("quantity %q: out of range", v)
 	}
-	return f * scale, nil
+	return f, nil
 }
 
 // topologyKeyRe is a prefixed Kubernetes label key (DNS-subdomain prefix,
@@ -255,6 +259,12 @@ func schedulingFromEnv(getenv func(string) string) (podScheduling, error) {
 		}
 		if !q.memory && len(suffix) == 2 {
 			return podScheduling{}, fmt.Errorf("kubernetes: %s=%q uses a byte suffix on a CPU quantity (want e.g. 500m, 2)", q.env, v)
+		}
+		// Below Kubernetes' own precision (1m of CPU, 1 byte of memory) the
+		// API server rounds up at admission: a "floor" of 5e-324 is a zero
+		// wearing a number.
+		if floor := 1.0; (!q.memory && value < 1e-3) || (q.memory && value < floor) {
+			return podScheduling{}, fmt.Errorf("kubernetes: %s=%q is below the quantity precision (1m of CPU, 1 byte of memory) — it schedules like no request at all", q.env, v)
 		}
 		*q.dst = v
 	}

--- a/pkg/sandbox/kubernetes/driver.go
+++ b/pkg/sandbox/kubernetes/driver.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -88,22 +89,76 @@ const (
 	LimitsCPUEnvVar      = "ITERION_SANDBOX_K8S_LIMITS_CPU"
 	LimitsMemoryEnvVar   = "ITERION_SANDBOX_K8S_LIMITS_MEMORY"
 	// SpreadEnvVar selects the topology key of the soft spread constraint
-	// over sandbox-run pods: "hostname" (the default when unset) →
-	// kubernetes.io/hostname, "none" → no constraint, any other value is
-	// used verbatim as the topology key (e.g. topology.kubernetes.io/zone).
+	// over sandbox-run pods: unset / "none" / "off" → no constraint (the
+	// scheduler's own policy decides, as it always did), "hostname" →
+	// kubernetes.io/hostname, any other value must be a prefixed label key
+	// (e.g. topology.kubernetes.io/zone) that the nodes actually carry —
+	// nodes without the label are excluded from scheduling, soft or not.
 	SpreadEnvVar = "ITERION_SANDBOX_K8S_SPREAD"
 )
 
-// defaultSpreadTopologyKey is the node-level spread every multi-node
-// cluster wants; on a single node the soft constraint is a no-op.
-const defaultSpreadTopologyKey = "kubernetes.io/hostname"
+// hostnameTopologyKey is the node-level spread, the one key every node
+// carries by construction.
+const hostnameTopologyKey = "kubernetes.io/hostname"
 
-// quantityRe is the grammar of a Kubernetes quantity as operators write one:
-// a decimal with an optional exponent or SI/binary suffix. The API server
-// owns the semantics (a limit below its request, an absurd size); the
-// driver only refuses what could never be a quantity, so a typo fails once
-// at startup instead of on every pod apply.
-var quantityRe = regexp.MustCompile(`^[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+|m|k|M|G|T|P|E|Ki|Mi|Gi|Ti|Pi|Ei)?$`)
+// quantityRe is the subset of the Kubernetes quantity grammar the driver
+// accepts: a decimal (`2`, `.5`, `1.`, `+1`), an optional exponent (`1e3`)
+// or one of the SI / binary suffixes operators actually write for CPU and
+// memory (`500m`, `4Gi`). The micro/nano suffixes (`u`, `n`) the API also
+// admits are left out on purpose — no run is sized in nanocores. The API
+// server owns the rest of the semantics; the driver refuses what could never
+// be a sane quantity, so a typo fails once at startup instead of on every
+// pod apply.
+var quantityRe = regexp.MustCompile(`^\+?([0-9]+(\.[0-9]*)?|\.[0-9]+)([eE][+-]?[0-9]+|m|k|M|G|T|P|E|Ki|Mi|Gi|Ti|Pi|Ei)?$`)
+
+// suffixScale is the multiplier of each quantity suffix, for the
+// request ≤ limit comparison.
+var suffixScale = map[string]float64{
+	"m": 1e-3, "k": 1e3, "M": 1e6, "G": 1e9, "T": 1e12, "P": 1e15, "E": 1e18,
+	"Ki": 1 << 10, "Mi": 1 << 20, "Gi": 1 << 30, "Ti": 1 << 40, "Pi": 1 << 50, "Ei": 1 << 60,
+}
+
+// splitQuantity separates a quantity matched by quantityRe into its numeric
+// text and its suffix ("" when none; an exponent counts as part of the
+// number).
+func splitQuantity(v string) (number, suffix string) {
+	v = strings.TrimPrefix(v, "+")
+	for i := len(v) - 1; i >= 0; i-- {
+		c := v[i]
+		if (c >= '0' && c <= '9') || c == '.' {
+			return v[:i+1], v[i+1:]
+		}
+		// An exponent's sign or digits are part of the number: stop at 'e'/'E'
+		// only when what precedes it is numeric (`1e3`), not a suffix (`1E`).
+		if (c == 'e' || c == 'E') && i > 0 && ((v[i-1] >= '0' && v[i-1] <= '9') || v[i-1] == '.') && i < len(v)-1 {
+			return v, ""
+		}
+	}
+	return "", v
+}
+
+// quantityValue converts a quantity matched by quantityRe to a float for
+// comparisons (a request against its limit). Precision is irrelevant here:
+// the API server re-parses the strings themselves.
+func quantityValue(v string) float64 {
+	number, suffix := splitQuantity(v)
+	f, err := strconv.ParseFloat(number, 64)
+	if err != nil {
+		return 0
+	}
+	if scale, ok := suffixScale[suffix]; ok {
+		return f * scale
+	}
+	return f
+}
+
+// topologyKeyRe is a prefixed Kubernetes label key (DNS-subdomain prefix,
+// "/", then the name). A bare word is refused on purpose: every topology
+// key a cluster actually carries is prefixed (kubernetes.io/hostname,
+// topology.kubernetes.io/zone, …), and a bare word is almost always a typo
+// of the keywords — which the API server would accept as a label no node
+// has, turning the spread into a silent no-op.
+var topologyKeyRe = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/[A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?$`)
 
 // podScheduling is the parsed form of the scheduling env vars.
 type podScheduling struct {
@@ -111,19 +166,74 @@ type podScheduling struct {
 	spreadKey string // "" = no spread constraint
 }
 
+// String renders the policy for logs, events and the doctor report.
+func (s podScheduling) String() string {
+	var parts []string
+	side := func(label string, l ResourceList) {
+		var kv []string
+		if l.CPU != "" {
+			kv = append(kv, "cpu="+l.CPU)
+		}
+		if l.Memory != "" {
+			kv = append(kv, "memory="+l.Memory)
+		}
+		if len(kv) > 0 {
+			parts = append(parts, label+" "+strings.Join(kv, " "))
+		}
+	}
+	side("requests", s.resources.Requests)
+	side("limits", s.resources.Limits)
+	if len(parts) == 0 {
+		parts = append(parts, "no resources")
+	}
+	if s.spreadKey == "" {
+		parts = append(parts, "no spread")
+	} else {
+		parts = append(parts, "spread="+s.spreadKey)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// zeroQuantity reports a quantity whose mantissa has no non-zero digit
+// (`0`, `0.0`, `0Gi`, `0m`): it renders a resources block that schedules
+// exactly like no resources block, which is the one thing the policy exists
+// to prevent — an operator reading the pod would believe the floor is set.
+func zeroQuantity(v string) bool {
+	mantissa := strings.TrimLeft(v, "+")
+	if i := strings.IndexFunc(mantissa, func(r rune) bool { return r != '.' && (r < '0' || r > '9') }); i >= 0 {
+		mantissa = mantissa[:i]
+	}
+	return !strings.ContainsAny(mantissa, "123456789")
+}
+
+// ValidateSchedulingEnv parses the scheduling policy from the process
+// environment and returns the error every sandbox Start would return. The
+// runner calls it at bootstrap so a misconfigured pod never becomes ready —
+// the driver factory skips constructor errors, so this is the only place a
+// bad value can stop a rollout instead of failing runs one by one.
+func ValidateSchedulingEnv() error {
+	_, err := schedulingFromEnv(os.Getenv)
+	return err
+}
+
 // schedulingFromEnv parses the scheduling env vars through getenv (injected
 // so tests never touch the process environment). Every set quantity must
-// match quantityRe; the error names the variable and the value.
+// match quantityRe, be non-zero and use a suffix that makes sense for its
+// resource; a limit needs its request (the API server would otherwise copy
+// the limit into the request at admission) and must not be below it; the
+// spread keywords are matched case-insensitively and anything else must be
+// a prefixed label key. Each error names the variable and the value.
 func schedulingFromEnv(getenv func(string) string) (podScheduling, error) {
 	var s podScheduling
 	quantities := []struct {
-		env string
-		dst *string
+		env    string
+		dst    *string
+		memory bool
 	}{
-		{RequestsCPUEnvVar, &s.resources.Requests.CPU},
-		{RequestsMemoryEnvVar, &s.resources.Requests.Memory},
-		{LimitsCPUEnvVar, &s.resources.Limits.CPU},
-		{LimitsMemoryEnvVar, &s.resources.Limits.Memory},
+		{RequestsCPUEnvVar, &s.resources.Requests.CPU, false},
+		{RequestsMemoryEnvVar, &s.resources.Requests.Memory, true},
+		{LimitsCPUEnvVar, &s.resources.Limits.CPU, false},
+		{LimitsMemoryEnvVar, &s.resources.Limits.Memory, true},
 	}
 	for _, q := range quantities {
 		v := strings.TrimSpace(getenv(q.env))
@@ -133,21 +243,56 @@ func schedulingFromEnv(getenv func(string) string) (podScheduling, error) {
 		if !quantityRe.MatchString(v) {
 			return podScheduling{}, fmt.Errorf("kubernetes: %s=%q is not a Kubernetes quantity (want e.g. 500m, 2, 4Gi)", q.env, v)
 		}
+		if zeroQuantity(v) {
+			return podScheduling{}, fmt.Errorf("kubernetes: %s=%q is a zero quantity — it schedules like no request at all; unset the variable instead", q.env, v)
+		}
+		_, suffix := splitQuantity(v)
+		if q.memory && suffix == "m" {
+			// `400m` of memory is 0.4 bytes — always the CPU suffix on the
+			// wrong variable, never a size anyone meant.
+			return podScheduling{}, fmt.Errorf("kubernetes: %s=%q is a milli-byte quantity (m is the CPU suffix; want e.g. 512Mi, 4Gi)", q.env, v)
+		}
+		if !q.memory && len(suffix) == 2 {
+			return podScheduling{}, fmt.Errorf("kubernetes: %s=%q uses a byte suffix on a CPU quantity (want e.g. 500m, 2)", q.env, v)
+		}
 		*q.dst = v
 	}
-	switch v := strings.TrimSpace(getenv(SpreadEnvVar)); v {
-	case "", "hostname":
-		s.spreadKey = defaultSpreadTopologyKey
-	case "none", "off":
+	for _, pair := range []struct {
+		name, reqEnv, limEnv, req, lim string
+	}{
+		{"cpu", RequestsCPUEnvVar, LimitsCPUEnvVar, s.resources.Requests.CPU, s.resources.Limits.CPU},
+		{"memory", RequestsMemoryEnvVar, LimitsMemoryEnvVar, s.resources.Requests.Memory, s.resources.Limits.Memory},
+	} {
+		if pair.lim == "" {
+			continue
+		}
+		if pair.req == "" {
+			return podScheduling{}, fmt.Errorf("kubernetes: %s=%q without %s — the API server would copy the limit into the request at admission; set the request explicitly", pair.limEnv, pair.lim, pair.reqEnv)
+		}
+		if quantityValue(pair.lim) < quantityValue(pair.req) {
+			return podScheduling{}, fmt.Errorf("kubernetes: %s=%q is below %s=%q — a %s limit cannot be lower than its request", pair.limEnv, pair.lim, pair.reqEnv, pair.req, pair.name)
+		}
+	}
+	v := strings.TrimSpace(getenv(SpreadEnvVar))
+	switch strings.ToLower(v) {
+	case "", "none", "off":
 		s.spreadKey = ""
+	case "hostname":
+		s.spreadKey = hostnameTopologyKey
 	default:
-		if strings.ContainsAny(v, " \t\r\n") {
-			return podScheduling{}, fmt.Errorf("kubernetes: %s=%q is not a topology key (want hostname, none, or a label key such as topology.kubernetes.io/zone)", SpreadEnvVar, v)
+		if !topologyKeyRe.MatchString(v) {
+			return podScheduling{}, fmt.Errorf("kubernetes: %s=%q is not a topology key (want hostname, none, or a prefixed label key such as topology.kubernetes.io/zone)", SpreadEnvVar, v)
 		}
 		s.spreadKey = v
 	}
 	return s, nil
 }
+
+// SpreadTopologyKey is the topology key of the spread constraint the driver
+// renders, "" when it renders none. The doctor uses it to check that the
+// cluster's nodes carry the label — a node without it is excluded from
+// scheduling, which a soft constraint does not waive.
+func (d *Driver) SpreadTopologyKey() string { return d.sched.spreadKey }
 
 // deadlineMarginSecs is added to the run's budgeted max_duration when
 // deriving spec.activeDeadlineSeconds, so a run that legitimately uses
@@ -189,8 +334,10 @@ func New() (sandbox.Driver, error) {
 	// A malformed scheduling value is kept on the driver and fails every
 	// Start, not the constructor: the factory's preference walk skips ANY
 	// constructor error and ends on the always-constructible noop driver,
-	// so returning it here would silently run cloud workloads on the runner
-	// pod itself. Failing each run with the variable named is the loud path.
+	// so returning it here would degrade cloud runs to unsandboxed with a
+	// warning event as the only trace. Failing each run with the variable
+	// named is the loud path; `iterion sandbox doctor` reads the same
+	// error through SchedulingPolicy.
 	sched, schedErr := schedulingFromEnv(os.Getenv)
 	return &Driver{
 		kubectl:   binPath,
@@ -236,6 +383,16 @@ func (d *Driver) WithLogger(l *iterlog.Logger) *Driver {
 
 // Name returns "kubernetes".
 func (d *Driver) Name() string { return "kubernetes" }
+
+// SchedulingPolicy implements [sandbox.SchedulingPolicyReporter]: the
+// deployment's pod scheduling policy as rendered on every sibling pod, or
+// the parse error every Start will return.
+func (d *Driver) SchedulingPolicy() (string, error) {
+	if d.schedErr != nil {
+		return "", d.schedErr
+	}
+	return d.sched.String(), nil
+}
 
 // ProxyConfig binds the network proxy on all interfaces (so sibling
 // sandbox pods can reach it across the cluster network) and advertises
@@ -334,6 +491,7 @@ func (d *Driver) Start(ctx context.Context, prepared sandbox.PreparedSpec, info 
 	if d.schedErr != nil {
 		return nil, d.schedErr
 	}
+	d.logger.Info("kubernetes: pod scheduling policy: %s", d.sched)
 
 	podName := podNameFor(info.RunID)
 

--- a/pkg/sandbox/kubernetes/driver.go
+++ b/pkg/sandbox/kubernetes/driver.go
@@ -129,8 +129,11 @@ func splitQuantity(v string) (number, suffix string) {
 			return v[:i+1], v[i+1:]
 		}
 		// An exponent's sign or digits are part of the number: stop at 'e'/'E'
-		// only when what precedes it is numeric (`1e3`), not a suffix (`1E`).
-		if (c == 'e' || c == 'E') && i > 0 && ((v[i-1] >= '0' && v[i-1] <= '9') || v[i-1] == '.') && i < len(v)-1 {
+		// only when what precedes it is numeric and what follows it starts an
+		// exponent (`1e3`, `1e+3`) — not a suffix (`1E`, `1Ei`).
+		if (c == 'e' || c == 'E') && i > 0 && i < len(v)-1 &&
+			((v[i-1] >= '0' && v[i-1] <= '9') || v[i-1] == '.') &&
+			(v[i+1] == '+' || v[i+1] == '-' || (v[i+1] >= '0' && v[i+1] <= '9')) {
 			return v, ""
 		}
 	}
@@ -139,17 +142,23 @@ func splitQuantity(v string) (number, suffix string) {
 
 // quantityValue converts a quantity matched by quantityRe to a float for
 // comparisons (a request against its limit). Precision is irrelevant here:
-// the API server re-parses the strings themselves.
-func quantityValue(v string) float64 {
+// the API server re-parses the strings themselves. A value it cannot
+// evaluate is an error, never a silent zero: a zero would pass a limit
+// check it should fail.
+func quantityValue(v string) (float64, error) {
 	number, suffix := splitQuantity(v)
 	f, err := strconv.ParseFloat(number, 64)
 	if err != nil {
-		return 0
+		return 0, fmt.Errorf("quantity %q: %w", v, err)
 	}
-	if scale, ok := suffixScale[suffix]; ok {
-		return f * scale
+	if suffix == "" {
+		return f, nil
 	}
-	return f
+	scale, ok := suffixScale[suffix]
+	if !ok {
+		return 0, fmt.Errorf("quantity %q: unknown suffix %q", v, suffix)
+	}
+	return f * scale, nil
 }
 
 // topologyKeyRe is a prefixed Kubernetes label key (DNS-subdomain prefix,
@@ -269,7 +278,15 @@ func schedulingFromEnv(getenv func(string) string) (podScheduling, error) {
 		if pair.req == "" {
 			return podScheduling{}, fmt.Errorf("kubernetes: %s=%q without %s — the API server would copy the limit into the request at admission; set the request explicitly", pair.limEnv, pair.lim, pair.reqEnv)
 		}
-		if quantityValue(pair.lim) < quantityValue(pair.req) {
+		lim, err := quantityValue(pair.lim)
+		if err != nil {
+			return podScheduling{}, fmt.Errorf("kubernetes: %s: %w", pair.limEnv, err)
+		}
+		req, err := quantityValue(pair.req)
+		if err != nil {
+			return podScheduling{}, fmt.Errorf("kubernetes: %s: %w", pair.reqEnv, err)
+		}
+		if lim < req {
 			return podScheduling{}, fmt.Errorf("kubernetes: %s=%q is below %s=%q — a %s limit cannot be lower than its request", pair.limEnv, pair.lim, pair.reqEnv, pair.req, pair.name)
 		}
 	}

--- a/pkg/sandbox/kubernetes/driver.go
+++ b/pkg/sandbox/kubernetes/driver.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -68,6 +69,86 @@ const (
 	RunnerPodUIDEnvVar  = "ITERION_RUNNER_POD_UID"
 )
 
+// Scheduling knobs of the sibling pod, read from the runner's environment
+// once at construction and rendered on every pod it creates. They are a
+// deployment policy, not a workflow's: the operator sizes what one run may
+// claim, and a bot cannot lower it.
+//
+// A pod that requests nothing scores every node the same, so the scheduler
+// packs a campaign's runs onto whichever node already holds the image
+// (measured: 5 of 6 run pods on one 8-core worker at 89 % CPU while two
+// workers idled, and an oracle's 300 s boot budget blown at 459 s). The
+// request is what makes LeastAllocated spread them and what a cluster
+// autoscaler sizes the pool on; the spread constraint steers what the
+// request leaves equal. Unset → no `resources` (the manifest of a driver
+// without the knobs).
+const (
+	RequestsCPUEnvVar    = "ITERION_SANDBOX_K8S_REQUESTS_CPU"
+	RequestsMemoryEnvVar = "ITERION_SANDBOX_K8S_REQUESTS_MEMORY"
+	LimitsCPUEnvVar      = "ITERION_SANDBOX_K8S_LIMITS_CPU"
+	LimitsMemoryEnvVar   = "ITERION_SANDBOX_K8S_LIMITS_MEMORY"
+	// SpreadEnvVar selects the topology key of the soft spread constraint
+	// over sandbox-run pods: "hostname" (the default when unset) →
+	// kubernetes.io/hostname, "none" → no constraint, any other value is
+	// used verbatim as the topology key (e.g. topology.kubernetes.io/zone).
+	SpreadEnvVar = "ITERION_SANDBOX_K8S_SPREAD"
+)
+
+// defaultSpreadTopologyKey is the node-level spread every multi-node
+// cluster wants; on a single node the soft constraint is a no-op.
+const defaultSpreadTopologyKey = "kubernetes.io/hostname"
+
+// quantityRe is the grammar of a Kubernetes quantity as operators write one:
+// a decimal with an optional exponent or SI/binary suffix. The API server
+// owns the semantics (a limit below its request, an absurd size); the
+// driver only refuses what could never be a quantity, so a typo fails once
+// at startup instead of on every pod apply.
+var quantityRe = regexp.MustCompile(`^[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+|m|k|M|G|T|P|E|Ki|Mi|Gi|Ti|Pi|Ei)?$`)
+
+// podScheduling is the parsed form of the scheduling env vars.
+type podScheduling struct {
+	resources PodResources
+	spreadKey string // "" = no spread constraint
+}
+
+// schedulingFromEnv parses the scheduling env vars through getenv (injected
+// so tests never touch the process environment). Every set quantity must
+// match quantityRe; the error names the variable and the value.
+func schedulingFromEnv(getenv func(string) string) (podScheduling, error) {
+	var s podScheduling
+	quantities := []struct {
+		env string
+		dst *string
+	}{
+		{RequestsCPUEnvVar, &s.resources.Requests.CPU},
+		{RequestsMemoryEnvVar, &s.resources.Requests.Memory},
+		{LimitsCPUEnvVar, &s.resources.Limits.CPU},
+		{LimitsMemoryEnvVar, &s.resources.Limits.Memory},
+	}
+	for _, q := range quantities {
+		v := strings.TrimSpace(getenv(q.env))
+		if v == "" {
+			continue
+		}
+		if !quantityRe.MatchString(v) {
+			return podScheduling{}, fmt.Errorf("kubernetes: %s=%q is not a Kubernetes quantity (want e.g. 500m, 2, 4Gi)", q.env, v)
+		}
+		*q.dst = v
+	}
+	switch v := strings.TrimSpace(getenv(SpreadEnvVar)); v {
+	case "", "hostname":
+		s.spreadKey = defaultSpreadTopologyKey
+	case "none", "off":
+		s.spreadKey = ""
+	default:
+		if strings.ContainsAny(v, " \t\r\n") {
+			return podScheduling{}, fmt.Errorf("kubernetes: %s=%q is not a topology key (want hostname, none, or a label key such as topology.kubernetes.io/zone)", SpreadEnvVar, v)
+		}
+		s.spreadKey = v
+	}
+	return s, nil
+}
+
 // deadlineMarginSecs is added to the run's budgeted max_duration when
 // deriving spec.activeDeadlineSeconds, so a run that legitimately uses
 // its full budget (plus sandbox setup/teardown slack) is never killed by
@@ -105,10 +186,18 @@ func New() (sandbox.Driver, error) {
 	if err != nil {
 		return nil, &sandbox.ErrUnavailable{Driver: "kubernetes", Reason: err.Error()}
 	}
+	// A malformed scheduling value is kept on the driver and fails every
+	// Start, not the constructor: the factory's preference walk skips ANY
+	// constructor error and ends on the always-constructible noop driver,
+	// so returning it here would silently run cloud workloads on the runner
+	// pod itself. Failing each run with the variable named is the loud path.
+	sched, schedErr := schedulingFromEnv(os.Getenv)
 	return &Driver{
 		kubectl:   binPath,
 		namespace: namespace,
 		logger:    iterlog.New(iterlog.LevelInfo, io.Discard),
+		sched:     sched,
+		schedErr:  schedErr,
 	}, nil
 }
 
@@ -126,6 +215,12 @@ type Driver struct {
 	kubectl   string
 	namespace string
 	logger    *iterlog.Logger
+
+	// sched is the deployment's pod scheduling policy (requests, limits,
+	// spread), parsed once from the environment; schedErr is the parse
+	// failure it carries, surfaced by Start on every run.
+	sched    podScheduling
+	schedErr error
 }
 
 // WithLogger returns a copy of the driver bound to a real logger.
@@ -236,6 +331,9 @@ func (d *Driver) Start(ctx context.Context, prepared sandbox.PreparedSpec, info 
 	if !ok {
 		return nil, fmt.Errorf("kubernetes: PreparedSpec from driver %q passed to kubernetes.Start", prepared.DriverName())
 	}
+	if d.schedErr != nil {
+		return nil, d.schedErr
+	}
 
 	podName := podNameFor(info.RunID)
 
@@ -308,6 +406,8 @@ func (d *Driver) Start(ctx context.Context, prepared sandbox.PreparedSpec, info 
 		SecretFilesSecretName: secretFilesSecretName,
 		Owner:                 owner,
 		ActiveDeadlineSeconds: activeDeadline,
+		Resources:             d.sched.resources,
+		SpreadTopologyKey:     d.sched.spreadKey,
 	})
 	if err != nil {
 		if caSecretName != "" {

--- a/pkg/sandbox/kubernetes/driver_scheduling_test.go
+++ b/pkg/sandbox/kubernetes/driver_scheduling_test.go
@@ -1,0 +1,103 @@
+package kubernetes
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+)
+
+func envOf(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+func TestSchedulingFromEnvDefaultsToNodeSpreadAndNoResources(t *testing.T) {
+	s, err := schedulingFromEnv(envOf(nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.resources != (PodResources{}) {
+		t.Fatalf("resources must be unset by default, got %+v", s.resources)
+	}
+	if s.spreadKey != defaultSpreadTopologyKey {
+		t.Fatalf("spread key = %q, want %q by default", s.spreadKey, defaultSpreadTopologyKey)
+	}
+}
+
+func TestSchedulingFromEnvParsesQuantities(t *testing.T) {
+	s, err := schedulingFromEnv(envOf(map[string]string{
+		RequestsCPUEnvVar:    " 2 ",
+		RequestsMemoryEnvVar: "4Gi",
+		LimitsCPUEnvVar:      "1.5",
+		LimitsMemoryEnvVar:   "1e3",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := PodResources{
+		Requests: ResourceList{CPU: "2", Memory: "4Gi"},
+		Limits:   ResourceList{CPU: "1.5", Memory: "1e3"},
+	}
+	if s.resources != want {
+		t.Fatalf("resources = %+v, want %+v", s.resources, want)
+	}
+	for _, v := range []string{"500m", "128Mi", "3", "0.25", "2Ti", "100k"} {
+		if _, err := schedulingFromEnv(envOf(map[string]string{RequestsCPUEnvVar: v})); err != nil {
+			t.Errorf("%q must be accepted as a quantity: %v", v, err)
+		}
+	}
+}
+
+// A typo must fail with the variable and the value named, never be rendered
+// for the API server to reject on every pod.
+func TestSchedulingFromEnvRejectsMalformedQuantities(t *testing.T) {
+	for _, v := range []string{"2 cores", "4GB", "-1", "1,5", "Gi", "two"} {
+		_, err := schedulingFromEnv(envOf(map[string]string{LimitsMemoryEnvVar: v}))
+		if err == nil {
+			t.Errorf("%q must be refused", v)
+			continue
+		}
+		if !strings.Contains(err.Error(), LimitsMemoryEnvVar) || !strings.Contains(err.Error(), v) {
+			t.Errorf("error for %q must name the variable and the value, got %q", v, err)
+		}
+	}
+}
+
+func TestSchedulingFromEnvSpreadSelector(t *testing.T) {
+	cases := map[string]string{
+		"":                            defaultSpreadTopologyKey,
+		"hostname":                    defaultSpreadTopologyKey,
+		"none":                        "",
+		"off":                         "",
+		"topology.kubernetes.io/zone": "topology.kubernetes.io/zone",
+	}
+	for v, want := range cases {
+		s, err := schedulingFromEnv(envOf(map[string]string{SpreadEnvVar: v}))
+		if err != nil {
+			t.Errorf("%q: unexpected error %v", v, err)
+			continue
+		}
+		if s.spreadKey != want {
+			t.Errorf("%q: spread key = %q, want %q", v, s.spreadKey, want)
+		}
+	}
+	if _, err := schedulingFromEnv(envOf(map[string]string{SpreadEnvVar: "not a key"})); err == nil || !strings.Contains(err.Error(), SpreadEnvVar) {
+		t.Fatalf("a key with whitespace must be refused naming the variable, got %v", err)
+	}
+}
+
+// The factory's preference walk skips any constructor error and lands on the
+// noop driver, so a malformed value must fail each run at Start instead —
+// loudly, with the variable named, before any kubectl call.
+func TestStartRefusesWhenSchedulingIsMalformed(t *testing.T) {
+	_, schedErr := schedulingFromEnv(envOf(map[string]string{RequestsCPUEnvVar: "two"}))
+	if schedErr == nil {
+		t.Fatal("precondition: malformed quantity must produce an error")
+	}
+	d := &Driver{namespace: "test", kubectl: "/nonexistent/kubectl", schedErr: schedErr}
+	_, err := d.Start(context.Background(), &Prepared{spec: sandbox.Spec{Image: "img", User: "1000:1000"}, workspace: "/workspace"}, sandbox.RunInfo{RunID: "r"})
+	if err == nil || !strings.Contains(err.Error(), RequestsCPUEnvVar) {
+		t.Fatalf("Start must surface the scheduling error naming %s, got %v", RequestsCPUEnvVar, err)
+	}
+}

--- a/pkg/sandbox/kubernetes/driver_scheduling_test.go
+++ b/pkg/sandbox/kubernetes/driver_scheduling_test.go
@@ -100,6 +100,10 @@ func TestSchedulingFromEnvRejectsSuffixOnWrongResource(t *testing.T) {
 	if _, err := schedulingFromEnv(envOf(map[string]string{LimitsCPUEnvVar: "2Gi"})); err == nil || !strings.Contains(err.Error(), "byte suffix") {
 		t.Fatalf("cpu=2Gi must be refused as a byte suffix on CPU, got %v", err)
 	}
+	// `Ei` must be read as a suffix, not as the start of an exponent.
+	if _, err := schedulingFromEnv(envOf(map[string]string{RequestsCPUEnvVar: "1Ei"})); err == nil || !strings.Contains(err.Error(), "byte suffix") {
+		t.Fatalf("cpu=1Ei must be refused as a byte suffix on CPU, got %v", err)
+	}
 }
 
 // A limit without its request becomes the request at admission (the API
@@ -122,15 +126,49 @@ func TestSchedulingFromEnvRequiresRequestUnderLimit(t *testing.T) {
 	if err == nil {
 		t.Fatalf("4G (decimal) is below 4Gi (binary) and must be refused")
 	}
+	// The exbibyte suffix evaluates like every other one: above a gibibyte
+	// as a limit, below a mebibyte never.
+	_, err = schedulingFromEnv(envOf(map[string]string{RequestsMemoryEnvVar: "1Gi", LimitsMemoryEnvVar: "10Ei"}))
+	if err != nil {
+		t.Fatalf("a 10Ei limit over a 1Gi request must be accepted, got %v", err)
+	}
+	_, err = schedulingFromEnv(envOf(map[string]string{RequestsMemoryEnvVar: "1Ei", LimitsMemoryEnvVar: "1Mi"}))
+	if err == nil || !strings.Contains(err.Error(), "below") {
+		t.Fatalf("a 1Mi limit under a 1Ei request must be refused, got %v", err)
+	}
 }
 
 func TestQuantityValue(t *testing.T) {
 	cases := map[string]float64{
 		"2": 2, "500m": 0.5, "4Gi": 4 * (1 << 30), "4G": 4e9, "1e3": 1000, ".5": 0.5, "1.": 1, "+3": 3, "128Mi": 128 * (1 << 20),
+		// `E` and `Ei` start like an exponent and are suffixes: an exponent
+		// needs digits or a sign after the `e`.
+		"2E": 2e18, "1Ei": 1 << 60, "10Ei": 10 * (1 << 60), "1E3": 1000, "1e+3": 1000, "1e-3": 0.001, "1.e2": 100,
 	}
 	for v, want := range cases {
-		if got := quantityValue(v); got != want {
-			t.Errorf("quantityValue(%q) = %v, want %v", v, got, want)
+		got, err := quantityValue(v)
+		if err != nil || got != want {
+			t.Errorf("quantityValue(%q) = %v, %v; want %v", v, got, err, want)
+		}
+	}
+	// What cannot be evaluated is an error, never a silent zero.
+	for _, v := range []string{"", "x", "1x", "1Ei3", "1e"} {
+		if got, err := quantityValue(v); err == nil {
+			t.Errorf("quantityValue(%q) = %v, want an error", v, got)
+		}
+	}
+}
+
+func TestSplitQuantity(t *testing.T) {
+	cases := map[string][2]string{
+		"2": {"2", ""}, "500m": {"500", "m"}, "4Gi": {"4", "Gi"}, "1e3": {"1e3", ""}, "1E3": {"1E3", ""},
+		"1e+3": {"1e+3", ""}, "1e-3": {"1e-3", ""}, "2E": {"2", "E"}, "1Ei": {"1", "Ei"}, "10Ei": {"10", "Ei"},
+		"1.E": {"1.", "E"}, ".5Ei": {".5", "Ei"}, "+1Ei": {"1", "Ei"},
+	}
+	for v, want := range cases {
+		number, suffix := splitQuantity(v)
+		if number != want[0] || suffix != want[1] {
+			t.Errorf("splitQuantity(%q) = (%q, %q), want (%q, %q)", v, number, suffix, want[0], want[1])
 		}
 	}
 }

--- a/pkg/sandbox/kubernetes/driver_scheduling_test.go
+++ b/pkg/sandbox/kubernetes/driver_scheduling_test.go
@@ -68,7 +68,9 @@ func TestSchedulingFromEnvParsesQuantities(t *testing.T) {
 // A typo must fail with the variable and the value named, never be rendered
 // for the API server to reject on every pod.
 func TestSchedulingFromEnvRejectsMalformedQuantities(t *testing.T) {
-	for _, v := range []string{"2 cores", "4GB", "-1", "1,5", "Gi", "two", "2ki", "1e", ".", "1u", "1n"} {
+	// `1e400` matches the grammar and overflows float64: refused, not rendered
+	// for the API server to reject on every pod.
+	for _, v := range []string{"2 cores", "4GB", "-1", "1,5", "Gi", "two", "2ki", "1e", ".", "1u", "1n", "1e400"} {
 		_, err := schedulingFromEnv(envOf(map[string]string{RequestsMemoryEnvVar: v}))
 		if err == nil {
 			t.Errorf("%q must be refused", v)
@@ -81,12 +83,15 @@ func TestSchedulingFromEnvRejectsMalformedQuantities(t *testing.T) {
 }
 
 // A zero quantity renders a resources block that schedules exactly like no
-// resources block — the one lie the policy exists to prevent.
+// resources block — the one lie the policy exists to prevent. `1e-400` is a
+// zero too: it underflows float64, and ParseFloat reports no error for it.
 func TestSchedulingFromEnvRejectsZeroQuantities(t *testing.T) {
-	for _, v := range []string{"0", "0.0", "0Gi", "0m", "+0", "0e3", ".0"} {
-		_, err := schedulingFromEnv(envOf(map[string]string{RequestsCPUEnvVar: v}))
-		if err == nil || !strings.Contains(err.Error(), "zero") || !strings.Contains(err.Error(), RequestsCPUEnvVar) {
-			t.Errorf("%q must be refused as a zero quantity naming the variable, got %v", v, err)
+	for _, v := range []string{"0", "0.0", "0Gi", "0m", "+0", "0e3", ".0", "1e-400", "0.0e0"} {
+		for _, env := range []string{RequestsCPUEnvVar, RequestsMemoryEnvVar} {
+			_, err := schedulingFromEnv(envOf(map[string]string{env: v}))
+			if err == nil || !strings.Contains(err.Error(), "zero") || !strings.Contains(err.Error(), env) {
+				t.Errorf("%s=%q must be refused as a zero quantity naming the variable, got %v", env, v, err)
+			}
 		}
 	}
 }

--- a/pkg/sandbox/kubernetes/driver_scheduling_test.go
+++ b/pkg/sandbox/kubernetes/driver_scheduling_test.go
@@ -96,6 +96,40 @@ func TestSchedulingFromEnvRejectsZeroQuantities(t *testing.T) {
 	}
 }
 
+// Below Kubernetes' precision (1m of CPU, 1 byte of memory) the API server
+// rounds up at admission: such a "floor" is a zero wearing a number. The
+// precision itself is accepted.
+func TestSchedulingFromEnvRejectsQuantitiesBelowPrecision(t *testing.T) {
+	for _, v := range []string{"0.0001", "5e-324", "1e-323", "0.5m"} {
+		_, err := schedulingFromEnv(envOf(map[string]string{RequestsCPUEnvVar: v}))
+		if err == nil || !strings.Contains(err.Error(), "precision") || !strings.Contains(err.Error(), v) {
+			t.Errorf("cpu=%q must be refused as below precision naming the value, got %v", v, err)
+		}
+	}
+	for _, v := range []string{"0.5", "5e-324", "0.9"} {
+		_, err := schedulingFromEnv(envOf(map[string]string{RequestsMemoryEnvVar: v}))
+		if err == nil || !strings.Contains(err.Error(), "precision") || !strings.Contains(err.Error(), v) {
+			t.Errorf("memory=%q must be refused as below precision naming the value, got %v", v, err)
+		}
+	}
+	if _, err := schedulingFromEnv(envOf(map[string]string{RequestsCPUEnvVar: "1m", RequestsMemoryEnvVar: "1"})); err != nil {
+		t.Fatalf("the precision itself must be accepted, got %v", err)
+	}
+}
+
+// A mantissa that fits float64 can still overflow once its suffix is applied;
+// out of range means out of range whichever step produced it.
+func TestSchedulingFromEnvRejectsOverflowAfterScaling(t *testing.T) {
+	v := strings.Repeat("9", 301) + "Ei"
+	_, err := schedulingFromEnv(envOf(map[string]string{RequestsMemoryEnvVar: v}))
+	if err == nil || !strings.Contains(err.Error(), "out of range") || !strings.Contains(err.Error(), RequestsMemoryEnvVar) {
+		t.Fatalf("a scaled overflow must be refused as out of range naming the variable, got %v", err)
+	}
+	if got, err := quantityValue(v); err == nil {
+		t.Fatalf("quantityValue(%q) = %v, want an out-of-range error", v[:8]+"…Ei", got)
+	}
+}
+
 // The suffix must fit the resource: `m` on memory is milli-bytes (a CPU
 // suffix on the wrong variable), a byte suffix on CPU is never a core count.
 func TestSchedulingFromEnvRejectsSuffixOnWrongResource(t *testing.T) {

--- a/pkg/sandbox/kubernetes/driver_scheduling_test.go
+++ b/pkg/sandbox/kubernetes/driver_scheduling_test.go
@@ -12,7 +12,9 @@ func envOf(m map[string]string) func(string) string {
 	return func(k string) string { return m[k] }
 }
 
-func TestSchedulingFromEnvDefaultsToNodeSpreadAndNoResources(t *testing.T) {
+// Unset means the manifest of a driver without the knobs: no resources and
+// no spread — the scheduler's own policy, as before.
+func TestSchedulingFromEnvDefaultsToNothing(t *testing.T) {
 	s, err := schedulingFromEnv(envOf(nil))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -20,8 +22,11 @@ func TestSchedulingFromEnvDefaultsToNodeSpreadAndNoResources(t *testing.T) {
 	if s.resources != (PodResources{}) {
 		t.Fatalf("resources must be unset by default, got %+v", s.resources)
 	}
-	if s.spreadKey != defaultSpreadTopologyKey {
-		t.Fatalf("spread key = %q, want %q by default", s.spreadKey, defaultSpreadTopologyKey)
+	if s.spreadKey != "" {
+		t.Fatalf("spread must be off by default, got %q", s.spreadKey)
+	}
+	if got := s.String(); got != "no resources, no spread" {
+		t.Fatalf("summary = %q", got)
 	}
 }
 
@@ -29,22 +34,33 @@ func TestSchedulingFromEnvParsesQuantities(t *testing.T) {
 	s, err := schedulingFromEnv(envOf(map[string]string{
 		RequestsCPUEnvVar:    " 2 ",
 		RequestsMemoryEnvVar: "4Gi",
-		LimitsCPUEnvVar:      "1.5",
-		LimitsMemoryEnvVar:   "1e3",
+		LimitsCPUEnvVar:      "2.5",
+		LimitsMemoryEnvVar:   "8Gi",
+		SpreadEnvVar:         "hostname",
 	}))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	want := PodResources{
 		Requests: ResourceList{CPU: "2", Memory: "4Gi"},
-		Limits:   ResourceList{CPU: "1.5", Memory: "1e3"},
+		Limits:   ResourceList{CPU: "2.5", Memory: "8Gi"},
 	}
 	if s.resources != want {
 		t.Fatalf("resources = %+v, want %+v", s.resources, want)
 	}
-	for _, v := range []string{"500m", "128Mi", "3", "0.25", "2Ti", "100k"} {
+	if got := s.String(); got != "requests cpu=2 memory=4Gi, limits cpu=2.5 memory=8Gi, spread=kubernetes.io/hostname" {
+		t.Fatalf("summary = %q", got)
+	}
+	// The accepted quantity subset: <digits>, <digits>.<digits>, <digits>., .<digits>,
+	// an optional sign, an exponent, a CPU (m) or byte (k…Ei) suffix.
+	for _, v := range []string{"500m", "3", "0.25", ".5", "1.", "+1", "1e3", "1E3"} {
 		if _, err := schedulingFromEnv(envOf(map[string]string{RequestsCPUEnvVar: v})); err != nil {
-			t.Errorf("%q must be accepted as a quantity: %v", v, err)
+			t.Errorf("%q must be accepted as a CPU quantity: %v", v, err)
+		}
+	}
+	for _, v := range []string{"128Mi", "2Ti", "100k", "0.5Gi", "1e9", "4G"} {
+		if _, err := schedulingFromEnv(envOf(map[string]string{RequestsMemoryEnvVar: v})); err != nil {
+			t.Errorf("%q must be accepted as a memory quantity: %v", v, err)
 		}
 	}
 }
@@ -52,25 +68,87 @@ func TestSchedulingFromEnvParsesQuantities(t *testing.T) {
 // A typo must fail with the variable and the value named, never be rendered
 // for the API server to reject on every pod.
 func TestSchedulingFromEnvRejectsMalformedQuantities(t *testing.T) {
-	for _, v := range []string{"2 cores", "4GB", "-1", "1,5", "Gi", "two"} {
-		_, err := schedulingFromEnv(envOf(map[string]string{LimitsMemoryEnvVar: v}))
+	for _, v := range []string{"2 cores", "4GB", "-1", "1,5", "Gi", "two", "2ki", "1e", ".", "1u", "1n"} {
+		_, err := schedulingFromEnv(envOf(map[string]string{RequestsMemoryEnvVar: v}))
 		if err == nil {
 			t.Errorf("%q must be refused", v)
 			continue
 		}
-		if !strings.Contains(err.Error(), LimitsMemoryEnvVar) || !strings.Contains(err.Error(), v) {
+		if !strings.Contains(err.Error(), RequestsMemoryEnvVar) || !strings.Contains(err.Error(), v) {
 			t.Errorf("error for %q must name the variable and the value, got %q", v, err)
 		}
 	}
 }
 
+// A zero quantity renders a resources block that schedules exactly like no
+// resources block — the one lie the policy exists to prevent.
+func TestSchedulingFromEnvRejectsZeroQuantities(t *testing.T) {
+	for _, v := range []string{"0", "0.0", "0Gi", "0m", "+0", "0e3", ".0"} {
+		_, err := schedulingFromEnv(envOf(map[string]string{RequestsCPUEnvVar: v}))
+		if err == nil || !strings.Contains(err.Error(), "zero") || !strings.Contains(err.Error(), RequestsCPUEnvVar) {
+			t.Errorf("%q must be refused as a zero quantity naming the variable, got %v", v, err)
+		}
+	}
+}
+
+// The suffix must fit the resource: `m` on memory is milli-bytes (a CPU
+// suffix on the wrong variable), a byte suffix on CPU is never a core count.
+func TestSchedulingFromEnvRejectsSuffixOnWrongResource(t *testing.T) {
+	if _, err := schedulingFromEnv(envOf(map[string]string{RequestsMemoryEnvVar: "400m"})); err == nil || !strings.Contains(err.Error(), "milli-byte") {
+		t.Fatalf("memory=400m must be refused as milli-bytes, got %v", err)
+	}
+	if _, err := schedulingFromEnv(envOf(map[string]string{LimitsCPUEnvVar: "2Gi"})); err == nil || !strings.Contains(err.Error(), "byte suffix") {
+		t.Fatalf("cpu=2Gi must be refused as a byte suffix on CPU, got %v", err)
+	}
+}
+
+// A limit without its request becomes the request at admission (the API
+// server copies it), and a limit below its request is rejected there too —
+// both are refused here, where the variable can be named.
+func TestSchedulingFromEnvRequiresRequestUnderLimit(t *testing.T) {
+	_, err := schedulingFromEnv(envOf(map[string]string{LimitsMemoryEnvVar: "8Gi"}))
+	if err == nil || !strings.Contains(err.Error(), LimitsMemoryEnvVar) || !strings.Contains(err.Error(), RequestsMemoryEnvVar) {
+		t.Fatalf("a limit without its request must be refused naming both variables, got %v", err)
+	}
+	_, err = schedulingFromEnv(envOf(map[string]string{RequestsCPUEnvVar: "2", LimitsCPUEnvVar: "500m"}))
+	if err == nil || !strings.Contains(err.Error(), "below") {
+		t.Fatalf("a limit below its request must be refused, got %v", err)
+	}
+	_, err = schedulingFromEnv(envOf(map[string]string{RequestsMemoryEnvVar: "4Gi", LimitsMemoryEnvVar: "4096Mi"}))
+	if err != nil {
+		t.Fatalf("an equal limit in another unit must be accepted, got %v", err)
+	}
+	_, err = schedulingFromEnv(envOf(map[string]string{RequestsMemoryEnvVar: "4Gi", LimitsMemoryEnvVar: "4G"}))
+	if err == nil {
+		t.Fatalf("4G (decimal) is below 4Gi (binary) and must be refused")
+	}
+}
+
+func TestQuantityValue(t *testing.T) {
+	cases := map[string]float64{
+		"2": 2, "500m": 0.5, "4Gi": 4 * (1 << 30), "4G": 4e9, "1e3": 1000, ".5": 0.5, "1.": 1, "+3": 3, "128Mi": 128 * (1 << 20),
+	}
+	for v, want := range cases {
+		if got := quantityValue(v); got != want {
+			t.Errorf("quantityValue(%q) = %v, want %v", v, got, want)
+		}
+	}
+}
+
+// The keywords fold case; anything else must be a prefixed label key — a bare
+// word is a typo the API server would accept as a label no node carries,
+// which turns the spread into a silent no-op.
 func TestSchedulingFromEnvSpreadSelector(t *testing.T) {
 	cases := map[string]string{
-		"":                            defaultSpreadTopologyKey,
-		"hostname":                    defaultSpreadTopologyKey,
+		"":                            "",
 		"none":                        "",
+		"NONE":                        "",
 		"off":                         "",
+		"Off":                         "",
+		"hostname":                    hostnameTopologyKey,
+		"Hostname":                    hostnameTopologyKey,
 		"topology.kubernetes.io/zone": "topology.kubernetes.io/zone",
+		"example.com/Rack_1":          "example.com/Rack_1",
 	}
 	for v, want := range cases {
 		s, err := schedulingFromEnv(envOf(map[string]string{SpreadEnvVar: v}))
@@ -82,8 +160,41 @@ func TestSchedulingFromEnvSpreadSelector(t *testing.T) {
 			t.Errorf("%q: spread key = %q, want %q", v, s.spreadKey, want)
 		}
 	}
-	if _, err := schedulingFromEnv(envOf(map[string]string{SpreadEnvVar: "not a key"})); err == nil || !strings.Contains(err.Error(), SpreadEnvVar) {
-		t.Fatalf("a key with whitespace must be refused naming the variable, got %v", err)
+	for _, v := range []string{"zone", "node", "hostnmae", "true", "1", "disabled", "not a key", "/zone", "Example.com/zone", "example.com/", "example.com/-zone", "bad/key/again"} {
+		_, err := schedulingFromEnv(envOf(map[string]string{SpreadEnvVar: v}))
+		if err == nil || !strings.Contains(err.Error(), SpreadEnvVar) || !strings.Contains(err.Error(), v) {
+			t.Errorf("%q must be refused naming the variable and the value, got %v", v, err)
+		}
+	}
+}
+
+func TestSchedulingPolicyReportsSummaryOrError(t *testing.T) {
+	sched, _ := schedulingFromEnv(envOf(map[string]string{RequestsCPUEnvVar: "2", SpreadEnvVar: "hostname"}))
+	d := &Driver{namespace: "test", sched: sched}
+	if got, err := d.SchedulingPolicy(); err != nil || got != "requests cpu=2, spread=kubernetes.io/hostname" {
+		t.Fatalf("SchedulingPolicy = %q, %v", got, err)
+	}
+	if d.SpreadTopologyKey() != hostnameTopologyKey {
+		t.Fatalf("SpreadTopologyKey = %q", d.SpreadTopologyKey())
+	}
+	_, schedErr := schedulingFromEnv(envOf(map[string]string{RequestsCPUEnvVar: "two"}))
+	bad := &Driver{namespace: "test", schedErr: schedErr}
+	if _, err := bad.SchedulingPolicy(); err == nil || !strings.Contains(err.Error(), RequestsCPUEnvVar) {
+		t.Fatalf("SchedulingPolicy must return the parse error naming the variable, got %v", err)
+	}
+	var _ sandbox.SchedulingPolicyReporter = bad
+}
+
+// ValidateSchedulingEnv is what the runner calls at bootstrap; it must read
+// the real environment and return the same error Start would.
+func TestValidateSchedulingEnvReadsTheProcessEnvironment(t *testing.T) {
+	t.Setenv(RequestsCPUEnvVar, "2 cores")
+	if err := ValidateSchedulingEnv(); err == nil || !strings.Contains(err.Error(), RequestsCPUEnvVar) {
+		t.Fatalf("expected the malformed value to be refused naming the variable, got %v", err)
+	}
+	t.Setenv(RequestsCPUEnvVar, "2")
+	if err := ValidateSchedulingEnv(); err != nil {
+		t.Fatalf("a valid value must pass, got %v", err)
 	}
 }
 

--- a/pkg/sandbox/kubernetes/driver_start_scheduling_test.go
+++ b/pkg/sandbox/kubernetes/driver_start_scheduling_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	iterlog "github.com/SocialGouv/iterion/pkg/log"
 	"github.com/SocialGouv/iterion/pkg/sandbox"
@@ -155,6 +156,24 @@ func TestNodeLabelCoverageReportsKubectlStderr(t *testing.T) {
 	_, _, err := NodeLabelCoverage(context.Background(), "topology.kubernetes.io/zone")
 	if err == nil || !strings.Contains(err.Error(), "Forbidden") || !strings.Contains(err.Error(), "cannot list resource") {
 		t.Fatalf("the error must carry kubectl's stderr, got %v", err)
+	}
+}
+
+// A cancelled context kills kubectl but not a child holding its pipes (a
+// credential plugin, here `sleep` under `sh`); the wait must still end near
+// the deadline, not when the child exits.
+func TestNodeLabelCoverageTimeoutIsBoundedWhenAChildHoldsThePipes(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte("#!/bin/sh\nsleep 5\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, _, err := NodeLabelCoverage(ctx, "topology.kubernetes.io/zone")
+	if elapsed := time.Since(start); err == nil || elapsed > 4*time.Second {
+		t.Fatalf("the wait must end within the deadline plus WaitDelay, took %s (err %v)", elapsed, err)
 	}
 }
 

--- a/pkg/sandbox/kubernetes/driver_start_scheduling_test.go
+++ b/pkg/sandbox/kubernetes/driver_start_scheduling_test.go
@@ -138,3 +138,22 @@ func TestNodeLabelCoverageCountsLabelledNodes(t *testing.T) {
 		t.Fatalf("coverage for an absent key = %d/%d, %v; want 0/3", labelled, total, err)
 	}
 }
+
+// The chart's runner Role cannot list nodes; the error must carry kubectl's
+// reason, not a bare exit status the doctor cannot explain.
+func TestNodeLabelCoverageReportsKubectlStderr(t *testing.T) {
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"case \"$*\" in\n" +
+		"  \"get nodes \"*) echo 'Error from server (Forbidden): nodes is forbidden: User \"system:serviceaccount:ns:runner\" cannot list resource \"nodes\" in API group \"\" at the cluster scope' >&2; exit 1 ;;\n" +
+		"esac\n" +
+		"exit 1\n"
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	_, _, err := NodeLabelCoverage(context.Background(), "topology.kubernetes.io/zone")
+	if err == nil || !strings.Contains(err.Error(), "Forbidden") || !strings.Contains(err.Error(), "cannot list resource") {
+		t.Fatalf("the error must carry kubectl's stderr, got %v", err)
+	}
+}

--- a/pkg/sandbox/kubernetes/driver_start_scheduling_test.go
+++ b/pkg/sandbox/kubernetes/driver_start_scheduling_test.go
@@ -1,0 +1,140 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	iterlog "github.com/SocialGouv/iterion/pkg/log"
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+)
+
+// kubectlCaptureShim puts a fake `kubectl` first on PATH that records every
+// manifest piped to `apply -f -` into the capture file and succeeds at
+// everything else, so Start can be driven end to end without a cluster and
+// the pod it actually applies can be read back.
+func kubectlCaptureShim(t *testing.T) (capture string) {
+	t.Helper()
+	dir := t.TempDir()
+	capture = filepath.Join(dir, "applied.jsonl")
+	script := "#!/bin/sh\n" +
+		"case \"$*\" in\n" +
+		"  *\" apply \"*) cat >> \"$ITERION_TEST_KUBECTL_CAPTURE\"; printf '\\n---\\n' >> \"$ITERION_TEST_KUBECTL_CAPTURE\"; exit 0 ;;\n" +
+		"esac\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("ITERION_TEST_KUBECTL_CAPTURE", capture)
+	return capture
+}
+
+// appliedPod returns the Pod manifest Start piped to `kubectl apply`.
+func appliedPod(t *testing.T, capture string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatalf("nothing was applied: %v", err)
+	}
+	for _, doc := range strings.Split(string(raw), "\n---\n") {
+		doc = strings.TrimSpace(doc)
+		if doc == "" {
+			continue
+		}
+		var obj map[string]any
+		if err := json.Unmarshal([]byte(doc), &obj); err != nil {
+			t.Fatalf("applied manifest is not JSON: %v\n%s", err, doc)
+		}
+		if obj["kind"] == "Pod" {
+			return obj
+		}
+	}
+	t.Fatalf("no Pod among the applied manifests:\n%s", raw)
+	return nil
+}
+
+// The parsed policy must reach the pod Start applies — the manifest tests
+// render PodManifestInput directly, so only this test covers the one
+// production composition site (the BuildPodManifest call in Start).
+func TestStartAppliesTheSchedulingPolicy(t *testing.T) {
+	capture := kubectlCaptureShim(t)
+	sched, err := schedulingFromEnv(envOf(map[string]string{
+		RequestsCPUEnvVar:    "2",
+		RequestsMemoryEnvVar: "4Gi",
+		SpreadEnvVar:         "hostname",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := &Driver{namespace: "ns", kubectl: "kubectl", logger: iterlog.New(iterlog.LevelInfo, io.Discard), sched: sched}
+	prepared := &Prepared{spec: sandbox.Spec{Image: "img", User: "1000:1000"}, workspace: "/workspace"}
+	_, startErr := d.Start(context.Background(), prepared, sandbox.RunInfo{RunID: "01a0-run"})
+
+	pod := appliedPod(t, capture)
+	spec, _ := pod["spec"].(map[string]any)
+	containers, _ := spec["containers"].([]any)
+	if len(containers) != 1 {
+		t.Fatalf("applied pod has %d containers: %v", len(containers), spec)
+	}
+	c, _ := containers[0].(map[string]any)
+	res, _ := c["resources"].(map[string]any)
+	req, _ := res["requests"].(map[string]any)
+	if req["cpu"] != "2" || req["memory"] != "4Gi" {
+		t.Fatalf("applied pod must carry the parsed requests, got resources=%v (Start error: %v)", res, startErr)
+	}
+	spread, _ := spec["topologySpreadConstraints"].([]any)
+	if len(spread) != 1 {
+		t.Fatalf("applied pod must carry the spread constraint, got %v (Start error: %v)", spec["topologySpreadConstraints"], startErr)
+	}
+	if startErr != nil {
+		// The shim answers every later kubectl call with an empty success;
+		// a Start that still fails after the apply is a change in what Start
+		// needs from the cluster and must be looked at, not ignored.
+		t.Fatalf("Start failed after applying the pod: %v", startErr)
+	}
+}
+
+// Without a policy the applied pod is the manifest of a driver that never
+// had the knobs.
+func TestStartAppliesNoPolicyByDefault(t *testing.T) {
+	capture := kubectlCaptureShim(t)
+	sched, _ := schedulingFromEnv(envOf(nil))
+	d := &Driver{namespace: "ns", kubectl: "kubectl", logger: iterlog.New(iterlog.LevelInfo, io.Discard), sched: sched}
+	prepared := &Prepared{spec: sandbox.Spec{Image: "img", User: "1000:1000"}, workspace: "/workspace"}
+	_, _ = d.Start(context.Background(), prepared, sandbox.RunInfo{RunID: "01a0-run"})
+	pod := appliedPod(t, capture)
+	spec, _ := pod["spec"].(map[string]any)
+	c, _ := spec["containers"].([]any)[0].(map[string]any)
+	if _, present := c["resources"]; present {
+		t.Fatalf("no resources must be rendered by default, got %v", c["resources"])
+	}
+	if _, present := spec["topologySpreadConstraints"]; present {
+		t.Fatalf("no spread must be rendered by default, got %v", spec["topologySpreadConstraints"])
+	}
+}
+
+func TestNodeLabelCoverageCountsLabelledNodes(t *testing.T) {
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"case \"$*\" in\n" +
+		"  \"get nodes \"*) printf '%s' '{\"items\":[{\"metadata\":{\"labels\":{\"kubernetes.io/hostname\":\"a\",\"topology.kubernetes.io/zone\":\"z1\"}}},{\"metadata\":{\"labels\":{\"kubernetes.io/hostname\":\"b\"}}},{\"metadata\":{\"labels\":{\"kubernetes.io/hostname\":\"c\",\"topology.kubernetes.io/zone\":\"z2\"}}}]}'; exit 0 ;;\n" +
+		"esac\n" +
+		"exit 1\n"
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	labelled, total, err := NodeLabelCoverage(context.Background(), "topology.kubernetes.io/zone")
+	if err != nil || labelled != 2 || total != 3 {
+		t.Fatalf("coverage = %d/%d, %v; want 2/3", labelled, total, err)
+	}
+	labelled, total, err = NodeLabelCoverage(context.Background(), "example.com/rack")
+	if err != nil || labelled != 0 || total != 3 {
+		t.Fatalf("coverage for an absent key = %d/%d, %v; want 0/3", labelled, total, err)
+	}
+}

--- a/pkg/sandbox/kubernetes/driver_start_scheduling_test.go
+++ b/pkg/sandbox/kubernetes/driver_start_scheduling_test.go
@@ -157,3 +157,17 @@ func TestNodeLabelCoverageReportsKubectlStderr(t *testing.T) {
 		t.Fatalf("the error must carry kubectl's stderr, got %v", err)
 	}
 }
+
+// A failure with nothing on stderr (a killed probe) must not end in a
+// dangling separator.
+func TestNodeLabelCoverageWithoutStderrKeepsTheExitError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	_, _, err := NodeLabelCoverage(context.Background(), "topology.kubernetes.io/zone")
+	if err == nil || err.Error() != "kubectl get nodes: exit status 1" {
+		t.Fatalf("want the bare exit error, got %q", err)
+	}
+}

--- a/pkg/sandbox/kubernetes/manifest.go
+++ b/pkg/sandbox/kubernetes/manifest.go
@@ -126,6 +126,84 @@ type PodManifestInput struct {
 	// rather than idling as `sleep infinity` forever. Derived from the
 	// run's max_duration + a margin (see driver.go). See ADR-070.
 	ActiveDeadlineSeconds int64
+
+	// Resources is rendered as the workload container's `resources` block.
+	// A pod that requests nothing scores every node the same, so the
+	// scheduler packs the runs of a whole campaign onto the node that
+	// already holds the image (measured: 5 of 6 run pods on one 8-core
+	// worker at 89 % CPU while two workers idled — an oracle's 300 s boot
+	// budget blown at 459 s). The request is what makes LeastAllocated
+	// spread them and what lets a cluster autoscaler size the pool. Zero
+	// value → no `resources` key, the manifest of a driver without the knob.
+	Resources PodResources
+
+	// SpreadTopologyKey, when non-empty, adds a soft
+	// topologySpreadConstraint (maxSkew 1, ScheduleAnyway) over that
+	// topology key across every pod carrying the sandbox-run component
+	// label — the steering that requests alone don't give when nodes are
+	// equally loaded. Soft: it never makes a pod unschedulable.
+	SpreadTopologyKey string
+}
+
+// PodResources is the `resources` block of the workload container.
+// Quantities are Kubernetes strings passed through verbatim (the driver
+// validates their grammar at startup, the API server their semantics);
+// "" means unset and the key is omitted.
+type PodResources struct {
+	Requests ResourceList
+	Limits   ResourceList
+}
+
+// ResourceList is one side of a resources block (requests or limits).
+type ResourceList struct {
+	CPU    string
+	Memory string
+}
+
+// json renders the list with only its set quantities, nil when empty.
+func (l ResourceList) json() map[string]any {
+	out := map[string]any{}
+	if l.CPU != "" {
+		out["cpu"] = l.CPU
+	}
+	if l.Memory != "" {
+		out["memory"] = l.Memory
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// json renders the block with only its set sides, nil when nothing is set
+// so the caller omits the key entirely.
+func (r PodResources) json() map[string]any {
+	out := map[string]any{}
+	if req := r.Requests.json(); req != nil {
+		out["requests"] = req
+	}
+	if lim := r.Limits.json(); lim != nil {
+		out["limits"] = lim
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// spreadConstraintJSON renders the soft topology spread over the sandbox-run
+// pods for the given topology key.
+func spreadConstraintJSON(topologyKey string) []any {
+	return []any{
+		map[string]any{
+			"maxSkew":           1,
+			"topologyKey":       topologyKey,
+			"whenUnsatisfiable": "ScheduleAnyway",
+			"labelSelector": map[string]any{
+				"matchLabels": map[string]any{LabelComponent: ComponentSandboxRun},
+			},
+		},
+	}
 }
 
 // caSecretKey is the Secret data key + projected filename for the egress
@@ -284,6 +362,20 @@ func BuildPodManifest(in PodManifestInput) ([]byte, error) {
 	volumes = append(volumes, secretFileVolumes...)
 	volumes = append(volumes, caVolumes...)
 
+	workload := map[string]any{
+		"name":            "workload",
+		"image":           in.Spec.Image,
+		"imagePullPolicy": pullPolicyForImage(in.Spec.Image),
+		"command":         []any{"sleep", "infinity"},
+		"workingDir":      workspace,
+		"env":             envSlice,
+		"securityContext": defaultContainerSecurityContext(in.Spec.User),
+		"volumeMounts":    volumeMounts,
+	}
+	if res := in.Resources.json(); res != nil {
+		workload["resources"] = res
+	}
+
 	podSpec := map[string]any{
 		"restartPolicy":                "Never",
 		"automountServiceAccountToken": false,
@@ -292,24 +384,16 @@ func BuildPodManifest(in PodManifestInput) ([]byte, error) {
 			"seccompProfile": map[string]any{"type": "RuntimeDefault"},
 			"fsGroup":        1000,
 		},
-		"containers": []any{
-			map[string]any{
-				"name":            "workload",
-				"image":           in.Spec.Image,
-				"imagePullPolicy": pullPolicyForImage(in.Spec.Image),
-				"command":         []any{"sleep", "infinity"},
-				"workingDir":      workspace,
-				"env":             envSlice,
-				"securityContext": defaultContainerSecurityContext(in.Spec.User),
-				"volumeMounts":    volumeMounts,
-			},
-		},
-		"volumes": volumes,
+		"containers": []any{workload},
+		"volumes":    volumes,
 	}
 	// Bound the pod's lifetime so a leaked pod self-fails instead of
 	// idling forever (runner killed mid-run before Cleanup fired).
 	if in.ActiveDeadlineSeconds > 0 {
 		podSpec["activeDeadlineSeconds"] = in.ActiveDeadlineSeconds
+	}
+	if in.SpreadTopologyKey != "" {
+		podSpec["topologySpreadConstraints"] = spreadConstraintJSON(in.SpreadTopologyKey)
 	}
 
 	pod := map[string]any{

--- a/pkg/sandbox/kubernetes/manifest_scheduling_test.go
+++ b/pkg/sandbox/kubernetes/manifest_scheduling_test.go
@@ -1,0 +1,106 @@
+package kubernetes
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/SocialGouv/iterion/pkg/sandbox"
+)
+
+func renderPodSpec(t *testing.T, in PodManifestInput) map[string]any {
+	t.Helper()
+	raw, err := BuildPodManifest(in)
+	if err != nil {
+		t.Fatalf("BuildPodManifest: %v", err)
+	}
+	var pod struct {
+		Spec map[string]any `json:"spec"`
+	}
+	if err := json.Unmarshal(raw, &pod); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	return pod.Spec
+}
+
+func schedulingInput() PodManifestInput {
+	return PodManifestInput{
+		Namespace: "iterion",
+		Name:      "iterion-run-test",
+		RunID:     "test",
+		Spec:      sandbox.Spec{Image: "ghcr.io/x/sandbox:edge", User: "1000:1000"},
+	}
+}
+
+func workloadContainer(t *testing.T, spec map[string]any) map[string]any {
+	t.Helper()
+	containers, _ := spec["containers"].([]any)
+	if len(containers) != 1 {
+		t.Fatalf("want exactly one container, got %v", spec["containers"])
+	}
+	c, _ := containers[0].(map[string]any)
+	return c
+}
+
+// A pod that requests nothing scores every node the same — the manifest must
+// carry exactly the quantities the operator set, and nothing it did not.
+func TestManifestRendersOnlySetResources(t *testing.T) {
+	in := schedulingInput()
+	in.Resources = PodResources{
+		Requests: ResourceList{CPU: "2", Memory: "4Gi"},
+		Limits:   ResourceList{Memory: "8Gi"},
+	}
+	c := workloadContainer(t, renderPodSpec(t, in))
+	want := map[string]any{
+		"requests": map[string]any{"cpu": "2", "memory": "4Gi"},
+		"limits":   map[string]any{"memory": "8Gi"},
+	}
+	if got := c["resources"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("resources = %v, want %v", got, want)
+	}
+}
+
+func TestManifestOmitsResourcesWhenNothingSet(t *testing.T) {
+	c := workloadContainer(t, renderPodSpec(t, schedulingInput()))
+	if _, present := c["resources"]; present {
+		t.Fatalf("resources key must be absent when nothing is set, got %v", c["resources"])
+	}
+	in := schedulingInput()
+	in.Resources = PodResources{Limits: ResourceList{CPU: "4"}}
+	c = workloadContainer(t, renderPodSpec(t, in))
+	res, _ := c["resources"].(map[string]any)
+	if _, present := res["requests"]; present {
+		t.Fatalf("an unset requests side must be absent, got %v", res)
+	}
+	if !reflect.DeepEqual(res["limits"], map[string]any{"cpu": "4"}) {
+		t.Fatalf("limits = %v, want cpu 4 only", res["limits"])
+	}
+}
+
+// The spread must select the sandbox-run component label — every run pod of
+// the deployment, and only them — and stay soft so it never blocks scheduling.
+func TestManifestSpreadConstraintOverSandboxRunPods(t *testing.T) {
+	in := schedulingInput()
+	in.SpreadTopologyKey = "kubernetes.io/hostname"
+	spec := renderPodSpec(t, in)
+	want := []any{
+		map[string]any{
+			"maxSkew":           float64(1),
+			"topologyKey":       "kubernetes.io/hostname",
+			"whenUnsatisfiable": "ScheduleAnyway",
+			"labelSelector": map[string]any{
+				"matchLabels": map[string]any{LabelComponent: ComponentSandboxRun},
+			},
+		},
+	}
+	if got := spec["topologySpreadConstraints"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("topologySpreadConstraints = %v, want %v", got, want)
+	}
+}
+
+func TestManifestNoSpreadWithoutTopologyKey(t *testing.T) {
+	spec := renderPodSpec(t, schedulingInput())
+	if _, present := spec["topologySpreadConstraints"]; present {
+		t.Fatalf("topologySpreadConstraints must be absent without a key, got %v", spec["topologySpreadConstraints"])
+	}
+}

--- a/pkg/sandbox/kubernetes/manifest_scheduling_test.go
+++ b/pkg/sandbox/kubernetes/manifest_scheduling_test.go
@@ -79,9 +79,27 @@ func TestManifestOmitsResourcesWhenNothingSet(t *testing.T) {
 
 // The spread must select the sandbox-run component label — every run pod of
 // the deployment, and only them — and stay soft so it never blocks scheduling.
+// The pod itself must carry that label: a selector matching no pod counts
+// zero in every domain, and the constraint steers nothing without a single
+// Kubernetes error.
 func TestManifestSpreadConstraintOverSandboxRunPods(t *testing.T) {
 	in := schedulingInput()
 	in.SpreadTopologyKey = "kubernetes.io/hostname"
+	raw, err := BuildPodManifest(in)
+	if err != nil {
+		t.Fatalf("BuildPodManifest: %v", err)
+	}
+	var pod struct {
+		Metadata struct {
+			Labels map[string]string `json:"labels"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(raw, &pod); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if pod.Metadata.Labels[LabelComponent] != ComponentSandboxRun {
+		t.Fatalf("the pod must carry the label its own spread selector matches, labels = %v", pod.Metadata.Labels)
+	}
 	spec := renderPodSpec(t, in)
 	want := []any{
 		map[string]any{

--- a/pkg/sandbox/kubernetes/runtime.go
+++ b/pkg/sandbox/kubernetes/runtime.go
@@ -163,7 +163,10 @@ func NodeLabelCoverage(ctx context.Context, key string) (labelled, total int, er
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
-		return 0, 0, fmt.Errorf("kubectl get nodes: %w: %s", err, strings.TrimSpace(stderr.String()))
+		if reason := strings.TrimSpace(stderr.String()); reason != "" {
+			return 0, 0, fmt.Errorf("kubectl get nodes: %w: %s", err, reason)
+		}
+		return 0, 0, fmt.Errorf("kubectl get nodes: %w", err)
 	}
 	var nodes struct {
 		Items []struct {

--- a/pkg/sandbox/kubernetes/runtime.go
+++ b/pkg/sandbox/kubernetes/runtime.go
@@ -33,6 +33,7 @@ package kubernetes
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -139,7 +140,57 @@ func waitForPodRunning(ctx context.Context, namespace, podName string, timeoutSe
 		fmt.Sprintf("--timeout=%ds", timeoutSecs))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("kubectl wait pod/%s: %w\noutput: %s", podName, err, string(out))
+		// `kubectl wait` only says the condition never came. The cluster
+		// knows WHY, and the reason decides between two different fixes: a
+		// resource request no node can hold (Unschedulable: Insufficient
+		// memory) and a slow or broken image pull. Read it on the error
+		// path only.
+		return fmt.Errorf("kubectl wait pod/%s: %w\noutput: %s%s", podName, err, string(out), podScheduledReason(ctx, namespace, podName))
 	}
 	return nil
+}
+
+// NodeLabelCoverage counts the cluster's nodes and those carrying the label
+// key, for the doctor: a topology spread over a key some nodes lack
+// excludes those nodes from scheduling, soft constraint or not, and a key
+// no node carries leaves every pod Pending.
+func NodeLabelCoverage(ctx context.Context, key string) (labelled, total int, err error) {
+	cmd := kubectlCmdContext(ctx, "get", "nodes", "-o", "json")
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, 0, fmt.Errorf("kubectl get nodes: %w", err)
+	}
+	var nodes struct {
+		Items []struct {
+			Metadata struct {
+				Labels map[string]string `json:"labels"`
+			} `json:"metadata"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(out, &nodes); err != nil {
+		return 0, 0, fmt.Errorf("kubectl get nodes: decode: %w", err)
+	}
+	for _, n := range nodes.Items {
+		if _, ok := n.Metadata.Labels[key]; ok {
+			labelled++
+		}
+	}
+	return labelled, len(nodes.Items), nil
+}
+
+// podScheduledReason renders the pod's PodScheduled condition (status,
+// reason, message) as a "\nscheduling: …" suffix for a wait error — "" when
+// it cannot be read. Best-effort: it decorates an error, it never creates one.
+func podScheduledReason(ctx context.Context, namespace, podName string) string {
+	cmd := kubectlCmdContext(ctx, "--namespace", namespace, "get", "pod", podName, "-o",
+		`jsonpath={.status.conditions[?(@.type=="PodScheduled")].status}{" "}{.status.conditions[?(@.type=="PodScheduled")].reason}{": "}{.status.conditions[?(@.type=="PodScheduled")].message}`)
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	reason := strings.TrimSpace(string(out))
+	if reason == "" || reason == ":" {
+		return ""
+	}
+	return "\nscheduling: " + reason
 }

--- a/pkg/sandbox/kubernetes/runtime.go
+++ b/pkg/sandbox/kubernetes/runtime.go
@@ -38,6 +38,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/SocialGouv/iterion/pkg/internal/proc"
 )
@@ -96,6 +97,11 @@ func kubectlCmdContext(ctx context.Context, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, kubeBinaryName, args...)
 	cmd.Env = append(cmd.Environ(), "LC_ALL=C", "LANG=C")
 	proc.DetachProcessGroup(cmd)
+	// A cancelled context kills kubectl, not the children it spawned (the
+	// process group is detached): a credential plugin still holding the
+	// stdout/stderr pipes would keep Wait blocked for as long as it lives.
+	// WaitDelay bounds that orphan-pipe wait so a timeout is a timeout.
+	cmd.WaitDelay = 2 * time.Second
 	return cmd
 }
 

--- a/pkg/sandbox/kubernetes/runtime.go
+++ b/pkg/sandbox/kubernetes/runtime.go
@@ -153,12 +153,17 @@ func waitForPodRunning(ctx context.Context, namespace, podName string, timeoutSe
 // NodeLabelCoverage counts the cluster's nodes and those carrying the label
 // key, for the doctor: a topology spread over a key some nodes lack
 // excludes those nodes from scheduling, soft constraint or not, and a key
-// no node carries leaves every pod Pending.
+// no node carries leaves every pod Pending. Listing nodes is a
+// cluster-scoped permission the chart's namespaced runner Role does not
+// grant on purpose, so the error must carry kubectl's reason (Forbidden)
+// for the doctor to say why it could not answer.
 func NodeLabelCoverage(ctx context.Context, key string) (labelled, total int, err error) {
 	cmd := kubectlCmdContext(ctx, "get", "nodes", "-o", "json")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
-		return 0, 0, fmt.Errorf("kubectl get nodes: %w", err)
+		return 0, 0, fmt.Errorf("kubectl get nodes: %w: %s", err, strings.TrimSpace(stderr.String()))
 	}
 	var nodes struct {
 		Items []struct {
@@ -188,8 +193,10 @@ func podScheduledReason(ctx context.Context, namespace, podName string) string {
 	if err != nil {
 		return ""
 	}
-	reason := strings.TrimSpace(string(out))
-	if reason == "" || reason == ":" {
+	// A scheduled pod has no reason and no message: the jsonpath's literal
+	// ": " then dangles after the status and is dropped here.
+	reason := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(string(out)), ":"))
+	if reason == "" {
 		return ""
 	}
 	return "\nscheduling: " + reason

--- a/pkg/sandbox/kubernetes/runtime_wait_test.go
+++ b/pkg/sandbox/kubernetes/runtime_wait_test.go
@@ -43,6 +43,20 @@ func TestWaitForPodRunningNamesTheSchedulingReason(t *testing.T) {
 	}
 }
 
+// A scheduled pod that never became Ready has a status but no reason and no
+// message; the decoration must not end in the jsonpath's dangling colon.
+func TestWaitForPodRunningScheduledPodReportsTheStatusOnly(t *testing.T) {
+	kubectlShim(t, "True : ")
+	err := waitForPodRunning(context.Background(), "ns", "iterion-run-x", 1)
+	if err == nil {
+		t.Fatal("expected the wait to fail")
+	}
+	msg := err.Error()
+	if !strings.HasSuffix(msg, "\nscheduling: True") {
+		t.Fatalf("a scheduled pod must report `scheduling: True` and nothing after it, got %q", msg)
+	}
+}
+
 func TestWaitForPodRunningWithoutConditionKeepsTheWaitError(t *testing.T) {
 	kubectlShim(t, "")
 	err := waitForPodRunning(context.Background(), "ns", "iterion-run-x", 1)

--- a/pkg/sandbox/kubernetes/runtime_wait_test.go
+++ b/pkg/sandbox/kubernetes/runtime_wait_test.go
@@ -1,0 +1,52 @@
+package kubernetes
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// kubectlShim puts a fake `kubectl` first on PATH whose `wait` times out and
+// whose `get pod … -o jsonpath=…` answers with the given scheduling
+// condition, so the wait error path can be exercised without a cluster.
+func kubectlShim(t *testing.T, scheduledCondition string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\n" +
+		"case \"$*\" in\n" +
+		"  *\" wait \"*) echo 'error: timed out waiting for the condition on pods/iterion-run-x'; exit 1 ;;\n" +
+		"  *\" get pod \"*) printf '%s' '" + scheduledCondition + "'; exit 0 ;;\n" +
+		"esac\n" +
+		"exit 2\n"
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// A pod that never becomes Ready must say why: a request no node can hold
+// reads differently from a slow image pull, and the fix differs.
+func TestWaitForPodRunningNamesTheSchedulingReason(t *testing.T) {
+	kubectlShim(t, "False Unschedulable: 0/3 nodes are available: 3 Insufficient memory.")
+	err := waitForPodRunning(context.Background(), "ns", "iterion-run-x", 1)
+	if err == nil {
+		t.Fatal("expected the wait to fail")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "timed out waiting for the condition") {
+		t.Fatalf("the kubectl wait output must be kept, got %q", msg)
+	}
+	if !strings.Contains(msg, "scheduling: False Unschedulable: 0/3 nodes are available: 3 Insufficient memory.") {
+		t.Fatalf("the PodScheduled condition must be appended, got %q", msg)
+	}
+}
+
+func TestWaitForPodRunningWithoutConditionKeepsTheWaitError(t *testing.T) {
+	kubectlShim(t, "")
+	err := waitForPodRunning(context.Background(), "ns", "iterion-run-x", 1)
+	if err == nil || strings.Contains(err.Error(), "scheduling:") {
+		t.Fatalf("an unreadable condition must not decorate the error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Problem (measured in production, 2026-09-04)

A sibling run pod that requests nothing scores every node the same, so the scheduler packs a campaign's runs onto whichever node already holds the sandbox image. On a three-worker pool (8 cores / 30 GiB each):

| node | run pods | CPU | memory |
|---|---|---|---|
| A | 5 of 6 | 89 % | 81 % |
| B | 0 | 29 % | — |
| C | 1 | 59 % | — |

Four hours later the same node held **7 of 8** run pods (two of them another tenant's) at **100 % CPU** while the two others sat at 23 % and 29 %. A behavioural oracle's application boot (Postgres, Keycloak, RabbitMQ, two Spring Boot apps) took **459 s against its 300 s budget** on that node: red verdicts on untouched trees, one run burning its 8 h budget looping on that red.

Nothing outside the engine fixes it cleanly: the workload autoscaler manages Deployments, not bare pods; a namespace `LimitRange` would also stamp the 16 datastore/sidecar containers that carry no request; an admission policy was not honoured on that cluster. `BuildPodManifest` is the single chokepoint every run pod goes through.

## Change

- `PodManifestInput` gains `Resources` (requests/limits, only the set keys are rendered) and `SpreadTopologyKey` (a soft `topologySpreadConstraints` over the `sandbox-run` label, `ScheduleAnyway`, `maxSkew: 1`). Nothing set → the manifest is **byte-identical** to today's (proved: 1743 bytes, `cmp` clean).
- The policy is read once in `New()` from `ITERION_SANDBOX_K8S_{REQUESTS,LIMITS}_{CPU,MEMORY}` and `ITERION_SANDBOX_K8S_SPREAD` (`none` | `hostname` | a prefixed topology label key). Spread is **off unless set**.
- Every set quantity is evaluated once and refused explicitly when malformed, zero (including a float64 underflow such as `1e-400`), below Kubernetes' precision (1m of CPU, 1 byte of memory), out of range (before or after its suffix), milli-byte memory, byte-suffixed CPU, a limit without its request, a limit below its request; a spread key must be a prefixed label key. The **runner validates at bootstrap** and refuses to start on a malformed value (the sandbox driver factory skips constructor errors, so nothing downstream could refuse it — every run would fail at sandbox start instead). `Start` refuses too.
- Chart: `runner.sandbox.scheduling` renders the knobs as **literal PodTemplate env**, never through the shared ConfigMap (a pod created from an old ReplicaSet must keep the policy it was rendered under). Values comment + `docs/sandbox.md` document the `runnerEpoch` bump as part of the rollout.
- Observability: `sandbox doctor` reports the policy or its error; `--strict` checks that the nodes carry a custom spread key (a soft constraint does **not** waive the label — nodes without it are excluded) and, when it cannot list nodes, asserts only the cause it knows (Forbidden → the chart's namespaced Role, on purpose; a deadline → the probe budget) and hands over `kubectl get nodes -L <key>`; `sandbox_started` records the policy the pod was rendered under; a pod-wait timeout appends the `PodScheduled` reason; the kubernetes driver's logger is finally wired into the run log.
- `kubectlCmdContext` (every kubectl call) now sets `WaitDelay = 2 s`: a cancelled context kills kubectl but not a child holding its pipes (a credential plugin), and the wait used to block until that child exited.

## Review trail

- Plan reviewed adversarially by a model of another family (11 findings: 7 adopted, 3 adjusted, 1 deferred — recorded in the plan).
- Four adversarial code-review rounds on the diff, each finding verified before fixing: round 1 on two surfaces (driver; manifest on a real kind cluster) → 3 high / 5 medium / 2 low, all folded in; rounds 2, 3 and 4 (verification of the previous round's fixes) → 2 medium / 2 low, 1 medium / 3 low, 1 medium / 3 low, all folded in. Nothing high or critical after round 1; the last round's medium was a pre-existing missing `WaitDelay` that the new hint made visible.
- Falsification: 22 mutants (drop the resources rendering, change the selector label, flip the default spread, accept a malformed / zero / milli-byte / `Ei`-as-exponent / underflowing / below-precision / post-scale-overflowing quantity, accept a limit without or below its request, break the `Start → PodManifestInput` composition, break the topology-key regex, drop kubectl's stderr, restore the dangling separators, point the operator at the wrong knob, blame RBAC for every failure, drop the `WaitDelay`, swap the cause order) — every one goes red under a test, none by a compile error.
- Placement measured on a 3-node kind cluster with 6 pods: no requests → 2/3/1 (image locality), requests alone → 2/2/2, requests + spread → 2/2/2.

## Rollout

1. Merge → image → runner digest bump.
2. Set `runner.sandbox.scheduling` (this cluster: `requests: {cpu: "2", memory: "4Gi"}`, `spread: hostname`) and bump `config.rollout.runnerEpoch` per the chart doctrine.
3. Acceptance on the first new pod: `resources.requests` present, `topologySpreadConstraints` present, then skew / `PodScheduled` reasons / start latency measured over the following burst.

Non-goals (deliberate): per-workflow `sandbox.resources` in the DSL, limits by default, priority classes, node selectors, the docker driver; the coverage check gets no ClusterRole (the chart's Role-not-ClusterRole doctrine stands).

Note: #689 also edits `pkg/sandbox/kubernetes/driver.go` (imports, constants, `Start`); whichever merges second will need a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
