### PR TITLE
fix(claw): an Anthropic forfait authenticates claw, on the pod and on disk

### DIFF
--- a/cmd/iterion/runner.go
+++ b/cmd/iterion/runner.go
@@ -191,7 +191,8 @@ func runRunner(cmd *cobra.Command, _ []string) error {
 	})
 	// Per-run OAuth-forfait dirs (codex / claude_code) the runner materialised
 	// at claim time. Lets the in-process claw model factory consume a tenant's
-	// resolved OpenAI ChatGPT-forfait in cloud mode (no ~/.codex on the pod).
+	// resolved subscription in cloud mode, where the pod has neither ~/.codex
+	// nor ~/.claude: codex → openai, claude_code → anthropic.
 	model.SetOAuthDirLookup(func(ctx context.Context) (func(string) string, bool) {
 		creds, ok := secrets.CredentialsFromContext(ctx)
 		if !ok {

--- a/pkg/backend/delegate/claude_code_cred_test.go
+++ b/pkg/backend/delegate/claude_code_cred_test.go
@@ -150,7 +150,7 @@ func assertForfaitEnv(t *testing.T, got map[string]string, wantDir string) {
 // without a readable file degrades to the file path (no token key).
 func TestClaudeForfaitEnv_ExportsOAuthTokenFromFile(t *testing.T) {
 	dir := t.TempDir()
-	blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat-TESTTOKEN","refreshToken":"r","expiresAt":1,"scopes":["user:inference"]}}`
+	blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat-TESTTOKEN","refreshToken":"r","expiresAt":4102444800000,"scopes":["user:inference"]}}`
 	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(blob), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -337,7 +337,7 @@ func TestShouldDropSessionFork_UnknownCurrentKeepsForkWithParentSet(t *testing.T
 // refresher keeps fresh.
 func TestClaudeForfaitEnv_SandboxedRemapsConfigDir(t *testing.T) {
 	dir := t.TempDir()
-	blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat-TESTTOKEN","refreshToken":"r","expiresAt":1,"scopes":["user:inference"]}}`
+	blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat-TESTTOKEN","refreshToken":"r","expiresAt":4102444800000,"scopes":["user:inference"]}}`
 	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(blob), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -394,5 +394,26 @@ func TestStampUsageSource(t *testing.T) {
 	}
 	if stampUsageSource(nil, "x") != nil {
 		t.Fatal("no observer must stay no observer")
+	}
+}
+
+// An EXPIRED credentials file must not export CLAUDE_CODE_OAUTH_TOKEN. That
+// variable is the first-precedence headless auth path — the CLI reads it BEFORE
+// the credentials file — so exporting a dead token would shadow the very file
+// the CLI (or the runner's refresh worker) can still renew from. Dropping the
+// key degrades to the file path, which is this resolver's documented fallback.
+func TestClaudeForfaitEnv_SkipsExpiredOAuthToken(t *testing.T) {
+	dir := t.TempDir()
+	blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat-STALE","refreshToken":"r","expiresAt":1,"scopes":["user:inference"]}}`
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(blob), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got := claudeForfaitEnv(dir, false)
+	if v, present := got["CLAUDE_CODE_OAUTH_TOKEN"]; present {
+		t.Errorf("expired token exported as %q — it would shadow the refreshable file", v)
+	}
+	// The file path itself still travels: the CLI reads and refreshes it.
+	if got["CLAUDE_CONFIG_DIR"] != dir {
+		t.Errorf("CLAUDE_CONFIG_DIR: got %q, want %q", got["CLAUDE_CONFIG_DIR"], dir)
 	}
 }

--- a/pkg/backend/delegate/claude_code_cred_test.go
+++ b/pkg/backend/delegate/claude_code_cred_test.go
@@ -160,10 +160,12 @@ func TestClaudeForfaitEnv_ExportsOAuthTokenFromFile(t *testing.T) {
 		t.Errorf("CLAUDE_CODE_OAUTH_TOKEN: got %q, want the file's accessToken", got["CLAUDE_CODE_OAUTH_TOKEN"])
 	}
 
-	// No file → no token key, file path preserved.
+	// No readable file → the key is still written, empty, for the same
+	// suppression reason: we have pointed the CLI at a per-run config dir, so
+	// an inherited platform token must not quietly serve in its place.
 	bare := claudeForfaitEnv(t.TempDir(), false)
-	if _, present := bare["CLAUDE_CODE_OAUTH_TOKEN"]; present {
-		t.Errorf("CLAUDE_CODE_OAUTH_TOKEN must be absent when no credentials file is present: %v", bare)
+	if v, present := bare["CLAUDE_CODE_OAUTH_TOKEN"]; !present || v != "" {
+		t.Errorf("CLAUDE_CODE_OAUTH_TOKEN must be present-and-empty with no credentials file: present=%v val=%q", present, v)
 	}
 }
 
@@ -409,8 +411,15 @@ func TestClaudeForfaitEnv_SkipsExpiredOAuthToken(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := claudeForfaitEnv(dir, false)
-	if v, present := got["CLAUDE_CODE_OAUTH_TOKEN"]; present {
-		t.Errorf("expired token exported as %q — it would shadow the refreshable file", v)
+	// PRESENT AND EMPTY, not absent. This variable is the CLI's
+	// first-precedence auth path, so an absent key lets the pod's own ambient
+	// CLAUDE_CODE_OAUTH_TOKEN — the PLATFORM forfait on a prod runner —
+	// outrank the per-run CLAUDE_CONFIG_DIR we just pointed at, and a tenant
+	// whose blob went stale would silently bill the platform's account. The
+	// three ANTHROPIC_* siblings are cleared for exactly this reason.
+	v, present := got["CLAUDE_CODE_OAUTH_TOKEN"]
+	if !present || v != "" {
+		t.Errorf("expired token must CLEAR the inherited one: present=%v val=%q", present, v)
 	}
 	// The file path itself still travels: the CLI reads and refreshes it.
 	if got["CLAUDE_CONFIG_DIR"] != dir {

--- a/pkg/backend/delegate/claude_code_creds.go
+++ b/pkg/backend/delegate/claude_code_creds.go
@@ -309,11 +309,19 @@ func claudeForfaitEnv(dir string, sandboxed bool) map[string]string {
 	// env can shadow it, so the CLI reports "Not logged in" despite a valid
 	// materialised forfait. Reading it here from the materialised file (kept
 	// fresh by the runner's refresh worker; re-read per spawn) makes the env
-	// token deterministically win. Best-effort: on any read/parse failure we
-	// fall back to the file path alone (prior behaviour).
-	if tok := readForfaitAccessToken(dir); tok != "" {
-		env["CLAUDE_CODE_OAUTH_TOKEN"] = tok
-	}
+	// token deterministically win.
+	//
+	// ALWAYS write the key, empty when there is no usable token. Leaving it
+	// ABSENT is not neutral: this variable outranks the credentials file, the
+	// host spawn inherits os.Environ(), and a prod runner pod carries an
+	// ambient CLAUDE_CODE_OAUTH_TOKEN of its own — the PLATFORM forfait. An
+	// absent key therefore lets that platform token serve in place of the
+	// per-run CLAUDE_CONFIG_DIR just pointed at, so a tenant whose blob is
+	// missing or stale (the refresh worker lagged) authenticates and bills
+	// against someone else's Claude account instead of failing. The three
+	// ANTHROPIC_* siblings above are cleared for exactly this reason; this one
+	// is the same class.
+	env["CLAUDE_CODE_OAUTH_TOKEN"] = readForfaitAccessToken(dir)
 	return env
 }
 

--- a/pkg/backend/delegate/claude_code_creds.go
+++ b/pkg/backend/delegate/claude_code_creds.go
@@ -2,10 +2,8 @@ package delegate
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -323,19 +321,7 @@ func claudeForfaitEnv(dir string, sandboxed bool) map[string]string {
 // materialised Claude Code credentials.json in dir. Returns "" (never an error)
 // when the file is absent or malformed — the caller degrades to the file path.
 func readForfaitAccessToken(dir string) string {
-	data, err := os.ReadFile(filepath.Join(dir, ".credentials.json"))
-	if err != nil {
-		return ""
-	}
-	var v struct {
-		ClaudeAIOauth struct {
-			AccessToken string `json:"accessToken"`
-		} `json:"claudeAiOauth"`
-	}
-	if err := json.Unmarshal(data, &v); err != nil {
-		return ""
-	}
-	return v.ClaudeAIOauth.AccessToken
+	return secrets.AnthropicForfaitAccessToken(dir)
 }
 
 // sandboxed reports that the CLI subprocess will execute inside a REAL

--- a/pkg/backend/delegate/claude_code_sandbox_env_test.go
+++ b/pkg/backend/delegate/claude_code_sandbox_env_test.go
@@ -149,7 +149,7 @@ func TestFormatOutput_SandboxExecParity(t *testing.T) {
 	t.Run("materialised ctx forfait (sealed-bundle shape)", func(t *testing.T) {
 		resetClaudeCredEnv(t)
 		dir := t.TempDir()
-		blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat-BUNDLE","refreshToken":"r","expiresAt":1}}`
+		blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat-BUNDLE","refreshToken":"r","expiresAt":4102444800000}}`
 		if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(blob), 0o600); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/backend/forfait/forfait.go
+++ b/pkg/backend/forfait/forfait.go
@@ -23,10 +23,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/SocialGouv/iterion/pkg/secrets"
 )
 
 // DefaultCapPct is the utilization percentage at or above which an
@@ -175,38 +176,9 @@ func fetchUsage(ctx context.Context, token string, doer httpDoer) (*Usage, error
 // missing file is the common "not a forfait host" case. The token value is
 // never logged.
 func readAccessToken(configDir func() string) (string, bool) {
-	dir := configDir()
-	if dir == "" {
-		return "", false
-	}
-	data, err := os.ReadFile(filepath.Join(dir, ".credentials.json"))
-	if err != nil {
-		return "", false
-	}
-	var creds struct {
-		ClaudeAiOauth struct {
-			AccessToken string `json:"accessToken"`
-		} `json:"claudeAiOauth"`
-	}
-	if err := json.Unmarshal(data, &creds); err != nil {
-		return "", false
-	}
-	tok := strings.TrimSpace(creds.ClaudeAiOauth.AccessToken)
-	if tok == "" {
-		return "", false
-	}
-	return tok, true
+	tok := secrets.AnthropicForfaitAccessToken(configDir())
+	return tok, tok != ""
 }
 
-// claudeConfigDir mirrors detect.claudeConfigDir without importing it (avoids
-// a heavier dependency for a one-liner): CLAUDE_CONFIG_DIR, else ~/.claude.
-func claudeConfigDir() string {
-	if d := os.Getenv("CLAUDE_CONFIG_DIR"); d != "" {
-		return d
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(home, ".claude")
-}
+// claudeConfigDir is the shared resolver: CLAUDE_CONFIG_DIR, else ~/.claude.
+func claudeConfigDir() string { return secrets.ClaudeCodeConfigDir() }

--- a/pkg/backend/model/anthropic_forfait_ctx_test.go
+++ b/pkg/backend/model/anthropic_forfait_ctx_test.go
@@ -1,0 +1,182 @@
+package model
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/SocialGouv/claw-code-go/pkg/api"
+)
+
+// clientBearerForTest reads the OAuth bearer a resolved claw client will send.
+// It is the only oracle that separates "a client was built" from "a client that
+// can authenticate": the unauthenticated fall-through returns a non-nil client
+// too.
+func clientBearerForTest(c api.APIClient) string {
+	cc, ok := c.(*api.Client)
+	if !ok {
+		return ""
+	}
+	return cc.OAuthToken
+}
+
+// writeClaudeCodeCreds drops a Claude Code .credentials.json into a fresh
+// CLAUDE_CONFIG_DIR-shaped dir and returns it (the shape
+// Credentials.OAuthDir("claude_code") yields on a runner pod).
+func writeClaudeCodeCreds(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat-test","refreshToken":"rt","expiresAt":9999999999999}}`
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(blob), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// A run whose only anthropic credential is a materialised Claude Code OAuth
+// forfait must resolve an AUTHENTICATED claw client. Before the ctx-forfait
+// branch existed, ResolveWithContext fell through to the env factory, which on
+// a runner pod finds no ANTHROPIC_* var and builds a client with no credential
+// at all — every call then answers 401 "x-api-key header is required". That is
+// exactly how Revi's pacer supervisor died in prod (issue #687) while its unit
+// tests stayed green.
+func TestResolveWithContext_AnthropicForfaitFromCtx(t *testing.T) {
+	dir := writeClaudeCodeCreds(t)
+	SetCredentialsLookup(func(ctx context.Context) (func(string) string, bool) {
+		return func(string) string { return "" }, true
+	})
+	SetOAuthDirLookup(func(ctx context.Context) (func(string) string, bool) {
+		return func(kind string) string {
+			if kind == "claude_code" {
+				return dir
+			}
+			return ""
+		}, true
+	})
+	t.Cleanup(func() {
+		SetCredentialsLookup(func(context.Context) (func(string) string, bool) { return nil, false })
+		SetOAuthDirLookup(func(context.Context) (func(string) string, bool) { return nil, false })
+	})
+	// No ambient anthropic auth: the ctx forfait is the only possible signal.
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("ZAI_API_KEY", "")
+	t.Setenv("ITERION_FORBID_SUBSCRIPTION_OAUTH", "")
+
+	reg := NewRegistry()
+	client, err := reg.ResolveWithContext(context.Background(), "anthropic/claude-haiku-4-5")
+	if err != nil {
+		t.Fatalf("ResolveWithContext: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected a forfait-backed client from the ctx-resolved claude_code dir, got nil")
+	}
+	// The oracle is the bearer, not the absence of an error: the env factory
+	// also returns a non-nil client — an unauthenticated one.
+	if tok := clientBearerForTest(client); tok != "sk-ant-oat-test" {
+		t.Fatalf("client carries bearer %q, want the forfait access token — an unauthenticated client is what produces the 401", tok)
+	}
+}
+
+// The desktop twin: no ctx credentials at all, but this host has a Claude
+// Code forfait on disk. The openai factory has read ~/.codex since day one;
+// the anthropic one read env vars only, so the commonest desktop setup (a
+// Claude subscription, no API key) resolved an unauthenticated client.
+func TestResolve_AnthropicForfaitFromDisk(t *testing.T) {
+	dir := writeClaudeCodeCreds(t)
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("ZAI_API_KEY", "")
+	t.Setenv("ITERION_FORBID_SUBSCRIPTION_OAUTH", "")
+
+	client, err := NewRegistry().Resolve("anthropic/claude-haiku-4-5")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if tok := clientBearerForTest(client); tok != "sk-ant-oat-test" {
+		t.Fatalf("client carries bearer %q, want the on-disk forfait token", tok)
+	}
+}
+
+// An operator who redirected the wire chose that destination: a subscription
+// bearer must not be sent there implicitly. An explicit ANTHROPIC_AUTH_TOKEN
+// still travels — that one is the operator's own choice.
+func TestResolve_AnthropicDiskForfaitNotSentToRedirectedWire(t *testing.T) {
+	dir := writeClaudeCodeCreds(t)
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("ZAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_BASE_URL", "https://gateway.example.test")
+
+	client, err := NewRegistry().Resolve("anthropic/claude-haiku-4-5")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if tok := clientBearerForTest(client); tok != "" {
+		t.Fatalf("forfait bearer %q leaked to a redirected base URL", tok)
+	}
+}
+
+func TestAnthropicFromCtxForfait_DisabledAndAbsent(t *testing.T) {
+	reg := NewRegistry()
+	clear := func() {
+		SetOAuthDirLookup(func(context.Context) (func(string) string, bool) { return nil, false })
+	}
+
+	t.Run("no oauth dir → not ok", func(t *testing.T) {
+		SetOAuthDirLookup(func(context.Context) (func(string) string, bool) {
+			return func(string) string { return "" }, true
+		})
+		t.Cleanup(clear)
+		if _, ok, _ := reg.anthropicFromCtxForfait(context.Background(), "claude-haiku-4-5"); ok {
+			t.Error("expected ok=false with no claude_code dir")
+		}
+	})
+
+	t.Run("z.ai base URL → not ok (the token is not a forfait bearer there)", func(t *testing.T) {
+		dir := writeClaudeCodeCreds(t)
+		SetOAuthDirLookup(func(context.Context) (func(string) string, bool) {
+			return func(string) string { return dir }, true
+		})
+		t.Cleanup(clear)
+		t.Setenv("ANTHROPIC_BASE_URL", "https://api.z.ai/api/anthropic")
+		if _, ok, _ := reg.anthropicFromCtxForfait(context.Background(), "claude-haiku-4-5"); ok {
+			t.Error("expected ok=false against a z.ai facade base URL")
+		}
+	})
+
+	t.Run("FORBID_SUBSCRIPTION_OAUTH=1 → refused, loudly", func(t *testing.T) {
+		dir := writeClaudeCodeCreds(t)
+		SetOAuthDirLookup(func(context.Context) (func(string) string, bool) {
+			return func(string) string { return dir }, true
+		})
+		t.Cleanup(clear)
+		t.Setenv("ANTHROPIC_BASE_URL", "")
+		t.Setenv("ITERION_FORBID_SUBSCRIPTION_OAUTH", "1")
+		_, ok, err := reg.anthropicFromCtxForfait(context.Background(), "claude-haiku-4-5")
+		if !ok || err == nil {
+			t.Fatalf("expected an explicit refusal (ok=true, err!=nil), got ok=%v err=%v", ok, err)
+		}
+	})
+
+	t.Run("malformed credentials file → not ok", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte("{nope"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		SetOAuthDirLookup(func(context.Context) (func(string) string, bool) {
+			return func(string) string { return dir }, true
+		})
+		t.Cleanup(clear)
+		t.Setenv("ANTHROPIC_BASE_URL", "")
+		t.Setenv("ITERION_FORBID_SUBSCRIPTION_OAUTH", "")
+		if _, ok, _ := reg.anthropicFromCtxForfait(context.Background(), "claude-haiku-4-5"); ok {
+			t.Error("expected ok=false on a malformed credentials.json")
+		}
+	})
+}

--- a/pkg/backend/model/anthropic_forfait_ctx_test.go
+++ b/pkg/backend/model/anthropic_forfait_ctx_test.go
@@ -2,11 +2,13 @@ package model
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/SocialGouv/claw-code-go/pkg/api"
+	"github.com/SocialGouv/iterion/pkg/secrets"
 )
 
 // clientBearerForTest reads the OAuth bearer a resolved claw client will send.
@@ -307,5 +309,46 @@ func TestResolve_AnthropicDiskForfaitSkipsExpiredToken(t *testing.T) {
 	}
 	if tok := clientBearerForTest(client); tok != "" {
 		t.Fatalf("expired bearer %q was baked into the cached client", tok)
+	}
+}
+
+// R721331: an EXPIRED ctx forfait is not "no credential here" — one WAS
+// provisioned and the refresh worker did not renew it. Falling through reaches
+// the env factory, finds no ANTHROPIC_* var on a pod, and builds the
+// unauthenticated client whose 401 loop is issue #687. It must surface.
+func TestAnthropicFromCtxForfait_ExpiredSurfacesInsteadOfDegrading(t *testing.T) {
+	dir := t.TempDir()
+	blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat-stale","expiresAt":1000000000000}}`
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(blob), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	SetOAuthDirLookup(func(context.Context) (func(string) string, bool) {
+		return func(string) string { return dir }, true
+	})
+	t.Cleanup(func() { SetOAuthDirLookup(func(context.Context) (func(string) string, bool) { return nil, false }) })
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("ITERION_FORBID_SUBSCRIPTION_OAUTH", "")
+
+	_, ok, err := NewRegistry().anthropicFromCtxForfait(context.Background(), "claude-haiku-4-5")
+	if !ok || err == nil {
+		t.Fatalf("an expired ctx forfait must fail loudly, got ok=%v err=%v", ok, err)
+	}
+	if !errors.Is(err, secrets.ErrAnthropicForfaitExpired) {
+		t.Errorf("error must name expiry so the cause is legible, got %v", err)
+	}
+}
+
+// An ABSENT or malformed blob keeps degrading quietly: nothing was provisioned,
+// so there is a legitimate fall-back to try.
+func TestAnthropicFromCtxForfait_AbsentStillDegradesQuietly(t *testing.T) {
+	SetOAuthDirLookup(func(context.Context) (func(string) string, bool) {
+		return func(string) string { return t.TempDir() }, true
+	})
+	t.Cleanup(func() { SetOAuthDirLookup(func(context.Context) (func(string) string, bool) { return nil, false }) })
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("ITERION_FORBID_SUBSCRIPTION_OAUTH", "")
+
+	if _, ok, err := NewRegistry().anthropicFromCtxForfait(context.Background(), "claude-haiku-4-5"); ok || err != nil {
+		t.Errorf("an absent blob must degrade quietly, got ok=%v err=%v", ok, err)
 	}
 }

--- a/pkg/backend/model/anthropic_forfait_ctx_test.go
+++ b/pkg/backend/model/anthropic_forfait_ctx_test.go
@@ -157,6 +157,11 @@ func TestAnthropicFromCtxForfait_DisabledAndAbsent(t *testing.T) {
 		})
 		t.Cleanup(clear)
 		t.Setenv("ANTHROPIC_BASE_URL", "")
+		// Sole candidate: with an ambient key present the flag means "look
+		// elsewhere" instead (see TestAnthropicFromCtxForfait_Forbid*).
+		t.Setenv("ANTHROPIC_API_KEY", "")
+		t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+		t.Setenv("ZAI_API_KEY", "")
 		t.Setenv("ITERION_FORBID_SUBSCRIPTION_OAUTH", "1")
 		_, ok, err := reg.anthropicFromCtxForfait(context.Background(), "claude-haiku-4-5")
 		if !ok || err == nil {
@@ -179,4 +184,128 @@ func TestAnthropicFromCtxForfait_DisabledAndAbsent(t *testing.T) {
 			t.Error("expected ok=false on a malformed credentials.json")
 		}
 	})
+}
+
+// --- Revi #698 findings, red-first ---
+
+// Rac606f: the forbid flag means "this credential does not count", not "the run
+// dies". A pod carrying an ambient ANTHROPIC_API_KEY (the `anthropic-env` shape
+// named in pkg/runner/usage_cap.go) served fine before the ctx branch existed;
+// refusing hard there would break it on exactly the shared deployments CLAUDE.md
+// tells operators to set the flag on. ctxFundsProvider already reads the flag as
+// "look elsewhere" — the two halves must agree.
+func TestAnthropicFromCtxForfait_ForbidFallsThroughToAmbientKey(t *testing.T) {
+	dir := writeClaudeCodeCreds(t)
+	SetCredentialsLookup(func(context.Context) (func(string) string, bool) {
+		return func(string) string { return "" }, true
+	})
+	SetOAuthDirLookup(func(context.Context) (func(string) string, bool) {
+		return func(kind string) string {
+			if kind == "claude_code" {
+				return dir
+			}
+			return ""
+		}, true
+	})
+	t.Cleanup(func() {
+		SetCredentialsLookup(func(context.Context) (func(string) string, bool) { return nil, false })
+		SetOAuthDirLookup(func(context.Context) (func(string) string, bool) { return nil, false })
+	})
+	t.Setenv("ITERION_FORBID_SUBSCRIPTION_OAUTH", "1")
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("ZAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-ambient")
+
+	client, err := NewRegistry().ResolveWithContext(context.Background(), "anthropic/claude-haiku-4-5")
+	if err != nil {
+		t.Fatalf("an ambient API key must still serve under the forbid flag, got error: %v", err)
+	}
+	if tok := clientBearerForTest(client); tok != "" {
+		t.Fatalf("forfait bearer %q was sent despite the forbid flag", tok)
+	}
+}
+
+// ...but when the forfait is the SOLE candidate, the refusal is the useful
+// answer: falling through would build the unauthenticated client this whole
+// function exists to prevent, and 401 per call is what #687 was.
+func TestAnthropicFromCtxForfait_ForbidRefusesWhenSoleCandidate(t *testing.T) {
+	dir := writeClaudeCodeCreds(t)
+	SetOAuthDirLookup(func(context.Context) (func(string) string, bool) {
+		return func(string) string { return dir }, true
+	})
+	t.Cleanup(func() { SetOAuthDirLookup(func(context.Context) (func(string) string, bool) { return nil, false }) })
+	t.Setenv("ITERION_FORBID_SUBSCRIPTION_OAUTH", "1")
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("ZAI_API_KEY", "")
+
+	_, ok, err := NewRegistry().anthropicFromCtxForfait(context.Background(), "claude-haiku-4-5")
+	if !ok || err == nil {
+		t.Fatalf("sole-candidate forfait under the forbid flag must refuse loudly, got ok=%v err=%v", ok, err)
+	}
+}
+
+// Rfa608f: the cloud path must not be more permissive than the desktop one with
+// the SAME secret. On cloud the base URL is set by the platform operator while
+// the bearer belongs to the tenant and carries their whole Claude account, so
+// the consent gap is strictly wider than on a laptop.
+func TestAnthropicFromCtxForfait_DeclinesCorporateGateway(t *testing.T) {
+	dir := writeClaudeCodeCreds(t)
+	SetOAuthDirLookup(func(context.Context) (func(string) string, bool) {
+		return func(string) string { return dir }, true
+	})
+	t.Cleanup(func() { SetOAuthDirLookup(func(context.Context) (func(string) string, bool) { return nil, false }) })
+	t.Setenv("ITERION_FORBID_SUBSCRIPTION_OAUTH", "")
+	t.Setenv("ANTHROPIC_BASE_URL", "https://llm-gateway.corp.example")
+
+	if _, ok, _ := NewRegistry().anthropicFromCtxForfait(context.Background(), "claude-haiku-4-5"); ok {
+		t.Error("a tenant forfait bearer must not be forwarded to an operator-chosen gateway")
+	}
+}
+
+// The mirror of that rule: an explicitly-named real Anthropic wire is NOT a
+// redirection, so the desktop path must not decline it — the previous
+// `baseURL == ""` test was over-strict in the other direction.
+func TestResolve_AnthropicDiskForfaitServesExplicitAnthropicBaseURL(t *testing.T) {
+	dir := writeClaudeCodeCreds(t)
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("ZAI_API_KEY", "")
+	t.Setenv("ITERION_FORBID_SUBSCRIPTION_OAUTH", "")
+	t.Setenv("ANTHROPIC_BASE_URL", "https://api.anthropic.com")
+
+	client, err := NewRegistry().Resolve("anthropic/claude-haiku-4-5")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if tok := clientBearerForTest(client); tok != "sk-ant-oat-test" {
+		t.Fatalf("bearer %q — an explicitly-named api.anthropic.com is the real wire, not a redirection", tok)
+	}
+}
+
+// R482f00: an already-expired blob must not be baked into the process-lifetime
+// client cache, where it answers 401 with no diagnostic until the daemon
+// restarts.
+func TestResolve_AnthropicDiskForfaitSkipsExpiredToken(t *testing.T) {
+	dir := t.TempDir()
+	blob := `{"claudeAiOauth":{"accessToken":"sk-ant-oat-expired","expiresAt":1000000000000}}`
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(blob), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	t.Setenv("ZAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+
+	client, err := NewRegistry().Resolve("anthropic/claude-haiku-4-5")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if tok := clientBearerForTest(client); tok != "" {
+		t.Fatalf("expired bearer %q was baked into the cached client", tok)
+	}
 }

--- a/pkg/backend/model/registry.go
+++ b/pkg/backend/model/registry.go
@@ -104,12 +104,20 @@ func (r *Registry) registerDefaults() {
 		// setup (a Claude subscription, no API key) builds a client with NO
 		// credential and every claw call answers 401.
 		//
-		// Only when the wire is un-redirected: an operator who pointed
-		// ANTHROPIC_BASE_URL at a gateway chose that destination, and a
-		// subscription bearer must not be sent there implicitly. An explicit
+		// Only onto the real Anthropic wire (secrets.AnthropicForfaitWireOK —
+		// the same predicate the ctx factory and the supervisor's funding check
+		// use): an operator who pointed ANTHROPIC_BASE_URL at a gateway chose
+		// that destination, and a subscription bearer, which carries the whole
+		// Claude account, must not be sent there implicitly. An explicit
 		// ANTHROPIC_AUTH_TOKEN still reaches any base URL — that one IS the
 		// operator's choice.
-		if apiKey == "" && authToken == "" && baseURL == "" {
+		//
+		// KNOWN LIMITATION, shared with the codex path below: the resolved
+		// client is cached for the life of the process, so a long-running
+		// studio/dispatcher keeps the token captured at first resolve. Claude
+		// Code rotates it on expiry; restart the daemon to pick up the new one.
+		// An already-expired token is skipped rather than baked in.
+		if apiKey == "" && authToken == "" && secrets.AnthropicForfaitWireOK(baseURL) {
 			authToken = secrets.AnthropicForfaitAccessTokenFromDisk()
 		}
 		cfg := api.ProviderConfig{
@@ -573,19 +581,31 @@ func (r *Registry) openAIFromCtxForfait(ctx context.Context, modelID string) (ap
 // balance rather than the plan's limits, hence the same one-time notice.
 func (r *Registry) anthropicFromCtxForfait(ctx context.Context, modelID string) (api.APIClient, bool, error) {
 	baseURL := os.Getenv("ANTHROPIC_BASE_URL")
-	lowBase := strings.ToLower(baseURL)
-	if strings.Contains(lowBase, "z.ai") || strings.Contains(lowBase, "bigmodel") {
+	if !secrets.AnthropicForfaitWireOK(baseURL) {
 		return nil, false, nil
 	}
 	dir := oauthDirLookup(ctx, string(secrets.OAuthKindClaudeCode))
 	if dir == "" {
 		return nil, false, nil
 	}
-	view, err := secrets.LoadAnthropicCredentialsFrom(dir)
-	if err != nil || view.ClaudeAIOauth.AccessToken == "" {
+	token := secrets.AnthropicForfaitAccessToken(dir)
+	if token == "" {
 		return nil, false, nil
 	}
 	if secrets.ForbidSubscriptionOAuth() {
+		// The flag means "this credential does not count", which is the reading
+		// pkg/supervise's ctxFundsProvider already takes — not "the run dies".
+		// A pod carrying an ambient key (the `anthropic-env` shape named in
+		// pkg/runner/usage_cap.go) served fine before this branch existed, and
+		// CLAUDE.md recommends the flag on exactly those shared deployments: a
+		// hard refusal here would break every run whose tenant merely HAS a
+		// forfait connected.
+		if ambientAnthropicCredential() {
+			return nil, false, nil
+		}
+		// Sole candidate: now the refusal IS the useful answer. Falling through
+		// would build the unauthenticated client this function exists to
+		// prevent, and a silent 401 per call is issue #687 itself.
 		return nil, true, fmt.Errorf("claw: %w", secrets.ErrSubscriptionOAuthForbidden)
 	}
 	claudeForfaitWarnOnce.Do(func() {
@@ -595,10 +615,24 @@ func (r *Registry) anthropicFromCtxForfait(ctx context.Context, modelID string) 
 	cfg := api.ProviderConfig{
 		Model:      modelID,
 		BaseURL:    baseURL,
-		OAuthToken: view.ClaudeAIOauth.AccessToken,
+		OAuthToken: token,
 	}
 	client, cerr := anthropicprovider.New().NewClient(withClientIdentity(cfg))
 	return client, true, cerr
+}
+
+// ambientAnthropicCredential reports whether this process's own environment
+// already carries something that can authenticate an Anthropic call without the
+// forfait. The AUTH_TOKEN case is shape-checked on purpose: that variable is
+// overloaded — a z.ai facade key or a gateway bearer is an ordinary credential,
+// while an `sk-ant-oat…` value is another subscription token, which is the very
+// thing the forbid flag refuses.
+func ambientAnthropicCredential() bool {
+	if os.Getenv("ANTHROPIC_API_KEY") != "" || os.Getenv("ZAI_API_KEY") != "" {
+		return true
+	}
+	tok := os.Getenv("ANTHROPIC_AUTH_TOKEN")
+	return tok != "" && !secrets.IsAnthropicSubscriptionToken(tok)
 }
 
 // oauthDirResolver maps an OAuth kind ("codex" / "claude_code") to its

--- a/pkg/backend/model/registry.go
+++ b/pkg/backend/model/registry.go
@@ -98,6 +98,20 @@ func (r *Registry) registerDefaults() {
 				}
 			}
 		}
+		// Desktop forfait, last: with no env credential at all, read this
+		// host's own Claude Code credentials — the twin of the openai factory's
+		// LoadCodexCredentialsFromDisk below. Without it the most common desktop
+		// setup (a Claude subscription, no API key) builds a client with NO
+		// credential and every claw call answers 401.
+		//
+		// Only when the wire is un-redirected: an operator who pointed
+		// ANTHROPIC_BASE_URL at a gateway chose that destination, and a
+		// subscription bearer must not be sent there implicitly. An explicit
+		// ANTHROPIC_AUTH_TOKEN still reaches any base URL — that one IS the
+		// operator's choice.
+		if apiKey == "" && authToken == "" && baseURL == "" {
+			authToken = secrets.AnthropicForfaitAccessTokenFromDisk()
+		}
 		cfg := api.ProviderConfig{
 			APIKey:  apiKey,
 			Model:   modelID,
@@ -454,6 +468,16 @@ func (r *Registry) ResolveWithContext(ctx context.Context, spec string) (api.API
 				return client, err
 			}
 		}
+		// Same for anthropic and the Claude Code forfait. Without this the
+		// fall-through below reaches the env factory, which on a runner pod
+		// sees no ANTHROPIC_* var and returns a client with NO credential —
+		// non-nil, so the caller proceeds, and every call answers 401
+		// "x-api-key header is required" (issue #687: Revi's pacer).
+		if providerName == "anthropic" {
+			if client, ok, err := r.anthropicFromCtxForfait(ctx, modelID); ok {
+				return client, err
+			}
+		}
 		// No tenant-scoped credential for this provider — fall back to the
 		// shared resolver (env vars + cache).
 		return r.Resolve(spec)
@@ -526,6 +550,54 @@ func (r *Registry) openAIFromCtxForfait(ctx context.Context, modelID string) (ap
 	cfg := api.ProviderConfig{Model: modelID, BaseURL: os.Getenv("OPENAI_BASE_URL")}
 	applyCodexOAuth(&cfg, view)
 	client, cerr := openaiprovider.New().NewClient(withClientIdentity(cfg))
+	return client, true, cerr
+}
+
+// anthropicFromCtxForfait builds an Anthropic client from the tenant's
+// per-run-materialised Claude Code forfait (Credentials.OAuthDir("claude_code")),
+// the twin of openAIFromCtxForfait. claw's anthropic provider takes the access
+// token as an OAuth bearer and sends `Authorization: Bearer` plus the
+// `anthropic-beta: oauth-2025-04-20` header the API requires — the same wire the
+// env factory builds from ANTHROPIC_AUTH_TOKEN.
+//
+// Returns ok=false (caller falls back to the shared resolver) when no dir is
+// resolved, when the blob carries no access token, or when the base URL points
+// at a z.ai/bigmodel facade — there the bearer is a BYOK key, not a forfait
+// token, so a subscription token would be the wrong credential entirely.
+//
+// Returns ok=true WITH an error when the operator forbade subscription-OAuth
+// spending: that is a refusal to surface, not a reason to fall through to an
+// unauthenticated client.
+//
+// BILLING: like the env path, this spends the subscription's EXTRA-USAGE
+// balance rather than the plan's limits, hence the same one-time notice.
+func (r *Registry) anthropicFromCtxForfait(ctx context.Context, modelID string) (api.APIClient, bool, error) {
+	baseURL := os.Getenv("ANTHROPIC_BASE_URL")
+	lowBase := strings.ToLower(baseURL)
+	if strings.Contains(lowBase, "z.ai") || strings.Contains(lowBase, "bigmodel") {
+		return nil, false, nil
+	}
+	dir := oauthDirLookup(ctx, string(secrets.OAuthKindClaudeCode))
+	if dir == "" {
+		return nil, false, nil
+	}
+	view, err := secrets.LoadAnthropicCredentialsFrom(dir)
+	if err != nil || view.ClaudeAIOauth.AccessToken == "" {
+		return nil, false, nil
+	}
+	if secrets.ForbidSubscriptionOAuth() {
+		return nil, true, fmt.Errorf("claw: %w", secrets.ErrSubscriptionOAuthForbidden)
+	}
+	claudeForfaitWarnOnce.Do(func() {
+		iterlog.NewFromEnv(os.Stderr).Warn("claw: %s",
+			secrets.SubscriptionOAuthNotice(secrets.ProviderAnthropic))
+	})
+	cfg := api.ProviderConfig{
+		Model:      modelID,
+		BaseURL:    baseURL,
+		OAuthToken: view.ClaudeAIOauth.AccessToken,
+	}
+	client, cerr := anthropicprovider.New().NewClient(withClientIdentity(cfg))
 	return client, true, cerr
 }
 

--- a/pkg/backend/model/registry.go
+++ b/pkg/backend/model/registry.go
@@ -4,6 +4,7 @@ package model
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -588,8 +589,17 @@ func (r *Registry) anthropicFromCtxForfait(ctx context.Context, modelID string) 
 	if dir == "" {
 		return nil, false, nil
 	}
-	token := secrets.AnthropicForfaitAccessToken(dir)
-	if token == "" {
+	token, terr := secrets.AnthropicForfaitToken(dir)
+	if errors.Is(terr, secrets.ErrAnthropicForfaitExpired) {
+		// The one case that is NOT "no credential here": a forfait was
+		// provisioned and its token lapsed, which means the refresh worker
+		// lagged or failed. Falling through would reach the env factory, find
+		// no ANTHROPIC_* var on a runner pod, and build the unauthenticated
+		// client whose 401 loop is issue #687 — the same reasoning that makes
+		// the forbid branch below refuse rather than degrade.
+		return nil, true, fmt.Errorf("claw: %w (model %s): the runner's OAuth refresh worker has not renewed it", terr, modelID)
+	}
+	if terr != nil || token == "" {
 		return nil, false, nil
 	}
 	if secrets.ForbidSubscriptionOAuth() {

--- a/pkg/secrets/files.go
+++ b/pkg/secrets/files.go
@@ -40,6 +40,14 @@ const (
 	// rewrites through the sandbox exec seam).
 	ClaudeCodeSandboxCredentialsPath = ClaudeCodeSandboxConfigDir + "/.credentials.json"
 
+	// ClaudeCodeCredentialsFileName is the file the Claude Code forfait
+	// blob is materialised as inside a CLAUDE_CONFIG_DIR-shaped directory —
+	// including the per-run one the runner builds
+	// (Credentials.OAuthDir("claude_code")). Named because several readers
+	// now open it: the CLI env builder, the in-process claw factory, and
+	// the runner's refresh worker.
+	ClaudeCodeCredentialsFileName = ".credentials.json"
+
 	// The same three for the ChatGPT (Codex) forfait. Without them a
 	// sandboxed node has no way to see a resolved subscription — the host
 	// temp dir does not exist in the container — and silently falls back to

--- a/pkg/secrets/oauth.go
+++ b/pkg/secrets/oauth.go
@@ -305,6 +305,29 @@ func LoadAnthropicCredentialsFrom(dir string) (AnthropicCredentialsView, error) 
 // It exists because three readers were extracting the same field from the same
 // file independently (the CLI env builder, the forfait usage prober, the claw
 // ctx factory); the fourth would have drifted. The token is never logged.
+// ErrAnthropicForfaitExpired names the one failure mode that is not "there is
+// no credential here": a forfait WAS provisioned into this dir and its access
+// token has lapsed. Callers that can still fall back keep treating it as
+// absent; callers whose fall-back is an unauthenticated client must surface it,
+// because a lapsed blob is a refresh that did not happen, not a host without a
+// subscription.
+var ErrAnthropicForfaitExpired = errors.New("secrets: the materialised Claude Code forfait has expired")
+
+// AnthropicForfaitToken returns the usable access token in dir, or an error
+// naming why there is none — ErrAnthropicForfaitExpired when the blob lapsed,
+// a read/parse error otherwise, and (\"\", nil) when the dir simply holds no
+// token. AnthropicForfaitAccessToken is the "usable or not" shorthand over it.
+func AnthropicForfaitToken(dir string) (string, error) {
+	view, err := LoadAnthropicCredentialsFrom(dir)
+	if err != nil {
+		return "", err
+	}
+	if exp := view.ClaudeAIOauth.ExpiresAt; exp > 0 && time.UnixMilli(exp).Before(time.Now()) {
+		return "", ErrAnthropicForfaitExpired
+	}
+	return strings.TrimSpace(view.ClaudeAIOauth.AccessToken), nil
+}
+
 func AnthropicForfaitAccessToken(dir string) string {
 	view, err := LoadAnthropicCredentialsFrom(dir)
 	if err != nil {

--- a/pkg/secrets/oauth.go
+++ b/pkg/secrets/oauth.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -309,7 +310,42 @@ func AnthropicForfaitAccessToken(dir string) string {
 	if err != nil {
 		return ""
 	}
+	// An expired blob is worse than no blob. Baked into a process-lifetime
+	// client cache it answers 401 with nothing naming expiry as the cause, and
+	// the CLI path degrades better without it — claude re-reads and refreshes
+	// the file itself. `expiresAt == 0` means the payload states no expiry, not
+	// that it expired.
+	if exp := view.ClaudeAIOauth.ExpiresAt; exp > 0 && time.UnixMilli(exp).Before(time.Now()) {
+		return ""
+	}
 	return strings.TrimSpace(view.ClaudeAIOauth.AccessToken)
+}
+
+// AnthropicForfaitWireOK reports whether a Claude subscription bearer may be
+// sent to baseURL. Only the real Anthropic API qualifies: an empty value (the
+// SDK default) or the exact host api.anthropic.com.
+//
+// Everything else is a destination the OPERATOR chose — a z.ai/bigmodel facade
+// that wants the token as an x-api-key-style key, a corporate gateway, an
+// interception proxy — and a forfait bearer is not a scoped key: it carries the
+// whole Claude account. On a cloud deployment the base URL is set by the
+// platform while the credential belongs to the tenant, so the consent gap is
+// wider there than on a laptop, never narrower.
+//
+// It is deliberately ONE predicate: the desktop factory, the per-run ctx
+// factory and pkg/supervise's funding check all decide this same question, and
+// a supervisor that calls anthropic funded for a wire the registry then
+// declines is the disagreement this package keeps paying for.
+func AnthropicForfaitWireOK(baseURL string) bool {
+	raw := strings.TrimSpace(baseURL)
+	if raw == "" {
+		return true
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(u.Hostname(), "api.anthropic.com")
 }
 
 // ClaudeCodeConfigDir returns the on-disk CLAUDE_CONFIG_DIR the Claude Code

--- a/pkg/secrets/oauth.go
+++ b/pkg/secrets/oauth.go
@@ -278,6 +278,64 @@ func LoadCodexCredentialsFrom(dir string) (CodexCredentialsView, error) {
 	return ParseCodexView(data)
 }
 
+// LoadAnthropicCredentialsFrom reads and parses a Claude Code
+// .credentials.json from an EXPLICIT CLAUDE_CONFIG_DIR-shaped directory, the
+// anthropic twin of LoadCodexCredentialsFrom. This is the cloud path: the
+// runner materialises the tenant's resolved Claude forfait into a per-run temp
+// dir (Credentials.OAuthDir("claude_code")), where the in-process claw factory
+// reads it instead of the pod's (empty) ~/.claude. Empty dir → error.
+func LoadAnthropicCredentialsFrom(dir string) (AnthropicCredentialsView, error) {
+	if strings.TrimSpace(dir) == "" {
+		return AnthropicCredentialsView{}, fmt.Errorf("secrets: empty claude_code credentials dir")
+	}
+	path := filepath.Join(dir, ClaudeCodeCredentialsFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return AnthropicCredentialsView{}, fmt.Errorf("secrets: read %s: %w", path, err)
+	}
+	return ParseAnthropicView(data)
+}
+
+// AnthropicForfaitAccessToken returns the Claude Code OAuth access token
+// materialised in a CLAUDE_CONFIG_DIR-shaped dir, or "" for every failure
+// mode (no dir, absent file, malformed JSON, blank token) — a missing file is
+// the ordinary "not a forfait host" case, not an error to propagate.
+//
+// It exists because three readers were extracting the same field from the same
+// file independently (the CLI env builder, the forfait usage prober, the claw
+// ctx factory); the fourth would have drifted. The token is never logged.
+func AnthropicForfaitAccessToken(dir string) string {
+	view, err := LoadAnthropicCredentialsFrom(dir)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(view.ClaudeAIOauth.AccessToken)
+}
+
+// ClaudeCodeConfigDir returns the on-disk CLAUDE_CONFIG_DIR the Claude Code
+// CLI stores its forfait credentials in, honouring the env override and
+// falling back to `~/.claude`. Returns "" when no home directory resolves,
+// which callers treat as "no forfait on this host".
+func ClaudeCodeConfigDir() string {
+	if d := strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR")); d != "" {
+		return d
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".claude")
+}
+
+// AnthropicForfaitAccessTokenFromDisk is the desktop twin of
+// LoadCodexCredentialsFromDisk: the Claude Code forfait token from this host's
+// own config dir, or "" when there is none. Used by the in-process claw
+// anthropic factory so a laptop with a Claude subscription authenticates the
+// same way one with a ChatGPT subscription already did.
+func AnthropicForfaitAccessTokenFromDisk() string {
+	return AnthropicForfaitAccessToken(ClaudeCodeConfigDir())
+}
+
 // LoadCodexCredentialsFromDisk reads and parses Codex CLI's auth.json from
 // its standard location. Returns the parsed view on success; on missing or
 // malformed file it returns the zero view plus a non-nil error. Callers

--- a/pkg/supervise/bot.go
+++ b/pkg/supervise/bot.go
@@ -179,22 +179,35 @@ func resolveModelWith(specModel, providerHint string, providers []detect.Provide
 
 // ctxFundsProvider maps the run's ctx credentials onto claw providers: a
 // per-provider API key funds its provider (ResolveWithContext →
-// providersWithKey), and the codex ChatGPT forfait funds openai
-// (Registry.openAIFromCtxForfait reads OAuthDir("codex")), mirroring
-// that path's env kill-switches. Anthropic's OAuth forfait is
-// deliberately NOT mapped: it is usable only by the claude_code CLI —
-// claw's anthropic factory reads env vars alone and ResolveWithContext
-// has no anthropic OAuth-dir branch — so claiming it funds the
-// anthropic provider would resolve an unauthenticated client.
+// providersWithKey), and each subscription forfait funds the provider its
+// ctx branch in Registry.ResolveWithContext can build a client from —
+// codex → openai (openAIFromCtxForfait), claude_code → anthropic
+// (anthropicFromCtxForfait) — mirroring each path's kill-switches.
+//
+// Keeping this in step with those branches is the whole job: a provider
+// claimed as funded but with no ctx branch behind it resolves an
+// UNAUTHENTICATED client, which fails 401 per eval instead of parking
+// supervision on a clean ErrNoSupervisorModel.
 func ctxFundsProvider(creds secrets.Credentials) func(provider string) bool {
 	return func(provider string) bool {
 		if creds.APIKeys[secrets.Provider(provider)] != "" {
 			return true
 		}
-		if provider == "openai" &&
-			os.Getenv("ITERION_OPENAI_USE_OAUTH") != "0" &&
-			os.Getenv("OPENAI_BASE_URL") == "" {
-			return creds.OAuthCredentialFiles["codex"] != ""
+		switch provider {
+		case "openai":
+			if os.Getenv("ITERION_OPENAI_USE_OAUTH") == "0" || os.Getenv("OPENAI_BASE_URL") != "" {
+				return false
+			}
+			return creds.OAuthCredentialFiles[string(secrets.OAuthKindCodex)] != ""
+		case "anthropic":
+			// The forfait bearer is not the credential a z.ai/bigmodel
+			// facade expects, and the opt-out refuses the path outright.
+			base := strings.ToLower(os.Getenv("ANTHROPIC_BASE_URL"))
+			if secrets.ForbidSubscriptionOAuth() ||
+				strings.Contains(base, "z.ai") || strings.Contains(base, "bigmodel") {
+				return false
+			}
+			return creds.OAuthCredentialFiles[string(secrets.OAuthKindClaudeCode)] != ""
 		}
 		return false
 	}
@@ -230,7 +243,12 @@ func (e *LLMEvaluator) Evaluate(ctx context.Context, in EvalInput) (*Decision, E
 	}
 	res, err := model.GenerateObjectDirect[Decision](ctx, e.client, opts)
 	if err != nil {
-		return nil, EvalUsage{}, fmt.Errorf("supervise: evaluation call: %w", err)
+		// Name the model that failed: a supervisor's model can come from a DSL
+		// pin, an env override, the supervised nodes' provider or the host
+		// detector, and an auth error says nothing about which of those was
+		// taken. Reading "anthropic: API error 401" with no spec is what made a
+		// dead pacer look like a provider outage rather than a resolution bug.
+		return nil, EvalUsage{}, fmt.Errorf("supervise: evaluation call (model %s): %w", e.modelSpec, err)
 	}
 	usage := EvalUsage{
 		InputTokens:  res.TotalUsage.InputTokens,

--- a/pkg/supervise/bot.go
+++ b/pkg/supervise/bot.go
@@ -200,11 +200,10 @@ func ctxFundsProvider(creds secrets.Credentials) func(provider string) bool {
 			}
 			return creds.OAuthCredentialFiles[string(secrets.OAuthKindCodex)] != ""
 		case "anthropic":
-			// The forfait bearer is not the credential a z.ai/bigmodel
-			// facade expects, and the opt-out refuses the path outright.
-			base := strings.ToLower(os.Getenv("ANTHROPIC_BASE_URL"))
+			// Same predicate the registry's two anthropic factories use, so a
+			// hint can never resolve a wire they will decline.
 			if secrets.ForbidSubscriptionOAuth() ||
-				strings.Contains(base, "z.ai") || strings.Contains(base, "bigmodel") {
+				!secrets.AnthropicForfaitWireOK(os.Getenv("ANTHROPIC_BASE_URL")) {
 				return false
 			}
 			return creds.OAuthCredentialFiles[string(secrets.OAuthKindClaudeCode)] != ""

--- a/pkg/supervise/model_hint_test.go
+++ b/pkg/supervise/model_hint_test.go
@@ -156,25 +156,55 @@ func TestResolveModelWithHonoursCtxFundedHint(t *testing.T) {
 	}
 }
 
-// ctxFundsProvider: a per-provider API key funds its provider; the codex
-// ChatGPT forfait funds openai (the only OAuth path ResolveWithContext
-// actually has). The claude_code OAuth forfait does NOT fund anthropic —
-// claw's anthropic factory is env-only, so claiming it would resolve an
-// unauthenticated client.
+// ctxFundsProvider: a per-provider API key funds its provider, and each
+// subscription forfait funds the provider ResolveWithContext has a ctx branch
+// for — codex → openai, claude_code → anthropic. This map must stay in step
+// with those branches in both directions: claiming a provider nothing can
+// build resolves an unauthenticated client (401 per eval), and denying one
+// that IS buildable parks supervision for no reason.
 func TestCtxFundsProvider(t *testing.T) {
-	f := ctxFundsProvider(secrets.Credentials{
+	creds := secrets.Credentials{
 		APIKeys:              map[secrets.Provider]string{"zai": "zk"},
 		OAuthCredentialFiles: map[string]string{"claude_code": "/tmp/cc", "codex": "/tmp/cx"},
-	})
-	for provider, want := range map[string]bool{
-		"zai":       true,
-		"anthropic": false,
-		"openai":    true,
-		"xai":       false,
-	} {
-		if got := f(provider); got != want {
-			t.Errorf("ctxFundsProvider(%q) = %v, want %v", provider, got, want)
+	}
+
+	t.Run("forfaits fund their provider", func(t *testing.T) {
+		t.Setenv("ITERION_FORBID_SUBSCRIPTION_OAUTH", "")
+		t.Setenv("ANTHROPIC_BASE_URL", "")
+		t.Setenv("OPENAI_BASE_URL", "")
+		t.Setenv("ITERION_OPENAI_USE_OAUTH", "")
+		f := ctxFundsProvider(creds)
+		for provider, want := range map[string]bool{
+			"zai":       true,
+			"anthropic": true, // via the claude_code forfait
+			"openai":    true, // via the codex forfait
+			"xai":       false,
+		} {
+			if got := f(provider); got != want {
+				t.Errorf("ctxFundsProvider(%q) = %v, want %v", provider, got, want)
+			}
 		}
+	})
+
+	// Each kill-switch that makes the registry's ctx branch decline must make
+	// this predicate decline too, or the hint resolves a model the branch
+	// refuses to build.
+	for name, tc := range map[string]struct{ key, val, provider string }{
+		"FORBID_SUBSCRIPTION_OAUTH": {"ITERION_FORBID_SUBSCRIPTION_OAUTH", "1", "anthropic"},
+		"anthropic z.ai facade":     {"ANTHROPIC_BASE_URL", "https://api.z.ai/api/anthropic", "anthropic"},
+		"openai oauth disabled":     {"ITERION_OPENAI_USE_OAUTH", "0", "openai"},
+		"openai base url override":  {"OPENAI_BASE_URL", "http://localhost:1234", "openai"},
+	} {
+		t.Run(name+" → unfunded", func(t *testing.T) {
+			t.Setenv("ITERION_FORBID_SUBSCRIPTION_OAUTH", "")
+			t.Setenv("ANTHROPIC_BASE_URL", "")
+			t.Setenv("OPENAI_BASE_URL", "")
+			t.Setenv("ITERION_OPENAI_USE_OAUTH", "")
+			t.Setenv(tc.key, tc.val)
+			if ctxFundsProvider(creds)(tc.provider) {
+				t.Errorf("ctxFundsProvider(%q) = true with %s=%s, want false", tc.provider, tc.key, tc.val)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #687

## What was wrong

A run whose only anthropic credential is a Claude Code OAuth forfait resolved an **unauthenticated** claw client: non-nil, so callers proceeded, and every call answered `401 x-api-key header is required`. Revi's `pacer` supervisor died this way in prod for a full day (#687) while its unit tests stayed green — a clean failure is a feature you believe you shipped.

claw was never the limitation: its anthropic provider documents "API key or OAuth 2.0 Bearer token" and sends the `anthropic-beta: oauth-2025-04-20` header; iterion simply never handed it a token. The comment asserting the opposite was the load-bearing falsehood, so it goes with the code.

Both seams had the same asymmetry against openai, which has been whole since day one:

- **cloud**: `ResolveWithContext` gained `openAIFromCtxForfait` but no anthropic twin, so a pod's materialised `OAuthDir("claude_code")` was never read;
- **desktop**: the openai factory reads `~/.codex`, the anthropic one read env vars only — so the commonest laptop setup (a Claude subscription, no API key) was 401 too.

## The fix

Both seams now resolve the Anthropic OAuth forfait into claw's OAuth token set, honouring `ITERION_FORBID_SUBSCRIPTION_OAUTH` and the extra-usage notice (option A of #687). The desktop path declines a redirected `ANTHROPIC_BASE_URL`: an operator who aimed the wire at a gateway did not implicitly consent to sending a subscription bearer there — an explicit `ANTHROPIC_AUTH_TOKEN` still wins.

**Option B of #687 is NOT in this PR** — the earlier wording here claimed it was, and that was wrong.
`resolveModel` still returns a DSL/env pin immediately (`pkg/supervise/bot.go`) without consulting
`ctxFundsProvider`, so a pin to any provider ctx does not fund still builds an unauthenticated
client. What this PR does add on that path is the diagnosis, not the prevention: the evaluation
error now names the resolved model, so the failure is legible *after* the 401 rather than opaque.
The pre-flight check and its test stay open on #687.

### Scope — what this does NOT cover

The "on the pod" half is the **in-process** path: supervisor evals and
`GenerateObjectDirect` (human/judge). That is what fixes #687's pacer.

It does **not** reach `backend: claw` AGENT nodes on a cloud pod, which are the
default shape: those run sandboxed, and the in-container `__claw-runner` rebuilds
its registry from env alone, where none of the three channels added here exist.
Such a node still falls back to the ambient `ANTHROPIC_API_KEY` — i.e. the platform
key — for a forfait-only tenant. Not a regression (that path never worked), but the
gap is real and is tracked in #736. The stale claw_backend.go comments asserting
that claw cannot use a forfait — the false premise behind #687 — are corrected here.

## Tests

`pkg/backend/model/anthropic_forfait_ctx_test.go` (ctx forfait → authenticated client; forbid flag refuses; redirected base URL declines), `pkg/supervise/model_hint_test.go` (forfait funding per provider + every kill switch that makes the registry decline). `task check` green on the rebased branch; the four touched packages green.

## Verification bar (from the ticket)

A prod run where `supervise[pacer]` logs an eval **decision** rather than a 401 — needs the runner digest bumped after merge; this PR closes the ticket only once that run exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

